### PR TITLE
ci: use FastLED/fbuild/setup action to warm per-board fbuild cache

### DIFF
--- a/.github/workflows/build_template.yml
+++ b/.github/workflows/build_template.yml
@@ -115,6 +115,22 @@ jobs:
         with:
           python-version-file: "trusted/.python-version"
 
+      # Extract board name (first positional in inputs.args) so per-board
+      # caches don't collide. Boards using PlatformIO get an empty cache —
+      # harmless; boards in FBUILD_BOARDS (see trusted/ci/compiler/fbuild_boards.py)
+      # get a warm toolchain + compile cache from previous runs.
+      - name: Extract board name from inputs.args
+        id: fbuild_board
+        shell: bash
+        run: |
+          board="$(echo '${{ inputs.args }}' | awk '{print $1}')"
+          echo "name=${board:-unknown}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up fbuild (install + cache)
+        uses: FastLED/fbuild/.github/actions/setup@main
+        with:
+          cache-key-extra: ${{ steps.fbuild_board.outputs.name }}-${{ hashFiles('trusted/platformio.ini', 'trusted/library.json', 'trusted/ci/compiler/fbuild_boards.py') }}
+
       - name: Install Platform
         if: inputs.platform != ''
         working-directory: trusted

--- a/.github/workflows/build_template.yml
+++ b/.github/workflows/build_template.yml
@@ -122,9 +122,11 @@ jobs:
       - name: Extract board name from inputs.args
         id: fbuild_board
         shell: bash
+        env:
+          BUILD_ARGS: ${{ inputs.args }}
         run: |
-          board="$(echo '${{ inputs.args }}' | awk '{print $1}')"
-          echo "name=${board:-unknown}" >> "$GITHUB_OUTPUT"
+          board="$(awk '{print $1}' <<< "$BUILD_ARGS")"
+          printf 'name=%s\n' "${board:-unknown}" >> "$GITHUB_OUTPUT"
 
       - name: Set up fbuild (install + cache)
         uses: FastLED/fbuild/.github/actions/setup@main


### PR DESCRIPTION
## Summary

Wires the new \`FastLED/fbuild/.github/actions/setup\` composite action into \`build_template.yml\` so every per-board workflow that routes through the template gets save/restore of fbuild's toolchain + compile cache across CI runs.

The action:

- Installs fbuild via pip
- Exports \`FBUILD_CACHE_DIR=\$RUNNER_TEMP/fbuild-cache\` to every later step
- Wires \`actions/cache@v4\` with sensible keys (OS/arch + board + graph-input hash)
- Excludes \`~/.fbuild/*/daemon/\` automatically by redirecting the cache root away from \`\$HOME\`

Source: [FastLED/fbuild PR #102](https://github.com/FastLED/fbuild/pull/102), tracked by [FastLED/fbuild#101](https://github.com/FastLED/fbuild/issues/101). Design doc: [FastLED/fbuild/docs/CI_CACHING.md](https://github.com/FastLED/fbuild/blob/main/docs/CI_CACHING.md).

## Cache-key strategy

\`\`\`
fbuild-v1-{os}-{arch}-{board}-hash(platformio.ini, library.json, fbuild_boards.py)
\`\`\`

Per-board shard keeps cache entries comfortably under \`actions/cache\`'s 10 GB limit even once toolchains for every supported board accumulate over many CI runs.

## Behavior by board

| Path | Boards | Effect |
|---|---|---|
| fbuild | \`uno\`, \`attiny85/88/4313\`, \`leonardo\`, \`esp32dev/s2/s3/c2/c3/c5/c6/h2/p4\`, \`upesy_wroom\`, \`seeed_xiao_esp32s3\` (see \`ci/compiler/fbuild_boards.py\`) | Warm toolchain + compile cache across runs |
| PlatformIO | everything else | Empty fbuild-cache entry written — zero-cost no-op |

## Risk

- **Low**: one step added to the template before Install Platform; no existing step modified.
- Falls back gracefully when fbuild install fails — the \`./compile\` invocation later still routes PlatformIO-path boards through PIO.
- Empty-cache entries for PIO-only boards are free.

## Test plan

- [ ] Open this PR, let the full matrix run.
- [ ] Confirm one FBUILD_BOARD workflow (e.g., \`build_uno.yml\`) reports a cache miss on first run, hit on second.
- [ ] Confirm one PlatformIO-only workflow (e.g., \`build_attiny1604.yml\`) is unaffected.
- [ ] Spot-check build times before/after on ESP32 boards.

## Follow-up

- Once cache warming lands, the commented-out \`./.build\`-directory cache block at the top of \`build_template.yml\` can be reconsidered or deleted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Introduced board-aware build caching that namespaces caches per target board and hashes relevant build configuration, reducing redundant rebuilds.
  * Added a workflow step to extract the board identifier from build arguments and expose it for cache scoping; no public-facing code changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->