### PR TITLE
encapsulate CLEDControllers' list

### DIFF
--- a/src/FastLED.h
+++ b/src/FastLED.h
@@ -562,10 +562,11 @@ public:
 	/// Get a reference to a registered controller
 	/// @returns a reference to the Nth controller
 	CLEDController & operator[](int x);
+	const CLEDController & operator[](int x) const;
 
 	/// Get the number of leds in the first controller
 	/// @returns the number of LEDs in the first controller
-	int size() { return (*this)[0].size(); }
+	int size() const { return (*this)[0].size(); }
 
 	/// Get a pointer to led data for the first controller
 	/// @returns pointer to the CRGB buffer for the first controller

--- a/src/platforms/arm/k20/clockless_block_arm_k20.h
+++ b/src/platforms/arm/k20/clockless_block_arm_k20.h
@@ -29,9 +29,9 @@ class InlineBlockClocklessController : public CPixelLEDController<RGB_ORDER, LAN
 	CMinWait<WAIT_TIME> mWait;
 
 public:
-	virtual int size() { return CLEDController::size() * LANES; }
+	int size() const override { return CLEDController::size() * LANES; }
 
-	virtual void showPixels(PixelController<RGB_ORDER, LANES, PORT_MASK> & pixels) { 
+	virtual void showPixels(PixelController<RGB_ORDER, LANES, PORT_MASK> & pixels) {
 		mWait.wait();
 		uint32_t clocks = showRGBInternal(pixels);
 		#if FASTLED_ALLOW_INTERRUPTS == 0
@@ -227,7 +227,7 @@ public:
 		}
 	}
 
-	virtual void showPixels(PixelController<RGB_ORDER, LANES, PMASK> & pixels) { 
+	virtual void showPixels(PixelController<RGB_ORDER, LANES, PMASK> & pixels) {
 		mWait.wait();
 		uint32_t clocks = showRGBInternal(pixels);
 		#if FASTLED_ALLOW_INTERRUPTS == 0

--- a/src/platforms/arm/k20/octows2811_controller.h
+++ b/src/platforms/arm/k20/octows2811_controller.h
@@ -28,7 +28,7 @@ class COctoWS2811Controller : public CPixelLEDController<RGB_ORDER, 8, 0xFF> {
   }
 public:
   COctoWS2811Controller() { pocto = NULL; }
-  virtual int size() { return CLEDController::size() * 8; }
+  int size() const override { return CLEDController::size() * 8; }
 
   virtual void init() { /* do nothing yet */ }
 

--- a/src/platforms/arm/k66/clockless_block_arm_k66.h
+++ b/src/platforms/arm/k66/clockless_block_arm_k66.h
@@ -32,9 +32,9 @@ class InlineBlockClocklessController : public CPixelLEDController<RGB_ORDER, LAN
 	CMinWait<WAIT_TIME> mWait;
 
 public:
-	virtual int size() { return CLEDController::size() * LANES; }
+	int size() const override { return CLEDController::size() * LANES; }
 
-	virtual void showPixels(PixelController<RGB_ORDER, LANES, LANE_MASK> & pixels) { 
+	virtual void showPixels(PixelController<RGB_ORDER, LANES, LANE_MASK> & pixels) {
 		mWait.wait();
 		uint32_t clocks = showRGBInternal(pixels);
 		#if FASTLED_ALLOW_INTERRUPTS == 0
@@ -241,7 +241,7 @@ public:
 		}
 	}
 
-	virtual void showPixels(PixelController<RGB_ORDER, LANES, PMASK> & pixels) { 
+	virtual void showPixels(PixelController<RGB_ORDER, LANES, PMASK> & pixels) {
 		mWait.wait();
 		uint32_t clocks = showRGBInternal(pixels);
 	#if FASTLED_ALLOW_INTERRUPTS == 0

--- a/src/platforms/arm/mxrt1062/block_clockless_arm_mxrt1062.h
+++ b/src/platforms/arm/mxrt1062/block_clockless_arm_mxrt1062.h
@@ -21,7 +21,7 @@ class FlexibleInlineBlockClocklessController : public CPixelLEDController<RGB_OR
     CMinWait<WAIT_TIME> mWait;
 
 public:
-    virtual int size() { return CLEDController::size() * m_nActualLanes; }
+    int size() const override { return CLEDController::size() * m_nActualLanes; }
 
     // For each pin, if we've hit our lane count, break, otherwise set the pin to output,
     // store the bit offset in our offset array, add this pin to the write mask, and if this

--- a/src/platforms/arm/sam/clockless_block_arm_sam.h
+++ b/src/platforms/arm/sam/clockless_block_arm_sam.h
@@ -39,7 +39,7 @@ class InlineBlockClocklessController : public CPixelLEDController<RGB_ORDER, LAN
 	CMinWait<WAIT_TIME> mWait;
 
 public:
-	virtual int size() { return CLEDController::size() * LANES; }
+	int size() const override { return CLEDController::size() * LANES; }
 	virtual void init() {
         static_assert(LANES <= 8, "Maximum of 8 lanes for Due parallel controllers!");
         if(FIRST_PIN == PORTA_FIRST_PIN) {

--- a/src/platforms/esp/8266/clockless_block_esp8266.h
+++ b/src/platforms/esp/8266/clockless_block_esp8266.h
@@ -25,7 +25,7 @@ class InlineBlockClocklessController : public CPixelLEDController<RGB_ORDER, LAN
 	CMinWait<WAIT_TIME> mWait;
 
 public:
-	virtual int size() { return CLEDController::size() * LANES; }
+	int size() const override { return CLEDController::size() * LANES; }
 
 	virtual void showPixels(PixelController<RGB_ORDER, LANES, PORT_MASK> & pixels) {
 		mWait.wait();

--- a/src/power_mgt.cpp
+++ b/src/power_mgt.cpp
@@ -101,11 +101,9 @@ uint8_t calculate_max_brightness_for_power_mW( uint8_t target_brightness, uint32
 {
     uint32_t total_mW = gMCU_mW;
 
-    CLEDController *pCur = CLEDController::head();
-	while(pCur) {
-        total_mW += calculate_unscaled_power_mW( pCur->leds(), pCur->size());
-		pCur = pCur->next();
-	}
+    for (const auto& cur : CLEDController::list()) {
+        total_mW += calculate_unscaled_power_mW(cur.leds(), cur.size());
+    }
 
 #if POWER_DEBUG_PRINT == 1
     Serial.print("power demand at full brightness mW = ");


### PR DESCRIPTION
Currently `CFastLED` (and other users) manages iterating through the list of `CLEDControllers` itself. This pr encaspulates the list part of `CLEDController` and adds support for range-for (see changes).

I'm using an `uint8_t` to save the list size instead of calculating it each time. This limits the size to 255 controllers.

- Should the size by calculated each time and thus be only limited by the memory size (i.e. how many controllers can fit in memory)?
- Should the size use a larger type?
- Yes, this is an indirection, but the list class being defined in the header makes the code ready for inlining. Even if it were in a .cpp file, the overhead would be minimal.
- Made the `virtual int size()` function of `CLEDController` `const` (and all of their overridden implementations in controllers; also marked `override`)
- `CLEDController::list()` can be used to access the list