### PR TITLE
Add hardware SPI support for Arduino Nano Every

### DIFF
--- a/src/platforms/avr/fastpin_avr.h
+++ b/src/platforms/avr/fastpin_avr.h
@@ -215,14 +215,11 @@ _FL_DEFPIN(16, 1, D); _FL_DEFPIN(17, 0, D); _FL_DEFPIN(18, 2, A); _FL_DEFPIN(19,
 _FL_DEFPIN(20, 4, D); _FL_DEFPIN(21, 5, D); _FL_DEFPIN(22, 2, A);
 
 // To confirm for the SPI interfaces
-//#define SPI_DATA 18
-//#define SPI_CLOCK 13
-//#define SPI_SELECT 19
-//#define AVR_HARDWARE_SPI 1
+#define SPI_DATA 11
+#define SPI_CLOCK 13
+#define SPI_SELECT 8
+#define AVR_HARDWARE_SPI 1
 #define HAS_HARDWARE_PIN_SUPPORT 1
-
-//#define SPI_UART0_DATA 1
-//#define SPI_UART0_CLOCK 4
 
 #elif defined(__AVR_ATmega4809__)
 


### PR DESCRIPTION
Tested working with official Arduino Nano Every and an APA102 LED strip.

The Arduino Nano Every pinout sheet (https://content.arduino.cc/assets/Pinout-NANOevery_latest.pdf),  lists the SPI0 ports in the ALT2 portmux position (PE[3:0]), so that's where they're set in this PR using the PORTMUX_TWISPIROUTEA register (page 138 in http://ww1.microchip.com/downloads/en/DeviceDoc/ATmega4808-4809-Data-Sheet-DS40002173A.pdf). This could be configurable with some more effort.