### PR TITLE
Improve OctoWS2811 driver

### DIFF
--- a/src/platforms/arm/k20/octows2811_controller.h
+++ b/src/platforms/arm/k20/octows2811_controller.h
@@ -9,9 +9,10 @@ FASTLED_NAMESPACE_BEGIN
 
 template<EOrder RGB_ORDER = GRB, uint8_t CHIP = WS2811_800kHz>
 class COctoWS2811Controller : public CPixelLEDController<RGB_ORDER, 8, 0xFF> {
+  void *framebuffer;
+  void *drawbuffer;
+  bool wantNullDrawBuffer;
   OctoWS2811 *pocto = nullptr;
-  uint8_t *drawbuffer = nullptr;
-  uint8_t *framebuffer = nullptr;
 
   bool tryToAllocate = true;
 
@@ -20,10 +21,14 @@ class COctoWS2811Controller : public CPixelLEDController<RGB_ORDER, 8, 0xFF> {
       // Allocate the draw buffer second in case the malloc fails,
       // because it can technically be NULL. In other words,
       // prioritize allocating the frame buffer.
-      framebuffer = static_cast<uint8_t *>(malloc(nLeds * 8 * 3));
+      if (framebuffer == nullptr) {
+        framebuffer = malloc(nLeds * 8 * 3);
+      }
 
       if (framebuffer != nullptr) {
-        drawbuffer = static_cast<uint8_t *>(malloc(nLeds * 8 * 3));
+        if (!wantNullDrawBuffer && drawbuffer == nullptr) {
+          drawbuffer = malloc(nLeds * 8 * 3);
+        }
         // Note: A NULL draw buffer is okay
 
         // byte ordering is handled in show by the pixel controller
@@ -45,7 +50,12 @@ class COctoWS2811Controller : public CPixelLEDController<RGB_ORDER, 8, 0xFF> {
     }
   }
 public:
-  COctoWS2811Controller() = default;
+  // If the frame buffer isn't NULL then the draw buffer won't be
+  // internally allocated.
+  COctoWS2811Controller(void *framebuf = nullptr, void *drawbuf = nullptr)
+      : framebuffer(framebuf),
+        drawbuffer(drawbuf),
+        wantNullDrawBuffer(framebuf != nullptr) {}
 
   virtual int size() { return CLEDController::size() * 8; }
 

--- a/src/platforms/arm/k20/octows2811_controller.h
+++ b/src/platforms/arm/k20/octows2811_controller.h
@@ -9,13 +9,14 @@ FASTLED_NAMESPACE_BEGIN
 
 template<EOrder RGB_ORDER = GRB, uint8_t CHIP = WS2811_800kHz>
 class COctoWS2811Controller : public CPixelLEDController<RGB_ORDER, 8, 0xFF> {
-  OctoWS2811  *pocto;
-  uint8_t *drawbuffer,*framebuffer;
+  OctoWS2811 *pocto = nullptr;
+  uint8_t *drawbuffer = nullptr;
+  uint8_t *framebuffer = nullptr;
 
   void _init(int nLeds) {
-    if(pocto == NULL) {
-      drawbuffer = (uint8_t*)malloc(nLeds * 8 * 3);
-      framebuffer = (uint8_t*)malloc(nLeds * 8 * 3);
+    if (pocto == nullptr) {
+      drawbuffer = static_cast<uint8_t *>(malloc(nLeds * 8 * 3));
+      framebuffer = static_cast<uint8_t *>(malloc(nLeds * 8 * 3));
 
       // byte ordering is handled in show by the pixel controller
       int config = WS2811_RGB;
@@ -27,7 +28,8 @@ class COctoWS2811Controller : public CPixelLEDController<RGB_ORDER, 8, 0xFF> {
     }
   }
 public:
-  COctoWS2811Controller() { pocto = NULL; }
+  COctoWS2811Controller() = default;
+
   virtual int size() { return CLEDController::size() * 8; }
 
   virtual void init() { /* do nothing yet */ }

--- a/src/platforms/arm/mxrt1062/octows2811_controller.h
+++ b/src/platforms/arm/mxrt1062/octows2811_controller.h
@@ -13,18 +13,35 @@ class COctoWS2811Controller : public CPixelLEDController<RGB_ORDER, 8, 0xFF> {
   uint8_t *drawbuffer = nullptr;
   uint8_t *framebuffer = nullptr;
 
+  bool tryToAllocate = true;
+
   void _init(int nLeds) {
-    if (pocto == nullptr) {
-      drawbuffer = static_cast<uint8_t *>(malloc(nLeds * 8 * 3));
+    if (pocto == nullptr && tryToAllocate) {
+      // Allocate the draw buffer second in case the malloc fails,
+      // because it can technically be NULL. In other words,
+      // prioritize allocating the frame buffer.
       framebuffer = static_cast<uint8_t *>(malloc(nLeds * 8 * 3));
 
-      // byte ordering is handled in show by the pixel controller
-      int config = WS2811_RGB;
-      config |= CHIP;
+      if (framebuffer != nullptr) {
+        drawbuffer = static_cast<uint8_t *>(malloc(nLeds * 8 * 3));
+        // Note: A NULL draw buffer is okay
 
-      pocto = new OctoWS2811(nLeds, framebuffer, drawbuffer, config);
+        // byte ordering is handled in show by the pixel controller
+        int config = WS2811_RGB;
+        config |= CHIP;
 
-      pocto->begin();
+        pocto = new OctoWS2811(nLeds, framebuffer, drawbuffer, config);
+
+        if (pocto != nullptr) {
+          pocto->begin();
+        } else {
+          // Don't try to allocate again
+          tryToAllocate = false;
+        }
+      } else {
+        // Don't try to allocate again
+        tryToAllocate = false;
+      }
     }
   }
 public:
@@ -38,6 +55,9 @@ public:
     uint32_t size = pixels.size();
     uint32_t sizeTimes8 = 8U * size;
     _init(size);
+    if (pocto == nullptr) {
+      return;
+    }
 
     uint32_t index = 0;
     while (pixels.has(1)) {

--- a/src/platforms/arm/mxrt1062/octows2811_controller.h
+++ b/src/platforms/arm/mxrt1062/octows2811_controller.h
@@ -9,9 +9,10 @@ FASTLED_NAMESPACE_BEGIN
 
 template<EOrder RGB_ORDER = GRB, uint8_t CHIP = WS2811_800kHz>
 class COctoWS2811Controller : public CPixelLEDController<RGB_ORDER, 8, 0xFF> {
+  void *framebuffer;
+  void *drawbuffer;
+  bool wantNullDrawBuffer;
   OctoWS2811 *pocto = nullptr;
-  uint8_t *drawbuffer = nullptr;
-  uint8_t *framebuffer = nullptr;
 
   bool tryToAllocate = true;
 
@@ -20,10 +21,14 @@ class COctoWS2811Controller : public CPixelLEDController<RGB_ORDER, 8, 0xFF> {
       // Allocate the draw buffer second in case the malloc fails,
       // because it can technically be NULL. In other words,
       // prioritize allocating the frame buffer.
-      framebuffer = static_cast<uint8_t *>(malloc(nLeds * 8 * 3));
+      if (framebuffer == nullptr) {
+        framebuffer = malloc(nLeds * 8 * 3);
+      }
 
       if (framebuffer != nullptr) {
-        drawbuffer = static_cast<uint8_t *>(malloc(nLeds * 8 * 3));
+        if (!wantNullDrawBuffer && drawbuffer == nullptr) {
+          drawbuffer = malloc(nLeds * 8 * 3);
+        }
         // Note: A NULL draw buffer is okay
 
         // byte ordering is handled in show by the pixel controller
@@ -45,7 +50,12 @@ class COctoWS2811Controller : public CPixelLEDController<RGB_ORDER, 8, 0xFF> {
     }
   }
 public:
-  COctoWS2811Controller() = default;
+  // If the frame buffer isn't NULL then the draw buffer won't be
+  // internally allocated.
+  COctoWS2811Controller(void *framebuf = nullptr, void *drawbuf = nullptr)
+      : framebuffer(framebuf),
+        drawbuffer(drawbuf),
+        wantNullDrawBuffer(framebuf != nullptr) {}
 
   virtual int size() { return CLEDController::size() * 8; }
 

--- a/src/platforms/arm/mxrt1062/octows2811_controller.h
+++ b/src/platforms/arm/mxrt1062/octows2811_controller.h
@@ -9,13 +9,14 @@ FASTLED_NAMESPACE_BEGIN
 
 template<EOrder RGB_ORDER = GRB, uint8_t CHIP = WS2811_800kHz>
 class COctoWS2811Controller : public CPixelLEDController<RGB_ORDER, 8, 0xFF> {
-  OctoWS2811  *pocto;
-  uint8_t *drawbuffer,*framebuffer;
+  OctoWS2811 *pocto = nullptr;
+  uint8_t *drawbuffer = nullptr;
+  uint8_t *framebuffer = nullptr;
 
   void _init(int nLeds) {
-    if(pocto == NULL) {
-      drawbuffer = (uint8_t*)malloc(nLeds * 8 * 3);
-      framebuffer = (uint8_t*)malloc(nLeds * 8 * 3);
+    if (pocto == nullptr) {
+      drawbuffer = static_cast<uint8_t *>(malloc(nLeds * 8 * 3));
+      framebuffer = static_cast<uint8_t *>(malloc(nLeds * 8 * 3));
 
       // byte ordering is handled in show by the pixel controller
       int config = WS2811_RGB;
@@ -27,7 +28,8 @@ class COctoWS2811Controller : public CPixelLEDController<RGB_ORDER, 8, 0xFF> {
     }
   }
 public:
-  COctoWS2811Controller() { pocto = NULL; }
+  COctoWS2811Controller() = default;
+
   virtual int size() { return CLEDController::size() * 8; }
 
   virtual void init() { /* do nothing yet */ }


### PR DESCRIPTION
These improvements include:
1. Some minor improvements for C++-isms,
2. Better handling for when there's low memory conditions so the system doesn't crash,
3. ~~Added a destructor for freeing the allocated memory, and~~
4. A way to use external buffers for the controller.

When there's low memory, the behaviour degrades gracefully. Firstly, the frame buffer is allocated first and the draw buffer is allocated next. Because a NULL draw buffer is allowed by the underlying OctoWS2811 driver, a failure to allocate it is okay. Second, if there's no frame buffer, then nothing else is allocated and `showPixels()` doesn't do anything. Same for an error allocating the OctoWS2811 driver.

Solving the potential system crash was necessary for a project of mine that let the user dynamically change a configuration. If the pixel count was too large, the memory allocation done in the original _Octo_ controller failed leading to a crash when `showPixels()` was eventually called. The system rebooted and didn't allow the user adjust the settings. Point number two solves this problem.

For the fourth point, the external buffers, that's very useful for a larger project of mine where I need to manage the memory externally. I use the `COctoWS2811Controller` controller directly. Note that the new parameters have defaults, meaning it’s optional to include them. This means that existing code won’t need to change.