### PR TITLE
Convert button unique_ptr to shared_ptr and test

### DIFF
--- a/src/fl/ui.h
+++ b/src/fl/ui.h
@@ -159,7 +159,7 @@ class UIButton : public UIElement {
     bool value() const { return clicked(); }
 
     void addRealButton(const Button& pin) {
-        mRealButton.reset(new Button(pin));
+        mRealButton = fl::make_shared<Button>(pin);
     }
 
     void click() { mImpl.click(); }
@@ -220,7 +220,7 @@ class UIButton : public UIElement {
   private:
     FunctionList<UIButton &> mCallbacks;
     Listener mListener;
-    fl::unique_ptr<Button> mRealButton;
+    fl::shared_ptr<Button> mRealButton;
 };
 
 class UICheckbox : public UIElement {
@@ -466,7 +466,7 @@ class UIDropdown : public UIElement {
     
     // Add a physical button that will advance to the next option when pressed
     void addNextButton(int pin) {
-        mNextButton.reset(new Button(pin));
+        mNextButton = fl::make_shared<Button>(pin);
     }
     
     // Advance to the next option (cycles back to first option after last)
@@ -521,7 +521,7 @@ class UIDropdown : public UIElement {
     int mLastFrameValue = -1;
     bool mLastFrameValueValid = false;
     Listener mListener;
-    fl::unique_ptr<Button> mNextButton;
+    fl::shared_ptr<Button> mNextButton;
 };
 
 class UIGroup {


### PR DESCRIPTION
Convert `Button` members in `UIButton` and `UIDropdown` from `fl::unique_ptr` to `fl::shared_ptr` to align with shared ownership patterns in UI elements.

---
<a href="https://cursor.com/background-agent?bcId=bc-7ad4b566-7966-4df0-a74e-f54987bd5255">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7ad4b566-7966-4df0-a74e-f54987bd5255">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

