### PR TITLE
fix(esp32s3,lcd): force full teardown on cross-driver switch (#2270)

### DIFF
--- a/src/platforms/esp/32/drivers/lcd_spi/channel_driver_lcd_clockless.cpp.hpp
+++ b/src/platforms/esp/32/drivers/lcd_spi/channel_driver_lcd_clockless.cpp.hpp
@@ -367,6 +367,9 @@ bool ChannelDriverLcdClockless::beginTransmission(
         config.max_transfer_bytes = slotCapacityBytes;
         config.use_psram = true;
         config.clock_hz = mClockHz;
+        // Issue #2270: tag the shared LCD_CAM singleton with this driver
+        // so it can detect a cross-driver switch and force full teardown.
+        config.owner = detail::LcdSpiOwnerDriver::LCD_CLOCKLESS;
 
         for (size_t i = 0; i < channels.size() && i < 16; i++) {
             config.data_gpios[i] = channels[i]->getPin();

--- a/src/platforms/esp/32/drivers/lcd_spi/channel_driver_lcd_spi.cpp.hpp
+++ b/src/platforms/esp/32/drivers/lcd_spi/channel_driver_lcd_spi.cpp.hpp
@@ -321,6 +321,9 @@ bool ChannelDriverLcdSpi::beginTransmission(
         // max_transfer_bytes = chunk DMA size (all chunks are uniform)
         config.max_transfer_bytes = slotCapacityBytes;
         config.use_psram = true;
+        // Issue #2270: tag the shared LCD_CAM singleton with this driver
+        // so it can detect a cross-driver switch and force full teardown.
+        config.owner = detail::LcdSpiOwnerDriver::LCD_SPI;
 
         for (size_t i = 0; i < channels.size() && i < 16; i++) {
             const auto &chipset = channels[i]->getChipset();

--- a/src/platforms/esp/32/drivers/lcd_spi/ilcd_spi_peripheral.h
+++ b/src/platforms/esp/32/drivers/lcd_spi/ilcd_spi_peripheral.h
@@ -17,6 +17,22 @@
 namespace fl {
 namespace detail {
 
+/// @brief Identifies which channel driver currently owns the shared
+///        LCD_CAM I80 peripheral singleton.
+///
+/// The ESP32-S3 LCD_CAM peripheral is a shared hardware resource that
+/// can be driven by either the clocked-SPI driver (APA102/SK9822) or the
+/// clockless driver (WS2812/SK6812) but not both simultaneously. When the
+/// active driver changes, the peripheral MUST be fully torn down — even
+/// if the lane count / clock / transfer size happen to match — because
+/// the ISR callback, ring-buffer ownership, and completion semaphore all
+/// belong to the previous driver. See issue #2270.
+enum class LcdSpiOwnerDriver : u8 {
+    NONE = 0,         ///< No driver has initialized the peripheral yet.
+    LCD_SPI = 1,      ///< Clocked-SPI driver (channel_driver_lcd_spi).
+    LCD_CLOCKLESS = 2 ///< Clockless driver (channel_driver_lcd_clockless).
+};
+
 /// @brief Configuration for LCD_CAM SPI peripheral
 struct LcdSpiConfig {
     fl::vector_fixed<int, 16> data_gpios; ///< Data lane GPIOs (D0-D15)
@@ -26,6 +42,7 @@ struct LcdSpiConfig {
     u32 clock_hz;                          ///< SPI clock frequency in Hz
     size_t max_transfer_bytes;             ///< Maximum bytes per transfer
     bool use_psram;                        ///< Allocate buffers in PSRAM
+    LcdSpiOwnerDriver owner;               ///< Which driver is initializing (issue #2270)
 
     LcdSpiConfig() FL_NOEXCEPT
         : data_gpios(),
@@ -34,7 +51,8 @@ struct LcdSpiConfig {
           num_lanes(0),
           clock_hz(0),
           max_transfer_bytes(0),
-          use_psram(true) {
+          use_psram(true),
+          owner(LcdSpiOwnerDriver::NONE) {
         data_gpios.resize(16);
         for (size_t i = 0; i < 16; i++) {
             data_gpios[i] = -1;
@@ -49,7 +67,8 @@ struct LcdSpiConfig {
           num_lanes(lanes),
           clock_hz(clk_hz),
           max_transfer_bytes(max_bytes),
-          use_psram(true) {
+          use_psram(true),
+          owner(LcdSpiOwnerDriver::NONE) {
         data_gpios.resize(16);
         for (size_t i = 0; i < 16; i++) {
             data_gpios[i] = -1;

--- a/src/platforms/esp/32/drivers/lcd_spi/lcd_spi_peripheral_esp.cpp.hpp
+++ b/src/platforms/esp/32/drivers/lcd_spi/lcd_spi_peripheral_esp.cpp.hpp
@@ -91,7 +91,8 @@ LcdSpiPeripheralEsp &LcdSpiPeripheralEsp::instance() FL_NOEXCEPT {
 LcdSpiPeripheralEsp::LcdSpiPeripheralEsp() FL_NOEXCEPT
     : mInitialized(false), mConfig(), mI80Bus(nullptr), mPanelIo(nullptr),
       mCompleteSem(nullptr), mCallback(nullptr), mUserCtx(nullptr),
-      mBusy(false), mLastTransmitSize(0) {}
+      mBusy(false), mLastTransmitSize(0),
+      mOwner(LcdSpiOwnerDriver::NONE) {}
 
 LcdSpiPeripheralEsp::~LcdSpiPeripheralEsp() { deinitialize(); }
 
@@ -100,13 +101,37 @@ LcdSpiPeripheralEsp::~LcdSpiPeripheralEsp() { deinitialize(); }
 //=============================================================================
 
 bool LcdSpiPeripheralEsp::initialize(const LcdSpiConfig &config) FL_NOEXCEPT {
+    // Issue #2270: when the owning driver changes between calls (e.g. the
+    // clocked-SPI driver handed the peripheral over to the clockless
+    // driver, or vice-versa) we MUST fully tear down even if the lane
+    // count / clock / transfer size happen to match. Otherwise the
+    // previous driver's ISR callback, ring buffers, and semaphore state
+    // leak into the new driver's session and the second cross-driver
+    // switch silently produces no DMA output.
+    const bool sameOwner =
+        (config.owner == mOwner) ||
+        (config.owner == LcdSpiOwnerDriver::NONE);
+
     if (mInitialized) {
-        if (mConfig.num_lanes == config.num_lanes &&
+        const bool sameShape =
+            mConfig.num_lanes == config.num_lanes &&
             mConfig.clock_hz == config.clock_hz &&
-            mConfig.max_transfer_bytes >= config.max_transfer_bytes) {
+            mConfig.max_transfer_bytes >= config.max_transfer_bytes;
+
+        if (sameShape && sameOwner) {
+            // Fast path - same driver, compatible config. Record the
+            // (possibly NONE) owner from the caller in case it now
+            // reports a concrete identity that was unset before.
+            if (config.owner != LcdSpiOwnerDriver::NONE) {
+                mOwner = config.owner;
+            }
             return true;
         }
-        deinitialize();
+
+        // Slow path - either the shape changed or the owning driver
+        // changed. Both cases require a full tear-down so we don't
+        // carry stale callback / semaphore / panel_io state forward.
+        teardownLocked();
     }
 
     if (config.num_lanes < 1 || config.num_lanes > 16) {
@@ -187,12 +212,23 @@ bool LcdSpiPeripheralEsp::initialize(const LcdSpiConfig &config) FL_NOEXCEPT {
 
     mLastTransmitSize = 0;
     mInitialized = true;
+    mOwner = config.owner;
     FL_DBG("LcdSpiPeripheralEsp: Initialized with " << config.num_lanes
-           << " lanes, " << config.clock_hz << " Hz clock");
+           << " lanes, " << config.clock_hz << " Hz clock, owner="
+           << static_cast<int>(config.owner));
     return true;
 }
 
-void LcdSpiPeripheralEsp::deinitialize() FL_NOEXCEPT {
+void LcdSpiPeripheralEsp::teardownLocked() FL_NOEXCEPT {
+    // Clear the ISR callback BEFORE deleting the panel_io so a late
+    // DMA-done interrupt from the previous owner can't dispatch into a
+    // stale context. The ESP-IDF LCD driver invokes our callback via
+    // the on_color_trans_done hook set when we create the panel_io, so
+    // nulling our user-level callback pointers here stops the trampoline
+    // in lcd_spi_flush_ready() from fanning out to the previous driver.
+    mCallback = nullptr;
+    mUserCtx = nullptr;
+
     if (mPanelIo != nullptr) {
         esp_lcd_panel_io_del(mPanelIo);
         mPanelIo = nullptr;
@@ -202,14 +238,22 @@ void LcdSpiPeripheralEsp::deinitialize() FL_NOEXCEPT {
         mI80Bus = nullptr;
     }
     if (mCompleteSem != nullptr) {
+        // Drain any stale "given" state from the previous owner, then
+        // delete the semaphore. Subsequent initialize() calls recreate
+        // and re-prime it so the new owner starts from a known-good
+        // state (given, ready to be taken by the first transmit()).
+        xSemaphoreTake(mCompleteSem, 0);
         vSemaphoreDelete(mCompleteSem);
         mCompleteSem = nullptr;
     }
     mInitialized = false;
-    mCallback = nullptr;
-    mUserCtx = nullptr;
     mBusy = false;
     mLastTransmitSize = 0;
+    mOwner = LcdSpiOwnerDriver::NONE;
+}
+
+void LcdSpiPeripheralEsp::deinitialize() FL_NOEXCEPT {
+    teardownLocked();
 }
 
 bool LcdSpiPeripheralEsp::isInitialized() const FL_NOEXCEPT {

--- a/src/platforms/esp/32/drivers/lcd_spi/lcd_spi_peripheral_esp.h
+++ b/src/platforms/esp/32/drivers/lcd_spi/lcd_spi_peripheral_esp.h
@@ -62,6 +62,11 @@ class LcdSpiPeripheralEsp : public ILcdSpiPeripheral {
     u64 getMicroseconds() FL_NOEXCEPT override;
     void delay(u32 ms) FL_NOEXCEPT override;
 
+    /// @brief Currently-recorded owning driver (issue #2270).
+    /// Exposed for diagnostics and tests — production callers should set
+    /// `LcdSpiConfig::owner` and let initialize() manage the transition.
+    LcdSpiOwnerDriver getOwner() const FL_NOEXCEPT { return mOwner; }
+
   private:
     template <typename T, int N>
     friend class ::fl::Singleton;
@@ -75,6 +80,11 @@ class LcdSpiPeripheralEsp : public ILcdSpiPeripheral {
     LcdSpiPeripheralEsp(const LcdSpiPeripheralEsp &) = delete;
     LcdSpiPeripheralEsp &operator=(const LcdSpiPeripheralEsp &) = delete;
 
+    /// @brief Tear down every piece of peripheral state held by this
+    /// singleton. Called from deinitialize() and from initialize() when
+    /// the owning driver changes (issue #2270).
+    void teardownLocked() FL_NOEXCEPT;
+
     bool mInitialized;
     LcdSpiConfig mConfig;
     esp_lcd_i80_bus_handle_t mI80Bus;
@@ -84,6 +94,7 @@ class LcdSpiPeripheralEsp : public ILcdSpiPeripheral {
     void *mUserCtx;
     volatile bool mBusy;
     size_t mLastTransmitSize;
+    LcdSpiOwnerDriver mOwner; ///< Tracks which driver owns the singleton (#2270).
 };
 
 } // namespace detail

--- a/src/platforms/esp/32/drivers/lcd_spi/lcd_spi_peripheral_mock.cpp.hpp
+++ b/src/platforms/esp/32/drivers/lcd_spi/lcd_spi_peripheral_mock.cpp.hpp
@@ -100,6 +100,14 @@ bool LcdSpiPeripheralMockImpl::initialize(
                 << config.num_lanes);
         return false;
     }
+    // Issue #2270: mirror the real peripheral's owner-aware teardown so
+    // host tests can exercise the cross-driver switch path.
+    const bool sameOwner =
+        (config.owner == mConfig.owner) ||
+        (config.owner == LcdSpiOwnerDriver::NONE);
+    if (mInitialized && !sameOwner) {
+        deinitialize();
+    }
     mConfig = config;
     mInitialized = true;
     mEnabled = true;

--- a/tests/platforms/esp/32/drivers/lcd_spi/lcd_spi_peripheral_mock.cpp
+++ b/tests/platforms/esp/32/drivers/lcd_spi/lcd_spi_peripheral_mock.cpp
@@ -196,6 +196,102 @@ FL_TEST_CASE("LcdSpiPeripheralMock - deinitialize") {
     FL_CHECK_FALSE(mock.isInitialized());
 }
 
+
+//=============================================================================
+// Issue #2270 — owner-aware teardown on cross-driver switch
+//=============================================================================
+
+FL_TEST_CASE("LcdSpiPeripheralMock - same owner reuse does not deinit") {
+    // Regression test for #2270: when the same driver re-initializes with
+    // the same config, the peripheral should NOT force a tear-down.
+    resetMockState();
+    auto &mock = LcdSpiPeripheralMock::instance();
+
+    LcdSpiConfig config(1, 18, 6000000, 1024);
+    config.owner = LcdSpiOwnerDriver::LCD_SPI;
+    FL_REQUIRE(mock.initialize(config));
+    size_t deinitsBefore = mock.getDeinitCount();
+
+    // Same owner, re-initialize -> fast path (no extra deinit).
+    FL_REQUIRE(mock.initialize(config));
+    FL_CHECK(mock.getDeinitCount() == deinitsBefore);
+}
+
+FL_TEST_CASE("LcdSpiPeripheralMock - cross-driver switch forces deinit") {
+    // Regression test for #2270: switching from LCD_SPI to LCD_CLOCKLESS
+    // MUST force a tear-down even if the hardware shape happens to match.
+    // Otherwise the previous driver's ISR callback and ring buffers leak
+    // into the new driver's session and the second switch silently fails.
+    resetMockState();
+    auto &mock = LcdSpiPeripheralMock::instance();
+
+    LcdSpiConfig spiConfig(1, 18, 6000000, 1024);
+    spiConfig.owner = LcdSpiOwnerDriver::LCD_SPI;
+    FL_REQUIRE(mock.initialize(spiConfig));
+    size_t deinitsBefore = mock.getDeinitCount();
+
+    // Switch to the clockless driver with identical lanes/clock/size.
+    // This is the bug's fingerprint: same shape, different owner.
+    LcdSpiConfig clocklessConfig(1, 18, 6000000, 1024);
+    clocklessConfig.owner = LcdSpiOwnerDriver::LCD_CLOCKLESS;
+    FL_REQUIRE(mock.initialize(clocklessConfig));
+
+    FL_CHECK(mock.getDeinitCount() == deinitsBefore + 1);
+    FL_CHECK(mock.getConfig().owner == LcdSpiOwnerDriver::LCD_CLOCKLESS);
+}
+
+FL_TEST_CASE(
+    "LcdSpiPeripheralMock - repeated cross-driver alternation never fails") {
+    // Regression test for #2270: the issue's failure table shows that
+    // switches 3 and 4 in an SPI -> CLOCKLESS -> SPI -> CLOCKLESS
+    // sequence start failing. After the fix every switch must deinit
+    // the previous owner and initialize successfully.
+    resetMockState();
+    auto &mock = LcdSpiPeripheralMock::instance();
+
+    LcdSpiConfig spiConfig(1, 18, 6000000, 1024);
+    spiConfig.owner = LcdSpiOwnerDriver::LCD_SPI;
+
+    LcdSpiConfig clocklessConfig(1, 18, 6000000, 1024);
+    clocklessConfig.owner = LcdSpiOwnerDriver::LCD_CLOCKLESS;
+
+    // Simulate the exact failing sequence from the issue table:
+    // 1. LCD_SPI       2. LCD_CLOCKLESS
+    // 3. LCD_SPI       4. LCD_CLOCKLESS
+    size_t baseDeinits = mock.getDeinitCount();
+
+    FL_REQUIRE(mock.initialize(spiConfig));       // #1 - cold init
+    FL_REQUIRE(mock.initialize(clocklessConfig)); // #2 - switch
+    FL_REQUIRE(mock.initialize(spiConfig));       // #3 - switch back
+    FL_REQUIRE(mock.initialize(clocklessConfig)); // #4 - switch again
+
+    // Each cross-driver switch must trigger one deinit (#2, #3, #4 = 3).
+    FL_CHECK(mock.getDeinitCount() == baseDeinits + 3);
+
+    // Final state: clockless owns the peripheral.
+    FL_CHECK(mock.isInitialized());
+    FL_CHECK(mock.getConfig().owner == LcdSpiOwnerDriver::LCD_CLOCKLESS);
+}
+
+FL_TEST_CASE(
+    "LcdSpiPeripheralMock - legacy caller without owner field still works") {
+    // Backward compatibility: existing callers that don't set `owner`
+    // leave it as NONE. The singleton should treat NONE as "don't force
+    // tear-down on owner mismatch" so legacy tests / wrappers still
+    // hit the fast path when the shape is compatible.
+    resetMockState();
+    auto &mock = LcdSpiPeripheralMock::instance();
+
+    LcdSpiConfig config(1, 18, 6000000, 1024);
+    // owner intentionally left as LcdSpiOwnerDriver::NONE (default).
+    FL_REQUIRE(mock.initialize(config));
+    size_t deinitsBefore = mock.getDeinitCount();
+
+    // Re-initialize with identical NONE-owner config -> no deinit.
+    FL_REQUIRE(mock.initialize(config));
+    FL_CHECK(mock.getDeinitCount() == deinitsBefore);
+}
+
 #endif // FASTLED_STUB_IMPL
 
 } // FL_TEST_FILE


### PR DESCRIPTION
## Summary

Fixes #2270. On ESP32-S3 the `LCD_SPI` and `LCD_CLOCKLESS` drivers share the same `LcdSpiPeripheralEsp` singleton. When alternating between the two drivers at runtime, the singleton's fast-path skipped teardown whenever the hardware shape (lanes / clock / transfer size) happened to match, leaving the previous owner's ISR callback, completion-semaphore state, panel_io handle, and ring-buffer ownership stale. The third alternating switch silently produced no DMA output (`passed:false` despite `mismatchedLeds:0`).

## Root cause

```cpp
// lcd_spi_peripheral_esp.cpp.hpp BEFORE
if (mInitialized) {
    if (mConfig.num_lanes == config.num_lanes &&
        mConfig.clock_hz == config.clock_hz &&
        mConfig.max_transfer_bytes >= config.max_transfer_bytes) {
        return true;   // fast-path — takes this branch on driver switch
    }
    deinitialize();
}
```

When the same shape came through a different driver, `initialize()` returned early without tearing down the ISR callback or draining the semaphore, so the next `transmit()` could reuse stale state.

## Fix

- Add `LcdSpiOwnerDriver` enum (`NONE`, `LCD_SPI`, `LCD_CLOCKLESS`) and an `owner` field on `LcdSpiConfig`.
- `LcdSpiPeripheralEsp` now tracks the owning driver on a new `mOwner` member.
- `initialize()` forces the slow-path (full teardown + recreate) when the incoming `owner` differs from the previously stored one, even if the shape matches.
- Both channel-driver wrappers (`channel_driver_lcd_spi`, `channel_driver_lcd_clockless`) tag their `LcdSpiConfig` with the correct owner.
- Hardened the teardown path (new `teardownLocked()` helper):
  1. Null the ISR callback **before** deleting the panel_io.
  2. Drain the completion semaphore (`xSemaphoreTake(..., 0)`) before `vSemaphoreDelete()`.
  3. Delete panel_io + i80 bus (already existed).
  4. Reset owner to `NONE`.
- Backward-compatible: legacy callers that leave `owner = NONE` keep the existing fast-path behavior.

## Expected behavior after fix

Reproducing the failing table from the issue:

| # | Driver        | Before fix    | After fix   |
|---|---------------|---------------|-------------|
| 1 | `LCD_SPI`        | `passed:true`   | `passed:true` |
| 2 | `LCD_CLOCKLESS`  | `passed:true`   | `passed:true` |
| 3 | `LCD_SPI`        | `passed:false`  | `passed:true` |
| 4 | `LCD_CLOCKLESS`  | `passed:false`  | `passed:true` |

## Tests

Added four regression tests in `tests/platforms/esp/32/drivers/lcd_spi/lcd_spi_peripheral_mock.cpp`:

- `same owner reuse does not deinit` — fast-path still works when the same driver re-initializes.
- `cross-driver switch forces deinit` — confirms `deinitCount` increments by 1 when the owner changes even if shape matches.
- `repeated cross-driver alternation never fails` — walks the exact 4-switch sequence from the issue; every switch succeeds.
- `legacy caller without owner field still works` — backward-compat guard for callers leaving `owner = NONE`.

All tests pass in both quick and debug (ASAN/LSAN/UBSAN) builds.
ESP32-S3 firmware compiles cleanly with the changes included.

## Test plan

- [x] `bash test --cpp lcd_spi_peripheral_mock` (quick + debug)
- [x] `bash test --cpp channel_driver_lcd_spi`
- [x] `bash test --cpp channel_driver_lcd_clockless`
- [x] `bash compile esp32s3 --examples Blink` (ESP-IDF build sanity)
- [x] `bash lint`
- [ ] **Hardware validation pending** — requires an ESP32-S3 running the autoresearch alternation sequence from the issue. Once hardware is available, run:
  ```
  bash autoresearch --lcd-spi --parallel
  bash autoresearch --lcd --parallel
  ```
  (or the equivalent `runSingleTest` RPC loop that reproduces the 4-switch pattern from the issue table).

## Non-goals

- Does not refactor the LCD architecture into two singletons (suggestion 3 from the issue).
- Does not change the public driver API — the `owner` field is an optional config member with a backward-compatible `NONE` default.
- Does not touch `LCD_RGB` on ESP32-P4 (separate singleton, unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved LCD peripheral management by implementing explicit ownership tracking, ensuring proper cleanup and re-initialization when switching between different LCD driver types on ESP32 platforms.

* **Tests**
  * Added regression tests verifying correct teardown behavior during LCD driver re-initialization and transitions between different driver types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->