### PR TITLE
Fix SPI Mode for Xiao MG24 board

### DIFF
--- a/src/platforms/arm/mgm240/clockless_ezws2812_spi.h
+++ b/src/platforms/arm/mgm240/clockless_ezws2812_spi.h
@@ -36,7 +36,7 @@ namespace fl {
 /// This controller uses the Silicon Labs ezWS2812 SPI driver to provide
 /// hardware-accelerated WS2812 control. It consumes one SPI peripheral.
 ///
-/// Each WS2812 bit is encoded as 8 SPI bits at 3.2MHz:
+/// Each WS2812 bit is encoded as 8 SPI bits at ~6.4MHz:
 /// - '1' bit: 0xFC (11111100) - long high pulse
 /// - '0' bit: 0x80 (10000000) - short high pulse
 ///
@@ -53,13 +53,13 @@ private:
     /// @brief Convert WS2812 bit to SPI signal for '1' bit
     /// @return SPI byte pattern for logical '1'
     FASTLED_FORCE_INLINE u8 spi_one() const {
-        return 0xFC; // 11111100 - long high pulse for '1'
+        return 0xF8; // 11111000 - ~0.78us high at 6.4MHz
     }
 
     /// @brief Convert WS2812 bit to SPI signal for '0' bit
     /// @return SPI byte pattern for logical '0'
     FASTLED_FORCE_INLINE u8 spi_zero() const {
-        return 0x80; // 10000000 - short high pulse for '0'
+        return 0xC0; // 11000000 - ~0.31us high at 6.4MHz
     }
 
     /// @brief Convert 8-bit color value to SPI bit pattern array
@@ -114,16 +114,20 @@ protected:
         // Pre-allocate SPI buffer for one pixel (3 colors × 8 bits = 24 SPI bytes)
         u8 spi_buffer[24];
 
+        // WS2812 requires a continuous stream; prevent long ISR gaps mid-frame.
+        noInterrupts();
+
         // Process all pixels directly via SPI
         while (pixels.has(1)) {
-            u8 r = pixels.loadAndScale0();
-            u8 g = pixels.loadAndScale1();
-            u8 b = pixels.loadAndScale2();
+            // loadAndScale* returns bytes in the RGB_ORDER output order
+            u8 c0 = pixels.loadAndScale0();
+            u8 c1 = pixels.loadAndScale1();
+            u8 c2 = pixels.loadAndScale2();
 
-            // Convert to SPI bit patterns (GRB order for WS2812)
-            colorToSPI(g, &spi_buffer[0]);  // Green first (8 SPI bytes)
-            colorToSPI(r, &spi_buffer[8]);  // Red second (8 SPI bytes)
-            colorToSPI(b, &spi_buffer[16]); // Blue third (8 SPI bytes)
+            // Convert to SPI bit patterns in output order
+            colorToSPI(c0, &spi_buffer[0]);  // Byte 0
+            colorToSPI(c1, &spi_buffer[8]);  // Byte 1
+            colorToSPI(c2, &spi_buffer[16]); // Byte 2
 
             // Send pixel data via SPI
             for (int j = 0; j < 24; j++) {
@@ -136,6 +140,8 @@ protected:
 
         // Complete transfer with reset pulse
         mDriver->end_transfer();
+
+        interrupts();
     }
 };
 

--- a/src/third_party/ezws2812/ezWS2812.h
+++ b/src/third_party/ezws2812/ezWS2812.h
@@ -58,17 +58,23 @@ private:
     uint16_t num_leds_;
     uint8_t brightness_;
     SPIClass* spi_;
+    // 8 SPI bits encode 1 WS2812 bit -> 8 * 1.25us = 10us at 0.125us per bit
+    // To hit ~1.25us per WS2812 bit, SPI should be ~6.4MHz (1/6.4MHz = 0.15625us)
+    static constexpr uint32_t kSpiClockHz = 6400000;
+    static constexpr uint16_t kResetTimeUs = 80;
+    static constexpr uint8_t kResetByte = 0x00;
+    static constexpr uint8_t kResetBytes = 32;
 
     /// @brief Convert color bit to SPI signal for '1' bit
     /// @return SPI byte pattern for logical '1'
     inline uint8_t one() const {
-        return 0xFC; // 11111100 - long high pulse for '1'
+        return 0xF8; // 11111000 - ~0.78us high at 6.4MHz
     }
 
     /// @brief Convert color bit to SPI signal for '0' bit
     /// @return SPI byte pattern for logical '0'
     inline uint8_t zero() const {
-        return 0x80; // 10000000 - short high pulse for '0'
+        return 0xC0; // 11000000 - ~0.31us high at 6.4MHz
     }
 
     /// @brief Convert color byte to SPI bit pattern
@@ -88,7 +94,7 @@ public:
     /// @brief Initialize SPI communication
     void begin() {
         spi_->begin();
-        spi_->beginTransaction(SPISettings(3200000, MSBFIRST, SPI_MODE0));
+        spi_->beginTransaction(SPISettings(kSpiClockHz, MSBFIRST, SPI_MODE0));
     }
 
     /// @brief End SPI communication
@@ -138,8 +144,12 @@ public:
     /// @brief Complete LED data transfer
     /// Sends reset signal to latch data into LEDs
     void end_transfer() {
-        // WS2812 reset time (>50µs low)
-        delayMicroseconds(300);
+        // Force MOSI low long enough to guarantee WS2812 reset/latch.
+        // Sending zero bytes ensures low even if the last data bit was high.
+        for (uint8_t i = 0; i < kResetBytes; i++) {
+            spi_->transfer(kResetByte);
+        }
+        delayMicroseconds(kResetTimeUs);
     }
 };
 


### PR DESCRIPTION
As reported here: https://github.com/FastLED/FastLED/issues/2172, 

When trying to run the FastLED sample program using SPI mode on Xiao MG24 board, the first several LEDs were being set to the white color while the rest of the chain did not work at all. Those fixes were suggested by GPT-5.2-Codex model and have been tested with several test projects:

`#define FASTLED_USES_EZWS2812_SPI
#include <FastLED.h>

#define PIXEL_COUNT 36
CRGB strip[PIXEL_COUNT];

void setup() {
  FastLED.addLeds<EZWS2812_SPI, GRB>(strip, PIXEL_COUNT);
}

void loop()
{
  for (int i = 0; i < PIXEL_COUNT; ++i) {
    strip[i] = CRGB::Red;
  }
  FastLED.show(); 
  delay(500);

  for (int i = 0; i < PIXEL_COUNT; ++i) {
    strip[i] = CRGB::Blue;
  }
  FastLED.show(); 
  delay(500);

    for (int i = 0; i < PIXEL_COUNT; ++i) {
    strip[i] = CRGB::Green;
  }
  FastLED.show(); 
  delay(500);
}`

Also tested with DemoReel100 example project: https://github.com/FastLED/FastLED/blob/master/examples/DemoReel100/DemoReel100.ino

And in my custom implementation of Matter over Thread based on Silicon Labs examples (I cannot share the code yet ;) ). 

All of the test projects worked well in regards to setting LED colours and the Matter functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved timing precision and reliability for WS2812 LED strip control.
  * Enhanced interrupt management during LED data transmission.
  * Refined reset sequence handling for more consistent LED behavior across hardware platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->