### PR TITLE
chore: bump fbuild to 2.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    "fbuild>=2.1.21",
+    "fbuild>=2.2.0",
     "platformio>=6.1.19,<6.2",
     "python-dateutil",
     "ruff",


### PR DESCRIPTION
## Summary

- Bump the `fbuild` dependency floor from `>=2.1.21` to `>=2.2.0`.

## Verification

- `python -m pip index versions fbuild` reports latest as `2.2.0`.
- `uv run fbuild --version` reports `fbuild 2.2.0`.
- `bash compile uno Blink --local`

## Notes

`uv.lock` is ignored by the repository (`.gitignore`), so this PR only changes the tracked dependency manifest.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated minimum required version of the fbuild dependency to 2.2.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->