### PR TITLE
Attempts to fix 1st pixel not working correctly on the esp32-wroom

### DIFF
--- a/src/platforms/esp/32/led_strip/rmt_strip.cpp
+++ b/src/platforms/esp/32/led_strip/rmt_strip.cpp
@@ -5,7 +5,7 @@
 #if FASTLED_RMT5
 
 #ifndef FASTLED_RMT5_NO_RECYCLE
-#define FASTLED_RMT5_NO_RECYCLE 0
+#define FASTLED_RMT5_NO_RECYCLE 1
 #endif
 
 #include "rmt_strip.h"


### PR DESCRIPTION
I can't reproduce the issue with ESP/Wroom-32/S3/C3/C6. However, there are a few hypothesis on why this is happening:

1. Either the RMT recycling feature I implemented causing this -or-
2. There is a bug in the ESP-IDF led-strip that we use to get this working
3. Something else

This PR is an attempt to address (1). This CL disables rmt recycling. If this doesn't work then I'll attempt a rebase to the most recent led-strip library with a careful file based merge, as our version of the library is now very different, due to exposing the clockless timings as part of the API.

This CL does is not test the functionality of more than one strip. It should *probably* work with more than 1 but 5-8 could be problematic until tested.


https://github.com/FastLED/FastLED/issues/1774

https://github.com/FastLED/FastLED/issues/1761

https://github.com/FastLED/FastLED/issues/1640