### PR TITLE
Fix incorrectly calling perlin noise "Simplex Noise"

### DIFF
--- a/examples/NoisePlusPalette/NoisePlusPalette.ino
+++ b/examples/NoisePlusPalette/NoisePlusPalette.ino
@@ -15,7 +15,7 @@ const bool    kMatrixSerpentineLayout = true;
 
 // This example combines two features of FastLED to produce a remarkable range of
 // effects from a relatively small amount of code.  This example combines FastLED's 
-// color palette lookup functions with FastLED's Perlin/simplex noise generator, and
+// color palette lookup functions with FastLED's Perlin noise generator, and
 // the combination is extremely powerful.
 //
 // You might want to look at the "ColorPalette" and "Noise" examples separately

--- a/src/noise.h
+++ b/src/noise.h
@@ -9,11 +9,11 @@ FASTLED_NAMESPACE_BEGIN
 /// Noise functions provided by the library.
 
 ///@defgroup Noise Noise functions
-///Simplex noise function definitions
+///Perlin noise function definitions
 ///@{
 /// @name scaled 16 bit noise functions
 ///@{
-/// 16 bit, fixed point implementation of perlin's Simplex Noise.  Coordinates are
+/// 16 bit, fixed point implementation of Perlin's noise.  Coordinates are
 /// 16.16 fixed point values, 32 bit integers with integral coordinates in the high 16
 /// bits and fractional in the low 16 bits, and the function takes 1d, 2d, and 3d coordinate
 /// values.  These functions are scaled to return 0-65535
@@ -34,7 +34,7 @@ extern int16_t inoise16_raw(uint32_t x);
 
 /// @name 8 bit scaled noise functions
 ///@{
-/// 8 bit, fixed point implementation of perlin's Simplex Noise.  Coordinates are
+/// 8 bit, fixed point implementation of Perlin's noise.  Coordinates are
 /// 8.8 fixed point values, 16 bit integers with integral coordinates in the high 8
 /// bits and fractional in the low 8 bits, and the function takes 1d, 2d, and 3d coordinate
 /// values.  These functions are scaled to return 0-255


### PR DESCRIPTION
Simplex noise is something different and is not implemented by the FastLED library (yet!). Therefore, don't confuse people by calling it Simplex Noise.

It appears there are 3 variants of noise developed by Ken Perlin:

- Classical Perlin noise.
- An "improved" noise - AFAIK just small improvements over classical Perlin noise.
- Simplex Noise. This algorithm is a bit more complicated and works in a different way. It allows noise up to many dimensions without too much computational overhead: O(n+1) instead of O(2^n). It also has fewer artifacts, that are sometimes quite visible in classical/improved noise. Downside: it's patented until early 2022.

I've looked at the noise.cpp file and it looks a lot more like the improved noise (https://mrl.cs.nyu.edu/~perlin/noise/) than simplex noise (https://github.com/stegu/perlin-noise/blob/master/src/simplexnoise1234.c).

Note: I have converted the simplex noise algorithm (1D, 2D, 3D, 4D) over to a fixed point implementation (written in Go) that I'm now converting to C++ for integration in FastLED. I hope to make a PR soon. This PR is just to fix some issues with the docs.