### PR TITLE
fix missing check for Adafruit Grand Central Metro M4 in platform.h

### DIFF
--- a/src/platforms.h
+++ b/src/platforms.h
@@ -31,7 +31,7 @@
 #include "platforms/arm/stm32/fastled_arm_stm32.h"
 #elif defined(__SAMD21G18A__) || defined(__SAMD21J18A__) || defined(__SAMD21E17A__) || defined(__SAMD21E18A__)
 #include "platforms/arm/d21/fastled_arm_d21.h"
-#elif defined(__SAMD51G19A__) || defined(__SAMD51J19A__) || defined(__SAME51J19A__) || defined(__SAMD51P19A__)
+#elif defined(__SAMD51G19A__) || defined(__SAMD51J19A__) || defined(__SAME51J19A__) || defined(__SAMD51P19A__) || defined(__SAMD51P20A__)
 #include "platforms/arm/d51/fastled_arm_d51.h"
 #elif defined(ARDUINO_ARCH_RP2040) // not sure a pico-sdk define for this
 // RP2040 (Raspberry Pi Pico etc)


### PR DESCRIPTION
The Adafruit Grand Central Metro M4 (`__SAMD51P20A__`) was in [led_sysdefs.h](https://github.com/FastLED/FastLED/blob/2874c7c8eb13d99ec4ad9a3201054c387d2d8aaa/src/led_sysdefs.h#L34) but missing from [platforms.h](https://github.com/FastLED/FastLED/blob/2874c7c8eb13d99ec4ad9a3201054c387d2d8aaa/src/platforms.h#L34).

This should fix Issues #920 and #1071 and potentially #1531.