### PR TITLE
cast memmove parameters to (void *) to avoid class-memaccess warnings

### DIFF
--- a/colorutils.h
+++ b/colorutils.h
@@ -452,11 +452,11 @@ public:
 
     CHSVPalette16( const CHSVPalette16& rhs)
     {
-        memmove8( &(entries[0]), &(rhs.entries[0]), sizeof( entries));
+        memmove8( (void *) &(entries[0]), (void *) &(rhs.entries[0]), sizeof( entries));
     }
     CHSVPalette16& operator=( const CHSVPalette16& rhs)
     {
-        memmove8( &(entries[0]), &(rhs.entries[0]), sizeof( entries));
+        memmove8( (void *) &(entries[0]), (void *) &(rhs.entries[0]), sizeof( entries));
         return *this;
     }
 
@@ -555,11 +555,11 @@ public:
 
     CHSVPalette256( const CHSVPalette256& rhs)
     {
-        memmove8( &(entries[0]), &(rhs.entries[0]), sizeof( entries));
+        memmove8( (void *) &(entries[0]), (void *) &(rhs.entries[0]), sizeof( entries));
     }
     CHSVPalette256& operator=( const CHSVPalette256& rhs)
     {
-        memmove8( &(entries[0]), &(rhs.entries[0]), sizeof( entries));
+        memmove8( (void *) &(entries[0]), (void *) &(rhs.entries[0]), sizeof( entries));
         return *this;
     }
 
@@ -660,20 +660,20 @@ public:
 
     CRGBPalette16( const CRGBPalette16& rhs)
     {
-        memmove8( &(entries[0]), &(rhs.entries[0]), sizeof( entries));
+        memmove8( (void *) &(entries[0]), (void *) &(rhs.entries[0]), sizeof( entries));
     }
     CRGBPalette16( const CRGB rhs[16])
     {
-        memmove8( &(entries[0]), &(rhs[0]), sizeof( entries));
+        memmove8( (void *) &(entries[0]), (void *) &(rhs[0]), sizeof( entries));
     }
     CRGBPalette16& operator=( const CRGBPalette16& rhs)
     {
-        memmove8( &(entries[0]), &(rhs.entries[0]), sizeof( entries));
+        memmove8( (void *) &(entries[0]), (void *) &(rhs.entries[0]), sizeof( entries));
         return *this;
     }
     CRGBPalette16& operator=( const CRGB rhs[16])
     {
-        memmove8( &(entries[0]), &(rhs[0]), sizeof( entries));
+        memmove8( (void *) &(entries[0]), (void *) &(rhs[0]), sizeof( entries));
         return *this;
     }
 
@@ -928,11 +928,11 @@ public:
     
     CHSVPalette32( const CHSVPalette32& rhs)
     {
-        memmove8( &(entries[0]), &(rhs.entries[0]), sizeof( entries));
+        memmove8( (void *) &(entries[0]), (void *) &(rhs.entries[0]), sizeof( entries));
     }
     CHSVPalette32& operator=( const CHSVPalette32& rhs)
     {
-        memmove8( &(entries[0]), &(rhs.entries[0]), sizeof( entries));
+        memmove8( (void *) &(entries[0]), (void *) &(rhs.entries[0]), sizeof( entries));
         return *this;
     }
     
@@ -1034,20 +1034,20 @@ public:
     
     CRGBPalette32( const CRGBPalette32& rhs)
     {
-        memmove8( &(entries[0]), &(rhs.entries[0]), sizeof( entries));
+        memmove8( (void *) &(entries[0]), (void *) &(rhs.entries[0]), sizeof( entries));
     }
     CRGBPalette32( const CRGB rhs[32])
     {
-        memmove8( &(entries[0]), &(rhs[0]), sizeof( entries));
+        memmove8( (void *) &(entries[0]), (void *) &(rhs[0]), sizeof( entries));
     }
     CRGBPalette32& operator=( const CRGBPalette32& rhs)
     {
-        memmove8( &(entries[0]), &(rhs.entries[0]), sizeof( entries));
+        memmove8( (void *) &(entries[0]), (void *) &(rhs.entries[0]), sizeof( entries));
         return *this;
     }
     CRGBPalette32& operator=( const CRGB rhs[32])
     {
-        memmove8( &(entries[0]), &(rhs[0]), sizeof( entries));
+        memmove8( (void *) &(entries[0]), (void *) &(rhs[0]), sizeof( entries));
         return *this;
     }
     
@@ -1322,20 +1322,20 @@ public:
 
     CRGBPalette256( const CRGBPalette256& rhs)
     {
-        memmove8( &(entries[0]), &(rhs.entries[0]), sizeof( entries));
+        memmove8( (void *) &(entries[0]), (void *) &(rhs.entries[0]), sizeof( entries));
     }
     CRGBPalette256( const CRGB rhs[256])
     {
-        memmove8( &(entries[0]), &(rhs[0]), sizeof( entries));
+        memmove8( (void *) &(entries[0]), (void *) &(rhs[0]), sizeof( entries));
     }
     CRGBPalette256& operator=( const CRGBPalette256& rhs)
     {
-        memmove8( &(entries[0]), &(rhs.entries[0]), sizeof( entries));
+        memmove8( (void *) &(entries[0]), (void *) &(rhs.entries[0]), sizeof( entries));
         return *this;
     }
     CRGBPalette256& operator=( const CRGB rhs[256])
     {
-        memmove8( &(entries[0]), &(rhs[0]), sizeof( entries));
+        memmove8( (void *) &(entries[0]), (void *) &(rhs[0]), sizeof( entries));
         return *this;
     }
 


### PR DESCRIPTION
Solves #971 by matching stdlib's memmove signature, should be pretty harmless otherwise.