### PR TITLE
fix(esp32): resolve SPI/LCD_SPI buffer growth failure on channel reuse

### DIFF
--- a/src/fl/channels/channel.cpp.hpp
+++ b/src/fl/channels/channel.cpp.hpp
@@ -153,10 +153,8 @@ Channel::Channel(const ChipsetVariant& chipset, EOrder rgbOrder, RegistrationMod
     , mAffinity()
     , mId(nextId())
     , mName(makeName(mId)) {
-    fl::pinMode(getPin(), fl::PinMode::InputPulldown);
-    if (const SpiChipsetConfig* spi = chipset.ptr<SpiChipsetConfig>()) {
-        fl::pinMode(spi->clockPin, fl::PinMode::InputPulldown);
-    }
+    // NOTE: Do NOT call fl::pinMode() here — see comment in the
+    // Channel(ChipsetVariant, span, EOrder, ChannelOptions) constructor.
     mChannelData = ChannelData::create(mChipset);
 }
 
@@ -169,15 +167,11 @@ Channel::Channel(const ChipsetVariant& chipset, fl::span<CRGB> leds,
     , mAffinity(options.mAffinity)  // Get affinity from ChannelOptions
     , mId(nextId())
     , mName(makeName(mId)) {
-    // Initialize GPIO with pulldown to ensure stable LOW state
-    // This prevents RX from capturing noise/glitches on uninitialized pins
-    // Must happen before any driver initialization
-    fl::pinMode(getPin(), fl::PinMode::InputPulldown);
-
-    // For SPI chipsets, also initialize the clock pin
-    if (const SpiChipsetConfig* spi = chipset.ptr<SpiChipsetConfig>()) {
-        fl::pinMode(spi->clockPin, fl::PinMode::InputPulldown);
-    }
+    // NOTE: Do NOT call fl::pinMode() here. The pin may already be
+    // configured for SPI output by a persistent driver (ChannelEngineSpi).
+    // Calling pinMode(InputPulldown) would disconnect the SPI MOSI from the
+    // GPIO matrix, causing subsequent transmissions to produce no output.
+    // The driver will configure the pin when it first uses it.
 
     // Set the LED data array
     setLeds(leds);
@@ -202,8 +196,8 @@ Channel::Channel(int pin, const ChipsetTimingConfig& timing, fl::span<CRGB> leds
     , mAffinity(options.mAffinity)  // Get affinity from ChannelOptions
     , mId(nextId())
     , mName(makeName(mId)) {
-    // Initialize GPIO with pulldown to ensure stable LOW state
-    fl::pinMode(pin, fl::PinMode::InputPulldown);
+    // NOTE: Do NOT call fl::pinMode() here — see comment in the
+    // Channel(ChipsetVariant, span, EOrder, ChannelOptions) constructor.
 
     // Set the LED data array
     setLeds(leds);

--- a/src/platforms/esp/32/drivers/lcd_spi/lcd_spi_peripheral_esp.cpp.hpp
+++ b/src/platforms/esp/32/drivers/lcd_spi/lcd_spi_peripheral_esp.cpp.hpp
@@ -27,6 +27,14 @@
 #include "esp_timer.h"
 #include "platforms/esp/esp_version.h"
 
+// Cache sync for PSRAM DMA buffers (IDF 5.0+)
+#if FL_HAS_INCLUDE("esp_cache.h")
+#include "esp_cache.h"
+#define FL_HAS_ESP_CACHE_MSYNC 1
+#else
+#define FL_HAS_ESP_CACHE_MSYNC 0
+#endif
+
 #ifndef LCD_SPI_PSRAM_ALIGNMENT
 #define LCD_SPI_PSRAM_ALIGNMENT 64
 #endif
@@ -83,7 +91,7 @@ LcdSpiPeripheralEsp &LcdSpiPeripheralEsp::instance() FL_NOEXCEPT {
 LcdSpiPeripheralEsp::LcdSpiPeripheralEsp() FL_NOEXCEPT
     : mInitialized(false), mConfig(), mI80Bus(nullptr), mPanelIo(nullptr),
       mCompleteSem(nullptr), mCallback(nullptr), mUserCtx(nullptr),
-      mBusy(false) {}
+      mBusy(false), mLastTransmitSize(0) {}
 
 LcdSpiPeripheralEsp::~LcdSpiPeripheralEsp() { deinitialize(); }
 
@@ -165,34 +173,19 @@ bool LcdSpiPeripheralEsp::initialize(const LcdSpiConfig &config) FL_NOEXCEPT {
         return false;
     }
 
-    esp_lcd_panel_io_i80_config_t io_config = {};
-    io_config.cs_gpio_num = -1;
-    io_config.pclk_hz = config.clock_hz;
-    io_config.trans_queue_depth = 1;
-    io_config.dc_levels = {
-        .dc_idle_level = 0,
-        .dc_cmd_level = 0,
-        .dc_dummy_level = 0,
-        .dc_data_level = 1,
-    };
-    io_config.lcd_cmd_bits = 0;
-    io_config.lcd_param_bits = 0;
-    io_config.user_ctx = this;
-    io_config.on_color_trans_done = lcd_spi_flush_ready;
+    // Panel IO is created lazily in transmit() so it can be recreated
+    // when the transaction size changes. This avoids stale GDMA
+    // descriptor state between different-sized transfers.
 
-    err = esp_lcd_new_panel_io_i80(mI80Bus, &io_config, &mPanelIo);
-    if (err != ESP_OK) {
-        FL_WARN("LcdSpiPeripheralEsp: Failed to create panel IO: " << err);
-        esp_lcd_del_i80_bus(mI80Bus);
-        mI80Bus = nullptr;
-        return false;
-    }
-
-    // Create completion semaphore
+    // Create completion semaphore and prime it so the first transmit()
+    // can take it without blocking. Subsequent transmits wait for the
+    // ISR to give the semaphore after DMA completion.
     if (mCompleteSem == nullptr) {
         mCompleteSem = xSemaphoreCreateBinary();
+        xSemaphoreGive(mCompleteSem);
     }
 
+    mLastTransmitSize = 0;
     mInitialized = true;
     FL_DBG("LcdSpiPeripheralEsp: Initialized with " << config.num_lanes
            << " lanes, " << config.clock_hz << " Hz clock");
@@ -216,6 +209,7 @@ void LcdSpiPeripheralEsp::deinitialize() FL_NOEXCEPT {
     mCallback = nullptr;
     mUserCtx = nullptr;
     mBusy = false;
+    mLastTransmitSize = 0;
 }
 
 bool LcdSpiPeripheralEsp::isInitialized() const FL_NOEXCEPT {
@@ -258,26 +252,84 @@ void LcdSpiPeripheralEsp::freeBuffer(u16 *buffer) FL_NOEXCEPT {
 
 bool LcdSpiPeripheralEsp::transmit(const u16 *buffer,
                                    size_t size_bytes) FL_NOEXCEPT {
-    if (!mInitialized || mPanelIo == nullptr) {
+    if (!mInitialized || mI80Bus == nullptr) {
         return false;
     }
 
-    // Drain stale semaphore from a previous transmit whose completion
-    // was detected via isBusy() rather than waitTransmitDone().
-    // Without this, esp_lcd_panel_io_tx_color may silently fail to
-    // start DMA on the second call because the I80 transaction queue
-    // (depth=1) still holds the completed-but-unconsumed transaction.
+    // Block until previous DMA is truly complete. The semaphore is
+    // primed during initialize() so the first call returns immediately.
+    // This is stronger than the old non-blocking drain — it guarantees
+    // the I80 bus has fully processed the previous transaction before
+    // we submit a new one.
     if (mCompleteSem) {
-        xSemaphoreTake(mCompleteSem, 0);
+        if (xSemaphoreTake(mCompleteSem, pdMS_TO_TICKS(2000)) != pdTRUE) {
+            FL_WARN("LcdSpiPeripheralEsp: Timed out waiting for previous "
+                    "transmit to complete");
+            mBusy = false;
+            return false;
+        }
     }
 
+    // Recreate panel IO when transaction size changes. The ESP-IDF I80
+    // bus driver builds a GDMA descriptor chain sized for each
+    // transaction. Reusing the same panel_io handle with a different
+    // size can leave stale DMA descriptor state that causes the second
+    // transmit to produce no output (ESP_OK but no DMA activity).
+    // Recreating panel_io is cheap (descriptor alloc + config) and does
+    // not touch the I80 bus GPIO routing.
+    if (size_bytes != mLastTransmitSize && mPanelIo != nullptr) {
+        esp_lcd_panel_io_del(mPanelIo);
+        mPanelIo = nullptr;
+    }
+
+    if (mPanelIo == nullptr) {
+        esp_lcd_panel_io_i80_config_t io_config = {};
+        io_config.cs_gpio_num = -1;
+        io_config.pclk_hz = mConfig.clock_hz;
+        io_config.trans_queue_depth = 1;
+        io_config.dc_levels = {
+            .dc_idle_level = 0,
+            .dc_cmd_level = 0,
+            .dc_dummy_level = 0,
+            .dc_data_level = 1,
+        };
+        io_config.lcd_cmd_bits = 0;
+        io_config.lcd_param_bits = 0;
+        io_config.user_ctx = this;
+        io_config.on_color_trans_done = lcd_spi_flush_ready;
+
+        esp_err_t err =
+            esp_lcd_new_panel_io_i80(mI80Bus, &io_config, &mPanelIo);
+        if (err != ESP_OK) {
+            FL_WARN("LcdSpiPeripheralEsp: Failed to recreate panel IO: "
+                    << err);
+            return false;
+        }
+    }
+
+    // Flush CPU cache to PSRAM so DMA sees the latest buffer contents.
+    // esp_lcd_panel_io_tx_color() should handle this internally in
+    // IDF 5.2+, but explicit sync guards against edge cases where the
+    // same buffer pointer is reused with different data.
+#if FL_HAS_ESP_CACHE_MSYNC
+    {
+        // Round up to cache-line boundary (64 bytes). Safe because the
+        // buffer allocation is always 64-byte aligned and oversized.
+        size_t sync_size = ((size_bytes + 63) & ~(size_t)63);
+        esp_cache_msync((void *)buffer, sync_size,
+                        ESP_CACHE_MSYNC_FLAG_DIR_C2M);
+    }
+#endif
+
     mBusy = true;
+    mLastTransmitSize = size_bytes;
 
     esp_err_t err =
         esp_lcd_panel_io_tx_color(mPanelIo, 0x2C, buffer, size_bytes);
 
     if (err != ESP_OK) {
         mBusy = false;
+        FL_WARN("LcdSpiPeripheralEsp: tx_color failed: " << err);
         return false;
     }
 

--- a/src/platforms/esp/32/drivers/lcd_spi/lcd_spi_peripheral_esp.h
+++ b/src/platforms/esp/32/drivers/lcd_spi/lcd_spi_peripheral_esp.h
@@ -83,6 +83,7 @@ class LcdSpiPeripheralEsp : public ILcdSpiPeripheral {
     void *mCallback;
     void *mUserCtx;
     volatile bool mBusy;
+    size_t mLastTransmitSize;
 };
 
 } // namespace detail

--- a/src/platforms/esp/32/drivers/rmt_rx/rmt_rx_channel.cpp.hpp
+++ b/src/platforms/esp/32/drivers/rmt_rx/rmt_rx_channel.cpp.hpp
@@ -1243,6 +1243,7 @@ class RmtRxChannelImpl : public RmtRxChannel {
     void clear() FL_NOEXCEPT {
         mReceiveDone = false;
         mSymbolsReceived = 0;
+        mAccumulationOffset = 0;
         // mSkipCounter is set in begin(), not here
         FL_LOG_RX("RX state cleared");
     }

--- a/src/platforms/esp/32/drivers/spi/channel_driver_spi.cpp.hpp
+++ b/src/platforms/esp/32/drivers/spi/channel_driver_spi.cpp.hpp
@@ -690,7 +690,25 @@ ChannelEngineSpi::acquireChannel(gpio_num_t pin, const ChipsetTimingConfig &timi
             channel.ledBytesRemaining = 0;
 
             if (channel.spi_host != SPI_HOST_MAX) {
-                // SPI hardware still allocated - reuse directly (same pin + timing)
+                // SPI hardware still allocated - reuse directly (same pin + timing).
+                // Reallocate LED source buffer if the new data is larger
+                // than the existing buffer. Without this, larger strips
+                // fall back to ISR-unsafe direct PSRAM access.
+                if (channel.ledSourceBufferSize < dataSize) {
+                    if (channel.ledSourceBuffer) {
+                        heap_caps_free(channel.ledSourceBuffer);
+                    }
+                    channel.ledSourceBuffer = (u8 *)heap_caps_malloc(
+                        dataSize,
+                        MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
+                    channel.ledSourceBufferSize =
+                        channel.ledSourceBuffer ? dataSize : 0;
+                    if (!channel.ledSourceBuffer) {
+                        FL_WARN("ChannelEngineSpi: Failed to reallocate "
+                                "LED source buffer ("
+                                << dataSize << " bytes)");
+                    }
+                }
                 FL_DBG_EVERY(100, "ChannelEngineSpi: Reusing SPI for pin " << pin);
                 return &channel;
             }


### PR DESCRIPTION
## Summary
- Fix SPI/LCD_SPI driver failure when strip size changes between `FastLED.clear()` + `FastLED.add()` cycles
- Root cause: Channel constructor called `fl::pinMode(pin, InputPulldown)` which disconnected the SPI MOSI from the GPIO matrix, breaking the persistent SPI driver's output
- Harden LCD_SPI peripheral with semaphore-based synchronization, lazy panel IO recreation on size change, and explicit PSRAM cache sync

Closes #2249

## Changes
| File | Change |
|------|--------|
| `channel.cpp.hpp` | Remove `fl::pinMode(InputPulldown)` from all 3 Channel constructors — the driver configures the pin |
| `channel_driver_spi.cpp.hpp` | Reallocate `ledSourceBuffer` on channel reuse when data exceeds existing buffer |
| `lcd_spi_peripheral_esp.cpp.hpp` | Semaphore priming, blocking wait, lazy panel IO with size-based recreation, `esp_cache_msync` |
| `lcd_spi_peripheral_esp.h` | Add `mLastTransmitSize` field for tracking transaction size changes |
| `rmt_rx_channel.cpp.hpp` | Reset `mAccumulationOffset` in `clear()` to prevent stale write position on re-arm |

## Test plan
- [x] 298/298 host unit tests pass
- [x] `bash autoresearch --spi --strip-sizes 100,250` — both pass
- [x] `bash autoresearch --spi --strip-sizes 100,250,100` — all 3 pass (round-trip)
- [x] `bash autoresearch --spi --strip-sizes 250` — standalone pass
- [ ] `bash autoresearch --i2s` — verify I2S LCD_CAM driver unaffected
- [ ] `bash autoresearch --all` — full driver matrix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed RMT receive channel state reset to properly clear accumulation offset.
  * Improved SPI channel buffer reallocation for reused channels with larger data transfers.

* **Improvements**
  * Enhanced LCD display driver with optimized DMA completion handling and PSRAM cache synchronization support.
  * Improved pin configuration timing for channel initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->