### PR TITLE
Investigate LLVM memory issues in tests and examples

### DIFF
--- a/ci/util/test_args.py
+++ b/ci/util/test_args.py
@@ -135,6 +135,11 @@ def parse_args(args: Optional[list[str]] = None) -> TestArgs:
         default=1,
         help="Number of unity chunks when building libfastled.a (default: 1)",
     )
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="Enable debug mode for C++ unit tests (e.g., full debug symbols)",
+    )
 
     parsed_args = parser.parse_args(args)
 
@@ -162,6 +167,7 @@ def parse_args(args: Optional[list[str]] = None) -> TestArgs:
         full=parsed_args.full,
         no_parallel=parsed_args.no_parallel,
         unity_chunks=parsed_args.unity_chunks,
+        debug=parsed_args.debug,
     )
 
     # Auto-enable --py or --cpp mode when a specific test is provided

--- a/ci/util/test_runner.py
+++ b/ci/util/test_runner.py
@@ -411,6 +411,8 @@ def create_unit_test_process(
         compile_cmd.append("--no-unity")
     if args.no_pch:
         compile_cmd.append("--no-pch")
+    if getattr(args, "debug", False):
+        compile_cmd.append("--debug")
 
     # subprocess.run(compile_cmd, check=True)
 

--- a/ci/util/test_types.py
+++ b/ci/util/test_types.py
@@ -83,6 +83,7 @@ class TestArgs:
 
     no_parallel: bool = False  # Force sequential test execution
     unity_chunks: int = 1  # Number of unity chunks for libfastled build
+    debug: bool = False  # Enable debug mode for unit tests
 
 
 @typechecked


### PR DESCRIPTION
Add `--debug` flag for C++ unit tests to enable debug symbols on demand.

---
<a href="https://cursor.com/background-agent?bcId=bc-0df5b5c6-e104-4d79-8501-431966972210">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0df5b5c6-e104-4d79-8501-431966972210">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

