### PR TITLE
feat: modernize non-linear power scaling

### DIFF
--- a/src/FastLED.cpp.hpp
+++ b/src/FastLED.cpp.hpp
@@ -428,11 +428,9 @@ fl::u32 CFastLED::getEstimatedPowerInMilliWatts(bool apply_limiter) const {
 		effective_brightness = (*mPPowerFunc)(mScale, mNPowerData);
 	}
 
-	// Scale by effective brightness (linear scaling)
-	// Power = unscaled_power * (brightness / 255)
-	// Uses scale32by8() to prevent overflow and ensure proper rounding
+	// Scale by the configured power-brightness response.
 	// Note: MCU power consumption is NOT included - caller should add platform-specific MCU power if needed
-	return fl::scale32by8(total_power_mW, effective_brightness);
+	return scale_power_for_brightness(total_power_mW, effective_brightness);
 }
 
 //

--- a/src/FastLED.h
+++ b/src/FastLED.h
@@ -1353,10 +1353,35 @@ public:
 	/// @{
 
 	/// Set custom RGB LED power consumption model
-	/// @param model RGB power consumption model
+	/// @param model RGB power consumption model. The model's `exponent` field
+	///        drives the brightness-to-power response, so channel weights and
+	///        the response curve can be configured in a single call:
+	///        @code
+	///        FastLED.setPowerModel(PowerModelRGB(40, 40, 40, 2, 0.87f));
+	///        @endcode
 	/// @example FastLED.setPowerModel(PowerModelRGB(40, 40, 40, 2));
 	inline void setPowerModel(const PowerModelRGB& model) {
 		set_power_model(model);
+	}
+
+	/// Set a non-linear brightness-to-power response exponent
+	/// @param exponent 1.0 = linear (default), values below 1.0 model higher power at mid brightness
+	/// @note Convenience wrapper: equivalent to setting `model.exponent` and
+	///       calling `setPowerModel`. Prefer passing the exponent directly via
+	///       `PowerModelRGB(r, g, b, d, e)` to set both in one step.
+	/// @note `exponent <= 0` or values within 1e-4 of 1.0 fall back to linear
+	///       (identity tables), ignoring the supplied value.
+	/// @note This affects power estimation and limiting only, not rendered brightness.
+	/// @note Only enabled when `SKETCH_HAS_LARGE_MEMORY==1`; smaller-memory targets keep legacy linear behavior.
+	inline void setPowerScalingExponent(float exponent) {
+		set_power_scaling_exponent(exponent);
+	}
+
+	/// Get the configured brightness-to-power response exponent
+	/// @returns the current exponent. Defaults to 1.0 for linear scaling.
+	/// @note Returns 1.0 when `SKETCH_HAS_LARGE_MEMORY==0`.
+	inline float getPowerScalingExponent() const {
+		return get_power_scaling_exponent();
 	}
 
 	/// Set custom RGBW LED power consumption model
@@ -1377,7 +1402,7 @@ public:
 
 	/// Get current RGB power model
 	/// @returns Current RGB power consumption model
-	inline PowerModelRGB getPowerModel() {
+	inline PowerModelRGB getPowerModel() const {
 		return get_power_model();
 	}
 
@@ -1411,11 +1436,14 @@ public:
 	///       fl::u32 total_power = FastLED.getEstimatedPowerInMilliWatts() + mcu_power_mW;
 	///       @endcode
 	///
-	/// @note Uses linear brightness scaling (conservative estimate).
-	///       Power = sum(channel_values * channel_power) * (brightness/255)
+	/// @note Uses the configured power-scaling response.
+	///       Default is linear scaling; use `model.exponent` via `setPowerModel()`
+	///       or the `setPowerScalingExponent()` convenience wrapper to enable a
+	///       non-linear model.
 	///
 	/// @see setMaxPowerInMilliWatts()
 	/// @see setPowerModel()
+	/// @see setPowerScalingExponent()
 	fl::u32 getEstimatedPowerInMilliWatts(bool apply_limiter = true) const;
 
 	/// @} Power Model Configuration

--- a/src/power_mgt.cpp.hpp
+++ b/src/power_mgt.cpp.hpp
@@ -6,6 +6,12 @@
 #include "pixeltypes.h"       // CRGB
 #include "controller.h"       // CLEDController
 #include "fastpin.h"          // Pin
+#include "fl/system/sketch_macros.h"
+#if SKETCH_HAS_LARGE_MEMORY
+#include "fl/math/math.h"
+#include "fl/stl/array.h"
+#include <math.h>
+#endif
 #include "fl/stl/int.h"           // fl::u32, fl::u8
 #include "power_mgt.h"        // Function declarations (to avoid redefinition errors)
 #include "fl/stl/singleton.h"    // fl::Singleton
@@ -30,9 +36,91 @@
 /// @endcode
 /// @{
 
-/// Global RGB power model (initialized to WS2812 @ 5V defaults)
+static constexpr float kLinearPowerScalingExponent = 1.0f;
+static constexpr float kPowerScalingExponentEpsilon = 0.0001f;
+
+/// Global RGB power model (initialized to WS2812 @ 5V defaults, linear response)
 static PowerModelRGB& gPowerModel() {
     return fl::Singleton<PowerModelRGB>::instance();
+}
+
+#if SKETCH_HAS_LARGE_MEMORY
+static constexpr fl::size kPowerScalingTableSize = 256;
+
+/// Cached forward/reverse LUTs derived from `gPowerModel().exponent`.
+/// Authoritative exponent storage lives in the PowerModel itself; this is a
+/// pure cache rebuilt whenever the model's exponent changes.
+struct PowerScalingState {
+    fl::array<fl::u8, kPowerScalingTableSize> forward;
+    fl::array<fl::u8, kPowerScalingTableSize> reverse;
+
+    PowerScalingState() {
+        reset_identity();
+    }
+
+    void reset_identity() {
+        for (fl::size i = 0; i < kPowerScalingTableSize; ++i) {
+            forward[i] = static_cast<fl::u8>(i);
+            reverse[i] = static_cast<fl::u8>(i);
+        }
+    }
+};
+
+static PowerScalingState& gPowerScaling() {
+    return fl::Singleton<PowerScalingState>::instance();
+}
+
+/// Rebuild the forward/reverse LUTs from the given exponent.
+/// Non-positive or near-1.0 exponents collapse to identity tables.
+static void rebuild_power_scaling_tables(float exponent) {
+    PowerScalingState& state = gPowerScaling();
+    if (!(exponent > 0.0f) ||
+        fl::almost_equal(exponent, kLinearPowerScalingExponent, kPowerScalingExponentEpsilon)) {
+        state.reset_identity();
+        return;
+    }
+
+    // Forward LUT: source brightness -> scaled brightness via pow(x/255, exponent)
+    state.forward[0] = 0;
+    for (fl::size i = 1; i < kPowerScalingTableSize; ++i) {
+        float normalized = static_cast<float>(i) / 255.0f;
+        int mapped = static_cast<int>(lroundf(powf(normalized, exponent) * 255.0f));
+        state.forward[i] = static_cast<fl::u8>(fl::clamp(mapped, 0, 255));
+    }
+    state.forward[255] = 255;
+
+    // Reverse LUT: scaled brightness -> largest source whose forward value is
+    // <= the scaled value. Floor-inverse, so `unmap_power_value()` never
+    // rounds a budgeted scaled brightness *up* past the power budget.
+    state.reverse[0] = 0;
+    int source = 0;
+    for (int scaled = 1; scaled < static_cast<int>(kPowerScalingTableSize); ++scaled) {
+        while (source < 255 && state.forward[source + 1] <= scaled) {
+            ++source;
+        }
+        state.reverse[scaled] = static_cast<fl::u8>(source);
+    }
+}
+#endif
+
+static fl::u8 map_power_value(fl::u8 brightness) {
+#if SKETCH_HAS_LARGE_MEMORY
+    return gPowerScaling().forward[brightness];
+#else
+    return brightness;
+#endif
+}
+
+static fl::u8 unmap_power_value(fl::u8 scaled_brightness) {
+#if SKETCH_HAS_LARGE_MEMORY
+    return gPowerScaling().reverse[scaled_brightness];
+#else
+    return scaled_brightness;
+#endif
+}
+
+fl::u32 scale_power_for_brightness(fl::u32 total_mW, fl::u8 brightness) {
+    return fl::scale32by8(total_mW, map_power_value(brightness));
 }
 
 /// @}
@@ -68,9 +156,9 @@ fl::u32 calculate_unscaled_power_mW(fl::span<const CRGB> leds) {
 
     // Iterate using span's safe indexing
     for(size_t i = 0; i < leds.size(); i++) {
-        red32   += leds[i].r;
-        green32 += leds[i].g;
-        blue32  += leds[i].b;
+        red32   += map_power_value(leds[i].r);
+        green32 += map_power_value(leds[i].g);
+        blue32  += map_power_value(leds[i].b);
     }
 
     red32   *= gPowerModel().red_mW;
@@ -100,11 +188,13 @@ fl::u8 calculate_max_brightness_for_power_vmA(const CRGB* ledbuffer, fl::u16 num
 fl::u8 calculate_max_brightness_for_power_mW(const CRGB* ledbuffer, fl::u16 numLeds, fl::u8 target_brightness, fl::u32 max_power_mW) {
  	fl::u32 total_mW = calculate_unscaled_power_mW( ledbuffer, numLeds);
 
-	fl::u32 requested_power_mW = fl::scale32by8(total_mW, target_brightness);
+	fl::u8 target_brightness_scaled = map_power_value(target_brightness);
+	fl::u32 requested_power_mW = scale_power_for_brightness(total_mW, target_brightness);
 
 	fl::u8 recommended_brightness = target_brightness;
 	if(requested_power_mW > max_power_mW) { 
-        recommended_brightness = (fl::u32)((fl::u8)(target_brightness) * (fl::u32)(max_power_mW)) / ((fl::u32)(requested_power_mW));
+        fl::u8 recommended_scaled = (fl::u32)(target_brightness_scaled * (fl::u32)(max_power_mW)) / requested_power_mW;
+        recommended_brightness = unmap_power_value(recommended_scaled);
 	}
 
 	return recommended_brightness;
@@ -128,7 +218,8 @@ fl::u8 calculate_max_brightness_for_power_mW( fl::u8 target_brightness, fl::u32 
     Serial.println( total_mW);
 #endif
 
-    fl::u32 requested_power_mW = fl::scale32by8(total_mW, target_brightness);
+    fl::u8 target_brightness_scaled = map_power_value(target_brightness);
+    fl::u32 requested_power_mW = scale_power_for_brightness(total_mW, target_brightness);
 #if POWER_DEBUG_PRINT == 1
     if( target_brightness != 255 ) {
         Serial.print("power demand at scaled brightness mW = ");
@@ -150,12 +241,13 @@ fl::u8 calculate_max_brightness_for_power_mW( fl::u8 target_brightness, fl::u32 
         return target_brightness;
     }
 
-    fl::u8 recommended_brightness = (fl::u32)((fl::u8)(target_brightness) * (fl::u32)(max_power_mW)) / ((fl::u32)(requested_power_mW));
+    fl::u8 recommended_scaled = (fl::u32)(target_brightness_scaled * (fl::u32)(max_power_mW)) / ((fl::u32)(requested_power_mW));
+    fl::u8 recommended_brightness = unmap_power_value(recommended_scaled);
 #if POWER_DEBUG_PRINT == 1
     Serial.print("recommended brightness # = ");
     Serial.println( recommended_brightness);
 
-    fl::u32 resultant_power_mW = (total_mW * recommended_brightness) / 256;
+    fl::u32 resultant_power_mW = scale_power_for_brightness(total_mW, recommended_brightness);
     Serial.print("resultant power demand mW = ");
     Serial.println( resultant_power_mW);
 
@@ -178,6 +270,25 @@ void set_max_power_indicator_LED( fl::u8 pinNumber)
 
 void set_power_model(const PowerModelRGB& model) {
     gPowerModel() = model;
+#if SKETCH_HAS_LARGE_MEMORY
+    rebuild_power_scaling_tables(model.exponent);
+#else
+    // Small-memory targets ignore non-linear exponent and keep linear behavior;
+    // clamp the stored field so get_power_scaling_exponent() reports the truth.
+    gPowerModel().exponent = kLinearPowerScalingExponent;
+#endif
+}
+
+void set_power_scaling_exponent(float exponent) {
+    PowerModelRGB model = gPowerModel();
+    model.exponent = exponent;
+    set_power_model(model);
+}
+
+float get_power_scaling_exponent() {
+    // Authoritative storage lives in the model; on small-memory builds the
+    // field is clamped to 1.0 by set_power_model.
+    return gPowerModel().exponent;
 }
 
 PowerModelRGB get_power_model() {

--- a/src/power_mgt.h
+++ b/src/power_mgt.h
@@ -20,23 +20,34 @@
 
 /// RGB LED power consumption model
 /// Used for standard 3-channel LEDs (WS2812, WS2812B, APA102, etc.)
+///
+/// The model carries the brightness-to-power response exponent alongside
+/// the per-channel draw so the scaling behavior travels with the model and
+/// can be set in a single `set_power_model(...)` call.
 struct PowerModelRGB {
     fl::u8 red_mW;    ///< Red channel power at full brightness (255), in milliwatts
     fl::u8 green_mW;  ///< Green channel power at full brightness (255), in milliwatts
     fl::u8 blue_mW;   ///< Blue channel power at full brightness (255), in milliwatts
     fl::u8 dark_mW;   ///< Dark LED baseline power consumption, in milliwatts
+    float  exponent;  ///< Brightness-to-power response exponent (1.0 = linear)
 
-    /// Default constructor - WS2812 @ 5V (16mA/11mA/15mA @ 5V)
+    /// Default constructor - WS2812 @ 5V (16mA/11mA/15mA @ 5V), linear response
     constexpr PowerModelRGB()
-        : red_mW(5 * 16), green_mW(5 * 11), blue_mW(5 * 15), dark_mW(5 * 1) {}
+        : red_mW(5 * 16), green_mW(5 * 11), blue_mW(5 * 15), dark_mW(5 * 1),
+          exponent(1.0f) {}
 
     /// Custom RGB power model
     /// @param r Red channel power (mW)
     /// @param g Green channel power (mW)
     /// @param b Blue channel power (mW)
     /// @param d Dark state power (mW)
-    constexpr PowerModelRGB(fl::u8 r, fl::u8 g, fl::u8 b, fl::u8 d)
-        : red_mW(r), green_mW(g), blue_mW(b), dark_mW(d) {}
+    /// @param e Brightness-to-power response exponent. 1.0 = linear (default),
+    ///          values < 1.0 model higher-than-linear draw at mid brightness,
+    ///          values > 1.0 model lower-than-linear draw. Non-positive or
+    ///          near-1.0 values fall back to linear. Only honored on large-memory
+    ///          targets; ignored where `SKETCH_HAS_LARGE_MEMORY==0`.
+    constexpr PowerModelRGB(fl::u8 r, fl::u8 g, fl::u8 b, fl::u8 d, float e = 1.0f)
+        : red_mW(r), green_mW(g), blue_mW(b), dark_mW(d), exponent(e) {}
 };
 
 /// RGBW LED power consumption model
@@ -48,10 +59,12 @@ struct PowerModelRGBW {
     fl::u8 blue_mW;   ///< Blue channel power at full brightness (255), in milliwatts
     fl::u8 white_mW;  ///< White channel power at full brightness (255), in milliwatts
     fl::u8 dark_mW;   ///< Dark LED baseline power consumption, in milliwatts
+    float  exponent;  ///< Brightness-to-power response exponent (1.0 = linear)
 
-    /// Default constructor - SK6812 RGBW @ 5V estimate
+    /// Default constructor - SK6812 RGBW @ 5V estimate, linear response
     constexpr PowerModelRGBW()
-        : red_mW(90), green_mW(70), blue_mW(90), white_mW(100), dark_mW(5) {}
+        : red_mW(90), green_mW(70), blue_mW(90), white_mW(100), dark_mW(5),
+          exponent(1.0f) {}
 
     /// Custom RGBW power model
     /// @param r Red channel power (mW)
@@ -59,13 +72,16 @@ struct PowerModelRGBW {
     /// @param b Blue channel power (mW)
     /// @param w White channel power (mW)
     /// @param d Dark state power (mW)
-    constexpr PowerModelRGBW(fl::u8 r, fl::u8 g, fl::u8 b, fl::u8 w, fl::u8 d)
-        : red_mW(r), green_mW(g), blue_mW(b), white_mW(w), dark_mW(d) {}
+    /// @param e Brightness-to-power response exponent. See PowerModelRGB for details.
+    constexpr PowerModelRGBW(fl::u8 r, fl::u8 g, fl::u8 b, fl::u8 w, fl::u8 d,
+                             float e = 1.0f)
+        : red_mW(r), green_mW(g), blue_mW(b), white_mW(w), dark_mW(d),
+          exponent(e) {}
 
-    /// Convert to RGB model (extracts RGB components only)
+    /// Convert to RGB model (extracts RGB components, preserves exponent)
     /// @note Used internally until RGBW power calculations are implemented
     constexpr PowerModelRGB toRGB() const {
-        return PowerModelRGB(red_mW, green_mW, blue_mW, dark_mW);
+        return PowerModelRGB(red_mW, green_mW, blue_mW, dark_mW, exponent);
     }
 };
 
@@ -79,11 +95,13 @@ struct PowerModelRGBWW {
     fl::u8 white_mW;      ///< Cool white channel power at full brightness (255), in milliwatts
     fl::u8 warm_white_mW; ///< Warm white channel power at full brightness (255), in milliwatts
     fl::u8 dark_mW;       ///< Dark LED baseline power consumption, in milliwatts
+    float  exponent;      ///< Brightness-to-power response exponent (1.0 = linear)
 
-    /// Default constructor - Hypothetical RGBWW @ 5V estimate
+    /// Default constructor - Hypothetical RGBWW @ 5V estimate, linear response
     constexpr PowerModelRGBWW()
         : red_mW(85), green_mW(65), blue_mW(85),
-          white_mW(95), warm_white_mW(95), dark_mW(5) {}
+          white_mW(95), warm_white_mW(95), dark_mW(5),
+          exponent(1.0f) {}
 
     /// Custom RGBWW power model
     /// @param r Red channel power (mW)
@@ -92,21 +110,47 @@ struct PowerModelRGBWW {
     /// @param w Cool white channel power (mW)
     /// @param ww Warm white channel power (mW)
     /// @param d Dark state power (mW)
+    /// @param e Brightness-to-power response exponent. See PowerModelRGB for details.
     constexpr PowerModelRGBWW(fl::u8 r, fl::u8 g, fl::u8 b,
-                              fl::u8 w, fl::u8 ww, fl::u8 d)
+                              fl::u8 w, fl::u8 ww, fl::u8 d,
+                              float e = 1.0f)
         : red_mW(r), green_mW(g), blue_mW(b),
-          white_mW(w), warm_white_mW(ww), dark_mW(d) {}
+          white_mW(w), warm_white_mW(ww), dark_mW(d),
+          exponent(e) {}
 
-    /// Convert to RGB model (extracts RGB components only)
+    /// Convert to RGB model (extracts RGB components, preserves exponent)
     /// @note Used internally until RGBWW power calculations are implemented
     constexpr PowerModelRGB toRGB() const {
-        return PowerModelRGB(red_mW, green_mW, blue_mW, dark_mW);
+        return PowerModelRGB(red_mW, green_mW, blue_mW, dark_mW, exponent);
     }
 };
 
 /// Set custom RGB LED power consumption model
-/// @param model RGB power consumption model
+/// @param model RGB power consumption model. The model's `exponent` field drives
+///        the brightness-to-power response curve used by estimation and limiting;
+///        pass `PowerModelRGB(r, g, b, d, e)` to set channel weights + response
+///        curve in a single call.
+/// @note `exponent <= 0` or values within 1e-4 of 1.0 fall back to linear
+///       (identity tables) rather than rebuilding with a degenerate curve.
 void set_power_model(const PowerModelRGB& model);
+
+/// Set a non-linear brightness-to-power response exponent
+/// @param exponent 1.0 = linear (default), values below 1.0 model higher-than-linear
+///        power draw at mid brightness, values above 1.0 model lower-than-linear draw
+/// @note Convenience wrapper: equivalent to setting `model.exponent` and calling
+///       `set_power_model`. Prefer `set_power_model(PowerModelRGB{..., e})` to
+///       configure channel weights and response in one step.
+/// @note This only affects power estimation and limiting, not rendered LED brightness.
+/// @note `exponent <= 0` or values within 1e-4 of 1.0 fall back to linear
+///       (identity tables) rather than rebuilding with a degenerate curve.
+/// @note Only enabled on platforms where `SKETCH_HAS_LARGE_MEMORY==1`.
+///       Smaller-memory targets keep the legacy linear behavior and ignore this setting.
+void set_power_scaling_exponent(float exponent);
+
+/// Get the current brightness-to-power response exponent
+/// @returns the configured exponent. Defaults to 1.0 for linear scaling.
+/// @note Returns 1.0 on platforms where `SKETCH_HAS_LARGE_MEMORY==0`.
+float get_power_scaling_exponent();
 
 /// Set custom RGBW LED power consumption model
 /// @param model RGBW power consumption model
@@ -187,6 +231,12 @@ fl::u32 calculate_unscaled_power_mW( const CRGB* ledbuffer, fl::u16 numLeds);
 /// @copydoc calculate_unscaled_power_mW(const CRGB*, uint16_t)
 /// @param leds span of LED data to check
 fl::u32 calculate_unscaled_power_mW(fl::span<const CRGB> leds);
+
+/// Applies the configured power-scaling response to a total power value
+/// @param total_mW unscaled total power at full brightness
+/// @param brightness requested brightness in FastLED's 0-255 brightness space
+/// @returns estimated power after applying the configured brightness-to-power response
+fl::u32 scale_power_for_brightness(fl::u32 total_mW, fl::u8 brightness);
 
 /// Determines the highest brightness level you can use and still stay under
 /// the specified power budget for a given set of LEDs.

--- a/tests/fl/power_estimation.cpp
+++ b/tests/fl/power_estimation.cpp
@@ -21,11 +21,22 @@ static CRGB gLeds4[10];    // For zero brightness
 static CRGB gLeds5[10];    // For high power limit
 static CRGB gLeds6[50];    // For brightness scaling with limiting
 
-// Fixture to reset power model to default before each test
-// This prevents power_mgt.cpp tests from affecting power_estimation.cpp tests
+// Fixture to reset power model to default around each test.
+// This prevents power_mgt.cpp tests from affecting power_estimation.cpp tests,
+// and the destructor prevents non-linear model state set mid-test from leaking
+// into any subsequent test in the process.
 struct PowerEstimationFixture {
     PowerEstimationFixture() {
-        // Reset power model to WS2812 @ 5V default (80, 55, 75, 5)
+        reset_to_default();
+    }
+    ~PowerEstimationFixture() {
+        reset_to_default();
+    }
+
+    static void reset_to_default() {
+        // Reset power model to WS2812 @ 5V default (80, 55, 75, 5) with linear
+        // response; set_power_model rebuilds the scaling LUTs from the model's
+        // exponent field so this is sufficient to restore linear behavior.
         set_power_model(PowerModelRGB());
     }
 };
@@ -186,4 +197,20 @@ FL_TEST_CASE_FIXTURE(PowerEstimationFixture,"Power estimation - brightness scali
     FL_REQUIRE(power_full <= 5000 + tolerance);
     FL_REQUIRE(power_half <= 5000 + tolerance);
     FL_REQUIRE(power_quarter <= 5000 + tolerance);
+}
+
+FL_TEST_CASE_FIXTURE(PowerEstimationFixture,"Power estimation - non linear scaling raises mid brightness estimate") {
+    fill_solid(gLeds1, 10, CRGB(255, 255, 255));
+
+    FastLED.addLeds<WS2812, 7, GRB>(gLeds1, 10);
+    FastLED.setBrightness(128);
+
+    uint32_t linear_power = FastLED.getEstimatedPowerInMilliWatts(false);
+
+    PowerModelRGB nonlinear_model = FastLED.getPowerModel();
+    nonlinear_model.exponent = 0.87f;
+    FastLED.setPowerModel(nonlinear_model);
+    uint32_t nonlinear_power = FastLED.getEstimatedPowerInMilliWatts(false);
+
+    FL_REQUIRE(nonlinear_power > linear_power);
 }

--- a/tests/power_mgt.cpp
+++ b/tests/power_mgt.cpp
@@ -9,6 +9,21 @@
 
 FL_TEST_FILE(FL_FILEPATH) {
 
+struct ScopedPowerScalingExponent {
+    explicit ScopedPowerScalingExponent(float exponent)
+        : previous_model(get_power_model()) {
+        PowerModelRGB updated_model = previous_model;
+        updated_model.exponent = exponent;
+        set_power_model(updated_model);
+    }
+
+    ~ScopedPowerScalingExponent() {
+        set_power_model(previous_model);
+    }
+
+    PowerModelRGB previous_model;
+};
+
 FL_TEST_CASE("PowerModelRGB - constructor") {
     PowerModelRGB model(40, 40, 40, 2);
     FL_CHECK(model.red_mW == 40);
@@ -165,6 +180,75 @@ FL_TEST_CASE("Default power model - WS2812 @ 5V") {
     FL_CHECK(current.green_mW == 55);
     FL_CHECK(current.blue_mW == 75);
     FL_CHECK(current.dark_mW == 5);
+}
+
+FL_TEST_CASE("Power scaling exponent - default is linear") {
+    set_power_model(PowerModelRGB(50, 50, 50, 0, 1.0f));
+    FL_CHECK(get_power_scaling_exponent() >= 0.999f);
+    FL_CHECK(get_power_scaling_exponent() <= 1.001f);
+
+    CRGB leds[1] = {CRGB(128, 0, 0)};
+    uint32_t power = calculate_unscaled_power_mW(leds, 1);
+
+    // 128 * 50 >> 8 = 25mW with the default linear scaling model
+    FL_CHECK(power >= 24);
+    FL_CHECK(power <= 25);
+}
+
+FL_TEST_CASE("Power scaling exponent - non linear estimate increases mid brightness demand") {
+    // Demonstrates the single-call pattern: channel weights + response curve
+    // configured together via PowerModelRGB's exponent field.
+    set_power_model(PowerModelRGB(50, 50, 50, 0, 0.87f));
+    FL_CHECK(get_power_scaling_exponent() >= 0.869f);
+    FL_CHECK(get_power_scaling_exponent() <= 0.871f);
+
+    CRGB leds[1] = {CRGB(128, 0, 0)};
+    uint32_t power = calculate_unscaled_power_mW(leds, 1);
+
+    // Non-linear mapping should estimate higher power than the linear 25mW case.
+    FL_CHECK(power > 25);
+
+    // Reset to linear for isolation from subsequent tests.
+    set_power_model(PowerModelRGB());
+}
+
+FL_TEST_CASE("PowerModelRGB - exponent field travels with the model") {
+    // Setting the model with a non-linear exponent replaces the two-call pattern
+    // (set_power_model + set_power_scaling_exponent) with a single call.
+    set_power_model(PowerModelRGB(40, 40, 40, 2, 0.87f));
+
+    PowerModelRGB retrieved = get_power_model();
+    FL_CHECK(retrieved.red_mW == 40);
+    FL_CHECK(retrieved.green_mW == 40);
+    FL_CHECK(retrieved.blue_mW == 40);
+    FL_CHECK(retrieved.dark_mW == 2);
+    FL_CHECK(retrieved.exponent >= 0.869f);
+    FL_CHECK(retrieved.exponent <= 0.871f);
+    FL_CHECK(get_power_scaling_exponent() >= 0.869f);
+    FL_CHECK(get_power_scaling_exponent() <= 0.871f);
+
+    // Reset to linear default via the same single-call pattern.
+    set_power_model(PowerModelRGB());
+    FL_CHECK(get_power_scaling_exponent() >= 0.999f);
+    FL_CHECK(get_power_scaling_exponent() <= 1.001f);
+}
+
+FL_TEST_CASE("Power scaling exponent - limiter becomes more conservative") {
+    set_power_model(PowerModelRGB(80, 80, 80, 0, 1.0f));
+
+    CRGB leds[10];
+    for (int i = 0; i < 10; ++i) {
+        leds[i] = CRGB(255, 255, 255);
+    }
+
+    fl::u8 linear_recommended = calculate_max_brightness_for_power_mW(leds, 10, 128, 1250);
+    FL_CHECK(linear_recommended == 128);
+
+    {
+        ScopedPowerScalingExponent scaling(0.87f);
+        fl::u8 nonlinear_recommended = calculate_max_brightness_for_power_mW(leds, 10, 128, 1250);
+        FL_CHECK(nonlinear_recommended < 128);
+    }
 }
 
 } // FL_TEST_FILE


### PR DESCRIPTION
This is a refreshed replacement for #1048, rebuilt against current `master`.

Problem being addressed:
- the original report showed that FastLED's linear power model can underestimate current draw for mixed colors / white on some LEDs, even when single-channel calibration looks correct
- that can cause the limiter to miss a configured current budget

What this PR changes:
- adds a configurable brightness-to-power response exponent for power estimation and brightness limiting
- keeps the default at `1.0f` so existing users retain today's linear behavior unless they opt in
- applies the configured response consistently in both:
  - per-channel power estimation
  - max-brightness calculation used by the power limiter
- updates `FastLED.getEstimatedPowerInMilliWatts()` so its estimate matches the limiter's model
- gates the newer non-linear implementation on `SKETCH_HAS_LARGE_MEMORY`
  - low-memory targets keep the legacy linear path automatically
  - larger-memory targets get the newer table-backed implementation
- adds focused tests for the new non-linear behavior

Why this is different from the original 2020 patch:
- the old patch no longer maps cleanly onto the current power-management code
- current `master` already has a power-model API, so this version keeps the change scoped to today's subsystem instead of replaying the old file-level diff
- this version does not hard-code one exponent globally for all users; it provides an opt-in calibration knob instead

Deliberate non-goals in this PR:
- no change to rendered LED brightness behavior, only power estimation / limiting
- no attempt to solve RGBW power accounting here
- no attempt to solve APA102HD / HD108 driver-level brightness accounting here

Focused verification:
- `uv run test.py power_mgt`
- `uv run test.py power_estimation`

If maintainers want to carry the original SK6805-1515 calibration forward, that can now be expressed as a user-configured exponent instead of a library-wide baked-in constant.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add public API to configure and read a non-linear brightness→power scaling exponent; power estimation and limiting now use the configured response (with smaller-memory targets falling back to linear).

* **Documentation**
  * Updated power-estimate docs to describe the configurable brightness→power response and reference the new API.

* **Tests**
  * Added/updated unit tests validating default linear behavior, non-linear effects on estimated power, and brightness limits under power constraints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->