### PR TITLE
fix(esp32): add noinline to IRAM_ATTR functions in RMT4 header

### DIFF
--- a/src/platforms/esp/32/drivers/rmt/rmt_4/channel_driver_rmt4.h
+++ b/src/platforms/esp/32/drivers/rmt/rmt_4/channel_driver_rmt4.h
@@ -277,10 +277,11 @@ private:
     bool mInitialized;
 
     // ═══════════════════════════════════════════════════════════════════════════
-    // ISR Handlers (IRAM) - INLINED TO AVOID DUPLICATE IRAM_ATTR
+    // ISR Handlers (IRAM) - noinline to prevent GCC 14+ literal pool
+    // reordering on Xtensa (l32r: literal placed after use)
     // ═══════════════════════════════════════════════════════════════════════════
 
-    static inline IRAM_ATTR void handleInterrupt(void* arg) FL_NOEXCEPT {
+    static __attribute__((noinline)) IRAM_ATTR void handleInterrupt(void* arg) FL_NOEXCEPT {
         // Main ISR dispatcher
         auto* driver = static_cast<ChannelEngineRMT4Impl*>(arg);
 
@@ -328,7 +329,7 @@ private:
         }
     }
 
-    inline IRAM_ATTR void onThresholdInterrupt(int channelNum) FL_NOEXCEPT {
+    __attribute__((noinline)) IRAM_ATTR void onThresholdInterrupt(int channelNum) FL_NOEXCEPT {
         // Threshold interrupt: Half of the RMT buffer has been transmitted
         ChannelState* state = findChannelByNumber(channelNum);
         if (state == nullptr || !state->inUse) {
@@ -339,7 +340,7 @@ private:
         fillNextBuffer(state, true);
     }
 
-    inline IRAM_ATTR void onTxDoneInterrupt(int channelNum) FL_NOEXCEPT {
+    __attribute__((noinline)) IRAM_ATTR void onTxDoneInterrupt(int channelNum) FL_NOEXCEPT {
         // TX done interrupt: Transmission is complete on this channel
         ChannelState* state = findChannelByNumber(channelNum);
         if (state == nullptr || !state->inUse) {
@@ -370,7 +371,7 @@ private:
         state->transmissionComplete = true;
     }
 
-    inline IRAM_ATTR void fillNextBuffer(ChannelState* state, bool checkTime) FL_NOEXCEPT {
+    __attribute__((noinline)) IRAM_ATTR void fillNextBuffer(ChannelState* state, bool checkTime) FL_NOEXCEPT {
         // Fill the next half of the RMT double-buffer with pixel data
         if (!state) {
             return;
@@ -420,7 +421,7 @@ private:
         state->memPtr = pItem;
     }
 
-    static inline IRAM_ATTR void convertByteToRMT(
+    static __attribute__((noinline)) IRAM_ATTR void convertByteToRMT(
         u8 byteval,
         const rmt_item32_t& zero,
         const rmt_item32_t& one,
@@ -451,7 +452,7 @@ private:
         pItem[7].val = tmp[7];
     }
 
-    static inline IRAM_ATTR void tx_start(ChannelState* state) FL_NOEXCEPT {
+    static __attribute__((noinline)) IRAM_ATTR void tx_start(ChannelState* state) FL_NOEXCEPT {
         // Start RMT transmission by setting hardware flag
         if (!state) {
             return;
@@ -532,7 +533,7 @@ private:
 #endif
     }
 
-    inline IRAM_ATTR ChannelState* findChannelByNumber(int channelNum) FL_NOEXCEPT {
+    __attribute__((noinline)) IRAM_ATTR ChannelState* findChannelByNumber(int channelNum) FL_NOEXCEPT {
         // Linear search through active channels
         for (auto& state : mChannels) {
             if (state.inUse && state.channel == channelNum) {


### PR DESCRIPTION
## Summary
- Replace `inline` with `__attribute__((noinline))` on 7 IRAM_ATTR functions in `channel_driver_rmt4.h`
- GCC 14+ on Xtensa reorders literal pools, placing `l32r` constants after the instruction that references them, causing linker errors: `dangerous relocation: l32r: literal placed after use`
- `noinline` prevents the compiler from inlining these ISR functions across translation units, keeping literal pool placement stable

## Context
- Root cause identified in #2203 (comment) and referenced from #2247 (comment)
- Same fix pattern that resolved the identical issue in the old Yves `I2SClockBasedLedDriver.h`

## Files changed
- `src/platforms/esp/32/drivers/rmt/rmt_4/channel_driver_rmt4.h` — 7 functions: `handleInterrupt`, `onThresholdInterrupt`, `onTxDoneInterrupt`, `fillNextBuffer`, `convertByteToRMT`, `tx_start`, `findChannelByNumber`

## Test plan
- [ ] Verify esp32dev build with GCC 14 toolchain (no l32r linker errors)
- [ ] Verify RMT4 LED output still works on esp32dev
- [ ] Verify no regression on esp32s3 (RMT5 path unaffected)

Closes #2247

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Optimized internal RMT driver implementation for enhanced stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->