### PR TITLE
Fix WS2816 on ObjectFLED and ESP32S3

### DIFF
--- a/src/FastLED.cpp
+++ b/src/FastLED.cpp
@@ -173,16 +173,31 @@ void CFastLED::showColor(const struct CRGB & color, uint8_t scale) {
 	int length = 0;
 	CLEDController *pCur = CLEDController::head();
 	while(pCur && length < MAX_CLED_CONTROLLERS) {
-		gControllersData[length++] = pCur->beginShowLeds(pCur->size());
+		if (pCur->getEnabled()) {
+			gControllersData[length] = pCur->beginShowLeds(pCur->size());
+		} else {
+			gControllersData[length] = nullptr;
+		}
+		length++;
+		pCur = pCur->next();
+	}
+
+	pCur = CLEDController::head();
+	while(pCur && length < MAX_CLED_CONTROLLERS) {
 		if(m_nFPS < 100) { pCur->setDither(0); }
-		pCur->showColorInternal(color, scale);
+		if (pCur->getEnabled()) {
+			pCur->showColorInternal(color, scale);
+		}
 		pCur = pCur->next();
 	}
 
 	pCur = CLEDController::head();
 	length = 0;  // Reset length to 0 and iterate again.
 	while(pCur && length < MAX_CLED_CONTROLLERS) {
-		pCur->endShowLeds(gControllersData[length++]);
+		if (pCur->getEnabled()) {
+			pCur->endShowLeds(gControllersData[length]);
+		}
+		length++;
 		pCur = pCur->next();
 	}
 	countFPS();

--- a/src/FastLED.cpp
+++ b/src/FastLED.cpp
@@ -106,14 +106,21 @@ void CFastLED::show(uint8_t scale) {
 	CLEDController *pCur = CLEDController::head();
 
 	while(pCur && length < MAX_CLED_CONTROLLERS) {
-		gControllersData[length++] = pCur->beginShowLeds(pCur->size());
+		if (pCur->getEnabled()) {
+			gControllersData[length] = pCur->beginShowLeds(pCur->size());
+		} else {
+			gControllersData[length] = nullptr;
+		}
+		length++;
 		if (m_nFPS < 100) { pCur->setDither(0); }
 		pCur = pCur->next();
 	}
 
 	pCur = CLEDController::head();
 	for (length = 0; length < MAX_CLED_CONTROLLERS && pCur; length++) {
-		pCur->showLedsInternal(scale);
+		if (pCur->getEnabled()) {
+			pCur->showLedsInternal(scale);
+		}
 		pCur = pCur->next();
 
 	}
@@ -121,7 +128,10 @@ void CFastLED::show(uint8_t scale) {
 	length = 0;  // Reset length to 0 and iterate again.
 	pCur = CLEDController::head();
 	while(pCur && length < MAX_CLED_CONTROLLERS) {
-		pCur->endShowLeds(gControllersData[length++]);
+		if (pCur->getEnabled()) {
+			pCur->endShowLeds(gControllersData[length]);
+		}
+		length++;
 		pCur = pCur->next();
 	}
 	countFPS();

--- a/src/cled_controller.h
+++ b/src/cled_controller.h
@@ -70,6 +70,7 @@ public:
     }
 
     void setEnabled(bool enabled) { m_enabled = enabled; }
+    bool getEnabled() { return m_enabled; }
 
     CLEDController();
     // If we added virtual to the AVR boards then we are going to add 600 bytes of memory to the binary

--- a/src/cpixel_ledcontroller.h
+++ b/src/cpixel_ledcontroller.h
@@ -24,7 +24,8 @@ FASTLED_NAMESPACE_BEGIN
 /// @tparam LANES how many parallel lanes of output to write
 /// @tparam MASK bitmask for the output lanes
 template<EOrder RGB_ORDER, int LANES=1, uint32_t MASK=0xFFFFFFFF> class CPixelLEDController : public CLEDController {
-protected:
+//protected:
+public:
 
 
     /// Set all the LEDs on the controller to a given color

--- a/src/platforms/arm/k20/clockless_objectfled.h
+++ b/src/platforms/arm/k20/clockless_objectfled.h
@@ -61,7 +61,7 @@ class ClocklessController_ObjectFLED_WS2812
     void init() override {}
     virtual uint16_t getMaxRefreshRate() const { return 800; }
 
-  protected:
+  //protected:
     // Wait until the last draw is complete, if necessary.
     virtual void *beginShowLeds(int nleds) override {
         void *data = Base::beginShowLeds(nleds);

--- a/src/platforms/esp/32/rmt_5/idf5_clockless_rmt_esp32.h
+++ b/src/platforms/esp/32/rmt_5/idf5_clockless_rmt_esp32.h
@@ -38,7 +38,7 @@ public:
     void init() override { }
     virtual uint16_t getMaxRefreshRate() const { return 800; }
 
-protected:
+//protected:
 
 
     // Prepares data for the draw.


### PR DESCRIPTION
These changes make WS2816 work with the Teensy4's ObjectFLED controller and ESP32S3's IDF5 RMT controller.  They also fix CFastLED::showColor.

FWIW, my ESP32 board is a Seeed XAIO ESP32S3.  That seems to be the default in `platformio.ini`, so I'm not the only one using it.  The examples all use pin 3, and when I run them, the LED signals appears on the pin labeled A2.  The parallel examples use pins 1 and 3, and those come out on A0 and A2.  This seems to be consistent with Arduino's pin assignments, but it contradicts the silkscreen and [Seeed's own documentation](https://wiki.seeedstudio.com/xiao_esp32s3_getting_started/).  It's also consistent across FastLED/PlatformIO and FastLED/Arduino, and not dependent on using WS2816, so I think it's right.  It's just disconcerting.