### PR TITLE
Add rp2040 workarounds to avoid register warnings

### DIFF
--- a/src/led_sysdefs.h
+++ b/src/led_sysdefs.h
@@ -30,6 +30,9 @@
 #include "platforms/arm/d21/led_sysdefs_arm_d21.h"
 #elif defined(__SAMD51G19A__) || defined(__SAMD51J19A__) || defined(__SAMD51P19A__)
 #include "platforms/arm/d51/led_sysdefs_arm_d51.h"
+#elif defined(ARDUINO_ARCH_RP2040) // not sure a pico-sdk define for this
+// RP2040 (Raspberry Pi Pico etc)
+#include "platforms/arm/rp2040/led_sysdefs_arm_rp2040.h"
 #elif defined(ESP8266)
 #include "platforms/esp/8266/led_sysdefs_esp8266.h"
 #elif defined(ESP32)

--- a/src/platforms.h
+++ b/src/platforms.h
@@ -30,6 +30,9 @@
 #include "platforms/arm/d21/fastled_arm_d21.h"
 #elif defined(__SAMD51G19A__) || defined(__SAMD51J19A__) || defined(__SAMD51P19A__)
 #include "platforms/arm/d51/fastled_arm_d51.h"
+#elif defined(ARDUINO_ARCH_RP2040) // not sure a pico-sdk define for this
+// RP2040 (Raspberry Pi Pico etc)
+#include "platforms/arm/rp2040/fastled_arm_rp2040.h"
 #elif defined(ESP8266)
 #include "platforms/esp/8266/fastled_esp8266.h"
 #elif defined(ESP32)

--- a/src/platforms/arm/rp2040/clockless_arm_rp2040.h
+++ b/src/platforms/arm/rp2040/clockless_arm_rp2040.h
@@ -1,0 +1,251 @@
+#ifndef __INC_CLOCKLESS_ARM_RP2040
+#define __INC_CLOCKLESS_ARM_RP2040
+
+#include "hardware/clocks.h"
+#include "hardware/dma.h"
+
+// compiler throws a warning about comparison that is always true
+// silence that so users don't see it
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wtype-limits"
+#include "hardware/pio.h"
+#pragma GCC diagnostic pop
+
+#include "pio_gen.h"
+
+/*
+ * This clockless implementation uses RP2040's PIO feature to perform
+ * non-blocking transfers to LEDs with very little memory overhead.
+ * (allocates one buffer of equal size to the data to be sent)
+ *
+ * The SDK-provided claims system is used so that resources can used without
+ * interfering with other code that behaves well and uses claims.
+ *
+ * Resource usage is 4 instructions of program memory on the first PIO instance
+ * with an unclaimed state machine, said unclaimed PIO state machine, and one
+ * DMA channel per instance of ClocklessController.
+ * Additionally, one interrupt handler for DMA_IRQ_0 (configurable as shared or
+ * exclusive via FASTLED_RP2040_CLOCKLESS_IRQ_SHARED) is used regardless of how
+ * many instances are created.
+ * 
+ * The DMA handler is likely the only significant risk in terms of conflicts,
+ * and users can adapt other code to use DMA_IRQ_1 and/or adopt shared handlers
+ * to avoid this becoming an issue.
+ */
+
+FASTLED_NAMESPACE_BEGIN
+#define FASTLED_HAS_CLOCKLESS 1
+
+static CMinWait<0> *dma_chan_waits[NUM_DMA_CHANNELS] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+static inline void __isr clockless_dma_complete_handler() {
+    for (unsigned int i = 0; i < NUM_DMA_CHANNELS; i++) {
+        // if dma triggered for this channel and it's been used (has a CMinWait)
+        if ((dma_hw->ints0 & (1 << i)) && dma_chan_waits[i]) {
+            dma_hw->ints0 = (1 << i); // clear/ack IRQ
+            dma_chan_waits[i]->mark(); // mark the wait
+            return;
+        }
+    }
+}
+static bool clockless_isr_installed = false;
+
+template <uint8_t DATA_PIN, int T1, int T2, int T3, EOrder RGB_ORDER = RGB, int XTRA0 = 0, bool FLIP = false, int WAIT_TIME = 50>
+class ClocklessController : public CPixelLEDController<RGB_ORDER> {
+    int dma_channel = -1;
+    void *dma_buf = nullptr;
+    size_t dma_buf_size = 0;
+    
+    // increase wait time by time taken to send 4 words (to flush PIO TX buffer)
+    CMinWait<WAIT_TIME + ( ((T1 + T2 + T3) * 32 * 4) / (CLOCKLESS_FREQUENCY / 1000000) )> mWait;
+    
+    // start a DMA transfer to the PIO state machine from addr (transfer count 32 bit words)
+    static void do_dma_transfer(int channel, const void *addr, uint count) {
+        dma_channel_set_read_addr(channel, addr, false);
+        dma_channel_set_trans_count(channel, count, true);
+    }
+    
+    // writes bits to an in-memory buffer (to DMA from)
+    // pico has enough memory to not really care about using a buffer for DMA
+    template<int BITS> __attribute__ ((always_inline)) inline static int writeBitsToBuf(int32_t *out_buf, unsigned int bitpos, uint8_t b)  {
+        // not really optimised and I haven't checked output assembly, but this should take ~50 cycles worst case
+        // (and on average substantially fewer -- LEDs without XTRA0 should never trigger the second half of the function)
+        
+        // position of word that takes highest bits (first word used)
+        int wordpos_1 = bitpos >> 5; // bitpos / 32;
+        
+        // number of bits from the byte that fit into first word
+        int bitcnt_1 = 32 - (bitpos & 0b11111); // bitpos % 32;
+        // shift required to place byte within the word
+        int bitshift_1 = bitcnt_1 - 8;
+        // mask for output bits that are taken from input
+        // int32_t bitmask_1 = 0xFF << bitshift_1;
+        int32_t bitmask_1 = ((1 << BITS) - 1) << (bitshift_1 - (BITS-8));
+        
+        out_buf[wordpos_1] = (out_buf[wordpos_1] & ~bitmask_1) | ((b << bitshift_1) & bitmask_1);
+        
+        if (bitcnt_1 >= BITS) return BITS; // fast case for entire byte fitting in word
+        
+        // number of bits from the byte to place into second word
+        int bitcnt_2 = 8 - bitcnt_1;
+        // shift required to place byte within the word
+        int bitshift_2 = 32 - bitcnt_2;
+        // mask for output bits that are taken from input
+        // int32_t bitmask_2 = ((1 << bitcnt_2) - 1) << bitshift_2;
+        int32_t bitmask_2 = ((1 << (bitcnt_2 + (BITS-8))) - 1) << (bitshift_2 - (BITS-8)); // fixed XTRA0
+        
+        out_buf[wordpos_1 + 1] = (out_buf[wordpos_1 + 1] & ~bitmask_2) | ((b << bitshift_2) & bitmask_2);
+        
+        return BITS;
+    }
+public:
+    virtual void init() {
+        if (dma_channel != -1) return; // maybe init was called twice somehow? not sure if possible
+        
+        PIO pio;
+        int sm;
+        int offset = -1;
+        
+        // find an unclaimed PIO state machine and upload the clockless program if possible
+        // there's two PIO instances, each with four state machines, so this should usually work out fine
+        static PIO pios[NUM_PIOS] = { pio0, pio1 };
+        // iterate over PIO instances
+        for (unsigned int i = 0; i < NUM_PIOS; i++) {
+            pio = pios[i];
+            sm = pio_claim_unused_sm(pio, false); // claim a state machine
+            if (sm == -1) continue; // skip this PIO if no unused sm
+            
+            offset = add_clockless_pio_program(pio, T1, T2, T3);
+            if (offset == -1) {
+                pio_sm_unclaim(pio, sm); // unclaim the state machine and skip this PIO
+                continue;                // if program couldn't be added
+            }
+            
+            break; // found pio and sm that work
+        }
+        if (offset == -1) return; // couldn't find good pio and sm
+        
+        
+        // claim an unused DMA channel (there's 12 in total,, so this should also usually work out fine)
+        dma_channel = dma_claim_unused_channel(false);
+        if (dma_channel == -1) return; // no free DMA channel
+        
+        
+        // setup PIO state machine
+        pio_gpio_init(pio, DATA_PIN);
+        pio_sm_set_consecutive_pindirs(pio, sm, DATA_PIN, 1, true);
+        
+        pio_sm_config c = clockless_pio_program_get_default_config(offset);
+        sm_config_set_sideset_pins(&c, DATA_PIN);
+        sm_config_set_out_shift(&c, false, true, 32);
+        
+        // uncommenting this makes the FIFO 8 words long,
+        // which seems like it won't actually benefit us
+        // sm_config_set_fifo_join(&c, PIO_FIFO_JOIN_TX);
+        
+        float div = clock_get_hz(clk_sys) / CLOCKLESS_FREQUENCY;
+        sm_config_set_clkdiv(&c, div);
+        
+        pio_sm_init(pio, sm, offset, &c);
+        pio_sm_set_enabled(pio, sm, true);
+        
+        
+        // setup DMA
+        dma_channel_config channel_config = dma_channel_get_default_config(dma_channel);
+        channel_config_set_dreq(&channel_config, pio_get_dreq(pio, sm, true));
+        dma_channel_configure(dma_channel,
+                              &channel_config,
+                              &pio->txf[sm],
+                              NULL,   // address set when making transfer
+                              1,      // count set when making transfer
+                              false); // don't trigger now
+        
+        
+        // setup DMA complete interrupt handler to update mWait time after transfer
+        
+        // store a pointer to mWait of this instance to a global array for the interrupt handler
+        // kinda dirty hack here to cast to CMinWait<0>*, but only mark is used, which isn't affected by the template var WAIT
+        dma_chan_waits[dma_channel] = (CMinWait<0>*)&mWait;
+        
+        if (!clockless_isr_installed) {
+#if FASTLED_RP2040_CLOCKLESS_IRQ_SHARED
+            irq_add_shared_handler(DMA_IRQ_0, clockless_dma_complete_handler, PICO_SHARED_IRQ_HANDLER_DEFAULT_ORDER_PRIORITY);
+#else
+            irq_set_exclusive_handler(DMA_IRQ_0, clockless_dma_complete_handler);
+#endif
+            irq_set_enabled(DMA_IRQ_0, true);
+            clockless_isr_installed = true;
+        }
+        dma_channel_set_irq0_enabled(dma_channel, true);
+    }
+
+    virtual uint16_t getMaxRefreshRate() const { return 400; }
+
+    virtual void showPixels(PixelController<RGB_ORDER> & pixels) {
+        if (dma_channel == -1) return; // setup failed
+        
+        // wait for past transfer to finish
+        // call when previous pixels are done will run without blocking,
+        // call when previous pixels are still being transmitted should block until complete
+        
+        // a potential improvement here would be to prepare data for the output before waiting,
+        // but that would require a smarter DMA buffer system
+        // (currently, the gap between LEDs is greater than 50us due to the time taken)
+        if (dma_channel_is_busy(dma_channel)) {
+            dma_channel_wait_for_finish_blocking(dma_channel);
+        }
+        mWait.wait();
+        
+        showRGBInternal(pixels);
+    }
+
+    void showRGBInternal(PixelController<RGB_ORDER> pixels) {
+        size_t req_buf_size = (pixels.mLen * 3 * (8+XTRA0) + 31) / 32;
+        
+        // (re)allocate DMA buffer if not large enough to hold req_buf_size 32-bit words
+        // pico has enough memory to not really care about using a buffer for DMA
+        // just give up on failure
+        if (dma_buf_size < req_buf_size) {
+            if (dma_buf != nullptr)
+                free(dma_buf);
+            
+            dma_buf = malloc(req_buf_size * 4);
+            if (dma_buf == nullptr) {
+                dma_buf_size = 0;
+                return;
+            }
+            dma_buf_size = req_buf_size;
+            
+            // fill with zeroes to ensure XTRA0s are really zero without needing extra work
+            memset(dma_buf, 0, dma_buf_size * 4);
+        }
+        
+        unsigned int bitpos = 0;
+        
+        pixels.preStepFirstByteDithering();
+        uint8_t b = pixels.loadAndScale0();
+        
+        while(pixels.has(1)) {
+            pixels.stepDithering();
+
+            // Write first byte, read next byte
+            bitpos += writeBitsToBuf<8+XTRA0>((int32_t*)(dma_buf), bitpos, b);
+            b = pixels.loadAndScale1();
+
+            // Write second byte, read 3rd byte
+            bitpos += writeBitsToBuf<8+XTRA0>((int32_t*)(dma_buf), bitpos, b);
+            b = pixels.loadAndScale2();
+
+            // Write third byte, read 1st byte of next pixel
+            bitpos += writeBitsToBuf<8+XTRA0>((int32_t*)(dma_buf), bitpos, b);
+            b = pixels.advanceAndLoadAndScale0();
+        };
+        
+        do_dma_transfer(dma_channel, dma_buf, req_buf_size);
+    }
+
+};
+
+FASTLED_NAMESPACE_END
+
+
+#endif // __INC_CLOCKLESS_ARM_RP2040

--- a/src/platforms/arm/rp2040/clockless_arm_rp2040.h
+++ b/src/platforms/arm/rp2040/clockless_arm_rp2040.h
@@ -171,7 +171,8 @@ public:
         pio_sm_set_consecutive_pindirs(pio, sm, DATA_PIN, 1, true);
         
         pio_sm_config c = clockless_pio_program_get_default_config(offset);
-        sm_config_set_sideset_pins(&c, DATA_PIN);
+        sm_config_set_set_pins(&c, DATA_PIN, 1);
+        sm_config_set_out_pins(&c, DATA_PIN, 1);
         sm_config_set_out_shift(&c, false, true, 32);
         
         // uncommenting this makes the FIFO 8 words long,

--- a/src/platforms/arm/rp2040/fastled_arm_rp2040.h
+++ b/src/platforms/arm/rp2040/fastled_arm_rp2040.h
@@ -1,0 +1,8 @@
+#ifndef __INC_FASTLED_ARM_RP2040_H
+#define __INC_FASTLED_ARM_RP2040_H
+
+// Include the rp2040 headers
+#include "fastpin_arm_rp2040.h"
+#include "clockless_arm_rp2040.h"
+
+#endif

--- a/src/platforms/arm/rp2040/fastpin_arm_rp2040.h
+++ b/src/platforms/arm/rp2040/fastpin_arm_rp2040.h
@@ -14,6 +14,7 @@ FASTLED_NAMESPACE_BEGIN
 
 #else
 
+// warning: set and fastset are not thread-safe! use with caution!
 template<uint PIN, uint32_t _MASK> class _RP2040PIN {
 public:
   typedef volatile uint32_t * port_ptr_t;
@@ -34,8 +35,8 @@ public:
   inline static void lo(register port_ptr_t port) __attribute__ ((always_inline)) { lo(); }
   inline static void fastset(register port_ptr_t port, register port_t val) __attribute__ ((always_inline)) { *port = val; }
 
-  inline static port_t hival() __attribute__ ((always_inline)) { return sio_hw->gpio_in | _MASK; }
-  inline static port_t loval() __attribute__ ((always_inline)) { return sio_hw->gpio_in & ~_MASK; }
+  inline static port_t hival() __attribute__ ((always_inline)) { return sio_hw->gpio_out | _MASK; }
+  inline static port_t loval() __attribute__ ((always_inline)) { return sio_hw->gpio_out & ~_MASK; }
   inline static port_ptr_t port() __attribute__ ((always_inline)) { return &sio_hw->gpio_out; }
   inline static port_t mask() __attribute__ ((always_inline)) { return _MASK; }
 };

--- a/src/platforms/arm/rp2040/fastpin_arm_rp2040.h
+++ b/src/platforms/arm/rp2040/fastpin_arm_rp2040.h
@@ -38,6 +38,8 @@ public:
   inline static port_t hival() __attribute__ ((always_inline)) { return sio_hw->gpio_out | _MASK; }
   inline static port_t loval() __attribute__ ((always_inline)) { return sio_hw->gpio_out & ~_MASK; }
   inline static port_ptr_t port() __attribute__ ((always_inline)) { return &sio_hw->gpio_out; }
+  inline static port_ptr_t sport() __attribute__ ((always_inline)) { return &sio_hw->gpio_set; }
+  inline static port_ptr_t cport() __attribute__ ((always_inline)) { return &sio_hw->gpio_clr; }
   inline static port_t mask() __attribute__ ((always_inline)) { return _MASK; }
 };
 

--- a/src/platforms/arm/rp2040/fastpin_arm_rp2040.h
+++ b/src/platforms/arm/rp2040/fastpin_arm_rp2040.h
@@ -1,0 +1,74 @@
+#ifndef __FASTPIN_ARM_RP2040_H
+#define __FASTPIN_ARM_RP2040_H
+
+#include "pico.h"
+#include "hardware/gpio.h"
+#include "hardware/structs/sio.h"
+
+FASTLED_NAMESPACE_BEGIN
+
+#if defined(FASTLED_FORCE_SOFTWARE_PINS)
+#warning "Software pin support forced, pin access will be sloightly slower."
+#define NO_HARDWARE_PIN_SUPPORT
+#undef HAS_HARDWARE_PIN_SUPPORT
+
+#else
+
+template<uint PIN, uint32_t _MASK> class _RP2040PIN {
+public:
+  typedef volatile uint32_t * port_ptr_t;
+  typedef uint32_t port_t;
+  
+  inline static void setOutput() { gpio_set_function(PIN, GPIO_FUNC_SIO); sio_hw->gpio_oe_set = _MASK; }
+  inline static void setInput() { gpio_set_function(PIN, GPIO_FUNC_SIO); sio_hw->gpio_oe_clr = _MASK; }
+
+  inline static void hi() __attribute__ ((always_inline)) { sio_hw->gpio_set = _MASK; }
+  inline static void lo() __attribute__ ((always_inline)) { sio_hw->gpio_clr = _MASK; }
+  inline static void set(register port_t val) __attribute__ ((always_inline)) { sio_hw->gpio_out = val; }
+
+  inline static void strobe() __attribute__ ((always_inline)) { toggle(); toggle(); }
+
+  inline static void toggle() __attribute__ ((always_inline)) { sio_hw->gpio_togl = _MASK; }
+
+  inline static void hi(register port_ptr_t port) __attribute__ ((always_inline)) { hi(); }
+  inline static void lo(register port_ptr_t port) __attribute__ ((always_inline)) { lo(); }
+  inline static void fastset(register port_ptr_t port, register port_t val) __attribute__ ((always_inline)) { *port = val; }
+
+  inline static port_t hival() __attribute__ ((always_inline)) { return sio_hw->gpio_in | _MASK; }
+  inline static port_t loval() __attribute__ ((always_inline)) { return sio_hw->gpio_in & ~_MASK; }
+  inline static port_ptr_t port() __attribute__ ((always_inline)) { return &sio_hw->gpio_out; }
+  inline static port_t mask() __attribute__ ((always_inline)) { return _MASK; }
+};
+
+#define _FL_DEFPIN(PIN) template<> class FastPin<PIN> : public _RP2040PIN<PIN, 1 << PIN> {};
+
+#define MAX_PIN 29
+_FL_DEFPIN(0); _FL_DEFPIN(1); _FL_DEFPIN(2); _FL_DEFPIN(3);
+_FL_DEFPIN(4); _FL_DEFPIN(5); _FL_DEFPIN(6); _FL_DEFPIN(7);
+_FL_DEFPIN(8); _FL_DEFPIN(9); _FL_DEFPIN(10); _FL_DEFPIN(11);
+_FL_DEFPIN(12); _FL_DEFPIN(13); _FL_DEFPIN(14); _FL_DEFPIN(15);
+_FL_DEFPIN(16); _FL_DEFPIN(17); _FL_DEFPIN(18); _FL_DEFPIN(19);
+_FL_DEFPIN(20); _FL_DEFPIN(21); _FL_DEFPIN(22); _FL_DEFPIN(23);
+_FL_DEFPIN(24); _FL_DEFPIN(25); _FL_DEFPIN(26); _FL_DEFPIN(27);
+_FL_DEFPIN(28); _FL_DEFPIN(29);
+
+#ifdef PICO_DEFAULT_SPI_TX_PIN
+#define SPI_DATA PICO_DEFAULT_SPI_TX_PIN
+#else
+#define SPI_DATA 19
+#endif
+
+#ifdef PICO_DEFAULT_SPI_SCK_PIN
+#define SPI_CLOCK PICO_DEFAULT_SPI_SCK_PIN
+#else
+#define SPI_CLOCK 18
+#endif
+
+#define HAS_HARDWARE_PIN_SUPPORT
+
+#endif // FASTLED_FORCE_SOFTWARE_PINS
+
+
+FASTLED_NAMESPACE_END
+
+#endif // __FASTPIN_ARM_RP2040_H

--- a/src/platforms/arm/rp2040/led_sysdefs_arm_rp2040.h
+++ b/src/platforms/arm/rp2040/led_sysdefs_arm_rp2040.h
@@ -1,0 +1,46 @@
+#ifndef __INC_LED_SYSDEFS_ARM_RP2040_H
+#define __INC_LED_SYSDEFS_ARM_RP2040_H
+
+#define FASTLED_ARM
+#define FASTLED_ARM_M0_PLUS
+
+// TODO: PORT SPI TO HW
+//#define FASTLED_SPI_BYTE_ONLY
+#define FASTLED_FORCE_SOFTWARE_SPI
+
+#define FASTLED_NO_PINMAP
+
+typedef volatile uint32_t RoReg;
+typedef volatile uint32_t RwReg;
+
+// #define F_CPU clock_get_hz(clk_sys) // can't use runtime function call
+// is the boot-time value in another var already for any platforms?
+// it doesn't seem to be, so hardcode the sdk default of 125 MHz
+#ifndef F_CPU
+#define F_CPU 125000000
+#endif
+
+// 8MHz for PIO
+#define CLOCKLESS_FREQUENCY 8000000
+
+// Default to allowing interrupts
+#ifndef FASTLED_ALLOW_INTERRUPTS
+#define FASTLED_ALLOW_INTERRUPTS 1
+#endif
+
+// not sure if this is wanted? but it probably is
+#if FASTLED_ALLOW_INTERRUPTS == 1
+#define FASTLED_ACCURATE_CLOCK
+#endif
+
+// Default to no PROGMEM
+#ifndef FASTLED_USE_PROGMEM
+#define FASTLED_USE_PROGMEM 0
+#endif
+
+// Default to shared interrupt handler for clockless DMA
+#ifndef FASTLED_RP2040_CLOCKLESS_IRQ_SHARED
+#define FASTLED_RP2040_CLOCKLESS_IRQ_SHARED 1
+#endif
+
+#endif // __INC_LED_SYSDEFS_ARM_RP2040_H

--- a/src/platforms/arm/rp2040/led_sysdefs_arm_rp2040.h
+++ b/src/platforms/arm/rp2040/led_sysdefs_arm_rp2040.h
@@ -7,6 +7,13 @@
 // TODO: PORT SPI TO HW
 //#define FASTLED_SPI_BYTE_ONLY
 #define FASTLED_FORCE_SOFTWARE_SPI
+// Force FAST_SPI_INTERRUPTS_WRITE_PINS on becuase two cores running
+// simultaneously could lead to data races on GPIO.
+// This could potentially be optimised by adding a mask to FastPin's set and
+// fastset, but for now it's probably safe to call that out of scope.
+#ifndef FAST_SPI_INTERRUPTS_WRITE_PINS
+#define FAST_SPI_INTERRUPTS_WRITE_PINS 1
+#endif
 
 #define FASTLED_NO_PINMAP
 

--- a/src/platforms/arm/rp2040/led_sysdefs_arm_rp2040.h
+++ b/src/platforms/arm/rp2040/led_sysdefs_arm_rp2040.h
@@ -1,6 +1,8 @@
 #ifndef __INC_LED_SYSDEFS_ARM_RP2040_H
 #define __INC_LED_SYSDEFS_ARM_RP2040_H
 
+#include "hardware/sync.h"
+
 #define FASTLED_ARM
 #define FASTLED_ARM_M0_PLUS
 
@@ -24,11 +26,20 @@ typedef volatile uint32_t RwReg;
 // is the boot-time value in another var already for any platforms?
 // it doesn't seem to be, so hardcode the sdk default of 125 MHz
 #ifndef F_CPU
+#ifdef VARIANT_MCK
+#define F_CPU VARIANT_MCK
+#else
 #define F_CPU 125000000
+#endif
+#endif
+
+#ifndef VARIANT_MCK
+#define VARIANT_MCK F_CPU
 #endif
 
 // 8MHz for PIO
-#define CLOCKLESS_FREQUENCY 8000000
+// #define CLOCKLESS_FREQUENCY 8000000
+#define CLOCKLESS_FREQUENCY F_CPU
 
 // Default to allowing interrupts
 #ifndef FASTLED_ALLOW_INTERRUPTS
@@ -45,9 +56,35 @@ typedef volatile uint32_t RwReg;
 #define FASTLED_USE_PROGMEM 0
 #endif
 
+// Default to non-blocking PIO-based implemnetation
+#ifndef FASTLED_RP2040_CLOCKLESS_PIO
+#define FASTLED_RP2040_CLOCKLESS_PIO 1
+#endif
+
 // Default to shared interrupt handler for clockless DMA
 #ifndef FASTLED_RP2040_CLOCKLESS_IRQ_SHARED
 #define FASTLED_RP2040_CLOCKLESS_IRQ_SHARED 1
 #endif
+
+// SPI pin defs for old SDK ver
+#ifndef PICO_DEFAULT_SPI
+#define PICO_DEFAULT_SPI 0
+#endif
+#ifndef PICO_DEFAULT_SPI_SCK_PIN
+#define PICO_DEFAULT_SPI_SCK_PIN 18
+#endif
+#ifndef PICO_DEFAULT_SPI_TX_PIN
+#define PICO_DEFAULT_SPI_TX_PIN 19
+#endif
+#ifndef PICO_DEFAULT_SPI_RX_PIN
+#define PICO_DEFAULT_SPI_RX_PIN 16
+#endif
+#ifndef PICO_DEFAULT_SPI_CSN_PIN
+#define PICO_DEFAULT_SPI_CSN_PIN 17
+#endif
+
+static uint32_t saved_interrupt_status;
+#define cli() (saved_interrupt_status = save_and_disable_interrupts())
+#define sei() (restore_interrupts(saved_interrupt_status))
 
 #endif // __INC_LED_SYSDEFS_ARM_RP2040_H

--- a/src/platforms/arm/rp2040/pio_asm.h
+++ b/src/platforms/arm/rp2040/pio_asm.h
@@ -1,0 +1,98 @@
+#ifndef _PIO_ASM_H
+#define _PIO_ASM_H
+
+/*
+ * PIO "assembly" macro header, written by somewhatlurker
+ * Released to public domain/CC0 license.
+ * Comes with no guarantees of correctness.
+ */
+
+typedef uint16_t pio_instr;
+
+#define PIO_INSTR_JMP  (0b000 << 13)
+#define PIO_INSTR_WAIT (0b001 << 13)
+#define PIO_INSTR_IN   (0b010 << 13)
+#define PIO_INSTR_OUT  (0b011 << 13)
+#define PIO_INSTR_PUSH (0b100 << 13)
+#define PIO_INSTR_PULL ((0b100 << 13) | (0b1 << 7))
+#define PIO_INSTR_MOV  (0b101 << 13)
+#define PIO_INSTR_IRQ  (0b110 << 13)
+#define PIO_INSTR_SET  (0b111 << 13)
+
+#define PIO_DELAY(x, sideset_count)   (((x) & ((1 << (5 - sideset_count)) - 1)) << 8)
+#define PIO_SIDESET(x, sideset_count) (((x) & ((1 << (sideset_count)) - 1)) << (13 - sideset_count))
+#define PIO_SIDESET_ENABLE_BIT        (0b1 << 12)
+
+#define PIO_JMP_CND_ALWAYS   (0b000 << 5)
+#define PIO_JMP_CND_NOT_X    (0b001 << 5)
+#define PIO_JMP_CND_X_DEC    (0b010 << 5)
+#define PIO_JMP_CND_NOT_Y    (0b011 << 5)
+#define PIO_JMP_CND_Y_DEC    (0b100 << 5)
+#define PIO_JMP_CND_X_NE_Y   (0b101 << 5)
+#define PIO_JMP_CND_PIN      (0b110 << 5)
+#define PIO_JMP_CND_NOT_OSRE (0b111 << 5)
+#define PIO_JMP_ADR(x)       ((x) & 0b11111)
+
+#define PIO_WAIT_POLARITY_1 (0b1 << 7)
+#define PIO_WAIT_POLARITY_0 (0b0 << 7)
+#define PIO_WAIT_SRC_GPIO   (0b00 << 5)
+#define PIO_WAIT_SRC_PIN    (0b01 << 5)
+#define PIO_WAIT_SRC_IRQ    (0b10 << 5)
+#define PIO_WAIT_IDX(x)     ((x) & 0b11111)
+
+#define PIO_IN_SRC_PINS (0b000 << 5)
+#define PIO_IN_SRC_X    (0b001 << 5)
+#define PIO_IN_SRC_Y    (0b010 << 5)
+#define PIO_IN_SRC_NULL (0b011 << 5)
+#define PIO_IN_SRC_ISR  (0b110 << 5)
+#define PIO_IN_SRC_OSR  (0b111 << 5)
+#define PIO_IN_CNT(x)   ((x) & 0b11111)
+
+#define PIO_OUT_DST_PINS    (0b000 << 5)
+#define PIO_OUT_DST_X       (0b001 << 5)
+#define PIO_OUT_DST_Y       (0b010 << 5)
+#define PIO_OUT_DST_NULL    (0b011 << 5)
+#define PIO_OUT_DST_PINDIRS (0b100 << 5)
+#define PIO_OUT_DST_PC      (0b101 << 5)
+#define PIO_OUT_DST_ISR     (0b110 << 5)
+#define PIO_OUT_DST_EXEC    (0b111 << 5)
+#define PIO_OUT_CNT(x)      ((x) & 0b11111)
+
+#define PIO_PUSH_IFFULL (0b1 << 6)
+#define PIO_PUSH_BLOCK  (0b1 << 5)
+
+#define PIO_PULL_IFEMPTY (0b1 << 6)
+#define PIO_PULL_BLOCK   (0b1 << 5)
+
+#define PIO_MOV_DST_PINS   (0b000 << 5)
+#define PIO_MOV_DST_X      (0b001 << 5)
+#define PIO_MOV_DST_Y      (0b010 << 5)
+#define PIO_MOV_DST_EXEC   (0b100 << 5)
+#define PIO_MOV_DST_PC     (0b101 << 5)
+#define PIO_MOV_DST_ISR    (0b110 << 5)
+#define PIO_MOV_DST_OSR    (0b111 << 5)
+#define PIO_MOV_OP_NONE    (0b00 << 3)
+#define PIO_MOV_OP_INVERT  (0b00 << 3)
+#define PIO_MOV_OP_REVERSE (0b00 << 3)
+#define PIO_MOV_SRC_PINS   (0b000)
+#define PIO_MOV_SRC_X      (0b001)
+#define PIO_MOV_SRC_Y      (0b010)
+#define PIO_MOV_SRC_NULL   (0b011)
+#define PIO_MOV_SRC_STATUS (0b101)
+#define PIO_MOV_SRC_ISR    (0b110)
+#define PIO_MOV_SRC_OSR    (0b111)
+
+#define PIO_IRQ_CLEAR   (0b1 << 6)
+#define PIO_IRQ_WAIT    (0b1 << 5)
+#define PIO_IRQ_IDX(x)  ((x) & 0b111)
+#define PIO_IRQ_IDX_REL (0b1 << 4)
+
+#define PIO_SET_DST_PINS    (0b000 << 5)
+#define PIO_SET_DST_X       (0b001 << 5)
+#define PIO_SET_DST_Y       (0b010 << 5)
+#define PIO_SET_DST_PINDIRS (0b100 << 5)
+#define PIO_SET_DATA(x)     ((x) & 0b11111)
+
+#define PIO_NOP (PIO_INSTR_MOV | PIO_MOV_DST_Y | PIO_MOV_SRC_Y)
+
+#endif // _PIO_ASM_H

--- a/src/platforms/arm/rp2040/pio_gen.h
+++ b/src/platforms/arm/rp2040/pio_gen.h
@@ -1,0 +1,81 @@
+#ifndef _PIO_GEN_H
+#define _PIO_GEN_H
+
+#include "pio_asm.h"
+#include "hardware/pio.h"
+
+/*
+ * This file contains code to manage the PIO program for clockless LEDs.
+ * 
+ * A PIO program is "assembled" from compiler macros so that T1, T2, T3 can be
+ * set from other code.
+ * Otherwise, this is quite similar to what would be output by pioasm, with the
+ * additional step of adding the program to a state machine integrated.
+ * 
+ * 
+ * The PIO program is copied from pico-examples, which uses a 3-clause BSD license:
+ * 
+ * Copyright 2020 (c) 2020 Raspberry Pi (Trading) Ltd.
+ * 
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+ * following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+ *    disclaimer.
+ * 
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided with the distribution.
+ * 
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#define CLOCKLESS_PIO_SIDESET_COUNT 1
+
+#define CLOCKLESS_PIO_BITLOOP_ADR 0
+#define CLOCKLESS_PIO_DOZERO_ADR 3
+
+#define CLOCKLESS_PIO_WRAP_TARGET 0
+#define CLOCKLESS_PIO_WRAP 3
+
+static inline int add_clockless_pio_program(PIO pio, int T1, int T2, int T3) {
+    pio_instr clockless_pio_instr[] = {
+        // wrap_target
+        // bitloop
+        (pio_instr)(PIO_INSTR_OUT | PIO_OUT_DST_X | PIO_OUT_CNT(1) | PIO_SIDESET(0, CLOCKLESS_PIO_SIDESET_COUNT) | PIO_DELAY(T3 - 1, CLOCKLESS_PIO_SIDESET_COUNT)),
+        (pio_instr)(PIO_INSTR_JMP | PIO_JMP_CND_NOT_X | PIO_JMP_ADR(CLOCKLESS_PIO_DOZERO_ADR) | PIO_SIDESET(1, CLOCKLESS_PIO_SIDESET_COUNT) | PIO_DELAY(T1 - 1, CLOCKLESS_PIO_SIDESET_COUNT)),
+        // do_one
+        (pio_instr)(PIO_INSTR_JMP | PIO_JMP_CND_ALWAYS | PIO_JMP_ADR(CLOCKLESS_PIO_BITLOOP_ADR) | PIO_SIDESET(1, CLOCKLESS_PIO_SIDESET_COUNT) | PIO_DELAY(T2 - 1, CLOCKLESS_PIO_SIDESET_COUNT)),
+        // do_zero
+        (pio_instr)(PIO_NOP | PIO_SIDESET(0, CLOCKLESS_PIO_SIDESET_COUNT) | PIO_DELAY(T2 - 1, CLOCKLESS_PIO_SIDESET_COUNT)),
+        // wrap
+    };
+    
+    struct pio_program clockless_pio_program = {
+        .instructions = clockless_pio_instr,
+        .length = sizeof(clockless_pio_instr) / sizeof(clockless_pio_instr[0]),
+        .origin = -1,
+    };
+    
+    if (!pio_can_add_program(pio, &clockless_pio_program))
+        return -1;
+    
+    return (int)pio_add_program(pio, &clockless_pio_program);
+}
+
+static inline pio_sm_config clockless_pio_program_get_default_config(uint offset) {
+    pio_sm_config c = pio_get_default_sm_config();
+    sm_config_set_wrap(&c, offset + CLOCKLESS_PIO_WRAP_TARGET, offset + CLOCKLESS_PIO_WRAP);
+    sm_config_set_sideset(&c, CLOCKLESS_PIO_SIDESET_COUNT, false, false);
+    return c;
+}
+
+#endif // _PIO_GEN_H

--- a/src/platforms/arm/rp2040/pio_gen.h
+++ b/src/platforms/arm/rp2040/pio_gen.h
@@ -46,6 +46,9 @@
 #define CLOCKLESS_PIO_WRAP_TARGET 0
 #define CLOCKLESS_PIO_WRAP 3
 
+// we have 4 bits to store delay in instruction encoding with one sideset bit, but we can accept up to 16 because 1 is always subtracted first
+#define CLOCKLESS_PIO_MAX_TIME_PERIOD (1 << (5 - CLOCKLESS_PIO_SIDESET_COUNT))
+
 static inline int add_clockless_pio_program(PIO pio, int T1, int T2, int T3) {
     pio_instr clockless_pio_instr[] = {
         // wrap_target


### PR DESCRIPTION
- add rp2040 platform
- rp2040: fix some issues with fastpin/spi bitbanging (thread safety and accidental use of wrong reg for hival,loval)
- rp2040: support using m0clockless output implementation for >8 strips
- rp2040: switch to custom PIO program that doesn't use sideset avoiding sideset means that we double the max instruction delay, which should increase our timing resolution it also means that there's no longer a separately-licensed block of code included
