### PR TITLE
fix(ci,win): retry lld link when runner.exe is locked (#2268)

### DIFF
--- a/ci/meson/compile.py
+++ b/ci/meson/compile.py
@@ -3,6 +3,7 @@
 import os
 import re
 import sys
+import time
 from collections import deque
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -16,11 +17,22 @@ from ci.meson.cache_utils import (
     save_ninja_skip_state,
 )
 from ci.meson.compiler import get_meson_executable
+from ci.meson.link_retry import (
+    is_link_permission_denied_error,
+    kill_stale_runner_processes,
+)
 from ci.meson.output import print_banner
 from ci.util.global_interrupt_handler import handle_keyboard_interrupt
 from ci.util.output_formatter import TimestampFormatter
 from ci.util.tee import StreamTee
 from ci.util.timestamp_print import ts_print as _ts_print
+
+
+# Maximum number of retries when ld.lld fails with 'permission denied' on
+# runner.exe / example_runner.exe (Windows-only transient failure; see #2268).
+# Each retry waits ``0.5 * (attempt + 1)`` seconds and is preceded by a
+# best-effort kill of any stale runner process under the build directory.
+_LLD_PERM_DENIED_MAX_RETRIES = 3
 
 
 @dataclass
@@ -177,6 +189,15 @@ def compile_meson(
     # Generate log filename
     test_name_slug = target.replace("/", "_") if target else "all"
     error_log_path = compile_errors_dir / f"{test_name_slug}.log"
+
+    # Pre-link safeguard (#2268): on Windows, kill any stale runner.exe /
+    # example_runner.exe processes under this build_dir. Windows refuses to
+    # overwrite a running .exe, so a leftover process from a prior invocation
+    # will cause ld.lld to fail with "permission denied". This is a no-op on
+    # non-Windows platforms.
+    _killed = kill_stale_runner_processes(build_dir)
+    if _killed:
+        _ts_print(f"[MESON] 🧹 Killed {_killed} stale runner process(es) before link")
 
     # Create tee for error log capture (stdout + stderr merged)
     stderr_tee = StreamTee(error_log_path, echo=False)
@@ -497,6 +518,70 @@ def compile_meson(
                     f"[MESON] ⚠️  Repair failed with exception: {repair_error}",
                     file=sys.stderr,
                 )
+
+        # Windows ld.lld 'permission denied' retry (#2268).
+        # If the link failed because runner.exe / example_runner.exe was
+        # locked (stale runner process or antivirus handle), retry the ninja
+        # invocation a few times with a short backoff. This is a no-op on
+        # non-Windows platforms because ``is_link_permission_denied_error``
+        # returns False off-Windows.
+        if returncode != 0 and is_link_permission_denied_error(output):
+            for _attempt in range(_LLD_PERM_DENIED_MAX_RETRIES):
+                _ts_print(
+                    f"[MESON] ⚠️  ld.lld permission denied on runner binary "
+                    f"(attempt {_attempt + 1}/{_LLD_PERM_DENIED_MAX_RETRIES}) - "
+                    f"killing stale runner processes and retrying",
+                    file=sys.stderr,
+                )
+                _killed_retry = kill_stale_runner_processes(build_dir)
+                if _killed_retry:
+                    _ts_print(
+                        f"[MESON] 🧹 Killed {_killed_retry} stale runner process(es)",
+                        file=sys.stderr,
+                    )
+                # Backoff 0.5s, 1.0s, 1.5s — gives Windows/AV time to release
+                # any remaining handles on the .exe.
+                time.sleep(0.5 * (_attempt + 1))
+
+                # Re-invoke ninja for the same compile command. We reuse the
+                # original ``cmd`` (meson compile -C build_dir [target]) so
+                # ninja does an incremental relink of just the failed target.
+                try:
+                    retry_proc = RunningProcess(
+                        cmd,
+                        timeout=600,
+                        auto_run=True,
+                        check=False,
+                        output_formatter=TimestampFormatter(),
+                    )
+                    retry_proc.wait(echo=False)
+                    returncode = cast(int, retry_proc.returncode)
+                    retry_output = str(retry_proc.stdout)
+                    # Merge retry output into the captured output so downstream
+                    # diagnostics include the retry context.
+                    output = output + "\n" + retry_output
+                except KeyboardInterrupt as ki:
+                    handle_keyboard_interrupt(ki)
+                    raise
+                except Exception as retry_error:
+                    _ts_print(
+                        f"[MESON] ⚠️  Retry invocation failed: {retry_error}",
+                        file=sys.stderr,
+                    )
+                    break
+
+                if returncode == 0:
+                    _ts_print(
+                        f"[MESON] ✅ Link retry succeeded on attempt {_attempt + 1}",
+                        file=sys.stderr,
+                    )
+                    break
+
+                # Only keep retrying while the failure is still the same
+                # permission-denied pattern. A different failure means the
+                # retry loop is done (fall through to normal error handling).
+                if not is_link_permission_denied_error(retry_output):
+                    break
 
         if returncode != 0:
             # In quiet mode, don't print failure messages (fallback retries handle this)

--- a/ci/meson/link_retry.py
+++ b/ci/meson/link_retry.py
@@ -1,0 +1,116 @@
+"""Windows-specific link retry helpers for transient ld.lld permission-denied failures.
+
+On Windows, the link step for `tests/runner.exe` can intermittently fail with:
+
+    ld.lld: error: failed to write output 'tests/runner.exe': permission denied
+
+The root cause is Windows refusing to overwrite a running .exe — either a stale
+runner process from a prior test invocation that hasn't been fully reaped, or
+an anti-virus / Windows Defender scanner holding a read handle on the freshly
+written .exe for a few milliseconds after close.
+
+This module provides:
+  * ``is_link_permission_denied_error`` — detect the specific error signature.
+  * ``kill_stale_runner_processes`` — terminate lingering runner.exe /
+    example_runner.exe processes whose executable lives under ``build_dir``.
+
+Both helpers are intentionally no-ops on non-Windows platforms so the callers
+can use them unconditionally without regressing Linux/macOS behavior.
+
+Related: FastLED issue #2268.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+from pathlib import Path
+
+
+# Names of runner executables that participate in the DLL-based test
+# architecture. These are the binaries that ``ld.lld`` overwrites at link time
+# and that may be left running from a prior invocation.
+_RUNNER_NAMES: tuple[str, ...] = (
+    "runner.exe",
+    "example_runner.exe",
+)
+
+
+# Match the ld.lld error on any of the runner binaries. Kept broad enough to
+# tolerate forward or backward slashes in the path as emitted by ninja.
+#
+# Example line:
+#   ld.lld: error: failed to write output 'tests/runner.exe': permission denied
+_PERM_DENIED_PATTERN = re.compile(
+    r"ld\.lld:\s*error:\s*failed to write output\s+'[^']*"
+    r"(?:runner|example_runner)\.exe'\s*:\s*permission denied",
+    re.IGNORECASE,
+)
+
+
+def is_link_permission_denied_error(output: str) -> bool:
+    """Return True if *output* contains the Windows ld.lld permission-denied error.
+
+    Only matches failures on runner.exe / example_runner.exe — other
+    permission-denied messages (e.g. an actual bug in build config) are NOT
+    treated as transient and therefore will NOT be retried.
+    """
+    if sys.platform != "win32":
+        return False
+    if not output:
+        return False
+    return bool(_PERM_DENIED_PATTERN.search(output))
+
+
+def kill_stale_runner_processes(build_dir: Path) -> int:
+    """Kill any runner.exe / example_runner.exe processes under *build_dir*.
+
+    Iterates running processes (via ``psutil``) and terminates any whose name
+    matches a known runner binary AND whose executable path resolves to
+    somewhere under ``build_dir``. This avoids killing unrelated processes
+    with the same name that happen to be running on the machine.
+
+    Returns the number of processes killed. No-op and returns 0 on non-Windows.
+
+    Safe to call when psutil is not importable — returns 0 silently.
+    """
+    if sys.platform != "win32":
+        return 0
+
+    try:
+        import psutil  # noqa: PLC0415 - lazy import, Windows-only helper
+    except ImportError:
+        return 0
+
+    try:
+        build_root = str(build_dir.resolve())
+    except OSError:
+        return 0
+
+    killed = 0
+    for proc in psutil.process_iter(["pid", "name", "exe"]):
+        try:
+            name = (proc.info.get("name") or "").lower()
+            if name not in _RUNNER_NAMES:
+                continue
+
+            exe = proc.info.get("exe")
+            if not exe:
+                continue
+
+            # Only terminate runners launched from *our* build directory.
+            try:
+                exe_resolved = str(Path(exe).resolve())
+            except OSError:
+                continue
+
+            if exe_resolved == build_root or exe_resolved.startswith(
+                build_root + os.sep
+            ):
+                proc.kill()
+                killed += 1
+        except (psutil.NoSuchProcess, psutil.AccessDenied, OSError):
+            continue
+
+    return killed

--- a/ci/meson/streaming.py
+++ b/ci/meson/streaming.py
@@ -18,12 +18,21 @@ from ci.meson.compile import (
     _is_compilation_error,
 )
 from ci.meson.compiler import get_meson_executable
+from ci.meson.link_retry import (
+    is_link_permission_denied_error,
+    kill_stale_runner_processes,
+)
 from ci.meson.mtime_stabilizer import stabilize_dll_mtimes
 from ci.meson.output import print_error, print_success
 from ci.meson.phase_tracker import PhaseTracker
 from ci.util.global_interrupt_handler import handle_keyboard_interrupt
 from ci.util.tee import StreamTee
 from ci.util.timestamp_print import ts_print as _ts_print
+
+
+# Maximum number of retries when ld.lld fails with 'permission denied' on
+# runner.exe / example_runner.exe (Windows-only transient failure; see #2268).
+_LLD_PERM_DENIED_MAX_RETRIES = 3
 
 
 @dataclass
@@ -112,6 +121,14 @@ def stream_compile_only(
     else:
         if verbose:
             _ts_print(f"[MESON] Streaming compilation of all test targets...")
+
+    # Pre-link safeguard (#2268): on Windows, kill any stale runner.exe /
+    # example_runner.exe processes under this build_dir. Windows refuses to
+    # overwrite a running .exe, so a leftover process from a prior invocation
+    # will cause ld.lld to fail with "permission denied". No-op off-Windows.
+    _killed = kill_stale_runner_processes(build_dir)
+    if _killed:
+        _ts_print(f"[MESON] 🧹 Killed {_killed} stale runner process(es) before link")
 
     # Pattern to detect test executable linking
     link_pattern = re.compile(
@@ -388,6 +405,66 @@ def stream_compile_only(
                     f.write("\n".join(last_error_lines))
 
             compilation_output = str(proc.stdout)
+
+            # Windows ld.lld 'permission denied' retry (#2268).
+            # If the link failed because runner.exe / example_runner.exe was
+            # locked (stale runner process or antivirus handle), retry the
+            # ninja invocation a few times with a short backoff. No-op on
+            # non-Windows platforms because ``is_link_permission_denied_error``
+            # returns False off-Windows.
+            if returncode != 0 and is_link_permission_denied_error(compilation_output):
+                for _attempt in range(_LLD_PERM_DENIED_MAX_RETRIES):
+                    _ts_print(
+                        f"[MESON] ⚠️  ld.lld permission denied on runner binary "
+                        f"(attempt {_attempt + 1}/{_LLD_PERM_DENIED_MAX_RETRIES}) - "
+                        f"killing stale runner processes and retrying",
+                        file=sys.stderr,
+                    )
+                    _killed_retry = kill_stale_runner_processes(build_dir)
+                    if _killed_retry:
+                        _ts_print(
+                            f"[MESON] 🧹 Killed {_killed_retry} stale runner process(es)",
+                            file=sys.stderr,
+                        )
+                    # Backoff 0.5s, 1.0s, 1.5s — gives Windows / antivirus
+                    # time to release any remaining handles on the .exe.
+                    time.sleep(0.5 * (_attempt + 1))
+
+                    try:
+                        retry_proc = RunningProcess(
+                            cmd,
+                            timeout=compile_timeout,
+                            auto_run=True,
+                            check=False,
+                            env=os.environ.copy(),
+                        )
+                        retry_proc.wait(echo=False)
+                        returncode = cast(int, retry_proc.returncode)
+                        retry_output = str(retry_proc.stdout)
+                        compilation_output = compilation_output + "\n" + retry_output
+                    except KeyboardInterrupt as ki:
+                        handle_keyboard_interrupt(ki)
+                        raise
+                    except Exception as retry_error:
+                        _ts_print(
+                            f"[MESON] ⚠️  Retry invocation failed: {retry_error}",
+                            file=sys.stderr,
+                        )
+                        break
+
+                    if returncode == 0:
+                        _ts_print(
+                            f"[MESON] ✅ Link retry succeeded on attempt {_attempt + 1}",
+                            file=sys.stderr,
+                        )
+                        break
+
+                    # Only keep retrying while the failure is still the same
+                    # permission-denied pattern. Non-retryable failures fall
+                    # through to the normal error path below.
+                    if not is_link_permission_denied_error(retry_output):
+                        break
+
             if returncode != 0:
                 phase_tracker.set_phase("LINK", target=target, path="streaming")
                 _ts_print(

--- a/ci/tests/test_link_retry.py
+++ b/ci/tests/test_link_retry.py
@@ -1,0 +1,175 @@
+"""Unit tests for ci.meson.link_retry helpers (#2268).
+
+These tests validate the pattern-matching and kill-under-build_dir logic
+without spawning real runner.exe processes. The helpers are intentionally
+no-ops on non-Windows platforms, so most tests assert that behavior too.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from ci.meson.link_retry import (
+    is_link_permission_denied_error,
+    kill_stale_runner_processes,
+)
+
+
+# ---------------------------------------------------------------------------
+# is_link_permission_denied_error
+# ---------------------------------------------------------------------------
+
+
+_WIN_ONLY = pytest.mark.skipif(
+    sys.platform != "win32", reason="Retry logic is Windows-specific"
+)
+
+
+@_WIN_ONLY
+def test_perm_denied_runner_exe_detected() -> None:
+    """Positive match for the canonical runner.exe permission-denied error."""
+    output = (
+        "FAILED: [code=1] tests/runner.exe\n"
+        "ld.lld: error: failed to write output 'tests/runner.exe': permission denied\n"
+    )
+    assert is_link_permission_denied_error(output)
+
+
+@_WIN_ONLY
+def test_perm_denied_example_runner_exe_detected() -> None:
+    """Positive match for example_runner.exe variant."""
+    output = (
+        "ld.lld: error: failed to write output 'examples/example_runner.exe': "
+        "permission denied"
+    )
+    assert is_link_permission_denied_error(output)
+
+
+@_WIN_ONLY
+def test_perm_denied_backslash_path_detected() -> None:
+    """Windows-style backslashes in the path should still match."""
+    output = (
+        "ld.lld: error: failed to write output 'tests\\runner.exe': permission denied"
+    )
+    assert is_link_permission_denied_error(output)
+
+
+@_WIN_ONLY
+def test_perm_denied_non_runner_not_detected() -> None:
+    """A permission-denied error on a NON-runner binary must NOT trigger retry.
+
+    This is the guard against retrying legitimate build failures — e.g. an
+    actual bug where a test .exe is locked by a user-spawned debugger.
+    """
+    output = (
+        "ld.lld: error: failed to write output 'tests/test_foo.exe': permission denied"
+    )
+    assert not is_link_permission_denied_error(output)
+
+
+@_WIN_ONLY
+def test_perm_denied_empty_output_not_detected() -> None:
+    assert not is_link_permission_denied_error("")
+
+
+@_WIN_ONLY
+def test_perm_denied_unrelated_output_not_detected() -> None:
+    output = "ninja: build stopped: subcommand failed.\n"
+    assert not is_link_permission_denied_error(output)
+
+
+def test_perm_denied_returns_false_off_windows() -> None:
+    """Detection is a no-op off Windows — never triggers retry on Linux/macOS."""
+    if sys.platform == "win32":
+        pytest.skip("Windows is the positive-case platform")
+    output = (
+        "ld.lld: error: failed to write output 'tests/runner.exe': permission denied"
+    )
+    assert not is_link_permission_denied_error(output)
+
+
+# ---------------------------------------------------------------------------
+# kill_stale_runner_processes
+# ---------------------------------------------------------------------------
+
+
+def test_kill_stale_runners_returns_zero_off_windows(tmp_path: Path) -> None:
+    """Kill is a no-op on non-Windows platforms."""
+    if sys.platform == "win32":
+        pytest.skip("Windows is the positive-case platform")
+    assert kill_stale_runner_processes(tmp_path) == 0
+
+
+@_WIN_ONLY
+def test_kill_stale_runners_skips_processes_outside_build_dir(
+    tmp_path: Path,
+) -> None:
+    """Processes whose exe path is NOT under build_dir must be left alone."""
+    build_dir = tmp_path / "build"
+    build_dir.mkdir()
+    outside_dir = tmp_path / "other"
+    outside_dir.mkdir()
+
+    outside_exe = outside_dir / "runner.exe"
+    outside_exe.write_bytes(b"")
+
+    fake_proc = mock.MagicMock()
+    fake_proc.info = {
+        "pid": 1234,
+        "name": "runner.exe",
+        "exe": str(outside_exe),
+    }
+
+    with mock.patch("psutil.process_iter", return_value=[fake_proc]):
+        killed = kill_stale_runner_processes(build_dir)
+
+    assert killed == 0
+    fake_proc.kill.assert_not_called()
+
+
+@_WIN_ONLY
+def test_kill_stale_runners_kills_matching_process(tmp_path: Path) -> None:
+    """Runner under build_dir whose name matches should be killed."""
+    build_dir = tmp_path / "build"
+    (build_dir / "tests").mkdir(parents=True)
+    inside_exe = build_dir / "tests" / "runner.exe"
+    inside_exe.write_bytes(b"")
+
+    fake_proc = mock.MagicMock()
+    fake_proc.info = {
+        "pid": 5678,
+        "name": "runner.exe",
+        "exe": str(inside_exe),
+    }
+
+    with mock.patch("psutil.process_iter", return_value=[fake_proc]):
+        killed = kill_stale_runner_processes(build_dir)
+
+    assert killed == 1
+    fake_proc.kill.assert_called_once()
+
+
+@_WIN_ONLY
+def test_kill_stale_runners_ignores_non_runner_names(tmp_path: Path) -> None:
+    """Processes in build_dir that are NOT runner/example_runner must be skipped."""
+    build_dir = tmp_path / "build"
+    build_dir.mkdir()
+    other_exe = build_dir / "some_test.exe"
+    other_exe.write_bytes(b"")
+
+    fake_proc = mock.MagicMock()
+    fake_proc.info = {
+        "pid": 9999,
+        "name": "some_test.exe",
+        "exe": str(other_exe),
+    }
+
+    with mock.patch("psutil.process_iter", return_value=[fake_proc]):
+        killed = kill_stale_runner_processes(build_dir)
+
+    assert killed == 0
+    fake_proc.kill.assert_not_called()


### PR DESCRIPTION
## Summary

Fixes #2268 — the transient Windows `ld.lld: error: failed to write output 'tests/runner.exe': permission denied` that occasionally kills `bash test --cpp` runs.

### Root cause
On Windows, a stale `runner.exe` process from a prior test run (or an antivirus/Defender scanner briefly holding a read handle on the freshly written .exe) prevents the next link from overwriting the file. The failure is transient — re-running the same test always passes.

### Fix: two-part safeguard in the build driver

1. **Pre-link kill** (always, Windows-only no-op elsewhere). In both the sequential (`compile_meson`) and streaming (`stream_compile_only`) paths, before invoking the build system, iterate running processes and kill any `runner.exe` / `example_runner.exe` whose executable path resolves **under the active build dir**. Processes living outside the build dir are left alone.

2. **Post-failure retry** (safety net). If the build returns non-zero AND the captured output matches the specific `ld.lld: error: failed to write output '<...>runner.exe|<...>example_runner.exe': permission denied` pattern:
   - kill stale runners again
   - sleep `0.5s * (attempt + 1)` — 0.5s, 1.0s, 1.5s backoff
   - re-invoke the same compile command (incremental relink)
   - up to **3 retries**
   - retry stops early on **success** OR on any **non-permission-denied** failure

### Important: non-permission-denied failures are NOT retried
The detection regex in `ci/meson/link_retry.py` deliberately matches **only** `runner.exe` / `example_runner.exe`. A real build bug that somehow produces a permission-denied on, say, `test_foo.exe` will surface immediately — no retry loop will mask it.

### Scope
- All changes are inside `ci/meson/` — the C++ code is untouched.
- Helpers are Windows-gated; `sys.platform != 'win32'` returns immediately, so Linux/macOS behavior is unchanged.
- `psutil` is already a `pyproject.toml` dependency — no new packages.

### Files
- `ci/meson/link_retry.py` (new) — `is_link_permission_denied_error()` + `kill_stale_runner_processes()`
- `ci/meson/compile.py` — pre-link kill + post-failure retry wrapper
- `ci/meson/streaming.py` — pre-link kill + post-failure retry wrapper (inside producer thread)
- `ci/tests/test_link_retry.py` (new) — 11 unit tests (9 pass on Windows, 2 skipped; 2 pass on Linux/macOS, 9 skipped)

## Test plan

- [x] `uv run pytest ci/tests/test_link_retry.py -v` — 9 passed, 2 skipped on Windows
- [x] `bash lint` — passes cleanly
- [x] Module imports verified (`from ci.meson.compile import compile_meson`, etc.)
- [ ] (manual) Reproduce permission-denied on Windows, confirm retry messages appear and build recovers
- [ ] CI green on Linux + macOS (no regression, helpers are no-ops)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic recovery mechanism for Windows builds experiencing transient linker permission errors, with configurable retry logic and stale process cleanup.

* **Tests**
  * Added comprehensive test coverage for link failure detection and process recovery utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->