### PR TITLE
Fix unused parameter warnings

### DIFF
--- a/examples/Downscale/src/wave.h
+++ b/examples/Downscale/src/wave.h
@@ -22,7 +22,7 @@ struct WaveEffect {
 
 struct DrawRasterToWaveSimulator {
     DrawRasterToWaveSimulator(WaveEffect* wave_fx) : mWaveFx(wave_fx) {}
-    void draw(const vec2<int16_t> &pt, uint32_t index, uint8_t value) {
+    void draw(const vec2<int16_t> &pt, uint32_t /*index*/, uint8_t value) {
         float valuef = value / 255.0f;
         int xx = pt.x;
         int yy = pt.y;

--- a/examples/XYPath/src/wave.h
+++ b/examples/XYPath/src/wave.h
@@ -22,7 +22,7 @@ struct WaveEffect {
 
 struct DrawRasterToWaveSimulator {
     DrawRasterToWaveSimulator(WaveEffect* wave_fx) : mWaveFx(wave_fx) {}
-    void draw(const vec2<int> &pt, uint32_t index, uint8_t value) {
+    void draw(const vec2<int> &pt, uint32_t /*index*/, uint8_t value) {
         float valuef = value / 255.0f;
         int xx = pt.x;
         int yy = pt.y;


### PR DESCRIPTION
Fix unused parameter warnings in `DrawRasterToWaveSimulator::draw` methods.

The `index` parameter is part of an interface required by a visitor pattern, but it is not utilized by this specific implementation. Commenting out the parameter name `/*index*/` suppresses the `-Wunused-parameter` warning while maintaining the necessary method signature.

---
<a href="https://cursor.com/background-agent?bcId=bc-5548951f-17de-4cdc-bb9a-e0ee32c03f1f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5548951f-17de-4cdc-bb9a-e0ee32c03f1f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>