### PR TITLE
Further clean up after PR 1719 for Nano Every

### DIFF
--- a/.github/workflows/build_nano_every.yml
+++ b/.github/workflows/build_nano_every.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+      - fix-nano-every-build
 
 jobs:
   build:

--- a/.github/workflows/build_nano_every.yml
+++ b/.github/workflows/build_nano_every.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - master
-      - fix-nano-every-build
 
 jobs:
   build:

--- a/src/platforms/avr/fastpin_avr.h
+++ b/src/platforms/avr/fastpin_avr.h
@@ -7,8 +7,16 @@
 // This god-header is too big and AI will stumble trying to generate the correct
 // edits.
 
-#if defined(ARDUINO_AVR_NANO_EVERY)
-#include "fastpin_avr_nano_every.h"
+// Nano Every is also powered by ATmega4809
+#ifdef __AVR_ATmega4809__
+    #ifdef ARDUINO_AVR_NANO_EVERY
+    #include "fastpin_avr_nano_every.h"
+
+    #else
+    #include "fastpin_avr_atmega4809.h"
+
+    #endif  // ARDUINO_AVR_NANO_EVERY
+
 #else
 
 #include "namespace.h"
@@ -16,7 +24,7 @@
 
 FASTLED_NAMESPACE_BEGIN
 
-#if defined(FASTLED_FORCE_SOFTWARE_PINS)
+#ifdef FASTLED_FORCE_SOFTWARE_PINS
 #warning "Software pin support forced, pin access will be slightly slower."
 #define NO_HARDWARE_PIN_SUPPORT
 #undef HAS_HARDWARE_PIN_SUPPORT
@@ -37,15 +45,7 @@ typedef volatile uint8_t & reg8_t;
 
 // Register name equivalent (using flat names)
 
-#if defined(ARDUINO_AVR_NANO_EVERY)
-// This block must be before the elif block of __AVR_ATmega4809__ , because Nano Every is also powered by ATmega4809
-// Optimize Nano Every: Leverage VPORTs instead of PORTs for faster access
-
-#define _FL_IO(L,C) _RD8(VPORT ## L ## _DIR); _RD8(VPORT ## L ## _OUT); _RD8(VPORT ## L ## _IN); _FL_DEFINE_PORT3(L, C, _R(VPORT ## L ## _OUT));
-#define _FL_DEFPIN(_PIN, BIT, L) template<> class FastPin<_PIN> : public _AVRPIN<_PIN, 1<<BIT, _R(VPORT ## L ## _OUT), _R(VPORT ## L ## _DIR), _R(VPORT ## L ## _IN)> {};
-
-#elif defined(__AVR_ATmega4809__) || defined(__AVR_ATtinyxy7__) || defined(__AVR_ATtinyxy6__) || defined(__AVR_ATtinyxy4__) || defined(__AVR_ATtinyxy2__)
-// ATmega series 0 , excludes Arduino Nano Every which optimised with VPORTs, include boards eg. Arduino Uno Wifi Rev 2 or Rev 3
+#if defined(__AVR_ATtinyxy7__) || defined(__AVR_ATtinyxy6__) || defined(__AVR_ATtinyxy4__) || defined(__AVR_ATtinyxy2__)
 // ATtiny series 0/1
 
 #define _FL_IO(L,C) _RD8(PORT ## L ## _DIR); _RD8(PORT ## L ## _OUT); _RD8(PORT ## L ## _IN); _FL_DEFINE_PORT3(L, C, _R(PORT ## L ## _OUT));
@@ -221,25 +221,6 @@ _FL_DEFPIN(16, 2, C); _FL_DEFPIN(17, 3, C); _FL_DEFPIN(18, 4, C); _FL_DEFPIN(19,
 #define SPI_UART0_CLOCK 12
 #endif
 
-#elif defined(ARDUINO_AVR_NANO_EVERY)
-
-#define MAX_PIN 22
-_FL_DEFPIN(0, 5, C); _FL_DEFPIN(1, 4, C); _FL_DEFPIN(2, 0, A); _FL_DEFPIN(3, 5, F);
-_FL_DEFPIN(4, 6, C); _FL_DEFPIN(5, 2, B); _FL_DEFPIN(6, 4, F); _FL_DEFPIN(7, 1, A);
-_FL_DEFPIN(8, 3, E); _FL_DEFPIN(9, 0, B); _FL_DEFPIN(10, 1, B); _FL_DEFPIN(11, 0, E);
-_FL_DEFPIN(12, 1, E); _FL_DEFPIN(13, 2, E); _FL_DEFPIN(14, 3, D); _FL_DEFPIN(15, 2, D);
-_FL_DEFPIN(16, 1, D); _FL_DEFPIN(17, 0, D);
-//_FL_DEFPIN(18, 2, A); _FL_DEFPIN(19, 3, A);
- _FL_DEFPIN(18, 2, F); _FL_DEFPIN(19, 3, F);
-_FL_DEFPIN(20, 4, D); _FL_DEFPIN(21, 5, D); _FL_DEFPIN(22, 2, A);
-
-// To confirm for the SPI interfaces
-#define SPI_DATA 11
-#define SPI_CLOCK 13
-#define SPI_SELECT 8
-#define AVR_HARDWARE_SPI 1
-#define HAS_HARDWARE_PIN_SUPPORT 1
-
 #elif defined(__AVR_ATtiny202__) || defined(__AVR_ATtiny204__) || defined(__AVR_ATtiny212__) || defined(__AVR_ATtiny214__)  || defined(__AVR_ATtiny402__) || defined(__AVR_ATtiny404__) || defined(__AVR_ATtiny406__) || defined(__AVR_ATtiny407__) || defined(__AVR_ATtiny412__) || defined(__AVR_ATtiny414__) || defined(__AVR_ATtiny416__) || defined(__AVR_ATtiny417__)
 #pragma message "ATtiny2YZ or ATtiny4YZ have very limited storage. This library could use up to more than 100% of its flash size"
 
@@ -273,26 +254,6 @@ _FL_DEFPIN(16, 4, C); _FL_DEFPIN(17, 5, C); _FL_DEFPIN(18, 1, A); _FL_DEFPIN(19,
 _FL_DEFPIN(20, 3, A); _FL_DEFPIN(21, 0, A);
 
 #define HAS_HARDWARE_PIN_SUPPORT 1
-
-#elif defined(__AVR_ATmega4809__)
-
-#define MAX_PIN 21
-_FL_DEFPIN(0, 4, C); _FL_DEFPIN(1, 5, C); _FL_DEFPIN(2, 0, A); _FL_DEFPIN(3, 5, F);
-_FL_DEFPIN(4, 6, C); _FL_DEFPIN(5, 2, B); _FL_DEFPIN(6, 4, F); _FL_DEFPIN(7, 1, A);
-_FL_DEFPIN(8, 3, E); _FL_DEFPIN(9, 0, B); _FL_DEFPIN(10, 1, B); _FL_DEFPIN(11, 0, E);
-_FL_DEFPIN(12, 1, E); _FL_DEFPIN(13, 2, E); _FL_DEFPIN(14, 3, D); _FL_DEFPIN(15, 2, D);
-_FL_DEFPIN(16, 1, D); _FL_DEFPIN(17, 0, D); _FL_DEFPIN(18, 2, A); _FL_DEFPIN(19, 3, A);
-_FL_DEFPIN(20, 4, D); _FL_DEFPIN(21, 5, D);
-
-#define SPI_DATA 11
-#define SPI_CLOCK 13
-#define SPI_SELECT 8
-#define AVR_HARDWARE_SPI 1
-#define HAS_HARDWARE_PIN_SUPPORT 1
-
-//#define SPI_UART0_DATA 1
-//#define SPI_UART0_CLOCK 4
-
 
 #elif defined(__AVR_ATmega328P__) || defined(__AVR_ATmega328PB__) || defined(__AVR_ATmega328__) || defined(__AVR_ATmega168__) || defined(__AVR_ATmega168P__) || defined(__AVR_ATmega8__)
 
@@ -485,6 +446,6 @@ _FL_DEFPIN(52, 7, F);
 FASTLED_NAMESPACE_END
 
 
-#endif  // __INC_FASTPIN_AVR_H
+#endif  // __AVR_ATmega4809__ or ARDUINO_AVR_NANO_EVERY
 
 #endif // __INC_FASTPIN_AVR_H

--- a/src/platforms/avr/fastpin_avr_atmega4809.h
+++ b/src/platforms/avr/fastpin_avr_atmega4809.h
@@ -1,3 +1,7 @@
+// ATmega series 0
+// excludes Arduino Nano Every which optimised with VPORTs
+// include boards eg. Arduino Uno Wifi Rev 2 or Rev 3
+
 #pragma once
 
 #include <avr/io.h>
@@ -22,22 +26,20 @@ typedef volatile uint8_t& reg8_t;
 #define _R(T) struct __gen_struct_##T
 #define _RD8(T) struct __gen_struct_##T { static inline reg8_t& r() { return T; } };
 
-#define _CONCAT2(a, b) a##b
-#define _CONCAT3(a, b, c) a##b##c
+#define _FL_IO(L,C)             \
+    _RD8(PORT ## L ## _DIR);    \
+    _RD8(PORT ## L ## _OUT);    \
+    _RD8(PORT ## L ## _IN);     \
+    _FL_DEFINE_PORT3(L, C, _R(PORT ## L ## _OUT));
 
-// Use VPORTx registers for direct port manipulation
-#define _FL_IO(L, C)                                                                                  \
-    struct _CONCAT3(__gen_struct_VPORT, L, _DIR) { static inline reg8_t& r() { return VPORT##L.DIR; } }; \
-    struct _CONCAT3(__gen_struct_VPORT, L, _OUT) { static inline reg8_t& r() { return VPORT##L.OUT; } }; \
-    struct _CONCAT3(__gen_struct_VPORT, L, _IN) { static inline reg8_t& r() { return VPORT##L.IN; } };   \
-    _FL_DEFINE_PORT3(L, C, _CONCAT3(__gen_struct_VPORT, L, _OUT));
-
-#define _FL_DEFPIN(_PIN, BIT, L)                                                                        \
-    template<> class FastPin<_PIN> : public _AVRPIN<_PIN, 1 << BIT,                                     \
-        _CONCAT3(__gen_struct_VPORT, L, _OUT),                                                          \
-        _CONCAT3(__gen_struct_VPORT, L, _DIR),                                                          \
-        _CONCAT3(__gen_struct_VPORT, L, _IN)> {};
-
+#define _FL_DEFPIN(_PIN, BIT, L)                        \
+    template<> class FastPin<_PIN> : public _AVRPIN<    \
+        _PIN,                                           \
+        1<<BIT,                                         \
+        _R(PORT ## L ## _OUT),                          \
+        _R(PORT ## L ## _DIR),                          \
+        _R(PORT ## L ## _IN)                            \
+    > {};
 
 
 // Pre-do all the port definitions
@@ -84,19 +86,23 @@ _FL_IO(M, 12)
 _FL_IO(N, 13)
 #endif
 
-#define MAX_PIN 22
-_FL_DEFPIN(0, 5, C); _FL_DEFPIN(1, 4, C); _FL_DEFPIN(2, 0, A); _FL_DEFPIN(3, 5, F);
+#define MAX_PIN 21
+_FL_DEFPIN(0, 4, C); _FL_DEFPIN(1, 5, C); _FL_DEFPIN(2, 0, A); _FL_DEFPIN(3, 5, F);
 _FL_DEFPIN(4, 6, C); _FL_DEFPIN(5, 2, B); _FL_DEFPIN(6, 4, F); _FL_DEFPIN(7, 1, A);
 _FL_DEFPIN(8, 3, E); _FL_DEFPIN(9, 0, B); _FL_DEFPIN(10, 1, B); _FL_DEFPIN(11, 0, E);
 _FL_DEFPIN(12, 1, E); _FL_DEFPIN(13, 2, E); _FL_DEFPIN(14, 3, D); _FL_DEFPIN(15, 2, D);
-_FL_DEFPIN(16, 1, D); _FL_DEFPIN(17, 0, D); _FL_DEFPIN(18, 2, F); _FL_DEFPIN(19, 3, F);
-_FL_DEFPIN(20, 4, D); _FL_DEFPIN(21, 5, D); _FL_DEFPIN(22, 2, A);
+_FL_DEFPIN(16, 1, D); _FL_DEFPIN(17, 0, D); _FL_DEFPIN(18, 2, A); _FL_DEFPIN(19, 3, A);
+_FL_DEFPIN(20, 4, D); _FL_DEFPIN(21, 5, D);
 
 #define SPI_DATA 11
 #define SPI_CLOCK 13
 #define SPI_SELECT 8
 #define AVR_HARDWARE_SPI 1
 #define HAS_HARDWARE_PIN_SUPPORT 1
+
+//todo: pins has not been confirmed thus not enabled
+//#define SPI_UART0_DATA 1
+//#define SPI_UART0_CLOCK 4
 
 
 

--- a/src/platforms/avr/fastpin_avr_atmega4809.h
+++ b/src/platforms/avr/fastpin_avr_atmega4809.h
@@ -23,8 +23,11 @@ FASTLED_NAMESPACE_BEGIN
 
 typedef volatile uint8_t& reg8_t;
 
+//todo: replace with _CONCAT3 like avr_nano_every.h
+//but why VPORT##L.DIR not VPORT##L##DIR - is it due to _DIR ?
 #define _R(T) struct __gen_struct_##T
 #define _RD8(T) struct __gen_struct_##T { static inline reg8_t& r() { return T; } };
+//#define _CONCAT3(a, b, c) a##b##c
 
 #define _FL_IO(L,C)             \
     _RD8(PORT ## L ## _DIR);    \

--- a/src/platforms/avr/fastpin_avr_nano_every.h
+++ b/src/platforms/avr/fastpin_avr_nano_every.h
@@ -19,10 +19,6 @@ FASTLED_NAMESPACE_BEGIN
 
 typedef volatile uint8_t& reg8_t;
 
-#define _R(T) struct __gen_struct_##T
-#define _RD8(T) struct __gen_struct_##T { static inline reg8_t& r() { return T; } };
-
-#define _CONCAT2(a, b) a##b
 #define _CONCAT3(a, b, c) a##b##c
 
 // Use VPORTx registers for direct port manipulation


### PR DESCRIPTION
Changes:
1. Complete removal of `ARDUINO_AVR_NANO_EVERY` conditionals from `fastpin_avr.h` to avoid unintentional overwriting pin definition. Arduino Nano Every is subset of ATmega4809 .
2. Extract file `fastpin_avr_atmega4809.h` from `fastpin_avr.h`

More details on:
- https://github.com/FastLED/FastLED/pull/1719#issuecomment-2359697145