### PR TITLE
Fix for crash caused when loading large palettes (Issue #378)

### DIFF
--- a/colorutils.h
+++ b/colorutils.h
@@ -825,7 +825,7 @@ public:
         TRGBGradientPaletteEntryUnion u;
 
         // Count entries
-        uint8_t count = 0;
+        uint16_t count = 0;
         do {
             u.dword = FL_PGM_READ_DWORD_NEAR(progent + count);
             count++;;
@@ -867,7 +867,7 @@ public:
         TRGBGradientPaletteEntryUnion u;
 
         // Count entries
-        uint8_t count = 0;
+        uint16_t count = 0;
         do {
             u = *(ent + count);
             count++;;
@@ -1222,7 +1222,7 @@ public:
         TRGBGradientPaletteEntryUnion u;
         
         // Count entries
-        uint8_t count = 0;
+        uint16_t count = 0;
         do {
             u.dword = FL_PGM_READ_DWORD_NEAR(progent + count);
             count++;;
@@ -1264,7 +1264,7 @@ public:
         TRGBGradientPaletteEntryUnion u;
         
         // Count entries
-        uint8_t count = 0;
+        uint16_t count = 0;
         do {
             u = *(ent + count);
             count++;;


### PR DESCRIPTION
Very simple patch which changes the counters used to scan the palette length from uint8_t to uint16_t.

This prevents a crash when palettes are larger than 255 bytes.  Granted they're still truncated down to 16 palette entries, but at least it isn't an infinite loop.