### PR TITLE
Document FastLED fx library and subfolders

### DIFF
--- a/src/fx/1d/README.md
+++ b/src/fx/1d/README.md
@@ -1,0 +1,32 @@
+# FastLED FX: 1D Effects
+
+This folder contains one-dimensional (strip) visual effects. All effects derive from `fl::Fx1d` and render into a linear `CRGB* leds` buffer using a common `DrawContext`.
+
+If you’re new to FastLED and C++: think of an effect as a small object you construct once and then call `draw(...)` every frame with the current time and your LED buffer.
+
+### What’s here
+- **Cylon (`cylon.h`)**: A single dot sweeps back and forth (Larson scanner). Tunable `fade_amount`, `delay_ms`.
+- **DemoReel100 (`demoreel100.h`)**: Classic demo with rotating patterns (rainbow, glitter, confetti, sinelon, bpm, juggle). Auto-advances every ~10 seconds.
+- **Fire2012 (`fire2012.h`)**: Procedural fire simulation with parameters `cooling` and `sparking`, optional reverse direction and palette.
+- **NoiseWave (`noisewave.h`)**: Smooth noise-driven red/blue waves across the strip.
+- **Pacifica (`pacifica.h`)**: Gentle blue-green ocean waves layered for depth.
+- **Pride2015 (`pride2015.h`)**: Ever-changing rainbow animation.
+- **TwinkleFox (`twinklefox.h`)**: Twinkling holiday-style lights using palettes; compile-time knobs for speed/density and incandescent-style cooling.
+
+### Common usage
+- Include the header for the effect you want and construct it with the LED count (e.g., `fl::Cylon fx(num_leds);`).
+- Each frame (e.g., in your loop), call `fx.draw(fl::Fx::DrawContext(now, leds));`.
+- Most effects expose small parameters via constructor (e.g., `Fire2012(num_leds, cooling, sparking)`), or have internal timing based on `now` from `DrawContext`.
+
+### Notes and tips
+- Effects guard against `nullptr` and zero length, but you should pass a valid `CRGB*` and correct `num_leds` to see output.
+- Try different frame rates. Many patterns look good at ~50–100 FPS, but 30 FPS is fine for most.
+- For palette-based effects (e.g., TwinkleFox, Pride2015, DemoReel’s BPM), experiment with `CRGBPalette16` to customize colors.
+- These 1D effects are lightweight to medium-weight. They depend on FastLED helpers such as `CHSV`, `beatsin*`, `nblend`, palettes, and random noise.
+
+### Key types referenced
+- **`fl::Fx1d`**: Base class for 1D effects. Holds `mNumLeds` and provides the `draw(DrawContext)` interface.
+- **`fl::Fx::DrawContext`**: Carries `now` (time in ms), `CRGB* leds`, and optional per-frame hints.
+- **`CRGB` / `CHSV`**: FastLED’s color types.
+
+Explore the headers to see per-effect parameters and internal logic; everything here is self-contained and ready to drop into your render loop.

--- a/src/fx/2d/README.md
+++ b/src/fx/2d/README.md
@@ -1,0 +1,36 @@
+# FastLED FX: 2D Effects
+
+This folder contains two-dimensional (matrix/panel) effects that derive from `fl::Fx2d`. 2D effects require an `XYMap` that translates a logical `(x, y)` coordinate into a linear LED index in your `CRGB*` buffer.
+
+If you’re new: construct the effect with your `XYMap` and call `draw(...)` each frame. The effect fills your LED buffer according to its internal animation.
+
+### What’s here
+- **RedSquare (`redsquare.h`)**: Simple centered red square demo. Good as a sanity check for your `XYMap` wiring.
+- **NoisePalette (`noisepalette.h`)**: 2D noise field mapped through color palettes. Includes helpers to randomize/select palettes and an optional fixed FPS hint.
+- **WaveFx (`wave.h`)**: 2D wave simulation with configurable speed, dampening, supersampling, cylindrical wrapping, and color mapping via:
+  - `WaveCrgbMapDefault`: grayscale by wave amplitude.
+  - `WaveCrgbGradientMap`: map amplitude to a `CRGBPalette16` gradient.
+- **ScaleUp (`scale_up.h`)**: Wrap another `Fx2d` and up-scale its output using bilinear interpolation. Useful when your MCU can’t render full resolution in real time.
+- **Blend2d (`blend.h`)**: Compose multiple `Fx2d` layers. Bottom layer draws at full strength; upper layers blend with optional blur passes.
+- **Animartrix (`animartrix.hpp`, `animartrix_detail.hpp`)**: Integration of Stefen Petrick’s ANIMartRIX library providing many parameterized 2D animations. See Licensing below.
+
+### Common usage
+- Provide an `fl::XYMap` that matches your panel/strip weaving, then construct effects like `fl::NoisePalette mapFx(xyMap);`, `fl::WaveFx waves(xyMap);`, etc.
+- Call `fx.draw(fl::Fx::DrawContext(now, leds));` each frame. Some effects (e.g., `NoisePalette`) advertise a fixed FPS via `hasFixedFrameRate` to help you pace the main loop.
+- For `Blend2d`, create it with your `XYMap`, add `Fx2d` layers, optionally set per-layer blur, then call `draw(...)` on the blender.
+- For `ScaleUp`, pass a low-res delegate `Fx2d`; it will render internally and upscale to your target resolution.
+
+### Parameters to try
+- WaveFx: `setSpeed`, `setDampening`, `setHalfDuplex`, `setSuperSample`, `setXCylindrical`, and switch CRGB mapping with `setCrgbMap(...)`.
+- NoisePalette: `setPalette`, `setSpeed`, `setScale`, or `setPalettePreset(...)` to quickly swap among curated looks.
+- Blend2d: `setGlobalBlurAmount`, `setGlobalBlurPasses`, or per-layer `Params` on `add(...)` / `setParams(...)`.
+
+### Licensing note (Animartrix)
+Animartrix is free for non‑commercial use and requires a paid license otherwise. See the top-level `src/fx/readme` and `animartrix_detail.hpp` header comments.
+
+### Key types referenced
+- **`fl::Fx2d`**: Base for 2D effects, wraps an `XYMap` and provides `draw(DrawContext)`.
+- **`fl::XYMap`**: Maps `(x, y)` to LED indices; can be rectangular or custom.
+- **`CRGBPalette16`**: 16‑entry FastLED palette used by several mappers/effects.
+
+These effects are designed for more capable MCUs, but many run well on modern 8‑bit boards at modest sizes. Start with `RedSquare` to validate mapping, then try `NoisePalette` and `WaveFx` for richer motion.

--- a/src/fx/README.md
+++ b/src/fx/README.md
@@ -1,0 +1,53 @@
+# FastLED FX Library (`src/fx`)
+
+The FX library adds optional, higher‑level visual effects and a small runtime around FastLED. It includes ready‑to‑use animations for strips (1D) and matrices (2D), utilities to layer/up‑scale/blend effects, and a simple video playback pipeline.
+
+If you’re new to FastLED and C++: an effect is an object that you construct once and call `draw(...)` on every frame, passing time and your LED buffer. Start with the 1D/2D examples, then explore composition and video as needed.
+
+### What’s included
+- [`1d/`](./1d/README.md): Strip effects like Cylon, DemoReel100, Fire2012, NoiseWave, Pacifica, Pride2015, and TwinkleFox.
+- [`2d/`](./2d/README.md): Matrix effects including NoisePalette, WaveFx, ScaleUp, Blend2d, RedSquare, and Animartrix integrations.
+- [`video/`](./video/README.md): Read frames from files/streams, buffer, and interpolate for smooth playback on your LEDs.
+- [`detail/`](./detail/README.md): Internal helpers for draw context, layering, transitions, and compositing.
+
+### Core concepts and types
+- **Base classes**:
+  - `fl::Fx`: abstract base with a single method to implement: `void draw(DrawContext ctx)`.
+  - `fl::Fx1d`: base for strip effects; holds LED count and (optionally) an `XMap`.
+  - `fl::Fx2d`: base for matrix effects; holds an `XYMap` to convert `(x,y)` to LED indices.
+- **DrawContext**: `Fx::DrawContext` carries per‑frame data: `now` (ms), `CRGB* leds`, optional `frame_time`, and a `speed` hint.
+- **Palettes and helpers**: Many effects use FastLED’s `CRGB`, `CHSV`, `CRGBPalette16`, and timing helpers like `beatsin*`.
+
+### Basic usage (1D example)
+```cpp
+#include "fx/1d/cylon.h"
+
+fl::Cylon fx(num_leds);
+...
+fx.draw(fl::Fx::DrawContext(millis(), leds));
+```
+
+### Basic usage (2D example)
+```cpp
+#include "fx/2d/noisepalette.h"
+
+fl::XYMap xy(width, height, /* your mapper */);
+fl::NoisePalette fx(xy);
+...
+fx.draw(fl::Fx::DrawContext(millis(), leds));
+```
+
+### Composition and transitions
+- Use `Blend2d` to stack multiple 2D effects and blur/blend them.
+- The `detail/` components (`FxLayer`, `FxCompositor`, `Transition`) support cross‑fading between effects over time.
+
+### Video playback
+- The `video/` pipeline reads frames from a `FileHandle` or `ByteStream`, keeps a small buffer, and interpolates between frames to match your output rate.
+
+### Performance and targets
+- FX components may use more memory/CPU than the FastLED core. They are designed for more capable MCUs (e.g., ESP32/Teensy/RP2040), but many examples will still run on modest hardware at smaller sizes.
+
+### Licensing
+- Most code follows the standard FastLED license. Animartrix is free for non‑commercial use and paid otherwise. See [`src/fx/readme`](./readme) and headers for details.
+
+Explore each subfolder’s README to find the effect you want, then copy the corresponding header into your project and call `draw(...)` every frame.

--- a/src/fx/detail/README.md
+++ b/src/fx/detail/README.md
@@ -1,0 +1,15 @@
+# FastLED FX: Internal Helpers (`detail/`)
+
+This folder contains utilities used by the FX engine. Most apps won’t include these directly; they’re pulled in by higher‑level classes.
+
+### Components
+- **`draw_context.h`**: Defines `fl::_DrawContext` (commonly referred to via `Fx::DrawContext`), which carries per‑frame data into effects: `now` (ms), `CRGB* leds`, `frame_time`, and a `speed` hint.
+- **`fx_layer.h`**: Wraps an `Fx` and a `Frame` surface. Manages start/pause/draw and exposes the surface for compositing.
+- **`fx_compositor.h`**: Cross‑fades between two `FxLayer`s over time using `Transition`. Produces a final buffer by blending surfaces each frame; automatically completes when progress reaches 100%.
+- **`transition.h`**: Tracks a time‑based 0–255 progress value between a start time and duration. Used by the compositor to animate transitions.
+
+### When you’ll encounter these
+- If you use an FX engine/controller that switches effects with fades.
+- If you build your own multi‑effect player, you may interact with `FxLayer` and `FxCompositor` directly.
+
+These pieces are small and dependency‑light, but they’re part of the internal plumbing for higher‑level modules.

--- a/src/fx/video/README.md
+++ b/src/fx/video/README.md
@@ -1,0 +1,25 @@
+# FastLED FX: Video Subsystem
+
+This folder implements a simple video playback pipeline for LED arrays. It reads frames from a file or stream, buffers them, and interpolates between them to produce smooth animation at your desired output rate.
+
+### Building blocks
+- **`PixelStream` (`pixel_stream.h`)**: Reads pixel data as bytes from either a file (`FileHandle`) or a live `ByteStream`. Knows the `bytesPerFrame`, can read by pixel, by frame, or at an absolute frame number. Reports availability and end-of-stream.
+- **`FrameTracker` (`frame_tracker.h`)**: Converts wall‑clock time to frame numbers (current and next) at a fixed FPS. Also exposes exact timestamps and frame interval in microseconds.
+- **`FrameInterpolator` (`frame_interpolator.h`)**: Holds a small history of frames and, given the current time, blends the nearest two frames to produce an in‑between result. Supports non‑monotonic time (e.g., pause/rewind, audio sync).
+- **`VideoImpl` (`video_impl.h`)**: High‑level orchestrator. Owns a `PixelStream` and a `FrameInterpolator`, manages fade‑in/out, time scaling, pause/resume, and draws into either a `Frame` or your `CRGB*` buffer.
+
+### Typical flow
+1. Create `VideoImpl` with your `pixelsPerFrame` and the source FPS.
+2. Call `begin(...)` with a `FileHandle` or `ByteStream`.
+3. Each frame, call `video.draw(now, leds)`.
+   - Internally maintains a buffer of recent frames.
+   - Interpolates between frames to match your output timing.
+4. Use `setFade(...)`, `pause(...)`, `resume(...)`, and `setTimeScale(...)` as needed.
+5. Call `end()` or `rewind()` to manage lifecycle.
+
+### Notes
+- Interpolation makes lower‑FPS content look smooth on higher‑FPS refresh loops.
+- For streaming sources, some random access features (e.g., `rewind`) may be limited.
+- `durationMicros()` reports the full duration for file sources, and `-1` for streams.
+
+This subsystem is optional, intended for MCUs with adequate RAM and I/O throughput.


### PR DESCRIPTION
Add beginner-friendly READMEs to the `src/fx` directory and its subfolders to document the FastLED FX library.

---
<a href="https://cursor.com/background-agent?bcId=bc-c7b60452-af09-4b62-bb9d-4fddf84b5101">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c7b60452-af09-4b62-bb9d-4fddf84b5101">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

