### PR TITLE
Fix CRGBArray operator=

### DIFF
--- a/pixelset.h
+++ b/pixelset.h
@@ -295,6 +295,7 @@ class CRGBArray : public CPixelView<CRGB> {
   CRGB rawleds[SIZE];
 public:
   CRGBArray() : CPixelView<CRGB>(rawleds, SIZE) {}
+  using CPixelView::operator=;
 };
 
 #endif


### PR DESCRIPTION
An implicit copy assignment operator is declared for CRGBArray, meaning we can't use the operator defined in the base class CPixelView.

A workaround is to use `operator()` to obtain a CPixelView:

```
CRGBArray<10> foo;
foo(0, foo.size()) = CRGB::White;
```

This fix allows us to use the CRGBArray directly:

```
CRGBArray<10> foo;
foo = CRGB::White;
```