### PR TITLE
- added a few methods to accept an offset parameter

### DIFF
--- a/colorutils.cpp
+++ b/colorutils.cpp
@@ -26,6 +26,15 @@ void fill_solid( struct CHSV * targetArray, int numToFill,
 }
 
 
+void fill_solid( struct CRGB * leds, int offset, int numToFill,
+                 const struct CRGB& color)
+{
+    for( int i = 0; i < numToFill; i++) {
+        leds[offset+i] = color;
+    }
+}
+
+
 // void fill_solid( struct CRGB* targetArray, int numToFill,
 // 				 const struct CHSV& hsvColor)
 // {
@@ -59,6 +68,21 @@ void fill_rainbow( struct CHSV * targetArray, int numToFill,
         hsv.hue += deltahue;
     }
 }
+
+void fill_rainbow( struct CRGB * pFirstLED, int offset, int numToFill,
+                  uint8_t initialhue,
+                  uint8_t deltahue )
+{
+    CHSV hsv;
+    hsv.hue = initialhue;
+    hsv.val = 255;
+    hsv.sat = 240;
+    for( int i = 0; i < numToFill; i++) {
+        pFirstLED[i+offset] = hsv;
+        hsv.hue += deltahue;
+    }
+}
+
 
 
 void fill_gradient_RGB( CRGB* leds,
@@ -191,6 +215,13 @@ void fadeToBlackBy( CRGB* leds, uint16_t num_leds, uint8_t fadeBy)
     nscale8( leds, num_leds, 255 - fadeBy);
 }
 
+void fadeToBlackBy( CRGB* leds,uint16_t offset, uint16_t num_leds, uint8_t fadeBy)
+{
+    nscale8( leds,offset, num_leds, 255 - fadeBy);
+
+}
+
+
 void fade_raw( CRGB* leds, uint16_t num_leds, uint8_t fadeBy)
 {
     nscale8( leds, num_leds, 255 - fadeBy);
@@ -205,6 +236,13 @@ void nscale8( CRGB* leds, uint16_t num_leds, uint8_t scale)
 {
     for( uint16_t i = 0; i < num_leds; i++) {
         leds[i].nscale8( scale);
+    }
+}
+
+void nscale8( CRGB* leds, uint16_t offset, uint16_t num_leds, uint8_t scale)
+{
+    for( uint16_t i = 0; i < num_leds; i++) {
+        leds[offset+i].nscale8( scale);
     }
 }
 

--- a/colorutils.h
+++ b/colorutils.h
@@ -18,11 +18,16 @@ FASTLED_NAMESPACE_BEGIN
 void fill_solid( struct CRGB * leds, int numToFill,
                  const struct CRGB& color);
 
+
 /// fill_solid -   fill a range of LEDs with a solid color
 ///                Example: fill_solid( leds, NUM_LEDS, CRGB(50,0,200));
 void fill_solid( struct CHSV* targetArray, int numToFill,
 				 const struct CHSV& hsvColor);
 
+/// fill_solid -   fill a part of an LED array (offset + number to fill ) with a solid color
+///                Example: fill_solid( leds, offset, NUM_LEDS, CRGB(50,0,200));
+void fill_solid( struct CRGB * leds, int offset, int numToFill, 
+                 const struct CRGB& color);
 
 /// fill_rainbow - fill a range of LEDs with a rainbow of colors, at
 ///                full saturation and full value (brightness)
@@ -36,6 +41,11 @@ void fill_rainbow( struct CHSV * targetArray, int numToFill,
                    uint8_t initialhue,
                    uint8_t deltahue = 5);
 
+// fill_rainbow - fill a part of an LED array ( not the whole strip ) with a rainbow of colors,
+//                full saturatyion and full value
+void fill_rainbow( struct CRGB * pFirstLED, int offset, int numToFill, 
+                  uint8_t initialhue,  
+                  uint8_t deltahue );
 
 // fill_gradient - fill an array of colors with a smooth HSV gradient
 //                 between two specified HSV colors.
@@ -245,13 +255,20 @@ void nscale8_video( CRGB* leds, uint16_t num_leds, uint8_t scale);
 //                              functions will eventually fade all
 //                              the way to black.
 //                              (The two names are synonyms.)
-void fadeToBlackBy( CRGB* leds, uint16_t num_leds, uint8_t fadeBy);
+void fadeToBlackBy( CRGB* leds, uint16_t num_leds, uint8_t fadeBy); 
+
+// fade part of an led array with black colors. 
+void fadeToBlackBy( CRGB* leds, uint16_t offset, uint16_t num_leds, uint8_t fadeBy);
 void fade_raw(      CRGB* leds, uint16_t num_leds, uint8_t fadeBy);
 
 // nscale8 - scale down the brightness of an array of pixels
 //           all at once.  This function can scale pixels all the
 //           way down to black even if 'scale' is not zero.
 void nscale8(       CRGB* leds, uint16_t num_leds, uint8_t scale);
+
+
+// scale brigthness of an led array LED array ( from offset until num_leds) 
+void nscale8( CRGB* leds,uint16_t offset, uint16_t num_leds, uint8_t scale);
 
 // fadeUsingColor - scale down the brightness of an array of pixels,
 //                  as though it were seen through a transparent


### PR DESCRIPTION
  this is useful if you keep all your LEDs in a single, large array.
  I do this to save dynamic memory -  because I have LED strands with
  different lengths; declaring a two-dimensional LED matrix will
  reserve too much memory; so i put them all in one single one-dimensional
  array
  New methods which accept an "offset parameter" are :
  - fill_solid
  - fill_rainbow
  - fadeToBlackBy
  - nscale8