### PR TITLE
fix(wasm): correct esbuild three.js alias to actual vendor path

### DIFF
--- a/ci/esbuild_frontend.py
+++ b/ci/esbuild_frontend.py
@@ -121,7 +121,7 @@ def _run_esbuild(args: list[str]) -> None:
     result = subprocess.run(
         [
             str(esbuild),
-            "--alias:three=./vendor/three/build/three.module.js",
+            "--alias:three=./vendor/three/three.module.js",
             *args,
         ],
         cwd=str(FRONTEND_DIR),


### PR DESCRIPTION
## Summary
esbuild fails to resolve \`three\` because the alias in \`ci/esbuild_frontend.py\` points to \`./vendor/three/build/three.module.js\` — a \`/build/\` subdirectory that does not exist. The vendored file is at \`examples/wasm/fastled_js/vendor/three/three.module.js\`.

This wrong alias was introduced with the Vite → esbuild migration in commit ade94342d.

Fixing the alias to match the actual path restores wasm / wasm_compile_test.

Failing runs:
- https://github.com/FastLED/FastLED/actions/runs/24590847704 (wasm_compile_test)
- https://github.com/FastLED/FastLED/actions/runs/24590847691 (wasm, downstream)

## Test plan
- [ ] wasm_compile_test workflow passes on this branch
- [ ] Verify fastled.js + fastled.wasm + index.html artifacts are produced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Three.js module resolution path in the build configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->