### PR TITLE
esp8266 clockless only define MIN if not already defined

### DIFF
--- a/src/platforms/esp/8266/clockless_block_esp8266.h
+++ b/src/platforms/esp/8266/clockless_block_esp8266.h
@@ -11,7 +11,10 @@
 
 #define FIX_BITS(bits) (((bits & 0x0fL) << 12) | (bits & 0x30))
 
+#ifndef MIN
 #define MIN(X,Y) (((X)<(Y)) ? (X):(Y))
+#endif
+
 #define USED_LANES (MIN(LANES, 6))
 #define PORT_MASK (((1 << USED_LANES)-1) & 0x0000FFFFL)
 #define PIN_MASK FIX_BITS(PORT_MASK)


### PR DESCRIPTION
MIN is also defined in fl/math_macros.h, avoid the compiler warning.