### PR TITLE
Fix Digispark follow-up review issues

### DIFF
--- a/ci/boards.py
+++ b/ci/boards.py
@@ -1065,6 +1065,7 @@ ATTINY85 = Board(
 
 DIGISPARK_TINY = Board(
     board_name="digispark-tiny",
+    board_build_mcu="attiny85",
     # PlatformIO only publishes Digistump core 1.7.2 and avr-gcc 5.4/7.3
     # packages, so the Arduino IDE 1.6.7 + avr-g++ 4.8.1 issue environment
     # cannot be pinned through platform_packages here.

--- a/src/fl/gfx/colorutils.cpp.hpp
+++ b/src/fl/gfx/colorutils.cpp.hpp
@@ -387,7 +387,7 @@ CRGB ColorFromPaletteExtended(const CRGBPalette32 &pal, fl::u16 index,
 CRGB16 ColorFromPaletteHD(const CRGBPalette32 &pal, fl::u16 index,
                           fl::u8x8 brightness, TBlendType blendType) {
     return ColorFromPaletteHDImpl<5>(
-        RuntimeRGBPaletteReader<32>{fl::span<const CRGB, 32>(&pal.entries[0])},
+        RuntimeRGBPaletteReader<32>{fl::span<const CRGB, 32>(&pal.entries[0], 32)},
         index, brightness, blendType);
 }
 
@@ -532,7 +532,7 @@ CRGB ColorFromPaletteExtended(const CRGBPalette16 &pal, fl::u16 index,
 CRGB16 ColorFromPaletteHD(const CRGBPalette16 &pal, fl::u16 index,
                           fl::u8x8 brightness, TBlendType blendType) {
     return ColorFromPaletteHDImpl<4>(
-        RuntimeRGBPaletteReader<16>{fl::span<const CRGB, 16>(&pal.entries[0])},
+        RuntimeRGBPaletteReader<16>{fl::span<const CRGB, 16>(&pal.entries[0], 16)},
         index, brightness, blendType);
 }
 
@@ -587,7 +587,7 @@ CRGB ColorFromPaletteExtended(const TProgmemRGBPalette16 &pal, fl::u16 index,
 CRGB16 ColorFromPaletteHD(const TProgmemRGBPalette16 &pal, fl::u16 index,
                           fl::u8x8 brightness, TBlendType blendType) {
     return ColorFromPaletteHDImpl<4>(
-        ProgmemRGBPaletteReader<16>{fl::span<const fl::u32, 16>(&pal[0])},
+        ProgmemRGBPaletteReader<16>{fl::span<const fl::u32, 16>(&pal[0], 16)},
         index, brightness, blendType);
 }
 
@@ -642,7 +642,7 @@ CRGB ColorFromPaletteExtended(const TProgmemRGBPalette32 &pal, fl::u16 index,
 CRGB16 ColorFromPaletteHD(const TProgmemRGBPalette32 &pal, fl::u16 index,
                           fl::u8x8 brightness, TBlendType blendType) {
     return ColorFromPaletteHDImpl<5>(
-        ProgmemRGBPaletteReader<32>{fl::span<const fl::u32, 32>(&pal[0])},
+        ProgmemRGBPaletteReader<32>{fl::span<const fl::u32, 32>(&pal[0], 32)},
         index, brightness, blendType);
 }
 
@@ -983,7 +983,7 @@ CRGB ColorFromPaletteExtended(const CRGBPalette256 &pal, fl::u16 index,
 CRGB16 ColorFromPaletteHD(const CRGBPalette256 &pal, fl::u16 index,
                           fl::u8x8 brightness, TBlendType blendType) {
     return ColorFromPaletteHDImpl<8>(
-        RuntimeRGBPaletteReader<256>{fl::span<const CRGB, 256>(&pal.entries[0])},
+        RuntimeRGBPaletteReader<256>{fl::span<const CRGB, 256>(&pal.entries[0], 256)},
         index, brightness, blendType);
 }
 

--- a/src/platforms/arduino/io_arduino.hpp
+++ b/src/platforms/arduino/io_arduino.hpp
@@ -45,10 +45,10 @@ int read() FL_NOEXCEPT {
 // This handles USB CDC multi-packet transfers correctly via Stream::timedRead()
 // which uses yield() (immediate context switch) instead of delay(1) (1ms sleep).
 int readLineNative(char delimiter, char* out, int outLen) FL_NOEXCEPT {
-#if defined(FL_IS_AVR_ATTINY)
     if (outLen <= 0) {
         return 0;
     }
+#if defined(FL_IS_AVR_ATTINY)
     // TinyDebugSerial lacks readStringUntil(), so keep Stream's blocking
     // line-read behavior without allocating Arduino String.
     const unsigned long timeoutMs = 1000UL;


### PR DESCRIPTION
## Summary
- add explicit `board_build.mcu = attiny85` metadata for `digispark-tiny` so MCU target filtering works
- hoist the Arduino `readLineNative` output length guard so the non-ATtiny path cannot copy with a negative length
- fix HD palette reader span construction by passing the static extent explicitly

## Arduino C++ standard note
Arduino AVR Boards set `compiler.cpp.flags` to include `-std=gnu++11`, and the installed Digistump 1.7.x framework package has the same `platform.txt` setting. The generated PlatformIO project does not consume that `platform.txt` flag, so this keeps the explicit `build_flags = -std=gnu++11` on `digispark-tiny` to match the Arduino stock compile mode.

## Validation
- `uv run ci/ci-compile.py digispark-tiny Blink`
- `uv run ci/ci-compile.py attiny85 Blink`
- `uv run test.py --unit --quick --no-interactive --no-fingerprint span`
- `uv run test.py --unit --quick --no-interactive --no-fingerprint colorutils`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed microcontroller target configuration for Digispark Tiny platform builds.
  * Enhanced palette color utilities with improved bounds checking for safer operations.
  * Added validation for serial input operations to prevent errors from invalid parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->