### PR TITLE
Documentation Updates, Squishy

### DIFF
--- a/PORTING.md
+++ b/PORTING.md
@@ -1,4 +1,4 @@
-New platform porting guide
+Platform Porting Guide
 ==========================
 
 # Fast porting for a new board on existing hardware

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-FastLED
+FastLED Library
 ===========
 [![arduino-library-badge](https://www.ardu-badge.com/badge/FastLED.svg)](https://www.ardu-badge.com/FastLED)
 [![build status](https://github.com/FastLED/FastLED/workflows/build/badge.svg)](https://github.com/FastLED/FastLED/actions/workflows/build.yml)
@@ -62,7 +62,7 @@ For more examples see this [link](examples).
 
 
 ## Supported Platforms
-#### Arduino
+### Arduino
 
 [![uno](https://github.com/FastLED/FastLED/actions/workflows/build_uno.yml/badge.svg)](https://github.com/FastLED/FastLED/actions/workflows/build_uno.yml)
 
@@ -97,7 +97,7 @@ For more examples see this [link](examples).
 [![nano_every](https://github.com/FastLED/FastLED/actions/workflows/build_nano_every.yml/badge.svg)](https://github.com/FastLED/FastLED/actions/workflows/build_nano_every.yml)
 
 
-#### Teensy
+### Teensy
 [![teensy30](https://github.com/FastLED/FastLED/actions/workflows/build_teensy30.yml/badge.svg)](https://github.com/FastLED/FastLED/actions/workflows/build_teensy30.yml)
 
 
@@ -116,7 +116,7 @@ For more examples see this [link](examples).
 
 [![teensy_octoWS2811](https://github.com/FastLED/FastLED/actions/workflows/build_teensy_octo.yml/badge.svg)](https://github.com/FastLED/FastLED/actions/workflows/build_teensy_octo.yml)
 
-#### NRF
+### NRF
 
 [![nrf52840_sense](https://github.com/FastLED/FastLED/actions/workflows/build_adafruit_feather_nrf52840_sense.yml/badge.svg)](https://github.com/FastLED/FastLED/actions/workflows/build_adafruit_feather_nrf52840_sense.yml)
 
@@ -127,7 +127,7 @@ For more examples see this [link](examples).
 [![nrf52_xiaoblesense](https://github.com/FastLED/FastLED/actions/workflows/build_nrf52_xiaoblesense.yml/badge.svg)](https://github.com/FastLED/FastLED/actions/workflows/build_nrf52_xiaoblesense.yml)
 (This board has mbed engine but doesn't compile against Arduino.h right now for some unknown reason.)
 
-#### STM
+### STM
 
 [![bluepill](https://github.com/FastLED/FastLED/actions/workflows/build_bluepill.yml/badge.svg)](https://github.com/FastLED/FastLED/actions/workflows/build_bluepill.yml)
 
@@ -136,7 +136,7 @@ For more examples see this [link](examples).
 [![stm103tb](https://github.com/FastLED/FastLED/actions/workflows/build_stm103tb.yml/badge.svg)](https://github.com/FastLED/FastLED/actions/workflows/build_stm103tb.yml)
 (PlatformIO doesn't support this board yet and we don't know what the build info is to support this is yet)
 
-#### Raspberry Pi
+### Raspberry Pi
 
 [![rp2040](https://github.com/FastLED/FastLED/actions/workflows/build_rp2040.yml/badge.svg)](https://github.com/FastLED/FastLED/actions/workflows/build_rp2040.yml)
 
@@ -144,7 +144,7 @@ For more examples see this [link](examples).
 [![rp2350](https://github.com/FastLED/FastLED/actions/workflows/build_rp2350.yml/badge.svg)](https://github.com/FastLED/FastLED/actions/workflows/build_rp2350.yml)
 
 
-#### Esp
+### Esp
 
 [![esp32-8266](https://github.com/FastLED/FastLED/actions/workflows/build_esp8622.yml/badge.svg)](https://github.com/FastLED/FastLED/actions/workflows/build_esp8622.yml)
 
@@ -378,10 +378,9 @@ Although APA102HD mode offers the highest dynamic range, the standard APA102 mod
 
 I hope this explanation clarifies the enhancements and the rationale behind these implementation choices. If you have any questions or require further clarification, please do not hesitate to ask.
 
-### Porting FastLED to a new platform
+## Porting FastLED to a new platform
 
-Information on porting FastLED can be found in the file
-[PORTING.md](./PORTING.md).
+Information on porting FastLED can be found in the file [PORTING.md](PORTING.md).
 
 ## What about that name?
 

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -941,7 +941,8 @@ WARN_LOGFILE           =
 
 INPUT                  = ../src \
                          ../examples \
-                         ../README.md
+                         ../README.md \
+                         ../PORTING.md
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses

--- a/src/chsv.h
+++ b/src/chsv.h
@@ -1,3 +1,5 @@
+/// @file chsv.h
+/// Defines the hue, saturation, and value (HSV) pixel struct
 
 #pragma once
 

--- a/src/chsv.h
+++ b/src/chsv.h
@@ -9,6 +9,9 @@
 
 FASTLED_NAMESPACE_BEGIN
 
+/// @addtogroup PixelTypes Pixel Data Types (CRGB/CHSV)
+/// @{
+
 /// Representation of an HSV pixel (hue, saturation, value (aka brightness)).
 struct CHSV {
     union {
@@ -101,5 +104,7 @@ typedef enum {
     HUE_PURPLE = 192,  ///< Purple (270°)
     HUE_PINK = 224     ///< Pink (315°)
 } HSVHue;
+
+/// @} PixelTypes
 
 FASTLED_NAMESPACE_END

--- a/src/cled_controller.cpp
+++ b/src/cled_controller.cpp
@@ -1,4 +1,5 @@
-
+/// @file cled_controller.cpp
+/// base definitions used by led controllers for writing out led data
 
 #define FASTLED_INTERNAL
 #include "FastLED.h"

--- a/src/cled_controller.h
+++ b/src/cled_controller.h
@@ -2,7 +2,7 @@
 
 #include <stddef.h>
 
-/// @file controller.h
+/// @file cled_controller.h
 /// base definitions used by led controllers for writing out led data
 
 #include "FastLED.h"

--- a/src/color.h
+++ b/src/color.h
@@ -94,5 +94,7 @@ typedef enum {
     UncorrectedTemperature=0xFFFFFF /* 255, 255, 255 */
 } ColorTemperature;
 
+/// @} ColorEnums
+
 FASTLED_NAMESPACE_END
 

--- a/src/colorutils.h
+++ b/src/colorutils.h
@@ -693,21 +693,21 @@ typedef TDynamicRGBGradientPalette_bytes TDynamicRGBGradientPaletteRef;  ///< Al
 /// @param srcpal16 the source palette to upscale
 /// @param destpal256 the destination palette for the upscaled data
 void UpscalePalette(const class CRGBPalette16& srcpal16, class CRGBPalette256& destpal256);
-/// @copydoc UpscalePalette(const struct CRGBPalette16&, struct CRGBPalette256&)
+/// @copydoc UpscalePalette(const class CRGBPalette16&, class CRGBPalette256&)
 void UpscalePalette(const class CHSVPalette16& srcpal16, class CHSVPalette256& destpal256);
 
 /// Convert a 16-entry palette to a 32-entry palette
 /// @param srcpal16 the source palette to upscale
 /// @param destpal32 the destination palette for the upscaled data
 void UpscalePalette(const class CRGBPalette16& srcpal16, class CRGBPalette32& destpal32);
-/// @copydoc UpscalePalette(const struct CRGBPalette16&, struct CRGBPalette32&)
+/// @copydoc UpscalePalette(const class CRGBPalette16&, class CRGBPalette32&)
 void UpscalePalette(const class CHSVPalette16& srcpal16, class CHSVPalette32& destpal32);
 
 /// Convert a 32-entry palette to a 256-entry palette
 /// @param srcpal32 the source palette to upscale
 /// @param destpal256 the destination palette for the upscaled data
 void UpscalePalette(const class CRGBPalette32& srcpal32, class CRGBPalette256& destpal256);
-/// @copydoc UpscalePalette(const struct CRGBPalette32&, class CRGBPalette256&)
+/// @copydoc UpscalePalette(const class CRGBPalette32&, class CRGBPalette256&)
 void UpscalePalette(const class CHSVPalette32& srcpal32, class CHSVPalette256& destpal256);
 
 /// @} PaletteUpscale
@@ -2004,9 +2004,9 @@ CRGB ColorFromPalette( const CRGBPalette16& pal,
 
 /// @brief Same as ColorFromPalette, but with uint16_t `index` to give greater precision.
 /// @author https://github.com/generalelectrix
-/// @source https://github.com/FastLED/FastLED/pull/202
-/// @example https://wokwi.com/projects/285170662915441160
-/// @example https://wokwi.com/projects/407831886158110721
+/// @see https://github.com/FastLED/FastLED/pull/202
+/// @see https://wokwi.com/projects/285170662915441160
+/// @see https://wokwi.com/projects/407831886158110721
 CRGB ColorFromPaletteExtended(
     const CRGBPalette16& pal,
     uint16_t index,
@@ -2016,8 +2016,8 @@ CRGB ColorFromPaletteExtended(
 /// @brief Same as ColorFromPalette, but higher precision. Will eventually
 ///        become the default.
 /// @author https://github.com/generalelectrix
-/// @source https://github.com/FastLED/FastLED/pull/202#issuecomment-631333384
-/// @example https://wokwi.com/projects/285170662915441160
+/// @see https://github.com/FastLED/FastLED/pull/202#issuecomment-631333384
+/// @see https://wokwi.com/projects/285170662915441160
 CRGB ColorFromPaletteExtended(
     const CRGBPalette32& pal,
     uint16_t index,

--- a/src/controller.h
+++ b/src/controller.h
@@ -2,7 +2,7 @@
 #define __INC_CONTROLLER_H
 
 /// @file controller.h
-/// base definitions used by led controllers for writing out led data
+/// deprecated: base definitions used by led controllers for writing out led data
 
 #include "cpixel_ledcontroller.h"
 

--- a/src/cpixel_ledcontroller.h
+++ b/src/cpixel_ledcontroller.h
@@ -1,7 +1,7 @@
 #pragma once
 
-/// @file controller.h
-/// base definitions used by led controllers for writing out led data
+/// @file cpixel_ledcontroller.h
+/// defines the templated version of the CLEDController class
 
 #include <stddef.h>
 

--- a/src/crgb.cpp
+++ b/src/crgb.cpp
@@ -1,3 +1,5 @@
+/// @file crgb.cpp
+/// Utility functions for the red, green, and blue (RGB) pixel struct
 
 #include "FastLED.h"
 #include "crgb.h"

--- a/src/crgb.h
+++ b/src/crgb.h
@@ -742,6 +742,8 @@ FASTLED_FORCE_INLINE CRGB operator*( const CRGB& p1, uint8_t d);
 /// Scale using CRGB::nscale8_video()
 FASTLED_FORCE_INLINE CRGB operator%( const CRGB& p1, uint8_t d);
 
+/// @} PixelTypes
+
 
 FASTLED_NAMESPACE_END
 

--- a/src/crgb.h
+++ b/src/crgb.h
@@ -1,3 +1,5 @@
+/// @file crgb.h
+/// Defines the red, green, and blue (RGB) pixel struct
 
 #pragma once
 

--- a/src/crgb.hpp
+++ b/src/crgb.hpp
@@ -1,3 +1,5 @@
+/// @file crgb.hpp
+/// Defines utility functions for the red, green, and blue (RGB) pixel struct
 
 #pragma once
 

--- a/src/dither_mode.h
+++ b/src/dither_mode.h
@@ -1,3 +1,6 @@
+/// @file dither_mode.h
+/// Declares dithering options and types
+
 #pragma once
 
 #include <stdint.h>

--- a/src/eorder.h
+++ b/src/eorder.h
@@ -1,3 +1,6 @@
+/// @file eorder.h
+/// Defines color channel ordering enumerations
+
 #pragma once
 #include "fl/namespace.h"
 

--- a/src/five_bit_hd_gamma.cpp
+++ b/src/five_bit_hd_gamma.cpp
@@ -1,4 +1,5 @@
-
+/// @file five_bit_hd_gamma.cpp
+/// Defines functions for five-bit gamma correction
 
 #define FASTLED_INTERNAL 1
 #include "five_bit_hd_gamma.h"

--- a/src/five_bit_hd_gamma.h
+++ b/src/five_bit_hd_gamma.h
@@ -1,3 +1,6 @@
+/// @file five_bit_hd_gamma.h
+/// Declares functions for five-bit gamma correction
+
 #pragma once
 
 #include <stdint.h>

--- a/src/fl/namespace.h
+++ b/src/fl/namespace.h
@@ -1,3 +1,6 @@
+/// @file namespace.h
+/// Implements the FastLED namespace macros
+
 #pragma once
 
 #if defined(FASTLED_FORCE_NAMESPACE) && !defined(FASTLED_IS_USING_NAMESPACE) && !defined(FASTLED_NAMESPACE)

--- a/src/fx/2d/bilinear_expansion.cpp
+++ b/src/fx/2d/bilinear_expansion.cpp
@@ -1,4 +1,4 @@
-/// @file    NoisePlusPalette.hpp
+/// @file    bilinear_expansion.cpp
 /// @brief   Demonstrates how to mix noise generation with color palettes on a
 /// 2D LED matrix
 
@@ -153,13 +153,6 @@ uint8_t bilinearInterpolatePowerOf2(uint8_t v00, uint8_t v10, uint8_t v01,
 
     return result;
 }
-
-
-/// @file    NoisePlusPalette.hpp
-/// @brief   Demonstrates how to mix noise generation with color palettes on a
-/// 2D LED matrix
-/// @example NoisePlusPalette.hpp
-
 
 
 // Floating-point version of bilinear interpolation

--- a/src/fx/2d/bilinear_expansion.cpp
+++ b/src/fx/2d/bilinear_expansion.cpp
@@ -1,7 +1,6 @@
 /// @file    NoisePlusPalette.hpp
 /// @brief   Demonstrates how to mix noise generation with color palettes on a
 /// 2D LED matrix
-/// @example NoisePlusPalette.hpp
 
 #include <stdint.h>
 

--- a/src/fx/2d/bilinear_expansion.h
+++ b/src/fx/2d/bilinear_expansion.h
@@ -1,7 +1,6 @@
 /// @file    NoisePlusPalette.hpp
 /// @brief   Demonstrates how to mix noise generation with color palettes on a
 /// 2D LED matrix
-/// @example NoisePlusPalette.hpp
 
 #pragma once
 
@@ -19,8 +18,6 @@ namespace fl {
 /// @param input The input grid to read from.
 /// @param inputWidth The width of the input grid.
 /// @param inputHeight The height of the input grid.
-/// @param outputWidth The width of the output grid.
-/// @param outputHeight The height of the output grid.
 /// @param xyMap The XYMap to use to determine where to write the pixel. If the
 /// pixel is mapped outside of the range then it is clipped.
 void bilinearExpandArbitrary(const CRGB *input, CRGB *output,
@@ -30,8 +27,8 @@ void bilinearExpandArbitrary(const CRGB *input, CRGB *output,
 /// @brief Performs bilinear interpolation for upscaling an image.
 /// @param output The output grid to write into the interpolated values.
 /// @param input The input grid to read from.
-/// @param outputWidth The width of the output grid.
-/// @param outputHeight The height of the output grid.
+/// @param inputWidth The width of the input grid.
+/// @param inputHeight The height of the input grid.
 /// @param xyMap The XYMap to use to determine where to write the pixel. If the
 /// pixel is mapped outside of the range then it is clipped.
 void bilinearExpandPowerOf2(const CRGB *input, CRGB *output, uint8_t inputWidth, uint8_t inputHeight, fl::XYMap xyMap);

--- a/src/fx/2d/bilinear_expansion.h
+++ b/src/fx/2d/bilinear_expansion.h
@@ -1,4 +1,4 @@
-/// @file    NoisePlusPalette.hpp
+/// @file    bilinear_expansion.h
 /// @brief   Demonstrates how to mix noise generation with color palettes on a
 /// 2D LED matrix
 

--- a/src/fx/2d/noisepalette.h
+++ b/src/fx/2d/noisepalette.h
@@ -1,7 +1,6 @@
 /// @file    NoisePlusPalette.hpp
 /// @brief   Demonstrates how to mix noise generation with color palettes on a
 /// 2D LED matrix
-/// @example NoisePlusPalette.hpp
 
 #pragma once
 

--- a/src/fx/2d/noisepalette.h
+++ b/src/fx/2d/noisepalette.h
@@ -1,4 +1,4 @@
-/// @file    NoisePlusPalette.hpp
+/// @file    noisepalette.h
 /// @brief   Demonstrates how to mix noise generation with color palettes on a
 /// 2D LED matrix
 

--- a/src/fx/2d/scale_up.h
+++ b/src/fx/2d/scale_up.h
@@ -1,4 +1,4 @@
-/// @file    expander.hpp
+/// @file    scale_up.h
 /// @brief   Expands a grid using bilinear interpolation and scaling up. This is
 /// useful for
 ///          under powered devices that can't handle the full resolution of the

--- a/src/lib8tion.h
+++ b/src/lib8tion.h
@@ -810,11 +810,6 @@ LIB8STATIC uint8_t squarewave8( uint8_t in, uint8_t pulsewidth=128)
 
 /// @} WaveformGenerators
 
-
-
-
-/// @}
-
 /// @} lib8tion (excluding the timekeeping functions from the nested group)
 
 

--- a/src/lib8tion/brightness_bitshifter.h
+++ b/src/lib8tion/brightness_bitshifter.h
@@ -1,3 +1,6 @@
+/// @file brightness_bitshifter.h
+/// Defines brightness bitshifting functions
+
 #pragma once
 
 #include <stdint.h>

--- a/src/lib8tion/brightness_bitshifter.h
+++ b/src/lib8tion/brightness_bitshifter.h
@@ -5,7 +5,11 @@
 
 #include <stdint.h>
 
+/// @addtogroup lib8tion
+/// @{
 
+/// @addtogroup Dimming
+/// @{
 
 inline uint8_t brightness_bitshifter8(uint8_t *brightness_src, uint8_t *brightness_dst, uint8_t max_shifts) {
     uint8_t src = *brightness_src;
@@ -70,4 +74,5 @@ inline uint8_t brightness_bitshifter16(uint8_t *brightness_src, uint16_t *bright
     return shifts;
 }
 
-
+/// @} Dimming
+/// @} lib8tion

--- a/src/lib8tion/intmap.h
+++ b/src/lib8tion/intmap.h
@@ -1,3 +1,5 @@
+/// @file intmap.h
+/// Defines integer mapping functions
 
 #pragma once
 

--- a/src/lib8tion/intmap.h
+++ b/src/lib8tion/intmap.h
@@ -9,6 +9,19 @@
 
 FASTLED_NAMESPACE_BEGIN
 
+/// @addtogroup lib8tion
+/// @{
+
+/// @defgroup intmap Integer Mapping Functions
+/// Maps a scalar from one integer size to another.
+///
+/// For example, a value representing 40% as an 8-bit unsigned integer would be
+/// `102 / 255`. Using `map8_to_16(uint8_t)` to convert that to a 16-bit
+/// unsigned integer would give you `26,214 / 65,535`, exactly 40% through the
+/// larger range.
+///
+/// @{
+
 LIB8STATIC_ALWAYS_INLINE uint16_t map8_to_16(uint8_t x) {
     return uint16_t(x) * 0x101;
 }
@@ -30,5 +43,8 @@ LIB8STATIC_ALWAYS_INLINE uint8_t map16_to_8(uint16_t x) {
 LIB8STATIC_ALWAYS_INLINE uint32_t map8_to_32(uint8_t x) {
     return uint32_t(x) * 0x1010101;
 }
+
+/// @} intmap
+/// @} lib8tion
 
 FASTLED_NAMESPACE_END

--- a/src/lib8tion/lib8static.h
+++ b/src/lib8tion/lib8static.h
@@ -3,7 +3,12 @@
 
 #pragma once
 
+/// @addtogroup lib8tion
+/// @{
+
 /// Define a LIB8TION member function as static inline with an "unused" attribute
 #define LIB8STATIC __attribute__ ((unused)) static inline
 /// Define a LIB8TION member function as always static inline
 #define LIB8STATIC_ALWAYS_INLINE __attribute__ ((always_inline)) static inline
+
+/// @} lib8tion

--- a/src/lib8tion/lib8static.h
+++ b/src/lib8tion/lib8static.h
@@ -1,3 +1,6 @@
+/// @file lib8static.h
+/// Defines static inlining macros for lib8tion functions
+
 #pragma once
 
 /// Define a LIB8TION member function as static inline with an "unused" attribute

--- a/src/lib8tion/qfx.h
+++ b/src/lib8tion/qfx.h
@@ -53,4 +53,6 @@ typedef qfx<uint16_t, 8,8> q88;
 /// A 12.4 integer (12 bits integer, 4 bits fraction)
 typedef qfx<uint16_t, 12,4> q124;
 
+/// @} FractionalTypes
+
 FASTLED_NAMESPACE_END

--- a/src/lib8tion/types.h
+++ b/src/lib8tion/types.h
@@ -1,3 +1,6 @@
+/// @file types.h
+/// Defines fractional types used for lib8tion functions
+
 #pragma once
 
 #include <stdint.h>

--- a/src/lib8tion/types.h
+++ b/src/lib8tion/types.h
@@ -8,6 +8,9 @@
 
 FASTLED_NAMESPACE_BEGIN
 
+/// @addtogroup lib8tion
+/// @{
+
 ///////////////////////////////////////////////////////////////////////
 ///
 /// @defgroup FractionalTypes Fixed-Point Fractional Types. 
@@ -84,5 +87,6 @@ typedef union {
 } IEEE754binary32_t;
 
 /// @} FractionalTypes
+/// @} lib8tion
 
 FASTLED_NAMESPACE_END

--- a/src/noise.h
+++ b/src/noise.h
@@ -102,11 +102,11 @@ extern int8_t inoise8_raw(uint16_t x, uint16_t y);
 extern int8_t inoise8_raw(uint16_t x);
 
 /// @} 8-Bit Raw Noise Functions
-/// @} NoiseGeneration
 
 
-/// @name 32 bit simplex noise functions
-///@{
+/// @name 32-Bit Simplex Noise Functions
+/// @{
+
 /// 32 bit, fixed point implementation of simplex noise functions.
 /// The inputs are 20.12 fixed-point value. The result covers the full
 /// range of a uint16_t averaging around 32768.
@@ -114,7 +114,9 @@ uint16_t snoise16(uint32_t x);
 uint16_t snoise16(uint32_t x, uint32_t y);
 uint16_t snoise16(uint32_t x, uint32_t y, uint32_t z);
 uint16_t snoise16(uint32_t x, uint32_t y, uint32_t z, uint32_t w);
-///@}
+
+/// @} 32-Bit Simplex Noise Functions
+/// @} NoiseGeneration
 
 
 

--- a/src/noisegen.h
+++ b/src/noisegen.h
@@ -1,3 +1,6 @@
+/// @file noisegen.h
+/// Noise generation classes
+
 #pragma once
 
 #include <stdint.h>

--- a/src/pixel_controller.h
+++ b/src/pixel_controller.h
@@ -1,7 +1,7 @@
 #pragma once
 
-/// @file controller.h
-/// base definitions used by led controllers for writing out led data
+/// @file pixel_controller.h
+/// Low level pixel data writing class
 
 // Note that new code should use the PixelIterator concrete object to write out
 // led data.

--- a/src/pixel_iterator.h
+++ b/src/pixel_iterator.h
@@ -1,3 +1,5 @@
+/// @file pixel_iterator.h
+/// Non-templated low level pixel data writing class
 
 #pragma once
 

--- a/src/pixeltypes.h
+++ b/src/pixeltypes.h
@@ -1,3 +1,6 @@
+/// @file pixeltypes.h
+/// Includes defintions for RGB and HSV pixels
+
 #ifndef __INC_PIXELS_H
 #define __INC_PIXELS_H
 

--- a/src/rgbw.cpp
+++ b/src/rgbw.cpp
@@ -1,3 +1,5 @@
+/// @file rgbw.cpp
+/// Functions for red, green, blue, white (RGBW) output
 
 #include <stdint.h>
 

--- a/src/rgbw.h
+++ b/src/rgbw.h
@@ -1,3 +1,6 @@
+/// @file rgbw.h
+/// Functions for red, green, blue, white (RGBW) output
+
 #pragma once
 
 #include <stdint.h>

--- a/src/rgbw.h
+++ b/src/rgbw.h
@@ -83,8 +83,11 @@ typedef void (*rgb_2_rgbw_function)(uint16_t w_color_temperature, uint8_t r,
 /// the pixel will never achieve full brightness since the white channel is
 /// 3x more efficient than the color channels mixed together, so in this mode
 /// the max brightness of a given pixel is reduced.
-/// @example RGB(255, 255, 255) -> RGBW(0, 0, 0, 85)
-/// @example RGB(255, 0, 0) -> RGBW(255, 0, 0, 0)
+///
+/// ```
+/// RGB(255, 255, 255) -> RGBW(0, 0, 0, 85)
+/// RGB(255, 0, 0) -> RGBW(255, 0, 0, 0)
+/// ```
 void rgb_2_rgbw_exact(uint16_t w_color_temperature, uint8_t r, uint8_t g,
                       uint8_t b, uint8_t r_scale, uint8_t g_scale,
                       uint8_t b_scale, uint8_t *out_r, uint8_t *out_g,
@@ -93,15 +96,21 @@ void rgb_2_rgbw_exact(uint16_t w_color_temperature, uint8_t r, uint8_t g,
 /// The minimum brigthness of the RGB channels is used to set the W channel.
 /// This will allow the max brightness of the led chipset to be used. However
 /// the leds will appear over-desaturated in this mode.
-/// @example RGB(255, 255, 255) -> RGBW(255, 255, 255, 255)
-/// @example RGB(1, 0, 0) -> RGBW(1, 0, 0, 1)
+///
+/// ```
+/// RGB(255, 255, 255) -> RGBW(255, 255, 255, 255)
+/// RGB(1, 0, 0) -> RGBW(1, 0, 0, 1)
+/// ```
 void rgb_2_rgbw_max_brightness(uint16_t w_color_temperature, uint8_t r,
                                uint8_t g, uint8_t b, uint8_t r_scale,
                                uint8_t g_scale, uint8_t b_scale, uint8_t *out_r,
                                uint8_t *out_g, uint8_t *out_b, uint8_t *out_w);
 
 /// @brief Converts RGB to RGBW with the W channel set to black, always.
-/// @example RGB(255, 255, 255) -> RGBW(255, 255, 255, 0)
+///
+/// ```
+/// RGB(255, 255, 255) -> RGBW(255, 255, 255, 0)
+/// ```
 void rgb_2_rgbw_null_white_pixel(uint16_t w_color_temperature, uint8_t r,
                                  uint8_t g, uint8_t b, uint8_t r_scale,
                                  uint8_t g_scale, uint8_t b_scale,
@@ -121,11 +130,10 @@ void rgb_2_rgbw_user_function(uint16_t w_color_temperature, uint8_t r,
 
 void set_rgb_2_rgbw_function(rgb_2_rgbw_function func);
 
-/// @brief Converts RGB to RGBW using one of the functions.
+/// @brief   Converts RGB to RGBW using one of the functions.
+/// @details Dynamic version of the rgb_w_rgbw function with less chance for
+///          the compiler to optimize.
 FASTLED_FORCE_INLINE void rgb_2_rgbw(
-    /// @brief Dynamic version of the rgb_w_rgbw function with less chance for
-    /// the compiler to optimize.
-    /// @param out_w
     RGBW_MODE mode, uint16_t w_color_temperature, uint8_t r, uint8_t g,
     uint8_t b, uint8_t r_scale, uint8_t g_scale, uint8_t b_scale,
     uint8_t *out_r, uint8_t *out_g, uint8_t *out_b, uint8_t *out_w) {

--- a/src/simplex.cpp
+++ b/src/simplex.cpp
@@ -1,3 +1,6 @@
+/// @file simplex.cpp
+/// Implements simplex noise functions
+
 #define FASTLED_INTERNAL
 #include "FastLED.h"
 

--- a/src/transpose8x1_noinline.cpp
+++ b/src/transpose8x1_noinline.cpp
@@ -1,3 +1,5 @@
+/// @file transpose8x1_noinline.cpp
+/// Defines the 8x1 transposition function
 
 #include <stdint.h>
 

--- a/src/transpose8x1_noinline.h
+++ b/src/transpose8x1_noinline.h
@@ -1,3 +1,5 @@
+/// @file transpose8x1_noinline.h
+/// Declares the 8x1 transposition function
 
 #pragma once
 void transpose8x1_noinline(unsigned char *A, unsigned char *B);


### PR DESCRIPTION
This PR fixes documentation regressions caused by splitting up some of the monolithic files into their component parts:

* All code files in the main folder (`src`) now have a proper `@file` header so they are picked up by doxygen and have their contents inventoried
    * Most of the `@brief` descriptions here are simple or tautological - the point is just to get them to be parsed again so their contents are in the documentation
* A few functions that had their signatures tweaked (`struct` -> `class`) have had their associated documentation adjusted
* Closing braces were added where missing to some documentation groups
* Some items which were inadvertently removed from their documentation groups have been put back into them (e.g. `CSHV` to `PixelTypes`)
* `@source` and `@example` tags which were incorrectly used were replaced by `@see` and code blocks as needed
* Mismatched header subsections in the `README` have been fixed
* "Library" has been appended to the `README` title for better navigation on the docs website

There are no (intended) functional changes in this PR. If this is merged, documentation should be regenerated the "docs" CI action and workflow dispatch.

---

This PR is a duplicate of #1794 and supersedes it, with commits squished into logical units as requested. Some commits now contain multiple logical changes, but are grouped into logical 'sets' for convenience.