### PR TITLE
Fix FastPin GPIO16 on ESP8266!

### DIFF
--- a/platforms/esp/8266/fastpin_esp8266.h
+++ b/platforms/esp/8266/fastpin_esp8266.h
@@ -19,8 +19,8 @@ public:
     inline static void setOutput() { pinMode(PIN, OUTPUT); }
     inline static void setInput() { pinMode(PIN, INPUT); }
 
-    inline static void hi() __attribute__ ((always_inline)) { if(PIN < 16) { _GPB._GPOS = MASK; } else { GP16O |= MASK; } }
-    inline static void lo() __attribute__ ((always_inline)) { if(PIN < 16) { _GPB._GPOC = MASK; } else { GP16O &= ~MASK; } }
+    inline static void hi() __attribute__ ((always_inline)) { if(PIN < 16) { _GPB._GPOS = MASK; } else { GP16O = 1; } }
+    inline static void lo() __attribute__ ((always_inline)) { if(PIN < 16) { _GPB._GPOC = MASK; } else { GP16O = 0; } }
     inline static void set(register port_t val) __attribute__ ((always_inline)) { if(PIN < 16) { _GPB._GPO = val; } else { GP16O = val; }}
 
     inline static void strobe() __attribute__ ((always_inline)) { toggle(); toggle(); }

--- a/platforms/esp/8266/fastpin_esp8266.h
+++ b/platforms/esp/8266/fastpin_esp8266.h
@@ -41,7 +41,7 @@ public:
     inline static bool isset() __attribute__ ((always_inline)) { return (PIN < 16) ? (GPO & MASK) : (GP16O & MASK); }
 };
 
-#define _FL_DEFPIN(PIN, REAL_PIN) template<> class FastPin<PIN> : public _ESPPIN<REAL_PIN, (1<<(REAL_PIN & 0xFF))> {};
+#define _FL_DEFPIN(PIN, REAL_PIN) template<> class FastPin<PIN> : public _ESPPIN<REAL_PIN, (1<<(REAL_PIN & 0x0F))> {};
 
 
 #ifdef FASTLED_ESP8266_RAW_PIN_ORDER


### PR DESCRIPTION
Fix #1103 

Tested with 2 ESP8266 boards and 2 WS2811 LEDs - more details in the issue above.