### PR TITLE
ci: add concurrency groups to top-level workflows

### DIFF
--- a/.github/workflows/avr8js_uno_test.yml
+++ b/.github/workflows/avr8js_uno_test.yml
@@ -1,5 +1,9 @@
 name: uno AVR8JS Test
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,9 @@
 name: build
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches:

--- a/.github/workflows/build_adafruit_feather_nrf52840_sense.yml
+++ b/.github/workflows/build_adafruit_feather_nrf52840_sense.yml
@@ -1,5 +1,9 @@
 name: adafruit_feather_nrf52840_sense
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches:

--- a/.github/workflows/build_adafruit_xiaoblesense.yml
+++ b/.github/workflows/build_adafruit_xiaoblesense.yml
@@ -1,5 +1,9 @@
 name: adafruit_xiaoblesense
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches:

--- a/.github/workflows/build_apollo3_red.yml
+++ b/.github/workflows/build_apollo3_red.yml
@@ -1,5 +1,9 @@
 name: apollo3_red
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches:

--- a/.github/workflows/build_apollo3_thing_explorable.yml
+++ b/.github/workflows/build_apollo3_thing_explorable.yml
@@ -1,5 +1,9 @@
 name: apollo3_thing_explorable
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches:

--- a/.github/workflows/build_atmega8a.yml
+++ b/.github/workflows/build_atmega8a.yml
@@ -1,5 +1,9 @@
 name: atmega8a
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches:

--- a/.github/workflows/build_attiny1604.yml
+++ b/.github/workflows/build_attiny1604.yml
@@ -1,5 +1,9 @@
 name: attiny1604
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches:

--- a/.github/workflows/build_attiny1616.yml
+++ b/.github/workflows/build_attiny1616.yml
@@ -1,5 +1,9 @@
 name: attiny1616
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches:

--- a/.github/workflows/build_attiny4313.yml
+++ b/.github/workflows/build_attiny4313.yml
@@ -1,5 +1,9 @@
 name: attiny4313
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches:

--- a/.github/workflows/build_attiny85.yml
+++ b/.github/workflows/build_attiny85.yml
@@ -1,5 +1,9 @@
 name: attiny85
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches:

--- a/.github/workflows/build_attiny88.yml
+++ b/.github/workflows/build_attiny88.yml
@@ -1,5 +1,9 @@
 name: attiny88
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches:

--- a/.github/workflows/build_blackpill_stm32f4.yml
+++ b/.github/workflows/build_blackpill_stm32f4.yml
@@ -1,5 +1,9 @@
 name: stm32f411ce_blackpill
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches:

--- a/.github/workflows/build_bluepill.yml
+++ b/.github/workflows/build_bluepill.yml
@@ -1,5 +1,9 @@
 name: stm32f103c8_bluepill
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches:

--- a/.github/workflows/build_clone_and_compile.yml
+++ b/.github/workflows/build_clone_and_compile.yml
@@ -1,5 +1,9 @@
 name: clone and compile
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches:

--- a/.github/workflows/build_digix.yml
+++ b/.github/workflows/build_digix.yml
@@ -1,5 +1,9 @@
 name: sam3x8e_due (digix merged)
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches:

--- a/.github/workflows/build_due.yml
+++ b/.github/workflows/build_due.yml
@@ -1,5 +1,9 @@
 name: sam3x8e_due
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches:

--- a/.github/workflows/build_esp32_i2s_ws2812.yml
+++ b/.github/workflows/build_esp32_i2s_ws2812.yml
@@ -1,5 +1,9 @@
 name: esp32_i2s_ws2812
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches:

--- a/.github/workflows/build_esp32c2.yml
+++ b/.github/workflows/build_esp32c2.yml
@@ -1,5 +1,9 @@
 name: esp32c2
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches:

--- a/.github/workflows/build_esp32c3.yml
+++ b/.github/workflows/build_esp32c3.yml
@@ -1,5 +1,9 @@
 name: esp32c3
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches:

--- a/.github/workflows/build_esp32c5.yml
+++ b/.github/workflows/build_esp32c5.yml
@@ -1,5 +1,9 @@
 name: esp32c5
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches:

--- a/.github/workflows/build_esp32c6.yml
+++ b/.github/workflows/build_esp32c6.yml
@@ -1,5 +1,9 @@
 name: esp32c6
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches:

--- a/.github/workflows/build_esp32dev.yml
+++ b/.github/workflows/build_esp32dev.yml
@@ -1,5 +1,9 @@
 name: esp32dev
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches:

--- a/.github/workflows/build_esp32dev_idf3.3.yml
+++ b/.github/workflows/build_esp32dev_idf3.3.yml
@@ -1,5 +1,9 @@
 name: esp32dev-idf3.3-lts
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches:

--- a/.github/workflows/build_esp32dev_idf4.4.yml
+++ b/.github/workflows/build_esp32dev_idf4.4.yml
@@ -1,5 +1,9 @@
 name: esp32dev_idf4.4
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches:

--- a/.github/workflows/build_esp32dev_namespace.yml
+++ b/.github/workflows/build_esp32dev_namespace.yml
@@ -1,5 +1,9 @@
 name: esp32dev_namespace
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches:

--- a/.github/workflows/build_esp32h2.yml
+++ b/.github/workflows/build_esp32h2.yml
@@ -1,5 +1,9 @@
 name: esp32h2
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches:

--- a/.github/workflows/build_esp32p4.yml
+++ b/.github/workflows/build_esp32p4.yml
@@ -1,5 +1,9 @@
 name: esp32p4
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches:

--- a/.github/workflows/build_esp32s2.yml
+++ b/.github/workflows/build_esp32s2.yml
@@ -1,5 +1,9 @@
 name: esp32s2
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches:

--- a/.github/workflows/build_esp32s3.yml
+++ b/.github/workflows/build_esp32s3.yml
@@ -1,5 +1,9 @@
 name: esp32s3
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches:

--- a/.github/workflows/build_esp32wroom.yml
+++ b/.github/workflows/build_esp32wroom.yml
@@ -1,5 +1,9 @@
 name: esp32wroom
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches:

--- a/.github/workflows/build_esp8266.yml
+++ b/.github/workflows/build_esp8266.yml
@@ -1,5 +1,9 @@
 name: esp8622
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches:

--- a/.github/workflows/build_esp_extra_libs.yml
+++ b/.github/workflows/build_esp_extra_libs.yml
@@ -1,5 +1,9 @@
 name: esp_extra_libs
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches:

--- a/.github/workflows/build_giga_r1.yml
+++ b/.github/workflows/build_giga_r1.yml
@@ -1,5 +1,9 @@
 name: stm32h747xi_giga
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches:

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -1,5 +1,9 @@
 name: linux_native
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches:

--- a/.github/workflows/build_maple_map.yml
+++ b/.github/workflows/build_maple_map.yml
@@ -1,5 +1,9 @@
 name: stm32f103cb_maplemini
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches:

--- a/.github/workflows/build_mgm240s_thingplusmatter.yml
+++ b/.github/workflows/build_mgm240s_thingplusmatter.yml
@@ -1,5 +1,9 @@
 name: ThingPlusMatter_mgm240s
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches:

--- a/.github/workflows/build_nano_every.yml
+++ b/.github/workflows/build_nano_every.yml
@@ -1,5 +1,9 @@
 name: nano_every
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches:

--- a/.github/workflows/build_nrf52840_dk.yml
+++ b/.github/workflows/build_nrf52840_dk.yml
@@ -1,5 +1,9 @@
 name: nrf52840_dk
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches:

--- a/.github/workflows/build_nrf52_xiaoblesense.yml
+++ b/.github/workflows/build_nrf52_xiaoblesense.yml
@@ -1,5 +1,9 @@
 name: nrf52_xiaoblesense
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches:

--- a/.github/workflows/build_nucleo_f429zi.yml
+++ b/.github/workflows/build_nucleo_f429zi.yml
@@ -1,5 +1,9 @@
 name: nucleo_f429zi
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches:

--- a/.github/workflows/build_nucleo_f439zi.yml
+++ b/.github/workflows/build_nucleo_f439zi.yml
@@ -1,5 +1,9 @@
 name: nucleo_f439zi
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches:

--- a/.github/workflows/build_rgbw.yml
+++ b/.github/workflows/build_rgbw.yml
@@ -1,5 +1,9 @@
 name: rgbw
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches:

--- a/.github/workflows/build_rp2040.yml
+++ b/.github/workflows/build_rp2040.yml
@@ -1,5 +1,9 @@
 name: rp2040
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches:

--- a/.github/workflows/build_rp2350.yml
+++ b/.github/workflows/build_rp2350.yml
@@ -1,5 +1,9 @@
 name: rp2350
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches:

--- a/.github/workflows/build_rp2350B.yml
+++ b/.github/workflows/build_rp2350B.yml
@@ -1,5 +1,9 @@
 name: rp2350B SparkfunXRP
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches:

--- a/.github/workflows/build_stm103tb.yml
+++ b/.github/workflows/build_stm103tb.yml
@@ -1,5 +1,9 @@
 name: stm32f103tb_tinystm
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches:

--- a/.github/workflows/build_teensy30.yml
+++ b/.github/workflows/build_teensy30.yml
@@ -1,5 +1,9 @@
 name: teensy30
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches:

--- a/.github/workflows/build_teensy31.yml
+++ b/.github/workflows/build_teensy31.yml
@@ -1,5 +1,9 @@
 name: teensy31
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches:

--- a/.github/workflows/build_teensy32.yml
+++ b/.github/workflows/build_teensy32.yml
@@ -1,5 +1,9 @@
 name: teensy32
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches:

--- a/.github/workflows/build_teensy35.yml
+++ b/.github/workflows/build_teensy35.yml
@@ -1,5 +1,9 @@
 name: teensy35
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches:

--- a/.github/workflows/build_teensy36.yml
+++ b/.github/workflows/build_teensy36.yml
@@ -1,5 +1,9 @@
 name: teensy36
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches:

--- a/.github/workflows/build_teensy40.yml
+++ b/.github/workflows/build_teensy40.yml
@@ -1,5 +1,9 @@
 name: teensy40
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches:

--- a/.github/workflows/build_teensy41.yml
+++ b/.github/workflows/build_teensy41.yml
@@ -1,5 +1,9 @@
 name: teensy41
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches:

--- a/.github/workflows/build_teensy41_ofled.yml
+++ b/.github/workflows/build_teensy41_ofled.yml
@@ -1,5 +1,9 @@
 name: teensy41_ofled
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches:

--- a/.github/workflows/build_teensyLC.yml
+++ b/.github/workflows/build_teensyLC.yml
@@ -1,5 +1,9 @@
 name: teensyLC
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches:

--- a/.github/workflows/build_teensy_octo.yml
+++ b/.github/workflows/build_teensy_octo.yml
@@ -1,5 +1,9 @@
 name: teensy_octoWS2811
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches:

--- a/.github/workflows/build_uno.yml
+++ b/.github/workflows/build_uno.yml
@@ -1,5 +1,9 @@
 name: uno
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches:

--- a/.github/workflows/build_uno_r4_wifif.yml
+++ b/.github/workflows/build_uno_r4_wifif.yml
@@ -1,5 +1,9 @@
 name: uno_r4_wifi
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches:

--- a/.github/workflows/build_wasm.yml
+++ b/.github/workflows/build_wasm.yml
@@ -1,5 +1,9 @@
 name: wasm
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches:

--- a/.github/workflows/build_wasm_compilers.yml
+++ b/.github/workflows/build_wasm_compilers.yml
@@ -1,5 +1,9 @@
 name: wasm_compile_test
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
     push:
       branches:

--- a/.github/workflows/build_yun.yml
+++ b/.github/workflows/build_yun.yml
@@ -1,5 +1,9 @@
 name: leonardo
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches:

--- a/.github/workflows/check_attiny85.yml
+++ b/.github/workflows/check_attiny85.yml
@@ -1,5 +1,9 @@
 name: attiny85_binary_size
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches:

--- a/.github/workflows/check_bluepill_size.yml
+++ b/.github/workflows/check_bluepill_size.yml
@@ -1,5 +1,9 @@
 name: check_stm32f103c8_bluepill_size
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches:

--- a/.github/workflows/check_esp32_size.yml
+++ b/.github/workflows/check_esp32_size.yml
@@ -1,5 +1,9 @@
 name: esp32dev_binary_size
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches:

--- a/.github/workflows/check_teensy30_size.yml
+++ b/.github/workflows/check_teensy30_size.yml
@@ -1,5 +1,9 @@
 name: check_teensy30_size
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches:

--- a/.github/workflows/check_teensy31_size.yml
+++ b/.github/workflows/check_teensy31_size.yml
@@ -1,5 +1,9 @@
 name: check_teensy31_size
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches:

--- a/.github/workflows/check_teensy32_size.yml
+++ b/.github/workflows/check_teensy32_size.yml
@@ -1,5 +1,9 @@
 name: check_teensy32_size
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches:

--- a/.github/workflows/check_teensy35_size.yml
+++ b/.github/workflows/check_teensy35_size.yml
@@ -1,5 +1,9 @@
 name: check_teensy35_size
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches:

--- a/.github/workflows/check_teensy36_size.yml
+++ b/.github/workflows/check_teensy36_size.yml
@@ -1,5 +1,9 @@
 name: check_teensy36_size
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches:

--- a/.github/workflows/check_teensy41_size.yml
+++ b/.github/workflows/check_teensy41_size.yml
@@ -1,5 +1,9 @@
 name: check_teensy41_size
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches:

--- a/.github/workflows/check_teensylc_size.yml
+++ b/.github/workflows/check_teensylc_size.yml
@@ -1,5 +1,9 @@
 name: check_teensylc_size
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches:

--- a/.github/workflows/check_uno_size.yml
+++ b/.github/workflows/check_uno_size.yml
@@ -1,5 +1,9 @@
 name: check_uno_size
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches:

--- a/.github/workflows/docs2.yml
+++ b/.github/workflows/docs2.yml
@@ -1,5 +1,9 @@
 name: docs2
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   workflow_dispatch:
   release:

--- a/.github/workflows/example_test_linux.yml
+++ b/.github/workflows/example_test_linux.yml
@@ -1,5 +1,9 @@
 name: example tests linux
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches:

--- a/.github/workflows/example_test_macos.yml
+++ b/.github/workflows/example_test_macos.yml
@@ -1,5 +1,9 @@
 name: example tests macos
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches:

--- a/.github/workflows/example_test_windows.yml
+++ b/.github/workflows/example_test_windows.yml
@@ -1,5 +1,9 @@
 name: example tests windows
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches:

--- a/.github/workflows/header-perf.yml
+++ b/.github/workflows/header-perf.yml
@@ -1,5 +1,9 @@
 name: Header Compilation Performance
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches: [master, main]

--- a/.github/workflows/iwyu.yml
+++ b/.github/workflows/iwyu.yml
@@ -1,5 +1,9 @@
 name: Include-What-You-Use (IWYU) Check
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches:

--- a/.github/workflows/qemu_esp32c3_test.yml
+++ b/.github/workflows/qemu_esp32c3_test.yml
@@ -1,5 +1,9 @@
 name: ESP32-C3 QEMU Test
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/qemu_esp32dev_test.yml
+++ b/.github/workflows/qemu_esp32dev_test.yml
@@ -1,5 +1,9 @@
 name: ESP32-DEV QEMU Test
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/qemu_esp32s3_test.yml
+++ b/.github/workflows/qemu_esp32s3_test.yml
@@ -1,5 +1,9 @@
 name: ESP32-S3 QEMU Test
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/unit_test_linux.yml
+++ b/.github/workflows/unit_test_linux.yml
@@ -1,5 +1,9 @@
 name: unit tests linux
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches:

--- a/.github/workflows/unit_test_macos.yml
+++ b/.github/workflows/unit_test_macos.yml
@@ -1,5 +1,9 @@
 name: unit tests macos
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches:

--- a/.github/workflows/unit_test_windows.yml
+++ b/.github/workflows/unit_test_windows.yml
@@ -1,5 +1,9 @@
 name: unit tests windows
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches:


### PR DESCRIPTION
## Summary
- Adds a concurrency block to 85 top-level workflow YAMLs so new PR pushes cancel their own previous in-progress runs.
- Uses `cancel-in-progress: ${{ github.event_name == 'pull_request' }}`, so master-branch pushes are still each validated end-to-end.
- Skips the 11 reusable templates (they inherit the caller's concurrency), the Claude/project-automation/drift-sync/lint coordination workflows, and the docker_compiler_*.yml image builds where mid-build cancellation would leave partial registry state.

## Motivation
A single feature branch fanning out ~100 parallel jobs was starving the GitHub-hosted runner pool — at the time this PR was opened the repo had ~1785 queued runs vs ~75 in_progress, with a 4-hour-old master push sitting in the queue unassigned. Canceling redundant per-branch PR runs is the standard fix for this.

## Test plan
- [ ] PR itself runs and passes with the new concurrency behavior.
- [ ] Push a second commit to this branch and verify the previous run is automatically cancelled.
- [ ] Confirm master pushes after merge still run to completion (not auto-cancelled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD pipeline efficiency by implementing concurrency controls across automated workflows. Pull requests now automatically cancel previous in-progress runs for the same branch, reducing resource consumption and providing faster feedback on updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->