### PR TITLE
Add RP2040 Arduino-Pico build

### DIFF
--- a/.github/workflows/build_rp2040_earle.yml
+++ b/.github/workflows/build_rp2040_earle.yml
@@ -1,0 +1,16 @@
+name: rp2040 earle
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    uses: ./.github/workflows/build_template_custom_board.yml
+    with:
+      args: --boards rpipico

--- a/ci/boards/rpipico.json
+++ b/ci/boards/rpipico.json
@@ -1,0 +1,56 @@
+{
+    "build": {
+        "arduino": {
+            "earlephilhower": {
+                "boot2_source": "boot2_w25q080_2_padded_checksum.S",
+                "usb_vid": "0x2E8A",
+                "usb_pid": "0x000A"
+            }
+        },
+        "core": "earlephilhower",
+        "cpu": "cortex-m0plus",
+        "extra_flags": "-DARDUINO_RASPBERRY_PI_PICO -DARDUINO_ARCH_RP2040 -DUSBD_MAX_POWER_MA=250 ",
+        "f_cpu": "133000000L",
+        "hwids": [
+            [
+                "0x2E8A",
+                "0x00C0"
+            ],
+            [
+                "0x2E8A",
+                "0x000A"
+            ]
+        ],
+        "mcu": "rp2040",
+        "variant": "rpipico"
+    },
+    "debug": {
+        "jlink_device": "RP2040_M0_0",
+        "openocd_target": "rp2040.cfg",
+        "svd_path": "rp2040.svd"
+    },
+    "frameworks": [
+        "arduino"
+    ],
+    "name": "Pico",
+    "upload": {
+        "maximum_ram_size": 262144,
+        "maximum_size": 2097152,
+        "require_upload_port": true,
+        "native_usb": true,
+        "use_1200bps_touch": true,
+        "wait_for_upload_port": false,
+        "protocol": "picotool",
+        "protocols": [
+            "blackmagic",
+            "cmsis-dap",
+            "jlink",
+            "raspberrypi-swd",
+            "picotool",
+            "picoprobe",
+            "pico-debug"
+        ]
+    },
+    "url": "https://www.raspberrypi.org/products/raspberry-pi-pico/",
+    "vendor": "Raspberry Pi"
+}

--- a/ci/ci-compile.py
+++ b/ci/ci-compile.py
@@ -87,8 +87,14 @@ CUSTOM_PROJECT_OPTIONS = {
     "esp32-s3-devkitc-1": [f"platform={ESP32_IDF_5_1}"],
     "esp32-h2-devkitm-1": [f"platform={ESP32_IDF_5_1_LATEST}"],
     "adafruit_feather_nrf52840_sense": ["platform=nordicnrf52"],
+    "rpipico": [
+        "platform=https://github.com/maxgerhardt/platform-raspberrypi.git",
+        "platform_packages=framework-arduinopico@https://github.com/earlephilhower/arduino-pico.git",
+        "framework=arduino",
+        "board_build.core=earlephilhower",
+        "board_build.filesystem_size=0.5m"
+    ],
     "rpipico2": [
-        #"platform=https://github.com/earlephilhower/arduino-pico.git",
         "platform=https://github.com/maxgerhardt/platform-raspberrypi.git",
         "platform_packages=framework-arduinopico@https://github.com/earlephilhower/arduino-pico.git",
         "framework=arduino",


### PR DESCRIPTION
Instead of just compiling for `nanorp2040connect` which by-default uses the ArduinoCore-mbed, explicitly adds `rpipico` to the build as Rasberry Pi Pico (Arduino-Pico core by Earle Phihower).