### PR TITLE
Fix some math8 functions, improve qmul8(), minor extensions, fix typos

### DIFF
--- a/src/lib8tion.h
+++ b/src/lib8tion.h
@@ -33,7 +33,7 @@ FASTLED_NAMESPACE_BEGIN
      qsub8( i, j) == MAX( (i - j), 0 )
 
  - Saturating signed 8-bit ("7-bit") add.
-     qadd7( i, j) == MIN( (i + j), 0x7F)
+     qadd7( i, j) == MAX( MIN( (i + j), 0x7F), -0x80)
 
 
  - Scaling (down) of unsigned 8- and 16- bit values.
@@ -99,7 +99,7 @@ FASTLED_NAMESPACE_BEGIN
 
 
  - Fast 8-bit "easing in/out" function.
-     ease8InOutCubic(x) == 3(x^i) - 2(x^3)
+     ease8InOutCubic(x) == 3(x^2) - 2(x^3)
      ease8InOutApprox(x) ==
        faster, rougher, approximation of cubic easing
      ease8InOutQuad(x) == quadratic (vs cubic) easing
@@ -732,9 +732,9 @@ LIB8STATIC uint8_t ease8InOutApprox( fract8 i)
 
         "Ldone_%=:               \n\t"
 
-        : [i] "+&a" (i)
+        : [i] "+a" (i)
         :
-        : "r0", "r1"
+        : "r0"
         );
     return i;
 }
@@ -744,7 +744,7 @@ LIB8STATIC uint8_t ease8InOutApprox( fract8 i)
 
 
 
-/// triwave8: triangle (sawtooth) wave generator.  Useful for
+/// triwave8: triangle wave generator.  Useful for
 ///           turning a one-byte ever-increasing value into a
 ///           one-byte value that oscillates up and down.
 ///

--- a/src/lib8tion.h
+++ b/src/lib8tion.h
@@ -208,8 +208,10 @@ Lib8tion is pronounced like 'libation': lie-BAY-shun
 #define SUB8_C 1
 #define EASE8_C 1
 #define AVG8_C 1
+#define AVG8R_C 1
 #define AVG7_C 1
 #define AVG16_C 1
+#define AVG16R_C 1
 #define AVG15_C 1
 #define BLEND8_C 1
 
@@ -231,8 +233,10 @@ Lib8tion is pronounced like 'libation': lie-BAY-shun
 #define SUB8_C 1
 #define EASE8_C 1
 #define AVG8_C 1
+#define AVG8R_C 1
 #define AVG7_C 1
 #define AVG16_C 1
+#define AVG16R_C 1
 #define AVG15_C 1
 #define BLEND8_C 1
 
@@ -249,8 +253,10 @@ Lib8tion is pronounced like 'libation': lie-BAY-shun
 #define ADD8_C 0
 #define SUB8_C 0
 #define AVG8_C 0
+#define AVG8R_C 0
 #define AVG7_C 0
 #define AVG16_C 0
+#define AVG16R_C 0
 #define AVG15_C 0
 
 #define QADD8_AVRASM 1
@@ -260,8 +266,10 @@ Lib8tion is pronounced like 'libation': lie-BAY-shun
 #define ADD8_AVRASM 1
 #define SUB8_AVRASM 1
 #define AVG8_AVRASM 1
+#define AVG8R_AVRASM 1
 #define AVG7_AVRASM 1
 #define AVG16_AVRASM 1
+#define AVG16R_AVRASM 1
 #define AVG15_AVRASM 1
 
 // Note: these require hardware MUL instruction
@@ -319,8 +327,10 @@ Lib8tion is pronounced like 'libation': lie-BAY-shun
 #define SUB8_C 1
 #define EASE8_C 1
 #define AVG8_C 1
+#define AVG8R_C 1
 #define AVG7_C 1
 #define AVG16_C 1
+#define AVG16R_C 1
 #define AVG15_C 1
 #define BLEND8_C 1
 

--- a/src/lib8tion/math8.h
+++ b/src/lib8tion/math8.h
@@ -53,7 +53,7 @@ LIB8STATIC_ALWAYS_INLINE uint8_t qadd8( uint8_t i, uint8_t j)
 /// Add one byte to another, saturating at 0x7F and -0x80
 /// @param i - first byte to add
 /// @param j - second byte to add
-/// @returns the sum of i & j, capped at 0xFF and -0x80
+/// @returns the sum of i & j, capped at 0x7F and -0x80
 LIB8STATIC_ALWAYS_INLINE int8_t qadd7( int8_t i, int8_t j)
 {
 #if QADD7_C == 1


### PR DESCRIPTION
* `qadd7()` behaved differently when compiled for different platforms
* `avg7()` and `avg15()` gave wrong results when their C versions were compiled
* `qmul8()` had an extra instruction
* Unused register was clobbered in `ease8InOutApprox()`
* Added `avg8r()` and `avg16r()`, they round the result up

#295 tried to fix `qadd7()`