### PR TITLE
Fix unused variable warning in ESP32RMTController

### DIFF
--- a/src/platforms/esp/32/clockless_rmt_esp32.cpp
+++ b/src/platforms/esp/32/clockless_rmt_esp32.cpp
@@ -158,6 +158,7 @@ void ESP32RMTController::init(gpio_num_t pin)
     }
 
     gInitialized = true;
+    (void)espErr;
 }
 
 // -- Show this string of pixels
@@ -279,6 +280,7 @@ void IRAM_ATTR ESP32RMTController::startOnChannel(int channel)
         // -- Kick off the transmission
         tx_start();
     }
+    (void)espErr;
 }
 
 // -- Start RMT transmission


### PR DESCRIPTION
When compiling FastLED with `FASTLED_RMT_SERIAL_DEBUG` unset, I get the failure below. This PR fixes that issue by telling the compiler that espErr is used. Another solution would be to tweak `FASTLED_DEBUG()` when `FASTLED_RMT_SERIAL_DEBUG` is `0` to always compile the debug parameters even if they're removed at link time, but I don't know which linkers you support and I don't want to create any performance regressions. This PR is a no-op apart from silencing the warning.

```
FastLED/src/platforms/esp/32/clockless_rmt_esp32.cpp: In static member function 'static void ESP32RMTController::init(gpio_num_t)':
FastLED/src/platforms/esp/32/clockless_rmt_esp32.cpp:111:15: warning: variable 'espErr' set but not used [-Wunused-but-set-variable]
     esp_err_t espErr = ESP_OK;
               ^
FastLED/src/platforms/esp/32/clockless_rmt_esp32.cpp: In member function 'void ESP32RMTController::startOnChannel(int)':
FastLED/src/platforms/esp/32/clockless_rmt_esp32.cpp:239:15: warning: variable 'espErr' set but not used [-Wunused-but-set-variable]
     esp_err_t espErr = ESP_OK;
               ^
```