### PR TITLE
fix(ci): bump platformio pin to >=6.1.19 for pioarduino compat

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.11"
 dependencies = [
     "fbuild>=2.1.12",
     "fbuild>=2.1.12",
-    "platformio==6.1.18",
+    "platformio>=6.1.19,<6.2",
     "python-dateutil",
     "ruff",
     "pyright>=1.1.373",


### PR DESCRIPTION
## Summary

The esp32c2 workflow (and any other CI path routing through `ci/cppcheck.py`) has been failing on master because `pyproject.toml` pinned `platformio==6.1.18`, while the current stable pioarduino espressif32 platform now requires PlatformIO Core `>=6.1.19`. `pio check` aborted with:

```
IncompatiblePlatform: Development platform 'espressif32' is not compatible
with PlatformIO Core v6.1.18 and depends on PlatformIO Core >=6.1.19.
```

Example failing run: https://github.com/FastLED/FastLED/actions/runs/24590168932/job/71909046151

## Root cause

`pyproject.toml` line 10 pinned PlatformIO one patch release behind what pioarduino stable expects.

## Change

- `pyproject.toml`: `"platformio==6.1.18"` → `"platformio>=6.1.19,<6.2"`
  - Picks up the compat fix
  - Range stays inside the 6.1.x minor so we don't accidentally jump a minor version
  - 6.1.19 is the current latest on PyPI as of this PR

`uv.lock` is gitignored in this repo so no lockfile diff is needed; local `uv lock` resolved cleanly and platformio pins to 6.1.19.

## Test plan

- [x] `bash test --cpp` — all 299 unit tests pass locally
- [x] Diff is minimal: single-line specifier change in `pyproject.toml`
- [ ] CI green on esp32c2 and other ESP32 `pio check`-consuming workflows after merge
- [ ] Spot-check adjacent ESP32 jobs (esp32dev, esp32s3, esp32c6) for any version-bump regressions

Closes #2281

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated platformio dependency to a compatible version range, allowing access to newer patch versions with bug fixes and improvements while maintaining stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->