### PR TITLE
Ensure getMaxRefreshRate() returns a non-zero default for Teensy 4.x

### DIFF
--- a/platforms/arm/mxrt1062/block_clockless_arm_mxrt1062.h
+++ b/platforms/arm/mxrt1062/block_clockless_arm_mxrt1062.h
@@ -92,6 +92,7 @@ public:
 
   }
 
+  virtual uint16_t getMaxRefreshRate() const { return 400; }
 
   virtual void showPixels(PixelController<RGB_ORDER, LANES, __FL_T4_MASK> & pixels) {
 		mWait.wait();

--- a/platforms/arm/mxrt1062/clockless_arm_mxrt1062.h
+++ b/platforms/arm/mxrt1062/clockless_arm_mxrt1062.h
@@ -38,6 +38,8 @@ public:
     FastPin<DATA_PIN>::lo();
 	}
 
+  virtual uint16_t getMaxRefreshRate() const { return 400; }
+
 protected:
 
 	virtual void showPixels(PixelController<RGB_ORDER> & pixels) {


### PR DESCRIPTION
Fixes #912 