### PR TITLE
Issue #1552: Fix to enhance ESP32-S3 SPI compatibility by enabling flexible pin assignment

### DIFF
--- a/src/platforms/esp/32/fastspi_esp32.h
+++ b/src/platforms/esp/32/fastspi_esp32.h
@@ -53,24 +53,33 @@ FASTLED_NAMESPACE_BEGIN
 
 static SPIClass ledSPI(FASTLED_ESP32_SPI_BUS);
 
-
+#if CONFIG_IDF_TARGET_ESP32S3
+#pragma message "S3 Mode, you tell me the pins, I use them!"
+#define spiMosi DATA_PIN
+#define spiClk CLOCK_PIN
+#define spiMiso -1
+#define spiCs -1
+#else
 #if FASTLED_ESP32_SPI_BUS == VSPI
+#pragma message "VSPI"
     static int8_t spiClk = 18;
     static int8_t spiMiso = 19;
     static int8_t spiMosi = 23;
     static int8_t spiCs = 5;
 #elif FASTLED_ESP32_SPI_BUS == HSPI
-    static int8_t spiClk = 14;
-    static int8_t spiMiso = 12;
-    static int8_t spiMosi = 13;
-    static int8_t spiCs = 15;
-#elif FASTLED_ESP32_SPI_BUS == FSPI  // ESP32S2 can re-route to arbitrary pins
-    #define spiMosi DATA_PIN
-    #define spiClk CLOCK_PIN
-    #define spiMiso -1
-    #define spiCs -1
+#pragma message "HSPI"
+static int8_t spiClk = 14;
+static int8_t spiMiso = 12;
+static int8_t spiMosi = 13;
+static int8_t spiCs = 15;
+#elif FASTLED_ESP32_SPI_BUS == FSPI // ESP32S2 can re-route to arbitrary pins
+#pragma message "FSPI"
+#define spiMosi DATA_PIN
+#define spiClk CLOCK_PIN
+#define spiMiso -1
+#define spiCs -1
 #endif
-
+#endif // CONFIG_IDF_TARGET_ESP32S3
 template <uint8_t DATA_PIN, uint8_t CLOCK_PIN, uint32_t SPI_SPEED>
 class ESP32SPIOutput {
 	Selectable 	*m_pSelect;

--- a/src/platforms/esp/32/fastspi_esp32.h
+++ b/src/platforms/esp/32/fastspi_esp32.h
@@ -8,9 +8,9 @@ FASTLED_NAMESPACE_BEGIN
  *
  * Copyright (c) 2020 Nick Wallace
  * Derived from code for ESP8266 hardware SPI by Benoit Anastay.
- * 
+ *
  * This hardware SPI implementation can drive clocked LEDs from either the
- * VSPI or HSPI bus (aka SPI2 & SPI3). No support is provided for SPI1, because it is 
+ * VSPI or HSPI bus (aka SPI2 & SPI3). No support is provided for SPI1, because it is
  * shared among devices and the cache for data (code) in the Flash as well as the PSRAM.
  *
  * To enable the hardware SPI driver, add the following line *before* including
@@ -18,12 +18,12 @@ FASTLED_NAMESPACE_BEGIN
  *
  * #define FASTLED_ALL_PINS_HARDWARE_SPI
  *
- * This driver uses the VSPI bus by default (GPIO 18, 19, 23, & 5). To use the 
+ * This driver uses the VSPI bus by default (GPIO 18, 19, 23, & 5). To use the
  * HSPI bus (GPIO 14, 12, 13, & 15) add the following line *before* including
  * FastLED.h:
- * 
+ *
  * #define FASTLED_ESP32_SPI_BUS HSPI
- * 
+ *
  */
 /*
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -45,16 +45,17 @@ FASTLED_NAMESPACE_BEGIN
  * THE SOFTWARE.
  */
 
-#include<SPI.h>
+#include <SPI.h>
 
 #ifndef FASTLED_ESP32_SPI_BUS
-    #define FASTLED_ESP32_SPI_BUS VSPI
+#define FASTLED_ESP32_SPI_BUS VSPI
 #endif
 
 static SPIClass ledSPI(FASTLED_ESP32_SPI_BUS);
 
 #if CONFIG_IDF_TARGET_ESP32S3
-#pragma message "S3 Mode, you tell me the pins, I use them!"
+#pragma message "Targeting ESP32S3, which has better SPI support. You tell me the pins, I'll use them!"
+// ESP32S3 seem to do away with the whole FSPI/VSPI/HSPI concept and just went with numbered SPI
 #define spiMosi DATA_PIN
 #define spiClk CLOCK_PIN
 #define spiMiso -1
@@ -62,10 +63,10 @@ static SPIClass ledSPI(FASTLED_ESP32_SPI_BUS);
 #else
 #if FASTLED_ESP32_SPI_BUS == VSPI
 #pragma message "VSPI"
-    static int8_t spiClk = 18;
-    static int8_t spiMiso = 19;
-    static int8_t spiMosi = 23;
-    static int8_t spiCs = 5;
+static int8_t spiClk = 18;
+static int8_t spiMiso = 19;
+static int8_t spiMosi = 23;
+static int8_t spiCs = 5;
 #elif FASTLED_ESP32_SPI_BUS == HSPI
 #pragma message "HSPI"
 static int8_t spiClk = 14;
@@ -80,110 +81,160 @@ static int8_t spiCs = 15;
 #define spiCs -1
 #endif
 #endif // CONFIG_IDF_TARGET_ESP32S3
-template <uint8_t DATA_PIN, uint8_t CLOCK_PIN, uint32_t SPI_SPEED>
-class ESP32SPIOutput {
-	Selectable 	*m_pSelect;
+template <uint8_t DATA_PIN, uint8_t CLOCK_PIN, uint32_t SPI_SPEED> class ESP32SPIOutput
+{
+    Selectable *m_pSelect;
 
-public:
-	// Verify that the pins are valid
-	static_assert(FastPin<DATA_PIN>::validpin(), "Invalid data pin specified");
-	static_assert(FastPin<CLOCK_PIN>::validpin(), "Invalid clock pin specified");
+  public:
+    // Verify that the pins are valid
+    static_assert(FastPin<DATA_PIN>::validpin(), "Invalid data pin specified");
+    static_assert(FastPin<CLOCK_PIN>::validpin(), "Invalid clock pin specified");
 
-	ESP32SPIOutput() { m_pSelect = NULL; }
-	ESP32SPIOutput(Selectable *pSelect) { m_pSelect = pSelect; }
-	void setSelect(Selectable *pSelect) { m_pSelect = pSelect; }
+    ESP32SPIOutput()
+    {
+        m_pSelect = NULL;
+    }
+    ESP32SPIOutput(Selectable *pSelect)
+    {
+        m_pSelect = pSelect;
+    }
+    void setSelect(Selectable *pSelect)
+    {
+        m_pSelect = pSelect;
+    }
 
-	void init() {
-		// set the pins to output and make sure the select is released (which apparently means hi?  This is a bit
-		// confusing to me)
-		ledSPI.begin(spiClk, spiMiso, spiMosi, spiCs);
-		release();
-	}
+    void init()
+    {
+        // set the pins to output and make sure the select is released (which apparently means hi?  This is a bit
+        // confusing to me)
+        ledSPI.begin(spiClk, spiMiso, spiMosi, spiCs);
+        release();
+    }
 
-	// stop the SPI output.  Pretty much a NOP with software, as there's no registers to kick
-	static void stop() { }
+    // stop the SPI output.  Pretty much a NOP with software, as there's no registers to kick
+    static void stop()
+    {
+    }
 
-	// wait until the SPI subsystem is ready for more data to write.  A NOP when bitbanging
-	static void wait() __attribute__((always_inline)) { }
-	static void waitFully() __attribute__((always_inline)) { wait(); }
+    // wait until the SPI subsystem is ready for more data to write.  A NOP when bitbanging
+    static void wait() __attribute__((always_inline))
+    {
+    }
+    static void waitFully() __attribute__((always_inline))
+    {
+        wait();
+    }
 
-	static void writeByteNoWait(uint8_t b) __attribute__((always_inline)) { writeByte(b); }
-	static void writeBytePostWait(uint8_t b) __attribute__((always_inline)) { writeByte(b); wait(); }
+    static void writeByteNoWait(uint8_t b) __attribute__((always_inline))
+    {
+        writeByte(b);
+    }
+    static void writeBytePostWait(uint8_t b) __attribute__((always_inline))
+    {
+        writeByte(b);
+        wait();
+    }
 
-	static void writeWord(uint16_t w) __attribute__((always_inline)) { writeByte(w>>8); writeByte(w&0xFF); }
+    static void writeWord(uint16_t w) __attribute__((always_inline))
+    {
+        writeByte(w >> 8);
+        writeByte(w & 0xFF);
+    }
 
-	// naive writeByte implelentation, simply calls writeBit on the 8 bits in the byte.
-	static void writeByte(uint8_t b) {
-		ledSPI.transfer(b);
-	}
+    // naive writeByte implelentation, simply calls writeBit on the 8 bits in the byte.
+    static void writeByte(uint8_t b)
+    {
+        ledSPI.transfer(b);
+    }
 
-public:
+  public:
+    // select the SPI output (TODO: research whether this really means hi or lo.  Alt TODO: move select responsibility
+    // out of the SPI classes entirely, make it up to the caller to remember to lock/select the line?)
+    void select()
+    {
+        ledSPI.beginTransaction(SPISettings(SPI_SPEED, MSBFIRST, SPI_MODE0));
+        if (m_pSelect != NULL)
+        {
+            m_pSelect->select();
+        }
+    }
 
-	// select the SPI output (TODO: research whether this really means hi or lo.  Alt TODO: move select responsibility out of the SPI classes
-	// entirely, make it up to the caller to remember to lock/select the line?)
-	void select() { 
-		ledSPI.beginTransaction(SPISettings(SPI_SPEED, MSBFIRST, SPI_MODE0));
-		if(m_pSelect != NULL) { m_pSelect->select(); } 
-	} 
+    // release the SPI line
+    void release()
+    {
+        if (m_pSelect != NULL)
+        {
+            m_pSelect->release();
+        }
+        ledSPI.endTransaction();
+    }
 
-	// release the SPI line
-	void release() { 
-		if(m_pSelect != NULL) { m_pSelect->release(); } 
-		ledSPI.endTransaction();
-	}
+    // Write out len bytes of the given value out over ledSPI.  Useful for quickly flushing, say, a line of 0's down the
+    // line.
+    void writeBytesValue(uint8_t value, int len)
+    {
+        select();
+        writeBytesValueRaw(value, len);
+        release();
+    }
 
-	// Write out len bytes of the given value out over ledSPI.  Useful for quickly flushing, say, a line of 0's down the line.
-	void writeBytesValue(uint8_t value, int len) {
-		select();
-		writeBytesValueRaw(value, len);
-		release();
-	}
+    static void writeBytesValueRaw(uint8_t value, int len)
+    {
+        while (len--)
+        {
+            ledSPI.transfer(value);
+        }
+    }
 
-	static void writeBytesValueRaw(uint8_t value, int len) {
-		while(len--) {
-			ledSPI.transfer(value); 
-		}
-	}
+    // write a block of len uint8_ts out.  Need to type this better so that explicit casts into the call aren't
+    // required. note that this template version takes a class parameter for a per-byte modifier to the data.
+    template <class D> void writeBytes(FASTLED_REGISTER uint8_t *data, int len)
+    {
+        select();
+        uint8_t *end = data + len;
+        while (data != end)
+        {
+            writeByte(D::adjust(*data++));
+        }
+        D::postBlock(len);
+        release();
+    }
 
-	// write a block of len uint8_ts out.  Need to type this better so that explicit casts into the call aren't required.
-	// note that this template version takes a class parameter for a per-byte modifier to the data.
-	template <class D> void writeBytes(FASTLED_REGISTER uint8_t *data, int len) {
-		select();
-		uint8_t *end = data + len;
-		while(data != end) {
-			writeByte(D::adjust(*data++));
-		}
-		D::postBlock(len);
-		release();
-	}
+    // default version of writing a block of data out to the SPI port, with no data modifications being made
+    void writeBytes(FASTLED_REGISTER uint8_t *data, int len)
+    {
+        writeBytes<DATA_NOP>(data, len);
+    }
 
-	// default version of writing a block of data out to the SPI port, with no data modifications being made
-	void writeBytes(FASTLED_REGISTER uint8_t *data, int len) { writeBytes<DATA_NOP>(data, len); }
+    // write a single bit out, which bit from the passed in byte is determined by template parameter
+    template <uint8_t BIT> inline void writeBit(uint8_t b)
+    {
+        ledSPI.transfer(b);
+    }
 
-	// write a single bit out, which bit from the passed in byte is determined by template parameter
-	template <uint8_t BIT> inline void writeBit(uint8_t b) {
-		ledSPI.transfer(b);
-	}
-
-	// write a block of uint8_ts out in groups of three.  len is the total number of uint8_ts to write out.  The template
-	// parameters indicate how many uint8_ts to skip at the beginning of each grouping, as well as a class specifying a per
-	// byte of data modification to be made.  (See DATA_NOP above)
-	template <uint8_t FLAGS, class D, EOrder RGB_ORDER>  __attribute__((noinline)) void writePixels(PixelController<RGB_ORDER> pixels) {
-		select();
-		int len = pixels.mLen;
-		while(pixels.has(1)) {
-			if(FLAGS & FLAG_START_BIT) {
-				writeBit<0>(1);
-			}
-			writeByte(D::adjust(pixels.loadAndScale0()));
-			writeByte(D::adjust(pixels.loadAndScale1()));
-			writeByte(D::adjust(pixels.loadAndScale2()));
-			pixels.advanceData();
-			pixels.stepDithering();
-		}
-		D::postBlock(len);
-		release();
-	}
+    // write a block of uint8_ts out in groups of three.  len is the total number of uint8_ts to write out.  The
+    // template parameters indicate how many uint8_ts to skip at the beginning of each grouping, as well as a class
+    // specifying a per byte of data modification to be made.  (See DATA_NOP above)
+    template <uint8_t FLAGS, class D, EOrder RGB_ORDER>
+    __attribute__((noinline)) void writePixels(PixelController<RGB_ORDER> pixels)
+    {
+        select();
+        int len = pixels.mLen;
+        while (pixels.has(1))
+        {
+            if (FLAGS & FLAG_START_BIT)
+            {
+                writeBit<0>(1);
+            }
+            writeByte(D::adjust(pixels.loadAndScale0()));
+            writeByte(D::adjust(pixels.loadAndScale1()));
+            writeByte(D::adjust(pixels.loadAndScale2()));
+            pixels.advanceData();
+            pixels.stepDithering();
+        }
+        D::postBlock(len);
+        release();
+    }
 };
 
 FASTLED_NAMESPACE_END

--- a/src/platforms/esp/32/fastspi_esp32.h
+++ b/src/platforms/esp/32/fastspi_esp32.h
@@ -47,40 +47,47 @@ FASTLED_NAMESPACE_BEGIN
 
 #include <SPI.h>
 
+// Conditional compilation for ESP32-S3 to utilize its flexible SPI capabilities
+#if CONFIG_IDF_TARGET_ESP32S3
+#pragma message "Targeting ESP32S3, which has better SPI support. Configuring for flexible pin assignment."
+#undef FASTLED_ESP32_SPI_BUS
+#define FASTLED_ESP32_SPI_BUS FSPI
+// Define SPI pins, assuming DATA_PIN and CLOCK_PIN are user-defined for maximum flexibility
+#define spiMosi DATA_PIN
+#define spiClk CLOCK_PIN
+// MISO and CS are not used in LED output, set to -1
+#define spiMiso -1
+#define spiCs -1
+#else // Configuration for other ESP32 variants
 #ifndef FASTLED_ESP32_SPI_BUS
 #define FASTLED_ESP32_SPI_BUS VSPI
 #endif
 
-static SPIClass ledSPI(FASTLED_ESP32_SPI_BUS);
-
-#if CONFIG_IDF_TARGET_ESP32S3
-#pragma message "Targeting ESP32S3, which has better SPI support. You tell me the pins, I'll use them!"
-// ESP32S3 seem to do away with the whole FSPI/VSPI/HSPI concept and just went with numbered SPI
-#define spiMosi DATA_PIN
-#define spiClk CLOCK_PIN
-#define spiMiso -1
-#define spiCs -1
-#else
+// Default pin assignments for VSPI and HSPI
 #if FASTLED_ESP32_SPI_BUS == VSPI
-#pragma message "VSPI"
+#pragma message "VSPI selected"
 static int8_t spiClk = 18;
 static int8_t spiMiso = 19;
 static int8_t spiMosi = 23;
 static int8_t spiCs = 5;
 #elif FASTLED_ESP32_SPI_BUS == HSPI
-#pragma message "HSPI"
+#pragma message "HSPI selected"
 static int8_t spiClk = 14;
 static int8_t spiMiso = 12;
 static int8_t spiMosi = 13;
 static int8_t spiCs = 15;
-#elif FASTLED_ESP32_SPI_BUS == FSPI // ESP32S2 can re-route to arbitrary pins
-#pragma message "FSPI"
+#elif FASTLED_ESP32_SPI_BUS == FSPI
+#pragma message "FSPI for flexible pin routing on some ESP32 chips"
 #define spiMosi DATA_PIN
 #define spiClk CLOCK_PIN
+// MISO and CS are not used in LED output, set to -1
 #define spiMiso -1
 #define spiCs -1
 #endif
-#endif // CONFIG_IDF_TARGET_ESP32S3
+#endif
+
+static SPIClass ledSPI(FASTLED_ESP32_SPI_BUS);
+
 template <uint8_t DATA_PIN, uint8_t CLOCK_PIN, uint32_t SPI_SPEED> class ESP32SPIOutput
 {
     Selectable *m_pSelect;


### PR DESCRIPTION
This pull request aims to resolve issue #1552 by adapting FastLED's SPI handling for the ESP32-S3. The ESP32-S3 diverges from previous ESP32 models by not using named SPI buses (VSPI/HSPI). Instead, it supports flexible pin assignments for SPI communication. In response, this update defaults to "FSPI" for the ESP32-S3, allowing dynamic pin assignment rather than relying on hardcoded pin mappings.

I want to note that while this solution aligns FastLED with the ESP32-S3's SPI flexibility, I'm not entirely certain this is the absolute "best practice" within the broader context of esp-idf and the arduino-espressif library ecosystem. If you know a better way, I'm all ears!