### PR TITLE
Fixed compile error: FastLED.h:437:47: error: expected type-specifier before 'SixteenWayInlineBlockClocklessCOntroller'

### DIFF
--- a/FastLED.h
+++ b/FastLED.h
@@ -434,7 +434,7 @@ public:
 		#ifdef HAS_PORTDC
 				case WS2811_PORTDC: return addLeds(new SixteenWayInlineBlockClocklessController<NUM_LANES,NS(320), NS(320), NS(640), RGB_ORDER>(), data, nLedsOrOffset, nLedsIfOffset);
 				case WS2811_400_PORTDC: return addLeds(new SixteenWayInlineBlockClocklessController<NUM_LANES,NS(800), NS(800), NS(900), RGB_ORDER>(), data, nLedsOrOffset, nLedsIfOffset);
-        case WS2813_PORTC: return addLeds(new SixteenWayInlineBlockClocklessCOntroller<NUM_LANES, NS(320), NS(320), NS(640), RGB_ORDER, 0, false, 300>(), data, nLedsOrOffset, nLedsIfOffset);
+        case WS2813_PORTC: return addLeds(new SixteenWayInlineBlockClocklessController<NUM_LANES, NS(320), NS(320), NS(640), RGB_ORDER, 0, false, 300>(), data, nLedsOrOffset, nLedsIfOffset);
 				case TM1803_PORTDC: return addLeds(new SixteenWayInlineBlockClocklessController<NUM_LANES, NS(700), NS(1100), NS(700), RGB_ORDER>(), data, nLedsOrOffset, nLedsIfOffset);
 				case UCS1903_PORTDC: return addLeds(new SixteenWayInlineBlockClocklessController<NUM_LANES, NS(500), NS(1500), NS(500), RGB_ORDER>(), data, nLedsOrOffset, nLedsIfOffset);
 		#endif


### PR DESCRIPTION
Was getting this compile error, tracked it down to a simple typo:

```
C:\Users\Jason\Documents\Arduino\libraries\FastLED/FastLED.h: In static member function 'static CLEDController& CFastLED::addLeds(CRGB*, int, int)':

C:\Users\Jason\Documents\Arduino\libraries\FastLED/FastLED.h:437:47: error: expected type-specifier before 'SixteenWayInlineBlockClocklessCOntroller'

         case WS2813_PORTC: return addLeds(new SixteenWayInlineBlockClocklessCOntroller<NUM_LANES, NS(320), NS(320), NS(640), RGB_ORDER, 0, false, 300>(), data, nLedsOrOffset, nLedsIfOffset);

                                               ^

C:\Users\Jason\Documents\Arduino\libraries\FastLED/FastLED.h:437:152: error: expected primary-expression before ')' token

         case WS2813_PORTC: return addLeds(new SixteenWayInlineBlockClocklessCOntroller<NUM_LANES, NS(320), NS(320), NS(640), RGB_ORDER, 0, false, 300>(), data, nLedsOrOffset, nLedsIfOffset);
```