### PR TITLE
Remove ESP32-nothing flags from ESP32-S3 build

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -42,8 +42,6 @@ board = seeed_xiao_esp32s3
 build_flags = 
     ${env:generic-esp.build_flags}
     -DBOARD_HAS_PSRAM
-    -mfix-esp32-psram-cache-issue
-    -mfix-esp32-psram-cache-strategy=memw
 board_build.partitions = huge_app.csv
 
 [env:esp32c6]


### PR DESCRIPTION
-mfix-esp32-psram* is meant to fix a bug in the (now nearly out of circulation) rev1 of the original ESP32. (The one with nothing after it.) It is inapplicable to the current stepping of that chip, and it's never been applicable to any of the chips with a -anything in their name. You can read about it at https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-guides/external-ram.html


https://esp32.com/viewtopic.php?f=13&p=132074
(Sprite is a high authority.)

I have removed this from a number of S3 projects. It has only a positive impact on the generated code. Its appearance in projects is always gentoo-style -O99 folklore :-)

Additionally, in Platformio-land, it's inappropriate to ever specify them out here at the "leaf" level. They're defined way up (down?) the hierarchy of inheritance, as in chip->module->board->model->product, not down here at the product level. In the cases it IS needed, it's added up in the core build system.

Citations:
https://github.com/espressif/esp-idf/blob/36a5a71d5c4b70a644a590c37b43a5da76f68ce3/docs/en/api-guides/build-system.rst?plain=1#L1056 (**only** esp32) https://github.com/espressif/esp-idf/blob/master/docs/en/api-guides/inc/external-ram-esp32-notes.rst