### PR TITLE
Add support for ATmega328 non-picopower hardware pins

### DIFF
--- a/platforms/avr/fastpin_avr.h
+++ b/platforms/avr/fastpin_avr.h
@@ -158,7 +158,7 @@ _DEFPIN_AVR(16, 0x04, C); _DEFPIN_AVR(17, 0x08, C); _DEFPIN_AVR(18, 0x10, C); _D
 #define SPI_UART0_CLOCK 12
 #endif
 
-#elif defined(__AVR_ATmega328P__) || defined(__AVR_ATmega168__) || defined(__AVR_ATmega168P__) || defined(__AVR_ATmega8__)
+#elif defined(__AVR_ATmega328P__)  || defined(__AVR_ATmega328__) || defined(__AVR_ATmega168__) || defined(__AVR_ATmega168P__) || defined(__AVR_ATmega8__)
 // Accelerated port definitions for arduino avrs
 _IO(D); _IO(B); _IO(C);
 


### PR DESCRIPTION
Should be a fairly simple pull request as it's only one line. The ATmega328 (not p - picopower) is not currently included in the logic check with the others in the same series. I've added it so that the hardware pin map is correctly assigned and it does not revert to software mapping.

I had a project fail to compile when I had a ATmega328 part so I think this will help others.

John. 