### PR TITLE
feat(audio): Reactive spectral metrics gate in silence (#2253)

### DIFF
--- a/src/fl/audio/audio_reactive.cpp.hpp
+++ b/src/fl/audio/audio_reactive.cpp.hpp
@@ -24,6 +24,15 @@ Reactive::Reactive()
     for (fl::size i = 0; i < mPreviousMagnitudes.size(); ++i) {
         mPreviousMagnitudes[i] = 0.0f;
     }
+
+    // Configure spectral silence envelopes — tau=0.2s chosen because FFT noise
+    // floor is brittle; these metrics should snap to zero quickly in silence.
+    SilenceEnvelope::Config envCfg;
+    envCfg.decayTauSeconds = 0.2f;
+    envCfg.targetValue = 0.0f;
+    mDominantFrequencyEnvelope.configure(envCfg);
+    mMagnitudeEnvelope.configure(envCfg);
+    mSpectralFluxEnvelope.configure(envCfg);
 }
 
 Reactive::~Reactive() FL_NOEXCEPT = default;
@@ -131,6 +140,11 @@ void Reactive::begin(const ReactiveConfig& config) {
         mPreviousMagnitudes[i] = 0.0f;
     }
 
+    // Reset silence envelopes for spectral metrics.
+    mDominantFrequencyEnvelope.reset(0.0f);
+    mMagnitudeEnvelope.reset(0.0f);
+    mSpectralFluxEnvelope.reset(0.0f);
+
     // Update Context sample rate
     mContext->setSampleRate(config.sampleRate);
 
@@ -210,6 +224,26 @@ void Reactive::processSample(const Sample& sample) {
     applyAWeighting();
 
     updateSpectralFlux();
+
+    // Silence gate for spectral metrics (FastLED#2253).
+    // During audio the envelopes are pass-through; during silence they
+    // exponentially decay (tau=0.2s) the raw argmax / flux outputs toward
+    // zero so the FFT noise floor cannot lock onto arbitrary bins.
+    // dt is the exact audio duration of this PCM buffer (frame-rate
+    // independent). When enableNoiseFloorTracking is false, isSilent()
+    // is always false, making this a strict pass-through (no behavior
+    // change for users who haven't opted in).
+    {
+        const bool silent = mContext->isSilent();
+        const float dt = computeAudioDt(processedSample.pcm().size(),
+                                        mConfig.sampleRate);
+        mCurrentData.dominantFrequency = mDominantFrequencyEnvelope.update(
+            silent, mCurrentData.dominantFrequency, dt);
+        mCurrentData.magnitude = mMagnitudeEnvelope.update(
+            silent, mCurrentData.magnitude, dt);
+        mCurrentData.spectralFlux = mSpectralFluxEnvelope.update(
+            silent, mCurrentData.spectralFlux, dt);
+    }
 
     // Enhanced beat detection (includes original)
     detectBeat(currentTimeMs);

--- a/src/fl/audio/audio_reactive.h
+++ b/src/fl/audio/audio_reactive.h
@@ -7,6 +7,7 @@
 #include "fl/audio/signal_conditioner.h"
 #include "fl/audio/noise_floor_tracker.h"
 #include "fl/audio/frequency_bin_mapper.h"
+#include "fl/audio/silence_envelope.h"
 #include "fl/audio/spectral_equalizer.h"
 #include "fl/stl/array.h"
 #include "fl/stl/span.h"
@@ -278,6 +279,16 @@ private:
 
     // Enhanced beat detection state
     fl::array<float, 16> mPreviousMagnitudes;
+
+    // Silence-gate envelopes for spectral metrics (FastLED#2253).
+    // During silence (Context::isSilent() true), these fast-decay the
+    // dominantFrequency / magnitude / spectralFlux outputs toward zero so
+    // the FFT noise floor does not lock onto arbitrary bins. During audio
+    // they are pass-through. Tau = 0.2 s — spectral metrics are brittle
+    // and should snap to zero quickly.
+    SilenceEnvelope mDominantFrequencyEnvelope;
+    SilenceEnvelope mMagnitudeEnvelope;
+    SilenceEnvelope mSpectralFluxEnvelope;
 
     // Internal Processor for detector-based polling getters
     fl::unique_ptr<Processor> mAudioProcessor;

--- a/tests/fl/audio/audio_reactive.cpp
+++ b/tests/fl/audio/audio_reactive.cpp
@@ -2066,5 +2066,79 @@ FL_TEST_CASE("audio::Processor - configureEqualizer silence threshold") {
     FL_CHECK(isSilence == false);
 }
 
+FL_TEST_CASE("audio::Reactive - spectral metrics decay to zero on silence (FastLED#2253)") {
+    // Drive Reactive with a loud 440 Hz sine so dominantFrequency / magnitude
+    // / spectralFlux all take on non-zero values, then switch to zero-PCM
+    // with Context::setSilent(true). The SilenceEnvelope (tau=0.2s) should
+    // snap the three fields to ~0 within 1 second (5 * tau).
+    audio::Reactive reactive;
+    audio::ReactiveConfig config;
+    config.sampleRate = 44100;
+    config.enableNoiseFloorTracking = true;  // Required for isSilent() to fire.
+    reactive.begin(config);
+
+    // Phase 1: 1 s of loud 440 Hz sine at full-scale amplitude.
+    constexpr fl::size kSamplesPerFrame = 512;
+    constexpr float kSampleRate = 44100.0f;
+    constexpr int kFramesPerSecond =
+        static_cast<int>(kSampleRate / static_cast<float>(kSamplesPerFrame));  // ~86
+
+    for (int i = 0; i < kFramesPerSecond; ++i) {
+        audio::Sample s = makeSample(440.0f, i * 12, 16000.0f,
+                                     kSamplesPerFrame, kSampleRate);
+        reactive.processSample(s);
+    }
+
+    // Sanity: all three metrics should be non-trivial after loud drive.
+    {
+        const auto& data = reactive.getData();
+        FL_CHECK_GT(data.dominantFrequency, 0.0f);
+        FL_CHECK_GT(data.magnitude, 0.0f);
+        // Flux may be near zero in steady state; don't gate on it here.
+        (void)data.spectralFlux;
+    }
+
+    // Phase 2: 1 s of zero-PCM silence. The pipeline's NoiseFloorTracker
+    // will flag each frame as silent, and the envelope should decay all
+    // three spectral metrics toward zero.
+    for (int i = 0; i < kFramesPerSecond; ++i) {
+        audio::Sample s = makeSilence(
+            (kFramesPerSecond + i) * 12, kSamplesPerFrame);
+        reactive.processSample(s);
+    }
+
+    // With tau=0.2s and ~1 s of silence (~5*tau), outputs should be
+    // within the envelope's isGated() epsilon (1e-4) of zero.
+    const auto& data = reactive.getData();
+    FL_CHECK_LT(data.dominantFrequency, 0.01f);
+    FL_CHECK_LT(data.magnitude, 0.01f);
+    FL_CHECK_LT(data.spectralFlux, 0.01f);
+}
+
+FL_TEST_CASE("audio::Reactive - spectral metrics are pass-through during loud audio (FastLED#2253)") {
+    // Sanity: with live audio, the SilenceEnvelope must be a strict
+    // pass-through — dominantFrequency / magnitude / spectralFlux should
+    // track the raw FFT outputs exactly, not be smoothed or attenuated.
+    audio::Reactive reactive;
+    audio::ReactiveConfig config;
+    config.sampleRate = 44100;
+    config.enableNoiseFloorTracking = true;
+    reactive.begin(config);
+
+    // Feed loud sine — during audio isSilent() is false and the envelope
+    // returns currentValue unchanged.
+    for (int i = 0; i < 30; ++i) {
+        audio::Sample s = makeSample(1000.0f, i * 12, 16000.0f, 512, 44100.0f);
+        reactive.processSample(s);
+    }
+
+    const auto& data = reactive.getData();
+    // Loud 1 kHz drive must yield a sensible dominant frequency in the
+    // audible range and a positive magnitude — same contract as the
+    // pre-gate behavior.
+    FL_CHECK_GT(data.dominantFrequency, 100.0f);
+    FL_CHECK_LT(data.dominantFrequency, 4000.0f);
+    FL_CHECK_GT(data.magnitude, 0.0f);
+}
 
 } // FL_TEST_FILE


### PR DESCRIPTION
## Summary

Part 3/4 of the FastLED#2253 silence-gate rollout. Gates three spectral `Data` fields on `fl::audio::Reactive` through `SilenceEnvelope` so they decay to zero when the pipeline signals silence.

- `Data::dominantFrequency` — previously the FFT argmax latched onto arbitrary bins during silence (numerical noise floor).
- `Data::magnitude` — companion to `dominantFrequency`; same issue.
- `Data::spectralFlux` — could fire false onsets on noise-floor flicker.

All three now pass through `SilenceEnvelope` (tau=0.2s) inside `processSample()`. During audio (`Context::isSilent() == false`) the envelope is a strict pass-through; during silence it exponentially decays toward zero. Frame-rate-independent `dt` comes from `computeAudioDt(pcm.size(), sampleRate)`. No behavior change for users who haven't opted into `enableNoiseFloorTracking`.

Tau=0.2s per the design-doc recommendation: spectral metrics are brittle and should snap to zero within ~1 s of silence onset. The existing argmax in `mapFFTBinsToFrequencyChannels()` is untouched — envelopes post-process its output.

Builds on #2306 (Phase 1: `Context::isSilent()` + `SilenceEnvelope`). Out-of-scope for this PR: `Vibe` (PR-C, parallel) and `TempoAnalyzer` (PR-E, next).

## Test plan

- [x] New: `audio::Reactive - spectral metrics decay to zero on silence (FastLED#2253)` — drives 1 s of 440 Hz sine, then 1 s of zero-PCM, asserts all three fields < 0.01 after silence.
- [x] New: `audio::Reactive - spectral metrics are pass-through during loud audio (FastLED#2253)` — confirms unchanged behavior during live audio (dominant frequency in audible range, magnitude > 0).
- [x] `bash test fl_audio --debug` passes (ASAN/LSAN/UBSAN clean).
- [x] `bash lint` clean on all three touched files.
- [x] All pre-existing `fl_audio` tests continue to pass (no behavior change when NFT not enabled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Audio reactive spectral analysis now includes refined silence handling. Dominant frequency, magnitude, and spectral flux metrics decay smoothly when audio drops below the noise floor, improving stability during quiet passages.

* **Tests**
  * Added test coverage validating spectral metric decay behavior during silence and normal pass-through operation during audio.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->