### PR TITLE
ESP32C2 Compile Fix

### DIFF
--- a/ci/ci-compile.py
+++ b/ci/ci-compile.py
@@ -157,6 +157,9 @@ def parse_args():
         "--defines", type=str, help="Comma-separated list of compiler definitions"
     )
     parser.add_argument(
+        "--customsdk", type=str, help="custom_sdkconfig project option"
+    )
+    parser.add_argument(
         "--extra-packages",
         type=str,
         help="Comma-separated list of extra packages to install",
@@ -299,6 +302,7 @@ def create_concurrent_run_args(args: argparse.Namespace) -> ConcurrentRunArgs:
         ]
         for exclude in exclude_examples:
             examples.remove(exclude)
+    customsdk = args.customsdk
     defines: list[str] = []
     if args.defines:
         defines.extend(args.defines.split(","))
@@ -314,6 +318,7 @@ def create_concurrent_run_args(args: argparse.Namespace) -> ConcurrentRunArgs:
         examples=examples_paths,
         skip_init=skip_init,
         defines=defines,
+        customsdk=customsdk,
         extra_packages=extra_packages,
         libs=LIBS,
         build_dir=build_dir,

--- a/ci/ci/boards.py
+++ b/ci/ci/boards.py
@@ -44,7 +44,7 @@ class Board:
     board_build_filesystem_size: str | None = None
     build_flags: list[str] | None = None  # Reserved for future use.
     defines: list[str] | None = None
-    customsdks: list[str] | None = None
+    customsdk: str | None = None
     board_partitions: str | None = None  # Reserved for future use.
 
     def __post_init__(self) -> None:
@@ -77,9 +77,8 @@ class Board:
         if self.defines:
             for define in self.defines:
                 options.append(f"build_flags=-D{define}")
-        if self.customsdks:
-            for customsdk in self.customsdks:
-                options.append(f"custom_sdkconfig={customsdk}")
+        if self.customsdk:
+            options.append(f"custom_sdkconfig={self.customsdk}")
         return out
 
     def __repr__(self) -> str:
@@ -163,9 +162,9 @@ ESP32_C2_DEVKITM_1 = Board(
     board_name="esp32c2",
     real_board_name="esp32-c2-devkitm-1",
     use_pio_run=True,
-    platform="https://github.com/pioarduino/platform-espressif32/releases/download/stable/platform-espressif32.zip",
+    platform="https://github.com/pioarduino/platform-espressif32.git#develop",
     defines=["CONFIG_IDF_TARGET_ESP32C2=1"],
-    customsdks=["CONFIG_IDF_TARGET=\"esp32c2\""],
+    customsdk="CONFIG_IDF_TARGET=esp32c2",
 )
 
 ESP32_C3_DEVKITM_1 = Board(

--- a/ci/ci/concurrent_run.py
+++ b/ci/ci/concurrent_run.py
@@ -35,6 +35,7 @@ class ConcurrentRunArgs:
     examples: list[Path]
     skip_init: bool
     defines: list[str]
+    customsdk: str | None
     extra_packages: list[str]
     libs: list[str] | None
     build_dir: str | None
@@ -53,6 +54,7 @@ def concurrent_run(
     examples = args.examples
     skip_init = args.skip_init
     defines = args.defines
+    customsdk = args.customsdk
     extra_packages = args.extra_packages
     build_dir = args.build_dir
     extra_scripts = args.extra_scripts
@@ -72,6 +74,7 @@ def concurrent_run(
     create_build_dir(
         board=first_project,
         defines=defines,
+        customsdk=customsdk,
         no_install_deps=skip_init,
         extra_packages=extra_packages,
         build_dir=build_dir,
@@ -96,6 +99,7 @@ def concurrent_run(
                 create_build_dir,
                 board,
                 defines,
+                customsdk,
                 skip_init,
                 extra_packages,
                 build_dir,

--- a/ci/ci/create_build_dir.py
+++ b/ci/ci/create_build_dir.py
@@ -87,6 +87,7 @@ def remove_readonly(func, path, _):
 def create_build_dir(
     board: Board,
     defines: list[str],
+    customsdk: str | None,
     no_install_deps: bool,
     extra_packages: list[str],
     build_dir: str | None,
@@ -163,6 +164,8 @@ def create_build_dir(
     if defines:
         build_flags_str = " ".join(f"-D{define}" for define in defines)
         cmd_list.append(f"--project-option=build_flags={build_flags_str}")
+    if board.customsdk:
+        cmd_list.append(f"--project-option=custom_sdkconfig={customsdk}")
     if extra_packages:
         cmd_list.append(f'--project-option=lib_deps={",".join(extra_packages)}')
     if no_install_deps:

--- a/platformio.ini
+++ b/platformio.ini
@@ -63,9 +63,9 @@ build_flags = ${env:generic-esp.build_flags}
 
 [env:esp32c2]
 extends = env:generic-esp
-platform = https://github.com/Jason2866/platform-espressif32.git#Arduino/IDF5
+platform = https://github.com/pioarduino/platform-espressif32.git#develop
 board = esp32-c2-devkitm-1
-custom_sdkconfig = 'CONFIG_IDF_TARGET="esp32c2"'
+custom_sdkconfig = CONFIG_IDF_TARGET="esp32c2"
 build_flags = 
   ${env:generic-esp.build_flags}
 


### PR DESCRIPTION
Updates the platform address and custom_sdkconfig parameter passing functions in order to correct compilation for the ESP32C2.

Thanks to the Github Actions CI now working to target PR changes, I have confirmed that the fixes included in this PR lead to successful build for the ESP32C2. Thank you again for swiftly fixing that!