### PR TITLE
fix(ci): cap example-test job at 45m to catch Windows runner hangs

### DIFF
--- a/.github/workflows/template_example_test.yml
+++ b/.github/workflows/template_example_test.yml
@@ -21,6 +21,11 @@ defaults:
 jobs:
   build:
     runs-on: ${{ inputs.os }}
+    # Fail fast instead of waiting for the 6h default runner timeout.
+    # Successful runs complete in ~8-20 minutes; anything past 45m is hung.
+    # Observed Windows runners hanging in the Install step for 3+ hours
+    # before losing communication with the server (runs/24593311481).
+    timeout-minutes: 45
     steps:
       - name: Checkout trusted base branch code
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Windows `example_test` runs have been hanging in the Install step for 3+ hours before the hosted runner eventually loses communication with the server (e.g. [runs/24593311481](https://github.com/FastLED/FastLED/actions/runs/24593311481/job/71918465369)).
- Successful runs across Linux / macOS / Windows complete in 8-20 minutes, so a 45m `timeout-minutes` cap fails fast on hangs without risking false positives on healthy runs.
- The edit is on `template_example_test.yml`, which is the shared `workflow_call` template used by `example_test_linux.yml`, `example_test_macos.yml`, and `example_test_windows.yml`, so the guard applies to all three OS matrices.

## Context
The underlying hang appears to be in one of the `./install` steps on Windows (uv sync / VSCode extension install via `timeout 10 code ...` which behaves differently under Windows `timeout.exe`, or unguarded `git submodule update --remote` for the `wiki` submodule). This PR is just the fail-fast guard; diagnosing/fixing the root cause of the Windows install hang is a follow-up.

## Test plan
- [ ] CI example-test workflow runs on Linux / macOS / Windows and the 45m cap does not trip healthy runs
- [ ] If Windows hangs recur, the job now fails at 45m instead of burning 3h of runner time

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added timeout configuration to build job execution to improve workflow management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->