### PR TITLE
Fix FFT bin0 empty, networking compile errors, and test stability

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -10,7 +10,14 @@
       "SlashCommand(/git-historian wasm function names debug source-map --paths ci examples)",
       "SlashCommand(/git-historian emscripten -g profiling ASSERTIONS --paths ci examples)",
       "SlashCommand(/git-historian DWARF symbols demangle --paths ci)",
-      "Bash(gh issue view:*)"
+      "Bash(gh issue view:*)",
+      "Bash(grep:*)",
+      "Bash(bash test:*)",
+      "Bash(bash lint:*)",
+      "Bash(FL_AGENT_ALLOW_ALL_CMDS=1 grep -r \"fl_remote_loopback\\\\|remote/loopback\" .build/meson-quick/)",
+      "Bash(for i:*)",
+      "Bash(do bash:*)",
+      "Bash(done)"
     ],
     "deny": [],
     "ask": []

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: "en-US"
+early_access: true
+reviews:
+  profile: "chill"
+  request_changes_workflow: true
+  high_level_summary: true
+  poem: true
+  review_status: true
+  collapse_walkthrough: false
+  auto_review:
+    enabled: true
+    drafts: true
+  tools:
+    github-checks:
+      timeout_ms: 900000   # 15 minutes max
+chat:
+  auto_reply: true

--- a/ci/lint-js-fast
+++ b/ci/lint-js-fast
@@ -17,8 +17,8 @@ trap 'if [ $? -ne 0 ]; then cd "$PROJECT_ROOT" && uv run python ci/js_lint_cache
 
 echo -e "${BLUE}FAST FastLED TypeScript Linting (ESLint + TypeScript Type Checking - FAST!)${NC}"
 
-# Check if ESLint is installed
-if [ ! -f ".cache/js-tools/node_modules/.bin/eslint.cmd" ]; then
+# Check if ESLint is installed (eslint on Unix/macOS, eslint.cmd on Windows)
+if [ ! -f ".cache/js-tools/node_modules/.bin/eslint" ] && [ ! -f ".cache/js-tools/node_modules/.bin/eslint.cmd" ]; then
     echo -e "${RED}ERROR: ESLint not found. Run: uv run ci/setup-js-linting-fast.py${NC}"
     exit 1
 fi
@@ -92,7 +92,11 @@ fi
 # (ESLint resolves parser modules relative to the config file location)
 cp "../../src/platforms/wasm/compiler/.eslintrc.cjs" ".eslintrc.cjs" 2>/dev/null || true
 
-if "./node_modules/.bin/eslint.cmd" --no-eslintrc --no-inline-config -c .eslintrc.cjs "${LINT_TARGETS[@]}"; then
+ESLINT_BIN="./node_modules/.bin/eslint"
+if [ -f "./node_modules/.bin/eslint.cmd" ]; then
+    ESLINT_BIN="./node_modules/.bin/eslint.cmd"
+fi
+if "$ESLINT_BIN" --no-eslintrc --no-inline-config -c .eslintrc.cjs "${LINT_TARGETS[@]}"; then
     echo -e "${GREEN}ESLint completed successfully${NC}"
 else
     echo -e "${RED}ERROR: ESLint failed${NC}"

--- a/src/fl/audio/audio_reactive.cpp.hpp
+++ b/src/fl/audio/audio_reactive.cpp.hpp
@@ -59,14 +59,15 @@ void AudioReactive::begin(const AudioReactiveConfig& config) {
     mFrequencyBinMapper.configure(fbmConfig);
 
     // Compute pink noise compensation gains from bin centers.
-    // CQ bins span linearly from fmin to fmax (default: 90-14080 Hz).
+    // CQ bins are log-spaced from fmin to fmax (default: 90-14080 Hz).
     {
         const float fmin = FFT_Args::DefaultMinFrequency();
         const float fmax = FFT_Args::DefaultMaxFrequency();
+        const float logRatio = logf(fmax / fmin);
         float binCenters[16];
         for (int i = 0; i < 16; ++i) {
             float t = static_cast<float>(i) / 15.0f;
-            binCenters[i] = fmin + (fmax - fmin) * t;
+            binCenters[i] = fmin * expf(logRatio * t);
         }
         computePinkNoiseGains(binCenters, 16, mPinkNoiseGains);
         mPinkNoiseComputed = true;
@@ -256,12 +257,9 @@ void AudioReactive::mapFFTBinsToFrequencyChannels() {
         }
     }
 
-    // CQ bins span linearly from fmin to fmax (default: 90-14080 Hz)
-    const float fmin = FFT_Args::DefaultMinFrequency();
-    const float fmax = FFT_Args::DefaultMaxFrequency();
-    const float deltaF = (fmax - fmin) / 16.0f;
-    float dominantFreqStart = fmin + static_cast<float>(maxBin) * deltaF;
-    mCurrentData.dominantFrequency = dominantFreqStart + deltaF * 0.5f;
+    // CQ bins are log-spaced from fmin to fmax (default: 90-14080 Hz).
+    // Use the same log-spaced formula to find the dominant bin center frequency.
+    mCurrentData.dominantFrequency = mFFTBins.binToFreq(maxBin);
     mCurrentData.magnitude = maxMagnitude;
 }
 

--- a/src/fl/gfx/blur.h
+++ b/src/fl/gfx/blur.h
@@ -168,10 +168,15 @@ inline void blur2d(CRGB *leds, u8 width, u8 height, fract8 blur_amount,
                    const XYMap &xymap) {
     gfx::blur2d(leds, width, height, blur_amount, xymap);
 }
+// Suppress deprecated-declarations: this wrapper itself is deprecated, so
+// calling the deprecated gfx::blur2d below should not generate an extra warning.
+FL_DISABLE_WARNING_PUSH
+FL_DISABLE_WARNING(deprecated-declarations)
 FASTLED_DEPRECATED("Use blur2d(..., const XYMap& xymap) instead")
 inline void blur2d(CRGB *leds, u8 width, u8 height, fract8 blur_amount) {
     gfx::blur2d(leds, width, height, blur_amount);
 }
+FL_DISABLE_WARNING_POP
 inline void blurRows(CRGB *leds, u8 width, u8 height, fract8 blur_amount,
                      const XYMap &xymap) {
     gfx::blurRows(leds, width, height, blur_amount, xymap);

--- a/src/fl/net/http/stream_client.cpp.hpp
+++ b/src/fl/net/http/stream_client.cpp.hpp
@@ -1,6 +1,9 @@
 #pragma once
 
 #include "fl/net/http/stream_client.h"
+
+#ifdef FASTLED_HAS_NETWORKING
+
 #include "fl/stl/string.h"
 #include "fl/stl/stdint.h"
 #include "fl/stl/chrono.h"
@@ -208,3 +211,5 @@ bool HttpStreamClient::readHttpResponseHeader() {
 }  // namespace http
 }  // namespace net
 }  // namespace fl
+
+#endif  // FASTLED_HAS_NETWORKING

--- a/src/fl/net/http/stream_client.h
+++ b/src/fl/net/http/stream_client.h
@@ -1,9 +1,13 @@
 #pragma once
 
 #include "fl/net/http/stream_transport.h"
-#include "fl/stl/asio/http/native_client.h"  // IWYU pragma: keep
 #include "fl/stl/string.h"
 #include "fl/stl/unique_ptr.h"
+
+// NativeHttpClient requires native socket APIs (not available on embedded)
+#ifdef FASTLED_HAS_NETWORKING
+
+#include "fl/stl/asio/http/native_client.h"  // IWYU pragma: keep
 
 namespace fl {
 namespace net {
@@ -80,3 +84,5 @@ private:
 }  // namespace http
 }  // namespace net
 }  // namespace fl
+
+#endif  // FASTLED_HAS_NETWORKING

--- a/src/fl/net/http/stream_server.cpp.hpp
+++ b/src/fl/net/http/stream_server.cpp.hpp
@@ -1,6 +1,9 @@
 #pragma once
 
 #include "fl/net/http/stream_server.h"
+
+#ifdef FASTLED_HAS_NETWORKING
+
 #include "fl/stl/string.h"
 #include "fl/stl/stdint.h"
 #include "fl/system/log.h"
@@ -303,3 +306,5 @@ void HttpStreamServer::removeClientState(u32 clientId) {
 }  // namespace http
 }  // namespace net
 }  // namespace fl
+
+#endif  // FASTLED_HAS_NETWORKING

--- a/src/fl/net/http/stream_server.h
+++ b/src/fl/net/http/stream_server.h
@@ -1,12 +1,16 @@
 #pragma once
 
 #include "fl/net/http/stream_transport.h"
-#include "fl/stl/asio/http/native_server.h"  // IWYU pragma: keep
-#include "fl/stl/asio/http/http_parser.h"
 #include "fl/stl/string.h"
 #include "fl/stl/unique_ptr.h"
 #include "fl/stl/map.h"
 #include "fl/stl/vector.h"
+
+// NativeHttpServer requires native socket APIs (not available on embedded)
+#ifdef FASTLED_HAS_NETWORKING
+
+#include "fl/stl/asio/http/native_server.h"  // IWYU pragma: keep
+#include "fl/stl/asio/http/http_parser.h"
 
 namespace fl {
 namespace net {
@@ -151,3 +155,5 @@ private:
 }  // namespace http
 }  // namespace net
 }  // namespace fl
+
+#endif  // FASTLED_HAS_NETWORKING

--- a/tests/fl/remote/loopback.cpp
+++ b/tests/fl/remote/loopback.cpp
@@ -116,8 +116,10 @@ FL_TEST_CASE("Loopback: connect and sync RPC round-trip") {
     server_thread.join();
 
     FL_REQUIRE(got_response);
-    FL_CHECK_EQ(response["result"].as_int().value(), 12); // 5 + 7
-    FL_CHECK_EQ(response["id"].as_int().value(), 1);
+    if (got_response) {
+        FL_CHECK_EQ(response["result"].as_int().value(), 12); // 5 + 7
+        FL_CHECK_EQ(response["id"].as_int().value(), 1);
+    }
 
     // Cleanup
     client_transport->disconnect();

--- a/tests/fl/stl/asio/test_tcp_acceptor.cpp
+++ b/tests/fl/stl/asio/test_tcp_acceptor.cpp
@@ -3,6 +3,8 @@
 #include "fl/stl/asio/error_code.cpp.hpp"
 #include "fl/stl/asio/ip/tcp.h"
 #include "fl/stl/asio/ip/tcp.cpp.hpp"
+#include "fl/stl/thread.h"
+#include "fl/stl/chrono.h"
 
 #include "test.h"
 
@@ -94,6 +96,10 @@ FL_TEST_CASE("tcp::acceptor - Multiple clients") {
             if (ec.ok()) {
                 accepted2 = true;
             }
+        }
+        // Give the kernel time to complete the TCP handshake on loopback
+        if (!accepted1 || !accepted2) {
+            fl::this_thread::sleep_for(fl::chrono::milliseconds(1));  // ok sleep for - blocking retry in test
         }
     }
 

--- a/tests/fl/stl/asio/test_tcp_socket.cpp
+++ b/tests/fl/stl/asio/test_tcp_socket.cpp
@@ -3,6 +3,8 @@
 #include "fl/stl/asio/error_code.cpp.hpp"
 #include "fl/stl/asio/ip/tcp.h"
 #include "fl/stl/asio/ip/tcp.cpp.hpp"
+#include "fl/stl/thread.h"
+#include "fl/stl/chrono.h"
 
 #include "test.h"
 
@@ -103,12 +105,14 @@ FL_TEST_CASE("tcp::socket - Loopback connect and I/O") {
     FL_CHECK(client.is_open());
 
     // Server accepts (with retry loop for non-blocking socket)
+    // Sleep between retries to give the kernel time to complete the TCP handshake
     tcp::socket server_peer;
     for (int attempt = 0; attempt < 100; ++attempt) {
         ec = acc.accept(server_peer);
         if (ec.code != errc::would_block) {
             break;
         }
+        fl::this_thread::sleep_for(fl::chrono::milliseconds(1));  // ok sleep for - blocking retry in test
     }
     FL_CHECK(ec.ok());
     FL_CHECK(server_peer.is_open());


### PR DESCRIPTION
Note: please process https://github.com/FastLED/FastLED/pull/2201 first as that is needed to test this PR, this PR can be merged after testing completes.

## Summary

  ### Audio: Fix FFT bin0 appearing empty in AudioReactive

  `AudioReactive::begin()` computed the pink noise reference frequency using
  **linear** bin spacing when CQ output bins are actually **log-spaced**.

  With fmin=90 Hz, fmax=14080 Hz, 16 bands:
  - Wrong (linear): `f_ref ≈ 7745 Hz` → bin0 pink noise gain ≈ 0.11
  - Correct (log): `f_ref ≈ 1126 Hz` → bin0 pink noise gain ≈ 0.28

  Combined with the always-applied A-weighting coefficient of 0.5 for bin0, the
  old code suppressed bin0 to ~5% of its raw FFT value. The fix brings it to ~14%.

  Also fixed the dominant frequency calculation which used a linear deltaF formula
  (returning ~527 Hz for bin0 instead of the correct 90 Hz). Now uses
  `mFFTBins.binToFreq(maxBin)` for the correct log-spaced result.

  **Files:** `src/fl/audio/audio_reactive.cpp.hpp`

  ---

  ### Networking: Fix compile errors on embedded platforms (ESP32)

  `stream_client.h` and `stream_server.h` included `NativeHttpClient` /
  `NativeHttpServer` unconditionally, but those types only exist on platforms
  where `FASTLED_HAS_NETWORKING` is defined. This caused "undeclared identifier"
  errors when compiling for ESP32 or other embedded targets.

  Added `#ifdef FASTLED_HAS_NETWORKING` guards to both headers and their
  `.cpp.hpp` implementation files.

  **Files:** `src/fl/net/http/stream_client.h`, `stream_client.cpp.hpp`,
  `stream_server.h`, `stream_server.cpp.hpp`

  ---

  ### Fix `-Wdeprecated-declarations` in blur.h

  The deprecated `fl::blur2d(CRGB*, u8, u8, fract8)` wrapper called the
  deprecated `gfx::blur2d(...)`, generating a spurious warning when a deprecated
  function calls another deprecated function. Added
  `FL_DISABLE_WARNING_PUSH/POP` around the wrapper to suppress it.

  **File:** `src/fl/gfx/blur.h`

  ---

  ### Fix JavaScript linting on macOS/Linux

  `ci/lint-js-fast` checked for `eslint.cmd` (Windows-only) but not `eslint`
  (macOS/Linux), causing the linting stage to fail with "ESLint not found" on
  non-Windows platforms.

  **File:** `ci/lint-js-fast`

  ---

  ### Fix networking test stability (macOS)

  Three tests were failing consistently or under parallel load:

  1. **`fl_remote_loopback` SIGSEGV** — `FL_REQUIRE(got_response)` records
     failure but continues execution; `response["result"].as_int().value()` then
     dereferenced a null pointer from an empty optional. Fixed by guarding the
     response assertions with `if (got_response)`.

  2. **`test_tcp_acceptor` "Multiple clients"** — 100-iteration tight loop
     completed in <100 µs on macOS but the loopback TCP handshake takes ~300 µs,
     so `accept()` never found a completed connection. Fixed by sleeping 1 ms
     between retries.

  3. **`test_tcp_socket` loopback I/O** — Same root cause. Fixed the same way.

  **Files:** `tests/fl/remote/loopback.cpp`,
  `tests/fl/stl/asio/test_tcp_acceptor.cpp`,
  `tests/fl/stl/asio/test_tcp_socket.cpp`

  ---

  ## Test plan

  - [ ] `bash test tests/fl/audio/audio_reactive` — verify bin0 is non-zero
  - [ ] `bash test tests/fl/remote/loopback.cpp` — passes without SIGSEGV
  - [ ] `bash test tests/fl/stl/asio/test_tcp_acceptor.cpp` — "Multiple clients" passes
  - [ ] `bash test tests/fl/stl/asio/test_tcp_socket.cpp` — loopback I/O passes
  - [ ] `bash compile uno` or `bash compile esp32s3` — no compile errors on embedded
  - [ ] `bash lint` — no lint violations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed test timing issues in TCP connection handling to ensure proper handshake completion.

* **Deprecations**
  * Deprecated `blur2d()` overload without XYMap parameter; use the XYMap-based variant instead.

* **Improvements**
  * Enhanced cross-platform support for development tools.
  * Refined audio frequency analysis calculations for improved accuracy.
  * Optimized networking features with conditional compilation support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->