### PR TITLE
Support on ATmega4809 with minimal changes

### DIFF
--- a/led_sysdefs.h
+++ b/led_sysdefs.h
@@ -32,7 +32,7 @@
 #include "platforms/esp/8266/led_sysdefs_esp8266.h"
 #elif defined(ESP32)
 #include "platforms/esp/32/led_sysdefs_esp32.h"
-#elif defined(__AVR__)
+#elif defined(__AVR__) || defined(__AVR_ATmega4809__)
 // AVR platforms
 #include "platforms/avr/led_sysdefs_avr.h"
 #elif defined(ARDUINO_ARCH_APOLLO3)

--- a/platforms/avr/clockless_trinket.h
+++ b/platforms/avr/clockless_trinket.h
@@ -323,10 +323,10 @@ protected:
 #define DUSE (0xFF - (DADVANCE-1))
 
 // Silence compiler warnings about switch/case that is explicitly intended to fall through.
-//#define FL_FALLTHROUGH __attribute__ ((fallthrough));
+#define FL_FALLTHROUGH __attribute__ ((fallthrough));
 
-// This method is made static to force making register Y available to use for data on AVR - if the method is non-static, then
-// gcc will use register Y for the this pointer.
+	// This method is made static to force making register Y available to use for data on AVR - if the method is non-static, then
+	// gcc will use register Y for the this pointer.
 	static void /*__attribute__((optimize("O0")))*/  /*__attribute__ ((always_inline))*/  showRGBInternal(PixelController<RGB_ORDER> & pixels)  {
 		uint8_t *data = (uint8_t*)pixels.mData;
 		data_ptr_t port = FastPin<DATA_PIN>::port();
@@ -406,9 +406,9 @@ protected:
 				HI1 _D1(1) QLO2(b0, 1) RORSC14(b1,7) 	_D2(4)	LO1 RORCLC2(b1) 	_D3(2)
 				HI1 _D1(1) QLO2(b0, 0)
 				switch(XTRA0) {
-					case 4: _D2(0) LO1 _D3(0) HI1 _D1(1) QLO2(b0,0)  /* fall through */
-					case 3: _D2(0) LO1 _D3(0) HI1 _D1(1) QLO2(b0,0)  /* fall through */
-					case 2: _D2(0) LO1 _D3(0) HI1 _D1(1) QLO2(b0,0)  /* fall through */
+					case 4: _D2(0) LO1 _D3(0) HI1 _D1(1) QLO2(b0,0)  FL_FALLTHROUGH
+					case 3: _D2(0) LO1 _D3(0) HI1 _D1(1) QLO2(b0,0)  FL_FALLTHROUGH
+					case 2: _D2(0) LO1 _D3(0) HI1 _D1(1) QLO2(b0,0)  FL_FALLTHROUGH
 					case 1: _D2(0) LO1 _D3(0) HI1 _D1(1) QLO2(b0,0)
 				}
 				MOV_ADDDE14(b0,b1,d1,e1) _D2(4) LO1 _D3(0)
@@ -422,9 +422,9 @@ protected:
 				HI1 _D1(1) QLO2(b0, 1) RORSC24(b1,7) 	_D2(4)	LO1 RORCLC2(b1) 	_D3(2)
 				HI1 _D1(1) QLO2(b0, 0)
 				switch(XTRA0) {
-					case 4: _D2(0) LO1 _D3(0) HI1 _D1(1) QLO2(b0,0)  /* fall through */
-					case 3: _D2(0) LO1 _D3(0) HI1 _D1(1) QLO2(b0,0)  /* fall through */
-					case 2: _D2(0) LO1 _D3(0) HI1 _D1(1) QLO2(b0,0)  /* fall through */
+					case 4: _D2(0) LO1 _D3(0) HI1 _D1(1) QLO2(b0,0)  FL_FALLTHROUGH
+					case 3: _D2(0) LO1 _D3(0) HI1 _D1(1) QLO2(b0,0)  FL_FALLTHROUGH
+					case 2: _D2(0) LO1 _D3(0) HI1 _D1(1) QLO2(b0,0)  FL_FALLTHROUGH
 					case 1: _D2(0) LO1 _D3(0) HI1 _D1(1) QLO2(b0,0)
 				}
 
@@ -441,9 +441,9 @@ protected:
 				HI1 _D1(1) QLO2(b0, 1) RORSC04(b1,7) 	_D2(4)	LO1 RORCLC2(b1) 	_D3(2)
 				HI1 _D1(1) QLO2(b0, 0)
 				switch(XTRA0) {
-					case 4: _D2(0) LO1 _D3(0) HI1 _D1(1) QLO2(b0,0)  /* fall through */
-					case 3: _D2(0) LO1 _D3(0) HI1 _D1(1) QLO2(b0,0)  /* fall through */
-					case 2: _D2(0) LO1 _D3(0) HI1 _D1(1) QLO2(b0,0)  /* fall through */
+					case 4: _D2(0) LO1 _D3(0) HI1 _D1(1) QLO2(b0,0)  FL_FALLTHROUGH
+					case 3: _D2(0) LO1 _D3(0) HI1 _D1(1) QLO2(b0,0)  FL_FALLTHROUGH
+					case 2: _D2(0) LO1 _D3(0) HI1 _D1(1) QLO2(b0,0)  FL_FALLTHROUGH
 					case 1: _D2(0) LO1 _D3(0) HI1 _D1(1) QLO2(b0,0)
 				}
 				MOV_ADDDE04(b0,b1,d0,e0) _D2(4) LO1 _D3(5)

--- a/platforms/avr/clockless_trinket.h
+++ b/platforms/avr/clockless_trinket.h
@@ -167,6 +167,12 @@ protected:
 	}
 #define USE_ASM_MACROS
 
+#if defined(__AVR_ATmega4809__)
+#define ASM_VAR_PORT "r" (((PORT_t*)FastPin<DATA_PIN>::port())->OUT)
+#else
+#define ASM_VAR_PORT "M" (FastPin<DATA_PIN>::port() - 0x20)
+#endif
+
 // The variables that our various asm statements use.  The same block of variables needs to be declared for
 // all the asm blocks because GCC is pretty stupid and it would clobber variables happily or optimize code away too aggressively
 #define ASM_VARS : /* write variables */				\
@@ -189,13 +195,11 @@ protected:
 				[e0] "r" (e0),							\
 				[e1] "r" (e1),							\
 				[e2] "r" (e2),							\
-				[PORT] "M" (FastPin<DATA_PIN>::port()-0x20),		\
+				[PORT] ASM_VAR_PORT,                    \
 				[O0] "M" (RGB_BYTE0(RGB_ORDER)),		\
 				[O1] "M" (RGB_BYTE1(RGB_ORDER)),		\
 				[O2] "M" (RGB_BYTE2(RGB_ORDER))		\
 				: "cc" /* clobber registers */
-
-
 // Note: the code in the else in HI1/LO1 will be turned into an sts (2 cycle, 2 word) opcode
 // 1 cycle, write hi to the port
 #define HI1 FASTLED_SLOW_CLOCK_ADJUST if((int)(FastPin<DATA_PIN>::port())-0x20 < 64) { asm __volatile__("out %[PORT], %[hi]" ASM_VARS ); } else { *FastPin<DATA_PIN>::port()=hi; }

--- a/platforms/avr/fastpin_avr.h
+++ b/platforms/avr/fastpin_avr.h
@@ -48,8 +48,17 @@ public:
 typedef volatile uint8_t & reg8_t;
 #define _R(T) struct __gen_struct_ ## T
 #define _RD8(T) struct __gen_struct_ ## T { static inline reg8_t r() { return T; }};
+
+// Register name equivalent (using flat names)
+#if defined(AVR_ATtinyxy7) || defined(AVR_ATtinyxy6) || defined(AVR_ATtinyxy4) || defined(AVR_ATtinyxy2) || defined(__AVR_ATmega4809__)
+// ATtiny series 0/1 and ATmega series 0
+#define _FL_IO(L,C) _RD8(PORT ## L ## _DIR); _RD8(PORT ## L ## _OUT); _RD8(PORT ## L ## _IN); _FL_DEFINE_PORT3(L, C, _R(PORT ## L ## _OUT));
+#define _FL_DEFPIN(_PIN, BIT, L) template<> class FastPin<_PIN> : public _AVRPIN<_PIN, 1<<BIT, _R(PORT ## L ## _OUT), _R(PORT ## L ## _DIR), _R(PORT ## L ## _IN)> {};
+#else
+// Others
 #define _FL_IO(L,C) _RD8(DDR ## L); _RD8(PORT ## L); _RD8(PIN ## L); _FL_DEFINE_PORT3(L, C, _R(PORT ## L));
 #define _FL_DEFPIN(_PIN, BIT, L) template<> class FastPin<_PIN> : public _AVRPIN<_PIN, 1<<BIT, _R(PORT ## L), _R(DDR ## L), _R(PIN ## L)> {};
+#endif
 
 // Pre-do all the port definitions
 #ifdef PORTA
@@ -194,6 +203,26 @@ _FL_DEFPIN(16, 2, C); _FL_DEFPIN(17, 3, C); _FL_DEFPIN(18, 4, C); _FL_DEFPIN(19,
 #define SPI_UART0_DATA 9
 #define SPI_UART0_CLOCK 12
 #endif
+
+#elif defined(__AVR_ATmega4809__)
+
+#define MAX_PIN 21
+_FL_DEFPIN(0, 4, C); _FL_DEFPIN(1, 5, C); _FL_DEFPIN(2, 0, A); _FL_DEFPIN(3, 5, F);
+_FL_DEFPIN(4, 6, C); _FL_DEFPIN(5, 2, B); _FL_DEFPIN(6, 4, F); _FL_DEFPIN(7, 1, A);
+_FL_DEFPIN(8, 3, E); _FL_DEFPIN(9, 0, B); _FL_DEFPIN(10, 1, B); _FL_DEFPIN(11, 0, E);
+_FL_DEFPIN(12, 1, E); _FL_DEFPIN(13, 2, E); _FL_DEFPIN(14, 3, D); _FL_DEFPIN(15, 2, D);
+_FL_DEFPIN(16, 1, D); _FL_DEFPIN(17, 0, D); _FL_DEFPIN(18, 2, A); _FL_DEFPIN(19, 3, A);
+_FL_DEFPIN(20, 4, D); _FL_DEFPIN(21, 5, D);
+
+// To confirm for the SPI interfaces
+//#define SPI_DATA 18
+//#define SPI_CLOCK 13
+//#define SPI_SELECT 19
+//#define AVR_HARDWARE_SPI 1
+#define HAS_HARDWARE_PIN_SUPPORT 1
+
+//#define SPI_UART0_DATA 1
+//#define SPI_UART0_CLOCK 4
 
 #elif defined(__AVR_ATmega328P__) || defined(__AVR_ATmega328PB__) || defined(__AVR_ATmega328__) || defined(__AVR_ATmega168__) || defined(__AVR_ATmega168P__) || defined(__AVR_ATmega8__)
 

--- a/platforms/avr/fastpin_avr.h
+++ b/platforms/avr/fastpin_avr.h
@@ -204,6 +204,26 @@ _FL_DEFPIN(16, 2, C); _FL_DEFPIN(17, 3, C); _FL_DEFPIN(18, 4, C); _FL_DEFPIN(19,
 #define SPI_UART0_CLOCK 12
 #endif
 
+#elif defined(ARDUINO_AVR_NANO_EVERY)
+
+#define MAX_PIN 22
+_FL_DEFPIN(0, 5, C); _FL_DEFPIN(1, 4, C); _FL_DEFPIN(2, 0, A); _FL_DEFPIN(3, 5, F);
+_FL_DEFPIN(4, 6, C); _FL_DEFPIN(5, 2, B); _FL_DEFPIN(6, 4, F); _FL_DEFPIN(7, 1, A);
+_FL_DEFPIN(8, 3, E); _FL_DEFPIN(9, 0, B); _FL_DEFPIN(10, 1, B); _FL_DEFPIN(11, 0, E);
+_FL_DEFPIN(12, 1, E); _FL_DEFPIN(13, 2, E); _FL_DEFPIN(14, 3, D); _FL_DEFPIN(15, 2, D);
+_FL_DEFPIN(16, 1, D); _FL_DEFPIN(17, 0, D); _FL_DEFPIN(18, 2, A); _FL_DEFPIN(19, 3, A);
+_FL_DEFPIN(20, 4, D); _FL_DEFPIN(21, 5, D); _FL_DEFPIN(22, 2, A);
+
+// To confirm for the SPI interfaces
+//#define SPI_DATA 18
+//#define SPI_CLOCK 13
+//#define SPI_SELECT 19
+//#define AVR_HARDWARE_SPI 1
+#define HAS_HARDWARE_PIN_SUPPORT 1
+
+//#define SPI_UART0_DATA 1
+//#define SPI_UART0_CLOCK 4
+
 #elif defined(__AVR_ATmega4809__)
 
 #define MAX_PIN 21

--- a/platforms/avr/led_sysdefs_avr.h
+++ b/platforms/avr/led_sysdefs_avr.h
@@ -46,6 +46,9 @@ extern volatile unsigned long timer0_millis_count;
 #  elif defined(ATTINY_CORE)
 extern volatile unsigned long millis_timer_millis;
 #    define MS_COUNTER millis_timer_millis
+#  elif defined(__AVR_ATmega4809__)
+extern volatile unsigned long timer_millis;
+#    define MS_COUNTER timer_millis
 #  else
 extern volatile unsigned long timer0_millis;
 #    define MS_COUNTER timer0_millis

--- a/platforms/avr/led_sysdefs_avr.h
+++ b/platforms/avr/led_sysdefs_avr.h
@@ -52,6 +52,11 @@ extern volatile unsigned long timer0_millis;
 #  endif
 };
 
+// special defs for mega environments
+#if defined(__AVR_ATmega4809__)
+    volatile unsigned long timer0_millis = 0;
+#endif
+
 // special defs for the tiny environments
 #if defined(__AVR_ATmega32U2__) || defined(__AVR_ATmega16U2__) || defined(__AVR_ATmega8U2__) || defined(__AVR_AT90USB162__) || defined(__AVR_ATtiny24__) || defined(__AVR_ATtiny44__) || defined(__AVR_ATtiny84__) || defined(__AVR_ATtiny25__) || defined(__AVR_ATtiny45__) || defined(__AVR_ATtiny85__) || defined(__AVR_ATtiny167__) || defined(__AVR_ATtiny87__) || defined(__AVR_ATtinyX41__) || defined(__AVR_ATtiny841__) || defined(__AVR_ATtiny441__)
 #define LIB8_ATTINY 1

--- a/platforms/avr/led_sysdefs_avr.h
+++ b/platforms/avr/led_sysdefs_avr.h
@@ -52,11 +52,6 @@ extern volatile unsigned long timer0_millis;
 #  endif
 };
 
-// special defs for mega environments
-#if defined(__AVR_ATmega4809__)
-    volatile unsigned long timer0_millis = 0;
-#endif
-
 // special defs for the tiny environments
 #if defined(__AVR_ATmega32U2__) || defined(__AVR_ATmega16U2__) || defined(__AVR_ATmega8U2__) || defined(__AVR_AT90USB162__) || defined(__AVR_ATtiny24__) || defined(__AVR_ATtiny44__) || defined(__AVR_ATtiny84__) || defined(__AVR_ATtiny25__) || defined(__AVR_ATtiny45__) || defined(__AVR_ATtiny85__) || defined(__AVR_ATtiny167__) || defined(__AVR_ATtiny87__) || defined(__AVR_ATtinyX41__) || defined(__AVR_ATtiny841__) || defined(__AVR_ATtiny441__)
 #define LIB8_ATTINY 1


### PR DESCRIPTION
The changes in PR is expecting no other behavioural changes, except on the support to ATmega4809 platform.

Changes was ported over in the zipfile in threads in https://github.com/FastLED/FastLED/issues/716, with some minimal changes detailed in the commit messages.

Pushing this forward as the changes is minimal, although I'm aware of the other working branch `avrmega` that commits are behind master. We can probably do the improvements (eg. refactoring/organizations of files) over there. Suggesting rebase master in the branch when possible. Related thread for work-in-progress on the same platform: https://github.com/FastLED/FastLED/issues/858.