### PR TITLE
Add support for Seeed Wio Terminal

### DIFF
--- a/src/led_sysdefs.h
+++ b/src/led_sysdefs.h
@@ -26,8 +26,10 @@
 #include "platforms/arm/sam/led_sysdefs_arm_sam.h"
 #elif defined(STM32F10X_MD) || defined(__STM32F1__)
 #include "platforms/arm/stm32/led_sysdefs_arm_stm32.h"
-#elif defined(__SAMD21G18A__) || defined(__SAMD21J18A__) || defined(__SAMD21E17A__) || defined(__SAMD21E18A__) || defined(__SAMD51G19A__) || defined(__SAMD51J19A__)
+#elif defined(__SAMD21G18A__) || defined(__SAMD21J18A__) || defined(__SAMD21E17A__) || defined(__SAMD21E18A__) 
 #include "platforms/arm/d21/led_sysdefs_arm_d21.h"
+#elif defined(__SAMD51G19A__) || defined(__SAMD51J19A__) || defined(__SAMD51P19A__)
+#include "platforms/arm/d51/led_sysdefs_arm_d51.h"
 #elif defined(ESP8266)
 #include "platforms/esp/8266/led_sysdefs_esp8266.h"
 #elif defined(ESP32)

--- a/src/platforms.h
+++ b/src/platforms.h
@@ -28,7 +28,7 @@
 #include "platforms/arm/stm32/fastled_arm_stm32.h"
 #elif defined(__SAMD21G18A__) || defined(__SAMD21J18A__) || defined(__SAMD21E17A__) || defined(__SAMD21E18A__)
 #include "platforms/arm/d21/fastled_arm_d21.h"
-#elif defined(__SAMD51G19A__) || defined(__SAMD51J19A__)
+#elif defined(__SAMD51G19A__) || defined(__SAMD51J19A__) || defined(__SAMD51P19A__)
 #include "platforms/arm/d51/fastled_arm_d51.h"
 #elif defined(ESP8266)
 #include "platforms/esp/8266/fastled_esp8266.h"

--- a/src/platforms/arm/d51/README.txt
+++ b/src/platforms/arm/d51/README.txt
@@ -1,4 +1,7 @@
 FastLED updates for adafruit FEATHER M4 and fixes to ITSBITSY M4 compiles
   SAMD51
 
-only tested on FEATHER M4 with DOTSTAR and neopixel strips
+Tested on 
+  - FEATHER M4 with DOTSTAR and neopixel strips
+  - Seeed Wio Terminal and WS8212B 
+

--- a/src/platforms/arm/d51/fastpin_arm_d51.h
+++ b/src/platforms/arm/d51/fastpin_arm_d51.h
@@ -127,6 +127,24 @@ _FL_DEFPIN(23, 22, 1); _FL_DEFPIN(24,  23, 1); _FL_DEFPIN(25,  17, 0);
 #define SPI_CLOCK 25
 
 #define HAS_HARDWARE_PIN_SUPPORT 1
+
+#elif defined(SEEED_WIO_TERMINAL)
+
+#define MAX_PIN 9
+// D0/A0-D8/A8
+_FL_DEFPIN( 0,  8, 1); _FL_DEFPIN( 1,  9, 1); _FL_DEFPIN( 2,  7, 0); _FL_DEFPIN( 3,  4, 1);
+_FL_DEFPIN( 4,  5, 1); _FL_DEFPIN( 5,  6, 1); _FL_DEFPIN( 6,  4, 0); _FL_DEFPIN( 7,  7, 1);
+_FL_DEFPIN( 8,  6, 0);
+// SDA/SCL
+_FL_DEFPIN(21, 17, 0); _FL_DEFPIN(22, 16, 0);
+// 23..25  MISO/MOSI/SCK
+_FL_DEFPIN(23, 0, 1); _FL_DEFPIN(24, 2, 1); _FL_DEFPIN(25, 3, 1);
+
+#define SPI_DATA 24
+#define SPI_CLOCK 25
+
+#define HAS_HARDWARE_PIN_SUPPORT 1
+
 #endif
 
 


### PR DESCRIPTION
adds FastLED support to SAMD51-based  Seeed Wio Terminal
