### PR TITLE
perf(ci): use fbuild for ESP32 QEMU merged-bin builds

### DIFF
--- a/ci/compiler/pio.py
+++ b/ci/compiler/pio.py
@@ -63,14 +63,17 @@ def _mirror_fbuild_artifacts_to_pio(build_dir: Path, environment: str) -> None:
     ``.pio/build/<env>/`` path because that was the PlatformIO convention.
 
     To keep those consumers working without plumbing fbuild-awareness into
-    every call site, copy ``firmware.elf``, ``firmware.bin``, ``firmware.hex``,
-    and ``firmware.map`` (when present) into ``.pio/build/<env>/`` after a
-    successful fbuild compile. This is a cheap no-op if the source files are
-    missing.
+    every call site, copy the artifacts fbuild produces — ``firmware.elf``,
+    ``firmware.bin``, ``firmware.hex``, ``firmware.map``, plus the ESP32
+    boot/partition artifacts ``bootloader.bin``, ``partitions.bin``, and
+    ``boot_app0.bin`` when present — into ``.pio/build/<env>/`` after a
+    successful fbuild compile. Missing source files are skipped silently.
 
-    Note: fbuild does NOT produce ``bootloader.bin`` / ``partitions.bin``.
-    Callers that need those (ESP32 merged-bin / QEMU) must run the PlatformIO
-    build explicitly — this function only covers the single-firmware case.
+    fbuild's ESP32 orchestrator (fbuild >= 2.1.7) emits
+    ``bootloader.bin`` / ``partitions.bin`` / ``boot_app0.bin`` alongside
+    ``firmware.bin`` in the release dir — copying them lets
+    ``build_with_merged_bin()`` run the ``esptool merge_bin`` step directly
+    on fbuild output, no PlatformIO build required.
     """
     pio_artifacts_dir = build_dir / ".pio" / "build" / environment
     pio_artifacts_dir.mkdir(parents=True, exist_ok=True)
@@ -85,6 +88,12 @@ def _mirror_fbuild_artifacts_to_pio(build_dir: Path, environment: str) -> None:
         (fbuild_release_dir / "firmware.bin", "firmware.bin"),
         (fbuild_release_dir / "firmware.hex", "firmware.hex"),
         (fbuild_release_dir / "firmware.map", "firmware.map"),
+        # ESP32 merged-bin inputs — produced by fbuild's Esp32Orchestrator
+        # (orchestrator.rs step 14: "Prepare boot artifacts for deployment /
+        # emulation"). Non-ESP32 builds simply won't have these files.
+        (fbuild_release_dir / "bootloader.bin", "bootloader.bin"),
+        (fbuild_release_dir / "partitions.bin", "partitions.bin"),
+        (fbuild_release_dir / "boot_app0.bin", "boot_app0.bin"),
         (fbuild_env_dir / "build_info.json", "build_info.json"),
     ]
 
@@ -1181,25 +1190,24 @@ class PioCompiler(Compiler):
 
         # 2. Build normally first.
         #
-        # Merged-bin builds need ``bootloader.bin`` and ``partitions.bin`` in
-        # ``.pio/build/<env>/`` — these are produced by PlatformIO's ESP-IDF
-        # post-build steps and are NOT emitted by fbuild (which only produces
-        # ``firmware.elf`` / ``firmware.bin``). Force the PlatformIO path for
-        # this build even on boards that normally use fbuild, so QEMU and
-        # other flash-image consumers get a complete artifact set.
-        original_use_fbuild = self.use_fbuild
-        if self.use_fbuild:
-            print(
-                "build_with_merged_bin: forcing PlatformIO build path "
-                "(fbuild does not produce bootloader.bin/partitions.bin)"
-            )
-            self.use_fbuild = False
-            self.initialized = False
-        try:
-            cancelled = threading.Event()
-            result = self._internal_build_no_lock(example, cancelled)
-        finally:
-            self.use_fbuild = original_use_fbuild
+        # Both build paths produce the full artifact set needed for
+        # ``esptool merge_bin``:
+        #
+        # - PlatformIO: ESP-IDF post-build steps write
+        #   ``bootloader.bin`` / ``partitions.bin`` / ``boot_app0.bin``
+        #   directly into ``.pio/build/<env>/``.
+        # - fbuild (>= 2.1.7): the ESP32 orchestrator emits the same three
+        #   files plus ``firmware.bin`` into ``.fbuild/build/<env>/release/``;
+        #   ``_build_with_fbuild`` then calls
+        #   ``_mirror_fbuild_artifacts_to_pio`` to copy them into the
+        #   ``.pio/build/<env>/`` path this function reads from.
+        #
+        # Whichever build tool the caller asked for is respected here —
+        # previously this function force-disabled fbuild because the old
+        # fbuild version could not emit the boot/partition artifacts, but
+        # that workaround is no longer needed (FastLED/FastLED#2287).
+        cancelled = threading.Event()
+        result = self._internal_build_no_lock(example, cancelled)
         if not result.success:
             return result
 


### PR DESCRIPTION
## Summary

Completes the QEMU→fbuild migration tracked in #2287.

**Approach chosen: option (1)** from #2287 — _"have fbuild emit bootloader/partitions natively"_ — which turns out to already be done in the currently-pinned fbuild (>=2.1.12 per \`pyproject.toml\`; installed 2.1.16). Reading \`fbuild/crates/fbuild-build/src/esp32/orchestrator.rs\` shows step 14 *"Prepare boot artifacts for deployment / emulation"* already writes \`bootloader.bin\`, \`partitions.bin\`, and \`boot_app0.bin\` into \`.fbuild/build/<env>/release/\` alongside \`firmware.bin\`. The assumption in PR #2285 that fbuild does not emit those files is stale.

So this PR is just plumbing:

- Extend \`_mirror_fbuild_artifacts_to_pio()\` (added in #2285) to mirror the three ESP32 boot/partition artifacts in addition to \`firmware.*\`.
- Drop the \`use_fbuild = False\` force-override inside \`build_with_merged_bin()\`; the compiler now honors whichever build tool the caller asked for.

No changes needed to the QEMU workflow templates — they still read from \`.pio/build/<env>/\` and the mirror puts the files there.

No changes needed to FastLED/fbuild.

## Verification (local)

- \`bash compile esp32s3 --examples Blink\` via fbuild produces \`firmware.bin\`, \`bootloader.bin\`, \`partitions.bin\`, \`boot_app0.bin\` in both \`.fbuild/build/esp32s3/release/\` and the mirrored \`.pio/build/esp32s3/\`.
- \`esptool --chip esp32s3 merge-bin\` directly against fbuild's artifacts produces a valid 4MB merged image with \`0xE9\` magic byte at both \`0x0\` (bootloader) and \`0x10000\` (app). This is the same command \`build_with_merged_bin()\` runs.
- \`bash test --cpp\`: 300/300 pass.
- \`bash lint\` Python portion: clean. (Unrelated pre-existing C++ lint violation on \`tests/fl/url_lnk.cpp\` from #2286 is not touched by this PR.)

## Remaining (CI)

- Confirm all three ESP32 QEMU workflows (\`qemu_esp32dev_test.yml\`, \`qemu_esp32c3_test.yml\`, \`qemu_esp32s3_test.yml\`) pass green on this PR.
- Once green, I'll post a follow-up comment with the PIO vs fbuild wall-clock delta for at least one workflow (#2287 acceptance criterion).

## Test plan

- [ ] \`bash test --cpp\` locally — done, 300/300
- [ ] ESP32-DEV QEMU Test on CI
- [ ] ESP32-C3 QEMU Test on CI
- [ ] ESP32-S3 QEMU Test on CI
- [ ] AVR8JS Uno Test on CI (baseline — should stay green)
- [ ] Add PIO-vs-fbuild wall-clock delta comment after first green CI run

Refs #2287

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved ESP32 build artifact handling to ensure bootloader, partition, and boot files are properly included in the build output directory.
  * Enhanced build system robustness with more flexible artifact detection and management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->