### PR TITLE
Fix nRF52 race condition / hard lock

### DIFF
--- a/platforms/arm/nrf52/clockless_arm_nrf52.h
+++ b/platforms/arm/nrf52/clockless_arm_nrf52.h
@@ -46,7 +46,7 @@ private:
     // may as well be static, as can only attach one LED string per _DATA_PIN....
     static uint16_t s_SequenceBuffer[_PWM_BUFFER_COUNT];
     static uint16_t s_SequenceBufferValidElements;
-    static uint32_t s_SequenceBufferInUse;
+    static volatile uint32_t s_SequenceBufferInUse;
     static CMinWait<_WAIT_TIME_MICROSECONDS> mWait;  // ensure data has time to latch
 
     FASTLED_NRF52_INLINE_ATTRIBUTE static void startPwmPlayback_InitializePinState() {
@@ -302,7 +302,7 @@ public:
 template <uint8_t _DATA_PIN, int _T1, int _T2, int _T3, EOrder _RGB_ORDER, int _XTRA0, bool _FLIP, int _WAIT_TIME_MICROSECONDS>
 uint16_t ClocklessController<_DATA_PIN, _T1, _T2, _T3, _RGB_ORDER, _XTRA0, _FLIP, _WAIT_TIME_MICROSECONDS>::s_SequenceBufferValidElements = 0;
 template <uint8_t _DATA_PIN, int _T1, int _T2, int _T3, EOrder _RGB_ORDER, int _XTRA0, bool _FLIP, int _WAIT_TIME_MICROSECONDS>
-uint32_t ClocklessController<_DATA_PIN, _T1, _T2, _T3, _RGB_ORDER, _XTRA0, _FLIP, _WAIT_TIME_MICROSECONDS>::s_SequenceBufferInUse = 0;
+uint32_t volatile ClocklessController<_DATA_PIN, _T1, _T2, _T3, _RGB_ORDER, _XTRA0, _FLIP, _WAIT_TIME_MICROSECONDS>::s_SequenceBufferInUse = 0;
 template <uint8_t _DATA_PIN, int _T1, int _T2, int _T3, EOrder _RGB_ORDER, int _XTRA0, bool _FLIP, int _WAIT_TIME_MICROSECONDS>
 uint16_t ClocklessController<_DATA_PIN, _T1, _T2, _T3, _RGB_ORDER, _XTRA0, _FLIP, _WAIT_TIME_MICROSECONDS>::s_SequenceBuffer[_PWM_BUFFER_COUNT];
 template <uint8_t _DATA_PIN, int _T1, int _T2, int _T3, EOrder _RGB_ORDER, int _XTRA0, bool _FLIP, int _WAIT_TIME_MICROSECONDS>

--- a/platforms/arm/nrf52/clockless_arm_nrf52.h
+++ b/platforms/arm/nrf52/clockless_arm_nrf52.h
@@ -146,6 +146,8 @@ public:
         if (nrf_pwm_event_check(pwm,NRF_PWM_EVENT_STOPPED)) {
             nrf_pwm_event_clear(pwm,NRF_PWM_EVENT_STOPPED);
 
+            // update the minimum time to next call
+            mWait.mark();
             // mark the sequence as no longer in use -- pointer, comparator, exchange value
             releaseSequenceBuffer();
             // prevent further interrupts from PWM events
@@ -175,7 +177,8 @@ public:
         // wait for the only sequence buffer to become available
         spinAcquireSequenceBuffer();
         prepareSequenceBuffers(pixels);
-        mWait.wait(); // ensure min time between updates
+        // ensure any prior data had time to latch
+        mWait.wait();
         startPwmPlayback(s_SequenceBufferValidElements);
         return;
     }


### PR DESCRIPTION
Fixes #840.
<details>
    <summary>A textbook case of where `volatile` is necessary</summary>

<p>

The variable `s_SequenceBufferInUse` is modified in an ISR.
However, the variable was **_not_** marked `volatile`:
```C++
virtual void showPixels(PixelController<_RGB_ORDER> & pixels) {
    while (s_SequenceBufferInUse != 0);
```

Because it wasn't marked `volatile`, the compiler was allowed to use the first value it read.  Using [compiler explorer](https://gcc.godbolt.org/) set to `ARM gcc 7.2.1 (none)` with optimizations (e.g., `-O5`), you would get something similar to:

```asm
.L10
        .word .LANCHOR0 // address of .LC0
        .word .LC0             // s_SequenceBufferInUse
showPixels():
        ldr     r3, .L10
        ldr     r3, [r3]
        cmp     r3, #0
        beq     .L6
.L7:
        b       .L7 // Note this doesn't re-read the value.....
.L6:
        // remainder of function
```     

</details>
