### PR TITLE
Clarify instructions for FASTLED_RMT_BUILTIN_DRIVER

### DIFF
--- a/platforms/esp/32/clockless_rmt_esp32.h
+++ b/platforms/esp/32/clockless_rmt_esp32.h
@@ -49,7 +49,7 @@
  * co-exist. To switch to this mode, add the following directive
  * before you include FastLED.h:
  *
- *      #define FASTLED_RMT_BUILTIN_DRIVER
+ *      #define FASTLED_RMT_BUILTIN_DRIVER 1
  *
  * There may be a performance penalty for using this mode. We need to
  * compute the RMT signal for the entire LED strip ahead of time,


### PR DESCRIPTION
It took me a second to realize there needs to be a value for this define or compilation fails. I've updated the comment to clarify this for future visitors.