### PR TITLE
Run json unit test without unity build

### DIFF
--- a/ci/ci/test_commands.py
+++ b/ci/ci/test_commands.py
@@ -30,6 +30,8 @@ def build_cpp_test_command(args: TestArgs) -> str:
         cmd_list.append("--check")
     if args.legacy:
         cmd_list.append("--legacy")
+    if args.no_unity:
+        cmd_list.append("--no-unity")
 
     return subprocess.list2cmdline(cmd_list)
 

--- a/ci/ci/test_runner.py
+++ b/ci/ci/test_runner.py
@@ -314,6 +314,8 @@ def create_unit_test_process(
         compile_cmd.append("--clang")
     if args.gcc:
         compile_cmd.append("--gcc")
+    if args.no_unity:
+        compile_cmd.append("--no-unity")
     # subprocess.run(compile_cmd, check=True)
 
     # Then run the tests using our new test runner

--- a/ci/compiler/cpp_test_run.py
+++ b/ci/compiler/cpp_test_run.py
@@ -358,12 +358,16 @@ def _compile_tests_python(
             check_iwyu_available,
         )
 
+        # Check for --no-unity flag in unknown_args
+        no_unity = "--no-unity" in unknown_args
+
         # Initialize the proven compiler system
         test_compiler = FastLEDTestCompiler.create_for_unit_tests(
             project_root=Path(PROJECT_ROOT),
             clean_build=clean,
             enable_static_analysis="--check" in unknown_args,
             specific_test=specific_test,
+            no_unity=no_unity,
         )
 
         # Compile all tests in parallel (8x faster than CMake)
@@ -921,6 +925,11 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="Use legacy CMake system instead of new Python API (8x slower)",
     )
+    parser.add_argument(
+        "--no-unity",
+        action="store_true",
+        help="Disable unity builds for cpp tests",
+    )
 
     args, unknown = parser.parse_known_args()
     args.unknown = unknown
@@ -940,6 +949,7 @@ def main() -> None:
     _ = args.only_run_failed_test
     use_clang = args.clang
     use_legacy_system = args.legacy
+    no_unity = args.no_unity
     # use_gcc = args.gcc
 
     if not run_only:
@@ -948,6 +958,8 @@ def main() -> None:
             passthrough_args.append("--use-clang")
         if args.check:
             passthrough_args.append("--check")
+        if no_unity:
+            passthrough_args.append("--no-unity")
         # Note: --gcc is handled by not passing --use-clang (GCC is the default in compiler/cpp_test_compile.py)
         compile_tests(
             clean=args.clean,

--- a/ci/compiler/test_compiler.py
+++ b/ci/compiler/test_compiler.py
@@ -113,12 +113,14 @@ class FastLEDTestCompiler:
         project_root: Path,
         quick_build: bool = False,
         strict_mode: bool = False,
+        no_unity: bool = False,
     ):
         self.compiler = compiler
         self.build_dir = build_dir
         self.project_root = project_root
         self.quick_build = quick_build
         self.strict_mode = strict_mode
+        self.no_unity = no_unity
         self.compiled_tests: List[TestExecutable] = []
         self.linking_failures: List[str] = []
         self.build_flags = self._load_build_flags()
@@ -138,6 +140,7 @@ class FastLEDTestCompiler:
         specific_test: str | None = None,
         quick_build: bool = False,
         strict_mode: bool = False,
+        no_unity: bool = False,
     ) -> "FastLEDTestCompiler":
         """
         Create compiler configured for FastLED unit tests using TOML build flags.
@@ -271,7 +274,7 @@ class FastLEDTestCompiler:
         compiler = Compiler(settings)
 
         # Create final instance with proper compiler and flags
-        instance = cls(compiler, build_dir, project_root, quick_build, strict_mode)
+        instance = cls(compiler, build_dir, project_root, quick_build, strict_mode, no_unity)
         return instance
 
     def discover_test_files(self, specific_test: str | None = None) -> List[Path]:
@@ -338,8 +341,11 @@ class FastLEDTestCompiler:
 
         # Always show build configuration in unit test mode
         print("\nFastLED Library Build Configuration:")
-        print("  ✅ Unity build enabled - Using glob pattern:")
-        print("    src/**/*.cpp")
+        if self.no_unity:
+            print("  ❌ Unity build disabled - Compiling individual source files")
+        else:
+            print("  ✅ Unity build enabled - Using glob pattern:")
+            print("    src/**/*.cpp")
 
         print("\nPrecompiled header status:")
         if self.compiler.settings.use_pch:
@@ -698,9 +704,14 @@ class FastLEDTestCompiler:
             # Include ALL files - no filtering needed
             fastled_sources.append(Path(cpp_file))
 
-        print(
-            f"Unity build mode: Found {len(fastled_sources)} FastLED .cpp files for compilation"
-        )
+        if self.no_unity:
+            print(
+                f"Individual compilation: Found {len(fastled_sources)} FastLED .cpp files for compilation"
+            )
+        else:
+            print(
+                f"Unity build mode: Found {len(fastled_sources)} FastLED .cpp files for compilation"
+            )
 
         # Compile all FastLED source files to object files
         fastled_objects: List[Path] = []


### PR DESCRIPTION
Ensure the `--no-unity` flag correctly disables the FastLED library unity build during testing.

Previously, the `--no-unity` flag was parsed but not propagated through the test command execution chain to the compiler, and the output message regarding unity build was hardcoded. This PR fixes the argument passing and makes the compiler output reflect the actual unity build status.

---
<a href="https://cursor.com/background-agent?bcId=bc-c4435c33-da0a-40a4-9880-673cd9f78b53">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c4435c33-da0a-40a4-9880-673cd9f78b53">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>