### PR TITLE
chore: bump fbuild pin to >=2.1.21

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    "fbuild>=2.1.20",
+    "fbuild>=2.1.21",
     "platformio>=6.1.19,<6.2",
     "python-dateutil",
     "ruff",


### PR DESCRIPTION
## Summary
Follow-up to #2353 (2.1.20 bump). fbuild 2.1.21 is now live on PyPI and picks up post-2.1.20 fixes. Pure pin bump — no behavioural change expected.

## Verified locally

```
$ uv run fbuild --version
fbuild 2.1.21
```

## Relation to other PRs
- #2353 (fbuild>=2.1.20) — merged
- #2346 (fbuild QEMU smoke test) — merged
- #2355 (hook conflict-marker guard) — open

## Test plan
- [ ] Uno / ESP32 / board-matrix workflows on master continue passing with 2.1.21
- [ ] `bash autoresearch` / `bash compile <board>` still work end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a dependency version to improve platform stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->