### PR TITLE
fix(ci): mirror fbuild artifacts AFTER pio metadata gen (AVR8JS+QEMU still red)

### DIFF
--- a/ci/compiler/pio.py
+++ b/ci/compiler/pio.py
@@ -667,9 +667,15 @@ class PioCompiler(Compiler):
             green_color = "\033[32m"
             reset_color = "\033[0m"
             print(f"{green_color}SUCCESS: {example}{reset_color}")
-            # Mirror top-level fbuild artifacts to the legacy .pio/build path so
-            # downstream tooling (QEMU/avr8js workflows, crash decoders) keeps
-            # working without having to know about fbuild's layout.
+            # Generate build metadata FIRST, because `pio project metadata`
+            # prepares `.pio/build/<env>/` by wiping and re-creating it —
+            # which would clobber any mirrored firmware files. Only after
+            # that settles do we copy fbuild's artifacts over so the legacy
+            # PlatformIO path also has `firmware.elf` / `firmware.hex` for
+            # downstream tooling (QEMU / avr8js workflows, crash decoders).
+            generate_build_info_json_from_existing_build(
+                self.build_dir, self.board, example
+            )
             try:
                 _mirror_fbuild_artifacts_to_pio(self.build_dir, environment)
             except Exception as mirror_err:
@@ -678,9 +684,6 @@ class PioCompiler(Compiler):
                     f"Warning: failed to mirror fbuild artifacts to .pio/build/{environment}: "
                     f"{mirror_err}"
                 )
-            generate_build_info_json_from_existing_build(
-                self.build_dir, self.board, example
-            )
         else:
             red_color = "\033[31m"
             reset_color = "\033[0m"


### PR DESCRIPTION
## Summary

PR #2285 added `_mirror_fbuild_artifacts_to_pio` to copy firmware artifacts from fbuild's `.fbuild/build/<env>/release/` path into the legacy `.pio/build/<env>/` path. This was supposed to unblock AVR8JS + QEMU workflows that look for `firmware.{elf,hex}` at the PlatformIO location.

**It didn't fully work.** AVR8JS + QEMU still appear broken. Reproduced locally and found the bug.

## Root cause

`_mirror_fbuild_artifacts_to_pio` was called **before** `generate_build_info_json_from_existing_build`. On a fresh build (CI is always fresh), the mirror target directory does not exist yet. `generate_build_info_json_from_existing_build` calls `pio project metadata --json-output`, which PREPARES that directory by wiping and re-creating it — clobbering the firmware files we just mirrored. Only `idedata.json` remains.

## Reproduction (local)

With pre-fix code, on a freshly-cleared `.pio/` subdirectory:

- `bash compile uno --examples Blink` prints `Mirrored fbuild artifacts to ... firmware.elf, firmware.hex`, then `Generating build metadata`, then `Generated build_info_Blink.json`.
- After completion, `.build/pio/uno/.pio/build/uno/` contains only `idedata.json`. The mirrored `firmware.elf` and `firmware.hex` are gone.

With the fix applied, same starting state:

- `bash compile uno --examples Blink` prints `Generating build metadata`, then `Generated build_info_Blink.json`, then `Mirrored fbuild artifacts to ... firmware.elf, firmware.hex`.
- After completion, `.build/pio/uno/.pio/build/uno/` contains `firmware.elf`, `firmware.hex`, and `idedata.json`.

## Fix

Swap the order inside `_build_with_fbuild`:

1. `generate_build_info_json_from_existing_build` first (this is what wipes the directory)
2. `_mirror_fbuild_artifacts_to_pio` second (nothing else touches the directory after this)

+9 / -6 in `ci/compiler/pio.py`. No API changes.

## Test plan

- [x] Fresh-dir reproduction confirmed pre-fix (idedata.json only → mirror files wiped)
- [x] Post-fix verification on fresh dir (all three files present)
- [ ] CI: AVR8JS Uno + QEMU C3/S3/DEV now pass

Note: GitHub Actions runners have been sitting on 46+ min queues for these specific workflows since #2285 merged, so CI hasn't surfaced that the previous fix was incomplete. This PR should make those runs green once they dequeue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Optimized the build process execution order for improved efficiency during compilation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->