### PR TITLE
New overloaded function ColorFromPalette what take color from GradientPalette

### DIFF
--- a/colorutils.h
+++ b/colorutils.h
@@ -1550,6 +1550,11 @@ CHSV ColorFromPalette( const CHSVPalette32& pal,
                       uint8_t brightness=255,
                       TBlendType blendType=LINEARBLEND);
 
+CRGB ColorFromPalette( const TProgmemRGBGradientPalette_byte &progpal,
+                      uint8_t index,
+                      uint8_t brightness=255,
+                      TBlendType blendType=LINEARBLEND);
+
 
 // Fill a range of LEDs with a sequece of entryies from a palette
 template <typename PALETTE>


### PR DESCRIPTION
ColorFromPalette from TProgmemRGBGradientPalette
This is a new implementation of a popular ColorFromPalette function. 
It became necessary for me when I began to use gradient palettes from progmem, and
also use a structure of variables with implementations of CRGBPalette16 palettes for different effects.
That all takeout an extra 64 bytes of memory for each effect. (((
Now we can use a simply pointer and... It's works! )))

For declaration of the array of palettes:
	...
	const TProgmemRGBGradientPalettePtr gradientPalettes[] = {
		&Sunset_Real_gp[0],	&es_rivendell_15_gp[0], &es_ocean_breeze_036_gp[0],	&rgi_15_gp[0], ...};
	...

To call someone:
	...
	CRGB color = ColorFromPalette(*gradientPalettes[1], index, brightness, blendType);
	...
	fill_palette(leds, NUM_LEDS, startIndex, incIndex, *gradientPalettes[0], brightness, blendType);
	...