### PR TITLE
feat(esp32): honor CoroutineConfig::core_id for task affinity

### DIFF
--- a/ci/hooks/check_pr_merge_reviews.py
+++ b/ci/hooks/check_pr_merge_reviews.py
@@ -20,6 +20,8 @@ import subprocess
 import sys
 from typing import Any, cast
 
+from ci.util.global_interrupt_handler import handle_keyboard_interrupt
+
 
 MERGE_RE = re.compile(r"\bgh\s+pr\s+merge\b")
 
@@ -27,6 +29,9 @@ MERGE_RE = re.compile(r"\bgh\s+pr\s+merge\b")
 def main() -> int:
     try:
         payload = cast(dict[str, Any], json.load(sys.stdin))
+    except KeyboardInterrupt as ki:
+        handle_keyboard_interrupt(ki)
+        raise
     except Exception:
         return 0
 
@@ -46,6 +51,9 @@ def main() -> int:
             text=True,
             timeout=30,
         )
+    except KeyboardInterrupt as ki:
+        handle_keyboard_interrupt(ki)
+        raise
     except (subprocess.TimeoutExpired, FileNotFoundError):
         return 0
 

--- a/src/platforms/esp/32/coroutine_esp32.impl.hpp
+++ b/src/platforms/esp/32/coroutine_esp32.impl.hpp
@@ -16,6 +16,7 @@
 // IWYU pragma: begin_keep
 #include "platforms/coroutine_runtime.h"
 #include "platforms/coroutine.h"
+#include "platforms/esp/32/feature_flags/enabled.h"
 #include "fl/stl/string.h"
 #include "fl/stl/functional.h"
 #include "fl/stl/atomic.h"
@@ -119,7 +120,8 @@ public:
     static TaskCoroutinePtr create(fl::string name,
                                     TaskFunction function,
                                     size_t stack_size = 4096,
-                                    u8 priority = 5) FL_NOEXCEPT;
+                                    u8 priority = 5,
+                                    int core_id = -1) FL_NOEXCEPT;
 
     ~TaskCoroutineESP32() override;
 
@@ -174,9 +176,19 @@ TaskCoroutinePtr TaskCoroutineESP32::create(
         fl::string name,
         TaskFunction function,
         size_t stack_size,
-        u8 priority) FL_NOEXCEPT {
+        u8 priority,
+        int core_id) FL_NOEXCEPT {
     if (stack_size < kMinStackSize) {
         stack_size = kMinStackSize;
+    }
+
+    // Resolve requested core_id against platform capabilities. An out-of-range
+    // or negative value is silently downgraded to tskNO_AFFINITY — the caller's
+    // task still runs, just without affinity. This matches the existing
+    // behaviour where every caller was implicitly tskNO_AFFINITY.
+    BaseType_t affinity = tskNO_AFFINITY;
+    if (core_id >= 0 && core_id < FL_CPU_CORES) {
+        affinity = static_cast<BaseType_t>(core_id);
     }
 
     TaskCoroutinePtr task(new TaskCoroutineESP32()) FL_NOEXCEPT;  // ok bare allocation
@@ -207,7 +219,7 @@ TaskCoroutinePtr TaskCoroutineESP32::create(
         tskIDLE_PRIORITY + priority,
         impl->mStackBuf.get(),
         impl->mTaskTcb.get(),
-        tskNO_AFFINITY);
+        affinity);
 #else
     // IDF 3.x: xTaskCreateStaticPinnedToCore may not be available
     // (configSUPPORT_STATIC_ALLOCATION not guaranteed). Use dynamic
@@ -219,7 +231,7 @@ TaskCoroutinePtr TaskCoroutineESP32::create(
         impl,                       // param = this
         tskIDLE_PRIORITY + priority,
         &impl->mTask,
-        tskNO_AFFINITY);
+        affinity);
     if (rc != pdPASS) {
         impl->mTask = nullptr;
     }
@@ -260,9 +272,9 @@ TaskCoroutinePtr createTaskCoroutine(fl::string name,
                                       ICoroutineTask::TaskFunction function,
                                       size_t stack_size,
                                       u8 priority,
-                                      int /*core_id*/) FL_NOEXCEPT {
+                                      int core_id) FL_NOEXCEPT {
     return TaskCoroutineESP32::create(fl::move(name), fl::move(function),
-                                      stack_size, priority);
+                                      stack_size, priority, core_id);
 }
 
 //=============================================================================

--- a/src/platforms/esp/32/feature_flags/enabled.h
+++ b/src/platforms/esp/32/feature_flags/enabled.h
@@ -25,6 +25,35 @@ FL_EXTERN_C_END
 #define SOC_RMT_SUPPORTED 0
 #endif
 
+// SOC_CPU_CORES_NUM is defined in soc/soc_caps.h on IDF 4.0+. For IDF 3.x
+// (where soc_caps.h does not exist) fall back to explicit variant checks.
+// Original ESP32 / ESP32-S3 / ESP32-P4 are dual-core; everything else is
+// single-core from an SMP-FreeRTOS perspective.
+#ifndef SOC_CPU_CORES_NUM
+#if defined(FL_IS_ESP_32DEV) || defined(FL_IS_ESP_32S3) || defined(FL_IS_ESP_32P4)
+#define SOC_CPU_CORES_NUM 2
+#else
+#define SOC_CPU_CORES_NUM 1
+#endif
+#endif
+
+// FL_CPU_CORES: Number of CPU cores available for RTOS task pinning.
+// FL_HAS_MULTICORE_AFFINITY: 1 when the platform supports xTaskCreatePinnedToCore
+// with a core argument other than tskNO_AFFINITY (i.e. has >=2 cores).
+//
+// Used by platforms/esp/32/coroutine_esp32.impl.hpp to validate
+// CoroutineConfig::core_id. Out-of-range requests fall back to tskNO_AFFINITY.
+#ifndef FL_CPU_CORES
+#define FL_CPU_CORES SOC_CPU_CORES_NUM
+#endif
+#ifndef FL_HAS_MULTICORE_AFFINITY
+#if FL_CPU_CORES > 1
+#define FL_HAS_MULTICORE_AFFINITY 1
+#else
+#define FL_HAS_MULTICORE_AFFINITY 0
+#endif
+#endif
+
 #ifndef SOC_PARLIO_SUPPORTED
 #define SOC_PARLIO_SUPPORTED 0
 #endif


### PR DESCRIPTION
## Summary

Phase 1 of [#2308](https://github.com/FastLED/FastLED/issues/2308) option (B) — restore audio-pipeline FPS by letting callers pin coroutines to a specific core on dual-core ESP32s.

The `CoroutineConfig::core_id` field has existed on `fl::task` for a while, but the ESP32 backend silently discarded it (`int /*core_id*/`) and always used `tskNO_AFFINITY`. This PR makes that parameter actually work.

## Changes

- **Feature flags** (`src/platforms/esp/32/feature_flags/enabled.h`):
  - `FL_CPU_CORES` — number of RTOS-usable cores. Derived from `SOC_CPU_CORES_NUM` on IDF 4.0+, with an explicit ESP32dev/S3/P4 vs S2/C2/C3/C5/C6/H2 fallback for IDF 3.x.
  - `FL_HAS_MULTICORE_AFFINITY` — `1` when `FL_CPU_CORES > 1`.
- **Coroutine backend** (`src/platforms/esp/32/coroutine_esp32.impl.hpp`):
  - `TaskCoroutineESP32::create()` gains a `core_id` parameter (default `-1`).
  - `core_id` is validated against `FL_CPU_CORES`. Out-of-range or negative values downgrade to `tskNO_AFFINITY`, matching prior behaviour for every existing caller.
  - Validated affinity is forwarded to `xTaskCreateStaticPinnedToCore` / `xTaskCreatePinnedToCore`.
  - `createTaskCoroutine()` entry point now forwards `core_id` instead of discarding it.

## What this unlocks

Once landed, a caller can do:

```cpp
auto t = fl::task::coroutine({
    .func    = []() { while (true) { processor->update(sample); } },
    .name    = "audio",
    .core_id = 0,   // run on core 0; leave core 1 free for FastLED.show()
});
```

On ESP32-dev / S3 / P4 this pins to core 0. On single-core variants (S2/C3/etc.) the `0` stays valid (core 0 is the only core); any out-of-range request silently falls back to no-affinity.

## What this does NOT change

- **No behaviour change for any existing caller.** Every current `createTaskCoroutine` call passes the default `core_id = -1`, which maps to `tskNO_AFFINITY` — identical to today.
- **Audio auto-pump untouched.** `Processor::createWithAutoInput` still uses `fl::task::every_ms(1)` (main scheduler thread). Converting that to a pinned coroutine changes the thread on which user callbacks fire, which can race with `FastLED.show()` if a callback touches LEDs. That opt-in API (`Processor::setCoreAffinity`) needs hardware FPS measurements and is deliberately left for a follow-up.

## Test plan

- [x] Compile-check `bash compile esp32dev --examples Blink` (dual-core Xtensa LX6)
- [x] Compile-check `bash compile esp32c3 --examples Blink` (single-core RISC-V)
- [ ] CI: full workflow matrix (happens on this PR)
- [ ] Follow-up PR: hardware FPS measurement on ESP32-S3 with audio pinned to core 0

## Also in this PR

One unrelated lint fix: `ci/hooks/check_pr_merge_reviews.py` was missing a `KeyboardInterrupt` handler (KBI001 was flagging on every stop hook). Separate commit, follows the existing convention in `ci/compiled_size.py`.

Refs #2308

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * ESP32 coroutines now support CPU core affinity control, allowing tasks to be pinned to specific processor cores for optimized multi-core performance. Invalid or out-of-range core selections automatically fall back to default scheduling.

* **Chores**
  * Improved keyboard interrupt handling in internal CI merge validation scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->