### PR TITLE
add a "host" platform

### DIFF
--- a/src/led_sysdefs.h
+++ b/src/led_sysdefs.h
@@ -5,7 +5,9 @@
 
 #include "fastled_config.h"
 
-#if defined(NRF51) || defined(__RFduino__) || defined (__Simblee__)
+#if defined(FASTLED_NO_MCU)
+#include "platforms/no_mcu/led_sysdefs_no_mcu.h"
+#elif defined(NRF51) || defined(__RFduino__) || defined (__Simblee__)
 #include "platforms/arm/nrf51/led_sysdefs_arm_nrf51.h"
 #elif defined(NRF52_SERIES)
 #include "platforms/arm/nrf52/led_sysdefs_arm_nrf52.h"

--- a/src/platforms.h
+++ b/src/platforms.h
@@ -5,7 +5,9 @@
 
 #include "fastled_config.h"
 
-#if defined(NRF51)
+#if defined(FASTLED_NO_MCU)
+// nothing to do
+#elif defined(NRF51)
 #include "platforms/arm/nrf51/fastled_arm_nrf51.h"
 #elif defined(NRF52_SERIES)
 #include "platforms/arm/nrf52/fastled_arm_nrf52.h"

--- a/src/platforms/no_mcu/led_sysdefs_no_mcu.h
+++ b/src/platforms/no_mcu/led_sysdefs_no_mcu.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#define F_CPU 16000000
+
+typedef volatile uint32_t RoReg;
+typedef volatile uint32_t RwReg;
+typedef unsigned long prog_uint32_t;
+
+
+// Default to NOT using PROGMEM here
+#ifndef FASTLED_USE_PROGMEM
+# define FASTLED_USE_PROGMEM 0
+#endif
+
+#ifndef FASTLED_ALLOW_INTERRUPTS
+# define FASTLED_ALLOW_INTERRUPTS 1
+# define INTERRUPT_THRESHOLD 0
+#endif
+
+#define NEED_CXX_BITS
+
+// These can be overridden
+#   define FASTLED_ESP32_RAW_PIN_ORDER
+


### PR DESCRIPTION
I added a "host" platform to compile FastLED on your host system, without cross-compilation.

The platform is selected by `#define` "FASTLED_HOST".

This allows e.g. to compile FastLED for the Web Assembly (WASM) target and run FastLED code directly in the browser (for demonstration and testing purposes).

Visit https://jandelgado.github.io/fastled-wasm for a demo. I had only to do slight modifications to the original FastLED examples. By adding a few `#ifdefs` and less use of global variables,  it would be also easily possible to directly compile the examples for WASM, without modifications.

![image](https://user-images.githubusercontent.com/11670798/103302934-130f6500-4a05-11eb-8e90-a37a021b2277.png)

BR
Jan
