### PR TITLE
Fix for ESP32 driver not properly handling setLeds

### DIFF
--- a/src/platforms/esp/32/clockless_rmt_esp32.cpp
+++ b/src/platforms/esp/32/clockless_rmt_esp32.cpp
@@ -42,7 +42,8 @@ int ESP32RMTController::gMemBlocks;
 ESP32RMTController::ESP32RMTController(int DATA_PIN, int T1, int T2, int T3, int maxChannel, int memBlocks)
     : mPixelData(0), 
       mSize(0), 
-      mCur(0), 
+      mCur(0),
+      mBufSize(0), 
       mWhichHalf(0),
       mBuffer(0),
       mBufferSize(0),
@@ -87,15 +88,17 @@ ESP32RMTController::ESP32RMTController(int DATA_PIN, int T1, int T2, int T3, int
 uint8_t * ESP32RMTController::getPixelBuffer(int size_in_bytes)
 {
     // -- Free the old buffer if it will be too small
-    if (mPixelData != 0 and mSize < size_in_bytes) {
+    if (mPixelData != 0 and mBufSize < size_in_bytes) {
         free(mPixelData);
         mPixelData = 0;
     }
 
     if (mPixelData == 0) {
-        mSize = size_in_bytes;
-        mPixelData = (uint8_t *) malloc(mSize);
+        mBufSize = size_in_bytes;
+        mPixelData = (uint8_t *) malloc(mBufSize);
     }
+
+    mSize = size_in_bytes;
 
     return mPixelData;
 }

--- a/src/platforms/esp/32/clockless_rmt_esp32.cpp
+++ b/src/platforms/esp/32/clockless_rmt_esp32.cpp
@@ -84,10 +84,17 @@ ESP32RMTController::ESP32RMTController(int DATA_PIN, int T1, int T2, int T3, int
 //    the PixelController object until show is called.
 uint8_t * ESP32RMTController::getPixelBuffer(int size_in_bytes)
 {
+    // -- Free the old buffer if it will be too small
+    if (mPixelData != 0 and mSize < size_in_bytes) {
+        free(mPixelData);
+        mPixelData = 0;
+    }
+
     if (mPixelData == 0) {
         mSize = size_in_bytes;
         mPixelData = (uint8_t *) malloc(mSize);
     }
+
     return mPixelData;
 }
 

--- a/src/platforms/esp/32/clockless_rmt_esp32.h
+++ b/src/platforms/esp/32/clockless_rmt_esp32.h
@@ -221,6 +221,7 @@ private:
     uint8_t *      mPixelData;
     int            mSize;
     int            mCur;
+    int            mBufSize;
 
     // -- RMT memory
     volatile uint32_t * mRMT_mem_ptr;


### PR DESCRIPTION
This fixes issue #1229 

The strategy is just to look at the size of the LEDs array at each call to show and make sure we adjust the size of the buffer to accommodate it. To avoid lots of dynamic memory allocation, we only grow the buffer -- a request for a smaller array of LEDs will just use a fraction of the buffer.