### PR TITLE
Fix lerp16by16 where uint32_t should be uint16_t

### DIFF
--- a/lib8tion.h
+++ b/lib8tion.h
@@ -477,7 +477,7 @@ LIB8STATIC uint16_t lerp16by16( uint16_t a, uint16_t b, fract16 frac)
     uint16_t result;
     if( b > a ) {
         uint16_t delta = b - a;
-        uint32_t scaled = scale16(delta, frac);
+        uint16_t scaled = scale16(delta, frac);
         result = a + scaled;
     } else {
         uint16_t delta = a - b;


### PR DESCRIPTION
scale16 returns a uint16_t and it doesn't seem necessary to upcast.