### PR TITLE
Fix symbol conflict on newer ESP-IDF.

### DIFF
--- a/src/platforms/esp/32/drivers/usb_serial_jtag_esp32_idf.hpp
+++ b/src/platforms/esp/32/drivers/usb_serial_jtag_esp32_idf.hpp
@@ -354,7 +354,11 @@ bool UsbSerialJtagEsp32::isConnected() const {
         return false;  // Driver not installed, cannot check connection
     }
 
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 3, 0)
     return usb_serial_jtag_is_connected();
+#else
+    return true;  // Fallback for older IDF versions
+#endif
 #else
     return false;
 #endif


### PR DESCRIPTION
Allows compilation on newer ESP-IDF without symbol collision.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved USB connection detection reliability for ESP32 devices with enhanced support across different SDK versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->