### PR TITLE
feat: option to disable M0 clockless fallback on RP2040

### DIFF
--- a/src/platforms/arm/rp2040/clockless_arm_rp2040.h
+++ b/src/platforms/arm/rp2040/clockless_arm_rp2040.h
@@ -2,7 +2,10 @@
 #define __INC_CLOCKLESS_ARM_RP2040
 
 #include "hardware/structs/sio.h"
+
+#if FASTLED_RP2040_CLOCKLESS_M0_FALLBACK || !FASTLED_RP2040_CLOCKLESS_PIO
 #include "../common/m0clockless.h"
+#endif
 
 #if FASTLED_RP2040_CLOCKLESS_PIO
 #include "hardware/clocks.h"
@@ -221,7 +224,9 @@ public:
     virtual void showPixels(PixelController<RGB_ORDER> & pixels) {
 #if FASTLED_RP2040_CLOCKLESS_PIO
         if (dma_channel == -1) { // setup failed, so fall back to a blocking implementation
+#if FASTLED_RP2040_CLOCKLESS_M0_FALLBACK
             showRGBBlocking(pixels);
+#endif
             return;
         }
         
@@ -292,6 +297,7 @@ public:
     }
 #endif // FASTLED_RP2040_CLOCKLESS_PIO
     
+#if FASTLED_RP2040_CLOCKLESS_M0_FALLBACK
     void showRGBBlocking(PixelController<RGB_ORDER> pixels) {
         struct M0ClocklessData data;
         data.d[0] = pixels.d[0];
@@ -314,6 +320,7 @@ public:
         showLedData<portSetOff, portClrOff, T1, T2, T3, RGB_ORDER, WAIT_TIME>(portBase, pin::mask(), pixels.mData, pixels.mLen, &data);
         sei();
     }
+#endif
 
 };
 

--- a/src/platforms/arm/rp2040/led_sysdefs_arm_rp2040.h
+++ b/src/platforms/arm/rp2040/led_sysdefs_arm_rp2040.h
@@ -66,6 +66,11 @@ typedef volatile uint32_t RwReg;
 #define FASTLED_RP2040_CLOCKLESS_IRQ_SHARED 1
 #endif
 
+// Default to disabling M0 assembly clockless implementation
+#ifndef FASTLED_RP2040_CLOCKLESS_M0_FALLBACK
+#define FASTLED_RP2040_CLOCKLESS_M0_FALLBACK 1
+#endif
+
 // SPI pin defs for old SDK ver
 #ifndef PICO_DEFAULT_SPI
 #define PICO_DEFAULT_SPI 0


### PR DESCRIPTION
Fixes: #1481, #1571

When building for RP2040, at least with -O3 optimizations and the arduino-pico core, the M0 clockless assembly code fails to be assembled for RP2040. This code is only included to be used as a fallback if it fails to claim a DMA channel, which is an undesirable situation to be in anyway.

To keep everyone happy, I've added an option `FASTLED_RP2040_CLOCKLESS_M0_FALLBACK` which is 1 by default but can be set to 0 to disable this fallback and skip compiling `m0clockless.h`. This means the default behaviour remains the same (not breaking backwards compatibility), but gives users the ability to disable the fallback if it's causing them issues.