### PR TITLE
Standardize Examples

### DIFF
--- a/examples/Blink/Blink.ino
+++ b/examples/Blink/Blink.ino
@@ -1,48 +1,28 @@
 #include "FastLED.h"
 
-// How many leds in your strip?
 #define NUM_LEDS 1
-
-// For led chips like Neopixels, which have a data line, ground, and power, you just
-// need to define DATA_PIN.  For led chipsets that are SPI based (four wires - data, clock,
-// ground, and power), like the LPD8806 define both DATA_PIN and CLOCK_PIN
+#define LED_TYPE NEOPIXEL
 #define DATA_PIN 3
 #define CLOCK_PIN 13
+#define COLOR_ORDER RGB
 
 // Define the array of leds
 CRGB leds[NUM_LEDS];
 
-void setup() { 
-      // Uncomment/edit one of the following lines for your leds arrangement.
-      // FastLED.addLeds<TM1803, DATA_PIN, RGB>(leds, NUM_LEDS);
-      // FastLED.addLeds<TM1804, DATA_PIN, RGB>(leds, NUM_LEDS);
-      // FastLED.addLeds<TM1809, DATA_PIN, RGB>(leds, NUM_LEDS);
-      // FastLED.addLeds<WS2811, DATA_PIN, RGB>(leds, NUM_LEDS);
-      // FastLED.addLeds<WS2812, DATA_PIN, RGB>(leds, NUM_LEDS);
-      // FastLED.addLeds<WS2812B, DATA_PIN, RGB>(leds, NUM_LEDS);
-  	  FastLED.addLeds<NEOPIXEL, DATA_PIN>(leds, NUM_LEDS);
-      // FastLED.addLeds<APA104, DATA_PIN, RGB>(leds, NUM_LEDS);
-      // FastLED.addLeds<UCS1903, DATA_PIN, RGB>(leds, NUM_LEDS);
-      // FastLED.addLeds<UCS1903B, DATA_PIN, RGB>(leds, NUM_LEDS);
-      // FastLED.addLeds<GW6205, DATA_PIN, RGB>(leds, NUM_LEDS);
-      // FastLED.addLeds<GW6205_400, DATA_PIN, RGB>(leds, NUM_LEDS);
-      
-      // FastLED.addLeds<WS2801, RGB>(leds, NUM_LEDS);
-      // FastLED.addLeds<SM16716, RGB>(leds, NUM_LEDS);
-      // FastLED.addLeds<LPD8806, RGB>(leds, NUM_LEDS);
-      // FastLED.addLeds<P9813, RGB>(leds, NUM_LEDS);
-      // FastLED.addLeds<APA102, RGB>(leds, NUM_LEDS);
-      // FastLED.addLeds<DOTSTAR, RGB>(leds, NUM_LEDS);
+void setup() {
+  delay(2000); //Safety delay
 
-      // FastLED.addLeds<WS2801, DATA_PIN, CLOCK_PIN, RGB>(leds, NUM_LEDS);
-      // FastLED.addLeds<SM16716, DATA_PIN, CLOCK_PIN, RGB>(leds, NUM_LEDS);
-      // FastLED.addLeds<LPD8806, DATA_PIN, CLOCK_PIN, RGB>(leds, NUM_LEDS);
-      // FastLED.addLeds<P9813, DATA_PIN, CLOCK_PIN, RGB>(leds, NUM_LEDS);
-      // FastLED.addLeds<APA102, DATA_PIN, CLOCK_PIN, RGB>(leds, NUM_LEDS);
-      // FastLED.addLeds<DOTSTAR, DATA_PIN, CLOCK_PIN, RGB>(leds, NUM_LEDS);
+  // Uncomment this line for a 3-Wire chipset
+  FastLED.addLeds<LED_TYPE, DATA_PIN, COLOR_ORDER>(leds, NUM_LEDS);
+
+  // Uncomment this line for a SPI chipset
+  //FastLED.addLeds<LED_TYPE, COLOR_ORDER>(leds, NUM_LEDS);
+
+  // Uncomment this line for a SPI chipset with the data and clock pins specified
+  //FastLED.addLeds<LED_TYPE, DATA_PIN, CLOCK_PIN, COLOR_ORDER>(leds, NUM_LEDS);
 }
 
-void loop() { 
+void loop() {
   // Turn the LED on, then pause
   leds[0] = CRGB::Red;
   FastLED.show();

--- a/examples/ColorPalette/ColorPalette.ino
+++ b/examples/ColorPalette/ColorPalette.ino
@@ -1,13 +1,17 @@
 #include <FastLED.h>
 
-#define LED_PIN     5
-#define NUM_LEDS    50
+#define NUM_LEDS 60
+#define LED_TYPE NEOPIXEL
+#define DATA_PIN 3
+#define CLOCK_PIN 13
+#define COLOR_ORDER RGB
+
 #define BRIGHTNESS  64
-#define LED_TYPE    WS2811
-#define COLOR_ORDER GRB
+#define FRAMES_PER_SECOND 100
+
+// Define the array of leds
 CRGB leds[NUM_LEDS];
 
-#define UPDATES_PER_SECOND 100
 
 // This example shows several ways to set up and use 'palettes' of colors
 // with FastLED.
@@ -37,9 +41,18 @@ extern const TProgmemPalette16 myRedWhiteBluePalette_p PROGMEM;
 
 void setup() {
     delay( 3000 ); // power-up safety delay
-    FastLED.addLeds<LED_TYPE, LED_PIN, COLOR_ORDER>(leds, NUM_LEDS).setCorrection( TypicalLEDStrip );
-    FastLED.setBrightness(  BRIGHTNESS );
-    
+
+    // Uncomment this line for a 3-Wire chipset
+    FastLED.addLeds<LED_TYPE, DATA_PIN, COLOR_ORDER>(leds, NUM_LEDS).setCorrection( TypicalLEDStrip );
+
+    // Uncomment this line for a SPI chipset
+    //FastLED.addLeds<LED_TYPE, COLOR_ORDER>(leds, NUM_LEDS).setCorrection( TypicalLEDStrip );
+
+    // Uncomment this line for a SPI chipset with the data and clock pins specified
+    //FastLED.addLeds<LED_TYPE, DATA_PIN, CLOCK_PIN, COLOR_ORDER>(leds, NUM_LEDS).setCorrection( TypicalLEDStrip );
+
+    FastLED.setBrightness( BRIGHTNESS );
+
     currentPalette = RainbowColors_p;
     currentBlending = LINEARBLEND;
 }
@@ -48,20 +61,20 @@ void setup() {
 void loop()
 {
     ChangePalettePeriodically();
-    
+
     static uint8_t startIndex = 0;
     startIndex = startIndex + 1; /* motion speed */
-    
+
     FillLEDsFromPaletteColors( startIndex);
-    
+
     FastLED.show();
-    FastLED.delay(1000 / UPDATES_PER_SECOND);
+    FastLED.delay(1000 / FRAMES_PER_SECOND);
 }
 
 void FillLEDsFromPaletteColors( uint8_t colorIndex)
 {
     uint8_t brightness = 255;
-    
+
     for( int i = 0; i < NUM_LEDS; i++) {
         leds[i] = ColorFromPalette( currentPalette, colorIndex, brightness, currentBlending);
         colorIndex += 3;
@@ -81,7 +94,7 @@ void ChangePalettePeriodically()
 {
     uint8_t secondHand = (millis() / 1000) % 60;
     static uint8_t lastSecond = 99;
-    
+
     if( lastSecond != secondHand) {
         lastSecond = secondHand;
         if( secondHand ==  0)  { currentPalette = RainbowColors_p;         currentBlending = LINEARBLEND; }
@@ -119,7 +132,7 @@ void SetupBlackAndWhiteStripedPalette()
     currentPalette[4] = CRGB::White;
     currentPalette[8] = CRGB::White;
     currentPalette[12] = CRGB::White;
-    
+
 }
 
 // This function sets up a palette of purple and green stripes.
@@ -128,7 +141,7 @@ void SetupPurpleAndGreenPalette()
     CRGB purple = CHSV( HUE_PURPLE, 255, 255);
     CRGB green  = CHSV( HUE_GREEN, 255, 255);
     CRGB black  = CRGB::Black;
-    
+
     currentPalette = CRGBPalette16(
                                    green,  green,  black,  black,
                                    purple, purple, black,  black,
@@ -147,12 +160,12 @@ const TProgmemPalette16 myRedWhiteBluePalette_p PROGMEM =
     CRGB::Gray, // 'white' is too bright compared to red and blue
     CRGB::Blue,
     CRGB::Black,
-    
+
     CRGB::Red,
     CRGB::Gray,
     CRGB::Blue,
     CRGB::Black,
-    
+
     CRGB::Red,
     CRGB::Red,
     CRGB::Gray,
@@ -182,7 +195,7 @@ const TProgmemPalette16 myRedWhiteBluePalette_p PROGMEM =
 // between the 16 explicit entries to create fifteen intermediate palette
 // entries between each pair.
 //
-// So for example, if you set the first two explicit entries of a compact 
-// palette to Green (0,255,0) and Blue (0,0,255), and then retrieved 
+// So for example, if you set the first two explicit entries of a compact
+// palette to Green (0,255,0) and Blue (0,0,255), and then retrieved
 // the first sixteen entries from the virtual palette (of 256), you'd get
 // Green, followed by a smooth gradient from green-to-blue, and then Blue.

--- a/examples/ColorTemperature/ColorTemperature.ino
+++ b/examples/ColorTemperature/ColorTemperature.ino
@@ -1,19 +1,21 @@
 #include <FastLED.h>
 
-#define LED_PIN     3
-
-// Information about the LED strip itself
-#define NUM_LEDS    60
-#define CHIPSET     WS2811
-#define COLOR_ORDER GRB
-CRGB leds[NUM_LEDS];
+#define NUM_LEDS 60
+#define LED_TYPE NEOPIXEL
+#define DATA_PIN 3
+#define CLOCK_PIN 13
+#define COLOR_ORDER RGB
 
 #define BRIGHTNESS  128
+
+// Define the array of leds
+CRGB leds[NUM_LEDS];
+
 
 
 // FastLED v2.1 provides two color-management controls:
 //   (1) color correction settings for each LED strip, and
-//   (2) master control of the overall output 'color temperature' 
+//   (2) master control of the overall output 'color temperature'
 //
 // THIS EXAMPLE demonstrates the second, "color temperature" control.
 // It shows a simple rainbow animation first with one temperature profile,
@@ -25,7 +27,7 @@ CRGB leds[NUM_LEDS];
 // * Don't look directly at the LED pixels.  Shine the LEDs aganst
 //   a white wall, table, or piece of paper, and look at the reflected light.
 //
-// * If you watch it for a bit, and then walk away, and then come back 
+// * If you watch it for a bit, and then walk away, and then come back
 //   to it, you'll probably be able to "see" whether it's currently using
 //   the 'redder' or the 'bluer' temperature profile, even not counting
 //   the lowest 'indicator' pixel.
@@ -70,16 +72,23 @@ void loop()
   if( (secs % DISPLAYTIME) < BLACKTIME) {
     memset8( leds, 0, NUM_LEDS * sizeof(CRGB));
   }
-  
+
   FastLED.show();
   FastLED.delay(8);
 }
 
 void setup() {
   delay( 3000 ); // power-up safety delay
+
   // It's important to set the color correction for your LED strip here,
   // so that colors can be more accurately rendered through the 'temperature' profiles
-  FastLED.addLeds<CHIPSET, LED_PIN, COLOR_ORDER>(leds, NUM_LEDS).setCorrection( TypicalSMD5050 );
+  // Uncomment this line for a 3-Wire chipset
+  FastLED.addLeds<LED_TYPE, DATA_PIN, COLOR_ORDER>(leds, NUM_LEDS).setCorrection( TypicalSMD5050 );
+
+  // Uncomment this line for a SPI chipset
+  //FastLED.addLeds<LED_TYPE, COLOR_ORDER>(leds, NUM_LEDS).setCorrection( TypicalSMD5050 );
+
+  // Uncomment this line for a SPI chipset with the data and clock pins specified
+  //FastLED.addLeds<LED_TYPE, DATA_PIN, CLOCK_PIN, COLOR_ORDER>(leds, NUM_LEDS).setCorrection( TypicalSMD5050 );
   FastLED.setBrightness( BRIGHTNESS );
 }
-

--- a/examples/Cylon/Cylon.ino
+++ b/examples/Cylon/Cylon.ino
@@ -1,35 +1,43 @@
 #include "FastLED.h"
 
-// How many leds in your strip?
-#define NUM_LEDS 64 
-
-// For led chips like Neopixels, which have a data line, ground, and power, you just
-// need to define DATA_PIN.  For led chipsets that are SPI based (four wires - data, clock,
-// ground, and power), like the LPD8806, define both DATA_PIN and CLOCK_PIN
-#define DATA_PIN 7
+#define NUM_LEDS 64
+#define LED_TYPE NEOPIXEL
+#define DATA_PIN 3
 #define CLOCK_PIN 13
+#define COLOR_ORDER RGB
+
+#define BRIGHTNESS  84
 
 // Define the array of leds
 CRGB leds[NUM_LEDS];
 
-void setup() { 
+void setup() {
 	Serial.begin(57600);
 	Serial.println("resetting");
-	LEDS.addLeds<WS2812,2,RGB>(leds,NUM_LEDS);
-	LEDS.setBrightness(84);
+
+	// Uncomment this line for a 3-Wire chipset
+  FastLED.addLeds<LED_TYPE, DATA_PIN, COLOR_ORDER>(leds, NUM_LEDS);
+
+  // Uncomment this line for a SPI chipset
+  //FastLED.addLeds<LED_TYPE, COLOR_ORDER>(leds, NUM_LEDS);
+
+  // Uncomment this line for a SPI chipset with the data and clock pins specified
+  //FastLED.addLeds<LED_TYPE, DATA_PIN, CLOCK_PIN, COLOR_ORDER>(leds, NUM_LEDS);
+
+	FastLED.setBrightness(BRIGHTNESS);
 }
 
 void fadeall() { for(int i = 0; i < NUM_LEDS; i++) { leds[i].nscale8(250); } }
 
-void loop() { 
+void loop() {
 	static uint8_t hue = 0;
 	Serial.print("x");
 	// First slide the led in one direction
 	for(int i = 0; i < NUM_LEDS; i++) {
-		// Set the i'th led to red 
+		// Set the i'th led to red
 		leds[i] = CHSV(hue++, 255, 255);
 		// Show the leds
-		FastLED.show(); 
+		FastLED.show();
 		// now that we've shown the leds, reset the i'th led to black
 		// leds[i] = CRGB::Black;
 		fadeall();
@@ -38,9 +46,9 @@ void loop() {
 	}
 	Serial.print("x");
 
-	// Now go in the other direction.  
+	// Now go in the other direction.
 	for(int i = (NUM_LEDS)-1; i >= 0; i--) {
-		// Set the i'th led to red 
+		// Set the i'th led to red
 		leds[i] = CHSV(hue++, 255, 255);
 		// Show the leds
 		FastLED.show();

--- a/examples/DemoReel100/DemoReel100.ino
+++ b/examples/DemoReel100/DemoReel100.ino
@@ -1,12 +1,23 @@
 #include "FastLED.h"
 
+#define NUM_LEDS 64
+#define LED_TYPE NEOPIXEL
+#define DATA_PIN 3
+#define CLOCK_PIN 13
+#define COLOR_ORDER RGB
+
+#define BRIGHTNESS  96
+#define FRAMES_PER_SECOND 120
+
+CRGB leds[NUM_LEDS];
+
 FASTLED_USING_NAMESPACE
 
-// FastLED "100-lines-of-code" demo reel, showing just a few 
-// of the kinds of animation patterns you can quickly and easily 
-// compose using FastLED.  
+// FastLED "100-lines-of-code" demo reel, showing just a few
+// of the kinds of animation patterns you can quickly and easily
+// compose using FastLED.
 //
-// This example also shows one easy way to define multiple 
+// This example also shows one easy way to define multiple
 // animations patterns and have them automatically rotate.
 //
 // -Mark Kriegsman, December 2014
@@ -15,22 +26,18 @@ FASTLED_USING_NAMESPACE
 #error "Requires FastLED 3.1 or later; check github for latest code."
 #endif
 
-#define DATA_PIN    3
-//#define CLK_PIN   4
-#define LED_TYPE    WS2811
-#define COLOR_ORDER GRB
-#define NUM_LEDS    64
-CRGB leds[NUM_LEDS];
-
-#define BRIGHTNESS          96
-#define FRAMES_PER_SECOND  120
 
 void setup() {
   delay(3000); // 3 second delay for recovery
-  
-  // tell FastLED about the LED strip configuration
-  FastLED.addLeds<LED_TYPE,DATA_PIN,COLOR_ORDER>(leds, NUM_LEDS).setCorrection(TypicalLEDStrip);
-  //FastLED.addLeds<LED_TYPE,DATA_PIN,CLK_PIN,COLOR_ORDER>(leds, NUM_LEDS).setCorrection(TypicalLEDStrip);
+
+  // Uncomment this line for a 3-Wire chipset
+  FastLED.addLeds<LED_TYPE, DATA_PIN, COLOR_ORDER>(leds, NUM_LEDS).setCorrection(TypicalLEDStrip);
+
+  // Uncomment this line for a SPI chipset
+  //FastLED.addLeds<LED_TYPE, COLOR_ORDER>(leds, NUM_LEDS).setCorrection(TypicalLEDStrip);
+
+  // Uncomment this line for a SPI chipset with the data and clock pins specified
+  //FastLED.addLeds<LED_TYPE, DATA_PIN, CLOCK_PIN, COLOR_ORDER>(leds, NUM_LEDS).setCorrection(TypicalLEDStrip);
 
   // set master brightness control
   FastLED.setBrightness(BRIGHTNESS);
@@ -43,16 +50,16 @@ SimplePatternList gPatterns = { rainbow, rainbowWithGlitter, confetti, sinelon, 
 
 uint8_t gCurrentPatternNumber = 0; // Index number of which pattern is current
 uint8_t gHue = 0; // rotating "base color" used by many of the patterns
-  
+
 void loop()
 {
   // Call the current pattern function once, updating the 'leds' array
   gPatterns[gCurrentPatternNumber]();
 
   // send the 'leds' array out to the actual LED strip
-  FastLED.show();  
+  FastLED.show();
   // insert a delay to keep the framerate modest
-  FastLED.delay(1000/FRAMES_PER_SECOND); 
+  FastLED.delay(1000/FRAMES_PER_SECOND);
 
   // do some periodic updates
   EVERY_N_MILLISECONDS( 20 ) { gHue++; } // slowly cycle the "base color" through the rainbow
@@ -67,27 +74,27 @@ void nextPattern()
   gCurrentPatternNumber = (gCurrentPatternNumber + 1) % ARRAY_SIZE( gPatterns);
 }
 
-void rainbow() 
+void rainbow()
 {
   // FastLED's built-in rainbow generator
   fill_rainbow( leds, NUM_LEDS, gHue, 7);
 }
 
-void rainbowWithGlitter() 
+void rainbowWithGlitter()
 {
   // built-in FastLED rainbow, plus some random sparkly glitter
   rainbow();
   addGlitter(80);
 }
 
-void addGlitter( fract8 chanceOfGlitter) 
+void addGlitter( fract8 chanceOfGlitter)
 {
   if( random8() < chanceOfGlitter) {
     leds[ random16(NUM_LEDS) ] += CRGB::White;
   }
 }
 
-void confetti() 
+void confetti()
 {
   // random colored speckles that blink in and fade smoothly
   fadeToBlackBy( leds, NUM_LEDS, 10);
@@ -123,4 +130,3 @@ void juggle() {
     dothue += 32;
   }
 }
-

--- a/examples/Fire2012/Fire2012.ino
+++ b/examples/Fire2012/Fire2012.ino
@@ -1,9 +1,10 @@
 #include <FastLED.h>
 
-#define LED_PIN     5
-#define COLOR_ORDER GRB
-#define CHIPSET     WS2811
-#define NUM_LEDS    30
+#define NUM_LEDS 30
+#define LED_TYPE NEOPIXEL
+#define DATA_PIN 3
+#define CLOCK_PIN 13
+#define COLOR_ORDER RGB
 
 #define BRIGHTNESS  200
 #define FRAMES_PER_SECOND 60
@@ -14,7 +15,16 @@ CRGB leds[NUM_LEDS];
 
 void setup() {
   delay(3000); // sanity delay
-  FastLED.addLeds<CHIPSET, LED_PIN, COLOR_ORDER>(leds, NUM_LEDS).setCorrection( TypicalLEDStrip );
+
+  // Uncomment this line for a 3-Wire chipset
+  FastLED.addLeds<LED_TYPE, DATA_PIN, COLOR_ORDER>(leds, NUM_LEDS).setCorrection(TypicalLEDStrip);
+
+  // Uncomment this line for a SPI chipset
+  //FastLED.addLeds<LED_TYPE, COLOR_ORDER>(leds, NUM_LEDS).setCorrection(TypicalLEDStrip);
+
+  // Uncomment this line for a SPI chipset with the data and clock pins specified
+  //FastLED.addLeds<LED_TYPE, DATA_PIN, CLOCK_PIN, COLOR_ORDER>(leds, NUM_LEDS).setCorrection(TypicalLEDStrip);
+
   FastLED.setBrightness( BRIGHTNESS );
 }
 
@@ -24,7 +34,7 @@ void loop()
   // random16_add_entropy( random());
 
   Fire2012(); // run simulation frame
-  
+
   FastLED.show(); // display this frame
   FastLED.delay(1000 / FRAMES_PER_SECOND);
 }
@@ -32,10 +42,10 @@ void loop()
 
 // Fire2012 by Mark Kriegsman, July 2012
 // as part of "Five Elements" shown here: http://youtu.be/knWiGsmgycY
-//// 
+////
 // This basic one-dimensional 'fire' simulation works roughly as follows:
 // There's a underlying array of 'heat' cells, that model the temperature
-// at each point along the line.  Every cycle through the simulation, 
+// at each point along the line.  Every cycle through the simulation,
 // four steps are performed:
 //  1) All cells cool down a little bit, losing heat to the air
 //  2) The heat from each cell drifts 'up' and diffuses a little
@@ -46,7 +56,7 @@ void loop()
 // Temperature is in arbitrary units from 0 (cold black) to 255 (white hot).
 //
 // This simulation scales it self a bit depending on NUM_LEDS; it should look
-// "OK" on anywhere from 20 to 100 LEDs without too much tweaking. 
+// "OK" on anywhere from 20 to 100 LEDs without too much tweaking.
 //
 // I recommend running this simulation at anywhere from 30-100 frames per second,
 // meaning an interframe delay of about 10-35 milliseconds.
@@ -60,7 +70,7 @@ void loop()
 //
 // COOLING: How much does the air cool as it rises?
 // Less cooling = taller flames.  More cooling = shorter flames.
-// Default 50, suggested range 20-100 
+// Default 50, suggested range 20-100
 #define COOLING  55
 
 // SPARKING: What chance (out of 255) is there that a new spark will be lit?
@@ -78,12 +88,12 @@ void Fire2012()
     for( int i = 0; i < NUM_LEDS; i++) {
       heat[i] = qsub8( heat[i],  random8(0, ((COOLING * 10) / NUM_LEDS) + 2));
     }
-  
+
     // Step 2.  Heat from each cell drifts 'up' and diffuses a little
     for( int k= NUM_LEDS - 1; k >= 2; k--) {
       heat[k] = (heat[k - 1] + heat[k - 2] + heat[k - 2] ) / 3;
     }
-    
+
     // Step 3.  Randomly ignite new 'sparks' of heat near the bottom
     if( random8() < SPARKING ) {
       int y = random8(7);
@@ -102,4 +112,3 @@ void Fire2012()
       leds[pixelnumber] = color;
     }
 }
-

--- a/examples/Fire2012WithPalette/Fire2012WithPalette.ino
+++ b/examples/Fire2012WithPalette/Fire2012WithPalette.ino
@@ -1,9 +1,10 @@
 #include <FastLED.h>
 
-#define LED_PIN     5
-#define COLOR_ORDER GRB
-#define CHIPSET     WS2811
-#define NUM_LEDS    30
+#define NUM_LEDS 30
+#define LED_TYPE NEOPIXEL
+#define DATA_PIN 3
+#define CLOCK_PIN 13
+#define COLOR_ORDER RGB
 
 #define BRIGHTNESS  200
 #define FRAMES_PER_SECOND 60
@@ -19,8 +20,8 @@ CRGB leds[NUM_LEDS];
 // programmable color palette, instead of through the "HeatColor(...)" function.
 //
 // Four different static color palettes are provided here, plus one dynamic one.
-// 
-// The three static ones are: 
+//
+// The three static ones are:
 //   1. the FastLED built-in HeatColors_p -- this is the default, and it looks
 //      pretty much exactly like the original Fire2012.
 //
@@ -43,20 +44,29 @@ CRGBPalette16 gPal;
 
 void setup() {
   delay(3000); // sanity delay
-  FastLED.addLeds<CHIPSET, LED_PIN, COLOR_ORDER>(leds, NUM_LEDS).setCorrection( TypicalLEDStrip );
+
+  // Uncomment this line for a 3-Wire chipset
+  FastLED.addLeds<LED_TYPE, DATA_PIN, COLOR_ORDER>(leds, NUM_LEDS).setCorrection(TypicalLEDStrip);
+
+  // Uncomment this line for a SPI chipset
+  //FastLED.addLeds<LED_TYPE, COLOR_ORDER>(leds, NUM_LEDS).setCorrection(TypicalLEDStrip);
+
+  // Uncomment this line for a SPI chipset with the data and clock pins specified
+  //FastLED.addLeds<LED_TYPE, DATA_PIN, CLOCK_PIN, COLOR_ORDER>(leds, NUM_LEDS).setCorrection(TypicalLEDStrip);
+
   FastLED.setBrightness( BRIGHTNESS );
 
   // This first palette is the basic 'black body radiation' colors,
   // which run from black to red to bright yellow to white.
   gPal = HeatColors_p;
-  
+
   // These are other ways to set up the color palette for the 'fire'.
   // First, a gradient from black to red to yellow to white -- similar to HeatColors_p
   //   gPal = CRGBPalette16( CRGB::Black, CRGB::Red, CRGB::Yellow, CRGB::White);
-  
+
   // Second, this palette is like the heat colors, but blue/aqua instead of red/yellow
   //   gPal = CRGBPalette16( CRGB::Black, CRGB::Blue, CRGB::Aqua,  CRGB::White);
-  
+
   // Third, here's a simpler, three-step gradient, from black to red to white
   //   gPal = CRGBPalette16( CRGB::Black, CRGB::Red, CRGB::White);
 
@@ -80,7 +90,7 @@ void loop()
 
 
   Fire2012WithPalette(); // run simulation frame, using palette colors
-  
+
   FastLED.show(); // display this frame
   FastLED.delay(1000 / FRAMES_PER_SECOND);
 }
@@ -88,10 +98,10 @@ void loop()
 
 // Fire2012 by Mark Kriegsman, July 2012
 // as part of "Five Elements" shown here: http://youtu.be/knWiGsmgycY
-//// 
+////
 // This basic one-dimensional 'fire' simulation works roughly as follows:
 // There's a underlying array of 'heat' cells, that model the temperature
-// at each point along the line.  Every cycle through the simulation, 
+// at each point along the line.  Every cycle through the simulation,
 // four steps are performed:
 //  1) All cells cool down a little bit, losing heat to the air
 //  2) The heat from each cell drifts 'up' and diffuses a little
@@ -102,7 +112,7 @@ void loop()
 // Temperature is in arbitrary units from 0 (cold black) to 255 (white hot).
 //
 // This simulation scales it self a bit depending on NUM_LEDS; it should look
-// "OK" on anywhere from 20 to 100 LEDs without too much tweaking. 
+// "OK" on anywhere from 20 to 100 LEDs without too much tweaking.
 //
 // I recommend running this simulation at anywhere from 30-100 frames per second,
 // meaning an interframe delay of about 10-35 milliseconds.
@@ -116,7 +126,7 @@ void loop()
 //
 // COOLING: How much does the air cool as it rises?
 // Less cooling = taller flames.  More cooling = shorter flames.
-// Default 55, suggested range 20-100 
+// Default 55, suggested range 20-100
 #define COOLING  55
 
 // SPARKING: What chance (out of 255) is there that a new spark will be lit?
@@ -134,12 +144,12 @@ void Fire2012WithPalette()
     for( int i = 0; i < NUM_LEDS; i++) {
       heat[i] = qsub8( heat[i],  random8(0, ((COOLING * 10) / NUM_LEDS) + 2));
     }
-  
+
     // Step 2.  Heat from each cell drifts 'up' and diffuses a little
     for( int k= NUM_LEDS - 1; k >= 2; k--) {
       heat[k] = (heat[k - 1] + heat[k - 2] + heat[k - 2] ) / 3;
     }
-    
+
     // Step 3.  Randomly ignite new 'sparks' of heat near the bottom
     if( random8() < SPARKING ) {
       int y = random8(7);
@@ -161,4 +171,3 @@ void Fire2012WithPalette()
       leds[pixelnumber] = color;
     }
 }
-

--- a/examples/FirstLight/FirstLight.ino
+++ b/examples/FirstLight/FirstLight.ino
@@ -9,59 +9,78 @@
 //
 // Move a white dot along the strip of leds.  This program simply shows how to configure the leds,
 // and then how to turn a single pixel white and then off, moving down the line of pixels.
-// 
+//
 
-// How many leds are in the strip?
-#define NUM_LEDS 60
+// NUM_LEDS:
+//   Set NUM_LEDS to the number of LEDs on your strip.
+//
+// LED_TYPE:
+//   Set LED_TYPE to one of the chipset constants below. Make note of whether it is
+//   a 3-Wire or SPI chipset and uncomment the appropriate line in setup().
+//   3-Wire Chipsets:
+//   TM1803
+//   TM1804
+//   TM1809
+//   WS2811
+//   WS2812
+//   WS2812B
+//   NEOPIXEL
+//   APA104
+//   UCS1903
+//   UCS1903B
+//   GW6205
+//   GW6205_400
+//
+//   SPI Chipsets:
+//   WS2801
+//   SM16716
+//   LPD8806
+//   P9813
+//   APA102
+//   DOTSTAR
+//
+// DATA_PIN:
+//   For 3-Wire chipsets, set DATA_PIN to the pin number where the data line is
+//   connected. For SPI chipsets, if you are not using the default hardware SPI
+//   pins and are specifying your own, set DATA_PIN to the pin number where the
+//   data line is connected.
+//
+// CLOCK_PIN:
+//   For SPI chipsets, if you are specifying your own pins, also
+//   set CLOCK_PIN to the pin number where the clock line is connected.
+//
+// COLOR_ORDER:
+//   Set COLOR_ORDER to the order the controller should send the color data out.
+//   In most cases leave this as RGB.
 
-// Data pin that led data will be written out over
+#define NUM_LEDS 1
+#define LED_TYPE NEOPIXEL
 #define DATA_PIN 3
-
-// Clock pin only needed for SPI based chipsets when not using hardware SPI
-//#define CLOCK_PIN 8
+#define CLOCK_PIN 13
+#define COLOR_ORDER RGB
 
 // This is an array of leds.  One item for each led in your strip.
 CRGB leds[NUM_LEDS];
 
 // This function sets up the ledsand tells the controller about them
 void setup() {
-	// sanity check delay - allows reprogramming if accidently blowing power w/leds
-   	delay(2000);
+  // sanity check delay - allows reprogramming if accidently blowing power w/leds
+  delay(2000);
 
-      // Uncomment one of the following lines for your leds arrangement.
-      // FastLED.addLeds<TM1803, DATA_PIN, RGB>(leds, NUM_LEDS);
-      // FastLED.addLeds<TM1804, DATA_PIN, RGB>(leds, NUM_LEDS);
-      // FastLED.addLeds<TM1809, DATA_PIN, RGB>(leds, NUM_LEDS);
-      FastLED.addLeds<WS2811, DATA_PIN, RGB>(leds, NUM_LEDS);
-      // FastLED.addLeds<WS2812, DATA_PIN, RGB>(leds, NUM_LEDS);
-      // FastLED.addLeds<WS2812B, DATA_PIN, RGB>(leds, NUM_LEDS);
-      // FastLED.addLeds<NEOPIXEL, DATA_PIN>(leds, NUM_LEDS);
-      // FastLED.addLeds<APA104, DATA_PIN>(leds, NUM_LEDS);
-      // FastLED.addLeds<WS2811_400, DATA_PIN, RGB>(leds, NUM_LEDS);
-      // FastLED.addLeds<GW6205, DATA_PIN, RGB>(leds, NUM_LEDS);
-      // FastLED.addLeds<GW6205_400, DATA_PIN, RGB>(leds, NUM_LEDS);
-      // FastLED.addLeds<UCS1903, DATA_PIN, RGB>(leds, NUM_LEDS);
-      // FastLED.addLeds<UCS1903B, DATA_PIN, RGB>(leds, NUM_LEDS);
+  // Uncomment this line for a 3-Wire chipset
+  FastLED.addLeds<LED_TYPE, DATA_PIN, COLOR_ORDER>(leds, NUM_LEDS);
 
-      // FastLED.addLeds<WS2801, RGB>(leds, NUM_LEDS);
-      // FastLED.addLeds<SM16716, RGB>(leds, NUM_LEDS);
-      // FastLED.addLeds<LPD8806, RGB>(leds, NUM_LEDS);
-      // FastLED.addLeds<P9813, RGB>(leds, NUM_LEDS);
-      // FastLED.addLeds<APA102, RGB>(leds, NUM_LEDS);
-      // FastLED.addLeds<DOTSTAR, RGB>(leds, NUM_LEDS);
-      
-      // FastLED.addLeds<WS2801, DATA_PIN, CLOCK_PIN, RGB>(leds, NUM_LEDS);
-      // FastLED.addLeds<SM16716, DATA_PIN, CLOCK_PIN, RGB>(leds, NUM_LEDS);
-      // FastLED.addLeds<LPD8806, DATA_PIN, CLOCK_PIN, RGB>(leds, NUM_LEDS);
-      // FastLED.addLeds<P9813, DATA_PIN, CLOCK_PIN, RGB>(leds, NUM_LEDS);
-      // FastLED.addLeds<APA102, DATA_PIN, CLOCK_PIN, RGB>(leds, NUM_LEDS);
-      // FastLED.addLeds<DOTSTAR, DATA_PIN, CLOCK_PIN, RGB>(leds, NUM_LEDS);
+  // Uncomment this line for a SPI chipset
+  //FastLED.addLeds<LED_TYPE, COLOR_ORDER>(leds, NUM_LEDS);
+
+  // Uncomment this line for a SPI chipset with the data and clock pins specified
+  //FastLED.addLeds<LED_TYPE, DATA_PIN, CLOCK_PIN, COLOR_ORDER>(leds, NUM_LEDS);
 }
 
 // This function runs over and over, and is where you do the magic to light
 // your leds.
 void loop() {
-   // Move a single white led 
+   // Move a single white led
    for(int whiteLed = 0; whiteLed < NUM_LEDS; whiteLed = whiteLed + 1) {
       // Turn our current led on to white, then show the leds
       leds[whiteLed] = CRGB::White;

--- a/examples/Multiple/OctoWS2811Demo/OctoWS2811Demo.ino
+++ b/examples/Multiple/OctoWS2811Demo/OctoWS2811Demo.ino
@@ -1,6 +1,6 @@
 #define USE_OCTOWS2811
-#include<OctoWS2811.h>
-#include<FastLED.h>
+#include <OctoWS2811.h>
+#include <FastLED.h>
 
 #define NUM_LEDS_PER_STRIP 64
 #define NUM_STRIPS 8

--- a/examples/Multiple/ParallelOutputDemo/ParallelOutputDemo.ino
+++ b/examples/Multiple/ParallelOutputDemo/ParallelOutputDemo.ino
@@ -1,4 +1,4 @@
-#include<FastLED.h>
+#include <FastLED.h>
 
 #define NUM_LEDS_PER_STRIP 64
 // Note: this can be 12 if you're using a teensy 3 and don't mind soldering the pads on the back

--- a/examples/Noise/Noise.ino
+++ b/examples/Noise/Noise.ino
@@ -1,4 +1,4 @@
-#include<FastLED.h>
+#include <FastLED.h>
 
 //
 // Mark's xy coordinate mapping code.  See the XYMatrix for more information on it.

--- a/examples/NoisePlusPalette/NoisePlusPalette.ino
+++ b/examples/NoisePlusPalette/NoisePlusPalette.ino
@@ -1,4 +1,4 @@
-#include<FastLED.h>
+#include <FastLED.h>
 
 #define LED_PIN     3
 #define BRIGHTNESS  96

--- a/examples/RGBCalibrate/RGBCalibrate.ino
+++ b/examples/RGBCalibrate/RGBCalibrate.ino
@@ -1,5 +1,10 @@
 #include "FastLED.h"
 
+#define NUM_LEDS 6
+#define LED_TYPE NEOPIXEL
+#define DATA_PIN 6
+#define CLOCK_PIN 13
+#define COLOR_ORDER RGB
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //
@@ -11,55 +16,37 @@
 //   all explicitly specify the RGB order as RGB)
 // * Define DATA_PIN to the pin that data is connected to.
 // * (Optional) if using software SPI for chipsets that are SPI based, define CLOCK_PIN to the clock pin
-// * Compile/upload/run the sketch 
+// * Compile/upload/run the sketch
 
-// You should see six leds on.  If the RGB ordering is correct, you should see 1 red led, 2 green 
-// leds, and 3 blue leds.  If you see different colors, the count of each color tells you what the 
+// You should see six leds on.  If the RGB ordering is correct, you should see 1 red led, 2 green
+// leds, and 3 blue leds.  If you see different colors, the count of each color tells you what the
 // position for that color in the rgb orering should be.  So, for example, if you see 1 Blue, and 2
-// Red, and 3 Green leds then the rgb ordering should be BRG (Blue, Red, Green).  
+// Red, and 3 Green leds then the rgb ordering should be BRG (Blue, Red, Green).
 
 // You can then test this ordering by setting the RGB ordering in the addLeds line below to the new ordering
 // and it should come out correctly, 1 red, 2 green, and 3 blue.
 //
 //////////////////////////////////////////////////
 
-#define NUM_LEDS 6
-
-// Data pin that led data will be written out over
-#define DATA_PIN 6
-// Clock pin only needed for SPI based chipsets when not using hardware SPI
-//#define CLOCK_PIN 8
 
 CRGB leds[NUM_LEDS];
 
 void setup() {
 	// sanity check delay - allows reprogramming if accidently blowing power w/leds
-   	delay(2000);
+  delay(2000);
 
-      // Uncomment one of the following lines for your leds arrangement.
-      // FastLED.addLeds<TM1803, DATA_PIN, RGB>(leds, NUM_LEDS);
-      // FastLED.addLeds<TM1804, DATA_PIN, RGB>(leds, NUM_LEDS);
-      // FastLED.addLeds<TM1809, DATA_PIN, RGB>(leds, NUM_LEDS);
-      // FastLED.addLeds<WS2811, DATA_PIN, RGB>(leds, NUM_LEDS);
-      // FastLED.addLeds<WS2812, DATA_PIN, RGB>(leds, NUM_LEDS);
-      // FastLED.addLeds<WS2812B, DATA_PIN, GRB>(leds, NUM_LEDS);
-      // FastLED.setBrightness(CRGB(255,255,255));
-      // FastLED.addLeds<GW6205, DATA_PIN, RGB>(leds, NUM_LEDS);
-      // FastLED.addLeds<GW6205_400, DATA_PIN, RGB>(leds, NUM_LEDS);
-      // FastLED.addLeds<UCS1903, DATA_PIN, RGB>(leds, NUM_LEDS);
-      // FastLED.addLeds<UCS1903B, DATA_PIN, RGB>(leds, NUM_LEDS);
+  // Uncomment this line for a 3-Wire chipset
+  FastLED.addLeds<LED_TYPE, DATA_PIN, COLOR_ORDER>(leds, NUM_LEDS);
 
-      // FastLED.addLeds<WS2801, RGB>(leds, NUM_LEDS);
-      // FastLED.addLeds<SM16716, RGB>(leds, NUM_LEDS);
-      FastLED.addLeds<LPD8806, 9, 10, RGB>(leds, NUM_LEDS);
+  // Uncomment this line for a SPI chipset
+  //FastLED.addLeds<LED_TYPE, COLOR_ORDER>(leds, NUM_LEDS);
 
-      // FastLED.addLeds<WS2801, DATA_PIN, CLOCK_PIN, RGB>(leds, NUM_LEDS);
-      // FastLED.addLeds<SM16716, DATA_PIN, CLOCK_PIN, RGB>(leds, NUM_LEDS);
-      // FastLED.addLeds<LPD8806, DATA_PIN, CLOCK_PIN, RGB>(leds, NUM_LEDS);
+  // Uncomment this line for a SPI chipset with the data and clock pins specified
+  //FastLED.addLeds<LED_TYPE, DATA_PIN, CLOCK_PIN, COLOR_ORDER>(leds, NUM_LEDS);
 }
 
 void loop() {
-   leds[0] = CRGB(255,0,0); 
+   leds[0] = CRGB(255,0,0);
    leds[1] = CRGB(0,255,0);
    leds[2] = CRGB(0,255,0);
    leds[3] = CRGB(0,0,255);

--- a/examples/SmartMatrix/SmartMatrix.ino
+++ b/examples/SmartMatrix/SmartMatrix.ino
@@ -1,5 +1,5 @@
-#include<SmartMatrix.h>
-#include<FastLED.h>
+#include <SmartMatrix.h>
+#include <FastLED.h>
 
 #define kMatrixWidth  32
 #define kMatrixHeight 32


### PR DESCRIPTION
Standardized all of the single stranded examples (i.e. not matrix or multiple) to use the same macros to define strip settings. addLeds() calls were consolidated into the three use cases. Full instructions were added to FirstLight for help on setting up the values for the macros.

This addresses #212 and is probably a step towards #52
