### PR TITLE
missing OCTOWS2813 in OWS2811 define

### DIFF
--- a/FastLED.h
+++ b/FastLED.h
@@ -80,7 +80,7 @@ enum ESPIChipsets {
 };
 
 enum ESM { SMART_MATRIX };
-enum OWS2811 { OCTOWS2811,OCTOWS2811_400 };
+enum OWS2811 { OCTOWS2811,OCTOWS2811_400, OCTOWS2813};
 
 #ifdef HAS_PIXIE
 template<uint8_t DATA_PIN, EOrder RGB_ORDER> class PIXIE : public PixieController<DATA_PIN, RGB_ORDER> {};


### PR DESCRIPTION
error spotted by @unimatrix27 regrading the WS2813 problem broad up here #328 