### PR TITLE
Fix missing null definition in libnsgif

### DIFF
--- a/src/third_party/cq_kernel/cq_kernel.cpp
+++ b/src/third_party/cq_kernel/cq_kernel.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <stddef.h>  // For NULL definition
+
 #include "fl/math.h"
 #include "fl/string.h"
 #include "fl/malloc.h"

--- a/src/third_party/cq_kernel/kiss_fft.cpp
+++ b/src/third_party/cq_kernel/kiss_fft.cpp
@@ -6,6 +6,8 @@
  *  See COPYING file for more information.
  */
 
+#include <stddef.h>  // For NULL definition
+
 #include "fl/str.h"
 #include "fl/memfill.h"  // for fl::memfill() and fl::memcopy()
 #include "_kiss_fft_guts.h"

--- a/src/third_party/cq_kernel/kiss_fftr.cpp
+++ b/src/third_party/cq_kernel/kiss_fftr.cpp
@@ -6,6 +6,8 @@
  *  See COPYING file for more information.
  */
 
+#include <stddef.h>  // For NULL definition
+
 #include "fl/stdio.h"
 #include "kiss_fftr.h"
 #include "_kiss_fft_guts.h"

--- a/src/third_party/libnsgif/src/gif.cpp
+++ b/src/third_party/libnsgif/src/gif.cpp
@@ -8,6 +8,8 @@
  *                http://www.opensource.org/licenses/mit-license.php
  */
 
+#include <stddef.h>  // For NULL definition
+
 #include "fl/assert.h"
 #include "fl/int.h"
 #include "fl/allocator.h"

--- a/src/third_party/libnsgif/src/lzw.cpp
+++ b/src/third_party/libnsgif/src/lzw.cpp
@@ -7,6 +7,8 @@
  * Copyright 2021 Michael Drake <tlsa@netsurf-browser.org>
  */
 
+#include <stddef.h>  // For NULL definition
+
 #include "fl/assert.h"
 #include "fl/int.h"
 #include "fl/allocator.h"

--- a/src/third_party/pl_mpeg/src/pl_mpeg.hpp
+++ b/src/third_party/pl_mpeg/src/pl_mpeg.hpp
@@ -151,6 +151,8 @@ See below for detailed the API documentation.
 
 // Include headers outside the namespace to avoid conflicts
 
+#include <stddef.h>  // For NULL definition
+
 #include "fl/stdint.h"
 #include "fl/math.h"
 #include "fl/math_macros.h"

--- a/tests/test_strstream.cpp
+++ b/tests/test_strstream.cpp
@@ -165,10 +165,10 @@ TEST_CASE("StrStream integer type handling") {
 
         // Verify output contains expected values
         const char* result = s.str().c_str();
-        CHECK(strstr(result, "-10") != nullptr);
-        CHECK(strstr(result, "200") != nullptr);
-        CHECK(strstr(result, "-1000") != nullptr);
-        CHECK(strstr(result, "50000") != nullptr);
+        CHECK(fl::strstr(result, "-10") != nullptr);
+        CHECK(fl::strstr(result, "200") != nullptr);
+        CHECK(fl::strstr(result, "-1000") != nullptr);
+        CHECK(fl::strstr(result, "50000") != nullptr);
     }
 
     SUBCASE("fl:: types work correctly") {
@@ -185,10 +185,10 @@ TEST_CASE("StrStream integer type handling") {
         s << i32v << " " << u32v;
 
         const char* result = s.str().c_str();
-        CHECK(strstr(result, "-10") != nullptr);
-        CHECK(strstr(result, "200") != nullptr);
-        CHECK(strstr(result, "-1000") != nullptr);
-        CHECK(strstr(result, "50000") != nullptr);
+        CHECK(fl::strstr(result, "-10") != nullptr);
+        CHECK(fl::strstr(result, "200") != nullptr);
+        CHECK(fl::strstr(result, "-1000") != nullptr);
+        CHECK(fl::strstr(result, "50000") != nullptr);
     }
 
     SUBCASE("chaining multiple types") {
@@ -262,7 +262,7 @@ TEST_CASE("StrStream comprehensive fl:: integer types") {
         StrStream s;
         fl::size val = 12345;
         s << val;
-        CHECK(strstr(s.str().c_str(), "12345") != nullptr);
+        CHECK(fl::strstr(s.str().c_str(), "12345") != nullptr);
     }
 
     SUBCASE("fl::uptr") {
@@ -276,14 +276,14 @@ TEST_CASE("StrStream comprehensive fl:: integer types") {
         StrStream s;
         fl::iptr val = -5000;
         s << val;
-        CHECK(strstr(s.str().c_str(), "-5000") != nullptr);
+        CHECK(fl::strstr(s.str().c_str(), "-5000") != nullptr);
     }
 
     SUBCASE("fl::ptrdiff") {
         StrStream s;
         fl::ptrdiff val = -1234;
         s << val;
-        CHECK(strstr(s.str().c_str(), "-1234") != nullptr);
+        CHECK(fl::strstr(s.str().c_str(), "-1234") != nullptr);
     }
 
     SUBCASE("fl::uint") {
@@ -349,14 +349,14 @@ TEST_CASE("StrStream comprehensive fundamental integer types") {
         StrStream s;
         long val = -1000000L;
         s << val;
-        CHECK(strstr(s.str().c_str(), "-1000000") != nullptr);
+        CHECK(fl::strstr(s.str().c_str(), "-1000000") != nullptr);
     }
 
     SUBCASE("unsigned long") {
         StrStream s;
         unsigned long val = 4000000000UL;
         s << val;
-        CHECK(strstr(s.str().c_str(), "4000000000") != nullptr);
+        CHECK(fl::strstr(s.str().c_str(), "4000000000") != nullptr);
     }
 
     SUBCASE("long long") {
@@ -477,10 +477,10 @@ TEST_CASE("StrStream mixed type chains") {
           << fl::u64(1000000000ULL);
 
         const char* result = s.str().c_str();
-        CHECK(strstr(result, "-10") != nullptr);
-        CHECK(strstr(result, "50000") != nullptr);
-        CHECK(strstr(result, "-100000") != nullptr);
-        CHECK(strstr(result, "1000000000") != nullptr);
+        CHECK(fl::strstr(result, "-10") != nullptr);
+        CHECK(fl::strstr(result, "50000") != nullptr);
+        CHECK(fl::strstr(result, "-100000") != nullptr);
+        CHECK(fl::strstr(result, "1000000000") != nullptr);
     }
 
     SUBCASE("mixed fundamental types") {
@@ -491,10 +491,10 @@ TEST_CASE("StrStream mixed type chains") {
           << (unsigned long long)(1000000000ULL);
 
         const char* result = s.str().c_str();
-        CHECK(strstr(result, "-10") != nullptr);
-        CHECK(strstr(result, "50000") != nullptr);
-        CHECK(strstr(result, "-100000") != nullptr);
-        CHECK(strstr(result, "1000000000") != nullptr);
+        CHECK(fl::strstr(result, "-10") != nullptr);
+        CHECK(fl::strstr(result, "50000") != nullptr);
+        CHECK(fl::strstr(result, "-100000") != nullptr);
+        CHECK(fl::strstr(result, "1000000000") != nullptr);
     }
 
     SUBCASE("fl:: and fundamental types mixed") {
@@ -505,9 +505,9 @@ TEST_CASE("StrStream mixed type chains") {
           << (unsigned long)(4000000000UL);
 
         const char* result = s.str().c_str();
-        CHECK(strstr(result, "-10") != nullptr);
-        CHECK(strstr(result, "-1000") != nullptr);
-        CHECK(strstr(result, "4000000") != nullptr);
+        CHECK(fl::strstr(result, "-10") != nullptr);
+        CHECK(fl::strstr(result, "-1000") != nullptr);
+        CHECK(fl::strstr(result, "4000000") != nullptr);
     }
 }
 
@@ -543,10 +543,10 @@ TEST_CASE("StrStream edge value testing") {
         s << fl::u32(4294967295U);              // max u32
 
         const char* result = s.str().c_str();
-        CHECK(strstr(result, "-2147483647") != nullptr);
-        CHECK(strstr(result, "2147483647") != nullptr);
-        CHECK(strstr(result, "0") != nullptr);
-        CHECK(strstr(result, "4294967295") != nullptr);
+        CHECK(fl::strstr(result, "-2147483647") != nullptr);
+        CHECK(fl::strstr(result, "2147483647") != nullptr);
+        CHECK(fl::strstr(result, "0") != nullptr);
+        CHECK(fl::strstr(result, "4294967295") != nullptr);
     }
 }
 
@@ -560,9 +560,9 @@ TEST_CASE("StrStream const and volatile qualifiers") {
         s << ci32 << " " << cu32 << " " << ci16;
         CHECK(s.str().size() > 0);
         const char* result = s.str().c_str();
-        CHECK(strstr(result, "100") != nullptr);
-        CHECK(strstr(result, "200") != nullptr);
-        CHECK(strstr(result, "300") != nullptr);
+        CHECK(fl::strstr(result, "100") != nullptr);
+        CHECK(fl::strstr(result, "200") != nullptr);
+        CHECK(fl::strstr(result, "300") != nullptr);
     }
 
     SUBCASE("volatile integer types") {
@@ -573,8 +573,8 @@ TEST_CASE("StrStream const and volatile qualifiers") {
         s << vu32 << " " << vi16;
         CHECK(s.str().size() > 0);
         const char* result = s.str().c_str();
-        CHECK(strstr(result, "200") != nullptr);
-        CHECK(strstr(result, "-300") != nullptr);
+        CHECK(fl::strstr(result, "200") != nullptr);
+        CHECK(fl::strstr(result, "-300") != nullptr);
     }
 
     SUBCASE("const volatile integer types") {
@@ -585,8 +585,8 @@ TEST_CASE("StrStream const and volatile qualifiers") {
         s << cvi16 << " " << cvu8;
         CHECK(s.str().size() > 0);
         const char* result = s.str().c_str();
-        CHECK(strstr(result, "300") != nullptr);
-        CHECK(strstr(result, "255") != nullptr);
+        CHECK(fl::strstr(result, "300") != nullptr);
+        CHECK(fl::strstr(result, "255") != nullptr);
     }
 }
 
@@ -722,8 +722,8 @@ TEST_CASE("StrStream platform-specific aliased types") {
         CHECK(s.str().size() > 0);
 
         const char* result = s.str().c_str();
-        CHECK(strstr(result, "100") != nullptr);
-        CHECK(strstr(result, "100000") != nullptr);
+        CHECK(fl::strstr(result, "100") != nullptr);
+        CHECK(fl::strstr(result, "100000") != nullptr);
     }
 
     SUBCASE("pointer-sized types") {

--- a/tests/test_ui.cpp
+++ b/tests/test_ui.cpp
@@ -523,7 +523,7 @@ TEST_CASE("JsonConsole dump function") {
     
     // Helper function to check if string contains substring
     auto contains = [](const fl::string& str, const char* substr) {
-        return strstr(str.c_str(), substr) != nullptr;
+        return fl::strstr(str.c_str(), substr) != nullptr;
     };
     
     // Test 1: Uninitialized JsonConsole dump


### PR DESCRIPTION
Add `<stddef.h>` to third-party files to define `NULL` and fix `strstr` ambiguity in tests.

The original build failure was due to `NULL` not being declared, which was resolved by including `<stddef.h>` in several third-party C++ files. This also exposed `strstr` ambiguity errors in the test suite, which were resolved by explicitly using `fl::strstr`.

---
<a href="https://cursor.com/background-agent?bcId=bc-c1e3df2a-b06e-461a-ab04-28261d1c9a4f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c1e3df2a-b06e-461a-ab04-28261d1c9a4f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

