### PR TITLE
1909: Add preproccesor check to prevent redefinition of new()

### DIFF
--- a/src/fl/inplacenew.h
+++ b/src/fl/inplacenew.h
@@ -2,7 +2,7 @@
 
 // This file must not be in the fl namespace, it must be in the global namespace.
 
-#if defined(__AVR__) || !defined(__has_include)
+#if (defined(__AVR__) || !defined(__has_include)) && (!defined(FASTLED_HAS_NEW))
 #ifndef __has_include
 #define _NO_EXCEPT
 #else


### PR DESCRIPTION
Closes: #1909

This adds a new define check using `FASTLED_HAS_NEW` to prevent redefinition of `operator new()` on AVR as that is also defined by the `ArduinoSTL` library.