### PR TITLE
split the esp32-idf 4.x vs 5.x rmt driver. 5.x just redirects to 4.x

### DIFF
--- a/src/led_sysdefs.h
+++ b/src/led_sysdefs.h
@@ -63,14 +63,7 @@
 #error "This platform isn't recognized by FastLED... yet.  See comments in FastLED/led_sysdefs.h for options."
 #endif
 
-#ifndef FASTLED_NAMESPACE_BEGIN
-/// Start of the FastLED namespace
-#define FASTLED_NAMESPACE_BEGIN
-/// End of the FastLED namespace
-#define FASTLED_NAMESPACE_END
-/// "Using" directive for the namespace
-#define FASTLED_USING_NAMESPACE
-#endif
+#include "namespace.h"
 
 // Arduino.h needed for convenience functions digitalPinToPort/BitMask/portOutputRegister and the pinMode methods.
 #ifdef ARDUINO

--- a/src/namespace.h
+++ b/src/namespace.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#ifndef FASTLED_NAMESPACE_BEGIN
+/// Start of the FastLED namespace
+#define FASTLED_NAMESPACE_BEGIN
+/// End of the FastLED namespace
+#define FASTLED_NAMESPACE_END
+/// "Using" directive for the namespace
+#define FASTLED_USING_NAMESPACE
+#endif

--- a/src/platforms/esp/32/clockless_rmt_esp32.h
+++ b/src/platforms/esp/32/clockless_rmt_esp32.h
@@ -25,99 +25,10 @@
 
 #pragma once
 
-#include "rmt.h"
+#include "esp_idf_version.h"
 
-FASTLED_NAMESPACE_BEGIN
-
-
-#define FASTLED_HAS_CLOCKLESS 1
-#define NUM_COLOR_CHANNELS 3
-
-
-template <int DATA_PIN, int T1, int T2, int T3, EOrder RGB_ORDER = RGB, int XTRA0 = 0, bool FLIP = false, int WAIT_TIME = 5>
-class ClocklessController : public CPixelLEDController<RGB_ORDER>
-{
-private:
-
-    // -- The actual controller object for ESP32
-    ESP32RMTController mRMTController;
-
-    // -- Verify that the pin is valid
-    static_assert(FastPin<DATA_PIN>::validpin(), "Invalid pin specified");
-
-public:
-
-    ClocklessController()
-        : mRMTController(DATA_PIN, T1, T2, T3, FASTLED_RMT_MAX_CHANNELS, FASTLED_RMT_BUILTIN_DRIVER)
-        {}
-
-    void init()
-    {
-    }
-
-    virtual uint16_t getMaxRefreshRate() const { return 400; }
-
-protected:
-
-    // -- Load pixel data
-    //    This method loads all of the pixel data into a separate buffer for use by
-    //    by the RMT driver. Copying does two important jobs: it fixes the color
-    //    order for the pixels, and it performs the scaling/adjusting ahead of time.
-    //    It also packs the bytes into 32 bit chunks with the right bit order.
-    void loadPixelData(PixelController<RGB_ORDER> & pixels)
-    {
-        // -- Make sure the buffer is allocated
-        int size_in_bytes = pixels.size() * 3;
-        uint8_t * pData = mRMTController.getPixelBuffer(size_in_bytes);
-
-        // -- This might be faster
-        while (pixels.has(1)) {
-            *pData++ = pixels.loadAndScale0();
-            *pData++ = pixels.loadAndScale1();
-            *pData++ = pixels.loadAndScale2();
-            pixels.advanceData();
-            pixels.stepDithering();
-        }
-    }
-
-    // -- Show pixels
-    //    This is the main entry point for the controller.
-    virtual void showPixels(PixelController<RGB_ORDER> & pixels)
-    {
-        if (FASTLED_RMT_BUILTIN_DRIVER) {
-            convertAllPixelData(pixels);
-        } else {
-            loadPixelData(pixels);
-        }
-
-        mRMTController.showPixels();
-    }
-
-    // -- Convert all pixels to RMT pulses
-    //    This function is only used when the user chooses to use the
-    //    built-in RMT driver, which needs all of the RMT pulses
-    //    up-front.
-    void convertAllPixelData(PixelController<RGB_ORDER> & pixels)
-    {
-        // -- Make sure the data buffer is allocated
-        mRMTController.initPulseBuffer(pixels.size() * 3);
-
-        // -- Cycle through the R,G, and B values in the right order,
-        //    storing the pulses in the big buffer
-
-        uint32_t byteval;
-        while (pixels.has(1)) {
-            byteval = pixels.loadAndScale0();
-            mRMTController.ingest(byteval);
-            byteval = pixels.loadAndScale1();
-            mRMTController.ingest(byteval);
-            byteval = pixels.loadAndScale2();
-            mRMTController.ingest(byteval);
-            pixels.advanceData();
-            pixels.stepDithering();
-        }
-    }
-};
-
-
-FASTLED_NAMESPACE_END
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 0, 0)
+#include "idf4_clockless_rmt_esp32.h"
+#else
+#include "idf5_clockless_rmt_esp32.h"
+#endif

--- a/src/platforms/esp/32/idf4_clockless_rmt_esp32.h
+++ b/src/platforms/esp/32/idf4_clockless_rmt_esp32.h
@@ -1,0 +1,126 @@
+/*
+ * Integration into FastLED ClocklessController
+ * Copyright (c) 2024, Zach Vorhies
+ * Copyright (c) 2018,2019,2020 Samuel Z. Guyer
+ * Copyright (c) 2017 Thomas Basler
+ * Copyright (c) 2017 Martin F. Falatic
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#pragma once
+
+
+#include "idf4_rmt.h"
+#include "FastLED.h"
+
+
+FASTLED_NAMESPACE_BEGIN
+
+
+#define FASTLED_HAS_CLOCKLESS 1
+#define NUM_COLOR_CHANNELS 3
+
+
+template <int DATA_PIN, int T1, int T2, int T3, EOrder RGB_ORDER = RGB, int XTRA0 = 0, bool FLIP = false, int WAIT_TIME = 5>
+class ClocklessController : public CPixelLEDController<RGB_ORDER>
+{
+private:
+
+    // -- The actual controller object for ESP32
+    ESP32RMTController mRMTController;
+
+    // -- Verify that the pin is valid
+    static_assert(FastPin<DATA_PIN>::validpin(), "Invalid pin specified");
+
+public:
+
+    ClocklessController()
+        : mRMTController(DATA_PIN, T1, T2, T3, FASTLED_RMT_MAX_CHANNELS, FASTLED_RMT_BUILTIN_DRIVER)
+        {}
+
+    void init()
+    {
+    }
+
+    virtual uint16_t getMaxRefreshRate() const { return 400; }
+
+protected:
+
+    // -- Load pixel data
+    //    This method loads all of the pixel data into a separate buffer for use by
+    //    by the RMT driver. Copying does two important jobs: it fixes the color
+    //    order for the pixels, and it performs the scaling/adjusting ahead of time.
+    //    It also packs the bytes into 32 bit chunks with the right bit order.
+    void loadPixelData(PixelController<RGB_ORDER> & pixels)
+    {
+        // -- Make sure the buffer is allocated
+        int size_in_bytes = pixels.size() * 3;
+        uint8_t * pData = mRMTController.getPixelBuffer(size_in_bytes);
+
+        // -- This might be faster
+        while (pixels.has(1)) {
+            *pData++ = pixels.loadAndScale0();
+            *pData++ = pixels.loadAndScale1();
+            *pData++ = pixels.loadAndScale2();
+            pixels.advanceData();
+            pixels.stepDithering();
+        }
+    }
+
+    // -- Show pixels
+    //    This is the main entry point for the controller.
+    virtual void showPixels(PixelController<RGB_ORDER> & pixels)
+    {
+        if (FASTLED_RMT_BUILTIN_DRIVER) {
+            convertAllPixelData(pixels);
+        } else {
+            loadPixelData(pixels);
+        }
+
+        mRMTController.showPixels();
+    }
+
+    // -- Convert all pixels to RMT pulses
+    //    This function is only used when the user chooses to use the
+    //    built-in RMT driver, which needs all of the RMT pulses
+    //    up-front.
+    void convertAllPixelData(PixelController<RGB_ORDER> & pixels)
+    {
+        // -- Make sure the data buffer is allocated
+        mRMTController.initPulseBuffer(pixels.size() * 3);
+
+        // -- Cycle through the R,G, and B values in the right order,
+        //    storing the pulses in the big buffer
+
+        uint32_t byteval;
+        while (pixels.has(1)) {
+            byteval = pixels.loadAndScale0();
+            mRMTController.ingest(byteval);
+            byteval = pixels.loadAndScale1();
+            mRMTController.ingest(byteval);
+            byteval = pixels.loadAndScale2();
+            mRMTController.ingest(byteval);
+            pixels.advanceData();
+            pixels.stepDithering();
+        }
+    }
+};
+
+
+FASTLED_NAMESPACE_END

--- a/src/platforms/esp/32/idf4_rmt.cpp
+++ b/src/platforms/esp/32/idf4_rmt.cpp
@@ -1,7 +1,9 @@
 
 #ifdef ESP32
 
-#include "led_sysdefs_esp32.h"
+#include "FastLED.h"
+#include "idf4_rmt.h"
+
 
 #ifndef FASTLED_ESP32_I2S
 
@@ -85,9 +87,8 @@ extern void spi_flash_op_unlock(void);
 }
 #endif
 
-
 #define FASTLED_INTERNAL
-#include "FastLED.h"
+
 
 __attribute__ ((always_inline)) inline static uint32_t __clock_cycles() {
   uint32_t cyc;

--- a/src/platforms/esp/32/idf4_rmt.h
+++ b/src/platforms/esp/32/idf4_rmt.h
@@ -114,6 +114,7 @@
 
 #pragma once
 
+#include "namespace.h"
 
 
 FASTLED_NAMESPACE_BEGIN

--- a/src/platforms/esp/32/idf5_clockless_rmt_esp32.h
+++ b/src/platforms/esp/32/idf5_clockless_rmt_esp32.h
@@ -1,0 +1,4 @@
+#pragma once
+
+#warning "Using the legacy RMT driver. This will crash your system if any other code initializes the new RMT driver."
+#include "idf4_clockless_rmt_esp32.h"


### PR DESCRIPTION
This is needed in preparation for a new RMT driver for the esp-idf 5.x platform.

There was an issue with having to include "FastLED.h" for the namespace stuff. So namespace.h has been created so that cpp files can use a more minimal inclusion system.