### PR TITLE
Run tests sequentially

### DIFF
--- a/ci/ci/test_runner.py
+++ b/ci/ci/test_runner.py
@@ -886,8 +886,12 @@ def runner(args: TestArgs, src_code_change: bool = True) -> None:
     if test_categories.examples or test_categories.examples_only:
         processes.append(create_examples_test_process(args, enable_stack_trace))
 
+    # Determine if we'll run in parallel
+    will_run_parallel = not bool(os.environ.get("NO_PARALLEL"))
+    
     # Print summary of what we're about to run
-    print(f"\nStarting {len(processes)} test processes in parallel:")
+    execution_mode = "in parallel" if will_run_parallel else "sequentially"
+    print(f"\nStarting {len(processes)} test processes {execution_mode}:")
     for proc in processes:
         print(f"  - {proc.command}")
     print()
@@ -895,6 +899,6 @@ def runner(args: TestArgs, src_code_change: bool = True) -> None:
     # Run processes (parallel unless NO_PARALLEL is set)
     run_test_processes(
         processes,
-        parallel=not bool(os.environ.get("NO_PARALLEL")),
+        parallel=will_run_parallel,
         verbose=args.verbose,
     )


### PR DESCRIPTION
Corrects the output message for `bash test --no-parallel` to accurately reflect sequential execution.

Previously, the `bash test` script would print "Starting X test processes in parallel" even when the `--no-parallel` flag was used and sequential execution was enforced, leading to user confusion. This change ensures the printed message matches the actual execution mode.

---
<a href="https://cursor.com/background-agent?bcId=bc-f2da046e-4bfa-49ad-a00c-3323ef4f47ed">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f2da046e-4bfa-49ad-a00c-3323ef4f47ed">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>