### PR TITLE
fix: don't use DMA with RMT on ESP32-C6

### DIFF
--- a/src/platforms/esp/32/led_strip/defs.h
+++ b/src/platforms/esp/32/led_strip/defs.h
@@ -23,7 +23,7 @@
 #endif  // LED_STRIP_RMT_DEFAULT_MEM_BLOCK_SYMBOLS
 
 #ifndef FASTLED_RMT_WITH_DMA
-#if defined(CONFIG_IDF_TARGET_ESP32) || defined(CONFIG_IDF_TARGET_ESP32S2) || defined(ESP8266) || defined(CONFIG_IDF_TARGET_ESP32C3)
+#if defined(CONFIG_IDF_TARGET_ESP32) || defined(CONFIG_IDF_TARGET_ESP32S2) || defined(ESP8266) || defined(CONFIG_IDF_TARGET_ESP32C3) || defined(CONFIG_IDF_TARGET_ESP32C6)
 // This can be a runtime parameter that adjusts to the chip detection feature of esp-idf.
  #define FASTLED_RMT_WITH_DMA 0
 #else


### PR DESCRIPTION
Using DMA with RMT on the ESP32-C6 causes a crash. This commit adds the -C6 to the list of devices for which FastLED shouldn't be using DMA.

Signed-off-by: Nita Vesa <nita.vesa@outlook.com>