### PR TITLE
Use relative paths for internal includes

### DIFF
--- a/platforms/arm/d21/clockless_arm_d21.h
+++ b/platforms/arm/d21/clockless_arm_d21.h
@@ -1,7 +1,7 @@
 #ifndef __INC_CLOCKLESS_ARM_D21
 #define __INC_CLOCKLESS_ARM_D21
 
-#include "platforms/arm/common/m0clockless.h"
+#include "../common/m0clockless.h"
 FASTLED_NAMESPACE_BEGIN
 #define FASTLED_HAS_CLOCKLESS 1
 

--- a/platforms/arm/kl26/clockless_arm_kl26.h
+++ b/platforms/arm/kl26/clockless_arm_kl26.h
@@ -1,7 +1,7 @@
 #ifndef __INC_CLOCKLESS_ARM_KL26
 #define __INC_CLOCKLESS_ARM_KL26
 
-#include "platforms/arm/common/m0clockless.h"
+#include "../common/m0clockless.h"
 FASTLED_NAMESPACE_BEGIN
 #define FASTLED_HAS_CLOCKLESS 1
 

--- a/platforms/arm/nrf51/clockless_arm_nrf51.h
+++ b/platforms/arm/nrf51/clockless_arm_nrf51.h
@@ -17,7 +17,7 @@
 #endif
 
 
-#include "platforms/arm/common/m0clockless.h"
+#include "../common/m0clockless.h"
 template <uint8_t DATA_PIN, int T1, int T2, int T3, EOrder RGB_ORDER = RGB, int XTRA0 = 0, bool FLIP = false, int WAIT_TIME = 75>
 class ClocklessController : public CPixelLEDController<RGB_ORDER> {
   typedef typename FastPinBB<DATA_PIN>::port_ptr_t data_ptr_t;

--- a/platforms/avr/clockless_trinket.h
+++ b/platforms/avr/clockless_trinket.h
@@ -1,8 +1,8 @@
 #ifndef __INC_CLOCKLESS_TRINKET_H
 #define __INC_CLOCKLESS_TRINKET_H
 
-#include "controller.h"
-#include "lib8tion.h"
+#include "../../controller.h"
+#include "../../lib8tion.h"
 #include <avr/interrupt.h> // for cli/se definitions
 
 FASTLED_NAMESPACE_BEGIN


### PR DESCRIPTION
This change allows the library to be used outside of the standard libraries folders. An example of when this is useful is bundling the library with a sketch so that it can be distributed as a self-contained package.

Prior to this change compiling the library when not located in a standard libraries folder would fail with a "No such file or directory" error.

Fixes https://github.com/FastLED/FastLED/issues/569