### PR TITLE
fix(ci): activate zccache 1.2.12 deploy-hook to cure DLL-126 flake (#2329)

### DIFF
--- a/ci/meson/runner.py
+++ b/ci/meson/runner.py
@@ -389,7 +389,21 @@ def _start_zccache_session(build_dir: Path) -> None:
     Sets ZCCACHE_SESSION_ID in os.environ so all subsequent compiler
     invocations through zccache use this session and get logged.
     The session auto-cleans up via PID monitoring when the process exits.
+
+    Also sets ZCCACHE_LINK_DEPLOY_CMD so zccache invokes
+    `clang-tool-chain-libdeploy` after each cache-miss link. This
+    materializes runtime DLLs next to the linked binary (on Windows
+    these otherwise don't get deployed because the native ctc-clang++
+    trampoline skips Python post-link hooks) and lets zccache's
+    side-effect scanner bundle them into the cached artifact set —
+    fixing flaky error-126 DLL load failures under parallel test
+    execution. See https://github.com/FastLED/FastLED/issues/2329.
     """
+    # Set the deploy hook regardless of zccache binary availability —
+    # zccache reads it from client env if set, and it's a no-op otherwise.
+    if "ZCCACHE_LINK_DEPLOY_CMD" not in os.environ:
+        os.environ["ZCCACHE_LINK_DEPLOY_CMD"] = "clang-tool-chain-libdeploy"
+
     zccache_bin = _find_zccache_binary()
     if not zccache_bin:
         return

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "fpvgcc",
     "uv",
     "clang-tool-chain>=1.2.9",
-    "zccache>=1.2.11",
+    "zccache>=1.2.12",
     "ninja",
     "meson>=1.10.0",
     "download",


### PR DESCRIPTION
## Summary

Closes #2329 — the flaky error-126 DLL load failures under parallel quick-mode test runs on Windows.

## Upstream

zccache 1.2.12 landed the upstream fix from zackees/zccache#33:
- **Cache-hit path:** sibling files the driver produced during the fresh link (runtime DLLs, `.pdb`, sanitizer runtimes, etc.) are now restored alongside the cached output.
- **Cache-miss path:** an env-gated post-link hook runs before the side-effect scanner captures sibling files, covering the case where the native `ctc-clang++` trampoline skips Python post-link hooks.

Fix commit on zccache main: `d7b1d69 feat(daemon): invoke ZCCACHE_LINK_DEPLOY_CMD after cache-miss links`.

## FastLED-side changes

1. **`pyproject.toml`:** bump `zccache>=1.2.11` -> `zccache>=1.2.12` so the cache-hit sibling-restore path is guaranteed available.
2. **`ci/meson/runner.py::_start_zccache_session`:** set `ZCCACHE_LINK_DEPLOY_CMD=clang-tool-chain-libdeploy` in the process env. zccache invokes `libdeploy` after each cache-miss link, deployed DLLs then get swept into the cached artifact set and restored on every future hit.

Both touched files are under the CI workflow's safe-file merge surface, so the fix reaches the workflow.

## Verification

- `zccache 1.2.12` installed via `uv sync`.
- `clang-tool-chain-libdeploy` resolvable in the venv.
- `bash test --cpp --setup-only` reports "Saved zccache version: zccache 1.2.12".

## Kept as belt-and-suspenders

The `runtime_dll_paths` PATH workaround in `ci/meson/native/meson.build` stays — harmless, covers any edge case the new env var misses, and the meta issue allows it.

## Test plan

- [x] Local setup succeeds with new pin
- [ ] CI runs 16 parallel test DLLs without the flake (the whole point)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed flaky parallel test DLL load failures by ensuring runtime DLLs are properly materialized during the linking process.

* **Chores**
  * Updated zccache dependency to version 1.2.12 or later.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->