### PR TITLE
Add Atmega16 support to fastpin_avr.h (Mightycore Arduino)

### DIFF
--- a/platforms/avr/fastpin_avr.h
+++ b/platforms/avr/fastpin_avr.h
@@ -215,7 +215,7 @@ _FL_DEFPIN(16, 2, C); _FL_DEFPIN(17, 3, C); _FL_DEFPIN(18, 4, C); _FL_DEFPIN(19,
 #define SPI_UART0_CLOCK 4
 #endif
 
-#elif defined(__AVR_ATmega1284P__) || defined(__AVR_ATmega644P__)  || defined(__AVR_ATmega32__)
+#elif defined(__AVR_ATmega1284P__) || defined(__AVR_ATmega644P__) || defined(__AVR_ATmega32__) || defined(__AVR_ATmega16__)
 
 #define MAX_PIN 31
 _FL_DEFPIN(0, 0, B); _FL_DEFPIN(1, 1, B); _FL_DEFPIN(2, 2, B); _FL_DEFPIN(3, 3, B);


### PR DESCRIPTION
The `atmega16` has the same pinout at the `atmega32` when using the MightyCore board
in arduino.

The pinout according to the Mightcore documentation can be seen here:
![image](https://user-images.githubusercontent.com/3894415/67167622-f54e6680-f350-11e9-9305-5e0834657828.png)

This commit just adds `__AVR_ATmega16__` to the macro in `fastpin_avr.h` so it builds with the atmega16 target.

It seems like this should be a safe change, but I'm not 100% sure this is how it should be done.  However, I tested this on my Atmega16 board, and appears to work like a charm so I figured it was worth tossing a PR out incase it can help other people :)

Signed-off-by: Charlie Mooney <cmooney3@gmail.com>