### PR TITLE
ci(uno): add workflow_dispatch trigger + verify fbuild 2.1.20 fix

### DIFF
--- a/.github/workflows/build_uno.yml
+++ b/.github/workflows/build_uno.yml
@@ -5,6 +5,7 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - master


### PR DESCRIPTION
## Summary
- Adds `workflow_dispatch:` to `.github/workflows/build_uno.yml` so the uno build can be manually re-run from the Actions UI.
- Doubles as the **validation run** for the fbuild 2.1.20 bump (#2353). The change itself lives in the uno workflow's own trigger-path list (`.github/workflows/build_uno.yml`), so this PR will run the uno build and confirm that `FastLED/fbuild#134` (P0 `Operation not permitted (os error 1)`) and `FastLED/fbuild#135` (exec bit on wheel) are both resolved.

## Background
Every uno CI run since April 19 has been red:
```
/opt/hostedtoolcache/Python/3.12.13/x64/bin/fbuild: Permission denied
FAILED: Blink — build failed: io error: Operation not permitted (os error 1)
```
Root cause was fbuild 2.1.19's wheel; fix released as fbuild 2.1.20 and picked up in FastLED#2353 (already merged). This PR provides the missing validation signal + a handy re-trigger mechanism.

## Test plan
- [ ] uno CI on this PR goes green (proves 2.1.20 fix)
- [ ] After merge, can manually dispatch uno from Actions UI via the new `workflow_dispatch` trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build workflow to support manual execution in addition to automatic triggers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->