### PR TITLE
Rebase generic palette refactor onto current master

### DIFF
--- a/src/fl/gfx/colorutils.cpp.hpp
+++ b/src/fl/gfx/colorutils.cpp.hpp
@@ -1058,50 +1058,64 @@ CHSV ColorFromPalette(const CHSVPalette256 &pal, fl::u8 index,
     return hsv;
 }
 
+namespace detail {
+
+template <typename TSrcPalette, typename TDestPalette>
+void UpscalePaletteRepeat(const TSrcPalette &srcpal,
+                          TDestPalette &destpal) {
+    const fl::u16 src_size = sizeof(srcpal.entries) / sizeof(srcpal.entries[0]);
+    const fl::u16 dest_size =
+        sizeof(destpal.entries) / sizeof(destpal.entries[0]);
+    const fl::u16 repeat = dest_size / src_size;
+    for (fl::u16 i = 0; i < src_size; ++i) {
+        const fl::u16 start = i * repeat;
+        for (fl::u16 j = 0; j < repeat; ++j) {
+            destpal[static_cast<fl::u8>(start + j)] = srcpal[static_cast<fl::u8>(i)];
+        }
+    }
+}
+
+template <typename TSrcPalette, typename TDestPalette>
+void UpscalePaletteInterpolated(const TSrcPalette &srcpal,
+                                TDestPalette &destpal) {
+    const fl::u16 dest_size =
+        sizeof(destpal.entries) / sizeof(destpal.entries[0]);
+    for (fl::u16 i = 0; i < dest_size; ++i) {
+        destpal[static_cast<fl::u8>(i)] =
+            ColorFromPalette(srcpal, static_cast<fl::u8>(i));
+    }
+}
+
+} // namespace detail
+
 void UpscalePalette(const class CRGBPalette16 &srcpal16,
                     class CRGBPalette256 &destpal256) {
-    for (int i = 0; i < 256; ++i) {
-        destpal256[(fl::u8)(i)] = ColorFromPalette(srcpal16, i);
-    }
+    detail::UpscalePaletteInterpolated(srcpal16, destpal256);
 }
 
 void UpscalePalette(const class CHSVPalette16 &srcpal16,
                     class CHSVPalette256 &destpal256) {
-    for (int i = 0; i < 256; ++i) {
-        destpal256[(fl::u8)(i)] = ColorFromPalette(srcpal16, i);
-    }
+    detail::UpscalePaletteInterpolated(srcpal16, destpal256);
 }
 
 void UpscalePalette(const class CRGBPalette16 &srcpal16,
                     class CRGBPalette32 &destpal32) {
-    for (fl::u8 i = 0; i < 16; ++i) {
-        fl::u8 j = i * 2;
-        destpal32[j + 0] = srcpal16[i];
-        destpal32[j + 1] = srcpal16[i];
-    }
+    detail::UpscalePaletteRepeat(srcpal16, destpal32);
 }
 
 void UpscalePalette(const class CHSVPalette16 &srcpal16,
                     class CHSVPalette32 &destpal32) {
-    for (fl::u8 i = 0; i < 16; ++i) {
-        fl::u8 j = i * 2;
-        destpal32[j + 0] = srcpal16[i];
-        destpal32[j + 1] = srcpal16[i];
-    }
+    detail::UpscalePaletteRepeat(srcpal16, destpal32);
 }
 
 void UpscalePalette(const class CRGBPalette32 &srcpal32,
                     class CRGBPalette256 &destpal256) {
-    for (int i = 0; i < 256; ++i) {
-        destpal256[(fl::u8)(i)] = ColorFromPalette(srcpal32, i);
-    }
+    detail::UpscalePaletteInterpolated(srcpal32, destpal256);
 }
 
 void UpscalePalette(const class CHSVPalette32 &srcpal32,
                     class CHSVPalette256 &destpal256) {
-    for (int i = 0; i < 256; ++i) {
-        destpal256[(fl::u8)(i)] = ColorFromPalette(srcpal32, i);
-    }
+    detail::UpscalePaletteInterpolated(srcpal32, destpal256);
 }
 
 #if 0

--- a/src/fl/gfx/colorutils.h
+++ b/src/fl/gfx/colorutils.h
@@ -371,425 +371,357 @@ void UpscalePalette(const class CHSVPalette32 &srcpal32,
 /// @addtogroup PaletteClasses
 /// @{
 
-/// HSV color palette with 16 discrete values
-class CHSVPalette16 {
+namespace detail {
+
+template <typename TColor>
+struct PaletteFillTraits;
+
+template <>
+struct PaletteFillTraits<CHSV> {
+    static void fillSolid(CHSV *entries, fl::u16 size, const CHSV &color) FL_NOEXCEPT {
+        fill_solid(entries, static_cast<int>(size), color);
+    }
+
+    static void fillGradient(CHSV *entries, fl::u16 size, const CHSV &c1,
+                             const CHSV &c2) FL_NOEXCEPT {
+        fill_gradient(entries, size, c1, c2);
+    }
+
+    static void fillGradient(CHSV *entries, fl::u16 size, const CHSV &c1,
+                             const CHSV &c2, const CHSV &c3) FL_NOEXCEPT {
+        fill_gradient(entries, size, c1, c2, c3);
+    }
+
+    static void fillGradient(CHSV *entries, fl::u16 size, const CHSV &c1,
+                             const CHSV &c2, const CHSV &c3,
+                             const CHSV &c4) FL_NOEXCEPT {
+        fill_gradient(entries, size, c1, c2, c3, c4);
+    }
+};
+
+template <>
+struct PaletteFillTraits<CRGB> {
+    static void fillSolid(CRGB *entries, fl::u16 size, const CRGB &color) FL_NOEXCEPT {
+        fill_solid(entries, static_cast<int>(size), color);
+    }
+
+    static void fillGradient(CRGB *entries, fl::u16 size, const CRGB &c1,
+                             const CRGB &c2) FL_NOEXCEPT {
+        fill_gradient_RGB(entries, size, c1, c2);
+    }
+
+    static void fillGradient(CRGB *entries, fl::u16 size, const CRGB &c1,
+                             const CRGB &c2, const CRGB &c3) FL_NOEXCEPT {
+        fill_gradient_RGB(entries, size, c1, c2, c3);
+    }
+
+    static void fillGradient(CRGB *entries, fl::u16 size, const CRGB &c1,
+                             const CRGB &c2, const CRGB &c3,
+                             const CRGB &c4) FL_NOEXCEPT {
+        fill_gradient_RGB(entries, size, c1, c2, c3, c4);
+    }
+};
+
+template <typename TColor, fl::u16 Size>
+class TColorPalette {
   public:
-    CHSV entries[16]; ///< the color entries that make up the palette
+    TColor entries[Size];
 
-    /// @copydoc CHSV::CHSV()
-    CHSVPalette16() FL_NOEXCEPT {};
+    TColorPalette() FL_NOEXCEPT {}
 
-    /// Create palette from 16 CHSV values
+    TColorPalette(const TColorPalette &rhs) FL_NOEXCEPT { copyBytes(rhs.entries); }
+
+    TColorPalette(const TColor (&rhs)[Size]) FL_NOEXCEPT { copyBytes(rhs); }
+
+    TColorPalette &operator=(const TColorPalette &rhs) FL_NOEXCEPT {
+        copyBytes(rhs.entries);
+        return *this;
+    }
+
+    TColorPalette &operator=(const TColor (&rhs)[Size]) FL_NOEXCEPT {
+        copyBytes(rhs);
+        return *this;
+    }
+
+    TColorPalette(const TColor &c1) FL_NOEXCEPT {
+        PaletteFillTraits<TColor>::fillSolid(entries, Size, c1);
+    }
+
+    TColorPalette(const TColor &c1, const TColor &c2) FL_NOEXCEPT {
+        PaletteFillTraits<TColor>::fillGradient(entries, Size, c1, c2);
+    }
+
+    TColorPalette(const TColor &c1, const TColor &c2,
+                  const TColor &c3) FL_NOEXCEPT {
+        PaletteFillTraits<TColor>::fillGradient(entries, Size, c1, c2, c3);
+    }
+
+    TColorPalette(const TColor &c1, const TColor &c2, const TColor &c3,
+                  const TColor &c4) FL_NOEXCEPT {
+        PaletteFillTraits<TColor>::fillGradient(entries, Size, c1, c2, c3, c4);
+    }
+
+    inline TColor &operator[](fl::u8 x) FL_NOEXCEPT __attribute__((always_inline)) {
+        return entries[x];
+    }
+
+    inline const TColor &operator[](fl::u8 x) const FL_NOEXCEPT
+        __attribute__((always_inline)) {
+        return entries[x];
+    }
+
+    inline TColor &operator[](int x) FL_NOEXCEPT __attribute__((always_inline)) {
+        return entries[(fl::u8)x];
+    }
+
+    inline const TColor &operator[](int x) const FL_NOEXCEPT
+        __attribute__((always_inline)) {
+        return entries[(fl::u8)x];
+    }
+
+    operator TColor *() FL_NOEXCEPT { return &(entries[0]); }
+
+    bool operator==(const TColorPalette &rhs) const FL_NOEXCEPT {
+        const fl::u8 *p = reinterpret_cast<const fl::u8 *>(&(this->entries[0]));
+        const fl::u8 *q = reinterpret_cast<const fl::u8 *>(&(rhs.entries[0]));
+        if (p == q) {
+            return true;
+        }
+        for (unsigned int i = 0; i < sizeof(entries); ++i) {
+            if (*p != *q) {
+                return false;
+            }
+            ++p;
+            ++q;
+        }
+        return true;
+    }
+
+    bool operator!=(const TColorPalette &rhs) const FL_NOEXCEPT {
+        return !(*this == rhs);
+    }
+
+  protected:
+    void copyBytes(const TColor *rhs) FL_NOEXCEPT {
+        memmove8((void *)&(entries[0]), rhs, sizeof(entries));
+    }
+
+    template <typename TOtherColor>
+    void copyConverted(const TOtherColor *rhs) FL_NOEXCEPT {
+        for (fl::u16 i = 0; i < Size; ++i) {
+            entries[i] = rhs[i];
+        }
+    }
+};
+
+template <fl::u16 Size>
+class TCRGBPalette : public TColorPalette<CRGB, Size> {
+  public:
+    using Base = TColorPalette<CRGB, Size>;
+    using Base::Base;
+    using Base::entries;
+    using Base::operator!=;
+    using Base::operator=;
+    using Base::operator==;
+    using Base::operator[];
+    using Base::operator CRGB*;
+
+    TCRGBPalette() FL_NOEXCEPT {}
+
+    TCRGBPalette(const TColorPalette<CHSV, Size> &rhs) FL_NOEXCEPT {
+        Base::copyConverted(rhs.entries);
+    }
+
+    TCRGBPalette(const CHSV (&rhs)[Size]) FL_NOEXCEPT {
+        Base::copyConverted(rhs);
+    }
+
+    TCRGBPalette &operator=(const TColorPalette<CHSV, Size> &rhs) FL_NOEXCEPT {
+        Base::copyConverted(rhs.entries);
+        return *this;
+    }
+
+    TCRGBPalette &operator=(const CHSV (&rhs)[Size]) FL_NOEXCEPT {
+        Base::copyConverted(rhs);
+        return *this;
+    }
+
+    TCRGBPalette(const CHSV &c1) FL_NOEXCEPT {
+        fill_solid(&(entries[0]), static_cast<int>(Size), c1);
+    }
+
+    TCRGBPalette(const CHSV &c1, const CHSV &c2) FL_NOEXCEPT {
+        fill_gradient(&(entries[0]), Size, c1, c2);
+    }
+
+    TCRGBPalette(const CHSV &c1, const CHSV &c2,
+                 const CHSV &c3) FL_NOEXCEPT {
+        fill_gradient(&(entries[0]), Size, c1, c2, c3);
+    }
+
+    TCRGBPalette(const CHSV &c1, const CHSV &c2, const CHSV &c3,
+                 const CHSV &c4) FL_NOEXCEPT {
+        fill_gradient(&(entries[0]), Size, c1, c2, c3, c4);
+    }
+};
+
+inline void loadProgmemPalette(CRGB *entries, const fl::u32 *rhs,
+                               fl::u16 count) FL_NOEXCEPT {
+    for (fl::u16 i = 0; i < count; ++i) {
+        entries[i] = FL_PGM_READ_DWORD_NEAR(rhs + i);
+    }
+}
+
+inline void loadProgmemPalette(CHSV *entries, const fl::u32 *rhs,
+                               fl::u16 count) FL_NOEXCEPT {
+    for (fl::u16 i = 0; i < count; ++i) {
+        CRGB xyz(FL_PGM_READ_DWORD_NEAR(rhs + i));
+        entries[i].hue = xyz.red;
+        entries[i].sat = xyz.green;
+        entries[i].val = xyz.blue;
+    }
+}
+
+template <typename TPalette16, typename TColor>
+void initPalette16(TPalette16 &palette, const TColor &c00, const TColor &c01,
+                   const TColor &c02, const TColor &c03, const TColor &c04,
+                   const TColor &c05, const TColor &c06, const TColor &c07,
+                   const TColor &c08, const TColor &c09, const TColor &c10,
+                   const TColor &c11, const TColor &c12, const TColor &c13,
+                   const TColor &c14, const TColor &c15) FL_NOEXCEPT {
+    const TColor colors[16] = {c00, c01, c02, c03, c04, c05, c06, c07,
+                               c08, c09, c10, c11, c12, c13, c14, c15};
+    palette = colors;
+}
+
+} // namespace detail
+
+/// HSV color palette with 16 discrete values
+class CHSVPalette16 : public detail::TColorPalette<CHSV, 16> {
+  public:
+    using Base = detail::TColorPalette<CHSV, 16>;
+    using Base::Base;
+    using Base::entries;
+    using Base::operator!=;
+    using Base::operator=;
+    using Base::operator==;
+    using Base::operator[];
+    using Base::operator CHSV*;
+
+    CHSVPalette16() FL_NOEXCEPT = default;
+    CHSVPalette16(const CHSVPalette16 &rhs) FL_NOEXCEPT = default;
+    CHSVPalette16 &operator=(const CHSVPalette16 &rhs) FL_NOEXCEPT = default;
+
     CHSVPalette16(const CHSV &c00, const CHSV &c01, const CHSV &c02,
                   const CHSV &c03, const CHSV &c04, const CHSV &c05,
                   const CHSV &c06, const CHSV &c07, const CHSV &c08,
                   const CHSV &c09, const CHSV &c10, const CHSV &c11,
                   const CHSV &c12, const CHSV &c13, const CHSV &c14,
                   const CHSV &c15) FL_NOEXCEPT {
-        entries[0] = c00;
-        entries[1] = c01;
-        entries[2] = c02;
-        entries[3] = c03;
-        entries[4] = c04;
-        entries[5] = c05;
-        entries[6] = c06;
-        entries[7] = c07;
-        entries[8] = c08;
-        entries[9] = c09;
-        entries[10] = c10;
-        entries[11] = c11;
-        entries[12] = c12;
-        entries[13] = c13;
-        entries[14] = c14;
-        entries[15] = c15;
-    };
-
-    /// Copy constructor
-    CHSVPalette16(const CHSVPalette16 &rhs) FL_NOEXCEPT {
-        memmove8((void *)&(entries[0]), &(rhs.entries[0]), sizeof(entries));
+        detail::initPalette16(*this, c00, c01, c02, c03, c04, c05, c06, c07,
+                              c08, c09, c10, c11, c12, c13, c14, c15);
     }
 
-    /// @copydoc CHSVPalette16(const CHSVPalette16& rhs)
-    CHSVPalette16 &operator=(const CHSVPalette16 &rhs) FL_NOEXCEPT {
-        memmove8((void *)&(entries[0]), &(rhs.entries[0]), sizeof(entries));
-        return *this;
-    }
-
-    /// Create palette from palette stored in PROGMEM
     CHSVPalette16(const TProgmemHSVPalette16 &rhs) FL_NOEXCEPT {
-        for (fl::u8 i = 0; i < 16; ++i) {
-            CRGB xyz(FL_PGM_READ_DWORD_NEAR(rhs + i));
-            entries[i].hue = xyz.red;
-            entries[i].sat = xyz.green;
-            entries[i].val = xyz.blue;
-        }
+        detail::loadProgmemPalette(entries, rhs, 16);
     }
 
-    /// @copydoc CHSVPalette16(const TProgmemHSVPalette16&)
     CHSVPalette16 &operator=(const TProgmemHSVPalette16 &rhs) FL_NOEXCEPT {
-        for (fl::u8 i = 0; i < 16; ++i) {
-            CRGB xyz(FL_PGM_READ_DWORD_NEAR(rhs + i));
-            entries[i].hue = xyz.red;
-            entries[i].sat = xyz.green;
-            entries[i].val = xyz.blue;
-        }
+        detail::loadProgmemPalette(entries, rhs, 16);
         return *this;
-    }
-
-    /// Array access operator to index into the gradient entries
-    /// @param x the index to retrieve
-    /// @returns reference to an entry in the palette's color array
-    /// @note This does not perform any interpolation like ColorFromPalette(),
-    /// it accesses the underlying entries that make up the gradient. Beware
-    /// of bounds issues!
-    inline CHSV &operator[](fl::u8 x) FL_NOEXCEPT __attribute__((always_inline)) {
-        return entries[x];
-    }
-
-    /// @copydoc operator[]
-    inline const CHSV &operator[](fl::u8 x) const FL_NOEXCEPT
-        __attribute__((always_inline)) {
-        return entries[x];
-    }
-
-    /// @copydoc operator[]
-    inline CHSV &operator[](int x) FL_NOEXCEPT __attribute__((always_inline)) {
-        return entries[(fl::u8)x];
-    }
-
-    /// @copydoc operator[]
-    inline const CHSV &operator[](int x) const FL_NOEXCEPT __attribute__((always_inline)) {
-        return entries[(fl::u8)x];
-    }
-
-    /// Get the underlying pointer to the CHSV entries making up the palette
-    operator CHSV *() FL_NOEXCEPT { return &(entries[0]); }
-
-    /// Check if two palettes have the same color entries
-    bool operator==(const CHSVPalette16 &rhs) const FL_NOEXCEPT {
-        const fl::u8 *p = (const fl::u8 *)(&(this->entries[0]));
-        const fl::u8 *q = (const fl::u8 *)(&(rhs.entries[0]));
-        if (p == q)
-            return true;
-        for (fl::u8 i = 0; i < (sizeof(entries)); ++i) {
-            if (*p != *q)
-                return false;
-            ++p;
-            ++q;
-        }
-        return true;
-    }
-
-    /// Check if two palettes do not have the same color entries
-    bool operator!=(const CHSVPalette16 &rhs) const FL_NOEXCEPT { return !(*this == rhs); }
-
-    /// Create palette filled with one color
-    /// @param c1 the color to fill the palette with
-    CHSVPalette16(const CHSV &c1) FL_NOEXCEPT { fill_solid(&(entries[0]), 16, c1); }
-
-    /// Create palette with a gradient from one color to another
-    /// @param c1 the starting color for the gradient
-    /// @param c2 the end color for the gradient
-    CHSVPalette16(const CHSV &c1, const CHSV &c2) FL_NOEXCEPT {
-        fill_gradient(&(entries[0]), 16, c1, c2);
-    }
-
-    /// Create palette with three-color gradient
-    /// @param c1 the starting color for the gradient
-    /// @param c2 the middle color for the gradient
-    /// @param c3 the end color for the gradient
-    CHSVPalette16(const CHSV &c1, const CHSV &c2, const CHSV &c3) FL_NOEXCEPT {
-        fill_gradient(&(entries[0]), 16, c1, c2, c3);
-    }
-
-    /// Create palette with four-color gradient
-    /// @param c1 the starting color for the gradient
-    /// @param c2 the first middle color for the gradient
-    /// @param c3 the second middle color for the gradient
-    /// @param c4 the end color for the gradient
-    CHSVPalette16(const CHSV &c1, const CHSV &c2, const CHSV &c3,
-                  const CHSV &c4) FL_NOEXCEPT {
-        fill_gradient(&(entries[0]), 16, c1, c2, c3, c4);
     }
 };
 
 /// HSV color palette with 256 discrete values
-class CHSVPalette256 {
+class CHSVPalette256 : public detail::TColorPalette<CHSV, 256> {
   public:
-    CHSV entries[256]; ///< @copydoc CHSVPalette16::entries
+    using Base = detail::TColorPalette<CHSV, 256>;
+    using Base::Base;
+    using Base::entries;
+    using Base::operator!=;
+    using Base::operator=;
+    using Base::operator==;
+    using Base::operator[];
+    using Base::operator CHSV*;
 
-    /// @copydoc CHSVPalette16::CHSVPalette16()
-    CHSVPalette256() FL_NOEXCEPT {};
+    CHSVPalette256() FL_NOEXCEPT = default;
+    CHSVPalette256(const CHSVPalette256 &rhs) FL_NOEXCEPT = default;
+    CHSVPalette256 &operator=(const CHSVPalette256 &rhs) FL_NOEXCEPT = default;
 
-    /// @copydoc CHSVPalette16::CHSVPalette16(const CHSV&, const CHSV&, const
-    /// CHSV&, const CHSV&, const CHSV&, const CHSV&, const CHSV&, const CHSV&,
-    /// const CHSV&, const CHSV&, const CHSV&, const CHSV&,
-    /// const CHSV&, const CHSV&, const CHSV&, const CHSV&)
     CHSVPalette256(const CHSV &c00, const CHSV &c01, const CHSV &c02,
                    const CHSV &c03, const CHSV &c04, const CHSV &c05,
                    const CHSV &c06, const CHSV &c07, const CHSV &c08,
                    const CHSV &c09, const CHSV &c10, const CHSV &c11,
                    const CHSV &c12, const CHSV &c13, const CHSV &c14,
                    const CHSV &c15) FL_NOEXCEPT {
-        CHSVPalette16 p16(c00, c01, c02, c03, c04, c05, c06, c07, c08, c09, c10,
-                          c11, c12, c13, c14, c15);
+        CHSVPalette16 p16(c00, c01, c02, c03, c04, c05, c06, c07, c08, c09,
+                          c10, c11, c12, c13, c14, c15);
         *this = p16;
-    };
-
-    /// Copy constructor
-    CHSVPalette256(const CHSVPalette256 &rhs) FL_NOEXCEPT {
-        memmove8((void *)&(entries[0]), &(rhs.entries[0]), sizeof(entries));
-    }
-    /// @copydoc CHSVPalette256( const CHSVPalette256&)
-    CHSVPalette256 &operator=(const CHSVPalette256 &rhs) FL_NOEXCEPT {
-        memmove8((void *)&(entries[0]), &(rhs.entries[0]), sizeof(entries));
-        return *this;
     }
 
-    /// Create upscaled palette from 16-entry palette
     CHSVPalette256(const CHSVPalette16 &rhs16) FL_NOEXCEPT { UpscalePalette(rhs16, *this); }
-    /// @copydoc  CHSVPalette256( const CHSVPalette16&)
+
+    CHSVPalette256(const CHSVPalette32 &rhs32) FL_NOEXCEPT { UpscalePalette(rhs32, *this); }
+
     CHSVPalette256 &operator=(const CHSVPalette16 &rhs16) FL_NOEXCEPT {
         UpscalePalette(rhs16, *this);
         return *this;
     }
 
-    /// @copydoc CHSVPalette16::CHSVPalette16(const TProgmemHSVPalette16&)
-    CHSVPalette256(const TProgmemRGBPalette16 &rhs) FL_NOEXCEPT {
+    CHSVPalette256 &operator=(const CHSVPalette32 &rhs32) FL_NOEXCEPT {
+        UpscalePalette(rhs32, *this);
+        return *this;
+    }
+
+    CHSVPalette256(const TProgmemHSVPalette16 &rhs) FL_NOEXCEPT {
         CHSVPalette16 p16(rhs);
         *this = p16;
     }
-    /// @copydoc CHSVPalette16::CHSVPalette16(const TProgmemHSVPalette16&)
-    CHSVPalette256 &operator=(const TProgmemRGBPalette16 &rhs) FL_NOEXCEPT {
+
+    CHSVPalette256 &operator=(const TProgmemHSVPalette16 &rhs) FL_NOEXCEPT {
         CHSVPalette16 p16(rhs);
         *this = p16;
         return *this;
     }
 
-    /// @copydoc CHSVPalette16::operator[]
-    inline CHSV &operator[](fl::u8 x) FL_NOEXCEPT __attribute__((always_inline)) {
-        return entries[x];
-    }
-    /// @copydoc operator[]
-    inline const CHSV &operator[](fl::u8 x) const FL_NOEXCEPT
-        __attribute__((always_inline)) {
-        return entries[x];
-    }
+    CHSVPalette256(const TProgmemHSVPalette32 &rhs) FL_NOEXCEPT;
 
-    /// @copydoc operator[]
-    inline CHSV &operator[](int x) FL_NOEXCEPT __attribute__((always_inline)) {
-        return entries[(fl::u8)x];
-    }
-    /// @copydoc operator[]
-    inline const CHSV &operator[](int x) const FL_NOEXCEPT __attribute__((always_inline)) {
-        return entries[(fl::u8)x];
-    }
-
-    /// Get the underlying pointer to the CHSV entries making up the palette
-    operator CHSV *() FL_NOEXCEPT { return &(entries[0]); }
-
-    /// @copydoc CHSVPalette16::operator==
-    bool operator==(const CHSVPalette256 &rhs) const FL_NOEXCEPT {
-        const fl::u8 *p = (const fl::u8 *)(&(this->entries[0]));
-        const fl::u8 *q = (const fl::u8 *)(&(rhs.entries[0]));
-        if (p == q)
-            return true;
-        for (fl::u16 i = 0; i < (sizeof(entries)); ++i) {
-            if (*p != *q)
-                return false;
-            ++p;
-            ++q;
-        }
-        return true;
-    }
-
-    /// @copydoc CHSVPalette16::operator!=
-    bool operator!=(const CHSVPalette256 &rhs) const FL_NOEXCEPT { return !(*this == rhs); }
-
-    /// @copydoc CHSVPalette16::CHSVPalette16(const CHSV&)
-    CHSVPalette256(const CHSV &c1) FL_NOEXCEPT { fill_solid(&(entries[0]), 256, c1); }
-    /// @copydoc CHSVPalette16::CHSVPalette16(const CHSV&, const CHSV&)
-    CHSVPalette256(const CHSV &c1, const CHSV &c2) FL_NOEXCEPT {
-        fill_gradient(&(entries[0]), 256, c1, c2);
-    }
-    /// @copydoc CHSVPalette16::CHSVPalette16(const CHSV&, const CHSV&, const
-    /// CHSV&)
-    CHSVPalette256(const CHSV &c1, const CHSV &c2, const CHSV &c3) FL_NOEXCEPT {
-        fill_gradient(&(entries[0]), 256, c1, c2, c3);
-    }
-    /// @copydoc CHSVPalette16::CHSVPalette16(const CHSV&, const CHSV&, const
-    /// CHSV&, const CHSV&)
-    CHSVPalette256(const CHSV &c1, const CHSV &c2, const CHSV &c3,
-                   const CHSV &c4) FL_NOEXCEPT {
-        fill_gradient(&(entries[0]), 256, c1, c2, c3, c4);
-    }
+    CHSVPalette256 &operator=(const TProgmemHSVPalette32 &rhs) FL_NOEXCEPT;
 };
 
 /// RGB color palette with 16 discrete values
-class CRGBPalette16 {
+class CRGBPalette16 : public detail::TCRGBPalette<16> {
   public:
-    CRGB entries[16]; ///< @copydoc CHSVPalette16::entries
+    using Base = detail::TCRGBPalette<16>;
+    using Base::Base;
+    using Base::entries;
+    using Base::operator!=;
+    using Base::operator=;
+    using Base::operator==;
+    using Base::operator[];
+    using Base::operator CRGB*;
 
-    /// @copydoc CRGB::CRGB()
-    CRGBPalette16() FL_NOEXCEPT {};
+    CRGBPalette16() FL_NOEXCEPT = default;
+    CRGBPalette16(const CRGBPalette16 &rhs) FL_NOEXCEPT = default;
+    CRGBPalette16 &operator=(const CRGBPalette16 &rhs) FL_NOEXCEPT = default;
 
-    /// Create palette from 16 CRGB values
     CRGBPalette16(const CRGB &c00, const CRGB &c01, const CRGB &c02,
                   const CRGB &c03, const CRGB &c04, const CRGB &c05,
                   const CRGB &c06, const CRGB &c07, const CRGB &c08,
                   const CRGB &c09, const CRGB &c10, const CRGB &c11,
                   const CRGB &c12, const CRGB &c13, const CRGB &c14,
                   const CRGB &c15) FL_NOEXCEPT {
-        entries[0] = c00;
-        entries[1] = c01;
-        entries[2] = c02;
-        entries[3] = c03;
-        entries[4] = c04;
-        entries[5] = c05;
-        entries[6] = c06;
-        entries[7] = c07;
-        entries[8] = c08;
-        entries[9] = c09;
-        entries[10] = c10;
-        entries[11] = c11;
-        entries[12] = c12;
-        entries[13] = c13;
-        entries[14] = c14;
-        entries[15] = c15;
-    };
-
-    /// Copy constructor
-    CRGBPalette16(const CRGBPalette16 &rhs) FL_NOEXCEPT {
-        memmove8((void *)&(entries[0]), &(rhs.entries[0]), sizeof(entries));
-    }
-    /// Create palette from array of CRGB colors
-    CRGBPalette16(const CRGB rhs[16]) FL_NOEXCEPT {
-        memmove8((void *)&(entries[0]), &(rhs[0]), sizeof(entries));
-    }
-    /// @copydoc CRGBPalette16(const CRGBPalette16&)
-    CRGBPalette16 &operator=(const CRGBPalette16 &rhs) FL_NOEXCEPT {
-        memmove8((void *)&(entries[0]), &(rhs.entries[0]), sizeof(entries));
-        return *this;
-    }
-    /// Create palette from array of CRGB colors
-    CRGBPalette16 &operator=(const CRGB rhs[16]) FL_NOEXCEPT {
-        memmove8((void *)&(entries[0]), &(rhs[0]), sizeof(entries));
-        return *this;
+        detail::initPalette16(*this, c00, c01, c02, c03, c04, c05, c06, c07,
+                              c08, c09, c10, c11, c12, c13, c14, c15);
     }
 
-    /// Create palette from CHSV palette
-    CRGBPalette16(const CHSVPalette16 &rhs) FL_NOEXCEPT {
-        for (fl::u8 i = 0; i < 16; ++i) {
-            entries[i] = rhs.entries[i]; // implicit HSV-to-RGB conversion
-        }
-    }
-    /// Create palette from array of CHSV colors
-    CRGBPalette16(const CHSV rhs[16]) FL_NOEXCEPT {
-        for (fl::u8 i = 0; i < 16; ++i) {
-            entries[i] = rhs[i]; // implicit HSV-to-RGB conversion
-        }
-    }
-    /// @copydoc CRGBPalette16(const CHSVPalette16&)
-    CRGBPalette16 &operator=(const CHSVPalette16 &rhs) FL_NOEXCEPT {
-        for (fl::u8 i = 0; i < 16; ++i) {
-            entries[i] = rhs.entries[i]; // implicit HSV-to-RGB conversion
-        }
-        return *this;
-    }
-    /// Create palette from array of CHSV colors
-    CRGBPalette16 &operator=(const CHSV rhs[16]) FL_NOEXCEPT {
-        for (fl::u8 i = 0; i < 16; ++i) {
-            entries[i] = rhs[i]; // implicit HSV-to-RGB conversion
-        }
-        return *this;
-    }
-
-    /// Create palette from palette stored in PROGMEM
     CRGBPalette16(const TProgmemRGBPalette16 &rhs) FL_NOEXCEPT {
-        for (fl::u8 i = 0; i < 16; ++i) {
-            entries[i] = FL_PGM_READ_DWORD_NEAR(rhs + i);
-        }
+        detail::loadProgmemPalette(entries, rhs, 16);
     }
-    /// @copydoc CRGBPalette16(const TProgmemRGBPalette16&)
+
     CRGBPalette16 &operator=(const TProgmemRGBPalette16 &rhs) FL_NOEXCEPT {
-        for (fl::u8 i = 0; i < 16; ++i) {
-            entries[i] = FL_PGM_READ_DWORD_NEAR(rhs + i);
-        }
+        detail::loadProgmemPalette(entries, rhs, 16);
         return *this;
-    }
-
-    /// @copydoc CHSVPalette16::operator==
-    bool operator==(const CRGBPalette16 &rhs) const FL_NOEXCEPT {
-        const fl::u8 *p = (const fl::u8 *)(&(this->entries[0]));
-        const fl::u8 *q = (const fl::u8 *)(&(rhs.entries[0]));
-        if (p == q)
-            return true;
-        for (fl::u8 i = 0; i < (sizeof(entries)); ++i) {
-            if (*p != *q)
-                return false;
-            ++p;
-            ++q;
-        }
-        return true;
-    }
-    /// @copydoc CHSVPalette16::operator!=
-    bool operator!=(const CRGBPalette16 &rhs) const FL_NOEXCEPT { return !(*this == rhs); }
-    /// @copydoc CHSVPalette16::operator[]
-    inline CRGB &operator[](fl::u8 x) FL_NOEXCEPT __attribute__((always_inline)) {
-        return entries[x];
-    }
-    /// @copydoc CHSVPalette16::operator[]
-    inline const CRGB &operator[](fl::u8 x) const FL_NOEXCEPT
-        __attribute__((always_inline)) {
-        return entries[x];
-    }
-
-    /// @copydoc CHSVPalette16::operator[]
-    inline CRGB &operator[](int x) FL_NOEXCEPT __attribute__((always_inline)) {
-        return entries[(fl::u8)x];
-    }
-    /// @copydoc CHSVPalette16::operator[]
-    inline const CRGB &operator[](int x) const FL_NOEXCEPT __attribute__((always_inline)) {
-        return entries[(fl::u8)x];
-    }
-
-    /// Get the underlying pointer to the CHSV entries making up the palette
-    operator CRGB *() FL_NOEXCEPT { return &(entries[0]); }
-
-    /// @copydoc CHSVPalette16::CHSVPalette16(const CHSV&)
-    CRGBPalette16(const CHSV &c1) FL_NOEXCEPT { fill_solid(&(entries[0]), 16, c1); }
-    /// @copydoc CHSVPalette16::CHSVPalette16(const CHSV&, const CHSV&)
-    CRGBPalette16(const CHSV &c1, const CHSV &c2) FL_NOEXCEPT {
-        fill_gradient(&(entries[0]), 16, c1, c2);
-    }
-    /// @copydoc CHSVPalette16::CHSVPalette16(const CHSV&, const CHSV&, const
-    /// CHSV&)
-    CRGBPalette16(const CHSV &c1, const CHSV &c2, const CHSV &c3) FL_NOEXCEPT {
-        fill_gradient(&(entries[0]), 16, c1, c2, c3);
-    }
-    /// @copydoc CHSVPalette16::CHSVPalette16(const CHSV&, const CHSV&, const
-    /// CHSV&, const CHSV&)
-    CRGBPalette16(const CHSV &c1, const CHSV &c2, const CHSV &c3,
-                  const CHSV &c4) FL_NOEXCEPT {
-        fill_gradient(&(entries[0]), 16, c1, c2, c3, c4);
-    }
-
-    /// @copydoc CHSVPalette16::CHSVPalette16(const CHSV&)
-    CRGBPalette16(const CRGB &c1) FL_NOEXCEPT { fill_solid(&(entries[0]), 16, c1); }
-    /// @copydoc CHSVPalette16::CHSVPalette16(const CHSV&, const CHSV&)
-    CRGBPalette16(const CRGB &c1, const CRGB &c2) FL_NOEXCEPT {
-        fill_gradient_RGB(&(entries[0]), 16, c1, c2);
-    }
-    /// @copydoc CHSVPalette16::CHSVPalette16(const CHSV&, const CHSV&, const
-    /// CHSV&)
-    CRGBPalette16(const CRGB &c1, const CRGB &c2, const CRGB &c3) FL_NOEXCEPT {
-        fill_gradient_RGB(&(entries[0]), 16, c1, c2, c3);
-    }
-    /// @copydoc CHSVPalette16::CHSVPalette16(const CHSV&, const CHSV&, const
-    /// CHSV&, const CHSV&)
-    CRGBPalette16(const CRGB &c1, const CRGB &c2, const CRGB &c3,
-                  const CRGB &c4) FL_NOEXCEPT {
-        fill_gradient_RGB(&(entries[0]), 16, c1, c2, c3, c4);
     }
 
     /// Creates a palette from a gradient palette in PROGMEM.
@@ -978,322 +910,123 @@ class CRGBPalette16 {
 };
 
 /// HSV color palette with 32 discrete values
-class CHSVPalette32 {
+class CHSVPalette32 : public detail::TColorPalette<CHSV, 32> {
   public:
-    CHSV entries[32]; ///< @copydoc CHSVPalette16::entries
+    using Base = detail::TColorPalette<CHSV, 32>;
+    using Base::Base;
+    using Base::entries;
+    using Base::operator!=;
+    using Base::operator=;
+    using Base::operator==;
+    using Base::operator[];
+    using Base::operator CHSV*;
 
-    /// @copydoc CHSVPalette16::CHSVPalette16()
-    CHSVPalette32() FL_NOEXCEPT {};
+    CHSVPalette32() FL_NOEXCEPT = default;
+    CHSVPalette32(const CHSVPalette32 &rhs) FL_NOEXCEPT = default;
+    CHSVPalette32 &operator=(const CHSVPalette32 &rhs) FL_NOEXCEPT = default;
 
-    /// @copydoc CHSVPalette16::CHSVPalette16(const CHSV&, const CHSV&, const
-    /// CHSV&, const CHSV&, const CHSV&, const CHSV&, const CHSV&, const CHSV&,
-    /// const CHSV&, const CHSV&, const CHSV&, const CHSV&,
-    /// const CHSV&, const CHSV&, const CHSV&, const CHSV&)
     CHSVPalette32(const CHSV &c00, const CHSV &c01, const CHSV &c02,
                   const CHSV &c03, const CHSV &c04, const CHSV &c05,
                   const CHSV &c06, const CHSV &c07, const CHSV &c08,
                   const CHSV &c09, const CHSV &c10, const CHSV &c11,
                   const CHSV &c12, const CHSV &c13, const CHSV &c14,
                   const CHSV &c15) FL_NOEXCEPT {
-        for (fl::u8 i = 0; i < 2; ++i) {
-            entries[0 + i] = c00;
-            entries[2 + i] = c01;
-            entries[4 + i] = c02;
-            entries[6 + i] = c03;
-            entries[8 + i] = c04;
-            entries[10 + i] = c05;
-            entries[12 + i] = c06;
-            entries[14 + i] = c07;
-            entries[16 + i] = c08;
-            entries[18 + i] = c09;
-            entries[20 + i] = c10;
-            entries[22 + i] = c11;
-            entries[24 + i] = c12;
-            entries[26 + i] = c13;
-            entries[28 + i] = c14;
-            entries[30 + i] = c15;
-        }
-    };
-
-    /// Copy constructor
-    CHSVPalette32(const CHSVPalette32 &rhs) FL_NOEXCEPT {
-        memmove8((void *)&(entries[0]), &(rhs.entries[0]), sizeof(entries));
+        CHSVPalette16 p16(c00, c01, c02, c03, c04, c05, c06, c07, c08, c09,
+                          c10, c11, c12, c13, c14, c15);
+        *this = p16;
     }
-    /// @copydoc CHSVPalette32( const CHSVPalette32&)
-    CHSVPalette32 &operator=(const CHSVPalette32 &rhs) FL_NOEXCEPT {
-        memmove8((void *)&(entries[0]), &(rhs.entries[0]), sizeof(entries));
+
+    CHSVPalette32(const CHSVPalette16 &rhs16) FL_NOEXCEPT { UpscalePalette(rhs16, *this); }
+
+    CHSVPalette32 &operator=(const CHSVPalette16 &rhs16) FL_NOEXCEPT {
+        UpscalePalette(rhs16, *this);
         return *this;
     }
 
-    /// @copydoc CHSVPalette16::CHSVPalette16(const TProgmemHSVPalette16&)
+    CHSVPalette32(const TProgmemHSVPalette16 &rhs) FL_NOEXCEPT {
+        CHSVPalette16 p16(rhs);
+        *this = p16;
+    }
+
+    CHSVPalette32 &operator=(const TProgmemHSVPalette16 &rhs) FL_NOEXCEPT {
+        CHSVPalette16 p16(rhs);
+        *this = p16;
+        return *this;
+    }
+
     CHSVPalette32(const TProgmemHSVPalette32 &rhs) FL_NOEXCEPT {
-        for (fl::u8 i = 0; i < 32; ++i) {
-            CRGB xyz(FL_PGM_READ_DWORD_NEAR(rhs + i));
-            entries[i].hue = xyz.red;
-            entries[i].sat = xyz.green;
-            entries[i].val = xyz.blue;
-        }
+        detail::loadProgmemPalette(entries, rhs, 32);
     }
-    /// @copydoc CHSVPalette16::CHSVPalette16(const TProgmemHSVPalette16&)
+
     CHSVPalette32 &operator=(const TProgmemHSVPalette32 &rhs) FL_NOEXCEPT {
-        for (fl::u8 i = 0; i < 32; ++i) {
-            CRGB xyz(FL_PGM_READ_DWORD_NEAR(rhs + i));
-            entries[i].hue = xyz.red;
-            entries[i].sat = xyz.green;
-            entries[i].val = xyz.blue;
-        }
+        detail::loadProgmemPalette(entries, rhs, 32);
         return *this;
-    }
-
-    /// @copydoc CHSVPalette16::CHSVPalette16(const TProgmemHSVPalette16&)
-    inline CHSV &operator[](fl::u8 x) FL_NOEXCEPT __attribute__((always_inline)) {
-        return entries[x];
-    }
-    /// @copydoc CHSVPalette16::CHSVPalette16(const TProgmemHSVPalette16&)
-    inline const CHSV &operator[](fl::u8 x) const FL_NOEXCEPT
-        __attribute__((always_inline)) {
-        return entries[x];
-    }
-
-    /// @copydoc CHSVPalette16::CHSVPalette16(const TProgmemHSVPalette16&)
-    inline CHSV &operator[](int x) FL_NOEXCEPT __attribute__((always_inline)) {
-        return entries[(fl::u8)x];
-    }
-    /// @copydoc CHSVPalette16::CHSVPalette16(const TProgmemHSVPalette16&)
-    inline const CHSV &operator[](int x) const FL_NOEXCEPT __attribute__((always_inline)) {
-        return entries[(fl::u8)x];
-    }
-
-    /// Get the underlying pointer to the CHSV entries making up the palette
-    operator CHSV *() FL_NOEXCEPT { return &(entries[0]); }
-
-    /// @copydoc CHSVPalette16::operator==
-    bool operator==(const CHSVPalette32 &rhs) const FL_NOEXCEPT {
-        const fl::u8 *p = (const fl::u8 *)(&(this->entries[0]));
-        const fl::u8 *q = (const fl::u8 *)(&(rhs.entries[0]));
-        if (p == q)
-            return true;
-        for (fl::u8 i = 0; i < (sizeof(entries)); ++i) {
-            if (*p != *q)
-                return false;
-            ++p;
-            ++q;
-        }
-        return true;
-    }
-    /// @copydoc CHSVPalette16::operator!=
-    bool operator!=(const CHSVPalette32 &rhs) const FL_NOEXCEPT { return !(*this == rhs); }
-
-    /// @copydoc CHSVPalette16::CHSVPalette16(const CHSV&)
-    CHSVPalette32(const CHSV &c1) FL_NOEXCEPT { fill_solid(&(entries[0]), 32, c1); }
-    /// @copydoc CHSVPalette16::CHSVPalette16(const CHSV&, const CHSV&)
-    CHSVPalette32(const CHSV &c1, const CHSV &c2) FL_NOEXCEPT {
-        fill_gradient(&(entries[0]), 32, c1, c2);
-    }
-    /// @copydoc CHSVPalette16::CHSVPalette16(const CHSV&, const CHSV&, const
-    /// CHSV&)
-    CHSVPalette32(const CHSV &c1, const CHSV &c2, const CHSV &c3) FL_NOEXCEPT {
-        fill_gradient(&(entries[0]), 32, c1, c2, c3);
-    }
-    /// @copydoc CHSVPalette16::CHSVPalette16(const CHSV&, const CHSV&, const
-    /// CHSV&, const CHSV&)
-    CHSVPalette32(const CHSV &c1, const CHSV &c2, const CHSV &c3,
-                  const CHSV &c4) FL_NOEXCEPT {
-        fill_gradient(&(entries[0]), 32, c1, c2, c3, c4);
     }
 };
 
+inline CHSVPalette256::CHSVPalette256(const TProgmemHSVPalette32 &rhs) FL_NOEXCEPT {
+    CHSVPalette32 p32(rhs);
+    *this = p32;
+}
+
+inline CHSVPalette256 &
+CHSVPalette256::operator=(const TProgmemHSVPalette32 &rhs) FL_NOEXCEPT {
+    CHSVPalette32 p32(rhs);
+    *this = p32;
+    return *this;
+}
+
 /// RGB color palette with 32 discrete values
-class CRGBPalette32 {
+class CRGBPalette32 : public detail::TCRGBPalette<32> {
   public:
-    CRGB entries[32]; ///< @copydoc CHSVPalette16::entries
+    using Base = detail::TCRGBPalette<32>;
+    using Base::Base;
+    using Base::entries;
+    using Base::operator!=;
+    using Base::operator=;
+    using Base::operator==;
+    using Base::operator[];
+    using Base::operator CRGB*;
 
-    /// @copydoc CRGB::CRGB()
-    CRGBPalette32() FL_NOEXCEPT {};
+    CRGBPalette32() FL_NOEXCEPT = default;
+    CRGBPalette32(const CRGBPalette32 &rhs) FL_NOEXCEPT = default;
+    CRGBPalette32 &operator=(const CRGBPalette32 &rhs) FL_NOEXCEPT = default;
 
-    /// @copydoc CRGBPalette16::CRGBPalette16(const CRGB&,
-    /// const CRGB&, const CRGB&, const CRGB&,
-    /// const CRGB&, const CRGB&, const CRGB&, const CRGB&,
-    /// const CRGB&, const CRGB&, const CRGB&, const CRGB&,
-    /// const CRGB&, const CRGB&, const CRGB&, const CRGB&)
     CRGBPalette32(const CRGB &c00, const CRGB &c01, const CRGB &c02,
                   const CRGB &c03, const CRGB &c04, const CRGB &c05,
                   const CRGB &c06, const CRGB &c07, const CRGB &c08,
                   const CRGB &c09, const CRGB &c10, const CRGB &c11,
                   const CRGB &c12, const CRGB &c13, const CRGB &c14,
                   const CRGB &c15) FL_NOEXCEPT {
-        for (fl::u8 i = 0; i < 2; ++i) {
-            entries[0 + i] = c00;
-            entries[2 + i] = c01;
-            entries[4 + i] = c02;
-            entries[6 + i] = c03;
-            entries[8 + i] = c04;
-            entries[10 + i] = c05;
-            entries[12 + i] = c06;
-            entries[14 + i] = c07;
-            entries[16 + i] = c08;
-            entries[18 + i] = c09;
-            entries[20 + i] = c10;
-            entries[22 + i] = c11;
-            entries[24 + i] = c12;
-            entries[26 + i] = c13;
-            entries[28 + i] = c14;
-            entries[30 + i] = c15;
-        }
-    };
-
-    /// @copydoc CRGBPalette16::CRGBPalette16(const CRGBPalette16&)
-    CRGBPalette32(const CRGBPalette32 &rhs) FL_NOEXCEPT {
-        memmove8((void *)&(entries[0]), &(rhs.entries[0]), sizeof(entries));
-    }
-    /// Create palette from array of CRGB colors
-    CRGBPalette32(const CRGB rhs[32]) FL_NOEXCEPT {
-        memmove8((void *)&(entries[0]), &(rhs[0]), sizeof(entries));
-    }
-    /// @copydoc CRGBPalette32(const CRGBPalette32&)
-    CRGBPalette32 &operator=(const CRGBPalette32 &rhs) FL_NOEXCEPT {
-        memmove8((void *)&(entries[0]), &(rhs.entries[0]), sizeof(entries));
-        return *this;
-    }
-    /// Create palette from array of CRGB colors
-    CRGBPalette32 &operator=(const CRGB rhs[32]) FL_NOEXCEPT {
-        memmove8((void *)&(entries[0]), &(rhs[0]), sizeof(entries));
-        return *this;
+        CRGBPalette16 p16(c00, c01, c02, c03, c04, c05, c06, c07, c08, c09,
+                          c10, c11, c12, c13, c14, c15);
+        *this = p16;
     }
 
-    /// @copydoc CRGBPalette16::CRGBPalette16(const CHSVPalette16&)
-    CRGBPalette32(const CHSVPalette32 &rhs) FL_NOEXCEPT {
-        for (fl::u8 i = 0; i < 32; ++i) {
-            entries[i] = rhs.entries[i]; // implicit HSV-to-RGB conversion
-        }
-    }
-    /// Create palette from array of CHSV colors
-    CRGBPalette32(const CHSV rhs[32]) FL_NOEXCEPT {
-        for (fl::u8 i = 0; i < 32; ++i) {
-            entries[i] = rhs[i]; // implicit HSV-to-RGB conversion
-        }
-    }
-    /// @copydoc CRGBPalette32(const CHSVPalette32&)
-    CRGBPalette32 &operator=(const CHSVPalette32 &rhs) FL_NOEXCEPT {
-        for (fl::u8 i = 0; i < 32; ++i) {
-            entries[i] = rhs.entries[i]; // implicit HSV-to-RGB conversion
-        }
-        return *this;
-    }
-    /// Create palette from array of CHSV colors
-    CRGBPalette32 &operator=(const CHSV rhs[32]) FL_NOEXCEPT {
-        for (fl::u8 i = 0; i < 32; ++i) {
-            entries[i] = rhs[i]; // implicit HSV-to-RGB conversion
-        }
-        return *this;
-    }
-
-    /// @copydoc CRGBPalette16::CRGBPalette16(const TProgmemRGBPalette16&)
-    CRGBPalette32(const TProgmemRGBPalette32 &rhs) FL_NOEXCEPT {
-        for (fl::u8 i = 0; i < 32; ++i) {
-            entries[i] = FL_PGM_READ_DWORD_NEAR(rhs + i);
-        }
-    }
-    /// @copydoc CRGBPalette32(const TProgmemRGBPalette32&)
-    CRGBPalette32 &operator=(const TProgmemRGBPalette32 &rhs) FL_NOEXCEPT {
-        for (fl::u8 i = 0; i < 32; ++i) {
-            entries[i] = FL_PGM_READ_DWORD_NEAR(rhs + i);
-        }
-        return *this;
-    }
-
-    /// @copydoc CRGBPalette16::operator==
-    bool operator==(const CRGBPalette32 &rhs) const FL_NOEXCEPT {
-        const fl::u8 *p = (const fl::u8 *)(&(this->entries[0]));
-        const fl::u8 *q = (const fl::u8 *)(&(rhs.entries[0]));
-        if (p == q)
-            return true;
-        for (fl::u8 i = 0; i < (sizeof(entries)); ++i) {
-            if (*p != *q)
-                return false;
-            ++p;
-            ++q;
-        }
-        return true;
-    }
-    /// @copydoc CRGBPalette16::operator!=
-    bool operator!=(const CRGBPalette32 &rhs) const FL_NOEXCEPT { return !(*this == rhs); }
-
-    /// @copydoc CRGBPalette16::operator[]
-    inline CRGB &operator[](fl::u8 x) FL_NOEXCEPT __attribute__((always_inline)) {
-        return entries[x];
-    }
-    /// @copydoc CRGBPalette16::operator[]
-    inline const CRGB &operator[](fl::u8 x) const FL_NOEXCEPT
-        __attribute__((always_inline)) {
-        return entries[x];
-    }
-
-    /// @copydoc CRGBPalette16::operator[]
-    inline CRGB &operator[](int x) FL_NOEXCEPT __attribute__((always_inline)) {
-        return entries[(fl::u8)x];
-    }
-    /// @copydoc CRGBPalette16::operator[]
-    inline const CRGB &operator[](int x) const FL_NOEXCEPT __attribute__((always_inline)) {
-        return entries[(fl::u8)x];
-    }
-
-    /// Get the underlying pointer to the CRGB entries making up the palette
-    operator CRGB *() FL_NOEXCEPT { return &(entries[0]); }
-
-    /// @copydoc CRGBPalette16::CRGBPalette16(const CHSV&)
-    CRGBPalette32(const CHSV &c1) FL_NOEXCEPT { fill_solid(&(entries[0]), 32, c1); }
-    /// @copydoc CRGBPalette16::CRGBPalette16(const CHSV&, const CHSV&)
-    CRGBPalette32(const CHSV &c1, const CHSV &c2) FL_NOEXCEPT {
-        fill_gradient(&(entries[0]), 32, c1, c2);
-    }
-    /// @copydoc CRGBPalette16::CRGBPalette16(const CHSV&, const CHSV&, const
-    /// CHSV&)
-    CRGBPalette32(const CHSV &c1, const CHSV &c2, const CHSV &c3) FL_NOEXCEPT {
-        fill_gradient(&(entries[0]), 32, c1, c2, c3);
-    }
-    /// @copydoc CRGBPalette16::CRGBPalette16(const CHSV&, const CHSV&, const
-    /// CHSV&, const CHSV&)
-    CRGBPalette32(const CHSV &c1, const CHSV &c2, const CHSV &c3,
-                  const CHSV &c4) FL_NOEXCEPT {
-        fill_gradient(&(entries[0]), 32, c1, c2, c3, c4);
-    }
-
-    /// @copydoc CRGBPalette16::CRGBPalette16(const CRGB&)
-    CRGBPalette32(const CRGB &c1) FL_NOEXCEPT { fill_solid(&(entries[0]), 32, c1); }
-    /// @copydoc CRGBPalette16::CRGBPalette16(const CRGB&, const CRGB&)
-    CRGBPalette32(const CRGB &c1, const CRGB &c2) FL_NOEXCEPT {
-        fill_gradient_RGB(&(entries[0]), 32, c1, c2);
-    }
-    /// @copydoc CRGBPalette16::CRGBPalette16(const CRGB&, const CRGB&, const
-    /// CRGB&)
-    CRGBPalette32(const CRGB &c1, const CRGB &c2, const CRGB &c3) FL_NOEXCEPT {
-        fill_gradient_RGB(&(entries[0]), 32, c1, c2, c3);
-    }
-    /// @copydoc CRGBPalette16::CRGBPalette16(const CRGB&, const CRGB&, const
-    /// CRGB&, const CRGB&)
-    CRGBPalette32(const CRGB &c1, const CRGB &c2, const CRGB &c3,
-                  const CRGB &c4) FL_NOEXCEPT {
-        fill_gradient_RGB(&(entries[0]), 32, c1, c2, c3, c4);
-    }
-
-    /// Create upscaled palette from 16-entry palette
     CRGBPalette32(const CRGBPalette16 &rhs16) FL_NOEXCEPT { UpscalePalette(rhs16, *this); }
-    /// @copydoc CRGBPalette32(const CRGBPalette16&)
+
     CRGBPalette32 &operator=(const CRGBPalette16 &rhs16) FL_NOEXCEPT {
         UpscalePalette(rhs16, *this);
         return *this;
     }
 
-    /// @copydoc CRGBPalette16::CRGBPalette16(const TProgmemRGBPalette16&)
     CRGBPalette32(const TProgmemRGBPalette16 &rhs) FL_NOEXCEPT {
         CRGBPalette16 p16(rhs);
         *this = p16;
     }
-    /// @copydoc CRGBPalette32(const TProgmemRGBPalette16&)
+
     CRGBPalette32 &operator=(const TProgmemRGBPalette16 &rhs) FL_NOEXCEPT {
         CRGBPalette16 p16(rhs);
         *this = p16;
+        return *this;
+    }
+
+    CRGBPalette32(const TProgmemRGBPalette32 &rhs) FL_NOEXCEPT {
+        detail::loadProgmemPalette(entries, rhs, 32);
+    }
+
+    CRGBPalette32 &operator=(const TProgmemRGBPalette32 &rhs) FL_NOEXCEPT {
+        detail::loadProgmemPalette(entries, rhs, 32);
         return *this;
     }
 
@@ -1456,168 +1189,65 @@ class CRGBPalette32 {
 };
 
 /// RGB color palette with 256 discrete values
-class CRGBPalette256 {
+class CRGBPalette256 : public detail::TCRGBPalette<256> {
   public:
-    CRGB entries[256]; ///< @copydoc CHSVPalette16::entries
+    using Base = detail::TCRGBPalette<256>;
+    using Base::Base;
+    using Base::entries;
+    using Base::operator!=;
+    using Base::operator=;
+    using Base::operator==;
+    using Base::operator[];
+    using Base::operator CRGB*;
 
-    /// @copydoc CRGB::CRGB()
-    CRGBPalette256() FL_NOEXCEPT {};
+    CRGBPalette256() FL_NOEXCEPT = default;
+    CRGBPalette256(const CRGBPalette256 &rhs) FL_NOEXCEPT = default;
+    CRGBPalette256 &operator=(const CRGBPalette256 &rhs) FL_NOEXCEPT = default;
 
-    /// @copydoc CRGBPalette16::CRGBPalette16(const CRGB&,
-    /// const CRGB&, const CRGB&, const CRGB&,
-    /// const CRGB&, const CRGB&, const CRGB&, const CRGB&,
-    /// const CRGB&, const CRGB&, const CRGB&, const CRGB&,
-    /// const CRGB&, const CRGB&, const CRGB&, const CRGB&)
     CRGBPalette256(const CRGB &c00, const CRGB &c01, const CRGB &c02,
                    const CRGB &c03, const CRGB &c04, const CRGB &c05,
                    const CRGB &c06, const CRGB &c07, const CRGB &c08,
                    const CRGB &c09, const CRGB &c10, const CRGB &c11,
                    const CRGB &c12, const CRGB &c13, const CRGB &c14,
                    const CRGB &c15) FL_NOEXCEPT {
-        CRGBPalette16 p16(c00, c01, c02, c03, c04, c05, c06, c07, c08, c09, c10,
-                          c11, c12, c13, c14, c15);
+        CRGBPalette16 p16(c00, c01, c02, c03, c04, c05, c06, c07, c08, c09,
+                          c10, c11, c12, c13, c14, c15);
         *this = p16;
-    };
-
-    /// @copydoc CRGBPalette16::CRGBPalette16(const CRGBPalette16&)
-    CRGBPalette256(const CRGBPalette256 &rhs) FL_NOEXCEPT {
-        memmove8((void *)&(entries[0]), &(rhs.entries[0]), sizeof(entries));
-    }
-    /// Create palette from array of CRGB colors
-    CRGBPalette256(const CRGB rhs[256]) FL_NOEXCEPT {
-        memmove8((void *)&(entries[0]), &(rhs[0]), sizeof(entries));
-    }
-    /// @copydoc CRGBPalette256(const CRGBPalette256&)
-    CRGBPalette256 &operator=(const CRGBPalette256 &rhs) FL_NOEXCEPT {
-        memmove8((void *)&(entries[0]), &(rhs.entries[0]), sizeof(entries));
-        return *this;
-    }
-    /// Create palette from array of CRGB colors
-    CRGBPalette256 &operator=(const CRGB rhs[256]) FL_NOEXCEPT {
-        memmove8((void *)&(entries[0]), &(rhs[0]), sizeof(entries));
-        return *this;
     }
 
-    /// @copydoc CRGBPalette16::CRGBPalette16(const CHSVPalette16&)
-    CRGBPalette256(const CHSVPalette256 &rhs) FL_NOEXCEPT {
-        for (int i = 0; i < 256; ++i) {
-            entries[i] = rhs.entries[i]; // implicit HSV-to-RGB conversion
-        }
-    }
-    /// Create palette from array of CHSV colors
-    CRGBPalette256(const CHSV rhs[256]) FL_NOEXCEPT {
-        for (int i = 0; i < 256; ++i) {
-            entries[i] = rhs[i]; // implicit HSV-to-RGB conversion
-        }
-    }
-    /// @copydoc CRGBPalette256(const CRGBPalette256&)
-    CRGBPalette256 &operator=(const CHSVPalette256 &rhs) FL_NOEXCEPT {
-        for (int i = 0; i < 256; ++i) {
-            entries[i] = rhs.entries[i]; // implicit HSV-to-RGB conversion
-        }
-        return *this;
-    }
-    /// Create palette from array of CHSV colors
-    CRGBPalette256 &operator=(const CHSV rhs[256]) FL_NOEXCEPT {
-        for (int i = 0; i < 256; ++i) {
-            entries[i] = rhs[i]; // implicit HSV-to-RGB conversion
-        }
-        return *this;
-    }
-
-    /// @copydoc CRGBPalette32::CRGBPalette32(const CRGBPalette16&)
     CRGBPalette256(const CRGBPalette16 &rhs16) FL_NOEXCEPT { UpscalePalette(rhs16, *this); }
-    /// @copydoc CRGBPalette256(const CRGBPalette16&)
+    CRGBPalette256(const CRGBPalette32 &rhs32) FL_NOEXCEPT { UpscalePalette(rhs32, *this); }
+
     CRGBPalette256 &operator=(const CRGBPalette16 &rhs16) FL_NOEXCEPT {
         UpscalePalette(rhs16, *this);
         return *this;
     }
 
-    /// @copydoc CRGBPalette16::CRGBPalette16(const TProgmemRGBPalette16&)
+    CRGBPalette256 &operator=(const CRGBPalette32 &rhs32) FL_NOEXCEPT {
+        UpscalePalette(rhs32, *this);
+        return *this;
+    }
+
     CRGBPalette256(const TProgmemRGBPalette16 &rhs) FL_NOEXCEPT {
         CRGBPalette16 p16(rhs);
         *this = p16;
     }
-    /// @copydoc CRGBPalette256(const TProgmemRGBPalette16&)
+
     CRGBPalette256 &operator=(const TProgmemRGBPalette16 &rhs) FL_NOEXCEPT {
         CRGBPalette16 p16(rhs);
         *this = p16;
         return *this;
     }
 
-    /// @copydoc CRGBPalette16::operator==
-    bool operator==(const CRGBPalette256 &rhs) const FL_NOEXCEPT {
-        const fl::u8 *p = (const fl::u8 *)(&(this->entries[0]));
-        const fl::u8 *q = (const fl::u8 *)(&(rhs.entries[0]));
-        if (p == q)
-            return true;
-        for (fl::u16 i = 0; i < (sizeof(entries)); ++i) {
-            if (*p != *q)
-                return false;
-            ++p;
-            ++q;
-        }
-        return true;
-    }
-    /// @copydoc CRGBPalette16::operator!=
-    bool operator!=(const CRGBPalette256 &rhs) const FL_NOEXCEPT { return !(*this == rhs); }
-
-    /// @copydoc CRGBPalette16::operator[]
-    inline CRGB &operator[](fl::u8 x) FL_NOEXCEPT __attribute__((always_inline)) {
-        return entries[x];
-    }
-    /// @copydoc CRGBPalette16::operator[]
-    inline const CRGB &operator[](fl::u8 x) const FL_NOEXCEPT
-        __attribute__((always_inline)) {
-        return entries[x];
+    CRGBPalette256(const TProgmemRGBPalette32 &rhs) FL_NOEXCEPT {
+        CRGBPalette32 p32(rhs);
+        *this = p32;
     }
 
-    /// @copydoc CRGBPalette16::operator[]
-    inline CRGB &operator[](int x) FL_NOEXCEPT __attribute__((always_inline)) {
-        return entries[(fl::u8)x];
-    }
-    /// @copydoc CRGBPalette16::operator[]
-    inline const CRGB &operator[](int x) const FL_NOEXCEPT __attribute__((always_inline)) {
-        return entries[(fl::u8)x];
-    }
-
-    /// Get the underlying pointer to the CHSV entries making up the palette
-    operator CRGB *() FL_NOEXCEPT { return &(entries[0]); }
-
-    /// @copydoc CRGBPalette16::CRGBPalette16(const CHSV&)
-    CRGBPalette256(const CHSV &c1) FL_NOEXCEPT { fill_solid(&(entries[0]), 256, c1); }
-    /// @copydoc CRGBPalette16::CRGBPalette16(const CHSV&, const CHSV&)
-    CRGBPalette256(const CHSV &c1, const CHSV &c2) FL_NOEXCEPT {
-        fill_gradient(&(entries[0]), 256, c1, c2);
-    }
-    /// @copydoc CRGBPalette16::CRGBPalette16(const CHSV&, const CHSV&, const
-    /// CHSV&)
-    CRGBPalette256(const CHSV &c1, const CHSV &c2, const CHSV &c3) FL_NOEXCEPT {
-        fill_gradient(&(entries[0]), 256, c1, c2, c3);
-    }
-    /// @copydoc CRGBPalette16::CRGBPalette16(const CHSV&, const CHSV&, const
-    /// CHSV&, const CHSV&)
-    CRGBPalette256(const CHSV &c1, const CHSV &c2, const CHSV &c3,
-                   const CHSV &c4) FL_NOEXCEPT {
-        fill_gradient(&(entries[0]), 256, c1, c2, c3, c4);
-    }
-
-    /// @copydoc CRGBPalette16::CRGBPalette16(const CRGB&)
-    CRGBPalette256(const CRGB &c1) FL_NOEXCEPT { fill_solid(&(entries[0]), 256, c1); }
-    /// @copydoc CRGBPalette16::CRGBPalette16(const CRGB&, const CRGB&)
-    CRGBPalette256(const CRGB &c1, const CRGB &c2) FL_NOEXCEPT {
-        fill_gradient_RGB(&(entries[0]), 256, c1, c2);
-    }
-    /// @copydoc CRGBPalette16::CRGBPalette16(const CRGB&, const CRGB&, const
-    /// CRGB&)
-    CRGBPalette256(const CRGB &c1, const CRGB &c2, const CRGB &c3) FL_NOEXCEPT {
-        fill_gradient_RGB(&(entries[0]), 256, c1, c2, c3);
-    }
-    /// @copydoc CRGBPalette16::CRGBPalette16(const CRGB&, const CRGB&, const
-    /// CRGB&, const CRGB&)
-    CRGBPalette256(const CRGB &c1, const CRGB &c2, const CRGB &c3,
-                   const CRGB &c4) FL_NOEXCEPT {
-        fill_gradient_RGB(&(entries[0]), 256, c1, c2, c3, c4);
+    CRGBPalette256 &operator=(const TProgmemRGBPalette32 &rhs) FL_NOEXCEPT {
+        CRGBPalette32 p32(rhs);
+        *this = p32;
+        return *this;
     }
 
     /// @copydoc CRGBPalette16::CRGBPalette16(TProgmemRGBGradientPalette_bytes)

--- a/tests/fl/gfx/colorutils_palette.cpp
+++ b/tests/fl/gfx/colorutils_palette.cpp
@@ -1,0 +1,163 @@
+#include "FastLED.h"
+#include "test.h"
+
+namespace {
+
+static const TProgmemHSVPalette16 kProgmemHsv16 FL_PROGMEM = {
+    0x010203, 0x111213, 0x212223, 0x313233,
+    0x414243, 0x515253, 0x616263, 0x717273,
+    0x818283, 0x919293, 0xA1A2A3, 0xB1B2B3,
+    0xC1C2C3, 0xD1D2D3, 0xE1E2E3, 0xF1F2F3,
+};
+
+static const TProgmemHSVPalette32 kProgmemHsv32 FL_PROGMEM = {
+    0x000102, 0x030405, 0x060708, 0x090A0B, 0x0C0D0E, 0x0F1011, 0x121314, 0x151617,
+    0x18191A, 0x1B1C1D, 0x1E1F20, 0x212223, 0x242526, 0x272829, 0x2A2B2C, 0x2D2E2F,
+    0x303132, 0x333435, 0x363738, 0x393A3B, 0x3C3D3E, 0x3F4041, 0x424344, 0x454647,
+    0x48494A, 0x4B4C4D, 0x4E4F50, 0x515253, 0x545556, 0x575859, 0x5A5B5C, 0x5D5E5F,
+};
+
+static const TProgmemRGBPalette32 kProgmemRgb32 FL_PROGMEM = {
+    0x000102, 0x030405, 0x060708, 0x090A0B, 0x0C0D0E, 0x0F1011, 0x121314, 0x151617,
+    0x18191A, 0x1B1C1D, 0x1E1F20, 0x212223, 0x242526, 0x272829, 0x2A2B2C, 0x2D2E2F,
+    0x303132, 0x333435, 0x363738, 0x393A3B, 0x3C3D3E, 0x3F4041, 0x424344, 0x454647,
+    0x48494A, 0x4B4C4D, 0x4E4F50, 0x515253, 0x545556, 0x575859, 0x5A5B5C, 0x5D5E5F,
+};
+
+CHSV make_hsv(int i) {
+    return CHSV(static_cast<fl::u8>(i), static_cast<fl::u8>(100 + i),
+                static_cast<fl::u8>(200 - i));
+}
+
+CRGB make_rgb(int i) {
+    return CRGB(static_cast<fl::u8>(i), static_cast<fl::u8>(2 * i),
+                static_cast<fl::u8>(255 - i));
+}
+
+void check_hsv_eq(const CHSV &lhs, const CHSV &rhs) {
+    FL_CHECK_EQ(lhs.hue, rhs.hue);
+    FL_CHECK_EQ(lhs.sat, rhs.sat);
+    FL_CHECK_EQ(lhs.val, rhs.val);
+}
+
+void check_rgb_eq(const CRGB &lhs, const CRGB &rhs) {
+    FL_CHECK_EQ(lhs.red, rhs.red);
+    FL_CHECK_EQ(lhs.green, rhs.green);
+    FL_CHECK_EQ(lhs.blue, rhs.blue);
+}
+
+} // namespace
+
+FL_TEST_FILE(FL_FILEPATH) {
+
+FL_TEST_CASE("CHSV palettes upscale consistently") {
+    CHSVPalette16 hsv16(
+        make_hsv(0), make_hsv(1), make_hsv(2), make_hsv(3),
+        make_hsv(4), make_hsv(5), make_hsv(6), make_hsv(7),
+        make_hsv(8), make_hsv(9), make_hsv(10), make_hsv(11),
+        make_hsv(12), make_hsv(13), make_hsv(14), make_hsv(15));
+
+    FL_SUBCASE("32-entry constructor and assignment repeat 16-entry anchors") {
+        CHSVPalette32 from_ctor(hsv16);
+        CHSVPalette32 from_assign;
+        from_assign = hsv16;
+
+        FL_CHECK(from_ctor == from_assign);
+        for (int i = 0; i < 16; ++i) {
+            check_hsv_eq(from_ctor[2 * i + 0], hsv16[i]);
+            check_hsv_eq(from_ctor[2 * i + 1], hsv16[i]);
+        }
+    }
+
+    FL_SUBCASE("256-entry constructor and assignment from 32-entry preserve ColorFromPalette semantics") {
+        CHSVPalette32 hsv32(hsv16);
+        CHSVPalette256 from_ctor(hsv32);
+        CHSVPalette256 from_assign;
+        from_assign = hsv32;
+
+        FL_CHECK(from_ctor == from_assign);
+        for (int i = 0; i < 256; ++i) {
+            check_hsv_eq(from_ctor[i], ColorFromPalette(hsv32, static_cast<fl::u8>(i)));
+        }
+    }
+}
+
+FL_TEST_CASE("palette progmem constructors stay aligned with runtime conversions") {
+    FL_SUBCASE("CHSV 16-entry progmem can build 32-entry and 256-entry palettes") {
+        CHSVPalette16 from_prog16(kProgmemHsv16);
+        CHSVPalette32 hsv32(kProgmemHsv16);
+        CHSVPalette256 hsv256(kProgmemHsv16);
+
+        for (int i = 0; i < 16; ++i) {
+            check_hsv_eq(hsv32[2 * i + 0], from_prog16[i]);
+            check_hsv_eq(hsv32[2 * i + 1], from_prog16[i]);
+            check_hsv_eq(hsv256[16 * i], from_prog16[i]);
+        }
+    }
+
+    FL_SUBCASE("CHSV 32-entry progmem can build a 256-entry palette") {
+        CHSVPalette32 from_prog32(kProgmemHsv32);
+        CHSVPalette256 hsv256(kProgmemHsv32);
+
+        for (int i = 0; i < 256; ++i) {
+            check_hsv_eq(hsv256[i], ColorFromPalette(from_prog32, static_cast<fl::u8>(i)));
+        }
+    }
+
+    FL_SUBCASE("CRGB 32-entry progmem can build a 256-entry palette") {
+        CRGBPalette32 from_prog32(kProgmemRgb32);
+        CRGBPalette256 rgb256(kProgmemRgb32);
+
+        for (int i = 0; i < 256; ++i) {
+            check_rgb_eq(rgb256[i], ColorFromPalette(from_prog32, static_cast<fl::u8>(i)));
+        }
+    }
+}
+
+FL_TEST_CASE("CRGB palettes still support same-size CHSV conversions and 32-to-256 upscaling") {
+    CHSVPalette32 hsv32(
+        make_hsv(0), make_hsv(1), make_hsv(2), make_hsv(3),
+        make_hsv(4), make_hsv(5), make_hsv(6), make_hsv(7),
+        make_hsv(8), make_hsv(9), make_hsv(10), make_hsv(11),
+        make_hsv(12), make_hsv(13), make_hsv(14), make_hsv(15));
+
+    CRGBPalette32 rgb32_from_hsv(hsv32);
+    for (int i = 0; i < 32; ++i) {
+        check_rgb_eq(rgb32_from_hsv[i], CRGB(hsv32[i]));
+    }
+
+    CRGBPalette32 rgb32(
+        make_rgb(0), make_rgb(1), make_rgb(2), make_rgb(3),
+        make_rgb(4), make_rgb(5), make_rgb(6), make_rgb(7),
+        make_rgb(8), make_rgb(9), make_rgb(10), make_rgb(11),
+        make_rgb(12), make_rgb(13), make_rgb(14), make_rgb(15));
+
+    CRGBPalette256 rgb256(rgb32);
+    CRGBPalette256 rgb256_assign;
+    rgb256_assign = rgb32;
+
+    FL_CHECK(rgb256 == rgb256_assign);
+    for (int i = 0; i < 256; ++i) {
+        check_rgb_eq(rgb256[i], ColorFromPalette(rgb32, static_cast<fl::u8>(i)));
+    }
+}
+
+FL_TEST_CASE("palette single-color constructors remain copy-initializable") {
+    CHSV hsv_color = make_hsv(7);
+    CRGB rgb_color = make_rgb(9);
+
+    CHSVPalette16 hsv_solid = hsv_color;
+    CRGBPalette32 rgb_solid = rgb_color;
+    CRGBPalette16 rgb_from_hsv = hsv_color;
+
+    for (int i = 0; i < 16; ++i) {
+        check_hsv_eq(hsv_solid[i], hsv_color);
+        check_rgb_eq(rgb_from_hsv[i], CRGB(hsv_color));
+    }
+
+    for (int i = 0; i < 32; ++i) {
+        check_rgb_eq(rgb_solid[i], rgb_color);
+    }
+}
+
+} // FL_TEST_FILE


### PR DESCRIPTION
## Summary
- rebase the generic-palette refactor from #1036 onto current `master`
- centralize duplicated palette behavior behind shared internal palette helpers
- preserve the current public palette API while keeping `UpscalePalette(...)` entry points intact
- add targeted coverage for 16/32/256 upscaling, progmem constructors, same-size CHSV to CRGB conversion, and implicit single-color constructors

## What This Keeps Intact
- public `CHSVPalette16/32/256` and `CRGBPalette16/32/256` types remain in place
- existing `UpscalePalette(...)` overloads remain the public path
- compatibility-sensitive constructor behavior such as copy-initializable single-color palettes is preserved
- gradient palette loaders for `CRGBPalette32/256` remain intact

## Verification
- `g++ -std=gnu++17 -I. -Isrc -Itests -Isrc/platforms/stub -DSTUB_PLATFORM -x c++ -fsyntax-only tests/fl/gfx/colorutils_palette.cpp`
- compiled the generated test translation unit after removing unrelated existing Meson/MinGW flag issues (`-Werror=division-by-zero`, missing PCH, forced AVX512 macros)
- compiled the generated `fl.gfx+.cpp` translation unit after removing those same unrelated toolchain flags

## Notes
This supersedes #1036 with a fresh implementation on top of current `master` instead of trying to revive the old branch directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for constructing palettes directly from PROGMEM sources for improved memory efficiency and additional constructor/assignment paths.

* **Refactor**
  * Consolidated palette implementations into a shared infrastructure, reducing duplication.
  * Streamlined and optimized palette upscaling and cross-type conversion behavior for consistent results.

* **Tests**
  * Added comprehensive tests for palette construction, PROGMEM loading, upscaling, and color-conversion consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->