### PR TITLE
Fix compile errors

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -10,7 +10,11 @@
       "SlashCommand(/git-historian wasm function names debug source-map --paths ci examples)",
       "SlashCommand(/git-historian emscripten -g profiling ASSERTIONS --paths ci examples)",
       "SlashCommand(/git-historian DWARF symbols demangle --paths ci)",
-      "Bash(gh issue view:*)"
+      "Bash(gh issue view:*)",
+      "Bash(bash lint:*)",
+      "Bash(bash ci/lint-js-fast)",
+      "Bash(uv run:*)",
+      "Bash(ls .cache/js-tools/node_modules/.bin/eslint*)"
     ],
     "deny": [],
     "ask": []

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: "en-US"
+early_access: true
+reviews:
+  profile: "chill"
+  request_changes_workflow: true
+  high_level_summary: true
+  poem: true
+  review_status: true
+  collapse_walkthrough: false
+  auto_review:
+    enabled: true
+    drafts: true
+  tools:
+    github-checks:
+      timeout_ms: 900000   # 15 minutes max
+chat:
+  auto_reply: true

--- a/ci/lint-js-fast
+++ b/ci/lint-js-fast
@@ -17,8 +17,8 @@ trap 'if [ $? -ne 0 ]; then cd "$PROJECT_ROOT" && uv run python ci/js_lint_cache
 
 echo -e "${BLUE}FAST FastLED TypeScript Linting (ESLint + TypeScript Type Checking - FAST!)${NC}"
 
-# Check if ESLint is installed
-if [ ! -f ".cache/js-tools/node_modules/.bin/eslint.cmd" ]; then
+# Check if ESLint is installed (eslint on Unix, eslint.cmd on Windows)
+if [ ! -f ".cache/js-tools/node_modules/.bin/eslint" ] && [ ! -f ".cache/js-tools/node_modules/.bin/eslint.cmd" ]; then
     echo -e "${RED}ERROR: ESLint not found. Run: uv run ci/setup-js-linting-fast.py${NC}"
     exit 1
 fi
@@ -92,7 +92,11 @@ fi
 # (ESLint resolves parser modules relative to the config file location)
 cp "../../src/platforms/wasm/compiler/.eslintrc.cjs" ".eslintrc.cjs" 2>/dev/null || true
 
-if "./node_modules/.bin/eslint.cmd" --no-eslintrc --no-inline-config -c .eslintrc.cjs "${LINT_TARGETS[@]}"; then
+ESLINT_BIN="./node_modules/.bin/eslint"
+if [ -f "./node_modules/.bin/eslint.cmd" ]; then
+    ESLINT_BIN="./node_modules/.bin/eslint.cmd"
+fi
+if "$ESLINT_BIN" --no-eslintrc --no-inline-config -c .eslintrc.cjs "${LINT_TARGETS[@]}"; then
     echo -e "${GREEN}ESLint completed successfully${NC}"
 else
     echo -e "${RED}ERROR: ESLint failed${NC}"

--- a/src/fl/gfx/blur.h
+++ b/src/fl/gfx/blur.h
@@ -170,7 +170,10 @@ inline void blur2d(CRGB *leds, u8 width, u8 height, fract8 blur_amount,
 }
 FASTLED_DEPRECATED("Use blur2d(..., const XYMap& xymap) instead")
 inline void blur2d(CRGB *leds, u8 width, u8 height, fract8 blur_amount) {
+    FL_DISABLE_WARNING_PUSH
+    FL_DISABLE_WARNING(deprecated-declarations)
     gfx::blur2d(leds, width, height, blur_amount);
+    FL_DISABLE_WARNING_POP
 }
 inline void blurRows(CRGB *leds, u8 width, u8 height, fract8 blur_amount,
                      const XYMap &xymap) {

--- a/src/fl/net/http/stream_client.cpp.hpp
+++ b/src/fl/net/http/stream_client.cpp.hpp
@@ -3,6 +3,9 @@
 #include "fl/net/http/stream_client.h"
 #include "fl/stl/string.h"
 #include "fl/stl/stdint.h"
+
+#ifdef FASTLED_HAS_NETWORKING
+
 #include "fl/stl/chrono.h"
 #include "fl/stl/cstdio.h"
 #include "fl/stl/thread.h"
@@ -208,3 +211,61 @@ bool HttpStreamClient::readHttpResponseHeader() {
 }  // namespace http
 }  // namespace net
 }  // namespace fl
+
+#else  // !FASTLED_HAS_NETWORKING
+
+namespace fl {
+namespace net {
+namespace http {
+
+HttpStreamClient::HttpStreamClient(const fl::string& host, u16 port, u32 heartbeatIntervalMs)
+    : HttpStreamTransport(host, port, heartbeatIntervalMs)
+    , mHttpHeaderSent(false)
+    , mHttpHeaderReceived(false)
+    , mHost(host)
+    , mPort(port) {
+}
+
+HttpStreamClient::~HttpStreamClient() {
+    disconnect();
+}
+
+bool HttpStreamClient::connect() {
+    return false;
+}
+
+void HttpStreamClient::disconnect() {
+    mHttpHeaderSent = false;
+    mHttpHeaderReceived = false;
+    mConnection.onDisconnected();
+}
+
+bool HttpStreamClient::isConnected() const {
+    return false;
+}
+
+int HttpStreamClient::sendData(fl::span<const u8> data) {
+    (void)data;
+    return -1;
+}
+
+int HttpStreamClient::recvData(fl::span<u8> buffer) {
+    (void)buffer;
+    return -1;
+}
+
+void HttpStreamClient::triggerReconnect() {}
+
+bool HttpStreamClient::sendHttpRequestHeader() {
+    return false;
+}
+
+bool HttpStreamClient::readHttpResponseHeader() {
+    return false;
+}
+
+}  // namespace http
+}  // namespace net
+}  // namespace fl
+
+#endif  // FASTLED_HAS_NETWORKING

--- a/src/fl/net/http/stream_client.h
+++ b/src/fl/net/http/stream_client.h
@@ -66,7 +66,9 @@ private:
     bool readHttpResponseHeader();
 
     /// Native socket client
+#ifdef FASTLED_HAS_NETWORKING
     fl::unique_ptr<NativeHttpClient> mNativeClient;
+#endif
 
     /// Connection state
     bool mHttpHeaderSent;

--- a/src/fl/net/http/stream_server.cpp.hpp
+++ b/src/fl/net/http/stream_server.cpp.hpp
@@ -3,6 +3,9 @@
 #include "fl/net/http/stream_server.h"
 #include "fl/stl/string.h"
 #include "fl/stl/stdint.h"
+
+#ifdef FASTLED_HAS_NETWORKING
+
 #include "fl/system/log.h"
 #include "fl/stl/cstdio.h"
 namespace fl {
@@ -303,3 +306,93 @@ void HttpStreamServer::removeClientState(u32 clientId) {
 }  // namespace http
 }  // namespace net
 }  // namespace fl
+
+#else  // !FASTLED_HAS_NETWORKING
+
+namespace fl {
+namespace net {
+namespace http {
+
+HttpStreamServer::HttpStreamServer(u16 port, u32 heartbeatIntervalMs)
+    : HttpStreamTransport("0.0.0.0", port, heartbeatIntervalMs)
+    , mPort(port)
+    , mLastProcessedClientId(0) {
+    mRecvBuffer.reserve(16384);
+}
+
+HttpStreamServer::~HttpStreamServer() {
+    disconnect();
+}
+
+bool HttpStreamServer::connect() {
+    return false;
+}
+
+void HttpStreamServer::disconnect() {
+    mClientStates.clear();
+    mConnection.onDisconnected();
+}
+
+bool HttpStreamServer::isConnected() const {
+    return false;
+}
+
+u16 HttpStreamServer::port() const {
+    return mPort;
+}
+
+void HttpStreamServer::acceptClients() {}
+
+size_t HttpStreamServer::getClientCount() const {
+    return 0;
+}
+
+void HttpStreamServer::disconnectClient(u32 clientId) {
+    (void)clientId;
+}
+
+fl::vector<u32> HttpStreamServer::getClientIds() const {
+    return fl::vector<u32>();
+}
+
+int HttpStreamServer::sendData(fl::span<const u8> data) {
+    (void)data;
+    return -1;
+}
+
+int HttpStreamServer::recvData(fl::span<u8> buffer) {
+    (void)buffer;
+    return -1;
+}
+
+void HttpStreamServer::triggerReconnect() {}
+
+bool HttpStreamServer::readHttpRequestHeader(u32 clientId) {
+    (void)clientId;
+    return false;
+}
+
+bool HttpStreamServer::sendHttpResponseHeader(u32 clientId) {
+    (void)clientId;
+    return false;
+}
+
+bool HttpStreamServer::processClientData(u32 clientId) {
+    (void)clientId;
+    return false;
+}
+
+HttpStreamServer::ClientState* HttpStreamServer::getOrCreateClientState(u32 clientId) {
+    (void)clientId;
+    return nullptr;
+}
+
+void HttpStreamServer::removeClientState(u32 clientId) {
+    (void)clientId;
+}
+
+}  // namespace http
+}  // namespace net
+}  // namespace fl
+
+#endif  // FASTLED_HAS_NETWORKING

--- a/src/fl/net/http/stream_server.h
+++ b/src/fl/net/http/stream_server.h
@@ -133,7 +133,9 @@ private:
     void removeClientState(u32 clientId);
 
     /// Native socket server
+#ifdef FASTLED_HAS_NETWORKING
     fl::unique_ptr<NativeHttpServer> mNativeServer;
+#endif
 
     /// Server port
     u16 mPort;


### PR DESCRIPTION
Fix ESP32 compile errors in HTTP stream client/server and blur.h deprecation warning                                                                                                         
                                                                                                                                                                                               
  Changes                                                                                                                                                                                      
                                                                                                                                                                                               
  src/fl/net/http/stream_client.h / stream_server.h                                                                                                                                            
   
  NativeHttpClient and NativeHttpServer are only defined when FASTLED_HAS_NETWORKING is set (desktop/POSIX/Windows). The mNativeClient / mNativeServer member declarations were missing the    
  guard, causing compile errors on ESP32 and other embedded targets.
                                                                                                                                                                                               
  src/fl/net/http/stream_client.cpp.hpp / stream_server.cpp.hpp                                                                                                                                
   
  Wrapped the full networking implementations with #ifdef FASTLED_HAS_NETWORKING. Added stub implementations in the #else branch for non-networking platforms (methods return false / -1 /     
  no-op), so the classes still link correctly on embedded targets.
                                                                                                                                                                                               
  This also fixes the secondary sleep_for template deduction error, which was inside the networking-only code path.                                                                            
   
  src/fl/gfx/blur.h                                                                                                                                                                            
                                                            
  The deprecated fl::blur2d(CRGB*, u8, u8, fract8) wrapper called the equally deprecated gfx::blur2d(...), triggering a -Wdeprecated-declarations warning inside its own body. Suppressed using
   FL_DISABLE_WARNING_PUSH / FL_DISABLE_WARNING(deprecated-declarations) / FL_DISABLE_WARNING_POP.
                                                                                                                                                                                               
  ci/lint-js-fast                                           

  The ESLint existence check and invocation used eslint.cmd (Windows binary name) unconditionally, causing JavaScript linting to always fail on macOS/Linux. Fixed to use eslint on Unix and   
  fall back to eslint.cmd on Windows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved cross-platform compatibility for ESLint detection in the CI linting pipeline.
  * Added graceful fallback implementations for HTTP network components to handle scenarios where networking is unavailable.

* **Chores**
  * Enhanced automated code review configuration with improved workflow settings.
  * Refined compiler warning suppression for deprecated function calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->