### PR TITLE
Two constexpr scalar operator overloads remain in fl/fixed_point

### DIFF
--- a/src/fl/fixed_point/s0x32.h
+++ b/src/fl/fixed_point/s0x32.h
@@ -124,7 +124,7 @@ class s0x32 {
         return from_raw(static_cast<i32>(result));
     }
 
-    friend constexpr FASTLED_FORCE_INLINE s0x32 operator*(i32 scalar, s0x32 a) {
+    friend FASTLED_FORCE_INLINE s0x32 operator*(i32 scalar, s0x32 a) {
         return a * scalar;  // Commutative
     }
 

--- a/src/fl/fixed_point/u0x32.h
+++ b/src/fl/fixed_point/u0x32.h
@@ -126,7 +126,7 @@ class u0x32 {
         return from_raw(static_cast<u32>(result));
     }
 
-    friend constexpr FASTLED_FORCE_INLINE u0x32 operator*(u32 scalar, u0x32 a) {
+    friend FASTLED_FORCE_INLINE u0x32 operator*(u32 scalar, u0x32 a) {
         return a * scalar;  // Commutative
     }
 


### PR DESCRIPTION
At least on AVR, I'm getting compile failures when including fixed_point due to these two.

It seems they were missed when `constexpr` was removed from the other implementations.

```
src/fl/fixed_point/s0x32.h: In function 'constexpr fl::s0x32 fl::operator*(fl::i32, fl::s0x32)':
src/fl/fixed_point/s0x32.h:128:20: error: call to non-constexpr function 'fl::s0x32 fl::s0x32::operator*(fl::i32) const'
         return a * scalar;  // Commutative
                    ^~~~~~
```

```
src/fl/fixed_point/u0x32.h: In function 'constexpr fl::u0x32 fl::operator*(fl::u32, fl::u0x32)':
src/fl/fixed_point/u0x32.h:130:20: error: call to non-constexpr function 'fl::u0x32 fl::u0x32::operator*(fl::u32) const'
         return a * scalar;  // Commutative
                    ^~~~~~
```