### PR TITLE
fix(audio): add #ifndef guards to vibe.h for PCH-safe inclusion

### DIFF
--- a/src/fl/audio/detector/vibe.h
+++ b/src/fl/audio/detector/vibe.h
@@ -27,6 +27,9 @@
 
 #pragma once
 
+#ifndef FL_AUDIO_DETECTOR_VIBE_H
+#define FL_AUDIO_DETECTOR_VIBE_H
+
 #include "fl/audio/audio_detector.h"
 #include "fl/audio/fft/fft.h"
 #include "fl/audio/silence_envelope.h"
@@ -169,3 +172,5 @@ private:
 } // namespace detector
 } // namespace audio
 } // namespace fl
+
+#endif // FL_AUDIO_DETECTOR_VIBE_H


### PR DESCRIPTION
Classic #ifndef guards alongside existing #pragma once. Works around a Clang-on-Windows PCH dedup quirk that caused VibeLevels/Vibe redefinition errors when vibe.h was pulled in via the test PCH (FastLED.h → audio_processor.h → vibe.h) and also directly by the standalone tests/fl/audio/detector/vibe.cpp. Confirmed fix with clean rebuild: all audio tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal code maintenance improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->