### PR TITLE
Add sin8/cos8 wrappers for USE_SIN_32

### DIFF
--- a/src/platforms/trig8.h
+++ b/src/platforms/trig8.h
@@ -42,6 +42,15 @@ namespace fl {
 inline i16 sin16(u16 theta) { return fl::sin16lut(theta); }
 inline i16 cos16(u16 theta) { return fl::cos16lut(theta); }
 
+// 8-bit wrappers derived from 16-bit LUTs.
+inline u8 sin8(u8 theta) {
+	return static_cast<u8>((static_cast<i32>(sin16(static_cast<u16>(theta) << 8)) + 32768) >> 8);
+}
+
+inline u8 cos8(u8 theta) {
+	return static_cast<u8>((static_cast<i32>(cos16(static_cast<u16>(theta) << 8)) + 32768) >> 8);
+}
+
 #endif
 
 }  // namespace fl


### PR DESCRIPTION
Works around compile failures coming from `beatsin8()` et al when `USE_SIN_32` defined.

```
src/lib8tion/trig8.h: At global scope:
src/lib8tion/trig8.h:13:11: error: 'fl::sin8' has not been declared
 using fl::sin8;
           ^~~~
src/lib8tion/trig8.h:14:11: error: 'fl::cos8' has not been declared
 using fl::cos8;
           ^~~~
In file included from src/pixeltypes.h:7:0,
                 from src/fl/fastled.h:61,
                 from src/FastLED.h:133,
                 from FastLED-fixed_point_tests2.ino:2:
src/lib8tion.h: In function 'fl::u8 beatsin8(fl::accum88, fl::u8, fl::u8, fl::u32, fl::u8)':
src/lib8tion.h:834:22: error: 'sin8' was not declared in this scope
     fl::u8 beatsin = sin8( beat + phase_offset);
                      ^~~~
src/lib8tion.h:834:22: note: suggested alternative: 'sinh'
     fl::u8 beatsin = sin8( beat + phase_offset);
                      ^~~~
                      sinh
```
