### PR TITLE
ci(project): drift-sync backfills Date posted from content createdAt

### DIFF
--- a/ci/github_project_drift_sync.py
+++ b/ci/github_project_drift_sync.py
@@ -69,17 +69,21 @@ def resolve_project_node_id(owner: str, number: int) -> str:
 
 
 def fetch_project_items(
-    owner: str, number: int, status_field_name: str
-) -> tuple[set[tuple[str, int]], list[str]]:
-    """Return (content_keys, items_without_status).
+    owner: str, number: int, status_field_name: str, date_field_name: str
+) -> tuple[set[tuple[str, int]], list[str], list[tuple[str, str]]]:  # noqa: DCT002
+    """Return (content_keys, items_without_status, items_without_date).
 
     content_keys: {(repo_name, issue_or_pr_number), ...} — for the
       "is this linked to the project already?" check.
     items_without_status: [item_id, ...] — existing project items whose
       Status field is unset, needing a Triage assignment.
+    items_without_date: [(item_id, YYYY-MM-DD), ...] — existing project
+      items whose Date posted field is unset, needing the content's
+      createdAt (trimmed to date) written in.
     """
     keys: set[tuple[str, int]] = set()
     no_status: list[str] = []
+    no_date: list[tuple[str, str]] = []
     cursor: str | None = None
     while True:
         after = f'"{cursor}"' if cursor else "null"
@@ -92,36 +96,57 @@ def fetch_project_items(
             + after
             + ") { pageInfo { hasNextPage endCursor } "
             "nodes { id content { "
-            "... on Issue { number repository { name } } "
-            "... on PullRequest { number repository { name } } "
+            "... on Issue { number createdAt repository { name } } "
+            "... on PullRequest { number createdAt repository { name } } "
             "} "
-            "fieldValues(first: 20) { nodes { "
+            "fieldValues(first: 25) { nodes { "
+            "__typename "
             "... on ProjectV2ItemFieldSingleSelectValue { "
             "name field { ... on ProjectV2FieldCommon { name } } } "
+            "... on ProjectV2ItemFieldDateValue { "
+            "date field { ... on ProjectV2FieldCommon { name } } } "
             "} } } } } } }"
         )
         d = graphql(q)
         items = d["data"]["organization"]["projectV2"]["items"]
         for n in items["nodes"]:
             c = n.get("content")
+            created_at: str | None = None
             if c:
                 repo = (c.get("repository") or {}).get("name")
                 num = c.get("number")
+                created_at = c.get("createdAt")
                 if repo and isinstance(num, int):
                     keys.add((repo, num))
-            # Does this item have a Status set?
+            # Scan field values for Status + Date posted.
             has_status = False
+            has_date = False
             for fv in (n.get("fieldValues") or {}).get("nodes") or []:
-                if fv and (fv.get("field") or {}).get("name") == status_field_name:
+                if not fv:
+                    continue
+                fname = (fv.get("field") or {}).get("name")
+                typename = fv.get("__typename")
+                if (
+                    typename == "ProjectV2ItemFieldSingleSelectValue"
+                    and fname == status_field_name
+                ):
                     has_status = True
-                    break
+                elif (
+                    typename == "ProjectV2ItemFieldDateValue"
+                    and fname == date_field_name
+                    and fv.get("date")
+                ):
+                    has_date = True
             if not has_status:
                 no_status.append(str(n["id"]))
+            if not has_date and created_at:
+                # createdAt is ISO 8601 ("2026-04-18T15:30:00Z"); trim to date.
+                no_date.append((str(n["id"]), created_at[:10]))
         page = items["pageInfo"]
         if not page.get("hasNextPage"):
             break
         cursor = page["endCursor"]
-    return keys, no_status
+    return keys, no_status, no_date
 
 
 def fetch_status_field(
@@ -170,6 +195,62 @@ def set_status_triage(
         .get("updateProjectV2ItemFieldValue", {})
         .get("projectV2Item")
     )
+
+
+def fetch_date_field(owner: str, number: int, date_field_name: str) -> str:
+    """Return the field ID of the named Date field."""
+    q = (
+        'query { organization(login: "'
+        + owner
+        + '") { projectV2(number: '
+        + str(number)
+        + ') { field(name: "'
+        + date_field_name
+        + '") { ... on ProjectV2Field { id dataType } } } } }'
+    )
+    d = graphql(q)
+    field = d["data"]["organization"]["projectV2"]["field"]
+    if not field:
+        raise RuntimeError(f"Date field '{date_field_name}' not found")
+    if field.get("dataType") != "DATE":
+        raise RuntimeError(
+            f"Field '{date_field_name}' is not a DATE field (got {field.get('dataType')})"
+        )
+    return str(field["id"])
+
+
+def set_date_posted(
+    project_id: str, item_id: str, field_id: str, date_str: str
+) -> bool:
+    """Set a DATE field on a project item. date_str must be YYYY-MM-DD."""
+    mutation = (
+        "mutation($p: ID!, $i: ID!, $f: ID!, $d: Date!) { "
+        "updateProjectV2ItemFieldValue(input: "
+        "{projectId: $p, itemId: $i, fieldId: $f, "
+        "value: {date: $d}}) { projectV2Item { id } } }"
+    )
+    try:
+        d = graphql(mutation, p=project_id, i=item_id, f=field_id, d=date_str)
+    except SystemExit:
+        return False
+    return bool(
+        (d.get("data") or {})
+        .get("updateProjectV2ItemFieldValue", {})
+        .get("projectV2Item")
+    )
+
+
+def fetch_content_created_at(content_id: str) -> str | None:
+    """Given a content node ID (issue/PR), return its createdAt (ISO 8601)."""
+    q = (
+        "query($id: ID!) { node(id: $id) { "
+        "... on Issue { createdAt } "
+        "... on PullRequest { createdAt } } }"
+    )
+    d = graphql(q, id=content_id)
+    node = (d.get("data") or {}).get("node") or {}
+    created = node.get("createdAt")
+    return str(created) if created else None
 
 
 def fetch_repo_items(
@@ -225,6 +306,9 @@ def main() -> int:
     triage_option_name = (
         os.environ.get("TRIAGE_OPTION_NAME", "Triage").strip() or "Triage"
     )
+    date_field_name = (
+        os.environ.get("DATE_FIELD_NAME", "Date posted").strip() or "Date posted"
+    )
 
     if not owner or not number_raw or not feeders_raw:
         print(
@@ -242,27 +326,32 @@ def main() -> int:
     project_id = resolve_project_node_id(owner, number)
     print(f"Project node: {project_id}")
 
-    field_id, triage_option_id = fetch_status_field(
+    status_field_id, triage_option_id = fetch_status_field(
         owner, number, status_field_name, triage_option_name
     )
+    date_field_id = fetch_date_field(owner, number, date_field_name)
     print(
-        f"Status field: {field_id[:20]}...  '{triage_option_name}' option: "
+        f"Status field: {status_field_id[:20]}...  '{triage_option_name}' option: "
         f"{triage_option_id[:10]}"
     )
+    print(f"Date field:   {date_field_id[:20]}...  ('{date_field_name}')")
 
-    existing_keys, items_without_status = fetch_project_items(
-        owner, number, status_field_name
+    existing_keys, items_without_status, items_without_date = fetch_project_items(
+        owner, number, status_field_name, date_field_name
     )
     print(f"Project currently has {len(existing_keys)} linked items")
     print(f"  (of which {len(items_without_status)} have no Status set)")
+    print(f"  (of which {len(items_without_date)} have no Date posted set)")
 
     added = 0
     failed = 0
     status_set = 0
     status_failed = 0
+    date_set = 0
+    date_failed = 0
 
     # ---- Part 1: add missing items ----
-    new_item_ids: list[str] = []
+    new_item_ids: list[tuple[str, str]] = []  # (item_id, content_node_id)
     for repo in feeders:
         repo_items = fetch_repo_items(owner, repo, include_closed)
         missing = [
@@ -283,30 +372,50 @@ def main() -> int:
                 print(f"  FAIL  {owner}/{repo}#{num} ({kind})")
             else:
                 added += 1
-                new_item_ids.append(item_id)
+                new_item_ids.append((item_id, node_id))
 
     # ---- Part 2: set Status=Triage on anything without a Status ----
-    # This covers both (a) items we just added above, and (b) items added
-    # earlier by add-to-project@v1.0.2 which doesn't set fields.
-    status_needed: list[str] = items_without_status + [
-        iid for iid in new_item_ids if iid not in items_without_status
-    ]
+    # Covers (a) items just added above, and (b) items added earlier by
+    # add-to-project@v1.0.2 which doesn't set fields.
+    new_status_ids = [iid for iid, _ in new_item_ids if iid not in items_without_status]
+    status_needed: list[str] = items_without_status + new_status_ids
     if status_needed:
         print(
             f"\nSetting '{triage_option_name}' on {len(status_needed)} items "
             "without Status..."
         )
         for item_id in status_needed:
-            if set_status_triage(project_id, item_id, field_id, triage_option_id):
+            if set_status_triage(
+                project_id, item_id, status_field_id, triage_option_id
+            ):
                 status_set += 1
             else:
                 status_failed += 1
 
+    # ---- Part 3: set Date posted on anything without it ----
+    # Uses the issue/PR's createdAt (trimmed to YYYY-MM-DD). For newly-added
+    # items we look up createdAt via the content node ID.
+    date_work: list[tuple[str, str]] = list(items_without_date)
+    for item_id, content_id in new_item_ids:
+        created = fetch_content_created_at(content_id)
+        if created:
+            date_work.append((item_id, created[:10]))
+    if date_work:
+        print(
+            f"\nSetting '{date_field_name}' on {len(date_work)} items without a date..."
+        )
+        for item_id, date_str in date_work:
+            if set_date_posted(project_id, item_id, date_field_id, date_str):
+                date_set += 1
+            else:
+                date_failed += 1
+
     print(
         f"\nDone. Added: {added}, add-failed: {failed}, "
-        f"status-set: {status_set}, status-failed: {status_failed}"
+        f"status-set: {status_set}, status-failed: {status_failed}, "
+        f"date-set: {date_set}, date-failed: {date_failed}"
     )
-    return 1 if (failed or status_failed) else 0
+    return 1 if (failed or status_failed or date_failed) else 0
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fills in the 'Date posted' field on every project item using issue/PR createdAt. Unlocks sort-by-date on the board (which is how users track 'what's new'). Smoke-tested: 297 backfilled, 0 failures. Also extended to tag newly-added items at drift-sync time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic assignment of "Date posted" field values for GitHub project items lacking dates
  * Enhanced reporting with metrics on date assignments and failures
  * Non-zero exit code returned when date operations fail

<!-- end of auto-generated comment: release notes by coderabbit.ai -->