### PR TITLE
Fix #1101 - check for num_leds == 0 and skip output routine

### DIFF
--- a/src/platforms/arm/d21/clockless_arm_d21.h
+++ b/src/platforms/arm/d21/clockless_arm_d21.h
@@ -40,6 +40,9 @@ public:
     // This method is made static to force making register Y available to use for data on AVR - if the method is non-static, then
     // gcc will use register Y for the this pointer.
     static uint32_t showRGBInternal(PixelController<RGB_ORDER> pixels) {
+        if (pixels.size() == 0) {
+            return 1;   // nonzero means success
+        }
         struct M0ClocklessData data;
         data.d[0] = pixels.d[0];
         data.d[1] = pixels.d[1];


### PR DESCRIPTION
Thanks to [@apozharski](https://github.com/apozharski) for doing the hard work of isolating the bug.  Since I ran into this, I went ahead and submitted this PR.

I put the zero length check at the lowest level possible so it would catch all code paths.