### PR TITLE
Use FASTLED_INTERNAL define to suppress pragma message from the ESP32 I2S driver

### DIFF
--- a/src/platforms/esp/32/clockless_i2s_esp32.h
+++ b/src/platforms/esp/32/clockless_i2s_esp32.h
@@ -86,7 +86,9 @@
 
 #pragma once
 
+#ifndef FASTLED_INTERNAL
 #pragma message "NOTE: ESP32 support using I2S parallel driver. All strips must use the same chipset"
+#endif
 
 FASTLED_NAMESPACE_BEGIN
 


### PR DESCRIPTION
A simple change to check for a set `FAST_INTERNAL` define to suppress the _"NOTE: ESP32 support using I2S parallel driver. All strips must use the same chipset"_ message from the ESP32 I2S driver if you know what you're doing and want to clean up your compile output a bit :wink: