### PR TITLE
Investigate macos arm crash

### DIFF
--- a/src/fl/shared_ptr.h
+++ b/src/fl/shared_ptr.h
@@ -167,8 +167,8 @@ public:
     // Converting move constructor
     template<typename Y>
     shared_ptr(shared_ptr<Y>&& other) noexcept : ptr_(other.ptr_), control_block_(other.control_block_) {
-        this->swap(other);
-        other.reset();
+        other.ptr_ = nullptr;
+        other.control_block_ = nullptr;
     }
     
     // Constructor from weak_ptr


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fix `fl::shared_ptr` converting move constructor to prevent use-after-free on macOS arm64.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The previous implementation of the converting move constructor `shared_ptr(shared_ptr<Y>&& other)` used `this->swap(other); other.reset();`. This could lead to the control block, now owned by `this`, being prematurely freed when `other.reset()` was called on the temporary `other` object. This was observed as an EXC_BAD_ACCESS crash on macOS arm64 when large lambdas, which use heap-allocated `shared_ptr` storage, were moved. The fix changes the constructor to simply steal the pointers and null out the source, preventing the premature deletion.

---
<a href="https://cursor.com/background-agent?bcId=bc-10f15725-0f52-4229-882a-27bd3df1d015">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-10f15725-0f52-4229-882a-27bd3df1d015">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

