### PR TITLE
fix(esp32-s3): LCD_CLOCKLESS GPIO crash fix + autoresearch --lcd/--lcd-spi

### DIFF
--- a/ci/autoresearch/args.py
+++ b/ci/autoresearch/args.py
@@ -18,6 +18,7 @@ class Args:
     spi: bool
     uart: bool
     lcd: bool
+    lcd_spi: bool
     lcd_rgb: bool
     object_fled: bool
     all: bool
@@ -99,10 +100,11 @@ Examples:
   %(prog)s --all                       # Test all drivers
   %(prog)s --parlio --skip-lint        # Skip linting for faster iteration
   %(prog)s --rmt --timeout 120         # Custom timeout (default: 60s)
-  %(prog)s --lcd --lanes 2 --strip-sizes 100,300  # Test I2S with 2 lanes, strips of 100 and 300 LEDs
+  %(prog)s --lcd --lanes 2 --strip-sizes 100,300  # Test LCD_CLOCKLESS with 2 lanes, strips of 100 and 300 LEDs
+  %(prog)s --lcd-spi --strip-sizes 100,500   # Test LCD_SPI (APA102) on ESP32-S3
   %(prog)s --parlio --lanes 1-4        # Test PARLIO with 1-4 lanes
   %(prog)s --rmt --strip-sizes small   # Test RMT with 'small' preset (100/500 LEDs)
-  %(prog)s --lcd --lane-counts 100,200,300  # Test I2S with 3 lanes (100, 200, 300 LEDs per lane)
+  %(prog)s --lcd --lane-counts 100,200,300  # Test LCD_CLOCKLESS with 3 lanes (100, 200, 300 LEDs per lane)
   %(prog)s --parlio --color-pattern 0xff00aa  # Test PARLIO with custom color pattern (RGB hex)
   %(prog)s --help                      # Show this help message
 
@@ -111,13 +113,15 @@ Driver Selection (JSON-RPC):
   You can instantly switch between drivers without rebuilding firmware.
 
   MANDATORY: You MUST specify at least one driver flag:
-    --parlio      Test only PARLIO driver
-    --rmt         Test only RMT driver
-    --spi         Test only SPI driver
-    --uart        Test only UART driver
-    --lcd-rgb     Test only LCD RGB driver (ESP32-P4 only)
-    --object-fled Test only ObjectFLED DMA driver (Teensy 4.x)
-    --all         Test all drivers
+    --parlio       Test only PARLIO driver
+    --rmt          Test only RMT driver
+    --spi          Test only SPI driver
+    --uart         Test only UART driver
+    --lcd          Test only LCD_CLOCKLESS driver (ESP32-S3 only, replaces misnamed I2S)
+    --lcd-spi      Test only LCD_SPI driver (ESP32-S3 only, APA102/SK9822)
+    --lcd-rgb      Test only LCD RGB driver (ESP32-P4 only)
+    --object-fled  Test only ObjectFLED DMA driver (Teensy 4.x)
+    --all          Test all drivers
 
 Strip Size Configuration:
   Configure LED strip sizes for autoresearch testing via JSON-RPC:
@@ -199,7 +203,12 @@ See Also:
         driver_group.add_argument(
             "--lcd",
             action="store_true",
-            help="Test only I2S LCD_CAM driver (ESP32-S3 only)",
+            help="Test only LCD_CLOCKLESS driver (ESP32-S3, clockless via LCD_CAM I80; replaces misnamed I2S)",
+        )
+        driver_group.add_argument(
+            "--lcd-spi",
+            action="store_true",
+            help="Test only LCD_SPI driver (ESP32-S3, APA102/SK9822 via LCD_CAM I80)",
         )
         driver_group.add_argument(
             "--lcd-rgb",
@@ -214,7 +223,7 @@ See Also:
         driver_group.add_argument(
             "--all",
             action="store_true",
-            help="Test all drivers (equivalent to --parlio --rmt --spi --uart --lcd --lcd-rgb --object-fled)",
+            help="Test all drivers (equivalent to --parlio --rmt --spi --uart --lcd --lcd-spi --lcd-rgb --object-fled)",
         )
         driver_group.add_argument(
             "--simd",
@@ -480,6 +489,7 @@ See Also:
             spi=parsed.spi,
             uart=parsed.uart,
             lcd=parsed.lcd,
+            lcd_spi=parsed.lcd_spi,
             lcd_rgb=parsed.lcd_rgb,
             object_fled=parsed.object_fled,
             all=parsed.all,

--- a/ci/autoresearch/gpio.py
+++ b/ci/autoresearch/gpio.py
@@ -46,14 +46,19 @@ async def run_gpio_pretest(
         client = RpcClient(
             port, timeout=timeout, serial_interface=serial_interface, verbose=True
         )
-        await client.connect(boot_wait=3.0, drain_boot=False)
+        # Wait longer than the nominal boot time: FbuildSerialAdapter's
+        # connect triggers a DTR reset, and ESP32-S3 AutoResearch setup
+        # takes ~5-7s before the RPC dispatcher is ready. A 3s boot_wait
+        # raced the first ping against setup() and caused intermittent
+        # timeouts.
+        await client.connect(boot_wait=8.0, drain_boot=True)
         try:
             print()
             print("=" * 60)
             print("PING TEST (verify basic RPC works)")
             print("=" * 60)
             try:
-                ping_response = await client.send("ping", retries=3)
+                ping_response = await client.send("ping", timeout=15.0, retries=3)
                 print(f"\u2705 Ping successful: {ping_response.data}")
             except KeyboardInterrupt as ki:
                 handle_keyboard_interrupt(ki)
@@ -181,7 +186,7 @@ async def run_pin_discovery(
         client = RpcClient(
             port, timeout=timeout, serial_interface=serial_interface, verbose=True
         )
-        await client.connect(boot_wait=3.0, drain_boot=True)
+        await client.connect(boot_wait=8.0, drain_boot=True)
 
         print()
         print("=" * 60)

--- a/ci/autoresearch/phases.py
+++ b/ci/autoresearch/phases.py
@@ -178,6 +178,12 @@ def _parse_args_and_build_commands(args: Args) -> RunContext | int:
             "\u2139\ufe0f  --lcd flag requires ESP32-S3, auto-selecting 'esp32s3' environment"
         )
 
+    if args.lcd_spi and not final_environment:
+        final_environment = "esp32s3"
+        print(
+            "\u2139\ufe0f  --lcd-spi flag requires ESP32-S3, auto-selecting 'esp32s3' environment"
+        )
+
     if args.lcd_rgb and not final_environment:
         final_environment = "esp32p4"
         print(
@@ -190,7 +196,16 @@ def _parse_args_and_build_commands(args: Args) -> RunContext | int:
     coroutine_test_mode = args.coroutine
 
     if args.all:
-        drivers = ["PARLIO", "RMT", "SPI", "UART", "I2S", "LCD_RGB", "OBJECTFLED"]
+        drivers = [
+            "PARLIO",
+            "RMT",
+            "SPI",
+            "UART",
+            "LCD_CLOCKLESS",
+            "LCD_SPI",
+            "LCD_RGB",
+            "OBJECTFLED",
+        ]
     else:
         if args.parlio:
             drivers.append("PARLIO")
@@ -201,7 +216,9 @@ def _parse_args_and_build_commands(args: Args) -> RunContext | int:
         if args.uart:
             drivers.append("UART")
         if args.lcd:
-            drivers.append("I2S")
+            drivers.append("LCD_CLOCKLESS")
+        if args.lcd_spi:
+            drivers.append("LCD_SPI")
         if args.lcd_rgb:
             drivers.append("LCD_RGB")
         if args.object_fled:

--- a/examples/AutoResearch/AutoResearchTest.cpp
+++ b/examples/AutoResearch/AutoResearchTest.cpp
@@ -8,6 +8,7 @@
 #include "fl/chipsets/encoders/ucs7604.h"
 #include "fl/chipsets/chipset_timing_config.h"
 #include "fl/chipsets/led_timing.h"
+#include "fl/channels/wave3.h"
 #include "fl/chipsets/encoders/pixel_iterator.h"
 #include "fl/math/ease.h"
 #include "pixel_controller.h"
@@ -487,13 +488,24 @@ size_t capture(fl::shared_ptr<fl::RxDevice> rx_channel, fl::span<uint8_t> rx_buf
     bool is_spi_driver = (fl::strcmp(driver_name, "SPI") == 0);
     bool is_parlio_driver = (fl::strcmp(driver_name, "PARLIO") == 0);
     bool is_i2s_driver = (fl::strcmp(driver_name, "I2S") == 0);
-    bool uses_wave8 = is_spi_driver || is_parlio_driver || is_i2s_driver;
+    // LCD_CLOCKLESS auto-selects wave3 vs wave8 based on canUseWave3() of the
+    // chipset timing. Compute the same eligibility check on the host side so
+    // the RX decoder reconstructs the correct quantized waveform.
+    bool is_lcd_clockless_driver = (fl::strcmp(driver_name, "LCD_CLOCKLESS") == 0);
+    bool lcd_clockless_uses_wave3 = false;
+    if (is_lcd_clockless_driver) {
+        fl::ChipsetTiming probe{timing.t1_ns, timing.t2_ns, timing.t3_ns, timing.reset_us, timing.name};
+        lcd_clockless_uses_wave3 = fl::canUseWave3(probe);
+    }
+    bool uses_wave8 = is_spi_driver || is_parlio_driver || is_i2s_driver
+                      || (is_lcd_clockless_driver && !lcd_clockless_uses_wave3);
+    bool uses_wave3 = is_lcd_clockless_driver && lcd_clockless_uses_wave3;
     fl::ChipsetTiming tx_timing;
     if (uses_wave8) {
         // Compute actual wave8 timing from chipset timing
         const uint32_t period = timing.t1_ns + timing.t2_ns + timing.t3_ns;
         // PARLIO uses fixed 8MHz clock (125ns/tick), not derived from period
-        // SPI/I2S derive clock from period: tick = period/8
+        // SPI/I2S/LCD_CLOCKLESS derive clock from period: tick = period/8
         const uint32_t tick_ns = is_parlio_driver ? 125 : (period / 8);
         // Wave8 LUT computes: pulses = round(fraction * 8)
         const uint32_t pulses_bit0 = static_cast<uint32_t>(
@@ -505,7 +517,8 @@ size_t capture(fl::shared_ptr<fl::RxDevice> rx_channel, fl::span<uint8_t> rx_buf
         const uint32_t actual_t1h = pulses_bit1 * tick_ns;
         const uint32_t actual_period = 8 * tick_ns;
         const char* wave8_name = is_spi_driver ? "SPI_wave8" :
-                                 is_parlio_driver ? "PARLIO_wave8" : "I2S_wave8";
+                                 is_parlio_driver ? "PARLIO_wave8" :
+                                 is_lcd_clockless_driver ? "LCD_CLOCKLESS_wave8" : "I2S_wave8";
         tx_timing = fl::ChipsetTiming{
             actual_t0h,                    // T1 = T0H
             actual_t1h - actual_t0h,       // T2 = T1H - T0H
@@ -518,13 +531,35 @@ size_t capture(fl::shared_ptr<fl::RxDevice> rx_channel, fl::span<uint8_t> rx_buf
                 << " tick_ns=" << tick_ns
                 << " -> T1=" << tx_timing.T1 << " T2=" << tx_timing.T2
                 << " T3=" << tx_timing.T3);
+    } else if (uses_wave3) {
+        // Wave3 encoding: 3 ticks per LED bit, clock = 3/(T1+T2+T3) Hz
+        const uint32_t period = timing.t1_ns + timing.t2_ns + timing.t3_ns;
+        const uint32_t tick_ns = period / 3;
+        const uint32_t ticks_bit0 = static_cast<uint32_t>(
+            static_cast<float>(timing.t1_ns) / period * 3.0f + 0.5f);
+        const uint32_t ticks_bit1 = static_cast<uint32_t>(
+            static_cast<float>(timing.t1_ns + timing.t2_ns) / period * 3.0f + 0.5f);
+        const uint32_t actual_t0h = ticks_bit0 * tick_ns;
+        const uint32_t actual_t1h = ticks_bit1 * tick_ns;
+        const uint32_t actual_period = 3 * tick_ns;
+        tx_timing = fl::ChipsetTiming{
+            actual_t0h,
+            actual_t1h - actual_t0h,
+            actual_period - actual_t1h,
+            timing.reset_us,
+            "LCD_CLOCKLESS_wave3"
+        };
+        FL_WARN("[RX TIMING] LCD_CLOCKLESS_wave3: ticks_bit0=" << ticks_bit0
+                << " ticks_bit1=" << ticks_bit1
+                << " tick_ns=" << tick_ns
+                << " -> T1=" << tx_timing.T1 << " T2=" << tx_timing.T2
+                << " T3=" << tx_timing.T3);
     } else {
         tx_timing = fl::ChipsetTiming{timing.t1_ns, timing.t2_ns, timing.t3_ns, timing.reset_us, timing.name};
     }
-    // Wave8 encoding has timing jitter due to clock quantization and GPIO matrix latency
-    // Use wider tolerance for wave8 drivers (200ns) to accommodate clock rounding
-    // (e.g., requested 6.535MHz → actual 6.666MHz = ~2% faster)
-    const uint32_t tolerance = uses_wave8 ? 200 : 170;
+    // Wave8/wave3 encoding has timing jitter due to clock quantization and GPIO matrix latency
+    // Use wider tolerance (200ns) to accommodate clock rounding
+    const uint32_t tolerance = (uses_wave8 || uses_wave3) ? 200 : 170;
     auto rx_timing = fl::make4PhaseTiming(tx_timing, tolerance);
 
     // Enable gap tolerance for PARLIO/SPI DMA gaps

--- a/src/platforms/esp/32/drivers/channel_manager_esp32.cpp.hpp
+++ b/src/platforms/esp/32/drivers/channel_manager_esp32.cpp.hpp
@@ -89,6 +89,9 @@
 // IWYU pragma: begin_keep
 #include "lcd_spi/channel_driver_lcd_spi.h"
 // IWYU pragma: end_keep
+// IWYU pragma: begin_keep
+#include "lcd_spi/channel_driver_lcd_clockless.h"
+// IWYU pragma: end_keep
 #endif
 
 namespace fl {
@@ -121,6 +124,11 @@ constexpr int PRIORITY_I2S_SPI = 10; ///< Native I2S parallel SPI driver (ESP32d
 constexpr int PRIORITY_LCD_SPI = PRIORITY_FORCE; ///< FORCED highest by FASTLED_ESP32_FORCE_LCD_SPI
 #else
 constexpr int PRIORITY_LCD_SPI = 10; ///< Native LCD_CAM SPI driver (ESP32-S3, true SPI chipsets)
+#endif
+#if defined(FASTLED_ESP32_FORCE_LCD_CLOCKLESS)
+constexpr int PRIORITY_LCD_CLOCKLESS = PRIORITY_FORCE; ///< FORCED highest by FASTLED_ESP32_FORCE_LCD_CLOCKLESS
+#else
+constexpr int PRIORITY_LCD_CLOCKLESS = 1; ///< LCD_CAM clockless driver (ESP32-S3, replaces misnamed I2S)
 #endif
 
 /// @brief Add HW SPI drivers if supported by platform (UNIFIED VERSION)
@@ -280,6 +288,21 @@ static void addLcdSpiIfPossible(ChannelManager& manager) FL_NOEXCEPT {
 #endif
 }
 
+/// @brief Add LCD_CAM clockless driver if supported (ESP32-S3, replaces misnamed I2S)
+static void addLcdClocklessIfPossible(ChannelManager& manager) FL_NOEXCEPT {
+#if FASTLED_ESP32_HAS_LCD_SPI
+    auto driver = createLcdClocklessEngine();
+    if (driver) {
+        manager.addDriver(PRIORITY_LCD_CLOCKLESS, driver);
+        FL_DBG("ESP32-S3: Added LCD_CLOCKLESS driver (priority " << PRIORITY_LCD_CLOCKLESS << ")");
+    } else {
+        FL_DBG("ESP32-S3: LCD_CLOCKLESS driver creation deferred");
+    }
+#else
+    (void)manager;
+#endif
+}
+
 /// @brief Add I2S LCD_CAM driver if supported by platform
 static void addI2sIfPossible(ChannelManager& manager) FL_NOEXCEPT {
 #if FASTLED_ESP32_HAS_I2S_LCD_CAM
@@ -320,7 +343,8 @@ void initChannelDrivers() FL_NOEXCEPT {
     detail::addSpiIfPossible(manager);          // Priority 0 (clockless-over-SPI)
     detail::addUartIfPossible(manager);         // Priority -1 (clockless)
     detail::addRmtIfPossible(manager);          // Priority 2 (clockless)
-    detail::addI2sIfPossible(manager);          // Priority 1 (clockless)
+    detail::addLcdClocklessIfPossible(manager); // Priority 1 (clockless, ESP32-S3, replaces misnamed I2S)
+    detail::addI2sIfPossible(manager);          // Priority 1 (clockless, legacy I2S name)
 
     FL_DBG("ESP32: Channel drivers initialized");
 }

--- a/src/platforms/esp/32/drivers/lcd_spi/_build.cpp.hpp
+++ b/src/platforms/esp/32/drivers/lcd_spi/_build.cpp.hpp
@@ -3,6 +3,7 @@
 /// @file _build.hpp
 /// @brief Unity build header for platforms\esp\32\drivers\lcd_spi/ directory
 
+#include "platforms/esp/32/drivers/lcd_spi/channel_driver_lcd_clockless.cpp.hpp"
 #include "platforms/esp/32/drivers/lcd_spi/channel_driver_lcd_spi.cpp.hpp"
 #include "platforms/esp/32/drivers/lcd_spi/lcd_spi_peripheral_esp.cpp.hpp"
 #include "platforms/esp/32/drivers/lcd_spi/lcd_spi_peripheral_mock.cpp.hpp"

--- a/src/platforms/esp/32/drivers/lcd_spi/channel_driver_lcd_clockless.cpp.hpp
+++ b/src/platforms/esp/32/drivers/lcd_spi/channel_driver_lcd_clockless.cpp.hpp
@@ -1,29 +1,32 @@
 // IWYU pragma: private
 
-/// @file channel_driver_lcd_spi.cpp
-/// @brief LCD_CAM SPI channel driver implementation
+/// @file channel_driver_lcd_clockless.cpp.hpp
+/// @brief LCD_CAM I80 clockless channel driver implementation
 ///
-/// ISR-driven chunked DMA streaming for SPI LED chipsets (APA102, SK9822).
-/// See channel_driver_lcd_spi.h and issue #2258 for architecture details.
+/// ISR-driven chunked DMA for clockless LED chipsets (WS2812, SK6812).
+/// Replaces the misnamed "I2S" driver on ESP32-S3.
+/// See channel_driver_lcd_clockless.h and issue #2258.
 
 #include "platforms/is_platform.h"
 
-// Compile for ESP32-S3 (with LCD_CAM) or host testing
 #if defined(FASTLED_STUB_IMPL) || \
     (!defined(ARDUINO) &&          \
      (defined(__linux__) || defined(__APPLE__) || defined(_WIN32)))
-#define FL_LCD_SPI_COMPILE 1
+#define FL_LCD_CLOCKLESS_COMPILE 1
 #elif defined(FL_IS_ESP32)
 #include "sdkconfig.h"
 #include "platforms/esp/32/feature_flags/enabled.h"
 #if FASTLED_ESP32_HAS_LCD_SPI
-#define FL_LCD_SPI_COMPILE 1
+#define FL_LCD_CLOCKLESS_COMPILE 1
 #endif
 #endif
 
-#ifdef FL_LCD_SPI_COMPILE
+#ifdef FL_LCD_CLOCKLESS_COMPILE
 
-#include "platforms/esp/32/drivers/lcd_spi/channel_driver_lcd_spi.h"
+#include "platforms/esp/32/drivers/lcd_spi/channel_driver_lcd_clockless.h"
+#include "fl/channels/detail/wave3.hpp"
+#include "fl/channels/detail/wave8.hpp"
+#include "fl/chipsets/led_timing.h"
 #include "fl/system/log.h"
 #include "fl/task/executor.h"
 #include "fl/stl/cstring.h"
@@ -36,11 +39,11 @@
 // IWYU pragma: begin_keep
 #include "platforms/esp/32/drivers/lcd_spi/lcd_spi_peripheral_esp.h"
 // IWYU pragma: end_keep
-#define FL_LCD_SPI_HAS_ESP_PERIPHERAL 1
+#define FL_LCD_CLOCKLESS_HAS_ESP_PERIPHERAL 1
 #endif
 #endif
-#ifndef FL_LCD_SPI_HAS_ESP_PERIPHERAL
-#define FL_LCD_SPI_HAS_ESP_PERIPHERAL 0
+#ifndef FL_LCD_CLOCKLESS_HAS_ESP_PERIPHERAL
+#define FL_LCD_CLOCKLESS_HAS_ESP_PERIPHERAL 0
 #endif
 
 namespace fl {
@@ -49,18 +52,18 @@ namespace fl {
 // Constructor / Destructor
 //=============================================================================
 
-ChannelDriverLcdSpi::ChannelDriverLcdSpi(
+ChannelDriverLcdClockless::ChannelDriverLcdClockless(
     fl::shared_ptr<detail::ILcdSpiPeripheral> peripheral) FL_NOEXCEPT
     : mPeripheral(fl::move(peripheral)), mInitialized(false),
       mEnqueuedChannels(), mTransmittingChannels(),
       mRingBuffers{nullptr, nullptr, nullptr}, mRingCapacity(0),
-      mNumLanes(0), mBusy(false), mIsrCtx(), mChunkInputBytesOverride(0) {
+      mNumLanes(0), mBusy(false), mIsrCtx(), mChunkInputBytesOverride(0),
+      mUseWave3(true), mWave3Lut(), mWave8Lut(), mClockHz(0),
+      mOutputBytesPerInputByte(0) {
     mIsrCtx.reset();
 }
 
-ChannelDriverLcdSpi::~ChannelDriverLcdSpi() {
-    // Block until DMA completes — ring buffers are DMA sources,
-    // so freeing them while DMA is active would be a use-after-free.
+ChannelDriverLcdClockless::~ChannelDriverLcdClockless() {
     if (mBusy && mPeripheral) {
         mPeripheral->waitTransmitDone(2000);
         mBusy = false;
@@ -72,7 +75,7 @@ ChannelDriverLcdSpi::~ChannelDriverLcdSpi() {
 // Ring Buffer Management
 //=============================================================================
 
-void ChannelDriverLcdSpi::freeRingBuffers() FL_NOEXCEPT {
+void ChannelDriverLcdClockless::freeRingBuffers() FL_NOEXCEPT {
     for (size_t i = 0; i < kRingBufferCount; i++) {
         if (mPeripheral && mRingBuffers[i] != nullptr) {
             mPeripheral->freeBuffer(mRingBuffers[i]);
@@ -82,10 +85,10 @@ void ChannelDriverLcdSpi::freeRingBuffers() FL_NOEXCEPT {
     mRingCapacity = 0;
 }
 
-bool ChannelDriverLcdSpi::allocateRingBuffers(
+bool ChannelDriverLcdClockless::allocateRingBuffers(
     size_t slotCapacityBytes) FL_NOEXCEPT {
     if (mRingCapacity >= slotCapacityBytes && mRingBuffers[0] != nullptr) {
-        return true; // already big enough
+        return true;
     }
 
     freeRingBuffers();
@@ -93,8 +96,7 @@ bool ChannelDriverLcdSpi::allocateRingBuffers(
     for (size_t i = 0; i < kRingBufferCount; i++) {
         mRingBuffers[i] = mPeripheral->allocateBuffer(slotCapacityBytes);
         if (mRingBuffers[i] == nullptr) {
-            FL_WARN("ChannelDriverLcdSpi: ring buffer alloc failed slot "
-                    << i);
+            FL_WARN("ChannelDriverLcdClockless: ring buffer alloc failed");
             freeRingBuffers();
             return false;
         }
@@ -107,27 +109,26 @@ bool ChannelDriverLcdSpi::allocateRingBuffers(
 // IChannelDriver Interface
 //=============================================================================
 
-bool ChannelDriverLcdSpi::canHandle(
+bool ChannelDriverLcdClockless::canHandle(
     const ChannelDataPtr &data) const FL_NOEXCEPT {
     if (!data) {
         return false;
     }
-    return data->isSpi();
+    return !data->isSpi(); // clockless only
 }
 
-void ChannelDriverLcdSpi::enqueue(ChannelDataPtr channelData) FL_NOEXCEPT {
+void ChannelDriverLcdClockless::enqueue(
+    ChannelDataPtr channelData) FL_NOEXCEPT {
     mEnqueuedChannels.push_back(fl::move(channelData));
 }
 
-void ChannelDriverLcdSpi::show() FL_NOEXCEPT {
-    // Release channels from any completed previous transmission
+void ChannelDriverLcdClockless::show() FL_NOEXCEPT {
     poll();
 
     if (mEnqueuedChannels.empty()) {
         return;
     }
 
-    // Wait for previous transmission to complete (max ~5 seconds)
     constexpr int kMaxIterations = 20000;
     int iterations = 0;
     while (mBusy && iterations++ < kMaxIterations) {
@@ -135,7 +136,7 @@ void ChannelDriverLcdSpi::show() FL_NOEXCEPT {
         fl::task::run(250, fl::task::ExecFlags::SYSTEM);
     }
     if (mBusy) {
-        FL_WARN("ChannelDriverLcdSpi: DMA hung — forcing release");
+        FL_WARN("ChannelDriverLcdClockless: DMA hung — forcing release");
         mBusy = false;
         for (auto &channel : mTransmittingChannels) {
             channel->setInUse(false);
@@ -153,12 +154,11 @@ void ChannelDriverLcdSpi::show() FL_NOEXCEPT {
     }
 }
 
-IChannelDriver::DriverState ChannelDriverLcdSpi::poll() FL_NOEXCEPT {
+IChannelDriver::DriverState ChannelDriverLcdClockless::poll() FL_NOEXCEPT {
     if (mTransmittingChannels.empty()) {
         return DriverState::READY;
     }
 
-    // Stream complete: ISR processed all chunks and peripheral is idle
     bool streamDone = mIsrCtx.mStreamComplete;
     bool peripheralIdle = mPeripheral && !mPeripheral->isBusy();
 
@@ -176,116 +176,151 @@ IChannelDriver::DriverState ChannelDriverLcdSpi::poll() FL_NOEXCEPT {
 }
 
 //=============================================================================
-// Transposition (byte → 16-bit word, per-chunk)
+// Encoding — wave3 or wave8 transpose into u16 DMA words
 //=============================================================================
 
-void ChannelDriverLcdSpi::transposeToWords(
+size_t ChannelDriverLcdClockless::encodeChunk(
     fl::span<const ChannelDataPtr> channels, u16 *output,
     size_t startByte, size_t byteCount) FL_NOEXCEPT {
-    // For each byte position in [startByte, startByte+byteCount),
-    // create 8 u16 words (one per bit, MSB first).
-    // Each bit N of the output word = corresponding bit of byte from lane N.
+    size_t outputIdx = 0; // bytes written
+
     for (size_t byteIdx = startByte; byteIdx < startByte + byteCount;
          byteIdx++) {
-        u8 lane_bytes[16];
-        fl::memset(lane_bytes, 0, sizeof(lane_bytes));
-
+        // Gather one byte from each lane (zero-fill unused lanes)
+        u8 lanes[16];
+        fl::memset(lanes, 0, sizeof(lanes));
         for (size_t lane = 0; lane < channels.size() && lane < 16; lane++) {
             const auto &data = channels[lane]->getData();
             if (byteIdx < data.size()) {
-                lane_bytes[lane] = data[byteIdx];
+                lanes[lane] = data[byteIdx];
             }
         }
 
-        for (int bit = 7; bit >= 0; bit--) {
-            u16 word = 0;
-            for (size_t lane = 0; lane < channels.size() && lane < 16;
-                 lane++) {
-                if (lane_bytes[lane] & (1 << bit)) {
-                    word |= (1 << lane);
-                }
-            }
-            *output++ = word;
+        if (mUseWave3) {
+            u8 transposed[16 * sizeof(Wave3Byte)]; // 48 bytes = 24 u16 words
+            wave3Transpose_16(
+                reinterpret_cast<const u8 (&)[16]>(lanes), // ok reinterpret cast
+                mWave3Lut,
+                reinterpret_cast<u8 (&)[16 * sizeof(Wave3Byte)]>( // ok reinterpret cast
+                    transposed));
+            fl::memcpy(reinterpret_cast<u8 *>(output) + outputIdx, // ok reinterpret cast
+                       transposed, sizeof(transposed));
+            outputIdx += sizeof(transposed);
+        } else {
+            u8 transposed[16 * sizeof(Wave8Byte)]; // 128 bytes = 64 u16 words
+            wave8Transpose_16(
+                reinterpret_cast<const u8 (&)[16]>(lanes), // ok reinterpret cast
+                mWave8Lut,
+                reinterpret_cast<u8 (&)[16 * sizeof(Wave8Byte)]>( // ok reinterpret cast
+                    transposed));
+            fl::memcpy(reinterpret_cast<u8 *>(output) + outputIdx, // ok reinterpret cast
+                       transposed, sizeof(transposed));
+            outputIdx += sizeof(transposed);
         }
     }
+
+    return outputIdx;
 }
 
 //=============================================================================
-// ISR Callback — processes chunk completion
+// ISR Callback
 //=============================================================================
 
-bool ChannelDriverLcdSpi::isrChunkDone(void *panel_io, const void *edata,
-                                       void *user_ctx) FL_NOEXCEPT {
+bool ChannelDriverLcdClockless::isrChunkDone(void *panel_io,
+                                              const void *edata,
+                                              void *user_ctx) FL_NOEXCEPT {
     (void)panel_io;
     (void)edata;
 
-    auto *self = static_cast<ChannelDriverLcdSpi *>(user_ctx);
+    auto *self = static_cast<ChannelDriverLcdClockless *>(user_ctx);
     IsrContext &ctx = self->mIsrCtx;
 
-    // All chunks transmitted?
     if (ctx.mNextByteOffset >= ctx.mTotalBytes) {
         ctx.mStreamComplete = true;
         self->mBusy = false;
         return false;
     }
 
-    // Transpose next chunk into the next ring buffer slot
     size_t writeIdx = ctx.mRingWriteIdx;
     u16 *buf = self->mRingBuffers[writeIdx];
 
-    // Calculate bytes for this chunk (may pad beyond source data — that's OK,
-    // transposeToWords outputs zeros for out-of-range bytes)
     size_t bytesRemaining = ctx.mTotalBytes - ctx.mNextByteOffset;
     size_t chunkBytes = ctx.mChunkInputBytes;
     if (chunkBytes > bytesRemaining) {
         chunkBytes = bytesRemaining;
     }
 
-    fl::memset(buf, 0, chunkBytes * 8 * sizeof(u16));
-    self->transposeToWords(self->mTransmittingChannels, buf,
-                           ctx.mNextByteOffset, chunkBytes);
+    size_t dmaBytes = self->encodeChunk(self->mTransmittingChannels, buf,
+                                        ctx.mNextByteOffset, chunkBytes);
 
     ctx.mNextByteOffset += chunkBytes;
     ctx.mRingWriteIdx = (writeIdx + 1) % kRingBufferCount;
 
-    // Submit this chunk for DMA
-    size_t dmaBytes = chunkBytes * 8 * sizeof(u16);
     if (!self->mPeripheral->transmit(buf, dmaBytes)) {
-        // Transmit failed — abort stream
         ctx.mStreamComplete = true;
         self->mBusy = false;
-        FL_WARN("ChannelDriverLcdSpi: ISR transmit failed");
+        FL_WARN("ChannelDriverLcdClockless: ISR transmit failed");
     }
 
     return false;
 }
 
 //=============================================================================
-// Begin Transmission — sets up chunked streaming
+// Begin Transmission
 //=============================================================================
 
-bool ChannelDriverLcdSpi::beginTransmission(
+bool ChannelDriverLcdClockless::beginTransmission(
     fl::span<const ChannelDataPtr> channels) FL_NOEXCEPT {
     if (channels.empty() || !mPeripheral) {
         return false;
     }
 
-    // Find max data size across all channels
+    // Find max data size and extract timing from first channel
     size_t maxSize = 0;
+    ChipsetTiming chipsetTiming = {};
+    bool timingFound = false;
+    int firstPin = -1;
+
     for (const auto &channel : channels) {
         size_t sz = channel->getSize();
         if (sz > maxSize) {
             maxSize = sz;
         }
+        if (!timingFound) {
+            auto timingCfg = channel->getTiming();
+            chipsetTiming.T1 = timingCfg.t1_ns;
+            chipsetTiming.T2 = timingCfg.t2_ns;
+            chipsetTiming.T3 = timingCfg.t3_ns;
+            chipsetTiming.RESET = timingCfg.reset_us;
+            chipsetTiming.name = timingCfg.name;
+            timingFound = true;
+        }
+        if (firstPin < 0) {
+            firstPin = channel->getPin();
+        }
     }
 
-    if (maxSize == 0) {
+    if (maxSize == 0 || !timingFound) {
         return false;
     }
 
     int numLanes = static_cast<int>(channels.size());
 
-    // Determine chunk size
+    // Auto-select wave3 or wave8 based on chipset timing
+    mUseWave3 = canUseWave3(chipsetTiming);
+    if (mUseWave3) {
+        mClockHz = wave3ClockFrequencyHz(chipsetTiming);
+        mWave3Lut = buildWave3ExpansionLUT(chipsetTiming);
+        mOutputBytesPerInputByte = 16 * sizeof(Wave3Byte); // 48
+    } else {
+        // wave8 clock: 8 ticks per bit period
+        u32 period = chipsetTiming.T1 + chipsetTiming.T2 + chipsetTiming.T3;
+        mClockHz = period > 0 ? static_cast<u32>(8000000000ULL / period) : 8000000;
+        mWave8Lut = buildWave8ExpansionLUT(chipsetTiming);
+        mOutputBytesPerInputByte = 16 * sizeof(Wave8Byte); // 128
+    }
+
+    // Chunk sizing
     size_t chunkInputBytes =
         mChunkInputBytesOverride > 0 ? mChunkInputBytesOverride
                                      : kDefaultChunkInputBytes;
@@ -293,11 +328,9 @@ bool ChannelDriverLcdSpi::beginTransmission(
         chunkInputBytes = maxSize;
     }
 
-    // Each source byte → 8 u16 words → 16 DMA bytes
-    size_t slotCapacityBytes = chunkInputBytes * 8 * sizeof(u16);
+    size_t slotCapacityBytes = chunkInputBytes * mOutputBytesPerInputByte;
 
-    // Only reinitialize the peripheral when hardware config changes
-    // (lane count). This avoids tearing down the I80 bus GPIO matrix.
+    // Peripheral init (only when lane count changes)
     bool needPeripheralInit = !mInitialized || (numLanes != mNumLanes);
 
     if (needPeripheralInit) {
@@ -310,28 +343,25 @@ bool ChannelDriverLcdSpi::beginTransmission(
 
         detail::LcdSpiConfig config;
         config.num_lanes = numLanes;
-        // max_transfer_bytes = chunk DMA size (all chunks are uniform)
         config.max_transfer_bytes = slotCapacityBytes;
         config.use_psram = true;
+        config.clock_hz = mClockHz;
 
         for (size_t i = 0; i < channels.size() && i < 16; i++) {
-            const auto &chipset = channels[i]->getChipset();
-            const auto *spiConfig = chipset.ptr<SpiChipsetConfig>();
-            if (spiConfig) {
-                config.data_gpios[i] = spiConfig->dataPin;
-                if (config.clock_gpio < 0) {
-                    config.clock_gpio = spiConfig->clockPin;
-                    config.clock_hz = spiConfig->timing.clock_hz;
-                }
-            }
+            config.data_gpios[i] = channels[i]->getPin();
         }
 
+        // PCLK needs a GPIO but is not connected to LEDs for clockless.
+        // Use GPIO 21 as dummy (same convention as SPI dc_gpio).
+        if (config.clock_gpio < 0) {
+            config.clock_gpio = 21;
+        }
         if (config.dc_gpio < 0) {
-            config.dc_gpio = 21;
+            config.dc_gpio = 22; // another unused GPIO
         }
 
         if (!mPeripheral->initialize(config)) {
-            FL_WARN("ChannelDriverLcdSpi: Failed to initialize peripheral");
+            FL_WARN("ChannelDriverLcdClockless: Failed to init peripheral");
             return false;
         }
 
@@ -339,46 +369,43 @@ bool ChannelDriverLcdSpi::beginTransmission(
         mInitialized = true;
     }
 
-    // Allocate ring buffers (reused across frames)
     if (!allocateRingBuffers(slotCapacityBytes)) {
         return false;
     }
 
-    // Register the ISR callback for chunked streaming
+    // Register ISR callback
     mPeripheral->registerTransmitCallback(
         reinterpret_cast<void *>(&isrChunkDone), this); // ok reinterpret cast
 
-    // Initialize ISR context for this frame
+    // Initialize ISR context
     mIsrCtx.reset();
     mIsrCtx.mTotalBytes = maxSize;
     mIsrCtx.mChunkInputBytes = chunkInputBytes;
+    mIsrCtx.mDmaBytesPerChunk = slotCapacityBytes;
 
-    // Mark channels in-use (DMA sources must stay alive)
     for (const auto &channel : channels) {
         channel->setInUse(true);
     }
 
-    // Transpose first chunk into ring[0]
+    // Encode first chunk
     size_t firstChunkBytes = chunkInputBytes;
     if (firstChunkBytes > maxSize) {
         firstChunkBytes = maxSize;
     }
 
-    fl::memset(mRingBuffers[0], 0, firstChunkBytes * 8 * sizeof(u16));
-    transposeToWords(channels, mRingBuffers[0], 0, firstChunkBytes);
+    size_t firstDmaBytes = encodeChunk(channels, mRingBuffers[0], 0,
+                                       firstChunkBytes);
 
     mIsrCtx.mNextByteOffset = firstChunkBytes;
-    mIsrCtx.mRingWriteIdx = 1; // next write goes to slot 1
+    mIsrCtx.mRingWriteIdx = 1;
 
-    // Submit first chunk — ISR callback handles the rest
     mBusy = true;
-    size_t firstDmaBytes = firstChunkBytes * 8 * sizeof(u16);
     if (!mPeripheral->transmit(mRingBuffers[0], firstDmaBytes)) {
         mBusy = false;
         for (const auto &channel : channels) {
             channel->setInUse(false);
         }
-        FL_WARN("ChannelDriverLcdSpi: Initial transmit failed");
+        FL_WARN("ChannelDriverLcdClockless: Initial transmit failed");
         return false;
     }
 
@@ -389,8 +416,8 @@ bool ChannelDriverLcdSpi::beginTransmission(
 // Factory
 //=============================================================================
 
-fl::shared_ptr<IChannelDriver> createLcdSpiEngine() FL_NOEXCEPT {
-#if FL_LCD_SPI_HAS_ESP_PERIPHERAL
+fl::shared_ptr<IChannelDriver> createLcdClocklessEngine() FL_NOEXCEPT {
+#if FL_LCD_CLOCKLESS_HAS_ESP_PERIPHERAL
     class EspWrapper : public detail::ILcdSpiPeripheral {
       public:
         bool initialize(const detail::LcdSpiConfig &c) FL_NOEXCEPT override {
@@ -432,7 +459,7 @@ fl::shared_ptr<IChannelDriver> createLcdSpiEngine() FL_NOEXCEPT {
         }
     };
     auto wrapper = fl::make_shared<EspWrapper>();
-    return fl::make_shared<ChannelDriverLcdSpi>(wrapper);
+    return fl::make_shared<ChannelDriverLcdClockless>(wrapper);
 #else
     return nullptr;
 #endif
@@ -440,6 +467,6 @@ fl::shared_ptr<IChannelDriver> createLcdSpiEngine() FL_NOEXCEPT {
 
 } // namespace fl
 
-#undef FL_LCD_SPI_COMPILE
+#undef FL_LCD_CLOCKLESS_COMPILE
 
-#endif // FL_LCD_SPI_COMPILE
+#endif // FL_LCD_CLOCKLESS_COMPILE

--- a/src/platforms/esp/32/drivers/lcd_spi/channel_driver_lcd_clockless.cpp.hpp
+++ b/src/platforms/esp/32/drivers/lcd_spi/channel_driver_lcd_clockless.cpp.hpp
@@ -351,13 +351,17 @@ bool ChannelDriverLcdClockless::beginTransmission(
             config.data_gpios[i] = channels[i]->getPin();
         }
 
-        // PCLK needs a GPIO but is not connected to LEDs for clockless.
-        // Use GPIO 21 as dummy (same convention as SPI dc_gpio).
+        // PCLK and DC pins are required by the LCD I80 bus API but the
+        // signals are not connected to LEDs for clockless output (data
+        // streams out on data_gpios). Use GPIO 0 for both (same convention
+        // as the legacy I2S LCD_CAM driver this replaces — proven safe on
+        // ESP32-S3 because the strapping pin tolerates being multiplexed
+        // to unused peripheral functions).
         if (config.clock_gpio < 0) {
-            config.clock_gpio = 21;
+            config.clock_gpio = 0;
         }
         if (config.dc_gpio < 0) {
-            config.dc_gpio = 22; // another unused GPIO
+            config.dc_gpio = 0;
         }
 
         if (!mPeripheral->initialize(config)) {

--- a/src/platforms/esp/32/drivers/lcd_spi/channel_driver_lcd_clockless.h
+++ b/src/platforms/esp/32/drivers/lcd_spi/channel_driver_lcd_clockless.h
@@ -1,0 +1,159 @@
+/// @file channel_driver_lcd_clockless.h
+/// @brief LCD_CAM I80 channel driver for clockless LED chipsets (WS2812, SK6812)
+///
+/// Uses LCD_CAM I80 bus on ESP32-S3 to drive clockless LED strips.
+/// Handles clockless chipsets only (not SPI). Data is encoded using
+/// wave3 or wave8 waveform expansion and transposed for parallel
+/// 16-bit output on the I80 bus.
+///
+/// This driver replaces the misnamed "I2S" driver on ESP32-S3 (which
+/// actually wraps the LCD_CAM peripheral, not I2S). The "I2S" name
+/// is retained only for ESP32dev which has a real I2S peripheral.
+///
+/// ## Encoding Auto-Selection
+///
+/// - wave3 (3 ticks/bit): Used when canUseWave3(timing) returns true.
+///   Saves 2.67x memory vs wave8. Works for WS2812, SK6812, etc.
+/// - wave8 (8 ticks/bit): Fallback for chipsets that need finer timing.
+///
+/// ## ISR-Driven Chunked DMA
+///
+/// Same architecture as ChannelDriverLcdSpi — 3-buffer ring, ISR callback
+/// transposes next chunk (~1-2 µs) and submits immediately.
+/// See issue #2258 for design details.
+
+#pragma once
+
+// IWYU pragma: private
+
+#include "fl/stl/compiler_control.h"
+#include "fl/channels/data.h"
+#include "fl/channels/driver.h"
+#include "fl/channels/wave3.h"
+#include "fl/channels/wave8.h"
+#include "fl/chipsets/led_timing.h"
+#include "fl/stl/noexcept.h"
+#include "fl/stl/span.h"
+#include "fl/stl/shared_ptr.h"
+#include "fl/stl/vector.h"
+#include "platforms/esp/32/drivers/lcd_spi/ilcd_spi_peripheral.h"
+
+namespace fl {
+
+/// @brief Channel driver for clockless chipsets via LCD_CAM I80 bus
+///
+/// Implements IChannelDriver for clockless protocols (WS2812, SK6812, etc.).
+/// Uses LCD_CAM peripheral with PCLK providing pulse timing and D0-D15 as
+/// parallel data lanes. Data bytes are wave-encoded and transposed into
+/// 16-bit words for I80 output.
+class ChannelDriverLcdClockless : public IChannelDriver {
+  public:
+    explicit ChannelDriverLcdClockless(
+        fl::shared_ptr<detail::ILcdSpiPeripheral> peripheral) FL_NOEXCEPT;
+    ~ChannelDriverLcdClockless() override;
+
+    bool canHandle(const ChannelDataPtr &data) const FL_NOEXCEPT override;
+    void enqueue(ChannelDataPtr channelData) FL_NOEXCEPT override;
+    void show() FL_NOEXCEPT override;
+    DriverState poll() FL_NOEXCEPT override;
+
+    fl::string getName() const FL_NOEXCEPT override {
+        return fl::string::from_literal("LCD_CLOCKLESS");
+    }
+
+    Capabilities getCapabilities() const FL_NOEXCEPT override {
+        return Capabilities(true, false); // clockless only
+    }
+
+    //=========================================================================
+    // Ring buffer configuration
+    //=========================================================================
+
+    static constexpr size_t kRingBufferCount = 3;
+
+    /// Default: ~30 LEDs per chunk for clockless (3 bytes/LED).
+    /// wave3: 90 bytes * 48 = 4.3KB per DMA slot → 13KB total ring.
+    /// wave8: 90 bytes * 128 = 11.5KB per DMA slot → 34.5KB total ring.
+    static constexpr size_t kDefaultChunkInputBytes = 90;
+
+    /// Override chunk input bytes for testing (0 = use default).
+    void setChunkInputBytesForTest(size_t bytes) FL_NOEXCEPT {
+        mChunkInputBytesOverride = bytes;
+    }
+
+  private:
+    bool beginTransmission(
+        fl::span<const ChannelDataPtr> channels) FL_NOEXCEPT;
+
+    /// @brief Encode and transpose a range of source bytes using wave3 or wave8
+    /// @param channels Source channel data spans
+    /// @param output DMA buffer (u16 words)
+    /// @param startByte First source byte index
+    /// @param byteCount Number of source bytes to encode
+    /// @return Number of DMA bytes written
+    size_t encodeChunk(fl::span<const ChannelDataPtr> channels,
+                       u16 *output, size_t startByte,
+                       size_t byteCount) FL_NOEXCEPT;
+
+    void freeRingBuffers() FL_NOEXCEPT;
+    bool allocateRingBuffers(size_t slotCapacityBytes) FL_NOEXCEPT;
+
+    //=========================================================================
+    // ISR callback
+    //=========================================================================
+
+    static bool isrChunkDone(void *panel_io, const void *edata,
+                             void *user_ctx) FL_NOEXCEPT;
+
+    //=========================================================================
+    // ISR context
+    //=========================================================================
+
+    struct IsrContext {
+        volatile bool mStreamComplete;
+        volatile size_t mNextByteOffset;
+        volatile size_t mRingWriteIdx;
+
+        size_t mTotalBytes;
+        size_t mChunkInputBytes;
+        size_t mDmaBytesPerChunk; // DMA output bytes for a full chunk
+
+        void reset() FL_NOEXCEPT {
+            mStreamComplete = false;
+            mNextByteOffset = 0;
+            mRingWriteIdx = 0;
+            mTotalBytes = 0;
+            mChunkInputBytes = 0;
+            mDmaBytesPerChunk = 0;
+        }
+    };
+
+    //=========================================================================
+    // Member state
+    //=========================================================================
+
+    fl::shared_ptr<detail::ILcdSpiPeripheral> mPeripheral;
+    bool mInitialized;
+    fl::vector<ChannelDataPtr> mEnqueuedChannels;
+    fl::vector<ChannelDataPtr> mTransmittingChannels;
+
+    u16 *mRingBuffers[kRingBufferCount];
+    size_t mRingCapacity;
+
+    int mNumLanes;
+    volatile bool mBusy;
+    IsrContext mIsrCtx;
+    size_t mChunkInputBytesOverride;
+
+    // Encoding state (set during beginTransmission, stable during ISR)
+    bool mUseWave3;
+    Wave3BitExpansionLut mWave3Lut;
+    Wave8BitExpansionLut mWave8Lut;
+    u32 mClockHz;
+    size_t mOutputBytesPerInputByte; // 48 for wave3, 128 for wave8 (with 16 lanes)
+};
+
+/// @brief Factory function to create LCD clockless driver
+fl::shared_ptr<IChannelDriver> createLcdClocklessEngine() FL_NOEXCEPT;
+
+} // namespace fl

--- a/src/platforms/esp/32/drivers/lcd_spi/channel_driver_lcd_spi.h
+++ b/src/platforms/esp/32/drivers/lcd_spi/channel_driver_lcd_spi.h
@@ -4,6 +4,16 @@
 /// Uses LCD_CAM I80 bus on ESP32-S3 to drive clocked SPI LED strips.
 /// Handles SPI chipsets only (not clockless). Data is transposed for
 /// parallel 16-bit output on the I80 bus.
+///
+/// ## ISR-Driven Chunked DMA Streaming
+///
+/// The driver splits LED data into fixed-size chunks and transmits them
+/// via a 3-buffer ring. When a DMA chunk completes, the ISR callback
+/// transposes the next chunk (~1-2 µs) and submits it immediately.
+/// This reduces peak memory from O(total_leds) to O(chunk_size × 3)
+/// and enables arbitrarily long strips without OOM.
+///
+/// See issue #2258 for design details and PARLIO reference.
 
 #pragma once
 
@@ -26,7 +36,9 @@ namespace fl {
 /// Uses LCD_CAM peripheral with PCLK as SPI clock and D0-D15 as parallel
 /// data lanes. Data bytes are transposed into 16-bit words for I80 output.
 ///
-/// Currently blocking: show() waits for transmission to complete.
+/// Transmission is ISR-driven: show() kicks off the first DMA chunk,
+/// then the ISR callback handles subsequent chunks automatically.
+/// poll() reports DRAINING until all chunks complete.
 class ChannelDriverLcdSpi : public IChannelDriver {
   public:
     explicit ChannelDriverLcdSpi(
@@ -46,24 +58,103 @@ class ChannelDriverLcdSpi : public IChannelDriver {
         return Capabilities(false, true); // SPI only
     }
 
+    //=========================================================================
+    // Ring buffer configuration (public for testing)
+    //=========================================================================
+
+    static constexpr size_t kRingBufferCount = 3;
+
+    /// Default source-byte capacity per ring buffer slot.
+    /// Each source byte produces 8 u16 words (16 bytes) in the DMA buffer.
+    /// Capped at ~100 APA102 LEDs (4+100*4+4 = 408 bytes → ~6.5KB DMA/slot).
+    static constexpr size_t kDefaultChunkInputBytes = 408;
+
+    /// Override chunk input bytes for testing (0 = use default).
+    void setChunkInputBytesForTest(size_t bytes) FL_NOEXCEPT {
+        mChunkInputBytesOverride = bytes;
+    }
+
   private:
     bool beginTransmission(
         fl::span<const ChannelDataPtr> channels) FL_NOEXCEPT;
 
-    /// @brief Transpose byte data into 16-bit words for I80 bus output
-    /// Each bit position in the output word corresponds to one data lane.
+    /// @brief Transpose a range of source bytes into 16-bit words
+    /// @param channels Source channel data spans
+    /// @param output DMA buffer to write transposed words into
+    /// @param startByte First source byte index to transpose
+    /// @param byteCount Number of source bytes to transpose
     void transposeToWords(fl::span<const ChannelDataPtr> channels,
-                          u16 *output, size_t maxBytes) FL_NOEXCEPT;
+                          u16 *output, size_t startByte,
+                          size_t byteCount) FL_NOEXCEPT;
+
+    /// @brief Free all ring buffer allocations
+    void freeRingBuffers() FL_NOEXCEPT;
+
+    /// @brief Allocate ring buffers with given per-slot capacity
+    bool allocateRingBuffers(size_t slotCapacityBytes) FL_NOEXCEPT;
+
+    //=========================================================================
+    // ISR callback — called when a DMA chunk completes
+    //=========================================================================
+
+    /// @brief ISR callback: transpose and submit next chunk, or mark complete.
+    ///
+    /// On ESP32: runs in ISR context (IRAM_ATTR). Must be <10 µs.
+    /// On host (mock): runs synchronously from simulateTransmitComplete().
+    ///
+    /// @param panel_io ESP panel IO handle (nullptr on mock)
+    /// @param edata ESP event data (nullptr on mock)
+    /// @param user_ctx Pointer to ChannelDriverLcdSpi instance
+    /// @return false (no higher-priority task woken by this callback)
+    static bool isrChunkDone(void *panel_io, const void *edata,
+                             void *user_ctx) FL_NOEXCEPT;
+
+    //=========================================================================
+    // ISR context — coordinates chunked streaming between ISR and main
+    //=========================================================================
+
+    /// @brief Stream state for ISR-driven chunked DMA
+    ///
+    /// Memory model (follows PARLIO's parlio_isr_context.h):
+    /// - ISR writes volatile fields (mStreamComplete, mNextByteOffset, etc.)
+    /// - Main thread reads volatile fields directly
+    /// - After detecting mStreamComplete==true, main reads non-volatile fields
+    struct IsrContext {
+        // Volatile: ISR writes, main reads
+        volatile bool mStreamComplete;
+        volatile size_t mNextByteOffset; // next source byte to transpose
+        volatile size_t mRingWriteIdx;   // next ring slot to write (0-2)
+
+        // Non-volatile: set once before streaming starts
+        size_t mTotalBytes;       // max source bytes across all channels
+        size_t mChunkInputBytes;  // source bytes per chunk
+
+        void reset() FL_NOEXCEPT {
+            mStreamComplete = false;
+            mNextByteOffset = 0;
+            mRingWriteIdx = 0;
+            mTotalBytes = 0;
+            mChunkInputBytes = 0;
+        }
+    };
+
+    //=========================================================================
+    // Member state
+    //=========================================================================
 
     fl::shared_ptr<detail::ILcdSpiPeripheral> mPeripheral;
     bool mInitialized;
     fl::vector<ChannelDataPtr> mEnqueuedChannels;
     fl::vector<ChannelDataPtr> mTransmittingChannels;
 
-    u16 *mBuffer;
-    size_t mBufferSize;
+    // Ring buffer: 3 DMA buffers for chunked streaming
+    u16 *mRingBuffers[kRingBufferCount];
+    size_t mRingCapacity; // DMA bytes per ring slot
+
     int mNumLanes;
     volatile bool mBusy;
+    IsrContext mIsrCtx;
+    size_t mChunkInputBytesOverride; // 0 = use kDefaultChunkInputBytes
 };
 
 /// @brief Factory function to create LCD_SPI driver with real hardware

--- a/src/platforms/esp/32/drivers/lcd_spi/lcd_spi_peripheral_mock.cpp.hpp
+++ b/src/platforms/esp/32/drivers/lcd_spi/lcd_spi_peripheral_mock.cpp.hpp
@@ -211,14 +211,25 @@ void LcdSpiPeripheralMockImpl::simulateTransmitComplete() FL_NOEXCEPT {
     if (mPendingTransmits == 0) {
         return;
     }
-    mPendingTransmits--;
-    if (mPendingTransmits == 0) {
-        mBusy = false;
-    }
-    if (mCallback != nullptr) {
-        using CallbackType = bool (*)(void *, const void *, void *);
-        auto cb = reinterpret_cast<CallbackType>(mCallback); // ok reinterpret cast
-        cb(nullptr, nullptr, mUserCtx);
+
+    // Drain the entire ISR callback chain. When a callback calls transmit()
+    // (to submit the next DMA chunk), mPendingTransmits increments again.
+    // The loop continues until no more chunks are queued.
+    // This simulates instant DMA completion for all chunks in the stream.
+    //
+    // For single-shot transmissions (no callback registered), the loop
+    // fires once and exits — behavior is identical to the old code.
+    while (mPendingTransmits > 0) {
+        mPendingTransmits--;
+        if (mPendingTransmits == 0) {
+            mBusy = false;
+        }
+        if (mCallback != nullptr) {
+            using CallbackType = bool (*)(void *, const void *, void *);
+            auto cb =
+                reinterpret_cast<CallbackType>(mCallback); // ok reinterpret cast
+            cb(nullptr, nullptr, mUserCtx);
+        }
     }
 }
 

--- a/tests/platforms/esp/32/drivers/lcd_spi/channel_driver_lcd_clockless.cpp
+++ b/tests/platforms/esp/32/drivers/lcd_spi/channel_driver_lcd_clockless.cpp
@@ -1,0 +1,349 @@
+/// @file channel_driver_lcd_clockless.cpp
+/// @brief Unit tests for LCD_CAM clockless channel driver
+
+#ifdef FASTLED_STUB_IMPL
+
+#include "test.h"
+#include "platforms/esp/32/drivers/lcd_spi/channel_driver_lcd_clockless.h"
+#include "platforms/esp/32/drivers/lcd_spi/lcd_spi_peripheral_mock.h"
+#include "fl/channels/data.h"
+#include "fl/channels/config.h"
+#include "fl/channels/wave3.h"
+#include "fl/channels/wave8.h"
+#include "fl/chipsets/led_timing.h"
+#include "fl/stl/vector.h"
+
+FL_TEST_FILE(FL_FILEPATH) {
+
+using namespace fl;
+using namespace fl::detail;
+
+namespace {
+
+void resetMockState() {
+    auto &mock = LcdSpiPeripheralMock::instance();
+    mock.reset();
+}
+
+fl::shared_ptr<ILcdSpiPeripheral> createMockPeripheral() {
+    class MockWrapper : public ILcdSpiPeripheral {
+      public:
+        bool initialize(const LcdSpiConfig &config) FL_NOEXCEPT override {
+            return LcdSpiPeripheralMock::instance().initialize(config);
+        }
+        void deinitialize() FL_NOEXCEPT override {
+            LcdSpiPeripheralMock::instance().deinitialize();
+        }
+        bool isInitialized() const FL_NOEXCEPT override {
+            return LcdSpiPeripheralMock::instance().isInitialized();
+        }
+        u16 *allocateBuffer(size_t size_bytes) FL_NOEXCEPT override {
+            return LcdSpiPeripheralMock::instance().allocateBuffer(size_bytes);
+        }
+        void freeBuffer(u16 *buffer) FL_NOEXCEPT override {
+            LcdSpiPeripheralMock::instance().freeBuffer(buffer);
+        }
+        bool transmit(const u16 *buffer,
+                      size_t size_bytes) FL_NOEXCEPT override {
+            return LcdSpiPeripheralMock::instance().transmit(buffer,
+                                                             size_bytes);
+        }
+        bool waitTransmitDone(u32 timeout_ms) FL_NOEXCEPT override {
+            return LcdSpiPeripheralMock::instance().waitTransmitDone(
+                timeout_ms);
+        }
+        bool isBusy() const FL_NOEXCEPT override {
+            return LcdSpiPeripheralMock::instance().isBusy();
+        }
+        bool registerTransmitCallback(void *callback,
+                                      void *user_ctx) FL_NOEXCEPT override {
+            return LcdSpiPeripheralMock::instance().registerTransmitCallback(
+                callback, user_ctx);
+        }
+        const LcdSpiConfig &getConfig() const FL_NOEXCEPT override {
+            return LcdSpiPeripheralMock::instance().getConfig();
+        }
+        u64 getMicroseconds() FL_NOEXCEPT override {
+            return LcdSpiPeripheralMock::instance().getMicroseconds();
+        }
+        void delay(u32 ms) FL_NOEXCEPT override {
+            LcdSpiPeripheralMock::instance().delay(ms);
+        }
+    };
+
+    return fl::make_shared<MockWrapper>();
+}
+
+ChannelDataPtr createClocklessChannelData(int pin, size_t numLeds) {
+    // WS2812 timing (eligible for wave3)
+    auto timing = makeTimingConfig<TIMING_WS2812_800KHZ>();
+    fl::vector_psram<u8> data;
+    data.resize(numLeds * 3); // RGB
+    for (size_t i = 0; i < numLeds * 3; i++) {
+        data[i] = static_cast<u8>(i % 256);
+    }
+    return ChannelData::create(pin, timing, fl::move(data));
+}
+
+} // anonymous namespace
+
+//=============================================================================
+// Creation
+//=============================================================================
+
+FL_TEST_CASE("ChannelDriverLcdClockless - creation") {
+    resetMockState();
+    auto peripheral = createMockPeripheral();
+    ChannelDriverLcdClockless driver(peripheral);
+    FL_CHECK(driver.getName() == "LCD_CLOCKLESS");
+}
+
+FL_TEST_CASE("ChannelDriverLcdClockless - initial state is READY") {
+    resetMockState();
+    auto peripheral = createMockPeripheral();
+    ChannelDriverLcdClockless driver(peripheral);
+    FL_CHECK(driver.poll() == IChannelDriver::DriverState::READY);
+}
+
+//=============================================================================
+// canHandle
+//=============================================================================
+
+FL_TEST_CASE("ChannelDriverLcdClockless - canHandle accepts clockless") {
+    resetMockState();
+    auto peripheral = createMockPeripheral();
+    ChannelDriverLcdClockless driver(peripheral);
+
+    auto data = createClocklessChannelData(5, 10);
+    FL_CHECK(driver.canHandle(data));
+}
+
+FL_TEST_CASE("ChannelDriverLcdClockless - canHandle rejects SPI") {
+    resetMockState();
+    auto peripheral = createMockPeripheral();
+    ChannelDriverLcdClockless driver(peripheral);
+
+    SpiEncoder encoder = SpiEncoder::apa102();
+    SpiChipsetConfig spiCfg{5, 18, encoder};
+    fl::vector_psram<u8> d;
+    d.resize(48);
+    auto spiData = ChannelData::create(spiCfg, fl::move(d));
+    FL_CHECK_FALSE(driver.canHandle(spiData));
+}
+
+FL_TEST_CASE("ChannelDriverLcdClockless - canHandle rejects null") {
+    resetMockState();
+    auto peripheral = createMockPeripheral();
+    ChannelDriverLcdClockless driver(peripheral);
+    FL_CHECK_FALSE(driver.canHandle(nullptr));
+}
+
+//=============================================================================
+// Wave3 auto-selection (WS2812 is wave3-eligible)
+//=============================================================================
+
+FL_TEST_CASE("ChannelDriverLcdClockless - WS2812 selects wave3") {
+    // Verify WS2812 timing is wave3-eligible
+    ChipsetTiming ws2812;
+    ws2812.T1 = 400; ws2812.T2 = 450; ws2812.T3 = 450;
+    FL_CHECK(canUseWave3(ws2812));
+}
+
+//=============================================================================
+// Single chunk transmission
+//=============================================================================
+
+FL_TEST_CASE("ChannelDriverLcdClockless - single chunk") {
+    resetMockState();
+    auto peripheral = createMockPeripheral();
+    ChannelDriverLcdClockless driver(peripheral);
+    auto &mock = LcdSpiPeripheralMock::instance();
+
+    // 1 LED = 3 bytes source → fits in one chunk (default 90 bytes)
+    auto data = createClocklessChannelData(5, 1);
+    driver.enqueue(data);
+    driver.show();
+
+    FL_CHECK(driver.poll() == IChannelDriver::DriverState::DRAINING);
+    FL_CHECK(mock.getTransmitCount() == 1);
+
+    mock.simulateTransmitComplete();
+    FL_CHECK(driver.poll() == IChannelDriver::DriverState::READY);
+    FL_CHECK(mock.getTransmitCount() == 1);
+}
+
+//=============================================================================
+// Multi-chunk streaming
+//=============================================================================
+
+FL_TEST_CASE("ChannelDriverLcdClockless - multi-chunk") {
+    resetMockState();
+    auto peripheral = createMockPeripheral();
+    ChannelDriverLcdClockless driver(peripheral);
+    auto &mock = LcdSpiPeripheralMock::instance();
+
+    // Force 3 bytes per chunk (1 LED per chunk)
+    driver.setChunkInputBytesForTest(3);
+
+    // 3 LEDs = 9 bytes → 3 chunks
+    auto data = createClocklessChannelData(5, 3);
+    driver.enqueue(data);
+    driver.show();
+
+    FL_CHECK(mock.getTransmitCount() == 1);
+
+    mock.simulateTransmitComplete();
+    FL_CHECK(driver.poll() == IChannelDriver::DriverState::READY);
+    FL_CHECK(mock.getTransmitCount() == 3);
+}
+
+//=============================================================================
+// Multi-lane
+//=============================================================================
+
+FL_TEST_CASE("ChannelDriverLcdClockless - two lanes") {
+    resetMockState();
+    auto peripheral = createMockPeripheral();
+    ChannelDriverLcdClockless driver(peripheral);
+    auto &mock = LcdSpiPeripheralMock::instance();
+
+    auto ch0 = createClocklessChannelData(5, 2);
+    auto ch1 = createClocklessChannelData(6, 2);
+    driver.enqueue(ch0);
+    driver.enqueue(ch1);
+    driver.show();
+
+    FL_CHECK(mock.getTransmitCount() == 1);
+    mock.simulateTransmitComplete();
+    FL_CHECK(driver.poll() == IChannelDriver::DriverState::READY);
+}
+
+//=============================================================================
+// Multi-chunk with ring wrap
+//=============================================================================
+
+FL_TEST_CASE("ChannelDriverLcdClockless - ring wrap") {
+    resetMockState();
+    auto peripheral = createMockPeripheral();
+    ChannelDriverLcdClockless driver(peripheral);
+    auto &mock = LcdSpiPeripheralMock::instance();
+
+    // 1 byte per chunk, 6 bytes source → 6 chunks (wraps 3-slot ring twice)
+    driver.setChunkInputBytesForTest(1);
+
+    auto timing = makeTimingConfig<TIMING_WS2812_800KHZ>();
+    fl::vector_psram<u8> d;
+    d.resize(6);
+    for (size_t i = 0; i < 6; i++) d[i] = 0xFF;
+    auto data = ChannelData::create(5, timing, fl::move(d));
+    driver.enqueue(data);
+    driver.show();
+    mock.simulateTransmitComplete();
+
+    FL_CHECK(driver.poll() == IChannelDriver::DriverState::READY);
+    FL_CHECK(mock.getTransmitCount() == 6);
+}
+
+//=============================================================================
+// Multi-cycle reuse
+//=============================================================================
+
+FL_TEST_CASE("ChannelDriverLcdClockless - multi-cycle reuse") {
+    resetMockState();
+    auto peripheral = createMockPeripheral();
+    ChannelDriverLcdClockless driver(peripheral);
+    auto &mock = LcdSpiPeripheralMock::instance();
+
+    driver.setChunkInputBytesForTest(3);
+
+    for (int cycle = 0; cycle < 3; cycle++) {
+        auto data = createClocklessChannelData(5, 2); // 6 bytes → 2 chunks
+        driver.enqueue(data);
+        driver.show();
+        mock.simulateTransmitComplete();
+        FL_CHECK(driver.poll() == IChannelDriver::DriverState::READY);
+    }
+
+    // 3 cycles × 2 chunks = 6
+    FL_CHECK(mock.getTransmitCount() == 6);
+}
+
+//=============================================================================
+// Error handling
+//=============================================================================
+
+FL_TEST_CASE("ChannelDriverLcdClockless - transmit failure") {
+    resetMockState();
+    auto peripheral = createMockPeripheral();
+    ChannelDriverLcdClockless driver(peripheral);
+    auto &mock = LcdSpiPeripheralMock::instance();
+
+    mock.setTransmitFailure(true);
+
+    auto data = createClocklessChannelData(5, 5);
+    driver.enqueue(data);
+    driver.show();
+
+    FL_CHECK(driver.poll() == IChannelDriver::DriverState::READY);
+}
+
+FL_TEST_CASE("ChannelDriverLcdClockless - error mid-stream") {
+    resetMockState();
+    auto peripheral = createMockPeripheral();
+    ChannelDriverLcdClockless driver(peripheral);
+    auto &mock = LcdSpiPeripheralMock::instance();
+
+    driver.setChunkInputBytesForTest(3);
+
+    auto data = createClocklessChannelData(5, 3); // 9 bytes → 3 chunks
+    driver.enqueue(data);
+    driver.show();
+
+    FL_CHECK(mock.getTransmitCount() == 1);
+
+    mock.setTransmitFailure(true);
+    mock.simulateTransmitComplete();
+
+    // ISR tried chunk 2 but transmit failed → abort
+    FL_CHECK(driver.poll() == IChannelDriver::DriverState::READY);
+}
+
+//=============================================================================
+// Empty enqueue
+//=============================================================================
+
+FL_TEST_CASE("ChannelDriverLcdClockless - empty enqueue") {
+    resetMockState();
+    auto peripheral = createMockPeripheral();
+    ChannelDriverLcdClockless driver(peripheral);
+    auto &mock = LcdSpiPeripheralMock::instance();
+
+    driver.show();
+    FL_CHECK(driver.poll() == IChannelDriver::DriverState::READY);
+    FL_CHECK(mock.getTransmitCount() == 0);
+}
+
+//=============================================================================
+// DMA output size verification
+//=============================================================================
+
+FL_TEST_CASE("ChannelDriverLcdClockless - wave3 DMA output size") {
+    resetMockState();
+    auto peripheral = createMockPeripheral();
+    ChannelDriverLcdClockless driver(peripheral);
+    auto &mock = LcdSpiPeripheralMock::instance();
+
+    // 1 LED = 3 source bytes.
+    // Wave3: 3 bytes × 48 output bytes/input byte = 144 DMA bytes
+    auto data = createClocklessChannelData(5, 1);
+    driver.enqueue(data);
+    driver.show();
+
+    const auto &history = mock.getTransmitHistory();
+    FL_REQUIRE(history.size() == 1);
+    FL_CHECK(history[0].size_bytes == 3 * 16 * sizeof(Wave3Byte));
+}
+
+#endif // FASTLED_STUB_IMPL
+
+} // FL_TEST_FILE

--- a/tests/platforms/esp/32/drivers/lcd_spi/channel_driver_lcd_spi.cpp
+++ b/tests/platforms/esp/32/drivers/lcd_spi/channel_driver_lcd_spi.cpp
@@ -663,6 +663,369 @@ FL_TEST_CASE("ChannelDriverLcdSpi - lane count change triggers reinit") {
     }
 }
 
+//=============================================================================
+// ISR-Driven Chunked Streaming Tests (Issue #2258)
+//=============================================================================
+
+FL_TEST_CASE("ChannelDriverLcdSpi - single chunk with ISR callback") {
+    // Small data that fits in one chunk — ISR fires once, marks complete
+    resetMockState();
+    auto peripheral = createMockPeripheral();
+    ChannelDriverLcdSpi driver(peripheral);
+    auto &mock = LcdSpiPeripheralMock::instance();
+
+    // 4 bytes = 32 u16 words. With default chunk size (2048 bytes), fits
+    // in one chunk.
+    SpiEncoder encoder = SpiEncoder::apa102();
+    SpiChipsetConfig cfg{5, 18, encoder};
+    fl::vector_psram<u8> d;
+    d.resize(4);
+    d[0] = 0xFF; d[1] = 0x00; d[2] = 0xAA; d[3] = 0x55;
+    driver.enqueue(ChannelData::create(cfg, fl::move(d)));
+    driver.show();
+
+    FL_CHECK(driver.poll() == IChannelDriver::DriverState::DRAINING);
+    FL_CHECK(mock.getTransmitCount() == 1);
+
+    mock.simulateTransmitComplete();
+    FL_CHECK(driver.poll() == IChannelDriver::DriverState::READY);
+
+    // Verify: exactly 1 transmit (no ISR-initiated follow-up)
+    FL_CHECK(mock.getTransmitCount() == 1);
+}
+
+FL_TEST_CASE("ChannelDriverLcdSpi - multi-chunk streaming") {
+    // Force small chunk size to create multiple chunks
+    resetMockState();
+    auto peripheral = createMockPeripheral();
+    ChannelDriverLcdSpi driver(peripheral);
+    auto &mock = LcdSpiPeripheralMock::instance();
+
+    // 16 source bytes, 4 bytes per chunk = 4 chunks
+    driver.setChunkInputBytesForTest(4);
+
+    SpiEncoder encoder = SpiEncoder::apa102();
+    SpiChipsetConfig cfg{5, 18, encoder};
+    fl::vector_psram<u8> d;
+    d.resize(16);
+    for (size_t i = 0; i < 16; i++) {
+        d[i] = static_cast<u8>(i);
+    }
+    driver.enqueue(ChannelData::create(cfg, fl::move(d)));
+    driver.show();
+
+    FL_CHECK(driver.poll() == IChannelDriver::DriverState::DRAINING);
+    // First chunk submitted by beginTransmission
+    FL_CHECK(mock.getTransmitCount() == 1);
+
+    // simulateTransmitComplete drains the entire ISR callback chain
+    mock.simulateTransmitComplete();
+    FL_CHECK(driver.poll() == IChannelDriver::DriverState::READY);
+
+    // 4 chunks total: 1 initial + 3 from ISR callbacks
+    FL_CHECK(mock.getTransmitCount() == 4);
+}
+
+FL_TEST_CASE("ChannelDriverLcdSpi - chunk transpose fidelity") {
+    // Verify chunked transpose produces identical output to full-buffer
+    resetMockState();
+    auto peripheral = createMockPeripheral();
+    ChannelDriverLcdSpi driver(peripheral);
+    auto &mock = LcdSpiPeripheralMock::instance();
+
+    // Force 4 bytes per chunk
+    driver.setChunkInputBytesForTest(4);
+
+    SpiEncoder encoder = SpiEncoder::apa102();
+    SpiChipsetConfig cfg{5, 18, encoder};
+    fl::vector_psram<u8> d;
+    d.resize(12);
+    d[0] = 0x00; d[1] = 0xFF; d[2] = 0xAA; d[3] = 0x55;
+    d[4] = 0x0F; d[5] = 0xF0; d[6] = 0x33; d[7] = 0xCC;
+    d[8] = 0x01; d[9] = 0x80; d[10] = 0x7E; d[11] = 0xBD;
+
+    driver.enqueue(ChannelData::create(cfg, fl::move(d)));
+    driver.show();
+    mock.simulateTransmitComplete();
+    FL_CHECK(driver.poll() == IChannelDriver::DriverState::READY);
+
+    // 3 chunks of 4 bytes each
+    FL_CHECK(mock.getTransmitCount() == 3);
+
+    // Concatenate all chunk outputs
+    const auto &history = mock.getTransmitHistory();
+    fl::vector<u16> combined;
+    for (const auto &record : history) {
+        for (const auto &word : record.buffer_copy) {
+            combined.push_back(word);
+        }
+    }
+
+    // Compare against single-shot reference
+    FL_REQUIRE(combined.size() == 12 * 8); // 96 words
+
+    // Byte 0 = 0x00 → 8 words of 0x0000
+    for (size_t i = 0; i < 8; i++) {
+        FL_CHECK(combined[i] == 0x0000);
+    }
+    // Byte 1 = 0xFF → 8 words of 0x0001 (lane 0 set)
+    for (size_t i = 8; i < 16; i++) {
+        FL_CHECK(combined[i] == 0x0001);
+    }
+    // Byte 2 = 0xAA (10101010) → alternating
+    FL_CHECK(combined[16] == 0x0001); FL_CHECK(combined[17] == 0x0000);
+    FL_CHECK(combined[18] == 0x0001); FL_CHECK(combined[19] == 0x0000);
+    FL_CHECK(combined[20] == 0x0001); FL_CHECK(combined[21] == 0x0000);
+    FL_CHECK(combined[22] == 0x0001); FL_CHECK(combined[23] == 0x0000);
+    // Byte 3 = 0x55 (01010101) → alternating (opposite)
+    FL_CHECK(combined[24] == 0x0000); FL_CHECK(combined[25] == 0x0001);
+    FL_CHECK(combined[26] == 0x0000); FL_CHECK(combined[27] == 0x0001);
+    FL_CHECK(combined[28] == 0x0000); FL_CHECK(combined[29] == 0x0001);
+    FL_CHECK(combined[30] == 0x0000); FL_CHECK(combined[31] == 0x0001);
+}
+
+FL_TEST_CASE("ChannelDriverLcdSpi - multi-chunk two lanes") {
+    // Multi-lane with small chunk size to exercise lane transposition
+    resetMockState();
+    auto peripheral = createMockPeripheral();
+    ChannelDriverLcdSpi driver(peripheral);
+    auto &mock = LcdSpiPeripheralMock::instance();
+
+    driver.setChunkInputBytesForTest(2);
+
+    SpiEncoder encoder = SpiEncoder::apa102();
+    SpiChipsetConfig cfg0{5, 18, encoder};
+    SpiChipsetConfig cfg1{6, 18, encoder};
+
+    fl::vector_psram<u8> d0, d1;
+    d0.resize(4); d1.resize(4);
+    d0[0] = 0xFF; d0[1] = 0xFF; d0[2] = 0xFF; d0[3] = 0xFF;
+    d1[0] = 0x00; d1[1] = 0x00; d1[2] = 0xFF; d1[3] = 0xFF;
+
+    driver.enqueue(ChannelData::create(cfg0, fl::move(d0)));
+    driver.enqueue(ChannelData::create(cfg1, fl::move(d1)));
+    driver.show();
+    mock.simulateTransmitComplete();
+    FL_CHECK(driver.poll() == IChannelDriver::DriverState::READY);
+
+    // 4 bytes / 2 per chunk = 2 chunks
+    FL_CHECK(mock.getTransmitCount() == 2);
+
+    // Concatenate
+    const auto &history = mock.getTransmitHistory();
+    fl::vector<u16> combined;
+    for (const auto &rec : history) {
+        for (const auto &w : rec.buffer_copy) {
+            combined.push_back(w);
+        }
+    }
+    FL_REQUIRE(combined.size() == 32); // 4 bytes * 8
+
+    // Chunk 0 (bytes 0-1): lane0=0xFF,0xFF  lane1=0x00,0x00
+    // Only lane 0 active
+    for (size_t i = 0; i < 16; i++) {
+        FL_CHECK(combined[i] == 0x0001);
+    }
+    // Chunk 1 (bytes 2-3): lane0=0xFF,0xFF  lane1=0xFF,0xFF
+    // Both lanes active
+    for (size_t i = 16; i < 32; i++) {
+        FL_CHECK(combined[i] == 0x0003);
+    }
+}
+
+FL_TEST_CASE("ChannelDriverLcdSpi - ring wrap 3+ chunks") {
+    // 6 chunks to wrap the ring buffer (3 slots) twice
+    resetMockState();
+    auto peripheral = createMockPeripheral();
+    ChannelDriverLcdSpi driver(peripheral);
+    auto &mock = LcdSpiPeripheralMock::instance();
+
+    driver.setChunkInputBytesForTest(2);
+
+    SpiEncoder encoder = SpiEncoder::apa102();
+    SpiChipsetConfig cfg{5, 18, encoder};
+    fl::vector_psram<u8> d;
+    d.resize(12); // 12 / 2 = 6 chunks
+    for (size_t i = 0; i < 12; i++) {
+        d[i] = static_cast<u8>(0xFF); // all ones for easy verification
+    }
+    driver.enqueue(ChannelData::create(cfg, fl::move(d)));
+    driver.show();
+    mock.simulateTransmitComplete();
+
+    FL_CHECK(driver.poll() == IChannelDriver::DriverState::READY);
+    FL_CHECK(mock.getTransmitCount() == 6);
+
+    // All chunks should produce the same output (all 0xFF → all 0x0001)
+    const auto &history = mock.getTransmitHistory();
+    for (size_t c = 0; c < history.size(); c++) {
+        FL_REQUIRE(history[c].buffer_copy.size() == 16); // 2 bytes * 8
+        for (size_t i = 0; i < 16; i++) {
+            FL_CHECK(history[c].buffer_copy[i] == 0x0001);
+        }
+    }
+}
+
+FL_TEST_CASE("ChannelDriverLcdSpi - multi-cycle chunked reuse") {
+    // Multiple show() calls reuse ring buffers
+    resetMockState();
+    auto peripheral = createMockPeripheral();
+    ChannelDriverLcdSpi driver(peripheral);
+    auto &mock = LcdSpiPeripheralMock::instance();
+
+    driver.setChunkInputBytesForTest(4);
+
+    SpiEncoder encoder = SpiEncoder::apa102();
+
+    for (int cycle = 0; cycle < 3; cycle++) {
+        SpiChipsetConfig cfg{5, 18, encoder};
+        fl::vector_psram<u8> d;
+        d.resize(8); // 2 chunks per cycle
+        for (size_t i = 0; i < 8; i++) {
+            d[i] = static_cast<u8>(cycle * 16 + i);
+        }
+        driver.enqueue(ChannelData::create(cfg, fl::move(d)));
+        driver.show();
+        mock.simulateTransmitComplete();
+        FL_CHECK(driver.poll() == IChannelDriver::DriverState::READY);
+    }
+
+    // 3 cycles × 2 chunks = 6 total transmits
+    FL_CHECK(mock.getTransmitCount() == 6);
+}
+
+FL_TEST_CASE("ChannelDriverLcdSpi - error mid-stream aborts cleanly") {
+    // Inject failure on the 2nd chunk — stream should abort
+    resetMockState();
+    auto peripheral = createMockPeripheral();
+    ChannelDriverLcdSpi driver(peripheral);
+    auto &mock = LcdSpiPeripheralMock::instance();
+
+    driver.setChunkInputBytesForTest(4);
+
+    SpiEncoder encoder = SpiEncoder::apa102();
+    SpiChipsetConfig cfg{5, 18, encoder};
+    fl::vector_psram<u8> d;
+    d.resize(12); // 3 chunks
+    for (size_t i = 0; i < 12; i++) d[i] = 0xFF;
+    driver.enqueue(ChannelData::create(cfg, fl::move(d)));
+    driver.show();
+
+    FL_CHECK(mock.getTransmitCount() == 1);
+
+    // Inject failure before completing first chunk
+    mock.setTransmitFailure(true);
+    mock.simulateTransmitComplete();
+
+    // ISR tried to submit chunk 2 but transmit failed → stream aborted
+    // The initial transmit succeeded, ISR callback's transmit failed
+    FL_CHECK(mock.getTransmitCount() == 1); // only the initial one succeeded
+
+    // Driver should transition to READY after stream abort
+    FL_CHECK(driver.poll() == IChannelDriver::DriverState::READY);
+}
+
+FL_TEST_CASE("ChannelDriverLcdSpi - asymmetric lanes with chunking") {
+    // Lane 0: 8 bytes, Lane 1: 4 bytes
+    // With chunk size 4, lane 1 runs out mid-stream
+    resetMockState();
+    auto peripheral = createMockPeripheral();
+    ChannelDriverLcdSpi driver(peripheral);
+    auto &mock = LcdSpiPeripheralMock::instance();
+
+    driver.setChunkInputBytesForTest(4);
+
+    SpiEncoder encoder = SpiEncoder::apa102();
+    SpiChipsetConfig cfg0{5, 18, encoder};
+    SpiChipsetConfig cfg1{6, 18, encoder};
+
+    fl::vector_psram<u8> d0, d1;
+    d0.resize(8); d1.resize(4);
+    for (size_t i = 0; i < 8; i++) d0[i] = 0xFF;
+    for (size_t i = 0; i < 4; i++) d1[i] = 0xFF;
+
+    driver.enqueue(ChannelData::create(cfg0, fl::move(d0)));
+    driver.enqueue(ChannelData::create(cfg1, fl::move(d1)));
+    driver.show();
+    mock.simulateTransmitComplete();
+
+    FL_CHECK(driver.poll() == IChannelDriver::DriverState::READY);
+    // max(8, 4) = 8 bytes, 8/4 = 2 chunks
+    FL_CHECK(mock.getTransmitCount() == 2);
+
+    const auto &history = mock.getTransmitHistory();
+
+    // Chunk 0 (bytes 0-3): both lanes 0xFF → 0x0003
+    FL_REQUIRE(history[0].buffer_copy.size() == 32);
+    for (size_t i = 0; i < 32; i++) {
+        FL_CHECK(history[0].buffer_copy[i] == 0x0003);
+    }
+
+    // Chunk 1 (bytes 4-7): lane0=0xFF, lane1=0x00 (past end) → 0x0001
+    FL_REQUIRE(history[1].buffer_copy.size() == 32);
+    for (size_t i = 0; i < 32; i++) {
+        FL_CHECK(history[1].buffer_copy[i] == 0x0001);
+    }
+}
+
+FL_TEST_CASE("ChannelDriverLcdSpi - single byte chunk") {
+    // Extreme case: 1 byte per chunk
+    resetMockState();
+    auto peripheral = createMockPeripheral();
+    ChannelDriverLcdSpi driver(peripheral);
+    auto &mock = LcdSpiPeripheralMock::instance();
+
+    driver.setChunkInputBytesForTest(1);
+
+    SpiEncoder encoder = SpiEncoder::apa102();
+    SpiChipsetConfig cfg{5, 18, encoder};
+    fl::vector_psram<u8> d;
+    d.resize(4);
+    d[0] = 0xFF; d[1] = 0x00; d[2] = 0xAA; d[3] = 0x55;
+    driver.enqueue(ChannelData::create(cfg, fl::move(d)));
+    driver.show();
+    mock.simulateTransmitComplete();
+
+    FL_CHECK(driver.poll() == IChannelDriver::DriverState::READY);
+    FL_CHECK(mock.getTransmitCount() == 4); // 4 chunks of 1 byte each
+
+    const auto &history = mock.getTransmitHistory();
+
+    // Chunk 0: 0xFF → all bits set → 8 words of 0x0001
+    FL_REQUIRE(history[0].buffer_copy.size() == 8);
+    for (size_t i = 0; i < 8; i++) {
+        FL_CHECK(history[0].buffer_copy[i] == 0x0001);
+    }
+    // Chunk 1: 0x00 → no bits set → 8 words of 0x0000
+    FL_REQUIRE(history[1].buffer_copy.size() == 8);
+    for (size_t i = 0; i < 8; i++) {
+        FL_CHECK(history[1].buffer_copy[i] == 0x0000);
+    }
+}
+
+FL_TEST_CASE("ChannelDriverLcdSpi - chunk size larger than data") {
+    // Chunk size > data size → single chunk, same as default behavior
+    resetMockState();
+    auto peripheral = createMockPeripheral();
+    ChannelDriverLcdSpi driver(peripheral);
+    auto &mock = LcdSpiPeripheralMock::instance();
+
+    driver.setChunkInputBytesForTest(1000);
+
+    SpiEncoder encoder = SpiEncoder::apa102();
+    SpiChipsetConfig cfg{5, 18, encoder};
+    fl::vector_psram<u8> d;
+    d.resize(8);
+    for (size_t i = 0; i < 8; i++) d[i] = 0xFF;
+    driver.enqueue(ChannelData::create(cfg, fl::move(d)));
+    driver.show();
+
+    FL_CHECK(mock.getTransmitCount() == 1);
+    mock.simulateTransmitComplete();
+    FL_CHECK(driver.poll() == IChannelDriver::DriverState::READY);
+    FL_CHECK(mock.getTransmitCount() == 1);
+}
+
 #endif // FASTLED_STUB_IMPL
 
 } // FL_TEST_FILE


### PR DESCRIPTION
## Summary

Hardware bring-up for the LCD_CAM drivers added in #2260 (merged). Fixes a boot crash in `LCD_CLOCKLESS` and wires the autoresearch CLI so `--lcd` and `--lcd-spi` both pass on an ESP32-S3.

## Crash fix

`ChannelDriverLcdClockless` defaulted `dc_gpio=22` and `clock_gpio=21`. GPIO 22 does not exist on common ESP32-S3 packages, so `esp_lcd_new_i80_bus` → `lcd_i80_bus_configure_gpio` → `gpio_func_sel` hit an error-log path that detected heap poisoning and triggered a Guru Meditation panic.

Changed both defaults to GPIO 0, matching the legacy I2S LCD_CAM driver this replaces (the strapping pin tolerates being multiplexed to the unused PCLK/DC peripheral functions).

## autoresearch CLI

- `--lcd` now maps to `LCD_CLOCKLESS` (was the legacy `I2S` name).
- New `--lcd-spi` flag maps to `LCD_SPI` (APA102/SK9822 via LCD_CAM I80).
- Both auto-select the `esp32s3` environment and are included in `--all`.

## autoresearch RX decoder

`examples/AutoResearch/AutoResearchTest.cpp` now recognises `LCD_CLOCKLESS` and reconstructs the RX timing for wave3 or wave8 encoding using the same `fl::canUseWave3()` eligibility check the firmware uses at runtime.

## GPIO pre-test timing

Bumped `RpcClient` `boot_wait` from 3s to 8s and enabled `drain_boot` in `ci/autoresearch/gpio.py`. The ESP32-S3 AutoResearch `setup()` takes ~5-7s before the RPC dispatcher is ready, so the old 3s wait raced the first ping against setup and produced intermittent `GPIO PRE-TEST TIMEOUT` failures.

## Hardware verification (ESP32-S3 @ COM13, jumper GPIO 1 → GPIO 2)

| Driver | Result |
|--------|--------|
| `LCD_SPI`       | 4/4 patterns pass (`passed:true`) |
| `LCD_CLOCKLESS` | 4/4 patterns pass (`passed:true`, after GPIO fix) |

## Test plan

- [x] Host unit tests: 299/299 pass
- [x] Lint clean
- [x] `LCD_SPI` single-driver hardware test passes
- [x] `LCD_CLOCKLESS` single-driver hardware test passes (crash fixed)
- [ ] `bash autoresearch --lcd` end-to-end (blocked by a pre-existing FbuildSerialAdapter DTR/RTS race — tracked separately; direct JSON-RPC path is reliable)

Follow-up to #2260.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added LCD_SPI driver for ESP32-S3 with chunked DMA streaming and ISR-assisted transmission.
  * Added LCD_CLOCKLESS driver supporting clockless LED chipsets via LCD_CAM I80 bus.
  * Introduced `--lcd-spi` CLI flag for driver selection.

* **Bug Fixes**
  * Increased RPC client connection timeout for improved reliability.
  * Corrected LCD driver naming from I2S to LCD_CLOCKLESS.

* **Tests**
  * Added comprehensive unit tests for both new LCD drivers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->