### PR TITLE
Remixing pixels on a single strip (and AVR clockless bugfixes)

### DIFF
--- a/src/FastLED.cpp
+++ b/src/FastLED.cpp
@@ -60,7 +60,7 @@ void CFastLED::show(uint8_t scale) {
 		pCur->setDither(d);
 		pCur = pCur->next();
 	}
-	//countFPS();
+	countFPS();
 }
 
 int CFastLED::count() {

--- a/src/FastLED.cpp
+++ b/src/FastLED.cpp
@@ -60,7 +60,7 @@ void CFastLED::show(uint8_t scale) {
 		pCur->setDither(d);
 		pCur = pCur->next();
 	}
-	countFPS();
+	//countFPS();
 }
 
 int CFastLED::count() {

--- a/src/controller.h
+++ b/src/controller.h
@@ -429,16 +429,93 @@ protected:
 
     virtual void showN(const struct CRGB **data, int *nLeds, CRGB scale, uint8_t N) {
         const uint8_t dither = getDither();
-        PixelController<RGB_ORDER, LANES, MASK> pixels(&data[0][0], 1, scale, dither);
+        PixelController<RGB_ORDER, LANES, MASK> *pixels7;
+        PixelController<RGB_ORDER, LANES, MASK> *pixels6;
+        PixelController<RGB_ORDER, LANES, MASK> *pixels5;
+        PixelController<RGB_ORDER, LANES, MASK> *pixels4;
+        PixelController<RGB_ORDER, LANES, MASK> *pixels3;
+        PixelController<RGB_ORDER, LANES, MASK> *pixels2;
+        PixelController<RGB_ORDER, LANES, MASK> *pixels1;
+        PixelController<RGB_ORDER, LANES, MASK> *pixels0;
 
-        for (uint8_t i=0; i<N; i++) {
-            if(nLeds[i]) {
-                pixels.mLen = nLeds[i];
-                pixels.mLenRemaining = nLeds[i];
-                pixels.mData = (uint8_t *)(&data[i][0]);
-                showPixels(pixels);
-            }
+        switch(N) {
+            // these fall through on purpose
+            case 8:
+                pixels7 = new PixelController<RGB_ORDER, LANES, MASK>(&data[7][0], nLeds[7], scale, dither);
+            case 7:
+                pixels6 = new PixelController<RGB_ORDER, LANES, MASK>(&data[6][0], nLeds[6], scale, dither);
+            case 6:
+                pixels5 = new PixelController<RGB_ORDER, LANES, MASK>(&data[5][0], nLeds[5], scale, dither);
+            case 5:
+                pixels4 = new PixelController<RGB_ORDER, LANES, MASK>(&data[4][0], nLeds[4], scale, dither);
+            case 4:
+                pixels3 = new PixelController<RGB_ORDER, LANES, MASK>(&data[3][0], nLeds[3], scale, dither);
+            case 3:
+                pixels2 = new PixelController<RGB_ORDER, LANES, MASK>(&data[2][0], nLeds[2], scale, dither);
+            case 2:
+                pixels1 = new PixelController<RGB_ORDER, LANES, MASK>(&data[1][0], nLeds[1], scale, dither);
+            case 1:
+                pixels0 = new PixelController<RGB_ORDER, LANES, MASK>(&data[0][0], nLeds[0], scale, dither);
+
+                break;
+
+            default:
+                // not ideal
+                pixels0 = new PixelController<RGB_ORDER, LANES, MASK>(&data[0][0], nLeds[0], scale, dither);
+                for (uint8_t i=0; i<N; i++) {
+                    pixels0->mLen = nLeds[i];
+                    // pixels.mLenRemaining = nLeds[i];
+                    // pixels.mData = my_data[i];
+                    pixels0->mData = (uint8_t *)(data[i]);
+                    showPixels(*pixels0);
+                }
+                break;
         }
+
+        switch(N) {
+            // these fall through on purpose
+            case 8:
+                if(pixels7->mLen) showPixels(*pixels7);
+            case 7:
+                if(pixels6->mLen)  showPixels(*pixels6);
+            case 6:
+                if(pixels5->mLen)  showPixels(*pixels5);
+            case 5:
+                if(pixels4->mLen)  showPixels(*pixels4);
+            case 4:
+                if(pixels3->mLen)  showPixels(*pixels3);
+            case 3:
+                if(pixels2->mLen)  showPixels(*pixels2);
+            case 2:
+                if(pixels1->mLen)  showPixels(*pixels1);
+            case 1:
+                if(pixels0->mLen)  showPixels(*pixels0);
+
+            default:
+                break;
+        }
+
+        switch(N) {
+            // these fall through on purpose
+            case 8:
+                delete pixels7;
+            case 7:
+                delete pixels6;
+            case 6:
+                delete pixels5;
+            case 5:
+                delete pixels4;
+            case 4:
+                delete pixels3;
+            case 3:
+                delete pixels2;
+            case 2:
+                delete pixels1;
+            case 1:
+            default:
+                delete pixels0;
+                break;
+        }        
     }
 
 public:

--- a/src/controller.h
+++ b/src/controller.h
@@ -66,9 +66,6 @@ protected:
 	///@param nLeds the number of leds being written out
 	///@param scale the rgb scaling to apply to each led before writing it out
     virtual void show(const struct CRGB *data, int nLeds, CRGB scale) = 0;
-    virtual void show2(const struct CRGB *data, int nLeds, const struct CRGB *data2, int nLeds2, CRGB scale) = 0;
-    virtual void show3(const struct CRGB *data, int nLeds, const struct CRGB *data2, int nLeds2, const struct CRGB *data3, int nLeds3, CRGB scale) = 0;
-
     virtual void show(const struct PixelCommand *command, CRGB scale) = 0;
 
 public:
@@ -91,19 +88,9 @@ public:
         show(data, nLeds, getAdjustment(brightness));
     }
 
-    void show2(const struct CRGB *data, int nLeds, const struct CRGB *data2, int nLeds2, uint8_t brightness) {
-        show2(data, nLeds, data2, nLeds2, getAdjustment(brightness));
-    }
-
-    void show3(const struct CRGB *data, int nLeds, const struct CRGB *data2, int nLeds2, const struct CRGB *data3, int nLeds3, uint8_t brightness) {
-        show3(data, nLeds, data2, nLeds2, data3, nLeds3, getAdjustment(brightness));
-    }
-
-    /// show function w/integer brightness, will scale for color correction and temperature
     void show(const struct PixelCommand *command, uint8_t brightness) {
         show(command, getAdjustment(brightness));
     }
-
 
     /// show function w/integer brightness, will scale for color correction and temperature
     void showColor(const struct CRGB &data, int nLeds, uint8_t brightness) {
@@ -414,8 +401,6 @@ struct PixelController {
 template<EOrder RGB_ORDER, int LANES=1, uint32_t MASK=0xFFFFFFFF> class CPixelLEDController : public CLEDController {
 protected:
     virtual void showPixels(PixelController<RGB_ORDER,LANES,MASK> & pixels) = 0;
-    virtual void showPixels2(PixelController<RGB_ORDER,LANES,MASK> & pixels, const struct CRGB * data2, int nLeds2) = 0;
-    virtual void showPixels3(PixelController<RGB_ORDER,LANES,MASK> & pixels, const struct CRGB * data2, int nLeds2, const struct CRGB * data3, int nLeds3) = 0;
     virtual void showPixels(PixelController<RGB_ORDER,LANES,MASK> & pixels, const struct PixelCommand *command) = 0;
 
     /// set all the leds on the controller to a given color
@@ -434,16 +419,6 @@ protected:
     virtual void show(const struct CRGB *data, int nLeds, CRGB scale) {
         PixelController<RGB_ORDER, LANES, MASK> pixels(data, nLeds, scale, getDither());
         showPixels(pixels);
-    }
-
-   virtual void show2(const struct CRGB *data, int nLeds, const struct CRGB *data2, int nLeds2, CRGB scale) {
-        PixelController<RGB_ORDER, LANES, MASK> pixels(data, nLeds, scale, getDither());
-        showPixels2(pixels, data2, nLeds2);
-    }
-
-   virtual void show3(const struct CRGB *data, int nLeds, const struct CRGB *data2, int nLeds2, const struct CRGB *data3, int nLeds3, CRGB scale) {
-        PixelController<RGB_ORDER, LANES, MASK> pixels(data, nLeds, scale, getDither());
-        showPixels3(pixels, data2, nLeds2, data3, nLeds3);
     }
 
     virtual void show(const struct PixelCommand *command, CRGB scale) {

--- a/src/controller.h
+++ b/src/controller.h
@@ -148,7 +148,7 @@ public:
     }
 
     static CRGB computeAdjustment(uint8_t scale, const CRGB & colorCorrection, const CRGB & colorTemperature) {
-      #if defined(NO_CORRECTION) && (NO_CORRECTION==1)
+      #if defined(NO_COLOR_CORRECTION) && (NO_COLOR_CORRECTION==1)
               return CRGB(scale,scale,scale);
       #else
               CRGB adj(0,0,0);

--- a/src/controller.h
+++ b/src/controller.h
@@ -428,7 +428,7 @@ protected:
     // }
 
     virtual void showN(const struct CRGB **data, int *nLeds, CRGB scale, uint8_t N) {
-        uint8_t dither = getDither();
+        const uint8_t dither = getDither();
         PixelController<RGB_ORDER, LANES, MASK> pixels(&data[0][0], 1, scale, dither);
 
         for (uint8_t i=0; i<N; i++) {

--- a/src/controller.h
+++ b/src/controller.h
@@ -60,7 +60,7 @@ protected:
 	///@param scale the rgb scaling to apply to each led before writing it out
     virtual void show(const struct CRGB *data, int nLeds, CRGB scale) = 0;
     // virtual void show2(const struct CRGB *data, int nLeds, CRGB scale, const struct CRGB *data2, int nLeds2, CRGB scale2) = 0;
-    virtual void showN(const struct CRGB **data, int **nLeds, CRGB scale, uint8_t N) = 0;
+    virtual void showN(const struct CRGB **data, int *nLeds, CRGB scale, uint8_t N) = 0;
 
 public:
 	/// create an led controller object, add it to the chain of controllers
@@ -88,7 +88,7 @@ public:
     // }
 
     /// show function w/integer brightness, will scale for color correction and temperature
-    void showN(const struct CRGB **data, int **nLeds, uint8_t brightness, uint8_t N) {
+    void showN(const struct CRGB **data, int *nLeds, uint8_t brightness, uint8_t N) {
         showN(data, nLeds, getAdjustment(brightness), N);
     }
 
@@ -427,21 +427,16 @@ protected:
     //     showPixels(pixels2);
     // }
 
-    virtual void showN(const struct CRGB **data, int **nLeds, CRGB scale, uint8_t N) {
+    virtual void showN(const struct CRGB **data, int *nLeds, CRGB scale, uint8_t N) {
         uint8_t dither = getDither();
+        PixelController<RGB_ORDER, LANES, MASK> pixels(&data[0][0], 1, scale, dither);
 
-        PixelController<RGB_ORDER, LANES, MASK> **controllers = new PixelController<RGB_ORDER, LANES, MASK>*[N];
-
         for (uint8_t i=0; i<N; i++) {
-            controllers[i] = new PixelController<RGB_ORDER, LANES, MASK> (data[i], nLeds[i], scale, dither);
+            pixels.mLen = nLeds[i];
+            pixels.mLenRemaining = nLeds[i];
+            pixels.mData = (uint8_t *)(&data[i][0]);
+            showPixels(pixels);
         }
-        for (uint8_t i=0; i<N; i++) {
-            showPixels(*controllers[i]);
-        }
-        for (uint8_t i=0; i<N; i++) {
-            delete controllers[i];
-        }
-        delete [] controllers;
     }
 
 public:

--- a/src/controller.h
+++ b/src/controller.h
@@ -59,6 +59,7 @@ protected:
 	///@param nLeds the number of leds being written out
 	///@param scale the rgb scaling to apply to each led before writing it out
     virtual void show(const struct CRGB *data, int nLeds, CRGB scale) = 0;
+    virtual void show2(const struct CRGB *data, int nLeds, CRGB scale, const struct CRGB *data2, int nLeds2, CRGB scale2) = 0;
 
 public:
 	/// create an led controller object, add it to the chain of controllers
@@ -78,6 +79,11 @@ public:
     /// show function w/integer brightness, will scale for color correction and temperature
     void show(const struct CRGB *data, int nLeds, uint8_t brightness) {
         show(data, nLeds, getAdjustment(brightness));
+    }
+
+    /// show function w/integer brightness, will scale for color correction and temperature
+    void show2(const struct CRGB *data, int nLeds, uint8_t brightness, const struct CRGB *data2, int nLeds2, uint8_t brightness2) {
+        show2(data, nLeds, getAdjustment(brightness), data2, nLeds2, getAdjustment(brightness2));
     }
 
     /// show function w/integer brightness, will scale for color correction and temperature
@@ -406,6 +412,13 @@ protected:
     virtual void show(const struct CRGB *data, int nLeds, CRGB scale) {
         PixelController<RGB_ORDER, LANES, MASK> pixels(data, nLeds, scale, getDither());
         showPixels(pixels);
+    }
+
+    virtual void show2(const struct CRGB *data, int nLeds, CRGB scale, const struct CRGB *data2, int nLeds2, CRGB scale2) {
+        PixelController<RGB_ORDER, LANES, MASK> pixels(data, nLeds, scale, getDither());
+        showPixels(pixels);
+        PixelController<RGB_ORDER, LANES, MASK> pixels2(data2, nLeds2, scale2, getDither());
+        showPixels(pixels2);
     }
 
 public:

--- a/src/controller.h
+++ b/src/controller.h
@@ -432,10 +432,12 @@ protected:
         PixelController<RGB_ORDER, LANES, MASK> pixels(&data[0][0], 1, scale, dither);
 
         for (uint8_t i=0; i<N; i++) {
-            pixels.mLen = nLeds[i];
-            pixels.mLenRemaining = nLeds[i];
-            pixels.mData = (uint8_t *)(&data[i][0]);
-            showPixels(pixels);
+            if(nLeds[i]) {
+                pixels.mLen = nLeds[i];
+                pixels.mLenRemaining = nLeds[i];
+                pixels.mData = (uint8_t *)(&data[i][0]);
+                showPixels(pixels);
+            }
         }
     }
 

--- a/src/platforms/avr/clockless_trinket.h
+++ b/src/platforms/avr/clockless_trinket.h
@@ -102,7 +102,7 @@ class ClocklessController : public CPixelLEDController<RGB_ORDER> {
 
 
 #ifdef NO_MINIMUM_WAIT
-	// Minimum wait interferes with the showN() functionality and isn't necessary if you're keeping your own framerate.
+	// Minimum wait interferes with the PixelCommand functionality and isn't necessary if you're keeping your own framerate.
 	CMinWait<WAIT_TIME> mWait;
 #endif
 
@@ -178,85 +178,6 @@ protected:
 #endif
 	}
 
-	virtual void showPixels2(PixelController<RGB_ORDER> & pixels, const struct CRGB * data2, int nLeds2) {
-
-#ifdef NO_MINIMUM_WAIT
-		mWait.wait();
-#endif
-
-		if(pixels.mLen > 0) {
-			showRGBInternal(pixels);
-		}
-
-		pixels.mData = (uint8_t *)data2;
-		pixels.mLen = nLeds2;
-
-		if(pixels.mLen > 0) {
-			showRGBInternal(pixels);
-		}
-
-
-#if (!defined(NO_CORRECTION) || (NO_CORRECTION == 0)) && (FASTLED_ALLOW_INTERRUPTS == 0)
-        uint32_t microsTaken = (uint32_t)pixels.size() * (uint32_t)CLKS_TO_MICROS(24 * (T1 + T2 + T3));
-        microsTaken += scale16by8(pixels.size(),(0.6 * 256) + 1) * CLKS_TO_MICROS(16);
-        if( microsTaken > 1000) {
-            microsTaken -= 1000;
-            uint16_t x256ths = microsTaken >> 2;
-            x256ths += scale16by8(x256ths,7);
-            x256ths += gTimeErrorAccum256ths;
-            MS_COUNTER += (x256ths >> 8);
-            gTimeErrorAccum256ths = x256ths & 0xFF;
-        }
-#endif
-
-#ifdef NO_MINIMUM_WAIT
-		mWait.mark();
-#endif
-	}
-
-	virtual void showPixels3(PixelController<RGB_ORDER> & pixels, const struct CRGB * data2, int nLeds2, const struct CRGB * data3, int nLeds3) {
-
-#ifdef NO_MINIMUM_WAIT
-		mWait.wait();
-#endif
-
-		if(pixels.mLen > 0) {
-			showRGBInternal(pixels);
-		}
-
-		pixels.mData = (uint8_t *)data2;
-		pixels.mLen = nLeds2;
-
-		if(pixels.mLen > 0) {
-			showRGBInternal(pixels);
-		}
-
-		pixels.mData = (uint8_t *)data3;
-		pixels.mLen = nLeds3;
-
-		if(pixels.mLen > 0) {
-			showRGBInternal(pixels);
-		}
-
-
-#if (!defined(NO_CORRECTION) || (NO_CORRECTION == 0)) && (FASTLED_ALLOW_INTERRUPTS == 0)
-        uint32_t microsTaken = (uint32_t)pixels.size() * (uint32_t)CLKS_TO_MICROS(24 * (T1 + T2 + T3));
-        microsTaken += scale16by8(pixels.size(),(0.6 * 256) + 1) * CLKS_TO_MICROS(16);
-        if( microsTaken > 1000) {
-            microsTaken -= 1000;
-            uint16_t x256ths = microsTaken >> 2;
-            x256ths += scale16by8(x256ths,7);
-            x256ths += gTimeErrorAccum256ths;
-            MS_COUNTER += (x256ths >> 8);
-            gTimeErrorAccum256ths = x256ths & 0xFF;
-        }
-#endif
-
-#ifdef NO_MINIMUM_WAIT
-		mWait.mark();
-#endif
-	}
-
 	virtual void showPixels(PixelController<RGB_ORDER> & pixels, const struct PixelCommand *command) {
 
 #ifdef NO_MINIMUM_WAIT
@@ -313,8 +234,8 @@ protected:
 				[loopvar] "+a" (loopvar),				\
 				[scale_base] "+a" (scale_base)			\
 				: /* use variables */					\
-				[ADV] "r" ((-advanceBy & 0xFF)),					\
-				[ADVU] "r" ((-advanceBy & 0xFF00) >> 8),					\
+				[ADV] "r" ((-advanceBy & 0xFF)),		\
+				[ADVU] "r" ((-advanceBy & 0xFF00) >> 8),\
 				[b0] "a" (b0),							\
 				[hi] "r" (hi),							\
 				[lo] "r" (lo),							\
@@ -542,57 +463,57 @@ protected:
 				// Inline scaling - RGB ordering
 				// DNOP
 				
-				cli(); HI1 _D1(3) QLO2(b0, 7) sei(); LDSCL4(b1,RGB_BYTE1(RGB_ORDER)) 	_D2(6)	LO1	PRESCALEA2(d1)	_D3(3) 
-				cli(); HI1 _D1(3) QLO2(b0, 6) sei(); PRESCALEB4(d1)	_D2(6)	LO1	SCALE12(b1,0)	_D3(3) 
-				cli(); HI1 _D1(3) QLO2(b0, 5) sei(); RORSC14(b1,1) 	_D2(6)	LO1 	RORCLC2(b1)	_D3(3) 
-				cli(); HI1 _D1(3) QLO2(b0, 4) sei(); SCROR14(b1,2)	_D2(6)	LO1 	SCALE12(b1,3)	_D3(3) 
-				cli(); HI1 _D1(3) QLO2(b0, 3) sei(); RORSC14(b1,4) 	_D2(6)	LO1 	RORCLC2(b1) 	_D3(3) 
-				cli(); HI1 _D1(3) QLO2(b0, 2) sei(); SCROR14(b1,5) 	_D2(6)	LO1 	SCALE12(b1,6)	_D3(3) 
-				cli(); HI1 _D1(3) QLO2(b0, 1) sei(); RORSC14(b1,7) 	_D2(6)	LO1 	RORCLC2(b1) 	_D3(3) 
-				cli(); HI1 _D1(3) QLO2(b0, 0) sei(); 
+				cli(); HI1 _D1(2) QLO2(b0, 7) sei(); LDSCL4(b1,RGB_BYTE1(RGB_ORDER)) 	_D2(5)	LO1	PRESCALEA2(d1)	_D3(2) 
+				cli(); HI1 _D1(2) QLO2(b0, 6) sei(); PRESCALEB4(d1)	_D2(5)	LO1	SCALE12(b1,0)	_D3(2) 
+				cli(); HI1 _D1(2) QLO2(b0, 5) sei(); RORSC14(b1,1) 	_D2(5)	LO1 	RORCLC2(b1)	_D3(2) 
+				cli(); HI1 _D1(2) QLO2(b0, 4) sei(); SCROR14(b1,2)	_D2(5)	LO1 	SCALE12(b1,3)	_D3(2) 
+				cli(); HI1 _D1(2) QLO2(b0, 3) sei(); RORSC14(b1,4) 	_D2(5)	LO1 	RORCLC2(b1) 	_D3(2) 
+				cli(); HI1 _D1(2) QLO2(b0, 2) sei(); SCROR14(b1,5) 	_D2(5)	LO1 	SCALE12(b1,6)	_D3(2) 
+				cli(); HI1 _D1(2) QLO2(b0, 1) sei(); RORSC14(b1,7) 	_D2(5)	LO1 	RORCLC2(b1) 	_D3(2) 
+				cli(); HI1 _D1(2) QLO2(b0, 0) sei(); 
 				switch(XTRA0) {
-					case 4: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)  /* fall through */
-					case 3: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)  /* fall through */
-					case 2: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)  /* fall through */
-					case 1: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)
+					case 4: _D2(1) LO1 _D3(0) cli(); HI1 _D1(2) QLO2(b0,0) sei(); /* fall through */
+					case 3: _D2(1) LO1 _D3(0) cli(); HI1 _D1(2) QLO2(b0,0) sei(); /* fall through */
+					case 2: _D2(1) LO1 _D3(0) cli(); HI1 _D1(2) QLO2(b0,0) sei(); /* fall through */
+					case 1: _D2(1) LO1 _D3(0) cli(); HI1 _D1(2) QLO2(b0,0) sei();
 				}
-				MOV_ADDDE14(b0,b1,d1,e1) _D2(6) LO1  _D3(2) 
+				MOV_ADDDE14(b0,b1,d1,e1) _D2(5) LO1  _D3(0) 
 				
 
-				cli(); HI1 _D1(3) QLO2(b0, 7) sei(); LDSCL4(b1,RGB_BYTE2(RGB_ORDER)) 	_D2(6)	LO1 PRESCALEA2(d2)	_D3(3)
-				cli(); HI1 _D1(3) QLO2(b0, 6) sei(); PSBIDATA4(d2)	_D2(6)	LO1 SCALE22(b1,0)	_D3(3)
-				cli(); HI1 _D1(3) QLO2(b0, 5) sei(); RORSC24(b1,1) 	_D2(6)	LO1 RORCLC2(b1) 	_D3(3)
-				cli(); HI1 _D1(3) QLO2(b0, 4) sei(); SCROR24(b1,2)	_D2(6)	LO1 SCALE22(b1,3)	_D3(3)
-				cli(); HI1 _D1(3) QLO2(b0, 3) sei(); RORSC24(b1,4) 	_D2(6)	LO1 RORCLC2(b1) 	_D3(3)
-				cli(); HI1 _D1(3) QLO2(b0, 2) sei(); SCROR24(b1,5) 	_D2(6)	LO1 SCALE22(b1,6)	_D3(3)
-				cli(); HI1 _D1(3) QLO2(b0, 1) sei(); RORSC24(b1,7) 	_D2(6)	LO1 RORCLC2(b1) 	_D3(3)
-				cli(); HI1 _D1(3) QLO2(b0, 0) sei();
+				cli(); HI1 _D1(2) QLO2(b0, 7) sei(); LDSCL4(b1,RGB_BYTE2(RGB_ORDER)) 	_D2(5)	LO1 PRESCALEA2(d2)	_D3(2)
+				cli(); HI1 _D1(2) QLO2(b0, 6) sei(); PSBIDATA4(d2)	_D2(5)	LO1 SCALE22(b1,0)	_D3(2)
+				cli(); HI1 _D1(2) QLO2(b0, 5) sei(); RORSC24(b1,1) 	_D2(5)	LO1 RORCLC2(b1) 	_D3(2)
+				cli(); HI1 _D1(2) QLO2(b0, 4) sei(); SCROR24(b1,2)	_D2(5)	LO1 SCALE22(b1,3)	_D3(2)
+				cli(); HI1 _D1(2) QLO2(b0, 3) sei(); RORSC24(b1,4) 	_D2(5)	LO1 RORCLC2(b1) 	_D3(2)
+				cli(); HI1 _D1(2) QLO2(b0, 2) sei(); SCROR24(b1,5) 	_D2(5)	LO1 SCALE22(b1,6)	_D3(2)
+				cli(); HI1 _D1(2) QLO2(b0, 1) sei(); RORSC24(b1,7) 	_D2(5)	LO1 RORCLC2(b1) 	_D3(2)
+				cli(); HI1 _D1(2) QLO2(b0, 0) sei();
 				switch(XTRA0) {
-					case 4: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)  /* fall through */
-					case 3: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)  /* fall through */
-					case 2: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)  /* fall through */
-					case 1: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)
+					case 4: _D2(1) LO1 _D3(0) cli(); HI1 _D1(2) QLO2(b0,0) sei(); /* fall through */
+					case 3: _D2(1) LO1 _D3(0) cli(); HI1 _D1(2) QLO2(b0,0) sei(); /* fall through */
+					case 2: _D2(1) LO1 _D3(0) cli(); HI1 _D1(2) QLO2(b0,0) sei(); /* fall through */
+					case 1: _D2(1) LO1 _D3(0) cli(); HI1 _D1(2) QLO2(b0,0) sei();
 				}
 
 				// Because Prescale on the middle byte also increments the data counter,
 				// we have to do both halves of updating d2 here - negating it (in the
 				// MOV_NEGD24 macro) and then adding E back into it
-				MOV_NEGD24(b0,b1,d2) _D2(5) LO1  ADDDE1(d2,e2) _D3(3)
-				cli(); HI1 _D1(3) QLO2(b0, 7) sei(); LDSCL4(b1,RGB_BYTE0(RGB_ORDER)) 	_D2(6)	LO1 PRESCALEA2(d0)	_D3(3)
-				cli(); HI1 _D1(3) QLO2(b0, 6) sei(); PRESCALEB4(d0)	_D2(6)	LO1 SCALE02(b1,0)	_D3(3)
-				cli(); HI1 _D1(3) QLO2(b0, 5) sei(); RORSC04(b1,1) 	_D2(6)	LO1 RORCLC2(b1) 	_D3(3)
-				cli(); HI1 _D1(3) QLO2(b0, 4) sei(); SCROR04(b1,2)	_D2(6)	LO1 SCALE02(b1,3)	_D3(3)
-				cli(); HI1 _D1(3) QLO2(b0, 3) sei(); RORSC04(b1,4) 	_D2(6)	LO1 RORCLC2(b1)  	_D3(3)
-				cli(); HI1 _D1(3) QLO2(b0, 2) sei(); SCROR04(b1,5) 	_D2(6)	LO1 SCALE02(b1,6)	_D3(3)
-				cli(); HI1 _D1(3) QLO2(b0, 1) sei(); RORSC04(b1,7) 	_D2(6)	LO1 RORCLC2(b1) 	_D3(3)
-				cli(); HI1 _D1(3) QLO2(b0, 0) sei();
+				MOV_NEGD24(b0,b1,d2) _D2(5) LO1  ADDDE1(d2,e2) _D3(1)
+				cli(); HI1 _D1(2) QLO2(b0, 7) sei(); LDSCL4(b1,RGB_BYTE0(RGB_ORDER)) 	_D2(5)	LO1 PRESCALEA2(d0)	_D3(2)
+				cli(); HI1 _D1(2) QLO2(b0, 6) sei(); PRESCALEB4(d0)	_D2(5)	LO1 SCALE02(b1,0)	_D3(2)
+				cli(); HI1 _D1(2) QLO2(b0, 5) sei(); RORSC04(b1,1) 	_D2(5)	LO1 RORCLC2(b1) 	_D3(2)
+				cli(); HI1 _D1(2) QLO2(b0, 4) sei(); SCROR04(b1,2)	_D2(5)	LO1 SCALE02(b1,3)	_D3(2)
+				cli(); HI1 _D1(2) QLO2(b0, 3) sei(); RORSC04(b1,4) 	_D2(5)	LO1 RORCLC2(b1)  	_D3(2)
+				cli(); HI1 _D1(2) QLO2(b0, 2) sei(); SCROR04(b1,5) 	_D2(5)	LO1 SCALE02(b1,6)	_D3(2)
+				cli(); HI1 _D1(2) QLO2(b0, 1) sei(); RORSC04(b1,7) 	_D2(5)	LO1 RORCLC2(b1) 	_D3(2)
+				cli(); HI1 _D1(2) QLO2(b0, 0) sei();
 				switch(XTRA0) {
-					case 4: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)  /* fall through */
-					case 3: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)  /* fall through */
-					case 2: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)  /* fall through */
-					case 1: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)
+					case 4: _D2(1) LO1 _D3(0) cli(); HI1 _D1(2) QLO2(b0,0) sei(); /* fall through */
+					case 3: _D2(1) LO1 _D3(0) cli(); HI1 _D1(2) QLO2(b0,0) sei(); /* fall through */
+					case 2: _D2(1) LO1 _D3(0) cli(); HI1 _D1(2) QLO2(b0,0) sei(); /* fall through */
+					case 1: _D2(1) LO1 _D3(0) cli(); HI1 _D1(2) QLO2(b0,0) sei();
 				}
-				MOV_ADDDE04(b0,b1,d0,e0) _D2(6) LO1  _D3(2)
+				MOV_ADDDE04(b0,b1,d0,e0) _D2(5) LO1  _D3(0)
 				ENDLOOP5
 			}
 			DONE;

--- a/src/platforms/avr/clockless_trinket.h
+++ b/src/platforms/avr/clockless_trinket.h
@@ -406,31 +406,31 @@ protected:
 				// Inline scaling - RGB ordering
 				// DNOP
 				
-				cli(); HI1 _D1(1) QLO2(b0, 7) LDSCL4(b1,O1) 	_D2(4)	LO1	sei();	PRESCALEA2(d1)	_D3(2) 
-				cli(); HI1 _D1(1) QLO2(b0, 6) PRESCALEB4(d1)	_D2(4)	LO1	sei();	SCALE12(b1,0)	_D3(2) 
-				cli(); HI1 _D1(1) QLO2(b0, 5) RORSC14(b1,1) 	_D2(4)	LO1 sei();	RORCLC2(b1)		_D3(2) 
-				cli(); HI1 _D1(1) QLO2(b0, 4) SCROR14(b1,2)		_D2(4)	LO1 sei();	SCALE12(b1,3)	_D3(2) 
-				cli(); HI1 _D1(1) QLO2(b0, 3) RORSC14(b1,4) 	_D2(4)	LO1 sei();	RORCLC2(b1) 	_D3(2) 
-				cli(); HI1 _D1(1) QLO2(b0, 2) SCROR14(b1,5) 	_D2(4)	LO1 sei();	SCALE12(b1,6)	_D3(2) 
-				cli(); HI1 _D1(1) QLO2(b0, 1) RORSC14(b1,7) 	_D2(4)	LO1 sei();	RORCLC2(b1) 	_D3(2) 
-				cli(); HI1 _D1(1) QLO2(b0, 0)
+				cli(); HI1 _D1(2) QLO2(b0, 7) LDSCL4(b1,O1) 	_D2(4)	LO1	sei();	PRESCALEA2(d1)	_D3(3) 
+				cli(); HI1 _D1(2) QLO2(b0, 6) PRESCALEB4(d1)	_D2(4)	LO1	sei();	SCALE12(b1,0)	_D3(3) 
+				cli(); HI1 _D1(2) QLO2(b0, 5) RORSC14(b1,1) 	_D2(4)	LO1 sei();	RORCLC2(b1)		_D3(3) 
+				cli(); HI1 _D1(2) QLO2(b0, 4) SCROR14(b1,2)		_D2(4)	LO1 sei();	SCALE12(b1,3)	_D3(3) 
+				cli(); HI1 _D1(2) QLO2(b0, 3) RORSC14(b1,4) 	_D2(4)	LO1 sei();	RORCLC2(b1) 	_D3(3) 
+				cli(); HI1 _D1(2) QLO2(b0, 2) SCROR14(b1,5) 	_D2(4)	LO1 sei();	SCALE12(b1,6)	_D3(3) 
+				cli(); HI1 _D1(2) QLO2(b0, 1) RORSC14(b1,7) 	_D2(4)	LO1 sei();	RORCLC2(b1) 	_D3(3) 
+				cli(); HI1 _D1(2) QLO2(b0, 0)
 				switch(XTRA0) {
 					case 4: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)  /* fall through */
 					case 3: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)  /* fall through */
 					case 2: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)  /* fall through */
 					case 1: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)
 				}
-				MOV_ADDDE14(b0,b1,d1,e1) _D2(4) LO1 sei(); _D3(0) 
+				MOV_ADDDE14(b0,b1,d1,e1) _D2(4) LO1 sei(); _D3(2) 
 				
 
-				cli(); HI1 _D1(1) QLO2(b0, 7) LDSCL4(b1,O2) 	_D2(4)	LO1	sei();	PRESCALEA2(d2)	_D3(2)
-				cli(); HI1 _D1(1) QLO2(b0, 6) PSBIDATA4(d2)		_D2(4)	LO1	sei();	SCALE22(b1,0)	_D3(2)
-				cli(); HI1 _D1(1) QLO2(b0, 5) RORSC24(b1,1) 	_D2(4)	LO1 sei();	RORCLC2(b1) 	_D3(2)
-				cli(); HI1 _D1(1) QLO2(b0, 4) SCROR24(b1,2)		_D2(4)	LO1 sei();	SCALE22(b1,3)	_D3(2)
-				cli(); HI1 _D1(1) QLO2(b0, 3) RORSC24(b1,4) 	_D2(4)	LO1 sei();	RORCLC2(b1) 	_D3(2)
-				cli(); HI1 _D1(1) QLO2(b0, 2) SCROR24(b1,5) 	_D2(4)	LO1 sei();	SCALE22(b1,6)	_D3(2)
-				cli(); HI1 _D1(1) QLO2(b0, 1) RORSC24(b1,7) 	_D2(4)	LO1 sei();	RORCLC2(b1) 	_D3(2)
-				cli(); HI1 _D1(1) QLO2(b0, 0)
+				cli(); HI1 _D1(2) QLO2(b0, 7) LDSCL4(b1,O2) 	_D2(4)	LO1	sei();	PRESCALEA2(d2)	_D3(3)
+				cli(); HI1 _D1(2) QLO2(b0, 6) PSBIDATA4(d2)		_D2(4)	LO1	sei();	SCALE22(b1,0)	_D3(3)
+				cli(); HI1 _D1(2) QLO2(b0, 5) RORSC24(b1,1) 	_D2(4)	LO1 sei();	RORCLC2(b1) 	_D3(3)
+				cli(); HI1 _D1(2) QLO2(b0, 4) SCROR24(b1,2)		_D2(4)	LO1 sei();	SCALE22(b1,3)	_D3(3)
+				cli(); HI1 _D1(2) QLO2(b0, 3) RORSC24(b1,4) 	_D2(4)	LO1 sei();	RORCLC2(b1) 	_D3(3)
+				cli(); HI1 _D1(2) QLO2(b0, 2) SCROR24(b1,5) 	_D2(4)	LO1 sei();	SCALE22(b1,6)	_D3(3)
+				cli(); HI1 _D1(2) QLO2(b0, 1) RORSC24(b1,7) 	_D2(4)	LO1 sei();	RORCLC2(b1) 	_D3(3)
+				cli(); HI1 _D1(2) QLO2(b0, 0)
 				switch(XTRA0) {
 					case 4: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)  /* fall through */
 					case 3: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)  /* fall through */
@@ -441,22 +441,22 @@ protected:
 				// Because Prescale on the middle byte also increments the data counter,
 				// we have to do both halves of updating d2 here - negating it (in the
 				// MOV_NEGD24 macro) and then adding E back into it
-				MOV_NEGD24(b0,b1,d2) _D2(4) LO1 sei(); ADDDE1(d2,e2) _D3(1)
-				cli(); HI1 _D1(1) QLO2(b0, 7) LDSCL4(b1,O0) 	_D2(4)	LO1 sei();	PRESCALEA2(d0)	_D3(2)
-				cli(); HI1 _D1(1) QLO2(b0, 6) PRESCALEB4(d0)	_D2(4)	LO1 sei();	SCALE02(b1,0)	_D3(2)
-				cli(); HI1 _D1(1) QLO2(b0, 5) RORSC04(b1,1) 	_D2(4)	LO1 sei(); RORCLC2(b1) 	_D3(2)
-				cli(); HI1 _D1(1) QLO2(b0, 4) SCROR04(b1,2)		_D2(4)	LO1 sei(); SCALE02(b1,3)	_D3(2)
-				cli(); HI1 _D1(1) QLO2(b0, 3) RORSC04(b1,4) 	_D2(4)	LO1 sei(); RORCLC2(b1)  	_D3(2)
-				cli(); HI1 _D1(1) QLO2(b0, 2) SCROR04(b1,5) 	_D2(4)	LO1 sei(); SCALE02(b1,6)	_D3(2)
-				cli(); HI1 _D1(1) QLO2(b0, 1) RORSC04(b1,7) 	_D2(4)	LO1 sei(); RORCLC2(b1) 	_D3(2)
-				cli(); HI1 _D1(1) QLO2(b0, 0)
+				MOV_NEGD24(b0,b1,d2) _D2(4) LO1 sei(); ADDDE1(d2,e2) _D3(3)
+				cli(); HI1 _D1(2) QLO2(b0, 7) LDSCL4(b1,O0) 	_D2(4)	LO1 sei();	PRESCALEA2(d0)	_D3(3)
+				cli(); HI1 _D1(2) QLO2(b0, 6) PRESCALEB4(d0)	_D2(4)	LO1 sei();	SCALE02(b1,0)	_D3(3)
+				cli(); HI1 _D1(2) QLO2(b0, 5) RORSC04(b1,1) 	_D2(4)	LO1 sei(); RORCLC2(b1) 	_D3(3)
+				cli(); HI1 _D1(2) QLO2(b0, 4) SCROR04(b1,2)		_D2(4)	LO1 sei(); SCALE02(b1,3)	_D3(3)
+				cli(); HI1 _D1(2) QLO2(b0, 3) RORSC04(b1,4) 	_D2(4)	LO1 sei(); RORCLC2(b1)  	_D3(3)
+				cli(); HI1 _D1(2) QLO2(b0, 2) SCROR04(b1,5) 	_D2(4)	LO1 sei(); SCALE02(b1,6)	_D3(3)
+				cli(); HI1 _D1(2) QLO2(b0, 1) RORSC04(b1,7) 	_D2(4)	LO1 sei(); RORCLC2(b1) 	_D3(3)
+				cli(); HI1 _D1(2) QLO2(b0, 0)
 				switch(XTRA0) {
 					case 4: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)  /* fall through */
 					case 3: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)  /* fall through */
 					case 2: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)  /* fall through */
 					case 1: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)
 				}
-				MOV_ADDDE04(b0,b1,d0,e0) _D2(4) LO1 sei(); _D3(5)
+				MOV_ADDDE04(b0,b1,d0,e0) _D2(4) LO1 sei(); _D3(2)
 				ENDLOOP5
 			}
 			DONE;

--- a/src/platforms/avr/clockless_trinket.h
+++ b/src/platforms/avr/clockless_trinket.h
@@ -112,9 +112,7 @@ public:
 protected:
 	virtual void showPixels(PixelController<RGB_ORDER> & pixels) {
 
-#ifndef NO_MINIMUM_WAIT
 		mWait.wait();
-#endif
 		//cli();
 
 		showRGBInternal(pixels);
@@ -169,9 +167,7 @@ protected:
 #endif
 
 		//sei();
-#ifndef NO_MINIMUM_WAIT
 		mWait.mark();
-#endif
 	}
 #define USE_ASM_MACROS
 

--- a/src/platforms/avr/clockless_trinket.h
+++ b/src/platforms/avr/clockless_trinket.h
@@ -406,31 +406,31 @@ protected:
 				// Inline scaling - RGB ordering
 				// DNOP
 				
-				cli(); HI1 _D1(2) QLO2(b0, 7) LDSCL4(b1,O1) 	_D2(4)	LO1	sei();	PRESCALEA2(d1)	_D3(3) 
-				cli(); HI1 _D1(2) QLO2(b0, 6) PRESCALEB4(d1)	_D2(4)	LO1	sei();	SCALE12(b1,0)	_D3(3) 
-				cli(); HI1 _D1(2) QLO2(b0, 5) RORSC14(b1,1) 	_D2(4)	LO1 sei();	RORCLC2(b1)		_D3(3) 
-				cli(); HI1 _D1(2) QLO2(b0, 4) SCROR14(b1,2)		_D2(4)	LO1 sei();	SCALE12(b1,3)	_D3(3) 
-				cli(); HI1 _D1(2) QLO2(b0, 3) RORSC14(b1,4) 	_D2(4)	LO1 sei();	RORCLC2(b1) 	_D3(3) 
-				cli(); HI1 _D1(2) QLO2(b0, 2) SCROR14(b1,5) 	_D2(4)	LO1 sei();	SCALE12(b1,6)	_D3(3) 
-				cli(); HI1 _D1(2) QLO2(b0, 1) RORSC14(b1,7) 	_D2(4)	LO1 sei();	RORCLC2(b1) 	_D3(3) 
-				cli(); HI1 _D1(2) QLO2(b0, 0)
+				cli(); HI1 _D1(2) QLO2(b0, 7) sei(); LDSCL4(b1,O1) 	_D2(5)	LO1	PRESCALEA2(d1)	_D3(2) 
+				cli(); HI1 _D1(2) QLO2(b0, 6) sei(); PRESCALEB4(d1)	_D2(5)	LO1	SCALE12(b1,0)	_D3(2) 
+				cli(); HI1 _D1(2) QLO2(b0, 5) sei(); RORSC14(b1,1) 	_D2(5)	LO1 	RORCLC2(b1)	_D3(2) 
+				cli(); HI1 _D1(2) QLO2(b0, 4) sei(); SCROR14(b1,2)	_D2(5)	LO1 	SCALE12(b1,3)	_D3(2) 
+				cli(); HI1 _D1(2) QLO2(b0, 3) sei(); RORSC14(b1,4) 	_D2(5)	LO1 	RORCLC2(b1) 	_D3(2) 
+				cli(); HI1 _D1(2) QLO2(b0, 2) sei(); SCROR14(b1,5) 	_D2(5)	LO1 	SCALE12(b1,6)	_D3(2) 
+				cli(); HI1 _D1(2) QLO2(b0, 1) sei(); RORSC14(b1,7) 	_D2(5)	LO1 	RORCLC2(b1) 	_D3(2) 
+				cli(); HI1 _D1(2) QLO2(b0, 0) sei(); 
 				switch(XTRA0) {
 					case 4: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)  /* fall through */
 					case 3: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)  /* fall through */
 					case 2: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)  /* fall through */
 					case 1: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)
 				}
-				MOV_ADDDE14(b0,b1,d1,e1) _D2(4) LO1 sei(); _D3(2) 
+				MOV_ADDDE14(b0,b1,d1,e1) _D2(5) LO1  _D3(1) 
 				
 
-				cli(); HI1 _D1(2) QLO2(b0, 7) LDSCL4(b1,O2) 	_D2(4)	LO1	sei();	PRESCALEA2(d2)	_D3(3)
-				cli(); HI1 _D1(2) QLO2(b0, 6) PSBIDATA4(d2)		_D2(4)	LO1	sei();	SCALE22(b1,0)	_D3(3)
-				cli(); HI1 _D1(2) QLO2(b0, 5) RORSC24(b1,1) 	_D2(4)	LO1 sei();	RORCLC2(b1) 	_D3(3)
-				cli(); HI1 _D1(2) QLO2(b0, 4) SCROR24(b1,2)		_D2(4)	LO1 sei();	SCALE22(b1,3)	_D3(3)
-				cli(); HI1 _D1(2) QLO2(b0, 3) RORSC24(b1,4) 	_D2(4)	LO1 sei();	RORCLC2(b1) 	_D3(3)
-				cli(); HI1 _D1(2) QLO2(b0, 2) SCROR24(b1,5) 	_D2(4)	LO1 sei();	SCALE22(b1,6)	_D3(3)
-				cli(); HI1 _D1(2) QLO2(b0, 1) RORSC24(b1,7) 	_D2(4)	LO1 sei();	RORCLC2(b1) 	_D3(3)
-				cli(); HI1 _D1(2) QLO2(b0, 0)
+				cli(); HI1 _D1(2) QLO2(b0, 7) sei(); LDSCL4(b1,O2) 	_D2(5)	LO1 PRESCALEA2(d2)	_D3(2)
+				cli(); HI1 _D1(2) QLO2(b0, 6) sei(); PSBIDATA4(d2)	_D2(5)	LO1 SCALE22(b1,0)	_D3(2)
+				cli(); HI1 _D1(2) QLO2(b0, 5) sei(); RORSC24(b1,1) 	_D2(5)	LO1 RORCLC2(b1) 	_D3(2)
+				cli(); HI1 _D1(2) QLO2(b0, 4) sei(); SCROR24(b1,2)	_D2(5)	LO1 SCALE22(b1,3)	_D3(2)
+				cli(); HI1 _D1(2) QLO2(b0, 3) sei(); RORSC24(b1,4) 	_D2(5)	LO1 RORCLC2(b1) 	_D3(2)
+				cli(); HI1 _D1(2) QLO2(b0, 2) sei(); SCROR24(b1,5) 	_D2(5)	LO1 SCALE22(b1,6)	_D3(2)
+				cli(); HI1 _D1(2) QLO2(b0, 1) sei(); RORSC24(b1,7) 	_D2(5)	LO1 RORCLC2(b1) 	_D3(2)
+				cli(); HI1 _D1(2) QLO2(b0, 0) sei();
 				switch(XTRA0) {
 					case 4: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)  /* fall through */
 					case 3: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)  /* fall through */
@@ -441,22 +441,22 @@ protected:
 				// Because Prescale on the middle byte also increments the data counter,
 				// we have to do both halves of updating d2 here - negating it (in the
 				// MOV_NEGD24 macro) and then adding E back into it
-				MOV_NEGD24(b0,b1,d2) _D2(4) LO1 sei(); ADDDE1(d2,e2) _D3(3)
-				cli(); HI1 _D1(2) QLO2(b0, 7) LDSCL4(b1,O0) 	_D2(4)	LO1 sei();	PRESCALEA2(d0)	_D3(3)
-				cli(); HI1 _D1(2) QLO2(b0, 6) PRESCALEB4(d0)	_D2(4)	LO1 sei();	SCALE02(b1,0)	_D3(3)
-				cli(); HI1 _D1(2) QLO2(b0, 5) RORSC04(b1,1) 	_D2(4)	LO1 sei(); RORCLC2(b1) 	_D3(3)
-				cli(); HI1 _D1(2) QLO2(b0, 4) SCROR04(b1,2)		_D2(4)	LO1 sei(); SCALE02(b1,3)	_D3(3)
-				cli(); HI1 _D1(2) QLO2(b0, 3) RORSC04(b1,4) 	_D2(4)	LO1 sei(); RORCLC2(b1)  	_D3(3)
-				cli(); HI1 _D1(2) QLO2(b0, 2) SCROR04(b1,5) 	_D2(4)	LO1 sei(); SCALE02(b1,6)	_D3(3)
-				cli(); HI1 _D1(2) QLO2(b0, 1) RORSC04(b1,7) 	_D2(4)	LO1 sei(); RORCLC2(b1) 	_D3(3)
-				cli(); HI1 _D1(2) QLO2(b0, 0)
+				MOV_NEGD24(b0,b1,d2) _D2(5) LO1  ADDDE1(d2,e2) _D3(2)
+				cli(); HI1 _D1(2) QLO2(b0, 7) sei(); LDSCL4(b1,O0) 	_D2(5)	LO1 PRESCALEA2(d0)	_D3(2)
+				cli(); HI1 _D1(2) QLO2(b0, 6) sei(); PRESCALEB4(d0)	_D2(5)	LO1 SCALE02(b1,0)	_D3(2)
+				cli(); HI1 _D1(2) QLO2(b0, 5) sei(); RORSC04(b1,1) 	_D2(5)	LO1 RORCLC2(b1) 	_D3(2)
+				cli(); HI1 _D1(2) QLO2(b0, 4) sei(); SCROR04(b1,2)	_D2(5)	LO1 SCALE02(b1,3)	_D3(2)
+				cli(); HI1 _D1(2) QLO2(b0, 3) sei(); RORSC04(b1,4) 	_D2(5)	LO1 RORCLC2(b1)  	_D3(2)
+				cli(); HI1 _D1(2) QLO2(b0, 2) sei(); SCROR04(b1,5) 	_D2(5)	LO1 SCALE02(b1,6)	_D3(2)
+				cli(); HI1 _D1(2) QLO2(b0, 1) sei(); RORSC04(b1,7) 	_D2(5)	LO1 RORCLC2(b1) 	_D3(2)
+				cli(); HI1 _D1(2) QLO2(b0, 0) sei();
 				switch(XTRA0) {
 					case 4: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)  /* fall through */
 					case 3: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)  /* fall through */
 					case 2: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)  /* fall through */
 					case 1: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)
 				}
-				MOV_ADDDE04(b0,b1,d0,e0) _D2(4) LO1 sei(); _D3(2)
+				MOV_ADDDE04(b0,b1,d0,e0) _D2(5) LO1  _D3(1)
 				ENDLOOP5
 			}
 			DONE;

--- a/src/platforms/avr/clockless_trinket.h
+++ b/src/platforms/avr/clockless_trinket.h
@@ -100,7 +100,11 @@ class ClocklessController : public CPixelLEDController<RGB_ORDER> {
 	typedef typename FastPin<DATA_PIN>::port_ptr_t data_ptr_t;
 	typedef typename FastPin<DATA_PIN>::port_t data_t;
 
+
+#ifndef NO_MINIMUM_WAIT
+	// Minimum wait interferes with the showN() functionality and isn't necessary if you're keeping your own framerate.
 	CMinWait<WAIT_TIME> mWait;
+#endif
 
 public:
 	virtual void init() {
@@ -112,7 +116,9 @@ public:
 protected:
 	virtual void showPixels(PixelController<RGB_ORDER> & pixels) {
 
+#ifndef NO_MINIMUM_WAIT
 		mWait.wait();
+#endif
 		//cli();
 
 		showRGBInternal(pixels);
@@ -167,7 +173,9 @@ protected:
 #endif
 
 		//sei();
+#ifndef NO_MINIMUM_WAIT
 		mWait.mark();
+#endif
 	}
 #define USE_ASM_MACROS
 

--- a/src/platforms/avr/clockless_trinket.h
+++ b/src/platforms/avr/clockless_trinket.h
@@ -112,7 +112,9 @@ public:
 protected:
 	virtual void showPixels(PixelController<RGB_ORDER> & pixels) {
 
+#ifndef NO_MINIMUM_WAIT
 		mWait.wait();
+#endif
 		//cli();
 
 		showRGBInternal(pixels);
@@ -167,7 +169,9 @@ protected:
 #endif
 
 		//sei();
+#ifndef NO_MINIMUM_WAIT
 		mWait.mark();
+#endif
 	}
 #define USE_ASM_MACROS
 

--- a/src/platforms/avr/clockless_trinket.h
+++ b/src/platforms/avr/clockless_trinket.h
@@ -121,7 +121,10 @@ protected:
 #endif
 		//cli();
 
-		showRGBInternal(pixels);
+
+		if(pixels.mLen > 0) {
+			showRGBInternal(pixels);
+		}
 
 		// Adjust the timer
 #if (!defined(NO_CORRECTION) || (NO_CORRECTION == 0)) && (FASTLED_ALLOW_INTERRUPTS == 0)

--- a/src/platforms/avr/clockless_trinket.h
+++ b/src/platforms/avr/clockless_trinket.h
@@ -119,8 +119,6 @@ protected:
 #ifdef NO_MINIMUM_WAIT
 		mWait.wait();
 #endif
-		//cli();
-
 
 		if(pixels.mLen > 0) {
 			showRGBInternal(pixels);
@@ -175,7 +173,85 @@ protected:
 
 #endif
 
-		//sei();
+#ifdef NO_MINIMUM_WAIT
+		mWait.mark();
+#endif
+	}
+
+	virtual void showPixels2(PixelController<RGB_ORDER> & pixels, const struct CRGB * data2, int nLeds2) {
+
+#ifdef NO_MINIMUM_WAIT
+		mWait.wait();
+#endif
+
+		if(pixels.mLen > 0) {
+			showRGBInternal(pixels);
+		}
+
+		pixels.mData = (uint8_t *)data2;
+		pixels.mLen = nLeds2;
+
+		if(pixels.mLen > 0) {
+			showRGBInternal(pixels);
+		}
+
+
+#if (!defined(NO_CORRECTION) || (NO_CORRECTION == 0)) && (FASTLED_ALLOW_INTERRUPTS == 0)
+	        uint32_t microsTaken = (uint32_t)pixels.size() * (uint32_t)CLKS_TO_MICROS(24 * (T1 + T2 + T3));
+	        microsTaken += scale16by8(pixels.size(),(0.6 * 256) + 1) * CLKS_TO_MICROS(16);
+	        if( microsTaken > 1000) {
+	            microsTaken -= 1000;
+	            uint16_t x256ths = microsTaken >> 2;
+	            x256ths += scale16by8(x256ths,7);
+	            x256ths += gTimeErrorAccum256ths;
+	            MS_COUNTER += (x256ths >> 8);
+	            gTimeErrorAccum256ths = x256ths & 0xFF;
+	        }
+#endif
+
+#ifdef NO_MINIMUM_WAIT
+		mWait.mark();
+#endif
+	}
+
+	virtual void showPixels3(PixelController<RGB_ORDER> & pixels, const struct CRGB * data2, int nLeds2, const struct CRGB * data3, int nLeds3) {
+
+#ifdef NO_MINIMUM_WAIT
+		mWait.wait();
+#endif
+
+		if(pixels.mLen > 0) {
+			showRGBInternal(pixels);
+		}
+
+		pixels.mData = (uint8_t *)data2;
+		pixels.mLen = nLeds2;
+
+		if(pixels.mLen > 0) {
+			showRGBInternal(pixels);
+		}
+
+		pixels.mData = (uint8_t *)data3;
+		pixels.mLen = nLeds3;
+
+		if(pixels.mLen > 0) {
+			showRGBInternal(pixels);
+		}
+
+
+#if (!defined(NO_CORRECTION) || (NO_CORRECTION == 0)) && (FASTLED_ALLOW_INTERRUPTS == 0)
+        uint32_t microsTaken = (uint32_t)pixels.size() * (uint32_t)CLKS_TO_MICROS(24 * (T1 + T2 + T3));
+        microsTaken += scale16by8(pixels.size(),(0.6 * 256) + 1) * CLKS_TO_MICROS(16);
+        if( microsTaken > 1000) {
+            microsTaken -= 1000;
+            uint16_t x256ths = microsTaken >> 2;
+            x256ths += scale16by8(x256ths,7);
+            x256ths += gTimeErrorAccum256ths;
+            MS_COUNTER += (x256ths >> 8);
+            gTimeErrorAccum256ths = x256ths & 0xFF;
+        }
+#endif
+
 #ifdef NO_MINIMUM_WAIT
 		mWait.mark();
 #endif

--- a/src/platforms/avr/clockless_trinket.h
+++ b/src/platforms/avr/clockless_trinket.h
@@ -473,10 +473,6 @@ protected:
 			DONE;
 		}
 
-		#if (FASTLED_ALLOW_INTERRUPTS == 1)
-		// stop using the clock juggler
-		TCCR0A &= ~0x30;
-		#endif
 	}
 
 };

--- a/src/platforms/avr/clockless_trinket.h
+++ b/src/platforms/avr/clockless_trinket.h
@@ -113,7 +113,7 @@ protected:
 	virtual void showPixels(PixelController<RGB_ORDER> & pixels) {
 
 		mWait.wait();
-		cli();
+		//cli();
 
 		showRGBInternal(pixels);
 
@@ -166,7 +166,7 @@ protected:
 
 #endif
 
-		sei();
+		//sei();
 		mWait.mark();
 	}
 #define USE_ASM_MACROS
@@ -405,56 +405,58 @@ protected:
 
 				// Inline scaling - RGB ordering
 				// DNOP
-				HI1 _D1(1) QLO2(b0, 7) LDSCL4(b1,O1) 	_D2(4)	LO1	PRESCALEA2(d1)	_D3(2)
-				HI1 _D1(1) QLO2(b0, 6) PRESCALEB4(d1)	_D2(4)	LO1	SCALE12(b1,0)	_D3(2)
-				HI1 _D1(1) QLO2(b0, 5) RORSC14(b1,1) 	_D2(4)	LO1 RORCLC2(b1)		_D3(2)
-				HI1 _D1(1) QLO2(b0, 4) SCROR14(b1,2)	_D2(4)	LO1 SCALE12(b1,3)	_D3(2)
-				HI1 _D1(1) QLO2(b0, 3) RORSC14(b1,4) 	_D2(4)	LO1 RORCLC2(b1) 	_D3(2)
-				HI1 _D1(1) QLO2(b0, 2) SCROR14(b1,5) 	_D2(4)	LO1 SCALE12(b1,6)	_D3(2)
-				HI1 _D1(1) QLO2(b0, 1) RORSC14(b1,7) 	_D2(4)	LO1 RORCLC2(b1) 	_D3(2)
-				HI1 _D1(1) QLO2(b0, 0)
+				
+				cli(); HI1 _D1(1) QLO2(b0, 7) LDSCL4(b1,O1) 	_D2(4)	LO1	sei();	PRESCALEA2(d1)	_D3(2) 
+				cli(); HI1 _D1(1) QLO2(b0, 6) PRESCALEB4(d1)	_D2(4)	LO1	sei();	SCALE12(b1,0)	_D3(2) 
+				cli(); HI1 _D1(1) QLO2(b0, 5) RORSC14(b1,1) 	_D2(4)	LO1 sei();	RORCLC2(b1)		_D3(2) 
+				cli(); HI1 _D1(1) QLO2(b0, 4) SCROR14(b1,2)		_D2(4)	LO1 sei();	SCALE12(b1,3)	_D3(2) 
+				cli(); HI1 _D1(1) QLO2(b0, 3) RORSC14(b1,4) 	_D2(4)	LO1 sei();	RORCLC2(b1) 	_D3(2) 
+				cli(); HI1 _D1(1) QLO2(b0, 2) SCROR14(b1,5) 	_D2(4)	LO1 sei();	SCALE12(b1,6)	_D3(2) 
+				cli(); HI1 _D1(1) QLO2(b0, 1) RORSC14(b1,7) 	_D2(4)	LO1 sei();	RORCLC2(b1) 	_D3(2) 
+				cli(); HI1 _D1(1) QLO2(b0, 0)
 				switch(XTRA0) {
-					case 4: _D2(0) LO1 _D3(0) HI1 _D1(1) QLO2(b0,0)  /* fall through */
-					case 3: _D2(0) LO1 _D3(0) HI1 _D1(1) QLO2(b0,0)  /* fall through */
-					case 2: _D2(0) LO1 _D3(0) HI1 _D1(1) QLO2(b0,0)  /* fall through */
-					case 1: _D2(0) LO1 _D3(0) HI1 _D1(1) QLO2(b0,0)
+					case 4: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)  /* fall through */
+					case 3: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)  /* fall through */
+					case 2: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)  /* fall through */
+					case 1: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)
 				}
-				MOV_ADDDE14(b0,b1,d1,e1) _D2(4) LO1 _D3(0)
+				MOV_ADDDE14(b0,b1,d1,e1) _D2(4) LO1 sei(); _D3(0) 
+				
 
-				HI1 _D1(1) QLO2(b0, 7) LDSCL4(b1,O2) 	_D2(4)	LO1	PRESCALEA2(d2)	_D3(2)
-				HI1 _D1(1) QLO2(b0, 6) PSBIDATA4(d2)	_D2(4)	LO1	SCALE22(b1,0)	_D3(2)
-				HI1 _D1(1) QLO2(b0, 5) RORSC24(b1,1) 	_D2(4)	LO1 RORCLC2(b1) 	_D3(2)
-				HI1 _D1(1) QLO2(b0, 4) SCROR24(b1,2)	_D2(4)	LO1 SCALE22(b1,3)	_D3(2)
-				HI1 _D1(1) QLO2(b0, 3) RORSC24(b1,4) 	_D2(4)	LO1 RORCLC2(b1) 	_D3(2)
-				HI1 _D1(1) QLO2(b0, 2) SCROR24(b1,5) 	_D2(4)	LO1 SCALE22(b1,6)	_D3(2)
-				HI1 _D1(1) QLO2(b0, 1) RORSC24(b1,7) 	_D2(4)	LO1 RORCLC2(b1) 	_D3(2)
-				HI1 _D1(1) QLO2(b0, 0)
+				cli(); HI1 _D1(1) QLO2(b0, 7) LDSCL4(b1,O2) 	_D2(4)	LO1	sei();	PRESCALEA2(d2)	_D3(2)
+				cli(); HI1 _D1(1) QLO2(b0, 6) PSBIDATA4(d2)		_D2(4)	LO1	sei();	SCALE22(b1,0)	_D3(2)
+				cli(); HI1 _D1(1) QLO2(b0, 5) RORSC24(b1,1) 	_D2(4)	LO1 sei();	RORCLC2(b1) 	_D3(2)
+				cli(); HI1 _D1(1) QLO2(b0, 4) SCROR24(b1,2)		_D2(4)	LO1 sei();	SCALE22(b1,3)	_D3(2)
+				cli(); HI1 _D1(1) QLO2(b0, 3) RORSC24(b1,4) 	_D2(4)	LO1 sei();	RORCLC2(b1) 	_D3(2)
+				cli(); HI1 _D1(1) QLO2(b0, 2) SCROR24(b1,5) 	_D2(4)	LO1 sei();	SCALE22(b1,6)	_D3(2)
+				cli(); HI1 _D1(1) QLO2(b0, 1) RORSC24(b1,7) 	_D2(4)	LO1 sei();	RORCLC2(b1) 	_D3(2)
+				cli(); HI1 _D1(1) QLO2(b0, 0)
 				switch(XTRA0) {
-					case 4: _D2(0) LO1 _D3(0) HI1 _D1(1) QLO2(b0,0)  /* fall through */
-					case 3: _D2(0) LO1 _D3(0) HI1 _D1(1) QLO2(b0,0)  /* fall through */
-					case 2: _D2(0) LO1 _D3(0) HI1 _D1(1) QLO2(b0,0)  /* fall through */
-					case 1: _D2(0) LO1 _D3(0) HI1 _D1(1) QLO2(b0,0)
+					case 4: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)  /* fall through */
+					case 3: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)  /* fall through */
+					case 2: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)  /* fall through */
+					case 1: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)
 				}
 
 				// Because Prescale on the middle byte also increments the data counter,
 				// we have to do both halves of updating d2 here - negating it (in the
 				// MOV_NEGD24 macro) and then adding E back into it
-				MOV_NEGD24(b0,b1,d2) _D2(4) LO1 ADDDE1(d2,e2) _D3(1)
-				HI1 _D1(1) QLO2(b0, 7) LDSCL4(b1,O0) 	_D2(4)	LO1	PRESCALEA2(d0)	_D3(2)
-				HI1 _D1(1) QLO2(b0, 6) PRESCALEB4(d0)	_D2(4)	LO1	SCALE02(b1,0)	_D3(2)
-				HI1 _D1(1) QLO2(b0, 5) RORSC04(b1,1) 	_D2(4)	LO1 RORCLC2(b1) 	_D3(2)
-				HI1 _D1(1) QLO2(b0, 4) SCROR04(b1,2)	_D2(4)	LO1 SCALE02(b1,3)	_D3(2)
-				HI1 _D1(1) QLO2(b0, 3) RORSC04(b1,4) 	_D2(4)	LO1 RORCLC2(b1)  	_D3(2)
-				HI1 _D1(1) QLO2(b0, 2) SCROR04(b1,5) 	_D2(4)	LO1 SCALE02(b1,6)	_D3(2)
-				HI1 _D1(1) QLO2(b0, 1) RORSC04(b1,7) 	_D2(4)	LO1 RORCLC2(b1) 	_D3(2)
-				HI1 _D1(1) QLO2(b0, 0)
+				MOV_NEGD24(b0,b1,d2) _D2(4) LO1 sei(); ADDDE1(d2,e2) _D3(1)
+				cli(); HI1 _D1(1) QLO2(b0, 7) LDSCL4(b1,O0) 	_D2(4)	LO1 sei();	PRESCALEA2(d0)	_D3(2)
+				cli(); HI1 _D1(1) QLO2(b0, 6) PRESCALEB4(d0)	_D2(4)	LO1 sei();	SCALE02(b1,0)	_D3(2)
+				cli(); HI1 _D1(1) QLO2(b0, 5) RORSC04(b1,1) 	_D2(4)	LO1 sei(); RORCLC2(b1) 	_D3(2)
+				cli(); HI1 _D1(1) QLO2(b0, 4) SCROR04(b1,2)		_D2(4)	LO1 sei(); SCALE02(b1,3)	_D3(2)
+				cli(); HI1 _D1(1) QLO2(b0, 3) RORSC04(b1,4) 	_D2(4)	LO1 sei(); RORCLC2(b1)  	_D3(2)
+				cli(); HI1 _D1(1) QLO2(b0, 2) SCROR04(b1,5) 	_D2(4)	LO1 sei(); SCALE02(b1,6)	_D3(2)
+				cli(); HI1 _D1(1) QLO2(b0, 1) RORSC04(b1,7) 	_D2(4)	LO1 sei(); RORCLC2(b1) 	_D3(2)
+				cli(); HI1 _D1(1) QLO2(b0, 0)
 				switch(XTRA0) {
-					case 4: _D2(0) LO1 _D3(0) HI1 _D1(1) QLO2(b0,0)  /* fall through */
-					case 3: _D2(0) LO1 _D3(0) HI1 _D1(1) QLO2(b0,0)  /* fall through */
-					case 2: _D2(0) LO1 _D3(0) HI1 _D1(1) QLO2(b0,0)  /* fall through */
-					case 1: _D2(0) LO1 _D3(0) HI1 _D1(1) QLO2(b0,0)
+					case 4: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)  /* fall through */
+					case 3: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)  /* fall through */
+					case 2: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)  /* fall through */
+					case 1: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)
 				}
-				MOV_ADDDE04(b0,b1,d0,e0) _D2(4) LO1 _D3(5)
+				MOV_ADDDE04(b0,b1,d0,e0) _D2(4) LO1 sei(); _D3(5)
 				ENDLOOP5
 			}
 			DONE;

--- a/src/platforms/avr/clockless_trinket.h
+++ b/src/platforms/avr/clockless_trinket.h
@@ -101,7 +101,7 @@ class ClocklessController : public CPixelLEDController<RGB_ORDER> {
 	typedef typename FastPin<DATA_PIN>::port_t data_t;
 
 
-#ifndef NO_MINIMUM_WAIT
+#ifdef NO_MINIMUM_WAIT
 	// Minimum wait interferes with the showN() functionality and isn't necessary if you're keeping your own framerate.
 	CMinWait<WAIT_TIME> mWait;
 #endif
@@ -116,7 +116,7 @@ public:
 protected:
 	virtual void showPixels(PixelController<RGB_ORDER> & pixels) {
 
-#ifndef NO_MINIMUM_WAIT
+#ifdef NO_MINIMUM_WAIT
 		mWait.wait();
 #endif
 		//cli();
@@ -173,7 +173,7 @@ protected:
 #endif
 
 		//sei();
-#ifndef NO_MINIMUM_WAIT
+#ifdef NO_MINIMUM_WAIT
 		mWait.mark();
 #endif
 	}

--- a/src/platforms/avr/clockless_trinket.h
+++ b/src/platforms/avr/clockless_trinket.h
@@ -406,31 +406,31 @@ protected:
 				// Inline scaling - RGB ordering
 				// DNOP
 				
-				cli(); HI1 _D1(2) QLO2(b0, 7) sei(); LDSCL4(b1,O1) 	_D2(5)	LO1	PRESCALEA2(d1)	_D3(2) 
-				cli(); HI1 _D1(2) QLO2(b0, 6) sei(); PRESCALEB4(d1)	_D2(5)	LO1	SCALE12(b1,0)	_D3(2) 
-				cli(); HI1 _D1(2) QLO2(b0, 5) sei(); RORSC14(b1,1) 	_D2(5)	LO1 	RORCLC2(b1)	_D3(2) 
-				cli(); HI1 _D1(2) QLO2(b0, 4) sei(); SCROR14(b1,2)	_D2(5)	LO1 	SCALE12(b1,3)	_D3(2) 
-				cli(); HI1 _D1(2) QLO2(b0, 3) sei(); RORSC14(b1,4) 	_D2(5)	LO1 	RORCLC2(b1) 	_D3(2) 
-				cli(); HI1 _D1(2) QLO2(b0, 2) sei(); SCROR14(b1,5) 	_D2(5)	LO1 	SCALE12(b1,6)	_D3(2) 
-				cli(); HI1 _D1(2) QLO2(b0, 1) sei(); RORSC14(b1,7) 	_D2(5)	LO1 	RORCLC2(b1) 	_D3(2) 
-				cli(); HI1 _D1(2) QLO2(b0, 0) sei(); 
+				cli(); HI1 _D1(3) QLO2(b0, 7) sei(); LDSCL4(b1,O1) 	_D2(6)	LO1	PRESCALEA2(d1)	_D3(3) 
+				cli(); HI1 _D1(3) QLO2(b0, 6) sei(); PRESCALEB4(d1)	_D2(6)	LO1	SCALE12(b1,0)	_D3(3) 
+				cli(); HI1 _D1(3) QLO2(b0, 5) sei(); RORSC14(b1,1) 	_D2(6)	LO1 	RORCLC2(b1)	_D3(3) 
+				cli(); HI1 _D1(3) QLO2(b0, 4) sei(); SCROR14(b1,2)	_D2(6)	LO1 	SCALE12(b1,3)	_D3(3) 
+				cli(); HI1 _D1(3) QLO2(b0, 3) sei(); RORSC14(b1,4) 	_D2(6)	LO1 	RORCLC2(b1) 	_D3(3) 
+				cli(); HI1 _D1(3) QLO2(b0, 2) sei(); SCROR14(b1,5) 	_D2(6)	LO1 	SCALE12(b1,6)	_D3(3) 
+				cli(); HI1 _D1(3) QLO2(b0, 1) sei(); RORSC14(b1,7) 	_D2(6)	LO1 	RORCLC2(b1) 	_D3(3) 
+				cli(); HI1 _D1(3) QLO2(b0, 0) sei(); 
 				switch(XTRA0) {
 					case 4: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)  /* fall through */
 					case 3: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)  /* fall through */
 					case 2: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)  /* fall through */
 					case 1: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)
 				}
-				MOV_ADDDE14(b0,b1,d1,e1) _D2(5) LO1  _D3(1) 
+				MOV_ADDDE14(b0,b1,d1,e1) _D2(6) LO1  _D3(2) 
 				
 
-				cli(); HI1 _D1(2) QLO2(b0, 7) sei(); LDSCL4(b1,O2) 	_D2(5)	LO1 PRESCALEA2(d2)	_D3(2)
-				cli(); HI1 _D1(2) QLO2(b0, 6) sei(); PSBIDATA4(d2)	_D2(5)	LO1 SCALE22(b1,0)	_D3(2)
-				cli(); HI1 _D1(2) QLO2(b0, 5) sei(); RORSC24(b1,1) 	_D2(5)	LO1 RORCLC2(b1) 	_D3(2)
-				cli(); HI1 _D1(2) QLO2(b0, 4) sei(); SCROR24(b1,2)	_D2(5)	LO1 SCALE22(b1,3)	_D3(2)
-				cli(); HI1 _D1(2) QLO2(b0, 3) sei(); RORSC24(b1,4) 	_D2(5)	LO1 RORCLC2(b1) 	_D3(2)
-				cli(); HI1 _D1(2) QLO2(b0, 2) sei(); SCROR24(b1,5) 	_D2(5)	LO1 SCALE22(b1,6)	_D3(2)
-				cli(); HI1 _D1(2) QLO2(b0, 1) sei(); RORSC24(b1,7) 	_D2(5)	LO1 RORCLC2(b1) 	_D3(2)
-				cli(); HI1 _D1(2) QLO2(b0, 0) sei();
+				cli(); HI1 _D1(3) QLO2(b0, 7) sei(); LDSCL4(b1,O2) 	_D2(6)	LO1 PRESCALEA2(d2)	_D3(3)
+				cli(); HI1 _D1(3) QLO2(b0, 6) sei(); PSBIDATA4(d2)	_D2(6)	LO1 SCALE22(b1,0)	_D3(3)
+				cli(); HI1 _D1(3) QLO2(b0, 5) sei(); RORSC24(b1,1) 	_D2(6)	LO1 RORCLC2(b1) 	_D3(3)
+				cli(); HI1 _D1(3) QLO2(b0, 4) sei(); SCROR24(b1,2)	_D2(6)	LO1 SCALE22(b1,3)	_D3(3)
+				cli(); HI1 _D1(3) QLO2(b0, 3) sei(); RORSC24(b1,4) 	_D2(6)	LO1 RORCLC2(b1) 	_D3(3)
+				cli(); HI1 _D1(3) QLO2(b0, 2) sei(); SCROR24(b1,5) 	_D2(6)	LO1 SCALE22(b1,6)	_D3(3)
+				cli(); HI1 _D1(3) QLO2(b0, 1) sei(); RORSC24(b1,7) 	_D2(6)	LO1 RORCLC2(b1) 	_D3(3)
+				cli(); HI1 _D1(3) QLO2(b0, 0) sei();
 				switch(XTRA0) {
 					case 4: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)  /* fall through */
 					case 3: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)  /* fall through */
@@ -441,22 +441,22 @@ protected:
 				// Because Prescale on the middle byte also increments the data counter,
 				// we have to do both halves of updating d2 here - negating it (in the
 				// MOV_NEGD24 macro) and then adding E back into it
-				MOV_NEGD24(b0,b1,d2) _D2(5) LO1  ADDDE1(d2,e2) _D3(2)
-				cli(); HI1 _D1(2) QLO2(b0, 7) sei(); LDSCL4(b1,O0) 	_D2(5)	LO1 PRESCALEA2(d0)	_D3(2)
-				cli(); HI1 _D1(2) QLO2(b0, 6) sei(); PRESCALEB4(d0)	_D2(5)	LO1 SCALE02(b1,0)	_D3(2)
-				cli(); HI1 _D1(2) QLO2(b0, 5) sei(); RORSC04(b1,1) 	_D2(5)	LO1 RORCLC2(b1) 	_D3(2)
-				cli(); HI1 _D1(2) QLO2(b0, 4) sei(); SCROR04(b1,2)	_D2(5)	LO1 SCALE02(b1,3)	_D3(2)
-				cli(); HI1 _D1(2) QLO2(b0, 3) sei(); RORSC04(b1,4) 	_D2(5)	LO1 RORCLC2(b1)  	_D3(2)
-				cli(); HI1 _D1(2) QLO2(b0, 2) sei(); SCROR04(b1,5) 	_D2(5)	LO1 SCALE02(b1,6)	_D3(2)
-				cli(); HI1 _D1(2) QLO2(b0, 1) sei(); RORSC04(b1,7) 	_D2(5)	LO1 RORCLC2(b1) 	_D3(2)
-				cli(); HI1 _D1(2) QLO2(b0, 0) sei();
+				MOV_NEGD24(b0,b1,d2) _D2(5) LO1  ADDDE1(d2,e2) _D3(3)
+				cli(); HI1 _D1(3) QLO2(b0, 7) sei(); LDSCL4(b1,O0) 	_D2(6)	LO1 PRESCALEA2(d0)	_D3(3)
+				cli(); HI1 _D1(3) QLO2(b0, 6) sei(); PRESCALEB4(d0)	_D2(6)	LO1 SCALE02(b1,0)	_D3(3)
+				cli(); HI1 _D1(3) QLO2(b0, 5) sei(); RORSC04(b1,1) 	_D2(6)	LO1 RORCLC2(b1) 	_D3(3)
+				cli(); HI1 _D1(3) QLO2(b0, 4) sei(); SCROR04(b1,2)	_D2(6)	LO1 SCALE02(b1,3)	_D3(3)
+				cli(); HI1 _D1(3) QLO2(b0, 3) sei(); RORSC04(b1,4) 	_D2(6)	LO1 RORCLC2(b1)  	_D3(3)
+				cli(); HI1 _D1(3) QLO2(b0, 2) sei(); SCROR04(b1,5) 	_D2(6)	LO1 SCALE02(b1,6)	_D3(3)
+				cli(); HI1 _D1(3) QLO2(b0, 1) sei(); RORSC04(b1,7) 	_D2(6)	LO1 RORCLC2(b1) 	_D3(3)
+				cli(); HI1 _D1(3) QLO2(b0, 0) sei();
 				switch(XTRA0) {
 					case 4: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)  /* fall through */
 					case 3: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)  /* fall through */
 					case 2: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)  /* fall through */
 					case 1: _D2(0) LO1 sei(); _D3(0) cli(); HI1 _D1(1) QLO2(b0,0)
 				}
-				MOV_ADDDE04(b0,b1,d0,e0) _D2(5) LO1  _D3(1)
+				MOV_ADDDE04(b0,b1,d0,e0) _D2(6) LO1  _D3(2)
 				ENDLOOP5
 			}
 			DONE;


### PR DESCRIPTION
I present here a patch (which is currently only implemented fully for Clockless Trinket) which fixes a few long standing bugs as well as enabling new features.

Features
---------

* Interrupts can now be enabled on AVR. 
* Linked-list type "PixelCommand" (implemented only in Clockless Trinket at the moment) allows you to link together pointers within your LED array to render on the same strip without physically moving the data round. This allows for example:
-- free "reverse" (on a per sub-block basis)
-- mirroring 
-- repeating a short array of pixels onto a longer strip on a loop
-- rotation (showing N...END, 0..N, then N+1..END, 0..N+1, etc)  
-- offsetting
-- could also be used for scrolling vertically or horizontally on grids
* define to disable the minimum wait period (if you do your own FPS)


Bugs Fixed
-----------

1. clockless_trinket can now use negative skips. I jumped through some hoops to get this to work on gcc by freeing up 3 variables in the ASM constraints!
3. NO_CORRECTION in controller.h is renamed to NO_COLOR_CORRECTION, because it clashes with a NO_CORRECTION In clockless_trinket (used to disable the clock skew correction
3. removed trace of timer juggling - clockless_trinket should not be interfering with TCCR0A
4. pixel arrays of length 0 no longer hang.

If you want to see it in action… i can provide video.