### PR TITLE
feat: fix #2254 SPI long-strip bug + enable RMT RX DMA streaming

### DIFF
--- a/examples/AutoResearch/AutoResearchTest.cpp
+++ b/examples/AutoResearch/AutoResearchTest.cpp
@@ -338,10 +338,17 @@ size_t capture(fl::shared_ptr<fl::RxDevice> rx_channel, fl::span<uint8_t> rx_buf
     // For other drivers (PARLIO, SPI, UART, I2S), disable io_loop_back (use external GPIO wire)
     bool is_rmt_driver = (fl::strcmp(driver_name, "RMT") == 0);
     rx_config.io_loop_back = is_rmt_driver;
+    // DMA streaming RX: extends capture past the non-DMA ~4096-symbol cap
+    // (~170 WS2812B LEDs) by firing the ISR on every partial-rx fill. Enable
+    // for non-RMT drivers where the TX path does not use RMT (SPI, PARLIO,
+    // I2S, UART, LCD_*) so there's no contention for the shared DMA slot.
+    // RMT loopback stays non-DMA because the TX also wants the DMA slot.
+    // See issue #2254.
+    rx_config.use_dma = !is_rmt_driver;
     if (is_rmt_driver) {
         FL_WARN("[CAPTURE] RMT TX -> RMT RX: Internal loopback enabled (io_loop_back=true)");
     } else {
-        FL_WARN("[CAPTURE] " << driver_name << " TX -> RMT RX: External GPIO wire (io_loop_back=false)");
+        FL_WARN("[CAPTURE] " << driver_name << " TX -> RMT RX: External GPIO wire (io_loop_back=false, use_dma=true)");
     }
 
     // Driver-aware capture strategy:

--- a/examples/AutoResearch/AutoResearchTest.cpp
+++ b/examples/AutoResearch/AutoResearchTest.cpp
@@ -338,13 +338,14 @@ size_t capture(fl::shared_ptr<fl::RxDevice> rx_channel, fl::span<uint8_t> rx_buf
     // For other drivers (PARLIO, SPI, UART, I2S), disable io_loop_back (use external GPIO wire)
     bool is_rmt_driver = (fl::strcmp(driver_name, "RMT") == 0);
     rx_config.io_loop_back = is_rmt_driver;
-    // DMA streaming RX: extends capture past the non-DMA ~4096-symbol cap
-    // (~170 WS2812B LEDs) by firing the ISR on every partial-rx fill. Enable
-    // for non-RMT drivers where the TX path does not use RMT (SPI, PARLIO,
-    // I2S, UART, LCD_*) so there's no contention for the shared DMA slot.
-    // RMT loopback stays non-DMA because the TX also wants the DMA slot.
+    // RX DMA streaming infrastructure is in place via RxConfig::use_dma, but
+    // ESP32-S3's RMT DMA descriptor cap limits rmt_receive() to ~4096 symbols
+    // total per call — same as non-DMA mode. Extending past this needs
+    // task-side re-submission which isn't wired up yet, so DMA auto-enable
+    // here would not actually extend capture length. Keep the toggle OFF to
+    // avoid the DMA-slot acquisition cost without a corresponding benefit.
     // See issue #2254.
-    rx_config.use_dma = !is_rmt_driver;
+    rx_config.use_dma = false;
     if (is_rmt_driver) {
         FL_WARN("[CAPTURE] RMT TX -> RMT RX: Internal loopback enabled (io_loop_back=true)");
     } else {

--- a/examples/AutoResearch/AutoResearchTest.cpp
+++ b/examples/AutoResearch/AutoResearchTest.cpp
@@ -338,14 +338,14 @@ size_t capture(fl::shared_ptr<fl::RxDevice> rx_channel, fl::span<uint8_t> rx_buf
     // For other drivers (PARLIO, SPI, UART, I2S), disable io_loop_back (use external GPIO wire)
     bool is_rmt_driver = (fl::strcmp(driver_name, "RMT") == 0);
     rx_config.io_loop_back = is_rmt_driver;
-    // RX DMA streaming infrastructure is in place via RxConfig::use_dma, but
-    // ESP32-S3's RMT DMA descriptor cap limits rmt_receive() to ~4096 symbols
-    // total per call — same as non-DMA mode. Extending past this needs
-    // task-side re-submission which isn't wired up yet, so DMA auto-enable
-    // here would not actually extend capture length. Keep the toggle OFF to
-    // avoid the DMA-slot acquisition cost without a corresponding benefit.
+    // RX DMA streaming: extends capture past the non-DMA cap by sizing
+    // mem_block_symbols = 14336 so ESP-IDF allocates ~14 DMA descriptor
+    // nodes (each 4092 bytes), yielding a 57 KB user-buffer cap — enough to
+    // capture ~583 WS2812B LEDs in a single rmt_receive() call. Safe for
+    // non-RMT TX paths (SPI, PARLIO, I2S, UART, LCD_*) that don't contend
+    // for the shared ESP32-S3 DMA slot. RMT loopback stays non-DMA.
     // See issue #2254.
-    rx_config.use_dma = false;
+    rx_config.use_dma = !is_rmt_driver;
     if (is_rmt_driver) {
         FL_WARN("[CAPTURE] RMT TX -> RMT RX: Internal loopback enabled (io_loop_back=true)");
     } else {

--- a/src/fl/rx_device.h
+++ b/src/fl/rx_device.h
@@ -226,6 +226,16 @@ struct RxConfig {
     // is actively receiving on a different GPIO.
     bool io_loop_back = false;              ///< Enable internal RMT loopback (RMT only, default: false)
 
+    // DMA streaming mode (ESP32 RMT only). Non-DMA RMT RX caps a single receive
+    // at one mem-block fill (~4096 symbols, ≈170 WS2812B LEDs). DMA mode + ESP-IDF
+    // 5.3+ en_partial_rx fires the ISR multiple times per transmission — each fill
+    // copies into a DRAM accumulation buffer, extending capture to the full
+    // buffer_size. DMA bypasses on-chip RMT memory (uses DRAM), so it does NOT
+    // consume the shared RX pool and is safe to enable alongside other RMT
+    // channels. ESP32-S3 has one shared DMA slot; acquisition is coordinated via
+    // RmtMemoryManager::allocateDMA(). See issue #2254.
+    bool use_dma = false;                   ///< Use DMA streaming for RX (RMT only, default: false)
+
     /// Default constructor with common WS2812B defaults
     constexpr RxConfig() FL_NOEXCEPT = default;
 };

--- a/src/platforms/esp/32/drivers/rmt_rx/rmt_rx_channel.cpp.hpp
+++ b/src/platforms/esp/32/drivers/rmt_rx/rmt_rx_channel.cpp.hpp
@@ -726,15 +726,17 @@ class RmtRxChannelImpl : public RmtRxChannel {
         rx_config.gpio_num = mPin;
         rx_config.clk_src = RMT_CLK_SRC_DEFAULT;
         rx_config.resolution_hz = mResolutionHz;
-        // mem_block_symbols: non-DMA = hardware RMT memory block (small, ~64);
-        // DMA = DRAM ping-pong buffer ESP-IDF allocates internally.
-        // EMPIRICAL FINDING (ESP32-S3, ESP-IDF 5.5): the absolute cap on the
-        // rmt_receive() user buffer is 1024 symbols = 4 KB regardless of
-        // mem_block_symbols. Exceeding this returns ESP_ERR_INVALID_SIZE
-        // ("buffer size exceeds DMA capacity"). Observed total capture per
-        // rmt_receive() is 4× the user buffer via ping-pong wrap (~4096
-        // symbols = 170 WS2812B LEDs). See issue #2254.
-        rx_config.mem_block_symbols = mUseDma ? 256 : 64;
+        // mem_block_symbols:
+        //   Non-DMA: hardware RMT memory block, small (~64 symbols hard cap).
+        //   DMA:     sizes ESP-IDF's DMA descriptor chain. Per rmt_rx.c:210-211:
+        //     num_dma_nodes = max(2, mem_block_symbols * 4 / 4095 + 1)
+        //   and the per-rmt_receive() user-buffer cap is num_dma_nodes * 4092
+        //   bytes (=1023 symbols/node). So to pass a 14000-symbol user buffer
+        //   (= 56 KB) we need ≥14 DMA nodes, which means mem_block_symbols ≥
+        //   14336. Set 14336 to cover ~595 WS2812B LEDs in a single rmt_receive.
+        //   Memory cost: 14336 × 4 = 56 KB internal-RAM DMA buffer — ESP32-S3
+        //   has ~320 KB so ~18%. See issue #2254.
+        rx_config.mem_block_symbols = mUseDma ? 14336 : 64;
         // Interrupt priority level 3 (maximum supported by ESP-IDF RMT driver
         // API) Note: Both RISC-V and Xtensa platforms are limited to level 3 by
         // driver validation RISC-V hardware supports 1-7, but ESP-IDF
@@ -1254,14 +1256,14 @@ class RmtRxChannelImpl : public RmtRxChannel {
         // ESP32-S3, which ESP-IDF rejects with "user buffer not in the internal
         // RAM". See issue #2254.
         constexpr size_t NONDMA_BUFFER_SIZE = 4096;
-        // DMA user buffer: capped at 1024 symbols by ESP-IDF on ESP32-S3
-        // (absolute DMA descriptor limit). ESP-IDF fires partial-rx ISR every
-        // mem_block_symbols=256 fill (ping-pong halves); total capture per
-        // rmt_receive() is 4× the user buffer via internal wrap = 4096 symbols
-        // max, same absolute cap as non-DMA mode. Extending past this requires
-        // task-side re-submission which is not yet wired up — the DMA path is
-        // present as groundwork for that future change. See issue #2254.
-        constexpr size_t DMA_BUFFER_SIZE = 1024;
+        // DMA user buffer sized to fit within num_dma_nodes × 4092 bytes. With
+        // mem_block_symbols=14336 we get 14 DMA nodes = 57288 bytes = 14322
+        // symbols capacity. Pass 14000 symbols (= 56000 bytes) with margin.
+        // Covers 583 WS2812B LEDs in a single rmt_receive() — no need for
+        // ISR re-submission on typical long strips. Partial-rx ISR still fires
+        // every ~1023-symbol DMA node fill, streaming into the accumulation
+        // buffer via rxDoneCallback.
+        constexpr size_t DMA_BUFFER_SIZE = 14000;
         const size_t hw_buffer_size = mUseDma ? DMA_BUFFER_SIZE : NONDMA_BUFFER_SIZE;
 
         if (mUseDma) {

--- a/src/platforms/esp/32/drivers/rmt_rx/rmt_rx_channel.cpp.hpp
+++ b/src/platforms/esp/32/drivers/rmt_rx/rmt_rx_channel.cpp.hpp
@@ -552,7 +552,9 @@ class RmtRxChannelImpl : public RmtRxChannel {
           mSignalRangeMaxNs(
               4000000) // 40us - Allow gaps between PARLIO streaming chunks
           ,
-          mSkipCounter(0), mStartLow(true), mIoLoopBack(false), mInternalBuffer(),
+          mSkipCounter(0), mStartLow(true), mIoLoopBack(false), mUseDma(false),
+          mDmaAllocated(false), mDmaCapableBuffer(nullptr),
+          mDmaCapableBufferSize(0), mInternalBuffer(),
           mAccumulationBuffer(), mAccumulationOffset(0), mCallbackCount(0),
           mMemoryRegistered(false), mMemoryChannelId(0) {
         FL_LOG_RX("RmtRxChannel constructed with pin="
@@ -591,6 +593,20 @@ class RmtRxChannelImpl : public RmtRxChannel {
             mChannel = nullptr;
         }
 
+        // Release the shared DMA slot if this channel was holding it
+        if (mDmaAllocated) {
+            auto &memMgr = RmtMemoryManager::instance();
+            memMgr.freeDMA(mMemoryChannelId, false);
+            mDmaAllocated = false;
+        }
+
+        // Free the DRAM-backed DMA capture buffer
+        if (mDmaCapableBuffer) {
+            heap_caps_free(mDmaCapableBuffer);
+            mDmaCapableBuffer = nullptr;
+            mDmaCapableBufferSize = 0;
+        }
+
         // Unregister from RMT memory manager to release resources for TX channels
         if (mMemoryRegistered) {
             auto &memMgr = RmtMemoryManager::instance();
@@ -602,6 +618,36 @@ class RmtRxChannelImpl : public RmtRxChannel {
     }
 
     bool begin(const RxConfig &config) FL_NOEXCEPT override {
+        // If the DMA setting changed on an already-created channel, we have to
+        // tear it down — ESP-IDF bakes `flags.with_dma` into the channel at
+        // rmt_new_rx_channel() time, so toggling on a later begin() is a no-op
+        // unless we rebuild. Also release the shared DMA slot and any DRAM
+        // capture buffer so first-time init below allocates cleanly.
+        if (mChannel && config.use_dma != mUseDma) {
+            FL_WARN("[RMT RX] use_dma changed ("
+                    << (mUseDma ? "true" : "false") << " -> "
+                    << (config.use_dma ? "true" : "false")
+                    << ") - rebuilding channel");
+            rmt_disable(mChannel);
+            rmt_del_channel(mChannel);
+            mChannel = nullptr;
+            if (mDmaAllocated) {
+                auto &memMgr = RmtMemoryManager::instance();
+                memMgr.freeDMA(mMemoryChannelId, false);
+                mDmaAllocated = false;
+            }
+            if (mMemoryRegistered) {
+                auto &memMgr = RmtMemoryManager::instance();
+                memMgr.free(mMemoryChannelId, false);
+                mMemoryRegistered = false;
+            }
+            if (mDmaCapableBuffer) {
+                heap_caps_free(mDmaCapableBuffer);
+                mDmaCapableBuffer = nullptr;
+                mDmaCapableBufferSize = 0;
+            }
+        }
+
         // Validate and extract hardware parameters on first call
         if (!mChannel) {
             // First-time initialization - extract hardware parameters from
@@ -627,6 +673,7 @@ class RmtRxChannelImpl : public RmtRxChannel {
         mSkipCounter = config.skip_signals;
         mStartLow = config.start_low;
         mIoLoopBack = config.io_loop_back;
+        mUseDma = config.use_dma;
 
         FL_LOG_RX("RX begin: signal_range_min="
                << mSignalRangeMinNs
@@ -650,9 +697,16 @@ class RmtRxChannelImpl : public RmtRxChannel {
                 return false;
             }
 
-            // Handle skip phase using small discard buffer
-            if (!handleSkipPhase()) {
-                return false;
+            // In non-DMA mode, skip_signals must be drained via a synchronous
+            // pre-capture loop because the receiver only fires one callback per
+            // rmt_receive() in non-DMA mode. In DMA streaming mode the ISR
+            // filters skip chunks inline as they arrive, so no pre-capture
+            // drain is needed (and would deadlock waiting for a TX that hasn't
+            // started yet).
+            if (!mUseDma) {
+                if (!handleSkipPhase()) {
+                    return false;
+                }
             }
 
             // Allocate buffer and arm receiver for actual capture
@@ -672,7 +726,13 @@ class RmtRxChannelImpl : public RmtRxChannel {
         rx_config.gpio_num = mPin;
         rx_config.clk_src = RMT_CLK_SRC_DEFAULT;
         rx_config.resolution_hz = mResolutionHz;
-        rx_config.mem_block_symbols = 64; // Use 64 symbols per memory block
+        // mem_block_symbols: non-DMA = hardware RMT memory block (small, ~64);
+        // DMA = DRAM ping-pong buffer size (ESP-IDF fires the ISR per half).
+        // For streaming DMA mode we want a larger chunk size so each partial-rx
+        // callback delivers meaningful work but not so large that allocation
+        // fails. 1024 symbols = 4 KB internal RAM — fits comfortably and gives
+        // ~42 WS2812B LEDs per callback, so a 550-LED capture fires ~13 times.
+        rx_config.mem_block_symbols = mUseDma ? 1024 : 64;
         // Interrupt priority level 3 (maximum supported by ESP-IDF RMT driver
         // API) Note: Both RISC-V and Xtensa platforms are limited to level 3 by
         // driver validation RISC-V hardware supports 1-7, but ESP-IDF
@@ -682,8 +742,15 @@ class RmtRxChannelImpl : public RmtRxChannel {
 
         // Additional flags
         rx_config.flags.invert_in = false; // No signal inversion
-        rx_config.flags.with_dma =
-            false; // Start with non-DMA (universal compatibility)
+        // DMA streaming mode: extends capture past the ~4096-symbol mem-block
+        // cap by firing the ISR on every ping-pong fill. Must be baked in at
+        // rmt_new_rx_channel() time; toggling later requires rebuilding.
+        rx_config.flags.with_dma = mUseDma ? 1 : 0;
+        if (mUseDma) {
+            FL_WARN("[RMT RX] DMA streaming mode requested on GPIO "
+                    << static_cast<int>(mPin)
+                    << " (mem_block_symbols=" << rx_config.mem_block_symbols << ")");
+        }
         // Internal loopback configuration:
         // When io_loop_back=true, RX receives from TX output internally (same GPIO).
         // This is REQUIRED for RMT TX → RMT RX validation on ESP32-S3 because
@@ -703,13 +770,34 @@ class RmtRxChannelImpl : public RmtRxChannel {
             FL_WARN("RMT RX was not pre-registered in constructor - registering now");
             auto &memMgr = RmtMemoryManager::instance();
             mMemoryChannelId = static_cast<u8>(128 + (mPin & 0x7F));
-            auto alloc_result = memMgr.allocateRx(mMemoryChannelId, rx_config.mem_block_symbols, false);
+            // Pass use_dma=true when DMA mode is on so the memory manager
+            // bypasses the on-chip RX pool (DMA uses DRAM). Without this,
+            // larger mem_block_symbols values (e.g., 1024 for DMA) would
+            // exceed ESP32-S3's 192-word dedicated RX pool and fail.
+            auto alloc_result = memMgr.allocateRx(
+                mMemoryChannelId, rx_config.mem_block_symbols, mUseDma);
             if (!alloc_result.ok()) {
                 FL_WARN("RMT RX memory allocation failed for channel "
                         << static_cast<int>(mMemoryChannelId));
                 return false;
             }
             mMemoryRegistered = true;
+        }
+
+        // ESP32-S3 has a single shared DMA slot between RMT TX and RX. Acquire
+        // it here when DMA mode is requested. If the slot is already held by a
+        // TX channel, fall back to non-DMA mode automatically so capture still
+        // works (just with the shorter 4096-symbol cap).
+        if (mUseDma) {
+            auto &memMgr = RmtMemoryManager::instance();
+            if (!memMgr.allocateDMA(mMemoryChannelId, false)) {
+                FL_WARN("[RMT RX] Shared DMA slot unavailable — falling back to non-DMA mode");
+                mUseDma = false;
+                rx_config.flags.with_dma = 0;
+                rx_config.mem_block_symbols = 64;
+            } else {
+                mDmaAllocated = true;
+            }
         }
 
         // Create RX channel
@@ -753,13 +841,17 @@ class RmtRxChannelImpl : public RmtRxChannel {
             return false;
         }
 
-        // Handle skip phase using small discard buffer
-        if (!handleSkipPhase()) {
-            FL_WARN("Failed to handle skip phase in begin()");
-            rmt_disable(mChannel);
-            rmt_del_channel(mChannel);
-            mChannel = nullptr;
-            return false;
+        // Non-DMA mode: drain skip_signals synchronously via a pre-capture
+        // discard receive. DMA streaming mode does the skip filter inline in
+        // the ISR so no pre-capture drain is required (see rxDoneCallback).
+        if (!mUseDma) {
+            if (!handleSkipPhase()) {
+                FL_WARN("Failed to handle skip phase in begin()");
+                rmt_disable(mChannel);
+                rmt_del_channel(mChannel);
+                mChannel = nullptr;
+                return false;
+            }
         }
 
         // Allocate buffer and arm receiver for actual capture
@@ -1131,12 +1223,44 @@ class RmtRxChannelImpl : public RmtRxChannel {
      * partial RX callback
      */
     bool allocateAndArm() FL_NOEXCEPT {
-        constexpr size_t DMA_BUFFER_SIZE =
-            4096; // Larger buffer to reduce callback frequency
-        mInternalBuffer.clear();
-        mInternalBuffer.reserve(DMA_BUFFER_SIZE);
-        for (size_t i = 0; i < DMA_BUFFER_SIZE; i++) {
-            mInternalBuffer.push_back(0);
+        // Per-receive buffer that ESP-IDF writes into. In non-DMA mode this is
+        // sized for a single mem-block fill; in DMA mode ESP-IDF requires the
+        // user buffer to be ≤ mem_block_symbols (the DRAM ping-pong size),
+        // and the ISR streams from it into the accumulation buffer on every
+        // partial-rx callback. The DMA variant MUST live in MALLOC_CAP_DMA |
+        // MALLOC_CAP_INTERNAL memory — a plain fl::vector can land in PSRAM on
+        // ESP32-S3, which ESP-IDF rejects with "user buffer not in the internal
+        // RAM". See issue #2254.
+        constexpr size_t NONDMA_BUFFER_SIZE = 4096;
+        constexpr size_t DMA_BUFFER_SIZE = 1024; // matches mem_block_symbols
+        const size_t hw_buffer_size = mUseDma ? DMA_BUFFER_SIZE : NONDMA_BUFFER_SIZE;
+
+        if (mUseDma) {
+            if (mDmaCapableBuffer && mDmaCapableBufferSize < hw_buffer_size) {
+                heap_caps_free(mDmaCapableBuffer);
+                mDmaCapableBuffer = nullptr;
+                mDmaCapableBufferSize = 0;
+            }
+            if (!mDmaCapableBuffer) {
+                size_t bytes = hw_buffer_size * sizeof(RmtSymbol);
+                mDmaCapableBuffer = static_cast<RmtSymbol *>(
+                    heap_caps_malloc(bytes, MALLOC_CAP_DMA | MALLOC_CAP_INTERNAL));
+                if (!mDmaCapableBuffer) {
+                    FL_WARN("allocateAndArm(): heap_caps_malloc("
+                            << bytes << ", DMA|INTERNAL) failed");
+                    return false;
+                }
+                mDmaCapableBufferSize = hw_buffer_size;
+            }
+            for (size_t i = 0; i < hw_buffer_size; i++) {
+                mDmaCapableBuffer[i] = 0;
+            }
+        } else {
+            mInternalBuffer.clear();
+            mInternalBuffer.reserve(hw_buffer_size);
+            for (size_t i = 0; i < hw_buffer_size; i++) {
+                mInternalBuffer.push_back(0);
+            }
         }
 
         // Allocate accumulation buffer (full user-requested size)
@@ -1148,13 +1272,13 @@ class RmtRxChannelImpl : public RmtRxChannel {
         size_t free_heap = esp_get_free_heap_size();
         size_t max_alloc = free_heap / 4;  // Use at most 25% of free heap
         size_t target_bytes = target_size * sizeof(RmtSymbol);
-        if (target_bytes > max_alloc && max_alloc > DMA_BUFFER_SIZE * sizeof(RmtSymbol)) {
+        if (target_bytes > max_alloc && max_alloc > hw_buffer_size * sizeof(RmtSymbol)) {
             target_size = max_alloc / sizeof(RmtSymbol);
         }
         mAccumulationBuffer.reserve(target_size);
-        // Fall back to DMA buffer size if reserve fails
-        if (mAccumulationBuffer.capacity() < DMA_BUFFER_SIZE) {
-            mAccumulationBuffer.reserve(DMA_BUFFER_SIZE);
+        // Fall back to hw buffer size if reserve fails
+        if (mAccumulationBuffer.capacity() < hw_buffer_size) {
+            mAccumulationBuffer.reserve(hw_buffer_size);
         }
         size_t effective_size = mAccumulationBuffer.capacity();
         if (effective_size < mBufferSize) {
@@ -1166,12 +1290,17 @@ class RmtRxChannelImpl : public RmtRxChannel {
             mAccumulationBuffer.push_back(0);
         }
 
-        FL_LOG_RX("allocateAndArm(): DMA buffer="
-               << DMA_BUFFER_SIZE << " symbols, accumulation buffer="
+        FL_LOG_RX("allocateAndArm(): hw buffer="
+               << hw_buffer_size << " symbols (use_dma="
+               << (mUseDma ? "true" : "false") << "), accumulation buffer="
                << mBufferSize << " symbols");
 
-        // Start receive operation (pass DMA buffer, not accumulation buffer)
-        if (!startReceive(mInternalBuffer.data(), DMA_BUFFER_SIZE)) {
+        // Start receive operation (pass the hardware buffer, not accumulation).
+        // In DMA streaming mode the ISR will fire repeatedly, copying each fill
+        // into the accumulation buffer before the next DMA chunk overwrites.
+        RmtSymbol *hw_buffer = mUseDma ? mDmaCapableBuffer
+                                        : mInternalBuffer.data();
+        if (!startReceive(hw_buffer, hw_buffer_size)) {
             FL_WARN("allocateAndArm(): failed to start receive");
             return false;
         }
@@ -1350,19 +1479,54 @@ class RmtRxChannelImpl : public RmtRxChannel {
         self->mCallbackCount =
             self->mCallbackCount + 1; // Debug: Track callback invocations
         size_t received_count = data->num_symbols;
+        const rmt_symbol_word_t *src = data->received_symbols;
+        size_t src_offset = 0; // symbols consumed by in-stream skip
 
-        // Check if we're in skip phase
+        // In-stream skip (DMA / partial-rx mode).
+        // Old single-shot handleSkipPhase() used mReceiveDone to hand back
+        // control after each 64-symbol drain. In DMA streaming mode the
+        // receiver fires the ISR on every ping-pong fill, and we want to
+        // filter skip chunks inline without terminating the receive op.
+        //
+        //   - Chunk entirely inside skip window → drop whole chunk, continue.
+        //   - Chunk straddles the skip boundary → advance past the skipped
+        //     prefix and copy the remainder into the accumulation buffer.
+        //   - Chunk entirely past the skip window → normal accumulation.
+        //
+        // In non-DMA mode the handleSkipPhase() wrapper still owns the drain
+        // loop (it calls rmt_receive() in a loop, each fill sets is_last).
+        // Preserving the legacy "set mReceiveDone on skip" behavior there so
+        // the host-side while-loop wakes up to submit the next chunk.
         if (self->mSkipCounter > 0) {
-            // Discard received symbols and decrement skip counter
             if (self->mSkipCounter >= received_count) {
+                // Entire chunk discarded
                 self->mSkipCounter -= received_count;
-            } else {
-                self->mSkipCounter = 0;
+                if (!self->mUseDma) {
+                    // Legacy non-DMA path: hand control back to handleSkipPhase
+                    self->mSymbolsReceived = 0;
+                    self->mReceiveDone = true;
+                    return false;
+                }
+                // DMA streaming: do not terminate; wait for next fill
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 3, 0)
+                if (data->flags.is_last) {
+                    self->mReceiveDone = true;
+                }
+#endif
+                return false;
             }
-
-            self->mSymbolsReceived = 0;
-            self->mReceiveDone = true; // Signal completion for skip phase
-            return false;
+            // Partial skip: skip window ends inside this chunk
+            src_offset = self->mSkipCounter;
+            received_count -= self->mSkipCounter;
+            self->mSkipCounter = 0;
+            if (!self->mUseDma) {
+                // Legacy non-DMA path terminates skip phase here; caller will
+                // re-arm for real capture.
+                self->mSymbolsReceived = 0;
+                self->mReceiveDone = true;
+                return false;
+            }
+            // DMA streaming: fall through and accumulate the non-skipped tail
         }
 
         // Capture phase - manually copy from DMA buffer to accumulation buffer
@@ -1384,11 +1548,11 @@ class RmtRxChannelImpl : public RmtRxChannel {
             // after use" linker errors
             RmtSymbol *dest =
                 self->mAccumulationBuffer.data() + self->mAccumulationOffset;
-            const rmt_symbol_word_t *src = data->received_symbols;
+            const rmt_symbol_word_t *src_effective = src + src_offset;
 
             // Copy word-by-word (32-bit aligned, efficient)
             for (size_t i = 0; i < symbols_to_copy; i++) {
-                dest[i] = reinterpret_cast<const RmtSymbol &>(src[i]); // ok reinterpret cast - ISR IRAM context
+                dest[i] = reinterpret_cast<const RmtSymbol &>(src_effective[i]); // ok reinterpret cast - ISR IRAM context
             }
 
             // Update accumulation offset
@@ -1432,6 +1596,10 @@ class RmtRxChannelImpl : public RmtRxChannel {
     bool mStartLow;   ///< Pin idle state: true=LOW (WS2812B), false=HIGH
                       ///< (inverted)
     bool mIoLoopBack; ///< Enable internal RMT loopback (TX→RX on same GPIO)
+    bool mUseDma;     ///< DMA streaming mode (ESP-IDF 5.3+ en_partial_rx)
+    bool mDmaAllocated; ///< True if we hold the shared DMA slot
+    RmtSymbol *mDmaCapableBuffer; ///< DRAM-resident ping-pong buffer for DMA
+    size_t mDmaCapableBufferSize; ///< Capacity in symbols
     fl::vector<RmtSymbol>
         mInternalBuffer; ///< DMA buffer for hardware RX (small, ≤4096 symbols)
     fl::vector<RmtSymbol>

--- a/src/platforms/esp/32/drivers/rmt_rx/rmt_rx_channel.cpp.hpp
+++ b/src/platforms/esp/32/drivers/rmt_rx/rmt_rx_channel.cpp.hpp
@@ -727,12 +727,13 @@ class RmtRxChannelImpl : public RmtRxChannel {
         rx_config.clk_src = RMT_CLK_SRC_DEFAULT;
         rx_config.resolution_hz = mResolutionHz;
         // mem_block_symbols: non-DMA = hardware RMT memory block (small, ~64);
-        // DMA = DRAM ping-pong buffer size (ESP-IDF fires the ISR per half).
-        // For streaming DMA mode we want a larger chunk size so each partial-rx
-        // callback delivers meaningful work but not so large that allocation
-        // fails. 1024 symbols = 4 KB internal RAM — fits comfortably and gives
-        // ~42 WS2812B LEDs per callback, so a 550-LED capture fires ~13 times.
-        rx_config.mem_block_symbols = mUseDma ? 1024 : 64;
+        // DMA = DRAM ping-pong buffer ESP-IDF allocates internally. The driver
+        // fires the partial-rx ISR every `mem_block_symbols` fill, so this is
+        // the per-callback chunk size, not an upper bound on capture length.
+        // Smaller value → more callbacks per transmission (finer streaming);
+        // larger value → less ISR overhead. Keep user buffer ≥ 2× this so
+        // ESP-IDF's partial-rx mode engages (equal size = single-shot).
+        rx_config.mem_block_symbols = mUseDma ? 256 : 64;
         // Interrupt priority level 3 (maximum supported by ESP-IDF RMT driver
         // API) Note: Both RISC-V and Xtensa platforms are limited to level 3 by
         // driver validation RISC-V hardware supports 1-7, but ESP-IDF
@@ -920,8 +921,15 @@ class RmtRxChannelImpl : public RmtRxChannel {
         // Receive completed naturally (spurious symbols already filtered in
         // ISR)
         FL_LOG_RX("wait(): receive done, count=" << mSymbolsReceived);
-        FL_LOG_RX("RMT RX callback count: " << mCallbackCount
-                                          << " (en_partial_rx test)");
+        // Visible (non-FL_DBG) telemetry: lets us see whether en_partial_rx
+        // is actually firing multiple callbacks per transmission on long
+        // streams. mCallbackCount == 1 on a long-stream capture indicates
+        // ESP-IDF ended the receive after one fill (likely due to idle
+        // timeout from signal_range_max_ns). See issue #2254.
+        FL_WARN("[RMT RX] wait(): symbols=" << mSymbolsReceived
+                                          << " callbacks=" << mCallbackCount
+                                          << " use_dma="
+                                          << (mUseDma ? "true" : "false"));
         return RxWaitResult::SUCCESS;
     }
 
@@ -1232,7 +1240,12 @@ class RmtRxChannelImpl : public RmtRxChannel {
         // ESP32-S3, which ESP-IDF rejects with "user buffer not in the internal
         // RAM". See issue #2254.
         constexpr size_t NONDMA_BUFFER_SIZE = 4096;
-        constexpr size_t DMA_BUFFER_SIZE = 1024; // matches mem_block_symbols
+        // DMA user buffer: pass 4× mem_block_symbols (=256) = 1024 symbols so
+        // ESP-IDF's partial-rx fires the ISR every 256-symbol fill, streaming
+        // multiple chunks into accumulation. If user buffer == mem_block_symbols
+        // the driver treats it as single-shot and we get only 1 callback per
+        // rmt_receive() — capping capture at ~4096 symbols (=170 LEDs).
+        constexpr size_t DMA_BUFFER_SIZE = 1024;
         const size_t hw_buffer_size = mUseDma ? DMA_BUFFER_SIZE : NONDMA_BUFFER_SIZE;
 
         if (mUseDma) {

--- a/src/platforms/esp/32/drivers/rmt_rx/rmt_rx_channel.cpp.hpp
+++ b/src/platforms/esp/32/drivers/rmt_rx/rmt_rx_channel.cpp.hpp
@@ -1240,12 +1240,13 @@ class RmtRxChannelImpl : public RmtRxChannel {
         // ESP32-S3, which ESP-IDF rejects with "user buffer not in the internal
         // RAM". See issue #2254.
         constexpr size_t NONDMA_BUFFER_SIZE = 4096;
-        // DMA user buffer: pass 4× mem_block_symbols (=256) = 1024 symbols so
-        // ESP-IDF's partial-rx fires the ISR every 256-symbol fill, streaming
-        // multiple chunks into accumulation. If user buffer == mem_block_symbols
-        // the driver treats it as single-shot and we get only 1 callback per
-        // rmt_receive() — capping capture at ~4096 symbols (=170 LEDs).
-        constexpr size_t DMA_BUFFER_SIZE = 1024;
+        // DMA user buffer: ESP-IDF's partial-rx streams multiple ping-pong
+        // halves through this buffer until the receiver goes idle. Observed
+        // that 1024-symbol buffer capped at 4× reloads = 4096 total symbols,
+        // so bump to 16384 symbols (64 KB DMA|INTERNAL) to cover ~680 WS2812B
+        // LEDs per single rmt_receive(). Ratio user_buf / mem_block_symbols =
+        // 64 gives ESP-IDF plenty of descriptor headroom for streaming.
+        constexpr size_t DMA_BUFFER_SIZE = 16384;
         const size_t hw_buffer_size = mUseDma ? DMA_BUFFER_SIZE : NONDMA_BUFFER_SIZE;
 
         if (mUseDma) {

--- a/src/platforms/esp/32/drivers/rmt_rx/rmt_rx_channel.cpp.hpp
+++ b/src/platforms/esp/32/drivers/rmt_rx/rmt_rx_channel.cpp.hpp
@@ -727,14 +727,14 @@ class RmtRxChannelImpl : public RmtRxChannel {
         rx_config.clk_src = RMT_CLK_SRC_DEFAULT;
         rx_config.resolution_hz = mResolutionHz;
         // mem_block_symbols: non-DMA = hardware RMT memory block (small, ~64);
-        // DMA = DRAM ping-pong buffer ESP-IDF allocates internally. The driver
-        // fires the partial-rx ISR every `mem_block_symbols` fill, so this is
-        // the per-callback chunk size, not an upper bound on capture length.
-        // ESP-IDF's internal capacity check rejects rmt_receive() when the
-        // user buffer exceeds 4 × mem_block_symbols (observed empirically).
-        // Use 1024 so we can pass a 4096-symbol user buffer — enough to
-        // capture ~680 WS2812B LEDs per rmt_receive() via 4 ping-pong wraps.
-        rx_config.mem_block_symbols = mUseDma ? 1024 : 64;
+        // DMA = DRAM ping-pong buffer ESP-IDF allocates internally.
+        // EMPIRICAL FINDING (ESP32-S3, ESP-IDF 5.5): the absolute cap on the
+        // rmt_receive() user buffer is 1024 symbols = 4 KB regardless of
+        // mem_block_symbols. Exceeding this returns ESP_ERR_INVALID_SIZE
+        // ("buffer size exceeds DMA capacity"). Observed total capture per
+        // rmt_receive() is 4× the user buffer via ping-pong wrap (~4096
+        // symbols = 170 WS2812B LEDs). See issue #2254.
+        rx_config.mem_block_symbols = mUseDma ? 256 : 64;
         // Interrupt priority level 3 (maximum supported by ESP-IDF RMT driver
         // API) Note: Both RISC-V and Xtensa platforms are limited to level 3 by
         // driver validation RISC-V hardware supports 1-7, but ESP-IDF
@@ -1254,13 +1254,14 @@ class RmtRxChannelImpl : public RmtRxChannel {
         // ESP32-S3, which ESP-IDF rejects with "user buffer not in the internal
         // RAM". See issue #2254.
         constexpr size_t NONDMA_BUFFER_SIZE = 4096;
-        // DMA user buffer: ESP-IDF rejects rmt_receive() with "buffer size
-        // exceeds DMA capacity" when user_buf > 4 × mem_block_symbols. With
-        // mem_block_symbols = 1024, max accepted buffer is 4096 symbols.
-        // Combined with the observed 4× wrap behavior of partial-rx, each
-        // rmt_receive() captures up to 4 × 4096 = 16384 symbols = ~680
-        // WS2812B LEDs. That covers the 550-LED target with margin.
-        constexpr size_t DMA_BUFFER_SIZE = 4096;
+        // DMA user buffer: capped at 1024 symbols by ESP-IDF on ESP32-S3
+        // (absolute DMA descriptor limit). ESP-IDF fires partial-rx ISR every
+        // mem_block_symbols=256 fill (ping-pong halves); total capture per
+        // rmt_receive() is 4× the user buffer via internal wrap = 4096 symbols
+        // max, same absolute cap as non-DMA mode. Extending past this requires
+        // task-side re-submission which is not yet wired up — the DMA path is
+        // present as groundwork for that future change. See issue #2254.
+        constexpr size_t DMA_BUFFER_SIZE = 1024;
         const size_t hw_buffer_size = mUseDma ? DMA_BUFFER_SIZE : NONDMA_BUFFER_SIZE;
 
         if (mUseDma) {

--- a/src/platforms/esp/32/drivers/rmt_rx/rmt_rx_channel.cpp.hpp
+++ b/src/platforms/esp/32/drivers/rmt_rx/rmt_rx_channel.cpp.hpp
@@ -730,10 +730,11 @@ class RmtRxChannelImpl : public RmtRxChannel {
         // DMA = DRAM ping-pong buffer ESP-IDF allocates internally. The driver
         // fires the partial-rx ISR every `mem_block_symbols` fill, so this is
         // the per-callback chunk size, not an upper bound on capture length.
-        // Smaller value → more callbacks per transmission (finer streaming);
-        // larger value → less ISR overhead. Keep user buffer ≥ 2× this so
-        // ESP-IDF's partial-rx mode engages (equal size = single-shot).
-        rx_config.mem_block_symbols = mUseDma ? 256 : 64;
+        // ESP-IDF's internal capacity check rejects rmt_receive() when the
+        // user buffer exceeds 4 × mem_block_symbols (observed empirically).
+        // Use 1024 so we can pass a 4096-symbol user buffer — enough to
+        // capture ~680 WS2812B LEDs per rmt_receive() via 4 ping-pong wraps.
+        rx_config.mem_block_symbols = mUseDma ? 1024 : 64;
         // Interrupt priority level 3 (maximum supported by ESP-IDF RMT driver
         // API) Note: Both RISC-V and Xtensa platforms are limited to level 3 by
         // driver validation RISC-V hardware supports 1-7, but ESP-IDF
@@ -861,6 +862,19 @@ class RmtRxChannelImpl : public RmtRxChannel {
             rmt_disable(mChannel);
             rmt_del_channel(mChannel);
             mChannel = nullptr;
+            // Release the DMA slot we acquired earlier — otherwise the slot
+            // leaks and subsequent begin() retries report "Shared DMA slot
+            // unavailable" until the RxDevice is destroyed.
+            if (mDmaAllocated) {
+                auto &memMgr = RmtMemoryManager::instance();
+                memMgr.freeDMA(mMemoryChannelId, false);
+                mDmaAllocated = false;
+            }
+            if (mMemoryRegistered) {
+                auto &memMgr = RmtMemoryManager::instance();
+                memMgr.free(mMemoryChannelId, false);
+                mMemoryRegistered = false;
+            }
             return false;
         }
 
@@ -1240,13 +1254,13 @@ class RmtRxChannelImpl : public RmtRxChannel {
         // ESP32-S3, which ESP-IDF rejects with "user buffer not in the internal
         // RAM". See issue #2254.
         constexpr size_t NONDMA_BUFFER_SIZE = 4096;
-        // DMA user buffer: ESP-IDF's partial-rx streams multiple ping-pong
-        // halves through this buffer until the receiver goes idle. Observed
-        // that 1024-symbol buffer capped at 4× reloads = 4096 total symbols,
-        // so bump to 16384 symbols (64 KB DMA|INTERNAL) to cover ~680 WS2812B
-        // LEDs per single rmt_receive(). Ratio user_buf / mem_block_symbols =
-        // 64 gives ESP-IDF plenty of descriptor headroom for streaming.
-        constexpr size_t DMA_BUFFER_SIZE = 16384;
+        // DMA user buffer: ESP-IDF rejects rmt_receive() with "buffer size
+        // exceeds DMA capacity" when user_buf > 4 × mem_block_symbols. With
+        // mem_block_symbols = 1024, max accepted buffer is 4096 symbols.
+        // Combined with the observed 4× wrap behavior of partial-rx, each
+        // rmt_receive() captures up to 4 × 4096 = 16384 symbols = ~680
+        // WS2812B LEDs. That covers the 550-LED target with margin.
+        constexpr size_t DMA_BUFFER_SIZE = 4096;
         const size_t hw_buffer_size = mUseDma ? DMA_BUFFER_SIZE : NONDMA_BUFFER_SIZE;
 
         if (mUseDma) {

--- a/src/platforms/esp/32/drivers/spi/channel_driver_spi.cpp.hpp
+++ b/src/platforms/esp/32/drivers/spi/channel_driver_spi.cpp.hpp
@@ -846,7 +846,14 @@ bool ChannelEngineSpi::reinitSpiHardware(SpiChannelState *state, gpio_num_t pin,
         return false;
     }
 
-    const size_t staging_size = 4096;
+    // Staging buffer sized to fit an entire ~680-LED WS2812B wave8 payload in
+    // one SPI transaction (1 LED = 24 wave8 bytes). With 4096-byte staging,
+    // any strip longer than ~170 LEDs was transmitted as multiple chunks with
+    // a poll()-timing-dependent gap between them — long enough to latch the
+    // first 170 LEDs and leave the rest dark (the "black frame between
+    // displays" bug in #2254). 16384 bytes lets ESP-IDF's SPI DMA descriptor
+    // chain produce continuous output for a single transaction.
+    const size_t staging_size = 16384;
     const size_t spiBufferSize = dataSize * WAVE8_BYTES_PER_COLOR_BYTE;
     state->useDMA = (spiBufferSize > 64);
 
@@ -933,9 +940,15 @@ bool ChannelEngineSpi::createChannel(SpiChannelState *state, gpio_num_t pin,
         return false;
     }
 
-    // Staging buffer size determines max SPI transaction size (chunked transmission)
-    // We use 4KB staging buffers, so max_transfer_sz matches staging capacity
-    const size_t staging_size = 4096;
+    // Staging buffer size determines max SPI transaction size. 16 KB lets a
+    // single ESP-IDF spi_device_queue_trans() produce continuous wave8 output
+    // for up to ~680 WS2812B LEDs. With the earlier 4 KB size, any strip >
+    // ~170 LEDs was split across multiple poll()-driven transactions with
+    // inter-chunk gaps long enough for WS2812B to latch — the "black frame
+    // between displays" bug reported in #2254. 16 KB matches the per-channel
+    // internal-SRAM cost (2× double-buffered = 32 KB) — tight but acceptable
+    // on ESP32-S3 (~320 KB internal SRAM).
+    const size_t staging_size = 16384;
 
     // Determine if we should use DMA
     // Use DMA for larger buffers (>64 bytes)


### PR DESCRIPTION
## Summary

Fixes two root causes together that land as the total fix for issue #2254 Issue 2 (ESP32-S3 SPI driver \"black frame between displays\" on long strips):

### Bug 1 — SPI TX staging buffer too small (the user-facing bug)

`channel_driver_spi.cpp.hpp` hardcoded `staging_size = 4096` bytes. With wave8 encoding at 24 bytes/LED, each SPI transaction held exactly 170 LEDs. Longer strips were split across multiple `spi_device_queue_trans()` calls advanced by the poll() loop. When poll() was preempted (WiFi, websockets, etc.), the SPI line idled long enough for WS2812B to latch → first 170 LEDs locked in the first frame, the rest went to a second partial frame that overwrote them. This is the symptom @ewowi videoed at https://github.com/user-attachments/assets/afe42d51-a635-42a4-a838-bca5b56bfdf9.

**Fix**: `staging_size = 16384` bytes. ESP-IDF's SPI DMA descriptor chain now produces continuous output for up to ~680 LEDs in a single queued transaction — no poll()-dependent gap between chunks.

### Bug 2 — RMT RX user buffer artificially capped (autoresearch harness limit)

Blocked me from seeing Bug 1. ESP-IDF 5.5 caps `rmt_receive()` user buffers at `num_dma_nodes × 4092` bytes where `num_dma_nodes = max(2, mem_block_symbols × 4 / 4095 + 1)` (`rmt_rx.c:210-211` and the check at `:380-381`). With our default `mem_block_symbols=64` that's 8184 bytes = 2046 symbols max.

**Fix**: opt-in DMA RX via `RxConfig::use_dma`. Channel is rebuilt when the flag toggles (ESP-IDF bakes `flags.with_dma` at creation time). `mem_block_symbols=14336` yields 14 DMA nodes and a ~60 KB cap. ISR-side `skip_signals` filter (drops skip chunks inline during partial-rx streaming — no synchronous pre-capture drain). DRAM-backed ping-pong buffer via `heap_caps_malloc(DMA|INTERNAL)` because ESP-IDF rejects PSRAM buffers for DMA.

## Test plan

**On the ESP32-S3 attached here, `bash autoresearch --spi --strip-sizes 550`:**

- [x] Before: `bytes_captured=512, Errors: 0/550 (100.0%)` — false-positive PASS, only first 170 LEDs were ever actually verified due to RX cap + silent truncation
- [x] After: `[RMT RX] wait(): symbols=13200 callbacks=15 use_dma=true; bytes_captured=1650; [Run 1/2] PASS | Errors: 0/550 (100.0%)` — **genuine PASS with all 550 LEDs byte-for-byte verified across 2 frames** (frameCount=2 from #2293 confirms no second-frame degradation).
- [x] 100-LED regression test still PASSes identically.
- [x] No impact on RMT driver loopback path (keeps non-DMA mode).

## Memory impact

- SPI channel: +24 KB internal SRAM (2 × 16 KB staging, up from 2 × 4 KB). Per channel.
- RMT RX DMA mode (opt-in): ~56 KB internal SRAM for `mem_block_symbols=14336` DMA descriptor buffer + 56 KB DRAM user buffer. Only allocated when `RxConfig::use_dma = true`. Autoresearch harness opts in for non-RMT TX paths.

## Files touched

- `src/platforms/esp/32/drivers/spi/channel_driver_spi.cpp.hpp` — staging_size bump (the #2254 user-facing fix).
- `src/fl/rx_device.h` — new `RxConfig::use_dma` field.
- `src/platforms/esp/32/drivers/rmt_rx/rmt_rx_channel.cpp.hpp` — DMA path: channel rebuild, allocateDMA integration, DRAM buffer, streaming ISR skip, telemetry.
- `examples/AutoResearch/AutoResearchTest.cpp` — opt-in DMA RX for non-RMT drivers.

## Related

- Closes the \"Issue 2\" portion of #2254 (SPI incorrect output).
- Complements #2297 (silent-truncation fail-on-break — defense-in-depth for any future RX cap regressions).
- Builds on #2293 (multi-frame `--frames N` — confirms no second-frame degradation once TX is continuous).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added DMA streaming mode option for ESP32 RMT RX channel, enabling alternative capture mechanism.
  * Increased SPI staging buffer capacity from 4KB to 16KB, improving transaction efficiency and reducing payload fragmentation.

* **Tests**
  * Updated test configuration to validate DMA streaming mode support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->