### PR TITLE
fix missing ICACHE_RAM_ATTR change to IRAM_ATTR

### DIFF
--- a/src/platforms/esp/8266/clockless_block_esp8266.h
+++ b/src/platforms/esp/8266/clockless_block_esp8266.h
@@ -108,7 +108,7 @@ public:
 
   	// This method is made static to force making register Y available to use for data on AVR - if the method is non-static, then
 	// gcc will use register Y for the this pointer.
-	static uint32_t ICACHE_RAM_ATTR showRGBInternal(PixelController<RGB_ORDER, LANES, PORT_MASK> &allpixels) {
+	static uint32_t IRAM_ATTR showRGBInternal(PixelController<RGB_ORDER, LANES, PORT_MASK> &allpixels) {
 
 		// Setup the pixel controller and load/scale the first byte
 		Lines b0;


### PR DESCRIPTION
As requested by @samguyer her is the missing change from ICACHE_RAM_ATTR  to IRAM_ATTR.  

 