### PR TITLE
Fix narrowing conversion warnings on arm/sam platforms using toolchain-gccarmnoneeabi >= 1.90201.191206

### DIFF
--- a/src/platforms/arm/sam/fastpin_arm_sam.h
+++ b/src/platforms/arm/sam/fastpin_arm_sam.h
@@ -80,7 +80,7 @@ public:
 	template<int BIT> static __attribute__((always_inline)) inline ptr_reg32_t rx() { return GPIO_BITBAND_PTR(T, BIT); } };
 #define _FL_IO(L,C) _RD32(REG_PIO ## L ## _ODSR); _RD32(REG_PIO ## L ## _SODR); _RD32(REG_PIO ## L ## _CODR); _RD32(REG_PIO ## L ## _OER); _FL_DEFINE_PORT3(L, C, _R(REG_PIO ## L ## _ODSR));
 
-#define _FL_DEFPIN(PIN, BIT, L) template<> class FastPin<PIN> : public _DUEPIN<PIN, 1 << BIT, _R(REG_PIO ## L ## _ODSR), _R(REG_PIO ## L ## _SODR), _R(REG_PIO ## L ## _CODR), \
+#define _FL_DEFPIN(PIN, BIT, L) template<> class FastPin<PIN> : public _DUEPIN<PIN, 1U << BIT, _R(REG_PIO ## L ## _ODSR), _R(REG_PIO ## L ## _SODR), _R(REG_PIO ## L ## _CODR), \
   																			_R(GPIO ## L ## _OER)> {}; \
   								   template<> class FastPinBB<PIN> : public _DUEPIN_BITBAND<PIN, BIT, _R(REG_PIO ## L ## _ODSR), _R(REG_PIO ## L ## _SODR), _R(REG_PIO ## L ## _CODR), \
   																			_R(GPIO ## L ## _OER)> {};


### PR DESCRIPTION
This PR fixes a narrowing conversion warning when using [platformio/toolchain-gccarmnoneeabi](https://registry.platformio.org/tools/platformio/toolchain-gccarmnoneeabi) `>= 1.90201.191206` on [atmelsam](https://registry.platformio.org/platforms/platformio/atmelsam) platforms. This issue is the same as in #1418, but that only fixed the problem on `arm/mxrt1062` platforms; this resolved the issue on `arm/sam` platforms. Perhaps someone should go through the rest of the platform code to fix the same issue on other platforms, but that person isn't me. ;-)