### PR TITLE
Fix pch compile flags visibility

### DIFF
--- a/ci/build_flags.toml
+++ b/ci/build_flags.toml
@@ -6,8 +6,9 @@
 # compilation to ensure they remain synchronized and compatible across the entire build system.
 
 [tools]
-# Build tool configuration
-compiler = "sccache"
+# Build tool configuration - Full compiler command with arguments
+compiler_command = ["uv", "run", "python", "-m", "ziglang", "c++"]
+compiler = "ziglang"  # For compatibility
 archiver = "ar"
 c_compiler = "clang"
 objcopy = "objcopy"

--- a/ci/compiler/clang_compiler.py
+++ b/ci/compiler/clang_compiler.py
@@ -575,11 +575,21 @@ class Compiler:
                     cmd.append(f"-D{define}")
 
             # Add compiler args but skip cache-related args
-            # Filter out sccache/ccache wrapper arguments that don't apply to direct compilation
+            # Filter out sccache/ccache wrapper arguments and compiler commands that don't apply to direct compilation
             filtered_args: list[str] = []
             skip_next = False
+            
+            # Define the ziglang command sequence to skip
+            ziglang_command_sequence = ["uv", "run", "python", "-m", "ziglang", "c++"]
+            
+            # Check if compiler_args starts with the ziglang command sequence
+            args_to_process = self.settings.compiler_args[:]
+            if len(args_to_process) >= len(ziglang_command_sequence) and \
+               args_to_process[:len(ziglang_command_sequence)] == ziglang_command_sequence:
+                # Skip the ziglang command sequence
+                args_to_process = args_to_process[len(ziglang_command_sequence):]
 
-            for arg in self.settings.compiler_args:
+            for arg in args_to_process:
                 if skip_next:
                     skip_next = False
                     continue

--- a/ci/compiler/test_compiler.py
+++ b/ci/compiler/test_compiler.py
@@ -236,11 +236,12 @@ class FastLEDTestCompiler:
         # Get tools configuration from BuildFlags (respects build_flags.toml)
         compiler_cmd = build_flags.tools.compiler
         archiver_tool = build_flags.tools.archiver
+        compiler_command = build_flags.tools.compiler_command
         
-        print(f"Using compiler from build_flags.toml: {compiler_cmd}")
+        print(f"Using compiler from build_flags.toml: {compiler_command}")
 
-        # Use compiler args as-is from TOML configuration
-        final_compiler_args = compiler_args
+        # Use compiler command from TOML + flags as final compiler args
+        final_compiler_args = compiler_command + compiler_args
 
         # Create compiler options with TOML-loaded flags and tools
         settings = CompilerOptions(

--- a/ci/compiler/test_compiler.py
+++ b/ci/compiler/test_compiler.py
@@ -233,20 +233,14 @@ class FastLEDTestCompiler:
             else:
                 defines.append(define)
 
-        # Get tools configuration
-        tools_config = config.get("tools", {})
-        archiver_tool = tools_config.get("archiver", "ar")
+        # Get tools configuration from BuildFlags (respects build_flags.toml)
+        compiler_cmd = build_flags.tools.compiler
+        archiver_tool = build_flags.tools.archiver
+        
+        print(f"Using compiler from build_flags.toml: {compiler_cmd}")
 
-        # Always use ziglang c++ as the actual compiler, regardless of TOML config
-        actual_compiler_args = ["uv", "run", "python", "-m", "ziglang", "c++"]
-
-        # For now, disable cache when using ziglang c++
-        compiler_cmd = "clang++"  # Use generic clang++ identifier for compatibility
-        cache_args = actual_compiler_args  # Put ziglang c++ command in cache_args for proper detection
-        print("Using direct compilation with ziglang c++")
-
-        # Combine cache args with compiler args (cache args go first for detection)
-        final_compiler_args = cache_args + compiler_args
+        # Use compiler args as-is from TOML configuration
+        final_compiler_args = compiler_args
 
         # Create compiler options with TOML-loaded flags and tools
         settings = CompilerOptions(


### PR DESCRIPTION
Filter `uv run python -m ziglang c++` prefix from PCH compilation command arguments to enable successful PCH compilation.

Previously, the PCH compilation command was malformed due to the `uv run python -m ziglang c++` prefix being duplicated when `self.settings.compiler_args` was added. This fix removes the duplicate prefix, allowing PCH files to be created successfully.

---
<a href="https://cursor.com/background-agent?bcId=bc-84a7b3ec-21e1-4709-acef-8793861a6a95">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-84a7b3ec-21e1-4709-acef-8793861a6a95">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>