### PR TITLE
fix: clean up legacy deprecated header files

### DIFF
--- a/src/colorpalettes.h
+++ b/src/colorpalettes.h
@@ -3,7 +3,6 @@
 #ifndef __INC_COLORPALETTES_H
 #define __INC_COLORPALETTES_H
 
-// #include "FastLED.h"
 #include "colorutils.h"
 #include "fastled_progmem.h"
 

--- a/src/controller.h
+++ b/src/controller.h
@@ -4,7 +4,8 @@
 #define __INC_CONTROLLER_H
 
 /// @file controller.h
-/// deprecated: base definitions used by led controllers for writing out led data
+/// @deprecated This header is deprecated. Use cpixel_ledcontroller.h directly
+/// for LED controller definitions and pixel control functionality.
 
 #include "cpixel_ledcontroller.h"
 

--- a/src/fastspi_dma.h
+++ b/src/fastspi_dma.h
@@ -1,5 +1,0 @@
-#pragma once
-
-/// @file fastspi_dma.h
-/// Direct memory access (DMA) functions for SPI interfaces
-/// @deprecated This header file is empty.


### PR DESCRIPTION
## Summary
Clean up legacy deprecated header files in FastLED codebase:

1. **Remove deprecated empty src/fastspi_dma.h** - This file was marked deprecated but contained no implementation code. No references to this file exist in the codebase, so it can be safely removed.

2. **Improve deprecation notice in src/controller.h** - Added clear documentation pointing users to use `cpixel_ledcontroller.h` directly instead of the deprecated wrapper.

3. **Remove commented-out include in src/colorpalettes.h** - Removed the debug leftover `// #include "FastLED.h"` line.

## Code Review Findings
These files were among the least recently updated (.h/.cpp) files in the src/ directory (last updated ~2025-05-08 to 2025-08-14).

Files analyzed for last commit date:
- src/controller.h: 2025-05-08
- src/fastspi_dma.h: 2025-05-08
- src/colorpalettes.h: 2025-08-14
- src/color.h: 2025-10-20
- src/pixeltypes.h: 2025-12-17

## Testing
- [x] Code compiles without the removed header
- [x] No other files reference fastspi_dma.h (verified via grep)

## Checklist
- [x] My code follows the style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

Co-Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed deprecated and unused header files
  * Updated deprecation notice in `controller.h` directing users to use `cpixel_ledcontroller.h` directly
  * Cleaned up commented-out code

<!-- end of auto-generated comment: release notes by coderabbit.ai -->