### PR TITLE
chore(hooks): skip hooks gracefully when pyproject.toml has merge conflict markers

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,6 @@
 {
   "_cwd_resolution": "Each hook walks up from $PWD looking for pyproject.toml (the project-root marker). If found, cd there and exec the hook script. If not found (cwd outside project, or inside a nested build dir with its own .git), the hook skips with a warning instead of blocking every subsequent tool call. Do NOT use `git rev-parse --show-toplevel` here — it gets fooled by nested .git dirs that build tools create under .build/.",
+  "_conflict_marker_guard": "Before execing `uv run python <hook>.py`, each command greps pyproject.toml for merge-conflict markers (`<<<<<<< `). If present, the hook skips instead of letting uv fail with a TOML parse error and cascade-block every tool. Without this guard, a mid-rebase state (git rebase leaving conflict markers in pyproject.toml) makes every Claude tool unrunnable until someone manually fixes the file — a catch-22 since the fix itself requires tools. Learned from an actual lockout on 2026-04-19 during PR #2346 rebase.",
   "hooks": {
     "PreToolUse": [
       {
@@ -7,7 +8,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "d=$PWD; while [ \"$d\" != / ] && [ ! -f \"$d/pyproject.toml\" ]; do d=$(dirname \"$d\"); done; [ -f \"$d/pyproject.toml\" ] && cd \"$d\" && exec uv run python ci/hooks/check_forbidden_commands.py || { echo 'FastLED hook skipped: project root (pyproject.toml) not found above $PWD' >&2; exit 0; }"
+            "command": "d=$PWD; while [ \"$d\" != / ] && [ ! -f \"$d/pyproject.toml\" ]; do d=$(dirname \"$d\"); done; [ -f \"$d/pyproject.toml\" ] && cd \"$d\" && ! grep -q '^<<<<<<< ' pyproject.toml && exec uv run python ci/hooks/check_forbidden_commands.py || { echo 'FastLED hook skipped: pyproject.toml missing or has unresolved merge conflict markers' >&2; exit 0; }"
           }
         ]
       },
@@ -16,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "d=$PWD; while [ \"$d\" != / ] && [ ! -f \"$d/pyproject.toml\" ]; do d=$(dirname \"$d\"); done; [ -f \"$d/pyproject.toml\" ] && cd \"$d\" && exec uv run python ci/hooks/check_test_file_pairing.py || { echo 'FastLED hook skipped: project root (pyproject.toml) not found above $PWD' >&2; exit 0; }"
+            "command": "d=$PWD; while [ \"$d\" != / ] && [ ! -f \"$d/pyproject.toml\" ]; do d=$(dirname \"$d\"); done; [ -f \"$d/pyproject.toml\" ] && cd \"$d\" && ! grep -q '^<<<<<<< ' pyproject.toml && exec uv run python ci/hooks/check_test_file_pairing.py || { echo 'FastLED hook skipped: pyproject.toml missing or has unresolved merge conflict markers' >&2; exit 0; }"
           }
         ]
       },
@@ -25,7 +26,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "d=$PWD; while [ \"$d\" != / ] && [ ! -f \"$d/pyproject.toml\" ]; do d=$(dirname \"$d\"); done; [ -f \"$d/pyproject.toml\" ] && cd \"$d\" && exec uv run python ci/hooks/check_pr_merge_reviews.py || { echo 'FastLED hook skipped: project root (pyproject.toml) not found above $PWD' >&2; exit 0; }",
+            "command": "d=$PWD; while [ \"$d\" != / ] && [ ! -f \"$d/pyproject.toml\" ]; do d=$(dirname \"$d\"); done; [ -f \"$d/pyproject.toml\" ] && cd \"$d\" && ! grep -q '^<<<<<<< ' pyproject.toml && exec uv run python ci/hooks/check_pr_merge_reviews.py || { echo 'FastLED hook skipped: pyproject.toml missing or has unresolved merge conflict markers' >&2; exit 0; }",
             "timeout": 45
           }
         ]
@@ -35,12 +36,12 @@
         "hooks": [
           {
             "type": "command",
-            "command": "d=$PWD; while [ \"$d\" != / ] && [ ! -f \"$d/pyproject.toml\" ]; do d=$(dirname \"$d\"); done; [ -f \"$d/pyproject.toml\" ] && cd \"$d\" && exec uv run python ci/hooks/tdd_guard.py || { echo 'FastLED hook skipped: project root (pyproject.toml) not found above $PWD' >&2; exit 0; }",
+            "command": "d=$PWD; while [ \"$d\" != / ] && [ ! -f \"$d/pyproject.toml\" ]; do d=$(dirname \"$d\"); done; [ -f \"$d/pyproject.toml\" ] && cd \"$d\" && ! grep -q '^<<<<<<< ' pyproject.toml && exec uv run python ci/hooks/tdd_guard.py || { echo 'FastLED hook skipped: pyproject.toml missing or has unresolved merge conflict markers' >&2; exit 0; }",
             "timeout": 10
           },
           {
             "type": "command",
-            "command": "d=$PWD; while [ \"$d\" != / ] && [ ! -f \"$d/pyproject.toml\" ]; do d=$(dirname \"$d\"); done; [ -f \"$d/pyproject.toml\" ] && cd \"$d\" && exec uv run python ci/hooks/protect_platform_headers.py || { echo 'FastLED hook skipped: project root (pyproject.toml) not found above $PWD' >&2; exit 0; }",
+            "command": "d=$PWD; while [ \"$d\" != / ] && [ ! -f \"$d/pyproject.toml\" ]; do d=$(dirname \"$d\"); done; [ -f \"$d/pyproject.toml\" ] && cd \"$d\" && ! grep -q '^<<<<<<< ' pyproject.toml && exec uv run python ci/hooks/protect_platform_headers.py || { echo 'FastLED hook skipped: pyproject.toml missing or has unresolved merge conflict markers' >&2; exit 0; }",
             "timeout": 10
           }
         ]
@@ -52,17 +53,17 @@
         "hooks": [
           {
             "type": "command",
-            "command": "d=$PWD; while [ \"$d\" != / ] && [ ! -f \"$d/pyproject.toml\" ]; do d=$(dirname \"$d\"); done; [ -f \"$d/pyproject.toml\" ] && cd \"$d\" && exec uv run python ci/hooks/lint-on-save.py || { echo 'FastLED hook skipped: project root (pyproject.toml) not found above $PWD' >&2; exit 0; }",
+            "command": "d=$PWD; while [ \"$d\" != / ] && [ ! -f \"$d/pyproject.toml\" ]; do d=$(dirname \"$d\"); done; [ -f \"$d/pyproject.toml\" ] && cd \"$d\" && ! grep -q '^<<<<<<< ' pyproject.toml && exec uv run python ci/hooks/lint-on-save.py || { echo 'FastLED hook skipped: pyproject.toml missing or has unresolved merge conflict markers' >&2; exit 0; }",
             "timeout": 30
           },
           {
             "type": "command",
-            "command": "d=$PWD; while [ \"$d\" != / ] && [ ! -f \"$d/pyproject.toml\" ]; do d=$(dirname \"$d\"); done; [ -f \"$d/pyproject.toml\" ] && cd \"$d\" && exec uv run python ci/hooks/auto_test_suggest.py || { echo 'FastLED hook skipped: project root (pyproject.toml) not found above $PWD' >&2; exit 0; }",
+            "command": "d=$PWD; while [ \"$d\" != / ] && [ ! -f \"$d/pyproject.toml\" ]; do d=$(dirname \"$d\"); done; [ -f \"$d/pyproject.toml\" ] && cd \"$d\" && ! grep -q '^<<<<<<< ' pyproject.toml && exec uv run python ci/hooks/auto_test_suggest.py || { echo 'FastLED hook skipped: pyproject.toml missing or has unresolved merge conflict markers' >&2; exit 0; }",
             "timeout": 10
           },
           {
             "type": "command",
-            "command": "d=$PWD; while [ \"$d\" != / ] && [ ! -f \"$d/pyproject.toml\" ]; do d=$(dirname \"$d\"); done; [ -f \"$d/pyproject.toml\" ] && cd \"$d\" && exec uv run python ci/hooks/compile_example.py || { echo 'FastLED hook skipped: project root (pyproject.toml) not found above $PWD' >&2; exit 0; }",
+            "command": "d=$PWD; while [ \"$d\" != / ] && [ ! -f \"$d/pyproject.toml\" ]; do d=$(dirname \"$d\"); done; [ -f \"$d/pyproject.toml\" ] && cd \"$d\" && ! grep -q '^<<<<<<< ' pyproject.toml && exec uv run python ci/hooks/compile_example.py || { echo 'FastLED hook skipped: pyproject.toml missing or has unresolved merge conflict markers' >&2; exit 0; }",
             "timeout": 300,
             "statusMessage": "Compiling example..."
           }
@@ -74,7 +75,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "d=$PWD; while [ \"$d\" != / ] && [ ! -f \"$d/pyproject.toml\" ]; do d=$(dirname \"$d\"); done; [ -f \"$d/pyproject.toml\" ] && cd \"$d\" && exec uv run python ci/hooks/check-on-start.py || { echo 'FastLED hook skipped: project root (pyproject.toml) not found above $PWD' >&2; exit 0; }",
+            "command": "d=$PWD; while [ \"$d\" != / ] && [ ! -f \"$d/pyproject.toml\" ]; do d=$(dirname \"$d\"); done; [ -f \"$d/pyproject.toml\" ] && cd \"$d\" && ! grep -q '^<<<<<<< ' pyproject.toml && exec uv run python ci/hooks/check-on-start.py || { echo 'FastLED hook skipped: pyproject.toml missing or has unresolved merge conflict markers' >&2; exit 0; }",
             "timeout": 10
           }
         ]
@@ -85,7 +86,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "d=$PWD; while [ \"$d\" != / ] && [ ! -f \"$d/pyproject.toml\" ]; do d=$(dirname \"$d\"); done; [ -f \"$d/pyproject.toml\" ] && cd \"$d\" && exec uv run python ci/hooks/check-on-stop.py || { echo 'FastLED hook skipped: project root (pyproject.toml) not found above $PWD' >&2; exit 0; }",
+            "command": "d=$PWD; while [ \"$d\" != / ] && [ ! -f \"$d/pyproject.toml\" ]; do d=$(dirname \"$d\"); done; [ -f \"$d/pyproject.toml\" ] && cd \"$d\" && ! grep -q '^<<<<<<< ' pyproject.toml && exec uv run python ci/hooks/check-on-stop.py || { echo 'FastLED hook skipped: pyproject.toml missing or has unresolved merge conflict markers' >&2; exit 0; }",
             "timeout": 600
           }
         ]
@@ -96,7 +97,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "d=$PWD; while [ \"$d\" != / ] && [ ! -f \"$d/pyproject.toml\" ]; do d=$(dirname \"$d\"); done; [ -f \"$d/pyproject.toml\" ] && cd \"$d\" && exec uv run python ci/hooks/desktop_notify.py || { echo 'FastLED hook skipped: project root (pyproject.toml) not found above $PWD' >&2; exit 0; }",
+            "command": "d=$PWD; while [ \"$d\" != / ] && [ ! -f \"$d/pyproject.toml\" ]; do d=$(dirname \"$d\"); done; [ -f \"$d/pyproject.toml\" ] && cd \"$d\" && ! grep -q '^<<<<<<< ' pyproject.toml && exec uv run python ci/hooks/desktop_notify.py || { echo 'FastLED hook skipped: pyproject.toml missing or has unresolved merge conflict markers' >&2; exit 0; }",
             "timeout": 10
           }
         ]
@@ -107,7 +108,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "d=$PWD; while [ \"$d\" != / ] && [ ! -f \"$d/pyproject.toml\" ]; do d=$(dirname \"$d\"); done; [ -f \"$d/pyproject.toml\" ] && cd \"$d\" && exec uv run python ci/hooks/git_context.py || { echo 'FastLED hook skipped: project root (pyproject.toml) not found above $PWD' >&2; exit 0; }",
+            "command": "d=$PWD; while [ \"$d\" != / ] && [ ! -f \"$d/pyproject.toml\" ]; do d=$(dirname \"$d\"); done; [ -f \"$d/pyproject.toml\" ] && cd \"$d\" && ! grep -q '^<<<<<<< ' pyproject.toml && exec uv run python ci/hooks/git_context.py || { echo 'FastLED hook skipped: pyproject.toml missing or has unresolved merge conflict markers' >&2; exit 0; }",
             "timeout": 10
           }
         ]


### PR DESCRIPTION
## Summary
Adds a `grep -q '^<<<<<<< ' pyproject.toml` pre-check to every `.claude/settings.json` hook command. If unresolved merge conflict markers are present, the hook short-circuits through the existing `||` fallback and exits 0 with a warning instead of letting `uv run` crash with a TOML parse error.

## The bug this fixes — real lockout observed today
During PR #2346's rebase, `pyproject.toml` had conflict markers mid-rebase. Every Claude tool triggered a PreToolUse hook → hook ran `uv run python ci/hooks/<script>.py` → uv tried to parse `pyproject.toml` for dependency resolution → TOML parse error → hook exited non-zero → tool was blocked.

**Result: total tool lockout.** Every single tool (Read, Write, Edit, Bash, Skill, ToolSearch, Glob, Grep) returned the same:

```
PreToolUse:Bash hook error: [d=$PWD; ...]: warning: Failed to parse `pyproject.toml` ...
error: Failed to parse: `pyproject.toml`
  Caused by: TOML parse error at line 9, column 5
9 |     "fbuild>=2.1.20",
missing comma between array elements, expected `,`
```

The agent couldn't fix `pyproject.toml` because editing it required Read → hook → uv → parse-fail → blocked. A catch-22. The user had to intervene manually from a terminal.

## Fix
Single-line change to each of the 12 hook command strings: add `&& ! grep -q '^<<<<<<< ' pyproject.toml` between `cd "$d"` and `exec uv run ...`. Conflict-marker detection is ~1ms, the `grep` is already on every system, and the existing `|| { echo ...; exit 0; }` fallback now gracefully handles both failure modes.

```diff
-[ -f "$d/pyproject.toml" ] && cd "$d" && exec uv run python ci/hooks/<SCRIPT> || { echo 'FastLED hook skipped: project root (pyproject.toml) not found above $PWD' >&2; exit 0; }
+[ -f "$d/pyproject.toml" ] && cd "$d" && ! grep -q '^<<<<<<< ' pyproject.toml && exec uv run python ci/hooks/<SCRIPT> || { echo 'FastLED hook skipped: pyproject.toml missing or has unresolved merge conflict markers' >&2; exit 0; }
```

Also adds a `_conflict_marker_guard` documentation key in `settings.json` next to the existing `_cwd_resolution` note, so future readers understand why the `grep` is there.

## Test plan
- [ ] Confirm hooks still fire correctly on a clean `pyproject.toml` (normal operation) — verified during this session; tools work.
- [ ] Confirm hooks skip with the new warning message when `pyproject.toml` contains `<<<<<<<` markers. Can be reproduced by running `git merge` with a deliberate conflict in `pyproject.toml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)