### PR TITLE
Build examples in CI using Github Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,28 @@
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+name: build
+jobs:
+
+  build:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v2
+
+      - name: install python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.8'
+
+      - name: install platformio
+        run: |
+          pip install platformio==5.0.3
+
+      - name: build FastLED examples
+        run: ./ci/ci-compile

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/FastLED/public)
 [![arduino-library-badge](https://www.ardu-badge.com/badge/FastLED.svg)](https://www.ardu-badge.com/FastLED)
+![build status](https://github.com/FastLED/FastLED/workflows/build/badge.svg)
 
 IMPORTANT NOTE: For AVR based systems, avr-gcc 4.8.x is supported and tested.  This means Arduino 1.6.5 and later.
 

--- a/ci/ci-compile
+++ b/ci/ci-compile
@@ -1,0 +1,36 @@
+#!/bin/bash
+#
+# compile FastLED examples with platformio for various boards. This script
+# is usually run by the CI, but can also be run locally. Only dependency
+# is platformio.
+#
+# usage:
+#   [BOARDS=boards] [EXAMPLES=examples] ./ci-compile
+#
+# e.g.
+#  $ ./compile-ci   
+#         - compile all board/examples combinations
+#
+#  $ BOARDS="esp32 esp01" EXAMPLES=Blink ./compile-ci 
+#         - compile only Blink example for the esp32 and esp8266 platforms
+#                                              
+set -eou pipefail
+
+# List of examples that will be compiled by default
+EXAMPLES=${EXAMPLES:-"Blink ColorPalette ColorTemperature Cylon DemoReel100
+    Fire2012  FirstLight  Multiple/MultipleStripsInOneArray
+    Multiple/ArrayOfLedArrays Noise NoisePlayground NoisePlusPalette Pacifica
+    Pride2015 RGBCalibrate RGBSetDemo TwinkleFox XYMatrix"}
+
+# list of boards to compile for by default
+BOARDS=${BOARDS:-"uno esp32dev esp01 yun digix teensy30"}
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+BOARD_OPTS=$(for b in $BOARDS; do echo -n "--board $b "; done)
+
+cd "$DIR/.."
+
+for d in $EXAMPLES ; do 
+  echo "*** building example $d for $BOARDS ***"
+  pio ci $BOARD_OPTS --lib=src "examples/$d/"*ino
+done

--- a/examples/Cylon/Cylon.ino
+++ b/examples/Cylon/Cylon.ino
@@ -6,7 +6,7 @@
 // For led chips like Neopixels, which have a data line, ground, and power, you just
 // need to define DATA_PIN.  For led chipsets that are SPI based (four wires - data, clock,
 // ground, and power), like the LPD8806, define both DATA_PIN and CLOCK_PIN
-#define DATA_PIN 7
+#define DATA_PIN 2
 #define CLOCK_PIN 13
 
 // Define the array of leds

--- a/examples/Multiple/ArrayOfLedArrays/ArrayOfLedArrays.ino
+++ b/examples/Multiple/ArrayOfLedArrays/ArrayOfLedArrays.ino
@@ -12,14 +12,14 @@ CRGB leds[NUM_STRIPS][NUM_LEDS_PER_STRIP];
 // For mirroring strips, all the "special" stuff happens just in setup.  We
 // just addLeds multiple times, once for each strip
 void setup() {
-  // tell FastLED there's 60 NEOPIXEL leds on pin 10
-  FastLED.addLeds<NEOPIXEL, 10>(leds[0], NUM_LEDS_PER_STRIP);
+  // tell FastLED there's 60 NEOPIXEL leds on pin 2
+  FastLED.addLeds<NEOPIXEL, 2>(leds[0], NUM_LEDS_PER_STRIP);
 
-  // tell FastLED there's 60 NEOPIXEL leds on pin 11
-  FastLED.addLeds<NEOPIXEL, 11>(leds[1], NUM_LEDS_PER_STRIP);
+  // tell FastLED there's 60 NEOPIXEL leds on pin 3
+  FastLED.addLeds<NEOPIXEL, 3>(leds[1], NUM_LEDS_PER_STRIP);
 
-  // tell FastLED there's 60 NEOPIXEL leds on pin 12
-  FastLED.addLeds<NEOPIXEL, 12>(leds[2], NUM_LEDS_PER_STRIP);
+  // tell FastLED there's 60 NEOPIXEL leds on pin 4
+  FastLED.addLeds<NEOPIXEL, 4>(leds[2], NUM_LEDS_PER_STRIP);
 
 }
 

--- a/examples/Multiple/MultipleStripsInOneArray/MultipleStripsInOneArray.ino
+++ b/examples/Multiple/MultipleStripsInOneArray/MultipleStripsInOneArray.ino
@@ -13,14 +13,14 @@ CRGB leds[NUM_STRIPS * NUM_LEDS_PER_STRIP];
 // For mirroring strips, all the "special" stuff happens just in setup.  We
 // just addLeds multiple times, once for each strip
 void setup() {
-  // tell FastLED there's 60 NEOPIXEL leds on pin 10, starting at index 0 in the led array
-  FastLED.addLeds<NEOPIXEL, 10>(leds, 0, NUM_LEDS_PER_STRIP);
+  // tell FastLED there's 60 NEOPIXEL leds on pin 2, starting at index 0 in the led array
+  FastLED.addLeds<NEOPIXEL, 2>(leds, 0, NUM_LEDS_PER_STRIP);
 
-  // tell FastLED there's 60 NEOPIXEL leds on pin 11, starting at index 60 in the led array
-  FastLED.addLeds<NEOPIXEL, 11>(leds, NUM_LEDS_PER_STRIP, NUM_LEDS_PER_STRIP);
+  // tell FastLED there's 60 NEOPIXEL leds on pin 3, starting at index 60 in the led array
+  FastLED.addLeds<NEOPIXEL, 3>(leds, NUM_LEDS_PER_STRIP, NUM_LEDS_PER_STRIP);
 
-  // tell FastLED there's 60 NEOPIXEL leds on pin 12, starting at index 120 in the led array
-  FastLED.addLeds<NEOPIXEL, 12>(leds, 2 * NUM_LEDS_PER_STRIP, NUM_LEDS_PER_STRIP);
+  // tell FastLED there's 60 NEOPIXEL leds on pin 4, starting at index 120 in the led array
+  FastLED.addLeds<NEOPIXEL, 4>(leds, 2 * NUM_LEDS_PER_STRIP, NUM_LEDS_PER_STRIP);
 
 }
 

--- a/examples/Noise/Noise.ino
+++ b/examples/Noise/Noise.ino
@@ -69,7 +69,7 @@ void setup() {
   // Serial.begin(38400);
   // Serial.println("resetting!");
   delay(3000);
-  LEDS.addLeds<WS2811,5,RGB>(leds,NUM_LEDS);
+  LEDS.addLeds<WS2811,2,RGB>(leds,NUM_LEDS);
   LEDS.setBrightness(96);
 
   // Initialize our coordinates to some random values

--- a/examples/NoisePlayground/NoisePlayground.ino
+++ b/examples/NoisePlayground/NoisePlayground.ino
@@ -61,7 +61,7 @@ void setup() {
   Serial.println("resetting!");
 
   delay(3000);
-  LEDS.addLeds<WS2811,6,GRB>(leds,NUM_LEDS);
+  LEDS.addLeds<WS2811,2,GRB>(leds,NUM_LEDS);
   LEDS.setBrightness(96);
 
   hxy = (uint32_t)((uint32_t)random16() << 16) + (uint32_t)random16();

--- a/examples/RGBSetDemo/RGBSetDemo.ino
+++ b/examples/RGBSetDemo/RGBSetDemo.ino
@@ -3,7 +3,7 @@
 
 CRGBArray<NUM_LEDS> leds;
 
-void setup() { FastLED.addLeds<NEOPIXEL,6>(leds, NUM_LEDS); }
+void setup() { FastLED.addLeds<NEOPIXEL,2>(leds, NUM_LEDS); }
 
 void loop(){ 
   static uint8_t hue;


### PR DESCRIPTION
Reason for Request: make sure code compiles when new PR's are submitted. This PR could later be used as a base for adding host-based unit tests for e.g. platform-independent code.

The examples are built for various different boards/platforms. Where necessary, examples were slightly changed to enable compilation also for ESP8266 and ESP32 platforms (to pass `static_asserts` checking for certain pin's).

The script `ci/ci-compile` performs the build and is run during a Github Actions workflow. The script can also be run locally.

See https://github.com/jandelgado/FastLED/actions/runs/445634210 for an example 
