### PR TITLE
Remove clobbering of TCCR0A left over from ancient times

### DIFF
--- a/src/platforms/avr/clockless_trinket.h
+++ b/src/platforms/avr/clockless_trinket.h
@@ -473,10 +473,6 @@ protected:
 			DONE;
 		}
 
-		#if (FASTLED_ALLOW_INTERRUPTS == 1)
-		// stop using the clock juggler
-		TCCR0A &= ~0x30;
-		#endif
 	}
 
 };


### PR DESCRIPTION
Daniel Garcia commented out all of the other code which goes with this block in b9b23091 (2015). Remove this last remnant.