### PR TITLE
Debug esp8266 progmem alignment issues

### DIFF
--- a/src/fl/colorutils_misc.h
+++ b/src/fl/colorutils_misc.h
@@ -2,18 +2,19 @@
 
 #include "fl/stdint.h"
 #include "fl/int.h"
+#include "fastled_progmem.h"  // For FL_ALIGN_PROGMEM
 
 // TODO: Figure out how to namespace these.
-typedef fl::u32 TProgmemRGBPalette16[16]; ///< CRGBPalette16 entries stored in
-                                           ///< PROGMEM memory
-typedef fl::u32 TProgmemHSVPalette16[16]; ///< CHSVPalette16 entries stored in
-                                           ///< PROGMEM memory
+typedef fl::u32 TProgmemRGBPalette16[16] FL_ALIGN_PROGMEM; ///< CRGBPalette16 entries stored in
+///< PROGMEM memory with proper alignment for DWORD reads
+typedef fl::u32 TProgmemHSVPalette16[16] FL_ALIGN_PROGMEM; ///< CHSVPalette16 entries stored in
+///< PROGMEM memory with proper alignment for DWORD reads
 /// Alias for TProgmemRGBPalette16
 #define TProgmemPalette16 TProgmemRGBPalette16
-typedef fl::u32 TProgmemRGBPalette32[32]; ///< CRGBPalette32 entries stored in
-                                           ///< PROGMEM memory
-typedef fl::u32 TProgmemHSVPalette32[32]; ///< CHSVPalette32 entries stored in
-                                           ///< PROGMEM memory
+typedef fl::u32 TProgmemRGBPalette32[32] FL_ALIGN_PROGMEM; ///< CRGBPalette32 entries stored in
+///< PROGMEM memory with proper alignment for DWORD reads
+typedef fl::u32 TProgmemHSVPalette32[32] FL_ALIGN_PROGMEM; ///< CHSVPalette32 entries stored in
+///< PROGMEM memory with proper alignment for DWORD reads
 /// Alias for TProgmemRGBPalette32
 #define TProgmemPalette32 TProgmemRGBPalette32
 

--- a/src/platforms/esp/8266/led_sysdefs_esp8266.h
+++ b/src/platforms/esp/8266/led_sysdefs_esp8266.h
@@ -16,7 +16,14 @@ typedef volatile uint32_t RwReg;
 typedef uint32_t prog_uint32_t;
 
 
-// Default to NOT using PROGMEM here
+// ESP8266 PROGMEM Support:
+// PROGMEM is disabled by default due to alignment issues with DWORD reads.
+// The ESP8266 requires 4-byte alignment for 32-bit progmem reads, but the
+// TProgmemRGBPalette16 arrays were not properly aligned, causing crashes.
+// 
+// This has been fixed by adding FL_ALIGN_PROGMEM to the palette typedefs
+// in fl/colorutils_misc.h. PROGMEM can now be enabled if needed, but is
+// kept disabled for backwards compatibility and safety.
 #ifndef FASTLED_USE_PROGMEM
 # define FASTLED_USE_PROGMEM 0
 #endif


### PR DESCRIPTION
Adds `FL_ALIGN_PROGMEM` to palette typedefs to fix unaligned PROGMEM DWORD reads on ESP8266.

Previously, `FASTLED_USE_PROGMEM` was set to `0` by default for ESP8266 due to runtime crashes caused by unaligned 32-bit (DWORD) reads from PROGMEM. The ESP8266 architecture requires 4-byte alignment for such reads, which the `TProgmemRGBPalette16` and similar structures lacked. This PR ensures these structures are properly aligned, resolving the underlying issue and allowing PROGMEM to be safely enabled if desired, though it remains disabled by default for backward compatibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-f964373d-75e1-4103-9f01-c7b98d32abb9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f964373d-75e1-4103-9f01-c7b98d32abb9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

