### PR TITLE
stm32duino (Maple, Blue Pill, etc): compile fix

### DIFF
--- a/platforms/arm/stm32/led_sysdefs_arm_stm32.h
+++ b/platforms/arm/stm32/led_sysdefs_arm_stm32.h
@@ -1,9 +1,9 @@
 #ifndef __INC_LED_SYSDEFS_ARM_SAM_H
 #define __INC_LED_SYSDEFS_ARM_SAM_H
 
-#include <application.h>
-
 #if defined(STM32F10X_MD)
+
+ #include <application.h>
 
  #define FASTLED_NAMESPACE_BEGIN namespace NSFastLED {
  #define FASTLED_NAMESPACE_END }


### PR DESCRIPTION
This fixes the infamous

> (...)/FastLED/platforms/arm/stm32/led_sysdefs_arm_stm32.h:4:25:
>  fatal error: application.h: No such file or directory

issue when compiling code for Blue Pill (STM32F1xx).

The above `#include <application.h>` was initially added by
commit f149084 as part of the port for the particle photon
boards. While it's not entirely clear where this header
is coming from, it is clear that it's not there for the
usual Arduino + stm32duino.

So, to fix compilation for Blue Pill, while not breaking
it for particle photon, let's move the include to under
`#ifdef STM32F10X_MD`, the define which the original code
used.

Fixes: https://github.com/FastLED/FastLED/issues/741