### PR TITLE
Update component.mk to work with ESP-IDF 3.3.x

### DIFF
--- a/component.mk
+++ b/component.mk
@@ -1,1 +1,3 @@
-COMPONENT_ADD_INCLUDEDIRS := .
+COMPONENT_ADD_INCLUDEDIRS := ./src src/platforms/esp/32
+COMPONENT_SRCDIRS := ./src src/platforms/esp/32
+

--- a/component.mk
+++ b/component.mk
@@ -1,3 +1,2 @@
 COMPONENT_ADD_INCLUDEDIRS := ./src src/platforms/esp/32
 COMPONENT_SRCDIRS := ./src src/platforms/esp/32
-


### PR DESCRIPTION
I found, when updating FastLED to the latest `src` directory change, that I was getting a lot of errors about missing files!

I think this is due to the new `src` directory, which I think is a very good idea and cleans up the repository a lot. Seems as though `component.mk`'s list of paths is not searched recursively for files.

I also had to add `src/platforms/esp32` to the paths for the new clockless files to be found, otherwise I had a lot of these errors in the linker:

```
libmain.a(main.o):(.literal._ZN15SoulmateLibrary15lightPercentageEf[SoulmateLibrary::lightPercentage(float)]+0xc): undefined reference to `FastLED'
libmain.a(main.o):(.literal._ZN15SoulmateLibrary15lightPercentageEf[SoulmateLibrary::lightPercentage(float)]+0x10): undefined reference to `fill_solid(CRGB*, int, CRGB const&)'
libmain.a(main.o):(.literal._ZN15SoulmateLibrary15lightPercentageEf[SoulmateLibrary::lightPercentage(float)]+0x18): undefined reference to `CFastLED::show(unsigned char)'
libmain.a(main.o):(.literal._ZN15SoulmateLibrary18playCurrentRoutineEv[SoulmateLibrary::playCurrentRoutine()]+0x0): undefined reference to `hsv2rgb_rainbow(CHSV const&, CRGB&)'
libmain.a(main.o):(.literal._ZN15SoulmateLibrary10showPixelsEv[SoulmateLibrary::showPixels()]+0x1c): undefined reference to `blend(CRGB const&, CRGB const&, unsigned char)'
libmain.a(main.o):(.literal._ZN15SoulmateLibrary5setupEv[SoulmateLibrary::setup()]+0x24): undefined reference to `FastLED'
libmain.a(main.o):(.literal._ZN15SoulmateLibrary5setupEv[SoulmateLibrary::setup()]+0x28): undefined reference to `calculate_max_brightness_for_power_mW(unsig
```

I found also that I had to add `COMPONENT_SRCDIRS` for this to work. Removing either of these lines causes compilation to fail. 

If there is a simpler fix, I'd love to know what it is, but this made everything work for me!