### PR TITLE
Change documentation link to Doxygen

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
 <!--
                 <nav>
                     <ul>
-                <li><a href="https://github.com/FastLED/FastLED/wiki/Overview">Documentation</a></li>
+                <li><a href="http://fastled.io/docs">Documentation</a></li>
 
                 <li><a href="http://fastled.io/releases">Releases</a></li>
 
@@ -91,7 +91,7 @@
 <!--                    <h3>Links</h3>
 -->
                     <ul>
-                <li><a href="https://github.com/FastLED/FastLED/wiki/Overview">Documentation</a></li>
+                <li><a href="http://fastled.io/docs">Documentation</a></li>
 
                 <li><a href="http://fastled.io/releases">Releases</a></li>
 
@@ -118,7 +118,7 @@
 -->
 				
                 <p>
-                <a href="https://github.com/FastLED/FastLED/wiki/Overview">Documentation</a> &nbsp; &nbsp;
+                <a href="http://fastled.io/docs">Documentation</a> &nbsp; &nbsp;
 
                 <a href="http://fastled.io/releases">Releases</a> &nbsp; &nbsp;
 


### PR DESCRIPTION
Changes the "Documentation" navigation links to on the website to point to the generated Doxygen documentation rather than to the Wiki.