### PR TITLE
use default copy constructor and copy assignments for CRGB and CHSV

### DIFF
--- a/pixeltypes.h
+++ b/pixeltypes.h
@@ -62,20 +62,9 @@ struct CHSV {
     }
 
     /// allow copy construction
-    inline CHSV(const CHSV& rhs) __attribute__((always_inline))
-    {
-        h = rhs.h;
-        s = rhs.s;
-        v = rhs.v;
-    }
+    inline CHSV(const CHSV& rhs) __attribute__((always_inline)) = default;
 
-    inline CHSV& operator= (const CHSV& rhs) __attribute__((always_inline))
-    {
-        h = rhs.h;
-        s = rhs.s;
-        v = rhs.v;
-        return *this;
-    }
+    inline CHSV& operator= (const CHSV& rhs) __attribute__((always_inline)) = default;
 
     inline CHSV& setHSV(uint8_t ih, uint8_t is, uint8_t iv) __attribute__((always_inline))
     {
@@ -162,13 +151,7 @@ struct CRGB {
     }
 
     /// allow copy construction
-	inline CRGB(const CRGB& rhs) __attribute__((always_inline))
-    {
-        r = rhs.r;
-        g = rhs.g;
-        b = rhs.b;
-    }
-
+	inline CRGB(const CRGB& rhs) __attribute__((always_inline)) = default;
     /// allow construction from HSV color
 	inline CRGB(const CHSV& rhs) __attribute__((always_inline))
     {
@@ -176,13 +159,7 @@ struct CRGB {
     }
 
     /// allow assignment from one RGB struct to another
-	inline CRGB& operator= (const CRGB& rhs) __attribute__((always_inline))
-    {
-        r = rhs.r;
-        g = rhs.g;
-        b = rhs.b;
-        return *this;
-    }
+	inline CRGB& operator= (const CRGB& rhs) __attribute__((always_inline)) = default;
 
     /// allow assignment from 32-bit (really 24-bit) 0xRRGGBB color code
 	inline CRGB& operator= (const uint32_t colorcode) __attribute__((always_inline))

--- a/pixeltypes.h
+++ b/pixeltypes.h
@@ -51,9 +51,7 @@ struct CHSV {
     }
 
     /// default values are UNITIALIZED
-    inline CHSV() __attribute__((always_inline))
-    {
-    }
+    inline CHSV() __attribute__((always_inline)) = default;
 
     /// allow construction from H, S, V
     inline CHSV( uint8_t ih, uint8_t is, uint8_t iv) __attribute__((always_inline))
@@ -120,9 +118,7 @@ struct CRGB {
     }
 
     // default values are UNINITIALIZED
-	inline CRGB() __attribute__((always_inline))
-    {
-    }
+    inline CRGB() __attribute__((always_inline)) = default;
 
     /// allow construction from R, G, B
     inline CRGB( uint8_t ir, uint8_t ig, uint8_t ib)  __attribute__((always_inline))


### PR DESCRIPTION
fix for class-memaccess warnings for the `CRGB` and `CHSV` structs.
fixes the same warnings as #986 (discussion #985) and #977 (discussion #971)(which are duplicates), except that this removes the warning from all uses that require `CRGB` and `CHSV` to be trivially copyable.

As littlebalckfish [said](https://github.com/FastLED/FastLED/issues/971#issuecomment-591734979)
<details><summary>Quote</summary>

> memmove signature from stdlib is
> 
> `void * memmove ( void * destination, const void * source, size_t num );`
> 
> So, casting all the pointers to (void*), I believe, is an appropriate, if not optimal solution to the problem, i.e.
> 
> `memmove8( &(entries[0]), &(rhs.entries[0]), sizeof( entries));`
> 
> to
> 
> `memmove8( (void *) &(entries[0]), (void *) &(rhs.entries[0]), sizeof( entries));`
> 
> etc.
> 
> This builds without complaints. I'd love to do a pull request but I have no way to test this with all the platforms, is there a recommended way to proceed?

</details>

the `memmove` signature takes `void *` as arguments and the warnings could be avoided by casting to `void *`, but the warnings could be completely removed for `CRGB` and `CHSV` by making both have a trivial copy assignment and a trivial copy constructor. Thus removing warnings when using for example `memmove` in user code and in the future.

Performance wise this shouldn't make a difference, but please test it. I've done a bit of testing myself and haven't found any real performance difference although I'm not sure how good my tests are.