### PR TITLE
refactor(ci/fbuild-static-analysis): drop default param, plumb project_root explicitly

### DIFF
--- a/ci/ci-cppcheck.py
+++ b/ci/ci-cppcheck.py
@@ -204,7 +204,7 @@ def main() -> int:
         # emits. Avoids `pio check`'s CMake-configure failure mode (missing
         # partition CSVs etc.) while giving us real cppcheck coverage, not a
         # skip. See FastLED#2303.
-        if was_compiled_with_fbuild(build, canonical_board_name):
+        if was_compiled_with_fbuild(project_root, build, canonical_board_name):
             compile_db = ensure_compile_commands(
                 project_root, build, canonical_board_name
             )

--- a/ci/ci-iwyu.py
+++ b/ci/ci-iwyu.py
@@ -842,8 +842,8 @@ def main() -> int:
     # compile_commands.json via clang-tool-chain-iwyu-tool. Bypasses the PIO
     # project-tree assumption entirely — no platformio.ini required. See
     # FastLED#2303.
-    if was_compiled_with_fbuild(build, canonical_board_name):
-        compile_db = get_compile_commands(canonical_board_name, build_root=build)
+    if was_compiled_with_fbuild(_PROJECT_ROOT, build, canonical_board_name):
+        compile_db = get_compile_commands(canonical_board_name, build)
         if compile_db is None:
             print(
                 f"ERROR: could not obtain fbuild compile_commands.json for "

--- a/ci/util/fbuild_adapter.py
+++ b/ci/util/fbuild_adapter.py
@@ -30,7 +30,7 @@ from pathlib import Path
 from ci.util.global_interrupt_handler import handle_keyboard_interrupt
 
 
-def get_compile_commands(board: str, build_root: Path | None = None) -> Path | None:
+def get_compile_commands(board: str, build_root: Path) -> Path | None:
     """Return the path to ``compile_commands.json`` for ``board``.
 
     Thin wrapper around :func:`ci.util.fbuild_compiledb.ensure_compile_commands`
@@ -45,9 +45,10 @@ def get_compile_commands(board: str, build_root: Path | None = None) -> Path | N
 
     Args:
         board: Canonical board / fbuild environment name (e.g. ``"esp32c2"``).
-        build_root: Optional ``.build/`` directory. Defaults to
-            ``<repo-root>/.build/`` — where fbuild writes its artifacts under
-            ``.fbuild/build/<env>/``.
+        build_root: The ``.build/`` directory — where fbuild writes its
+            artifacts under ``.fbuild/build/<env>/``. Callers know their build
+            root; no default is applied (per repo style: parameters don't have
+            defaults).
 
     Returns:
         Path to ``compile_commands.json`` on success, ``None`` if fbuild
@@ -59,8 +60,6 @@ def get_compile_commands(board: str, build_root: Path | None = None) -> Path | N
     from ci.util.fbuild_compiledb import ensure_compile_commands
 
     project_root = Path(__file__).resolve().parent.parent.parent
-    if build_root is None:
-        build_root = project_root / ".build"
     return ensure_compile_commands(project_root, build_root, board)
 
 

--- a/ci/util/fbuild_compiledb.py
+++ b/ci/util/fbuild_compiledb.py
@@ -17,7 +17,9 @@ import sys
 from pathlib import Path
 
 
-def _candidate_fbuild_release_dirs(build_root: Path, board_name: str) -> list[Path]:
+def _candidate_fbuild_release_dirs(
+    project_root: Path, build_root: Path, board_name: str
+) -> list[Path]:
     """Candidate locations where fbuild may have written artifacts.
 
     FastLED compiles fbuild with ``build_dir=<repo>/.build/pio/<board>/`` (see
@@ -28,18 +30,22 @@ def _candidate_fbuild_release_dirs(build_root: Path, board_name: str) -> list[Pa
     direct ``--target compiledb`` invocation (no prior FastLED compile) also
     works. An older ``.build/.fbuild/…`` layout is kept as a tail fallback.
 
+    ``project_root`` is passed explicitly rather than derived from
+    ``build_root.name == ".build"`` — callers always know their repo root
+    (every call site has ``_PROJECT_ROOT`` or ``project_root`` locally), and
+    an explicit arg removes the fragile name-based heuristic that silently
+    collapsed candidates when ``build_root`` wasn't conventionally named.
+
     Returned in preference order (first hit wins).
     """
-    # Repo root is the parent of .build/ when build_root follows convention.
-    repo_root = build_root.parent if build_root.name == ".build" else build_root
     return [
         build_root / "pio" / board_name / ".fbuild" / "build" / board_name / "release",
-        repo_root / ".fbuild" / "build" / board_name / "release",
+        project_root / ".fbuild" / "build" / board_name / "release",
         build_root / ".fbuild" / "build" / board_name / "release",
     ]
 
 
-def fbuild_release_dir(build_root: Path, board_name: str) -> Path:
+def fbuild_release_dir(project_root: Path, build_root: Path, board_name: str) -> Path:
     """Return the canonical fbuild release dir for ``board_name``.
 
     Prefers the first of the candidate locations in
@@ -49,14 +55,16 @@ def fbuild_release_dir(build_root: Path, board_name: str) -> Path:
     callers can still materialize artifacts there via
     :func:`ensure_compile_commands`.
     """
-    candidates = _candidate_fbuild_release_dirs(build_root, board_name)
+    candidates = _candidate_fbuild_release_dirs(project_root, build_root, board_name)
     for cand in candidates:
         if cand.exists():
             return cand
     return candidates[0]
 
 
-def was_compiled_with_fbuild(build_root: Path, board_name: str) -> bool:
+def was_compiled_with_fbuild(
+    project_root: Path, build_root: Path, board_name: str
+) -> bool:
     """True iff fbuild produced artifacts for ``board_name`` anywhere we look.
 
     Probes every candidate release dir from
@@ -65,13 +73,16 @@ def was_compiled_with_fbuild(build_root: Path, board_name: str) -> bool:
     the canonical fbuild-vs-PIO backend signal for post-compile tooling.
     """
     return any(
-        cand.exists() for cand in _candidate_fbuild_release_dirs(build_root, board_name)
+        cand.exists()
+        for cand in _candidate_fbuild_release_dirs(project_root, build_root, board_name)
     )
 
 
-def _find_existing_compile_db(build_root: Path, board_name: str) -> Path | None:
+def _find_existing_compile_db(
+    project_root: Path, build_root: Path, board_name: str
+) -> Path | None:
     """Return an existing ``compile_commands.json`` for ``board_name``, or None."""
-    for cand in _candidate_fbuild_release_dirs(build_root, board_name):
+    for cand in _candidate_fbuild_release_dirs(project_root, build_root, board_name):
         cdb = cand / "compile_commands.json"
         if cdb.exists():
             return cdb
@@ -99,7 +110,7 @@ def ensure_compile_commands(
     Returns:
         Path to ``compile_commands.json`` on success, ``None`` otherwise.
     """
-    cdb = _find_existing_compile_db(build_root, board_name)
+    cdb = _find_existing_compile_db(project_root, build_root, board_name)
     if cdb is not None:
         return cdb
 
@@ -141,4 +152,4 @@ def ensure_compile_commands(
     # Re-scan candidate locations — ``fbuild --target compiledb`` writes to
     # ``<repo>/.fbuild/build/<env>/release/`` regardless of which candidate
     # the prior FastLED compile populated.
-    return _find_existing_compile_db(build_root, board_name)
+    return _find_existing_compile_db(project_root, build_root, board_name)


### PR DESCRIPTION
## Summary

Addresses the two outstanding CodeRabbit nitpicks from the original #2331 review that were deferred pending follow-up. Both tighten the public API for fbuild-backed static analysis.

1. **`ci/util/fbuild_adapter.py`**: drop the default on \`get_compile_commands(board, build_root: Path | None = None)\`. Repo style says parameters don't have defaults; the sole caller already passes build_root explicitly, so making it required is a no-op at call sites.

2. **\`ci/util/fbuild_compiledb.py\`**: replace the fragile \`repo_root = build_root.parent if build_root.name == \".build\" else build_root\` heuristic in \`_candidate_fbuild_release_dirs\` with an explicit \`project_root\` parameter. The heuristic silently collapsed two of the three candidate release-dirs into one whenever a caller passed a \`build_root\` not literally named \`.build/\` — a surprise waiting to happen as callers multiply.

   \`project_root\` now flows through the public API: \`fbuild_release_dir\`, \`was_compiled_with_fbuild\`, \`_find_existing_compile_db\`, \`ensure_compile_commands\`. Callers updated: \`ci/ci-iwyu.py\` (\`_PROJECT_ROOT\`), \`ci/ci-cppcheck.py\` (\`project_root\`), \`ci/util/fbuild_adapter.py\` (already computed).

## Test plan

- [x] \`bash lint\` on all four touched files passes
- [x] \`uv run python ci/ci-iwyu.py --help\` and \`ci-cppcheck.py --help\` both boot (import chain intact)
- [x] No behavioral change on conventionally-named \`.build/\` roots (all three candidates resolve to the same paths as before)

## Related

- #2331 — original PR whose review deferred these items
- #2338 — prior follow-up addressing the major CodeRabbit findings
- #2303 — umbrella issue for IWYU/cppcheck + fbuild integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal build detection and compilation database retrieval logic to explicitly pass the project root directory to fbuild utility functions, removing reliance on naming heuristics.
  * Made the build root parameter required instead of optional in compile database retrieval functions for clearer API contracts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->