### PR TITLE
fix(hooks): harden .claude/settings.json cwd resolution (degenerate lockout fix)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,5 @@
 {
+  "_cwd_resolution": "Each hook walks up from $PWD looking for pyproject.toml (the project-root marker). If found, cd there and exec the hook script. If not found (cwd outside project, or inside a nested build dir with its own .git), the hook skips with a warning instead of blocking every subsequent tool call. Do NOT use `git rev-parse --show-toplevel` here — it gets fooled by nested .git dirs that build tools create under .build/.",
   "hooks": {
     "PreToolUse": [
       {
@@ -6,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cd \"$(git rev-parse --show-superproject-working-tree 2>/dev/null || git rev-parse --show-toplevel 2>/dev/null || echo .)\" && uv run python ci/hooks/check_forbidden_commands.py"
+            "command": "d=$PWD; while [ \"$d\" != / ] && [ ! -f \"$d/pyproject.toml\" ]; do d=$(dirname \"$d\"); done; [ -f \"$d/pyproject.toml\" ] && cd \"$d\" && exec uv run python ci/hooks/check_forbidden_commands.py || { echo 'FastLED hook skipped: project root (pyproject.toml) not found above $PWD' >&2; exit 0; }"
           }
         ]
       },
@@ -15,7 +16,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cd \"$(git rev-parse --show-superproject-working-tree 2>/dev/null || git rev-parse --show-toplevel 2>/dev/null || echo .)\" && uv run python ci/hooks/check_test_file_pairing.py"
+            "command": "d=$PWD; while [ \"$d\" != / ] && [ ! -f \"$d/pyproject.toml\" ]; do d=$(dirname \"$d\"); done; [ -f \"$d/pyproject.toml\" ] && cd \"$d\" && exec uv run python ci/hooks/check_test_file_pairing.py || { echo 'FastLED hook skipped: project root (pyproject.toml) not found above $PWD' >&2; exit 0; }"
           }
         ]
       },
@@ -24,12 +25,12 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cd \"$(git rev-parse --show-superproject-working-tree 2>/dev/null || git rev-parse --show-toplevel 2>/dev/null || echo .)\" && uv run python ci/hooks/tdd_guard.py",
+            "command": "d=$PWD; while [ \"$d\" != / ] && [ ! -f \"$d/pyproject.toml\" ]; do d=$(dirname \"$d\"); done; [ -f \"$d/pyproject.toml\" ] && cd \"$d\" && exec uv run python ci/hooks/tdd_guard.py || { echo 'FastLED hook skipped: project root (pyproject.toml) not found above $PWD' >&2; exit 0; }",
             "timeout": 10
           },
           {
             "type": "command",
-            "command": "cd \"$(git rev-parse --show-superproject-working-tree 2>/dev/null || git rev-parse --show-toplevel 2>/dev/null || echo .)\" && uv run python ci/hooks/protect_platform_headers.py",
+            "command": "d=$PWD; while [ \"$d\" != / ] && [ ! -f \"$d/pyproject.toml\" ]; do d=$(dirname \"$d\"); done; [ -f \"$d/pyproject.toml\" ] && cd \"$d\" && exec uv run python ci/hooks/protect_platform_headers.py || { echo 'FastLED hook skipped: project root (pyproject.toml) not found above $PWD' >&2; exit 0; }",
             "timeout": 10
           }
         ]
@@ -41,17 +42,17 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cd \"$(git rev-parse --show-superproject-working-tree 2>/dev/null || git rev-parse --show-toplevel 2>/dev/null || echo .)\" && uv run python ci/hooks/lint-on-save.py",
+            "command": "d=$PWD; while [ \"$d\" != / ] && [ ! -f \"$d/pyproject.toml\" ]; do d=$(dirname \"$d\"); done; [ -f \"$d/pyproject.toml\" ] && cd \"$d\" && exec uv run python ci/hooks/lint-on-save.py || { echo 'FastLED hook skipped: project root (pyproject.toml) not found above $PWD' >&2; exit 0; }",
             "timeout": 30
           },
           {
             "type": "command",
-            "command": "cd \"$(git rev-parse --show-superproject-working-tree 2>/dev/null || git rev-parse --show-toplevel 2>/dev/null || echo .)\" && uv run python ci/hooks/auto_test_suggest.py",
+            "command": "d=$PWD; while [ \"$d\" != / ] && [ ! -f \"$d/pyproject.toml\" ]; do d=$(dirname \"$d\"); done; [ -f \"$d/pyproject.toml\" ] && cd \"$d\" && exec uv run python ci/hooks/auto_test_suggest.py || { echo 'FastLED hook skipped: project root (pyproject.toml) not found above $PWD' >&2; exit 0; }",
             "timeout": 10
           },
           {
             "type": "command",
-            "command": "cd \"$(git rev-parse --show-superproject-working-tree 2>/dev/null || git rev-parse --show-toplevel 2>/dev/null || echo .)\" && uv run python ci/hooks/compile_example.py",
+            "command": "d=$PWD; while [ \"$d\" != / ] && [ ! -f \"$d/pyproject.toml\" ]; do d=$(dirname \"$d\"); done; [ -f \"$d/pyproject.toml\" ] && cd \"$d\" && exec uv run python ci/hooks/compile_example.py || { echo 'FastLED hook skipped: project root (pyproject.toml) not found above $PWD' >&2; exit 0; }",
             "timeout": 300,
             "statusMessage": "Compiling example..."
           }
@@ -63,7 +64,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cd \"$(git rev-parse --show-superproject-working-tree 2>/dev/null || git rev-parse --show-toplevel 2>/dev/null || echo .)\" && uv run python ci/hooks/check-on-start.py",
+            "command": "d=$PWD; while [ \"$d\" != / ] && [ ! -f \"$d/pyproject.toml\" ]; do d=$(dirname \"$d\"); done; [ -f \"$d/pyproject.toml\" ] && cd \"$d\" && exec uv run python ci/hooks/check-on-start.py || { echo 'FastLED hook skipped: project root (pyproject.toml) not found above $PWD' >&2; exit 0; }",
             "timeout": 10
           }
         ]
@@ -74,7 +75,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cd \"$(git rev-parse --show-superproject-working-tree 2>/dev/null || git rev-parse --show-toplevel 2>/dev/null || echo .)\" && uv run python ci/hooks/check-on-stop.py",
+            "command": "d=$PWD; while [ \"$d\" != / ] && [ ! -f \"$d/pyproject.toml\" ]; do d=$(dirname \"$d\"); done; [ -f \"$d/pyproject.toml\" ] && cd \"$d\" && exec uv run python ci/hooks/check-on-stop.py || { echo 'FastLED hook skipped: project root (pyproject.toml) not found above $PWD' >&2; exit 0; }",
             "timeout": 600
           }
         ]
@@ -85,7 +86,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cd \"$(git rev-parse --show-superproject-working-tree 2>/dev/null || git rev-parse --show-toplevel 2>/dev/null || echo .)\" && uv run python ci/hooks/desktop_notify.py",
+            "command": "d=$PWD; while [ \"$d\" != / ] && [ ! -f \"$d/pyproject.toml\" ]; do d=$(dirname \"$d\"); done; [ -f \"$d/pyproject.toml\" ] && cd \"$d\" && exec uv run python ci/hooks/desktop_notify.py || { echo 'FastLED hook skipped: project root (pyproject.toml) not found above $PWD' >&2; exit 0; }",
             "timeout": 10
           }
         ]
@@ -96,7 +97,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cd \"$(git rev-parse --show-superproject-working-tree 2>/dev/null || git rev-parse --show-toplevel 2>/dev/null || echo .)\" && uv run python ci/hooks/git_context.py",
+            "command": "d=$PWD; while [ \"$d\" != / ] && [ ! -f \"$d/pyproject.toml\" ]; do d=$(dirname \"$d\"); done; [ -f \"$d/pyproject.toml\" ] && cd \"$d\" && exec uv run python ci/hooks/git_context.py || { echo 'FastLED hook skipped: project root (pyproject.toml) not found above $PWD' >&2; exit 0; }",
             "timeout": 10
           }
         ]


### PR DESCRIPTION
## Summary

Every hook in `.claude/settings.json` was using `git rev-parse --show-toplevel` to locate the FastLED project root. This gets fooled when the agent's shell CWD drifts into a nested `.git` directory — e.g., fbuild/PIO creates its own git init under `.build/pio/<env>/` for incremental-build caching.

When that happens, `git rev-parse` returns the nested toplevel, the hook tries to `cd` there and exec `ci/hooks/<script>.py`, which doesn't exist there, and exits non-zero — blocking **every subsequent tool call**. The Stop hook hits the same bug and re-fires on each session cycle, trapping the agent in a loop that only a manual `rm -rf .git` or session reset can break.

## What this fixes

- Agent CI/CD sessions getting locked out after a `cd` into any build-tool-created nested-git directory.
- Stop-hook feedback loop with identical error message on every turn.
- Downstream effect: agent cannot commit, push, open PRs, read files, or even exit its own worktree once wedged.

## Fix

Replace `git rev-parse --show-toplevel` with a shell walk-up for `pyproject.toml` (the real FastLED project marker). Pattern used across all 11 hook commands:

```sh
d=$PWD
while [ "$d" != / ] && [ ! -f "$d/pyproject.toml" ]; do d=$(dirname "$d"); done
[ -f "$d/pyproject.toml" ] && cd "$d" && exec uv run python ci/hooks/<script>.py \
  || { echo 'FastLED hook skipped: project root (pyproject.toml) not found above $PWD' >&2; exit 0; }
```

Two key properties:

1. **Walk-up past nested `.git` dirs** — stops only at a directory that actually has `pyproject.toml`, which build-tool scratch dirs don't.
2. **`exec` for the real hook path** — replaces the bash process, so genuine hook failures (forbidden commands, TDD guard, etc.) still propagate their non-zero exit code and correctly block the tool call. Only the "project root not found" branch becomes non-blocking.

Result: if the CWD is outside any FastLED checkout or deep inside a nested scratch dir, the hook emits **one** stderr warning and exits 0 — the agent gets a soft skip instead of a hard lockout.

## Verification

Reproduced the exact failure in a `/tmp` simulation (nested `.git` under a `pyproject.toml` root):

- **Old pattern**: `git rev-parse` returned the nested toplevel → `python ci/hooks/test_hook.py` → `can't open file`. Hook fails; next tool call blocked.
- **New pattern**: walks up past `.build/pio/uno/.git` → finds `pyproject.toml` at the real root → runs hook correctly.

Also verified CWD outside any project (`/tmp/nowhere-special`): walks to `/`, no marker → single warning line, exit 0, subsequent tools unaffected.

```
$ python -c "import json; d=json.load(open('.claude/settings.json'))"
# validates

$ grep -c 'git rev-parse' .claude/settings.json
0
```

## Scope

11 hook commands migrated (PreToolUse x4, PostToolUse x3, SessionStart, Stop, Notification, UserPromptSubmit). No functional change to hook *behavior* — only how they locate the root. No other files touched.

## Test plan

- [x] Simulation of old-pattern failure — reproduces the lockout.
- [x] Simulation of new-pattern success on same layout — no lockout.
- [x] JSON validity check.
- [x] grep confirms no hook still uses `git rev-parse`.
- [ ] Next agent session starting from a nested build dir does not wedge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development hook resolution logic to improve project directory detection during script execution.
  * Enhanced hook configuration documentation with clearer guidance on directory resolution behavior and fallback handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->