### PR TITLE
Fix pch compile flags visibility

### DIFF
--- a/ci/build_flags.toml
+++ b/ci/build_flags.toml
@@ -6,7 +6,7 @@
 # compilation to ensure they remain synchronized and compatible across the entire build system.
 
 [tools]
-# Build tool configuration
+# Build tool configuration - all tools must be specified
 compiler = ["sccache", "--", "uv", "run", "python", "-m", "ziglang", "c++"]
 archiver = "ar"
 c_compiler = "clang"

--- a/ci/build_flags.toml
+++ b/ci/build_flags.toml
@@ -7,7 +7,7 @@
 
 [tools]
 # Build tool configuration
-compiler = "sccache"
+compiler = ["sccache", "--", "uv", "run", "python", "-m", "ziglang", "c++"]
 archiver = "ar"
 c_compiler = "clang"
 objcopy = "objcopy"


### PR DESCRIPTION
Refactor compiler command generation to be entirely driven by `build_flags.toml`, removing all hardcoded defaults.

The initial problem of PCH flags not being revealed exposed a deeper issue where compiler commands were partially hardcoded within the Python logic, rather than being fully defined in `build_flags.toml`. This PR moves the complete compiler command (e.g., `sccache -- uv run python -m ziglang c++`) into `build_flags.toml` and updates the compiler logic to read this list directly, ensuring consistency, maintainability, and proper failure when configuration is missing.

---
<a href="https://cursor.com/background-agent?bcId=bc-872064e1-3b47-472c-8782-b28ee6cf7287">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-872064e1-3b47-472c-8782-b28ee6cf7287">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>