### PR TITLE
fix for newer SoftwareSerial.h using differently named macro for inclusion

### DIFF
--- a/chipsets.h
+++ b/chipsets.h
@@ -16,7 +16,7 @@ FASTLED_NAMESPACE_BEGIN
 #if defined(ARDUINO) //&& defined(SoftwareSerial_h)
 
 
-#if defined(SoftwareSerial_h)
+#if defined(SoftwareSerial_h) || defined(__SoftwareSerial_h)
 #include <SoftwareSerial.h>
 
 #define HAS_PIXIE


### PR DESCRIPTION
Fixes PIXIE and the PixieController being undefined for newer versions of [espsoftwareserial](https://github.com/plerup/espsoftwareserial) because of the different symbol defined for inclusion.
```
#if defined(SoftwareSerial_h) || defined(__SoftwareSerial_h)
```
should get both versions.
[SoftwareSerial.h](https://github.com/plerup/espsoftwareserial/blob/91ea6b1b1c34601565b23c96c4441f2d399a4f99/src/SoftwareSerial.h#L25)
