### PR TITLE
fix: AVR 16-bit int breaks large left-shifts in some implementations of `fixed_point` types

### DIFF
--- a/src/fl/fixed_point/s16x16.h
+++ b/src/fl/fixed_point/s16x16.h
@@ -17,13 +17,13 @@ class s16x16 {
   public:
     static constexpr int INT_BITS = 16;
     static constexpr int FRAC_BITS = 16;
+    static constexpr i32 SCALE = static_cast<i32>(1) << FRAC_BITS;
 
     // ---- Construction ------------------------------------------------------
 
     constexpr s16x16() = default;
 
-    explicit constexpr s16x16(float f)
-        : mValue(static_cast<i32>(f * (1 << FRAC_BITS))) {}
+    explicit constexpr s16x16(float f) : mValue(static_cast<i32>(f * SCALE)) {}
 
     static FASTLED_FORCE_INLINE s16x16 from_raw(i32 raw) {
         s16x16 r;
@@ -35,7 +35,7 @@ class s16x16 {
 
     i32 raw() const { return mValue; }
     i32 to_int() const { return mValue >> FRAC_BITS; }
-    float to_float() const { return static_cast<float>(mValue) / (1 << FRAC_BITS); }
+    float to_float() const { return static_cast<float>(mValue) / SCALE; }
 
     // ---- Fixed-point arithmetic --------------------------------------------
 
@@ -91,19 +91,20 @@ class s16x16 {
     }
 
     static FASTLED_FORCE_INLINE s16x16 floor(s16x16 x) {
-        constexpr i32 frac_mask = (1 << FRAC_BITS) - 1;
+        constexpr i32 frac_mask = SCALE - 1;
         return from_raw(x.mValue & ~frac_mask);
     }
 
     static FASTLED_FORCE_INLINE s16x16 ceil(s16x16 x) {
-        constexpr i32 frac_mask = (1 << FRAC_BITS) - 1;
+        constexpr i32 frac_mask = SCALE - 1;
         i32 floored = x.mValue & ~frac_mask;
-        if (x.mValue & frac_mask) floored += (1 << FRAC_BITS);
+        if (x.mValue & frac_mask)
+            floored += SCALE;
         return from_raw(floored);
     }
 
     static FASTLED_FORCE_INLINE s16x16 fract(s16x16 x) {
-        constexpr i32 frac_mask = (1 << FRAC_BITS) - 1;
+        constexpr i32 frac_mask = SCALE - 1;
         return from_raw(x.mValue & frac_mask);
     }
 
@@ -197,7 +198,7 @@ class s16x16 {
     static FASTLED_FORCE_INLINE s16x16 rsqrt(s16x16 x) {
         s16x16 s = sqrt(x);
         if (s.mValue == 0) return s16x16();
-        return from_raw(static_cast<i32>(1) << FRAC_BITS) / s;
+        return from_raw(SCALE) / s;
     }
 
     static FASTLED_FORCE_INLINE s16x16 pow(s16x16 base, s16x16 exp) {
@@ -253,11 +254,9 @@ class s16x16 {
         i32 int_part = msb - FRAC_BITS;
         i32 t;
         if (msb >= FRAC_BITS) {
-            t = static_cast<i32>(
-                (val >> (msb - FRAC_BITS)) - (1u << FRAC_BITS));
+            t = static_cast<i32>((val >> (msb - FRAC_BITS)) - SCALE);
         } else {
-            t = static_cast<i32>(
-                (val << (FRAC_BITS - msb)) - (1u << FRAC_BITS));
+            t = static_cast<i32>((val << (FRAC_BITS - msb)) - SCALE);
         }
         // 4-term minimax coefficients for log2(1+t), t in [0,1).
         // Stored as i64 with 24 fractional bits. Max product ~2^49, fits i64.
@@ -290,9 +289,9 @@ class s16x16 {
         if (n < -FRAC_BITS) return s16x16();
         i32 int_pow;
         if (n >= 0) {
-            int_pow = static_cast<i32>(1u << FRAC_BITS) << n;
+            int_pow = SCALE << n;
         } else {
-            int_pow = static_cast<i32>(1u << FRAC_BITS) >> (-n);
+            int_pow = SCALE >> (-n);
         }
         // 4-term minimax coefficients for 2^t - 1, t in [0,1).
         // Stored as i64 with 24 fractional bits. Max product ~2^48, fits i64.

--- a/src/fl/fixed_point/s24x8.h
+++ b/src/fl/fixed_point/s24x8.h
@@ -17,13 +17,14 @@ class s24x8 {
   public:
     static constexpr int INT_BITS = 24;
     static constexpr int FRAC_BITS = 8;
+    static constexpr i32 SCALE = static_cast<i32>(1) << FRAC_BITS;
 
     // ---- Construction ------------------------------------------------------
 
     constexpr s24x8() = default;
 
     explicit constexpr s24x8(float f)
-        : mValue(static_cast<i32>(f * (1 << FRAC_BITS))) {}
+        : mValue(static_cast<i32>(f * SCALE)) {}
 
     static FASTLED_FORCE_INLINE s24x8 from_raw(i32 raw) {
         s24x8 r;
@@ -35,7 +36,7 @@ class s24x8 {
 
     i32 raw() const { return mValue; }
     i32 to_int() const { return mValue >> FRAC_BITS; }
-    float to_float() const { return static_cast<float>(mValue) / (1 << FRAC_BITS); }
+    float to_float() const { return static_cast<float>(mValue) / SCALE; }
 
     // ---- Fixed-point arithmetic --------------------------------------------
 
@@ -46,7 +47,7 @@ class s24x8 {
 
     FASTLED_FORCE_INLINE s24x8 operator/(s24x8 b) const {
         return from_raw(static_cast<i32>(
-            (static_cast<i64>(mValue) * (static_cast<i64>(1) << FRAC_BITS)) / b.mValue));
+            (static_cast<i64>(mValue) * SCALE) / b.mValue));
     }
 
     FASTLED_FORCE_INLINE s24x8 operator+(s24x8 b) const {
@@ -91,19 +92,19 @@ class s24x8 {
     }
 
     static FASTLED_FORCE_INLINE s24x8 floor(s24x8 x) {
-        constexpr i32 frac_mask = (1 << FRAC_BITS) - 1;
+        constexpr i32 frac_mask = SCALE - 1;
         return from_raw(x.mValue & ~frac_mask);
     }
 
     static FASTLED_FORCE_INLINE s24x8 ceil(s24x8 x) {
-        constexpr i32 frac_mask = (1 << FRAC_BITS) - 1;
+        constexpr i32 frac_mask = SCALE - 1;
         i32 floored = x.mValue & ~frac_mask;
-        if (x.mValue & frac_mask) floored += (1 << FRAC_BITS);
+        if (x.mValue & frac_mask) floored += SCALE;
         return from_raw(floored);
     }
 
     static FASTLED_FORCE_INLINE s24x8 fract(s24x8 x) {
-        constexpr i32 frac_mask = (1 << FRAC_BITS) - 1;
+        constexpr i32 frac_mask = SCALE - 1;
         return from_raw(x.mValue & frac_mask);
     }
 
@@ -197,7 +198,7 @@ class s24x8 {
     static FASTLED_FORCE_INLINE s24x8 rsqrt(s24x8 x) {
         s24x8 s = sqrt(x);
         if (s.mValue == 0) return s24x8();
-        return from_raw(static_cast<i32>(1) << FRAC_BITS) / s;
+        return from_raw(SCALE) / s;
     }
 
     static FASTLED_FORCE_INLINE s24x8 pow(s24x8 base, s24x8 exp) {
@@ -252,10 +253,10 @@ class s24x8 {
         i32 t;
         if (msb >= FRAC_BITS) {
             t = static_cast<i32>(
-                (val >> (msb - FRAC_BITS)) - (1u << FRAC_BITS));
+                (val >> (msb - FRAC_BITS)) - SCALE);
         } else {
             t = static_cast<i32>(
-                (val << (FRAC_BITS - msb)) - (1u << FRAC_BITS));
+                (val << (FRAC_BITS - msb)) - SCALE);
         }
         // 4-term minimax coefficients for log2(1+t), t in [0,1).
         // Stored as i64 with 16 fractional bits.
@@ -288,9 +289,9 @@ class s24x8 {
         if (n < -FRAC_BITS) return s24x8();
         i32 int_pow;
         if (n >= 0) {
-            int_pow = static_cast<i32>(1u << FRAC_BITS) << n;
+            int_pow = SCALE << n;
         } else {
-            int_pow = static_cast<i32>(1u << FRAC_BITS) >> (-n);
+            int_pow = SCALE >> (-n);
         }
         // 4-term minimax coefficients for 2^t - 1, t in [0,1).
         // Stored as i64 with 16 fractional bits.

--- a/src/fl/fixed_point/s8x24.h
+++ b/src/fl/fixed_point/s8x24.h
@@ -17,13 +17,14 @@ class s8x24 {
   public:
     static constexpr int INT_BITS = 8;
     static constexpr int FRAC_BITS = 24;
+    static constexpr i32 SCALE = static_cast<i32>(1) << FRAC_BITS;
 
     // ---- Construction ------------------------------------------------------
 
     constexpr s8x24() = default;
 
     explicit constexpr s8x24(float f)
-        : mValue(static_cast<i32>(f * (1 << FRAC_BITS))) {}
+        : mValue(static_cast<i32>(f * SCALE)) {}
 
     static FASTLED_FORCE_INLINE s8x24 from_raw(i32 raw) {
         s8x24 r;
@@ -35,7 +36,7 @@ class s8x24 {
 
     i32 raw() const { return mValue; }
     i32 to_int() const { return mValue >> FRAC_BITS; }
-    float to_float() const { return static_cast<float>(mValue) / (1 << FRAC_BITS); }
+    float to_float() const { return static_cast<float>(mValue) / SCALE; }
 
     // ---- Fixed-point arithmetic --------------------------------------------
 
@@ -46,7 +47,7 @@ class s8x24 {
 
     FASTLED_FORCE_INLINE s8x24 operator/(s8x24 b) const {
         return from_raw(static_cast<i32>(
-            (static_cast<i64>(mValue) * (static_cast<i64>(1) << FRAC_BITS)) / b.mValue));
+            (static_cast<i64>(mValue) * SCALE) / b.mValue));
     }
 
     FASTLED_FORCE_INLINE s8x24 operator+(s8x24 b) const {
@@ -91,19 +92,19 @@ class s8x24 {
     }
 
     static FASTLED_FORCE_INLINE s8x24 floor(s8x24 x) {
-        constexpr i32 frac_mask = (1 << FRAC_BITS) - 1;
+        constexpr i32 frac_mask = SCALE - 1;
         return from_raw(x.mValue & ~frac_mask);
     }
 
     static FASTLED_FORCE_INLINE s8x24 ceil(s8x24 x) {
-        constexpr i32 frac_mask = (1 << FRAC_BITS) - 1;
+        constexpr i32 frac_mask = SCALE - 1;
         i32 floored = x.mValue & ~frac_mask;
-        if (x.mValue & frac_mask) floored += (1 << FRAC_BITS);
+        if (x.mValue & frac_mask) floored += SCALE;
         return from_raw(floored);
     }
 
     static FASTLED_FORCE_INLINE s8x24 fract(s8x24 x) {
-        constexpr i32 frac_mask = (1 << FRAC_BITS) - 1;
+        constexpr i32 frac_mask = SCALE - 1;
         return from_raw(x.mValue & frac_mask);
     }
 
@@ -197,7 +198,7 @@ class s8x24 {
     static FASTLED_FORCE_INLINE s8x24 rsqrt(s8x24 x) {
         s8x24 s = sqrt(x);
         if (s.mValue == 0) return s8x24();
-        return from_raw(static_cast<i32>(1) << FRAC_BITS) / s;
+        return from_raw(SCALE) / s;
     }
 
     static FASTLED_FORCE_INLINE s8x24 pow(s8x24 base, s8x24 exp) {
@@ -252,10 +253,10 @@ class s8x24 {
         i32 t;
         if (msb >= FRAC_BITS) {
             t = static_cast<i32>(
-                (val >> (msb - FRAC_BITS)) - (1u << FRAC_BITS));
+                (val >> (msb - FRAC_BITS)) - SCALE);
         } else {
             t = static_cast<i32>(
-                (val << (FRAC_BITS - msb)) - (1u << FRAC_BITS));
+                (val << (FRAC_BITS - msb)) - SCALE);
         }
         // 4-term minimax coefficients for log2(1+t), t in [0,1).
         // Stored as i64 with 24 fractional bits (same as FRAC_BITS).
@@ -287,9 +288,9 @@ class s8x24 {
         if (n < -FRAC_BITS) return s8x24();
         i32 int_pow;
         if (n >= 0) {
-            int_pow = static_cast<i32>(1u << FRAC_BITS) << n;
+            int_pow = SCALE << n;
         } else {
-            int_pow = static_cast<i32>(1u << FRAC_BITS) >> (-n);
+            int_pow = SCALE >> (-n);
         }
         // 4-term minimax coefficients for 2^t - 1, t in [0,1).
         // Stored as i64 with 24 fractional bits (same as FRAC_BITS).


### PR DESCRIPTION
I'm hoping this fixes #2174. I think an extensive test suite would improve my confidence.