### PR TITLE
Suggest to `#define FASTLED_RMT_BUILTIN_DRIVER 1`

### DIFF
--- a/platforms/esp/32/clockless_esp32.h
+++ b/platforms/esp/32/clockless_esp32.h
@@ -49,7 +49,7 @@
  * co-exist. To switch to this mode, add the following directive
  * before you include FastLED.h:
  *
- *      #define FASTLED_RMT_BUILTIN_DRIVER
+ *      #define FASTLED_RMT_BUILTIN_DRIVER 1
  *
  * There may be a performance penalty for using this mode. We need to
  * compute the RMT signal for the entire LED strip ahead of time,


### PR DESCRIPTION
The documentation for FASTLED_RMT_BUILTIN_DRIVER says that you should

    #define FASTLED_RMT_BUILTIN_DRIVER

before `#include`ing FastLED if you have custom RMT applications running.
Without any non-zero value, this results in the following compile error:

    /path/to/Arduino/libraries/FastLED/platforms/esp/32/clockless_esp32.h: In member function 'void ClocklessController<DATA_PIN, T1, T2, T3, RGB_ORDER, XTRA0, FLIP, WAIT_TIME>::initRMT()':
    /path/to/Arduino/libraries/FastLED/platforms/esp/32/clockless_esp32.h:253:43: error: expected primary-expression before ')' token
             if (FASTLED_RMT_BUILTIN_DRIVER) {
                                           ^