### PR TITLE
only handle own rmt interrupts

### DIFF
--- a/platforms/esp/32/clockless_esp32.h
+++ b/platforms/esp/32/clockless_esp32.h
@@ -462,6 +462,8 @@ protected:
     //    controller is done until we look it up.
     static void doneOnChannel(rmt_channel_t channel, void * arg)
     {
+        if (channel >= FASTLED_RMT_MAX_CHANNELS) return;
+
         ClocklessController * controller = static_cast<ClocklessController*>(gOnChannel[channel]);
         portBASE_TYPE HPTaskAwoken = 0;
 


### PR DESCRIPTION
Exit early if the interrupt is for another channel which is used by something else than FastLED.

This is needed if we use FASTLED_RMT_BUILTIN_DRIVER and lower FASTLED_RMT_MAX_CHANNELS in order to free some rmt channels for something else.
In this case doneOnChannel() is called for all rmt channels even if they don't belong to FastLED. So exit early in this case before the esp32 notices and reboots on its own.