### PR TITLE
Enable SAMD51 (ARM Cortex M4) Support

### DIFF
--- a/platforms.h
+++ b/platforms.h
@@ -21,8 +21,10 @@
 #include "platforms/arm/sam/fastled_arm_sam.h"
 #elif defined(STM32F10X_MD) || defined(__STM32F1__)
 #include "platforms/arm/stm32/fastled_arm_stm32.h"
-#elif defined(__SAMD21G18A__) || defined(__SAMD21J18A__) || defined(__SAMD21E17A__) || defined(__SAMD21E18A__) || defined(__SAMD51G19A__)
+#elif defined(__SAMD21G18A__) || defined(__SAMD21J18A__) || defined(__SAMD21E17A__) || defined(__SAMD21E18A__)
 #include "platforms/arm/d21/fastled_arm_d21.h"
+#elif defined(__SAMD51G19A__)
+#include "platforms/arm/d51/fastled_arm_d51.h"
 #elif defined(ESP8266)
 #include "platforms/esp/8266/fastled_esp8266.h"
 #elif defined(ESP32)

--- a/platforms/arm/d21/fastpin_arm_d21.h
+++ b/platforms/arm/d21/fastpin_arm_d21.h
@@ -172,7 +172,7 @@ _DEFPIN_ARM( 20, 0,  6); _DEFPIN_ARM( 21, 0,  7);
 #elif defined(ARDUINO_GEMMA_M0)
 
 #define MAX_PIN 4
-_DEFPIN_ARM( 0, 0, 4); _DEFPIN_ARM( 1, 0, 2); _DEFPIN_ARM( 2, 0, 5); 
+_DEFPIN_ARM( 0, 0, 4); _DEFPIN_ARM( 1, 0, 2); _DEFPIN_ARM( 2, 0, 5);
 _DEFPIN_ARM( 3, 0, 0); _DEFPIN_ARM( 4, 0, 1);
 
 #define HAS_HARDWARE_PIN_SUPPORT 1
@@ -185,27 +185,6 @@ _DEFPIN_ARM( 3, 0, 7); _DEFPIN_ARM( 4, 0, 6); _DEFPIN_ARM( 7, 0, 0); _DEFPIN_ARM
 
 #define SPI_DATA  4
 #define SPI_CLOCK 3
-
-#define HAS_HARDWARE_PIN_SUPPORT 1
-
-#elif defined(ADAFRUIT_ITSYBITSY_M4_EXPRESS)
-
-#define MAX_PIN 19
-// D0-D13, including D6+D8 (DotStar CLK + DATA)
-_DEFPIN_ARM( 0, 0, 16); _DEFPIN_ARM( 1, 0, 17); _DEFPIN_ARM( 2, 0,  7); _DEFPIN_ARM( 3, 1, 22);
-_DEFPIN_ARM( 4, 0, 14); _DEFPIN_ARM( 5, 0, 15); _DEFPIN_ARM( 6, 1,  2); _DEFPIN_ARM( 7, 0, 18);
-_DEFPIN_ARM( 8, 1,  3); _DEFPIN_ARM( 9, 0, 19); _DEFPIN_ARM(10, 0, 20); _DEFPIN_ARM(11, 0, 21);
-_DEFPIN_ARM(12, 0, 23); _DEFPIN_ARM(13, 0, 22);
-// A0-A5
-_DEFPIN_ARM(14, 0,  2); _DEFPIN_ARM(15, 0,  5); _DEFPIN_ARM(16, 1,  8); _DEFPIN_ARM(17, 1,  9);
-_DEFPIN_ARM(18, 0,  4); _DEFPIN_ARM(19, 0,  6); /* A6 is present in variant.h but couldn't find it on the schematic */
-// SDA/SCL
-_DEFPIN_ARM(21, 0, 12); _DEFPIN_ARM(22, 0, 13);
-// MISO/SCK/MOSI
-_DEFPIN_ARM(23, 1, 23); _DEFPIN_ARM(24, 0,  1); _DEFPIN_ARM(25, 0,  0);
-
-#define SPI_DATA 25
-#define SPI_CLOCK 24
 
 #define HAS_HARDWARE_PIN_SUPPORT 1
 

--- a/platforms/arm/d51/clockless_arm_d51.h
+++ b/platforms/arm/d51/clockless_arm_d51.h
@@ -1,0 +1,62 @@
+#ifndef __INC_CLOCKLESS_ARM_D51
+#define __INC_CLOCKLESS_ARM_D51
+
+// D51 is an M4 chip, however the M0 clockless logic seems to work.
+#include "../common/m0clockless.h"
+FASTLED_NAMESPACE_BEGIN
+#define FASTLED_HAS_CLOCKLESS 1
+
+template <uint8_t DATA_PIN, int T1, int T2, int T3, EOrder RGB_ORDER = RGB, int XTRA0 = 0, bool FLIP = false, int WAIT_TIME = 50>
+class ClocklessController : public CPixelLEDController<RGB_ORDER> {
+  typedef typename FastPinBB<DATA_PIN>::port_ptr_t data_ptr_t;
+  typedef typename FastPinBB<DATA_PIN>::port_t data_t;
+
+  data_t mPinMask;
+  data_ptr_t mPort;
+  CMinWait<WAIT_TIME> mWait;
+public:
+  virtual void init() {
+    FastPinBB<DATA_PIN>::setOutput();
+    mPinMask = FastPinBB<DATA_PIN>::mask();
+    mPort = FastPinBB<DATA_PIN>::port();
+  }
+
+	virtual uint16_t getMaxRefreshRate() const { return 400; }
+
+  virtual void showPixels(PixelController<RGB_ORDER> & pixels) {
+    mWait.wait();
+    cli();
+    if(!showRGBInternal(pixels)) {
+      sei(); delayMicroseconds(WAIT_TIME); cli();
+      showRGBInternal(pixels);
+    }
+    sei();
+    mWait.mark();
+  }
+
+  // This method is made static to force making register Y available to use for data on AVR - if the method is non-static, then
+  // gcc will use register Y for the this pointer.
+  static uint32_t showRGBInternal(PixelController<RGB_ORDER> pixels) {
+    struct M0ClocklessData data;
+    data.d[0] = pixels.d[0];
+    data.d[1] = pixels.d[1];
+    data.d[2] = pixels.d[2];
+    data.s[0] = pixels.mScale[0];
+    data.s[1] = pixels.mScale[1];
+    data.s[2] = pixels.mScale[2];
+    data.e[0] = pixels.e[0];
+    data.e[1] = pixels.e[1];
+    data.e[2] = pixels.e[2];
+    data.adj = pixels.mAdvance;
+
+    typename FastPin<DATA_PIN>::port_ptr_t portBase = FastPin<DATA_PIN>::port();
+    return showLedData<8,4,T1,T2,T3,RGB_ORDER, WAIT_TIME>(portBase, FastPin<DATA_PIN>::mask(), pixels.mData, pixels.mLen, &data);
+  }
+
+
+};
+
+FASTLED_NAMESPACE_END
+
+
+#endif // __INC_CLOCKLESS_ARM_D51

--- a/platforms/arm/d51/fastled_arm_d51.h
+++ b/platforms/arm/d51/fastled_arm_d51.h
@@ -1,0 +1,7 @@
+#ifndef __INC_FASTLED_ARM_D51_H
+#define __INC_FASTLED_ARM_D51_H
+
+#include "fastpin_arm_d51.h"
+#include "clockless_arm_d51.h"
+
+#endif

--- a/platforms/arm/d51/fastpin_arm_d51.h
+++ b/platforms/arm/d51/fastpin_arm_d51.h
@@ -1,0 +1,95 @@
+#ifndef __INC_FASTPIN_ARM_D51_H
+#define __INC_FASTPIN_ARM_D51_H
+
+FASTLED_NAMESPACE_BEGIN
+
+#if defined(FASTLED_FORCE_SOFTWARE_PINS)
+#warning "Software pin support forced, pin access will be slightly slower."
+#define NO_HARDWARE_PIN_SUPPORT
+#undef HAS_HARDWARE_PIN_SUPPORT
+
+#else
+
+/// Template definition for STM32 style ARM pins, providing direct access to the various GPIO registers.  Note that this
+/// uses the full port GPIO registers.  In theory, in some way, bit-band register access -should- be faster, however I have found
+/// that something about the way gcc does register allocation results in the bit-band code being slower.  It will need more fine tuning.
+/// The registers are data output, set output, clear output, toggle output, input, and direction
+
+template<uint8_t PIN, uint8_t _BIT, uint32_t _MASK, int _GRP> class _ARMPIN {
+public:
+  typedef volatile uint32_t * port_ptr_t;
+  typedef uint32_t port_t;
+
+  #if 0
+  inline static void setOutput() {
+    if(_BIT<8) {
+      _CRL::r() = (_CRL::r() & (0xF << (_BIT*4)) | (0x1 << (_BIT*4));
+    } else {
+      _CRH::r() = (_CRH::r() & (0xF << ((_BIT-8)*4))) | (0x1 << ((_BIT-8)*4));
+    }
+  }
+  inline static void setInput() { /* TODO */ } // TODO: preform MUX config { _PDDR::r() &= ~_MASK; }
+  #endif
+
+  inline static void setOutput() { pinMode(PIN, OUTPUT); } // TODO: perform MUX config { _PDDR::r() |= _MASK; }
+  inline static void setInput() { pinMode(PIN, INPUT); } // TODO: preform MUX config { _PDDR::r() &= ~_MASK; }
+
+  inline static void hi() __attribute__ ((always_inline)) { PORT->Group[_GRP].OUTSET.reg = _MASK; }
+  inline static void lo() __attribute__ ((always_inline)) { PORT->Group[_GRP].OUTCLR.reg = _MASK; }
+  inline static void set(register port_t val) __attribute__ ((always_inline)) { PORT->Group[_GRP].OUT.reg = val; }
+
+  inline static void strobe() __attribute__ ((always_inline)) { toggle(); toggle(); }
+
+  inline static void toggle() __attribute__ ((always_inline)) { PORT->Group[_GRP].OUTTGL.reg = _MASK; }
+
+  inline static void hi(register port_ptr_t port) __attribute__ ((always_inline)) { hi(); }
+  inline static void lo(register port_ptr_t port) __attribute__ ((always_inline)) { lo(); }
+  inline static void fastset(register port_ptr_t port, register port_t val) __attribute__ ((always_inline)) { *port = val; }
+
+  inline static port_t hival() __attribute__ ((always_inline)) { return PORT->Group[_GRP].OUT.reg | _MASK; }
+  inline static port_t loval() __attribute__ ((always_inline)) { return PORT->Group[_GRP].OUT.reg & ~_MASK; }
+  inline static port_ptr_t port() __attribute__ ((always_inline)) { return &PORT->Group[_GRP].OUT.reg; }
+  inline static port_ptr_t sport() __attribute__ ((always_inline)) { return &PORT->Group[_GRP].OUTSET.reg; }
+  inline static port_ptr_t cport() __attribute__ ((always_inline)) { return &PORT->Group[_GRP].OUTCLR.reg; }
+  inline static port_t mask() __attribute__ ((always_inline)) { return _MASK; }
+};
+
+#define _R(T) struct __gen_struct_ ## T
+#define _RD32(T) struct __gen_struct_ ## T { static __attribute__((always_inline)) inline volatile PortGroup * r() { return T; } };
+
+#define _IO32(L) _RD32(GPIO ## L)
+
+#define _DEFPIN_ARM(PIN, L, BIT) template<> class FastPin<PIN> : public _ARMPIN<PIN, BIT, 1 << BIT, L> {};
+
+// Actual pin definitions
+#if defined(ADAFRUIT_ITSYBITSY_M4_EXPRESS)
+
+#define MAX_PIN 19
+// D0-D13, including D6+D8 (DotStar CLK + DATA)
+_DEFPIN_ARM( 0, 0, 16); _DEFPIN_ARM( 1, 0, 17); _DEFPIN_ARM( 2, 0,  7); _DEFPIN_ARM( 3, 1, 22);
+_DEFPIN_ARM( 4, 0, 14); _DEFPIN_ARM( 5, 0, 15); _DEFPIN_ARM( 6, 1,  2); _DEFPIN_ARM( 7, 0, 18);
+_DEFPIN_ARM( 8, 1,  3); _DEFPIN_ARM( 9, 0, 19); _DEFPIN_ARM(10, 0, 20); _DEFPIN_ARM(11, 0, 21);
+_DEFPIN_ARM(12, 0, 23); _DEFPIN_ARM(13, 0, 22);
+// A0-A5
+_DEFPIN_ARM(14, 0,  2); _DEFPIN_ARM(15, 0,  5); _DEFPIN_ARM(16, 1,  8); _DEFPIN_ARM(17, 1,  9);
+_DEFPIN_ARM(18, 0,  4); _DEFPIN_ARM(19, 0,  6); /* A6 is present in variant.h but couldn't find it on the schematic */
+// SDA/SCL
+_DEFPIN_ARM(21, 0, 12); _DEFPIN_ARM(22, 0, 13);
+// MISO/SCK/MOSI
+_DEFPIN_ARM(23, 1, 23); _DEFPIN_ARM(24, 0,  1); _DEFPIN_ARM(25, 0,  0);
+
+#define SPI_DATA 25
+#define SPI_CLOCK 24
+
+#define HAS_HARDWARE_PIN_SUPPORT 1
+
+#endif
+
+
+
+#endif // FASTLED_FORCE_SOFTWARE_PINS
+
+FASTLED_NAMESPACE_END
+
+
+#endif // __INC_FASTPIN_ARM_D51_H

--- a/platforms/arm/d51/led_sysdefs_arm_d51.h
+++ b/platforms/arm/d51/led_sysdefs_arm_d51.h
@@ -1,0 +1,27 @@
+#ifndef __INC_LED_SYSDEFS_ARM_D51_H
+#define __INC_LED_SYSDEFS_ARM_D51_H
+
+
+#define FASTLED_ARM
+// Note this is an M4, not an M0+, but this enables the shared m0clockless.h
+#define FASTLED_ARM_M0_PLUS
+
+#ifndef INTERRUPT_THRESHOLD
+#define INTERRUPT_THRESHOLD 1
+#endif
+
+// Default to allowing interrupts
+#ifndef FASTLED_ALLOW_INTERRUPTS
+#define FASTLED_ALLOW_INTERRUPTS 0
+#endif
+
+#if FASTLED_ALLOW_INTERRUPTS == 1
+#define FASTLED_ACCURATE_CLOCK
+#endif
+
+// reusing/abusing cli/sei defs for due
+#define cli()  __disable_irq();
+#define sei() __enable_irq();
+
+
+#endif


### PR DESCRIPTION
Adds support for SAMD51 devices like the Adafruit M4 Express line.

I did see that support was added in 8f2e86434b2bfa4d6178622ca3745a68303f8b00 by assuming SAMD51 devices are the same as SAMD21, however in my experience this isn't the case. In fact I could not get FastLED to compile for the Adafruit Itsy-Bitsy M4 Express.

While this PR still mostly wholesale copies code from the D21 implementation (I noticed that D21 mostly wholesale copied from SAM, so hopefully this approach is ok) the critical difference is replacing `PORT_IOBUS` with `PORT` for fast pin access. `PORT_IOBUS` isn't defined by D51 devices (see another reference to this here: https://github.com/adafruit/Adafruit-GFX-Library/blob/master/Adafruit_SPITFT.cpp#L48)

With this patch I was able to compile and run the "Simple Example" from the readme on the Adafruit Itsy-Bitsy M4 and see it light up a DotStar