### PR TITLE
fixes https://github.com/FastLED/FastLED/issues/1457

### DIFF
--- a/src/fastpin.h
+++ b/src/fastpin.h
@@ -88,7 +88,7 @@ public:
 	/// Set the state of a port
 	/// @param port the port to modify
 	/// @param val the state to set the port to
-	inline void fastset(REGISTER port_ptr_t port, register port_t val) __attribute__ ((always_inline)) { *port  = val; }
+	inline void fastset(REGISTER port_ptr_t port, REGISTER port_t val) __attribute__((always_inline)) { *port = val; }
 
 	/// Gets the state of the port with this pin `HIGH`
 	port_t hival() __attribute__ ((always_inline)) { return *mPort | mPinMask;  }
@@ -237,7 +237,7 @@ public:
 	inline static void set(REGISTER port_t val) __attribute__ ((always_inline)) { *sPort = val; }
 
 	/// @copydoc Pin::fastset()
-	inline static void fastset(REGISTER port_ptr_t port, register port_t val) __attribute__ ((always_inline)) { *port  = val; }
+	inline static void fastset(REGISTER port_ptr_t port, REGISTER port_t val) __attribute__ ((always_inline)) { *port  = val; }
 
 	/// @copydoc Pin::hival()
 	static port_t hival() __attribute__ ((always_inline)) { return *sPort | sPinMask;  }
@@ -290,7 +290,7 @@ public:
 	inline static void set(REGISTER port_t val) __attribute__ ((always_inline)) { }
 
 	/// @copydoc Pin::fastset()
-	inline static void fastset(REGISTER port_ptr_t port, register port_t val) __attribute__ ((always_inline)) { }
+	inline static void fastset(REGISTER port_ptr_t port, REGISTER port_t val) __attribute__ ((always_inline)) { }
 
 	/// @copydoc Pin::hival()
 	static port_t hival() __attribute__ ((always_inline)) { return 0; }

--- a/src/fastspi_types.h
+++ b/src/fastspi_types.h
@@ -41,7 +41,7 @@ public:
     /// @param data input byte
     /// @param scale scale value
     /// @returns input byte rescaled using ::scale8(uint8_t, uint8_t)
-    static __attribute__((always_inline)) inline uint8_t adjust(REGISTER uint8_t data, register uint8_t scale) { return scale8(data, scale); }
+    static __attribute__((always_inline)) inline uint8_t adjust(REGISTER uint8_t data, REGISTER uint8_t scale) { return scale8(data, scale); }
 
     /// Hook called after a block of data is written to the output. 
     /// In this dummy version, no action is performed.


### PR DESCRIPTION
C++17 doesn't support the register keyword. This was already accounted for with the new `#define REGISTER`, however it wasn't applied everywhere. This pull request completes the migration in `fastpin.h` in order to address issue https://github.com/FastLED/FastLED/issues/1457