### PR TITLE
Require zccache strict path flag support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "fpvgcc",
     "uv",
     "clang-tool-chain>=1.2.9",
-    "zccache>=1.2.12",
+    "zccache>=1.3.7",
     "ninja",
     "meson>=1.10.0",
     "download",


### PR DESCRIPTION
## Summary
- bump zccache to 1.3.7 so FastLED can use the new `--strict-paths` command-line flag
- keep the change scoped to the dependency floor in `pyproject.toml`

## Context
- `zccache 1.3.7` exposes `--strict-paths <off|consistent|absolute>`
- this supports the path validation needed for FastLED/FastLED#2376, where mixed include path spellings can defeat `#pragma once` under Windows PCH builds

## Testing
- `uv tool run --from zccache==1.3.7 zccache --version`
- `uv tool run --from zccache==1.3.7 zccache --help`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependencies to ensure compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->