### PR TITLE
Update platformio version to 6.1.15

### DIFF
--- a/ci/requirements.txt
+++ b/ci/requirements.txt
@@ -1,1 +1,1 @@
-platformio==6.1.11
+platformio==6.1.15


### PR DESCRIPTION
I'm getting build errors with the 6.1.11 version.

Updating to latest in order to silence build errors.

This seems to only happen on my local machine and not the build bot. But better to take care of it now.