### PR TITLE
Add support for Adafruit MatrixPortal M4

### DIFF
--- a/src/platforms/arm/d51/fastpin_arm_d51.h
+++ b/src/platforms/arm/d51/fastpin_arm_d51.h
@@ -59,7 +59,7 @@ public:
 
 #define _FL_IO(L) _RD32(GPIO ## L)
 
-#define _FL_DEFPIN(PIN, BIT, L) template<> class FastPin<PIN> : public _ARMPIN<PIN, BIT, 1 << BIT, L> {};
+#define _FL_DEFPIN(PIN, BIT, L) template<> class FastPin<PIN> : public _ARMPIN<PIN, BIT, 1ul << BIT, L> {};
 
 // Actual pin definitions
 #if defined(ADAFRUIT_ITSYBITSY_M4_EXPRESS)
@@ -127,6 +127,39 @@ _FL_DEFPIN(23, 22, 1); _FL_DEFPIN(24,  23, 1); _FL_DEFPIN(25,  17, 0);
 #define SPI_CLOCK 25
 
 #define HAS_HARDWARE_PIN_SUPPORT 1
+
+#elif defined(ADAFRUIT_MATRIXPORTAL_M4_EXPRESS)
+
+#define MAX_PIN 21
+// 0/1 - SERCOM/UART (Serial1)
+_FL_DEFPIN( 0,  1, 0); _FL_DEFPIN( 1,  0, 0);
+// 2..3 buttons
+_FL_DEFPIN( 2, 22, 1); _FL_DEFPIN( 3, 23, 1);
+// 4 neopixel
+_FL_DEFPIN( 4, 23, 0);
+// SDA/SCL
+_FL_DEFPIN( 5, 31, 1); _FL_DEFPIN( 6, 30, 1);
+// 7..12 RGBRGB pins
+_FL_DEFPIN( 7,  0, 1); _FL_DEFPIN( 8,  1, 1); _FL_DEFPIN( 9,  2, 1); _FL_DEFPIN(10,  3, 1);
+_FL_DEFPIN(11,  4, 1); _FL_DEFPIN(12,  5, 1);
+// 13 LED
+_FL_DEFPIN(13, 14, 0);
+// 14..21  Control pins
+_FL_DEFPIN(14,  6, 1); _FL_DEFPIN(15, 14, 1); _FL_DEFPIN(16, 12, 1); _FL_DEFPIN(17,  7, 1);
+_FL_DEFPIN(18,  8, 1); _FL_DEFPIN(19,  9, 1); _FL_DEFPIN(20, 15, 1); _FL_DEFPIN(21, 13, 1);
+// 22..26 Analog pins
+_FL_DEFPIN(22,  2, 1); _FL_DEFPIN(23,  5, 1); _FL_DEFPIN(24,  4, 1); _FL_DEFPIN(25,  6, 1);
+_FL_DEFPIN(26,  7, 1);
+// 34..36 ESP SPI
+_FL_DEFPIN(34, 16, 0); _FL_DEFPIN(35, 17, 0); _FL_DEFPIN(36, 19, 0); 
+// 48..50 external SPI #2 on sercom 0
+_FL_DEFPIN(48,  5, 0); _FL_DEFPIN(49,  4, 0); _FL_DEFPIN(50,  7, 0); 
+
+#define SPI_DATA 4
+#define SPI_CLOCK 7
+
+#define HAS_HARDWARE_PIN_SUPPORT 1
+
 #endif
 
 


### PR DESCRIPTION
Pulled the definitions from the [variants](https://github.com/adafruit/ArduinoCore-samd/blob/master/variants/matrixportal_m4/variant.cpp) file. Tested working (for pin 4/`PIN_NEOPIXEL`, at least). For SPI I chose the secondary SPI port, since the first is in use by the ESP32 coprocessor. It's rather academic as neither of the SPI ports are broken out to the board.

As one of the pins is bit 31, I needed to [change the definition](https://github.com/FastLED/FastLED/compare/master...Hevi-dev:matrixportal-m4?expand=1#diff-f18dce76c03225559d8bfb64c2b8ac4ce0aea030652e04f39599fb4a889f731eR62) of the macro to unisgned long. I hopefully did so in a manner that is compatible with other boards/compilers.