### PR TITLE
add include for arduino library 

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,3 +7,4 @@ paragraph=Multi-platform library for controlling dozens of different types of LE
 category=Display
 url=https://github.com/FastLED/FastLED
 architectures=*
+includes=FastLED.h


### PR DESCRIPTION
re: [ardiono library spec](https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification)

add ```includes``` section to the arduino ```library.properties``` file to allow the arduino IDE to only include the specified include (arduino IDE >v1.6.10) 
instead of every ```.h``` file found in the root dir of the library

