### PR TITLE
Add CRGB16 palette lookup API

### DIFF
--- a/src/colorutils.h
+++ b/src/colorutils.h
@@ -38,6 +38,7 @@ using fl::TGradientDirectionCode;
 using fl::TBlendType;
 using fl::ColorFromPalette;
 using fl::ColorFromPaletteExtended;
+using fl::ColorFromPaletteHD;
 using fl::fill_palette;
 using fl::fill_gradient;
 using fl::fill_rainbow;

--- a/src/fl/gfx/colorutils.cpp.hpp
+++ b/src/fl/gfx/colorutils.cpp.hpp
@@ -251,6 +251,91 @@ inline fl::u8 lsrX4(fl::u8 dividend) {
     return dividend;
 }
 
+namespace {
+
+template <fl::size Size> struct RuntimeRGBPaletteReader {
+    fl::span<const CRGB, Size> entries;
+
+    CRGB read(fl::u8 index) const { return entries[index]; }
+};
+
+template <fl::size Size> struct ProgmemRGBPaletteReader {
+    fl::span<const fl::u32, Size> entries;
+
+    CRGB read(fl::u8 index) const {
+        return CRGB(FL_PGM_READ_DWORD_NEAR(entries.data() + index));
+    }
+};
+
+inline fl::u16 promote_channel_to_hd(fl::u8 channel) {
+    return static_cast<fl::u16>(channel) << 8;
+}
+
+inline fl::u16 lerp_channel_to_hd(fl::u8 a, fl::u8 b, fl::u16 frac,
+                                  fl::u32 segment_size) {
+    const fl::u32 a_raw = static_cast<fl::u32>(a) << 8;
+    const fl::u32 b_raw = static_cast<fl::u32>(b) << 8;
+    return static_cast<fl::u16>(
+        (a_raw * (segment_size - frac) + b_raw * frac) / segment_size);
+}
+
+inline CRGB16 promote_rgb_to_hd(const CRGB &rgb) {
+    return CRGB16(u8x8::from_raw(promote_channel_to_hd(rgb.red)),
+                  u8x8::from_raw(promote_channel_to_hd(rgb.green)),
+                  u8x8::from_raw(promote_channel_to_hd(rgb.blue)));
+}
+
+inline fl::u16 scale_hd_channel(fl::u16 channel, fl::u8x8 scale) {
+    const fl::u32 scaled =
+        (static_cast<fl::u32>(channel) * scale.raw()) >> 8;
+    return scaled > 0xFFFFu ? fl::u16(0xFFFF) : static_cast<fl::u16>(scaled);
+}
+
+inline void scale_rgb_hd(CRGB16 &rgb, fl::u8x8 brightness) {
+    if (brightness.raw() == 256) {
+        return;
+    }
+    rgb.r = u8x8::from_raw(scale_hd_channel(rgb.r.raw(), brightness));
+    rgb.g = u8x8::from_raw(scale_hd_channel(rgb.g.raw(), brightness));
+    rgb.b = u8x8::from_raw(scale_hd_channel(rgb.b.raw(), brightness));
+}
+
+template <fl::u8 PaletteBits, typename Reader>
+CRGB16 ColorFromPaletteHDImpl(const Reader &reader, fl::u16 index,
+                              fl::u8x8 brightness,
+                              TBlendType blendType) {
+    const fl::u8 frac_bits = 16 - PaletteBits;
+    const fl::u8 palette_last = (fl::u8(1) << PaletteBits) - 1;
+    const fl::u32 segment_size = fl::u32(1) << frac_bits;
+    const fl::u8 entry_index = static_cast<fl::u8>(index >> frac_bits);
+    const fl::u16 frac =
+        static_cast<fl::u16>(index & (segment_size - fl::u32(1)));
+
+    const CRGB rgb1 = reader.read(entry_index);
+    CRGB16 out;
+    if (frac && blendType != NOBLEND) {
+        CRGB rgb2;
+        if (entry_index == palette_last) {
+            rgb2 = blendType == LINEARBLEND_NOWRAP ? rgb1 : reader.read(0);
+        } else {
+            rgb2 = reader.read(entry_index + 1);
+        }
+        out = CRGB16(u8x8::from_raw(lerp_channel_to_hd(
+                         rgb1.red, rgb2.red, frac, segment_size)),
+                     u8x8::from_raw(lerp_channel_to_hd(
+                         rgb1.green, rgb2.green, frac, segment_size)),
+                     u8x8::from_raw(lerp_channel_to_hd(
+                         rgb1.blue, rgb2.blue, frac, segment_size)));
+    } else {
+        out = promote_rgb_to_hd(rgb1);
+    }
+
+    scale_rgb_hd(out, brightness);
+    return out;
+}
+
+} // namespace
+
 CRGB ColorFromPaletteExtended(const CRGBPalette32 &pal, fl::u16 index,
                               fl::u8 brightness, TBlendType blendType) {
     // Extract the five most significant bits of the index as a palette index.
@@ -297,6 +382,13 @@ CRGB ColorFromPaletteExtended(const CRGBPalette32 &pal, fl::u16 index,
         nscale8x3(red1, green1, blue1, brightness);
     }
     return CRGB(red1, green1, blue1);
+}
+
+CRGB16 ColorFromPaletteHD(const CRGBPalette32 &pal, fl::u16 index,
+                          fl::u8x8 brightness, TBlendType blendType) {
+    return ColorFromPaletteHDImpl<5>(
+        RuntimeRGBPaletteReader<32>{fl::span<const CRGB, 32>(pal.entries)},
+        index, brightness, blendType);
 }
 
 CRGB ColorFromPalette(const CRGBPalette16 &pal, fl::u8 index,
@@ -437,6 +529,13 @@ CRGB ColorFromPaletteExtended(const CRGBPalette16 &pal, fl::u16 index,
     return CRGB(red1, green1, blue1);
 }
 
+CRGB16 ColorFromPaletteHD(const CRGBPalette16 &pal, fl::u16 index,
+                          fl::u8x8 brightness, TBlendType blendType) {
+    return ColorFromPaletteHDImpl<4>(
+        RuntimeRGBPaletteReader<16>{fl::span<const CRGB, 16>(pal.entries)},
+        index, brightness, blendType);
+}
+
 CRGB ColorFromPaletteExtended(const TProgmemRGBPalette16 &pal, fl::u16 index,
                               fl::u8 brightness, TBlendType blendType) {
     // Extract the four most significant bits of the index as a palette index.
@@ -485,6 +584,13 @@ CRGB ColorFromPaletteExtended(const TProgmemRGBPalette16 &pal, fl::u16 index,
     return CRGB(red1, green1, blue1);
 }
 
+CRGB16 ColorFromPaletteHD(const TProgmemRGBPalette16 &pal, fl::u16 index,
+                          fl::u8x8 brightness, TBlendType blendType) {
+    return ColorFromPaletteHDImpl<4>(
+        ProgmemRGBPaletteReader<16>{fl::span<const fl::u32, 16>(pal)}, index,
+        brightness, blendType);
+}
+
 CRGB ColorFromPaletteExtended(const TProgmemRGBPalette32 &pal, fl::u16 index,
                               fl::u8 brightness, TBlendType blendType) {
     // Extract the five most significant bits of the index as a palette index.
@@ -531,6 +637,13 @@ CRGB ColorFromPaletteExtended(const TProgmemRGBPalette32 &pal, fl::u16 index,
         nscale8x3(red1, green1, blue1, brightness);
     }
     return CRGB(red1, green1, blue1);
+}
+
+CRGB16 ColorFromPaletteHD(const TProgmemRGBPalette32 &pal, fl::u16 index,
+                          fl::u8x8 brightness, TBlendType blendType) {
+    return ColorFromPaletteHDImpl<5>(
+        ProgmemRGBPaletteReader<32>{fl::span<const fl::u32, 32>(pal)}, index,
+        brightness, blendType);
 }
 
 CRGB ColorFromPalette(const TProgmemRGBPalette16 &pal, fl::u8 index,
@@ -865,6 +978,13 @@ CRGB ColorFromPaletteExtended(const CRGBPalette256 &pal, fl::u16 index,
         nscale8x3(red1, green1, blue1, brightness);
     }
     return CRGB(red1, green1, blue1);
+}
+
+CRGB16 ColorFromPaletteHD(const CRGBPalette256 &pal, fl::u16 index,
+                          fl::u8x8 brightness, TBlendType blendType) {
+    return ColorFromPaletteHDImpl<8>(
+        RuntimeRGBPaletteReader<256>{fl::span<const CRGB, 256>(pal.entries)},
+        index, brightness, blendType);
 }
 
 CHSV ColorFromPalette(const CHSVPalette16 &pal, fl::u8 index,

--- a/src/fl/gfx/colorutils.h
+++ b/src/fl/gfx/colorutils.h
@@ -10,6 +10,7 @@
 #include "crgb.h"  // IWYU pragma: keep
 #include "fastled_progmem.h"
 #include "fl/gfx/blur.h"  // IWYU pragma: keep
+#include "fl/gfx/crgb16.h"
 #include "fl/gfx/colorutils_misc.h"
 #include "fl/gfx/fill.h"
 #include "fl/math/xymap.h"  // IWYU pragma: keep
@@ -1367,6 +1368,23 @@ CRGB ColorFromPalette(const CRGBPalette16 &pal, fl::u8 index,
 CRGB ColorFromPaletteExtended(const CRGBPalette16 &pal, fl::u16 index,
                               fl::u8 brightness, TBlendType blendType) FL_NOEXCEPT;
 
+/// @brief High-precision palette lookup with fl::u16 `index` and CRGB16 output.
+///
+/// Existing palettes still store 8-bit CRGB entries, but interpolation and
+/// brightness scaling are preserved in CRGB16 8.8 fixed-point channels.
+/// The u8x8 brightness overload treats u8x8(1) as identity.
+CRGB16 ColorFromPaletteHD(const CRGBPalette16 &pal, fl::u16 index,
+                          fl::u8x8 brightness = fl::u8x8(1),
+                          TBlendType blendType = LINEARBLEND) FL_NOEXCEPT;
+
+/// @copydoc ColorFromPaletteHD(const CRGBPalette16&, fl::u16, fl::u8x8, TBlendType)
+inline CRGB16 ColorFromPaletteHD(const CRGBPalette16 &pal, fl::u16 index,
+                                 fl::u8 brightness,
+                                 TBlendType blendType = LINEARBLEND) FL_NOEXCEPT {
+    const fl::u16 raw = brightness == 255 ? fl::u16(256) : brightness;
+    return ColorFromPaletteHD(pal, index, fl::u8x8::from_raw(raw), blendType);
+}
+
 /// @brief Same as ColorFromPalette, but higher precision. Will eventually
 ///        become the default.
 /// @author https://github.com/generalelectrix
@@ -1375,15 +1393,54 @@ CRGB ColorFromPaletteExtended(const CRGBPalette16 &pal, fl::u16 index,
 CRGB ColorFromPaletteExtended(const CRGBPalette32 &pal, fl::u16 index,
                               fl::u8 brightness, TBlendType blendType) FL_NOEXCEPT;
 
+/// @copydoc ColorFromPaletteHD(const CRGBPalette16&, fl::u16, fl::u8x8, TBlendType)
+CRGB16 ColorFromPaletteHD(const CRGBPalette32 &pal, fl::u16 index,
+                          fl::u8x8 brightness = fl::u8x8(1),
+                          TBlendType blendType = LINEARBLEND) FL_NOEXCEPT;
+
+/// @copydoc ColorFromPaletteHD(const CRGBPalette32&, fl::u16, fl::u8x8, TBlendType)
+inline CRGB16 ColorFromPaletteHD(const CRGBPalette32 &pal, fl::u16 index,
+                                 fl::u8 brightness,
+                                 TBlendType blendType = LINEARBLEND) FL_NOEXCEPT {
+    const fl::u16 raw = brightness == 255 ? fl::u16(256) : brightness;
+    return ColorFromPaletteHD(pal, index, fl::u8x8::from_raw(raw), blendType);
+}
+
 /// @copydoc ColorFromPaletteExtended(const CRGBPalette16&, fl::u16, fl::u8, TBlendType)
 CRGB ColorFromPaletteExtended(const TProgmemRGBPalette16 &pal, fl::u16 index,
                               fl::u8 brightness = 255,
                               TBlendType blendType = LINEARBLEND) FL_NOEXCEPT;
 
+/// @copydoc ColorFromPaletteHD(const CRGBPalette16&, fl::u16, fl::u8x8, TBlendType)
+CRGB16 ColorFromPaletteHD(const TProgmemRGBPalette16 &pal, fl::u16 index,
+                          fl::u8x8 brightness = fl::u8x8(1),
+                          TBlendType blendType = LINEARBLEND) FL_NOEXCEPT;
+
+/// @copydoc ColorFromPaletteHD(const TProgmemRGBPalette16&, fl::u16, fl::u8x8, TBlendType)
+inline CRGB16 ColorFromPaletteHD(const TProgmemRGBPalette16 &pal, fl::u16 index,
+                                 fl::u8 brightness,
+                                 TBlendType blendType = LINEARBLEND) FL_NOEXCEPT {
+    const fl::u16 raw = brightness == 255 ? fl::u16(256) : brightness;
+    return ColorFromPaletteHD(pal, index, fl::u8x8::from_raw(raw), blendType);
+}
+
 /// @copydoc ColorFromPaletteExtended(const CRGBPalette32&, fl::u16, fl::u8, TBlendType)
 CRGB ColorFromPaletteExtended(const TProgmemRGBPalette32 &pal, fl::u16 index,
                               fl::u8 brightness = 255,
                               TBlendType blendType = LINEARBLEND) FL_NOEXCEPT;
+
+/// @copydoc ColorFromPaletteHD(const CRGBPalette32&, fl::u16, fl::u8x8, TBlendType)
+CRGB16 ColorFromPaletteHD(const TProgmemRGBPalette32 &pal, fl::u16 index,
+                          fl::u8x8 brightness = fl::u8x8(1),
+                          TBlendType blendType = LINEARBLEND) FL_NOEXCEPT;
+
+/// @copydoc ColorFromPaletteHD(const TProgmemRGBPalette32&, fl::u16, fl::u8x8, TBlendType)
+inline CRGB16 ColorFromPaletteHD(const TProgmemRGBPalette32 &pal, fl::u16 index,
+                                 fl::u8 brightness,
+                                 TBlendType blendType = LINEARBLEND) FL_NOEXCEPT {
+    const fl::u16 raw = brightness == 255 ? fl::u16(256) : brightness;
+    return ColorFromPaletteHD(pal, index, fl::u8x8::from_raw(raw), blendType);
+}
 
 /// @copydoc ColorFromPalette(const CRGBPalette16&, fl::u8, fl::u8,
 /// TBlendType)
@@ -1400,6 +1457,19 @@ CRGB ColorFromPalette(const CRGBPalette256 &pal, fl::u8 index,
 CRGB ColorFromPaletteExtended(const CRGBPalette256 &pal, fl::u16 index,
                               fl::u8 brightness = 255,
                               TBlendType blendType = LINEARBLEND) FL_NOEXCEPT;
+
+/// @copydoc ColorFromPaletteHD(const CRGBPalette16&, fl::u16, fl::u8x8, TBlendType)
+CRGB16 ColorFromPaletteHD(const CRGBPalette256 &pal, fl::u16 index,
+                          fl::u8x8 brightness = fl::u8x8(1),
+                          TBlendType blendType = LINEARBLEND) FL_NOEXCEPT;
+
+/// @copydoc ColorFromPaletteHD(const CRGBPalette256&, fl::u16, fl::u8x8, TBlendType)
+inline CRGB16 ColorFromPaletteHD(const CRGBPalette256 &pal, fl::u16 index,
+                                 fl::u8 brightness,
+                                 TBlendType blendType = LINEARBLEND) FL_NOEXCEPT {
+    const fl::u16 raw = brightness == 255 ? fl::u16(256) : brightness;
+    return ColorFromPaletteHD(pal, index, fl::u8x8::from_raw(raw), blendType);
+}
 
 /// @copydoc ColorFromPalette(const CRGBPalette16&, fl::u8, fl::u8,
 /// TBlendType)

--- a/tests/fl/gfx/colorutils_palette.cpp
+++ b/tests/fl/gfx/colorutils_palette.cpp
@@ -24,6 +24,13 @@ static const TProgmemRGBPalette32 kProgmemRgb32 FL_PROGMEM = {
     0x48494A, 0x4B4C4D, 0x4E4F50, 0x515253, 0x545556, 0x575859, 0x5A5B5C, 0x5D5E5F,
 };
 
+static const TProgmemRGBPalette16 kProgmemRgb16 FL_PROGMEM = {
+    0x000000, 0xFFFFFF, 0x000000, 0x000000,
+    0x000000, 0x000000, 0x000000, 0x000000,
+    0x000000, 0x000000, 0x000000, 0x000000,
+    0x000000, 0x000000, 0x000000, 0x800000,
+};
+
 CHSV make_hsv(int i) {
     return CHSV(static_cast<fl::u8>(i), static_cast<fl::u8>(100 + i),
                 static_cast<fl::u8>(200 - i));
@@ -44,6 +51,12 @@ void check_rgb_eq(const CRGB &lhs, const CRGB &rhs) {
     FL_CHECK_EQ(lhs.red, rhs.red);
     FL_CHECK_EQ(lhs.green, rhs.green);
     FL_CHECK_EQ(lhs.blue, rhs.blue);
+}
+
+CRGB downconvert(const fl::CRGB16 &rgb) {
+    return CRGB(static_cast<fl::u8>(rgb.r.to_int()),
+                static_cast<fl::u8>(rgb.g.to_int()),
+                static_cast<fl::u8>(rgb.b.to_int()));
 }
 
 } // namespace
@@ -158,6 +171,85 @@ FL_TEST_CASE("palette single-color constructors remain copy-initializable") {
     for (int i = 0; i < 32; ++i) {
         check_rgb_eq(rgb_solid[i], rgb_color);
     }
+}
+
+FL_TEST_CASE("ColorFromPaletteHD preserves CRGB16 precision") {
+    CRGBPalette16 pal(CRGB::Black);
+    pal[0] = CRGB::Black;
+    pal[1] = CRGB::White;
+    pal[15] = CRGB(128, 0, 0);
+
+    FL_SUBCASE("CRGBPalette16 lookup keeps sub-8-bit interpolation") {
+        fl::CRGB16 color = ColorFromPaletteHD(pal, 1, fl::u8x8(1),
+                                              LINEARBLEND);
+
+        FL_CHECK_EQ(color.r.to_int(), 0u);
+        FL_CHECK_GT(color.r.raw(), 0u);
+        FL_CHECK_EQ(color.r.raw(), color.g.raw());
+        FL_CHECK_EQ(color.g.raw(), color.b.raw());
+    }
+
+    FL_SUBCASE("low brightness scaling keeps fractional channel data") {
+        fl::CRGB16 color = ColorFromPaletteHD(
+            pal, 0x1000, fl::u8x8::from_raw(1), NOBLEND);
+
+        FL_CHECK_EQ(color.r.to_int(), 0u);
+        FL_CHECK_GT(color.r.raw(), 0u);
+        FL_CHECK_EQ(color.r.raw(), color.g.raw());
+        FL_CHECK_EQ(color.g.raw(), color.b.raw());
+    }
+
+    FL_SUBCASE("LINEARBLEND wraps and LINEARBLEND_NOWRAP holds final entry") {
+        fl::CRGB16 wrap = ColorFromPaletteHD(pal, 0xF800, fl::u8x8(1),
+                                             LINEARBLEND);
+        fl::CRGB16 no_wrap = ColorFromPaletteHD(pal, 0xF800, fl::u8x8(1),
+                                                LINEARBLEND_NOWRAP);
+
+        FL_CHECK_LT(wrap.r.raw(), no_wrap.r.raw());
+        FL_CHECK_EQ(no_wrap.r.raw(), fl::u16(128) << 8);
+        FL_CHECK_EQ(no_wrap.g.raw(), 0u);
+        FL_CHECK_EQ(no_wrap.b.raw(), 0u);
+    }
+
+    FL_SUBCASE("downconversion matches existing extended lookup at anchors") {
+        const fl::u16 anchors[] = {0x0000, 0x1000, 0xF000};
+        for (fl::u16 index : anchors) {
+            CRGB legacy =
+                ColorFromPaletteExtended(pal, index, 255, LINEARBLEND);
+            CRGB hd = downconvert(
+                ColorFromPaletteHD(pal, index, fl::u8x8(1), LINEARBLEND));
+            check_rgb_eq(hd, legacy);
+        }
+    }
+}
+
+FL_TEST_CASE("ColorFromPaletteHD supports existing RGB palette families") {
+    CRGBPalette16 pal16(CRGB::Black);
+    pal16[0] = CRGB(0, 0, 0);
+    pal16[1] = CRGB(255, 0, 0);
+
+    CRGBPalette32 pal32(CRGB::Black);
+    pal32[0] = CRGB(0, 0, 0);
+    pal32[1] = CRGB(0, 255, 0);
+
+    CRGBPalette256 pal256(CRGB::Black);
+    pal256[0] = CRGB(0, 0, 0);
+    pal256[1] = CRGB(0, 0, 255);
+
+    FL_CHECK_GT(ColorFromPaletteHD(pal16, 1, fl::u8x8(1), LINEARBLEND).r.raw(),
+                0u);
+    FL_CHECK_GT(ColorFromPaletteHD(pal32, 1, fl::u8x8(1), LINEARBLEND).g.raw(),
+                0u);
+    FL_CHECK_GT(ColorFromPaletteHD(pal256, 1, fl::u8x8(1), LINEARBLEND).b.raw(),
+                0u);
+
+    FL_CHECK_GT(
+        ColorFromPaletteHD(kProgmemRgb16, 1, fl::u8x8(1), LINEARBLEND).r.raw(),
+        0u);
+    FL_CHECK_GT(
+        ColorFromPaletteHD(kProgmemRgb32, 0x0800, fl::u8x8(1), LINEARBLEND)
+            .r.raw(),
+        0u);
 }
 
 } // FL_TEST_FILE


### PR DESCRIPTION
## Summary

Addresses the first PR-sized slice of #2372 by adding `ColorFromPaletteHD(...)`, a high-precision palette lookup path that returns `fl::CRGB16`.

- Adds `ColorFromPaletteHD` overloads for `CRGBPalette16`, `CRGBPalette32`, `CRGBPalette256`, `TProgmemRGBPalette16`, and `TProgmemRGBPalette32`
- Preserves interpolation and brightness scaling in `u8x8` / 8.8 fixed-point channel precision
- Keeps existing `ColorFromPalette` and `ColorFromPaletteExtended` behavior unchanged
- Adds focused coverage for sub-8-bit interpolation, low-brightness scaling, wrap/no-wrap behavior, and existing RGB palette families

Fixes #2372 for the initial lookup API slice.

## Test

```sh
python test.py colorutils_palette --no-interactive
```

diff --check also passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added high‑definition palette lookup that returns higher‑precision colors (CRGB16), supports multiple palette formats, configurable brightness scaling, and linear/NOBLEND blending modes. Includes convenience overloads for standard 8‑bit brightness.
* **Chores**
  * Added a legacy re‑export alias to preserve compatibility with existing palette APIs.
* **Tests**
  * Added tests verifying HD precision, brightness/scaling behavior, blending variants, and compatibility across palette families.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->