### PR TITLE
fix(audio): add ifndef guard to vibe.h so pragma once survives mixed-slash include paths

### DIFF
--- a/src/fl/audio/detector/vibe.h
+++ b/src/fl/audio/detector/vibe.h
@@ -27,6 +27,9 @@
 
 #pragma once
 
+#ifndef FL_AUDIO_DETECTOR_VIBE_H
+#define FL_AUDIO_DETECTOR_VIBE_H
+
 #include "fl/audio/audio_detector.h"
 #include "fl/audio/fft/fft.h"
 #include "fl/audio/silence_envelope.h"
@@ -169,3 +172,5 @@ private:
 } // namespace detector
 } // namespace audio
 } // namespace fl
+
+#endif // FL_AUDIO_DETECTOR_VIBE_H


### PR DESCRIPTION
## Summary

- Add classic `#ifndef FL_AUDIO_DETECTOR_VIBE_H` guard alongside the existing `#pragma once` in `src/fl/audio/detector/vibe.h`.
- Matches the belt-and-suspenders pattern already used in `src/fl/audio/audio_processor.h`.

## Background

On Windows builds, clang sometimes presents the include path for `vibe.h` with mixed slashes:

```
C:/Users/niteris/dev/fastled6/./src\fl/audio/detector/vibe.h
```

When `vibe.h` is pulled in through two different paths in the same translation unit — once via `audio_processor.h` (line 9) and once via `tests/fl/audio/detector/vibe.hpp` (line 6) — `#pragma once`'s file-identity check can fail to deduplicate. The TU then sees `VibeLevels` and `Vibe` defined twice and fails with:

```
error: redefinition of 'VibeLevels'
error: redefinition of 'Vibe'
note: included multiple times, additional include site here
```

Adding an `#ifndef` guard is content-based and path-agnostic, so it deduplicates regardless of how the include path is spelled. This mirrors what `audio_processor.h` already does.

## Why this matters

Master CI has been failing on this error. Reproduced locally on Windows; the guard fixes it.

## Test plan

- [x] `bash test vibe --cpp` — vibe unit test passes
- [x] `bash test --cpp` — all 299 C++ unit tests + examples pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Internal code maintenance improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->