### PR TITLE
Fix qadd7()

### DIFF
--- a/lib8tion/math8.h
+++ b/lib8tion/math8.h
@@ -47,15 +47,16 @@ LIB8STATIC_ALWAYS_INLINE uint8_t qadd8( uint8_t i, uint8_t j)
 #endif
 }
 
-/// Add one byte to another, saturating at 0x7F
+/// Add one byte to another, saturating at 0x7F / 0x80
 /// @param i - first byte to add
 /// @param j - second byte to add
-/// @returns the sum of i & j, capped at 0xFF
+/// @returns the sum of i & j, capped at 0x7F / 0x80
 LIB8STATIC_ALWAYS_INLINE int8_t qadd7( int8_t i, int8_t j)
 {
-#if QADD7_C == 1
+#if QADD7_C == 1 || 1
     int16_t t = i + j;
-    if( t > 127) t = 127;
+    if(t > 127) t = 127;
+    if(t < -128) t = -128;
     return t;
 #elif QADD7_AVRASM == 1
     asm volatile(


### PR DESCRIPTION
**No AVR implementation was added, defaulting to the c code!**

Test Sketch:
```cpp
#include "FastLED.h"
void setup() {}

void loop() {
  // put your main code here, to run repeatedly:
  Serial.println(qadd7(-100, -100));
  Serial.println(qadd7(100, 100));
  Serial.println(qadd7(-100, -10));
  Serial.println(qadd7(100, -10));
  Serial.println("*****");
  delay(1000);
}
```

Feel free to close the PR and copy the code to get a better commit if you wish.