### PR TITLE
Fix WS2816 on ObjectFLED

### DIFF
--- a/.github/workflows/check_teensy41_size.yml
+++ b/.github/workflows/check_teensy41_size.yml
@@ -13,6 +13,6 @@ jobs:
     uses: ./.github/workflows/build_template_binary_size.yml
     with:
       board: teensy41
-      max_size: 80000
+      max_size: 104000
       max_size_apa102: 84000
 

--- a/.github/workflows/check_uno_size.yml
+++ b/.github/workflows/check_uno_size.yml
@@ -14,7 +14,7 @@ jobs:
     with:
       board: uno
       max_size: 11000
-      max_size_apa102: 12050
+      max_size_apa102: 9300
   build_no_forced_inline:
     uses: ./.github/workflows/build_template_binary_size.yml
     with:

--- a/README.md
+++ b/README.md
@@ -270,6 +270,10 @@ If you are willing to make a custom board with shift registers, then the ESp32S3
 
 # New Feature Announcements
 
+## New in 3.9.12: WS2816 "HD" LED support
+
+![image](https://github.com/user-attachments/assets/258ec44c-af82-44b7-ad7b-fac08daa9bcb)
+
 ## New in 3.9.10: Super Stable WS2812 SPI driver for ESP32
 
 ![image (2)](https://github.com/user-attachments/assets/b3c5801c-66df-40af-a6b8-bbd1520fbb36)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -24,10 +24,10 @@ Release notes should list highlight changes (not necessarily all minor bug fixes
 
 Git commands to commit and tag release'
 ```bash
-$ git commit -m "Rev 3.9.11 - Bug fix for Massive Parallel Drivers for Teensy and ESP32S3"
-$ git tag 3.9.11 master 
+$ git commit -m "Rev 3.9.12 - Adds BETA support for WS2816 HD pixel strip, Teensy 4.x now uses massive parallel driver by default."
+$ git tag 3.9.12 master 
 $ git push 
-$ git push origin 3.9.11
+$ git push origin 3.9.12
 ```
 
 Then use the GitHub UI to make a new “Release”:

--- a/ci/ci-compile.py
+++ b/ci/ci-compile.py
@@ -104,6 +104,7 @@ DEFAULT_EXAMPLES = [
     "FxNoisePlusPalette",
     "FxPacifica",
     "FxEngine",
+    "WS2816"
 ]
 
 EXTRA_EXAMPLES: dict[Board, list[str]] = {

--- a/ci/ci-compile.py
+++ b/ci/ci-compile.py
@@ -104,7 +104,7 @@ DEFAULT_EXAMPLES = [
     "FxNoisePlusPalette",
     "FxPacifica",
     "FxEngine",
-    "WS2816"
+    "WS2816",
 ]
 
 EXTRA_EXAMPLES: dict[Board, list[str]] = {

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -48,7 +48,7 @@ PROJECT_NAME           = FastLED
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 3.9.11
+PROJECT_NUMBER         = 3.9.12
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/examples/TeensyMassiveParallel/TeensyMassiveParallel.ino
+++ b/examples/TeensyMassiveParallel/TeensyMassiveParallel.ino
@@ -16,6 +16,7 @@ void setup() {}
 void loop() {}
 #else
 
+// As if FastLED 3.9.12, this is no longer needed for Teensy 4.0/4.1.
 #define FASTLED_USES_OBJECTFLED
 
 // Optional define to override the latch delay (microseconds)

--- a/examples/WS2816/WS2816.ino
+++ b/examples/WS2816/WS2816.ino
@@ -1,0 +1,35 @@
+/// @file    WS2816.ino
+/// @brief   A blink example using the WS2816 controller
+/// @example WS2816.ino
+/// Note that the WS2816 has a 4 bit gamma correction built in. As of 3.9.12, no gamma
+/// correction in FastLED is applied. However, in the future this could change to improve
+/// the color accuracy.
+
+#include <FastLED.h>
+
+// How many leds in your strip?
+#define NUM_LEDS 1
+
+
+#define DATA_PIN 3
+
+
+// Define the array of leds
+CRGB leds[NUM_LEDS];
+
+void setup() { 
+    // Uncomment/edit one of the following lines for your leds arrangement.
+    // ## Clockless types ##
+    FastLED.addLeds<WS2816, DATA_PIN>(leds, NUM_LEDS);  // GRB ordering is assumed
+}
+
+void loop() { 
+  // Turn the LED on, then pause
+  leds[0] = CRGB::Red;
+  FastLED.show();
+  delay(500);
+  // Now turn the LED off, then pause
+  leds[0] = CRGB::Black;
+  FastLED.show();
+  delay(500);
+}

--- a/library.json
+++ b/library.json
@@ -38,7 +38,7 @@
         "type": "git",
         "url": "https://github.com/FastLED/FastLED.git"
     },
-    "version": "3.9.11",
+    "version": "3.9.12",
     "license": "MIT",
     "homepage": "http://fastled.io",
     "frameworks": "arduino",

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=FastLED
-version=3.9.11
+version=3.9.12
 author=Daniel Garcia
 maintainer=Daniel Garcia <dgarcia@fastled.io>
 sentence=Multi-platform library for controlling dozens of different types of LEDs along with optimized math, effect, and noise functions.

--- a/platformio.ini
+++ b/platformio.ini
@@ -26,6 +26,11 @@ build_flags =
     -DFASTLED_ESP32_SPI_BULK_TRANSFER=1    
 check_tool = clangtidy
 
+[env:uno]
+platform = atmelavr
+board = uno
+framework = arduino
+
 [env:esp32s3]
 extends = env:generic-esp
 board = seeed_xiao_esp32s3

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,10 +1,13 @@
 FastLED 3.9.12
 ==============
+* WS2816 (high definition) chipset now supported.
+  * Thank you https://github.com/kbob for the code to do this!
 * Apollo3 SPE LoRa Thing Plus expLoRaBLE now supported
 * ESP32C3 - WS2812 Flicker when using WIFI / Interrupts is now fixed.
 * ObjectFLED is now automatic for Teensy 4.0/4.1 for WS2812.
   * To disable use `#define FASTLED_NOT_USES_OBJECTFLED` before `#include "FastLED.h"`
 * Fixes for RGBW emulated mode for SAMD (digit, due) chipsets.
+
 
 FastLED 3.9.11
 ==============

--- a/release_notes.md
+++ b/release_notes.md
@@ -2,6 +2,11 @@ FastLED 3.9.12
 ==============
 * WS2816 (high definition) chipset now supported.
   * Thank you https://github.com/kbob for the code to do this!
+  * This is a 16-bit per channel LED that runs on the WS2812 protocol.
+  * 4-bit internal gamma correction on the chipset.
+    * 8-bit gamma correction from software + hardware is possible, but not implemented yet.
+    * Therefore this is a beta release of the driver that may see a color correction enhancement down the line.
+  * See example: https://github.com/FastLED/FastLED/blob/master/examples/WS2816/WS2816.ino
 * Apollo3 SPE LoRa Thing Plus expLoRaBLE now supported
 * ESP32C3 - WS2812 Flicker when using WIFI / Interrupts is now fixed.
 * ObjectFLED is now automatic for Teensy 4.0/4.1 for WS2812.

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,7 +1,10 @@
-FastLED 3.9.12 (next release)
+FastLED 3.9.12
 ==============
 * Apollo3 SPE LoRa Thing Plus expLoRaBLE now supported
 * ESP32C3 - WS2812 Flicker when using WIFI / Interrupts is now fixed.
+* ObjectFLED is now automatic for Teensy 4.0/4.1 for WS2812.
+  * To disable use `#define FASTLED_NOT_USES_OBJECTFLED` before `#include "FastLED.h"`
+* Fixes for RGBW emulated mode for SAMD (digit, due) chipsets.
 
 FastLED 3.9.11
 ==============

--- a/release_notes.md
+++ b/release_notes.md
@@ -15,8 +15,8 @@ FastLED 3.9.12
 * ObjectFLED is now automatic for Teensy 4.0/4.1 for WS2812.
   * To disable use `#define FASTLED_NOT_USES_OBJECTFLED` before `#include "FastLED.h"`
 * Fixes for RGBW emulated mode for SAMD (digit, due) chipsets.
-* AVR platforms will see a 22% shrinkage when using the APA102 chipset.
-  * Firmware size (bytes):
+* AVR platforms will see a 22% shrinkage when using the APA102 and APA102-HD chipset.
+  * Uno Firmware (bytes) w/ APA102-HD (bytes):
     * 3.9.11: 11787
     * 3.9.12: 9243 (-22%)
 

--- a/release_notes.md
+++ b/release_notes.md
@@ -8,10 +8,17 @@ FastLED 3.9.12
     * Therefore this is a beta release of the driver that may see a color correction enhancement down the line.
   * See example: https://github.com/FastLED/FastLED/blob/master/examples/WS2816/WS2816.ino
 * Apollo3 SPE LoRa Thing Plus expLoRaBLE now supported
-* ESP32C3 - WS2812 Flicker when using WIFI / Interrupts is now fixed.
+* ESP32-C3 - WS2812 Flicker when using WIFI / Interrupts is now fixed.
+  * This has always been a problem since before 3.9.X series.
+  * ESP32-C3 now is more stable than ESP32-S3 for the RMT controller because they can allocate much more memory per channel.
+  * If you are on the ESP32-S3, please try out the SPI controller if driving one strip, or use the new I2S driver if driving lots of strips.
 * ObjectFLED is now automatic for Teensy 4.0/4.1 for WS2812.
   * To disable use `#define FASTLED_NOT_USES_OBJECTFLED` before `#include "FastLED.h"`
 * Fixes for RGBW emulated mode for SAMD (digit, due) chipsets.
+* AVR platforms will see a 22% shrinkage when using the APA102 chipset.
+  * Firmware size (bytes):
+    * 3.9.11: 11787
+    * 3.9.12: 9243 (-22%)
 
 
 FastLED 3.9.11

--- a/src/FastLED.cpp
+++ b/src/FastLED.cpp
@@ -106,14 +106,21 @@ void CFastLED::show(uint8_t scale) {
 	CLEDController *pCur = CLEDController::head();
 
 	while(pCur && length < MAX_CLED_CONTROLLERS) {
-		gControllersData[length++] = pCur->beginShowLeds(pCur->size());
+		if (pCur->getEnabled()) {
+			gControllersData[length] = pCur->beginShowLeds(pCur->size());
+		} else {
+			gControllersData[length] = nullptr;
+		}
+		length++;
 		if (m_nFPS < 100) { pCur->setDither(0); }
 		pCur = pCur->next();
 	}
 
 	pCur = CLEDController::head();
 	for (length = 0; length < MAX_CLED_CONTROLLERS && pCur; length++) {
-		pCur->showLedsInternal(scale);
+		if (pCur->getEnabled()) {
+			pCur->showLedsInternal(scale);
+		}
 		pCur = pCur->next();
 
 	}
@@ -121,7 +128,10 @@ void CFastLED::show(uint8_t scale) {
 	length = 0;  // Reset length to 0 and iterate again.
 	pCur = CLEDController::head();
 	while(pCur && length < MAX_CLED_CONTROLLERS) {
-		pCur->endShowLeds(gControllersData[length++]);
+		if (pCur->getEnabled()) {
+			pCur->endShowLeds(gControllersData[length]);
+		}
+		length++;
 		pCur = pCur->next();
 	}
 	countFPS();

--- a/src/FastLED.h
+++ b/src/FastLED.h
@@ -193,6 +193,10 @@ class WS2812 : public WS2812Controller800Khz<DATA_PIN, RGB_ORDER> {};
 template<uint8_t DATA_PIN, EOrder RGB_ORDER>
 class WS2815 : public WS2815Controller<DATA_PIN, RGB_ORDER> {};
 
+/// @brief WS2816 controller class.
+template <uint8_t DATA_PIN, EOrder RGB_ORDER>
+class WS2816 : public WS2816Controller<DATA_PIN, RGB_ORDER> {};
+
 /// @brief WS2852 controller class.
 /// @copydetails WS2812Controller800Khz
 template<uint8_t DATA_PIN, EOrder RGB_ORDER>

--- a/src/FastLED.h
+++ b/src/FastLED.h
@@ -16,13 +16,13 @@
 /// * 1 digit for the major version
 /// * 3 digits for the minor version
 /// * 3 digits for the patch version
-#define FASTLED_VERSION 3009011
+#define FASTLED_VERSION 3009012
 #ifndef FASTLED_INTERNAL
 #  ifdef  FASTLED_SHOW_VERSION
 #    ifdef FASTLED_HAS_PRAGMA_MESSAGE
-#      pragma message "FastLED version 3.009.011"
+#      pragma message "FastLED version 3.009.012"
 #    else
-#      warning FastLED version 3.009.011  (Not really a warning, just telling you here.)
+#      warning FastLED version 3.009.012  (Not really a warning, just telling you here.)
 #    endif
 #  endif
 #endif

--- a/src/chipsets.h
+++ b/src/chipsets.h
@@ -396,14 +396,13 @@ public:
 protected:
 	/// @copydoc CPixelLEDController::showPixels()
 	virtual void showPixels(PixelController<RGB_ORDER> & pixels) override {
-		PixelIterator iterator = pixels.as_iterator(this->getRgbw());
 		switch (GAMMA_CORRECTION_MODE) {
 			case kFiveBitGammaCorrectionMode_Null: {
-				showPixelsDefault(iterator);
+				showPixelsDefault(pixels);
 				break;
 			}
 			case kFiveBitGammaCorrectionMode_BitShift: {
-				showPixelsGammaBitShift(iterator);
+				showPixelsGammaBitShift(pixels);
 				break;
 			}
 		}
@@ -412,7 +411,7 @@ protected:
 private:
 
 	static inline void getGlobalBrightnessAndScalingFactors(
-		    PixelIterator& pixels,
+		    PixelController<RGB_ORDER> & pixels,
 		    uint8_t* out_s0, uint8_t* out_s1, uint8_t* out_s2, uint8_t* out_brightness) {
 #if FASTLED_HD_COLOR_MIXING
 		uint8_t brightness;
@@ -448,7 +447,7 @@ private:
 	}
 
 	// Legacy showPixels implementation.
-	inline void showPixelsDefault(PixelIterator& pixels) {
+	inline void showPixelsDefault(PixelController<RGB_ORDER> & pixels) {
 		mSPI.select();
 		uint8_t s0, s1, s2, global_brightness;
 		getGlobalBrightnessAndScalingFactors(pixels, &s0, &s1, &s2, &global_brightness);
@@ -466,7 +465,7 @@ private:
 		mSPI.release();
 	}
 
-	inline void showPixelsGammaBitShift(PixelIterator& pixels) {
+	inline void showPixelsGammaBitShift(PixelController<RGB_ORDER> & pixels) {
 		mSPI.select();
 		startBoundary();
 		while (pixels.has(1)) {

--- a/src/chipsets.h
+++ b/src/chipsets.h
@@ -974,10 +974,10 @@ class WS2813Controller : public ClocklessController<DATA_PIN, C_NS_WS2813(320), 
 #endif
 
 
-#ifdef FASTLED_USES_OBJECTFLED
-#ifndef __IMXRT1062__
-#error "ObjectFLED is only supported on Teensy 4.0/4.1"
-#else
+#if defined(__IMXRT1062__) && !defined(FASTLED_NOT_USES_OBJECTFLED)
+#if defined(FASTLED_USES_OBJECTFLED)
+#warning "FASTLED_USES_OBJECTFLED is now implicit for Teensy 4.0/4.1 for WS2812 and is no longer needed."
+#endif
 template <uint8_t DATA_PIN, EOrder RGB_ORDER = GRB>
 class WS2812Controller800Khz:
 	public fl::ClocklessController_ObjectFLED_WS2812<
@@ -987,7 +987,6 @@ class WS2812Controller800Khz:
     typedef fl::ClocklessController_ObjectFLED_WS2812<DATA_PIN, RGB_ORDER> Base;
 	WS2812Controller800Khz(): Base(FASTLED_OVERCLOCK) {}
 };
-#endif  // __IMXRT1062__
 #elif defined(FASTLED_USES_ESP32S3_I2S)
 #include "platforms/esp/32/clockless_i2s_esp32s3.h"
 template <uint8_t DATA_PIN, EOrder RGB_ORDER = GRB>

--- a/src/chipsets.h
+++ b/src/chipsets.h
@@ -1015,6 +1015,84 @@ class WS2811Controller400Khz : public ClocklessController<DATA_PIN, C_NS_WS2811(
 template <uint8_t DATA_PIN, EOrder RGB_ORDER = GRB>
 class WS2815Controller : public ClocklessController<DATA_PIN, C_NS_WS2815(250), C_NS_WS2815(1090), C_NS_WS2815(550), RGB_ORDER> {};
 
+// WS2816 - is an emulated controller that emits 48 bit pixels by forwarding
+// them to a platform specific WS2812 controller.  The WS2812 controller
+// has to output twice as many 24 bit pixels.
+template <uint8_t DATA_PIN, EOrder RGB_ORDER = GRB>
+class WS2816Controller // : public ClocklessController<DATA_PIN, C_NS_WS2816(250), C_NS_WS2816(625), C_NS_WS2816(375)> {
+    : public CPixelLEDController<RGB_ORDER, 
+								 WS2812Controller800Khz<DATA_PIN, RGB>::LANES_VALUE,
+                                 WS2812Controller800Khz<DATA_PIN, RGB>::MASK_VALUE> {
+
+public:
+    typedef WS2812Controller800Khz<DATA_PIN, RGB> ControllerT;
+    static const int LANES = ControllerT::LANES_VALUE;
+    static const uint32_t MASK = ControllerT::MASK_VALUE;
+
+    WS2816Controller() {}
+    ~WS2816Controller() {
+        mController.setLeds(nullptr, 0);
+        delete [] mData;
+    }
+
+    virtual void showPixels(PixelController<RGB_ORDER, LANES, MASK> &pixels) {
+        // Ensure buffer is large enough
+        ensureBuffer(pixels.size());
+
+		// expand and copy all the pixels
+        PixelIterator iterator = pixels.as_iterator(this->getRgbw());
+		size_t out_index = 0;
+        while (iterator.has(1)) {
+            pixels.stepDithering();
+
+			uint16_t s0, s1, s2;
+            iterator.loadAndScale_WS2816_HD(&s0, &s1, &s2);
+			uint8_t b0_hi = s0 >> 8;
+			uint8_t b0_lo = s0 & 0xFF;
+			uint8_t b1_hi = s1 >> 8;
+			uint8_t b1_lo = s1 & 0xFF;
+			uint8_t b2_hi = s2 >> 8;
+			uint8_t b2_lo = s2 & 0xFF;
+
+			mData[out_index] = CRGB(b0_hi, b0_lo, b1_hi);
+			mData[out_index + 1] = CRGB(b1_lo, b2_hi, b2_lo);
+
+            iterator.advanceData();
+			out_index += 2;
+        }
+
+		// ensure device controller won't modify color values
+        mController.setCorrection(CRGB(255, 255, 255));
+        mController.setTemperature(CRGB(255, 255, 255));
+        mController.setDither(DISABLE_DITHER);
+
+		// output the data stream
+        mController.setEnabled(true);
+        mController.showLeds(255);
+        mController.setEnabled(false);
+    }
+
+private:
+    void init() override {
+        mController.init();
+        mController.setEnabled(false);
+    }
+
+    void ensureBuffer(int size_8bit) {
+        int size_16bit = 2 * size_8bit;
+        if (mController.size() != size_16bit) {
+            delete [] mData;
+            CRGB *new_leds = new CRGB[size_16bit];
+			mData = new_leds;
+            mController.setLeds(new_leds, size_16bit);
+        }
+    }
+
+    CRGB *mData = 0;
+    ControllerT mController;
+
+};
+
 // 750NS, 750NS, 750NS
 template <uint8_t DATA_PIN, EOrder RGB_ORDER = RGB>
 class TM1803Controller400Khz : public ClocklessController<DATA_PIN, C_NS(700), C_NS(1100), C_NS(700), RGB_ORDER> {};

--- a/src/chipsets.h
+++ b/src/chipsets.h
@@ -125,12 +125,11 @@ class RGBWEmulatedController
         // Ensure buffer is large enough
         ensureBuffer(pixels.size());
         uint8_t *data = reinterpret_cast<uint8_t *>(mRGBWPixels);
-        PixelIterator iterator = pixels.as_iterator(this->getRgbw());
-        while (iterator.has(1)) {
+        while (pixels.has(1)) {
             pixels.stepDithering();
-            iterator.loadAndScaleRGBW(data, data + 1, data + 2, data + 3);
+            pixels.loadAndScaleRGBW(data, data + 1, data + 2, data + 3);
             data += 4;
-            iterator.advanceData();
+            pixels.advanceData();
         }
 
 		// Force the device controller to a state where it passes data through
@@ -1153,13 +1152,12 @@ public:
         ensureBuffer(pixels.size());
 
 		// expand and copy all the pixels
-        PixelIterator iterator = pixels.as_iterator(this->getRgbw());
 		size_t out_index = 0;
-        while (iterator.has(1)) {
+        while (pixels.has(1)) {
             pixels.stepDithering();
 
 			uint16_t s0, s1, s2;
-            iterator.loadAndScale_WS2816_HD(&s0, &s1, &s2);
+            pixels.loadAndScale_WS2816_HD(&s0, &s1, &s2);
 			uint8_t b0_hi = s0 >> 8;
 			uint8_t b0_lo = s0 & 0xFF;
 			uint8_t b1_hi = s1 >> 8;
@@ -1170,7 +1168,7 @@ public:
 			mData[out_index] = CRGB(b0_hi, b0_lo, b1_hi);
 			mData[out_index + 1] = CRGB(b1_lo, b2_hi, b2_lo);
 
-            iterator.advanceData();
+            pixels.advanceData();
 			out_index += 2;
         }
 

--- a/src/chipsets.h
+++ b/src/chipsets.h
@@ -1065,11 +1065,11 @@ public:
     static const int LANES = ControllerT::LANES_VALUE;
     static const uint32_t MASK = ControllerT::MASK_VALUE;
 
-    WS2816Controller() {}
-    ~WS2816Controller() {
-        mController.setLeds(nullptr, 0);
-        delete [] mData;
-    }
+//     WS2816Controller() {}
+//     ~WS2816Controller() {
+//         mController.setLeds(nullptr, 0);
+//         delete [] mData;
+//     }
 
     virtual void *beginShowLeds(int size) override {
         mController.setEnabled(true);

--- a/src/chipsets.h
+++ b/src/chipsets.h
@@ -1127,6 +1127,85 @@ class UCS1912Controller : public ClocklessController<DATA_PIN, C_NS(250), C_NS(1
 #endif
 /// @} ClocklessChipsets
 
+
+// WS2816 - is an emulated controller that emits 48 bit pixels by forwarding
+// them to a platform specific WS2812 controller.  The WS2812 controller
+// has to output twice as many 24 bit pixels.
+template <uint8_t DATA_PIN, EOrder RGB_ORDER = GRB>
+class WS2816Controller // : public ClocklessController<DATA_PIN, C_NS_WS2816(250), C_NS_WS2816(625), C_NS_WS2816(375)> {
+    : public CPixelLEDController<RGB_ORDER, 
+								 WS2812Controller800Khz<DATA_PIN, RGB>::LANES_VALUE,
+                                 WS2812Controller800Khz<DATA_PIN, RGB>::MASK_VALUE> {
+
+public:
+    typedef WS2812Controller800Khz<DATA_PIN, RGB> ControllerT;
+    static const int LANES = ControllerT::LANES_VALUE;
+    static const uint32_t MASK = ControllerT::MASK_VALUE;
+
+    WS2816Controller() {}
+    ~WS2816Controller() {
+        mController.setLeds(nullptr, 0);
+        delete [] mData;
+    }
+
+    virtual void showPixels(PixelController<RGB_ORDER, LANES, MASK> &pixels) {
+        // Ensure buffer is large enough
+        ensureBuffer(pixels.size());
+
+		// expand and copy all the pixels
+        PixelIterator iterator = pixels.as_iterator(this->getRgbw());
+		size_t out_index = 0;
+        while (iterator.has(1)) {
+            pixels.stepDithering();
+
+			uint16_t s0, s1, s2;
+            iterator.loadAndScale_WS2816_HD(&s0, &s1, &s2);
+			uint8_t b0_hi = s0 >> 8;
+			uint8_t b0_lo = s0 & 0xFF;
+			uint8_t b1_hi = s1 >> 8;
+			uint8_t b1_lo = s1 & 0xFF;
+			uint8_t b2_hi = s2 >> 8;
+			uint8_t b2_lo = s2 & 0xFF;
+
+			mData[out_index] = CRGB(b0_hi, b0_lo, b1_hi);
+			mData[out_index + 1] = CRGB(b1_lo, b2_hi, b2_lo);
+
+            iterator.advanceData();
+			out_index += 2;
+        }
+
+		// ensure device controller won't modify color values
+        mController.setCorrection(CRGB(255, 255, 255));
+        mController.setTemperature(CRGB(255, 255, 255));
+        mController.setDither(DISABLE_DITHER);
+
+		// output the data stream
+        mController.setEnabled(true);
+        mController.showLeds(255);
+        mController.setEnabled(false);
+    }
+
+private:
+    void init() override {
+        mController.init();
+        mController.setEnabled(false);
+    }
+
+    void ensureBuffer(int size_8bit) {
+        int size_16bit = 2 * size_8bit;
+        if (mController.size() != size_16bit) {
+            delete [] mData;
+            CRGB *new_leds = new CRGB[size_16bit];
+			mData = new_leds;
+            mController.setLeds(new_leds, size_16bit);
+        }
+    }
+
+    CRGB *mData = 0;
+    ControllerT mController;
+};
+
+
 #endif
 /// @} Chipsets
 

--- a/src/chipsets.h
+++ b/src/chipsets.h
@@ -1013,6 +1013,7 @@ class WS2811Controller400Khz : public ClocklessController<DATA_PIN, C_NS_WS2811(
 template <uint8_t DATA_PIN, EOrder RGB_ORDER = GRB>
 class WS2815Controller : public ClocklessController<DATA_PIN, C_NS_WS2815(250), C_NS_WS2815(1090), C_NS_WS2815(550), RGB_ORDER> {};
 
+
 // 750NS, 750NS, 750NS
 template <uint8_t DATA_PIN, EOrder RGB_ORDER = RGB>
 class TM1803Controller400Khz : public ClocklessController<DATA_PIN, C_NS(700), C_NS(1100), C_NS(700), RGB_ORDER> {};

--- a/src/chipsets.h
+++ b/src/chipsets.h
@@ -124,10 +124,11 @@ class RGBWEmulatedController
     virtual void showPixels(PixelController<RGB_ORDER, LANES, MASK> &pixels) {
         // Ensure buffer is large enough
         ensureBuffer(pixels.size());
+		Rgbw rgbw = this->getRgbw();
         uint8_t *data = reinterpret_cast<uint8_t *>(mRGBWPixels);
         while (pixels.has(1)) {
             pixels.stepDithering();
-            pixels.loadAndScaleRGBW(data, data + 1, data + 2, data + 3);
+            pixels.loadAndScaleRGBW(rgbw, data, data + 1, data + 2, data + 3);
             data += 4;
             pixels.advanceData();
         }

--- a/src/chipsets.h
+++ b/src/chipsets.h
@@ -1013,6 +1013,43 @@ class WS2811Controller400Khz : public ClocklessController<DATA_PIN, C_NS_WS2811(
 template <uint8_t DATA_PIN, EOrder RGB_ORDER = GRB>
 class WS2815Controller : public ClocklessController<DATA_PIN, C_NS_WS2815(250), C_NS_WS2815(1090), C_NS_WS2815(550), RGB_ORDER> {};
 
+
+// 750NS, 750NS, 750NS
+template <uint8_t DATA_PIN, EOrder RGB_ORDER = RGB>
+class TM1803Controller400Khz : public ClocklessController<DATA_PIN, C_NS(700), C_NS(1100), C_NS(700), RGB_ORDER> {};
+
+template <uint8_t DATA_PIN, EOrder RGB_ORDER = RGB>
+class TM1829Controller800Khz : public ClocklessController<DATA_PIN, C_NS(340), C_NS(340), C_NS(550), RGB_ORDER, 0, true, 500> {};
+
+template <uint8_t DATA_PIN, EOrder RGB_ORDER = RGB>
+class TM1829Controller1600Khz : public ClocklessController<DATA_PIN, C_NS(100), C_NS(300), C_NS(200), RGB_ORDER, 0, true, 500> {};
+
+template <uint8_t DATA_PIN, EOrder RGB_ORDER = RGB>
+class LPD1886Controller1250Khz : public ClocklessController<DATA_PIN, C_NS(200), C_NS(400), C_NS(200), RGB_ORDER, 4> {};
+
+template <uint8_t DATA_PIN, EOrder RGB_ORDER = RGB>
+class LPD1886Controller1250Khz_8bit : public ClocklessController<DATA_PIN, C_NS(200), C_NS(400), C_NS(200), RGB_ORDER> {};
+
+
+template <uint8_t DATA_PIN, EOrder RGB_ORDER = RGB>
+class SK6822Controller : public ClocklessController<DATA_PIN, C_NS_SK6822(375), C_NS_SK6822(1000), C_NS_SK6822(375), RGB_ORDER> {};
+
+template <uint8_t DATA_PIN, EOrder RGB_ORDER = RGB>
+class SK6812Controller : public ClocklessController<DATA_PIN, C_NS_SK6812(300), C_NS_SK6812(300), C_NS_SK6812(600), RGB_ORDER> {};
+
+template <uint8_t DATA_PIN, EOrder RGB_ORDER = RGB>
+class SM16703Controller : public ClocklessController<DATA_PIN, C_NS(300), C_NS(600), C_NS(300), RGB_ORDER> {};
+
+template <uint8_t DATA_PIN, EOrder RGB_ORDER = RGB>
+class PL9823Controller : public ClocklessController<DATA_PIN, C_NS(350), C_NS(1010), C_NS(350), RGB_ORDER> {};
+
+// UCS1912 - Note, never been tested, this is according to the datasheet
+template <uint8_t DATA_PIN, EOrder RGB_ORDER = RGB>
+class UCS1912Controller : public ClocklessController<DATA_PIN, C_NS(250), C_NS(1000), C_NS(350), RGB_ORDER> {};
+#endif
+/// @} ClocklessChipsets
+
+
 // WS2816 - is an emulated controller that emits 48 bit pixels by forwarding
 // them to a platform specific WS2812 controller.  The WS2812 controller
 // has to output twice as many 24 bit pixels.
@@ -1052,13 +1089,12 @@ public:
         ensureBuffer(pixels.size());
 
         // expand and copy all the pixels
-        PixelIterator iterator = pixels.as_iterator(this->getRgbw());
         size_t out_index = 0;
-        while (iterator.has(1)) {
+        while (pixels.has(1)) {
             pixels.stepDithering();
 
             uint16_t s0, s1, s2;
-            iterator.loadAndScale_WS2816_HD(&s0, &s1, &s2);
+            pixels.loadAndScale_WS2816_HD(&s0, &s1, &s2);
             uint8_t b0_hi = s0 >> 8;
             uint8_t b0_lo = s0 & 0xFF;
             uint8_t b1_hi = s1 >> 8;
@@ -1069,7 +1105,7 @@ public:
             mData[out_index] = CRGB(b0_hi, b0_lo, b1_hi);
             mData[out_index + 1] = CRGB(b1_lo, b2_hi, b2_lo);
 
-            iterator.advanceData();
+            pixels.advanceData();
             out_index += 2;
         }
 
@@ -1104,42 +1140,6 @@ private:
     ControllerT mController;
 
 };
-
-// 750NS, 750NS, 750NS
-template <uint8_t DATA_PIN, EOrder RGB_ORDER = RGB>
-class TM1803Controller400Khz : public ClocklessController<DATA_PIN, C_NS(700), C_NS(1100), C_NS(700), RGB_ORDER> {};
-
-template <uint8_t DATA_PIN, EOrder RGB_ORDER = RGB>
-class TM1829Controller800Khz : public ClocklessController<DATA_PIN, C_NS(340), C_NS(340), C_NS(550), RGB_ORDER, 0, true, 500> {};
-
-template <uint8_t DATA_PIN, EOrder RGB_ORDER = RGB>
-class TM1829Controller1600Khz : public ClocklessController<DATA_PIN, C_NS(100), C_NS(300), C_NS(200), RGB_ORDER, 0, true, 500> {};
-
-template <uint8_t DATA_PIN, EOrder RGB_ORDER = RGB>
-class LPD1886Controller1250Khz : public ClocklessController<DATA_PIN, C_NS(200), C_NS(400), C_NS(200), RGB_ORDER, 4> {};
-
-template <uint8_t DATA_PIN, EOrder RGB_ORDER = RGB>
-class LPD1886Controller1250Khz_8bit : public ClocklessController<DATA_PIN, C_NS(200), C_NS(400), C_NS(200), RGB_ORDER> {};
-
-
-template <uint8_t DATA_PIN, EOrder RGB_ORDER = RGB>
-class SK6822Controller : public ClocklessController<DATA_PIN, C_NS_SK6822(375), C_NS_SK6822(1000), C_NS_SK6822(375), RGB_ORDER> {};
-
-template <uint8_t DATA_PIN, EOrder RGB_ORDER = RGB>
-class SK6812Controller : public ClocklessController<DATA_PIN, C_NS_SK6812(300), C_NS_SK6812(300), C_NS_SK6812(600), RGB_ORDER> {};
-
-template <uint8_t DATA_PIN, EOrder RGB_ORDER = RGB>
-class SM16703Controller : public ClocklessController<DATA_PIN, C_NS(300), C_NS(600), C_NS(300), RGB_ORDER> {};
-
-template <uint8_t DATA_PIN, EOrder RGB_ORDER = RGB>
-class PL9823Controller : public ClocklessController<DATA_PIN, C_NS(350), C_NS(1010), C_NS(350), RGB_ORDER> {};
-
-// UCS1912 - Note, never been tested, this is according to the datasheet
-template <uint8_t DATA_PIN, EOrder RGB_ORDER = RGB>
-class UCS1912Controller : public ClocklessController<DATA_PIN, C_NS(250), C_NS(1000), C_NS(350), RGB_ORDER> {};
-#endif
-/// @} ClocklessChipsets
-
 
 // // WS2816 - is an emulated controller that emits 48 bit pixels by forwarding
 // // them to a platform specific WS2812 controller.  The WS2812 controller

--- a/src/chipsets.h
+++ b/src/chipsets.h
@@ -1013,7 +1013,6 @@ class WS2811Controller400Khz : public ClocklessController<DATA_PIN, C_NS_WS2811(
 template <uint8_t DATA_PIN, EOrder RGB_ORDER = GRB>
 class WS2815Controller : public ClocklessController<DATA_PIN, C_NS_WS2815(250), C_NS_WS2815(1090), C_NS_WS2815(550), RGB_ORDER> {};
 
-
 // 750NS, 750NS, 750NS
 template <uint8_t DATA_PIN, EOrder RGB_ORDER = RGB>
 class TM1803Controller400Khz : public ClocklessController<DATA_PIN, C_NS(700), C_NS(1100), C_NS(700), RGB_ORDER> {};

--- a/src/cled_controller.h
+++ b/src/cled_controller.h
@@ -70,6 +70,7 @@ public:
     }
 
     void setEnabled(bool enabled) { m_enabled = enabled; }
+    bool getEnabled() { return m_enabled; }
 
     CLEDController();
     // If we added virtual to the AVR boards then we are going to add 600 bytes of memory to the binary

--- a/src/cpixel_ledcontroller.h
+++ b/src/cpixel_ledcontroller.h
@@ -24,7 +24,7 @@ FASTLED_NAMESPACE_BEGIN
 /// @tparam LANES how many parallel lanes of output to write
 /// @tparam MASK bitmask for the output lanes
 template<EOrder RGB_ORDER, int LANES=1, uint32_t MASK=0xFFFFFFFF> class CPixelLEDController : public CLEDController {
-protected:
+public:
 
 
     /// Set all the LEDs on the controller to a given color

--- a/src/fl/screenmap.h
+++ b/src/fl/screenmap.h
@@ -12,9 +12,9 @@
 #include "fl/namespace.h"
 
 /* Screenmap maps strip indexes to x,y coordinates. This is used for FastLED Web
- * to map the 1D strip to a 2D grid. Note that the strip can have arbitrary
- * size. this was first motivated during the (attempted? Oct. 19th 2024) port of
- * the Chromancer project to FastLED Web.
+ * to map the 1D strip to a 2D screen. Note that the strip can have arbitrary
+ * size. this was first motivated by the effort to port theChromancer project to
+ * FastLED for the browser.
  */
 
 namespace fl {

--- a/src/pixel_controller.h
+++ b/src/pixel_controller.h
@@ -519,6 +519,9 @@ struct PixelController {
     // WS2816B has native 16 bit/channel color and internal 4 bit gamma correction.
     // So we don't do gamma here, and we don't bother with dithering.
     FASTLED_FORCE_INLINE void loadAndScale_WS2816_HD(uint16_t *s0_out, uint16_t *s1_out, uint16_t *s2_out) {
+        // Note that the WS2816 has a 4 bit gamma correction built in. To improve things this algorithm may
+        // change in the future with a partial gamma correction that is completed by the chipset gamma
+        // correction.
         uint16_t r16 = map8_to_16(mData[0]);
         uint16_t g16 = map8_to_16(mData[1]);
         uint16_t b16 = map8_to_16(mData[2]);

--- a/src/pixel_controller.h
+++ b/src/pixel_controller.h
@@ -83,7 +83,7 @@ struct PixelController {
         kMask = MASK
     };
 
-    PixelIterator as_iterator(const Rgbw& rgbw) {
+    FASTLED_FORCE_INLINE PixelIterator as_iterator(const Rgbw& rgbw) {
         return PixelIterator(this, rgbw);
     }
 

--- a/src/pixel_iterator.h
+++ b/src/pixel_iterator.h
@@ -79,6 +79,9 @@ typedef void (*getHdScaleFunction)(void* pixel_controller, uint8_t* c0, uint8_t*
 // PixelIterator is turns a PixelController<> into a concrete object that can be used to iterate
 // over pixels and transform them into driver data. See PixelController<>::as_iterator() for how
 // to create a PixelIterator.
+// Note: This is designed for micro-controllers with a lot of memory. DO NOT use this in the core library
+// as a PixelIterator consumes a *lot* more instruction data than an instance of PixelController<RGB_ORDER>.
+// This iterator is designed for code in src/platforms/**.
 class PixelIterator {
   public:
     template<typename PixelControllerT>

--- a/src/pixel_iterator.h
+++ b/src/pixel_iterator.h
@@ -31,6 +31,11 @@ struct PixelControllerVtable {
     pc->loadAndScale_APA102_HD(b0_out, b1_out, b2_out, brightness_out);
   }
 
+  static void loadAndScale_WS2816_HD(void* pixel_controller, uint16_t *s0_out, uint16_t* s1_out, uint16_t* s2_out) {
+    PixelControllerT* pc = static_cast<PixelControllerT*>(pixel_controller);
+    pc->loadAndScale_WS2816_HD(s0_out, s1_out, s2_out);
+  }
+
   static void stepDithering(void* pixel_controller) {
     PixelControllerT* pc = static_cast<PixelControllerT*>(pixel_controller);
     pc->stepDithering();
@@ -62,6 +67,7 @@ struct PixelControllerVtable {
 typedef void (*loadAndScaleRGBWFunction)(void* pixel_controller, Rgbw rgbw, uint8_t* b0_out, uint8_t* b1_out, uint8_t* b2_out, uint8_t* b3_out);
 typedef void (*loadAndScaleRGBFunction)(void* pixel_controller, uint8_t* r_out, uint8_t* g_out, uint8_t* b_out);
 typedef void (*loadAndScale_APA102_HDFunction)(void* pixel_controller, uint8_t* b0_out, uint8_t* b1_out, uint8_t* b2_out, uint8_t* brightness_out);
+typedef void (*loadAndScale_WS2816_HDFunction)(void* pixel_controller, uint16_t* b0_out, uint16_t* b1_out, uint16_t* b2_out);
 typedef void (*stepDitheringFunction)(void* pixel_controller);
 typedef void (*advanceDataFunction)(void* pixel_controller);
 typedef int (*sizeFunction)(void* pixel_controller);
@@ -106,6 +112,7 @@ class PixelIterator {
       mLoadAndScaleRGBW = &Vtable::loadAndScaleRGBW;
       mLoadAndScaleRGB = &Vtable::loadAndScaleRGB;
       mLoadAndScale_APA102_HD = &Vtable::loadAndScale_APA102_HD;
+      mLoadAndScale_WS2816_HD = &Vtable::loadAndScale_WS2816_HD;
       mStepDithering = &Vtable::stepDithering;
       mAdvanceData = &Vtable::advanceData;
       mSize = &Vtable::size;
@@ -124,6 +131,9 @@ class PixelIterator {
     }
     void loadAndScale_APA102_HD(uint8_t *b0_out, uint8_t *b1_out, uint8_t *b2_out, uint8_t *brightness_out) {
       mLoadAndScale_APA102_HD(mPixelController, b0_out, b1_out, b2_out, brightness_out);
+    }
+    void loadAndScale_WS2816_HD(uint16_t *s0_out, uint16_t *s1_out, uint16_t *s2_out) {
+      mLoadAndScale_WS2816_HD(mPixelController, s0_out, s1_out, s2_out);
     }
     void stepDithering() { mStepDithering(mPixelController); }
     void advanceData() { mAdvanceData(mPixelController); }
@@ -145,6 +155,7 @@ class PixelIterator {
     loadAndScaleRGBWFunction mLoadAndScaleRGBW = nullptr;
     loadAndScaleRGBFunction mLoadAndScaleRGB = nullptr;
     loadAndScale_APA102_HDFunction mLoadAndScale_APA102_HD = nullptr;
+    loadAndScale_WS2816_HDFunction mLoadAndScale_WS2816_HD = nullptr;
     stepDitheringFunction mStepDithering = nullptr;
     advanceDataFunction mAdvanceData = nullptr;
     sizeFunction mSize = nullptr;

--- a/src/platforms/arm/k20/clockless_objectfled.h
+++ b/src/platforms/arm/k20/clockless_objectfled.h
@@ -61,7 +61,7 @@ class ClocklessController_ObjectFLED_WS2812
     void init() override {}
     virtual uint16_t getMaxRefreshRate() const { return 800; }
 
-  protected:
+  // protected:
     // Wait until the last draw is complete, if necessary.
     virtual void *beginShowLeds(int nleds) override {
         void *data = Base::beginShowLeds(nleds);


### PR DESCRIPTION
Fixes the regression that WS2816 does not work on ObjectFLED.

    ObjectFLED was failing because beginShowLeds/endShowLeds were
    being called on disabled controllers.  This code puts guards
    (controller.getEnabled()) around those calls.  It also reorders
    the calls to all controllers' beginShowLeds -> all controllers'
    showPixels -> all controllers' endShowLeds, so that ObjectFLED
    can write all pins simultaneously.

N.B., this is still not thoroughly tested.  I know of one code path that doesn't work (CFastLED::showColor), and I've only tested two platforms.  So you can take this fix or you can wait for a more complete one.  I am continuing to test and debug, so I should have something solid in a day or two.