### PR TITLE
Fix static_assert call on C++11 (fixes #1734)

### DIFF
--- a/src/chipsets.h
+++ b/src/chipsets.h
@@ -90,7 +90,7 @@ class RGBWEmulatedController
     static const uint32_t MASK = CONTROLLER::MASK_VALUE;
 
     // The delegated controller must do no reordering.
-    static_assert(RGB == CONTROLLER::RGB_ORDER_VALUE);
+    static_assert(RGB == CONTROLLER::RGB_ORDER_VALUE, "The delegated controller MUST NOT do reordering");
 
     RGBWEmulatedController(const Rgbw& rgbw = RgbwDefault()) {
         this->setRgbw(rgbw);


### PR DESCRIPTION
C/++11 does not support calling static_assert with no error message. This PR adds it. 
In all honest I did not completely understand the functioning so I just copied the message from above. 
Please feel free to edit it as deemed necessary :)

Thanks for all the awesome work in FastLED <3

EDIT: This fixes #1734.