### PR TITLE
fix(ci-iwyu): fail fast on missing IWYU mappings, handle missing uv, reword --fix note

### DIFF
--- a/ci/ci-iwyu.py
+++ b/ci/ci-iwyu.py
@@ -497,8 +497,13 @@ def run_iwyu_against_compile_db(
     mapping_args: list[str] = []
     for name in ("fastled.imp", "stdlib.imp"):
         p = project_root / "ci" / "iwyu" / name
-        if p.exists():
-            mapping_args.extend(["-Xiwyu", f"--mapping_file={p}"])
+        if not p.exists():
+            print(
+                f"ERROR: required IWYU mapping file not found: {p}",
+                file=sys.stderr,
+            )
+            return 1
+        mapping_args.extend(["-Xiwyu", f"--mapping_file={p}"])
 
     if args.mapping_file:
         for mapping in args.mapping_file:
@@ -540,6 +545,13 @@ def run_iwyu_against_compile_db(
 
         handle_keyboard_interrupt(ki)
         raise
+    except FileNotFoundError as e:
+        print(
+            "ERROR: fbuild IWYU mode requires `uv run clang-tool-chain-iwyu-tool`, "
+            f"but the command could not be started: {e}",
+            file=sys.stderr,
+        )
+        return 1
     except subprocess.CalledProcessError as e:
         print(f"clang-tool-chain-iwyu-tool failed with return code {e.returncode}")
         return e.returncode
@@ -849,7 +861,7 @@ def main() -> int:
             # (tracked upstream); fail loudly rather than silently no-op.
             print(
                 "NOTE: --fix is not yet supported for fbuild-backed boards; "
-                "violations were reported but not auto-fixed.",
+                "IWYU was run in report-only mode — no changes were auto-fixed.",
                 file=sys.stderr,
             )
         return result_code


### PR DESCRIPTION
## Summary

Follow-up to #2331 — applies the three CodeRabbit findings from the final review pass that didn't make it into the merge.

- **Fail fast on missing `fastled.imp` / `stdlib.imp`**. Silently skipping either mapping changes IWYU's answers while still returning a passing status — a classic silent-correctness bug. Absence is now a hard error with the expected path in the message.
- **Handle `FileNotFoundError` from `subprocess.run` when `uv` is missing**. `check_iwyu_available()` can succeed via the system IWYU path, so it's legitimately possible to reach this code without `uv` installed. Convert the cryptic traceback into a clear CI diagnostic.
- **Reword the `--fix`-unsupported note**. Dropping the `result_code == 0` guard in #2331 made the warning unconditional, which turned the old "violations were reported but not auto-fixed" into a lie when IWYU exits clean. Change to "IWYU was run in report-only mode — no changes were auto-fixed" so the note stays accurate regardless of result.

All three align with CLAUDE.md's "find root causes, no temporary fixes — senior developer standards" stance.

## Test plan

- [x] `bash lint ci/ci-iwyu.py` passes
- [ ] `uv run python ci/ci-iwyu.py esp32c2` still exits 0 on a board that actually has both .imp files + uv (no regression)
- [ ] Manually delete `ci/iwyu/fastled.imp` → confirm the new error fires and returns 1

## Related

- #2331 — the merged PR this follows up
- #2303 — the original IWYU-on-fbuild gap this PR chain closes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced error handling in CI checks for missing dependencies and failed processes.
  * Improved error messaging to provide clearer feedback when build tools fail to initialize.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->