### PR TITLE
Safer nrf52 debug print enable/disable

### DIFF
--- a/platforms/arm/nrf52/led_sysdefs_arm_nrf52.h
+++ b/platforms/arm/nrf52/led_sysdefs_arm_nrf52.h
@@ -46,14 +46,8 @@ typedef __IO uint32_t RwReg;
 #define cli()  __disable_irq()
 #define sei()  __enable_irq()
 
-#define FASTLED_NRF52_DEBUGPRINT(format, ...)
-/*
 #define FASTLED_NRF52_DEBUGPRINT(format, ...)\
-    do {\
-        FastLED_NRF52_DebugPrint(format, ##__VA_ARGS__);\
-    } while(0);
-*/
-
+//    do { FastLED_NRF52_DebugPrint(format, ##__VA_ARGS__); } while(0);
 
 
 #endif // __LED_SYSDEFS_ARM_NRF52


### PR DESCRIPTION
<details><summary>Superceded by PR #1027.</summary><P/>

Make it simpler and safer to enable/disable debug
prints with single-line comment, and simultaneously
avoid warning from compiler about multi-line comments.

Thanks to @ardnew for the idea!

Fixes #1023.

</details>