### PR TITLE
feat(audio): TempoAnalyzer confidence fades in silence (#2253)

### DIFF
--- a/src/fl/audio/detector/tempo_analyzer.cpp.hpp
+++ b/src/fl/audio/detector/tempo_analyzer.cpp.hpp
@@ -22,6 +22,14 @@ TempoAnalyzer::TempoAnalyzer()
 {
     mPreviousMagnitudes.resize(8, 0.0f);  // Track first 8 bins for spectral flux
     mHypotheses.reserve(MAX_HYPOTHESES);
+
+    // BPM confidence fades over ~2s of silence — musical tempo has natural
+    // persistence; snapping faster feels wrong. Raw BPM is NOT gated so that
+    // when audio returns, beat sync resumes from the same tempo estimate.
+    SilenceEnvelope::Config cfg;
+    cfg.decayTauSeconds = 2.0f;
+    cfg.targetValue = 0.0f;
+    mConfidenceEnvelope.configure(cfg);
 }
 
 TempoAnalyzer::~TempoAnalyzer() FL_NOEXCEPT = default;
@@ -65,6 +73,19 @@ void TempoAnalyzer::update(shared_ptr<Context> context) {
     // Update stability analysis
     updateStability();
 
+    // Silence gate: fade confidence toward 0 during silence. The BPM estimate
+    // itself survives unchanged so beat sync is seamless on audio re-entry.
+    // dt derived from timestamp deltas (ms→s). First frame: dt=0 → pass-through.
+    float dt = 0.0f;
+    if (mHasPrevTimestamp && timestamp >= mPrevTimestamp) {
+        dt = static_cast<float>(timestamp - mPrevTimestamp) * 0.001f;
+    }
+    mPrevTimestamp = timestamp;
+    mHasPrevTimestamp = true;
+
+    const bool isSilent = context->isSilent();
+    mConfidence = mConfidenceEnvelope.update(isSilent, mConfidence, dt);
+
     // Track state changes for fireCallbacks()
     float bpmDiff = fl::abs(mCurrentBPM - mPreviousBPM);
     mBpmChanged = (bpmDiff > 5.0f);
@@ -104,6 +125,9 @@ void TempoAnalyzer::reset() {
     mFluxAvg.reset();
     mBPMMedian.reset();
     mBPMHistory.clear();
+    mConfidenceEnvelope.reset(0.0f);
+    mPrevTimestamp = 0;
+    mHasPrevTimestamp = false;
 }
 
 float TempoAnalyzer::calculateSpectralFlux(const fft::Bins& fft) {

--- a/src/fl/audio/detector/tempo_analyzer.h
+++ b/src/fl/audio/detector/tempo_analyzer.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "fl/audio/audio_detector.h"
+#include "fl/audio/silence_envelope.h"
 #include "fl/math/filter/filter.h"
 #include "fl/stl/function.h"
 #include "fl/stl/vector.h"
@@ -90,6 +91,18 @@ private:
     static constexpr u32 MAX_BEAT_INTERVAL_MS = 2000; // Min 30 BPM
 
     shared_ptr<const fft::Bins> mRetainedFFT;
+
+    // Silence gate for confidence. Decays confidence (not BPM) toward 0 with
+    // tau ~2s during silence; the BPM estimate itself is preserved so that
+    // when audio returns, beat sync resumes from the same tempo. Musical tempo
+    // has natural persistence — snapping too fast feels wrong to users.
+    SilenceEnvelope mConfidenceEnvelope;
+
+    // Timestamp of the previous update() call, used to compute dt for the
+    // envelope. Zero means "no previous frame" and the envelope skips decay
+    // for that one-off call.
+    u32 mPrevTimestamp = 0;
+    bool mHasPrevTimestamp = false;
 
     // Internal methods
     float calculateSpectralFlux(const fft::Bins& fft);

--- a/tests/fl/audio/detector/tempo_analyzer.hpp
+++ b/tests/fl/audio/detector/tempo_analyzer.hpp
@@ -269,6 +269,123 @@ FL_TEST_CASE("audio::detector::TempoAnalyzer - onTempoChange callback fires on B
     FL_CHECK_LT(lastChangedBPM, 200.0f);
 }
 
+FL_TEST_CASE("audio::detector::TempoAnalyzer - confidence fades in silence, BPM preserved") {
+    // Part 4/4 of FastLED#2253 silence-gate rollout.
+    //
+    // 1. Drive TempoAnalyzer with ~5s of synthetic onsets at 120 BPM.
+    // 2. Confirm confidence rises above a threshold.
+    // 3. Switch to silence with context->setSilent(true) for ~3s.
+    // 4. Assert confidence < 0.05, but BPM estimate is preserved.
+    audio::detector::TempoAnalyzer analyzer;
+    analyzer.setMinBPM(60.0f);
+    analyzer.setMaxBPM(180.0f);
+    analyzer.setStabilityThreshold(5.0f);
+    const int framesPerBeat = 22;
+    const int totalBeats = 15;
+    const u32 frameIntervalMs = 23;  // ~43 fps → 22 frames * 23ms ≈ 506ms/beat ≈ 118.6 BPM
+
+    fl::vector<fl::i16> silenceData(512, 0);
+    audio::Sample silence(silenceData, 0);
+    auto ctx = fl::make_shared<audio::Context>(silence);
+    ctx->setSampleRate(44100);
+    ctx->getFFT(16);
+    ctx->setFFTHistoryDepth(4);
+
+    u32 timestamp = 0;
+    // Phase 1: 15 beats of synthetic onsets at ~120 BPM, NOT silent.
+    for (int beat = 0; beat < totalBeats; ++beat) {
+        for (int frame = 0; frame < framesPerBeat; ++frame) {
+            timestamp += frameIntervalMs;
+            if (frame == 0) {
+                fl::vector<fl::i16> bassData;
+                bassData.reserve(512);
+                for (int s = 0; s < 512; ++s) {
+                    float phase = 2.0f * FL_M_PI * 200.0f * s / 44100.0f;
+                    bassData.push_back(static_cast<fl::i16>(20000.0f * fl::sinf(phase)));
+                }
+                ctx->setSample(audio::Sample(bassData, timestamp));
+            } else {
+                ctx->setSample(audio::Sample(silenceData, timestamp));
+            }
+            ctx->setSilent(false);  // audio present — envelope is pass-through
+            ctx->getFFT(16);
+            analyzer.update(ctx);
+        }
+    }
+
+    const float liveConfidence = analyzer.getConfidence();
+    const float liveBPM = analyzer.getBPM();
+
+    // Confidence should have risen above the integration threshold from the
+    // design doc (>= 0.3). If the fixture's onsets are weak we still require
+    // at least a meaningful non-zero value so the decay test is well-posed.
+    FL_CHECK_GT(liveConfidence, 0.3f);
+    // BPM is in the ballpark of the 120 BPM click track.
+    FL_CHECK_GT(liveBPM, 90.0f);
+    FL_CHECK_LT(liveBPM, 150.0f);
+
+    // Phase 2: ~3 seconds of silence with context->setSilent(true).
+    // At 43 fps (23ms per frame), 3s ≈ 130 frames. With tau=2s the envelope
+    // crosses 95% of the decay in 3*tau = 6s, but at 3s we expect ≈ exp(-1.5) = 0.22
+    // of the starting value, which for a start around 0.5 lands near 0.11.
+    // Run longer (5s) to be well past 95% → comfortably below the 0.05 target.
+    const int silenceFrames = 220;  // ~5s
+    for (int i = 0; i < silenceFrames; ++i) {
+        timestamp += frameIntervalMs;
+        ctx->setSample(audio::Sample(silenceData, timestamp));
+        ctx->setSilent(true);  // silence declared — envelope decays
+        ctx->getFFT(16);
+        analyzer.update(ctx);
+    }
+
+    // Confidence should have decayed well below the integration threshold.
+    FL_CHECK_LT(analyzer.getConfidence(), 0.05f);
+    // BPM estimate is preserved — decaying confidence, not raw BPM, so beat
+    // sync can resume from the same tempo when audio returns.
+    FL_CHECK_EQ(analyzer.getBPM(), liveBPM);
+}
+
+FL_TEST_CASE("audio::detector::TempoAnalyzer - confidence pass-through when not silent") {
+    // Envelope must be a no-op when context->isSilent() is false, even if
+    // the underlying confidence briefly dips (e.g. between onsets).
+    audio::detector::TempoAnalyzer analyzer;
+    analyzer.setMinBPM(60.0f);
+    analyzer.setMaxBPM(180.0f);
+
+    fl::vector<fl::i16> silenceData(512, 0);
+    audio::Sample silence(silenceData, 0);
+    auto ctx = fl::make_shared<audio::Context>(silence);
+    ctx->setSampleRate(44100);
+    ctx->getFFT(16);
+    ctx->setFFTHistoryDepth(4);
+
+    u32 timestamp = 0;
+    // Drive with onsets, keeping isSilent=false throughout.
+    for (int beat = 0; beat < 15; ++beat) {
+        for (int frame = 0; frame < 22; ++frame) {
+            timestamp += 23;
+            if (frame == 0) {
+                fl::vector<fl::i16> bassData;
+                bassData.reserve(512);
+                for (int s = 0; s < 512; ++s) {
+                    float phase = 2.0f * FL_M_PI * 200.0f * s / 44100.0f;
+                    bassData.push_back(static_cast<fl::i16>(20000.0f * fl::sinf(phase)));
+                }
+                ctx->setSample(audio::Sample(bassData, timestamp));
+            } else {
+                ctx->setSample(audio::Sample(silenceData, timestamp));
+            }
+            ctx->setSilent(false);
+            ctx->getFFT(16);
+            analyzer.update(ctx);
+        }
+    }
+
+    // With isSilent=false, envelope is pass-through → confidence matches what
+    // the core algorithm produced (non-zero after consistent onsets).
+    FL_CHECK_GT(analyzer.getConfidence(), 0.0f);
+}
+
 FL_TEST_CASE("audio::detector::TempoAnalyzer - isStable becomes true with consistent tempo") {
     audio::detector::TempoAnalyzer analyzer;
     analyzer.setMinBPM(60.0f);


### PR DESCRIPTION
## Summary

- Gates `TempoAnalyzer::mConfidence` through a `SilenceEnvelope` (tau=2.0s, target=0) so rhythmic-effect confidence decays smoothly during silence instead of clinging to stale onset hypotheses for 5–10+ seconds.
- Leaves the raw BPM estimate untouched — when audio returns, beat sync resumes from the same tempo with zero attack lag. Only the "should I drive rhythmic effects right now?" signal fades.
- dt comes from context timestamp deltas so the first-order decay is frame-rate independent. `!isSilent` is a strict pass-through, preserving behavior for users who haven't opted into `NoiseFloorTracker`.

Part 4/4 of FastLED#2253 silence-gate rollout. Builds on #2306 (Phase 1 foundations).

## Design notes

- Tau = 2.0s: musical tempo has natural persistence. 0.5s tau (Vibe-style) felt twitchy for BPM; 2s matches listener intuition while still clearing within ~6s of silence.
- Confidence, not BPM, is gated. The design doc rationale: preserving BPM means a tempo-locked effect can pick up exactly where it left off when music restarts, without a re-learning delay. The confidence gate prevents the effect from firing while the tempo is "live" but not actually audible.
- No new public API surface. The envelope is a private member; existing `getConfidence()` / `getBPM()` / callback semantics are unchanged.

## Test plan

- [x] `bash test fl_audio --debug` passes (211/211 doctest cases).
- [x] `bash lint src/fl/audio/detector/tempo_analyzer.{h,cpp.hpp} tests/fl/audio/detector/tempo_analyzer.hpp` clean.
- [x] New test `TempoAnalyzer - confidence fades in silence, BPM preserved`:
  - Drive 15 beats of synthetic 120 BPM onsets → assert confidence > 0.3, BPM in [90, 150].
  - Switch to `context->setSilent(true)` for ~5s → assert confidence < 0.05 AND BPM == pre-silence value.
- [x] New test `TempoAnalyzer - confidence pass-through when not silent` covers the audio-path no-op.
- [x] All 7 existing TempoAnalyzer tests still pass (no regression).

Scope-limited to tempo_analyzer; parallel agents are handling Vibe (PR-C) and Reactive spectral (PR-D).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced tempo detection to gracefully handle silent periods by decaying confidence levels while maintaining accurate BPM estimates, ensuring seamless resumption of reliable tempo tracking when audio resumes

* **Tests**
  * Added unit tests validating proper confidence behavior during detected silence and confidence stability during active audio periods

<!-- end of auto-generated comment: release notes by coderabbit.ai -->