### PR TITLE
Use correct cancel value for gpio_matrix_out on esp32c3

### DIFF
--- a/src/platforms/esp/32/clockless_rmt_esp32.cpp
+++ b/src/platforms/esp/32/clockless_rmt_esp32.cpp
@@ -343,8 +343,10 @@ void IRAM_ATTR ESP32RMTController::doneOnChannel(rmt_channel_t channel, void * a
     ESP32RMTController * pController = gOnChannel[channel];
 
     // -- Turn off output on the pin
-    // SZG: Do I really need to do this?
-    gpio_matrix_out(pController->mPin, 0x100, 0, 0);
+    //    Otherwise the pin will stay connected to the RMT controller,
+    //    and if the same RMT controller is used for another output
+    //    pin the RMT output will be routed to both pins.
+    gpio_matrix_out(pController->mPin, SIG_GPIO_OUT_IDX, 0, 0);
 
     // -- Turn off the interrupts
     // rmt_set_tx_intr_en(channel, false);


### PR DESCRIPTION
The documentation for gpio_matrix_out on esp32c3 is incorrect (https://github.com/espressif/esp-idf/issues/11737), and 0x80 needs to be used instead of 0x100.  Use SIG_GPIO_OUT_IDX, which has the correct value on all platforms.

Fixes #1498