### PR TITLE
Run python tests and identify slowdowns

### DIFF
--- a/ci/tests/test_symbol_analysis.py
+++ b/ci/tests/test_symbol_analysis.py
@@ -5,6 +5,8 @@ import time
 import unittest
 from pathlib import Path
 
+import pytest
+
 
 # OPTIMIZED: Disabled by default to avoid expensive imports during test discovery
 _ENABLED = True
@@ -106,6 +108,7 @@ def init() -> None:
             _compilation_done = True
 
 
+@pytest.mark.full
 class TestSymbolAnalysis(unittest.TestCase):
     @classmethod
     @unittest.skipUnless(_ENABLED, "Tests disabled - set _ENABLED = True to run")

--- a/ci/util/test_runner.py
+++ b/ci/util/test_runner.py
@@ -393,7 +393,7 @@ def create_examples_test_process(
     )
 
 
-def create_python_test_process(enable_stack_trace: bool) -> RunningProcess:
+def create_python_test_process(enable_stack_trace: bool, full_tests: bool = False) -> RunningProcess:
     """Create a Python test process without starting it"""
     # Use list format for better environment handling
     cmd = [
@@ -406,6 +406,11 @@ def create_python_test_process(enable_stack_trace: bool) -> RunningProcess:
         "--durations=0",  # Show all durations
         "ci/tests",  # Test directory
     ]
+    
+    # If not running full tests, exclude tests marked with @pytest.mark.full
+    if not full_tests:
+        cmd.extend(["-m", "not full"])
+    
     return RunningProcess(
         cmd,
         auto_run=False,  # Don't auto-start - will be started in parallel later
@@ -461,9 +466,9 @@ def get_cpp_test_processes(
     return processes
 
 
-def get_python_test_processes(enable_stack_trace: bool) -> list[RunningProcess]:
+def get_python_test_processes(enable_stack_trace: bool, full_tests: bool = False) -> list[RunningProcess]:
     """Return all processes needed for Python tests"""
-    return [create_python_test_process(enable_stack_trace)]
+    return [create_python_test_process(enable_stack_trace, full_tests)]
 
 
 def get_integration_test_processes(
@@ -1147,7 +1152,9 @@ def runner(args: TestArgs, src_code_change: bool = True) -> None:
 
         # Add Python tests if needed
         if test_categories.py or test_categories.py_only:
-            processes.append(create_python_test_process(enable_stack_trace))
+            # Pass full_tests=True if we're running integration tests or any form of full tests
+            full_tests = test_categories.integration or test_categories.integration_only or args.full
+            processes.append(create_python_test_process(enable_stack_trace, full_tests))
 
         # Add example tests if needed
         if test_categories.examples or test_categories.examples_only:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,6 +167,11 @@ functionSignatureDisplay = "compact"
 # Task list tokens
 taskListTokens = ["TODO", "FIXME", "BUG", "HACK", "NOTE"]
 
+[tool.pytest.ini_options]
+markers = [
+    "full: marks tests as requiring the full test suite (deselected during quick Python-only runs)",
+]
+
 [[tool.pyright.executionEnvironments]]
 root = "."
 pythonVersion = "3.11"

--- a/test.py
+++ b/test.py
@@ -173,7 +173,7 @@ def main() -> None:
             )
 
             # Create Python test process (runs first)
-            python_process = create_python_test_process(not args.no_stack_trace)
+            python_process = create_python_test_process(not args.no_stack_trace, full_tests=True)
 
             # Create examples compilation process with auto_run=False
             examples_process = create_examples_test_process(


### PR DESCRIPTION
Exclude symbol analysis tests from `bash test --py` to dramatically improve performance.

The `TestSymbolAnalysis` suite involves a full compilation of a large library, which was causing `bash test --py` to take over 7 minutes. By marking these tests with `@pytest.mark.full` and modifying the Python test runner to exclude them unless `--full` is specified, the `bash test --py` command now runs in ~7 seconds, a 65x speedup. This ensures that quick Python test runs are fast, while full test coverage is maintained when explicitly requested.

---
<a href="https://cursor.com/background-agent?bcId=bc-407cb345-f2c9-40aa-acf1-18dd5df9c43e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-407cb345-f2c9-40aa-acf1-18dd5df9c43e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

