### PR TITLE
Fix case insensitive json test matching

### DIFF
--- a/ci/compiler/cpp_test_run.py
+++ b/ci/compiler/cpp_test_run.py
@@ -497,20 +497,20 @@ def _run_tests_cmake(
         if sys.platform == "win32":
             test_name += ".exe"
 
-        # Modified to support partial matching
+        # Modified to support partial matching (case-insensitive)
         matching_files = []
         for f in files:
-            # Check for exact match
-            if f == test_name:
+            # Check for exact match (case-insensitive)
+            if f.lower() == test_name.lower():
                 matching_files.append(f)
                 break
 
-            # Check for partial match in the filename
-            base_name = f.replace("test_", "")
+            # Check for partial match in the filename (case-insensitive)
+            base_name = f.replace("test_", "").replace(".cpp", "")
             if sys.platform == "win32":
                 base_name = base_name.replace(".exe", "")
 
-            if specific_test in base_name:
+            if specific_test.lower() in base_name.lower():
                 matching_files.append(f)
 
         if matching_files:

--- a/ci/compiler/test_compiler.py
+++ b/ci/compiler/test_compiler.py
@@ -307,11 +307,11 @@ class FastLEDTestCompiler:
                     if re.search(pattern, test_stem) or re.search(pattern, test_name):
                         test_files.append(test_file)
                 else:
-                    # Exact matching - either the full name or with test_ prefix
+                    # Exact matching - either the full name or with test_ prefix (case-insensitive)
                     if (
-                        test_stem == specific_test
-                        or test_stem == f"test_{specific_test}"
-                        or test_name == specific_test
+                        test_stem.lower() == specific_test.lower()
+                        or test_stem.lower() == f"test_{specific_test}".lower()
+                        or test_name.lower() == specific_test.lower()
                     ):
                         test_files.append(test_file)
             else:
@@ -839,14 +839,14 @@ class FastLEDTestCompiler:
                     or re.search(pattern, f"test_{t.name}")
                 ]
             else:
-                # Exact matching - either the full name or with test_ prefix
+                # Exact matching - either the full name or with test_ prefix (case-insensitive)
                 return [
                     t
                     for t in self.compiled_tests
                     if (
-                        t.name == specific_test
-                        or t.name == f"test_{specific_test}"
-                        or t.name == specific_test.replace("test_", "")
+                        t.name.lower() == specific_test.lower()
+                        or t.name.lower() == f"test_{specific_test}".lower()
+                        or t.name.lower() == specific_test.replace("test_", "").lower()
                     )
                 ]
         return self.compiled_tests


### PR DESCRIPTION
Implement case-insensitive test name matching to improve test discovery robustness.

Previously, specifying a test name with incorrect casing (e.g., `Json` instead of `json`) would result in a 'No test found' error. This PR updates the test discovery logic in both the legacy CMake and new Python API build systems to perform case-insensitive comparisons, ensuring tests are found regardless of casing.

---
<a href="https://cursor.com/background-agent?bcId=bc-264b71e2-7655-45cb-a3ac-014f3b3393fd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-264b71e2-7655-45cb-a3ac-014f3b3393fd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>