### PR TITLE
Fixes five_bit_gamma - scale16b8 global fix for brightness == 0 and improve user overrides

### DIFF
--- a/src/five_bit_hd_gamma.cpp
+++ b/src/five_bit_hd_gamma.cpp
@@ -11,10 +11,9 @@
 
 FASTLED_NAMESPACE_BEGIN
 
-
+#ifndef FASTLED_FIVE_BIT_HD_GAMMA_BITSHIFT_FUNCTION_OVERRIDE
 #ifndef FASTLED_FIVE_BIT_HD_GAMMA_FUNCTION_2_8
 // Fast a memory efficient gamma=2 function.
-__attribute__((weak)) 
 void five_bit_hd_gamma_function(
   uint8_t r8, uint8_t g8, uint8_t b8,
   uint16_t* r16, uint16_t* g16, uint16_t* b16) {
@@ -50,17 +49,19 @@ static const uint16_t PROGMEM _gamma_2_8[256] = {
     57199, 57816, 58436, 59061, 59690, 60323, 60960, 61601, 62246, 62896, 63549,
     64207, 64869, 65535};
 
-__attribute__((weak)) void five_bit_hd_gamma_function(uint8_t r8, uint8_t g8,
-                                                      uint8_t b8, uint16_t *r16,
-                                                      uint16_t *g16,
-                                                      uint16_t *b16) {
+void five_bit_hd_gamma_function(uint8_t r8, uint8_t g8,
+                                uint8_t b8, uint16_t *r16,
+                                uint16_t *g16,
+                                uint16_t *b16) {
   *r16 = _gamma_2_8[r8];
   *g16 = _gamma_2_8[g8];
   *b16 = _gamma_2_8[b8];
 }
-#endif
+#endif  // FASTLED_FIVE_BIT_HD_GAMMA_FUNCTION_2_8
+#endif  // FASTLED_FIVE_BIT_HD_GAMMA_BITSHIFT_FUNCTION_OVERRIDE
 
-__attribute__((weak))
+#ifndef FASTLED_FIVE_BIT_HD_BITSHIFT_FUNCTION_OVERRIDE
+
 void five_bit_hd_gamma_bitshift(
     uint8_t r8, uint8_t g8, uint8_t b8,
     uint8_t r8_scale, uint8_t g8_scale, uint8_t b8_scale,
@@ -182,5 +183,7 @@ void five_bit_hd_gamma_bitshift(
     *out_b8 = b8_final;
     *out_power_5bit = v8;
 }
+
+#endif // FASTLED_FIVE_BIT_HD_BITSHIFT_FUNCTION_OVERRIDE
 
 FASTLED_NAMESPACE_END

--- a/src/five_bit_hd_gamma.h
+++ b/src/five_bit_hd_gamma.h
@@ -12,8 +12,9 @@ enum FiveBitGammaCorrectionMode {
 
 // Applies gamma correction for the RGBV(8, 8, 8, 5) color space, where
 // the last byte is the brightness byte at 5 bits.
-// To override this five_bit_hd_gamma_bitshift function just define
-// your own version anywhere in your project.
+// To override this five_bit_hd_gamma_bitshift you'll need to define
+// FASTLED_FIVE_BIT_HD_BITSHIFT_FUNCTION_OVERRIDE in your build settings
+// then define the function anywhere in your project.
 // Example:
 //  FASTLED_NAMESPACE_BEGIN
 //  void five_bit_hd_gamma_bitshift(
@@ -26,19 +27,32 @@ enum FiveBitGammaCorrectionMode {
 //        cout << "hello world\n";
 //  }
 //  FASTLED_NAMESPACE_END
+
+#ifdef FASTLED_FIVE_BIT_HD_BITSHIFT_FUNCTION_OVERRIDE
+// This function is located somewhere else in your project, so it's declared
+// extern here.
+extern void five_bit_hd_gamma_bitshift(
+		uint8_t r8, uint8_t g8, uint8_t b8,
+		uint8_t r8_scale, uint8_t g8_scale, uint8_t b8_scale,
+		uint8_t* out_r8,
+		uint8_t* out_g8,
+		uint8_t* out_b8,
+		uint8_t* out_power_5bit);
+#else
 void five_bit_hd_gamma_bitshift(
     uint8_t r8, uint8_t g8, uint8_t b8,
     uint8_t r8_scale, uint8_t g8_scale, uint8_t b8_scale,
     uint8_t* out_r8,
     uint8_t* out_g8,
     uint8_t* out_b8,
-    uint8_t* out_power_5bit)  __attribute__((weak));
+    uint8_t* out_power_5bit);
+#endif  // FASTLED_FIVE_BIT_HD_BITSHIFT_FUNCTION_OVERRIDE
 
 // Simple gamma correction function that converts from
 // 8-bit color component and converts it to gamma corrected 16-bit
 // color component. Fast and no memory overhead!
-// To override this function just define your own version
-// anywhere in your project.
+// To override this function you'll need to define FASTLED_FIVE_BIT_HD_GAMMA_BITSHIFT_FUNCTION_OVERRIDE
+// in your build settings and then define your own version anywhere in your project.
 // Example:
 //  FASTLED_NAMESPACE_BEGIN
 //  void five_bit_hd_gamma_function(
@@ -47,10 +61,17 @@ void five_bit_hd_gamma_bitshift(
 //      cout << "hello world\n";
 //  }
 //  FASTLED_NAMESPACE_END
+#ifdef FASTLED_FIVE_BIT_HD_GAMMA_FUNCTION_OVERRIDE
+// This function is located somewhere else in your project, so it's declared
+// extern here.
+extern void five_bit_hd_gamma_function(
+	uint8_t r8, uint8_t g8, uint8_t b8,
+	uint16_t* r16, uint16_t* g16, uint16_t* b16);
+#else
 void five_bit_hd_gamma_function(
   uint8_t r8, uint8_t g8, uint8_t b8,
-  uint16_t* r16, uint16_t* g16, uint16_t* b16)  __attribute__((weak));
-
+  uint16_t* r16, uint16_t* g16, uint16_t* b16);
+#endif	// FASTLED_FIVE_BIT_HD_GAMMA_FUNCTION_OVERRIDE
 FASTLED_NAMESPACE_END
 
 #endif // _FIVE_BIT_HD_GAMMA_H_

--- a/src/lib8tion/scale8.h
+++ b/src/lib8tion/scale8.h
@@ -471,9 +471,18 @@ LIB8STATIC void nscale8x2_video( uint8_t& i, uint8_t& j, fract8 scale)
 /// @returns scaled value
 LIB8STATIC_ALWAYS_INLINE uint16_t scale16by8( uint16_t i, fract8 scale )
 {
+	  if (scale == 0) {
+			// FASTLED_SCALE8_FIXED == 1 has problems with scale == 0,
+			// so we just fast out here.
+			return 0;
+		}
 #if SCALE16BY8_C == 1
     uint16_t result;
 #if FASTLED_SCALE8_FIXED == 1
+		// Note that FASTLED_SCALE8_FIXED is documented to recommend
+		// to include +1 allows so that scale8(255,255) will result in 255.
+		// It's assumed that this also allows scale16by8(65535,255) to result
+		// in 65535.
     result = (i * (1+((uint16_t)scale))) >> 8;
 #else
     result = (i * scale) / 256;


### PR DESCRIPTION
This is a follow up CL to fix five_bit_gamma brightness when brightness == 0 and also to improve user overrides in platformio. This was found while using the Teensy 4.1 platform.

# brightness == 0

It turns out that `uint16_t scale16by8( uint16_t i, fract8 scale )` doesn't work correctly when scale==0 and `FASTLED_SCALE8_FIXED == 1`, which is the case with Teensy 4.1.

This is because there is a +1 that is added on to the scaling factor so that scale16by8(0xffff, 0xff) == 0xffff (well, at least that's the documentation for `scale8(...)`, I'm not sure it applies to `scale16by8(...)`, but I assume it does). However this factor results in a non zero value when using `scale16b8(i, 0)`.

Therefore, an early test is performed where if scale == 0, then zero is immediately returned.

To be honest, I could have fixed this in just my own code but this seems to be a bug that could affect other clients so it's probably better that the fix to `scale16by8` is applied globally.

# improve user override

It turns out that platformio doesn't do static linking in the correct order to allow a strong symbol in client code to override a weak symbol in the fastled library. Therefore I've added two `#define` statements that turn on user override by conditionally declaring `five_bit_hd_gamma_function()` and `five_bit_hd_gamma_bitshift()` as extern functions. Now if the user doesn't define these replacement functions then this will result in a linker error, but only if the proper defines are entered into the build system. The defines are:

  * `FASTLED_FIVE_BIT_HD_BITSHIFT_FUNCTION_OVERRIDE`
  * `FASTLED_FIVE_BIT_HD_GAMMA_FUNCTION_OVERRIDE`