### PR TITLE
Add interrupt enable and disable points between each tightly timed clockless signal.

### DIFF
--- a/src/controller.h
+++ b/src/controller.h
@@ -148,7 +148,7 @@ public:
     }
 
     static CRGB computeAdjustment(uint8_t scale, const CRGB & colorCorrection, const CRGB & colorTemperature) {
-      #if defined(NO_CORRECTION) && (NO_CORRECTION==1)
+      #if defined(NO_COLOR_CORRECTION) && (NO_COLOR_CORRECTION==1)
               return CRGB(scale,scale,scale);
       #else
               CRGB adj(0,0,0);

--- a/src/platforms/avr/clockless_trinket.h
+++ b/src/platforms/avr/clockless_trinket.h
@@ -406,31 +406,31 @@ protected:
 				// Inline scaling - RGB ordering
 				// DNOP
 				
-				cli(); HI1 _D1(1) QLO2(b0, 7) LDSCL4(b1,O1) 	_D2(4)	LO1	sei();	PRESCALEA2(d1)	_D3(2) 
-				cli(); HI1 _D1(1) QLO2(b0, 6) PRESCALEB4(d1)	_D2(4)	LO1	sei();	SCALE12(b1,0)	_D3(2) 
-				cli(); HI1 _D1(1) QLO2(b0, 5) RORSC14(b1,1) 	_D2(4)	LO1 sei();	RORCLC2(b1)		_D3(2) 
-				cli(); HI1 _D1(1) QLO2(b0, 4) SCROR14(b1,2)		_D2(4)	LO1 sei();	SCALE12(b1,3)	_D3(2) 
-				cli(); HI1 _D1(1) QLO2(b0, 3) RORSC14(b1,4) 	_D2(4)	LO1 sei();	RORCLC2(b1) 	_D3(2) 
-				cli(); HI1 _D1(1) QLO2(b0, 2) SCROR14(b1,5) 	_D2(4)	LO1 sei();	SCALE12(b1,6)	_D3(2) 
-				cli(); HI1 _D1(1) QLO2(b0, 1) RORSC14(b1,7) 	_D2(4)	LO1 sei();	RORCLC2(b1) 	_D3(2) 
-				cli(); HI1 _D1(1) QLO2(b0, 0)
+				cli(); HI1 _D1(2) QLO2(b0, 7) LDSCL4(b1,O1) 	_D2(4)	LO1	sei();	PRESCALEA2(d1)	_D3(3) 
+				cli(); HI1 _D1(2) QLO2(b0, 6) PRESCALEB4(d1)	_D2(4)	LO1	sei();	SCALE12(b1,0)	_D3(3) 
+				cli(); HI1 _D1(2) QLO2(b0, 5) RORSC14(b1,1) 	_D2(4)	LO1 sei();	RORCLC2(b1)		_D3(3) 
+				cli(); HI1 _D1(2) QLO2(b0, 4) SCROR14(b1,2)		_D2(4)	LO1 sei();	SCALE12(b1,3)	_D3(3) 
+				cli(); HI1 _D1(2) QLO2(b0, 3) RORSC14(b1,4) 	_D2(4)	LO1 sei();	RORCLC2(b1) 	_D3(3) 
+				cli(); HI1 _D1(2) QLO2(b0, 2) SCROR14(b1,5) 	_D2(4)	LO1 sei();	SCALE12(b1,6)	_D3(3) 
+				cli(); HI1 _D1(2) QLO2(b0, 1) RORSC14(b1,7) 	_D2(4)	LO1 sei();	RORCLC2(b1) 	_D3(3) 
+				cli(); HI1 _D1(2) QLO2(b0, 0)
 				switch(XTRA0) {
 					case 4: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)  /* fall through */
 					case 3: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)  /* fall through */
 					case 2: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)  /* fall through */
 					case 1: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)
 				}
-				MOV_ADDDE14(b0,b1,d1,e1) _D2(4) LO1 sei(); _D3(0) 
+				MOV_ADDDE14(b0,b1,d1,e1) _D2(4) LO1 sei(); _D3(2) 
 				
 
-				cli(); HI1 _D1(1) QLO2(b0, 7) LDSCL4(b1,O2) 	_D2(4)	LO1	sei();	PRESCALEA2(d2)	_D3(2)
-				cli(); HI1 _D1(1) QLO2(b0, 6) PSBIDATA4(d2)		_D2(4)	LO1	sei();	SCALE22(b1,0)	_D3(2)
-				cli(); HI1 _D1(1) QLO2(b0, 5) RORSC24(b1,1) 	_D2(4)	LO1 sei();	RORCLC2(b1) 	_D3(2)
-				cli(); HI1 _D1(1) QLO2(b0, 4) SCROR24(b1,2)		_D2(4)	LO1 sei();	SCALE22(b1,3)	_D3(2)
-				cli(); HI1 _D1(1) QLO2(b0, 3) RORSC24(b1,4) 	_D2(4)	LO1 sei();	RORCLC2(b1) 	_D3(2)
-				cli(); HI1 _D1(1) QLO2(b0, 2) SCROR24(b1,5) 	_D2(4)	LO1 sei();	SCALE22(b1,6)	_D3(2)
-				cli(); HI1 _D1(1) QLO2(b0, 1) RORSC24(b1,7) 	_D2(4)	LO1 sei();	RORCLC2(b1) 	_D3(2)
-				cli(); HI1 _D1(1) QLO2(b0, 0)
+				cli(); HI1 _D1(2) QLO2(b0, 7) LDSCL4(b1,O2) 	_D2(4)	LO1	sei();	PRESCALEA2(d2)	_D3(3)
+				cli(); HI1 _D1(2) QLO2(b0, 6) PSBIDATA4(d2)		_D2(4)	LO1	sei();	SCALE22(b1,0)	_D3(3)
+				cli(); HI1 _D1(2) QLO2(b0, 5) RORSC24(b1,1) 	_D2(4)	LO1 sei();	RORCLC2(b1) 	_D3(3)
+				cli(); HI1 _D1(2) QLO2(b0, 4) SCROR24(b1,2)		_D2(4)	LO1 sei();	SCALE22(b1,3)	_D3(3)
+				cli(); HI1 _D1(2) QLO2(b0, 3) RORSC24(b1,4) 	_D2(4)	LO1 sei();	RORCLC2(b1) 	_D3(3)
+				cli(); HI1 _D1(2) QLO2(b0, 2) SCROR24(b1,5) 	_D2(4)	LO1 sei();	SCALE22(b1,6)	_D3(3)
+				cli(); HI1 _D1(2) QLO2(b0, 1) RORSC24(b1,7) 	_D2(4)	LO1 sei();	RORCLC2(b1) 	_D3(3)
+				cli(); HI1 _D1(2) QLO2(b0, 0)
 				switch(XTRA0) {
 					case 4: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)  /* fall through */
 					case 3: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)  /* fall through */
@@ -441,22 +441,22 @@ protected:
 				// Because Prescale on the middle byte also increments the data counter,
 				// we have to do both halves of updating d2 here - negating it (in the
 				// MOV_NEGD24 macro) and then adding E back into it
-				MOV_NEGD24(b0,b1,d2) _D2(4) LO1 sei(); ADDDE1(d2,e2) _D3(1)
-				cli(); HI1 _D1(1) QLO2(b0, 7) LDSCL4(b1,O0) 	_D2(4)	LO1 sei();	PRESCALEA2(d0)	_D3(2)
-				cli(); HI1 _D1(1) QLO2(b0, 6) PRESCALEB4(d0)	_D2(4)	LO1 sei();	SCALE02(b1,0)	_D3(2)
-				cli(); HI1 _D1(1) QLO2(b0, 5) RORSC04(b1,1) 	_D2(4)	LO1 sei(); RORCLC2(b1) 	_D3(2)
-				cli(); HI1 _D1(1) QLO2(b0, 4) SCROR04(b1,2)		_D2(4)	LO1 sei(); SCALE02(b1,3)	_D3(2)
-				cli(); HI1 _D1(1) QLO2(b0, 3) RORSC04(b1,4) 	_D2(4)	LO1 sei(); RORCLC2(b1)  	_D3(2)
-				cli(); HI1 _D1(1) QLO2(b0, 2) SCROR04(b1,5) 	_D2(4)	LO1 sei(); SCALE02(b1,6)	_D3(2)
-				cli(); HI1 _D1(1) QLO2(b0, 1) RORSC04(b1,7) 	_D2(4)	LO1 sei(); RORCLC2(b1) 	_D3(2)
-				cli(); HI1 _D1(1) QLO2(b0, 0)
+				MOV_NEGD24(b0,b1,d2) _D2(4) LO1 sei(); ADDDE1(d2,e2) _D3(3)
+				cli(); HI1 _D1(2) QLO2(b0, 7) LDSCL4(b1,O0) 	_D2(4)	LO1 sei();	PRESCALEA2(d0)	_D3(3)
+				cli(); HI1 _D1(2) QLO2(b0, 6) PRESCALEB4(d0)	_D2(4)	LO1 sei();	SCALE02(b1,0)	_D3(3)
+				cli(); HI1 _D1(2) QLO2(b0, 5) RORSC04(b1,1) 	_D2(4)	LO1 sei(); RORCLC2(b1) 	_D3(3)
+				cli(); HI1 _D1(2) QLO2(b0, 4) SCROR04(b1,2)		_D2(4)	LO1 sei(); SCALE02(b1,3)	_D3(3)
+				cli(); HI1 _D1(2) QLO2(b0, 3) RORSC04(b1,4) 	_D2(4)	LO1 sei(); RORCLC2(b1)  	_D3(3)
+				cli(); HI1 _D1(2) QLO2(b0, 2) SCROR04(b1,5) 	_D2(4)	LO1 sei(); SCALE02(b1,6)	_D3(3)
+				cli(); HI1 _D1(2) QLO2(b0, 1) RORSC04(b1,7) 	_D2(4)	LO1 sei(); RORCLC2(b1) 	_D3(3)
+				cli(); HI1 _D1(2) QLO2(b0, 0)
 				switch(XTRA0) {
 					case 4: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)  /* fall through */
 					case 3: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)  /* fall through */
 					case 2: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)  /* fall through */
 					case 1: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)
 				}
-				MOV_ADDDE04(b0,b1,d0,e0) _D2(4) LO1 sei(); _D3(5)
+				MOV_ADDDE04(b0,b1,d0,e0) _D2(4) LO1 sei(); _D3(2)
 				ENDLOOP5
 			}
 			DONE;

--- a/src/platforms/avr/clockless_trinket.h
+++ b/src/platforms/avr/clockless_trinket.h
@@ -406,31 +406,31 @@ protected:
 				// Inline scaling - RGB ordering
 				// DNOP
 				
-				cli(); HI1 _D1(2) QLO2(b0, 7) LDSCL4(b1,O1) 	_D2(4)	LO1	sei();	PRESCALEA2(d1)	_D3(3) 
-				cli(); HI1 _D1(2) QLO2(b0, 6) PRESCALEB4(d1)	_D2(4)	LO1	sei();	SCALE12(b1,0)	_D3(3) 
-				cli(); HI1 _D1(2) QLO2(b0, 5) RORSC14(b1,1) 	_D2(4)	LO1 sei();	RORCLC2(b1)		_D3(3) 
-				cli(); HI1 _D1(2) QLO2(b0, 4) SCROR14(b1,2)		_D2(4)	LO1 sei();	SCALE12(b1,3)	_D3(3) 
-				cli(); HI1 _D1(2) QLO2(b0, 3) RORSC14(b1,4) 	_D2(4)	LO1 sei();	RORCLC2(b1) 	_D3(3) 
-				cli(); HI1 _D1(2) QLO2(b0, 2) SCROR14(b1,5) 	_D2(4)	LO1 sei();	SCALE12(b1,6)	_D3(3) 
-				cli(); HI1 _D1(2) QLO2(b0, 1) RORSC14(b1,7) 	_D2(4)	LO1 sei();	RORCLC2(b1) 	_D3(3) 
-				cli(); HI1 _D1(2) QLO2(b0, 0)
+				cli(); HI1 _D1(2) QLO2(b0, 7) sei(); LDSCL4(b1,O1) 	_D2(5)	LO1	PRESCALEA2(d1)	_D3(2) 
+				cli(); HI1 _D1(2) QLO2(b0, 6) sei(); PRESCALEB4(d1)	_D2(5)	LO1	SCALE12(b1,0)	_D3(2) 
+				cli(); HI1 _D1(2) QLO2(b0, 5) sei(); RORSC14(b1,1) 	_D2(5)	LO1 	RORCLC2(b1)	_D3(2) 
+				cli(); HI1 _D1(2) QLO2(b0, 4) sei(); SCROR14(b1,2)	_D2(5)	LO1 	SCALE12(b1,3)	_D3(2) 
+				cli(); HI1 _D1(2) QLO2(b0, 3) sei(); RORSC14(b1,4) 	_D2(5)	LO1 	RORCLC2(b1) 	_D3(2) 
+				cli(); HI1 _D1(2) QLO2(b0, 2) sei(); SCROR14(b1,5) 	_D2(5)	LO1 	SCALE12(b1,6)	_D3(2) 
+				cli(); HI1 _D1(2) QLO2(b0, 1) sei(); RORSC14(b1,7) 	_D2(5)	LO1 	RORCLC2(b1) 	_D3(2) 
+				cli(); HI1 _D1(2) QLO2(b0, 0) sei(); 
 				switch(XTRA0) {
 					case 4: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)  /* fall through */
 					case 3: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)  /* fall through */
 					case 2: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)  /* fall through */
 					case 1: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)
 				}
-				MOV_ADDDE14(b0,b1,d1,e1) _D2(4) LO1 sei(); _D3(2) 
+				MOV_ADDDE14(b0,b1,d1,e1) _D2(5) LO1  _D3(1) 
 				
 
-				cli(); HI1 _D1(2) QLO2(b0, 7) LDSCL4(b1,O2) 	_D2(4)	LO1	sei();	PRESCALEA2(d2)	_D3(3)
-				cli(); HI1 _D1(2) QLO2(b0, 6) PSBIDATA4(d2)		_D2(4)	LO1	sei();	SCALE22(b1,0)	_D3(3)
-				cli(); HI1 _D1(2) QLO2(b0, 5) RORSC24(b1,1) 	_D2(4)	LO1 sei();	RORCLC2(b1) 	_D3(3)
-				cli(); HI1 _D1(2) QLO2(b0, 4) SCROR24(b1,2)		_D2(4)	LO1 sei();	SCALE22(b1,3)	_D3(3)
-				cli(); HI1 _D1(2) QLO2(b0, 3) RORSC24(b1,4) 	_D2(4)	LO1 sei();	RORCLC2(b1) 	_D3(3)
-				cli(); HI1 _D1(2) QLO2(b0, 2) SCROR24(b1,5) 	_D2(4)	LO1 sei();	SCALE22(b1,6)	_D3(3)
-				cli(); HI1 _D1(2) QLO2(b0, 1) RORSC24(b1,7) 	_D2(4)	LO1 sei();	RORCLC2(b1) 	_D3(3)
-				cli(); HI1 _D1(2) QLO2(b0, 0)
+				cli(); HI1 _D1(2) QLO2(b0, 7) sei(); LDSCL4(b1,O2) 	_D2(5)	LO1 PRESCALEA2(d2)	_D3(2)
+				cli(); HI1 _D1(2) QLO2(b0, 6) sei(); PSBIDATA4(d2)	_D2(5)	LO1 SCALE22(b1,0)	_D3(2)
+				cli(); HI1 _D1(2) QLO2(b0, 5) sei(); RORSC24(b1,1) 	_D2(5)	LO1 RORCLC2(b1) 	_D3(2)
+				cli(); HI1 _D1(2) QLO2(b0, 4) sei(); SCROR24(b1,2)	_D2(5)	LO1 SCALE22(b1,3)	_D3(2)
+				cli(); HI1 _D1(2) QLO2(b0, 3) sei(); RORSC24(b1,4) 	_D2(5)	LO1 RORCLC2(b1) 	_D3(2)
+				cli(); HI1 _D1(2) QLO2(b0, 2) sei(); SCROR24(b1,5) 	_D2(5)	LO1 SCALE22(b1,6)	_D3(2)
+				cli(); HI1 _D1(2) QLO2(b0, 1) sei(); RORSC24(b1,7) 	_D2(5)	LO1 RORCLC2(b1) 	_D3(2)
+				cli(); HI1 _D1(2) QLO2(b0, 0) sei();
 				switch(XTRA0) {
 					case 4: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)  /* fall through */
 					case 3: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)  /* fall through */
@@ -441,22 +441,22 @@ protected:
 				// Because Prescale on the middle byte also increments the data counter,
 				// we have to do both halves of updating d2 here - negating it (in the
 				// MOV_NEGD24 macro) and then adding E back into it
-				MOV_NEGD24(b0,b1,d2) _D2(4) LO1 sei(); ADDDE1(d2,e2) _D3(3)
-				cli(); HI1 _D1(2) QLO2(b0, 7) LDSCL4(b1,O0) 	_D2(4)	LO1 sei();	PRESCALEA2(d0)	_D3(3)
-				cli(); HI1 _D1(2) QLO2(b0, 6) PRESCALEB4(d0)	_D2(4)	LO1 sei();	SCALE02(b1,0)	_D3(3)
-				cli(); HI1 _D1(2) QLO2(b0, 5) RORSC04(b1,1) 	_D2(4)	LO1 sei(); RORCLC2(b1) 	_D3(3)
-				cli(); HI1 _D1(2) QLO2(b0, 4) SCROR04(b1,2)		_D2(4)	LO1 sei(); SCALE02(b1,3)	_D3(3)
-				cli(); HI1 _D1(2) QLO2(b0, 3) RORSC04(b1,4) 	_D2(4)	LO1 sei(); RORCLC2(b1)  	_D3(3)
-				cli(); HI1 _D1(2) QLO2(b0, 2) SCROR04(b1,5) 	_D2(4)	LO1 sei(); SCALE02(b1,6)	_D3(3)
-				cli(); HI1 _D1(2) QLO2(b0, 1) RORSC04(b1,7) 	_D2(4)	LO1 sei(); RORCLC2(b1) 	_D3(3)
-				cli(); HI1 _D1(2) QLO2(b0, 0)
+				MOV_NEGD24(b0,b1,d2) _D2(5) LO1  ADDDE1(d2,e2) _D3(2)
+				cli(); HI1 _D1(2) QLO2(b0, 7) sei(); LDSCL4(b1,O0) 	_D2(5)	LO1 PRESCALEA2(d0)	_D3(2)
+				cli(); HI1 _D1(2) QLO2(b0, 6) sei(); PRESCALEB4(d0)	_D2(5)	LO1 SCALE02(b1,0)	_D3(2)
+				cli(); HI1 _D1(2) QLO2(b0, 5) sei(); RORSC04(b1,1) 	_D2(5)	LO1 RORCLC2(b1) 	_D3(2)
+				cli(); HI1 _D1(2) QLO2(b0, 4) sei(); SCROR04(b1,2)	_D2(5)	LO1 SCALE02(b1,3)	_D3(2)
+				cli(); HI1 _D1(2) QLO2(b0, 3) sei(); RORSC04(b1,4) 	_D2(5)	LO1 RORCLC2(b1)  	_D3(2)
+				cli(); HI1 _D1(2) QLO2(b0, 2) sei(); SCROR04(b1,5) 	_D2(5)	LO1 SCALE02(b1,6)	_D3(2)
+				cli(); HI1 _D1(2) QLO2(b0, 1) sei(); RORSC04(b1,7) 	_D2(5)	LO1 RORCLC2(b1) 	_D3(2)
+				cli(); HI1 _D1(2) QLO2(b0, 0) sei();
 				switch(XTRA0) {
 					case 4: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)  /* fall through */
 					case 3: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)  /* fall through */
 					case 2: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)  /* fall through */
 					case 1: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)
 				}
-				MOV_ADDDE04(b0,b1,d0,e0) _D2(4) LO1 sei(); _D3(2)
+				MOV_ADDDE04(b0,b1,d0,e0) _D2(5) LO1  _D3(1)
 				ENDLOOP5
 			}
 			DONE;

--- a/src/platforms/avr/clockless_trinket.h
+++ b/src/platforms/avr/clockless_trinket.h
@@ -113,7 +113,7 @@ protected:
 	virtual void showPixels(PixelController<RGB_ORDER> & pixels) {
 
 		mWait.wait();
-		cli();
+		//cli();
 
 		showRGBInternal(pixels);
 
@@ -166,7 +166,7 @@ protected:
 
 #endif
 
-		sei();
+		//sei();
 		mWait.mark();
 	}
 #define USE_ASM_MACROS
@@ -405,56 +405,58 @@ protected:
 
 				// Inline scaling - RGB ordering
 				// DNOP
-				HI1 _D1(1) QLO2(b0, 7) LDSCL4(b1,O1) 	_D2(4)	LO1	PRESCALEA2(d1)	_D3(2)
-				HI1 _D1(1) QLO2(b0, 6) PRESCALEB4(d1)	_D2(4)	LO1	SCALE12(b1,0)	_D3(2)
-				HI1 _D1(1) QLO2(b0, 5) RORSC14(b1,1) 	_D2(4)	LO1 RORCLC2(b1)		_D3(2)
-				HI1 _D1(1) QLO2(b0, 4) SCROR14(b1,2)	_D2(4)	LO1 SCALE12(b1,3)	_D3(2)
-				HI1 _D1(1) QLO2(b0, 3) RORSC14(b1,4) 	_D2(4)	LO1 RORCLC2(b1) 	_D3(2)
-				HI1 _D1(1) QLO2(b0, 2) SCROR14(b1,5) 	_D2(4)	LO1 SCALE12(b1,6)	_D3(2)
-				HI1 _D1(1) QLO2(b0, 1) RORSC14(b1,7) 	_D2(4)	LO1 RORCLC2(b1) 	_D3(2)
-				HI1 _D1(1) QLO2(b0, 0)
+				
+				cli(); HI1 _D1(1) QLO2(b0, 7) LDSCL4(b1,O1) 	_D2(4)	LO1	sei();	PRESCALEA2(d1)	_D3(2) 
+				cli(); HI1 _D1(1) QLO2(b0, 6) PRESCALEB4(d1)	_D2(4)	LO1	sei();	SCALE12(b1,0)	_D3(2) 
+				cli(); HI1 _D1(1) QLO2(b0, 5) RORSC14(b1,1) 	_D2(4)	LO1 sei();	RORCLC2(b1)		_D3(2) 
+				cli(); HI1 _D1(1) QLO2(b0, 4) SCROR14(b1,2)		_D2(4)	LO1 sei();	SCALE12(b1,3)	_D3(2) 
+				cli(); HI1 _D1(1) QLO2(b0, 3) RORSC14(b1,4) 	_D2(4)	LO1 sei();	RORCLC2(b1) 	_D3(2) 
+				cli(); HI1 _D1(1) QLO2(b0, 2) SCROR14(b1,5) 	_D2(4)	LO1 sei();	SCALE12(b1,6)	_D3(2) 
+				cli(); HI1 _D1(1) QLO2(b0, 1) RORSC14(b1,7) 	_D2(4)	LO1 sei();	RORCLC2(b1) 	_D3(2) 
+				cli(); HI1 _D1(1) QLO2(b0, 0)
 				switch(XTRA0) {
-					case 4: _D2(0) LO1 _D3(0) HI1 _D1(1) QLO2(b0,0)  /* fall through */
-					case 3: _D2(0) LO1 _D3(0) HI1 _D1(1) QLO2(b0,0)  /* fall through */
-					case 2: _D2(0) LO1 _D3(0) HI1 _D1(1) QLO2(b0,0)  /* fall through */
-					case 1: _D2(0) LO1 _D3(0) HI1 _D1(1) QLO2(b0,0)
+					case 4: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)  /* fall through */
+					case 3: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)  /* fall through */
+					case 2: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)  /* fall through */
+					case 1: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)
 				}
-				MOV_ADDDE14(b0,b1,d1,e1) _D2(4) LO1 _D3(0)
+				MOV_ADDDE14(b0,b1,d1,e1) _D2(4) LO1 sei(); _D3(0) 
+				
 
-				HI1 _D1(1) QLO2(b0, 7) LDSCL4(b1,O2) 	_D2(4)	LO1	PRESCALEA2(d2)	_D3(2)
-				HI1 _D1(1) QLO2(b0, 6) PSBIDATA4(d2)	_D2(4)	LO1	SCALE22(b1,0)	_D3(2)
-				HI1 _D1(1) QLO2(b0, 5) RORSC24(b1,1) 	_D2(4)	LO1 RORCLC2(b1) 	_D3(2)
-				HI1 _D1(1) QLO2(b0, 4) SCROR24(b1,2)	_D2(4)	LO1 SCALE22(b1,3)	_D3(2)
-				HI1 _D1(1) QLO2(b0, 3) RORSC24(b1,4) 	_D2(4)	LO1 RORCLC2(b1) 	_D3(2)
-				HI1 _D1(1) QLO2(b0, 2) SCROR24(b1,5) 	_D2(4)	LO1 SCALE22(b1,6)	_D3(2)
-				HI1 _D1(1) QLO2(b0, 1) RORSC24(b1,7) 	_D2(4)	LO1 RORCLC2(b1) 	_D3(2)
-				HI1 _D1(1) QLO2(b0, 0)
+				cli(); HI1 _D1(1) QLO2(b0, 7) LDSCL4(b1,O2) 	_D2(4)	LO1	sei();	PRESCALEA2(d2)	_D3(2)
+				cli(); HI1 _D1(1) QLO2(b0, 6) PSBIDATA4(d2)		_D2(4)	LO1	sei();	SCALE22(b1,0)	_D3(2)
+				cli(); HI1 _D1(1) QLO2(b0, 5) RORSC24(b1,1) 	_D2(4)	LO1 sei();	RORCLC2(b1) 	_D3(2)
+				cli(); HI1 _D1(1) QLO2(b0, 4) SCROR24(b1,2)		_D2(4)	LO1 sei();	SCALE22(b1,3)	_D3(2)
+				cli(); HI1 _D1(1) QLO2(b0, 3) RORSC24(b1,4) 	_D2(4)	LO1 sei();	RORCLC2(b1) 	_D3(2)
+				cli(); HI1 _D1(1) QLO2(b0, 2) SCROR24(b1,5) 	_D2(4)	LO1 sei();	SCALE22(b1,6)	_D3(2)
+				cli(); HI1 _D1(1) QLO2(b0, 1) RORSC24(b1,7) 	_D2(4)	LO1 sei();	RORCLC2(b1) 	_D3(2)
+				cli(); HI1 _D1(1) QLO2(b0, 0)
 				switch(XTRA0) {
-					case 4: _D2(0) LO1 _D3(0) HI1 _D1(1) QLO2(b0,0)  /* fall through */
-					case 3: _D2(0) LO1 _D3(0) HI1 _D1(1) QLO2(b0,0)  /* fall through */
-					case 2: _D2(0) LO1 _D3(0) HI1 _D1(1) QLO2(b0,0)  /* fall through */
-					case 1: _D2(0) LO1 _D3(0) HI1 _D1(1) QLO2(b0,0)
+					case 4: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)  /* fall through */
+					case 3: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)  /* fall through */
+					case 2: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)  /* fall through */
+					case 1: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)
 				}
 
 				// Because Prescale on the middle byte also increments the data counter,
 				// we have to do both halves of updating d2 here - negating it (in the
 				// MOV_NEGD24 macro) and then adding E back into it
-				MOV_NEGD24(b0,b1,d2) _D2(4) LO1 ADDDE1(d2,e2) _D3(1)
-				HI1 _D1(1) QLO2(b0, 7) LDSCL4(b1,O0) 	_D2(4)	LO1	PRESCALEA2(d0)	_D3(2)
-				HI1 _D1(1) QLO2(b0, 6) PRESCALEB4(d0)	_D2(4)	LO1	SCALE02(b1,0)	_D3(2)
-				HI1 _D1(1) QLO2(b0, 5) RORSC04(b1,1) 	_D2(4)	LO1 RORCLC2(b1) 	_D3(2)
-				HI1 _D1(1) QLO2(b0, 4) SCROR04(b1,2)	_D2(4)	LO1 SCALE02(b1,3)	_D3(2)
-				HI1 _D1(1) QLO2(b0, 3) RORSC04(b1,4) 	_D2(4)	LO1 RORCLC2(b1)  	_D3(2)
-				HI1 _D1(1) QLO2(b0, 2) SCROR04(b1,5) 	_D2(4)	LO1 SCALE02(b1,6)	_D3(2)
-				HI1 _D1(1) QLO2(b0, 1) RORSC04(b1,7) 	_D2(4)	LO1 RORCLC2(b1) 	_D3(2)
-				HI1 _D1(1) QLO2(b0, 0)
+				MOV_NEGD24(b0,b1,d2) _D2(4) LO1 sei(); ADDDE1(d2,e2) _D3(1)
+				cli(); HI1 _D1(1) QLO2(b0, 7) LDSCL4(b1,O0) 	_D2(4)	LO1 sei();	PRESCALEA2(d0)	_D3(2)
+				cli(); HI1 _D1(1) QLO2(b0, 6) PRESCALEB4(d0)	_D2(4)	LO1 sei();	SCALE02(b1,0)	_D3(2)
+				cli(); HI1 _D1(1) QLO2(b0, 5) RORSC04(b1,1) 	_D2(4)	LO1 sei(); RORCLC2(b1) 	_D3(2)
+				cli(); HI1 _D1(1) QLO2(b0, 4) SCROR04(b1,2)		_D2(4)	LO1 sei(); SCALE02(b1,3)	_D3(2)
+				cli(); HI1 _D1(1) QLO2(b0, 3) RORSC04(b1,4) 	_D2(4)	LO1 sei(); RORCLC2(b1)  	_D3(2)
+				cli(); HI1 _D1(1) QLO2(b0, 2) SCROR04(b1,5) 	_D2(4)	LO1 sei(); SCALE02(b1,6)	_D3(2)
+				cli(); HI1 _D1(1) QLO2(b0, 1) RORSC04(b1,7) 	_D2(4)	LO1 sei(); RORCLC2(b1) 	_D3(2)
+				cli(); HI1 _D1(1) QLO2(b0, 0)
 				switch(XTRA0) {
-					case 4: _D2(0) LO1 _D3(0) HI1 _D1(1) QLO2(b0,0)  /* fall through */
-					case 3: _D2(0) LO1 _D3(0) HI1 _D1(1) QLO2(b0,0)  /* fall through */
-					case 2: _D2(0) LO1 _D3(0) HI1 _D1(1) QLO2(b0,0)  /* fall through */
-					case 1: _D2(0) LO1 _D3(0) HI1 _D1(1) QLO2(b0,0)
+					case 4: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)  /* fall through */
+					case 3: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)  /* fall through */
+					case 2: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)  /* fall through */
+					case 1: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)
 				}
-				MOV_ADDDE04(b0,b1,d0,e0) _D2(4) LO1 _D3(5)
+				MOV_ADDDE04(b0,b1,d0,e0) _D2(4) LO1 sei(); _D3(5)
 				ENDLOOP5
 			}
 			DONE;

--- a/src/platforms/avr/clockless_trinket.h
+++ b/src/platforms/avr/clockless_trinket.h
@@ -406,31 +406,31 @@ protected:
 				// Inline scaling - RGB ordering
 				// DNOP
 				
-				cli(); HI1 _D1(2) QLO2(b0, 7) sei(); LDSCL4(b1,O1) 	_D2(5)	LO1	PRESCALEA2(d1)	_D3(2) 
-				cli(); HI1 _D1(2) QLO2(b0, 6) sei(); PRESCALEB4(d1)	_D2(5)	LO1	SCALE12(b1,0)	_D3(2) 
-				cli(); HI1 _D1(2) QLO2(b0, 5) sei(); RORSC14(b1,1) 	_D2(5)	LO1 	RORCLC2(b1)	_D3(2) 
-				cli(); HI1 _D1(2) QLO2(b0, 4) sei(); SCROR14(b1,2)	_D2(5)	LO1 	SCALE12(b1,3)	_D3(2) 
-				cli(); HI1 _D1(2) QLO2(b0, 3) sei(); RORSC14(b1,4) 	_D2(5)	LO1 	RORCLC2(b1) 	_D3(2) 
-				cli(); HI1 _D1(2) QLO2(b0, 2) sei(); SCROR14(b1,5) 	_D2(5)	LO1 	SCALE12(b1,6)	_D3(2) 
-				cli(); HI1 _D1(2) QLO2(b0, 1) sei(); RORSC14(b1,7) 	_D2(5)	LO1 	RORCLC2(b1) 	_D3(2) 
-				cli(); HI1 _D1(2) QLO2(b0, 0) sei(); 
+				cli(); HI1 _D1(3) QLO2(b0, 7) sei(); LDSCL4(b1,O1) 	_D2(6)	LO1	PRESCALEA2(d1)	_D3(3) 
+				cli(); HI1 _D1(3) QLO2(b0, 6) sei(); PRESCALEB4(d1)	_D2(6)	LO1	SCALE12(b1,0)	_D3(3) 
+				cli(); HI1 _D1(3) QLO2(b0, 5) sei(); RORSC14(b1,1) 	_D2(6)	LO1 	RORCLC2(b1)	_D3(3) 
+				cli(); HI1 _D1(3) QLO2(b0, 4) sei(); SCROR14(b1,2)	_D2(6)	LO1 	SCALE12(b1,3)	_D3(3) 
+				cli(); HI1 _D1(3) QLO2(b0, 3) sei(); RORSC14(b1,4) 	_D2(6)	LO1 	RORCLC2(b1) 	_D3(3) 
+				cli(); HI1 _D1(3) QLO2(b0, 2) sei(); SCROR14(b1,5) 	_D2(6)	LO1 	SCALE12(b1,6)	_D3(3) 
+				cli(); HI1 _D1(3) QLO2(b0, 1) sei(); RORSC14(b1,7) 	_D2(6)	LO1 	RORCLC2(b1) 	_D3(3) 
+				cli(); HI1 _D1(3) QLO2(b0, 0) sei(); 
 				switch(XTRA0) {
 					case 4: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)  /* fall through */
 					case 3: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)  /* fall through */
 					case 2: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)  /* fall through */
 					case 1: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)
 				}
-				MOV_ADDDE14(b0,b1,d1,e1) _D2(5) LO1  _D3(1) 
+				MOV_ADDDE14(b0,b1,d1,e1) _D2(6) LO1  _D3(2) 
 				
 
-				cli(); HI1 _D1(2) QLO2(b0, 7) sei(); LDSCL4(b1,O2) 	_D2(5)	LO1 PRESCALEA2(d2)	_D3(2)
-				cli(); HI1 _D1(2) QLO2(b0, 6) sei(); PSBIDATA4(d2)	_D2(5)	LO1 SCALE22(b1,0)	_D3(2)
-				cli(); HI1 _D1(2) QLO2(b0, 5) sei(); RORSC24(b1,1) 	_D2(5)	LO1 RORCLC2(b1) 	_D3(2)
-				cli(); HI1 _D1(2) QLO2(b0, 4) sei(); SCROR24(b1,2)	_D2(5)	LO1 SCALE22(b1,3)	_D3(2)
-				cli(); HI1 _D1(2) QLO2(b0, 3) sei(); RORSC24(b1,4) 	_D2(5)	LO1 RORCLC2(b1) 	_D3(2)
-				cli(); HI1 _D1(2) QLO2(b0, 2) sei(); SCROR24(b1,5) 	_D2(5)	LO1 SCALE22(b1,6)	_D3(2)
-				cli(); HI1 _D1(2) QLO2(b0, 1) sei(); RORSC24(b1,7) 	_D2(5)	LO1 RORCLC2(b1) 	_D3(2)
-				cli(); HI1 _D1(2) QLO2(b0, 0) sei();
+				cli(); HI1 _D1(3) QLO2(b0, 7) sei(); LDSCL4(b1,O2) 	_D2(6)	LO1 PRESCALEA2(d2)	_D3(3)
+				cli(); HI1 _D1(3) QLO2(b0, 6) sei(); PSBIDATA4(d2)	_D2(6)	LO1 SCALE22(b1,0)	_D3(3)
+				cli(); HI1 _D1(3) QLO2(b0, 5) sei(); RORSC24(b1,1) 	_D2(6)	LO1 RORCLC2(b1) 	_D3(3)
+				cli(); HI1 _D1(3) QLO2(b0, 4) sei(); SCROR24(b1,2)	_D2(6)	LO1 SCALE22(b1,3)	_D3(3)
+				cli(); HI1 _D1(3) QLO2(b0, 3) sei(); RORSC24(b1,4) 	_D2(6)	LO1 RORCLC2(b1) 	_D3(3)
+				cli(); HI1 _D1(3) QLO2(b0, 2) sei(); SCROR24(b1,5) 	_D2(6)	LO1 SCALE22(b1,6)	_D3(3)
+				cli(); HI1 _D1(3) QLO2(b0, 1) sei(); RORSC24(b1,7) 	_D2(6)	LO1 RORCLC2(b1) 	_D3(3)
+				cli(); HI1 _D1(3) QLO2(b0, 0) sei();
 				switch(XTRA0) {
 					case 4: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)  /* fall through */
 					case 3: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)  /* fall through */
@@ -441,22 +441,22 @@ protected:
 				// Because Prescale on the middle byte also increments the data counter,
 				// we have to do both halves of updating d2 here - negating it (in the
 				// MOV_NEGD24 macro) and then adding E back into it
-				MOV_NEGD24(b0,b1,d2) _D2(5) LO1  ADDDE1(d2,e2) _D3(2)
-				cli(); HI1 _D1(2) QLO2(b0, 7) sei(); LDSCL4(b1,O0) 	_D2(5)	LO1 PRESCALEA2(d0)	_D3(2)
-				cli(); HI1 _D1(2) QLO2(b0, 6) sei(); PRESCALEB4(d0)	_D2(5)	LO1 SCALE02(b1,0)	_D3(2)
-				cli(); HI1 _D1(2) QLO2(b0, 5) sei(); RORSC04(b1,1) 	_D2(5)	LO1 RORCLC2(b1) 	_D3(2)
-				cli(); HI1 _D1(2) QLO2(b0, 4) sei(); SCROR04(b1,2)	_D2(5)	LO1 SCALE02(b1,3)	_D3(2)
-				cli(); HI1 _D1(2) QLO2(b0, 3) sei(); RORSC04(b1,4) 	_D2(5)	LO1 RORCLC2(b1)  	_D3(2)
-				cli(); HI1 _D1(2) QLO2(b0, 2) sei(); SCROR04(b1,5) 	_D2(5)	LO1 SCALE02(b1,6)	_D3(2)
-				cli(); HI1 _D1(2) QLO2(b0, 1) sei(); RORSC04(b1,7) 	_D2(5)	LO1 RORCLC2(b1) 	_D3(2)
-				cli(); HI1 _D1(2) QLO2(b0, 0) sei();
+				MOV_NEGD24(b0,b1,d2) _D2(5) LO1  ADDDE1(d2,e2) _D3(3)
+				cli(); HI1 _D1(3) QLO2(b0, 7) sei(); LDSCL4(b1,O0) 	_D2(6)	LO1 PRESCALEA2(d0)	_D3(3)
+				cli(); HI1 _D1(3) QLO2(b0, 6) sei(); PRESCALEB4(d0)	_D2(6)	LO1 SCALE02(b1,0)	_D3(3)
+				cli(); HI1 _D1(3) QLO2(b0, 5) sei(); RORSC04(b1,1) 	_D2(6)	LO1 RORCLC2(b1) 	_D3(3)
+				cli(); HI1 _D1(3) QLO2(b0, 4) sei(); SCROR04(b1,2)	_D2(6)	LO1 SCALE02(b1,3)	_D3(3)
+				cli(); HI1 _D1(3) QLO2(b0, 3) sei(); RORSC04(b1,4) 	_D2(6)	LO1 RORCLC2(b1)  	_D3(3)
+				cli(); HI1 _D1(3) QLO2(b0, 2) sei(); SCROR04(b1,5) 	_D2(6)	LO1 SCALE02(b1,6)	_D3(3)
+				cli(); HI1 _D1(3) QLO2(b0, 1) sei(); RORSC04(b1,7) 	_D2(6)	LO1 RORCLC2(b1) 	_D3(3)
+				cli(); HI1 _D1(3) QLO2(b0, 0) sei();
 				switch(XTRA0) {
 					case 4: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)  /* fall through */
 					case 3: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)  /* fall through */
 					case 2: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)  /* fall through */
 					case 1: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)
 				}
-				MOV_ADDDE04(b0,b1,d0,e0) _D2(5) LO1  _D3(1)
+				MOV_ADDDE04(b0,b1,d0,e0) _D2(6) LO1  _D3(2)
 				ENDLOOP5
 			}
 			DONE;


### PR DESCRIPTION
This enables very fast interrupts (such an audio sampler) to work for e.g. sound reactive light setups, with minimal jitter.

cc @samguyer - this is what I was discussing with you on Reddit at https://www.reddit.com/r/FastLED/comments/kpvni2/fastled_soundreactive_visualisers_beat_detection/gi0er9w/

There is an explanation in that thread of the limitations / the timing flexibility that can be afforded by neopixels even though it is out of spec. The key information on what timings are critical and which are not is here: https://wp.josh.com/2014/05/13/ws2812-neopixels-are-not-so-finicky-once-you-get-to-know-them/

This patch doesn't take the theory from that article to its limit; each bit is is still in its own critical section. But as long as your ISRs don't take more than about 90cycles (for example the `millis()` ISR takes around 50) then the lights won't latch and neopixels will happily show at a stable framerate even with jittery data.

Obviously with ISRs enabled like this I defined NO_CORRECTION to disable the unnecessary clock skew correction.

I can't promise this will work nicely with the LED dithering feature, however.