### PR TITLE
Add FL_STATIC_ASSERT wrapper and lint

### DIFF
--- a/ci/lint_cpp/banned_macros_checker.py
+++ b/ci/lint_cpp/banned_macros_checker.py
@@ -38,6 +38,41 @@ HAS_INCLUDE_PATTERN = re.compile(r"\b__has_include\s*\(")
 STATIC_ASSERT_PATTERN = re.compile(r"\bstatic_assert\s*\(")
 
 
+def _strip_string_literals(code: str) -> str:
+    """Replace C/C++ string and character literal contents with spaces."""
+    result: list[str] = []
+    quote: str | None = None
+    escaped = False
+
+    for char in code:
+        if quote is None:
+            if char in ('"', "'"):
+                quote = char
+                result.append(char)
+            else:
+                result.append(char)
+            continue
+
+        if escaped:
+            escaped = False
+            result.append(" ")
+            continue
+
+        if char == "\\":
+            escaped = True
+            result.append(" ")
+            continue
+
+        if char == quote:
+            quote = None
+            result.append(char)
+            continue
+
+        result.append(" ")
+
+    return "".join(result)
+
+
 class BannedMacrosChecker(FileContentChecker):
     """Checker for banned preprocessor macros - should use FL_* wrappers instead."""
 
@@ -100,15 +135,20 @@ class BannedMacrosChecker(FileContentChecker):
             if "#define" in code_part and "FL_HAS_INCLUDE" in code_part:
                 continue
 
+            code_no_strings = _strip_string_literals(code_part)
+
             # Fast first pass: skip regex if no banned keyword is present
-            if "__has_include" not in code_part and "static_assert" not in code_part:
+            if (
+                "__has_include" not in code_no_strings
+                and "static_assert" not in code_no_strings
+            ):
                 continue
 
             # Check for __has_include(...) usage
-            if HAS_INCLUDE_PATTERN.search(code_part):
+            if HAS_INCLUDE_PATTERN.search(code_no_strings):
                 # Skip if it's in a #ifndef __has_include guard (definition pattern)
                 # This allows: #ifndef __has_include / #define FL_HAS_INCLUDE(x) 0 / #else ...
-                if "#ifndef" in code_part or "#ifdef" in code_part:
+                if "#ifndef" in code_no_strings or "#ifdef" in code_no_strings:
                     continue
 
                 violations.append(
@@ -121,7 +161,7 @@ class BannedMacrosChecker(FileContentChecker):
                     )
                 )
 
-            if STATIC_ASSERT_PATTERN.search(code_part):
+            if STATIC_ASSERT_PATTERN.search(code_no_strings):
                 violations.append(
                     (
                         line_number,

--- a/ci/lint_cpp/banned_macros_checker.py
+++ b/ci/lint_cpp/banned_macros_checker.py
@@ -7,11 +7,14 @@ across all platforms and compilers.
 
 Banned macros/features checked:
 - __has_include(...) (C++17/compiler extension) -> FL_HAS_INCLUDE(...)
+- static_assert(...) -> FL_STATIC_ASSERT(...)
 
 Rationale:
 - __has_include() is not universally supported across all compilers/platforms
 - FL_HAS_INCLUDE provides a fallback implementation (returns 0) for compilers
   without __has_include support
+- FL_STATIC_ASSERT provides a C++98-compatible fallback for legacy embedded
+  toolchains and preserves native static_assert on modern compilers
 - Ensures code compiles consistently across all target platforms
 """
 
@@ -24,11 +27,15 @@ from ci.util.paths import PROJECT_ROOT
 # Mapping of banned macros to their FL_* macro equivalents
 MACRO_MAPPINGS = {
     "__has_include": "FL_HAS_INCLUDE",
+    "static_assert": "FL_STATIC_ASSERT",
 }
 
 # Pattern to match __has_include(...) usage
 # Matches: __has_include(<header>) or __has_include("header")
 HAS_INCLUDE_PATTERN = re.compile(r"\b__has_include\s*\(")
+
+# Pattern to match raw static_assert(...) usage
+STATIC_ASSERT_PATTERN = re.compile(r"\bstatic_assert\s*\(")
 
 
 class BannedMacrosChecker(FileContentChecker):
@@ -43,9 +50,9 @@ class BannedMacrosChecker(FileContentChecker):
         if not file_path.endswith((".cpp", ".h", ".hpp", ".ino", ".cpp.hpp")):
             return False
 
-        # Skip files that define FL_HAS_INCLUDE
+        # Skip files that define the portable wrappers themselves
         if file_path.endswith("has_include.h") or file_path.endswith(
-            "compiler_control.h"
+            ("compiler_control.h", "cpp_compat.h", "static_assert.h")
         ):
             return False
 
@@ -93,8 +100,8 @@ class BannedMacrosChecker(FileContentChecker):
             if "#define" in code_part and "FL_HAS_INCLUDE" in code_part:
                 continue
 
-            # Fast first pass: skip regex if keyword not present
-            if "__has_include" not in code_part:
+            # Fast first pass: skip regex if no banned keyword is present
+            if "__has_include" not in code_part and "static_assert" not in code_part:
                 continue
 
             # Check for __has_include(...) usage
@@ -111,6 +118,16 @@ class BannedMacrosChecker(FileContentChecker):
                         f"      Rationale: __has_include is not universally supported. "
                         f"FL_HAS_INCLUDE provides a portable wrapper with fallback for older compilers.\n"
                         f"      Include 'fl/stl/has_include.h' and replace __has_include(...) with FL_HAS_INCLUDE(...)",
+                    )
+                )
+
+            if STATIC_ASSERT_PATTERN.search(code_part):
+                violations.append(
+                    (
+                        line_number,
+                        f"Use FL_STATIC_ASSERT instead of raw static_assert: {stripped}\n"
+                        f"      Rationale: FL_STATIC_ASSERT keeps compile-time assertions portable on old embedded toolchains.\n"
+                        f"      Include 'fl/stl/static_assert.h' when needed and replace static_assert(...) with FL_STATIC_ASSERT(...)",
                     )
                 )
 

--- a/ci/lint_cpp/test_banned_macros_checker.py
+++ b/ci/lint_cpp/test_banned_macros_checker.py
@@ -50,6 +50,16 @@ class TestBannedMacrosChecker(unittest.TestCase):
     def test_multiline_comments_are_ignored(self) -> None:
         self.assertEqual(len(_violations('/*\nstatic_assert(true, "ok");\n*/')), 0)
 
+    def test_string_literals_are_ignored(self) -> None:
+        self.assertEqual(
+            len(_violations('FL_WARN("use FL_STATIC_ASSERT not static_assert(true)");')),
+            0,
+        )
+        self.assertEqual(
+            len(_violations("FL_WARN('__has_include(<vector>) is banned');")),
+            0,
+        )
+
     def test_definition_file_is_skipped(self) -> None:
         self.assertFalse(BannedMacrosChecker().should_process_file(_CPP_COMPAT_PATH))
         self.assertFalse(BannedMacrosChecker().should_process_file(_STATIC_ASSERT_PATH))

--- a/ci/lint_cpp/test_banned_macros_checker.py
+++ b/ci/lint_cpp/test_banned_macros_checker.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Unit tests for BannedMacrosChecker."""
+
+import unittest
+
+from ci.lint_cpp.banned_macros_checker import BannedMacrosChecker
+from ci.util.check_files import FileContent
+
+
+_SRC_PATH = "src/fl/example.h"
+_TEST_PATH = "tests/fl/example.cpp"
+_CPP_COMPAT_PATH = "src/cpp_compat.h"
+_STATIC_ASSERT_PATH = "src/fl/stl/static_assert.h"
+_THIRD_PARTY_PATH = "src/third_party/example.h"
+
+
+def _make(code: str, path: str = _SRC_PATH) -> FileContent:
+    return FileContent(path=path, content=code, lines=code.splitlines())
+
+
+def _violations(code: str, path: str = _SRC_PATH) -> list[tuple[int, str]]:
+    checker = BannedMacrosChecker()
+    if not checker.should_process_file(path):
+        return []
+    checker.check_file_content(_make(code, path))
+    return checker.violations.get(path, [])
+
+
+class TestBannedMacrosChecker(unittest.TestCase):
+    def test_static_assert_is_banned_in_src(self) -> None:
+        self.assertEqual(len(_violations('static_assert(true, "ok");')), 1)
+
+    def test_static_assert_is_banned_in_tests(self) -> None:
+        self.assertEqual(
+            len(_violations('static_assert(sizeof(int) > 0, "ok");', _TEST_PATH)), 1
+        )
+
+    def test_fl_static_assert_is_allowed(self) -> None:
+        self.assertEqual(len(_violations('FL_STATIC_ASSERT(true, "ok");')), 0)
+
+    def test_has_include_is_still_banned(self) -> None:
+        self.assertEqual(len(_violations("#if __has_include(<vector>)")), 1)
+
+    def test_comments_are_ignored(self) -> None:
+        self.assertEqual(len(_violations('// static_assert(true, "ok");')), 0)
+        self.assertEqual(
+            len(_violations('int x = 1; // static_assert(true, "ok");')), 0
+        )
+
+    def test_multiline_comments_are_ignored(self) -> None:
+        self.assertEqual(len(_violations('/*\nstatic_assert(true, "ok");\n*/')), 0)
+
+    def test_definition_file_is_skipped(self) -> None:
+        self.assertFalse(BannedMacrosChecker().should_process_file(_CPP_COMPAT_PATH))
+        self.assertFalse(BannedMacrosChecker().should_process_file(_STATIC_ASSERT_PATH))
+
+    def test_third_party_is_skipped(self) -> None:
+        self.assertFalse(BannedMacrosChecker().should_process_file(_THIRD_PARTY_PATH))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/FastLED.h
+++ b/src/FastLED.h
@@ -1005,7 +1005,7 @@ public:
 		// Instantiate the controller using ClockedChipsetHelper
 		typedef ClockedChipsetHelper<CHIPSET, DATA_PIN, CLOCK_PIN> CHIP;
 		typedef typename CHIP::template CONTROLLER_CLASS_WITH_ORDER_AND_FREQ<RGB_ORDER, SPI_DATA_RATE>::ControllerType ControllerTypeWithFreq;
-		static_assert(CHIP::IS_VALID, "Unsupported chipset");
+		FL_STATIC_ASSERT(CHIP::IS_VALID, "Unsupported chipset");
 		static ControllerTypeWithFreq c;
 		return addLeds(&c, data, nLedsOrOffset, nLedsIfOffset);
 	}
@@ -1014,7 +1014,7 @@ public:
 	template<ESPIChipsets CHIPSET, fl::u8 DATA_PIN, fl::u8 CLOCK_PIN > static ::CLEDController &addLeds(CRGB *data, int nLedsOrOffset, int nLedsIfOffset = 0) {
 		typedef ClockedChipsetHelper<CHIPSET, DATA_PIN, CLOCK_PIN> CHIP;
 		typedef typename CHIP::ControllerType ControllerType;
-		static_assert(CHIP::IS_VALID, "Unsupported chipset");
+		FL_STATIC_ASSERT(CHIP::IS_VALID, "Unsupported chipset");
 		static ControllerType c;
 		return addLeds(&c, data, nLedsOrOffset, nLedsIfOffset);
 	}
@@ -1023,7 +1023,7 @@ public:
 	template<ESPIChipsets CHIPSET, fl::u8 DATA_PIN, fl::u8 CLOCK_PIN, fl::EOrder RGB_ORDER>
 	::CLEDController& addLeds(CRGB* data, int nLedsOrOffset, int nLedsIfOffset = 0) {
 		typedef ClockedChipsetHelper<CHIPSET, DATA_PIN, CLOCK_PIN> CHIP;
-		static_assert(CHIP::IS_VALID, "Unsupported chipset");
+		FL_STATIC_ASSERT(CHIP::IS_VALID, "Unsupported chipset");
 		typedef typename CHIP::template CONTROLLER_CLASS_WITH_ORDER<RGB_ORDER>::ControllerType ControllerTypeWithOrder;
 		static ControllerTypeWithOrder c;
 		return addLeds(&c, data, nLedsOrOffset, nLedsIfOffset);

--- a/src/FastLED.h
+++ b/src/FastLED.h
@@ -149,6 +149,7 @@
 
 
 #include "fl/stl/compiler_control.h"
+#include "fl/stl/static_assert.h"
 #include "cpp_compat.h"
 
 #include "fastled_config.h"
@@ -1004,8 +1005,8 @@ public:
 	template<ESPIChipsets CHIPSET, fl::u8 DATA_PIN, fl::u8 CLOCK_PIN, fl::EOrder RGB_ORDER, fl::u32 SPI_DATA_RATE > ::CLEDController &addLeds(CRGB *data, int nLedsOrOffset, int nLedsIfOffset = 0) {
 		// Instantiate the controller using ClockedChipsetHelper
 		typedef ClockedChipsetHelper<CHIPSET, DATA_PIN, CLOCK_PIN> CHIP;
-		typedef typename CHIP::template CONTROLLER_CLASS_WITH_ORDER_AND_FREQ<RGB_ORDER, SPI_DATA_RATE>::ControllerType ControllerTypeWithFreq;
 		FL_STATIC_ASSERT(CHIP::IS_VALID, "Unsupported chipset");
+		typedef typename CHIP::template CONTROLLER_CLASS_WITH_ORDER_AND_FREQ<RGB_ORDER, SPI_DATA_RATE>::ControllerType ControllerTypeWithFreq;
 		static ControllerTypeWithFreq c;
 		return addLeds(&c, data, nLedsOrOffset, nLedsIfOffset);
 	}
@@ -1013,8 +1014,8 @@ public:
 	/// Add an SPI based CLEDController instance to the world (legacy path).
 	template<ESPIChipsets CHIPSET, fl::u8 DATA_PIN, fl::u8 CLOCK_PIN > static ::CLEDController &addLeds(CRGB *data, int nLedsOrOffset, int nLedsIfOffset = 0) {
 		typedef ClockedChipsetHelper<CHIPSET, DATA_PIN, CLOCK_PIN> CHIP;
-		typedef typename CHIP::ControllerType ControllerType;
 		FL_STATIC_ASSERT(CHIP::IS_VALID, "Unsupported chipset");
+		typedef typename CHIP::ControllerType ControllerType;
 		static ControllerType c;
 		return addLeds(&c, data, nLedsOrOffset, nLedsIfOffset);
 	}

--- a/src/chipsets.h
+++ b/src/chipsets.h
@@ -8,6 +8,7 @@
 #include "pixeltypes.h"
 #include "fl/gfx/five_bit_hd_gamma.h"
 #include "fl/stl/compiler_control.h"
+#include "fl/stl/static_assert.h"
 #include "fl/stl/bit_cast.h"
 #include "fl/stl/unique_ptr.h"
 #include "pixel_iterator.h"

--- a/src/chipsets.h
+++ b/src/chipsets.h
@@ -214,7 +214,7 @@ class RGBWEmulatedController
     static const fl::u32 MASK = CONTROLLER::MASK_VALUE;
 
     // The delegated controller must do no reordering.
-    static_assert(RGB == CONTROLLER::RGB_ORDER_VALUE, "The delegated controller MUST NOT do reordering");
+    FL_STATIC_ASSERT(RGB == CONTROLLER::RGB_ORDER_VALUE, "The delegated controller MUST NOT do reordering");
 
     /// @brief Constructor with optional RGBW configuration
     /// @param rgbw Configuration for RGBW color conversion (defaults to kRGBWExactColors mode)

--- a/src/cpp_compat.h
+++ b/src/cpp_compat.h
@@ -6,19 +6,14 @@
 #ifndef __INC_CPP_COMPAT_H
 #define __INC_CPP_COMPAT_H
 
-#if __cplusplus <= 199711L
+#include "fl/stl/static_assert.h"
 
-/// Compile-time assertion checking, introduced in C++11
-/// @see https://en.cppreference.com/w/cpp/language/static_assert
-#define static_assert(expression, message)
+#if __cplusplus <= 199711L
 
 /// Declares that it is possible to evaluate a value at compile time, introduced in C++11
 /// @see https://en.cppreference.com/w/cpp/language/constexpr
 #define constexpr const
 
-#else
-
-// things that we can turn on if we're in a C++11 environment
 #endif
 
 #include "fl/stl/compiler_control.h"

--- a/src/fl/asset.h
+++ b/src/fl/asset.h
@@ -22,11 +22,12 @@
 /// is future work and intentionally omitted.
 ///
 /// **Compile-time validation:** `FL_ASSET("data/../foo.mp3")` and any path
-/// containing `..` segments is rejected via `static_assert`. The normalized
+/// containing `..` segments is rejected via `FL_STATIC_ASSERT`. The normalized
 /// path is stored verbatim; runtime resolution never walks parent directories.
 
 #include "fl/stl/int.h"
 #include "fl/stl/noexcept.h"
+#include "fl/stl/static_assert.h"
 #include "fl/stl/string.h"
 #include "fl/stl/string_view.h"
 #include "fl/stl/url.h"
@@ -79,7 +80,7 @@ constexpr bool path_has_parent_segment(const char* p) FL_NOEXCEPT {
 ///
 /// Value type: cheap to copy (a single pointer + size). Created via the
 /// `FL_ASSET()` macro or `fl::asset(const char*)` below. The `FL_ASSET()`
-/// macro performs a `static_assert` that the path contains no `..` segments.
+/// macro performs an `FL_STATIC_ASSERT` that the path contains no `..` segments.
 class asset_ref {
   public:
     /// Construct from a pointer to a null-terminated string with known length.
@@ -118,7 +119,7 @@ class asset_ref {
 /// Construct an asset handle from a relative sketch path at runtime.
 ///
 /// For **compile-time rejection** of `..` paths, use the `FL_ASSET()` macro
-/// instead — it wraps this function with a `static_assert`.
+/// instead — it wraps this function with `FL_STATIC_ASSERT`.
 ///
 /// This overload accepts any `const char*` (including runtime-computed
 /// pointers) and, for safety, returns an empty handle if the path contains
@@ -130,7 +131,7 @@ constexpr asset_ref asset(const char* path) FL_NOEXCEPT {
                : asset_ref(path, asset_detail::clen(path));
 }
 
-/// Preferred entry point: rejects `..` at compile time via `static_assert`.
+/// Preferred entry point: rejects `..` at compile time via `FL_STATIC_ASSERT`.
 ///
 /// Use: `fl::UIAudio audio("Audio", FL_ASSET("data/track.mp3"));`
 #define FL_ASSET(LITERAL_PATH)                                                 \

--- a/src/fl/asset.h
+++ b/src/fl/asset.h
@@ -135,7 +135,7 @@ constexpr asset_ref asset(const char* path) FL_NOEXCEPT {
 /// Use: `fl::UIAudio audio("Audio", FL_ASSET("data/track.mp3"));`
 #define FL_ASSET(LITERAL_PATH)                                                 \
     ([]() -> ::fl::asset_ref {                                                 \
-        static_assert(                                                         \
+        FL_STATIC_ASSERT(                                                         \
             !::fl::asset_detail::path_has_parent_segment(LITERAL_PATH),        \
             "fl::asset path must not contain '..' segments");                  \
         return ::fl::asset_ref(                                                \

--- a/src/fl/detail/async_log_queue.h
+++ b/src/fl/detail/async_log_queue.h
@@ -5,6 +5,7 @@
 
 #include "fl/stl/int.h"
 #include "fl/stl/noexcept.h"
+#include "fl/stl/static_assert.h"
 
 namespace fl {
 

--- a/src/fl/detail/async_log_queue.h
+++ b/src/fl/detail/async_log_queue.h
@@ -16,12 +16,12 @@ class string;
 template <fl::size DescriptorCount = 128, fl::size ArenaSize = 4096>
 class AsyncLogQueue {
     // Compile-time assertions for power-of-2 sizes (enables cheap modulo with &)
-    static_assert((DescriptorCount & (DescriptorCount - 1)) == 0,
+    FL_STATIC_ASSERT((DescriptorCount & (DescriptorCount - 1)) == 0,
                   "DescriptorCount must be power of 2");
-    static_assert((ArenaSize & (ArenaSize - 1)) == 0,
+    FL_STATIC_ASSERT((ArenaSize & (ArenaSize - 1)) == 0,
                   "ArenaSize must be power of 2");
-    static_assert(DescriptorCount >= 4, "DescriptorCount must be >= 4");
-    static_assert(ArenaSize >= 32, "ArenaSize must be >= 32");
+    FL_STATIC_ASSERT(DescriptorCount >= 4, "DescriptorCount must be >= 4");
+    FL_STATIC_ASSERT(ArenaSize >= 32, "ArenaSize must be >= 32");
 
 public:
     /// Maximum message length (bounded for ISR safety)

--- a/src/fl/fltest.h
+++ b/src/fl/fltest.h
@@ -27,6 +27,7 @@
 #include "fl/stl/vector.h"
 #include "fl/stl/strstream.h"
 #include "fl/stl/cstring.h"
+#include "fl/stl/static_assert.h"
 
 // Conditionally include <exception> for platforms with exception support
 // This must be at the top of the file (before any namespace declarations)

--- a/src/fl/fltest.h
+++ b/src/fl/fltest.h
@@ -1903,7 +1903,7 @@ struct TypeIterator<TypeList<T, Rest...>, TestFunc> {
                 FLTEST_CAT(id, _REG_)::baseName(), __FILE__, __LINE__, 0);      \
         }                                                                        \
     } FLTEST_UNIQUE(FLTEST_TMPL_INVOKE_INST_);                                  \
-    static_assert(true, "")
+    FL_STATIC_ASSERT(true, "")
 
 // FL_TEST_CASE_TEMPLATE_APPLY - Same as INVOKE but takes a TypeList instead of types
 // Usage: FL_TEST_CASE_TEMPLATE_APPLY(my_test_id, MyTypeList);  // Note: semicolon required
@@ -1915,7 +1915,7 @@ struct TypeIterator<TypeList<T, Rest...>, TestFunc> {
                 FLTEST_CAT(id, _REG_)::baseName(), __FILE__, __LINE__, 0);      \
         }                                                                        \
     } FLTEST_UNIQUE(FLTEST_TMPL_APPLY_INST_);                                   \
-    static_assert(true, "")
+    FL_STATIC_ASSERT(true, "")
 
 // =============================================================================
 // Standalone main implementation macro

--- a/src/fl/fx/2d/noisepalette.cpp.hpp
+++ b/src/fl/fx/2d/noisepalette.cpp.hpp
@@ -1,4 +1,5 @@
 #include "fl/stl/stdint.h"
+#include "fl/stl/static_assert.h"
 
 #ifndef FASTLED_INTERNAL
 #define FASTLED_INTERNAL

--- a/src/fl/fx/2d/noisepalette.cpp.hpp
+++ b/src/fl/fx/2d/noisepalette.cpp.hpp
@@ -18,7 +18,7 @@ namespace fl {
 NoisePalette::NoisePalette(XYMap xyMap, float fps)
     : Fx2d(xyMap), speed(0), scale(0), colorLoop(1), mFps(fps) {
     // currentPalette = PartyColors_p;
-    static_assert(sizeof(currentPalette) == sizeof(CRGBPalette16),
+    FL_STATIC_ASSERT(sizeof(currentPalette) == sizeof(CRGBPalette16),
                   "Palette size mismatch");
     currentPalette = PartyColors_p;
     width = xyMap.getWidth();

--- a/src/fl/math/filter/hampel_filter_impl.h
+++ b/src/fl/math/filter/hampel_filter_impl.h
@@ -5,6 +5,7 @@
 #include "fl/stl/algorithm.h"
 #include "fl/stl/span.h"
 #include "fl/math/filter/div_by_count.h"
+#include "fl/stl/static_assert.h"
 
 namespace fl {
 namespace detail {

--- a/src/fl/math/filter/hampel_filter_impl.h
+++ b/src/fl/math/filter/hampel_filter_impl.h
@@ -11,7 +11,7 @@ namespace detail {
 
 template <typename T, fl::size N = 0>
 class HampelFilterImpl {
-    static_assert(N == 0 || (N % 2 == 1),
+    FL_STATIC_ASSERT(N == 0 || (N % 2 == 1),
                   "HampelFilter: N must be odd for an unambiguous median");
   public:
     explicit HampelFilterImpl(T threshold = T(3.0f))

--- a/src/fl/math/filter/median_filter_impl.h
+++ b/src/fl/math/filter/median_filter_impl.h
@@ -11,7 +11,7 @@ namespace detail {
 
 template <typename T, fl::size N = 0>
 class MedianFilterImpl {
-    static_assert(N == 0 || (N % 2 == 1),
+    FL_STATIC_ASSERT(N == 0 || (N % 2 == 1),
                   "MedianFilter: N must be odd for an unambiguous median");
   public:
     MedianFilterImpl() FL_NOEXCEPT : mSortedCount(0), mLastMedian(T(0)) {}

--- a/src/fl/math/filter/median_filter_impl.h
+++ b/src/fl/math/filter/median_filter_impl.h
@@ -5,6 +5,7 @@
 #include "fl/stl/algorithm.h"
 #include "fl/stl/span.h"
 #include "fl/stl/noexcept.h"
+#include "fl/stl/static_assert.h"
 
 namespace fl {
 namespace detail {

--- a/src/fl/math/filter/savitzky_golay_filter_impl.h
+++ b/src/fl/math/filter/savitzky_golay_filter_impl.h
@@ -11,7 +11,7 @@ namespace detail {
 
 template <typename T, fl::size N = 0>
 class SavitzkyGolayFilterImpl {
-    static_assert(N == 0 || (N % 2 == 1),
+    FL_STATIC_ASSERT(N == 0 || (N % 2 == 1),
                   "SavitzkyGolayFilter: N must be odd for symmetric polynomial fit");
   public:
     SavitzkyGolayFilterImpl() FL_NOEXCEPT : mLastValue(T(0)) {}

--- a/src/fl/math/filter/savitzky_golay_filter_impl.h
+++ b/src/fl/math/filter/savitzky_golay_filter_impl.h
@@ -5,6 +5,7 @@
 #include "fl/math/filter/div_by_count.h"
 #include "fl/stl/span.h"
 #include "fl/stl/noexcept.h"
+#include "fl/stl/static_assert.h"
 
 namespace fl {
 namespace detail {

--- a/src/fl/math/filter/triangular_filter_impl.h
+++ b/src/fl/math/filter/triangular_filter_impl.h
@@ -11,7 +11,7 @@ namespace detail {
 
 template <typename T, fl::size N = 0>
 class TriangularFilterImpl {
-    static_assert(N == 0 || (N % 2 == 1),
+    FL_STATIC_ASSERT(N == 0 || (N % 2 == 1),
                   "TriangularFilter: N must be odd for a symmetric tent shape");
   public:
     TriangularFilterImpl() FL_NOEXCEPT : mLastValue(T(0)) {}

--- a/src/fl/math/filter/triangular_filter_impl.h
+++ b/src/fl/math/filter/triangular_filter_impl.h
@@ -5,6 +5,7 @@
 #include "fl/math/math.h"
 #include "fl/stl/span.h"
 #include "fl/stl/noexcept.h"
+#include "fl/stl/static_assert.h"
 
 namespace fl {
 namespace detail {

--- a/src/fl/math/fixed_point/traits.h
+++ b/src/fl/math/fixed_point/traits.h
@@ -140,7 +140,7 @@ struct fixed_point_traits {
     // Compile-time overflow safety checks
     // Verify intermediate_type can hold worst-case products for operator*
     // raw_max * raw_max needs 2*TOTAL_BITS bits
-    static_assert(sizeof(intermediate_type) * 8 >= TOTAL_BITS * 2,
+    FL_STATIC_ASSERT(sizeof(intermediate_type) * 8 >= TOTAL_BITS * 2,
                   "intermediate_type too narrow for operator* overflow safety");
 
     // Verify poly_intermediate_type can hold polynomial products
@@ -150,7 +150,7 @@ struct fixed_point_traits {
     // Max product: ~1.5 * 2^IFRAC * 2^IFRAC = ~1.5 * 2^(2*IFRAC)
     // For i32: needs 2*IFRAC + 1 <= 31, so IFRAC <= 15 (but we use i64 for multiply, safe)
     // For i64: needs 2*IFRAC + 1 <= 63, so IFRAC <= 31 (all our types fit)
-    static_assert((IFRAC <= 16 && sizeof(poly_intermediate_type) * 8 >= 32) ||
+    FL_STATIC_ASSERT((IFRAC <= 16 && sizeof(poly_intermediate_type) * 8 >= 32) ||
                   (IFRAC > 16 && sizeof(poly_intermediate_type) * 8 >= 64),
                   "poly_intermediate_type insufficient for polynomial evaluation");
 };

--- a/src/fl/math/fixed_point/traits.h
+++ b/src/fl/math/fixed_point/traits.h
@@ -6,6 +6,7 @@
 #include "fl/stl/stdint.h"
 #include "fl/stl/type_traits.h"
 #include "fl/stl/noexcept.h"
+#include "fl/stl/static_assert.h"
 
 namespace fl {
 

--- a/src/fl/math/screenmap.cpp.hpp
+++ b/src/fl/math/screenmap.cpp.hpp
@@ -14,6 +14,7 @@
 // IWYU pragma: begin_keep
 #include "fl/stl/function.h"
 // IWYU pragma: end_keep  // ~5ms - only needed for function<> constructor implementation
+#include "fl/stl/static_assert.h"
 
 // Other implementation dependencies
 #include "fl/math/math.h"

--- a/src/fl/math/screenmap.cpp.hpp
+++ b/src/fl/math/screenmap.cpp.hpp
@@ -40,7 +40,7 @@ fl::vector<float> jsonArrayToFloatVector(const fl::json& jsonArray) {
     auto end_float = jsonArray.end_array<float>();
 
     using T = decltype(*begin_float);
-    static_assert(fl::is_same<T, fl::parse_result<float>>::value, "Value type must be parse_result<float>");
+    FL_STATIC_ASSERT(fl::is_same<T, fl::parse_result<float>>::value, "Value type must be parse_result<float>");
     
     // Use explicit array iterator style as demonstrated in FEATURE.md
     // DO NOT CHANGE THIS CODE. FIX THE IMPLIMENTATION IF NECESSARY.

--- a/src/fl/stl/allocator.h
+++ b/src/fl/stl/allocator.h
@@ -10,6 +10,7 @@
 #include "fl/stl/malloc.h"
 #include "fl/stl/align.h"
 #include "fl/stl/noexcept.h"
+#include "fl/stl/static_assert.h"
 
 #ifndef FASTLED_DEFAULT_SLAB_SIZE
 #define FASTLED_DEFAULT_SLAB_SIZE 8

--- a/src/fl/stl/allocator.h
+++ b/src/fl/stl/allocator.h
@@ -270,7 +270,7 @@ class allocator_realloc {
 private:
     // SAFETY CHECK: Compile-time verification that T is trivially copyable
     // This prevents undefined behavior from using realloc() with non-trivially-copyable types
-    static_assert(fl::is_trivially_copyable<T>::value,
+    FL_STATIC_ASSERT(fl::is_trivially_copyable<T>::value,
         "allocator_realloc<T> requires T to be trivially copyable. "
         "NOTE: This allocator is now redundant - fl::allocator<T> automatically "
         "optimizes trivially copyable types. Just use fl::vector<T> instead.");

--- a/src/fl/stl/bit_cast.h
+++ b/src/fl/stl/bit_cast.h
@@ -11,6 +11,7 @@
 #include "fl/stl/cstring.h"
 #include "fl/stl/int.h"
 #include "fl/stl/noexcept.h"
+#include "fl/stl/static_assert.h"
 
 namespace fl {
 

--- a/src/fl/stl/bit_cast.h
+++ b/src/fl/stl/bit_cast.h
@@ -45,9 +45,9 @@ struct is_bitcast_compatible<T*> {
 // Compilers recognize this pattern and optimize it to a single register move.
 template <typename To, typename From>
 To bit_cast(const From& from) FL_NOEXCEPT {
-    static_assert(sizeof(To) == sizeof(From), "bit_cast: types must have the same size");
-    static_assert(is_bitcast_compatible<To>::value, "bit_cast: destination type must be bitcast compatible");
-    static_assert(is_bitcast_compatible<From>::value, "bit_cast: source type must be bitcast compatible");
+    FL_STATIC_ASSERT(sizeof(To) == sizeof(From), "bit_cast: types must have the same size");
+    FL_STATIC_ASSERT(is_bitcast_compatible<To>::value, "bit_cast: destination type must be bitcast compatible");
+    FL_STATIC_ASSERT(is_bitcast_compatible<From>::value, "bit_cast: source type must be bitcast compatible");
 
     To to;
     fl::memcpy(&to, &from, sizeof(To));

--- a/src/fl/stl/bitset.h
+++ b/src/fl/stl/bitset.h
@@ -3,6 +3,7 @@
 #include "fl/stl/variant.h"
 #include "fl/stl/bitset_dynamic.h"
 #include "fl/stl/int.h"
+#include "fl/stl/static_assert.h"
 
 #include "fl/stl/compiler_control.h"
 #include "fl/stl/move.h"

--- a/src/fl/stl/bitset.h
+++ b/src/fl/stl/bitset.h
@@ -41,7 +41,7 @@ inline fl::u8 countr_zero(IntType value) FL_NOEXCEPT {
 /// A simple fixed-size Bitset implementation similar to std::Bitset.
 template <fl::u32 N> class bitset_fixed {
   private:
-    static_assert(sizeof(fl::u16) == 2, "u16 should be 2 bytes");
+    FL_STATIC_ASSERT(sizeof(fl::u16) == 2, "u16 should be 2 bytes");
     static constexpr fl::u32 bits_per_block = 8 * sizeof(fl::u16);
     static constexpr fl::u32 block_count =
         (N + bits_per_block - 1) / bits_per_block;

--- a/src/fl/stl/charconv.h
+++ b/src/fl/stl/charconv.h
@@ -57,7 +57,7 @@ fl::string hex(u64 value, HexIntWidth width, bool is_negative, bool uppercase, b
 /// @brief Compile-time integer width determination (default - triggers error)
 template<size_t Size>
 constexpr HexIntWidth get_hex_int_width() FL_NOEXCEPT {
-    static_assert(Size == 0, "Unsupported type size for hex conversion");
+    FL_STATIC_ASSERT(Size == 0, "Unsupported type size for hex conversion");
     return HexIntWidth::Width8; // Unreachable, but needed for compilation
 }
 

--- a/src/fl/stl/charconv.h
+++ b/src/fl/stl/charconv.h
@@ -12,6 +12,7 @@
 #include "fl/stl/stdint.h"  // For u64, uint8_t
 #include "fl/stl/cstddef.h" // For fl::size_t
 #include "fl/stl/noexcept.h"
+#include "fl/stl/static_assert.h"
 
 namespace fl {
 

--- a/src/fl/stl/function.h
+++ b/src/fl/stl/function.h
@@ -85,9 +85,9 @@ private:
         
         template <typename Function>
         InlinedLambda(Function f) FL_NOEXCEPT {
-            static_assert(sizeof(Function) <= kInlineLambdaSize, 
+            FL_STATIC_ASSERT(sizeof(Function) <= kInlineLambdaSize,
                          "Lambda/functor too large for inline storage");
-            static_assert(alignof(Function) <= alignof(max_align_t), 
+            FL_STATIC_ASSERT(alignof(Function) <= alignof(max_align_t),
                          "Lambda/functor requires stricter alignment than storage provides");
             
             // Initialize the entire storage to zero to avoid copying uninitialized memory
@@ -175,7 +175,7 @@ private:
         template <typename C>
         NonConstMemberCallable(C* o, R (C::*mf)(Args...)) FL_NOEXCEPT : obj(o) {
             // Store the member function pointer as raw bytes
-            static_assert(sizeof(mf) <= sizeof(member_func_storage), 
+            FL_STATIC_ASSERT(sizeof(mf) <= sizeof(member_func_storage),
                          "Member function pointer too large");
             fl::memcpy(member_func_storage.bytes, &mf, sizeof(mf));
             // Set the invoker to a function that knows how to cast back and call
@@ -211,7 +211,7 @@ private:
         template <typename C>
         ConstMemberCallable(const C* o, R (C::*mf)(Args...) const) FL_NOEXCEPT : obj(o) {
             // Store the member function pointer as raw bytes
-            static_assert(sizeof(mf) <= sizeof(member_func_storage), 
+            FL_STATIC_ASSERT(sizeof(mf) <= sizeof(member_func_storage),
                          "Member function pointer too large");
             fl::memcpy(member_func_storage.bytes, &mf, sizeof(mf));
             // Set the invoker to a function that knows how to cast back and call
@@ -354,7 +354,7 @@ private:
 // Only specializations for function signatures (e.g., function_list<void(Args...)>) are valid
 template <typename T>
 class function_list {
-    static_assert(fl::is_same<T, void>::value && !fl::is_same<T, void>::value,
+    FL_STATIC_ASSERT(fl::is_same<T, void>::value && !fl::is_same<T, void>::value,
                   "function_list requires a void returning function signature.");
 };
 
@@ -509,7 +509,7 @@ class function_list<void(Args...)> {
 // Triggers a compile-time error when attempting to use non-void return types
 template <typename R, typename... Args>
 class function_list<R(Args...)> {
-    static_assert(fl::is_same<R, void>::value,
+    FL_STATIC_ASSERT(fl::is_same<R, void>::value,
                   "function_list only supports void return type. "
                   "Use function_list<void(Args...)> instead of function_list<ReturnType(Args...)>.");
 };

--- a/src/fl/stl/function.h
+++ b/src/fl/stl/function.h
@@ -10,6 +10,7 @@
 #include "fl/stl/vector.h"
 #include "fl/stl/algorithm.h"  // for fl::sort
 #include "fl/stl/noexcept.h"
+#include "fl/stl/static_assert.h"
 
 #ifndef FASTLED_INLINE_LAMBDA_SIZE
 #define FASTLED_INLINE_LAMBDA_SIZE 64

--- a/src/fl/stl/hash.h
+++ b/src/fl/stl/hash.h
@@ -105,7 +105,7 @@ static inline u32 fast_hash64(u64 x) FL_NOEXCEPT {
 //-----------------------------------------------------------------------------
 // https://github.com/aappleby/smhasher/blob/master/src/MurmurHash3.cpp
 template <typename T> struct Hash {
-    static_assert(fl::is_pod<T>::value,
+    FL_STATIC_ASSERT(fl::is_pod<T>::value,
                   "fl::Hash<T> only supports POD types (integrals, floats, "
                   "etc.), you need to define your own hash.");
     u32 operator()(const T &key) const FL_NOEXCEPT {
@@ -114,7 +114,7 @@ template <typename T> struct Hash {
 };
 
 template <typename T> struct FastHash {
-    static_assert(fl::is_pod<T>::value,
+    FL_STATIC_ASSERT(fl::is_pod<T>::value,
                   "fl::FastHash<T> only supports POD types (integrals, floats, "
                   "etc.), you need to define your own hash.");
     u32 operator()(const T &key) const FL_NOEXCEPT {

--- a/src/fl/stl/hash.h
+++ b/src/fl/stl/hash.h
@@ -6,6 +6,7 @@
 #include "fl/stl/bit_cast.h"
 #include "fl/stl/string.h"
 #include "fl/stl/noexcept.h"
+#include "fl/stl/static_assert.h"
 
 namespace fl {
 

--- a/src/fl/stl/noexcept.h
+++ b/src/fl/stl/noexcept.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "fl/stl/static_assert.h"
+
 // FL_NOEXCEPT: intentionally a noop on all platforms.
 // noexcept was causing too many platform compatibility issues (AVR, WASM, etc.)
 // so it is disabled everywhere until a robust cross-platform solution is found.

--- a/src/fl/stl/noexcept.h
+++ b/src/fl/stl/noexcept.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include "fl/stl/static_assert.h"
-
 // FL_NOEXCEPT: intentionally a noop on all platforms.
 // noexcept was causing too many platform compatibility issues (AVR, WASM, etc.)
 // so it is disabled everywhere until a robust cross-platform solution is found.

--- a/src/fl/stl/not_null.h
+++ b/src/fl/stl/not_null.h
@@ -151,10 +151,10 @@ private:
     T mPtr;  // Underlying pointer (mCamelCase naming per FastLED standards)
 
     // Static assertions to enforce template constraints
-    static_assert(detail::is_comparable_to_nullptr<T>::value,
+    FL_STATIC_ASSERT(detail::is_comparable_to_nullptr<T>::value,
                   "not_null<T>: T must be comparable to nullptr");
 
-    static_assert(!detail::is_reference<T>::value,
+    FL_STATIC_ASSERT(!detail::is_reference<T>::value,
                   "not_null<T>: T must not be a reference type");
 
 public:

--- a/src/fl/stl/not_null.h
+++ b/src/fl/stl/not_null.h
@@ -48,6 +48,7 @@
 #include "fl/stl/type_traits.h"
 #include "fl/stl/cstddef.h"
 #include "fl/stl/noexcept.h"
+#include "fl/stl/static_assert.h"
 
 // Forward declarations to break circular dependency with assert.h
 // not_null needs assertions, but assert.h might need not_null in the future

--- a/src/fl/stl/pair.h
+++ b/src/fl/stl/pair.h
@@ -4,6 +4,7 @@
 #include "fl/stl/compiler_control.h"
 #include "fl/stl/type_traits.h"
 #include "fl/stl/noexcept.h"
+#include "fl/stl/static_assert.h"
 
 namespace fl {
 

--- a/src/fl/stl/pair.h
+++ b/src/fl/stl/pair.h
@@ -112,7 +112,7 @@ struct pair_element<1, T1, T2> {
 // get function overloads for tuple-like access by index
 template <fl::size I, typename T1, typename T2>
 typename pair_element<I, T1, T2>::type& get(pair<T1, T2> &p) FL_NOEXCEPT {
-    static_assert(I < 2, "Index out of bounds for pair");
+    FL_STATIC_ASSERT(I < 2, "Index out of bounds for pair");
     if (I == 0) {
         return p.first;
     } else {
@@ -122,7 +122,7 @@ typename pair_element<I, T1, T2>::type& get(pair<T1, T2> &p) FL_NOEXCEPT {
 
 template <fl::size I, typename T1, typename T2>
 const typename pair_element<I, T1, T2>::type& get(const pair<T1, T2> &p) FL_NOEXCEPT {
-    static_assert(I < 2, "Index out of bounds for pair");
+    FL_STATIC_ASSERT(I < 2, "Index out of bounds for pair");
     if (I == 0) {
         return p.first;
     } else {
@@ -132,7 +132,7 @@ const typename pair_element<I, T1, T2>::type& get(const pair<T1, T2> &p) FL_NOEX
 
 template <fl::size I, typename T1, typename T2>
 typename pair_element<I, T1, T2>::type&& get(pair<T1, T2> &&p) FL_NOEXCEPT {
-    static_assert(I < 2, "Index out of bounds for pair");
+    FL_STATIC_ASSERT(I < 2, "Index out of bounds for pair");
     if (I == 0) {
         return fl::move(p.first);
     } else {
@@ -143,9 +143,9 @@ typename pair_element<I, T1, T2>::type&& get(pair<T1, T2> &&p) FL_NOEXCEPT {
 // get by type overloads (when T1 and T2 are different types)
 template <typename T, typename T1, typename T2>
 T& get(pair<T1, T2> &p) FL_NOEXCEPT {
-    static_assert(fl::is_same<T, T1>::value || fl::is_same<T, T2>::value, 
+    FL_STATIC_ASSERT(fl::is_same<T, T1>::value || fl::is_same<T, T2>::value,
                   "Type T must be one of the pair's element types");
-    static_assert(!(fl::is_same<T, T1>::value && fl::is_same<T, T2>::value), 
+    FL_STATIC_ASSERT(!(fl::is_same<T, T1>::value && fl::is_same<T, T2>::value),
                   "Type T must be unique in the pair");
     if (fl::is_same<T, T1>::value) {
         return p.first;
@@ -156,9 +156,9 @@ T& get(pair<T1, T2> &p) FL_NOEXCEPT {
 
 template <typename T, typename T1, typename T2>
 const T& get(const pair<T1, T2> &p) FL_NOEXCEPT {
-    static_assert(fl::is_same<T, T1>::value || fl::is_same<T, T2>::value, 
+    FL_STATIC_ASSERT(fl::is_same<T, T1>::value || fl::is_same<T, T2>::value,
                   "Type T must be one of the pair's element types");
-    static_assert(!(fl::is_same<T, T1>::value && fl::is_same<T, T2>::value), 
+    FL_STATIC_ASSERT(!(fl::is_same<T, T1>::value && fl::is_same<T, T2>::value),
                   "Type T must be unique in the pair");
     if (fl::is_same<T, T1>::value) {
         return p.first;
@@ -169,9 +169,9 @@ const T& get(const pair<T1, T2> &p) FL_NOEXCEPT {
 
 template <typename T, typename T1, typename T2>
 T&& get(pair<T1, T2> &&p) FL_NOEXCEPT {
-    static_assert(fl::is_same<T, T1>::value || fl::is_same<T, T2>::value, 
+    FL_STATIC_ASSERT(fl::is_same<T, T1>::value || fl::is_same<T, T2>::value,
                   "Type T must be one of the pair's element types");
-    static_assert(!(fl::is_same<T, T1>::value && fl::is_same<T, T2>::value), 
+    FL_STATIC_ASSERT(!(fl::is_same<T, T1>::value && fl::is_same<T, T2>::value),
                   "Type T must be unique in the pair");
     if (fl::is_same<T, T1>::value) {
         return fl::move(p.first);

--- a/src/fl/stl/ratio.h
+++ b/src/fl/stl/ratio.h
@@ -7,6 +7,7 @@
 /// used primarily for duration period types in fl::chrono.
 
 #include "fl/stl/int.h"
+#include "fl/stl/static_assert.h"
 
 namespace fl {
 

--- a/src/fl/stl/ratio.h
+++ b/src/fl/stl/ratio.h
@@ -18,7 +18,7 @@ namespace fl {
 /// Used for duration period types (e.g., milliseconds = 1/1000 second).
 template<fl::i64 Num, fl::i64 Denom = 1>
 struct ratio {
-    static_assert(Denom != 0, "ratio denominator cannot be zero");
+    FL_STATIC_ASSERT(Denom != 0, "ratio denominator cannot be zero");
 
     static constexpr fl::i64 num = Num;
     static constexpr fl::i64 den = Denom;

--- a/src/fl/stl/static_assert.h
+++ b/src/fl/stl/static_assert.h
@@ -1,0 +1,78 @@
+#pragma once
+
+/// @file static_assert.h
+/// Portable compile-time assertion wrapper.
+
+#if __cplusplus <= 199711L
+
+namespace fl {
+template <bool> struct static_assert_failure;
+template <> struct static_assert_failure<true> {};
+} // namespace fl
+
+#define FL_STATIC_ASSERT_JOIN_IMPL(a, b) a##b
+#define FL_STATIC_ASSERT_JOIN(a, b) FL_STATIC_ASSERT_JOIN_IMPL(a, b)
+#ifdef __COUNTER__
+#define FL_STATIC_ASSERT_NAME FL_STATIC_ASSERT_JOIN(fl_static_assert_, __COUNTER__)
+#else
+#define FL_STATIC_ASSERT_NAME FL_STATIC_ASSERT_JOIN(fl_static_assert_, __LINE__)
+#endif
+#define FL_STATIC_ASSERT_IMPL(expression)                                      \
+    typedef char FL_STATIC_ASSERT_NAME[sizeof(                                \
+        ::fl::static_assert_failure<(bool)(expression)>)]
+#define FL_STATIC_ASSERT_SELECT(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10,     \
+                                _11, _12, _13, _14, _15, _16, NAME, ...)     \
+    NAME
+#define FL_STATIC_ASSERT_EXPR_1(expression) expression
+#define FL_STATIC_ASSERT_EXPR_2(expression, message) expression
+#define FL_STATIC_ASSERT_EXPR_3(a, b, message) a, b
+#define FL_STATIC_ASSERT_EXPR_4(a, b, c, message) a, b, c
+#define FL_STATIC_ASSERT_EXPR_5(a, b, c, d, message) a, b, c, d
+#define FL_STATIC_ASSERT_EXPR_6(a, b, c, d, e, message) a, b, c, d, e
+#define FL_STATIC_ASSERT_EXPR_7(a, b, c, d, e, f, message) a, b, c, d, e, f
+#define FL_STATIC_ASSERT_EXPR_8(a, b, c, d, e, f, g, message) a, b, c, d, e, \
+    f, g
+#define FL_STATIC_ASSERT_EXPR_9(a, b, c, d, e, f, g, h, message) a, b, c, d, \
+    e, f, g, h
+#define FL_STATIC_ASSERT_EXPR_10(a, b, c, d, e, f, g, h, i, message) a, b, c, \
+    d, e, f, g, h, i
+#define FL_STATIC_ASSERT_EXPR_11(a, b, c, d, e, f, g, h, i, j, message) a, b, \
+    c, d, e, f, g, h, i, j
+#define FL_STATIC_ASSERT_EXPR_12(a, b, c, d, e, f, g, h, i, j, k, message) a, \
+    b, c, d, e, f, g, h, i, j, k
+#define FL_STATIC_ASSERT_EXPR_13(a, b, c, d, e, f, g, h, i, j, k, l,         \
+                                 message)                                     \
+    a, b, c, d, e, f, g, h, i, j, k, l
+#define FL_STATIC_ASSERT_EXPR_14(a, b, c, d, e, f, g, h, i, j, k, l, m,      \
+                                 message)                                     \
+    a, b, c, d, e, f, g, h, i, j, k, l, m
+#define FL_STATIC_ASSERT_EXPR_15(a, b, c, d, e, f, g, h, i, j, k, l, m, n,   \
+                                 message)                                     \
+    a, b, c, d, e, f, g, h, i, j, k, l, m, n
+#define FL_STATIC_ASSERT_EXPR_16(a, b, c, d, e, f, g, h, i, j, k, l, m, n,   \
+                                 o, message)                                  \
+    a, b, c, d, e, f, g, h, i, j, k, l, m, n, o
+#define FL_STATIC_ASSERT_EXPR(...)                                            \
+    FL_STATIC_ASSERT_SELECT(__VA_ARGS__, FL_STATIC_ASSERT_EXPR_16,            \
+                            FL_STATIC_ASSERT_EXPR_15,                         \
+                            FL_STATIC_ASSERT_EXPR_14,                         \
+                            FL_STATIC_ASSERT_EXPR_13,                         \
+                            FL_STATIC_ASSERT_EXPR_12,                         \
+                            FL_STATIC_ASSERT_EXPR_11,                         \
+                            FL_STATIC_ASSERT_EXPR_10,                         \
+                            FL_STATIC_ASSERT_EXPR_9, FL_STATIC_ASSERT_EXPR_8, \
+                            FL_STATIC_ASSERT_EXPR_7, FL_STATIC_ASSERT_EXPR_6, \
+                            FL_STATIC_ASSERT_EXPR_5, FL_STATIC_ASSERT_EXPR_4, \
+                            FL_STATIC_ASSERT_EXPR_3, FL_STATIC_ASSERT_EXPR_2, \
+                            FL_STATIC_ASSERT_EXPR_1)(__VA_ARGS__)
+
+// Template commas split macro arguments on old preprocessors. Drop the message
+// argument, then rejoin the remaining tokens as the assertion expression.
+#define FL_STATIC_ASSERT(...)                                                 \
+    FL_STATIC_ASSERT_IMPL((FL_STATIC_ASSERT_EXPR(__VA_ARGS__)))
+
+#else
+
+#define FL_STATIC_ASSERT(...) static_assert(__VA_ARGS__)
+
+#endif

--- a/src/fl/stl/string.cpp.hpp
+++ b/src/fl/stl/string.cpp.hpp
@@ -11,6 +11,7 @@
 #include "fl/gfx/crgb.h"                 // for CRGB
 #include "fl/gfx/tile2x2.h"
 #include "fl/stl/compiler_control.h"
+#include "fl/stl/static_assert.h"
 #include "fl/math/xymap.h"
 // UI dependency moved to separate compilation unit to break dependency chain
 

--- a/src/fl/stl/string.cpp.hpp
+++ b/src/fl/stl/string.cpp.hpp
@@ -84,9 +84,9 @@ void string::swap(string &other) {
 }
 
 void string::compileTimeAssertions() {
-    static_assert(FASTLED_STR_INLINED_SIZE > 0,
+    FL_STATIC_ASSERT(FASTLED_STR_INLINED_SIZE > 0,
                   "FASTLED_STR_INLINED_SIZE must be greater than 0");
-    static_assert(FASTLED_STR_INLINED_SIZE == kStrInlineSize,
+    FL_STATIC_ASSERT(FASTLED_STR_INLINED_SIZE == kStrInlineSize,
                   "If you want to change the FASTLED_STR_INLINED_SIZE, then it "
                   "must be through a build define and not an include define.");
 }

--- a/src/fl/stl/type_traits.cpp.hpp
+++ b/src/fl/stl/type_traits.cpp.hpp
@@ -13,112 +13,112 @@ FL_DISABLE_WARNING(unused-function)
 // typetrait test
 namespace {
 FL_MAYBE_UNUSED void __compile_test() {
-    static_assert(fl::is_integral<int>::value, "int should be integral");
-    static_assert(fl::is_integral<float>::value == false,
+    FL_STATIC_ASSERT(fl::is_integral<int>::value, "int should be integral");
+    FL_STATIC_ASSERT(fl::is_integral<float>::value == false,
                   "float should not be integral");
-    static_assert(fl::is_integral<bool>::value, "bool should be integral");
-    static_assert(fl::is_integral<char>::value, "char should be integral");
-    static_assert(fl::is_integral<unsigned char>::value,
+    FL_STATIC_ASSERT(fl::is_integral<bool>::value, "bool should be integral");
+    FL_STATIC_ASSERT(fl::is_integral<char>::value, "char should be integral");
+    FL_STATIC_ASSERT(fl::is_integral<unsigned char>::value,
                   "unsigned char should be integral");
-    static_assert(fl::is_integral<signed char>::value,
+    FL_STATIC_ASSERT(fl::is_integral<signed char>::value,
                   "signed char should be integral");
-    static_assert(fl::is_integral<short>::value, "short should be integral");
-    static_assert(fl::is_integral<unsigned short>::value,
+    FL_STATIC_ASSERT(fl::is_integral<short>::value, "short should be integral");
+    FL_STATIC_ASSERT(fl::is_integral<unsigned short>::value,
                   "unsigned short should be integral");
-    static_assert(fl::is_integral<long>::value, "long should be integral");
-    static_assert(fl::is_integral<unsigned long>::value,
+    FL_STATIC_ASSERT(fl::is_integral<long>::value, "long should be integral");
+    FL_STATIC_ASSERT(fl::is_integral<unsigned long>::value,
                   "unsigned long should be integral");
-    static_assert(fl::is_integral<long long>::value,
+    FL_STATIC_ASSERT(fl::is_integral<long long>::value,
                   "long long should be integral");
-    static_assert(fl::is_integral<unsigned long long>::value,
+    FL_STATIC_ASSERT(fl::is_integral<unsigned long long>::value,
                   "unsigned long long should be integral");
-    static_assert(fl::is_integral<int *>::value == false,
+    FL_STATIC_ASSERT(fl::is_integral<int *>::value == false,
                   "int* should not be integral");
-    static_assert(fl::is_integral<float *>::value == false,
+    FL_STATIC_ASSERT(fl::is_integral<float *>::value == false,
                   "float* should not be integral");
-    static_assert(fl::is_integral<void>::value == false,
+    FL_STATIC_ASSERT(fl::is_integral<void>::value == false,
                   "void should not be integral");
-    static_assert(fl::is_integral<void *>::value == false,
+    FL_STATIC_ASSERT(fl::is_integral<void *>::value == false,
                   "void* should not be integral");
-    static_assert(fl::is_integral<const int>::value,
+    FL_STATIC_ASSERT(fl::is_integral<const int>::value,
                   "const int should be integral");
-    static_assert(fl::is_integral<const float>::value == false,
+    FL_STATIC_ASSERT(fl::is_integral<const float>::value == false,
                   "const float should not be integral");
-    static_assert(fl::is_integral<const char>::value,
+    FL_STATIC_ASSERT(fl::is_integral<const char>::value,
                   "const char should be integral");
-    static_assert(fl::is_integral<const unsigned char>::value,
+    FL_STATIC_ASSERT(fl::is_integral<const unsigned char>::value,
                   "const unsigned char should be integral");
-    static_assert(fl::is_integral<const signed char>::value,
+    FL_STATIC_ASSERT(fl::is_integral<const signed char>::value,
                   "const signed char should be integral");
-    static_assert(fl::is_integral<const short>::value,
+    FL_STATIC_ASSERT(fl::is_integral<const short>::value,
                   "const short should be integral");
-    static_assert(fl::is_integral<const unsigned short>::value,
+    FL_STATIC_ASSERT(fl::is_integral<const unsigned short>::value,
                   "const unsigned short should be integral");
-    static_assert(fl::is_integral<const long>::value,
+    FL_STATIC_ASSERT(fl::is_integral<const long>::value,
                   "const long should be integral");
-    static_assert(fl::is_integral<const unsigned long>::value,
+    FL_STATIC_ASSERT(fl::is_integral<const unsigned long>::value,
                   "const unsigned long should be integral");
-    static_assert(fl::is_integral<const long long>::value,
+    FL_STATIC_ASSERT(fl::is_integral<const long long>::value,
                   "const long long should be integral");
-    static_assert(fl::is_integral<const unsigned long long>::value,
+    FL_STATIC_ASSERT(fl::is_integral<const unsigned long long>::value,
                   "const unsigned long long should be integral");
 
     // volatile
-    static_assert(fl::is_integral<volatile int>::value,
+    FL_STATIC_ASSERT(fl::is_integral<volatile int>::value,
                   "volatile int should be integral");
-    static_assert(fl::is_integral<volatile float>::value == false,
+    FL_STATIC_ASSERT(fl::is_integral<volatile float>::value == false,
                   "volatile float should not be integral");
-    static_assert(fl::is_integral<volatile char>::value,
+    FL_STATIC_ASSERT(fl::is_integral<volatile char>::value,
                   "volatile char should be integral");
 
     // ref
-    static_assert(fl::is_integral<unsigned char &>::value,
+    FL_STATIC_ASSERT(fl::is_integral<unsigned char &>::value,
                   "unsigned char& should be integral");
-    static_assert(fl::is_integral<const unsigned char &>::value,
+    FL_STATIC_ASSERT(fl::is_integral<const unsigned char &>::value,
                   "const unsigned char& should be integral");
 
     // fixed width int types from fl/int.h
-    static_assert(fl::is_integral<fl::i8>::value, "i8 should be integral");
-    static_assert(fl::is_integral<fl::u8>::value,
+    FL_STATIC_ASSERT(fl::is_integral<fl::i8>::value, "i8 should be integral");
+    FL_STATIC_ASSERT(fl::is_integral<fl::u8>::value,
                   "u8 should be integral");
-    static_assert(fl::is_integral<fl::i16>::value,
+    FL_STATIC_ASSERT(fl::is_integral<fl::i16>::value,
                   "i16 should be integral");
-    static_assert(fl::is_integral<fl::u16>::value,
+    FL_STATIC_ASSERT(fl::is_integral<fl::u16>::value,
                   "u16 should be integral");
-    static_assert(fl::is_integral<fl::i32>::value,
+    FL_STATIC_ASSERT(fl::is_integral<fl::i32>::value,
                   "i32 should be integral");
-    static_assert(fl::is_integral<fl::u32>::value,
+    FL_STATIC_ASSERT(fl::is_integral<fl::u32>::value,
                   "u32 should be integral");
-    static_assert(fl::is_integral<fl::i64>::value,
+    FL_STATIC_ASSERT(fl::is_integral<fl::i64>::value,
                   "fl::i64 should be integral");
-    static_assert(fl::is_integral<fl::u64>::value,
+    FL_STATIC_ASSERT(fl::is_integral<fl::u64>::value,
                   "fl::u64 should be integral");
-    static_assert(fl::is_integral<fl::i8 *>::value == false,
+    FL_STATIC_ASSERT(fl::is_integral<fl::i8 *>::value == false,
                   "i8* should not be integral");
-    static_assert(fl::is_integral<fl::u8 *>::value == false,
+    FL_STATIC_ASSERT(fl::is_integral<fl::u8 *>::value == false,
                   "u8* should not be integral");
-    static_assert(fl::is_integral<fl::uint>::value,
+    FL_STATIC_ASSERT(fl::is_integral<fl::uint>::value,
                   "uint should be integral");
 
     // fixed width int types from fl/stl/stdint.h
-    static_assert(fl::is_integral<fl::i8>::value, "fl::i8 should be integral");
-    static_assert(fl::is_integral<fl::u8>::value,
+    FL_STATIC_ASSERT(fl::is_integral<fl::i8>::value, "fl::i8 should be integral");
+    FL_STATIC_ASSERT(fl::is_integral<fl::u8>::value,
                   "fl::u8 should be integral");
-    static_assert(fl::is_integral<fl::i16>::value,
+    FL_STATIC_ASSERT(fl::is_integral<fl::i16>::value,
                   "fl::i16 should be integral");
-    static_assert(fl::is_integral<fl::u16>::value,
+    FL_STATIC_ASSERT(fl::is_integral<fl::u16>::value,
                   "fl::u16 should be integral");
-    static_assert(fl::is_integral<fl::i32>::value,
+    FL_STATIC_ASSERT(fl::is_integral<fl::i32>::value,
                   "fl::i32 should be integral");
-    static_assert(fl::is_integral<fl::u32>::value,
+    FL_STATIC_ASSERT(fl::is_integral<fl::u32>::value,
                   "fl::u32 should be integral");
-    static_assert(fl::is_integral<i64>::value,
+    FL_STATIC_ASSERT(fl::is_integral<i64>::value,
                   "i64 should be integral");
-    static_assert(fl::is_integral<u64>::value,
+    FL_STATIC_ASSERT(fl::is_integral<u64>::value,
                   "u64 should be integral");
-    static_assert(fl::is_integral<fl::i8 *>::value == false,
+    FL_STATIC_ASSERT(fl::is_integral<fl::i8 *>::value == false,
                   "fl::i8* should not be integral");
-    static_assert(fl::is_integral<fl::u8 *>::value == false,
+    FL_STATIC_ASSERT(fl::is_integral<fl::u8 *>::value == false,
                   "fl::u8* should not be integral");
 }
 } // namespace

--- a/src/fl/stl/type_traits.cpp.hpp
+++ b/src/fl/stl/type_traits.cpp.hpp
@@ -2,6 +2,7 @@
 #include "fl/stl/type_traits.h"
 #include "fl/stl/int.h"
 #include "fl/stl/compiler_control.h"
+#include "fl/stl/static_assert.h"
 
 FL_DISABLE_WARNING_PUSH
 FL_DISABLE_WARNING(unused-function)

--- a/src/fl/stl/type_traits.h
+++ b/src/fl/stl/type_traits.h
@@ -237,7 +237,7 @@ constexpr T &&forward(typename remove_reference<T>::type &t) FL_NOEXCEPT {
 // Overload for rvalue references
 template <typename T>
 constexpr T &&forward(typename remove_reference<T>::type &&t) FL_NOEXCEPT {
-    static_assert(!is_lvalue_reference<T>::value,
+    FL_STATIC_ASSERT(!is_lvalue_reference<T>::value,
                   "Cannot forward an rvalue as an lvalue");
     return static_cast<T &&>(t);
 }
@@ -611,7 +611,7 @@ template <> struct unsigned_by_size<8> { using type = unsigned long long; };
 template <typename T, typename Enable = void>
 struct make_unsigned {
     // Dependent false to delay static_assert until instantiation
-    static_assert(is_integral<T>::value && !is_same<typename remove_cv<T>::type, bool>::value,
+    FL_STATIC_ASSERT(is_integral<T>::value && !is_same<typename remove_cv<T>::type, bool>::value,
                   "make_unsigned requires a non-bool integral type");
 };
 

--- a/src/fl/stl/type_traits.h
+++ b/src/fl/stl/type_traits.h
@@ -7,6 +7,7 @@ Provides eanble_if and is_derived for compilers before C++14.
 #include "fl/stl/move.h"
 #include "fl/stl/int.h"
 #include "fl/stl/noexcept.h"
+#include "fl/stl/static_assert.h"
 
 namespace fl { // mandatory namespace to prevent name collision with
                // std::enable_if.

--- a/src/fl/stl/unique_ptr.h
+++ b/src/fl/stl/unique_ptr.h
@@ -11,7 +11,7 @@ namespace fl {
 template<typename T>
 struct default_delete {
     void operator()(T* ptr) const FL_NOEXCEPT {
-        static_assert(sizeof(T) > 0,
+        FL_STATIC_ASSERT(sizeof(T) > 0,
             "Cannot delete pointer to incomplete type. "
             "Ensure the type is fully defined where unique_ptr destructor is instantiated.");
         delete ptr;

--- a/src/fl/stl/unique_ptr.h
+++ b/src/fl/stl/unique_ptr.h
@@ -5,6 +5,7 @@
 #include "fl/stl/stdint.h"        // for fl::size_t  // IWYU pragma: keep
 #include "fl/stl/cstddef.h"       // for fl::nullptr_t
 #include "fl/stl/noexcept.h"
+#include "fl/stl/static_assert.h"
 
 namespace fl {
 

--- a/src/fl/stl/vector.h
+++ b/src/fl/stl/vector.h
@@ -18,6 +18,7 @@
 #include "fl/stl/align.h"
 #include "fl/stl/compiler_control.h"
 #include "fl/stl/basic_vector.h"
+#include "fl/stl/static_assert.h"
 #include "fl/stl/noexcept.h"
 
 namespace fl {

--- a/src/fl/stl/vector.h
+++ b/src/fl/stl/vector.h
@@ -111,7 +111,7 @@ class FL_ALIGN FixedVector {
     }
 
     template <fl::size M> FixedVector(T (&values)[M]) FL_NOEXCEPT : current_size(0) {
-        static_assert(M <= N, "Too many elements for FixedVector");
+        FL_STATIC_ASSERT(M <= N, "Too many elements for FixedVector");
         assign_array(values, M);
     }
 

--- a/src/fl/system/fastpin_base.h
+++ b/src/fl/system/fastpin_base.h
@@ -9,6 +9,7 @@
 #include "platforms/is_platform.h"
 #include "fl/stl/compiler_control.h"
 #include "fl/stl/noexcept.h"
+#include "fl/stl/static_assert.h"
 
 FL_DISABLE_WARNING_PUSH
 FL_DISABLE_WARNING_DEPRECATED_REGISTER

--- a/src/fl/system/fastpin_base.h
+++ b/src/fl/system/fastpin_base.h
@@ -142,7 +142,7 @@ template<fl::u8 PIN> class FastPin {
         return false; // choosing default to be FALSE, to allow users to ATTEMPT to use high-speed on pins where support is not known
     }
 
-	static_assert(validpin(), "This pin has been marked as an invalid pin, common reasons includes it being a ground pin, read only, or too noisy (e.g. hooked up to the uart).");
+	FL_STATIC_ASSERT(validpin(), "This pin has been marked as an invalid pin, common reasons includes it being a ground pin, read only, or too noisy (e.g. hooked up to the uart).");
 
 	static void _init() FL_NOEXCEPT { }
 

--- a/src/pixel_controller.h
+++ b/src/pixel_controller.h
@@ -135,8 +135,8 @@ struct PixelController {
 
     template<typename PixelControllerT>
     void copy(const PixelControllerT& other) {
-        static_assert(int(kLanes) == int(PixelControllerT::kLanes), "PixelController lanes must match or mOffsets will be wrong");
-        static_assert(int(kMask) == int(PixelControllerT::kMask), "PixelController mask must match or else one or the other controls different lanes");
+        FL_STATIC_ASSERT(int(kLanes) == int(PixelControllerT::kLanes), "PixelController lanes must match or mOffsets will be wrong");
+        FL_STATIC_ASSERT(int(kMask) == int(PixelControllerT::kMask), "PixelController mask must match or else one or the other controls different lanes");
         d[0] = other.d[0];
         d[1] = other.d[1];
         d[2] = other.d[2];

--- a/src/pixel_controller.h
+++ b/src/pixel_controller.h
@@ -17,6 +17,7 @@
 #include "rgbw.h"
 #include "fl/gfx/five_bit_hd_gamma.h"
 #include "fl/stl/compiler_control.h"
+#include "fl/stl/static_assert.h"
 #include "fl/math/scale8.h"
 #include "fl/math/math8.h"
 #include "eorder.h"

--- a/src/platforms/arm/common/m0clockless_c.h
+++ b/src/platforms/arm/common/m0clockless_c.h
@@ -27,6 +27,7 @@
  ******************************************************************************/
 
 #include "fl/stl/compiler_control.h"
+#include "fl/stl/static_assert.h"
 #include "fl/stl/stdint.h"
 #include "fl/chipsets/timing_traits.h"
 #include "fl/stl/noexcept.h"
@@ -335,9 +336,9 @@ int showLedData(volatile fl::u32* port, fl::u32 bitmask,
                 M0ClocklessData* pData) FL_NOEXCEPT {
 
     // Compile-time validation of GPIO offsets
-    static_assert((HI_OFFSET & 3) == 0 && (LO_OFFSET & 3) == 0,
+    FL_STATIC_ASSERT((HI_OFFSET & 3) == 0 && (LO_OFFSET & 3) == 0,
                   "HI_OFFSET and LO_OFFSET must be 4-byte aligned");
-    static_assert(HI_OFFSET != LO_OFFSET,
+    FL_STATIC_ASSERT(HI_OFFSET != LO_OFFSET,
                   "HI_OFFSET and LO_OFFSET must be different");
 
     // Convert timing values from nanoseconds to CPU cycles at compile-time

--- a/src/platforms/arm/compile_test.hpp
+++ b/src/platforms/arm/compile_test.hpp
@@ -4,6 +4,7 @@
 
 #define FASTLED_INTERNAL  
 #include "FastLED.h"
+#include "fl/stl/static_assert.h"
 
 namespace fl {
 static void arm_compile_tests() {
@@ -119,7 +120,7 @@ static void arm_compile_tests() {
 #if defined(STM32F1) || defined(__STM32F1__) || defined(STM32F1xx)
     // Static assert to ensure we're aware of memory constraints
     // STM32F103C8 has only 64KB flash and 20KB RAM
-    static_assert(sizeof(void*) == 4, "STM32F1 should be 32-bit platform");
+    FL_STATIC_ASSERT(sizeof(void*) == 4, "STM32F1 should be 32-bit platform");
     
     // Compile-time check for sketch memory usage awareness
     #if SKETCH_HAS_LARGE_MEMORY != 0

--- a/src/platforms/arm/k20/clockless_block_arm_k20.h
+++ b/src/platforms/arm/k20/clockless_block_arm_k20.h
@@ -24,6 +24,7 @@
 #include <kinetis.h>
 // IWYU pragma: end_keep
 #include "fl/stl/compiler_control.h"
+#include "fl/stl/static_assert.h"
 #include "fl/stl/noexcept.h"
 
 FL_DISABLE_WARNING_PUSH
@@ -231,7 +232,7 @@ class SixteenWayInlineBlockClocklessController : public CPixelLEDController<RGB_
 
 public:
 	virtual void init() FL_NOEXCEPT {
-		static_assert(LANES <= 16, "Maximum of 16 lanes for Teensy parallel controllers!");
+		FL_STATIC_ASSERT(LANES <= 16, "Maximum of 16 lanes for Teensy parallel controllers!");
 		// FastPin<30>::setOutput();
 		// FastPin<29>::setOutput();
 		// FastPin<27>::setOutput();

--- a/src/platforms/arm/k66/clockless_block_arm_k66.h
+++ b/src/platforms/arm/k66/clockless_block_arm_k66.h
@@ -30,6 +30,7 @@
 #include <kinetis.h>
 // IWYU pragma: end_keep
 #include "fl/stl/compiler_control.h"
+#include "fl/stl/static_assert.h"
 #include "fl/stl/noexcept.h"
 
 FL_DISABLE_WARNING_PUSH
@@ -248,7 +249,7 @@ class SixteenWayInlineBlockClocklessController : public CPixelLEDController<RGB_
 
 public:
 	virtual void init() FL_NOEXCEPT {
-		static_assert(LANES <= 16, "Maximum of 16 lanes for Teensy parallel controllers!");
+		FL_STATIC_ASSERT(LANES <= 16, "Maximum of 16 lanes for Teensy parallel controllers!");
 		// FastPin<30>::setOutput();
 		// FastPin<29>::setOutput();
 		// FastPin<27>::setOutput();

--- a/src/platforms/arm/nrf52/arbiter_nrf52.h
+++ b/src/platforms/arm/nrf52/arbiter_nrf52.h
@@ -10,6 +10,7 @@
 
 #include "platforms/arm/nrf52/led_sysdefs_arm_nrf52.h"
 #include "fl/stl/noexcept.h"
+#include "fl/stl/static_assert.h"
 
 typedef void (*FASTLED_NRF52_PWM_INTERRUPT_HANDLER)();
 
@@ -36,12 +37,12 @@ typedef enum _FASTLED_NRF52_ENABLED_PWM_INSTANCE { // ok plain enum
     FASTLED_NRF52_PWM_INSTANCE_COUNT
 } FASTLED_NRF52_ENABLED_PWM_INSTANCES;
 
-static_assert(FASTLED_NRF52_PWM_INSTANCE_COUNT > 0, "Instance count must be greater than zero -- define FASTLED_NRF52_ENABLE_PWM_INSTNACE[n] (replace `[n]` with digit)");
+FL_STATIC_ASSERT(FASTLED_NRF52_PWM_INSTANCE_COUNT > 0, "Instance count must be greater than zero -- define FASTLED_NRF52_ENABLE_PWM_INSTNACE[n] (replace `[n]` with digit)");
 
 template <fl::u32 _PWM_ID>
 class PWM_Arbiter {
 private:
-    static_assert(_PWM_ID < 32, "PWM_ID over 31 breaks current arbitration bitmask");
+    FL_STATIC_ASSERT(_PWM_ID < 32, "PWM_ID over 31 breaks current arbitration bitmask");
     //const  uint32_t _ACQUIRE_MASK =             (1u << _PWM_ID) ;
     //const  uint32_t _CLEAR_MASK   = ~((uint32_t)(1u << _PWM_ID));
     static fl::u32                              s_PwmInUse;

--- a/src/platforms/arm/nrf52/clockless_arm_nrf52.h
+++ b/src/platforms/arm/nrf52/clockless_arm_nrf52.h
@@ -13,6 +13,7 @@
 
 #include "eorder.h"
 #include "fl/stl/noexcept.h"
+#include "fl/stl/static_assert.h"
 namespace fl {
 
 #define FL_CLOCKLESS_CONTROLLER_DEFINED 1
@@ -36,17 +37,17 @@ class ClocklessController : public CPixelLEDController<_RGB_ORDER> {
     static constexpr int _T2 = (TIMING::T2 * (CLOCKLESS_FREQUENCY / 1000000UL) + 500) / 1000;
     static constexpr int _T3 = (TIMING::T3 * (CLOCKLESS_FREQUENCY / 1000000UL) + 500) / 1000;
 
-    static_assert(FASTLED_NRF52_MAXIMUM_PIXELS_PER_STRING > 0, "Maximum string length must be positive value (FASTLED_NRF52_MAXIMUM_PIXELS_PER_STRING)");
-    static_assert(_T1         >             0 , "negative values are not allowed");
-    static_assert(_T2         >             0 , "negative values are not allowed");
-    static_assert(_T3         >             0 , "negative values are not allowed");
-    static_assert(_T1         <  (0x8000u-2u), "_T1 must fit in 15 bits");
-    static_assert(_T2         <  (0x8000u-2u), "_T2 must fit in 15 bits");
-    static_assert(_T3         <  (0x8000u-2u), "_T3 must fit in 15 bits");
-    static_assert(_T1         <  (0x8000u-2u), "_T0H must fit in 15 bits");
-    static_assert(_T1+_T2     <  (0x8000u-2u), "_T1H must fit in 15 bits");
-    static_assert(_T1+_T2+_T3 <  (0x8000u-2u), "_TOP must fit in 15 bits");
-    static_assert(_T1+_T2+_T3 <= PWM_COUNTERTOP_COUNTERTOP_Msk, "_TOP too large for peripheral");
+    FL_STATIC_ASSERT(FASTLED_NRF52_MAXIMUM_PIXELS_PER_STRING > 0, "Maximum string length must be positive value (FASTLED_NRF52_MAXIMUM_PIXELS_PER_STRING)");
+    FL_STATIC_ASSERT(_T1         >             0 , "negative values are not allowed");
+    FL_STATIC_ASSERT(_T2         >             0 , "negative values are not allowed");
+    FL_STATIC_ASSERT(_T3         >             0 , "negative values are not allowed");
+    FL_STATIC_ASSERT(_T1         <  (0x8000u-2u), "_T1 must fit in 15 bits");
+    FL_STATIC_ASSERT(_T2         <  (0x8000u-2u), "_T2 must fit in 15 bits");
+    FL_STATIC_ASSERT(_T3         <  (0x8000u-2u), "_T3 must fit in 15 bits");
+    FL_STATIC_ASSERT(_T1         <  (0x8000u-2u), "_T0H must fit in 15 bits");
+    FL_STATIC_ASSERT(_T1+_T2     <  (0x8000u-2u), "_T1H must fit in 15 bits");
+    FL_STATIC_ASSERT(_T1+_T2+_T3 <  (0x8000u-2u), "_TOP must fit in 15 bits");
+    FL_STATIC_ASSERT(_T1+_T2+_T3 <= PWM_COUNTERTOP_COUNTERTOP_Msk, "_TOP too large for peripheral");
 
 private:
     static const bool     _INITIALIZE_PIN_HIGH = (_FLIP ? 1 : 0);

--- a/src/platforms/arm/nrf52/fastspi_arm_nrf52.h
+++ b/src/platforms/arm/nrf52/fastspi_arm_nrf52.h
@@ -4,6 +4,7 @@
 #define __FASTSPI_ARM_NRF52_H
 
 #include "fl/stl/compiler_control.h"
+#include "fl/stl/static_assert.h"
 #include "fl/system/fastpin_base.h"
 #include "fastspi_types.h"
 #include "fl/gfx/eorder.h"
@@ -125,8 +126,8 @@ namespace fl {
         NRF52HardwareSPIOutput() {}
 
         // Low frequency GPIO is for signals with a frequency up to 10 kHz.  Lowest speed SPIM is 125kbps.
-        static_assert(!FastPin<_DATA_PIN>::LowSpeedOnlyRecommended(),  "Invalid (low-speed only) pin specified");
-        static_assert(!FastPin<_CLOCK_PIN>::LowSpeedOnlyRecommended(), "Invalid (low-speed only) pin specified");
+        FL_STATIC_ASSERT(!FastPin<_DATA_PIN>::LowSpeedOnlyRecommended(),  "Invalid (low-speed only) pin specified");
+        FL_STATIC_ASSERT(!FastPin<_CLOCK_PIN>::LowSpeedOnlyRecommended(), "Invalid (low-speed only) pin specified");
 
         /// initialize the SPI subssytem
         void init() FL_NOEXCEPT {

--- a/src/platforms/arm/sam/clockless_block_arm_sam.h
+++ b/src/platforms/arm/sam/clockless_block_arm_sam.h
@@ -8,6 +8,7 @@
 #include "bitswap.h"
 #include "platforms/arm/sam/is_sam.h"
 #include "fl/stl/compiler_control.h"
+#include "fl/stl/static_assert.h"
 #include "fl/stl/noexcept.h"
 
 FL_DISABLE_WARNING_PUSH
@@ -57,7 +58,7 @@ class InlineBlockClocklessController : public CPixelLEDController<RGB_ORDER, LAN
 public:
 	virtual int size() { return CLEDController::size() * LANES; }
 	virtual void init() FL_NOEXCEPT {
-        static_assert(LANES <= 8, "Maximum of 8 lanes for Due parallel controllers!");
+        FL_STATIC_ASSERT(LANES <= 8, "Maximum of 8 lanes for Due parallel controllers!");
         if(FIRST_PIN == PORTA_FIRST_PIN) {
             switch(LANES) {
                 case 8: FastPin<31>::setOutput();

--- a/src/platforms/arm/stm32/fastspi_arm_stm32.h
+++ b/src/platforms/arm/stm32/fastspi_arm_stm32.h
@@ -17,6 +17,7 @@
 #include "fastspi_types.h"
 #include "platforms/arm/stm32/is_stm32.h"
 #include "fl/stl/compiler_control.h"
+#include "fl/stl/static_assert.h"
 #include "fl/stl/noexcept.h"
 
 FL_DISABLE_WARNING_PUSH
@@ -60,8 +61,8 @@ private:
 
 public:
     // Verify that the pins are valid
-    static_assert(FastPin<DATA_PIN>::validpin(), "Invalid data pin specified");
-    static_assert(FastPin<CLOCK_PIN>::validpin(), "Invalid clock pin specified");
+    FL_STATIC_ASSERT(FastPin<DATA_PIN>::validpin(), "Invalid data pin specified");
+    FL_STATIC_ASSERT(FastPin<CLOCK_PIN>::validpin(), "Invalid clock pin specified");
 
     STM32SPIOutput()
         : mPSelect(nullptr)

--- a/src/platforms/arm/teensy/teensy31_32/clockless_block_arm_k20.h
+++ b/src/platforms/arm/teensy/teensy31_32/clockless_block_arm_k20.h
@@ -26,6 +26,7 @@
 #include <kinetis.h>
 // IWYU pragma: end_keep
 #include "fl/stl/compiler_control.h"
+#include "fl/stl/static_assert.h"
 #include "fl/stl/noexcept.h"
 
 FL_DISABLE_WARNING_PUSH
@@ -225,7 +226,7 @@ class SixteenWayInlineBlockClocklessController : public CPixelLEDController<RGB_
 
 public:
 	virtual void init() FL_NOEXCEPT {
-		static_assert(LANES <= 16, "Maximum of 16 lanes for Teensy parallel controllers!");
+		FL_STATIC_ASSERT(LANES <= 16, "Maximum of 16 lanes for Teensy parallel controllers!");
 		// FastPin<30>::setOutput();
 		// FastPin<29>::setOutput();
 		// FastPin<27>::setOutput();

--- a/src/platforms/arm/teensy/teensy36/clockless_block_arm_k66.h
+++ b/src/platforms/arm/teensy/teensy36/clockless_block_arm_k66.h
@@ -30,6 +30,7 @@
 #include <kinetis.h>
 // IWYU pragma: end_keep
 #include "fl/stl/compiler_control.h"
+#include "fl/stl/static_assert.h"
 #include "fl/stl/noexcept.h"
 
 FL_DISABLE_WARNING_PUSH
@@ -240,7 +241,7 @@ class SixteenWayInlineBlockClocklessController : public CPixelLEDController<RGB_
 
 public:
 	virtual void init() FL_NOEXCEPT {
-		static_assert(LANES <= 16, "Maximum of 16 lanes for Teensy parallel controllers!");
+		FL_STATIC_ASSERT(LANES <= 16, "Maximum of 16 lanes for Teensy parallel controllers!");
 		// FastPin<30>::setOutput();
 		// FastPin<29>::setOutput();
 		// FastPin<27>::setOutput();

--- a/src/platforms/avr/attiny/clockless_blocking.h
+++ b/src/platforms/avr/attiny/clockless_blocking.h
@@ -13,6 +13,7 @@
 #include <avr/interrupt.h> // for cli/sei definitions
 // IWYU pragma: end_keep
 #include "fl/stl/compiler_control.h"
+#include "fl/stl/static_assert.h"
 #include "fl/stl/compiler_control.h"
 #include "fl/system/fastpin.h"
 #include "platforms/avr/is_avr.h"
@@ -167,7 +168,7 @@ class ClocklessController : public CPixelLEDController<RGB_ORDER> {
 	static constexpr u32 T2 = (TIMING::T2 * (F_CPU / 1000000UL) + 500) / 1000;
 	static constexpr u32 T3 = (TIMING::T3 * (F_CPU / 1000000UL) + 500) / 1000;
 
-	static_assert(T1 >= 2 && T2 >= 2 && T3 >= 3, "Not enough cycles - use a higher clock speed");
+	FL_STATIC_ASSERT(T1 >= 2 && T2 >= 2 && T3 >= 3, "Not enough cycles - use a higher clock speed");
 
 	typedef typename FastPin<DATA_PIN>::port_ptr_t data_ptr_t;
 	typedef typename FastPin<DATA_PIN>::port_t data_t;

--- a/src/platforms/avr/attiny/clockless_blocking_controller.h
+++ b/src/platforms/avr/attiny/clockless_blocking_controller.h
@@ -9,6 +9,7 @@
 #include <avr/interrupt.h> // for cli/se definitions
 // IWYU pragma: end_keep
 #include "fl/stl/compiler_control.h"
+#include "fl/stl/static_assert.h"
 #include "fl/chipsets/led_timing.h"
 #include "fl/chipsets/timing_traits.h"
 #include "fastled_delay.h"
@@ -155,7 +156,7 @@ static u8 gTimeErrorAccum256ths;
 
 template <u8 DATA_PIN, int T1, int T2, int T3, EOrder RGB_ORDER = RGB, int XTRA0 = 0, bool FLIP = false, int WAIT_TIME = 10>
 class ClocklessController : public CPixelLEDController<RGB_ORDER> {
-	static_assert(T1 >= 2 && T2 >= 2 && T3 >= 3, "Not enough cycles - use a higher clock speed");
+	FL_STATIC_ASSERT(T1 >= 2 && T2 >= 2 && T3 >= 3, "Not enough cycles - use a higher clock speed");
 
 	typedef typename FastPin<DATA_PIN>::port_ptr_t data_ptr_t;
 	typedef typename FastPin<DATA_PIN>::port_t data_t;

--- a/src/platforms/avr/clockless_avr.h
+++ b/src/platforms/avr/clockless_avr.h
@@ -9,6 +9,7 @@
 #include <avr/interrupt.h> // for cli/se definitions
 // IWYU pragma: end_keep
 #include "fl/stl/compiler_control.h"
+#include "fl/stl/static_assert.h"
 #include "fl/chipsets/led_timing.h"
 #include "fl/chipsets/timing_traits.h"
 #include "fastled_delay.h"
@@ -224,7 +225,7 @@ class ClocklessController : public CPixelLEDController<RGB_ORDER> {
 	static constexpr u32 T2 = (TIMING::T2 * (F_CPU / 1000000UL) + 500) / 1000;
 	static constexpr u32 T3 = (TIMING::T3 * (F_CPU / 1000000UL) + 500) / 1000;
 
-	static_assert(T1 >= 2 && T2 >= 2 && T3 >= 3, "Not enough cycles - use a higher clock speed");
+	FL_STATIC_ASSERT(T1 >= 2 && T2 >= 2 && T3 >= 3, "Not enough cycles - use a higher clock speed");
 
 	typedef typename FastPin<DATA_PIN>::port_ptr_t data_ptr_t;
 	typedef typename FastPin<DATA_PIN>::port_t data_t;

--- a/src/platforms/compile_test.cpp.hpp
+++ b/src/platforms/compile_test.cpp.hpp
@@ -2,6 +2,7 @@
 #define FASTLED_INTERNAL  
 #include "fl/fastled.h"
 #include "fl/stl/int.h"
+#include "fl/stl/static_assert.h"
 #include "fl/stl/stdint.h"
 #include "fl/stl/type_traits.h"
 
@@ -90,29 +91,29 @@ FL_MAYBE_UNUSED static void test_strstream_integer_operators() FL_NOEXCEPT {
 // any compile-time errors if the platform is not configured correctly.
 FL_MAYBE_UNUSED static void compile_tests() FL_NOEXCEPT {
 
-    static_assert(fl::is_same<u32, u32>::value, "u32 must be the same type as u32");
-    static_assert(fl::is_same<u16, u16>::value, "u16 must be the same type as u16");
-    static_assert(fl::is_same<u8, u8>::value, "u8 must be the same type as u8");
-    static_assert(fl::is_same<i32, i32>::value, "i32 must be the same type as i32");
-    static_assert(fl::is_same<i16, i16>::value, "i16 must be the same type as i16");
-    static_assert(fl::is_same<i8, i8>::value, "i8 must be the same type as i8");
-    static_assert(fl::is_same<size, size_t>::value, "size must be the same type as size_t");
-    static_assert(fl::is_same<uptr, uintptr_t>::value, "uptr must be the same type as uintptr_t");
+    FL_STATIC_ASSERT(fl::is_same<u32, u32>::value, "u32 must be the same type as u32");
+    FL_STATIC_ASSERT(fl::is_same<u16, u16>::value, "u16 must be the same type as u16");
+    FL_STATIC_ASSERT(fl::is_same<u8, u8>::value, "u8 must be the same type as u8");
+    FL_STATIC_ASSERT(fl::is_same<i32, i32>::value, "i32 must be the same type as i32");
+    FL_STATIC_ASSERT(fl::is_same<i16, i16>::value, "i16 must be the same type as i16");
+    FL_STATIC_ASSERT(fl::is_same<i8, i8>::value, "i8 must be the same type as i8");
+    FL_STATIC_ASSERT(fl::is_same<size, size_t>::value, "size must be the same type as size_t");
+    FL_STATIC_ASSERT(fl::is_same<uptr, uintptr_t>::value, "uptr must be the same type as uintptr_t");
 
     // Test sstream integer operator overloads
     test_strstream_integer_operators();
 
     // Size assertions for FastLED integer types
-    static_assert(sizeof(i8) == 1, "i8 must be exactly 1 byte");
-    static_assert(sizeof(u8) == 1, "u8 must be exactly 1 byte");
-    static_assert(sizeof(i16) == 2, "i16 must be exactly 2 bytes");
-    static_assert(sizeof(u16) == 2, "u16 must be exactly 2 bytes");
-    static_assert(sizeof(i32) == 4, "i32 must be exactly 4 bytes");
-    static_assert(sizeof(u32) == 4, "u32 must be exactly 4 bytes");
-    static_assert(sizeof(i64) == 8, "i64 must be exactly 8 bytes");
-    static_assert(sizeof(u64) == 8, "u64 must be exactly 8 bytes");
-    static_assert(sizeof(uptr) == sizeof(uintptr_t), "uptr must be exactly the same size as uintptr_t");
-    static_assert(sizeof(size) == sizeof(size_t), "size must be exactly the same size as size_t");
+    FL_STATIC_ASSERT(sizeof(i8) == 1, "i8 must be exactly 1 byte");
+    FL_STATIC_ASSERT(sizeof(u8) == 1, "u8 must be exactly 1 byte");
+    FL_STATIC_ASSERT(sizeof(i16) == 2, "i16 must be exactly 2 bytes");
+    FL_STATIC_ASSERT(sizeof(u16) == 2, "u16 must be exactly 2 bytes");
+    FL_STATIC_ASSERT(sizeof(i32) == 4, "i32 must be exactly 4 bytes");
+    FL_STATIC_ASSERT(sizeof(u32) == 4, "u32 must be exactly 4 bytes");
+    FL_STATIC_ASSERT(sizeof(i64) == 8, "i64 must be exactly 8 bytes");
+    FL_STATIC_ASSERT(sizeof(u64) == 8, "u64 must be exactly 8 bytes");
+    FL_STATIC_ASSERT(sizeof(uptr) == sizeof(uintptr_t), "uptr must be exactly the same size as uintptr_t");
+    FL_STATIC_ASSERT(sizeof(size) == sizeof(size_t), "size must be exactly the same size as size_t");
 
 #if defined(__AVR__)
     avr_compile_tests();
@@ -128,7 +129,7 @@ FL_MAYBE_UNUSED static void compile_tests() FL_NOEXCEPT {
     stub_compile_tests();
 #else
     // No platform-specific tests available for this platform
-    static_assert(false, "Unknown platform - no compile tests available");
+    FL_STATIC_ASSERT(false, "Unknown platform - no compile tests available");
 #endif
 }
 }

--- a/src/platforms/esp/32/clockless_block_esp32.h
+++ b/src/platforms/esp/32/clockless_block_esp32.h
@@ -4,6 +4,7 @@
 #define __INC_CLOCKLESS_BLOCK_ESP8266_H
 
 #include "fl/stl/stdint.h"
+#include "fl/stl/static_assert.h"
 #include "platforms/esp/32/core/clock_cycles.h"
 #include "esp_intr_alloc.h"
 #include "eorder.h"
@@ -67,7 +68,7 @@ class InlineBlockClocklessController : public CPixelLEDController<RGB_ORDER, LAN
     };
 
 	// Verify that the pin is valid
-	static_assert(FastPin<FIRST_PIN>::validpin(), "This pin has been marked as an invalid pin, common reasons includes it being a ground pin, read only, or too noisy (e.g. hooked up to the uart).");
+	FL_STATIC_ASSERT(FastPin<FIRST_PIN>::validpin(), "This pin has been marked as an invalid pin, common reasons includes it being a ground pin, read only, or too noisy (e.g. hooked up to the uart).");
 
 	data_t mPinMask;
     data_ptr_t mPort;

--- a/src/platforms/esp/32/core/fastpin_esp32.h
+++ b/src/platforms/esp/32/core/fastpin_esp32.h
@@ -5,6 +5,7 @@
 #include "platforms/esp/is_esp.h"
 
 #include "fl/stl/stdint.h"
+#include "fl/stl/static_assert.h"
 
 #include "fl/stl/compiler_control.h"
 #include "platforms/esp/esp_version.h"
@@ -37,7 +38,7 @@ public:
   #endif
 
   inline static void setOutput() FL_NOEXCEPT {
-      static_assert(validpin(), "This pin has been marked as an invalid pin, common reasons includes it being a ground pin, read only, or too noisy (e.g. hooked up to the uart).");
+      FL_STATIC_ASSERT(validpin(), "This pin has been marked as an invalid pin, common reasons includes it being a ground pin, read only, or too noisy (e.g. hooked up to the uart).");
       pinMode(PIN, PinMode::Output);
   }
   inline static void setInput() { pinMode(PIN, PinMode::Input); }

--- a/src/platforms/esp/32/core/fastspi_esp32_arduino.h
+++ b/src/platforms/esp/32/core/fastspi_esp32_arduino.h
@@ -13,6 +13,7 @@
 #include <SPI.h>
 // IWYU pragma: end_keep
 #include "fl/stl/compiler_control.h"
+#include "fl/stl/static_assert.h"
 #include "fl/stl/noexcept.h"
 
 FL_DISABLE_WARNING_PUSH
@@ -124,8 +125,8 @@ class ESP32SPIOutput {
 
 public:
 	// Verify that the pins are valid
-	static_assert(FastPin<DATA_PIN>::validpin(), "Invalid data pin specified");
-	static_assert(FastPin<CLOCK_PIN>::validpin(), "Invalid clock pin specified");
+	FL_STATIC_ASSERT(FastPin<DATA_PIN>::validpin(), "Invalid data pin specified");
+	FL_STATIC_ASSERT(FastPin<CLOCK_PIN>::validpin(), "Invalid clock pin specified");
 
 	ESP32SPIOutput() :
 	  mLedSPI(FASTLED_ESP32_SPI_BUS),

--- a/src/platforms/esp/32/core/fastspi_esp32_idf.h
+++ b/src/platforms/esp/32/core/fastspi_esp32_idf.h
@@ -10,6 +10,7 @@
 #include "crgb.h"
 #include "fastspi_types.h"
 #include "fl/stl/bit_cast.h"
+#include "fl/stl/static_assert.h"
 #include "fl/stl/cstring.h"  // For fl::memset
 #include "fl/system/log.h"  // For FL_WARN macro
 
@@ -52,8 +53,8 @@ class ESP32SPIOutput {
 
 public:
     // Verify that the pins are valid
-    static_assert(FastPin<DATA_PIN>::validpin(), "Invalid data pin specified");
-    static_assert(FastPin<CLOCK_PIN>::validpin(), "Invalid clock pin specified");
+    FL_STATIC_ASSERT(FastPin<DATA_PIN>::validpin(), "Invalid data pin specified");
+    FL_STATIC_ASSERT(FastPin<CLOCK_PIN>::validpin(), "Invalid clock pin specified");
 
     ESP32SPIOutput()
         : mSPIHandle(nullptr)

--- a/src/platforms/esp/32/drivers/gpio_isr_rx/dual_isr_context.h
+++ b/src/platforms/esp/32/drivers/gpio_isr_rx/dual_isr_context.h
@@ -28,7 +28,9 @@
  */
 
 #include "fl/stl/stdint.h"  // IWYU pragma: keep
+#ifdef __cplusplus
 #include "fl/stl/static_assert.h"
+#endif
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/platforms/esp/32/drivers/gpio_isr_rx/dual_isr_context.h
+++ b/src/platforms/esp/32/drivers/gpio_isr_rx/dual_isr_context.h
@@ -28,6 +28,7 @@
  */
 
 #include "fl/stl/stdint.h"  // IWYU pragma: keep
+#include "fl/stl/static_assert.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -55,8 +56,8 @@ typedef struct __attribute__((packed, aligned(4))) {
 
 // Static assertions for structure layout (C11/C++11 compatible)
 #ifdef __cplusplus
-static_assert(sizeof(EdgeEntry) == 8, "EdgeEntry must be exactly 8 bytes");
-static_assert(alignof(EdgeEntry) == 4, "EdgeEntry must be 4-byte aligned");
+FL_STATIC_ASSERT(sizeof(EdgeEntry) == 8, "EdgeEntry must be exactly 8 bytes");
+FL_STATIC_ASSERT(alignof(EdgeEntry) == 4, "EdgeEntry must be 4-byte aligned");
 #else
 _Static_assert(sizeof(EdgeEntry) == 8, "EdgeEntry must be exactly 8 bytes");
 _Static_assert(_Alignof(EdgeEntry) == 4, "EdgeEntry must be 4-byte aligned");
@@ -265,8 +266,8 @@ typedef struct __attribute__((aligned(64))) {
 // Note: Structure is now >64 bytes due to buffer_size_mask optimization field
 // First 64 bytes (hot path + medium-hot) should still fit in first cache line
 #ifdef __cplusplus
-static_assert(sizeof(DualIsrContext) <= 128, "DualIsrContext must fit in 2 cache lines or less");
-static_assert(alignof(DualIsrContext) == 64, "DualIsrContext must be 64-byte aligned");
+FL_STATIC_ASSERT(sizeof(DualIsrContext) <= 128, "DualIsrContext must fit in 2 cache lines or less");
+FL_STATIC_ASSERT(alignof(DualIsrContext) == 64, "DualIsrContext must be 64-byte aligned");
 #else
 _Static_assert(sizeof(DualIsrContext) <= 128, "DualIsrContext must fit in 2 cache lines or less");
 _Static_assert(_Alignof(DualIsrContext) == 64, "DualIsrContext must be 64-byte aligned");

--- a/src/platforms/esp/32/drivers/i2s/clockless_i2s_esp32.h
+++ b/src/platforms/esp/32/drivers/i2s/clockless_i2s_esp32.h
@@ -112,6 +112,7 @@
 #include "fl/chipsets/led_timing.h"
 #include "fl/chipsets/timing_traits.h"
 #include "fl/stl/allocator.h"
+#include "fl/stl/static_assert.h"
 #include "fl/stl/noexcept.h"
 #include "fastled_delay.h"
 namespace fl {
@@ -168,7 +169,7 @@ class ClocklessI2S : public CPixelLEDController<RGB_ORDER> {
     static constexpr u32 T3 = TIMING::T3;
 
     // -- Verify that the pin is valid
-    static_assert(FastPin<DATA_PIN>::validpin(), "This pin has been marked as an invalid pin, common reasons includes it being a ground pin, read only, or too noisy (e.g. hooked up to the uart).");
+    FL_STATIC_ASSERT(FastPin<DATA_PIN>::validpin(), "This pin has been marked as an invalid pin, common reasons includes it being a ground pin, read only, or too noisy (e.g. hooked up to the uart).");
 
     // -- Save the pixel controller
     PixelController<RGB_ORDER> *mPixels;

--- a/src/platforms/esp/32/drivers/lcd_cam/clockless_lcd_i80_esp32.h.disabled
+++ b/src/platforms/esp/32/drivers/lcd_cam/clockless_lcd_i80_esp32.h.disabled
@@ -31,6 +31,7 @@
 #endif
 
 #include "sdkconfig.h"
+#include "fl/stl/static_assert.h"
 
 #include "crgb.h"
 #include "cpixel_ledcontroller.h"
@@ -82,14 +83,14 @@ class ClocklessController_LCD_I80_Proxy
     typedef CPixelLEDController<RGB_ORDER> Base;
 
     // Compile-time GPIO validation (same as before)
-    static_assert(!(DATA_PIN == 19 || DATA_PIN == 20),
+    FL_STATIC_ASSERT(!(DATA_PIN == 19 || DATA_PIN == 20),
                   "GPIO19 and GPIO20 are reserved for USB-JTAG and CANNOT be used");
-    static_assert(!(DATA_PIN >= 26 && DATA_PIN <= 32),
+    FL_STATIC_ASSERT(!(DATA_PIN >= 26 && DATA_PIN <= 32),
                   "GPIO26-32 are reserved for Flash/PSRAM and CANNOT be used");
-    static_assert(!(DATA_PIN == 0 || DATA_PIN == 3 || DATA_PIN == 45 || DATA_PIN == 46) || true,
+    FL_STATIC_ASSERT(!(DATA_PIN == 0 || DATA_PIN == 3 || DATA_PIN == 45 || DATA_PIN == 46) || true,
                   "WARNING: Strapping pins - use with caution");
     #if defined(CONFIG_SPIRAM_MODE_OCT) || defined(CONFIG_ESPTOOLPY_FLASHMODE_OPI)
-    static_assert(!(DATA_PIN >= 33 && DATA_PIN <= 37),
+    FL_STATIC_ASSERT(!(DATA_PIN >= 33 && DATA_PIN <= 37),
                   "GPIO33-37 reserved for Octal Flash/PSRAM");
     #endif
 

--- a/src/platforms/esp/32/drivers/lcd_cam/clockless_lcd_i80_esp32.h.disabled
+++ b/src/platforms/esp/32/drivers/lcd_cam/clockless_lcd_i80_esp32.h.disabled
@@ -87,8 +87,8 @@ class ClocklessController_LCD_I80_Proxy
                   "GPIO19 and GPIO20 are reserved for USB-JTAG and CANNOT be used");
     FL_STATIC_ASSERT(!(DATA_PIN >= 26 && DATA_PIN <= 32),
                   "GPIO26-32 are reserved for Flash/PSRAM and CANNOT be used");
-    FL_STATIC_ASSERT(!(DATA_PIN == 0 || DATA_PIN == 3 || DATA_PIN == 45 || DATA_PIN == 46) || true,
-                  "WARNING: Strapping pins - use with caution");
+    // GPIO0, GPIO3, GPIO45, and GPIO46 are strapping pins. They are risky but
+    // not invalid, so this disabled driver keeps the note non-blocking.
     #if defined(CONFIG_SPIRAM_MODE_OCT) || defined(CONFIG_ESPTOOLPY_FLASHMODE_OPI)
     FL_STATIC_ASSERT(!(DATA_PIN >= 33 && DATA_PIN <= 37),
                   "GPIO33-37 reserved for Octal Flash/PSRAM");

--- a/src/platforms/esp/32/drivers/parlio/parlio_buffer_calc.h
+++ b/src/platforms/esp/32/drivers/parlio/parlio_buffer_calc.h
@@ -11,6 +11,7 @@
 #include "platforms/esp/is_esp.h"
 
 #include "fl/stl/compiler_control.h"
+#include "fl/stl/static_assert.h"
 #include "fl/system/log.h"
 #include "fl/stl/noexcept.h"
 
@@ -34,7 +35,7 @@ namespace detail {
 #endif
 
 // Minimum cap validation (supports at least 1 LED × 16 lanes)
-static_assert(FASTLED_PARLIO_MAX_RING_BUFFER_TOTAL_BYTES >= 12UL * 1024UL,
+FL_STATIC_ASSERT(FASTLED_PARLIO_MAX_RING_BUFFER_TOTAL_BYTES >= 12UL * 1024UL,
               "FASTLED_PARLIO_MAX_RING_BUFFER_TOTAL_BYTES too small (minimum 12 KB)");
 
 // PSRAM ring buffer memory cap (used when PSRAM is available at runtime)

--- a/src/platforms/esp/32/drivers/rmt/rmt_4/idf4_clockless_rmt_esp32.h
+++ b/src/platforms/esp/32/drivers/rmt/rmt_4/idf4_clockless_rmt_esp32.h
@@ -43,6 +43,7 @@
 #include "platforms/esp/32/core/fastpin_esp32.h"
 #include "fl/chipsets/timing_traits.h"
 #include "fl/stl/noexcept.h"
+#include "fl/stl/static_assert.h"
 
 namespace fl {
 
@@ -57,7 +58,7 @@ private:
     fl::shared_ptr<IChannelDriver> mDriver;
 
     // -- Verify that the pin is valid
-    static_assert(FastPin<DATA_PIN>::validpin(), "This pin has been marked as an invalid pin, common reasons includes it being a ground pin, read only, or too noisy (e.g. hooked up to the uart).");
+    FL_STATIC_ASSERT(FastPin<DATA_PIN>::validpin(), "This pin has been marked as an invalid pin, common reasons includes it being a ground pin, read only, or too noisy (e.g. hooked up to the uart).");
 
 public:
     ClocklessIdf4() FL_NOEXCEPT

--- a/src/platforms/esp/32/drivers/rmt/rmt_5/idf5_clockless.h
+++ b/src/platforms/esp/32/drivers/rmt/rmt_5/idf5_clockless.h
@@ -14,13 +14,14 @@
 #include "fl/channels/config.h"
 #include "fl/chipsets/timing_traits.h"
 #include "fl/stl/noexcept.h"
+#include "fl/stl/static_assert.h"
 
 namespace fl {
 template <int DATA_PIN, typename TIMING, EOrder RGB_ORDER = RGB, int XTRA0 = 0, bool FLIP = false, int WAIT_TIME = 280>
 class ClocklessIdf5 : public Channel
 {
     // -- Verify that the pin is valid
-    static_assert(FastPin<DATA_PIN>::validpin(), "This pin has been marked as an invalid pin, common reasons includes it being a ground pin, read only, or too noisy (e.g. hooked up to the uart).");
+    FL_STATIC_ASSERT(FastPin<DATA_PIN>::validpin(), "This pin has been marked as an invalid pin, common reasons includes it being a ground pin, read only, or too noisy (e.g. hooked up to the uart).");
 
     static ChipsetVariant makeChipset() FL_NOEXCEPT {
         return ClocklessChipset(DATA_PIN, makeTimingConfig<TIMING>());

--- a/src/platforms/esp/32/drivers/rmt_rx/rmt_rx_channel.cpp.hpp
+++ b/src/platforms/esp/32/drivers/rmt_rx/rmt_rx_channel.cpp.hpp
@@ -16,6 +16,7 @@
 
 #include "fl/system/log.h"
 #include "fl/stl/iterator.h"
+#include "fl/stl/static_assert.h"
 
 // RX device logging: Disabled by default to reduce noise
 // Enable with: #define FASTLED_RX_LOG_ENABLED 1
@@ -62,9 +63,9 @@ FL_EXTERN_C_END
 namespace fl {
 
 // Ensure RmtSymbol (uint32_t) and rmt_symbol_word_t have the same size
-static_assert(sizeof(RmtSymbol) == sizeof(rmt_symbol_word_t),
+FL_STATIC_ASSERT(sizeof(RmtSymbol) == sizeof(rmt_symbol_word_t),
               "RmtSymbol must be the same size as rmt_symbol_word_t (32 bits)");
-static_assert(fl::is_trivially_copyable<rmt_symbol_word_t>::value,
+FL_STATIC_ASSERT(fl::is_trivially_copyable<rmt_symbol_word_t>::value,
               "rmt_symbol_word_t must be trivially copyable for safe casting");
 
 // ============================================================================

--- a/src/platforms/esp/32/drivers/spi/idf5_clockless_spi_esp32.h
+++ b/src/platforms/esp/32/drivers/spi/idf5_clockless_spi_esp32.h
@@ -20,6 +20,7 @@
 #include "fl/chipsets/timing_traits.h"
 #include "fl/system/log.h"
 #include "fl/stl/noexcept.h"
+#include "fl/stl/static_assert.h"
 
 namespace fl {
 template <int DATA_PIN, typename TIMING, EOrder RGB_ORDER = RGB, int XTRA0 = 0, bool FLIP = false, int WAIT_TIME = 5>
@@ -33,7 +34,7 @@ private:
     fl::shared_ptr<IChannelDriver> mDriver;
 
     // -- Verify that the pin is valid
-    static_assert(FastPin<DATA_PIN>::validpin(), "This pin has been marked as an invalid pin, common reasons includes it being a ground pin, read only, or too noisy (e.g. hooked up to the uart).");
+    FL_STATIC_ASSERT(FastPin<DATA_PIN>::validpin(), "This pin has been marked as an invalid pin, common reasons includes it being a ground pin, read only, or too noisy (e.g. hooked up to the uart).");
 
 public:
     ClocklessSPI()

--- a/src/platforms/esp/32/interrupts/riscv.hpp
+++ b/src/platforms/esp/32/interrupts/riscv.hpp
@@ -6,6 +6,7 @@
 #include "platforms/esp/is_esp.h"
 
 #include "fl/stl/compiler_control.h"
+#include "fl/stl/static_assert.h"
 // Assembly Shims for High-Priority Interrupts on ESP32-C3/C6 (RISC-V)
 //
 // This file provides interrupt service routine (ISR) shims for high-priority
@@ -473,7 +474,7 @@ void FL_IRAM fastled_riscv_rmt_experimental_handler(void *arg) FL_NOEXCEPT;
 #if 0  // DISABLED - Broken assembly implementation
 #define FASTLED_ESP_RISCV_ASM_INTERRUPT_TRAMPOLINE(new_function_name, function_pointer) \
     /* THIS MACRO IS DISABLED DUE TO CRITICAL TECHNICAL ERRORS */ \
-    static_assert(false, "FASTLED_ESP_RISCV_ASM_INTERRUPT_TRAMPOLINE is disabled due to critical errors. Use FASTLED_ESP_RISCV_INTERRUPT_TRAMPOLINE instead.");
+    FL_STATIC_ASSERT(false, "FASTLED_ESP_RISCV_ASM_INTERRUPT_TRAMPOLINE is disabled due to critical errors. Use FASTLED_ESP_RISCV_INTERRUPT_TRAMPOLINE instead.");
 #endif  // DISABLED
 
 /*

--- a/src/platforms/intmap.h
+++ b/src/platforms/intmap.h
@@ -24,6 +24,7 @@
 
 #include "fl/math/lib8static.h"
 #include "fl/stl/stdint.h"
+#include "fl/stl/static_assert.h"
 #include "fl/system/sketch_macros.h"
 #include "fl/stl/type_traits.h"
 #include "fl/stl/compiler_control.h"
@@ -71,7 +72,7 @@ struct int_scale_impl {
     static INT_TO apply(INT_FROM) FL_NOEXCEPT {
         // This will only be instantiated if no specialization matches
         // Use dependent expression to delay assertion until instantiation
-        static_assert(fl::is_same<INT_FROM, void>::value, "int_scale: unsupported type conversion pair");
+        FL_STATIC_ASSERT(fl::is_same<INT_FROM, void>::value, "int_scale: unsupported type conversion pair");
         return INT_TO(0);  // Never reached, but satisfies return type
     }
 };

--- a/src/platforms/shared/clockless_blocking.h
+++ b/src/platforms/shared/clockless_blocking.h
@@ -20,6 +20,7 @@
 #include "fl/system/delay.h"
 #include "fl/chipsets/led_timing.h"
 #include "fl/stl/compiler_control.h"
+#include "fl/stl/static_assert.h"
 #include "fl/chipsets/timing_traits.h"
 #include "fl/system/log.h"
 #include "controller.h"
@@ -74,9 +75,9 @@ private:
     // static_assert(fl::FastPin<DATA_PIN>::validpin(), "Invalid pin for clockless controller");
 
     // Static timing assertions for protocol sanity
-    static_assert(T1 > 0, "T1 (high time for bit 0) must be positive");
-    static_assert(T2 > 0, "T2 (additional high time for bit 1) must be positive");
-    static_assert(T3 > 0, "T3 (addtional time for low tail duration) must be positive");
+    FL_STATIC_ASSERT(T1 > 0, "T1 (high time for bit 0) must be positive");
+    FL_STATIC_ASSERT(T2 > 0, "T2 (additional high time for bit 1) must be positive");
+    FL_STATIC_ASSERT(T3 > 0, "T3 (addtional time for low tail duration) must be positive");
 
     // Minimum wait time between frames
     CMinWait<WAIT_TIME> mWait;

--- a/src/platforms/shared/clockless_blocking.h
+++ b/src/platforms/shared/clockless_blocking.h
@@ -77,7 +77,7 @@ private:
     // Static timing assertions for protocol sanity
     FL_STATIC_ASSERT(T1 > 0, "T1 (high time for bit 0) must be positive");
     FL_STATIC_ASSERT(T2 > 0, "T2 (additional high time for bit 1) must be positive");
-    FL_STATIC_ASSERT(T3 > 0, "T3 (addtional time for low tail duration) must be positive");
+    FL_STATIC_ASSERT(T3 > 0, "T3 (additional time for low tail duration) must be positive");
 
     // Minimum wait time between frames
     CMinWait<WAIT_TIME> mWait;

--- a/src/platforms/shared/spi_bitbang/spi_isr_16.h
+++ b/src/platforms/shared/spi_bitbang/spi_isr_16.h
@@ -4,6 +4,7 @@
 // IWYU pragma: private
 
 #include "fl/stl/stdint.h"
+#include "fl/stl/static_assert.h"
 #include "fl/stl/cstddef.h"
 #include "fl/stl/bit_cast.h"
 #include "platforms/shared/spi_bitbang/spi_isr_engine.h"
@@ -34,11 +35,11 @@ struct GPIOEvent {
 
 // Verify memory layout matches between C and C++ structures
 // Use FL_OFFSETOF macro (defined in fl/cstddef.h) instead of <stddef.h>
-static_assert(sizeof(GPIOEvent) == sizeof(FastLED_GPIO_Event),
+FL_STATIC_ASSERT(sizeof(GPIOEvent) == sizeof(FastLED_GPIO_Event),
               "C++ GPIOEvent must match C FastLED_GPIO_Event layout");
-static_assert(FL_OFFSETOF(GPIOEvent, event_type) == FL_OFFSETOF(FastLED_GPIO_Event, event_type),
+FL_STATIC_ASSERT(FL_OFFSETOF(GPIOEvent, event_type) == FL_OFFSETOF(FastLED_GPIO_Event, event_type),
               "event_type offset must match");
-static_assert(FL_OFFSETOF(GPIOEvent, payload) == FL_OFFSETOF(FastLED_GPIO_Event, payload),
+FL_STATIC_ASSERT(FL_OFFSETOF(GPIOEvent, payload) == FL_OFFSETOF(FastLED_GPIO_Event, payload),
               "payload offset must match");
 #endif
 

--- a/src/platforms/shared/spi_bitbang/spi_isr_32.h
+++ b/src/platforms/shared/spi_bitbang/spi_isr_32.h
@@ -4,6 +4,7 @@
 // IWYU pragma: private
 
 #include "fl/stl/stdint.h"
+#include "fl/stl/static_assert.h"
 #include "fl/stl/cstddef.h"
 #include "fl/stl/bit_cast.h"
 #include "platforms/shared/spi_bitbang/spi_isr_engine.h"
@@ -34,11 +35,11 @@ struct GPIOEvent {
 
 // Verify memory layout matches between C and C++ structures
 // Use FL_OFFSETOF macro (defined in fl/cstddef.h) instead of <stddef.h>
-static_assert(sizeof(GPIOEvent) == sizeof(FastLED_GPIO_Event),
+FL_STATIC_ASSERT(sizeof(GPIOEvent) == sizeof(FastLED_GPIO_Event),
               "C++ GPIOEvent must match C FastLED_GPIO_Event layout");
-static_assert(FL_OFFSETOF(GPIOEvent, event_type) == FL_OFFSETOF(FastLED_GPIO_Event, event_type),
+FL_STATIC_ASSERT(FL_OFFSETOF(GPIOEvent, event_type) == FL_OFFSETOF(FastLED_GPIO_Event, event_type),
               "event_type offset must match");
-static_assert(FL_OFFSETOF(GPIOEvent, payload) == FL_OFFSETOF(FastLED_GPIO_Event, payload),
+FL_STATIC_ASSERT(FL_OFFSETOF(GPIOEvent, payload) == FL_OFFSETOF(FastLED_GPIO_Event, payload),
               "payload offset must match");
 #endif
 

--- a/src/platforms/shared/spi_bitbang/spi_isr_8.h
+++ b/src/platforms/shared/spi_bitbang/spi_isr_8.h
@@ -4,6 +4,7 @@
 // IWYU pragma: private
 
 #include "fl/stl/stdint.h"
+#include "fl/stl/static_assert.h"
 #include "fl/stl/cstddef.h"
 #include "fl/stl/bit_cast.h"
 #include "platforms/shared/spi_bitbang/spi_isr_engine.h"
@@ -34,11 +35,11 @@ struct GPIOEvent {
 
 // Verify memory layout matches between C and C++ structures
 // Use FL_OFFSETOF macro (defined in fl/cstddef.h) instead of <stddef.h>
-static_assert(sizeof(GPIOEvent) == sizeof(FastLED_GPIO_Event),
+FL_STATIC_ASSERT(sizeof(GPIOEvent) == sizeof(FastLED_GPIO_Event),
               "C++ GPIOEvent must match C FastLED_GPIO_Event layout");
-static_assert(FL_OFFSETOF(GPIOEvent, event_type) == FL_OFFSETOF(FastLED_GPIO_Event, event_type),
+FL_STATIC_ASSERT(FL_OFFSETOF(GPIOEvent, event_type) == FL_OFFSETOF(FastLED_GPIO_Event, event_type),
               "event_type offset must match");
-static_assert(FL_OFFSETOF(GPIOEvent, payload) == FL_OFFSETOF(FastLED_GPIO_Event, payload),
+FL_STATIC_ASSERT(FL_OFFSETOF(GPIOEvent, payload) == FL_OFFSETOF(FastLED_GPIO_Event, payload),
               "payload offset must match");
 #endif
 

--- a/src/platforms/stub/thread_stub_stl.h
+++ b/src/platforms/stub/thread_stub_stl.h
@@ -13,6 +13,7 @@
 // Standard library includes must be OUTSIDE namespaces
 #include <thread>  // ok include
 #include "fl/stl/chrono.h"
+#include "fl/stl/static_assert.h"
 #include "platforms/win/is_win.h"
 
 #ifdef FL_IS_WIN
@@ -129,7 +130,7 @@ namespace this_thread {
         // For time_point support, we would need fl::chrono::time_point and fl::chrono::clock
         // For now, this is a placeholder - implement when needed
         (void)wake_time;  // Suppress unused parameter warning
-        static_assert(sizeof(Rep) == 0, "sleep_until not yet implemented for fl::chrono::time_point");
+        FL_STATIC_ASSERT(sizeof(Rep) == 0, "sleep_until not yet implemented for fl::chrono::time_point");
     }
 } // namespace this_thread
 

--- a/tests/fl/asset.cpp
+++ b/tests/fl/asset.cpp
@@ -6,6 +6,7 @@
 #include "fl/stl/string_view.h"
 #include "fl/stl/url.h"
 #include "test.h"
+#include "fl/stl/static_assert.h"
 
 FL_TEST_FILE(FL_FILEPATH) {
 
@@ -16,29 +17,29 @@ using namespace fl;
 // innocent-looking paths that merely contain dot characters.
 // -----------------------------------------------------------------------------
 
-static_assert(!fl::asset_detail::path_has_parent_segment("data/track.mp3"),
+FL_STATIC_ASSERT(!fl::asset_detail::path_has_parent_segment("data/track.mp3"),
               "plain relative path should not be flagged");
-static_assert(!fl::asset_detail::path_has_parent_segment("track.mp3"),
+FL_STATIC_ASSERT(!fl::asset_detail::path_has_parent_segment("track.mp3"),
               "bare file should not be flagged");
-static_assert(!fl::asset_detail::path_has_parent_segment("folder.with.dots/a.mp3"),
+FL_STATIC_ASSERT(!fl::asset_detail::path_has_parent_segment("folder.with.dots/a.mp3"),
               "dots inside segments must not trigger false positive");
-static_assert(!fl::asset_detail::path_has_parent_segment("."),
+FL_STATIC_ASSERT(!fl::asset_detail::path_has_parent_segment("."),
               "single dot is not a parent segment");
-static_assert(!fl::asset_detail::path_has_parent_segment(""),
+FL_STATIC_ASSERT(!fl::asset_detail::path_has_parent_segment(""),
               "empty path is not a parent segment");
 
-static_assert(fl::asset_detail::path_has_parent_segment(".."),
+FL_STATIC_ASSERT(fl::asset_detail::path_has_parent_segment(".."),
               "bare .. must be rejected");
-static_assert(fl::asset_detail::path_has_parent_segment("../foo"),
+FL_STATIC_ASSERT(fl::asset_detail::path_has_parent_segment("../foo"),
               "leading .. must be rejected");
-static_assert(fl::asset_detail::path_has_parent_segment("foo/.."),
+FL_STATIC_ASSERT(fl::asset_detail::path_has_parent_segment("foo/.."),
               "trailing .. must be rejected");
-static_assert(fl::asset_detail::path_has_parent_segment("data/../foo.mp3"),
+FL_STATIC_ASSERT(fl::asset_detail::path_has_parent_segment("data/../foo.mp3"),
               "embedded .. must be rejected");
-static_assert(fl::asset_detail::path_has_parent_segment("a/b/../c"),
+FL_STATIC_ASSERT(fl::asset_detail::path_has_parent_segment("a/b/../c"),
               "deep embedded .. must be rejected");
 // Windows-style separators are treated the same.
-static_assert(fl::asset_detail::path_has_parent_segment("data\\..\\foo.mp3"),
+FL_STATIC_ASSERT(fl::asset_detail::path_has_parent_segment("data\\..\\foo.mp3"),
               "backslash-style .. must also be rejected");
 
 // FL_ASSET() macro returns a valid handle at compile time when the path is OK.

--- a/tests/fl/force_inline.cpp
+++ b/tests/fl/force_inline.cpp
@@ -1,6 +1,7 @@
 
 #include "fl/stl/compiler_control.h"
 #include "test.h"
+#include "fl/stl/static_assert.h"
 
 FL_TEST_FILE(FL_FILEPATH) {
 
@@ -79,7 +80,7 @@ FL_TEST_CASE("FASTLED_FORCE_INLINE macro") {
 
         // Compile-time evaluation test
         constexpr int result = square_force_inline(7);
-        static_assert(result == 49, "constexpr function should work at compile time");
+        FL_STATIC_ASSERT(result == 49, "constexpr function should work at compile time");
     }
 
     FL_SUBCASE("macro is defined") {

--- a/tests/fl/gfx/corkscrew.cpp
+++ b/tests/fl/gfx/corkscrew.cpp
@@ -1,6 +1,7 @@
 // g++ --std=c++11 test.cpp
 
 #include "fl/math/math.h"
+#include "fl/stl/static_assert.h"
 
 
 #include "fl/gfx/corkscrew.h"
@@ -149,15 +150,15 @@ FL_TEST_CASE("Constexpr corkscrew dimension calculation") {
     constexpr uint16_t festival_width = fl::calculateCorkscrewWidth(19.0f, 288);
     constexpr uint16_t festival_height = fl::calculateCorkscrewHeight(19.0f, 288);
     
-    static_assert(festival_width == 16, "FestivalStick width should be 16");
-    static_assert(festival_height == 18, "FestivalStick height should be 18");
+    FL_STATIC_ASSERT(festival_width == 16, "FestivalStick width should be 16");
+    FL_STATIC_ASSERT(festival_height == 18, "FestivalStick height should be 18");
     
     // Default case: 19 turns, 144 LEDs
     constexpr uint16_t default_width = fl::calculateCorkscrewWidth(19.0f, 144);
     constexpr uint16_t default_height = fl::calculateCorkscrewHeight(19.0f, 144);
     
-    static_assert(default_width == 8, "Default width should be 8");
-    static_assert(default_height == 18, "Default height should be 18");
+    FL_STATIC_ASSERT(default_width == 8, "Default width should be 8");
+    FL_STATIC_ASSERT(default_height == 18, "Default height should be 18");
     
     // Verify runtime and compile-time versions match
     fl::Corkscrew runtime_corkscrew(19.0f, 288);
@@ -169,8 +170,8 @@ FL_TEST_CASE("Constexpr corkscrew dimension calculation") {
     constexpr uint16_t simple_width = fl::calculateCorkscrewWidth(10.0f, 100);
     constexpr uint16_t simple_height = fl::calculateCorkscrewHeight(10.0f, 100);
     
-    static_assert(simple_width == 10, "Simple width should be 10");
-    static_assert(simple_height == 10, "Simple height should be 10");
+    FL_STATIC_ASSERT(simple_width == 10, "Simple width should be 10");
+    FL_STATIC_ASSERT(simple_height == 10, "Simple height should be 10");
 }
 
 FL_TEST_CASE("TestCorkscrewBufferFunctionality") {

--- a/tests/fl/math/alpha.cpp
+++ b/tests/fl/math/alpha.cpp
@@ -1,4 +1,5 @@
 #include "test.h"
+#include "fl/stl/static_assert.h"
 
 #include "fl/math/alpha.h"
 
@@ -253,89 +254,89 @@ template <typename Alpha, typename Raw, int MaxVal>
 static void test_alpha_constexpr() {
     // Default construction
     constexpr Alpha def;
-    static_assert(def.raw() == 0, "default ctor");
+    FL_STATIC_ASSERT(def.raw() == 0, "default ctor");
 
     // Integer construction — every width and signedness
     constexpr Alpha from_raw_type(static_cast<Raw>(MaxVal));
-    static_assert(from_raw_type.raw() == MaxVal, "raw type ctor");
+    FL_STATIC_ASSERT(from_raw_type.raw() == MaxVal, "raw type ctor");
 
     constexpr Alpha from_char(static_cast<signed char>(42));
-    static_assert(from_char.raw() == 42, "signed char ctor");
+    FL_STATIC_ASSERT(from_char.raw() == 42, "signed char ctor");
 
     constexpr Alpha from_uchar(static_cast<unsigned char>(42));
-    static_assert(from_uchar.raw() == 42, "unsigned char ctor");
+    FL_STATIC_ASSERT(from_uchar.raw() == 42, "unsigned char ctor");
 
     constexpr Alpha from_short(static_cast<short>(42));
-    static_assert(from_short.raw() == 42, "short ctor");
+    FL_STATIC_ASSERT(from_short.raw() == 42, "short ctor");
 
     constexpr Alpha from_ushort(static_cast<unsigned short>(42));
-    static_assert(from_ushort.raw() == 42, "unsigned short ctor");
+    FL_STATIC_ASSERT(from_ushort.raw() == 42, "unsigned short ctor");
 
     constexpr Alpha from_int(42);
-    static_assert(from_int.raw() == 42, "int ctor");
+    FL_STATIC_ASSERT(from_int.raw() == 42, "int ctor");
 
     constexpr Alpha from_uint(42u);
-    static_assert(from_uint.raw() == 42, "unsigned int ctor");
+    FL_STATIC_ASSERT(from_uint.raw() == 42, "unsigned int ctor");
 
     constexpr Alpha from_long(42L);
-    static_assert(from_long.raw() == 42, "long ctor");
+    FL_STATIC_ASSERT(from_long.raw() == 42, "long ctor");
 
     constexpr Alpha from_ulong(42UL);
-    static_assert(from_ulong.raw() == 42, "unsigned long ctor");
+    FL_STATIC_ASSERT(from_ulong.raw() == 42, "unsigned long ctor");
 
     constexpr Alpha from_ll(42LL);
-    static_assert(from_ll.raw() == 42, "long long ctor");
+    FL_STATIC_ASSERT(from_ll.raw() == 42, "long long ctor");
 
     constexpr Alpha from_ull(42ULL);
-    static_assert(from_ull.raw() == 42, "unsigned long long ctor");
+    FL_STATIC_ASSERT(from_ull.raw() == 42, "unsigned long long ctor");
 
     // Float / double construction (explicit)
     constexpr Alpha from_f0(0.0f);
-    static_assert(from_f0.raw() == 0, "float ctor 0.0");
+    FL_STATIC_ASSERT(from_f0.raw() == 0, "float ctor 0.0");
 
     constexpr Alpha from_f1(1.0f);
-    static_assert(from_f1.raw() == MaxVal, "float ctor 1.0");
+    FL_STATIC_ASSERT(from_f1.raw() == MaxVal, "float ctor 1.0");
 
     constexpr Alpha from_d0(0.0);
-    static_assert(from_d0.raw() == 0, "double ctor 0.0");
+    FL_STATIC_ASSERT(from_d0.raw() == 0, "double ctor 0.0");
 
     constexpr Alpha from_d1(1.0);
-    static_assert(from_d1.raw() == MaxVal, "double ctor 1.0");
+    FL_STATIC_ASSERT(from_d1.raw() == MaxVal, "double ctor 1.0");
 
     // Float clamp boundaries
     constexpr Alpha clamp_above(2.0f);
-    static_assert(clamp_above.raw() == MaxVal, "float clamp above");
+    FL_STATIC_ASSERT(clamp_above.raw() == MaxVal, "float clamp above");
 
     constexpr Alpha clamp_below(-1.0f);
-    static_assert(clamp_below.raw() == 0, "float clamp below");
+    FL_STATIC_ASSERT(clamp_below.raw() == 0, "float clamp below");
 
     // Implicit conversion to Raw
     constexpr Raw r = from_raw_type;
-    static_assert(r == static_cast<Raw>(MaxVal), "implicit conversion");
+    FL_STATIC_ASSERT(r == static_cast<Raw>(MaxVal), "implicit conversion");
 
     // raw() accessor
-    static_assert(from_int.raw() == 42, "raw()");
+    FL_STATIC_ASSERT(from_int.raw() == 42, "raw()");
 
     // to_float() — verify constexpr (boundaries are exact in IEEE 754)
     constexpr float f_zero = Alpha(static_cast<Raw>(0)).to_float();
-    static_assert(f_zero == 0.0f, "to_float 0");
+    FL_STATIC_ASSERT(f_zero == 0.0f, "to_float 0");
 
     constexpr float f_one = Alpha(static_cast<Raw>(MaxVal)).to_float();
-    static_assert(f_one == 1.0f, "to_float max");
+    FL_STATIC_ASSERT(f_one == 1.0f, "to_float max");
 
     // from_float() static method
     constexpr Alpha ff0 = Alpha::from_float(0.0f);
-    static_assert(ff0.raw() == 0, "from_float 0");
+    FL_STATIC_ASSERT(ff0.raw() == 0, "from_float 0");
 
     constexpr Alpha ff1 = Alpha::from_float(1.0f);
-    static_assert(ff1.raw() == MaxVal, "from_float 1");
+    FL_STATIC_ASSERT(ff1.raw() == MaxVal, "from_float 1");
 
     constexpr Alpha ff_clamp = Alpha::from_float(5.0f);
-    static_assert(ff_clamp.raw() == MaxVal, "from_float clamp");
+    FL_STATIC_ASSERT(ff_clamp.raw() == MaxVal, "from_float clamp");
 
     // Copy construction
     constexpr Alpha copy = from_raw_type;
-    static_assert(copy.raw() == MaxVal, "copy ctor");
+    FL_STATIC_ASSERT(copy.raw() == MaxVal, "copy ctor");
 
     // All checks passed at compile time; runtime just confirms we got here.
     FL_CHECK(true);

--- a/tests/fl/math/fixed_point.cpp
+++ b/tests/fl/math/fixed_point.cpp
@@ -105,6 +105,7 @@
 #include "fl/stl/compiler_control.h"
 #include "fl/math/fixed_point.h"
 #include "fl/math/math.h"
+#include "fl/stl/static_assert.h"
 
 FL_TEST_FILE(FL_FILEPATH) {
 
@@ -809,21 +810,21 @@ void test_to_float_impl(float epsilon, float epsilon_large) {
 // This is a compile-time check: if raw() is not constexpr, static_assert fails.
 FL_TEST_CASE("constexpr raw() - all fixed-point types") {
     // Signed types
-    static_assert(constexpr_raw_check<s0x32>(0.5f), "s0x32::raw() must be constexpr");
-    static_assert(constexpr_raw_check<s4x12>(1.0f), "s4x12::raw() must be constexpr");
-    static_assert(constexpr_raw_check<s8x8>(1.0f), "s8x8::raw() must be constexpr");
-    static_assert(constexpr_raw_check<s8x24>(1.0f), "s8x24::raw() must be constexpr");
-    static_assert(constexpr_raw_check<s12x4>(1.0f), "s12x4::raw() must be constexpr");
-    static_assert(constexpr_raw_check<s16x16>(1.0f), "s16x16::raw() must be constexpr");
-    static_assert(constexpr_raw_check<s24x8>(1.0f), "s24x8::raw() must be constexpr");
+    FL_STATIC_ASSERT(constexpr_raw_check<s0x32>(0.5f), "s0x32::raw() must be constexpr");
+    FL_STATIC_ASSERT(constexpr_raw_check<s4x12>(1.0f), "s4x12::raw() must be constexpr");
+    FL_STATIC_ASSERT(constexpr_raw_check<s8x8>(1.0f), "s8x8::raw() must be constexpr");
+    FL_STATIC_ASSERT(constexpr_raw_check<s8x24>(1.0f), "s8x24::raw() must be constexpr");
+    FL_STATIC_ASSERT(constexpr_raw_check<s12x4>(1.0f), "s12x4::raw() must be constexpr");
+    FL_STATIC_ASSERT(constexpr_raw_check<s16x16>(1.0f), "s16x16::raw() must be constexpr");
+    FL_STATIC_ASSERT(constexpr_raw_check<s24x8>(1.0f), "s24x8::raw() must be constexpr");
     // Unsigned types
-    static_assert(constexpr_raw_check<u0x32>(0.5f), "u0x32::raw() must be constexpr");
-    static_assert(constexpr_raw_check<u4x12>(1.0f), "u4x12::raw() must be constexpr");
-    static_assert(constexpr_raw_check<u8x8>(1.0f), "u8x8::raw() must be constexpr");
-    static_assert(constexpr_raw_check<u8x24>(1.0f), "u8x24::raw() must be constexpr");
-    static_assert(constexpr_raw_check<u12x4>(1.0f), "u12x4::raw() must be constexpr");
-    static_assert(constexpr_raw_check<u16x16>(1.0f), "u16x16::raw() must be constexpr");
-    static_assert(constexpr_raw_check<u24x8>(1.0f), "u24x8::raw() must be constexpr");
+    FL_STATIC_ASSERT(constexpr_raw_check<u0x32>(0.5f), "u0x32::raw() must be constexpr");
+    FL_STATIC_ASSERT(constexpr_raw_check<u4x12>(1.0f), "u4x12::raw() must be constexpr");
+    FL_STATIC_ASSERT(constexpr_raw_check<u8x8>(1.0f), "u8x8::raw() must be constexpr");
+    FL_STATIC_ASSERT(constexpr_raw_check<u8x24>(1.0f), "u8x24::raw() must be constexpr");
+    FL_STATIC_ASSERT(constexpr_raw_check<u12x4>(1.0f), "u12x4::raw() must be constexpr");
+    FL_STATIC_ASSERT(constexpr_raw_check<u16x16>(1.0f), "u16x16::raw() must be constexpr");
+    FL_STATIC_ASSERT(constexpr_raw_check<u24x8>(1.0f), "u24x8::raw() must be constexpr");
 }
 
 // ============================================================================
@@ -966,164 +967,164 @@ constexpr bool constexpr_rsqrt_check(float a) {
 
 FL_TEST_CASE("constexpr from_raw - all types") {
     // Signed
-    static_assert(constexpr_from_raw_check<s4x12>(), "s4x12::from_raw must be constexpr");
-    static_assert(constexpr_from_raw_check<s8x8>(), "s8x8::from_raw must be constexpr");
-    static_assert(constexpr_from_raw_check<s8x24>(), "s8x24::from_raw must be constexpr");
-    static_assert(constexpr_from_raw_check<s12x4>(), "s12x4::from_raw must be constexpr");
-    static_assert(constexpr_from_raw_check<s16x16>(), "s16x16::from_raw must be constexpr");
-    static_assert(constexpr_from_raw_check<s24x8>(), "s24x8::from_raw must be constexpr");
+    FL_STATIC_ASSERT(constexpr_from_raw_check<s4x12>(), "s4x12::from_raw must be constexpr");
+    FL_STATIC_ASSERT(constexpr_from_raw_check<s8x8>(), "s8x8::from_raw must be constexpr");
+    FL_STATIC_ASSERT(constexpr_from_raw_check<s8x24>(), "s8x24::from_raw must be constexpr");
+    FL_STATIC_ASSERT(constexpr_from_raw_check<s12x4>(), "s12x4::from_raw must be constexpr");
+    FL_STATIC_ASSERT(constexpr_from_raw_check<s16x16>(), "s16x16::from_raw must be constexpr");
+    FL_STATIC_ASSERT(constexpr_from_raw_check<s24x8>(), "s24x8::from_raw must be constexpr");
     // Unsigned
-    static_assert(constexpr_from_raw_check<u4x12>(), "u4x12::from_raw must be constexpr");
-    static_assert(constexpr_from_raw_check<u8x8>(), "u8x8::from_raw must be constexpr");
-    static_assert(constexpr_from_raw_check<u8x24>(), "u8x24::from_raw must be constexpr");
-    static_assert(constexpr_from_raw_check<u12x4>(), "u12x4::from_raw must be constexpr");
-    static_assert(constexpr_from_raw_check<u16x16>(), "u16x16::from_raw must be constexpr");
-    static_assert(constexpr_from_raw_check<u24x8>(), "u24x8::from_raw must be constexpr");
+    FL_STATIC_ASSERT(constexpr_from_raw_check<u4x12>(), "u4x12::from_raw must be constexpr");
+    FL_STATIC_ASSERT(constexpr_from_raw_check<u8x8>(), "u8x8::from_raw must be constexpr");
+    FL_STATIC_ASSERT(constexpr_from_raw_check<u8x24>(), "u8x24::from_raw must be constexpr");
+    FL_STATIC_ASSERT(constexpr_from_raw_check<u12x4>(), "u12x4::from_raw must be constexpr");
+    FL_STATIC_ASSERT(constexpr_from_raw_check<u16x16>(), "u16x16::from_raw must be constexpr");
+    FL_STATIC_ASSERT(constexpr_from_raw_check<u24x8>(), "u24x8::from_raw must be constexpr");
 }
 
 FL_TEST_CASE("constexpr arithmetic operators") {
     // Addition
-    static_assert(constexpr_add_check<s8x8>(1.5f, 0.5f), "s8x8 + must be constexpr");
-    static_assert(constexpr_add_check<s16x16>(1.5f, 0.5f), "s16x16 + must be constexpr");
-    static_assert(constexpr_add_check<u8x8>(1.5f, 0.5f), "u8x8 + must be constexpr");
-    static_assert(constexpr_add_check<u16x16>(1.5f, 0.5f), "u16x16 + must be constexpr");
+    FL_STATIC_ASSERT(constexpr_add_check<s8x8>(1.5f, 0.5f), "s8x8 + must be constexpr");
+    FL_STATIC_ASSERT(constexpr_add_check<s16x16>(1.5f, 0.5f), "s16x16 + must be constexpr");
+    FL_STATIC_ASSERT(constexpr_add_check<u8x8>(1.5f, 0.5f), "u8x8 + must be constexpr");
+    FL_STATIC_ASSERT(constexpr_add_check<u16x16>(1.5f, 0.5f), "u16x16 + must be constexpr");
     // Subtraction
-    static_assert(constexpr_sub_check<s8x8>(1.5f, 0.5f), "s8x8 - must be constexpr");
-    static_assert(constexpr_sub_check<s16x16>(1.5f, 0.5f), "s16x16 - must be constexpr");
+    FL_STATIC_ASSERT(constexpr_sub_check<s8x8>(1.5f, 0.5f), "s8x8 - must be constexpr");
+    FL_STATIC_ASSERT(constexpr_sub_check<s16x16>(1.5f, 0.5f), "s16x16 - must be constexpr");
     // Unary minus
-    static_assert(constexpr_neg_check<s8x8>(1.5f), "s8x8 unary- must be constexpr");
-    static_assert(constexpr_neg_check<s16x16>(1.5f), "s16x16 unary- must be constexpr");
+    FL_STATIC_ASSERT(constexpr_neg_check<s8x8>(1.5f), "s8x8 unary- must be constexpr");
+    FL_STATIC_ASSERT(constexpr_neg_check<s16x16>(1.5f), "s16x16 unary- must be constexpr");
     // Multiply
-    static_assert(constexpr_mul_check<s8x8>(2.0f, 0.5f), "s8x8 * must be constexpr");
-    static_assert(constexpr_mul_check<s16x16>(2.0f, 0.5f), "s16x16 * must be constexpr");
-    static_assert(constexpr_mul_check<u8x8>(2.0f, 0.5f), "u8x8 * must be constexpr");
+    FL_STATIC_ASSERT(constexpr_mul_check<s8x8>(2.0f, 0.5f), "s8x8 * must be constexpr");
+    FL_STATIC_ASSERT(constexpr_mul_check<s16x16>(2.0f, 0.5f), "s16x16 * must be constexpr");
+    FL_STATIC_ASSERT(constexpr_mul_check<u8x8>(2.0f, 0.5f), "u8x8 * must be constexpr");
     // Divide
-    static_assert(constexpr_div_check<s8x8>(2.0f, 0.5f), "s8x8 / must be constexpr");
-    static_assert(constexpr_div_check<s16x16>(2.0f, 0.5f), "s16x16 / must be constexpr");
+    FL_STATIC_ASSERT(constexpr_div_check<s8x8>(2.0f, 0.5f), "s8x8 / must be constexpr");
+    FL_STATIC_ASSERT(constexpr_div_check<s16x16>(2.0f, 0.5f), "s16x16 / must be constexpr");
     // Right shift
-    static_assert(constexpr_rshift_check<s16x16>(4.0f), "s16x16 >> must be constexpr");
+    FL_STATIC_ASSERT(constexpr_rshift_check<s16x16>(4.0f), "s16x16 >> must be constexpr");
 }
 
 FL_TEST_CASE("constexpr comparisons") {
-    static_assert(constexpr_lt_check<s16x16>(1.0f, 2.0f), "s16x16 < must be constexpr");
-    static_assert(constexpr_eq_check<s16x16>(1.0f), "s16x16 == must be constexpr");
-    static_assert(constexpr_lt_check<s8x8>(1.0f, 2.0f), "s8x8 < must be constexpr");
-    static_assert(constexpr_eq_check<u16x16>(1.0f), "u16x16 == must be constexpr");
+    FL_STATIC_ASSERT(constexpr_lt_check<s16x16>(1.0f, 2.0f), "s16x16 < must be constexpr");
+    FL_STATIC_ASSERT(constexpr_eq_check<s16x16>(1.0f), "s16x16 == must be constexpr");
+    FL_STATIC_ASSERT(constexpr_lt_check<s8x8>(1.0f, 2.0f), "s8x8 < must be constexpr");
+    FL_STATIC_ASSERT(constexpr_eq_check<u16x16>(1.0f), "u16x16 == must be constexpr");
 }
 
 FL_TEST_CASE("constexpr conversions") {
-    static_assert(constexpr_to_int_check<s16x16>(2.0f) == 2, "s16x16 to_int must be constexpr");
-    static_assert(constexpr_to_int_check<s8x8>(3.0f) == 3, "s8x8 to_int must be constexpr");
+    FL_STATIC_ASSERT(constexpr_to_int_check<s16x16>(2.0f) == 2, "s16x16 to_int must be constexpr");
+    FL_STATIC_ASSERT(constexpr_to_int_check<s8x8>(3.0f) == 3, "s8x8 to_int must be constexpr");
     // to_float constexpr check (just verify it compiles)
-    static_assert(constexpr_to_float_check<s16x16>(1.0f) > 0.0f, "s16x16 to_float must be constexpr");
+    FL_STATIC_ASSERT(constexpr_to_float_check<s16x16>(1.0f) > 0.0f, "s16x16 to_float must be constexpr");
 }
 
 FL_TEST_CASE("constexpr math functions") {
     // mod
-    static_assert(constexpr_mod_check<s16x16>(1.5f, 1.0f), "s16x16 mod must be constexpr");
-    static_assert(constexpr_mod_check<s8x8>(1.5f, 1.0f), "s8x8 mod must be constexpr");
+    FL_STATIC_ASSERT(constexpr_mod_check<s16x16>(1.5f, 1.0f), "s16x16 mod must be constexpr");
+    FL_STATIC_ASSERT(constexpr_mod_check<s8x8>(1.5f, 1.0f), "s8x8 mod must be constexpr");
     // floor
-    static_assert(constexpr_floor_check<s16x16>(1.7f), "s16x16 floor must be constexpr");
-    static_assert(constexpr_floor_check<s8x8>(1.7f), "s8x8 floor must be constexpr");
+    FL_STATIC_ASSERT(constexpr_floor_check<s16x16>(1.7f), "s16x16 floor must be constexpr");
+    FL_STATIC_ASSERT(constexpr_floor_check<s8x8>(1.7f), "s8x8 floor must be constexpr");
     // ceil
-    static_assert(constexpr_ceil_check<s16x16>(1.3f), "s16x16 ceil must be constexpr");
-    static_assert(constexpr_ceil_check<s8x8>(1.3f), "s8x8 ceil must be constexpr");
+    FL_STATIC_ASSERT(constexpr_ceil_check<s16x16>(1.3f), "s16x16 ceil must be constexpr");
+    FL_STATIC_ASSERT(constexpr_ceil_check<s8x8>(1.3f), "s8x8 ceil must be constexpr");
     // fract
-    static_assert(constexpr_fract_check<s16x16>(1.7f), "s16x16 fract must be constexpr");
+    FL_STATIC_ASSERT(constexpr_fract_check<s16x16>(1.7f), "s16x16 fract must be constexpr");
     // abs
-    static_assert(constexpr_abs_check<s16x16>(-1.5f), "s16x16 abs must be constexpr");
-    static_assert(constexpr_abs_check<s8x8>(-1.5f), "s8x8 abs must be constexpr");
+    FL_STATIC_ASSERT(constexpr_abs_check<s16x16>(-1.5f), "s16x16 abs must be constexpr");
+    FL_STATIC_ASSERT(constexpr_abs_check<s8x8>(-1.5f), "s8x8 abs must be constexpr");
     // sign
-    static_assert(constexpr_sign_check<s16x16>(1.0f) == 1, "s16x16 sign(+) must be 1");
-    static_assert(constexpr_sign_check<s16x16>(-1.0f) == -1, "s16x16 sign(-) must be -1");
+    FL_STATIC_ASSERT(constexpr_sign_check<s16x16>(1.0f) == 1, "s16x16 sign(+) must be 1");
+    FL_STATIC_ASSERT(constexpr_sign_check<s16x16>(-1.0f) == -1, "s16x16 sign(-) must be -1");
     // lerp
-    static_assert(constexpr_lerp_check<s16x16>(0.0f, 2.0f, 0.5f), "s16x16 lerp must be constexpr");
+    FL_STATIC_ASSERT(constexpr_lerp_check<s16x16>(0.0f, 2.0f, 0.5f), "s16x16 lerp must be constexpr");
     // clamp
-    static_assert(constexpr_clamp_check<s16x16>(3.0f, 0.0f, 2.0f), "s16x16 clamp must be constexpr");
+    FL_STATIC_ASSERT(constexpr_clamp_check<s16x16>(3.0f, 0.0f, 2.0f), "s16x16 clamp must be constexpr");
     // step
-    static_assert(constexpr_step_check<s16x16>(0.5f, 1.0f), "s16x16 step must be constexpr");
+    FL_STATIC_ASSERT(constexpr_step_check<s16x16>(0.5f, 1.0f), "s16x16 step must be constexpr");
     // sqrt - all signed types
-    static_assert(constexpr_sqrt_check<s4x12>(1.0f), "s4x12 sqrt must be constexpr");
-    static_assert(constexpr_sqrt_check<s8x8>(1.0f), "s8x8 sqrt must be constexpr");
-    static_assert(constexpr_sqrt_check<s8x24>(1.0f), "s8x24 sqrt must be constexpr");
-    static_assert(constexpr_sqrt_check<s12x4>(1.0f), "s12x4 sqrt must be constexpr");
-    static_assert(constexpr_sqrt_check<s16x16>(1.0f), "s16x16 sqrt must be constexpr");
-    static_assert(constexpr_sqrt_check<s24x8>(1.0f), "s24x8 sqrt must be constexpr");
+    FL_STATIC_ASSERT(constexpr_sqrt_check<s4x12>(1.0f), "s4x12 sqrt must be constexpr");
+    FL_STATIC_ASSERT(constexpr_sqrt_check<s8x8>(1.0f), "s8x8 sqrt must be constexpr");
+    FL_STATIC_ASSERT(constexpr_sqrt_check<s8x24>(1.0f), "s8x24 sqrt must be constexpr");
+    FL_STATIC_ASSERT(constexpr_sqrt_check<s12x4>(1.0f), "s12x4 sqrt must be constexpr");
+    FL_STATIC_ASSERT(constexpr_sqrt_check<s16x16>(1.0f), "s16x16 sqrt must be constexpr");
+    FL_STATIC_ASSERT(constexpr_sqrt_check<s24x8>(1.0f), "s24x8 sqrt must be constexpr");
     // sqrt - all unsigned types
-    static_assert(constexpr_sqrt_check<u4x12>(1.0f), "u4x12 sqrt must be constexpr");
-    static_assert(constexpr_sqrt_check<u8x8>(1.0f), "u8x8 sqrt must be constexpr");
-    static_assert(constexpr_sqrt_check<u8x24>(1.0f), "u8x24 sqrt must be constexpr");
-    static_assert(constexpr_sqrt_check<u12x4>(1.0f), "u12x4 sqrt must be constexpr");
-    static_assert(constexpr_sqrt_check<u16x16>(1.0f), "u16x16 sqrt must be constexpr");
-    static_assert(constexpr_sqrt_check<u24x8>(1.0f), "u24x8 sqrt must be constexpr");
+    FL_STATIC_ASSERT(constexpr_sqrt_check<u4x12>(1.0f), "u4x12 sqrt must be constexpr");
+    FL_STATIC_ASSERT(constexpr_sqrt_check<u8x8>(1.0f), "u8x8 sqrt must be constexpr");
+    FL_STATIC_ASSERT(constexpr_sqrt_check<u8x24>(1.0f), "u8x24 sqrt must be constexpr");
+    FL_STATIC_ASSERT(constexpr_sqrt_check<u12x4>(1.0f), "u12x4 sqrt must be constexpr");
+    FL_STATIC_ASSERT(constexpr_sqrt_check<u16x16>(1.0f), "u16x16 sqrt must be constexpr");
+    FL_STATIC_ASSERT(constexpr_sqrt_check<u24x8>(1.0f), "u24x8 sqrt must be constexpr");
     // rsqrt - all signed types
-    static_assert(constexpr_rsqrt_check<s4x12>(1.0f), "s4x12 rsqrt must be constexpr");
-    static_assert(constexpr_rsqrt_check<s8x8>(1.0f), "s8x8 rsqrt must be constexpr");
-    static_assert(constexpr_rsqrt_check<s8x24>(1.0f), "s8x24 rsqrt must be constexpr");
-    static_assert(constexpr_rsqrt_check<s12x4>(1.0f), "s12x4 rsqrt must be constexpr");
-    static_assert(constexpr_rsqrt_check<s16x16>(1.0f), "s16x16 rsqrt must be constexpr");
-    static_assert(constexpr_rsqrt_check<s24x8>(1.0f), "s24x8 rsqrt must be constexpr");
+    FL_STATIC_ASSERT(constexpr_rsqrt_check<s4x12>(1.0f), "s4x12 rsqrt must be constexpr");
+    FL_STATIC_ASSERT(constexpr_rsqrt_check<s8x8>(1.0f), "s8x8 rsqrt must be constexpr");
+    FL_STATIC_ASSERT(constexpr_rsqrt_check<s8x24>(1.0f), "s8x24 rsqrt must be constexpr");
+    FL_STATIC_ASSERT(constexpr_rsqrt_check<s12x4>(1.0f), "s12x4 rsqrt must be constexpr");
+    FL_STATIC_ASSERT(constexpr_rsqrt_check<s16x16>(1.0f), "s16x16 rsqrt must be constexpr");
+    FL_STATIC_ASSERT(constexpr_rsqrt_check<s24x8>(1.0f), "s24x8 rsqrt must be constexpr");
     // rsqrt - all unsigned types
-    static_assert(constexpr_rsqrt_check<u4x12>(1.0f), "u4x12 rsqrt must be constexpr");
-    static_assert(constexpr_rsqrt_check<u8x8>(1.0f), "u8x8 rsqrt must be constexpr");
-    static_assert(constexpr_rsqrt_check<u8x24>(1.0f), "u8x24 rsqrt must be constexpr");
-    static_assert(constexpr_rsqrt_check<u12x4>(1.0f), "u12x4 rsqrt must be constexpr");
-    static_assert(constexpr_rsqrt_check<u16x16>(1.0f), "u16x16 rsqrt must be constexpr");
-    static_assert(constexpr_rsqrt_check<u24x8>(1.0f), "u24x8 rsqrt must be constexpr");
+    FL_STATIC_ASSERT(constexpr_rsqrt_check<u4x12>(1.0f), "u4x12 rsqrt must be constexpr");
+    FL_STATIC_ASSERT(constexpr_rsqrt_check<u8x8>(1.0f), "u8x8 rsqrt must be constexpr");
+    FL_STATIC_ASSERT(constexpr_rsqrt_check<u8x24>(1.0f), "u8x24 rsqrt must be constexpr");
+    FL_STATIC_ASSERT(constexpr_rsqrt_check<u12x4>(1.0f), "u12x4 rsqrt must be constexpr");
+    FL_STATIC_ASSERT(constexpr_rsqrt_check<u16x16>(1.0f), "u16x16 rsqrt must be constexpr");
+    FL_STATIC_ASSERT(constexpr_rsqrt_check<u24x8>(1.0f), "u24x8 rsqrt must be constexpr");
 }
 
 // Verify constexpr works for concrete value computation
 FL_TEST_CASE("constexpr value verification") {
     // s16x16: 1.5 + 0.5 = 2.0
-    static_assert((s16x16(1.5f) + s16x16(0.5f)).raw() == s16x16(2.0f).raw(),
+    FL_STATIC_ASSERT((s16x16(1.5f) + s16x16(0.5f)).raw() == s16x16(2.0f).raw(),
                   "1.5 + 0.5 must equal 2.0");
 
     // s16x16: 3.0 * 2.0 = 6.0
-    static_assert((s16x16(3.0f) * s16x16(2.0f)).raw() == s16x16(6.0f).raw(),
+    FL_STATIC_ASSERT((s16x16(3.0f) * s16x16(2.0f)).raw() == s16x16(6.0f).raw(),
                   "3.0 * 2.0 must equal 6.0");
 
     // s16x16: floor(1.7) = 1.0
-    static_assert(s16x16::floor(s16x16(1.7f)).raw() == s16x16(1.0f).raw(),
+    FL_STATIC_ASSERT(s16x16::floor(s16x16(1.7f)).raw() == s16x16(1.0f).raw(),
                   "floor(1.7) must equal 1.0");
 
     // s8x8: -2.0 negation
-    static_assert((-s8x8(2.0f)).raw() == s8x8(-2.0f).raw(),
+    FL_STATIC_ASSERT((-s8x8(2.0f)).raw() == s8x8(-2.0f).raw(),
                   "-(2.0) must equal -2.0");
 
     // s16x16: clamp(3.0, 0.0, 2.0) = 2.0
-    static_assert(s16x16::clamp(s16x16(3.0f), s16x16(0.0f), s16x16(2.0f)).raw() == s16x16(2.0f).raw(),
+    FL_STATIC_ASSERT(s16x16::clamp(s16x16(3.0f), s16x16(0.0f), s16x16(2.0f)).raw() == s16x16(2.0f).raw(),
                   "clamp(3.0, 0.0, 2.0) must equal 2.0");
 
     // s16x16: abs(-1.5) = 1.5
-    static_assert(s16x16::abs(s16x16(-1.5f)).raw() == s16x16(1.5f).raw(),
+    FL_STATIC_ASSERT(s16x16::abs(s16x16(-1.5f)).raw() == s16x16(1.5f).raw(),
                   "abs(-1.5) must equal 1.5");
 
     // s16x16: sqrt(4.0) = 2.0
-    static_assert(s16x16::sqrt(s16x16(4.0f)).raw() == s16x16(2.0f).raw(),
+    FL_STATIC_ASSERT(s16x16::sqrt(s16x16(4.0f)).raw() == s16x16(2.0f).raw(),
                   "sqrt(4.0) must equal 2.0");
 
     // s16x16: sqrt(1.0) = 1.0
-    static_assert(s16x16::sqrt(s16x16(1.0f)).raw() == s16x16(1.0f).raw(),
+    FL_STATIC_ASSERT(s16x16::sqrt(s16x16(1.0f)).raw() == s16x16(1.0f).raw(),
                   "sqrt(1.0) must equal 1.0");
 
     // s16x16: sqrt(0.0) = 0.0
-    static_assert(s16x16::sqrt(s16x16(0.0f)).raw() == 0,
+    FL_STATIC_ASSERT(s16x16::sqrt(s16x16(0.0f)).raw() == 0,
                   "sqrt(0.0) must equal 0.0");
 
     // u16x16: sqrt(4.0) = 2.0
-    static_assert(u16x16::sqrt(u16x16(4.0f)).raw() == u16x16(2.0f).raw(),
+    FL_STATIC_ASSERT(u16x16::sqrt(u16x16(4.0f)).raw() == u16x16(2.0f).raw(),
                   "u16x16 sqrt(4.0) must equal 2.0");
 
     // s16x16: rsqrt(1.0) = 1.0
-    static_assert(s16x16::rsqrt(s16x16(1.0f)).raw() == s16x16(1.0f).raw(),
+    FL_STATIC_ASSERT(s16x16::rsqrt(s16x16(1.0f)).raw() == s16x16(1.0f).raw(),
                   "rsqrt(1.0) must equal 1.0");
 
     // s16x16: rsqrt(0.0) = 0.0 (zero guard)
-    static_assert(s16x16::rsqrt(s16x16(0.0f)).raw() == 0,
+    FL_STATIC_ASSERT(s16x16::rsqrt(s16x16(0.0f)).raw() == 0,
                   "rsqrt(0.0) must equal 0.0");
 
     // u16x16: rsqrt(1.0) = 1.0
-    static_assert(u16x16::rsqrt(u16x16(1.0f)).raw() == u16x16(1.0f).raw(),
+    FL_STATIC_ASSERT(u16x16::rsqrt(u16x16(1.0f)).raw() == u16x16(1.0f).raw(),
                   "u16x16 rsqrt(1.0) must equal 1.0");
 }
 

--- a/tests/fl/math/random.cpp
+++ b/tests/fl/math/random.cpp
@@ -8,6 +8,7 @@
 #include "fl/stl/vector.h"
 #include "fl/stl/move.h"
 #include "fl/stl/type_traits.h"
+#include "fl/stl/static_assert.h"
 
 FL_TEST_FILE(FL_FILEPATH) {
 
@@ -456,8 +457,8 @@ FL_TEST_CASE("fl::fl_random - Type traits") {
 
     FL_SUBCASE("Constexpr minimum and maximum") {
         // These should be usable in constant expressions
-        static_assert(fl_random::minimum() == 0, "minimum should be 0");
-        static_assert(fl_random::maximum() == 4294967295U, "maximum should be u32 max");
+        FL_STATIC_ASSERT(fl_random::minimum() == 0, "minimum should be 0");
+        FL_STATIC_ASSERT(fl_random::maximum() == 4294967295U, "maximum should be u32 max");
     }
 }
 

--- a/tests/fl/rx_device.cpp
+++ b/tests/fl/rx_device.cpp
@@ -10,6 +10,7 @@
 #include "fl/stl/move.h"
 #include "fl/stl/shared_ptr.h"
 #include "platforms/is_platform.h"
+#include "fl/stl/static_assert.h"
 
 FL_TEST_FILE(FL_FILEPATH) {
 
@@ -215,12 +216,12 @@ FL_TEST_CASE("EdgeTime - WS2812B pattern") {
 FL_TEST_CASE("EdgeTime - constexpr") {
     // Ensure constexpr constructors work at compile time
     constexpr EdgeTime e1;
-    static_assert(e1.high == 0, "Default constructor should create low edge");
-    static_assert(e1.ns == 0, "Default constructor should create 0ns duration");
+    FL_STATIC_ASSERT(e1.high == 0, "Default constructor should create low edge");
+    FL_STATIC_ASSERT(e1.ns == 0, "Default constructor should create 0ns duration");
 
     constexpr EdgeTime e2(true, 1000);
-    static_assert(e2.high == 1, "Constructor should set high flag");
-    static_assert(e2.ns == 1000, "Constructor should set ns value");
+    FL_STATIC_ASSERT(e2.high == 1, "Constructor should set high flag");
+    FL_STATIC_ASSERT(e2.ns == 1000, "Constructor should set ns value");
 
     // Runtime checks to ensure constexpr works correctly
     uint32_t high1 = e1.high;

--- a/tests/fl/stl/allocator.cpp
+++ b/tests/fl/stl/allocator.cpp
@@ -7,6 +7,7 @@
 #include "fl/stl/move.h"
 #include "fl/stl/type_traits.h"
 #include "fl/stl/int.h"
+#include "fl/stl/static_assert.h"
 
 FL_TEST_FILE(FL_FILEPATH) {
 
@@ -37,23 +38,23 @@ FL_TEST_CASE("fl::allocator_traits") {
 
     FL_SUBCASE("allocator_realloc has both capabilities") {
         // allocator_realloc should support both reallocate() and allocate_at_least()
-        static_assert(allocator_traits<allocator_realloc<int>>::has_reallocate_v,
+        FL_STATIC_ASSERT(allocator_traits<allocator_realloc<int>>::has_reallocate_v,
                      "allocator_realloc should support reallocate()");
-        static_assert(allocator_traits<allocator_realloc<int>>::has_allocate_at_least_v,
+        FL_STATIC_ASSERT(allocator_traits<allocator_realloc<int>>::has_allocate_at_least_v,
                      "allocator_realloc should support allocate_at_least()");
         FL_CHECK(true);  // Compile-time checks passed
     }
 
     FL_SUBCASE("base allocator<T> has allocate_at_least") {
         // Standard allocator should have allocate_at_least() (with default implementation)
-        static_assert(allocator_traits<allocator<int>>::has_allocate_at_least_v,
+        FL_STATIC_ASSERT(allocator_traits<allocator<int>>::has_allocate_at_least_v,
                      "allocator<T> should support allocate_at_least()");
         FL_CHECK(true);
     }
 
     FL_SUBCASE("base allocator<T> has default reallocate") {
         // Standard allocator has reallocate() that returns nullptr (no-op)
-        static_assert(allocator_traits<allocator<int>>::has_reallocate_v,
+        FL_STATIC_ASSERT(allocator_traits<allocator<int>>::has_reallocate_v,
                      "allocator<T> should have reallocate() method");
         FL_CHECK(true);
     }

--- a/tests/fl/stl/array.cpp
+++ b/tests/fl/stl/array.cpp
@@ -6,6 +6,7 @@
 #include "fl/stl/move.h"
 #include "fl/stl/type_traits.h"
 #include "fl/stl/int.h"
+#include "fl/stl/static_assert.h"
 
 FL_TEST_FILE(FL_FILEPATH) {
 
@@ -386,18 +387,18 @@ FL_TEST_CASE("fl::array - Edge cases") {
 FL_TEST_CASE("fl::array - Type traits") {
     FL_SUBCASE("value_type") {
         using ArrayType = array<int, 5>;
-        static_assert(fl::is_same<ArrayType::value_type, int>::value, "value_type should be int");
+        FL_STATIC_ASSERT(fl::is_same<ArrayType::value_type, int>::value, "value_type should be int");
     }
 
     FL_SUBCASE("size_type") {
         using ArrayType = array<int, 5>;
-        static_assert(fl::is_same<ArrayType::size_type, fl::size>::value, "size_type should be fl::size");
+        FL_STATIC_ASSERT(fl::is_same<ArrayType::size_type, fl::size>::value, "size_type should be fl::size");
     }
 
     FL_SUBCASE("iterator types") {
         using ArrayType = array<int, 5>;
-        static_assert(fl::is_same<ArrayType::iterator, int*>::value, "iterator should be int*");
-        static_assert(fl::is_same<ArrayType::const_iterator, const int*>::value, "const_iterator should be const int*");
+        FL_STATIC_ASSERT(fl::is_same<ArrayType::iterator, int*>::value, "iterator should be int*");
+        FL_STATIC_ASSERT(fl::is_same<ArrayType::const_iterator, const int*>::value, "const_iterator should be const int*");
     }
 }
 

--- a/tests/fl/stl/bit_cast.cpp
+++ b/tests/fl/stl/bit_cast.cpp
@@ -2,6 +2,7 @@
 #include "fl/stl/bit_cast.h"
 #include "test.h"
 #include "fl/stl/int.h"
+#include "fl/stl/static_assert.h"
 
 FL_TEST_FILE(FL_FILEPATH) {
 
@@ -217,35 +218,35 @@ FL_TEST_CASE("fl::ptr_to_int and fl::int_to_ptr") {
 FL_TEST_CASE("fl::is_bitcast_compatible trait") {
     FL_SUBCASE("Integral types are compatible") {
         // Use static_assert to check at compile time
-        static_assert(is_bitcast_compatible<u8>::value, "u8 should be bitcast compatible");
-        static_assert(is_bitcast_compatible<u16>::value, "u16 should be bitcast compatible");
-        static_assert(is_bitcast_compatible<u32>::value, "u32 should be bitcast compatible");
-        static_assert(is_bitcast_compatible<u64>::value, "u64 should be bitcast compatible");
-        static_assert(is_bitcast_compatible<i8>::value, "i8 should be bitcast compatible");
-        static_assert(is_bitcast_compatible<i16>::value, "i16 should be bitcast compatible");
-        static_assert(is_bitcast_compatible<i32>::value, "i32 should be bitcast compatible");
-        static_assert(is_bitcast_compatible<i64>::value, "i64 should be bitcast compatible");
+        FL_STATIC_ASSERT(is_bitcast_compatible<u8>::value, "u8 should be bitcast compatible");
+        FL_STATIC_ASSERT(is_bitcast_compatible<u16>::value, "u16 should be bitcast compatible");
+        FL_STATIC_ASSERT(is_bitcast_compatible<u32>::value, "u32 should be bitcast compatible");
+        FL_STATIC_ASSERT(is_bitcast_compatible<u64>::value, "u64 should be bitcast compatible");
+        FL_STATIC_ASSERT(is_bitcast_compatible<i8>::value, "i8 should be bitcast compatible");
+        FL_STATIC_ASSERT(is_bitcast_compatible<i16>::value, "i16 should be bitcast compatible");
+        FL_STATIC_ASSERT(is_bitcast_compatible<i32>::value, "i32 should be bitcast compatible");
+        FL_STATIC_ASSERT(is_bitcast_compatible<i64>::value, "i64 should be bitcast compatible");
         FL_CHECK(true);  // Dummy runtime check
     }
 
     FL_SUBCASE("Floating point types are compatible") {
-        static_assert(is_bitcast_compatible<float>::value, "float should be bitcast compatible");
-        static_assert(is_bitcast_compatible<double>::value, "double should be bitcast compatible");
+        FL_STATIC_ASSERT(is_bitcast_compatible<float>::value, "float should be bitcast compatible");
+        FL_STATIC_ASSERT(is_bitcast_compatible<double>::value, "double should be bitcast compatible");
         FL_CHECK(true);  // Dummy runtime check
     }
 
     FL_SUBCASE("Pointer types are compatible") {
-        static_assert(is_bitcast_compatible<int*>::value, "int* should be bitcast compatible");
-        static_assert(is_bitcast_compatible<float*>::value, "float* should be bitcast compatible");
-        static_assert(is_bitcast_compatible<void*>::value, "void* should be bitcast compatible");
-        static_assert(is_bitcast_compatible<const int*>::value, "const int* should be bitcast compatible");
+        FL_STATIC_ASSERT(is_bitcast_compatible<int*>::value, "int* should be bitcast compatible");
+        FL_STATIC_ASSERT(is_bitcast_compatible<float*>::value, "float* should be bitcast compatible");
+        FL_STATIC_ASSERT(is_bitcast_compatible<void*>::value, "void* should be bitcast compatible");
+        FL_STATIC_ASSERT(is_bitcast_compatible<const int*>::value, "const int* should be bitcast compatible");
         FL_CHECK(true);  // Dummy runtime check
     }
 
     FL_SUBCASE("Const types preserve compatibility") {
-        static_assert(is_bitcast_compatible<const int>::value, "const int should be bitcast compatible");
-        static_assert(is_bitcast_compatible<const float>::value, "const float should be bitcast compatible");
-        static_assert(is_bitcast_compatible<const u32>::value, "const u32 should be bitcast compatible");
+        FL_STATIC_ASSERT(is_bitcast_compatible<const int>::value, "const int should be bitcast compatible");
+        FL_STATIC_ASSERT(is_bitcast_compatible<const float>::value, "const float should be bitcast compatible");
+        FL_STATIC_ASSERT(is_bitcast_compatible<const u32>::value, "const u32 should be bitcast compatible");
         FL_CHECK(true);  // Dummy runtime check
     }
 }

--- a/tests/fl/stl/cstddef.cpp
+++ b/tests/fl/stl/cstddef.cpp
@@ -1,6 +1,7 @@
 #include "fl/stl/cstddef.h"
 #include "fl/stl/cstddef.h"
 #include "test.h"
+#include "fl/stl/static_assert.h"
 
 FL_TEST_FILE(FL_FILEPATH) {
 
@@ -239,7 +240,7 @@ FL_TEST_CASE("FL_OFFSETOF macro") {
         // This test verifies that FL_OFFSETOF can be used in contexts
         // requiring compile-time constants
         constexpr fl::size_t offset = FL_OFFSETOF(SimpleStruct, b);
-        static_assert(offset == FL_OFFSETOF(SimpleStruct, b), "FL_OFFSETOF should be constexpr");
+        FL_STATIC_ASSERT(offset == FL_OFFSETOF(SimpleStruct, b), "FL_OFFSETOF should be constexpr");
 
         // Use the constexpr value
         FL_CHECK(offset >= 0);

--- a/tests/fl/stl/functional.cpp
+++ b/tests/fl/stl/functional.cpp
@@ -6,6 +6,7 @@
 #include "fl/stl/move.h"
 #include "fl/stl/type_traits.h"
 #include "fl/stl/unique_ptr.h"
+#include "fl/stl/static_assert.h"
 
 FL_TEST_FILE(FL_FILEPATH) {
 
@@ -202,18 +203,18 @@ FL_TEST_CASE("fl::invoke helper traits") {
     // Test is_member_data_pointer
     FL_SUBCASE("is_member_data_pointer trait") {
         using namespace detail;
-        static_assert(!is_member_data_pointer<int>::value, "int is not a member data pointer");
-        static_assert(is_member_data_pointer<int Calculator::*>::value, "int Calculator::* is a member data pointer");
-        static_assert(!is_member_data_pointer<int (Calculator::*)(int)>::value, "member function pointer is not a member data pointer");
+        FL_STATIC_ASSERT(!is_member_data_pointer<int>::value, "int is not a member data pointer");
+        FL_STATIC_ASSERT(is_member_data_pointer<int Calculator::*>::value, "int Calculator::* is a member data pointer");
+        FL_STATIC_ASSERT(!is_member_data_pointer<int (Calculator::*)(int)>::value, "member function pointer is not a member data pointer");
     }
 
     // Test is_pointer_like
     FL_SUBCASE("is_pointer_like trait") {
         using namespace detail;
-        static_assert(!is_pointer_like<int>::value, "int is not pointer-like");
-        static_assert(!is_pointer_like<Calculator>::value, "Calculator is not pointer-like");
-        static_assert(is_pointer_like<int*>::value, "int* is pointer-like");
-        static_assert(is_pointer_like<Calculator*>::value, "Calculator* is pointer-like");
+        FL_STATIC_ASSERT(!is_pointer_like<int>::value, "int is not pointer-like");
+        FL_STATIC_ASSERT(!is_pointer_like<Calculator>::value, "Calculator is not pointer-like");
+        FL_STATIC_ASSERT(is_pointer_like<int*>::value, "int* is pointer-like");
+        FL_STATIC_ASSERT(is_pointer_like<Calculator*>::value, "Calculator* is pointer-like");
     }
 }
 

--- a/tests/fl/stl/limits.cpp
+++ b/tests/fl/stl/limits.cpp
@@ -1,6 +1,7 @@
 #include "test.h"
 #include "fl/stl/limits.h"
 #include "test.h"
+#include "fl/stl/static_assert.h"
 
 FL_TEST_FILE(FL_FILEPATH) {
 
@@ -47,9 +48,9 @@ FL_TEST_CASE("fl::numeric_limits<bool>") {
     }
 
     FL_SUBCASE("constexpr evaluation") {
-        static_assert(numeric_limits<bool>::min() == false, "min() must be constexpr");
-        static_assert(numeric_limits<bool>::max() == true, "max() must be constexpr");
-        static_assert(numeric_limits<bool>::is_specialized, "is_specialized must be constexpr");
+        FL_STATIC_ASSERT(numeric_limits<bool>::min() == false, "min() must be constexpr");
+        FL_STATIC_ASSERT(numeric_limits<bool>::max() == true, "max() must be constexpr");
+        FL_STATIC_ASSERT(numeric_limits<bool>::is_specialized, "is_specialized must be constexpr");
     }
 }
 
@@ -113,8 +114,8 @@ FL_TEST_CASE("fl::numeric_limits<signed char>") {
     }
 
     FL_SUBCASE("constexpr evaluation") {
-        static_assert(numeric_limits<signed char>::min() == -128, "min() must be constexpr");
-        static_assert(numeric_limits<signed char>::max() == 127, "max() must be constexpr");
+        FL_STATIC_ASSERT(numeric_limits<signed char>::min() == -128, "min() must be constexpr");
+        FL_STATIC_ASSERT(numeric_limits<signed char>::max() == 127, "max() must be constexpr");
     }
 }
 
@@ -139,8 +140,8 @@ FL_TEST_CASE("fl::numeric_limits<unsigned char>") {
     }
 
     FL_SUBCASE("constexpr evaluation") {
-        static_assert(numeric_limits<unsigned char>::min() == 0, "min() must be constexpr");
-        static_assert(numeric_limits<unsigned char>::max() == 255, "max() must be constexpr");
+        FL_STATIC_ASSERT(numeric_limits<unsigned char>::min() == 0, "min() must be constexpr");
+        FL_STATIC_ASSERT(numeric_limits<unsigned char>::max() == 255, "max() must be constexpr");
     }
 }
 
@@ -165,8 +166,8 @@ FL_TEST_CASE("fl::numeric_limits<short>") {
     }
 
     FL_SUBCASE("constexpr evaluation") {
-        static_assert(numeric_limits<short>::min() == -32768, "min() must be constexpr");
-        static_assert(numeric_limits<short>::max() == 32767, "max() must be constexpr");
+        FL_STATIC_ASSERT(numeric_limits<short>::min() == -32768, "min() must be constexpr");
+        FL_STATIC_ASSERT(numeric_limits<short>::max() == 32767, "max() must be constexpr");
     }
 }
 
@@ -191,8 +192,8 @@ FL_TEST_CASE("fl::numeric_limits<unsigned short>") {
     }
 
     FL_SUBCASE("constexpr evaluation") {
-        static_assert(numeric_limits<unsigned short>::min() == 0, "min() must be constexpr");
-        static_assert(numeric_limits<unsigned short>::max() == 65535, "max() must be constexpr");
+        FL_STATIC_ASSERT(numeric_limits<unsigned short>::min() == 0, "min() must be constexpr");
+        FL_STATIC_ASSERT(numeric_limits<unsigned short>::max() == 65535, "max() must be constexpr");
     }
 }
 
@@ -338,8 +339,8 @@ FL_TEST_CASE("fl::numeric_limits<long long>") {
     }
 
     FL_SUBCASE("constexpr evaluation") {
-        static_assert(numeric_limits<long long>::digits == 63, "digits must be constexpr");
-        static_assert(numeric_limits<long long>::max() == 9223372036854775807LL, "max() must be constexpr");
+        FL_STATIC_ASSERT(numeric_limits<long long>::digits == 63, "digits must be constexpr");
+        FL_STATIC_ASSERT(numeric_limits<long long>::max() == 9223372036854775807LL, "max() must be constexpr");
     }
 }
 
@@ -364,8 +365,8 @@ FL_TEST_CASE("fl::numeric_limits<unsigned long long>") {
     }
 
     FL_SUBCASE("constexpr evaluation") {
-        static_assert(numeric_limits<unsigned long long>::digits == 64, "digits must be constexpr");
-        static_assert(numeric_limits<unsigned long long>::max() == 18446744073709551615ull, "max() must be constexpr");
+        FL_STATIC_ASSERT(numeric_limits<unsigned long long>::digits == 64, "digits must be constexpr");
+        FL_STATIC_ASSERT(numeric_limits<unsigned long long>::max() == 18446744073709551615ull, "max() must be constexpr");
     }
 }
 
@@ -449,9 +450,9 @@ FL_TEST_CASE("fl::numeric_limits<float>") {
         constexpr float max_val = numeric_limits<float>::max();
         constexpr float eps = numeric_limits<float>::epsilon();
 
-        static_assert(min_val > 0.0f, "min() must be constexpr");
-        static_assert(max_val > 0.0f, "max() must be constexpr");
-        static_assert(eps > 0.0f, "epsilon() must be constexpr");
+        FL_STATIC_ASSERT(min_val > 0.0f, "min() must be constexpr");
+        FL_STATIC_ASSERT(max_val > 0.0f, "max() must be constexpr");
+        FL_STATIC_ASSERT(eps > 0.0f, "epsilon() must be constexpr");
     }
 }
 
@@ -536,9 +537,9 @@ FL_TEST_CASE("fl::numeric_limits<double>") {
         constexpr double max_val = numeric_limits<double>::max();
         constexpr double eps = numeric_limits<double>::epsilon();
 
-        static_assert(min_val > 0.0, "min() must be constexpr");
-        static_assert(max_val > 0.0, "max() must be constexpr");
-        static_assert(eps > 0.0, "epsilon() must be constexpr");
+        FL_STATIC_ASSERT(min_val > 0.0, "min() must be constexpr");
+        FL_STATIC_ASSERT(max_val > 0.0, "max() must be constexpr");
+        FL_STATIC_ASSERT(eps > 0.0, "epsilon() must be constexpr");
     }
 }
 

--- a/tests/fl/stl/limits.hpp
+++ b/tests/fl/stl/limits.hpp
@@ -1,5 +1,6 @@
 #include "test.h"
 #include "fl/stl/limits.h"
+#include "fl/stl/static_assert.h"
 
 using namespace fl;
 
@@ -10,7 +11,7 @@ FL_TEST_CASE("fl::numeric_limits<int>") {
         FL_CHECK_EQ(min_val, -2147483647 - 1);
 
         // Compile-time check
-        static_assert(numeric_limits<int>::min() < 0, "int min should be negative");
+        FL_STATIC_ASSERT(numeric_limits<int>::min() < 0, "int min should be negative");
     }
 
     FL_SUBCASE("max returns maximum int value") {
@@ -19,11 +20,11 @@ FL_TEST_CASE("fl::numeric_limits<int>") {
         FL_CHECK_EQ(max_val, 2147483647);
 
         // Compile-time check
-        static_assert(numeric_limits<int>::max() > 0, "int max should be positive");
+        FL_STATIC_ASSERT(numeric_limits<int>::max() > 0, "int max should be positive");
     }
 
     FL_SUBCASE("min is less than max") {
-        static_assert(numeric_limits<int>::min() < numeric_limits<int>::max(),
+        FL_STATIC_ASSERT(numeric_limits<int>::min() < numeric_limits<int>::max(),
                       "min should be less than max");
     }
 }
@@ -33,7 +34,7 @@ FL_TEST_CASE("fl::numeric_limits<unsigned int>") {
         constexpr unsigned int min_val = numeric_limits<unsigned int>::min();
         FL_CHECK_EQ(min_val, 0u);
 
-        static_assert(numeric_limits<unsigned int>::min() == 0,
+        FL_STATIC_ASSERT(numeric_limits<unsigned int>::min() == 0,
                       "unsigned int min should be 0");
     }
 
@@ -42,7 +43,7 @@ FL_TEST_CASE("fl::numeric_limits<unsigned int>") {
         // Should be 2^32 - 1 for 32-bit unsigned int
         FL_CHECK_EQ(max_val, 4294967295u);
 
-        static_assert(numeric_limits<unsigned int>::max() > 0,
+        FL_STATIC_ASSERT(numeric_limits<unsigned int>::max() > 0,
                       "unsigned int max should be positive");
     }
 }
@@ -52,14 +53,14 @@ FL_TEST_CASE("fl::numeric_limits<long>") {
         constexpr long min_val = numeric_limits<long>::min();
         FL_CHECK(min_val < 0);
 
-        static_assert(numeric_limits<long>::min() < 0, "long min should be negative");
+        FL_STATIC_ASSERT(numeric_limits<long>::min() < 0, "long min should be negative");
     }
 
     FL_SUBCASE("max returns maximum long value") {
         constexpr long max_val = numeric_limits<long>::max();
         FL_CHECK(max_val > 0);
 
-        static_assert(numeric_limits<long>::max() > 0, "long max should be positive");
+        FL_STATIC_ASSERT(numeric_limits<long>::max() > 0, "long max should be positive");
     }
 
     FL_SUBCASE("consistent with sizeof") {
@@ -81,7 +82,7 @@ FL_TEST_CASE("fl::numeric_limits<unsigned long>") {
         constexpr unsigned long min_val = numeric_limits<unsigned long>::min();
         FL_CHECK_EQ(min_val, 0ul);
 
-        static_assert(numeric_limits<unsigned long>::min() == 0,
+        FL_STATIC_ASSERT(numeric_limits<unsigned long>::min() == 0,
                       "unsigned long min should be 0");
     }
 
@@ -89,7 +90,7 @@ FL_TEST_CASE("fl::numeric_limits<unsigned long>") {
         constexpr unsigned long max_val = numeric_limits<unsigned long>::max();
         FL_CHECK(max_val > 0);
 
-        static_assert(numeric_limits<unsigned long>::max() > 0,
+        FL_STATIC_ASSERT(numeric_limits<unsigned long>::max() > 0,
                       "unsigned long max should be positive");
     }
 
@@ -109,7 +110,7 @@ FL_TEST_CASE("fl::numeric_limits<long long>") {
         // Should be -2^63
         FL_CHECK_EQ(min_val, -9223372036854775807LL - 1);
 
-        static_assert(numeric_limits<long long>::min() < 0,
+        FL_STATIC_ASSERT(numeric_limits<long long>::min() < 0,
                       "long long min should be negative");
     }
 
@@ -118,7 +119,7 @@ FL_TEST_CASE("fl::numeric_limits<long long>") {
         // Should be 2^63 - 1
         FL_CHECK_EQ(max_val, 9223372036854775807LL);
 
-        static_assert(numeric_limits<long long>::max() > 0,
+        FL_STATIC_ASSERT(numeric_limits<long long>::max() > 0,
                       "long long max should be positive");
     }
 }
@@ -128,7 +129,7 @@ FL_TEST_CASE("fl::numeric_limits<unsigned long long>") {
         constexpr unsigned long long min_val = numeric_limits<unsigned long long>::min();
         FL_CHECK_EQ(min_val, 0ull);
 
-        static_assert(numeric_limits<unsigned long long>::min() == 0,
+        FL_STATIC_ASSERT(numeric_limits<unsigned long long>::min() == 0,
                       "unsigned long long min should be 0");
     }
 
@@ -137,7 +138,7 @@ FL_TEST_CASE("fl::numeric_limits<unsigned long long>") {
         // Should be 2^64 - 1
         FL_CHECK_EQ(max_val, 18446744073709551615ull);
 
-        static_assert(numeric_limits<unsigned long long>::max() > 0,
+        FL_STATIC_ASSERT(numeric_limits<unsigned long long>::max() > 0,
                       "unsigned long long max should be positive");
     }
 }
@@ -151,7 +152,7 @@ FL_TEST_CASE("fl::numeric_limits<float>") {
         // Should match __FLT_MIN__
         FL_CHECK_EQ(min_val, __FLT_MIN__);
 
-        static_assert(numeric_limits<float>::min() > 0,
+        FL_STATIC_ASSERT(numeric_limits<float>::min() > 0,
                       "float min should be positive (smallest normalized value)");
     }
 
@@ -162,7 +163,7 @@ FL_TEST_CASE("fl::numeric_limits<float>") {
         // Should match __FLT_MAX__
         FL_CHECK_EQ(max_val, __FLT_MAX__);
 
-        static_assert(numeric_limits<float>::max() > 0,
+        FL_STATIC_ASSERT(numeric_limits<float>::max() > 0,
                       "float max should be positive");
     }
 }
@@ -176,7 +177,7 @@ FL_TEST_CASE("fl::numeric_limits<double>") {
         // Should match __DBL_MIN__
         FL_CHECK_EQ(min_val, __DBL_MIN__);
 
-        static_assert(numeric_limits<double>::min() > 0,
+        FL_STATIC_ASSERT(numeric_limits<double>::min() > 0,
                       "double min should be positive (smallest normalized value)");
     }
 
@@ -187,15 +188,15 @@ FL_TEST_CASE("fl::numeric_limits<double>") {
         // Should match __DBL_MAX__
         FL_CHECK_EQ(max_val, __DBL_MAX__);
 
-        static_assert(numeric_limits<double>::max() > 0,
+        FL_STATIC_ASSERT(numeric_limits<double>::max() > 0,
                       "double max should be positive");
     }
 
     FL_SUBCASE("double range is larger than float range") {
         // Double should have larger range than float
-        static_assert(numeric_limits<double>::max() > numeric_limits<float>::max(),
+        FL_STATIC_ASSERT(numeric_limits<double>::max() > numeric_limits<float>::max(),
                       "double max should be larger than float max");
-        static_assert(numeric_limits<double>::min() < numeric_limits<float>::min(),
+        FL_STATIC_ASSERT(numeric_limits<double>::min() < numeric_limits<float>::min(),
                       "double min should be smaller than float min");
     }
 }
@@ -228,7 +229,7 @@ FL_TEST_CASE("fl::numeric_limits compile-time evaluation") {
 FL_TEST_CASE("fl::numeric_limits integral relationships") {
     FL_SUBCASE("unsigned max is about twice signed max") {
         // For same-sized types, unsigned max ≈ 2 * signed max + 1
-        static_assert(numeric_limits<unsigned int>::max() ==
+        FL_STATIC_ASSERT(numeric_limits<unsigned int>::max() ==
                       static_cast<unsigned int>(numeric_limits<int>::max()) * 2u + 1u,
                       "unsigned max should be 2*signed_max + 1");
     }

--- a/tests/fl/stl/move.cpp
+++ b/tests/fl/stl/move.cpp
@@ -28,6 +28,7 @@
 #include "fl/stl/unordered_map_lru.h"
 #include "fl/stl/bitset_dynamic.h"
 #include "fl/stl/bitset.h"
+#include "fl/stl/static_assert.h"
 
 FL_TEST_FILE(FL_FILEPATH) {
 
@@ -83,69 +84,69 @@ struct MoveTestTypeMove {
 
 FL_TEST_CASE("fl::remove_reference trait") {
     FL_SUBCASE("Non-reference types remain unchanged") {
-        static_assert(fl::is_same<typename remove_reference<int>::type, int>::value,
+        FL_STATIC_ASSERT(fl::is_same<typename remove_reference<int>::type, int>::value,
                      "remove_reference should not change int");
-        static_assert(fl::is_same<typename remove_reference<float>::type, float>::value,
+        FL_STATIC_ASSERT(fl::is_same<typename remove_reference<float>::type, float>::value,
                      "remove_reference should not change float");
-        static_assert(fl::is_same<typename remove_reference<double>::type, double>::value,
+        FL_STATIC_ASSERT(fl::is_same<typename remove_reference<double>::type, double>::value,
                      "remove_reference should not change double");
-        static_assert(fl::is_same<typename remove_reference<char>::type, char>::value,
+        FL_STATIC_ASSERT(fl::is_same<typename remove_reference<char>::type, char>::value,
                      "remove_reference should not change char");
         FL_CHECK(true);  // Dummy runtime check
     }
 
     FL_SUBCASE("Pointer types remain unchanged") {
-        static_assert(fl::is_same<typename remove_reference<int*>::type, int*>::value,
+        FL_STATIC_ASSERT(fl::is_same<typename remove_reference<int*>::type, int*>::value,
                      "remove_reference should not change int*");
-        static_assert(fl::is_same<typename remove_reference<const int*>::type, const int*>::value,
+        FL_STATIC_ASSERT(fl::is_same<typename remove_reference<const int*>::type, const int*>::value,
                      "remove_reference should not change const int*");
-        static_assert(fl::is_same<typename remove_reference<void*>::type, void*>::value,
+        FL_STATIC_ASSERT(fl::is_same<typename remove_reference<void*>::type, void*>::value,
                      "remove_reference should not change void*");
         FL_CHECK(true);  // Dummy runtime check
     }
 
     FL_SUBCASE("Lvalue references are removed") {
-        static_assert(fl::is_same<typename remove_reference<int&>::type, int>::value,
+        FL_STATIC_ASSERT(fl::is_same<typename remove_reference<int&>::type, int>::value,
                      "remove_reference should remove lvalue reference from int&");
-        static_assert(fl::is_same<typename remove_reference<float&>::type, float>::value,
+        FL_STATIC_ASSERT(fl::is_same<typename remove_reference<float&>::type, float>::value,
                      "remove_reference should remove lvalue reference from float&");
-        static_assert(fl::is_same<typename remove_reference<const double&>::type, const double>::value,
+        FL_STATIC_ASSERT(fl::is_same<typename remove_reference<const double&>::type, const double>::value,
                      "remove_reference should remove lvalue reference from const double&");
         FL_CHECK(true);  // Dummy runtime check
     }
 
     FL_SUBCASE("Rvalue references are removed") {
-        static_assert(fl::is_same<typename remove_reference<int&&>::type, int>::value,
+        FL_STATIC_ASSERT(fl::is_same<typename remove_reference<int&&>::type, int>::value,
                      "remove_reference should remove rvalue reference from int&&");
-        static_assert(fl::is_same<typename remove_reference<float&&>::type, float>::value,
+        FL_STATIC_ASSERT(fl::is_same<typename remove_reference<float&&>::type, float>::value,
                      "remove_reference should remove rvalue reference from float&&");
-        static_assert(fl::is_same<typename remove_reference<const double&&>::type, const double>::value,
+        FL_STATIC_ASSERT(fl::is_same<typename remove_reference<const double&&>::type, const double>::value,
                      "remove_reference should remove rvalue reference from const double&&");
         FL_CHECK(true);  // Dummy runtime check
     }
 
     FL_SUBCASE("Const qualification is preserved") {
-        static_assert(fl::is_same<typename remove_reference<const int>::type, const int>::value,
+        FL_STATIC_ASSERT(fl::is_same<typename remove_reference<const int>::type, const int>::value,
                      "remove_reference should preserve const on non-reference");
-        static_assert(fl::is_same<typename remove_reference<const int&>::type, const int>::value,
+        FL_STATIC_ASSERT(fl::is_same<typename remove_reference<const int&>::type, const int>::value,
                      "remove_reference should preserve const when removing reference");
-        static_assert(fl::is_same<typename remove_reference<const int&&>::type, const int>::value,
+        FL_STATIC_ASSERT(fl::is_same<typename remove_reference<const int&&>::type, const int>::value,
                      "remove_reference should preserve const when removing rvalue reference");
         FL_CHECK(true);  // Dummy runtime check
     }
 
     FL_SUBCASE("Volatile qualification is preserved") {
-        static_assert(fl::is_same<typename remove_reference<volatile int>::type, volatile int>::value,
+        FL_STATIC_ASSERT(fl::is_same<typename remove_reference<volatile int>::type, volatile int>::value,
                      "remove_reference should preserve volatile on non-reference");
-        static_assert(fl::is_same<typename remove_reference<volatile int&>::type, volatile int>::value,
+        FL_STATIC_ASSERT(fl::is_same<typename remove_reference<volatile int&>::type, volatile int>::value,
                      "remove_reference should preserve volatile when removing reference");
         FL_CHECK(true);  // Dummy runtime check
     }
 
     FL_SUBCASE("CV qualifications are preserved") {
-        static_assert(fl::is_same<typename remove_reference<const volatile int>::type, const volatile int>::value,
+        FL_STATIC_ASSERT(fl::is_same<typename remove_reference<const volatile int>::type, const volatile int>::value,
                      "remove_reference should preserve const volatile");
-        static_assert(fl::is_same<typename remove_reference<const volatile int&>::type, const volatile int>::value,
+        FL_STATIC_ASSERT(fl::is_same<typename remove_reference<const volatile int&>::type, const volatile int>::value,
                      "remove_reference should preserve const volatile when removing reference");
         FL_CHECK(true);  // Dummy runtime check
     }
@@ -153,19 +154,19 @@ FL_TEST_CASE("fl::remove_reference trait") {
 
 FL_TEST_CASE("fl::remove_reference_t alias") {
     FL_SUBCASE("Alias works correctly for basic types") {
-        static_assert(fl::is_same<remove_reference_t<int>, int>::value,
+        FL_STATIC_ASSERT(fl::is_same<remove_reference_t<int>, int>::value,
                      "remove_reference_t should work like remove_reference::type");
-        static_assert(fl::is_same<remove_reference_t<int&>, int>::value,
+        FL_STATIC_ASSERT(fl::is_same<remove_reference_t<int&>, int>::value,
                      "remove_reference_t should remove lvalue reference");
-        static_assert(fl::is_same<remove_reference_t<int&&>, int>::value,
+        FL_STATIC_ASSERT(fl::is_same<remove_reference_t<int&&>, int>::value,
                      "remove_reference_t should remove rvalue reference");
         FL_CHECK(true);  // Dummy runtime check
     }
 
     FL_SUBCASE("Alias preserves qualifiers") {
-        static_assert(fl::is_same<remove_reference_t<const int&>, const int>::value,
+        FL_STATIC_ASSERT(fl::is_same<remove_reference_t<const int&>, const int>::value,
                      "remove_reference_t should preserve const");
-        static_assert(fl::is_same<remove_reference_t<volatile int&>, volatile int>::value,
+        FL_STATIC_ASSERT(fl::is_same<remove_reference_t<volatile int&>, volatile int>::value,
                      "remove_reference_t should preserve volatile");
         FL_CHECK(true);  // Dummy runtime check
     }
@@ -308,19 +309,19 @@ FL_TEST_CASE("fl::move is noexcept") {
     FL_SUBCASE("move is noexcept for basic types") {
         // fl::move itself should be noexcept
         int x = 10;
-        static_assert(noexcept(fl::move(x)), "fl::move should be noexcept");
+        FL_STATIC_ASSERT(noexcept(fl::move(x)), "fl::move should be noexcept");
         FL_CHECK(true);  // Dummy runtime check
     }
 
     FL_SUBCASE("move is noexcept for pointer types") {
         int* ptr = nullptr;
-        static_assert(noexcept(fl::move(ptr)), "fl::move should be noexcept");
+        FL_STATIC_ASSERT(noexcept(fl::move(ptr)), "fl::move should be noexcept");
         FL_CHECK(true);  // Dummy runtime check
     }
 
     FL_SUBCASE("move is noexcept for user types") {
         MoveTestTypeMove obj(10);
-        static_assert(noexcept(fl::move(obj)), "fl::move should be noexcept");
+        FL_STATIC_ASSERT(noexcept(fl::move(obj)), "fl::move should be noexcept");
         FL_CHECK(true);  // Dummy runtime check
     }
 #endif  // FL_HAS_NOEXCEPT
@@ -426,14 +427,14 @@ FL_TEST_CASE("fl::move type deduction") {
     FL_SUBCASE("Return type is rvalue reference") {
         int x = 10;
         // The return type should be int&&
-        static_assert(fl::is_same<decltype(fl::move(x)), int&&>::value,
+        FL_STATIC_ASSERT(fl::is_same<decltype(fl::move(x)), int&&>::value,
                      "fl::move should return rvalue reference");
         FL_CHECK(true);  // Dummy runtime check
     }
 
     FL_SUBCASE("Return type preserves base type") {
         float f = 3.14f;
-        static_assert(fl::is_same<decltype(fl::move(f)), float&&>::value,
+        FL_STATIC_ASSERT(fl::is_same<decltype(fl::move(f)), float&&>::value,
                      "fl::move should return float&&");
         FL_CHECK(true);  // Dummy runtime check
     }
@@ -442,14 +443,14 @@ FL_TEST_CASE("fl::move type deduction") {
         int x = 10;
         int& ref = x;
         // Input is int&, output should be int&&
-        static_assert(fl::is_same<decltype(fl::move(ref)), int&&>::value,
+        FL_STATIC_ASSERT(fl::is_same<decltype(fl::move(ref)), int&&>::value,
                      "fl::move should convert int& to int&&");
         FL_CHECK(true);  // Dummy runtime check
     }
 
     FL_SUBCASE("Return type for const types") {
         const int x = 10;
-        static_assert(fl::is_same<decltype(fl::move(x)), const int&&>::value,
+        FL_STATIC_ASSERT(fl::is_same<decltype(fl::move(x)), const int&&>::value,
                      "fl::move should return const int&&");
         FL_CHECK(true);  // Dummy runtime check
     }
@@ -505,18 +506,18 @@ FL_TEST_CASE("fl::move comparison with std semantics") {
 FL_TEST_CASE("fl::remove_reference with complex types") {
     FL_SUBCASE("remove_reference with function pointers") {
         typedef void (*FuncPtr)(int);
-        static_assert(fl::is_same<typename remove_reference<FuncPtr>::type, FuncPtr>::value,
+        FL_STATIC_ASSERT(fl::is_same<typename remove_reference<FuncPtr>::type, FuncPtr>::value,
                      "remove_reference should not change function pointer");
-        static_assert(fl::is_same<typename remove_reference<FuncPtr&>::type, FuncPtr>::value,
+        FL_STATIC_ASSERT(fl::is_same<typename remove_reference<FuncPtr&>::type, FuncPtr>::value,
                      "remove_reference should remove reference from function pointer");
         FL_CHECK(true);  // Dummy runtime check
     }
 
     FL_SUBCASE("remove_reference with array types") {
         typedef int ArrayType[10];
-        static_assert(fl::is_same<typename remove_reference<ArrayType>::type, ArrayType>::value,
+        FL_STATIC_ASSERT(fl::is_same<typename remove_reference<ArrayType>::type, ArrayType>::value,
                      "remove_reference should not change array type");
-        static_assert(fl::is_same<typename remove_reference<ArrayType&>::type, ArrayType>::value,
+        FL_STATIC_ASSERT(fl::is_same<typename remove_reference<ArrayType&>::type, ArrayType>::value,
                      "remove_reference should remove reference from array type");
         FL_CHECK(true);  // Dummy runtime check
     }

--- a/tests/fl/stl/not_null.cpp
+++ b/tests/fl/stl/not_null.cpp
@@ -3,6 +3,7 @@
 
 #include "test.h"
 #include "fl/stl/not_null.h"
+#include "fl/stl/static_assert.h"
 
 using namespace fl;
 
@@ -349,27 +350,27 @@ FL_TEST_CASE("not_null - compile-time type constraints") {
 // Test that verifies the type traits are working correctly
 FL_TEST_CASE("not_null - type traits verification") {
     // Verify is_comparable_to_nullptr works
-    static_assert(fl::detail::is_comparable_to_nullptr<int*>::value,
+    FL_STATIC_ASSERT(fl::detail::is_comparable_to_nullptr<int*>::value,
                   "int* should be comparable to nullptr");
-    static_assert(fl::detail::is_comparable_to_nullptr<const int*>::value,
+    FL_STATIC_ASSERT(fl::detail::is_comparable_to_nullptr<const int*>::value,
                   "const int* should be comparable to nullptr");
-    static_assert(fl::detail::is_comparable_to_nullptr<fl::CRGB*>::value,
+    FL_STATIC_ASSERT(fl::detail::is_comparable_to_nullptr<fl::CRGB*>::value,
                   "CRGB* should be comparable to nullptr");
 
     // Verify is_reference works
-    static_assert(!fl::detail::is_reference<int>::value,
+    FL_STATIC_ASSERT(!fl::detail::is_reference<int>::value,
                   "int should not be a reference");
-    static_assert(!fl::detail::is_reference<int*>::value,
+    FL_STATIC_ASSERT(!fl::detail::is_reference<int*>::value,
                   "int* should not be a reference");
-    static_assert(fl::detail::is_reference<int&>::value,
+    FL_STATIC_ASSERT(fl::detail::is_reference<int&>::value,
                   "int& should be a reference");
-    static_assert(fl::detail::is_reference<int&&>::value,
+    FL_STATIC_ASSERT(fl::detail::is_reference<int&&>::value,
                   "int&& should be a reference");
 
     // Verify is_dereferenceable works
-    static_assert(fl::detail::is_dereferenceable<int*>::value,
+    FL_STATIC_ASSERT(fl::detail::is_dereferenceable<int*>::value,
                   "int* should be dereferenceable");
-    static_assert(fl::detail::is_dereferenceable<fl::CRGB*>::value,
+    FL_STATIC_ASSERT(fl::detail::is_dereferenceable<fl::CRGB*>::value,
                   "CRGB* should be dereferenceable");
 
     // This test passes if all static_assert succeed at compile time

--- a/tests/fl/stl/pair.cpp
+++ b/tests/fl/stl/pair.cpp
@@ -2,6 +2,7 @@
 #include "test.h"
 #include "fl/stl/move.h"
 #include "fl/stl/type_traits.h"
+#include "fl/stl/static_assert.h"
 
 FL_TEST_FILE(FL_FILEPATH) {
 
@@ -228,13 +229,13 @@ FL_TEST_CASE("fl::pair move assignment") {
 
 FL_TEST_CASE("fl::pair member typedefs") {
     FL_SUBCASE("first_type typedef") {
-        static_assert(fl::is_same<pair<int, double>::first_type, int>::value, "first_type should be int");
-        static_assert(fl::is_same<pair<float, char>::first_type, float>::value, "first_type should be float");
+        FL_STATIC_ASSERT(fl::is_same<pair<int, double>::first_type, int>::value, "first_type should be int");
+        FL_STATIC_ASSERT(fl::is_same<pair<float, char>::first_type, float>::value, "first_type should be float");
     }
 
     FL_SUBCASE("second_type typedef") {
-        static_assert(fl::is_same<pair<int, double>::second_type, double>::value, "second_type should be double");
-        static_assert(fl::is_same<pair<float, char>::second_type, char>::value, "second_type should be char");
+        FL_STATIC_ASSERT(fl::is_same<pair<int, double>::second_type, double>::value, "second_type should be double");
+        FL_STATIC_ASSERT(fl::is_same<pair<float, char>::second_type, char>::value, "second_type should be char");
     }
 }
 
@@ -411,7 +412,7 @@ FL_TEST_CASE("fl::pair greater-than-or-equal operator") {
 FL_TEST_CASE("fl::make_pair function") {
     FL_SUBCASE("make_pair with primitives") {
         auto p = make_pair(42, 3.14);
-        static_assert(fl::is_same<decltype(p), pair<int, double>>::value, "make_pair should deduce types");
+        FL_STATIC_ASSERT(fl::is_same<decltype(p), pair<int, double>>::value, "make_pair should deduce types");
         FL_CHECK_EQ(p.first, 42);
         FL_CHECK_EQ(p.second, 3.14);
     }
@@ -434,7 +435,7 @@ FL_TEST_CASE("fl::make_pair function") {
         int arr[3] = {1, 2, 3};
         auto p = make_pair(arr, 42);
         // Array should decay to pointer
-        static_assert(fl::is_same<decltype(p.first), int*>::value, "Array should decay to pointer");
+        FL_STATIC_ASSERT(fl::is_same<decltype(p.first), int*>::value, "Array should decay to pointer");
         FL_CHECK_EQ(p.second, 42);
     }
 }
@@ -461,28 +462,28 @@ FL_TEST_CASE("fl::make_pair function") {
 
 FL_TEST_CASE("fl::pair_element type trait") {
     FL_SUBCASE("pair_element<0>") {
-        static_assert(fl::is_same<pair_element<0, int, double>::type, int>::value, "pair_element<0> should be int");
+        FL_STATIC_ASSERT(fl::is_same<pair_element<0, int, double>::type, int>::value, "pair_element<0> should be int");
     }
 
     FL_SUBCASE("pair_element<1>") {
-        static_assert(fl::is_same<pair_element<1, int, double>::type, double>::value, "pair_element<1> should be double");
+        FL_STATIC_ASSERT(fl::is_same<pair_element<1, int, double>::type, double>::value, "pair_element<1> should be double");
     }
 }
 
 FL_TEST_CASE("fl::tuple_size for pair") {
     FL_SUBCASE("tuple_size value") {
-        static_assert(tuple_size<pair<int, double>>::value == 2, "tuple_size should be 2");
-        static_assert(tuple_size<pair<float, char>>::value == 2, "tuple_size should be 2");
+        FL_STATIC_ASSERT(tuple_size<pair<int, double>>::value == 2, "tuple_size should be 2");
+        FL_STATIC_ASSERT(tuple_size<pair<float, char>>::value == 2, "tuple_size should be 2");
     }
 }
 
 FL_TEST_CASE("fl::tuple_element for pair") {
     FL_SUBCASE("tuple_element<0>") {
-        static_assert(fl::is_same<tuple_element<0, pair<int, double>>::type, int>::value, "tuple_element<0> should be int");
+        FL_STATIC_ASSERT(fl::is_same<tuple_element<0, pair<int, double>>::type, int>::value, "tuple_element<0> should be int");
     }
 
     FL_SUBCASE("tuple_element<1>") {
-        static_assert(fl::is_same<tuple_element<1, pair<int, double>>::type, double>::value, "tuple_element<1> should be double");
+        FL_STATIC_ASSERT(fl::is_same<tuple_element<1, pair<int, double>>::type, double>::value, "tuple_element<1> should be double");
     }
 }
 
@@ -587,7 +588,7 @@ FL_TEST_CASE("fl::Pair backwards compatibility") {
         Pair<int, double> p(42, 3.14);
         FL_CHECK_EQ(p.first, 42);
         FL_CHECK_EQ(p.second, 3.14);
-        static_assert(fl::is_same<Pair<int, double>, pair<int, double>>::value, "Pair should be alias for pair");
+        FL_STATIC_ASSERT(fl::is_same<Pair<int, double>, pair<int, double>>::value, "Pair should be alias for pair");
     }
 }
 

--- a/tests/fl/stl/range_access.cpp
+++ b/tests/fl/stl/range_access.cpp
@@ -1,6 +1,7 @@
 #include "fl/stl/range_access.h"
 #include "fl/stl/array.h"
 #include "test.h"
+#include "fl/stl/static_assert.h"
 
 FL_TEST_FILE(FL_FILEPATH) {
 
@@ -108,7 +109,7 @@ FL_TEST_CASE("fl::begin and fl::end constexpr") {
         constexpr const int* b = fl::begin(arr);
         constexpr const int* e = fl::end(arr);
 
-        static_assert(e - b == 3, "size should be 3");
+        FL_STATIC_ASSERT(e - b == 3, "size should be 3");
         FL_CHECK_EQ(e - b, 3);
     }
 

--- a/tests/fl/stl/stdint.cpp
+++ b/tests/fl/stl/stdint.cpp
@@ -2,6 +2,7 @@
 #include "fl/stl/stdint.h"
 #include "test.h"
 #include "stdint.h" // ok include - testing FL types against standard
+#include "fl/stl/static_assert.h"
 
 FL_TEST_FILE(FL_FILEPATH) {
 
@@ -334,17 +335,17 @@ FL_TEST_CASE("stdint constexpr compatibility") {
 
     FL_SUBCASE("static assertions") {
         // These should compile successfully
-        static_assert(sizeof(uint8_t) == 1, "uint8_t should be 1 byte");
-        static_assert(sizeof(uint16_t) == 2, "uint16_t should be 2 bytes");
-        static_assert(sizeof(uint32_t) == 4, "uint32_t should be 4 bytes");
-        static_assert(sizeof(uint64_t) == 8, "uint64_t should be 8 bytes");
+        FL_STATIC_ASSERT(sizeof(uint8_t) == 1, "uint8_t should be 1 byte");
+        FL_STATIC_ASSERT(sizeof(uint16_t) == 2, "uint16_t should be 2 bytes");
+        FL_STATIC_ASSERT(sizeof(uint32_t) == 4, "uint32_t should be 4 bytes");
+        FL_STATIC_ASSERT(sizeof(uint64_t) == 8, "uint64_t should be 8 bytes");
 
-        static_assert(INT8_MAX == 127, "INT8_MAX should be 127");
-        static_assert(UINT8_MAX == 255, "UINT8_MAX should be 255");
-        static_assert(INT16_MAX == 32767, "INT16_MAX should be 32767");
-        static_assert(UINT16_MAX == 65535, "UINT16_MAX should be 65535");
-        static_assert(INT32_MAX == 2147483647, "INT32_MAX should be 2147483647");
-        static_assert(UINT32_MAX == 4294967295U, "UINT32_MAX should be 4294967295U");
+        FL_STATIC_ASSERT(INT8_MAX == 127, "INT8_MAX should be 127");
+        FL_STATIC_ASSERT(UINT8_MAX == 255, "UINT8_MAX should be 255");
+        FL_STATIC_ASSERT(INT16_MAX == 32767, "INT16_MAX should be 32767");
+        FL_STATIC_ASSERT(UINT16_MAX == 65535, "UINT16_MAX should be 65535");
+        FL_STATIC_ASSERT(INT32_MAX == 2147483647, "INT32_MAX should be 2147483647");
+        FL_STATIC_ASSERT(UINT32_MAX == 4294967295U, "UINT32_MAX should be 4294967295U");
     }
 }
 

--- a/tests/fl/stl/type_traits.cpp
+++ b/tests/fl/stl/type_traits.cpp
@@ -2,6 +2,7 @@
 #include "test.h"
 #include "fl/stl/int.h"
 #include "fl/stl/move.h"
+#include "fl/stl/static_assert.h"
 
 FL_TEST_FILE(FL_FILEPATH) {
 
@@ -53,32 +54,32 @@ FL_TEST_CASE("fl::integral_constant") {
 
 FL_TEST_CASE("fl::identity") {
     FL_SUBCASE("preserves type") {
-        static_assert(is_same<identity<int>::type, int>::value, "identity should preserve int");
-        static_assert(is_same<identity<float>::type, float>::value, "identity should preserve float");
-        static_assert(is_same<identity<Base>::type, Base>::value, "identity should preserve class");
+        FL_STATIC_ASSERT(is_same<identity<int>::type, int>::value, "identity should preserve int");
+        FL_STATIC_ASSERT(is_same<identity<float>::type, float>::value, "identity should preserve float");
+        FL_STATIC_ASSERT(is_same<identity<Base>::type, Base>::value, "identity should preserve class");
     }
 }
 
 FL_TEST_CASE("fl::add_rvalue_reference") {
     FL_SUBCASE("non-reference types") {
-        static_assert(is_same<add_rvalue_reference<int>::type, int&&>::value, "should add rvalue ref to int");
-        static_assert(is_same<add_rvalue_reference<float>::type, float&&>::value, "should add rvalue ref to float");
+        FL_STATIC_ASSERT(is_same<add_rvalue_reference<int>::type, int&&>::value, "should add rvalue ref to int");
+        FL_STATIC_ASSERT(is_same<add_rvalue_reference<float>::type, float&&>::value, "should add rvalue ref to float");
     }
 
     FL_SUBCASE("lvalue reference types") {
-        static_assert(is_same<add_rvalue_reference<int&>::type, int&>::value, "should preserve lvalue ref");
-        static_assert(is_same<add_rvalue_reference<float&>::type, float&>::value, "should preserve lvalue ref");
+        FL_STATIC_ASSERT(is_same<add_rvalue_reference<int&>::type, int&>::value, "should preserve lvalue ref");
+        FL_STATIC_ASSERT(is_same<add_rvalue_reference<float&>::type, float&>::value, "should preserve lvalue ref");
     }
 }
 
 FL_TEST_CASE("fl::enable_if") {
     FL_SUBCASE("true condition") {
-        static_assert(is_same<enable_if<true, int>::type, int>::value, "enable_if true should provide type");
-        static_assert(is_same<enable_if_t<true, int>, int>::value, "enable_if_t true should provide type");
+        FL_STATIC_ASSERT(is_same<enable_if<true, int>::type, int>::value, "enable_if true should provide type");
+        FL_STATIC_ASSERT(is_same<enable_if_t<true, int>, int>::value, "enable_if_t true should provide type");
     }
 
     FL_SUBCASE("default type") {
-        static_assert(is_same<enable_if<true>::type, void>::value, "enable_if default should be void");
+        FL_STATIC_ASSERT(is_same<enable_if<true>::type, void>::value, "enable_if default should be void");
     }
 }
 
@@ -123,16 +124,16 @@ FL_TEST_CASE("fl::is_same") {
 
 FL_TEST_CASE("fl::conditional") {
     FL_SUBCASE("true condition") {
-        static_assert(is_same<conditional<true, int, float>::type, int>::value,
+        FL_STATIC_ASSERT(is_same<conditional<true, int, float>::type, int>::value,
                       "conditional true should choose first type");
-        static_assert(is_same<conditional_t<true, int, float>, int>::value,
+        FL_STATIC_ASSERT(is_same<conditional_t<true, int, float>, int>::value,
                       "conditional_t true should choose first type");
     }
 
     FL_SUBCASE("false condition") {
-        static_assert(is_same<conditional<false, int, float>::type, float>::value,
+        FL_STATIC_ASSERT(is_same<conditional<false, int, float>::type, float>::value,
                       "conditional false should choose second type");
-        static_assert(is_same<conditional_t<false, int, float>, float>::value,
+        FL_STATIC_ASSERT(is_same<conditional_t<false, int, float>, float>::value,
                       "conditional_t false should choose second type");
     }
 }
@@ -153,18 +154,18 @@ FL_TEST_CASE("fl::is_array") {
 
 FL_TEST_CASE("fl::remove_extent") {
     FL_SUBCASE("array types") {
-        static_assert(is_same<remove_extent<int[]>::type, int>::value,
+        FL_STATIC_ASSERT(is_same<remove_extent<int[]>::type, int>::value,
                       "should remove extent from unbounded array");
-        static_assert(is_same<remove_extent<int[10]>::type, int>::value,
+        FL_STATIC_ASSERT(is_same<remove_extent<int[10]>::type, int>::value,
                       "should remove extent from bounded array");
-        static_assert(is_same<remove_extent<float[5]>::type, float>::value,
+        FL_STATIC_ASSERT(is_same<remove_extent<float[5]>::type, float>::value,
                       "should remove extent from array");
     }
 
     FL_SUBCASE("non-array types") {
-        static_assert(is_same<remove_extent<int>::type, int>::value,
+        FL_STATIC_ASSERT(is_same<remove_extent<int>::type, int>::value,
                       "should not affect non-array");
-        static_assert(is_same<remove_extent<int*>::type, int*>::value,
+        FL_STATIC_ASSERT(is_same<remove_extent<int*>::type, int*>::value,
                       "should not affect pointer");
     }
 }
@@ -187,32 +188,32 @@ FL_TEST_CASE("fl::is_function") {
 
 FL_TEST_CASE("fl::add_pointer") {
     FL_SUBCASE("non-reference types") {
-        static_assert(is_same<add_pointer<int>::type, int*>::value,
+        FL_STATIC_ASSERT(is_same<add_pointer<int>::type, int*>::value,
                       "should add pointer to int");
-        static_assert(is_same<add_pointer_t<float>, float*>::value,
+        FL_STATIC_ASSERT(is_same<add_pointer_t<float>, float*>::value,
                       "should add pointer to float");
     }
 
     FL_SUBCASE("reference types") {
-        static_assert(is_same<add_pointer<int&>::type, int*>::value,
+        FL_STATIC_ASSERT(is_same<add_pointer<int&>::type, int*>::value,
                       "should convert lvalue ref to pointer");
-        static_assert(is_same<add_pointer<int&&>::type, int*>::value,
+        FL_STATIC_ASSERT(is_same<add_pointer<int&&>::type, int*>::value,
                       "should convert rvalue ref to pointer");
     }
 }
 
 FL_TEST_CASE("fl::remove_const") {
     FL_SUBCASE("const types") {
-        static_assert(is_same<remove_const<const int>::type, int>::value,
+        FL_STATIC_ASSERT(is_same<remove_const<const int>::type, int>::value,
                       "should remove const from int");
-        static_assert(is_same<remove_const<const float>::type, float>::value,
+        FL_STATIC_ASSERT(is_same<remove_const<const float>::type, float>::value,
                       "should remove const from float");
     }
 
     FL_SUBCASE("non-const types") {
-        static_assert(is_same<remove_const<int>::type, int>::value,
+        FL_STATIC_ASSERT(is_same<remove_const<int>::type, int>::value,
                       "should not affect non-const");
-        static_assert(is_same<remove_const<volatile int>::type, volatile int>::value,
+        FL_STATIC_ASSERT(is_same<remove_const<volatile int>::type, volatile int>::value,
                       "should not affect volatile");
     }
 }
@@ -273,50 +274,50 @@ FL_TEST_CASE("fl::forward") {
 
 FL_TEST_CASE("fl::remove_cv") {
     FL_SUBCASE("const") {
-        static_assert(is_same<remove_cv<const int>::type, int>::value,
+        FL_STATIC_ASSERT(is_same<remove_cv<const int>::type, int>::value,
                       "should remove const");
-        static_assert(is_same<remove_cv_t<const int>, int>::value,
+        FL_STATIC_ASSERT(is_same<remove_cv_t<const int>, int>::value,
                       "remove_cv_t should remove const");
     }
 
     FL_SUBCASE("volatile") {
-        static_assert(is_same<remove_cv<volatile int>::type, int>::value,
+        FL_STATIC_ASSERT(is_same<remove_cv<volatile int>::type, int>::value,
                       "should remove volatile");
     }
 
     FL_SUBCASE("const volatile") {
-        static_assert(is_same<remove_cv<const volatile int>::type, int>::value,
+        FL_STATIC_ASSERT(is_same<remove_cv<const volatile int>::type, int>::value,
                       "should remove const volatile");
     }
 
     FL_SUBCASE("neither") {
-        static_assert(is_same<remove_cv<int>::type, int>::value,
+        FL_STATIC_ASSERT(is_same<remove_cv<int>::type, int>::value,
                       "should not affect non-cv type");
     }
 }
 
 FL_TEST_CASE("fl::decay") {
     FL_SUBCASE("array decay") {
-        static_assert(is_same<decay<int[10]>::type, int*>::value,
+        FL_STATIC_ASSERT(is_same<decay<int[10]>::type, int*>::value,
                       "array should decay to pointer");
-        static_assert(is_same<decay_t<int[]>, int*>::value,
+        FL_STATIC_ASSERT(is_same<decay_t<int[]>, int*>::value,
                       "unbounded array should decay to pointer");
     }
 
     FL_SUBCASE("function decay") {
-        static_assert(is_same<decay<int()>::type, int(*)()>::value,
+        FL_STATIC_ASSERT(is_same<decay<int()>::type, int(*)()>::value,
                       "function should decay to function pointer");
     }
 
     FL_SUBCASE("reference and cv decay") {
-        static_assert(is_same<decay<const int&>::type, int>::value,
+        FL_STATIC_ASSERT(is_same<decay<const int&>::type, int>::value,
                       "should remove ref and const");
-        static_assert(is_same<decay<volatile int&&>::type, int>::value,
+        FL_STATIC_ASSERT(is_same<decay<volatile int&&>::type, int>::value,
                       "should remove ref and volatile");
     }
 
     FL_SUBCASE("no decay") {
-        static_assert(is_same<decay<int>::type, int>::value,
+        FL_STATIC_ASSERT(is_same<decay<int>::type, int>::value,
                       "should not affect plain int");
     }
 }
@@ -465,32 +466,32 @@ FL_TEST_CASE("fl::type_rank") {
 
 FL_TEST_CASE("fl::common_type") {
     FL_SUBCASE("same type") {
-        static_assert(is_same<common_type<int, int>::type, int>::value,
+        FL_STATIC_ASSERT(is_same<common_type<int, int>::type, int>::value,
                       "common type of same types should be that type");
-        static_assert(is_same<common_type_t<float, float>, float>::value,
+        FL_STATIC_ASSERT(is_same<common_type_t<float, float>, float>::value,
                       "common_type_t of same types should be that type");
     }
 
     FL_SUBCASE("integer promotion") {
-        static_assert(is_same<common_type<int, long>::type, long>::value,
+        FL_STATIC_ASSERT(is_same<common_type<int, long>::type, long>::value,
                       "larger integer type should win");
-        static_assert(is_same<common_type<short, int>::type, int>::value,
+        FL_STATIC_ASSERT(is_same<common_type<short, int>::type, int>::value,
                       "int should win over short");
     }
 
     FL_SUBCASE("floating point promotion") {
-        static_assert(is_same<common_type<int, float>::type, float>::value,
+        FL_STATIC_ASSERT(is_same<common_type<int, float>::type, float>::value,
                       "float should win over int");
-        static_assert(is_same<common_type<float, double>::type, double>::value,
+        FL_STATIC_ASSERT(is_same<common_type<float, double>::type, double>::value,
                       "double should win over float");
-        static_assert(is_same<common_type<double, long double>::type, long double>::value,
+        FL_STATIC_ASSERT(is_same<common_type<double, long double>::type, long double>::value,
                       "long double should win");
     }
 
     FL_SUBCASE("symmetric") {
-        static_assert(is_same<common_type<int, float>::type, common_type<float, int>::type>::value,
+        FL_STATIC_ASSERT(is_same<common_type<int, float>::type, common_type<float, int>::type>::value,
                       "common_type should be symmetric");
-        static_assert(is_same<common_type<int, long>::type, common_type<long, int>::type>::value,
+        FL_STATIC_ASSERT(is_same<common_type<int, long>::type, common_type<long, int>::type>::value,
                       "common_type should be symmetric for integers");
     }
 }
@@ -623,7 +624,7 @@ namespace compile_time_tests {
     void test_declval() {
         // declval should be usable in unevaluated contexts
         using result = decltype(declval<T>());
-        static_assert(is_same<result, typename add_rvalue_reference<T>::type>::value,
+        FL_STATIC_ASSERT(is_same<result, typename add_rvalue_reference<T>::type>::value,
                       "declval should return rvalue reference");
     }
 

--- a/tests/fl/stl/utility.cpp
+++ b/tests/fl/stl/utility.cpp
@@ -1,6 +1,7 @@
 #include "fl/stl/utility.h"
 #include "fl/stl/limits.h"
 #include "test.h"
+#include "fl/stl/static_assert.h"
 
 FL_TEST_FILE(FL_FILEPATH) {
 
@@ -61,9 +62,9 @@ FL_TEST_CASE("fl::less<T>") {
     FL_SUBCASE("constexpr evaluation") {
         // Test that less can be used in constexpr contexts
         constexpr less<int> cmp;
-        static_assert(cmp(1, 2), "1 < 2 should be true");
-        static_assert(!cmp(2, 1), "2 < 1 should be false");
-        static_assert(!cmp(5, 5), "5 < 5 should be false");
+        FL_STATIC_ASSERT(cmp(1, 2), "1 < 2 should be true");
+        FL_STATIC_ASSERT(!cmp(2, 1), "2 < 1 should be false");
+        FL_STATIC_ASSERT(!cmp(5, 5), "5 < 5 should be false");
     }
 }
 
@@ -121,9 +122,9 @@ FL_TEST_CASE("fl::less<void> - transparent comparator") {
 
     FL_SUBCASE("constexpr with void") {
         constexpr less<void> cmp_void;
-        static_assert(cmp_void(1, 2), "1 < 2 should be true");
-        static_assert(!cmp_void(2, 1), "2 < 1 should be false");
-        static_assert(cmp_void(1.0f, 2.0), "1.0f < 2.0 should be true");
+        FL_STATIC_ASSERT(cmp_void(1, 2), "1 < 2 should be true");
+        FL_STATIC_ASSERT(!cmp_void(2, 1), "2 < 1 should be false");
+        FL_STATIC_ASSERT(cmp_void(1.0f, 2.0), "1.0f < 2.0 should be true");
     }
 }
 
@@ -147,7 +148,7 @@ FL_TEST_CASE("fl::DefaultLess - backward compatibility") {
 
     FL_SUBCASE("constexpr compatibility") {
         constexpr DefaultLess<int> cmp;
-        static_assert(cmp(1, 2), "DefaultLess should work in constexpr context");
+        FL_STATIC_ASSERT(cmp(1, 2), "DefaultLess should work in constexpr context");
     }
 }
 

--- a/tests/fl/system/delay.cpp
+++ b/tests/fl/system/delay.cpp
@@ -4,6 +4,7 @@
 #include "fl/system/delay.h"
 #include "fl/task/executor.h"
 #include "test.h"
+#include "fl/stl/static_assert.h"
 
 FL_TEST_FILE(FL_FILEPATH) {
 
@@ -11,11 +12,11 @@ namespace delay_lookup_regression {
 char delay(fl::u32);
 using fl::delay;
 
-static_assert(fl::is_same<decltype(delay(fl::u32{1})), char>::value,
+FL_STATIC_ASSERT(fl::is_same<decltype(delay(fl::u32{1})), char>::value,
               "Bare delay(u32) should prefer the non-template Arduino-style overload");
-static_assert(fl::is_same<decltype(delay(static_cast<unsigned long>(1))), char>::value,
+FL_STATIC_ASSERT(fl::is_same<decltype(delay(static_cast<unsigned long>(1))), char>::value,
               "Bare delay(unsigned long) should prefer the non-template Arduino-style overload");
-static_assert(fl::is_same<decltype(delay(fl::u32{1}, false)), void>::value,
+FL_STATIC_ASSERT(fl::is_same<decltype(delay(fl::u32{1}, false)), void>::value,
               "Two-argument delay(ms, run_async) should resolve to fl::delay");
 }  // namespace delay_lookup_regression
 

--- a/tests/platforms/cycle_type.cpp
+++ b/tests/platforms/cycle_type.cpp
@@ -3,6 +3,7 @@
 #include "test.h"
 #include "fl/stl/type_traits.h"
 #include "fl/stl/int.h"
+#include "fl/stl/static_assert.h"
 
 using namespace fl;
 
@@ -19,7 +20,7 @@ FL_TEST_CASE("fl::cycle_t type definition") {
 #if defined(__AVR__)
     FL_SUBCASE("cycle_t is int on AVR platforms") {
         // On AVR, cycle_t should be int (typically 16-bit)
-        static_assert(fl::is_same<cycle_t, int>::value,
+        FL_STATIC_ASSERT(fl::is_same<cycle_t, int>::value,
                      "cycle_t should be int on AVR");
 
         // Verify it's the expected size for AVR
@@ -28,7 +29,7 @@ FL_TEST_CASE("fl::cycle_t type definition") {
 #else
     FL_SUBCASE("cycle_t is fl::i64 on non-AVR platforms") {
         // On non-AVR platforms, cycle_t should be fl::i64
-        static_assert(fl::is_same<cycle_t, fl::i64>::value,
+        FL_STATIC_ASSERT(fl::is_same<cycle_t, fl::i64>::value,
                      "cycle_t should be fl::i64 on non-AVR");
 
         // Verify it's 64-bit

--- a/tests/platforms/shared/clockless_timing.cpp
+++ b/tests/platforms/shared/clockless_timing.cpp
@@ -4,6 +4,7 @@
 #include "test.h"
 #include "platforms/shared/clockless_timing.h"
 #include "crgb.h"
+#include "fl/stl/static_assert.h"
 
 using namespace fl;
 
@@ -345,21 +346,21 @@ FL_TEST_CASE("ClocklessTiming - constexpr evaluation") {
         350, 700, 600, 3
     );
 
-    static_assert(result.valid, "Calculation should succeed at compile time");
-    static_assert(result.n_bit == 3, "Should use 3 words per bit");
-    static_assert(result.pclk_hz > 0, "PCLK should be positive");
+    FL_STATIC_ASSERT(result.valid, "Calculation should succeed at compile time");
+    FL_STATIC_ASSERT(result.n_bit == 3, "Should use 3 words per bit");
+    FL_STATIC_ASSERT(result.pclk_hz > 0, "PCLK should be positive");
 
     // Verify constexpr buffer size calculation
     constexpr size_t buffer_size = fl::ClocklessTiming::calculate_buffer_size(
         1000, 24, 3, 300, 500
     );
-    static_assert(buffer_size > 0, "Buffer size should be positive");
+    FL_STATIC_ASSERT(buffer_size > 0, "Buffer size should be positive");
 
     // Verify constexpr frame time calculation
     constexpr uint32_t frame_time = fl::ClocklessTiming::calculate_frame_time_us(
         1000, 24, 3, 500, 300
     );
-    static_assert(frame_time > 0, "Frame time should be positive");
+    FL_STATIC_ASSERT(frame_time > 0, "Frame time should be positive");
 }
 #endif // __cplusplus >= 201402L
 


### PR DESCRIPTION
## Summary
- add FL_STATIC_ASSERT as the project wrapper for compile-time assertions, with a C++98 fallback in fl/stl/static_assert.h
- update the banned macro checker to reject raw static_assert(...) usage and add unit coverage for that rule
- migrate existing source and test static_assert(...) call sites to FL_STATIC_ASSERT(...)

Split out from #2386.

## Validation
- uv run python ci/lint_cpp/banned_macros_checker.py
- uv run pytest ci/lint_cpp/test_banned_macros_checker.py -q
- git diff --check
- uv run test.py --unit --quick --no-interactive --no-fingerprint type_traits
- uv run test.py --unit --quick --no-interactive --no-fingerprint fixed_point
- uv run test.py --unit --quick --no-interactive --no-fingerprint pair
- uv run test.py --unit --quick --no-interactive --no-fingerprint bit_cast

Note: uv run python ci/lint_cpp/run_all_checkers.py still reports existing unrelated colorutils/test path lint violations on master.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added unified compile-time assertion facility compatible with C++03 and later versions.

* **Chores**
  * Standardized compile-time validation across the codebase to use a consistent assertion mechanism, improving code maintainability while preserving all existing compile-time checks and error messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->