### PR TITLE
fix: avoid global delay overload conflict

### DIFF
--- a/ci/lint_cpp/using_namespace_fl_in_examples_checker.py
+++ b/ci/lint_cpp/using_namespace_fl_in_examples_checker.py
@@ -2,8 +2,8 @@
 """Checker to ensure 'using namespace fl;' is not used in example files.
 
 This checker prevents namespace conflicts between fl:: and Arduino built-in functions.
-When FastLED.h does 'using fl::delay;' and an example also does 'using namespace fl;',
-it can create ambiguity with Arduino's delay() function.
+FastLED.h re-exports selected fl:: names, so examples should keep fl:: usage explicit
+instead of pulling the whole namespace into sketch scope.
 
 Examples should use:
 - Explicit qualification: fl::delay(), fl::XYMap, etc.

--- a/src/FastLED.h
+++ b/src/FastLED.h
@@ -1599,7 +1599,7 @@ using fl::UIDropdown;
 using fl::UIGroup;
 using fl::XYMap;
 using fl::round;  // Template version avoids conflicts with ::round
-using fl::delay;  // Template version coexists with Arduino's extern "C" delay()
+using fl::delay;  // Explicit fl::delay() stays available without hijacking bare Arduino delay()
 
 // Common fl:: type aliases for global namespace convenience
 template<typename T> using fl_vector = fl::vector<T>;

--- a/src/fl/stl/cstdio.cpp.hpp
+++ b/src/fl/stl/cstdio.cpp.hpp
@@ -10,8 +10,10 @@
 
 // Forward declare delay to avoid Arduino conflict
 namespace fl {
-    void delay(u32 ms, bool run_async);
     void delayMicroseconds(u32 us);
+    namespace detail {
+        void delay_impl(u32 ms, bool run_async);
+    }
 }
 
 // =============================================================================

--- a/src/fl/system/delay.cpp.hpp
+++ b/src/fl/system/delay.cpp.hpp
@@ -172,7 +172,9 @@ template<> void delaycycles<50>() { delaycycles<40>(); delaycycles<10>(); }
 // Millisecond and Microsecond delay implementations
 // ============================================================================
 
-void delay(u32 ms, bool run_async) {
+namespace detail {
+
+void delay_impl(u32 ms, bool run_async) {
 #if SKETCH_HAS_LARGE_MEMORY
   // Check if delay override is active (for fast testing with stub platform)
   // When override is active, skip async pumping and use platform delay directly
@@ -194,9 +196,11 @@ void delay(u32 ms, bool run_async) {
 #endif
 }
 
+}  // namespace detail
+
 void delayMillis(u32 ms) {
   // Legacy function - no async pumping (backward compatibility)
-  delay(ms, false);
+  detail::delay_impl(ms, false);
 }
 
 void delayMicroseconds(u32 us) {

--- a/src/fl/system/delay.h
+++ b/src/fl/system/delay.h
@@ -81,29 +81,23 @@ template<cycle_t CYCLES> inline void delaycycles_min1() FL_NOEXCEPT {
 // Millisecond and Microsecond delay wrappers
 // ============================================================================
 
-/// Delay for a given number of milliseconds with optional async task pumping
+namespace detail {
+
+/// Internal delay implementation used by the public fl::delay wrapper
 /// @param ms Milliseconds to delay
 /// @param run_async If true, pump async tasks during delay (only on platforms with SKETCH_HAS_LARGE_MEMORY==1)
-void delay(u32 ms, bool run_async = true) FL_NOEXCEPT;
+void delay_impl(u32 ms, bool run_async = true) FL_NOEXCEPT;
 
-/// Template overload for all arithmetic types - coexists with Arduino's extern "C" delay()
-/// Templates have different overload resolution rules and don't conflict with C-linkage functions
-/// This allows "using fl::delay;" to work universally on all platforms including Arduino
-/// @param ms Milliseconds to delay (accepts integers, floats, doubles)
-/// @note Similar technique used by fl::round to coexist with Arduino's ::round()
-/// @note Accepts all integer types (char, short, int, long, etc.) and floating-point types (float, double)
-template<typename T, typename = fl::enable_if_t<fl::is_arithmetic<T>::value>>
-inline void delay(T ms) FL_NOEXCEPT {
-    delay(static_cast<u32>(ms), true);
-}
+}  // namespace detail
 
-/// Template overload with async flag for all arithmetic types
-/// @param ms Milliseconds to delay (accepts integers, floats, doubles)
-/// @param run_async If true, pump async tasks during delay
-/// @note Accepts all integer types (char, short, int, long, etc.) and floating-point types (float, double)
-template<typename T, typename = fl::enable_if_t<fl::is_arithmetic<T>::value>>
-inline void delay(T ms, bool run_async) FL_NOEXCEPT {
-    delay(static_cast<u32>(ms), run_async);
+/// Public delay wrapper that keeps bare Arduino delay() preferred after
+/// `using fl::delay;` while still allowing explicit fl::delay() calls.
+/// @param ms Milliseconds to delay
+/// @param run_async If true, pump async tasks during delay (only on platforms with SKETCH_HAS_LARGE_MEMORY==1)
+template<int Dummy = 0>
+inline void delay(u32 ms, bool run_async = true) FL_NOEXCEPT {
+    (void)Dummy;
+    detail::delay_impl(ms, run_async);
 }
 
 /// Delay for a given number of milliseconds (legacy - no async pumping)
@@ -124,7 +118,7 @@ inline void delayUs(u32 us) FL_NOEXCEPT {
 /// @param ms Milliseconds to delay
 /// @param run_async If true, pump async tasks during delay (only on platforms with SKETCH_HAS_LARGE_MEMORY==1)
 inline void delayMs(u32 ms, bool run_async = true) FL_NOEXCEPT {
-  delay(ms, run_async);
+  detail::delay_impl(ms, run_async);
 }
 
 /// Shorter alias for delayNanoseconds (template version)

--- a/tests/fl/system/delay.cpp
+++ b/tests/fl/system/delay.cpp
@@ -7,6 +7,18 @@
 
 FL_TEST_FILE(FL_FILEPATH) {
 
+namespace delay_lookup_regression {
+char delay(fl::u32);
+using fl::delay;
+
+static_assert(fl::is_same<decltype(delay(fl::u32{1})), char>::value,
+              "Bare delay(u32) should prefer the non-template Arduino-style overload");
+static_assert(fl::is_same<decltype(delay(static_cast<unsigned long>(1))), char>::value,
+              "Bare delay(unsigned long) should prefer the non-template Arduino-style overload");
+static_assert(fl::is_same<decltype(delay(fl::u32{1}, false)), void>::value,
+              "Two-argument delay(ms, run_async) should resolve to fl::delay");
+}  // namespace delay_lookup_regression
+
 // ============================================================================
 // Test Suite: Compile-time Template Delays
 // ============================================================================


### PR DESCRIPTION
Fixes #2360.

This changes the public `fl::delay` export to a dummy-template wrapper and moves the real implementation behind `fl::detail::delay_impl(...)`.

Why:
- `FastLED.h` re-exported `using fl::delay;`
- the previous public overload set could make unqualified `delay(...)` ambiguous against Arduino/core `delay(...)`
- this showed up with IRremote on ESP32-S3 in issue #2360

What changed:
- keep `using fl::delay;` available for explicit `fl::delay(...)` use
- preserve preference for bare non-template Arduino `delay(...)`
- route the two-argument FastLED path through the wrapper/internal implementation
- add a compile-time regression check for overload resolution
- update the related lint checker wording

Validation:
- added compile-time regression assertions in `tests/fl/system/delay.cpp`
- verified the new overload pattern with a local `g++ -fsyntax-only` probe
- did not run the full project test/build matrix


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Refactor
- Reorganized the delay implementation to prevent conflicts with platform default delays while preserving existing functionality.
- Updated the delay API to require explicit parameter types instead of accepting flexible arithmetic types.

## Documentation
- Enhanced comments clarifying delay function behavior and interaction patterns.

## Tests
- Added compile-time validation for delay function overload resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->