### PR TITLE
Fixed port definitions for ATtiny45

### DIFF
--- a/fastpin.h
+++ b/fastpin.h
@@ -262,13 +262,13 @@ typedef volatile uint32_t * ptr_reg32_t;
 #warning "Softwrae pin support forced pin access will be slightly slower.  See fastpin.h for info."
 #define NO_HARDWARE_PIN_SUPPORT
 
-#elif defined(__AVR_ATtiny85__) 
+#elif defined(__AVR_ATtiny85__) || defined(__AVR_ATtiny45__)
 _IO(B);
 
 _DEFPIN_AVR(0, 0x01, B); _DEFPIN_AVR(1, 0x02, B); _DEFPIN_AVR(2, 0x04, B); _DEFPIN_AVR(3, 0x08, B);
 _DEFPIN_AVR(4, 0x10, B); _DEFPIN_AVR(5, 0x20, B);
 
-#elif(__AVR_ATtiny24__) || defined(__AVR_ATtiny44__) || defined(__AVR_ATtiny84__) || defined(__AVR_ATtiny25__) || defined(__AVR_ATtiny45__)
+#elif(__AVR_ATtiny24__) || defined(__AVR_ATtiny44__) || defined(__AVR_ATtiny84__) || defined(__AVR_ATtiny25__)
 _IO(A); _IO(B);
 
 _DEFPIN_AVR(0, 0x01, A); _DEFPIN_AVR(1, 0x02, A); _DEFPIN_AVR(2, 0x04, A); _DEFPIN_AVR(3, 0x08, A);


### PR DESCRIPTION
The #ifdef's were not correct and caused compiler errors because of DDRA, PORTA and PINA, which does not exist on the ATtiny45. The pinout of the ATtiny45 is similar to the ATtiny85.
