### PR TITLE
fix(ci): point esp32dev_i2s workflow at the renamed DriverTest example

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,7 +89,7 @@ jobs:
   build_esp32dev_i2s:
     uses: ./.github/workflows/build_template.yml
     with:
-      args: "esp32dev_i2s --examples SpecialDrivers/ESP/I2S/EspI2SDemo"
+      args: "esp32dev_i2s --examples SpecialDrivers/ESP/DriverTest"
 
   build_esp32dev_idf44:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_esp32_i2s_ws2812.yml
+++ b/.github/workflows/build_esp32_i2s_ws2812.yml
@@ -40,4 +40,4 @@ jobs:
   build:
     uses: ./.github/workflows/build_template.yml
     with:
-      args: esp32dev_i2s --examples SpecialDrivers/ESP/I2S/EspI2SDemo
+      args: esp32dev_i2s --examples SpecialDrivers/ESP/DriverTest


### PR DESCRIPTION
## Summary
\`SpecialDrivers/ESP/I2S/EspI2SDemo\` no longer exists — the example was consolidated into \`SpecialDrivers/ESP/DriverTest\`. Two workflow files still referenced the old path, causing the esp32_i2s_ws2812 build to abort with \`ValueError: Example not found: SpecialDrivers/ESP/I2S/EspI2SDemo\`.

Updated:
- \`.github/workflows/build_esp32_i2s_ws2812.yml\`
- \`.github/workflows/build.yml\` (the mirror entry)

Failing run: https://github.com/FastLED/FastLED/actions/runs/24590835568

## Test plan
- [ ] esp32_i2s_ws2812 workflow passes
- [ ] DriverTest.ino compiles under esp32dev_i2s platform variant

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build workflow configurations to verify different example sets during CI/CD pipeline execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->