### PR TITLE
fix(esp32): guarantee deep yield in driver wait loops (Refs #2254)

### DIFF
--- a/src/fl/task/executor.cpp.hpp
+++ b/src/fl/task/executor.cpp.hpp
@@ -115,13 +115,25 @@ void run(fl::u32 microseconds, ExecFlags flags) {
             Executor::instance().update_all();
         }
 
-        // SYSTEM: OS-level yield. Normally uses fl::yield() which maps to
-        // vTaskDelay(0) on ESP32 — only yields to same-or-higher priority.
-        // When WiFi is active, ESP32 needs vTaskDelay(1) (1 FreeRTOS tick)
-        // to give lower-priority WiFi/lwIP tasks CPU time.
+        // SYSTEM: OS-level yield.
+        //
+        // When the caller provided a non-zero microseconds budget we treat
+        // this as an explicit spin-wait on hardware (typical DMA / driver
+        // wait loops). In that case we MUST use a deep yield (≥ 1 FreeRTOS
+        // tick on ESP32) so that lower-priority network tasks — WiFi,
+        // Ethernet lwIP, etc. — actually get CPU time. Previously this
+        // path was gated on an active WiFi mode check, which missed
+        // Ethernet-only deployments and also the pre-connection window
+        // where `esp_wifi_get_mode` still returns WIFI_MODE_NULL. That
+        // regression manifested as the ESP32-S3 I2S-vs-websockets
+        // starvation reported in https://github.com/FastLED/FastLED/issues/2254
+        // (Issue 1).
+        //
+        // When microseconds == 0 the caller wants the cheapest possible
+        // yield (we are between other pumped subsystems and will loop
+        // again immediately), so we keep the lightweight fl::yield() path.
         if (do_system) {
-            if (microseconds > 0 &&
-                fl::platforms::ICoroutineRuntime::instance().needsDeepYield()) {
+            if (microseconds > 0) {
                 fl::platforms::ICoroutineRuntime::instance().pumpCoroutines(1000);
             } else {
                 fl::yield();

--- a/src/platforms/esp/32/coroutine_esp32.impl.hpp
+++ b/src/platforms/esp/32/coroutine_esp32.impl.hpp
@@ -64,11 +64,25 @@ public:
         const fl::u32 tick_period_us = 1000000u / configTICK_RATE_HZ;
         fl::u32 ticks = us / tick_period_us;
 
-        if (ticks > 0) {
-            vTaskDelay(ticks);
-        } else {
+        if (us == 0) {
+            // Caller explicitly asked for no delay — just yield among
+            // equal/higher priority tasks.
             taskYIELD();
+            return;
         }
+
+        // Caller asked for a non-zero wait. Round UP to at least 1 tick so
+        // that lower-priority tasks (e.g. lwIP/WiFi) actually get CPU time.
+        // Otherwise, on default ESP-IDF tick rates (100 Hz, tick_period_us
+        // = 10 000) a sub-tick request such as pumpCoroutines(1000) would
+        // truncate to ticks == 0 and degenerate into taskYIELD(), which
+        // does NOT yield to lower-priority tasks. That regression was the
+        // root cause of websocket starvation on ESP32-S3 I2S wait loops
+        // (see https://github.com/FastLED/FastLED/issues/2254, Issue 1).
+        if (ticks == 0) {
+            ticks = 1;
+        }
+        vTaskDelay(ticks);
     }
 
     bool needsDeepYield() const FL_NOEXCEPT override {


### PR DESCRIPTION
## Summary

Restores WiFi / Ethernet / lwIP throughput on ESP32-S3 when the I2S LCD_CAM channel driver (and any other driver that spin-waits on DMA via `task::run(us, ExecFlags::SYSTEM)`) is active. Addresses **Issue 1** of #2254.

## Sub-issues from #2254

| Sub-issue | Status in this PR |
|-----------|-------------------|
| 1. I2S driver starves websockets (~1 FPS) | **Addressed** |
| 2. SPI driver — incorrect LED output     | Not addressed — see notes below |
| 3. FastLED Audio driver reduces FPS       | Not addressed — see notes below |

## Diagnosis

The Mar 10 cooperative-yield refactor (#2167) and the Apr 5 `needsDeepYield()` machinery intended a `vTaskDelay(>=1)` in the SYSTEM-yield path when WiFi was active, so that lower-priority lwIP tasks could run during LED DMA spin-waits. Two regressions made the deep yield degenerate back to `taskYIELD()`, which does **not** yield to lower-priority tasks:

1. **Tick-rate truncation.** `pumpCoroutines(1000)` in `src/platforms/esp/32/coroutine_esp32.impl.hpp` computes ticks as `us / tick_period_us`. On the default **ESP-IDF tick rate of 100 Hz**, `1000 / 10000 = 0` → `taskYIELD()` instead of `vTaskDelay(1)`. Arduino-ESP32 at 1000 Hz happened to work; ESP-IDF-native projects (MoonLight among them) hit the bad path and saw ~1 FPS websockets while LEDs rendered correctly.

2. **Over-narrow deep-yield gate.** The SYSTEM yield in `executor.cpp.hpp` only took the deep path when `esp_wifi_get_mode() != WIFI_MODE_NULL`. That condition misses:
   - Ethernet-only deployments (no WiFi mode, but lwIP is live).
   - The pre-`WiFi.begin()` window where the mode is still `WIFI_MODE_NULL` but network stacks may be initializing.
   - Weak-linkage edge cases where `esp_wifi_get_mode` resolves to `nullptr` even when WiFi is in use.

## Fix

Two minimal changes:

* **`src/platforms/esp/32/coroutine_esp32.impl.hpp`** — `pumpCoroutines()` now rounds a non-zero microseconds request **UP** to at least 1 FreeRTOS tick. A 0 us request still just does `taskYIELD()`.
* **`src/fl/task/executor.cpp.hpp`** — `task::run(us, ExecFlags::SYSTEM)` takes the deep-yield path whenever `microseconds > 0`, independent of WiFi mode. This is the path used by every driver's DMA spin-wait (I2S, SPI, LCD_SPI, LCD_CLOCKLESS, LCD_RGB, PARLIO, RMT, UART, I2S_SPI) and by `FastLED.show()`'s minFPS wait.

Net effect: any spin-wait loop that calls `task::run(>0, SYSTEM)` now guarantees at least one FreeRTOS tick of delay per iteration on ESP32, freeing the CPU for lwIP / WiFi / Ethernet tasks.

## What I built / tested locally

- `bash test --cpp` — 299 / 299 tests pass.
- `bash lint` — clean (Python, C++, JS, Meson).
- `bash compile esp32s3 --examples Blink` — succeeds.
- `bash compile esp32s3 --examples SpecialDrivers/ESP/DriverTest` — succeeds.

## Hardware verification (USER action required)

I cannot run on a physical board. Please verify on ESP32-S3 with WiFi + I2S channel driver + websockets:

- [ ] Confirm websocket throughput returns to expected levels (roughly match RMT's numbers)
- [ ] Confirm LED output remains visually correct on I2S
- [ ] Re-measure FPS and confirm no unexpected regression (a per-iteration 1-tick delay adds ~10 ms on 100 Hz tick or ~1 ms on 1 kHz tick during spin-waits, vs. the old busy-spin; this is a trade-off and should be a net win because DMA typically takes longer than one tick)
- [ ] Repeat with Ethernet-only setup if possible (this PR also unblocks that case)

If FPS regresses significantly because a driver is completing DMA in well under one tick, please report — we may need a `vTaskDelay(0)` + tight re-check fast-path for ultra-short DMA transfers.

## Not addressed in this PR

- **Issue 2 (SPI driver — incorrect LED output)** — I read the LCD_SPI driver (`channel_driver_lcd_spi.cpp.hpp`, `lcd_spi_peripheral_esp.cpp.hpp`) and the #2251 fix. I could not identify a plausible root cause from code inspection alone — the transpose encoder, the APA102 frame encoder, the chunked DMA streaming, and the buffer-reallocation fix from #2251 all look internally consistent. Diagnosing the visible rendering defect realistically needs the video reference reproduced on a bench. Leaving open.

- **Issue 3 (Audio driver reduces FPS 100→60)** — Confirmed by code inspection: the audio pump runs via `fl::task::every_ms(1).then(...)` in `src/fl/audio/audio_processor.cpp.hpp::createWithAutoInput`, which executes on whichever thread calls `task::run(... TASKS ...)` — i.e. the LED main loop. The fix is to dispatch audio pumping to its own FreeRTOS task (`TaskCoroutineESP32::create()` already exists in `src/platforms/esp/32/coroutine_esp32.impl.hpp`). This requires auditing Processor / Context thread safety to avoid races on shared detector state, which I intentionally did not gold-plate in this PR. Leaving open as a follow-up.

Refs #2254

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved task scheduling and delay handling for more reliable timing behavior in OS-level yield operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->