### PR TITLE
Make gcc register allocation still more flexible

### DIFF
--- a/lib8tion/trig8.h
+++ b/lib8tion/trig8.h
@@ -195,7 +195,7 @@ LIB8STATIC uint8_t  sin8_avr( uint8_t theta)
                  "andi %[xr1], 0xF0         \n\t"
                  "or   %[mx], %[xr1]        \n\t"
                  : [mx] "=d" (mx), [xr1] "=d" (xr1)
-                 : [m16] "d" (m16), [secoffset] "d" (secoffset)
+                 : [m16] "r" (m16), [secoffset] "r" (secoffset)
                  );
 
     int8_t y = mx + b;


### PR DESCRIPTION
Regarding  a5e92af and #302

Looking at the datasheet says:
mul: 0 <= d <= 31, 0 <= r <= 31
mov: 0 <= d <= 31, 0 <= r <= 31
eor: 0 <= d <= 31
swap: 0 <= d <= 31
andi: 16 <= d <= 31, 0 <= K <= 255
or: 0 <= d <= 31, 0 <= r <= 31

This means only mx and xr1 should be a "d", the other can be "r". This makes compilation still flexible but should fix the bug too.
I tested this and my assumption is correct.