### PR TITLE
Debug esp32c2 linker script path issues

### DIFF
--- a/ci/compiler/cache_setup.scons
+++ b/ci/compiler/cache_setup.scons
@@ -466,17 +466,32 @@ if USE_CACHE and env is not None and hasattr(env, "get"):  # type: ignore[has-ty
             print("  CXX: " + str(new_cxx))
 
             # Apply to both environments
-            env.Replace(CC=new_cc, CXX=new_cxx)  # type: ignore
-            if has_projenv and projenv is not None:
-                projenv.Replace(CC=new_cc, CXX=new_cxx)  # type: ignore
-                print("Applied Python fake compilers to both env and projenv")
+            # NOTE: For ESP32C2 (espressif32 + esp-idf), the build system's
+            # linker script generator constructs a path using TOOLCHAIN_DIR/bin/$CC
+            # and thus expects $CC to be a bare compiler name (e.g. riscv32-esp-elf-gcc).
+            # Replacing CC with an absolute path to a Python wrapper breaks that logic.
+            # To preserve compatibility, skip CC/CXX replacement for the esp32c2 PIOENV.
+            try:
+                pioenv = str(env.get("PIOENV", "")) if env is not None else ""
+            except Exception:
+                pioenv = ""
+
+            skip_cc_wrap_for_ldgen = pioenv == "esp32c2"
+            if skip_cc_wrap_for_ldgen:
+                print("Skipping CC/CXX wrapper for 'esp32c2' to preserve ESP-IDF ldgen compatibility")
             else:
-                print("Applied Python fake compilers to env (projenv not available)")
+                env.Replace(CC=new_cc, CXX=new_cxx)  # type: ignore
+                if has_projenv and projenv is not None:
+                    projenv.Replace(CC=new_cc, CXX=new_cxx)  # type: ignore
+                    print("Applied Python fake compilers to both env and projenv")
+                else:
+                    print("Applied Python fake compilers to env (projenv not available)")
 
             # Apply to library builders (critical for framework caching)
             try:
                 for lib_builder in env.GetLibBuilders():  # type: ignore
-                    lib_builder.env.Replace(CC=new_cc, CXX=new_cxx)  # type: ignore
+                    if not skip_cc_wrap_for_ldgen:
+                        lib_builder.env.Replace(CC=new_cc, CXX=new_cxx)  # type: ignore
                     if _VERBOSE:
                         print(
                             "Applied Python fake compilers to library builder: "

--- a/failures/AnalogOutput.log
+++ b/failures/AnalogOutput.log
@@ -1,0 +1,236 @@
+Initial build failed: 0.13 ********************************************************************************
+0.13 If you like PlatformIO, please:
+0.13 - star it on GitHub > https://github.com/platformio/platformio-core
+0.13 - follow us on LinkedIn to stay up-to-date on the latest project news > https://www.linkedin.com/company/platformio/
+0.13 - try PlatformIO IDE for embedded development > https://platformio.org/platformio-ide
+0.13 ********************************************************************************
+0.13 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.13 --------------------------------------------------------------------------------
+0.13 Platform Manager: Installing git+https://github.com/pioarduino/platform-espressif32.git#develop
+0.13 git version 2.48.1
+0.13 Cloning into '/home/ubuntu/.fastled/compile/pio/esp32c2/.cache/tmp/pkg-installing-r0xtm2al'...
+0.86 Platform Manager: espressif32@55.3.30+develop.sha.9651ee8 has been installed!
+0.87 Tool Manager: Installing https://github.com/pioarduino/esp_install/releases/download/v5.3.0/esp_install-v5.3.0.zip
+1.18 Downloading 0% 10% 20% 30% 40% 50% 60% 70%
+1.18 Unpacking 0% 10% 20% 30% 40% 50% 60% 70% 80% 90% 100%
+1.18 Tool Manager: tool-esp_install@5.3.0 has been installed!
+1.33 Tool Manager: Installing https://github.com/espressif/arduino-esp32/archive/master.zip
+1.68 Downloading...
+4.15 Unpacking 0% 10% 20% 30% 40% 50% 60% 70% 80% 90% 100%
+4.39 Tool Manager: framework-arduinoespressif32@3.3.0 has been installed!
+4.39 Tool Manager: Installing https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-b66b5448-v1.zip
+6.10 Downloading 0% 10% 20% 30% 40% 50% 60% 70% 80% 90% 100%
+14.87 Unpacking 0% 10% 20% 30% 40% 50% 60% 70% 80% 90% 100%
+19.27 Tool Manager: framework-arduinoespressif32-libs@5.5.0+sha.b66b5448e0 has been installed!
+19.28 Tool Manager: Installing https://github.com/pioarduino/platform-espressif32/releases/download/55.03.30-alpha1/c2_cbe9388f45_compile_skeleton.zip
+20.30 Downloading 0% 10% 20% 30% 40% 50% 60% 70% 80% 90% 100%
+20.88 Unpacking 0% 10% 20% 30% 40% 50% 60% 70% 80% 90% 100%
+21.17 Tool Manager: framework-arduino-c2-skeleton-lib@5.5.0+sha.cbe9388f45 has been installed!
+21.17 Tool Manager: Installing https://github.com/pioarduino/esp-idf/releases/download/v5.5.0/esp-idf-v5.5.0.zip
+23.88 Downloading 0% 10% 20% 30% 40% 50% 60% 70% 80% 90% 100%
+27.16 Unpacking 0% 10% 20% 30% 40% 50% 60% 70% 80% 90% 100%
+29.57 Tool Manager: framework-espidf@3.50500.0 has been installed!
+29.57 Tool Manager: Installing https://github.com/pioarduino/registry/releases/download/0.0.1/riscv32-esp-elf-14.2.0_20241119.zip
+29.76 Downloading 0% 10%
+29.76 Unpacking 0% 10% 20%
+29.76 Tool Manager: toolchain-riscv32-esp@14.2.0+20241119 has been installed!
+29.76 Tool Manager: Installing https://github.com/pioarduino/registry/releases/download/0.0.1/esptoolpy-v5.0.2.zip
+29.96 Downloading 0% 10%
+29.96 Unpacking 0% 10% 20%
+29.96 Tool Manager: tool-esptoolpy@5.0.2 has been installed!
+29.96 Tool Manager: Installing https://github.com/pioarduino/registry/releases/download/0.0.1/contrib-piohome-3.4.4.tar.gz
+30.25 Downloading 0% 10% 20% 30% 40% 50% 60% 70% 80% 90% 100%
+30.28 Unpacking 0% 10% 20% 30% 40% 50% 60% 70% 80% 90% 100%
+30.28 Tool Manager: contrib-piohome@3.4.4 has been installed!
+30.28 Tool Manager: Installing https://github.com/pioarduino/registry/releases/download/0.0.1/mklittlefs-3.2.0-new.zip
+30.47 Downloading 0% 10%
+30.47 Unpacking 0% 10% 20%
+30.47 Tool Manager: tool-mklittlefs@3.2.0 has been installed!
+30.48 Tool Manager: Installing https://github.com/pioarduino/registry/releases/download/0.0.1/cmake-3.30.2.zip
+30.72 Downloading 0% 10%
+30.72 Unpacking 0% 10% 20%
+30.72 Tool Manager: tool-cmake@3.30.2 has been installed!
+30.72 Tool Manager: Installing https://github.com/pioarduino/registry/releases/download/0.0.1/esp-rom-elfs-20241011.zip
+31.03 Downloading 0% 10% 20% 30% 40% 50% 60% 70% 80% 90% 100%
+31.07 Unpacking 0% 10% 20% 30% 40% 50% 60% 70% 80% 90% 100%
+31.08 Tool Manager: tool-esp-rom-elfs@2024.10.11 has been installed!
+31.08 Tool Manager: Installing https://github.com/pioarduino/registry/releases/download/0.0.1/ninja-1.13.1.zip
+31.33 Downloading 0% 10%
+31.33 Unpacking 0% 10% 20%
+31.33 Tool Manager: tool-ninja@1.13.1 has been installed!
+31.34 Tool Manager: Installing https://github.com/pioarduino/registry/releases/download/0.0.1/scons-4.8.1.zip
+31.53 Downloading 0% 10%
+31.53 Unpacking 0% 10% 20%
+31.53 Tool Manager: tool-scons@4.40801.0 has been installed!
+31.54 Tool Manager: Installing platformio/tool-scons @ ~4.40801.0
+34.15 Downloading 0% 10% 20% 30% 40% 50% 60% 70% 80% 90% 100%
+34.19 Unpacking 0% 10% 20% 30% 40% 50% 60% 70% 80% 90% 100%
+34.21 Tool Manager: tool-scons@4.40801.0 has been installed!
+34.48 Tool Manager: Installing file:///home/ubuntu/.platformio/tools/tool-esptoolpy
+34.51 Tool Manager: tool-esptoolpy@5.0.2 has been installed!
+52.48 Tool Manager: Installing file:///home/ubuntu/.platformio/tools/toolchain-riscv32-esp
+57.48 Tool Manager: toolchain-riscv32-esp@14.2.0+20241119 has been installed!
+57.89 Tool Manager: Installing file:///home/ubuntu/.platformio/tools/tool-mklittlefs
+57.89 Tool Manager: tool-mklittlefs@3.2.0 has been installed!
+58.11 Tool Manager: Installing file:///home/ubuntu/.platformio/tools/tool-cmake
+60.19 Tool Manager: tool-cmake@3.30.2 has been installed!
+60.50 Tool Manager: Installing file:///home/ubuntu/.platformio/tools/tool-ninja
+60.51 Tool Manager: tool-ninja@1.13.1 has been installed!
+60.62 Tool Manager: Installing file:///home/ubuntu/.platformio/tools/tool-esp-rom-elfs
+60.65 Tool Manager: tool-esp-rom-elfs@2024.10.11 has been installed!
+60.95 Verbose mode can be enabled via `-v, --verbose` option
+61.02 Creating pioarduino Python virtual environment: /home/ubuntu/.fastled/compile/pio/esp32c2/penv
+61.05 The virtual environment was not created successfully because ensurepip is not
+61.05 available.  On Debian/Ubuntu systems, you need to install the python3-venv
+61.05 package using the following command.
+61.05     apt install python3.13-venv
+61.05 You may need to use sudo with that command.  After installing the python3-venv
+61.05 package, recreate your virtual environment.
+61.05 Failing command: /home/ubuntu/.fastled/compile/pio/esp32c2/penv/bin/python3.13
+61.06 *** Error 1
+61.06 AssertionError: Error: Failed to create a proper virtual environment. Missing the `pip` binary!:
+61.06   File "/workspace/.venv/lib/python3.13/site-packages/platformio/builder/main.py", line 173:
+61.06     env.SConscript("$BUILD_SCRIPT")
+61.06   File "/home/ubuntu/.fastled/packages/esp32c2/tool-scons/scons-local-4.8.1/SCons/Script/SConscript.py", line 620:
+61.06     return _SConscript(self.fs, *files, **subst_kw)
+61.06   File "/home/ubuntu/.fastled/packages/esp32c2/tool-scons/scons-local-4.8.1/SCons/Script/SConscript.py", line 280:
+61.06     exec(compile(scriptdata, scriptname, 'exec'), call_stack[-1].globals)
+61.06   File "/home/ubuntu/.fastled/compile/pio/esp32c2/platforms/espressif32/builder/main.py", line 46:
+61.06     PYTHON_EXE, esptool_binary_path = setup_python_environment(env, platform, platformio_dir)
+61.06   File "/home/ubuntu/.fastled/compile/pio/esp32c2/platforms/espressif32/builder/penv_setup.py", line 352:
+61.06     setup_pipenv_in_package(env, penv_dir)
+61.06   File "/home/ubuntu/.fastled/compile/pio/esp32c2/platforms/espressif32/builder/penv_setup.py", line 83:
+61.06     assert os.path.isfile(
+61.10 ========================= [FAILED] Took 60.97 seconds =========================
+Initial build failed: 0.13 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.13 --------------------------------------------------------------------------------
+0.55 Verbose mode can be enabled via `-v, --verbose` option
+3.89 CONFIGURATION: https://docs.platformio.org/page/boards/espressif32/esp32-c2-devkitm-1.html
+3.89 PLATFORM: Espressif 32 (55.3.30+develop.sha.9651ee8) > Espressif ESP32-C2-DevKitM-1
+3.89 HARDWARE: ESP32C2 120MHz, 272KB RAM, 4MB Flash
+3.89 DEBUG: Current (cmsis-dap) External (cmsis-dap, esp-bridge, esp-prog, iot-bus-jtag, jlink, minimodule, olimex-arm-usb-ocd, olimex-arm-usb-ocd-h, olimex-arm-usb-tiny-h, olimex-jtag-tiny, tumpa)
+3.89 PACKAGES:
+3.89  - contrib-piohome @ 3.4.4
+3.89  - framework-arduino-c2-skeleton-lib @ 5.5.0+sha.cbe9388f45
+3.89  - framework-arduinoespressif32 @ 3.3.0
+3.89  - framework-arduinoespressif32-libs @ 5.5.0+sha.b66b5448e0
+3.89  - framework-espidf @ 3.50500.0 (5.5.0)
+3.89  - tool-cmake @ 3.30.2
+3.89  - tool-esp-rom-elfs @ 2024.10.11
+3.89  - tool-esptoolpy @ 5.0.2
+3.89  - tool-mklittlefs @ 3.2.0
+3.89  - tool-ninja @ 1.13.1
+3.89  - tool-scons @ 4.40801.0 (4.8.1)
+3.89  - toolchain-riscv32-esp @ 14.2.0+20241119
+3.90 *** Compile Arduino IDF libs for esp32c2 ***
+4.68 *** Add "custom_sdkconfig" settings to IDF sdkconfig.defaults ***
+4.68 Replace: CONFIG_IDF_TARGET="esp32c2" with: CONFIG_IDF_TARGET=esp32c2
+4.68 Replace: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y with: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y
+4.68 Replace: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y with: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y
+4.68 Replace: CONFIG_ESPTOOLPY_FLASHFREQ="60m" with: CONFIG_ESPTOOLPY_FLASHFREQ="60m"
+4.68 Add: # CONFIG_ESPTOOLPY_FLASHFREQ_80M is not set
+4.68 Creating a new virtual environment for IDF Python dependencies
+6.26 Using Python 3.13.3 environment at: /home/ubuntu/.fastled/compile/pio/esp32c2/penv/.espidf-5.5.0
+6.26 Installing ESP-IDF's Python dependencies with uv
+6.27 Using Python 3.13.3 environment at: /home/ubuntu/.fastled/compile/pio/esp32c2/penv/.espidf-5.5.0
+6.46 Resolved 28 packages in 188ms
+6.48 Downloading cryptography (4.0MiB)
+6.48 Downloading uv (18.4MiB)
+6.59  Downloading cryptography
+6.69  Downloading uv
+6.69 Prepared 12 packages in 224ms
+6.70 Installed 28 packages in 10ms
+6.70  + annotated-types==0.7.0
+6.70  + certifi==2025.8.3
+6.70  + cffi==1.17.1
+6.70  + charset-normalizer==3.4.3
+6.70  + click==8.2.1
+6.70  + colorama==0.4.6
+6.70  + cryptography==44.0.3
+6.70  + esp-idf-kconfig==2.5.0
+6.70  + idf-component-manager==2.2.2
+6.70  + idna==3.10
+6.70  + jsonref==1.1.0
+6.70  + pycparser==2.22
+6.70  + pydantic==2.11.7
+6.70  + pydantic-core==2.33.2
+6.70  + pydantic-settings==2.10.1
+6.70  + pyparsing==3.2.3
+6.70  + python-dotenv==1.1.1
+6.70  + requests==2.32.4
+6.70  + requests-file==2.1.0
+6.70  + requests-toolbelt==1.0.0
+6.70  + ruamel-yaml==0.18.14
+6.70  + ruamel-yaml-clib==0.2.12
+6.70  + tqdm==4.67.1
+6.70  + truststore==0.10.4
+6.70  + typing-extensions==4.14.1
+6.70  + typing-inspection==0.4.1
+6.70  + urllib3==1.26.20
+6.70  + uv==0.8.9
+6.71 Warning! Arduino framework as an ESP-IDF component doesn't handle the `variant` field! The default `esp32` variant will be used.
+6.71 Reading CMake configuration...
+15.23 Generating assembly for certificate bundle...
+15.40 LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
+15.40 LDF Modes: Finder ~ chain, Compatibility ~ soft
+15.45 Found 42 compatible libraries
+15.45 Scanning dependencies...
+15.46 No dependencies
+15.46 Building in release mode
+15.47 Environment state dumped to: env_dump.json
+15.47 Projenv state dumped to: projenv_dump.json
+15.47 Cache configuration from environment:
+15.47   Cache type: xcache
+15.47   Cache executable: python /workspace/ci/util/xcache.py
+15.47   SCCACHE path: /workspace/.venv/bin/sccache
+15.47   SCCACHE dir: /home/ubuntu/.fastled/sccache
+15.47   Debug enabled: False
+15.47 xcache wrapper detected and configured for Python fake compilers
+15.47   xcache path: /workspace/ci/util/xcache.py
+15.47   cache executable: python /workspace/ci/util/xcache.py
+15.47 DEBUG: Found compilers in env:
+15.47   CC: 'riscv32-esp-elf-gcc' (type: str)
+15.47   CXX: 'riscv32-esp-elf-g++' (type: str)
+15.47 Extracted compiler names:
+15.47   CC name: riscv32-esp-elf-gcc
+15.47   CXX name: riscv32-esp-elf-g++
+15.47 No valid cache found, creating compiler toolset from scratch...
+15.47   This is the first compile or configuration changed
+15.47 Searching platform packages (this may take ~10 seconds)...
+16.22 Found 71 platform package directories
+16.22 Resolving real compiler paths...
+16.22 Found real compilers:
+16.22   Real CC: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-gcc
+16.22   Real CXX: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-g++
+16.22 Created new compiler toolset:
+16.22   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+16.22   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+16.22 Saved compiler toolset to local cache: /workspace/.build/pio/esp32c2/compiler_cache.json
+16.22   This cache will persist across builds for this platform
+16.22 Created Python cached compilers:
+16.22   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+16.22   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+16.22 Applied Python fake compilers to both env and projenv
+16.22 Python fake compiler cache enabled: xcache
+16.22   Original CC: riscv32-esp-elf-gcc
+16.22   Original CXX: riscv32-esp-elf-g++
+16.22   Fake CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+16.22   Fake CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+16.22 Python fake compiler cache environment configured successfully
+16.38 Compiling .pio/build/esp32c2/.dummy/sketch.cpp.o
+16.39 Compiling .pio/build/esp32c2/.dummy/arduino-lib-builder-gcc.c.o
+16.39 Compiling .pio/build/esp32c2/.dummy/arduino-lib-builder-cpp.cpp.o
+16.40 Compiling .pio/build/esp32c2/.dummy/arduino-lib-builder-as.S.o
+16.44 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+16.44 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+16.44   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+16.44   RET_CODE: no such file or directory
+16.44   ERROR_MESSAGE:
+16.45 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in] Error 1
+16.45 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+16.45 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+16.45   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+16.45   RET_CODE: no such file or directory
+16.45   ERROR_MESSAGE:
+16.45 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in] Error 1
+17.13 ========================= [FAILED] Took 17.00 seconds =========================

--- a/failures/Animartrix.log
+++ b/failures/Animartrix.log
@@ -1,0 +1,95 @@
+Initial build failed: 0.12 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.12 --------------------------------------------------------------------------------
+0.43 Verbose mode can be enabled via `-v, --verbose` option
+0.51 Error output: /home/ubuntu/.fastled/compile/pio/esp32c2/penv/bin/python: No module named pip
+0.51 Error: Failed to install Python dependencies into penv
+0.55 ========================== [FAILED] Took 0.42 seconds ==========================
+Initial build failed: 0.16 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.16 --------------------------------------------------------------------------------
+0.49 Verbose mode can be enabled via `-v, --verbose` option
+1.05 CONFIGURATION: https://docs.platformio.org/page/boards/espressif32/esp32-c2-devkitm-1.html
+1.05 PLATFORM: Espressif 32 (55.3.30+develop.sha.9651ee8) > Espressif ESP32-C2-DevKitM-1
+1.05 HARDWARE: ESP32C2 120MHz, 272KB RAM, 4MB Flash
+1.05 DEBUG: Current (cmsis-dap) External (cmsis-dap, esp-bridge, esp-prog, iot-bus-jtag, jlink, minimodule, olimex-arm-usb-ocd, olimex-arm-usb-ocd-h, olimex-arm-usb-tiny-h, olimex-jtag-tiny, tumpa)
+1.05 PACKAGES:
+1.05  - contrib-piohome @ 3.4.4
+1.05  - framework-arduino-c2-skeleton-lib @ 5.5.0+sha.cbe9388f45
+1.05  - framework-arduinoespressif32 @ 3.3.0
+1.05  - framework-arduinoespressif32-libs @ 5.5.0+sha.b66b5448e0
+1.05  - framework-espidf @ 3.50500.0 (5.5.0)
+1.05  - tool-cmake @ 3.30.2
+1.05  - tool-esp-rom-elfs @ 2024.10.11
+1.05  - tool-esptoolpy @ 5.0.2
+1.05  - tool-mklittlefs @ 3.2.0
+1.05  - tool-ninja @ 1.13.1
+1.05  - tool-scons @ 4.40801.0 (4.8.1)
+1.05  - toolchain-riscv32-esp @ 14.2.0+20241119
+1.05 *** Compile Arduino IDF libs for esp32c2 ***
+1.07 *** Add "custom_sdkconfig" settings to IDF sdkconfig.defaults ***
+1.07 Replace: CONFIG_IDF_TARGET="esp32c2" with: CONFIG_IDF_TARGET=esp32c2
+1.07 Replace: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y with: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y
+1.07 Replace: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y with: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y
+1.07 Replace: CONFIG_ESPTOOLPY_FLASHFREQ="60m" with: CONFIG_ESPTOOLPY_FLASHFREQ="60m"
+1.08 Add: # CONFIG_ESPTOOLPY_FLASHFREQ_80M is not set
+1.09 Warning! Arduino framework as an ESP-IDF component doesn't handle the `variant` field! The default `esp32` variant will be used.
+1.09 Reading CMake configuration...
+5.55 Generating assembly for certificate bundle...
+5.71 LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
+5.71 LDF Modes: Finder ~ chain, Compatibility ~ soft
+5.77 Found 42 compatible libraries
+5.77 Scanning dependencies...
+5.77 No dependencies
+5.77 Building in release mode
+5.78 Environment state dumped to: env_dump.json
+5.78 Projenv state dumped to: projenv_dump.json
+5.78 Cache configuration from environment:
+5.78   Cache type: xcache
+5.78   Cache executable: python /workspace/ci/util/xcache.py
+5.78   SCCACHE path: /workspace/.venv/bin/sccache
+5.78   SCCACHE dir: /home/ubuntu/.fastled/sccache
+5.78   Debug enabled: False
+5.78 xcache wrapper detected and configured for Python fake compilers
+5.78   xcache path: /workspace/ci/util/xcache.py
+5.78   cache executable: python /workspace/ci/util/xcache.py
+5.78 DEBUG: Found compilers in env:
+5.78   CC: 'riscv32-esp-elf-gcc' (type: str)
+5.78   CXX: 'riscv32-esp-elf-g++' (type: str)
+5.78 Extracted compiler names:
+5.78   CC name: riscv32-esp-elf-gcc
+5.78   CXX name: riscv32-esp-elf-g++
+5.78 Found local compiler cache:
+5.78   Cache file: /workspace/.build/pio/esp32c2/compiler_cache.json
+5.78   Real CC: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-gcc
+5.78   Real CXX: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-g++
+5.78 SUCCESS: Using cached compilers (instant, no platform search needed):
+5.78   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.78   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.78   Platform search skipped - using cached toolset
+5.78 Created Python cached compilers:
+5.78   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.78   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.78 Applied Python fake compilers to both env and projenv
+5.78 Python fake compiler cache enabled: xcache
+5.78   Original CC: riscv32-esp-elf-gcc
+5.78   Original CXX: riscv32-esp-elf-g++
+5.78   Fake CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.78   Fake CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.78 Python fake compiler cache environment configured successfully
+5.88 Retrieved `.pio/build/esp32c2/.dummy/sketch.cpp.o' from cache
+5.89 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-gcc.c.o' from cache
+5.89 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-cpp.cpp.o' from cache
+5.90 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-as.S.o' from cache
+5.90 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.90 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.90 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.90   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.90   RET_CODE: no such file or directory
+5.90   ERROR_MESSAGE:
+5.91 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.91   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.91   RET_CODE: no such file or directory
+5.91   ERROR_MESSAGE:
+5.92 Compiling .pio/build/esp32c2/app_trace/app_trace.c.o
+5.92 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in] Error 1
+5.92 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in] Error 1
+6.18 ========================== [FAILED] Took 6.02 seconds ==========================

--- a/failures/Apa102.log
+++ b/failures/Apa102.log
@@ -1,0 +1,90 @@
+Initial build failed: 0.12 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.12 --------------------------------------------------------------------------------
+0.42 Verbose mode can be enabled via `-v, --verbose` option
+0.51 Error: Failed to install Python dependencies into penv
+0.51 Error output: /home/ubuntu/.fastled/compile/pio/esp32c2/penv/bin/python: No module named pip
+0.55 ========================== [FAILED] Took 0.42 seconds ==========================
+Initial build failed: 0.13 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.13 --------------------------------------------------------------------------------
+0.44 Verbose mode can be enabled via `-v, --verbose` option
+0.99 CONFIGURATION: https://docs.platformio.org/page/boards/espressif32/esp32-c2-devkitm-1.html
+0.99 PLATFORM: Espressif 32 (55.3.30+develop.sha.9651ee8) > Espressif ESP32-C2-DevKitM-1
+0.99 HARDWARE: ESP32C2 120MHz, 272KB RAM, 4MB Flash
+0.99 DEBUG: Current (cmsis-dap) External (cmsis-dap, esp-bridge, esp-prog, iot-bus-jtag, jlink, minimodule, olimex-arm-usb-ocd, olimex-arm-usb-ocd-h, olimex-arm-usb-tiny-h, olimex-jtag-tiny, tumpa)
+0.99 PACKAGES:
+0.99  - contrib-piohome @ 3.4.4
+0.99  - framework-arduino-c2-skeleton-lib @ 5.5.0+sha.cbe9388f45
+0.99  - framework-arduinoespressif32 @ 3.3.0
+0.99  - framework-arduinoespressif32-libs @ 5.5.0+sha.b66b5448e0
+0.99  - framework-espidf @ 3.50500.0 (5.5.0)
+0.99  - tool-cmake @ 3.30.2
+0.99  - tool-esp-rom-elfs @ 2024.10.11
+0.99  - tool-esptoolpy @ 5.0.2
+0.99  - tool-mklittlefs @ 3.2.0
+0.99  - tool-ninja @ 1.13.1
+0.99  - tool-scons @ 4.40801.0 (4.8.1)
+0.99  - toolchain-riscv32-esp @ 14.2.0+20241119
+0.99 *** Compile Arduino IDF libs for esp32c2 ***
+1.01 *** Add "custom_sdkconfig" settings to IDF sdkconfig.defaults ***
+1.01 Replace: CONFIG_IDF_TARGET="esp32c2" with: CONFIG_IDF_TARGET=esp32c2
+1.01 Replace: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y with: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y
+1.01 Replace: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y with: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y
+1.01 Replace: CONFIG_ESPTOOLPY_FLASHFREQ="60m" with: CONFIG_ESPTOOLPY_FLASHFREQ="60m"
+1.01 Add: # CONFIG_ESPTOOLPY_FLASHFREQ_80M is not set
+1.02 Warning! Arduino framework as an ESP-IDF component doesn't handle the `variant` field! The default `esp32` variant will be used.
+1.02 Reading CMake configuration...
+5.16 LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
+5.16 LDF Modes: Finder ~ chain, Compatibility ~ soft
+5.22 Found 42 compatible libraries
+5.22 Scanning dependencies...
+5.22 No dependencies
+5.22 Building in release mode
+5.23 Environment state dumped to: env_dump.json
+5.23 Projenv state dumped to: projenv_dump.json
+5.23 Cache configuration from environment:
+5.23   Cache type: xcache
+5.23   Cache executable: python /workspace/ci/util/xcache.py
+5.23   SCCACHE path: /workspace/.venv/bin/sccache
+5.23   SCCACHE dir: /home/ubuntu/.fastled/sccache
+5.23   Debug enabled: False
+5.23 xcache wrapper detected and configured for Python fake compilers
+5.23   xcache path: /workspace/ci/util/xcache.py
+5.23   cache executable: python /workspace/ci/util/xcache.py
+5.23 DEBUG: Found compilers in env:
+5.23   CC: 'riscv32-esp-elf-gcc' (type: str)
+5.23   CXX: 'riscv32-esp-elf-g++' (type: str)
+5.23 Extracted compiler names:
+5.23   CC name: riscv32-esp-elf-gcc
+5.23   CXX name: riscv32-esp-elf-g++
+5.23 Found local compiler cache:
+5.23   Cache file: /workspace/.build/pio/esp32c2/compiler_cache.json
+5.23   Real CC: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-gcc
+5.23   Real CXX: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-g++
+5.23 SUCCESS: Using cached compilers (instant, no platform search needed):
+5.23   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.23   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.23   Platform search skipped - using cached toolset
+5.23 Created Python cached compilers:
+5.23   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.23   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.23 Applied Python fake compilers to both env and projenv
+5.23 Python fake compiler cache enabled: xcache
+5.23   Original CC: riscv32-esp-elf-gcc
+5.23   Original CXX: riscv32-esp-elf-g++
+5.23   Fake CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.23   Fake CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.23 Python fake compiler cache environment configured successfully
+5.26 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.26 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.26 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.26   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.26   RET_CODE: no such file or directory
+5.26   ERROR_MESSAGE:
+5.27 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.27   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.27   RET_CODE: no such file or directory
+5.27   ERROR_MESSAGE:
+5.28 Compiling .pio/build/esp32c2/app_trace/app_trace_util.c.o
+5.29 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in] Error 1
+5.29 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in] Error 1
+5.49 ========================== [FAILED] Took 5.36 seconds ==========================

--- a/failures/Apa102HD.log
+++ b/failures/Apa102HD.log
@@ -1,0 +1,90 @@
+Initial build failed: 0.12 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.12 --------------------------------------------------------------------------------
+0.43 Verbose mode can be enabled via `-v, --verbose` option
+0.50 Error: Failed to install Python dependencies into penv
+0.50 Error output: /home/ubuntu/.fastled/compile/pio/esp32c2/penv/bin/python: No module named pip
+0.54 ========================== [FAILED] Took 0.42 seconds ==========================
+Initial build failed: 0.13 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.13 --------------------------------------------------------------------------------
+0.44 Verbose mode can be enabled via `-v, --verbose` option
+1.01 CONFIGURATION: https://docs.platformio.org/page/boards/espressif32/esp32-c2-devkitm-1.html
+1.01 PLATFORM: Espressif 32 (55.3.30+develop.sha.9651ee8) > Espressif ESP32-C2-DevKitM-1
+1.01 HARDWARE: ESP32C2 120MHz, 272KB RAM, 4MB Flash
+1.01 DEBUG: Current (cmsis-dap) External (cmsis-dap, esp-bridge, esp-prog, iot-bus-jtag, jlink, minimodule, olimex-arm-usb-ocd, olimex-arm-usb-ocd-h, olimex-arm-usb-tiny-h, olimex-jtag-tiny, tumpa)
+1.01 PACKAGES:
+1.01  - contrib-piohome @ 3.4.4
+1.01  - framework-arduino-c2-skeleton-lib @ 5.5.0+sha.cbe9388f45
+1.01  - framework-arduinoespressif32 @ 3.3.0
+1.01  - framework-arduinoespressif32-libs @ 5.5.0+sha.b66b5448e0
+1.01  - framework-espidf @ 3.50500.0 (5.5.0)
+1.01  - tool-cmake @ 3.30.2
+1.01  - tool-esp-rom-elfs @ 2024.10.11
+1.01  - tool-esptoolpy @ 5.0.2
+1.01  - tool-mklittlefs @ 3.2.0
+1.01  - tool-ninja @ 1.13.1
+1.01  - tool-scons @ 4.40801.0 (4.8.1)
+1.01  - toolchain-riscv32-esp @ 14.2.0+20241119
+1.02 *** Compile Arduino IDF libs for esp32c2 ***
+1.04 *** Add "custom_sdkconfig" settings to IDF sdkconfig.defaults ***
+1.04 Replace: CONFIG_IDF_TARGET="esp32c2" with: CONFIG_IDF_TARGET=esp32c2
+1.04 Replace: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y with: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y
+1.04 Replace: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y with: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y
+1.04 Replace: CONFIG_ESPTOOLPY_FLASHFREQ="60m" with: CONFIG_ESPTOOLPY_FLASHFREQ="60m"
+1.04 Add: # CONFIG_ESPTOOLPY_FLASHFREQ_80M is not set
+1.05 Warning! Arduino framework as an ESP-IDF component doesn't handle the `variant` field! The default `esp32` variant will be used.
+1.05 Reading CMake configuration...
+5.17 LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
+5.17 LDF Modes: Finder ~ chain, Compatibility ~ soft
+5.22 Found 42 compatible libraries
+5.22 Scanning dependencies...
+5.22 No dependencies
+5.23 Building in release mode
+5.23 Environment state dumped to: env_dump.json
+5.23 Projenv state dumped to: projenv_dump.json
+5.23 Cache configuration from environment:
+5.23   Cache type: xcache
+5.23   Cache executable: python /workspace/ci/util/xcache.py
+5.23   SCCACHE path: /workspace/.venv/bin/sccache
+5.23   SCCACHE dir: /home/ubuntu/.fastled/sccache
+5.23   Debug enabled: False
+5.23 xcache wrapper detected and configured for Python fake compilers
+5.23   xcache path: /workspace/ci/util/xcache.py
+5.23   cache executable: python /workspace/ci/util/xcache.py
+5.23 DEBUG: Found compilers in env:
+5.23   CC: 'riscv32-esp-elf-gcc' (type: str)
+5.23   CXX: 'riscv32-esp-elf-g++' (type: str)
+5.23 Extracted compiler names:
+5.23   CC name: riscv32-esp-elf-gcc
+5.23   CXX name: riscv32-esp-elf-g++
+5.23 Found local compiler cache:
+5.23   Cache file: /workspace/.build/pio/esp32c2/compiler_cache.json
+5.23   Real CC: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-gcc
+5.23   Real CXX: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-g++
+5.23 SUCCESS: Using cached compilers (instant, no platform search needed):
+5.23   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.23   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.23   Platform search skipped - using cached toolset
+5.23 Created Python cached compilers:
+5.23   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.23   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.23 Applied Python fake compilers to both env and projenv
+5.23 Python fake compiler cache enabled: xcache
+5.24   Original CC: riscv32-esp-elf-gcc
+5.24   Original CXX: riscv32-esp-elf-g++
+5.24   Fake CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.24   Fake CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.24 Python fake compiler cache environment configured successfully
+5.27 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.27 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.27 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.27   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.27   RET_CODE: no such file or directory
+5.27   ERROR_MESSAGE:
+5.27 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.27   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.27   RET_CODE: no such file or directory
+5.27   ERROR_MESSAGE:
+5.30 Compiling .pio/build/esp32c2/app_trace/host_file_io.c.o
+5.30 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in] Error 1
+5.30 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in] Error 1
+5.47 ========================== [FAILED] Took 5.34 seconds ==========================

--- a/failures/Apa102HDOverride.log
+++ b/failures/Apa102HDOverride.log
@@ -1,0 +1,90 @@
+Initial build failed: 0.12 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.12 --------------------------------------------------------------------------------
+0.42 Verbose mode can be enabled via `-v, --verbose` option
+0.49 Error output: /home/ubuntu/.fastled/compile/pio/esp32c2/penv/bin/python: No module named pip
+0.49 Error: Failed to install Python dependencies into penv
+0.53 ========================== [FAILED] Took 0.41 seconds ==========================
+Initial build failed: 0.13 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.13 --------------------------------------------------------------------------------
+0.44 Verbose mode can be enabled via `-v, --verbose` option
+0.90 CONFIGURATION: https://docs.platformio.org/page/boards/espressif32/esp32-c2-devkitm-1.html
+0.90 PLATFORM: Espressif 32 (55.3.30+develop.sha.9651ee8) > Espressif ESP32-C2-DevKitM-1
+0.90 HARDWARE: ESP32C2 120MHz, 272KB RAM, 4MB Flash
+0.90 DEBUG: Current (cmsis-dap) External (cmsis-dap, esp-bridge, esp-prog, iot-bus-jtag, jlink, minimodule, olimex-arm-usb-ocd, olimex-arm-usb-ocd-h, olimex-arm-usb-tiny-h, olimex-jtag-tiny, tumpa)
+0.90 PACKAGES:
+0.90  - contrib-piohome @ 3.4.4
+0.90  - framework-arduino-c2-skeleton-lib @ 5.5.0+sha.cbe9388f45
+0.90  - framework-arduinoespressif32 @ 3.3.0
+0.90  - framework-arduinoespressif32-libs @ 5.5.0+sha.b66b5448e0
+0.90  - framework-espidf @ 3.50500.0 (5.5.0)
+0.90  - tool-cmake @ 3.30.2
+0.90  - tool-esp-rom-elfs @ 2024.10.11
+0.90  - tool-esptoolpy @ 5.0.2
+0.90  - tool-mklittlefs @ 3.2.0
+0.90  - tool-ninja @ 1.13.1
+0.90  - tool-scons @ 4.40801.0 (4.8.1)
+0.90  - toolchain-riscv32-esp @ 14.2.0+20241119
+0.90 *** Compile Arduino IDF libs for esp32c2 ***
+0.92 *** Add "custom_sdkconfig" settings to IDF sdkconfig.defaults ***
+0.92 Replace: CONFIG_IDF_TARGET="esp32c2" with: CONFIG_IDF_TARGET=esp32c2
+0.92 Replace: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y with: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y
+0.92 Replace: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y with: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y
+0.92 Replace: CONFIG_ESPTOOLPY_FLASHFREQ="60m" with: CONFIG_ESPTOOLPY_FLASHFREQ="60m"
+0.92 Add: # CONFIG_ESPTOOLPY_FLASHFREQ_80M is not set
+0.93 Warning! Arduino framework as an ESP-IDF component doesn't handle the `variant` field! The default `esp32` variant will be used.
+0.93 Reading CMake configuration...
+5.07 LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
+5.07 LDF Modes: Finder ~ chain, Compatibility ~ soft
+5.12 Found 42 compatible libraries
+5.12 Scanning dependencies...
+5.13 No dependencies
+5.13 Building in release mode
+5.14 Environment state dumped to: env_dump.json
+5.14 Projenv state dumped to: projenv_dump.json
+5.14 Cache configuration from environment:
+5.14   Cache type: xcache
+5.14   Cache executable: python /workspace/ci/util/xcache.py
+5.14   SCCACHE path: /workspace/.venv/bin/sccache
+5.14   SCCACHE dir: /home/ubuntu/.fastled/sccache
+5.14   Debug enabled: False
+5.14 xcache wrapper detected and configured for Python fake compilers
+5.14   xcache path: /workspace/ci/util/xcache.py
+5.14   cache executable: python /workspace/ci/util/xcache.py
+5.14 DEBUG: Found compilers in env:
+5.14   CC: 'riscv32-esp-elf-gcc' (type: str)
+5.14   CXX: 'riscv32-esp-elf-g++' (type: str)
+5.14 Extracted compiler names:
+5.14   CC name: riscv32-esp-elf-gcc
+5.14   CXX name: riscv32-esp-elf-g++
+5.14 Found local compiler cache:
+5.14   Cache file: /workspace/.build/pio/esp32c2/compiler_cache.json
+5.14   Real CC: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-gcc
+5.14   Real CXX: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-g++
+5.14 SUCCESS: Using cached compilers (instant, no platform search needed):
+5.14   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.14   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.14   Platform search skipped - using cached toolset
+5.14 Created Python cached compilers:
+5.14   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.14   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.14 Applied Python fake compilers to both env and projenv
+5.14 Python fake compiler cache enabled: xcache
+5.14   Original CC: riscv32-esp-elf-gcc
+5.14   Original CXX: riscv32-esp-elf-g++
+5.14   Fake CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.14   Fake CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.14 Python fake compiler cache environment configured successfully
+5.17 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.17 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.17 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.17   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.17   RET_CODE: no such file or directory
+5.17   ERROR_MESSAGE:
+5.18 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.18   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.18   RET_CODE: no such file or directory
+5.18   ERROR_MESSAGE:
+5.20 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in] Error 1
+5.20 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in] Error 1
+5.20 Compiling .pio/build/esp32c2/app_trace/port/port_uart.c.o
+5.40 ========================== [FAILED] Took 5.27 seconds ==========================

--- a/failures/Async.log
+++ b/failures/Async.log
@@ -1,0 +1,95 @@
+Initial build failed: 0.12 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.12 --------------------------------------------------------------------------------
+0.42 Verbose mode can be enabled via `-v, --verbose` option
+0.50 Error: Failed to install Python dependencies into penv
+0.50 Error output: /home/ubuntu/.fastled/compile/pio/esp32c2/penv/bin/python: No module named pip
+0.54 ========================== [FAILED] Took 0.41 seconds ==========================
+Initial build failed: 0.16 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.16 --------------------------------------------------------------------------------
+0.46 Verbose mode can be enabled via `-v, --verbose` option
+0.88 CONFIGURATION: https://docs.platformio.org/page/boards/espressif32/esp32-c2-devkitm-1.html
+0.88 PLATFORM: Espressif 32 (55.3.30+develop.sha.9651ee8) > Espressif ESP32-C2-DevKitM-1
+0.88 HARDWARE: ESP32C2 120MHz, 272KB RAM, 4MB Flash
+0.88 DEBUG: Current (cmsis-dap) External (cmsis-dap, esp-bridge, esp-prog, iot-bus-jtag, jlink, minimodule, olimex-arm-usb-ocd, olimex-arm-usb-ocd-h, olimex-arm-usb-tiny-h, olimex-jtag-tiny, tumpa)
+0.88 PACKAGES:
+0.88  - contrib-piohome @ 3.4.4
+0.88  - framework-arduino-c2-skeleton-lib @ 5.5.0+sha.cbe9388f45
+0.88  - framework-arduinoespressif32 @ 3.3.0
+0.88  - framework-arduinoespressif32-libs @ 5.5.0+sha.b66b5448e0
+0.88  - framework-espidf @ 3.50500.0 (5.5.0)
+0.88  - tool-cmake @ 3.30.2
+0.88  - tool-esp-rom-elfs @ 2024.10.11
+0.88  - tool-esptoolpy @ 5.0.2
+0.88  - tool-mklittlefs @ 3.2.0
+0.88  - tool-ninja @ 1.13.1
+0.88  - tool-scons @ 4.40801.0 (4.8.1)
+0.88  - toolchain-riscv32-esp @ 14.2.0+20241119
+0.89 *** Compile Arduino IDF libs for esp32c2 ***
+0.91 *** Add "custom_sdkconfig" settings to IDF sdkconfig.defaults ***
+0.91 Replace: CONFIG_IDF_TARGET="esp32c2" with: CONFIG_IDF_TARGET=esp32c2
+0.91 Replace: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y with: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y
+0.91 Replace: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y with: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y
+0.91 Replace: CONFIG_ESPTOOLPY_FLASHFREQ="60m" with: CONFIG_ESPTOOLPY_FLASHFREQ="60m"
+0.91 Add: # CONFIG_ESPTOOLPY_FLASHFREQ_80M is not set
+0.92 Warning! Arduino framework as an ESP-IDF component doesn't handle the `variant` field! The default `esp32` variant will be used.
+0.92 Reading CMake configuration...
+5.35 Generating assembly for certificate bundle...
+5.51 LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
+5.51 LDF Modes: Finder ~ chain, Compatibility ~ soft
+5.56 Found 42 compatible libraries
+5.56 Scanning dependencies...
+5.57 No dependencies
+5.57 Building in release mode
+5.57 Environment state dumped to: env_dump.json
+5.58 Projenv state dumped to: projenv_dump.json
+5.58 Cache configuration from environment:
+5.58   Cache type: xcache
+5.58   Cache executable: python /workspace/ci/util/xcache.py
+5.58   SCCACHE path: /workspace/.venv/bin/sccache
+5.58   SCCACHE dir: /home/ubuntu/.fastled/sccache
+5.58   Debug enabled: False
+5.58 xcache wrapper detected and configured for Python fake compilers
+5.58   xcache path: /workspace/ci/util/xcache.py
+5.58   cache executable: python /workspace/ci/util/xcache.py
+5.58 DEBUG: Found compilers in env:
+5.58   CC: 'riscv32-esp-elf-gcc' (type: str)
+5.58   CXX: 'riscv32-esp-elf-g++' (type: str)
+5.58 Extracted compiler names:
+5.58   CC name: riscv32-esp-elf-gcc
+5.58   CXX name: riscv32-esp-elf-g++
+5.58 Found local compiler cache:
+5.58   Cache file: /workspace/.build/pio/esp32c2/compiler_cache.json
+5.58   Real CC: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-gcc
+5.58   Real CXX: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-g++
+5.58 SUCCESS: Using cached compilers (instant, no platform search needed):
+5.58   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.58   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.58   Platform search skipped - using cached toolset
+5.58 Created Python cached compilers:
+5.58   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.58   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.58 Applied Python fake compilers to both env and projenv
+5.58 Python fake compiler cache enabled: xcache
+5.58   Original CC: riscv32-esp-elf-gcc
+5.58   Original CXX: riscv32-esp-elf-g++
+5.58   Fake CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.58   Fake CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.58 Python fake compiler cache environment configured successfully
+5.68 Retrieved `.pio/build/esp32c2/.dummy/sketch.cpp.o' from cache
+5.68 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-gcc.c.o' from cache
+5.69 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-cpp.cpp.o' from cache
+5.69 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-as.S.o' from cache
+5.70 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.70 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.70   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.70   RET_CODE: no such file or directory
+5.70   ERROR_MESSAGE:
+5.70 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.70 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.70   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.70   RET_CODE: no such file or directory
+5.70   ERROR_MESSAGE:
+5.71 Retrieved `.pio/build/esp32c2/app_trace/app_trace.c.o' from cache
+5.71 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in] Error 1
+5.71 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in] Error 1
+5.86 ========================== [FAILED] Took 5.70 seconds ==========================

--- a/failures/Audio.log
+++ b/failures/Audio.log
@@ -1,0 +1,95 @@
+Initial build failed: 0.14 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.14 --------------------------------------------------------------------------------
+0.47 Verbose mode can be enabled via `-v, --verbose` option
+0.55 Error output: /home/ubuntu/.fastled/compile/pio/esp32c2/penv/bin/python: No module named pip
+0.55 Error: Failed to install Python dependencies into penv
+0.59 ========================== [FAILED] Took 0.45 seconds ==========================
+Initial build failed: 0.16 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.16 --------------------------------------------------------------------------------
+0.47 Verbose mode can be enabled via `-v, --verbose` option
+0.85 CONFIGURATION: https://docs.platformio.org/page/boards/espressif32/esp32-c2-devkitm-1.html
+0.85 PLATFORM: Espressif 32 (55.3.30+develop.sha.9651ee8) > Espressif ESP32-C2-DevKitM-1
+0.85 HARDWARE: ESP32C2 120MHz, 272KB RAM, 4MB Flash
+0.85 DEBUG: Current (cmsis-dap) External (cmsis-dap, esp-bridge, esp-prog, iot-bus-jtag, jlink, minimodule, olimex-arm-usb-ocd, olimex-arm-usb-ocd-h, olimex-arm-usb-tiny-h, olimex-jtag-tiny, tumpa)
+0.85 PACKAGES:
+0.85  - contrib-piohome @ 3.4.4
+0.85  - framework-arduino-c2-skeleton-lib @ 5.5.0+sha.cbe9388f45
+0.85  - framework-arduinoespressif32 @ 3.3.0
+0.85  - framework-arduinoespressif32-libs @ 5.5.0+sha.b66b5448e0
+0.85  - framework-espidf @ 3.50500.0 (5.5.0)
+0.85  - tool-cmake @ 3.30.2
+0.85  - tool-esp-rom-elfs @ 2024.10.11
+0.85  - tool-esptoolpy @ 5.0.2
+0.85  - tool-mklittlefs @ 3.2.0
+0.85  - tool-ninja @ 1.13.1
+0.85  - tool-scons @ 4.40801.0 (4.8.1)
+0.85  - toolchain-riscv32-esp @ 14.2.0+20241119
+0.86 *** Compile Arduino IDF libs for esp32c2 ***
+0.87 *** Add "custom_sdkconfig" settings to IDF sdkconfig.defaults ***
+0.87 Replace: CONFIG_IDF_TARGET="esp32c2" with: CONFIG_IDF_TARGET=esp32c2
+0.87 Replace: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y with: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y
+0.87 Replace: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y with: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y
+0.87 Replace: CONFIG_ESPTOOLPY_FLASHFREQ="60m" with: CONFIG_ESPTOOLPY_FLASHFREQ="60m"
+0.88 Add: # CONFIG_ESPTOOLPY_FLASHFREQ_80M is not set
+0.89 Warning! Arduino framework as an ESP-IDF component doesn't handle the `variant` field! The default `esp32` variant will be used.
+0.89 Reading CMake configuration...
+5.30 Generating assembly for certificate bundle...
+5.46 LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
+5.46 LDF Modes: Finder ~ chain, Compatibility ~ soft
+5.52 Found 42 compatible libraries
+5.52 Scanning dependencies...
+5.52 No dependencies
+5.52 Building in release mode
+5.53 Environment state dumped to: env_dump.json
+5.53 Projenv state dumped to: projenv_dump.json
+5.53 Cache configuration from environment:
+5.53   Cache type: xcache
+5.53   Cache executable: python /workspace/ci/util/xcache.py
+5.53   SCCACHE path: /workspace/.venv/bin/sccache
+5.53   SCCACHE dir: /home/ubuntu/.fastled/sccache
+5.53   Debug enabled: False
+5.53 xcache wrapper detected and configured for Python fake compilers
+5.53   xcache path: /workspace/ci/util/xcache.py
+5.53   cache executable: python /workspace/ci/util/xcache.py
+5.53 DEBUG: Found compilers in env:
+5.53   CC: 'riscv32-esp-elf-gcc' (type: str)
+5.53   CXX: 'riscv32-esp-elf-g++' (type: str)
+5.53 Extracted compiler names:
+5.53   CC name: riscv32-esp-elf-gcc
+5.53   CXX name: riscv32-esp-elf-g++
+5.53 Found local compiler cache:
+5.53   Cache file: /workspace/.build/pio/esp32c2/compiler_cache.json
+5.53   Real CC: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-gcc
+5.53   Real CXX: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-g++
+5.53 SUCCESS: Using cached compilers (instant, no platform search needed):
+5.53   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.53   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.53   Platform search skipped - using cached toolset
+5.53 Created Python cached compilers:
+5.53   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.53   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.53 Applied Python fake compilers to both env and projenv
+5.53 Python fake compiler cache enabled: xcache
+5.53   Original CC: riscv32-esp-elf-gcc
+5.53   Original CXX: riscv32-esp-elf-g++
+5.53   Fake CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.53   Fake CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.53 Python fake compiler cache environment configured successfully
+5.63 Retrieved `.pio/build/esp32c2/.dummy/sketch.cpp.o' from cache
+5.64 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-gcc.c.o' from cache
+5.64 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-cpp.cpp.o' from cache
+5.65 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-as.S.o' from cache
+5.65 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.65 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.65 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.65   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.65   RET_CODE: no such file or directory
+5.65   ERROR_MESSAGE:
+5.65 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.65   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.65   RET_CODE: no such file or directory
+5.65   ERROR_MESSAGE:
+5.66 Retrieved `.pio/build/esp32c2/app_trace/app_trace.c.o' from cache
+5.66 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in] Error 1
+5.66 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in] Error 1
+5.81 ========================== [FAILED] Took 5.64 seconds ==========================

--- a/failures/Blink.log
+++ b/failures/Blink.log
@@ -1,0 +1,95 @@
+Initial build failed: 0.12 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.12 --------------------------------------------------------------------------------
+0.44 Verbose mode can be enabled via `-v, --verbose` option
+0.51 Error output: /home/ubuntu/.fastled/compile/pio/esp32c2/penv/bin/python: No module named pip
+0.51 Error: Failed to install Python dependencies into penv
+0.55 ========================== [FAILED] Took 0.43 seconds ==========================
+Initial build failed: 0.17 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.17 --------------------------------------------------------------------------------
+0.48 Verbose mode can be enabled via `-v, --verbose` option
+0.87 CONFIGURATION: https://docs.platformio.org/page/boards/espressif32/esp32-c2-devkitm-1.html
+0.87 PLATFORM: Espressif 32 (55.3.30+develop.sha.9651ee8) > Espressif ESP32-C2-DevKitM-1
+0.87 HARDWARE: ESP32C2 120MHz, 272KB RAM, 4MB Flash
+0.87 DEBUG: Current (cmsis-dap) External (cmsis-dap, esp-bridge, esp-prog, iot-bus-jtag, jlink, minimodule, olimex-arm-usb-ocd, olimex-arm-usb-ocd-h, olimex-arm-usb-tiny-h, olimex-jtag-tiny, tumpa)
+0.87 PACKAGES:
+0.87  - contrib-piohome @ 3.4.4
+0.87  - framework-arduino-c2-skeleton-lib @ 5.5.0+sha.cbe9388f45
+0.87  - framework-arduinoespressif32 @ 3.3.0
+0.87  - framework-arduinoespressif32-libs @ 5.5.0+sha.b66b5448e0
+0.87  - framework-espidf @ 3.50500.0 (5.5.0)
+0.87  - tool-cmake @ 3.30.2
+0.87  - tool-esp-rom-elfs @ 2024.10.11
+0.87  - tool-esptoolpy @ 5.0.2
+0.87  - tool-mklittlefs @ 3.2.0
+0.87  - tool-ninja @ 1.13.1
+0.87  - tool-scons @ 4.40801.0 (4.8.1)
+0.87  - toolchain-riscv32-esp @ 14.2.0+20241119
+0.87 *** Compile Arduino IDF libs for esp32c2 ***
+0.89 *** Add "custom_sdkconfig" settings to IDF sdkconfig.defaults ***
+0.89 Replace: CONFIG_IDF_TARGET="esp32c2" with: CONFIG_IDF_TARGET=esp32c2
+0.89 Replace: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y with: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y
+0.89 Replace: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y with: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y
+0.89 Replace: CONFIG_ESPTOOLPY_FLASHFREQ="60m" with: CONFIG_ESPTOOLPY_FLASHFREQ="60m"
+0.89 Add: # CONFIG_ESPTOOLPY_FLASHFREQ_80M is not set
+0.90 Warning! Arduino framework as an ESP-IDF component doesn't handle the `variant` field! The default `esp32` variant will be used.
+0.90 Reading CMake configuration...
+5.37 Generating assembly for certificate bundle...
+5.53 LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
+5.53 LDF Modes: Finder ~ chain, Compatibility ~ soft
+5.59 Found 42 compatible libraries
+5.59 Scanning dependencies...
+5.59 No dependencies
+5.59 Building in release mode
+5.60 Environment state dumped to: env_dump.json
+5.60 Projenv state dumped to: projenv_dump.json
+5.60 Cache configuration from environment:
+5.60   Cache type: xcache
+5.60   Cache executable: python /workspace/ci/util/xcache.py
+5.60   SCCACHE path: /workspace/.venv/bin/sccache
+5.60   SCCACHE dir: /home/ubuntu/.fastled/sccache
+5.60   Debug enabled: False
+5.60 xcache wrapper detected and configured for Python fake compilers
+5.60   xcache path: /workspace/ci/util/xcache.py
+5.60   cache executable: python /workspace/ci/util/xcache.py
+5.60 DEBUG: Found compilers in env:
+5.60   CC: 'riscv32-esp-elf-gcc' (type: str)
+5.60   CXX: 'riscv32-esp-elf-g++' (type: str)
+5.60 Extracted compiler names:
+5.60   CC name: riscv32-esp-elf-gcc
+5.60   CXX name: riscv32-esp-elf-g++
+5.60 Found local compiler cache:
+5.60   Cache file: /workspace/.build/pio/esp32c2/compiler_cache.json
+5.60   Real CC: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-gcc
+5.60   Real CXX: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-g++
+5.60 SUCCESS: Using cached compilers (instant, no platform search needed):
+5.60   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.60   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.60   Platform search skipped - using cached toolset
+5.60 Created Python cached compilers:
+5.60   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.60   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.60 Applied Python fake compilers to both env and projenv
+5.60 Python fake compiler cache enabled: xcache
+5.60   Original CC: riscv32-esp-elf-gcc
+5.60   Original CXX: riscv32-esp-elf-g++
+5.60   Fake CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.60   Fake CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.60 Python fake compiler cache environment configured successfully
+5.70 Retrieved `.pio/build/esp32c2/.dummy/sketch.cpp.o' from cache
+5.71 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-gcc.c.o' from cache
+5.71 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-cpp.cpp.o' from cache
+5.72 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-as.S.o' from cache
+5.72 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.73 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.73 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.73   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.73   RET_CODE: no such file or directory
+5.73   ERROR_MESSAGE:
+5.73 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.73   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.73   RET_CODE: no such file or directory
+5.73   ERROR_MESSAGE:
+5.74 Retrieved `.pio/build/esp32c2/app_trace/app_trace.c.o' from cache
+5.74 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in] Error 1
+5.74 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in] Error 1
+5.89 ========================== [FAILED] Took 5.72 seconds ==========================

--- a/failures/BlinkParallel.log
+++ b/failures/BlinkParallel.log
@@ -1,0 +1,90 @@
+Initial build failed: 0.12 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.12 --------------------------------------------------------------------------------
+0.44 Verbose mode can be enabled via `-v, --verbose` option
+0.52 Error output: /home/ubuntu/.fastled/compile/pio/esp32c2/penv/bin/python: No module named pip
+0.52 Error: Failed to install Python dependencies into penv
+0.56 ========================== [FAILED] Took 0.44 seconds ==========================
+Initial build failed: 0.13 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.13 --------------------------------------------------------------------------------
+0.44 Verbose mode can be enabled via `-v, --verbose` option
+0.84 CONFIGURATION: https://docs.platformio.org/page/boards/espressif32/esp32-c2-devkitm-1.html
+0.84 PLATFORM: Espressif 32 (55.3.30+develop.sha.9651ee8) > Espressif ESP32-C2-DevKitM-1
+0.84 HARDWARE: ESP32C2 120MHz, 272KB RAM, 4MB Flash
+0.84 DEBUG: Current (cmsis-dap) External (cmsis-dap, esp-bridge, esp-prog, iot-bus-jtag, jlink, minimodule, olimex-arm-usb-ocd, olimex-arm-usb-ocd-h, olimex-arm-usb-tiny-h, olimex-jtag-tiny, tumpa)
+0.84 PACKAGES:
+0.84  - contrib-piohome @ 3.4.4
+0.84  - framework-arduino-c2-skeleton-lib @ 5.5.0+sha.cbe9388f45
+0.84  - framework-arduinoespressif32 @ 3.3.0
+0.84  - framework-arduinoespressif32-libs @ 5.5.0+sha.b66b5448e0
+0.84  - framework-espidf @ 3.50500.0 (5.5.0)
+0.84  - tool-cmake @ 3.30.2
+0.84  - tool-esp-rom-elfs @ 2024.10.11
+0.84  - tool-esptoolpy @ 5.0.2
+0.84  - tool-mklittlefs @ 3.2.0
+0.84  - tool-ninja @ 1.13.1
+0.84  - tool-scons @ 4.40801.0 (4.8.1)
+0.84  - toolchain-riscv32-esp @ 14.2.0+20241119
+0.85 *** Compile Arduino IDF libs for esp32c2 ***
+0.87 *** Add "custom_sdkconfig" settings to IDF sdkconfig.defaults ***
+0.87 Replace: CONFIG_IDF_TARGET="esp32c2" with: CONFIG_IDF_TARGET=esp32c2
+0.87 Replace: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y with: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y
+0.87 Replace: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y with: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y
+0.87 Replace: CONFIG_ESPTOOLPY_FLASHFREQ="60m" with: CONFIG_ESPTOOLPY_FLASHFREQ="60m"
+0.87 Add: # CONFIG_ESPTOOLPY_FLASHFREQ_80M is not set
+0.88 Warning! Arduino framework as an ESP-IDF component doesn't handle the `variant` field! The default `esp32` variant will be used.
+0.88 Reading CMake configuration...
+5.05 LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
+5.05 LDF Modes: Finder ~ chain, Compatibility ~ soft
+5.11 Found 42 compatible libraries
+5.11 Scanning dependencies...
+5.11 No dependencies
+5.11 Building in release mode
+5.12 Environment state dumped to: env_dump.json
+5.12 Projenv state dumped to: projenv_dump.json
+5.12 Cache configuration from environment:
+5.12   Cache type: xcache
+5.12   Cache executable: python /workspace/ci/util/xcache.py
+5.12   SCCACHE path: /workspace/.venv/bin/sccache
+5.12   SCCACHE dir: /home/ubuntu/.fastled/sccache
+5.12   Debug enabled: False
+5.12 xcache wrapper detected and configured for Python fake compilers
+5.12   xcache path: /workspace/ci/util/xcache.py
+5.12   cache executable: python /workspace/ci/util/xcache.py
+5.12 DEBUG: Found compilers in env:
+5.12   CC: 'riscv32-esp-elf-gcc' (type: str)
+5.12   CXX: 'riscv32-esp-elf-g++' (type: str)
+5.12 Extracted compiler names:
+5.12   CC name: riscv32-esp-elf-gcc
+5.12   CXX name: riscv32-esp-elf-g++
+5.12 Found local compiler cache:
+5.12   Cache file: /workspace/.build/pio/esp32c2/compiler_cache.json
+5.12   Real CC: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-gcc
+5.12   Real CXX: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-g++
+5.12 SUCCESS: Using cached compilers (instant, no platform search needed):
+5.12   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.12   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.12   Platform search skipped - using cached toolset
+5.12 Created Python cached compilers:
+5.12   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.12   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.12 Applied Python fake compilers to both env and projenv
+5.12 Python fake compiler cache enabled: xcache
+5.12   Original CC: riscv32-esp-elf-gcc
+5.12   Original CXX: riscv32-esp-elf-g++
+5.12   Fake CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.12   Fake CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.12 Python fake compiler cache environment configured successfully
+5.15 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.16 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.16 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.16   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.16   RET_CODE: no such file or directory
+5.16   ERROR_MESSAGE:
+5.16 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.16   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.16   RET_CODE: no such file or directory
+5.16   ERROR_MESSAGE:
+5.18 Retrieved `.pio/build/esp32c2/app_trace/app_trace_util.c.o' from cache
+5.18 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in] Error 1
+5.18 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in] Error 1
+5.32 ========================== [FAILED] Took 5.19 seconds ==========================

--- a/failures/Blur.log
+++ b/failures/Blur.log
@@ -1,0 +1,90 @@
+Initial build failed: 0.12 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.12 --------------------------------------------------------------------------------
+0.42 Verbose mode can be enabled via `-v, --verbose` option
+0.50 Error: Failed to install Python dependencies into penv
+0.50 Error output: /home/ubuntu/.fastled/compile/pio/esp32c2/penv/bin/python: No module named pip
+0.54 ========================== [FAILED] Took 0.41 seconds ==========================
+Initial build failed: 0.13 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.13 --------------------------------------------------------------------------------
+0.45 Verbose mode can be enabled via `-v, --verbose` option
+0.90 CONFIGURATION: https://docs.platformio.org/page/boards/espressif32/esp32-c2-devkitm-1.html
+0.90 PLATFORM: Espressif 32 (55.3.30+develop.sha.9651ee8) > Espressif ESP32-C2-DevKitM-1
+0.90 HARDWARE: ESP32C2 120MHz, 272KB RAM, 4MB Flash
+0.90 DEBUG: Current (cmsis-dap) External (cmsis-dap, esp-bridge, esp-prog, iot-bus-jtag, jlink, minimodule, olimex-arm-usb-ocd, olimex-arm-usb-ocd-h, olimex-arm-usb-tiny-h, olimex-jtag-tiny, tumpa)
+0.90 PACKAGES:
+0.90  - contrib-piohome @ 3.4.4
+0.90  - framework-arduino-c2-skeleton-lib @ 5.5.0+sha.cbe9388f45
+0.90  - framework-arduinoespressif32 @ 3.3.0
+0.90  - framework-arduinoespressif32-libs @ 5.5.0+sha.b66b5448e0
+0.90  - framework-espidf @ 3.50500.0 (5.5.0)
+0.90  - tool-cmake @ 3.30.2
+0.90  - tool-esp-rom-elfs @ 2024.10.11
+0.90  - tool-esptoolpy @ 5.0.2
+0.90  - tool-mklittlefs @ 3.2.0
+0.90  - tool-ninja @ 1.13.1
+0.90  - tool-scons @ 4.40801.0 (4.8.1)
+0.90  - toolchain-riscv32-esp @ 14.2.0+20241119
+0.90 *** Compile Arduino IDF libs for esp32c2 ***
+0.92 *** Add "custom_sdkconfig" settings to IDF sdkconfig.defaults ***
+0.92 Replace: CONFIG_IDF_TARGET="esp32c2" with: CONFIG_IDF_TARGET=esp32c2
+0.92 Replace: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y with: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y
+0.92 Replace: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y with: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y
+0.92 Replace: CONFIG_ESPTOOLPY_FLASHFREQ="60m" with: CONFIG_ESPTOOLPY_FLASHFREQ="60m"
+0.93 Add: # CONFIG_ESPTOOLPY_FLASHFREQ_80M is not set
+0.94 Warning! Arduino framework as an ESP-IDF component doesn't handle the `variant` field! The default `esp32` variant will be used.
+0.94 Reading CMake configuration...
+5.03 LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
+5.03 LDF Modes: Finder ~ chain, Compatibility ~ soft
+5.09 Found 42 compatible libraries
+5.09 Scanning dependencies...
+5.09 No dependencies
+5.10 Building in release mode
+5.10 Environment state dumped to: env_dump.json
+5.10 Projenv state dumped to: projenv_dump.json
+5.10 Cache configuration from environment:
+5.10   Cache type: xcache
+5.10   Cache executable: python /workspace/ci/util/xcache.py
+5.10   SCCACHE path: /workspace/.venv/bin/sccache
+5.10   SCCACHE dir: /home/ubuntu/.fastled/sccache
+5.10   Debug enabled: False
+5.10 xcache wrapper detected and configured for Python fake compilers
+5.10   xcache path: /workspace/ci/util/xcache.py
+5.10   cache executable: python /workspace/ci/util/xcache.py
+5.10 DEBUG: Found compilers in env:
+5.10   CC: 'riscv32-esp-elf-gcc' (type: str)
+5.10   CXX: 'riscv32-esp-elf-g++' (type: str)
+5.10 Extracted compiler names:
+5.10   CC name: riscv32-esp-elf-gcc
+5.10   CXX name: riscv32-esp-elf-g++
+5.10 Found local compiler cache:
+5.10   Cache file: /workspace/.build/pio/esp32c2/compiler_cache.json
+5.10   Real CC: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-gcc
+5.10   Real CXX: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-g++
+5.10 SUCCESS: Using cached compilers (instant, no platform search needed):
+5.10   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.10   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.10   Platform search skipped - using cached toolset
+5.10 Created Python cached compilers:
+5.10   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.10   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.10 Applied Python fake compilers to both env and projenv
+5.10 Python fake compiler cache enabled: xcache
+5.10   Original CC: riscv32-esp-elf-gcc
+5.10   Original CXX: riscv32-esp-elf-g++
+5.10   Fake CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.10   Fake CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.10 Python fake compiler cache environment configured successfully
+5.14 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.14 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.14 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.14   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.14   RET_CODE: no such file or directory
+5.14   ERROR_MESSAGE:
+5.14 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.14   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.14   RET_CODE: no such file or directory
+5.14   ERROR_MESSAGE:
+5.16 Retrieved `.pio/build/esp32c2/app_trace/host_file_io.c.o' from cache
+5.16 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in] Error 1
+5.16 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in] Error 1
+5.30 ========================== [FAILED] Took 5.17 seconds ==========================

--- a/failures/Blur2d.log
+++ b/failures/Blur2d.log
@@ -1,0 +1,90 @@
+Initial build failed: 0.12 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.12 --------------------------------------------------------------------------------
+0.45 Verbose mode can be enabled via `-v, --verbose` option
+0.52 Error output: /home/ubuntu/.fastled/compile/pio/esp32c2/penv/bin/python: No module named pip
+0.52 Error: Failed to install Python dependencies into penv
+0.56 ========================== [FAILED] Took 0.44 seconds ==========================
+Initial build failed: 0.13 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.13 --------------------------------------------------------------------------------
+0.44 Verbose mode can be enabled via `-v, --verbose` option
+0.82 CONFIGURATION: https://docs.platformio.org/page/boards/espressif32/esp32-c2-devkitm-1.html
+0.82 PLATFORM: Espressif 32 (55.3.30+develop.sha.9651ee8) > Espressif ESP32-C2-DevKitM-1
+0.82 HARDWARE: ESP32C2 120MHz, 272KB RAM, 4MB Flash
+0.82 DEBUG: Current (cmsis-dap) External (cmsis-dap, esp-bridge, esp-prog, iot-bus-jtag, jlink, minimodule, olimex-arm-usb-ocd, olimex-arm-usb-ocd-h, olimex-arm-usb-tiny-h, olimex-jtag-tiny, tumpa)
+0.82 PACKAGES:
+0.82  - contrib-piohome @ 3.4.4
+0.82  - framework-arduino-c2-skeleton-lib @ 5.5.0+sha.cbe9388f45
+0.82  - framework-arduinoespressif32 @ 3.3.0
+0.82  - framework-arduinoespressif32-libs @ 5.5.0+sha.b66b5448e0
+0.82  - framework-espidf @ 3.50500.0 (5.5.0)
+0.82  - tool-cmake @ 3.30.2
+0.82  - tool-esp-rom-elfs @ 2024.10.11
+0.82  - tool-esptoolpy @ 5.0.2
+0.82  - tool-mklittlefs @ 3.2.0
+0.82  - tool-ninja @ 1.13.1
+0.82  - tool-scons @ 4.40801.0 (4.8.1)
+0.82  - toolchain-riscv32-esp @ 14.2.0+20241119
+0.83 *** Compile Arduino IDF libs for esp32c2 ***
+0.84 *** Add "custom_sdkconfig" settings to IDF sdkconfig.defaults ***
+0.85 Replace: CONFIG_IDF_TARGET="esp32c2" with: CONFIG_IDF_TARGET=esp32c2
+0.85 Replace: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y with: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y
+0.85 Replace: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y with: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y
+0.85 Replace: CONFIG_ESPTOOLPY_FLASHFREQ="60m" with: CONFIG_ESPTOOLPY_FLASHFREQ="60m"
+0.85 Add: # CONFIG_ESPTOOLPY_FLASHFREQ_80M is not set
+0.86 Warning! Arduino framework as an ESP-IDF component doesn't handle the `variant` field! The default `esp32` variant will be used.
+0.86 Reading CMake configuration...
+4.92 LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
+4.92 LDF Modes: Finder ~ chain, Compatibility ~ soft
+4.98 Found 42 compatible libraries
+4.98 Scanning dependencies...
+4.98 No dependencies
+4.98 Building in release mode
+4.99 Environment state dumped to: env_dump.json
+4.99 Projenv state dumped to: projenv_dump.json
+4.99 Cache configuration from environment:
+4.99   Cache type: xcache
+4.99   Cache executable: python /workspace/ci/util/xcache.py
+4.99   SCCACHE path: /workspace/.venv/bin/sccache
+4.99   SCCACHE dir: /home/ubuntu/.fastled/sccache
+4.99   Debug enabled: False
+4.99 xcache wrapper detected and configured for Python fake compilers
+4.99   xcache path: /workspace/ci/util/xcache.py
+4.99   cache executable: python /workspace/ci/util/xcache.py
+4.99 DEBUG: Found compilers in env:
+4.99   CC: 'riscv32-esp-elf-gcc' (type: str)
+4.99   CXX: 'riscv32-esp-elf-g++' (type: str)
+4.99 Extracted compiler names:
+4.99   CC name: riscv32-esp-elf-gcc
+4.99   CXX name: riscv32-esp-elf-g++
+4.99 Found local compiler cache:
+4.99   Cache file: /workspace/.build/pio/esp32c2/compiler_cache.json
+4.99   Real CC: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-gcc
+4.99   Real CXX: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-g++
+4.99 SUCCESS: Using cached compilers (instant, no platform search needed):
+4.99   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+4.99   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+4.99   Platform search skipped - using cached toolset
+4.99 Created Python cached compilers:
+4.99   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+4.99   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+4.99 Applied Python fake compilers to both env and projenv
+4.99 Python fake compiler cache enabled: xcache
+4.99   Original CC: riscv32-esp-elf-gcc
+4.99   Original CXX: riscv32-esp-elf-g++
+4.99   Fake CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+4.99   Fake CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+4.99 Python fake compiler cache environment configured successfully
+5.02 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.03 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.03 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.03   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.03   RET_CODE: no such file or directory
+5.03   ERROR_MESSAGE:
+5.03 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.03   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.03   RET_CODE: no such file or directory
+5.03   ERROR_MESSAGE:
+5.05 Retrieved `.pio/build/esp32c2/app_trace/port/port_uart.c.o' from cache
+5.05 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in] Error 1
+5.05 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in] Error 1
+5.20 ========================== [FAILED] Took 5.07 seconds ==========================

--- a/failures/Chromancer.log
+++ b/failures/Chromancer.log
@@ -1,0 +1,95 @@
+Initial build failed: 0.13 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.13 --------------------------------------------------------------------------------
+0.43 Verbose mode can be enabled via `-v, --verbose` option
+0.52 Error output: /home/ubuntu/.fastled/compile/pio/esp32c2/penv/bin/python: No module named pip
+0.52 Error: Failed to install Python dependencies into penv
+0.55 ========================== [FAILED] Took 0.43 seconds ==========================
+Initial build failed: 0.17 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.17 --------------------------------------------------------------------------------
+0.48 Verbose mode can be enabled via `-v, --verbose` option
+0.87 CONFIGURATION: https://docs.platformio.org/page/boards/espressif32/esp32-c2-devkitm-1.html
+0.87 PLATFORM: Espressif 32 (55.3.30+develop.sha.9651ee8) > Espressif ESP32-C2-DevKitM-1
+0.87 HARDWARE: ESP32C2 120MHz, 272KB RAM, 4MB Flash
+0.87 DEBUG: Current (cmsis-dap) External (cmsis-dap, esp-bridge, esp-prog, iot-bus-jtag, jlink, minimodule, olimex-arm-usb-ocd, olimex-arm-usb-ocd-h, olimex-arm-usb-tiny-h, olimex-jtag-tiny, tumpa)
+0.87 PACKAGES:
+0.87  - contrib-piohome @ 3.4.4
+0.87  - framework-arduino-c2-skeleton-lib @ 5.5.0+sha.cbe9388f45
+0.87  - framework-arduinoespressif32 @ 3.3.0
+0.87  - framework-arduinoespressif32-libs @ 5.5.0+sha.b66b5448e0
+0.87  - framework-espidf @ 3.50500.0 (5.5.0)
+0.87  - tool-cmake @ 3.30.2
+0.87  - tool-esp-rom-elfs @ 2024.10.11
+0.87  - tool-esptoolpy @ 5.0.2
+0.87  - tool-mklittlefs @ 3.2.0
+0.87  - tool-ninja @ 1.13.1
+0.87  - tool-scons @ 4.40801.0 (4.8.1)
+0.87  - toolchain-riscv32-esp @ 14.2.0+20241119
+0.87 *** Compile Arduino IDF libs for esp32c2 ***
+0.89 *** Add "custom_sdkconfig" settings to IDF sdkconfig.defaults ***
+0.89 Replace: CONFIG_IDF_TARGET="esp32c2" with: CONFIG_IDF_TARGET=esp32c2
+0.89 Replace: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y with: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y
+0.89 Replace: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y with: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y
+0.89 Replace: CONFIG_ESPTOOLPY_FLASHFREQ="60m" with: CONFIG_ESPTOOLPY_FLASHFREQ="60m"
+0.89 Add: # CONFIG_ESPTOOLPY_FLASHFREQ_80M is not set
+0.90 Warning! Arduino framework as an ESP-IDF component doesn't handle the `variant` field! The default `esp32` variant will be used.
+0.90 Reading CMake configuration...
+5.28 Generating assembly for certificate bundle...
+5.44 LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
+5.44 LDF Modes: Finder ~ chain, Compatibility ~ soft
+5.50 Found 42 compatible libraries
+5.50 Scanning dependencies...
+5.50 No dependencies
+5.50 Building in release mode
+5.51 Environment state dumped to: env_dump.json
+5.51 Projenv state dumped to: projenv_dump.json
+5.51 Cache configuration from environment:
+5.51   Cache type: xcache
+5.51   Cache executable: python /workspace/ci/util/xcache.py
+5.51   SCCACHE path: /workspace/.venv/bin/sccache
+5.51   SCCACHE dir: /home/ubuntu/.fastled/sccache
+5.51   Debug enabled: False
+5.51 xcache wrapper detected and configured for Python fake compilers
+5.51   xcache path: /workspace/ci/util/xcache.py
+5.51   cache executable: python /workspace/ci/util/xcache.py
+5.51 DEBUG: Found compilers in env:
+5.51   CC: 'riscv32-esp-elf-gcc' (type: str)
+5.51   CXX: 'riscv32-esp-elf-g++' (type: str)
+5.51 Extracted compiler names:
+5.51   CC name: riscv32-esp-elf-gcc
+5.51   CXX name: riscv32-esp-elf-g++
+5.51 Found local compiler cache:
+5.51   Cache file: /workspace/.build/pio/esp32c2/compiler_cache.json
+5.51   Real CC: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-gcc
+5.51   Real CXX: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-g++
+5.51 SUCCESS: Using cached compilers (instant, no platform search needed):
+5.51   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.51   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.51   Platform search skipped - using cached toolset
+5.51 Created Python cached compilers:
+5.51   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.51   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.51 Applied Python fake compilers to both env and projenv
+5.51 Python fake compiler cache enabled: xcache
+5.51   Original CC: riscv32-esp-elf-gcc
+5.51   Original CXX: riscv32-esp-elf-g++
+5.51   Fake CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.51   Fake CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.51 Python fake compiler cache environment configured successfully
+5.61 Retrieved `.pio/build/esp32c2/.dummy/sketch.cpp.o' from cache
+5.62 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-gcc.c.o' from cache
+5.62 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-cpp.cpp.o' from cache
+5.63 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-as.S.o' from cache
+5.63 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.63 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.63 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.63   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.63   RET_CODE: no such file or directory
+5.63   ERROR_MESSAGE:
+5.64 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.64   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.64   RET_CODE: no such file or directory
+5.64   ERROR_MESSAGE:
+5.65 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in] Error 1
+5.65 Retrieved `.pio/build/esp32c2/app_trace/app_trace.c.o' from cache
+5.65 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in] Error 1
+5.79 ========================== [FAILED] Took 5.62 seconds ==========================

--- a/failures/ColorBoost.log
+++ b/failures/ColorBoost.log
@@ -1,0 +1,95 @@
+Initial build failed: 0.12 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.12 --------------------------------------------------------------------------------
+0.44 Verbose mode can be enabled via `-v, --verbose` option
+0.51 Error output: /home/ubuntu/.fastled/compile/pio/esp32c2/penv/bin/python: No module named pip
+0.51 Error: Failed to install Python dependencies into penv
+0.55 ========================== [FAILED] Took 0.43 seconds ==========================
+Initial build failed: 0.16 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.16 --------------------------------------------------------------------------------
+0.48 Verbose mode can be enabled via `-v, --verbose` option
+0.88 CONFIGURATION: https://docs.platformio.org/page/boards/espressif32/esp32-c2-devkitm-1.html
+0.88 PLATFORM: Espressif 32 (55.3.30+develop.sha.9651ee8) > Espressif ESP32-C2-DevKitM-1
+0.88 HARDWARE: ESP32C2 120MHz, 272KB RAM, 4MB Flash
+0.88 DEBUG: Current (cmsis-dap) External (cmsis-dap, esp-bridge, esp-prog, iot-bus-jtag, jlink, minimodule, olimex-arm-usb-ocd, olimex-arm-usb-ocd-h, olimex-arm-usb-tiny-h, olimex-jtag-tiny, tumpa)
+0.88 PACKAGES:
+0.88  - contrib-piohome @ 3.4.4
+0.88  - framework-arduino-c2-skeleton-lib @ 5.5.0+sha.cbe9388f45
+0.88  - framework-arduinoespressif32 @ 3.3.0
+0.88  - framework-arduinoespressif32-libs @ 5.5.0+sha.b66b5448e0
+0.88  - framework-espidf @ 3.50500.0 (5.5.0)
+0.88  - tool-cmake @ 3.30.2
+0.88  - tool-esp-rom-elfs @ 2024.10.11
+0.88  - tool-esptoolpy @ 5.0.2
+0.88  - tool-mklittlefs @ 3.2.0
+0.88  - tool-ninja @ 1.13.1
+0.88  - tool-scons @ 4.40801.0 (4.8.1)
+0.88  - toolchain-riscv32-esp @ 14.2.0+20241119
+0.88 *** Compile Arduino IDF libs for esp32c2 ***
+0.90 *** Add "custom_sdkconfig" settings to IDF sdkconfig.defaults ***
+0.90 Replace: CONFIG_IDF_TARGET="esp32c2" with: CONFIG_IDF_TARGET=esp32c2
+0.90 Replace: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y with: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y
+0.90 Replace: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y with: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y
+0.90 Replace: CONFIG_ESPTOOLPY_FLASHFREQ="60m" with: CONFIG_ESPTOOLPY_FLASHFREQ="60m"
+0.90 Add: # CONFIG_ESPTOOLPY_FLASHFREQ_80M is not set
+0.91 Warning! Arduino framework as an ESP-IDF component doesn't handle the `variant` field! The default `esp32` variant will be used.
+0.91 Reading CMake configuration...
+5.32 Generating assembly for certificate bundle...
+5.48 LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
+5.48 LDF Modes: Finder ~ chain, Compatibility ~ soft
+5.54 Found 42 compatible libraries
+5.54 Scanning dependencies...
+5.54 No dependencies
+5.54 Building in release mode
+5.55 Environment state dumped to: env_dump.json
+5.55 Projenv state dumped to: projenv_dump.json
+5.55 Cache configuration from environment:
+5.55   Cache type: xcache
+5.55   Cache executable: python /workspace/ci/util/xcache.py
+5.55   SCCACHE path: /workspace/.venv/bin/sccache
+5.55   SCCACHE dir: /home/ubuntu/.fastled/sccache
+5.55   Debug enabled: False
+5.55 xcache wrapper detected and configured for Python fake compilers
+5.55   xcache path: /workspace/ci/util/xcache.py
+5.55   cache executable: python /workspace/ci/util/xcache.py
+5.55 DEBUG: Found compilers in env:
+5.55   CC: 'riscv32-esp-elf-gcc' (type: str)
+5.55   CXX: 'riscv32-esp-elf-g++' (type: str)
+5.55 Extracted compiler names:
+5.55   CC name: riscv32-esp-elf-gcc
+5.55   CXX name: riscv32-esp-elf-g++
+5.55 Found local compiler cache:
+5.55   Cache file: /workspace/.build/pio/esp32c2/compiler_cache.json
+5.55   Real CC: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-gcc
+5.55   Real CXX: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-g++
+5.55 SUCCESS: Using cached compilers (instant, no platform search needed):
+5.55   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.55   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.55   Platform search skipped - using cached toolset
+5.55 Created Python cached compilers:
+5.55   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.55   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.55 Applied Python fake compilers to both env and projenv
+5.55 Python fake compiler cache enabled: xcache
+5.55   Original CC: riscv32-esp-elf-gcc
+5.55   Original CXX: riscv32-esp-elf-g++
+5.55   Fake CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.55   Fake CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.55 Python fake compiler cache environment configured successfully
+5.65 Retrieved `.pio/build/esp32c2/.dummy/sketch.cpp.o' from cache
+5.66 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-gcc.c.o' from cache
+5.66 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-cpp.cpp.o' from cache
+5.67 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-as.S.o' from cache
+5.67 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.67 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.67 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.67   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.67   RET_CODE: no such file or directory
+5.67   ERROR_MESSAGE:
+5.68 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.68   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.68   RET_CODE: no such file or directory
+5.68   ERROR_MESSAGE:
+5.69 Retrieved `.pio/build/esp32c2/app_trace/app_trace.c.o' from cache
+5.69 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in] Error 1
+5.69 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in] Error 1
+5.82 ========================== [FAILED] Took 5.66 seconds ==========================

--- a/failures/ColorPalette.log
+++ b/failures/ColorPalette.log
@@ -1,0 +1,95 @@
+Initial build failed: 0.13 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.13 --------------------------------------------------------------------------------
+0.43 Verbose mode can be enabled via `-v, --verbose` option
+0.51 Error output: /home/ubuntu/.fastled/compile/pio/esp32c2/penv/bin/python: No module named pip
+0.51 Error: Failed to install Python dependencies into penv
+0.55 ========================== [FAILED] Took 0.42 seconds ==========================
+Initial build failed: 0.16 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.16 --------------------------------------------------------------------------------
+0.47 Verbose mode can be enabled via `-v, --verbose` option
+1.01 CONFIGURATION: https://docs.platformio.org/page/boards/espressif32/esp32-c2-devkitm-1.html
+1.01 PLATFORM: Espressif 32 (55.3.30+develop.sha.9651ee8) > Espressif ESP32-C2-DevKitM-1
+1.01 HARDWARE: ESP32C2 120MHz, 272KB RAM, 4MB Flash
+1.01 DEBUG: Current (cmsis-dap) External (cmsis-dap, esp-bridge, esp-prog, iot-bus-jtag, jlink, minimodule, olimex-arm-usb-ocd, olimex-arm-usb-ocd-h, olimex-arm-usb-tiny-h, olimex-jtag-tiny, tumpa)
+1.01 PACKAGES:
+1.01  - contrib-piohome @ 3.4.4
+1.01  - framework-arduino-c2-skeleton-lib @ 5.5.0+sha.cbe9388f45
+1.01  - framework-arduinoespressif32 @ 3.3.0
+1.01  - framework-arduinoespressif32-libs @ 5.5.0+sha.b66b5448e0
+1.01  - framework-espidf @ 3.50500.0 (5.5.0)
+1.01  - tool-cmake @ 3.30.2
+1.01  - tool-esp-rom-elfs @ 2024.10.11
+1.01  - tool-esptoolpy @ 5.0.2
+1.01  - tool-mklittlefs @ 3.2.0
+1.01  - tool-ninja @ 1.13.1
+1.01  - tool-scons @ 4.40801.0 (4.8.1)
+1.01  - toolchain-riscv32-esp @ 14.2.0+20241119
+1.01 *** Compile Arduino IDF libs for esp32c2 ***
+1.03 *** Add "custom_sdkconfig" settings to IDF sdkconfig.defaults ***
+1.03 Replace: CONFIG_IDF_TARGET="esp32c2" with: CONFIG_IDF_TARGET=esp32c2
+1.03 Replace: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y with: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y
+1.03 Replace: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y with: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y
+1.03 Replace: CONFIG_ESPTOOLPY_FLASHFREQ="60m" with: CONFIG_ESPTOOLPY_FLASHFREQ="60m"
+1.03 Add: # CONFIG_ESPTOOLPY_FLASHFREQ_80M is not set
+1.04 Warning! Arduino framework as an ESP-IDF component doesn't handle the `variant` field! The default `esp32` variant will be used.
+1.04 Reading CMake configuration...
+5.45 Generating assembly for certificate bundle...
+5.60 LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
+5.60 LDF Modes: Finder ~ chain, Compatibility ~ soft
+5.66 Found 42 compatible libraries
+5.66 Scanning dependencies...
+5.66 No dependencies
+5.67 Building in release mode
+5.67 Environment state dumped to: env_dump.json
+5.68 Projenv state dumped to: projenv_dump.json
+5.68 Cache configuration from environment:
+5.68   Cache type: xcache
+5.68   Cache executable: python /workspace/ci/util/xcache.py
+5.68   SCCACHE path: /workspace/.venv/bin/sccache
+5.68   SCCACHE dir: /home/ubuntu/.fastled/sccache
+5.68   Debug enabled: False
+5.68 xcache wrapper detected and configured for Python fake compilers
+5.68   xcache path: /workspace/ci/util/xcache.py
+5.68   cache executable: python /workspace/ci/util/xcache.py
+5.68 DEBUG: Found compilers in env:
+5.68   CC: 'riscv32-esp-elf-gcc' (type: str)
+5.68   CXX: 'riscv32-esp-elf-g++' (type: str)
+5.68 Extracted compiler names:
+5.68   CC name: riscv32-esp-elf-gcc
+5.68   CXX name: riscv32-esp-elf-g++
+5.68 Found local compiler cache:
+5.68   Cache file: /workspace/.build/pio/esp32c2/compiler_cache.json
+5.68   Real CC: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-gcc
+5.68   Real CXX: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-g++
+5.68 SUCCESS: Using cached compilers (instant, no platform search needed):
+5.68   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.68   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.68   Platform search skipped - using cached toolset
+5.68 Created Python cached compilers:
+5.68   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.68   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.68 Applied Python fake compilers to both env and projenv
+5.68 Python fake compiler cache enabled: xcache
+5.68   Original CC: riscv32-esp-elf-gcc
+5.68   Original CXX: riscv32-esp-elf-g++
+5.68   Fake CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.68   Fake CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.68 Python fake compiler cache environment configured successfully
+5.78 Retrieved `.pio/build/esp32c2/.dummy/sketch.cpp.o' from cache
+5.78 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-gcc.c.o' from cache
+5.79 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-cpp.cpp.o' from cache
+5.79 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-as.S.o' from cache
+5.80 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.80 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.80   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.80   RET_CODE: no such file or directory
+5.80   ERROR_MESSAGE:
+5.80 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.80 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.80   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.80   RET_CODE: no such file or directory
+5.80   ERROR_MESSAGE:
+5.81 Retrieved `.pio/build/esp32c2/app_trace/app_trace.c.o' from cache
+5.81 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in] Error 1
+5.81 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in] Error 1
+5.95 ========================== [FAILED] Took 5.79 seconds ==========================

--- a/failures/ColorTemperature.log
+++ b/failures/ColorTemperature.log
@@ -1,0 +1,90 @@
+Initial build failed: 0.12 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.12 --------------------------------------------------------------------------------
+0.43 Verbose mode can be enabled via `-v, --verbose` option
+0.51 Error output: /home/ubuntu/.fastled/compile/pio/esp32c2/penv/bin/python: No module named pip
+0.51 Error: Failed to install Python dependencies into penv
+0.55 ========================== [FAILED] Took 0.43 seconds ==========================
+Initial build failed: 0.13 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.13 --------------------------------------------------------------------------------
+0.44 Verbose mode can be enabled via `-v, --verbose` option
+0.87 CONFIGURATION: https://docs.platformio.org/page/boards/espressif32/esp32-c2-devkitm-1.html
+0.87 PLATFORM: Espressif 32 (55.3.30+develop.sha.9651ee8) > Espressif ESP32-C2-DevKitM-1
+0.87 HARDWARE: ESP32C2 120MHz, 272KB RAM, 4MB Flash
+0.87 DEBUG: Current (cmsis-dap) External (cmsis-dap, esp-bridge, esp-prog, iot-bus-jtag, jlink, minimodule, olimex-arm-usb-ocd, olimex-arm-usb-ocd-h, olimex-arm-usb-tiny-h, olimex-jtag-tiny, tumpa)
+0.87 PACKAGES:
+0.87  - contrib-piohome @ 3.4.4
+0.87  - framework-arduino-c2-skeleton-lib @ 5.5.0+sha.cbe9388f45
+0.87  - framework-arduinoespressif32 @ 3.3.0
+0.87  - framework-arduinoespressif32-libs @ 5.5.0+sha.b66b5448e0
+0.87  - framework-espidf @ 3.50500.0 (5.5.0)
+0.87  - tool-cmake @ 3.30.2
+0.87  - tool-esp-rom-elfs @ 2024.10.11
+0.87  - tool-esptoolpy @ 5.0.2
+0.87  - tool-mklittlefs @ 3.2.0
+0.87  - tool-ninja @ 1.13.1
+0.87  - tool-scons @ 4.40801.0 (4.8.1)
+0.87  - toolchain-riscv32-esp @ 14.2.0+20241119
+0.88 *** Compile Arduino IDF libs for esp32c2 ***
+0.90 *** Add "custom_sdkconfig" settings to IDF sdkconfig.defaults ***
+0.90 Replace: CONFIG_IDF_TARGET="esp32c2" with: CONFIG_IDF_TARGET=esp32c2
+0.90 Replace: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y with: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y
+0.90 Replace: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y with: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y
+0.90 Replace: CONFIG_ESPTOOLPY_FLASHFREQ="60m" with: CONFIG_ESPTOOLPY_FLASHFREQ="60m"
+0.90 Add: # CONFIG_ESPTOOLPY_FLASHFREQ_80M is not set
+0.91 Warning! Arduino framework as an ESP-IDF component doesn't handle the `variant` field! The default `esp32` variant will be used.
+0.91 Reading CMake configuration...
+5.05 LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
+5.05 LDF Modes: Finder ~ chain, Compatibility ~ soft
+5.11 Found 42 compatible libraries
+5.11 Scanning dependencies...
+5.11 No dependencies
+5.11 Building in release mode
+5.12 Environment state dumped to: env_dump.json
+5.12 Projenv state dumped to: projenv_dump.json
+5.12 Cache configuration from environment:
+5.12   Cache type: xcache
+5.12   Cache executable: python /workspace/ci/util/xcache.py
+5.12   SCCACHE path: /workspace/.venv/bin/sccache
+5.12   SCCACHE dir: /home/ubuntu/.fastled/sccache
+5.12   Debug enabled: False
+5.12 xcache wrapper detected and configured for Python fake compilers
+5.12   xcache path: /workspace/ci/util/xcache.py
+5.12   cache executable: python /workspace/ci/util/xcache.py
+5.12 DEBUG: Found compilers in env:
+5.12   CC: 'riscv32-esp-elf-gcc' (type: str)
+5.12   CXX: 'riscv32-esp-elf-g++' (type: str)
+5.12 Extracted compiler names:
+5.12   CC name: riscv32-esp-elf-gcc
+5.12   CXX name: riscv32-esp-elf-g++
+5.12 Found local compiler cache:
+5.12   Cache file: /workspace/.build/pio/esp32c2/compiler_cache.json
+5.12   Real CC: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-gcc
+5.12   Real CXX: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-g++
+5.12 SUCCESS: Using cached compilers (instant, no platform search needed):
+5.12   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.12   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.12   Platform search skipped - using cached toolset
+5.12 Created Python cached compilers:
+5.12   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.12   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.12 Applied Python fake compilers to both env and projenv
+5.12 Python fake compiler cache enabled: xcache
+5.12   Original CC: riscv32-esp-elf-gcc
+5.12   Original CXX: riscv32-esp-elf-g++
+5.12   Fake CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.12   Fake CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.12 Python fake compiler cache environment configured successfully
+5.16 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.16 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.16 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.16   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.16   RET_CODE: no such file or directory
+5.16   ERROR_MESSAGE:
+5.16 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.16   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.16   RET_CODE: no such file or directory
+5.16   ERROR_MESSAGE:
+5.18 Retrieved `.pio/build/esp32c2/app_trace/app_trace_util.c.o' from cache
+5.18 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in] Error 1
+5.18 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in] Error 1
+5.33 ========================== [FAILED] Took 5.20 seconds ==========================

--- a/failures/Corkscrew.log
+++ b/failures/Corkscrew.log
@@ -1,0 +1,95 @@
+Initial build failed: 0.13 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.13 --------------------------------------------------------------------------------
+0.55 Verbose mode can be enabled via `-v, --verbose` option
+0.62 Error output: /home/ubuntu/.fastled/compile/pio/esp32c2/penv/bin/python: No module named pip
+0.62 Error: Failed to install Python dependencies into penv
+0.66 ========================== [FAILED] Took 0.53 seconds ==========================
+Initial build failed: 0.16 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.16 --------------------------------------------------------------------------------
+0.47 Verbose mode can be enabled via `-v, --verbose` option
+0.92 CONFIGURATION: https://docs.platformio.org/page/boards/espressif32/esp32-c2-devkitm-1.html
+0.92 PLATFORM: Espressif 32 (55.3.30+develop.sha.9651ee8) > Espressif ESP32-C2-DevKitM-1
+0.92 HARDWARE: ESP32C2 120MHz, 272KB RAM, 4MB Flash
+0.92 DEBUG: Current (cmsis-dap) External (cmsis-dap, esp-bridge, esp-prog, iot-bus-jtag, jlink, minimodule, olimex-arm-usb-ocd, olimex-arm-usb-ocd-h, olimex-arm-usb-tiny-h, olimex-jtag-tiny, tumpa)
+0.92 PACKAGES:
+0.92  - contrib-piohome @ 3.4.4
+0.92  - framework-arduino-c2-skeleton-lib @ 5.5.0+sha.cbe9388f45
+0.92  - framework-arduinoespressif32 @ 3.3.0
+0.92  - framework-arduinoespressif32-libs @ 5.5.0+sha.b66b5448e0
+0.92  - framework-espidf @ 3.50500.0 (5.5.0)
+0.92  - tool-cmake @ 3.30.2
+0.92  - tool-esp-rom-elfs @ 2024.10.11
+0.92  - tool-esptoolpy @ 5.0.2
+0.92  - tool-mklittlefs @ 3.2.0
+0.92  - tool-ninja @ 1.13.1
+0.92  - tool-scons @ 4.40801.0 (4.8.1)
+0.92  - toolchain-riscv32-esp @ 14.2.0+20241119
+0.93 *** Compile Arduino IDF libs for esp32c2 ***
+0.95 *** Add "custom_sdkconfig" settings to IDF sdkconfig.defaults ***
+0.95 Replace: CONFIG_IDF_TARGET="esp32c2" with: CONFIG_IDF_TARGET=esp32c2
+0.95 Replace: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y with: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y
+0.95 Replace: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y with: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y
+0.95 Replace: CONFIG_ESPTOOLPY_FLASHFREQ="60m" with: CONFIG_ESPTOOLPY_FLASHFREQ="60m"
+0.95 Add: # CONFIG_ESPTOOLPY_FLASHFREQ_80M is not set
+0.96 Warning! Arduino framework as an ESP-IDF component doesn't handle the `variant` field! The default `esp32` variant will be used.
+0.96 Reading CMake configuration...
+5.34 Generating assembly for certificate bundle...
+5.50 LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
+5.50 LDF Modes: Finder ~ chain, Compatibility ~ soft
+5.55 Found 42 compatible libraries
+5.55 Scanning dependencies...
+5.56 No dependencies
+5.56 Building in release mode
+5.56 Environment state dumped to: env_dump.json
+5.57 Projenv state dumped to: projenv_dump.json
+5.57 Cache configuration from environment:
+5.57   Cache type: xcache
+5.57   Cache executable: python /workspace/ci/util/xcache.py
+5.57   SCCACHE path: /workspace/.venv/bin/sccache
+5.57   SCCACHE dir: /home/ubuntu/.fastled/sccache
+5.57   Debug enabled: False
+5.57 xcache wrapper detected and configured for Python fake compilers
+5.57   xcache path: /workspace/ci/util/xcache.py
+5.57   cache executable: python /workspace/ci/util/xcache.py
+5.57 DEBUG: Found compilers in env:
+5.57   CC: 'riscv32-esp-elf-gcc' (type: str)
+5.57   CXX: 'riscv32-esp-elf-g++' (type: str)
+5.57 Extracted compiler names:
+5.57   CC name: riscv32-esp-elf-gcc
+5.57   CXX name: riscv32-esp-elf-g++
+5.57 Found local compiler cache:
+5.57   Cache file: /workspace/.build/pio/esp32c2/compiler_cache.json
+5.57   Real CC: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-gcc
+5.57   Real CXX: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-g++
+5.57 SUCCESS: Using cached compilers (instant, no platform search needed):
+5.57   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.57   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.57   Platform search skipped - using cached toolset
+5.57 Created Python cached compilers:
+5.57   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.57   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.57 Applied Python fake compilers to both env and projenv
+5.57 Python fake compiler cache enabled: xcache
+5.57   Original CC: riscv32-esp-elf-gcc
+5.57   Original CXX: riscv32-esp-elf-g++
+5.57   Fake CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.57   Fake CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.57 Python fake compiler cache environment configured successfully
+5.67 Retrieved `.pio/build/esp32c2/.dummy/sketch.cpp.o' from cache
+5.67 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-gcc.c.o' from cache
+5.68 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-cpp.cpp.o' from cache
+5.69 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-as.S.o' from cache
+5.69 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.69 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.69 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.69   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.69   RET_CODE: no such file or directory
+5.69   ERROR_MESSAGE:
+5.69 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.69   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.69   RET_CODE: no such file or directory
+5.69   ERROR_MESSAGE:
+5.70 Retrieved `.pio/build/esp32c2/app_trace/app_trace.c.o' from cache
+5.70 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in] Error 1
+5.70 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in] Error 1
+5.85 ========================== [FAILED] Took 5.69 seconds ==========================

--- a/failures/Cylon.log
+++ b/failures/Cylon.log
@@ -1,0 +1,95 @@
+Initial build failed: 0.12 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.12 --------------------------------------------------------------------------------
+0.42 Verbose mode can be enabled via `-v, --verbose` option
+0.50 Error: Failed to install Python dependencies into penv
+0.50 Error output: /home/ubuntu/.fastled/compile/pio/esp32c2/penv/bin/python: No module named pip
+0.54 ========================== [FAILED] Took 0.42 seconds ==========================
+Initial build failed: 0.16 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.16 --------------------------------------------------------------------------------
+0.46 Verbose mode can be enabled via `-v, --verbose` option
+0.87 CONFIGURATION: https://docs.platformio.org/page/boards/espressif32/esp32-c2-devkitm-1.html
+0.87 PLATFORM: Espressif 32 (55.3.30+develop.sha.9651ee8) > Espressif ESP32-C2-DevKitM-1
+0.87 HARDWARE: ESP32C2 120MHz, 272KB RAM, 4MB Flash
+0.87 DEBUG: Current (cmsis-dap) External (cmsis-dap, esp-bridge, esp-prog, iot-bus-jtag, jlink, minimodule, olimex-arm-usb-ocd, olimex-arm-usb-ocd-h, olimex-arm-usb-tiny-h, olimex-jtag-tiny, tumpa)
+0.87 PACKAGES:
+0.87  - contrib-piohome @ 3.4.4
+0.87  - framework-arduino-c2-skeleton-lib @ 5.5.0+sha.cbe9388f45
+0.87  - framework-arduinoespressif32 @ 3.3.0
+0.87  - framework-arduinoespressif32-libs @ 5.5.0+sha.b66b5448e0
+0.87  - framework-espidf @ 3.50500.0 (5.5.0)
+0.87  - tool-cmake @ 3.30.2
+0.87  - tool-esp-rom-elfs @ 2024.10.11
+0.87  - tool-esptoolpy @ 5.0.2
+0.87  - tool-mklittlefs @ 3.2.0
+0.87  - tool-ninja @ 1.13.1
+0.87  - tool-scons @ 4.40801.0 (4.8.1)
+0.87  - toolchain-riscv32-esp @ 14.2.0+20241119
+0.87 *** Compile Arduino IDF libs for esp32c2 ***
+0.89 *** Add "custom_sdkconfig" settings to IDF sdkconfig.defaults ***
+0.89 Replace: CONFIG_IDF_TARGET="esp32c2" with: CONFIG_IDF_TARGET=esp32c2
+0.89 Replace: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y with: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y
+0.89 Replace: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y with: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y
+0.89 Replace: CONFIG_ESPTOOLPY_FLASHFREQ="60m" with: CONFIG_ESPTOOLPY_FLASHFREQ="60m"
+0.89 Add: # CONFIG_ESPTOOLPY_FLASHFREQ_80M is not set
+0.90 Warning! Arduino framework as an ESP-IDF component doesn't handle the `variant` field! The default `esp32` variant will be used.
+0.90 Reading CMake configuration...
+5.27 Generating assembly for certificate bundle...
+5.43 LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
+5.43 LDF Modes: Finder ~ chain, Compatibility ~ soft
+5.49 Found 42 compatible libraries
+5.49 Scanning dependencies...
+5.49 No dependencies
+5.49 Building in release mode
+5.50 Environment state dumped to: env_dump.json
+5.50 Projenv state dumped to: projenv_dump.json
+5.50 Cache configuration from environment:
+5.50   Cache type: xcache
+5.50   Cache executable: python /workspace/ci/util/xcache.py
+5.50   SCCACHE path: /workspace/.venv/bin/sccache
+5.50   SCCACHE dir: /home/ubuntu/.fastled/sccache
+5.50   Debug enabled: False
+5.50 xcache wrapper detected and configured for Python fake compilers
+5.50   xcache path: /workspace/ci/util/xcache.py
+5.50   cache executable: python /workspace/ci/util/xcache.py
+5.50 DEBUG: Found compilers in env:
+5.50   CC: 'riscv32-esp-elf-gcc' (type: str)
+5.50   CXX: 'riscv32-esp-elf-g++' (type: str)
+5.50 Extracted compiler names:
+5.50   CC name: riscv32-esp-elf-gcc
+5.50   CXX name: riscv32-esp-elf-g++
+5.50 Found local compiler cache:
+5.50   Cache file: /workspace/.build/pio/esp32c2/compiler_cache.json
+5.50   Real CC: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-gcc
+5.50   Real CXX: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-g++
+5.50 SUCCESS: Using cached compilers (instant, no platform search needed):
+5.50   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.50   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.50   Platform search skipped - using cached toolset
+5.50 Created Python cached compilers:
+5.50   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.50   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.50 Applied Python fake compilers to both env and projenv
+5.50 Python fake compiler cache enabled: xcache
+5.50   Original CC: riscv32-esp-elf-gcc
+5.50   Original CXX: riscv32-esp-elf-g++
+5.50   Fake CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.50   Fake CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.50 Python fake compiler cache environment configured successfully
+5.60 Retrieved `.pio/build/esp32c2/.dummy/sketch.cpp.o' from cache
+5.61 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-gcc.c.o' from cache
+5.61 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-cpp.cpp.o' from cache
+5.62 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-as.S.o' from cache
+5.62 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.62 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.62 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.62   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.62   RET_CODE: no such file or directory
+5.62   ERROR_MESSAGE:
+5.63 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.63   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.63   RET_CODE: no such file or directory
+5.63   ERROR_MESSAGE:
+5.63 Retrieved `.pio/build/esp32c2/app_trace/app_trace.c.o' from cache
+5.63 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in] Error 1
+5.63 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in] Error 1
+5.78 ========================== [FAILED] Took 5.62 seconds ==========================

--- a/failures/DemoReel100.log
+++ b/failures/DemoReel100.log
@@ -1,0 +1,90 @@
+Initial build failed: 0.12 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.12 --------------------------------------------------------------------------------
+0.44 Verbose mode can be enabled via `-v, --verbose` option
+0.51 Error output: /home/ubuntu/.fastled/compile/pio/esp32c2/penv/bin/python: No module named pip
+0.51 Error: Failed to install Python dependencies into penv
+0.55 ========================== [FAILED] Took 0.42 seconds ==========================
+Initial build failed: 0.13 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.13 --------------------------------------------------------------------------------
+0.45 Verbose mode can be enabled via `-v, --verbose` option
+0.84 CONFIGURATION: https://docs.platformio.org/page/boards/espressif32/esp32-c2-devkitm-1.html
+0.84 PLATFORM: Espressif 32 (55.3.30+develop.sha.9651ee8) > Espressif ESP32-C2-DevKitM-1
+0.84 HARDWARE: ESP32C2 120MHz, 272KB RAM, 4MB Flash
+0.84 DEBUG: Current (cmsis-dap) External (cmsis-dap, esp-bridge, esp-prog, iot-bus-jtag, jlink, minimodule, olimex-arm-usb-ocd, olimex-arm-usb-ocd-h, olimex-arm-usb-tiny-h, olimex-jtag-tiny, tumpa)
+0.84 PACKAGES:
+0.84  - contrib-piohome @ 3.4.4
+0.84  - framework-arduino-c2-skeleton-lib @ 5.5.0+sha.cbe9388f45
+0.84  - framework-arduinoespressif32 @ 3.3.0
+0.84  - framework-arduinoespressif32-libs @ 5.5.0+sha.b66b5448e0
+0.84  - framework-espidf @ 3.50500.0 (5.5.0)
+0.84  - tool-cmake @ 3.30.2
+0.84  - tool-esp-rom-elfs @ 2024.10.11
+0.84  - tool-esptoolpy @ 5.0.2
+0.84  - tool-mklittlefs @ 3.2.0
+0.84  - tool-ninja @ 1.13.1
+0.84  - tool-scons @ 4.40801.0 (4.8.1)
+0.84  - toolchain-riscv32-esp @ 14.2.0+20241119
+0.85 *** Compile Arduino IDF libs for esp32c2 ***
+0.87 *** Add "custom_sdkconfig" settings to IDF sdkconfig.defaults ***
+0.87 Replace: CONFIG_IDF_TARGET="esp32c2" with: CONFIG_IDF_TARGET=esp32c2
+0.87 Replace: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y with: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y
+0.87 Replace: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y with: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y
+0.87 Replace: CONFIG_ESPTOOLPY_FLASHFREQ="60m" with: CONFIG_ESPTOOLPY_FLASHFREQ="60m"
+0.87 Add: # CONFIG_ESPTOOLPY_FLASHFREQ_80M is not set
+0.88 Warning! Arduino framework as an ESP-IDF component doesn't handle the `variant` field! The default `esp32` variant will be used.
+0.88 Reading CMake configuration...
+4.97 LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
+4.97 LDF Modes: Finder ~ chain, Compatibility ~ soft
+5.02 Found 42 compatible libraries
+5.02 Scanning dependencies...
+5.03 No dependencies
+5.03 Building in release mode
+5.03 Environment state dumped to: env_dump.json
+5.04 Projenv state dumped to: projenv_dump.json
+5.04 Cache configuration from environment:
+5.04   Cache type: xcache
+5.04   Cache executable: python /workspace/ci/util/xcache.py
+5.04   SCCACHE path: /workspace/.venv/bin/sccache
+5.04   SCCACHE dir: /home/ubuntu/.fastled/sccache
+5.04   Debug enabled: False
+5.04 xcache wrapper detected and configured for Python fake compilers
+5.04   xcache path: /workspace/ci/util/xcache.py
+5.04   cache executable: python /workspace/ci/util/xcache.py
+5.04 DEBUG: Found compilers in env:
+5.04   CC: 'riscv32-esp-elf-gcc' (type: str)
+5.04   CXX: 'riscv32-esp-elf-g++' (type: str)
+5.04 Extracted compiler names:
+5.04   CC name: riscv32-esp-elf-gcc
+5.04   CXX name: riscv32-esp-elf-g++
+5.04 Found local compiler cache:
+5.04   Cache file: /workspace/.build/pio/esp32c2/compiler_cache.json
+5.04   Real CC: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-gcc
+5.04   Real CXX: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-g++
+5.04 SUCCESS: Using cached compilers (instant, no platform search needed):
+5.04   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.04   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.04   Platform search skipped - using cached toolset
+5.04 Created Python cached compilers:
+5.04   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.04   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.04 Applied Python fake compilers to both env and projenv
+5.04 Python fake compiler cache enabled: xcache
+5.04   Original CC: riscv32-esp-elf-gcc
+5.04   Original CXX: riscv32-esp-elf-g++
+5.04   Fake CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.04   Fake CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.04 Python fake compiler cache environment configured successfully
+5.07 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.07 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.07 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.07   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.07   RET_CODE: no such file or directory
+5.07   ERROR_MESSAGE:
+5.07 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.07   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.07   RET_CODE: no such file or directory
+5.07   ERROR_MESSAGE:
+5.09 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in] Error 1
+5.09 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in] Error 1
+5.09 Retrieved `.pio/build/esp32c2/app_trace/app_trace_util.c.o' from cache
+5.22 ========================== [FAILED] Took 5.09 seconds ==========================

--- a/failures/Downscale.log
+++ b/failures/Downscale.log
@@ -1,0 +1,95 @@
+Initial build failed: 0.12 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.12 --------------------------------------------------------------------------------
+0.42 Verbose mode can be enabled via `-v, --verbose` option
+0.50 Error output: /home/ubuntu/.fastled/compile/pio/esp32c2/penv/bin/python: No module named pip
+0.50 Error: Failed to install Python dependencies into penv
+0.54 ========================== [FAILED] Took 0.41 seconds ==========================
+Initial build failed: 0.16 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.16 --------------------------------------------------------------------------------
+0.47 Verbose mode can be enabled via `-v, --verbose` option
+0.85 CONFIGURATION: https://docs.platformio.org/page/boards/espressif32/esp32-c2-devkitm-1.html
+0.85 PLATFORM: Espressif 32 (55.3.30+develop.sha.9651ee8) > Espressif ESP32-C2-DevKitM-1
+0.85 HARDWARE: ESP32C2 120MHz, 272KB RAM, 4MB Flash
+0.85 DEBUG: Current (cmsis-dap) External (cmsis-dap, esp-bridge, esp-prog, iot-bus-jtag, jlink, minimodule, olimex-arm-usb-ocd, olimex-arm-usb-ocd-h, olimex-arm-usb-tiny-h, olimex-jtag-tiny, tumpa)
+0.85 PACKAGES:
+0.85  - contrib-piohome @ 3.4.4
+0.85  - framework-arduino-c2-skeleton-lib @ 5.5.0+sha.cbe9388f45
+0.85  - framework-arduinoespressif32 @ 3.3.0
+0.85  - framework-arduinoespressif32-libs @ 5.5.0+sha.b66b5448e0
+0.85  - framework-espidf @ 3.50500.0 (5.5.0)
+0.85  - tool-cmake @ 3.30.2
+0.85  - tool-esp-rom-elfs @ 2024.10.11
+0.85  - tool-esptoolpy @ 5.0.2
+0.85  - tool-mklittlefs @ 3.2.0
+0.85  - tool-ninja @ 1.13.1
+0.85  - tool-scons @ 4.40801.0 (4.8.1)
+0.85  - toolchain-riscv32-esp @ 14.2.0+20241119
+0.85 *** Compile Arduino IDF libs for esp32c2 ***
+0.87 *** Add "custom_sdkconfig" settings to IDF sdkconfig.defaults ***
+0.87 Replace: CONFIG_IDF_TARGET="esp32c2" with: CONFIG_IDF_TARGET=esp32c2
+0.87 Replace: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y with: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y
+0.87 Replace: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y with: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y
+0.87 Replace: CONFIG_ESPTOOLPY_FLASHFREQ="60m" with: CONFIG_ESPTOOLPY_FLASHFREQ="60m"
+0.87 Add: # CONFIG_ESPTOOLPY_FLASHFREQ_80M is not set
+0.88 Warning! Arduino framework as an ESP-IDF component doesn't handle the `variant` field! The default `esp32` variant will be used.
+0.88 Reading CMake configuration...
+5.28 Generating assembly for certificate bundle...
+5.43 LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
+5.43 LDF Modes: Finder ~ chain, Compatibility ~ soft
+5.49 Found 42 compatible libraries
+5.49 Scanning dependencies...
+5.49 No dependencies
+5.50 Building in release mode
+5.50 Environment state dumped to: env_dump.json
+5.50 Projenv state dumped to: projenv_dump.json
+5.50 Cache configuration from environment:
+5.50   Cache type: xcache
+5.50   Cache executable: python /workspace/ci/util/xcache.py
+5.50   SCCACHE path: /workspace/.venv/bin/sccache
+5.50   SCCACHE dir: /home/ubuntu/.fastled/sccache
+5.50   Debug enabled: False
+5.50 xcache wrapper detected and configured for Python fake compilers
+5.50   xcache path: /workspace/ci/util/xcache.py
+5.50   cache executable: python /workspace/ci/util/xcache.py
+5.50 DEBUG: Found compilers in env:
+5.50   CC: 'riscv32-esp-elf-gcc' (type: str)
+5.50   CXX: 'riscv32-esp-elf-g++' (type: str)
+5.50 Extracted compiler names:
+5.50   CC name: riscv32-esp-elf-gcc
+5.50   CXX name: riscv32-esp-elf-g++
+5.50 Found local compiler cache:
+5.50   Cache file: /workspace/.build/pio/esp32c2/compiler_cache.json
+5.50   Real CC: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-gcc
+5.50   Real CXX: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-g++
+5.50 SUCCESS: Using cached compilers (instant, no platform search needed):
+5.50   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.50   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.50   Platform search skipped - using cached toolset
+5.50 Created Python cached compilers:
+5.50   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.50   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.50 Applied Python fake compilers to both env and projenv
+5.50 Python fake compiler cache enabled: xcache
+5.50   Original CC: riscv32-esp-elf-gcc
+5.50   Original CXX: riscv32-esp-elf-g++
+5.50   Fake CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.50   Fake CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.50 Python fake compiler cache environment configured successfully
+5.60 Retrieved `.pio/build/esp32c2/.dummy/sketch.cpp.o' from cache
+5.61 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-gcc.c.o' from cache
+5.61 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-cpp.cpp.o' from cache
+5.62 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-as.S.o' from cache
+5.62 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.62 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.62 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.62   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.62   RET_CODE: no such file or directory
+5.62   ERROR_MESSAGE:
+5.62 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.62   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.62   RET_CODE: no such file or directory
+5.62   ERROR_MESSAGE:
+5.64 Retrieved `.pio/build/esp32c2/app_trace/app_trace.c.o' from cache
+5.64 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in] Error 1
+5.64 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in] Error 1
+5.78 ========================== [FAILED] Took 5.62 seconds ==========================

--- a/failures/EaseInOut.log
+++ b/failures/EaseInOut.log
@@ -1,0 +1,95 @@
+Initial build failed: 0.13 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.13 --------------------------------------------------------------------------------
+0.43 Verbose mode can be enabled via `-v, --verbose` option
+0.51 Error output: /home/ubuntu/.fastled/compile/pio/esp32c2/penv/bin/python: No module named pip
+0.51 Error: Failed to install Python dependencies into penv
+0.55 ========================== [FAILED] Took 0.41 seconds ==========================
+Initial build failed: 0.16 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.16 --------------------------------------------------------------------------------
+0.48 Verbose mode can be enabled via `-v, --verbose` option
+0.99 CONFIGURATION: https://docs.platformio.org/page/boards/espressif32/esp32-c2-devkitm-1.html
+0.99 PLATFORM: Espressif 32 (55.3.30+develop.sha.9651ee8) > Espressif ESP32-C2-DevKitM-1
+0.99 HARDWARE: ESP32C2 120MHz, 272KB RAM, 4MB Flash
+0.99 DEBUG: Current (cmsis-dap) External (cmsis-dap, esp-bridge, esp-prog, iot-bus-jtag, jlink, minimodule, olimex-arm-usb-ocd, olimex-arm-usb-ocd-h, olimex-arm-usb-tiny-h, olimex-jtag-tiny, tumpa)
+0.99 PACKAGES:
+0.99  - contrib-piohome @ 3.4.4
+0.99  - framework-arduino-c2-skeleton-lib @ 5.5.0+sha.cbe9388f45
+0.99  - framework-arduinoespressif32 @ 3.3.0
+0.99  - framework-arduinoespressif32-libs @ 5.5.0+sha.b66b5448e0
+0.99  - framework-espidf @ 3.50500.0 (5.5.0)
+0.99  - tool-cmake @ 3.30.2
+0.99  - tool-esp-rom-elfs @ 2024.10.11
+0.99  - tool-esptoolpy @ 5.0.2
+0.99  - tool-mklittlefs @ 3.2.0
+0.99  - tool-ninja @ 1.13.1
+0.99  - tool-scons @ 4.40801.0 (4.8.1)
+0.99  - toolchain-riscv32-esp @ 14.2.0+20241119
+1.00 *** Compile Arduino IDF libs for esp32c2 ***
+1.01 *** Add "custom_sdkconfig" settings to IDF sdkconfig.defaults ***
+1.02 Replace: CONFIG_IDF_TARGET="esp32c2" with: CONFIG_IDF_TARGET=esp32c2
+1.02 Replace: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y with: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y
+1.02 Replace: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y with: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y
+1.02 Replace: CONFIG_ESPTOOLPY_FLASHFREQ="60m" with: CONFIG_ESPTOOLPY_FLASHFREQ="60m"
+1.02 Add: # CONFIG_ESPTOOLPY_FLASHFREQ_80M is not set
+1.03 Warning! Arduino framework as an ESP-IDF component doesn't handle the `variant` field! The default `esp32` variant will be used.
+1.03 Reading CMake configuration...
+5.42 Generating assembly for certificate bundle...
+5.58 LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
+5.58 LDF Modes: Finder ~ chain, Compatibility ~ soft
+5.64 Found 42 compatible libraries
+5.64 Scanning dependencies...
+5.64 No dependencies
+5.64 Building in release mode
+5.65 Environment state dumped to: env_dump.json
+5.65 Projenv state dumped to: projenv_dump.json
+5.65 Cache configuration from environment:
+5.65   Cache type: xcache
+5.65   Cache executable: python /workspace/ci/util/xcache.py
+5.65   SCCACHE path: /workspace/.venv/bin/sccache
+5.65   SCCACHE dir: /home/ubuntu/.fastled/sccache
+5.65   Debug enabled: False
+5.65 xcache wrapper detected and configured for Python fake compilers
+5.65   xcache path: /workspace/ci/util/xcache.py
+5.65   cache executable: python /workspace/ci/util/xcache.py
+5.65 DEBUG: Found compilers in env:
+5.65   CC: 'riscv32-esp-elf-gcc' (type: str)
+5.65   CXX: 'riscv32-esp-elf-g++' (type: str)
+5.65 Extracted compiler names:
+5.65   CC name: riscv32-esp-elf-gcc
+5.65   CXX name: riscv32-esp-elf-g++
+5.65 Found local compiler cache:
+5.65   Cache file: /workspace/.build/pio/esp32c2/compiler_cache.json
+5.65   Real CC: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-gcc
+5.65   Real CXX: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-g++
+5.65 SUCCESS: Using cached compilers (instant, no platform search needed):
+5.65   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.65   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.65   Platform search skipped - using cached toolset
+5.65 Created Python cached compilers:
+5.65   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.65   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.65 Applied Python fake compilers to both env and projenv
+5.65 Python fake compiler cache enabled: xcache
+5.65   Original CC: riscv32-esp-elf-gcc
+5.65   Original CXX: riscv32-esp-elf-g++
+5.65   Fake CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.65   Fake CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.65 Python fake compiler cache environment configured successfully
+5.75 Retrieved `.pio/build/esp32c2/.dummy/sketch.cpp.o' from cache
+5.75 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-gcc.c.o' from cache
+5.76 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-cpp.cpp.o' from cache
+5.76 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-as.S.o' from cache
+5.77 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.77 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.77   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.77   RET_CODE: no such file or directory
+5.77   ERROR_MESSAGE:
+5.77 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.77 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.77   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.77   RET_CODE: no such file or directory
+5.77   ERROR_MESSAGE:
+5.78 Retrieved `.pio/build/esp32c2/app_trace/app_trace.c.o' from cache
+5.78 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in] Error 1
+5.78 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in] Error 1
+5.93 ========================== [FAILED] Took 5.77 seconds ==========================

--- a/failures/Esp32S3I2SDemo.log
+++ b/failures/Esp32S3I2SDemo.log
@@ -1,0 +1,95 @@
+Initial build failed: 0.12 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.12 --------------------------------------------------------------------------------
+0.44 Verbose mode can be enabled via `-v, --verbose` option
+0.51 Error output: /home/ubuntu/.fastled/compile/pio/esp32c2/penv/bin/python: No module named pip
+0.51 Error: Failed to install Python dependencies into penv
+0.55 ========================== [FAILED] Took 0.43 seconds ==========================
+Initial build failed: 0.16 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.16 --------------------------------------------------------------------------------
+0.46 Verbose mode can be enabled via `-v, --verbose` option
+0.87 CONFIGURATION: https://docs.platformio.org/page/boards/espressif32/esp32-c2-devkitm-1.html
+0.87 PLATFORM: Espressif 32 (55.3.30+develop.sha.9651ee8) > Espressif ESP32-C2-DevKitM-1
+0.87 HARDWARE: ESP32C2 120MHz, 272KB RAM, 4MB Flash
+0.87 DEBUG: Current (cmsis-dap) External (cmsis-dap, esp-bridge, esp-prog, iot-bus-jtag, jlink, minimodule, olimex-arm-usb-ocd, olimex-arm-usb-ocd-h, olimex-arm-usb-tiny-h, olimex-jtag-tiny, tumpa)
+0.87 PACKAGES:
+0.87  - contrib-piohome @ 3.4.4
+0.87  - framework-arduino-c2-skeleton-lib @ 5.5.0+sha.cbe9388f45
+0.87  - framework-arduinoespressif32 @ 3.3.0
+0.87  - framework-arduinoespressif32-libs @ 5.5.0+sha.b66b5448e0
+0.87  - framework-espidf @ 3.50500.0 (5.5.0)
+0.87  - tool-cmake @ 3.30.2
+0.87  - tool-esp-rom-elfs @ 2024.10.11
+0.87  - tool-esptoolpy @ 5.0.2
+0.87  - tool-mklittlefs @ 3.2.0
+0.87  - tool-ninja @ 1.13.1
+0.87  - tool-scons @ 4.40801.0 (4.8.1)
+0.87  - toolchain-riscv32-esp @ 14.2.0+20241119
+0.88 *** Compile Arduino IDF libs for esp32c2 ***
+0.90 *** Add "custom_sdkconfig" settings to IDF sdkconfig.defaults ***
+0.90 Replace: CONFIG_IDF_TARGET="esp32c2" with: CONFIG_IDF_TARGET=esp32c2
+0.90 Replace: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y with: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y
+0.90 Replace: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y with: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y
+0.90 Replace: CONFIG_ESPTOOLPY_FLASHFREQ="60m" with: CONFIG_ESPTOOLPY_FLASHFREQ="60m"
+0.90 Add: # CONFIG_ESPTOOLPY_FLASHFREQ_80M is not set
+0.91 Warning! Arduino framework as an ESP-IDF component doesn't handle the `variant` field! The default `esp32` variant will be used.
+0.91 Reading CMake configuration...
+5.30 Generating assembly for certificate bundle...
+5.47 LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
+5.47 LDF Modes: Finder ~ chain, Compatibility ~ soft
+5.52 Found 42 compatible libraries
+5.52 Scanning dependencies...
+5.53 No dependencies
+5.53 Building in release mode
+5.53 Environment state dumped to: env_dump.json
+5.54 Projenv state dumped to: projenv_dump.json
+5.54 Cache configuration from environment:
+5.54   Cache type: xcache
+5.54   Cache executable: python /workspace/ci/util/xcache.py
+5.54   SCCACHE path: /workspace/.venv/bin/sccache
+5.54   SCCACHE dir: /home/ubuntu/.fastled/sccache
+5.54   Debug enabled: False
+5.54 xcache wrapper detected and configured for Python fake compilers
+5.54   xcache path: /workspace/ci/util/xcache.py
+5.54   cache executable: python /workspace/ci/util/xcache.py
+5.54 DEBUG: Found compilers in env:
+5.54   CC: 'riscv32-esp-elf-gcc' (type: str)
+5.54   CXX: 'riscv32-esp-elf-g++' (type: str)
+5.54 Extracted compiler names:
+5.54   CC name: riscv32-esp-elf-gcc
+5.54   CXX name: riscv32-esp-elf-g++
+5.54 Found local compiler cache:
+5.54   Cache file: /workspace/.build/pio/esp32c2/compiler_cache.json
+5.54   Real CC: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-gcc
+5.54   Real CXX: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-g++
+5.54 SUCCESS: Using cached compilers (instant, no platform search needed):
+5.54   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.54   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.54   Platform search skipped - using cached toolset
+5.54 Created Python cached compilers:
+5.54   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.54   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.54 Applied Python fake compilers to both env and projenv
+5.54 Python fake compiler cache enabled: xcache
+5.54   Original CC: riscv32-esp-elf-gcc
+5.54   Original CXX: riscv32-esp-elf-g++
+5.54   Fake CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.54   Fake CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.54 Python fake compiler cache environment configured successfully
+5.64 Retrieved `.pio/build/esp32c2/.dummy/sketch.cpp.o' from cache
+5.64 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-gcc.c.o' from cache
+5.65 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-cpp.cpp.o' from cache
+5.65 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-as.S.o' from cache
+5.66 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.66 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.66 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.66   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.66   RET_CODE: no such file or directory
+5.66   ERROR_MESSAGE:
+5.66 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.66   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.66   RET_CODE: no such file or directory
+5.66   ERROR_MESSAGE:
+5.67 Retrieved `.pio/build/esp32c2/app_trace/app_trace.c.o' from cache
+5.67 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in] Error 1
+5.67 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in] Error 1
+5.81 ========================== [FAILED] Took 5.64 seconds ==========================

--- a/failures/EspI2SDemo.log
+++ b/failures/EspI2SDemo.log
@@ -1,0 +1,95 @@
+Initial build failed: 0.12 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.12 --------------------------------------------------------------------------------
+0.43 Verbose mode can be enabled via `-v, --verbose` option
+0.50 Error output: /home/ubuntu/.fastled/compile/pio/esp32c2/penv/bin/python: No module named pip
+0.50 Error: Failed to install Python dependencies into penv
+0.54 ========================== [FAILED] Took 0.41 seconds ==========================
+Initial build failed: 0.16 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.16 --------------------------------------------------------------------------------
+0.46 Verbose mode can be enabled via `-v, --verbose` option
+0.85 CONFIGURATION: https://docs.platformio.org/page/boards/espressif32/esp32-c2-devkitm-1.html
+0.85 PLATFORM: Espressif 32 (55.3.30+develop.sha.9651ee8) > Espressif ESP32-C2-DevKitM-1
+0.85 HARDWARE: ESP32C2 120MHz, 272KB RAM, 4MB Flash
+0.85 DEBUG: Current (cmsis-dap) External (cmsis-dap, esp-bridge, esp-prog, iot-bus-jtag, jlink, minimodule, olimex-arm-usb-ocd, olimex-arm-usb-ocd-h, olimex-arm-usb-tiny-h, olimex-jtag-tiny, tumpa)
+0.85 PACKAGES:
+0.85  - contrib-piohome @ 3.4.4
+0.85  - framework-arduino-c2-skeleton-lib @ 5.5.0+sha.cbe9388f45
+0.85  - framework-arduinoespressif32 @ 3.3.0
+0.85  - framework-arduinoespressif32-libs @ 5.5.0+sha.b66b5448e0
+0.85  - framework-espidf @ 3.50500.0 (5.5.0)
+0.85  - tool-cmake @ 3.30.2
+0.85  - tool-esp-rom-elfs @ 2024.10.11
+0.85  - tool-esptoolpy @ 5.0.2
+0.85  - tool-mklittlefs @ 3.2.0
+0.85  - tool-ninja @ 1.13.1
+0.85  - tool-scons @ 4.40801.0 (4.8.1)
+0.85  - toolchain-riscv32-esp @ 14.2.0+20241119
+0.86 *** Compile Arduino IDF libs for esp32c2 ***
+0.88 *** Add "custom_sdkconfig" settings to IDF sdkconfig.defaults ***
+0.88 Replace: CONFIG_IDF_TARGET="esp32c2" with: CONFIG_IDF_TARGET=esp32c2
+0.88 Replace: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y with: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y
+0.88 Replace: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y with: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y
+0.88 Replace: CONFIG_ESPTOOLPY_FLASHFREQ="60m" with: CONFIG_ESPTOOLPY_FLASHFREQ="60m"
+0.88 Add: # CONFIG_ESPTOOLPY_FLASHFREQ_80M is not set
+0.89 Warning! Arduino framework as an ESP-IDF component doesn't handle the `variant` field! The default `esp32` variant will be used.
+0.89 Reading CMake configuration...
+5.29 Generating assembly for certificate bundle...
+5.45 LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
+5.45 LDF Modes: Finder ~ chain, Compatibility ~ soft
+5.51 Found 42 compatible libraries
+5.51 Scanning dependencies...
+5.51 No dependencies
+5.52 Building in release mode
+5.52 Environment state dumped to: env_dump.json
+5.52 Projenv state dumped to: projenv_dump.json
+5.52 Cache configuration from environment:
+5.52   Cache type: xcache
+5.52   Cache executable: python /workspace/ci/util/xcache.py
+5.52   SCCACHE path: /workspace/.venv/bin/sccache
+5.52   SCCACHE dir: /home/ubuntu/.fastled/sccache
+5.52   Debug enabled: False
+5.52 xcache wrapper detected and configured for Python fake compilers
+5.52   xcache path: /workspace/ci/util/xcache.py
+5.52   cache executable: python /workspace/ci/util/xcache.py
+5.52 DEBUG: Found compilers in env:
+5.52   CC: 'riscv32-esp-elf-gcc' (type: str)
+5.52   CXX: 'riscv32-esp-elf-g++' (type: str)
+5.52 Extracted compiler names:
+5.52   CC name: riscv32-esp-elf-gcc
+5.52   CXX name: riscv32-esp-elf-g++
+5.52 Found local compiler cache:
+5.52   Cache file: /workspace/.build/pio/esp32c2/compiler_cache.json
+5.52   Real CC: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-gcc
+5.52   Real CXX: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-g++
+5.52 SUCCESS: Using cached compilers (instant, no platform search needed):
+5.52   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.52   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.52   Platform search skipped - using cached toolset
+5.52 Created Python cached compilers:
+5.52   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.52   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.52 Applied Python fake compilers to both env and projenv
+5.52 Python fake compiler cache enabled: xcache
+5.52   Original CC: riscv32-esp-elf-gcc
+5.52   Original CXX: riscv32-esp-elf-g++
+5.52   Fake CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.52   Fake CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.52 Python fake compiler cache environment configured successfully
+5.63 Retrieved `.pio/build/esp32c2/.dummy/sketch.cpp.o' from cache
+5.63 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-gcc.c.o' from cache
+5.64 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-cpp.cpp.o' from cache
+5.64 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-as.S.o' from cache
+5.64 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.65 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.65 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.65   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.65   RET_CODE: no such file or directory
+5.65   ERROR_MESSAGE:
+5.65 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.65   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.65   RET_CODE: no such file or directory
+5.65   ERROR_MESSAGE:
+5.66 Retrieved `.pio/build/esp32c2/app_trace/app_trace.c.o' from cache
+5.66 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in] Error 1
+5.66 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in] Error 1
+5.80 ========================== [FAILED] Took 5.64 seconds ==========================

--- a/failures/FestivalStick.log
+++ b/failures/FestivalStick.log
@@ -1,0 +1,94 @@
+Initial build failed: 0.13 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.13 --------------------------------------------------------------------------------
+0.43 Verbose mode can be enabled via `-v, --verbose` option
+0.50 Error output: /home/ubuntu/.fastled/compile/pio/esp32c2/penv/bin/python: No module named pip
+0.50 Error: Failed to install Python dependencies into penv
+0.54 ========================== [FAILED] Took 0.41 seconds ==========================
+Initial build failed: 0.16 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.16 --------------------------------------------------------------------------------
+0.48 Verbose mode can be enabled via `-v, --verbose` option
+0.97 CONFIGURATION: https://docs.platformio.org/page/boards/espressif32/esp32-c2-devkitm-1.html
+0.97 PLATFORM: Espressif 32 (55.3.30+develop.sha.9651ee8) > Espressif ESP32-C2-DevKitM-1
+0.97 HARDWARE: ESP32C2 120MHz, 272KB RAM, 4MB Flash
+0.97 DEBUG: Current (cmsis-dap) External (cmsis-dap, esp-bridge, esp-prog, iot-bus-jtag, jlink, minimodule, olimex-arm-usb-ocd, olimex-arm-usb-ocd-h, olimex-arm-usb-tiny-h, olimex-jtag-tiny, tumpa)
+0.97 PACKAGES:
+0.97  - contrib-piohome @ 3.4.4
+0.97  - framework-arduino-c2-skeleton-lib @ 5.5.0+sha.cbe9388f45
+0.97  - framework-arduinoespressif32 @ 3.3.0
+0.97  - framework-arduinoespressif32-libs @ 5.5.0+sha.b66b5448e0
+0.97  - framework-espidf @ 3.50500.0 (5.5.0)
+0.97  - tool-cmake @ 3.30.2
+0.97  - tool-esp-rom-elfs @ 2024.10.11
+0.97  - tool-esptoolpy @ 5.0.2
+0.97  - tool-mklittlefs @ 3.2.0
+0.97  - tool-ninja @ 1.13.1
+0.97  - tool-scons @ 4.40801.0 (4.8.1)
+0.97  - toolchain-riscv32-esp @ 14.2.0+20241119
+0.98 *** Compile Arduino IDF libs for esp32c2 ***
+0.99 *** Add "custom_sdkconfig" settings to IDF sdkconfig.defaults ***
+0.99 Replace: CONFIG_IDF_TARGET="esp32c2" with: CONFIG_IDF_TARGET=esp32c2
+0.99 Replace: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y with: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y
+0.99 Replace: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y with: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y
+0.99 Replace: CONFIG_ESPTOOLPY_FLASHFREQ="60m" with: CONFIG_ESPTOOLPY_FLASHFREQ="60m"
+1.00 Add: # CONFIG_ESPTOOLPY_FLASHFREQ_80M is not set
+1.01 Warning! Arduino framework as an ESP-IDF component doesn't handle the `variant` field! The default `esp32` variant will be used.
+1.01 Reading CMake configuration...
+5.38 Generating assembly for certificate bundle...
+5.54 LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
+5.54 LDF Modes: Finder ~ chain, Compatibility ~ soft
+5.59 Found 42 compatible libraries
+5.59 Scanning dependencies...
+5.60 No dependencies
+5.60 Building in release mode
+5.60 Environment state dumped to: env_dump.json
+5.60 Projenv state dumped to: projenv_dump.json
+5.60 Cache configuration from environment:
+5.60   Cache type: xcache
+5.60   Cache executable: python /workspace/ci/util/xcache.py
+5.60   SCCACHE path: /workspace/.venv/bin/sccache
+5.60   SCCACHE dir: /home/ubuntu/.fastled/sccache
+5.60   Debug enabled: False
+5.60 xcache wrapper detected and configured for Python fake compilers
+5.60   xcache path: /workspace/ci/util/xcache.py
+5.60   cache executable: python /workspace/ci/util/xcache.py
+5.60 DEBUG: Found compilers in env:
+5.60   CC: 'riscv32-esp-elf-gcc' (type: str)
+5.60   CXX: 'riscv32-esp-elf-g++' (type: str)
+5.60 Extracted compiler names:
+5.60   CC name: riscv32-esp-elf-gcc
+5.60   CXX name: riscv32-esp-elf-g++
+5.60 Found local compiler cache:
+5.60   Cache file: /workspace/.build/pio/esp32c2/compiler_cache.json
+5.60   Real CC: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-gcc
+5.60   Real CXX: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-g++
+5.60 SUCCESS: Using cached compilers (instant, no platform search needed):
+5.60   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.60   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.60   Platform search skipped - using cached toolset
+5.60 Created Python cached compilers:
+5.60   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.60   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.60 Applied Python fake compilers to both env and projenv
+5.60 Python fake compiler cache enabled: xcache
+5.60   Original CC: riscv32-esp-elf-gcc
+5.60   Original CXX: riscv32-esp-elf-g++
+5.60   Fake CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.60   Fake CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.60 Python fake compiler cache environment configured successfully
+5.71 Retrieved `.pio/build/esp32c2/.dummy/sketch.cpp.o' from cache
+5.71 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-gcc.c.o' from cache
+5.71 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-cpp.cpp.o' from cache
+5.72 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-as.S.o' from cache
+5.72 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.72 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.72   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.72   RET_CODE: no such file or directory
+5.72   ERROR_MESSAGE:
+5.73 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.73 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in] Error 1
+5.73 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.73   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.73   RET_CODE: no such file or directory
+5.73   ERROR_MESSAGE:
+5.73 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in] Error 1
+5.86 ========================== [FAILED] Took 5.70 seconds ==========================

--- a/failures/Fire2012.log
+++ b/failures/Fire2012.log
@@ -1,0 +1,94 @@
+Initial build failed: 0.13 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.13 --------------------------------------------------------------------------------
+0.44 Verbose mode can be enabled via `-v, --verbose` option
+0.54 Error: Failed to install Python dependencies into penv
+0.54 Error output: /home/ubuntu/.fastled/compile/pio/esp32c2/penv/bin/python: No module named pip
+0.58 ========================== [FAILED] Took 0.45 seconds ==========================
+Initial build failed: 0.16 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.16 --------------------------------------------------------------------------------
+0.47 Verbose mode can be enabled via `-v, --verbose` option
+0.86 CONFIGURATION: https://docs.platformio.org/page/boards/espressif32/esp32-c2-devkitm-1.html
+0.86 PLATFORM: Espressif 32 (55.3.30+develop.sha.9651ee8) > Espressif ESP32-C2-DevKitM-1
+0.86 HARDWARE: ESP32C2 120MHz, 272KB RAM, 4MB Flash
+0.86 DEBUG: Current (cmsis-dap) External (cmsis-dap, esp-bridge, esp-prog, iot-bus-jtag, jlink, minimodule, olimex-arm-usb-ocd, olimex-arm-usb-ocd-h, olimex-arm-usb-tiny-h, olimex-jtag-tiny, tumpa)
+0.86 PACKAGES:
+0.86  - contrib-piohome @ 3.4.4
+0.86  - framework-arduino-c2-skeleton-lib @ 5.5.0+sha.cbe9388f45
+0.86  - framework-arduinoespressif32 @ 3.3.0
+0.86  - framework-arduinoespressif32-libs @ 5.5.0+sha.b66b5448e0
+0.86  - framework-espidf @ 3.50500.0 (5.5.0)
+0.86  - tool-cmake @ 3.30.2
+0.86  - tool-esp-rom-elfs @ 2024.10.11
+0.86  - tool-esptoolpy @ 5.0.2
+0.86  - tool-mklittlefs @ 3.2.0
+0.86  - tool-ninja @ 1.13.1
+0.86  - tool-scons @ 4.40801.0 (4.8.1)
+0.86  - toolchain-riscv32-esp @ 14.2.0+20241119
+0.87 *** Compile Arduino IDF libs for esp32c2 ***
+0.89 *** Add "custom_sdkconfig" settings to IDF sdkconfig.defaults ***
+0.89 Replace: CONFIG_IDF_TARGET="esp32c2" with: CONFIG_IDF_TARGET=esp32c2
+0.89 Replace: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y with: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y
+0.89 Replace: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y with: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y
+0.89 Replace: CONFIG_ESPTOOLPY_FLASHFREQ="60m" with: CONFIG_ESPTOOLPY_FLASHFREQ="60m"
+0.89 Add: # CONFIG_ESPTOOLPY_FLASHFREQ_80M is not set
+0.90 Warning! Arduino framework as an ESP-IDF component doesn't handle the `variant` field! The default `esp32` variant will be used.
+0.90 Reading CMake configuration...
+5.91 Generating assembly for certificate bundle...
+6.06 LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
+6.06 LDF Modes: Finder ~ chain, Compatibility ~ soft
+6.12 Found 42 compatible libraries
+6.12 Scanning dependencies...
+6.12 No dependencies
+6.13 Building in release mode
+6.13 Environment state dumped to: env_dump.json
+6.13 Projenv state dumped to: projenv_dump.json
+6.13 Cache configuration from environment:
+6.13   Cache type: xcache
+6.13   Cache executable: python /workspace/ci/util/xcache.py
+6.13   SCCACHE path: /workspace/.venv/bin/sccache
+6.13   SCCACHE dir: /home/ubuntu/.fastled/sccache
+6.13   Debug enabled: False
+6.13 xcache wrapper detected and configured for Python fake compilers
+6.13   xcache path: /workspace/ci/util/xcache.py
+6.13   cache executable: python /workspace/ci/util/xcache.py
+6.13 DEBUG: Found compilers in env:
+6.13   CC: 'riscv32-esp-elf-gcc' (type: str)
+6.13   CXX: 'riscv32-esp-elf-g++' (type: str)
+6.13 Extracted compiler names:
+6.13   CC name: riscv32-esp-elf-gcc
+6.13   CXX name: riscv32-esp-elf-g++
+6.13 Found local compiler cache:
+6.13   Cache file: /workspace/.build/pio/esp32c2/compiler_cache.json
+6.13   Real CC: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-gcc
+6.13   Real CXX: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-g++
+6.13 SUCCESS: Using cached compilers (instant, no platform search needed):
+6.13   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+6.13   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+6.13   Platform search skipped - using cached toolset
+6.13 Created Python cached compilers:
+6.13   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+6.13   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+6.13 Applied Python fake compilers to both env and projenv
+6.13 Python fake compiler cache enabled: xcache
+6.13   Original CC: riscv32-esp-elf-gcc
+6.13   Original CXX: riscv32-esp-elf-g++
+6.13   Fake CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+6.13   Fake CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+6.13 Python fake compiler cache environment configured successfully
+6.23 Retrieved `.pio/build/esp32c2/.dummy/sketch.cpp.o' from cache
+6.24 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-gcc.c.o' from cache
+6.25 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-cpp.cpp.o' from cache
+6.25 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-as.S.o' from cache
+6.25 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+6.25 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+6.25   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+6.25   RET_CODE: no such file or directory
+6.25   ERROR_MESSAGE:
+6.26 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+6.26 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in] Error 1
+6.26 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+6.26   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+6.26   RET_CODE: no such file or directory
+6.26   ERROR_MESSAGE:
+6.26 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in] Error 1
+6.40 ========================== [FAILED] Took 6.24 seconds ==========================

--- a/failures/Fire2012WithPalette.log
+++ b/failures/Fire2012WithPalette.log
@@ -1,0 +1,90 @@
+Initial build failed: 0.12 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.12 --------------------------------------------------------------------------------
+0.42 Verbose mode can be enabled via `-v, --verbose` option
+0.51 Error: Failed to install Python dependencies into penv
+0.51 Error output: /home/ubuntu/.fastled/compile/pio/esp32c2/penv/bin/python: No module named pip
+0.55 ========================== [FAILED] Took 0.43 seconds ==========================
+Initial build failed: 0.13 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.13 --------------------------------------------------------------------------------
+0.45 Verbose mode can be enabled via `-v, --verbose` option
+0.97 CONFIGURATION: https://docs.platformio.org/page/boards/espressif32/esp32-c2-devkitm-1.html
+0.97 PLATFORM: Espressif 32 (55.3.30+develop.sha.9651ee8) > Espressif ESP32-C2-DevKitM-1
+0.97 HARDWARE: ESP32C2 120MHz, 272KB RAM, 4MB Flash
+0.97 DEBUG: Current (cmsis-dap) External (cmsis-dap, esp-bridge, esp-prog, iot-bus-jtag, jlink, minimodule, olimex-arm-usb-ocd, olimex-arm-usb-ocd-h, olimex-arm-usb-tiny-h, olimex-jtag-tiny, tumpa)
+0.97 PACKAGES:
+0.97  - contrib-piohome @ 3.4.4
+0.97  - framework-arduino-c2-skeleton-lib @ 5.5.0+sha.cbe9388f45
+0.97  - framework-arduinoespressif32 @ 3.3.0
+0.97  - framework-arduinoespressif32-libs @ 5.5.0+sha.b66b5448e0
+0.97  - framework-espidf @ 3.50500.0 (5.5.0)
+0.97  - tool-cmake @ 3.30.2
+0.97  - tool-esp-rom-elfs @ 2024.10.11
+0.97  - tool-esptoolpy @ 5.0.2
+0.97  - tool-mklittlefs @ 3.2.0
+0.97  - tool-ninja @ 1.13.1
+0.97  - tool-scons @ 4.40801.0 (4.8.1)
+0.97  - toolchain-riscv32-esp @ 14.2.0+20241119
+0.98 *** Compile Arduino IDF libs for esp32c2 ***
+0.99 *** Add "custom_sdkconfig" settings to IDF sdkconfig.defaults ***
+0.99 Replace: CONFIG_IDF_TARGET="esp32c2" with: CONFIG_IDF_TARGET=esp32c2
+0.99 Replace: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y with: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y
+0.99 Replace: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y with: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y
+0.99 Replace: CONFIG_ESPTOOLPY_FLASHFREQ="60m" with: CONFIG_ESPTOOLPY_FLASHFREQ="60m"
+1.00 Add: # CONFIG_ESPTOOLPY_FLASHFREQ_80M is not set
+1.01 Warning! Arduino framework as an ESP-IDF component doesn't handle the `variant` field! The default `esp32` variant will be used.
+1.01 Reading CMake configuration...
+5.08 LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
+5.08 LDF Modes: Finder ~ chain, Compatibility ~ soft
+5.13 Found 42 compatible libraries
+5.13 Scanning dependencies...
+5.14 No dependencies
+5.14 Building in release mode
+5.15 Environment state dumped to: env_dump.json
+5.15 Projenv state dumped to: projenv_dump.json
+5.15 Cache configuration from environment:
+5.15   Cache type: xcache
+5.15   Cache executable: python /workspace/ci/util/xcache.py
+5.15   SCCACHE path: /workspace/.venv/bin/sccache
+5.15   SCCACHE dir: /home/ubuntu/.fastled/sccache
+5.15   Debug enabled: False
+5.15 xcache wrapper detected and configured for Python fake compilers
+5.15   xcache path: /workspace/ci/util/xcache.py
+5.15   cache executable: python /workspace/ci/util/xcache.py
+5.15 DEBUG: Found compilers in env:
+5.15   CC: 'riscv32-esp-elf-gcc' (type: str)
+5.15   CXX: 'riscv32-esp-elf-g++' (type: str)
+5.15 Extracted compiler names:
+5.15   CC name: riscv32-esp-elf-gcc
+5.15   CXX name: riscv32-esp-elf-g++
+5.15 Found local compiler cache:
+5.15   Cache file: /workspace/.build/pio/esp32c2/compiler_cache.json
+5.15   Real CC: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-gcc
+5.15   Real CXX: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-g++
+5.15 SUCCESS: Using cached compilers (instant, no platform search needed):
+5.15   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.15   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.15   Platform search skipped - using cached toolset
+5.15 Created Python cached compilers:
+5.15   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.15   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.15 Applied Python fake compilers to both env and projenv
+5.15 Python fake compiler cache enabled: xcache
+5.15   Original CC: riscv32-esp-elf-gcc
+5.15   Original CXX: riscv32-esp-elf-g++
+5.15   Fake CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.15   Fake CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.15 Python fake compiler cache environment configured successfully
+5.18 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.18 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.18 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.18   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.18   RET_CODE: no such file or directory
+5.18   ERROR_MESSAGE:
+5.19 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.19   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.19   RET_CODE: no such file or directory
+5.19   ERROR_MESSAGE:
+5.20 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in] Error 1
+5.20 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in] Error 1
+5.20 Retrieved `.pio/build/esp32c2/app_trace/app_trace.c.o' from cache
+5.34 ========================== [FAILED] Took 5.21 seconds ==========================

--- a/failures/Fire2023.log
+++ b/failures/Fire2023.log
@@ -1,0 +1,95 @@
+Initial build failed: 0.12 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.12 --------------------------------------------------------------------------------
+0.44 Verbose mode can be enabled via `-v, --verbose` option
+0.51 Error output: /home/ubuntu/.fastled/compile/pio/esp32c2/penv/bin/python: No module named pip
+0.51 Error: Failed to install Python dependencies into penv
+0.55 ========================== [FAILED] Took 0.43 seconds ==========================
+Initial build failed: 0.16 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.16 --------------------------------------------------------------------------------
+0.48 Verbose mode can be enabled via `-v, --verbose` option
+0.87 CONFIGURATION: https://docs.platformio.org/page/boards/espressif32/esp32-c2-devkitm-1.html
+0.87 PLATFORM: Espressif 32 (55.3.30+develop.sha.9651ee8) > Espressif ESP32-C2-DevKitM-1
+0.87 HARDWARE: ESP32C2 120MHz, 272KB RAM, 4MB Flash
+0.87 DEBUG: Current (cmsis-dap) External (cmsis-dap, esp-bridge, esp-prog, iot-bus-jtag, jlink, minimodule, olimex-arm-usb-ocd, olimex-arm-usb-ocd-h, olimex-arm-usb-tiny-h, olimex-jtag-tiny, tumpa)
+0.87 PACKAGES:
+0.87  - contrib-piohome @ 3.4.4
+0.87  - framework-arduino-c2-skeleton-lib @ 5.5.0+sha.cbe9388f45
+0.87  - framework-arduinoespressif32 @ 3.3.0
+0.87  - framework-arduinoespressif32-libs @ 5.5.0+sha.b66b5448e0
+0.87  - framework-espidf @ 3.50500.0 (5.5.0)
+0.87  - tool-cmake @ 3.30.2
+0.87  - tool-esp-rom-elfs @ 2024.10.11
+0.87  - tool-esptoolpy @ 5.0.2
+0.87  - tool-mklittlefs @ 3.2.0
+0.87  - tool-ninja @ 1.13.1
+0.87  - tool-scons @ 4.40801.0 (4.8.1)
+0.87  - toolchain-riscv32-esp @ 14.2.0+20241119
+0.88 *** Compile Arduino IDF libs for esp32c2 ***
+0.90 *** Add "custom_sdkconfig" settings to IDF sdkconfig.defaults ***
+0.90 Replace: CONFIG_IDF_TARGET="esp32c2" with: CONFIG_IDF_TARGET=esp32c2
+0.90 Replace: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y with: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y
+0.90 Replace: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y with: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y
+0.90 Replace: CONFIG_ESPTOOLPY_FLASHFREQ="60m" with: CONFIG_ESPTOOLPY_FLASHFREQ="60m"
+0.90 Add: # CONFIG_ESPTOOLPY_FLASHFREQ_80M is not set
+0.91 Warning! Arduino framework as an ESP-IDF component doesn't handle the `variant` field! The default `esp32` variant will be used.
+0.91 Reading CMake configuration...
+5.27 Generating assembly for certificate bundle...
+5.43 LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
+5.43 LDF Modes: Finder ~ chain, Compatibility ~ soft
+5.48 Found 42 compatible libraries
+5.48 Scanning dependencies...
+5.48 No dependencies
+5.49 Building in release mode
+5.49 Environment state dumped to: env_dump.json
+5.49 Projenv state dumped to: projenv_dump.json
+5.49 Cache configuration from environment:
+5.49   Cache type: xcache
+5.49   Cache executable: python /workspace/ci/util/xcache.py
+5.49   SCCACHE path: /workspace/.venv/bin/sccache
+5.49   SCCACHE dir: /home/ubuntu/.fastled/sccache
+5.49   Debug enabled: False
+5.49 xcache wrapper detected and configured for Python fake compilers
+5.49   xcache path: /workspace/ci/util/xcache.py
+5.49   cache executable: python /workspace/ci/util/xcache.py
+5.49 DEBUG: Found compilers in env:
+5.49   CC: 'riscv32-esp-elf-gcc' (type: str)
+5.49   CXX: 'riscv32-esp-elf-g++' (type: str)
+5.49 Extracted compiler names:
+5.49   CC name: riscv32-esp-elf-gcc
+5.49   CXX name: riscv32-esp-elf-g++
+5.49 Found local compiler cache:
+5.49   Cache file: /workspace/.build/pio/esp32c2/compiler_cache.json
+5.49   Real CC: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-gcc
+5.49   Real CXX: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-g++
+5.49 SUCCESS: Using cached compilers (instant, no platform search needed):
+5.49   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.49   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.49   Platform search skipped - using cached toolset
+5.49 Created Python cached compilers:
+5.49   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.49   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.49 Applied Python fake compilers to both env and projenv
+5.49 Python fake compiler cache enabled: xcache
+5.49   Original CC: riscv32-esp-elf-gcc
+5.49   Original CXX: riscv32-esp-elf-g++
+5.49   Fake CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.49   Fake CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.49 Python fake compiler cache environment configured successfully
+5.60 Retrieved `.pio/build/esp32c2/.dummy/sketch.cpp.o' from cache
+5.60 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-gcc.c.o' from cache
+5.61 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-cpp.cpp.o' from cache
+5.61 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-as.S.o' from cache
+5.62 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.62 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.62 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.62   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.62   RET_CODE: no such file or directory
+5.62   ERROR_MESSAGE:
+5.62 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.62   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.62   RET_CODE: no such file or directory
+5.62   ERROR_MESSAGE:
+5.63 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in] Error 1
+5.63 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in] Error 1
+5.63 Retrieved `.pio/build/esp32c2/app_trace/app_trace.c.o' from cache
+5.77 ========================== [FAILED] Took 5.61 seconds ==========================

--- a/failures/FireCylinder.log
+++ b/failures/FireCylinder.log
@@ -1,0 +1,94 @@
+Initial build failed: 0.12 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.12 --------------------------------------------------------------------------------
+0.44 Verbose mode can be enabled via `-v, --verbose` option
+0.51 Error output: /home/ubuntu/.fastled/compile/pio/esp32c2/penv/bin/python: No module named pip
+0.51 Error: Failed to install Python dependencies into penv
+0.56 ========================== [FAILED] Took 0.43 seconds ==========================
+Initial build failed: 0.16 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.16 --------------------------------------------------------------------------------
+0.48 Verbose mode can be enabled via `-v, --verbose` option
+1.07 CONFIGURATION: https://docs.platformio.org/page/boards/espressif32/esp32-c2-devkitm-1.html
+1.07 PLATFORM: Espressif 32 (55.3.30+develop.sha.9651ee8) > Espressif ESP32-C2-DevKitM-1
+1.07 HARDWARE: ESP32C2 120MHz, 272KB RAM, 4MB Flash
+1.07 DEBUG: Current (cmsis-dap) External (cmsis-dap, esp-bridge, esp-prog, iot-bus-jtag, jlink, minimodule, olimex-arm-usb-ocd, olimex-arm-usb-ocd-h, olimex-arm-usb-tiny-h, olimex-jtag-tiny, tumpa)
+1.07 PACKAGES:
+1.07  - contrib-piohome @ 3.4.4
+1.07  - framework-arduino-c2-skeleton-lib @ 5.5.0+sha.cbe9388f45
+1.07  - framework-arduinoespressif32 @ 3.3.0
+1.07  - framework-arduinoespressif32-libs @ 5.5.0+sha.b66b5448e0
+1.07  - framework-espidf @ 3.50500.0 (5.5.0)
+1.07  - tool-cmake @ 3.30.2
+1.07  - tool-esp-rom-elfs @ 2024.10.11
+1.07  - tool-esptoolpy @ 5.0.2
+1.07  - tool-mklittlefs @ 3.2.0
+1.07  - tool-ninja @ 1.13.1
+1.07  - tool-scons @ 4.40801.0 (4.8.1)
+1.07  - toolchain-riscv32-esp @ 14.2.0+20241119
+1.07 *** Compile Arduino IDF libs for esp32c2 ***
+1.09 *** Add "custom_sdkconfig" settings to IDF sdkconfig.defaults ***
+1.09 Replace: CONFIG_IDF_TARGET="esp32c2" with: CONFIG_IDF_TARGET=esp32c2
+1.09 Replace: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y with: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y
+1.09 Replace: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y with: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y
+1.09 Replace: CONFIG_ESPTOOLPY_FLASHFREQ="60m" with: CONFIG_ESPTOOLPY_FLASHFREQ="60m"
+1.09 Add: # CONFIG_ESPTOOLPY_FLASHFREQ_80M is not set
+1.10 Warning! Arduino framework as an ESP-IDF component doesn't handle the `variant` field! The default `esp32` variant will be used.
+1.10 Reading CMake configuration...
+6.09 Generating assembly for certificate bundle...
+6.25 LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
+6.25 LDF Modes: Finder ~ chain, Compatibility ~ soft
+6.30 Found 42 compatible libraries
+6.30 Scanning dependencies...
+6.31 No dependencies
+6.31 Building in release mode
+6.31 Environment state dumped to: env_dump.json
+6.31 Projenv state dumped to: projenv_dump.json
+6.31 Cache configuration from environment:
+6.31   Cache type: xcache
+6.31   Cache executable: python /workspace/ci/util/xcache.py
+6.31   SCCACHE path: /workspace/.venv/bin/sccache
+6.31   SCCACHE dir: /home/ubuntu/.fastled/sccache
+6.31   Debug enabled: False
+6.31 xcache wrapper detected and configured for Python fake compilers
+6.31   xcache path: /workspace/ci/util/xcache.py
+6.31   cache executable: python /workspace/ci/util/xcache.py
+6.31 DEBUG: Found compilers in env:
+6.31   CC: 'riscv32-esp-elf-gcc' (type: str)
+6.31   CXX: 'riscv32-esp-elf-g++' (type: str)
+6.31 Extracted compiler names:
+6.31   CC name: riscv32-esp-elf-gcc
+6.31   CXX name: riscv32-esp-elf-g++
+6.31 Found local compiler cache:
+6.31   Cache file: /workspace/.build/pio/esp32c2/compiler_cache.json
+6.31   Real CC: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-gcc
+6.31   Real CXX: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-g++
+6.31 SUCCESS: Using cached compilers (instant, no platform search needed):
+6.31   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+6.31   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+6.31   Platform search skipped - using cached toolset
+6.31 Created Python cached compilers:
+6.31   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+6.31   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+6.31 Applied Python fake compilers to both env and projenv
+6.31 Python fake compiler cache enabled: xcache
+6.31   Original CC: riscv32-esp-elf-gcc
+6.31   Original CXX: riscv32-esp-elf-g++
+6.31   Fake CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+6.31   Fake CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+6.31 Python fake compiler cache environment configured successfully
+6.42 Retrieved `.pio/build/esp32c2/.dummy/sketch.cpp.o' from cache
+6.42 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-gcc.c.o' from cache
+6.43 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-cpp.cpp.o' from cache
+6.43 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-as.S.o' from cache
+6.43 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+6.43 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+6.43   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+6.43   RET_CODE: no such file or directory
+6.43   ERROR_MESSAGE:
+6.43 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+6.43 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in] Error 1
+6.44 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+6.44   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+6.44   RET_CODE: no such file or directory
+6.44   ERROR_MESSAGE:
+6.44 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in] Error 1
+6.57 ========================== [FAILED] Took 6.41 seconds ==========================

--- a/failures/FireMatrix.log
+++ b/failures/FireMatrix.log
@@ -1,0 +1,95 @@
+Initial build failed: 0.12 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.12 --------------------------------------------------------------------------------
+0.42 Verbose mode can be enabled via `-v, --verbose` option
+0.49 Error output: /home/ubuntu/.fastled/compile/pio/esp32c2/penv/bin/python: No module named pip
+0.49 Error: Failed to install Python dependencies into penv
+0.53 ========================== [FAILED] Took 0.40 seconds ==========================
+Initial build failed: 0.16 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.16 --------------------------------------------------------------------------------
+0.47 Verbose mode can be enabled via `-v, --verbose` option
+0.91 CONFIGURATION: https://docs.platformio.org/page/boards/espressif32/esp32-c2-devkitm-1.html
+0.91 PLATFORM: Espressif 32 (55.3.30+develop.sha.9651ee8) > Espressif ESP32-C2-DevKitM-1
+0.91 HARDWARE: ESP32C2 120MHz, 272KB RAM, 4MB Flash
+0.91 DEBUG: Current (cmsis-dap) External (cmsis-dap, esp-bridge, esp-prog, iot-bus-jtag, jlink, minimodule, olimex-arm-usb-ocd, olimex-arm-usb-ocd-h, olimex-arm-usb-tiny-h, olimex-jtag-tiny, tumpa)
+0.91 PACKAGES:
+0.91  - contrib-piohome @ 3.4.4
+0.91  - framework-arduino-c2-skeleton-lib @ 5.5.0+sha.cbe9388f45
+0.91  - framework-arduinoespressif32 @ 3.3.0
+0.91  - framework-arduinoespressif32-libs @ 5.5.0+sha.b66b5448e0
+0.91  - framework-espidf @ 3.50500.0 (5.5.0)
+0.91  - tool-cmake @ 3.30.2
+0.91  - tool-esp-rom-elfs @ 2024.10.11
+0.91  - tool-esptoolpy @ 5.0.2
+0.91  - tool-mklittlefs @ 3.2.0
+0.91  - tool-ninja @ 1.13.1
+0.91  - tool-scons @ 4.40801.0 (4.8.1)
+0.91  - toolchain-riscv32-esp @ 14.2.0+20241119
+0.92 *** Compile Arduino IDF libs for esp32c2 ***
+0.93 *** Add "custom_sdkconfig" settings to IDF sdkconfig.defaults ***
+0.93 Replace: CONFIG_IDF_TARGET="esp32c2" with: CONFIG_IDF_TARGET=esp32c2
+0.93 Replace: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y with: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y
+0.93 Replace: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y with: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y
+0.93 Replace: CONFIG_ESPTOOLPY_FLASHFREQ="60m" with: CONFIG_ESPTOOLPY_FLASHFREQ="60m"
+0.94 Add: # CONFIG_ESPTOOLPY_FLASHFREQ_80M is not set
+0.95 Warning! Arduino framework as an ESP-IDF component doesn't handle the `variant` field! The default `esp32` variant will be used.
+0.95 Reading CMake configuration...
+5.31 Generating assembly for certificate bundle...
+5.47 LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
+5.47 LDF Modes: Finder ~ chain, Compatibility ~ soft
+5.53 Found 42 compatible libraries
+5.53 Scanning dependencies...
+5.53 No dependencies
+5.53 Building in release mode
+5.54 Environment state dumped to: env_dump.json
+5.54 Projenv state dumped to: projenv_dump.json
+5.54 Cache configuration from environment:
+5.54   Cache type: xcache
+5.54   Cache executable: python /workspace/ci/util/xcache.py
+5.54   SCCACHE path: /workspace/.venv/bin/sccache
+5.54   SCCACHE dir: /home/ubuntu/.fastled/sccache
+5.54   Debug enabled: False
+5.54 xcache wrapper detected and configured for Python fake compilers
+5.54   xcache path: /workspace/ci/util/xcache.py
+5.54   cache executable: python /workspace/ci/util/xcache.py
+5.54 DEBUG: Found compilers in env:
+5.54   CC: 'riscv32-esp-elf-gcc' (type: str)
+5.54   CXX: 'riscv32-esp-elf-g++' (type: str)
+5.54 Extracted compiler names:
+5.54   CC name: riscv32-esp-elf-gcc
+5.54   CXX name: riscv32-esp-elf-g++
+5.54 Found local compiler cache:
+5.54   Cache file: /workspace/.build/pio/esp32c2/compiler_cache.json
+5.54   Real CC: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-gcc
+5.54   Real CXX: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-g++
+5.54 SUCCESS: Using cached compilers (instant, no platform search needed):
+5.54   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.54   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.54   Platform search skipped - using cached toolset
+5.54 Created Python cached compilers:
+5.54   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.54   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.54 Applied Python fake compilers to both env and projenv
+5.54 Python fake compiler cache enabled: xcache
+5.54   Original CC: riscv32-esp-elf-gcc
+5.54   Original CXX: riscv32-esp-elf-g++
+5.54   Fake CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.54   Fake CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.54 Python fake compiler cache environment configured successfully
+5.64 Retrieved `.pio/build/esp32c2/.dummy/sketch.cpp.o' from cache
+5.65 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-cpp.cpp.o' from cache
+5.65 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-gcc.c.o' from cache
+5.65 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-as.S.o' from cache
+5.66 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.66 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.66 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.66   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.66   RET_CODE: no such file or directory
+5.66   ERROR_MESSAGE:
+5.66 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.66   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.66   RET_CODE: no such file or directory
+5.66   ERROR_MESSAGE:
+5.67 Retrieved `.pio/build/esp32c2/app_trace/app_trace.c.o' from cache
+5.67 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in] Error 1
+5.67 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in] Error 1
+5.82 ========================== [FAILED] Took 5.66 seconds ==========================

--- a/failures/FirstLight.log
+++ b/failures/FirstLight.log
@@ -1,0 +1,94 @@
+Initial build failed: 0.12 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.12 --------------------------------------------------------------------------------
+0.43 Verbose mode can be enabled via `-v, --verbose` option
+0.52 Error output: /home/ubuntu/.fastled/compile/pio/esp32c2/penv/bin/python: No module named pip
+0.52 Error: Failed to install Python dependencies into penv
+0.56 ========================== [FAILED] Took 0.43 seconds ==========================
+Initial build failed: 0.16 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.16 --------------------------------------------------------------------------------
+0.48 Verbose mode can be enabled via `-v, --verbose` option
+0.97 CONFIGURATION: https://docs.platformio.org/page/boards/espressif32/esp32-c2-devkitm-1.html
+0.97 PLATFORM: Espressif 32 (55.3.30+develop.sha.9651ee8) > Espressif ESP32-C2-DevKitM-1
+0.97 HARDWARE: ESP32C2 120MHz, 272KB RAM, 4MB Flash
+0.97 DEBUG: Current (cmsis-dap) External (cmsis-dap, esp-bridge, esp-prog, iot-bus-jtag, jlink, minimodule, olimex-arm-usb-ocd, olimex-arm-usb-ocd-h, olimex-arm-usb-tiny-h, olimex-jtag-tiny, tumpa)
+0.97 PACKAGES:
+0.97  - contrib-piohome @ 3.4.4
+0.97  - framework-arduino-c2-skeleton-lib @ 5.5.0+sha.cbe9388f45
+0.97  - framework-arduinoespressif32 @ 3.3.0
+0.97  - framework-arduinoespressif32-libs @ 5.5.0+sha.b66b5448e0
+0.97  - framework-espidf @ 3.50500.0 (5.5.0)
+0.97  - tool-cmake @ 3.30.2
+0.97  - tool-esp-rom-elfs @ 2024.10.11
+0.97  - tool-esptoolpy @ 5.0.2
+0.97  - tool-mklittlefs @ 3.2.0
+0.97  - tool-ninja @ 1.13.1
+0.97  - tool-scons @ 4.40801.0 (4.8.1)
+0.97  - toolchain-riscv32-esp @ 14.2.0+20241119
+0.98 *** Compile Arduino IDF libs for esp32c2 ***
+1.00 *** Add "custom_sdkconfig" settings to IDF sdkconfig.defaults ***
+1.00 Replace: CONFIG_IDF_TARGET="esp32c2" with: CONFIG_IDF_TARGET=esp32c2
+1.00 Replace: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y with: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y
+1.00 Replace: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y with: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y
+1.00 Replace: CONFIG_ESPTOOLPY_FLASHFREQ="60m" with: CONFIG_ESPTOOLPY_FLASHFREQ="60m"
+1.00 Add: # CONFIG_ESPTOOLPY_FLASHFREQ_80M is not set
+1.01 Warning! Arduino framework as an ESP-IDF component doesn't handle the `variant` field! The default `esp32` variant will be used.
+1.01 Reading CMake configuration...
+5.38 Generating assembly for certificate bundle...
+5.54 LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
+5.54 LDF Modes: Finder ~ chain, Compatibility ~ soft
+5.59 Found 42 compatible libraries
+5.59 Scanning dependencies...
+5.60 No dependencies
+5.60 Building in release mode
+5.61 Environment state dumped to: env_dump.json
+5.61 Projenv state dumped to: projenv_dump.json
+5.61 Cache configuration from environment:
+5.61   Cache type: xcache
+5.61   Cache executable: python /workspace/ci/util/xcache.py
+5.61   SCCACHE path: /workspace/.venv/bin/sccache
+5.61   SCCACHE dir: /home/ubuntu/.fastled/sccache
+5.61   Debug enabled: False
+5.61 xcache wrapper detected and configured for Python fake compilers
+5.61   xcache path: /workspace/ci/util/xcache.py
+5.61   cache executable: python /workspace/ci/util/xcache.py
+5.61 DEBUG: Found compilers in env:
+5.61   CC: 'riscv32-esp-elf-gcc' (type: str)
+5.61   CXX: 'riscv32-esp-elf-g++' (type: str)
+5.61 Extracted compiler names:
+5.61   CC name: riscv32-esp-elf-gcc
+5.61   CXX name: riscv32-esp-elf-g++
+5.61 Found local compiler cache:
+5.61   Cache file: /workspace/.build/pio/esp32c2/compiler_cache.json
+5.61   Real CC: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-gcc
+5.61   Real CXX: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-g++
+5.61 SUCCESS: Using cached compilers (instant, no platform search needed):
+5.61   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.61   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.61   Platform search skipped - using cached toolset
+5.61 Created Python cached compilers:
+5.61   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.61   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.61 Applied Python fake compilers to both env and projenv
+5.61 Python fake compiler cache enabled: xcache
+5.61   Original CC: riscv32-esp-elf-gcc
+5.61   Original CXX: riscv32-esp-elf-g++
+5.61   Fake CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.61   Fake CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.61 Python fake compiler cache environment configured successfully
+5.71 Retrieved `.pio/build/esp32c2/.dummy/sketch.cpp.o' from cache
+5.71 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-gcc.c.o' from cache
+5.72 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-cpp.cpp.o' from cache
+5.72 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-as.S.o' from cache
+5.73 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.73 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.73   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.73   RET_CODE: no such file or directory
+5.73   ERROR_MESSAGE:
+5.73 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.73 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in] Error 1
+5.73 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.73   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.73   RET_CODE: no such file or directory
+5.73   ERROR_MESSAGE:
+5.73 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in] Error 1
+5.87 ========================== [FAILED] Took 5.71 seconds ==========================

--- a/failures/FxCylon.log
+++ b/failures/FxCylon.log
@@ -1,0 +1,90 @@
+Initial build failed: 0.12 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.12 --------------------------------------------------------------------------------
+0.42 Verbose mode can be enabled via `-v, --verbose` option
+0.49 Error: Failed to install Python dependencies into penv
+0.49 Error output: /home/ubuntu/.fastled/compile/pio/esp32c2/penv/bin/python: No module named pip
+0.53 ========================== [FAILED] Took 0.40 seconds ==========================
+Initial build failed: 0.13 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.13 --------------------------------------------------------------------------------
+0.44 Verbose mode can be enabled via `-v, --verbose` option
+0.84 CONFIGURATION: https://docs.platformio.org/page/boards/espressif32/esp32-c2-devkitm-1.html
+0.84 PLATFORM: Espressif 32 (55.3.30+develop.sha.9651ee8) > Espressif ESP32-C2-DevKitM-1
+0.84 HARDWARE: ESP32C2 120MHz, 272KB RAM, 4MB Flash
+0.84 DEBUG: Current (cmsis-dap) External (cmsis-dap, esp-bridge, esp-prog, iot-bus-jtag, jlink, minimodule, olimex-arm-usb-ocd, olimex-arm-usb-ocd-h, olimex-arm-usb-tiny-h, olimex-jtag-tiny, tumpa)
+0.84 PACKAGES:
+0.84  - contrib-piohome @ 3.4.4
+0.84  - framework-arduino-c2-skeleton-lib @ 5.5.0+sha.cbe9388f45
+0.84  - framework-arduinoespressif32 @ 3.3.0
+0.84  - framework-arduinoespressif32-libs @ 5.5.0+sha.b66b5448e0
+0.84  - framework-espidf @ 3.50500.0 (5.5.0)
+0.84  - tool-cmake @ 3.30.2
+0.84  - tool-esp-rom-elfs @ 2024.10.11
+0.84  - tool-esptoolpy @ 5.0.2
+0.84  - tool-mklittlefs @ 3.2.0
+0.84  - tool-ninja @ 1.13.1
+0.84  - tool-scons @ 4.40801.0 (4.8.1)
+0.84  - toolchain-riscv32-esp @ 14.2.0+20241119
+0.85 *** Compile Arduino IDF libs for esp32c2 ***
+0.86 *** Add "custom_sdkconfig" settings to IDF sdkconfig.defaults ***
+0.86 Replace: CONFIG_IDF_TARGET="esp32c2" with: CONFIG_IDF_TARGET=esp32c2
+0.86 Replace: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y with: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y
+0.86 Replace: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y with: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y
+0.86 Replace: CONFIG_ESPTOOLPY_FLASHFREQ="60m" with: CONFIG_ESPTOOLPY_FLASHFREQ="60m"
+0.87 Add: # CONFIG_ESPTOOLPY_FLASHFREQ_80M is not set
+0.88 Warning! Arduino framework as an ESP-IDF component doesn't handle the `variant` field! The default `esp32` variant will be used.
+0.88 Reading CMake configuration...
+4.96 LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
+4.96 LDF Modes: Finder ~ chain, Compatibility ~ soft
+5.02 Found 42 compatible libraries
+5.02 Scanning dependencies...
+5.02 No dependencies
+5.02 Building in release mode
+5.03 Environment state dumped to: env_dump.json
+5.03 Projenv state dumped to: projenv_dump.json
+5.03 Cache configuration from environment:
+5.03   Cache type: xcache
+5.03   Cache executable: python /workspace/ci/util/xcache.py
+5.03   SCCACHE path: /workspace/.venv/bin/sccache
+5.03   SCCACHE dir: /home/ubuntu/.fastled/sccache
+5.03   Debug enabled: False
+5.03 xcache wrapper detected and configured for Python fake compilers
+5.03   xcache path: /workspace/ci/util/xcache.py
+5.03   cache executable: python /workspace/ci/util/xcache.py
+5.03 DEBUG: Found compilers in env:
+5.03   CC: 'riscv32-esp-elf-gcc' (type: str)
+5.03   CXX: 'riscv32-esp-elf-g++' (type: str)
+5.03 Extracted compiler names:
+5.03   CC name: riscv32-esp-elf-gcc
+5.03   CXX name: riscv32-esp-elf-g++
+5.03 Found local compiler cache:
+5.03   Cache file: /workspace/.build/pio/esp32c2/compiler_cache.json
+5.03   Real CC: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-gcc
+5.03   Real CXX: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-g++
+5.03 SUCCESS: Using cached compilers (instant, no platform search needed):
+5.03   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.03   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.03   Platform search skipped - using cached toolset
+5.03 Created Python cached compilers:
+5.03   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.03   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.03 Applied Python fake compilers to both env and projenv
+5.03 Python fake compiler cache enabled: xcache
+5.03   Original CC: riscv32-esp-elf-gcc
+5.03   Original CXX: riscv32-esp-elf-g++
+5.03   Fake CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.03   Fake CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.03 Python fake compiler cache environment configured successfully
+5.06 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.06 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.06 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.06   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.06   RET_CODE: no such file or directory
+5.06   ERROR_MESSAGE:
+5.07 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.07   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.07   RET_CODE: no such file or directory
+5.07   ERROR_MESSAGE:
+5.08 Retrieved `.pio/build/esp32c2/app_trace/app_trace.c.o' from cache
+5.08 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in] Error 1
+5.08 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in] Error 1
+5.22 ========================== [FAILED] Took 5.09 seconds ==========================

--- a/failures/FxDemoReel100.log
+++ b/failures/FxDemoReel100.log
@@ -1,0 +1,95 @@
+Initial build failed: 0.14 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.14 --------------------------------------------------------------------------------
+0.45 Verbose mode can be enabled via `-v, --verbose` option
+0.53 Error output: /home/ubuntu/.fastled/compile/pio/esp32c2/penv/bin/python: No module named pip
+0.53 Error: Failed to install Python dependencies into penv
+0.57 ========================== [FAILED] Took 0.43 seconds ==========================
+Initial build failed: 0.16 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.16 --------------------------------------------------------------------------------
+0.47 Verbose mode can be enabled via `-v, --verbose` option
+0.86 CONFIGURATION: https://docs.platformio.org/page/boards/espressif32/esp32-c2-devkitm-1.html
+0.86 PLATFORM: Espressif 32 (55.3.30+develop.sha.9651ee8) > Espressif ESP32-C2-DevKitM-1
+0.86 HARDWARE: ESP32C2 120MHz, 272KB RAM, 4MB Flash
+0.86 DEBUG: Current (cmsis-dap) External (cmsis-dap, esp-bridge, esp-prog, iot-bus-jtag, jlink, minimodule, olimex-arm-usb-ocd, olimex-arm-usb-ocd-h, olimex-arm-usb-tiny-h, olimex-jtag-tiny, tumpa)
+0.86 PACKAGES:
+0.86  - contrib-piohome @ 3.4.4
+0.86  - framework-arduino-c2-skeleton-lib @ 5.5.0+sha.cbe9388f45
+0.86  - framework-arduinoespressif32 @ 3.3.0
+0.86  - framework-arduinoespressif32-libs @ 5.5.0+sha.b66b5448e0
+0.86  - framework-espidf @ 3.50500.0 (5.5.0)
+0.86  - tool-cmake @ 3.30.2
+0.86  - tool-esp-rom-elfs @ 2024.10.11
+0.86  - tool-esptoolpy @ 5.0.2
+0.86  - tool-mklittlefs @ 3.2.0
+0.86  - tool-ninja @ 1.13.1
+0.86  - tool-scons @ 4.40801.0 (4.8.1)
+0.86  - toolchain-riscv32-esp @ 14.2.0+20241119
+0.87 *** Compile Arduino IDF libs for esp32c2 ***
+0.88 *** Add "custom_sdkconfig" settings to IDF sdkconfig.defaults ***
+0.88 Replace: CONFIG_IDF_TARGET="esp32c2" with: CONFIG_IDF_TARGET=esp32c2
+0.88 Replace: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y with: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y
+0.88 Replace: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y with: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y
+0.88 Replace: CONFIG_ESPTOOLPY_FLASHFREQ="60m" with: CONFIG_ESPTOOLPY_FLASHFREQ="60m"
+0.89 Add: # CONFIG_ESPTOOLPY_FLASHFREQ_80M is not set
+0.90 Warning! Arduino framework as an ESP-IDF component doesn't handle the `variant` field! The default `esp32` variant will be used.
+0.90 Reading CMake configuration...
+5.28 Generating assembly for certificate bundle...
+5.44 LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
+5.44 LDF Modes: Finder ~ chain, Compatibility ~ soft
+5.49 Found 42 compatible libraries
+5.49 Scanning dependencies...
+5.50 No dependencies
+5.50 Building in release mode
+5.51 Environment state dumped to: env_dump.json
+5.51 Projenv state dumped to: projenv_dump.json
+5.51 Cache configuration from environment:
+5.51   Cache type: xcache
+5.51   Cache executable: python /workspace/ci/util/xcache.py
+5.51   SCCACHE path: /workspace/.venv/bin/sccache
+5.51   SCCACHE dir: /home/ubuntu/.fastled/sccache
+5.51   Debug enabled: False
+5.51 xcache wrapper detected and configured for Python fake compilers
+5.51   xcache path: /workspace/ci/util/xcache.py
+5.51   cache executable: python /workspace/ci/util/xcache.py
+5.51 DEBUG: Found compilers in env:
+5.51   CC: 'riscv32-esp-elf-gcc' (type: str)
+5.51   CXX: 'riscv32-esp-elf-g++' (type: str)
+5.51 Extracted compiler names:
+5.51   CC name: riscv32-esp-elf-gcc
+5.51   CXX name: riscv32-esp-elf-g++
+5.51 Found local compiler cache:
+5.51   Cache file: /workspace/.build/pio/esp32c2/compiler_cache.json
+5.51   Real CC: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-gcc
+5.51   Real CXX: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-g++
+5.51 SUCCESS: Using cached compilers (instant, no platform search needed):
+5.51   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.51   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.51   Platform search skipped - using cached toolset
+5.51 Created Python cached compilers:
+5.51   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.51   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.51 Applied Python fake compilers to both env and projenv
+5.51 Python fake compiler cache enabled: xcache
+5.51   Original CC: riscv32-esp-elf-gcc
+5.51   Original CXX: riscv32-esp-elf-g++
+5.51   Fake CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.51   Fake CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.51 Python fake compiler cache environment configured successfully
+5.61 Retrieved `.pio/build/esp32c2/.dummy/sketch.cpp.o' from cache
+5.61 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-gcc.c.o' from cache
+5.62 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-cpp.cpp.o' from cache
+5.62 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-as.S.o' from cache
+5.62 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.63 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.63   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.63   RET_CODE: no such file or directory
+5.63   ERROR_MESSAGE:
+5.63 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.63 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.63   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.63   RET_CODE: no such file or directory
+5.63   ERROR_MESSAGE:
+5.64 Retrieved `.pio/build/esp32c2/app_trace/app_trace.c.o' from cache
+5.64 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in] Error 1
+5.64 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in] Error 1
+5.78 ========================== [FAILED] Took 5.62 seconds ==========================

--- a/failures/FxEngine.log
+++ b/failures/FxEngine.log
@@ -1,0 +1,95 @@
+Initial build failed: 0.12 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.12 --------------------------------------------------------------------------------
+0.42 Verbose mode can be enabled via `-v, --verbose` option
+0.50 Error output: /home/ubuntu/.fastled/compile/pio/esp32c2/penv/bin/python: No module named pip
+0.50 Error: Failed to install Python dependencies into penv
+0.53 ========================== [FAILED] Took 0.41 seconds ==========================
+Initial build failed: 0.17 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.17 --------------------------------------------------------------------------------
+0.48 Verbose mode can be enabled via `-v, --verbose` option
+0.87 CONFIGURATION: https://docs.platformio.org/page/boards/espressif32/esp32-c2-devkitm-1.html
+0.87 PLATFORM: Espressif 32 (55.3.30+develop.sha.9651ee8) > Espressif ESP32-C2-DevKitM-1
+0.87 HARDWARE: ESP32C2 120MHz, 272KB RAM, 4MB Flash
+0.87 DEBUG: Current (cmsis-dap) External (cmsis-dap, esp-bridge, esp-prog, iot-bus-jtag, jlink, minimodule, olimex-arm-usb-ocd, olimex-arm-usb-ocd-h, olimex-arm-usb-tiny-h, olimex-jtag-tiny, tumpa)
+0.87 PACKAGES:
+0.87  - contrib-piohome @ 3.4.4
+0.87  - framework-arduino-c2-skeleton-lib @ 5.5.0+sha.cbe9388f45
+0.87  - framework-arduinoespressif32 @ 3.3.0
+0.87  - framework-arduinoespressif32-libs @ 5.5.0+sha.b66b5448e0
+0.87  - framework-espidf @ 3.50500.0 (5.5.0)
+0.87  - tool-cmake @ 3.30.2
+0.87  - tool-esp-rom-elfs @ 2024.10.11
+0.87  - tool-esptoolpy @ 5.0.2
+0.87  - tool-mklittlefs @ 3.2.0
+0.87  - tool-ninja @ 1.13.1
+0.87  - tool-scons @ 4.40801.0 (4.8.1)
+0.87  - toolchain-riscv32-esp @ 14.2.0+20241119
+0.88 *** Compile Arduino IDF libs for esp32c2 ***
+0.90 *** Add "custom_sdkconfig" settings to IDF sdkconfig.defaults ***
+0.90 Replace: CONFIG_IDF_TARGET="esp32c2" with: CONFIG_IDF_TARGET=esp32c2
+0.90 Replace: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y with: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y
+0.90 Replace: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y with: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y
+0.90 Replace: CONFIG_ESPTOOLPY_FLASHFREQ="60m" with: CONFIG_ESPTOOLPY_FLASHFREQ="60m"
+0.90 Add: # CONFIG_ESPTOOLPY_FLASHFREQ_80M is not set
+0.91 Warning! Arduino framework as an ESP-IDF component doesn't handle the `variant` field! The default `esp32` variant will be used.
+0.91 Reading CMake configuration...
+5.40 Generating assembly for certificate bundle...
+5.56 LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
+5.56 LDF Modes: Finder ~ chain, Compatibility ~ soft
+5.62 Found 42 compatible libraries
+5.62 Scanning dependencies...
+5.62 No dependencies
+5.62 Building in release mode
+5.63 Environment state dumped to: env_dump.json
+5.63 Projenv state dumped to: projenv_dump.json
+5.63 Cache configuration from environment:
+5.63   Cache type: xcache
+5.63   Cache executable: python /workspace/ci/util/xcache.py
+5.63   SCCACHE path: /workspace/.venv/bin/sccache
+5.63   SCCACHE dir: /home/ubuntu/.fastled/sccache
+5.63   Debug enabled: False
+5.63 xcache wrapper detected and configured for Python fake compilers
+5.63   xcache path: /workspace/ci/util/xcache.py
+5.63   cache executable: python /workspace/ci/util/xcache.py
+5.63 DEBUG: Found compilers in env:
+5.63   CC: 'riscv32-esp-elf-gcc' (type: str)
+5.63   CXX: 'riscv32-esp-elf-g++' (type: str)
+5.63 Extracted compiler names:
+5.63   CC name: riscv32-esp-elf-gcc
+5.63   CXX name: riscv32-esp-elf-g++
+5.63 Found local compiler cache:
+5.63   Cache file: /workspace/.build/pio/esp32c2/compiler_cache.json
+5.63   Real CC: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-gcc
+5.63   Real CXX: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-g++
+5.63 SUCCESS: Using cached compilers (instant, no platform search needed):
+5.63   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.63   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.63   Platform search skipped - using cached toolset
+5.63 Created Python cached compilers:
+5.63   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.63   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.63 Applied Python fake compilers to both env and projenv
+5.63 Python fake compiler cache enabled: xcache
+5.63   Original CC: riscv32-esp-elf-gcc
+5.63   Original CXX: riscv32-esp-elf-g++
+5.63   Fake CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.63   Fake CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.63 Python fake compiler cache environment configured successfully
+5.73 Retrieved `.pio/build/esp32c2/.dummy/sketch.cpp.o' from cache
+5.74 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-gcc.c.o' from cache
+5.74 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-cpp.cpp.o' from cache
+5.75 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-as.S.o' from cache
+5.75 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.75 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.75 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.75   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.75   RET_CODE: no such file or directory
+5.75   ERROR_MESSAGE:
+5.76 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.76   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.76   RET_CODE: no such file or directory
+5.76   ERROR_MESSAGE:
+5.77 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in] Error 1
+5.77 Retrieved `.pio/build/esp32c2/app_trace/app_trace.c.o' from cache
+5.77 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in] Error 1
+5.91 ========================== [FAILED] Took 5.75 seconds ==========================

--- a/failures/FxFire2012.log
+++ b/failures/FxFire2012.log
@@ -1,0 +1,90 @@
+Initial build failed: 0.12 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.12 --------------------------------------------------------------------------------
+0.42 Verbose mode can be enabled via `-v, --verbose` option
+0.50 Error output: /home/ubuntu/.fastled/compile/pio/esp32c2/penv/bin/python: No module named pip
+0.50 Error: Failed to install Python dependencies into penv
+0.54 ========================== [FAILED] Took 0.41 seconds ==========================
+Initial build failed: 0.13 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.13 --------------------------------------------------------------------------------
+0.43 Verbose mode can be enabled via `-v, --verbose` option
+0.83 CONFIGURATION: https://docs.platformio.org/page/boards/espressif32/esp32-c2-devkitm-1.html
+0.83 PLATFORM: Espressif 32 (55.3.30+develop.sha.9651ee8) > Espressif ESP32-C2-DevKitM-1
+0.83 HARDWARE: ESP32C2 120MHz, 272KB RAM, 4MB Flash
+0.83 DEBUG: Current (cmsis-dap) External (cmsis-dap, esp-bridge, esp-prog, iot-bus-jtag, jlink, minimodule, olimex-arm-usb-ocd, olimex-arm-usb-ocd-h, olimex-arm-usb-tiny-h, olimex-jtag-tiny, tumpa)
+0.83 PACKAGES:
+0.83  - contrib-piohome @ 3.4.4
+0.83  - framework-arduino-c2-skeleton-lib @ 5.5.0+sha.cbe9388f45
+0.83  - framework-arduinoespressif32 @ 3.3.0
+0.83  - framework-arduinoespressif32-libs @ 5.5.0+sha.b66b5448e0
+0.83  - framework-espidf @ 3.50500.0 (5.5.0)
+0.83  - tool-cmake @ 3.30.2
+0.83  - tool-esp-rom-elfs @ 2024.10.11
+0.83  - tool-esptoolpy @ 5.0.2
+0.83  - tool-mklittlefs @ 3.2.0
+0.83  - tool-ninja @ 1.13.1
+0.83  - tool-scons @ 4.40801.0 (4.8.1)
+0.83  - toolchain-riscv32-esp @ 14.2.0+20241119
+0.84 *** Compile Arduino IDF libs for esp32c2 ***
+0.86 *** Add "custom_sdkconfig" settings to IDF sdkconfig.defaults ***
+0.86 Replace: CONFIG_IDF_TARGET="esp32c2" with: CONFIG_IDF_TARGET=esp32c2
+0.86 Replace: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y with: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y
+0.86 Replace: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y with: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y
+0.86 Replace: CONFIG_ESPTOOLPY_FLASHFREQ="60m" with: CONFIG_ESPTOOLPY_FLASHFREQ="60m"
+0.86 Add: # CONFIG_ESPTOOLPY_FLASHFREQ_80M is not set
+0.87 Warning! Arduino framework as an ESP-IDF component doesn't handle the `variant` field! The default `esp32` variant will be used.
+0.87 Reading CMake configuration...
+4.96 LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
+4.96 LDF Modes: Finder ~ chain, Compatibility ~ soft
+5.01 Found 42 compatible libraries
+5.01 Scanning dependencies...
+5.01 No dependencies
+5.02 Building in release mode
+5.02 Environment state dumped to: env_dump.json
+5.02 Projenv state dumped to: projenv_dump.json
+5.02 Cache configuration from environment:
+5.02   Cache type: xcache
+5.02   Cache executable: python /workspace/ci/util/xcache.py
+5.02   SCCACHE path: /workspace/.venv/bin/sccache
+5.02   SCCACHE dir: /home/ubuntu/.fastled/sccache
+5.02   Debug enabled: False
+5.02 xcache wrapper detected and configured for Python fake compilers
+5.02   xcache path: /workspace/ci/util/xcache.py
+5.02   cache executable: python /workspace/ci/util/xcache.py
+5.02 DEBUG: Found compilers in env:
+5.02   CC: 'riscv32-esp-elf-gcc' (type: str)
+5.02   CXX: 'riscv32-esp-elf-g++' (type: str)
+5.02 Extracted compiler names:
+5.02   CC name: riscv32-esp-elf-gcc
+5.02   CXX name: riscv32-esp-elf-g++
+5.02 Found local compiler cache:
+5.02   Cache file: /workspace/.build/pio/esp32c2/compiler_cache.json
+5.02   Real CC: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-gcc
+5.02   Real CXX: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-g++
+5.02 SUCCESS: Using cached compilers (instant, no platform search needed):
+5.02   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.02   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.02   Platform search skipped - using cached toolset
+5.02 Created Python cached compilers:
+5.02   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.02   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.02 Applied Python fake compilers to both env and projenv
+5.03 Python fake compiler cache enabled: xcache
+5.03   Original CC: riscv32-esp-elf-gcc
+5.03   Original CXX: riscv32-esp-elf-g++
+5.03   Fake CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.03   Fake CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.03 Python fake compiler cache environment configured successfully
+5.06 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.06 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.06 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.06   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.06   RET_CODE: no such file or directory
+5.06   ERROR_MESSAGE:
+5.06 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.06   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.06   RET_CODE: no such file or directory
+5.06   ERROR_MESSAGE:
+5.08 Retrieved `.pio/build/esp32c2/app_trace/app_trace_util.c.o' from cache
+5.08 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in] Error 1
+5.08 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in] Error 1
+5.22 ========================== [FAILED] Took 5.09 seconds ==========================

--- a/failures/FxGfx2Video.log
+++ b/failures/FxGfx2Video.log
@@ -1,0 +1,90 @@
+Initial build failed: 0.12 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.12 --------------------------------------------------------------------------------
+0.42 Verbose mode can be enabled via `-v, --verbose` option
+0.50 Error: Failed to install Python dependencies into penv
+0.50 Error output: /home/ubuntu/.fastled/compile/pio/esp32c2/penv/bin/python: No module named pip
+0.53 ========================== [FAILED] Took 0.41 seconds ==========================
+Initial build failed: 0.13 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.13 --------------------------------------------------------------------------------
+0.45 Verbose mode can be enabled via `-v, --verbose` option
+0.85 CONFIGURATION: https://docs.platformio.org/page/boards/espressif32/esp32-c2-devkitm-1.html
+0.85 PLATFORM: Espressif 32 (55.3.30+develop.sha.9651ee8) > Espressif ESP32-C2-DevKitM-1
+0.85 HARDWARE: ESP32C2 120MHz, 272KB RAM, 4MB Flash
+0.85 DEBUG: Current (cmsis-dap) External (cmsis-dap, esp-bridge, esp-prog, iot-bus-jtag, jlink, minimodule, olimex-arm-usb-ocd, olimex-arm-usb-ocd-h, olimex-arm-usb-tiny-h, olimex-jtag-tiny, tumpa)
+0.85 PACKAGES:
+0.85  - contrib-piohome @ 3.4.4
+0.85  - framework-arduino-c2-skeleton-lib @ 5.5.0+sha.cbe9388f45
+0.85  - framework-arduinoespressif32 @ 3.3.0
+0.85  - framework-arduinoespressif32-libs @ 5.5.0+sha.b66b5448e0
+0.85  - framework-espidf @ 3.50500.0 (5.5.0)
+0.85  - tool-cmake @ 3.30.2
+0.85  - tool-esp-rom-elfs @ 2024.10.11
+0.85  - tool-esptoolpy @ 5.0.2
+0.85  - tool-mklittlefs @ 3.2.0
+0.85  - tool-ninja @ 1.13.1
+0.85  - tool-scons @ 4.40801.0 (4.8.1)
+0.85  - toolchain-riscv32-esp @ 14.2.0+20241119
+0.85 *** Compile Arduino IDF libs for esp32c2 ***
+0.87 *** Add "custom_sdkconfig" settings to IDF sdkconfig.defaults ***
+0.87 Replace: CONFIG_IDF_TARGET="esp32c2" with: CONFIG_IDF_TARGET=esp32c2
+0.87 Replace: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y with: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y
+0.87 Replace: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y with: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y
+0.87 Replace: CONFIG_ESPTOOLPY_FLASHFREQ="60m" with: CONFIG_ESPTOOLPY_FLASHFREQ="60m"
+0.87 Add: # CONFIG_ESPTOOLPY_FLASHFREQ_80M is not set
+0.88 Warning! Arduino framework as an ESP-IDF component doesn't handle the `variant` field! The default `esp32` variant will be used.
+0.88 Reading CMake configuration...
+4.95 LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
+4.95 LDF Modes: Finder ~ chain, Compatibility ~ soft
+5.00 Found 42 compatible libraries
+5.00 Scanning dependencies...
+5.00 No dependencies
+5.01 Building in release mode
+5.01 Environment state dumped to: env_dump.json
+5.01 Projenv state dumped to: projenv_dump.json
+5.01 Cache configuration from environment:
+5.01   Cache type: xcache
+5.01   Cache executable: python /workspace/ci/util/xcache.py
+5.01   SCCACHE path: /workspace/.venv/bin/sccache
+5.01   SCCACHE dir: /home/ubuntu/.fastled/sccache
+5.01   Debug enabled: False
+5.01 xcache wrapper detected and configured for Python fake compilers
+5.01   xcache path: /workspace/ci/util/xcache.py
+5.01   cache executable: python /workspace/ci/util/xcache.py
+5.01 DEBUG: Found compilers in env:
+5.01   CC: 'riscv32-esp-elf-gcc' (type: str)
+5.01   CXX: 'riscv32-esp-elf-g++' (type: str)
+5.01 Extracted compiler names:
+5.01   CC name: riscv32-esp-elf-gcc
+5.01   CXX name: riscv32-esp-elf-g++
+5.01 Found local compiler cache:
+5.01   Cache file: /workspace/.build/pio/esp32c2/compiler_cache.json
+5.01   Real CC: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-gcc
+5.01   Real CXX: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-g++
+5.01 SUCCESS: Using cached compilers (instant, no platform search needed):
+5.01   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.01   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.01   Platform search skipped - using cached toolset
+5.01 Created Python cached compilers:
+5.01   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.01   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.01 Applied Python fake compilers to both env and projenv
+5.01 Python fake compiler cache enabled: xcache
+5.01   Original CC: riscv32-esp-elf-gcc
+5.01   Original CXX: riscv32-esp-elf-g++
+5.01   Fake CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.01   Fake CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.01 Python fake compiler cache environment configured successfully
+5.05 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.05 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.05 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.05   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.05   RET_CODE: no such file or directory
+5.05   ERROR_MESSAGE:
+5.05 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.05   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.05   RET_CODE: no such file or directory
+5.05   ERROR_MESSAGE:
+5.07 Retrieved `.pio/build/esp32c2/app_trace/host_file_io.c.o' from cache
+5.07 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in] Error 1
+5.07 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in] Error 1
+5.21 ========================== [FAILED] Took 5.08 seconds ==========================

--- a/failures/FxNoisePlusPalette.log
+++ b/failures/FxNoisePlusPalette.log
@@ -1,0 +1,90 @@
+Initial build failed: 0.12 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.12 --------------------------------------------------------------------------------
+0.42 Verbose mode can be enabled via `-v, --verbose` option
+0.50 Error: Failed to install Python dependencies into penv
+0.50 Error output: /home/ubuntu/.fastled/compile/pio/esp32c2/penv/bin/python: No module named pip
+0.53 ========================== [FAILED] Took 0.41 seconds ==========================
+Initial build failed: 0.13 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.13 --------------------------------------------------------------------------------
+0.43 Verbose mode can be enabled via `-v, --verbose` option
+0.85 CONFIGURATION: https://docs.platformio.org/page/boards/espressif32/esp32-c2-devkitm-1.html
+0.85 PLATFORM: Espressif 32 (55.3.30+develop.sha.9651ee8) > Espressif ESP32-C2-DevKitM-1
+0.85 HARDWARE: ESP32C2 120MHz, 272KB RAM, 4MB Flash
+0.85 DEBUG: Current (cmsis-dap) External (cmsis-dap, esp-bridge, esp-prog, iot-bus-jtag, jlink, minimodule, olimex-arm-usb-ocd, olimex-arm-usb-ocd-h, olimex-arm-usb-tiny-h, olimex-jtag-tiny, tumpa)
+0.85 PACKAGES:
+0.85  - contrib-piohome @ 3.4.4
+0.85  - framework-arduino-c2-skeleton-lib @ 5.5.0+sha.cbe9388f45
+0.85  - framework-arduinoespressif32 @ 3.3.0
+0.85  - framework-arduinoespressif32-libs @ 5.5.0+sha.b66b5448e0
+0.85  - framework-espidf @ 3.50500.0 (5.5.0)
+0.85  - tool-cmake @ 3.30.2
+0.85  - tool-esp-rom-elfs @ 2024.10.11
+0.85  - tool-esptoolpy @ 5.0.2
+0.85  - tool-mklittlefs @ 3.2.0
+0.85  - tool-ninja @ 1.13.1
+0.85  - tool-scons @ 4.40801.0 (4.8.1)
+0.85  - toolchain-riscv32-esp @ 14.2.0+20241119
+0.85 *** Compile Arduino IDF libs for esp32c2 ***
+0.87 *** Add "custom_sdkconfig" settings to IDF sdkconfig.defaults ***
+0.87 Replace: CONFIG_IDF_TARGET="esp32c2" with: CONFIG_IDF_TARGET=esp32c2
+0.87 Replace: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y with: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y
+0.87 Replace: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y with: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y
+0.87 Replace: CONFIG_ESPTOOLPY_FLASHFREQ="60m" with: CONFIG_ESPTOOLPY_FLASHFREQ="60m"
+0.87 Add: # CONFIG_ESPTOOLPY_FLASHFREQ_80M is not set
+0.88 Warning! Arduino framework as an ESP-IDF component doesn't handle the `variant` field! The default `esp32` variant will be used.
+0.88 Reading CMake configuration...
+4.97 LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
+4.97 LDF Modes: Finder ~ chain, Compatibility ~ soft
+5.02 Found 42 compatible libraries
+5.02 Scanning dependencies...
+5.03 No dependencies
+5.03 Building in release mode
+5.03 Environment state dumped to: env_dump.json
+5.04 Projenv state dumped to: projenv_dump.json
+5.04 Cache configuration from environment:
+5.04   Cache type: xcache
+5.04   Cache executable: python /workspace/ci/util/xcache.py
+5.04   SCCACHE path: /workspace/.venv/bin/sccache
+5.04   SCCACHE dir: /home/ubuntu/.fastled/sccache
+5.04   Debug enabled: False
+5.04 xcache wrapper detected and configured for Python fake compilers
+5.04   xcache path: /workspace/ci/util/xcache.py
+5.04   cache executable: python /workspace/ci/util/xcache.py
+5.04 DEBUG: Found compilers in env:
+5.04   CC: 'riscv32-esp-elf-gcc' (type: str)
+5.04   CXX: 'riscv32-esp-elf-g++' (type: str)
+5.04 Extracted compiler names:
+5.04   CC name: riscv32-esp-elf-gcc
+5.04   CXX name: riscv32-esp-elf-g++
+5.04 Found local compiler cache:
+5.04   Cache file: /workspace/.build/pio/esp32c2/compiler_cache.json
+5.04   Real CC: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-gcc
+5.04   Real CXX: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-g++
+5.04 SUCCESS: Using cached compilers (instant, no platform search needed):
+5.04   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.04   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.04   Platform search skipped - using cached toolset
+5.04 Created Python cached compilers:
+5.04   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.04   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.04 Applied Python fake compilers to both env and projenv
+5.04 Python fake compiler cache enabled: xcache
+5.04   Original CC: riscv32-esp-elf-gcc
+5.04   Original CXX: riscv32-esp-elf-g++
+5.04   Fake CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.04   Fake CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.04 Python fake compiler cache environment configured successfully
+5.07 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.07 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.07 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.07   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.07   RET_CODE: no such file or directory
+5.07   ERROR_MESSAGE:
+5.07 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.07   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.07   RET_CODE: no such file or directory
+5.07   ERROR_MESSAGE:
+5.10 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in] Error 1
+5.10 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in] Error 1
+5.10 Retrieved `.pio/build/esp32c2/app_trace/port/port_uart.c.o' from cache
+5.24 ========================== [FAILED] Took 5.11 seconds ==========================

--- a/failures/FxNoiseRing.log
+++ b/failures/FxNoiseRing.log
@@ -1,0 +1,94 @@
+Initial build failed: 0.12 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.12 --------------------------------------------------------------------------------
+0.44 Verbose mode can be enabled via `-v, --verbose` option
+0.51 Error output: /home/ubuntu/.fastled/compile/pio/esp32c2/penv/bin/python: No module named pip
+0.51 Error: Failed to install Python dependencies into penv
+0.55 ========================== [FAILED] Took 0.43 seconds ==========================
+Initial build failed: 0.16 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.16 --------------------------------------------------------------------------------
+0.47 Verbose mode can be enabled via `-v, --verbose` option
+0.87 CONFIGURATION: https://docs.platformio.org/page/boards/espressif32/esp32-c2-devkitm-1.html
+0.87 PLATFORM: Espressif 32 (55.3.30+develop.sha.9651ee8) > Espressif ESP32-C2-DevKitM-1
+0.87 HARDWARE: ESP32C2 120MHz, 272KB RAM, 4MB Flash
+0.87 DEBUG: Current (cmsis-dap) External (cmsis-dap, esp-bridge, esp-prog, iot-bus-jtag, jlink, minimodule, olimex-arm-usb-ocd, olimex-arm-usb-ocd-h, olimex-arm-usb-tiny-h, olimex-jtag-tiny, tumpa)
+0.87 PACKAGES:
+0.87  - contrib-piohome @ 3.4.4
+0.87  - framework-arduino-c2-skeleton-lib @ 5.5.0+sha.cbe9388f45
+0.87  - framework-arduinoespressif32 @ 3.3.0
+0.87  - framework-arduinoespressif32-libs @ 5.5.0+sha.b66b5448e0
+0.87  - framework-espidf @ 3.50500.0 (5.5.0)
+0.87  - tool-cmake @ 3.30.2
+0.87  - tool-esp-rom-elfs @ 2024.10.11
+0.87  - tool-esptoolpy @ 5.0.2
+0.87  - tool-mklittlefs @ 3.2.0
+0.87  - tool-ninja @ 1.13.1
+0.87  - tool-scons @ 4.40801.0 (4.8.1)
+0.87  - toolchain-riscv32-esp @ 14.2.0+20241119
+0.87 *** Compile Arduino IDF libs for esp32c2 ***
+0.89 *** Add "custom_sdkconfig" settings to IDF sdkconfig.defaults ***
+0.89 Replace: CONFIG_IDF_TARGET="esp32c2" with: CONFIG_IDF_TARGET=esp32c2
+0.89 Replace: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y with: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y
+0.89 Replace: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y with: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y
+0.89 Replace: CONFIG_ESPTOOLPY_FLASHFREQ="60m" with: CONFIG_ESPTOOLPY_FLASHFREQ="60m"
+0.89 Add: # CONFIG_ESPTOOLPY_FLASHFREQ_80M is not set
+0.90 Warning! Arduino framework as an ESP-IDF component doesn't handle the `variant` field! The default `esp32` variant will be used.
+0.90 Reading CMake configuration...
+5.27 Generating assembly for certificate bundle...
+5.43 LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
+5.43 LDF Modes: Finder ~ chain, Compatibility ~ soft
+5.48 Found 42 compatible libraries
+5.48 Scanning dependencies...
+5.49 No dependencies
+5.49 Building in release mode
+5.50 Environment state dumped to: env_dump.json
+5.50 Projenv state dumped to: projenv_dump.json
+5.50 Cache configuration from environment:
+5.50   Cache type: xcache
+5.50   Cache executable: python /workspace/ci/util/xcache.py
+5.50   SCCACHE path: /workspace/.venv/bin/sccache
+5.50   SCCACHE dir: /home/ubuntu/.fastled/sccache
+5.50   Debug enabled: False
+5.50 xcache wrapper detected and configured for Python fake compilers
+5.50   xcache path: /workspace/ci/util/xcache.py
+5.50   cache executable: python /workspace/ci/util/xcache.py
+5.50 DEBUG: Found compilers in env:
+5.50   CC: 'riscv32-esp-elf-gcc' (type: str)
+5.50   CXX: 'riscv32-esp-elf-g++' (type: str)
+5.50 Extracted compiler names:
+5.50   CC name: riscv32-esp-elf-gcc
+5.50   CXX name: riscv32-esp-elf-g++
+5.50 Found local compiler cache:
+5.50   Cache file: /workspace/.build/pio/esp32c2/compiler_cache.json
+5.50   Real CC: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-gcc
+5.50   Real CXX: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-g++
+5.50 SUCCESS: Using cached compilers (instant, no platform search needed):
+5.50   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.50   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.50   Platform search skipped - using cached toolset
+5.50 Created Python cached compilers:
+5.50   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.50   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.50 Applied Python fake compilers to both env and projenv
+5.50 Python fake compiler cache enabled: xcache
+5.50   Original CC: riscv32-esp-elf-gcc
+5.50   Original CXX: riscv32-esp-elf-g++
+5.50   Fake CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.50   Fake CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.50 Python fake compiler cache environment configured successfully
+5.60 Retrieved `.pio/build/esp32c2/.dummy/sketch.cpp.o' from cache
+5.60 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-gcc.c.o' from cache
+5.61 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-cpp.cpp.o' from cache
+5.61 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-as.S.o' from cache
+5.62 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.62 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.62   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.62   RET_CODE: no such file or directory
+5.62   ERROR_MESSAGE:
+5.62 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.62 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in] Error 1
+5.62 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.62   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.62   RET_CODE: no such file or directory
+5.62   ERROR_MESSAGE:
+5.62 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in] Error 1
+5.76 ========================== [FAILED] Took 5.60 seconds ==========================

--- a/failures/FxPacifica.log
+++ b/failures/FxPacifica.log
@@ -1,0 +1,95 @@
+Initial build failed: 0.12 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.12 --------------------------------------------------------------------------------
+0.42 Verbose mode can be enabled via `-v, --verbose` option
+0.49 Error: Failed to install Python dependencies into penv
+0.49 Error output: /home/ubuntu/.fastled/compile/pio/esp32c2/penv/bin/python: No module named pip
+0.53 ========================== [FAILED] Took 0.40 seconds ==========================
+Initial build failed: 0.16 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.16 --------------------------------------------------------------------------------
+0.48 Verbose mode can be enabled via `-v, --verbose` option
+0.88 CONFIGURATION: https://docs.platformio.org/page/boards/espressif32/esp32-c2-devkitm-1.html
+0.88 PLATFORM: Espressif 32 (55.3.30+develop.sha.9651ee8) > Espressif ESP32-C2-DevKitM-1
+0.88 HARDWARE: ESP32C2 120MHz, 272KB RAM, 4MB Flash
+0.88 DEBUG: Current (cmsis-dap) External (cmsis-dap, esp-bridge, esp-prog, iot-bus-jtag, jlink, minimodule, olimex-arm-usb-ocd, olimex-arm-usb-ocd-h, olimex-arm-usb-tiny-h, olimex-jtag-tiny, tumpa)
+0.88 PACKAGES:
+0.88  - contrib-piohome @ 3.4.4
+0.88  - framework-arduino-c2-skeleton-lib @ 5.5.0+sha.cbe9388f45
+0.88  - framework-arduinoespressif32 @ 3.3.0
+0.88  - framework-arduinoespressif32-libs @ 5.5.0+sha.b66b5448e0
+0.88  - framework-espidf @ 3.50500.0 (5.5.0)
+0.88  - tool-cmake @ 3.30.2
+0.88  - tool-esp-rom-elfs @ 2024.10.11
+0.88  - tool-esptoolpy @ 5.0.2
+0.88  - tool-mklittlefs @ 3.2.0
+0.88  - tool-ninja @ 1.13.1
+0.88  - tool-scons @ 4.40801.0 (4.8.1)
+0.88  - toolchain-riscv32-esp @ 14.2.0+20241119
+0.89 *** Compile Arduino IDF libs for esp32c2 ***
+0.91 *** Add "custom_sdkconfig" settings to IDF sdkconfig.defaults ***
+0.91 Replace: CONFIG_IDF_TARGET="esp32c2" with: CONFIG_IDF_TARGET=esp32c2
+0.91 Replace: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y with: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y
+0.91 Replace: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y with: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y
+0.91 Replace: CONFIG_ESPTOOLPY_FLASHFREQ="60m" with: CONFIG_ESPTOOLPY_FLASHFREQ="60m"
+0.91 Add: # CONFIG_ESPTOOLPY_FLASHFREQ_80M is not set
+0.92 Warning! Arduino framework as an ESP-IDF component doesn't handle the `variant` field! The default `esp32` variant will be used.
+0.92 Reading CMake configuration...
+5.28 Generating assembly for certificate bundle...
+5.44 LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
+5.44 LDF Modes: Finder ~ chain, Compatibility ~ soft
+5.50 Found 42 compatible libraries
+5.50 Scanning dependencies...
+5.50 No dependencies
+5.50 Building in release mode
+5.51 Environment state dumped to: env_dump.json
+5.51 Projenv state dumped to: projenv_dump.json
+5.51 Cache configuration from environment:
+5.51   Cache type: xcache
+5.51   Cache executable: python /workspace/ci/util/xcache.py
+5.51   SCCACHE path: /workspace/.venv/bin/sccache
+5.51   SCCACHE dir: /home/ubuntu/.fastled/sccache
+5.51   Debug enabled: False
+5.51 xcache wrapper detected and configured for Python fake compilers
+5.51   xcache path: /workspace/ci/util/xcache.py
+5.51   cache executable: python /workspace/ci/util/xcache.py
+5.51 DEBUG: Found compilers in env:
+5.51   CC: 'riscv32-esp-elf-gcc' (type: str)
+5.51   CXX: 'riscv32-esp-elf-g++' (type: str)
+5.51 Extracted compiler names:
+5.51   CC name: riscv32-esp-elf-gcc
+5.51   CXX name: riscv32-esp-elf-g++
+5.51 Found local compiler cache:
+5.51   Cache file: /workspace/.build/pio/esp32c2/compiler_cache.json
+5.51   Real CC: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-gcc
+5.51   Real CXX: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-g++
+5.51 SUCCESS: Using cached compilers (instant, no platform search needed):
+5.51   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.51   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.51   Platform search skipped - using cached toolset
+5.51 Created Python cached compilers:
+5.51   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.51   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.51 Applied Python fake compilers to both env and projenv
+5.51 Python fake compiler cache enabled: xcache
+5.51   Original CC: riscv32-esp-elf-gcc
+5.51   Original CXX: riscv32-esp-elf-g++
+5.51   Fake CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.51   Fake CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.51 Python fake compiler cache environment configured successfully
+5.61 Retrieved `.pio/build/esp32c2/.dummy/sketch.cpp.o' from cache
+5.62 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-gcc.c.o' from cache
+5.62 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-cpp.cpp.o' from cache
+5.63 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-as.S.o' from cache
+5.63 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.63 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.63 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.63   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.63   RET_CODE: no such file or directory
+5.63   ERROR_MESSAGE:
+5.63 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.63   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.63   RET_CODE: no such file or directory
+5.63   ERROR_MESSAGE:
+5.65 Retrieved `.pio/build/esp32c2/app_trace/app_trace.c.o' from cache
+5.65 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in] Error 1
+5.65 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in] Error 1
+5.79 ========================== [FAILED] Took 5.63 seconds ==========================

--- a/failures/FxPride2015.log
+++ b/failures/FxPride2015.log
@@ -1,0 +1,94 @@
+Initial build failed: 0.12 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.12 --------------------------------------------------------------------------------
+0.42 Verbose mode can be enabled via `-v, --verbose` option
+0.50 Error output: /home/ubuntu/.fastled/compile/pio/esp32c2/penv/bin/python: No module named pip
+0.50 Error: Failed to install Python dependencies into penv
+0.54 ========================== [FAILED] Took 0.41 seconds ==========================
+Initial build failed: 0.16 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.16 --------------------------------------------------------------------------------
+0.46 Verbose mode can be enabled via `-v, --verbose` option
+1.17 CONFIGURATION: https://docs.platformio.org/page/boards/espressif32/esp32-c2-devkitm-1.html
+1.17 PLATFORM: Espressif 32 (55.3.30+develop.sha.9651ee8) > Espressif ESP32-C2-DevKitM-1
+1.17 HARDWARE: ESP32C2 120MHz, 272KB RAM, 4MB Flash
+1.17 DEBUG: Current (cmsis-dap) External (cmsis-dap, esp-bridge, esp-prog, iot-bus-jtag, jlink, minimodule, olimex-arm-usb-ocd, olimex-arm-usb-ocd-h, olimex-arm-usb-tiny-h, olimex-jtag-tiny, tumpa)
+1.17 PACKAGES:
+1.17  - contrib-piohome @ 3.4.4
+1.17  - framework-arduino-c2-skeleton-lib @ 5.5.0+sha.cbe9388f45
+1.17  - framework-arduinoespressif32 @ 3.3.0
+1.17  - framework-arduinoespressif32-libs @ 5.5.0+sha.b66b5448e0
+1.17  - framework-espidf @ 3.50500.0 (5.5.0)
+1.17  - tool-cmake @ 3.30.2
+1.17  - tool-esp-rom-elfs @ 2024.10.11
+1.17  - tool-esptoolpy @ 5.0.2
+1.17  - tool-mklittlefs @ 3.2.0
+1.17  - tool-ninja @ 1.13.1
+1.17  - tool-scons @ 4.40801.0 (4.8.1)
+1.17  - toolchain-riscv32-esp @ 14.2.0+20241119
+1.17 *** Compile Arduino IDF libs for esp32c2 ***
+1.19 *** Add "custom_sdkconfig" settings to IDF sdkconfig.defaults ***
+1.19 Replace: CONFIG_IDF_TARGET="esp32c2" with: CONFIG_IDF_TARGET=esp32c2
+1.19 Replace: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y with: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y
+1.19 Replace: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y with: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y
+1.19 Replace: CONFIG_ESPTOOLPY_FLASHFREQ="60m" with: CONFIG_ESPTOOLPY_FLASHFREQ="60m"
+1.19 Add: # CONFIG_ESPTOOLPY_FLASHFREQ_80M is not set
+1.20 Warning! Arduino framework as an ESP-IDF component doesn't handle the `variant` field! The default `esp32` variant will be used.
+1.20 Reading CMake configuration...
+5.57 Generating assembly for certificate bundle...
+5.73 LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
+5.73 LDF Modes: Finder ~ chain, Compatibility ~ soft
+5.79 Found 42 compatible libraries
+5.79 Scanning dependencies...
+5.79 No dependencies
+5.79 Building in release mode
+5.80 Environment state dumped to: env_dump.json
+5.80 Projenv state dumped to: projenv_dump.json
+5.80 Cache configuration from environment:
+5.80   Cache type: xcache
+5.80   Cache executable: python /workspace/ci/util/xcache.py
+5.80   SCCACHE path: /workspace/.venv/bin/sccache
+5.80   SCCACHE dir: /home/ubuntu/.fastled/sccache
+5.80   Debug enabled: False
+5.80 xcache wrapper detected and configured for Python fake compilers
+5.80   xcache path: /workspace/ci/util/xcache.py
+5.80   cache executable: python /workspace/ci/util/xcache.py
+5.80 DEBUG: Found compilers in env:
+5.80   CC: 'riscv32-esp-elf-gcc' (type: str)
+5.80   CXX: 'riscv32-esp-elf-g++' (type: str)
+5.80 Extracted compiler names:
+5.80   CC name: riscv32-esp-elf-gcc
+5.80   CXX name: riscv32-esp-elf-g++
+5.80 Found local compiler cache:
+5.80   Cache file: /workspace/.build/pio/esp32c2/compiler_cache.json
+5.80   Real CC: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-gcc
+5.80   Real CXX: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-g++
+5.80 SUCCESS: Using cached compilers (instant, no platform search needed):
+5.80   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.80   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.80   Platform search skipped - using cached toolset
+5.80 Created Python cached compilers:
+5.80   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.80   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.80 Applied Python fake compilers to both env and projenv
+5.80 Python fake compiler cache enabled: xcache
+5.80   Original CC: riscv32-esp-elf-gcc
+5.80   Original CXX: riscv32-esp-elf-g++
+5.80   Fake CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.80   Fake CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.80 Python fake compiler cache environment configured successfully
+5.90 Retrieved `.pio/build/esp32c2/.dummy/sketch.cpp.o' from cache
+5.90 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-gcc.c.o' from cache
+5.91 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-cpp.cpp.o' from cache
+5.91 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-as.S.o' from cache
+5.91 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.92 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.92   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.92   RET_CODE: no such file or directory
+5.92   ERROR_MESSAGE:
+5.92 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.92 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.92   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.92   RET_CODE: no such file or directory
+5.92   ERROR_MESSAGE:
+5.92 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in] Error 1
+5.92 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in] Error 1
+6.06 ========================== [FAILED] Took 5.90 seconds ==========================

--- a/failures/FxSdCard.log
+++ b/failures/FxSdCard.log
@@ -1,0 +1,90 @@
+Initial build failed: 0.12 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.12 --------------------------------------------------------------------------------
+0.42 Verbose mode can be enabled via `-v, --verbose` option
+0.50 Error output: /home/ubuntu/.fastled/compile/pio/esp32c2/penv/bin/python: No module named pip
+0.50 Error: Failed to install Python dependencies into penv
+0.54 ========================== [FAILED] Took 0.42 seconds ==========================
+Initial build failed: 0.13 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.13 --------------------------------------------------------------------------------
+0.43 Verbose mode can be enabled via `-v, --verbose` option
+0.86 CONFIGURATION: https://docs.platformio.org/page/boards/espressif32/esp32-c2-devkitm-1.html
+0.86 PLATFORM: Espressif 32 (55.3.30+develop.sha.9651ee8) > Espressif ESP32-C2-DevKitM-1
+0.86 HARDWARE: ESP32C2 120MHz, 272KB RAM, 4MB Flash
+0.86 DEBUG: Current (cmsis-dap) External (cmsis-dap, esp-bridge, esp-prog, iot-bus-jtag, jlink, minimodule, olimex-arm-usb-ocd, olimex-arm-usb-ocd-h, olimex-arm-usb-tiny-h, olimex-jtag-tiny, tumpa)
+0.86 PACKAGES:
+0.86  - contrib-piohome @ 3.4.4
+0.86  - framework-arduino-c2-skeleton-lib @ 5.5.0+sha.cbe9388f45
+0.86  - framework-arduinoespressif32 @ 3.3.0
+0.86  - framework-arduinoespressif32-libs @ 5.5.0+sha.b66b5448e0
+0.86  - framework-espidf @ 3.50500.0 (5.5.0)
+0.86  - tool-cmake @ 3.30.2
+0.86  - tool-esp-rom-elfs @ 2024.10.11
+0.86  - tool-esptoolpy @ 5.0.2
+0.86  - tool-mklittlefs @ 3.2.0
+0.86  - tool-ninja @ 1.13.1
+0.86  - tool-scons @ 4.40801.0 (4.8.1)
+0.86  - toolchain-riscv32-esp @ 14.2.0+20241119
+0.87 *** Compile Arduino IDF libs for esp32c2 ***
+0.89 *** Add "custom_sdkconfig" settings to IDF sdkconfig.defaults ***
+0.89 Replace: CONFIG_IDF_TARGET="esp32c2" with: CONFIG_IDF_TARGET=esp32c2
+0.89 Replace: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y with: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y
+0.89 Replace: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y with: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y
+0.89 Replace: CONFIG_ESPTOOLPY_FLASHFREQ="60m" with: CONFIG_ESPTOOLPY_FLASHFREQ="60m"
+0.89 Add: # CONFIG_ESPTOOLPY_FLASHFREQ_80M is not set
+0.90 Warning! Arduino framework as an ESP-IDF component doesn't handle the `variant` field! The default `esp32` variant will be used.
+0.90 Reading CMake configuration...
+4.98 LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
+4.98 LDF Modes: Finder ~ chain, Compatibility ~ soft
+5.04 Found 42 compatible libraries
+5.04 Scanning dependencies...
+5.04 No dependencies
+5.04 Building in release mode
+5.05 Environment state dumped to: env_dump.json
+5.05 Projenv state dumped to: projenv_dump.json
+5.05 Cache configuration from environment:
+5.05   Cache type: xcache
+5.05   Cache executable: python /workspace/ci/util/xcache.py
+5.05   SCCACHE path: /workspace/.venv/bin/sccache
+5.05   SCCACHE dir: /home/ubuntu/.fastled/sccache
+5.05   Debug enabled: False
+5.05 xcache wrapper detected and configured for Python fake compilers
+5.05   xcache path: /workspace/ci/util/xcache.py
+5.05   cache executable: python /workspace/ci/util/xcache.py
+5.05 DEBUG: Found compilers in env:
+5.05   CC: 'riscv32-esp-elf-gcc' (type: str)
+5.05   CXX: 'riscv32-esp-elf-g++' (type: str)
+5.05 Extracted compiler names:
+5.05   CC name: riscv32-esp-elf-gcc
+5.05   CXX name: riscv32-esp-elf-g++
+5.05 Found local compiler cache:
+5.05   Cache file: /workspace/.build/pio/esp32c2/compiler_cache.json
+5.05   Real CC: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-gcc
+5.05   Real CXX: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-g++
+5.05 SUCCESS: Using cached compilers (instant, no platform search needed):
+5.05   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.05   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.05   Platform search skipped - using cached toolset
+5.05 Created Python cached compilers:
+5.05   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.05   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.05 Applied Python fake compilers to both env and projenv
+5.05 Python fake compiler cache enabled: xcache
+5.05   Original CC: riscv32-esp-elf-gcc
+5.05   Original CXX: riscv32-esp-elf-g++
+5.05   Fake CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.05   Fake CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.05 Python fake compiler cache environment configured successfully
+5.08 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.08 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.08   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.08   RET_CODE: no such file or directory
+5.08   ERROR_MESSAGE:
+5.08 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.09 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.09   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.09   RET_CODE: no such file or directory
+5.09   ERROR_MESSAGE:
+5.11 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in] Error 1
+5.11 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in] Error 1
+5.11 Retrieved `.pio/build/esp32c2/app_trace/app_trace.c.o' from cache
+5.24 ========================== [FAILED] Took 5.12 seconds ==========================

--- a/failures/FxTwinkleFox.log
+++ b/failures/FxTwinkleFox.log
@@ -1,0 +1,90 @@
+Initial build failed: 0.12 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.12 --------------------------------------------------------------------------------
+0.42 Verbose mode can be enabled via `-v, --verbose` option
+0.49 Error: Failed to install Python dependencies into penv
+0.49 Error output: /home/ubuntu/.fastled/compile/pio/esp32c2/penv/bin/python: No module named pip
+0.53 ========================== [FAILED] Took 0.41 seconds ==========================
+Initial build failed: 0.13 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.13 --------------------------------------------------------------------------------
+0.43 Verbose mode can be enabled via `-v, --verbose` option
+0.93 CONFIGURATION: https://docs.platformio.org/page/boards/espressif32/esp32-c2-devkitm-1.html
+0.93 PLATFORM: Espressif 32 (55.3.30+develop.sha.9651ee8) > Espressif ESP32-C2-DevKitM-1
+0.93 HARDWARE: ESP32C2 120MHz, 272KB RAM, 4MB Flash
+0.93 DEBUG: Current (cmsis-dap) External (cmsis-dap, esp-bridge, esp-prog, iot-bus-jtag, jlink, minimodule, olimex-arm-usb-ocd, olimex-arm-usb-ocd-h, olimex-arm-usb-tiny-h, olimex-jtag-tiny, tumpa)
+0.93 PACKAGES:
+0.93  - contrib-piohome @ 3.4.4
+0.93  - framework-arduino-c2-skeleton-lib @ 5.5.0+sha.cbe9388f45
+0.93  - framework-arduinoespressif32 @ 3.3.0
+0.93  - framework-arduinoespressif32-libs @ 5.5.0+sha.b66b5448e0
+0.93  - framework-espidf @ 3.50500.0 (5.5.0)
+0.93  - tool-cmake @ 3.30.2
+0.93  - tool-esp-rom-elfs @ 2024.10.11
+0.93  - tool-esptoolpy @ 5.0.2
+0.93  - tool-mklittlefs @ 3.2.0
+0.93  - tool-ninja @ 1.13.1
+0.93  - tool-scons @ 4.40801.0 (4.8.1)
+0.93  - toolchain-riscv32-esp @ 14.2.0+20241119
+0.94 *** Compile Arduino IDF libs for esp32c2 ***
+0.95 *** Add "custom_sdkconfig" settings to IDF sdkconfig.defaults ***
+0.95 Replace: CONFIG_IDF_TARGET="esp32c2" with: CONFIG_IDF_TARGET=esp32c2
+0.95 Replace: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y with: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y
+0.95 Replace: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y with: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y
+0.95 Replace: CONFIG_ESPTOOLPY_FLASHFREQ="60m" with: CONFIG_ESPTOOLPY_FLASHFREQ="60m"
+0.96 Add: # CONFIG_ESPTOOLPY_FLASHFREQ_80M is not set
+0.97 Warning! Arduino framework as an ESP-IDF component doesn't handle the `variant` field! The default `esp32` variant will be used.
+0.97 Reading CMake configuration...
+5.07 LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
+5.07 LDF Modes: Finder ~ chain, Compatibility ~ soft
+5.13 Found 42 compatible libraries
+5.13 Scanning dependencies...
+5.13 No dependencies
+5.13 Building in release mode
+5.14 Environment state dumped to: env_dump.json
+5.14 Projenv state dumped to: projenv_dump.json
+5.14 Cache configuration from environment:
+5.14   Cache type: xcache
+5.14   Cache executable: python /workspace/ci/util/xcache.py
+5.14   SCCACHE path: /workspace/.venv/bin/sccache
+5.14   SCCACHE dir: /home/ubuntu/.fastled/sccache
+5.14   Debug enabled: False
+5.14 xcache wrapper detected and configured for Python fake compilers
+5.14   xcache path: /workspace/ci/util/xcache.py
+5.14   cache executable: python /workspace/ci/util/xcache.py
+5.14 DEBUG: Found compilers in env:
+5.14   CC: 'riscv32-esp-elf-gcc' (type: str)
+5.14   CXX: 'riscv32-esp-elf-g++' (type: str)
+5.14 Extracted compiler names:
+5.14   CC name: riscv32-esp-elf-gcc
+5.14   CXX name: riscv32-esp-elf-g++
+5.14 Found local compiler cache:
+5.14   Cache file: /workspace/.build/pio/esp32c2/compiler_cache.json
+5.14   Real CC: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-gcc
+5.14   Real CXX: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-g++
+5.14 SUCCESS: Using cached compilers (instant, no platform search needed):
+5.14   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.14   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.14   Platform search skipped - using cached toolset
+5.14 Created Python cached compilers:
+5.14   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.14   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.14 Applied Python fake compilers to both env and projenv
+5.14 Python fake compiler cache enabled: xcache
+5.14   Original CC: riscv32-esp-elf-gcc
+5.14   Original CXX: riscv32-esp-elf-g++
+5.14   Fake CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.14   Fake CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.14 Python fake compiler cache environment configured successfully
+5.17 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.18 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.18 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.18   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.18   RET_CODE: no such file or directory
+5.18   ERROR_MESSAGE:
+5.18 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.18   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.18   RET_CODE: no such file or directory
+5.18   ERROR_MESSAGE:
+5.20 Retrieved `.pio/build/esp32c2/app_trace/app_trace_util.c.o' from cache
+5.20 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in] Error 1
+5.20 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in] Error 1
+5.33 ========================== [FAILED] Took 5.20 seconds ==========================

--- a/failures/FxWater.log
+++ b/failures/FxWater.log
@@ -1,0 +1,94 @@
+Initial build failed: 0.13 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.13 --------------------------------------------------------------------------------
+0.45 Verbose mode can be enabled via `-v, --verbose` option
+0.53 Error output: /home/ubuntu/.fastled/compile/pio/esp32c2/penv/bin/python: No module named pip
+0.53 Error: Failed to install Python dependencies into penv
+0.57 ========================== [FAILED] Took 0.43 seconds ==========================
+Initial build failed: 0.16 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.16 --------------------------------------------------------------------------------
+0.47 Verbose mode can be enabled via `-v, --verbose` option
+0.88 CONFIGURATION: https://docs.platformio.org/page/boards/espressif32/esp32-c2-devkitm-1.html
+0.88 PLATFORM: Espressif 32 (55.3.30+develop.sha.9651ee8) > Espressif ESP32-C2-DevKitM-1
+0.88 HARDWARE: ESP32C2 120MHz, 272KB RAM, 4MB Flash
+0.88 DEBUG: Current (cmsis-dap) External (cmsis-dap, esp-bridge, esp-prog, iot-bus-jtag, jlink, minimodule, olimex-arm-usb-ocd, olimex-arm-usb-ocd-h, olimex-arm-usb-tiny-h, olimex-jtag-tiny, tumpa)
+0.88 PACKAGES:
+0.88  - contrib-piohome @ 3.4.4
+0.88  - framework-arduino-c2-skeleton-lib @ 5.5.0+sha.cbe9388f45
+0.88  - framework-arduinoespressif32 @ 3.3.0
+0.88  - framework-arduinoespressif32-libs @ 5.5.0+sha.b66b5448e0
+0.88  - framework-espidf @ 3.50500.0 (5.5.0)
+0.88  - tool-cmake @ 3.30.2
+0.88  - tool-esp-rom-elfs @ 2024.10.11
+0.88  - tool-esptoolpy @ 5.0.2
+0.88  - tool-mklittlefs @ 3.2.0
+0.88  - tool-ninja @ 1.13.1
+0.88  - tool-scons @ 4.40801.0 (4.8.1)
+0.88  - toolchain-riscv32-esp @ 14.2.0+20241119
+0.88 *** Compile Arduino IDF libs for esp32c2 ***
+0.90 *** Add "custom_sdkconfig" settings to IDF sdkconfig.defaults ***
+0.90 Replace: CONFIG_IDF_TARGET="esp32c2" with: CONFIG_IDF_TARGET=esp32c2
+0.90 Replace: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y with: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y
+0.90 Replace: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y with: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y
+0.90 Replace: CONFIG_ESPTOOLPY_FLASHFREQ="60m" with: CONFIG_ESPTOOLPY_FLASHFREQ="60m"
+0.90 Add: # CONFIG_ESPTOOLPY_FLASHFREQ_80M is not set
+0.91 Warning! Arduino framework as an ESP-IDF component doesn't handle the `variant` field! The default `esp32` variant will be used.
+0.91 Reading CMake configuration...
+5.27 Generating assembly for certificate bundle...
+5.43 LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
+5.43 LDF Modes: Finder ~ chain, Compatibility ~ soft
+5.49 Found 42 compatible libraries
+5.49 Scanning dependencies...
+5.49 No dependencies
+5.49 Building in release mode
+5.50 Environment state dumped to: env_dump.json
+5.50 Projenv state dumped to: projenv_dump.json
+5.50 Cache configuration from environment:
+5.50   Cache type: xcache
+5.50   Cache executable: python /workspace/ci/util/xcache.py
+5.50   SCCACHE path: /workspace/.venv/bin/sccache
+5.50   SCCACHE dir: /home/ubuntu/.fastled/sccache
+5.50   Debug enabled: False
+5.50 xcache wrapper detected and configured for Python fake compilers
+5.50   xcache path: /workspace/ci/util/xcache.py
+5.50   cache executable: python /workspace/ci/util/xcache.py
+5.50 DEBUG: Found compilers in env:
+5.50   CC: 'riscv32-esp-elf-gcc' (type: str)
+5.50   CXX: 'riscv32-esp-elf-g++' (type: str)
+5.50 Extracted compiler names:
+5.50   CC name: riscv32-esp-elf-gcc
+5.50   CXX name: riscv32-esp-elf-g++
+5.50 Found local compiler cache:
+5.50   Cache file: /workspace/.build/pio/esp32c2/compiler_cache.json
+5.50   Real CC: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-gcc
+5.50   Real CXX: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-g++
+5.50 SUCCESS: Using cached compilers (instant, no platform search needed):
+5.50   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.50   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.50   Platform search skipped - using cached toolset
+5.50 Created Python cached compilers:
+5.50   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.50   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.50 Applied Python fake compilers to both env and projenv
+5.50 Python fake compiler cache enabled: xcache
+5.50   Original CC: riscv32-esp-elf-gcc
+5.50   Original CXX: riscv32-esp-elf-g++
+5.50   Fake CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.50   Fake CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.50 Python fake compiler cache environment configured successfully
+5.60 Retrieved `.pio/build/esp32c2/.dummy/sketch.cpp.o' from cache
+5.61 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-gcc.c.o' from cache
+5.61 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-cpp.cpp.o' from cache
+5.62 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-as.S.o' from cache
+5.62 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.62 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.62   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.62   RET_CODE: no such file or directory
+5.62   ERROR_MESSAGE:
+5.62 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.62 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.62   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.62   RET_CODE: no such file or directory
+5.62   ERROR_MESSAGE:
+5.63 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in] Error 1
+5.63 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in] Error 1
+5.76 ========================== [FAILED] Took 5.60 seconds ==========================

--- a/failures/FxWave2d.log
+++ b/failures/FxWave2d.log
@@ -1,0 +1,94 @@
+Initial build failed: 0.13 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.13 --------------------------------------------------------------------------------
+0.44 Verbose mode can be enabled via `-v, --verbose` option
+0.52 Error output: /home/ubuntu/.fastled/compile/pio/esp32c2/penv/bin/python: No module named pip
+0.52 Error: Failed to install Python dependencies into penv
+0.56 ========================== [FAILED] Took 0.43 seconds ==========================
+Initial build failed: 0.16 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.16 --------------------------------------------------------------------------------
+0.46 Verbose mode can be enabled via `-v, --verbose` option
+0.84 CONFIGURATION: https://docs.platformio.org/page/boards/espressif32/esp32-c2-devkitm-1.html
+0.84 PLATFORM: Espressif 32 (55.3.30+develop.sha.9651ee8) > Espressif ESP32-C2-DevKitM-1
+0.84 HARDWARE: ESP32C2 120MHz, 272KB RAM, 4MB Flash
+0.84 DEBUG: Current (cmsis-dap) External (cmsis-dap, esp-bridge, esp-prog, iot-bus-jtag, jlink, minimodule, olimex-arm-usb-ocd, olimex-arm-usb-ocd-h, olimex-arm-usb-tiny-h, olimex-jtag-tiny, tumpa)
+0.84 PACKAGES:
+0.84  - contrib-piohome @ 3.4.4
+0.84  - framework-arduino-c2-skeleton-lib @ 5.5.0+sha.cbe9388f45
+0.84  - framework-arduinoespressif32 @ 3.3.0
+0.84  - framework-arduinoespressif32-libs @ 5.5.0+sha.b66b5448e0
+0.84  - framework-espidf @ 3.50500.0 (5.5.0)
+0.84  - tool-cmake @ 3.30.2
+0.84  - tool-esp-rom-elfs @ 2024.10.11
+0.84  - tool-esptoolpy @ 5.0.2
+0.84  - tool-mklittlefs @ 3.2.0
+0.84  - tool-ninja @ 1.13.1
+0.84  - tool-scons @ 4.40801.0 (4.8.1)
+0.84  - toolchain-riscv32-esp @ 14.2.0+20241119
+0.84 *** Compile Arduino IDF libs for esp32c2 ***
+0.86 *** Add "custom_sdkconfig" settings to IDF sdkconfig.defaults ***
+0.86 Replace: CONFIG_IDF_TARGET="esp32c2" with: CONFIG_IDF_TARGET=esp32c2
+0.86 Replace: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y with: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y
+0.86 Replace: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y with: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y
+0.86 Replace: CONFIG_ESPTOOLPY_FLASHFREQ="60m" with: CONFIG_ESPTOOLPY_FLASHFREQ="60m"
+0.86 Add: # CONFIG_ESPTOOLPY_FLASHFREQ_80M is not set
+0.87 Warning! Arduino framework as an ESP-IDF component doesn't handle the `variant` field! The default `esp32` variant will be used.
+0.87 Reading CMake configuration...
+5.24 Generating assembly for certificate bundle...
+5.39 LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
+5.40 LDF Modes: Finder ~ chain, Compatibility ~ soft
+5.45 Found 42 compatible libraries
+5.45 Scanning dependencies...
+5.45 No dependencies
+5.46 Building in release mode
+5.46 Environment state dumped to: env_dump.json
+5.46 Projenv state dumped to: projenv_dump.json
+5.46 Cache configuration from environment:
+5.46   Cache type: xcache
+5.46   Cache executable: python /workspace/ci/util/xcache.py
+5.46   SCCACHE path: /workspace/.venv/bin/sccache
+5.46   SCCACHE dir: /home/ubuntu/.fastled/sccache
+5.46   Debug enabled: False
+5.46 xcache wrapper detected and configured for Python fake compilers
+5.46   xcache path: /workspace/ci/util/xcache.py
+5.46   cache executable: python /workspace/ci/util/xcache.py
+5.46 DEBUG: Found compilers in env:
+5.46   CC: 'riscv32-esp-elf-gcc' (type: str)
+5.46   CXX: 'riscv32-esp-elf-g++' (type: str)
+5.46 Extracted compiler names:
+5.46   CC name: riscv32-esp-elf-gcc
+5.46   CXX name: riscv32-esp-elf-g++
+5.46 Found local compiler cache:
+5.46   Cache file: /workspace/.build/pio/esp32c2/compiler_cache.json
+5.46   Real CC: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-gcc
+5.46   Real CXX: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-g++
+5.46 SUCCESS: Using cached compilers (instant, no platform search needed):
+5.46   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.46   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.46   Platform search skipped - using cached toolset
+5.46 Created Python cached compilers:
+5.46   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.46   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.46 Applied Python fake compilers to both env and projenv
+5.46 Python fake compiler cache enabled: xcache
+5.46   Original CC: riscv32-esp-elf-gcc
+5.46   Original CXX: riscv32-esp-elf-g++
+5.46   Fake CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.46   Fake CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.46 Python fake compiler cache environment configured successfully
+5.56 Retrieved `.pio/build/esp32c2/.dummy/sketch.cpp.o' from cache
+5.57 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-gcc.c.o' from cache
+5.57 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-cpp.cpp.o' from cache
+5.58 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-as.S.o' from cache
+5.58 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.58 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.58   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.58   RET_CODE: no such file or directory
+5.58   ERROR_MESSAGE:
+5.59 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.59 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in] Error 1
+5.59 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.59   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.59   RET_CODE: no such file or directory
+5.59   ERROR_MESSAGE:
+5.59 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in] Error 1
+5.72 ========================== [FAILED] Took 5.56 seconds ==========================

--- a/failures/HD107.log
+++ b/failures/HD107.log
@@ -1,0 +1,95 @@
+Initial build failed: 0.13 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.13 --------------------------------------------------------------------------------
+0.44 Verbose mode can be enabled via `-v, --verbose` option
+0.51 Error: Failed to install Python dependencies into penv
+0.51 Error output: /home/ubuntu/.fastled/compile/pio/esp32c2/penv/bin/python: No module named pip
+0.55 ========================== [FAILED] Took 0.42 seconds ==========================
+Initial build failed: 0.16 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.16 --------------------------------------------------------------------------------
+0.47 Verbose mode can be enabled via `-v, --verbose` option
+0.90 CONFIGURATION: https://docs.platformio.org/page/boards/espressif32/esp32-c2-devkitm-1.html
+0.90 PLATFORM: Espressif 32 (55.3.30+develop.sha.9651ee8) > Espressif ESP32-C2-DevKitM-1
+0.90 HARDWARE: ESP32C2 120MHz, 272KB RAM, 4MB Flash
+0.90 DEBUG: Current (cmsis-dap) External (cmsis-dap, esp-bridge, esp-prog, iot-bus-jtag, jlink, minimodule, olimex-arm-usb-ocd, olimex-arm-usb-ocd-h, olimex-arm-usb-tiny-h, olimex-jtag-tiny, tumpa)
+0.90 PACKAGES:
+0.90  - contrib-piohome @ 3.4.4
+0.90  - framework-arduino-c2-skeleton-lib @ 5.5.0+sha.cbe9388f45
+0.90  - framework-arduinoespressif32 @ 3.3.0
+0.90  - framework-arduinoespressif32-libs @ 5.5.0+sha.b66b5448e0
+0.90  - framework-espidf @ 3.50500.0 (5.5.0)
+0.90  - tool-cmake @ 3.30.2
+0.90  - tool-esp-rom-elfs @ 2024.10.11
+0.90  - tool-esptoolpy @ 5.0.2
+0.90  - tool-mklittlefs @ 3.2.0
+0.90  - tool-ninja @ 1.13.1
+0.90  - tool-scons @ 4.40801.0 (4.8.1)
+0.90  - toolchain-riscv32-esp @ 14.2.0+20241119
+0.91 *** Compile Arduino IDF libs for esp32c2 ***
+0.93 *** Add "custom_sdkconfig" settings to IDF sdkconfig.defaults ***
+0.93 Replace: CONFIG_IDF_TARGET="esp32c2" with: CONFIG_IDF_TARGET=esp32c2
+0.93 Replace: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y with: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y
+0.93 Replace: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y with: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y
+0.93 Replace: CONFIG_ESPTOOLPY_FLASHFREQ="60m" with: CONFIG_ESPTOOLPY_FLASHFREQ="60m"
+0.93 Add: # CONFIG_ESPTOOLPY_FLASHFREQ_80M is not set
+0.94 Warning! Arduino framework as an ESP-IDF component doesn't handle the `variant` field! The default `esp32` variant will be used.
+0.94 Reading CMake configuration...
+5.30 Generating assembly for certificate bundle...
+5.45 LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
+5.45 LDF Modes: Finder ~ chain, Compatibility ~ soft
+5.51 Found 42 compatible libraries
+5.51 Scanning dependencies...
+5.51 No dependencies
+5.51 Building in release mode
+5.52 Environment state dumped to: env_dump.json
+5.52 Projenv state dumped to: projenv_dump.json
+5.52 Cache configuration from environment:
+5.52   Cache type: xcache
+5.52   Cache executable: python /workspace/ci/util/xcache.py
+5.52   SCCACHE path: /workspace/.venv/bin/sccache
+5.52   SCCACHE dir: /home/ubuntu/.fastled/sccache
+5.52   Debug enabled: False
+5.52 xcache wrapper detected and configured for Python fake compilers
+5.52   xcache path: /workspace/ci/util/xcache.py
+5.52   cache executable: python /workspace/ci/util/xcache.py
+5.52 DEBUG: Found compilers in env:
+5.52   CC: 'riscv32-esp-elf-gcc' (type: str)
+5.52   CXX: 'riscv32-esp-elf-g++' (type: str)
+5.52 Extracted compiler names:
+5.52   CC name: riscv32-esp-elf-gcc
+5.52   CXX name: riscv32-esp-elf-g++
+5.52 Found local compiler cache:
+5.52   Cache file: /workspace/.build/pio/esp32c2/compiler_cache.json
+5.52   Real CC: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-gcc
+5.52   Real CXX: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-g++
+5.52 SUCCESS: Using cached compilers (instant, no platform search needed):
+5.52   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.52   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.52   Platform search skipped - using cached toolset
+5.52 Created Python cached compilers:
+5.52   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.52   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.52 Applied Python fake compilers to both env and projenv
+5.52 Python fake compiler cache enabled: xcache
+5.52   Original CC: riscv32-esp-elf-gcc
+5.52   Original CXX: riscv32-esp-elf-g++
+5.52   Fake CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.52   Fake CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.52 Python fake compiler cache environment configured successfully
+5.62 Retrieved `.pio/build/esp32c2/.dummy/sketch.cpp.o' from cache
+5.63 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-gcc.c.o' from cache
+5.63 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-cpp.cpp.o' from cache
+5.64 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-as.S.o' from cache
+5.64 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.64 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.64   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.64   RET_CODE: no such file or directory
+5.64   ERROR_MESSAGE:
+5.64 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.64 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.64   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.64   RET_CODE: no such file or directory
+5.64   ERROR_MESSAGE:
+5.66 Retrieved `.pio/build/esp32c2/app_trace/app_trace.c.o' from cache
+5.66 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in] Error 1
+5.66 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in] Error 1
+5.79 ========================== [FAILED] Took 5.63 seconds ==========================

--- a/failures/HSVTest.log
+++ b/failures/HSVTest.log
@@ -1,0 +1,94 @@
+Initial build failed: 0.13 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.13 --------------------------------------------------------------------------------
+0.45 Verbose mode can be enabled via `-v, --verbose` option
+0.52 Error: Failed to install Python dependencies into penv
+0.52 Error output: /home/ubuntu/.fastled/compile/pio/esp32c2/penv/bin/python: No module named pip
+0.56 ========================== [FAILED] Took 0.43 seconds ==========================
+Initial build failed: 0.16 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.16 --------------------------------------------------------------------------------
+0.46 Verbose mode can be enabled via `-v, --verbose` option
+0.85 CONFIGURATION: https://docs.platformio.org/page/boards/espressif32/esp32-c2-devkitm-1.html
+0.85 PLATFORM: Espressif 32 (55.3.30+develop.sha.9651ee8) > Espressif ESP32-C2-DevKitM-1
+0.85 HARDWARE: ESP32C2 120MHz, 272KB RAM, 4MB Flash
+0.85 DEBUG: Current (cmsis-dap) External (cmsis-dap, esp-bridge, esp-prog, iot-bus-jtag, jlink, minimodule, olimex-arm-usb-ocd, olimex-arm-usb-ocd-h, olimex-arm-usb-tiny-h, olimex-jtag-tiny, tumpa)
+0.85 PACKAGES:
+0.85  - contrib-piohome @ 3.4.4
+0.85  - framework-arduino-c2-skeleton-lib @ 5.5.0+sha.cbe9388f45
+0.85  - framework-arduinoespressif32 @ 3.3.0
+0.85  - framework-arduinoespressif32-libs @ 5.5.0+sha.b66b5448e0
+0.85  - framework-espidf @ 3.50500.0 (5.5.0)
+0.85  - tool-cmake @ 3.30.2
+0.85  - tool-esp-rom-elfs @ 2024.10.11
+0.85  - tool-esptoolpy @ 5.0.2
+0.85  - tool-mklittlefs @ 3.2.0
+0.85  - tool-ninja @ 1.13.1
+0.85  - tool-scons @ 4.40801.0 (4.8.1)
+0.85  - toolchain-riscv32-esp @ 14.2.0+20241119
+0.85 *** Compile Arduino IDF libs for esp32c2 ***
+0.87 *** Add "custom_sdkconfig" settings to IDF sdkconfig.defaults ***
+0.87 Replace: CONFIG_IDF_TARGET="esp32c2" with: CONFIG_IDF_TARGET=esp32c2
+0.87 Replace: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y with: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y
+0.87 Replace: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y with: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y
+0.87 Replace: CONFIG_ESPTOOLPY_FLASHFREQ="60m" with: CONFIG_ESPTOOLPY_FLASHFREQ="60m"
+0.87 Add: # CONFIG_ESPTOOLPY_FLASHFREQ_80M is not set
+0.89 Warning! Arduino framework as an ESP-IDF component doesn't handle the `variant` field! The default `esp32` variant will be used.
+0.89 Reading CMake configuration...
+5.30 Generating assembly for certificate bundle...
+5.45 LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
+5.45 LDF Modes: Finder ~ chain, Compatibility ~ soft
+5.51 Found 42 compatible libraries
+5.51 Scanning dependencies...
+5.51 No dependencies
+5.52 Building in release mode
+5.52 Environment state dumped to: env_dump.json
+5.52 Projenv state dumped to: projenv_dump.json
+5.52 Cache configuration from environment:
+5.52   Cache type: xcache
+5.52   Cache executable: python /workspace/ci/util/xcache.py
+5.52   SCCACHE path: /workspace/.venv/bin/sccache
+5.52   SCCACHE dir: /home/ubuntu/.fastled/sccache
+5.52   Debug enabled: False
+5.52 xcache wrapper detected and configured for Python fake compilers
+5.52   xcache path: /workspace/ci/util/xcache.py
+5.52   cache executable: python /workspace/ci/util/xcache.py
+5.52 DEBUG: Found compilers in env:
+5.52   CC: 'riscv32-esp-elf-gcc' (type: str)
+5.52   CXX: 'riscv32-esp-elf-g++' (type: str)
+5.52 Extracted compiler names:
+5.52   CC name: riscv32-esp-elf-gcc
+5.52   CXX name: riscv32-esp-elf-g++
+5.52 Found local compiler cache:
+5.52   Cache file: /workspace/.build/pio/esp32c2/compiler_cache.json
+5.52   Real CC: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-gcc
+5.52   Real CXX: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-g++
+5.52 SUCCESS: Using cached compilers (instant, no platform search needed):
+5.52   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.52   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.52   Platform search skipped - using cached toolset
+5.52 Created Python cached compilers:
+5.52   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.52   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.52 Applied Python fake compilers to both env and projenv
+5.52 Python fake compiler cache enabled: xcache
+5.52   Original CC: riscv32-esp-elf-gcc
+5.52   Original CXX: riscv32-esp-elf-g++
+5.52   Fake CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.52   Fake CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.52 Python fake compiler cache environment configured successfully
+5.62 Retrieved `.pio/build/esp32c2/.dummy/sketch.cpp.o' from cache
+5.63 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-gcc.c.o' from cache
+5.64 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-cpp.cpp.o' from cache
+5.64 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-as.S.o' from cache
+5.64 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.64 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.64   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.64   RET_CODE: no such file or directory
+5.64   ERROR_MESSAGE:
+5.65 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.65 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in] Error 1
+5.65 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.65   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.65   RET_CODE: no such file or directory
+5.65   ERROR_MESSAGE:
+5.65 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in] Error 1
+5.79 ========================== [FAILED] Took 5.63 seconds ==========================

--- a/failures/Json.log
+++ b/failures/Json.log
@@ -1,0 +1,95 @@
+Initial build failed: 0.13 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.13 --------------------------------------------------------------------------------
+0.46 Verbose mode can be enabled via `-v, --verbose` option
+0.54 Error: Failed to install Python dependencies into penv
+0.54 Error output: /home/ubuntu/.fastled/compile/pio/esp32c2/penv/bin/python: No module named pip
+0.58 ========================== [FAILED] Took 0.45 seconds ==========================
+Initial build failed: 0.16 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.16 --------------------------------------------------------------------------------
+0.49 Verbose mode can be enabled via `-v, --verbose` option
+0.88 CONFIGURATION: https://docs.platformio.org/page/boards/espressif32/esp32-c2-devkitm-1.html
+0.88 PLATFORM: Espressif 32 (55.3.30+develop.sha.9651ee8) > Espressif ESP32-C2-DevKitM-1
+0.88 HARDWARE: ESP32C2 120MHz, 272KB RAM, 4MB Flash
+0.88 DEBUG: Current (cmsis-dap) External (cmsis-dap, esp-bridge, esp-prog, iot-bus-jtag, jlink, minimodule, olimex-arm-usb-ocd, olimex-arm-usb-ocd-h, olimex-arm-usb-tiny-h, olimex-jtag-tiny, tumpa)
+0.88 PACKAGES:
+0.88  - contrib-piohome @ 3.4.4
+0.88  - framework-arduino-c2-skeleton-lib @ 5.5.0+sha.cbe9388f45
+0.88  - framework-arduinoespressif32 @ 3.3.0
+0.88  - framework-arduinoespressif32-libs @ 5.5.0+sha.b66b5448e0
+0.88  - framework-espidf @ 3.50500.0 (5.5.0)
+0.88  - tool-cmake @ 3.30.2
+0.88  - tool-esp-rom-elfs @ 2024.10.11
+0.88  - tool-esptoolpy @ 5.0.2
+0.88  - tool-mklittlefs @ 3.2.0
+0.88  - tool-ninja @ 1.13.1
+0.88  - tool-scons @ 4.40801.0 (4.8.1)
+0.88  - toolchain-riscv32-esp @ 14.2.0+20241119
+0.89 *** Compile Arduino IDF libs for esp32c2 ***
+0.90 *** Add "custom_sdkconfig" settings to IDF sdkconfig.defaults ***
+0.90 Replace: CONFIG_IDF_TARGET="esp32c2" with: CONFIG_IDF_TARGET=esp32c2
+0.90 Replace: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y with: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y
+0.90 Replace: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y with: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y
+0.90 Replace: CONFIG_ESPTOOLPY_FLASHFREQ="60m" with: CONFIG_ESPTOOLPY_FLASHFREQ="60m"
+0.90 Add: # CONFIG_ESPTOOLPY_FLASHFREQ_80M is not set
+0.91 Warning! Arduino framework as an ESP-IDF component doesn't handle the `variant` field! The default `esp32` variant will be used.
+0.92 Reading CMake configuration...
+5.36 Generating assembly for certificate bundle...
+5.52 LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
+5.52 LDF Modes: Finder ~ chain, Compatibility ~ soft
+5.57 Found 42 compatible libraries
+5.57 Scanning dependencies...
+5.58 No dependencies
+5.58 Building in release mode
+5.59 Environment state dumped to: env_dump.json
+5.59 Projenv state dumped to: projenv_dump.json
+5.59 Cache configuration from environment:
+5.59   Cache type: xcache
+5.59   Cache executable: python /workspace/ci/util/xcache.py
+5.59   SCCACHE path: /workspace/.venv/bin/sccache
+5.59   SCCACHE dir: /home/ubuntu/.fastled/sccache
+5.59   Debug enabled: False
+5.59 xcache wrapper detected and configured for Python fake compilers
+5.59   xcache path: /workspace/ci/util/xcache.py
+5.59   cache executable: python /workspace/ci/util/xcache.py
+5.59 DEBUG: Found compilers in env:
+5.59   CC: 'riscv32-esp-elf-gcc' (type: str)
+5.59   CXX: 'riscv32-esp-elf-g++' (type: str)
+5.59 Extracted compiler names:
+5.59   CC name: riscv32-esp-elf-gcc
+5.59   CXX name: riscv32-esp-elf-g++
+5.59 Found local compiler cache:
+5.59   Cache file: /workspace/.build/pio/esp32c2/compiler_cache.json
+5.59   Real CC: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-gcc
+5.59   Real CXX: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-g++
+5.59 SUCCESS: Using cached compilers (instant, no platform search needed):
+5.59   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.59   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.59   Platform search skipped - using cached toolset
+5.59 Created Python cached compilers:
+5.59   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.59   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.59 Applied Python fake compilers to both env and projenv
+5.59 Python fake compiler cache enabled: xcache
+5.59   Original CC: riscv32-esp-elf-gcc
+5.59   Original CXX: riscv32-esp-elf-g++
+5.59   Fake CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.59   Fake CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.59 Python fake compiler cache environment configured successfully
+5.69 Retrieved `.pio/build/esp32c2/.dummy/sketch.cpp.o' from cache
+5.69 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-gcc.c.o' from cache
+5.70 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-cpp.cpp.o' from cache
+5.70 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-as.S.o' from cache
+5.71 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.71 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.71 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.71   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.71   RET_CODE: no such file or directory
+5.71   ERROR_MESSAGE:
+5.71 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.71   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.71   RET_CODE: no such file or directory
+5.71   ERROR_MESSAGE:
+5.72 Retrieved `.pio/build/esp32c2/app_trace/app_trace.c.o' from cache
+5.72 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in] Error 1
+5.72 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in] Error 1
+5.86 ========================== [FAILED] Took 5.70 seconds ==========================

--- a/failures/LuminescentGrand.log
+++ b/failures/LuminescentGrand.log
@@ -1,0 +1,95 @@
+Initial build failed: 0.13 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.13 --------------------------------------------------------------------------------
+0.45 Verbose mode can be enabled via `-v, --verbose` option
+0.53 Error output: /home/ubuntu/.fastled/compile/pio/esp32c2/penv/bin/python: No module named pip
+0.53 Error: Failed to install Python dependencies into penv
+0.58 ========================== [FAILED] Took 0.45 seconds ==========================
+Initial build failed: 0.17 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.17 --------------------------------------------------------------------------------
+0.47 Verbose mode can be enabled via `-v, --verbose` option
+0.86 CONFIGURATION: https://docs.platformio.org/page/boards/espressif32/esp32-c2-devkitm-1.html
+0.86 PLATFORM: Espressif 32 (55.3.30+develop.sha.9651ee8) > Espressif ESP32-C2-DevKitM-1
+0.86 HARDWARE: ESP32C2 120MHz, 272KB RAM, 4MB Flash
+0.86 DEBUG: Current (cmsis-dap) External (cmsis-dap, esp-bridge, esp-prog, iot-bus-jtag, jlink, minimodule, olimex-arm-usb-ocd, olimex-arm-usb-ocd-h, olimex-arm-usb-tiny-h, olimex-jtag-tiny, tumpa)
+0.86 PACKAGES:
+0.86  - contrib-piohome @ 3.4.4
+0.86  - framework-arduino-c2-skeleton-lib @ 5.5.0+sha.cbe9388f45
+0.86  - framework-arduinoespressif32 @ 3.3.0
+0.86  - framework-arduinoespressif32-libs @ 5.5.0+sha.b66b5448e0
+0.86  - framework-espidf @ 3.50500.0 (5.5.0)
+0.86  - tool-cmake @ 3.30.2
+0.86  - tool-esp-rom-elfs @ 2024.10.11
+0.86  - tool-esptoolpy @ 5.0.2
+0.86  - tool-mklittlefs @ 3.2.0
+0.86  - tool-ninja @ 1.13.1
+0.86  - tool-scons @ 4.40801.0 (4.8.1)
+0.86  - toolchain-riscv32-esp @ 14.2.0+20241119
+0.87 *** Compile Arduino IDF libs for esp32c2 ***
+0.88 *** Add "custom_sdkconfig" settings to IDF sdkconfig.defaults ***
+0.88 Replace: CONFIG_IDF_TARGET="esp32c2" with: CONFIG_IDF_TARGET=esp32c2
+0.88 Replace: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y with: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y
+0.88 Replace: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y with: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y
+0.88 Replace: CONFIG_ESPTOOLPY_FLASHFREQ="60m" with: CONFIG_ESPTOOLPY_FLASHFREQ="60m"
+0.89 Add: # CONFIG_ESPTOOLPY_FLASHFREQ_80M is not set
+0.90 Warning! Arduino framework as an ESP-IDF component doesn't handle the `variant` field! The default `esp32` variant will be used.
+0.90 Reading CMake configuration...
+5.28 Generating assembly for certificate bundle...
+5.44 LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
+5.44 LDF Modes: Finder ~ chain, Compatibility ~ soft
+5.50 Found 42 compatible libraries
+5.50 Scanning dependencies...
+5.50 No dependencies
+5.50 Building in release mode
+5.51 Environment state dumped to: env_dump.json
+5.51 Projenv state dumped to: projenv_dump.json
+5.51 Cache configuration from environment:
+5.51   Cache type: xcache
+5.51   Cache executable: python /workspace/ci/util/xcache.py
+5.51   SCCACHE path: /workspace/.venv/bin/sccache
+5.51   SCCACHE dir: /home/ubuntu/.fastled/sccache
+5.51   Debug enabled: False
+5.51 xcache wrapper detected and configured for Python fake compilers
+5.51   xcache path: /workspace/ci/util/xcache.py
+5.51   cache executable: python /workspace/ci/util/xcache.py
+5.51 DEBUG: Found compilers in env:
+5.51   CC: 'riscv32-esp-elf-gcc' (type: str)
+5.51   CXX: 'riscv32-esp-elf-g++' (type: str)
+5.51 Extracted compiler names:
+5.51   CC name: riscv32-esp-elf-gcc
+5.51   CXX name: riscv32-esp-elf-g++
+5.51 Found local compiler cache:
+5.51   Cache file: /workspace/.build/pio/esp32c2/compiler_cache.json
+5.51   Real CC: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-gcc
+5.51   Real CXX: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-g++
+5.51 SUCCESS: Using cached compilers (instant, no platform search needed):
+5.51   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.51   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.51   Platform search skipped - using cached toolset
+5.51 Created Python cached compilers:
+5.51   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.51   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.51 Applied Python fake compilers to both env and projenv
+5.51 Python fake compiler cache enabled: xcache
+5.51   Original CC: riscv32-esp-elf-gcc
+5.51   Original CXX: riscv32-esp-elf-g++
+5.51   Fake CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.51   Fake CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.51 Python fake compiler cache environment configured successfully
+5.61 Retrieved `.pio/build/esp32c2/.dummy/sketch.cpp.o' from cache
+5.61 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-gcc.c.o' from cache
+5.62 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-cpp.cpp.o' from cache
+5.63 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-as.S.o' from cache
+5.63 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.63 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.63   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.63   RET_CODE: no such file or directory
+5.63   ERROR_MESSAGE:
+5.63 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.63 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.63   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.63   RET_CODE: no such file or directory
+5.63   ERROR_MESSAGE:
+5.64 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in] Error 1
+5.64 Retrieved `.pio/build/esp32c2/app_trace/app_trace.c.o' from cache
+5.64 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in] Error 1
+5.79 ========================== [FAILED] Took 5.62 seconds ==========================

--- a/failures/Luminova.log
+++ b/failures/Luminova.log
@@ -1,0 +1,95 @@
+Initial build failed: 0.13 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.13 --------------------------------------------------------------------------------
+0.44 Verbose mode can be enabled via `-v, --verbose` option
+0.52 Error: Failed to install Python dependencies into penv
+0.52 Error output: /home/ubuntu/.fastled/compile/pio/esp32c2/penv/bin/python: No module named pip
+0.56 ========================== [FAILED] Took 0.42 seconds ==========================
+Initial build failed: 0.17 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.17 --------------------------------------------------------------------------------
+0.48 Verbose mode can be enabled via `-v, --verbose` option
+0.93 CONFIGURATION: https://docs.platformio.org/page/boards/espressif32/esp32-c2-devkitm-1.html
+0.93 PLATFORM: Espressif 32 (55.3.30+develop.sha.9651ee8) > Espressif ESP32-C2-DevKitM-1
+0.93 HARDWARE: ESP32C2 120MHz, 272KB RAM, 4MB Flash
+0.93 DEBUG: Current (cmsis-dap) External (cmsis-dap, esp-bridge, esp-prog, iot-bus-jtag, jlink, minimodule, olimex-arm-usb-ocd, olimex-arm-usb-ocd-h, olimex-arm-usb-tiny-h, olimex-jtag-tiny, tumpa)
+0.93 PACKAGES:
+0.93  - contrib-piohome @ 3.4.4
+0.93  - framework-arduino-c2-skeleton-lib @ 5.5.0+sha.cbe9388f45
+0.93  - framework-arduinoespressif32 @ 3.3.0
+0.93  - framework-arduinoespressif32-libs @ 5.5.0+sha.b66b5448e0
+0.93  - framework-espidf @ 3.50500.0 (5.5.0)
+0.93  - tool-cmake @ 3.30.2
+0.93  - tool-esp-rom-elfs @ 2024.10.11
+0.93  - tool-esptoolpy @ 5.0.2
+0.93  - tool-mklittlefs @ 3.2.0
+0.93  - tool-ninja @ 1.13.1
+0.93  - tool-scons @ 4.40801.0 (4.8.1)
+0.93  - toolchain-riscv32-esp @ 14.2.0+20241119
+0.93 *** Compile Arduino IDF libs for esp32c2 ***
+0.95 *** Add "custom_sdkconfig" settings to IDF sdkconfig.defaults ***
+0.95 Replace: CONFIG_IDF_TARGET="esp32c2" with: CONFIG_IDF_TARGET=esp32c2
+0.95 Replace: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y with: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y
+0.95 Replace: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y with: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y
+0.95 Replace: CONFIG_ESPTOOLPY_FLASHFREQ="60m" with: CONFIG_ESPTOOLPY_FLASHFREQ="60m"
+0.95 Add: # CONFIG_ESPTOOLPY_FLASHFREQ_80M is not set
+0.96 Warning! Arduino framework as an ESP-IDF component doesn't handle the `variant` field! The default `esp32` variant will be used.
+0.96 Reading CMake configuration...
+5.34 Generating assembly for certificate bundle...
+5.50 LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
+5.50 LDF Modes: Finder ~ chain, Compatibility ~ soft
+5.55 Found 42 compatible libraries
+5.55 Scanning dependencies...
+5.55 No dependencies
+5.56 Building in release mode
+5.56 Environment state dumped to: env_dump.json
+5.56 Projenv state dumped to: projenv_dump.json
+5.56 Cache configuration from environment:
+5.56   Cache type: xcache
+5.56   Cache executable: python /workspace/ci/util/xcache.py
+5.56   SCCACHE path: /workspace/.venv/bin/sccache
+5.56   SCCACHE dir: /home/ubuntu/.fastled/sccache
+5.56   Debug enabled: False
+5.56 xcache wrapper detected and configured for Python fake compilers
+5.56   xcache path: /workspace/ci/util/xcache.py
+5.56   cache executable: python /workspace/ci/util/xcache.py
+5.56 DEBUG: Found compilers in env:
+5.56   CC: 'riscv32-esp-elf-gcc' (type: str)
+5.56   CXX: 'riscv32-esp-elf-g++' (type: str)
+5.56 Extracted compiler names:
+5.56   CC name: riscv32-esp-elf-gcc
+5.56   CXX name: riscv32-esp-elf-g++
+5.56 Found local compiler cache:
+5.56   Cache file: /workspace/.build/pio/esp32c2/compiler_cache.json
+5.56   Real CC: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-gcc
+5.56   Real CXX: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-g++
+5.56 SUCCESS: Using cached compilers (instant, no platform search needed):
+5.56   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.56   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.56   Platform search skipped - using cached toolset
+5.56 Created Python cached compilers:
+5.56   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.56   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.56 Applied Python fake compilers to both env and projenv
+5.56 Python fake compiler cache enabled: xcache
+5.56   Original CC: riscv32-esp-elf-gcc
+5.56   Original CXX: riscv32-esp-elf-g++
+5.56   Fake CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.56   Fake CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.56 Python fake compiler cache environment configured successfully
+5.67 Retrieved `.pio/build/esp32c2/.dummy/sketch.cpp.o' from cache
+5.67 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-gcc.c.o' from cache
+5.67 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-cpp.cpp.o' from cache
+5.68 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-as.S.o' from cache
+5.68 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.68 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.68   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.68   RET_CODE: no such file or directory
+5.68   ERROR_MESSAGE:
+5.68 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.69 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.69   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.69   RET_CODE: no such file or directory
+5.69   ERROR_MESSAGE:
+5.70 Retrieved `.pio/build/esp32c2/app_trace/app_trace.c.o' from cache
+5.70 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in] Error 1
+5.70 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in] Error 1
+5.84 ========================== [FAILED] Took 5.67 seconds ==========================

--- a/failures/NetTest.log
+++ b/failures/NetTest.log
@@ -1,0 +1,95 @@
+Initial build failed: 0.13 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.13 --------------------------------------------------------------------------------
+0.47 Verbose mode can be enabled via `-v, --verbose` option
+0.54 Error output: /home/ubuntu/.fastled/compile/pio/esp32c2/penv/bin/python: No module named pip
+0.54 Error: Failed to install Python dependencies into penv
+0.58 ========================== [FAILED] Took 0.45 seconds ==========================
+Initial build failed: 0.16 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.16 --------------------------------------------------------------------------------
+0.46 Verbose mode can be enabled via `-v, --verbose` option
+0.87 CONFIGURATION: https://docs.platformio.org/page/boards/espressif32/esp32-c2-devkitm-1.html
+0.87 PLATFORM: Espressif 32 (55.3.30+develop.sha.9651ee8) > Espressif ESP32-C2-DevKitM-1
+0.87 HARDWARE: ESP32C2 120MHz, 272KB RAM, 4MB Flash
+0.87 DEBUG: Current (cmsis-dap) External (cmsis-dap, esp-bridge, esp-prog, iot-bus-jtag, jlink, minimodule, olimex-arm-usb-ocd, olimex-arm-usb-ocd-h, olimex-arm-usb-tiny-h, olimex-jtag-tiny, tumpa)
+0.87 PACKAGES:
+0.87  - contrib-piohome @ 3.4.4
+0.87  - framework-arduino-c2-skeleton-lib @ 5.5.0+sha.cbe9388f45
+0.87  - framework-arduinoespressif32 @ 3.3.0
+0.87  - framework-arduinoespressif32-libs @ 5.5.0+sha.b66b5448e0
+0.87  - framework-espidf @ 3.50500.0 (5.5.0)
+0.87  - tool-cmake @ 3.30.2
+0.87  - tool-esp-rom-elfs @ 2024.10.11
+0.87  - tool-esptoolpy @ 5.0.2
+0.87  - tool-mklittlefs @ 3.2.0
+0.87  - tool-ninja @ 1.13.1
+0.87  - tool-scons @ 4.40801.0 (4.8.1)
+0.87  - toolchain-riscv32-esp @ 14.2.0+20241119
+0.87 *** Compile Arduino IDF libs for esp32c2 ***
+0.89 *** Add "custom_sdkconfig" settings to IDF sdkconfig.defaults ***
+0.89 Replace: CONFIG_IDF_TARGET="esp32c2" with: CONFIG_IDF_TARGET=esp32c2
+0.89 Replace: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y with: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y
+0.89 Replace: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y with: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y
+0.89 Replace: CONFIG_ESPTOOLPY_FLASHFREQ="60m" with: CONFIG_ESPTOOLPY_FLASHFREQ="60m"
+0.89 Add: # CONFIG_ESPTOOLPY_FLASHFREQ_80M is not set
+0.90 Warning! Arduino framework as an ESP-IDF component doesn't handle the `variant` field! The default `esp32` variant will be used.
+0.90 Reading CMake configuration...
+5.25 Generating assembly for certificate bundle...
+5.40 LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
+5.40 LDF Modes: Finder ~ chain, Compatibility ~ soft
+5.46 Found 42 compatible libraries
+5.46 Scanning dependencies...
+5.46 No dependencies
+5.46 Building in release mode
+5.47 Environment state dumped to: env_dump.json
+5.47 Projenv state dumped to: projenv_dump.json
+5.47 Cache configuration from environment:
+5.47   Cache type: xcache
+5.47   Cache executable: python /workspace/ci/util/xcache.py
+5.47   SCCACHE path: /workspace/.venv/bin/sccache
+5.47   SCCACHE dir: /home/ubuntu/.fastled/sccache
+5.47   Debug enabled: False
+5.47 xcache wrapper detected and configured for Python fake compilers
+5.47   xcache path: /workspace/ci/util/xcache.py
+5.47   cache executable: python /workspace/ci/util/xcache.py
+5.47 DEBUG: Found compilers in env:
+5.47   CC: 'riscv32-esp-elf-gcc' (type: str)
+5.47   CXX: 'riscv32-esp-elf-g++' (type: str)
+5.47 Extracted compiler names:
+5.47   CC name: riscv32-esp-elf-gcc
+5.47   CXX name: riscv32-esp-elf-g++
+5.47 Found local compiler cache:
+5.47   Cache file: /workspace/.build/pio/esp32c2/compiler_cache.json
+5.47   Real CC: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-gcc
+5.47   Real CXX: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-g++
+5.47 SUCCESS: Using cached compilers (instant, no platform search needed):
+5.47   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.47   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.47   Platform search skipped - using cached toolset
+5.47 Created Python cached compilers:
+5.47   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.47   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.47 Applied Python fake compilers to both env and projenv
+5.47 Python fake compiler cache enabled: xcache
+5.47   Original CC: riscv32-esp-elf-gcc
+5.47   Original CXX: riscv32-esp-elf-g++
+5.47   Fake CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.47   Fake CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.47 Python fake compiler cache environment configured successfully
+5.57 Retrieved `.pio/build/esp32c2/.dummy/sketch.cpp.o' from cache
+5.58 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-gcc.c.o' from cache
+5.58 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-cpp.cpp.o' from cache
+5.59 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-as.S.o' from cache
+5.59 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.59 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.59   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.59   RET_CODE: no such file or directory
+5.59   ERROR_MESSAGE:
+5.59 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.60 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.60   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.60   RET_CODE: no such file or directory
+5.60   ERROR_MESSAGE:
+5.61 Retrieved `.pio/build/esp32c2/app_trace/app_trace.c.o' from cache
+5.61 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in] Error 1
+5.61 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in] Error 1
+5.75 ========================== [FAILED] Took 5.59 seconds ==========================

--- a/failures/Noise.log
+++ b/failures/Noise.log
@@ -1,0 +1,94 @@
+Initial build failed: 0.13 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.13 --------------------------------------------------------------------------------
+0.44 Verbose mode can be enabled via `-v, --verbose` option
+0.52 Error: Failed to install Python dependencies into penv
+0.52 Error output: /home/ubuntu/.fastled/compile/pio/esp32c2/penv/bin/python: No module named pip
+0.56 ========================== [FAILED] Took 0.44 seconds ==========================
+Initial build failed: 0.16 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.16 --------------------------------------------------------------------------------
+0.47 Verbose mode can be enabled via `-v, --verbose` option
+0.93 CONFIGURATION: https://docs.platformio.org/page/boards/espressif32/esp32-c2-devkitm-1.html
+0.93 PLATFORM: Espressif 32 (55.3.30+develop.sha.9651ee8) > Espressif ESP32-C2-DevKitM-1
+0.93 HARDWARE: ESP32C2 120MHz, 272KB RAM, 4MB Flash
+0.93 DEBUG: Current (cmsis-dap) External (cmsis-dap, esp-bridge, esp-prog, iot-bus-jtag, jlink, minimodule, olimex-arm-usb-ocd, olimex-arm-usb-ocd-h, olimex-arm-usb-tiny-h, olimex-jtag-tiny, tumpa)
+0.93 PACKAGES:
+0.93  - contrib-piohome @ 3.4.4
+0.93  - framework-arduino-c2-skeleton-lib @ 5.5.0+sha.cbe9388f45
+0.93  - framework-arduinoespressif32 @ 3.3.0
+0.93  - framework-arduinoespressif32-libs @ 5.5.0+sha.b66b5448e0
+0.93  - framework-espidf @ 3.50500.0 (5.5.0)
+0.93  - tool-cmake @ 3.30.2
+0.93  - tool-esp-rom-elfs @ 2024.10.11
+0.93  - tool-esptoolpy @ 5.0.2
+0.93  - tool-mklittlefs @ 3.2.0
+0.93  - tool-ninja @ 1.13.1
+0.93  - tool-scons @ 4.40801.0 (4.8.1)
+0.93  - toolchain-riscv32-esp @ 14.2.0+20241119
+0.94 *** Compile Arduino IDF libs for esp32c2 ***
+0.96 *** Add "custom_sdkconfig" settings to IDF sdkconfig.defaults ***
+0.96 Replace: CONFIG_IDF_TARGET="esp32c2" with: CONFIG_IDF_TARGET=esp32c2
+0.96 Replace: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y with: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y
+0.96 Replace: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y with: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y
+0.96 Replace: CONFIG_ESPTOOLPY_FLASHFREQ="60m" with: CONFIG_ESPTOOLPY_FLASHFREQ="60m"
+0.96 Add: # CONFIG_ESPTOOLPY_FLASHFREQ_80M is not set
+0.97 Warning! Arduino framework as an ESP-IDF component doesn't handle the `variant` field! The default `esp32` variant will be used.
+0.97 Reading CMake configuration...
+5.28 Generating assembly for certificate bundle...
+5.44 LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
+5.44 LDF Modes: Finder ~ chain, Compatibility ~ soft
+5.50 Found 42 compatible libraries
+5.50 Scanning dependencies...
+5.50 No dependencies
+5.50 Building in release mode
+5.51 Environment state dumped to: env_dump.json
+5.51 Projenv state dumped to: projenv_dump.json
+5.51 Cache configuration from environment:
+5.51   Cache type: xcache
+5.51   Cache executable: python /workspace/ci/util/xcache.py
+5.51   SCCACHE path: /workspace/.venv/bin/sccache
+5.51   SCCACHE dir: /home/ubuntu/.fastled/sccache
+5.51   Debug enabled: False
+5.51 xcache wrapper detected and configured for Python fake compilers
+5.51   xcache path: /workspace/ci/util/xcache.py
+5.51   cache executable: python /workspace/ci/util/xcache.py
+5.51 DEBUG: Found compilers in env:
+5.51   CC: 'riscv32-esp-elf-gcc' (type: str)
+5.51   CXX: 'riscv32-esp-elf-g++' (type: str)
+5.51 Extracted compiler names:
+5.51   CC name: riscv32-esp-elf-gcc
+5.51   CXX name: riscv32-esp-elf-g++
+5.51 Found local compiler cache:
+5.51   Cache file: /workspace/.build/pio/esp32c2/compiler_cache.json
+5.51   Real CC: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-gcc
+5.51   Real CXX: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-g++
+5.51 SUCCESS: Using cached compilers (instant, no platform search needed):
+5.51   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.51   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.51   Platform search skipped - using cached toolset
+5.51 Created Python cached compilers:
+5.51   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.51   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.51 Applied Python fake compilers to both env and projenv
+5.51 Python fake compiler cache enabled: xcache
+5.51   Original CC: riscv32-esp-elf-gcc
+5.51   Original CXX: riscv32-esp-elf-g++
+5.51   Fake CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.51   Fake CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.51 Python fake compiler cache environment configured successfully
+5.61 Retrieved `.pio/build/esp32c2/.dummy/sketch.cpp.o' from cache
+5.61 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-gcc.c.o' from cache
+5.62 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-cpp.cpp.o' from cache
+5.62 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-as.S.o' from cache
+5.63 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.63 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.63   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.63   RET_CODE: no such file or directory
+5.63   ERROR_MESSAGE:
+5.63 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.63 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in] Error 1
+5.63 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.63   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.63   RET_CODE: no such file or directory
+5.63   ERROR_MESSAGE:
+5.63 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in] Error 1
+5.76 ========================== [FAILED] Took 5.60 seconds ==========================

--- a/failures/NoisePlayground.log
+++ b/failures/NoisePlayground.log
@@ -1,0 +1,95 @@
+Initial build failed: 0.12 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.12 --------------------------------------------------------------------------------
+0.42 Verbose mode can be enabled via `-v, --verbose` option
+0.49 Error: Failed to install Python dependencies into penv
+0.49 Error output: /home/ubuntu/.fastled/compile/pio/esp32c2/penv/bin/python: No module named pip
+0.53 ========================== [FAILED] Took 0.41 seconds ==========================
+Initial build failed: 0.16 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.16 --------------------------------------------------------------------------------
+0.46 Verbose mode can be enabled via `-v, --verbose` option
+0.92 CONFIGURATION: https://docs.platformio.org/page/boards/espressif32/esp32-c2-devkitm-1.html
+0.92 PLATFORM: Espressif 32 (55.3.30+develop.sha.9651ee8) > Espressif ESP32-C2-DevKitM-1
+0.92 HARDWARE: ESP32C2 120MHz, 272KB RAM, 4MB Flash
+0.92 DEBUG: Current (cmsis-dap) External (cmsis-dap, esp-bridge, esp-prog, iot-bus-jtag, jlink, minimodule, olimex-arm-usb-ocd, olimex-arm-usb-ocd-h, olimex-arm-usb-tiny-h, olimex-jtag-tiny, tumpa)
+0.92 PACKAGES:
+0.92  - contrib-piohome @ 3.4.4
+0.92  - framework-arduino-c2-skeleton-lib @ 5.5.0+sha.cbe9388f45
+0.92  - framework-arduinoespressif32 @ 3.3.0
+0.92  - framework-arduinoespressif32-libs @ 5.5.0+sha.b66b5448e0
+0.92  - framework-espidf @ 3.50500.0 (5.5.0)
+0.92  - tool-cmake @ 3.30.2
+0.92  - tool-esp-rom-elfs @ 2024.10.11
+0.92  - tool-esptoolpy @ 5.0.2
+0.92  - tool-mklittlefs @ 3.2.0
+0.92  - tool-ninja @ 1.13.1
+0.92  - tool-scons @ 4.40801.0 (4.8.1)
+0.92  - toolchain-riscv32-esp @ 14.2.0+20241119
+0.93 *** Compile Arduino IDF libs for esp32c2 ***
+0.95 *** Add "custom_sdkconfig" settings to IDF sdkconfig.defaults ***
+0.95 Replace: CONFIG_IDF_TARGET="esp32c2" with: CONFIG_IDF_TARGET=esp32c2
+0.95 Replace: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y with: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y
+0.95 Replace: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y with: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y
+0.95 Replace: CONFIG_ESPTOOLPY_FLASHFREQ="60m" with: CONFIG_ESPTOOLPY_FLASHFREQ="60m"
+0.95 Add: # CONFIG_ESPTOOLPY_FLASHFREQ_80M is not set
+0.96 Warning! Arduino framework as an ESP-IDF component doesn't handle the `variant` field! The default `esp32` variant will be used.
+0.96 Reading CMake configuration...
+5.29 Generating assembly for certificate bundle...
+5.45 LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
+5.45 LDF Modes: Finder ~ chain, Compatibility ~ soft
+5.51 Found 42 compatible libraries
+5.51 Scanning dependencies...
+5.51 No dependencies
+5.51 Building in release mode
+5.52 Environment state dumped to: env_dump.json
+5.52 Projenv state dumped to: projenv_dump.json
+5.52 Cache configuration from environment:
+5.52   Cache type: xcache
+5.52   Cache executable: python /workspace/ci/util/xcache.py
+5.52   SCCACHE path: /workspace/.venv/bin/sccache
+5.52   SCCACHE dir: /home/ubuntu/.fastled/sccache
+5.52   Debug enabled: False
+5.52 xcache wrapper detected and configured for Python fake compilers
+5.52   xcache path: /workspace/ci/util/xcache.py
+5.52   cache executable: python /workspace/ci/util/xcache.py
+5.52 DEBUG: Found compilers in env:
+5.52   CC: 'riscv32-esp-elf-gcc' (type: str)
+5.52   CXX: 'riscv32-esp-elf-g++' (type: str)
+5.52 Extracted compiler names:
+5.52   CC name: riscv32-esp-elf-gcc
+5.52   CXX name: riscv32-esp-elf-g++
+5.52 Found local compiler cache:
+5.52   Cache file: /workspace/.build/pio/esp32c2/compiler_cache.json
+5.52   Real CC: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-gcc
+5.52   Real CXX: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-g++
+5.52 SUCCESS: Using cached compilers (instant, no platform search needed):
+5.52   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.52   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.52   Platform search skipped - using cached toolset
+5.52 Created Python cached compilers:
+5.52   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.52   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.52 Applied Python fake compilers to both env and projenv
+5.52 Python fake compiler cache enabled: xcache
+5.52   Original CC: riscv32-esp-elf-gcc
+5.52   Original CXX: riscv32-esp-elf-g++
+5.52   Fake CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.52   Fake CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.52 Python fake compiler cache environment configured successfully
+5.62 Retrieved `.pio/build/esp32c2/.dummy/sketch.cpp.o' from cache
+5.62 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-gcc.c.o' from cache
+5.63 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-cpp.cpp.o' from cache
+5.63 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-as.S.o' from cache
+5.64 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.64 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.64 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.64   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.64   RET_CODE: no such file or directory
+5.64   ERROR_MESSAGE:
+5.65 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.65   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.65   RET_CODE: no such file or directory
+5.65   ERROR_MESSAGE:
+5.65 Retrieved `.pio/build/esp32c2/app_trace/app_trace.c.o' from cache
+5.65 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in] Error 1
+5.65 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in] Error 1
+5.79 ========================== [FAILED] Took 5.63 seconds ==========================

--- a/failures/NoisePlusPalette.log
+++ b/failures/NoisePlusPalette.log
@@ -1,0 +1,95 @@
+Initial build failed: 0.13 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.13 --------------------------------------------------------------------------------
+0.42 Verbose mode can be enabled via `-v, --verbose` option
+0.49 Error output: /home/ubuntu/.fastled/compile/pio/esp32c2/penv/bin/python: No module named pip
+0.49 Error: Failed to install Python dependencies into penv
+0.53 ========================== [FAILED] Took 0.40 seconds ==========================
+Initial build failed: 0.16 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.16 --------------------------------------------------------------------------------
+0.54 Verbose mode can be enabled via `-v, --verbose` option
+0.93 CONFIGURATION: https://docs.platformio.org/page/boards/espressif32/esp32-c2-devkitm-1.html
+0.93 PLATFORM: Espressif 32 (55.3.30+develop.sha.9651ee8) > Espressif ESP32-C2-DevKitM-1
+0.93 HARDWARE: ESP32C2 120MHz, 272KB RAM, 4MB Flash
+0.93 DEBUG: Current (cmsis-dap) External (cmsis-dap, esp-bridge, esp-prog, iot-bus-jtag, jlink, minimodule, olimex-arm-usb-ocd, olimex-arm-usb-ocd-h, olimex-arm-usb-tiny-h, olimex-jtag-tiny, tumpa)
+0.93 PACKAGES:
+0.93  - contrib-piohome @ 3.4.4
+0.93  - framework-arduino-c2-skeleton-lib @ 5.5.0+sha.cbe9388f45
+0.93  - framework-arduinoespressif32 @ 3.3.0
+0.93  - framework-arduinoespressif32-libs @ 5.5.0+sha.b66b5448e0
+0.93  - framework-espidf @ 3.50500.0 (5.5.0)
+0.93  - tool-cmake @ 3.30.2
+0.93  - tool-esp-rom-elfs @ 2024.10.11
+0.93  - tool-esptoolpy @ 5.0.2
+0.93  - tool-mklittlefs @ 3.2.0
+0.93  - tool-ninja @ 1.13.1
+0.93  - tool-scons @ 4.40801.0 (4.8.1)
+0.93  - toolchain-riscv32-esp @ 14.2.0+20241119
+0.94 *** Compile Arduino IDF libs for esp32c2 ***
+0.96 *** Add "custom_sdkconfig" settings to IDF sdkconfig.defaults ***
+0.96 Replace: CONFIG_IDF_TARGET="esp32c2" with: CONFIG_IDF_TARGET=esp32c2
+0.96 Replace: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y with: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y
+0.96 Replace: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y with: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y
+0.96 Replace: CONFIG_ESPTOOLPY_FLASHFREQ="60m" with: CONFIG_ESPTOOLPY_FLASHFREQ="60m"
+0.96 Add: # CONFIG_ESPTOOLPY_FLASHFREQ_80M is not set
+0.97 Warning! Arduino framework as an ESP-IDF component doesn't handle the `variant` field! The default `esp32` variant will be used.
+0.97 Reading CMake configuration...
+5.33 Generating assembly for certificate bundle...
+5.49 LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
+5.49 LDF Modes: Finder ~ chain, Compatibility ~ soft
+5.55 Found 42 compatible libraries
+5.55 Scanning dependencies...
+5.55 No dependencies
+5.55 Building in release mode
+5.56 Environment state dumped to: env_dump.json
+5.56 Projenv state dumped to: projenv_dump.json
+5.56 Cache configuration from environment:
+5.56   Cache type: xcache
+5.56   Cache executable: python /workspace/ci/util/xcache.py
+5.56   SCCACHE path: /workspace/.venv/bin/sccache
+5.56   SCCACHE dir: /home/ubuntu/.fastled/sccache
+5.56   Debug enabled: False
+5.56 xcache wrapper detected and configured for Python fake compilers
+5.56   xcache path: /workspace/ci/util/xcache.py
+5.56   cache executable: python /workspace/ci/util/xcache.py
+5.56 DEBUG: Found compilers in env:
+5.56   CC: 'riscv32-esp-elf-gcc' (type: str)
+5.56   CXX: 'riscv32-esp-elf-g++' (type: str)
+5.56 Extracted compiler names:
+5.56   CC name: riscv32-esp-elf-gcc
+5.56   CXX name: riscv32-esp-elf-g++
+5.56 Found local compiler cache:
+5.56   Cache file: /workspace/.build/pio/esp32c2/compiler_cache.json
+5.56   Real CC: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-gcc
+5.56   Real CXX: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-g++
+5.56 SUCCESS: Using cached compilers (instant, no platform search needed):
+5.56   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.56   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.56   Platform search skipped - using cached toolset
+5.56 Created Python cached compilers:
+5.56   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.56   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.56 Applied Python fake compilers to both env and projenv
+5.56 Python fake compiler cache enabled: xcache
+5.56   Original CC: riscv32-esp-elf-gcc
+5.56   Original CXX: riscv32-esp-elf-g++
+5.56   Fake CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.56   Fake CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.56 Python fake compiler cache environment configured successfully
+5.66 Retrieved `.pio/build/esp32c2/.dummy/sketch.cpp.o' from cache
+5.66 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-gcc.c.o' from cache
+5.67 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-cpp.cpp.o' from cache
+5.68 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-as.S.o' from cache
+5.68 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.68 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.68   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.68   RET_CODE: no such file or directory
+5.68   ERROR_MESSAGE:
+5.68 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.69 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.69   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.69   RET_CODE: no such file or directory
+5.69   ERROR_MESSAGE:
+5.69 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in] Error 1
+5.69 Retrieved `.pio/build/esp32c2/app_trace/app_trace.c.o' from cache
+5.69 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in] Error 1
+5.83 ========================== [FAILED] Took 5.67 seconds ==========================

--- a/failures/OctoWS2811.log
+++ b/failures/OctoWS2811.log
@@ -1,0 +1,94 @@
+Initial build failed: 0.12 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.12 --------------------------------------------------------------------------------
+0.43 Verbose mode can be enabled via `-v, --verbose` option
+0.50 Error output: /home/ubuntu/.fastled/compile/pio/esp32c2/penv/bin/python: No module named pip
+0.50 Error: Failed to install Python dependencies into penv
+0.54 ========================== [FAILED] Took 0.42 seconds ==========================
+Initial build failed: 0.16 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.16 --------------------------------------------------------------------------------
+0.47 Verbose mode can be enabled via `-v, --verbose` option
+1.00 CONFIGURATION: https://docs.platformio.org/page/boards/espressif32/esp32-c2-devkitm-1.html
+1.00 PLATFORM: Espressif 32 (55.3.30+develop.sha.9651ee8) > Espressif ESP32-C2-DevKitM-1
+1.00 HARDWARE: ESP32C2 120MHz, 272KB RAM, 4MB Flash
+1.00 DEBUG: Current (cmsis-dap) External (cmsis-dap, esp-bridge, esp-prog, iot-bus-jtag, jlink, minimodule, olimex-arm-usb-ocd, olimex-arm-usb-ocd-h, olimex-arm-usb-tiny-h, olimex-jtag-tiny, tumpa)
+1.00 PACKAGES:
+1.00  - contrib-piohome @ 3.4.4
+1.00  - framework-arduino-c2-skeleton-lib @ 5.5.0+sha.cbe9388f45
+1.00  - framework-arduinoespressif32 @ 3.3.0
+1.00  - framework-arduinoespressif32-libs @ 5.5.0+sha.b66b5448e0
+1.00  - framework-espidf @ 3.50500.0 (5.5.0)
+1.00  - tool-cmake @ 3.30.2
+1.00  - tool-esp-rom-elfs @ 2024.10.11
+1.00  - tool-esptoolpy @ 5.0.2
+1.00  - tool-mklittlefs @ 3.2.0
+1.00  - tool-ninja @ 1.13.1
+1.00  - tool-scons @ 4.40801.0 (4.8.1)
+1.00  - toolchain-riscv32-esp @ 14.2.0+20241119
+1.00 *** Compile Arduino IDF libs for esp32c2 ***
+1.02 *** Add "custom_sdkconfig" settings to IDF sdkconfig.defaults ***
+1.02 Replace: CONFIG_IDF_TARGET="esp32c2" with: CONFIG_IDF_TARGET=esp32c2
+1.02 Replace: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y with: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y
+1.02 Replace: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y with: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y
+1.02 Replace: CONFIG_ESPTOOLPY_FLASHFREQ="60m" with: CONFIG_ESPTOOLPY_FLASHFREQ="60m"
+1.02 Add: # CONFIG_ESPTOOLPY_FLASHFREQ_80M is not set
+1.03 Warning! Arduino framework as an ESP-IDF component doesn't handle the `variant` field! The default `esp32` variant will be used.
+1.03 Reading CMake configuration...
+8.34 Generating assembly for certificate bundle...
+8.50 LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
+8.50 LDF Modes: Finder ~ chain, Compatibility ~ soft
+8.55 Found 42 compatible libraries
+8.55 Scanning dependencies...
+8.56 No dependencies
+8.56 Building in release mode
+8.57 Environment state dumped to: env_dump.json
+8.57 Projenv state dumped to: projenv_dump.json
+8.57 Cache configuration from environment:
+8.57   Cache type: xcache
+8.57   Cache executable: python /workspace/ci/util/xcache.py
+8.57   SCCACHE path: /workspace/.venv/bin/sccache
+8.57   SCCACHE dir: /home/ubuntu/.fastled/sccache
+8.57   Debug enabled: False
+8.57 xcache wrapper detected and configured for Python fake compilers
+8.57   xcache path: /workspace/ci/util/xcache.py
+8.57   cache executable: python /workspace/ci/util/xcache.py
+8.57 DEBUG: Found compilers in env:
+8.57   CC: 'riscv32-esp-elf-gcc' (type: str)
+8.57   CXX: 'riscv32-esp-elf-g++' (type: str)
+8.57 Extracted compiler names:
+8.57   CC name: riscv32-esp-elf-gcc
+8.57   CXX name: riscv32-esp-elf-g++
+8.57 Found local compiler cache:
+8.57   Cache file: /workspace/.build/pio/esp32c2/compiler_cache.json
+8.57   Real CC: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-gcc
+8.57   Real CXX: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-g++
+8.57 SUCCESS: Using cached compilers (instant, no platform search needed):
+8.57   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+8.57   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+8.57   Platform search skipped - using cached toolset
+8.57 Created Python cached compilers:
+8.57   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+8.57   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+8.57 Applied Python fake compilers to both env and projenv
+8.57 Python fake compiler cache enabled: xcache
+8.57   Original CC: riscv32-esp-elf-gcc
+8.57   Original CXX: riscv32-esp-elf-g++
+8.57   Fake CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+8.57   Fake CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+8.57 Python fake compiler cache environment configured successfully
+8.67 Retrieved `.pio/build/esp32c2/.dummy/sketch.cpp.o' from cache
+8.67 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-gcc.c.o' from cache
+8.68 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-cpp.cpp.o' from cache
+8.68 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-as.S.o' from cache
+8.69 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+8.69 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+8.69   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+8.69   RET_CODE: no such file or directory
+8.69   ERROR_MESSAGE:
+8.69 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+8.69 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in] Error 1
+8.69 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+8.69   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+8.69   RET_CODE: no such file or directory
+8.69   ERROR_MESSAGE:
+8.69 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in] Error 1
+8.83 ========================== [FAILED] Took 8.67 seconds ==========================

--- a/failures/Overclock.log
+++ b/failures/Overclock.log
@@ -1,0 +1,95 @@
+Initial build failed: 0.12 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.12 --------------------------------------------------------------------------------
+0.44 Verbose mode can be enabled via `-v, --verbose` option
+0.52 Error: Failed to install Python dependencies into penv
+0.52 Error output: /home/ubuntu/.fastled/compile/pio/esp32c2/penv/bin/python: No module named pip
+0.56 ========================== [FAILED] Took 0.44 seconds ==========================
+Initial build failed: 0.16 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.16 --------------------------------------------------------------------------------
+0.46 Verbose mode can be enabled via `-v, --verbose` option
+0.95 CONFIGURATION: https://docs.platformio.org/page/boards/espressif32/esp32-c2-devkitm-1.html
+0.95 PLATFORM: Espressif 32 (55.3.30+develop.sha.9651ee8) > Espressif ESP32-C2-DevKitM-1
+0.95 HARDWARE: ESP32C2 120MHz, 272KB RAM, 4MB Flash
+0.95 DEBUG: Current (cmsis-dap) External (cmsis-dap, esp-bridge, esp-prog, iot-bus-jtag, jlink, minimodule, olimex-arm-usb-ocd, olimex-arm-usb-ocd-h, olimex-arm-usb-tiny-h, olimex-jtag-tiny, tumpa)
+0.95 PACKAGES:
+0.95  - contrib-piohome @ 3.4.4
+0.95  - framework-arduino-c2-skeleton-lib @ 5.5.0+sha.cbe9388f45
+0.95  - framework-arduinoespressif32 @ 3.3.0
+0.95  - framework-arduinoespressif32-libs @ 5.5.0+sha.b66b5448e0
+0.95  - framework-espidf @ 3.50500.0 (5.5.0)
+0.95  - tool-cmake @ 3.30.2
+0.95  - tool-esp-rom-elfs @ 2024.10.11
+0.95  - tool-esptoolpy @ 5.0.2
+0.95  - tool-mklittlefs @ 3.2.0
+0.95  - tool-ninja @ 1.13.1
+0.95  - tool-scons @ 4.40801.0 (4.8.1)
+0.95  - toolchain-riscv32-esp @ 14.2.0+20241119
+0.95 *** Compile Arduino IDF libs for esp32c2 ***
+0.97 *** Add "custom_sdkconfig" settings to IDF sdkconfig.defaults ***
+0.97 Replace: CONFIG_IDF_TARGET="esp32c2" with: CONFIG_IDF_TARGET=esp32c2
+0.97 Replace: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y with: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y
+0.97 Replace: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y with: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y
+0.97 Replace: CONFIG_ESPTOOLPY_FLASHFREQ="60m" with: CONFIG_ESPTOOLPY_FLASHFREQ="60m"
+0.97 Add: # CONFIG_ESPTOOLPY_FLASHFREQ_80M is not set
+0.98 Warning! Arduino framework as an ESP-IDF component doesn't handle the `variant` field! The default `esp32` variant will be used.
+0.98 Reading CMake configuration...
+5.35 Generating assembly for certificate bundle...
+5.50 LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
+5.50 LDF Modes: Finder ~ chain, Compatibility ~ soft
+5.56 Found 42 compatible libraries
+5.56 Scanning dependencies...
+5.56 No dependencies
+5.56 Building in release mode
+5.57 Environment state dumped to: env_dump.json
+5.57 Projenv state dumped to: projenv_dump.json
+5.57 Cache configuration from environment:
+5.57   Cache type: xcache
+5.57   Cache executable: python /workspace/ci/util/xcache.py
+5.57   SCCACHE path: /workspace/.venv/bin/sccache
+5.57   SCCACHE dir: /home/ubuntu/.fastled/sccache
+5.57   Debug enabled: False
+5.57 xcache wrapper detected and configured for Python fake compilers
+5.57   xcache path: /workspace/ci/util/xcache.py
+5.57   cache executable: python /workspace/ci/util/xcache.py
+5.57 DEBUG: Found compilers in env:
+5.57   CC: 'riscv32-esp-elf-gcc' (type: str)
+5.57   CXX: 'riscv32-esp-elf-g++' (type: str)
+5.57 Extracted compiler names:
+5.57   CC name: riscv32-esp-elf-gcc
+5.57   CXX name: riscv32-esp-elf-g++
+5.57 Found local compiler cache:
+5.57   Cache file: /workspace/.build/pio/esp32c2/compiler_cache.json
+5.57   Real CC: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-gcc
+5.57   Real CXX: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-g++
+5.57 SUCCESS: Using cached compilers (instant, no platform search needed):
+5.57   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.57   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.57   Platform search skipped - using cached toolset
+5.57 Created Python cached compilers:
+5.57   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.57   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.57 Applied Python fake compilers to both env and projenv
+5.57 Python fake compiler cache enabled: xcache
+5.57   Original CC: riscv32-esp-elf-gcc
+5.57   Original CXX: riscv32-esp-elf-g++
+5.57   Fake CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.57   Fake CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.57 Python fake compiler cache environment configured successfully
+5.67 Retrieved `.pio/build/esp32c2/.dummy/sketch.cpp.o' from cache
+5.68 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-gcc.c.o' from cache
+5.68 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-cpp.cpp.o' from cache
+5.69 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-as.S.o' from cache
+5.69 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.69 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.69 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.69   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.69   RET_CODE: no such file or directory
+5.69   ERROR_MESSAGE:
+5.70 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.70   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.70   RET_CODE: no such file or directory
+5.70   ERROR_MESSAGE:
+5.71 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in] Error 1
+5.71 Retrieved `.pio/build/esp32c2/app_trace/app_trace.c.o' from cache
+5.71 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in] Error 1
+5.85 ========================== [FAILED] Took 5.69 seconds ==========================

--- a/failures/Pacifica.log
+++ b/failures/Pacifica.log
@@ -1,0 +1,90 @@
+Initial build failed: 0.13 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.13 --------------------------------------------------------------------------------
+0.44 Verbose mode can be enabled via `-v, --verbose` option
+0.52 Error output: /home/ubuntu/.fastled/compile/pio/esp32c2/penv/bin/python: No module named pip
+0.52 Error: Failed to install Python dependencies into penv
+0.56 ========================== [FAILED] Took 0.43 seconds ==========================
+Initial build failed: 0.13 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.13 --------------------------------------------------------------------------------
+0.45 Verbose mode can be enabled via `-v, --verbose` option
+0.83 CONFIGURATION: https://docs.platformio.org/page/boards/espressif32/esp32-c2-devkitm-1.html
+0.83 PLATFORM: Espressif 32 (55.3.30+develop.sha.9651ee8) > Espressif ESP32-C2-DevKitM-1
+0.83 HARDWARE: ESP32C2 120MHz, 272KB RAM, 4MB Flash
+0.83 DEBUG: Current (cmsis-dap) External (cmsis-dap, esp-bridge, esp-prog, iot-bus-jtag, jlink, minimodule, olimex-arm-usb-ocd, olimex-arm-usb-ocd-h, olimex-arm-usb-tiny-h, olimex-jtag-tiny, tumpa)
+0.83 PACKAGES:
+0.83  - contrib-piohome @ 3.4.4
+0.83  - framework-arduino-c2-skeleton-lib @ 5.5.0+sha.cbe9388f45
+0.83  - framework-arduinoespressif32 @ 3.3.0
+0.83  - framework-arduinoespressif32-libs @ 5.5.0+sha.b66b5448e0
+0.83  - framework-espidf @ 3.50500.0 (5.5.0)
+0.83  - tool-cmake @ 3.30.2
+0.83  - tool-esp-rom-elfs @ 2024.10.11
+0.83  - tool-esptoolpy @ 5.0.2
+0.83  - tool-mklittlefs @ 3.2.0
+0.83  - tool-ninja @ 1.13.1
+0.83  - tool-scons @ 4.40801.0 (4.8.1)
+0.83  - toolchain-riscv32-esp @ 14.2.0+20241119
+0.83 *** Compile Arduino IDF libs for esp32c2 ***
+0.85 *** Add "custom_sdkconfig" settings to IDF sdkconfig.defaults ***
+0.85 Replace: CONFIG_IDF_TARGET="esp32c2" with: CONFIG_IDF_TARGET=esp32c2
+0.85 Replace: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y with: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y
+0.85 Replace: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y with: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y
+0.85 Replace: CONFIG_ESPTOOLPY_FLASHFREQ="60m" with: CONFIG_ESPTOOLPY_FLASHFREQ="60m"
+0.85 Add: # CONFIG_ESPTOOLPY_FLASHFREQ_80M is not set
+0.87 Warning! Arduino framework as an ESP-IDF component doesn't handle the `variant` field! The default `esp32` variant will be used.
+0.87 Reading CMake configuration...
+4.94 LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
+4.94 LDF Modes: Finder ~ chain, Compatibility ~ soft
+5.00 Found 42 compatible libraries
+5.00 Scanning dependencies...
+5.00 No dependencies
+5.00 Building in release mode
+5.01 Environment state dumped to: env_dump.json
+5.01 Projenv state dumped to: projenv_dump.json
+5.01 Cache configuration from environment:
+5.01   Cache type: xcache
+5.01   Cache executable: python /workspace/ci/util/xcache.py
+5.01   SCCACHE path: /workspace/.venv/bin/sccache
+5.01   SCCACHE dir: /home/ubuntu/.fastled/sccache
+5.01   Debug enabled: False
+5.01 xcache wrapper detected and configured for Python fake compilers
+5.01   xcache path: /workspace/ci/util/xcache.py
+5.01   cache executable: python /workspace/ci/util/xcache.py
+5.01 DEBUG: Found compilers in env:
+5.01   CC: 'riscv32-esp-elf-gcc' (type: str)
+5.01   CXX: 'riscv32-esp-elf-g++' (type: str)
+5.01 Extracted compiler names:
+5.01   CC name: riscv32-esp-elf-gcc
+5.01   CXX name: riscv32-esp-elf-g++
+5.01 Found local compiler cache:
+5.01   Cache file: /workspace/.build/pio/esp32c2/compiler_cache.json
+5.01   Real CC: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-gcc
+5.01   Real CXX: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-g++
+5.01 SUCCESS: Using cached compilers (instant, no platform search needed):
+5.01   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.01   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.01   Platform search skipped - using cached toolset
+5.01 Created Python cached compilers:
+5.01   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.01   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.01 Applied Python fake compilers to both env and projenv
+5.01 Python fake compiler cache enabled: xcache
+5.01   Original CC: riscv32-esp-elf-gcc
+5.01   Original CXX: riscv32-esp-elf-g++
+5.01   Fake CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.01   Fake CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.01 Python fake compiler cache environment configured successfully
+5.04 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.05 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.05 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.05   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.05   RET_CODE: no such file or directory
+5.05   ERROR_MESSAGE:
+5.05 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.05   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.05   RET_CODE: no such file or directory
+5.05   ERROR_MESSAGE:
+5.07 Retrieved `.pio/build/esp32c2/app_trace/app_trace_util.c.o' from cache
+5.07 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in] Error 1
+5.07 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in] Error 1
+5.20 ========================== [FAILED] Took 5.07 seconds ==========================

--- a/failures/PinMode.log
+++ b/failures/PinMode.log
@@ -1,0 +1,90 @@
+Initial build failed: 0.12 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.12 --------------------------------------------------------------------------------
+0.42 Verbose mode can be enabled via `-v, --verbose` option
+0.51 Error: Failed to install Python dependencies into penv
+0.51 Error output: /home/ubuntu/.fastled/compile/pio/esp32c2/penv/bin/python: No module named pip
+0.55 ========================== [FAILED] Took 0.42 seconds ==========================
+Initial build failed: 0.13 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.13 --------------------------------------------------------------------------------
+0.43 Verbose mode can be enabled via `-v, --verbose` option
+0.84 CONFIGURATION: https://docs.platformio.org/page/boards/espressif32/esp32-c2-devkitm-1.html
+0.84 PLATFORM: Espressif 32 (55.3.30+develop.sha.9651ee8) > Espressif ESP32-C2-DevKitM-1
+0.84 HARDWARE: ESP32C2 120MHz, 272KB RAM, 4MB Flash
+0.84 DEBUG: Current (cmsis-dap) External (cmsis-dap, esp-bridge, esp-prog, iot-bus-jtag, jlink, minimodule, olimex-arm-usb-ocd, olimex-arm-usb-ocd-h, olimex-arm-usb-tiny-h, olimex-jtag-tiny, tumpa)
+0.84 PACKAGES:
+0.84  - contrib-piohome @ 3.4.4
+0.84  - framework-arduino-c2-skeleton-lib @ 5.5.0+sha.cbe9388f45
+0.84  - framework-arduinoespressif32 @ 3.3.0
+0.84  - framework-arduinoespressif32-libs @ 5.5.0+sha.b66b5448e0
+0.84  - framework-espidf @ 3.50500.0 (5.5.0)
+0.84  - tool-cmake @ 3.30.2
+0.84  - tool-esp-rom-elfs @ 2024.10.11
+0.84  - tool-esptoolpy @ 5.0.2
+0.84  - tool-mklittlefs @ 3.2.0
+0.84  - tool-ninja @ 1.13.1
+0.84  - tool-scons @ 4.40801.0 (4.8.1)
+0.84  - toolchain-riscv32-esp @ 14.2.0+20241119
+0.84 *** Compile Arduino IDF libs for esp32c2 ***
+0.86 *** Add "custom_sdkconfig" settings to IDF sdkconfig.defaults ***
+0.86 Replace: CONFIG_IDF_TARGET="esp32c2" with: CONFIG_IDF_TARGET=esp32c2
+0.86 Replace: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y with: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y
+0.86 Replace: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y with: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y
+0.86 Replace: CONFIG_ESPTOOLPY_FLASHFREQ="60m" with: CONFIG_ESPTOOLPY_FLASHFREQ="60m"
+0.86 Add: # CONFIG_ESPTOOLPY_FLASHFREQ_80M is not set
+0.87 Warning! Arduino framework as an ESP-IDF component doesn't handle the `variant` field! The default `esp32` variant will be used.
+0.87 Reading CMake configuration...
+4.93 LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
+4.93 LDF Modes: Finder ~ chain, Compatibility ~ soft
+4.99 Found 42 compatible libraries
+4.99 Scanning dependencies...
+4.99 No dependencies
+4.99 Building in release mode
+5.00 Environment state dumped to: env_dump.json
+5.00 Projenv state dumped to: projenv_dump.json
+5.00 Cache configuration from environment:
+5.00   Cache type: xcache
+5.00   Cache executable: python /workspace/ci/util/xcache.py
+5.00   SCCACHE path: /workspace/.venv/bin/sccache
+5.00   SCCACHE dir: /home/ubuntu/.fastled/sccache
+5.00   Debug enabled: False
+5.00 xcache wrapper detected and configured for Python fake compilers
+5.00   xcache path: /workspace/ci/util/xcache.py
+5.00   cache executable: python /workspace/ci/util/xcache.py
+5.00 DEBUG: Found compilers in env:
+5.00   CC: 'riscv32-esp-elf-gcc' (type: str)
+5.00   CXX: 'riscv32-esp-elf-g++' (type: str)
+5.00 Extracted compiler names:
+5.00   CC name: riscv32-esp-elf-gcc
+5.00   CXX name: riscv32-esp-elf-g++
+5.00 Found local compiler cache:
+5.00   Cache file: /workspace/.build/pio/esp32c2/compiler_cache.json
+5.00   Real CC: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-gcc
+5.00   Real CXX: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-g++
+5.00 SUCCESS: Using cached compilers (instant, no platform search needed):
+5.00   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.00   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.00   Platform search skipped - using cached toolset
+5.00 Created Python cached compilers:
+5.00   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.00   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.00 Applied Python fake compilers to both env and projenv
+5.00 Python fake compiler cache enabled: xcache
+5.00   Original CC: riscv32-esp-elf-gcc
+5.00   Original CXX: riscv32-esp-elf-g++
+5.00   Fake CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.00   Fake CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.00 Python fake compiler cache environment configured successfully
+5.03 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.04 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.04 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.04   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.04   RET_CODE: no such file or directory
+5.04   ERROR_MESSAGE:
+5.04 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.04   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.04   RET_CODE: no such file or directory
+5.04   ERROR_MESSAGE:
+5.06 Retrieved `.pio/build/esp32c2/app_trace/host_file_io.c.o' from cache
+5.06 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in] Error 1
+5.06 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in] Error 1
+5.20 ========================== [FAILED] Took 5.07 seconds ==========================

--- a/failures/Pintest.log
+++ b/failures/Pintest.log
@@ -1,0 +1,95 @@
+Initial build failed: 0.12 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.12 --------------------------------------------------------------------------------
+0.46 Verbose mode can be enabled via `-v, --verbose` option
+0.56 Error output: /home/ubuntu/.fastled/compile/pio/esp32c2/penv/bin/python: No module named pip
+0.56 Error: Failed to install Python dependencies into penv
+0.61 ========================== [FAILED] Took 0.48 seconds ==========================
+Initial build failed: 0.16 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.16 --------------------------------------------------------------------------------
+0.47 Verbose mode can be enabled via `-v, --verbose` option
+0.85 CONFIGURATION: https://docs.platformio.org/page/boards/espressif32/esp32-c2-devkitm-1.html
+0.85 PLATFORM: Espressif 32 (55.3.30+develop.sha.9651ee8) > Espressif ESP32-C2-DevKitM-1
+0.85 HARDWARE: ESP32C2 120MHz, 272KB RAM, 4MB Flash
+0.85 DEBUG: Current (cmsis-dap) External (cmsis-dap, esp-bridge, esp-prog, iot-bus-jtag, jlink, minimodule, olimex-arm-usb-ocd, olimex-arm-usb-ocd-h, olimex-arm-usb-tiny-h, olimex-jtag-tiny, tumpa)
+0.85 PACKAGES:
+0.85  - contrib-piohome @ 3.4.4
+0.85  - framework-arduino-c2-skeleton-lib @ 5.5.0+sha.cbe9388f45
+0.85  - framework-arduinoespressif32 @ 3.3.0
+0.85  - framework-arduinoespressif32-libs @ 5.5.0+sha.b66b5448e0
+0.85  - framework-espidf @ 3.50500.0 (5.5.0)
+0.85  - tool-cmake @ 3.30.2
+0.85  - tool-esp-rom-elfs @ 2024.10.11
+0.85  - tool-esptoolpy @ 5.0.2
+0.85  - tool-mklittlefs @ 3.2.0
+0.85  - tool-ninja @ 1.13.1
+0.85  - tool-scons @ 4.40801.0 (4.8.1)
+0.85  - toolchain-riscv32-esp @ 14.2.0+20241119
+0.86 *** Compile Arduino IDF libs for esp32c2 ***
+0.87 *** Add "custom_sdkconfig" settings to IDF sdkconfig.defaults ***
+0.87 Replace: CONFIG_IDF_TARGET="esp32c2" with: CONFIG_IDF_TARGET=esp32c2
+0.87 Replace: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y with: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y
+0.87 Replace: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y with: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y
+0.87 Replace: CONFIG_ESPTOOLPY_FLASHFREQ="60m" with: CONFIG_ESPTOOLPY_FLASHFREQ="60m"
+0.88 Add: # CONFIG_ESPTOOLPY_FLASHFREQ_80M is not set
+0.89 Warning! Arduino framework as an ESP-IDF component doesn't handle the `variant` field! The default `esp32` variant will be used.
+0.89 Reading CMake configuration...
+5.26 Generating assembly for certificate bundle...
+5.42 LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
+5.42 LDF Modes: Finder ~ chain, Compatibility ~ soft
+5.48 Found 42 compatible libraries
+5.48 Scanning dependencies...
+5.48 No dependencies
+5.49 Building in release mode
+5.49 Environment state dumped to: env_dump.json
+5.49 Projenv state dumped to: projenv_dump.json
+5.49 Cache configuration from environment:
+5.49   Cache type: xcache
+5.49   Cache executable: python /workspace/ci/util/xcache.py
+5.49   SCCACHE path: /workspace/.venv/bin/sccache
+5.49   SCCACHE dir: /home/ubuntu/.fastled/sccache
+5.49   Debug enabled: False
+5.49 xcache wrapper detected and configured for Python fake compilers
+5.49   xcache path: /workspace/ci/util/xcache.py
+5.49   cache executable: python /workspace/ci/util/xcache.py
+5.49 DEBUG: Found compilers in env:
+5.49   CC: 'riscv32-esp-elf-gcc' (type: str)
+5.49   CXX: 'riscv32-esp-elf-g++' (type: str)
+5.49 Extracted compiler names:
+5.49   CC name: riscv32-esp-elf-gcc
+5.49   CXX name: riscv32-esp-elf-g++
+5.49 Found local compiler cache:
+5.49   Cache file: /workspace/.build/pio/esp32c2/compiler_cache.json
+5.49   Real CC: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-gcc
+5.49   Real CXX: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-g++
+5.49 SUCCESS: Using cached compilers (instant, no platform search needed):
+5.49   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.49   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.49   Platform search skipped - using cached toolset
+5.49 Created Python cached compilers:
+5.49   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.49   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.49 Applied Python fake compilers to both env and projenv
+5.49 Python fake compiler cache enabled: xcache
+5.49   Original CC: riscv32-esp-elf-gcc
+5.49   Original CXX: riscv32-esp-elf-g++
+5.49   Fake CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.49   Fake CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.49 Python fake compiler cache environment configured successfully
+5.60 Retrieved `.pio/build/esp32c2/.dummy/sketch.cpp.o' from cache
+5.60 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-gcc.c.o' from cache
+5.61 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-cpp.cpp.o' from cache
+5.61 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-as.S.o' from cache
+5.62 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.62 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.62 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.62   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.62   RET_CODE: no such file or directory
+5.62   ERROR_MESSAGE:
+5.62 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.62   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.62   RET_CODE: no such file or directory
+5.62   ERROR_MESSAGE:
+5.63 Retrieved `.pio/build/esp32c2/app_trace/app_trace.c.o' from cache
+5.63 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in] Error 1
+5.63 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in] Error 1
+5.77 ========================== [FAILED] Took 5.61 seconds ==========================

--- a/failures/Pride2015.log
+++ b/failures/Pride2015.log
@@ -1,0 +1,94 @@
+Initial build failed: 0.15 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.15 --------------------------------------------------------------------------------
+0.51 Verbose mode can be enabled via `-v, --verbose` option
+0.58 Error output: /home/ubuntu/.fastled/compile/pio/esp32c2/penv/bin/python: No module named pip
+0.58 Error: Failed to install Python dependencies into penv
+0.63 ========================== [FAILED] Took 0.47 seconds ==========================
+Initial build failed: 0.16 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.16 --------------------------------------------------------------------------------
+0.47 Verbose mode can be enabled via `-v, --verbose` option
+0.86 CONFIGURATION: https://docs.platformio.org/page/boards/espressif32/esp32-c2-devkitm-1.html
+0.86 PLATFORM: Espressif 32 (55.3.30+develop.sha.9651ee8) > Espressif ESP32-C2-DevKitM-1
+0.86 HARDWARE: ESP32C2 120MHz, 272KB RAM, 4MB Flash
+0.86 DEBUG: Current (cmsis-dap) External (cmsis-dap, esp-bridge, esp-prog, iot-bus-jtag, jlink, minimodule, olimex-arm-usb-ocd, olimex-arm-usb-ocd-h, olimex-arm-usb-tiny-h, olimex-jtag-tiny, tumpa)
+0.86 PACKAGES:
+0.86  - contrib-piohome @ 3.4.4
+0.86  - framework-arduino-c2-skeleton-lib @ 5.5.0+sha.cbe9388f45
+0.86  - framework-arduinoespressif32 @ 3.3.0
+0.86  - framework-arduinoespressif32-libs @ 5.5.0+sha.b66b5448e0
+0.86  - framework-espidf @ 3.50500.0 (5.5.0)
+0.86  - tool-cmake @ 3.30.2
+0.86  - tool-esp-rom-elfs @ 2024.10.11
+0.86  - tool-esptoolpy @ 5.0.2
+0.86  - tool-mklittlefs @ 3.2.0
+0.86  - tool-ninja @ 1.13.1
+0.86  - tool-scons @ 4.40801.0 (4.8.1)
+0.86  - toolchain-riscv32-esp @ 14.2.0+20241119
+0.87 *** Compile Arduino IDF libs for esp32c2 ***
+0.89 *** Add "custom_sdkconfig" settings to IDF sdkconfig.defaults ***
+0.89 Replace: CONFIG_IDF_TARGET="esp32c2" with: CONFIG_IDF_TARGET=esp32c2
+0.89 Replace: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y with: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y
+0.89 Replace: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y with: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y
+0.89 Replace: CONFIG_ESPTOOLPY_FLASHFREQ="60m" with: CONFIG_ESPTOOLPY_FLASHFREQ="60m"
+0.89 Add: # CONFIG_ESPTOOLPY_FLASHFREQ_80M is not set
+0.90 Warning! Arduino framework as an ESP-IDF component doesn't handle the `variant` field! The default `esp32` variant will be used.
+0.90 Reading CMake configuration...
+5.27 Generating assembly for certificate bundle...
+5.43 LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
+5.43 LDF Modes: Finder ~ chain, Compatibility ~ soft
+5.49 Found 42 compatible libraries
+5.49 Scanning dependencies...
+5.49 No dependencies
+5.49 Building in release mode
+5.50 Environment state dumped to: env_dump.json
+5.50 Projenv state dumped to: projenv_dump.json
+5.50 Cache configuration from environment:
+5.50   Cache type: xcache
+5.50   Cache executable: python /workspace/ci/util/xcache.py
+5.50   SCCACHE path: /workspace/.venv/bin/sccache
+5.50   SCCACHE dir: /home/ubuntu/.fastled/sccache
+5.50   Debug enabled: False
+5.50 xcache wrapper detected and configured for Python fake compilers
+5.50   xcache path: /workspace/ci/util/xcache.py
+5.50   cache executable: python /workspace/ci/util/xcache.py
+5.50 DEBUG: Found compilers in env:
+5.50   CC: 'riscv32-esp-elf-gcc' (type: str)
+5.50   CXX: 'riscv32-esp-elf-g++' (type: str)
+5.50 Extracted compiler names:
+5.50   CC name: riscv32-esp-elf-gcc
+5.50   CXX name: riscv32-esp-elf-g++
+5.50 Found local compiler cache:
+5.50   Cache file: /workspace/.build/pio/esp32c2/compiler_cache.json
+5.50   Real CC: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-gcc
+5.50   Real CXX: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-g++
+5.50 SUCCESS: Using cached compilers (instant, no platform search needed):
+5.50   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.50   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.50   Platform search skipped - using cached toolset
+5.50 Created Python cached compilers:
+5.50   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.50   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.50 Applied Python fake compilers to both env and projenv
+5.50 Python fake compiler cache enabled: xcache
+5.50   Original CC: riscv32-esp-elf-gcc
+5.50   Original CXX: riscv32-esp-elf-g++
+5.50   Fake CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.50   Fake CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.50 Python fake compiler cache environment configured successfully
+5.60 Retrieved `.pio/build/esp32c2/.dummy/sketch.cpp.o' from cache
+5.61 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-gcc.c.o' from cache
+5.61 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-cpp.cpp.o' from cache
+5.62 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-as.S.o' from cache
+5.62 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.62 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.62   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.62   RET_CODE: no such file or directory
+5.62   ERROR_MESSAGE:
+5.62 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.63 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in] Error 1
+5.63 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.63   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.63   RET_CODE: no such file or directory
+5.63   ERROR_MESSAGE:
+5.63 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in] Error 1
+5.77 ========================== [FAILED] Took 5.60 seconds ==========================

--- a/failures/RGBCalibrate.log
+++ b/failures/RGBCalibrate.log
@@ -1,0 +1,90 @@
+Initial build failed: 0.16 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.16 --------------------------------------------------------------------------------
+0.52 Verbose mode can be enabled via `-v, --verbose` option
+0.61 Error output: /home/ubuntu/.fastled/compile/pio/esp32c2/penv/bin/python: No module named pip
+0.61 Error: Failed to install Python dependencies into penv
+0.66 ========================== [FAILED] Took 0.50 seconds ==========================
+Initial build failed: 0.13 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.13 --------------------------------------------------------------------------------
+0.43 Verbose mode can be enabled via `-v, --verbose` option
+0.82 CONFIGURATION: https://docs.platformio.org/page/boards/espressif32/esp32-c2-devkitm-1.html
+0.82 PLATFORM: Espressif 32 (55.3.30+develop.sha.9651ee8) > Espressif ESP32-C2-DevKitM-1
+0.82 HARDWARE: ESP32C2 120MHz, 272KB RAM, 4MB Flash
+0.82 DEBUG: Current (cmsis-dap) External (cmsis-dap, esp-bridge, esp-prog, iot-bus-jtag, jlink, minimodule, olimex-arm-usb-ocd, olimex-arm-usb-ocd-h, olimex-arm-usb-tiny-h, olimex-jtag-tiny, tumpa)
+0.82 PACKAGES:
+0.82  - contrib-piohome @ 3.4.4
+0.82  - framework-arduino-c2-skeleton-lib @ 5.5.0+sha.cbe9388f45
+0.82  - framework-arduinoespressif32 @ 3.3.0
+0.82  - framework-arduinoespressif32-libs @ 5.5.0+sha.b66b5448e0
+0.82  - framework-espidf @ 3.50500.0 (5.5.0)
+0.82  - tool-cmake @ 3.30.2
+0.82  - tool-esp-rom-elfs @ 2024.10.11
+0.82  - tool-esptoolpy @ 5.0.2
+0.82  - tool-mklittlefs @ 3.2.0
+0.82  - tool-ninja @ 1.13.1
+0.82  - tool-scons @ 4.40801.0 (4.8.1)
+0.82  - toolchain-riscv32-esp @ 14.2.0+20241119
+0.83 *** Compile Arduino IDF libs for esp32c2 ***
+0.85 *** Add "custom_sdkconfig" settings to IDF sdkconfig.defaults ***
+0.85 Replace: CONFIG_IDF_TARGET="esp32c2" with: CONFIG_IDF_TARGET=esp32c2
+0.85 Replace: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y with: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y
+0.85 Replace: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y with: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y
+0.85 Replace: CONFIG_ESPTOOLPY_FLASHFREQ="60m" with: CONFIG_ESPTOOLPY_FLASHFREQ="60m"
+0.85 Add: # CONFIG_ESPTOOLPY_FLASHFREQ_80M is not set
+0.86 Warning! Arduino framework as an ESP-IDF component doesn't handle the `variant` field! The default `esp32` variant will be used.
+0.86 Reading CMake configuration...
+4.91 LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
+4.91 LDF Modes: Finder ~ chain, Compatibility ~ soft
+4.97 Found 42 compatible libraries
+4.97 Scanning dependencies...
+4.97 No dependencies
+4.97 Building in release mode
+4.98 Environment state dumped to: env_dump.json
+4.98 Projenv state dumped to: projenv_dump.json
+4.98 Cache configuration from environment:
+4.98   Cache type: xcache
+4.98   Cache executable: python /workspace/ci/util/xcache.py
+4.98   SCCACHE path: /workspace/.venv/bin/sccache
+4.98   SCCACHE dir: /home/ubuntu/.fastled/sccache
+4.98   Debug enabled: False
+4.98 xcache wrapper detected and configured for Python fake compilers
+4.98   xcache path: /workspace/ci/util/xcache.py
+4.98   cache executable: python /workspace/ci/util/xcache.py
+4.98 DEBUG: Found compilers in env:
+4.98   CC: 'riscv32-esp-elf-gcc' (type: str)
+4.98   CXX: 'riscv32-esp-elf-g++' (type: str)
+4.98 Extracted compiler names:
+4.98   CC name: riscv32-esp-elf-gcc
+4.98   CXX name: riscv32-esp-elf-g++
+4.98 Found local compiler cache:
+4.98   Cache file: /workspace/.build/pio/esp32c2/compiler_cache.json
+4.98   Real CC: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-gcc
+4.98   Real CXX: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-g++
+4.98 SUCCESS: Using cached compilers (instant, no platform search needed):
+4.98   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+4.98   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+4.98   Platform search skipped - using cached toolset
+4.98 Created Python cached compilers:
+4.98   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+4.98   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+4.98 Applied Python fake compilers to both env and projenv
+4.98 Python fake compiler cache enabled: xcache
+4.98   Original CC: riscv32-esp-elf-gcc
+4.98   Original CXX: riscv32-esp-elf-g++
+4.98   Fake CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+4.98   Fake CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+4.98 Python fake compiler cache environment configured successfully
+5.02 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.02 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.02 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.02   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.02   RET_CODE: no such file or directory
+5.02   ERROR_MESSAGE:
+5.02 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.02   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.02   RET_CODE: no such file or directory
+5.02   ERROR_MESSAGE:
+5.04 Retrieved `.pio/build/esp32c2/app_trace/app_trace.c.o' from cache
+5.04 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in] Error 1
+5.04 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in] Error 1
+5.17 ========================== [FAILED] Took 5.05 seconds ==========================

--- a/failures/RGBSetDemo.log
+++ b/failures/RGBSetDemo.log
@@ -1,0 +1,90 @@
+Initial build failed: 0.13 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.13 --------------------------------------------------------------------------------
+0.43 Verbose mode can be enabled via `-v, --verbose` option
+0.51 Error output: /home/ubuntu/.fastled/compile/pio/esp32c2/penv/bin/python: No module named pip
+0.51 Error: Failed to install Python dependencies into penv
+0.55 ========================== [FAILED] Took 0.42 seconds ==========================
+Initial build failed: 0.13 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.13 --------------------------------------------------------------------------------
+0.52 Verbose mode can be enabled via `-v, --verbose` option
+0.90 CONFIGURATION: https://docs.platformio.org/page/boards/espressif32/esp32-c2-devkitm-1.html
+0.90 PLATFORM: Espressif 32 (55.3.30+develop.sha.9651ee8) > Espressif ESP32-C2-DevKitM-1
+0.90 HARDWARE: ESP32C2 120MHz, 272KB RAM, 4MB Flash
+0.90 DEBUG: Current (cmsis-dap) External (cmsis-dap, esp-bridge, esp-prog, iot-bus-jtag, jlink, minimodule, olimex-arm-usb-ocd, olimex-arm-usb-ocd-h, olimex-arm-usb-tiny-h, olimex-jtag-tiny, tumpa)
+0.90 PACKAGES:
+0.90  - contrib-piohome @ 3.4.4
+0.90  - framework-arduino-c2-skeleton-lib @ 5.5.0+sha.cbe9388f45
+0.90  - framework-arduinoespressif32 @ 3.3.0
+0.90  - framework-arduinoespressif32-libs @ 5.5.0+sha.b66b5448e0
+0.90  - framework-espidf @ 3.50500.0 (5.5.0)
+0.90  - tool-cmake @ 3.30.2
+0.90  - tool-esp-rom-elfs @ 2024.10.11
+0.90  - tool-esptoolpy @ 5.0.2
+0.90  - tool-mklittlefs @ 3.2.0
+0.90  - tool-ninja @ 1.13.1
+0.90  - tool-scons @ 4.40801.0 (4.8.1)
+0.90  - toolchain-riscv32-esp @ 14.2.0+20241119
+0.91 *** Compile Arduino IDF libs for esp32c2 ***
+0.93 *** Add "custom_sdkconfig" settings to IDF sdkconfig.defaults ***
+0.93 Replace: CONFIG_IDF_TARGET="esp32c2" with: CONFIG_IDF_TARGET=esp32c2
+0.93 Replace: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y with: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y
+0.93 Replace: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y with: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y
+0.93 Replace: CONFIG_ESPTOOLPY_FLASHFREQ="60m" with: CONFIG_ESPTOOLPY_FLASHFREQ="60m"
+0.93 Add: # CONFIG_ESPTOOLPY_FLASHFREQ_80M is not set
+0.94 Warning! Arduino framework as an ESP-IDF component doesn't handle the `variant` field! The default `esp32` variant will be used.
+0.94 Reading CMake configuration...
+5.17 LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
+5.17 LDF Modes: Finder ~ chain, Compatibility ~ soft
+5.23 Found 42 compatible libraries
+5.23 Scanning dependencies...
+5.23 No dependencies
+5.23 Building in release mode
+5.24 Environment state dumped to: env_dump.json
+5.24 Projenv state dumped to: projenv_dump.json
+5.24 Cache configuration from environment:
+5.24   Cache type: xcache
+5.24   Cache executable: python /workspace/ci/util/xcache.py
+5.24   SCCACHE path: /workspace/.venv/bin/sccache
+5.24   SCCACHE dir: /home/ubuntu/.fastled/sccache
+5.24   Debug enabled: False
+5.24 xcache wrapper detected and configured for Python fake compilers
+5.24   xcache path: /workspace/ci/util/xcache.py
+5.24   cache executable: python /workspace/ci/util/xcache.py
+5.24 DEBUG: Found compilers in env:
+5.24   CC: 'riscv32-esp-elf-gcc' (type: str)
+5.24   CXX: 'riscv32-esp-elf-g++' (type: str)
+5.24 Extracted compiler names:
+5.24   CC name: riscv32-esp-elf-gcc
+5.24   CXX name: riscv32-esp-elf-g++
+5.24 Found local compiler cache:
+5.24   Cache file: /workspace/.build/pio/esp32c2/compiler_cache.json
+5.24   Real CC: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-gcc
+5.24   Real CXX: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-g++
+5.24 SUCCESS: Using cached compilers (instant, no platform search needed):
+5.24   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.24   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.24   Platform search skipped - using cached toolset
+5.24 Created Python cached compilers:
+5.24   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.24   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.24 Applied Python fake compilers to both env and projenv
+5.24 Python fake compiler cache enabled: xcache
+5.24   Original CC: riscv32-esp-elf-gcc
+5.24   Original CXX: riscv32-esp-elf-g++
+5.24   Fake CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.24   Fake CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.24 Python fake compiler cache environment configured successfully
+5.28 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.28 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.28 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.28   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.28   RET_CODE: no such file or directory
+5.28   ERROR_MESSAGE:
+5.28 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.28   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.28   RET_CODE: no such file or directory
+5.28   ERROR_MESSAGE:
+5.30 Retrieved `.pio/build/esp32c2/app_trace/app_trace_util.c.o' from cache
+5.30 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in] Error 1
+5.30 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in] Error 1
+5.45 ========================== [FAILED] Took 5.33 seconds ==========================

--- a/failures/RGBW.log
+++ b/failures/RGBW.log
@@ -1,0 +1,90 @@
+Initial build failed: 0.12 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.12 --------------------------------------------------------------------------------
+0.42 Verbose mode can be enabled via `-v, --verbose` option
+0.49 Error output: /home/ubuntu/.fastled/compile/pio/esp32c2/penv/bin/python: No module named pip
+0.49 Error: Failed to install Python dependencies into penv
+0.53 ========================== [FAILED] Took 0.40 seconds ==========================
+Initial build failed: 0.13 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.13 --------------------------------------------------------------------------------
+0.45 Verbose mode can be enabled via `-v, --verbose` option
+0.88 CONFIGURATION: https://docs.platformio.org/page/boards/espressif32/esp32-c2-devkitm-1.html
+0.88 PLATFORM: Espressif 32 (55.3.30+develop.sha.9651ee8) > Espressif ESP32-C2-DevKitM-1
+0.88 HARDWARE: ESP32C2 120MHz, 272KB RAM, 4MB Flash
+0.88 DEBUG: Current (cmsis-dap) External (cmsis-dap, esp-bridge, esp-prog, iot-bus-jtag, jlink, minimodule, olimex-arm-usb-ocd, olimex-arm-usb-ocd-h, olimex-arm-usb-tiny-h, olimex-jtag-tiny, tumpa)
+0.88 PACKAGES:
+0.88  - contrib-piohome @ 3.4.4
+0.88  - framework-arduino-c2-skeleton-lib @ 5.5.0+sha.cbe9388f45
+0.88  - framework-arduinoespressif32 @ 3.3.0
+0.88  - framework-arduinoespressif32-libs @ 5.5.0+sha.b66b5448e0
+0.88  - framework-espidf @ 3.50500.0 (5.5.0)
+0.88  - tool-cmake @ 3.30.2
+0.88  - tool-esp-rom-elfs @ 2024.10.11
+0.88  - tool-esptoolpy @ 5.0.2
+0.88  - tool-mklittlefs @ 3.2.0
+0.88  - tool-ninja @ 1.13.1
+0.88  - tool-scons @ 4.40801.0 (4.8.1)
+0.88  - toolchain-riscv32-esp @ 14.2.0+20241119
+0.88 *** Compile Arduino IDF libs for esp32c2 ***
+0.90 *** Add "custom_sdkconfig" settings to IDF sdkconfig.defaults ***
+0.91 Replace: CONFIG_IDF_TARGET="esp32c2" with: CONFIG_IDF_TARGET=esp32c2
+0.91 Replace: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y with: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y
+0.91 Replace: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y with: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y
+0.91 Replace: CONFIG_ESPTOOLPY_FLASHFREQ="60m" with: CONFIG_ESPTOOLPY_FLASHFREQ="60m"
+0.91 Add: # CONFIG_ESPTOOLPY_FLASHFREQ_80M is not set
+0.92 Warning! Arduino framework as an ESP-IDF component doesn't handle the `variant` field! The default `esp32` variant will be used.
+0.92 Reading CMake configuration...
+5.10 LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
+5.10 LDF Modes: Finder ~ chain, Compatibility ~ soft
+5.15 Found 42 compatible libraries
+5.15 Scanning dependencies...
+5.16 No dependencies
+5.16 Building in release mode
+5.17 Environment state dumped to: env_dump.json
+5.17 Projenv state dumped to: projenv_dump.json
+5.17 Cache configuration from environment:
+5.17   Cache type: xcache
+5.17   Cache executable: python /workspace/ci/util/xcache.py
+5.17   SCCACHE path: /workspace/.venv/bin/sccache
+5.17   SCCACHE dir: /home/ubuntu/.fastled/sccache
+5.17   Debug enabled: False
+5.17 xcache wrapper detected and configured for Python fake compilers
+5.17   xcache path: /workspace/ci/util/xcache.py
+5.17   cache executable: python /workspace/ci/util/xcache.py
+5.17 DEBUG: Found compilers in env:
+5.17   CC: 'riscv32-esp-elf-gcc' (type: str)
+5.17   CXX: 'riscv32-esp-elf-g++' (type: str)
+5.17 Extracted compiler names:
+5.17   CC name: riscv32-esp-elf-gcc
+5.17   CXX name: riscv32-esp-elf-g++
+5.17 Found local compiler cache:
+5.17   Cache file: /workspace/.build/pio/esp32c2/compiler_cache.json
+5.17   Real CC: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-gcc
+5.17   Real CXX: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-g++
+5.17 SUCCESS: Using cached compilers (instant, no platform search needed):
+5.17   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.17   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.17   Platform search skipped - using cached toolset
+5.17 Created Python cached compilers:
+5.17   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.17   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.17 Applied Python fake compilers to both env and projenv
+5.17 Python fake compiler cache enabled: xcache
+5.17   Original CC: riscv32-esp-elf-gcc
+5.17   Original CXX: riscv32-esp-elf-g++
+5.17   Fake CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.17   Fake CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.17 Python fake compiler cache environment configured successfully
+5.20 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.20 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.21 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.21   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.21   RET_CODE: no such file or directory
+5.21   ERROR_MESSAGE:
+5.21 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.21   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.21   RET_CODE: no such file or directory
+5.21   ERROR_MESSAGE:
+5.23 Retrieved `.pio/build/esp32c2/app_trace/host_file_io.c.o' from cache
+5.23 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in] Error 1
+5.23 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in] Error 1
+5.38 ========================== [FAILED] Took 5.25 seconds ==========================

--- a/failures/RGBWEmulated.log
+++ b/failures/RGBWEmulated.log
@@ -1,0 +1,90 @@
+Initial build failed: 0.12 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.12 --------------------------------------------------------------------------------
+0.43 Verbose mode can be enabled via `-v, --verbose` option
+0.51 Error output: /home/ubuntu/.fastled/compile/pio/esp32c2/penv/bin/python: No module named pip
+0.51 Error: Failed to install Python dependencies into penv
+0.54 ========================== [FAILED] Took 0.42 seconds ==========================
+Initial build failed: 0.13 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.13 --------------------------------------------------------------------------------
+0.45 Verbose mode can be enabled via `-v, --verbose` option
+0.84 CONFIGURATION: https://docs.platformio.org/page/boards/espressif32/esp32-c2-devkitm-1.html
+0.84 PLATFORM: Espressif 32 (55.3.30+develop.sha.9651ee8) > Espressif ESP32-C2-DevKitM-1
+0.84 HARDWARE: ESP32C2 120MHz, 272KB RAM, 4MB Flash
+0.84 DEBUG: Current (cmsis-dap) External (cmsis-dap, esp-bridge, esp-prog, iot-bus-jtag, jlink, minimodule, olimex-arm-usb-ocd, olimex-arm-usb-ocd-h, olimex-arm-usb-tiny-h, olimex-jtag-tiny, tumpa)
+0.84 PACKAGES:
+0.84  - contrib-piohome @ 3.4.4
+0.84  - framework-arduino-c2-skeleton-lib @ 5.5.0+sha.cbe9388f45
+0.84  - framework-arduinoespressif32 @ 3.3.0
+0.84  - framework-arduinoespressif32-libs @ 5.5.0+sha.b66b5448e0
+0.84  - framework-espidf @ 3.50500.0 (5.5.0)
+0.84  - tool-cmake @ 3.30.2
+0.84  - tool-esp-rom-elfs @ 2024.10.11
+0.84  - tool-esptoolpy @ 5.0.2
+0.84  - tool-mklittlefs @ 3.2.0
+0.84  - tool-ninja @ 1.13.1
+0.84  - tool-scons @ 4.40801.0 (4.8.1)
+0.84  - toolchain-riscv32-esp @ 14.2.0+20241119
+0.85 *** Compile Arduino IDF libs for esp32c2 ***
+0.87 *** Add "custom_sdkconfig" settings to IDF sdkconfig.defaults ***
+0.87 Replace: CONFIG_IDF_TARGET="esp32c2" with: CONFIG_IDF_TARGET=esp32c2
+0.87 Replace: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y with: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y
+0.87 Replace: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y with: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y
+0.87 Replace: CONFIG_ESPTOOLPY_FLASHFREQ="60m" with: CONFIG_ESPTOOLPY_FLASHFREQ="60m"
+0.87 Add: # CONFIG_ESPTOOLPY_FLASHFREQ_80M is not set
+0.88 Warning! Arduino framework as an ESP-IDF component doesn't handle the `variant` field! The default `esp32` variant will be used.
+0.88 Reading CMake configuration...
+4.96 LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
+4.96 LDF Modes: Finder ~ chain, Compatibility ~ soft
+5.01 Found 42 compatible libraries
+5.01 Scanning dependencies...
+5.02 No dependencies
+5.02 Building in release mode
+5.02 Environment state dumped to: env_dump.json
+5.03 Projenv state dumped to: projenv_dump.json
+5.03 Cache configuration from environment:
+5.03   Cache type: xcache
+5.03   Cache executable: python /workspace/ci/util/xcache.py
+5.03   SCCACHE path: /workspace/.venv/bin/sccache
+5.03   SCCACHE dir: /home/ubuntu/.fastled/sccache
+5.03   Debug enabled: False
+5.03 xcache wrapper detected and configured for Python fake compilers
+5.03   xcache path: /workspace/ci/util/xcache.py
+5.03   cache executable: python /workspace/ci/util/xcache.py
+5.03 DEBUG: Found compilers in env:
+5.03   CC: 'riscv32-esp-elf-gcc' (type: str)
+5.03   CXX: 'riscv32-esp-elf-g++' (type: str)
+5.03 Extracted compiler names:
+5.03   CC name: riscv32-esp-elf-gcc
+5.03   CXX name: riscv32-esp-elf-g++
+5.03 Found local compiler cache:
+5.03   Cache file: /workspace/.build/pio/esp32c2/compiler_cache.json
+5.03   Real CC: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-gcc
+5.03   Real CXX: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-g++
+5.03 SUCCESS: Using cached compilers (instant, no platform search needed):
+5.03   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.03   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.03   Platform search skipped - using cached toolset
+5.03 Created Python cached compilers:
+5.03   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.03   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.03 Applied Python fake compilers to both env and projenv
+5.03 Python fake compiler cache enabled: xcache
+5.03   Original CC: riscv32-esp-elf-gcc
+5.03   Original CXX: riscv32-esp-elf-g++
+5.03   Fake CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.03   Fake CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.03 Python fake compiler cache environment configured successfully
+5.06 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.06 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.06 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.06   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.06   RET_CODE: no such file or directory
+5.06   ERROR_MESSAGE:
+5.06 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.06   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.06   RET_CODE: no such file or directory
+5.06   ERROR_MESSAGE:
+5.09 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in] Error 1
+5.09 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in] Error 1
+5.09 Retrieved `.pio/build/esp32c2/app_trace/port/port_uart.c.o' from cache
+5.22 ========================== [FAILED] Took 5.09 seconds ==========================

--- a/failures/SmartMatrix.log
+++ b/failures/SmartMatrix.log
@@ -1,0 +1,94 @@
+Initial build failed: 0.12 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.12 --------------------------------------------------------------------------------
+0.43 Verbose mode can be enabled via `-v, --verbose` option
+0.51 Error output: /home/ubuntu/.fastled/compile/pio/esp32c2/penv/bin/python: No module named pip
+0.51 Error: Failed to install Python dependencies into penv
+0.54 ========================== [FAILED] Took 0.42 seconds ==========================
+Initial build failed: 0.16 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.16 --------------------------------------------------------------------------------
+0.47 Verbose mode can be enabled via `-v, --verbose` option
+0.93 CONFIGURATION: https://docs.platformio.org/page/boards/espressif32/esp32-c2-devkitm-1.html
+0.93 PLATFORM: Espressif 32 (55.3.30+develop.sha.9651ee8) > Espressif ESP32-C2-DevKitM-1
+0.93 HARDWARE: ESP32C2 120MHz, 272KB RAM, 4MB Flash
+0.93 DEBUG: Current (cmsis-dap) External (cmsis-dap, esp-bridge, esp-prog, iot-bus-jtag, jlink, minimodule, olimex-arm-usb-ocd, olimex-arm-usb-ocd-h, olimex-arm-usb-tiny-h, olimex-jtag-tiny, tumpa)
+0.93 PACKAGES:
+0.93  - contrib-piohome @ 3.4.4
+0.93  - framework-arduino-c2-skeleton-lib @ 5.5.0+sha.cbe9388f45
+0.93  - framework-arduinoespressif32 @ 3.3.0
+0.93  - framework-arduinoespressif32-libs @ 5.5.0+sha.b66b5448e0
+0.93  - framework-espidf @ 3.50500.0 (5.5.0)
+0.93  - tool-cmake @ 3.30.2
+0.93  - tool-esp-rom-elfs @ 2024.10.11
+0.93  - tool-esptoolpy @ 5.0.2
+0.93  - tool-mklittlefs @ 3.2.0
+0.93  - tool-ninja @ 1.13.1
+0.93  - tool-scons @ 4.40801.0 (4.8.1)
+0.93  - toolchain-riscv32-esp @ 14.2.0+20241119
+0.94 *** Compile Arduino IDF libs for esp32c2 ***
+0.95 *** Add "custom_sdkconfig" settings to IDF sdkconfig.defaults ***
+0.95 Replace: CONFIG_IDF_TARGET="esp32c2" with: CONFIG_IDF_TARGET=esp32c2
+0.95 Replace: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y with: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y
+0.95 Replace: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y with: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y
+0.95 Replace: CONFIG_ESPTOOLPY_FLASHFREQ="60m" with: CONFIG_ESPTOOLPY_FLASHFREQ="60m"
+0.96 Add: # CONFIG_ESPTOOLPY_FLASHFREQ_80M is not set
+0.97 Warning! Arduino framework as an ESP-IDF component doesn't handle the `variant` field! The default `esp32` variant will be used.
+0.97 Reading CMake configuration...
+5.40 Generating assembly for certificate bundle...
+5.55 LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
+5.55 LDF Modes: Finder ~ chain, Compatibility ~ soft
+5.61 Found 42 compatible libraries
+5.61 Scanning dependencies...
+5.61 No dependencies
+5.61 Building in release mode
+5.62 Environment state dumped to: env_dump.json
+5.62 Projenv state dumped to: projenv_dump.json
+5.62 Cache configuration from environment:
+5.62   Cache type: xcache
+5.62   Cache executable: python /workspace/ci/util/xcache.py
+5.62   SCCACHE path: /workspace/.venv/bin/sccache
+5.62   SCCACHE dir: /home/ubuntu/.fastled/sccache
+5.62   Debug enabled: False
+5.62 xcache wrapper detected and configured for Python fake compilers
+5.62   xcache path: /workspace/ci/util/xcache.py
+5.62   cache executable: python /workspace/ci/util/xcache.py
+5.62 DEBUG: Found compilers in env:
+5.62   CC: 'riscv32-esp-elf-gcc' (type: str)
+5.62   CXX: 'riscv32-esp-elf-g++' (type: str)
+5.62 Extracted compiler names:
+5.62   CC name: riscv32-esp-elf-gcc
+5.62   CXX name: riscv32-esp-elf-g++
+5.62 Found local compiler cache:
+5.62   Cache file: /workspace/.build/pio/esp32c2/compiler_cache.json
+5.62   Real CC: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-gcc
+5.62   Real CXX: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-g++
+5.62 SUCCESS: Using cached compilers (instant, no platform search needed):
+5.62   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.62   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.62   Platform search skipped - using cached toolset
+5.62 Created Python cached compilers:
+5.62   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.62   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.62 Applied Python fake compilers to both env and projenv
+5.62 Python fake compiler cache enabled: xcache
+5.62   Original CC: riscv32-esp-elf-gcc
+5.62   Original CXX: riscv32-esp-elf-g++
+5.62   Fake CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.62   Fake CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.62 Python fake compiler cache environment configured successfully
+5.72 Retrieved `.pio/build/esp32c2/.dummy/sketch.cpp.o' from cache
+5.73 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-gcc.c.o' from cache
+5.73 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-cpp.cpp.o' from cache
+5.74 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-as.S.o' from cache
+5.74 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.74 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.74   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.74   RET_CODE: no such file or directory
+5.74   ERROR_MESSAGE:
+5.74 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.74 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in] Error 1
+5.75 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.75   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.75   RET_CODE: no such file or directory
+5.75   ERROR_MESSAGE:
+5.75 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in] Error 1
+5.87 ========================== [FAILED] Took 5.72 seconds ==========================

--- a/failures/TeensyMassiveParallel.log
+++ b/failures/TeensyMassiveParallel.log
@@ -1,0 +1,95 @@
+Initial build failed: 0.12 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.12 --------------------------------------------------------------------------------
+0.42 Verbose mode can be enabled via `-v, --verbose` option
+0.50 Error: Failed to install Python dependencies into penv
+0.50 Error output: /home/ubuntu/.fastled/compile/pio/esp32c2/penv/bin/python: No module named pip
+0.54 ========================== [FAILED] Took 0.41 seconds ==========================
+Initial build failed: 0.16 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.16 --------------------------------------------------------------------------------
+0.46 Verbose mode can be enabled via `-v, --verbose` option
+0.90 CONFIGURATION: https://docs.platformio.org/page/boards/espressif32/esp32-c2-devkitm-1.html
+0.90 PLATFORM: Espressif 32 (55.3.30+develop.sha.9651ee8) > Espressif ESP32-C2-DevKitM-1
+0.90 HARDWARE: ESP32C2 120MHz, 272KB RAM, 4MB Flash
+0.90 DEBUG: Current (cmsis-dap) External (cmsis-dap, esp-bridge, esp-prog, iot-bus-jtag, jlink, minimodule, olimex-arm-usb-ocd, olimex-arm-usb-ocd-h, olimex-arm-usb-tiny-h, olimex-jtag-tiny, tumpa)
+0.90 PACKAGES:
+0.90  - contrib-piohome @ 3.4.4
+0.90  - framework-arduino-c2-skeleton-lib @ 5.5.0+sha.cbe9388f45
+0.90  - framework-arduinoespressif32 @ 3.3.0
+0.90  - framework-arduinoespressif32-libs @ 5.5.0+sha.b66b5448e0
+0.90  - framework-espidf @ 3.50500.0 (5.5.0)
+0.90  - tool-cmake @ 3.30.2
+0.90  - tool-esp-rom-elfs @ 2024.10.11
+0.90  - tool-esptoolpy @ 5.0.2
+0.90  - tool-mklittlefs @ 3.2.0
+0.90  - tool-ninja @ 1.13.1
+0.90  - tool-scons @ 4.40801.0 (4.8.1)
+0.90  - toolchain-riscv32-esp @ 14.2.0+20241119
+0.90 *** Compile Arduino IDF libs for esp32c2 ***
+0.92 *** Add "custom_sdkconfig" settings to IDF sdkconfig.defaults ***
+0.92 Replace: CONFIG_IDF_TARGET="esp32c2" with: CONFIG_IDF_TARGET=esp32c2
+0.92 Replace: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y with: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y
+0.92 Replace: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y with: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y
+0.92 Replace: CONFIG_ESPTOOLPY_FLASHFREQ="60m" with: CONFIG_ESPTOOLPY_FLASHFREQ="60m"
+0.92 Add: # CONFIG_ESPTOOLPY_FLASHFREQ_80M is not set
+0.93 Warning! Arduino framework as an ESP-IDF component doesn't handle the `variant` field! The default `esp32` variant will be used.
+0.93 Reading CMake configuration...
+5.29 Generating assembly for certificate bundle...
+5.45 LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
+5.45 LDF Modes: Finder ~ chain, Compatibility ~ soft
+5.51 Found 42 compatible libraries
+5.51 Scanning dependencies...
+5.51 No dependencies
+5.51 Building in release mode
+5.52 Environment state dumped to: env_dump.json
+5.52 Projenv state dumped to: projenv_dump.json
+5.52 Cache configuration from environment:
+5.52   Cache type: xcache
+5.52   Cache executable: python /workspace/ci/util/xcache.py
+5.52   SCCACHE path: /workspace/.venv/bin/sccache
+5.52   SCCACHE dir: /home/ubuntu/.fastled/sccache
+5.52   Debug enabled: False
+5.52 xcache wrapper detected and configured for Python fake compilers
+5.52   xcache path: /workspace/ci/util/xcache.py
+5.52   cache executable: python /workspace/ci/util/xcache.py
+5.52 DEBUG: Found compilers in env:
+5.52   CC: 'riscv32-esp-elf-gcc' (type: str)
+5.52   CXX: 'riscv32-esp-elf-g++' (type: str)
+5.52 Extracted compiler names:
+5.52   CC name: riscv32-esp-elf-gcc
+5.52   CXX name: riscv32-esp-elf-g++
+5.52 Found local compiler cache:
+5.52   Cache file: /workspace/.build/pio/esp32c2/compiler_cache.json
+5.52   Real CC: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-gcc
+5.52   Real CXX: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-g++
+5.52 SUCCESS: Using cached compilers (instant, no platform search needed):
+5.52   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.52   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.52   Platform search skipped - using cached toolset
+5.52 Created Python cached compilers:
+5.52   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.52   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.52 Applied Python fake compilers to both env and projenv
+5.52 Python fake compiler cache enabled: xcache
+5.52   Original CC: riscv32-esp-elf-gcc
+5.52   Original CXX: riscv32-esp-elf-g++
+5.52   Fake CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.52   Fake CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.52 Python fake compiler cache environment configured successfully
+5.62 Retrieved `.pio/build/esp32c2/.dummy/sketch.cpp.o' from cache
+5.62 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-gcc.c.o' from cache
+5.63 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-cpp.cpp.o' from cache
+5.64 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-as.S.o' from cache
+5.64 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.64 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.64 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.64   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.64   RET_CODE: no such file or directory
+5.64   ERROR_MESSAGE:
+5.64 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.64   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.64   RET_CODE: no such file or directory
+5.64   ERROR_MESSAGE:
+5.65 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in] Error 1
+5.65 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in] Error 1
+5.65 Retrieved `.pio/build/esp32c2/app_trace/app_trace.c.o' from cache
+5.79 ========================== [FAILED] Took 5.64 seconds ==========================

--- a/failures/TeensyParallel.log
+++ b/failures/TeensyParallel.log
@@ -1,0 +1,95 @@
+Initial build failed: 0.12 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.12 --------------------------------------------------------------------------------
+0.44 Verbose mode can be enabled via `-v, --verbose` option
+0.52 Error output: /home/ubuntu/.fastled/compile/pio/esp32c2/penv/bin/python: No module named pip
+0.52 Error: Failed to install Python dependencies into penv
+0.55 ========================== [FAILED] Took 0.43 seconds ==========================
+Initial build failed: 0.16 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.16 --------------------------------------------------------------------------------
+0.48 Verbose mode can be enabled via `-v, --verbose` option
+0.92 CONFIGURATION: https://docs.platformio.org/page/boards/espressif32/esp32-c2-devkitm-1.html
+0.92 PLATFORM: Espressif 32 (55.3.30+develop.sha.9651ee8) > Espressif ESP32-C2-DevKitM-1
+0.92 HARDWARE: ESP32C2 120MHz, 272KB RAM, 4MB Flash
+0.92 DEBUG: Current (cmsis-dap) External (cmsis-dap, esp-bridge, esp-prog, iot-bus-jtag, jlink, minimodule, olimex-arm-usb-ocd, olimex-arm-usb-ocd-h, olimex-arm-usb-tiny-h, olimex-jtag-tiny, tumpa)
+0.92 PACKAGES:
+0.92  - contrib-piohome @ 3.4.4
+0.92  - framework-arduino-c2-skeleton-lib @ 5.5.0+sha.cbe9388f45
+0.92  - framework-arduinoespressif32 @ 3.3.0
+0.92  - framework-arduinoespressif32-libs @ 5.5.0+sha.b66b5448e0
+0.92  - framework-espidf @ 3.50500.0 (5.5.0)
+0.92  - tool-cmake @ 3.30.2
+0.92  - tool-esp-rom-elfs @ 2024.10.11
+0.92  - tool-esptoolpy @ 5.0.2
+0.92  - tool-mklittlefs @ 3.2.0
+0.92  - tool-ninja @ 1.13.1
+0.92  - tool-scons @ 4.40801.0 (4.8.1)
+0.92  - toolchain-riscv32-esp @ 14.2.0+20241119
+0.93 *** Compile Arduino IDF libs for esp32c2 ***
+0.95 *** Add "custom_sdkconfig" settings to IDF sdkconfig.defaults ***
+0.95 Replace: CONFIG_IDF_TARGET="esp32c2" with: CONFIG_IDF_TARGET=esp32c2
+0.95 Replace: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y with: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y
+0.95 Replace: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y with: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y
+0.95 Replace: CONFIG_ESPTOOLPY_FLASHFREQ="60m" with: CONFIG_ESPTOOLPY_FLASHFREQ="60m"
+0.95 Add: # CONFIG_ESPTOOLPY_FLASHFREQ_80M is not set
+0.96 Warning! Arduino framework as an ESP-IDF component doesn't handle the `variant` field! The default `esp32` variant will be used.
+0.96 Reading CMake configuration...
+5.40 Generating assembly for certificate bundle...
+5.56 LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
+5.56 LDF Modes: Finder ~ chain, Compatibility ~ soft
+5.62 Found 42 compatible libraries
+5.62 Scanning dependencies...
+5.62 No dependencies
+5.62 Building in release mode
+5.63 Environment state dumped to: env_dump.json
+5.63 Projenv state dumped to: projenv_dump.json
+5.63 Cache configuration from environment:
+5.63   Cache type: xcache
+5.63   Cache executable: python /workspace/ci/util/xcache.py
+5.63   SCCACHE path: /workspace/.venv/bin/sccache
+5.63   SCCACHE dir: /home/ubuntu/.fastled/sccache
+5.63   Debug enabled: False
+5.63 xcache wrapper detected and configured for Python fake compilers
+5.63   xcache path: /workspace/ci/util/xcache.py
+5.63   cache executable: python /workspace/ci/util/xcache.py
+5.63 DEBUG: Found compilers in env:
+5.63   CC: 'riscv32-esp-elf-gcc' (type: str)
+5.63   CXX: 'riscv32-esp-elf-g++' (type: str)
+5.63 Extracted compiler names:
+5.63   CC name: riscv32-esp-elf-gcc
+5.63   CXX name: riscv32-esp-elf-g++
+5.63 Found local compiler cache:
+5.63   Cache file: /workspace/.build/pio/esp32c2/compiler_cache.json
+5.63   Real CC: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-gcc
+5.63   Real CXX: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-g++
+5.63 SUCCESS: Using cached compilers (instant, no platform search needed):
+5.63   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.63   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.63   Platform search skipped - using cached toolset
+5.63 Created Python cached compilers:
+5.63   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.63   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.63 Applied Python fake compilers to both env and projenv
+5.63 Python fake compiler cache enabled: xcache
+5.63   Original CC: riscv32-esp-elf-gcc
+5.63   Original CXX: riscv32-esp-elf-g++
+5.63   Fake CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.63   Fake CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.63 Python fake compiler cache environment configured successfully
+5.73 Retrieved `.pio/build/esp32c2/.dummy/sketch.cpp.o' from cache
+5.74 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-gcc.c.o' from cache
+5.74 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-cpp.cpp.o' from cache
+5.74 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-as.S.o' from cache
+5.75 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.75 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.75   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.75   RET_CODE: no such file or directory
+5.75   ERROR_MESSAGE:
+5.75 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.75 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.75   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.75   RET_CODE: no such file or directory
+5.75   ERROR_MESSAGE:
+5.77 Retrieved `.pio/build/esp32c2/app_trace/app_trace.c.o' from cache
+5.77 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in] Error 1
+5.77 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in] Error 1
+5.90 ========================== [FAILED] Took 5.74 seconds ==========================

--- a/failures/TwinkleFox.log
+++ b/failures/TwinkleFox.log
@@ -1,0 +1,90 @@
+Initial build failed: 0.12 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.12 --------------------------------------------------------------------------------
+0.42 Verbose mode can be enabled via `-v, --verbose` option
+0.50 Error: Failed to install Python dependencies into penv
+0.50 Error output: /home/ubuntu/.fastled/compile/pio/esp32c2/penv/bin/python: No module named pip
+0.53 ========================== [FAILED] Took 0.41 seconds ==========================
+Initial build failed: 0.13 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.13 --------------------------------------------------------------------------------
+0.46 Verbose mode can be enabled via `-v, --verbose` option
+0.84 CONFIGURATION: https://docs.platformio.org/page/boards/espressif32/esp32-c2-devkitm-1.html
+0.84 PLATFORM: Espressif 32 (55.3.30+develop.sha.9651ee8) > Espressif ESP32-C2-DevKitM-1
+0.84 HARDWARE: ESP32C2 120MHz, 272KB RAM, 4MB Flash
+0.84 DEBUG: Current (cmsis-dap) External (cmsis-dap, esp-bridge, esp-prog, iot-bus-jtag, jlink, minimodule, olimex-arm-usb-ocd, olimex-arm-usb-ocd-h, olimex-arm-usb-tiny-h, olimex-jtag-tiny, tumpa)
+0.84 PACKAGES:
+0.84  - contrib-piohome @ 3.4.4
+0.84  - framework-arduino-c2-skeleton-lib @ 5.5.0+sha.cbe9388f45
+0.84  - framework-arduinoespressif32 @ 3.3.0
+0.84  - framework-arduinoespressif32-libs @ 5.5.0+sha.b66b5448e0
+0.84  - framework-espidf @ 3.50500.0 (5.5.0)
+0.84  - tool-cmake @ 3.30.2
+0.84  - tool-esp-rom-elfs @ 2024.10.11
+0.84  - tool-esptoolpy @ 5.0.2
+0.84  - tool-mklittlefs @ 3.2.0
+0.84  - tool-ninja @ 1.13.1
+0.84  - tool-scons @ 4.40801.0 (4.8.1)
+0.84  - toolchain-riscv32-esp @ 14.2.0+20241119
+0.84 *** Compile Arduino IDF libs for esp32c2 ***
+0.86 *** Add "custom_sdkconfig" settings to IDF sdkconfig.defaults ***
+0.86 Replace: CONFIG_IDF_TARGET="esp32c2" with: CONFIG_IDF_TARGET=esp32c2
+0.86 Replace: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y with: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y
+0.86 Replace: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y with: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y
+0.86 Replace: CONFIG_ESPTOOLPY_FLASHFREQ="60m" with: CONFIG_ESPTOOLPY_FLASHFREQ="60m"
+0.86 Add: # CONFIG_ESPTOOLPY_FLASHFREQ_80M is not set
+0.87 Warning! Arduino framework as an ESP-IDF component doesn't handle the `variant` field! The default `esp32` variant will be used.
+0.87 Reading CMake configuration...
+4.94 LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
+4.94 LDF Modes: Finder ~ chain, Compatibility ~ soft
+5.00 Found 42 compatible libraries
+5.00 Scanning dependencies...
+5.01 No dependencies
+5.01 Building in release mode
+5.01 Environment state dumped to: env_dump.json
+5.01 Projenv state dumped to: projenv_dump.json
+5.01 Cache configuration from environment:
+5.01   Cache type: xcache
+5.01   Cache executable: python /workspace/ci/util/xcache.py
+5.01   SCCACHE path: /workspace/.venv/bin/sccache
+5.01   SCCACHE dir: /home/ubuntu/.fastled/sccache
+5.01   Debug enabled: False
+5.01 xcache wrapper detected and configured for Python fake compilers
+5.02   xcache path: /workspace/ci/util/xcache.py
+5.02   cache executable: python /workspace/ci/util/xcache.py
+5.02 DEBUG: Found compilers in env:
+5.02   CC: 'riscv32-esp-elf-gcc' (type: str)
+5.02   CXX: 'riscv32-esp-elf-g++' (type: str)
+5.02 Extracted compiler names:
+5.02   CC name: riscv32-esp-elf-gcc
+5.02   CXX name: riscv32-esp-elf-g++
+5.02 Found local compiler cache:
+5.02   Cache file: /workspace/.build/pio/esp32c2/compiler_cache.json
+5.02   Real CC: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-gcc
+5.02   Real CXX: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-g++
+5.02 SUCCESS: Using cached compilers (instant, no platform search needed):
+5.02   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.02   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.02   Platform search skipped - using cached toolset
+5.02 Created Python cached compilers:
+5.02   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.02   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.02 Applied Python fake compilers to both env and projenv
+5.02 Python fake compiler cache enabled: xcache
+5.02   Original CC: riscv32-esp-elf-gcc
+5.02   Original CXX: riscv32-esp-elf-g++
+5.02   Fake CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.02   Fake CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.02 Python fake compiler cache environment configured successfully
+5.05 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.05 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.05 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.05   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.05   RET_CODE: no such file or directory
+5.05   ERROR_MESSAGE:
+5.05 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.05   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.05   RET_CODE: no such file or directory
+5.05   ERROR_MESSAGE:
+5.07 Retrieved `.pio/build/esp32c2/app_trace/app_trace_util.c.o' from cache
+5.07 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in] Error 1
+5.07 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in] Error 1
+5.21 ========================== [FAILED] Took 5.08 seconds ==========================

--- a/failures/UITest.log
+++ b/failures/UITest.log
@@ -1,0 +1,90 @@
+Initial build failed: 0.12 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.12 --------------------------------------------------------------------------------
+0.44 Verbose mode can be enabled via `-v, --verbose` option
+0.51 Error output: /home/ubuntu/.fastled/compile/pio/esp32c2/penv/bin/python: No module named pip
+0.51 Error: Failed to install Python dependencies into penv
+0.55 ========================== [FAILED] Took 0.43 seconds ==========================
+Initial build failed: 0.13 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.13 --------------------------------------------------------------------------------
+0.44 Verbose mode can be enabled via `-v, --verbose` option
+0.83 CONFIGURATION: https://docs.platformio.org/page/boards/espressif32/esp32-c2-devkitm-1.html
+0.83 PLATFORM: Espressif 32 (55.3.30+develop.sha.9651ee8) > Espressif ESP32-C2-DevKitM-1
+0.83 HARDWARE: ESP32C2 120MHz, 272KB RAM, 4MB Flash
+0.83 DEBUG: Current (cmsis-dap) External (cmsis-dap, esp-bridge, esp-prog, iot-bus-jtag, jlink, minimodule, olimex-arm-usb-ocd, olimex-arm-usb-ocd-h, olimex-arm-usb-tiny-h, olimex-jtag-tiny, tumpa)
+0.83 PACKAGES:
+0.83  - contrib-piohome @ 3.4.4
+0.83  - framework-arduino-c2-skeleton-lib @ 5.5.0+sha.cbe9388f45
+0.83  - framework-arduinoespressif32 @ 3.3.0
+0.83  - framework-arduinoespressif32-libs @ 5.5.0+sha.b66b5448e0
+0.83  - framework-espidf @ 3.50500.0 (5.5.0)
+0.83  - tool-cmake @ 3.30.2
+0.83  - tool-esp-rom-elfs @ 2024.10.11
+0.83  - tool-esptoolpy @ 5.0.2
+0.83  - tool-mklittlefs @ 3.2.0
+0.83  - tool-ninja @ 1.13.1
+0.83  - tool-scons @ 4.40801.0 (4.8.1)
+0.83  - toolchain-riscv32-esp @ 14.2.0+20241119
+0.83 *** Compile Arduino IDF libs for esp32c2 ***
+0.85 *** Add "custom_sdkconfig" settings to IDF sdkconfig.defaults ***
+0.85 Replace: CONFIG_IDF_TARGET="esp32c2" with: CONFIG_IDF_TARGET=esp32c2
+0.85 Replace: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y with: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y
+0.85 Replace: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y with: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y
+0.85 Replace: CONFIG_ESPTOOLPY_FLASHFREQ="60m" with: CONFIG_ESPTOOLPY_FLASHFREQ="60m"
+0.85 Add: # CONFIG_ESPTOOLPY_FLASHFREQ_80M is not set
+0.86 Warning! Arduino framework as an ESP-IDF component doesn't handle the `variant` field! The default `esp32` variant will be used.
+0.86 Reading CMake configuration...
+4.94 LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
+4.94 LDF Modes: Finder ~ chain, Compatibility ~ soft
+5.00 Found 42 compatible libraries
+5.00 Scanning dependencies...
+5.00 No dependencies
+5.00 Building in release mode
+5.01 Environment state dumped to: env_dump.json
+5.01 Projenv state dumped to: projenv_dump.json
+5.01 Cache configuration from environment:
+5.01   Cache type: xcache
+5.01   Cache executable: python /workspace/ci/util/xcache.py
+5.01   SCCACHE path: /workspace/.venv/bin/sccache
+5.01   SCCACHE dir: /home/ubuntu/.fastled/sccache
+5.01   Debug enabled: False
+5.01 xcache wrapper detected and configured for Python fake compilers
+5.01   xcache path: /workspace/ci/util/xcache.py
+5.01   cache executable: python /workspace/ci/util/xcache.py
+5.01 DEBUG: Found compilers in env:
+5.01   CC: 'riscv32-esp-elf-gcc' (type: str)
+5.01   CXX: 'riscv32-esp-elf-g++' (type: str)
+5.01 Extracted compiler names:
+5.01   CC name: riscv32-esp-elf-gcc
+5.01   CXX name: riscv32-esp-elf-g++
+5.01 Found local compiler cache:
+5.01   Cache file: /workspace/.build/pio/esp32c2/compiler_cache.json
+5.01   Real CC: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-gcc
+5.01   Real CXX: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-g++
+5.01 SUCCESS: Using cached compilers (instant, no platform search needed):
+5.01   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.01   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.01   Platform search skipped - using cached toolset
+5.01 Created Python cached compilers:
+5.01   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.01   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.01 Applied Python fake compilers to both env and projenv
+5.01 Python fake compiler cache enabled: xcache
+5.01   Original CC: riscv32-esp-elf-gcc
+5.01   Original CXX: riscv32-esp-elf-g++
+5.01   Fake CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.01   Fake CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.01 Python fake compiler cache environment configured successfully
+5.04 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.04 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.05 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.05   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.05   RET_CODE: no such file or directory
+5.05   ERROR_MESSAGE:
+5.05 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.05   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.05   RET_CODE: no such file or directory
+5.05   ERROR_MESSAGE:
+5.07 Retrieved `.pio/build/esp32c2/app_trace/host_file_io.c.o' from cache
+5.07 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in] Error 1
+5.07 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in] Error 1
+5.21 ========================== [FAILED] Took 5.08 seconds ==========================

--- a/failures/WS2816.log
+++ b/failures/WS2816.log
@@ -1,0 +1,90 @@
+Initial build failed: 0.12 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.12 --------------------------------------------------------------------------------
+0.42 Verbose mode can be enabled via `-v, --verbose` option
+0.50 Error: Failed to install Python dependencies into penv
+0.50 Error output: /home/ubuntu/.fastled/compile/pio/esp32c2/penv/bin/python: No module named pip
+0.54 ========================== [FAILED] Took 0.41 seconds ==========================
+Initial build failed: 0.13 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.13 --------------------------------------------------------------------------------
+0.46 Verbose mode can be enabled via `-v, --verbose` option
+0.94 CONFIGURATION: https://docs.platformio.org/page/boards/espressif32/esp32-c2-devkitm-1.html
+0.94 PLATFORM: Espressif 32 (55.3.30+develop.sha.9651ee8) > Espressif ESP32-C2-DevKitM-1
+0.94 HARDWARE: ESP32C2 120MHz, 272KB RAM, 4MB Flash
+0.94 DEBUG: Current (cmsis-dap) External (cmsis-dap, esp-bridge, esp-prog, iot-bus-jtag, jlink, minimodule, olimex-arm-usb-ocd, olimex-arm-usb-ocd-h, olimex-arm-usb-tiny-h, olimex-jtag-tiny, tumpa)
+0.94 PACKAGES:
+0.94  - contrib-piohome @ 3.4.4
+0.94  - framework-arduino-c2-skeleton-lib @ 5.5.0+sha.cbe9388f45
+0.94  - framework-arduinoespressif32 @ 3.3.0
+0.94  - framework-arduinoespressif32-libs @ 5.5.0+sha.b66b5448e0
+0.94  - framework-espidf @ 3.50500.0 (5.5.0)
+0.94  - tool-cmake @ 3.30.2
+0.94  - tool-esp-rom-elfs @ 2024.10.11
+0.94  - tool-esptoolpy @ 5.0.2
+0.94  - tool-mklittlefs @ 3.2.0
+0.94  - tool-ninja @ 1.13.1
+0.94  - tool-scons @ 4.40801.0 (4.8.1)
+0.94  - toolchain-riscv32-esp @ 14.2.0+20241119
+0.94 *** Compile Arduino IDF libs for esp32c2 ***
+0.96 *** Add "custom_sdkconfig" settings to IDF sdkconfig.defaults ***
+0.96 Replace: CONFIG_IDF_TARGET="esp32c2" with: CONFIG_IDF_TARGET=esp32c2
+0.96 Replace: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y with: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y
+0.96 Replace: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y with: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y
+0.96 Replace: CONFIG_ESPTOOLPY_FLASHFREQ="60m" with: CONFIG_ESPTOOLPY_FLASHFREQ="60m"
+0.96 Add: # CONFIG_ESPTOOLPY_FLASHFREQ_80M is not set
+0.97 Warning! Arduino framework as an ESP-IDF component doesn't handle the `variant` field! The default `esp32` variant will be used.
+0.97 Reading CMake configuration...
+5.06 LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
+5.06 LDF Modes: Finder ~ chain, Compatibility ~ soft
+5.12 Found 42 compatible libraries
+5.12 Scanning dependencies...
+5.12 No dependencies
+5.12 Building in release mode
+5.13 Environment state dumped to: env_dump.json
+5.13 Projenv state dumped to: projenv_dump.json
+5.13 Cache configuration from environment:
+5.13   Cache type: xcache
+5.13   Cache executable: python /workspace/ci/util/xcache.py
+5.13   SCCACHE path: /workspace/.venv/bin/sccache
+5.13   SCCACHE dir: /home/ubuntu/.fastled/sccache
+5.13   Debug enabled: False
+5.13 xcache wrapper detected and configured for Python fake compilers
+5.13   xcache path: /workspace/ci/util/xcache.py
+5.13   cache executable: python /workspace/ci/util/xcache.py
+5.13 DEBUG: Found compilers in env:
+5.13   CC: 'riscv32-esp-elf-gcc' (type: str)
+5.13   CXX: 'riscv32-esp-elf-g++' (type: str)
+5.13 Extracted compiler names:
+5.13   CC name: riscv32-esp-elf-gcc
+5.13   CXX name: riscv32-esp-elf-g++
+5.13 Found local compiler cache:
+5.13   Cache file: /workspace/.build/pio/esp32c2/compiler_cache.json
+5.13   Real CC: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-gcc
+5.13   Real CXX: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-g++
+5.13 SUCCESS: Using cached compilers (instant, no platform search needed):
+5.13   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.13   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.13   Platform search skipped - using cached toolset
+5.13 Created Python cached compilers:
+5.13   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.13   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.13 Applied Python fake compilers to both env and projenv
+5.13 Python fake compiler cache enabled: xcache
+5.13   Original CC: riscv32-esp-elf-gcc
+5.13   Original CXX: riscv32-esp-elf-g++
+5.13   Fake CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.13   Fake CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.13 Python fake compiler cache environment configured successfully
+5.16 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.16 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.17 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.17   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.17   RET_CODE: no such file or directory
+5.17   ERROR_MESSAGE:
+5.17 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.17   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.17   RET_CODE: no such file or directory
+5.17   ERROR_MESSAGE:
+5.19 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in] Error 1
+5.19 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in] Error 1
+5.19 Retrieved `.pio/build/esp32c2/app_trace/port/port_uart.c.o' from cache
+5.33 ========================== [FAILED] Took 5.20 seconds ==========================

--- a/failures/WasmScreenCoords.log
+++ b/failures/WasmScreenCoords.log
@@ -1,0 +1,91 @@
+Initial build failed: 0.12 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.12 --------------------------------------------------------------------------------
+0.44 Verbose mode can be enabled via `-v, --verbose` option
+0.52 Error output: /home/ubuntu/.fastled/compile/pio/esp32c2/penv/bin/python: No module named pip
+0.52 Error: Failed to install Python dependencies into penv
+0.56 ========================== [FAILED] Took 0.43 seconds ==========================
+Initial build failed: 0.13 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.13 --------------------------------------------------------------------------------
+0.44 Verbose mode can be enabled via `-v, --verbose` option
+0.83 CONFIGURATION: https://docs.platformio.org/page/boards/espressif32/esp32-c2-devkitm-1.html
+0.83 PLATFORM: Espressif 32 (55.3.30+develop.sha.9651ee8) > Espressif ESP32-C2-DevKitM-1
+0.83 HARDWARE: ESP32C2 120MHz, 272KB RAM, 4MB Flash
+0.83 DEBUG: Current (cmsis-dap) External (cmsis-dap, esp-bridge, esp-prog, iot-bus-jtag, jlink, minimodule, olimex-arm-usb-ocd, olimex-arm-usb-ocd-h, olimex-arm-usb-tiny-h, olimex-jtag-tiny, tumpa)
+0.83 PACKAGES:
+0.83  - contrib-piohome @ 3.4.4
+0.83  - framework-arduino-c2-skeleton-lib @ 5.5.0+sha.cbe9388f45
+0.83  - framework-arduinoespressif32 @ 3.3.0
+0.83  - framework-arduinoespressif32-libs @ 5.5.0+sha.b66b5448e0
+0.83  - framework-espidf @ 3.50500.0 (5.5.0)
+0.83  - tool-cmake @ 3.30.2
+0.83  - tool-esp-rom-elfs @ 2024.10.11
+0.83  - tool-esptoolpy @ 5.0.2
+0.83  - tool-mklittlefs @ 3.2.0
+0.83  - tool-ninja @ 1.13.1
+0.83  - tool-scons @ 4.40801.0 (4.8.1)
+0.83  - toolchain-riscv32-esp @ 14.2.0+20241119
+0.83 *** Compile Arduino IDF libs for esp32c2 ***
+0.85 *** Add "custom_sdkconfig" settings to IDF sdkconfig.defaults ***
+0.85 Replace: CONFIG_IDF_TARGET="esp32c2" with: CONFIG_IDF_TARGET=esp32c2
+0.85 Replace: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y with: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y
+0.85 Replace: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y with: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y
+0.85 Replace: CONFIG_ESPTOOLPY_FLASHFREQ="60m" with: CONFIG_ESPTOOLPY_FLASHFREQ="60m"
+0.85 Add: # CONFIG_ESPTOOLPY_FLASHFREQ_80M is not set
+0.86 Warning! Arduino framework as an ESP-IDF component doesn't handle the `variant` field! The default `esp32` variant will be used.
+0.86 Reading CMake configuration...
+4.98 LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
+4.98 LDF Modes: Finder ~ chain, Compatibility ~ soft
+5.04 Found 42 compatible libraries
+5.04 Scanning dependencies...
+5.04 No dependencies
+5.05 Building in release mode
+5.05 Environment state dumped to: env_dump.json
+5.05 Projenv state dumped to: projenv_dump.json
+5.05 Cache configuration from environment:
+5.05   Cache type: xcache
+5.05   Cache executable: python /workspace/ci/util/xcache.py
+5.05   SCCACHE path: /workspace/.venv/bin/sccache
+5.05   SCCACHE dir: /home/ubuntu/.fastled/sccache
+5.05   Debug enabled: False
+5.05 xcache wrapper detected and configured for Python fake compilers
+5.05   xcache path: /workspace/ci/util/xcache.py
+5.05   cache executable: python /workspace/ci/util/xcache.py
+5.05 DEBUG: Found compilers in env:
+5.05   CC: 'riscv32-esp-elf-gcc' (type: str)
+5.05   CXX: 'riscv32-esp-elf-g++' (type: str)
+5.05 Extracted compiler names:
+5.05   CC name: riscv32-esp-elf-gcc
+5.05   CXX name: riscv32-esp-elf-g++
+5.05 Found local compiler cache:
+5.05   Cache file: /workspace/.build/pio/esp32c2/compiler_cache.json
+5.05   Real CC: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-gcc
+5.05   Real CXX: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-g++
+5.05 SUCCESS: Using cached compilers (instant, no platform search needed):
+5.05   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.05   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.05   Platform search skipped - using cached toolset
+5.05 Created Python cached compilers:
+5.05   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.05   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.05 Applied Python fake compilers to both env and projenv
+5.05 Python fake compiler cache enabled: xcache
+5.05   Original CC: riscv32-esp-elf-gcc
+5.05   Original CXX: riscv32-esp-elf-g++
+5.05   Fake CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.05   Fake CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.05 Python fake compiler cache environment configured successfully
+5.09 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.09 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.09 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.09   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.09   RET_CODE: no such file or directory
+5.09   ERROR_MESSAGE:
+5.09 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.09   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.09   RET_CODE: no such file or directory
+5.09   ERROR_MESSAGE:
+5.10 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in] Error 1
+5.10 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in] Error 1
+5.10 Archiving .pio/build/esp32c2/esp-idf/app_trace/libapp_trace.a
+5.10 Indexing .pio/build/esp32c2/esp-idf/app_trace/libapp_trace.a
+5.25 ========================== [FAILED] Took 5.12 seconds ==========================

--- a/failures/Wave.log
+++ b/failures/Wave.log
@@ -1,0 +1,95 @@
+Initial build failed: 0.12 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.12 --------------------------------------------------------------------------------
+0.42 Verbose mode can be enabled via `-v, --verbose` option
+0.50 Error: Failed to install Python dependencies into penv
+0.50 Error output: /home/ubuntu/.fastled/compile/pio/esp32c2/penv/bin/python: No module named pip
+0.53 ========================== [FAILED] Took 0.41 seconds ==========================
+Initial build failed: 0.16 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.16 --------------------------------------------------------------------------------
+0.47 Verbose mode can be enabled via `-v, --verbose` option
+0.89 CONFIGURATION: https://docs.platformio.org/page/boards/espressif32/esp32-c2-devkitm-1.html
+0.89 PLATFORM: Espressif 32 (55.3.30+develop.sha.9651ee8) > Espressif ESP32-C2-DevKitM-1
+0.89 HARDWARE: ESP32C2 120MHz, 272KB RAM, 4MB Flash
+0.89 DEBUG: Current (cmsis-dap) External (cmsis-dap, esp-bridge, esp-prog, iot-bus-jtag, jlink, minimodule, olimex-arm-usb-ocd, olimex-arm-usb-ocd-h, olimex-arm-usb-tiny-h, olimex-jtag-tiny, tumpa)
+0.89 PACKAGES:
+0.89  - contrib-piohome @ 3.4.4
+0.89  - framework-arduino-c2-skeleton-lib @ 5.5.0+sha.cbe9388f45
+0.89  - framework-arduinoespressif32 @ 3.3.0
+0.89  - framework-arduinoespressif32-libs @ 5.5.0+sha.b66b5448e0
+0.89  - framework-espidf @ 3.50500.0 (5.5.0)
+0.89  - tool-cmake @ 3.30.2
+0.89  - tool-esp-rom-elfs @ 2024.10.11
+0.89  - tool-esptoolpy @ 5.0.2
+0.89  - tool-mklittlefs @ 3.2.0
+0.89  - tool-ninja @ 1.13.1
+0.89  - tool-scons @ 4.40801.0 (4.8.1)
+0.89  - toolchain-riscv32-esp @ 14.2.0+20241119
+0.90 *** Compile Arduino IDF libs for esp32c2 ***
+0.92 *** Add "custom_sdkconfig" settings to IDF sdkconfig.defaults ***
+0.92 Replace: CONFIG_IDF_TARGET="esp32c2" with: CONFIG_IDF_TARGET=esp32c2
+0.92 Replace: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y with: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y
+0.92 Replace: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y with: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y
+0.92 Replace: CONFIG_ESPTOOLPY_FLASHFREQ="60m" with: CONFIG_ESPTOOLPY_FLASHFREQ="60m"
+0.92 Add: # CONFIG_ESPTOOLPY_FLASHFREQ_80M is not set
+0.93 Warning! Arduino framework as an ESP-IDF component doesn't handle the `variant` field! The default `esp32` variant will be used.
+0.93 Reading CMake configuration...
+5.35 Generating assembly for certificate bundle...
+5.51 LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
+5.51 LDF Modes: Finder ~ chain, Compatibility ~ soft
+5.56 Found 42 compatible libraries
+5.56 Scanning dependencies...
+5.57 No dependencies
+5.57 Building in release mode
+5.58 Environment state dumped to: env_dump.json
+5.58 Projenv state dumped to: projenv_dump.json
+5.58 Cache configuration from environment:
+5.58   Cache type: xcache
+5.58   Cache executable: python /workspace/ci/util/xcache.py
+5.58   SCCACHE path: /workspace/.venv/bin/sccache
+5.58   SCCACHE dir: /home/ubuntu/.fastled/sccache
+5.58   Debug enabled: False
+5.58 xcache wrapper detected and configured for Python fake compilers
+5.58   xcache path: /workspace/ci/util/xcache.py
+5.58   cache executable: python /workspace/ci/util/xcache.py
+5.58 DEBUG: Found compilers in env:
+5.58   CC: 'riscv32-esp-elf-gcc' (type: str)
+5.58   CXX: 'riscv32-esp-elf-g++' (type: str)
+5.58 Extracted compiler names:
+5.58   CC name: riscv32-esp-elf-gcc
+5.58   CXX name: riscv32-esp-elf-g++
+5.58 Found local compiler cache:
+5.58   Cache file: /workspace/.build/pio/esp32c2/compiler_cache.json
+5.58   Real CC: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-gcc
+5.58   Real CXX: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-g++
+5.58 SUCCESS: Using cached compilers (instant, no platform search needed):
+5.58   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.58   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.58   Platform search skipped - using cached toolset
+5.58 Created Python cached compilers:
+5.58   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.58   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.58 Applied Python fake compilers to both env and projenv
+5.58 Python fake compiler cache enabled: xcache
+5.58   Original CC: riscv32-esp-elf-gcc
+5.58   Original CXX: riscv32-esp-elf-g++
+5.58   Fake CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.58   Fake CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.58 Python fake compiler cache environment configured successfully
+5.68 Retrieved `.pio/build/esp32c2/.dummy/sketch.cpp.o' from cache
+5.68 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-gcc.c.o' from cache
+5.69 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-cpp.cpp.o' from cache
+5.69 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-as.S.o' from cache
+5.70 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.70 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.70 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.70   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.70   RET_CODE: no such file or directory
+5.70   ERROR_MESSAGE:
+5.70 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.70   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.70   RET_CODE: no such file or directory
+5.70   ERROR_MESSAGE:
+5.71 Retrieved `.pio/build/esp32c2/app_trace/app_trace.c.o' from cache
+5.71 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in] Error 1
+5.71 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in] Error 1
+5.86 ========================== [FAILED] Took 5.70 seconds ==========================

--- a/failures/Wave2d.log
+++ b/failures/Wave2d.log
@@ -1,0 +1,94 @@
+Initial build failed: 0.12 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.12 --------------------------------------------------------------------------------
+0.43 Verbose mode can be enabled via `-v, --verbose` option
+0.51 Error output: /home/ubuntu/.fastled/compile/pio/esp32c2/penv/bin/python: No module named pip
+0.51 Error: Failed to install Python dependencies into penv
+0.55 ========================== [FAILED] Took 0.43 seconds ==========================
+Initial build failed: 0.16 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.16 --------------------------------------------------------------------------------
+0.48 Verbose mode can be enabled via `-v, --verbose` option
+0.86 CONFIGURATION: https://docs.platformio.org/page/boards/espressif32/esp32-c2-devkitm-1.html
+0.86 PLATFORM: Espressif 32 (55.3.30+develop.sha.9651ee8) > Espressif ESP32-C2-DevKitM-1
+0.86 HARDWARE: ESP32C2 120MHz, 272KB RAM, 4MB Flash
+0.86 DEBUG: Current (cmsis-dap) External (cmsis-dap, esp-bridge, esp-prog, iot-bus-jtag, jlink, minimodule, olimex-arm-usb-ocd, olimex-arm-usb-ocd-h, olimex-arm-usb-tiny-h, olimex-jtag-tiny, tumpa)
+0.86 PACKAGES:
+0.86  - contrib-piohome @ 3.4.4
+0.86  - framework-arduino-c2-skeleton-lib @ 5.5.0+sha.cbe9388f45
+0.86  - framework-arduinoespressif32 @ 3.3.0
+0.86  - framework-arduinoespressif32-libs @ 5.5.0+sha.b66b5448e0
+0.86  - framework-espidf @ 3.50500.0 (5.5.0)
+0.86  - tool-cmake @ 3.30.2
+0.86  - tool-esp-rom-elfs @ 2024.10.11
+0.86  - tool-esptoolpy @ 5.0.2
+0.86  - tool-mklittlefs @ 3.2.0
+0.86  - tool-ninja @ 1.13.1
+0.86  - tool-scons @ 4.40801.0 (4.8.1)
+0.86  - toolchain-riscv32-esp @ 14.2.0+20241119
+0.87 *** Compile Arduino IDF libs for esp32c2 ***
+0.89 *** Add "custom_sdkconfig" settings to IDF sdkconfig.defaults ***
+0.89 Replace: CONFIG_IDF_TARGET="esp32c2" with: CONFIG_IDF_TARGET=esp32c2
+0.89 Replace: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y with: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y
+0.89 Replace: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y with: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y
+0.89 Replace: CONFIG_ESPTOOLPY_FLASHFREQ="60m" with: CONFIG_ESPTOOLPY_FLASHFREQ="60m"
+0.89 Add: # CONFIG_ESPTOOLPY_FLASHFREQ_80M is not set
+0.90 Warning! Arduino framework as an ESP-IDF component doesn't handle the `variant` field! The default `esp32` variant will be used.
+0.90 Reading CMake configuration...
+5.27 Generating assembly for certificate bundle...
+5.42 LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
+5.42 LDF Modes: Finder ~ chain, Compatibility ~ soft
+5.48 Found 42 compatible libraries
+5.48 Scanning dependencies...
+5.48 No dependencies
+5.48 Building in release mode
+5.49 Environment state dumped to: env_dump.json
+5.49 Projenv state dumped to: projenv_dump.json
+5.49 Cache configuration from environment:
+5.49   Cache type: xcache
+5.49   Cache executable: python /workspace/ci/util/xcache.py
+5.49   SCCACHE path: /workspace/.venv/bin/sccache
+5.49   SCCACHE dir: /home/ubuntu/.fastled/sccache
+5.49   Debug enabled: False
+5.49 xcache wrapper detected and configured for Python fake compilers
+5.49   xcache path: /workspace/ci/util/xcache.py
+5.49   cache executable: python /workspace/ci/util/xcache.py
+5.49 DEBUG: Found compilers in env:
+5.49   CC: 'riscv32-esp-elf-gcc' (type: str)
+5.49   CXX: 'riscv32-esp-elf-g++' (type: str)
+5.49 Extracted compiler names:
+5.49   CC name: riscv32-esp-elf-gcc
+5.49   CXX name: riscv32-esp-elf-g++
+5.49 Found local compiler cache:
+5.49   Cache file: /workspace/.build/pio/esp32c2/compiler_cache.json
+5.49   Real CC: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-gcc
+5.49   Real CXX: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-g++
+5.49 SUCCESS: Using cached compilers (instant, no platform search needed):
+5.49   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.49   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.49   Platform search skipped - using cached toolset
+5.49 Created Python cached compilers:
+5.49   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.49   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.49 Applied Python fake compilers to both env and projenv
+5.49 Python fake compiler cache enabled: xcache
+5.49   Original CC: riscv32-esp-elf-gcc
+5.49   Original CXX: riscv32-esp-elf-g++
+5.49   Fake CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.49   Fake CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.49 Python fake compiler cache environment configured successfully
+5.59 Retrieved `.pio/build/esp32c2/.dummy/sketch.cpp.o' from cache
+5.60 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-gcc.c.o' from cache
+5.60 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-cpp.cpp.o' from cache
+5.61 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-as.S.o' from cache
+5.61 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.61 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.61   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.61   RET_CODE: no such file or directory
+5.61   ERROR_MESSAGE:
+5.61 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.61 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in] Error 1
+5.61 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.61   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.61   RET_CODE: no such file or directory
+5.61   ERROR_MESSAGE:
+5.61 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in] Error 1
+5.75 ========================== [FAILED] Took 5.59 seconds ==========================

--- a/failures/XYMatrix.log
+++ b/failures/XYMatrix.log
@@ -1,0 +1,95 @@
+Initial build failed: 0.13 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.13 --------------------------------------------------------------------------------
+0.45 Verbose mode can be enabled via `-v, --verbose` option
+0.52 Error output: /home/ubuntu/.fastled/compile/pio/esp32c2/penv/bin/python: No module named pip
+0.52 Error: Failed to install Python dependencies into penv
+0.56 ========================== [FAILED] Took 0.43 seconds ==========================
+Initial build failed: 0.16 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.16 --------------------------------------------------------------------------------
+0.47 Verbose mode can be enabled via `-v, --verbose` option
+0.86 CONFIGURATION: https://docs.platformio.org/page/boards/espressif32/esp32-c2-devkitm-1.html
+0.86 PLATFORM: Espressif 32 (55.3.30+develop.sha.9651ee8) > Espressif ESP32-C2-DevKitM-1
+0.86 HARDWARE: ESP32C2 120MHz, 272KB RAM, 4MB Flash
+0.86 DEBUG: Current (cmsis-dap) External (cmsis-dap, esp-bridge, esp-prog, iot-bus-jtag, jlink, minimodule, olimex-arm-usb-ocd, olimex-arm-usb-ocd-h, olimex-arm-usb-tiny-h, olimex-jtag-tiny, tumpa)
+0.86 PACKAGES:
+0.86  - contrib-piohome @ 3.4.4
+0.86  - framework-arduino-c2-skeleton-lib @ 5.5.0+sha.cbe9388f45
+0.86  - framework-arduinoespressif32 @ 3.3.0
+0.86  - framework-arduinoespressif32-libs @ 5.5.0+sha.b66b5448e0
+0.86  - framework-espidf @ 3.50500.0 (5.5.0)
+0.86  - tool-cmake @ 3.30.2
+0.86  - tool-esp-rom-elfs @ 2024.10.11
+0.86  - tool-esptoolpy @ 5.0.2
+0.86  - tool-mklittlefs @ 3.2.0
+0.86  - tool-ninja @ 1.13.1
+0.86  - tool-scons @ 4.40801.0 (4.8.1)
+0.86  - toolchain-riscv32-esp @ 14.2.0+20241119
+0.87 *** Compile Arduino IDF libs for esp32c2 ***
+0.89 *** Add "custom_sdkconfig" settings to IDF sdkconfig.defaults ***
+0.89 Replace: CONFIG_IDF_TARGET="esp32c2" with: CONFIG_IDF_TARGET=esp32c2
+0.89 Replace: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y with: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y
+0.89 Replace: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y with: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y
+0.89 Replace: CONFIG_ESPTOOLPY_FLASHFREQ="60m" with: CONFIG_ESPTOOLPY_FLASHFREQ="60m"
+0.89 Add: # CONFIG_ESPTOOLPY_FLASHFREQ_80M is not set
+0.90 Warning! Arduino framework as an ESP-IDF component doesn't handle the `variant` field! The default `esp32` variant will be used.
+0.90 Reading CMake configuration...
+5.27 Generating assembly for certificate bundle...
+5.43 LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
+5.43 LDF Modes: Finder ~ chain, Compatibility ~ soft
+5.49 Found 42 compatible libraries
+5.49 Scanning dependencies...
+5.49 No dependencies
+5.49 Building in release mode
+5.50 Environment state dumped to: env_dump.json
+5.50 Projenv state dumped to: projenv_dump.json
+5.50 Cache configuration from environment:
+5.50   Cache type: xcache
+5.50   Cache executable: python /workspace/ci/util/xcache.py
+5.50   SCCACHE path: /workspace/.venv/bin/sccache
+5.50   SCCACHE dir: /home/ubuntu/.fastled/sccache
+5.50   Debug enabled: False
+5.50 xcache wrapper detected and configured for Python fake compilers
+5.50   xcache path: /workspace/ci/util/xcache.py
+5.50   cache executable: python /workspace/ci/util/xcache.py
+5.50 DEBUG: Found compilers in env:
+5.50   CC: 'riscv32-esp-elf-gcc' (type: str)
+5.50   CXX: 'riscv32-esp-elf-g++' (type: str)
+5.50 Extracted compiler names:
+5.50   CC name: riscv32-esp-elf-gcc
+5.50   CXX name: riscv32-esp-elf-g++
+5.50 Found local compiler cache:
+5.50   Cache file: /workspace/.build/pio/esp32c2/compiler_cache.json
+5.50   Real CC: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-gcc
+5.50   Real CXX: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-g++
+5.50 SUCCESS: Using cached compilers (instant, no platform search needed):
+5.50   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.50   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.50   Platform search skipped - using cached toolset
+5.50 Created Python cached compilers:
+5.50   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.50   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.50 Applied Python fake compilers to both env and projenv
+5.50 Python fake compiler cache enabled: xcache
+5.50   Original CC: riscv32-esp-elf-gcc
+5.50   Original CXX: riscv32-esp-elf-g++
+5.50   Fake CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.50   Fake CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.50 Python fake compiler cache environment configured successfully
+5.60 Retrieved `.pio/build/esp32c2/.dummy/sketch.cpp.o' from cache
+5.61 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-gcc.c.o' from cache
+5.61 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-cpp.cpp.o' from cache
+5.62 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-as.S.o' from cache
+5.62 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.62 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.62 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.62   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.62   RET_CODE: no such file or directory
+5.62   ERROR_MESSAGE:
+5.63 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.63   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.63   RET_CODE: no such file or directory
+5.63   ERROR_MESSAGE:
+5.64 Retrieved `.pio/build/esp32c2/app_trace/app_trace.c.o' from cache
+5.64 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in] Error 1
+5.64 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in] Error 1
+5.78 ========================== [FAILED] Took 5.62 seconds ==========================

--- a/failures/XYPath.log
+++ b/failures/XYPath.log
@@ -1,0 +1,94 @@
+Initial build failed: 0.13 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.13 --------------------------------------------------------------------------------
+0.44 Verbose mode can be enabled via `-v, --verbose` option
+0.51 Error output: /home/ubuntu/.fastled/compile/pio/esp32c2/penv/bin/python: No module named pip
+0.51 Error: Failed to install Python dependencies into penv
+0.55 ========================== [FAILED] Took 0.42 seconds ==========================
+Initial build failed: 0.16 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.16 --------------------------------------------------------------------------------
+0.48 Verbose mode can be enabled via `-v, --verbose` option
+0.87 CONFIGURATION: https://docs.platformio.org/page/boards/espressif32/esp32-c2-devkitm-1.html
+0.87 PLATFORM: Espressif 32 (55.3.30+develop.sha.9651ee8) > Espressif ESP32-C2-DevKitM-1
+0.87 HARDWARE: ESP32C2 120MHz, 272KB RAM, 4MB Flash
+0.87 DEBUG: Current (cmsis-dap) External (cmsis-dap, esp-bridge, esp-prog, iot-bus-jtag, jlink, minimodule, olimex-arm-usb-ocd, olimex-arm-usb-ocd-h, olimex-arm-usb-tiny-h, olimex-jtag-tiny, tumpa)
+0.87 PACKAGES:
+0.87  - contrib-piohome @ 3.4.4
+0.87  - framework-arduino-c2-skeleton-lib @ 5.5.0+sha.cbe9388f45
+0.87  - framework-arduinoespressif32 @ 3.3.0
+0.87  - framework-arduinoespressif32-libs @ 5.5.0+sha.b66b5448e0
+0.87  - framework-espidf @ 3.50500.0 (5.5.0)
+0.87  - tool-cmake @ 3.30.2
+0.87  - tool-esp-rom-elfs @ 2024.10.11
+0.87  - tool-esptoolpy @ 5.0.2
+0.87  - tool-mklittlefs @ 3.2.0
+0.87  - tool-ninja @ 1.13.1
+0.87  - tool-scons @ 4.40801.0 (4.8.1)
+0.87  - toolchain-riscv32-esp @ 14.2.0+20241119
+0.88 *** Compile Arduino IDF libs for esp32c2 ***
+0.90 *** Add "custom_sdkconfig" settings to IDF sdkconfig.defaults ***
+0.90 Replace: CONFIG_IDF_TARGET="esp32c2" with: CONFIG_IDF_TARGET=esp32c2
+0.90 Replace: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y with: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y
+0.90 Replace: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y with: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y
+0.90 Replace: CONFIG_ESPTOOLPY_FLASHFREQ="60m" with: CONFIG_ESPTOOLPY_FLASHFREQ="60m"
+0.90 Add: # CONFIG_ESPTOOLPY_FLASHFREQ_80M is not set
+0.91 Warning! Arduino framework as an ESP-IDF component doesn't handle the `variant` field! The default `esp32` variant will be used.
+0.91 Reading CMake configuration...
+5.27 Generating assembly for certificate bundle...
+5.42 LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
+5.42 LDF Modes: Finder ~ chain, Compatibility ~ soft
+5.48 Found 42 compatible libraries
+5.48 Scanning dependencies...
+5.48 No dependencies
+5.48 Building in release mode
+5.49 Environment state dumped to: env_dump.json
+5.49 Projenv state dumped to: projenv_dump.json
+5.49 Cache configuration from environment:
+5.49   Cache type: xcache
+5.49   Cache executable: python /workspace/ci/util/xcache.py
+5.49   SCCACHE path: /workspace/.venv/bin/sccache
+5.49   SCCACHE dir: /home/ubuntu/.fastled/sccache
+5.49   Debug enabled: False
+5.49 xcache wrapper detected and configured for Python fake compilers
+5.49   xcache path: /workspace/ci/util/xcache.py
+5.49   cache executable: python /workspace/ci/util/xcache.py
+5.49 DEBUG: Found compilers in env:
+5.49   CC: 'riscv32-esp-elf-gcc' (type: str)
+5.49   CXX: 'riscv32-esp-elf-g++' (type: str)
+5.49 Extracted compiler names:
+5.49   CC name: riscv32-esp-elf-gcc
+5.49   CXX name: riscv32-esp-elf-g++
+5.49 Found local compiler cache:
+5.49   Cache file: /workspace/.build/pio/esp32c2/compiler_cache.json
+5.49   Real CC: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-gcc
+5.49   Real CXX: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-g++
+5.49 SUCCESS: Using cached compilers (instant, no platform search needed):
+5.49   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.49   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.49   Platform search skipped - using cached toolset
+5.49 Created Python cached compilers:
+5.49   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.49   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.49 Applied Python fake compilers to both env and projenv
+5.49 Python fake compiler cache enabled: xcache
+5.49   Original CC: riscv32-esp-elf-gcc
+5.49   Original CXX: riscv32-esp-elf-g++
+5.49   Fake CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.49   Fake CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.49 Python fake compiler cache environment configured successfully
+5.59 Retrieved `.pio/build/esp32c2/.dummy/sketch.cpp.o' from cache
+5.60 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-gcc.c.o' from cache
+5.60 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-cpp.cpp.o' from cache
+5.61 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-as.S.o' from cache
+5.61 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.61 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.61   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.61   RET_CODE: no such file or directory
+5.61   ERROR_MESSAGE:
+5.61 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.61 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in] Error 1
+5.62 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.62   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.62   RET_CODE: no such file or directory
+5.62   ERROR_MESSAGE:
+5.62 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in] Error 1
+5.75 ========================== [FAILED] Took 5.59 seconds ==========================

--- a/failures/wasm.log
+++ b/failures/wasm.log
@@ -1,0 +1,95 @@
+Initial build failed: 0.12 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.12 --------------------------------------------------------------------------------
+0.43 Verbose mode can be enabled via `-v, --verbose` option
+0.51 Error: Failed to install Python dependencies into penv
+0.51 Error output: /home/ubuntu/.fastled/compile/pio/esp32c2/penv/bin/python: No module named pip
+0.54 ========================== [FAILED] Took 0.42 seconds ==========================
+Initial build failed: 0.17 Processing esp32c2 (board: esp32-c2-devkitm-1; platform: https://github.com/pioarduino/platform-espressif32.git#develop; framework: arduino)
+0.17 --------------------------------------------------------------------------------
+0.48 Verbose mode can be enabled via `-v, --verbose` option
+0.93 CONFIGURATION: https://docs.platformio.org/page/boards/espressif32/esp32-c2-devkitm-1.html
+0.93 PLATFORM: Espressif 32 (55.3.30+develop.sha.9651ee8) > Espressif ESP32-C2-DevKitM-1
+0.93 HARDWARE: ESP32C2 120MHz, 272KB RAM, 4MB Flash
+0.93 DEBUG: Current (cmsis-dap) External (cmsis-dap, esp-bridge, esp-prog, iot-bus-jtag, jlink, minimodule, olimex-arm-usb-ocd, olimex-arm-usb-ocd-h, olimex-arm-usb-tiny-h, olimex-jtag-tiny, tumpa)
+0.93 PACKAGES:
+0.93  - contrib-piohome @ 3.4.4
+0.93  - framework-arduino-c2-skeleton-lib @ 5.5.0+sha.cbe9388f45
+0.93  - framework-arduinoespressif32 @ 3.3.0
+0.93  - framework-arduinoespressif32-libs @ 5.5.0+sha.b66b5448e0
+0.93  - framework-espidf @ 3.50500.0 (5.5.0)
+0.93  - tool-cmake @ 3.30.2
+0.93  - tool-esp-rom-elfs @ 2024.10.11
+0.93  - tool-esptoolpy @ 5.0.2
+0.93  - tool-mklittlefs @ 3.2.0
+0.93  - tool-ninja @ 1.13.1
+0.93  - tool-scons @ 4.40801.0 (4.8.1)
+0.93  - toolchain-riscv32-esp @ 14.2.0+20241119
+0.93 *** Compile Arduino IDF libs for esp32c2 ***
+0.95 *** Add "custom_sdkconfig" settings to IDF sdkconfig.defaults ***
+0.95 Replace: CONFIG_IDF_TARGET="esp32c2" with: CONFIG_IDF_TARGET=esp32c2
+0.95 Replace: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y with: CONFIG_ESPTOOLPY_FLASHMODE_QIO=y
+0.95 Replace: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y with: CONFIG_ESPTOOLPY_FLASHFREQ_60M=y
+0.95 Replace: CONFIG_ESPTOOLPY_FLASHFREQ="60m" with: CONFIG_ESPTOOLPY_FLASHFREQ="60m"
+0.95 Add: # CONFIG_ESPTOOLPY_FLASHFREQ_80M is not set
+0.96 Warning! Arduino framework as an ESP-IDF component doesn't handle the `variant` field! The default `esp32` variant will be used.
+0.96 Reading CMake configuration...
+5.34 Generating assembly for certificate bundle...
+5.49 LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
+5.49 LDF Modes: Finder ~ chain, Compatibility ~ soft
+5.55 Found 42 compatible libraries
+5.55 Scanning dependencies...
+5.55 No dependencies
+5.55 Building in release mode
+5.56 Environment state dumped to: env_dump.json
+5.56 Projenv state dumped to: projenv_dump.json
+5.56 Cache configuration from environment:
+5.56   Cache type: xcache
+5.56   Cache executable: python /workspace/ci/util/xcache.py
+5.56   SCCACHE path: /workspace/.venv/bin/sccache
+5.56   SCCACHE dir: /home/ubuntu/.fastled/sccache
+5.56   Debug enabled: False
+5.56 xcache wrapper detected and configured for Python fake compilers
+5.56   xcache path: /workspace/ci/util/xcache.py
+5.56   cache executable: python /workspace/ci/util/xcache.py
+5.56 DEBUG: Found compilers in env:
+5.56   CC: 'riscv32-esp-elf-gcc' (type: str)
+5.56   CXX: 'riscv32-esp-elf-g++' (type: str)
+5.56 Extracted compiler names:
+5.56   CC name: riscv32-esp-elf-gcc
+5.56   CXX name: riscv32-esp-elf-g++
+5.56 Found local compiler cache:
+5.56   Cache file: /workspace/.build/pio/esp32c2/compiler_cache.json
+5.56   Real CC: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-gcc
+5.56   Real CXX: /home/ubuntu/.fastled/packages/esp32c2/toolchain-riscv32-esp/bin/riscv32-esp-elf-g++
+5.56 SUCCESS: Using cached compilers (instant, no platform search needed):
+5.56   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.56   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.56   Platform search skipped - using cached toolset
+5.56 Created Python cached compilers:
+5.56   CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.56   CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.56 Applied Python fake compilers to both env and projenv
+5.56 Python fake compiler cache enabled: xcache
+5.56   Original CC: riscv32-esp-elf-gcc
+5.56   Original CXX: riscv32-esp-elf-g++
+5.56   Fake CC: /workspace/.build/pio/esp32c2/cached_compilers/cached_CC.py
+5.56   Fake CXX: /workspace/.build/pio/esp32c2/cached_compilers/cached_CXX.py
+5.56 Python fake compiler cache environment configured successfully
+5.66 Retrieved `.pio/build/esp32c2/.dummy/sketch.cpp.o' from cache
+5.67 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-gcc.c.o' from cache
+5.67 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-cpp.cpp.o' from cache
+5.67 Retrieved `.pio/build/esp32c2/.dummy/arduino-lib-builder-as.S.o' from cache
+5.68 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.68 Generating LD script .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.68 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.68   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in
+5.68   RET_CODE: no such file or directory
+5.68   ERROR_MESSAGE:
+5.68 CMake Error at .pio/build/esp32c2/esp-idf/esp_system/ld/linker_script_generator.cmake:6 (message):
+5.68   Can't generate .pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in
+5.68   RET_CODE: no such file or directory
+5.68   ERROR_MESSAGE:
+5.69 Retrieved `.pio/build/esp32c2/app_trace/app_trace.c.o' from cache
+5.69 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/memory.ld.in] Error 1
+5.70 *** [.pio/build/esp32c2/esp-idf/esp_system/ld/sections.ld.in] Error 1
+5.83 ========================== [FAILED] Took 5.67 seconds ==========================


### PR DESCRIPTION
Skip CC/CXX compiler wrapping for `esp32c2` to fix linker script generation.

ESP-IDF's linker script generator expects `$CC` to be a bare compiler name (e.g., `riscv32-esp-elf-gcc`), but our compiler caching system was replacing it with a Python wrapper path. This change prevents the wrapper replacement for `esp32c2`, allowing the linker script generator to find the correct compiler path and resolve "no such file or directory" errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-8454e994-3c99-4279-b5cf-cbce56be6c39">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8454e994-3c99-4279-b5cf-cbce56be6c39">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

