### PR TITLE
Underscore was missing

### DIFF
--- a/platforms/arm/nrf52/fastpin_arm_nrf52.h
+++ b/platforms/arm/nrf52/fastpin_arm_nrf52.h
@@ -290,7 +290,7 @@ public:
 //     _FL_DEFPIN(47, 47, 1);
 //
 
-#define FL_DEFPIN(ARDUINO_PIN, BOARD_PIN, BOARD_PORT)    \
+#define _FL_DEFPIN(ARDUINO_PIN, BOARD_PIN, BOARD_PORT)    \
     template<> class FastPin<ARDUINO_PIN> :              \
     public _ARMPIN<                                      \
         1u << (BOARD_PIN & 31u),                         \


### PR DESCRIPTION
This was causing it to not compile on the Adafruit Feather nRF52840 Express for me.

This should fix this issue: https://github.com/FastLED/FastLED/issues/938