### PR TITLE
Keep Teensy 4.x builds on PlatformIO

### DIFF
--- a/ci/compiler/fbuild_boards.py
+++ b/ci/compiler/fbuild_boards.py
@@ -6,10 +6,11 @@
 # Supported platforms (fbuild orchestrator must exist):
 #   - atmelavr  -> AvrOrchestrator  (avr-gcc with -mmcu=)
 #   - espressif32 (pioarduino) -> Esp32Orchestrator (metadata-driven toolchain)
-#   - teensy    -> TeensyOrchestrator (arm-none-eabi-gcc, Cortex-M7 only)
 #
 # NOT supported by fbuild (must stay on PlatformIO):
 #   - atmelmegaavr boards (ATtiny1604, ATtiny1616, nano_every) -- platform not recognized
+#   - Teensy 4.x (teensy40, teensy41) -- fbuild does not yet discover Teensyduino
+#     framework libraries such as SPI and OctoWS2811 (FastLED/FastLED#2365)
 #   - Teensy 3.x/LC (teensy30..36, teensylc) -- no Cortex-M7
 #   - Specialized ESP32 variants (qemu, idf33, idf44, i2s) -- custom IDF/driver configs
 #   - uno_r4_wifi -- uses renesas-ra platform, no fbuild orchestrator
@@ -36,8 +37,5 @@ FBUILD_BOARDS: frozenset[str] = frozenset(
         "esp32h2",
         "upesy_wroom",
         "seeed_xiao_esp32s3",
-        # Teensy (arm-none-eabi-gcc, Cortex-M7)
-        "teensy40",
-        "teensy41",
     }
 )

--- a/ci/tests/test_fbuild_boards.py
+++ b/ci/tests/test_fbuild_boards.py
@@ -1,0 +1,14 @@
+"""Tests for fbuild board routing decisions."""
+
+from ci.compiler.fbuild_boards import FBUILD_BOARDS
+
+
+def test_teensy_4x_stays_on_platformio_until_fbuild_framework_libs_work() -> None:
+    """Teensy 4.x needs Teensyduino framework libraries that fbuild misses."""
+    assert "teensy40" not in FBUILD_BOARDS
+    assert "teensy41" not in FBUILD_BOARDS
+
+
+def test_known_fbuild_boards_remain_enabled() -> None:
+    assert "uno" in FBUILD_BOARDS
+    assert "esp32dev" in FBUILD_BOARDS


### PR DESCRIPTION
## Summary
- remove Teensy 4.0/4.1 from the fbuild board allowlist
- document that these boards need Teensyduino framework libraries that fbuild does not yet discover
- add focused tests for the board routing list

## Testing
- `uv run pytest ci/tests/test_fbuild_boards.py -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Teensy 4.x board compilation configuration to align with actual support capabilities.

* **Tests**
  * Added test suite to validate board support detection and ensure all supported boards remain fully functional.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->