### PR TITLE
Max number supported controllers increased.

### DIFF
--- a/FastLED.h
+++ b/FastLED.h
@@ -30,7 +30,7 @@ enum EClocklessChipsets {
 	UCS1903
 };
 
-#define NUM_CONTROLLERS 8
+#define NUM_CONTROLLERS 16
 
 class CFastLED {
 	struct CControllerInfo { 


### PR DESCRIPTION
Boards like the Teensy 3.1 support up to 16 controllers comfortably.
