### PR TITLE
Add global brightness support for ADA102 and SK9822

### DIFF
--- a/controller.h
+++ b/controller.h
@@ -357,12 +357,19 @@ struct PixelController {
 
         template<int SLOT>  __attribute__((always_inline)) inline static uint8_t advanceAndLoadAndScale(PixelController & pc) { pc.advanceData(); return pc.loadAndScale<SLOT>(pc); }
         template<int SLOT>  __attribute__((always_inline)) inline static uint8_t advanceAndLoadAndScale(PixelController & pc, int lane) { pc.advanceData(); return pc.loadAndScale<SLOT>(pc, lane); }
+        template<int SLOT>  __attribute__((always_inline)) inline static uint8_t advanceAndLoadAndScale(PixelController & pc, int lane, uint8_t scale) { pc.advanceData(); return pc.loadAndScale<SLOT>(pc, lane, scale); }
 
-        template<int SLOT> __attribute__((always_inline)) inline static uint8_t getd(PixelController & pc) { return pc.d[RO(SLOT)]; }
-        template<int SLOT> __attribute__((always_inline)) inline static uint8_t getscale(PixelController & pc) { return pc.mScale.raw[RO(SLOT)]; }
+        template<int SLOT>  __attribute__((always_inline)) inline static uint8_t getd(PixelController & pc) { return pc.d[RO(SLOT)]; }
+        template<int SLOT>  __attribute__((always_inline)) inline static uint8_t getscale(PixelController & pc) { return pc.mScale.raw[RO(SLOT)]; }
 
         // Helper functions to get around gcc stupidities
-        __attribute__((always_inline)) inline uint8_t loadAndScale0(int lane) { return loadAndScale<0>(*this, lane); }
+        __attribute__((always_inline)) inline uint8_t loadAndScale0(int lane, uint8_t scale) { return loadAndScale<0>(*this, lane, scale); }
+        __attribute__((always_inline)) inline uint8_t loadAndScale1(int lane, uint8_t scale) { return loadAndScale<1>(*this, lane, scale); }
+        __attribute__((always_inline)) inline uint8_t loadAndScale2(int lane, uint8_t scale) { return loadAndScale<2>(*this, lane, scale); }
+		__attribute__((always_inline)) inline uint8_t advanceAndLoadAndScale0(int lane, uint8_t scale) { return advanceAndLoadAndScale<0>(*this, lane, scale); }
+		__attribute__((always_inline)) inline uint8_t stepAdvanceAndLoadAndScale0(int lane, uint8_t scale) { stepDithering(); return advanceAndLoadAndScale<0>(*this, lane, scale); }
+
+		__attribute__((always_inline)) inline uint8_t loadAndScale0(int lane) { return loadAndScale<0>(*this, lane); }
         __attribute__((always_inline)) inline uint8_t loadAndScale1(int lane) { return loadAndScale<1>(*this, lane); }
         __attribute__((always_inline)) inline uint8_t loadAndScale2(int lane) { return loadAndScale<2>(*this, lane); }
         __attribute__((always_inline)) inline uint8_t advanceAndLoadAndScale0(int lane) { return advanceAndLoadAndScale<0>(*this, lane); }
@@ -373,6 +380,10 @@ struct PixelController {
         __attribute__((always_inline)) inline uint8_t loadAndScale2() { return loadAndScale<2>(*this); }
         __attribute__((always_inline)) inline uint8_t advanceAndLoadAndScale0() { return advanceAndLoadAndScale<0>(*this); }
         __attribute__((always_inline)) inline uint8_t stepAdvanceAndLoadAndScale0() { stepDithering(); return advanceAndLoadAndScale<0>(*this); }
+
+		__attribute__((always_inline)) inline uint8_t getScale0() { return getscale<0>(*this); }
+		__attribute__((always_inline)) inline uint8_t getScale1() { return getscale<1>(*this); }
+		__attribute__((always_inline)) inline uint8_t getScale2() { return getscale<2>(*this); }
 };
 
 template<EOrder RGB_ORDER, int LANES=1, uint32_t MASK=0xFFFFFFFF> class CPixelLEDController : public CLEDController {

--- a/fastled_config.h
+++ b/fastled_config.h
@@ -61,5 +61,11 @@
 #define FASTLED_INTERRUPT_RETRY_COUNT 2
 #endif
 
+// Use this toggle to enable global brightness in contollers that support is (ADA102 and SK9822).
+// It changes how color scaling works and uses global brightness before scaling down color values.
+// This enable much more accurate color control on low brightness settings.
+// Value 1 means faster bit operations but only uses 6 extra brightness levels (powers of 2).
+// Value 2 means slightly slower math operations but it uses all 31 brightness levels.
+//#define FASTLED_USE_GLOBAL_BRIGHTNESS 2
 
 #endif


### PR DESCRIPTION
`ADA102` and `SK9822` controllers allow fine brightness control using lower 5 bits in the first byte of each pixel. Currently this byte is hardcoded to be `0xFF` which means it always uses full brightness. FastLED does brightness scaling by dividing 8-bit values and it produces super inaccurate results with low brightness settings (values below 5 is almost unusable).

This pull requests makes full use of per-pixel brightness control to avoid scaling down actual color values and this preserves much better color accuracy at low brightness settings, creating pretty much "HDR mode".

I've tested this code using `LOLIN D32` and `ADA102` strip. I don't have `SK9822` in my posession yet but its code was identical to `ADA102` before my changes so I expect it to work as well.

To enable "HDR mode" uncomment new config parameter in `fastled_config.h` and set your strip brightness to some very low number. `FASTLED_USE_GLOBAL_BRIGHTNESS=1` is faster but less accurate and `FASTLED_USE_GLOBAL_BRIGHTNESS=2` is slower but more accurate.

Fixes #91 and #469.