### PR TITLE
Run bash test and fix

### DIFF
--- a/ci/ci/watchdog_state.py
+++ b/ci/ci/watchdog_state.py
@@ -1,0 +1,40 @@
+"""
+Watchdog state management for tracking active processes.
+
+This module provides simple state management for tracking which processes
+are currently active, which can be useful for monitoring and cleanup operations.
+"""
+
+from typing import List
+
+# Global state to track active processes
+_active_processes: List[str] = []
+
+
+def set_active_processes(processes: List[str]) -> None:
+    """
+    Set the list of currently active processes.
+    
+    Args:
+        processes: List of command strings representing active processes
+    """
+    global _active_processes
+    _active_processes = processes.copy()
+
+
+def clear_active_processes() -> None:
+    """
+    Clear all tracked active processes.
+    """
+    global _active_processes
+    _active_processes = []
+
+
+def get_active_processes() -> List[str]:
+    """
+    Get the current list of active processes.
+    
+    Returns:
+        List of command strings representing active processes
+    """
+    return _active_processes.copy()

--- a/ci/compiler/clang_compiler.py
+++ b/ci/compiler/clang_compiler.py
@@ -195,7 +195,7 @@ class BuildFlags:
             # Return minimal fallback configuration
             return cls(
                 defines=["-DSTUB_PLATFORM", "-DFASTLED_UNIT_TEST=1"],
-                compiler_flags=[],  # Empty - should come from TOML
+                compiler_flags=["-std=gnu++17", "-Wall"],  # Default compiler flags
                 include_flags=["-I.", "-Isrc", "-Itests"],
                 link_flags=[],  # Empty - should come from TOML
                 strict_mode_flags=[],
@@ -206,7 +206,7 @@ class BuildFlags:
             # Return minimal fallback configuration
             return cls(
                 defines=["-DSTUB_PLATFORM", "-DFASTLED_UNIT_TEST=1"],
-                compiler_flags=[],  # Empty - should come from TOML
+                compiler_flags=["-std=gnu++17", "-Wall"],  # Default compiler flags
                 include_flags=["-I.", "-Isrc", "-Itests"],
                 link_flags=[],  # Empty - should come from TOML
                 strict_mode_flags=[],

--- a/ci/compiler/clang_compiler.py
+++ b/ci/compiler/clang_compiler.py
@@ -191,27 +191,9 @@ class BuildFlags:
             with open(toml_path, "rb") as f:
                 config = tomllib.load(f)
         except FileNotFoundError:
-            print(f"Warning: build_flags.toml not found at {toml_path}")
-            # Return minimal fallback configuration
-            return cls(
-                defines=["-DSTUB_PLATFORM", "-DFASTLED_UNIT_TEST=1"],
-                compiler_flags=["-std=gnu++17", "-Wall"],  # Default compiler flags
-                include_flags=["-I.", "-Isrc", "-Itests"],
-                link_flags=[],  # Empty - should come from TOML
-                strict_mode_flags=[],
-                tools=BuildTools(),  # Use default tools
-            )
+            raise FileNotFoundError(f"Required build_flags.toml not found at {toml_path}")
         except Exception as e:
-            print(f"Warning: Failed to parse build_flags.toml: {e}")
-            # Return minimal fallback configuration
-            return cls(
-                defines=["-DSTUB_PLATFORM", "-DFASTLED_UNIT_TEST=1"],
-                compiler_flags=["-std=gnu++17", "-Wall"],  # Default compiler flags
-                include_flags=["-I.", "-Isrc", "-Itests"],
-                link_flags=[],  # Empty - should come from TOML
-                strict_mode_flags=[],
-                tools=BuildTools(),  # Use default tools
-            )
+            raise RuntimeError(f"Failed to parse build_flags.toml: {e}")
 
         # Extract tools configuration
         tools_config = config.get("tools", {})

--- a/ci/js/lint-js-fast
+++ b/ci/js/lint-js-fast
@@ -11,7 +11,7 @@ NC='\033[0m' # No Color
 echo -e "${BLUE}FAST FastLED JavaScript Linting (Node.js + ESLint - FAST!)${NC}"
 
 # Check if ESLint is installed
-if [ ! -f ".js-tools/node_modules/.bin/eslint.cmd" ]; then
+if [ ! -f ".js-tools/node_modules/.bin/eslint" ]; then
     echo -e "${RED}ERROR: ESLint not found. Run: uv run ci/setup-js-linting-fast.py${NC}"
     exit 1
 fi
@@ -30,7 +30,7 @@ echo "$JS_FILES" | sed 's/^/  /'
 # Run ESLint
 echo -e "${BLUE}Running ESLint...${NC}"
 cd .js-tools
-if "./node_modules/.bin/eslint.cmd" --no-eslintrc --no-inline-config -c .eslintrc.js ../src/platforms/wasm/compiler/*.js ../src/platforms/wasm/compiler/modules/*.js; then
+if "./node_modules/.bin/eslint" --no-eslintrc --no-inline-config -c .eslintrc.js ../src/platforms/wasm/compiler/*.js ../src/platforms/wasm/compiler/modules/*.js; then
     echo -e "${GREEN}SUCCESS: JavaScript linting completed successfully${NC}"
 else
     echo -e "${RED}ERROR: JavaScript linting failed${NC}"

--- a/ci/tests/test_build_flags_toml.py
+++ b/ci/tests/test_build_flags_toml.py
@@ -233,16 +233,14 @@ archiver = "custom-ar"
         self.assertEqual(parsed_flags.tools.c_compiler, original_flags.tools.c_compiler)
 
     def test_parse_missing_file(self) -> None:
-        """Test parsing non-existent TOML file returns fallback configuration"""
+        """Test parsing non-existent TOML file raises FileNotFoundError"""
         nonexistent_file = self.temp_dir / "does_not_exist.toml"
 
-        flags = BuildFlags.parse(nonexistent_file, quick_build=False, strict_mode=False)
-
-        # Should return fallback configuration with default tools
-        self.assertEqual(flags.defines, ["-DSTUB_PLATFORM", "-DFASTLED_UNIT_TEST=1"])
-        self.assertEqual(flags.compiler_flags, ["-std=gnu++17", "-Wall"])
-        self.assertEqual(flags.tools.compiler, "clang++")  # Default tools
-        self.assertEqual(flags.tools.archiver, "ar")
+        # Should raise FileNotFoundError when file is missing
+        with self.assertRaises(FileNotFoundError) as context:
+            BuildFlags.parse(nonexistent_file, quick_build=False, strict_mode=False)
+        
+        self.assertIn("Required build_flags.toml not found", str(context.exception))
 
     def test_from_toml_file_alias(self) -> None:
         """Test that from_toml_file() is an alias for parse()"""


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Make `build_flags.toml` mandatory for the clang compiler and create a missing `watchdog_state` module to fix test failures.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The `build_flags.toml` file is now mandatory for the clang compiler, ensuring all build flags are explicitly defined and removing silent fallbacks to hardcoded defaults. This aligns with the requirement that the clang compiler should have no default arguments. A missing `watchdog_state.py` module was also created to resolve initial import errors, and a minor fix for the JS linting script was included.

---
<a href="https://cursor.com/background-agent?bcId=bc-5d25ade5-34cf-46c3-9c5a-981b62b6e430">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5d25ade5-34cf-46c3-9c5a-981b62b6e430">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>