### PR TITLE
Fixed compiler errors in Arduino 1.6.7

### DIFF
--- a/examples/DemoReel100/DemoReel100.ino
+++ b/examples/DemoReel100/DemoReel100.ino
@@ -36,6 +36,14 @@ void setup() {
   FastLED.setBrightness(BRIGHTNESS);
 }
 
+void rainbow();
+void rainbowWithGlitter();
+void confetti();
+void sinelon();
+void juggle();
+void bpm();
+void nextPattern();
+void addGlitter(fract8 chanceOfGlitter);
 
 // List of patterns to cycle through.  Each is defined as a separate function below.
 typedef void (*SimplePatternList[])();


### PR DESCRIPTION
I just added forward declaration for the offending functions.  Please let me know if there's another way you'd prefer to fix these errors.

```
C:\Users\Jason\Documents\Arduino\FastLED\examples\DemoReel100\DemoReel100.ino:41:33: error: 'rainbow' was not declared in this scope
SimplePatternList gPatterns = { rainbow, rainbowWithGlitter, confetti, sinelon, juggle, bpm };
^
C:\Users\Jason\Documents\Arduino\FastLED\examples\DemoReel100\DemoReel100.ino:41:42: error: 'rainbowWithGlitter' was not declared in this scope
SimplePatternList gPatterns = { rainbow, rainbowWithGlitter, confetti, sinelon, juggle, bpm };
^
C:\Users\Jason\Documents\Arduino\FastLED\examples\DemoReel100\DemoReel100.ino:41:62: error: 'confetti' was not declared in this scope
SimplePatternList gPatterns = { rainbow, rainbowWithGlitter, confetti, sinelon, juggle, bpm };
^
C:\Users\Jason\Documents\Arduino\FastLED\examples\DemoReel100\DemoReel100.ino:41:72: error: 'sinelon' was not declared in this scope
SimplePatternList gPatterns = { rainbow, rainbowWithGlitter, confetti, sinelon, juggle, bpm };
^
C:\Users\Jason\Documents\Arduino\FastLED\examples\DemoReel100\DemoReel100.ino:41:81: error: 'juggle' was not declared in this scope
SimplePatternList gPatterns = { rainbow, rainbowWithGlitter, confetti, sinelon, juggle, bpm };
^
C:\Users\Jason\Documents\Arduino\FastLED\examples\DemoReel100\DemoReel100.ino:41:89: error: 'bpm' was not declared in this scope
SimplePatternList gPatterns = { rainbow, rainbowWithGlitter, confetti, sinelon, juggle, bpm };
^
C:\Users\Jason\Documents\Arduino\FastLED\examples\DemoReel100\DemoReel100.ino: In function 'void loop()':
C:\Users\Jason\Documents\Arduino\FastLED\examples\DemoReel100\DemoReel100.ino:58:39: error: 'nextPattern' was not declared in this scope
EVERY_N_SECONDS( 10 ) { nextPattern(); } // change patterns periodically
^
C:\Users\Jason\Documents\Arduino\FastLED\examples\DemoReel100\DemoReel100.ino: In function 'void rainbowWithGlitter()':
C:\Users\Jason\Documents\Arduino\FastLED\examples\DemoReel100\DemoReel100.ino:79:16: error: 'addGlitter' was not declared in this scope
addGlitter(80);
^
```