### PR TITLE
Remove -Wregister warnings during CI

### DIFF
--- a/ci/ci-compile
+++ b/ci/ci-compile
@@ -8,12 +8,12 @@
 #   [BOARDS=boards] [EXAMPLES=examples] ./ci-compile
 #
 # e.g.
-#  $ ./compile-ci   
+#  $ ./compile-ci
 #         - compile all board/examples combinations
 #
-#  $ BOARDS="esp32 esp01" EXAMPLES=Blink ./compile-ci 
+#  $ BOARDS="esp32 esp01" EXAMPLES=Blink ./compile-ci
 #         - compile only Blink example for the esp32 and esp8266 platforms
-#                                              
+#
 set -eou pipefail
 
 # List of examples that will be compiled by default
@@ -30,7 +30,9 @@ BOARD_OPTS=$(for b in $BOARDS; do echo -n "--board $b "; done)
 
 cd "$DIR/.."
 
-for d in $EXAMPLES ; do 
+export PLATFORMIO_EXTRA_SCRIPTS="pre:lib/ci/ci-flags.py"
+
+for d in $EXAMPLES ; do
   echo "*** building example $d for $BOARDS ***"
-  pio ci $BOARD_OPTS --lib=src "examples/$d/"*ino
+  pio ci $BOARD_OPTS --lib=ci --lib=src "examples/$d/"*ino
 done

--- a/ci/ci-flags.py
+++ b/ci/ci-flags.py
@@ -1,0 +1,3 @@
+Import("env")
+
+env.Append(CXXFLAGS=["-Wno-register"])


### PR DESCRIPTION
Reduces so many warnings about `-Wregister`
```
$ pio ci --board=esp01 --lib src "examples/Blink/" |& grep -o '\[\-W.*\]' | sort | uniq -c | sort -n
      2 [-Wdeprecated-declarations]
      9 [-Wmisleading-indentation]
    632 [-Wregister]
$ PLATFORMIO_BUILD_FLAGS="-Wno-register" pio ci --board=esp01  --lib src "examples/Blink/" |& grep -o '\[\-W.*\]' | sort | uniq -c | sort -n
      2 [-Wdeprecated-declarations]
      9 [-Wmisleading-indentation]
```

Locally this removes 11382 of 11658 total warnings during ci/ci-compile

My other pull request has 54,353 lines in CI check. This PR reduces that to 13,866!

---

You can get 95% of the way here with 
`$ PLATFORMIO_BUILD_FLAGS="-Wno-register" pio ci --board=esp01  --lib src "examples/Blink/"`
But you'll get a few extra warnings about
`cc1: warning: command-line option '-Wno-register' is valid for C++/ObjC++ but not for C`

