### PR TITLE
Require fbuild Teensy toolchain fix

### DIFF
--- a/ci/tests/test_fbuild_boards.py
+++ b/ci/tests/test_fbuild_boards.py
@@ -1,0 +1,23 @@
+"""Tests for fbuild board routing decisions."""
+
+import tomllib
+from pathlib import Path
+
+from ci.compiler.fbuild_boards import FBUILD_BOARDS
+
+
+def test_teensy_4x_uses_fbuild() -> None:
+    assert "teensy40" in FBUILD_BOARDS
+    assert "teensy41" in FBUILD_BOARDS
+
+
+def test_known_fbuild_boards_remain_enabled() -> None:
+    assert "uno" in FBUILD_BOARDS
+    assert "esp32dev" in FBUILD_BOARDS
+
+
+def test_fbuild_dependency_requires_teensy_toolchain_fix() -> None:
+    pyproject = Path(__file__).resolve().parents[2] / "pyproject.toml"
+    dependencies = tomllib.loads(pyproject.read_text())["project"]["dependencies"]
+
+    assert "fbuild>=2.2.1" in dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,9 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    "fbuild>=2.2.0",
+    # fbuild 2.2.1+ includes Teensy framework library resolution and the
+    # Teensy-compatible GCC 11 toolchain fix needed for teensy40/teensy41.
+    "fbuild>=2.2.1",
     "platformio>=6.1.19,<6.2",
     "python-dateutil",
     "ruff",


### PR DESCRIPTION
## Summary
- bump the FastLED fbuild requirement to the release expected to contain the Teensy framework-library and GCC 11 toolchain fixes
- keep Teensy 4.0/4.1 routed through fbuild
- add CI-side guard tests for fbuild board routing and dependency floor

## Notes
- fbuild `2.2.0` includes the missing `SPI.h` / `OctoWS2811.h` framework library fix, but not the later GCC 11 Teensy toolchain fix from FastLED/fbuild#180
- this PR intentionally targets the next packaged fbuild release containing that merged fix

## Testing
- `uv run --no-sync pytest ci/tests/test_fbuild_boards.py -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added validation tests for Teensy board support and project dependencies.

* **Chores**
  * Updated fbuild dependency to version 2.2.1 for improved Teensy board toolchain support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->