### PR TITLE
chore(ci): add teensy40/41 to fbuild, KeyboardInterrupt in RPG, dedupe pyproject

### DIFF
--- a/ci/compiler/fbuild_boards.py
+++ b/ci/compiler/fbuild_boards.py
@@ -10,10 +10,12 @@
 #
 # NOT supported by fbuild (must stay on PlatformIO):
 #   - atmelmegaavr boards (ATtiny1604, ATtiny1616, nano_every) -- platform not recognized
-#   - Teensy 3.x/LC (teensy30..36, teensylc)
-#   - Specialized ESP32 variants (qemu, idf33, idf44, i2s)
+#   - Teensy 3.x/LC (teensy30..36, teensylc) -- no Cortex-M7
+#   - Specialized ESP32 variants (qemu, idf33, idf44, i2s) -- custom IDF/driver configs
 #   - uno_r4_wifi -- uses renesas-ra platform, no fbuild orchestrator
-#   - teensy40, teensy41
+#   - atmega8a -- MiniCore framework: core path + board name mapping broken
+#   - STM32, RP2040/RP2350, NRF52, Apollo3, SAM/SAMD, MGM240 -- no orchestrators
+#   - esp8266 -- no orchestrator
 FBUILD_BOARDS: frozenset[str] = frozenset(
     {
         # AVR (atmelavr)
@@ -34,5 +36,8 @@ FBUILD_BOARDS: frozenset[str] = frozenset(
         "esp32h2",
         "upesy_wroom",
         "seeed_xiao_esp32s3",
+        # Teensy (arm-none-eabi-gcc, Cortex-M7)
+        "teensy40",
+        "teensy41",
     }
 )

--- a/ci/util/running_process_group.py
+++ b/ci/util/running_process_group.py
@@ -367,11 +367,16 @@ class RunningProcessGroup:
                 if not any_activity:
                     time.sleep(0.01)
 
+        except KeyboardInterrupt:
+            # Kill all active child processes on interrupt
+            for proc in active_processes:
+                proc.kill()
+            handle_keyboard_interrupt(KeyboardInterrupt())
+            raise
         finally:
             # Clean up monitoring
             if stuck_monitor:
-                for proc in self.processes:
-                    stuck_monitor.stop_monitoring(proc)
+                stuck_monitor.shutdown()
             self._status_monitoring_active = False
 
         # Check for processes that failed with non-zero exit codes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,6 @@ dependencies = [
     "colorama>=0.4.6",
     "ty>=0.0.15",
     "bleak>=0.22.3",
-    "running-process>=3.0.7",
 ]
 
 [build-system]


### PR DESCRIPTION
## Summary
- `ci/compiler/fbuild_boards.py`: add `teensy40`/`teensy41` to `FBUILD_BOARDS` (teensy orchestrator already supports Cortex-M7) and refresh the "NOT supported" comments to list actual gaps (STM32, RP2040/RP2350, NRF52, Apollo3, SAM/SAMD, MGM240, esp8266, atmega8a).
- `ci/util/running_process_group.py`: catch `KeyboardInterrupt` in the main wait loop — kill active children, delegate to `handle_keyboard_interrupt`, then reraise. Replace per-process `stop_monitoring` cleanup with a single `StuckMonitor.shutdown()` call.
- `pyproject.toml`: remove duplicate `running-process>=3.0.7` dep (canonical `running-process>=3.0.9` remains at line 45).

## Test plan
- [ ] `bash lint` clean
- [ ] `bash fbuild teensy40 --examples Blink` succeeds
- [ ] `bash fbuild teensy41 --examples Blink` succeeds
- [ ] Existing AVR/ESP32 `FBUILD_BOARDS` still compile
- [ ] Ctrl-C during `bash test` terminates cleanly without orphaned child processes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Teensy 4.0 and Teensy 4.1 boards.

* **Bug Fixes**
  * Improved keyboard interrupt handling to ensure all child processes are properly terminated when interrupted.
  * Enhanced process group cleanup mechanism for better reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->