### PR TITLE
Fix allocator.cpp memset error

### DIFF
--- a/src/fl/allocator.cpp
+++ b/src/fl/allocator.cpp
@@ -79,7 +79,7 @@ void *PSRamAllocate(fl::size size, bool zero) {
 
     void *ptr = Alloc(size);
     if (ptr && zero) {
-        memset(ptr, 0, size);
+        fl::memfill(ptr, 0, size);
     }
     
 #if defined(FASTLED_TESTING)


### PR DESCRIPTION
Replace `memset` with `fl::memfill` to resolve a compilation error on the UNO platform and adhere to FastLED's internal utility conventions.

The `memset` function was causing a 'not declared in scope' error during compilation for the UNO platform, likely due to missing standard library headers. Using `fl::memfill` ensures platform compatibility and aligns with the project's practice of using its own utility functions.

---
<a href="https://cursor.com/background-agent?bcId=bc-09efa422-e98f-48ac-972d-cabf99b47708"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-09efa422-e98f-48ac-972d-cabf99b47708"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

