### PR TITLE
feat(ci): fbuild native-QEMU smoke test

### DIFF
--- a/ci/tests/README.md
+++ b/ci/tests/README.md
@@ -1,0 +1,7 @@
+# ci/tests
+
+Pytest suite for FastLED's CI-side tooling. Run via `uv run pytest ci/tests/`
+or from the repo root via `uv run pytest`.
+
+Covers: flash-merge utilities, example filtering, daemon/process helpers,
+fbuild adapters, and other CI glue.

--- a/ci/tests/test_fbuild_qemu.py
+++ b/ci/tests/test_fbuild_qemu.py
@@ -1,0 +1,73 @@
+"""fbuild native-QEMU smoke test.
+
+Runs `fbuild test-emu` on a tiny FastLED sketch under
+``tests/fbuild_qemu_smoke/`` and asserts the ESP32 QEMU emulator boots far
+enough to print a known marker string. This exercises fbuild's native
+emulator path (not Docker) so we can catch regressions in the
+fbuild ↔ FastLED-library integration without spinning up containers.
+
+If fbuild is not installed or the test project is missing, the test is
+skipped. If fbuild runs but fails to build or boot, the test fails with the
+full stdout/stderr so the failure mode is diagnosable.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+PROJECT_DIR = ROOT / "tests" / "fbuild_qemu_smoke"
+SUCCESS_MARKER = "FBUILD-QEMU-TEST-OK"
+
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("fbuild") is None,
+    reason="fbuild CLI not on PATH — install with `uv pip install fbuild>=2.1.20`",
+)
+
+
+@pytest.mark.skipif(
+    not PROJECT_DIR.exists(),
+    reason=f"smoke project missing at {PROJECT_DIR}",
+)
+@pytest.mark.skipif(
+    os.environ.get("FASTLED_SKIP_FBUILD_QEMU") == "1",
+    reason="FASTLED_SKIP_FBUILD_QEMU=1",
+)
+def test_fbuild_test_emu_esp32dev() -> None:
+    """`fbuild test-emu` builds and boots the smoke sketch under ESP32 QEMU."""
+    cmd = [
+        "fbuild",
+        "test-emu",
+        str(PROJECT_DIR),
+        "-e",
+        "esp32dev",
+        "--emulator",
+        "qemu",
+        "--timeout",
+        "10",
+    ]
+    proc = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        timeout=600,
+    )
+    output = proc.stdout + "\n" + proc.stderr
+    assert proc.returncode == 0, (
+        f"fbuild test-emu exited with rc={proc.returncode}.\n"
+        f"CMD: {subprocess.list2cmdline(cmd)}\n"
+        f"--- STDOUT ---\n{proc.stdout}\n"
+        f"--- STDERR ---\n{proc.stderr}"
+    )
+    assert SUCCESS_MARKER in output, (
+        f"Expected marker {SUCCESS_MARKER!r} not found in emulator output.\n"
+        f"--- STDOUT ---\n{proc.stdout}\n"
+        f"--- STDERR ---\n{proc.stderr}"
+    )

--- a/tests/fbuild_qemu_smoke/README.md
+++ b/tests/fbuild_qemu_smoke/README.md
@@ -1,0 +1,16 @@
+# fbuild_qemu_smoke
+
+Minimal standalone PlatformIO project used by `ci/tests/test_fbuild_qemu.py` to
+verify that fbuild's native QEMU path (`fbuild test-emu`) can build and boot a
+FastLED sketch on ESP32-QEMU.
+
+The sketch includes FastLED and a `WS2812` controller addition so a failure in
+library resolution, compile, link, or early boot surfaces as a test failure.
+
+Run manually:
+
+```
+fbuild test-emu tests/fbuild_qemu_smoke -e esp32dev --emulator qemu --timeout 10
+```
+
+If the emulator prints `FBUILD-QEMU-TEST-OK` the path is working end-to-end.

--- a/tests/fbuild_qemu_smoke/platformio.ini
+++ b/tests/fbuild_qemu_smoke/platformio.ini
@@ -1,0 +1,19 @@
+; Minimal standalone project for exercising fbuild's native QEMU path against FastLED.
+; Referenced by ci/tests/test_fbuild_qemu.py.
+;
+; Why a dedicated project (vs. the root platformio.ini): the root platformio.ini
+; uses src_dir = ./src (i.e., FastLED's library source) which has no setup()/loop().
+; This sketch provides a tiny main that includes FastLED so fbuild test-emu has
+; something to build + boot in QEMU.
+
+[env:esp32dev]
+platform = platformio/espressif32
+board = esp32dev
+framework = arduino
+; Use DIO flash mode — QEMU's ESP32 doesn't support QIO (matches fastled root's esp32dev env).
+board_build.flash_mode = dio
+board_build.partitions = huge_app.csv
+lib_deps = FastLED=symlink://../..
+build_flags =
+    -DFASTLED_ESP32_IS_QEMU
+    -DCORE_DEBUG_LEVEL=0

--- a/tests/fbuild_qemu_smoke/src/README.md
+++ b/tests/fbuild_qemu_smoke/src/README.md
@@ -1,0 +1,5 @@
+# src/
+
+FastLED-dependent sketch (`main.ino`) for the fbuild native-QEMU smoke test.
+Prints `FBUILD-QEMU-TEST-OK` on successful boot so the test runner can detect
+a clean emulator startup.

--- a/tests/fbuild_qemu_smoke/src/main.ino
+++ b/tests/fbuild_qemu_smoke/src/main.ino
@@ -1,0 +1,26 @@
+// Minimal FastLED sketch for fbuild native-QEMU smoke test.
+// Must print FBUILD-QEMU-TEST-OK once early init completes so the QEMU
+// runner's halt-on-success matcher can exit the emulator cleanly.
+
+#include <Arduino.h>
+#include <FastLED.h>
+
+#define NUM_LEDS 1
+#define PIN_DATA 5
+
+CRGB leds[NUM_LEDS];
+
+void setup() {
+    Serial.begin(115200);
+    Serial.println("FBUILD-QEMU-TEST-BOOT");
+
+    FastLED.addLeds<WS2812, PIN_DATA, GRB>(leds, NUM_LEDS);
+    leds[0] = CRGB::Red;
+    FastLED.show();
+
+    Serial.println("FBUILD-QEMU-TEST-OK");
+}
+
+void loop() {
+    delay(1000);
+}


### PR DESCRIPTION
## Summary
- Adds `tests/fbuild_qemu_smoke/` — a minimal standalone PlatformIO project with a tiny FastLED sketch that prints `FBUILD-QEMU-TEST-OK` on boot.
- Adds `ci/tests/test_fbuild_qemu.py` — invokes `fbuild test-emu` on the smoke project and asserts the boot marker.

## Status: no longer xfail

The previous revision carried `xfail(strict=False)` tracking [FastLED/fbuild#130](https://github.com/FastLED/fbuild/issues/130) (`daemon error: request failed` on Windows despite a healthy daemon). That upstream bug was fixed in **fbuild 2.1.20** (closed 2026-04-19). Since master now pins `fbuild>=2.1.20` via #2353, this smoke test should pass on all platforms — the `xfail` marker is removed and `subprocess.list2cmdline()` is used in the error diagnostic per CodeRabbit's guideline feedback.

## Why a dedicated project under `tests/fbuild_qemu_smoke/`
FastLED's root `platformio.ini` uses `src_dir = ./src` (the library itself, no `setup()`/`loop()`). `fbuild test-emu` needs an actual sketch. Keeping the smoke project small and standalone (single-env `esp32dev`, DIO flash mode for QEMU compat, FastLED via `lib_deps = symlink://../..`) avoids tangling with the Docker-based QEMU runner in `ci/runners/qemu_runner.py`.

## Test plan
- [ ] `uv sync` (resolves `fbuild==2.1.20`)
- [ ] `uv run pytest ci/tests/test_fbuild_qemu.py -v` — now passes (xfail removed)
- [ ] Manual: `uv run fbuild test-emu tests/fbuild_qemu_smoke -e esp32dev --emulator qemu --timeout 10`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added CI test suite documentation with commands and coverage overview
  * Added QEMU smoke test project documentation with manual execution instructions

* **Tests**
  * Added smoke test for QEMU emulation flow validation, including library resolution and boot behavior verification
  * Test includes configurable skip conditions and comprehensive output validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->