### PR TITLE
Silence -Wstack-usage for noise.cpp

### DIFF
--- a/src/noise.cpp
+++ b/src/noise.cpp
@@ -6,6 +6,8 @@
 #include "FastLED.h"
 #include <string.h>
 
+// Compiler throws a warning about stack usage possibly being unbounded even
+// though bounds are checked, silence that so users don't see it
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wstack-usage="
 

--- a/src/noise.cpp
+++ b/src/noise.cpp
@@ -861,4 +861,4 @@ void fill_2dnoise16(CRGB *leds, int width, int height, bool serpentine,
 
 FASTLED_NAMESPACE_END
 
-#pragma GCC diagnostic push
+#pragma GCC diagnostic pop

--- a/src/noise.cpp
+++ b/src/noise.cpp
@@ -6,6 +6,9 @@
 #include "FastLED.h"
 #include <string.h>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstack-usage="
+
 FASTLED_NAMESPACE_BEGIN
 
 /// Reads a single byte from the p array
@@ -855,3 +858,5 @@ void fill_2dnoise16(CRGB *leds, int width, int height, bool serpentine,
 }
 
 FASTLED_NAMESPACE_END
+
+#pragma GCC diagnostic push


### PR DESCRIPTION
The `fill_...()` functions in `noise.cpp` trigger "warning: stack usage 
might be unbounded [-Wstack-usage=]" if you have -Wstack-usage enabled. There clearly are bound checks in the code, so this warning should be suppressed.