### PR TITLE
Enforce zccache strict paths in Meson builds

### DIFF
--- a/ci/meson/build_config.py
+++ b/ci/meson/build_config.py
@@ -310,6 +310,79 @@ def is_ar_content_preserving_active(build_dir: Path) -> bool:
 _ar_opt_status_cache: dict[str, bool] = {}
 
 
+_MESON_PRIVATE_INCLUDE_RE = re.compile(r'("-I)([^"]+\.p)(")')
+
+
+def _is_forward_slash_absolute(path: str) -> bool:
+    return path.startswith("/") or re.match(r"^[A-Za-z]:/", path) is not None
+
+
+def _normalize_meson_private_include_paths(build_dir: Path) -> bool:
+    """Normalize Meson's private ``-I*.p`` scratch includes for zccache strict mode."""
+
+    changed_any = False
+
+    def _replacement(match: re.Match[str]) -> str:
+        prefix, raw_path, suffix = match.groups()
+        normalized = raw_path.replace("\\", "/")
+        if _is_forward_slash_absolute(normalized):
+            absolute = normalized
+        else:
+            absolute = (build_dir / normalized).resolve().as_posix()
+        if absolute == raw_path:
+            return match.group(0)
+        return f"{prefix}{absolute}{suffix}"
+
+    def _normalize_text(content: str) -> str:
+        return _MESON_PRIVATE_INCLUDE_RE.sub(_replacement, content)
+
+    build_ninja = build_dir / "build.ninja"
+    if build_ninja.exists():
+        try:
+            content = build_ninja.read_text(encoding="utf-8")
+        except OSError:
+            pass
+        else:
+            normalized = _normalize_text(content)
+            if normalized != content:
+                try:
+                    build_ninja.write_text(normalized, encoding="utf-8")
+                    changed_any = True
+                except OSError:
+                    pass
+
+    compile_commands = build_dir / "compile_commands.json"
+    if compile_commands.exists():
+        try:
+            data = json.loads(compile_commands.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            data = None
+        if isinstance(data, list):
+            changed_json = False
+            for entry in data:
+                if not isinstance(entry, dict):
+                    continue
+                entry_dict = cast(dict[str, object], entry)
+                command = entry_dict.get("command")
+                if not isinstance(command, str):
+                    continue
+                normalized = _normalize_text(command)
+                if normalized != command:
+                    entry_dict["command"] = normalized
+                    changed_json = True
+            if changed_json:
+                try:
+                    compile_commands.write_text(
+                        json.dumps(data, indent=2) + "\n",
+                        encoding="utf-8",
+                    )
+                    changed_any = True
+                except OSError:
+                    pass
+
+    return changed_any
+
+
 def _write_configuration_markers(
     *,
     build_mode_marker: Path,
@@ -1718,6 +1791,9 @@ endian = 'little'
         _ts_print(f"[MESON] Warning: Could not write native file: {e}", file=sys.stderr)
 
     env = os.environ.copy()
+    if cache_binary:
+        env.setdefault("ZCCACHE_STRICT_PATHS", "absolute")
+
     # PERFORMANCE: Use raw compiler binaries for env vars when available.
     # The native file takes precedence over env vars for meson, but these
     # serve as fallback. Raw binaries avoid ~3.6s Python wrapper overhead.
@@ -1811,6 +1887,8 @@ endian = 'little'
         # Combined function reads build.ninja once and populates _ar_opt_status_cache,
         # so a subsequent is_ar_content_preserving_active() call in runner.py is free.
         inject_ar_optimization_patches(build_dir, source_dir)
+        if _normalize_meson_private_include_paths(build_dir):
+            _ts_print("[MESON] Normalized private include paths for zccache strict mode")
 
         return True
 
@@ -1908,6 +1986,8 @@ endian = 'little'
         # so a subsequent is_ar_content_preserving_active() call in runner.py is free.
         # Must be called after meson setup so build.ninja exists.
         inject_ar_optimization_patches(build_dir, source_dir)
+        if _normalize_meson_private_include_paths(build_dir):
+            _ts_print("[MESON] Normalized private include paths for zccache strict mode")
 
         return True
 

--- a/ci/meson/build_config.py
+++ b/ci/meson/build_config.py
@@ -317,7 +317,7 @@ def _is_forward_slash_absolute(path: str) -> bool:
     return path.startswith("/") or re.match(r"^[A-Za-z]:/", path) is not None
 
 
-def _normalize_meson_private_include_paths(build_dir: Path) -> bool:
+def normalize_meson_private_include_paths(build_dir: Path) -> bool:
     """Normalize Meson's private ``-I*.p`` scratch includes for zccache strict mode."""
 
     changed_any = False
@@ -340,23 +340,33 @@ def _normalize_meson_private_include_paths(build_dir: Path) -> bool:
     if build_ninja.exists():
         try:
             content = build_ninja.read_text(encoding="utf-8")
-        except OSError:
-            pass
+        except OSError as e:
+            raise RuntimeError(
+                f"Could not read {build_ninja} while normalizing Meson strict paths"
+            ) from e
         else:
             normalized = _normalize_text(content)
             if normalized != content:
                 try:
                     build_ninja.write_text(normalized, encoding="utf-8")
                     changed_any = True
-                except OSError:
-                    pass
+                except OSError as e:
+                    raise RuntimeError(
+                        f"Could not write {build_ninja} after normalizing Meson strict paths"
+                    ) from e
 
     compile_commands = build_dir / "compile_commands.json"
     if compile_commands.exists():
         try:
             data = json.loads(compile_commands.read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError):
-            data = None
+        except OSError as e:
+            raise RuntimeError(
+                f"Could not read {compile_commands} while normalizing Meson strict paths"
+            ) from e
+        except json.JSONDecodeError as e:
+            raise RuntimeError(
+                f"Could not parse {compile_commands} while normalizing Meson strict paths"
+            ) from e
         if isinstance(data, list):
             changed_json = False
             for entry in data:
@@ -377,8 +387,10 @@ def _normalize_meson_private_include_paths(build_dir: Path) -> bool:
                         encoding="utf-8",
                     )
                     changed_any = True
-                except OSError:
-                    pass
+                except OSError as e:
+                    raise RuntimeError(
+                        f"Could not write {compile_commands} after normalizing Meson strict paths"
+                    ) from e
 
     return changed_any
 
@@ -1887,7 +1899,7 @@ endian = 'little'
         # Combined function reads build.ninja once and populates _ar_opt_status_cache,
         # so a subsequent is_ar_content_preserving_active() call in runner.py is free.
         inject_ar_optimization_patches(build_dir, source_dir)
-        if _normalize_meson_private_include_paths(build_dir):
+        if normalize_meson_private_include_paths(build_dir):
             _ts_print("[MESON] Normalized private include paths for zccache strict mode")
 
         return True
@@ -1986,7 +1998,7 @@ endian = 'little'
         # so a subsequent is_ar_content_preserving_active() call in runner.py is free.
         # Must be called after meson setup so build.ninja exists.
         inject_ar_optimization_patches(build_dir, source_dir)
-        if _normalize_meson_private_include_paths(build_dir):
+        if normalize_meson_private_include_paths(build_dir):
             _ts_print("[MESON] Normalized private include paths for zccache strict mode")
 
         return True

--- a/ci/meson/native/meson.build
+++ b/ci/meson/native/meson.build
@@ -448,6 +448,7 @@ endif
 crash_handler_lib = static_library('crash_handler',
   files(meson.project_source_root() / 'tests' / 'shared' / 'crash_handler_main.cpp'),
   cpp_args: crash_handler_cpp_args,
+  implicit_include_directories: false,
   install: false
 )
 
@@ -475,6 +476,7 @@ fastled_lib = shared_library('fastled',
   cpp_args: base_compile_args + ['-DFASTLED_BUILDING_DLL'] + fastled_lib_abs_include_args,
   link_args: fastled_shared_link_args,
   name_prefix: '',  # Produce 'fastled.dll' not 'libfastled.dll'
+  implicit_include_directories: false,
   install: false
 )
 

--- a/ci/meson/runner.py
+++ b/ci/meson/runner.py
@@ -403,6 +403,7 @@ def _start_zccache_session(build_dir: Path) -> None:
     # zccache reads it from client env if set, and it's a no-op otherwise.
     if "ZCCACHE_LINK_DEPLOY_CMD" not in os.environ:
         os.environ["ZCCACHE_LINK_DEPLOY_CMD"] = "clang-tool-chain-libdeploy"
+    os.environ.setdefault("ZCCACHE_STRICT_PATHS", "absolute")
 
     zccache_bin = _find_zccache_binary()
     if not zccache_bin:

--- a/ci/meson/shared/meson.build
+++ b/ci/meson/shared/meson.build
@@ -35,10 +35,9 @@ shared_defines = ['-DFASTLED_USE_PROGMEM=0']
 # ============================================================================
 
 # meson.project_source_root() on Windows returns native backslashes
-# (e.g. C:\Users\...). The '/' operator normalizes to forward slashes
-# (e.g. C:/Users/...). Always compose -I paths via '/' so they are
-# absolute + forward-slash + spelled identically everywhere.
-path_norm_root = meson.project_source_root() / '.'
+# (e.g. C:\Users\...). Normalize it once and compose every derived path via
+# '/' so paths are absolute + forward-slash + spelled identically everywhere.
+path_norm_root = meson.project_source_root().replace('\\', '/')
 
 # Canonical absolute forward-slash -I args for the four project-wide
 # include roots. Use these everywhere instead of redeclaring.

--- a/ci/meson/wasm/meson.build
+++ b/ci/meson/wasm/meson.build
@@ -50,6 +50,7 @@ fastled_wasm_lib = static_library('fastled',
   wasm_all_sources,
   cpp_args: wasm_abs_include_args + wasm_lib_compile_args,
   pic: false,
+  implicit_include_directories: false,
   install: false
 )
 

--- a/ci/tests/test_meson_include_paths.py
+++ b/ci/tests/test_meson_include_paths.py
@@ -46,13 +46,28 @@ _SEPARATE_PATH_FLAGS = {
     "-imacros",
     "/I",
 }
-_ATTACHED_PATH_PREFIXES = ("-I", "-F", "/I")
+_ATTACHED_PATH_PREFIXES = (
+    "-include-pch",
+    "-iframework",
+    "-idirafter",
+    "-isystem",
+    "-include",
+    "-iquote",
+    "-imacros",
+    "-imsvc",
+    "-I",
+    "-F",
+    "/I",
+)
 
 
 def _tokens_from_entry(entry: dict[str, object]) -> list[str]:
     raw_args = entry.get("arguments")
     if isinstance(raw_args, list):
-        return [str(arg) for arg in raw_args]
+        tokens: list[str] = []
+        for arg in raw_args:
+            tokens.append(str(arg))
+        return tokens
 
     raw = entry.get("command", "")
     assert isinstance(raw, str)
@@ -71,14 +86,11 @@ def _extract_strict_path_flags(entry: dict[str, object]) -> list[tuple[str, str]
             i += 2
             continue
 
-        attached = next(
-            (
-                prefix
-                for prefix in _ATTACHED_PATH_PREFIXES
-                if token.startswith(prefix) and len(token) > len(prefix)
-            ),
-            None,
-        )
+        attached = None
+        for prefix in _ATTACHED_PATH_PREFIXES:
+            if token.startswith(prefix) and len(token) > len(prefix):
+                attached = prefix
+                break
         if attached is not None:
             out.append((attached, token[len(attached) :]))
         i += 1
@@ -99,7 +111,10 @@ def _path_violation(path: str) -> str | None:
     if not _is_absolute_forward_slash(path):
         return "non-absolute path"
 
-    parts = [part for part in re.split(r"/+", path) if part]
+    parts: list[str] = []
+    for part in re.split(r"/+", path):
+        if part:
+            parts.append(part)
     if "." in parts or ".." in parts:
         return "dot path component"
     return None
@@ -107,6 +122,40 @@ def _path_violation(path: str) -> str | None:
 
 class TestMesonIncludePaths(unittest.TestCase):
     """Every path-bearing compile flag must satisfy zccache strict mode."""
+
+    def test_extract_strict_path_flags_includes_attached_forms(self) -> None:
+        entry = {
+            "arguments": [
+                "clang++",
+                "-IC:/bad/include",
+                "/IC:/bad/msvc",
+                "-isystemC:/bad/system",
+                "-iquoteC:/bad/quote",
+                "-include-pchC:/bad/header.pch",
+                "-imacrosC:/bad/macros.h",
+                "-idirafterC:/bad/after",
+                "-iframeworkC:/bad/framework",
+                "-imsvcC:/bad/imsvc",
+                "-include",
+                "C:/bad/forced.h",
+            ]
+        }
+
+        self.assertEqual(
+            _extract_strict_path_flags(entry),
+            [
+                ("-I", "C:/bad/include"),
+                ("/I", "C:/bad/msvc"),
+                ("-isystem", "C:/bad/system"),
+                ("-iquote", "C:/bad/quote"),
+                ("-include-pch", "C:/bad/header.pch"),
+                ("-imacros", "C:/bad/macros.h"),
+                ("-idirafter", "C:/bad/after"),
+                ("-iframework", "C:/bad/framework"),
+                ("-imsvc", "C:/bad/imsvc"),
+                ("-include", "C:/bad/forced.h"),
+            ],
+        )
 
     def _check_build_dir(self, build_dir: Path) -> None:
         cc_json = build_dir / "compile_commands.json"

--- a/ci/tests/test_meson_include_paths.py
+++ b/ci/tests/test_meson_include_paths.py
@@ -1,20 +1,12 @@
-"""Meson `-I` path normalization check (issue #2328).
+"""Meson strict path normalization check (issues #2328, #2376).
 
-On Windows, Meson's `include_directories()` propagates `-I` flags using native
-backslash + relative path spellings (e.g. `-I..\\..\\src\\platforms\\stub`).
-Clang keys `#pragma once` deduplication on the raw resolved path string — if
-the same directory reaches a translation unit via two different spellings
-(forward slash vs backslash, absolute vs relative, with/without `/./`), the
-header appears to be two different files and `#pragma once` is silently
-defeated, producing double-definition errors (see #2324, #2325).
-
-The fix is to make every `-I` flag we generate be absolute + forward-slash +
-spelled identically everywhere. This test inspects the generated
-`compile_commands.json` after `meson setup` and fails if any `-I` flag
-contains a backslash or is not absolute.
+On Windows, native backslash and relative path spellings can defeat clang's
+file identity checks and are rejected by zccache strict path mode. This test
+inspects generated Meson compile databases and fails if any path-bearing
+compiler flag would be rejected by ``ZCCACHE_STRICT_PATHS=absolute``.
 
 Run via:
-    bash test                              # all python tests, incl. this one
+    bash test
     uv run pytest ci/tests/test_meson_include_paths.py -v
 """
 
@@ -22,6 +14,7 @@ from __future__ import annotations
 
 import json
 import re
+import shlex
 import unittest
 from pathlib import Path
 
@@ -40,94 +33,80 @@ _MESON_BUILD_DIRS = [
     BUILD / "meson-wasm-quick",
 ]
 
-# Matches a single -I flag token. compile_commands.json "command" strings
-# emit tokens wrapped in double-quotes like `"-Ici/foo"` or `"-IC:/foo"` on
-# Windows, so we match between quotes as well as bare -Ifoo. The captured
-# path value never includes the surrounding quotes.
-_I_FLAG_RE = re.compile(r'"-I([^"]+)"|(?<!\S)-I(\S+)')
-
-# Whitelisted -I flags that come from Meson itself, not our meson.build files.
-# Meson unconditionally adds four kinds of -I for every target; we cannot
-# remove them without patching Meson. They are harmless because our canonical
-# absolute forward-slash -I flags are tried first during header resolution:
-#
-#   1. "-I<target-name>.p"         — private scratch dir for the target
-#                                     (holds .obj files, no headers)
-#   2. "-I<path-to-build-subdir>"  — e.g. "tests", "ci/meson/native"
-#                                     (build output subdir, usually empty)
-#   3. "-I<path-to-source-subdir>" — e.g. "..\..\tests", "..\..\examples"
-#                                     (source subdir containing the meson.build)
-#   4. "-I." / "-I<up-relative>"   — build root and project root
-#
-# These are always *relative* to the build dir and cannot be normalized by us.
-# The PCH is built with absolute forward-slash spellings, so consumer compiles
-# resolve the same absolute path first; pragma-once dedup works despite these.
-#
-# We whitelist them by shape: any relative path that either
-#   (a) ends in .p (Meson's "target private scratch"), or
-#   (b) is a known source/build subdirectory (examples, tests, tests/profile,
-#       ci/meson/*, or the plain build-dir markers "." / "..").
-_MESON_AUTO_SUBDIRS = {
-    ".",
-    "..",
-    "../..",
-    "examples",
-    "tests",
-    "tests/profile",
-    "ci/meson",
-    "ci/meson/native",
-    "ci/meson/shared",
-    "ci/meson/wasm",
+_SEPARATE_PATH_FLAGS = {
+    "-I",
+    "-F",
+    "-isystem",
+    "-iquote",
+    "-idirafter",
+    "-iframework",
+    "-imsvc",
+    "-include",
+    "-include-pch",
+    "-imacros",
+    "/I",
 }
-_MESON_P_SCRATCH_RE = re.compile(r"(?:^|/)[A-Za-z0-9._+-]+\.p$")
+_ATTACHED_PATH_PREFIXES = ("-I", "-F", "/I")
 
 
-def _extract_includes_from_entry(entry: dict[str, object]) -> list[str]:
-    """Extract -I <path> values from a compile_commands.json entry."""
-    raw = entry.get("command") or " ".join(entry.get("arguments", []))  # type: ignore[arg-type]
+def _tokens_from_entry(entry: dict[str, object]) -> list[str]:
+    raw_args = entry.get("arguments")
+    if isinstance(raw_args, list):
+        return [str(arg) for arg in raw_args]
+
+    raw = entry.get("command", "")
     assert isinstance(raw, str)
-    out: list[str] = []
-    for m in _I_FLAG_RE.finditer(raw):
-        out.append(m.group(1) or m.group(2))
+    return shlex.split(raw, posix=True)
+
+
+def _extract_strict_path_flags(entry: dict[str, object]) -> list[tuple[str, str]]:
+    """Extract path-bearing compiler flags checked by zccache strict mode."""
+    tokens = _tokens_from_entry(entry)
+    out: list[tuple[str, str]] = []
+    i = 0
+    while i < len(tokens):
+        token = tokens[i]
+        if token in _SEPARATE_PATH_FLAGS and i + 1 < len(tokens):
+            out.append((token, tokens[i + 1]))
+            i += 2
+            continue
+
+        attached = next(
+            (
+                prefix
+                for prefix in _ATTACHED_PATH_PREFIXES
+                if token.startswith(prefix) and len(token) > len(prefix)
+            ),
+            None,
+        )
+        if attached is not None:
+            out.append((attached, token[len(attached) :]))
+        i += 1
     return out
 
 
-def _is_meson_auto_include(include_path: str) -> bool:
-    """Return True if this -I path is Meson-injected (not user-controlled).
-
-    We normalize forward/back slashes before matching so the function behaves
-    the same regardless of how Meson spelled the path on a given platform.
-    """
-    norm = include_path.replace("\\", "/").rstrip("/")
-    # (a) Private per-target scratch dir (contains only .obj files)
-    if _MESON_P_SCRATCH_RE.search(norm):
-        return True
-    # (b) Known Meson source/build subdirs; also accept them with a
-    #     leading "../../" prefix (Meson relativises them to the build root).
-    if norm.startswith("../../"):
-        norm = norm[len("../../") :]
-    return norm in _MESON_AUTO_SUBDIRS
-
-
 def _is_absolute_forward_slash(path: str) -> bool:
-    """Return True if `path` is absolute (POSIX `/...` or Windows `X:/...`)
-    and contains no backslashes.
-    """
     if "\\" in path:
         return False
-    # Windows drive letter
     if re.match(r"^[A-Za-z]:/", path):
         return True
-    # POSIX absolute
-    if path.startswith("/"):
-        return True
-    return False
+    return path.startswith("/")
+
+
+def _path_violation(path: str) -> str | None:
+    if "\\" in path:
+        return "backslash in path"
+    if not _is_absolute_forward_slash(path):
+        return "non-absolute path"
+
+    parts = [part for part in re.split(r"/+", path) if part]
+    if "." in parts or ".." in parts:
+        return "dot path component"
+    return None
 
 
 class TestMesonIncludePaths(unittest.TestCase):
-    """Every -I flag in every compile_commands.json must be absolute +
-    forward-slash + spelled identically everywhere.
-    """
+    """Every path-bearing compile flag must satisfy zccache strict mode."""
 
     def _check_build_dir(self, build_dir: Path) -> None:
         cc_json = build_dir / "compile_commands.json"
@@ -137,8 +116,7 @@ class TestMesonIncludePaths(unittest.TestCase):
         with open(cc_json, "r", encoding="utf-8") as f:
             data = json.load(f)
 
-        offenders_backslash: dict[str, list[str]] = {}
-        offenders_relative: dict[str, list[str]] = {}
+        offenders: dict[tuple[str, str, str], list[str]] = {}
 
         for entry in data:
             source_file = entry.get("file", "<unknown>")
@@ -148,48 +126,31 @@ class TestMesonIncludePaths(unittest.TestCase):
             except ValueError:
                 source_rel = source_file
 
-            for inc in _extract_includes_from_entry(entry):
-                if _is_meson_auto_include(inc):
-                    continue
-                if "\\" in inc:
-                    offenders_backslash.setdefault(inc, []).append(source_rel)
-                elif not _is_absolute_forward_slash(inc):
-                    offenders_relative.setdefault(inc, []).append(source_rel)
+            assert isinstance(entry, dict)
+            for flag, path in _extract_strict_path_flags(entry):
+                violation = _path_violation(path)
+                if violation is not None:
+                    offenders.setdefault((flag, path, violation), []).append(source_rel)
 
-        if offenders_backslash or offenders_relative:
+        if offenders:
             lines = [
-                f"Non-normalized -I flags found in {cc_json}:",
+                f"Non-normalized compiler path flags found in {cc_json}:",
                 "",
-                "See https://github.com/FastLED/FastLED/issues/2328 — all -I flags",
-                "must be absolute + forward-slash. Backslashes or relative paths",
-                "defeat clang's #pragma once dedup on Windows.",
+                "See https://github.com/FastLED/FastLED/issues/2328 and #2376.",
+                "All path-bearing compiler flags must satisfy",
+                "ZCCACHE_STRICT_PATHS=absolute: absolute, forward-slash, and no",
+                "dot path components.",
                 "",
             ]
-            if offenders_backslash:
+            for (flag, path, violation), sources in sorted(offenders.items())[:20]:
                 lines.append(
-                    f"  Backslash in path ({len(offenders_backslash)} distinct):"
+                    f"    {flag} {path}  ({violation}; seen in {len(sources)} TUs, e.g. {sources[0]})"
                 )
-                for flag, sources in sorted(offenders_backslash.items())[:10]:
-                    lines.append(
-                        f"    {flag}  (seen in {len(sources)} TUs, e.g. {sources[0]})"
-                    )
-                if len(offenders_backslash) > 10:
-                    lines.append(f"    ... {len(offenders_backslash) - 10} more")
-                lines.append("")
-            if offenders_relative:
-                lines.append(
-                    f"  Non-absolute path ({len(offenders_relative)} distinct):"
-                )
-                for flag, sources in sorted(offenders_relative.items())[:10]:
-                    lines.append(
-                        f"    {flag}  (seen in {len(sources)} TUs, e.g. {sources[0]})"
-                    )
-                if len(offenders_relative) > 10:
-                    lines.append(f"    ... {len(offenders_relative) - 10} more")
+            if len(offenders) > 20:
+                lines.append(f"    ... {len(offenders) - 20} more")
             self.fail("\n".join(lines))
 
     def test_all_meson_build_dirs_have_normalized_includes(self) -> None:
-        """Check every known meson build dir. Skip any that don't exist yet."""
         checked_any = False
         for build_dir in _MESON_BUILD_DIRS:
             if not (build_dir / "compile_commands.json").exists():

--- a/ci/wasm_build.py
+++ b/ci/wasm_build.py
@@ -69,6 +69,13 @@ def get_meson_executable() -> str:
     return "meson"
 
 
+def _normalize_meson_private_paths(build_dir: Path) -> None:
+    from ci.meson.build_config import _normalize_meson_private_include_paths
+
+    if _normalize_meson_private_include_paths(build_dir):
+        print("[WASM] Normalized private include paths for strict path mode")
+
+
 # ============================================================================
 # Library fingerprint — skip meson/ninja when source tree hasn't changed
 # ============================================================================
@@ -407,6 +414,7 @@ def _recover_stale_wasm_build(build_dir: Path) -> bool:
         ]
         result = subprocess.run(cmd, cwd=PROJECT_ROOT)
         if result.returncode == 0:
+            _normalize_meson_private_paths(build_dir)
             print("[WASM] Self-healing reconfiguration complete")
             return True
         else:
@@ -441,6 +449,7 @@ def ensure_meson_configured(build_dir: Path, mode: str, force: bool = False) -> 
             except OSError:
                 pass
         if stored_hash == current_hash:
+            _normalize_meson_private_paths(build_dir)
             return True  # No file list changes, skip reconfigure
 
         # Source file list changed — need reconfigure
@@ -466,6 +475,7 @@ def ensure_meson_configured(build_dir: Path, mode: str, force: bool = False) -> 
         if result.returncode != 0:
             print(f"[WASM] Meson reconfiguration failed (rc {result.returncode})")
             return False
+        _normalize_meson_private_paths(build_dir)
         try:
             file_list_marker.write_text(current_hash, encoding="utf-8")
         except OSError:
@@ -493,6 +503,7 @@ def ensure_meson_configured(build_dir: Path, mode: str, force: bool = False) -> 
     if result.returncode != 0:
         print(f"[WASM] Meson setup failed with return code {result.returncode}")
         return False
+    _normalize_meson_private_paths(build_dir)
 
     # Write file list hash marker for future staleness detection
     try:

--- a/ci/wasm_build.py
+++ b/ci/wasm_build.py
@@ -70,9 +70,9 @@ def get_meson_executable() -> str:
 
 
 def _normalize_meson_private_paths(build_dir: Path) -> None:
-    from ci.meson.build_config import _normalize_meson_private_include_paths
+    from ci.meson.build_config import normalize_meson_private_include_paths
 
-    if _normalize_meson_private_include_paths(build_dir):
+    if normalize_meson_private_include_paths(build_dir):
         print("[WASM] Normalized private include paths for strict path mode")
 
 

--- a/examples/meson.build
+++ b/examples/meson.build
@@ -157,6 +157,7 @@ example_runner_exe = executable('example_runner',
   cpp_args: runner_cpp_args + [path_norm_I_src, path_norm_I_stub, path_norm_I_tests],
   link_args: runner_link_args,
   link_with: [crash_handler_lib],  # Shared crash handler from root meson.build
+  implicit_include_directories: false,
   install: false
 )
 
@@ -289,6 +290,7 @@ foreach example_name : example_paths.keys()
         link_args: dll_link_args,  # Minimal linking (defined in root meson.build)
         name_prefix: '',  # Remove 'lib' prefix on Windows (produce 'example-Blink.dll' not 'libexample-Blink.dll')
         build_by_default: false,  # Only build when explicitly requested
+        implicit_include_directories: false,
         install: false
     )
 

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -17,6 +17,7 @@ uv = find_program('uv')
 # or clang's #pragma once dedup is silently defeated on Windows.
 test_abs_include_args = [
   path_norm_I_root,  # For test includes (normalized abs forward-slash).
+  path_norm_I_tests, # For "test.h" includes from test subdirectories.
   path_norm_I_src,   # For library.
 ]
 
@@ -82,9 +83,10 @@ test_pch = custom_target('test_pch',
 # here. Meson emits -I..\..\src on Windows which breaks #pragma once.
 runner_exe = executable('runner',
   'shared/runner.cpp',
-  cpp_args: runner_cpp_args + [path_norm_I_src, path_norm_I_stub],
+  cpp_args: runner_cpp_args + [path_norm_I_src, path_norm_I_stub, path_norm_I_tests],
   link_args: runner_link_args,
   link_with: [crash_handler_lib],  # Shared crash handler from root meson.build
+  implicit_include_directories: false,
   install: false
 )
 
@@ -179,6 +181,7 @@ test_shared_objs_lib = static_library('test_shared_objs',
   ['doctest_main.cpp', 'shared/fl_unittest.cpp', 'misc' / 'coroutine_impl.cpp', test_pch],
   cpp_args: shared_test_cpp_args,
   pic: true,
+  implicit_include_directories: false,
   install: false
 )
 shared_test_objects = test_shared_objs_lib.extract_all_objects(recursive: false)
@@ -216,6 +219,7 @@ foreach test_name : test_names
     link_args: test_link_args,
     link_with: test_link_with,
     name_prefix: '',  # Remove 'lib' prefix on Windows (produce 'test.dll' not 'libtest.dll')
+    implicit_include_directories: false,
     install: false
   )
 

--- a/tests/profile/meson.build
+++ b/tests/profile/meson.build
@@ -52,6 +52,7 @@ if profile_test_files != ''
       link_args: profile_link_args,
       link_with: [fastled_lib, crash_handler_lib],
       install: false,
+      implicit_include_directories: false,
       build_by_default: false  # Only build when explicitly requested via 'bash profile <function>'
     )
   endforeach


### PR DESCRIPTION
## Summary
- Enable `ZCCACHE_STRICT_PATHS=absolute` for Meson/zccache builds so mixed separator or relative compiler paths fail locally instead of regressing silently.
- Normalize Meson's private `.p` include paths in generated Ninja/compile database files after setup/reconfigure.
- Disable Meson's implicit include directories for FastLED test/example targets and keep explicit canonical absolute forward-slash include roots.
- Expand the Meson include-path regression test to cover zccache strict path-bearing flags, including `-I`, `/I`, `-include`, and related forms.

## Issue #2376 status
The merged dependency updates make the original `#pragma once` failure stop reproducing on current `master`: `bash test --cpp` passed before this patch. However, running with zccache strict mode still failed on current `master` because Meson emitted private scratch includes like `ci/meson/native\fastled.dll.p`. This PR makes strict mode part of the Meson/zccache path and fixes the remaining path hygiene problem.

Fixes #2376.

## Testing
- `uv run zccache --version` -> `zccache 1.3.7`
- Current `master`: `bash test --cpp` -> passed 302/302
- Current `master`: `ZCCACHE_STRICT_PATHS=absolute bash test --cpp --clean --force` -> failed on zccache strict path rejection for Meson private `.p` include
- This branch: `ZCCACHE_STRICT_PATHS=absolute bash test --cpp --force --no-parallel` -> passed 327/327
- This branch: `uv run pytest ci/tests/test_meson_include_paths.py -v` -> passed
- This branch: `uv run test.py --examples Fire2023 --full --force` with strict paths -> passed
- `git diff --check` -> clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Normalize compiler include paths so build artifacts use consistent forward-slash absolute paths across platforms
  * Enable strict path mode for the compiler cache to improve cache reliability
  * Disable automatic implicit include directories for several build targets to align include behavior with explicit settings
  * Expand and harden tests to validate include-flag parsing and strict-path compliance
  * Run normalization at key build steps and emit status messages when changes occur
<!-- end of auto-generated comment: release notes by coderabbit.ai -->