### PR TITLE
refactor(ci): decouple IWYU + cppcheck from PIO project tree (#2303)

### DIFF
--- a/ci/ci-iwyu.py
+++ b/ci/ci-iwyu.py
@@ -532,8 +532,13 @@ def run_iwyu_against_compile_db(
         f"using compile DB: {compile_db}"
     )
     try:
-        result = subprocess.run(cmd)
+        result = subprocess.run(cmd, check=True)
         return result.returncode
+    except KeyboardInterrupt as ki:
+        from ci.util.global_interrupt_handler import handle_keyboard_interrupt
+
+        handle_keyboard_interrupt(ki)
+        raise
     except subprocess.CalledProcessError as e:
         print(f"clang-tool-chain-iwyu-tool failed with return code {e.returncode}")
         return e.returncode
@@ -811,8 +816,10 @@ def main() -> int:
 
         handle_keyboard_interrupt(ki)
         raise
-    except Exception:
-        canonical_board_name = args.board
+    except Exception as e:
+        raise RuntimeError(
+            f"Failed to resolve board '{args.board}' via ci.boards.create_board: {e}"
+        ) from e
     if canonical_board_name != args.board:
         print(
             f"Resolved board '{args.board}' to canonical name '{canonical_board_name}'"

--- a/ci/ci-iwyu.py
+++ b/ci/ci-iwyu.py
@@ -18,7 +18,8 @@ from concurrent.futures import ProcessPoolExecutor, as_completed
 from pathlib import Path
 
 from ci.iwyu_cache import IWYUCache, compute_source_tree_hash
-from ci.util.fbuild_compiledb import ensure_compile_commands, was_compiled_with_fbuild
+from ci.util.fbuild_adapter import get_compile_commands
+from ci.util.fbuild_compiledb import was_compiled_with_fbuild
 
 
 # ---------------------------------------------------------------------------
@@ -830,7 +831,7 @@ def main() -> int:
     # project-tree assumption entirely — no platformio.ini required. See
     # FastLED#2303.
     if was_compiled_with_fbuild(build, canonical_board_name):
-        compile_db = ensure_compile_commands(_PROJECT_ROOT, build, canonical_board_name)
+        compile_db = get_compile_commands(canonical_board_name, build_root=build)
         if compile_db is None:
             print(
                 f"ERROR: could not obtain fbuild compile_commands.json for "
@@ -842,7 +843,7 @@ def main() -> int:
             )
             return 1
         result_code = run_iwyu_against_compile_db(compile_db, _PROJECT_ROOT, args)
-        if args.fix and result_code == 0:
+        if args.fix:
             # IWYU-tool mode emits fixits to stdout only — `fix_includes` is a
             # separate pass. For fbuild boards `--fix` is not wired up yet
             # (tracked upstream); fail loudly rather than silently no-op.
@@ -865,8 +866,13 @@ def main() -> int:
         print(f"Board {args.board} not found in {build}")
         print("Available boards:")
         for d in build.iterdir():
-            if d.is_dir():
+            if d.is_dir() and d.name != "pio":
                 print(f"  {d.name}")
+        pio_root = build / "pio"
+        if pio_root.exists():
+            for d in pio_root.iterdir():
+                if d.is_dir():
+                    print(f"  {d.name}")
         return 1
 
     project_dir = find_platformio_project_dir(board_dir)

--- a/ci/ci-iwyu.py
+++ b/ci/ci-iwyu.py
@@ -18,6 +18,7 @@ from concurrent.futures import ProcessPoolExecutor, as_completed
 from pathlib import Path
 
 from ci.iwyu_cache import IWYUCache, compute_source_tree_hash
+from ci.util.fbuild_compiledb import ensure_compile_commands, was_compiled_with_fbuild
 
 
 # ---------------------------------------------------------------------------
@@ -416,6 +417,128 @@ def check_iwyu_available() -> tuple[bool, str]:
 # ---------------------------------------------------------------------------
 
 
+def _load_src_files_from_compile_db(compile_db: Path, project_root: Path) -> list[str]:
+    """Return the list of TUs in ``compile_db`` that live under ``<project_root>/src/``.
+
+    Filters out third-party / framework translation units so we only analyze
+    FastLED's own code — matches the scope of the legacy
+    ``pio check --src-filters=+<src/>`` invocation (and the identically-named
+    helper in ``ci/ci-cppcheck.py``). Without this scoping, ESP32-class
+    compile DBs carry thousands of framework TUs whose aggregated argv
+    overflows Windows' ``CreateProcess`` 32 KiB command-line limit.
+
+    Per the JSON Compilation Database spec, ``file`` may be absolute OR
+    relative to ``directory`` (which is itself absolute); resolve relatives
+    against ``directory`` (fallback: ``compile_db.parent``) rather than the
+    Python CWD.
+    """
+    src_root = (project_root / "src").resolve()
+    with compile_db.open("r", encoding="utf-8") as fh:
+        entries = json.load(fh)
+    files: list[str] = []
+    for entry in entries:
+        raw = entry.get("file")
+        if not raw:
+            continue
+        raw_path = Path(raw)
+        if not raw_path.is_absolute():
+            directory = entry.get("directory") or compile_db.parent
+            raw_path = Path(directory) / raw_path
+        try:
+            resolved = raw_path.resolve()
+        except OSError:
+            continue
+        try:
+            resolved.relative_to(src_root)
+        except ValueError:
+            continue
+        files.append(str(resolved))
+    return files
+
+
+def run_iwyu_against_compile_db(
+    compile_db: Path, project_root: Path, args: argparse.Namespace
+) -> int:
+    """Run IWYU against a ``compile_commands.json`` via ``clang-tool-chain-iwyu-tool``.
+
+    This is the fbuild-backend entry point — it drives IWYU off the compile
+    database fbuild emits (``fbuild build -e <env> --target compiledb``),
+    bypassing the PlatformIO project-tree assumption entirely. The same
+    pattern generalizes to other ``clang-tool-chain-*`` wrappers: adding
+    ``clang-tidy``, ``clang-format-check``, or ``clang-query`` is a ~10-LOC
+    addition — wire the wrapper name, point it at ``compile_db.parent`` via
+    ``-p``, and pass the source file list through
+    ``_load_src_files_from_compile_db``.
+
+    Args:
+        compile_db: Path to ``compile_commands.json`` (its *parent* directory
+            is what ``iwyu-tool -p`` expects).
+        project_root: Repo root — used to resolve IWYU mapping files
+            (``ci/iwyu/fastled.imp``, ``ci/iwyu/stdlib.imp``) and to filter
+            the compile DB down to ``src/`` TUs.
+        args: Parsed CLI args (consumes ``--verbose``, ``--max-line-length``,
+            ``--mapping-file``).
+
+    Returns:
+        Subprocess return code from ``clang-tool-chain-iwyu-tool`` (``0`` if
+        there were no ``src/`` TUs in the compile DB — nothing to analyze is
+        not a failure).
+    """
+    files = _load_src_files_from_compile_db(compile_db, project_root)
+    if not files:
+        print(
+            f"No src/ translation units found in {compile_db} — nothing to "
+            f"analyze. (Compile DB may cover only framework code for this "
+            f"board.)"
+        )
+        return 0
+
+    mapping_args: list[str] = []
+    for name in ("fastled.imp", "stdlib.imp"):
+        p = project_root / "ci" / "iwyu" / name
+        if p.exists():
+            mapping_args.extend(["-Xiwyu", f"--mapping_file={p}"])
+
+    if args.mapping_file:
+        for mapping in args.mapping_file:
+            mapping_args.extend(["-Xiwyu", f"--mapping_file={mapping}"])
+
+    iwyu_tail: list[str] = [
+        "-Xiwyu",
+        f"--max_line_length={args.max_line_length}",
+        "-Xiwyu",
+        "--quoted_includes_first",
+        "-Xiwyu",
+        "--no_comments",
+        "-Xiwyu",
+        "--verbose=3" if args.verbose else "--verbose=1",
+    ] + mapping_args
+
+    jobs = str(os.cpu_count() or 4)
+    cmd: list[str] = [
+        "uv",
+        "run",
+        "clang-tool-chain-iwyu-tool",
+        "-p",
+        str(compile_db.parent),
+        "-j",
+        jobs,
+        *files,
+        "--",
+    ] + iwyu_tail
+
+    print(
+        f"Running clang-tool-chain-iwyu-tool against {len(files)} src/ files "
+        f"using compile DB: {compile_db}"
+    )
+    try:
+        result = subprocess.run(cmd)
+        return result.returncode
+    except subprocess.CalledProcessError as e:
+        print(f"clang-tool-chain-iwyu-tool failed with return code {e.returncode}")
+        return e.returncode
+
+
 def find_platformio_project_dir(board_dir: Path) -> Path | None:
     """Find a directory containing platformio.ini in the board's build directory."""
     if not board_dir.exists():
@@ -670,15 +793,68 @@ def main() -> int:
                 print("✅ All src/fl/ headers pass IWYU")
         return 0
 
-    # --- Board mode: PlatformIO ---
+    # --- Board mode: fbuild (preferred) or PlatformIO (legacy) ---
     build = _PROJECT_ROOT / ".build"
     if not build.exists():
         print(f"Build directory {build} not found")
         print("Run a compilation first: ./compile [board] --examples [example]")
         return 1
 
-    board_dir = build / args.board
-    if not board_dir.exists():
+    # Resolve board aliases to the canonical fbuild env / PIO build dir name.
+    # Must match ci-cppcheck.py so both tools see the same backend signal.
+    try:
+        from ci.boards import create_board
+
+        canonical_board_name = create_board(args.board).board_name
+    except KeyboardInterrupt as ki:
+        from ci.util.global_interrupt_handler import handle_keyboard_interrupt
+
+        handle_keyboard_interrupt(ki)
+        raise
+    except Exception:
+        canonical_board_name = args.board
+    if canonical_board_name != args.board:
+        print(
+            f"Resolved board '{args.board}' to canonical name '{canonical_board_name}'"
+        )
+
+    # fbuild-backed boards (esp32c2, esp32c6, …): drive IWYU off fbuild's
+    # compile_commands.json via clang-tool-chain-iwyu-tool. Bypasses the PIO
+    # project-tree assumption entirely — no platformio.ini required. See
+    # FastLED#2303.
+    if was_compiled_with_fbuild(build, canonical_board_name):
+        compile_db = ensure_compile_commands(_PROJECT_ROOT, build, canonical_board_name)
+        if compile_db is None:
+            print(
+                f"ERROR: could not obtain fbuild compile_commands.json for "
+                f"'{canonical_board_name}'. fbuild >= 2.1 should emit this "
+                f"via `fbuild build -e {canonical_board_name} --target "
+                f"compiledb`; verify the fbuild version and the env name. "
+                f"Tracking: FastLED#2303.",
+                file=sys.stderr,
+            )
+            return 1
+        result_code = run_iwyu_against_compile_db(compile_db, _PROJECT_ROOT, args)
+        if args.fix and result_code == 0:
+            # IWYU-tool mode emits fixits to stdout only — `fix_includes` is a
+            # separate pass. For fbuild boards `--fix` is not wired up yet
+            # (tracked upstream); fail loudly rather than silently no-op.
+            print(
+                "NOTE: --fix is not yet supported for fbuild-backed boards; "
+                "violations were reported but not auto-fixed.",
+                file=sys.stderr,
+            )
+        return result_code
+
+    # PIO-backed boards: search both the modern layout
+    # (``.build/pio/<board>/``) and the legacy one (``.build/<board>/``).
+    # This matches ci-cppcheck.py's multi-layout resolver.
+    candidate_dirs = [
+        build / "pio" / canonical_board_name,
+        build / canonical_board_name,
+    ]
+    board_dir: Path | None = next((d for d in candidate_dirs if d.exists()), None)
+    if board_dir is None:
         print(f"Board {args.board} not found in {build}")
         print("Available boards:")
         for d in build.iterdir():

--- a/ci/util/fbuild_adapter.py
+++ b/ci/util/fbuild_adapter.py
@@ -30,6 +30,40 @@ from pathlib import Path
 from ci.util.global_interrupt_handler import handle_keyboard_interrupt
 
 
+def get_compile_commands(board: str, build_root: Path | None = None) -> Path | None:
+    """Return the path to ``compile_commands.json`` for ``board``.
+
+    Thin wrapper around :func:`ci.util.fbuild_compiledb.ensure_compile_commands`
+    that serves as the public, stable entry point for static-analysis tools
+    (``ci/ci-iwyu.py``, ``ci/ci-cppcheck.py``, future ``clang-tidy`` /
+    ``clang-format-check`` front-ends) to obtain an fbuild-produced compile
+    database without reaching into the implementation module directly.
+
+    If fbuild has already emitted the database for this board, its existing
+    path is returned. Otherwise fbuild is invoked with
+    ``fbuild <project> build -e <board> --target compiledb`` to materialize it.
+
+    Args:
+        board: Canonical board / fbuild environment name (e.g. ``"esp32c2"``).
+        build_root: Optional ``.build/`` directory. Defaults to
+            ``<repo-root>/.build/`` — where fbuild writes its artifacts under
+            ``.fbuild/build/<env>/``.
+
+    Returns:
+        Path to ``compile_commands.json`` on success, ``None`` if fbuild
+        couldn't produce one (binary missing, build failure, etc.).
+    """
+    # Local import: keep this module importable even when fbuild isn't
+    # installed, so callers that only need the identity-probe helpers
+    # (``is_fbuild_available``) stay lightweight.
+    from ci.util.fbuild_compiledb import ensure_compile_commands
+
+    project_root = Path(__file__).resolve().parent.parent.parent
+    if build_root is None:
+        build_root = project_root / ".build"
+    return ensure_compile_commands(project_root, build_root, board)
+
+
 def is_fbuild_available() -> bool:
     """Check if fbuild is available in the environment.
 

--- a/ci/util/fbuild_compiledb.py
+++ b/ci/util/fbuild_compiledb.py
@@ -17,23 +17,65 @@ import sys
 from pathlib import Path
 
 
-def fbuild_release_dir(build_root: Path, board_name: str) -> Path:
-    """Path to the fbuild release dir for ``board_name`` under ``build_root``.
+def _candidate_fbuild_release_dirs(build_root: Path, board_name: str) -> list[Path]:
+    """Candidate locations where fbuild may have written artifacts.
 
-    Matches ``PioCompiler._artifacts_dir`` in ``ci/compiler/pio.py``.
+    FastLED compiles fbuild with ``build_dir=<repo>/.build/pio/<board>/`` (see
+    ``ci/compiler/pio.py::_artifacts_dir``), so fbuild's output lives at
+    ``.build/pio/<board>/.fbuild/build/<env>/release/``. The standalone CLI
+    (``fbuild <repo> build --target compiledb``) instead emits
+    ``<repo>/.fbuild/build/<env>/release/`` — we treat both as valid so that a
+    direct ``--target compiledb`` invocation (no prior FastLED compile) also
+    works. An older ``.build/.fbuild/…`` layout is kept as a tail fallback.
+
+    Returned in preference order (first hit wins).
     """
-    return build_root / ".fbuild" / "build" / board_name / "release"
+    # Repo root is the parent of .build/ when build_root follows convention.
+    repo_root = build_root.parent if build_root.name == ".build" else build_root
+    return [
+        build_root / "pio" / board_name / ".fbuild" / "build" / board_name / "release",
+        repo_root / ".fbuild" / "build" / board_name / "release",
+        build_root / ".fbuild" / "build" / board_name / "release",
+    ]
+
+
+def fbuild_release_dir(build_root: Path, board_name: str) -> Path:
+    """Return the canonical fbuild release dir for ``board_name``.
+
+    Prefers the first of the candidate locations in
+    :func:`_candidate_fbuild_release_dirs` that already exists, and falls back
+    to the FastLED-orchestrated layout
+    (``.build/pio/<board>/.fbuild/build/<env>/release/``) when none do — so
+    callers can still materialize artifacts there via
+    :func:`ensure_compile_commands`.
+    """
+    candidates = _candidate_fbuild_release_dirs(build_root, board_name)
+    for cand in candidates:
+        if cand.exists():
+            return cand
+    return candidates[0]
 
 
 def was_compiled_with_fbuild(build_root: Path, board_name: str) -> bool:
-    """True iff fbuild produced artifacts for ``board_name``.
+    """True iff fbuild produced artifacts for ``board_name`` anywhere we look.
 
-    Detection probes the release dir (``.build/.fbuild/build/<env>/release/``)
-    which fbuild's ESP32 orchestrator populates during compile. This matches
-    the detection logic lifted from ``ci/ci-cppcheck.py`` and is the canonical
-    fbuild-vs-PIO backend signal for post-compile tooling.
+    Probes every candidate release dir from
+    :func:`_candidate_fbuild_release_dirs` — fbuild's ESP32 / AVR / Teensy
+    orchestrators populate this directory during compile, so its presence is
+    the canonical fbuild-vs-PIO backend signal for post-compile tooling.
     """
-    return fbuild_release_dir(build_root, board_name).exists()
+    return any(
+        cand.exists() for cand in _candidate_fbuild_release_dirs(build_root, board_name)
+    )
+
+
+def _find_existing_compile_db(build_root: Path, board_name: str) -> Path | None:
+    """Return an existing ``compile_commands.json`` for ``board_name``, or None."""
+    for cand in _candidate_fbuild_release_dirs(build_root, board_name):
+        cdb = cand / "compile_commands.json"
+        if cdb.exists():
+            return cdb
+    return None
 
 
 def ensure_compile_commands(
@@ -41,24 +83,24 @@ def ensure_compile_commands(
 ) -> Path | None:
     """Ensure ``compile_commands.json`` exists for ``board_name``; return its path.
 
-    If the DB is already present, returns it immediately. Otherwise shells out
-    to ``fbuild build -e <env> --target compiledb`` and returns the resulting
-    path. Returns ``None`` if fbuild isn't on PATH or the subprocess fails.
+    If the DB is already present at any known location (see
+    :func:`_candidate_fbuild_release_dirs`), returns it immediately. Otherwise
+    shells out to ``fbuild <project_root> build -e <env> --target compiledb``
+    and returns the resulting path. Returns ``None`` if fbuild isn't on PATH
+    or the subprocess fails.
 
     Args:
         project_root: FastLED repo root (the directory fbuild resolves
             ``fbuild.toml`` / ``pyproject.toml`` from).
-        build_root: The ``.build/`` directory — fbuild writes its artifacts
-            under ``<build_root>/.fbuild/build/<env>/``.
+        build_root: The ``.build/`` directory.
         board_name: Canonical board / fbuild environment name (e.g.
             ``esp32c2``, matching the ``-e`` flag on fbuild).
 
     Returns:
         Path to ``compile_commands.json`` on success, ``None`` otherwise.
     """
-    release = fbuild_release_dir(build_root, board_name)
-    cdb = release / "compile_commands.json"
-    if cdb.exists():
+    cdb = _find_existing_compile_db(build_root, board_name)
+    if cdb is not None:
         return cdb
 
     # Canonical FastLED fbuild invocation order (matches
@@ -96,4 +138,7 @@ def ensure_compile_commands(
         )
         return None
 
-    return cdb if cdb.exists() else None
+    # Re-scan candidate locations — ``fbuild --target compiledb`` writes to
+    # ``<repo>/.fbuild/build/<env>/release/`` regardless of which candidate
+    # the prior FastLED compile populated.
+    return _find_existing_compile_db(build_root, board_name)


### PR DESCRIPTION
## Summary

Makes fbuild a first-class backend for IWYU and cppcheck static analysis so fbuild-only boards (esp32c2 today, more coming) no longer break CI. Closes the IWYU half of #2303 (the cppcheck half landed in #2307).

- **`ci/util/fbuild_adapter.py`**: add `get_compile_commands(board)` as the stable, public entry point static-analysis tools use to get an fbuild-produced `compile_commands.json`.
- **`ci/util/fbuild_compiledb.py`**: probe all three real-world release-dir layouts (`.build/pio/<board>/.fbuild/...`, `<repo>/.fbuild/...`, `.build/.fbuild/...`) instead of only the theoretical one. The prior detector silently missed FastLED-orchestrated fbuild builds.
- **`ci/ci-iwyu.py`**: when `was_compiled_with_fbuild()` is true, drive IWYU via `clang-tool-chain-iwyu-tool -p <db-dir>` scoped to `src/` TUs (matching `ci-cppcheck`'s scoping) — Windows `CreateProcess` can't handle the full aggregated argv of a raw ESP32 compile DB. The PIO path is preserved for non-fbuild boards and extended to understand the modern `.build/pio/<board>/` layout.

## Extension point

Adding future `clang-tool-chain-*` wrappers (clang-tidy, clang-format-check, clang-query) is ~10 LOC — wire the wrapper name, point it at `compile_db.parent` via `-p`, and pass the src-filtered file list. Documented inline in `run_iwyu_against_compile_db`.

## Test plan

- [x] `uv run python ci/ci-iwyu.py esp32c2` exits 0 (was failing with "No platformio.ini found")
- [x] `uv run python ci/ci-cppcheck.py esp32c2` exits 0
- [x] Synthetic-src-entry probe confirms `iwyu-tool` actually processes `src/` TUs when the compile DB contains them (fbuild's `--target compiledb` currently emits framework-only on ESP32, so this is a future-proofing measure)
- [x] PIO-backed boards: `was_compiled_with_fbuild()` returns False; legacy `find_platformio_project_dir()` path still dispatches correctly
- [x] `bash lint ci/ci-iwyu.py ci/ci-cppcheck.py ci/util/fbuild_adapter.py ci/util/fbuild_compiledb.py` — all checks pass
- [x] Ruff + pyright clean (no new errors introduced)

Related: #2301 (cppcheck subset), #2302 (esp32c2 regression), #2307 (phase A — cppcheck).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Run IWYU using a generated compile_commands.json so projects built with the fbuild workflow can be analyzed.
* **Chores**
  * Improved detection of build/output layouts (multiple fbuild and PlatformIO layouts) when locating build artifacts.
  * More reliable discovery/generation of compilation databases for analysis tools.
  * Tool now reports that automatic --fix is not supported for fbuild-backed builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->