### PR TITLE
BugFix in Colorutils blend functions

### DIFF
--- a/colorutils.cpp
+++ b/colorutils.cpp
@@ -267,7 +267,7 @@ CRGB blend( const CRGB& p1, const CRGB& p2, fract8 amountOfP2 )
 CRGB* blend( const CRGB* src1, const CRGB* src2, CRGB* dest, uint16_t count, fract8 amountOfsrc2 )
 {
     for( uint16_t i = count; i; i--) {
-        dest[i] = blend(src1[i], src2[i], amountOfsrc2);
+        dest[i-1] = blend(src1[i-1], src2[i-1], amountOfsrc2);
     }
     return dest;
 }
@@ -343,7 +343,7 @@ CHSV blend( const CHSV& p1, const CHSV& p2, fract8 amountOfP2, TGradientDirectio
 CHSV* blend( const CHSV* src1, const CHSV* src2, CHSV* dest, uint16_t count, fract8 amountOfsrc2, TGradientDirectionCode directionCode )
 {
     for( uint16_t i = count; i; i--) {
-        dest[i] = blend(src1[i], src2[i], amountOfsrc2, directionCode);
+        dest[i-1] = blend(src1[i-1], src2[i-1], amountOfsrc2, directionCode);
     }
     return dest;
 }


### PR DESCRIPTION
There is a bug in the function 
CRGB\* blend( const CRGB\* src1, const CRGB\* src2, CRGB\* dest,
uint16_t count, fract8 amountOfsrc2 );
and
CHSV\* blend( const CHSV\* src1, const CHSV\* src2, CHSV\* dest,
uint16_t count, fract8 amountOfsrc2,
TGradientDirectionCode directionCode = SHORTEST_HUES );
which prevents the blending of the first pixel ([0]). Because the for loop is going form PIXEL_COUNT to 1. But the indexes of the pixels are PIXEL_COUNT-1 to 0
