### PR TITLE
Don't define MIN and MAX in platform headers

### DIFF
--- a/src/platforms/arm/k20/fastspi_arm_k20.h
+++ b/src/platforms/arm/k20/fastspi_arm_k20.h
@@ -37,8 +37,6 @@ public:
 	static int highestBit() __attribute__((always_inline)) { return 0; }
 };
 
-#define MAX(A, B) (( (A) > (B) ) ? (A) : (B))
-
 #define USE_CONT 0
 // intra-frame backup data
 struct SPIState {


### PR DESCRIPTION
I'm trying to compile this for Teensy 3.2 and getting a few warnings with platformio

```
In file included from .pio/libdeps/teensy32/FastLED/src/platforms/arm/k20/fastled_arm_k20.h:6,
                 from .pio/libdeps/teensy32/FastLED/src/platforms.h:19,
                 from .pio/libdeps/teensy32/FastLED/src/FastLED.h:70,
                 from src/main.cpp:48:
.pio/libdeps/teensy32/FastLED/src/platforms/arm/k20/fastspi_arm_k20.h:40: warning: "MAX" redefined
   40 | #define MAX(A, B) (( (A) > (B) ) ? (A) : (B))
      |
In file included from .pio/libdeps/teensy32/FastLED/src/fl/str.h:10,
                 from .pio/libdeps/teensy32/FastLED/src/crgb.hpp:12,
                 from .pio/libdeps/teensy32/FastLED/src/pixeltypes.h:11,
                 from .pio/libdeps/teensy32/FastLED/src/cpixel_ledcontroller.h:10,
                 from .pio/libdeps/teensy32/FastLED/src/controller.h:7,
                 from .pio/libdeps/teensy32/FastLED/src/FastLED.h:65,
                 from src/main.cpp:48:
.pio/libdeps/teensy32/FastLED/src/fl/math_macros.h:4: note: this is the location of the previous definition
    4 | #define MAX(a,b) ((a)>(b)?(a):(b))
      |
In file included from .pio/libdeps/teensy32/FastLED/src/platforms/arm/k20/fastled_arm_k20.h:11,
                 from .pio/libdeps/teensy32/FastLED/src/platforms.h:19,
                 from .pio/libdeps/teensy32/FastLED/src/FastLED.h:70,
                 from src/main.cpp:48:
.pio/libdeps/teensy32/FastLED/src/platforms/arm/k20/clockless_block_arm_k20.h:17: warning: "MIN" redefined
   17 | #define MIN(X,Y) (((X)<(Y)) ? (X):(Y))
      |
In file included from .pio/libdeps/teensy32/FastLED/src/fl/str.h:10,
                 from .pio/libdeps/teensy32/FastLED/src/crgb.hpp:12,
                 from .pio/libdeps/teensy32/FastLED/src/pixeltypes.h:11,
                 from .pio/libdeps/teensy32/FastLED/src/cpixel_ledcontroller.h:10,
                 from .pio/libdeps/teensy32/FastLED/src/controller.h:7,
                 from .pio/libdeps/teensy32/FastLED/src/FastLED.h:65,
                 from src/main.cpp:48:
.pio/libdeps/teensy32/FastLED/src/fl/math_macros.h:8: note: this is the location of the previous definition
    8 | #define MIN(a,b) ((a)<(b)?(a):(b))
      |
```