### PR TITLE
feat(audio): Vibe adopts silence gate (#2253)

### DIFF
--- a/src/fl/audio/detector/vibe.cpp.hpp
+++ b/src/fl/audio/detector/vibe.cpp.hpp
@@ -21,8 +21,24 @@ int Vibe::getPrivateFFTCount() { return sVibeFFTCount; }
 void Vibe::resetPrivateFFTCount() { sVibeFFTCount = 0; }
 
 
-Vibe::Vibe()
-{}
+Vibe::Vibe() {
+    // Tau chosen for LED visualizer feel: ~0.3s gives ~1 second of silence
+    // to fully gate, matching user expectation that beats decay quickly when
+    // music stops. The envelope targets 0.0 — full silence on the metric.
+    SilenceEnvelope::Config cfg;
+    cfg.decayTauSeconds = 0.3f;
+    cfg.targetValue = 0.0f;
+    for (int i = 0; i < 3; ++i) {
+        mImmRelEnv[i].configure(cfg);
+        mAvgRelEnv[i].configure(cfg);
+        // Seed cached "last audio" value at 1.0 to match the detector's
+        // initial public state (getBass()/getMid()/getTreb() return 1.0
+        // before any update()). Without this, the first silent update
+        // would immediately decay from 0 — no visible change, but semantic.
+        mImmRelEnv[i].reset(1.0f);
+        mAvgRelEnv[i].reset(1.0f);
+    }
+}
 
 Vibe::~Vibe() FL_NOEXCEPT = default;
 
@@ -92,6 +108,19 @@ void Vibe::update(shared_ptr<Context> context) {
         }
     }
 
+    // --- Step 4b: Silence gate ---
+    // MilkDrop's self-normalization drives mImmRel toward 1.0 when input is
+    // silent (noise / noise → 1.0), and the < 0.001f clamp above also pins
+    // to 1.0. Neither is what LED effects want when music stops. Route each
+    // band through its SilenceEnvelope: pass-through during audio, exponential
+    // decay toward 0 during silence. The Context::isSilent() flag is populated
+    // by Processor/Reactive from NoiseFloorTracker. Re-uses dt computed above.
+    const bool silent = context->isSilent();
+    for (int i = 0; i < 3; i++) {
+        mImmRel[i] = mImmRelEnv[i].update(silent, mImmRel[i], dt);
+        mAvgRel[i] = mAvgRelEnv[i].update(silent, mAvgRel[i], dt);
+    }
+
     // --- Step 5: Spike detection ---
     // When immediate exceeds smoothed, energy is rising — a beat is in progress.
     mPrevBassSpike = mBassSpike;
@@ -145,6 +174,10 @@ void Vibe::reset() {
         mLongAvg[i] = 0.0f;
         mImmRel[i] = 1.0f;
         mAvgRel[i] = 1.0f;
+        // Match the mImmRel/mAvgRel defaults of 1.0 so the silence gate
+        // picks up from the public state after reset().
+        mImmRelEnv[i].reset(1.0f);
+        mAvgRelEnv[i].reset(1.0f);
     }
     mBassSpike = false;
     mMidSpike = false;

--- a/src/fl/audio/detector/vibe.h
+++ b/src/fl/audio/detector/vibe.h
@@ -29,6 +29,7 @@
 
 #include "fl/audio/audio_detector.h"
 #include "fl/audio/fft/fft.h"
+#include "fl/audio/silence_envelope.h"
 #include "fl/stl/function.h"
 #include "fl/stl/shared_ptr.h"
 #include "fl/stl/noexcept.h"
@@ -153,6 +154,13 @@ private:
     bool mPrevBassSpike = false;
     bool mPrevMidSpike = false;
     bool mPrevTrebSpike = false;
+
+    // Silence gate envelopes — decay mImmRel[i] and mAvgRel[i] toward zero
+    // when Context::isSilent() is true. Fixes MilkDrop self-normalization's
+    // stuck-at-1.0 behavior when music stops. Pass-through during audio so
+    // beat dynamics are preserved exactly.
+    SilenceEnvelope mImmRelEnv[3];
+    SilenceEnvelope mAvgRelEnv[3];
 
     // FPS-independent rate adjustment
     static float adjustRateToFPS(float rateAtFps1, float fps1, float actualFps) FL_NOEXCEPT;

--- a/tests/fl/audio/detector/vibe.hpp
+++ b/tests/fl/audio/detector/vibe.hpp
@@ -1012,3 +1012,120 @@ FL_TEST_CASE("ADVERSARIAL - phase-coherent sweep across all 3 bands tracks smoot
     FL_CHECK_LT(midNormDelta, 0.30f);
     FL_CHECK_LT(trebNormDelta, 0.30f);
 }
+
+// ============================================================================
+// Silence gate tests (Phase 2 PR-C — FastLED #2253)
+//
+// Vibe adopts SilenceEnvelope so getVol()/getBass()/getMid()/getTreb() and the
+// smoothed *Att variants decay toward 0 when Context::isSilent() is true. This
+// fixes MilkDrop self-normalization's stuck-at-1.0 behavior during silence.
+// ============================================================================
+
+FL_TEST_CASE("audio::detector::Vibe - getVol decays to zero during silence") {
+    audio::detector::Vibe detector;
+
+    // Feed ~30 frames of 440 Hz audio to establish live levels (no silence yet).
+    // These frames drive mImmRel toward real values — NOT 1.0 pass-through.
+    for (int i = 0; i < 30; ++i) {
+        auto sample = makeSample(440.0f, i * 12, 16000.0f);
+        auto ctx = fl::make_shared<audio::Context>(sample);
+        ctx->setSampleRate(44100);
+        // isSilent() defaults to false — no gating during audio.
+        detector.update(ctx);
+        detector.fireCallbacks();
+    }
+
+    // Baseline: getVol() should be non-trivial after audio settles.
+    float liveVol = detector.getVol();
+    FL_WARN("Vibe silence-gate: live getVol=" << liveVol);
+    FL_CHECK_GT(liveVol, 0.1f);
+
+    // Now feed ~90 frames of silence with setSilent(true). At 512 samples /
+    // 44100 Hz ≈ 11.6 ms/frame, 90 frames ≈ 1.05s. With tau=0.3s that's
+    // ~3.5*tau → within ~3% of target (well under the 0.05 threshold).
+    for (int i = 0; i < 90; ++i) {
+        auto sample = makeSilence((30 + i) * 12);
+        auto ctx = fl::make_shared<audio::Context>(sample);
+        ctx->setSampleRate(44100);
+        ctx->setSilent(true);
+        detector.update(ctx);
+        detector.fireCallbacks();
+    }
+
+    float silentVol = detector.getVol();
+    float silentVolAtt = detector.getVolAtt();
+    FL_WARN("Vibe silence-gate: after 90 silent frames getVol=" << silentVol
+                 << " getVolAtt=" << silentVolAtt);
+
+    // User-visible metrics must be gated to near-zero.
+    FL_CHECK_LT(silentVol, 0.05f);
+    FL_CHECK_LT(silentVolAtt, 0.05f);
+    // Each band is individually gated too.
+    FL_CHECK_LT(detector.getBass(), 0.05f);
+    FL_CHECK_LT(detector.getMid(), 0.05f);
+    FL_CHECK_LT(detector.getTreb(), 0.05f);
+    FL_CHECK_LT(detector.getBassAtt(), 0.05f);
+    FL_CHECK_LT(detector.getMidAtt(), 0.05f);
+    FL_CHECK_LT(detector.getTrebAtt(), 0.05f);
+}
+
+FL_TEST_CASE("audio::detector::Vibe - silence gate is pass-through when isSilent is false") {
+    // Regression guard: when the pipeline has NOT opted into NFT (so
+    // Context::isSilent() stays false), the envelope must not alter values.
+    // This protects existing users who rely on the self-normalizing levels.
+    audio::detector::Vibe gated;
+    audio::detector::Vibe ungated;
+
+    for (int i = 0; i < 60; ++i) {
+        auto sample = makeSample(440.0f, i * 12, 16000.0f);
+
+        auto gctx = fl::make_shared<audio::Context>(sample);
+        gctx->setSampleRate(44100);
+        // Leaving isSilent at default (false) = envelope is pass-through.
+        gated.update(gctx);
+
+        auto uctx = fl::make_shared<audio::Context>(sample);
+        uctx->setSampleRate(44100);
+        ungated.update(uctx);
+    }
+
+    // Both detectors should produce identical outputs since neither activated
+    // the silence gate. This proves default behavior is unchanged.
+    FL_CHECK_EQ(gated.getVol(), ungated.getVol());
+    FL_CHECK_EQ(gated.getBass(), ungated.getBass());
+    FL_CHECK_EQ(gated.getMid(), ungated.getMid());
+    FL_CHECK_EQ(gated.getTreb(), ungated.getTreb());
+}
+
+FL_TEST_CASE("audio::detector::Vibe - silence-to-audio transition snaps back (no attack lag)") {
+    audio::detector::Vibe detector;
+
+    // Drive to gated state via silence.
+    for (int i = 0; i < 30; ++i) {
+        auto sample = makeSample(440.0f, i * 12, 16000.0f);
+        auto ctx = fl::make_shared<audio::Context>(sample);
+        ctx->setSampleRate(44100);
+        detector.update(ctx);
+    }
+    for (int i = 0; i < 120; ++i) {
+        auto sample = makeSilence((30 + i) * 12);
+        auto ctx = fl::make_shared<audio::Context>(sample);
+        ctx->setSampleRate(44100);
+        ctx->setSilent(true);
+        detector.update(ctx);
+    }
+    FL_CHECK_LT(detector.getVol(), 0.01f);
+
+    // Audio returns — a beat should NOT be attenuated by residual decay state.
+    // The envelope must snap back to pass-through immediately.
+    auto loudSample = makeSample(440.0f, 1000, 30000.0f);
+    auto ctx = fl::make_shared<audio::Context>(loudSample);
+    ctx->setSampleRate(44100);
+    // isSilent = false — audio is back.
+    detector.update(ctx);
+
+    // After one audio frame, the live signal flows through unchanged.
+    // With loud audio vs the previously quiet baseline (long_avg still low),
+    // bass should exceed 1.0 — no attack lag from the envelope.
+    FL_CHECK_GT(detector.getBass(), 0.5f);
+}


### PR DESCRIPTION
## Summary
Fixes `Vibe::getVol()` (and all 7 other user-visible getters) converging to 1.0 in silence. MilkDrop self-normalization (`mImm / mLongAvg → noise/noise → 1.0`, plus the `< 0.001f` clamp pinning to 1.0) was never gated by the silence flag. Route each of the 3 bands' `mImmRel`/`mAvgRel` through a `SilenceEnvelope` (tau=0.3s → ~1s to fully gate).

- Pass-through during audio — MilkDrop dynamics preserved exactly
- Exponential decay to 0 when `Context::isSilent()` is true
- Snap-back on silence→audio transition — no attack lag on re-entry
- `< 0.001f` startup clamp stays intact (envelope handles silence downstream)

Part 2/4 of FastLED#2253 silence-gate rollout. Builds on #2306 (Context::isSilent + SilenceEnvelope). Sibling PR #2309 (Reactive) landed independently.

## Test plan
- [x] `bash test fl_audio --debug` — 211/211 test cases pass
- [x] `bash test fl_audio_detector_vibe --debug` — 34/34 vibe test cases pass including 3 new silence-gate tests
- [x] `bash lint` on all 3 modified files — clean
- [x] New test asserts `getVol() < 0.05f` after ~1s silence (90 frames @ 512/44100 Hz)
- [x] New regression test asserts default behavior unchanged when `isSilent` stays `false` (pass-through)
- [x] New test asserts no attack lag on silence→audio transition
- [ ] CI green on push

## Files
- `src/fl/audio/detector/vibe.h` — 6 new lines (+include, +6 SilenceEnvelope members)
- `src/fl/audio/detector/vibe.cpp.hpp` — ~30 new lines (constructor seeding, Step 4b gate, reset)
- `tests/fl/audio/detector/vibe.hpp` — 3 new FL_TEST_CASE blocks

160 insertions, 2 deletions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added silence-gating capability to the audio detector to accurately track and report audio levels during silent periods and maintain proper detection behavior during audio playback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->