### PR TITLE
feat(audio): silence gate foundations — Context::isSilent() + SilenceEnvelope (#2253)

### DIFF
--- a/docs/audio_silence_gate_design.md
+++ b/docs/audio_silence_gate_design.md
@@ -1,0 +1,148 @@
+# Audio Silence Gate — Design
+
+**Status:** Design approved, Phase 1 in progress
+**Tracks:** [FastLED #2253](https://github.com/FastLED/FastLED/issues/2253) — volume not returning to zero in silence
+**Scope:** `src/fl/audio/` — `Vibe`, `Reactive` (dominant freq / magnitude / flux), `TempoAnalyzer`
+
+## Problem
+
+FastLED's audio-reactive metrics do not return to zero when audio input stops:
+
+- `Vibe::getVol()` converges to **1.0** during silence (MilkDrop self-normalization — `mImm / mLongAvg → noise / noise → 1.0`, and the `< 0.001f` clamp in `vibe.cpp.hpp:86-88` hard-codes `mImmRel = 1.0f`).
+- `Reactive::Data::volume` decays but takes ~2 s because `EnergyAnalyzer::mRunningMaxFilter` has a 2 s decay tau and a hard floor of 1.0 on the denominator.
+- `Reactive::Data::dominantFrequency` / `magnitude` / `spectralFlux` are instantaneous FFT reads with **no decay** — they lock onto whatever FFT bin is strongest (usually numerical noise) during silence.
+- `TempoAnalyzer::mCurrentBPM` is updated only on onset detection → **persists unchanged** through silence.
+
+Root cause: the pipeline already computes a high-quality silence signal (`NoiseFloorTracker::isAboveFloor()` at `noise_floor_tracker.h:95`) but its output is never consumed by any detector. The tracker is orphaned.
+
+## Approach — two cooperating layers
+
+### Layer 1: Silence flag in Context (plumbing)
+
+One boolean field on `audio::Context` populated by `Processor`/`Reactive` from `NoiseFloorTracker::isAboveFloor()`. This gives every detector a zero-cost, frame-wide signal-quality signal without refactoring detector interfaces.
+
+```cpp
+// audio_context.h — new methods
+void setSilent(bool silent) FL_NOEXCEPT { mIsSilent = silent; }
+bool isSilent() const FL_NOEXCEPT { return mIsSilent; }
+
+// audio_processor.cpp.hpp — after NoiseFloorTracker.update()
+if (mNoiseFloorTrackingEnabled && conditioned.isValid()) {
+    mNoiseFloorTracker.update(conditioned.rms());
+    mContext->setSilent(!mNoiseFloorTracker.isAboveFloor(conditioned.rms()));
+} else {
+    mContext->setSilent(false);  // tracking disabled → never claim silence
+}
+```
+
+Default behavior preserved: `mNoiseFloorTrackingEnabled` stays `false` by default, so `isSilent()` returns `false` for existing users who haven't opted in. Silence gating is a user opt-in via `Processor::enableNoiseFloorTracker(true)` or the equivalent `ReactiveConfig`.
+
+### Layer 2: `SilenceEnvelope` — reusable decay helper
+
+A small composable class that detectors embed to translate the boolean flag into smooth per-metric decay. This preserves detector algorithm integrity (MilkDrop math stays MilkDrop math during audio) and gives each detector a tuned decay rate.
+
+```cpp
+class SilenceEnvelope {
+public:
+    struct Config {
+        float decayTauSeconds = 0.5f;   // Time constant for decay-to-zero
+        float targetValue = 0.0f;       // What to decay toward (usually 0)
+    };
+
+    SilenceEnvelope() FL_NOEXCEPT;
+    explicit SilenceEnvelope(const Config& cfg) FL_NOEXCEPT;
+    void configure(const Config& cfg) FL_NOEXCEPT;
+
+    // Pass-through during audio; exponential decay to targetValue during silence.
+    float update(bool isSilent, float currentValue, float dt) FL_NOEXCEPT;
+
+    // Snap to a fresh value (called on re-attack or reset)
+    void reset(float initialValue = 0.0f) FL_NOEXCEPT;
+
+    // True once the envelope has decayed to within epsilon of target
+    bool isGated(float epsilon = 1e-4f) const FL_NOEXCEPT;
+};
+```
+
+Semantics:
+- `!isSilent` → return `currentValue` unchanged, cache it as the last live value
+- `isSilent && |lastLive| > epsilon` → exponentially decay the cached value toward `targetValue` with rate `exp(-dt / decayTauSeconds)`
+- On silence→audio transition, snap back to the fresh `currentValue` (no attack lag — users want beats to hit hard)
+
+## Phase-by-phase plan
+
+### Phase 1 — foundations (parallelizable)
+
+| ID  | Scope | Files | LOC | Blocks | Blocked by |
+|-----|-------|-------|-----|--------|-----------|
+| PR-A | Silence flag on Context + Processor/Reactive populate it | `audio_context.h/.cpp.hpp`, `audio_processor.cpp.hpp`, `audio_reactive.cpp.hpp`, new test | ~60 | C, D, E | — |
+| PR-B | `SilenceEnvelope` class + unit tests | `silence_envelope.h/.cpp.hpp`, new test, `_build.cpp.hpp` | ~120 | C, D, E | — |
+
+**PR-A and PR-B touch disjoint files — can ship in parallel (same branch, different commits, or independent branches).**
+
+### Phase 2 — adoption (parallelizable, after Phase 1)
+
+| ID  | Scope | Files | LOC | Blocked by |
+|-----|-------|-------|-----|-----------|
+| PR-C | Vibe adopts silence gate (fixes user-visible `getVol()` → 1.0 bug) | `vibe.h`, `vibe.cpp.hpp`, test | ~60 | A, B |
+| PR-D | Reactive adopts: `dominantFrequency`, `magnitude`, `spectralFlux` gate | `audio_reactive.cpp.hpp`, test | ~40 | A, B |
+| PR-E | TempoAnalyzer adopts BPM fast-decay (tau ~2 s) | `tempo_analyzer.cpp.hpp`, test | ~50 | A, B |
+
+**PR-C/D/E touch disjoint detector files — can ship in parallel once A + B land.**
+
+## API additions (full detail)
+
+### `audio::Context`
+```cpp
+void setSilent(bool silent) FL_NOEXCEPT;
+bool isSilent() const FL_NOEXCEPT;
+```
+- Default state is `false` (no silence claim).
+- Cleared to `false` on `setSample()` (per-frame reset — Processor/Reactive must re-populate after NFT update).
+
+### `audio::SilenceEnvelope` (new)
+See Layer 2 above. Lives in `src/fl/audio/silence_envelope.{h,cpp.hpp}`. Added to `src/fl/audio/_build.cpp.hpp` unity include. Unit test at `tests/fl/audio/silence_envelope.cpp`.
+
+### No breaking changes
+- All existing getters unchanged.
+- Default behavior unchanged for users who haven't enabled `NoiseFloorTracker`.
+- New behavior is strictly additive — silence gate kicks in only when (a) NFT enabled AND (b) detector adopts `SilenceEnvelope`.
+
+## Testing strategy
+
+### Per-layer unit tests
+
+- **Context silence flag**: feed a sample, assert `isSilent()` returns what `setSilent()` set; assert `setSample()` resets to false.
+- **SilenceEnvelope**:
+  - Pass-through during audio (flag=false, returns currentValue)
+  - Exponential decay during silence to tau within 5% at `3 * decayTauSeconds`
+  - Snap-back on silence→audio transition (no attack lag)
+  - `isGated()` returns true once decayed below epsilon
+
+### Integration tests (Phase 2)
+
+- **Vibe silence test**: drive Vibe with 1 s of 440 Hz sine, then 3 s of true silence. Assert `getVol()` crosses below 0.01 within 1 s of silence start.
+- **Reactive spectral silence test**: same drive pattern. Assert `dominantFrequency == 0.0f` and `magnitude == 0.0f` after 1 s silence.
+- **BPM decay test**: drive TempoAnalyzer with a 120 BPM click track for 5 s, then silence. Assert BPM confidence → 0 within 3 s.
+
+### Regression tests
+
+- All existing audio tests must still pass unchanged (no breaking API).
+- `deficiencies.cpp` (the TDD-style test file for known issues) gets three new entries that were previously failing and now pass.
+
+## Risks & open questions
+
+- **Default NFT off**: if users don't enable NFT, silence gate does nothing. Should we flip NFT on by default after this lands? *Decision: defer to a separate PR with benchmarks showing no perf regression. Silence gate is opt-in for v1.*
+- **SilenceEnvelope decay tau per detector**: Vibe wants ~0.5 s (fast, matches visual expectation). BPM wants ~2 s (musical tempo lingers naturally). Spectral wants ~0.2 s (FFT noise floor is brittle). These are tunable constants; initial values chosen by ear, may need tuning after user feedback.
+- **Interaction with signal conditioner noise gate**: the conditioner already zeros PCM below RMS 300. If the conditioner gates aggressively, detectors see zero PCM → RMS drops → NFT sees silence → flag goes high. Consistent. No conflict.
+- **Reactive's own NFT instance**: Reactive has its own `mNoiseFloorTracker` separate from `Processor`'s. Both paths need to populate the Context silence flag. Done in both `Processor::update()` and `Reactive::processSample()`.
+
+## Out of scope
+
+- Unified volume concept (`AudioLevel` struct replacing all volume getters) — considered and rejected as too churn-heavy; preserved as Option 2 in the discussion. Can be layered on top later if demand emerges.
+- Subscriber / event model on `NoiseFloorTracker` (Option 5) — Silence detector already fires transition events; no need to duplicate.
+- Signal conditioner changes.
+
+## Revision history
+
+- 2026-04-18: Initial draft (Claude, for zackees)

--- a/src/fl/audio/_build.cpp.hpp
+++ b/src/fl/audio/_build.cpp.hpp
@@ -13,6 +13,7 @@
 #include "fl/audio/frequency_bin_mapper.cpp.hpp"
 #include "fl/audio/noise_floor_tracker.cpp.hpp"
 #include "fl/audio/signal_conditioner.cpp.hpp"
+#include "fl/audio/silence_envelope.cpp.hpp"
 #include "fl/audio/spectral_equalizer.cpp.hpp"
 #include "fl/audio/synth.cpp.hpp"
 

--- a/src/fl/audio/audio_context.cpp.hpp
+++ b/src/fl/audio/audio_context.cpp.hpp
@@ -157,6 +157,8 @@ void Context::setSample(const Sample& sample) {
     mSample = sample;
     // Clear per-frame fft::FFT cache (new sample = new data)
     mFFTCache.clear();
+    // Reset silence flag — pipeline must re-populate after NFT update this frame.
+    mIsSilent = false;
 }
 
 void Context::clearCache() {

--- a/src/fl/audio/audio_context.h
+++ b/src/fl/audio/audio_context.h
@@ -58,6 +58,16 @@ public:
     void setSampleRate(int sampleRate) FL_NOEXCEPT { mSampleRate = sampleRate; }
     int getSampleRate() const FL_NOEXCEPT { return mSampleRate; }
 
+    // ----- Silence Flag -----
+    // Populated per-frame by the pipeline owner (Processor / Reactive) from
+    // NoiseFloorTracker::isAboveFloor(). Detectors read this to gate their
+    // outputs during silence. Default false — detectors that check this flag
+    // simply won't gate if the pipeline hasn't enabled noise-floor tracking.
+    // Reset to false on each setSample(); callers must re-populate after their
+    // NoiseFloorTracker.update() call.
+    void setSilent(bool silent) FL_NOEXCEPT { mIsSilent = silent; }
+    bool isSilent() const FL_NOEXCEPT { return mIsSilent; }
+
     // ----- Update & Reset -----
     void setSample(const Sample& sample) FL_NOEXCEPT;
     void clearCache() FL_NOEXCEPT;
@@ -82,6 +92,7 @@ private:
     vector<fft::Bins> mFFTHistory;
     int mFFTHistoryDepth = 0;
     int mFFTHistoryIndex = 0;
+    bool mIsSilent = false;
 };
 
 /// Compute the time delta (in seconds) for an audio buffer.

--- a/src/fl/audio/audio_processor.cpp.hpp
+++ b/src/fl/audio/audio_processor.cpp.hpp
@@ -60,6 +60,13 @@ void Processor::update(const Sample& sample) {
 
     mContext->setSample(conditioned);
 
+    // Stage 4: Silence flag — detectors use this to gate outputs when audio stops.
+    // Only populated when NFT is enabled; otherwise silence is unknowable and
+    // stays at its default (false) after setSample() above.
+    if (mNoiseFloorTrackingEnabled && conditioned.isValid()) {
+        mContext->setSilent(!mNoiseFloorTracker.isAboveFloor(conditioned.rms()));
+    }
+
     // Phase 1: Compute state for all active detector
     for (auto& d : mActiveDetectors) {
         d->update(mContext);

--- a/src/fl/audio/audio_reactive.cpp.hpp
+++ b/src/fl/audio/audio_reactive.cpp.hpp
@@ -175,6 +175,12 @@ void Reactive::processSample(const Sample& sample) {
     // Set conditioned sample on shared Context (clears per-frame FFT cache)
     mContext->setSample(processedSample);
 
+    // Populate silence flag after setSample() resets it — detectors run via
+    // updateFromContext() below and will read context->isSilent().
+    if (mConfig.enableNoiseFloorTracking) {
+        mContext->setSilent(!mNoiseFloorTracker.isAboveFloor(processedSample.rms()));
+    }
+
     // Process the conditioned Sample - timing is gated by sample availability
     processFFT(processedSample);
 

--- a/src/fl/audio/silence_envelope.cpp.hpp
+++ b/src/fl/audio/silence_envelope.cpp.hpp
@@ -1,0 +1,45 @@
+#pragma once
+
+#include "fl/audio/silence_envelope.h"
+#include "fl/math/math.h"
+
+namespace fl {
+namespace audio {
+
+SilenceEnvelope::SilenceEnvelope() FL_NOEXCEPT : mConfig{}, mCurrent(0.0f) {}
+
+SilenceEnvelope::SilenceEnvelope(const Config& cfg) FL_NOEXCEPT
+    : mConfig(cfg), mCurrent(cfg.targetValue) {}
+
+float SilenceEnvelope::update(bool isSilent, float currentValue, float dt) FL_NOEXCEPT {
+    if (!isSilent) {
+        // Pass-through during audio; cache for decay if silence starts next frame.
+        mCurrent = currentValue;
+        return mCurrent;
+    }
+
+    // During silence — exponential decay toward target with time constant tau.
+    // alpha = 1 - exp(-dt/tau) gives a proper first-order response independent
+    // of dt. At dt=tau, alpha ≈ 0.632; at dt=3*tau, we've crossed 95% of the way.
+    if (mConfig.decayTauSeconds <= 0.0f || dt <= 0.0f) {
+        // No decay time or zero dt → snap to target immediately.
+        mCurrent = mConfig.targetValue;
+        return mCurrent;
+    }
+    const float alpha = 1.0f - fl::expf(-dt / mConfig.decayTauSeconds);
+    mCurrent = mCurrent + (mConfig.targetValue - mCurrent) * alpha;
+    return mCurrent;
+}
+
+void SilenceEnvelope::reset(float initialValue) FL_NOEXCEPT {
+    mCurrent = initialValue;
+}
+
+bool SilenceEnvelope::isGated(float epsilon) const FL_NOEXCEPT {
+    float delta = mCurrent - mConfig.targetValue;
+    if (delta < 0.0f) delta = -delta;
+    return delta <= epsilon;
+}
+
+} // namespace audio
+} // namespace fl

--- a/src/fl/audio/silence_envelope.h
+++ b/src/fl/audio/silence_envelope.h
@@ -1,0 +1,58 @@
+// SilenceEnvelope — decay-to-target helper for silence gating.
+//
+// Detectors compose a SilenceEnvelope into their update() to translate the
+// boolean `Context::isSilent()` flag into a smooth per-metric decay. During
+// audio the envelope is a pass-through; during silence it exponentially
+// decays the cached value toward `targetValue`. On silence→audio transition
+// it snaps back to the fresh value so beats hit hard with zero attack lag.
+//
+// Example:
+//   SilenceEnvelope env;                 // default tau = 0.5s, target = 0
+//   float vol = env.update(context->isSilent(), rawVol, dt);
+
+#pragma once
+
+#include "fl/stl/noexcept.h"
+
+namespace fl {
+namespace audio {
+
+class SilenceEnvelope {
+public:
+    struct Config {
+        // Time constant for exponential decay toward targetValue during silence.
+        // After ~3*decayTauSeconds the envelope is within 5% of target.
+        float decayTauSeconds = 0.5f;
+        // Value the envelope decays toward during silence (usually 0).
+        float targetValue = 0.0f;
+    };
+
+    SilenceEnvelope() FL_NOEXCEPT;
+    explicit SilenceEnvelope(const Config& cfg) FL_NOEXCEPT;
+
+    void configure(const Config& cfg) FL_NOEXCEPT { mConfig = cfg; }
+
+    // Pass-through when !isSilent (returns currentValue, caches it internally).
+    // Exponential decay toward Config::targetValue when isSilent. Snaps back
+    // to currentValue on silence→audio transition so re-attack has no lag.
+    // `dt` is seconds since last call; use computeAudioDt() from audio_context.h.
+    float update(bool isSilent, float currentValue, float dt) FL_NOEXCEPT;
+
+    // Snap the envelope to `initialValue` (used on reset or explicit jumps).
+    void reset(float initialValue = 0.0f) FL_NOEXCEPT;
+
+    // True once the envelope has decayed to within `epsilon` of targetValue.
+    bool isGated(float epsilon = 1e-4f) const FL_NOEXCEPT;
+
+    // Current envelope output (last value returned by update()).
+    float value() const FL_NOEXCEPT { return mCurrent; }
+
+    const Config& config() const FL_NOEXCEPT { return mConfig; }
+
+private:
+    Config mConfig;
+    float mCurrent = 0.0f;
+};
+
+} // namespace audio
+} // namespace fl

--- a/tests/fl/audio.cpp
+++ b/tests/fl/audio.cpp
@@ -20,6 +20,7 @@ FL_TEST_CASE("Audio - Test registration works") {
 #include "tests/fl/audio/frequency_bin_mapper.hpp"
 #include "tests/fl/audio/noise_floor_tracker.hpp"
 #include "tests/fl/audio/signal_conditioner.hpp"
+#include "tests/fl/audio/silence_envelope.hpp"
 #include "tests/fl/audio/spectral_equalizer.hpp"
 #include "tests/fl/audio/synth.hpp"
 #include "tests/fl/audio/detector/equalizer.hpp"

--- a/tests/fl/audio/audio_context.hpp
+++ b/tests/fl/audio/audio_context.hpp
@@ -161,3 +161,25 @@ FL_TEST_CASE("audio::Context - new sample produces fresh audio::fft::FFT data") 
     }
     FL_CHECK_GT(secondMaxBin, 100.0f);
 }
+
+FL_TEST_CASE("audio::Context - silence flag") {
+    audio::Sample sample = makeSineAudioSample(440.0f, 1000);
+    audio::Context ctx(sample);
+
+    // Default: no silence claim until pipeline populates the flag.
+    FL_CHECK_FALSE(ctx.isSilent());
+
+    // Pipeline owner (Processor/Reactive) sets it after NFT update.
+    ctx.setSilent(true);
+    FL_CHECK(ctx.isSilent());
+
+    // Next frame — setSample() must reset the flag so a stale claim can't
+    // survive a frame where NFT is disabled or the pipeline forgot to populate.
+    audio::Sample sample2 = makeSineAudioSample(880.0f, 2000);
+    ctx.setSample(sample2);
+    FL_CHECK_FALSE(ctx.isSilent());
+
+    // And re-populating works after setSample.
+    ctx.setSilent(true);
+    FL_CHECK(ctx.isSilent());
+}

--- a/tests/fl/audio/silence_envelope.hpp
+++ b/tests/fl/audio/silence_envelope.hpp
@@ -1,0 +1,103 @@
+// Unit tests for fl::audio::SilenceEnvelope
+
+#include "fl/audio/silence_envelope.h"
+#include "fl/math/math.h"
+
+using namespace fl;
+
+FL_TEST_CASE("audio::SilenceEnvelope - pass-through during audio") {
+    audio::SilenceEnvelope env;
+    // Default config: tau=0.5s, target=0. During audio (isSilent=false) the
+    // envelope must return currentValue unchanged regardless of tau.
+    FL_CHECK_EQ(env.update(false, 0.7f, 0.016f), 0.7f);
+    FL_CHECK_EQ(env.update(false, 1.2f, 0.016f), 1.2f);
+    FL_CHECK_EQ(env.update(false, -0.3f, 0.016f), -0.3f);
+    // Cached value tracks the last audio sample.
+    FL_CHECK_EQ(env.value(), -0.3f);
+}
+
+FL_TEST_CASE("audio::SilenceEnvelope - exponential decay toward target") {
+    audio::SilenceEnvelope::Config cfg;
+    cfg.decayTauSeconds = 0.5f;
+    cfg.targetValue = 0.0f;
+    audio::SilenceEnvelope env(cfg);
+
+    // Seed with a value from "audio" frame, then go silent.
+    env.update(false, 1.0f, 0.016f);
+    FL_CHECK_EQ(env.value(), 1.0f);
+
+    // After one full tau of silence, envelope should be within ~37% of start.
+    // We integrate in small steps (16ms ≈ 60fps) and check the curve.
+    float dt = 0.016f;
+    // Run for 0.5s (= 1 tau).
+    for (int i = 0; i < 31; ++i) { env.update(true, 0.0f, dt); }
+    // At 1*tau with target=0 the envelope should be near exp(-1) ≈ 0.368.
+    FL_CHECK_GT(env.value(), 0.30f);
+    FL_CHECK_LT(env.value(), 0.45f);
+
+    // Run another 1s (total 3*tau). Should be within 5% of target (0).
+    for (int i = 0; i < 63; ++i) { env.update(true, 0.0f, dt); }
+    FL_CHECK_LT(env.value(), 0.05f);
+}
+
+FL_TEST_CASE("audio::SilenceEnvelope - snap-back on silence-to-audio transition") {
+    // Tight tau so the envelope truly converges within epsilon in the test time.
+    audio::SilenceEnvelope::Config cfg;
+    cfg.decayTauSeconds = 0.1f;
+    cfg.targetValue = 0.0f;
+    audio::SilenceEnvelope env(cfg);
+
+    // Drive to zero via silence.
+    env.update(false, 1.0f, 0.016f);
+    for (int i = 0; i < 200; ++i) { env.update(true, 0.0f, 0.016f); }
+    FL_CHECK(env.isGated());
+
+    // Audio returns — a beat hits with value 2.0. Envelope must NOT apply
+    // any attack lag; it must pass through immediately.
+    FL_CHECK_EQ(env.update(false, 2.0f, 0.016f), 2.0f);
+    FL_CHECK_FALSE(env.isGated());
+}
+
+FL_TEST_CASE("audio::SilenceEnvelope - isGated threshold") {
+    audio::SilenceEnvelope env;
+    env.reset(1.0f);
+    FL_CHECK_FALSE(env.isGated());
+
+    env.reset(0.00005f);
+    FL_CHECK(env.isGated());   // below default epsilon 1e-4
+
+    env.reset(0.002f);
+    FL_CHECK_FALSE(env.isGated(1e-4f));
+    FL_CHECK(env.isGated(0.01f)); // larger epsilon accepts
+}
+
+FL_TEST_CASE("audio::SilenceEnvelope - non-zero target value") {
+    audio::SilenceEnvelope::Config cfg;
+    cfg.decayTauSeconds = 0.2f;
+    cfg.targetValue = 0.5f;
+    audio::SilenceEnvelope env(cfg);
+
+    env.update(false, 1.0f, 0.016f);   // live value = 1.0
+    for (int i = 0; i < 125; ++i) { env.update(true, 0.0f, 0.016f); }  // 2s = 10*tau
+    // Well past 10*tau → converged to targetValue 0.5.
+    FL_CHECK_GT(env.value(), 0.49f);
+    FL_CHECK_LT(env.value(), 0.51f);
+}
+
+FL_TEST_CASE("audio::SilenceEnvelope - reset with initial value") {
+    audio::SilenceEnvelope env;
+    env.update(false, 42.0f, 0.016f);
+    env.reset(7.0f);
+    FL_CHECK_EQ(env.value(), 7.0f);
+}
+
+FL_TEST_CASE("audio::SilenceEnvelope - zero tau snaps to target immediately") {
+    audio::SilenceEnvelope::Config cfg;
+    cfg.decayTauSeconds = 0.0f;
+    cfg.targetValue = 0.0f;
+    audio::SilenceEnvelope env(cfg);
+
+    env.update(false, 1.0f, 0.016f);
+    env.update(true, 0.0f, 0.016f);
+    FL_CHECK_EQ(env.value(), 0.0f);
+}


### PR DESCRIPTION
## Summary

Phase 1 of the fix for #2253 (audio volume not returning to zero in silence). Lays the architectural groundwork; no user-visible behavior change yet — Phase 2 PRs will adopt this in Vibe, Reactive spectral metrics, and TempoAnalyzer.

See [`docs/audio_silence_gate_design.md`](./docs/audio_silence_gate_design.md) for the full design.

Two commits, each a self-contained unit:

### 1. `Context::isSilent()` plumbing
- New `setSilent`/`isSilent` on `audio::Context` (default `false`, cleared on `setSample()`)
- `Processor::update()` and `Reactive::processSample()` populate it from `NoiseFloorTracker::isAboveFloor()` after the existing NFT update
- No behavior change for users who haven't enabled NFT — `isSilent()` stays `false`

### 2. `SilenceEnvelope` helper class
- Composable decay-to-target helper: pass-through during audio, exponential decay during silence, snap-back on re-attack (zero attack lag — beats must hit hard)
- Frame-rate-independent (`alpha = 1 - exp(-dt/tau)`)
- Unit tests cover pass-through, decay curve, snap-back, `isGated` threshold, non-zero targets, degenerate `tau=0`

## Why architecture-first

The survey (see design doc §Problem) found `NoiseFloorTracker` was already computing high-quality silence info but *nothing read it*. Phase 1 plugs that orphaned infrastructure into a shared bus (`Context`) and ships a reusable primitive so Phase 2 can be three small, parallelizable adoption PRs instead of three one-off patches.

## Test plan

- [x] `bash test fl_audio --debug` — 211 tests pass under ASAN/UBSAN
- [x] `bash lint` on all touched files — clean
- [ ] Phase 2 adoption: Vibe (PR-C), Reactive spectral metrics (PR-D), TempoAnalyzer (PR-E) — will reference this PR

## Non-goals (explicitly out of scope)

- Unified `AudioLevel` value type (considered — rejected as too churn-heavy for a bug fix; can layer on later)
- Flipping NFT on by default (deferred to a separate PR with benchmarks)
- Changes to signal conditioner

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added audio silence-gating infrastructure with smooth exponential decay during silent periods to improve detector behavior when audio is quiet.

* **Tests**
  * Added unit tests validating silence-detection and smooth envelope decay behavior.

* **Documentation**
  * Added design documentation for the audio silence-gating approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->