### PR TITLE
Add scale8(uint8)

### DIFF
--- a/src/pixeltypes.h
+++ b/src/pixeltypes.h
@@ -353,6 +353,14 @@ struct CRGB {
     }
 
     /// return a CRGB object that is a scaled down version of this object
+    inline CRGB scale8 (uint8_t scaledown ) const
+    {
+        CRGB out = *this;
+        nscale8x3( out.r, out.g, out.b, scaledown);
+        return out;
+    }
+
+    /// return a CRGB object that is a scaled down version of this object
     inline CRGB scale8 (const CRGB & scaledown ) const
     {
         CRGB out;


### PR DESCRIPTION
http://fastled.io/docs/3.1/struct_c_r_g_b.html

`nscale8` accepts both `uint8_t scaledown` and `const CRGB & scaledown` while `scale8` only accepts `const CRGB & scaledown`

If anyone is currently passing a `uint32_t` or `uint8_t` it gets cast to a CRGB, which causes the R and G channel to be zerod and scales only the blue channel. This will be a behavior "change" but IMHO it's a fix.