### PR TITLE
feat(autoresearch): add --frames N multi-frame capture

### DIFF
--- a/ci/autoresearch/args.py
+++ b/ci/autoresearch/args.py
@@ -86,6 +86,11 @@ class Args:
     # Decode autoresearch mode (host-only, no device needed)
     decode: str | None
 
+    # Multi-frame capture — number of back-to-back show()/capture cycles per pattern.
+    # None = driver-default (SPI → 2, others → 1). Explicit value overrides.
+    # See issues #2254 and #2288 (ESP32-S3 SPI second-frame degradation).
+    frames: int | None
+
     @staticmethod
     def parse_args() -> "Args":
         """Parse command-line arguments and return Args dataclass instance."""
@@ -479,6 +484,18 @@ See Also:
             help="Chipset timing to use for autoresearch (default: ws2812). ucs7604 uses UCS7604-800KHZ timing with 16-bit encoding.",
         )
 
+        # Multi-frame capture (second-frame degradation detection)
+        parser.add_argument(
+            "--frames",
+            type=int,
+            default=None,
+            metavar="N",
+            help="Consecutive back-to-back show()/capture cycles per pattern (1-16). "
+            "Exposes second-frame degradation bugs (e.g., SPI driver zeroing its "
+            "DMA buffer after first show). Default: 2 for --spi, 1 otherwise. "
+            "See issues #2254, #2288.",
+        )
+
         parsed = parser.parse_args()
 
         # Convert argparse.Namespace to Args dataclass
@@ -527,4 +544,5 @@ See Also:
             ble=parsed.ble,
             parallel=parsed.parallel,
             decode=parsed.decode,
+            frames=parsed.frames,
         )

--- a/ci/autoresearch/context.py
+++ b/ci/autoresearch/context.py
@@ -164,10 +164,14 @@ def display_pattern_details(result: dict[str, Any]) -> None:
     lane_count = result.get("laneCount", 0)
     lane_sizes = result.get("laneSizes", [])
     total_leds = sum(lane_sizes) if lane_sizes else 0
+    frame_count = result.get("frameCount", 1)
 
     print()
     print("=" * 62)
-    print(f"{driver} — {lane_count} lane(s), {total_leds} LEDs")
+    header = f"{driver} — {lane_count} lane(s), {total_leds} LEDs"
+    if frame_count and frame_count > 1:
+        header += f", frames={frame_count}"
+    print(header)
     print("=" * 62)
 
     agg_total_bytes = 0
@@ -177,13 +181,15 @@ def display_pattern_details(result: dict[str, Any]) -> None:
     for pat in patterns:
         name = pat.get("name", "Unknown")
         passed = pat.get("passed", False)
+        run_number = pat.get("runNumber")
         status = (
             f"{Fore.GREEN}PASS{Style.RESET_ALL}"
             if passed
             else f"{Fore.RED}FAIL{Style.RESET_ALL}"
         )
 
-        print(f"\n  {name}  {status}")
+        frame_suffix = f" [frame {run_number}]" if run_number else ""
+        print(f"\n  {name}{frame_suffix}  {status}")
 
         if passed:
             num_leds = pat.get("totalLeds", 0)

--- a/ci/autoresearch/phases.py
+++ b/ci/autoresearch/phases.py
@@ -502,6 +502,17 @@ def _parse_args_and_build_commands(args: Args) -> RunContext | int:
                     }
                     if args.legacy:
                         test_config["useLegacyApi"] = True
+                    # Multi-frame capture: back-to-back show()/capture cycles per pattern.
+                    # Defaults: SPI -> 2 (catches #2254/#2288 second-frame degradation),
+                    # others -> 1. User can override with --frames N.
+                    if args.frames is not None:
+                        frame_count = args.frames
+                    elif driver == "SPI":
+                        frame_count = 2
+                    else:
+                        frame_count = 1
+                    if frame_count > 1:
+                        test_config["frameCount"] = frame_count
                     rpc_command = {"method": "runSingleTest", "params": test_config}
                     rpc_commands_list.append(rpc_command)
 

--- a/ci/tests/test_autoresearch_phases.py
+++ b/ci/tests/test_autoresearch_phases.py
@@ -80,6 +80,7 @@ def _make_args(**overrides) -> Args:
         ble=False,
         parallel=False,
         decode=None,
+        frames=None,
     )
     defaults.update(overrides)
     return Args(**defaults)

--- a/examples/AutoResearch/AutoResearchRemote.cpp
+++ b/examples/AutoResearch/AutoResearchRemote.cpp
@@ -214,6 +214,22 @@ fl::json AutoResearchRemoteControl::runSingleTestImpl(const fl::json& args) {
         }
     }
 
+    // 4b. Extract frameCount (optional, default: 1)
+    // Number of back-to-back captures of the SAME LED buffer within a single
+    // pattern. frameCount >= 2 exposes second-frame degradation bugs where a
+    // driver corrupts or zeroes its DMA buffer after the first show() — see
+    // issues #2254 and #2288 (ESP32-S3 SPI \"black frame between displays\").
+    int frame_count = 1;
+    if (config.contains("frameCount") && config["frameCount"].is_int()) {
+        frame_count = static_cast<int>(config["frameCount"].as_int().value());
+        if (frame_count < 1 || frame_count > 16) {
+            response.set("success", false);
+            response.set("error", "InvalidFrameCount");
+            response.set("message", "frameCount must be in [1, 16]");
+            return response;
+        }
+    }
+
     // 5. Extract pinTx (optional, default: use mState->pin_tx)
     int pin_tx = mState->pin_tx;
     if (config.contains("pinTx") && config["pinTx"].is_int()) {
@@ -373,7 +389,7 @@ fl::json AutoResearchRemoteControl::runSingleTestImpl(const fl::json& args) {
             // Legacy API path: WS2812B<PIN> template instantiation
             for (int iter = 0; iter < iterations; iter++) {
                 int iter_total = 0, iter_passed = 0;
-                autoResearchChipsetTimingLegacy(autoresearch_config, iter_total, iter_passed, show_duration_ms, &run_results);
+                autoResearchChipsetTimingLegacy(autoresearch_config, iter_total, iter_passed, show_duration_ms, &run_results, frame_count);
                 total_tests += iter_total;
                 passed_tests += iter_passed;
             }
@@ -381,7 +397,7 @@ fl::json AutoResearchRemoteControl::runSingleTestImpl(const fl::json& args) {
             // Channel API path: FastLED.add(channel_config)
             for (int iter = 0; iter < iterations; iter++) {
                 int iter_total = 0, iter_passed = 0;
-                autoResearchChipsetTiming(autoresearch_config, iter_total, iter_passed, show_duration_ms, &run_results);
+                autoResearchChipsetTiming(autoresearch_config, iter_total, iter_passed, show_duration_ms, &run_results, frame_count);
                 total_tests += iter_total;
                 passed_tests += iter_passed;
             }
@@ -409,6 +425,7 @@ fl::json AutoResearchRemoteControl::runSingleTestImpl(const fl::json& args) {
     response.set("laneSizes", sizes_response);
     response.set("pattern", pattern.c_str());
     response.set("useLegacyApi", use_legacy_api);
+    response.set("frameCount", static_cast<int64_t>(frame_count));
 
     // Free run_results before building response to reclaim heap
     // Only serialize pattern details when tests FAIL (saves heap on passing tests)
@@ -418,6 +435,7 @@ fl::json AutoResearchRemoteControl::runSingleTestImpl(const fl::json& args) {
             const auto& rr = run_results[ri];
             if (rr.passed) continue;  // Skip passing patterns
             fl::json pat = fl::json::object();
+            pat.set("runNumber", static_cast<int64_t>(rr.run_number));
             pat.set("totalLeds", static_cast<int64_t>(rr.total_leds));
             pat.set("mismatchedLeds", static_cast<int64_t>(rr.mismatches));
             pat.set("mismatchedBytes", static_cast<int64_t>(rr.mismatchedBytes));

--- a/examples/AutoResearch/AutoResearchTest.cpp
+++ b/examples/AutoResearch/AutoResearchTest.cpp
@@ -980,7 +980,8 @@ void runMultiTest(const char* test_name,
 void autoResearchChipsetTiming(fl::AutoResearchConfig& config,
                            int& driver_total, int& driver_passed,
                            uint32_t& out_show_duration_ms,
-                           fl::vector<fl::RunResult>* out_results) {
+                           fl::vector<fl::RunResult>* out_results,
+                           int num_runs_per_pattern) {
     fl::sstream ss;
     ss << "\n========================================\n";
     ss << "Testing: " << config.timing_name << "\n";
@@ -1047,8 +1048,11 @@ void autoResearchChipsetTiming(fl::AutoResearchConfig& config,
 
     // Multi-run configuration - optimized for speed
     fl::MultiRunConfig multi_config;
-    multi_config.num_runs = 1;            // Single run per pattern (Python orchestrates retries)
-    multi_config.print_all_runs = false;  // Only print failed runs
+    // num_runs=1: Python orchestrates retries (default).
+    // num_runs>=2: Back-to-back captures of the same buffer to expose second-frame
+    // degradation (e.g., SPI driver zeroing its DMA buffer after the first show()).
+    multi_config.num_runs = (num_runs_per_pattern > 0) ? num_runs_per_pattern : 1;
+    multi_config.print_all_runs = (multi_config.num_runs > 1);
     multi_config.print_per_led_errors = false;  // Errors reported via JSON-RPC
     multi_config.max_errors_per_run = 10;  // Store first 10 errors for JSON response
 
@@ -1090,7 +1094,8 @@ void autoResearchChipsetTiming(fl::AutoResearchConfig& config,
 void autoResearchChipsetTimingLegacy(fl::AutoResearchConfig& config,
                                  int& driver_total, int& driver_passed,
                                  uint32_t& out_show_duration_ms,
-                                 fl::vector<fl::RunResult>* out_results) {
+                                 fl::vector<fl::RunResult>* out_results,
+                                 int num_runs_per_pattern) {
     fl::sstream ss;
     ss << "\n========================================\n";
     ss << "Testing (LEGACY API): " << config.timing_name << "\n";
@@ -1140,8 +1145,8 @@ void autoResearchChipsetTimingLegacy(fl::AutoResearchConfig& config,
     int passed = 0;
 
     fl::MultiRunConfig multi_config;
-    multi_config.num_runs = 1;
-    multi_config.print_all_runs = false;
+    multi_config.num_runs = (num_runs_per_pattern > 0) ? num_runs_per_pattern : 1;
+    multi_config.print_all_runs = (multi_config.num_runs > 1);
     multi_config.print_per_led_errors = false;
     multi_config.max_errors_per_run = 10;
 

--- a/examples/AutoResearch/AutoResearchTest.h
+++ b/examples/AutoResearch/AutoResearchTest.h
@@ -142,10 +142,13 @@ void runMultiTest(const char* test_name,
 // @param total Output parameter - total tests run (incremented)
 // @param passed Output parameter - tests passed (incremented)
 // @param out_results Optional output for per-pattern results with LED error details
+// @param num_runs_per_pattern Consecutive captures per pattern (default 1). >=2 exposes
+//        second-frame degradation bugs like SPI driver zeroing DMA buffer after first show().
 void autoResearchChipsetTiming(fl::AutoResearchConfig& config,
                            int& total, int& passed,
                            uint32_t& out_show_duration_ms,
-                           fl::vector<fl::RunResult>* out_results = nullptr);
+                           fl::vector<fl::RunResult>* out_results = nullptr,
+                           int num_runs_per_pattern = 1);
 
 // AutoResearch using the legacy template addLeds API (supports multi-lane)
 // Uses LegacyClocklessProxy to map runtime pin to WS2812B<PIN> template instantiation
@@ -153,10 +156,12 @@ void autoResearchChipsetTiming(fl::AutoResearchConfig& config,
 // @param total Output parameter - total tests run (incremented)
 // @param passed Output parameter - tests passed (incremented)
 // @param out_results Optional output for per-pattern results with LED error details
+// @param num_runs_per_pattern Consecutive captures per pattern (default 1).
 void autoResearchChipsetTimingLegacy(fl::AutoResearchConfig& config,
                                  int& total, int& passed,
                                  uint32_t& out_show_duration_ms,
-                                 fl::vector<fl::RunResult>* out_results = nullptr);
+                                 fl::vector<fl::RunResult>* out_results = nullptr,
+                                 int num_runs_per_pattern = 1);
 
 // Set mixed RGB bit patterns to test MSB vs LSB handling
 // @param leds LED array to fill with pattern


### PR DESCRIPTION
## Summary
- Adds `--frames N` (1-16) to `bash autoresearch` for back-to-back `show()`/capture cycles per pattern.
- Defaults to `2` when `--spi` is used, `1` otherwise — exposes second-frame degradation bugs where a driver corrupts or zeroes its DMA buffer after the first `show()`.
- Plumbed end-to-end: CLI → Python JSON-RPC → firmware `runSingleTest` → `MultiRunConfig.num_runs`.
- Reports per-pattern `runNumber` and adds `frames=N` to the header when frameCount > 1.

Context: issues #2254 and #2288 — ESP32-S3 SPI "black frame between displays".

## Test plan
- [ ] `uv run pytest ci/tests/test_autoresearch_phases.py`
- [ ] `bash autoresearch --spi` locally — confirm defaults to frames=2 and reports runNumber on failure
- [ ] `bash autoresearch --parlio --frames 1` — confirm override works
- [ ] CI green on the branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--frames` command-line option to configure capture frame count (1–16) per test
  * SPI driver defaults to 2 frames; other drivers default to 1 unless explicitly set
  * Enhanced test output now displays frame count and run details for improved diagnostics

<!-- end of auto-generated comment: release notes by coderabbit.ai -->