### PR TITLE
Fix static span subview construction

### DIFF
--- a/src/fl/stl/span.h
+++ b/src/fl/stl/span.h
@@ -465,7 +465,7 @@ template <typename T, fl::size Extent> class span {
     // Compile-time sized first N elements
     template<fl::size N>
     span<T, N> first() const FL_NOEXCEPT {
-        return span<T, N>(mData);
+        return span<T, N>(mData, N);
     }
 
     // Runtime-sized first count elements
@@ -476,7 +476,7 @@ template <typename T, fl::size Extent> class span {
     // Compile-time sized last N elements
     template<fl::size N>
     span<T, N> last() const FL_NOEXCEPT {
-        return span<T, N>(mData + Extent - N);
+        return span<T, N>(mData + Extent - N, N);
     }
 
     // Runtime-sized last count elements
@@ -488,9 +488,9 @@ template <typename T, fl::size Extent> class span {
     template<fl::size Offset, fl::size Count = dynamic_extent>
     span<T, Count> subspan() const FL_NOEXCEPT {
         if (Count == dynamic_extent) {
-            return span<T, Extent - Offset>(mData + Offset);
+            return span<T, Extent - Offset>(mData + Offset, Extent - Offset);
         }
-        return span<T, Count>(mData + Offset);
+        return span<T, Count>(mData + Offset, Count);
     }
 
     // Runtime subspan


### PR DESCRIPTION
## Summary
- fix static-extent `fl::span` compile-time subviews to construct returned spans with both pointer and extent
- addresses the `tests/fl/slice.cpp` compile failure seen in the PR #2380 Linux unit-test job after zccache 1.3.7 was merged

## Testing
- `uv run python test.py --unit fl/slice --quick --no-interactive --no-parallel --force`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal span template implementation for static-extent specializations to enhance compile-time subview construction consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->