### PR TITLE
Feature/avr clockless trinket negative advance by

### DIFF
--- a/src/controller.h
+++ b/src/controller.h
@@ -407,7 +407,7 @@ protected:
         PixelController<RGB_ORDER, LANES, MASK> pixels(data, nLeds < 0 ? -nLeds : nLeds, scale, getDither());
         if(nLeds < 0) {
             // nLeds < 0 implies that we want to show them in reverse
-            pixels.mAdvance = -3;
+            pixels.mAdvance = -pixels.mAdvance;
         }
         showPixels(pixels);
     }

--- a/src/controller.h
+++ b/src/controller.h
@@ -404,7 +404,11 @@ protected:
     ///@param nLeds the number of leds being written out
     ///@param scale the rgb scaling to apply to each led before writing it out
     virtual void show(const struct CRGB *data, int nLeds, CRGB scale) {
-        PixelController<RGB_ORDER, LANES, MASK> pixels(data, nLeds, scale, getDither());
+        PixelController<RGB_ORDER, LANES, MASK> pixels(data, nLeds < 0 ? -nLeds : nLeds, scale, getDither());
+        if(nLeds < 0) {
+            // nLeds < 0 implies that we want to show them in reverse
+            pixels.mAdvance = -3;
+        }
         showPixels(pixels);
     }
 


### PR DESCRIPTION
This PR mainly allows Clockless Trinket to deal with negative advanceBy values, which are allowed.

A negative advanceBy implies that you want to render an array of LEDS backward, starting at the end. 

Example usage:

Show forward (as usual, but spelled out to illustrate the subsequent example):
```C++   
FastLED[0].setLeds(&leds[0], STRIP_LENGTH);
FastLED.show();
```

Show in reverse:
```C++      
FastLED[0].setLeds(&leds[STRIP_LENGTH-1], -STRIP_LENGTH);
FastLED.show();   
```

I don't think the change to Controller::show() is ideal; I think this needs explicit support in the API. (it's currently only half there). It appears to be very difficult to access PixelController objects from the main scope, as they're created by show() right before showing.

But, regardless, the changes to clockless_trinket are independent and could be taken on their own.
