### PR TITLE
fix(core): flush channel drivers on direct CLEDController::showLeds (#2371)

### DIFF
--- a/src/fl/cled_controller.h
+++ b/src/fl/cled_controller.h
@@ -106,9 +106,16 @@ public:
 
     // Compatibility with the 3.8.x codebase.
     VIRTUAL_IF_NOT_AVR void showLeds(fl::u8 brightness) FL_NOEXCEPT {
+#if FASTLED_HAS_ENGINE_EVENTS
+        fl::EngineEvents::onBeginFrame();
+#endif
         void* data = beginShowLeds(mLeds.size());
         showLedsInternal(brightness);
         endShowLeds(data);
+#if FASTLED_HAS_ENGINE_EVENTS
+        fl::EngineEvents::onEndFrame();
+        fl::EngineEvents::onEndShowLeds();
+#endif
     }
 
     ColorAdjustment getAdjustmentData(fl::u8 brightness) FL_NOEXCEPT;

--- a/src/fl/stl/span.h
+++ b/src/fl/stl/span.h
@@ -407,10 +407,10 @@ template <typename T, fl::size Extent> class span {
         (void)size; // Suppress unused parameter warning
     }
 
-    // Constructor from pointer only (size is known at compile-time)
-    explicit span(T *data) FL_NOEXCEPT : mData(data) {}
-
     // Constructor from C-array with matching size
+    // Matches std::span: when the argument is an array of exactly Extent
+    // elements, size is known at compile time and no runtime length is
+    // required.  See std::span<T, N>::span(std::type_identity_t<T>(&)[N]).
     span(T (&array)[Extent]) FL_NOEXCEPT : mData(array) {}
 
     // Copy constructor

--- a/tests/fl/channels/driver.cpp
+++ b/tests/fl/channels/driver.cpp
@@ -44,6 +44,7 @@ public:
     int transmitCount = 0;
     int lastChannelCount = 0;
     int enqueueCount = 0;
+    int showCount = 0;
     fl::vector<ChannelDataPtr> mEnqueuedChannels;
     fl::vector<ChannelDataPtr> mTransmittingChannels;
 
@@ -60,6 +61,7 @@ public:
     }
 
     void show() override {
+        showCount++;
         if (!mEnqueuedChannels.empty()) {
             mTransmittingChannels = fl::move(mEnqueuedChannels);
             mEnqueuedChannels.clear();
@@ -130,17 +132,69 @@ FL_TEST_CASE("Channel transmission") {
     ChannelConfig config(1, timing, fl::span<CRGB>(leds, 5), RGB, options);
     auto channel = Channel::create(config);
 
-    // Trigger show - this encodes and enqueues
+    // Direct show should encode, enqueue, and flush via frame-end events.
     channel->showLeds(255);
-
-    // Engine's show() triggers transmission
-    mockEngine->show();
 
     FL_CHECK(mockEngine->transmitCount == 1);
     FL_CHECK(mockEngine->lastChannelCount == 1);
+    FL_CHECK(mockEngine->showCount >= 1);
 
     // Clean up: disable mock driver after test
     manager.setDriverEnabled("MOCK_TX", false);
+}
+
+FL_TEST_CASE("CLEDController direct showLeds flushes channel drivers") {
+    auto mockEngine = fl::make_shared<MockEngine>("MOCK_DIRECT_CTL");
+
+    ChannelManager& manager = ChannelManager::instance();
+    manager.addDriver(1000, mockEngine);
+
+    CRGB leds[5];
+    fill_solid(leds, 5, CRGB::Green);
+
+    auto timing = makeTimingConfig<TIMING_WS2812_800KHZ>();
+    ChannelOptions options;
+    options.mAffinity = "MOCK_DIRECT_CTL";
+    ChannelConfig config(2, timing, fl::span<CRGB>(leds, 5), RGB, options);
+    auto channel = Channel::create(config);
+
+    CLEDController* controller = channel->asController();
+    controller->showLeds(255);
+
+    FL_CHECK_EQ(mockEngine->enqueueCount, 1);
+    FL_CHECK_EQ(mockEngine->transmitCount, 1);
+    FL_CHECK_EQ(mockEngine->lastChannelCount, 1);
+    FL_CHECK(mockEngine->mEnqueuedChannels.empty());
+
+    manager.removeDriver(mockEngine);
+}
+
+FL_TEST_CASE("CLEDController clearLeds flushes cleared channel data") {
+    auto mockEngine = fl::make_shared<MockEngine>("MOCK_DIRECT_CLEAR");
+
+    ChannelManager& manager = ChannelManager::instance();
+    manager.addDriver(1000, mockEngine);
+
+    CRGB leds[5];
+    fill_solid(leds, 5, CRGB::White);
+
+    auto timing = makeTimingConfig<TIMING_WS2812_800KHZ>();
+    ChannelOptions options;
+    options.mAffinity = "MOCK_DIRECT_CLEAR";
+    ChannelConfig config(3, timing, fl::span<CRGB>(leds, 5), RGB, options);
+    auto channel = Channel::create(config);
+
+    CLEDController* controller = channel->asController();
+    controller->clearLeds();
+
+    FL_CHECK_EQ(mockEngine->enqueueCount, 1);
+    FL_CHECK_EQ(mockEngine->transmitCount, 1);
+    FL_CHECK_EQ(mockEngine->lastChannelCount, 1);
+    for (const CRGB& led : leds) {
+        FL_CHECK(led == CRGB::Black);
+    }
+
+    manager.removeDriver(mockEngine);
 }
 
 FL_TEST_CASE("FastLED.show() with channels") {
@@ -166,17 +220,7 @@ FL_TEST_CASE("FastLED.show() with channels") {
     FastLED.show();
     int enqueueAfter = mockEngine->enqueueCount;
 
-    // Debug: Check if enqueue was called
-    if (enqueueAfter == enqueueBefore) {
-        FL_WARN("enqueue() was NOT called by FastLED.show() - enqueue count: " << enqueueAfter);
-    } else {
-        FL_WARN("enqueue() WAS called " << (enqueueAfter - enqueueBefore) << " times");
-    }
-
-    // The issue: FastLED.show() calls enqueue() but not show() on the driver
-    // We need to explicitly call show() or FastLED.show() needs to call it
-    mockEngine->show();
-
+    FL_CHECK(enqueueAfter > enqueueBefore);
     FL_CHECK(mockEngine->transmitCount > before);
 
     // Clean up


### PR DESCRIPTION
Fixes #2371.

## Summary

- `FastLED[0].showLeds(255)` on channel-backed platforms (e.g. ESP32-S3 RMT5 / `ClocklessIdf5`) stopped producing output on `master`: the call queued encoded pixel bytes on the `ChannelManager` driver but never told the driver to transmit, because that flush is normally driven by the frame-end event that `FastLED.show()` emits.
- Bracket `CLEDController::showLeds()` with `EngineEvents::onBeginFrame()` / `onEndFrame()` / `onEndShowLeds()`, gated on `FASTLED_HAS_ENGINE_EVENTS` so tiny/low-memory targets keep the lightweight inlined path with no `EngineEvents`/`ChannelManager` pulled in.
- Piggybacked span change needed to unblock builds after picking up `e713d6f9f3` (`Add CRGB16 palette lookup API`): delete the non-`std::span` single-argument `explicit span(T *data)` constructor on the static-extent specialization — it was ambiguous with `span(T (&arr)[N])` under clang 21. The C-array constructor already handles the compile-time-sized case without a redundant runtime length, matching `std::span<T, N>::span(std::type_identity_t<T>(&)[N])`.

## Design notes

Fixing at `CLEDController::showLeds()` (not `Channel::showLeds()`) because other channel-driver-backed controller wrappers (ESP32 RMT4, clockless-SPI paths that are `CPixelLEDController` subclasses rather than `fl::Channel` subclasses) share the same enqueue-without-flush structure — the base-class fix covers all of them.

Global batching is unaffected: `FastLED.show()` calls `showLedsInternal()` on each controller (not public `showLeds()`), then fires frame events once at the end.

See #2371 for the full investigation and the design-note comment.

## Test plan

- [x] `bash test --cpp fl/channels/driver.cpp` — existing `Channel transmission` test updated to drop the manual `mockEngine->show()` and exercise direct `channel->showLeds(255)`; two new test cases cover `controller->showLeds(255)` and `controller->clearLeds()` via `asController()`; `FastLED.show() with channels` simplified to assert both enqueue and transmit fire without a manual mock `show()`.
- [x] `bash test --cpp fl/gfx/colorutils_palette.cpp` — confirms the span ambiguity fix keeps `ColorFromPaletteHD` instantiations working.
- [x] `bash test --cpp fl/stl/span` — span unit tests.
- [x] `bash lint --cpp`.

## Related

Filed #2376 for the pre-existing `#pragma once` + PCH redefinition issue on Windows that shows up with `bash test --cpp` (full suite) for `fl/cled_controller.h` and `fl/gfx/colorutils.h`. Not in scope for this PR and reproduces on `master` independent of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Breaking Changes**
  * `fl::span` static-extent constructor updated—pointer-based construction removed and replaced with array-based construction.

* **Improvements**
  * LED controller now conditionally emits additional event hooks when engine events feature is enabled.

* **Tests**
  * Expanded coverage for LED driver transmission, channel flushing, and buffer clearing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->