### PR TITLE
Fix audio input build failure

### DIFF
--- a/src/platforms/audio.h
+++ b/src/platforms/audio.h
@@ -6,10 +6,18 @@
 #if !defined(ESP32) || !__has_include("sdkconfig.h")
 #define FASTLED_HAS_AUDIO_INPUT 0
 #else
+// Include ESP version detection to check IDF version
+#include "platforms/esp/esp_version.h"
+// soc/soc_caps.h was introduced in ESP-IDF 4.0, not available in 3.3
+#if ESP_IDF_VERSION_4_OR_HIGHER && __has_include("soc/soc_caps.h")
 #include "soc/soc_caps.h"
 #if SOC_I2S_SUPPORTED
 #define FASTLED_HAS_AUDIO_INPUT 1
 #else
+#define FASTLED_HAS_AUDIO_INPUT 0
+#endif
+#else
+// ESP-IDF 3.3 and older - audio input not supported
 #define FASTLED_HAS_AUDIO_INPUT 0
 #endif
 #endif  // ESP32


### PR DESCRIPTION
Add conditional inclusion for `soc/soc_caps.h` to fix ESP-IDF 3.3 build failures while preserving audio input for newer versions.

The `soc/soc_caps.h` header, required for audio input feature detection, was introduced in ESP-IDF 4.0+. This change ensures that ESP-IDF 3.3 builds succeed by disabling audio input gracefully for older platforms, preventing a fatal "No such file or directory" error.

---
<a href="https://cursor.com/background-agent?bcId=bc-f55bead1-7135-4d17-b1b6-15c5ca674047">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f55bead1-7135-4d17-b1b6-15c5ca674047">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

