### PR TITLE
fixing ESP IDF V 5.4 compiler error [-Werror=mismatched-new-delete]

### DIFF
--- a/src/fx/2d/noisepalette.cpp
+++ b/src/fx/2d/noisepalette.cpp
@@ -33,10 +33,10 @@ NoisePalette::NoisePalette(XYMap xyMap, float fps)
     setPalettePreset(0);
 
     // Allocate memory for the noise array using scoped_ptr
-    noise = scoped_ptr<uint8_t>(new uint8_t[width * height]);
+    noise = scoped_array<uint8_t>(new uint8_t[width * height]);
 }
 
-void NoisePalette::setPalettePreset(int paletteIndex) {
+void NoisePalette::setPalettePreset(int paletteIndex) { 
     currentPaletteIndex = paletteIndex % 12; // Ensure the index wraps around
     switch (currentPaletteIndex) {
     case 0:

--- a/src/fx/2d/noisepalette.h
+++ b/src/fx/2d/noisepalette.h
@@ -60,7 +60,7 @@ class NoisePalette : public Fx2d {
     uint16_t width, height;
     uint16_t speed = 0;
     uint16_t scale = 0;
-    fl::scoped_ptr<uint8_t> noise;
+    fl::scoped_array<uint8_t> noise;
     CRGBPalette16 currentPalette;
     bool colorLoop = 0;
     int currentPaletteIndex = 0;


### PR DESCRIPTION
compiling the library using latest EDP IDF V5.4 produce compiler warning as error [-Werror=mismatched-new-delete] 
this is due to allocating  using 
new uint8_t[width * height]  ( using [] ) 
while deleter is not using [] operators  in scoped_ptr  
fix : using scoped_array instead 