### PR TITLE
Add runtime summary to test execution

### DIFF
--- a/test.py
+++ b/test.py
@@ -198,6 +198,26 @@ def main() -> None:
             if examples_return_code != 0:
                 sys.exit(examples_return_code)
 
+            # Display timing summary for sequential execution
+            from ci.util.test_runner import ProcessTiming, _format_timing_summary, _get_friendly_test_name
+            timings = []
+            if python_process.duration is not None:
+                timings.append(ProcessTiming(
+                    name=_get_friendly_test_name(python_process.command),
+                    duration=python_process.duration,
+                    command=str(python_process.command)
+                ))
+            if examples_process.duration is not None:
+                timings.append(ProcessTiming(
+                    name=_get_friendly_test_name(examples_process.command),
+                    duration=examples_process.duration,
+                    command=str(examples_process.command)
+                ))
+            
+            if timings:
+                summary = _format_timing_summary(timings)
+                print(summary)
+
             print("Sequential test execution completed successfully")
         else:
             # Use normal test runner for other cases


### PR DESCRIPTION
Add a summary table displaying the runtime of each subtest to the test runner output.

The existing test runner executes various types of tests (Python, C++, examples) in parallel or sequentially without a unified mechanism to report individual test durations. This change introduces per-process timing and a formatted summary table, enabling developers to quickly identify long-running subtests.

---
<a href="https://cursor.com/background-agent?bcId=bc-12c6d3aa-8eed-4ec9-b24b-71cf4c419d27">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-12c6d3aa-8eed-4ec9-b24b-71cf4c419d27">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>