### PR TITLE
fixes build for ESP32s

### DIFF
--- a/FastLED.cpp
+++ b/FastLED.cpp
@@ -239,7 +239,7 @@ extern "C" void yield(void) { }
 #ifdef NEED_CXX_BITS
 namespace __cxxabiv1
 {
-	#ifndef ESP8266
+	#if !defined(ESP8266) && !defined(ESP32)
 	extern "C" void __cxa_pure_virtual (void) {}
 	#endif
 

--- a/FastLED.h
+++ b/FastLED.h
@@ -11,12 +11,12 @@
 #define FASTLED_HAS_PRAGMA_MESSAGE
 #endif
 
-#define FASTLED_VERSION 3001006
+#define FASTLED_VERSION 3001007
 #ifndef FASTLED_INTERNAL
 #  ifdef FASTLED_HAS_PRAGMA_MESSAGE
-#    pragma message "FastLED version 3.001.006"
+#    pragma message "FastLED version 3.001.007"
 #  else
-#    warning FastLED version 3.001.006  (Not really a warning, just telling you here.)
+#    warning FastLED version 3.001.007  (Not really a warning, just telling you here.)
 #  endif
 #endif
 

--- a/FastLED.h
+++ b/FastLED.h
@@ -11,12 +11,12 @@
 #define FASTLED_HAS_PRAGMA_MESSAGE
 #endif
 
-#define FASTLED_VERSION 3001007
+#define FASTLED_VERSION 3001008
 #ifndef FASTLED_INTERNAL
 #  ifdef FASTLED_HAS_PRAGMA_MESSAGE
-#    pragma message "FastLED version 3.001.007"
+#    pragma message "FastLED version 3.001.008"
 #  else
-#    warning FastLED version 3.001.007  (Not really a warning, just telling you here.)
+#    warning FastLED version 3.001.008  (Not really a warning, just telling you here.)
 #  endif
 #endif
 

--- a/library.json
+++ b/library.json
@@ -18,7 +18,7 @@
         "type": "git",
         "url": "https://github.com/FastLED/FastLED.git"
     },
-    "version": "3.1.6",
+    "version": "3.1.7",
     "license": "MIT",
     "homepage": "http://fastled.io",
     "frameworks": "arduino",

--- a/library.json
+++ b/library.json
@@ -18,7 +18,7 @@
         "type": "git",
         "url": "https://github.com/FastLED/FastLED.git"
     },
-    "version": "3.1.7",
+    "version": "3.1.8",
     "license": "MIT",
     "homepage": "http://fastled.io",
     "frameworks": "arduino",

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,10 +1,12 @@
-3.1.7
+3.1.8 
 * Added support for Adafruit Circuit Playground Express (Thanks to Lady Ada)
 * Improved support for Adafruit Gemma and Trinket m0 (Thanks to Lady Ada)
 * Added support for PJRC's WS2812Serial (Thanks to Paul Stoffregen)
 * Added support for ATmega328 non-picopower hardware pins (Thanks to John Whittington)
 * Fixes for ESP32 support (Thanks to Daniel Tullemans)
 * 'Makefile' compilation fix (Thanks to Nico Hood)
+
+3.1.7 (skipped)
 
 3.1.6
 * Preliminary support for esp32

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,3 +1,11 @@
+3.1.7
+* Added support for Adafruit Circuit Playground Express (Thanks to Lady Ada)
+* Improved support for Adafruit Gemma and Trinket m0 (Thanks to Lady Ada)
+* Added support for PJRC's WS2812Serial (Thanks to Paul Stoffregen)
+* Added support for ATmega328 non-picopower hardware pins (Thanks to John Whittington)
+* Fixes for ESP32 support (Thanks to Daniel Tullemans)
+* 'Makefile' compilation fix (Thanks to Nico Hood)
+
 3.1.6
 * Preliminary support for esp32
 * Variety of random bug fixes


### PR DESCRIPTION
it seems that definition of __cxa_pure_virtual is already included in ESP32 build chain