### PR TITLE
CPixelView operator-() result points to wrong data

### DIFF
--- a/pixelset.h
+++ b/pixelset.h
@@ -64,7 +64,7 @@ public:
   /// Not sure i want this? inline CPixelView operator()(int end) { return CPixelView(leds, 0, end); }
 
   /// Return the reverse ordering of this set
-  inline CPixelView operator-() { return CPixelView(leds + len - dir, len - dir, 0); }
+  inline CPixelView operator-() { return CPixelView(leds, len - dir, 0); }
 
   /// Return a pointer to the first element in this set
   inline operator PIXEL_TYPE* () const { return leds; }


### PR DESCRIPTION
… data

In the operator implementation the `leds` pointer is already shifted to the opposite end of the data. Using the constructor with start and end index however does the shift again. A simple fix would be the shift in the operator.