### PR TITLE
scale16by8: explicitly use uint32_t for intermediate computations

### DIFF
--- a/src/lib8tion/scale8.h
+++ b/src/lib8tion/scale8.h
@@ -473,7 +473,7 @@ LIB8STATIC_ALWAYS_INLINE uint16_t scale16by8(uint16_t i, fract8 scale) {
 #if SCALE16BY8_C == 1
     uint16_t result;
 #if FASTLED_SCALE8_FIXED == 1
-    result = (i * (1 + ((uint16_t)scale))) >> 8;
+    result = (((uint32_t)(i) * (1 + ((uint32_t)scale))) >> 8;
 #else
     result = (i * scale) / 256;
 #endif


### PR DESCRIPTION
`i * (1 + scale)` would overflow before the `>> 8` if it was stored in a uint16_t. Some implicit type conversion must be going on to make this work, but it's unclear if that implicit type conversion would reliably work on all platforms. The `1` literal may be casting `1 + scale` to an `unsigned int`, which on most platforms is 32 bits, but the C++ standard allows it to be 16 bits.

Fixes https://github.com/FastLED/FastLED/issues/1821