### PR TITLE
Enable test compiles for ESP32 with ESP-IDF 3.3 LTS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,3 +85,8 @@ jobs:
     uses: ./.github/workflows/build_template.yml
     with:
       args: "esp32dev_idf44"
+
+  build_esp32dev_idf33:
+    uses: ./.github/workflows/build_template.yml
+    with:
+      args: "esp32dev_idf33"

--- a/.github/workflows/build_esp32dev_idf3.3.yml
+++ b/.github/workflows/build_esp32dev_idf3.3.yml
@@ -1,0 +1,15 @@
+name: esp32dev-idf3.3-lts
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    uses: ./.github/workflows/build_template.yml
+    with:
+      args: esp32dev_idf33

--- a/ci/ci/boards.py
+++ b/ci/ci/boards.py
@@ -104,6 +104,12 @@ ESP32DEV = Board(
     platform=ESP32_IDF_5_3_PIOARDUINO,
 )
 
+ESP32DEV_IDF3_3 = Board(
+    board_name="esp32dev_idf33",
+    real_board_name="esp32dev",
+    platform="espressif32@1.11.2",
+)
+
 ESP32DEV_IDF4_4 = Board(
     board_name="esp32dev_idf44",
     real_board_name="esp32dev",
@@ -269,6 +275,7 @@ ALL: list[Board] = [
     APOLLO3_RED_BOARD,
     APOLLO3_SPARKFUN_THING_PLUS_EXPLORERABLE,
     ESP32DEV,
+    ESP32DEV_IDF3_3,
     ESP32DEV_IDF4_4,
     ESP32DEV_I2S,
     # ESP01,

--- a/src/fx/1d/fire2012.h
+++ b/src/fx/1d/fire2012.h
@@ -50,7 +50,7 @@ class Fire2012 : public Fx1d {
   public:
     Fire2012(uint16_t num_leds, uint8_t cooling = 55, uint8_t sparking = 120,
              bool reverse_direction = false,
-             const CRGBPalette16 &palette = HeatColors_p)
+             const CRGBPalette16 &palette = (const CRGBPalette16&)HeatColors_p)
         : Fx1d(num_leds), cooling(cooling), sparking(sparking),
           reverse_direction(reverse_direction), palette(palette) {
         heat.reset(new uint8_t[num_leds]()); // Initialize to zero


### PR DESCRIPTION
add a test build task to avoid future ESP32 compile problems for projects based on  ESP-IDF 3.3 LTS 