### PR TITLE
Find and fix action run issues

### DIFF
--- a/src/platforms/esp/32/parallel_spi/fastled_parallel_spi_esp32c3.hpp
+++ b/src/platforms/esp/32/parallel_spi/fastled_parallel_spi_esp32c3.hpp
@@ -3,6 +3,7 @@
 
 #include "fl/namespace.h"
 #include "fl/stdint.h"
+#include <stddef.h>  // For offsetof
 #include "fl_parallel_spi_isr_rv.h"
 
 #ifdef FL_SPI_ISR_VALIDATE


### PR DESCRIPTION
Add `#include <stddef.h>` to define `offsetof` for ESP32-C3 parallel SPI, fixing a build failure.

The `static_assert` statements in `fastled_parallel_spi_esp32c3.hpp` were using `offsetof` without including the necessary header, leading to compilation errors on ESP32-C3.

---
<a href="https://cursor.com/background-agent?bcId=bc-800bcee6-3813-4d6f-8cad-492819a54eec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-800bcee6-3813-4d6f-8cad-492819a54eec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

