### PR TITLE
Verify linux stack trace functionality

### DIFF
--- a/ci/build_unit.toml
+++ b/ci/build_unit.toml
@@ -103,14 +103,11 @@ flags = [
 ]
 
 [linux]
-# Linux-specific build configuration for libunwind
+# Linux-specific build configuration – libunwind disabled (fallback to execinfo)
 link_flags = [
-    "-lunwind",                           # Link libunwind for stack traces
-    "-lunwind-x86_64",                    # Platform-specific libunwind functions
 ]
 
 defines = [
-    "USE_LIBUNWIND",                      # Enable libunwind crash handler
 ]
 
 [build_modes.quick]
@@ -178,7 +175,6 @@ defines = [
     "-DFASTLED_DEBUG_LEVEL=1",                  # Set debug level
     "-DFASTLED_NO_ATEXIT=1",                    # Disable atexit to fix Windows lld-link errors
     "-DDOCTEST_CONFIG_NO_EXCEPTIONS_BUT_WITH_ALL_ASSERTS", # Doctest configuration
-    "-DUSE_LIBUNWIND",                          # Enable libunwind crash handler
     "-DENABLE_CRASH_HANDLER",                   # Enable global crash handler in tests
 ]
 

--- a/ci/compiler/cpp_test_compile.py
+++ b/ci/compiler/cpp_test_compile.py
@@ -390,7 +390,6 @@ def create_unit_test_compiler(
         "FASTLED_NO_ATEXIT=1",
         "DOCTEST_CONFIG_NO_EXCEPTIONS_BUT_WITH_ALL_ASSERTS",
         "ENABLE_CRASH_HANDLER",
-        "USE_LIBUNWIND",
         "RELEASE=1",  # Disable FASTLED_FORCE_DBG to avoid fl::println dependency
     ]
 
@@ -665,7 +664,7 @@ def compile_unit_tests_python_api(
             if os.name == "nt":  # Windows
                 linker_args = ["-ldbghelp", "-lpsapi"]
             else:  # Linux/macOS
-                linker_args = ["-pthread", "-lunwind"]
+                linker_args = ["-pthread"]
 
             # HASH-BASED CACHE CHECK (same as examples)
             if not fastled_lib_path:

--- a/tests/test_math.cpp
+++ b/tests/test_math.cpp
@@ -266,3 +266,9 @@ TEST_CASE("fl_min and fl_max type promotion") {
         CHECK_EQ(float_result, 750.5f);
     }
 }
+
+TEST_CASE("intentional crash - stack trace probe") {
+    // Force a crash to verify stack trace symbolization on Linux
+    volatile int* ptr = nullptr;
+    *ptr = 123;  // Intentional null dereference
+}


### PR DESCRIPTION
Add an intentional crash test and temporarily disable libunwind to verify stack trace generation on Linux.

The libunwind setup was causing linker errors, preventing any stack trace from being generated. These changes temporarily disable libunwind, allowing the system to fall back to `execinfo` and produce a basic stack trace for diagnostic purposes.

---
<a href="https://cursor.com/background-agent?bcId=bc-719ad338-27b1-4975-803e-8d3572dd1f35">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-719ad338-27b1-4975-803e-8d3572dd1f35">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

