### PR TITLE
perf(autoresearch): replace sleep-based reset waits with spin-poll (#2265)

### DIFF
--- a/ci/rpc_client.py
+++ b/ci/rpc_client.py
@@ -160,12 +160,29 @@ class RpcClient:
         """Check if serial connection is open."""
         return self._serial is not None and self._connected
 
-    async def connect(self, boot_wait: float = 3.0, drain_boot: bool = True) -> None:
+    async def connect(
+        self,
+        boot_wait: float = 3.0,
+        drain_boot: bool = True,
+        boot_signals: "list[str] | tuple[str, ...] | None" = None,
+    ) -> None:
         """Open serial connection (async).
 
         Args:
-            boot_wait: Time to wait for device boot (seconds)
-            drain_boot: Whether to drain boot output after connecting
+            boot_wait: Maximum time to wait for device boot (seconds). When
+                ``boot_signals`` is non-empty, this is the *deadline* for the
+                spin-poll — the helper returns as soon as any signal appears,
+                otherwise it falls back to waiting the full duration (matching
+                the legacy fixed-sleep behavior so slow devices still work).
+            drain_boot: Whether to drain boot output after connecting. Lines
+                consumed while spinning for ``boot_signals`` count toward the
+                drain, so this second pass only catches leftovers.
+            boot_signals: Substrings to look for in serial output during the
+                boot wait. When a match is found, ``connect()`` returns
+                immediately instead of sleeping the full ``boot_wait``. Pass
+                an empty list to opt out of spin-polling (legacy sleep path).
+                Defaults to ``BOOT_SIGNALS_ANY`` which covers both ROM-loader
+                and Arduino ``setup()`` banners.
         """
         if self._connected:
             return
@@ -191,22 +208,69 @@ class RpcClient:
         if self.verbose:
             print(f"✅ [RPC] Serial connection established")
 
+        # Resolve default boot signals lazily so tests that don't touch
+        # serial I/O don't import the util module.
+        effective_signals: tuple[str, ...] | list[str]
+        if boot_signals is None:
+            from ci.util.boot_wait import BOOT_SIGNALS_ANY
+
+            effective_signals = BOOT_SIGNALS_ANY
+        else:
+            effective_signals = boot_signals
+
+        poll_drained_lines: list[str] = []
+
         if boot_wait > 0:
             if self.verbose:
-                print(f"⏳ [RPC] Waiting {boot_wait}s for device boot...")
-            # Use async sleep to allow other tasks to run
-            # Poll in small increments for interrupt checking
-            start = time.time()
-            while time.time() - start < boot_wait:
-                self._check_interrupt()
-                await asyncio.sleep(0.05)  # Async sleep, check interrupt every 50ms
+                print(f"⏳ [RPC] Waiting up to {boot_wait}s for device boot...")
+            from ci.util.boot_wait import wait_for_signal
+
+            def _mirror(line: str) -> None:
+                if self.verbose:
+                    print(f"  [boot-poll] {line[:120]}")
+
+            # Spin-poll for a boot signal. If none of the expected signals
+            # arrive within ``boot_wait`` the call still returns (timeout IS
+            # the fallback — see issue #2265), preserving the original
+            # "waited N seconds then moved on" behavior.
+            assert self._serial is not None
+            try:
+                matched, poll_drained_lines = await wait_for_signal(
+                    self._serial,
+                    effective_signals,
+                    timeout=boot_wait,
+                    on_line=_mirror if self.verbose else None,
+                )
+            except KeyboardInterrupt:
+                notify_main_thread()
+                raise
+
+            self._check_interrupt()
+
+            if self.verbose:
+                if matched is not None:
+                    print(
+                        f"✅ [RPC] Boot signal {matched!r} detected after "
+                        f"draining {len(poll_drained_lines)} line(s); "
+                        f"skipping fixed sleep."
+                    )
+                else:
+                    print(
+                        f"⏳ [RPC] No boot signal in {boot_wait}s "
+                        f"(drained {len(poll_drained_lines)} line(s)); "
+                        f"falling back to timeout behavior."
+                    )
 
         if drain_boot:
             if self.verbose:
                 print(f"📥 [RPC] Draining boot output...")
             lines_drained = await self.drain_boot_output(verbose=self.verbose)
             if self.verbose:
-                print(f"📥 [RPC] Drained {lines_drained} boot lines")
+                total = lines_drained + len(poll_drained_lines)
+                print(
+                    f"📥 [RPC] Drained {lines_drained} boot lines "
+                    f"(plus {len(poll_drained_lines)} during spin-poll = {total})"
+                )
 
     async def close(self) -> None:
         """Close serial connection (async)."""

--- a/ci/tests/test_boot_wait.py
+++ b/ci/tests/test_boot_wait.py
@@ -1,0 +1,169 @@
+"""Unit tests for ci.util.boot_wait spin-poll helper (issue #2265).
+
+These tests use a fake ``SerialInterface`` so they run in host unit tests
+without any hardware. They exercise three behaviors:
+
+1. ``wait_for_signal`` returns immediately when a matching line appears.
+2. It falls back to the ``timeout`` deadline when no signal arrives (the
+   "slow device" path — must NOT raise).
+3. It drains and mirrors lines so existing verbose-logging callers still
+   see the boot banner.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import AsyncIterator
+
+import pytest
+
+from ci.util.boot_wait import (
+    BOOT_SIGNALS_ANY,
+    BOOT_SIGNALS_ROM,
+    BOOT_SIGNALS_SETUP,
+    wait_for_signal,
+)
+
+
+class _FakeSerial:
+    """Minimal ``SerialInterface`` stand-in that emits canned lines.
+
+    Each ``read_lines`` call yields the next chunk of queued lines then
+    returns (mimicking the fbuild adapter which returns early once its
+    current batch is exhausted rather than blocking for the full timeout).
+    """
+
+    def __init__(self, batches: list[list[str]], per_batch_delay: float = 0.0) -> None:
+        self._batches = list(batches)
+        self._per_batch_delay = per_batch_delay
+
+    async def read_lines(self, timeout: float) -> AsyncIterator[str]:  # noqa: ARG002
+        if not self._batches:
+            # Simulate "nothing available within timeout" by sleeping the
+            # requested interval, like a real serial adapter would.
+            await asyncio.sleep(min(timeout, 0.01))
+            return
+        batch = self._batches.pop(0)
+        for line in batch:
+            if self._per_batch_delay:
+                await asyncio.sleep(self._per_batch_delay)
+            yield line
+
+
+def test_boot_signal_constants_are_populated() -> None:
+    assert BOOT_SIGNALS_ROM, "ROM signals must not be empty"
+    assert BOOT_SIGNALS_SETUP, "setup signals must not be empty"
+    assert set(BOOT_SIGNALS_ROM).issubset(set(BOOT_SIGNALS_ANY))
+    assert set(BOOT_SIGNALS_SETUP).issubset(set(BOOT_SIGNALS_ANY))
+
+
+def test_wait_for_signal_returns_early_on_match() -> None:
+    """Spin-poll exits as soon as any expected pattern is seen."""
+    iface = _FakeSerial(
+        batches=[
+            ["garbage line"],
+            ["ESP-ROM:esp32s3-20210327"],  # should match BOOT_SIGNALS_ROM
+            ["Before Setup Start"],  # should NOT be consumed — we exit first
+        ]
+    )
+
+    start = time.monotonic()
+    matched, drained = asyncio.run(
+        wait_for_signal(iface, BOOT_SIGNALS_ANY, timeout=2.0, spin_interval=0.02)  # type: ignore[arg-type]
+    )
+    elapsed = time.monotonic() - start
+
+    assert matched == "ESP-ROM:", f"expected ESP-ROM: match, got {matched!r}"
+    assert any("ESP-ROM:" in line for line in drained), (
+        f"drained lines missing banner: {drained}"
+    )
+    # Should return well under the 2s deadline.
+    assert elapsed < 1.0, f"took {elapsed:.2f}s for early-exit path"
+
+
+def test_wait_for_signal_times_out_without_raising() -> None:
+    """When no signal appears, return (None, lines) — do NOT raise.
+
+    This is the critical contract from issue #2265: "slow devices still
+    work via the max timeout" — the timeout IS the fallback.
+    """
+    iface = _FakeSerial(batches=[["unrelated"], ["more junk"]])
+    matched, drained = asyncio.run(
+        wait_for_signal(
+            iface,
+            ["THIS_NEVER_APPEARS"],
+            timeout=0.15,
+            spin_interval=0.02,
+        )
+    )
+    assert matched is None
+    # Drained lines were still captured for verbose logging callers.
+    for expected in ("unrelated", "more junk"):
+        assert any(expected in line for line in drained), (
+            f"expected {expected!r} in drained lines: {drained}"
+        )
+
+
+def test_wait_for_signal_invokes_on_line_callback() -> None:
+    """Verbose callers can mirror lines via the on_line callback."""
+    iface = _FakeSerial(
+        batches=[
+            ["booting..."],
+            ["entry 0x40080000"],
+        ]
+    )
+    mirrored: list[str] = []
+
+    matched, drained = asyncio.run(
+        wait_for_signal(
+            iface,
+            BOOT_SIGNALS_ROM,
+            timeout=1.0,
+            spin_interval=0.02,
+            on_line=mirrored.append,
+        )
+    )
+    assert matched == "entry 0x"
+    assert "booting..." in mirrored
+    assert any("entry 0x" in m for m in mirrored)
+    assert mirrored == drained
+
+
+def test_wait_for_signal_empty_patterns_drains_for_timeout() -> None:
+    """Empty patterns list means "just drain for the timeout window."""
+    iface = _FakeSerial(batches=[["line-a", "line-b"]])
+    start = time.monotonic()
+    matched, drained = asyncio.run(
+        wait_for_signal(iface, [], timeout=0.1, spin_interval=0.02)
+    )
+    elapsed = time.monotonic() - start
+
+    assert matched is None
+    assert "line-a" in drained and "line-b" in drained
+    # Should wait close to timeout (within a small slack), since no patterns
+    # means we never early-exit.
+    assert elapsed >= 0.08, f"returned too early: {elapsed:.3f}s"
+
+
+@pytest.mark.parametrize(
+    "pattern,line,should_match",
+    [
+        ("entry 0x", "I (123) entry 0x40080000 boot", True),
+        ("ESP-ROM:", "ESP-ROM:esp32s3-20210327", True),
+        ("Before Setup Start", "[user] Before Setup Start now", True),
+        ("entry 0x", "some unrelated log line", False),
+    ],
+)
+def test_pattern_matching_is_substring_containment(
+    pattern: str, line: str, should_match: bool
+) -> None:
+    """Patterns are matched by ``in`` containment, not regex or equality."""
+    iface = _FakeSerial(batches=[[line]])
+    matched, _ = asyncio.run(
+        wait_for_signal(iface, [pattern], timeout=0.2, spin_interval=0.02)
+    )
+    if should_match:
+        assert matched == pattern
+    else:
+        assert matched is None

--- a/ci/tests/test_rpc_client_connect_spin_poll.py
+++ b/ci/tests/test_rpc_client_connect_spin_poll.py
@@ -1,0 +1,109 @@
+"""Integration-ish tests for ``RpcClient.connect`` spin-poll (issue #2265).
+
+Uses a fake SerialInterface so these run in host unit tests with no hardware.
+Verifies that connect() returns quickly when a boot signal appears, rather
+than sleeping the full ``boot_wait`` duration.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import AsyncIterator
+
+import pytest
+
+from ci.rpc_client import RpcClient
+
+
+class _FakeSerial:
+    """Fake SerialInterface that emits a boot signal after a tiny delay."""
+
+    def __init__(
+        self,
+        banner: str = "ESP-ROM:esp32s3-20210327\n",
+        emit_banner: bool = True,
+    ) -> None:
+        self._banner_line = banner.rstrip("\n")
+        self._emit_banner = emit_banner
+        self._connected = False
+        self._banner_sent = False
+        self._closed = False
+
+    async def connect(self) -> None:
+        self._connected = True
+
+    async def close(self) -> None:
+        self._closed = True
+
+    async def write(self, data: str) -> None:  # pragma: no cover - unused here
+        pass
+
+    async def read_lines(self, timeout: float) -> AsyncIterator[str]:  # noqa: ARG002
+        if self._emit_banner and not self._banner_sent:
+            self._banner_sent = True
+            yield self._banner_line
+        else:
+            # Simulate "no data within timeout" by sleeping a tick.
+            await asyncio.sleep(min(timeout, 0.01))
+
+    async def reset_device(self, board: str | None) -> bool:  # pragma: no cover
+        return True
+
+
+def test_connect_returns_early_on_boot_signal() -> None:
+    """If a boot signal appears, connect() returns well under boot_wait."""
+    fake = _FakeSerial(banner="ESP-ROM:esp32s3-20210327", emit_banner=True)
+    client = RpcClient("FAKE_PORT", serial_interface=fake)
+
+    async def _run() -> float:
+        start = time.monotonic()
+        # Use a generous 3.0s boot_wait — historical default. We expect to
+        # return in a fraction of that once the banner line is consumed.
+        await client.connect(boot_wait=3.0, drain_boot=False)
+        elapsed = time.monotonic() - start
+        await client.close()
+        return elapsed
+
+    elapsed = asyncio.run(_run())
+    assert elapsed < 1.5, (
+        f"connect() took {elapsed:.2f}s despite banner being available; "
+        "spin-poll should have exited early"
+    )
+
+
+def test_connect_falls_back_to_timeout_without_signal() -> None:
+    """Slow device (no banner) must still complete — timeout IS the fallback."""
+    fake = _FakeSerial(emit_banner=False)
+    client = RpcClient("FAKE_PORT", serial_interface=fake)
+
+    async def _run() -> float:
+        start = time.monotonic()
+        # Short boot_wait so the test stays fast.
+        await client.connect(boot_wait=0.25, drain_boot=False)
+        elapsed = time.monotonic() - start
+        await client.close()
+        return elapsed
+
+    elapsed = asyncio.run(_run())
+    # Should wait roughly the full boot_wait (with slack for scheduling).
+    assert 0.15 <= elapsed <= 2.0, f"expected to wait ~0.25s, got {elapsed:.2f}s"
+
+
+def test_connect_respects_empty_boot_signals_opts_out_of_spin_poll() -> None:
+    """Passing boot_signals=[] disables early-exit (legacy behavior)."""
+    fake = _FakeSerial(banner="ESP-ROM:", emit_banner=True)
+    client = RpcClient("FAKE_PORT", serial_interface=fake)
+
+    async def _run() -> float:
+        start = time.monotonic()
+        await client.connect(boot_wait=0.3, drain_boot=False, boot_signals=[])
+        elapsed = time.monotonic() - start
+        await client.close()
+        return elapsed
+
+    elapsed = asyncio.run(_run())
+    # With empty patterns we must NOT early-exit — we wait the full boot_wait.
+    assert elapsed >= 0.2, (
+        f"connect() returned too early ({elapsed:.2f}s) with boot_signals=[]"
+    )

--- a/ci/util/boot_wait.py
+++ b/ci/util/boot_wait.py
@@ -1,0 +1,133 @@
+"""Spin-poll helpers for device boot/reset signals.
+
+Replaces fixed ``asyncio.sleep(3.0)``-style waits used by autoresearch /
+``RpcClient`` with a poll loop that watches serial output for an expected
+validation signal (e.g. ``"entry 0x"``, ``"ESP-ROM:"``, ``"Before Setup Start"``).
+
+If any of the ``patterns`` appears in a serial line the helper returns
+immediately; otherwise it keeps reading until ``timeout`` elapses. The caller
+gets back the matched signal (or ``None`` on timeout) plus any lines that were
+drained during the wait, so the existing verbose logging / boot-drain paths
+can keep their behavior.
+
+The issue (#2265) mandates that ``timeout`` IS the fallback — on a slow device
+that never produces the expected signature the helper simply times out,
+matching the behavior of the previous fixed sleep. It never raises.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import TYPE_CHECKING, Iterable
+
+
+if TYPE_CHECKING:
+    from ci.util.serial_interface import SerialInterface
+
+
+# Canonical validation signals per boot phase.
+#
+# - ``BOOT_SIGNALS_ROM``: ROM bootloader / second-stage loader markers. Hit as
+#   soon as the ESP32 starts booting after a reset.
+# - ``BOOT_SIGNALS_SETUP``: Arduino ``setup()`` has started executing; RPC
+#   dispatcher is about to come up.
+# - ``BOOT_SIGNALS_ANY``: Any line that indicates the device has come back to
+#   life. Used by generic ``connect()`` which doesn't know which phase it is in.
+BOOT_SIGNALS_ROM: tuple[str, ...] = (
+    "entry 0x",
+    "ESP-ROM:",
+    "rst:",
+    "boot:",
+)
+
+BOOT_SIGNALS_SETUP: tuple[str, ...] = (
+    "Before Setup Start",
+    "setup() start",
+    "RESULT:",
+    "REMOTE: ",
+)
+
+BOOT_SIGNALS_ANY: tuple[str, ...] = BOOT_SIGNALS_ROM + BOOT_SIGNALS_SETUP
+
+
+async def wait_for_signal(
+    iface: "SerialInterface",
+    patterns: Iterable[str],
+    timeout: float,
+    spin_interval: float = 0.05,
+    on_line: "callable[[str], None] | None" = None,  # type: ignore[valid-type]
+) -> tuple[str | None, list[str]]:
+    """Spin-poll ``iface`` for any of ``patterns`` until ``timeout`` elapses.
+
+    Args:
+        iface: SerialInterface to read lines from.
+        patterns: Substrings to look for in incoming serial lines. Match is by
+            simple ``in`` containment (not regex) so callers can pass the
+            literal boot banner text.
+        timeout: Maximum wall-clock seconds to wait. Acts as the fallback when
+            the expected signal never arrives: the helper returns ``None``
+            without raising so slow devices still work.
+        spin_interval: Per-iteration read timeout / polling cadence (seconds).
+            The helper calls ``iface.read_lines(timeout=spin_interval)`` each
+            tick so it can exit promptly once a matching line appears.
+        on_line: Optional callback invoked for every non-matching line that
+            was drained. Useful for mirroring verbose boot output.
+
+    Returns:
+        Tuple of (matched_pattern, drained_lines). ``matched_pattern`` is the
+        first ``patterns`` element found, or ``None`` on timeout. ``drained_lines``
+        contains every line observed during the wait, including the matching
+        one, so callers that previously relied on ``drain_boot_output()`` still
+        see the boot banner.
+    """
+    patterns_list = list(patterns)
+    drained: list[str] = []
+    # Short-circuit: nothing to match means caller expects us to just drain
+    # for the full duration. We still poll so we can yield to the event loop.
+    if not patterns_list:
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            try:
+                async for line in iface.read_lines(timeout=spin_interval):
+                    drained.append(line)
+                    if on_line is not None:
+                        on_line(line)
+                    if time.monotonic() >= deadline:
+                        break
+            except KeyboardInterrupt as ki:
+                from ci.util.global_interrupt_handler import handle_keyboard_interrupt
+
+                handle_keyboard_interrupt(ki)
+                raise
+            except Exception:
+                # Read timeouts are normal.
+                pass
+            await asyncio.sleep(0)
+        return (None, drained)
+
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            async for line in iface.read_lines(timeout=spin_interval):
+                drained.append(line)
+                if on_line is not None:
+                    on_line(line)
+                for pat in patterns_list:
+                    if pat in line:
+                        return (pat, drained)
+                if time.monotonic() >= deadline:
+                    break
+        except KeyboardInterrupt as ki:
+            from ci.util.global_interrupt_handler import handle_keyboard_interrupt
+
+            handle_keyboard_interrupt(ki)
+            raise
+        except Exception:
+            # Read timeouts are normal — keep polling until deadline.
+            pass
+        # Yield to the event loop so other tasks (interrupt handler, etc.)
+        # can run between read attempts.
+        await asyncio.sleep(0)
+
+    return (None, drained)


### PR DESCRIPTION
## Summary

Replaces the fixed `asyncio.sleep(boot_wait)` loop inside `RpcClient.connect()` with a spin-poll (`ci/util/boot_wait.wait_for_signal`) that watches serial output for ROM-loader / Arduino `setup()` banners and exits immediately when one appears. Fixes #2265.

- **Validation signals watched** (substring containment, any match wins):
  - `BOOT_SIGNALS_ROM`: `entry 0x`, `ESP-ROM:`, `rst:`, `boot:`
  - `BOOT_SIGNALS_SETUP`: `Before Setup Start`, `setup() start`, `RESULT:`, `REMOTE: `
- **Slow-device fallback**: if no signal arrives within `boot_wait` the call still returns cleanly. The timeout IS the fallback — no raising, no regressions for devices that boot slowly or don't emit a banner.
- **Opt-out**: callers can pass `boot_signals=[]` to disable spin-polling and get the legacy "sleep the full duration" behavior.

Only `ci/rpc_client.py` changes. All autoresearch callers (`phases.py`, `gpio.py`, `net.py`, `ota.py`, `ble.py`, `driver_sweep.py`, `decode.py`) inherit the speedup for free via the shared `connect()` entry point.

Out of scope (intentionally):
- `ci/autoresearch/gpio.py`'s DTR reset pyserial sequence — that's #2264, blocked on fbuild upstream.
- Non-Python code.
- Public CLI / RPC surface.

## Expected speedup

| Scenario | Before | After |
|---|---|---|
| Fast ESP32-S3 w/ USB-CDC, 3.0s `boot_wait` | ~3.0s fixed | <500ms (banner arrives in ~200-400ms) |
| Slow ESP32-S3 autoresearch, 8.0s `boot_wait` (`gpio.py`) | ~8.0s fixed | <1s once `Before Setup Start` fires |
| Device stuck / no banner | ~boot_wait | ~boot_wait (fallback — unchanged) |

Rough claim: **~2s saved per autoresearch cycle on fast devices**, with no regression on slow ones.

## Test plan

- [x] `uv run pytest ci/tests/test_boot_wait.py -v` — 9 unit tests for the helper (early-exit, timeout-fallback, on_line mirroring, empty-patterns drain, substring-containment semantics)
- [x] `uv run pytest ci/tests/test_rpc_client_connect_spin_poll.py -v` — 3 integration tests exercising `RpcClient.connect()` end-to-end with a fake `SerialInterface` (early-exit on banner, fallback on silence, opt-out via `boot_signals=[]`)
- [x] `uv run pytest ci/tests/test_serial_interface_reset.py -v` — unchanged, still passes
- [x] `uv run ruff check ci/rpc_client.py ci/util/boot_wait.py ci/tests/test_boot_wait.py ci/tests/test_rpc_client_connect_spin_poll.py` — clean
- [ ] Live `bash autoresearch --parlio` on ESP32-S3 to confirm sub-second banner detection (requires hardware)

Pre-existing unrelated test failures in `test_autoresearch_phases.py` (`lcd_spi` arg) and `test_running_process.py::test_output_formatter` are **not** affected by this change — verified on master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved device boot detection with early signal matching for faster connection initialization
  * Added optional boot signals configuration for customized boot wait behavior

* **Tests**
  * Added comprehensive test coverage for boot signal detection and connection timing validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->