### PR TITLE
Fix RMT driver member names for ESP32S3

### DIFF
--- a/src/platforms/esp/32/clockless_rmt_esp32.cpp
+++ b/src/platforms/esp/32/clockless_rmt_esp32.cpp
@@ -323,17 +323,17 @@ void IRAM_ATTR ESP32RMTController::tx_start()
     RMT.tx_conf[mRMT_channel].tx_start = 1;
 #elif CONFIG_IDF_TARGET_ESP32S3
     // rmt_ll_tx_reset_pointer(&RMT, mRMT_channel)
-    RMT.chnconf0[mRMT_channel].mem_rd_rst_n = 1;
-    RMT.chnconf0[mRMT_channel].mem_rd_rst_n = 0;
-    RMT.chnconf0[mRMT_channel].apb_mem_rst_n = 1;
-    RMT.chnconf0[mRMT_channel].apb_mem_rst_n = 0;
+    RMT.chnconf0[mRMT_channel].mem_rd_rst_chn = 1;
+    RMT.chnconf0[mRMT_channel].mem_rd_rst_chn = 0;
+    RMT.chnconf0[mRMT_channel].apb_mem_rst_chn = 1;
+    RMT.chnconf0[mRMT_channel].apb_mem_rst_chn = 0;
     // rmt_ll_clear_tx_end_interrupt(&RMT, mRMT_channel)
     RMT.int_clr.val = (1 << (mRMT_channel));
     // rmt_ll_enable_tx_end_interrupt(&RMT, mRMT_channel, true)
     RMT.int_ena.val |= (1 << mRMT_channel);
     // rmt_ll_tx_start(&RMT, mRMT_channel)
-    RMT.chnconf0[mRMT_channel].conf_update_n = 1;
-    RMT.chnconf0[mRMT_channel].tx_start_n = 1;
+    RMT.chnconf0[mRMT_channel].conf_update_chn = 1;
+    RMT.chnconf0[mRMT_channel].tx_start_chn = 1;
 #elif CONFIG_IDF_TARGET_ESP32S2 || CONFIG_IDF_TARGET_ESP32
     // rmt_ll_tx_reset_pointer(&RMT, mRMT_channel)
     RMT.conf_ch[mRMT_channel].conf1.mem_rd_rst = 1;
@@ -386,13 +386,13 @@ void IRAM_ATTR ESP32RMTController::doneOnChannel(rmt_channel_t channel, void * a
     // rmt_ll_enable_tx_end_interrupt(&RMT, channel)
     RMT.int_ena.val &= ~(1 << channel);
     // rmt_ll_tx_stop(&RMT, channel)
-    RMT.chnconf0[channel].tx_stop_n = 1;
-    RMT.chnconf0[channel].conf_update_n = 1;
+    RMT.chnconf0[channel].tx_stop_chn = 1;
+    RMT.chnconf0[channel].conf_update_chn = 1;
     // rmt_ll_tx_reset_pointer(&RMT, channel)
-    RMT.chnconf0[channel].mem_rd_rst_n = 1;
-    RMT.chnconf0[channel].mem_rd_rst_n = 0;
-    RMT.chnconf0[channel].apb_mem_rst_n = 1;
-    RMT.chnconf0[channel].apb_mem_rst_n = 0;
+    RMT.chnconf0[channel].mem_rd_rst_chn = 1;
+    RMT.chnconf0[channel].mem_rd_rst_chn = 0;
+    RMT.chnconf0[channel].apb_mem_rst_chn = 1;
+    RMT.chnconf0[channel].apb_mem_rst_chn = 0;
 #elif CONFIG_IDF_TARGET_ESP32S2
     // rmt_ll_enable_tx_end_interrupt(&RMT, channel)
     RMT.int_ena.val &= ~(1 << (channel * 3));


### PR DESCRIPTION
This should fix https://github.com/FastLED/FastLED/issues/1631