### PR TITLE
Some Modernization updates for #1208

### DIFF
--- a/examples/Cylon/Cylon.ino
+++ b/examples/Cylon/Cylon.ino
@@ -15,8 +15,8 @@ CRGB leds[NUM_LEDS];
 void setup() { 
 	Serial.begin(57600);
 	Serial.println("resetting");
-	LEDS.addLeds<WS2812,DATA_PIN,RGB>(leds,NUM_LEDS);
-	LEDS.setBrightness(84);
+	FastLED.addLeds<WS2812,DATA_PIN,RGB>(leds,NUM_LEDS);
+	FastLED.setBrightness(84);
 }
 
 void fadeall() { for(int i = 0; i < NUM_LEDS; i++) { leds[i].nscale8(250); } }

--- a/examples/DemoReel100/DemoReel100.ino
+++ b/examples/DemoReel100/DemoReel100.ino
@@ -11,9 +11,6 @@ FASTLED_USING_NAMESPACE
 //
 // -Mark Kriegsman, December 2014
 
-#if defined(FASTLED_VERSION) && (FASTLED_VERSION < 3001000)
-#warning "Requires FastLED 3.1 or later; check github for latest code."
-#endif
 
 #define DATA_PIN    3
 //#define CLK_PIN   4
@@ -117,7 +114,7 @@ void bpm()
 void juggle() {
   // eight colored dots, weaving in and out of sync with each other
   fadeToBlackBy( leds, NUM_LEDS, 20);
-  byte dothue = 0;
+  uint8_t dothue = 0;
   for( int i = 0; i < 8; i++) {
     leds[beatsin16( i+7, 0, NUM_LEDS-1 )] |= CHSV(dothue, 200, 255);
     dothue += 32;

--- a/examples/Fire2012/Fire2012.ino
+++ b/examples/Fire2012/Fire2012.ino
@@ -72,7 +72,7 @@ void loop()
 void Fire2012()
 {
 // Array of temperature readings at each simulation cell
-  static byte heat[NUM_LEDS];
+  static uint8_t heat[NUM_LEDS];
 
   // Step 1.  Cool down every cell a little
     for( int i = 0; i < NUM_LEDS; i++) {

--- a/examples/Fire2012WithPalette/Fire2012WithPalette.ino
+++ b/examples/Fire2012WithPalette/Fire2012WithPalette.ino
@@ -128,7 +128,7 @@ void loop()
 void Fire2012WithPalette()
 {
 // Array of temperature readings at each simulation cell
-  static byte heat[NUM_LEDS];
+  static uint8_t heat[NUM_LEDS];
 
   // Step 1.  Cool down every cell a little
     for( int i = 0; i < NUM_LEDS; i++) {
@@ -150,7 +150,7 @@ void Fire2012WithPalette()
     for( int j = 0; j < NUM_LEDS; j++) {
       // Scale the heat value from 0-255 down to 0-240
       // for best results with color palettes.
-      byte colorindex = scale8( heat[j], 240);
+      uint8_t colorindex = scale8( heat[j], 240);
       CRGB color = ColorFromPalette( gPal, colorindex);
       int pixelnumber;
       if( gReverseDirection ) {

--- a/examples/Multiple/OctoWS2811Demo/OctoWS2811Demo.ino
+++ b/examples/Multiple/OctoWS2811Demo/OctoWS2811Demo.ino
@@ -11,8 +11,8 @@ CRGB leds[NUM_STRIPS * NUM_LEDS_PER_STRIP];
 // OctoWS2811: 2,14,7,8,6,20,21,5
 
 void setup() {
-  LEDS.addLeds<OCTOWS2811>(leds, NUM_LEDS_PER_STRIP);
-  LEDS.setBrightness(32);
+  FastLED.addLeds<OCTOWS2811>(leds, NUM_LEDS_PER_STRIP);
+  FastLED.setBrightness(32);
 }
 
 void loop() {
@@ -32,6 +32,6 @@ void loop() {
 
   hue++;
 
-  LEDS.show();
-  LEDS.delay(10);
+  FastLED.show();
+  FastLED.delay(10);
 }

--- a/examples/Multiple/ParallelOutputDemo/ParallelOutputDemo.ino
+++ b/examples/Multiple/ParallelOutputDemo/ParallelOutputDemo.ino
@@ -24,13 +24,13 @@ void setup() {
   delay(5000);
   Serial.begin(57600);
   Serial.println("Starting...");
-  // LEDS.addLeds<WS2811_PORTA,NUM_STRIPS>(leds, NUM_LEDS_PER_STRIP);
-  // LEDS.addLeds<WS2811_PORTB,NUM_STRIPS>(leds, NUM_LEDS_PER_STRIP);
-  // LEDS.addLeds<WS2811_PORTD,NUM_STRIPS>(leds, NUM_LEDS_PER_STRIP).setCorrection(TypicalLEDStrip);
-  LEDS.addLeds<WS2811_PORTDC,NUM_STRIPS>(leds, NUM_LEDS_PER_STRIP);
+  // FastLED.addLeds<WS2811_PORTA,NUM_STRIPS>(leds, NUM_LEDS_PER_STRIP);
+  // FastLED.addLeds<WS2811_PORTB,NUM_STRIPS>(leds, NUM_LEDS_PER_STRIP);
+  // FastLED.addLeds<WS2811_PORTD,NUM_STRIPS>(leds, NUM_LEDS_PER_STRIP).setCorrection(TypicalLEDStrip);
+  FastLED.addLeds<WS2811_PORTDC,NUM_STRIPS>(leds, NUM_LEDS_PER_STRIP);
 
   // Teensy 4 parallel output example
-  // LEDS.addLeds<NUM_STRIPS, WS2811, 1>(leds,NUM_LEDS_PER_STRIP);
+  // FastLED.addLeds<NUM_STRIPS, WS2811, 1>(leds,NUM_LEDS_PER_STRIP);
 }
 
 void loop() {
@@ -51,6 +51,6 @@ void loop() {
 
   hue++;
 
-  LEDS.show();
-  // LEDS.delay(100);
+  FastLED.show();
+  // FastLED.delay(100);
 }

--- a/examples/Noise/Noise.ino
+++ b/examples/Noise/Noise.ino
@@ -5,15 +5,17 @@
 //
 
 // Params for width and height
-const uint16_t kMatrixWidth = 16;
-const uint16_t kMatrixHeight = 16;
+const uint8_t kMatrixWidth = 16;
+const uint8_t kMatrixHeight = 16;
+
 #define MAX_DIMENSION ((kMatrixWidth>kMatrixHeight) ? kMatrixWidth : kMatrixHeight)
 #define NUM_LEDS (kMatrixWidth * kMatrixHeight)
+
 // Param for different pixel layouts
 const bool    kMatrixSerpentineLayout = true;
 
 
-uint16_t XY( uint16_t x, uint16_t y)
+uint16_t XY( uint8_t x, uint8_t y)
 {
   uint16_t i;
 
@@ -24,7 +26,7 @@ uint16_t XY( uint16_t x, uint16_t y)
   if( kMatrixSerpentineLayout == true) {
     if( y & 0x01) {
       // Odd rows run backwards
-      uint16_t reverseX = (kMatrixWidth - 1) - x;
+      uint8_t reverseX = (kMatrixWidth - 1) - x;
       i = (y * kMatrixWidth) + reverseX;
     } else {
       // Even rows run forwards

--- a/examples/Noise/Noise.ino
+++ b/examples/Noise/Noise.ino
@@ -5,15 +5,15 @@
 //
 
 // Params for width and height
-const uint8_t kMatrixWidth = 16;
-const uint8_t kMatrixHeight = 16;
+const uint16_t kMatrixWidth = 16;
+const uint16_t kMatrixHeight = 16;
 #define MAX_DIMENSION ((kMatrixWidth>kMatrixHeight) ? kMatrixWidth : kMatrixHeight)
 #define NUM_LEDS (kMatrixWidth * kMatrixHeight)
 // Param for different pixel layouts
 const bool    kMatrixSerpentineLayout = true;
 
 
-uint16_t XY( uint8_t x, uint8_t y)
+uint16_t XY( uint16_t x, uint16_t y)
 {
   uint16_t i;
 
@@ -24,7 +24,7 @@ uint16_t XY( uint8_t x, uint8_t y)
   if( kMatrixSerpentineLayout == true) {
     if( y & 0x01) {
       // Odd rows run backwards
-      uint8_t reverseX = (kMatrixWidth - 1) - x;
+      uint16_t reverseX = (kMatrixWidth - 1) - x;
       i = (y * kMatrixWidth) + reverseX;
     } else {
       // Even rows run forwards
@@ -62,15 +62,15 @@ uint16_t speed = 20; // a nice starting speed, mixes well with a scale of 100
 uint16_t scale = 311;
 
 // This is the array that we keep our computed noise values in
-uint8_t noise[MAX_DIMENSION][MAX_DIMENSION];
+uint16_t noise[MAX_DIMENSION][MAX_DIMENSION];
 
 void setup() {
   // uncomment the following lines if you want to see FPS count information
   // Serial.begin(38400);
   // Serial.println("resetting!");
   delay(3000);
-  LEDS.addLeds<WS2811,2,RGB>(leds,NUM_LEDS);
-  LEDS.setBrightness(96);
+  FastLED.addLeds<WS2811,2,RGB>(leds,NUM_LEDS);
+  FastLED.setBrightness(96);
 
   // Initialize our coordinates to some random values
   x = random16();
@@ -107,6 +107,6 @@ void loop() {
   }
   ihue+=1;
 
-  LEDS.show();
+  FastLED.show();
   // delay(10);
 }

--- a/examples/NoisePlayground/NoisePlayground.ino
+++ b/examples/NoisePlayground/NoisePlayground.ino
@@ -1,9 +1,11 @@
 #include <FastLED.h>
 
-#define kMatrixWidth  16
-#define kMatrixHeight 16
+// Params for width and height
+const uint8_t kMatrixWidth = 16;
+const uint8_t kMatrixHeight = 16;
 
 #define NUM_LEDS (kMatrixWidth * kMatrixHeight)
+
 // Param for different pixel layouts
 #define kMatrixSerpentineLayout  true
 

--- a/examples/NoisePlayground/NoisePlayground.ino
+++ b/examples/NoisePlayground/NoisePlayground.ino
@@ -37,11 +37,11 @@ int y_speed=1111;
 
 void loop() {
   // fill the led array 2/16-bit noise values
-  fill_2dnoise16(LEDS.leds(), kMatrixWidth, kMatrixHeight, kMatrixSerpentineLayout,
+  fill_2dnoise16(leds, kMatrixWidth, kMatrixHeight, kMatrixSerpentineLayout,
                 octaves,x,xscale,y,yscale,v_time,
                 hue_octaves,hxy,hue_scale,hxy,hue_scale,hue_time, false);
 
-  LEDS.show();
+  FastLED.show();
 
   // adjust the intra-frame time values
   x += x_speed;
@@ -61,8 +61,8 @@ void setup() {
   Serial.println("resetting!");
 
   delay(3000);
-  LEDS.addLeds<WS2811,2,GRB>(leds,NUM_LEDS);
-  LEDS.setBrightness(96);
+  FastLED.addLeds<WS2811,2,GRB>(leds,NUM_LEDS);
+  FastLED.setBrightness(96);
 
   hxy = (uint32_t)((uint32_t)random16() << 16) + (uint32_t)random16();
   x = (uint32_t)((uint32_t)random16() << 16) + (uint32_t)random16();

--- a/examples/NoisePlusPalette/NoisePlusPalette.ino
+++ b/examples/NoisePlusPalette/NoisePlusPalette.ino
@@ -5,8 +5,11 @@
 #define LED_TYPE    WS2811
 #define COLOR_ORDER GRB
 
+// Params for width and height
 const uint8_t kMatrixWidth  = 16;
 const uint8_t kMatrixHeight = 16;
+
+// Param for different pixel layouts
 const bool    kMatrixSerpentineLayout = true;
 
 

--- a/examples/NoisePlusPalette/NoisePlusPalette.ino
+++ b/examples/NoisePlusPalette/NoisePlusPalette.ino
@@ -67,8 +67,8 @@ uint8_t       colorLoop = 1;
 
 void setup() {
   delay(3000);
-  LEDS.addLeds<LED_TYPE,LED_PIN,COLOR_ORDER>(leds,NUM_LEDS);
-  LEDS.setBrightness(BRIGHTNESS);
+  FastLED.addLeds<LED_TYPE,LED_PIN,COLOR_ORDER>(leds,NUM_LEDS);
+  FastLED.setBrightness(BRIGHTNESS);
 
   // Initialize our coordinates to some random values
   x = random16();
@@ -163,7 +163,7 @@ void loop() {
   // using the current palette
   mapNoiseToLEDsUsingPalette();
 
-  LEDS.show();
+  FastLED.show();
   // delay(10);
 }
 

--- a/examples/SmartMatrix/SmartMatrix.ino
+++ b/examples/SmartMatrix/SmartMatrix.ino
@@ -63,8 +63,8 @@ void setup() {
   // Serial.begin(38400);
   // Serial.println("resetting!");
   delay(3000);
-  LEDS.addLeds<SMART_MATRIX>(leds,NUM_LEDS);
-  LEDS.setBrightness(96);
+  FastLED.addLeds<SMART_MATRIX>(leds,NUM_LEDS);
+  FastLED.setBrightness(96);
 
   // Initialize our coordinates to some random values
   x = random16();
@@ -116,6 +116,6 @@ void loop() {
   pSmartMatrix->fillCircle(circlex % 32,circley % 32,6,CRGB(CHSV(ihue+128,255,255)));
   circlex += random16(2);
   circley += random16(2);
-  LEDS.show();
+  FastLED.show();
   // delay(10);
 }

--- a/examples/TwinkleFox/TwinkleFox.ino
+++ b/examples/TwinkleFox/TwinkleFox.ino
@@ -1,9 +1,5 @@
 #include "FastLED.h"
 
-#if defined(FASTLED_VERSION) && (FASTLED_VERSION < 3001000)
-#warning "Requires FastLED 3.1 or later; check github for latest code."
-#endif
-
 
 #define NUM_LEDS      100
 #define LED_TYPE   WS2811

--- a/examples/XYMatrix/XYMatrix.ino
+++ b/examples/XYMatrix/XYMatrix.ino
@@ -15,7 +15,7 @@
 //             No error checking is performed on the ranges of x and y.
 //
 //     XYsafe(x,y) takes x and y coordinates and returns an LED index number,
-//             for use like this:  leds[ XY(x,y) ] == CRGB::Red;
+//             for use like this:  leds[ XYsafe(x,y) ] == CRGB::Red;
 //             Error checking IS performed on the ranges of x and y, and an
 //             index of "-1" is returned.  Special instructions below
 //             explain how to use this without having to do your own error
@@ -25,12 +25,13 @@
 
 
 // Params for width and height
-const uint16_t kMatrixWidth = 16;
-const uint16_t kMatrixHeight = 16;
+const uint8_t kMatrixWidth = 16;
+const uint8_t kMatrixHeight = 16;
 
 // Param for different pixel layouts
 const bool    kMatrixSerpentineLayout = true;
 const bool    kMatrixVertical = false;
+
 // Set 'kMatrixSerpentineLayout' to false if your pixels are 
 // laid out all running the same way, like this:
 //
@@ -74,8 +75,8 @@ const bool    kMatrixVertical = false;
 //
 // Use the "XY" function like this:
 //
-//    for( uint16_t x = 0; x < kMatrixWidth; x++) {
-//      for( uint16_t y = 0; y < kMatrixHeight; y++) {
+//    for( uint8_t x = 0; x < kMatrixWidth; x++) {
+//      for( uint8_t y = 0; y < kMatrixHeight; y++) {
 //      
 //        // Here's the x, y to 'led index' in action: 
 //        leds[ XY( x, y) ] = CHSV( random8(), 255, 255);
@@ -84,7 +85,7 @@ const bool    kMatrixVertical = false;
 //    }
 //
 //
-uint16_t XY( uint16_t x, uint16_t y)
+uint16_t XY( uint8_t x, uint8_t y)
 {
   uint16_t i;
   
@@ -100,7 +101,7 @@ uint16_t XY( uint16_t x, uint16_t y)
     if (kMatrixVertical == false) {
       if( y & 0x01) {
         // Odd rows run backwards
-        uint16_t reverseX = (kMatrixWidth - 1) - x;
+        uint8_t reverseX = (kMatrixWidth - 1) - x;
         i = (y * kMatrixWidth) + reverseX;
       } else {
         // Even rows run forwards
@@ -165,7 +166,7 @@ uint16_t XY( uint16_t x, uint16_t y)
 CRGB leds_plus_safety_pixel[ NUM_LEDS + 1];
 CRGB* const leds( leds_plus_safety_pixel + 1);
 
-uint16_t XYsafe( uint16_t x, uint16_t y)
+uint16_t XYsafe( uint8_t x, uint8_t y)
 {
   if( x >= kMatrixWidth) return -1;
   if( y >= kMatrixHeight) return -1;
@@ -192,10 +193,10 @@ void loop()
 void DrawOneFrame( uint8_t startHue8, int8_t yHueDelta8, int8_t xHueDelta8)
 {
   uint8_t lineStartHue = startHue8;
-  for( uint16_t y = 0; y < kMatrixHeight; y++) {
+  for( uint8_t y = 0; y < kMatrixHeight; y++) {
     lineStartHue += yHueDelta8;
     uint8_t pixelHue = lineStartHue;      
-    for( uint16_t x = 0; x < kMatrixWidth; x++) {
+    for( uint8_t x = 0; x < kMatrixWidth; x++) {
       pixelHue += xHueDelta8;
       leds[ XY(x, y)]  = CHSV( pixelHue, 255, 255);
     }

--- a/examples/XYMatrix/XYMatrix.ino
+++ b/examples/XYMatrix/XYMatrix.ino
@@ -25,8 +25,8 @@
 
 
 // Params for width and height
-const uint8_t kMatrixWidth = 16;
-const uint8_t kMatrixHeight = 16;
+const uint16_t kMatrixWidth = 16;
+const uint16_t kMatrixHeight = 16;
 
 // Param for different pixel layouts
 const bool    kMatrixSerpentineLayout = true;
@@ -74,8 +74,8 @@ const bool    kMatrixVertical = false;
 //
 // Use the "XY" function like this:
 //
-//    for( uint8_t x = 0; x < kMatrixWidth; x++) {
-//      for( uint8_t y = 0; y < kMatrixHeight; y++) {
+//    for( uint16_t x = 0; x < kMatrixWidth; x++) {
+//      for( uint16_t y = 0; y < kMatrixHeight; y++) {
 //      
 //        // Here's the x, y to 'led index' in action: 
 //        leds[ XY( x, y) ] = CHSV( random8(), 255, 255);
@@ -84,7 +84,7 @@ const bool    kMatrixVertical = false;
 //    }
 //
 //
-uint16_t XY( uint8_t x, uint8_t y)
+uint16_t XY( uint16_t x, uint16_t y)
 {
   uint16_t i;
   
@@ -100,7 +100,7 @@ uint16_t XY( uint8_t x, uint8_t y)
     if (kMatrixVertical == false) {
       if( y & 0x01) {
         // Odd rows run backwards
-        uint8_t reverseX = (kMatrixWidth - 1) - x;
+        uint16_t reverseX = (kMatrixWidth - 1) - x;
         i = (y * kMatrixWidth) + reverseX;
       } else {
         // Even rows run forwards
@@ -165,7 +165,7 @@ uint16_t XY( uint8_t x, uint8_t y)
 CRGB leds_plus_safety_pixel[ NUM_LEDS + 1];
 CRGB* const leds( leds_plus_safety_pixel + 1);
 
-uint16_t XYsafe( uint8_t x, uint8_t y)
+uint16_t XYsafe( uint16_t x, uint16_t y)
 {
   if( x >= kMatrixWidth) return -1;
   if( y >= kMatrixHeight) return -1;
@@ -189,13 +189,13 @@ void loop()
     FastLED.show();
 }
 
-void DrawOneFrame( byte startHue8, int8_t yHueDelta8, int8_t xHueDelta8)
+void DrawOneFrame( uint8_t startHue8, int8_t yHueDelta8, int8_t xHueDelta8)
 {
-  byte lineStartHue = startHue8;
-  for( byte y = 0; y < kMatrixHeight; y++) {
+  uint8_t lineStartHue = startHue8;
+  for( uint16_t y = 0; y < kMatrixHeight; y++) {
     lineStartHue += yHueDelta8;
-    byte pixelHue = lineStartHue;      
-    for( byte x = 0; x < kMatrixWidth; x++) {
+    uint8_t pixelHue = lineStartHue;      
+    for( uint16_t x = 0; x < kMatrixWidth; x++) {
       pixelHue += xHueDelta8;
       leds[ XY(x, y)]  = CHSV( pixelHue, 255, 255);
     }


### PR DESCRIPTION
As suggested in #1208 this updates:
LEDS.[function] to FastLED.[function]
Switch from byte to uint8_t
Use uint16_t for all LED index variables
Remove messages about minimum version