### PR TITLE
hd108: Initial working state

### DIFF
--- a/src/FastLED.h
+++ b/src/FastLED.h
@@ -137,7 +137,7 @@ enum ESPIChipsets {
 	APA102HD, ///< APA102 LED chipset with 5-bit gamma correction
 	HD107,  /// Same as APA102, but in turbo 40-mhz mode.
 	HD107HD,  /// Same as APA102HD, but in turbo 40-mhz mode.
-	HD108,  /// 16bit HD108 variant of HD107
+	HD108,  /// 16bit variant of HD107, always gamma corrected.
 
 };
 


### PR DESCRIPTION
I'm throwing this quickly here for feedback and maybe it's even useful for someone who accidentally bought such an LED strip (didn't expect these strips where so exotic!).

It's a really basic implementation that simply scales the 8bit values to 16. It looks pretty good to me but I have very little reference. Maybe HD108 should rather be HD108_SD.... If people are interested I can make a quick video showing how this looks.

Tested on:
- Teensy 4.1 using 30mhz SPI (40 should work but my setup is far from ideal noise wise, so it's a little flickery at above 30, I will redo some tests with better wiring later)
- Also on an Uno R4, obviously there it can't keep up with the 20mhz SPI but it does what it can :) (was just easier to debug with my logic analyser)
- a 43 LED long strip (future me shall use a smaller test strip...)
- This is the strip I used, https://www.superlightingled.com/hd108-ic-individually-addressable-led-rgb-full-color-changing-digital-flexible-dc5v-led-strip-lights-p-4522.html

A few disclaimers:
- it's the first RGB LED strip I use so I have no reference point, I also cheated to try get the blues a little brighter, not sure if this is the right place for it
- I've never used fastled before, and I will run the linters etc, just didn't get round to it on this winpc and figured feedback is probably good before I go further
- tried to follow the coding style of the controllers before me but seems it's not fully consistent so that's what i have

Partially implements #1885 , #1045

Quick demo: https://www.youtube.com/shorts/joDvO3hzpU8
