### PR TITLE
Make lerp8 and lerp16 reference parameters const

### DIFF
--- a/pixeltypes.h
+++ b/pixeltypes.h
@@ -485,7 +485,7 @@ struct CRGB {
     }
 
     /// return a new CRGB object after performing a linear interpolation between this object and the passed in object
-    inline CRGB lerp8( const CRGB& other, fract8 frac)
+    inline CRGB lerp8( const CRGB& other, fract8 frac) const
     {
       CRGB ret;
 
@@ -497,7 +497,7 @@ struct CRGB {
     }
 
     /// return a new CRGB object after performing a linear interpolation between this object and the passed in object
-    inline CRGB lerp16( const CRGB& other, fract16 frac)
+    inline CRGB lerp16( const CRGB& other, fract16 frac) const
     {
       CRGB ret;
 

--- a/pixeltypes.h
+++ b/pixeltypes.h
@@ -485,7 +485,7 @@ struct CRGB {
     }
 
     /// return a new CRGB object after performing a linear interpolation between this object and the passed in object
-    inline CRGB lerp8( CRGB & other, fract8 frac)
+    inline CRGB lerp8( const CRGB& other, fract8 frac)
     {
       CRGB ret;
 
@@ -497,7 +497,7 @@ struct CRGB {
     }
 
     /// return a new CRGB object after performing a linear interpolation between this object and the passed in object
-    inline CRGB lerp16( CRGB & other, fract16 frac)
+    inline CRGB lerp16( const CRGB& other, fract16 frac)
     {
       CRGB ret;
 


### PR DESCRIPTION
Allows the use of `const CRGB` objects and rvalue expressions as the first argument to *CRGB::lerp8* and *CRGB::lerp16*.
Consider the following example:
```
CRGB pixel;
CRGB red = CRGB::Red;
const CRGB red_const = red;

pixel.lerp8(red,       0); // OK
pixel.lerp8(-red,      0); // error: no known conversion for argument 1 from 'CRGB' to 'CRGB&'
pixel.lerp8(red_const, 0); // error: no known conversion for argument 1 from 'const CRGB' to 'CRGB&'
pixel.lerp8(CRGB::Red, 0); // error: no known conversion for argument 1 from 'CRGB::HTMLColorCode' to 'CRGB&'
```
The proposed change allows the latter three lines to compile and function as expected.