### PR TITLE
Verify missing compiler for pch creation

### DIFF
--- a/ci/compiler/clang_compiler.py
+++ b/ci/compiler/clang_compiler.py
@@ -587,7 +587,7 @@ class Compiler:
 
             # Build PCH compilation command using TOML configuration
             # Use compiler_args from TOML without any filtering or hardcoding
-            cmd: list[str] = self.settings.compiler_args.copy()
+            cmd: list[str] = optimize_python_command(self.settings.compiler_args.copy())
 
             # Add PCH-specific flags (don't override std version - use what's in TOML)
             cmd.extend(


### PR DESCRIPTION
Apply `optimize_python_command` to PCH creation to correctly resolve the Python executable.

PCH creation was failing because the `compiler_args` from the TOML configuration specified `python` as the executable, but `python` was not available in the PATH (only `python3` was). The existing `optimize_python_command` function handles this by replacing `python` with `sys.executable`, but it was not being applied to the PCH compilation command. This fix ensures the correct Python executable is used, resolving the "missing compiler executable" error.

---
<a href="https://cursor.com/background-agent?bcId=bc-3db36062-3770-4c3b-a314-418c163db4d9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3db36062-3770-4c3b-a314-418c163db4d9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>