### PR TITLE
Change PaletteKnife bookmarklet link to HTTPS

### DIFF
--- a/tools/paletteknife/index.html
+++ b/tools/paletteknife/index.html
@@ -27,7 +27,7 @@
 
 	<h2>Installing PaletteKnife</h2>
 <p>CHROME or SAFARI is REQUIRED; will NOT work with FF or IE (or NCSA Mosiac).</p>
-<p>Drag this bookmarklet into a browser toolbar: [<a href="javascript:(function(){s=document.createElement(%27script%27);s.type=%27text/javascript%27;s.src=%27http://fastled.io/tools/paletteknife/pk2.js?v=%27+parseInt(Math.random()*99999999);document.body.appendChild(s);})();">PaletteKnife</a>]</p>
+<p>Drag this bookmarklet into a browser toolbar: [<a href="javascript:(function(){s=document.createElement(%27script%27);s.type=%27text/javascript%27;s.src=%27https://fastled.io/tools/paletteknife/pk2.js?v=%27+parseInt(Math.random()*99999999);document.body.appendChild(s);})();">PaletteKnife</a>]</p>
 
 	<h2>Using PaletteKnife</h2>
 	<ol>


### PR DESCRIPTION
Updated the bookmarklet link to use HTTPS instead of HTTP.

Fixes problem reported privately by chemdoc77 in latest Chrome: "Mixed Content: The page at '...' was loaded over HTTPS, but requested an insecure script 'http://fastled.io/tools/paletteknife/pk2.js?v=69764348'. This request has been blocked; the content must be served over HTTPS."