### PR TITLE
use prefix notation for ++ and -- where possible

### DIFF
--- a/FastLED.cpp
+++ b/FastLED.cpp
@@ -67,7 +67,7 @@ int CFastLED::count() {
     int x = 0;
 	CLEDController *pCur = CLEDController::head();
 	while( pCur) {
-        x++;
+        ++x;
 		pCur = pCur->next();
 	}
     return x;

--- a/bitswap.h
+++ b/bitswap.h
@@ -126,7 +126,7 @@ __attribute__((always_inline)) inline void swapbits8(bitswap_type in, bitswap_ty
   // SWAPSB(b.c,1);
   // SWAPSB(b.d,0);
 
-  for(int i = 0; i < 8; i++) {
+  for(int i = 0; i < 8; ++i) {
     just8bits work;
     work.a3 = in.word[0] >> 31;
     work.a2 = in.word[0] >> 23;
@@ -145,7 +145,7 @@ __attribute__((always_inline)) inline void swapbits8(bitswap_type in, bitswap_ty
 /// Slow version of the 8 byte by 8 bit rotation
 __attribute__((always_inline)) inline void slowswap(unsigned char *A, unsigned char *B) {
 
-  for(int row = 0; row < 7; row++) {
+  for(int row = 0; row < 7; ++row) {
     uint8_t x = A[row];
 
     uint8_t bit = (1<<row);

--- a/colorutils.cpp
+++ b/colorutils.cpp
@@ -13,7 +13,7 @@ FASTLED_NAMESPACE_BEGIN
 void fill_solid( struct CRGB * leds, int numToFill,
                  const struct CRGB& color)
 {
-    for( int i = 0; i < numToFill; i++) {
+    for( int i = 0; i < numToFill; ++i) {
         leds[i] = color;
     }
 }
@@ -21,7 +21,7 @@ void fill_solid( struct CRGB * leds, int numToFill,
 void fill_solid( struct CHSV * targetArray, int numToFill,
                  const struct CHSV& hsvColor)
 {
-    for( int i = 0; i < numToFill; i++) {
+    for( int i = 0; i < numToFill; ++i) {
         targetArray[i] = hsvColor;
     }
 }
@@ -41,7 +41,7 @@ void fill_rainbow( struct CRGB * pFirstLED, int numToFill,
     hsv.hue = initialhue;
     hsv.val = 255;
     hsv.sat = 240;
-    for( int i = 0; i < numToFill; i++) {
+    for( int i = 0; i < numToFill; ++i) {
         pFirstLED[i] = hsv;
         hsv.hue += deltahue;
     }
@@ -55,7 +55,7 @@ void fill_rainbow( struct CHSV * targetArray, int numToFill,
     hsv.hue = initialhue;
     hsv.val = 255;
     hsv.sat = 240;
-    for( int i = 0; i < numToFill; i++) {
+    for( int i = 0; i < numToFill; ++i) {
         targetArray[i] = hsv;
         hsv.hue += deltahue;
     }
@@ -98,7 +98,7 @@ void fill_gradient_RGB( CRGB* leds,
     accum88 r88 = startcolor.r << 8;
     accum88 g88 = startcolor.g << 8;
     accum88 b88 = startcolor.b << 8;
-    for( uint16_t i = startpos; i <= endpos; i++) {
+    for( uint16_t i = startpos; i <= endpos; ++i) {
         leds[i] = CRGB( r88 >> 8, g88 >> 8, b88 >> 8);
         r88 += rdelta87;
         g88 += gdelta87;
@@ -171,7 +171,7 @@ void fill_gradient_RGB( CRGB* leds, uint16_t numLeds, const CRGB& c1, const CRGB
 
 void nscale8_video( CRGB* leds, uint16_t num_leds, uint8_t scale)
 {
-    for( uint16_t i = 0; i < num_leds; i++) {
+    for( uint16_t i = 0; i < num_leds; ++i) {
         leds[i].nscale8_video( scale);
     }
 }
@@ -204,7 +204,7 @@ void nscale8_raw( CRGB* leds, uint16_t num_leds, uint8_t scale)
 
 void nscale8( CRGB* leds, uint16_t num_leds, uint8_t scale)
 {
-    for( uint16_t i = 0; i < num_leds; i++) {
+    for( uint16_t i = 0; i < num_leds; ++i) {
         leds[i].nscale8( scale);
     }
 }
@@ -216,7 +216,7 @@ void fadeUsingColor( CRGB* leds, uint16_t numLeds, const CRGB& colormask)
     fg = colormask.g;
     fb = colormask.b;
 
-    for( uint16_t i = 0; i < numLeds; i++) {
+    for( uint16_t i = 0; i < numLeds; ++i) {
         leds[i].r = scale8_LEAVING_R1_DIRTY( leds[i].r, fr);
         leds[i].g = scale8_LEAVING_R1_DIRTY( leds[i].g, fg);
         leds[i].b = scale8                 ( leds[i].b, fb);
@@ -261,10 +261,10 @@ CRGB& nblend( CRGB& existing, const CRGB& overlay, fract8 amountOfOverlay )
 
 void nblend( CRGB* existing, CRGB* overlay, uint16_t count, fract8 amountOfOverlay)
 {
-    for( uint16_t i = count; i; i--) {
+    for( uint16_t i = count; i; --i) {
         nblend( *existing, *overlay, amountOfOverlay);
-        existing++;
-        overlay++;
+        ++existing;
+        ++overlay;
     }
 }
 
@@ -277,7 +277,7 @@ CRGB blend( const CRGB& p1, const CRGB& p2, fract8 amountOfP2 )
 
 CRGB* blend( const CRGB* src1, const CRGB* src2, CRGB* dest, uint16_t count, fract8 amountOfsrc2 )
 {
-    for( uint16_t i = 0; i < count; i++) {
+    for( uint16_t i = 0; i < count; ++i) {
         dest[i] = blend(src1[i], src2[i], amountOfsrc2);
     }
     return dest;
@@ -338,10 +338,10 @@ CHSV& nblend( CHSV& existing, const CHSV& overlay, fract8 amountOfOverlay, TGrad
 void nblend( CHSV* existing, CHSV* overlay, uint16_t count, fract8 amountOfOverlay, TGradientDirectionCode directionCode )
 {
     if(existing == overlay) return;
-    for( uint16_t i = count; i; i--) {
+    for( uint16_t i = count; i; --i) {
         nblend( *existing, *overlay, amountOfOverlay, directionCode);
-        existing++;
-        overlay++;
+        ++existing;
+        ++overlay;
     }
 }
 
@@ -354,7 +354,7 @@ CHSV blend( const CHSV& p1, const CHSV& p2, fract8 amountOfP2, TGradientDirectio
 
 CHSV* blend( const CHSV* src1, const CHSV* src2, CHSV* dest, uint16_t count, fract8 amountOfsrc2, TGradientDirectionCode directionCode )
 {
-    for( uint16_t i = 0; i < count; i++) {
+    for( uint16_t i = 0; i < count; ++i) {
         dest[i] = blend(src1[i], src2[i], amountOfsrc2, directionCode);
     }
     return dest;
@@ -385,7 +385,7 @@ void blur1d( CRGB* leds, uint16_t numLeds, fract8 blur_amount)
     uint8_t keep = 255 - blur_amount;
     uint8_t seep = blur_amount >> 1;
     CRGB carryover = CRGB::Black;
-    for( uint16_t i = 0; i < numLeds; i++) {
+    for( uint16_t i = 0; i < numLeds; ++i) {
         CRGB cur = leds[i];
         CRGB part = cur;
         part.nscale8( seep);
@@ -406,7 +406,7 @@ void blur2d( CRGB* leds, uint8_t width, uint8_t height, fract8 blur_amount)
 // blurRows: perform a blur1d on every row of a rectangular matrix
 void blurRows( CRGB* leds, uint8_t width, uint8_t height, fract8 blur_amount)
 {
-    for( uint8_t row = 0; row < height; row++) {
+    for( uint8_t row = 0; row < height; ++row) {
         CRGB* rowbase = leds + (row * width);
         blur1d( rowbase, width, blur_amount);
     }
@@ -418,9 +418,9 @@ void blurColumns(CRGB* leds, uint8_t width, uint8_t height, fract8 blur_amount)
     // blur columns
     uint8_t keep = 255 - blur_amount;
     uint8_t seep = blur_amount >> 1;
-    for( uint8_t col = 0; col < width; col++) {
+    for( uint8_t col = 0; col < width; ++col) {
         CRGB carryover = CRGB::Black;
-        for( uint8_t i = 0; i < height; i++) {
+        for( uint8_t i = 0; i < height; ++i) {
             CRGB cur = leds[XY(col,i)];
             CRGB part = cur;
             part.nscale8( seep);
@@ -529,7 +529,7 @@ CRGB ColorFromPalette( const CRGBPalette16& pal, uint8_t index, uint8_t brightne
         if( hi4 == 15 ) {
             entry = &(pal[0]);
         } else {
-            entry++;
+            ++entry;
         }
         
         uint8_t f2 = lo4 << 4;
@@ -556,25 +556,25 @@ CRGB ColorFromPalette( const CRGBPalette16& pal, uint8_t index, uint8_t brightne
     
     if( brightness != 255) {
         if( brightness ) {
-            brightness++; // adjust for rounding
+            ++brightness; // adjust for rounding
             // Now, since brightness is nonzero, we don't need the full scale8_video logic;
             // we can just to scale8 and then add one (unless scale8 fixed) to all nonzero inputs.
             if( red1 )   {
                 red1 = scale8_LEAVING_R1_DIRTY( red1, brightness);
 #if !(FASTLED_SCALE8_FIXED==1)
-                red1++;
+                ++red1;
 #endif
             }
             if( green1 ) {
                 green1 = scale8_LEAVING_R1_DIRTY( green1, brightness);
 #if !(FASTLED_SCALE8_FIXED==1)
-                green1++;
+                ++green1;
 #endif
             }
             if( blue1 )  {
                 blue1 = scale8_LEAVING_R1_DIRTY( blue1, brightness);
 #if !(FASTLED_SCALE8_FIXED==1)
-                blue1++;
+                ++blue1;
 #endif
             }
             cleanup_R1();
@@ -634,25 +634,25 @@ CRGB ColorFromPalette( const TProgmemRGBPalette16& pal, uint8_t index, uint8_t b
 
     if( brightness != 255) {
         if( brightness ) {
-            brightness++; // adjust for rounding
+            ++brightness; // adjust for rounding
             // Now, since brightness is nonzero, we don't need the full scale8_video logic;
             // we can just to scale8 and then add one (unless scale8 fixed) to all nonzero inputs.
             if( red1 )   {
                 red1 = scale8_LEAVING_R1_DIRTY( red1, brightness);
 #if !(FASTLED_SCALE8_FIXED==1)
-                red1++;
+                ++red1;
 #endif
             }
             if( green1 ) {
                 green1 = scale8_LEAVING_R1_DIRTY( green1, brightness);
 #if !(FASTLED_SCALE8_FIXED==1)
-                green1++;
+                ++green1;
 #endif
             }
             if( blue1 )  {
                 blue1 = scale8_LEAVING_R1_DIRTY( blue1, brightness);
 #if !(FASTLED_SCALE8_FIXED==1)
-                blue1++;
+                ++blue1;
 #endif
             }
             cleanup_R1();
@@ -698,7 +698,7 @@ CRGB ColorFromPalette( const CRGBPalette32& pal, uint8_t index, uint8_t brightne
         if( hi5 == 31 ) {
             entry = &(pal[0]);
         } else {
-            entry++;
+            ++entry;
         }
         
         uint8_t f2 = lo3 << 5;
@@ -725,25 +725,25 @@ CRGB ColorFromPalette( const CRGBPalette32& pal, uint8_t index, uint8_t brightne
     
     if( brightness != 255) {
         if( brightness ) {
-            brightness++; // adjust for rounding
+            ++brightness; // adjust for rounding
             // Now, since brightness is nonzero, we don't need the full scale8_video logic;
             // we can just to scale8 and then add one (unless scale8 fixed) to all nonzero inputs.
             if( red1 )   {
                 red1 = scale8_LEAVING_R1_DIRTY( red1, brightness);
 #if !(FASTLED_SCALE8_FIXED==1)
-                red1++;
+                ++red1;
 #endif
             }
             if( green1 ) {
                 green1 = scale8_LEAVING_R1_DIRTY( green1, brightness);
 #if !(FASTLED_SCALE8_FIXED==1)
-                green1++;
+                ++green1;
 #endif
             }
             if( blue1 )  {
                 blue1 = scale8_LEAVING_R1_DIRTY( blue1, brightness);
 #if !(FASTLED_SCALE8_FIXED==1)
-                blue1++;
+                ++blue1;
 #endif
             }
             cleanup_R1();
@@ -809,25 +809,25 @@ CRGB ColorFromPalette( const TProgmemRGBPalette32& pal, uint8_t index, uint8_t b
     
     if( brightness != 255) {
         if( brightness ) {
-            brightness++; // adjust for rounding
+            ++brightness; // adjust for rounding
             // Now, since brightness is nonzero, we don't need the full scale8_video logic;
             // we can just to scale8 and then add one (unless scale8 fixed) to all nonzero inputs.
             if( red1 )   {
                 red1 = scale8_LEAVING_R1_DIRTY( red1, brightness);
 #if !(FASTLED_SCALE8_FIXED==1)
-                red1++;
+                ++red1;
 #endif
             }
             if( green1 ) {
                 green1 = scale8_LEAVING_R1_DIRTY( green1, brightness);
 #if !(FASTLED_SCALE8_FIXED==1)
-                green1++;
+                ++green1;
 #endif
             }
             if( blue1 )  {
                 blue1 = scale8_LEAVING_R1_DIRTY( blue1, brightness);
 #if !(FASTLED_SCALE8_FIXED==1)
-                blue1++;
+                ++blue1;
 #endif
             }
             cleanup_R1();
@@ -852,7 +852,7 @@ CRGB ColorFromPalette( const CRGBPalette256& pal, uint8_t index, uint8_t brightn
     uint8_t blue  = entry->blue;
 
     if( brightness != 255) {
-        brightness++; // adjust for rounding
+        ++brightness; // adjust for rounding
         red   = scale8_video_LEAVING_R1_DIRTY( red,   brightness);
         green = scale8_video_LEAVING_R1_DIRTY( green, brightness);
         blue  = scale8_video_LEAVING_R1_DIRTY( blue,  brightness);
@@ -883,7 +883,7 @@ CHSV ColorFromPalette( const struct CHSVPalette16& pal, uint8_t index, uint8_t b
         if( hi4 == 15 ) {
             entry = &(pal[0]);
         } else {
-            entry++;
+            ++entry;
         }
 
         uint8_t f2 = lo4 << 4;
@@ -973,7 +973,7 @@ CHSV ColorFromPalette( const struct CHSVPalette32& pal, uint8_t index, uint8_t b
         if( hi5 == 31 ) {
             entry = &(pal[0]);
         } else {
-            entry++;
+            ++entry;
         }
         
         uint8_t f2 = lo3 << 5;
@@ -1050,14 +1050,14 @@ CHSV ColorFromPalette( const struct CHSVPalette256& pal, uint8_t index, uint8_t 
 
 void UpscalePalette(const struct CRGBPalette16& srcpal16, struct CRGBPalette256& destpal256)
 {
-    for( int i = 0; i < 256; i++) {
+    for( int i = 0; i < 256; ++i) {
         destpal256[(uint8_t)(i)] = ColorFromPalette( srcpal16, i);
     }
 }
 
 void UpscalePalette(const struct CHSVPalette16& srcpal16, struct CHSVPalette256& destpal256)
 {
-    for( int i = 0; i < 256; i++) {
+    for( int i = 0; i < 256; ++i) {
         destpal256[(uint8_t)(i)] = ColorFromPalette( srcpal16, i);
     }
 }
@@ -1065,7 +1065,7 @@ void UpscalePalette(const struct CHSVPalette16& srcpal16, struct CHSVPalette256&
 
 void UpscalePalette(const struct CRGBPalette16& srcpal16, struct CRGBPalette32& destpal32)
 {
-    for( uint8_t i = 0; i < 16; i++) {
+    for( uint8_t i = 0; i < 16; ++i) {
         uint8_t j = i * 2;
         destpal32[j+0] = srcpal16[i];
         destpal32[j+1] = srcpal16[i];
@@ -1074,7 +1074,7 @@ void UpscalePalette(const struct CRGBPalette16& srcpal16, struct CRGBPalette32& 
 
 void UpscalePalette(const struct CHSVPalette16& srcpal16, struct CHSVPalette32& destpal32)
 {
-    for( uint8_t i = 0; i < 16; i++) {
+    for( uint8_t i = 0; i < 16; ++i) {
         uint8_t j = i * 2;
         destpal32[j+0] = srcpal16[i];
         destpal32[j+1] = srcpal16[i];
@@ -1083,14 +1083,14 @@ void UpscalePalette(const struct CHSVPalette16& srcpal16, struct CHSVPalette32& 
 
 void UpscalePalette(const struct CRGBPalette32& srcpal32, struct CRGBPalette256& destpal256)
 {
-    for( int i = 0; i < 256; i++) {
+    for( int i = 0; i < 256; ++i) {
         destpal256[(uint8_t)(i)] = ColorFromPalette( srcpal32, i);
     }
 }
 
 void UpscalePalette(const struct CHSVPalette32& srcpal32, struct CHSVPalette256& destpal256)
 {
-    for( int i = 0; i < 256; i++) {
+    for( int i = 0; i < 256; ++i) {
         destpal256[(uint8_t)(i)] = ColorFromPalette( srcpal32, i);
     }
 }
@@ -1117,18 +1117,18 @@ void nblendPaletteTowardPalette( CRGBPalette16& current, CRGBPalette16& target, 
     p2 = (uint8_t*)target.entries;
 
     const uint8_t totalChannels = sizeof(CRGBPalette16);
-    for( uint8_t i = 0; i < totalChannels; i++) {
+    for( uint8_t i = 0; i < totalChannels; ++i) {
         // if the values are equal, no changes are needed
         if( p1[i] == p2[i] ) { continue; }
 
         // if the current value is less than the target, increase it by one
-        if( p1[i] < p2[i] ) { p1[i]++; changes++; }
+        if( p1[i] < p2[i] ) { ++p1[i]; ++changes; }
 
         // if the current value is greater than the target,
         // increase it by one (or two if it's still greater).
         if( p1[i] > p2[i] ) {
-            p1[i]--; changes++;
-            if( p1[i] > p2[i] ) { p1[i]--; }
+            --p1[i]; ++changes;
+            if( p1[i] > p2[i] ) { --p1[i]; }
         }
 
         // if we've hit the maximum number of changes, exit
@@ -1182,14 +1182,14 @@ CRGB& napplyGamma_video( CRGB& rgb, float gammaR, float gammaG, float gammaB)
 
 void napplyGamma_video( CRGB* rgbarray, uint16_t count, float gamma)
 {
-    for( uint16_t i = 0; i < count; i++) {
+    for( uint16_t i = 0; i < count; ++i) {
         rgbarray[i] = applyGamma_video( rgbarray[i], gamma);
     }
 }
 
 void napplyGamma_video( CRGB* rgbarray, uint16_t count, float gammaR, float gammaG, float gammaB)
 {
-    for( uint16_t i = 0; i < count; i++) {
+    for( uint16_t i = 0; i < count; ++i) {
         rgbarray[i] = applyGamma_video( rgbarray[i], gammaR, gammaG, gammaB);
     }
 }

--- a/colorutils.h
+++ b/colorutils.h
@@ -168,7 +168,7 @@ void fill_gradient( T* targetArray,
     accum88 hue88 = startcolor.hue << 8;
     accum88 sat88 = startcolor.sat << 8;
     accum88 val88 = startcolor.val << 8;
-    for( uint16_t i = startpos; i <= endpos; i++) {
+    for( uint16_t i = startpos; i <= endpos; ++i) {
         targetArray[i] = CHSV( hue88 >> 8, sat88 >> 8, val88 >> 8);
         hue88 += huedelta87;
         sat88 += satdelta87;
@@ -462,7 +462,7 @@ public:
 
     CHSVPalette16( const TProgmemHSVPalette16& rhs)
     {
-        for( uint8_t i = 0; i < 16; i++) {
+        for( uint8_t i = 0; i < 16; ++i) {
             CRGB xyz   =  FL_PGM_READ_DWORD_NEAR( rhs + i);
             entries[i].hue = xyz.red;
             entries[i].sat = xyz.green;
@@ -471,7 +471,7 @@ public:
     }
     CHSVPalette16& operator=( const TProgmemHSVPalette16& rhs)
     {
-        for( uint8_t i = 0; i < 16; i++) {
+        for( uint8_t i = 0; i < 16; ++i) {
             CRGB xyz   =  FL_PGM_READ_DWORD_NEAR( rhs + i);
             entries[i].hue = xyz.red;
             entries[i].sat = xyz.green;
@@ -508,10 +508,10 @@ public:
         const uint8_t* p = (const uint8_t*)(&(this->entries[0]));
         const uint8_t* q = (const uint8_t*)(&(rhs.entries[0]));
         if( p == q) return true;
-        for( uint8_t i = 0; i < (sizeof( entries)); i++) {
+        for( uint8_t i = 0; i < (sizeof( entries)); ++i) {
             if( *p != *q) return false;
-            p++;
-            q++;
+            ++p;
+            ++q;
         }
         return true;
     }
@@ -613,10 +613,10 @@ public:
         const uint8_t* p = (const uint8_t*)(&(this->entries[0]));
         const uint8_t* q = (const uint8_t*)(&(rhs.entries[0]));
         if( p == q) return true;
-        for( uint16_t i = 0; i < (sizeof( entries)); i++) {
+        for( uint16_t i = 0; i < (sizeof( entries)); ++i) {
             if( *p != *q) return false;
-            p++;
-            q++;
+            ++p;
+            ++q;
         }
         return true;
     }
@@ -679,26 +679,26 @@ public:
 
     CRGBPalette16( const CHSVPalette16& rhs)
     {
-        for( uint8_t i = 0; i < 16; i++) {
+        for( uint8_t i = 0; i < 16; ++i) {
     		entries[i] = rhs.entries[i]; // implicit HSV-to-RGB conversion
         }
     }
     CRGBPalette16( const CHSV rhs[16])
     {
-        for( uint8_t i = 0; i < 16; i++) {
+        for( uint8_t i = 0; i < 16; ++i) {
             entries[i] = rhs[i]; // implicit HSV-to-RGB conversion
         }
     }
     CRGBPalette16& operator=( const CHSVPalette16& rhs)
     {
-        for( uint8_t i = 0; i < 16; i++) {
+        for( uint8_t i = 0; i < 16; ++i) {
     		entries[i] = rhs.entries[i]; // implicit HSV-to-RGB conversion
         }
         return *this;
     }
     CRGBPalette16& operator=( const CHSV rhs[16])
     {
-        for( uint8_t i = 0; i < 16; i++) {
+        for( uint8_t i = 0; i < 16; ++i) {
             entries[i] = rhs[i]; // implicit HSV-to-RGB conversion
         }
         return *this;
@@ -706,13 +706,13 @@ public:
 
     CRGBPalette16( const TProgmemRGBPalette16& rhs)
     {
-        for( uint8_t i = 0; i < 16; i++) {
+        for( uint8_t i = 0; i < 16; ++i) {
             entries[i] =  FL_PGM_READ_DWORD_NEAR( rhs + i);
         }
     }
     CRGBPalette16& operator=( const TProgmemRGBPalette16& rhs)
     {
-        for( uint8_t i = 0; i < 16; i++) {
+        for( uint8_t i = 0; i < 16; ++i) {
             entries[i] =  FL_PGM_READ_DWORD_NEAR( rhs + i);
         }
         return *this;
@@ -723,10 +723,10 @@ public:
         const uint8_t* p = (const uint8_t*)(&(this->entries[0]));
         const uint8_t* q = (const uint8_t*)(&(rhs.entries[0]));
         if( p == q) return true;
-        for( uint8_t i = 0; i < (sizeof( entries)); i++) {
+        for( uint8_t i = 0; i < (sizeof( entries)); ++i) {
             if( *p != *q) return false;
-            p++;
-            q++;
+            ++p;
+            ++q;
         }
         return true;
     }
@@ -828,7 +828,7 @@ public:
         uint16_t count = 0;
         do {
             u.dword = FL_PGM_READ_DWORD_NEAR(progent + count);
-            count++;;
+            ++count;;
         } while ( u.index != 255);
 
         int8_t lastSlotUsed = -1;
@@ -840,7 +840,7 @@ public:
         uint8_t istart8 = 0;
         uint8_t iend8 = 0;
         while( indexstart < 255) {
-            progent++;
+            ++progent;
             u.dword = FL_PGM_READ_DWORD_NEAR( progent);
             int indexend  = u.index;
             CRGB rgbend( u.r, u.g, u.b);
@@ -870,7 +870,7 @@ public:
         uint16_t count = 0;
         do {
             u = *(ent + count);
-            count++;;
+            ++count;;
         } while ( u.index != 255);
 
         int8_t lastSlotUsed = -1;
@@ -883,7 +883,7 @@ public:
         uint8_t istart8 = 0;
         uint8_t iend8 = 0;
         while( indexstart < 255) {
-            ent++;
+            ++ent;
             u = *ent;
             int indexend  = u.index;
             CRGB rgbend( u.r, u.g, u.b);
@@ -918,7 +918,7 @@ public:
                   const CHSV& c08,const CHSV& c09,const CHSV& c10,const CHSV& c11,
                   const CHSV& c12,const CHSV& c13,const CHSV& c14,const CHSV& c15 )
     {
-        for( uint8_t i = 0; i < 2; i++) {
+        for( uint8_t i = 0; i < 2; ++i) {
             entries[0+i]=c00; entries[2+i]=c01; entries[4+i]=c02; entries[6+i]=c03;
             entries[8+i]=c04; entries[10+i]=c05; entries[12+i]=c06; entries[14+i]=c07;
             entries[16+i]=c08; entries[18+i]=c09; entries[20+i]=c10; entries[22+i]=c11;
@@ -938,7 +938,7 @@ public:
     
     CHSVPalette32( const TProgmemHSVPalette32& rhs)
     {
-        for( uint8_t i = 0; i < 32; i++) {
+        for( uint8_t i = 0; i < 32; ++i) {
             CRGB xyz   =  FL_PGM_READ_DWORD_NEAR( rhs + i);
             entries[i].hue = xyz.red;
             entries[i].sat = xyz.green;
@@ -947,7 +947,7 @@ public:
     }
     CHSVPalette32& operator=( const TProgmemHSVPalette32& rhs)
     {
-        for( uint8_t i = 0; i < 32; i++) {
+        for( uint8_t i = 0; i < 32; ++i) {
             CRGB xyz   =  FL_PGM_READ_DWORD_NEAR( rhs + i);
             entries[i].hue = xyz.red;
             entries[i].sat = xyz.green;
@@ -984,10 +984,10 @@ public:
         const uint8_t* p = (const uint8_t*)(&(this->entries[0]));
         const uint8_t* q = (const uint8_t*)(&(rhs.entries[0]));
         if( p == q) return true;
-        for( uint8_t i = 0; i < (sizeof( entries)); i++) {
+        for( uint8_t i = 0; i < (sizeof( entries)); ++i) {
             if( *p != *q) return false;
-            p++;
-            q++;
+            ++p;
+            ++q;
         }
         return true;
     }
@@ -1024,7 +1024,7 @@ public:
                   const CRGB& c08,const CRGB& c09,const CRGB& c10,const CRGB& c11,
                   const CRGB& c12,const CRGB& c13,const CRGB& c14,const CRGB& c15 )
     {
-        for( uint8_t i = 0; i < 2; i++) {
+        for( uint8_t i = 0; i < 2; ++i) {
             entries[0+i]=c00; entries[2+i]=c01; entries[4+i]=c02; entries[6+i]=c03;
             entries[8+i]=c04; entries[10+i]=c05; entries[12+i]=c06; entries[14+i]=c07;
             entries[16+i]=c08; entries[18+i]=c09; entries[20+i]=c10; entries[22+i]=c11;
@@ -1053,26 +1053,26 @@ public:
     
     CRGBPalette32( const CHSVPalette32& rhs)
     {
-        for( uint8_t i = 0; i < 32; i++) {
+        for( uint8_t i = 0; i < 32; ++i) {
             entries[i] = rhs.entries[i]; // implicit HSV-to-RGB conversion
         }
     }
     CRGBPalette32( const CHSV rhs[32])
     {
-        for( uint8_t i = 0; i < 32; i++) {
+        for( uint8_t i = 0; i < 32; ++i) {
             entries[i] = rhs[i]; // implicit HSV-to-RGB conversion
         }
     }
     CRGBPalette32& operator=( const CHSVPalette32& rhs)
     {
-        for( uint8_t i = 0; i < 32; i++) {
+        for( uint8_t i = 0; i < 32; ++i) {
             entries[i] = rhs.entries[i]; // implicit HSV-to-RGB conversion
         }
         return *this;
     }
     CRGBPalette32& operator=( const CHSV rhs[32])
     {
-        for( uint8_t i = 0; i < 32; i++) {
+        for( uint8_t i = 0; i < 32; ++i) {
             entries[i] = rhs[i]; // implicit HSV-to-RGB conversion
         }
         return *this;
@@ -1080,13 +1080,13 @@ public:
     
     CRGBPalette32( const TProgmemRGBPalette32& rhs)
     {
-        for( uint8_t i = 0; i < 32; i++) {
+        for( uint8_t i = 0; i < 32; ++i) {
             entries[i] =  FL_PGM_READ_DWORD_NEAR( rhs + i);
         }
     }
     CRGBPalette32& operator=( const TProgmemRGBPalette32& rhs)
     {
-        for( uint8_t i = 0; i < 32; i++) {
+        for( uint8_t i = 0; i < 32; ++i) {
             entries[i] =  FL_PGM_READ_DWORD_NEAR( rhs + i);
         }
         return *this;
@@ -1097,10 +1097,10 @@ public:
         const uint8_t* p = (const uint8_t*)(&(this->entries[0]));
         const uint8_t* q = (const uint8_t*)(&(rhs.entries[0]));
         if( p == q) return true;
-        for( uint8_t i = 0; i < (sizeof( entries)); i++) {
+        for( uint8_t i = 0; i < (sizeof( entries)); ++i) {
             if( *p != *q) return false;
-            p++;
-            q++;
+            ++p;
+            ++q;
         }
         return true;
     }
@@ -1225,7 +1225,7 @@ public:
         uint16_t count = 0;
         do {
             u.dword = FL_PGM_READ_DWORD_NEAR(progent + count);
-            count++;;
+            ++count;;
         } while ( u.index != 255);
         
         int8_t lastSlotUsed = -1;
@@ -1237,7 +1237,7 @@ public:
         uint8_t istart8 = 0;
         uint8_t iend8 = 0;
         while( indexstart < 255) {
-            progent++;
+            ++progent;
             u.dword = FL_PGM_READ_DWORD_NEAR( progent);
             int indexend  = u.index;
             CRGB rgbend( u.r, u.g, u.b);
@@ -1267,7 +1267,7 @@ public:
         uint16_t count = 0;
         do {
             u = *(ent + count);
-            count++;;
+            ++count;;
         } while ( u.index != 255);
         
         int8_t lastSlotUsed = -1;
@@ -1280,7 +1280,7 @@ public:
         uint8_t istart8 = 0;
         uint8_t iend8 = 0;
         while( indexstart < 255) {
-            ent++;
+            ++ent;
             u = *ent;
             int indexend  = u.index;
             CRGB rgbend( u.r, u.g, u.b);
@@ -1341,26 +1341,26 @@ public:
 
     CRGBPalette256( const CHSVPalette256& rhs)
     {
-    	for( int i = 0; i < 256; i++) {
+    	for( int i = 0; i < 256; ++i) {
 	    	entries[i] = rhs.entries[i]; // implicit HSV-to-RGB conversion
     	}
     }
     CRGBPalette256( const CHSV rhs[256])
     {
-        for( int i = 0; i < 256; i++) {
+        for( int i = 0; i < 256; ++i) {
             entries[i] = rhs[i]; // implicit HSV-to-RGB conversion
         }
     }
     CRGBPalette256& operator=( const CHSVPalette256& rhs)
     {
-    	for( int i = 0; i < 256; i++) {
+    	for( int i = 0; i < 256; ++i) {
 	    	entries[i] = rhs.entries[i]; // implicit HSV-to-RGB conversion
     	}
         return *this;
     }
     CRGBPalette256& operator=( const CHSV rhs[256])
     {
-        for( int i = 0; i < 256; i++) {
+        for( int i = 0; i < 256; ++i) {
             entries[i] = rhs[i]; // implicit HSV-to-RGB conversion
         }
         return *this;
@@ -1393,10 +1393,10 @@ public:
         const uint8_t* p = (const uint8_t*)(&(this->entries[0]));
         const uint8_t* q = (const uint8_t*)(&(rhs.entries[0]));
         if( p == q) return true;
-        for( uint16_t i = 0; i < (sizeof( entries)); i++) {
+        for( uint16_t i = 0; i < (sizeof( entries)); ++i) {
             if( *p != *q) return false;
-            p++;
-            q++;
+            ++p;
+            ++q;
         }
         return true;
     }
@@ -1475,7 +1475,7 @@ public:
 
         int indexstart = 0;
         while( indexstart < 255) {
-            progent++;
+            ++progent;
             u.dword = FL_PGM_READ_DWORD_NEAR( progent);
             int indexend  = u.index;
             CRGB rgbend( u.r, u.g, u.b);
@@ -1494,7 +1494,7 @@ public:
 
         int indexstart = 0;
         while( indexstart < 255) {
-            ent++;
+            ++ent;
             u = *ent;
             int indexend  = u.index;
             CRGB rgbend( u.r, u.g, u.b);
@@ -1557,7 +1557,7 @@ void fill_palette(CRGB* L, uint16_t N, uint8_t startIndex, uint8_t incIndex,
                   const PALETTE& pal, uint8_t brightness, TBlendType blendType)
 {
     uint8_t colorIndex = startIndex;
-    for( uint16_t i = 0; i < N; i++) {
+    for( uint16_t i = 0; i < N; ++i) {
         L[i] = ColorFromPalette( pal, colorIndex, brightness, blendType);
         colorIndex += incIndex;
     }
@@ -1572,7 +1572,7 @@ void map_data_into_colors_through_palette(
 	uint8_t opacity=255,
 	TBlendType blendType=LINEARBLEND)
 {
-	for( uint16_t i = 0; i < dataCount; i++) {
+	for( uint16_t i = 0; i < dataCount; ++i) {
 		uint8_t d = dataArray[i];
 		CRGB rgb = ColorFromPalette( pal, d, brightness, blendType);
 		if( opacity == 255 ) {

--- a/colorutils.h
+++ b/colorutils.h
@@ -828,7 +828,7 @@ public:
         uint16_t count = 0;
         do {
             u.dword = FL_PGM_READ_DWORD_NEAR(progent + count);
-            ++count;;
+            ++count;
         } while ( u.index != 255);
 
         int8_t lastSlotUsed = -1;
@@ -870,7 +870,7 @@ public:
         uint16_t count = 0;
         do {
             u = *(ent + count);
-            ++count;;
+            ++count;
         } while ( u.index != 255);
 
         int8_t lastSlotUsed = -1;
@@ -1225,7 +1225,7 @@ public:
         uint16_t count = 0;
         do {
             u.dword = FL_PGM_READ_DWORD_NEAR(progent + count);
-            ++count;;
+            ++count;
         } while ( u.index != 255);
         
         int8_t lastSlotUsed = -1;
@@ -1267,7 +1267,7 @@ public:
         uint16_t count = 0;
         do {
             u = *(ent + count);
-            ++count;;
+            ++count;
         } while ( u.index != 255);
         
         int8_t lastSlotUsed = -1;

--- a/controller.h
+++ b/controller.h
@@ -154,7 +154,7 @@ public:
               CRGB adj(0,0,0);
 
               if(scale > 0) {
-                  for(uint8_t i = 0; i < 3; i++) {
+                  for(uint8_t i = 0; i < 3; ++i) {
                       uint8_t cc = colorCorrection.raw[i];
                       uint8_t ct = colorTemperature.raw[i];
                       if(cc > 0 && ct > 0) {
@@ -195,13 +195,13 @@ struct PixelController {
             mScale = other.mScale;
             mAdvance = other.mAdvance;
             mLenRemaining = mLen = other.mLen;
-            for(int i = 0; i < LANES; i++) { mOffsets[i] = other.mOffsets[i]; }
+            for(int i = 0; i < LANES; ++i) { mOffsets[i] = other.mOffsets[i]; }
 
         }
 
         void initOffsets(int len) {
           int nOffset = 0;
-          for(int i = 0; i < LANES; i++) {
+          for(int i = 0; i < LANES; ++i) {
             mOffsets[i] = nOffset;
             if((1<<i) & MASK) { nOffset += (len * mAdvance); }
           }
@@ -256,7 +256,7 @@ struct PixelController {
 
             // R is the digther signal 'counter'.
             static uint8_t R = 0;
-            R++;
+            ++R;
 
             // R is wrapped around at 2^ditherBits,
             // so if ditherBits is 2, R will cycle through (0,1,2,3)
@@ -293,14 +293,14 @@ struct PixelController {
             // actual dithering.
 
             // Setup the initial D and E values
-            for(int i = 0; i < 3; i++) {
+            for(int i = 0; i < 3; ++i) {
                     uint8_t s = mScale.raw[i];
                     e[i] = s ? (256/s) + 1 : 0;
                     d[i] = scale8(Q, e[i]);
 #if (FASTLED_SCALE8_FIXED == 1)
-                    if(d[i]) (d[i]--);
+                    if(d[i]) (--d[i]);
 #endif
-                    if(e[i]) e[i]--;
+                    if(e[i]) --e[i];
             }
 #endif
         }
@@ -324,7 +324,7 @@ struct PixelController {
         __attribute__((always_inline)) inline int advanceBy() { return mAdvance; }
 
         // advance the data pointer forward, adjust position counter
-         __attribute__((always_inline)) inline void advanceData() { mData += mAdvance; mLenRemaining--;}
+         __attribute__((always_inline)) inline void advanceData() { mData += mAdvance; --mLenRemaining;}
 
         // step the dithering forward
          __attribute__((always_inline)) inline void stepDithering() {

--- a/examples/ColorPalette/ColorPalette.ino
+++ b/examples/ColorPalette/ColorPalette.ino
@@ -62,7 +62,7 @@ void FillLEDsFromPaletteColors( uint8_t colorIndex)
 {
     uint8_t brightness = 255;
     
-    for( int i = 0; i < NUM_LEDS; i++) {
+    for( int i = 0; i < NUM_LEDS; ++i) {
         leds[i] = ColorFromPalette( currentPalette, colorIndex, brightness, currentBlending);
         colorIndex += 3;
     }
@@ -101,7 +101,7 @@ void ChangePalettePeriodically()
 // This function fills the palette with totally random colors.
 void SetupTotallyRandomPalette()
 {
-    for( int i = 0; i < 16; i++) {
+    for( int i = 0; i < 16; ++i) {
         currentPalette[i] = CHSV( random8(), 255, random8());
     }
 }

--- a/hsv2rgb.cpp
+++ b/hsv2rgb.cpp
@@ -496,19 +496,19 @@ void hsv2rgb_rainbow( const CHSV& hsv, CRGB& rgb)
 
 
 void hsv2rgb_raw(const struct CHSV * phsv, struct CRGB * prgb, int numLeds) {
-    for(int i = 0; i < numLeds; i++) {
+    for(int i = 0; i < numLeds; ++i) {
         hsv2rgb_raw(phsv[i], prgb[i]);
     }
 }
 
 void hsv2rgb_rainbow( const struct CHSV* phsv, struct CRGB * prgb, int numLeds) {
-    for(int i = 0; i < numLeds; i++) {
+    for(int i = 0; i < numLeds; ++i) {
         hsv2rgb_rainbow(phsv[i], prgb[i]);
     }
 }
 
 void hsv2rgb_spectrum( const struct CHSV* phsv, struct CRGB * prgb, int numLeds) {
-    for(int i = 0; i < numLeds; i++) {
+    for(int i = 0; i < numLeds; ++i) {
         hsv2rgb_spectrum(phsv[i], prgb[i]);
     }
 }

--- a/lib8tion.cpp
+++ b/lib8tion.cpp
@@ -142,7 +142,7 @@ void test1abs( int8_t i)
 void testabs()
 {
     delay(5000);
-    for( int8_t q = -128; q != 127; q++) {
+    for( int8_t q = -128; q != 127; ++q) {
         test1abs(q);
     }
     for(;;){};
@@ -225,7 +225,7 @@ void testnscale8x3()
 {
     delay(5000);
     byte r, g, b, sc;
-    for( byte z = 0; z < 10; z++) {
+    for( byte z = 0; z < 10; ++z) {
         r = random8(); g = random8(); b = random8(); sc = random8();
 
         Serial.print("nscale8x3_video( ");

--- a/lib8tion/trig8.h
+++ b/lib8tion/trig8.h
@@ -169,7 +169,7 @@ LIB8STATIC uint8_t  sin8_avr( uint8_t theta)
     offset &= 0x3F; // 0..63
 
     uint8_t secoffset  = offset & 0x0F; // 0..15
-    if( theta & 0x40) secoffset++;
+    if( theta & 0x40) ++secoffset;
 
     uint8_t m16; uint8_t b;
 
@@ -179,7 +179,7 @@ LIB8STATIC uint8_t  sin8_avr( uint8_t theta)
     const uint8_t* p = b_m16_interleave;
     p += s2;
     b   = *p;
-    p++;
+    ++p;
     m16 = *p;
 
     uint8_t mx;
@@ -223,14 +223,14 @@ LIB8STATIC uint8_t sin8_C( uint8_t theta)
     offset &= 0x3F; // 0..63
 
     uint8_t secoffset  = offset & 0x0F; // 0..15
-    if( theta & 0x40) secoffset++;
+    if( theta & 0x40) ++secoffset;
 
     uint8_t section = offset >> 4; // 0..3
     uint8_t s2 = section * 2;
     const uint8_t* p = b_m16_interleave;
     p += s2;
     uint8_t b   =  *p;
-    p++;
+    ++p;
     uint8_t m16 =  *p;
 
     uint8_t mx = (m16 * secoffset) >> 4;

--- a/noise.cpp
+++ b/noise.cpp
@@ -565,8 +565,8 @@ uint8_t inoise8(uint16_t x) {
 void fill_raw_noise8(uint8_t *pData, uint8_t num_points, uint8_t octaves, uint16_t x, int scale, uint16_t time) {
   uint32_t _xx = x;
   uint32_t scx = scale;
-  for(int o = 0; o < octaves; o++) {
-    for(int i = 0,xx=_xx; i < num_points; i++, xx+=scx) {
+  for(int o = 0; o < octaves; ++o) {
+    for(int i = 0,xx=_xx; i < num_points; ++i, xx+=scx) {
           pData[i] = qadd8(pData[i],inoise8(xx,time)>>o);
     }
 
@@ -578,8 +578,8 @@ void fill_raw_noise8(uint8_t *pData, uint8_t num_points, uint8_t octaves, uint16
 void fill_raw_noise16into8(uint8_t *pData, uint8_t num_points, uint8_t octaves, uint32_t x, int scale, uint32_t time) {
   uint32_t _xx = x;
   uint32_t scx = scale;
-  for(int o = 0; o < octaves; o++) {
-    for(int i = 0,xx=_xx; i < num_points; i++, xx+=scx) {
+  for(int o = 0; o < octaves; ++o) {
+    for(int i = 0,xx=_xx; i < num_points; ++i, xx+=scx) {
       uint32_t accum = (inoise16(xx,time))>>o;
       accum += (pData[i]<<8);
       if(accum > 65535) { accum = 65535; }
@@ -604,19 +604,19 @@ void fill_raw_2dnoise8(uint8_t *pData, int width, int height, uint8_t octaves, q
 
   fract8 invamp = 255-amplitude;
   uint16_t xx = x;
-  for(int i = 0; i < height; i++, y+=scaley) {
+  for(int i = 0; i < height; ++i, y+=scaley) {
     uint8_t *pRow = pData + (i*width);
     xx = x;
-    for(int j = 0; j < width; j++, xx+=scalex) {
+    for(int j = 0; j < width; ++j, xx+=scalex) {
       uint8_t noise_base = inoise8(xx,y,time);
       noise_base = (0x80 & noise_base) ? (noise_base - 127) : (127 - noise_base);
       noise_base = scale8(noise_base<<1,amplitude);
       if(skip == 1) {
         pRow[j] = scale8(pRow[j],invamp) + noise_base;
       } else {
-        for(int ii = i; ii<(i+skip) && ii<height; ii++) {
+        for(int ii = i; ii<(i+skip) && ii<height; ++ii) {
           uint8_t *pRow = pData + (ii*width);
-          for(int jj=j; jj<(j+skip) && jj<width; jj++) {
+          for(int jj=j; jj<(j+skip) && jj<width; ++jj) {
             pRow[jj] = scale8(pRow[jj],invamp) + noise_base;
           }
         }
@@ -649,9 +649,9 @@ void fill_raw_2dnoise16(uint16_t *pData, int width, int height, uint8_t octaves,
       if(skip==1) {
         pRow[j] = scale16(pRow[j],invamp) + noise_base;
       } else {
-        for(int ii = i; ii<(i+skip) && ii<height; ii++) {
+        for(int ii = i; ii<(i+skip) && ii<height; ++ii) {
           uint16_t *pRow = pData + (ii*width);
-          for(int jj=j; jj<(j+skip) && jj<width; jj++) {
+          for(int jj=j; jj<(j+skip) && jj<width; ++jj) {
             pRow[jj] = scale16(pRow[jj],invamp) + noise_base;
           }
         }
@@ -685,9 +685,9 @@ void fill_raw_2dnoise16into8(uint8_t *pData, int width, int height, uint8_t octa
       if(skip==1) {
         pRow[j] = qadd8(scale8(pRow[j],invamp),noise_base);
       } else {
-        for(int ii = i; ii<(i+skip) && ii<height; ii++) {
+        for(int ii = i; ii<(i+skip) && ii<height; ++ii) {
           uint8_t *pRow = pData + (ii*width);
-          for(int jj=j; jj<(j+skip) && jj<width; jj++) {
+          for(int jj=j; jj<(j+skip) && jj<width; ++jj) {
             pRow[jj] = scale8(pRow[jj],invamp) + noise_base;
           }
         }
@@ -713,7 +713,7 @@ void fill_noise8(CRGB *leds, int num_leds,
   fill_raw_noise8(V,num_leds,octaves,x,scale,time);
   fill_raw_noise8(H,num_leds,hue_octaves,hue_x,hue_scale,time);
 
-  for(int i = 0; i < num_leds; i++) {
+  for(int i = 0; i < num_leds; ++i) {
     leds[i] = CHSV(H[i],255,V[i]);
   }
 }
@@ -731,7 +731,7 @@ void fill_noise16(CRGB *leds, int num_leds,
   fill_raw_noise16into8(V,num_leds,octaves,x,scale,time);
   fill_raw_noise8(H,num_leds,hue_octaves,hue_x,hue_scale,time);
 
-  for(int i = 0; i < num_leds; i++) {
+  for(int i = 0; i < num_leds; ++i) {
     leds[i] = CHSV(H[i] + hue_shift,255,V[i]);
   }
 }
@@ -750,9 +750,9 @@ void fill_2dnoise8(CRGB *leds, int width, int height, bool serpentine,
 
   int w1 = width-1;
   int h1 = height-1;
-  for(int i = 0; i < height; i++) {
+  for(int i = 0; i < height; ++i) {
     int wb = i*width;
-    for(int j = 0; j < width; j++) {
+    for(int j = 0; j < width; ++j) {
       CRGB led(CHSV(H[h1-i][w1-j],255,V[i][j]));
 
       int pos = j;
@@ -788,9 +788,9 @@ void fill_2dnoise16(CRGB *leds, int width, int height, bool serpentine,
   int h1 = height-1;
   hue_shift >>= 8;
 
-  for(int i = 0; i < height; i++) {
+  for(int i = 0; i < height; ++i) {
     int wb = i*width;
-    for(int j = 0; j < width; j++) {
+    for(int j = 0; j < width; ++j) {
       CRGB led(CHSV(hue_shift + (H[h1-i][w1-j]),196,V[i][j]));
 
       int pos = j;

--- a/pixeltypes.h
+++ b/pixeltypes.h
@@ -538,14 +538,14 @@ struct CRGB {
             // going 'up'
             if( (b > 0) && (b < 255)) {
                 if( r == g && g == b) {
-                    r++;
-                    g++;
+                    ++r;
+                    ++g;
                 }
-                b++;
+                ++b;
             } else if( (r > 0) && (r < 255)) {
-                r++;
+                ++r;
             } else if( (g > 0) && (g < 255)) {
-                g++;
+                ++g;
             } else {
                 if( r == g && g == b) {
                     r ^= 0x01;
@@ -557,14 +557,14 @@ struct CRGB {
             // going 'down'
             if( b > 1) {
                 if( r == g && g == b) {
-                    r--;
-                    g--;
+                    --r;
+                    --g;
                 }
-                b--;
+                --b;
             } else if( g > 1) {
-                g--;
+                --g;
             } else if( r > 1) {
-                r--;
+                --r;
             } else {
                 if( r == g && g == b) {
                     r ^= 0x01;

--- a/platforms.cpp
+++ b/platforms.cpp
@@ -17,16 +17,16 @@
     #endif
             // NOTE: Update platforms.cpp in root of FastLED library if this changes        
             #if defined(FASTLED_NRF52_ENABLE_PWM_INSTANCE0)
-                void PWM0_IRQHandler(void) { isrCount++; PWM_Arbiter<0>::isr_handler(); }
+                void PWM0_IRQHandler(void) { ++isrCount; PWM_Arbiter<0>::isr_handler(); }
             #endif
             #if defined(FASTLED_NRF52_ENABLE_PWM_INSTANCE1)
-                void PWM1_IRQHandler(void) { isrCount++; PWM_Arbiter<1>::isr_handler(); }
+                void PWM1_IRQHandler(void) { ++isrCount; PWM_Arbiter<1>::isr_handler(); }
             #endif
             #if defined(FASTLED_NRF52_ENABLE_PWM_INSTANCE2)
-                void PWM2_IRQHandler(void) { isrCount++; PWM_Arbiter<2>::isr_handler(); }
+                void PWM2_IRQHandler(void) { ++isrCount; PWM_Arbiter<2>::isr_handler(); }
             #endif
             #if defined(FASTLED_NRF52_ENABLE_PWM_INSTANCE3)
-                void PWM3_IRQHandler(void) { isrCount++; PWM_Arbiter<3>::isr_handler(); }
+                void PWM3_IRQHandler(void) { ++isrCount; PWM_Arbiter<3>::isr_handler(); }
             #endif
     #ifdef __cplusplus
         }

--- a/platforms/arm/common/m0clockless.h
+++ b/platforms/arm/common/m0clockless.h
@@ -2,182 +2,182 @@
 #define __INC_M0_CLOCKLESS_H
 
 struct M0ClocklessData {
-    uint8_t d[3];
-    uint8_t e[3];
-    uint8_t adj;
-    uint8_t pad;
-    uint32_t s[3];
+  uint8_t d[3];
+  uint8_t e[3];
+  uint8_t adj;
+  uint8_t pad;
+  uint32_t s[3];
 };
 
 
 template<int HI_OFFSET, int LO_OFFSET, int T1, int T2, int T3, EOrder RGB_ORDER, int WAIT_TIME>int
 showLedData(volatile uint32_t *_port, uint32_t _bitmask, const uint8_t *_leds, uint32_t num_leds, struct M0ClocklessData *pData) {
-    // Lo register variables
-    register uint32_t scratch=0;
-    register struct M0ClocklessData *base = pData;
-    register volatile uint32_t *port = _port;
-    register uint32_t d=0;
-    register uint32_t counter=num_leds;
-    register uint32_t bn=0;
-    register uint32_t b=0;
-    register uint32_t bitmask = _bitmask;
+  // Lo register variables
+  register uint32_t scratch=0;
+  register struct M0ClocklessData *base = pData;
+  register volatile uint32_t *port = _port;
+  register uint32_t d=0;
+  register uint32_t counter=num_leds;
+  register uint32_t bn=0;
+  register uint32_t b=0;
+  register uint32_t bitmask = _bitmask;
 
-    // high register variable
-    register const uint8_t *leds = _leds;
+  // high register variable
+  register const uint8_t *leds = _leds;
 #if (FASTLED_SCALE8_FIXED == 1)
-    pData->s[0]++;
-    pData->s[1]++;
-    pData->s[2]++;
+  ++pData->s[0];
+  ++pData->s[1];
+  ++pData->s[2];
 #endif
-    asm __volatile__ (
-        ///////////////////////////////////////////////////////////////////////////
-        //
-        // asm macro definitions - used to assemble the clockless output
-        //
-        ".ifnotdef fl_delay_def;"
+  asm __volatile__ (
+    ///////////////////////////////////////////////////////////////////////////
+    //
+    // asm macro definitions - used to assemble the clockless output
+    //
+    ".ifnotdef fl_delay_def;"
 #ifdef FASTLED_ARM_M0_PLUS
-        "  .set fl_is_m0p, 1;"
-        "  .macro m0pad;"
-        "    nop;"
-        "  .endm;"
+    "  .set fl_is_m0p, 1;"
+    "  .macro m0pad;"
+    "    nop;"
+    "  .endm;"
 #else
-        "  .set fl_is_m0p, 0;"
-        "  .macro m0pad;"
-        "  .endm;"
+    "  .set fl_is_m0p, 0;"
+    "  .macro m0pad;"
+    "  .endm;"
 #endif
-        "  .set fl_delay_def, 1;"
-        "  .set fl_delay_mod, 4;"
-        "  .if fl_is_m0p == 1;"
-        "    .set fl_delay_mod, 3;"
-        "  .endif;"
-        "  .macro fl_delay dtime, reg=r0;"
-        "    .if (\\dtime > 0);"
-        "      .set dcycle, (\\dtime / fl_delay_mod);"
-        "      .set dwork, (dcycle * fl_delay_mod);"
-        "      .set drem, (\\dtime - dwork);"
-        "      .rept (drem);"
-        "        nop;"
-        "      .endr;"
-        "      .if dcycle > 0;"
-        "        mov \\reg, #dcycle;"
-        "        delayloop_\\@:;"
-        "        sub \\reg, #1;"
-        "        bne delayloop_\\@;"
-        "	     .if fl_is_m0p == 0;"
-        "          nop;"
-        "        .endif;"
-        "      .endif;"
-        "    .endif;"
-        "  .endm;"
+    "  .set fl_delay_def, 1;"
+    "  .set fl_delay_mod, 4;"
+    "  .if fl_is_m0p == 1;"
+    "    .set fl_delay_mod, 3;"
+    "  .endif;"
+    "  .macro fl_delay dtime, reg=r0;"
+    "    .if (\\dtime > 0);"
+    "      .set dcycle, (\\dtime / fl_delay_mod);"
+    "      .set dwork, (dcycle * fl_delay_mod);"
+    "      .set drem, (\\dtime - dwork);"
+    "      .rept (drem);"
+    "        nop;"
+    "      .endr;"
+    "      .if dcycle > 0;"
+    "        mov \\reg, #dcycle;"
+    "        delayloop_\\@:;"
+    "        sub \\reg, #1;"
+    "        bne delayloop_\\@;"
+    "	     .if fl_is_m0p == 0;"
+    "          nop;"
+    "        .endif;"
+    "      .endif;"
+    "    .endif;"
+    "  .endm;"
 
-        "  .macro mod_delay dtime,b1,b2,reg;"
-        "    .set adj, (\\b1 + \\b2);"
-        "    .if adj < \\dtime;"
-        "      .set dtime2, (\\dtime - adj);"
-        "      fl_delay dtime2, \\reg;"
-        "    .endif;"
-        "  .endm;"
+    "  .macro mod_delay dtime,b1,b2,reg;"
+    "    .set adj, (\\b1 + \\b2);"
+    "    .if adj < \\dtime;"
+    "      .set dtime2, (\\dtime - adj);"
+    "      fl_delay dtime2, \\reg;"
+    "    .endif;"
+    "  .endm;"
 
-        // check the bit and drop the line low if it isn't set
-        "  .macro qlo4 b,bitmask,port,loff	;"
-        "    lsl \\b, #1			;"
-        "    bcs skip_\\@			;"
-        "    str \\bitmask, [\\port, \\loff]	;"
-        "    skip_\\@:			;"
-        "    m0pad;"
-        "  .endm				;"
+    // check the bit and drop the line low if it isn't set
+    "  .macro qlo4 b,bitmask,port,loff	;"
+    "    lsl \\b, #1			;"
+    "    bcs skip_\\@			;"
+    "    str \\bitmask, [\\port, \\loff]	;"
+    "    skip_\\@:			;"
+    "    m0pad;"
+    "  .endm				;"
 
-        // set the pin hi or low (determined by the offset passed in )
-        "  .macro qset2 bitmask,port,loff;"
-        "    str \\bitmask, [\\port, \\loff];"
-        "    m0pad;"
-        "  .endm;"
+    // set the pin hi or low (determined by the offset passed in )
+    "  .macro qset2 bitmask,port,loff;"
+    "    str \\bitmask, [\\port, \\loff];"
+    "    m0pad;"
+    "  .endm;"
 
-        // Load up the next led byte to work with, put it in bn
-        "  .macro loadleds3 leds, bn, rled, scratch;"
-        "    mov \\scratch, \\leds;"
-        "    ldrb \\bn, [\\scratch, \\rled];"
-        "  .endm;"
+    // Load up the next led byte to work with, put it in bn
+    "  .macro loadleds3 leds, bn, rled, scratch;"
+    "    mov \\scratch, \\leds;"
+    "    ldrb \\bn, [\\scratch, \\rled];"
+    "  .endm;"
 
-        // check whether or not we should dither
-        "  .macro loaddither7 bn,d,base,rdither;"
-        "    ldrb \\d, [\\base, \\rdither];"
-        "    lsl \\d, #24;"  //; shift high for the qadd w/bn
-        "    lsl \\bn, #24;" //; shift high for the qadd w/d
-        "    bne chkskip_\\@;" //; if bn==0, clear d;"
-        "    eor \\d, \\d;" //; clear d;"
-        "    m0pad;"
-        "    chkskip_\\@:;"
-        "  .endm;"
+    // check whether or not we should dither
+    "  .macro loaddither7 bn,d,base,rdither;"
+    "    ldrb \\d, [\\base, \\rdither];"
+    "    lsl \\d, #24;"  //; shift high for the qadd w/bn
+    "    lsl \\bn, #24;" //; shift high for the qadd w/d
+    "    bne chkskip_\\@;" //; if bn==0, clear d;"
+    "    eor \\d, \\d;" //; clear d;"
+    "    m0pad;"
+    "    chkskip_\\@:;"
+    "  .endm;"
 
-        // Do the qadd8 for dithering -- there's two versions of this.  The m0 version
-        // takes advantage of the 3 cycle branch to do two things after the branch,
-        // while keeping timing constant.  The m0+, however, branches in 2 cycles, so
-        // we have to work around that a bit more.  This is one of the few times
-        // where the m0 will actually be _more_ efficient than the m0+
-        "  .macro dither5 bn,d;"
-        "  .syntax unified;"
-        "    .if fl_is_m0p == 0;"
-        "      adds \\bn, \\d;"         // do the add
-        "      bcc dither5_1_\\@;"
-        "      mvns \\bn, \\bn;"        // set the low 24bits ot 1's
-        "      lsls \\bn, \\bn, #24;"   // move low 8 bits to the high bits
-        "      dither5_1_\\@:;"
-        "      nop;"                    // nop to keep timing in line
-        "    .else;"
-        "      adds \\bn, \\d;"         // do the add"
-        "      bcc dither5_2_\\@;"
-        "      mvns \\bn, \\bn;"        // set the low 24bits ot 1's
-        "      dither5_2_\\@:;"
-        "      bcc dither5_3_\\@;"
-        "      lsls \\bn, \\bn, #24;"   // move low 8 bits to the high bits
-        "      dither5_3_\\@:;"
-        "    .endif;"
-        "  .syntax divided;"
-        "  .endm;"
+    // Do the qadd8 for dithering -- there's two versions of this.  The m0 version
+    // takes advantage of the 3 cycle branch to do two things after the branch,
+    // while keeping timing constant.  The m0+, however, branches in 2 cycles, so
+    // we have to work around that a bit more.  This is one of the few times
+    // where the m0 will actually be _more_ efficient than the m0+
+    "  .macro dither5 bn,d;"
+    "  .syntax unified;"
+    "    .if fl_is_m0p == 0;"
+    "      adds \\bn, \\d;"         // do the add
+    "      bcc dither5_1_\\@;"
+    "      mvns \\bn, \\bn;"        // set the low 24bits ot 1's
+    "      lsls \\bn, \\bn, #24;"   // move low 8 bits to the high bits
+    "      dither5_1_\\@:;"
+    "      nop;"                    // nop to keep timing in line
+    "    .else;"
+    "      adds \\bn, \\d;"         // do the add"
+    "      bcc dither5_2_\\@;"
+    "      mvns \\bn, \\bn;"        // set the low 24bits ot 1's
+    "      dither5_2_\\@:;"
+    "      bcc dither5_3_\\@;"
+    "      lsls \\bn, \\bn, #24;"   // move low 8 bits to the high bits
+    "      dither5_3_\\@:;"
+    "    .endif;"
+    "  .syntax divided;"
+    "  .endm;"
 
-        // Do our scaling
-        "  .macro scale4 bn, base, scale, scratch;"
-        "    ldr \\scratch, [\\base, \\scale];"
-        "    lsr \\bn, \\bn, #24;"                  // bring bn back down to its low 8 bits
-        "    mul \\bn, \\scratch;"                  // do the multiply
-        "  .endm;"
+    // Do our scaling
+    "  .macro scale4 bn, base, scale, scratch;"
+    "    ldr \\scratch, [\\base, \\scale];"
+    "    lsr \\bn, \\bn, #24;"                  // bring bn back down to its low 8 bits
+    "    mul \\bn, \\scratch;"                  // do the multiply
+    "  .endm;"
 
-        // swap bn into b
-        "  .macro swapbbn1 b,bn;"
-        "    lsl \\b, \\bn, #16;"  // put the 8 bits we want for output high
-        "  .endm;"
+    // swap bn into b
+    "  .macro swapbbn1 b,bn;"
+    "    lsl \\b, \\bn, #16;"  // put the 8 bits we want for output high
+    "  .endm;"
 
-        // adjust the dithering value for the next time around (load e from memory
-        // to do the math)
-        "  .macro adjdither7 base,d,rled,eoffset,scratch;"
-        "    ldrb \\d, [\\base, \\rled];"
-        "    ldrb \\scratch,[\\base,\\eoffset];"          // load e
-        "    .syntax unified;"
-        "    subs \\d, \\scratch, \\d;"                   // d=e-d
-        "    .syntax divided;"
-        "    strb \\d, [\\base, \\rled];"                 // save d
-        "  .endm;"
+    // adjust the dithering value for the next time around (load e from memory
+    // to do the math)
+    "  .macro adjdither7 base,d,rled,eoffset,scratch;"
+    "    ldrb \\d, [\\base, \\rled];"
+    "    ldrb \\scratch,[\\base,\\eoffset];"          // load e
+    "    .syntax unified;"
+    "    subs \\d, \\scratch, \\d;"                   // d=e-d
+    "    .syntax divided;"
+    "    strb \\d, [\\base, \\rled];"                 // save d
+    "  .endm;"
 
-        // increment the led pointer (base+6 has what we're incrementing by)
-        "  .macro incleds3   leds, base, scratch;"
-        "    ldrb \\scratch, [\\base, #6];"               // load incremen
-        "    add \\leds, \\leds, \\scratch;"              // update leds pointer
-        "  .endm;"
+    // increment the led pointer (base+6 has what we're incrementing by)
+    "  .macro incleds3   leds, base, scratch;"
+    "    ldrb \\scratch, [\\base, #6];"               // load incremen
+    "    add \\leds, \\leds, \\scratch;"              // update leds pointer
+    "  .endm;"
 
-        // compare and loop
-        "  .macro cmploop5 counter,label;"
-        "    .syntax unified;"
-        "    subs \\counter, #1;"
-        "    .syntax divided;"
-        "    beq done_\\@;"
-        "    m0pad;"
-        "    b \\label;"
-        "    done_\\@:;"
-        "  .endm;"
+    // compare and loop
+    "  .macro cmploop5 counter,label;"
+    "    .syntax unified;"
+    "    subs \\counter, #1;"
+    "    .syntax divided;"
+    "    beq done_\\@;"
+    "    m0pad;"
+    "    b \\label;"
+    "    done_\\@:;"
+    "  .endm;"
 
-        " .endif;"
-    );
+    " .endif;"
+  );
 
 #define M0_ASM_ARGS     :             \
       [leds] "+h" (leds),             \
@@ -198,9 +198,9 @@ showLedData(volatile uint32_t *_port, uint32_t _bitmask, const uint8_t *_leds, u
       [e0] "I" (3+RO(0)),             \
       [e1] "I" (3+RO(1)),             \
       [e2] "I" (3+RO(2)),             \
-      [scale0] "I" (4*(2+RO(0))),     \
-      [scale1] "I" (4*(2+RO(1))),     \
-      [scale2] "I" (4*(2+RO(2))),     \
+      [scale0] "I" (4*(2+RO(0))),         \
+      [scale1] "I" (4*(2+RO(1))),         \
+      [scale2] "I" (4*(2+RO(2))),         \
       [T1] "I" (T1),                  \
       [T2] "I" (T2),                  \
       [T3] "I" (T3)                   \
@@ -230,157 +230,157 @@ showLedData(volatile uint32_t *_port, uint32_t _bitmask, const uint8_t *_leds, u
     // track the loop outside the asm code, to allow inserting the interrupt
     // overrun checks.
     asm __volatile__ (
-        // pre-load byte 0
-        LOADLEDS3(0) LOADDITHER7(0) DITHER5 SCALE4(0) ADJDITHER7(0) SWAPBBN1
-        M0_ASM_ARGS);
+      // pre-load byte 0
+      LOADLEDS3(0) LOADDITHER7(0) DITHER5 SCALE4(0) ADJDITHER7(0) SWAPBBN1
+      M0_ASM_ARGS);
 
     do {
-        asm __volatile__ (
-            // Write out byte 0, prepping byte 1
-            HI2 _D1 QLO4 NOTHING         _D2(0) LO2 _D3(0)
-            HI2 _D1 QLO4 LOADLEDS3(1)    _D2(3) LO2 _D3(0)
-            HI2 _D1 QLO4 LOADDITHER7(1)  _D2(7) LO2 _D3(0)
-            HI2 _D1 QLO4 DITHER5         _D2(5) LO2 _D3(0)
-            HI2 _D1 QLO4 SCALE4(1)       _D2(4) LO2 _D3(0)
-            HI2 _D1 QLO4 ADJDITHER7(1)   _D2(7) LO2 _D3(0)
-            HI2 _D1 QLO4 NOTHING         _D2(0) LO2 _D3(0)
-            HI2 _D1 QLO4 SWAPBBN1        _D2(1) LO2 _D3(0)
+      asm __volatile__ (
+      // Write out byte 0, prepping byte 1
+      HI2 _D1 QLO4 NOTHING         _D2(0) LO2 _D3(0)
+      HI2 _D1 QLO4 LOADLEDS3(1)    _D2(3) LO2 _D3(0)
+      HI2 _D1 QLO4 LOADDITHER7(1)  _D2(7) LO2 _D3(0)
+      HI2 _D1 QLO4 DITHER5         _D2(5) LO2 _D3(0)
+      HI2 _D1 QLO4 SCALE4(1)       _D2(4) LO2 _D3(0)
+      HI2 _D1 QLO4 ADJDITHER7(1)   _D2(7) LO2 _D3(0)
+      HI2 _D1 QLO4 NOTHING         _D2(0) LO2 _D3(0)
+      HI2 _D1 QLO4 SWAPBBN1        _D2(1) LO2 _D3(0)
 
-            // Write out byte 1, prepping byte 2
-            HI2 _D1 QLO4 NOTHING         _D2(0) LO2 _D3(0)
-            HI2 _D1 QLO4 LOADLEDS3(2)    _D2(3) LO2 _D3(0)
-            HI2 _D1 QLO4 LOADDITHER7(2)  _D2(7) LO2 _D3(0)
-            HI2 _D1 QLO4 DITHER5         _D2(5) LO2 _D3(0)
-            HI2 _D1 QLO4 SCALE4(2)       _D2(4) LO2 _D3(0)
-            HI2 _D1 QLO4 ADJDITHER7(2)   _D2(7) LO2 _D3(0)
-            HI2 _D1 QLO4 NOTHING         _D2(0) LO2 _D3(0)
-            HI2 _D1 QLO4 SWAPBBN1        _D2(1) LO2 _D3(0)
+      // Write out byte 1, prepping byte 2
+      HI2 _D1 QLO4 NOTHING         _D2(0) LO2 _D3(0)
+      HI2 _D1 QLO4 LOADLEDS3(2)    _D2(3) LO2 _D3(0)
+      HI2 _D1 QLO4 LOADDITHER7(2)  _D2(7) LO2 _D3(0)
+      HI2 _D1 QLO4 DITHER5         _D2(5) LO2 _D3(0)
+      HI2 _D1 QLO4 SCALE4(2)       _D2(4) LO2 _D3(0)
+      HI2 _D1 QLO4 ADJDITHER7(2)   _D2(7) LO2 _D3(0)
+      HI2 _D1 QLO4 NOTHING         _D2(0) LO2 _D3(0)
+      HI2 _D1 QLO4 SWAPBBN1        _D2(1) LO2 _D3(0)
 
-            // Write out byte 2, prepping byte 0
-            HI2 _D1 QLO4 INCLEDS3        _D2(3) LO2 _D3(0)
-            HI2 _D1 QLO4 LOADLEDS3(0)    _D2(3) LO2 _D3(0)
-            HI2 _D1 QLO4 LOADDITHER7(0)  _D2(7) LO2 _D3(0)
-            HI2 _D1 QLO4 DITHER5         _D2(5) LO2 _D3(0)
-            HI2 _D1 QLO4 SCALE4(0)       _D2(4) LO2 _D3(0)
-            HI2 _D1 QLO4 ADJDITHER7(0)   _D2(7) LO2 _D3(0)
-            HI2 _D1 QLO4 NOTHING         _D2(0) LO2 _D3(0)
-            HI2 _D1 QLO4 SWAPBBN1        _D2(1) LO2 _D3(5)
+      // Write out byte 2, prepping byte 0
+      HI2 _D1 QLO4 INCLEDS3        _D2(3) LO2 _D3(0)
+      HI2 _D1 QLO4 LOADLEDS3(0)    _D2(3) LO2 _D3(0)
+      HI2 _D1 QLO4 LOADDITHER7(0)  _D2(7) LO2 _D3(0)
+      HI2 _D1 QLO4 DITHER5         _D2(5) LO2 _D3(0)
+      HI2 _D1 QLO4 SCALE4(0)       _D2(4) LO2 _D3(0)
+      HI2 _D1 QLO4 ADJDITHER7(0)   _D2(7) LO2 _D3(0)
+      HI2 _D1 QLO4 NOTHING         _D2(0) LO2 _D3(0)
+      HI2 _D1 QLO4 SWAPBBN1        _D2(1) LO2 _D3(5)
 
-            M0_ASM_ARGS
-        );
-        SEI_CHK; INNER_SEI; --counter; CLI_CHK;
+      M0_ASM_ARGS
+      );
+      SEI_CHK; INNER_SEI; --counter; CLI_CHK;
     } while(counter);
 #elif (FASTLED_ALLOW_INTERRUPTS == 1)
     // We're allowing interrupts - track the loop outside the asm code, and
     // re-enable interrupts in between each iteration.
     asm __volatile__ (
-        // pre-load byte 0
-        LOADLEDS3(0) LOADDITHER7(0) DITHER5 SCALE4(0) ADJDITHER7(0) SWAPBBN1
-        M0_ASM_ARGS);
+      // pre-load byte 0
+      LOADLEDS3(0) LOADDITHER7(0) DITHER5 SCALE4(0) ADJDITHER7(0) SWAPBBN1
+      M0_ASM_ARGS);
 
     do {
-        asm __volatile__ (
-            // Write out byte 0, prepping byte 1
-            HI2 _D1 QLO4 NOTHING         _D2(0) LO2 _D3(0)
-            HI2 _D1 QLO4 LOADLEDS3(1)    _D2(3) LO2 _D3(0)
-            HI2 _D1 QLO4 LOADDITHER7(1)  _D2(7) LO2 _D3(0)
-            HI2 _D1 QLO4 DITHER5         _D2(5) LO2 _D3(0)
-            HI2 _D1 QLO4 SCALE4(1)       _D2(4) LO2 _D3(0)
-            HI2 _D1 QLO4 ADJDITHER7(1)   _D2(7) LO2 _D3(0)
-            HI2 _D1 QLO4 NOTHING         _D2(0) LO2 _D3(0)
-            HI2 _D1 QLO4 SWAPBBN1        _D2(1) LO2 _D3(0)
+      asm __volatile__ (
+      // Write out byte 0, prepping byte 1
+      HI2 _D1 QLO4 NOTHING         _D2(0) LO2 _D3(0)
+      HI2 _D1 QLO4 LOADLEDS3(1)    _D2(3) LO2 _D3(0)
+      HI2 _D1 QLO4 LOADDITHER7(1)  _D2(7) LO2 _D3(0)
+      HI2 _D1 QLO4 DITHER5         _D2(5) LO2 _D3(0)
+      HI2 _D1 QLO4 SCALE4(1)       _D2(4) LO2 _D3(0)
+      HI2 _D1 QLO4 ADJDITHER7(1)   _D2(7) LO2 _D3(0)
+      HI2 _D1 QLO4 NOTHING         _D2(0) LO2 _D3(0)
+      HI2 _D1 QLO4 SWAPBBN1        _D2(1) LO2 _D3(0)
 
-            // Write out byte 1, prepping byte 2
-            HI2 _D1 QLO4 NOTHING         _D2(0) LO2 _D3(0)
-            HI2 _D1 QLO4 LOADLEDS3(2)    _D2(3) LO2 _D3(0)
-            HI2 _D1 QLO4 LOADDITHER7(2)  _D2(7) LO2 _D3(0)
-            HI2 _D1 QLO4 DITHER5         _D2(5) LO2 _D3(0)
-            HI2 _D1 QLO4 SCALE4(2)       _D2(4) LO2 _D3(0)
-            HI2 _D1 QLO4 ADJDITHER7(2)   _D2(7) LO2 _D3(0)
-            HI2 _D1 QLO4 INCLEDS3        _D2(3) LO2 _D3(0)
-            HI2 _D1 QLO4 SWAPBBN1        _D2(1) LO2 _D3(0)
+      // Write out byte 1, prepping byte 2
+      HI2 _D1 QLO4 NOTHING         _D2(0) LO2 _D3(0)
+      HI2 _D1 QLO4 LOADLEDS3(2)    _D2(3) LO2 _D3(0)
+      HI2 _D1 QLO4 LOADDITHER7(2)  _D2(7) LO2 _D3(0)
+      HI2 _D1 QLO4 DITHER5         _D2(5) LO2 _D3(0)
+      HI2 _D1 QLO4 SCALE4(2)       _D2(4) LO2 _D3(0)
+      HI2 _D1 QLO4 ADJDITHER7(2)   _D2(7) LO2 _D3(0)
+      HI2 _D1 QLO4 INCLEDS3        _D2(3) LO2 _D3(0)
+      HI2 _D1 QLO4 SWAPBBN1        _D2(1) LO2 _D3(0)
 
-            // Write out byte 2, prepping byte 0
-            HI2 _D1 QLO4 NOTHING         _D2(0) LO2 _D3(0)
-            HI2 _D1 QLO4 LOADLEDS3(0)    _D2(3) LO2 _D3(0)
-            HI2 _D1 QLO4 LOADDITHER7(0)  _D2(7) LO2 _D3(0)
-            HI2 _D1 QLO4 DITHER5         _D2(5) LO2 _D3(0)
-            HI2 _D1 QLO4 SCALE4(0)       _D2(4) LO2 _D3(0)
-            HI2 _D1 QLO4 ADJDITHER7(0)   _D2(7) LO2 _D3(0)
-            HI2 _D1 QLO4 NOTHING         _D2(0) LO2 _D3(0)
-            HI2 _D1 QLO4 SWAPBBN1        _D2(1) LO2 _D3(5)
+      // Write out byte 2, prepping byte 0
+      HI2 _D1 QLO4 NOTHING         _D2(0) LO2 _D3(0)
+      HI2 _D1 QLO4 LOADLEDS3(0)    _D2(3) LO2 _D3(0)
+      HI2 _D1 QLO4 LOADDITHER7(0)  _D2(7) LO2 _D3(0)
+      HI2 _D1 QLO4 DITHER5         _D2(5) LO2 _D3(0)
+      HI2 _D1 QLO4 SCALE4(0)       _D2(4) LO2 _D3(0)
+      HI2 _D1 QLO4 ADJDITHER7(0)   _D2(7) LO2 _D3(0)
+      HI2 _D1 QLO4 NOTHING         _D2(0) LO2 _D3(0)
+      HI2 _D1 QLO4 SWAPBBN1        _D2(1) LO2 _D3(5)
 
-            M0_ASM_ARGS
-        );
+      M0_ASM_ARGS
+      );
 
-        uint32_t ticksBeforeInterrupts = SysTick->VAL;
-        sei();
-        --counter;
-        cli();
+      uint32_t ticksBeforeInterrupts = SysTick->VAL;
+      sei();
+      --counter;
+      cli();
 
-        // If more than 45 uSecs have elapsed, give up on this frame and start over.
-        // Note: this isn't completely correct. It's possible that more than one
-        // millisecond will elapse, and so SysTick->VAL will lap
-        // ticksBeforeInterrupts.
-        // Note: ticksBeforeInterrupts DECREASES
-        const uint32_t kTicksPerMs = VARIANT_MCK / 1000;
-        const uint32_t kTicksPerUs = kTicksPerMs / 1000;
-        const uint32_t kTicksIn45us = kTicksPerUs * 45;
+      // If more than 45 uSecs have elapsed, give up on this frame and start over.
+      // Note: this isn't completely correct. It's possible that more than one
+      // millisecond will elapse, and so SysTick->VAL will lap
+      // ticksBeforeInterrupts.
+      // Note: ticksBeforeInterrupts DECREASES
+      const uint32_t kTicksPerMs = VARIANT_MCK / 1000;
+      const uint32_t kTicksPerUs = kTicksPerMs / 1000;
+      const uint32_t kTicksIn45us = kTicksPerUs * 45;
 
-        const uint32_t currentTicks = SysTick->VAL;
+      const uint32_t currentTicks = SysTick->VAL;
 
-        if (ticksBeforeInterrupts < currentTicks) {
-            // Timer started over
-            if ((ticksBeforeInterrupts + (kTicksPerMs - currentTicks)) > kTicksIn45us) {
-                return 0;
-            }
-        } else {
-            if ((ticksBeforeInterrupts - currentTicks) > kTicksIn45us) {
-                return 0;
-            }
+      if (ticksBeforeInterrupts < currentTicks) {
+        // Timer started over
+        if ((ticksBeforeInterrupts + (kTicksPerMs - currentTicks)) > kTicksIn45us) {
+          return 0;
         }
+      } else {
+        if ((ticksBeforeInterrupts - currentTicks) > kTicksIn45us) {
+          return 0;
+        }
+      }
     } while(counter);
 #else
     // We're not allowing interrupts - run the entire loop in asm to keep things
     // as tight as possible.  In an ideal world, we should be pushing out ws281x
     // leds (or other 3-wire leds) with zero gaps between pixels.
     asm __volatile__ (
-        // pre-load byte 0
-        LOADLEDS3(0) LOADDITHER7(0) DITHER5 SCALE4(0) ADJDITHER7(0) SWAPBBN1
+      // pre-load byte 0
+    LOADLEDS3(0) LOADDITHER7(0) DITHER5 SCALE4(0) ADJDITHER7(0) SWAPBBN1
 
-        // loop over writing out the data
-        LOOP
-            // Write out byte 0, prepping byte 1
-            HI2 _D1 QLO4 NOTHING         _D2(0) LO2 _D3(0)
-            HI2 _D1 QLO4 LOADLEDS3(1)    _D2(3) LO2 _D3(0)
-            HI2 _D1 QLO4 LOADDITHER7(1)  _D2(7) LO2 _D3(0)
-            HI2 _D1 QLO4 DITHER5         _D2(5) LO2 _D3(0)
-            HI2 _D1 QLO4 SCALE4(1)       _D2(4) LO2 _D3(0)
-            HI2 _D1 QLO4 ADJDITHER7(1)   _D2(7) LO2 _D3(0)
-            HI2 _D1 QLO4 NOTHING         _D2(0) LO2 _D3(0)
-            HI2 _D1 QLO4 SWAPBBN1        _D2(1) LO2 _D3(0)
+    // loop over writing out the data
+    LOOP
+      // Write out byte 0, prepping byte 1
+      HI2 _D1 QLO4 NOTHING         _D2(0) LO2 _D3(0)
+      HI2 _D1 QLO4 LOADLEDS3(1)    _D2(3) LO2 _D3(0)
+      HI2 _D1 QLO4 LOADDITHER7(1)  _D2(7) LO2 _D3(0)
+      HI2 _D1 QLO4 DITHER5         _D2(5) LO2 _D3(0)
+      HI2 _D1 QLO4 SCALE4(1)       _D2(4) LO2 _D3(0)
+      HI2 _D1 QLO4 ADJDITHER7(1)   _D2(7) LO2 _D3(0)
+      HI2 _D1 QLO4 NOTHING         _D2(0) LO2 _D3(0)
+      HI2 _D1 QLO4 SWAPBBN1        _D2(1) LO2 _D3(0)
 
-            // Write out byte 1, prepping byte 2
-            HI2 _D1 QLO4 NOTHING         _D2(0) LO2 _D3(0)
-            HI2 _D1 QLO4 LOADLEDS3(2)    _D2(3) LO2 _D3(0)
-            HI2 _D1 QLO4 LOADDITHER7(2)  _D2(7) LO2 _D3(0)
-            HI2 _D1 QLO4 DITHER5         _D2(5) LO2 _D3(0)
-            HI2 _D1 QLO4 SCALE4(2)       _D2(4) LO2 _D3(0)
-            HI2 _D1 QLO4 ADJDITHER7(2)   _D2(7) LO2 _D3(0)
-            HI2 _D1 QLO4 INCLEDS3        _D2(3) LO2 _D3(0)
-            HI2 _D1 QLO4 SWAPBBN1        _D2(1) LO2 _D3(0)
+      // Write out byte 1, prepping byte 2
+      HI2 _D1 QLO4 NOTHING         _D2(0) LO2 _D3(0)
+      HI2 _D1 QLO4 LOADLEDS3(2)    _D2(3) LO2 _D3(0)
+      HI2 _D1 QLO4 LOADDITHER7(2)  _D2(7) LO2 _D3(0)
+      HI2 _D1 QLO4 DITHER5         _D2(5) LO2 _D3(0)
+      HI2 _D1 QLO4 SCALE4(2)       _D2(4) LO2 _D3(0)
+      HI2 _D1 QLO4 ADJDITHER7(2)   _D2(7) LO2 _D3(0)
+      HI2 _D1 QLO4 INCLEDS3        _D2(3) LO2 _D3(0)
+      HI2 _D1 QLO4 SWAPBBN1        _D2(1) LO2 _D3(0)
 
-            // Write out byte 2, prepping byte 0
-            HI2 _D1 QLO4 NOTHING         _D2(0) LO2 _D3(0)
-            HI2 _D1 QLO4 LOADLEDS3(0)    _D2(3) LO2 _D3(0)
-            HI2 _D1 QLO4 LOADDITHER7(0)  _D2(7) LO2 _D3(0)
-            HI2 _D1 QLO4 DITHER5         _D2(5) LO2 _D3(0)
-            HI2 _D1 QLO4 SCALE4(0)       _D2(4) LO2 _D3(0)
-            HI2 _D1 QLO4 ADJDITHER7(0)   _D2(7) LO2 _D3(0)
-            HI2 _D1 QLO4 NOTHING         _D2(0) LO2 _D3(0)
-            HI2 _D1 QLO4 SWAPBBN1        _D2(1) LO2 _D3(5) CMPLOOP5
+      // Write out byte 2, prepping byte 0
+      HI2 _D1 QLO4 NOTHING         _D2(0) LO2 _D3(0)
+      HI2 _D1 QLO4 LOADLEDS3(0)    _D2(3) LO2 _D3(0)
+      HI2 _D1 QLO4 LOADDITHER7(0)  _D2(7) LO2 _D3(0)
+      HI2 _D1 QLO4 DITHER5         _D2(5) LO2 _D3(0)
+      HI2 _D1 QLO4 SCALE4(0)       _D2(4) LO2 _D3(0)
+      HI2 _D1 QLO4 ADJDITHER7(0)   _D2(7) LO2 _D3(0)
+      HI2 _D1 QLO4 NOTHING         _D2(0) LO2 _D3(0)
+      HI2 _D1 QLO4 SWAPBBN1        _D2(1) LO2 _D3(5) CMPLOOP5
 
-            M0_ASM_ARGS
+      M0_ASM_ARGS
     );
 #endif
     return num_leds;

--- a/platforms/arm/d51/clockless_arm_d51.h
+++ b/platforms/arm/d51/clockless_arm_d51.h
@@ -43,7 +43,7 @@ protected:
 	}
 
 	template<int BITS> __attribute__ ((always_inline)) inline static void writeBits(register uint32_t & next_mark, register data_ptr_t port, register data_t hi, register data_t lo, register uint8_t & b)  {
-		for(register uint32_t i = BITS-1; i > 0; i--) {
+		for(register uint32_t i = BITS-1; i > 0; --i) {
 			while(ARM_DWT_CYCCNT < next_mark);
 			next_mark = ARM_DWT_CYCCNT + (T1+T2+T3);
 			FastPin<DATA_PIN>::fastset(port, hi);

--- a/platforms/arm/d51/clockless_arm_d51.h
+++ b/platforms/arm/d51/clockless_arm_d51.h
@@ -79,8 +79,8 @@ protected:
 		ARM_DWT_CYCCNT = 0;
 
 		register data_ptr_t port = FastPin<DATA_PIN>::port();
-		register data_t hi = *port | FastPin<DATA_PIN>::mask();;
-		register data_t lo = *port & ~FastPin<DATA_PIN>::mask();;
+		register data_t hi = *port | FastPin<DATA_PIN>::mask();
+		register data_t lo = *port & ~FastPin<DATA_PIN>::mask();
 		*port = lo;
 
 		// Setup the pixel controller and load/scale the first byte

--- a/platforms/arm/k20/clockless_arm_k20.h
+++ b/platforms/arm/k20/clockless_arm_k20.h
@@ -38,7 +38,7 @@ protected:
 	}
 
 	template<int BITS> __attribute__ ((always_inline)) inline static void writeBits(register uint32_t & next_mark, register data_ptr_t port, register data_t hi, register data_t lo, register uint8_t & b)  {
-		for(register uint32_t i = BITS-1; i > 0; i--) {
+		for(register uint32_t i = BITS-1; i > 0; --i) {
 			while(ARM_DWT_CYCCNT < next_mark);
 			next_mark = ARM_DWT_CYCCNT + (T1+T2+T3);
 			FastPin<DATA_PIN>::fastset(port, hi);

--- a/platforms/arm/k20/clockless_arm_k20.h
+++ b/platforms/arm/k20/clockless_arm_k20.h
@@ -74,8 +74,8 @@ protected:
 		ARM_DWT_CYCCNT = 0;
 
 		register data_ptr_t port = FastPin<DATA_PIN>::port();
-		register data_t hi = *port | FastPin<DATA_PIN>::mask();;
-		register data_t lo = *port & ~FastPin<DATA_PIN>::mask();;
+		register data_t hi = *port | FastPin<DATA_PIN>::mask();
+		register data_t lo = *port & ~FastPin<DATA_PIN>::mask();
 		*port = lo;
 
 		// Setup the pixel controller and load/scale the first byte

--- a/platforms/arm/k20/clockless_block_arm_k20.h
+++ b/platforms/arm/k20/clockless_block_arm_k20.h
@@ -94,7 +94,7 @@ public:
 		register uint8_t d = pixels.template getd<PX>(pixels);
 		register uint8_t scale = pixels.template getscale<PX>(pixels);
 
-		for(register uint32_t i = 0; i < (USED_LANES/2); i++) {
+		for(register uint32_t i = 0; i < (USED_LANES/2); ++i) {
 			while(ARM_DWT_CYCCNT < next_mark);
 			next_mark = ARM_DWT_CYCCNT + (T1+T2+T3)-3;
 			*FastPin<FIRST_PIN>::sport() = PORT_MASK;
@@ -118,7 +118,7 @@ public:
 			b.bytes[USED_LANES-1] = pixels.template loadAndScale<PX>(pixels,USED_LANES-1,d,scale);
 		}
 
-		for(register uint32_t i = USED_LANES/2; i < 8; i++) {
+		for(register uint32_t i = USED_LANES/2; i < 8; ++i) {
 			while(ARM_DWT_CYCCNT < next_mark);
 			next_mark = ARM_DWT_CYCCNT + (T1+T2+T3)-3;
 			*FastPin<FIRST_PIN>::sport() = PORT_MASK;
@@ -151,7 +151,7 @@ public:
 		register Lines b0;
 
 		allpixels.preStepFirstByteDithering();
-		for(int i = 0; i < USED_LANES; i++) {
+		for(int i = 0; i < USED_LANES; ++i) {
 			b0.bytes[i] = allpixels.loadAndScale0(i);
 		}
 
@@ -252,7 +252,7 @@ public:
 		register uint8_t d = pixels.template getd<PX>(pixels);
 		register uint8_t scale = pixels.template getscale<PX>(pixels);
 
-		for(register uint32_t i = 0; (i < LANES) && (i < 8); i++) {
+		for(register uint32_t i = 0; (i < LANES) && (i < 8); ++i) {
 			while(ARM_DWT_CYCCNT < next_mark);
 			next_mark = ARM_DWT_CYCCNT + (T1+T2+T3)-3;
 			*FastPin<PORTD_FIRST_PIN>::sport() = PMASK_LO;
@@ -288,7 +288,7 @@ public:
 		register Lines b0;
 
 		allpixels.preStepFirstByteDithering();
-		for(int i = 0; i < LANES; i++) {
+		for(int i = 0; i < LANES; ++i) {
 			b0.bytes[i] = allpixels.loadAndScale0(i);
 		}
 

--- a/platforms/arm/k20/fastspi_arm_k20.h
+++ b/platforms/arm/k20/fastspi_arm_k20.h
@@ -87,7 +87,7 @@ template <int VAL> void getScalars(uint32_t & preScalar, uint32_t & scalar, uint
 
 			dbl = 0;
 			if(scalar == 0) { dbl = 1; }
-			else if(scalar < 3) { scalar--; }
+			else if(scalar < 3) { --scalar; }
 		}
 	}
 	return;

--- a/platforms/arm/k20/octows2811_controller.h
+++ b/platforms/arm/k20/octows2811_controller.h
@@ -9,54 +9,54 @@ FASTLED_NAMESPACE_BEGIN
 
 template<EOrder RGB_ORDER = GRB, uint8_t CHIP = WS2811_800kHz>
 class COctoWS2811Controller : public CPixelLEDController<RGB_ORDER, 8, 0xFF> {
-    OctoWS2811  *pocto;
-    uint8_t *drawbuffer,*framebuffer;
+  OctoWS2811  *pocto;
+  uint8_t *drawbuffer,*framebuffer;
 
-    void _init(int nLeds) {
-        if(pocto == NULL) {
-            drawbuffer = (uint8_t*)malloc(nLeds * 8 * 3);
-            framebuffer = (uint8_t*)malloc(nLeds * 8 * 3);
+  void _init(int nLeds) {
+    if(pocto == NULL) {
+      drawbuffer = (uint8_t*)malloc(nLeds * 8 * 3);
+      framebuffer = (uint8_t*)malloc(nLeds * 8 * 3);
 
-            // byte ordering is handled in show by the pixel controller
-            int config = WS2811_RGB;
-            config |= CHIP;
+      // byte ordering is handled in show by the pixel controller
+      int config = WS2811_RGB;
+      config |= CHIP;
 
-            pocto = new OctoWS2811(nLeds, framebuffer, drawbuffer, config);
+      pocto = new OctoWS2811(nLeds, framebuffer, drawbuffer, config);
 
-            pocto->begin();
-        }
+      pocto->begin();
     }
-
+  }
 public:
-    COctoWS2811Controller() { pocto = NULL; }
-    virtual int size() { return CLEDController::size() * 8; }
+  COctoWS2811Controller() { pocto = NULL; }
+  virtual int size() { return CLEDController::size() * 8; }
 
-    virtual void init() { /* do nothing yet */ }
+  virtual void init() { /* do nothing yet */ }
 
-    typedef union {
-        uint8_t bytes[8];
-        uint32_t raw[2];
-    } Lines;
+  typedef union {
+    uint8_t bytes[8];
+    uint32_t raw[2];
+  } Lines;
 
-    virtual void showPixels(PixelController<RGB_ORDER, 8, 0xFF> & pixels) {
-        _init(pixels.size());
+  virtual void showPixels(PixelController<RGB_ORDER, 8, 0xFF> & pixels) {
+    _init(pixels.size());
 
-        uint8_t *pData = drawbuffer;
-        while(pixels.has(1)) {
-            Lines b;
+    uint8_t *pData = drawbuffer;
+    while(pixels.has(1)) {
+      Lines b;
 
-            for(int i = 0; i < 8; i++) { b.bytes[i] = pixels.loadAndScale0(i); }
-            transpose8x1_MSB(b.bytes,pData); pData += 8;
-            for(int i = 0; i < 8; i++) { b.bytes[i] = pixels.loadAndScale1(i); }
-            transpose8x1_MSB(b.bytes,pData); pData += 8;
-            for(int i = 0; i < 8; i++) { b.bytes[i] = pixels.loadAndScale2(i); }
-            transpose8x1_MSB(b.bytes,pData); pData += 8;
-            pixels.stepDithering();
-            pixels.advanceData();
-        }
-
-        pocto->show();
+      for(int i = 0; i < 8; ++i) { b.bytes[i] = pixels.loadAndScale0(i); }
+      transpose8x1_MSB(b.bytes,pData); pData += 8;
+      for(int i = 0; i < 8; ++i) { b.bytes[i] = pixels.loadAndScale1(i); }
+      transpose8x1_MSB(b.bytes,pData); pData += 8;
+      for(int i = 0; i < 8; ++i) { b.bytes[i] = pixels.loadAndScale2(i); }
+      transpose8x1_MSB(b.bytes,pData); pData += 8;
+      pixels.stepDithering();
+      pixels.advanceData();
     }
+
+    pocto->show();
+  }
+
 };
 
 FASTLED_NAMESPACE_END

--- a/platforms/arm/k66/clockless_arm_k66.h
+++ b/platforms/arm/k66/clockless_arm_k66.h
@@ -38,7 +38,7 @@ protected:
 	}
 
 	template<int BITS> __attribute__ ((always_inline)) inline static void writeBits(register uint32_t & next_mark, register data_ptr_t port, register data_t hi, register data_t lo, register uint8_t & b)  {
-		for(register uint32_t i = BITS-1; i > 0; i--) {
+		for(register uint32_t i = BITS-1; i > 0; --i) {
 			while(ARM_DWT_CYCCNT < next_mark);
 			next_mark = ARM_DWT_CYCCNT + (T1+T2+T3);
 			FastPin<DATA_PIN>::fastset(port, hi);

--- a/platforms/arm/k66/clockless_arm_k66.h
+++ b/platforms/arm/k66/clockless_arm_k66.h
@@ -74,8 +74,8 @@ protected:
 		ARM_DWT_CYCCNT = 0;
 
 		register data_ptr_t port = FastPin<DATA_PIN>::port();
-		register data_t hi = *port | FastPin<DATA_PIN>::mask();;
-		register data_t lo = *port & ~FastPin<DATA_PIN>::mask();;
+		register data_t hi = *port | FastPin<DATA_PIN>::mask();
+		register data_t lo = *port & ~FastPin<DATA_PIN>::mask();
 		*port = lo;
 
 		// Setup the pixel controller and load/scale the first byte

--- a/platforms/arm/k66/clockless_block_arm_k66.h
+++ b/platforms/arm/k66/clockless_block_arm_k66.h
@@ -108,7 +108,7 @@ public:
 		register uint8_t d = pixels.template getd<PX>(pixels);
 		register uint8_t scale = pixels.template getscale<PX>(pixels);
 
-		for(register uint32_t i = 0; i < (USED_LANES/2); i++) {
+		for(register uint32_t i = 0; i < (USED_LANES/2); ++i) {
 			while(ARM_DWT_CYCCNT < next_mark);
 			next_mark = ARM_DWT_CYCCNT + (T1+T2+T3)-3;
 			*FastPin<FIRST_PIN>::sport() = PORT_MASK;
@@ -132,7 +132,7 @@ public:
 			b.bytes[USED_LANES-1] = pixels.template loadAndScale<PX>(pixels,USED_LANES-1,d,scale);
 		}
 
-		for(register uint32_t i = USED_LANES/2; i < 8; i++) {
+		for(register uint32_t i = USED_LANES/2; i < 8; ++i) {
 			while(ARM_DWT_CYCCNT < next_mark);
 			next_mark = ARM_DWT_CYCCNT + (T1+T2+T3)-3;
 			*FastPin<FIRST_PIN>::sport() = PORT_MASK;
@@ -165,7 +165,7 @@ public:
 		register Lines b0;
 
 		allpixels.preStepFirstByteDithering();
-		for(int i = 0; i < USED_LANES; i++) {
+		for(int i = 0; i < USED_LANES; ++i) {
 			b0.bytes[i] = allpixels.loadAndScale0(i);
 		}
 
@@ -266,7 +266,7 @@ public:
 		register uint8_t d = pixels.template getd<PX>(pixels);
 		register uint8_t scale = pixels.template getscale<PX>(pixels);
 
-		for(register uint32_t i = 0; (i < LANES) && (i < 8); i++) {
+		for(register uint32_t i = 0; (i < LANES) && (i < 8); ++i) {
 			while(ARM_DWT_CYCCNT < next_mark);
 			next_mark = ARM_DWT_CYCCNT + (T1+T2+T3)-3;
 			*FastPin<PORTD_FIRST_PIN>::sport() = PMASK_LO;
@@ -301,7 +301,7 @@ public:
 		register Lines b0;
 
 		allpixels.preStepFirstByteDithering();
-		for(int i = 0; i < LANES; i++) {
+		for(int i = 0; i < LANES; ++i) {
 			b0.bytes[i] = allpixels.loadAndScale0(i);
 		}
 

--- a/platforms/arm/k66/fastspi_arm_k66.h
+++ b/platforms/arm/k66/fastspi_arm_k66.h
@@ -95,7 +95,7 @@ template <int VAL> void getScalars(uint32_t & preScalar, uint32_t & scalar, uint
 
 			dbl = 0;
 			if(scalar == 0) { dbl = 1; }
-			else if(scalar < 3) { scalar--; }
+			else if(scalar < 3) { --scalar; }
 		}
 	}
 	return;

--- a/platforms/arm/mxrt1062/block_clockless_arm_mxrt1062.h
+++ b/platforms/arm/mxrt1062/block_clockless_arm_mxrt1062.h
@@ -82,7 +82,7 @@ public:
             _BLOCK_PIN(30);
         }
 
-        for(int i = 0; i < m_nActualLanes; i++) {
+        for(int i = 0; i < m_nActualLanes; ++i) {
             if(m_bitOffsets[i] < m_nLowBit) { m_nLowBit = m_bitOffsets[i]; }
             if(m_bitOffsets[i] > m_nHighBit) { m_nHighBit = m_bitOffsets[i]; }
         }
@@ -106,49 +106,48 @@ public:
 		mWait.mark();
 	}
 
-    typedef union {
-        uint8_t bytes[32];
-        uint8_t bg[4][8];
-        uint16_t shorts[16];
-        uint32_t raw[8];
-    } _outlines;
+  typedef union {
+    uint8_t bytes[32];
+    uint8_t bg[4][8];
+    uint16_t shorts[16];
+    uint32_t raw[8];
+  } _outlines;
 
-    template<int BITS,int PX> __attribute__ ((always_inline)) inline void writeBits(register uint32_t & next_mark, register _outlines & b, PixelController<RGB_ORDER, LANES, __FL_T4_MASK> &pixels) {
-        _outlines b2;
-        transpose8x1(b.bg[3], b2.bg[3]);
-        transpose8x1(b.bg[2], b2.bg[2]);
-        transpose8x1(b.bg[1], b2.bg[1]);
-        transpose8x1(b.bg[0], b2.bg[0]);
 
-        register uint8_t d = pixels.template getd<PX>(pixels);
-        register uint8_t scale = pixels.template getscale<PX>(pixels);
+  template<int BITS,int PX> __attribute__ ((always_inline)) inline void writeBits(register uint32_t & next_mark, register _outlines & b, PixelController<RGB_ORDER, LANES, __FL_T4_MASK> &pixels) {
+    _outlines b2;
+    transpose8x1(b.bg[3], b2.bg[3]);
+    transpose8x1(b.bg[2], b2.bg[2]);
+    transpose8x1(b.bg[1], b2.bg[1]);
+    transpose8x1(b.bg[0], b2.bg[0]);
 
-        int x = 0;
-        for(uint32_t i = 8; i > 0;) {
-            i--;
-            while(ARM_DWT_CYCCNT < next_mark);
-            *FastPin<FIRST_PIN>::sport() = m_nWriteMask;
-            next_mark = ARM_DWT_CYCCNT + m_offsets[0];
+    register uint8_t d = pixels.template getd<PX>(pixels);
+    register uint8_t scale = pixels.template getscale<PX>(pixels);
 
-            uint32_t out = (b2.bg[3][i] << 24) | (b2.bg[2][i] << 16) | (b2.bg[1][i] << 8) | b2.bg[0][i];
+    int x = 0;
+    for(uint32_t i = 8; i > 0;) {
+      --i;
+      while(ARM_DWT_CYCCNT < next_mark);
+      *FastPin<FIRST_PIN>::sport() = m_nWriteMask;
+      next_mark = ARM_DWT_CYCCNT + m_offsets[0];
 
-            out = ((~out) & m_nWriteMask);
-            while((next_mark - ARM_DWT_CYCCNT) > m_offsets[1]);
-            *FastPin<FIRST_PIN>::cport() = out;
+      uint32_t out = (b2.bg[3][i] << 24) | (b2.bg[2][i] << 16) | (b2.bg[1][i] << 8) | b2.bg[0][i];
 
-            out = m_nWriteMask;
-            while((next_mark - ARM_DWT_CYCCNT) > m_offsets[2]);
-            *FastPin<FIRST_PIN>::cport() = out;
+      out = ((~out) & m_nWriteMask);
+      while((next_mark - ARM_DWT_CYCCNT) > m_offsets[1]);
+      *FastPin<FIRST_PIN>::cport() = out;
 
-            // Read and store up to two bytes
-            if (x < m_nActualLanes) {
-                b.bytes[m_bitOffsets[x]] = pixels.template loadAndScale<PX>(pixels,x,d,scale);
-                x++;
-                if (x < m_nActualLanes) {
-                    b.bytes[m_bitOffsets[x]] = pixels.template loadAndScale<PX>(pixels,x,d,scale);
-                    x++;
-                }
-            }
+      out = m_nWriteMask;
+      while((next_mark - ARM_DWT_CYCCNT) > m_offsets[2]);
+      *FastPin<FIRST_PIN>::cport() = out;
+
+      // Read and store up to two bytes
+      if (x < m_nActualLanes) {
+        b.bytes[m_bitOffsets[x]] = pixels.template loadAndScale<PX>(pixels,x,d,scale);
+        ++x;
+        if (x < m_nActualLanes) {
+          b.bytes[m_bitOffsets[x]] = pixels.template loadAndScale<PX>(pixels,x,d,scale);
+          ++x;
         }
     }
 
@@ -157,9 +156,15 @@ public:
         _outlines b0;
         uint32_t start = ARM_DWT_CYCCNT;
 
+<<<<<<< HEAD
         for(int i = 0; i < m_nActualLanes; i++) {
             b0.bytes[m_bitOffsets[i]] = allpixels.loadAndScale0(i);
         }
+=======
+    for(int i = 0; i < m_nActualLanes; ++i) {
+      b0.bytes[m_bitOffsets[i]] = allpixels.loadAndScale0(i);
+    }
+>>>>>>> use prefix notation for ++ and -- where possible
 
         cli();
 

--- a/platforms/arm/mxrt1062/clockless_arm_mxrt1062.h
+++ b/platforms/arm/mxrt1062/clockless_arm_mxrt1062.h
@@ -51,7 +51,7 @@ protected:
   	}
 
 	template<int BITS> __attribute__ ((always_inline)) inline void writeBits(register uint32_t & next_mark, register uint32_t & b)  {
-		for(register uint32_t i = BITS-1; i > 0; i--) {
+		for(register uint32_t i = BITS-1; i > 0; --i) {
 			while(ARM_DWT_CYCCNT < next_mark);
 			next_mark = ARM_DWT_CYCCNT + off[0];
 			FastPin<DATA_PIN>::hi();

--- a/platforms/arm/nrf52/clockless_arm_nrf52.h
+++ b/platforms/arm/nrf52/clockless_arm_nrf52.h
@@ -206,45 +206,45 @@ public:
 
         while (pixels.has(1) && (remainingSequenceElements >= _BITS_PER_PIXEL)) {
             uint8_t b0 = pixels.loadAndScale0();
-            WriteBitToSequence<7>(b0, e); e++;
-            WriteBitToSequence<6>(b0, e); e++;
-            WriteBitToSequence<5>(b0, e); e++;
-            WriteBitToSequence<4>(b0, e); e++;
-            WriteBitToSequence<3>(b0, e); e++;
-            WriteBitToSequence<2>(b0, e); e++;
-            WriteBitToSequence<1>(b0, e); e++;
-            WriteBitToSequence<0>(b0, e); e++;
+            WriteBitToSequence<7>(b0, e); ++e;
+            WriteBitToSequence<6>(b0, e); ++e;
+            WriteBitToSequence<5>(b0, e); ++e;
+            WriteBitToSequence<4>(b0, e); ++e;
+            WriteBitToSequence<3>(b0, e); ++e;
+            WriteBitToSequence<2>(b0, e); ++e;
+            WriteBitToSequence<1>(b0, e); ++e;
+            WriteBitToSequence<0>(b0, e); ++e;
             if (_XTRA0 > 0) {
-                for (int i = 0; i < _XTRA0; i++) {
-                    WriteBitToSequence<0>(0,e); e++;
+                for (int i = 0; i < _XTRA0; ++i) {
+                    WriteBitToSequence<0>(0,e); ++e;
                 }
             }
             uint8_t b1 = pixels.loadAndScale1();
-            WriteBitToSequence<7>(b1, e); e++;
-            WriteBitToSequence<6>(b1, e); e++;
-            WriteBitToSequence<5>(b1, e); e++;
-            WriteBitToSequence<4>(b1, e); e++;
-            WriteBitToSequence<3>(b1, e); e++;
-            WriteBitToSequence<2>(b1, e); e++;
-            WriteBitToSequence<1>(b1, e); e++;
-            WriteBitToSequence<0>(b1, e); e++;
+            WriteBitToSequence<7>(b1, e); ++e;
+            WriteBitToSequence<6>(b1, e); ++e;
+            WriteBitToSequence<5>(b1, e); ++e;
+            WriteBitToSequence<4>(b1, e); ++e;
+            WriteBitToSequence<3>(b1, e); ++e;
+            WriteBitToSequence<2>(b1, e); ++e;
+            WriteBitToSequence<1>(b1, e); ++e;
+            WriteBitToSequence<0>(b1, e); ++e;
             if (_XTRA0 > 0) {
-                for (int i = 0; i < _XTRA0; i++) {
-                    WriteBitToSequence<0>(0,e); e++;
+                for (int i = 0; i < _XTRA0; ++i) {
+                    WriteBitToSequence<0>(0,e); ++e;
                 }
             }
             uint8_t b2 = pixels.loadAndScale2();
-            WriteBitToSequence<7>(b2, e); e++;
-            WriteBitToSequence<6>(b2, e); e++;
-            WriteBitToSequence<5>(b2, e); e++;
-            WriteBitToSequence<4>(b2, e); e++;
-            WriteBitToSequence<3>(b2, e); e++;
-            WriteBitToSequence<2>(b2, e); e++;
-            WriteBitToSequence<1>(b2, e); e++;
-            WriteBitToSequence<0>(b2, e); e++;
+            WriteBitToSequence<7>(b2, e); ++e;
+            WriteBitToSequence<6>(b2, e); ++e;
+            WriteBitToSequence<5>(b2, e); ++e;
+            WriteBitToSequence<4>(b2, e); ++e;
+            WriteBitToSequence<3>(b2, e); ++e;
+            WriteBitToSequence<2>(b2, e); ++e;
+            WriteBitToSequence<1>(b2, e); ++e;
+            WriteBitToSequence<0>(b2, e); ++e;
             if (_XTRA0 > 0) {
-                for (int i = 0; i < _XTRA0; i++) {
-                    WriteBitToSequence<0>(0,e); e++;
+                for (int i = 0; i < _XTRA0; ++i) {
+                    WriteBitToSequence<0>(0,e); ++e;
                 }
             }
 
@@ -291,22 +291,22 @@ public:
         uint8_t  * nextByte    = arrayOfBytes;
         for (uint16_t bytesRemain = bytesToSend;
             (remainingSequenceElements >= 8) && (bytesRemain > 0);
-            bytesRemain--,
+            --bytesRemain,
             remainingSequenceElements     -= 8,
             s_SequenceBufferValidElements += 8
             ) {
             uint8_t b = *nextByte;
-            WriteBitToSequence<7,false>(b, e); e++;
-            WriteBitToSequence<6,false>(b, e); e++;
-            WriteBitToSequence<5,false>(b, e); e++;
-            WriteBitToSequence<4,false>(b, e); e++;
-            WriteBitToSequence<3,false>(b, e); e++;
-            WriteBitToSequence<2,false>(b, e); e++;
-            WriteBitToSequence<1,false>(b, e); e++;
-            WriteBitToSequence<0,false>(b, e); e++;
+            WriteBitToSequence<7,false>(b, e); ++e;
+            WriteBitToSequence<6,false>(b, e); ++e;
+            WriteBitToSequence<5,false>(b, e); ++e;
+            WriteBitToSequence<4,false>(b, e); ++e;
+            WriteBitToSequence<3,false>(b, e); ++e;
+            WriteBitToSequence<2,false>(b, e); ++e;
+            WriteBitToSequence<1,false>(b, e); ++e;
+            WriteBitToSequence<0,false>(b, e); ++e;
             if (_XTRA0 > 0) {
-                for (int i = 0; i < _XTRA0; i++) {
-                    WriteBitToSequence<0,_FLIP>(0,e); e++;
+                for (int i = 0; i < _XTRA0; ++i) {
+                    WriteBitToSequence<0,_FLIP>(0,e); ++e;
                 }
             }
         }

--- a/platforms/arm/sam/clockless_arm_sam.h
+++ b/platforms/arm/sam/clockless_arm_sam.h
@@ -48,7 +48,7 @@ protected:
 		// while(VAL < (TOTAL*10)) { bShift=true; }
 		// if(bShift) { next_mark = (VAL-TOTAL); };
 
-		for(register uint32_t i = BITS; i > 0; i--) {
+		for(register uint32_t i = BITS; i > 0; --i) {
 			// wait to start the bit, then set the pin high
 			while(DUE_TIMER_VAL < next_mark);
 			next_mark = (DUE_TIMER_VAL+TOTAL);

--- a/platforms/arm/stm32/clockless_arm_stm32.h
+++ b/platforms/arm/stm32/clockless_arm_stm32.h
@@ -38,7 +38,7 @@ protected:
 #define _CYCCNT (*(volatile uint32_t*)(0xE0001004UL))
 
     template<int BITS> __attribute__ ((always_inline)) inline static void writeBits(register uint32_t & next_mark, register data_ptr_t port, register data_t hi, register data_t lo, register uint8_t & b)  {
-        for(register uint32_t i = BITS-1; i > 0; i--) {
+        for(register uint32_t i = BITS-1; i > 0; --i) {
             while(_CYCCNT < (T1+T2+T3-20));
             FastPin<DATA_PIN>::fastset(port, hi);
             _CYCCNT = 4;

--- a/platforms/esp/32/clockless_block_esp32.h
+++ b/platforms/esp/32/clockless_block_esp32.h
@@ -35,7 +35,7 @@ public:
 	while(!showRGBInternal(pixels) && cnt--) {
 	    ets_intr_unlock();
 #ifdef FASTLED_DEBUG_COUNT_FRAME_RETRIES
-	    _retry_cnt++;
+	    ++_retry_cnt;
 #endif
 	    delayMicroseconds(WAIT_TIME * 10);
 	    ets_intr_lock();
@@ -86,7 +86,7 @@ public:
 	register uint8_t d = pixels.template getd<PX>(pixels);
 	register uint8_t scale = pixels.template getscale<PX>(pixels);
 	
-	for(register uint32_t i = 0; i < USED_LANES; i++) {
+	for(register uint32_t i = 0; i < USED_LANES; ++i) {
 	    while((__clock_cycles() - last_mark) < (T1+T2+T3));
 	    last_mark = __clock_cycles();
 	    *FastPin<FIRST_PIN>::sport() = PORT_MASK << REAL_FIRST_PIN;
@@ -101,7 +101,7 @@ public:
 	    b.bytes[i] = pixels.template loadAndScale<PX>(pixels,i,d,scale);
 	}
 
-	for(register uint32_t i = USED_LANES; i < 8; i++) {
+	for(register uint32_t i = USED_LANES; i < 8; ++i) {
 	    while((__clock_cycles() - last_mark) < (T1+T2+T3));
 	    last_mark = __clock_cycles();
 	    *FastPin<FIRST_PIN>::sport() = PORT_MASK << REAL_FIRST_PIN;
@@ -122,7 +122,7 @@ public:
 	// Setup the pixel controller and load/scale the first byte
 	Lines b0;
 	
-	for(int i = 0; i < USED_LANES; i++) {
+	for(int i = 0; i < USED_LANES; ++i) {
 	    b0.bytes[i] = allpixels.loadAndScale0(i);
 	}
 	allpixels.preStepFirstByteDithering();
@@ -159,7 +159,7 @@ public:
 	
 	ets_intr_unlock();
 #ifdef FASTLED_DEBUG_COUNT_FRAME_RETRIES
-	_frame_cnt++;
+	++_frame_cnt;
 #endif
 	return __clock_cycles() - _start;
     }

--- a/platforms/esp/32/clockless_esp32.h.orig
+++ b/platforms/esp/32/clockless_esp32.h.orig
@@ -1,0 +1,786 @@
+/*
+ * Integration into FastLED ClocklessController 2017 Thomas Basler
+ *
+ * Modifications Copyright (c) 2017 Martin F. Falatic
+ *
+ * Modifications Copyright (c) 2018 Samuel Z. Guyer
+ *
+ * ESP32 support is provided using the RMT peripheral device -- a unit
+ * on the chip designed specifically for generating (and receiving)
+ * precisely-timed digital signals. Nominally for use in infrared
+ * remote controls, we use it to generate the signals for clockless
+ * LED strips. The main advantage of using the RMT device is that,
+ * once programmed, it generates the signal asynchronously, allowing
+ * the CPU to continue executing other code. It is also not vulnerable
+ * to interrupts or other timing problems that could disrupt the signal.
+ *
+ * The implementation strategy is borrowed from previous work and from
+ * the RMT support built into the ESP32 IDF. The RMT device has 8
+ * channels, which can be programmed independently to send sequences
+ * of high/low bits. Memory for each channel is limited, however, so
+ * in order to send a long sequence of bits, we need to continuously
+ * refill the buffer until all the data is sent. To do this, we fill
+ * half the buffer and then set an interrupt to go off when that half
+ * is sent. Then we refill that half while the second half is being
+ * sent. This strategy effectively overlaps computation (by the CPU)
+ * and communication (by the RMT).
+ *
+ * Since the RMT device only has 8 channels, we need a strategy to
+ * allow more than 8 LED controllers. Our driver assigns controllers
+ * to channels on the fly, queuing up controllers as necessary until a
+ * channel is free. The main showPixels routine just fires off the
+ * first 8 controllers; the interrupt handler starts new controllers
+ * asynchronously as previous ones finish. So, for example, it can
+ * send the data for 8 controllers simultaneously, but 16 controllers
+ * would take approximately twice as much time.
+ *
+ * There is a #define that allows a program to control the total
+ * number of channels that the driver is allowed to use. It defaults
+ * to 8 -- use all the channels. Setting it to 1, for example, results
+ * in fully serial output:
+ *
+ *     #define FASTLED_RMT_MAX_CHANNELS 1
+ *
+ * OTHER RMT APPLICATIONS
+ *
+ * The default FastLED driver takes over control of the RMT interrupt
+ * handler, making it hard to use the RMT device for other
+ * (non-FastLED) purposes. You can change it's behavior to use the ESP
+ * core driver instead, allowing other RMT applications to
+ * co-exist. To switch to this mode, add the following directive
+ * before you include FastLED.h:
+ *
+ *      #define FASTLED_RMT_BUILTIN_DRIVER
+ *
+ * There may be a performance penalty for using this mode. We need to
+ * compute the RMT signal for the entire LED strip ahead of time,
+ * rather than overlapping it with communication. We also need a large
+ * buffer to hold the signal specification. Each bit of pixel data is
+ * represented by a 32-bit pulse specification, so it is a 32X blow-up
+ * in memory use.
+ *
+ *
+ * Based on public domain code created 19 Nov 2016 by Chris Osborn <fozztexx@fozztexx.com>
+ * http://insentricity.com *
+ *
+ */
+/*
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#pragma once
+
+FASTLED_NAMESPACE_BEGIN
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "esp32-hal.h"
+#include "esp_intr.h"
+#include "driver/gpio.h"
+#include "driver/rmt.h"
+#include "driver/periph_ctrl.h"
+#include "freertos/semphr.h"
+#include "soc/rmt_struct.h"
+
+#include "esp_log.h"
+
+#ifdef __cplusplus
+}
+#endif
+
+__attribute__ ((always_inline)) inline static uint32_t __clock_cycles() {
+  uint32_t cyc;
+  __asm__ __volatile__ ("rsr %0,ccount":"=a" (cyc));
+  return cyc;
+}
+
+#define FASTLED_HAS_CLOCKLESS 1
+
+// -- Configuration constants
+#define DIVIDER             2 /* 4, 8 still seem to work, but timings become marginal */
+#define MAX_PULSES         32 /* A channel has a 64 "pulse" buffer - we use half per pass */
+
+// -- Convert ESP32 cycles back into nanoseconds
+#define ESPCLKS_TO_NS(_CLKS) (((long)(_CLKS) * 1000L) / F_CPU_MHZ)
+
+// -- Convert nanoseconds into RMT cycles
+#define F_CPU_RMT       (  80000000L)
+#define NS_PER_SEC      (1000000000L)
+#define CYCLES_PER_SEC  (F_CPU_RMT/DIVIDER)
+#define NS_PER_CYCLE    ( NS_PER_SEC / CYCLES_PER_SEC )
+#define NS_TO_CYCLES(n) ( (n) / NS_PER_CYCLE )
+
+// -- Convert ESP32 cycles to RMT cycles
+#define TO_RMT_CYCLES(_CLKS) NS_TO_CYCLES(ESPCLKS_TO_NS(_CLKS))    
+
+// -- Number of cycles to signal the strip to latch
+#define RMT_RESET_DURATION NS_TO_CYCLES(50000)
+
+// -- Core or custom driver
+#ifndef FASTLED_RMT_BUILTIN_DRIVER
+#define FASTLED_RMT_BUILTIN_DRIVER false
+#endif
+
+// -- Max number of controllers we can support
+#ifndef FASTLED_RMT_MAX_CONTROLLERS
+#define FASTLED_RMT_MAX_CONTROLLERS 32
+#endif
+
+// -- Number of RMT channels to use (up to 8)
+//    Redefine this value to 1 to force serial output
+#ifndef FASTLED_RMT_MAX_CHANNELS
+#define FASTLED_RMT_MAX_CHANNELS 8
+#endif
+
+// -- Array of all controllers
+static CLEDController * gControllers[FASTLED_RMT_MAX_CONTROLLERS];
+
+// -- Current set of active controllers, indexed by the RMT
+//    channel assigned to them.
+static CLEDController * gOnChannel[FASTLED_RMT_MAX_CHANNELS];
+
+static int gNumControllers = 0;
+static int gNumStarted = 0;
+static int gNumDone = 0;
+static int gNext = 0;
+
+static intr_handle_t gRMT_intr_handle = NULL;
+
+// -- Global semaphore for the whole show process
+//    Semaphore is not given until all data has been sent
+static xSemaphoreHandle gTX_sem = NULL;
+
+static bool gInitialized = false;
+
+template <int DATA_PIN, int T1, int T2, int T3, EOrder RGB_ORDER = RGB, int XTRA0 = 0, bool FLIP = false, int WAIT_TIME = 5>
+class ClocklessController : public CPixelLEDController<RGB_ORDER>
+{
+    // -- RMT has 8 channels, numbered 0 to 7
+    rmt_channel_t  mRMT_channel;
+
+    // -- Store the GPIO pin
+    gpio_num_t     mPin;
+<<<<<<< HEAD
+
+    // -- This instantiation forces a check on the pin choice
+    FastPin<DATA_PIN> mFastPin;
+
+    // -- Timing values for zero and one bits, derived from T1, T2, and T3
+    rmt_item32_t   mZero;
+    rmt_item32_t   mOne;
+
+=======
+
+    // -- Timing values for zero and one bits, derived from T1, T2, and T3
+    rmt_item32_t   mZero;
+    rmt_item32_t   mOne;
+
+>>>>>>> upstream/master
+    // -- State information for keeping track of where we are in the pixel data
+    PixelController<RGB_ORDER> * mPixels = NULL;
+    void *         mPixelSpace = NULL;
+    uint8_t        mRGB_channel;
+    uint16_t       mCurPulse;
+
+    // -- Buffer to hold all of the pulses. For the version that uses
+    //    the RMT driver built into the ESP core.
+    rmt_item32_t * mBuffer;
+    uint16_t       mBufferSize;
+
+public:
+
+    virtual void init()
+    {
+        // -- Precompute rmt items corresponding to a zero bit and a one bit
+        //    according to the timing values given in the template instantiation
+        // T1H
+        mOne.level0 = 1;
+        mOne.duration0 = TO_RMT_CYCLES(T1+T2);
+        // T1L
+        mOne.level1 = 0;
+        mOne.duration1 = TO_RMT_CYCLES(T3);
+
+        // T0H
+        mZero.level0 = 1;
+        mZero.duration0 = TO_RMT_CYCLES(T1);
+        // T0L
+        mZero.level1 = 0;
+        mZero.duration1 = TO_RMT_CYCLES(T2 + T3);
+
+<<<<<<< HEAD
+        gControllers[gNumControllers] = this;
+        ++gNumControllers;
+
+        mPin = gpio_num_t(DATA_PIN);
+=======
+	gControllers[gNumControllers] = this;
+        ++gNumControllers;
+
+	mPin = gpio_num_t(DATA_PIN);
+>>>>>>> upstream/master
+    }
+
+    virtual uint16_t getMaxRefreshRate() const { return 400; }
+
+protected:
+
+    void initRMT()
+    {
+<<<<<<< HEAD
+        // -- Only need to do this once
+        if (gInitialized) return;
+
+        for (int i = 0; i < FASTLED_RMT_MAX_CHANNELS; ++i) {
+            gOnChannel[i] = NULL;
+
+            // -- RMT configuration for transmission
+            rmt_config_t rmt_tx;
+            rmt_tx.channel = rmt_channel_t(i);
+            rmt_tx.rmt_mode = RMT_MODE_TX;
+            rmt_tx.gpio_num = mPin;  // The particular pin will be assigned later
+            rmt_tx.mem_block_num = 1;
+            rmt_tx.clk_div = DIVIDER;
+            rmt_tx.tx_config.loop_en = false;
+            rmt_tx.tx_config.carrier_level = RMT_CARRIER_LEVEL_LOW;
+            rmt_tx.tx_config.carrier_en = false;
+            rmt_tx.tx_config.idle_level = RMT_IDLE_LEVEL_LOW;
+            rmt_tx.tx_config.idle_output_en = true;
+                
+            // -- Apply the configuration
+            rmt_config(&rmt_tx);
+
+            if (FASTLED_RMT_BUILTIN_DRIVER) {
+                rmt_driver_install(rmt_channel_t(i), 0, 0);
+            } else {
+                // -- Set up the RMT to send 1/2 of the pulse buffer and then
+                //    generate an interrupt. When we get this interrupt we
+                //    fill the other half in preparation (kind of like double-buffering)
+                rmt_set_tx_thr_intr_en(rmt_channel_t(i), true, MAX_PULSES);
+            }
+        }
+
+        // -- Create a semaphore to block execution until all the controllers are done
+        if (gTX_sem == NULL) {
+            gTX_sem = xSemaphoreCreateBinary();
+            xSemaphoreGive(gTX_sem);
+        }
+                
+        if ( ! FASTLED_RMT_BUILTIN_DRIVER) {
+            // -- Allocate the interrupt if we have not done so yet. This
+            //    interrupt handler must work for all different kinds of
+            //    strips, so it delegates to the refill function for each
+            //    specific instantiation of ClocklessController.
+            if (gRMT_intr_handle == NULL)
+                esp_intr_alloc(ETS_RMT_INTR_SOURCE, 0, interruptHandler, 0, &gRMT_intr_handle);
+        }
+
+        gInitialized = true;
+    }
+
+    virtual void showPixels(PixelController<RGB_ORDER> & pixels)
+    {
+        if (gNumStarted == 0) {
+            // -- First controller: make sure everything is set up
+            initRMT();
+            xSemaphoreTake(gTX_sem, portMAX_DELAY);
+        }
+
+        // -- Initialize the local state, save a pointer to the pixel
+        //    data. We need to make a copy because pixels is a local
+        //    variable in the calling function, and this data structure
+        //    needs to outlive this call to showPixels.
+
+        if (mPixels != NULL) delete mPixels;
+        mPixels = new PixelController<RGB_ORDER>(pixels);
+        
+        // -- Keep track of the number of strips we've seen
+        ++gNumStarted;
+
+        // -- The last call to showPixels is the one responsible for doing
+        //    all of the actual worl
+        if (gNumStarted == gNumControllers) {
+            gNext = 0;
+
+            // -- First, fill all the available channels
+            int channel = 0;
+            while (channel < FASTLED_RMT_MAX_CHANNELS && gNext < gNumControllers) {
+                startNext(channel);
+                ++channel;
+            }
+
+            // -- Wait here while the rest of the data is sent. The interrupt handler
+            //    will keep refilling the RMT buffers until it is all sent; then it
+            //    gives the semaphore back.
+            xSemaphoreTake(gTX_sem, portMAX_DELAY);
+            xSemaphoreGive(gTX_sem);
+
+            // -- Reset the counters
+            gNumStarted = 0;
+            gNumDone = 0;
+            gNext = 0;
+        }
+    }
+
+    // -- Start up the next controller
+    //    This method is static so that it can dispatch to the appropriate
+    //    startOnChannel method of the given controller.
+    static void startNext(int channel)
+    {
+        if (gNext < gNumControllers) {
+            ClocklessController * pController = static_cast<ClocklessController*>(gControllers[gNext]);
+            pController->startOnChannel(channel);
+            ++gNext;
+        }
+    }
+
+    virtual void startOnChannel(int channel)
+    {
+        // -- Assign this channel and configure the RMT
+        mRMT_channel = rmt_channel_t(channel);
+
+        // -- Store a reference to this controller, so we can get it
+        //    inside the interrupt handler
+        gOnChannel[channel] = this;
+
+        // -- Assign the pin to this channel
+        rmt_set_pin(mRMT_channel, RMT_MODE_TX, mPin);
+
+        if (FASTLED_RMT_BUILTIN_DRIVER) {
+            // -- Use the built-in RMT driver to send all the data in one shot
+            rmt_register_tx_end_callback(doneOnChannel, 0);
+            writeAllRMTItems();
+        } else {
+            // -- Use our custom driver to send the data incrementally
+
+            // -- Turn on the interrupts
+            rmt_set_tx_intr_en(mRMT_channel, true);
+        
+            // -- Initialize the counters that keep track of where we are in
+            //    the pixel data.
+            mCurPulse = 0;
+            mRGB_channel = 0;
+
+            // -- Fill both halves of the buffer
+            fillHalfRMTBuffer();
+            fillHalfRMTBuffer();
+
+            // -- Turn on the interrupts
+            rmt_set_tx_intr_en(mRMT_channel, true);
+            
+            // -- Start the RMT TX operation
+            rmt_tx_start(mRMT_channel, true);
+        }
+    }
+
+    static void doneOnChannel(rmt_channel_t channel, void * arg)
+    {
+        ClocklessController * controller = static_cast<ClocklessController*>(gOnChannel[channel]);
+        portBASE_TYPE HPTaskAwoken = 0;
+
+        // -- Turn off output on the pin
+        gpio_matrix_out(controller->mPin, 0x100, 0, 0);
+
+        gOnChannel[channel] = NULL;
+        ++gNumDone;
+
+        if (gNumDone == gNumControllers) {
+            // -- If this is the last controller, signal that we are all done
+            xSemaphoreGiveFromISR(gTX_sem, &HPTaskAwoken);
+            if(HPTaskAwoken == pdTRUE) portYIELD_FROM_ISR();
+        } else {
+            // -- Otherwise, if there are still controllers waiting, then
+            //    start the next one on this channel
+            if (gNext < gNumControllers)
+                startNext(channel);
+        }
+=======
+	// -- Only need to do this once
+	if (gInitialized) return;
+
+	for (int i = 0; i < FASTLED_RMT_MAX_CHANNELS; ++i) {
+	    gOnChannel[i] = NULL;
+
+	    // -- RMT configuration for transmission
+	    rmt_config_t rmt_tx;
+	    rmt_tx.channel = rmt_channel_t(i);
+	    rmt_tx.rmt_mode = RMT_MODE_TX;
+	    rmt_tx.gpio_num = mPin;  // The particular pin will be assigned later
+	    rmt_tx.mem_block_num = 1;
+	    rmt_tx.clk_div = DIVIDER;
+	    rmt_tx.tx_config.loop_en = false;
+	    rmt_tx.tx_config.carrier_level = RMT_CARRIER_LEVEL_LOW;
+	    rmt_tx.tx_config.carrier_en = false;
+	    rmt_tx.tx_config.idle_level = RMT_IDLE_LEVEL_LOW;
+	    rmt_tx.tx_config.idle_output_en = true;
+		
+	    // -- Apply the configuration
+	    rmt_config(&rmt_tx);
+
+	    if (FASTLED_RMT_BUILTIN_DRIVER) {
+		rmt_driver_install(rmt_channel_t(i), 0, 0);
+	    } else {
+		// -- Set up the RMT to send 1/2 of the pulse buffer and then
+		//    generate an interrupt. When we get this interrupt we
+		//    fill the other half in preparation (kind of like double-buffering)
+		rmt_set_tx_thr_intr_en(rmt_channel_t(i), true, MAX_PULSES);
+	    }
+	}
+
+	// -- Create a semaphore to block execution until all the controllers are done
+	if (gTX_sem == NULL) {
+	    gTX_sem = xSemaphoreCreateBinary();
+	    xSemaphoreGive(gTX_sem);
+	}
+		
+	if ( ! FASTLED_RMT_BUILTIN_DRIVER) {
+	    // -- Allocate the interrupt if we have not done so yet. This
+	    //    interrupt handler must work for all different kinds of
+	    //    strips, so it delegates to the refill function for each
+	    //    specific instantiation of ClocklessController.
+	    if (gRMT_intr_handle == NULL)
+		esp_intr_alloc(ETS_RMT_INTR_SOURCE, 0, interruptHandler, 0, &gRMT_intr_handle);
+	}
+
+	gInitialized = true;
+    }
+
+    virtual void showPixels(PixelController<RGB_ORDER> & pixels)
+    {
+	if (gNumStarted == 0) {
+	    // -- First controller: make sure everything is set up
+	    initRMT();
+	    xSemaphoreTake(gTX_sem, portMAX_DELAY);
+	}
+
+	// -- Initialize the local state, save a pointer to the pixel
+	//    data. We need to make a copy because pixels is a local
+	//    variable in the calling function, and this data structure
+	//    needs to outlive this call to showPixels.
+
+	if (mPixels != NULL) delete mPixels;
+	mPixels = new PixelController<RGB_ORDER>(pixels);
+	
+	// -- Keep track of the number of strips we've seen
+	++gNumStarted;
+
+	// -- The last call to showPixels is the one responsible for doing
+	//    all of the actual worl
+	if (gNumStarted == gNumControllers) {
+	    gNext = 0;
+
+	    // -- First, fill all the available channels
+	    int channel = 0;
+	    while (channel < FASTLED_RMT_MAX_CHANNELS && gNext < gNumControllers) {
+		startNext(channel);
+		++channel;
+	    }
+
+	    // -- Wait here while the rest of the data is sent. The interrupt handler
+	    //    will keep refilling the RMT buffers until it is all sent; then it
+	    //    gives the semaphore back.
+	    xSemaphoreTake(gTX_sem, portMAX_DELAY);
+	    xSemaphoreGive(gTX_sem);
+
+	    // -- Reset the counters
+	    gNumStarted = 0;
+	    gNumDone = 0;
+	    gNext = 0;
+	}
+    }
+
+    // -- Start up the next controller
+    //    This method is static so that it can dispatch to the appropriate
+    //    startOnChannel method of the given controller.
+    static void startNext(int channel)
+    {
+	if (gNext < gNumControllers) {
+	    ClocklessController * pController = static_cast<ClocklessController*>(gControllers[gNext]);
+	    pController->startOnChannel(channel);
+	    ++gNext;
+	}
+    }
+
+    virtual void startOnChannel(int channel)
+    {
+	// -- Assign this channel and configure the RMT
+	mRMT_channel = rmt_channel_t(channel);
+
+	// -- Store a reference to this controller, so we can get it
+	//    inside the interrupt handler
+	gOnChannel[channel] = this;
+
+	// -- Assign the pin to this channel
+	rmt_set_pin(mRMT_channel, RMT_MODE_TX, mPin);
+
+	if (FASTLED_RMT_BUILTIN_DRIVER) {
+	    // -- Use the built-in RMT driver to send all the data in one shot
+	    rmt_register_tx_end_callback(doneOnChannel, 0);
+	    writeAllRMTItems();
+	} else {
+	    // -- Use our custom driver to send the data incrementally
+
+	    // -- Turn on the interrupts
+	    rmt_set_tx_intr_en(mRMT_channel, true);
+	
+	    // -- Initialize the counters that keep track of where we are in
+	    //    the pixel data.
+	    mCurPulse = 0;
+	    mRGB_channel = 0;
+
+	    // -- Fill both halves of the buffer
+	    fillHalfRMTBuffer();
+	    fillHalfRMTBuffer();
+
+	    // -- Turn on the interrupts
+	    rmt_set_tx_intr_en(mRMT_channel, true);
+	    
+	    // -- Start the RMT TX operation
+	    rmt_tx_start(mRMT_channel, true);
+	}
+    }
+
+    static void doneOnChannel(rmt_channel_t channel, void * arg)
+    {
+	ClocklessController * controller = static_cast<ClocklessController*>(gOnChannel[channel]);
+        portBASE_TYPE HPTaskAwoken = 0;
+
+	// -- Turn off output on the pin
+	gpio_matrix_out(controller->mPin, 0x100, 0, 0);
+
+	gOnChannel[channel] = NULL;
+	++gNumDone;
+
+	if (gNumDone == gNumControllers) {
+	    // -- If this is the last controller, signal that we are all done
+	    xSemaphoreGiveFromISR(gTX_sem, &HPTaskAwoken);
+	    if(HPTaskAwoken == pdTRUE) portYIELD_FROM_ISR();
+	} else {
+	    // -- Otherwise, if there are still controllers waiting, then
+	    //    start the next one on this channel
+	    if (gNext < gNumControllers)
+		startNext(channel);
+	}
+>>>>>>> upstream/master
+    }
+    
+    static IRAM_ATTR void interruptHandler(void *arg)
+    {
+        // -- The basic structure of this code is borrowed from the
+        //    interrupt handler in esp-idf/components/driver/rmt.c
+        uint32_t intr_st = RMT.int_st.val;
+        uint8_t channel;
+
+        for (channel = 0; channel < FASTLED_RMT_MAX_CHANNELS; ++channel) {
+            int tx_done_bit = channel * 3;
+            int tx_next_bit = channel + 24;
+
+            if (gOnChannel[channel] != NULL) {
+
+<<<<<<< HEAD
+                ClocklessController * controller = static_cast<ClocklessController*>(gOnChannel[channel]);
+
+                // -- More to send on this channel
+                if (intr_st & BIT(tx_next_bit)) {
+                    RMT.int_clr.val |= BIT(tx_next_bit);
+
+                    // -- Refill the half of the buffer that we just finished,
+                    //    allowing the other half to proceed.
+                    controller->fillHalfRMTBuffer();
+                }
+
+                // -- Transmission is complete on this channel
+                if (intr_st & BIT(tx_done_bit)) {
+                    RMT.int_clr.val |= BIT(tx_done_bit);
+                    doneOnChannel(rmt_channel_t(channel), 0);
+=======
+		ClocklessController * controller = static_cast<ClocklessController*>(gOnChannel[channel]);
+
+		// -- More to send on this channel
+                if (intr_st & BIT(tx_next_bit)) {
+		    RMT.int_clr.val |= BIT(tx_next_bit);
+
+                    // -- Refill the half of the buffer that we just finished,
+                    //    allowing the other half to proceed.
+		    controller->fillHalfRMTBuffer();
+                }
+
+		// -- Transmission is complete on this channel
+                if (intr_st & BIT(tx_done_bit)) {
+                    RMT.int_clr.val |= BIT(tx_done_bit);
+		    doneOnChannel(rmt_channel_t(channel), 0);
+>>>>>>> upstream/master
+                }
+            }
+        }
+    }
+
+    virtual void fillHalfRMTBuffer()
+    {
+        // -- Fill half of the RMT pulse buffer
+
+        //    The buffer holds 64 total pulse items, so this loop converts
+        //    as many pixels as can fit in half of the buffer (MAX_PULSES =
+        //    32 items). In our case, each pixel consists of three bytes,
+        //    each bit turns into one pulse item -- 24 items per pixel. So,
+        //    each half of the buffer can hold 1 and 1/3 of a pixel.
+
+        //    The member variable mCurPulse keeps track of which of the 64
+        //    items we are writing. During the first call to this method it
+        //    fills 0-31; in the second call it fills 32-63, and then wraps
+        //    back around to zero.
+
+        //    When we run out of pixel data, just fill the remaining items
+        //    with zero pulses.
+
+        uint16_t pulse_count = 0; // Ranges from 0-31 (half a buffer)
+        uint32_t byteval = 0;
+        uint32_t one_val = mOne.val;
+        uint32_t zero_val = mZero.val;
+        bool done_strip = false;
+
+        while (pulse_count < MAX_PULSES) {
+            if (! mPixels->has(1)) {
+<<<<<<< HEAD
+                if (mCurPulse > 0) {
+                    // -- Extend the last pulse to force the strip to latch. Honestly, I'm not
+                    //    sure if this is really necessary.
+                    // RMTMEM.chan[mRMT_channel].data32[mCurPulse-1].duration1 = RMT_RESET_DURATION;
+                }
+=======
+>>>>>>> upstream/master
+                done_strip = true;
+                break;
+            }
+
+            // -- Cycle through the R,G, and B values in the right order
+            switch (mRGB_channel) {
+            case 0:
+                byteval = mPixels->loadAndScale0();
+                mRGB_channel = 1;
+                break;
+            case 1:
+                byteval = mPixels->loadAndScale1();
+                mRGB_channel = 2;
+                break;
+            case 2:
+                byteval = mPixels->loadAndScale2();
+                mPixels->advanceData();
+                mPixels->stepDithering();
+                mRGB_channel = 0;
+                break;
+            default:
+                break;
+            }
+
+            byteval <<= 24;
+            // Shift bits out, MSB first, setting RMTMEM.chan[n].data32[x] to the 
+            // rmt_item32_t value corresponding to the buffered bit value
+            for (register uint32_t j = 0; j < 8; ++j) {
+                uint32_t val = (byteval & 0x80000000L) ? one_val : zero_val;
+                RMTMEM.chan[mRMT_channel].data32[mCurPulse].val = val;
+                byteval <<= 1;
+                ++mCurPulse;
+                ++pulse_count;
+            }
+<<<<<<< HEAD
+=======
+
+	    if (done_strip)
+		RMTMEM.chan[mRMT_channel].data32[mCurPulse-1].duration1 = RMT_RESET_DURATION;
+>>>>>>> upstream/master
+        }
+        
+        if (done_strip) {
+            // -- And fill the remaining items with zero pulses. The zero values triggers
+            //    the tx_done interrupt.
+            while (pulse_count < MAX_PULSES) {
+                RMTMEM.chan[mRMT_channel].data32[mCurPulse].val = 0;
+                ++mCurPulse;
+                ++pulse_count;
+            }
+        }
+
+        // -- When we have filled the back half the buffer, reset the position to the first half
+        if (mCurPulse >= MAX_PULSES*2)
+            mCurPulse = 0;
+    }
+
+    virtual void writeAllRMTItems()
+    {
+        // -- Compute the pulse values for the whole strip at once.
+        //    Requires a large buffer
+<<<<<<< HEAD
+        mBufferSize = mPixels->size() * 3 * 8;
+=======
+	mBufferSize = mPixels->size() * 3 * 8;
+>>>>>>> upstream/master
+
+        // TODO: need a specific number here
+        if (mBuffer == NULL) {
+            mBuffer = (rmt_item32_t *) calloc( mBufferSize, sizeof(rmt_item32_t));
+        }
+
+        mCurPulse = 0;
+        mRGB_channel = 0;
+        uint32_t byteval = 0;
+        while (mPixels->has(1)) {
+            // -- Cycle through the R,G, and B values in the right order
+            switch (mRGB_channel) {
+            case 0:
+                byteval = mPixels->loadAndScale0();
+                mRGB_channel = 1;
+                break;
+            case 1:
+                byteval = mPixels->loadAndScale1();
+                mRGB_channel = 2;
+                break;
+            case 2:
+                byteval = mPixels->loadAndScale2();
+                mPixels->advanceData();
+                mPixels->stepDithering();
+                mRGB_channel = 0;
+                break;
+            default:
+                break;
+            }
+
+            byteval <<= 24;
+            // Shift bits out, MSB first, setting RMTMEM.chan[n].data32[x] to the 
+            // rmt_item32_t value corresponding to the buffered bit value
+            for (register uint32_t j = 0; j < 8; ++j) {
+                mBuffer[mCurPulse] = (byteval & 0x80000000L) ? mOne : mZero;
+                byteval <<= 1;
+                ++mCurPulse;
+            }
+        }
+
+        mBuffer[mCurPulse-1].duration1 = RMT_RESET_DURATION;
+        assert(mCurPulse == mBufferSize);
+
+<<<<<<< HEAD
+        rmt_write_items(mRMT_channel, mBuffer, mBufferSize, false);
+=======
+	rmt_write_items(mRMT_channel, mBuffer, mBufferSize, false);
+>>>>>>> upstream/master
+    }
+};
+
+FASTLED_NAMESPACE_END

--- a/platforms/esp/32/clockless_i2s_esp32.h
+++ b/platforms/esp/32/clockless_i2s_esp32.h
@@ -213,7 +213,7 @@ public:
         
         gControllers[gNumControllers] = this;
         int my_index = gNumControllers;
-        gNumControllers++;
+        ++gNumControllers;
         
         // -- Set up the pin We have to do two things: configure the
         //    actual GPIO pin, and route the output from the default
@@ -235,7 +235,7 @@ protected:
    static int pgcd(int smallest,int precision,int a,int b,int c)
     {
         int pgc_=1;
-        for( int i=smallest;i>0;i--)
+        for( int i=smallest;i>0;--i)
         {
             
             if( a%i<=precision && b%i<=precision && c%i<=precision)
@@ -293,7 +293,7 @@ protected:
         //Serial.printf("%f\n",I2S_MAX_CLK/(1000000000L*freq));
         while(pgc_==1 ||  (T1/pgc_ +T2/pgc_ +T3/pgc_)>I2S_MAX_PULSE_PER_BIT) //while(pgc_==1 ||  (T1/pgc_ +T2/pgc_ +T3/pgc_)>I2S_MAX_CLK/(1000000000L*freq))
         {
-            precision++;
+            ++precision;
             pgc_=pgcd(smallest,precision,T1,T2,T3);
             //Serial.printf("%d %d\n",pgc_,(a+b+c)/pgc_);
         }
@@ -327,9 +327,9 @@ protected:
         int b=0;
         CLOCK_DIVIDER_A=1;
         CLOCK_DIVIDER_B=0;
-        for(a=1;a<64;a++)
+        for(a=1;a<64;++a)
         {
-            for(b=0;b<a;b++)
+            for(b=0;b<a;++b)
             {
                 //printf("%d %d %f %f %f\n",b,a,v,(double)v*(double)a,fabsf(v-(double)b/a));
                 if(fabsf(v-(double)b/a) <= prec/2)
@@ -356,7 +356,7 @@ protected:
         {
             CLOCK_DIVIDER_A=1;
             CLOCK_DIVIDER_B=0;
-            CLOCK_DIVIDER_N++;
+            ++CLOCK_DIVIDER_N;
         }
         
         //printf("%d %d %f %f %d\n",CLOCK_DIVIDER_B,CLOCK_DIVIDER_A,(double)CLOCK_DIVIDER_B/CLOCK_DIVIDER_A,v,CLOCK_DIVIDER_N);
@@ -382,11 +382,11 @@ protected:
         int i = 0;
         while ( i < ones_for_one ) {
             gOneBit[i] = 0xFFFFFF00;
-            i++;
+            ++i;
         }
         while ( i < gPulsesPerBit ) {
             gOneBit[i] = 0x00000000;
-            i++;
+            ++i;
         }
         
         //int ones_for_zero = ((T1ns - 1)/FASTLED_I2S_NS_PER_PULSE) + 1;
@@ -399,11 +399,11 @@ protected:
         i = 0;
         while ( i < ones_for_zero ) {
             gZeroBit[i] = 0xFFFFFF00;
-            i++;
+            ++i;
         }
         while ( i < gPulsesPerBit ) {
             gZeroBit[i] = 0x00000000;
-            i++;
+            ++i;
         }
         
         memset(gPixelRow, 0, NUM_COLOR_CHANNELS * 32);
@@ -531,13 +531,13 @@ protected:
      */
     static void empty( uint32_t *buf)
     {
-        for(int i=0;i<8*NUM_COLOR_CHANNELS;i++)
+        for(int i=0;i<8*NUM_COLOR_CHANNELS;++i)
         {
             int offset=gPulsesPerBit*i;
-            for(int j=0;j<ones_for_zero;j++)
+            for(int j=0;j<ones_for_zero;++j)
                 buf[offset+j]=0xffffffff;
             
-            for(int j=ones_for_one;j<gPulsesPerBit;j++)
+            for(int j=ones_for_one;j<gPulsesPerBit;++j)
                 buf[offset+j]=0;
         }
     }
@@ -558,7 +558,7 @@ protected:
         (*mPixels) = pixels;
         
         // -- Keep track of the number of strips we've seen
-        gNumStarted++;
+        ++gNumStarted;
 
         // Serial.print("Show pixels ");
         // Serial.println(gNumStarted);
@@ -626,7 +626,7 @@ protected:
         // -- Get the requested pixel from each controller. Store the
         //    data for each color channel in a separate array.
         uint32_t has_data_mask = 0;
-        for (int i = 0; i < gNumControllers; i++) {
+        for (int i = 0; i < gNumControllers; ++i) {
             // -- Store the pixels in reverse controller order starting at index 23
             //    This causes the bits to come out in the right position after we
             //    transpose them.
@@ -652,24 +652,24 @@ protected:
         
         // -- Transpose and encode the pixel data for the DMA buffer
         // int buf_index = 0;
-        for (int channel = 0; channel < NUM_COLOR_CHANNELS; channel++) {
+        for (int channel = 0; channel < NUM_COLOR_CHANNELS; ++channel) {
             
             // -- Tranpose each array: all the bit 7's, then all the bit 6's, ...
             transpose32(gPixelRow[channel], gPixelBits[channel][0] );
             
             //Serial.print("Channel: "); Serial.print(channel); Serial.print(" ");
-            for (int bitnum = 0; bitnum < 8; bitnum++) {
+            for (int bitnum = 0; bitnum < 8; ++bitnum) {
                 uint8_t * row = (uint8_t *) (gPixelBits[channel][bitnum]);
                 uint32_t bit = (row[0] << 24) | (row[1] << 16) | (row[2] << 8) | row[3];
                 
-                /* SZG: More general, but too slow:
-                for (int pulse_num = 0; pulse_num < gPulsesPerBit; pulse_num++) {
-                    buf[buf_index++] = has_data_mask & ( (bit & gOneBit[pulse_num]) | (~bit & gZeroBit[pulse_num]) );
-                }
-                */
+               /* SZG: More general, but too slow:
+                    for (int pulse_num = 0; pulse_num < gPulsesPerBit; ++pulse_num) {
+                        buf[buf_index++] = has_data_mask & ( (bit & gOneBit[pulse_num]) | (~bit & gZeroBit[pulse_num]) );
+                     }
+               */
 
                 // -- Only fill in the pulses that are different between the "0" and "1" encodings
-                for(int pulse_num = ones_for_zero; pulse_num < ones_for_one; pulse_num++) {
+                for(int pulse_num = ones_for_zero; pulse_num < ones_for_one; ++pulse_num) {
                     buf[bitnum*gPulsesPerBit+channel*8*gPulsesPerBit+pulse_num] = has_data_mask & bit;
                 }
             }

--- a/platforms/esp/32/clockless_rmt_esp32.h
+++ b/platforms/esp/32/clockless_rmt_esp32.h
@@ -237,7 +237,7 @@ public:
         mZero.duration1 = ESP_TO_RMT_CYCLES(T2+T3); // TO_RMT_CYCLES(T2 + T3);
 
         gControllers[gNumControllers] = this;
-        gNumControllers++;
+        ++gNumControllers;
 
         mPin = gpio_num_t(DATA_PIN);
     }
@@ -247,7 +247,7 @@ public:
 protected:
     void initRMT()
     {
-        for (int i = 0; i < FASTLED_RMT_MAX_CHANNELS; i++) {
+        for (int i = 0; i < FASTLED_RMT_MAX_CHANNELS; ++i) {
             gOnChannel[i] = NULL;
 
             // -- RMT configuration for transmission
@@ -323,7 +323,7 @@ protected:
         }
 
         // -- Keep track of the number of strips we've seen
-        gNumStarted++;
+        ++gNumStarted;
 
         // -- The last call to showPixels is the one responsible for doing
         //    all of the actual worl
@@ -334,14 +334,14 @@ protected:
             int channel = 0;
             while (channel < FASTLED_RMT_MAX_CHANNELS && gNext < gNumControllers) {
                 startNext(channel);
-                channel++;
+                ++channel;
             }
 
             // -- Make sure it's been at least 50ms since last show
             mWait.wait();
 
             // -- Start them all
-            for (int i = 0; i < channel; i++) {
+            for (int i = 0; i < channel; ++i) {
                 ClocklessController * pController = static_cast<ClocklessController*>(gControllers[i]);
                 rmt_tx_start(pController->mRMT_channel, true);
             }
@@ -404,10 +404,10 @@ protected:
     {
         // -- Write one byte's worth of RMT pulses to the big buffer
         byteval <<= 24;
-        for (register uint32_t j = 0; j < 8; j++) {
+        for (register uint32_t j = 0; j < 8; ++j) {
             mBuffer[mCurPulse] = (byteval & 0x80000000L) ? mOne : mZero;
             byteval <<= 1;
-            mCurPulse++;
+            ++mCurPulse;
         }
     }
 
@@ -419,7 +419,7 @@ protected:
         if (gNext < gNumControllers) {
             ClocklessController * pController = static_cast<ClocklessController*>(gControllers[gNext]);
             pController->startOnChannel(channel);
-            gNext++;
+            ++gNext;
         }
     }
 
@@ -475,7 +475,7 @@ protected:
         gpio_matrix_out(controller->mPin, 0x100, 0, 0);
 
         gOnChannel[channel] = NULL;
-        gNumDone++;
+        ++gNumDone;
 
         if (gNumDone == gNumControllers) {
             // -- If this is the last controller, signal that we are all done
@@ -508,7 +508,7 @@ protected:
         uint32_t intr_st = RMT.int_st.val;
         uint8_t channel;
 
-        for (channel = 0; channel < FASTLED_RMT_MAX_CHANNELS; channel++) {
+        for (channel = 0; channel < FASTLED_RMT_MAX_CHANNELS; ++channel) {
             int tx_done_bit = channel * 3;
             int tx_next_bit = channel + 24;
 
@@ -557,13 +557,13 @@ protected:
             
             // Shift bits out, MSB first, setting RMTMEM.chan[n].data32[x] to the 
             // rmt_item32_t value corresponding to the buffered bit value
-            for (register uint32_t j = 0; j < 24; j++) {
+            for (register uint32_t j = 0; j < 24; ++j) {
                 uint32_t val = (pixel & 0x80000000L) ? one_val : zero_val;
                 *pItem++ = val;
                 // Replaces: RMTMEM.chan[mRMT_channel].data32[mCurPulse].val = val;
 
                 pixel <<= 1;
-                curPulse++;
+                ++curPulse;
 
                 if (curPulse == MAX_PULSES) {
                     pItem = & (RMTMEM.chan[mRMT_channel].data32[0].val);
@@ -576,7 +576,7 @@ protected:
             mRMT_mem_ptr = pItem;
         } else {
             // -- No more data; signal to the RMT we are done
-            for (uint32_t j = 0; j < 8; j++) {
+            for (uint32_t j = 0; j < 8; ++j) {
                 * mRMT_mem_ptr++ = 0;
             }
         }   
@@ -605,7 +605,7 @@ protected:
             byte = 0;
         }
 
-        mCurColor++;
+        ++mCurColor;
         if (mCurColor == NUM_COLOR_CHANNELS) mCurColor = 0;
 
         return byte;
@@ -647,19 +647,19 @@ protected:
                 byteval = 0;
             }
 
-            mCurColor++;
+            ++mCurColor;
             if (mCurColor == NUM_COLOR_CHANNELS) mCurColor = 0;
         
             // byteval = getNextByte();
             byteval <<= 24;
             // Shift bits out, MSB first, setting RMTMEM.chan[n].data32[x] to the 
             // rmt_item32_t value corresponding to the buffered bit value
-            for (register uint32_t j = 0; j < 8; j++) {
+            for (register uint32_t j = 0; j < 8; ++j) {
                 uint32_t val = (byteval & 0x80000000L) ? one_val : zero_val;
                 * mRMT_mem_ptr++ = val;
                 // Replaces: RMTMEM.chan[mRMT_channel].data32[mCurPulse].val = val;
                 byteval <<= 1;
-                mCurPulse++;
+                ++mCurPulse;
             }
             pulses += 8;
         }
@@ -670,8 +670,8 @@ protected:
             while (pulses < 32) {
                 * mRMT_mem_ptr++ = 0;
                 // Replaces: RMTMEM.chan[mRMT_channel].data32[mCurPulse].val = 0;
-                mCurPulse++;
-                pulses++;
+                ++mCurPulse;
+                ++pulses;
             }
         }
         

--- a/platforms/esp/8266/clockless_block_esp8266.h
+++ b/platforms/esp/8266/clockless_block_esp8266.h
@@ -34,7 +34,7 @@ public:
 		while(!showRGBInternal(pixels) && cnt--) {
       		os_intr_unlock();
 			#ifdef FASTLED_DEBUG_COUNT_FRAME_RETRIES
-			_retry_cnt++;
+			++_retry_cnt;
 			#endif
 			delayMicroseconds(WAIT_TIME * 10);
 			os_intr_lock();
@@ -77,7 +77,7 @@ public:
 		register uint8_t d = pixels.template getd<PX>(pixels);
 		register uint8_t scale = pixels.template getscale<PX>(pixels);
 
-		for(register uint32_t i = 0; i < USED_LANES; i++) {
+		for(register uint32_t i = 0; i < USED_LANES; ++i) {
 			while((__clock_cycles() - last_mark) < (T1+T2+T3));
 			last_mark = __clock_cycles();
 			*FastPin<FIRST_PIN>::sport() = PIN_MASK;
@@ -92,7 +92,7 @@ public:
 			b.bytes[i] = pixels.template loadAndScale<PX>(pixels,i,d,scale);
 		}
 
-		for(register uint32_t i = USED_LANES; i < 8; i++) {
+		for(register uint32_t i = USED_LANES; i < 8; ++i) {
 			while((__clock_cycles() - last_mark) < (T1+T2+T3));
 			last_mark = __clock_cycles();
 			*FastPin<FIRST_PIN>::sport() = PIN_MASK;
@@ -113,7 +113,7 @@ public:
 		// Setup the pixel controller and load/scale the first byte
 		Lines b0;
 
-		for(int i = 0; i < USED_LANES; i++) {
+		for(int i = 0; i < USED_LANES; ++i) {
 			b0.bytes[i] = allpixels.loadAndScale0(i);
 		}
 		allpixels.preStepFirstByteDithering();
@@ -150,7 +150,7 @@ public:
 
 		os_intr_unlock();
 		#ifdef FASTLED_DEBUG_COUNT_FRAME_RETRIES
-		_frame_cnt++;
+		++_frame_cnt;
 		#endif
 		return __clock_cycles() - _start;
 	}

--- a/power_mgt.cpp
+++ b/power_mgt.cpp
@@ -60,7 +60,7 @@ uint32_t calculate_unscaled_power_mW( const CRGB* ledbuffer, uint16_t numLeds ) 
         red32   += *p++;
         green32 += *p++;
         blue32  += *p++;
-        count--;
+        --count;
     }
 
     red32   *= gRed_mW;

--- a/wiring.cpp
+++ b/wiring.cpp
@@ -17,16 +17,16 @@ volatile unsigned long FastLED_timer0_overflow_count=0;
 volatile unsigned long FastLED_timer0_millis = 0;
 
 LIB8STATIC void  __attribute__((always_inline)) fastinc32 (volatile uint32_t & _long) {
-    uint8_t b = ++((tBytesForLong&)_long).raw[0];
+  uint8_t b = ++((tBytesForLong&)_long).raw[0];
+  if(!b) {
+    b = ++((tBytesForLong&)_long).raw[1];
     if(!b) {
-        b = ++((tBytesForLong&)_long).raw[1];
-        if(!b) {
-            b = ++((tBytesForLong&)_long).raw[2];
-            if(!b) {
-                ++((tBytesForLong&)_long).raw[3];
-            }
-        }
+      b = ++((tBytesForLong&)_long).raw[2];
+      if(!b) {
+        ++((tBytesForLong&)_long).raw[3];
+      }
     }
+  }
 }
 
 #if defined(__AVR_ATtiny24__) || defined(__AVR_ATtiny44__) || defined(__AVR_ATtiny84__)
@@ -35,200 +35,200 @@ ISR(TIM0_OVF_vect)
 ISR(TIMER0_OVF_vect)
 #endif
 {
-    fastinc32(FastLED_timer0_overflow_count);
-    // FastLED_timer0_overflow_count++;
+  fastinc32(FastLED_timer0_overflow_count);
+  // FastLED_timer0_overflow_count++;
 }
 
 // there are 1024 microseconds per overflow counter tick.
 unsigned long millis()
 {
-    unsigned long m;
-    uint8_t oldSREG = SREG;
+        unsigned long m;
+        uint8_t oldSREG = SREG;
 
-    // disable interrupts while we read FastLED_timer0_millis or we might get an
-    // inconsistent value (e.g. in the middle of a write to FastLED_timer0_millis)
-    cli();
-    m = FastLED_timer0_overflow_count;  //._long;
-    SREG = oldSREG;
+        // disable interrupts while we read FastLED_timer0_millis or we might get an
+        // inconsistent value (e.g. in the middle of a write to FastLED_timer0_millis)
+        cli();
+        m = FastLED_timer0_overflow_count;  //._long;
+        SREG = oldSREG;
 
-    return (m*(MICROSECONDS_PER_TIMER0_OVERFLOW/8))/(1000/8);
+        return (m*(MICROSECONDS_PER_TIMER0_OVERFLOW/8))/(1000/8);
 }
 
 unsigned long micros() {
-    unsigned long m;
-    uint8_t oldSREG = SREG, t;
+        unsigned long m;
+        uint8_t oldSREG = SREG, t;
 
-    cli();
-    m = FastLED_timer0_overflow_count; // ._long;
+        cli();
+        m = FastLED_timer0_overflow_count; // ._long;
 #if defined(TCNT0)
-    t = TCNT0;
+        t = TCNT0;
 #elif defined(TCNT0L)
-    t = TCNT0L;
+        t = TCNT0L;
 #else
-#error TIMER 0 not defined
+        #error TIMER 0 not defined
 #endif
 
 
 #ifdef TIFR0
-    if ((TIFR0 & _BV(TOV0)) && (t < 255))
-        m++;
+        if ((TIFR0 & _BV(TOV0)) && (t < 255))
+                ++m;
 #else
-    if ((TIFR & _BV(TOV0)) && (t < 255))
-        m++;
+        if ((TIFR & _BV(TOV0)) && (t < 255))
+                ++m;
 #endif
 
-    SREG = oldSREG;
+        SREG = oldSREG;
 
-    return ((m << 8) + t) * (64 / clockCyclesPerMicrosecond());
+        return ((m << 8) + t) * (64 / clockCyclesPerMicrosecond());
 }
 
 void delay(unsigned long ms)
 {
-    uint16_t start = (uint16_t)micros();
+        uint16_t start = (uint16_t)micros();
 
-    while (ms > 0) {
-        if (((uint16_t)micros() - start) >= 1000) {
-            ms--;
-            start += 1000;
+        while (ms > 0) {
+                if (((uint16_t)micros() - start) >= 1000) {
+                        --ms;
+                        start += 1000;
+                }
         }
-    }
 }
 
 #define sbi(sfr, bit) (_SFR_BYTE(sfr) |= _BV(bit))
 void init()
 {
-    // this needs to be called before setup() or some functions won't
-    // work there
-    sei();
+  // this needs to be called before setup() or some functions won't
+  // work there
+  sei();
 
-    // on the ATmega168, timer 0 is also used for fast hardware pwm
-    // (using phase-correct PWM would mean that timer 0 overflowed half as often
-    // resulting in different millis() behavior on the ATmega8 and ATmega168)
+  // on the ATmega168, timer 0 is also used for fast hardware pwm
+  // (using phase-correct PWM would mean that timer 0 overflowed half as often
+  // resulting in different millis() behavior on the ATmega8 and ATmega168)
 #if defined(TCCR0A) && defined(WGM01)
-    sbi(TCCR0A, WGM01);
-    sbi(TCCR0A, WGM00);
+  sbi(TCCR0A, WGM01);
+  sbi(TCCR0A, WGM00);
 #endif
 
-    // set timer 0 prescale factor to 64
+  // set timer 0 prescale factor to 64
 #if defined(__AVR_ATmega128__)
-    // CPU specific: different values for the ATmega128
-    sbi(TCCR0, CS02);
+  // CPU specific: different values for the ATmega128
+  sbi(TCCR0, CS02);
 #elif defined(TCCR0) && defined(CS01) && defined(CS00)
-    // this combination is for the standard atmega8
-    sbi(TCCR0, CS01);
-    sbi(TCCR0, CS00);
+  // this combination is for the standard atmega8
+  sbi(TCCR0, CS01);
+  sbi(TCCR0, CS00);
 #elif defined(TCCR0B) && defined(CS01) && defined(CS00)
-    // this combination is for the standard 168/328/1280/2560
-    sbi(TCCR0B, CS01);
-    sbi(TCCR0B, CS00);
+  // this combination is for the standard 168/328/1280/2560
+  sbi(TCCR0B, CS01);
+  sbi(TCCR0B, CS00);
 #elif defined(TCCR0A) && defined(CS01) && defined(CS00)
-    // this combination is for the __AVR_ATmega645__ series
-    sbi(TCCR0A, CS01);
-    sbi(TCCR0A, CS00);
+  // this combination is for the __AVR_ATmega645__ series
+  sbi(TCCR0A, CS01);
+  sbi(TCCR0A, CS00);
 #else
-#error Timer 0 prescale factor 64 not set correctly
+  #error Timer 0 prescale factor 64 not set correctly
 #endif
 
-    // enable timer 0 overflow interrupt
+  // enable timer 0 overflow interrupt
 #if defined(TIMSK) && defined(TOIE0)
-    sbi(TIMSK, TOIE0);
+  sbi(TIMSK, TOIE0);
 #elif defined(TIMSK0) && defined(TOIE0)
-    sbi(TIMSK0, TOIE0);
+  sbi(TIMSK0, TOIE0);
 #else
-#error	Timer 0 overflow interrupt not set correctly
+  #error	Timer 0 overflow interrupt not set correctly
 #endif
 
-    // timers 1 and 2 are used for phase-correct hardware pwm
-    // this is better for motors as it ensures an even waveform
-    // note, however, that fast pwm mode can achieve a frequency of up
-    // 8 MHz (with a 16 MHz clock) at 50% duty cycle
+  // timers 1 and 2 are used for phase-correct hardware pwm
+  // this is better for motors as it ensures an even waveform
+  // note, however, that fast pwm mode can achieve a frequency of up
+  // 8 MHz (with a 16 MHz clock) at 50% duty cycle
 
 #if defined(TCCR1B) && defined(CS11) && defined(CS10)
-    TCCR1B = 0;
+  TCCR1B = 0;
 
-    // set timer 1 prescale factor to 64
-    sbi(TCCR1B, CS11);
+  // set timer 1 prescale factor to 64
+  sbi(TCCR1B, CS11);
 #if F_CPU >= 8000000L
-    sbi(TCCR1B, CS10);
+  sbi(TCCR1B, CS10);
 #endif
 #elif defined(TCCR1) && defined(CS11) && defined(CS10)
-    sbi(TCCR1, CS11);
+  sbi(TCCR1, CS11);
 #if F_CPU >= 8000000L
-    sbi(TCCR1, CS10);
+  sbi(TCCR1, CS10);
 #endif
 #endif
-    // put timer 1 in 8-bit phase correct pwm mode
+  // put timer 1 in 8-bit phase correct pwm mode
 #if defined(TCCR1A) && defined(WGM10)
-    sbi(TCCR1A, WGM10);
+  sbi(TCCR1A, WGM10);
 #elif defined(TCCR1)
-#warning this needs to be finished
+  #warning this needs to be finished
 #endif
 
   // set timer 2 prescale factor to 64
 #if defined(TCCR2) && defined(CS22)
-    sbi(TCCR2, CS22);
+  sbi(TCCR2, CS22);
 #elif defined(TCCR2B) && defined(CS22)
-    sbi(TCCR2B, CS22);
+  sbi(TCCR2B, CS22);
 #else
-#warning Timer 2 not finished (may not be present on this CPU)
+  #warning Timer 2 not finished (may not be present on this CPU)
 #endif
 
   // configure timer 2 for phase correct pwm (8-bit)
 #if defined(TCCR2) && defined(WGM20)
-    sbi(TCCR2, WGM20);
+  sbi(TCCR2, WGM20);
 #elif defined(TCCR2A) && defined(WGM20)
-    sbi(TCCR2A, WGM20);
+  sbi(TCCR2A, WGM20);
 #else
-#warning Timer 2 not finished (may not be present on this CPU)
+  #warning Timer 2 not finished (may not be present on this CPU)
 #endif
 
 #if defined(TCCR3B) && defined(CS31) && defined(WGM30)
-    sbi(TCCR3B, CS31);		// set timer 3 prescale factor to 64
-    sbi(TCCR3B, CS30);
-    sbi(TCCR3A, WGM30);		// put timer 3 in 8-bit phase correct pwm mode
+  sbi(TCCR3B, CS31);		// set timer 3 prescale factor to 64
+  sbi(TCCR3B, CS30);
+  sbi(TCCR3A, WGM30);		// put timer 3 in 8-bit phase correct pwm mode
 #endif
 
 #if defined(TCCR4A) && defined(TCCR4B) && defined(TCCR4D) /* beginning of timer4 block for 32U4 and similar */
-    sbi(TCCR4B, CS42);		// set timer4 prescale factor to 64
-    sbi(TCCR4B, CS41);
-    sbi(TCCR4B, CS40);
-    sbi(TCCR4D, WGM40);		// put timer 4 in phase- and frequency-correct PWM mode
-    sbi(TCCR4A, PWM4A);		// enable PWM mode for comparator OCR4A
-    sbi(TCCR4C, PWM4D);		// enable PWM mode for comparator OCR4D
+  sbi(TCCR4B, CS42);		// set timer4 prescale factor to 64
+  sbi(TCCR4B, CS41);
+  sbi(TCCR4B, CS40);
+  sbi(TCCR4D, WGM40);		// put timer 4 in phase- and frequency-correct PWM mode
+  sbi(TCCR4A, PWM4A);		// enable PWM mode for comparator OCR4A
+  sbi(TCCR4C, PWM4D);		// enable PWM mode for comparator OCR4D
 #else /* beginning of timer4 block for ATMEGA1280 and ATMEGA2560 */
 #if defined(TCCR4B) && defined(CS41) && defined(WGM40)
-    sbi(TCCR4B, CS41);		// set timer 4 prescale factor to 64
-    sbi(TCCR4B, CS40);
-    sbi(TCCR4A, WGM40);		// put timer 4 in 8-bit phase correct pwm mode
+  sbi(TCCR4B, CS41);		// set timer 4 prescale factor to 64
+  sbi(TCCR4B, CS40);
+  sbi(TCCR4A, WGM40);		// put timer 4 in 8-bit phase correct pwm mode
 #endif
 #endif /* end timer4 block for ATMEGA1280/2560 and similar */
 
 #if defined(TCCR5B) && defined(CS51) && defined(WGM50)
-    sbi(TCCR5B, CS51);		// set timer 5 prescale factor to 64
-    sbi(TCCR5B, CS50);
-    sbi(TCCR5A, WGM50);		// put timer 5 in 8-bit phase correct pwm mode
+  sbi(TCCR5B, CS51);		// set timer 5 prescale factor to 64
+  sbi(TCCR5B, CS50);
+  sbi(TCCR5A, WGM50);		// put timer 5 in 8-bit phase correct pwm mode
 #endif
 
 #if defined(ADCSRA)
-    // set a2d prescale factor to 128
-    // 16 MHz / 128 = 125 KHz, inside the desired 50-200 KHz range.
-    // XXX: this will not work properly for other clock speeds, and
-    // this code should use F_CPU to determine the prescale factor.
-    sbi(ADCSRA, ADPS2);
-    sbi(ADCSRA, ADPS1);
-    sbi(ADCSRA, ADPS0);
+  // set a2d prescale factor to 128
+  // 16 MHz / 128 = 125 KHz, inside the desired 50-200 KHz range.
+  // XXX: this will not work properly for other clock speeds, and
+  // this code should use F_CPU to determine the prescale factor.
+  sbi(ADCSRA, ADPS2);
+  sbi(ADCSRA, ADPS1);
+  sbi(ADCSRA, ADPS0);
 
-    // enable a2d conversions
-    sbi(ADCSRA, ADEN);
+  // enable a2d conversions
+  sbi(ADCSRA, ADEN);
 #endif
 
-    // the bootloader connects pins 0 and 1 to the USART; disconnect them
-    // here so they can be used as normal digital i/o; they will be
-    // reconnected in Serial.begin()
+  // the bootloader connects pins 0 and 1 to the USART; disconnect them
+  // here so they can be used as normal digital i/o; they will be
+  // reconnected in Serial.begin()
 #if defined(UCSRB)
-    UCSRB = 0;
+  UCSRB = 0;
 #elif defined(UCSR0B)
-    UCSR0B = 0;
+  UCSR0B = 0;
 #endif
 }
 };


### PR DESCRIPTION
Changes every suffix notation of the increment and decrement operator to the prefix notation where possible, i.e. outside of using expressions.
It is better code style and on the off-chance that some ancient weird compiler is in play, or for some weird reason optimization on these operations is not happening it'll help, though it shouldn't make a huge difference in speed if so.

Changed (everywhere, except in examples):
- every in-/decrement in for loops `for ( int i = 0; i < x; ++i)`
- standalone in-/decrements e.g. `x++` -> `++x` or `x[y]++` -> `++x[y]`

The rest was kept unchanged.
(formatted ;; to ; when not intended)

I went through each change I made and can't find any that could change the behavior the code, but please check, as I could have missed something in there.