### PR TITLE
Run and fix kitchensink project

### DIFF
--- a/src/platforms/esp/32/audio/audio_impl.hpp
+++ b/src/platforms/esp/32/audio/audio_impl.hpp
@@ -11,7 +11,7 @@
 namespace fl {
 
 // Static factory method implementation
-fl::shared_ptr<IAudioInput>
+inline fl::shared_ptr<IAudioInput>
 IAudioInput::create(const AudioConfig &config, fl::string *error_message) {
     if (config.is<AudioConfigI2S>()) {
 #if FASTLED_ESP32_I2S_SUPPORTED

--- a/src/platforms/esp/32/audio/devices/idf5_i2s_context.hpp
+++ b/src/platforms/esp/32/audio/devices/idf5_i2s_context.hpp
@@ -25,7 +25,7 @@ struct I2SContext {
     i2s_std_config_t std_config;
 };
 
-I2SContext make_context(const AudioConfigI2S &config) {
+inline I2SContext make_context(const AudioConfigI2S &config) {
     auto detect_slot_mode = [](AudioChannel value) -> i2s_slot_mode_t {
         switch (value) {
         case Left:
@@ -113,7 +113,7 @@ I2SContext make_context(const AudioConfigI2S &config) {
     return out;
 }
 
-I2SContext i2s_audio_init(const AudioConfigI2S &config) {
+inline I2SContext i2s_audio_init(const AudioConfigI2S &config) {
     I2SContext ctx = make_context(config);
 
     // Create I2S channel configuration with DMA buffer settings
@@ -137,7 +137,7 @@ I2SContext i2s_audio_init(const AudioConfigI2S &config) {
     return ctx;
 }
 
-size_t i2s_read_raw_samples(const I2SContext &ctx,
+inline size_t i2s_read_raw_samples(const I2SContext &ctx,
                             audio_sample_t (&buffer)[I2S_AUDIO_BUFFER_LEN]) {
     size_t bytes_read = 0;
 
@@ -153,7 +153,7 @@ size_t i2s_read_raw_samples(const I2SContext &ctx,
     return 0;
 }
 
-void i2s_audio_destroy(const I2SContext &ctx) {
+inline void i2s_audio_destroy(const I2SContext &ctx) {
     if (ctx.rx_handle != nullptr) {
         // Disable the channel first
         i2s_channel_disable(ctx.rx_handle);


### PR DESCRIPTION
Mark ESP32 I2S audio functions as `inline` to resolve multiple definition linker errors.

The `kitchensink` project build was failing due to multiple definition errors for functions like `i2s_read_raw_samples`, `i2s_audio_destroy`, `make_context`, `i2s_audio_init`, and `IAudioInput::create`. These functions were defined in header files (`idf5_i2s_context.hpp` and `audio_impl.hpp`) and included in multiple source files, leading to duplicate symbol definitions during linking. Marking them `inline` ensures they are defined only once per translation unit.

---
<a href="https://cursor.com/background-agent?bcId=bc-745b97ac-0bb6-4fea-8efc-32f6748b9907">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-745b97ac-0bb6-4fea-8efc-32f6748b9907">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

