### PR TITLE
Compile uno Blink project

### DIFF
--- a/src/fl/corkscrew.cpp
+++ b/src/fl/corkscrew.cpp
@@ -123,7 +123,7 @@ vec2f Corkscrew::at_exact(fl::u16 i) const {
     vec2f position = at_no_wrap(i);
     
     // Apply cylindrical wrapping to the x-position (like at_wrap does)
-    position.x = fmodf(position.x, static_cast<float>(mWidth));
+    position.x = fl::fmod(position.x, static_cast<float>(mWidth));
     
     return position;
 }
@@ -139,8 +139,8 @@ Tile2x2_u8 Corkscrew::at_splat_extrapolate(float i) const {
     }
     
     // Use the splat function to convert the vec2f to a Tile2x2_u8
-    float i_floor = floorf(i);
-    float i_ceil = ceilf(i);
+    float i_floor = fl::floor(i);
+    float i_ceil = fl::ceil(i);
     if (FL_ALMOST_EQUAL_FLOAT(i_floor, i_ceil)) {
         // If the index is the same, just return the splat of that index
         vec2f position = at_no_wrap(static_cast<fl::u16>(i_floor));
@@ -186,7 +186,7 @@ Tile2x2_u8_wrap Corkscrew::calculateTileAtWrap(float i) const {
             // is mapped to the correct position on the cylinder.
             vec2<u16> pos = origin + vec2<u16>(x, y);
             // now wrap the x-position
-            pos.x = fmodf(pos.x, static_cast<float>(mWidth));
+            pos.x = static_cast<u16>(fl::fmod(static_cast<float>(pos.x), static_cast<float>(mWidth)));
             data[x][y] = {pos, tile.at(x, y)};
         }
     }

--- a/src/fl/math.cpp
+++ b/src/fl/math.cpp
@@ -109,4 +109,87 @@ double sqrt_impl(double value) {
     return guess;
 }
 
+// Standalone sin implementation using Taylor series
+// sin(x) ≈ x - x³/3! + x⁵/5! - x⁷/7! + ...
+float sin_impl(float x) {
+    // Reduce angle to [-π, π] range
+    const float PI = 3.14159265358979323846f;
+    const float TWO_PI = 2.0f * PI;
+    
+    while (x > PI) x -= TWO_PI;
+    while (x < -PI) x += TWO_PI;
+    
+    // Taylor series approximation
+    float result = x;
+    float term = x;
+    float x_squared = x * x;
+    
+    // Calculate up to x^9 term for reasonable accuracy
+    for (int i = 1; i <= 4; ++i) {
+        term *= -x_squared / ((2 * i) * (2 * i + 1));
+        result += term;
+    }
+    
+    return result;
+}
+
+double sin_impl(double x) {
+    const double PI = 3.14159265358979323846;
+    const double TWO_PI = 2.0 * PI;
+    
+    while (x > PI) x -= TWO_PI;
+    while (x < -PI) x += TWO_PI;
+    
+    double result = x;
+    double term = x;
+    double x_squared = x * x;
+    
+    for (int i = 1; i <= 6; ++i) {
+        term *= -x_squared / ((2 * i) * (2 * i + 1));
+        result += term;
+    }
+    
+    return result;
+}
+
+// Standalone cos implementation using Taylor series
+// cos(x) ≈ 1 - x²/2! + x⁴/4! - x⁶/6! + ...
+float cos_impl(float x) {
+    const float PI = 3.14159265358979323846f;
+    const float TWO_PI = 2.0f * PI;
+    
+    while (x > PI) x -= TWO_PI;
+    while (x < -PI) x += TWO_PI;
+    
+    float result = 1.0f;
+    float term = 1.0f;
+    float x_squared = x * x;
+    
+    for (int i = 1; i <= 4; ++i) {
+        term *= -x_squared / ((2 * i - 1) * (2 * i));
+        result += term;
+    }
+    
+    return result;
+}
+
+double cos_impl(double x) {
+    const double PI = 3.14159265358979323846;
+    const double TWO_PI = 2.0 * PI;
+    
+    while (x > PI) x -= TWO_PI;
+    while (x < -PI) x += TWO_PI;
+    
+    double result = 1.0;
+    double term = 1.0;
+    double x_squared = x * x;
+    
+    for (int i = 1; i <= 6; ++i) {
+        term *= -x_squared / ((2 * i - 1) * (2 * i));
+        result += term;
+    }
+    
+    return result;
+}
+
 } // namespace fl

--- a/src/fl/math.h
+++ b/src/fl/math.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "fl/clamp.h"
-#include "fl/map_range.h"
 #include "fl/math_macros.h"
 
 namespace fl {
@@ -15,6 +14,10 @@ float exp_impl(float value);
 double exp_impl(double value);
 float sqrt_impl(float value);
 double sqrt_impl(double value);
+float sin_impl(float value);
+double sin_impl(double value);
+float cos_impl(float value);
+double cos_impl(double value);
 
 template <typename T> inline T floor(T value) {
     if (value >= 0) {
@@ -38,6 +41,24 @@ template <typename T> inline T exp(T value) {
 // Square root using Newton-Raphson method
 template <typename T> inline T sqrt(T value) {
     return static_cast<T>(sqrt_impl(static_cast<float>(value)));
+}
+
+// Floating point modulo operation: fmod(x, y) = x - floor(x/y) * y
+// This is compatible with platforms that don't have fmodf() in their math library
+template <typename T> inline T fmod(T x, T y) {
+    if (y == 0) {
+        return static_cast<T>(0);  // Avoid division by zero
+    }
+    return x - floor(x / y) * y;
+}
+
+// Trigonometric functions
+template <typename T> inline T sin(T value) {
+    return static_cast<T>(sin_impl(static_cast<float>(value)));
+}
+
+template <typename T> inline T cos(T value) {
+    return static_cast<T>(cos_impl(static_cast<float>(value)));
 }
 
 // Constexpr version for compile-time evaluation (compatible with older C++
@@ -66,3 +87,7 @@ constexpr int ceil_constexpr(float value) {
 // }
 
 } // namespace fl
+
+// Include map_range.h at the end to avoid circular dependency issues
+// geometry.h (included by map_range.h) uses fl::sqrt which must be defined first
+#include "fl/map_range.h"

--- a/src/fl/screenmap.cpp
+++ b/src/fl/screenmap.cpp
@@ -78,8 +78,8 @@ ScreenMap ScreenMap::Circle(int numLeds, float cm_between_leds,
 
     for (int i = 0; i < numLeds; ++i) {
         float angle = startAngle + (i * totalAngle) / divisor;
-        float x = radius * cos(angle) * 2;
-        float y = radius * sin(angle) * 2;
+        float x = radius * fl::cos(angle) * 2;
+        float y = radius * fl::sin(angle) * 2;
         screenMap[i] = {x, y};
     }
 

--- a/src/fl/splat.cpp
+++ b/src/fl/splat.cpp
@@ -17,8 +17,8 @@ Tile2x2_u8 splat(vec2f xy) {
     float y = xy.y;
 
     // 2) integer cell indices
-    i16 cx = static_cast<i16>(floorf(x));
-    i16 cy = static_cast<i16>(floorf(y));
+    i16 cx = static_cast<i16>(fl::floor(x));
+    i16 cy = static_cast<i16>(fl::floor(y));
 
     // 3) fractional offsets in [0..1)
     float fx = x - cx;

--- a/src/fl/stdint.h
+++ b/src/fl/stdint.h
@@ -25,25 +25,54 @@
 #include "fl/int.h"
 #include "fl/cstddef.h"
 
+// On Arduino platforms, the system headers will define these types
+// We must use the system definitions to avoid conflicts
+#if defined(ARDUINO) && !defined(__EMSCRIPTEN__)
+    // Arduino platform - use system stdint.h
+    #include <stdint.h>  // ok include - required for Arduino compatibility
+#else
+    // Non-Arduino platforms - define our own types for faster compilation
+    // IMPORTANT: Only define these if system headers haven't already defined them
+    //            Guard against redefinition conflicts with system <stdint.h>
+    
+    // Check if system stdint.h has already been included
+    // If so, skip our typedefs to avoid conflicts
+    #if !defined(_STDINT_H) && !defined(_STDINT_H_) && !defined(_STDINT) && !defined(__STDINT_H) && !defined(_GCC_STDINT_H) && !defined(_GCC_WRAP_STDINT_H)
+    
+    // Only define basic integer types if system headers haven't
+    typedef unsigned char uint8_t;
+    typedef signed char int8_t;
+    typedef unsigned short uint16_t;
+    typedef short int16_t;
+    typedef fl::u32 uint32_t;
+    typedef fl::i32 int32_t;
+    typedef fl::u64 uint64_t;
+    typedef fl::i64 int64_t;
+    
+    #endif // !defined(_STDINT_H) && ...
+#endif // defined(ARDUINO)
 
-// Define standard integer type names using raw primitive types
-// This avoids the slow <stdint.h> include while maintaining compatibility
-// IMPORTANT: Use raw primitive types (not fl:: typedefs) to match system headers exactly
-//            This allows duplicate typedefs when system headers are also included
-typedef unsigned char uint8_t;
-typedef signed char int8_t;
-typedef unsigned short uint16_t;
-typedef short int16_t;
+// Define size_t, uintptr_t, ptrdiff_t using fl:: types
+// Only define these if not already defined by system headers
+// On Arduino platforms, these are already defined by system headers
 
-// Define standard types using fl:: types from platform-specific int.h
-// This ensures we match the platform's type sizes correctly
-typedef fl::u32 uint32_t;
-typedef fl::i32 int32_t;
-typedef fl::u64 uint64_t;
-typedef fl::i64 int64_t;
-typedef fl::size size_t;
-typedef fl::uptr uintptr_t;
-typedef fl::ptrdiff ptrdiff_t;
+#if !defined(ARDUINO) || defined(__EMSCRIPTEN__)
+    // Non-Arduino platforms - define our own types
+    #ifndef _SIZE_T_DEFINED
+    typedef fl::size size_t;
+    #define _SIZE_T_DEFINED
+    #endif
+    
+    #ifndef _UINTPTR_T_DEFINED  
+    typedef fl::uptr uintptr_t;
+    #define _UINTPTR_T_DEFINED
+    #endif
+    
+    #ifndef _PTRDIFF_T_DEFINED
+    typedef fl::ptrdiff ptrdiff_t;
+    #define _PTRDIFF_T_DEFINED
+    #endif
+#endif // !defined(ARDUINO) || defined(__EMSCRIPTEN__)
 
 // stdint.h limit macros
 // These match the standard stdint.h definitions


### PR DESCRIPTION
Refactor FastLED's math and stdint headers to enable compilation on Arduino (AVR) platforms.

The compilation of the `Blink` example for Arduino UNO failed due to several platform-specific issues:
1.  **`stdint.h` conflicts:** FastLED's custom `stdint.h` definitions conflicted with AVR's system headers. This was resolved by conditionally including the system `<stdint.H>` on Arduino and adding robust include guards for custom types.
2.  **Missing math functions:** AVR platforms lack certain float-specific math functions (`fmodf`, `sinf`, `cosf`, `floorf`, `ceilf`). FastLED's own implementations were added to `fl/math.h` and `fl/math.cpp`, and existing code was updated to use these `fl::` versions.
3.  **Circular include:** A circular dependency between `fl/math.h` and `fl/geometry.h` (via `fl/map_range.h`) was resolved by reordering includes.

These changes allow the core FastLED library to compile successfully on Arduino platforms, addressing the initial compilation failures.

---
<a href="https://cursor.com/background-agent?bcId=bc-55ec7712-5841-471f-93f3-b1b1923715bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-55ec7712-5841-471f-93f3-b1b1923715bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

