### PR TITLE
fix(esp32): tighten ESP-IDF version gates for ledc and heap_caps helpers

### DIFF
--- a/src/platforms/esp/32/drivers/i2s_spi/i2s_spi_peripheral_esp.cpp.hpp
+++ b/src/platforms/esp/32/drivers/i2s_spi/i2s_spi_peripheral_esp.cpp.hpp
@@ -401,8 +401,16 @@ bool I2sSpiPeripheralEsp::isInitialized() const FL_NOEXCEPT {
 
 u8 *I2sSpiPeripheralEsp::allocateBuffer(size_t size_bytes) FL_NOEXCEPT {
     size_t aligned_size = ((size_bytes + 3) / 4) * 4;
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 3, 0)
     void *buffer = heap_caps_aligned_calloc(4, aligned_size, 1,
                                             MALLOC_CAP_DMA | MALLOC_CAP_8BIT);
+#else
+    // ESP-IDF prior to 4.3 (including 3.3-LTS) lacks heap_caps_aligned_calloc.
+    // aligned_size is already a multiple of 4, and ESP32 heap allocations are
+    // naturally 4-byte aligned, so heap_caps_calloc gives us what we need.
+    void *buffer = heap_caps_calloc(1, aligned_size,
+                                    MALLOC_CAP_DMA | MALLOC_CAP_8BIT);
+#endif
     return static_cast<u8 *>(buffer);
 }
 

--- a/src/platforms/esp/32/pin_esp32_native_impl.hpp
+++ b/src/platforms/esp/32/pin_esp32_native_impl.hpp
@@ -289,8 +289,10 @@ inline int setPwmFrequencyNative(int pin, u32 frequency_hz) FL_NOEXCEPT {
 
     // Determine the best duty resolution for the requested frequency.
     // LEDC supports 1-20 bit resolution depending on the clock and frequency.
-#if ESP_IDF_VERSION_5_OR_HIGHER
-    // ESP-IDF v5+ provides a helper to find the best resolution
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 3, 0)
+    // ESP-IDF v5.3+ provides a helper to find the best resolution.
+    // Prior to 5.3 (including 5.0-5.2 shipped with arduino-esp32 3.0.x),
+    // the helper does not exist and we fall back to manual calculation below.
     // For ESP32 with LEDC_AUTO_CLK, typical source clock is 80MHz APB clock
     const u32 ledc_src_clk_hz = 80000000;  // 80MHz APB clock
     u32 resolution = ledc_find_suitable_duty_resolution(
@@ -299,7 +301,7 @@ inline int setPwmFrequencyNative(int pin, u32 frequency_hz) FL_NOEXCEPT {
         return -3;  // Could not find a suitable resolution
     }
 #else
-    // ESP-IDF v4.x: calculate manually.
+    // ESP-IDF v4.x / v5.0-5.2: calculate manually.
     // resolution = floor(log2(APB_CLK_FREQ / frequency))
     // APB_CLK_FREQ is typically 80 MHz.
     u32 ratio = APB_CLK_FREQ / frequency_hz;
@@ -308,7 +310,7 @@ inline int setPwmFrequencyNative(int pin, u32 frequency_hz) FL_NOEXCEPT {
         ratio >>= 1;
         resolution++;
     }
-    // Clamp resolution to valid range [1, 16] for v4.x
+    // Clamp resolution to valid range [1, 16]
     if (resolution < 1) {
         resolution = 1;
     }


### PR DESCRIPTION
## Summary
Two post-merge CI failures traced to ESP-IDF API version assumptions:

- **esp_extra_libs** (pioarduino 51.03.04 → framework-arduinoespressif32-libs@5.1.0 → IDF 5.1): `ledc_find_suitable_duty_resolution` does not exist until IDF v5.3 — the code was gated on \`ESP_IDF_VERSION_5_OR_HIGHER\` which matches any 5.x. Tightened to \`ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 3, 0)\`; older IDF 5.x falls through to the existing manual \`log2(APB_CLK/freq)\` calculation.
- **esp32dev-idf3.3-lts**: \`heap_caps_aligned_calloc\` was added in IDF v4.3 and is missing on IDF 3.3-LTS. Added a fallback to \`heap_caps_calloc\` (ESP32 heap allocations are already 4-byte aligned; \`aligned_size\` is already a multiple of 4).

Failing runs:
- https://github.com/FastLED/FastLED/actions/runs/24590835481 (esp_extra_libs)
- https://github.com/FastLED/FastLED/actions/runs/24590507101 (esp32dev-idf3.3)

## Test plan
- [ ] esp_extra_libs build passes (IDF 5.1)
- [ ] esp32dev-idf3.3 build passes (IDF 3.3)
- [ ] esp32s3 / esp32dev still build (IDF 5.3+ path exercised)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized I2S memory allocation for newer ESP-IDF versions to utilize improved allocation APIs.
  * Refined PWM frequency handling logic with more precise ESP-IDF version compatibility checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->