### PR TITLE
Add support for non-P ATMega1284 device

### DIFF
--- a/platforms/avr/fastpin_avr.h
+++ b/platforms/avr/fastpin_avr.h
@@ -215,7 +215,7 @@ _FL_DEFPIN(16, 2, C); _FL_DEFPIN(17, 3, C); _FL_DEFPIN(18, 4, C); _FL_DEFPIN(19,
 #define SPI_UART0_CLOCK 4
 #endif
 
-#elif defined(__AVR_ATmega1284P__) || defined(__AVR_ATmega644P__) || defined(__AVR_ATmega32__) || defined(__AVR_ATmega16__)
+#elif defined(__AVR_ATmega1284__) || defined(__AVR_ATmega1284P__) || defined(__AVR_ATmega644P__) || defined(__AVR_ATmega32__) || defined(__AVR_ATmega16__)
 
 #define MAX_PIN 31
 _FL_DEFPIN(0, 0, B); _FL_DEFPIN(1, 1, B); _FL_DEFPIN(2, 2, B); _FL_DEFPIN(3, 3, B);


### PR DESCRIPTION
FastLED already supports the ATMega1284P, but I happen to only have plain ATMega1284 parts in my geekroom.

The only difference between an ATMega1284P and a regular ATMega1284 is that the P is the picopower version that uses less power, so all one needs to do is add one more define and it works just fine.