### PR TITLE
Debug and fix esp32c2 blink compilation

### DIFF
--- a/src/platforms/esp/32/audio/audio_impl.hpp
+++ b/src/platforms/esp/32/audio/audio_impl.hpp
@@ -14,10 +14,19 @@ namespace fl {
 fl::shared_ptr<IAudioInput>
 IAudioInput::create(const AudioConfig &config, fl::string *error_message) {
     if (config.is<AudioConfigI2S>()) {
+#if FASTLED_ESP32_I2S_SUPPORTED
         FL_WARN("Creating I2S standard mode audio source");
         AudioConfigI2S std_config = config.get<AudioConfigI2S>();
         fl::shared_ptr<IAudioInput> out = fl::make_shared<fl::I2S_Audio>(std_config);
         return out;
+#else
+        const char* ERROR_MESSAGE = "I2S audio not supported on this ESP32 variant (no I2S hardware)";
+        FL_WARN(ERROR_MESSAGE);
+        if (error_message) {
+            *error_message = ERROR_MESSAGE;
+        }
+        return fl::make_shared<fl::Null_Audio>();
+#endif
     }
     const char* ERROR_MESSAGE = "Unsupported audio configuration";
     FL_WARN(ERROR_MESSAGE);

--- a/src/platforms/esp/32/audio/audio_impl.hpp
+++ b/src/platforms/esp/32/audio/audio_impl.hpp
@@ -14,19 +14,10 @@ namespace fl {
 fl::shared_ptr<IAudioInput>
 IAudioInput::create(const AudioConfig &config, fl::string *error_message) {
     if (config.is<AudioConfigI2S>()) {
-#if FASTLED_ESP32_I2S_SUPPORTED
         FL_WARN("Creating I2S standard mode audio source");
         AudioConfigI2S std_config = config.get<AudioConfigI2S>();
         fl::shared_ptr<IAudioInput> out = fl::make_shared<fl::I2S_Audio>(std_config);
         return out;
-#else
-        const char* ERROR_MESSAGE = "I2S audio not supported on this ESP32 variant (no I2S hardware)";
-        FL_WARN(ERROR_MESSAGE);
-        if (error_message) {
-            *error_message = ERROR_MESSAGE;
-        }
-        return fl::make_shared<fl::Null_Audio>();
-#endif
     }
     const char* ERROR_MESSAGE = "Unsupported audio configuration";
     FL_WARN(ERROR_MESSAGE);

--- a/src/platforms/esp/32/audio/audio_impl.hpp
+++ b/src/platforms/esp/32/audio/audio_impl.hpp
@@ -14,7 +14,7 @@ IAudioInput::create(const AudioConfig &config, fl::string *error_message) {
         fl::shared_ptr<IAudioInput> out = fl::make_shared<fl::I2S_Audio>(std_config);
         return out;
     }
-    const char* ERROR_MESSAGE = "Unsupported I2S configuration";
+    const char* ERROR_MESSAGE = "Unsupported audio configuration";
     FL_WARN(ERROR_MESSAGE);
     if (error_message) {
         *error_message = ERROR_MESSAGE;

--- a/src/platforms/esp/32/audio/audio_impl.hpp
+++ b/src/platforms/esp/32/audio/audio_impl.hpp
@@ -3,16 +3,30 @@
 #include "platforms/esp/32/audio/devices/i2s.hpp"
 #include "platforms/esp/32/audio/devices/null.hpp"
 
+// Ensure FASTLED_ESP32_I2S_SUPPORTED is defined (included via i2s.hpp)
+#ifndef FASTLED_ESP32_I2S_SUPPORTED
+#error "FASTLED_ESP32_I2S_SUPPORTED should be defined by including i2s.hpp"
+#endif
+
 namespace fl {
 
 // Static factory method implementation
 fl::shared_ptr<IAudioInput>
 IAudioInput::create(const AudioConfig &config, fl::string *error_message) {
     if (config.is<AudioConfigI2S>()) {
+#if FASTLED_ESP32_I2S_SUPPORTED
         FL_WARN("Creating I2S standard mode audio source");
         AudioConfigI2S std_config = config.get<AudioConfigI2S>();
         fl::shared_ptr<IAudioInput> out = fl::make_shared<fl::I2S_Audio>(std_config);
         return out;
+#else
+        const char* ERROR_MESSAGE = "I2S audio not supported on this ESP32 variant (no I2S hardware)";
+        FL_WARN(ERROR_MESSAGE);
+        if (error_message) {
+            *error_message = ERROR_MESSAGE;
+        }
+        return fl::make_shared<fl::Null_Audio>();
+#endif
     }
     const char* ERROR_MESSAGE = "Unsupported audio configuration";
     FL_WARN(ERROR_MESSAGE);

--- a/src/platforms/esp/32/audio/devices/i2s.hpp
+++ b/src/platforms/esp/32/audio/devices/i2s.hpp
@@ -7,27 +7,23 @@
 
 #include "platforms/esp/esp_version.h"
 
-// ESP32-C2 specific detection - no I2S hardware support
 #ifndef FASTLED_ESP32_I2S_SUPPORTED
     #if defined(CONFIG_IDF_TARGET_ESP32C2)
         #define FASTLED_ESP32_I2S_SUPPORTED 0
     #endif
 #endif
 
-// Default case - assume I2S is supported on other ESP32 variants
 #ifndef FASTLED_ESP32_I2S_SUPPORTED
-    #define FASTLED_ESP32_I2S_SUPPORTED 1
-#endif
-
-#if FASTLED_ESP32_I2S_SUPPORTED
     #if ESP_IDF_VERSION_5_OR_HIGHER
-    #include "platforms/esp/32/audio/devices/idf5_i2s_context.hpp"
+        #define FASTLED_ESP32_I2S_SUPPORTED 1
+        #include "platforms/esp/32/audio/devices/idf5_i2s_context.hpp"
     #elif ESP_IDF_VERSION_4_OR_HIGHER
-    #include "platforms/esp/32/audio/devices/idf4_i2s_context.hpp"
+        #define FASTLED_ESP32_I2S_SUPPORTED 1
+        #include "platforms/esp/32/audio/devices/idf4_i2s_context.hpp"
     #else
-    #error "This should not be reachable when using ESP-IDF < 4.0"
-    #endif  //
-#endif  // FASTLED_ESP32_I2S_SUPPORTED
+        #define FASTLED_ESP32_I2S_SUPPORTED 0
+    #endif
+#endif
 
 namespace fl {
 

--- a/src/platforms/esp/32/audio/devices/i2s.hpp
+++ b/src/platforms/esp/32/audio/devices/i2s.hpp
@@ -105,35 +105,5 @@ class I2S_Audio : public IAudioInput {
 
 #endif // FASTLED_ESP32_I2S_SUPPORTED
 
-#if !FASTLED_ESP32_I2S_SUPPORTED
-// Stub implementation for ESP32 variants without I2S support (e.g., ESP32-C2)
-class I2S_Audio : public IAudioInput {
-public:
-    I2S_Audio(const AudioConfigI2S &config) {
-        FL_WARN("I2S audio not supported on this ESP32 variant (no I2S hardware)");
-    }
-    
-    ~I2S_Audio() {}
-    
-    void start() override {
-        FL_WARN("I2S audio not supported on this ESP32 variant");
-    }
-    
-    void stop() override {
-        FL_WARN("I2S audio not supported on this ESP32 variant");
-    }
-    
-    bool error(fl::string *msg = nullptr) override {
-        if (msg) {
-            *msg = "I2S audio not supported on this ESP32 variant (no I2S hardware)";
-        }
-        return true; // Always in error state
-    }
-    
-    AudioSample read() override {
-        return AudioSample(); // Return invalid sample
-    }
-};
-#endif // !FASTLED_ESP32_I2S_SUPPORTED
 
 } // namespace fl

--- a/src/platforms/esp/32/audio/devices/i2s.hpp
+++ b/src/platforms/esp/32/audio/devices/i2s.hpp
@@ -7,12 +7,13 @@
 
 #include "platforms/esp/esp_version.h"
 
-// Check if I2S is supported on this ESP32 variant
-// ESP32-C2 does not have I2S hardware support
-#if defined(CONFIG_IDF_TARGET_ESP32C2)
-    #define FASTLED_ESP32_I2S_SUPPORTED 0
-#else
-    #define FASTLED_ESP32_I2S_SUPPORTED 1
+// Define I2S support for ESP32 variants that don't have I2S hardware
+#ifndef FASTLED_ESP32_I2S_SUPPORTED
+    #if defined(CONFIG_IDF_TARGET_ESP32C2)
+        #define FASTLED_ESP32_I2S_SUPPORTED 0
+    #else
+        #define FASTLED_ESP32_I2S_SUPPORTED 1
+    #endif
 #endif
 
 #if FASTLED_ESP32_I2S_SUPPORTED
@@ -103,8 +104,13 @@ class I2S_Audio : public IAudioInput {
     fl::u64 mTotalSamplesRead;
 };
 
-#else // !FASTLED_ESP32_I2S_SUPPORTED
+#endif // FASTLED_ESP32_I2S_SUPPORTED
 
+#ifndef FASTLED_ESP32_I2S_SUPPORTED
+#error "FASTLED_ESP32_I2S_SUPPORTED should be defined by this point"
+#endif
+
+#if !FASTLED_ESP32_I2S_SUPPORTED
 // Stub implementation for ESP32 variants without I2S support (e.g., ESP32-C2)
 class I2S_Audio : public IAudioInput {
 public:
@@ -133,7 +139,6 @@ public:
         return AudioSample(); // Return invalid sample
     }
 };
-
-#endif // FASTLED_ESP32_I2S_SUPPORTED
+#endif // !FASTLED_ESP32_I2S_SUPPORTED
 
 } // namespace fl

--- a/src/platforms/esp/32/audio/devices/i2s.hpp
+++ b/src/platforms/esp/32/audio/devices/i2s.hpp
@@ -107,7 +107,38 @@ class I2S_Audio : public IAudioInput {
 #endif // FASTLED_ESP32_I2S_SUPPORTED
 
 #ifndef FASTLED_ESP32_I2S_SUPPORTED
-#error "FASTLED_ESP32_I2S_SUPPORTED should be defined by this point"
+#error "FASTLED_ESP32_I2S_SUPPORTED should be defined by this point"  
 #endif
+
+#if !FASTLED_ESP32_I2S_SUPPORTED
+// Stub implementation for ESP32 variants without I2S support (e.g., ESP32-C2)
+class I2S_Audio : public IAudioInput {
+public:
+    I2S_Audio(const AudioConfigI2S &config) {
+        FL_WARN("I2S audio not supported on this ESP32 variant (no I2S hardware)");
+    }
+    
+    ~I2S_Audio() {}
+    
+    void start() override {
+        FL_WARN("I2S audio not supported on this ESP32 variant");
+    }
+    
+    void stop() override {
+        FL_WARN("I2S audio not supported on this ESP32 variant");
+    }
+    
+    bool error(fl::string *msg = nullptr) override {
+        if (msg) {
+            *msg = "I2S audio not supported on this ESP32 variant (no I2S hardware)";
+        }
+        return true; // Always in error state
+    }
+    
+    AudioSample read() override {
+        return AudioSample(); // Return invalid sample
+    }
+};
+#endif // !FASTLED_ESP32_I2S_SUPPORTED
 
 } // namespace fl

--- a/src/platforms/esp/32/audio/devices/i2s.hpp
+++ b/src/platforms/esp/32/audio/devices/i2s.hpp
@@ -7,13 +7,16 @@
 
 #include "platforms/esp/esp_version.h"
 
-// Define I2S support for ESP32 variants that don't have I2S hardware
+// ESP32-C2 specific detection - no I2S hardware support
 #ifndef FASTLED_ESP32_I2S_SUPPORTED
     #if defined(CONFIG_IDF_TARGET_ESP32C2)
         #define FASTLED_ESP32_I2S_SUPPORTED 0
-    #else
-        #define FASTLED_ESP32_I2S_SUPPORTED 1
     #endif
+#endif
+
+// Default case - assume I2S is supported on other ESP32 variants
+#ifndef FASTLED_ESP32_I2S_SUPPORTED
+    #define FASTLED_ESP32_I2S_SUPPORTED 1
 #endif
 
 #if FASTLED_ESP32_I2S_SUPPORTED
@@ -105,10 +108,6 @@ class I2S_Audio : public IAudioInput {
 };
 
 #endif // FASTLED_ESP32_I2S_SUPPORTED
-
-#ifndef FASTLED_ESP32_I2S_SUPPORTED
-#error "FASTLED_ESP32_I2S_SUPPORTED should be defined by this point"  
-#endif
 
 #if !FASTLED_ESP32_I2S_SUPPORTED
 // Stub implementation for ESP32 variants without I2S support (e.g., ESP32-C2)

--- a/src/platforms/esp/32/audio/devices/i2s.hpp
+++ b/src/platforms/esp/32/audio/devices/i2s.hpp
@@ -110,35 +110,4 @@ class I2S_Audio : public IAudioInput {
 #error "FASTLED_ESP32_I2S_SUPPORTED should be defined by this point"
 #endif
 
-#if !FASTLED_ESP32_I2S_SUPPORTED
-// Stub implementation for ESP32 variants without I2S support (e.g., ESP32-C2)
-class I2S_Audio : public IAudioInput {
-public:
-    I2S_Audio(const AudioConfigI2S &config) {
-        FL_WARN("I2S audio not supported on this ESP32 variant (no I2S hardware)");
-    }
-    
-    ~I2S_Audio() {}
-    
-    void start() override {
-        FL_WARN("I2S audio not supported on this ESP32 variant");
-    }
-    
-    void stop() override {
-        FL_WARN("I2S audio not supported on this ESP32 variant");
-    }
-    
-    bool error(fl::string *msg = nullptr) override {
-        if (msg) {
-            *msg = "I2S audio not supported on this ESP32 variant (no I2S hardware)";
-        }
-        return true; // Always in error state
-    }
-    
-    AudioSample read() override {
-        return AudioSample(); // Return invalid sample
-    }
-};
-#endif // !FASTLED_ESP32_I2S_SUPPORTED
-
 } // namespace fl


### PR DESCRIPTION
Add conditional compilation to disable I2S audio features on ESP32-C2, as it lacks I2S hardware support and caused compilation errors.

The ESP32-C2 compilation failed because the existing I2S audio implementation attempted to use `I2S_CLK_SRC_DEFAULT`, which is undefined for ESP32-C2. Research confirmed that ESP32-C2 does not possess an I2S peripheral, necessitating the conditional exclusion of I2S-specific code for this target.

---
<a href="https://cursor.com/background-agent?bcId=bc-b38f722c-2135-44ff-8633-39a120ae1180">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b38f722c-2135-44ff-8633-39a120ae1180">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

