### PR TITLE
Fix ESP32C2 build action

### DIFF
--- a/.github/workflows/build_wasm_compilers.yml
+++ b/.github/workflows/build_wasm_compilers.yml
@@ -4,7 +4,7 @@ on:
     push:
       branches:
         - master
-    paths:
+      paths:
       - 'src/**'
       - 'examples/wasm/**'
       - 'examples/WasmScreenCoords/**'
@@ -17,7 +17,7 @@ on:
     pull_request_target:
       branches:
         - master
-    paths:
+      paths:
       - 'src/**'
       - 'examples/wasm/**'
       - 'examples/WasmScreenCoords/**'

--- a/.github/workflows/build_wasm_compilers.yml
+++ b/.github/workflows/build_wasm_compilers.yml
@@ -5,28 +5,28 @@ on:
       branches:
         - master
       paths:
-      - 'src/**'
-      - 'examples/wasm/**'
-      - 'examples/WasmScreenCoords/**'
-      - 'ci/**'
-      - '.github/workflows/**'
-      - 'CMakeLists.txt'
-      - 'platformio.ini'
-      - 'library.json'
-      - 'library.properties'
+        - 'src/**'
+        - 'examples/wasm/**'
+        - 'examples/WasmScreenCoords/**'
+        - 'ci/**'
+        - '.github/workflows/**'
+        - 'CMakeLists.txt'
+        - 'platformio.ini'
+        - 'library.json'
+        - 'library.properties'
     pull_request_target:
       branches:
         - master
       paths:
-      - 'src/**'
-      - 'examples/wasm/**'
-      - 'examples/WasmScreenCoords/**'
-      - 'ci/**'
-      - '.github/workflows/**'
-      - 'CMakeLists.txt'
-      - 'platformio.ini'
-      - 'library.json'
-      - 'library.properties'
+        - 'src/**'
+        - 'examples/wasm/**'
+        - 'examples/WasmScreenCoords/**'
+        - 'ci/**'
+        - '.github/workflows/**'
+        - 'CMakeLists.txt'
+        - 'platformio.ini'
+        - 'library.json'
+        - 'library.properties'
   
 
 jobs:

--- a/ci/ci/boards.py
+++ b/ci/ci/boards.py
@@ -164,7 +164,7 @@ ESP32_C2_DEVKITM_1 = Board(
     use_pio_run=True,
     platform="https://github.com/pioarduino/platform-espressif32/releases/download/stable/platform-espressif32.zip",
     defines=["CONFIG_IDF_TARGET_ESP32C2=1"],
-    customsdks=['CONFIG_IDF_TARGET="esp32c2"'],
+    customsdks=["CONFIG_IDF_TARGET=\"esp32c2\""],
 )
 
 ESP32_C3_DEVKITM_1 = Board(

--- a/ci/ci/boards.py
+++ b/ci/ci/boards.py
@@ -76,6 +76,9 @@ class Board:
         if self.defines:
             for define in self.defines:
                 options.append(f"build_flags=-D{define}")
+        if self.customsdks:
+            for customsdk in self.customsdks:
+                options.append(f"custom_sdkconfig={customsdk}")
         return out
 
     def __repr__(self) -> str:
@@ -161,6 +164,7 @@ ESP32_C2_DEVKITM_1 = Board(
     use_pio_run=True,
     platform="https://github.com/pioarduino/platform-espressif32/releases/download/stable/platform-espressif32.zip",
     defines=["CONFIG_IDF_TARGET_ESP32C2=1"],
+    customsdks=['CONFIG_IDF_TARGET="esp32c2"'],
 )
 
 ESP32_C3_DEVKITM_1 = Board(

--- a/ci/ci/boards.py
+++ b/ci/ci/boards.py
@@ -44,6 +44,7 @@ class Board:
     board_build_filesystem_size: str | None = None
     build_flags: list[str] | None = None  # Reserved for future use.
     defines: list[str] | None = None
+    customsdks: list[str] | None = None
     board_partitions: str | None = None  # Reserved for future use.
 
     def __post_init__(self) -> None:

--- a/platformio.ini
+++ b/platformio.ini
@@ -18,7 +18,7 @@ lib_deps =
 build_type = debug
 
 build_flags =
-	  -DDEBUG
+	-DDEBUG
     -DPIN_DATA=9
     -DPIN_CLOCK=7
     -DFASTLED_RMT5=1
@@ -90,6 +90,7 @@ board = sparkfun_xrp_controller
 framework = arduino
 build_flags = -fopt-info-all=optimization_report.txt
 extra_scripts = C:\Users\niteris\dev\fastled\pre:lib\ci\ci-flags.py
+; TODO: Why is the above line a hardcoded Windows directory for a specific user?
 
 
 [env:dev]

--- a/platformio.ini
+++ b/platformio.ini
@@ -65,6 +65,7 @@ build_flags = ${env:generic-esp.build_flags}
 extends = env:generic-esp
 platform = https://github.com/Jason2866/platform-espressif32.git#Arduino/IDF5
 board = esp32-c2-devkitm-1bjec
+custom_sdkconfig = 'CONFIG_IDF_TARGET="esp32c2"'
 build_flags = 
   ${env:generic-esp.build_flags}
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -18,7 +18,7 @@ lib_deps =
 build_type = debug
 
 build_flags =
-	-DDEBUG
+    -DDEBUG
     -DPIN_DATA=9
     -DPIN_CLOCK=7
     -DFASTLED_RMT5=1

--- a/platformio.ini
+++ b/platformio.ini
@@ -64,7 +64,7 @@ build_flags = ${env:generic-esp.build_flags}
 [env:esp32c2]
 extends = env:generic-esp
 platform = https://github.com/Jason2866/platform-espressif32.git#Arduino/IDF5
-board = esp32-c2-devkitm-1bjec
+board = esp32-c2-devkitm-1
 custom_sdkconfig = 'CONFIG_IDF_TARGET="esp32c2"'
 build_flags = 
   ${env:generic-esp.build_flags}


### PR DESCRIPTION
This should fix the ESP32C2 build action by updating the `platformio.ini` file with an updated SDK definition. This definition is required to avoid the `**** missing SConscript file ‘/home/cw/.platformio/packages/framework-arduinoespressif32-libs/esp32c2/pioarduino-build.py’*` error, per [this discussion](https://community.platformio.org/t/use-of-arduino-esp32-in-platformio/45382/22).

It also fixes some improper indentation in `build_wasm_compilers.yml` which was causing errors when the action tried to start.