### PR TITLE
Add missing entry for io_esp.cpp to CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ file(GLOB FastLED_SENSORS_SRCS "src/sensors/*.cpp")
 file(GLOB FastLED_PLATFORM_ARDUINO_SRCS "src/platforms/arduino/*.cpp")
 file(GLOB FastLED_FX_SRCS "src/fx/*.cpp" "src/fx/**/*.cpp")
 
-file(GLOB ESP32_SRCS "src/platforms/esp/32/*.cpp" "src/platforms/esp/32/rmt_5/*.cpp")
+file(GLOB ESP32_SRCS "src/platforms/esp/*.cpp" "src/platforms/esp/32/*.cpp" "src/platforms/esp/32/rmt_5/*.cpp")
 file(GLOB ESP32_THIRD_PARTY_SRCS "src/third_party/**/src/*.c" "src/third_party/**/src/*.cpp")
 file(GLOB ESP32_LED_STRIP_SRCS "src/third_party/espressif/led_strip/src/*.cpp")
 


### PR DESCRIPTION
As in title: io_esp_cpp isn't picked up by IDF so building fails at linking stage.

