### PR TITLE
fix(ci): pin esp32c2 platform to IDF 5.4 instead of floating stable tag

### DIFF
--- a/ci/boards.py
+++ b/ci/boards.py
@@ -768,7 +768,11 @@ STM32H747XI_GIGA = Board(
 ESP32_C2_DEVKITM_1 = Board(
     board_name="esp32c2",
     real_board_name="esp32-c2-devkitm-1",
-    platform="https://github.com/pioarduino/platform-espressif32/releases/download/stable/platform-espressif32.zip",
+    # Pinned to 54.03.20 (IDF 5.4) — matches the constant used by most other
+    # ESP32 boards here. Previously tracked the floating `stable` tag, which
+    # upstream bumped to 55.03.38 requiring PlatformIO Core >=6.1.19; CI ships
+    # 6.1.18, so `stable` now fails with IncompatiblePlatform.
+    platform=ESP32_IDF_5_4_PIOARDUINO,
     framework="arduino",  # IMPORTANT: Do not add "espidf" - see comment above
     board_partitions="huge_app.csv",  # Default partition only allows 1.25MB app; Validation needs ~1.6MB
 )


### PR DESCRIPTION
## Summary

`ESP32_C2_DEVKITM_1` in `ci/boards.py` was tracking the floating `stable` tag of `pioarduino/platform-espressif32`. Upstream bumped `stable` → **55.03.38**, which requires **PlatformIO Core >=6.1.19**. FastLED CI runs Core **6.1.18**, so every esp32c2 build has been failing with `IncompatiblePlatform`.

## Error from CI

```
PIO: IncompatiblePlatform: Development platform 'espressif32' is not compatible
with PlatformIO Core v6.1.18 and depends on PlatformIO Core >=6.1.19.
```
(seen in run 24591055571 and every esp32c2 master run in the past ~day)

## Fix

Pin esp32c2 to `ESP32_IDF_5_4_PIOARDUINO` (= `54.03.20`) — the same constant used by `esp32s3` and other C-series boards in `ci/boards.py`. Matches the existing pinning pattern; no more floating-tag drift.

```diff
-    platform="https://github.com/pioarduino/platform-espressif32/releases/download/stable/platform-espressif32.zip",
+    platform=ESP32_IDF_5_4_PIOARDUINO,
```

## Test plan

- [x] `import ci.boards` resolves `ESP32_C2_DEVKITM_1.platform` to the pinned URL
- [ ] CI `esp32c2` job on this PR passes (the real validation)

## Why not bump PIO Core instead

Bumping to 6.1.19 across all of CI is a higher-blast-radius change that would affect every board simultaneously. Pinning esp32c2 to a known-good platform version is lower-risk and consistent with how every other board in `boards.py` is configured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build configuration for ESP32_C2_DEVKITM_1 to use a specific pinned version of the development platform instead of a floating release, ensuring more reliable and reproducible builds across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->