### PR TITLE
Bugfix/duplicate define no correction

### DIFF
--- a/src/platforms/avr/clockless_trinket.h
+++ b/src/platforms/avr/clockless_trinket.h
@@ -87,9 +87,9 @@ template<> __attribute__((always_inline)) inline void _dc<20>(register uint8_t &
 //
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-#if (FASTLED_ALLOW_INTERRUPTS == 1) && defined(NO_CORRECTION) && (NO_CORRECTION == 1) && !(defined(NO_CLOCK_CORRECTION))
-#	warning In older versions of FastLED defining NO_CORRECTION 1 would mistakenly turn off color correction as well as clock correction.
-#	warning As clock correction is unnecessary with FASTLED_ALLOW_INTERRUPTS 1, you should define NO_CLOCK_CORRECTION 1 instead.
+#if ((FASTLED_ALLOW_INTERRUPTS == 1) && defined(NO_CORRECTION) && (NO_CORRECTION == 1) && !(defined(NO_CLOCK_CORRECTION)))
+#	pragma message "In older versions of FastLED defining NO_CORRECTION 1 would mistakenly turn off color correction as well as clock correction."
+#	pragma message "Clock correction is unnecessary with FASTLED_ALLOW_INTERRUPTS 1. define NO_CLOCK_CORRECTION 1 to fix this warning."
 #	define NO_CLOCK_CORRECTION 1
 #endif
 

--- a/src/platforms/avr/clockless_trinket.h
+++ b/src/platforms/avr/clockless_trinket.h
@@ -87,9 +87,10 @@ template<> __attribute__((always_inline)) inline void _dc<20>(register uint8_t &
 //
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-#if ((FASTLED_ALLOW_INTERRUPTS == 1) && defined(NO_CORRECTION) && (NO_CORRECTION == 1) && !(defined(NO_CLOCK_CORRECTION)))
+#if ((FASTLED_ALLOW_INTERRUPTS == 0) && defined(NO_CORRECTION) && (NO_CORRECTION == 1) && !(defined(NO_CLOCK_CORRECTION)))
+// we hit this if you were trying to turn off clock correction without also trying to enable interrupts.
 #	pragma message "In older versions of FastLED defining NO_CORRECTION 1 would mistakenly turn off color correction as well as clock correction."
-#	pragma message "Clock correction is unnecessary with FASTLED_ALLOW_INTERRUPTS 1. define NO_CLOCK_CORRECTION 1 to fix this warning."
+#	pragma message "define NO_CLOCK_CORRECTION 1 to fix this warning."
 #	define NO_CLOCK_CORRECTION 1
 #endif
 

--- a/src/platforms/avr/clockless_trinket.h
+++ b/src/platforms/avr/clockless_trinket.h
@@ -87,7 +87,13 @@ template<> __attribute__((always_inline)) inline void _dc<20>(register uint8_t &
 //
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-#if (!defined(NO_CORRECTION) || (NO_CORRECTION == 0)) && (FASTLED_ALLOW_INTERRUPTS == 0)
+#if (FASTLED_ALLOW_INTERRUPTS == 1) && defined(NO_CORRECTION) && (NO_CORRECTION == 1) && !(defined(NO_CLOCK_CORRECTION))
+#	warning In older versions of FastLED defining NO_CORRECTION 1 would mistakenly turn off color correction as well as clock correction.
+#	warning As clock correction is unnecessary with FASTLED_ALLOW_INTERRUPTS 1, you should define NO_CLOCK_CORRECTION 1 instead.
+#	define NO_CLOCK_CORRECTION 1
+#endif
+
+#if (!defined(NO_CLOCK_CORRECTION) || (NO_CLOCK_CORRECTION == 0)) && (FASTLED_ALLOW_INTERRUPTS == 0)
 static uint8_t gTimeErrorAccum256ths;
 #endif
 
@@ -118,7 +124,7 @@ protected:
 		showRGBInternal(pixels);
 
 		// Adjust the timer
-#if (!defined(NO_CORRECTION) || (NO_CORRECTION == 0)) && (FASTLED_ALLOW_INTERRUPTS == 0)
+#if (!defined(NO_CLOCK_CORRECTION) || (NO_CLOCK_CORRECTION == 0)) && (FASTLED_ALLOW_INTERRUPTS == 0)
         uint32_t microsTaken = (uint32_t)pixels.size() * (uint32_t)CLKS_TO_MICROS(24 * (T1 + T2 + T3));
 
         // adust for approximate observed actal runtime (as of January 2015)


### PR DESCRIPTION
An implementation of the solution suggested on #1263 

The NO_CORRECTION define accidentally has two meanings. On clockless trinket, when combined with FASTLED_ALLOW_INTERRUPTS, it disables the clock skew correction. (with my AVR interrupts branch clock skew correction becomes unnecessary, but that's another story).

This change renames the more specific define to NO_CLOCK_CORRECTION. In configurations where it would have made a difference, NO_CORRECTION will still work the same way, but will print a helpful warning of how to fix the problem to be unambiguous.

**N.B.** the warning is only true if my PR #1268 is merged, otherwise it might need rewording.