### PR TITLE
Remove deprecated compiler and archiver flags

### DIFF
--- a/ci/build_flags.toml
+++ b/ci/build_flags.toml
@@ -9,13 +9,12 @@
 # Build tool configuration - Full compiler command with arguments
 # Optimized: Use direct python instead of 'uv run' when already in uv environment
 compiler_command = ["python", "-m", "ziglang", "c++"]
-compiler = "ziglang"  # For compatibility
-archiver = "ar"
-c_compiler = "clang"
-objcopy = "objcopy"
-nm = "nm"
-strip = "strip"
-ranlib = "ranlib"
+c_compiler_command = ["python", "-m", "ziglang", "cc"]
+archiver_command = ["python", "-m", "ziglang", "ar"]
+objcopy_command = ["objcopy"]
+nm_command = ["nm"]
+strip_command = ["strip"]
+ranlib_command = ["ranlib"]
 
 [all]
 # Universal compilation flags (compiler command handled separately)


### PR DESCRIPTION
Modernize `ci/build_flags.toml` by removing deprecated single-string tool names and adopting the `_command` array format.

---
<a href="https://cursor.com/background-agent?bcId=bc-b1f8be4a-c607-44c1-b705-e606c21eec74">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b1f8be4a-c607-44c1-b705-e606c21eec74">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>