### PR TITLE
perf(autoresearch): replace sleep-based reset waits with spin-poll

### DIFF
--- a/ci/autoresearch/gpio.py
+++ b/ci/autoresearch/gpio.py
@@ -67,14 +67,17 @@ async def run_gpio_pretest(
 
                     # Use SerialInterface.reset_device(wait_for_output=True)
                     # to block until the device starts producing serial output
+                    reset_ok = False
                     if serial_interface is not None:
                         print("  Resetting device via SerialInterface.reset_device(wait_for_output=True)...")
-                        await serial_interface.reset_device(board=None)
+                        reset_ok = await serial_interface.reset_device(board=None)
                     else:
                         from ci.util.serial_interface import _pyserial_dtr_reset
 
-                        _pyserial_dtr_reset(port)
-                        await asyncio.sleep(1.0)
+                        reset_ok = _pyserial_dtr_reset(port)
+
+                    # Use longer boot_wait if reset reported failure
+                    boot_wait = 1.0 if reset_ok else 3.0
 
                     client = RpcClient(
                         port,
@@ -82,7 +85,7 @@ async def run_gpio_pretest(
                         serial_interface=serial_interface,
                         verbose=True,
                     )
-                    await client.connect(boot_wait=1.0, drain_boot=True)
+                    await client.connect(boot_wait=boot_wait, drain_boot=True)
                     ping_response = await client.send("ping", retries=3)
                     print(f"\u2705 Ping successful after DTR reset: {ping_response.data}")
                 except KeyboardInterrupt as ki:
@@ -260,14 +263,16 @@ async def run_pin_discovery(
                 client = None
 
                 # Use SerialInterface.reset_device(wait_for_output=True)
+                reset_ok = False
                 if serial_interface is not None:
                     print("  Resetting device via SerialInterface.reset_device(wait_for_output=True)...")
-                    await serial_interface.reset_device(board=None)
+                    reset_ok = await serial_interface.reset_device(board=None)
                 else:
                     from ci.util.serial_interface import _pyserial_dtr_reset
 
-                    _pyserial_dtr_reset(port)
-                    await asyncio.sleep(1.0)
+                    reset_ok = _pyserial_dtr_reset(port)
+
+                boot_wait = 1.0 if reset_ok else 3.0
 
                 client = RpcClient(
                     port,
@@ -275,7 +280,7 @@ async def run_pin_discovery(
                     serial_interface=serial_interface,
                     verbose=True,
                 )
-                await client.connect(boot_wait=1.0, drain_boot=True)
+                await client.connect(boot_wait=boot_wait, drain_boot=True)
                 ping_response = await client.send("ping", timeout=30.0, retries=3)
                 print(f"\u2705 Ping successful after DTR reset: {ping_response.data}")
             except KeyboardInterrupt as ki:

--- a/ci/autoresearch/gpio.py
+++ b/ci/autoresearch/gpio.py
@@ -65,16 +65,16 @@ async def run_gpio_pretest(
                     await client.close()
                     client = None  # Prevent double-close in outer finally
 
-                    # Use SerialInterface.reset_device() if available
+                    # Use SerialInterface.reset_device(wait_for_output=True)
+                    # to block until the device starts producing serial output
                     if serial_interface is not None:
-                        print("  Resetting device via SerialInterface.reset_device()...")
+                        print("  Resetting device via SerialInterface.reset_device(wait_for_output=True)...")
                         await serial_interface.reset_device(board=None)
                     else:
                         from ci.util.serial_interface import _pyserial_dtr_reset
 
                         _pyserial_dtr_reset(port)
-
-                    await asyncio.sleep(3.0)
+                        await asyncio.sleep(1.0)
 
                     client = RpcClient(
                         port,
@@ -82,7 +82,7 @@ async def run_gpio_pretest(
                         serial_interface=serial_interface,
                         verbose=True,
                     )
-                    await client.connect(boot_wait=3.0, drain_boot=True)
+                    await client.connect(boot_wait=1.0, drain_boot=True)
                     ping_response = await client.send("ping", retries=3)
                     print(f"\u2705 Ping successful after DTR reset: {ping_response.data}")
                 except KeyboardInterrupt as ki:
@@ -259,16 +259,15 @@ async def run_pin_discovery(
                     await client.close()
                 client = None
 
-                # Use SerialInterface.reset_device() if available
+                # Use SerialInterface.reset_device(wait_for_output=True)
                 if serial_interface is not None:
-                    print("  Resetting device via SerialInterface.reset_device()...")
+                    print("  Resetting device via SerialInterface.reset_device(wait_for_output=True)...")
                     await serial_interface.reset_device(board=None)
                 else:
                     from ci.util.serial_interface import _pyserial_dtr_reset
 
                     _pyserial_dtr_reset(port)
-
-                await asyncio.sleep(3.0)
+                    await asyncio.sleep(1.0)
 
                 client = RpcClient(
                     port,
@@ -276,7 +275,7 @@ async def run_pin_discovery(
                     serial_interface=serial_interface,
                     verbose=True,
                 )
-                await client.connect(boot_wait=3.0, drain_boot=True)
+                await client.connect(boot_wait=1.0, drain_boot=True)
                 ping_response = await client.send("ping", timeout=30.0, retries=3)
                 print(f"\u2705 Ping successful after DTR reset: {ping_response.data}")
             except KeyboardInterrupt as ki:

--- a/ci/util/serial_interface.py
+++ b/ci/util/serial_interface.py
@@ -214,12 +214,17 @@ class FbuildSerialAdapter:
             yield item
 
     async def reset_device(self, board: str | None) -> bool:
-        """Reset device via fbuild daemon's reset endpoint."""
+        """Reset device via fbuild daemon's reset endpoint.
+
+        Uses wait_for_output=True to block until the device produces
+        serial output (rebooted and running), avoiding fixed sleep delays.
+        """
         if not hasattr(self._monitor, "reset_device"):
-            # Older fbuild version — fall back to pyserial
             return _pyserial_dtr_reset(self._monitor.port)
         try:
-            result = await self._run_in_thread(self._monitor.reset_device, board)
+            result = await self._run_in_thread(
+                self._monitor.reset_device, board, True, 5.0
+            )
             return bool(result)
         except Exception:
             return False


### PR DESCRIPTION
## Summary

Eliminates fixed `sleep(3.0)` delays after device reset by using fbuild 2.1.16's `reset_device(wait_for_output=True)`, which polls for serial output and returns as soon as the device reboots.

**Before:** reset + 3s sleep + 3s boot_wait = ~6s wasted per reset
**After:** reset + wait_for_output (~0.5s) + 1s boot_wait = ~1.5s

## Changes

- `FbuildSerialAdapter.reset_device()`: passes `wait_for_output=True, timeout=5.0`
- `gpio.py`: removes `sleep(3.0)` after reset, reduces `boot_wait` from 3.0 to 1.0

## Test plan

- [x] Unit tests pass (`test_serial_interface_reset.py`)
- [x] Autoresearch on real ESP32-S3: I2S test passes, all 4 patterns OK

Closes #2271
Depends on fbuild 2.1.16 (fbuild#68, fbuild#69)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device reset and boot recovery to react to actual reset results rather than always using a fixed delay.
  * Reconnection now adjusts boot wait time dynamically, shortening waits after successful resets to speed initialization.
  * Reset operations now wait for device output (with a short timeout) to confirm progress, improving serial reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->