### PR TITLE
fix(autoresearch): fail the test when RX capture is truncated

### DIFF
--- a/examples/AutoResearch/AutoResearchTest.cpp
+++ b/examples/AutoResearch/AutoResearchTest.cpp
@@ -837,11 +837,13 @@ void runMultiTest(const char* test_name,
                                          bytes_expected;
                 (void)bytes_to_check;
 
+                size_t verified_leds = 0;
                 for (size_t i = 0; i < num_leds; i++) {
                     size_t byte_offset = rx_buffer_offset + i * 3; // Apply offset for PARLIO front padding
                     if (byte_offset + 2 >= bytes_captured) { // Check against total captured bytes
                         break;
                     }
+                    verified_leds = i + 1;
 
                     uint8_t expected_r = leds[i].r;
                     uint8_t expected_g = leds[i].g;
@@ -888,6 +890,22 @@ void runMultiTest(const char* test_name,
                             ));
                         }
                     }
+                }
+
+                // Truncated capture: RX returned fewer bytes than expected. Count
+                // the unchecked LEDs as mismatches rather than silently passing.
+                // A short capture means we did NOT verify those LEDs, so the run
+                // MUST fail. The old silent break hid real bugs on strips longer
+                // than the RMT DMA buffer (~170 LEDs for WS2812B). See issue #2254.
+                if (verified_leds < num_leds) {
+                    size_t unchecked = num_leds - verified_leds;
+                    mismatches += static_cast<int>(unchecked);
+                    result.mismatchedBytes += static_cast<int>(unchecked * 3);
+                    FL_WARN("[TRUNCATED CAPTURE] Only verified " << verified_leds
+                            << "/" << num_leds << " LEDs (" << bytes_captured
+                            << " bytes captured, needed " << (num_leds * 3)
+                            << "). Marking " << unchecked
+                            << " unchecked LEDs as mismatches.");
                 }
             }
 


### PR DESCRIPTION
## Summary

The autoresearch WS2812 comparator silently `break`s the per-LED compare loop when `bytes_captured` runs short, then reports `Errors: 0/<num_leds>` as PASS. Any LEDs past the first `bytes_captured / 3` are skipped without comparison — turning truncated captures into **false-positive PASSes**.

On ESP32-S3 the RMT RX DMA buffer caps a single receive at 4096 symbols (≈ 170 WS2812B LEDs), so every autoresearch run on a strip longer than ~170 LEDs was passing without actually verifying the tail.

## Change

Track `verified_leds`. After the loop, if it's short of `num_leds`, count the unchecked LEDs as mismatches and emit a clear `[TRUNCATED CAPTURE]` diagnostic so the run hard-FAILs. No-op when capture is full.

**Before** on `bash autoresearch --spi --strip-sizes 550` (ESP32-S3):
```
[RUN 1] Driver=SPI, bytes_captured=512
[Run 1/2] PASS | Errors: 0/550 (100.0%)    ← false positive
```

**After**:
```
[RUN 1] Driver=SPI, bytes_captured=512
[TRUNCATED CAPTURE] Only verified 170/550 LEDs (512 bytes captured,
needed 1650). Marking 380 unchecked LEDs as mismatches.
[Run 1/2] FAIL | Errors: 380/550 (30.91%)
```

## Test plan

- [x] `bash autoresearch --spi --strip-sizes 550` on ESP32-S3 now hard-FAILs with the `[TRUNCATED CAPTURE]` diagnostic.
- [x] `bash autoresearch --spi --strip-sizes 100` on ESP32-S3 still PASSes legitimately (`bytes_captured=300`, all 100 LEDs verified).
- [x] No regression in the RMT driver test path (uses the same comparator but captures fit easily within 4096 symbols for the `--strip-sizes small` default).

## Background

Exposed while reproducing issue #2254 (ESP32-S3 SPI driver "black frame between displays"). Independent of any driver fix; this is purely a test-harness correctness improvement that makes the harness stop lying on long strips.

The underlying RX-capacity limit (~170 LEDs per pass) is a separate, larger investigation documented in #2254 — it requires RmtMemoryManager refactoring to support DMA-mode RX allocations. Until that lands, this PR at least ensures such runs FAIL loudly instead of passing silently.

## Related

- #2254 — the SPI driver investigation that surfaced this bug
- #2293 — earlier merged companion (`--frames N` multi-frame capture)
- #2288 — sibling tracker for second-frame degradation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced RGB LED validation testing to properly identify and report incomplete data captures. Unchecked LEDs are now correctly flagged as mismatches rather than ignored, with diagnostic messages provided for better visibility into test failures. This ensures more accurate validation results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->