### PR TITLE
Fix for issue #1130: don't use pin 0 to configure the RMT device

### DIFF
--- a/src/platforms/esp/32/clockless_rmt_esp32.cpp
+++ b/src/platforms/esp/32/clockless_rmt_esp32.cpp
@@ -84,7 +84,7 @@ uint32_t * ESP32RMTController::getPixelBuffer(int size_in_bytes)
 
 // -- Initialize RMT subsystem
 //    This only needs to be done once
-void ESP32RMTController::init()
+void ESP32RMTController::init(gpio_num_t pin)
 {
     if (gInitialized) return;
 
@@ -95,7 +95,7 @@ void ESP32RMTController::init()
         rmt_config_t rmt_tx;
         rmt_tx.channel = rmt_channel_t(i);
         rmt_tx.rmt_mode = RMT_MODE_TX;
-        rmt_tx.gpio_num = gpio_num_t(0);  // The particular pin will be assigned later
+        rmt_tx.gpio_num = pin;  // The particular pin will be assigned later
         rmt_tx.mem_block_num = FASTLED_RMT_MEM_BLOCKS;
         rmt_tx.clk_div = DIVIDER;
         rmt_tx.tx_config.loop_en = false;
@@ -141,7 +141,7 @@ void IRAM_ATTR ESP32RMTController::showPixels()
 {
     if (gNumStarted == 0) {
         // -- First controller: make sure everything is set up
-        ESP32RMTController::init();
+        ESP32RMTController::init(mPin);
 
 #if FASTLED_ESP32_FLASH_LOCK == 1
         // -- Make sure no flash operations happen right now

--- a/src/platforms/esp/32/clockless_rmt_esp32.h
+++ b/src/platforms/esp/32/clockless_rmt_esp32.h
@@ -239,8 +239,9 @@ public:
     uint32_t * getPixelBuffer(int size_in_bytes);
 
     // -- Initialize RMT subsystem
-    //    This only needs to be done once
-    static void init();
+    //    This only needs to be done once. The particular pin is not important,
+    //    because we need to configure the RMT channels on the fly.
+    static void init(gpio_num_t pin);
 
     // -- Show this string of pixels
     //    This is the main entry point for the pixel controller


### PR DESCRIPTION
The RMT init code only needs to be invoked one time, the first time show() is called, so I chose pin 0 as a stand-in for whatever pins would be used later. Unfortunately, the rmt_config code does configure the pin, so choosing pin 0 is not benign. Instead, I just pass in one of the pins that will actually be used (it doesn't matter which one).

In the long run I'd like to change the setup code to avoid this problem altogether.