### PR TITLE
Use GitHub App client ID for project sync token

### DIFF
--- a/.github/workflows/project_automation.yml
+++ b/.github/workflows/project_automation.yml
@@ -13,6 +13,7 @@ jobs:
   sync:
     runs-on: ubuntu-latest
     if: >-
+      vars.PROJECT_APP_CLIENT_ID != '' &&
       vars.PROJECT_NUMBER != '' &&
       vars.PROJECT_OWNER != ''
     steps:
@@ -26,9 +27,9 @@ jobs:
 
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.PROJECT_APP_ID }}
+          client-id: ${{ vars.PROJECT_APP_CLIENT_ID }}
           private-key: ${{ secrets.PROJECT_APP_PRIVATE_KEY }}
           owner: ${{ vars.PROJECT_OWNER }}
 

--- a/.github/workflows/project_drift_sync.yml
+++ b/.github/workflows/project_drift_sync.yml
@@ -26,7 +26,7 @@ jobs:
   sync:
     runs-on: ubuntu-latest
     if: >-
-      vars.PROJECT_APP_ID != '' &&
+      vars.PROJECT_APP_CLIENT_ID != '' &&
       vars.PROJECT_OWNER != '' &&
       vars.PROJECT_NUMBER != ''
     steps:
@@ -40,9 +40,9 @@ jobs:
 
       - name: Generate App token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.PROJECT_APP_ID }}
+          client-id: ${{ vars.PROJECT_APP_CLIENT_ID }}
           private-key: ${{ secrets.PROJECT_APP_PRIVATE_KEY }}
           owner: ${{ vars.PROJECT_OWNER }}
 


### PR DESCRIPTION
## Summary
- update project sync workflows to use actions/create-github-app-token@v3
- switch token generation from legacy PROJECT_APP_ID to PROJECT_APP_CLIENT_ID
- keep PROJECT_APP_ID in place for traceability, but stop relying on it in the workflows

## Notes
This does not install the GitHub App. The FastLED-owned app with client ID Iv23liL4dLxjYFwTNWKt still needs to be installed on the FastLED org for token generation to succeed.

Related: #2383

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflows to use the latest version of the authentication action for improved compatibility and reliability.
  * Updated workflow configurations to use revised authentication variables for project automation processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->