### PR TITLE
feat(ci): add GitHub Projects v2 automation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,130 @@
+name: Bug Report
+description: Report a bug in FastLED
+labels: ["type: bug", "status: triage"]
+body:
+  - type: dropdown
+    id: board
+    attributes:
+      label: Board / MCU
+      description: Which board or microcontroller are you using?
+      options:
+        - ESP32
+        - ESP32-S2
+        - ESP32-S3
+        - ESP32-C3
+        - ESP32-C6
+        - ESP32-H2
+        - ESP8266
+        - Arduino Uno (ATmega328P)
+        - Arduino Mega (ATmega2560)
+        - ATtiny85
+        - ATtiny1616
+        - Teensy 3.x
+        - Teensy 4.x
+        - RP2040 (Pico)
+        - STM32 (Bluepill)
+        - SAMD21
+        - SAMD51
+        - nRF52840
+        - Apollo3
+        - Other
+    validations:
+      required: true
+
+  - type: dropdown
+    id: led-chipset
+    attributes:
+      label: LED Chipset
+      description: Which LED chipset are you using?
+      options:
+        - WS2812B / NeoPixel
+        - WS2811
+        - APA102 / DotStar
+        - SK9822
+        - WS2801
+        - LPD8806
+        - SM16703
+        - TM1809
+        - TM1804
+        - UCS1903
+        - GW6205
+        - Other
+        - N/A
+    validations:
+      required: true
+
+  - type: input
+    id: fastled-version
+    attributes:
+      label: FastLED Version
+      description: Which version of FastLED are you using?
+      placeholder: "e.g. 3.9.7 or git master"
+    validations:
+      required: true
+
+  - type: input
+    id: arduino-platformio-version
+    attributes:
+      label: Arduino / PlatformIO version
+      description: Which IDE and version are you using?
+      placeholder: "e.g. Arduino IDE 2.3.2, PlatformIO 6.1"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: operating-system
+    attributes:
+      label: Operating System
+      description: Which OS are you developing on?
+      options:
+        - Windows
+        - macOS
+        - Linux
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Describe the bug. What did you expect vs what happened?
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps to reproduce the issue
+    validations:
+      required: true
+
+  - type: textarea
+    id: minimal-sketch
+    attributes:
+      label: Minimal sketch
+      description: Paste the smallest sketch that reproduces the issue
+      render: shell
+    validations:
+      required: false
+
+  - type: textarea
+    id: serial-debug-output
+    attributes:
+      label: Serial / debug output
+      description: Paste any relevant serial monitor output
+      render: shell
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      options:
+        - label: I have searched existing issues for duplicates
+          required: true
+        - label: I have tested with the latest FastLED release or git master
+          required: true
+        - label: I can reproduce this with a minimal sketch
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: FastLED Documentation
+    url: https://fastled.io/docs
+    about: Check the documentation before opening an issue
+  - name: FastLED Reddit
+    url: https://www.reddit.com/r/FastLED/
+    about: Ask usage questions on the FastLED subreddit
+  - name: FastLED Discord
+    url: https://discord.gg/fastled
+    about: Chat with the community on Discord

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,53 @@
+name: Feature Request
+description: Suggest a new feature or enhancement
+labels: ["type: feature", "status: triage"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: "What problem does this solve? (e.g. I'm frustrated when...)"
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed-solution
+    attributes:
+      label: Proposed solution
+      description: Describe the solution you'd like
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives-considered
+    attributes:
+      label: Alternatives considered
+      description: Any alternative approaches you've considered
+    validations:
+      required: false
+
+  - type: dropdown
+    id: platform-relevance
+    attributes:
+      label: Platform relevance
+      description: Which platforms does this feature apply to?
+      multiple: true
+      options:
+        - All platforms
+        - ESP32
+        - AVR
+        - Teensy
+        - RP2040
+        - STM32
+        - WASM/Web
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: "Anything else \u2014 links, screenshots, references"
+    validations:
+      required: false

--- a/.github/workflows/project_automation.yml
+++ b/.github/workflows/project_automation.yml
@@ -1,0 +1,50 @@
+name: project-automation
+
+on:
+  issues:
+    types: [opened, closed, reopened]
+  pull_request_target:
+    types: [opened, closed, reopened, converted_to_draft, ready_for_review]
+
+permissions:
+  contents: read
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    if: >-
+      vars.GITHUB_PROJECT_NUMBER != '' &&
+      vars.GITHUB_PROJECT_OWNER != ''
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: ci
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.GITHUB_PROJECT_APP_ID }}
+          private-key: ${{ secrets.GITHUB_PROJECT_APP_PRIVATE_KEY }}
+          owner: ${{ vars.GITHUB_PROJECT_OWNER }}
+
+      - name: Sync to project board
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PROJECT_OWNER: ${{ vars.GITHUB_PROJECT_OWNER }}
+          PROJECT_OWNER_TYPE: ${{ vars.GITHUB_PROJECT_OWNER_TYPE || 'organization' }}
+          PROJECT_NUMBER: ${{ vars.GITHUB_PROJECT_NUMBER }}
+          STATUS_FIELD: ${{ vars.GITHUB_PROJECT_STATUS_FIELD_NAME || 'Status' }}
+          STATUS_TODO: ${{ vars.GITHUB_PROJECT_STATUS_TODO || 'Todo' }}
+          STATUS_DONE: ${{ vars.GITHUB_PROJECT_STATUS_DONE || 'Done' }}
+          STATUS_DRAFT: ${{ vars.GITHUB_PROJECT_STATUS_DRAFT || '' }}
+          DATE_FIELD: ${{ vars.GITHUB_PROJECT_DATE_FIELD_NAME || '' }}
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_ACTION: ${{ github.event.action }}
+          ITEM_NODE_ID: ${{ github.event.issue.node_id || github.event.pull_request.node_id }}
+          IS_DRAFT: ${{ github.event.pull_request.draft || 'false' }}
+        run: python ci/github_project_sync.py

--- a/.github/workflows/project_automation.yml
+++ b/.github/workflows/project_automation.yml
@@ -39,10 +39,10 @@ jobs:
           PROJECT_OWNER_TYPE: ${{ vars.GITHUB_PROJECT_OWNER_TYPE || 'organization' }}
           PROJECT_NUMBER: ${{ vars.GITHUB_PROJECT_NUMBER }}
           STATUS_FIELD: ${{ vars.GITHUB_PROJECT_STATUS_FIELD_NAME || 'Status' }}
-          STATUS_TODO: ${{ vars.GITHUB_PROJECT_STATUS_TODO || 'Todo' }}
+          STATUS_TODO: ${{ vars.GITHUB_PROJECT_STATUS_TODO || 'Triage' }}
           STATUS_DONE: ${{ vars.GITHUB_PROJECT_STATUS_DONE || 'Done' }}
-          STATUS_DRAFT: ${{ vars.GITHUB_PROJECT_STATUS_DRAFT || '' }}
-          DATE_FIELD: ${{ vars.GITHUB_PROJECT_DATE_FIELD_NAME || '' }}
+          STATUS_DRAFT: ${{ vars.GITHUB_PROJECT_STATUS_DRAFT || 'In Progress' }}
+          DATE_FIELD: ${{ vars.GITHUB_PROJECT_DATE_FIELD_NAME || 'Date posted' }}
           EVENT_NAME: ${{ github.event_name }}
           EVENT_ACTION: ${{ github.event.action }}
           ITEM_NODE_ID: ${{ github.event.issue.node_id || github.event.pull_request.node_id }}

--- a/.github/workflows/project_automation.yml
+++ b/.github/workflows/project_automation.yml
@@ -13,8 +13,8 @@ jobs:
   sync:
     runs-on: ubuntu-latest
     if: >-
-      vars.GITHUB_PROJECT_NUMBER != '' &&
-      vars.GITHUB_PROJECT_OWNER != ''
+      vars.PROJECT_NUMBER != '' &&
+      vars.PROJECT_OWNER != ''
     steps:
       - uses: actions/checkout@v4
         with:
@@ -28,21 +28,21 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v1
         with:
-          app-id: ${{ vars.GITHUB_PROJECT_APP_ID }}
-          private-key: ${{ secrets.GITHUB_PROJECT_APP_PRIVATE_KEY }}
-          owner: ${{ vars.GITHUB_PROJECT_OWNER }}
+          app-id: ${{ vars.PROJECT_APP_ID }}
+          private-key: ${{ secrets.PROJECT_APP_PRIVATE_KEY }}
+          owner: ${{ vars.PROJECT_OWNER }}
 
       - name: Sync to project board
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          PROJECT_OWNER: ${{ vars.GITHUB_PROJECT_OWNER }}
-          PROJECT_OWNER_TYPE: ${{ vars.GITHUB_PROJECT_OWNER_TYPE || 'organization' }}
-          PROJECT_NUMBER: ${{ vars.GITHUB_PROJECT_NUMBER }}
-          STATUS_FIELD: ${{ vars.GITHUB_PROJECT_STATUS_FIELD_NAME || 'Status' }}
-          STATUS_TODO: ${{ vars.GITHUB_PROJECT_STATUS_TODO || 'Triage' }}
-          STATUS_DONE: ${{ vars.GITHUB_PROJECT_STATUS_DONE || 'Done' }}
-          STATUS_DRAFT: ${{ vars.GITHUB_PROJECT_STATUS_DRAFT || 'In Progress' }}
-          DATE_FIELD: ${{ vars.GITHUB_PROJECT_DATE_FIELD_NAME || 'Date posted' }}
+          PROJECT_OWNER: ${{ vars.PROJECT_OWNER }}
+          PROJECT_OWNER_TYPE: ${{ vars.PROJECT_OWNER_TYPE || 'organization' }}
+          PROJECT_NUMBER: ${{ vars.PROJECT_NUMBER }}
+          STATUS_FIELD: ${{ vars.PROJECT_STATUS_FIELD_NAME || 'Status' }}
+          STATUS_TODO: ${{ vars.PROJECT_STATUS_TODO || 'Triage' }}
+          STATUS_DONE: ${{ vars.PROJECT_STATUS_DONE || 'Done' }}
+          STATUS_DRAFT: ${{ vars.PROJECT_STATUS_DRAFT || 'In Progress' }}
+          DATE_FIELD: ${{ vars.PROJECT_DATE_FIELD_NAME || 'Date posted' }}
           EVENT_NAME: ${{ github.event_name }}
           EVENT_ACTION: ${{ github.event.action }}
           ITEM_NODE_ID: ${{ github.event.issue.node_id || github.event.pull_request.node_id }}

--- a/ci/github_project_sync.py
+++ b/ci/github_project_sync.py
@@ -18,8 +18,23 @@ import subprocess
 import sys
 from dataclasses import dataclass
 from datetime import datetime, timezone
+from typing import Any
+
+from typeguard import typechecked
+
+VALID_OWNER_TYPES = {"organization", "user"}
 
 
+@typechecked
+@dataclass
+class FieldOption:
+    """Resolved field and option IDs for a single-select project field."""
+
+    field_id: str
+    option_id: str
+
+
+@typechecked
 @dataclass
 class Config:
     """Configuration parsed from environment variables."""
@@ -38,7 +53,7 @@ class Config:
     is_draft: bool
 
     @classmethod
-    def from_env(cls) -> Config:
+    def from_env(cls: type[Config]) -> Config:
         """Parse configuration from environment variables."""
         project_number_raw = os.environ.get("PROJECT_NUMBER", "")
         if not project_number_raw:
@@ -64,19 +79,18 @@ class Config:
         )
 
 
-def graphql(query: str, variables: dict | None = None) -> dict:
+def graphql(query: str, variables: dict[str, Any]) -> dict[str, Any]:
     """Execute a GitHub GraphQL query via the gh CLI."""
     cmd = ["gh", "api", "graphql", "-f", f"query={query}"]
-    if variables:
-        for key, value in variables.items():
-            cmd.extend(["-F", f"{key}={value}"])
+    for key, value in variables.items():
+        cmd.extend(["-F", f"{key}={value}"])
 
     result = subprocess.run(cmd, capture_output=True, text=True, check=False)
     if result.returncode != 0:
         print(f"GraphQL error (stderr): {result.stderr}", file=sys.stderr)
         raise SystemExit(f"GraphQL request failed: {result.returncode}")
 
-    data = json.loads(result.stdout)
+    data: dict[str, Any] = json.loads(result.stdout)
     if "errors" in data:
         print(
             f"GraphQL errors: {json.dumps(data['errors'], indent=2)}", file=sys.stderr
@@ -88,6 +102,11 @@ def graphql(query: str, variables: dict | None = None) -> dict:
 
 def find_project(owner: str, owner_type: str, number: int) -> str:
     """Look up a project by owner and number, return the project node ID."""
+    if owner_type not in VALID_OWNER_TYPES:
+        raise SystemExit(
+            f"PROJECT_OWNER_TYPE must be 'organization' or 'user', got '{owner_type}'"
+        )
+
     if owner_type == "organization":
         query = """
         query($owner: String!, $number: Int!) {
@@ -99,7 +118,12 @@ def find_project(owner: str, owner_type: str, number: int) -> str:
         }
         """
         data = graphql(query, {"owner": owner, "number": number})
-        return data["data"]["organization"]["projectV2"]["id"]
+        project = data["data"]["organization"]["projectV2"]
+        if not project:
+            raise SystemExit(
+                f"Project #{number} not found for organization '{owner}'"
+            )
+        return project["id"]
     else:
         query = """
         query($owner: String!, $number: Int!) {
@@ -111,7 +135,10 @@ def find_project(owner: str, owner_type: str, number: int) -> str:
         }
         """
         data = graphql(query, {"owner": owner, "number": number})
-        return data["data"]["user"]["projectV2"]["id"]
+        project = data["data"]["user"]["projectV2"]
+        if not project:
+            raise SystemExit(f"Project #{number} not found for user '{owner}'")
+        return project["id"]
 
 
 def add_item_to_project(project_id: str, content_id: str) -> str:
@@ -131,11 +158,8 @@ def add_item_to_project(project_id: str, content_id: str) -> str:
 
 def get_field_and_option(
     project_id: str, field_name: str, option_name: str
-) -> tuple[str, str]:
-    """Find a single-select field and a specific option by name.
-
-    Returns (field_id, option_id).
-    """
+) -> FieldOption:
+    """Find a single-select field and a specific option by name."""
     query = """
     query($projectId: ID!) {
       node(id: $projectId) {
@@ -157,20 +181,28 @@ def get_field_and_option(
     }
     """
     data = graphql(query, {"projectId": project_id})
-    fields = data["data"]["node"]["fields"]["nodes"]
+    fields: list[dict[str, Any]] = data["data"]["node"]["fields"]["nodes"]
 
     for field in fields:
         if field.get("name") == field_name:
             for option in field.get("options", []):
                 if option["name"] == option_name:
-                    return field["id"], option["id"]
-            available = [o["name"] for o in field.get("options", [])]
+                    return FieldOption(
+                        field_id=field["id"], option_id=option["id"]
+                    )
+            available: list[str] = []
+            for opt in field.get("options", []):
+                available.append(opt["name"])
             raise SystemExit(
                 f"Option '{option_name}' not found in field '{field_name}'. "
                 f"Available: {available}"
             )
 
-    available_fields = [f.get("name") for f in fields if f.get("name")]
+    available_fields: list[str] = []
+    for f in fields:
+        name = f.get("name")
+        if name:
+            available_fields.append(name)
     raise SystemExit(
         f"Field '{field_name}' not found. Available: {available_fields}"
     )
@@ -196,7 +228,7 @@ def get_date_field(project_id: str, field_name: str) -> str:
     }
     """
     data = graphql(query, {"projectId": project_id})
-    fields = data["data"]["node"]["fields"]["nodes"]
+    fields: list[dict[str, Any]] = data["data"]["node"]["fields"]["nodes"]
 
     for field in fields:
         if field.get("name") == field_name and field.get("dataType") == "DATE":
@@ -275,6 +307,7 @@ def determine_status(config: Config) -> str:
 
 
 def main() -> None:
+    """Entry point: parse config, sync item to project, set status and date."""
     config = Config.from_env()
 
     if not config.project_owner:
@@ -292,10 +325,10 @@ def main() -> None:
 
     status_name = determine_status(config)
     print(f"Setting status to: {status_name}")
-    field_id, option_id = get_field_and_option(
+    resolved = get_field_and_option(
         project_id, config.status_field, status_name
     )
-    update_single_select(project_id, item_id, field_id, option_id)
+    update_single_select(project_id, item_id, resolved.field_id, resolved.option_id)
     print("Status updated")
 
     if config.date_field and config.event_action in ("opened", "ready_for_review"):

--- a/ci/github_project_sync.py
+++ b/ci/github_project_sync.py
@@ -1,0 +1,312 @@
+"""Sync GitHub issues and pull requests to a GitHub Projects v2 board.
+
+Reads configuration from environment variables set by the
+project_automation.yml workflow. Uses the GitHub GraphQL API to:
+  - look up a project by owner + number
+  - add the issue or PR to the project
+  - set a Status single-select field
+  - optionally set a Date field
+
+Requires a GitHub App token with project read/write scope.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+
+@dataclass
+class Config:
+    """Configuration parsed from environment variables."""
+
+    project_owner: str
+    project_owner_type: str  # "organization" or "user"
+    project_number: int
+    status_field: str
+    status_todo: str
+    status_done: str
+    status_draft: str  # empty string means unused
+    date_field: str  # empty string means unused
+    event_name: str
+    event_action: str
+    item_node_id: str
+    is_draft: bool
+
+    @classmethod
+    def from_env(cls) -> Config:
+        """Parse configuration from environment variables."""
+        project_number_raw = os.environ.get("PROJECT_NUMBER", "")
+        if not project_number_raw:
+            raise SystemExit("PROJECT_NUMBER is required")
+
+        item_node_id = os.environ.get("ITEM_NODE_ID", "")
+        if not item_node_id:
+            raise SystemExit("ITEM_NODE_ID is required (no issue or PR node ID)")
+
+        return cls(
+            project_owner=os.environ.get("PROJECT_OWNER", ""),
+            project_owner_type=os.environ.get("PROJECT_OWNER_TYPE", "organization"),
+            project_number=int(project_number_raw),
+            status_field=os.environ.get("STATUS_FIELD", "Status"),
+            status_todo=os.environ.get("STATUS_TODO", "Todo"),
+            status_done=os.environ.get("STATUS_DONE", "Done"),
+            status_draft=os.environ.get("STATUS_DRAFT", ""),
+            date_field=os.environ.get("DATE_FIELD", ""),
+            event_name=os.environ.get("EVENT_NAME", ""),
+            event_action=os.environ.get("EVENT_ACTION", ""),
+            item_node_id=item_node_id,
+            is_draft=os.environ.get("IS_DRAFT", "false").lower() == "true",
+        )
+
+
+def graphql(query: str, variables: dict | None = None) -> dict:
+    """Execute a GitHub GraphQL query via the gh CLI."""
+    cmd = ["gh", "api", "graphql", "-f", f"query={query}"]
+    if variables:
+        for key, value in variables.items():
+            cmd.extend(["-F", f"{key}={value}"])
+
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    if result.returncode != 0:
+        print(f"GraphQL error (stderr): {result.stderr}", file=sys.stderr)
+        raise SystemExit(f"GraphQL request failed: {result.returncode}")
+
+    data = json.loads(result.stdout)
+    if "errors" in data:
+        print(
+            f"GraphQL errors: {json.dumps(data['errors'], indent=2)}", file=sys.stderr
+        )
+        raise SystemExit("GraphQL returned errors")
+
+    return data
+
+
+def find_project(owner: str, owner_type: str, number: int) -> str:
+    """Look up a project by owner and number, return the project node ID."""
+    if owner_type == "organization":
+        query = """
+        query($owner: String!, $number: Int!) {
+          organization(login: $owner) {
+            projectV2(number: $number) {
+              id
+            }
+          }
+        }
+        """
+        data = graphql(query, {"owner": owner, "number": number})
+        return data["data"]["organization"]["projectV2"]["id"]
+    else:
+        query = """
+        query($owner: String!, $number: Int!) {
+          user(login: $owner) {
+            projectV2(number: $number) {
+              id
+            }
+          }
+        }
+        """
+        data = graphql(query, {"owner": owner, "number": number})
+        return data["data"]["user"]["projectV2"]["id"]
+
+
+def add_item_to_project(project_id: str, content_id: str) -> str:
+    """Add an issue or PR to the project. Returns the project item ID."""
+    query = """
+    mutation($projectId: ID!, $contentId: ID!) {
+      addProjectV2ItemById(input: {projectId: $projectId, contentId: $contentId}) {
+        item {
+          id
+        }
+      }
+    }
+    """
+    data = graphql(query, {"projectId": project_id, "contentId": content_id})
+    return data["data"]["addProjectV2ItemById"]["item"]["id"]
+
+
+def get_field_and_option(
+    project_id: str, field_name: str, option_name: str
+) -> tuple[str, str]:
+    """Find a single-select field and a specific option by name.
+
+    Returns (field_id, option_id).
+    """
+    query = """
+    query($projectId: ID!) {
+      node(id: $projectId) {
+        ... on ProjectV2 {
+          fields(first: 50) {
+            nodes {
+              ... on ProjectV2SingleSelectField {
+                id
+                name
+                options {
+                  id
+                  name
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    """
+    data = graphql(query, {"projectId": project_id})
+    fields = data["data"]["node"]["fields"]["nodes"]
+
+    for field in fields:
+        if field.get("name") == field_name:
+            for option in field.get("options", []):
+                if option["name"] == option_name:
+                    return field["id"], option["id"]
+            available = [o["name"] for o in field.get("options", [])]
+            raise SystemExit(
+                f"Option '{option_name}' not found in field '{field_name}'. "
+                f"Available: {available}"
+            )
+
+    available_fields = [f.get("name") for f in fields if f.get("name")]
+    raise SystemExit(
+        f"Field '{field_name}' not found. Available: {available_fields}"
+    )
+
+
+def get_date_field(project_id: str, field_name: str) -> str:
+    """Find a date field by name. Returns field_id."""
+    query = """
+    query($projectId: ID!) {
+      node(id: $projectId) {
+        ... on ProjectV2 {
+          fields(first: 50) {
+            nodes {
+              ... on ProjectV2Field {
+                id
+                name
+                dataType
+              }
+            }
+          }
+        }
+      }
+    }
+    """
+    data = graphql(query, {"projectId": project_id})
+    fields = data["data"]["node"]["fields"]["nodes"]
+
+    for field in fields:
+        if field.get("name") == field_name and field.get("dataType") == "DATE":
+            return field["id"]
+
+    raise SystemExit(f"Date field '{field_name}' not found in project")
+
+
+def update_single_select(
+    project_id: str, item_id: str, field_id: str, option_id: str
+) -> None:
+    """Update a single-select field on a project item."""
+    query = """
+    mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+      updateProjectV2ItemFieldValue(input: {
+        projectId: $projectId
+        itemId: $itemId
+        fieldId: $fieldId
+        value: {singleSelectOptionId: $optionId}
+      }) {
+        projectV2Item { id }
+      }
+    }
+    """
+    graphql(
+        query,
+        {
+            "projectId": project_id,
+            "itemId": item_id,
+            "fieldId": field_id,
+            "optionId": option_id,
+        },
+    )
+
+
+def update_date(
+    project_id: str, item_id: str, field_id: str, date_value: str
+) -> None:
+    """Update a date field on a project item."""
+    query = """
+    mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $dateValue: Date!) {
+      updateProjectV2ItemFieldValue(input: {
+        projectId: $projectId
+        itemId: $itemId
+        fieldId: $fieldId
+        value: {date: $dateValue}
+      }) {
+        projectV2Item { id }
+      }
+    }
+    """
+    graphql(
+        query,
+        {
+            "projectId": project_id,
+            "itemId": item_id,
+            "fieldId": field_id,
+            "dateValue": date_value,
+        },
+    )
+
+
+def determine_status(config: Config) -> str:
+    """Determine what status to set based on the event."""
+    if config.event_action == "closed":
+        return config.status_done
+
+    if (
+        config.event_name == "pull_request_target"
+        and config.is_draft
+        and config.status_draft
+    ):
+        return config.status_draft
+
+    return config.status_todo
+
+
+def main() -> None:
+    config = Config.from_env()
+
+    if not config.project_owner:
+        raise SystemExit("PROJECT_OWNER is required")
+
+    print(f"Looking up project: {config.project_owner}#{config.project_number}")
+    project_id = find_project(
+        config.project_owner, config.project_owner_type, config.project_number
+    )
+    print(f"Project ID: {project_id}")
+
+    print(f"Adding item {config.item_node_id} to project")
+    item_id = add_item_to_project(project_id, config.item_node_id)
+    print(f"Project item ID: {item_id}")
+
+    status_name = determine_status(config)
+    print(f"Setting status to: {status_name}")
+    field_id, option_id = get_field_and_option(
+        project_id, config.status_field, status_name
+    )
+    update_single_select(project_id, item_id, field_id, option_id)
+    print("Status updated")
+
+    if config.date_field and config.event_action in ("opened", "ready_for_review"):
+        today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        print(f"Setting {config.date_field} to {today}")
+        date_field_id = get_date_field(project_id, config.date_field)
+        update_date(project_id, item_id, date_field_id, today)
+        print("Date updated")
+
+    print("Done")
+
+
+if __name__ == "__main__":
+    main()

--- a/ci/tests/test_github_project_sync.py
+++ b/ci/tests/test_github_project_sync.py
@@ -1,0 +1,147 @@
+"""Tests for github_project_sync.py config parsing and status logic."""
+
+from __future__ import annotations
+
+import os
+import unittest
+from unittest.mock import patch
+
+from ci.github_project_sync import Config, determine_status
+
+
+class TestConfigFromEnv(unittest.TestCase):
+    """Test Config.from_env() environment variable parsing."""
+
+    BASE_ENV = {
+        "PROJECT_OWNER": "FastLED",
+        "PROJECT_OWNER_TYPE": "organization",
+        "PROJECT_NUMBER": "1",
+        "STATUS_FIELD": "Status",
+        "STATUS_TODO": "Todo",
+        "STATUS_DONE": "Done",
+        "STATUS_DRAFT": "Draft",
+        "DATE_FIELD": "Date posted",
+        "EVENT_NAME": "issues",
+        "EVENT_ACTION": "opened",
+        "ITEM_NODE_ID": "I_abc123",
+        "IS_DRAFT": "false",
+    }
+
+    @patch.dict(os.environ, BASE_ENV, clear=False)
+    def test_parses_all_fields(self) -> None:
+        config = Config.from_env()
+        self.assertEqual(config.project_owner, "FastLED")
+        self.assertEqual(config.project_owner_type, "organization")
+        self.assertEqual(config.project_number, 1)
+        self.assertEqual(config.status_field, "Status")
+        self.assertEqual(config.status_todo, "Todo")
+        self.assertEqual(config.status_done, "Done")
+        self.assertEqual(config.status_draft, "Draft")
+        self.assertEqual(config.date_field, "Date posted")
+        self.assertEqual(config.item_node_id, "I_abc123")
+        self.assertFalse(config.is_draft)
+
+    @patch.dict(os.environ, {**BASE_ENV, "IS_DRAFT": "true"}, clear=False)
+    def test_is_draft_true(self) -> None:
+        config = Config.from_env()
+        self.assertTrue(config.is_draft)
+
+    @patch.dict(os.environ, {**BASE_ENV, "STATUS_DRAFT": ""}, clear=False)
+    def test_empty_draft_status(self) -> None:
+        config = Config.from_env()
+        self.assertEqual(config.status_draft, "")
+
+    @patch.dict(os.environ, {**BASE_ENV, "DATE_FIELD": ""}, clear=False)
+    def test_empty_date_field(self) -> None:
+        config = Config.from_env()
+        self.assertEqual(config.date_field, "")
+
+    @patch.dict(
+        os.environ,
+        {k: v for k, v in BASE_ENV.items() if k != "PROJECT_NUMBER"},
+        clear=False,
+    )
+    def test_missing_project_number_exits(self) -> None:
+        os.environ.pop("PROJECT_NUMBER", None)
+        with self.assertRaises(SystemExit):
+            Config.from_env()
+
+    @patch.dict(
+        os.environ,
+        {k: v for k, v in BASE_ENV.items() if k != "ITEM_NODE_ID"},
+        clear=False,
+    )
+    def test_missing_item_node_id_exits(self) -> None:
+        os.environ.pop("ITEM_NODE_ID", None)
+        with self.assertRaises(SystemExit):
+            Config.from_env()
+
+
+class TestDetermineStatus(unittest.TestCase):
+    """Test status determination logic."""
+
+    def _make_config(self, **overrides) -> Config:
+        defaults = {
+            "project_owner": "FastLED",
+            "project_owner_type": "organization",
+            "project_number": 1,
+            "status_field": "Status",
+            "status_todo": "Todo",
+            "status_done": "Done",
+            "status_draft": "Draft",
+            "date_field": "",
+            "event_name": "issues",
+            "event_action": "opened",
+            "item_node_id": "I_abc",
+            "is_draft": False,
+        }
+        defaults.update(overrides)
+        return Config(**defaults)
+
+    def test_closed_returns_done(self) -> None:
+        config = self._make_config(event_action="closed")
+        self.assertEqual(determine_status(config), "Done")
+
+    def test_opened_issue_returns_todo(self) -> None:
+        config = self._make_config(event_name="issues", event_action="opened")
+        self.assertEqual(determine_status(config), "Todo")
+
+    def test_opened_pr_returns_todo(self) -> None:
+        config = self._make_config(
+            event_name="pull_request_target", event_action="opened", is_draft=False
+        )
+        self.assertEqual(determine_status(config), "Todo")
+
+    def test_draft_pr_returns_draft(self) -> None:
+        config = self._make_config(
+            event_name="pull_request_target",
+            event_action="opened",
+            is_draft=True,
+            status_draft="Draft",
+        )
+        self.assertEqual(determine_status(config), "Draft")
+
+    def test_draft_pr_without_draft_status_returns_todo(self) -> None:
+        config = self._make_config(
+            event_name="pull_request_target",
+            event_action="opened",
+            is_draft=True,
+            status_draft="",
+        )
+        self.assertEqual(determine_status(config), "Todo")
+
+    def test_reopened_returns_todo(self) -> None:
+        config = self._make_config(event_action="reopened")
+        self.assertEqual(determine_status(config), "Todo")
+
+    def test_ready_for_review_returns_todo(self) -> None:
+        config = self._make_config(
+            event_name="pull_request_target",
+            event_action="ready_for_review",
+            is_draft=False,
+        )
+        self.assertEqual(determine_status(config), "Todo")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ci/tests/test_github_project_sync.py
+++ b/ci/tests/test_github_project_sync.py
@@ -86,9 +86,9 @@ class TestDetermineStatus(unittest.TestCase):
             "project_owner_type": "organization",
             "project_number": 1,
             "status_field": "Status",
-            "status_todo": "Todo",
+            "status_todo": "Triage",
             "status_done": "Done",
-            "status_draft": "Draft",
+            "status_draft": "In Progress",
             "date_field": "",
             "event_name": "issues",
             "event_action": "opened",
@@ -102,45 +102,45 @@ class TestDetermineStatus(unittest.TestCase):
         config = self._make_config(event_action="closed")
         self.assertEqual(determine_status(config), "Done")
 
-    def test_opened_issue_returns_todo(self) -> None:
+    def test_opened_issue_returns_triage(self) -> None:
         config = self._make_config(event_name="issues", event_action="opened")
-        self.assertEqual(determine_status(config), "Todo")
+        self.assertEqual(determine_status(config), "Triage")
 
-    def test_opened_pr_returns_todo(self) -> None:
+    def test_opened_pr_returns_triage(self) -> None:
         config = self._make_config(
             event_name="pull_request_target", event_action="opened", is_draft=False
         )
-        self.assertEqual(determine_status(config), "Todo")
+        self.assertEqual(determine_status(config), "Triage")
 
-    def test_draft_pr_returns_draft(self) -> None:
+    def test_draft_pr_returns_in_progress(self) -> None:
         config = self._make_config(
             event_name="pull_request_target",
             event_action="opened",
             is_draft=True,
-            status_draft="Draft",
+            status_draft="In Progress",
         )
-        self.assertEqual(determine_status(config), "Draft")
+        self.assertEqual(determine_status(config), "In Progress")
 
-    def test_draft_pr_without_draft_status_returns_todo(self) -> None:
+    def test_draft_pr_without_draft_status_returns_triage(self) -> None:
         config = self._make_config(
             event_name="pull_request_target",
             event_action="opened",
             is_draft=True,
             status_draft="",
         )
-        self.assertEqual(determine_status(config), "Todo")
+        self.assertEqual(determine_status(config), "Triage")
 
-    def test_reopened_returns_todo(self) -> None:
+    def test_reopened_returns_triage(self) -> None:
         config = self._make_config(event_action="reopened")
-        self.assertEqual(determine_status(config), "Todo")
+        self.assertEqual(determine_status(config), "Triage")
 
-    def test_ready_for_review_returns_todo(self) -> None:
+    def test_ready_for_review_returns_triage(self) -> None:
         config = self._make_config(
             event_name="pull_request_target",
             event_action="ready_for_review",
             is_draft=False,
         )
-        self.assertEqual(determine_status(config), "Todo")
+        self.assertEqual(determine_status(config), "Triage")
 
 
 if __name__ == "__main__":

--- a/ci/tests/test_github_project_sync.py
+++ b/ci/tests/test_github_project_sync.py
@@ -4,15 +4,25 @@ from __future__ import annotations
 
 import os
 import unittest
+from typing import Any
 from unittest.mock import patch
 
 from ci.github_project_sync import Config, determine_status
 
 
+def _without_key(source: dict[str, str], key_to_remove: str) -> dict[str, str]:
+    """Return a copy of source with one key removed."""
+    result: dict[str, str] = {}
+    for key, value in source.items():
+        if key != key_to_remove:
+            result[key] = value
+    return result
+
+
 class TestConfigFromEnv(unittest.TestCase):
     """Test Config.from_env() environment variable parsing."""
 
-    BASE_ENV = {
+    BASE_ENV: dict[str, str] = {
         "PROJECT_OWNER": "FastLED",
         "PROJECT_OWNER_TYPE": "organization",
         "PROJECT_NUMBER": "1",
@@ -29,6 +39,7 @@ class TestConfigFromEnv(unittest.TestCase):
 
     @patch.dict(os.environ, BASE_ENV, clear=False)
     def test_parses_all_fields(self) -> None:
+        """Verify all env vars map to the correct Config fields."""
         config = Config.from_env()
         self.assertEqual(config.project_owner, "FastLED")
         self.assertEqual(config.project_owner_type, "organization")
@@ -43,35 +54,40 @@ class TestConfigFromEnv(unittest.TestCase):
 
     @patch.dict(os.environ, {**BASE_ENV, "IS_DRAFT": "true"}, clear=False)
     def test_is_draft_true(self) -> None:
+        """Verify IS_DRAFT=true parses correctly."""
         config = Config.from_env()
         self.assertTrue(config.is_draft)
 
     @patch.dict(os.environ, {**BASE_ENV, "STATUS_DRAFT": ""}, clear=False)
     def test_empty_draft_status(self) -> None:
+        """Verify empty STATUS_DRAFT is preserved as empty string."""
         config = Config.from_env()
         self.assertEqual(config.status_draft, "")
 
     @patch.dict(os.environ, {**BASE_ENV, "DATE_FIELD": ""}, clear=False)
     def test_empty_date_field(self) -> None:
+        """Verify empty DATE_FIELD is preserved as empty string."""
         config = Config.from_env()
         self.assertEqual(config.date_field, "")
 
     @patch.dict(
         os.environ,
-        {k: v for k, v in BASE_ENV.items() if k != "PROJECT_NUMBER"},
+        _without_key(BASE_ENV, "PROJECT_NUMBER"),
         clear=False,
     )
     def test_missing_project_number_exits(self) -> None:
+        """Verify missing PROJECT_NUMBER raises SystemExit."""
         os.environ.pop("PROJECT_NUMBER", None)
         with self.assertRaises(SystemExit):
             Config.from_env()
 
     @patch.dict(
         os.environ,
-        {k: v for k, v in BASE_ENV.items() if k != "ITEM_NODE_ID"},
+        _without_key(BASE_ENV, "ITEM_NODE_ID"),
         clear=False,
     )
     def test_missing_item_node_id_exits(self) -> None:
+        """Verify missing ITEM_NODE_ID raises SystemExit."""
         os.environ.pop("ITEM_NODE_ID", None)
         with self.assertRaises(SystemExit):
             Config.from_env()
@@ -80,8 +96,9 @@ class TestConfigFromEnv(unittest.TestCase):
 class TestDetermineStatus(unittest.TestCase):
     """Test status determination logic."""
 
-    def _make_config(self, **overrides) -> Config:
-        defaults = {
+    def _make_config(self, **overrides: Any) -> Config:
+        """Build a Config with sensible defaults, overriding specific fields."""
+        defaults: dict[str, Any] = {
             "project_owner": "FastLED",
             "project_owner_type": "organization",
             "project_number": 1,
@@ -99,20 +116,24 @@ class TestDetermineStatus(unittest.TestCase):
         return Config(**defaults)
 
     def test_closed_returns_done(self) -> None:
+        """Closing an issue or PR sets status to Done."""
         config = self._make_config(event_action="closed")
         self.assertEqual(determine_status(config), "Done")
 
     def test_opened_issue_returns_triage(self) -> None:
+        """New issues land in Triage."""
         config = self._make_config(event_name="issues", event_action="opened")
         self.assertEqual(determine_status(config), "Triage")
 
     def test_opened_pr_returns_triage(self) -> None:
+        """Non-draft PRs land in Triage."""
         config = self._make_config(
             event_name="pull_request_target", event_action="opened", is_draft=False
         )
         self.assertEqual(determine_status(config), "Triage")
 
     def test_draft_pr_returns_in_progress(self) -> None:
+        """Draft PRs go to In Progress when status_draft is configured."""
         config = self._make_config(
             event_name="pull_request_target",
             event_action="opened",
@@ -122,6 +143,7 @@ class TestDetermineStatus(unittest.TestCase):
         self.assertEqual(determine_status(config), "In Progress")
 
     def test_draft_pr_without_draft_status_returns_triage(self) -> None:
+        """Draft PRs fall back to Triage when status_draft is empty."""
         config = self._make_config(
             event_name="pull_request_target",
             event_action="opened",
@@ -131,10 +153,12 @@ class TestDetermineStatus(unittest.TestCase):
         self.assertEqual(determine_status(config), "Triage")
 
     def test_reopened_returns_triage(self) -> None:
+        """Reopened issues return to Triage."""
         config = self._make_config(event_action="reopened")
         self.assertEqual(determine_status(config), "Triage")
 
     def test_ready_for_review_returns_triage(self) -> None:
+        """PRs marked ready for review go to Triage."""
         config = self._make_config(
             event_name="pull_request_target",
             event_action="ready_for_review",


### PR DESCRIPTION
## Summary

Implements the repo-side automation from #2250 — auto-syncs all issues and PRs into a GitHub Projects v2 board.

- **`.github/workflows/project_automation.yml`** — triggers on issue/PR open, close, reopen, draft, and ready-for-review events
- **`ci/github_project_sync.py`** — GraphQL-based sync script that adds items to the project and sets Status/Date fields
- **`ci/tests/test_github_project_sync.py`** — 13 unit tests covering config parsing and status determination logic

### How it works

1. Workflow fires on issue/PR lifecycle events
2. Generates a GitHub App token (configured via repo variables/secrets)
3. Looks up the target Projects v2 board by owner + number
4. Adds the issue/PR to the board
5. Sets `Status` to `Todo`, `Done`, or `Draft` based on the event
6. Optionally stamps a `Date posted` field on open/ready-for-review

### Setup required (after merge)

1. Create an org-level Projects v2 board under FastLED
2. Create a GitHub App with `project:read/write`, `issues:read`, `pull_requests:read`
3. Install the app on `FastLED/FastLED`
4. Set repo variables: `GITHUB_PROJECT_OWNER`, `GITHUB_PROJECT_NUMBER`, `GITHUB_PROJECT_APP_ID`, etc.
5. Set repo secret: `GITHUB_PROJECT_APP_PRIVATE_KEY`
6. Enable auto-archive in the project UI settings

The workflow is gated on `vars.GITHUB_PROJECT_NUMBER` being non-empty, so it's a no-op until setup is complete.

## Test plan

- [x] All 13 unit tests pass locally
- [ ] After merge + setup: open a test issue, confirm it appears in project with Status=Todo
- [ ] Close the test issue, confirm Status moves to Done
- [ ] Open a draft PR, confirm Status=Draft (if configured)
- [ ] Mark PR ready for review, confirm Status=Todo and Date stamped

Closes #2250

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated workflow to sync issues and pull requests into the project board, automatically creating/updating project items and setting status for opened/closed/reopened, draft/ready transitions; optionally records a date when items are opened or marked ready.

* **Tests**
  * Unit tests covering environment configuration parsing and status-determination logic.

* **Documentation**
  * Added standardized bug report and feature request issue templates and template configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->