### PR TITLE
fix(esp32): make _FL_BIT macro available when FASTLED_UNUSABLE_PIN_MASK is externally defined

### DIFF
--- a/src/platforms/esp/32/core/fastpin_esp32.h
+++ b/src/platforms/esp/32/core/fastpin_esp32.h
@@ -91,9 +91,9 @@ public:
   }
 };
 
-#ifndef FASTLED_UNUSABLE_PIN_MASK
-
 #define _FL_BIT(B) (1ULL << B)
+
+#ifndef FASTLED_UNUSABLE_PIN_MASK
 
 // CONFIG_IDF_TARGET_ESP32 was introduced in ESP-IDF v4.0
 // For v3.x (where the macro doesn't exist), assume original ESP32


### PR DESCRIPTION
## Summary

Move the `_FL_BIT(B)` helper macro out of the `#ifndef FASTLED_UNUSABLE_PIN_MASK` block in `src/platforms/esp/32/core/fastpin_esp32.h` so that it is always defined.

Previously `_FL_BIT` was only defined when the user did NOT override `FASTLED_UNUSABLE_PIN_MASK`. However the macro is also used unconditionally further down the file (inside the `SOC_GPIO_VALID_GPIO_MASK` fallback for older ESP-IDF versions at lines 164/166). As a result, users who tried to override the pin mask via a build flag — for example, ESP32-PICO-V3-02 users who need to re-enable GPIO7/8/20 that the SiP package exposes externally — would get `_FL_BIT undeclared` compile errors.

Moving the single-line `#define` outside the guard fixes this without changing any existing behavior.

## Fixes

Fixes #1372

## Test plan
- [x] `bash compile esp32dev --examples Blink` succeeds on this branch
- [ ] CI: confirm all ESP32 variants still build
- [ ] Verify user can now set `-DFASTLED_UNUSABLE_PIN_MASK=0x100740LL` as a build flag and compile cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized platform-specific ESP32 code structure for improved maintainability while preserving all existing functionality and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->