### PR TITLE
Fix WS2812B timing on Teensy 4.x

### DIFF
--- a/src/platforms/arm/mxrt1062/clockless_arm_mxrt1062.h
+++ b/src/platforms/arm/mxrt1062/clockless_arm_mxrt1062.h
@@ -56,24 +56,24 @@ protected:
 			next_mark = ARM_DWT_CYCCNT + off[0];
 			FastPin<DATA_PIN>::hi();
 			if(b&0x80) {
-				while((next_mark - ARM_DWT_CYCCNT) > off[1]);
+				while((next_mark - ARM_DWT_CYCCNT) > off[2]);
 				FastPin<DATA_PIN>::lo();
 			} else {
-				while((next_mark - ARM_DWT_CYCCNT) > off[2]);
+				while((next_mark - ARM_DWT_CYCCNT) > off[1]);
 				FastPin<DATA_PIN>::lo();
 			}
 			b <<= 1;
 		}
 
 		while(ARM_DWT_CYCCNT < next_mark);
-		next_mark = ARM_DWT_CYCCNT + off[1];
+		next_mark = ARM_DWT_CYCCNT + off[0];
 		FastPin<DATA_PIN>::hi();
 
 		if(b&0x80) {
 			while((next_mark - ARM_DWT_CYCCNT) > off[2]);
 			FastPin<DATA_PIN>::lo();
 		} else {
-			while((next_mark - ARM_DWT_CYCCNT) > off[2]);
+			while((next_mark - ARM_DWT_CYCCNT) > off[1]);
 			FastPin<DATA_PIN>::lo();
 		}
 	}
@@ -91,7 +91,7 @@ protected:
 		off[1] = _FASTLED_NS_TO_DWT(T2+T3);
 		off[2] = _FASTLED_NS_TO_DWT(T3);
 
-    	uint32_t wait_off = _FASTLED_NS_TO_DWT((WAIT_TIME-INTERRUPT_THRESHOLD));
+	uint32_t wait_off = _FASTLED_NS_TO_DWT((WAIT_TIME-INTERRUPT_THRESHOLD)*1000);
 
     	uint32_t next_mark = ARM_DWT_CYCCNT + off[0];
 

--- a/src/platforms/arm/mxrt1062/fastled_arm_mxrt1062.h
+++ b/src/platforms/arm/mxrt1062/fastled_arm_mxrt1062.h
@@ -3,7 +3,7 @@
 
 #include "fastpin_arm_mxrt1062.h"
 #include "fastspi_arm_mxrt1062.h"
-#include "../k20/octows2811_controller.h"
+#include "octows2811_controller.h"
 #include "../k20/ws2812serial_controller.h"
 #include "../k20/smartmatrix_t3.h"
 #include "clockless_arm_mxrt1062.h"

--- a/src/platforms/arm/mxrt1062/octows2811_controller.h
+++ b/src/platforms/arm/mxrt1062/octows2811_controller.h
@@ -1,0 +1,64 @@
+#ifndef __INC_OCTOWS2811_CONTROLLER_H
+#define __INC_OCTOWS2811_CONTROLLER_H
+
+#ifdef USE_OCTOWS2811
+
+// #include "OctoWS2811.h"
+
+FASTLED_NAMESPACE_BEGIN
+
+template<EOrder RGB_ORDER = GRB, uint8_t CHIP = WS2811_800kHz>
+class COctoWS2811Controller : public CPixelLEDController<RGB_ORDER, 8, 0xFF> {
+  OctoWS2811  *pocto;
+  uint8_t *drawbuffer,*framebuffer;
+
+  void _init(int nLeds) {
+    if(pocto == NULL) {
+      drawbuffer = (uint8_t*)malloc(nLeds * 8 * 3);
+      framebuffer = (uint8_t*)malloc(nLeds * 8 * 3);
+
+      // byte ordering is handled in show by the pixel controller
+      int config = WS2811_RGB;
+      config |= CHIP;
+
+      pocto = new OctoWS2811(nLeds, framebuffer, drawbuffer, config);
+
+      pocto->begin();
+    }
+  }
+public:
+  COctoWS2811Controller() { pocto = NULL; }
+  virtual int size() { return CLEDController::size() * 8; }
+
+  virtual void init() { /* do nothing yet */ }
+
+  virtual void showPixels(PixelController<RGB_ORDER, 8, 0xFF> &pixels) {
+    uint32_t size = pixels.size();
+    uint32_t sizeTimes8 = 8U * size;
+    _init(size);
+
+    uint32_t index = 0;
+    while (pixels.has(1)) {
+      for (uint32_t i = 0; i < 8; i++) {
+        uint8_t r = pixels.loadAndScale0(i);
+        uint8_t g = pixels.loadAndScale1(i);
+        uint8_t b = pixels.loadAndScale2(i);
+        pocto->setPixel(index, r, g, b);
+        index += size;
+      }
+      index -= sizeTimes8;
+      index++;
+      pixels.stepDithering();
+      pixels.advanceData();
+    }
+
+    pocto->show();
+  }
+
+};
+
+FASTLED_NAMESPACE_END
+
+#endif
+
+#endif


### PR DESCRIPTION
Fixes multiple timing issues with Teensy 4.0 & 4.1.

Issue first reported on this forum thread:
https://forum.pjrc.com/threads/68437-FastLED-SK6805-Teensy-4-1-and-a-Teensy-rookie-full-white-only