### PR TITLE
Added Fastpin InputPullup() and get() functions

### DIFF
--- a/fastpin.h
+++ b/fastpin.h
@@ -206,14 +206,14 @@ template<uint8_t PIN> class FastPin {
 
 	static_assert(validpin(), "Invalid pin specified");
 
-	static void _init() {
-	}
+	static void _init() { }
 public:
 	typedef volatile RwReg * port_ptr_t;
 	typedef RwReg port_t;
 
 	inline static void setOutput() { }
 	inline static void setInput() { }
+    inline static void setInputPullup() { }
 
 	inline static void hi() __attribute__ ((always_inline)) { }
 	inline static void lo() __attribute__ ((always_inline)) { }
@@ -221,6 +221,8 @@ public:
 	inline static void strobe() __attribute__ ((always_inline)) { }
 
 	inline static void toggle() __attribute__ ((always_inline)) { }
+
+    inline static bool get() __attribute__ ((always_inline)) { return false; }
 
 	inline static void hi(register port_ptr_t port) __attribute__ ((always_inline)) { }
 	inline static void lo(register port_ptr_t port) __attribute__ ((always_inline)) { }

--- a/fastpin.h
+++ b/fastpin.h
@@ -238,6 +238,21 @@ public:
 
 #endif
 
+template<uint8_t PIN> class FastOutputPin : public FastPin<PIN> {
+public:
+	FastOutputPin(void) { this->setOutput(); }
+};
+
+template<uint8_t PIN> class FastInputPin : public FastPin<PIN> {
+public:
+	FastInputPin(void) { this->setInput(); }
+};
+
+template<uint8_t PIN> class FastInputPullupPin : public FastPin<PIN> {
+public:
+	FastInputPullupPin(void) { this->setInputPullup(); }
+};
+
 template<uint8_t PIN> class FastPinBB : public FastPin<PIN> {};
 
 typedef volatile uint32_t & reg32_t;

--- a/platforms/avr/fastpin_avr.h
+++ b/platforms/avr/fastpin_avr.h
@@ -21,6 +21,7 @@ public:
 
 	inline static void setOutput() { _DDR::r() |= _MASK; }
 	inline static void setInput() { _DDR::r() &= ~_MASK; }
+    inline static void setInputPullup() { setInput(); hi(); }
 
 	inline static void hi() __attribute__ ((always_inline)) { _PORT::r() |= _MASK; }
 	inline static void lo() __attribute__ ((always_inline)) { _PORT::r() &= ~_MASK; }
@@ -29,6 +30,8 @@ public:
 	inline static void strobe() __attribute__ ((always_inline)) { toggle(); toggle(); }
 
 	inline static void toggle() __attribute__ ((always_inline)) { _PIN::r() = _MASK; }
+
+    inline static bool get() __attribute__ ((always_inline)) { return _PIN::r() & _MASK; }
 
 	inline static void hi(register port_ptr_t /*port*/) __attribute__ ((always_inline)) { hi(); }
 	inline static void lo(register port_ptr_t /*port*/) __attribute__ ((always_inline)) { lo(); }


### PR DESCRIPTION
Currently there are only operations to set a pin, but not to read it. It is very simple to add this functionality. I only implemented it for AVR, but it should not influence any of the other architectures if its missing there.

The source has tabs, it should be "untabified". Maybe other files as well. Is it okay when I do it inside the PR?