### PR TITLE
Additional platform identifier define added for giga r1

### DIFF
--- a/src/led_sysdefs.h
+++ b/src/led_sysdefs.h
@@ -53,7 +53,7 @@
 #include "platforms/apollo3/led_sysdefs_apollo3.h"
 #elif defined(ARDUINO_ARCH_RENESAS) || defined(ARDUINO_ARCH_RENESAS_UNO) || defined(ARDUINO_ARCH_RENESAS_PORTENTA)
 #include "platforms/arm/renesas/led_sysdef_arm_renesas.h"
-#elif defined(ARDUINO_GIGA_M7)
+#elif defined(ARDUINO_GIGA)|| defined(ARDUINO_GIGA_M7)
 #include "platforms/arm/giga/led_sysdef_arm_giga.h"
 #elif defined(__x86_64__) || defined(FASTLED_STUB_IMPL) || defined(__APPLE__) || defined(__linux__) || defined(__unix__) || defined(__EMSCRIPTEN__)
 // Not on a microcontroller

--- a/src/platforms.h
+++ b/src/platforms.h
@@ -46,7 +46,7 @@
 #include "platforms/apollo3/fastled_apollo3.h"
 #elif defined(ARDUINO_ARCH_RENESAS) || defined(ARDUINO_ARCH_RENESAS_UNO) || defined(ARDUINO_ARCH_RENESAS_PORTENTA)
 #include "platforms/arm/renesas/fastled_arm_renesas.h"
-#elif defined(ARDUINO_GIGA_M7)
+#elif defined(ARDUINO_GIGA) || defined(ARDUINO_GIGA_M7)
 #include "platforms/arm/giga/fastled_arm_giga.h"
 #elif defined(__x86_64__) || defined(FASTLED_STUB_IMPL)
 

--- a/src/platforms/arm/giga/fastpin_arm_giga.h
+++ b/src/platforms/arm/giga/fastpin_arm_giga.h
@@ -7,7 +7,7 @@
 
 FASTLED_NAMESPACE_BEGIN
 
-#if defined (ARDUINO_GIGA_M7)
+#if defined(ARDUINO_GIGA) || defined(ARDUINO_GIGA_M7)
 #define _RD32(T) struct __gen_struct_ ## T { static FASTLED_FORCE_INLINE volatile GPIO_TypeDef * r() { return T; } };
 #define _FL_IO(L,C) _RD32(GPIO ## L);
 
@@ -28,7 +28,7 @@ _FL_IO(J,9);
 _FL_IO(K,10);
 
 // Actual pin definitions
-#if defined(ARDUINO_GIGA_M7)
+#if defined(ARDUINO_GIGA) || defined(ARDUINO_GIGA_M7)
 #define MAX_PIN 102
 
 // PA0-PA15
@@ -201,7 +201,7 @@ _FL_DEFPIN(41, 7, K);
 
 #define HAS_HARDWARE_PIN_SUPPORT
 
-#endif // ARDUINO_GIGA_M7
+#endif // ARDUINO_GIGA || ARDUINO_GIGA_M7
 
 FASTLED_NAMESPACE_END
 


### PR DESCRIPTION
Additional platform identifier define ARDUINO_GIGA added. Fixes issues with non recognizable platform when building with Arduino IDE