### PR TITLE
automatically build and deploy docs upon release

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,37 @@
+name: Build docs via Doxygen and publish to gh-pages
+on:
+  release:
+    types: [published]
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Generate Docs
+        run: |
+          git fetch
+          git checkout origin/master
+
+          cd docs
+          sed -i -E 's/(PROJECT_NUMBER\s*=\s*).*/\1${{ github.event.release.tag_name }}/g' Doxyfile
+
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+          git commit Doxyfile -m "Update release version in Doxyfile"
+          git push origin HEAD:master
+
+          sudo apt install doxygen
+          doxygen Doxyfile
+      - name: Deploy Docs
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages
+          publish_dir: ./docs/html
+          destination_dir: docs/
+          keep_files: true
+          user_name: github-actions[bot]
+          user_email: github-actions[bot]@users.noreply.github.com
+          full_commit_message: Update docs for ${{ github.event.release.tag_name }}

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = FastLED
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 3.3.3
+PROJECT_NUMBER         = 3.4.0
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a
@@ -812,7 +812,7 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = ../ ../lib8tion
+INPUT                  = ../src ../src/lib8tion
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses


### PR DESCRIPTION
This github action builds and deploys the docs on each release.
Current behavior of this pr is to overwrite existing docs.
~Current behavior of this pr is to create a new directory for the new version of docs.~
~As an example gh-pages/docs/3.1 currently exists and is pointed to by fastled.io/docs.~
When a new release is created, this action would overwrite the docs in the gh-pages/docs/ directory.
The existing docs/3.1 folder should get removed after merging this pr (or even after generating the new docs).
The library version of the library is updated in the Doxyfile and commited to master.

Also fixes the Doxyfile not pointing into the new src/ directory.