### PR TITLE
Add missing const in unary operator-

### DIFF
--- a/src/pixeltypes.h
+++ b/src/pixeltypes.h
@@ -412,7 +412,7 @@ struct CRGB {
     }
 
     /// invert each channel
-    inline CRGB operator- ()
+    inline CRGB operator- () const
     {
         CRGB retval;
         retval.r = 255 - r;


### PR DESCRIPTION
The unary minus operator of `CRGB` returns a new `CRGB` object and should therefore be `const`. In fact, this is a bug. Having a function like the following cannot call the unary minus.
```c++
CRGB complement(CRGB const& color) {
    return -color; // yields CRGB(255, 255, 255)
}
```
Adding a `const` qualifier should resolve the issue.