### PR TITLE
Fix unused variable t1

### DIFF
--- a/platforms/esp/32/clockless_rmt_esp32.h
+++ b/platforms/esp/32/clockless_rmt_esp32.h
@@ -538,8 +538,6 @@ protected:
     void IRAM_ATTR fillNext()
     {
         if (mPixels->has(1)) {
-            uint32_t t1 = __clock_cycles();
-            
             uint32_t one_val = mOne.val;
             uint32_t zero_val = mZero.val;
 


### PR DESCRIPTION
Deleted unused variables.

```
In file included from C:\Users\tanaka\Documents\Arduino\libraries\FastLED-master/platforms/esp/32/fastled_esp32.h:8:0,
                 from C:\Users\tanaka\Documents\Arduino\libraries\FastLED-master/platforms.h:36,
                 from C:\Users\tanaka\Documents\Arduino\libraries\FastLED-master/FastLED.h:52,
                 from sketch\M5LiteLED.h:5,
                 from sketch\M5Lite.h:30,
                 from C:\Users\tanaka\Documents\Arduino\_M5Lite\_M5Lite.ino:2:
C:\Users\tanaka\Documents\Arduino\libraries\FastLED-master/platforms/esp/32/clockless_rmt_esp32.h: In instantiation of 'void ClocklessController<DATA_PIN, T1, T2, T3, RGB_ORDER, XTRA0, FLIP, WAIT_TIME>::fillNext() [with int DATA_PIN = 27; int T1 = 60; int T2 = 150; int T3 = 90; EOrder RGB_ORDER = (EOrder)66u; int XTRA0 = 0; bool FLIP = false; int WAIT_TIME = 5]':
C:\Users\tanaka\Documents\Arduino\libraries\FastLED-master/platforms/esp/32/clockless_rmt_esp32.h:524:21:   required from 'static void ClocklessController<DATA_PIN, T1, T2, T3, RGB_ORDER, XTRA0, FLIP, WAIT_TIME>::interruptHandler(void*) [with int DATA_PIN = 27; int T1 = 60; int T2 = 150; int T3 = 90; EOrder RGB_ORDER = (EOrder)66u; int XTRA0 = 0; bool FLIP = false; int WAIT_TIME = 5]'
C:\Users\tanaka\Documents\Arduino\libraries\FastLED-master/platforms/esp/32/clockless_rmt_esp32.h:291:31:   required from 'void ClocklessController<DATA_PIN, T1, T2, T3, RGB_ORDER, XTRA0, FLIP, WAIT_TIME>::initRMT() [with int DATA_PIN = 27; int T1 = 60; int T2 = 150; int T3 = 90; EOrder RGB_ORDER = (EOrder)66u; int XTRA0 = 0; bool FLIP = false; int WAIT_TIME = 5]'
C:\Users\tanaka\Documents\Arduino\libraries\FastLED-master/platforms/esp/32/clockless_rmt_esp32.h:305:24:   required from 'void ClocklessController<DATA_PIN, T1, T2, T3, RGB_ORDER, XTRA0, FLIP, WAIT_TIME>::showPixels(PixelController<RGB_ORDER>&) [with int DATA_PIN = 27; int T1 = 60; int T2 = 150; int T3 = 90; EOrder RGB_ORDER = (EOrder)66u; int XTRA0 = 0; bool FLIP = false; int WAIT_TIME = 5]'
C:\Users\tanaka\Documents\Arduino\_M5Lite\_M5Lite.ino:38:1:   required from here
C:\Users\tanaka\Documents\Arduino\libraries\FastLED-master/platforms/esp/32/clockless_rmt_esp32.h:541:22: warning: unused variable 't1' [-Wunused-variable]
             uint32_t t1 = __clock_cycles();
                      ^
```