### PR TITLE
feat(chipsets): add TX1813N1 and SK6812WWA aliases

### DIFF
--- a/src/FastLED.h
+++ b/src/FastLED.h
@@ -306,6 +306,14 @@ class SM16824E : public SM16824EController<DATA_PIN, RGB_ORDER> {};
 template<fl::u8 DATA_PIN, fl::EOrder RGB_ORDER>
 class TM1829 : public TM1829Controller800Khz<DATA_PIN, RGB_ORDER> {};
 
+/// @brief TX1813N1 controller class (2020-package 3-in-1 RGB).
+/// @details Protocol-compatible with TM1829 per reporter field-testing on
+/// 2.2 mm × 2.2 mm 2020-package parts. Uses the TM1829 800 kHz timing.
+/// @see TM1829Controller800Khz
+/// @see https://github.com/FastLED/FastLED/issues/1362
+template<fl::u8 DATA_PIN, fl::EOrder RGB_ORDER>
+class TX1813N1 : public TM1829Controller800Khz<DATA_PIN, RGB_ORDER> {};
+
 /// @brief TM1812 controller class.
 /// @copydetails TM1809Controller800Khz
 template<fl::u8 DATA_PIN, fl::EOrder RGB_ORDER>
@@ -404,6 +412,18 @@ class GS1903 : public WS2812Controller800Khz<DATA_PIN, RGB_ORDER> {};
 /// @copydetails SK6812Controller
 template<fl::u8 DATA_PIN, fl::EOrder RGB_ORDER>
 class SK6812 : public SK6812Controller<DATA_PIN, RGB_ORDER> {};
+
+/// @brief SK6812 WWA controller alias.
+/// @details SK6812 WWA (Warm-White / White / Amber) strips use the same 800 kHz
+/// timing and wire protocol as regular SK6812 RGB strips. The three bytes per
+/// pixel are independent white/amber channel intensities instead of R/G/B.
+/// Use the CRGB struct as a 3-byte carrier: \c leds[i].r → channel 1,
+/// \c leds[i].g → channel 2, \c leds[i].b → channel 3 (check your strip's
+/// physical ordering; swap \c RGB_ORDER if channels look transposed).
+/// @see SK6812Controller
+/// @see https://github.com/FastLED/FastLED/issues/1347
+template<fl::u8 DATA_PIN, fl::EOrder RGB_ORDER>
+class SK6812WWA : public SK6812Controller<DATA_PIN, RGB_ORDER> {};
 
 /// @brief SK6822 controller class.
 /// @copydetails SK6822Controller


### PR DESCRIPTION
## Summary

Two one-line-each chipset aliases so users can spell what they have rather than knowing the compatible controller.

- **TX1813N1** (#1362): 2020-package 3-in-1 RGB LED, protocol-compatible with TM1829 per field-testing in the issue thread. Aliased to \`TM1829Controller800Khz\`.
- **SK6812WWA** (#1347): SK6812 family warm-white / white / amber variant. Same 800 kHz wire protocol as SK6812 RGB; pixel bytes carry three independent channel intensities instead of R/G/B. Aliased to \`SK6812Controller\`.

No new timing tables or controller templates — both are direct typedef-style subclasses of existing controllers. Header comments explain intent and link to the originating issues.

## Not in scope (also triaged in the same sweep)

Comments posted on the related chipset issues; code not changed because the fixes are already in tree or the ask needs more info:

- #2187 UCS7604 @ 1600 kHz — already shipped as \`UCS7604HD_1600\`.
- #1311 WS2812B-V5 — already shipped as \`WS2812BV5\` with dedicated timing.
- #1941 SM16824E + SM16703P3 — both already shipped (\`SM16824E\`, \`SM16703\`).
- #1340 / #1622 SM16703 timing — centralized in \`fl/chipsets/led_timing.h\`, duplicate-declaration bug resolved.
- #1881 LC8816E — asked reporter to confirm color-order mismatch before adding a speculative timing entry.
- #1441 TM1908 — asked reporter for datasheet/logic-analyzer capture; won't ship guessed timings.
- #1490 OSTW2020C1E — 2020-package LED almost certainly WS2812-compatible; asked reporter to verify with existing \`WS2812\` driver first.

## Test plan

- [x] \`bash compile uno --examples Blink\` passes (template aliases are valid).
- [ ] CI will exercise the full platform matrix.
- [ ] Users with TX1813N1 / SK6812 WWA hardware confirm the alias lights up cleanly.

Refs #1362 #1347

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for TX1813N1 clockless LED chipset controller
  * Added support for SK6812WWA clockless LED chipset controller

<!-- end of auto-generated comment: release notes by coderabbit.ai -->