### PR TITLE
NRF52 -- Prevent pin initialization affecting clockless LED data

### DIFF
--- a/platforms/arm/nrf52/clockless_arm_nrf52.h
+++ b/platforms/arm/nrf52/clockless_arm_nrf52.h
@@ -156,6 +156,11 @@ public:
         FASTLED_NRF52_DEBUGPRINT("    T0H == %d", _T0H);
         FASTLED_NRF52_DEBUGPRINT("    T1H == %d", _T1H);
         FASTLED_NRF52_DEBUGPRINT("    TOP == %d\n", _TOP);
+        // to avoid pin initialization from causing first LED to have invalid color,
+        // call mWait.mark() to ensure data latches before color data gets sent.
+        startPwmPlayback_InitializePinState();
+        mWait.mark();
+
     }
     virtual uint16_t getMaxRefreshRate() const { return 800; }
 


### PR DESCRIPTION
Avoid first-time pin initialization from affecting showLeds() for clockless chipsets.

Fixes #856.

If a sketch does not initialize pins to low state (or high when _FLIP=1), 
the first call to showLeds() may intialize pin state, which clockless LEDs
may treat as part of a data stream.

Avoid this by also initializing the pin state in Init(), and
call mWait.mark() to ensure LEDs will not consider this part of the
LED data.