### PR TITLE
Move integer type definitions to fl/int.h

### DIFF
--- a/src/fl/stdint.h
+++ b/src/fl/stdint.h
@@ -39,12 +39,11 @@ typedef short int16_t;
 // This ensures we match the platform's type sizes correctly
 typedef fl::u32 uint32_t;
 typedef fl::i32 int32_t;
+typedef fl::u64 uint64_t;
+typedef fl::i64 int64_t;
 typedef fl::size size_t;
 typedef fl::uptr uintptr_t;
 typedef fl::ptrdiff ptrdiff_t;
-
-typedef unsigned long long uint64_t;
-typedef long long int64_t;
 
 // stdint.h limit macros
 // These match the standard stdint.h definitions


### PR DESCRIPTION
Refactor `uint64_t` and `int64_t` definitions in `fl/stdint.h` to use `fl::u64` and `fl::i64` for consistency and platform-awareness.

This change aligns the 64-bit integer typedefs with the existing pattern used for 32-bit types (`uint32_t` -> `fl::u32`), ensuring all standard integer types leverage platform-specific `fl::` types. No changes were required in `platforms/*/int.h` as `fl::i64` and `fl::u64` were already correctly defined there.

---
<a href="https://cursor.com/background-agent?bcId=bc-77e05129-8c4f-4ef7-91a8-c8a53a9071ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-77e05129-8c4f-4ef7-91a8-c8a53a9071ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

