### PR TITLE
generic color palettes

### DIFF
--- a/colorutils.cpp
+++ b/colorutils.cpp
@@ -993,6 +993,39 @@ CHSV ColorFromPalette( const struct CHSVPalette256& pal, uint8_t index, uint8_t 
     return hsv;
 }
 
+template <typename TSRCPalette, typename TDESTPalette>
+void UpscalePalette(const TSRCPalette &srcpal, TDESTPalette &destpal)
+{
+    constexpr uint16_t srcsize{static_cast<uint16_t>(sizeof(srcpal.entries)/sizeof(srcpal.entries[0]))};
+    constexpr uint16_t destsize{static_cast<uint16_t>(sizeof(destpal.entries)/sizeof(destpal.entries[0]))};
+    constexpr uint16_t steps{destsize/srcsize};
+    for (uint16_t i{0}; i < srcsize; ++i)
+        for (uint16_t j{0}; j < steps; ++j)
+            destpal[steps*i+j] = srcpal[i];
+}
+template void UpscalePalette(const CRGBPalette16 &srcpal, CRGBPalette32 &destpal);
+template void UpscalePalette(const CRGBPalette16 &srcpal, CRGBPalette256 &destpal);
+template void UpscalePalette(const CRGBPalette32 &srcpal, CRGBPalette256 &destpal);
+template void UpscalePalette(const CHSVPalette16 &srcpal, CHSVPalette32 &destpal);
+template void UpscalePalette(const CHSVPalette16 &srcpal, CHSVPalette256 &destpal);
+template void UpscalePalette(const CHSVPalette32 &srcpal, CHSVPalette256 &destpal);
+
+
+template <typename TSRCPalette, typename TDESTPalette>
+void UpscalePaletteInterpolated(const TSRCPalette &srcpal, TDESTPalette &destpal)
+{
+    constexpr uint16_t size{static_cast<uint16_t>(sizeof(destpal.entries)/sizeof(destpal.entries[0]))};
+    for (uint16_t i{0}; i < size; ++i)
+        destpal[i] = ColorFromPalette(srcpal, static_cast<uint8_t>(i));
+}
+template void UpscalePaletteInterpolated(const CRGBPalette16 &srcpal, CRGBPalette32 &destpal);
+template void UpscalePaletteInterpolated(const CRGBPalette16 &srcpal, CRGBPalette256 &destpal);
+template void UpscalePaletteInterpolated(const CRGBPalette32 &srcpal, CRGBPalette256 &destpal);
+template void UpscalePaletteInterpolated(const CHSVPalette16 &srcpal, CHSVPalette32 &destpal);
+template void UpscalePaletteInterpolated(const CHSVPalette16 &srcpal, CHSVPalette256 &destpal);
+template void UpscalePaletteInterpolated(const CHSVPalette32 &srcpal, CHSVPalette256 &destpal);
+
+
 #if 0
 // replaced by PartyColors_p
 void SetupPartyColors(CRGBPalette16& pal)

--- a/colorutils.cpp
+++ b/colorutils.cpp
@@ -993,56 +993,6 @@ CHSV ColorFromPalette( const struct CHSVPalette256& pal, uint8_t index, uint8_t 
     return hsv;
 }
 
-
-void UpscalePalette(const struct CRGBPalette16& srcpal16, struct CRGBPalette256& destpal256)
-{
-    for( int i = 0; i < 256; ++i) {
-        destpal256[(uint8_t)(i)] = ColorFromPalette( srcpal16, i);
-    }
-}
-
-void UpscalePalette(const struct CHSVPalette16& srcpal16, struct CHSVPalette256& destpal256)
-{
-    for( int i = 0; i < 256; ++i) {
-        destpal256[(uint8_t)(i)] = ColorFromPalette( srcpal16, i);
-    }
-}
-
-
-void UpscalePalette(const struct CRGBPalette16& srcpal16, struct CRGBPalette32& destpal32)
-{
-    for( uint8_t i = 0; i < 16; ++i) {
-        uint8_t j = i * 2;
-        destpal32[j+0] = srcpal16[i];
-        destpal32[j+1] = srcpal16[i];
-    }
-}
-
-void UpscalePalette(const struct CHSVPalette16& srcpal16, struct CHSVPalette32& destpal32)
-{
-    for( uint8_t i = 0; i < 16; ++i) {
-        uint8_t j = i * 2;
-        destpal32[j+0] = srcpal16[i];
-        destpal32[j+1] = srcpal16[i];
-    }
-}
-
-void UpscalePalette(const struct CRGBPalette32& srcpal32, struct CRGBPalette256& destpal256)
-{
-    for( int i = 0; i < 256; ++i) {
-        destpal256[(uint8_t)(i)] = ColorFromPalette( srcpal32, i);
-    }
-}
-
-void UpscalePalette(const struct CHSVPalette32& srcpal32, struct CHSVPalette256& destpal256)
-{
-    for( int i = 0; i < 256; ++i) {
-        destpal256[(uint8_t)(i)] = ColorFromPalette( srcpal32, i);
-    }
-}
-
-
-
 #if 0
 // replaced by PartyColors_p
 void SetupPartyColors(CRGBPalette16& pal)

--- a/colorutils.cpp
+++ b/colorutils.cpp
@@ -8,61 +8,7 @@
 
 FASTLED_NAMESPACE_BEGIN
 
-
-
-void fill_solid( struct CRGB * leds, int numToFill,
-                 const struct CRGB& color)
-{
-    for( int i = 0; i < numToFill; i++) {
-        leds[i] = color;
-    }
-}
-
-void fill_solid( struct CHSV * targetArray, int numToFill,
-                 const struct CHSV& hsvColor)
-{
-    for( int i = 0; i < numToFill; i++) {
-        targetArray[i] = hsvColor;
-    }
-}
-
-
-// void fill_solid( struct CRGB* targetArray, int numToFill,
-// 				 const struct CHSV& hsvColor)
-// {
-// 	fill_solid<CRGB>( targetArray, numToFill, (CRGB) hsvColor);
-// }
-
-void fill_rainbow( struct CRGB * pFirstLED, int numToFill,
-                  uint8_t initialhue,
-                  uint8_t deltahue )
-{
-    CHSV hsv;
-    hsv.hue = initialhue;
-    hsv.val = 255;
-    hsv.sat = 240;
-    for( int i = 0; i < numToFill; i++) {
-        pFirstLED[i] = hsv;
-        hsv.hue += deltahue;
-    }
-}
-
-void fill_rainbow( struct CHSV * targetArray, int numToFill,
-                  uint8_t initialhue,
-                  uint8_t deltahue )
-{
-    CHSV hsv;
-    hsv.hue = initialhue;
-    hsv.val = 255;
-    hsv.sat = 240;
-    for( int i = 0; i < numToFill; i++) {
-        targetArray[i] = hsv;
-        hsv.hue += deltahue;
-    }
-}
-
-
-void fill_gradient_RGB( CRGB* leds,
+void fill_gradient( CRGB* leds,
                    uint16_t startpos, CRGB startcolor,
                    uint16_t endpos,   CRGB endcolor )
 {
@@ -98,7 +44,7 @@ void fill_gradient_RGB( CRGB* leds,
     accum88 r88 = startcolor.r << 8;
     accum88 g88 = startcolor.g << 8;
     accum88 b88 = startcolor.b << 8;
-    for( uint16_t i = startpos; i <= endpos; i++) {
+    for( uint16_t i = startpos; i <= endpos; ++i) {
         leds[i] = CRGB( r88 >> 8, g88 >> 8, b88 >> 8);
         r88 += rdelta87;
         g88 += gdelta87;
@@ -122,48 +68,48 @@ void fill_gradient( const CHSV& c1, const CHSV& c2, const CHSV& c3, const CHSV& 
     fill_gradient( FastLED[0].leds(), FastLED[0].size(), c1, c2, c3, c4);
 }
 
-void fill_gradient_RGB( const CRGB& c1, const CRGB& c2)
+void fill_gradient( const CRGB& c1, const CRGB& c2)
 {
-    fill_gradient_RGB( FastLED[0].leds(), FastLED[0].size(), c1, c2);
+    fill_gradient( FastLED[0].leds(), FastLED[0].size(), c1, c2);
 }
 
-void fill_gradient_RGB( const CRGB& c1, const CRGB& c2, const CRGB& c3)
+void fill_gradient( const CRGB& c1, const CRGB& c2, const CRGB& c3)
 {
-    fill_gradient_RGB( FastLED[0].leds(), FastLED[0].size(), c1, c2, c3);
+    fill_gradient( FastLED[0].leds(), FastLED[0].size(), c1, c2, c3);
 }
 
-void fill_gradient_RGB( const CRGB& c1, const CRGB& c2, const CRGB& c3, const CRGB& c4)
+void fill_gradient( const CRGB& c1, const CRGB& c2, const CRGB& c3, const CRGB& c4)
 {
-    fill_gradient_RGB( FastLED[0].leds(), FastLED[0].size(), c1, c2, c3, c4);
+    fill_gradient( FastLED[0].leds(), FastLED[0].size(), c1, c2, c3, c4);
 }
 #endif
 
 
 
 
-void fill_gradient_RGB( CRGB* leds, uint16_t numLeds, const CRGB& c1, const CRGB& c2)
+void fill_gradient( CRGB* leds, uint16_t numLeds, const CRGB& c1, const CRGB& c2)
 {
     uint16_t last = numLeds - 1;
-    fill_gradient_RGB( leds, 0, c1, last, c2);
+    fill_gradient( leds, 0, c1, last, c2);
 }
 
 
-void fill_gradient_RGB( CRGB* leds, uint16_t numLeds, const CRGB& c1, const CRGB& c2, const CRGB& c3)
+void fill_gradient( CRGB* leds, uint16_t numLeds, const CRGB& c1, const CRGB& c2, const CRGB& c3)
 {
     uint16_t half = (numLeds / 2);
     uint16_t last = numLeds - 1;
-    fill_gradient_RGB( leds,    0, c1, half, c2);
-    fill_gradient_RGB( leds, half, c2, last, c3);
+    fill_gradient( leds,    0, c1, half, c2);
+    fill_gradient( leds, half, c2, last, c3);
 }
 
-void fill_gradient_RGB( CRGB* leds, uint16_t numLeds, const CRGB& c1, const CRGB& c2, const CRGB& c3, const CRGB& c4)
+void fill_gradient( CRGB* leds, uint16_t numLeds, const CRGB& c1, const CRGB& c2, const CRGB& c3, const CRGB& c4)
 {
     uint16_t onethird = (numLeds / 3);
     uint16_t twothirds = ((numLeds * 2) / 3);
     uint16_t last = numLeds - 1;
-    fill_gradient_RGB( leds,         0, c1,  onethird, c2);
-    fill_gradient_RGB( leds,  onethird, c2, twothirds, c3);
-    fill_gradient_RGB( leds, twothirds, c3,      last, c4);
+    fill_gradient( leds,         0, c1,  onethird, c2);
+    fill_gradient( leds,  onethird, c2, twothirds, c3);
+    fill_gradient( leds, twothirds, c3,      last, c4);
 }
 
 
@@ -171,7 +117,7 @@ void fill_gradient_RGB( CRGB* leds, uint16_t numLeds, const CRGB& c1, const CRGB
 
 void nscale8_video( CRGB* leds, uint16_t num_leds, uint8_t scale)
 {
-    for( uint16_t i = 0; i < num_leds; i++) {
+    for( uint16_t i = 0; i < num_leds; ++i) {
         leds[i].nscale8_video( scale);
     }
 }
@@ -204,7 +150,7 @@ void nscale8_raw( CRGB* leds, uint16_t num_leds, uint8_t scale)
 
 void nscale8( CRGB* leds, uint16_t num_leds, uint8_t scale)
 {
-    for( uint16_t i = 0; i < num_leds; i++) {
+    for( uint16_t i = 0; i < num_leds; ++i) {
         leds[i].nscale8( scale);
     }
 }
@@ -216,7 +162,7 @@ void fadeUsingColor( CRGB* leds, uint16_t numLeds, const CRGB& colormask)
     fg = colormask.g;
     fb = colormask.b;
 
-    for( uint16_t i = 0; i < numLeds; i++) {
+    for( uint16_t i = 0; i < numLeds; ++i) {
         leds[i].r = scale8_LEAVING_R1_DIRTY( leds[i].r, fr);
         leds[i].g = scale8_LEAVING_R1_DIRTY( leds[i].g, fg);
         leds[i].b = scale8                 ( leds[i].b, fb);
@@ -261,10 +207,10 @@ CRGB& nblend( CRGB& existing, const CRGB& overlay, fract8 amountOfOverlay )
 
 void nblend( CRGB* existing, CRGB* overlay, uint16_t count, fract8 amountOfOverlay)
 {
-    for( uint16_t i = count; i; i--) {
+    for( uint16_t i = count; i; --i) {
         nblend( *existing, *overlay, amountOfOverlay);
-        existing++;
-        overlay++;
+        ++existing;
+        ++overlay;
     }
 }
 
@@ -277,7 +223,7 @@ CRGB blend( const CRGB& p1, const CRGB& p2, fract8 amountOfP2 )
 
 CRGB* blend( const CRGB* src1, const CRGB* src2, CRGB* dest, uint16_t count, fract8 amountOfsrc2 )
 {
-    for( uint16_t i = 0; i < count; i++) {
+    for( uint16_t i = 0; i < count; ++i) {
         dest[i] = blend(src1[i], src2[i], amountOfsrc2);
     }
     return dest;
@@ -338,10 +284,10 @@ CHSV& nblend( CHSV& existing, const CHSV& overlay, fract8 amountOfOverlay, TGrad
 void nblend( CHSV* existing, CHSV* overlay, uint16_t count, fract8 amountOfOverlay, TGradientDirectionCode directionCode )
 {
     if(existing == overlay) return;
-    for( uint16_t i = count; i; i--) {
+    for( uint16_t i = count; i; --i) {
         nblend( *existing, *overlay, amountOfOverlay, directionCode);
-        existing++;
-        overlay++;
+        ++existing;
+        ++overlay;
     }
 }
 
@@ -354,7 +300,7 @@ CHSV blend( const CHSV& p1, const CHSV& p2, fract8 amountOfP2, TGradientDirectio
 
 CHSV* blend( const CHSV* src1, const CHSV* src2, CHSV* dest, uint16_t count, fract8 amountOfsrc2, TGradientDirectionCode directionCode )
 {
-    for( uint16_t i = 0; i < count; i++) {
+    for( uint16_t i = 0; i < count; ++i) {
         dest[i] = blend(src1[i], src2[i], amountOfsrc2, directionCode);
     }
     return dest;
@@ -385,7 +331,7 @@ void blur1d( CRGB* leds, uint16_t numLeds, fract8 blur_amount)
     uint8_t keep = 255 - blur_amount;
     uint8_t seep = blur_amount >> 1;
     CRGB carryover = CRGB::Black;
-    for( uint16_t i = 0; i < numLeds; i++) {
+    for( uint16_t i = 0; i < numLeds; ++i) {
         CRGB cur = leds[i];
         CRGB part = cur;
         part.nscale8( seep);
@@ -406,7 +352,7 @@ void blur2d( CRGB* leds, uint8_t width, uint8_t height, fract8 blur_amount)
 // blurRows: perform a blur1d on every row of a rectangular matrix
 void blurRows( CRGB* leds, uint8_t width, uint8_t height, fract8 blur_amount)
 {
-    for( uint8_t row = 0; row < height; row++) {
+    for( uint8_t row = 0; row < height; ++row) {
         CRGB* rowbase = leds + (row * width);
         blur1d( rowbase, width, blur_amount);
     }
@@ -418,9 +364,9 @@ void blurColumns(CRGB* leds, uint8_t width, uint8_t height, fract8 blur_amount)
     // blur columns
     uint8_t keep = 255 - blur_amount;
     uint8_t seep = blur_amount >> 1;
-    for( uint8_t col = 0; col < width; col++) {
+    for( uint8_t col = 0; col < width; ++col) {
         CRGB carryover = CRGB::Black;
-        for( uint8_t i = 0; i < height; i++) {
+        for( uint8_t i = 0; i < height; ++i) {
             CRGB cur = leds[XY(col,i)];
             CRGB part = cur;
             part.nscale8( seep);
@@ -529,7 +475,7 @@ CRGB ColorFromPalette( const CRGBPalette16& pal, uint8_t index, uint8_t brightne
         if( hi4 == 15 ) {
             entry = &(pal[0]);
         } else {
-            entry++;
+            ++entry;
         }
         
         uint8_t f2 = lo4 << 4;
@@ -556,25 +502,25 @@ CRGB ColorFromPalette( const CRGBPalette16& pal, uint8_t index, uint8_t brightne
     
     if( brightness != 255) {
         if( brightness ) {
-            brightness++; // adjust for rounding
+            ++brightness; // adjust for rounding
             // Now, since brightness is nonzero, we don't need the full scale8_video logic;
             // we can just to scale8 and then add one (unless scale8 fixed) to all nonzero inputs.
             if( red1 )   {
                 red1 = scale8_LEAVING_R1_DIRTY( red1, brightness);
 #if !(FASTLED_SCALE8_FIXED==1)
-                red1++;
+                ++red1;
 #endif
             }
             if( green1 ) {
                 green1 = scale8_LEAVING_R1_DIRTY( green1, brightness);
 #if !(FASTLED_SCALE8_FIXED==1)
-                green1++;
+                ++green1;
 #endif
             }
             if( blue1 )  {
                 blue1 = scale8_LEAVING_R1_DIRTY( blue1, brightness);
 #if !(FASTLED_SCALE8_FIXED==1)
-                blue1++;
+                ++blue1;
 #endif
             }
             cleanup_R1();
@@ -634,25 +580,25 @@ CRGB ColorFromPalette( const TProgmemRGBPalette16& pal, uint8_t index, uint8_t b
 
     if( brightness != 255) {
         if( brightness ) {
-            brightness++; // adjust for rounding
+            ++brightness; // adjust for rounding
             // Now, since brightness is nonzero, we don't need the full scale8_video logic;
             // we can just to scale8 and then add one (unless scale8 fixed) to all nonzero inputs.
             if( red1 )   {
                 red1 = scale8_LEAVING_R1_DIRTY( red1, brightness);
 #if !(FASTLED_SCALE8_FIXED==1)
-                red1++;
+                ++red1;
 #endif
             }
             if( green1 ) {
                 green1 = scale8_LEAVING_R1_DIRTY( green1, brightness);
 #if !(FASTLED_SCALE8_FIXED==1)
-                green1++;
+                ++green1;
 #endif
             }
             if( blue1 )  {
                 blue1 = scale8_LEAVING_R1_DIRTY( blue1, brightness);
 #if !(FASTLED_SCALE8_FIXED==1)
-                blue1++;
+                ++blue1;
 #endif
             }
             cleanup_R1();
@@ -698,7 +644,7 @@ CRGB ColorFromPalette( const CRGBPalette32& pal, uint8_t index, uint8_t brightne
         if( hi5 == 31 ) {
             entry = &(pal[0]);
         } else {
-            entry++;
+            ++entry;
         }
         
         uint8_t f2 = lo3 << 5;
@@ -725,25 +671,25 @@ CRGB ColorFromPalette( const CRGBPalette32& pal, uint8_t index, uint8_t brightne
     
     if( brightness != 255) {
         if( brightness ) {
-            brightness++; // adjust for rounding
+            ++brightness; // adjust for rounding
             // Now, since brightness is nonzero, we don't need the full scale8_video logic;
             // we can just to scale8 and then add one (unless scale8 fixed) to all nonzero inputs.
             if( red1 )   {
                 red1 = scale8_LEAVING_R1_DIRTY( red1, brightness);
 #if !(FASTLED_SCALE8_FIXED==1)
-                red1++;
+                ++red1;
 #endif
             }
             if( green1 ) {
                 green1 = scale8_LEAVING_R1_DIRTY( green1, brightness);
 #if !(FASTLED_SCALE8_FIXED==1)
-                green1++;
+                ++green1;
 #endif
             }
             if( blue1 )  {
                 blue1 = scale8_LEAVING_R1_DIRTY( blue1, brightness);
 #if !(FASTLED_SCALE8_FIXED==1)
-                blue1++;
+                ++blue1;
 #endif
             }
             cleanup_R1();
@@ -809,25 +755,25 @@ CRGB ColorFromPalette( const TProgmemRGBPalette32& pal, uint8_t index, uint8_t b
     
     if( brightness != 255) {
         if( brightness ) {
-            brightness++; // adjust for rounding
+            ++brightness; // adjust for rounding
             // Now, since brightness is nonzero, we don't need the full scale8_video logic;
             // we can just to scale8 and then add one (unless scale8 fixed) to all nonzero inputs.
             if( red1 )   {
                 red1 = scale8_LEAVING_R1_DIRTY( red1, brightness);
 #if !(FASTLED_SCALE8_FIXED==1)
-                red1++;
+                ++red1;
 #endif
             }
             if( green1 ) {
                 green1 = scale8_LEAVING_R1_DIRTY( green1, brightness);
 #if !(FASTLED_SCALE8_FIXED==1)
-                green1++;
+                ++green1;
 #endif
             }
             if( blue1 )  {
                 blue1 = scale8_LEAVING_R1_DIRTY( blue1, brightness);
 #if !(FASTLED_SCALE8_FIXED==1)
-                blue1++;
+                ++blue1;
 #endif
             }
             cleanup_R1();
@@ -852,7 +798,7 @@ CRGB ColorFromPalette( const CRGBPalette256& pal, uint8_t index, uint8_t brightn
     uint8_t blue  = entry->blue;
 
     if( brightness != 255) {
-        brightness++; // adjust for rounding
+        ++brightness; // adjust for rounding
         red   = scale8_video_LEAVING_R1_DIRTY( red,   brightness);
         green = scale8_video_LEAVING_R1_DIRTY( green, brightness);
         blue  = scale8_video_LEAVING_R1_DIRTY( blue,  brightness);
@@ -883,7 +829,7 @@ CHSV ColorFromPalette( const struct CHSVPalette16& pal, uint8_t index, uint8_t b
         if( hi4 == 15 ) {
             entry = &(pal[0]);
         } else {
-            entry++;
+            ++entry;
         }
 
         uint8_t f2 = lo4 << 4;
@@ -973,7 +919,7 @@ CHSV ColorFromPalette( const struct CHSVPalette32& pal, uint8_t index, uint8_t b
         if( hi5 == 31 ) {
             entry = &(pal[0]);
         } else {
-            entry++;
+            ++entry;
         }
         
         uint8_t f2 = lo3 << 5;
@@ -1050,14 +996,14 @@ CHSV ColorFromPalette( const struct CHSVPalette256& pal, uint8_t index, uint8_t 
 
 void UpscalePalette(const struct CRGBPalette16& srcpal16, struct CRGBPalette256& destpal256)
 {
-    for( int i = 0; i < 256; i++) {
+    for( int i = 0; i < 256; ++i) {
         destpal256[(uint8_t)(i)] = ColorFromPalette( srcpal16, i);
     }
 }
 
 void UpscalePalette(const struct CHSVPalette16& srcpal16, struct CHSVPalette256& destpal256)
 {
-    for( int i = 0; i < 256; i++) {
+    for( int i = 0; i < 256; ++i) {
         destpal256[(uint8_t)(i)] = ColorFromPalette( srcpal16, i);
     }
 }
@@ -1065,7 +1011,7 @@ void UpscalePalette(const struct CHSVPalette16& srcpal16, struct CHSVPalette256&
 
 void UpscalePalette(const struct CRGBPalette16& srcpal16, struct CRGBPalette32& destpal32)
 {
-    for( uint8_t i = 0; i < 16; i++) {
+    for( uint8_t i = 0; i < 16; ++i) {
         uint8_t j = i * 2;
         destpal32[j+0] = srcpal16[i];
         destpal32[j+1] = srcpal16[i];
@@ -1074,7 +1020,7 @@ void UpscalePalette(const struct CRGBPalette16& srcpal16, struct CRGBPalette32& 
 
 void UpscalePalette(const struct CHSVPalette16& srcpal16, struct CHSVPalette32& destpal32)
 {
-    for( uint8_t i = 0; i < 16; i++) {
+    for( uint8_t i = 0; i < 16; ++i) {
         uint8_t j = i * 2;
         destpal32[j+0] = srcpal16[i];
         destpal32[j+1] = srcpal16[i];
@@ -1083,14 +1029,14 @@ void UpscalePalette(const struct CHSVPalette16& srcpal16, struct CHSVPalette32& 
 
 void UpscalePalette(const struct CRGBPalette32& srcpal32, struct CRGBPalette256& destpal256)
 {
-    for( int i = 0; i < 256; i++) {
+    for( int i = 0; i < 256; ++i) {
         destpal256[(uint8_t)(i)] = ColorFromPalette( srcpal32, i);
     }
 }
 
 void UpscalePalette(const struct CHSVPalette32& srcpal32, struct CHSVPalette256& destpal256)
 {
-    for( int i = 0; i < 256; i++) {
+    for( int i = 0; i < 256; ++i) {
         destpal256[(uint8_t)(i)] = ColorFromPalette( srcpal32, i);
     }
 }
@@ -1117,18 +1063,18 @@ void nblendPaletteTowardPalette( CRGBPalette16& current, CRGBPalette16& target, 
     p2 = (uint8_t*)target.entries;
 
     const uint8_t totalChannels = sizeof(CRGBPalette16);
-    for( uint8_t i = 0; i < totalChannels; i++) {
+    for( uint8_t i = 0; i < totalChannels; ++i) {
         // if the values are equal, no changes are needed
         if( p1[i] == p2[i] ) { continue; }
 
         // if the current value is less than the target, increase it by one
-        if( p1[i] < p2[i] ) { p1[i]++; changes++; }
+        if( p1[i] < p2[i] ) { ++p1[i]; ++changes; }
 
         // if the current value is greater than the target,
         // increase it by one (or two if it's still greater).
         if( p1[i] > p2[i] ) {
-            p1[i]--; changes++;
-            if( p1[i] > p2[i] ) { p1[i]--; }
+            --p1[i]; ++changes;
+            if( p1[i] > p2[i] ) { --p1[i]; }
         }
 
         // if we've hit the maximum number of changes, exit
@@ -1182,14 +1128,14 @@ CRGB& napplyGamma_video( CRGB& rgb, float gammaR, float gammaG, float gammaB)
 
 void napplyGamma_video( CRGB* rgbarray, uint16_t count, float gamma)
 {
-    for( uint16_t i = 0; i < count; i++) {
+    for( uint16_t i = 0; i < count; ++i) {
         rgbarray[i] = applyGamma_video( rgbarray[i], gamma);
     }
 }
 
 void napplyGamma_video( CRGB* rgbarray, uint16_t count, float gammaR, float gammaG, float gammaB)
 {
-    for( uint16_t i = 0; i < count; i++) {
+    for( uint16_t i = 0; i < count; ++i) {
         rgbarray[i] = applyGamma_video( rgbarray[i], gammaR, gammaG, gammaB);
     }
 }

--- a/colorutils.h
+++ b/colorutils.h
@@ -468,33 +468,6 @@ public:
         return *this;
     }
 
-    // ColorPalette( const CHSVPalette16& rhs)
-    // {
-    //     for( uint8_t i = 0; i < 16; ++i) {
-    // 		entries[i] = rhs.entries[i]; // implicit HSV-to-RGB conversion
-    //     }
-    // }
-    // TColorPalette( const CHSV rhs[16])
-    // {
-    //     for( uint8_t i = 0; i < 16; ++i) {
-    //         entries[i] = rhs[i]; // implicit HSV-to-RGB conversion
-    //     }
-    // }
-    // ColorPalette& operator=( const CHSVPalette16& rhs)
-    // {
-    //     for( uint8_t i = 0; i < 16; ++i) {
-    // 		entries[i] = rhs.entries[i]; // implicit HSV-to-RGB conversion
-    //     }
-    //     return *this;
-    // }
-    // TColorPalette& operator=( const CHSV rhs[16])
-    // {
-    //     for( uint8_t i = 0; i < 16; ++i) {
-    //         entries[i] = rhs[i]; // implicit HSV-to-RGB conversion
-    //     }
-    //     return *this;
-    // }
-
     bool operator==( const TColorPalette rhs)
     {
         const uint8_t* p = (const uint8_t*)(&(this->entries[0]));
@@ -534,23 +507,6 @@ public:
     {
         return &(entries[0]);
     }
-/*
-    ColorPalette( const CHSV& c1)
-    {
-        fill_solid( &(entries[0]), size, c1);
-    }
-    ColorPalette( const CHSV& c1, const CHSV& c2)
-    {
-        fill_gradient( &(entries[0]), size, c1, c2);
-    }
-    ColorPalette( const CHSV& c1, const CHSV& c2, const CHSV& c3)
-    {
-        fill_gradient( &(entries[0]), size, c1, c2, c3);
-    }
-    ColorPalette( const CHSV& c1, const CHSV& c2, const CHSV& c3, const CHSV& c4)
-    {
-        fill_gradient( &(entries[0]), size, c1, c2, c3, c4);
-    }*/
 
     TColorPalette( const TColor& c1)
     {
@@ -570,6 +526,64 @@ public:
     }
 };
 
+template <int size>
+class CRGBPalette : public TColorPalette<CRGB,size>
+{
+public:
+    CRGBPalette() {}; // needed to compile for unknown reason
+    using TColorPalette<CRGB,size>::TColorPalette;
+    using TColorPalette<CRGB,size>::operator=;
+    using TColorPalette<CRGB,size>::operator==;
+    using TColorPalette<CRGB,size>::operator!=;
+    using TColorPalette<CRGB,size>::operator[];
+    using TColorPalette<CRGB,size>::operator CRGB *;
+    
+    CRGBPalette(const TColorPalette<CHSV,size> &rhs)
+    {
+         for( uint8_t i = 0; i < size; i++) {
+    		this->entries[i] = rhs.entries[i]; // implicit HSV-to-RGB conversion
+        }
+    }
+    CRGBPalette( const CHSV rhs[size])
+    {
+        for( uint8_t i = 0; i < size; i++) {
+            this->entries[i] = rhs[i]; // implicit HSV-to-RGB conversion
+        }
+    }
+
+    CRGBPalette& operator=( const TColorPalette<CHSV,size>& rhs)
+    {
+        for( uint8_t i = 0; i < size; i++) {
+    		this->entries[i] = rhs.entries[i]; // implicit HSV-to-RGB conversion
+        }
+        return *this;
+    }
+    CRGBPalette& operator=( const CHSV rhs[size])
+    {
+        for( uint8_t i = 0; i < size; i++) {
+            this->entries[i] = rhs[i]; // implicit HSV-to-RGB conversion
+        }
+        return *this;
+    }
+
+    CRGBPalette( const CHSV& c1)
+    {
+        fill_solid( &(this->entries[0]), size, c1);
+    }
+    CRGBPalette( const CHSV& c1, const CHSV& c2)
+    {
+        fill_gradient( &(this->entries[0]), size, c1, c2);
+    }
+    CRGBPalette( const CHSV& c1, const CHSV& c2, const CHSV& c3)
+    {
+        fill_gradient( &(this->entries[0]), size, c1, c2, c3);
+    }
+    CRGBPalette( const CHSV& c1, const CHSV& c2, const CHSV& c3, const CHSV& c4)
+    {
+        fill_gradient( &(this->entries[0]), size, c1, c2, c3, c4);
+    }
+};
+
 class CHSVPalette16 : public TColorPalette<CHSV,16> {
 public:
     using TColorPalette<CHSV,16>::TColorPalette;
@@ -578,6 +592,7 @@ public:
     using TColorPalette<CHSV,16>::operator!=;
     using TColorPalette<CHSV,16>::operator[];
     using TColorPalette<CHSV,16>::operator CHSV *;
+
     CHSVPalette16( const CHSV& c00,const CHSV& c01,const CHSV& c02,const CHSV& c03,
                     const CHSV& c04,const CHSV& c05,const CHSV& c06,const CHSV& c07,
                     const CHSV& c08,const CHSV& c09,const CHSV& c10,const CHSV& c11,
@@ -609,7 +624,6 @@ public:
         return *this;
     }
 };
-
 
 class CHSVPalette32: public TColorPalette<CHSV,32> {
 public:
@@ -694,16 +708,16 @@ public:
     }
 };
 
-class CRGBPalette16 : public TColorPalette<CRGB,16>
+class CRGBPalette16 : public CRGBPalette<16>
 {
 public:
-    using TColorPalette<CRGB,16>::TColorPalette;
-    using TColorPalette<CRGB,16>::operator=;
-    using TColorPalette<CRGB,16>::operator==;
-    using TColorPalette<CRGB,16>::operator!=;
-    using TColorPalette<CRGB,16>::operator[];
-    using TColorPalette<CRGB,16>::operator CRGB *;
-
+    using CRGBPalette<16>::CRGBPalette;
+    using CRGBPalette<16>::operator=;
+    using CRGBPalette<16>::operator==;
+    using CRGBPalette<16>::operator!=;
+    using CRGBPalette<16>::operator[];
+    using CRGBPalette<16>::operator CRGB *;
+    
     CRGBPalette16( const CRGB& c00,const CRGB& c01,const CRGB& c02,const CRGB& c03,
                     const CRGB& c04,const CRGB& c05,const CRGB& c06,const CRGB& c07,
                     const CRGB& c08,const CRGB& c09,const CRGB& c10,const CRGB& c11,
@@ -842,15 +856,15 @@ public:
     }
 };
 
-class CRGBPalette32 : public TColorPalette<CRGB,32>
+class CRGBPalette32 : public CRGBPalette<32>
 {
 public:
-    using TColorPalette<CRGB,32>::TColorPalette;
-    using TColorPalette<CRGB,32>::operator=;
-    using TColorPalette<CRGB,32>::operator==;
-    using TColorPalette<CRGB,32>::operator!=;
-    using TColorPalette<CRGB,32>::operator[];
-    using TColorPalette<CRGB,32>::operator CRGB *;
+    using CRGBPalette<32>::CRGBPalette;
+    using CRGBPalette<32>::operator=;
+    using CRGBPalette<32>::operator==;
+    using CRGBPalette<32>::operator!=;
+    using CRGBPalette<32>::operator[];
+    using CRGBPalette<32>::operator CRGB *;
     
     CRGBPalette32( const CRGB& c00,const CRGB& c01,const CRGB& c02,const CRGB& c03,
                   const CRGB& c04,const CRGB& c05,const CRGB& c06,const CRGB& c07,
@@ -1001,15 +1015,15 @@ public:
 };
 
 
-class CRGBPalette256 : public TColorPalette<CRGB,256>
+class CRGBPalette256 : public CRGBPalette<256>
 {
 public:
-    using TColorPalette<CRGB,256>::TColorPalette;
-    using TColorPalette<CRGB,256>::operator=;
-    using TColorPalette<CRGB,256>::operator==;
-    using TColorPalette<CRGB,256>::operator!=;
-    using TColorPalette<CRGB,256>::operator[];
-    using TColorPalette<CRGB,256>::operator CRGB *;
+    using CRGBPalette<256>::CRGBPalette;
+    using CRGBPalette<256>::operator=;
+    using CRGBPalette<256>::operator==;
+    using CRGBPalette<256>::operator!=;
+    using CRGBPalette<256>::operator[];
+    using CRGBPalette<256>::operator CRGB *;
 
     CRGBPalette256( const CRGB& c00,const CRGB& c01,const CRGB& c02,const CRGB& c03,
                   const CRGB& c04,const CRGB& c05,const CRGB& c06,const CRGB& c07,

--- a/colorutils.h
+++ b/colorutils.h
@@ -1123,12 +1123,12 @@ public:
         return *this;
     }
 
-    CHSVPalette256( const TProgmemRGBPalette16& rhs)
+    CHSVPalette256( const TProgmemHSVPalette16& rhs)
     {
         CHSVPalette16 p16(rhs);
         *this = p16;
     }
-    CHSVPalette256& operator=( const TProgmemRGBPalette16& rhs)
+    CHSVPalette256& operator=( const TProgmemHSVPalette16& rhs)
     {
         CHSVPalette16 p16(rhs);
         *this = p16;

--- a/colorutils.h
+++ b/colorutils.h
@@ -457,7 +457,7 @@ public:
         const uint8_t* p = (const uint8_t*)(&(this->entries[0]));
         const uint8_t* q = (const uint8_t*)(&(rhs.entries[0]));
         if( p == q) return true;
-        for( uint8_t i = 0; i < size; ++i) {
+        for( uint16_t i = 0; i < size; ++i) {
             if( *p != *q) return false;
             ++p;
             ++q;
@@ -524,27 +524,27 @@ public:
     
     CRGBPalette(const TColorPalette<CHSV,size> &rhs)
     {
-         for( uint8_t i = 0; i < size; i++) {
+         for( uint16_t i = 0; i < size; i++) {
     		this->entries[i] = rhs.entries[i]; // implicit HSV-to-RGB conversion
         }
     }
     CRGBPalette( const CHSV rhs[size])
     {
-        for( uint8_t i = 0; i < size; i++) {
+        for( uint16_t i = 0; i < size; i++) {
             this->entries[i] = rhs[i]; // implicit HSV-to-RGB conversion
         }
     }
 
     CRGBPalette& operator=( const TColorPalette<CHSV,size>& rhs)
     {
-        for( uint8_t i = 0; i < size; i++) {
+        for( uint16_t i = 0; i < size; i++) {
     		this->entries[i] = rhs.entries[i]; // implicit HSV-to-RGB conversion
         }
         return *this;
     }
     CRGBPalette& operator=( const CHSV rhs[size])
     {
-        for( uint8_t i = 0; i < size; i++) {
+        for( uint16_t i = 0; i < size; i++) {
             this->entries[i] = rhs[i]; // implicit HSV-to-RGB conversion
         }
         return *this;

--- a/colorutils.h
+++ b/colorutils.h
@@ -652,15 +652,13 @@ public:
         CRGB rgbstart( u.r, u.g, u.b);
 
         int indexstart = 0;
-        uint8_t istart8 = 0;
-        uint8_t iend8 = 0;
         while( indexstart < 255) {
             ++progent;
             u.dword = FL_PGM_READ_DWORD_NEAR( progent);
             int indexend  = u.index;
             CRGB rgbend( u.r, u.g, u.b);
-            istart8 = indexstart / 16;
-            iend8   = indexend   / 16;
+            uint8_t istart8 = indexstart / 16;
+            uint8_t iend8   = indexend   / 16;
             if( count < 16) {
                 if( (istart8 <= lastSlotUsed) && (lastSlotUsed < 15)) {
                     istart8 = lastSlotUsed + 1;
@@ -695,15 +693,13 @@ public:
         CRGB rgbstart( u.r, u.g, u.b);
 
         int indexstart = 0;
-        uint8_t istart8 = 0;
-        uint8_t iend8 = 0;
         while( indexstart < 255) {
             ++ent;
             u = *ent;
             int indexend  = u.index;
             CRGB rgbend( u.r, u.g, u.b);
-            istart8 = indexstart / 16;
-            iend8   = indexend   / 16;
+            uint8_t istart8 = indexstart / 16;
+            uint8_t iend8   = indexend   / 16;
             if( count < 16) {
                 if( (istart8 <= lastSlotUsed) && (lastSlotUsed < 15)) {
                     istart8 = lastSlotUsed + 1;
@@ -824,15 +820,13 @@ public:
         CRGB rgbstart( u.r, u.g, u.b);
         
         int indexstart = 0;
-        uint8_t istart8 = 0;
-        uint8_t iend8 = 0;
         while( indexstart < 255) {
             ++progent;
             u.dword = FL_PGM_READ_DWORD_NEAR( progent);
             int indexend  = u.index;
             CRGB rgbend( u.r, u.g, u.b);
-            istart8 = indexstart / 8;
-            iend8   = indexend   / 8;
+            uint8_t istart8 = indexstart / 8;
+            uint8_t iend8   = indexend   / 8;
             if( count < 16) {
                 if( (istart8 <= lastSlotUsed) && (lastSlotUsed < 31)) {
                     istart8 = lastSlotUsed + 1;
@@ -867,15 +861,13 @@ public:
         CRGB rgbstart( u.r, u.g, u.b);
         
         int indexstart = 0;
-        uint8_t istart8 = 0;
-        uint8_t iend8 = 0;
         while( indexstart < 255) {
             ++ent;
             u = *ent;
             int indexend  = u.index;
             CRGB rgbend( u.r, u.g, u.b);
-            istart8 = indexstart / 8;
-            iend8   = indexend   / 8;
+            uint8_t istart8 = indexstart / 8;
+            uint8_t iend8   = indexend   / 8;
             if( count < 16) {
                 if( (istart8 <= lastSlotUsed) && (lastSlotUsed < 31)) {
                     istart8 = lastSlotUsed + 1;

--- a/colorutils.h
+++ b/colorutils.h
@@ -168,7 +168,7 @@ void fill_gradient( T* targetArray,
     accum88 hue88 = startcolor.hue << 8;
     accum88 sat88 = startcolor.sat << 8;
     accum88 val88 = startcolor.val << 8;
-    for( uint16_t i = startpos; i <= endpos; i++) {
+    for( uint16_t i = startpos; i <= endpos; ++i) {
         targetArray[i] = CHSV( hue88 >> 8, sat88 >> 8, val88 >> 8);
         hue88 += huedelta87;
         sat88 += satdelta87;
@@ -390,6 +390,8 @@ CRGB HeatColor( uint8_t temperature);
 //
 //    It's easier to use than it sounds.
 //
+template<typename TColor, int size>
+class TColorPalette;
 
 class CRGBPalette16;
 class CRGBPalette32;
@@ -435,10 +437,147 @@ void UpscalePalette(const struct CRGBPalette32& srcpal32, struct CRGBPalette256&
 void UpscalePalette(const struct CHSVPalette32& srcpal32, struct CHSVPalette256& destpal256);
 
 
-class CHSVPalette16 {
+template<typename TColor, int size>
+class TColorPalette
+{
 public:
-    CHSV entries[16];
-    CHSVPalette16() {};
+    TColor entries[size];
+    TColorPalette() {};
+    TColorPalette( const TColor& c00,const TColor& c01,const TColor& c02,const TColor& c03,
+                    const TColor& c04,const TColor& c05,const TColor& c06,const TColor& c07,
+                    const TColor& c08,const TColor& c09,const TColor& c10,const TColor& c11,
+                    const TColor& c12,const TColor& c13,const TColor& c14,const TColor& c15 )
+    {};
+
+    TColorPalette( const TColorPalette& rhs)
+    {
+        memmove8( &(entries[0]), &(rhs.entries[0]), sizeof(entries));
+    }
+    TColorPalette( const TColor rhs[size])
+    {
+        memmove8( &(entries[0]), &(rhs[0]), sizeof(entries));
+    }
+    TColorPalette& operator=( const TColorPalette& rhs)
+    {
+        memmove8( &(entries[0]), &(rhs.entries[0]), sizeof(entries));
+        return *this;
+    }
+    TColorPalette& operator=( const TColor rhs[size])
+    {
+        memmove8( &(entries[0]), &(rhs[0]), sizeof(entries));
+        return *this;
+    }
+
+    // ColorPalette( const CHSVPalette16& rhs)
+    // {
+    //     for( uint8_t i = 0; i < 16; ++i) {
+    // 		entries[i] = rhs.entries[i]; // implicit HSV-to-RGB conversion
+    //     }
+    // }
+    // TColorPalette( const CHSV rhs[16])
+    // {
+    //     for( uint8_t i = 0; i < 16; ++i) {
+    //         entries[i] = rhs[i]; // implicit HSV-to-RGB conversion
+    //     }
+    // }
+    // ColorPalette& operator=( const CHSVPalette16& rhs)
+    // {
+    //     for( uint8_t i = 0; i < 16; ++i) {
+    // 		entries[i] = rhs.entries[i]; // implicit HSV-to-RGB conversion
+    //     }
+    //     return *this;
+    // }
+    // TColorPalette& operator=( const CHSV rhs[16])
+    // {
+    //     for( uint8_t i = 0; i < 16; ++i) {
+    //         entries[i] = rhs[i]; // implicit HSV-to-RGB conversion
+    //     }
+    //     return *this;
+    // }
+
+    bool operator==( const TColorPalette rhs)
+    {
+        const uint8_t* p = (const uint8_t*)(&(this->entries[0]));
+        const uint8_t* q = (const uint8_t*)(&(rhs.entries[0]));
+        if( p == q) return true;
+        for( uint8_t i = 0; i < size; ++i) {
+            if( *p != *q) return false;
+            ++p;
+            ++q;
+        }
+        return true;
+    }
+    bool operator!=( const TColorPalette rhs)
+    {
+        return !( *this == rhs);
+    }
+    
+    inline TColor& operator[] (uint8_t x) __attribute__((always_inline))
+    {
+        return entries[x];
+    }
+    inline const TColor& operator[] (uint8_t x) const __attribute__((always_inline))
+    {
+        return entries[x];
+    }
+
+    inline TColor& operator[] (int x) __attribute__((always_inline))
+    {
+        return entries[(uint8_t)x];
+    }
+    inline const TColor& operator[] (int x) const __attribute__((always_inline))
+    {
+        return entries[(uint8_t)x];
+    }
+
+    operator TColor*()
+    {
+        return &(entries[0]);
+    }
+/*
+    ColorPalette( const CHSV& c1)
+    {
+        fill_solid( &(entries[0]), size, c1);
+    }
+    ColorPalette( const CHSV& c1, const CHSV& c2)
+    {
+        fill_gradient( &(entries[0]), size, c1, c2);
+    }
+    ColorPalette( const CHSV& c1, const CHSV& c2, const CHSV& c3)
+    {
+        fill_gradient( &(entries[0]), size, c1, c2, c3);
+    }
+    ColorPalette( const CHSV& c1, const CHSV& c2, const CHSV& c3, const CHSV& c4)
+    {
+        fill_gradient( &(entries[0]), size, c1, c2, c3, c4);
+    }*/
+
+    TColorPalette( const TColor& c1)
+    {
+        fill_solid( &(entries[0]), size, c1);
+    }
+    TColorPalette( const TColor& c1, const TColor& c2)
+    {
+        fill_gradient_RGB( &(entries[0]), size, c1, c2);
+    }
+    TColorPalette( const TColor& c1, const TColor& c2, const TColor& c3)
+    {
+        fill_gradient_RGB( &(entries[0]), size, c1, c2, c3);
+    }
+    TColorPalette( const TColor& c1, const TColor& c2, const TColor& c3, const TColor& c4)
+    {
+        fill_gradient_RGB( &(entries[0]), size, c1, c2, c3, c4);
+    }
+};
+
+class CHSVPalette16 : public TColorPalette<CHSV,16> {
+public:
+    using TColorPalette<CHSV,16>::TColorPalette;
+    using TColorPalette<CHSV,16>::operator=;
+    using TColorPalette<CHSV,16>::operator==;
+    using TColorPalette<CHSV,16>::operator!=;
+    using TColorPalette<CHSV,16>::operator[];
+    using TColorPalette<CHSV,16>::operator CHSV *;
     CHSVPalette16( const CHSV& c00,const CHSV& c01,const CHSV& c02,const CHSV& c03,
                     const CHSV& c04,const CHSV& c05,const CHSV& c06,const CHSV& c07,
                     const CHSV& c08,const CHSV& c09,const CHSV& c10,const CHSV& c11,
@@ -450,19 +589,9 @@ public:
         entries[12]=c12; entries[13]=c13; entries[14]=c14; entries[15]=c15;
     };
 
-    CHSVPalette16( const CHSVPalette16& rhs)
-    {
-        memmove8( &(entries[0]), &(rhs.entries[0]), sizeof( entries));
-    }
-    CHSVPalette16& operator=( const CHSVPalette16& rhs)
-    {
-        memmove8( &(entries[0]), &(rhs.entries[0]), sizeof( entries));
-        return *this;
-    }
-
     CHSVPalette16( const TProgmemHSVPalette16& rhs)
     {
-        for( uint8_t i = 0; i < 16; i++) {
+        for( uint8_t i = 0; i < 16; ++i) {
             CRGB xyz   =  FL_PGM_READ_DWORD_NEAR( rhs + i);
             entries[i].hue = xyz.red;
             entries[i].sat = xyz.green;
@@ -471,7 +600,7 @@ public:
     }
     CHSVPalette16& operator=( const TProgmemHSVPalette16& rhs)
     {
-        for( uint8_t i = 0; i < 16; i++) {
+        for( uint8_t i = 0; i < 16; ++i) {
             CRGB xyz   =  FL_PGM_READ_DWORD_NEAR( rhs + i);
             entries[i].hue = xyz.red;
             entries[i].sat = xyz.green;
@@ -479,70 +608,59 @@ public:
         }
         return *this;
     }
-
-    inline CHSV& operator[] (uint8_t x) __attribute__((always_inline))
-    {
-        return entries[x];
-    }
-    inline const CHSV& operator[] (uint8_t x) const __attribute__((always_inline))
-    {
-        return entries[x];
-    }
-
-    inline CHSV& operator[] (int x) __attribute__((always_inline))
-    {
-        return entries[(uint8_t)x];
-    }
-    inline const CHSV& operator[] (int x) const __attribute__((always_inline))
-    {
-        return entries[(uint8_t)x];
-    }
-
-    operator CHSV*()
-    {
-        return &(entries[0]);
-    }
-
-    bool operator==( const CHSVPalette16 rhs)
-    {
-        const uint8_t* p = (const uint8_t*)(&(this->entries[0]));
-        const uint8_t* q = (const uint8_t*)(&(rhs.entries[0]));
-        if( p == q) return true;
-        for( uint8_t i = 0; i < (sizeof( entries)); i++) {
-            if( *p != *q) return false;
-            p++;
-            q++;
-        }
-        return true;
-    }
-    bool operator!=( const CHSVPalette16 rhs)
-    {
-        return !( *this == rhs);
-    }
-    
-    CHSVPalette16( const CHSV& c1)
-    {
-        fill_solid( &(entries[0]), 16, c1);
-    }
-    CHSVPalette16( const CHSV& c1, const CHSV& c2)
-    {
-        fill_gradient( &(entries[0]), 16, c1, c2);
-    }
-    CHSVPalette16( const CHSV& c1, const CHSV& c2, const CHSV& c3)
-    {
-        fill_gradient( &(entries[0]), 16, c1, c2, c3);
-    }
-    CHSVPalette16( const CHSV& c1, const CHSV& c2, const CHSV& c3, const CHSV& c4)
-    {
-        fill_gradient( &(entries[0]), 16, c1, c2, c3, c4);
-    }
-
 };
 
-class CHSVPalette256 {
+
+class CHSVPalette32: public TColorPalette<CHSV,32> {
 public:
-    CHSV entries[256];
-    CHSVPalette256() {};
+    using TColorPalette<CHSV,32>::TColorPalette;
+    using TColorPalette<CHSV,32>::operator=;
+    using TColorPalette<CHSV,32>::operator==;
+    using TColorPalette<CHSV,32>::operator!=;
+    using TColorPalette<CHSV,32>::operator[];
+    using TColorPalette<CHSV,32>::operator CHSV *;
+    CHSVPalette32( const CHSV& c00,const CHSV& c01,const CHSV& c02,const CHSV& c03,
+                  const CHSV& c04,const CHSV& c05,const CHSV& c06,const CHSV& c07,
+                  const CHSV& c08,const CHSV& c09,const CHSV& c10,const CHSV& c11,
+                  const CHSV& c12,const CHSV& c13,const CHSV& c14,const CHSV& c15 )
+    {
+        for( uint8_t i = 0; i < 2; ++i) {
+            entries[0+i]=c00; entries[2+i]=c01; entries[4+i]=c02; entries[6+i]=c03;
+            entries[8+i]=c04; entries[10+i]=c05; entries[12+i]=c06; entries[14+i]=c07;
+            entries[16+i]=c08; entries[18+i]=c09; entries[20+i]=c10; entries[22+i]=c11;
+            entries[24+i]=c12; entries[26+i]=c13; entries[28+i]=c14; entries[30+i]=c15;
+        }
+    };
+
+    CHSVPalette32( const TProgmemHSVPalette32& rhs)
+    {
+        for( uint8_t i = 0; i < 32; ++i) {
+            CRGB xyz   =  FL_PGM_READ_DWORD_NEAR( rhs + i);
+            entries[i].hue = xyz.red;
+            entries[i].sat = xyz.green;
+            entries[i].val = xyz.blue;
+        }
+    }
+    CHSVPalette32& operator=( const TProgmemHSVPalette32& rhs)
+    {
+        for( uint8_t i = 0; i < 32; ++i) {
+            CRGB xyz   =  FL_PGM_READ_DWORD_NEAR( rhs + i);
+            entries[i].hue = xyz.red;
+            entries[i].sat = xyz.green;
+            entries[i].val = xyz.blue;
+        }
+        return *this;
+    }
+};
+
+class CHSVPalette256 : public TColorPalette<CHSV,256> {
+public:
+    using TColorPalette<CHSV,256>::TColorPalette;
+    using TColorPalette<CHSV,256>::operator=;
+    using TColorPalette<CHSV,256>::operator==;
+    using TColorPalette<CHSV,256>::operator!=;
+    using TColorPalette<CHSV,256>::operator[];
+    using TColorPalette<CHSV,256>::operator CHSV *;
     CHSVPalette256( const CHSV& c00,const CHSV& c01,const CHSV& c02,const CHSV& c03,
                   const CHSV& c04,const CHSV& c05,const CHSV& c06,const CHSV& c07,
                   const CHSV& c08,const CHSV& c09,const CHSV& c10,const CHSV& c11,
@@ -552,16 +670,6 @@ public:
                           c08,c09,c10,c11,c12,c13,c14,c15);
         *this = p16;
     };
-
-    CHSVPalette256( const CHSVPalette256& rhs)
-    {
-        memmove8( &(entries[0]), &(rhs.entries[0]), sizeof( entries));
-    }
-    CHSVPalette256& operator=( const CHSVPalette256& rhs)
-    {
-        memmove8( &(entries[0]), &(rhs.entries[0]), sizeof( entries));
-        return *this;
-    }
 
     CHSVPalette256( const CHSVPalette16& rhs16)
     {
@@ -584,214 +692,42 @@ public:
         *this = p16;
         return *this;
     }
-
-    inline CHSV& operator[] (uint8_t x) __attribute__((always_inline))
-    {
-        return entries[x];
-    }
-    inline const CHSV& operator[] (uint8_t x) const __attribute__((always_inline))
-    {
-        return entries[x];
-    }
-
-    inline CHSV& operator[] (int x) __attribute__((always_inline))
-    {
-        return entries[(uint8_t)x];
-    }
-    inline const CHSV& operator[] (int x) const __attribute__((always_inline))
-    {
-        return entries[(uint8_t)x];
-    }
-
-    operator CHSV*()
-    {
-        return &(entries[0]);
-    }
-
-    bool operator==( const CHSVPalette256 rhs)
-    {
-        const uint8_t* p = (const uint8_t*)(&(this->entries[0]));
-        const uint8_t* q = (const uint8_t*)(&(rhs.entries[0]));
-        if( p == q) return true;
-        for( uint16_t i = 0; i < (sizeof( entries)); i++) {
-            if( *p != *q) return false;
-            p++;
-            q++;
-        }
-        return true;
-    }
-    bool operator!=( const CHSVPalette256 rhs)
-    {
-        return !( *this == rhs);
-    }
-    
-    CHSVPalette256( const CHSV& c1)
-    {
-      fill_solid( &(entries[0]), 256, c1);
-    }
-    CHSVPalette256( const CHSV& c1, const CHSV& c2)
-    {
-        fill_gradient( &(entries[0]), 256, c1, c2);
-    }
-    CHSVPalette256( const CHSV& c1, const CHSV& c2, const CHSV& c3)
-    {
-        fill_gradient( &(entries[0]), 256, c1, c2, c3);
-    }
-    CHSVPalette256( const CHSV& c1, const CHSV& c2, const CHSV& c3, const CHSV& c4)
-    {
-        fill_gradient( &(entries[0]), 256, c1, c2, c3, c4);
-    }
 };
 
-class CRGBPalette16 {
+class CRGBPalette16 : public TColorPalette<CRGB,16>
+{
 public:
-    CRGB entries[16];
-    CRGBPalette16() {};
+    using TColorPalette<CRGB,16>::TColorPalette;
+    using TColorPalette<CRGB,16>::operator=;
+    using TColorPalette<CRGB,16>::operator==;
+    using TColorPalette<CRGB,16>::operator!=;
+    using TColorPalette<CRGB,16>::operator[];
+    using TColorPalette<CRGB,16>::operator CRGB *;
+
     CRGBPalette16( const CRGB& c00,const CRGB& c01,const CRGB& c02,const CRGB& c03,
                     const CRGB& c04,const CRGB& c05,const CRGB& c06,const CRGB& c07,
                     const CRGB& c08,const CRGB& c09,const CRGB& c10,const CRGB& c11,
                     const CRGB& c12,const CRGB& c13,const CRGB& c14,const CRGB& c15 )
     {
-        entries[0]=c00; entries[1]=c01; entries[2]=c02; entries[3]=c03;
-        entries[4]=c04; entries[5]=c05; entries[6]=c06; entries[7]=c07;
-        entries[8]=c08; entries[9]=c09; entries[10]=c10; entries[11]=c11;
-        entries[12]=c12; entries[13]=c13; entries[14]=c14; entries[15]=c15;
+        this->entries[0]=c00; this->entries[1]=c01; this->entries[2]=c02; this->entries[3]=c03;
+        this->entries[4]=c04; this->entries[5]=c05; this->entries[6]=c06; this->entries[7]=c07;
+        this->entries[8]=c08; this->entries[9]=c09; this->entries[10]=c10; this->entries[11]=c11;
+        this->entries[12]=c12; this->entries[13]=c13; this->entries[14]=c14; this->entries[15]=c15;
     };
-
-    CRGBPalette16( const CRGBPalette16& rhs)
-    {
-        memmove8( &(entries[0]), &(rhs.entries[0]), sizeof( entries));
-    }
-    CRGBPalette16( const CRGB rhs[16])
-    {
-        memmove8( &(entries[0]), &(rhs[0]), sizeof( entries));
-    }
-    CRGBPalette16& operator=( const CRGBPalette16& rhs)
-    {
-        memmove8( &(entries[0]), &(rhs.entries[0]), sizeof( entries));
-        return *this;
-    }
-    CRGBPalette16& operator=( const CRGB rhs[16])
-    {
-        memmove8( &(entries[0]), &(rhs[0]), sizeof( entries));
-        return *this;
-    }
-
-    CRGBPalette16( const CHSVPalette16& rhs)
-    {
-        for( uint8_t i = 0; i < 16; i++) {
-    		entries[i] = rhs.entries[i]; // implicit HSV-to-RGB conversion
-        }
-    }
-    CRGBPalette16( const CHSV rhs[16])
-    {
-        for( uint8_t i = 0; i < 16; i++) {
-            entries[i] = rhs[i]; // implicit HSV-to-RGB conversion
-        }
-    }
-    CRGBPalette16& operator=( const CHSVPalette16& rhs)
-    {
-        for( uint8_t i = 0; i < 16; i++) {
-    		entries[i] = rhs.entries[i]; // implicit HSV-to-RGB conversion
-        }
-        return *this;
-    }
-    CRGBPalette16& operator=( const CHSV rhs[16])
-    {
-        for( uint8_t i = 0; i < 16; i++) {
-            entries[i] = rhs[i]; // implicit HSV-to-RGB conversion
-        }
-        return *this;
-    }
 
     CRGBPalette16( const TProgmemRGBPalette16& rhs)
     {
         for( uint8_t i = 0; i < 16; i++) {
-            entries[i] =  FL_PGM_READ_DWORD_NEAR( rhs + i);
+            this->entries[i] =  FL_PGM_READ_DWORD_NEAR( rhs + i);
         }
     }
     CRGBPalette16& operator=( const TProgmemRGBPalette16& rhs)
     {
         for( uint8_t i = 0; i < 16; i++) {
-            entries[i] =  FL_PGM_READ_DWORD_NEAR( rhs + i);
+            this->entries[i] =  FL_PGM_READ_DWORD_NEAR( rhs + i);
         }
         return *this;
     }
-
-    bool operator==( const CRGBPalette16 rhs)
-    {
-        const uint8_t* p = (const uint8_t*)(&(this->entries[0]));
-        const uint8_t* q = (const uint8_t*)(&(rhs.entries[0]));
-        if( p == q) return true;
-        for( uint8_t i = 0; i < (sizeof( entries)); i++) {
-            if( *p != *q) return false;
-            p++;
-            q++;
-        }
-        return true;
-    }
-    bool operator!=( const CRGBPalette16 rhs)
-    {
-        return !( *this == rhs);
-    }
-    
-    inline CRGB& operator[] (uint8_t x) __attribute__((always_inline))
-    {
-        return entries[x];
-    }
-    inline const CRGB& operator[] (uint8_t x) const __attribute__((always_inline))
-    {
-        return entries[x];
-    }
-
-    inline CRGB& operator[] (int x) __attribute__((always_inline))
-    {
-        return entries[(uint8_t)x];
-    }
-    inline const CRGB& operator[] (int x) const __attribute__((always_inline))
-    {
-        return entries[(uint8_t)x];
-    }
-
-    operator CRGB*()
-    {
-        return &(entries[0]);
-    }
-
-    CRGBPalette16( const CHSV& c1)
-    {
-        fill_solid( &(entries[0]), 16, c1);
-    }
-    CRGBPalette16( const CHSV& c1, const CHSV& c2)
-    {
-        fill_gradient( &(entries[0]), 16, c1, c2);
-    }
-    CRGBPalette16( const CHSV& c1, const CHSV& c2, const CHSV& c3)
-    {
-        fill_gradient( &(entries[0]), 16, c1, c2, c3);
-    }
-    CRGBPalette16( const CHSV& c1, const CHSV& c2, const CHSV& c3, const CHSV& c4)
-    {
-        fill_gradient( &(entries[0]), 16, c1, c2, c3, c4);
-    }
-
-    CRGBPalette16( const CRGB& c1)
-    {
-        fill_solid( &(entries[0]), 16, c1);
-    }
-    CRGBPalette16( const CRGB& c1, const CRGB& c2)
-    {
-        fill_gradient_RGB( &(entries[0]), 16, c1, c2);
-    }
-    CRGBPalette16( const CRGB& c1, const CRGB& c2, const CRGB& c3)
-    {
-        fill_gradient_RGB( &(entries[0]), 16, c1, c2, c3);
-    }
-    CRGBPalette16( const CRGB& c1, const CRGB& c2, const CRGB& c3, const CRGB& c4)
-    {
-        fill_gradient_RGB( &(entries[0]), 16, c1, c2, c3, c4);
-    }
-
 
     // Gradient palettes are loaded into CRGB16Palettes in such a way
     // that, if possible, every color represented in the gradient palette
@@ -828,7 +764,7 @@ public:
         uint16_t count = 0;
         do {
             u.dword = FL_PGM_READ_DWORD_NEAR(progent + count);
-            count++;;
+            ++count;;
         } while ( u.index != 255);
 
         int8_t lastSlotUsed = -1;
@@ -840,7 +776,7 @@ public:
         uint8_t istart8 = 0;
         uint8_t iend8 = 0;
         while( indexstart < 255) {
-            progent++;
+            ++progent;
             u.dword = FL_PGM_READ_DWORD_NEAR( progent);
             int indexend  = u.index;
             CRGB rgbend( u.r, u.g, u.b);
@@ -855,7 +791,7 @@ public:
                 }
                 lastSlotUsed = iend8;
             }
-            fill_gradient_RGB( &(entries[0]), istart8, rgbstart, iend8, rgbend);
+            fill_gradient_RGB( &(this->entries[0]), istart8, rgbstart, iend8, rgbend);
             indexstart = indexend;
             rgbstart = rgbend;
         }
@@ -870,7 +806,7 @@ public:
         uint16_t count = 0;
         do {
             u = *(ent + count);
-            count++;;
+            ++count;;
         } while ( u.index != 255);
 
         int8_t lastSlotUsed = -1;
@@ -883,7 +819,7 @@ public:
         uint8_t istart8 = 0;
         uint8_t iend8 = 0;
         while( indexstart < 255) {
-            ent++;
+            ++ent;
             u = *ent;
             int indexend  = u.index;
             CRGB rgbend( u.r, u.g, u.b);
@@ -898,275 +834,37 @@ public:
                 }
                 lastSlotUsed = iend8;
             }
-            fill_gradient_RGB( &(entries[0]), istart8, rgbstart, iend8, rgbend);
+            fill_gradient_RGB( &(this->entries[0]), istart8, rgbstart, iend8, rgbend);
             indexstart = indexend;
             rgbstart = rgbend;
         }
         return *this;
     }
-
 };
 
-
-
-class CHSVPalette32 {
+class CRGBPalette32 : public TColorPalette<CRGB,32>
+{
 public:
-    CHSV entries[32];
-    CHSVPalette32() {};
-    CHSVPalette32( const CHSV& c00,const CHSV& c01,const CHSV& c02,const CHSV& c03,
-                  const CHSV& c04,const CHSV& c05,const CHSV& c06,const CHSV& c07,
-                  const CHSV& c08,const CHSV& c09,const CHSV& c10,const CHSV& c11,
-                  const CHSV& c12,const CHSV& c13,const CHSV& c14,const CHSV& c15 )
-    {
-        for( uint8_t i = 0; i < 2; i++) {
-            entries[0+i]=c00; entries[2+i]=c01; entries[4+i]=c02; entries[6+i]=c03;
-            entries[8+i]=c04; entries[10+i]=c05; entries[12+i]=c06; entries[14+i]=c07;
-            entries[16+i]=c08; entries[18+i]=c09; entries[20+i]=c10; entries[22+i]=c11;
-            entries[24+i]=c12; entries[26+i]=c13; entries[28+i]=c14; entries[30+i]=c15;
-        }
-    };
+    using TColorPalette<CRGB,32>::TColorPalette;
+    using TColorPalette<CRGB,32>::operator=;
+    using TColorPalette<CRGB,32>::operator==;
+    using TColorPalette<CRGB,32>::operator!=;
+    using TColorPalette<CRGB,32>::operator[];
+    using TColorPalette<CRGB,32>::operator CRGB *;
     
-    CHSVPalette32( const CHSVPalette32& rhs)
-    {
-        memmove8( &(entries[0]), &(rhs.entries[0]), sizeof( entries));
-    }
-    CHSVPalette32& operator=( const CHSVPalette32& rhs)
-    {
-        memmove8( &(entries[0]), &(rhs.entries[0]), sizeof( entries));
-        return *this;
-    }
-    
-    CHSVPalette32( const TProgmemHSVPalette32& rhs)
-    {
-        for( uint8_t i = 0; i < 32; i++) {
-            CRGB xyz   =  FL_PGM_READ_DWORD_NEAR( rhs + i);
-            entries[i].hue = xyz.red;
-            entries[i].sat = xyz.green;
-            entries[i].val = xyz.blue;
-        }
-    }
-    CHSVPalette32& operator=( const TProgmemHSVPalette32& rhs)
-    {
-        for( uint8_t i = 0; i < 32; i++) {
-            CRGB xyz   =  FL_PGM_READ_DWORD_NEAR( rhs + i);
-            entries[i].hue = xyz.red;
-            entries[i].sat = xyz.green;
-            entries[i].val = xyz.blue;
-        }
-        return *this;
-    }
-    
-    inline CHSV& operator[] (uint8_t x) __attribute__((always_inline))
-    {
-        return entries[x];
-    }
-    inline const CHSV& operator[] (uint8_t x) const __attribute__((always_inline))
-    {
-        return entries[x];
-    }
-    
-    inline CHSV& operator[] (int x) __attribute__((always_inline))
-    {
-        return entries[(uint8_t)x];
-    }
-    inline const CHSV& operator[] (int x) const __attribute__((always_inline))
-    {
-        return entries[(uint8_t)x];
-    }
-    
-    operator CHSV*()
-    {
-        return &(entries[0]);
-    }
-    
-    bool operator==( const CHSVPalette32 rhs)
-    {
-        const uint8_t* p = (const uint8_t*)(&(this->entries[0]));
-        const uint8_t* q = (const uint8_t*)(&(rhs.entries[0]));
-        if( p == q) return true;
-        for( uint8_t i = 0; i < (sizeof( entries)); i++) {
-            if( *p != *q) return false;
-            p++;
-            q++;
-        }
-        return true;
-    }
-    bool operator!=( const CHSVPalette32 rhs)
-    {
-        return !( *this == rhs);
-    }
-    
-    CHSVPalette32( const CHSV& c1)
-    {
-        fill_solid( &(entries[0]), 32, c1);
-    }
-    CHSVPalette32( const CHSV& c1, const CHSV& c2)
-    {
-        fill_gradient( &(entries[0]), 32, c1, c2);
-    }
-    CHSVPalette32( const CHSV& c1, const CHSV& c2, const CHSV& c3)
-    {
-        fill_gradient( &(entries[0]), 32, c1, c2, c3);
-    }
-    CHSVPalette32( const CHSV& c1, const CHSV& c2, const CHSV& c3, const CHSV& c4)
-    {
-        fill_gradient( &(entries[0]), 32, c1, c2, c3, c4);
-    }
-    
-};
-
-class CRGBPalette32 {
-public:
-    CRGB entries[32];
-    CRGBPalette32() {};
     CRGBPalette32( const CRGB& c00,const CRGB& c01,const CRGB& c02,const CRGB& c03,
                   const CRGB& c04,const CRGB& c05,const CRGB& c06,const CRGB& c07,
                   const CRGB& c08,const CRGB& c09,const CRGB& c10,const CRGB& c11,
                   const CRGB& c12,const CRGB& c13,const CRGB& c14,const CRGB& c15 )
     {
         for( uint8_t i = 0; i < 2; i++) {
-            entries[0+i]=c00; entries[2+i]=c01; entries[4+i]=c02; entries[6+i]=c03;
-            entries[8+i]=c04; entries[10+i]=c05; entries[12+i]=c06; entries[14+i]=c07;
-            entries[16+i]=c08; entries[18+i]=c09; entries[20+i]=c10; entries[22+i]=c11;
-            entries[24+i]=c12; entries[26+i]=c13; entries[28+i]=c14; entries[30+i]=c15;
+            this->entries[0+i]=c00; this->entries[2+i]=c01; this->entries[4+i]=c02; this->entries[6+i]=c03;
+            this->entries[8+i]=c04; this->entries[10+i]=c05; this->entries[12+i]=c06; this->entries[14+i]=c07;
+            this->entries[16+i]=c08; this->entries[18+i]=c09; this->entries[20+i]=c10; this->entries[22+i]=c11;
+            this->entries[24+i]=c12; this->entries[26+i]=c13; this->entries[28+i]=c14; this->entries[30+i]=c15;
         }
     };
-    
-    CRGBPalette32( const CRGBPalette32& rhs)
-    {
-        memmove8( &(entries[0]), &(rhs.entries[0]), sizeof( entries));
-    }
-    CRGBPalette32( const CRGB rhs[32])
-    {
-        memmove8( &(entries[0]), &(rhs[0]), sizeof( entries));
-    }
-    CRGBPalette32& operator=( const CRGBPalette32& rhs)
-    {
-        memmove8( &(entries[0]), &(rhs.entries[0]), sizeof( entries));
-        return *this;
-    }
-    CRGBPalette32& operator=( const CRGB rhs[32])
-    {
-        memmove8( &(entries[0]), &(rhs[0]), sizeof( entries));
-        return *this;
-    }
-    
-    CRGBPalette32( const CHSVPalette32& rhs)
-    {
-        for( uint8_t i = 0; i < 32; i++) {
-            entries[i] = rhs.entries[i]; // implicit HSV-to-RGB conversion
-        }
-    }
-    CRGBPalette32( const CHSV rhs[32])
-    {
-        for( uint8_t i = 0; i < 32; i++) {
-            entries[i] = rhs[i]; // implicit HSV-to-RGB conversion
-        }
-    }
-    CRGBPalette32& operator=( const CHSVPalette32& rhs)
-    {
-        for( uint8_t i = 0; i < 32; i++) {
-            entries[i] = rhs.entries[i]; // implicit HSV-to-RGB conversion
-        }
-        return *this;
-    }
-    CRGBPalette32& operator=( const CHSV rhs[32])
-    {
-        for( uint8_t i = 0; i < 32; i++) {
-            entries[i] = rhs[i]; // implicit HSV-to-RGB conversion
-        }
-        return *this;
-    }
-    
-    CRGBPalette32( const TProgmemRGBPalette32& rhs)
-    {
-        for( uint8_t i = 0; i < 32; i++) {
-            entries[i] =  FL_PGM_READ_DWORD_NEAR( rhs + i);
-        }
-    }
-    CRGBPalette32& operator=( const TProgmemRGBPalette32& rhs)
-    {
-        for( uint8_t i = 0; i < 32; i++) {
-            entries[i] =  FL_PGM_READ_DWORD_NEAR( rhs + i);
-        }
-        return *this;
-    }
-    
-    bool operator==( const CRGBPalette32 rhs)
-    {
-        const uint8_t* p = (const uint8_t*)(&(this->entries[0]));
-        const uint8_t* q = (const uint8_t*)(&(rhs.entries[0]));
-        if( p == q) return true;
-        for( uint8_t i = 0; i < (sizeof( entries)); i++) {
-            if( *p != *q) return false;
-            p++;
-            q++;
-        }
-        return true;
-    }
-    bool operator!=( const CRGBPalette32 rhs)
-    {
-        return !( *this == rhs);
-    }
-    
-    inline CRGB& operator[] (uint8_t x) __attribute__((always_inline))
-    {
-        return entries[x];
-    }
-    inline const CRGB& operator[] (uint8_t x) const __attribute__((always_inline))
-    {
-        return entries[x];
-    }
-    
-    inline CRGB& operator[] (int x) __attribute__((always_inline))
-    {
-        return entries[(uint8_t)x];
-    }
-    inline const CRGB& operator[] (int x) const __attribute__((always_inline))
-    {
-        return entries[(uint8_t)x];
-    }
-    
-    operator CRGB*()
-    {
-        return &(entries[0]);
-    }
-    
-    CRGBPalette32( const CHSV& c1)
-    {
-        fill_solid( &(entries[0]), 32, c1);
-    }
-    CRGBPalette32( const CHSV& c1, const CHSV& c2)
-    {
-        fill_gradient( &(entries[0]), 32, c1, c2);
-    }
-    CRGBPalette32( const CHSV& c1, const CHSV& c2, const CHSV& c3)
-    {
-        fill_gradient( &(entries[0]), 32, c1, c2, c3);
-    }
-    CRGBPalette32( const CHSV& c1, const CHSV& c2, const CHSV& c3, const CHSV& c4)
-    {
-        fill_gradient( &(entries[0]), 32, c1, c2, c3, c4);
-    }
-    
-    CRGBPalette32( const CRGB& c1)
-    {
-        fill_solid( &(entries[0]), 32, c1);
-    }
-    CRGBPalette32( const CRGB& c1, const CRGB& c2)
-    {
-        fill_gradient_RGB( &(entries[0]), 32, c1, c2);
-    }
-    CRGBPalette32( const CRGB& c1, const CRGB& c2, const CRGB& c3)
-    {
-        fill_gradient_RGB( &(entries[0]), 32, c1, c2, c3);
-    }
-    CRGBPalette32( const CRGB& c1, const CRGB& c2, const CRGB& c3, const CRGB& c4)
-    {
-        fill_gradient_RGB( &(entries[0]), 32, c1, c2, c3, c4);
-    }
-    
-    
+
     CRGBPalette32( const CRGBPalette16& rhs16)
     {
         UpscalePalette( rhs16, *this);
@@ -1177,18 +875,17 @@ public:
         return *this;
     }
     
-    CRGBPalette32( const TProgmemRGBPalette16& rhs)
+    CRGBPalette32( const TProgmemRGBPalette32& rhs)
     {
-        CRGBPalette16 p16(rhs);
-        *this = p16;
+        CRGBPalette32 p32(rhs);
+        *this = p32;
     }
-    CRGBPalette32& operator=( const TProgmemRGBPalette16& rhs)
+    CRGBPalette32& operator=( const TProgmemRGBPalette32& rhs)
     {
-        CRGBPalette16 p16(rhs);
-        *this = p16;
+        CRGBPalette32 p32(rhs);
+        *this = p32;
         return *this;
     }
-    
     
     // Gradient palettes are loaded into CRGB16Palettes in such a way
     // that, if possible, every color represented in the gradient palette
@@ -1225,7 +922,7 @@ public:
         uint16_t count = 0;
         do {
             u.dword = FL_PGM_READ_DWORD_NEAR(progent + count);
-            count++;;
+            ++count;;
         } while ( u.index != 255);
         
         int8_t lastSlotUsed = -1;
@@ -1237,7 +934,7 @@ public:
         uint8_t istart8 = 0;
         uint8_t iend8 = 0;
         while( indexstart < 255) {
-            progent++;
+            ++progent;
             u.dword = FL_PGM_READ_DWORD_NEAR( progent);
             int indexend  = u.index;
             CRGB rgbend( u.r, u.g, u.b);
@@ -1252,7 +949,7 @@ public:
                 }
                 lastSlotUsed = iend8;
             }
-            fill_gradient_RGB( &(entries[0]), istart8, rgbstart, iend8, rgbend);
+            fill_gradient_RGB( &(this->entries[0]), istart8, rgbstart, iend8, rgbend);
             indexstart = indexend;
             rgbstart = rgbend;
         }
@@ -1267,7 +964,7 @@ public:
         uint16_t count = 0;
         do {
             u = *(ent + count);
-            count++;;
+            ++count;;
         } while ( u.index != 255);
         
         int8_t lastSlotUsed = -1;
@@ -1280,7 +977,7 @@ public:
         uint8_t istart8 = 0;
         uint8_t iend8 = 0;
         while( indexstart < 255) {
-            ent++;
+            ++ent;
             u = *ent;
             int indexend  = u.index;
             CRGB rgbend( u.r, u.g, u.b);
@@ -1295,21 +992,25 @@ public:
                 }
                 lastSlotUsed = iend8;
             }
-            fill_gradient_RGB( &(entries[0]), istart8, rgbstart, iend8, rgbend);
+            fill_gradient_RGB( &(this->entries[0]), istart8, rgbstart, iend8, rgbend);
             indexstart = indexend;
             rgbstart = rgbend;
         }
         return *this;
     }
-    
 };
 
 
-
-class CRGBPalette256 {
+class CRGBPalette256 : public TColorPalette<CRGB,256>
+{
 public:
-    CRGB entries[256];
-    CRGBPalette256() {};
+    using TColorPalette<CRGB,256>::TColorPalette;
+    using TColorPalette<CRGB,256>::operator=;
+    using TColorPalette<CRGB,256>::operator==;
+    using TColorPalette<CRGB,256>::operator!=;
+    using TColorPalette<CRGB,256>::operator[];
+    using TColorPalette<CRGB,256>::operator CRGB *;
+
     CRGBPalette256( const CRGB& c00,const CRGB& c01,const CRGB& c02,const CRGB& c03,
                   const CRGB& c04,const CRGB& c05,const CRGB& c06,const CRGB& c07,
                   const CRGB& c08,const CRGB& c09,const CRGB& c10,const CRGB& c11,
@@ -1319,52 +1020,6 @@ public:
                           c08,c09,c10,c11,c12,c13,c14,c15);
         *this = p16;
     };
-
-    CRGBPalette256( const CRGBPalette256& rhs)
-    {
-        memmove8( &(entries[0]), &(rhs.entries[0]), sizeof( entries));
-    }
-    CRGBPalette256( const CRGB rhs[256])
-    {
-        memmove8( &(entries[0]), &(rhs[0]), sizeof( entries));
-    }
-    CRGBPalette256& operator=( const CRGBPalette256& rhs)
-    {
-        memmove8( &(entries[0]), &(rhs.entries[0]), sizeof( entries));
-        return *this;
-    }
-    CRGBPalette256& operator=( const CRGB rhs[256])
-    {
-        memmove8( &(entries[0]), &(rhs[0]), sizeof( entries));
-        return *this;
-    }
-
-    CRGBPalette256( const CHSVPalette256& rhs)
-    {
-    	for( int i = 0; i < 256; i++) {
-	    	entries[i] = rhs.entries[i]; // implicit HSV-to-RGB conversion
-    	}
-    }
-    CRGBPalette256( const CHSV rhs[256])
-    {
-        for( int i = 0; i < 256; i++) {
-            entries[i] = rhs[i]; // implicit HSV-to-RGB conversion
-        }
-    }
-    CRGBPalette256& operator=( const CHSVPalette256& rhs)
-    {
-    	for( int i = 0; i < 256; i++) {
-	    	entries[i] = rhs.entries[i]; // implicit HSV-to-RGB conversion
-    	}
-        return *this;
-    }
-    CRGBPalette256& operator=( const CHSV rhs[256])
-    {
-        for( int i = 0; i < 256; i++) {
-            entries[i] = rhs[i]; // implicit HSV-to-RGB conversion
-        }
-        return *this;
-    }
 
     CRGBPalette256( const CRGBPalette16& rhs16)
     {
@@ -1376,90 +1031,14 @@ public:
         return *this;
     }
 
-    CRGBPalette256( const TProgmemRGBPalette16& rhs)
+    CRGBPalette256( const CRGBPalette32& rhs32)
     {
-        CRGBPalette16 p16(rhs);
-        *this = p16;
+        UpscalePalette( rhs32, *this);
     }
-    CRGBPalette256& operator=( const TProgmemRGBPalette16& rhs)
+    CRGBPalette256& operator=( const CRGBPalette32& rhs32)
     {
-        CRGBPalette16 p16(rhs);
-        *this = p16;
+        UpscalePalette( rhs32, *this);
         return *this;
-    }
-
-    bool operator==( const CRGBPalette256 rhs)
-    {
-        const uint8_t* p = (const uint8_t*)(&(this->entries[0]));
-        const uint8_t* q = (const uint8_t*)(&(rhs.entries[0]));
-        if( p == q) return true;
-        for( uint16_t i = 0; i < (sizeof( entries)); i++) {
-            if( *p != *q) return false;
-            p++;
-            q++;
-        }
-        return true;
-    }
-    bool operator!=( const CRGBPalette256 rhs)
-    {
-        return !( *this == rhs);
-    }
-    
-    inline CRGB& operator[] (uint8_t x) __attribute__((always_inline))
-    {
-        return entries[x];
-    }
-    inline const CRGB& operator[] (uint8_t x) const __attribute__((always_inline))
-    {
-        return entries[x];
-    }
-
-    inline CRGB& operator[] (int x) __attribute__((always_inline))
-    {
-        return entries[(uint8_t)x];
-    }
-    inline const CRGB& operator[] (int x) const __attribute__((always_inline))
-    {
-        return entries[(uint8_t)x];
-    }
-
-    operator CRGB*()
-    {
-        return &(entries[0]);
-    }
-
-    CRGBPalette256( const CHSV& c1)
-    {
-        fill_solid( &(entries[0]), 256, c1);
-    }
-    CRGBPalette256( const CHSV& c1, const CHSV& c2)
-    {
-        fill_gradient( &(entries[0]), 256, c1, c2);
-    }
-    CRGBPalette256( const CHSV& c1, const CHSV& c2, const CHSV& c3)
-    {
-        fill_gradient( &(entries[0]), 256, c1, c2, c3);
-    }
-    CRGBPalette256( const CHSV& c1, const CHSV& c2, const CHSV& c3, const CHSV& c4)
-    {
-        fill_gradient( &(entries[0]), 256, c1, c2, c3, c4);
-    }
-
-    CRGBPalette256( const CRGB& c1)
-    {
-        fill_solid( &(entries[0]), 256, c1);
-    }
-    CRGBPalette256( const CRGB& c1, const CRGB& c2)
-    {
-        fill_gradient_RGB( &(entries[0]), 256, c1, c2);
-    }
-    CRGBPalette256( const CRGB& c1, const CRGB& c2, const CRGB& c3)
-    {
-        fill_gradient_RGB( &(entries[0]), 256, c1, c2, c3);
-    }
-    CRGBPalette256( const CRGB& c1, const CRGB& c2, const CRGB& c3, const CRGB& c4)
-    {
-        fill_gradient_RGB( &(entries[0]), 256, c1, c2, c3, c4);
     }
 
     CRGBPalette256( TProgmemRGBGradientPalette_bytes progpal )
@@ -1475,11 +1054,11 @@ public:
 
         int indexstart = 0;
         while( indexstart < 255) {
-            progent++;
+            ++progent;
             u.dword = FL_PGM_READ_DWORD_NEAR( progent);
             int indexend  = u.index;
             CRGB rgbend( u.r, u.g, u.b);
-            fill_gradient_RGB( &(entries[0]), indexstart, rgbstart, indexend, rgbend);
+            fill_gradient_RGB( &(this->entries[0]), indexstart, rgbstart, indexend, rgbend);
             indexstart = indexend;
             rgbstart = rgbend;
         }
@@ -1494,19 +1073,17 @@ public:
 
         int indexstart = 0;
         while( indexstart < 255) {
-            ent++;
+            ++ent;
             u = *ent;
             int indexend  = u.index;
             CRGB rgbend( u.r, u.g, u.b);
-            fill_gradient_RGB( &(entries[0]), indexstart, rgbstart, indexend, rgbend);
+            fill_gradient_RGB( &(this->entries[0]), indexstart, rgbstart, indexend, rgbend);
             indexstart = indexend;
             rgbstart = rgbend;
         }
         return *this;
     }
 };
-
-
 
 typedef enum { NOBLEND=0, LINEARBLEND=1 } TBlendType;
 
@@ -1557,7 +1134,7 @@ void fill_palette(CRGB* L, uint16_t N, uint8_t startIndex, uint8_t incIndex,
                   const PALETTE& pal, uint8_t brightness, TBlendType blendType)
 {
     uint8_t colorIndex = startIndex;
-    for( uint16_t i = 0; i < N; i++) {
+    for( uint16_t i = 0; i < N; ++i) {
         L[i] = ColorFromPalette( pal, colorIndex, brightness, blendType);
         colorIndex += incIndex;
     }
@@ -1572,7 +1149,7 @@ void map_data_into_colors_through_palette(
 	uint8_t opacity=255,
 	TBlendType blendType=LINEARBLEND)
 {
-	for( uint16_t i = 0; i < dataCount; i++) {
+	for( uint16_t i = 0; i < dataCount; ++i) {
 		uint8_t d = dataArray[i];
 		CRGB rgb = ColorFromPalette( pal, d, brightness, blendType);
 		if( opacity == 255 ) {

--- a/colorutils.h
+++ b/colorutils.h
@@ -772,15 +772,29 @@ public:
         return *this;
     }
     
+    CRGBPalette32( const TProgmemRGBPalette16& rhs)
+    {
+        CRGBPalette16 p16(rhs);
+        *this = p16;
+    }
+    CRGBPalette32& operator=( const TProgmemRGBPalette16& rhs)
+    {
+        CRGBPalette16 p16(rhs);
+        *this = p16;
+        return *this;
+    }
+
     CRGBPalette32( const TProgmemRGBPalette32& rhs)
     {
-        CRGBPalette32 p32(rhs);
-        *this = p32;
+        for( uint8_t i = 0; i < 32; i++) {
+            entries[i] =  FL_PGM_READ_DWORD_NEAR( rhs + i);
+        }
     }
     CRGBPalette32& operator=( const TProgmemRGBPalette32& rhs)
     {
-        CRGBPalette32 p32(rhs);
-        *this = p32;
+        for( uint8_t i = 0; i < 32; i++) {
+            entries[i] =  FL_PGM_READ_DWORD_NEAR( rhs + i);
+        }
         return *this;
     }
     
@@ -936,6 +950,30 @@ public:
         UpscalePaletteInterpolated( rhs32, *this);
         return *this;
     }
+    
+    CRGBPalette256( const TProgmemRGBPalette16& rhs)
+    {
+        CRGBPalette16 p16(rhs);
+        *this = p16;
+    }
+    CRGBPalette256& operator=( const TProgmemRGBPalette16& rhs)
+    {
+        CRGBPalette16 p16(rhs);
+        *this = p16;
+        return *this;
+    }
+        
+    CRGBPalette256( const TProgmemRGBPalette32& rhs)
+    {
+        CRGBPalette32 p32(rhs);
+        *this = p32;
+    }
+    CRGBPalette256& operator=( const TProgmemRGBPalette32& rhs)
+    {
+        CRGBPalette32 p32(rhs);
+        *this = p32;
+        return *this;
+    }
 
     CRGBPalette256( TProgmemRGBGradientPalette_bytes progpal )
     {
@@ -1059,6 +1097,19 @@ public:
         return *this;
     }
 
+    CHSVPalette32( const TProgmemHSVPalette16& rhs)
+    {
+        CHSVPalette16 p16(rhs);
+        *this = p16;
+    }
+
+    CHSVPalette32& operator=( const TProgmemHSVPalette16& rhs)
+    {
+        CHSVPalette16 p16(rhs);
+        *this = p16;
+        return *this;
+    }
+
     CHSVPalette32( const TProgmemHSVPalette32& rhs)
     {
         for( uint8_t i = 0; i < 32; ++i) {
@@ -1132,6 +1183,18 @@ public:
     {
         CHSVPalette16 p16(rhs);
         *this = p16;
+        return *this;
+    }
+
+    CHSVPalette256( const TProgmemHSVPalette32& rhs)
+    {
+        CHSVPalette32 p32(rhs);
+        *this = p32;
+    }
+    CHSVPalette256& operator=( const TProgmemHSVPalette32& rhs)
+    {
+        CHSVPalette32 p32(rhs);
+        *this = p32;
         return *this;
     }
 };

--- a/colorutils.h
+++ b/colorutils.h
@@ -432,18 +432,9 @@ public:
                     const TColor& c12,const TColor& c13,const TColor& c14,const TColor& c15 )
     {};
 
-    TColorPalette( const TColorPalette& rhs)
-    {
-        memmove8( &(entries[0]), &(rhs.entries[0]), sizeof(entries));
-    }
     TColorPalette( const TColor rhs[size])
     {
         memmove8( &(entries[0]), &(rhs[0]), sizeof(entries));
-    }
-    TColorPalette& operator=( const TColorPalette& rhs)
-    {
-        memmove8( &(entries[0]), &(rhs.entries[0]), sizeof(entries));
-        return *this;
     }
     TColorPalette& operator=( const TColor rhs[size])
     {
@@ -590,6 +581,18 @@ public:
         entries[8]=c08; entries[9]=c09; entries[10]=c10; entries[11]=c11;
         entries[12]=c12; entries[13]=c13; entries[14]=c14; entries[15]=c15;
     };
+
+    CRGBPalette16( const CRGBPalette16& rhs)
+    {
+        memmove8( &(entries[0]), &(rhs.entries[0]), sizeof(entries));
+    }    
+    CRGBPalette16& operator=( const CRGBPalette16& rhs)
+    {
+        memmove8( &(entries[0]), &(rhs.entries[0]), sizeof(entries));
+        return *this;
+    }
+
+    ~CRGBPalette16() = default;
 
     CRGBPalette16( const TProgmemRGBPalette16& rhs)
     {
@@ -742,6 +745,18 @@ public:
             entries[24+i]=c12; entries[26+i]=c13; entries[28+i]=c14; entries[30+i]=c15;
         }
     };
+
+    CRGBPalette32( const CRGBPalette32& rhs)
+    {
+        memmove8( &(entries[0]), &(rhs.entries[0]), sizeof(entries));
+    }    
+    CRGBPalette32& operator=( const CRGBPalette32& rhs)
+    {
+        memmove8( &(entries[0]), &(rhs.entries[0]), sizeof(entries));
+        return *this;
+    }
+    
+    ~CRGBPalette32() = default;
 
     CRGBPalette32( const CRGBPalette16& rhs16)
     {
@@ -900,6 +915,18 @@ public:
         *this = p16;
     };
 
+    CRGBPalette256( const CRGBPalette256& rhs)
+    {
+        memmove8( &(entries[0]), &(rhs.entries[0]), sizeof(entries));
+    }    
+    CRGBPalette256& operator=( const CRGBPalette256& rhs)
+    {
+        memmove8( &(entries[0]), &(rhs.entries[0]), sizeof(entries));
+        return *this;
+    }
+
+    ~CRGBPalette256() = default;
+
     CRGBPalette256( const CRGBPalette16& rhs16)
     {
         UpscalePalette( rhs16, *this);
@@ -987,6 +1014,18 @@ public:
         entries[12]=c12; entries[13]=c13; entries[14]=c14; entries[15]=c15;
     };
 
+    CHSVPalette16( const CHSVPalette16& rhs)
+    {
+        memmove8( &(entries[0]), &(rhs.entries[0]), sizeof(entries));
+    }    
+    CHSVPalette16& operator=( const CHSVPalette16& rhs)
+    {
+        memmove8( &(entries[0]), &(rhs.entries[0]), sizeof(entries));
+        return *this;
+    }
+
+    ~CHSVPalette16() = default;
+
     CHSVPalette16( const TProgmemHSVPalette16& rhs)
     {
         for( uint8_t i = 0; i < 16; ++i) {
@@ -1031,6 +1070,18 @@ public:
             entries[24+i]=c12; entries[26+i]=c13; entries[28+i]=c14; entries[30+i]=c15;
         }
     };
+
+    CHSVPalette32( const CHSVPalette32& rhs)
+    {
+        memmove8( &(entries[0]), &(rhs.entries[0]), sizeof(entries));
+    }    
+    CHSVPalette32& operator=( const CHSVPalette32& rhs)
+    {
+        memmove8( &(entries[0]), &(rhs.entries[0]), sizeof(entries));
+        return *this;
+    }
+
+    ~CHSVPalette32() = default;
 
     CHSVPalette32( const CHSVPalette16& rhs16)
     {
@@ -1083,6 +1134,18 @@ public:
                           c08,c09,c10,c11,c12,c13,c14,c15);
         *this = p16;
     };
+
+    CHSVPalette256( const CHSVPalette256& rhs)
+    {
+        memmove8( &(entries[0]), &(rhs.entries[0]), sizeof(entries));
+    }    
+    CHSVPalette256& operator=( const CHSVPalette256& rhs)
+    {
+        memmove8( &(entries[0]), &(rhs.entries[0]), sizeof(entries));
+        return *this;
+    }
+
+    ~CHSVPalette256() = default;
 
     CHSVPalette256( const CHSVPalette16& rhs16)
     {

--- a/colorutils.h
+++ b/colorutils.h
@@ -568,133 +568,6 @@ public:
     }
 };
 
-class CHSVPalette16 : public TColorPalette<CHSV,16> {
-public:
-    CHSVPalette16() = default; // needed to compile for unknown reason
-    using TColorPalette<CHSV,16>::TColorPalette;
-    using TColorPalette<CHSV,16>::operator=;
-    using TColorPalette<CHSV,16>::operator==;
-    using TColorPalette<CHSV,16>::operator!=;
-    using TColorPalette<CHSV,16>::operator[];
-    using TColorPalette<CHSV,16>::operator CHSV *;
-
-    CHSVPalette16( const CHSV& c00,const CHSV& c01,const CHSV& c02,const CHSV& c03,
-                    const CHSV& c04,const CHSV& c05,const CHSV& c06,const CHSV& c07,
-                    const CHSV& c08,const CHSV& c09,const CHSV& c10,const CHSV& c11,
-                    const CHSV& c12,const CHSV& c13,const CHSV& c14,const CHSV& c15 )
-    {
-        entries[0]=c00; entries[1]=c01; entries[2]=c02; entries[3]=c03;
-        entries[4]=c04; entries[5]=c05; entries[6]=c06; entries[7]=c07;
-        entries[8]=c08; entries[9]=c09; entries[10]=c10; entries[11]=c11;
-        entries[12]=c12; entries[13]=c13; entries[14]=c14; entries[15]=c15;
-    };
-
-    CHSVPalette16( const TProgmemHSVPalette16& rhs)
-    {
-        for( uint8_t i = 0; i < 16; ++i) {
-            CRGB xyz   =  FL_PGM_READ_DWORD_NEAR( rhs + i);
-            entries[i].hue = xyz.red;
-            entries[i].sat = xyz.green;
-            entries[i].val = xyz.blue;
-        }
-    }
-    CHSVPalette16& operator=( const TProgmemHSVPalette16& rhs)
-    {
-        for( uint8_t i = 0; i < 16; ++i) {
-            CRGB xyz   =  FL_PGM_READ_DWORD_NEAR( rhs + i);
-            entries[i].hue = xyz.red;
-            entries[i].sat = xyz.green;
-            entries[i].val = xyz.blue;
-        }
-        return *this;
-    }
-};
-
-class CHSVPalette32: public TColorPalette<CHSV,32> {
-public:
-    CHSVPalette32() = default; // needed to compile for unknown reason
-    using TColorPalette<CHSV,32>::TColorPalette;
-    using TColorPalette<CHSV,32>::operator=;
-    using TColorPalette<CHSV,32>::operator==;
-    using TColorPalette<CHSV,32>::operator!=;
-    using TColorPalette<CHSV,32>::operator[];
-    using TColorPalette<CHSV,32>::operator CHSV *;
-    CHSVPalette32( const CHSV& c00,const CHSV& c01,const CHSV& c02,const CHSV& c03,
-                  const CHSV& c04,const CHSV& c05,const CHSV& c06,const CHSV& c07,
-                  const CHSV& c08,const CHSV& c09,const CHSV& c10,const CHSV& c11,
-                  const CHSV& c12,const CHSV& c13,const CHSV& c14,const CHSV& c15 )
-    {
-        for( uint8_t i = 0; i < 2; ++i) {
-            entries[0+i]=c00; entries[2+i]=c01; entries[4+i]=c02; entries[6+i]=c03;
-            entries[8+i]=c04; entries[10+i]=c05; entries[12+i]=c06; entries[14+i]=c07;
-            entries[16+i]=c08; entries[18+i]=c09; entries[20+i]=c10; entries[22+i]=c11;
-            entries[24+i]=c12; entries[26+i]=c13; entries[28+i]=c14; entries[30+i]=c15;
-        }
-    };
-
-    CHSVPalette32( const TProgmemHSVPalette32& rhs)
-    {
-        for( uint8_t i = 0; i < 32; ++i) {
-            CRGB xyz   =  FL_PGM_READ_DWORD_NEAR( rhs + i);
-            entries[i].hue = xyz.red;
-            entries[i].sat = xyz.green;
-            entries[i].val = xyz.blue;
-        }
-    }
-    CHSVPalette32& operator=( const TProgmemHSVPalette32& rhs)
-    {
-        for( uint8_t i = 0; i < 32; ++i) {
-            CRGB xyz   =  FL_PGM_READ_DWORD_NEAR( rhs + i);
-            entries[i].hue = xyz.red;
-            entries[i].sat = xyz.green;
-            entries[i].val = xyz.blue;
-        }
-        return *this;
-    }
-};
-
-class CHSVPalette256 : public TColorPalette<CHSV,256> {
-public:
-    CHSVPalette256() = default; // needed to compile for unknown reason
-    using TColorPalette<CHSV,256>::TColorPalette;
-    using TColorPalette<CHSV,256>::operator=;
-    using TColorPalette<CHSV,256>::operator==;
-    using TColorPalette<CHSV,256>::operator!=;
-    using TColorPalette<CHSV,256>::operator[];
-    using TColorPalette<CHSV,256>::operator CHSV *;
-    CHSVPalette256( const CHSV& c00,const CHSV& c01,const CHSV& c02,const CHSV& c03,
-                  const CHSV& c04,const CHSV& c05,const CHSV& c06,const CHSV& c07,
-                  const CHSV& c08,const CHSV& c09,const CHSV& c10,const CHSV& c11,
-                  const CHSV& c12,const CHSV& c13,const CHSV& c14,const CHSV& c15 )
-    {
-        CHSVPalette16 p16(c00,c01,c02,c03,c04,c05,c06,c07,
-                          c08,c09,c10,c11,c12,c13,c14,c15);
-        *this = p16;
-    };
-
-    CHSVPalette256( const CHSVPalette16& rhs16)
-    {
-        UpscalePalette( rhs16, *this);
-    }
-    CHSVPalette256& operator=( const CHSVPalette16& rhs16)
-    {
-        UpscalePalette( rhs16, *this);
-        return *this;
-    }
-
-    CHSVPalette256( const TProgmemRGBPalette16& rhs)
-    {
-        CHSVPalette16 p16(rhs);
-        *this = p16;
-    }
-    CHSVPalette256& operator=( const TProgmemRGBPalette16& rhs)
-    {
-        CHSVPalette16 p16(rhs);
-        *this = p16;
-        return *this;
-    }
-};
-
 class CRGBPalette16 : public CRGBPalette<16>
 {
 public:
@@ -1087,6 +960,135 @@ public:
         return *this;
     }
 };
+
+
+class CHSVPalette16 : public TColorPalette<CHSV,16> {
+public:
+    CHSVPalette16() = default; // needed to compile for unknown reason
+    using TColorPalette<CHSV,16>::TColorPalette;
+    using TColorPalette<CHSV,16>::operator=;
+    using TColorPalette<CHSV,16>::operator==;
+    using TColorPalette<CHSV,16>::operator!=;
+    using TColorPalette<CHSV,16>::operator[];
+    using TColorPalette<CHSV,16>::operator CHSV *;
+
+    CHSVPalette16( const CHSV& c00,const CHSV& c01,const CHSV& c02,const CHSV& c03,
+                    const CHSV& c04,const CHSV& c05,const CHSV& c06,const CHSV& c07,
+                    const CHSV& c08,const CHSV& c09,const CHSV& c10,const CHSV& c11,
+                    const CHSV& c12,const CHSV& c13,const CHSV& c14,const CHSV& c15 )
+    {
+        entries[0]=c00; entries[1]=c01; entries[2]=c02; entries[3]=c03;
+        entries[4]=c04; entries[5]=c05; entries[6]=c06; entries[7]=c07;
+        entries[8]=c08; entries[9]=c09; entries[10]=c10; entries[11]=c11;
+        entries[12]=c12; entries[13]=c13; entries[14]=c14; entries[15]=c15;
+    };
+
+    CHSVPalette16( const TProgmemHSVPalette16& rhs)
+    {
+        for( uint8_t i = 0; i < 16; ++i) {
+            CRGB xyz   =  FL_PGM_READ_DWORD_NEAR( rhs + i);
+            entries[i].hue = xyz.red;
+            entries[i].sat = xyz.green;
+            entries[i].val = xyz.blue;
+        }
+    }
+    CHSVPalette16& operator=( const TProgmemHSVPalette16& rhs)
+    {
+        for( uint8_t i = 0; i < 16; ++i) {
+            CRGB xyz   =  FL_PGM_READ_DWORD_NEAR( rhs + i);
+            entries[i].hue = xyz.red;
+            entries[i].sat = xyz.green;
+            entries[i].val = xyz.blue;
+        }
+        return *this;
+    }
+};
+
+class CHSVPalette32: public TColorPalette<CHSV,32> {
+public:
+    CHSVPalette32() = default; // needed to compile for unknown reason
+    using TColorPalette<CHSV,32>::TColorPalette;
+    using TColorPalette<CHSV,32>::operator=;
+    using TColorPalette<CHSV,32>::operator==;
+    using TColorPalette<CHSV,32>::operator!=;
+    using TColorPalette<CHSV,32>::operator[];
+    using TColorPalette<CHSV,32>::operator CHSV *;
+    CHSVPalette32( const CHSV& c00,const CHSV& c01,const CHSV& c02,const CHSV& c03,
+                  const CHSV& c04,const CHSV& c05,const CHSV& c06,const CHSV& c07,
+                  const CHSV& c08,const CHSV& c09,const CHSV& c10,const CHSV& c11,
+                  const CHSV& c12,const CHSV& c13,const CHSV& c14,const CHSV& c15 )
+    {
+        for( uint8_t i = 0; i < 2; ++i) {
+            entries[0+i]=c00; entries[2+i]=c01; entries[4+i]=c02; entries[6+i]=c03;
+            entries[8+i]=c04; entries[10+i]=c05; entries[12+i]=c06; entries[14+i]=c07;
+            entries[16+i]=c08; entries[18+i]=c09; entries[20+i]=c10; entries[22+i]=c11;
+            entries[24+i]=c12; entries[26+i]=c13; entries[28+i]=c14; entries[30+i]=c15;
+        }
+    };
+
+    CHSVPalette32( const TProgmemHSVPalette32& rhs)
+    {
+        for( uint8_t i = 0; i < 32; ++i) {
+            CRGB xyz   =  FL_PGM_READ_DWORD_NEAR( rhs + i);
+            entries[i].hue = xyz.red;
+            entries[i].sat = xyz.green;
+            entries[i].val = xyz.blue;
+        }
+    }
+    CHSVPalette32& operator=( const TProgmemHSVPalette32& rhs)
+    {
+        for( uint8_t i = 0; i < 32; ++i) {
+            CRGB xyz   =  FL_PGM_READ_DWORD_NEAR( rhs + i);
+            entries[i].hue = xyz.red;
+            entries[i].sat = xyz.green;
+            entries[i].val = xyz.blue;
+        }
+        return *this;
+    }
+};
+
+class CHSVPalette256 : public TColorPalette<CHSV,256> {
+public:
+    CHSVPalette256() = default; // needed to compile for unknown reason
+    using TColorPalette<CHSV,256>::TColorPalette;
+    using TColorPalette<CHSV,256>::operator=;
+    using TColorPalette<CHSV,256>::operator==;
+    using TColorPalette<CHSV,256>::operator!=;
+    using TColorPalette<CHSV,256>::operator[];
+    using TColorPalette<CHSV,256>::operator CHSV *;
+    CHSVPalette256( const CHSV& c00,const CHSV& c01,const CHSV& c02,const CHSV& c03,
+                  const CHSV& c04,const CHSV& c05,const CHSV& c06,const CHSV& c07,
+                  const CHSV& c08,const CHSV& c09,const CHSV& c10,const CHSV& c11,
+                  const CHSV& c12,const CHSV& c13,const CHSV& c14,const CHSV& c15 )
+    {
+        CHSVPalette16 p16(c00,c01,c02,c03,c04,c05,c06,c07,
+                          c08,c09,c10,c11,c12,c13,c14,c15);
+        *this = p16;
+    };
+
+    CHSVPalette256( const CHSVPalette16& rhs16)
+    {
+        UpscalePalette( rhs16, *this);
+    }
+    CHSVPalette256& operator=( const CHSVPalette16& rhs16)
+    {
+        UpscalePalette( rhs16, *this);
+        return *this;
+    }
+
+    CHSVPalette256( const TProgmemRGBPalette16& rhs)
+    {
+        CHSVPalette16 p16(rhs);
+        *this = p16;
+    }
+    CHSVPalette256& operator=( const TProgmemRGBPalette16& rhs)
+    {
+        CHSVPalette16 p16(rhs);
+        *this = p16;
+        return *this;
+    }
+};
+
 
 typedef enum { NOBLEND=0, LINEARBLEND=1 } TBlendType;
 

--- a/colorutils.h
+++ b/colorutils.h
@@ -603,7 +603,7 @@ public:
     using CRGBPalette<16>::operator CRGB *;
     using CRGBPalette<16>::entries;
 
-    CRGBPalette16( const CRGBPalette16& rhs)
+    CRGBPalette16( const CRGBPalette16& rhs) : CRGBPalette<16>()
     {
         memmove8( &(entries[0]), &(rhs.entries[0]), sizeof(entries));
     }    
@@ -750,7 +750,7 @@ public:
     using CRGBPalette<32>::operator CRGB *;
     using CRGBPalette<32>::entries;
 
-    CRGBPalette32( const CRGBPalette32& rhs)
+    CRGBPalette32( const CRGBPalette32& rhs) : CRGBPalette<32>()
     {
         memmove8( &(entries[0]), &(rhs.entries[0]), sizeof(entries));
     }    
@@ -905,7 +905,7 @@ public:
     using CRGBPalette<256>::operator CRGB *;
     using CRGBPalette<256>::entries;
 
-    CRGBPalette256( const CRGBPalette256& rhs)
+    CRGBPalette256( const CRGBPalette256& rhs) : CRGBPalette<256>()
     {
         memmove8( &(entries[0]), &(rhs.entries[0]), sizeof(entries));
     }    
@@ -993,7 +993,7 @@ public:
     using TColorPalette<CHSV,16>::operator CHSV *;
     using TColorPalette<CHSV,16>::entries;
 
-    CHSVPalette16( const CHSVPalette16& rhs)
+    CHSVPalette16( const CHSVPalette16& rhs) : TColorPalette<CHSV,16>()
     {
         memmove8( &(entries[0]), &(rhs.entries[0]), sizeof(entries));
     }    
@@ -1037,7 +1037,7 @@ public:
     using TColorPalette<CHSV,32>::operator CHSV *;
     using TColorPalette<CHSV,32>::entries;
 
-    CHSVPalette32( const CHSVPalette32& rhs)
+    CHSVPalette32( const CHSVPalette32& rhs) : TColorPalette<CHSV,32>()
     {
         memmove8( &(entries[0]), &(rhs.entries[0]), sizeof(entries));
     }    
@@ -1091,7 +1091,7 @@ public:
     using TColorPalette<CHSV,256>::operator CHSV *;
     using TColorPalette<CHSV,256>::entries;
 
-    CHSVPalette256( const CHSVPalette256& rhs)
+    CHSVPalette256( const CHSVPalette256& rhs) : TColorPalette<CHSV,256>()
     {
         memmove8( &(entries[0]), &(rhs.entries[0]), sizeof(entries));
     }    

--- a/colorutils.h
+++ b/colorutils.h
@@ -426,7 +426,7 @@ class TColorPalette
 {
 public:
     TColor entries[size];
-    TColorPalette() {};
+    TColorPalette() = default;
     TColorPalette( const TColor& c00,const TColor& c01,const TColor& c02,const TColor& c03,
                     const TColor& c04,const TColor& c05,const TColor& c06,const TColor& c07,
                     const TColor& c08,const TColor& c09,const TColor& c10,const TColor& c11,
@@ -514,7 +514,7 @@ template <int size>
 class CRGBPalette : public TColorPalette<CRGB,size>
 {
 public:
-    CRGBPalette() {}; // needed to compile for unknown reason
+    CRGBPalette() = default; // needed to compile for unknown reason
     using TColorPalette<CRGB,size>::TColorPalette;
     using TColorPalette<CRGB,size>::operator=;
     using TColorPalette<CRGB,size>::operator==;
@@ -570,6 +570,7 @@ public:
 
 class CHSVPalette16 : public TColorPalette<CHSV,16> {
 public:
+    CHSVPalette16() = default; // needed to compile for unknown reason
     using TColorPalette<CHSV,16>::TColorPalette;
     using TColorPalette<CHSV,16>::operator=;
     using TColorPalette<CHSV,16>::operator==;
@@ -611,6 +612,7 @@ public:
 
 class CHSVPalette32: public TColorPalette<CHSV,32> {
 public:
+    CHSVPalette32() = default; // needed to compile for unknown reason
     using TColorPalette<CHSV,32>::TColorPalette;
     using TColorPalette<CHSV,32>::operator=;
     using TColorPalette<CHSV,32>::operator==;
@@ -653,6 +655,7 @@ public:
 
 class CHSVPalette256 : public TColorPalette<CHSV,256> {
 public:
+    CHSVPalette256() = default; // needed to compile for unknown reason
     using TColorPalette<CHSV,256>::TColorPalette;
     using TColorPalette<CHSV,256>::operator=;
     using TColorPalette<CHSV,256>::operator==;
@@ -695,6 +698,7 @@ public:
 class CRGBPalette16 : public CRGBPalette<16>
 {
 public:
+    CRGBPalette16() = default; // needed to compile for unknown reason
     using CRGBPalette<16>::CRGBPalette;
     using CRGBPalette<16>::operator=;
     using CRGBPalette<16>::operator==;
@@ -843,6 +847,7 @@ public:
 class CRGBPalette32 : public CRGBPalette<32>
 {
 public:
+    CRGBPalette32() = default; // needed to compile for unknown reason
     using CRGBPalette<32>::CRGBPalette;
     using CRGBPalette<32>::operator=;
     using CRGBPalette<32>::operator==;
@@ -1001,6 +1006,7 @@ public:
 class CRGBPalette256 : public CRGBPalette<256>
 {
 public:
+    CRGBPalette256() = default; // needed to compile for unknown reason
     using CRGBPalette<256>::CRGBPalette;
     using CRGBPalette<256>::operator=;
     using CRGBPalette<256>::operator==;

--- a/colorutils.h
+++ b/colorutils.h
@@ -52,7 +52,6 @@ template void fill_rainbow(CHSV * pFirstLED, int numToFill, uint8_t initialhue, 
 typedef enum { FORWARD_HUES, BACKWARD_HUES, SHORTEST_HUES, LONGEST_HUES } TGradientDirectionCode;
 
 
-
 #define saccum87 int16_t
 
 /// fill_gradient - fill an array of colors with a smooth HSV gradient
@@ -469,20 +468,20 @@ public:
         return !( *this == rhs);
     }
     
-    inline TColor& operator[] (uint8_t x) __attribute__((always_inline))
+    inline TColor& operator[] (const uint8_t x) __attribute__((always_inline))
     {
         return entries[x];
     }
-    inline const TColor& operator[] (uint8_t x) const __attribute__((always_inline))
+    inline const TColor& operator[] (const uint8_t x) const __attribute__((always_inline))
     {
         return entries[x];
     }
 
-    inline TColor& operator[] (int x) __attribute__((always_inline))
+    inline TColor& operator[] (const int x) __attribute__((always_inline))
     {
         return entries[(uint8_t)x];
     }
-    inline const TColor& operator[] (int x) const __attribute__((always_inline))
+    inline const TColor& operator[] (const int x) const __attribute__((always_inline))
     {
         return entries[(uint8_t)x];
     }

--- a/colorutils.h
+++ b/colorutils.h
@@ -407,18 +407,39 @@ typedef uint8_t TDynamicRGBGradientPalette_byte ;
 typedef const TDynamicRGBGradientPalette_byte *TDynamicRGBGradientPalette_bytes;
 typedef TDynamicRGBGradientPalette_bytes TDynamicRGBGradientPalettePtr;
 
-// Convert a 16-entry palette to a 256-entry palette
-void UpscalePalette(const struct CRGBPalette16& srcpal16, struct CRGBPalette256& destpal256);
-void UpscalePalette(const struct CHSVPalette16& srcpal16, struct CHSVPalette256& destpal256);
+// Fast upscaling functions for palettes, similarities to noblend
+template <typename TSRCPalette, typename TDESTPalette>
+void UpscalePalette(const TSRCPalette &srcpal, TDESTPalette &destpal)
+{
+    constexpr uint16_t srcsize{static_cast<uint16_t>(sizeof(srcpal.entries)/sizeof(srcpal.entries[0]))};
+    constexpr uint16_t destsize{static_cast<uint16_t>(sizeof(destpal.entries)/sizeof(destpal.entries[0]))};
+    constexpr uint16_t steps{destsize/srcsize};
+    for (uint16_t i{0}; i < srcsize; ++i)
+        for (uint16_t j{0}; j < steps; ++j)
+            destpal[i+j] = srcpal[i];
+}
+template void UpscalePalette(const CRGBPalette16 &srcpal, CRGBPalette32 &destpal);
+template void UpscalePalette(const CRGBPalette16 &srcpal, CRGBPalette256 &destpal);
+template void UpscalePalette(const CRGBPalette32 &srcpal, CRGBPalette256 &destpal);
+template void UpscalePalette(const CHSVPalette16 &srcpal, CHSVPalette32 &destpal);
+template void UpscalePalette(const CHSVPalette16 &srcpal, CHSVPalette256 &destpal);
+template void UpscalePalette(const CHSVPalette32 &srcpal, CHSVPalette256 &destpal);
 
-// Convert a 16-entry palette to a 32-entry palette
-void UpscalePalette(const struct CRGBPalette16& srcpal16, struct CRGBPalette32& destpal32);
-void UpscalePalette(const struct CHSVPalette16& srcpal16, struct CHSVPalette32& destpal32);
-
-// Convert a 32-entry palette to a 256-entry palette
-void UpscalePalette(const struct CRGBPalette32& srcpal32, struct CRGBPalette256& destpal256);
-void UpscalePalette(const struct CHSVPalette32& srcpal32, struct CHSVPalette256& destpal256);
-
+// High res upscaling function for palettes
+// as ColorFromPalette only takes uint8_t limit the destsize to 256
+template <typename TSRCPalette, typename TDESTPalette>
+void UpscalePaletteInterpolated(const TSRCPalette &srcpal, TDESTPalette &destpal)
+{
+    constexpr uint16_t size{static_cast<uint16_t>(sizeof(destpal.entries)/sizeof(destpal.entries[0]))};
+    for (uint16_t i{0}; i < size; ++i)
+        destpal[i] = ColorFromPalette(srcpal, static_cast<uint8_t>(i));
+}
+template void UpscalePaletteInterpolated(const CRGBPalette16 &srcpal, CRGBPalette32 &destpal);
+template void UpscalePaletteInterpolated(const CRGBPalette16 &srcpal, CRGBPalette256 &destpal);
+template void UpscalePaletteInterpolated(const CRGBPalette32 &srcpal, CRGBPalette256 &destpal);
+template void UpscalePaletteInterpolated(const CHSVPalette16 &srcpal, CHSVPalette32 &destpal);
+template void UpscalePaletteInterpolated(const CHSVPalette16 &srcpal, CHSVPalette256 &destpal);
+template void UpscalePaletteInterpolated(const CHSVPalette32 &srcpal, CHSVPalette256 &destpal);
 
 template<typename TColor, int size>
 class TColorPalette
@@ -921,21 +942,21 @@ public:
 
     CRGBPalette256( const CRGBPalette16& rhs16)
     {
-        UpscalePalette( rhs16, *this);
+        UpscalePaletteInterpolated( rhs16, *this);
     }
     CRGBPalette256& operator=( const CRGBPalette16& rhs16)
     {
-        UpscalePalette( rhs16, *this);
+        UpscalePaletteInterpolated( rhs16, *this);
         return *this;
     }
 
     CRGBPalette256( const CRGBPalette32& rhs32)
     {
-        UpscalePalette( rhs32, *this);
+        UpscalePaletteInterpolated( rhs32, *this);
     }
     CRGBPalette256& operator=( const CRGBPalette32& rhs32)
     {
-        UpscalePalette( rhs32, *this);
+        UpscalePaletteInterpolated( rhs32, *this);
         return *this;
     }
 
@@ -1141,21 +1162,21 @@ public:
 
     CHSVPalette256( const CHSVPalette16& rhs16)
     {
-        UpscalePalette( rhs16, *this);
+        UpscalePaletteInterpolated( rhs16, *this);
     }
     CHSVPalette256& operator=( const CHSVPalette16& rhs16)
     {
-        UpscalePalette( rhs16, *this);
+        UpscalePaletteInterpolated( rhs16, *this);
         return *this;
     }
 
     CHSVPalette256( const CHSVPalette32& rhs32)
     {
-        UpscalePalette( rhs32, *this);
+        UpscalePaletteInterpolated( rhs32, *this);
     }
     CHSVPalette256& operator=( const CHSVPalette32& rhs32)
     {
-        UpscalePalette( rhs32, *this);
+        UpscalePaletteInterpolated( rhs32, *this);
         return *this;
     }
 

--- a/colorutils.h
+++ b/colorutils.h
@@ -1026,6 +1026,16 @@ public:
         }
     };
 
+    CHSVPalette32( const CHSVPalette16& rhs16)
+    {
+        UpscalePalette( rhs16, *this);
+    }
+    CHSVPalette32& operator=( const CHSVPalette16& rhs16)
+    {
+        UpscalePalette( rhs16, *this);
+        return *this;
+    }
+
     CHSVPalette32( const TProgmemHSVPalette32& rhs)
     {
         for( uint8_t i = 0; i < 32; ++i) {
@@ -1073,6 +1083,16 @@ public:
     CHSVPalette256& operator=( const CHSVPalette16& rhs16)
     {
         UpscalePalette( rhs16, *this);
+        return *this;
+    }
+
+    CHSVPalette256( const CHSVPalette32& rhs32)
+    {
+        UpscalePalette( rhs32, *this);
+    }
+    CHSVPalette256& operator=( const CHSVPalette32& rhs32)
+    {
+        UpscalePalette( rhs32, *this);
         return *this;
     }
 

--- a/colorutils.h
+++ b/colorutils.h
@@ -453,10 +453,10 @@ public:
 
     bool operator==( const TColorPalette &rhs) const
     {
-        const uint8_t* p = (const uint8_t*)(&(this->entries[0]));
+        const uint8_t* p = (const uint8_t*)(&(entries[0]));
         const uint8_t* q = (const uint8_t*)(&(rhs.entries[0]));
         if( p == q) return true;
-        for( uint16_t i = 0; i < sizeof(this->entries); ++i) {
+        for( uint16_t i = 0; i < sizeof(entries); ++i) {
             if( *p != *q) return false;
             ++p;
             ++q;
@@ -520,50 +520,51 @@ public:
     using TColorPalette<CRGB,size>::operator!=;
     using TColorPalette<CRGB,size>::operator[];
     using TColorPalette<CRGB,size>::operator CRGB *;
+    using TColorPalette<CRGB,size>::entries;
     
     CRGBPalette(const TColorPalette<CHSV,size> &rhs)
     {
          for( uint16_t i = 0; i < size; i++) {
-    		this->entries[i] = rhs.entries[i]; // implicit HSV-to-RGB conversion
+    		entries[i] = rhs.entries[i]; // implicit HSV-to-RGB conversion
         }
     }
     CRGBPalette( const CHSV rhs[size])
     {
         for( uint16_t i = 0; i < size; i++) {
-            this->entries[i] = rhs[i]; // implicit HSV-to-RGB conversion
+            entries[i] = rhs[i]; // implicit HSV-to-RGB conversion
         }
     }
 
     CRGBPalette& operator=( const TColorPalette<CHSV,size>& rhs)
     {
         for( uint16_t i = 0; i < size; i++) {
-    		this->entries[i] = rhs.entries[i]; // implicit HSV-to-RGB conversion
+    		entries[i] = rhs.entries[i]; // implicit HSV-to-RGB conversion
         }
         return *this;
     }
     CRGBPalette& operator=( const CHSV rhs[size])
     {
         for( uint16_t i = 0; i < size; i++) {
-            this->entries[i] = rhs[i]; // implicit HSV-to-RGB conversion
+            entries[i] = rhs[i]; // implicit HSV-to-RGB conversion
         }
         return *this;
     }
 
     CRGBPalette( const CHSV& c1)
     {
-        fill_solid( &(this->entries[0]), size, c1);
+        fill_solid( &(entries[0]), size, c1);
     }
     CRGBPalette( const CHSV& c1, const CHSV& c2)
     {
-        fill_gradient( &(this->entries[0]), size, c1, c2);
+        fill_gradient( &(entries[0]), size, c1, c2);
     }
     CRGBPalette( const CHSV& c1, const CHSV& c2, const CHSV& c3)
     {
-        fill_gradient( &(this->entries[0]), size, c1, c2, c3);
+        fill_gradient( &(entries[0]), size, c1, c2, c3);
     }
     CRGBPalette( const CHSV& c1, const CHSV& c2, const CHSV& c3, const CHSV& c4)
     {
-        fill_gradient( &(this->entries[0]), size, c1, c2, c3, c4);
+        fill_gradient( &(entries[0]), size, c1, c2, c3, c4);
     }
 };
 
@@ -577,28 +578,29 @@ public:
     using CRGBPalette<16>::operator!=;
     using CRGBPalette<16>::operator[];
     using CRGBPalette<16>::operator CRGB *;
+    using CRGBPalette<16>::entries;
     
     CRGBPalette16( const CRGB& c00,const CRGB& c01,const CRGB& c02,const CRGB& c03,
                     const CRGB& c04,const CRGB& c05,const CRGB& c06,const CRGB& c07,
                     const CRGB& c08,const CRGB& c09,const CRGB& c10,const CRGB& c11,
                     const CRGB& c12,const CRGB& c13,const CRGB& c14,const CRGB& c15 )
     {
-        this->entries[0]=c00; this->entries[1]=c01; this->entries[2]=c02; this->entries[3]=c03;
-        this->entries[4]=c04; this->entries[5]=c05; this->entries[6]=c06; this->entries[7]=c07;
-        this->entries[8]=c08; this->entries[9]=c09; this->entries[10]=c10; this->entries[11]=c11;
-        this->entries[12]=c12; this->entries[13]=c13; this->entries[14]=c14; this->entries[15]=c15;
+        entries[0]=c00; entries[1]=c01; entries[2]=c02; entries[3]=c03;
+        entries[4]=c04; entries[5]=c05; entries[6]=c06; entries[7]=c07;
+        entries[8]=c08; entries[9]=c09; entries[10]=c10; entries[11]=c11;
+        entries[12]=c12; entries[13]=c13; entries[14]=c14; entries[15]=c15;
     };
 
     CRGBPalette16( const TProgmemRGBPalette16& rhs)
     {
         for( uint8_t i = 0; i < 16; i++) {
-            this->entries[i] =  FL_PGM_READ_DWORD_NEAR( rhs + i);
+            entries[i] =  FL_PGM_READ_DWORD_NEAR( rhs + i);
         }
     }
     CRGBPalette16& operator=( const TProgmemRGBPalette16& rhs)
     {
         for( uint8_t i = 0; i < 16; i++) {
-            this->entries[i] =  FL_PGM_READ_DWORD_NEAR( rhs + i);
+            entries[i] =  FL_PGM_READ_DWORD_NEAR( rhs + i);
         }
         return *this;
     }
@@ -665,7 +667,7 @@ public:
                 }
                 lastSlotUsed = iend8;
             }
-            fill_gradient( &(this->entries[0]), istart8, rgbstart, iend8, rgbend);
+            fill_gradient( &(entries[0]), istart8, rgbstart, iend8, rgbend);
             indexstart = indexend;
             rgbstart = rgbend;
         }
@@ -708,7 +710,7 @@ public:
                 }
                 lastSlotUsed = iend8;
             }
-            fill_gradient( &(this->entries[0]), istart8, rgbstart, iend8, rgbend);
+            fill_gradient( &(entries[0]), istart8, rgbstart, iend8, rgbend);
             indexstart = indexend;
             rgbstart = rgbend;
         }
@@ -726,6 +728,7 @@ public:
     using CRGBPalette<32>::operator!=;
     using CRGBPalette<32>::operator[];
     using CRGBPalette<32>::operator CRGB *;
+    using CRGBPalette<32>::entries;
     
     CRGBPalette32( const CRGB& c00,const CRGB& c01,const CRGB& c02,const CRGB& c03,
                   const CRGB& c04,const CRGB& c05,const CRGB& c06,const CRGB& c07,
@@ -733,10 +736,10 @@ public:
                   const CRGB& c12,const CRGB& c13,const CRGB& c14,const CRGB& c15 )
     {
         for( uint8_t i = 0; i < 2; i++) {
-            this->entries[0+i]=c00; this->entries[2+i]=c01; this->entries[4+i]=c02; this->entries[6+i]=c03;
-            this->entries[8+i]=c04; this->entries[10+i]=c05; this->entries[12+i]=c06; this->entries[14+i]=c07;
-            this->entries[16+i]=c08; this->entries[18+i]=c09; this->entries[20+i]=c10; this->entries[22+i]=c11;
-            this->entries[24+i]=c12; this->entries[26+i]=c13; this->entries[28+i]=c14; this->entries[30+i]=c15;
+            entries[0+i]=c00; entries[2+i]=c01; entries[4+i]=c02; entries[6+i]=c03;
+            entries[8+i]=c04; entries[10+i]=c05; entries[12+i]=c06; entries[14+i]=c07;
+            entries[16+i]=c08; entries[18+i]=c09; entries[20+i]=c10; entries[22+i]=c11;
+            entries[24+i]=c12; entries[26+i]=c13; entries[28+i]=c14; entries[30+i]=c15;
         }
     };
 
@@ -824,7 +827,7 @@ public:
                 }
                 lastSlotUsed = iend8;
             }
-            fill_gradient( &(this->entries[0]), istart8, rgbstart, iend8, rgbend);
+            fill_gradient( &(entries[0]), istart8, rgbstart, iend8, rgbend);
             indexstart = indexend;
             rgbstart = rgbend;
         }
@@ -867,7 +870,7 @@ public:
                 }
                 lastSlotUsed = iend8;
             }
-            fill_gradient( &(this->entries[0]), istart8, rgbstart, iend8, rgbend);
+            fill_gradient( &(entries[0]), istart8, rgbstart, iend8, rgbend);
             indexstart = indexend;
             rgbstart = rgbend;
         }
@@ -885,6 +888,7 @@ public:
     using CRGBPalette<256>::operator!=;
     using CRGBPalette<256>::operator[];
     using CRGBPalette<256>::operator CRGB *;
+    using CRGBPalette<256>::entries;
 
     CRGBPalette256( const CRGB& c00,const CRGB& c01,const CRGB& c02,const CRGB& c03,
                   const CRGB& c04,const CRGB& c05,const CRGB& c06,const CRGB& c07,
@@ -933,7 +937,7 @@ public:
             u.dword = FL_PGM_READ_DWORD_NEAR( progent);
             int indexend  = u.index;
             CRGB rgbend( u.r, u.g, u.b);
-            fill_gradient( &(this->entries[0]), indexstart, rgbstart, indexend, rgbend);
+            fill_gradient( &(entries[0]), indexstart, rgbstart, indexend, rgbend);
             indexstart = indexend;
             rgbstart = rgbend;
         }
@@ -952,7 +956,7 @@ public:
             u = *ent;
             int indexend  = u.index;
             CRGB rgbend( u.r, u.g, u.b);
-            fill_gradient( &(this->entries[0]), indexstart, rgbstart, indexend, rgbend);
+            fill_gradient( &(entries[0]), indexstart, rgbstart, indexend, rgbend);
             indexstart = indexend;
             rgbstart = rgbend;
         }
@@ -970,6 +974,7 @@ public:
     using TColorPalette<CHSV,16>::operator!=;
     using TColorPalette<CHSV,16>::operator[];
     using TColorPalette<CHSV,16>::operator CHSV *;
+    using TColorPalette<CHSV,16>::entries;
 
     CHSVPalette16( const CHSV& c00,const CHSV& c01,const CHSV& c02,const CHSV& c03,
                     const CHSV& c04,const CHSV& c05,const CHSV& c06,const CHSV& c07,
@@ -1012,6 +1017,8 @@ public:
     using TColorPalette<CHSV,32>::operator!=;
     using TColorPalette<CHSV,32>::operator[];
     using TColorPalette<CHSV,32>::operator CHSV *;
+    using TColorPalette<CHSV,32>::entries;
+
     CHSVPalette32( const CHSV& c00,const CHSV& c01,const CHSV& c02,const CHSV& c03,
                   const CHSV& c04,const CHSV& c05,const CHSV& c06,const CHSV& c07,
                   const CHSV& c08,const CHSV& c09,const CHSV& c10,const CHSV& c11,
@@ -1065,6 +1072,8 @@ public:
     using TColorPalette<CHSV,256>::operator!=;
     using TColorPalette<CHSV,256>::operator[];
     using TColorPalette<CHSV,256>::operator CHSV *;
+    using TColorPalette<CHSV,256>::entries;
+
     CHSVPalette256( const CHSV& c00,const CHSV& c01,const CHSV& c02,const CHSV& c03,
                   const CHSV& c04,const CHSV& c05,const CHSV& c06,const CHSV& c07,
                   const CHSV& c08,const CHSV& c09,const CHSV& c10,const CHSV& c11,

--- a/colorutils.h
+++ b/colorutils.h
@@ -513,7 +513,7 @@ template <int size>
 class CRGBPalette : public TColorPalette<CRGB,size>
 {
 public:
-    CRGBPalette() = default; // needed to compile for unknown reason
+    CRGBPalette() = default; // inheritance and using do not inherit a default constructor
     using TColorPalette<CRGB,size>::TColorPalette;
     using TColorPalette<CRGB,size>::operator=;
     using TColorPalette<CRGB,size>::operator==;
@@ -571,7 +571,7 @@ public:
 class CRGBPalette16 : public CRGBPalette<16>
 {
 public:
-    CRGBPalette16() = default; // needed to compile for unknown reason
+    CRGBPalette16() = default; // inheritance and using do not inherit a default constructor
     using CRGBPalette<16>::CRGBPalette;
     using CRGBPalette<16>::operator=;
     using CRGBPalette<16>::operator==;
@@ -721,7 +721,7 @@ public:
 class CRGBPalette32 : public CRGBPalette<32>
 {
 public:
-    CRGBPalette32() = default; // needed to compile for unknown reason
+    CRGBPalette32() = default; // inheritance and using do not inherit a default constructor
     using CRGBPalette<32>::CRGBPalette;
     using CRGBPalette<32>::operator=;
     using CRGBPalette<32>::operator==;
@@ -881,7 +881,7 @@ public:
 class CRGBPalette256 : public CRGBPalette<256>
 {
 public:
-    CRGBPalette256() = default; // needed to compile for unknown reason
+    CRGBPalette256() = default; // inheritance and using do not inherit a default constructor
     using CRGBPalette<256>::CRGBPalette;
     using CRGBPalette<256>::operator=;
     using CRGBPalette<256>::operator==;
@@ -967,7 +967,7 @@ public:
 
 class CHSVPalette16 : public TColorPalette<CHSV,16> {
 public:
-    CHSVPalette16() = default; // needed to compile for unknown reason
+    CHSVPalette16() = default; // inheritance and using do not inherit a default constructor
     using TColorPalette<CHSV,16>::TColorPalette;
     using TColorPalette<CHSV,16>::operator=;
     using TColorPalette<CHSV,16>::operator==;
@@ -1010,7 +1010,7 @@ public:
 
 class CHSVPalette32: public TColorPalette<CHSV,32> {
 public:
-    CHSVPalette32() = default; // needed to compile for unknown reason
+    CHSVPalette32() = default; // inheritance and using do not inherit a default constructor
     using TColorPalette<CHSV,32>::TColorPalette;
     using TColorPalette<CHSV,32>::operator=;
     using TColorPalette<CHSV,32>::operator==;
@@ -1065,7 +1065,7 @@ public:
 
 class CHSVPalette256 : public TColorPalette<CHSV,256> {
 public:
-    CHSVPalette256() = default; // needed to compile for unknown reason
+    CHSVPalette256() = default; // inheritance and using do not inherit a default constructor
     using TColorPalette<CHSV,256>::TColorPalette;
     using TColorPalette<CHSV,256>::operator=;
     using TColorPalette<CHSV,256>::operator==;

--- a/colorutils.h
+++ b/colorutils.h
@@ -452,19 +452,19 @@ public:
         return *this;
     }
 
-    bool operator==( const TColorPalette rhs)
+    bool operator==( const TColorPalette &rhs) const
     {
         const uint8_t* p = (const uint8_t*)(&(this->entries[0]));
         const uint8_t* q = (const uint8_t*)(&(rhs.entries[0]));
         if( p == q) return true;
-        for( uint16_t i = 0; i < size; ++i) {
+        for( uint16_t i = 0; i < sizeof(this->entries); ++i) {
             if( *p != *q) return false;
             ++p;
             ++q;
         }
         return true;
     }
-    bool operator!=( const TColorPalette rhs)
+    bool operator!=( const TColorPalette &rhs) const
     {
         return !( *this == rhs);
     }

--- a/colorutils.h
+++ b/colorutils.h
@@ -409,37 +409,24 @@ typedef TDynamicRGBGradientPalette_bytes TDynamicRGBGradientPalettePtr;
 
 // Fast upscaling functions for palettes, similarities to noblend
 template <typename TSRCPalette, typename TDESTPalette>
-void UpscalePalette(const TSRCPalette &srcpal, TDESTPalette &destpal)
-{
-    constexpr uint16_t srcsize{static_cast<uint16_t>(sizeof(srcpal.entries)/sizeof(srcpal.entries[0]))};
-    constexpr uint16_t destsize{static_cast<uint16_t>(sizeof(destpal.entries)/sizeof(destpal.entries[0]))};
-    constexpr uint16_t steps{destsize/srcsize};
-    for (uint16_t i{0}; i < srcsize; ++i)
-        for (uint16_t j{0}; j < steps; ++j)
-            destpal[i+j] = srcpal[i];
-}
-template void UpscalePalette(const CRGBPalette16 &srcpal, CRGBPalette32 &destpal);
-template void UpscalePalette(const CRGBPalette16 &srcpal, CRGBPalette256 &destpal);
-template void UpscalePalette(const CRGBPalette32 &srcpal, CRGBPalette256 &destpal);
-template void UpscalePalette(const CHSVPalette16 &srcpal, CHSVPalette32 &destpal);
-template void UpscalePalette(const CHSVPalette16 &srcpal, CHSVPalette256 &destpal);
-template void UpscalePalette(const CHSVPalette32 &srcpal, CHSVPalette256 &destpal);
+void UpscalePalette(const TSRCPalette &srcpal, TDESTPalette &destpal);
+extern template void UpscalePalette(const CRGBPalette16 &srcpal, CRGBPalette32 &destpal);
+extern template void UpscalePalette(const CRGBPalette16 &srcpal, CRGBPalette256 &destpal);
+extern template void UpscalePalette(const CRGBPalette32 &srcpal, CRGBPalette256 &destpal);
+extern template void UpscalePalette(const CHSVPalette16 &srcpal, CHSVPalette32 &destpal);
+extern template void UpscalePalette(const CHSVPalette16 &srcpal, CHSVPalette256 &destpal);
+extern template void UpscalePalette(const CHSVPalette32 &srcpal, CHSVPalette256 &destpal);
 
 // High res upscaling function for palettes
 // as ColorFromPalette only takes uint8_t limit the destsize to 256
 template <typename TSRCPalette, typename TDESTPalette>
-void UpscalePaletteInterpolated(const TSRCPalette &srcpal, TDESTPalette &destpal)
-{
-    constexpr uint16_t size{static_cast<uint16_t>(sizeof(destpal.entries)/sizeof(destpal.entries[0]))};
-    for (uint16_t i{0}; i < size; ++i)
-        destpal[i] = ColorFromPalette(srcpal, static_cast<uint8_t>(i));
-}
-template void UpscalePaletteInterpolated(const CRGBPalette16 &srcpal, CRGBPalette32 &destpal);
-template void UpscalePaletteInterpolated(const CRGBPalette16 &srcpal, CRGBPalette256 &destpal);
-template void UpscalePaletteInterpolated(const CRGBPalette32 &srcpal, CRGBPalette256 &destpal);
-template void UpscalePaletteInterpolated(const CHSVPalette16 &srcpal, CHSVPalette32 &destpal);
-template void UpscalePaletteInterpolated(const CHSVPalette16 &srcpal, CHSVPalette256 &destpal);
-template void UpscalePaletteInterpolated(const CHSVPalette32 &srcpal, CHSVPalette256 &destpal);
+void UpscalePaletteInterpolated(const TSRCPalette &srcpal, TDESTPalette &destpal);
+extern template void UpscalePaletteInterpolated(const CRGBPalette16 &srcpal, CRGBPalette32 &destpal);
+extern template void UpscalePaletteInterpolated(const CRGBPalette16 &srcpal, CRGBPalette256 &destpal);
+extern template void UpscalePaletteInterpolated(const CRGBPalette32 &srcpal, CRGBPalette256 &destpal);
+extern template void UpscalePaletteInterpolated(const CHSVPalette16 &srcpal, CHSVPalette32 &destpal);
+extern template void UpscalePaletteInterpolated(const CHSVPalette16 &srcpal, CHSVPalette256 &destpal);
+extern template void UpscalePaletteInterpolated(const CHSVPalette32 &srcpal, CHSVPalette256 &destpal);
 
 template<typename TColor, int size>
 class TColorPalette

--- a/colorutils.h
+++ b/colorutils.h
@@ -536,7 +536,7 @@ template <int size>
 class CRGBPalette : public TColorPalette<CRGB,size>
 {
 public:
-    CRGBPalette() = default; // inheritance and using do not inherit a default constructor
+    CRGBPalette() = default; 
     using TColorPalette<CRGB,size>::TColorPalette;
     using TColorPalette<CRGB,size>::operator=;
     using TColorPalette<CRGB,size>::operator==;
@@ -594,7 +594,7 @@ public:
 class CRGBPalette16 : public CRGBPalette<16>
 {
 public:
-    CRGBPalette16() = default; // inheritance and using do not inherit a default constructor
+    CRGBPalette16() = default; 
     using CRGBPalette<16>::CRGBPalette;
     using CRGBPalette<16>::operator=;
     using CRGBPalette<16>::operator==;
@@ -741,7 +741,7 @@ public:
 class CRGBPalette32 : public CRGBPalette<32>
 {
 public:
-    CRGBPalette32() = default; // inheritance and using do not inherit a default constructor
+    CRGBPalette32() = default; 
     using CRGBPalette<32>::CRGBPalette;
     using CRGBPalette<32>::operator=;
     using CRGBPalette<32>::operator==;
@@ -896,7 +896,7 @@ public:
 class CRGBPalette256 : public CRGBPalette<256>
 {
 public:
-    CRGBPalette256() = default; // inheritance and using do not inherit a default constructor
+    CRGBPalette256() = default; 
     using CRGBPalette<256>::CRGBPalette;
     using CRGBPalette<256>::operator=;
     using CRGBPalette<256>::operator==;
@@ -984,7 +984,7 @@ public:
 
 class CHSVPalette16 : public TColorPalette<CHSV,16> {
 public:
-    CHSVPalette16() = default; // inheritance and using do not inherit a default constructor
+    CHSVPalette16() = default; 
     using TColorPalette<CHSV,16>::TColorPalette;
     using TColorPalette<CHSV,16>::operator=;
     using TColorPalette<CHSV,16>::operator==;
@@ -1028,7 +1028,7 @@ public:
 
 class CHSVPalette32: public TColorPalette<CHSV,32> {
 public:
-    CHSVPalette32() = default; // inheritance and using do not inherit a default constructor
+    CHSVPalette32() = default; 
     using TColorPalette<CHSV,32>::TColorPalette;
     using TColorPalette<CHSV,32>::operator=;
     using TColorPalette<CHSV,32>::operator==;
@@ -1082,7 +1082,7 @@ public:
 
 class CHSVPalette256 : public TColorPalette<CHSV,256> {
 public:
-    CHSVPalette256() = default; // inheritance and using do not inherit a default constructor
+    CHSVPalette256() = default; 
     using TColorPalette<CHSV,256>::TColorPalette;
     using TColorPalette<CHSV,256>::operator=;
     using TColorPalette<CHSV,256>::operator==;

--- a/colorutils.h
+++ b/colorutils.h
@@ -15,50 +15,39 @@ FASTLED_NAMESPACE_BEGIN
 
 /// fill_solid -   fill a range of LEDs with a solid color
 ///                Example: fill_solid( leds, NUM_LEDS, CRGB(50,0,200));
-void fill_solid( struct CRGB * leds, int numToFill,
-                 const struct CRGB& color);
+inline void fill_solid(CRGB *target, int numTarget, const CRGB& color)
+{
+    for (int i{0}; i < numTarget; ++i)
+        target[i] = color;
+}
 
 /// fill_solid -   fill a range of LEDs with a solid color
-///                Example: fill_solid( leds, NUM_LEDS, CRGB(50,0,200));
-void fill_solid( struct CHSV* targetArray, int numToFill,
-				 const struct CHSV& hsvColor);
+///                Example: fill_solid( leds, NUM_LEDS, CHSV(50,0,200));
+inline void fill_solid(CHSV *target, int numTarget, const CHSV& color)
+{
+    for (int i{0}; i < numTarget; ++i)
+        target[i] = color;
+}
 
 
 /// fill_rainbow - fill a range of LEDs with a rainbow of colors, at
 ///                full saturation and full value (brightness)
-void fill_rainbow( struct CRGB * pFirstLED, int numToFill,
+template<typename TColor>
+void fill_rainbow( TColor * pFirstLED, int numToFill,
                    uint8_t initialhue,
-                   uint8_t deltahue = 5);
-
-/// fill_rainbow - fill a range of LEDs with a rainbow of colors, at
-///                full saturation and full value (brightness)
-void fill_rainbow( struct CHSV * targetArray, int numToFill,
-                   uint8_t initialhue,
-                   uint8_t deltahue = 5);
-
-
-// fill_gradient - fill an array of colors with a smooth HSV gradient
-//                 between two specified HSV colors.
-//                 Since 'hue' is a value around a color wheel,
-//                 there are always two ways to sweep from one hue
-//                 to another.
-//                 This function lets you specify which way you want
-//                 the hue gradient to sweep around the color wheel:
-//                   FORWARD_HUES: hue always goes clockwise
-//                   BACKWARD_HUES: hue always goes counter-clockwise
-//                   SHORTEST_HUES: hue goes whichever way is shortest
-//                   LONGEST_HUES: hue goes whichever way is longest
-//                 The default is SHORTEST_HUES, as this is nearly
-//                 always what is wanted.
-//
-// fill_gradient can write the gradient colors EITHER
-//     (1) into an array of CRGBs (e.g., into leds[] array, or an RGB Palette)
-//   OR
-//     (2) into an array of CHSVs (e.g. an HSV Palette).
-//
-//   In the case of writing into a CRGB array, the gradient is
-//   computed in HSV space, and then HSV values are converted to RGB
-//   as they're written into the RGB array.
+                   uint8_t deltahue = 5)
+                   {
+                    CHSV hsv;
+                        hsv.hue = initialhue;
+                        hsv.val = 255;
+                        hsv.sat = 255;
+                        for( int i = 0; i < numToFill; ++i) {
+                            pFirstLED[i] = hsv;
+                            hsv.hue += deltahue;
+                        }
+                   }
+template void fill_rainbow(CRGB * pFirstLED, int numToFill, uint8_t initialhue, uint8_t deltahue);
+template void fill_rainbow(CHSV * pFirstLED, int numToFill, uint8_t initialhue, uint8_t deltahue);
 
 typedef enum { FORWARD_HUES, BACKWARD_HUES, SHORTEST_HUES, LONGEST_HUES } TGradientDirectionCode;
 
@@ -211,22 +200,17 @@ void fill_gradient( T* targetArray, uint16_t numLeds,
     fill_gradient( targetArray, twothirds, c3,      last, c4, directionCode);
 }
 
-// convenience synonym
-#define fill_gradient_HSV fill_gradient
-
-
-// fill_gradient_RGB - fill a range of LEDs with a smooth RGB gradient
+// fill_gradient - fill a range of LEDs with a smooth RGB gradient
 //                     between two specified RGB colors.
 //                     Unlike HSV, there is no 'color wheel' in RGB space,
 //                     and therefore there's only one 'direction' for the
 //                     gradient to go, and no 'direction code' is needed.
-void fill_gradient_RGB( CRGB* leds,
+void fill_gradient( CRGB* leds,
                        uint16_t startpos, CRGB startcolor,
                        uint16_t endpos,   CRGB endcolor );
-void fill_gradient_RGB( CRGB* leds, uint16_t numLeds, const CRGB& c1, const CRGB& c2);
-void fill_gradient_RGB( CRGB* leds, uint16_t numLeds, const CRGB& c1, const CRGB& c2, const CRGB& c3);
-void fill_gradient_RGB( CRGB* leds, uint16_t numLeds, const CRGB& c1, const CRGB& c2, const CRGB& c3, const CRGB& c4);
-
+void fill_gradient( CRGB* leds, uint16_t numLeds, const CRGB& c1, const CRGB& c2);
+void fill_gradient( CRGB* leds, uint16_t numLeds, const CRGB& c1, const CRGB& c2, const CRGB& c3);
+void fill_gradient( CRGB* leds, uint16_t numLeds, const CRGB& c1, const CRGB& c2, const CRGB& c3, const CRGB& c4);
 
 // fadeLightBy and fade_video - reduce the brightness of an array
 //                              of pixels all at once.  Guaranteed
@@ -514,15 +498,15 @@ public:
     }
     TColorPalette( const TColor& c1, const TColor& c2)
     {
-        fill_gradient_RGB( &(entries[0]), size, c1, c2);
+        fill_gradient( &(entries[0]), size, c1, c2);
     }
     TColorPalette( const TColor& c1, const TColor& c2, const TColor& c3)
     {
-        fill_gradient_RGB( &(entries[0]), size, c1, c2, c3);
+        fill_gradient( &(entries[0]), size, c1, c2, c3);
     }
     TColorPalette( const TColor& c1, const TColor& c2, const TColor& c3, const TColor& c4)
     {
-        fill_gradient_RGB( &(entries[0]), size, c1, c2, c3, c4);
+        fill_gradient( &(entries[0]), size, c1, c2, c3, c4);
     }
 };
 
@@ -805,7 +789,7 @@ public:
                 }
                 lastSlotUsed = iend8;
             }
-            fill_gradient_RGB( &(this->entries[0]), istart8, rgbstart, iend8, rgbend);
+            fill_gradient( &(this->entries[0]), istart8, rgbstart, iend8, rgbend);
             indexstart = indexend;
             rgbstart = rgbend;
         }
@@ -848,7 +832,7 @@ public:
                 }
                 lastSlotUsed = iend8;
             }
-            fill_gradient_RGB( &(this->entries[0]), istart8, rgbstart, iend8, rgbend);
+            fill_gradient( &(this->entries[0]), istart8, rgbstart, iend8, rgbend);
             indexstart = indexend;
             rgbstart = rgbend;
         }
@@ -963,7 +947,7 @@ public:
                 }
                 lastSlotUsed = iend8;
             }
-            fill_gradient_RGB( &(this->entries[0]), istart8, rgbstart, iend8, rgbend);
+            fill_gradient( &(this->entries[0]), istart8, rgbstart, iend8, rgbend);
             indexstart = indexend;
             rgbstart = rgbend;
         }
@@ -1006,14 +990,13 @@ public:
                 }
                 lastSlotUsed = iend8;
             }
-            fill_gradient_RGB( &(this->entries[0]), istart8, rgbstart, iend8, rgbend);
+            fill_gradient( &(this->entries[0]), istart8, rgbstart, iend8, rgbend);
             indexstart = indexend;
             rgbstart = rgbend;
         }
         return *this;
     }
 };
-
 
 class CRGBPalette256 : public CRGBPalette<256>
 {
@@ -1072,7 +1055,7 @@ public:
             u.dword = FL_PGM_READ_DWORD_NEAR( progent);
             int indexend  = u.index;
             CRGB rgbend( u.r, u.g, u.b);
-            fill_gradient_RGB( &(this->entries[0]), indexstart, rgbstart, indexend, rgbend);
+            fill_gradient( &(this->entries[0]), indexstart, rgbstart, indexend, rgbend);
             indexstart = indexend;
             rgbstart = rgbend;
         }
@@ -1091,7 +1074,7 @@ public:
             u = *ent;
             int indexend  = u.index;
             CRGB rgbend( u.r, u.g, u.b);
-            fill_gradient_RGB( &(this->entries[0]), indexstart, rgbstart, indexend, rgbend);
+            fill_gradient( &(this->entries[0]), indexstart, rgbstart, indexend, rgbend);
             indexstart = indexend;
             rgbstart = rgbend;
         }

--- a/colorutils.h
+++ b/colorutils.h
@@ -438,7 +438,31 @@ public:
                     const TColor& c04,const TColor& c05,const TColor& c06,const TColor& c07,
                     const TColor& c08,const TColor& c09,const TColor& c10,const TColor& c11,
                     const TColor& c12,const TColor& c13,const TColor& c14,const TColor& c15 )
-    {};
+    {
+        if (size == 16)
+        {
+            entries[0]= c00; entries[1]= c01; entries[2]= c02; entries[3]= c03;
+            entries[4]= c04; entries[5]= c05; entries[6]= c06; entries[7]= c07;
+            entries[8]= c08; entries[9]= c09; entries[10]=c10; entries[11]=c11;
+            entries[12]=c12; entries[13]=c13; entries[14]=c14; entries[15]=c15;
+        }
+        else if (size == 32)
+        {
+            for( uint8_t i = 0; i < 2; i++) 
+            {
+                entries[0+i]= c00; entries[2+i]= c01; entries[4+i]= c02; entries[6+i]= c03;
+                entries[8+i]= c04; entries[10+i]=c05; entries[12+i]=c06; entries[14+i]=c07;
+                entries[16+i]=c08; entries[18+i]=c09; entries[20+i]=c10; entries[22+i]=c11;
+                entries[24+i]=c12; entries[26+i]=c13; entries[28+i]=c14; entries[30+i]=c15;
+            }
+        }
+        else 
+        {
+            TColorPalette<TColor,16> p16( c00,c01,c02,c03,c04,c05,c06,c07,
+                                        c08,c09,c10,c11,c12,c13,c14,c15);
+            *this = p16;
+        }
+    };
 
     TColorPalette( const TColor rhs[size])
     {
@@ -578,17 +602,6 @@ public:
     using CRGBPalette<16>::operator[];
     using CRGBPalette<16>::operator CRGB *;
     using CRGBPalette<16>::entries;
-    
-    CRGBPalette16( const CRGB& c00,const CRGB& c01,const CRGB& c02,const CRGB& c03,
-                    const CRGB& c04,const CRGB& c05,const CRGB& c06,const CRGB& c07,
-                    const CRGB& c08,const CRGB& c09,const CRGB& c10,const CRGB& c11,
-                    const CRGB& c12,const CRGB& c13,const CRGB& c14,const CRGB& c15 )
-    {
-        entries[0]=c00; entries[1]=c01; entries[2]=c02; entries[3]=c03;
-        entries[4]=c04; entries[5]=c05; entries[6]=c06; entries[7]=c07;
-        entries[8]=c08; entries[9]=c09; entries[10]=c10; entries[11]=c11;
-        entries[12]=c12; entries[13]=c13; entries[14]=c14; entries[15]=c15;
-    };
 
     CRGBPalette16( const CRGBPalette16& rhs)
     {
@@ -736,19 +749,6 @@ public:
     using CRGBPalette<32>::operator[];
     using CRGBPalette<32>::operator CRGB *;
     using CRGBPalette<32>::entries;
-    
-    CRGBPalette32( const CRGB& c00,const CRGB& c01,const CRGB& c02,const CRGB& c03,
-                  const CRGB& c04,const CRGB& c05,const CRGB& c06,const CRGB& c07,
-                  const CRGB& c08,const CRGB& c09,const CRGB& c10,const CRGB& c11,
-                  const CRGB& c12,const CRGB& c13,const CRGB& c14,const CRGB& c15 )
-    {
-        for( uint8_t i = 0; i < 2; i++) {
-            entries[0+i]=c00; entries[2+i]=c01; entries[4+i]=c02; entries[6+i]=c03;
-            entries[8+i]=c04; entries[10+i]=c05; entries[12+i]=c06; entries[14+i]=c07;
-            entries[16+i]=c08; entries[18+i]=c09; entries[20+i]=c10; entries[22+i]=c11;
-            entries[24+i]=c12; entries[26+i]=c13; entries[28+i]=c14; entries[30+i]=c15;
-        }
-    };
 
     CRGBPalette32( const CRGBPalette32& rhs)
     {
@@ -905,16 +905,6 @@ public:
     using CRGBPalette<256>::operator CRGB *;
     using CRGBPalette<256>::entries;
 
-    CRGBPalette256( const CRGB& c00,const CRGB& c01,const CRGB& c02,const CRGB& c03,
-                  const CRGB& c04,const CRGB& c05,const CRGB& c06,const CRGB& c07,
-                  const CRGB& c08,const CRGB& c09,const CRGB& c10,const CRGB& c11,
-                  const CRGB& c12,const CRGB& c13,const CRGB& c14,const CRGB& c15 )
-    {
-        CRGBPalette16 p16(c00,c01,c02,c03,c04,c05,c06,c07,
-                          c08,c09,c10,c11,c12,c13,c14,c15);
-        *this = p16;
-    };
-
     CRGBPalette256( const CRGBPalette256& rhs)
     {
         memmove8( &(entries[0]), &(rhs.entries[0]), sizeof(entries));
@@ -1003,17 +993,6 @@ public:
     using TColorPalette<CHSV,16>::operator CHSV *;
     using TColorPalette<CHSV,16>::entries;
 
-    CHSVPalette16( const CHSV& c00,const CHSV& c01,const CHSV& c02,const CHSV& c03,
-                    const CHSV& c04,const CHSV& c05,const CHSV& c06,const CHSV& c07,
-                    const CHSV& c08,const CHSV& c09,const CHSV& c10,const CHSV& c11,
-                    const CHSV& c12,const CHSV& c13,const CHSV& c14,const CHSV& c15 )
-    {
-        entries[0]=c00; entries[1]=c01; entries[2]=c02; entries[3]=c03;
-        entries[4]=c04; entries[5]=c05; entries[6]=c06; entries[7]=c07;
-        entries[8]=c08; entries[9]=c09; entries[10]=c10; entries[11]=c11;
-        entries[12]=c12; entries[13]=c13; entries[14]=c14; entries[15]=c15;
-    };
-
     CHSVPalette16( const CHSVPalette16& rhs)
     {
         memmove8( &(entries[0]), &(rhs.entries[0]), sizeof(entries));
@@ -1057,19 +1036,6 @@ public:
     using TColorPalette<CHSV,32>::operator[];
     using TColorPalette<CHSV,32>::operator CHSV *;
     using TColorPalette<CHSV,32>::entries;
-
-    CHSVPalette32( const CHSV& c00,const CHSV& c01,const CHSV& c02,const CHSV& c03,
-                  const CHSV& c04,const CHSV& c05,const CHSV& c06,const CHSV& c07,
-                  const CHSV& c08,const CHSV& c09,const CHSV& c10,const CHSV& c11,
-                  const CHSV& c12,const CHSV& c13,const CHSV& c14,const CHSV& c15 )
-    {
-        for( uint8_t i = 0; i < 2; ++i) {
-            entries[0+i]=c00; entries[2+i]=c01; entries[4+i]=c02; entries[6+i]=c03;
-            entries[8+i]=c04; entries[10+i]=c05; entries[12+i]=c06; entries[14+i]=c07;
-            entries[16+i]=c08; entries[18+i]=c09; entries[20+i]=c10; entries[22+i]=c11;
-            entries[24+i]=c12; entries[26+i]=c13; entries[28+i]=c14; entries[30+i]=c15;
-        }
-    };
 
     CHSVPalette32( const CHSVPalette32& rhs)
     {
@@ -1124,16 +1090,6 @@ public:
     using TColorPalette<CHSV,256>::operator[];
     using TColorPalette<CHSV,256>::operator CHSV *;
     using TColorPalette<CHSV,256>::entries;
-
-    CHSVPalette256( const CHSV& c00,const CHSV& c01,const CHSV& c02,const CHSV& c03,
-                  const CHSV& c04,const CHSV& c05,const CHSV& c06,const CHSV& c07,
-                  const CHSV& c08,const CHSV& c09,const CHSV& c10,const CHSV& c11,
-                  const CHSV& c12,const CHSV& c13,const CHSV& c14,const CHSV& c15 )
-    {
-        CHSVPalette16 p16(c00,c01,c02,c03,c04,c05,c06,c07,
-                          c08,c09,c10,c11,c12,c13,c14,c15);
-        *this = p16;
-    };
 
     CHSVPalette256( const CHSVPalette256& rhs)
     {

--- a/keywords.txt
+++ b/keywords.txt
@@ -128,7 +128,6 @@ fadeToBlackBy	KEYWORD2
 fade_raw	KEYWORD2
 fade_video	KEYWORD2
 fill_gradient	KEYWORD2
-fill_gradient_RGB	KEYWORD2
 fill_palette	KEYWORD2
 fill_rainbow	KEYWORD2
 fill_solid	KEYWORD2

--- a/keywords.txt
+++ b/keywords.txt
@@ -128,6 +128,8 @@ fadeToBlackBy	KEYWORD2
 fade_raw	KEYWORD2
 fade_video	KEYWORD2
 fill_gradient	KEYWORD2
+fill_gradient_RGB	KEYWORD2
+fill_gradient_HSV	KEYWORD2
 fill_palette	KEYWORD2
 fill_rainbow	KEYWORD2
 fill_solid	KEYWORD2

--- a/pixelset.h
+++ b/pixelset.h
@@ -199,7 +199,7 @@ public:
     return *this;
   }
 
-  inline CPixelView & fill_gradient_RGB(const PIXEL_TYPE & startcolor, const PIXEL_TYPE & endcolor, TGradientDirectionCode directionCode  = SHORTEST_HUES) {
+  inline CPixelView & fill_gradient_RGB(const PIXEL_TYPE & startcolor, const PIXEL_TYPE & endcolor) {
     if(dir >= 0) {
       ::fill_gradient(leds,len,startcolor, endcolor);
     } else {

--- a/pixelset.h
+++ b/pixelset.h
@@ -201,27 +201,27 @@ public:
 
   inline CPixelView & fill_gradient_RGB(const PIXEL_TYPE & startcolor, const PIXEL_TYPE & endcolor, TGradientDirectionCode directionCode  = SHORTEST_HUES) {
     if(dir >= 0) {
-      ::fill_gradient_RGB(leds,len,startcolor, endcolor);
+      ::fill_gradient(leds,len,startcolor, endcolor);
     } else {
-      ::fill_gradient_RGB(leds + len + 1, (-len), endcolor, startcolor);
+      ::fill_gradient(leds + len + 1, (-len), endcolor, startcolor);
     }
     return *this;
   }
 
   inline CPixelView & fill_gradient_RGB(const PIXEL_TYPE & c1, const PIXEL_TYPE & c2, const PIXEL_TYPE &  c3) {
     if(dir >= 0) {
-      ::fill_gradient_RGB(leds, len, c1, c2, c3);
+      ::fill_gradient(leds, len, c1, c2, c3);
     } else {
-      ::fill_gradient_RGB(leds + len + 1, -len, c3, c2, c1);
+      ::fill_gradient(leds + len + 1, -len, c3, c2, c1);
     }
     return *this;
   }
 
   inline CPixelView & fill_gradient_RGB(const PIXEL_TYPE & c1, const PIXEL_TYPE & c2, const PIXEL_TYPE & c3, const PIXEL_TYPE & c4) {
     if(dir >= 0) {
-      ::fill_gradient_RGB(leds, len, c1, c2, c3, c4);
+      ::fill_gradient(leds, len, c1, c2, c3, c4);
     } else {
-      ::fill_gradient_RGB(leds + len + 1, -len, c4, c3, c2, c1);
+      ::fill_gradient(leds + len + 1, -len, c4, c3, c2, c1);
     }
     return *this;
   }


### PR DESCRIPTION
Alright this one is a bit bigger, maybe too big :) so I know it will take time to go through the changes. I've been sitting on this since april and rebased the commits recently so here we go.

@kriegsman looking at the commits this is your code.

This started as an idea that the palettes are very similar/the same in their implementation and that it would be better to make them have a base class to avoid code duplication and slight differences between them. The CRGBPalettes have the CRGBPalette<size> to inherit from, so they inherit the things from TColorPalette as well as constructors for CHSV colors and palettes.

Do note that there are no virtual functions/operators/constructors. The inheritance makes it look look like we call multiple constructors when we use the ones from TColorPalette. That is true when compiling with -O0 (i.e. no optimization), but even -Os optimizes this away (should be default for embedded ide's).

[proof of concept for no hit in speed](https://godbolt.org/z/Qde-os) (orange means warnings, this is because -std=c++11 or -std=gnu++11 is not set (all green if set), default in Arduino IDE since 1.6.6 and it was also default for me in platformio, so should be default for all relatively up to date environments) (note: only use x86 compilers, as I've used std::time in this example to make sure the constructors wont get optimized too far). You can inspect the generated code on the right, if you specify any optimization level other than -O0 there are no calls to constructors from base classes.

### Basics:
Color palettes inherit from a common template class base, to make the color palette implementations more consistent and avoid code duplication. Examples of differences between palettes in the current implementation:
- all CHSVPalettes have no copy assignment constructor and assignment for CHSV[16/32/256].
- missing upscaling constructors in CHSVPalettes (with this easier to see them).
- UpscalePalette functions do different things for different palettes

### Changes:
- TColorPalette<typename TColor, int size> is the base class that all palettes inherit from
- CRGBPalette\<int size> is a proxy class that acts as a base for all CRGBPalettes to allow for construction and assignment from CHSV colors and palettes
- each palette has to define their own default constructor and copy constructors and assignments as well as a destructor
- use references for the comparison operator of all palettes, before this, every time a palette gets compared to another a copy of one of the palettes would be made
- const args for subscript [] operator
- generic versions of UpscalePalette and one that Interpolates the values like in the current XPalette256 upscaling versions. Making it explicit what version is used in the upscaling constructors for the palettes, and when used on their own (for XPalette256's this could change the behavior of older code).
- moved fill_solid implementations into header (no reason)
- made fill_rainbow generic
- renamed fill_gradient_RGB to fill_gradient and removed fill_gradient_HSV synonym
- removed directionCode from CPixelViews fill_gradient_RGB (and renamed fill_gradient functions to comply with removal of _CRGB and _CHSV synonyms)
- note: I've implemented #943 as well (please merge that pr first to give credit)

### Things to discuss:
- UpscalePalette-/Interpolate: older user code can observe a change in behavior when using the UpscalePalette function with a 256 entry palette (using the constructors of the palettes do the same thing though).
- UpscalePalette-/Interpolate: I've decided to make the instantiated functions extern to avoid users to make either downscaling calls or plain copy calls that could be costly. The current implementation throws linkage errors upon misuse. Another way would be to allow what I've said before, and just trust the user. Then it would be possible to convert CHSVPalettes into CRGB ones, by implicit conversion of the entries/calculated colors. Undefined conversions would give a compilation error and downscaling/copy calls would just work, but a static_assert could check for size differences between src and dest. Note that fill_rainbow is not that restrictive, so maybe we should just trust the user.
- fill_gradient: I have a commit ready that reintroduces the fill_gradient_RGB and fill_gradient_HSV synonyms via always inlined functions. I guess that would be better as to not break user code. The reason why I changed it in the first place was to allow for overload resolution to pick the correct constructor for the inherited TColorPalette constructors.

### Moving forward
<details><summary>Definition of the CHSVPalette16 as an example</summary>

```cpp
class CHSVPalette16 : public TColorPalette<CHSV,16> {
public:
    CHSVPalette16() = default; 
    using TColorPalette<CHSV,16>::TColorPalette;
    using TColorPalette<CHSV,16>::operator=;
    using TColorPalette<CHSV,16>::operator==;
    using TColorPalette<CHSV,16>::operator!=;
    using TColorPalette<CHSV,16>::operator[];
    using TColorPalette<CHSV,16>::operator CHSV *;
    using TColorPalette<CHSV,16>::entries;

    CHSVPalette16( const CHSVPalette16& rhs) : TColorPalette<CHSV,16>()
    {
        memmove8( &(entries[0]), &(rhs.entries[0]), sizeof(entries));
    }    
    CHSVPalette16& operator=( const CHSVPalette16& rhs)
    {
        memmove8( &(entries[0]), &(rhs.entries[0]), sizeof(entries));
        return *this;
    }

    ~CHSVPalette16() = default;

    CHSVPalette16( const TProgmemHSVPalette16& rhs)
    {
        for( uint8_t i = 0; i < 16; ++i) {
            CRGB xyz   =  FL_PGM_READ_DWORD_NEAR( rhs + i);
            entries[i].hue = xyz.red;
            entries[i].sat = xyz.green;
            entries[i].val = xyz.blue;
        }
    }
    CHSVPalette16& operator=( const TProgmemHSVPalette16& rhs)
    {
        for( uint8_t i = 0; i < 16; ++i) {
            CRGB xyz   =  FL_PGM_READ_DWORD_NEAR( rhs + i);
            entries[i].hue = xyz.red;
            entries[i].sat = xyz.green;
            entries[i].val = xyz.blue;
        }
        return *this;
    }
};
```
</details>

This could also proof useful for the future when CRGBW get's introduced (I know you guys are currently working on it), as the amount of things to define is greatly reduced. The above example (maybe without the progmem part) could be quite similar to a CRGBWPalette16. The only things left to do after defining the palette like above would be declaring the upscaling functions (way of declaration and if needed depends on discussion) and defining fill_gradient functions, as well as the ColorFromPalette functions of course (no change here).

 
### Test
<details><summary>code used to test the implementation (note does not compile on current master bc of the mentioned missing constructors)</summary>

```cpp
#include <FastLED.h>

#ifdef ESP32_1
#define NUM_LEDS 194
#pragma message "ESP32_1"

#elif defined ESP32_2
#define NUM_LEDS 17
#pragma message "ESP32_2"

#elif defined ESP32_3
#define NUM_LEDS 6
#pragma message "ESP32_3"

#endif

//LEDS
#define DATA_PIN 19
const int delay_amt{250};

CRGB *leds = (CRGB *)malloc(NUM_LEDS * sizeof(CRGB));
int brightness = 255;

template <typename TPalette, typename TColor, int size>
void testCopySemantics()
{
  printf("\t\ttesting copy semantics\n");
  TPalette defaultConstr;
  TPalette copyConstruction(defaultConstr);
  TPalette copyAssignment = copyConstruction;
  copyAssignment = copyConstruction;
  assert(copyAssignment == copyConstruction);
  assert(copyAssignment == defaultConstr);
  assert(copyConstruction == defaultConstr);
}

template <typename TPalette, typename TColor>
void testMoveConstruction()
{
  printf("\t\ttesting move semantics\n");
  TPalette p(TColor(0, 0, 0),
             TColor(255, 255, 255));
  TPalette p_bckp{p};
  TPalette p_bckp_assign{p};
  TPalette p2{std::move(p)};
  TPalette p3;
  p3 = std::move(p_bckp_assign);
  assert(p_bckp == p2);
  assert(p_bckp == p3);
}

template <typename TPalette, typename TColor, int size>
void testConstructionFromColorObj()
{
  printf("\t\ttesting construction from color objects\n");
  TPalette singleColor(TColor(1, 1, 1));
  TPalette twoColors(TColor(1, 1, 1),
                     TColor(1, 1, 1));
  TPalette threeColors(TColor(1, 1, 1),
                       TColor(1, 1, 1),
                       TColor(1, 1, 1));
  TPalette fourColors(TColor(1, 1, 1),
                      TColor(1, 1, 1),
                      TColor(1, 1, 1),
                      TColor(1, 1, 1));
  assert(singleColor == twoColors);
  assert(singleColor == threeColors);
  assert(singleColor == fourColors);
}

template <typename TPalette, typename TColor, int size>
void testArrayConstruction()
{
  printf("\t\ttesting construction from color array\n");
  TPalette defaultConstr;
  TColor colorArray[size];
  for (int i{0}; i < size; ++i)
    colorArray[i] = TColor(1, 255, 255);
  TPalette constrFromArray(colorArray);
  TPalette copyAssignmentFromArray;
  copyAssignmentFromArray = colorArray;

  assert(constrFromArray == copyAssignmentFromArray);
  assert(defaultConstr != constrFromArray);
}

void testUpscalingConstructors()
{
  CRGBPalette16 p1{CRGB{1, 1, 1}, CRGB{255, 255, 255}};
  CRGBPalette32 p2{p1};
  CRGBPalette256 p3{p1};
  CRGBPalette256 p8{p2};

  for (auto i{0}; i < 16; ++i)
  {
    assert((CRGB)p1[i] == (CRGB)p2[2 * i]);
    assert((CRGB)p1[i] == (CRGB)p3[16 * i]);
  }

  for (auto i{0}; i < 32; ++i)
  {
    assert(p2[i] == p8[8 * i]);
  }

  CHSVPalette16 p4(CHSV{1, 1, 1}, CHSV{255, 255, 255});
  CHSVPalette32 p5(p4);
  CHSVPalette256 p6(p4);
  CHSVPalette256 p7(p5);

  for (auto i{0}; i < 16; ++i)
  {
    assert(p4[i] == p5[2 * i]);
    assert(p4[i] == p6[16 * i]);
  }

  for (auto i{0}; i < 32; ++i)
  {
    assert(p5[i] == p7[8 * i]);
  }
}

template <typename TPalette, typename TColor, int size>
void testBasePaletteFunctions()
{
  TPalette defaultConstr;
  TPalette defaultConstr2{};
  TPalette constrFrom16(TColor(1, 1, 1), TColor(1, 1, 1), TColor(1, 1, 1), TColor(1, 1, 1),
                        TColor(1, 1, 1), TColor(1, 1, 1), TColor(1, 1, 1), TColor(1, 1, 1),
                        TColor(1, 1, 1), TColor(1, 1, 1), TColor(1, 1, 1), TColor(1, 1, 1),
                        TColor(1, 1, 1), TColor(1, 1, 1), TColor(1, 1, 1), TColor(1, 1, 1));
  for (int i{0}; i < size; ++i)
  {
    leds[0] = constrFrom16[i];
    FastLED.show();
  }

  testCopySemantics<TPalette, TColor, size>();
  testMoveConstruction<TPalette, TColor>();
  testArrayConstruction<TPalette, TColor, size>();
  testConstructionFromColorObj<TPalette, TColor, size>();
}

template <typename TPalette, int size>
void testCRGBPalettes()
{
  printf("\ttesting construction from CRGB objects\n");
  testBasePaletteFunctions<TPalette, CRGB, size>();
  printf("\ttesting construction from CHSV objects\n");
  testArrayConstruction<TPalette, CHSV, size>();
  testConstructionFromColorObj<TPalette, CHSV, size>();
}

template <typename TPalette, int size>
void testCHSVPalettes()
{
  testBasePaletteFunctions<TPalette, CHSV, size>();
}

template <typename TTargetColor, typename TSourceColor>
void test_fill_solid()
{
  TTargetColor l[NUM_LEDS];
  fill_solid(l, NUM_LEDS, TSourceColor(128, 255, 255));
}

template <typename TSourceColor>
void test_fill_solid()
{
  fill_solid(leds, NUM_LEDS, TSourceColor(128, 255, 255));
  FastLED.show();
  delay(delay_amt);
}

template <typename TColor>
void test_fill_rainbow()
{
  TColor l[NUM_LEDS];
  fill_rainbow(l, NUM_LEDS, 12, 255 / NUM_LEDS);
}

template <>
void test_fill_rainbow<CRGB>()
{
  fill_rainbow(leds, NUM_LEDS, 12, 255 / NUM_LEDS);
  FastLED.show();
  delay(delay_amt);
}

template <typename TTargetColor, typename TSourceColor>
void test_fill_gradient()
{
  TTargetColor l[NUM_LEDS];
  fill_gradient(l, 0, TSourceColor(32, 255, 255), NUM_LEDS - 1, TSourceColor(128, 255, 64));
  fill_gradient(l, NUM_LEDS, TSourceColor(32, 255, 255), TSourceColor(128, 255, 64));
  fill_gradient(l, NUM_LEDS, TSourceColor(32, 255, 255), TSourceColor(128, 255, 64), TSourceColor(0, 255, 255));
  fill_gradient(l, NUM_LEDS, TSourceColor(32, 255, 255), TSourceColor(128, 255, 64), TSourceColor(0, 255, 255), TSourceColor(13, 25, 128));
}

template <typename TSourceColor>
void test_fill_gradient()
{
  TSourceColor a(32, 255, 255);
  TSourceColor b(128, 255, 64);
  TSourceColor c(0, 255, 255);
  TSourceColor d(13, 25, 128);
  fill_gradient(leds, 0, a,
                NUM_LEDS - 1, b);
  FastLED.show();
  delay(delay_amt);
  fill_gradient(leds, NUM_LEDS, a, b);
  FastLED.show();
  delay(delay_amt);
  fill_gradient(leds, NUM_LEDS, a, b, c);
  FastLED.show();
  delay(delay_amt);
  fill_gradient(leds, NUM_LEDS, a, b, c, d);
  FastLED.show();
  delay(delay_amt);
}

template <typename TPalette>
void projectPalette(CRGB *leds, const int num_leds, TPalette &p)
{
  for (int i{0}; i < num_leds; ++i)
    leds[i] = ColorFromPalette(p, (i * 255) / num_leds);
}

template <typename TCRGBPalette, typename TCHSVPalette>
void testCrossConstructionCRGB_part1()
{
  printf("\t\tTCHSVPalette p{CHSV(123, 255, 255)}\n");
  TCHSVPalette p{CHSV(123, 255, 255)};
  projectPalette(leds, NUM_LEDS, p);
  FastLED.show();
  delay(delay_amt);

  printf("\t\tTCRGBPalette p1{p}\n");
  TCRGBPalette p1{p};
  projectPalette(leds, NUM_LEDS, p1);
  FastLED.show();
  delay(delay_amt);
  printf("\t\tTCRGBPalette p2 = p\n");
  TCRGBPalette p2 = p;
  projectPalette(leds, NUM_LEDS, p2);
  FastLED.show();
  delay(delay_amt);
  assert(p1 == p2);
}

template <typename TCRGBPalette, typename TCHSVPalette>
void testCrossConstructionCRGB_part2()
{
  TCHSVPalette p;
  constexpr int size{sizeof(p.entries) / sizeof(p.entries[0])};
  CHSV a[size];
  for (int i{0}; i < size; ++i)
    a[i] = CHSV(static_cast<uint8_t>(i), 255, 255);

  printf("\t\tTCRGBPalette p3{a}\n");
  TCRGBPalette p3{a};
  projectPalette(leds, NUM_LEDS, p3);
  FastLED.show();
  delay(delay_amt);
  printf("\t\tTCRGBPalette p4 = a\n");
  TCRGBPalette p4 = a;
  projectPalette(leds, NUM_LEDS, p4);
  FastLED.show();
  delay(delay_amt);
  assert(p3 == p4);
}

template <typename TCRGBPalette, typename TCHSVPalette>
void testCrossConstructionCRGB_part3()
{
  printf("\t\tTCRGBPalette p5{CHSV(64, 200, 255)}\n");
  TCRGBPalette p5{CHSV(0, 200, 255)};
  projectPalette(leds, NUM_LEDS, p5);
  FastLED.show();
  delay(delay_amt);
  printf("\t\tTCRGBPalette p6{CHSV(64, 200, 255), CHSV(12, 255, 255)}\n");
  TCRGBPalette p6{CHSV(64, 200, 255), CHSV(12, 255, 255)};
  projectPalette(leds, NUM_LEDS, p6);
  FastLED.show();
  delay(delay_amt);
  printf("\t\tTCRGBPalette p7{CHSV(64, 200, 255), CHSV(12, 255, 255), CHSV(240, 255, 200)}\n");
  TCRGBPalette p7{CHSV(64, 200, 255), CHSV(12, 255, 255), CHSV(240, 255, 200)};
  projectPalette(leds, NUM_LEDS, p7);
  FastLED.show();
  delay(delay_amt);
  printf("\t\tTCRGBPalette p8{CHSV(64, 200, 255), CHSV(12, 255, 255), CHSV(240, 255, 200), CHSV(240, 255, 200)}\n");
  TCRGBPalette p8{CHSV(64, 200, 255), CHSV(12, 255, 255), CHSV(240, 255, 200), CHSV(240, 255, 200)};
  projectPalette(leds, NUM_LEDS, p8);
  FastLED.show();
  delay(delay_amt);
}

template <typename TCRGBPalette, typename TCHSVPalette>
void testCrossConstructionCRGB()
{
  testCrossConstructionCRGB_part1<TCRGBPalette, TCHSVPalette>();
  testCrossConstructionCRGB_part2<TCRGBPalette, TCHSVPalette>();
  testCrossConstructionCRGB_part3<TCRGBPalette, TCHSVPalette>();
}

void setup()
{
  Serial.begin(115200);
  delay(delay_amt);
  pinMode(BUILTIN_LED, OUTPUT);
  digitalWrite(BUILTIN_LED, HIGH);

  // FastLED
  FastLED.addLeds<WS2812, DATA_PIN, GRB>(leds, NUM_LEDS);
  FastLED.setBrightness(brightness);
  FastLED.setCorrection(TypicalLEDStrip);
  fadeToBlackBy(leds, NUM_LEDS, 255);

  printf("testing CRGBPalette16\n");
  testCRGBPalettes<CRGBPalette16, 16>();
  printf("testing CRGBPalette32\n");
  testCRGBPalettes<CRGBPalette32, 32>();
  printf("testing CRGBPalette256\n");
  testCRGBPalettes<CRGBPalette256, 256>();

  printf("testing CHSVPalette16\n");
  testCHSVPalettes<CHSVPalette16, 16>();
  printf("testing CHSVPalette32\n");
  testCHSVPalettes<CHSVPalette32, 32>();
  printf("testing CHSVPalette256\n");
  testCHSVPalettes<CHSVPalette256, 256>();

  printf("testing UpscalingConstructors\n");
  testUpscalingConstructors();

  printf("testing fill_solid<CRGB, CRGB>\n");
  test_fill_solid<CRGB>();
  printf("testing fill_solid<CRGB, CHSV>\n");
  test_fill_solid<CHSV>();
  printf("testing fill_solid<CHSV, CHSV>\n");
  test_fill_solid<CHSV, CHSV>();

  fadeToBlackBy(leds, NUM_LEDS, 255);

  printf("testing fill_rainbow<CRGB>\n");
  test_fill_rainbow<CRGB>();
  printf("testing fill_rainbow<CHSV>\n");
  test_fill_rainbow<CHSV>();

  fadeToBlackBy(leds, NUM_LEDS, 255);

  printf("testing fill_gradient<CRGB,CRGB>\n");
  test_fill_gradient<CRGB>();
  printf("testing fill_gradient<CRGB,CHSV>\n");
  test_fill_gradient<CHSV>();
  printf("testing fill_gradient<CHSV,CHSV>\n");
  test_fill_gradient<CHSV, CHSV>();

  fadeToBlackBy(leds, NUM_LEDS, 255);

  CRGBPalette16 p1(CRGB(255, 255, 0));
  CRGBPalette16 p2(CHSV(255, 255, 0));
  CHSVPalette16 p3(CHSV(255, 255, 0));
  // CHSVPalette16 p4(CRGB(255, 255, 0)); // error: no matching function for call to 'CHSVPalette16::CHSVPalette16(CRGB)
  // as there is no construction from CRGB to CHSV
  CHSV chsv;
  CRGB crgb;
  CRGBPalette256 p123;
  // UpscalePalette(p123, p1);   // linkage error: undefined reference
  // fill_solid(&chsv, 1, crgb); // error: no matching function for call to 'fill_solid(CHSV*, int, CRGB&)
  fill_solid(&chsv, 1, chsv);
  fill_solid(&crgb, 1, crgb);
  fill_solid(&crgb, 1, chsv);

  printf("testing CrossConstructionCRGB<CRGBPalette16, CHSVPalette16>\n");
  testCrossConstructionCRGB<CRGBPalette16, CHSVPalette16>();
  printf("testing CrossConstructionCRGB<CRGBPalette32, CHSVPalette32>\n");
  testCrossConstructionCRGB<CRGBPalette32, CHSVPalette32>();
  printf("testing CrossConstructionCRGB<CRGBPalette256, CHSVPalette256>\n");
  testCrossConstructionCRGB<CRGBPalette256, CHSVPalette256>();

  printf("tests were successful\n");

  digitalWrite(BUILTIN_LED, LOW);
}

void loop()
{
}

```
</details>

I've tested a lot of parts in compiler explorer using gcc 4.8.1. I've also compared compiled assembly (esp32) (regex to remove all code addresses, bc those would change), of an example (only tested one palette, but only got like 4 changes or so in multiple of tens of thousands of lines).

Note: the diff in github is quite messy, I suggest opening up the branch in another window and comparing with master side by side as well as the diff.

...

Too far? ;D
