### PR TITLE
Support ATtinyX41 boards.

### DIFF
--- a/FastLED.cpp
+++ b/FastLED.cpp
@@ -129,7 +129,7 @@ void CFastLED::delay(unsigned long ms) {
 		::delay(1);
 #endif
 		show();
-#if defined(ARDUINO) && (ARDUINO > 150) && !defined(IS_BEAN) && !defined (ARDUINO_AVR_DIGISPARK)
+#if defined(ARDUINO) && (ARDUINO > 150) && !defined(IS_BEAN) && !defined (ARDUINO_AVR_DIGISPARK) && !defined (__AVR_ATtinyX41__)
 		yield();
 #endif
 	}

--- a/lib8tion.h
+++ b/lib8tion.h
@@ -183,7 +183,7 @@ Lib8tion is pronounced like 'libation': lie-BAY-shun
 // for memmove, memcpy, and memset if not defined here
 #endif
 
-#if defined(__AVR_ATmega32U2__) || defined(__AVR_ATmega16U2__) || defined(__AVR_ATmega8U2__) || defined(__AVR_AT90USB162__) || defined(__AVR_ATtiny24__) || defined(__AVR_ATtiny44__) || defined(__AVR_ATtiny84__) || defined(__AVR_ATtiny25__) || defined(__AVR_ATtiny45__) || defined(__AVR_ATtiny85__) || defined(__AVR_ATtiny167__) || defined(__AVR_ATtiny87__)
+#if defined(__AVR_ATmega32U2__) || defined(__AVR_ATmega16U2__) || defined(__AVR_ATmega8U2__) || defined(__AVR_AT90USB162__) || defined(__AVR_ATtiny24__) || defined(__AVR_ATtiny44__) || defined(__AVR_ATtiny84__) || defined(__AVR_ATtiny25__) || defined(__AVR_ATtiny45__) || defined(__AVR_ATtiny85__) || defined(__AVR_ATtiny167__) || defined(__AVR_ATtiny87__) || defined(__AVR_ATtinyX41__)
 #define LIB8_ATTINY 1
 #endif
 

--- a/platforms/avr/fastpin_avr.h
+++ b/platforms/avr/fastpin_avr.h
@@ -61,6 +61,17 @@ _DEFPIN_AVR(4, 0x10, B); _DEFPIN_AVR(5, 0x20, B);
 
 #define HAS_HARDWARE_PIN_SUPPORT 1
 
+#elif defined(__AVR_ATtiny841__) || defined(__AVR_ATtiny441__)
+#define MAX_PIN 11
+_IO(A); _IO(B);
+
+_DEFPIN_AVR(0, 0x01, B); _DEFPIN_AVR(1, 0x02, B); _DEFPIN_AVR(2, 0x04, B);
+_DEFPIN_AVR(3, 0x80, A); _DEFPIN_AVR(4, 0x40, A); _DEFPIN_AVR(5, 0x20, A);
+_DEFPIN_AVR(6, 0x10, A); _DEFPIN_AVR(7, 0x08, A); _DEFPIN_AVR(8, 0x04, A);
+_DEFPIN_AVR(9, 0x02, A); _DEFPIN_AVR(10, 0x01, A); _DEFPIN_AVR(11, 0x08, B);
+
+#define HAS_HARDWARE_PIN_SUPPORT 1
+
 #elif defined(ARDUINO_AVR_DIGISPARK) // digispark pin layout
 #define MAX_PIN 5
 #define HAS_HARDWARE_PIN_SUPPORT 1


### PR DESCRIPTION
Adds support for ATtiny 841 and 441 controllers. I only have 841 hardware to test, but the 441 *should* be identical.

These controllers have hardware SPI, but the standard AVR SPI stuff didn't seem to work for me, so I've left it off for now.