### PR TITLE
stm32duino port (Maple, Blue Pill etc.)

### DIFF
--- a/led_sysdefs.h
+++ b/led_sysdefs.h
@@ -19,7 +19,7 @@
 #elif defined(__SAM3X8E__)
 // Include sam/due headers
 #include "platforms/arm/sam/led_sysdefs_arm_sam.h"
-#elif defined(STM32F10X_MD)
+#elif defined(STM32F10X_MD) || defined(__STM32F1__)
 #include "platforms/arm/stm32/led_sysdefs_arm_stm32.h"
 #elif defined(__SAMD21G18A__) || defined(__SAMD21J18A__) || defined(__SAMD21E17A__) || defined(__SAMD21E18A__)
 #include "platforms/arm/d21/led_sysdefs_arm_d21.h"

--- a/platforms.h
+++ b/platforms.h
@@ -19,7 +19,7 @@
 #elif defined(__SAM3X8E__)
 // Include sam/due headers
 #include "platforms/arm/sam/fastled_arm_sam.h"
-#elif defined(STM32F10X_MD)
+#elif defined(STM32F10X_MD) || defined(__STM32F1__)
 #include "platforms/arm/stm32/fastled_arm_stm32.h"
 #elif defined(__SAMD21G18A__) || defined(__SAMD21J18A__) || defined(__SAMD21E17A__) || defined(__SAMD21E18A__)
 #include "platforms/arm/d21/fastled_arm_d21.h"

--- a/platforms/arm/stm32/cm3_regs.h
+++ b/platforms/arm/stm32/cm3_regs.h
@@ -1,0 +1,63 @@
+#ifndef __CM3_REGS
+#define __CM3_REGS
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+  #define   __I     volatile             /*!< Defines 'read only' permissions                 */
+#else
+  #define   __I     volatile const       /*!< Defines 'read only' permissions                 */
+#endif
+#define     __O     volatile             /*!< Defines 'write only' permissions                */
+#define     __IO    volatile             /*!< Defines 'read / write' permissions              */
+
+
+typedef struct
+{
+  __IO uint32_t DHCSR;                   /*!< Offset: 0x000 (R/W)  Debug Halting Control and Status Register    */
+  __O  uint32_t DCRSR;                   /*!< Offset: 0x004 ( /W)  Debug Core Register Selector Register        */
+  __IO uint32_t DCRDR;                   /*!< Offset: 0x008 (R/W)  Debug Core Register Data Register            */
+  __IO uint32_t DEMCR;                   /*!< Offset: 0x00C (R/W)  Debug Exception and Monitor Control Register */
+} CoreDebug_Type;
+
+#define CoreDebug_BASE      (0xE000EDF0UL)                            /*!< Core Debug Base Address            */
+#define CoreDebug           ((CoreDebug_Type *)     CoreDebug_BASE)   /*!< Core Debug configuration struct    */
+
+#define CoreDebug_DEMCR_TRCENA_Pos         24                                             /*!< CoreDebug DEMCR: TRCENA Position */
+#define CoreDebug_DEMCR_TRCENA_Msk         (1UL << CoreDebug_DEMCR_TRCENA_Pos)            /*!< CoreDebug DEMCR: TRCENA Mask */
+
+typedef struct
+{
+  __IO uint32_t CTRL;                    /*!< Offset: 0x000 (R/W)  Control Register                          */
+  __IO uint32_t CYCCNT;                  /*!< Offset: 0x004 (R/W)  Cycle Count Register                      */
+  __IO uint32_t CPICNT;                  /*!< Offset: 0x008 (R/W)  CPI Count Register                        */
+  __IO uint32_t EXCCNT;                  /*!< Offset: 0x00C (R/W)  Exception Overhead Count Register         */
+  __IO uint32_t SLEEPCNT;                /*!< Offset: 0x010 (R/W)  Sleep Count Register                      */
+  __IO uint32_t LSUCNT;                  /*!< Offset: 0x014 (R/W)  LSU Count Register                        */
+  __IO uint32_t FOLDCNT;                 /*!< Offset: 0x018 (R/W)  Folded-instruction Count Register         */
+  __I  uint32_t PCSR;                    /*!< Offset: 0x01C (R/ )  Program Counter Sample Register           */
+  __IO uint32_t COMP0;                   /*!< Offset: 0x020 (R/W)  Comparator Register 0                     */
+  __IO uint32_t MASK0;                   /*!< Offset: 0x024 (R/W)  Mask Register 0                           */
+  __IO uint32_t FUNCTION0;               /*!< Offset: 0x028 (R/W)  Function Register 0                       */
+       uint32_t RESERVED0[1];
+  __IO uint32_t COMP1;                   /*!< Offset: 0x030 (R/W)  Comparator Register 1                     */
+  __IO uint32_t MASK1;                   /*!< Offset: 0x034 (R/W)  Mask Register 1                           */
+  __IO uint32_t FUNCTION1;               /*!< Offset: 0x038 (R/W)  Function Register 1                       */
+       uint32_t RESERVED1[1];
+  __IO uint32_t COMP2;                   /*!< Offset: 0x040 (R/W)  Comparator Register 2                     */
+  __IO uint32_t MASK2;                   /*!< Offset: 0x044 (R/W)  Mask Register 2                           */
+  __IO uint32_t FUNCTION2;               /*!< Offset: 0x048 (R/W)  Function Register 2                       */
+       uint32_t RESERVED2[1];
+  __IO uint32_t COMP3;                   /*!< Offset: 0x050 (R/W)  Comparator Register 3                     */
+  __IO uint32_t MASK3;                   /*!< Offset: 0x054 (R/W)  Mask Register 3                           */
+  __IO uint32_t FUNCTION3;               /*!< Offset: 0x058 (R/W)  Function Register 3                       */
+} DWT_Type;
+
+
+#define DWT_BASE            (0xE0001000UL)                            /*!< DWT Base Address                   */
+#define DWT                 ((DWT_Type       *)     DWT_BASE      )   /*!< DWT configuration struct           */
+
+#define DWT_CTRL_CYCCNTENA_Pos              0                                          /*!< DWT CTRL: CYCCNTENA Position */
+#define DWT_CTRL_CYCCNTENA_Msk             (0x1UL << DWT_CTRL_CYCCNTENA_Pos)           /*!< DWT CTRL: CYCCNTENA Mask */
+
+#endif // __CM3_REGS

--- a/platforms/arm/stm32/fastpin_arm_stm32.h
+++ b/platforms/arm/stm32/fastpin_arm_stm32.h
@@ -55,15 +55,21 @@ public:
   inline static port_t mask() __attribute__ ((always_inline)) { return _MASK; }
 };
 
+#if defined(STM32F10X_MD)
+ #define _RD32(T) struct __gen_struct_ ## T { static __attribute__((always_inline)) inline volatile GPIO_TypeDef * r() { return T; } };
+ #define _IO32(L) _RD32(GPIO ## L)
+#elif defined(__STM32F1__)
+ #define _RD32(T) struct __gen_struct_ ## T { static __attribute__((always_inline)) inline gpio_reg_map* r() { return T->regs; } };
+ #define _IO32(L) _RD32(GPIO ## L)
+#else
+ #error "Platform not supported"
+#endif
+
 #define _R(T) struct __gen_struct_ ## T
-#define _RD32(T) struct __gen_struct_ ## T { static __attribute__((always_inline)) inline volatile GPIO_TypeDef * r() { return T; } };
-
-#define _IO32(L) _RD32(GPIO ## L)
-
 #define _DEFPIN_ARM(PIN, BIT, L) template<> class FastPin<PIN> : public _ARMPIN<PIN, BIT, 1 << BIT, _R(GPIO ## L)> {};
 
 // Actual pin definitions
-#if defined(SPARK)
+#if defined(SPARK) // Sparkfun STM32F103 based board
 
 _IO32(A); _IO32(B); _IO32(C); _IO32(D); _IO32(E); _IO32(F); _IO32(G);
 
@@ -96,7 +102,54 @@ _DEFPIN_ARM(19, 2, A);
 
 #define HAS_HARDWARE_PIN_SUPPORT
 
-#endif
+#endif // SPARK
+
+#if defined(__STM32F1__) // Generic STM32F103 aka "Blue Pill"
+
+_IO32(A); _IO32(B); _IO32(C);
+
+#define MAX_PIN 46
+
+_DEFPIN_ARM(10, 0, A);	// PA0 - PA7
+_DEFPIN_ARM(11, 1, A);
+_DEFPIN_ARM(12, 2, A);
+_DEFPIN_ARM(13, 3, A);
+_DEFPIN_ARM(14, 4, A);
+_DEFPIN_ARM(15, 5, A);
+_DEFPIN_ARM(16, 6, A);
+_DEFPIN_ARM(17, 7, A);
+_DEFPIN_ARM(29, 8, A);	// PA8 - PA15
+_DEFPIN_ARM(30, 9, A);
+_DEFPIN_ARM(31, 10, A);
+_DEFPIN_ARM(32, 11, A);
+_DEFPIN_ARM(33, 12, A);
+_DEFPIN_ARM(34, 13, A);
+_DEFPIN_ARM(37, 14, A);
+_DEFPIN_ARM(38, 15, A);
+
+_DEFPIN_ARM(18, 0, B);	// PB0 - PB11
+_DEFPIN_ARM(19, 1, B);
+_DEFPIN_ARM(20, 2, B);
+_DEFPIN_ARM(39, 3, B);
+_DEFPIN_ARM(40, 4, B);
+_DEFPIN_ARM(41, 5, B);
+_DEFPIN_ARM(42, 6, B);
+_DEFPIN_ARM(43, 7, B);
+_DEFPIN_ARM(45, 8, B);
+_DEFPIN_ARM(46, 9, B);
+_DEFPIN_ARM(21, 10, B);
+_DEFPIN_ARM(22, 11, B);
+
+_DEFPIN_ARM(2, 13, C);	// PC13 - PC15
+_DEFPIN_ARM(3, 14, C);
+_DEFPIN_ARM(4, 15, C);
+
+#define SPI_DATA BOARD_SPI1_MOSI_PIN
+#define SPI_CLOCK BOARD_SPI1_SCK_PIN
+
+#define HAS_HARDWARE_PIN_SUPPORT
+
+#endif // __STM32F1__
 
 #endif // FASTLED_FORCE_SOFTWARE_PINS
 

--- a/platforms/arm/stm32/led_sysdefs_arm_stm32.h
+++ b/platforms/arm/stm32/led_sysdefs_arm_stm32.h
@@ -3,9 +3,26 @@
 
 #include <application.h>
 
-#define FASTLED_NAMESPACE_BEGIN namespace NSFastLED {
-#define FASTLED_NAMESPACE_END }
-#define FASTLED_USING_NAMESPACE using namespace NSFastLED;
+#if defined(STM32F10X_MD)
+
+ #define FASTLED_NAMESPACE_BEGIN namespace NSFastLED {
+ #define FASTLED_NAMESPACE_END }
+ #define FASTLED_USING_NAMESPACE using namespace NSFastLED;
+
+ // reusing/abusing cli/sei defs for due
+ #define cli()  __disable_irq(); __disable_fault_irq();
+ #define sei() __enable_irq(); __enable_fault_irq();
+
+#elif defined (__STM32F1__)
+
+ #include "cm3_regs.h"
+
+ #define cli() nvic_globalirq_disable()
+ #define sei() nvic_globalirq_enable()
+
+#else
+ #error "Platform not supported"
+#endif
 
 #define FASTLED_ARM
 
@@ -21,10 +38,6 @@
 #if FASTLED_ALLOW_INTERRUPTS == 1
 #define FASTLED_ACCURATE_CLOCK
 #endif
-
-// reusing/abusing cli/sei defs for due
-#define cli()  __disable_irq(); __disable_fault_irq();
-#define sei() __enable_irq(); __enable_fault_irq();
 
 // pgmspace definitions
 #define PROGMEM
@@ -42,6 +55,7 @@ typedef volatile       uint8_t RwReg; /**< Read-Write 8-bit register (volatile u
 
 #define FASTLED_NO_PINMAP
 
-#define F_CPU 72000000
-
+#ifndef F_CPU
+ #define F_CPU 72000000
+#endif
 #endif


### PR DESCRIPTION
This mostly builds on previous work for SparkCore STM32103 (Cortex M3),
and patches from Evey Quirk @evq.

Unfortunately, stm32duino distribution does not include a header
with definitions for CoreDebug registers and flags etc.
so they were added to a newly created cm3_regs.h from
https://github.com/ARM-software/CMSIS/blob/master/CMSIS/Include/core_cm3.h

Tested on my Blue Pill, works fine