### PR TITLE
add more tests for brightness_bitshifter functions

### DIFF
--- a/tests/test_brightness_bitshifter.cpp
+++ b/tests/test_brightness_bitshifter.cpp
@@ -12,7 +12,7 @@
 #include "fl/namespace.h"
 FASTLED_USING_NAMESPACE
 
-TEST_CASE("brightness_bitshifter") {
+TEST_CASE("brightness_bitshifter8") {
     SUBCASE("random test to check that the product is the same") {
         int count = 0;
         for (int i = 0; i < 10000; ++i) {
@@ -27,6 +27,52 @@ TEST_CASE("brightness_bitshifter") {
             }
         }
         CHECK_GT(count, 0);
+    }
+
+    SUBCASE("fixed test data mimicing actual use") {
+        const uint8_t test_data[][2][2] = {
+            // brightness_bitshifter8 is always called with brightness_src = 0b00010000
+            { // test case
+                // src       dst
+                {0b00010000, 0b00000000}, // input
+                {0b00010000, 0b00000000}, // output
+            },
+            {
+                {0b00010000, 0b00000001},
+                {0b00000001, 0b00010000},
+            },
+            {
+                {0b00010000, 0b00000100},
+                {0b00000001, 0b01000000},
+            },
+            {
+                {0b00010000, 0b00010000},
+                {0b00000010, 0b10000000},
+            },
+            {
+                {0b00010000, 0b00001010},
+                {0b00000001, 0b10100000},
+            },
+            {
+                {0b00010000, 0b00101010},
+                {0b00000100, 0b10101000},
+            },
+            {
+                {0b00010000, 0b11101010},
+                {0b00010000, 0b11101010},
+            },
+        };
+
+        for (const auto& data : test_data) {
+            uint8_t brightness_src = data[0][0];
+            uint8_t brightness_dst = data[0][1];
+            uint8_t shifts = brightness_bitshifter8(&brightness_src, &brightness_dst, 4);
+            INFO("input  brightness_src: ", data[0][0], " ; input brightness_dst: ", data[0][1]);
+            INFO("output brightness_src: ", brightness_src, " ; output brightness_dst: ", brightness_dst);
+            INFO("shifts : ", shifts);
+            CHECK_EQ(brightness_src, data[1][0]);
+            CHECK_EQ(brightness_dst, data[1][1]);
+        }
     }
 }
 
@@ -73,5 +119,59 @@ TEST_CASE("brightness_bitshifter16") {
             }
         }
         CHECK_GT(count, 0);
+    }
+
+    SUBCASE("fixed test data mimicing actual use") {
+        const uint16_t test_data[][2][2] = {
+            // brightness_bitshifter16 is always called with brightness_src between 0b00000001 - 0b00010000
+            { // test case
+                // src       dst
+                {0b00000001, 0b0000000000000000}, // input
+                {0b00000001, 0b0000000000000000}, // output
+            },
+            {
+                {0b00000001, 0b0000000000000001},
+                {0b00000001, 0b0000000000000001},
+            },
+            {
+                {0b00000001, 0b0000000000000010},
+                {0b00000001, 0b0000000000000010},
+            },
+            {
+                {0b00000010, 0b0000000000000001},
+                {0b00000001, 0b0000000000000100},
+            },
+            {
+                {0b00001010, 0b0000000000001010},
+                {0b00000101, 0b0000000000101000},
+            },
+            {
+                {0b00010000, 0b0000111000100100},
+                {0b00000100, 0b1110001001000000},
+            },
+            {
+                {0b00010000, 0b0011100010010010},
+                {0b00001000, 0b1110001001001000},
+            },
+            {
+                {0b00010000, 0b0110001001001110},
+                {0b00010000, 0b0110001001001110},
+            },
+            {
+                {0b00010000, 0b1110001001001110},
+                {0b00010000, 0b1110001001001110},
+            },
+        };
+
+        for (const auto& data : test_data) {
+            uint8_t brightness_src = static_cast<uint8_t>(data[0][0]);
+            uint16_t brightness_dst = data[0][1];
+            uint8_t shifts = brightness_bitshifter16(&brightness_src, &brightness_dst, 4, 2);
+            INFO("input  brightness_src: ", data[0][0], " ; input brightness_dst: ", data[0][1]);
+            INFO("output brightness_src: ", brightness_src, " ; output brightness_dst: ", brightness_dst);
+            INFO("shifts (by 2 bits): ", shifts);
+            CHECK_EQ(brightness_src, data[1][0]);
+            CHECK_EQ(brightness_dst, data[1][1]);
+        }
     }
 }


### PR DESCRIPTION
using fixed data in addition to the existing tests using randomly generated data.

I didn't realize these functions had some tests already before writing these. I figure they're helpful to add anyway; they helped me understand how these functions work.