### PR TITLE
fix(esp32): move _FL_BIT macro out of FASTLED_UNUSABLE_PIN_MASK ifndef

### DIFF
--- a/ci/autoresearch/gpio.py
+++ b/ci/autoresearch/gpio.py
@@ -74,7 +74,9 @@ async def run_gpio_pretest(
                     # to block until the device starts producing serial output
                     reset_ok = False
                     if serial_interface is not None:
-                        print("  Resetting device via SerialInterface.reset_device(wait_for_output=True)...")
+                        print(
+                            "  Resetting device via SerialInterface.reset_device(wait_for_output=True)..."
+                        )
                         reset_ok = await serial_interface.reset_device(board=None)
                     else:
                         from ci.util.serial_interface import _pyserial_dtr_reset
@@ -92,7 +94,9 @@ async def run_gpio_pretest(
                     )
                     await client.connect(boot_wait=boot_wait, drain_boot=True)
                     ping_response = await client.send("ping", retries=3)
-                    print(f"\u2705 Ping successful after DTR reset: {ping_response.data}")
+                    print(
+                        f"\u2705 Ping successful after DTR reset: {ping_response.data}"
+                    )
                 except KeyboardInterrupt as ki:
                     handle_keyboard_interrupt(ki)
                     raise
@@ -102,9 +106,7 @@ async def run_gpio_pretest(
                     print(
                         f"   {Fore.RED}DIAGNOSIS: RPC communication failure{Style.RESET_ALL}"
                     )
-                    print(
-                        "   The device is not responding to JSON-RPC commands."
-                    )
+                    print("   The device is not responding to JSON-RPC commands.")
                     print("   This is NOT a jumper wire issue.")
                     print()
                     print("   Possible causes:")
@@ -270,7 +272,9 @@ async def run_pin_discovery(
                 # Use SerialInterface.reset_device(wait_for_output=True)
                 reset_ok = False
                 if serial_interface is not None:
-                    print("  Resetting device via SerialInterface.reset_device(wait_for_output=True)...")
+                    print(
+                        "  Resetting device via SerialInterface.reset_device(wait_for_output=True)..."
+                    )
                     reset_ok = await serial_interface.reset_device(board=None)
                 else:
                     from ci.util.serial_interface import _pyserial_dtr_reset

--- a/ci/github_project_sync.py
+++ b/ci/github_project_sync.py
@@ -22,6 +22,7 @@ from typing import Any
 
 from typeguard import typechecked
 
+
 VALID_OWNER_TYPES = {"organization", "user"}
 
 
@@ -120,9 +121,7 @@ def find_project(owner: str, owner_type: str, number: int) -> str:
         data = graphql(query, {"owner": owner, "number": number})
         project = data["data"]["organization"]["projectV2"]
         if not project:
-            raise SystemExit(
-                f"Project #{number} not found for organization '{owner}'"
-            )
+            raise SystemExit(f"Project #{number} not found for organization '{owner}'")
         return project["id"]
     else:
         query = """
@@ -187,9 +186,7 @@ def get_field_and_option(
         if field.get("name") == field_name:
             for option in field.get("options", []):
                 if option["name"] == option_name:
-                    return FieldOption(
-                        field_id=field["id"], option_id=option["id"]
-                    )
+                    return FieldOption(field_id=field["id"], option_id=option["id"])
             available: list[str] = []
             for opt in field.get("options", []):
                 available.append(opt["name"])
@@ -203,9 +200,7 @@ def get_field_and_option(
         name = f.get("name")
         if name:
             available_fields.append(name)
-    raise SystemExit(
-        f"Field '{field_name}' not found. Available: {available_fields}"
-    )
+    raise SystemExit(f"Field '{field_name}' not found. Available: {available_fields}")
 
 
 def get_date_field(project_id: str, field_name: str) -> str:
@@ -264,9 +259,7 @@ def update_single_select(
     )
 
 
-def update_date(
-    project_id: str, item_id: str, field_id: str, date_value: str
-) -> None:
+def update_date(project_id: str, item_id: str, field_id: str, date_value: str) -> None:
     """Update a date field on a project item."""
     query = """
     mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $dateValue: Date!) {
@@ -325,9 +318,7 @@ def main() -> None:
 
     status_name = determine_status(config)
     print(f"Setting status to: {status_name}")
-    resolved = get_field_and_option(
-        project_id, config.status_field, status_name
-    )
+    resolved = get_field_and_option(project_id, config.status_field, status_name)
     update_single_select(project_id, item_id, resolved.field_id, resolved.option_id)
     print("Status updated")
 

--- a/ci/util/serial_interface.py
+++ b/ci/util/serial_interface.py
@@ -17,6 +17,8 @@ from typing import Protocol, runtime_checkable
 
 import serial as pyserial
 
+from ci.util.global_interrupt_handler import handle_keyboard_interrupt
+
 
 def _pyserial_dtr_reset(port: str) -> bool:
     """Reset an ESP32 device using the esptool ClassicReset DTR/RTS sequence.
@@ -226,6 +228,9 @@ class FbuildSerialAdapter:
                 self._monitor.reset_device, board, True, 5.0
             )
             return bool(result)
+        except KeyboardInterrupt as ki:
+            handle_keyboard_interrupt(ki)
+            raise
         except Exception:
             return False
 

--- a/src/platforms/esp/32/core/fastpin_esp32.h
+++ b/src/platforms/esp/32/core/fastpin_esp32.h
@@ -91,9 +91,9 @@ public:
   }
 };
 
-#ifndef FASTLED_UNUSABLE_PIN_MASK
-
 #define _FL_BIT(B) (1ULL << B)
+
+#ifndef FASTLED_UNUSABLE_PIN_MASK
 
 // CONFIG_IDF_TARGET_ESP32 was introduced in ESP-IDF v4.0
 // For v3.x (where the macro doesn't exist), assume original ESP32


### PR DESCRIPTION
## Summary
- Move `_FL_BIT` macro definition outside the `FASTLED_UNUSABLE_PIN_MASK` ifndef guard so it is always defined on ESP32.
- Apply formatter changes to `ci/autoresearch/gpio.py` and `ci/github_project_sync.py`.
- Forward `KeyboardInterrupt` in `FbuildSerialAdapter.reset_device` so Ctrl+C is not swallowed by the bare except.

## Test plan
- [ ] ESP32 compile passes with the macro always available
- [ ] Autoresearch flows still work for ESP32 boards
- [ ] Ctrl+C during reset propagates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced keyboard interrupt handling during serial device reset operations to prevent unexpected behavior.

* **Style**
  * Improved code formatting and console output readability across configuration and debugging utilities.

* **Chores**
  * Optimized conditional compilation directives for cleaner build configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->