### PR TITLE
Fix unused parameter compiler warnings

### DIFF
--- a/src/fx/fx.h
+++ b/src/fx/fx.h
@@ -40,10 +40,10 @@ class Fx : public Referent {
     virtual int fxNum() const {
         return 1;
     }; // Return 1 if you only have one fx managed by this class.
-    virtual void fxSet(int fx) {}; // Set the current fx number.
+    virtual void fxSet(int fx) {(void)fx;}; // Set the current fx number.
 
      // Negative numbers are allowed. -1 means previous fx.
-    virtual void fxNext(int fx = 1) {};
+    virtual void fxNext(int fx = 1) {(void)fx;};
     virtual int fxGet() const { return 0; }; // Get the current fx number.
 
     virtual void pause() {

--- a/src/rgbw.cpp
+++ b/src/rgbw.cpp
@@ -39,6 +39,7 @@ void rgb_2_rgbw_exact(uint16_t w_color_temperature, uint8_t r, uint8_t g,
                       uint8_t b, uint8_t r_scale, uint8_t g_scale,
                       uint8_t b_scale, uint8_t *out_r, uint8_t *out_g,
                       uint8_t *out_b, uint8_t *out_w) {
+    (void)w_color_temperature;
     r = scale8(r, r_scale);
     g = scale8(g, g_scale);
     b = scale8(b, b_scale);
@@ -53,6 +54,7 @@ void rgb_2_rgbw_max_brightness(uint16_t w_color_temperature, uint8_t r,
                                uint8_t g, uint8_t b, uint8_t r_scale,
                                uint8_t g_scale, uint8_t b_scale, uint8_t *out_r,
                                uint8_t *out_g, uint8_t *out_b, uint8_t *out_w) {
+    (void)w_color_temperature;
     *out_r = scale8(r, r_scale);
     *out_g = scale8(g, g_scale);
     *out_b = scale8(b, b_scale);
@@ -64,6 +66,7 @@ void rgb_2_rgbw_null_white_pixel(uint16_t w_color_temperature, uint8_t r,
                                  uint8_t g_scale, uint8_t b_scale,
                                  uint8_t *out_r, uint8_t *out_g, uint8_t *out_b,
                                  uint8_t *out_w) {
+    (void)w_color_temperature;
     *out_r = scale8(r, r_scale);
     *out_g = scale8(g, g_scale);
     *out_b = scale8(b, b_scale);
@@ -74,6 +77,7 @@ void rgb_2_rgbw_white_boosted(uint16_t w_color_temperature, uint8_t r,
                               uint8_t g, uint8_t b, uint8_t r_scale,
                               uint8_t g_scale, uint8_t b_scale, uint8_t *out_r,
                               uint8_t *out_g, uint8_t *out_b, uint8_t *out_w) {
+    (void)w_color_temperature;
     r = scale8(r, r_scale);
     g = scale8(g, g_scale);
     b = scale8(b, b_scale);

--- a/src/xymap.h
+++ b/src/xymap.h
@@ -27,6 +27,7 @@ FASTLED_FORCE_INLINE uint16_t xy_serpentine(uint16_t x, uint16_t y,
 
 FASTLED_FORCE_INLINE uint16_t xy_line_by_line(uint16_t x, uint16_t y,
                                               uint16_t width, uint16_t height) {
+    (void)height;
     return y * width + x;
 }
 


### PR DESCRIPTION
This fixes several compiler warnings by casting unused parameters into the void where they belong.