### PR TITLE
Fix WS2816 to bypass `protected` scope in various platform controller…

### DIFF
--- a/src/cpixel_ledcontroller.h
+++ b/src/cpixel_ledcontroller.h
@@ -24,8 +24,7 @@ FASTLED_NAMESPACE_BEGIN
 /// @tparam LANES how many parallel lanes of output to write
 /// @tparam MASK bitmask for the output lanes
 template<EOrder RGB_ORDER, int LANES=1, uint32_t MASK=0xFFFFFFFF> class CPixelLEDController : public CLEDController {
-//protected:
-public:
+protected:
 
 
     /// Set all the LEDs on the controller to a given color

--- a/src/platforms/arm/k20/clockless_objectfled.h
+++ b/src/platforms/arm/k20/clockless_objectfled.h
@@ -61,7 +61,7 @@ class ClocklessController_ObjectFLED_WS2812
     void init() override {}
     virtual uint16_t getMaxRefreshRate() const { return 800; }
 
-  //protected:
+  protected:
     // Wait until the last draw is complete, if necessary.
     virtual void *beginShowLeds(int nleds) override {
         void *data = Base::beginShowLeds(nleds);

--- a/src/platforms/esp/32/rmt_5/idf5_clockless_rmt_esp32.h
+++ b/src/platforms/esp/32/rmt_5/idf5_clockless_rmt_esp32.h
@@ -38,7 +38,7 @@ public:
     void init() override { }
     virtual uint16_t getMaxRefreshRate() const { return 800; }
 
-//protected:
+protected:
 
 
     // Prepares data for the draw.


### PR DESCRIPTION
… classes

Added a helper class to WS2816Controller that subclasses the platform's controller and allows access to the controller's protected methods. Ugly, I'm sorry.