### PR TITLE
Add some defaults to avoid build failure on old platform versions e.g. 1.0.4

### DIFF
--- a/src/platforms/esp/32/clockless_rmt_esp32.cpp
+++ b/src/platforms/esp/32/clockless_rmt_esp32.cpp
@@ -455,9 +455,9 @@ void IRAM_ATTR ESP32RMTController::fillNext(bool check_time)
 {
     uint32_t now = __clock_cycles();
     if (check_time) {
-        if (mLastFill != 0 and now > mLastFill) {
-            uint32_t delta = (now - mLastFill);
-            if (delta > mMaxCyclesPerFill) {
+        if (mLastFill != 0) {
+            int32_t delta = (now - mLastFill);
+            if (delta > (int32_t)mMaxCyclesPerFill) {
                 // Serial.print(delta);
                 // Serial.print(" BAIL ");
                 // Serial.println(mCur);

--- a/src/platforms/esp/32/fastled_esp32.h
+++ b/src/platforms/esp/32/fastled_esp32.h
@@ -1,5 +1,14 @@
 #pragma once
 
+// macros and platform define are not available in older platform versions
+// so set some defaults to avoid build errors
+#ifndef ESP_IDF_VERSION_VAL
+#define ESP_IDF_VERSION_VAL(major, minor, patch) ((major << 16) | (minor << 8) | (patch))
+#ifndef CONFIG_IDF_TARGET_ESP32
+#define CONFIG_IDF_TARGET_ESP32 1
+#endif
+#endif
+
 #include "fastpin_esp32.h"
 
 #ifdef FASTLED_ALL_PINS_HARDWARE_SPI


### PR DESCRIPTION
see also issue https://github.com/FastLED/FastLED/pull/1320#issuecomment-994761190
and https://github.com/FastLED/FastLED/pull/1320#issuecomment-995114712
