### PR TITLE
Overload array subscript operator for CHSV structs

### DIFF
--- a/pixeltypes.h
+++ b/pixeltypes.h
@@ -38,6 +38,18 @@ struct CHSV {
 		uint8_t raw[3];
 	};
 
+    /// Array access operator to index into the chsv object
+	inline uint8_t& operator[] (uint8_t x) __attribute__((always_inline))
+    {
+        return raw[x];
+    }
+
+    /// Array access operator to index into the chsv object
+    inline const uint8_t& operator[] (uint8_t x) const __attribute__((always_inline))
+    {
+        return raw[x];
+    }
+
     /// default values are UNITIALIZED
     inline CHSV() __attribute__((always_inline))
     {
@@ -106,7 +118,7 @@ struct CRGB {
 		uint8_t raw[3];
 	};
 
-  /// Array access operator to index into the crgb object
+    /// Array access operator to index into the crgb object
 	inline uint8_t& operator[] (uint8_t x) __attribute__((always_inline))
     {
         return raw[x];
@@ -478,7 +490,7 @@ struct CRGB {
         uint8_t max = red;
         if( green > max) max = green;
         if( blue > max) max = blue;
-        
+
         // stop div/0 when color is black
         if(max > 0) {
             uint16_t factor = ((uint16_t)(limit) * 256) / max;


### PR DESCRIPTION
RGB values in CRGB structs can be accessed through the array subscript operator but the values in CHSV structs can not.