### PR TITLE
Improve the speed of blend8 on AVR by 20-30%, and on other platforms by some amount

### DIFF
--- a/src/lib8tion/math8.h
+++ b/src/lib8tion/math8.h
@@ -504,7 +504,7 @@ LIB8STATIC uint8_t blend8( uint8_t a, uint8_t b, uint8_t amountOfB)
     // result = 256*A + B - A*amountOfB + B*amountOfB
 
     // 1 or 2 cycles depending on how the compiler optimises
-    partial = (a << 8) + b;
+    partial = (a << 8) | b;
 
     // 7 cycles
     asm volatile (


### PR DESCRIPTION
The SCALE8_FIXED version of blend8 uses the formula

```
  result = (A*(255-amountOfB) + A + B*amountOfB + B) >> 8
```

The current implementation takes 11 cycles on AVR, and requires 2 multiplications on all platforms.

However, by rearranging this to

```
  result = (256*A + B - A*amountOfB + B*amountOfB) >> 8
```

We can save 4 or 5 cycles (depending on how the optimiser sets up a and b inputs for that extra cycle)

We can rearrange further to 

```
  result = (256*A + B + (B-A)*amountOfB) >> 8
```

…and this seems to compile down to fewer instructions and reduce it to only 1 multiplication on other platforms.