### PR TITLE
Increase test timeout for bash script

### DIFF
--- a/ci/util/test_runner.py
+++ b/ci/util/test_runner.py
@@ -31,7 +31,7 @@ from ci.util.test_types import (
 
 
 _IS_GITHUB_ACTIONS = os.getenv("GITHUB_ACTIONS") == "true"
-_TIMEOUT = 240 if _IS_GITHUB_ACTIONS else 60
+_TIMEOUT = 240 if _IS_GITHUB_ACTIONS else 180
 _GLOBAL_TIMEOUT = 600 if _IS_GITHUB_ACTIONS else 300
 
 # Abort threshold for total failures across all processes (unit + examples)
@@ -854,7 +854,7 @@ def _process_single_test_output(
 
     while True:
         try:
-            line = proc.get_next_line(timeout=60)  # 60 sec timeout per line
+            line = proc.get_next_line(timeout=180)  # 180 sec timeout per line
 
             is_done = isinstance(line, EndOfStream)
             if is_done:


### PR DESCRIPTION
Increase local test runner and per-line read timeouts to 180 seconds to prevent premature test failures.

---
<a href="https://cursor.com/background-agent?bcId=bc-48134c60-0f71-4c64-b411-d0451360fe4e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-48134c60-0f71-4c64-b411-d0451360fe4e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

