### PR TITLE
Update T1H and T0H timing to fix flicker on UNO R4

### DIFF
--- a/src/platforms/arm/renesas/clockless_arm_renesas.h
+++ b/src/platforms/arm/renesas/clockless_arm_renesas.h
@@ -48,10 +48,10 @@ protected:
 			next_mark = ARM_DWT_CYCCNT + (T1+T2+T3);
 			FastPin<DATA_PIN>::fastset(port, hi);
 			if(b&0x80) {
-				while((next_mark - ARM_DWT_CYCCNT) > (T3+(2*(F_CPU/24000000))));
+				while((next_mark - ARM_DWT_CYCCNT) > (T3+(4*(F_CPU/24000000))));
 				FastPin<DATA_PIN>::fastset(port, lo);
 			} else {
-				while((next_mark - ARM_DWT_CYCCNT) > (T2+T3+(2*(F_CPU/24000000))));
+				while((next_mark - ARM_DWT_CYCCNT) > (T2+T3+(4*(F_CPU/24000000))));
 				FastPin<DATA_PIN>::fastset(port, lo);
 			}
 			b <<= 1;
@@ -62,10 +62,10 @@ protected:
 		FastPin<DATA_PIN>::fastset(port, hi);
 
 		if(b&0x80) {
-			while((next_mark - ARM_DWT_CYCCNT) > (T3+(2*(F_CPU/24000000))));
+			while((next_mark - ARM_DWT_CYCCNT) > (T3+(4*(F_CPU/24000000))));
 			FastPin<DATA_PIN>::fastset(port, lo);
 		} else {
-			while((next_mark - ARM_DWT_CYCCNT) > (T2+T3+(2*(F_CPU/24000000))));
+			while((next_mark - ARM_DWT_CYCCNT) > (T2+T3+(4*(F_CPU/24000000))));
 			FastPin<DATA_PIN>::fastset(port, lo);
 		}
 	}


### PR DESCRIPTION
I found that the timing gave a flicker on WS2812 and WS2818 LED drivers, I think this is due to the T1H timing being >1050ns. The new timing puts the timing at ~800ns for T1H and ~340ns for T0L. This has been tested on genuine UNO R4 WiFi and Minima boards with WS2818B LED strips and WS2812B LED modules 