### PR TITLE
chore: bump fbuild pin to 2.1.19

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    "fbuild>=2.1.12",
+    "fbuild>=2.1.19",
     "platformio>=6.1.19,<6.2",
     "python-dateutil",
     "ruff",


### PR DESCRIPTION
fbuild 2.1.19 on PyPI ships:
- [`.lnk` resource pointers](https://github.com/FastLED/fbuild/pull/119) — JSON manifests that point at remote binary blobs, fetched + verified + cached at build time
- zccache 1.2.12 post-link deploy hook integration — fixes the error-126 DLL load flake

Minimum version needed to consume either feature from FastLED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated fbuild dependency to version 2.1.19.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->