### PR TITLE
Make NRF sense work

### DIFF
--- a/examples/Apa102HD/Apa102HD.ino
+++ b/examples/Apa102HD/Apa102HD.ino
@@ -34,6 +34,7 @@
 
 #define NUM_LEDS  20
 // uint8_t DATA_PIN, uint8_t CLOCK_PIN,
+
 #define STRIP_0_DATA_PIN 1
 #define STRIP_0_CLOCK_PIN 2
 #define STRIP_1_DATA_PIN 3
@@ -84,4 +85,3 @@ void loop() {
     FastLED.show();  // All leds are now written out.
     delay(8);  // Wait 8 milliseconds until the next frame.
 }
-

--- a/src/platforms/arm/nrf52/fastpin_arm_nrf52.h
+++ b/src/platforms/arm/nrf52/fastpin_arm_nrf52.h
@@ -1,6 +1,8 @@
 #ifndef __FASTPIN_ARM_NRF52_H
 #define __FASTPIN_ARM_NRF52_H
 
+#include <assert.h>
+
 
 /*
 //
@@ -144,7 +146,11 @@ public:
 template <uint32_t _MASK, typename _PORT, uint8_t _PORT_NUMBER, uint8_t _PIN_NUMBER>
 class _INVALID_ARMPIN: public _ARMPIN<_MASK, _PORT, _PORT_NUMBER, _PIN_NUMBER> {
 public:
-    static_assert(false, "For whatever reason, this pin has been marked as invalid and you should use a different pin.");
+    _INVALID_ARMPIN() {
+        Serial.println("For whatever reason, this pin has been marked as invalid and you should use a different pin.")
+        assert(false);
+    }
+    
 };
 
 //


### PR DESCRIPTION
Turn 20 pages of compiler error messages into one line on the nrf sense boards.

This pattern should probably be copied everywhere to reduce compiler spew.