### PR TITLE
correct RP2350 PIO count / fix double define SysTick

### DIFF
--- a/src/platforms/arm/common/m0clockless.h
+++ b/src/platforms/arm/common/m0clockless.h
@@ -26,8 +26,6 @@ typedef struct {
     volatile const uint32_t CALIB;
 } SysTick_Type;
 
-// Define the SysTick
-#define SysTick ((SysTick_Type *)SysTick_BASE)
 #endif
 // END SysTick DEFINITION
 

--- a/src/platforms/arm/rp2040/clockless_arm_rp2040.h
+++ b/src/platforms/arm/rp2040/clockless_arm_rp2040.h
@@ -144,9 +144,14 @@ public:
         int sm;
         int offset = -1;
         
+	#if defined(PICO_RP2040)
         // find an unclaimed PIO state machine and upload the clockless program if possible
         // there's two PIO instances, each with four state machines, so this should usually work out fine
-        const PIO pios[NUM_PIOS] = { pio0, pio1 };
+		const PIO pios[NUM_PIOS] = { pio0, pio1 };
+	#elif defined(PICO_RP2350)
+		// RP2350 features three PIO instances!
+		const PIO pios[NUM_PIOS] = { pio0, pio1, pio2 };
+	#endif
         // iterate over PIO instances
         for (unsigned int i = 0; i < NUM_PIOS; i++) {
             pio = pios[i];


### PR DESCRIPTION
- RP2350 features three PIO instances!
- fix double define for SysTick