### PR TITLE
fix(esp32): SpiChannelEngineAdapter fails to initialize SPI2 for clocked strips

### DIFF
--- a/src/fl/channels/adapters/spi_channel_adapter.cpp.hpp
+++ b/src/fl/channels/adapters/spi_channel_adapter.cpp.hpp
@@ -168,6 +168,7 @@ bool SpiChannelEngineAdapter::initializeControllerIfNeeded(
 
     if (lanes == 1) {
         SpiHw1::Config config;
+        config.bus_num = static_cast<fl::u8>(ctrl.controller->getBusId());
         config.clock_pin = clockPin;
         config.data_pin = dataPin;
         config.clock_speed_hz = 20000000;  // 20 MHz for APA102

--- a/src/platforms/esp/32/drivers/spi/spi_hw_1_esp32.cpp.hpp
+++ b/src/platforms/esp/32/drivers/spi/spi_hw_1_esp32.cpp.hpp
@@ -131,7 +131,14 @@ bool SPISingleESP32::begin(const SpiHw1::Config& config) FL_NOEXCEPT {
     // Initialize bus with auto DMA channel selection
     esp_err_t ret = spi_bus_initialize(mHost, &bus_config, SPI_DMA_CH_AUTO);
     if (ret != ESP_OK) {
-        return false;
+        if (ret != ESP_ERR_INVALID_STATE) {
+            // Genuine initialization failure — bail out
+            return false;
+        }
+        // ESP_ERR_INVALID_STATE means the bus is already initialized
+        // by another driver. This is the canonical ESP-IDF pattern for
+        // sharing an SPI bus: skip bus init and proceed to
+        // spi_bus_add_device.
     }
 
     // Configure SPI device

--- a/src/platforms/esp/32/drivers/spi/spi_hw_1_esp32.cpp.hpp
+++ b/src/platforms/esp/32/drivers/spi/spi_hw_1_esp32.cpp.hpp
@@ -59,6 +59,7 @@ private:
     spi_host_device_t mHost;
     bool mInitialized;
     bool mTransactionActive;
+    bool mBusInitializedByUs = false;
 
     // DMA buffer management
     DMABuffer mDMABuffer;            // Current DMA buffer
@@ -82,6 +83,7 @@ SPISingleESP32::SPISingleESP32(int bus_id, const char* name) FL_NOEXCEPT
     , mHost(SPI2_HOST)
     , mInitialized(false)
     , mTransactionActive(false)
+    , mBusInitializedByUs(false)
     , mDMABuffer()
     , mBufferAcquired(false) {
 }
@@ -139,6 +141,8 @@ bool SPISingleESP32::begin(const SpiHw1::Config& config) FL_NOEXCEPT {
         // by another driver. This is the canonical ESP-IDF pattern for
         // sharing an SPI bus: skip bus init and proceed to
         // spi_bus_add_device.
+    } else {
+        mBusInitializedByUs = true;
     }
 
     // Configure SPI device
@@ -152,7 +156,9 @@ bool SPISingleESP32::begin(const SpiHw1::Config& config) FL_NOEXCEPT {
     // Add device to bus
     ret = spi_bus_add_device(mHost, &dev_config, &mSPIHandle);
     if (ret != ESP_OK) {
-        spi_bus_free(mHost);
+        if (mBusInitializedByUs) {
+            spi_bus_free(mHost);
+        }
         return false;
     }
 
@@ -283,7 +289,9 @@ void SPISingleESP32::cleanup() FL_NOEXCEPT {
             mSPIHandle = nullptr;
         }
 
-        spi_bus_free(mHost);
+        if (mBusInitializedByUs) {
+            spi_bus_free(mHost);
+        }
         mInitialized = false;
     }
 }


### PR DESCRIPTION
Two bugs prevented `SpiChannelEngineAdapter` from driving APA102/SK9822
strips on ESP32-S3 when I2S audio is active simultaneously.

## Bug 1 — `spi_channel_adapter.cpp.hpp`: missing `config.bus_num` assignment

`initializeControllerIfNeeded()` builds a `SpiHw1::Config` but never sets
`config.bus_num`. The default value is 0. `SPISingleESP32::begin()` has a
guard that returns `false` silently when `config.bus_num != mBusId` (which
is 2 for SPI2). This caused `begin()` to return `false` every frame before
ever reaching `spi_bus_initialize()`, producing the per-frame
`"Failed to initialize SPI2"` warning with no hardware ever touched.

**Fix:** set `config.bus_num` from `ctrl.controller->getBusId()` so the bus
ID matches what `SPISingleESP32` expects.

## Bug 2 — `spi_hw_1_esp32.cpp.hpp`: `ESP_ERR_INVALID_STATE` not handled

`spi_bus_initialize()` returns `ESP_ERR_INVALID_STATE` when the bus is
already initialized by another driver (e.g. I2S audio on ESP32-S3). The
original error check treated this as a fatal failure and returned `false`,
preventing `spi_bus_add_device()` from ever being called.

**Fix:** treat `ESP_ERR_INVALID_STATE` as a shared-bus scenario and fall
through to `spi_bus_add_device()`, which is the canonical ESP-IDF pattern
for attaching a device to an already-initialized bus.

## Testing

Tested on ESP32-S3 (Seeed XIAO ESP32-S3) with SK9822 LEDs (GPIO7 clock,
GPIO9 data) and an ICS43434 I2S microphone active simultaneously on the
same chip. Both bugs must be fixed together for `SPI_UNIFIED` to
initialize correctly. Serial output confirming successful initialization
after the fix:

```
SpiChannelEngineAdapter: Initialized SPI2 with clock pin 7
SpiChannelEngineAdapter: Transmitting channel via SPI2 (pin 9, 600 bytes)
SpiChannelEngineAdapter: Transmission queued successfully
```

## Pre-existing lint failures

`bash lint --cpp` reports 4 violations in `src/fl/gfx/colorutils.h` and
`tests/fl/gfx/colorutils_palette.cpp` that are unrelated to this PR and
present on master before these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More robust SPI initialization when multiple devices share the same bus—devices can now proceed when the bus is already active and will no longer incorrectly free a shared bus.

* **Improvements**
  * Corrected SPI controller setup for single-lane configurations to ensure proper bus identification and reliable hardware communication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->