### PR TITLE
Fix compile errors in examples

### DIFF
--- a/examples/Fire2012WithPalette/Fire2012WithPalette.ino
+++ b/examples/Fire2012WithPalette/Fire2012WithPalette.ino
@@ -16,79 +16,7 @@ bool gReverseDirection = false;
 
 CRGB leds[NUM_LEDS];
 
-// Fire2012 with programmable Color Palette
-//
-// This code is the same fire simulation as the original "Fire2012",
-// but each heat cell's temperature is translated to color through a FastLED
-// programmable color palette, instead of through the "HeatColor(...)" function.
-//
-// Four different static color palettes are provided here, plus one dynamic one.
-// 
-// The three static ones are: 
-//   1. the FastLED built-in HeatColors_p -- this is the default, and it looks
-//      pretty much exactly like the original Fire2012.
-//
-//  To use any of the other palettes below, just "uncomment" the corresponding code.
-//
-//   2. a gradient from black to red to yellow to white, which is
-//      visually similar to the HeatColors_p, and helps to illustrate
-//      what the 'heat colors' palette is actually doing,
-//   3. a similar gradient, but in blue colors rather than red ones,
-//      i.e. from black to blue to aqua to white, which results in
-//      an "icy blue" fire effect,
-//   4. a simplified three-step gradient, from black to red to white, just to show
-//      that these gradients need not have four components; two or
-//      three are possible, too, even if they don't look quite as nice for fire.
-//
-// The dynamic palette shows how you can change the basic 'hue' of the
-// color palette every time through the loop, producing "rainbow fire".
-
 CRGBPalette16 gPal;
-
-void setup() {
-  delay(3000); // sanity delay
-  FastLED.addLeds<CHIPSET, LED_PIN, COLOR_ORDER>(leds, NUM_LEDS).setCorrection( TypicalLEDStrip );
-  FastLED.setBrightness( BRIGHTNESS );
-
-  // This first palette is the basic 'black body radiation' colors,
-  // which run from black to red to bright yellow to white.
-  gPal = HeatColors_p;
-  
-  // These are other ways to set up the color palette for the 'fire'.
-  // First, a gradient from black to red to yellow to white -- similar to HeatColors_p
-  //   gPal = CRGBPalette16( CRGB::Black, CRGB::Red, CRGB::Yellow, CRGB::White);
-  
-  // Second, this palette is like the heat colors, but blue/aqua instead of red/yellow
-  //   gPal = CRGBPalette16( CRGB::Black, CRGB::Blue, CRGB::Aqua,  CRGB::White);
-  
-  // Third, here's a simpler, three-step gradient, from black to red to white
-  //   gPal = CRGBPalette16( CRGB::Black, CRGB::Red, CRGB::White);
-
-}
-
-void loop()
-{
-  // Add entropy to random number generator; we use a lot of it.
-  random16_add_entropy( random());
-
-  // Fourth, the most sophisticated: this one sets up a new palette every
-  // time through the loop, based on a hue that changes every time.
-  // The palette is a gradient from black, to a dark color based on the hue,
-  // to a light color based on the hue, to white.
-  //
-  //   static uint8_t hue = 0;
-  //   hue++;
-  //   CRGB darkcolor  = CHSV(hue,255,192); // pure hue, three-quarters brightness
-  //   CRGB lightcolor = CHSV(hue,128,255); // half 'whitened', full brightness
-  //   gPal = CRGBPalette16( CRGB::Black, darkcolor, lightcolor, CRGB::White);
-
-
-  Fire2012WithPalette(); // run simulation frame, using palette colors
-  
-  FastLED.show(); // display this frame
-  FastLED.delay(1000 / FRAMES_PER_SECOND);
-}
-
 
 // Fire2012 by Mark Kriegsman, July 2012
 // as part of "Five Elements" shown here: http://youtu.be/knWiGsmgycY
@@ -166,3 +94,73 @@ void Fire2012WithPalette()
     }
 }
 
+// Fire2012 with programmable Color Palette
+//
+// This code is the same fire simulation as the original "Fire2012",
+// but each heat cell's temperature is translated to color through a FastLED
+// programmable color palette, instead of through the "HeatColor(...)" function.
+//
+// Four different static color palettes are provided here, plus one dynamic one.
+// 
+// The three static ones are: 
+//   1. the FastLED built-in HeatColors_p -- this is the default, and it looks
+//      pretty much exactly like the original Fire2012.
+//
+//  To use any of the other palettes below, just "uncomment" the corresponding code.
+//
+//   2. a gradient from black to red to yellow to white, which is
+//      visually similar to the HeatColors_p, and helps to illustrate
+//      what the 'heat colors' palette is actually doing,
+//   3. a similar gradient, but in blue colors rather than red ones,
+//      i.e. from black to blue to aqua to white, which results in
+//      an "icy blue" fire effect,
+//   4. a simplified three-step gradient, from black to red to white, just to show
+//      that these gradients need not have four components; two or
+//      three are possible, too, even if they don't look quite as nice for fire.
+//
+// The dynamic palette shows how you can change the basic 'hue' of the
+// color palette every time through the loop, producing "rainbow fire".
+
+void setup() {
+  delay(3000); // sanity delay
+  FastLED.addLeds<CHIPSET, LED_PIN, COLOR_ORDER>(leds, NUM_LEDS).setCorrection( TypicalLEDStrip );
+  FastLED.setBrightness( BRIGHTNESS );
+
+  // This first palette is the basic 'black body radiation' colors,
+  // which run from black to red to bright yellow to white.
+  gPal = HeatColors_p;
+  
+  // These are other ways to set up the color palette for the 'fire'.
+  // First, a gradient from black to red to yellow to white -- similar to HeatColors_p
+  //   gPal = CRGBPalette16( CRGB::Black, CRGB::Red, CRGB::Yellow, CRGB::White);
+  
+  // Second, this palette is like the heat colors, but blue/aqua instead of red/yellow
+  //   gPal = CRGBPalette16( CRGB::Black, CRGB::Blue, CRGB::Aqua,  CRGB::White);
+  
+  // Third, here's a simpler, three-step gradient, from black to red to white
+  //   gPal = CRGBPalette16( CRGB::Black, CRGB::Red, CRGB::White);
+
+}
+
+void loop()
+{
+  // Add entropy to random number generator; we use a lot of it.
+  random16_add_entropy( random());
+
+  // Fourth, the most sophisticated: this one sets up a new palette every
+  // time through the loop, based on a hue that changes every time.
+  // The palette is a gradient from black, to a dark color based on the hue,
+  // to a light color based on the hue, to white.
+  //
+  //   static uint8_t hue = 0;
+  //   hue++;
+  //   CRGB darkcolor  = CHSV(hue,255,192); // pure hue, three-quarters brightness
+  //   CRGB lightcolor = CHSV(hue,128,255); // half 'whitened', full brightness
+  //   gPal = CRGBPalette16( CRGB::Black, darkcolor, lightcolor, CRGB::White);
+
+
+  Fire2012WithPalette(); // run simulation frame, using palette colors
+  
+  FastLED.show(); // display this frame
+  FastLED.delay(1000 / FRAMES_PER_SECOND);
+}

--- a/examples/FxEngine/FxEngine.ino
+++ b/examples/FxEngine/FxEngine.ino
@@ -5,7 +5,7 @@
 
 #include <FastLED.h>
 
-#include "fx/2d/noisepalette.hpp"
+#include "fx/2d/noisepalette.h"
 #include "fx/2d/animartrix.hpp"
 #include "fx/fx_engine.h"
 #include "fx/storage/sd.h"

--- a/examples/Overclock/Overclock.ino
+++ b/examples/Overclock/Overclock.ino
@@ -4,7 +4,7 @@
 
 #define FASTLED_W2812_OVERCLOCK 1.1 // Overclocks by 10%, I've seen 25% work fine.
 
-#include "fx/2d/noisepalette.hpp"
+#include "fx/2d/noisepalette.h"
 #include "fx/fx.h"
 #include <FastLED.h>
 

--- a/examples/PinMode/PinMode.ino
+++ b/examples/PinMode/PinMode.ino
@@ -8,20 +8,19 @@
 
 void setup() {
 	delay(1000);
-    Serial.begin(9600);
+  Serial.begin(9600);
 }
 
 void loop() {
-
-    pinMode(PIN, OUTPUT);
-    digitalWrite(PIN, HIGH);
-    delay(100);
-    digitalWrite(PIN, LOW);
-    pinMode(PIN, INPUT);
-    bool on = digitalRead(PIN) ? Serial.println("HIGH") : Serial.println("LOW");
-    Serial.print("Pin: ");
-    Serial.print(PIN);
-    Serial.print(" is ");
-    Serial.println(on ? "HIGH" : "LOW");
-    delay(1000);
+  pinMode(PIN, OUTPUT);
+  digitalWrite(PIN, HIGH);
+  delay(100);
+  digitalWrite(PIN, LOW);
+  pinMode(PIN, INPUT);
+  bool on = digitalRead(PIN);
+  Serial.print("Pin: ");
+  Serial.print(PIN);
+  Serial.print(" is ");
+  Serial.println(on ? "HIGH" : "LOW");
+  delay(1000);
 }

--- a/examples/PinMode/PinMode.ino
+++ b/examples/PinMode/PinMode.ino
@@ -7,7 +7,7 @@
 #define PIN 1
 
 void setup() {
-	delay(1000);
+  delay(1000);
   Serial.begin(9600);
 }
 


### PR DESCRIPTION
This fixes several compile errors that have cropped up in example sketches.

The fixes to `FxEngine.ino` and `Overclock.ino` are due to the changes from commit be60207.

Note that the order of operations shift in `Fire2012WithPalette.ino` was made because the WASM compiler does not automatically insert function prototypes like the Arduino IDE does and so it was erroring out. Moving the custom function above the loop resolves this issue (and in fact this keeping of custom functions above the loop can be seen in FastLED's existing example sketches such as `SmartMatrix.ino`).

On the topic of the WASM compile test, `Esp32Rmt51.ino` should be excluded as its platform definition lacks `FASTLED_RMT5` and thus this is an invalid sketch for WASM. Additionally `SmartMatrix.ino` should be excluded as this sketch is only valid on Teensy and uses an external third-party library that the WASM check is not using as a dependency.