### PR TITLE
feat(fl::url): add parse_lnk() for .lnk asset link files (slice 1 of #2284)

### DIFF
--- a/examples/AudioUrl/data/track.mp3.lnk
+++ b/examples/AudioUrl/data/track.mp3.lnk
@@ -1,0 +1,6 @@
+# .lnk asset link file — see FastLED issue #2284.
+# The first non-comment line is the URL this asset resolves to.
+# Lines starting with '#' and blank lines are ignored.
+# Additional lines (metadata like sha256=, fallback=) are reserved for
+# future use and are ignored by the v1 parser.
+https://www.soundhelix.com/examples/mp3/SoundHelix-Song-1.mp3

--- a/src/fl/stl/url.h
+++ b/src/fl/stl/url.h
@@ -245,4 +245,52 @@ class url {
 
 using Url = url;
 
+/// Parse the contents of a `.lnk` file into a `fl::url`.
+///
+/// Format: one URL per line. Leading/trailing whitespace on each line is
+/// ignored. Blank lines and lines whose first non-whitespace character is
+/// `#` are treated as comments and skipped. The first non-comment,
+/// non-blank line is returned as a `fl::url`.
+///
+/// Future-compat: additional lines (metadata like `sha256=...`,
+/// `fallback=...`) are ignored by this v1 parser so older binaries keep
+/// working when future `.lnk` files grow richer.
+inline url parse_lnk(fl::string_view content) FL_NOEXCEPT {
+    fl::size pos = 0;
+    while (pos < content.size()) {
+        fl::size eol = content.find('\n', pos);
+        fl::size lineEnd = (eol == fl::string_view::npos) ? content.size() : eol;
+        fl::string_view line = content.substr(pos, lineEnd - pos);
+        pos = (eol == fl::string_view::npos) ? content.size() : eol + 1;
+
+        // Strip a trailing '\r' from CRLF line endings.
+        if (!line.empty() && line[line.size() - 1] == '\r') {
+            line = line.substr(0, line.size() - 1);
+        }
+
+        // Trim leading whitespace.
+        fl::size s = 0;
+        while (s < line.size() &&
+               (line[s] == ' ' || line[s] == '\t')) {
+            ++s;
+        }
+        // Trim trailing whitespace.
+        fl::size e = line.size();
+        while (e > s &&
+               (line[e - 1] == ' ' || line[e - 1] == '\t')) {
+            --e;
+        }
+        line = line.substr(s, e - s);
+
+        if (line.empty()) {
+            continue;
+        }
+        if (line[0] == '#') {
+            continue;
+        }
+        return url(line);
+    }
+    return url();
+}
+
 } // namespace fl

--- a/tests/fl/url_lnk.cpp
+++ b/tests/fl/url_lnk.cpp
@@ -1,0 +1,80 @@
+
+// Tests for fl::parse_lnk — the .lnk file format parser that turns
+// a `data/track.mp3.lnk` file into a fl::url.
+
+#include "fl/stl/string_view.h"
+#include "fl/stl/url.h"
+#include "test.h"
+
+using namespace fl;
+
+FL_TEST_CASE("fl::parse_lnk") {
+    FL_SUBCASE("plain URL") {
+        url u = parse_lnk(string_view("https://example.com/track.mp3"));
+        FL_CHECK(u.isValid());
+        FL_CHECK_EQ(u.host(), string_view("example.com"));
+    }
+
+    FL_SUBCASE("URL with trailing newline") {
+        url u = parse_lnk(string_view("https://example.com/track.mp3\n"));
+        FL_CHECK(u.isValid());
+        FL_CHECK_EQ(u.host(), string_view("example.com"));
+    }
+
+    FL_SUBCASE("CRLF line endings") {
+        url u = parse_lnk(string_view("https://example.com/track.mp3\r\n"));
+        FL_CHECK(u.isValid());
+        FL_CHECK_EQ(u.host(), string_view("example.com"));
+    }
+
+    FL_SUBCASE("leading blank lines are skipped") {
+        url u = parse_lnk(string_view("\n\n\nhttps://example.com/a.mp3\n"));
+        FL_CHECK(u.isValid());
+        FL_CHECK_EQ(u.host(), string_view("example.com"));
+    }
+
+    FL_SUBCASE("# comment lines are skipped") {
+        url u = parse_lnk(string_view(
+            "# this is a comment\n"
+            "# another comment\n"
+            "https://example.com/b.mp3\n"));
+        FL_CHECK(u.isValid());
+        FL_CHECK_EQ(u.host(), string_view("example.com"));
+    }
+
+    FL_SUBCASE("leading whitespace before URL is trimmed") {
+        url u = parse_lnk(string_view("   \thttps://example.com/c.mp3   \n"));
+        FL_CHECK(u.isValid());
+        FL_CHECK_EQ(u.host(), string_view("example.com"));
+    }
+
+    FL_SUBCASE("trailing metadata lines are ignored") {
+        url u = parse_lnk(string_view(
+            "https://example.com/d.mp3\n"
+            "sha256=abcdef\n"
+            "fallback=https://mirror.example.com/d.mp3\n"));
+        FL_CHECK(u.isValid());
+        FL_CHECK_EQ(u.host(), string_view("example.com"));
+    }
+
+    FL_SUBCASE("empty content returns invalid url") {
+        url u = parse_lnk(string_view(""));
+        FL_CHECK_FALSE(u.isValid());
+    }
+
+    FL_SUBCASE("only comments returns invalid url") {
+        url u = parse_lnk(string_view(
+            "# comment one\n"
+            "   # indented comment\n"
+            "\n"));
+        FL_CHECK_FALSE(u.isValid());
+    }
+
+    FL_SUBCASE("indented comment is still a comment") {
+        url u = parse_lnk(string_view(
+            "    # leading space then hash\n"
+            "https://example.com/e.mp3\n"));
+        FL_CHECK(u.isValid());
+        FL_CHECK_EQ(u.host(), string_view("example.com"));
+    }
+}


### PR DESCRIPTION
## Summary

First slice of the `data/` asset pipeline feature described in #2284.

- Adds `fl::parse_lnk(fl::string_view)` which returns a `fl::url` parsed from the proposed `.lnk` file format (one URL per line, `#` comments, blank lines skipped, trailing lines reserved for future metadata).
- Adds `examples/AudioUrl/data/track.mp3.lnk` so the format convention is visible in-tree alongside the existing `AudioUrl` sketch.
- Adds unit tests covering plain URLs, CRLF endings, `#` comments, leading blanks, indented comments, trailing metadata lines, and empty input.

No behavior changes to existing code paths — `UIAudio`, fbuild, and the WASM runtime are untouched in this slice.

## Scope — why this slice is small

The full feature (see #2284) has four independent pieces:

1. **`.lnk` format + parser** ← this PR
2. fbuild scan of `<sketch>/data/` to emit an asset manifest (lives in the external `fbuild` package, separate repo)
3. WASM runtime resolution: `.lnk` → `fl::url` → existing `url` JSON field on the audio element
4. ESP32 LittleFS packing (future; requires partition-table coordination)

Landing the parser first lets downstream work (fbuild, WASM loader, `fl::asset` handle) target a stable format without cross-repo coordination on the parse semantics.

## Test plan

- [x] `bash test url_lnk` — new test passes (9 subcases)
- [x] `bash test url` — existing URL tests still pass (no regression)
- [x] `bash test audio_url` — existing audio URL UI tests still pass
- [x] `bash lint` — clean

## Follow-ups tracked in #2284

- [ ] `fl::asset(path)` handle type
- [ ] fbuild `data/` scan (external `fbuild` package)
- [ ] WASM runtime: fetch+parse `.lnk` at load time, thread resolved URL into audio element
- [ ] ESP32 LittleFS partition generation
- [ ] `UIAudio` overload accepting `fl::asset`

Closes: none (keeps #2284 open as the umbrella tracker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for `.lnk` asset link files that declare external resource URLs, such as audio tracks and other media assets.
  * Link files support comments (lines starting with `#`) and blank lines for improved readability and future extensibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->