### PR TITLE
ESP32 RMT4 driver blocks FastLED.show() 

### DIFF
--- a/src/platforms/esp/32/rmt_4/idf4_rmt_impl.h
+++ b/src/platforms/esp/32/rmt_4/idf4_rmt_impl.h
@@ -13,7 +13,7 @@
 #include "FastLED.h"
 #include "idf4_rmt.h"
 #include "platforms/esp/32/clock_cycles.h"
-#include "esp_version.h"
+#include "platforms/esp/esp_version.h"
 
 // ESP_IDF_VERSION_MAJOR 3 uses the thread safe register and ISR handling
 #if !defined(RMT4_USE_SAFE_REGISTERS) && ESP_IDF_VERSION_MAJOR<4 

--- a/src/platforms/esp/32/rmt_4/idf4_rmt_impl.h
+++ b/src/platforms/esp/32/rmt_4/idf4_rmt_impl.h
@@ -13,6 +13,12 @@
 #include "FastLED.h"
 #include "idf4_rmt.h"
 #include "platforms/esp/32/clock_cycles.h"
+#include "esp_version.h"
+
+// ESP_IDF_VERSION_MAJOR 3 uses the thread safe register and ISR handling
+#if !defined(RMT4_USE_SAFE_REGISTERS) && ESP_IDF_VERSION_MAJOR<4 
+#define RMT4_USE_THREADSAFE_REGISTERS
+#endif
 
 #ifdef __cplusplus
 extern "C"


### PR DESCRIPTION
Fix for #1856 and #1438


introduce a new define RMT4_USE_THREADSAFE_REGISTERS 
with the define a thread safe variant of the RMT4 register handling is used
1.) gTxSem is now triggered every time a channel has finished sending data. Adding a waiting controller to the freed channel is no longer done within the interrupt.
Now inside showPixel method a loop takes care about waiting for all controllers to be finished and/or assigning controllers to channel that got free.
2.) I protect access to RMT registers with a lock
