### PR TITLE
Add Particle Photon(STM32F2XX) support

### DIFF
--- a/src/led_sysdefs.h
+++ b/src/led_sysdefs.h
@@ -24,7 +24,7 @@
 #elif defined(__SAM3X8E__)
 // Include sam/due headers
 #include "platforms/arm/sam/led_sysdefs_arm_sam.h"
-#elif defined(STM32F10X_MD) || defined(__STM32F1__)
+#elif defined(STM32F10X_MD) || defined(__STM32F1__) || defined(STM32F2XX)
 #include "platforms/arm/stm32/led_sysdefs_arm_stm32.h"
 #elif defined(__SAMD21G18A__) || defined(__SAMD21J18A__) || defined(__SAMD21E17A__) || defined(__SAMD21E18A__) || defined(__SAMD51G19A__) || defined(__SAMD51J19A__)
 #include "platforms/arm/d21/led_sysdefs_arm_d21.h"

--- a/src/platforms.h
+++ b/src/platforms.h
@@ -24,7 +24,7 @@
 #elif defined(__SAM3X8E__)
 // Include sam/due headers
 #include "platforms/arm/sam/fastled_arm_sam.h"
-#elif defined(STM32F10X_MD) || defined(__STM32F1__)
+#elif defined(STM32F10X_MD) || defined(__STM32F1__) || defined(STM32F2XX)
 #include "platforms/arm/stm32/fastled_arm_stm32.h"
 #elif defined(__SAMD21G18A__) || defined(__SAMD21J18A__) || defined(__SAMD21E17A__) || defined(__SAMD21E18A__)
 #include "platforms/arm/d21/fastled_arm_d21.h"

--- a/src/platforms/arm/stm32/led_sysdefs_arm_stm32.h
+++ b/src/platforms/arm/stm32/led_sysdefs_arm_stm32.h
@@ -1,7 +1,7 @@
 #ifndef __INC_LED_SYSDEFS_ARM_SAM_H
 #define __INC_LED_SYSDEFS_ARM_SAM_H
 
-#if defined(STM32F10X_MD)
+#if defined(STM32F10X_MD) || defined(STM32F2XX)
 
 #include <application.h>
 
@@ -55,7 +55,16 @@ typedef volatile       uint8_t RwReg; /**< Read-Write 8-bit register (volatile u
 
 #define FASTLED_NO_PINMAP
 
-#ifndef F_CPU
+#if defined(STM32F2XX)
+#define F_CPU 120000000
+#else
 #define F_CPU 72000000
 #endif
+
+#if defined(STM32F2XX)
+// Photon doesn't provide yield
+#define FASTLED_NEEDS_YIELD
+extern "C" void yield();
 #endif
+
+#endif // defined(STM32F10X_MD) || defined(STM32F2XX)


### PR DESCRIPTION
Pinout and other changes upstreamed from
https://github.com/focalintent/FastLED-Sparkcore/blob/master/firmware/fastpin_arm_stm32.h
As that repository is 5 years old.

---

A few other steps are needed to actually compile using particle compiler because of how it flattens the directory structure[1]
Afterwards I can build both with the particle compiler and local toolchain.

```
cd src
  
# Particle compile flattens structure, fix includes to point to top level
sed -i 's!#include "lib8tion/!#include "!' lib8tion.h
sed -i 's!platforms/arm/stm32/!!' src/led_sysdefs.h platforms.h

# Softlink files needed by particle to top level
for fn in `ls lib8tion/* platforms/arm/stm32/*`; do echo "ln -s $fn $(basename $fn)"; done

# Fixes for errors in pixeltypes.h
# Feels like Adding FASTLED_NAMESPACE_BEGIN in pixeltypes.h should fix this (it doesn't)

git checkout pixelset.h pixeltypes.h
sed -i -E 's! ::(scale8|fill_rainbow|fill_gradient|napplyGamma_video|nblend|blur1d)! NSFastLED::\1!' pixeltypes.h pixelset.h
sed -i -E 's! \b(CHSV|CRGB|TGradientDirectionCode|SHORTEST_HUES|fract8)\b! NSFastLED::\1!g' pixelset.h
sed -i -e 's!<CRGB>!<NSFastLED::CRGB>!g' -e 's!(CRGB\*)!(NSFastLED::CRGB*)!g' -e 's!(fract8 !(NSFastLED::fract8 !g' pixelset.h
```

[1] https://community.particle.io/t/library-import-flattens-directory-structure-workaround/9915/25