### PR TITLE
Compile esp32dev blink and fix int.h issues

### DIFF
--- a/src/fl/int.h
+++ b/src/fl/int.h
@@ -9,6 +9,7 @@
 // This includes platform-specific 16/32/64-bit types
 #include "platforms/int.h"
 
+#ifdef __cplusplus
 namespace fl {
     // 8-bit types - char is reliably 8 bits on all supported platforms
     // These must be defined BEFORE platform includes so fractional types can use them
@@ -20,9 +21,15 @@ namespace fl {
     // uptr (pointer type) and size (size type) are defined per-platform
 
 }
+#else
+// C language compatibility - define types in global namespace
+typedef signed char i8;
+typedef unsigned char u8;
+typedef unsigned int uint;
+#endif
 
 
-
+#ifdef __cplusplus
 namespace fl {
     ///////////////////////////////////////////////////////////////////////
     ///
@@ -91,3 +98,18 @@ using fl::accum1616;
 using fl::saccum1516;
 using fl::accum124;
 using fl::saccum114;
+#else
+// C language compatibility - define fractional types in global namespace
+typedef u8   fract8;
+typedef i8   sfract7;
+typedef u16  fract16;
+typedef i32  sfract31;
+typedef u32  fract32;
+typedef i16  sfract15;
+typedef u16  accum88;
+typedef i16  saccum78;
+typedef u32  accum1616;
+typedef i32  saccum1516;
+typedef u16  accum124;
+typedef i32  saccum114;
+#endif

--- a/src/fl/stdint.h
+++ b/src/fl/stdint.h
@@ -4,6 +4,7 @@
 // This defines types using primitive types which compiles faster than <stdint.h>
 #include "fl/int.h"
 
+#ifdef __cplusplus
 // Define standard integer type names as aliases to FastLED types in global namespace
 // This avoids the slow <stdint.h> include while maintaining compatibility
 // The compile tests in platforms/compile_test.cpp enforce that fl::u8 == ::uint8_t, etc.
@@ -17,3 +18,9 @@ typedef fl::u64 uint64_t;
 typedef fl::i64 int64_t;
 typedef fl::size size_t;
 typedef fl::uptr uintptr_t;
+#else
+// C language compatibility - types are already defined in global namespace by fl/int.h
+// Include standard headers to ensure compatibility
+#include <stdint.h>
+#include <stddef.h>
+#endif

--- a/src/platforms/esp/int.h
+++ b/src/platforms/esp/int.h
@@ -3,6 +3,7 @@
 #include <stdint.h>
 #include <stddef.h>
 
+#ifdef __cplusplus
 namespace fl {
     // ESP platforms (ESP8266/ESP32): Like ARM platforms, uint32_t and int32_t are 'unsigned long' and 'long'
     // This matches the Xtensa toolchain behavior similar to ARM toolchains
@@ -18,3 +19,14 @@ namespace fl {
     typedef size_t size;
     typedef uintptr_t uptr;
 }
+#else
+// C language compatibility - define types in global namespace
+typedef short i16;
+typedef unsigned short u16;
+typedef int32_t i32;
+typedef uint32_t u32;
+typedef long long i64;
+typedef unsigned long long u64;
+typedef size_t size;
+typedef uintptr_t uptr;
+#endif


### PR DESCRIPTION
Add C/C++ compatibility guards and C-compatible type definitions to FastLED headers to enable compilation of C files that include them.

C files in the ESP32 LED strip library were failing to compile because they included FastLED headers (`fl/stdint.h` and `fl/int.h`) which contained C++ features (namespaces and `using` statements) incompatible with C compilers. This PR wraps C++-specific code with `#ifdef __cplusplus` and provides C-compatible type definitions.

---
<a href="https://cursor.com/background-agent?bcId=bc-034a96be-2510-4cdb-916a-c7b93f6b5d2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-034a96be-2510-4cdb-916a-c7b93f6b5d2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

