### PR TITLE
reduces the time it takes to build from 12 mins to 2.5 (on Windows 10,12-core)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,9 +21,9 @@ jobs:
         with:
           python-version: '3.10'
 
-      - name: install platformio
+      - name: Install platformio build dependencies
         run: |
-          pip install platformio==6.1.4
+          pip install -r ci/requirements.txt
 
-      - name: build FastLED examples
-        run: ./ci/ci-compile
+      - name: Build FastLED examples
+        run: python ./ci/ci-compile.py

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /docs/html
 /docs/latex
 /docs/doxygen-awesome-css
+.build/

--- a/ci/ci-compile
+++ b/ci/ci-compile
@@ -1,38 +1,6 @@
 #!/bin/bash
-#
-# compile FastLED examples with platformio for various boards. This script
-# is usually run by the CI, but can also be run locally. Only dependency
-# is platformio.
-#
-# usage:
-#   [BOARDS=boards] [EXAMPLES=examples] ./ci-compile
-#
-# e.g.
-#  $ ./compile-ci
-#         - compile all board/examples combinations
-#
-#  $ BOARDS="esp32 esp01" EXAMPLES=Blink ./compile-ci
-#         - compile only Blink example for the esp32 and esp8266 platforms
-#
-set -eou pipefail
 
-# List of examples that will be compiled by default
-EXAMPLES=${EXAMPLES:-"Apa102HD Blink ColorPalette ColorTemperature Cylon DemoReel100
-    Fire2012  FirstLight  Multiple/MultipleStripsInOneArray
-    Multiple/ArrayOfLedArrays Noise NoisePlayground NoisePlusPalette Pacifica
-    Pride2015 RGBCalibrate RGBSetDemo TwinkleFox XYMatrix"}
+# cd to the directory of the script
+cd "$(dirname "$0")"
 
-# list of boards to compile for by default
-BOARDS=${BOARDS:-"uno esp32dev esp01 yun digix teensy30"}
-
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-BOARD_OPTS=$(for b in $BOARDS; do echo -n "--board $b "; done)
-
-cd "$DIR/.."
-
-export PLATFORMIO_EXTRA_SCRIPTS="pre:lib/ci/ci-flags.py"
-
-for d in $EXAMPLES ; do
-  echo "*** building example $d for $BOARDS ***"
-  pio ci $BOARD_OPTS --lib=ci --lib=src "examples/$d/"*ino
-done
+python ci-compile.py

--- a/ci/ci-compile.py
+++ b/ci/ci-compile.py
@@ -1,0 +1,148 @@
+"""
+Runs the compilation process for all examples on all boards in parallel.
+Build artifacts are recycled within a board group so that subsequent ino
+files are built faster.
+"""
+
+import os
+import sys
+import subprocess
+import concurrent.futures
+import time
+from pathlib import Path
+from threading import Lock
+
+ERROR_HAPPENED = False
+FIRST_JOB_LOCK = Lock()
+IS_GITHUB = "GITHUB_WORKFLOW" in os.environ
+
+
+EXAMPLES = [
+    "Apa102HD",
+    "Blink",
+    "ColorPalette",
+    "ColorTemperature",
+    "Cylon",
+    "DemoReel100",
+    "Fire2012",
+    "FirstLight",
+    "Multiple/MultipleStripsInOneArray",
+    "Multiple/ArrayOfLedArrays",
+    "Noise",
+    "NoisePlayground",
+    "NoisePlusPalette",
+    "Pacifica",
+    "Pride2015",
+    "RGBCalibrate",
+    "RGBSetDemo",
+    "TwinkleFox",
+    "XYMatrix",
+]
+
+BOARDS = ["uno", "esp32dev", "esp01", "yun", "digix", "teensy30"]
+PRINT_LOCK = Lock()
+
+
+def locked_print(*args, **kwargs):
+    """Print with a lock to prevent garbled output for multiple threads."""
+    with PRINT_LOCK:
+        print(*args, **kwargs)
+
+
+def compile_for_board_and_example(board: str, example: str):
+    """Compile the given example for the given board."""
+    builddir = Path(".build") / board
+    builddir = builddir.absolute()
+    builddir.mkdir(parents=True, exist_ok=True)
+    srcdir = builddir / "src"
+    # Remove the previous *.ino file if it exists, everything else is recycled
+    # to speed up the next build.
+    if srcdir.exists():
+        subprocess.run(["rm", "-rf", str(srcdir)], check=True)
+
+    locked_print(f"*** Building example {example} for board {board} ***")
+    result = subprocess.run(
+        [
+            "pio",
+            "ci",
+            "--board",
+            board,
+            "--lib=ci",
+            "--lib=src",
+            "--keep-build-dir",
+            f"--build-dir={builddir}",
+            f"examples/{example}/*ino",
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        check=False,
+    )
+
+    locked_print(result.stdout)
+    if result.returncode != 0:
+        locked_print(f"*** Error compiling example {example} for board {board} ***")
+        return False
+    locked_print(f"*** Finished building example {example} for board {board} ***")
+    return True
+
+
+# Function to process task queues for each board
+def process_queue(board: str, examples: list[str]):
+    """Process the task queue for the given board."""
+    global ERROR_HAPPENED  # pylint: disable=global-statement
+    is_first = True
+    for example in examples:
+        if ERROR_HAPPENED:
+            return True
+        locked_print(f"\n*** Building examples for board {board} ***")
+        if is_first and IS_GITHUB:
+            with FIRST_JOB_LOCK:
+                # Github runners are memory limited and the first job is the most
+                # memory intensive since all the artifacts are being generated in parallel.
+                success = compile_for_board_and_example(board, example)
+        else:
+            success = compile_for_board_and_example(board, example)
+        is_first = False
+        if not success:
+            ERROR_HAPPENED = True
+            return False
+    return True
+
+
+def main() -> int:
+    """Main function."""
+    start_time = time.time()
+
+    # Set the working directory to the script's parent directory.
+    script_dir = Path(__file__).parent.resolve()
+    os.chdir(script_dir.parent)
+    os.environ["PLATFORMIO_EXTRA_SCRIPTS"] = "pre:lib/ci/ci-flags.py"
+
+    task_queues = {board: EXAMPLES.copy() for board in BOARDS}
+    num_cpus = min(os.cpu_count(), len(BOARDS))
+
+    # Run the compilation process
+    with concurrent.futures.ThreadPoolExecutor(max_workers=num_cpus) as executor:
+        future_to_board = {
+            executor.submit(process_queue, board, task_queues[board]): board
+            for board in BOARDS
+        }
+        for future in concurrent.futures.as_completed(future_to_board):
+            board = future_to_board[future]
+            if not future.result():
+                locked_print(f"Compilation failed for board {board}. Stopping.")
+                break
+
+    total_time = (time.time() - start_time) / 60
+    if ERROR_HAPPENED:
+        locked_print("\nDone. Errors happened during compilation.")
+        return 1
+    locked_print(
+        f"\nDone. Built all projects for all boards in {total_time:.2f} minutes."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ci/requirements.txt
+++ b/ci/requirements.txt
@@ -1,0 +1,1 @@
+platformio==6.1.11


### PR DESCRIPTION
Reduces the build time by ~75% on a Windows box. Reduces build time by ~65% on github builders.

## Build artifact recycling

In the previous iteration, the build artifacts were discarded after every board example.ino. Now the build artifacts are generated just once and then subsequent builds in the board group build the ino file (and its dependencies) and then link the elf file, offering massive speed improvements.

## Builds are linked in parallel

For each board group, the first example.ino build is done under a lock to generate the artifacts, then the rest of the ino files are allowed to be built/linked in parallel.

If this is not done then the github runner will crash without a useful error message. I looked into this a bit and my conclusion is that the cause is an OOM error. Most likely because the massive compilation of the framework and other dependencies likely already runs in parallel. To work around this limitation the initial job of each board group is built under a global lock, while the rest of the jobs are allowed to be built/linked in parallel with respect to the other board groups.

## How build artifact recycling works

Every *.ino file expects to live in the /src directory and this was a challenge. Hence for each ino in a board group the previous *.ino file needs to be removed before the next one can be compiled. This limits us to working with each example.ino file in the board group sequentially. Hence the granularity of the parallelization is done at the board group, rather than the jobs within the board group.

## ci-compile is now ci-compile.py

Bash just doesn't work well with a task queue and signaling errors. Python does this no problem so the script was re-written in python and when an error happens the script halts pretty fast. It's also a lot more clear IMO. The ci-compile bash script now just calls into ci-compile.py, incase anything was relying on the script to be there. I tested with by inserting random characters in some of the example ino files and the result was that the build halted pretty quickly and gave a helpful error message.

## Build messages are out of order, but not that much different the previously.

Previously, the build was done in which one example was compiled on multiple boards in a bulk operation. So the build messages from the previous iteration were done in the sequence of each board per example.ino. Now it's a little bit more out of order since the print outs happen after each job from a board group is done. In practice, there isn't much difference.

## pio library updates

The pio library was updated to latest version. Everything seems to run fine. A requirements.txt was also generated since that's standard operating procedure, rather than having to look through the build.yml file belonging to the github runner to figure out the build dependencies.