### PR TITLE
ci(project): drift-sync also sets Status=Triage on no-status items

### DIFF
--- a/ci/github_project_drift_sync.py
+++ b/ci/github_project_drift_sync.py
@@ -1,24 +1,25 @@
 """Reconcile FastLED Tracker project items against live repo state.
 
-Safety net behind the event-driven add-to-project workflows: runs on a cron
-and adds any open issue/PR from the feeder repos that isn't already in the
-project. `addProjectV2ItemById` is idempotent, so re-adds cost nothing.
+Two jobs, both safety nets behind the event-driven workflows:
 
-Why we need this: the per-repo `add-to-project.yml` (and
-`project_automation.yml` on FastLED) listen for `issues.opened` and
-`pull_request_target.opened`. Anything that slips past — workflow outage,
-revoked App key, event delivery failure, items converted from discussion,
-renames, etc. — eventually drifts. This drift-sync catches it up.
+  1. Add any open issue/PR from the feeder repos that isn't yet in the project.
+  2. Set Status=Triage on any item currently in the project with no Status —
+     otherwise the project board (grouped by Status) hides them from every
+     column because they don't match any lane.
 
-Environment variables (set by the workflow):
-  GH_TOKEN           GitHub App installation token with Projects: read/write,
-                     Contents/Issues/Pull requests: read.
-  PROJECT_OWNER      Org login (e.g. "FastLED").
-  PROJECT_NUMBER     Project number (e.g. "1").
-  FEEDER_REPOS       Comma-separated list of repo names (owner implied).
-  INCLUDE_CLOSED     "true" to include closed/merged items (default: "false").
-                     Closed historical items bloat the project board; leave off
-                     for routine runs, enable on manual triggers if desired.
+Both mutations are idempotent.
+
+Env vars (set by the workflow):
+  GH_TOKEN               GitHub App installation token with Projects: read/write,
+                         Contents/Issues/Pull requests: read.
+  PROJECT_OWNER          Org login (e.g. "FastLED").
+  PROJECT_NUMBER         Project number (e.g. "1").
+  FEEDER_REPOS           Comma-separated list of repo names (owner implied).
+  INCLUDE_CLOSED         "true" to include closed/merged items. Default "false"
+                         — closed items bloat the board; enable on rare manual
+                         runs if you want a full historical backfill.
+  STATUS_FIELD_NAME      Name of the Status single-select field. Default "Status".
+  TRIAGE_OPTION_NAME     Name of the triage option. Default "Triage".
 """
 
 from __future__ import annotations
@@ -67,9 +68,18 @@ def resolve_project_node_id(owner: str, number: int) -> str:
     return node_id
 
 
-def fetch_project_content_keys(owner: str, number: int) -> set[tuple[str, int]]:
-    """Return {(repo_name, issue_or_pr_number), ...} for everything currently in the project."""
+def fetch_project_items(
+    owner: str, number: int, status_field_name: str
+) -> tuple[set[tuple[str, int]], list[str]]:
+    """Return (content_keys, items_without_status).
+
+    content_keys: {(repo_name, issue_or_pr_number), ...} — for the
+      "is this linked to the project already?" check.
+    items_without_status: [item_id, ...] — existing project items whose
+      Status field is unset, needing a Triage assignment.
+    """
     keys: set[tuple[str, int]] = set()
+    no_status: list[str] = []
     cursor: str | None = None
     while True:
         after = f'"{cursor}"' if cursor else "null"
@@ -80,26 +90,86 @@ def fetch_project_content_keys(owner: str, number: int) -> set[tuple[str, int]]:
             + str(number)
             + ") { items(first: 100, after: "
             + after
-            + ") { pageInfo { hasNextPage endCursor } nodes { content { "
+            + ") { pageInfo { hasNextPage endCursor } "
+            "nodes { id content { "
             "... on Issue { number repository { name } } "
             "... on PullRequest { number repository { name } } "
-            "} } } } } }"
+            "} "
+            "fieldValues(first: 20) { nodes { "
+            "... on ProjectV2ItemFieldSingleSelectValue { "
+            "name field { ... on ProjectV2FieldCommon { name } } } "
+            "} } } } } } }"
         )
         d = graphql(q)
         items = d["data"]["organization"]["projectV2"]["items"]
         for n in items["nodes"]:
             c = n.get("content")
-            if not c:
-                continue
-            repo = (c.get("repository") or {}).get("name")
-            num = c.get("number")
-            if repo and isinstance(num, int):
-                keys.add((repo, num))
+            if c:
+                repo = (c.get("repository") or {}).get("name")
+                num = c.get("number")
+                if repo and isinstance(num, int):
+                    keys.add((repo, num))
+            # Does this item have a Status set?
+            has_status = False
+            for fv in (n.get("fieldValues") or {}).get("nodes") or []:
+                if fv and (fv.get("field") or {}).get("name") == status_field_name:
+                    has_status = True
+                    break
+            if not has_status:
+                no_status.append(str(n["id"]))
         page = items["pageInfo"]
         if not page.get("hasNextPage"):
             break
         cursor = page["endCursor"]
-    return keys
+    return keys, no_status
+
+
+def fetch_status_field(
+    owner: str, number: int, status_field_name: str, triage_option_name: str
+) -> tuple[str, str]:
+    """Return (field_id, triage_option_id) for the Status single-select field."""
+    q = (
+        'query { organization(login: "'
+        + owner
+        + '") { projectV2(number: '
+        + str(number)
+        + ') { field(name: "'
+        + status_field_name
+        + '") { ... on ProjectV2SingleSelectField { id options { id name } } } } } }'
+    )
+    d = graphql(q)
+    field = d["data"]["organization"]["projectV2"]["field"]
+    if not field:
+        raise RuntimeError(f"Status field '{status_field_name}' not found")
+    field_id = str(field["id"])
+    option_id: str | None = None
+    for o in field["options"]:
+        if o["name"] == triage_option_name:
+            option_id = str(o["id"])
+            break
+    if option_id is None:
+        raise RuntimeError(f"Option '{triage_option_name}' not found on Status field")
+    return field_id, option_id
+
+
+def set_status_triage(
+    project_id: str, item_id: str, field_id: str, option_id: str
+) -> bool:
+    mutation = (
+        "mutation($p: ID!, $i: ID!, $f: ID!, $o: String!) { "
+        "updateProjectV2ItemFieldValue(input: "
+        "{projectId: $p, itemId: $i, fieldId: $f, "
+        "value: {singleSelectOptionId: $o}}) { projectV2Item { id } } }"
+    )
+    try:
+        d = graphql(mutation, p=project_id, i=item_id, f=field_id, o=option_id)
+    except SystemExit:
+        return False
+    return bool(
+        (d.get("data") or {})
+        .get("updateProjectV2ItemFieldValue", {})
+        .get("projectV2Item")
+    )
 
 
 def fetch_repo_items(
@@ -149,6 +219,12 @@ def main() -> int:
     number_raw = os.environ.get("PROJECT_NUMBER", "").strip()
     feeders_raw = os.environ.get("FEEDER_REPOS", "").strip()
     include_closed = os.environ.get("INCLUDE_CLOSED", "false").lower() == "true"
+    status_field_name = (
+        os.environ.get("STATUS_FIELD_NAME", "Status").strip() or "Status"
+    )
+    triage_option_name = (
+        os.environ.get("TRIAGE_OPTION_NAME", "Triage").strip() or "Triage"
+    )
 
     if not owner or not number_raw or not feeders_raw:
         print(
@@ -166,21 +242,38 @@ def main() -> int:
     project_id = resolve_project_node_id(owner, number)
     print(f"Project node: {project_id}")
 
-    existing = fetch_project_content_keys(owner, number)
-    print(f"Project currently has {len(existing)} linked items")
+    field_id, triage_option_id = fetch_status_field(
+        owner, number, status_field_name, triage_option_name
+    )
+    print(
+        f"Status field: {field_id[:20]}...  '{triage_option_name}' option: "
+        f"{triage_option_id[:10]}"
+    )
+
+    existing_keys, items_without_status = fetch_project_items(
+        owner, number, status_field_name
+    )
+    print(f"Project currently has {len(existing_keys)} linked items")
+    print(f"  (of which {len(items_without_status)} have no Status set)")
 
     added = 0
     failed = 0
+    status_set = 0
+    status_failed = 0
+
+    # ---- Part 1: add missing items ----
+    new_item_ids: list[str] = []
     for repo in feeders:
         repo_items = fetch_repo_items(owner, repo, include_closed)
         missing = [
             (node_id, num, kind)
             for (node_id, num, kind) in repo_items
-            if (repo, num) not in existing
+            if (repo, num) not in existing_keys
         ]
         print(f"\n=== {owner}/{repo} ===")
         print(
-            f"  repo items (state={'all' if include_closed else 'open'}): {len(repo_items)}"
+            f"  repo items (state={'all' if include_closed else 'open'}): "
+            f"{len(repo_items)}"
         )
         print(f"  missing from project: {len(missing)}")
         for node_id, num, kind in missing:
@@ -190,9 +283,30 @@ def main() -> int:
                 print(f"  FAIL  {owner}/{repo}#{num} ({kind})")
             else:
                 added += 1
+                new_item_ids.append(item_id)
 
-    print(f"\nDone. Added: {added}, failed: {failed}")
-    return 1 if failed else 0
+    # ---- Part 2: set Status=Triage on anything without a Status ----
+    # This covers both (a) items we just added above, and (b) items added
+    # earlier by add-to-project@v1.0.2 which doesn't set fields.
+    status_needed: list[str] = items_without_status + [
+        iid for iid in new_item_ids if iid not in items_without_status
+    ]
+    if status_needed:
+        print(
+            f"\nSetting '{triage_option_name}' on {len(status_needed)} items "
+            "without Status..."
+        )
+        for item_id in status_needed:
+            if set_status_triage(project_id, item_id, field_id, triage_option_id):
+                status_set += 1
+            else:
+                status_failed += 1
+
+    print(
+        f"\nDone. Added: {added}, add-failed: {failed}, "
+        f"status-set: {status_set}, status-failed: {status_failed}"
+    )
+    return 1 if (failed or status_failed) else 0
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes the 'board doesn't show new items' bug. add-to-project@v1.0.2 only links items to the project; it can't set Status fields. Items with no Status get hidden from every board column (grouped by Status). Drift-sync now backfills Triage on both pre-existing and newly-added no-status items. Smoke-tested: 30 re-flagged, 2 added, 0 failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Project items now automatically tracked and identified when missing status values.
  * Status field on project items can now be automatically set to a configurable triage option.
  * Environment variables added to customize status field and triage option names.

* **Improvements**
  * Enhanced error reporting to separately track status assignment failures and provide clearer job status indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->