### PR TITLE
Fix fill_noise functions with lengths > 255

### DIFF
--- a/src/noise.cpp
+++ b/src/noise.cpp
@@ -705,6 +705,8 @@ void fill_noise8(CRGB *leds, int num_leds,
             uint8_t hue_octaves, uint16_t hue_x, int hue_scale,
             uint16_t time) {
 
+    if (num_leds <= 0) return;
+
     for (int j = 0; j < num_leds; j += 255) {
         const int LedsRemaining = num_leds - j;
         const int LedsPer = LedsRemaining > 255 ? 255 : LedsRemaining;  // limit to 255 max
@@ -728,6 +730,8 @@ void fill_noise16(CRGB *leds, int num_leds,
             uint8_t octaves, uint16_t x, int scale,
             uint8_t hue_octaves, uint16_t hue_x, int hue_scale,
             uint16_t time, uint8_t hue_shift) {
+
+    if (num_leds <= 0) return;
 
     for (int j = 0; j < num_leds; j += 255) {
         const int LedsRemaining = num_leds - j;

--- a/src/noise.cpp
+++ b/src/noise.cpp
@@ -704,36 +704,48 @@ void fill_noise8(CRGB *leds, int num_leds,
             uint8_t octaves, uint16_t x, int scale,
             uint8_t hue_octaves, uint16_t hue_x, int hue_scale,
             uint16_t time) {
-  uint8_t V[num_leds];
-  uint8_t H[num_leds];
 
-  memset(V,0,num_leds);
-  memset(H,0,num_leds);
+    for (int j = 0; j < num_leds; j += 255) {
+        const int LedsRemaining = num_leds - j;
+        const int LedsPer = LedsRemaining > 255 ? 255 : LedsRemaining;  // limit to 255 max
 
-  fill_raw_noise8(V,num_leds,octaves,x,scale,time);
-  fill_raw_noise8(H,num_leds,hue_octaves,hue_x,hue_scale,time);
+        uint8_t V[LedsPer];
+        uint8_t H[LedsPer];
 
-  for(int i = 0; i < num_leds; ++i) {
-    leds[i] = CHSV(H[i],255,V[i]);
-  }
+        memset(V, 0, LedsPer);
+        memset(H, 0, LedsPer);
+
+        fill_raw_noise8(V, LedsPer, octaves, x, scale, time);
+        fill_raw_noise8(H, LedsPer, hue_octaves, hue_x, hue_scale, time);
+
+        for (int i = 0; i < LedsPer; ++i) {
+            leds[i + j] = CHSV(H[i], 255, V[i]);
+        }
+    }
 }
 
 void fill_noise16(CRGB *leds, int num_leds,
             uint8_t octaves, uint16_t x, int scale,
             uint8_t hue_octaves, uint16_t hue_x, int hue_scale,
             uint16_t time, uint8_t hue_shift) {
-  uint8_t V[num_leds];
-  uint8_t H[num_leds];
 
-  memset(V,0,num_leds);
-  memset(H,0,num_leds);
+    for (int j = 0; j < num_leds; j += 255) {
+        const int LedsRemaining = num_leds - j;
+        const int LedsPer = LedsRemaining > 255 ? 255 : LedsRemaining;  // limit to 255 max
 
-  fill_raw_noise16into8(V,num_leds,octaves,x,scale,time);
-  fill_raw_noise8(H,num_leds,hue_octaves,hue_x,hue_scale,time);
+        uint8_t V[LedsPer];
+        uint8_t H[LedsPer];
 
-  for(int i = 0; i < num_leds; ++i) {
-    leds[i] = CHSV(H[i] + hue_shift,255,V[i]);
-  }
+        memset(V, 0, LedsPer);
+        memset(H, 0, LedsPer);
+
+        fill_raw_noise16into8(V, LedsPer, octaves, x, scale, time);
+        fill_raw_noise8(H, LedsPer, hue_octaves, hue_x, hue_scale, time);
+
+        for (int i = 0; i < LedsPer; ++i) {
+            leds[i + j] = CHSV(H[i] + hue_shift, 255, V[i]);
+        }
+    }
 }
 
 void fill_2dnoise8(CRGB *leds, int width, int height, bool serpentine,


### PR DESCRIPTION
These two functions (`fill_noise8` and `fill_noise16`) take an `int` for the length parameter but use the `fill_noise_raw` functions internally which use a `uint8_t` for the same parameter. This causes an issue where CRGB arrays longer than 255 won't be filled.

To fix, this changes these functions so that they loop through the fills in increments of 255. This preserves the existing behavior and function signature while allowing fills longer than 255.