### PR TITLE
fixes 1653 compiler error for Apa102 hardware spi pins on ESP32-S3

### DIFF
--- a/src/chipsets.h
+++ b/src/chipsets.h
@@ -92,8 +92,9 @@ class LPD8806Controller : public CPixelLEDController<RGB_ORDER> {
 	public:
 		// LPD8806 spec wants the high bit of every rgb data byte sent out to be set.
 		__attribute__((always_inline)) inline static uint8_t adjust(FASTLED_REGISTER uint8_t data) { return ((data>>1) | 0x80) + ((data && (data<254)) & 0x01); }
-		__attribute__((always_inline)) inline static void postBlock(int len) {
-			SPI::writeBytesValueRaw(0, ((len*3+63)>>6));
+		__attribute__((always_inline)) inline static void postBlock(int len, void* context = NULL) {
+			SPI* pSPI = static_cast<SPI*>(context);
+			pSPI->writeBytesValueRaw(0, ((len*3+63)>>6));
 		}
 
 	};
@@ -110,7 +111,7 @@ protected:
 
 	/// @copydoc CPixelLEDController::showPixels()
 	virtual void showPixels(PixelController<RGB_ORDER> & pixels) {
-		mSPI.template writePixels<0, LPD8806_ADJUST, RGB_ORDER>(pixels);
+		mSPI.template writePixels<0, LPD8806_ADJUST, RGB_ORDER>(pixels, &mSPI);
 	}
 };
 
@@ -146,7 +147,7 @@ protected:
 	/// @copydoc CPixelLEDController::showPixels()
 	virtual void showPixels(PixelController<RGB_ORDER> & pixels) {
 		mWaitDelay.wait();
-		mSPI.template writePixels<0, DATA_NOP, RGB_ORDER>(pixels);
+		mSPI.template writePixels<0, DATA_NOP, RGB_ORDER>(pixels, NULL);
 		mWaitDelay.mark();
 	}
 };
@@ -522,7 +523,7 @@ protected:
 		// Make sure the FLAG_START_BIT flag is set to ensure that an extra 1 bit is sent at the start
 		// of each triplet of bytes for rgb data
 		// writeHeader();
-		mSPI.template writePixels<FLAG_START_BIT, DATA_NOP, RGB_ORDER>( pixels );
+		mSPI.template writePixels<FLAG_START_BIT, DATA_NOP, RGB_ORDER>(pixels, NULL);
 		writeHeader();
 	}
 

--- a/src/fastspi_bitbang.h
+++ b/src/fastspi_bitbang.h
@@ -348,7 +348,7 @@ public:
 	/// @tparam D Per-byte modifier class, e.g. ::DATA_NOP
 	/// @tparam RGB_ORDER the rgb ordering for the LED data (e.g. what order red, green, and blue data is written out in)
 	/// @param pixels a ::PixelController with the LED data and modifier options
-	template <uint8_t FLAGS, class D, EOrder RGB_ORDER>  __attribute__((noinline)) void writePixels(PixelController<RGB_ORDER> pixels) {
+	template <uint8_t FLAGS, class D, EOrder RGB_ORDER>  __attribute__((noinline)) void writePixels(PixelController<RGB_ORDER> pixels, void* context = NULL) {
 		select();
 		int len = pixels.mLen;
 

--- a/src/fastspi_nop.h
+++ b/src/fastspi_nop.h
@@ -61,7 +61,7 @@ public:
 	template <uint8_t BIT> inline static void writeBit(uint8_t b) { /* TODO */ }
 
 	/// write out pixel data from the given PixelController object
-	template <uint8_t FLAGS, class D, EOrder RGB_ORDER> void writePixels(PixelController<RGB_ORDER> pixels) { /* TODO */ }
+	template <uint8_t FLAGS, class D, EOrder RGB_ORDER> void writePixels(PixelController<RGB_ORDER> pixels, void* context = NULL) { /* TODO */ }
 
 };
 

--- a/src/fastspi_ref.h
+++ b/src/fastspi_ref.h
@@ -75,7 +75,7 @@ public:
 
 	/// write a block of uint8_ts out in groups of three.  len is the total number of uint8_ts to write out.  The template
 	/// parameters indicate how many uint8_ts to skip at the beginning and/or end of each grouping
-	template <uint8_t FLAGS, class D, EOrder RGB_ORDER> void writePixels(PixelController<RGB_ORDER> pixels) {
+	template <uint8_t FLAGS, class D, EOrder RGB_ORDER> void writePixels(PixelController<RGB_ORDER> pixels, void* context = NULL) {
 		select();
 		while(data != end) {
 			if(FLAGS & FLAG_START_BIT) {

--- a/src/fastspi_types.h
+++ b/src/fastspi_types.h
@@ -45,7 +45,7 @@ public:
 
     /// Hook called after a block of data is written to the output. 
     /// In this dummy version, no action is performed.
-    static __attribute__((always_inline)) inline void postBlock(int /* len */) { }
+    static __attribute__((always_inline)) inline void postBlock(int /* len */, void* context = NULL) { }
 };
 
 /// Flag for the start of an SPI transaction

--- a/src/platforms/apollo3/fastspi_apollo3.h
+++ b/src/platforms/apollo3/fastspi_apollo3.h
@@ -104,7 +104,7 @@ public:
 
 	// write a block of uint8_ts out in groups of three.  len is the total number of uint8_ts to write out.  The template
 	// parameters indicate how many uint8_ts to skip at the beginning and/or end of each grouping
-	template <uint8_t FLAGS, class D, EOrder RGB_ORDER> void writePixels(PixelController<RGB_ORDER> pixels) {
+	template <uint8_t FLAGS, class D, EOrder RGB_ORDER> void writePixels(PixelController<RGB_ORDER> pixels, void* context = NULL) {
 		select();
 
 		int len = pixels.mLen;

--- a/src/platforms/arm/k20/fastspi_arm_k20.h
+++ b/src/platforms/arm/k20/fastspi_arm_k20.h
@@ -405,7 +405,7 @@ public:
 
 	// write a block of uint8_ts out in groups of three.  len is the total number of uint8_ts to write out.  The template
 	// parameters indicate how many uint8_ts to skip at the beginning and/or end of each grouping
-	template <uint8_t FLAGS, class D, EOrder RGB_ORDER> void writePixels(PixelController<RGB_ORDER> pixels) {
+	template <uint8_t FLAGS, class D, EOrder RGB_ORDER> void writePixels(PixelController<RGB_ORDER> pixels, void* context = NULL) {
 		select();
 		int len = pixels.mLen;
 

--- a/src/platforms/arm/k66/fastspi_arm_k66.h
+++ b/src/platforms/arm/k66/fastspi_arm_k66.h
@@ -409,7 +409,7 @@ public:
 
 	// write a block of uint8_ts out in groups of three.  len is the total number of uint8_ts to write out.  The template
 	// parameters indicate how many uint8_ts to skip at the beginning and/or end of each grouping
-	template <uint8_t FLAGS, class D, EOrder RGB_ORDER> void writePixels(PixelController<RGB_ORDER> pixels) {
+	template <uint8_t FLAGS, class D, EOrder RGB_ORDER> void writePixels(PixelController<RGB_ORDER> pixels, void* context = NULL) {
 		select();
 		int len = pixels.mLen;
 

--- a/src/platforms/arm/kl26/fastspi_arm_kl26.h
+++ b/src/platforms/arm/kl26/fastspi_arm_kl26.h
@@ -222,7 +222,7 @@ public:
   void writeBytes(FASTLED_REGISTER uint8_t *data, int len) { writeBytes<DATA_NOP>(data, len); }
 
 
-  template <uint8_t FLAGS, class D, EOrder RGB_ORDER> void writePixels(PixelController<RGB_ORDER> pixels) {
+  template <uint8_t FLAGS, class D, EOrder RGB_ORDER> void writePixels(PixelController<RGB_ORDER> pixels, void* context = NULL) {
     int len = pixels.mLen;
 
     select();

--- a/src/platforms/arm/mxrt1062/fastspi_arm_mxrt1062.h
+++ b/src/platforms/arm/mxrt1062/fastspi_arm_mxrt1062.h
@@ -112,7 +112,7 @@ public:
 
 	// write a block of uint8_ts out in groups of three.  len is the total number of uint8_ts to write out.  The template
 	// parameters indicate how many uint8_ts to skip at the beginning and/or end of each grouping
-	template <uint8_t FLAGS, class D, EOrder RGB_ORDER> void writePixels(PixelController<RGB_ORDER> pixels) {
+	template <uint8_t FLAGS, class D, EOrder RGB_ORDER> void writePixels(PixelController<RGB_ORDER> pixels, void* context = NULL) {
 		select();
     int len = pixels.mLen;
 

--- a/src/platforms/arm/nrf51/fastspi_arm_nrf51.h
+++ b/src/platforms/arm/nrf51/fastspi_arm_nrf51.h
@@ -123,7 +123,7 @@ public:
         NRF_SPI0->ENABLE = 1;
     }
 
-    template <uint8_t FLAGS, class D, EOrder RGB_ORDER> void writePixels(PixelController<RGB_ORDER> pixels) {
+    template <uint8_t FLAGS, class D, EOrder RGB_ORDER> void writePixels(PixelController<RGB_ORDER> pixels, void* context = NULL) {
         select();
         int len = pixels.mLen;
         while(pixels.has(1)) {

--- a/src/platforms/arm/nrf52/fastspi_arm_nrf52.h
+++ b/src/platforms/arm/nrf52/fastspi_arm_nrf52.h
@@ -299,7 +299,7 @@
         }
 
         /// write out pixel data from the given PixelController object, including select, release, and waiting
-        template <uint8_t FLAGS, class D, EOrder RGB_ORDER> void writePixels(PixelController<RGB_ORDER> pixels) {
+        template <uint8_t FLAGS, class D, EOrder RGB_ORDER> void writePixels(PixelController<RGB_ORDER> pixels, void* context = NULL) {
             select();
             int len = pixels.mLen;
             // TODO: If user indicates a pre-allocated double-buffer,

--- a/src/platforms/arm/sam/fastspi_arm_sam.h
+++ b/src/platforms/arm/sam/fastspi_arm_sam.h
@@ -131,7 +131,7 @@ public:
 
 	// write a block of uint8_ts out in groups of three.  len is the total number of uint8_ts to write out.  The template
 	// parameters indicate how many uint8_ts to skip at the beginning and/or end of each grouping
-	template <uint8_t FLAGS, class D, EOrder RGB_ORDER> void writePixels(PixelController<RGB_ORDER> pixels) {
+	template <uint8_t FLAGS, class D, EOrder RGB_ORDER> void writePixels(PixelController<RGB_ORDER> pixels, void* context = NULL) {
 		select();
 		int len = pixels.mLen;
 

--- a/src/platforms/avr/fastspi_avr.h
+++ b/src/platforms/avr/fastspi_avr.h
@@ -140,7 +140,7 @@ public:
 
 	// write a block of uint8_ts out in groups of three.  len is the total number of uint8_ts to write out.  The template
 	// parameters indicate how many uint8_ts to skip at the beginning and/or end of each grouping
-	template <uint8_t FLAGS, class D, EOrder RGB_ORDER> void writePixels(PixelController<RGB_ORDER> pixels) {
+	template <uint8_t FLAGS, class D, EOrder RGB_ORDER> void writePixels(PixelController<RGB_ORDER> pixels, void* context = NULL) {
 		//setSPIRate();
 		int len = pixels.mLen;
 
@@ -286,7 +286,7 @@ public:
 
 	// write a block of uint8_ts out in groups of three.  len is the total number of uint8_ts to write out.  The template
 	// parameters indicate how many uint8_ts to skip at the beginning and/or end of each grouping
-	template <uint8_t FLAGS, class D, EOrder RGB_ORDER> void writePixels(PixelController<RGB_ORDER> pixels) {
+	template <uint8_t FLAGS, class D, EOrder RGB_ORDER> void writePixels(PixelController<RGB_ORDER> pixels, void* context = NULL) {
 		//setSPIRate();
 		int len = pixels.mLen;
 
@@ -447,7 +447,7 @@ public:
 
 	// write a block of uint8_ts out in groups of three.  len is the total number of uint8_ts to write out.  The template
 	// parameters indicate how many uint8_ts to skip at the beginning and/or end of each grouping
-	template <uint8_t FLAGS, class D, EOrder RGB_ORDER> void writePixels(PixelController<RGB_ORDER> pixels) {
+	template <uint8_t FLAGS, class D, EOrder RGB_ORDER> void writePixels(PixelController<RGB_ORDER> pixels, void* context = NULL) {
 		//setSPIRate();
 		int len = pixels.mLen;
 
@@ -627,7 +627,7 @@ public:
 
 	// write a block of uint8_ts out in groups of three.  len is the total number of uint8_ts to write out.  The template
 	// parameters indicate how many uint8_ts to skip at the beginning and/or end of each grouping
-	template <uint8_t FLAGS, class D, EOrder RGB_ORDER> void writePixels(PixelController<RGB_ORDER> pixels) {
+	template <uint8_t FLAGS, class D, EOrder RGB_ORDER> void writePixels(PixelController<RGB_ORDER> pixels, void* context = NULL) {
 		//setSPIRate();
 		int len = pixels.mLen;
 
@@ -805,7 +805,7 @@ public:
 
 	// write a block of uint8_ts out in groups of three.  len is the total number of uint8_ts to write out.  The template
 	// parameters indicate how many uint8_ts to skip at the beginning and/or end of each grouping
-	template <uint8_t FLAGS, class D, EOrder RGB_ORDER> void writePixels(PixelController<RGB_ORDER> pixels) {
+	template <uint8_t FLAGS, class D, EOrder RGB_ORDER> void writePixels(PixelController<RGB_ORDER> pixels, void* context = NULL) {
 		//setSPIRate();
 		int len = pixels.mLen;
 

--- a/src/platforms/esp/32/fastspi_esp32.h
+++ b/src/platforms/esp/32/fastspi_esp32.h
@@ -112,10 +112,13 @@ public:
 	static void wait() __attribute__((always_inline)) { }
 	static void waitFully() __attribute__((always_inline)) { wait(); }
 
-	static void writeByteNoWait(uint8_t b) __attribute__((always_inline)) { writeByte(b); }
-	static void writeBytePostWait(uint8_t b) __attribute__((always_inline)) { writeByte(b); wait(); }
+	void writeByteNoWait(uint8_t b) __attribute__((always_inline)) { writeByte(b); }
+	void writeBytePostWait(uint8_t b) __attribute__((always_inline)) { writeByte(b); wait(); }
 
-	static void writeWord(uint16_t w) __attribute__((always_inline)) { writeByte(w>>8); writeByte(w&0xFF); }
+	void writeWord(uint16_t w) __attribute__((always_inline)) {
+		writeByte(static_cast<uint8_t>(w>>8));
+		writeByte(static_cast<uint8_t>(w&0xFF));
+	}
 
 	// naive writeByte implelentation, simply calls writeBit on the 8 bits in the byte.
 	void writeByte(uint8_t b) {
@@ -158,7 +161,7 @@ public:
 		while(data != end) {
 			writeByte(D::adjust(*data++));
 		}
-		D::postBlock(len);
+		D::postBlock(len, &m_ledSPI);
 		release();
 	}
 
@@ -173,7 +176,7 @@ public:
 	// write a block of uint8_ts out in groups of three.  len is the total number of uint8_ts to write out.  The template
 	// parameters indicate how many uint8_ts to skip at the beginning of each grouping, as well as a class specifying a per
 	// byte of data modification to be made.  (See DATA_NOP above)
-	template <uint8_t FLAGS, class D, EOrder RGB_ORDER>  __attribute__((noinline)) void writePixels(PixelController<RGB_ORDER> pixels) {
+	template <uint8_t FLAGS, class D, EOrder RGB_ORDER>  __attribute__((noinline)) void writePixels(PixelController<RGB_ORDER> pixels, void* context) {
 		select();
 		int len = pixels.mLen;
 		while(pixels.has(1)) {
@@ -186,7 +189,7 @@ public:
 			pixels.advanceData();
 			pixels.stepDithering();
 		}
-		D::postBlock(len);
+		D::postBlock(len, context);
 		release();
 	}
 };

--- a/src/platforms/esp/8266/fastspi_esp8266.h
+++ b/src/platforms/esp/8266/fastspi_esp8266.h
@@ -124,7 +124,7 @@ public:
 	// write a block of uint8_ts out in groups of three.  len is the total number of uint8_ts to write out.  The template
 	// parameters indicate how many uint8_ts to skip at the beginning of each grouping, as well as a class specifying a per
 	// byte of data modification to be made.  (See DATA_NOP above)
-	template <uint8_t FLAGS, class D, EOrder RGB_ORDER>  __attribute__((noinline)) void writePixels(PixelController<RGB_ORDER> pixels) {
+	template <uint8_t FLAGS, class D, EOrder RGB_ORDER>  __attribute__((noinline)) void writePixels(PixelController<RGB_ORDER> pixels, void* context = NULL) {
 		select();
 		int len = pixels.mLen;
 		while(pixels.has(1)) {

--- a/src/platforms/fastspi_ardunio_core.h
+++ b/src/platforms/fastspi_ardunio_core.h
@@ -75,7 +75,7 @@ public:
 
 	// write a block of uint8_ts out in groups of three.  len is the total number of uint8_ts to write out.  The template
 	// parameters indicate how many uint8_ts to skip at the beginning and/or end of each grouping
-	template <uint8_t FLAGS, class D, EOrder RGB_ORDER> void writePixels(PixelController<RGB_ORDER> pixels) {
+	template <uint8_t FLAGS, class D, EOrder RGB_ORDER> void writePixels(PixelController<RGB_ORDER> pixels, void* context = NULL) {
 		select();
     int len = pixels.mLen;
 


### PR DESCRIPTION
Fixes https://github.com/FastLED/FastLED/issues/1653

The compiler fix can be verified by running

`ci/ci-compile --boards esp32-s3-devkitc-1 --examples _bugs/1653_S3_Apa102_Hardware_Pins`

Note that I don't actually know if this works or not, I just fixed the compiler errors.