### PR TITLE
Fix fill_rainbow and operator() for CPixelView with reverse direction

### DIFF
--- a/src/pixelset.h
+++ b/src/pixelset.h
@@ -109,7 +109,7 @@ public:
     /// result in a reverse ordering for many functions (useful for mirroring).
     /// @param start the first element from this set for the new subset
     /// @param end the last element for the new subset
-    inline CPixelView operator()(int start, int end) { return CPixelView(leds, start, end); }
+    inline CPixelView operator()(int start, int end) { if(dir & 0x80) { return CPixelView(leds+len+1, -len-start-1, -len-end-1); } else { return CPixelView(leds, start, end); } }
 
     // Access an inclusive subset of the LEDs in this set, starting from the first.
     // @param end the last element for the new subset
@@ -242,7 +242,7 @@ public:
         if(dir >= 0) {
             FUNCTION_FILL_RAINBOW(leds,len,initialhue,deltahue);
         } else {
-            FUNCTION_FILL_RAINBOW(leds+len+1,-len,initialhue,deltahue);
+            FUNCTION_FILL_RAINBOW(leds + len + 1, -len, initialhue - deltahue * (len+1), -deltahue);
         }
         return *this;
     }


### PR DESCRIPTION
This PR includes two fixes when working with `CPixelView` when reverse direction is set (`dir == -1`).

For `operator()`, it now returns a new CPixelView with the correct `dir` value, respecting the `dir` value of the original `CPixelView`. It hides the internal `led` array from the user, so they do not need to know whether the original `CPixelView` is in forwards or reverse order.

For `CPixelView::fill_rainbow`, it now behaves similar to `CPixelView::fill_gradient`, `CPixelView::fill_gradient_RGB`, `CPixelView::nblend`, and other methods. It swaps the start and end colours when `dir == -1`. Again, this allows a reversed `CPixelView` to be treated the same as a physically reversed strip of LEDs, so the user does not need to know any details of the internal `led` array and `dir` value to use it correctly.