### PR TITLE
Add ESP32P4 to specialized ws2812 drivers

### DIFF
--- a/src/platforms/chipsets_specialized_ws2812.h
+++ b/src/platforms/chipsets_specialized_ws2812.h
@@ -49,6 +49,15 @@ class WS2812Controller800Khz:
 		RGB_ORDER
 	> {};
 #define FASTLED_WS2812_HAS_SPECIAL_DRIVER 1
+#elif defined(FASTLED_ESP32_LCD_RGB_DRIVER) && defined(CONFIG_IDF_TARGET_ESP32P4)
+#include "platforms/esp/32/clockless_lcd_rgb_esp32.h"
+template <fl::u8 DATA_PIN, EOrder RGB_ORDER = fl::GRB>
+class WS2812Controller800Khz:
+	public fl::ClocklessController_LCD_RGB_WS2812<
+		DATA_PIN,
+		RGB_ORDER
+	> {};
+#define FASTLED_WS2812_HAS_SPECIAL_DRIVER 1
 #elif defined(FASTLED_USES_ESP32P4_PARLIO)
 #include "platforms/esp/32/clockless_parlio_esp32p4.h"
 template <fl::u8 DATA_PIN, EOrder RGB_ORDER = fl::GRB>


### PR DESCRIPTION
When I told you before that I got the ESP32P4 LCD RGB driver working, I was mistaken. I had not tested my sketch with more than 4 pins, and even though I had defined FASTLED_ESP32_LCD_RGB_DRIVER, it was actually still using RMT. I discovered the issue when I tried running my sketch with 6 pins, and I traced the problem back to this. 

This particular issue would not show up for anyone using the ESP32-P4 LCD RGB parallel driver demo example either, as that sketch uses only 4 pins. It would probably be a good idea to start using more than 4 pins in tests and examples of the new parallel drivers being added.

  