### PR TITLE
Add stub implementation for local testing

### DIFF
--- a/src/fastspi.h
+++ b/src/fastspi.h
@@ -59,6 +59,11 @@ template<uint8_t _DATA_PIN, uint8_t _CLOCK_PIN, uint32_t _SPI_CLOCK_DIVIDER>
 class SPIOutput : public ESP32SPIOutput<_DATA_PIN, _CLOCK_PIN, _SPI_CLOCK_DIVIDER> {};
 #endif
 
+#if defined(FASTLED_STUB_IMPL)
+template<uint8_t _DATA_PIN, uint8_t _CLOCK_PIN, uint32_t _SPI_CLOCK_DIVIDER>
+class SPIOutput : public StubSPIOutput {};
+#endif
+
 #if defined(SPI_DATA) && defined(SPI_CLOCK)
 
 #if defined(FASTLED_TEENSY3) && defined(ARM_HARDWARE_SPI)

--- a/src/led_sysdefs.h
+++ b/src/led_sysdefs.h
@@ -40,6 +40,15 @@
 #elif defined(ARDUINO_ARCH_APOLLO3)
 // Apollo3 platforms (e.g. the Ambiq Micro Apollo3 Blue as used by the SparkFun Artemis platforms)
 #include "platforms/apollo3/led_sysdefs_apollo3.h"
+#elif defined(__x86_64__)
+// Not on a microcontroller
+//#    ifdef FASTLED_HAS_PRAGMA_MESSAGE
+//#      pragma message "Using stub, no data will be written to pins"
+//#    else
+//#      warning "Using stub, no data will be written to pins"
+//#    endif
+#include "platforms/stub/led_sysdefs_stub.h"
+
 #else
 //
 // We got here because we don't recognize the platform that you're

--- a/src/platforms.h
+++ b/src/platforms.h
@@ -36,6 +36,9 @@
 #include "platforms/esp/32/fastled_esp32.h"
 #elif defined(ARDUINO_ARCH_APOLLO3)
 #include "platforms/apollo3/fastled_apollo3.h"
+#elif defined(__x86_64__) // FIXME: Review decision: Repeat the defined from led_sysdefs.h or use FASTLED_STUB_IMPL which is defined at this point
+// stub platform for testing (on cpu)
+#include "platforms/stub/fastled_stub.h"
 #else
 // AVR platforms
 #include "platforms/avr/fastled_avr.h"

--- a/src/platforms/stub/clockless_stub.h
+++ b/src/platforms/stub/clockless_stub.h
@@ -1,0 +1,23 @@
+#ifndef __INC_CLOCKLESS_STUB_H
+#define __INC_CLOCKLESS_STUB_H
+
+FASTLED_NAMESPACE_BEGIN
+
+#if defined(FASTLED_STUB_IMPL)
+
+#define FASTLED_HAS_CLOCKLESS 1
+
+template <int DATA_PIN, int T1, int T2, int T3, EOrder RGB_ORDER = RGB, int XTRA0 = 0, bool FLIP = false, int WAIT_TIME = 0>
+class ClocklessController : public CPixelLEDController<RGB_ORDER> {
+public:
+	virtual void init() { }
+
+protected:
+	virtual void showPixels(PixelController<RGB_ORDER> & pixels) { }
+};
+
+#endif // defined(FASTLED_STUB_IMPL)
+
+FASTLED_NAMESPACE_END
+
+#endif // __INC_CLOCKLESS_STUB_H

--- a/src/platforms/stub/fastled_stub.h
+++ b/src/platforms/stub/fastled_stub.h
@@ -1,0 +1,16 @@
+#ifndef __INC_FASTLED_STUB_H
+#define __INC_FASTLED_STUB_H
+
+// fastpin_stub.h isn't needed (as it's not used by clockless)
+#include "fastspi_stub.h"
+#include "clockless_stub.h"
+
+/**
+ * Could avoid clockless and fastspi with
+ * #define NO_HARDWARE_PIN_SUPPORT
+ * #undef HAS_HARDWARE_PIN_SUPPORT
+ * But then compiling throws pragma message about "Forcing software SPI"
+ */
+#define HAS_HARDWARE_PIN_SUPPORT
+
+#endif // __INC_FASTLED_STUB_H

--- a/src/platforms/stub/fastspi_stub.h
+++ b/src/platforms/stub/fastspi_stub.h
@@ -1,0 +1,21 @@
+#ifndef __INC_FASTSPI_STUB_H
+#define __INC_FASTSPI_STUB_H
+
+// This is a stub implementation of fastspi.
+
+FASTLED_NAMESPACE_BEGIN
+
+#if defined(FASTLED_STUB_IMPL)
+
+#define FASTLED_ALL_PINS_HARDWARE_SPI
+
+class StubSPIOutput {
+public:
+    StubSPIOutput() { }
+};
+
+#endif // defined(FASTLED_STUB_IMPL)
+
+FASTLED_NAMESPACE_END
+
+#endif // __INC_FASTSPI_STUB_H

--- a/src/platforms/stub/led_sysdefs_stub.cpp
+++ b/src/platforms/stub/led_sysdefs_stub.cpp
@@ -1,0 +1,20 @@
+#include "led_sysdefs_stub.h"
+
+#include <chrono>
+#include <thread>
+
+void pinMode(uint8_t pin, uint8_t mode) {
+    // Empty stub as we don't actually ever write anything
+}
+
+uint32_t millis() {
+    return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+}
+
+uint32_t micros() {
+    return std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+}
+
+void delay(int ms) {
+    std::this_thread::sleep_for (std::chrono::milliseconds(ms));
+}

--- a/src/platforms/stub/led_sysdefs_stub.cpp
+++ b/src/platforms/stub/led_sysdefs_stub.cpp
@@ -1,5 +1,7 @@
 #include "led_sysdefs_stub.h"
 
+#if defined(FASTLED_STUB_IMPL)
+
 #include <chrono>
 #include <thread>
 
@@ -18,3 +20,5 @@ uint32_t micros() {
 void delay(int ms) {
     std::this_thread::sleep_for (std::chrono::milliseconds(ms));
 }
+
+#endif // defined(FASTLED_STUB_IMPL)

--- a/src/platforms/stub/led_sysdefs_stub.h
+++ b/src/platforms/stub/led_sysdefs_stub.h
@@ -1,0 +1,37 @@
+#ifndef __INC_LED_SYSDEFS_STUB_H
+#define __INC_LED_SYSDEFS_STUB_H
+
+#define FASTLED_STUB_IMPL
+
+#include <stdint.h>
+
+#ifndef F_CPU
+#define F_CPU 1000000000
+#endif // F_CPU
+
+#define FASTLED_HAS_MILLIS
+
+#define digitalPinToBitMask(P) ( 0 )
+#define digitalPinToPort(P) ( 0 )
+#define portOutputRegister(P) ( 0 )
+#define portInputRegister(P) ( 0 )
+
+#define INPUT  0
+#define OUTPUT 1
+
+typedef volatile uint32_t RoReg;
+typedef volatile uint32_t RwReg;
+
+#define FASTLED_NEEDS_YIELD
+
+extern "C" {
+    void pinMode(uint8_t pin, uint8_t mode);
+
+    uint32_t millis(void);
+    uint32_t micros(void);
+
+    void delay(int ms);
+    void yield(void);
+}
+
+#endif // __INC_LED_SYSDEFS_STUB_H

--- a/src/platforms/stub/led_sysdefs_stub.h
+++ b/src/platforms/stub/led_sysdefs_stub.h
@@ -1,6 +1,8 @@
 #ifndef __INC_LED_SYSDEFS_STUB_H
 #define __INC_LED_SYSDEFS_STUB_H
 
+#if defined(__x86_64__)
+
 #define FASTLED_STUB_IMPL
 
 #include <stdint.h>
@@ -33,5 +35,7 @@ extern "C" {
     void delay(int ms);
     void yield(void);
 }
+
+#endif // defined(__x86_64__)
 
 #endif // __INC_LED_SYSDEFS_STUB_H


### PR DESCRIPTION
I wanted to test some of my patterns on my computer were it's much quicker to compile, test, tune, and iterate.

So I wrote a little wrapper [demo_simple.cpp](https://gist.github.com/sethtroisi/079bc61d5d905feed9026f168d592227) around  FastLED so that I could see the pixels on my computer (while still using 99% of my same pattern code).

I'd love to upstream the FastLED Controller Stub if you consider it reasonable. I think I got the right pieces in the right place and I'm happy to change if there are things I've messed up.

FastLED continues to make my art fabulous!

---

EDIT: Looking at the tests using `defined(__x86_64__)` might conflict on some platforms, I'm open to better solutions; possible passing in `-DSTUB_IMPL` or adding a setting a new `#define` to fastled_config.h