### PR TITLE
Fix CI Build Issues

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,5 @@
 on:
+  workflow_dispatch:
   push:
     branches:
       - master

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: install platformio
         run: |
-          pip install platformio==5.0.3
+          pip install platformio==6.1.4
 
       - name: build FastLED examples
         run: ./ci/ci-compile

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,15 +11,15 @@ name: build
 jobs:
 
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: install python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
-          python-version: '3.8'
+          python-version: '3.10'
 
       - name: install platformio
         run: |


### PR DESCRIPTION
The build script used for checking all examples with PlatformIO is currently broken. It appears that this is due to the older version of PlatformIO being incompatible with the current platform packages.

This PR updates the packages used in the build script to their latest versions:

| Dependency           | From  | To     |
|----------------------|-------|--------|
| PlatformIO           | 5.03  | 6.1.4  |
| Python               | 3.8   | 3.10   |
| actions/checkout     | v2    | v3     |
| actions/setup-python | v2    | v4     |
| Ubuntu               | 20.04 | latest |

I ran the latest commit (637fac50a28d597e122678340a5cb07a1c766fdc) on my fork [here](https://github.com/dmadison/FastLED/runs/8145649975) and everything appears to be working swimmingly.