### PR TITLE
Inline RMT functions needed to get code in IRAM

### DIFF
--- a/src/platforms/esp/32/clockless_rmt_esp32.cpp
+++ b/src/platforms/esp/32/clockless_rmt_esp32.cpp
@@ -273,8 +273,8 @@ void ESP32RMTController::doneOnChannel(rmt_channel_t channel, void * arg)
 
     // -- Turn off the interrupts
     // rmt_set_tx_intr_en(channel, false);
-    RMT.int_ena.val &= ~(1 << (mRMT_channel * 3));
-    RMT.int_ena.val |= (enable << (mRMT_channel * 3));
+    RMT.int_ena.val &= ~(1 << (channel * 3));
+    // Not needed: RMT.int_ena.val |= (false << (mRMT_channel * 3));
 
     gOnChannel[channel] = NULL;
     gNumDone++;

--- a/src/platforms/esp/32/clockless_rmt_esp32.cpp
+++ b/src/platforms/esp/32/clockless_rmt_esp32.cpp
@@ -252,7 +252,8 @@ void ESP32RMTController::startOnChannel(int channel)
 //    Setting this RMT flag is what actually kicks off the peripheral
 void ESP32RMTController::tx_start()
 {
-    rmt_tx_start(mRMT_channel, true);
+    //rmt_tx_start(mRMT_channel, true);
+    RMT.conf_ch[mRMT_channel].conf1.tx_start = 1;
     mLastFill = __clock_cycles();
 }
 
@@ -271,7 +272,9 @@ void ESP32RMTController::doneOnChannel(rmt_channel_t channel, void * arg)
     gpio_matrix_out(pController->mPin, 0x100, 0, 0);
 
     // -- Turn off the interrupts
-    rmt_set_tx_intr_en(channel, false);
+    // rmt_set_tx_intr_en(channel, false);
+    RMT.int_ena.val &= ~(1 << (mRMT_channel * 3));
+    RMT.int_ena.val |= (enable << (mRMT_channel * 3));
 
     gOnChannel[channel] = NULL;
     gNumDone++;

--- a/src/platforms/esp/32/clockless_rmt_esp32.cpp
+++ b/src/platforms/esp/32/clockless_rmt_esp32.cpp
@@ -252,8 +252,8 @@ void ESP32RMTController::startOnChannel(int channel)
 //    Setting this RMT flag is what actually kicks off the peripheral
 void ESP32RMTController::tx_start()
 {
-    //rmt_tx_start(mRMT_channel, true);
-    RMT.conf_ch[mRMT_channel].conf1.tx_start = 1;
+    rmt_tx_start(mRMT_channel, true);
+    //RMT.conf_ch[mRMT_channel].conf1.tx_start = 1;
     mLastFill = __clock_cycles();
 }
 

--- a/src/platforms/esp/32/clockless_rmt_esp32.cpp
+++ b/src/platforms/esp/32/clockless_rmt_esp32.cpp
@@ -341,11 +341,11 @@ void IRAM_ATTR ESP32RMTController::fillNext(bool check_time)
         if (mLastFill != 0 and now > mLastFill) {
             uint32_t delta = (now - mLastFill);
             if (delta > mMaxCyclesPerFill) {
-                Serial.print(delta);
-                Serial.print(" BAIL ");
-                Serial.println(mCur);
+                // Serial.print(delta);
+                // Serial.print(" BAIL ");
+                // Serial.println(mCur);
                 mCur = mSize;
-                rmt_tx_stop(mRMT_channel);
+                // rmt_tx_stop(mRMT_channel);
             }
         }
     }

--- a/src/platforms/esp/32/clockless_rmt_esp32.cpp
+++ b/src/platforms/esp/32/clockless_rmt_esp32.cpp
@@ -137,7 +137,7 @@ void ESP32RMTController::init()
 
 // -- Show this string of pixels
 //    This is the main entry point for the pixel controller
-void ESP32RMTController::showPixels()
+void IRAM_ATTR ESP32RMTController::showPixels()
 {
     if (gNumStarted == 0) {
         // -- First controller: make sure everything is set up
@@ -197,7 +197,7 @@ void ESP32RMTController::showPixels()
 // -- Start up the next controller
 //    This method is static so that it can dispatch to the
 //    appropriate startOnChannel method of the given controller.
-void ESP32RMTController::startNext(int channel)
+void IRAM_ATTR ESP32RMTController::startNext(int channel)
 {
     if (gNext < gNumControllers) {
         ESP32RMTController * pController = gControllers[gNext];
@@ -209,7 +209,7 @@ void ESP32RMTController::startNext(int channel)
 // -- Start this controller on the given channel
 //    This function just initiates the RMT write; it does not wait
 //    for it to finish.
-void ESP32RMTController::startOnChannel(int channel)
+void IRAM_ATTR ESP32RMTController::startOnChannel(int channel)
 {
     // -- Assign this channel and configure the RMT
     mRMT_channel = rmt_channel_t(channel);
@@ -250,10 +250,15 @@ void ESP32RMTController::startOnChannel(int channel)
 
 // -- Start RMT transmission
 //    Setting this RMT flag is what actually kicks off the peripheral
-void ESP32RMTController::tx_start()
+void IRAM_ATTR ESP32RMTController::tx_start()
 {
-    rmt_tx_start(mRMT_channel, true);
-    //RMT.conf_ch[mRMT_channel].conf1.tx_start = 1;
+    // rmt_tx_start(mRMT_channel, true);
+    // Inline the code for rmt_tx_start, so it can be placed in IRAM
+    RMT.conf_ch[mRMT_channel].conf1.mem_rd_rst = 1;
+    RMT.conf_ch[mRMT_channel].conf1.mem_rd_rst = 0;
+    RMT.int_ena.val &= ~(1 << (mRMT_channel * 3));
+    RMT.int_ena.val |= (1 << (mRMT_channel * 3));
+    RMT.conf_ch[mRMT_channel].conf1.tx_start = 1;
     mLastFill = __clock_cycles();
 }
 
@@ -263,7 +268,7 @@ void ESP32RMTController::tx_start()
 //    handler (below), or as a callback from the built-in
 //    interrupt handler. It is static because we don't know which
 //    controller is done until we look it up.
-void ESP32RMTController::doneOnChannel(rmt_channel_t channel, void * arg)
+void IRAM_ATTR ESP32RMTController::doneOnChannel(rmt_channel_t channel, void * arg)
 {
     ESP32RMTController * pController = gOnChannel[channel];
 
@@ -273,8 +278,10 @@ void ESP32RMTController::doneOnChannel(rmt_channel_t channel, void * arg)
 
     // -- Turn off the interrupts
     // rmt_set_tx_intr_en(channel, false);
+    // Inline the code for rmt_tx_stop, so it can be placed in IRAM
     RMT.int_ena.val &= ~(1 << (channel * 3));
-    // Not needed: RMT.int_ena.val |= (false << (mRMT_channel * 3));
+    RMT.conf_ch[channel].conf1.mem_rd_rst = 1;
+    RMT.conf_ch[channel].conf1.mem_rd_rst = 0;
 
     gOnChannel[channel] = NULL;
     gNumDone++;
@@ -344,8 +351,14 @@ void IRAM_ATTR ESP32RMTController::fillNext(bool check_time)
                 // Serial.print(delta);
                 // Serial.print(" BAIL ");
                 // Serial.println(mCur);
-                mCur = mSize;
                 // rmt_tx_stop(mRMT_channel);
+                // Inline the code for rmt_tx_stop, so it can be placed in IRAM
+                * mRMT_mem_start = 0;
+                RMT.int_ena.val &= ~(1 << (mRMT_channel * 3));
+                RMT.conf_ch[mRMT_channel].conf1.tx_start = 0;
+                RMT.conf_ch[mRMT_channel].conf1.mem_rd_rst = 1;
+                RMT.conf_ch[mRMT_channel].conf1.mem_rd_rst = 0;
+                return;
             }
         }
     }


### PR DESCRIPTION
These changes should ensure that all code needed to push the bits out during FastLED.show() are in IRAM. Some of the ESP-IDF function we rely on do not have the IRAM_ATTR, so if they are executed during a flash memory operation, the program fails. The solution is to inline the code (basically, direct access to RMT registers) into our functions, which do have the IRAM attribute.