### PR TITLE
Fix for a bug that was limiting parallelism

### DIFF
--- a/src/platforms/esp/32/clockless_rmt_esp32.cpp
+++ b/src/platforms/esp/32/clockless_rmt_esp32.cpp
@@ -32,7 +32,12 @@ CMinWait<50>   gWait;
 
 static bool gInitialized = false;
 
-ESP32RMTController::ESP32RMTController(int DATA_PIN, int T1, int T2, int T3)
+// -- Stored values for FASTLED_RMT_MAX_CHANNELS and FASTLED_RMT_MEM_BLOCKS
+int ESP32RMTController::gMaxChannel;
+int ESP32RMTController::gMemBlocks;
+
+
+ESP32RMTController::ESP32RMTController(int DATA_PIN, int T1, int T2, int T3, int maxChannel, int memBlocks)
     : mPixelData(0), 
       mSize(0), 
       mCur(0), 
@@ -41,6 +46,10 @@ ESP32RMTController::ESP32RMTController(int DATA_PIN, int T1, int T2, int T3)
       mBufferSize(0),
       mCurPulse(0)
 {
+    // -- Store the max channel and mem blocks parameters
+    gMaxChannel = maxChannel;
+    gMemBlocks = memBlocks;
+
     // -- Precompute rmt items corresponding to a zero bit and a one bit
     //    according to the timing values given in the template instantiation
     // T1H
@@ -73,11 +82,11 @@ ESP32RMTController::ESP32RMTController(int DATA_PIN, int T1, int T2, int T3)
 // -- Get or create the buffer for the pixel data
 //    We can't allocate it ahead of time because we don't have
 //    the PixelController object until show is called.
-uint32_t * ESP32RMTController::getPixelBuffer(int size_in_bytes)
+uint8_t * ESP32RMTController::getPixelBuffer(int size_in_bytes)
 {
     if (mPixelData == 0) {
-        mSize = ((size_in_bytes-1) / sizeof(uint32_t)) + 1;
-        mPixelData = (uint32_t *) calloc( mSize, sizeof(uint32_t));
+        mSize = size_in_bytes;
+        mPixelData = (uint8_t *) malloc(mSize);
     }
     return mPixelData;
 }
@@ -88,15 +97,15 @@ void ESP32RMTController::init(gpio_num_t pin)
 {
     if (gInitialized) return;
 
-    for (int i = 0; i < FASTLED_RMT_MAX_CHANNELS; i++) {
+    for (int i = 0; i < gMaxChannel; i += gMemBlocks) {
         gOnChannel[i] = NULL;
 
         // -- RMT configuration for transmission
         rmt_config_t rmt_tx;
         rmt_tx.channel = rmt_channel_t(i);
         rmt_tx.rmt_mode = RMT_MODE_TX;
-        rmt_tx.gpio_num = pin;  // The particular pin will be assigned later
-        rmt_tx.mem_block_num = FASTLED_RMT_MEM_BLOCKS;
+        rmt_tx.gpio_num = pin;
+        rmt_tx.mem_block_num = gMemBlocks;
         rmt_tx.clk_div = DIVIDER;
         rmt_tx.tx_config.loop_en = false;
         rmt_tx.tx_config.carrier_level = RMT_CARRIER_LEVEL_LOW;
@@ -165,11 +174,11 @@ void IRAM_ATTR ESP32RMTController::showPixels()
 
         // -- First, fill all the available channels
         int channel = 0;
-        while (channel < FASTLED_RMT_MAX_CHANNELS && gNext < gNumControllers) {
+        while (channel < gMaxChannel && gNext < gNumControllers) {
             ESP32RMTController::startNext(channel);
             // -- Important: when we use more than one memory block, we need to
             //    skip the channels that would otherwise overlap in memory.
-            channel += FASTLED_RMT_MEM_BLOCKS;
+            channel += gMemBlocks;
         }
 
         // -- Wait here while the data is sent. The interrupt handler
@@ -316,7 +325,7 @@ void IRAM_ATTR ESP32RMTController::interruptHandler(void *arg)
     uint8_t channel;
 
     bool stuff_to_do = false;
-    for (channel = 0; channel < FASTLED_RMT_MAX_CHANNELS; channel++) {
+    for (channel = 0; channel < gMaxChannel; channel++) {
         int tx_done_bit = channel * 3;
         int tx_next_bit = channel + 24;
 
@@ -374,16 +383,16 @@ void IRAM_ATTR ESP32RMTController::fillNext(bool check_time)
     // -- Use locals for speed
     volatile register uint32_t * pItem =  mRMT_mem_ptr;
 
-    for (register int i = 0; i < PULSES_PER_FILL/32; i++) {
+    for (register int i = 0; i < PULSES_PER_FILL/8; i++) {
         if (mCur < mSize) {
 
             // -- Get the next four bytes of pixel data
-            register uint32_t pixeldata = mPixelData[mCur];
+            register uint32_t pixeldata = mPixelData[mCur] << 24;
             mCur++;
             
             // Shift bits out, MSB first, setting RMTMEM.chan[n].data32[x] to the 
             // rmt_item32_t value corresponding to the buffered bit value
-            for (register uint32_t j = 0; j < 32; j++) {
+            for (register uint32_t j = 0; j < 8; j++) {
                 *pItem++ = (pixeldata & 0x80000000L) ? one_val : zero_val;
                 // Replaces: RMTMEM.chan[mRMT_channel].data32[mCurPulse].val = val;
 


### PR DESCRIPTION
These changes fix a bug related to the management of the number of RMT channels used (and the number of RMT memory blocks used). There were two problems: 
(1) The preprocessor values FASTLED_RMT_MAX_CHANNELS and FASTLED_RMT_MEM_BLOCKS were not configurable from within a sketch because the code for the driver is now in a separate cpp file, which is not compiled with the sketch file.
(2) FASTLED_RMT_MAX_CHANNELS was being incorrectly computed as a function of FASTLED_RMT_MEM_BLOCKS, which is not right. The max channel should be independent of the number of memory blocks.
This PR also includes a change to the code that copies the pixel data to make it faster.