### PR TITLE
fix(esp8266): eliminate remaining compile-time warnings

### DIFF
--- a/src/fl/channels/detail/validation/platform.cpp.hpp
+++ b/src/fl/channels/detail/validation/platform.cpp.hpp
@@ -6,6 +6,7 @@
 
 #include "fl/channels/detail/validation/platform.h"
 #include "fl/channels/manager.h"
+#include "fl/stl/compiler_control.h"
 #include "fl/system/log.h"
 
 namespace fl {
@@ -27,6 +28,7 @@ void printEngineValidation() {
     FL_WARN("\n[VALIDATION] Registered drivers: " << infos.size());
     for (fl::size i = 0; i < infos.size(); i++) {
         const auto& info = infos[i];
+        FL_UNUSED(info);  // silences -Wunused-variable when FL_WARN is a no-op
         FL_WARN("  - " << info.name.c_str()
                         << " (priority=" << info.priority
                         << ", enabled=" << (info.enabled ? "true" : "false")

--- a/src/fl/stl/detail/memory_file_handle.h
+++ b/src/fl/stl/detail/memory_file_handle.h
@@ -27,7 +27,7 @@ public:
         if (!buffer || count == 0) return 0;
         fl::size_t actual = FL_MIN(count, mBuffer.size());
         for (fl::size_t i = 0; i < actual; ++i) {
-            fl::u8 b;
+            fl::u8 b = 0;
             mBuffer.pop_front(&b);
             buffer[i] = static_cast<char>(b);
         }

--- a/src/platforms/esp/8266/clockless_esp8266.h
+++ b/src/platforms/esp/8266/clockless_esp8266.h
@@ -165,7 +165,7 @@ protected:
 				intlock.Lock();
 				// if interrupts took longer than 45µs, punt on the current frame
 				if((i32)(__clock_cycles()-last_mark) > 0) {
-					if((i32)(__clock_cycles()-last_mark) > (T1+T2+T3+((WAIT_TIME-INTERRUPT_THRESHOLD)*CLKS_PER_US))) {
+					if((i32)(__clock_cycles()-last_mark) > (i32)(T1+T2+T3+((WAIT_TIME-INTERRUPT_THRESHOLD)*CLKS_PER_US))) {
 						return 0;
 					}
 				}

--- a/src/platforms/esp/8266/pin_esp8266_native.hpp
+++ b/src/platforms/esp/8266/pin_esp8266_native.hpp
@@ -33,7 +33,16 @@ namespace platforms {
 // ============================================================================
 // GPIO Register Access Macros (ESP8266)
 // ============================================================================
+//
+// Several of these names collide with the Arduino-ESP8266 core's
+// <esp8266_peri.h>, which defines them as function-like macros with
+// different parameter shapes than FastLED uses internally (see issue
+// #1264). We explicitly #undef each colliding name before redefining so
+// the redefinition is a replacement, not a diagnostic — silences
+// -Wbuiltin-macro-redefined / redefined-warning noise on every TU that
+// pulls this header in.
 
+#undef ESP8266_REG
 // Base register address for GPIO
 #define ESP8266_REG(addr) (*reinterpret_cast<volatile u32*>(0x60000000 + (addr)))  // ok reinterpret cast
 
@@ -50,16 +59,20 @@ namespace platforms {
 #define GPC(p)   ESP8266_REG(0x328 + ((p & 0xF) * 4))
 
 // GPIO pin function register (one per pin)
+#undef GPF
 #define GPF(p)   ESP8266_REG(0x800 + ((p & 0xF) * 4))
 
 // GPIO pin input read macro
+#undef GPIP
 #define GPIP(p)  ((GPI >> (p)) & 1)
 
 // GPIO 16 special registers (separate from 0-15)
 #define GP16O    ESP8266_REG(0x768)  // GPIO16 output
 #define GP16E    ESP8266_REG(0x774)  // GPIO16 enable
 #define GP16I    ESP8266_REG(0x78C)  // GPIO16 input
+#undef GPC16
 #define GPC16    ESP8266_REG(0x790)  // GPIO16 control
+#undef GPF16
 #define GPF16    ESP8266_REG(0x7A0)  // GPIO16 function
 
 // Pin control register bit positions
@@ -69,11 +82,15 @@ namespace platforms {
 // Pin function register bit positions
 #define GPFPU    7   // Pull-up enable (1 = enable)
 #define GPFPD    6   // Pull-down enable (1 = enable)
+#undef GPFFS
 #define GPFFS    4   // Function select bits (4-6)
 
 // GPIO function select helper - sets function select bits to GPIO mode
+#undef GPFFS_GPIO
 #define GPFFS_GPIO(p)  (((p) < 16) ? 0 : 0)  // Function 0 = GPIO for pins 0-15
+#undef GP16FFS
 #define GP16FFS(v)     ((v) << 0)  // GPIO16 function select
+#undef GP16FPD
 #define GP16FPD        6   // GPIO16 pull-down bit
 
 // ============================================================================


### PR DESCRIPTION
## Summary

ESP8266 Blink build now compiles warning-free on the default PlatformIO espressif8266 toolchain: **13 warnings → 0** (verified locally with \`bash compile esp8266 --examples Blink\`).

Fixes:

- **9 macro-redefinition warnings** in \`src/platforms/esp/8266/pin_esp8266_native.hpp\` — the core's \`<esp8266_peri.h>\` defines \`GPFFS\`, \`GPFFS_GPIO\`, \`GP16FFS\`, \`GP16FPD\`, \`GPF\`, \`GPC16\`, \`GPF16\`, \`GPIP\`, \`ESP8266_REG\` as function-like macros with different parameter shapes than FastLED uses internally. Added \`#undef\` immediately before each \`#define\` so the redefinition is a replacement, not a diagnostic — FastLED's semantics are preserved for all nine.
- **2 \`-Wmaybe-uninitialized\` warnings** in \`src/fl/stl/detail/memory_file_handle.h\` — zero-init local \`fl::u8 b\`. \`pop_front\` writes via pointer but the compiler can't prove that on every path.
- **1 \`-Wunused-variable\`** in \`src/fl/channels/detail/validation/platform.cpp.hpp\` — mark \`info\` with \`FL_UNUSED\` because \`FL_WARN\` compiles to a no-op in release builds, making the captured reference unused.
- **1 \`-Wsign-compare\`** in \`src/platforms/esp/8266/clockless_esp8266.h:168\` — cast RHS to \`i32\` to match the LHS.

## Why this matters

The reporter of #1264 gave up on ESP8266 support partly because of the warning volume. Zeroing them restores trust in the toolchain and unblocks future \`-Werror\` in CI for this platform.

## Test plan

- [x] \`bash compile esp8266 --examples Blink\` → 0 warnings, 0 errors, exit 0.
- [ ] Full CI matrix (this PR will exercise it).

Refs #1264

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed potential uninitialized memory reads in buffer operations
  * Corrected integer type handling in ESP8266 timing comparisons to prevent calculation errors
  * Resolved GPIO macro naming conflicts on ESP8266 platforms
  * Eliminated compiler warnings during the build process for improved code quality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->