### PR TITLE
#1552: Improve ESP32-S3 SPI Support

### DIFF
--- a/src/platforms/esp/32/fastspi_esp32.h
+++ b/src/platforms/esp/32/fastspi_esp32.h
@@ -49,8 +49,18 @@ FASTLED_NAMESPACE_BEGIN
 
 #include<SPI.h>
 
-#ifndef FASTLED_ESP32_SPI_BUS
-    #define FASTLED_ESP32_SPI_BUS VSPI
+// Conditional compilation for ESP32-S3 to utilize its flexible SPI capabilities
+#if CONFIG_IDF_TARGET_ESP32S3
+	#pragma message "Targeting ESP32S3, which has better SPI support. Configuring for flexible pin assignment."
+	#undef FASTLED_ESP32_SPI_BUS
+	// I *think* we have to "fake" being FSPI... there might be a better way to do this.
+	// whatever the case, this "tricks" the pin assignment defines below into using DATA_PIN & CLOCK_PIN
+	#define FASTLED_ESP32_SPI_BUS FSPI
+#else // Configuration for other ESP32 variants
+	#ifndef FASTLED_ESP32_SPI_BUS
+	#pragma message "Setting ESP32 SPI bus to VSPI by default"
+	#define FASTLED_ESP32_SPI_BUS VSPI
+	#endif
 #endif
 
 #if FASTLED_ESP32_SPI_BUS == VSPI


### PR DESCRIPTION
This pull request aims to resolve issue #1552  by adapting FastLED's SPI handling for the ESP32-S3. The ESP32-S3 diverges from previous ESP32 models by not using named SPI buses (VSPI/HSPI). Instead, it supports flexible pin assignments for SPI communication. In response, this update defaults to "FSPI" for the ESP32-S3, allowing dynamic pin assignment rather than relying on hardcoded pin mappings.

I want to note that while this solution aligns FastLED with the ESP32-S3's SPI flexibility, I'm not entirely certain this is the absolute "best practice" within the broader context of esp-idf and the arduino-espressif library ecosystem. If you know a better way, I'm all ears!