### PR TITLE
apply post gamma correction color scaling / brightness control

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Here's a list of all the LED chipsets are supported.  More details on the LED ch
 * WS2801 - SPI based chipset, cheap and widely available
 * SM16716 - SPI based chipset
 * APA102 - SPI based chipset
+  * APA102HD - Same as APA102 but with a high definition gamma correction function applied at the driver level.
 * P9813 - aka Cool Neon's Total Control Lighting
 * DMX - send rgb data out over DMX using Arduino DMX libraries
 * SmartMatrix panels - needs the SmartMatrix library (https://github.com/pixelmatix/SmartMatrix)

--- a/src/five_bit_hd_gamma.cpp
+++ b/src/five_bit_hd_gamma.cpp
@@ -1,13 +1,19 @@
 #include "FastLED.h"
 #include "five_bit_hd_gamma.h"
+#include "fastled_progmem.h"
+#include "lib8tion/scale8.h"
+
+// Author: Zach Vorhies
 
 #ifndef FASTLED_FIVE_BIT_HD_GAMMA_LOW_END_LINEAR_RAMP
-#define FASTLED_FIVE_BIT_HD_GAMMA_LOW_END_LINEAR_RAMP 1
+#define FASTLED_FIVE_BIT_HD_GAMMA_LOW_END_LINEAR_RAMP 0
 #endif
 
 FASTLED_NAMESPACE_BEGIN
 
 
+#ifndef FASTLED_FIVE_BIT_HD_GAMMA_FUNCTION_2_8
+// Fast a memory efficient gamma=2 function.
 __attribute__((weak)) 
 void five_bit_hd_gamma_function(
   uint8_t r8, uint8_t g8, uint8_t b8,
@@ -16,10 +22,48 @@ void five_bit_hd_gamma_function(
     *g16 = uint16_t(g8) * g8;
     *b16 = uint16_t(b8) * b8;
 }
+#else
+// Using look up table for gamma16 correction at power of 2.8
+static const uint16_t PROGMEM _gamma_2_8[256] = {
+    0,     0,     0,     1,     1,     2,     4,     6,     8,     11,    14,
+    18,    23,    29,    35,    41,    49,    57,    67,    77,    88,    99,
+    112,   126,   141,   156,   173,   191,   210,   230,   251,   274,   297,
+    322,   348,   375,   404,   433,   464,   497,   531,   566,   602,   640,
+    680,   721,   763,   807,   853,   899,   948,   998,   1050,  1103,  1158,
+    1215,  1273,  1333,  1394,  1458,  1523,  1590,  1658,  1729,  1801,  1875,
+    1951,  2029,  2109,  2190,  2274,  2359,  2446,  2536,  2627,  2720,  2816,
+    2913,  3012,  3114,  3217,  3323,  3431,  3541,  3653,  3767,  3883,  4001,
+    4122,  4245,  4370,  4498,  4627,  4759,  4893,  5030,  5169,  5310,  5453,
+    5599,  5747,  5898,  6051,  6206,  6364,  6525,  6688,  6853,  7021,  7191,
+    7364,  7539,  7717,  7897,  8080,  8266,  8454,  8645,  8838,  9034,  9233,
+    9434,  9638,  9845,  10055, 10267, 10482, 10699, 10920, 11143, 11369, 11598,
+    11829, 12064, 12301, 12541, 12784, 13030, 13279, 13530, 13785, 14042, 14303,
+    14566, 14832, 15102, 15374, 15649, 15928, 16209, 16493, 16781, 17071, 17365,
+    17661, 17961, 18264, 18570, 18879, 19191, 19507, 19825, 20147, 20472, 20800,
+    21131, 21466, 21804, 22145, 22489, 22837, 23188, 23542, 23899, 24260, 24625,
+    24992, 25363, 25737, 26115, 26496, 26880, 27268, 27659, 28054, 28452, 28854,
+    29259, 29667, 30079, 30495, 30914, 31337, 31763, 32192, 32626, 33062, 33503,
+    33947, 34394, 34846, 35300, 35759, 36221, 36687, 37156, 37629, 38106, 38586,
+    39071, 39558, 40050, 40545, 41045, 41547, 42054, 42565, 43079, 43597, 44119,
+    44644, 45174, 45707, 46245, 46786, 47331, 47880, 48432, 48989, 49550, 50114,
+    50683, 51255, 51832, 52412, 52996, 53585, 54177, 54773, 55374, 55978, 56587,
+    57199, 57816, 58436, 59061, 59690, 60323, 60960, 61601, 62246, 62896, 63549,
+    64207, 64869, 65535};
+
+__attribute__((weak)) void five_bit_hd_gamma_function(uint8_t r8, uint8_t g8,
+                                                      uint8_t b8, uint16_t *r16,
+                                                      uint16_t *g16,
+                                                      uint16_t *b16) {
+  *r16 = _gamma_2_8[r8];
+  *g16 = _gamma_2_8[g8];
+  *b16 = _gamma_2_8[b8];
+}
+#endif
 
 __attribute__((weak))
 void five_bit_hd_gamma_bitshift(
     uint8_t r8, uint8_t g8, uint8_t b8,
+    uint8_t r8_scale, uint8_t g8_scale, uint8_t b8_scale,
     uint8_t* out_r8,
     uint8_t* out_g8,
     uint8_t* out_b8,
@@ -29,7 +73,14 @@ void five_bit_hd_gamma_bitshift(
     uint16_t r16, g16, b16;
     five_bit_hd_gamma_function(r8, g8, b8, &r16, &g16, &b16);
 
-    // Step 2: Initialize 5-bit brightness.
+    // Step 2: Post gamma correction scale.
+    if (r8_scale != 0xff || g8_scale != 0xff || b8_scale != 0xff) {
+      r16 = scale16by8(r16, r8_scale);
+      g16 = scale16by8(g16, g8_scale);
+      b16 = scale16by8(b16, b8_scale);
+    }
+
+    // Step 3: Initialize 5-bit brightness.
     // Note: we only get 5 levels of brightness
     uint8_t v8 = 31;
 
@@ -39,7 +90,7 @@ void five_bit_hd_gamma_bitshift(
     const uint32_t g16_const = g16;
     const uint32_t b16_const = b16;
 
-    // Step 3: Bit Shifting Loop, can probably replaced with a
+    // Step 4: Bit Shifting Loop, can probably replaced with a
     // single pass bit-twiddling hack.
     do {
         // Note that to avoid slow divisions, we multiply the max_value
@@ -104,28 +155,28 @@ void five_bit_hd_gamma_bitshift(
     g16 = uint16_t(g16_const * numerator / denominator);
     b16 = uint16_t(b16_const * numerator / denominator);
 
-    // Step 4: Conversion Back to 8-bit.
+    // Step 5: Conversion Back to 8-bit.
     uint8_t r8_final = (r8 == 255 && uint8_t(r16 >> 8) >= 254) ? 255 : uint8_t(r16 >> 8);
     uint8_t g8_final = (g8 == 255 && uint8_t(g16 >> 8) >= 254) ? 255 : uint8_t(g16 >> 8);
     uint8_t b8_final = (b8 == 255 && uint8_t(b16 >> 8) >= 254) ? 255 : uint8_t(b16 >> 8);
 
-#if FASTLED_FIVE_BIT_HD_GAMMA_LOW_END_LINEAR_RAMP == 1
+#if FASTLED_FIVE_BIT_HD_GAMMA_LOW_END_LINEAR_RAMP > 0
     if (v8 == 1) {
       // Linear tuning for the lowest possible brightness. x=y until
       // the intersection point at 9.
-      if (r8 < 9 && r16 > 0) {
+      if (r8 < FASTLED_FIVE_BIT_HD_GAMMA_LOW_END_LINEAR_RAMP && r16 > 0) {
         r8_final = r8;
       }
-      if (g8 < 9 && g16 > 0) {
+      if (g8 < FASTLED_FIVE_BIT_HD_GAMMA_LOW_END_LINEAR_RAMP && g16 > 0) {
         g8_final = g8;
       }
-      if (b8 < 9 && b16 > 0) {
+      if (b8 < FASTLED_FIVE_BIT_HD_GAMMA_LOW_END_LINEAR_RAMP && b16 > 0) {
         b8_final = b8;
       }
     }
 #endif
 
-    // Step 5: Output
+    // Step 6: Output
     *out_r8 = r8_final;
     *out_g8 = g8_final;
     *out_b8 = b8_final;

--- a/src/five_bit_hd_gamma.h
+++ b/src/five_bit_hd_gamma.h
@@ -18,6 +18,7 @@ enum FiveBitGammaCorrectionMode {
 //  FASTLED_NAMESPACE_BEGIN
 //  void five_bit_hd_gamma_bitshift(
 //      uint8_t r8, uint8_t g8, uint8_t b8,
+//      uint8_t r8_scale, uint8_t g8_scale, uint8_t b8_scale,
 //      uint8_t* out_r8,
 //      uint8_t* out_g8,
 //      uint8_t* out_b8,
@@ -27,6 +28,7 @@ enum FiveBitGammaCorrectionMode {
 //  FASTLED_NAMESPACE_END
 void five_bit_hd_gamma_bitshift(
     uint8_t r8, uint8_t g8, uint8_t b8,
+    uint8_t r8_scale, uint8_t g8_scale, uint8_t b8_scale,
     uint8_t* out_r8,
     uint8_t* out_g8,
     uint8_t* out_b8,


### PR DESCRIPTION
Real-world testing shows that the ordering between the gamma correction and color correction is wrong.

This cl fixes this and has other tweaks.

## Demo of Fixed Color Mapping

This demo demonstrates how the colors are able to hold together, even with conservative power settings (5v @ 5amp power supply). Although some of the frames look white, that is camera sensor saturation and it looks more saturated in the real world.

https://github.com/FastLED/FastLED/assets/6856673/5945fed6-5ea5-437a-bad6-1cb0cce0dd2b


## Fixes `FastLED.setMaxPowerInVoltsAndMilliamps(...);`

This function made the leds appear washed out and desaturated. This becomes apparent as the power control is applied, which triggers the scaling down of colors.

## Fix - Post gamma correction scaling

![image](https://github.com/FastLED/FastLED/assets/6856673/0befe421-75fc-4a12-8f8b-6368d2e40b33)

# Other changes:

  * APA102HD now longer uses GLOBAL_BRIGHTNESS, as it was causing problems and is redundant with `five_bit_hd_gamma_bitshift()` anyway
    * APA102 - no code/behavior change
    * Optional gamma = 2.8 uint16_t lookup table is provided
      * `#define FASTLED_FIVE_BIT_HD_GAMMA_FUNCTION_2_8`
      * Platformio:  `-DFASTLED_FIVE_BIT_HD_GAMMA_FUNCTION_2_8` in your `build_src_flags
```
build_src_flags = 
  -DFASTLED_FIVE_BIT_HD_GAMMA_FUNCTION_2_8
```

  * `FASTLED_FIVE_BIT_HD_GAMMA_LOW_END_LINEAR_RAMP` is now disabled by default. The value now represents the linear -> gamma ramp intersection index.
  
 