### PR TITLE
Added Simblee to led_sysdefs.h (same as NRF51 and RFduino).

### DIFF
--- a/led_sysdefs.h
+++ b/led_sysdefs.h
@@ -5,7 +5,7 @@
 
 #include "fastled_config.h"
 
-#if defined(NRF51) || defined(__RFduino__)
+#if defined(NRF51) || defined(__RFduino__) || defined (__Simblee__)
 #include "platforms/arm/nrf51/led_sysdefs_arm_nrf51.h"
 #elif defined(__MK20DX128__) || defined(__MK20DX256__)
 // Include k20/T3 headers


### PR DESCRIPTION
[Simblee](https://www.simblee.com) seems identical to NRF51 and RFduino.

I've verified that this compiles, and a friend with the hardware has verified that it actually works, while I wait on my hardware to arrive.  Please let me know if you'd prefer this handled differently (or not at all).  :)

Thanks!