### PR TITLE
Remove padding from <a> elements

### DIFF
--- a/homepage/css/main.css
+++ b/homepage/css/main.css
@@ -23,7 +23,6 @@ body {
 
 a {
     margin-bottom: 10px;
-    padding: 15px 0;
 
     text-align: center;
     text-decoration: underline;


### PR DESCRIPTION
The padding causes the active areas of the links in the homepage sidebar to overlap. It's easy to click one link and accidentally get sent to the adjacent link instead.
