### PR TITLE
SmartMatrix 3.x Compatibility

### DIFF
--- a/pixeltypes.h
+++ b/pixeltypes.h
@@ -400,7 +400,7 @@ struct CRGB {
         return retval;
     }
 
-#ifdef SmartMatrix_h
+#if (defined SmartMatrix_h || defined SmartMatrix3_h)
     operator rgb24() const {
       rgb24 ret;
       ret.red = r;


### PR DESCRIPTION
tl;dr Major new release of SmartMatrix is coming that isn't backwards compatible with the `SMART_MATRIX` controller, but still needs the CRGB-rgb24 conversion.  This minor change prevents conflicts.

We've been working on a major release for SmartMatrix that isn't going to be backwards compatible.  This is going to break the FastLED `SMART_MATRIX` controller, which I plan to fix and submit through a separate pull request after I lock down the major features for SmartMatrix 3.0.  In the meantime, I want to be sure that people who use FastLED functions can continue to do so with SmartMatrix 3.x.

New features in SmartMatrix 3.0 that may be relevant:

* New Layer class
  * Default Foreground and Background Layers are separated and optional
  * Custom layers (e.g. a Fadecandy Layer converting Fadecandy's USB buffers and interpolation to SmartMatrix rgb48 values each refresh) can be defined
  * FastLED could define a custom SmartMatrix Layer in a new `SMART_MATRIX3` controller, but I'm not sure if there's any advantage over the previous method
* Classes use templates to choose color depths for Layer storage (right now rgb24 and rgb48) and for refreshing the matrix (right now 24, 36, 48-bit)
* Support for larger displays: 16x32, 32x32, 32x64 are supported now.  Will support larger displays before release including using multiple rows of panels to make a 64x64 display

More discussion here: https://github.com/pixelmatix/SmartMatrix/issues/25

If there are any features in the SmartMatrix Library that you think are missing or need to be tweaked for better compatibility with FastLED, please let me know.