### PR TITLE
fixes scale16by8 when scale == 0 and FASTLED_SCALE8_FIXED == 1

### DIFF
--- a/src/lib8tion/scale8.h
+++ b/src/lib8tion/scale8.h
@@ -471,6 +471,9 @@ LIB8STATIC void nscale8x2_video( uint8_t& i, uint8_t& j, fract8 scale)
 /// @returns scaled value
 LIB8STATIC_ALWAYS_INLINE uint16_t scale16by8( uint16_t i, fract8 scale )
 {
+    if (scale == 0) {
+			return 0;  // Fixes non zero output when scale == 0 and FASTLED_SCALE8_FIXED==1
+		}
 #if SCALE16BY8_C == 1
     uint16_t result;
 #if FASTLED_SCALE8_FIXED == 1


### PR DESCRIPTION
This function was messing up the APA102HD mode on Teensy 4.1 when brightness == 0.