### PR TITLE
clockless_rmt_esp32 FastLED.show() hang fix

### DIFF
--- a/src/platforms/esp/32/clockless_rmt_esp32.cpp
+++ b/src/platforms/esp/32/clockless_rmt_esp32.cpp
@@ -58,6 +58,15 @@ typedef struct {
 extern rmt_block_mem_t RMTMEM;
 #endif
 
+
+void IRAM_ATTR GiveGTX_sem()
+{
+    if (gTX_sem != NULL)
+        {
+        xSemaphoreGive(gTX_sem);
+        }
+}
+
 ESP32RMTController::ESP32RMTController(int DATA_PIN, int T1, int T2, int T3, int maxChannel, int memBlocks)
     : mPixelData(0), 
       mSize(0), 
@@ -198,7 +207,7 @@ void IRAM_ATTR ESP32RMTController::showPixels()
     gNumStarted++;
 
     // -- The last call to showPixels is the one responsible for doing
-    //    all of the actual worl
+    //    all of the actual work
     if (gNumStarted == gNumControllers) {
         gNext = 0;
 
@@ -220,7 +229,7 @@ void IRAM_ATTR ESP32RMTController::showPixels()
         // -- Wait here while the data is sent. The interrupt handler
         //    will keep refilling the RMT buffers until it is all
         //    done; then it gives the semaphore back.
-        xSemaphoreTake(gTX_sem, portMAX_DELAY);
+        xSemaphoreTake(gTX_sem, FASTLED_RMT_MAX_TICKS_FOR_GTX_SEM);
         xSemaphoreGive(gTX_sem);
 
         // -- Make sure we don't call showPixels too quickly


### PR DESCRIPTION
# clockless_rmt_esp32 FastLED.show() infrequent hang fix

See issue 1438 (https://github.com/FastLED/FastLED/issues/1438) and others.  FastLED.show() does not return (hangs) very infrequently, sometimes many hours after starting usually while under load.

See https://github.com/davidlmorris/FastLED_Hang_Fix_Demo for a demonstration of this problem (noting that the hang will happen extremely infrequently).

The FastLed RMT driver makes extensive use of interrupts. The comments in the FastLED driver hint at least one per 32 bits of data out. The driver does all the sending in one hit so that even with multiple controllers (as we have in this demo) it is only when the last one is called does it finally does the work. I am uncertain what might happen if only one controller that is not the last one is called. (Something for a future experiment?). On a send, it waits 50 microseconds to signal a start, then starts the channels for each controller. It then sets a semaphore which is then released when the final channel on the final controller is complete. It appears that rarely something goes wrong here, and presumably, that interrupt is swallowed by the Esp32 system. The result is that ESP32RMTController::showPixels() waits forever for the semaphore to be released (which it never will be) so we have a hang. Note that this hang will occur minutes or hours into a run, depending on other factors (like load or power), and is essentially out of the control of the FastLED driver.

The quick and dirty fix is simply to assign some timeout value to the semaphore take rather than portMAX_DELAY (line 204 for version 3.6.0 and line 223 for version 3.7.0).

We do this in the modified FastLED lib forked [here](https://github.com/davidlmorris/FastLED) by defining FASTLED_RMT_MAX_TICKS_FOR_GTX_SEM to a value like (2000/portTICK_PERIOD_MS) before we call FastLED.h (see [clockless_rmt_esp32.h](https://github.com/davidlmorris/FastLED/tree/master/src/platforms/esp/32/clockless_rmt_esp32.h)).

Alternatively, we can call GiveGTX_sem(); which has been added to [clockless_rmt_esp32.cpp](https://github.com/davidlmorris/FastLED/tree/master/src/platforms/esp/32/clockless_rmt_esp32.cpp) so we can programmatically decide on the wait time.