### PR TITLE
Fixes apa102HD five bit gamma override on Teensy 4.1 on platformio, others

### DIFF
--- a/src/five_bit_hd_gamma.cpp
+++ b/src/five_bit_hd_gamma.cpp
@@ -11,10 +11,9 @@
 
 FASTLED_NAMESPACE_BEGIN
 
-
+#ifndef FASTLED_FIVE_BIT_HD_GAMMA_BITSHIFT_FUNCTION_OVERRIDE
 #ifndef FASTLED_FIVE_BIT_HD_GAMMA_FUNCTION_2_8
 // Fast a memory efficient gamma=2 function.
-__attribute__((weak)) 
 void five_bit_hd_gamma_function(
   uint8_t r8, uint8_t g8, uint8_t b8,
   uint16_t* r16, uint16_t* g16, uint16_t* b16) {
@@ -50,17 +49,19 @@ static const uint16_t PROGMEM _gamma_2_8[256] = {
     57199, 57816, 58436, 59061, 59690, 60323, 60960, 61601, 62246, 62896, 63549,
     64207, 64869, 65535};
 
-__attribute__((weak)) void five_bit_hd_gamma_function(uint8_t r8, uint8_t g8,
-                                                      uint8_t b8, uint16_t *r16,
-                                                      uint16_t *g16,
-                                                      uint16_t *b16) {
+void five_bit_hd_gamma_function(uint8_t r8, uint8_t g8,
+                                uint8_t b8, uint16_t *r16,
+                                uint16_t *g16,
+                                uint16_t *b16) {
   *r16 = _gamma_2_8[r8];
   *g16 = _gamma_2_8[g8];
   *b16 = _gamma_2_8[b8];
 }
-#endif
+#endif  // FASTLED_FIVE_BIT_HD_GAMMA_FUNCTION_2_8
+#endif  // FASTLED_FIVE_BIT_HD_GAMMA_BITSHIFT_FUNCTION_OVERRIDE
 
-__attribute__((weak))
+#ifndef FASTLED_FIVE_BIT_HD_BITSHIFT_FUNCTION_OVERRIDE
+
 void five_bit_hd_gamma_bitshift(
     uint8_t r8, uint8_t g8, uint8_t b8,
     uint8_t r8_scale, uint8_t g8_scale, uint8_t b8_scale,
@@ -182,5 +183,7 @@ void five_bit_hd_gamma_bitshift(
     *out_b8 = b8_final;
     *out_power_5bit = v8;
 }
+
+#endif // FASTLED_FIVE_BIT_HD_BITSHIFT_FUNCTION_OVERRIDE
 
 FASTLED_NAMESPACE_END

--- a/src/five_bit_hd_gamma.h
+++ b/src/five_bit_hd_gamma.h
@@ -12,8 +12,9 @@ enum FiveBitGammaCorrectionMode {
 
 // Applies gamma correction for the RGBV(8, 8, 8, 5) color space, where
 // the last byte is the brightness byte at 5 bits.
-// To override this five_bit_hd_gamma_bitshift function just define
-// your own version anywhere in your project.
+// To override this five_bit_hd_gamma_bitshift you'll need to define
+// FASTLED_FIVE_BIT_HD_BITSHIFT_FUNCTION_OVERRIDE in your build settings
+// then define the function anywhere in your project.
 // Example:
 //  FASTLED_NAMESPACE_BEGIN
 //  void five_bit_hd_gamma_bitshift(
@@ -26,19 +27,32 @@ enum FiveBitGammaCorrectionMode {
 //        cout << "hello world\n";
 //  }
 //  FASTLED_NAMESPACE_END
+
+#ifdef FASTLED_FIVE_BIT_HD_BITSHIFT_FUNCTION_OVERRIDE
+// This function is located somewhere else in your project, so it's declared
+// extern here.
+extern void five_bit_hd_gamma_bitshift(
+		uint8_t r8, uint8_t g8, uint8_t b8,
+		uint8_t r8_scale, uint8_t g8_scale, uint8_t b8_scale,
+		uint8_t* out_r8,
+		uint8_t* out_g8,
+		uint8_t* out_b8,
+		uint8_t* out_power_5bit);
+#else
 void five_bit_hd_gamma_bitshift(
     uint8_t r8, uint8_t g8, uint8_t b8,
     uint8_t r8_scale, uint8_t g8_scale, uint8_t b8_scale,
     uint8_t* out_r8,
     uint8_t* out_g8,
     uint8_t* out_b8,
-    uint8_t* out_power_5bit)  __attribute__((weak));
+    uint8_t* out_power_5bit);
+#endif  // FASTLED_FIVE_BIT_HD_BITSHIFT_FUNCTION_OVERRIDE
 
 // Simple gamma correction function that converts from
 // 8-bit color component and converts it to gamma corrected 16-bit
 // color component. Fast and no memory overhead!
-// To override this function just define your own version
-// anywhere in your project.
+// To override this function you'll need to define FASTLED_FIVE_BIT_HD_GAMMA_BITSHIFT_FUNCTION_OVERRIDE
+// in your build settings and then define your own version anywhere in your project.
 // Example:
 //  FASTLED_NAMESPACE_BEGIN
 //  void five_bit_hd_gamma_function(
@@ -47,10 +61,17 @@ void five_bit_hd_gamma_bitshift(
 //      cout << "hello world\n";
 //  }
 //  FASTLED_NAMESPACE_END
+#ifdef FASTLED_FIVE_BIT_HD_GAMMA_FUNCTION_OVERRIDE
+// This function is located somewhere else in your project, so it's declared
+// extern here.
+extern void five_bit_hd_gamma_function(
+	uint8_t r8, uint8_t g8, uint8_t b8,
+	uint16_t* r16, uint16_t* g16, uint16_t* b16);
+#else
 void five_bit_hd_gamma_function(
   uint8_t r8, uint8_t g8, uint8_t b8,
-  uint16_t* r16, uint16_t* g16, uint16_t* b16)  __attribute__((weak));
-
+  uint16_t* r16, uint16_t* g16, uint16_t* b16);
+#endif	// FASTLED_FIVE_BIT_HD_GAMMA_FUNCTION_OVERRIDE
 FASTLED_NAMESPACE_END
 
 #endif // _FIVE_BIT_HD_GAMMA_H_


### PR DESCRIPTION
# Background

It turns out that weak symbol override doesn't work on Teensy 4.1 and platformio. This has been documented and has something to do with the order of linking.

# Fix

This CL fixes this by using `#define FASTLED_FIVE_BIT_HD_GAMMA_BITSHIFT_FUNCTION_OVERRIDE` and  `#define FASTLED_FIVE_BIT_HD_BITSHIFT_FUNCTION_OVERRIDE` to force extern linking in the FastLED library. This means that if the user doesn't define their own function override then there will be a linker error, rather than silently fail to bind to the strong symbol, which was what was happening before.