### PR TITLE
fix(esp32): clear SPI bus ownership after release

### DIFF
--- a/src/platforms/esp/32/drivers/spi/spi_hw_1_esp32.cpp.hpp
+++ b/src/platforms/esp/32/drivers/spi/spi_hw_1_esp32.cpp.hpp
@@ -97,6 +97,8 @@ bool SPISingleESP32::begin(const SpiHw1::Config& config) FL_NOEXCEPT {
         return true;  // Already initialized
     }
 
+    mBusInitializedByUs = false;
+
     // Validate bus_num against mBusId if driver has pre-assigned ID
     if (mBusId != -1 && config.bus_num != static_cast<u8>(mBusId)) {
         return false;  // Mismatch: driver is for bus X but config requests bus Y
@@ -137,6 +139,7 @@ bool SPISingleESP32::begin(const SpiHw1::Config& config) FL_NOEXCEPT {
             // Genuine initialization failure — bail out
             return false;
         }
+        mBusInitializedByUs = false;
         // ESP_ERR_INVALID_STATE means the bus is already initialized
         // by another driver. This is the canonical ESP-IDF pattern for
         // sharing an SPI bus: skip bus init and proceed to
@@ -158,6 +161,7 @@ bool SPISingleESP32::begin(const SpiHw1::Config& config) FL_NOEXCEPT {
     if (ret != ESP_OK) {
         if (mBusInitializedByUs) {
             spi_bus_free(mHost);
+            mBusInitializedByUs = false;
         }
         return false;
     }
@@ -291,6 +295,7 @@ void SPISingleESP32::cleanup() FL_NOEXCEPT {
 
         if (mBusInitializedByUs) {
             spi_bus_free(mHost);
+            mBusInitializedByUs = false;
         }
         mInitialized = false;
     }


### PR DESCRIPTION
## Summary

- Clear `mBusInitializedByUs` before each fresh `SPISingleESP32::begin()` attempt.
- Explicitly keep ownership false when `spi_bus_initialize()` reports `ESP_ERR_INVALID_STATE` for an already-initialized shared bus.
- Reset ownership immediately after each guarded `spi_bus_free(mHost)` call.

Fixes #2368.

## Verification

- `rg -n mBusInitializedByUs\s*=\s*(true|false)|spi_bus_free\(mHost\)|ESP_ERR_INVALID_STATE src/platforms/esp/32/drivers/spi/spi_hw_1_esp32.cpp.hpp -C 2`
- `bash compile esp32s3 Blink --local`

## Notes

- `bash lint --cpp` still fails on the pre-existing `src/fl/gfx/colorutils.h` and `tests/fl/gfx/colorutils_palette.cpp` violations already noted in PR #2366; this patch does not touch those files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SPI bus initialization reliability on ESP32 devices. The driver now correctly handles error conditions during device initialization and cleanup, preventing potential state inconsistencies that could impact subsequent SPI operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->