### PR TITLE
fix: use dma if enabled

### DIFF
--- a/src/platforms/esp/32/rmt_5/strip_rmt.cpp
+++ b/src/platforms/esp/32/rmt_5/strip_rmt.cpp
@@ -56,7 +56,7 @@ led_strip_handle_t configure_led_with_timings(int pin, uint32_t led_count, bool 
         .resolution_hz = LED_STRIP_RMT_RES_HZ,     // RMT counter clock frequency
         .mem_block_symbols = memory_block_symbols, // the memory size of each RMT channel, in words (4 bytes)
         .flags = {
-            .with_dma = false, // DMA feature is available on chips like ESP32-S3/P4
+            .with_dma = with_dma, // DMA feature is available on chips like ESP32-S3/P4
         },
         .interrupt_priority = interrupt_priority, // RMT interrupt priority
     };


### PR DESCRIPTION
Didn't dig much deeper, but it seems, that this makes at least for my setup a difference (ESP32-WROVER-E).
Sadly the Clockless SPI doesn't work on my ESP32 version. Was not able to find out why this is not possible on this board, but will dig deeper on the exact reason.

Thanks a lot for your great work!
