### PR TITLE
Create fill_rainbow_circular and fill_palette_circular functions

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -130,8 +130,9 @@ fade_video	KEYWORD2
 fill_gradient	KEYWORD2
 fill_gradient_RGB	KEYWORD2
 fill_palette	KEYWORD2
+fill_palette_circular	KEYWORD2
 fill_rainbow	KEYWORD2
-fill_rainbow_endless	KEYWORD2
+fill_rainbow_circular	KEYWORD2
 fill_solid	KEYWORD2
 map_data_into_colors_through_palette	KEYWORD2
 nblend	KEYWORD2

--- a/keywords.txt
+++ b/keywords.txt
@@ -131,6 +131,7 @@ fill_gradient	KEYWORD2
 fill_gradient_RGB	KEYWORD2
 fill_palette	KEYWORD2
 fill_rainbow	KEYWORD2
+fill_rainbow_endless	KEYWORD2
 fill_solid	KEYWORD2
 map_data_into_colors_through_palette	KEYWORD2
 nblend	KEYWORD2

--- a/src/colorutils.cpp
+++ b/src/colorutils.cpp
@@ -71,7 +71,7 @@ void fill_rainbow_circular(struct CRGB* targetArray, int numToFill, uint8_t init
     hsv.val = 255;
     hsv.sat = 240;
 
-    const uint16_t hueChange = 65536 / (uint16_t)numToFill;  // hue change for each LED, * 256 for precision
+    const uint16_t hueChange = 65535 / (uint16_t)numToFill;  // hue change for each LED, * 256 for precision (256 * 256 - 1)
     uint16_t hueOffset = 0;  // offset for hue value, with precision (*256)
 
     for (int i = 0; i < numToFill; ++i) {
@@ -90,7 +90,7 @@ void fill_rainbow_circular(struct CHSV* targetArray, int numToFill, uint8_t init
     hsv.val = 255;
     hsv.sat = 240;
 
-    const uint16_t hueChange = 65536 / (uint16_t)numToFill;  // hue change for each LED, * 256 for precision
+    const uint16_t hueChange = 65535 / (uint16_t) numToFill;  // hue change for each LED, * 256 for precision (256 * 256 - 1)
     uint16_t hueOffset = 0;  // offset for hue value, with precision (*256)
 
     for (int i = 0; i < numToFill; ++i) {

--- a/src/colorutils.cpp
+++ b/src/colorutils.cpp
@@ -62,7 +62,7 @@ void fill_rainbow( struct CHSV * targetArray, int numToFill,
 }
 
 
-void fill_rainbow_circular(struct CRGB* targetArray, int numToFill, uint8_t initialhue)
+void fill_rainbow_circular(struct CRGB* targetArray, int numToFill, uint8_t initialhue, bool reversed)
 {
     if (numToFill == 0) return;  // avoiding div/0
 
@@ -76,12 +76,13 @@ void fill_rainbow_circular(struct CRGB* targetArray, int numToFill, uint8_t init
 
     for (int i = 0; i < numToFill; ++i) {
         targetArray[i] = hsv;
-        hueOffset += hueChange;  // increase precise offset
+        if (reversed) hueOffset -= hueChange;
+        else hueOffset += hueChange;
         hsv.hue = initialhue + (uint8_t)(hueOffset >> 8);  // assign new hue with precise offset (as 8-bit)
     }
 }
 
-void fill_rainbow_circular(struct CHSV* targetArray, int numToFill, uint8_t initialhue)
+void fill_rainbow_circular(struct CHSV* targetArray, int numToFill, uint8_t initialhue, bool reversed)
 {
     if (numToFill == 0) return;  // avoiding div/0
 
@@ -95,7 +96,8 @@ void fill_rainbow_circular(struct CHSV* targetArray, int numToFill, uint8_t init
 
     for (int i = 0; i < numToFill; ++i) {
         targetArray[i] = hsv;
-        hueOffset += hueChange;  // increase precise offset
+        if (reversed) hueOffset -= hueChange;
+        else hueOffset += hueChange;
         hsv.hue = initialhue + (uint8_t)(hueOffset >> 8);  // assign new hue with precise offset (as 8-bit)
     }
 }

--- a/src/colorutils.cpp
+++ b/src/colorutils.cpp
@@ -62,6 +62,45 @@ void fill_rainbow( struct CHSV * targetArray, int numToFill,
 }
 
 
+void fill_rainbow_endless(struct CRGB* targetArray, int numToFill, uint8_t initialhue)
+{
+    if (numToFill == 0) return;  // avoiding div/0
+
+    CHSV hsv;
+    hsv.hue = initialhue;
+    hsv.val = 255;
+    hsv.sat = 240;
+
+    const uint16_t hueChange = 65536 / (uint16_t)numToFill;  // hue change for each LED, * 256 for precision
+    uint16_t hueOffset = 0;  // offset for hue value, with precision (*256)
+
+    for (int i = 0; i < numToFill; ++i) {
+        targetArray[i] = hsv;
+        hueOffset += hueChange;  // increase precise offset
+        hsv.hue = initialhue + (uint8_t)(hueOffset >> 8);  // assign new hue with precise offset (as 8-bit)
+    }
+}
+
+void fill_rainbow_endless(struct CHSV* targetArray, int numToFill, uint8_t initialhue)
+{
+    if (numToFill == 0) return;  // avoiding div/0
+
+    CHSV hsv;
+    hsv.hue = initialhue;
+    hsv.val = 255;
+    hsv.sat = 240;
+
+    const uint16_t hueChange = 65536 / (uint16_t)numToFill;  // hue change for each LED, * 256 for precision
+    uint16_t hueOffset = 0;  // offset for hue value, with precision (*256)
+
+    for (int i = 0; i < numToFill; ++i) {
+        targetArray[i] = hsv;
+        hueOffset += hueChange;  // increase precise offset
+        hsv.hue = initialhue + (uint8_t)(hueOffset >> 8);  // assign new hue with precise offset (as 8-bit)
+    }
+}
+
+
 void fill_gradient_RGB( CRGB* leds,
                    uint16_t startpos, CRGB startcolor,
                    uint16_t endpos,   CRGB endcolor )

--- a/src/colorutils.cpp
+++ b/src/colorutils.cpp
@@ -62,7 +62,7 @@ void fill_rainbow( struct CHSV * targetArray, int numToFill,
 }
 
 
-void fill_rainbow_endless(struct CRGB* targetArray, int numToFill, uint8_t initialhue)
+void fill_rainbow_circular(struct CRGB* targetArray, int numToFill, uint8_t initialhue)
 {
     if (numToFill == 0) return;  // avoiding div/0
 
@@ -81,7 +81,7 @@ void fill_rainbow_endless(struct CRGB* targetArray, int numToFill, uint8_t initi
     }
 }
 
-void fill_rainbow_endless(struct CHSV* targetArray, int numToFill, uint8_t initialhue)
+void fill_rainbow_circular(struct CHSV* targetArray, int numToFill, uint8_t initialhue)
 {
     if (numToFill == 0) return;  // avoiding div/0
 

--- a/src/colorutils.h
+++ b/src/colorutils.h
@@ -1569,7 +1569,7 @@ CHSV ColorFromPalette( const CHSVPalette32& pal,
 // Fill a range of LEDs with a sequence of entries from a palette
 template <typename PALETTE>
 void fill_palette(CRGB* L, uint16_t N, uint8_t startIndex, uint8_t incIndex,
-                  const PALETTE& pal, uint8_t brightness, TBlendType blendType)
+                  const PALETTE& pal, uint8_t brightness=255, TBlendType blendType=LINEARBLEND)
 {
     uint8_t colorIndex = startIndex;
     for( uint16_t i = 0; i < N; ++i) {
@@ -1582,7 +1582,7 @@ void fill_palette(CRGB* L, uint16_t N, uint8_t startIndex, uint8_t incIndex,
 // the entire palette smoothly covers the range of LEDs
 template <typename PALETTE>
 void fill_palette_circular(CRGB* L, uint16_t N, uint8_t startIndex,
-                           const PALETTE& pal, uint8_t brightness, TBlendType blendType)
+                           const PALETTE& pal, uint8_t brightness=255, TBlendType blendType=LINEARBLEND)
 {
     if (N == 0) return;  // avoiding div/0
 

--- a/src/colorutils.h
+++ b/src/colorutils.h
@@ -1586,7 +1586,7 @@ void fill_palette_circular(CRGB* L, uint16_t N, uint8_t startIndex,
 {
     if (N == 0) return;  // avoiding div/0
 
-    const uint16_t colorChange = 65536 / N;              // color change for each LED, * 256 for precision
+    const uint16_t colorChange = 65535 / N;              // color change for each LED, * 256 for precision
     uint16_t colorIndex = ((uint16_t) startIndex) << 8;  // offset for color index, with precision (*256)
  
    for (uint16_t i = 0; i < N; ++i) {

--- a/src/colorutils.h
+++ b/src/colorutils.h
@@ -1566,7 +1566,7 @@ CHSV ColorFromPalette( const CHSVPalette32& pal,
                       TBlendType blendType=LINEARBLEND);
 
 
-// Fill a range of LEDs with a sequece of entryies from a palette
+// Fill a range of LEDs with a sequence of entries from a palette
 template <typename PALETTE>
 void fill_palette(CRGB* L, uint16_t N, uint8_t startIndex, uint8_t incIndex,
                   const PALETTE& pal, uint8_t brightness, TBlendType blendType)
@@ -1575,6 +1575,23 @@ void fill_palette(CRGB* L, uint16_t N, uint8_t startIndex, uint8_t incIndex,
     for( uint16_t i = 0; i < N; ++i) {
         L[i] = ColorFromPalette( pal, colorIndex, brightness, blendType);
         colorIndex += incIndex;
+    }
+}
+
+// Fill a range of LEDs with a sequence of entries from a palette, so that
+// the entire palette smoothly covers the range of LEDs
+template <typename PALETTE>
+void fill_palette_circular(CRGB* L, uint16_t N, uint8_t startIndex,
+                           const PALETTE& pal, uint8_t brightness, TBlendType blendType)
+{
+    if (N == 0) return;  // avoiding div/0
+
+    const uint16_t colorChange = 65536 / N;              // color change for each LED, * 256 for precision
+    uint16_t colorIndex = ((uint16_t) startIndex) << 8;  // offset for color index, with precision (*256)
+ 
+   for (uint16_t i = 0; i < N; ++i) {
+        L[i] = ColorFromPalette(pal, (colorIndex >> 8), brightness, blendType);
+        colorIndex += colorChange;
     }
 }
 

--- a/src/colorutils.h
+++ b/src/colorutils.h
@@ -37,6 +37,21 @@ void fill_rainbow( struct CHSV * targetArray, int numToFill,
                    uint8_t deltahue = 5);
 
 
+/// fill_rainbow_endless - fill a range of LEDs with a rainbow of colors, at
+///                        full saturation and full value (brightness),
+///                        so that the hues are continuous between the end
+///                        of the strip and the beginning
+void fill_rainbow_endless(struct CRGB* targetArray, int numToFill,
+                          uint8_t initialhue);
+
+/// fill_rainbow_endless - fill a range of LEDs with a rainbow of colors, at
+///                        full saturation and full value (brightness),
+///                        so that the hues are continuous between the end
+///                        of the strip and the beginning
+void fill_rainbow_endless(struct CHSV* targetArray, int numToFill,
+                          uint8_t initialhue);
+
+
 // fill_gradient - fill an array of colors with a smooth HSV gradient
 //                 between two specified HSV colors.
 //                 Since 'hue' is a value around a color wheel,

--- a/src/colorutils.h
+++ b/src/colorutils.h
@@ -42,14 +42,14 @@ void fill_rainbow( struct CHSV * targetArray, int numToFill,
 ///                         so that the hues are continuous between the end
 ///                         of the strip and the beginning
 void fill_rainbow_circular(struct CRGB* targetArray, int numToFill,
-                          uint8_t initialhue);
+                          uint8_t initialhue, bool reversed=false);
 
 /// fill_rainbow_circular - fill a range of LEDs with a rainbow of colors, at
 ///                         full saturation and full value (brightness),
 ///                         so that the hues are continuous between the end
 ///                         of the strip and the beginning
 void fill_rainbow_circular(struct CHSV* targetArray, int numToFill,
-                          uint8_t initialhue);
+                          uint8_t initialhue, bool reversed=false);
 
 
 // fill_gradient - fill an array of colors with a smooth HSV gradient
@@ -1582,7 +1582,8 @@ void fill_palette(CRGB* L, uint16_t N, uint8_t startIndex, uint8_t incIndex,
 // the entire palette smoothly covers the range of LEDs
 template <typename PALETTE>
 void fill_palette_circular(CRGB* L, uint16_t N, uint8_t startIndex,
-                           const PALETTE& pal, uint8_t brightness=255, TBlendType blendType=LINEARBLEND)
+                           const PALETTE& pal, uint8_t brightness=255, TBlendType blendType=LINEARBLEND,
+                           bool reversed=false)
 {
     if (N == 0) return;  // avoiding div/0
 
@@ -1591,7 +1592,8 @@ void fill_palette_circular(CRGB* L, uint16_t N, uint8_t startIndex,
  
    for (uint16_t i = 0; i < N; ++i) {
         L[i] = ColorFromPalette(pal, (colorIndex >> 8), brightness, blendType);
-        colorIndex += colorChange;
+        if (reversed) colorIndex -= colorChange;
+        else colorIndex += colorChange;
     }
 }
 

--- a/src/colorutils.h
+++ b/src/colorutils.h
@@ -37,18 +37,18 @@ void fill_rainbow( struct CHSV * targetArray, int numToFill,
                    uint8_t deltahue = 5);
 
 
-/// fill_rainbow_endless - fill a range of LEDs with a rainbow of colors, at
-///                        full saturation and full value (brightness),
-///                        so that the hues are continuous between the end
-///                        of the strip and the beginning
-void fill_rainbow_endless(struct CRGB* targetArray, int numToFill,
+/// fill_rainbow_circular - fill a range of LEDs with a rainbow of colors, at
+///                         full saturation and full value (brightness),
+///                         so that the hues are continuous between the end
+///                         of the strip and the beginning
+void fill_rainbow_circular(struct CRGB* targetArray, int numToFill,
                           uint8_t initialhue);
 
-/// fill_rainbow_endless - fill a range of LEDs with a rainbow of colors, at
-///                        full saturation and full value (brightness),
-///                        so that the hues are continuous between the end
-///                        of the strip and the beginning
-void fill_rainbow_endless(struct CHSV* targetArray, int numToFill,
+/// fill_rainbow_circular - fill a range of LEDs with a rainbow of colors, at
+///                         full saturation and full value (brightness),
+///                         so that the hues are continuous between the end
+///                         of the strip and the beginning
+void fill_rainbow_circular(struct CHSV* targetArray, int numToFill,
                           uint8_t initialhue);
 
 


### PR DESCRIPTION
This adds a utility function (`fill_rainbow_endless`) for filling a complete rainbow pattern onto a strip so that it's continuous in hue between the end of the strip and the beginning. Useful for out-of-the-box rainbow animations on looped strips and LED rings.

#### Basic Demo:
```cpp
void loop() {
    static uint8_t hue = 0;
    EVERY_N_MILLIS(2) { hue++; }
    fill_rainbow_endless(leds, NUM_LEDS, hue);
    FastLED.show();
}
```

#### Result (12 LED ring):

https://user-images.githubusercontent.com/24282108/129810065-a7c7325e-2ba4-42af-b8a5-01132f9e012f.mp4


