### PR TITLE
Fix native compilation for arduino header

### DIFF
--- a/ci/native/platformio.ini
+++ b/ci/native/platformio.ini
@@ -9,5 +9,8 @@ lib_deps =
 
 build_flags = 
   -DFASTLED_STUB_IMPL
+  -DFASTLED_USE_STUB_ARDUINO
   -DFASTLED_STUB_MAIN_INCLUDE_INO="../examples/Blink/Blink.ino"
   -std=c++17
+  -I/workspace/src/platforms
+  -I/workspace/src/platforms/stub


### PR DESCRIPTION
Enable native compilation by adding include paths for stub Arduino headers and defining `FASTLED_USE_STUB_ARDUINO`.

The `ci/ci-compile-native.py` script failed to compile due to missing `Arduino.h` includes and undefined symbols when building against the stub platform. This change provides the necessary include paths and ensures the stub implementation of Arduino functions is linked.

---
<a href="https://cursor.com/background-agent?bcId=bc-c782c93b-491f-44b8-9d19-cbe0d18bdff2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c782c93b-491f-44b8-9d19-cbe0d18bdff2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

