### PR TITLE
Fix: Avoid FL_ALIGN_PROGMEM redefinition warning. platforms/null_prog…

### DIFF
--- a/src/fastled_progmem.h
+++ b/src/fastled_progmem.h
@@ -94,10 +94,12 @@
 /// palette code uses 'read dword', and now uses this macro
 /// to make sure that gradient palettes are 4-byte aligned.
 
+#ifndef FL_ALIGN_PROGMEM
 #if defined(FASTLED_ARM) || defined(ESP32) || defined(ESP8266) || defined(FASTLED_DOXYGEN)
 #define FL_ALIGN_PROGMEM  __attribute__ ((aligned (4)))
 #else
 #define FL_ALIGN_PROGMEM
+#endif
 #endif
 
 #endif  // defined(__EMSCRIPTEN__) || defined(FASTLED_TESTING) || defined(FASTLED_STUB_IMPL)


### PR DESCRIPTION
…mem.h already defines it. Fixes a warning seen on platforms like RP2040 with FastLED 3.9.17