### PR TITLE
Remove timestamp prefix from test output

### DIFF
--- a/ci/ci/test_runner.py
+++ b/ci/ci/test_runner.py
@@ -69,10 +69,8 @@ class TestOutputFormatter:
         else:
             color = "\033[0m"  # Reset
 
-        # Build message
+        # Build message - only include timestamp, not command name
         msg = f"{delta:.2f} "
-        if result.test_name:
-            msg += f"[{result.test_name}] "
         msg += f"{color}{result.message}\033[0m"
 
         # Print with indentation


### PR DESCRIPTION
Remove command name from verbose test output prefix to improve readability.

---
<a href="https://cursor.com/background-agent?bcId=bc-16bdaef8-eca5-46ef-91b7-1ed40fff376b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-16bdaef8-eca5-46ef-91b7-1ed40fff376b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>