### PR TITLE
Support WS2812Serial Library on Teensy T4

### DIFF
--- a/platforms/arm/mxrt1062/fastled_arm_mxrt1062.h
+++ b/platforms/arm/mxrt1062/fastled_arm_mxrt1062.h
@@ -3,6 +3,9 @@
 
 #include "fastpin_arm_mxrt1062.h"
 #include "fastspi_arm_mxrt1062.h"
+#include "../k20/octows2811_controller.h"
+#include "../k20/ws2812serial_controller.h"
+#include "../k20/smartmatrix_t3.h"
 #include "clockless_arm_mxrt1062.h"
 #include "block_clockless_arm_mxrt1062.h"
 


### PR DESCRIPTION
Recently there was reported that the WS2812Serial library (github.com/PaulStoffregen/WS2812Serial) was not ported over to work on the new Teensy T4, so I thought I would take a look.

I added the T4 support, which is now pending in a Pull Request.  During that I also found that there were errors in one of the core header files for the T4, which I also fixed, which is now pending in another Pull Request (github.com/PaulStoffregen/Cores)

After that was working, it was pointed out that the FastLED sample in the WS2812Serial librry did not compile. So...

More details in the forum Thread:
https://forum.pjrc.com/threads/58442-Non-Blocking-WS2812-LED-Library-and-Teensy-4-0

Note: I simply added the three include files from the ../k20 directory in the same way that was done for the T3.5 and T3.6