### PR TITLE
Add workflow dispatch to docs action

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,6 +1,7 @@
 name: docs
 
 on:
+  workflow_dispatch:
   release:
     types: released
 


### PR DESCRIPTION
This makes it possible to generate the documentation without needing to push a new release, in case documentation is updated between releases, documentation software is updated, or if the documentation action fails for any reason.