### PR TITLE
ATTinyCore support

### DIFF
--- a/platforms/avr/led_sysdefs_avr.h
+++ b/platforms/avr/led_sysdefs_avr.h
@@ -43,6 +43,9 @@ extern "C" {
 #  if defined(CORE_TEENSY) || defined(TEENSYDUINO)
 extern volatile unsigned long timer0_millis_count;
 #    define MS_COUNTER timer0_millis_count
+#  elif defined(ATTINY_CORE)
+extern volatile unsigned long millis_timer_millis;
+#    define MS_COUNTER millis_timer_millis
 #  else
 extern volatile unsigned long timer0_millis;
 #    define MS_COUNTER timer0_millis


### PR DESCRIPTION
Arduino's timer0_millis is called millis_timer_millis in ATTinyCore from Spence Konde (https://github.com/SpenceKonde/ATTinyCore)
I've compiled some example sketches to make sure nothing else looks broken
You have to use ATTinyCore 1.1.5 (or higher)  because of missing yield() export in previous versions