### PR TITLE
Remove str and xstr macros

### DIFF
--- a/FastLED.h
+++ b/FastLED.h
@@ -4,9 +4,6 @@
 ///@file FastLED.h
 /// central include file for FastLED, defines the CFastLED class/object
 
-#define xstr(s) str(s)
-#define str(s) #s
-
 #if (__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 4)
 #define FASTLED_HAS_PRAGMA_MESSAGE
 #endif


### PR DESCRIPTION
`str` macro conflicts with any function or method that has the same name ignoring namespaces and class names. Most noticeably it conflicts with `std::basic_stringstream::str()`. Using the standard library is possible on platforms like ESP32.

Secondly, there is no usage of the `str` macro in the library. A `grep -nr 'str(' .` gives:
```
./FastLED.h:7:#define xstr(s) str(s)
./FastLED.h:8:#define str(s) #s
./platforms/avr/clockless_trinket.h:271:// #define xstr(a) str(a)
./platforms/avr/clockless_trinket.h:272:// #define str(a) #a
./platforms/avr/clockless_trinket.h:273:// #define ADJDITHER2(D,E) asm __volatile__("subi %[" #D "], " xstr(DUSE) "\n\tand %[" #D "], %[" #E "]\n\t" ASM_VARS);
```
So there is a second, commented implementation for the avr platform, which is left untouched by this commit. For avr the standard library cannot be used, so on avr it would not conflict immediately, but I would still consider `str` as a too common name.