### PR TITLE
Add some defaults to avoid build failure on old platform versions e.g. 1.0.4

### DIFF
--- a/src/platforms/esp/32/fastled_esp32.h
+++ b/src/platforms/esp/32/fastled_esp32.h
@@ -1,5 +1,14 @@
 #pragma once
 
+// macros and platform define are not available in older platform versions
+// so set some defaults to avoid build errors
+#ifndef ESP_IDF_VERSION_VAL
+#define ESP_IDF_VERSION_VAL(major, minor, patch) ((major << 16) | (minor << 8) | (patch))
+#ifndef CONFIG_IDF_TARGET_ESP32
+#define CONFIG_IDF_TARGET_ESP32 1
+#endif
+#endif
+
 #include "fastpin_esp32.h"
 
 #ifdef FASTLED_ALL_PINS_HARDWARE_SPI


### PR DESCRIPTION
see also issue https://github.com/FastLED/FastLED/pull/1320#issuecomment-994761190
and https://github.com/FastLED/FastLED/pull/1320#issuecomment-995114712