### PR TITLE
Improve compatibility with older ESP32 Arduino core versions

### DIFF
--- a/src/platforms/esp/32/led_sysdefs_esp32.h
+++ b/src/platforms/esp/32/led_sysdefs_esp32.h
@@ -8,10 +8,17 @@
 
 #if CONFIG_IDF_TARGET_ARCH_RISCV
 #define FASTLED_RISCV
+#else
+#define FASTLED_XTENSA
 #endif
 
-#if CONFIG_IDF_TARGET_ARCH_XTENSA || CONFIG_XTENSA_IMPL
-#define FASTLED_XTENSA
+// Handling for older versions of ESP32 Arduino core
+#if !defined(ESP_IDF_VERSION)
+// Older versions of ESP_IDF only supported ESP32
+#define CONFIG_IDF_TARGET_ESP32 1
+// Define missing version macros.  Hard code older version 3.0 since actual version is unknown
+#define ESP_IDF_VERSION_VAL(major, minor, patch) ((major << 16) | (minor << 8) | (patch))
+#define ESP_IDF_VERSION ESP_IDF_VERSION_VAL(3, 0, 0)
 #endif
 
 // Use system millis timer


### PR DESCRIPTION
Improve compatibily with older versions of ESP32 Arduino core.  Tested with versions 1.0 & higher.