### PR TITLE
Limit agent PR workflow triggers

### DIFF
--- a/.github/workflows/avr8js_uno_test.yml
+++ b/.github/workflows/avr8js_uno_test.yml
@@ -19,20 +19,6 @@ on:
       - 'library.json'
       - '.github/workflows/avr8js_uno_test.yml'
       - '.github/workflows/avr8js_docker_template.yml'
-  pull_request:
-    branches: [master]
-    paths:
-      - 'src/**/*.cpp'
-      - 'src/**/*.h'
-      - 'examples/**/*.ino'
-      - 'examples/**/*.cpp'
-      - 'examples/**/*.h'
-      - 'platformio.ini'
-      - 'CMakeLists.txt'
-      - 'library.json'
-      - '.github/workflows/avr8js_uno_test.yml'
-      - '.github/workflows/avr8js_docker_template.yml'
-
 jobs:
   uno_avr8js_test:
     uses: ./.github/workflows/avr8js_docker_template.yml

--- a/.github/workflows/build_adafruit_feather_nrf52840_sense.yml
+++ b/.github/workflows/build_adafruit_feather_nrf52840_sense.yml
@@ -18,21 +18,6 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
-  pull_request:
-    branches:
-      - master
-    paths:
-      - 'src/**'
-      - 'examples/**'
-      - 'ci/**'
-      - '.github/workflows/build_adafruit_feather_nrf52840_sense.yml'
-      - '.github/workflows/build_template.yml'
-      - 'CMakeLists.txt'
-      - 'platformio.ini'
-      - 'library.json'
-      - 'library.properties'
-
-
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_adafruit_xiaoblesense.yml
+++ b/.github/workflows/build_adafruit_xiaoblesense.yml
@@ -18,21 +18,6 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
-  pull_request:
-    branches:
-      - master
-    paths:
-      - 'src/**'
-      - 'examples/**'
-      - 'ci/**'
-      - '.github/workflows/build_adafruit_xiaoblesense.yml'
-      - '.github/workflows/build_template.yml'
-      - 'CMakeLists.txt'
-      - 'platformio.ini'
-      - 'library.json'
-      - 'library.properties'
-
-
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_apollo3_red.yml
+++ b/.github/workflows/build_apollo3_red.yml
@@ -18,21 +18,6 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
-  pull_request:
-    branches:
-      - master
-    paths:
-      - 'src/**'
-      - 'examples/**'
-      - 'ci/**'
-      - '.github/workflows/build_apollo3_red.yml'
-      - '.github/workflows/build_template.yml'
-      - 'CMakeLists.txt'
-      - 'platformio.ini'
-      - 'library.json'
-      - 'library.properties'
-
-
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_apollo3_thing_explorable.yml
+++ b/.github/workflows/build_apollo3_thing_explorable.yml
@@ -18,21 +18,6 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
-  pull_request:
-    branches:
-      - master
-    paths:
-      - 'src/**'
-      - 'examples/**'
-      - 'ci/**'
-      - '.github/workflows/build_apollo3_thing_explorable.yml'
-      - '.github/workflows/build_template.yml'
-      - 'CMakeLists.txt'
-      - 'platformio.ini'
-      - 'library.json'
-      - 'library.properties'
-
-
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_atmega8a.yml
+++ b/.github/workflows/build_atmega8a.yml
@@ -18,20 +18,6 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
-  pull_request:
-    branches:
-      - master
-    paths:
-      - 'src/**'
-      - 'examples/**'
-      - 'ci/**'
-      - '.github/workflows/build_atmega8a.yml'
-      - '.github/workflows/build_template.yml'
-      - 'CMakeLists.txt'
-      - 'platformio.ini'
-      - 'library.json'
-      - 'library.properties'
-
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_attiny1604.yml
+++ b/.github/workflows/build_attiny1604.yml
@@ -18,21 +18,6 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
-  pull_request:
-    branches:
-      - master
-    paths:
-      - 'src/**'
-      - 'examples/**'
-      - 'ci/**'
-      - '.github/workflows/build_attiny1604.yml'
-      - '.github/workflows/build_template.yml'
-      - 'CMakeLists.txt'
-      - 'platformio.ini'
-      - 'library.json'
-      - 'library.properties'
-
-
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_attiny1616.yml
+++ b/.github/workflows/build_attiny1616.yml
@@ -18,20 +18,6 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
-  pull_request:
-    branches:
-      - master
-    paths:
-      - 'src/**'
-      - 'examples/**'
-      - 'ci/**'
-      - '.github/workflows/build_attiny1616.yml'
-      - '.github/workflows/build_template.yml'
-      - 'CMakeLists.txt'
-      - 'platformio.ini'
-      - 'library.json'
-      - 'library.properties'
-
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_attiny4313.yml
+++ b/.github/workflows/build_attiny4313.yml
@@ -18,21 +18,6 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
-  pull_request:
-    branches:
-      - master
-    paths:
-      - 'src/**'
-      - 'examples/**'
-      - 'ci/**'
-      - '.github/workflows/build_attiny4313.yml'
-      - '.github/workflows/build_template.yml'
-      - 'CMakeLists.txt'
-      - 'platformio.ini'
-      - 'library.json'
-      - 'library.properties'
-
-
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_attiny85.yml
+++ b/.github/workflows/build_attiny85.yml
@@ -18,20 +18,6 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
-  pull_request:
-    branches:
-      - master
-    paths:
-      - 'src/**'
-      - 'examples/**'
-      - 'ci/**'
-      - '.github/workflows/build_attiny85.yml'
-      - '.github/workflows/build_template.yml'
-      - 'CMakeLists.txt'
-      - 'platformio.ini'
-      - 'library.json'
-      - 'library.properties'
-
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_attiny88.yml
+++ b/.github/workflows/build_attiny88.yml
@@ -18,20 +18,6 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
-  pull_request:
-    branches:
-      - master
-    paths:
-      - 'src/**'
-      - 'examples/**'
-      - 'ci/**'
-      - '.github/workflows/build_attiny88.yml'
-      - '.github/workflows/build_template.yml'
-      - 'CMakeLists.txt'
-      - 'platformio.ini'
-      - 'library.json'
-      - 'library.properties'
-
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_blackpill_stm32f4.yml
+++ b/.github/workflows/build_blackpill_stm32f4.yml
@@ -18,20 +18,6 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
-  pull_request:
-    branches:
-      - master
-    paths:
-      - 'src/**'
-      - 'examples/**'
-      - 'ci/**'
-      - '.github/workflows/build_blackpill_stm32f4.yml'
-      - '.github/workflows/build_template.yml'
-      - 'CMakeLists.txt'
-      - 'platformio.ini'
-      - 'library.json'
-      - 'library.properties'
-
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_bluepill.yml
+++ b/.github/workflows/build_bluepill.yml
@@ -18,20 +18,6 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
-  pull_request:
-    branches:
-      - master
-    paths:
-      - 'src/**'
-      - 'examples/**'
-      - 'ci/**'
-      - '.github/workflows/build_bluepill.yml'
-      - '.github/workflows/build_template.yml'
-      - 'CMakeLists.txt'
-      - 'platformio.ini'
-      - 'library.json'
-      - 'library.properties'
-
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_digix.yml
+++ b/.github/workflows/build_digix.yml
@@ -18,20 +18,6 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
-  pull_request:
-    branches:
-      - master
-    paths:
-      - 'src/**'
-      - 'examples/**'
-      - 'ci/**'
-      - '.github/workflows/build_digix.yml'
-      - '.github/workflows/build_template.yml'
-      - 'CMakeLists.txt'
-      - 'platformio.ini'
-      - 'library.json'
-      - 'library.properties'
-
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_due.yml
+++ b/.github/workflows/build_due.yml
@@ -18,20 +18,6 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
-  pull_request:
-    branches:
-      - master
-    paths:
-      - 'src/**'
-      - 'examples/**'
-      - 'ci/**'
-      - '.github/workflows/build_due.yml'
-      - '.github/workflows/build_template.yml'
-      - 'CMakeLists.txt'
-      - 'platformio.ini'
-      - 'library.json'
-      - 'library.properties'
-
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_esp32_i2s_ws2812.yml
+++ b/.github/workflows/build_esp32_i2s_ws2812.yml
@@ -22,24 +22,6 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
-  pull_request:
-    branches:
-      - master
-    paths:
-      - 'src/**'
-      - '!src/platforms/arm/**'
-      - '!src/platforms/wasm/**'
-      - '!src/platforms/avr/**'
-      - 'src/platforms/esp/**'
-      - 'examples/**'
-      - 'ci/**'
-      - '.github/workflows/build_esp32_i2s_ws2812.yml'
-      - '.github/workflows/build_template.yml'
-      - 'CMakeLists.txt'
-      - 'platformio.ini'
-      - 'library.json'
-      - 'library.properties'
-
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_esp32c2.yml
+++ b/.github/workflows/build_esp32c2.yml
@@ -22,24 +22,6 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
-  pull_request:
-    branches:
-      - master
-    paths:
-      - 'src/**'
-      - '!src/platforms/arm/**'
-      - '!src/platforms/wasm/**'
-      - '!src/platforms/avr/**'
-      - 'src/platforms/esp/**'
-      - 'examples/**'
-      - 'ci/**'
-      - '.github/workflows/build_esp32c2.yml'
-      - '.github/workflows/build_template.yml'
-      - 'CMakeLists.txt'
-      - 'platformio.ini'
-      - 'library.json'
-      - 'library.properties'
-
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_esp32c3.yml
+++ b/.github/workflows/build_esp32c3.yml
@@ -22,24 +22,6 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
-  pull_request:
-    branches:
-      - master
-    paths:
-      - 'src/**'
-      - '!src/platforms/arm/**'
-      - '!src/platforms/wasm/**'
-      - '!src/platforms/avr/**'
-      - 'src/platforms/esp/**'
-      - 'examples/**'
-      - 'ci/**'
-      - '.github/workflows/build_esp32c3.yml'
-      - '.github/workflows/build_template.yml'
-      - 'CMakeLists.txt'
-      - 'platformio.ini'
-      - 'library.json'
-      - 'library.properties'
-
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_esp32c5.yml
+++ b/.github/workflows/build_esp32c5.yml
@@ -22,24 +22,6 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
-  pull_request:
-    branches:
-      - master
-    paths:
-      - 'src/**'
-      - '!src/platforms/arm/**'
-      - '!src/platforms/wasm/**'
-      - '!src/platforms/avr/**'
-      - 'src/platforms/esp/**'
-      - 'examples/**'
-      - 'ci/**'
-      - '.github/workflows/build_esp32c5.yml'
-      - '.github/workflows/build_template.yml'
-      - 'CMakeLists.txt'
-      - 'platformio.ini'
-      - 'library.json'
-      - 'library.properties'
-
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_esp32c6.yml
+++ b/.github/workflows/build_esp32c6.yml
@@ -22,24 +22,6 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
-  pull_request:
-    branches:
-      - master
-    paths:
-      - 'src/**'
-      - '!src/platforms/arm/**'
-      - '!src/platforms/wasm/**'
-      - '!src/platforms/avr/**'
-      - 'src/platforms/esp/**'
-      - 'examples/**'
-      - 'ci/**'
-      - '.github/workflows/build_esp32c6.yml'
-      - '.github/workflows/build_template.yml'
-      - 'CMakeLists.txt'
-      - 'platformio.ini'
-      - 'library.json'
-      - 'library.properties'
-
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_esp32dev.yml
+++ b/.github/workflows/build_esp32dev.yml
@@ -22,24 +22,6 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
-  pull_request:
-    branches:
-      - master
-    paths:
-      - 'src/**'
-      - '!src/platforms/arm/**'
-      - '!src/platforms/wasm/**'
-      - '!src/platforms/avr/**'
-      - 'src/platforms/esp/**'
-      - 'examples/**'
-      - 'ci/**'
-      - '.github/workflows/build_esp32dev.yml'
-      - '.github/workflows/build_template.yml'
-      - 'CMakeLists.txt'
-      - 'platformio.ini'
-      - 'library.json'
-      - 'library.properties'
-
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_esp32dev_idf3.3.yml
+++ b/.github/workflows/build_esp32dev_idf3.3.yml
@@ -22,24 +22,6 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
-  pull_request:
-    branches:
-      - master
-    paths:
-      - 'src/**'
-      - '!src/platforms/arm/**'
-      - '!src/platforms/wasm/**'
-      - '!src/platforms/avr/**'
-      - 'src/platforms/esp/**'
-      - 'examples/**'
-      - 'ci/**'
-      - '.github/workflows/build_esp32dev_idf3.3.yml'
-      - '.github/workflows/build_template.yml'
-      - 'CMakeLists.txt'
-      - 'platformio.ini'
-      - 'library.json'
-      - 'library.properties'
-
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_esp32dev_idf4.4.yml
+++ b/.github/workflows/build_esp32dev_idf4.4.yml
@@ -22,24 +22,6 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
-  pull_request:
-    branches:
-      - master
-    paths:
-      - 'src/**'
-      - '!src/platforms/arm/**'
-      - '!src/platforms/wasm/**'
-      - '!src/platforms/avr/**'
-      - 'src/platforms/esp/**'
-      - 'examples/**'
-      - 'ci/**'
-      - '.github/workflows/build_esp32dev_idf4.4.yml'
-      - '.github/workflows/build_template.yml'
-      - 'CMakeLists.txt'
-      - 'platformio.ini'
-      - 'library.json'
-      - 'library.properties'
-
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_esp32dev_namespace.yml
+++ b/.github/workflows/build_esp32dev_namespace.yml
@@ -22,24 +22,6 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
-  pull_request:
-    branches:
-      - master
-    paths:
-      - 'src/**'
-      - '!src/platforms/arm/**'
-      - '!src/platforms/wasm/**'
-      - '!src/platforms/avr/**'
-      - 'src/platforms/esp/**'
-      - 'examples/**'
-      - 'ci/**'
-      - '.github/workflows/build_esp32dev_namespace.yml'
-      - '.github/workflows/build_template.yml'
-      - 'CMakeLists.txt'
-      - 'platformio.ini'
-      - 'library.json'
-      - 'library.properties'
-
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_esp32h2.yml
+++ b/.github/workflows/build_esp32h2.yml
@@ -22,24 +22,6 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
-  pull_request:
-    branches:
-      - master
-    paths:
-      - 'src/**'
-      - '!src/platforms/arm/**'
-      - '!src/platforms/wasm/**'
-      - '!src/platforms/avr/**'
-      - 'src/platforms/esp/**'
-      - 'examples/**'
-      - 'ci/**'
-      - '.github/workflows/build_esp32h2.yml'
-      - '.github/workflows/build_template.yml'
-      - 'CMakeLists.txt'
-      - 'platformio.ini'
-      - 'library.json'
-      - 'library.properties'
-
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_esp32p4.yml
+++ b/.github/workflows/build_esp32p4.yml
@@ -22,24 +22,6 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
-  pull_request:
-    branches:
-      - master
-    paths:
-      - 'src/**'
-      - '!src/platforms/arm/**'
-      - '!src/platforms/wasm/**'
-      - '!src/platforms/avr/**'
-      - 'src/platforms/esp/**'
-      - 'examples/**'
-      - 'ci/**'
-      - '.github/workflows/build_esp32p4.yml'
-      - '.github/workflows/build_template.yml'
-      - 'CMakeLists.txt'
-      - 'platformio.ini'
-      - 'library.json'
-      - 'library.properties'
-
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_esp32s2.yml
+++ b/.github/workflows/build_esp32s2.yml
@@ -22,24 +22,6 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
-  pull_request:
-    branches:
-      - master
-    paths:
-      - 'src/**'
-      - '!src/platforms/arm/**'
-      - '!src/platforms/wasm/**'
-      - '!src/platforms/avr/**'
-      - 'src/platforms/esp/**'
-      - 'examples/**'
-      - 'ci/**'
-      - '.github/workflows/build_esp32s2.yml'
-      - '.github/workflows/build_template.yml'
-      - 'CMakeLists.txt'
-      - 'platformio.ini'
-      - 'library.json'
-      - 'library.properties'
-
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_esp32wroom.yml
+++ b/.github/workflows/build_esp32wroom.yml
@@ -22,24 +22,6 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
-  pull_request:
-    branches:
-      - master
-    paths:
-      - 'src/**'
-      - '!src/platforms/arm/**'
-      - '!src/platforms/wasm/**'
-      - '!src/platforms/avr/**'
-      - 'src/platforms/esp/**'
-      - 'examples/**'
-      - 'ci/**'
-      - '.github/workflows/build_esp32wroom.yml'
-      - '.github/workflows/build_template.yml'
-      - 'CMakeLists.txt'
-      - 'platformio.ini'
-      - 'library.json'
-      - 'library.properties'
-
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_esp8266.yml
+++ b/.github/workflows/build_esp8266.yml
@@ -22,24 +22,6 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
-  pull_request:
-    branches:
-      - master
-    paths:
-      - 'src/**'
-      - '!src/platforms/arm/**'
-      - '!src/platforms/wasm/**'
-      - '!src/platforms/avr/**'
-      - 'src/platforms/esp/**'
-      - 'examples/**'
-      - 'ci/**'
-      - '.github/workflows/build_esp8266.yml'
-      - '.github/workflows/build_template.yml'
-      - 'CMakeLists.txt'
-      - 'platformio.ini'
-      - 'library.json'
-      - 'library.properties'
-
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_giga_r1.yml
+++ b/.github/workflows/build_giga_r1.yml
@@ -18,20 +18,6 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
-  pull_request:
-    branches:
-      - master
-    paths:
-      - 'src/**'
-      - 'examples/**'
-      - 'ci/**'
-      - '.github/workflows/build_giga_r1.yml'
-      - '.github/workflows/build_template.yml'
-      - 'CMakeLists.txt'
-      - 'platformio.ini'
-      - 'library.json'
-      - 'library.properties'
-
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -17,19 +17,6 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
-  pull_request:
-    branches:
-      - master
-    paths:
-      - 'src/**'
-      - 'examples/**'
-      - 'ci/**'
-      - '.github/workflows/build_linux.yml'
-      - 'CMakeLists.txt'
-      - 'platformio.ini'
-      - 'library.json'
-      - 'library.properties'
-
 permissions:
   contents: read        # Required to checkout code
   actions: read         # Required for artifact operations  

--- a/.github/workflows/build_maple_map.yml
+++ b/.github/workflows/build_maple_map.yml
@@ -18,21 +18,6 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
-  pull_request:
-    branches:
-      - master
-    paths:
-      - 'src/**'
-      - 'examples/**'
-      - 'ci/**'
-      - '.github/workflows/build_maple_map.yml'
-      - '.github/workflows/build_template.yml'
-      - 'CMakeLists.txt'
-      - 'platformio.ini'
-      - 'library.json'
-      - 'library.properties'
-
-
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_mgm240s_thingplusmatter.yml
+++ b/.github/workflows/build_mgm240s_thingplusmatter.yml
@@ -18,20 +18,6 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
-  pull_request:
-    branches:
-      - master
-    paths:
-      - 'src/**'
-      - 'examples/**'
-      - 'ci/**'
-      - '.github/workflows/build_mgm240s_thingplusmatter.yml'
-      - '.github/workflows/build_template.yml'
-      - 'CMakeLists.txt'
-      - 'platformio.ini'
-      - 'library.json'
-      - 'library.properties'
-
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_nano_every.yml
+++ b/.github/workflows/build_nano_every.yml
@@ -18,21 +18,6 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
-  pull_request:
-    branches:
-      - master
-    paths:
-      - 'src/**'
-      - 'examples/**'
-      - 'ci/**'
-      - '.github/workflows/build_nano_every.yml'
-      - '.github/workflows/build_template.yml'
-      - 'CMakeLists.txt'
-      - 'platformio.ini'
-      - 'library.json'
-      - 'library.properties'
-
-
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_nrf52840_dk.yml
+++ b/.github/workflows/build_nrf52840_dk.yml
@@ -18,21 +18,6 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
-  pull_request:
-    branches:
-      - master
-    paths:
-      - 'src/**'
-      - 'examples/**'
-      - 'ci/**'
-      - '.github/workflows/build_nrf52840_dk.yml'
-      - '.github/workflows/build_template.yml'
-      - 'CMakeLists.txt'
-      - 'platformio.ini'
-      - 'library.json'
-      - 'library.properties'
-
-
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_nrf52_xiaoblesense.yml
+++ b/.github/workflows/build_nrf52_xiaoblesense.yml
@@ -18,20 +18,6 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
-  pull_request:
-    branches:
-      - master
-    paths:
-      - 'src/**'
-      - 'examples/**'
-      - 'ci/**'
-      - '.github/workflows/build_nrf52_xiaoblesense.yml'
-      - '.github/workflows/build_template.yml'
-      - 'CMakeLists.txt'
-      - 'platformio.ini'
-      - 'library.json'
-      - 'library.properties'
-
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_nucleo_f429zi.yml
+++ b/.github/workflows/build_nucleo_f429zi.yml
@@ -18,20 +18,6 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
-  pull_request:
-    branches:
-      - master
-    paths:
-      - 'src/**'
-      - 'examples/**'
-      - 'ci/**'
-      - '.github/workflows/build_nucleo_f429zi.yml'
-      - '.github/workflows/build_template.yml'
-      - 'CMakeLists.txt'
-      - 'platformio.ini'
-      - 'library.json'
-      - 'library.properties'
-
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_nucleo_f439zi.yml
+++ b/.github/workflows/build_nucleo_f439zi.yml
@@ -18,20 +18,6 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
-  pull_request:
-    branches:
-      - master
-    paths:
-      - 'src/**'
-      - 'examples/**'
-      - 'ci/**'
-      - '.github/workflows/build_nucleo_f439zi.yml'
-      - '.github/workflows/build_template.yml'
-      - 'CMakeLists.txt'
-      - 'platformio.ini'
-      - 'library.json'
-      - 'library.properties'
-
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_rgbw.yml
+++ b/.github/workflows/build_rgbw.yml
@@ -18,21 +18,6 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
-  pull_request:
-    branches:
-      - master
-    paths:
-      - 'src/**'
-      - 'examples/**'
-      - 'ci/**'
-      - '.github/workflows/build_rgbw.yml'
-      - '.github/workflows/build_template.yml'
-      - 'CMakeLists.txt'
-      - 'platformio.ini'
-      - 'library.json'
-      - 'library.properties'
-
-
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_rp2040.yml
+++ b/.github/workflows/build_rp2040.yml
@@ -18,20 +18,6 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
-  pull_request:
-    branches:
-      - master
-    paths:
-      - 'src/**'
-      - 'examples/**'
-      - 'ci/**'
-      - '.github/workflows/build_rp2040.yml'
-      - '.github/workflows/build_template.yml'
-      - 'CMakeLists.txt'
-      - 'platformio.ini'
-      - 'library.json'
-      - 'library.properties'
-
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_rp2350.yml
+++ b/.github/workflows/build_rp2350.yml
@@ -18,20 +18,6 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
-  pull_request:
-    branches:
-      - master
-    paths:
-      - 'src/**'
-      - 'examples/**'
-      - 'ci/**'
-      - '.github/workflows/build_rp2350.yml'
-      - '.github/workflows/build_template.yml'
-      - 'CMakeLists.txt'
-      - 'platformio.ini'
-      - 'library.json'
-      - 'library.properties'
-
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_rp2350B.yml
+++ b/.github/workflows/build_rp2350B.yml
@@ -18,20 +18,6 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
-  pull_request:
-    branches:
-      - master
-    paths:
-      - 'src/**'
-      - 'examples/**'
-      - 'ci/**'
-      - '.github/workflows/build_rp2350B.yml'
-      - '.github/workflows/build_template.yml'
-      - 'CMakeLists.txt'
-      - 'platformio.ini'
-      - 'library.json'
-      - 'library.properties'
-
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_stm103tb.yml
+++ b/.github/workflows/build_stm103tb.yml
@@ -18,21 +18,6 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
-  pull_request:
-    branches:
-      - master
-    paths:
-      - 'src/**'
-      - 'examples/**'
-      - 'ci/**'
-      - '.github/workflows/build_stm103tb.yml'
-      - '.github/workflows/build_template.yml'
-      - 'CMakeLists.txt'
-      - 'platformio.ini'
-      - 'library.json'
-      - 'library.properties'
-
-
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_teensy30.yml
+++ b/.github/workflows/build_teensy30.yml
@@ -27,29 +27,6 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
-  pull_request:
-    branches:
-      - master
-    paths:
-      - 'src/**'
-      - '!src/platforms/esp/**'
-      - '!src/platforms/wasm/**'
-      - '!src/platforms/avr/**'
-      - '!src/platforms/arm/rp2040/**'
-      - '!src/platforms/arm/sam/**'
-      - 'src/platforms/arm/k20/**'
-      - 'src/platforms/arm/k66/**'
-      - 'src/platforms/arm/kl26/**'
-      - 'src/platforms/arm/mxrt1062/**'
-      - 'examples/**'
-      - 'ci/**'
-      - '.github/workflows/build_teensy30.yml'
-      - '.github/workflows/build_template.yml'
-      - 'CMakeLists.txt'
-      - 'platformio.ini'
-      - 'library.json'
-      - 'library.properties'
-
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_teensy31.yml
+++ b/.github/workflows/build_teensy31.yml
@@ -27,29 +27,6 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
-  pull_request:
-    branches:
-      - master
-    paths:
-      - 'src/**'
-      - '!src/platforms/esp/**'
-      - '!src/platforms/wasm/**'
-      - '!src/platforms/avr/**'
-      - '!src/platforms/arm/rp2040/**'
-      - '!src/platforms/arm/sam/**'
-      - 'src/platforms/arm/k20/**'
-      - 'src/platforms/arm/k66/**'
-      - 'src/platforms/arm/kl26/**'
-      - 'src/platforms/arm/mxrt1062/**'
-      - 'examples/**'
-      - 'ci/**'
-      - '.github/workflows/build_teensy31.yml'
-      - '.github/workflows/build_template.yml'
-      - 'CMakeLists.txt'
-      - 'platformio.ini'
-      - 'library.json'
-      - 'library.properties'
-
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_teensy32.yml
+++ b/.github/workflows/build_teensy32.yml
@@ -27,29 +27,6 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
-  pull_request:
-    branches:
-      - master
-    paths:
-      - 'src/**'
-      - '!src/platforms/esp/**'
-      - '!src/platforms/wasm/**'
-      - '!src/platforms/avr/**'
-      - '!src/platforms/arm/rp2040/**'
-      - '!src/platforms/arm/sam/**'
-      - 'src/platforms/arm/k20/**'
-      - 'src/platforms/arm/k66/**'
-      - 'src/platforms/arm/kl26/**'
-      - 'src/platforms/arm/mxrt1062/**'
-      - 'examples/**'
-      - 'ci/**'
-      - '.github/workflows/build_teensy32.yml'
-      - '.github/workflows/build_template.yml'
-      - 'CMakeLists.txt'
-      - 'platformio.ini'
-      - 'library.json'
-      - 'library.properties'
-
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_teensy35.yml
+++ b/.github/workflows/build_teensy35.yml
@@ -27,29 +27,6 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
-  pull_request:
-    branches:
-      - master
-    paths:
-      - 'src/**'
-      - '!src/platforms/esp/**'
-      - '!src/platforms/wasm/**'
-      - '!src/platforms/avr/**'
-      - '!src/platforms/arm/rp2040/**'
-      - '!src/platforms/arm/sam/**'
-      - 'src/platforms/arm/k20/**'
-      - 'src/platforms/arm/k66/**'
-      - 'src/platforms/arm/kl26/**'
-      - 'src/platforms/arm/mxrt1062/**'
-      - 'examples/**'
-      - 'ci/**'
-      - '.github/workflows/build_teensy35.yml'
-      - '.github/workflows/build_template.yml'
-      - 'CMakeLists.txt'
-      - 'platformio.ini'
-      - 'library.json'
-      - 'library.properties'
-
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_teensy36.yml
+++ b/.github/workflows/build_teensy36.yml
@@ -27,29 +27,6 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
-  pull_request:
-    branches:
-      - master
-    paths:
-      - 'src/**'
-      - '!src/platforms/esp/**'
-      - '!src/platforms/wasm/**'
-      - '!src/platforms/avr/**'
-      - '!src/platforms/arm/rp2040/**'
-      - '!src/platforms/arm/sam/**'
-      - 'src/platforms/arm/k20/**'
-      - 'src/platforms/arm/k66/**'
-      - 'src/platforms/arm/kl26/**'
-      - 'src/platforms/arm/mxrt1062/**'
-      - 'examples/**'
-      - 'ci/**'
-      - '.github/workflows/build_teensy36.yml'
-      - '.github/workflows/build_template.yml'
-      - 'CMakeLists.txt'
-      - 'platformio.ini'
-      - 'library.json'
-      - 'library.properties'
-
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_teensy40.yml
+++ b/.github/workflows/build_teensy40.yml
@@ -27,29 +27,6 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
-  pull_request:
-    branches:
-      - master
-    paths:
-      - 'src/**'
-      - '!src/platforms/esp/**'
-      - '!src/platforms/wasm/**'
-      - '!src/platforms/avr/**'
-      - '!src/platforms/arm/rp2040/**'
-      - '!src/platforms/arm/sam/**'
-      - 'src/platforms/arm/k20/**'
-      - 'src/platforms/arm/k66/**'
-      - 'src/platforms/arm/kl26/**'
-      - 'src/platforms/arm/mxrt1062/**'
-      - 'examples/**'
-      - 'ci/**'
-      - '.github/workflows/build_teensy40.yml'
-      - '.github/workflows/build_template.yml'
-      - 'CMakeLists.txt'
-      - 'platformio.ini'
-      - 'library.json'
-      - 'library.properties'
-
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_teensy41_ofled.yml
+++ b/.github/workflows/build_teensy41_ofled.yml
@@ -27,29 +27,6 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
-  pull_request:
-    branches:
-      - master
-    paths:
-      - 'src/**'
-      - '!src/platforms/esp/**'
-      - '!src/platforms/wasm/**'
-      - '!src/platforms/avr/**'
-      - '!src/platforms/arm/rp2040/**'
-      - '!src/platforms/arm/sam/**'
-      - 'src/platforms/arm/k20/**'
-      - 'src/platforms/arm/k66/**'
-      - 'src/platforms/arm/kl26/**'
-      - 'src/platforms/arm/mxrt1062/**'
-      - 'examples/**'
-      - 'ci/**'
-      - '.github/workflows/build_teensy41_ofled.yml'
-      - '.github/workflows/build_template.yml'
-      - 'CMakeLists.txt'
-      - 'platformio.ini'
-      - 'library.json'
-      - 'library.properties'
-
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_teensyLC.yml
+++ b/.github/workflows/build_teensyLC.yml
@@ -27,29 +27,6 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
-  pull_request:
-    branches:
-      - master
-    paths:
-      - 'src/**'
-      - '!src/platforms/esp/**'
-      - '!src/platforms/wasm/**'
-      - '!src/platforms/avr/**'
-      - '!src/platforms/arm/rp2040/**'
-      - '!src/platforms/arm/sam/**'
-      - 'src/platforms/arm/k20/**'
-      - 'src/platforms/arm/k66/**'
-      - 'src/platforms/arm/kl26/**'
-      - 'src/platforms/arm/mxrt1062/**'
-      - 'examples/**'
-      - 'ci/**'
-      - '.github/workflows/build_teensyLC.yml'
-      - '.github/workflows/build_template.yml'
-      - 'CMakeLists.txt'
-      - 'platformio.ini'
-      - 'library.json'
-      - 'library.properties'
-
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_teensy_octo.yml
+++ b/.github/workflows/build_teensy_octo.yml
@@ -27,29 +27,6 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
-  pull_request:
-    branches:
-      - master
-    paths:
-      - 'src/**'
-      - '!src/platforms/esp/**'
-      - '!src/platforms/wasm/**'
-      - '!src/platforms/avr/**'
-      - '!src/platforms/arm/rp2040/**'
-      - '!src/platforms/arm/sam/**'
-      - 'src/platforms/arm/k20/**'
-      - 'src/platforms/arm/k66/**'
-      - 'src/platforms/arm/kl26/**'
-      - 'src/platforms/arm/mxrt1062/**'
-      - 'examples/**'
-      - 'ci/**'
-      - '.github/workflows/build_teensy_octo.yml'
-      - '.github/workflows/build_template.yml'
-      - 'CMakeLists.txt'
-      - 'platformio.ini'
-      - 'library.json'
-      - 'library.properties'
-
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_uno_r4_wifif.yml
+++ b/.github/workflows/build_uno_r4_wifif.yml
@@ -18,20 +18,6 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
-  pull_request:
-    branches:
-      - master
-    paths:
-      - 'src/**'
-      - 'examples/**'
-      - 'ci/**'
-      - '.github/workflows/build_uno_r4_wifif.yml'
-      - '.github/workflows/build_template.yml'
-      - 'CMakeLists.txt'
-      - 'platformio.ini'
-      - 'library.json'
-      - 'library.properties'
-
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_wasm_compilers.yml
+++ b/.github/workflows/build_wasm_compilers.yml
@@ -18,20 +18,6 @@ on:
         - 'platformio.ini'
         - 'library.json'
         - 'library.properties'
-    pull_request:
-      branches:
-        - master
-      paths:
-        - 'src/**'
-        - 'examples/wasm/**'
-        - 'examples/WasmScreenCoords/**'
-        - 'ci/**'
-        - '.github/workflows/build_wasm_compilers.yml'
-        - 'CMakeLists.txt'
-        - 'platformio.ini'
-        - 'library.json'
-        - 'library.properties'
-
 permissions:
   contents: read        # Required to checkout code
   actions: read         # Required for artifact operations  

--- a/.github/workflows/build_yun.yml
+++ b/.github/workflows/build_yun.yml
@@ -18,20 +18,6 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
-  pull_request:
-    branches:
-      - master
-    paths:
-      - 'src/**'
-      - 'examples/**'
-      - 'ci/**'
-      - '.github/workflows/build_yun.yml'
-      - '.github/workflows/build_template.yml'
-      - 'CMakeLists.txt'
-      - 'platformio.ini'
-      - 'library.json'
-      - 'library.properties'
-
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/check_attiny85.yml
+++ b/.github/workflows/check_attiny85.yml
@@ -18,20 +18,6 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
-  pull_request:
-    branches:
-      - master
-    paths:
-      - 'src/**'
-      - 'examples/**'
-      - 'ci/**'
-      - '.github/workflows/check_attiny85.yml'
-      - '.github/workflows/build_template_binary_size.yml'
-      - 'CMakeLists.txt'
-      - 'platformio.ini'
-      - 'library.json'
-      - 'library.properties'
-
 jobs:
   build:
     uses: ./.github/workflows/build_template_binary_size.yml

--- a/.github/workflows/check_bluepill_size.yml
+++ b/.github/workflows/check_bluepill_size.yml
@@ -18,20 +18,6 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
-  pull_request:
-    branches:
-      - master
-    paths:
-      - 'src/**'
-      - 'examples/**'
-      - 'ci/**'
-      - '.github/workflows/check_bluepill_size.yml'
-      - '.github/workflows/build_template_binary_size.yml'
-      - 'CMakeLists.txt'
-      - 'platformio.ini'
-      - 'library.json'
-      - 'library.properties'
-
 jobs:
   build:
     uses: ./.github/workflows/build_template_binary_size.yml

--- a/.github/workflows/check_esp32_size.yml
+++ b/.github/workflows/check_esp32_size.yml
@@ -18,20 +18,6 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
-  pull_request:
-    branches:
-      - master
-    paths:
-      - 'src/**'
-      - 'examples/**'
-      - 'ci/**'
-      - '.github/workflows/check_esp32_size.yml'
-      - '.github/workflows/build_template_binary_size.yml'
-      - 'CMakeLists.txt'
-      - 'platformio.ini'
-      - 'library.json'
-      - 'library.properties'
-
 jobs:
   build:
     uses: ./.github/workflows/build_template_binary_size.yml

--- a/.github/workflows/check_teensy30_size.yml
+++ b/.github/workflows/check_teensy30_size.yml
@@ -27,29 +27,6 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
-  pull_request:
-    branches:
-      - master
-    paths:
-      - 'src/**'
-      - '!src/platforms/esp/**'
-      - '!src/platforms/wasm/**'
-      - '!src/platforms/avr/**'
-      - '!src/platforms/arm/rp2040/**'
-      - '!src/platforms/arm/sam/**'
-      - 'src/platforms/arm/k20/**'
-      - 'src/platforms/arm/k66/**'
-      - 'src/platforms/arm/kl26/**'
-      - 'src/platforms/arm/mxrt1062/**'
-      - 'examples/**'
-      - 'ci/**'
-      - '.github/workflows/check_teensy30_size.yml'
-      - '.github/workflows/build_template.yml'
-      - 'CMakeLists.txt'
-      - 'platformio.ini'
-      - 'library.json'
-      - 'library.properties'
-
 jobs:
   build:
     uses: ./.github/workflows/build_template_binary_size.yml

--- a/.github/workflows/check_teensy31_size.yml
+++ b/.github/workflows/check_teensy31_size.yml
@@ -27,29 +27,6 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
-  pull_request:
-    branches:
-      - master
-    paths:
-      - 'src/**'
-      - '!src/platforms/esp/**'
-      - '!src/platforms/wasm/**'
-      - '!src/platforms/avr/**'
-      - '!src/platforms/arm/rp2040/**'
-      - '!src/platforms/arm/sam/**'
-      - 'src/platforms/arm/k20/**'
-      - 'src/platforms/arm/k66/**'
-      - 'src/platforms/arm/kl26/**'
-      - 'src/platforms/arm/mxrt1062/**'
-      - 'examples/**'
-      - 'ci/**'
-      - '.github/workflows/check_teensy31_size.yml'
-      - '.github/workflows/build_template.yml'
-      - 'CMakeLists.txt'
-      - 'platformio.ini'
-      - 'library.json'
-      - 'library.properties'
-
 jobs:
   build:
     uses: ./.github/workflows/build_template_binary_size.yml

--- a/.github/workflows/check_teensy32_size.yml
+++ b/.github/workflows/check_teensy32_size.yml
@@ -27,29 +27,6 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
-  pull_request:
-    branches:
-      - master
-    paths:
-      - 'src/**'
-      - '!src/platforms/esp/**'
-      - '!src/platforms/wasm/**'
-      - '!src/platforms/avr/**'
-      - '!src/platforms/arm/rp2040/**'
-      - '!src/platforms/arm/sam/**'
-      - 'src/platforms/arm/k20/**'
-      - 'src/platforms/arm/k66/**'
-      - 'src/platforms/arm/kl26/**'
-      - 'src/platforms/arm/mxrt1062/**'
-      - 'examples/**'
-      - 'ci/**'
-      - '.github/workflows/check_teensy32_size.yml'
-      - '.github/workflows/build_template.yml'
-      - 'CMakeLists.txt'
-      - 'platformio.ini'
-      - 'library.json'
-      - 'library.properties'
-
 jobs:
   build:
     uses: ./.github/workflows/build_template_binary_size.yml

--- a/.github/workflows/check_teensy35_size.yml
+++ b/.github/workflows/check_teensy35_size.yml
@@ -27,29 +27,6 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
-  pull_request:
-    branches:
-      - master
-    paths:
-      - 'src/**'
-      - '!src/platforms/esp/**'
-      - '!src/platforms/wasm/**'
-      - '!src/platforms/avr/**'
-      - '!src/platforms/arm/rp2040/**'
-      - '!src/platforms/arm/sam/**'
-      - 'src/platforms/arm/k20/**'
-      - 'src/platforms/arm/k66/**'
-      - 'src/platforms/arm/kl26/**'
-      - 'src/platforms/arm/mxrt1062/**'
-      - 'examples/**'
-      - 'ci/**'
-      - '.github/workflows/check_teensy35_size.yml'
-      - '.github/workflows/build_template.yml'
-      - 'CMakeLists.txt'
-      - 'platformio.ini'
-      - 'library.json'
-      - 'library.properties'
-
 jobs:
   build:
     uses: ./.github/workflows/build_template_binary_size.yml

--- a/.github/workflows/check_teensy36_size.yml
+++ b/.github/workflows/check_teensy36_size.yml
@@ -27,29 +27,6 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
-  pull_request:
-    branches:
-      - master
-    paths:
-      - 'src/**'
-      - '!src/platforms/esp/**'
-      - '!src/platforms/wasm/**'
-      - '!src/platforms/avr/**'
-      - '!src/platforms/arm/rp2040/**'
-      - '!src/platforms/arm/sam/**'
-      - 'src/platforms/arm/k20/**'
-      - 'src/platforms/arm/k66/**'
-      - 'src/platforms/arm/kl26/**'
-      - 'src/platforms/arm/mxrt1062/**'
-      - 'examples/**'
-      - 'ci/**'
-      - '.github/workflows/check_teensy36_size.yml'
-      - '.github/workflows/build_template.yml'
-      - 'CMakeLists.txt'
-      - 'platformio.ini'
-      - 'library.json'
-      - 'library.properties'
-
 jobs:
   build:
     uses: ./.github/workflows/build_template_binary_size.yml

--- a/.github/workflows/check_teensy41_size.yml
+++ b/.github/workflows/check_teensy41_size.yml
@@ -27,29 +27,6 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
-  pull_request:
-    branches:
-      - master
-    paths:
-      - 'src/**'
-      - '!src/platforms/esp/**'
-      - '!src/platforms/wasm/**'
-      - '!src/platforms/avr/**'
-      - '!src/platforms/arm/rp2040/**'
-      - '!src/platforms/arm/sam/**'
-      - 'src/platforms/arm/k20/**'
-      - 'src/platforms/arm/k66/**'
-      - 'src/platforms/arm/kl26/**'
-      - 'src/platforms/arm/mxrt1062/**'
-      - 'examples/**'
-      - 'ci/**'
-      - '.github/workflows/check_teensy41_size.yml'
-      - '.github/workflows/build_template.yml'
-      - 'CMakeLists.txt'
-      - 'platformio.ini'
-      - 'library.json'
-      - 'library.properties'
-
 jobs:
   build:
     uses: ./.github/workflows/build_template_binary_size.yml

--- a/.github/workflows/check_teensylc_size.yml
+++ b/.github/workflows/check_teensylc_size.yml
@@ -27,29 +27,6 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
-  pull_request:
-    branches:
-      - master
-    paths:
-      - 'src/**'
-      - '!src/platforms/esp/**'
-      - '!src/platforms/wasm/**'
-      - '!src/platforms/avr/**'
-      - '!src/platforms/arm/rp2040/**'
-      - '!src/platforms/arm/sam/**'
-      - 'src/platforms/arm/k20/**'
-      - 'src/platforms/arm/k66/**'
-      - 'src/platforms/arm/kl26/**'
-      - 'src/platforms/arm/mxrt1062/**'
-      - 'examples/**'
-      - 'ci/**'
-      - '.github/workflows/check_teensylc_size.yml'
-      - '.github/workflows/build_template.yml'
-      - 'CMakeLists.txt'
-      - 'platformio.ini'
-      - 'library.json'
-      - 'library.properties'
-
 jobs:
   build:
     uses: ./.github/workflows/build_template_binary_size.yml

--- a/.github/workflows/check_uno_size.yml
+++ b/.github/workflows/check_uno_size.yml
@@ -18,20 +18,6 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
-  pull_request:
-    branches:
-      - master
-    paths:
-      - 'src/**'
-      - 'examples/**'
-      - 'ci/**'
-      - '.github/workflows/check_uno_size.yml'
-      - '.github/workflows/build_template_binary_size.yml'
-      - 'CMakeLists.txt'
-      - 'platformio.ini'
-      - 'library.json'
-      - 'library.properties'
-
 jobs:
   build:
     uses: ./.github/workflows/build_template_binary_size.yml

--- a/.github/workflows/example_test_macos.yml
+++ b/.github/workflows/example_test_macos.yml
@@ -20,22 +20,6 @@ on:
       - 'pyproject.toml'
       - 'test'
       - 'test.py'
-  pull_request:
-    branches:
-      - master
-    paths:
-      - 'src/**'
-      - 'examples/**'
-      - 'ci/**'
-      - '.github/workflows/example_test*.yml'
-      - '.github/workflows/template_example_test.yml'
-      - 'CMakeLists.txt'
-      - 'meson.build'
-      - 'examples/meson.build'
-      - 'pyproject.toml'
-      - 'test'
-      - 'test.py'
-
 jobs:
   test:
     uses: ./.github/workflows/template_example_test.yml

--- a/.github/workflows/example_test_windows.yml
+++ b/.github/workflows/example_test_windows.yml
@@ -20,22 +20,6 @@ on:
       - 'pyproject.toml'
       - 'test'
       - 'test.py'
-  pull_request:
-    branches:
-      - master
-    paths:
-      - 'src/**'
-      - 'examples/**'
-      - 'ci/**'
-      - '.github/workflows/example_test*.yml'
-      - '.github/workflows/template_example_test.yml'
-      - 'CMakeLists.txt'
-      - 'meson.build'
-      - 'examples/meson.build'
-      - 'pyproject.toml'
-      - 'test'
-      - 'test.py'
-
 jobs:
   test:
     uses: ./.github/workflows/template_example_test.yml

--- a/.github/workflows/header-perf.yml
+++ b/.github/workflows/header-perf.yml
@@ -11,11 +11,6 @@ on:
       - 'src/**/*.h'
       - 'src/**/*.hpp'
       - '.github/workflows/header-perf.yml'
-  pull_request:
-    paths:
-      - 'src/**/*.h'
-      - 'src/**/*.hpp'
-
 jobs:
   header-perf:
     runs-on: ubuntu-latest

--- a/.github/workflows/qemu_esp32c3_test.yml
+++ b/.github/workflows/qemu_esp32c3_test.yml
@@ -19,20 +19,6 @@ on:
       - 'library.json'
       - '.github/workflows/qemu_esp32c3_test.yml'
       - '.github/workflows/qemu_docker_template.yml'
-  pull_request:
-    branches: [master]
-    paths:
-      - 'src/**/*.cpp'
-      - 'src/**/*.h'
-      - 'examples/**/*.ino'
-      - 'examples/**/*.cpp'
-      - 'examples/**/*.h'
-      - 'platformio.ini'
-      - 'CMakeLists.txt'
-      - 'library.json'
-      - '.github/workflows/qemu_esp32c3_test.yml'
-      - '.github/workflows/qemu_docker_template.yml'
-
 jobs:
   esp32c3_qemu_test:
     strategy:

--- a/.github/workflows/qemu_esp32dev_test.yml
+++ b/.github/workflows/qemu_esp32dev_test.yml
@@ -19,20 +19,6 @@ on:
       - 'library.json'
       - '.github/workflows/qemu_esp32dev_test.yml'
       - '.github/workflows/qemu_docker_template.yml'
-  pull_request:
-    branches: [master]
-    paths:
-      - 'src/**/*.cpp'
-      - 'src/**/*.h'
-      - 'examples/**/*.ino'
-      - 'examples/**/*.cpp'
-      - 'examples/**/*.h'
-      - 'platformio.ini'
-      - 'CMakeLists.txt'
-      - 'library.json'
-      - '.github/workflows/qemu_esp32dev_test.yml'
-      - '.github/workflows/qemu_docker_template.yml'
-
 jobs:
   esp32dev_qemu_test:
     uses: ./.github/workflows/qemu_docker_template.yml

--- a/.github/workflows/qemu_esp32s3_test.yml
+++ b/.github/workflows/qemu_esp32s3_test.yml
@@ -19,20 +19,6 @@ on:
       - 'library.json'
       - '.github/workflows/qemu_esp32s3_test.yml'
       - '.github/workflows/qemu_docker_template.yml'
-  pull_request:
-    branches: [master]
-    paths:
-      - 'src/**/*.cpp'
-      - 'src/**/*.h'
-      - 'examples/**/*.ino'
-      - 'examples/**/*.cpp'
-      - 'examples/**/*.h'
-      - 'platformio.ini'
-      - 'CMakeLists.txt'
-      - 'library.json'
-      - '.github/workflows/qemu_esp32s3_test.yml'
-      - '.github/workflows/qemu_docker_template.yml'
-
 jobs:
   esp32s3_qemu_rmt:
     uses: ./.github/workflows/qemu_docker_template.yml

--- a/.github/workflows/unit_test_macos.yml
+++ b/.github/workflows/unit_test_macos.yml
@@ -20,22 +20,6 @@ on:
       - 'pyproject.toml'
       - 'test'
       - 'test.py'
-  pull_request:
-    branches:
-      - master
-    paths:
-      - 'src/**'
-      - 'tests/**'
-      - 'ci/**'
-      - '.github/workflows/build_unit_test*.yml'
-      - '.github/workflows/template_unit_test.yml'
-      - 'CMakeLists.txt'
-      - 'meson.build'
-      - 'examples/meson.build'
-      - 'pyproject.toml'
-      - 'test'
-      - 'test.py'
-
 jobs:
   test:
     uses: ./.github/workflows/template_unit_test.yml

--- a/.github/workflows/unit_test_windows.yml
+++ b/.github/workflows/unit_test_windows.yml
@@ -20,22 +20,6 @@ on:
       - 'pyproject.toml'
       - 'test'
       - 'test.py'
-  pull_request:
-    branches:
-      - master
-    paths:
-      - 'src/**'
-      - 'tests/**'
-      - 'ci/**'
-      - '.github/workflows/build_unit_test*.yml'
-      - '.github/workflows/template_unit_test.yml'
-      - 'CMakeLists.txt'
-      - 'meson.build'
-      - 'examples/meson.build'
-      - 'pyproject.toml'
-      - 'test'
-      - 'test.py'
-
 jobs:
   test:
     uses: ./.github/workflows/template_unit_test.yml

--- a/ci/tools/gh/limit_agent_pr_workflows.py
+++ b/ci/tools/gh/limit_agent_pr_workflows.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""Limit GitHub Actions pull_request triggers to the agent PR allowlist.
+
+By default this script is a dry run. Pass --apply to rewrite workflow files.
+It intentionally leaves existing push, paths, and workflow_dispatch settings
+alone; the repo's workflow shape was already mostly correct.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+DEFAULT_PR_ALLOWLIST = frozenset(
+    {
+        "unit_test_linux.yml",
+        "example_test_linux.yml",
+        "build_uno.yml",
+        "build_esp32s3.yml",
+        "build_teensy41.yml",
+        "build_wasm.yml",
+    }
+)
+
+EVENT_RE = re.compile(r"^([A-Za-z0-9_-]+):(?:\s*(?:#.*)?)?$")
+
+
+@dataclass(frozen=True)
+class EventBlock:
+    name: str
+    start: int
+    end: int
+    indent: int
+
+
+@dataclass(frozen=True)
+class OnBlock:
+    start: int
+    end: int
+    child_indent: int
+    events: dict[str, EventBlock]
+
+
+@dataclass(frozen=True)
+class WorkflowResult:
+    path: Path
+    changes: tuple[str, ...]
+    original_text: str
+    updated_text: str
+
+    @property
+    def changed(self) -> bool:
+        return self.original_text != self.updated_text
+
+
+def line_indent(line: str) -> int:
+    return len(line) - len(line.lstrip(" "))
+
+
+def find_on_block(lines: list[str]) -> OnBlock | None:
+    on_start = None
+    on_indent = 0
+    for index, line in enumerate(lines):
+        if line.strip() == "on:":
+            on_start = index
+            on_indent = line_indent(line)
+            break
+
+    if on_start is None:
+        return None
+
+    on_end = len(lines)
+    for index in range(on_start + 1, len(lines)):
+        stripped = lines[index].strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if line_indent(lines[index]) <= on_indent:
+            on_end = index
+            break
+
+    child_indent = 2
+    for index in range(on_start + 1, on_end):
+        stripped = lines[index].strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        indent = line_indent(lines[index])
+        if indent > on_indent:
+            child_indent = indent
+            break
+
+    event_starts: list[tuple[str, int]] = []
+    for index in range(on_start + 1, on_end):
+        if line_indent(lines[index]) != child_indent:
+            continue
+        match = EVENT_RE.match(lines[index].strip())
+        if match:
+            event_starts.append((match.group(1), index))
+
+    events: dict[str, EventBlock] = {}
+    for position, (name, start) in enumerate(event_starts):
+        end = event_starts[position + 1][1] if position + 1 < len(event_starts) else on_end
+        events[name] = EventBlock(name=name, start=start, end=end, indent=child_indent)
+
+    return OnBlock(start=on_start, end=on_end, child_indent=child_indent, events=events)
+
+
+def remove_pull_request_if_needed(path: Path, allow_pr: bool) -> WorkflowResult:
+    original_text = path.read_text(encoding="utf-8")
+    if allow_pr:
+        return WorkflowResult(path, (), original_text, original_text)
+
+    lines = original_text.splitlines(keepends=True)
+    on_block = find_on_block(lines)
+    if on_block is None:
+        return WorkflowResult(path, (), original_text, original_text)
+
+    pull_request = on_block.events.get("pull_request")
+    if pull_request is None:
+        return WorkflowResult(path, (), original_text, original_text)
+
+    updated_lines = lines[: pull_request.start] + lines[pull_request.end :]
+    return WorkflowResult(
+        path=path,
+        changes=("remove pull_request",),
+        original_text=original_text,
+        updated_text="".join(updated_lines),
+    )
+
+
+def workflow_files(workflows_dir: Path) -> list[Path]:
+    files = [*workflows_dir.glob("*.yml"), *workflows_dir.glob("*.yaml")]
+    return sorted(path for path in files if path.is_file())
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Limit GitHub Actions pull_request triggers to the agent PR allowlist."
+    )
+    parser.add_argument(
+        "--workflows-dir",
+        type=Path,
+        default=Path(".github/workflows"),
+        help="Directory containing workflow .yml/.yaml files.",
+    )
+    parser.add_argument(
+        "--allow-pr",
+        action="append",
+        default=[],
+        metavar="FILENAME",
+        help="Additional workflow filename allowed to keep pull_request.",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Rewrite workflow files. Without this flag, only print the planned changes.",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Return a non-zero exit code if any workflow would change.",
+    )
+    parser.add_argument(
+        "--print-allowlist",
+        action="store_true",
+        help="Print the effective PR allowlist and exit.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    allowlist = DEFAULT_PR_ALLOWLIST | set(args.allow_pr)
+
+    if args.print_allowlist:
+        for filename in sorted(allowlist):
+            print(filename)
+        return 0
+
+    workflows_dir = args.workflows_dir
+    if not workflows_dir.is_dir():
+        print(f"Workflow directory not found: {workflows_dir}", file=sys.stderr)
+        return 2
+
+    results = [
+        remove_pull_request_if_needed(path, allow_pr=path.name in allowlist)
+        for path in workflow_files(workflows_dir)
+    ]
+    changed = [result for result in results if result.changed]
+
+    for result in changed:
+        print(result.path.as_posix())
+        for change in result.changes:
+            print(f"  - {change}")
+
+    if args.apply:
+        for result in changed:
+            result.path.write_text(result.updated_text, encoding="utf-8")
+        print(f"Updated {len(changed)} workflow file(s).")
+    else:
+        print(f"Would update {len(changed)} workflow file(s). Pass --apply to rewrite.")
+
+    if args.check and changed:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- limits automatic PR workflows to the lightweight allowlist from #2393
- leaves existing push, path, branch, and manual-dispatch settings alone
- removes only non-allowlisted `pull_request` trigger blocks
- adds `ci/tools/gh/limit_agent_pr_workflows.py` as a dry-run/apply/check helper for the same narrow policy

## PR allowlist after this change

- `.github/workflows/unit_test_linux.yml`
- `.github/workflows/example_test_linux.yml`
- `.github/workflows/build_uno.yml`
- `.github/workflows/build_esp32s3.yml`
- `.github/workflows/build_teensy41.yml`
- `.github/workflows/build_wasm.yml`

## Validation

- `python -m py_compile ci/tools/gh/limit_agent_pr_workflows.py`
- `python ci/tools/gh/limit_agent_pr_workflows.py --check`
- parsed all 108 workflow YAML files successfully
- verified remaining `pull_request` triggers are limited to the six allowlisted workflows above
- `git diff --check -- .github/workflows ci/tools/gh/limit_agent_pr_workflows.py`

Closes #2393

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Modified GitHub Actions workflows to trigger only on push events to the master branch. Pull request checks will no longer automatically run upon PR creation.
* Added automation tooling for managing workflow trigger configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->