### PR TITLE
Include OctoWS2811.h if USE_OCTOWS2811 is defined

### DIFF
--- a/src/FastLED.h
+++ b/src/FastLED.h
@@ -43,6 +43,10 @@
 #include <DMXSerial.h>
 #endif
 
+#ifdef USE_OCTOWS2811
+#include <OctoWS2811.h>
+#endif
+
 #include <stdint.h>
 
 #include "cpp_compat.h"

--- a/src/platforms/arm/k20/octows2811_controller.h
+++ b/src/platforms/arm/k20/octows2811_controller.h
@@ -3,7 +3,7 @@
 
 #ifdef USE_OCTOWS2811
 
-// #include "OctoWS2811.h"
+#include "OctoWS2811.h"
 
 FASTLED_NAMESPACE_BEGIN
 

--- a/src/platforms/arm/mxrt1062/octows2811_controller.h
+++ b/src/platforms/arm/mxrt1062/octows2811_controller.h
@@ -3,7 +3,7 @@
 
 #ifdef USE_OCTOWS2811
 
-// #include "OctoWS2811.h"
+#include "OctoWS2811.h"
 
 FASTLED_NAMESPACE_BEGIN
 


### PR DESCRIPTION
This is a convenience in the style of the library already including SmartMatrix, DmxSimple, and DMXSerial. It avoids having to include the header every time FastLED.h is included; this can get tedious for a larger project.