### PR TITLE
Fix python emoticon crashes in cmd.exe

### DIFF
--- a/clean
+++ b/clean
@@ -1,4 +1,19 @@
 #!/bin/bash
+# Ensure UTF-8 everywhere (console and Python), including on Windows msys/cygwin
+case "$OSTYPE" in
+  msys*|cygwin*)
+    if command -v chcp.com >/dev/null 2>&1; then
+      chcp.com 65001 >NUL 2>NUL || chcp.com 65001 >/dev/null 2>&1
+    fi
+    ;;
+  *)
+    :
+    ;;
+esac
+export LANG=C.UTF-8
+export LC_ALL=C.UTF-8
+export PYTHONUTF8=1
+export PYTHONIOENCODING=UTF-8
 
 set -x
 

--- a/install
+++ b/install
@@ -1,4 +1,21 @@
 #!/bin/bash
+# Ensure UTF-8 everywhere (console and Python), including on Windows msys/cygwin
+case "$OSTYPE" in
+  msys*|cygwin*)
+    if command -v chcp.com >/dev/null 2>&1; then
+      # Attempt to switch Windows code page to UTF-8 (65001)
+      chcp.com 65001 >NUL 2>NUL || chcp.com 65001 >/dev/null 2>&1
+    fi
+    ;;
+  *)
+    :
+    ;;
+esac
+export LANG=C.UTF-8
+export LC_ALL=C.UTF-8
+export PYTHONUTF8=1
+export PYTHONIOENCODING=UTF-8
+
 set -ex
 uv venv --python 3.11
 uv pip install -e . --refresh-package fastled


### PR DESCRIPTION
Force UTF-8 encoding in `install` and `clean` scripts to prevent emoticon-related crashes on Windows `cmd.exe`.

---
<a href="https://cursor.com/background-agent?bcId=bc-d4ac001f-1d06-4d95-81ca-51aecca48776">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d4ac001f-1d06-4d95-81ca-51aecca48776">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

