### PR TITLE
fix(audio): silence-gate uses absolute RMS threshold, not adaptive floor (#2253)

### DIFF
--- a/ci/util/fbuild_compiledb.py
+++ b/ci/util/fbuild_compiledb.py
@@ -80,10 +80,13 @@ def ensure_compile_commands(
             check=True,
             cwd=str(project_root),
         )
-    except KeyboardInterrupt:
+    except KeyboardInterrupt as ki:
         # Per project guideline: all try/except blocks must handle
         # KeyboardInterrupt before broader exceptions so Ctrl-C is never
         # swallowed.
+        from ci.util.global_interrupt_handler import handle_keyboard_interrupt
+
+        handle_keyboard_interrupt(ki)
         raise
     except (subprocess.CalledProcessError, FileNotFoundError) as exc:
         print(

--- a/src/fl/audio/audio_processor.cpp.hpp
+++ b/src/fl/audio/audio_processor.cpp.hpp
@@ -63,8 +63,14 @@ void Processor::update(const Sample& sample) {
     // Stage 4: Silence flag — detectors use this to gate outputs when audio stops.
     // Only populated when NFT is enabled; otherwise silence is unknowable and
     // stays at its default (false) after setSample() above.
+    //
+    // Uses an absolute RMS threshold rather than NFT.isAboveFloor(): the
+    // adaptive floor's first-sample init matches the current level, so
+    // isAboveFloor() stays false for any steady signal. Absolute RMS is the
+    // right silence primitive — a loud constant tone has large RMS.
     if (mNoiseFloorTrackingEnabled && conditioned.isValid()) {
-        mContext->setSilent(!mNoiseFloorTracker.isAboveFloor(conditioned.rms()));
+        constexpr float kSilenceRmsThreshold = 10.0f;
+        mContext->setSilent(conditioned.rms() < kSilenceRmsThreshold);
     }
 
     // Phase 1: Compute state for all active detector

--- a/src/fl/audio/audio_reactive.cpp.hpp
+++ b/src/fl/audio/audio_reactive.cpp.hpp
@@ -191,8 +191,16 @@ void Reactive::processSample(const Sample& sample) {
 
     // Populate silence flag after setSample() resets it — detectors run via
     // updateFromContext() below and will read context->isSilent().
+    //
+    // Uses an absolute RMS threshold (not the adaptive noise floor). The
+    // adaptive floor's first-sample init matches the current level, which
+    // causes isAboveFloor() to be stuck at false for any steady signal —
+    // wrongly flagging loud constant tones as silent. Absolute RMS is the
+    // right primitive for "no signal present": a steady loud tone has
+    // large RMS and is not silent regardless of noise-floor adaptation.
     if (mConfig.enableNoiseFloorTracking) {
-        mContext->setSilent(!mNoiseFloorTracker.isAboveFloor(processedSample.rms()));
+        constexpr float kSilenceRmsThreshold = 10.0f;
+        mContext->setSilent(processedSample.rms() < kSilenceRmsThreshold);
     }
 
     // Process the conditioned Sample - timing is gated by sample availability

--- a/tests/fl/audio/audio_reactive.cpp
+++ b/tests/fl/audio/audio_reactive.cpp
@@ -2098,17 +2098,19 @@ FL_TEST_CASE("audio::Reactive - spectral metrics decay to zero on silence (FastL
         (void)data.spectralFlux;
     }
 
-    // Phase 2: 1 s of zero-PCM silence. The pipeline's NoiseFloorTracker
-    // will flag each frame as silent, and the envelope should decay all
-    // three spectral metrics toward zero.
-    for (int i = 0; i < kFramesPerSecond; ++i) {
+    // Phase 2: zero-PCM silence. With tau=0.2s, the envelope follows
+    // exp(-t/tau) — after t seconds the residual fraction is exp(-t/0.2).
+    // We want the residual to be small enough that the *absolute* value is
+    // < 0.01 regardless of the peak. For initial peaks ~O(1e3), that needs
+    // about exp(-t/0.2) < 1e-5 → t ≳ 2.3s. Run 2.5s of silence (~11 taus).
+    constexpr int kSilenceSeconds = 3;
+    for (int i = 0; i < kSilenceSeconds * kFramesPerSecond; ++i) {
         audio::Sample s = makeSilence(
             (kFramesPerSecond + i) * 12, kSamplesPerFrame);
         reactive.processSample(s);
     }
 
-    // With tau=0.2s and ~1 s of silence (~5*tau), outputs should be
-    // within the envelope's isGated() epsilon (1e-4) of zero.
+    // After ~15 taus of silence the envelopes are effectively zero.
     const auto& data = reactive.getData();
     FL_CHECK_LT(data.dominantFrequency, 0.01f);
     FL_CHECK_LT(data.magnitude, 0.01f);

--- a/tests/fl/audio/detector/tempo_analyzer.hpp
+++ b/tests/fl/audio/detector/tempo_analyzer.hpp
@@ -324,12 +324,13 @@ FL_TEST_CASE("audio::detector::TempoAnalyzer - confidence fades in silence, BPM 
     FL_CHECK_GT(liveBPM, 90.0f);
     FL_CHECK_LT(liveBPM, 150.0f);
 
-    // Phase 2: ~3 seconds of silence with context->setSilent(true).
-    // At 43 fps (23ms per frame), 3s ≈ 130 frames. With tau=2s the envelope
-    // crosses 95% of the decay in 3*tau = 6s, but at 3s we expect ≈ exp(-1.5) = 0.22
-    // of the starting value, which for a start around 0.5 lands near 0.11.
-    // Run longer (5s) to be well past 95% → comfortably below the 0.05 target.
-    const int silenceFrames = 220;  // ~5s
+    // Phase 2: ~8 seconds of silence with context->setSilent(true).
+    // tau=2s → after t seconds residual fraction is exp(-t/2). At t=8s,
+    // residual ≈ 0.018 — for liveConfidence up to ~2.5 this lands at
+    // ~0.045, comfortably below the 0.05 target even at the high end.
+    // Earlier durations (5s ≈ exp(-2.5) = 0.082) were too tight to the
+    // threshold and flaked when liveConfidence came in near its upper end.
+    const int silenceFrames = 350;  // ~8s at 43 fps
     for (int i = 0; i < silenceFrames; ++i) {
         timestamp += frameIntervalMs;
         ctx->setSample(audio::Sample(silenceData, timestamp));


### PR DESCRIPTION
## Summary

Fixes a pre-existing regression where `Reactive::dominantFrequency` / `magnitude` / `spectralFlux` decayed to zero during **loud** audio.

**Root cause:** `NoiseFloorTracker::update()` initializes `mCurrentFloor = combinedLevel` on the first sample. For a steady loud signal the floor immediately matches the level, so `isAboveFloor(level)` stays false forever (`level > floor + hysteresisMargin` never holds). Reactive (merged in #2309) and Processor wired `setSilent(!isAboveFloor(rms))` — so a loud 1 kHz tone was flagged as silent on every frame, and `SilenceEnvelope` decayed all three spectral metrics to 0.

**Fix:** gate silence on an absolute RMS threshold (10.0, matching `NoiseFloorTrackerConfig::minFloor`). The noise floor is still tracked for detector internals, but "no signal present" is an absolute-level concept, not an adaptive-floor one.

## Tests restored

Three tests in `fl_audio_audio_reactive` and one in `fl_audio_detectors` were failing on master:

- `audio::Reactive - dominant frequency uses log-spaced bin centers`
- `audio::Reactive - spectral metrics decay to zero on silence (FastLED#2253)`
- `audio::Reactive - spectral metrics are pass-through during loud audio (FastLED#2253)`
- `audio::detector::TempoAnalyzer - confidence fades in silence, BPM preserved`

The "decay to zero" tests were only passing by accident of the buggy silent-during-loud shortcut; with the fix they now rely on actual exponential decay, so phase 2 was extended to 3s (audio_reactive, tau=0.2s → 15 taus) and 8s (tempo_analyzer, tau=2s → 4 taus) so the assertions hold on the clean math.

## Also

Pre-existing KBI003 lint in `ci/util/fbuild_compiledb.py` was blocking this branch's lint gate; fixed in-place.

## Test plan

- [x] `bash test fl_audio_audio_reactive --cpp` — passes
- [x] `bash test fl_audio_detectors --cpp` — passes
- [x] `bash test fl_audio_audio_reactive --debug` — passes (ASAN/LSAN/UBSAN clean)
- [x] `bash test fl_audio_detectors --debug` — passes
- [x] `bash lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated audio silence detection to use a fixed RMS threshold instead of adaptive tracking, improving consistency in signal classification.

* **Tests**
  * Adjusted audio reactive and tempo analyzer test expectations to reflect updated silence detection behavior.

* **Chores**
  * Enhanced interrupt handling in the build system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->