### PR TITLE
nblend overlay data is const, mark it as such

### DIFF
--- a/src/colorutils.cpp
+++ b/src/colorutils.cpp
@@ -335,7 +335,7 @@ CRGB& nblend( CRGB& existing, const CRGB& overlay, fract8 amountOfOverlay )
 
 
 
-void nblend( CRGB* existing, CRGB* overlay, uint16_t count, fract8 amountOfOverlay)
+void nblend( CRGB* existing, const CRGB* overlay, uint16_t count, fract8 amountOfOverlay)
 {
     for( uint16_t i = count; i; --i) {
         nblend( *existing, *overlay, amountOfOverlay);
@@ -411,7 +411,7 @@ CHSV& nblend( CHSV& existing, const CHSV& overlay, fract8 amountOfOverlay, TGrad
 
 
 
-void nblend( CHSV* existing, CHSV* overlay, uint16_t count, fract8 amountOfOverlay, TGradientDirectionCode directionCode )
+void nblend( CHSV* existing, const CHSV* overlay, uint16_t count, fract8 amountOfOverlay, TGradientDirectionCode directionCode )
 {
     if(existing == overlay) return;
     for( uint16_t i = count; i; --i) {

--- a/src/colorutils.h
+++ b/src/colorutils.h
@@ -504,11 +504,11 @@ CHSV& nblend( CHSV& existing, const CHSV& overlay, fract8 amountOfOverlay,
 /// @param overlay the color array to blend into existing
 /// @param count the number of colors to process
 /// @param amountOfOverlay the fraction of overlay to blend into existing
-void  nblend( CRGB* existing, CRGB* overlay, uint16_t count, fract8 amountOfOverlay);
+void  nblend( CRGB* existing, const CRGB* overlay, uint16_t count, fract8 amountOfOverlay);
 
-/// @copydoc nblend(CRGB*, CRGB*, uint16_t, fract8)
+/// @copydoc nblend(CRGB*, const CRGB*, uint16_t, fract8)
 /// @param directionCode the direction to travel around the color wheel
-void  nblend( CHSV* existing, CHSV* overlay, uint16_t count, fract8 amountOfOverlay,
+void  nblend( CHSV* existing, const CHSV* overlay, uint16_t count, fract8 amountOfOverlay,
              TGradientDirectionCode directionCode = SHORTEST_HUES);
 
 /// @} ColorBlends


### PR DESCRIPTION
nblend take two buffer: the first (`existing`) that is used as _input/output_ and a second `overlay` that as the name imply is overlayed on top of the first one by `amountOfOverlay` amount

`overlay` buffer data is never modified, mark the signature as "mutable pointer to const data"
