### PR TITLE
Add new platform "PIN_DEFINITIONS_MANUALLY_CONFIGURED"

### DIFF
--- a/platforms.h
+++ b/platforms.h
@@ -27,6 +27,8 @@
 #include "platforms/esp/8266/fastled_esp8266.h"
 #elif defined(ESP32)
 #include "platforms/esp/32/fastled_esp32.h"
+#elif defined(PIN_DEFINITIONS_MANUALLY_CONFIGURED)
+// If you have a custom pin layout that isn't specified above you can manually configure pins using this setting.
 #else
 // AVR platforms
 #include "platforms/avr/fastled_avr.h"


### PR DESCRIPTION
PIN_DEFINITIONS_MANUALLY_CONFIGURED is used when none of the preexisting board definitions align with a custom board you've designed for a one-off. Generally these one-off projects are not worth contributing back to FastLED by virtue of their non-common use.