### PR TITLE
Allow control of the built in Dotstar on the Gemma M0

### DIFF
--- a/platforms/arm/d21/fastpin_arm_d21.h
+++ b/platforms/arm/d21/fastpin_arm_d21.h
@@ -147,8 +147,9 @@ _DEFPIN_ARM( 20, 0,  6); _DEFPIN_ARM( 21, 0,  7);
 
 #elif defined(ARDUINO_GEMMA_M0)
 
-#define MAX_PIN 3
-_DEFPIN_ARM( 0, 0, 4); _DEFPIN_ARM( 1, 0, 2); _DEFPIN_ARM( 2, 0, 5);
+#define MAX_PIN 4
+_DEFPIN_ARM( 0, 0, 4); _DEFPIN_ARM( 1, 0, 2); _DEFPIN_ARM( 2, 0, 5); 
+_DEFPIN_ARM( 3, 0, 0); _DEFPIN_ARM( 4, 0, 1);
 
 #define HAS_HARDWARE_PIN_SUPPORT 1
 


### PR DESCRIPTION
The [Gemma M0](https://www.adafruit.com/product/3501) has a Dotstar on pins 3 and 4. These aren't exposed via pads, however it's nice to be able to control it with FastLED, especially to chain it with the rest of the strands so it is included in light patterns (as it's a wearable platform).

This change adds pins 3 and 4 to the Gemma M0 definition and raises MAX_PIN to 4.