### PR TITLE
kRGBWMaxBrightness / rgb_2_rgbw_max_brightness: fix white channel not respecting global brightness

### DIFF
--- a/src/fl/rgbw.cpp.hpp
+++ b/src/fl/rgbw.cpp.hpp
@@ -61,7 +61,7 @@ void rgb_2_rgbw_max_brightness(u16 w_color_temperature, u8 r,
     *out_r = scale8(r, r_scale);
     *out_g = scale8(g, g_scale);
     *out_b = scale8(b, b_scale);
-    *out_w = min3(r, g, b);
+    *out_w = min3(*out_r, *out_g, *out_b);
 }
 
 void rgb_2_rgbw_null_white_pixel(u16 w_color_temperature, u8 r,


### PR DESCRIPTION
In kRGBWMaxBrightness mode, the white channel was derived from the
unscaled RGB inputs:

    *out_w = min3(r, g, b);

However, RGB outputs are computed from scaled values:

    *out_r = scale8(r, r_scale);
    ...

This caused W to remain non-zero when global brightness (or per-channel
scales) reduced RGB to zero.

Compute W from the scaled RGB outputs instead so it respects global
brightness and other scaling.