### PR TITLE
Added WS2852 support

### DIFF
--- a/FastLED.h
+++ b/FastLED.h
@@ -90,6 +90,7 @@ template<uint8_t DATA_PIN, EOrder RGB_ORDER> class UCS1904 : public UCS1904Contr
 template<uint8_t DATA_PIN, EOrder RGB_ORDER> class UCS2903 : public UCS2903Controller<DATA_PIN, RGB_ORDER> {};
 template<uint8_t DATA_PIN, EOrder RGB_ORDER> class WS2812 : public WS2812Controller800Khz<DATA_PIN, RGB_ORDER> {};
 template<uint8_t DATA_PIN, EOrder RGB_ORDER> class WS2812B : public WS2812Controller800Khz<DATA_PIN, RGB_ORDER> {};
+template<uint8_t DATA_PIN> class WS2852 : public WS2812Controller800Khz<DATA_PIN, GRB> {};
 template<uint8_t DATA_PIN, EOrder RGB_ORDER> class SK6812 : public SK6812Controller<DATA_PIN, RGB_ORDER> {};
 template<uint8_t DATA_PIN, EOrder RGB_ORDER> class SK6822 : public SK6822Controller<DATA_PIN, RGB_ORDER> {};
 template<uint8_t DATA_PIN, EOrder RGB_ORDER> class PL9823 : public PL9823Controller<DATA_PIN, RGB_ORDER> {};


### PR DESCRIPTION
World Semi has released a 3.5 x 3.5mm package version of the WS2812B. It integrates the controller and RGB leds into a PLCC4 SMD package. 

Like the Neopixel, ordering is defaulted to GRB.