### PR TITLE
Update URL for cpt-city

### DIFF
--- a/tools/paletteknife/index.html
+++ b/tools/paletteknife/index.html
@@ -18,7 +18,7 @@
 	<div class="row">
 	<h2>About</h2>
 		<p><img class="float-right" src="cpt-city-examples.png"></p>
-		<p>PaletteKnife lets you use thousands of high-quality color palettes from "<a href="http://soliton.vm.bytemark.co.uk/pub/cpt-city/" target=_new>cpt-city</a>" in your FastLED animations.</p>
+		<p>PaletteKnife lets you use thousands of high-quality color palettes from "<a href="http://seaviewsensing.com/pub/cpt-city/" target=_new>cpt-city</a>" in your FastLED animations.</p>
 		
 <h2>Getting Started</h2>
 <p>A basic understanding of FastLED color palettes is absolutely required.
@@ -31,8 +31,8 @@
 
 	<h2>Using PaletteKnife</h2>
 	<ol>
-	<li>Go to cpt-city here, <a href="http://soliton.vm.bytemark.co.uk/pub/cpt-city/" target=_new>http://soliton.vm.bytemark.co.uk/pub/cpt-city/</a></li>
-	<li>Find a palette you like, e.g. <a href="http://soliton.vm.bytemark.co.uk/pub/cpt-city/rc/tn/purplefly.png.index.html" target=_new>http://soliton.vm.bytemark.co.uk/pub/cpt-city/rc/tn/purplefly.png.index.html</a></li>
+	<li>Go to cpt-city here, <a href="http://seaviewsensing.com/pub/cpt-city/" target=_new>http://seaviewsensing.com/pub/cpt-city/</a></li>
+	<li>Find a palette you like, e.g. <a href="http://seaviewsensing.com/pub/cpt-city/rc/tn/purplefly.png.index.html" target=_new>http://seaviewsensing.com/pub/cpt-city/rc/tn/purplefly.png.index.html</a></li>
 <li>Click PaletteKnife in your toolbar.  If you get warnings, choose a different palette and try again.</li>
 <li>Copy the resulting code and paste it into your source file.</li>
 <li>Use your new color palette by name (e.g. "purplefly_gp") as you would any other FastLED pre-defined color palette (e.g. "RainbowColors_p").</li>

--- a/tools/paletteknife/pk2.js
+++ b/tools/paletteknife/pk2.js
@@ -41,15 +41,15 @@ function adjustGamma( orig, gamma)
 
 
 var origurl = document.location.href;
-//"http://soliton.vm.bytemark.co.uk/pub/cpt-city/dca/tn/alarm.p1.0.2.png.index.html";
+//"http://seaviewsensing.com/pub/cpt-city/dca/tn/alarm.p1.0.2.png.index.html";
 
 // origurl = //document.location.href;
 var url2 = origurl.replace( "/tn/", "/");
 var url3 = url2.replace( ".png.index.html", ".c3g");
 
-var onSite = url3.indexOf("http://soliton.vm.bytemark.co.uk/");
+var onSite = url3.indexOf("http://seaviewsensing.com/");
 if( onSite != 0) {
-    window.location.href="http://soliton.vm.bytemark.co.uk/pub/cpt-city/";
+    window.location.href="http://seaviewsensing.com/pub/cpt-city/";
     //return;
 }
 
@@ -187,7 +187,7 @@ if( onSite == 0) {
     i.src = url3;
     document.body.appendChild(i);
 } else {
-    window.location.href="http://soliton.vm.bytemark.co.uk/pub/cpt-city/";
+    window.location.href="http://seaviewsensing.com/pub/cpt-city/";
 }
 cursor_clear();
 //alert(stdout);


### PR DESCRIPTION
> The original URL for cpt-city now redirects to a mirror of the site, but it only redirects to the base URL rather than the full pathname. This behaviour breaks paletteknife.
> 
> The changes here point paletteknife directly to the mirror, which resolves the problem for me.

Thank you to @sutaburosu for these changes, which were originally submitted here: FastLED/fastled-fastled.github.io#1