### PR TITLE
Add lightness LUT support for AP102 and SK9822

### DIFF
--- a/src/controller.h
+++ b/src/controller.h
@@ -363,6 +363,9 @@ struct PixelController {
         template<int SLOT>  __attribute__((always_inline)) inline static uint8_t getscale(PixelController & pc) { return pc.mScale.raw[RO(SLOT)]; }
 
         // Helper functions to get around gcc stupidities
+        __attribute__((always_inline)) inline uint8_t loadByte0() { return loadByte<0>(*this); }
+        __attribute__((always_inline)) inline uint8_t loadByte1() { return loadByte<1>(*this); }
+        __attribute__((always_inline)) inline uint8_t loadByte2() { return loadByte<2>(*this); }
         __attribute__((always_inline)) inline uint8_t loadAndScale0(int lane, uint8_t scale) { return loadAndScale<0>(*this, lane, scale); }
         __attribute__((always_inline)) inline uint8_t loadAndScale1(int lane, uint8_t scale) { return loadAndScale<1>(*this, lane, scale); }
         __attribute__((always_inline)) inline uint8_t loadAndScale2(int lane, uint8_t scale) { return loadAndScale<2>(*this, lane, scale); }

--- a/src/fastled_config.h
+++ b/src/fastled_config.h
@@ -64,6 +64,9 @@
 // Use this toggle to enable global brightness in contollers that support is (ADA102 and SK9822).
 // It changes how color scaling works and uses global brightness before scaling down color values.
 // This enable much more accurate color control on low brightness settings.
-//#define FASTLED_USE_GLOBAL_BRIGHTNESS 1
+// Use value 1 for using global brightness in a linear way.
+// Use value 2 for using human perception lightness, which increases the dynamic
+// range by orders of magnitude.
+//#define FASTLED_USE_GLOBAL_BRIGHTNESS 2
 
 #endif

--- a/src/lightness_lut.h
+++ b/src/lightness_lut.h
@@ -1,0 +1,54 @@
+#ifndef __INC_LIGHTNESS_LUT_H
+#define __INC_LIGHTNESS_LUT_H
+
+#include "FastLED.h"
+
+///@file lut.h
+/// contains a lightness look up table for chipsets that supports a higher range than 8 bits.
+
+FASTLED_NAMESPACE_BEGIN
+
+// LightnessLUT defines a lightness look up table at compile time to map 8 bits per
+// channel RGB data to a higher range when a display supports more than 8 bits
+// per channel.
+template<uint16_t maxOut>
+struct LightnessLUT {
+public:
+	// Init initiates a lookup table with the maximum intensity i.
+	void init(uint8_t i) {
+		if (last == i) {
+			return;
+		}
+		// linearCutOff defines the linear section of the curve. Inputs between
+		// [0, linearCutOff] are mapped linearly to the output. It is 1% of maximum
+		// output.
+		const uint16_t max = (maxOut * i + 127) / 255;
+		const uint32_t linearCutOff = uint32_t((max + 50) / 100);
+		const uint32_t inRange = 255 - linearCutOff;
+		const uint32_t outRange = uint32_t(max) - linearCutOff;
+		const uint32_t offset = inRange >> 1;
+		for (uint32_t l = 1; l < 256; l++) {
+			if (l < linearCutOff) {
+				data[l] = uint16_t(l);
+			} else {
+				uint16_t v = l-linearCutOff;
+				data[l] = uint16_t((((v*v*v + offset) / inRange)*outRange+(offset*offset))/inRange/inRange + linearCutOff);
+			}
+		}
+		last = i;
+	}
+	void init(const LightnessLUT& rhs) {
+		if (last == rhs.last) {
+			return;
+		}
+		memcpy(data, rhs.data, sizeof(data));
+		last = rhs.last;
+	}
+
+	uint16_t data[255];
+	uint8_t last;
+};
+
+FASTLED_NAMESPACE_END
+
+#endif


### PR DESCRIPTION
This changes the color intensity to use perceptual lightness when
LED_USE_GLOBAL_BRIGHTNESS=2 is defined.

This increases the dynamic range by orders of magnitude and makes it
much more pleasant at low intensity, even compared to
LED_USE_GLOBAL_BRIGHTNESS=1. The dynamic range is calculated by taking
the per channel intensity into account. This leads to a 256\*3\*2 bytes
RAM overhead so it cannot be used by default but it's fine for more
powerful devices like a esp8266 or ESP32. I personally tested on a
esp8266 running esphome 2021.11.4 with 150 LEDs. Here's the stats:

  LED_USE_GLOBAL_BRIGHTNESS=0 (default):
    RAM:   [====      ]  38.2% (used 31300 bytes from 81920 bytes)
    Flash: [====      ]  40.6% (used 423688 bytes from 1044464 bytes)

  LED_USE_GLOBAL_BRIGHTNESS=2:
    RAM:   [====      ]  40.1% (used 32836 bytes from 81920 bytes)
    Flash: [====      ]  40.6% (used 424168 bytes from 1044464 bytes)

  RAM:   +1536
  Flash:  +480

Since with this the scaling is done inside the chipset controller, add
loadByte0/1/2() methods to PixelController for gcc.

This is based on the algorithm I wrote for periph.io/x/devices/apa102 a
few years ago. My algorithm there includes temperature in addition to
intensity correction in the ramp. It does provides a slightly better
ramp but doing this here would require a lot more surgery so starting
smaller.

The transitions aren't as nice as they should where the library seems to
be doing a lot of calculation in PixelController that doesn't match to
the resulting lightness generated by the LEDs. Still, the end result
makes a Christmas tree with such LEDs *much more* enjoyable at low
intensity than even LED_USE_GLOBAL_BRIGHTNESS=1.

Copy pasted to SK9822 but only physically tested on APA102. A follow up
should consider regrouping the code.

Another possible follow up is to use static members for LUT, assuming a
use case of single threaded and multiple APA102Controller instances. I
think it's a niche case so not doing this here.

The LightnessLUT struct assumes memory is zero-initialized.