### PR TITLE
Remove unused variable; ret

### DIFF
--- a/src/third_party/espressif/led_strip/src/led_strip_rmt_encoder.c
+++ b/src/third_party/espressif/led_strip/src/led_strip_rmt_encoder.c
@@ -82,7 +82,6 @@ static esp_err_t rmt_led_strip_encoder_reset(rmt_encoder_t *encoder)
 
 esp_err_t rmt_new_led_strip_encoder(const led_strip_encoder_config_t *config, rmt_encoder_handle_t *ret_encoder)
 {
-    esp_err_t ret = ESP_OK;
     ESP_GOTO_ON_FALSE(config && ret_encoder, ESP_ERR_INVALID_ARG, err, TAG, "invalid argument");
     ESP_GOTO_ON_FALSE(config->led_model < LED_MODEL_INVALID, ESP_ERR_INVALID_ARG, err, TAG, "invalid led model");
     // Create a temporary config with the same base values


### PR DESCRIPTION
- Fixing warning:
```
 warning: variable 'ret' set but not used [-Wunused-but-set-variable]
   85 |     esp_err_t ret = ESP_OK;
      |               ^~~
```
The function returns the error code from `rmt_new_led_strip_encoder_with_timings`, or a defined error.