### PR TITLE
Increased ESP Size, Fix ESP32C2 and STM103TB build

### DIFF
--- a/.github/workflows/check_esp32_size.yml
+++ b/.github/workflows/check_esp32_size.yml
@@ -31,5 +31,5 @@ jobs:
     uses: ./.github/workflows/build_template_binary_size.yml
     with:
       board: esp32dev
-      max_size: 320000
-      max_size_apa102: 320000
+      max_size: 330000
+      max_size_apa102: 330000

--- a/ci/boards.py
+++ b/ci/boards.py
@@ -531,6 +531,11 @@ MAPLE_MINI = Board(
     platform="ststm32",
 )
 
+HY_TINYSTM103TB = Board(
+    board_name="hy_tinystm103tb",
+    platform="ststm32",
+)
+
 ATTINY88 = Board(
     board_name="attiny88",
     platform="atmelavr",

--- a/ci/compiler/pio.py
+++ b/ci/compiler/pio.py
@@ -214,7 +214,7 @@ def _apply_board_specific_config(
     additional_defines: list[str] | None = None,
     additional_include_dirs: list[str] | None = None,
     additional_libs: list[str] | None = None,
-    cache_type: CacheType = CacheType.NO_CACHE,
+    cache_config: dict[str, str] | None = None,
 ) -> bool:
     """Apply board-specific build configuration from Board class."""
     # Use centralized path management
@@ -231,9 +231,7 @@ def _apply_board_specific_config(
         packages_dir=str(paths.packages_dir),
         project_root=str(_PROJECT_ROOT),
         build_cache_dir=str(paths.build_cache_dir),
-        extra_scripts=["post:cache_setup.scons"]
-        if cache_type != CacheType.NO_CACHE
-        else None,
+        extra_scripts=["post:cache_setup.scons"] if cache_config else None,
     )
 
     platformio_ini_path.write_text(config_content)
@@ -1001,7 +999,7 @@ def _init_platformio_build(
         additional_defines,
         additional_include_dirs,
         additional_libs,
-        cache_type,
+        cache_config,
     ):
         return InitResult(
             success=False,

--- a/src/platforms/arm/stm32/fastpin_arm_stm32.h
+++ b/src/platforms/arm/stm32/fastpin_arm_stm32.h
@@ -10,7 +10,9 @@
 // Use new pin definitions for all STM32F1 variants to fix pin mapping issues
 // The legacy definitions use incorrect Arduino pin numbers instead of STM32 pin names
 #if defined(ARDUINO_BLUEPILL_F103C8) || defined(ARDUINO_MAPLE_MINI) || defined(ARDUINO_GENERIC_STM32F103T) || defined(STM32F103TBU6) || defined(STM32F103TB) || defined(__STM32F1__) || defined(STM32F1) || defined(STM32F103C8) || defined(ARDUINO_GENERIC_STM32F103C8) || defined(ARDUINO_GENERIC_F103C8TX)
+#if !defined(ARDUINO_HY_TINYSTM103TB)
 #define USE_NEW_STM32_PIN_DEFINITIONS
+#endif
 #endif
 #endif
 


### PR DESCRIPTION
Fixed ESP32C2 CI/CD build, due to pio cache configurations

Fixed STM103TB build, wasn't set in boards.py and it must use the legacy fastpin structure

Due to Arduino-ESP32 framework updates, the binary size has increased a little bit, not a FastLED problem, so I increased the size a little bit in the workflow.