### PR TITLE
Fixed ESP32 clockless RMT to work on ESP32S2

### DIFF
--- a/src/platforms/esp/32/clockless_rmt_esp32.cpp
+++ b/src/platforms/esp/32/clockless_rmt_esp32.cpp
@@ -328,7 +328,11 @@ void IRAM_ATTR ESP32RMTController::interruptHandler(void *arg)
 
     for (channel = 0; channel < gMaxChannel; channel++) {
         int tx_done_bit = channel * 3;
+        #ifdef CONFIG_IDF_TARGET_ESP32S2
+        int tx_next_bit = channel + 12;
+        #else
         int tx_next_bit = channel + 24;
+        #endif
 
         ESP32RMTController * pController = gOnChannel[channel];
         if (pController != NULL) {

--- a/src/platforms/esp/32/clockless_rmt_esp32.h
+++ b/src/platforms/esp/32/clockless_rmt_esp32.h
@@ -188,9 +188,13 @@ __attribute__ ((always_inline)) inline static uint32_t __clock_cycles() {
 #define FASTLED_RMT_MAX_CONTROLLERS 32
 #endif
 
-// -- Max RMT channel (default to 8)
+// -- Max RMT channel (default to 8 on ESP32 and 4 on ESP32-S2)
 #ifndef FASTLED_RMT_MAX_CHANNELS
+#ifdef CONFIG_IDF_TARGET_ESP32S2
+#define FASTLED_RMT_MAX_CHANNELS 4
+#else
 #define FASTLED_RMT_MAX_CHANNELS 8
+#endif
 #endif
 
 class ESP32RMTController


### PR DESCRIPTION
ESP32S2 has only 4 channels in the RMT peripheral compared to the 8 channels in ESP32. Some interrupt bits need to fixed to ensure it works properly on both platforms.

Sanity tested this fix on both ESP32 and ESP32S2.

I'm not sure this is the best way to test for S2 vs. vanilla - happy to change it if anyone suggests a better option