### PR TITLE
Fix Audio advanced.h drawSpectrumBars()

### DIFF
--- a/examples/Audio/advanced/advanced.h
+++ b/examples/Audio/advanced/advanced.h
@@ -195,7 +195,7 @@ void drawSpectrumBars(FFTBins* fft, float /* peak */) {
         int barHeight = magnitude * HEIGHT;
         int xStart = band * barWidth;
         
-        for (int x = 0; x < barWidth - 1; x++) {
+        for (int x = 0; x < MAX(barWidth, 1); x++) {
             for (int y = 0; y < barHeight; y++) {
                 uint8_t colorIndex = fl::map_range<float, uint8_t>(
                     float(y) / HEIGHT, 0, 1, 0, 255


### PR DESCRIPTION
If matrix WIDTH < (2 x NUM_BINS) , then `int barWidth =  WIDTH / NUM_BANDS` = 1 (or even 0). 
So `barWidth - 1` = 0,
So the loop at line 198 ` for (int x = 0; x < barWidth - 1; x++)`  never executes.