### PR TITLE
fixed cause the assertion in panel_io_i80_tx_color, assert(color_size <= bus->max_transfer_bytes && "color bytes too long, enlarge max_transfer_bytes");

### DIFF
--- a/examples/Esp32S3I2SDemo/Esp32S3I2SDemo.ino
+++ b/examples/Esp32S3I2SDemo/Esp32S3I2SDemo.ino
@@ -47,7 +47,7 @@
 //
 // Want to get a contributor badge for FastLED? This driver has only been lightly tested.
 // There are certain open questions:
-//  - Can the pins order for the strips be changed?
+//  - Can the pins order for the strips be changed?    (the pins can be defined arbitrarily,Tested on esp32s3, esp32duino version 3.2.0)
 //  - Are there some combination of pins that can be ommitted?
 //  - What other caveats are there?
 //

--- a/src/third_party/yves/I2SClockLessLedDriveresp32s3/src/I2SClockLessLedDriveresp32s3.h
+++ b/src/third_party/yves/I2SClockLessLedDriveresp32s3/src/I2SClockLessLedDriveresp32s3.h
@@ -336,7 +336,7 @@ class I2SClocklessLedDriveresp32S3 {
         }
         bus_config.bus_width = 16;
         bus_config.max_transfer_bytes =
-            _nb_components * NUM_LED_PER_STRIP * 8 * 3 * 2 + __OFFSET;
+            _nb_components * NUM_LED_PER_STRIP * 8 * 3 * 2 + __OFFSET + __OFFSET_END;
         #if IDF_5_3_OR_EARLIER
         #pragma GCC diagnostic push
         #pragma GCC diagnostic ignored "-Wdeprecated-declarations"


### PR DESCRIPTION
I tried to add __OFFSET_END in the initialization, and it worked. And the pins can be defined arbitrarily, unlike the fixed pins described in the example.