### PR TITLE
Fix overclock examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ We have multiple goals with this library:
 *This is an Arduino Sketch that will run on Arduino Uno/Esp32/Raspberri Pi*
 ```C++
 // New feature! Overclocking WS2812
-// #define FASTLED_OVERCLOCK 1.2 // 20% overclock ~ 960 khz.
+// #define FASTLED_LED_OVERCLOCK 1.2 // 20% overclock ~ 960 khz.
 #include <FastLED.h>
 #define NUM_LEDS 60
 #define DATA_PIN 6

--- a/examples/Overclock/Overclock.ino
+++ b/examples/Overclock/Overclock.ino
@@ -12,7 +12,7 @@ void loop() {}
 #else
 
 
-#define FASTLED_W2812_OVERCLOCK 1.1 // Overclocks by 10%, I've seen 25% work fine.
+#define FASTLED_LED_OVERCLOCK 1.1 // Overclocks by 10%, I've seen 25% work fine.
 
 #include "fx/2d/noisepalette.h"
 #include "fx/fx.h"

--- a/release_notes.md
+++ b/release_notes.md
@@ -19,7 +19,7 @@ FastLED 3.9.8 - FastLED now supports 27.5k pixels and more, on the Teensy 4.x
   * Q/A:
     * Is anything else supported other than WS2812? - Not at this moment. As far as I know, all strips on this bulk controller **must** use the same
       timings. Because of the popularity of WS2812, it is enabled for this controller first. I will add support for other controllers based on the number of feature requests for other WS281x chipsets.
-    * Is overclocking supported? Yes, and it binds to the current overclock `#define FASTLED_OVERCLOCK 1.2` @ a 20% overlock.
+    * Is overclocking supported? Yes, and it binds to the current overclock `#define FASTLED_LED_OVERCLOCK 1.2` @ a 20% overlock.
     * Have you tested this? Very lightly in FastLED, but Kurt has done his own tests and FastLED just provides some wrappers to map it to our familiar and easy api.
     * How does this compare to the stock LED driver on Teensy for just one strip? Better and way less random light flashes. For some reason the stock Teensy WS2812 driver seems to produce glitches, but with the ObjectFLED driver seems to fix this.
     * Will this become the default driver on Teensy 4.x? Yes, in the next release, unless users report problems.
@@ -140,7 +140,7 @@ FastLED 3.9.2
   * We have compile fixes for 3.9.X
 * WS28XX family of led chipsets can now be overclocked
   * See also define `FASTLED_LED_OVERCLOCK`
-    * Example: `#define FASTLED_OVERCLOCK 1.2` (gives 20% overclock).
+    * Example: `#define FASTLED_LED_OVERCLOCK 1.2` (gives 20% overclock).
     * You can set this define before you include `"FastLED.h"`
     * Slower chips like AVR which do software bitbanging will ignore this.
     * This discovery came from this reddit thread:
@@ -165,7 +165,7 @@ FastLED 3.9.2
 Example of how to enable overclocking.
 
 ```
-#define FASTLED_OVERCLOCK 1.2 // 20% overclock ~ 960 khz.
+#define FASTLED_LED_OVERCLOCK 1.2 // 20% overclock ~ 960 khz.
 #include "FastLED.h"
 ```
 


### PR DESCRIPTION
Fix the overclock examples. The define should be FASTLED_LED_OVERCLOCK