### PR TITLE
Remove stray `#endif` directive

### DIFF
--- a/src/platforms/arm/mgm240/led_sysdefs_arm_mgm240.h
+++ b/src/platforms/arm/mgm240/led_sysdefs_arm_mgm240.h
@@ -26,5 +26,3 @@
 #ifndef FASTLED_USE_PROGMEM
 #define FASTLED_USE_PROGMEM 0
 #endif
-
-#endif


### PR DESCRIPTION
This `#endif` directive does not have a companion `#if` directive, so it caused compilation of the library for any of the MGM240-based boards to fail:

```
In file included from c:\Users\per\Documents\Arduino\libraries\FastLED\src/led_sysdefs.h:62,
                 from c:\Users\per\Documents\Arduino\libraries\FastLED\src/FastLED.h:76,
                 from C:\Users\per\AppData\Local\Temp\.arduinoIDE-unsaved2025813-31520-l9rljz.363as\Blink\Blink.ino:6:
c:\Users\per\Documents\Arduino\libraries\FastLED\src/platforms/arm/mgm240/led_sysdefs_arm_mgm240.h:30:2: error: #endif without #if
   30 | #endif
      |  ^~~~~
exit status 1
```

Since the stray directive does not appear to have any intended purpose (perhaps it was originally part of a traditional include guard, which was later replaced by the `#pragma once` directive?), the bug is solved by the removal of the directive.