### PR TITLE
Reduce build warnings [please]

### DIFF
--- a/src/FastLED.h
+++ b/src/FastLED.h
@@ -9,7 +9,7 @@
 #endif
 
 #define FASTLED_VERSION 3004000
-#if !defined(FASTLED_INTERNAL) || defined(FASTLED_NO_VERSION_MESSAGE)
+#if defined(FASTLED_SHOW_VERSION_MESSAGE)
 #  ifdef FASTLED_HAS_PRAGMA_MESSAGE
 #    pragma message "FastLED version 3.004.000"
 #  else

--- a/src/FastLED.h
+++ b/src/FastLED.h
@@ -9,7 +9,7 @@
 #endif
 
 #define FASTLED_VERSION 3004000
-#ifndef FASTLED_INTERNAL
+#if !defined(FASTLED_INTERNAL) || defined(FASTLED_NO_VERSION_MESSAGE)
 #  ifdef FASTLED_HAS_PRAGMA_MESSAGE
 #    pragma message "FastLED version 3.004.000"
 #  else


### PR DESCRIPTION
Version information is being output as a build warning (or message).  Either way, this is not desired.  Defining `FASTLED_INTERNAL` is not good, as it disables useful warnings (such as lack of hardware SPI pins):

https://github.com/FastLED/FastLED/blob/5cc17b2be88982eb34b1998de22b83fee56d4f07/src/fastspi.h#L143-L149

Therefore, define new symbol `FASTLED_NO_VERSION_MESSAGE` whose sole purpose is to disable this spurious warning, without disabling true warnings.