### PR TITLE
Index out-of-bounds

### DIFF
--- a/examples/RGBCalibrate/RGBCalibrate.ino
+++ b/examples/RGBCalibrate/RGBCalibrate.ino
@@ -23,7 +23,7 @@
 //
 //////////////////////////////////////////////////
 
-#define NUM_LEDS 6
+#define NUM_LEDS 7
 
 // Data pin that led data will be written out over
 #define DATA_PIN 6

--- a/examples/RGBCalibrate/RGBCalibrate.ino
+++ b/examples/RGBCalibrate/RGBCalibrate.ino
@@ -66,7 +66,7 @@ void loop() {
     leds[3] = CRGB(0,0,255);
     leds[4] = CRGB(0,0,255);
     leds[5] = CRGB(0,0,255);
-    leds[6] = CRGB(0,0,0);
+    
     FastLED.show();
     delay(1000);
 }

--- a/examples/RGBCalibrate/RGBCalibrate.ino
+++ b/examples/RGBCalibrate/RGBCalibrate.ino
@@ -66,7 +66,7 @@ void loop() {
     leds[3] = CRGB(0,0,255);
     leds[4] = CRGB(0,0,255);
     leds[5] = CRGB(0,0,255);
-    
+    leds[6] = CRGB(0,0,0);
     FastLED.show();
     delay(1000);
 }


### PR DESCRIPTION
Accessing leds[6] when NUM_LEDS==6 causes out-of-bounds access.  On ESP32, this causes an out-of-bounds exception and the program will not work.

Issue #928 