### PR TITLE
Prevent FastLED from hanging on 0-length pixel arrays

### DIFF
--- a/src/platforms/avr/clockless_trinket.h
+++ b/src/platforms/avr/clockless_trinket.h
@@ -115,7 +115,9 @@ protected:
 		mWait.wait();
 		cli();
 
-		showRGBInternal(pixels);
+		if(pixels.mLen > 0) {
+			showRGBInternal(pixels);
+		}
 
 		// Adjust the timer
 #if (!defined(NO_CORRECTION) || (NO_CORRECTION == 0)) && (FASTLED_ALLOW_INTERRUPTS == 0)


### PR DESCRIPTION
Without this patch, a 0 length pixel array is treated as if it's 65535 long. Whilst few people will encounter this bug in simple applications, it comes up frequently when manipulating ranges of pixels with multiple PixelControllers.