### PR TITLE
Fix ESP32-S3 warnings promoted by Werror

### DIFF
--- a/src/fl/audio/fft/fft.cpp.hpp
+++ b/src/fl/audio/fft/fft.cpp.hpp
@@ -194,10 +194,8 @@ template <> struct Hash<audio::fft::Args> {
         h ^= MurmurHash3_x86_32(&key.fmin, sizeof(key.fmin)) * 2246822519u;
         h ^= MurmurHash3_x86_32(&key.fmax, sizeof(key.fmax)) * 3266489917u;
         h ^= MurmurHash3_x86_32(&key.sample_rate, sizeof(key.sample_rate)) * 668265263u;
-        int mode_int = static_cast<int>(key.mode);
-        h ^= MurmurHash3_x86_32(&mode_int, sizeof(mode_int)) * 374761393u;
-        int window_int = static_cast<int>(key.window);
-        h ^= MurmurHash3_x86_32(&window_int, sizeof(window_int)) * 2246822519u;
+        h ^= static_cast<fl::u32>(key.mode) * 374761393u;
+        h ^= static_cast<fl::u32>(key.window) * 2246822519u;
         return h;
     }
 };

--- a/src/fl/gfx/corkscrew.cpp.hpp
+++ b/src/fl/gfx/corkscrew.cpp.hpp
@@ -418,8 +418,7 @@ void Corkscrew::readFromMulti(const fl::Grid<CRGB>& source_grid) const {
                 fl::u8 weight = entry.second; // weight is the second element of the pair
                 
                 // Bounds check for the source grid
-                if (pos.x >= 0 && pos.x < width && 
-                    pos.y >= 0 && pos.y < height) {
+                if (pos.x < width && pos.y < height) {
                     
                     // Sample from the source grid
                     CRGB sample_color = source_grid.at(pos.x, pos.y);

--- a/src/fl/math/fixed_point/u12x4.h
+++ b/src/fl/math/fixed_point/u12x4.h
@@ -252,12 +252,7 @@ class u12x4 {
         u12x4 fr = x - fl_val;
         u32 n = fl_val.mValue >> FRAC_BITS;
         if (n >= INT_BITS - 1) return from_raw(0xFFFF);
-        u32 int_pow;
-        if (n >= 0) {
-            int_pow = static_cast<u32>(SCALE) << n;
-        } else {
-            int_pow = static_cast<u32>(SCALE) >> (-static_cast<int>(n));
-        }
+        u32 int_pow = static_cast<u32>(SCALE) << n;
         // 4-term minimax coefficients for 2^t - 1, t in [0,1).
         // Stored as u32 with 12 fractional bits.
         constexpr int IFRAC = 12;

--- a/src/platforms/esp/32/audio/devices/idf5_i2s_context.hpp
+++ b/src/platforms/esp/32/audio/devices/idf5_i2s_context.hpp
@@ -109,10 +109,14 @@ I2SContext make_context(const audio::ConfigI2S &config) FL_NOEXCEPT {
                 .bit_order_lsb = false,
             },
 #endif
-        .gpio_cfg = {.bclk = static_cast<gpio_num_t>(pin_clk),
+        .gpio_cfg = {.mclk = GPIO_NUM_NC,
+                     .bclk = static_cast<gpio_num_t>(pin_clk),
                      .ws = static_cast<gpio_num_t>(pin_ws),
                      .dout = GPIO_NUM_NC,
-                     .din = static_cast<gpio_num_t>(pin_sd)}};
+                     .din = static_cast<gpio_num_t>(pin_sd),
+                     .invert_flags = {.mclk_inv = false,
+                                      .bclk_inv = false,
+                                      .ws_inv = false}}};
 
     I2SContext out = {nullptr, std_cfg};
     return out;

--- a/src/platforms/generic_pin.h
+++ b/src/platforms/generic_pin.h
@@ -11,6 +11,7 @@
 // Note: This must be included before using Selectable as a base class
 #include "fl/system/fastpin_base.h"
 #include "fl/stl/compiler_control.h"
+#include "fl/stl/type_traits.h"
 #include "fl/system/pin.h"  // For PinMode, PinValue enums and pinMode/digitalWrite/digitalRead functions
 #include "fl/stl/noexcept.h"
 
@@ -51,7 +52,7 @@ public:
 	#endif
 
 	typedef volatile RwReg * port_ptr_t;  ///< type for a pin read/write register, volatile
-	typedef RwReg port_t;  ///< type for a pin read/write register, non-volatile
+	typedef typename fl::remove_cv<RwReg>::type port_t;  ///< type for a pin read/write register, non-volatile
 
 	/// Set the pin mode as `OUTPUT`
 	inline void setOutput() { pinMode(mPin, PinMode::Output); }
@@ -112,7 +113,7 @@ public:
 	/// Gets the state of the port with this pin `HIGH`
 	FL_DISABLE_WARNING_PUSH
 	FL_DISABLE_WARNING_VOLATILE
-	volatile port_t hival() FL_NOEXCEPT __attribute__ ((always_inline)) {
+	port_t hival() FL_NOEXCEPT __attribute__ ((always_inline)) {
 		if (mPort) { return *mPort | mPinMask; }
 		else { return 1; }  // Return 1 (HIGH equivalent)
 	}
@@ -120,7 +121,7 @@ public:
 	/// Gets the state of the port with this pin `LOW`
 	FL_DISABLE_WARNING_PUSH
 	FL_DISABLE_WARNING_VOLATILE
-	volatile port_t loval() FL_NOEXCEPT __attribute__ ((always_inline)) {
+	port_t loval() FL_NOEXCEPT __attribute__ ((always_inline)) {
 		if (mPort) { return *mPort & ~mPinMask; }
 		else { return 0; }  // Return 0 (LOW equivalent)
 	}
@@ -130,7 +131,7 @@ public:
 	/// Get the pin mask
 	FL_DISABLE_WARNING_PUSH
 	FL_DISABLE_WARNING_VOLATILE
-	volatile port_t mask() __attribute__ ((always_inline)) { return mPinMask; }
+	port_t mask() __attribute__ ((always_inline)) { return mPinMask; }
 	FL_DISABLE_WARNING_POP
 	FL_DISABLE_WARNING_POP
 


### PR DESCRIPTION
## Summary
- fix the warning errors reported in #2388 for the current master warning dump
- keep the patch focused to the direct warning sites: `u12x4`, `generic_pin`, ESP-IDF5 I2S GPIO config, Corkscrew bounds checks, and FFT args hashing
- avoid broader cleanup of later ESP32 aggregate initializer warnings in unrelated platform features

## Notes
This intentionally does not try to make the entire pioarduino/Arduino-ESP32 dependency graph compile with project-wide `-Werror`. After these fixes, the exact reproducer advances to later `-Wmissing-field-initializers` warnings in other ESP32 platform code and the external framework. Those can be handled separately if desired.

## Testing
- `pio run -d repros\issue-2388-esp32s3-werror -e esp32-s3-local-master` now gets past the warning sites from the issue comment and fails later on unrelated `-Wmissing-field-initializers` warnings
- `pio run -d repros\issue-2388-esp32s3-werror -e esp32-s3-local-master-demote-framework-missing-field` succeeds

Refs #2388


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized FFT hashing algorithm for improved efficiency
  * Simplified graphics bounds checking logic
  * Enhanced fixed-point mathematical operations performance
  * Improved ESP32 audio device GPIO configuration initialization
  * Updated pin abstraction layer type safety by removing volatile qualifiers from public accessors

<!-- end of auto-generated comment: release notes by coderabbit.ai -->