### PR TITLE
adds support for ESP32S3 RMT for esp-idf 5.X.X

### DIFF
--- a/src/platforms/esp/32/clockless_rmt_esp32.cpp
+++ b/src/platforms/esp/32/clockless_rmt_esp32.cpp
@@ -323,7 +323,20 @@ void IRAM_ATTR ESP32RMTController::tx_start()
     RMT.tx_conf[mRMT_channel].tx_start = 1;
 #elif CONFIG_IDF_TARGET_ESP32S3
     // rmt_ll_tx_reset_pointer(&RMT, mRMT_channel)
-    RMT.chnconf0[mRMT_channel].mem_rd_rst_n = 1;
+    #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
+    RMT.chnconf0[mRMT_channel].mem_rd_rst_chn = 1;
+    RMT.chnconf0[mRMT_channel].mem_rd_rst_chn = 0;
+    RMT.chnconf0[mRMT_channel].apb_mem_rst_chn = 1;
+    RMT.chnconf0[mRMT_channel].apb_mem_rst_chn = 0;
+    // rmt_ll_clear_tx_end_interrupt(&RMT, mRMT_channel)
+    RMT.int_clr.val = (1 << (mRMT_channel));
+    // rmt_ll_enable_tx_end_interrupt(&RMT, mRMT_channel, true)
+    RMT.int_ena.val |= (1 << mRMT_channel);
+    // rmt_ll_tx_start(&RMT, mRMT_channel)
+    RMT.chnconf0[mRMT_channel].conf_update_chn = 1;
+    RMT.chnconf0[mRMT_channel].tx_start_chn = 1;
+    #else
+        RMT.chnconf0[mRMT_channel].mem_rd_rst_n = 1;
     RMT.chnconf0[mRMT_channel].mem_rd_rst_n = 0;
     RMT.chnconf0[mRMT_channel].apb_mem_rst_n = 1;
     RMT.chnconf0[mRMT_channel].apb_mem_rst_n = 0;
@@ -334,6 +347,7 @@ void IRAM_ATTR ESP32RMTController::tx_start()
     // rmt_ll_tx_start(&RMT, mRMT_channel)
     RMT.chnconf0[mRMT_channel].conf_update_n = 1;
     RMT.chnconf0[mRMT_channel].tx_start_n = 1;
+    #endif
 #elif CONFIG_IDF_TARGET_ESP32S2 || CONFIG_IDF_TARGET_ESP32
     // rmt_ll_tx_reset_pointer(&RMT, mRMT_channel)
     RMT.conf_ch[mRMT_channel].conf1.mem_rd_rst = 1;
@@ -386,6 +400,15 @@ void IRAM_ATTR ESP32RMTController::doneOnChannel(rmt_channel_t channel, void * a
     // rmt_ll_enable_tx_end_interrupt(&RMT, channel)
     RMT.int_ena.val &= ~(1 << channel);
     // rmt_ll_tx_stop(&RMT, channel)
+    #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
+    RMT.chnconf0[channel].tx_stop_chn = 1;
+    RMT.chnconf0[channel].conf_update_chn = 1;
+    // rmt_ll_tx_reset_pointer(&RMT, channel)
+    RMT.chnconf0[channel].mem_rd_rst_chn = 1;
+    RMT.chnconf0[channel].mem_rd_rst_chn = 0;
+    RMT.chnconf0[channel].apb_mem_rst_chn = 1;
+    RMT.chnconf0[channel].apb_mem_rst_chn = 0;
+    #else
     RMT.chnconf0[channel].tx_stop_n = 1;
     RMT.chnconf0[channel].conf_update_n = 1;
     // rmt_ll_tx_reset_pointer(&RMT, channel)
@@ -393,6 +416,7 @@ void IRAM_ATTR ESP32RMTController::doneOnChannel(rmt_channel_t channel, void * a
     RMT.chnconf0[channel].mem_rd_rst_n = 0;
     RMT.chnconf0[channel].apb_mem_rst_n = 1;
     RMT.chnconf0[channel].apb_mem_rst_n = 0;
+    #endif
 #elif CONFIG_IDF_TARGET_ESP32S2
     // rmt_ll_enable_tx_end_interrupt(&RMT, channel)
     RMT.int_ena.val &= ~(1 << (channel * 3));


### PR DESCRIPTION
Espressif slightly changed the variable names of their S3 RMT code for idf 5.X. This cl tests the current compiler toolchain to see if it's >= 5.0.0 and if true, uses the correct member variable names.