### PR TITLE
fixed os_intr_lock without unlock

### DIFF
--- a/src/platforms/esp/8266/clockless_esp8266.h
+++ b/src/platforms/esp/8266/clockless_esp8266.h
@@ -42,9 +42,7 @@ protected:
       #ifdef FASTLED_DEBUG_COUNT_FRAME_RETRIES
       ++_retry_cnt;
       #endif
-      os_intr_unlock();
       delayMicroseconds(WAIT_TIME);
-      os_intr_lock();
     }
     mWait.mark();
   }


### PR DESCRIPTION
At this point interrupts are unlocked, calling os_intr_lock() without unlock leaves them locked.
This state fixes itself once the main loop() is left, but might cause issues with other code that runs later in the loop() function.

If interrupts are locked, can_yield() returns false even outside any ISR. It seems this does not cause any issues with the WDT since the NMI cannot be locked, but once the loop() function is left, all the code that was paused runs at once.