### PR TITLE
fix for older gcc versions

### DIFF
--- a/platforms/avr/clockless_trinket.h
+++ b/platforms/avr/clockless_trinket.h
@@ -323,14 +323,10 @@ protected:
 #define DUSE (0xFF - (DADVANCE-1))
 
 // Silence compiler warnings about switch/case that is explicitly intended to fall through.
-#if defined(__GNUC__) && __GNUC__ >= 7
- #define FL_FALLTHROUGH __attribute__ ((fallthrough));
-#else
- #define FL_FALLTHROUGH ((void)0);
-#endif /* __GNUC__ >= 7 */
+//#define FL_FALLTHROUGH __attribute__ ((fallthrough));
 
-	// This method is made static to force making register Y available to use for data on AVR - if the method is non-static, then
-	// gcc will use register Y for the this pointer.
+// This method is made static to force making register Y available to use for data on AVR - if the method is non-static, then
+// gcc will use register Y for the this pointer.
 	static void /*__attribute__((optimize("O0")))*/  /*__attribute__ ((always_inline))*/  showRGBInternal(PixelController<RGB_ORDER> & pixels)  {
 		uint8_t *data = (uint8_t*)pixels.mData;
 		data_ptr_t port = FastPin<DATA_PIN>::port();
@@ -410,9 +406,9 @@ protected:
 				HI1 _D1(1) QLO2(b0, 1) RORSC14(b1,7) 	_D2(4)	LO1 RORCLC2(b1) 	_D3(2)
 				HI1 _D1(1) QLO2(b0, 0)
 				switch(XTRA0) {
-					case 4: _D2(0) LO1 _D3(0) HI1 _D1(1) QLO2(b0,0)  FL_FALLTHROUGH
-					case 3: _D2(0) LO1 _D3(0) HI1 _D1(1) QLO2(b0,0)  FL_FALLTHROUGH
-					case 2: _D2(0) LO1 _D3(0) HI1 _D1(1) QLO2(b0,0)  FL_FALLTHROUGH
+					case 4: _D2(0) LO1 _D3(0) HI1 _D1(1) QLO2(b0,0)  /* fall through */
+					case 3: _D2(0) LO1 _D3(0) HI1 _D1(1) QLO2(b0,0)  /* fall through */
+					case 2: _D2(0) LO1 _D3(0) HI1 _D1(1) QLO2(b0,0)  /* fall through */
 					case 1: _D2(0) LO1 _D3(0) HI1 _D1(1) QLO2(b0,0)
 				}
 				MOV_ADDDE14(b0,b1,d1,e1) _D2(4) LO1 _D3(0)
@@ -426,9 +422,9 @@ protected:
 				HI1 _D1(1) QLO2(b0, 1) RORSC24(b1,7) 	_D2(4)	LO1 RORCLC2(b1) 	_D3(2)
 				HI1 _D1(1) QLO2(b0, 0)
 				switch(XTRA0) {
-					case 4: _D2(0) LO1 _D3(0) HI1 _D1(1) QLO2(b0,0)  FL_FALLTHROUGH
-					case 3: _D2(0) LO1 _D3(0) HI1 _D1(1) QLO2(b0,0)  FL_FALLTHROUGH
-					case 2: _D2(0) LO1 _D3(0) HI1 _D1(1) QLO2(b0,0)  FL_FALLTHROUGH
+					case 4: _D2(0) LO1 _D3(0) HI1 _D1(1) QLO2(b0,0)  /* fall through */
+					case 3: _D2(0) LO1 _D3(0) HI1 _D1(1) QLO2(b0,0)  /* fall through */
+					case 2: _D2(0) LO1 _D3(0) HI1 _D1(1) QLO2(b0,0)  /* fall through */
 					case 1: _D2(0) LO1 _D3(0) HI1 _D1(1) QLO2(b0,0)
 				}
 
@@ -445,9 +441,9 @@ protected:
 				HI1 _D1(1) QLO2(b0, 1) RORSC04(b1,7) 	_D2(4)	LO1 RORCLC2(b1) 	_D3(2)
 				HI1 _D1(1) QLO2(b0, 0)
 				switch(XTRA0) {
-					case 4: _D2(0) LO1 _D3(0) HI1 _D1(1) QLO2(b0,0)  FL_FALLTHROUGH
-					case 3: _D2(0) LO1 _D3(0) HI1 _D1(1) QLO2(b0,0)  FL_FALLTHROUGH
-					case 2: _D2(0) LO1 _D3(0) HI1 _D1(1) QLO2(b0,0)  FL_FALLTHROUGH
+					case 4: _D2(0) LO1 _D3(0) HI1 _D1(1) QLO2(b0,0)  /* fall through */
+					case 3: _D2(0) LO1 _D3(0) HI1 _D1(1) QLO2(b0,0)  /* fall through */
+					case 2: _D2(0) LO1 _D3(0) HI1 _D1(1) QLO2(b0,0)  /* fall through */
 					case 1: _D2(0) LO1 _D3(0) HI1 _D1(1) QLO2(b0,0)
 				}
 				MOV_ADDDE04(b0,b1,d0,e0) _D2(4) LO1 _D3(5)

--- a/platforms/avr/clockless_trinket.h
+++ b/platforms/avr/clockless_trinket.h
@@ -323,7 +323,11 @@ protected:
 #define DUSE (0xFF - (DADVANCE-1))
 
 // Silence compiler warnings about switch/case that is explicitly intended to fall through.
-#define FL_FALLTHROUGH __attribute__ ((fallthrough));
+#if defined(__GNUC__) && __GNUC__ >= 7
+ #define FL_FALLTHROUGH __attribute__ ((fallthrough));
+#else
+ #define FL_FALLTHROUGH ((void)0);
+#endif /* __GNUC__ >= 7 */
 
 	// This method is made static to force making register Y available to use for data on AVR - if the method is non-static, then
 	// gcc will use register Y for the this pointer.


### PR DESCRIPTION
fixes clockless_trinket.h:326:24: error: expected primary-expression before '__attribute__' on older gcc versions