### PR TITLE
STM32 include guard improves

### DIFF
--- a/src/platforms/arm/stm32/armpin.h
+++ b/src/platforms/arm/stm32/armpin.h
@@ -1,4 +1,5 @@
 #pragma once
+
 #include "fl/stl/stdint.h"
 #include "fl/fastpin_base.h"
 

--- a/src/platforms/arm/stm32/clockless_arm_stm32.h
+++ b/src/platforms/arm/stm32/clockless_arm_stm32.h
@@ -1,5 +1,4 @@
-#ifndef __INC_CLOCKLESS_ARM_STM32_H
-#define __INC_CLOCKLESS_ARM_STM32_H
+#pragma once
 
 #include "fl/chipsets/timing_traits.h"
 #include "fl/stl/vector.h"
@@ -165,5 +164,3 @@ protected:
 };
 
 }  // namespace fl
-
-#endif

--- a/src/platforms/arm/stm32/cm3_regs.h
+++ b/src/platforms/arm/stm32/cm3_regs.h
@@ -1,6 +1,5 @@
 // ok no namespace fl
-#ifndef __CM3_REGS
-#define __CM3_REGS
+#pragma once
 
 #include "fl/stl/stdint.h"
 
@@ -60,5 +59,3 @@ typedef struct
 
 #define DWT_CTRL_CYCCNTENA_Pos              0                                          /*!< DWT CTRL: CYCCNTENA Position */
 #define DWT_CTRL_CYCCNTENA_Msk             (0x1UL << DWT_CTRL_CYCCNTENA_Pos)           /*!< DWT CTRL: CYCCNTENA Mask */
-
-#endif // __CM3_REGS

--- a/src/platforms/arm/stm32/delay.h
+++ b/src/platforms/arm/stm32/delay.h
@@ -1,8 +1,5 @@
 #pragma once
 
-#ifndef __INC_FASTLED_PLATFORMS_STM32_DELAY_H
-#define __INC_FASTLED_PLATFORMS_STM32_DELAY_H
-
 #include "platforms/cycle_type.h"
 #include "fl/force_inline.h"
 
@@ -42,5 +39,3 @@ FASTLED_FORCE_INLINE void delayNanoseconds_impl(u32 ns) {
 }
 
 }  // namespace fl
-
-#endif // __INC_FASTLED_PLATFORMS_STM32_DELAY_H

--- a/src/platforms/arm/stm32/delaycycles.h
+++ b/src/platforms/arm/stm32/delaycycles.h
@@ -1,9 +1,6 @@
 // ok no namespace fl
 #pragma once
 
-#ifndef __INC_FASTLED_PLATFORMS_STM32_DELAYCYCLES_H
-#define __INC_FASTLED_PLATFORMS_STM32_DELAYCYCLES_H
-
 #include "platforms/cycle_type.h"
 #include "fl/force_inline.h"
 
@@ -33,5 +30,3 @@ FASTLED_FORCE_INLINE void delay_cycles_dwt_arm(fl::u32 cycles) {
   fl::u32 start = dwt_cyccnt_arm();
   while ((fl::u32)(dwt_cyccnt_arm() - start) < cycles) { }
 }
-
-#endif  // __INC_FASTLED_PLATFORMS_STM32_DELAYCYCLES_H

--- a/src/platforms/arm/stm32/fastled_arm_stm32.h
+++ b/src/platforms/arm/stm32/fastled_arm_stm32.h
@@ -1,10 +1,7 @@
 // ok no namespace fl
-#ifndef __INC_FASTLED_ARM_SAM_H
-#define __INC_FASTLED_ARM_SAM_H
+#pragma once
 
-// Include the sam headers
+// Include the stm32 headers
 #include "fastpin_arm_stm32.h"
 #include "fastspi_arm_stm32.h"
 #include "clockless_arm_stm32.h"
-
-#endif

--- a/src/platforms/arm/stm32/fastpin_arm_stm_legacy.h
+++ b/src/platforms/arm/stm32/fastpin_arm_stm_legacy.h
@@ -1,5 +1,4 @@
-#ifndef __FASTPIN_ARM_STM32_H
-#define __FASTPIN_ARM_STM32_H
+#pragma once
 
 #include "fl/force_inline.h"
 #include "armpin.h"
@@ -210,7 +209,7 @@ _FL_DEFPIN(36, 1, D);
 #define MAX_PIN 36
 
 // Generic STM32F1/F4 pin layout - covers most stm32duino boards including:
-// - STM32F103 variants (Blue Pill, etc.)  
+// - STM32F103 variants (Blue Pill, etc.)
 // - STM32F411CE (WeAct Black Pill V2.0)
 // - Other STM32F1/F4 boards with standard GPIO layout
 
@@ -261,7 +260,7 @@ _FL_DEFPIN(36, 1, D);
 
 // SPI2 MOSI
 #define SPI_DATA PB_15
-// SPI2 SCK  
+// SPI2 SCK
 #define SPI_CLOCK PB_13
 
 #define HAS_HARDWARE_PIN_SUPPORT
@@ -269,5 +268,3 @@ _FL_DEFPIN(36, 1, D);
 #endif // STM32F1 or STM32F4
 
 }  // namespace fl
-
-#endif // __INC_FASTPIN_ARM_STM32

--- a/src/platforms/arm/stm32/fastspi_arm_stm32.h
+++ b/src/platforms/arm/stm32/fastspi_arm_stm32.h
@@ -1,5 +1,4 @@
-#ifndef __INC_FASTSPI_ARM_STM32_H
-#define __INC_FASTSPI_ARM_STM32_H
+#pragma once
 
 #ifndef FASTLED_FORCE_SOFTWARE_SPI
 
@@ -315,5 +314,3 @@ public:
 }  // namespace fl
 
 #endif // #ifndef FASTLED_FORCE_SOFTWARE_SPI
-
-#endif // #ifndef __INC_FASTSPI_ARM_STM32_H

--- a/src/platforms/arm/stm32/led_sysdefs_arm_stm32.h
+++ b/src/platforms/arm/stm32/led_sysdefs_arm_stm32.h
@@ -1,6 +1,5 @@
 // ok no namespace fl
-#ifndef __INC_LED_SYSDEFS_ARM_SAM_H
-#define __INC_LED_SYSDEFS_ARM_SAM_H
+#pragma once
 
 #include "platforms/arm/is_arm.h"
 
@@ -105,6 +104,4 @@ extern "C" void yield();
   // Generate unique section name using __COUNTER__ (e.g., .text_ram.0, .text_ram.1)
   #define _FL_IRAM_SECTION_NAME(counter) ".text_ram." _FL_IRAM_STRINGIFY(counter)
   #define FL_IRAM __attribute__((section(_FL_IRAM_SECTION_NAME(__COUNTER__))))
-#endif
-
 #endif


### PR DESCRIPTION
Minor improvements about STM32 header inclusion guards:
- SAM copy-paste typo (vs STM32)
- overlap of `#pragma once` and `#ifndef __INC_..._H`/`#define __INC_..._H`
- comments about `#endif` portion of guards

I am unable to test these locally, though have tried; apologies for any mistakes.  Things I've noticed in that regard:
1. `sccache` is an unstated dependency for `test.py`; I was only able to discover with `--verbose`.
2. linking of `examples/example_runner` fails on my system:
```[BUILD] ld.lld: error: attempted static link of dynamic object /usr/lib/x86_64-linux-gnu/libunwind.so```
3. `CONTRIBUTING.md` details using CMake directly with `tests/` as source directory, but there is no `tests/CMakeLists.txt`.
4. Testing by trying to build a project (PlatformIO) with the branch always fails to link, unless it is `master`, e.g.:
```lib_deps = https://github.com/nmschulte/FastLED.git#nms/test```, where `nms/test` branch references the same commit as `master` fails to link.  Same goes for when using a commit/sha, even if it's the same as `master` (which succeeds).

Finally, attempting to follow the updated `CONTRIBUTING.md`, telling N > 1 commits is acceptable; let me know if I misunderstand.