### PR TITLE
non linear power scaling

### DIFF
--- a/FastLED.h
+++ b/FastLED.h
@@ -490,7 +490,7 @@ public:
 
 	/// Set the maximum power to be used, given in milliwatts
 	/// @param milliwatts - the max power draw desired, in milliwatts
-	inline void setMaxPowerInMilliWatts(uint32_t milliwatts) { m_pPowerFunc = &calculate_max_brightness_for_power_mW; m_nPowerData = milliwatts; }
+	inline void setMaxPowerInMilliWatts(uint32_t milliwatts) { setupPowerScaleTable(); m_pPowerFunc = &calculate_max_brightness_for_power_mW; m_nPowerData = milliwatts; }
 
 	/// Update all our controllers with the current led colors, using the passed in brightness
 	/// @param scale temporarily override the scale

--- a/power_mgt.cpp
+++ b/power_mgt.cpp
@@ -23,17 +23,17 @@ FASTLED_NAMESPACE_BEGIN
 // be compile-time constants.
 
 constexpr float POWER_EXPONENENT = 0.87; // 50% pwm will result in 0.5^0.87 = 54.7% of power usage
-//constexpr uint8_t gRed_mW   = 16 * 5; // 16mA @ 5v = 80mW
-//constexpr uint8_t gGreen_mW = 11 * 5; // 11mA @ 5v = 55mW
-//constexpr uint8_t gBlue_mW  = 15 * 5; // 15mA @ 5v = 75mW
-//constexpr uint8_t gDark_mW  = 1 * 5;  // 1mA @ 5v = 75mW
+constexpr uint8_t gRed_mW   = 16 * 5; // 16mA @ 5v = 80mW
+constexpr uint8_t gGreen_mW = 11 * 5; // 11mA @ 5v = 55mW
+constexpr uint8_t gBlue_mW  = 15 * 5; // 15mA @ 5v = 75mW
+constexpr uint8_t gDark_mW  = 1 * 5;  // 1mA @ 5v = 75mW
 
 // Alternate measurements for sk6805-1515
 // constexpr float POWER_EXPONENENT = 0.87;
- constexpr uint8_t gRed_mW   = 25;
- constexpr uint8_t gGreen_mW = 18;
- constexpr uint8_t gBlue_mW  = 24;
- constexpr uint8_t gDark_mW  = 4;
+// constexpr uint8_t gRed_mW   = 25;
+// constexpr uint8_t gGreen_mW = 18;
+// constexpr uint8_t gBlue_mW  = 24;
+// constexpr uint8_t gDark_mW  = 4;
 
 // Alternate calibration by RAtkins via pre-PSU wattage measurments;
 // these are all probably about 20%-25% too high due to PSU heat losses,

--- a/power_mgt.cpp
+++ b/power_mgt.cpp
@@ -67,21 +67,21 @@ static uint8_t gMaxPowerIndicatorLEDPinNumber = 0; // default = Arduino onboard 
 
 // if defined, use linear power scaling.
 #ifdef FASTLED_POWER_SCALING_FAST
-inline uint8_t getPowerValue(uint8_t brightness) {
+inline constexpr uint8_t getPowerValue(uint8_t brightness) {
     return brightness;
 }
-inline uint8_t getReversePowerValue(uint8_t brightness_scaled) {
+inline constexpr uint8_t getReversePowerValue(uint8_t brightness_scaled) {
     return brightness_scaled;
 }
 void setupPowerScaleTable() {}
 #else
 #define calcPowerValue(brightness) static_cast<uint8_t>(pow(brightness, POWER_EXPONENENT) * pow(256, 1 - POWER_EXPONENENT))
-inline uint8_t getReversePowerValue(uint8_t brightness_scaled) {
+inline constexpr uint8_t getReversePowerValue(uint8_t brightness_scaled) {
     return static_cast<uint8_t>(pow(brightness_scaled / pow(256, 1 - POWER_EXPONENENT), 1.f/POWER_EXPONENENT));
 }
 // if defined, compute power value each time.
 #ifdef FASTLED_POWER_SCALING_COMPUTE
-inline uint8_t getPowerValue(uint8_t brightness) {
+inline constexpr uint8_t getPowerValue(uint8_t brightness) {
     return calcPowerValue(brightness);
 }
 void setupPowerScaleTable() {}

--- a/power_mgt.cpp
+++ b/power_mgt.cpp
@@ -1,7 +1,6 @@
 #define FASTLED_INTERNAL
 #include "FastLED.h"
 #include "power_mgt.h"
-#include <array>
 
 FASTLED_NAMESPACE_BEGIN
 
@@ -24,17 +23,17 @@ FASTLED_NAMESPACE_BEGIN
 // be compile-time constants.
 
 constexpr float POWER_EXPONENENT = 0.87; // 50% pwm will result in 0.5^0.87 = 54.7% of power usage
-constexpr uint8_t gRed_mW   = 16 * 5; // 16mA @ 5v = 80mW
-constexpr uint8_t gGreen_mW = 11 * 5; // 11mA @ 5v = 55mW
-constexpr uint8_t gBlue_mW  = 15 * 5; // 15mA @ 5v = 75mW
-constexpr uint8_t gDark_mW  = 1 * 5;  // 1mA @ 5v = 75mW
+//constexpr uint8_t gRed_mW   = 16 * 5; // 16mA @ 5v = 80mW
+//constexpr uint8_t gGreen_mW = 11 * 5; // 11mA @ 5v = 55mW
+//constexpr uint8_t gBlue_mW  = 15 * 5; // 15mA @ 5v = 75mW
+//constexpr uint8_t gDark_mW  = 1 * 5;  // 1mA @ 5v = 75mW
 
 // Alternate measurements for sk6805-1515
 // constexpr float POWER_EXPONENENT = 0.87;
-// constexpr uint8_t gRed_mW   = 25;
-// constexpr uint8_t gGreen_mW = 18;
-// constexpr uint8_t gBlue_mW  = 24;
-// constexpr uint8_t gDark_mW  = 4;
+ constexpr uint8_t gRed_mW   = 25;
+ constexpr uint8_t gGreen_mW = 18;
+ constexpr uint8_t gBlue_mW  = 24;
+ constexpr uint8_t gDark_mW  = 4;
 
 // Alternate calibration by RAtkins via pre-PSU wattage measurments;
 // these are all probably about 20%-25% too high due to PSU heat losses,
@@ -44,7 +43,6 @@ constexpr uint8_t gDark_mW  = 1 * 5;  // 1mA @ 5v = 75mW
 //  constexpr uint8_t gGreen_mW =  48;
 //  constexpr uint8_t gBlue_mW  = 100;
 //  constexpr uint8_t gDark_mW  =  12;
-
 
 
 #define POWER_LED 0
@@ -57,7 +55,17 @@ constexpr uint8_t gMCU_mW  =  25 * 5; // 25mA @ 5v = 125 mW
 static uint8_t gMaxPowerIndicatorLEDPinNumber = 0; // default = Arduino onboard LED pin.  set to zero to skip this.
 
 
-// if defined, use linear power scaling. Cheapest but inaccurate (~20%).
+
+// Power scaling has 3 modes:
+// (default)                      builds a 256 byte table in advance with the power scale mappings. Recommended when unsure.
+// FASTLED_POWER_SCALING_COMPUTE  Computes the power scaling on each show() for each led. Recommended when low on memory.
+//                                Can get compute intensive for large amounts of leds.
+// FASTLED_POWER_SCALING_FAST     Uses linear power scaling. Only recommended when low on both memory and compute,
+//                                can result in power draw exceeding the power limits. (up to ~20%)
+
+
+
+// if defined, use linear power scaling.
 #ifdef FASTLED_POWER_SCALING_FAST
 constexpr uint8_t getPowerValue(uint8_t brightness) {
     return brightness;
@@ -65,66 +73,33 @@ constexpr uint8_t getPowerValue(uint8_t brightness) {
 constexpr uint8_t getReversePowerValue(uint8_t brightness_scaled) {
     return brightness_scaled;
 }
+void setupPowerScaleTable() {}
 #else
-#define calcPowerValue(brightness) pow(brightness, POWER_EXPONENENT) * pow(256, 1 - POWER_EXPONENENT)
+#define calcPowerValue(brightness) static_cast<uint8_t>(pow(brightness, POWER_EXPONENENT) * pow(256, 1 - POWER_EXPONENENT))
 constexpr uint8_t getReversePowerValue(uint8_t brightness_scaled) {
-    return pow(brightness_scaled / pow(256, 1 - POWER_EXPONENENT), 1.f/POWER_EXPONENENT);
+    return static_cast<uint8_t>(pow(brightness_scaled / pow(256, 1 - POWER_EXPONENENT), 1.f/POWER_EXPONENENT));
 }
 // if defined, compute power value each time.
 #ifdef FASTLED_POWER_SCALING_COMPUTE
 constexpr uint8_t getPowerValue(uint8_t brightness) {
     return calcPowerValue(brightness);
 }
+void setupPowerScaleTable() {}
 #else
 // precompute values and store them in an array.
+static uint8_t* powerScaleTable = nullptr;
+void setupPowerScaleTable() {
+    if (powerScaleTable != nullptr)
+        return;
+    powerScaleTable = new uint8_t[256];
+    uint8_t i = 0;
+    do {
+        powerScaleTable[i] = calcPowerValue(i);
+    } while (i++ < 255);
+}
 
-#if __cplusplus >= 201700L
-// c++17
-constexpr std::array<uint8_t, 256> POWERTABLE = [] {
-  std::array<uint8_t, 256> A = {};
-  for (unsigned i = 0; i < 256; i++) {
-    A[i] = calcPowerValue(i);
-  }
-  return A;
-}();
-#else
-constexpr std::array<uint8_t, 256> POWERTABLE = {
-    calcPowerValue(0), calcPowerValue(1), calcPowerValue(2), calcPowerValue(3), calcPowerValue(4), calcPowerValue(5), calcPowerValue(6), calcPowerValue(7), 
-    calcPowerValue(8), calcPowerValue(9), calcPowerValue(10), calcPowerValue(11), calcPowerValue(12), calcPowerValue(13), calcPowerValue(14), calcPowerValue(15), 
-    calcPowerValue(16), calcPowerValue(17), calcPowerValue(18), calcPowerValue(19), calcPowerValue(20), calcPowerValue(21), calcPowerValue(22), calcPowerValue(23), 
-    calcPowerValue(24), calcPowerValue(25), calcPowerValue(26), calcPowerValue(27), calcPowerValue(28), calcPowerValue(29), calcPowerValue(30), calcPowerValue(31), 
-    calcPowerValue(32), calcPowerValue(33), calcPowerValue(34), calcPowerValue(35), calcPowerValue(36), calcPowerValue(37), calcPowerValue(38), calcPowerValue(39), 
-    calcPowerValue(40), calcPowerValue(41), calcPowerValue(42), calcPowerValue(43), calcPowerValue(44), calcPowerValue(45), calcPowerValue(46), calcPowerValue(47), 
-    calcPowerValue(48), calcPowerValue(49), calcPowerValue(50), calcPowerValue(51), calcPowerValue(52), calcPowerValue(53), calcPowerValue(54), calcPowerValue(55), 
-    calcPowerValue(56), calcPowerValue(57), calcPowerValue(58), calcPowerValue(59), calcPowerValue(60), calcPowerValue(61), calcPowerValue(62), calcPowerValue(63), 
-    calcPowerValue(64), calcPowerValue(65), calcPowerValue(66), calcPowerValue(67), calcPowerValue(68), calcPowerValue(69), calcPowerValue(70), calcPowerValue(71), 
-    calcPowerValue(72), calcPowerValue(73), calcPowerValue(74), calcPowerValue(75), calcPowerValue(76), calcPowerValue(77), calcPowerValue(78), calcPowerValue(79), 
-    calcPowerValue(80), calcPowerValue(81), calcPowerValue(82), calcPowerValue(83), calcPowerValue(84), calcPowerValue(85), calcPowerValue(86), calcPowerValue(87), 
-    calcPowerValue(88), calcPowerValue(89), calcPowerValue(90), calcPowerValue(91), calcPowerValue(92), calcPowerValue(93), calcPowerValue(94), calcPowerValue(95), 
-    calcPowerValue(96), calcPowerValue(97), calcPowerValue(98), calcPowerValue(99), calcPowerValue(100), calcPowerValue(101), calcPowerValue(102), calcPowerValue(103), 
-    calcPowerValue(104), calcPowerValue(105), calcPowerValue(106), calcPowerValue(107), calcPowerValue(108), calcPowerValue(109), calcPowerValue(110), calcPowerValue(111), 
-    calcPowerValue(112), calcPowerValue(113), calcPowerValue(114), calcPowerValue(115), calcPowerValue(116), calcPowerValue(117), calcPowerValue(118), calcPowerValue(119), 
-    calcPowerValue(120), calcPowerValue(121), calcPowerValue(122), calcPowerValue(123), calcPowerValue(124), calcPowerValue(125), calcPowerValue(126), calcPowerValue(127), 
-    calcPowerValue(128), calcPowerValue(129), calcPowerValue(130), calcPowerValue(131), calcPowerValue(132), calcPowerValue(133), calcPowerValue(134), calcPowerValue(135), 
-    calcPowerValue(136), calcPowerValue(137), calcPowerValue(138), calcPowerValue(139), calcPowerValue(140), calcPowerValue(141), calcPowerValue(142), calcPowerValue(143), 
-    calcPowerValue(144), calcPowerValue(145), calcPowerValue(146), calcPowerValue(147), calcPowerValue(148), calcPowerValue(149), calcPowerValue(150), calcPowerValue(151), 
-    calcPowerValue(152), calcPowerValue(153), calcPowerValue(154), calcPowerValue(155), calcPowerValue(156), calcPowerValue(157), calcPowerValue(158), calcPowerValue(159), 
-    calcPowerValue(160), calcPowerValue(161), calcPowerValue(162), calcPowerValue(163), calcPowerValue(164), calcPowerValue(165), calcPowerValue(166), calcPowerValue(167), 
-    calcPowerValue(168), calcPowerValue(169), calcPowerValue(170), calcPowerValue(171), calcPowerValue(172), calcPowerValue(173), calcPowerValue(174), calcPowerValue(175), 
-    calcPowerValue(176), calcPowerValue(177), calcPowerValue(178), calcPowerValue(179), calcPowerValue(180), calcPowerValue(181), calcPowerValue(182), calcPowerValue(183), 
-    calcPowerValue(184), calcPowerValue(185), calcPowerValue(186), calcPowerValue(187), calcPowerValue(188), calcPowerValue(189), calcPowerValue(190), calcPowerValue(191), 
-    calcPowerValue(192), calcPowerValue(193), calcPowerValue(194), calcPowerValue(195), calcPowerValue(196), calcPowerValue(197), calcPowerValue(198), calcPowerValue(199), 
-    calcPowerValue(200), calcPowerValue(201), calcPowerValue(202), calcPowerValue(203), calcPowerValue(204), calcPowerValue(205), calcPowerValue(206), calcPowerValue(207), 
-    calcPowerValue(208), calcPowerValue(209), calcPowerValue(210), calcPowerValue(211), calcPowerValue(212), calcPowerValue(213), calcPowerValue(214), calcPowerValue(215), 
-    calcPowerValue(216), calcPowerValue(217), calcPowerValue(218), calcPowerValue(219), calcPowerValue(220), calcPowerValue(221), calcPowerValue(222), calcPowerValue(223), 
-    calcPowerValue(224), calcPowerValue(225), calcPowerValue(226), calcPowerValue(227), calcPowerValue(228), calcPowerValue(229), calcPowerValue(230), calcPowerValue(231), 
-    calcPowerValue(232), calcPowerValue(233), calcPowerValue(234), calcPowerValue(235), calcPowerValue(236), calcPowerValue(237), calcPowerValue(238), calcPowerValue(239), 
-    calcPowerValue(240), calcPowerValue(241), calcPowerValue(242), calcPowerValue(243), calcPowerValue(244), calcPowerValue(245), calcPowerValue(246), calcPowerValue(247), 
-    calcPowerValue(248), calcPowerValue(249), calcPowerValue(250), calcPowerValue(251), calcPowerValue(252), calcPowerValue(253), calcPowerValue(254), calcPowerValue(255), 
-};
-#endif
-constexpr uint8_t getPowerValue(uint8_t brightness) {
-    return POWERTABLE[brightness];
+uint8_t getPowerValue(uint8_t brightness) {
+    return *(powerScaleTable + brightness);
 }
 #endif // !FASTLED_POWER_SCALING_COMPUTE
 #endif // !FASTLED_POWER_SCALING_FAST

--- a/power_mgt.cpp
+++ b/power_mgt.cpp
@@ -23,80 +23,111 @@ FASTLED_NAMESPACE_BEGIN
 // for changing these on the fly, but it saves codespace and RAM to have them
 // be compile-time constants.
 
-constexpr float POWER_EXPONENENT = 0.77; // 50% pwm will result in 0.5^0.75 = 58.6% of power usage
-static const uint8_t gRed_mW   = 16 * 5; // 16mA @ 5v = 80mW
-static const uint8_t gGreen_mW = 11 * 5; // 11mA @ 5v = 55mW
-static const uint8_t gBlue_mW  = 15 * 5; // 15mA @ 5v = 75mW
-static const uint8_t gDark_mW  =  1 * 5; //  1mA @ 5v =  5mW
+constexpr float POWER_EXPONENENT = 0.87; // 50% pwm will result in 0.5^0.87 = 54.7% of power usage
+constexpr uint8_t gRed_mW   = 16 * 5; // 16mA @ 5v = 80mW
+constexpr uint8_t gGreen_mW = 11 * 5; // 11mA @ 5v = 55mW
+constexpr uint8_t gBlue_mW  = 15 * 5; // 15mA @ 5v = 75mW
+constexpr uint8_t gDark_mW  = 1 * 5;  // 1mA @ 5v = 75mW
+
+// Alternate measurements for sk6805-1515
+// constexpr float POWER_EXPONENENT = 0.87;
+// constexpr uint8_t gRed_mW   = 25;
+// constexpr uint8_t gGreen_mW = 18;
+// constexpr uint8_t gBlue_mW  = 24;
+// constexpr uint8_t gDark_mW  = 4;
 
 // Alternate calibration by RAtkins via pre-PSU wattage measurments;
 // these are all probably about 20%-25% too high due to PSU heat losses,
 // but if you're measuring wattage on the PSU input side, this may
 // be a better set of calibrations.  (WS2812B)
-//  static const uint8_t gRed_mW   = 100;
-//  static const uint8_t gGreen_mW =  48;
-//  static const uint8_t gBlue_mW  = 100;
-//  static const uint8_t gDark_mW  =  12;
+//  constexpr uint8_t gRed_mW   = 100;
+//  constexpr uint8_t gGreen_mW =  48;
+//  constexpr uint8_t gBlue_mW  = 100;
+//  constexpr uint8_t gDark_mW  =  12;
 
 
-#define POWER_LED 1
+
+#define POWER_LED 0
 #define POWER_DEBUG_PRINT 0
 
 
 // Power consumed by the MCU
-static const uint8_t gMCU_mW  =  25 * 5; // 25mA @ 5v = 125 mW
+constexpr uint8_t gMCU_mW  =  25 * 5; // 25mA @ 5v = 125 mW
 
-static uint8_t  gMaxPowerIndicatorLEDPinNumber = 0; // default = Arduino onboard LED pin.  set to zero to skip this.
+static uint8_t gMaxPowerIndicatorLEDPinNumber = 0; // default = Arduino onboard LED pin.  set to zero to skip this.
 
 
-constexpr uint8_t getPowerValue(const uint8_t& brightness) {
-    return pow(brightness, POWER_EXPONENENT) * pow(256, 1 - POWER_EXPONENENT);
+// if defined, use linear power scaling. Cheapest but inaccurate (~20%).
+#ifdef FASTLED_POWER_SCALING_FAST
+constexpr uint8_t getPowerValue(uint8_t brightness) {
+    return brightness;
 }
+constexpr uint8_t getReversePowerValue(uint8_t brightness_scaled) {
+    return brightness_scaled;
+}
+#else
+#define calcPowerValue(brightness) pow(brightness, POWER_EXPONENENT) * pow(256, 1 - POWER_EXPONENENT)
+constexpr uint8_t getReversePowerValue(uint8_t brightness_scaled) {
+    return pow(brightness_scaled / pow(256, 1 - POWER_EXPONENENT), 1.f/POWER_EXPONENENT);
+}
+// if defined, compute power value each time.
+#ifdef FASTLED_POWER_SCALING_COMPUTE
+constexpr uint8_t getPowerValue(uint8_t brightness) {
+    return calcPowerValue(brightness);
+}
+#else
+// precompute values and store them in an array.
+
 #if __cplusplus >= 201700L
 // c++17
 constexpr std::array<uint8_t, 256> POWERTABLE = [] {
   std::array<uint8_t, 256> A = {};
   for (unsigned i = 0; i < 256; i++) {
-    A[i] = getPowerValue(i);
+    A[i] = calcPowerValue(i);
   }
   return A;
 }();
 #else
 constexpr std::array<uint8_t, 256> POWERTABLE = {
-    getPowerValue(0), getPowerValue(1), getPowerValue(2), getPowerValue(3), getPowerValue(4), getPowerValue(5), getPowerValue(6), getPowerValue(7), 
-    getPowerValue(8), getPowerValue(9), getPowerValue(10), getPowerValue(11), getPowerValue(12), getPowerValue(13), getPowerValue(14), getPowerValue(15), 
-    getPowerValue(16), getPowerValue(17), getPowerValue(18), getPowerValue(19), getPowerValue(20), getPowerValue(21), getPowerValue(22), getPowerValue(23), 
-    getPowerValue(24), getPowerValue(25), getPowerValue(26), getPowerValue(27), getPowerValue(28), getPowerValue(29), getPowerValue(30), getPowerValue(31), 
-    getPowerValue(32), getPowerValue(33), getPowerValue(34), getPowerValue(35), getPowerValue(36), getPowerValue(37), getPowerValue(38), getPowerValue(39), 
-    getPowerValue(40), getPowerValue(41), getPowerValue(42), getPowerValue(43), getPowerValue(44), getPowerValue(45), getPowerValue(46), getPowerValue(47), 
-    getPowerValue(48), getPowerValue(49), getPowerValue(50), getPowerValue(51), getPowerValue(52), getPowerValue(53), getPowerValue(54), getPowerValue(55), 
-    getPowerValue(56), getPowerValue(57), getPowerValue(58), getPowerValue(59), getPowerValue(60), getPowerValue(61), getPowerValue(62), getPowerValue(63), 
-    getPowerValue(64), getPowerValue(65), getPowerValue(66), getPowerValue(67), getPowerValue(68), getPowerValue(69), getPowerValue(70), getPowerValue(71), 
-    getPowerValue(72), getPowerValue(73), getPowerValue(74), getPowerValue(75), getPowerValue(76), getPowerValue(77), getPowerValue(78), getPowerValue(79), 
-    getPowerValue(80), getPowerValue(81), getPowerValue(82), getPowerValue(83), getPowerValue(84), getPowerValue(85), getPowerValue(86), getPowerValue(87), 
-    getPowerValue(88), getPowerValue(89), getPowerValue(90), getPowerValue(91), getPowerValue(92), getPowerValue(93), getPowerValue(94), getPowerValue(95), 
-    getPowerValue(96), getPowerValue(97), getPowerValue(98), getPowerValue(99), getPowerValue(100), getPowerValue(101), getPowerValue(102), getPowerValue(103), 
-    getPowerValue(104), getPowerValue(105), getPowerValue(106), getPowerValue(107), getPowerValue(108), getPowerValue(109), getPowerValue(110), getPowerValue(111), 
-    getPowerValue(112), getPowerValue(113), getPowerValue(114), getPowerValue(115), getPowerValue(116), getPowerValue(117), getPowerValue(118), getPowerValue(119), 
-    getPowerValue(120), getPowerValue(121), getPowerValue(122), getPowerValue(123), getPowerValue(124), getPowerValue(125), getPowerValue(126), getPowerValue(127), 
-    getPowerValue(128), getPowerValue(129), getPowerValue(130), getPowerValue(131), getPowerValue(132), getPowerValue(133), getPowerValue(134), getPowerValue(135), 
-    getPowerValue(136), getPowerValue(137), getPowerValue(138), getPowerValue(139), getPowerValue(140), getPowerValue(141), getPowerValue(142), getPowerValue(143), 
-    getPowerValue(144), getPowerValue(145), getPowerValue(146), getPowerValue(147), getPowerValue(148), getPowerValue(149), getPowerValue(150), getPowerValue(151), 
-    getPowerValue(152), getPowerValue(153), getPowerValue(154), getPowerValue(155), getPowerValue(156), getPowerValue(157), getPowerValue(158), getPowerValue(159), 
-    getPowerValue(160), getPowerValue(161), getPowerValue(162), getPowerValue(163), getPowerValue(164), getPowerValue(165), getPowerValue(166), getPowerValue(167), 
-    getPowerValue(168), getPowerValue(169), getPowerValue(170), getPowerValue(171), getPowerValue(172), getPowerValue(173), getPowerValue(174), getPowerValue(175), 
-    getPowerValue(176), getPowerValue(177), getPowerValue(178), getPowerValue(179), getPowerValue(180), getPowerValue(181), getPowerValue(182), getPowerValue(183), 
-    getPowerValue(184), getPowerValue(185), getPowerValue(186), getPowerValue(187), getPowerValue(188), getPowerValue(189), getPowerValue(190), getPowerValue(191), 
-    getPowerValue(192), getPowerValue(193), getPowerValue(194), getPowerValue(195), getPowerValue(196), getPowerValue(197), getPowerValue(198), getPowerValue(199), 
-    getPowerValue(200), getPowerValue(201), getPowerValue(202), getPowerValue(203), getPowerValue(204), getPowerValue(205), getPowerValue(206), getPowerValue(207), 
-    getPowerValue(208), getPowerValue(209), getPowerValue(210), getPowerValue(211), getPowerValue(212), getPowerValue(213), getPowerValue(214), getPowerValue(215), 
-    getPowerValue(216), getPowerValue(217), getPowerValue(218), getPowerValue(219), getPowerValue(220), getPowerValue(221), getPowerValue(222), getPowerValue(223), 
-    getPowerValue(224), getPowerValue(225), getPowerValue(226), getPowerValue(227), getPowerValue(228), getPowerValue(229), getPowerValue(230), getPowerValue(231), 
-    getPowerValue(232), getPowerValue(233), getPowerValue(234), getPowerValue(235), getPowerValue(236), getPowerValue(237), getPowerValue(238), getPowerValue(239), 
-    getPowerValue(240), getPowerValue(241), getPowerValue(242), getPowerValue(243), getPowerValue(244), getPowerValue(245), getPowerValue(246), getPowerValue(247), 
-    getPowerValue(248), getPowerValue(249), getPowerValue(250), getPowerValue(251), getPowerValue(252), getPowerValue(253), getPowerValue(254), getPowerValue(255), 
+    calcPowerValue(0), calcPowerValue(1), calcPowerValue(2), calcPowerValue(3), calcPowerValue(4), calcPowerValue(5), calcPowerValue(6), calcPowerValue(7), 
+    calcPowerValue(8), calcPowerValue(9), calcPowerValue(10), calcPowerValue(11), calcPowerValue(12), calcPowerValue(13), calcPowerValue(14), calcPowerValue(15), 
+    calcPowerValue(16), calcPowerValue(17), calcPowerValue(18), calcPowerValue(19), calcPowerValue(20), calcPowerValue(21), calcPowerValue(22), calcPowerValue(23), 
+    calcPowerValue(24), calcPowerValue(25), calcPowerValue(26), calcPowerValue(27), calcPowerValue(28), calcPowerValue(29), calcPowerValue(30), calcPowerValue(31), 
+    calcPowerValue(32), calcPowerValue(33), calcPowerValue(34), calcPowerValue(35), calcPowerValue(36), calcPowerValue(37), calcPowerValue(38), calcPowerValue(39), 
+    calcPowerValue(40), calcPowerValue(41), calcPowerValue(42), calcPowerValue(43), calcPowerValue(44), calcPowerValue(45), calcPowerValue(46), calcPowerValue(47), 
+    calcPowerValue(48), calcPowerValue(49), calcPowerValue(50), calcPowerValue(51), calcPowerValue(52), calcPowerValue(53), calcPowerValue(54), calcPowerValue(55), 
+    calcPowerValue(56), calcPowerValue(57), calcPowerValue(58), calcPowerValue(59), calcPowerValue(60), calcPowerValue(61), calcPowerValue(62), calcPowerValue(63), 
+    calcPowerValue(64), calcPowerValue(65), calcPowerValue(66), calcPowerValue(67), calcPowerValue(68), calcPowerValue(69), calcPowerValue(70), calcPowerValue(71), 
+    calcPowerValue(72), calcPowerValue(73), calcPowerValue(74), calcPowerValue(75), calcPowerValue(76), calcPowerValue(77), calcPowerValue(78), calcPowerValue(79), 
+    calcPowerValue(80), calcPowerValue(81), calcPowerValue(82), calcPowerValue(83), calcPowerValue(84), calcPowerValue(85), calcPowerValue(86), calcPowerValue(87), 
+    calcPowerValue(88), calcPowerValue(89), calcPowerValue(90), calcPowerValue(91), calcPowerValue(92), calcPowerValue(93), calcPowerValue(94), calcPowerValue(95), 
+    calcPowerValue(96), calcPowerValue(97), calcPowerValue(98), calcPowerValue(99), calcPowerValue(100), calcPowerValue(101), calcPowerValue(102), calcPowerValue(103), 
+    calcPowerValue(104), calcPowerValue(105), calcPowerValue(106), calcPowerValue(107), calcPowerValue(108), calcPowerValue(109), calcPowerValue(110), calcPowerValue(111), 
+    calcPowerValue(112), calcPowerValue(113), calcPowerValue(114), calcPowerValue(115), calcPowerValue(116), calcPowerValue(117), calcPowerValue(118), calcPowerValue(119), 
+    calcPowerValue(120), calcPowerValue(121), calcPowerValue(122), calcPowerValue(123), calcPowerValue(124), calcPowerValue(125), calcPowerValue(126), calcPowerValue(127), 
+    calcPowerValue(128), calcPowerValue(129), calcPowerValue(130), calcPowerValue(131), calcPowerValue(132), calcPowerValue(133), calcPowerValue(134), calcPowerValue(135), 
+    calcPowerValue(136), calcPowerValue(137), calcPowerValue(138), calcPowerValue(139), calcPowerValue(140), calcPowerValue(141), calcPowerValue(142), calcPowerValue(143), 
+    calcPowerValue(144), calcPowerValue(145), calcPowerValue(146), calcPowerValue(147), calcPowerValue(148), calcPowerValue(149), calcPowerValue(150), calcPowerValue(151), 
+    calcPowerValue(152), calcPowerValue(153), calcPowerValue(154), calcPowerValue(155), calcPowerValue(156), calcPowerValue(157), calcPowerValue(158), calcPowerValue(159), 
+    calcPowerValue(160), calcPowerValue(161), calcPowerValue(162), calcPowerValue(163), calcPowerValue(164), calcPowerValue(165), calcPowerValue(166), calcPowerValue(167), 
+    calcPowerValue(168), calcPowerValue(169), calcPowerValue(170), calcPowerValue(171), calcPowerValue(172), calcPowerValue(173), calcPowerValue(174), calcPowerValue(175), 
+    calcPowerValue(176), calcPowerValue(177), calcPowerValue(178), calcPowerValue(179), calcPowerValue(180), calcPowerValue(181), calcPowerValue(182), calcPowerValue(183), 
+    calcPowerValue(184), calcPowerValue(185), calcPowerValue(186), calcPowerValue(187), calcPowerValue(188), calcPowerValue(189), calcPowerValue(190), calcPowerValue(191), 
+    calcPowerValue(192), calcPowerValue(193), calcPowerValue(194), calcPowerValue(195), calcPowerValue(196), calcPowerValue(197), calcPowerValue(198), calcPowerValue(199), 
+    calcPowerValue(200), calcPowerValue(201), calcPowerValue(202), calcPowerValue(203), calcPowerValue(204), calcPowerValue(205), calcPowerValue(206), calcPowerValue(207), 
+    calcPowerValue(208), calcPowerValue(209), calcPowerValue(210), calcPowerValue(211), calcPowerValue(212), calcPowerValue(213), calcPowerValue(214), calcPowerValue(215), 
+    calcPowerValue(216), calcPowerValue(217), calcPowerValue(218), calcPowerValue(219), calcPowerValue(220), calcPowerValue(221), calcPowerValue(222), calcPowerValue(223), 
+    calcPowerValue(224), calcPowerValue(225), calcPowerValue(226), calcPowerValue(227), calcPowerValue(228), calcPowerValue(229), calcPowerValue(230), calcPowerValue(231), 
+    calcPowerValue(232), calcPowerValue(233), calcPowerValue(234), calcPowerValue(235), calcPowerValue(236), calcPowerValue(237), calcPowerValue(238), calcPowerValue(239), 
+    calcPowerValue(240), calcPowerValue(241), calcPowerValue(242), calcPowerValue(243), calcPowerValue(244), calcPowerValue(245), calcPowerValue(246), calcPowerValue(247), 
+    calcPowerValue(248), calcPowerValue(249), calcPowerValue(250), calcPowerValue(251), calcPowerValue(252), calcPowerValue(253), calcPowerValue(254), calcPowerValue(255), 
 };
 #endif
+constexpr uint8_t getPowerValue(uint8_t brightness) {
+    return POWERTABLE[brightness];
+}
+#endif // !FASTLED_POWER_SCALING_COMPUTE
+#endif // !FASTLED_POWER_SCALING_FAST
 
 
 
@@ -110,9 +141,9 @@ uint32_t calculate_unscaled_power_mW( const CRGB* ledbuffer, uint16_t numLeds ) 
 
     // This loop might benefit from an AVR assembly version -MEK
     while(count) {
-        red32   += POWERTABLE[*p++];
-        green32 += POWERTABLE[*p++];
-        blue32  += POWERTABLE[*p++];
+        red32   += getPowerValue(*p++);
+        green32 += getPowerValue(*p++);
+        blue32  += getPowerValue(*p++);
         count--;
     }
 
@@ -152,7 +183,7 @@ uint8_t calculate_max_brightness_for_power_mW(const CRGB* ledbuffer, uint16_t nu
 //  - no more than max_mW milliwatts
 uint8_t calculate_max_brightness_for_power_mW( uint8_t target_brightness, uint32_t max_power_mW)
 {
-    target_brightness = pow(target_brightness, POWER_EXPONENENT) * pow(256, 1 - POWER_EXPONENENT);
+    uint8_t target_brightness_scaled = getPowerValue(target_brightness);
 
     uint32_t total_mW = gMCU_mW;
 
@@ -167,7 +198,7 @@ uint8_t calculate_max_brightness_for_power_mW( uint8_t target_brightness, uint32
     Serial.println( total_mW);
 #endif
 
-    uint32_t requested_power_mW = ((uint32_t)total_mW * target_brightness) / 256;
+    uint32_t requested_power_mW = ((uint32_t)total_mW * target_brightness_scaled) / 256;
 #if POWER_DEBUG_PRINT == 1
     if( target_brightness != 255 ) {
         Serial.print("power demand at scaled brightness mW = ");
@@ -186,10 +217,10 @@ uint8_t calculate_max_brightness_for_power_mW( uint8_t target_brightness, uint32
 #if POWER_DEBUG_PRINT == 1
         Serial.print("demand is under the limit");
 #endif
-        return pow(target_brightness / pow(256, 1 - POWER_EXPONENENT), 1.f/POWER_EXPONENENT);
+        return target_brightness;
     }
 
-    uint8_t recommended_brightness = (uint32_t)(target_brightness * max_power_mW) / requested_power_mW;
+    uint8_t recommended_brightness = (uint32_t)(target_brightness_scaled * max_power_mW) / requested_power_mW;
 #if POWER_DEBUG_PRINT == 1
     Serial.print("recommended brightness # = ");
     Serial.println( recommended_brightness);
@@ -207,7 +238,7 @@ uint8_t calculate_max_brightness_for_power_mW( uint8_t target_brightness, uint32
     }
 #endif
 
-    return  pow(recommended_brightness / pow(256, 1 - POWER_EXPONENENT), 1.f/POWER_EXPONENENT);
+    return getReversePowerValue(recommended_brightness);
 }
 
 

--- a/power_mgt.cpp
+++ b/power_mgt.cpp
@@ -24,10 +24,10 @@ FASTLED_NAMESPACE_BEGIN
 // be compile-time constants.
 
 constexpr float POWER_EXPONENENT = 0.77; // 50% pwm will result in 0.5^0.75 = 58.6% of power usage
-static const uint8_t gRed_mW   = 26; // 16mA @ 5v = 80mW
-static const uint8_t gGreen_mW = 16; // 11mA @ 5v = 55mW
-static const uint8_t gBlue_mW  = 26; // 15mA @ 5v = 75mW
-static const uint8_t gDark_mW  = 6; //  1mA @ 5v =  5mW
+static const uint8_t gRed_mW   = 16 * 5; // 16mA @ 5v = 80mW
+static const uint8_t gGreen_mW = 11 * 5; // 11mA @ 5v = 55mW
+static const uint8_t gBlue_mW  = 15 * 5; // 15mA @ 5v = 75mW
+static const uint8_t gDark_mW  =  1 * 5; //  1mA @ 5v =  5mW
 
 // Alternate calibration by RAtkins via pre-PSU wattage measurments;
 // these are all probably about 20%-25% too high due to PSU heat losses,

--- a/power_mgt.cpp
+++ b/power_mgt.cpp
@@ -67,21 +67,21 @@ static uint8_t gMaxPowerIndicatorLEDPinNumber = 0; // default = Arduino onboard 
 
 // if defined, use linear power scaling.
 #ifdef FASTLED_POWER_SCALING_FAST
-constexpr uint8_t getPowerValue(uint8_t brightness) {
+inline uint8_t getPowerValue(uint8_t brightness) {
     return brightness;
 }
-constexpr uint8_t getReversePowerValue(uint8_t brightness_scaled) {
+inline uint8_t getReversePowerValue(uint8_t brightness_scaled) {
     return brightness_scaled;
 }
 void setupPowerScaleTable() {}
 #else
 #define calcPowerValue(brightness) static_cast<uint8_t>(pow(brightness, POWER_EXPONENENT) * pow(256, 1 - POWER_EXPONENENT))
-constexpr uint8_t getReversePowerValue(uint8_t brightness_scaled) {
+inline uint8_t getReversePowerValue(uint8_t brightness_scaled) {
     return static_cast<uint8_t>(pow(brightness_scaled / pow(256, 1 - POWER_EXPONENENT), 1.f/POWER_EXPONENENT));
 }
 // if defined, compute power value each time.
 #ifdef FASTLED_POWER_SCALING_COMPUTE
-constexpr uint8_t getPowerValue(uint8_t brightness) {
+inline uint8_t getPowerValue(uint8_t brightness) {
     return calcPowerValue(brightness);
 }
 void setupPowerScaleTable() {}
@@ -98,7 +98,7 @@ void setupPowerScaleTable() {
     } while (i++ < 255);
 }
 
-uint8_t getPowerValue(uint8_t brightness) {
+inline uint8_t getPowerValue(uint8_t brightness) {
     return *(powerScaleTable + brightness);
 }
 #endif // !FASTLED_POWER_SCALING_COMPUTE

--- a/power_mgt.cpp
+++ b/power_mgt.cpp
@@ -1,6 +1,7 @@
 #define FASTLED_INTERNAL
 #include "FastLED.h"
 #include "power_mgt.h"
+#include <array>
 
 FASTLED_NAMESPACE_BEGIN
 
@@ -22,11 +23,11 @@ FASTLED_NAMESPACE_BEGIN
 // for changing these on the fly, but it saves codespace and RAM to have them
 // be compile-time constants.
 
-constexpr float POWER_EXPONENENT = 0.75; // 50% pwm will result in 0.5^0.75 = 59.4% of power usage
-static const uint8_t gRed_mW   = 16 * 5; // 16mA @ 5v = 80mW
-static const uint8_t gGreen_mW = 11 * 5; // 11mA @ 5v = 55mW
-static const uint8_t gBlue_mW  = 15 * 5; // 15mA @ 5v = 75mW
-static const uint8_t gDark_mW  =  1 * 5; //  1mA @ 5v =  5mW
+constexpr float POWER_EXPONENENT = 0.77; // 50% pwm will result in 0.5^0.75 = 58.6% of power usage
+static const uint8_t gRed_mW   = 26; // 16mA @ 5v = 80mW
+static const uint8_t gGreen_mW = 16; // 11mA @ 5v = 55mW
+static const uint8_t gBlue_mW  = 26; // 15mA @ 5v = 75mW
+static const uint8_t gDark_mW  = 6; //  1mA @ 5v =  5mW
 
 // Alternate calibration by RAtkins via pre-PSU wattage measurments;
 // these are all probably about 20%-25% too high due to PSU heat losses,
@@ -48,6 +49,57 @@ static const uint8_t gMCU_mW  =  25 * 5; // 25mA @ 5v = 125 mW
 static uint8_t  gMaxPowerIndicatorLEDPinNumber = 0; // default = Arduino onboard LED pin.  set to zero to skip this.
 
 
+constexpr uint8_t getPowerValue(const uint8_t& brightness) {
+    return pow(brightness, POWER_EXPONENENT) * pow(256, 1 - POWER_EXPONENENT);
+}
+#if __cplusplus >= 201700L
+// c++17
+constexpr std::array<uint8_t, 256> POWERTABLE = [] {
+  std::array<uint8_t, 256> A = {};
+  for (unsigned i = 0; i < 256; i++) {
+    A[i] = getPowerValue(i);
+  }
+  return A;
+}();
+#else
+constexpr std::array<uint8_t, 256> POWERTABLE = {
+    getPowerValue(0), getPowerValue(1), getPowerValue(2), getPowerValue(3), getPowerValue(4), getPowerValue(5), getPowerValue(6), getPowerValue(7), 
+    getPowerValue(8), getPowerValue(9), getPowerValue(10), getPowerValue(11), getPowerValue(12), getPowerValue(13), getPowerValue(14), getPowerValue(15), 
+    getPowerValue(16), getPowerValue(17), getPowerValue(18), getPowerValue(19), getPowerValue(20), getPowerValue(21), getPowerValue(22), getPowerValue(23), 
+    getPowerValue(24), getPowerValue(25), getPowerValue(26), getPowerValue(27), getPowerValue(28), getPowerValue(29), getPowerValue(30), getPowerValue(31), 
+    getPowerValue(32), getPowerValue(33), getPowerValue(34), getPowerValue(35), getPowerValue(36), getPowerValue(37), getPowerValue(38), getPowerValue(39), 
+    getPowerValue(40), getPowerValue(41), getPowerValue(42), getPowerValue(43), getPowerValue(44), getPowerValue(45), getPowerValue(46), getPowerValue(47), 
+    getPowerValue(48), getPowerValue(49), getPowerValue(50), getPowerValue(51), getPowerValue(52), getPowerValue(53), getPowerValue(54), getPowerValue(55), 
+    getPowerValue(56), getPowerValue(57), getPowerValue(58), getPowerValue(59), getPowerValue(60), getPowerValue(61), getPowerValue(62), getPowerValue(63), 
+    getPowerValue(64), getPowerValue(65), getPowerValue(66), getPowerValue(67), getPowerValue(68), getPowerValue(69), getPowerValue(70), getPowerValue(71), 
+    getPowerValue(72), getPowerValue(73), getPowerValue(74), getPowerValue(75), getPowerValue(76), getPowerValue(77), getPowerValue(78), getPowerValue(79), 
+    getPowerValue(80), getPowerValue(81), getPowerValue(82), getPowerValue(83), getPowerValue(84), getPowerValue(85), getPowerValue(86), getPowerValue(87), 
+    getPowerValue(88), getPowerValue(89), getPowerValue(90), getPowerValue(91), getPowerValue(92), getPowerValue(93), getPowerValue(94), getPowerValue(95), 
+    getPowerValue(96), getPowerValue(97), getPowerValue(98), getPowerValue(99), getPowerValue(100), getPowerValue(101), getPowerValue(102), getPowerValue(103), 
+    getPowerValue(104), getPowerValue(105), getPowerValue(106), getPowerValue(107), getPowerValue(108), getPowerValue(109), getPowerValue(110), getPowerValue(111), 
+    getPowerValue(112), getPowerValue(113), getPowerValue(114), getPowerValue(115), getPowerValue(116), getPowerValue(117), getPowerValue(118), getPowerValue(119), 
+    getPowerValue(120), getPowerValue(121), getPowerValue(122), getPowerValue(123), getPowerValue(124), getPowerValue(125), getPowerValue(126), getPowerValue(127), 
+    getPowerValue(128), getPowerValue(129), getPowerValue(130), getPowerValue(131), getPowerValue(132), getPowerValue(133), getPowerValue(134), getPowerValue(135), 
+    getPowerValue(136), getPowerValue(137), getPowerValue(138), getPowerValue(139), getPowerValue(140), getPowerValue(141), getPowerValue(142), getPowerValue(143), 
+    getPowerValue(144), getPowerValue(145), getPowerValue(146), getPowerValue(147), getPowerValue(148), getPowerValue(149), getPowerValue(150), getPowerValue(151), 
+    getPowerValue(152), getPowerValue(153), getPowerValue(154), getPowerValue(155), getPowerValue(156), getPowerValue(157), getPowerValue(158), getPowerValue(159), 
+    getPowerValue(160), getPowerValue(161), getPowerValue(162), getPowerValue(163), getPowerValue(164), getPowerValue(165), getPowerValue(166), getPowerValue(167), 
+    getPowerValue(168), getPowerValue(169), getPowerValue(170), getPowerValue(171), getPowerValue(172), getPowerValue(173), getPowerValue(174), getPowerValue(175), 
+    getPowerValue(176), getPowerValue(177), getPowerValue(178), getPowerValue(179), getPowerValue(180), getPowerValue(181), getPowerValue(182), getPowerValue(183), 
+    getPowerValue(184), getPowerValue(185), getPowerValue(186), getPowerValue(187), getPowerValue(188), getPowerValue(189), getPowerValue(190), getPowerValue(191), 
+    getPowerValue(192), getPowerValue(193), getPowerValue(194), getPowerValue(195), getPowerValue(196), getPowerValue(197), getPowerValue(198), getPowerValue(199), 
+    getPowerValue(200), getPowerValue(201), getPowerValue(202), getPowerValue(203), getPowerValue(204), getPowerValue(205), getPowerValue(206), getPowerValue(207), 
+    getPowerValue(208), getPowerValue(209), getPowerValue(210), getPowerValue(211), getPowerValue(212), getPowerValue(213), getPowerValue(214), getPowerValue(215), 
+    getPowerValue(216), getPowerValue(217), getPowerValue(218), getPowerValue(219), getPowerValue(220), getPowerValue(221), getPowerValue(222), getPowerValue(223), 
+    getPowerValue(224), getPowerValue(225), getPowerValue(226), getPowerValue(227), getPowerValue(228), getPowerValue(229), getPowerValue(230), getPowerValue(231), 
+    getPowerValue(232), getPowerValue(233), getPowerValue(234), getPowerValue(235), getPowerValue(236), getPowerValue(237), getPowerValue(238), getPowerValue(239), 
+    getPowerValue(240), getPowerValue(241), getPowerValue(242), getPowerValue(243), getPowerValue(244), getPowerValue(245), getPowerValue(246), getPowerValue(247), 
+    getPowerValue(248), getPowerValue(249), getPowerValue(250), getPowerValue(251), getPowerValue(252), getPowerValue(253), getPowerValue(254), getPowerValue(255), 
+};
+#endif
+
+
+
 uint32_t calculate_unscaled_power_mW( const CRGB* ledbuffer, uint16_t numLeds ) //25354
 {
     uint32_t red32 = 0, green32 = 0, blue32 = 0;
@@ -57,10 +109,10 @@ uint32_t calculate_unscaled_power_mW( const CRGB* ledbuffer, uint16_t numLeds ) 
     uint16_t count = numLeds;
 
     // This loop might benefit from an AVR assembly version -MEK
-    while( count) {
-        red32   += pow(*p++, POWER_EXPONENENT) * pow(256, 1 - POWER_EXPONENENT);
-        green32 += pow(*p++, POWER_EXPONENENT) * pow(256, 1 - POWER_EXPONENENT);
-        blue32  += pow(*p++, POWER_EXPONENENT) * pow(256, 1 - POWER_EXPONENENT);
+    while(count) {
+        red32   += POWERTABLE[*p++];
+        green32 += POWERTABLE[*p++];
+        blue32  += POWERTABLE[*p++];
         count--;
     }
 
@@ -155,7 +207,7 @@ uint8_t calculate_max_brightness_for_power_mW( uint8_t target_brightness, uint32
     }
 #endif
 
-    return pow(recommended_brightness / pow(256, 1 - POWER_EXPONENENT), 1.f/POWER_EXPONENENT);
+    return  pow(recommended_brightness / pow(256, 1 - POWER_EXPONENENT), 1.f/POWER_EXPONENENT);
 }
 
 

--- a/power_mgt.h
+++ b/power_mgt.h
@@ -29,6 +29,11 @@ void set_max_power_in_milliwatts( uint32_t powerInmW);
 void set_max_power_indicator_LED( uint8_t pinNumber); // zero = no indicator LED
 
 
+// MUST be called before calling m_pPowerFunc.
+void setupPowerScaleTable();
+
+
+
 // Power Control 'show' and 'delay' functions
 //
 // These are drop-in replacements for FastLED.show() and FastLED.delay()


### PR DESCRIPTION
I was having issues with power limiting: when I did my full brightness current test on 88x sk6805-1515, I measured R: .55A, G: .33A, B: .56A, R+G+B: 1.46A. I am trying to comply to USB spec so a current limit of 0.5A is needed. After changing the mw constants for each color and setting the appropriate current limit, I obtained results of R: .48A, G: .33A, B: .48A. All good. However, when I use mixed colors such as white, the current draw went up to as much as .62A.
There seems to be non-linear current scaling coming into play, this PR attempts to fix this. With the exponent I've implemented of 0.77, the white current draw nicely sits at .48A in the same setup without affecting the other colors.

I've attempted to implement non linear power scaling in a way that shouldn't impact performance too much. Additional testing is needed as I only measured power on sk6805-1515's.