### PR TITLE
Add public RxChannel API under fl/channels/rx

### DIFF
--- a/examples/AutoResearch/AutoResearch.ino
+++ b/examples/AutoResearch/AutoResearch.ino
@@ -213,7 +213,7 @@
 // Serial port timeout (milliseconds) - wait for serial monitor to attach
 #define SERIAL_TIMEOUT_MS 120000  // 120 seconds
 
-const fl::RxDeviceType RX_TYPE = fl::RxDeviceType::PLATFORM_DEFAULT;
+const fl::RxBackend RX_BACKEND = fl::RxBackend::PLATFORM_DEFAULT;
 
 // ============================================================================
 // Platform-Specific Pin Defaults
@@ -240,10 +240,11 @@ constexpr int RX_BUFFER_SIZE = 100 * 32 + 100;  // Memory-constrained: 100 LEDs 
 constexpr int RX_BUFFER_SIZE = 3000 * 32 + 100;  // LEDs × 32:1 expansion + headroom
 #endif
 
-// Factory function for creating RxDevice instances
+// Factory function for creating RxChannel instances
 // This allows AutoResearchRemoteControl to recreate the RX channel when the pin changes
-fl::shared_ptr<fl::RxDevice> createRxDevice(int pin) {
-    return fl::RxDevice::create<RX_TYPE>(pin);
+fl::shared_ptr<fl::RxChannel> createRxDevice(int pin) {
+    fl::RxChannelConfig config(pin, RX_BACKEND);
+    return FastLED.addRx(config);
 }
 
 // Global autoresearch state (shared between main loop and RPC handlers)
@@ -317,7 +318,7 @@ void setup() {
     ss << "\n[HARDWARE]\n";
     ss << "  TX Pin: " << PIN_TX << "\n";  // --expect "TX Pin: 0"
     ss << "  RX Pin: " << PIN_RX << "\n";  // --expect "RX Pin: 1"
-    ss << "  RX Device: " << fl::toString(RX_TYPE) << "\n";
+    ss << "  RX Device: " << fl::toString(RX_BACKEND) << "\n";
     ss << "  Loopback Mode: " << loop_back_mode << "\n";
     ss << "  Color Order: RGB\n";
     ss << "  RX Buffer Size: " << RX_BUFFER_SIZE << " bytes";
@@ -341,7 +342,7 @@ void setup() {
        << " (" << (40000000 / 1000000) << "MHz, " << RX_BUFFER_SIZE << " symbols)";
     FL_PRINT(ss.str());
 
-    g_autoresearch_state->rx_channel = fl::RxDevice::create<RX_TYPE>(PIN_RX);
+    g_autoresearch_state->rx_channel = createRxDevice(PIN_RX);
 
     if (!g_autoresearch_state->rx_channel) {
         ss.clear();

--- a/examples/AutoResearch/AutoResearchHelpers.cpp
+++ b/examples/AutoResearch/AutoResearchHelpers.cpp
@@ -8,7 +8,7 @@
 #include "fl/channels/detail/validation/result_formatter.h"
 
 bool testRxChannel(
-    fl::shared_ptr<fl::RxDevice> rx_channel,
+    fl::shared_ptr<fl::RxChannel> rx_channel,
     int pin_tx,
     int pin_rx,
     uint32_t hz,
@@ -30,7 +30,7 @@ void testDriver(
     size_t num_leds,
     CRGB* leds,
     EOrder color_order,
-    fl::shared_ptr<fl::RxDevice> rx_channel,
+    fl::shared_ptr<fl::RxChannel> rx_channel,
     fl::span<uint8_t> rx_buffer,
     int base_strip_size,
     fl::RxDeviceType rx_type,

--- a/examples/AutoResearch/AutoResearchHelpers.h
+++ b/examples/AutoResearch/AutoResearchHelpers.h
@@ -6,7 +6,6 @@
 #include <FastLED.h>
 #include "Common.h"
 #include "AutoResearchTest.h"
-#include "fl/rx_device.h"
 
 /// @brief Test RX channel with manual GPIO toggle
 /// @param rx_channel RX channel to test
@@ -16,7 +15,7 @@
 /// @param buffer_size Size of RX buffer in symbols
 /// @return true if test passes, false otherwise
 bool testRxChannel(
-    fl::shared_ptr<fl::RxDevice> rx_channel,
+    fl::shared_ptr<fl::RxChannel> rx_channel,
     int pin_tx,
     int pin_rx,
     uint32_t hz,
@@ -46,7 +45,7 @@ void testDriver(
     size_t num_leds,
     CRGB* leds,
     EOrder color_order,
-    fl::shared_ptr<fl::RxDevice> rx_channel,
+    fl::shared_ptr<fl::RxChannel> rx_channel,
     fl::span<uint8_t> rx_buffer,
     int base_strip_size,
     fl::RxDeviceType rx_type,

--- a/examples/AutoResearch/AutoResearchRemote.cpp
+++ b/examples/AutoResearch/AutoResearchRemote.cpp
@@ -349,7 +349,7 @@ fl::json AutoResearchRemoteControl::runSingleTestImpl(const fl::json& args) {
     }
 
     // Create temporary RX channel if pinRx differs from default
-    fl::shared_ptr<fl::RxDevice> rx_channel_to_use = mState->rx_channel;
+    fl::shared_ptr<fl::RxChannel> rx_channel_to_use = mState->rx_channel;
 
     if (pin_rx != mState->pin_rx && mState->rx_factory) {
         rx_channel_to_use = mState->rx_factory(pin_rx);

--- a/examples/AutoResearch/AutoResearchRemote.h
+++ b/examples/AutoResearch/AutoResearchRemote.h
@@ -22,19 +22,19 @@
 namespace fl {
 class json;
 class Remote;
-class RxDevice;
+class RxChannel;
 namespace net { namespace ble { struct TransportState; } }
 }
 
-/// @brief Factory function type for creating RxDevice instances
-/// @param pin The GPIO pin to create the RxDevice on
-/// @return A shared_ptr to the created RxDevice, or nullptr on failure
-using RxDeviceFactory = fl::shared_ptr<fl::RxDevice>(*)(int pin);
+/// @brief Factory function type for creating RxChannel instances
+/// @param pin The GPIO pin to create the RxChannel on
+/// @return A shared_ptr to the created RxChannel, or nullptr on failure
+using RxDeviceFactory = fl::shared_ptr<fl::RxChannel>(*)(int pin);
 
 /// @brief AutoResearch runtime state (shared between main loop and RPC handlers)
 struct AutoResearchState {
     fl::vector<fl::DriverInfo> drivers_available;
-    fl::shared_ptr<fl::RxDevice> rx_channel;
+    fl::shared_ptr<fl::RxChannel> rx_channel;
     fl::span<uint8_t> rx_buffer;
     int pin_tx;
     int pin_rx;

--- a/examples/AutoResearch/AutoResearchTest.cpp
+++ b/examples/AutoResearch/AutoResearchTest.cpp
@@ -25,7 +25,7 @@
 /// @param rx_channel RX device to read edge data from
 /// @param timing Chipset timing configuration for pattern analysis
 /// @param range Edge range to print (offset, count)
-void dumpRawEdgeTiming(fl::shared_ptr<fl::RxDevice> rx_channel,
+void dumpRawEdgeTiming(fl::shared_ptr<fl::RxChannel> rx_channel,
                        const fl::ChipsetTimingConfig& timing,
                        fl::EdgeRange range) {
     if (!rx_channel) {
@@ -171,7 +171,7 @@ static fl::vector<uint8_t> buildExpectedUCS7604(fl::span<CRGB> leds, const fl::C
 // RMT RX captures edges on the data pin. Each edge duration / bit_period_ns
 // gives the number of consecutive same-value bits.
 // Returns number of LED RGB bytes written to rx_buffer, or 0 on error.
-static size_t decodeSpiEdges(fl::shared_ptr<fl::RxDevice> rx_channel,
+static size_t decodeSpiEdges(fl::shared_ptr<fl::RxChannel> rx_channel,
                              fl::span<uint8_t> rx_buffer,
                              uint32_t clock_hz) {
     if (!rx_channel || clock_hz == 0) {
@@ -314,7 +314,7 @@ static size_t decodeSpiEdges(fl::shared_ptr<fl::RxDevice> rx_channel,
 // - timing: Chipset timing configuration for RX decoder
 // - driver_name: Name of the TX driver being tested (e.g., "RMT", "PARLIO") - enables io_loop_back only for RMT
 // Returns number of bytes captured, or 0 on error
-size_t capture(fl::shared_ptr<fl::RxDevice> rx_channel, fl::span<uint8_t> rx_buffer, const fl::ChipsetTimingConfig& timing, const char* driver_name) {
+size_t capture(fl::shared_ptr<fl::RxChannel> rx_channel, fl::span<uint8_t> rx_buffer, const fl::ChipsetTimingConfig& timing, const char* driver_name) {
     if (!rx_channel) {
         FL_ERROR("RX channel is null");
         return 0;
@@ -324,13 +324,13 @@ size_t capture(fl::shared_ptr<fl::RxDevice> rx_channel, fl::span<uint8_t> rx_buf
     fl::memset(rx_buffer.data(), 0, rx_buffer.size());
 
     // Prepare RX config (but don't arm yet to avoid locking TX resources)
-    fl::RxConfig rx_config;  // Use default WS2812B-compatible settings
+    fl::RxChannelConfig rx_config(rx_channel->getPin());
     rx_config.hz = 40000000; // 40MHz for high-precision LED timing capture
 
     // Buffer size: 1 LED byte = 8 bits = 8 RMT symbols
     // UART with TX inversion produces standard WS2812 waveform, same symbol count
     bool is_uart_driver = (fl::strcmp(driver_name, "UART") == 0);
-    rx_config.buffer_size = rx_buffer.size() * 8;
+    rx_config.edge_capacity = rx_buffer.size() * 8;
 
     // Internal loopback configuration: Enable ONLY for RMT TX -> RMT RX scenarios
     // When driver_name == "RMT", enable io_loop_back to route RMT TX output to RMT RX internally

--- a/examples/AutoResearch/AutoResearchTest.h
+++ b/examples/AutoResearch/AutoResearchTest.h
@@ -5,7 +5,6 @@
 
 #include <FastLED.h>
 #include "fl/channels/validation.h"
-#include "fl/rx_device.h"
 
 namespace fl {
 
@@ -16,7 +15,7 @@ struct AutoResearchConfig {
     const char* timing_name;                     ///< Timing name for logging (e.g., "WS2812B-V5")
     fl::span<fl::ChannelConfig> tx_configs;      ///< TX channel configurations to test (mutable for LED manipulation)
     const char* driver_name;                     ///< Driver name for logging (e.g., "RMT", "SPI", "PARLIO")
-    fl::shared_ptr<fl::RxDevice> rx_channel;     ///< RX channel for loopback capture (created in .ino, passed in)
+    fl::shared_ptr<fl::RxChannel> rx_channel;    ///< RX channel for loopback capture (created in .ino, passed in)
     fl::span<uint8_t> rx_buffer;                 ///< Buffer to store received bytes
     int base_strip_size;                         ///< Base strip size (10 or 300 LEDs)
     fl::RxDeviceType rx_type;                    ///< RX device type (RMT or ISR)
@@ -25,7 +24,7 @@ struct AutoResearchConfig {
                      const char* tn,
                      fl::span<fl::ChannelConfig> tc,
                      const char* dn,
-                     fl::shared_ptr<fl::RxDevice> rc,
+                     fl::shared_ptr<fl::RxChannel> rc,
                      fl::span<uint8_t> rb,
                      int bss,
                      fl::RxDeviceType rt)
@@ -110,7 +109,7 @@ struct MultiRunConfig {
 // - timing: Chipset timing configuration for RX decoder
 // - driver_name: Name of the TX driver being tested (e.g., "RMT", "PARLIO") - enables io_loop_back only for RMT
 // Returns number of bytes captured, or 0 on error
-size_t capture(fl::shared_ptr<fl::RxDevice> rx_channel, fl::span<uint8_t> rx_buffer, const fl::ChipsetTimingConfig& timing, const char* driver_name);
+size_t capture(fl::shared_ptr<fl::RxChannel> rx_channel, fl::span<uint8_t> rx_buffer, const fl::ChipsetTimingConfig& timing, const char* driver_name);
 
 // Generic driver-agnostic autoresearch test runner (single run)
 // Tests all channels using the specified configuration

--- a/examples/RX/RX.ino
+++ b/examples/RX/RX.ino
@@ -1,11 +1,11 @@
 // @filter: (platform is esp32)
 
 /// @file    RX.ino
-/// @brief   RX device test for ESP32
+/// @brief   RX channel test for ESP32
 /// @example RX.ino
 ///
-/// This example demonstrates FastLED's RX device on ESP32 by capturing
-/// edge transitions from manual pin toggles. This validates the RX device can
+/// This example demonstrates FastLED's RX channel API on ESP32 by capturing
+/// edge transitions from manual pin toggles. This validates the RX channel can
 /// accurately capture timing data.
 ///
 /// Hardware Setup:
@@ -13,9 +13,9 @@
 ///   - No external wiring required (internal loopback test)
 ///
 /// Test Flow:
-///   1. Create and initialize RX device
+///   1. Create and initialize RX channel
 ///   2. Toggle pin in a defined pattern (HIGH/LOW with specific delays)
-///   3. Capture edge timing data using RX device
+///   3. Capture edge timing data using RX channel
 ///   4. Analyze and display raw edge timings
 ///
 /// Platform Support:
@@ -25,7 +25,7 @@
 //    bash debug RX --expect "TX Pin: GPIO 0" --expect "RX Pin: GPIO 1" --expect "RX Device: RMT" --fail-on ERROR
 
 #include <FastLED.h>
-#include "fl/rx_device.h"
+#include "fl/stl/singleton.h"
 #include "test.h"
 #include "SketchHalt.h"
 
@@ -43,7 +43,7 @@
 // Pin and RX type configuration (extern for test.cpp access)
 const int PIN_TX = 0;   // DO NOT CHANGE - REQUIRED FOR TEST INFRASTRUCTURE
 const int PIN_RX = 1;   // DO NOT CHANGE - REQUIRED FOR TEST INFRASTRUCTURE
-constexpr fl::RxDeviceType RX_TYPE = fl::RxDeviceType::RMT;
+constexpr fl::RxBackend RX_BACKEND = fl::RxBackend::RMT;
 
 // ============================================================================
 // Pin Toggle Pattern
@@ -63,7 +63,9 @@ const fl::array<PinToggle, 6> TEST_PATTERN = {{
 // Global State
 // ============================================================================
 
-fl::shared_ptr<fl::RxDevice> g_rx_device;
+fl::shared_ptr<fl::RxChannel>& rxDeviceSingleton() {
+    return fl::Singleton<fl::shared_ptr<fl::RxChannel>>::instance();
+}
 
 // Sketch halt controller - handles safe halting without watchdog timer resets
 SketchHalt halt;
@@ -77,11 +79,11 @@ void setup() {
     while (!Serial && millis() < 3000);
     const char* loop_back_mode = PIN_TX == PIN_RX ? "INTERNAL" : "JUMPER WIRE";
 
-    FL_WARN("\n=== FastLED RX Device Test ===");
+    FL_WARN("\n=== FastLED RX Channel Test ===");
     FL_WARN("Platform: ESP32");
     FL_WARN("TX Pin: GPIO " << PIN_TX);
     FL_WARN("RX Pin: GPIO " << PIN_RX);
-    FL_WARN("RX Device: " << (RX_TYPE == fl::RxDeviceType::RMT ? "RMT" : "ISR"));
+    FL_WARN("RX Device: " << (RX_BACKEND == fl::RxBackend::RMT ? "RMT" : "ISR"));
     FL_WARN("LOOP BACK MODE: " << loop_back_mode);
 
     // Sanity check: Verify jumper wire connection when TX and RX are different pins
@@ -96,44 +98,46 @@ void setup() {
 
     FL_WARN("");
 
-    // Create RX device for testing
+    // Create RX channel for testing
     // Use 1MHz resolution for better timing accuracy (1us per tick)
-    FL_WARN("Creating RX device for testing...");
-    auto rx_test = fl::RxDevice::create<RX_TYPE>(PIN_RX);
+    FL_WARN("Creating RX channel for testing...");
+    fl::RxChannelConfig test_channel_config(PIN_RX, RX_BACKEND);
+    auto rx_test = FastLED.addRx(test_channel_config);
     if (!rx_test) {
-        halt.error("Failed to create RX device for testing");
+        halt.error("Failed to create RX channel for testing");
         return;
     }
 
-    // Initialize test RX device with config
-    fl::RxConfig test_config;
-    test_config.buffer_size = 10;
+    // Initialize test RX channel with config
+    fl::RxChannelConfig test_config(PIN_RX, RX_BACKEND);
+    test_config.edge_capacity = 10;
     test_config.hz = 1000000;  // 1MHz resolution for better timing accuracy
     test_config.signal_range_min_ns = 100;
     test_config.signal_range_max_ns = 10000000;
     test_config.start_low = true;
 
     if (!rx_test->begin(test_config)) {
-        halt.error("Failed to initialize test RX device");
+        halt.error("Failed to initialize test RX channel");
         return;
     }
 
-    // Test RX device functionality
+    // Test RX channel functionality
     if (!testRxDevice(rx_test, PIN_TX)) {
-        halt.error("RX device sanity check failed - RX not working");
+        halt.error("RX channel sanity check failed - RX not working");
         return;
     }
     FL_WARN("");
 
-    // Create main RX device for the loop
+    // Create main RX channel for the loop
     // Use 1MHz resolution to allow longer timeouts (40MHz = ~819us max, 1MHz = ~32ms max)
-    FL_WARN("Creating main RX device...");
-    g_rx_device = fl::RxDevice::create<RX_TYPE>(PIN_RX);
-    if (!g_rx_device) {
-        halt.error("Failed to create main RX device");
+    FL_WARN("Creating main RX channel...");
+    fl::RxChannelConfig main_channel_config(PIN_RX, RX_BACKEND);
+    rxDeviceSingleton() = FastLED.addRx(main_channel_config);
+    if (!rxDeviceSingleton()) {
+        halt.error("Failed to create main RX channel");
         return;
     }
-    FL_WARN("✓ Main RX device created\n");
+    FL_WARN("✓ Main RX channel created\n");
 
     delay(1000);
 }
@@ -146,21 +150,23 @@ void loop() {
     FL_WARN("║  RX DEVICE TEST");
     FL_WARN("╚════════════════════════════════════════════════════════════════╝\n");
 
-    // Configure RX device
-    fl::RxConfig config;
-    config.buffer_size = EDGE_BUFFER_SIZE;
+    // Configure RX channel
+    fl::RxChannelConfig config(PIN_RX, RX_BACKEND);
+    config.edge_capacity = EDGE_BUFFER_SIZE;
     config.hz = 1000000;                     // 1MHz resolution (allows up to ~32ms timeout)
     config.signal_range_min_ns = 100;       // 100ns glitch filter
     config.signal_range_max_ns = 10000000;  // 10ms idle timeout (1MHz RMT allows up to ~32ms)
     config.start_low = true;                 // Pin starts LOW
 
     // Execute toggles and capture data
-    FL_WARN("[TEST] Initializing RX device and executing toggles...");
-    executeToggles(*g_rx_device, config, TEST_PATTERN, PIN_TX, WAIT_TIMEOUT_MS);
+    FL_WARN("[TEST] Initializing RX channel and executing toggles...");
+    auto& rx_device = rxDeviceSingleton();
+    rx_device->setConfig(config);
+    executeToggles(*rx_device, TEST_PATTERN, PIN_TX, WAIT_TIMEOUT_MS);
 
     // Wait for capture completion
     FL_WARN("[TEST] Waiting for capture (timeout: " << WAIT_TIMEOUT_MS << "ms)...");
-    auto wait_result = g_rx_device->wait(WAIT_TIMEOUT_MS);
+    auto wait_result = rx_device->wait(WAIT_TIMEOUT_MS);
 
     if (wait_result == fl::RxWaitResult::TIMEOUT) {
         FL_ERROR("Timeout waiting for data");
@@ -171,7 +177,7 @@ void loop() {
 
         // Get edge timings
         fl::array<fl::EdgeTime, EDGE_BUFFER_SIZE> edge_buffer;
-        size_t edge_count = g_rx_device->getRawEdgeTimes(edge_buffer);
+        size_t edge_count = rx_device->getRawEdgeTimes(edge_buffer);
 
         // Validate edge timing against expected pattern
         const uint32_t TOLERANCE_PERCENT = 15;  // ±15% tolerance for timing jitter

--- a/examples/RX/test.cpp
+++ b/examples/RX/test.cpp
@@ -2,7 +2,6 @@
 
 #include <Arduino.h>
 #include "FastLED.h"
-#include "fl/rx_device.h"
 #include "test.h"
 
 bool verifyJumperWire(int pin_tx, int pin_rx) {
@@ -34,11 +33,11 @@ bool verifyJumperWire(int pin_tx, int pin_rx) {
     return true;
 }
 
-void executeToggles(fl::RxDevice& rx,
-                    const fl::RxConfig& config,
+void executeToggles(fl::RxChannel& rx,
                     fl::span<const PinToggle> toggles,
                     int pin_tx,
                     uint32_t wait_ms) {
+    const fl::RxChannelConfig& config = rx.config();
 
     // Set pin to initial state before begin()
     pinMode(pin_tx, OUTPUT);
@@ -158,7 +157,7 @@ bool validateEdgeTiming(fl::span<const fl::EdgeTime> edges,
     }
 }
 
-bool testRxDevice(fl::shared_ptr<fl::RxDevice> rx, int pin_tx) {
+bool testRxDevice(fl::shared_ptr<fl::RxChannel> rx, int pin_tx) {
     FL_WARN("Testing RX device with low-frequency pattern...");
 
     if (!rx) {
@@ -169,7 +168,7 @@ bool testRxDevice(fl::shared_ptr<fl::RxDevice> rx, int pin_tx) {
     int pin_rx = rx->getPin();
 
     // Configure RX device for low-frequency test
-    fl::RxConfig config;
+    fl::RxChannelConfig config(pin_rx);
     config.signal_range_min_ns = 100;       // 100ns glitch filter
     config.signal_range_max_ns = 30000000;  // 30ms idle timeout (ESP-IDF RMT limit: 32767000ns)
     config.start_low = true;                 // Pin starts LOW

--- a/examples/RX/test.h
+++ b/examples/RX/test.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "fl/system/log.h"
-#include "fl/rx_device.h"
+#include "fl/channels/rx/channel.h"
 
 /**
  * @brief Pin toggle instruction for RX device testing
@@ -34,22 +34,20 @@ bool verifyJumperWire(int pin_tx, int pin_rx);
  * @param pin_tx TX pin number to toggle
  * @return true if RX device captures expected edges, false otherwise
  */
-bool testRxDevice(fl::shared_ptr<fl::RxDevice> rx, int pin_tx);
+bool testRxDevice(fl::shared_ptr<fl::RxChannel> rx, int pin_tx);
 
 /**
- * @brief Execute pin toggles and initialize RX device for capture
+ * @brief Execute pin toggles and initialize RX channel for capture
  *
- * Configures the RX device with the given config, sets the TX pin to the
+ * Reads the current config from the RX channel, sets the TX pin to the
  * initial state, begins capture, and executes the sequence of pin toggles.
  *
- * @param rx RX device to initialize and use for capture
- * @param config Configuration for the RX device
+ * @param rx RX channel to initialize and use for capture
  * @param toggles Sequence of pin state changes to execute
  * @param pin_tx TX pin number to toggle
  * @param wait_ms Unused parameter (kept for API compatibility)
  */
-void executeToggles(fl::RxDevice& rx,
-                    const fl::RxConfig& config,
+void executeToggles(fl::RxChannel& rx,
                     fl::span<const PinToggle> toggles,
                     int pin_tx,
                     uint32_t wait_ms);

--- a/src/FastLED.cpp.hpp
+++ b/src/FastLED.cpp.hpp
@@ -640,6 +640,10 @@ fl::vector<fl::ChannelPtr> CFastLED::add(const fl::MultiChannelConfig& multiConf
     return channels;
 }
 
+fl::RxChannelPtr CFastLED::addRx(const fl::RxChannelConfig& config) {
+    return fl::RxChannel::create(config);
+}
+
 // ============================================================================
 
 #ifdef NEED_CXX_BITS

--- a/src/FastLED.h
+++ b/src/FastLED.h
@@ -162,6 +162,7 @@
 #include "fl/channels/channel_events.h"
 #include "fl/channels/manager.h"
 #include "fl/channels/config.h"  // for ChannelConfig, MultiChannelConfig
+#include "fl/channels/rx/channel.h"
 
 #include "fl/audio/input.h"
 #include "fl/audio/audio_processor.h"
@@ -763,6 +764,16 @@ public:
 	/// auto channels = FastLED.add(multiConfig);
 	/// @endcode
 	static fl::vector<fl::ChannelPtr> add(const fl::MultiChannelConfig& multiConfig);
+
+	/// @brief Add an RX channel with runtime configuration
+	///
+	/// Creates a first-class RX channel handle backed by the existing platform RX
+	/// device layer. The returned object exposes RX-specific lifecycle methods such
+	/// as begin(), wait(), decode(), and getRawEdgeTimes().
+	///
+	/// @param config RX channel configuration (pin, backend, capture settings)
+	/// @returns Shared pointer to RxChannel
+	static fl::RxChannelPtr addRx(const fl::RxChannelConfig& config);
 
 	/// @brief Add an audio input and return an auto-pumped Processor
 	///

--- a/src/fl/channels/_build.cpp.hpp
+++ b/src/fl/channels/_build.cpp.hpp
@@ -16,4 +16,5 @@
 // begin sub directory includes
 #include "fl/channels/adapters/_build.cpp.hpp"
 #include "fl/channels/detail/_build.cpp.hpp"
+#include "fl/channels/rx/_build.cpp.hpp"
 #include "fl/channels/spi/_build.cpp.hpp"

--- a/src/fl/channels/detail/validation/rx_test.cpp.hpp
+++ b/src/fl/channels/detail/validation/rx_test.cpp.hpp
@@ -3,7 +3,7 @@
 // RX channel testing implementation
 
 #include "fl/channels/detail/validation/rx_test.h"
-#include "fl/rx_device.h"
+#include "fl/channels/rx/channel.h"
 #include "fl/system/pin.h"
 #include "fl/system/log.h"
 #include "fl/system/delay.h"
@@ -13,7 +13,7 @@ namespace fl {
 namespace validation {
 
 bool testRxChannel(
-    fl::shared_ptr<fl::RxDevice> rx_channel,
+    fl::shared_ptr<fl::RxChannel> rx_channel,
     int pin_tx,
     int pin_rx,
     u32 hz,
@@ -31,8 +31,8 @@ bool testRxChannel(
     const u32 signal_range_max_ns = 2000000; // 2ms idle threshold
 
     // Initialize RX channel with signal range for fast GPIO toggles
-    fl::RxConfig rx_config;
-    rx_config.buffer_size = buffer_size;
+    fl::RxChannelConfig rx_config(pin_rx);
+    rx_config.edge_capacity = buffer_size;
     rx_config.hz = hz;
     rx_config.signal_range_min_ns = 100;    // min=100ns
     rx_config.signal_range_max_ns = signal_range_max_ns;

--- a/src/fl/channels/detail/validation/rx_test.h
+++ b/src/fl/channels/detail/validation/rx_test.h
@@ -10,7 +10,7 @@
 namespace fl {
 
 // Forward declarations
-class RxDevice;
+class RxChannel;
 
 namespace validation {
 
@@ -24,7 +24,7 @@ namespace validation {
 /// @note Generates 10 fast toggles (100μs pulses = 5kHz square wave)
 /// @note Uses fl::pin API for platform-independent pin control
 bool testRxChannel(
-    fl::shared_ptr<fl::RxDevice> rx_channel,
+    fl::shared_ptr<fl::RxChannel> rx_channel,
     int pin_tx,
     int pin_rx,
     u32 hz,

--- a/src/fl/channels/rx/_build.cpp.hpp
+++ b/src/fl/channels/rx/_build.cpp.hpp
@@ -1,0 +1,4 @@
+/// @file _build.hpp
+/// @brief Unity build header for fl/channels/rx directory
+
+#include "fl/channels/rx/channel.cpp.hpp"

--- a/src/fl/channels/rx/channel.cpp.hpp
+++ b/src/fl/channels/rx/channel.cpp.hpp
@@ -1,0 +1,120 @@
+#include "fl/channels/rx/channel.h"
+
+#include "fl/stl/atomic.h"
+#include "fl/stl/string.h"
+
+namespace fl {
+
+namespace {
+
+static RxConfig toRxConfig(const RxChannelConfig& config) FL_NOEXCEPT {
+    RxConfig out;
+    out.buffer_size = config.edge_capacity;
+    out.hz = config.hz;
+    out.signal_range_min_ns = config.signal_range_min_ns;
+    out.signal_range_max_ns = config.signal_range_max_ns;
+    out.skip_signals = config.skip_signals;
+    out.start_low = config.start_low;
+    out.io_loop_back = config.io_loop_back;
+    out.use_dma = config.use_dma;
+    return out;
+}
+
+static fl::shared_ptr<RxDevice> createBackendDevice(const RxChannelConfig& config) FL_NOEXCEPT {
+    switch (config.backend) {
+    case RxBackend::PLATFORM_DEFAULT:
+        return RxDevice::create<RxDeviceType::PLATFORM_DEFAULT>(config.pin);
+    case RxBackend::RMT:
+        return RxDevice::create<RxDeviceType::RMT>(config.pin);
+    case RxBackend::ISR:
+        return RxDevice::create<RxDeviceType::ISR>(config.pin);
+    case RxBackend::FLEXPWM:
+        return RxDevice::create<RxDeviceType::FLEXPWM>(config.pin);
+    }
+    return RxDevice::create<RxDeviceType::PLATFORM_DEFAULT>(config.pin);
+}
+
+}  // namespace
+
+i32 RxChannel::nextId() FL_NOEXCEPT {
+    static fl::atomic<i32> gNextRxChannelId(0);
+    return gNextRxChannelId.fetch_add(1);
+}
+
+fl::string RxChannel::makeName(i32 id, const fl::string& config_name) FL_NOEXCEPT {
+    if (!config_name.empty()) {
+        return config_name;
+    }
+    return "RxChannel_" + fl::to_string(static_cast<i64>(id));
+}
+
+RxChannelPtr RxChannel::create(const RxChannelConfig& config) FL_NOEXCEPT {
+    return fl::make_shared<RxChannel>(config, createBackendDevice(config));
+}
+
+RxChannel::RxChannel(const RxChannelConfig& config, fl::shared_ptr<RxDevice> device) FL_NOEXCEPT
+    : mId(nextId())
+    , mName(makeName(mId, config.name))
+    , mConfig(config)
+    , mDevice(fl::move(device)) {
+}
+
+RxChannel::~RxChannel() FL_NOEXCEPT = default;
+
+int RxChannel::getPin() const FL_NOEXCEPT {
+    return mDevice ? mDevice->getPin() : mConfig.pin;
+}
+
+fl::string RxChannel::getEngineName() const FL_NOEXCEPT {
+    if (!mConfig.affinity.empty()) {
+        return mConfig.affinity;
+    }
+    return mDevice ? fl::string(mDevice->name()) : fl::string();
+}
+
+bool RxChannel::begin(const RxChannelConfig& config) FL_NOEXCEPT {
+    bool recreate_device = !mDevice ||
+                           config.pin != mConfig.pin ||
+                           config.backend != mConfig.backend;
+    if (recreate_device) {
+        mDevice = createBackendDevice(config);
+    }
+    if (!config.name.empty()) {
+        mName = config.name;
+    }
+    mConfig = config;
+    return mDevice ? mDevice->begin(toRxConfig(mConfig)) : false;
+}
+
+void RxChannel::setConfig(const RxChannelConfig& config) FL_NOEXCEPT {
+    if (!config.name.empty()) {
+        mName = config.name;
+    }
+    mConfig = config;
+}
+
+bool RxChannel::finished() const FL_NOEXCEPT {
+    return mDevice ? mDevice->finished() : true;
+}
+
+RxWaitResult RxChannel::wait(u32 timeout_ms) FL_NOEXCEPT {
+    return mDevice ? mDevice->wait(timeout_ms) : RxWaitResult::TIMEOUT;
+}
+
+fl::result<u32, DecodeError> RxChannel::decode(const ChipsetTiming4Phase& timing,
+                                               fl::span<u8> out) FL_NOEXCEPT {
+    if (!mDevice) {
+        return fl::result<u32, DecodeError>::failure(DecodeError::INVALID_ARGUMENT);
+    }
+    return mDevice->decode(timing, out);
+}
+
+size_t RxChannel::getRawEdgeTimes(fl::span<EdgeTime> out, size_t offset) FL_NOEXCEPT {
+    return mDevice ? mDevice->getRawEdgeTimes(out, offset) : 0;
+}
+
+bool RxChannel::injectEdges(fl::span<const EdgeTime> edges) FL_NOEXCEPT {
+    return mDevice ? mDevice->injectEdges(edges) : false;
+}
+
+}  // namespace fl

--- a/src/fl/channels/rx/channel.h
+++ b/src/fl/channels/rx/channel.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include "fl/channels/rx/config.h"
+#include "fl/rx_device.h"
+#include "fl/stl/compiler_control.h"
+#include "fl/stl/noexcept.h"
+#include "fl/stl/shared_ptr.h"
+#include "fl/stl/stdint.h"
+#include "fl/stl/string.h"
+
+namespace fl {
+
+class RxChannel;
+FASTLED_SHARED_PTR(RxChannel);
+
+class RxChannel {
+public:
+    static RxChannelPtr create(const RxChannelConfig& config) FL_NOEXCEPT;
+
+    virtual ~RxChannel() FL_NOEXCEPT;
+
+    i32 id() const FL_NOEXCEPT { return mId; }
+    const fl::string& name() const FL_NOEXCEPT { return mName; }
+    int getPin() const FL_NOEXCEPT;
+    fl::string getEngineName() const FL_NOEXCEPT;
+
+    bool begin(const RxChannelConfig& config) FL_NOEXCEPT;
+    void setConfig(const RxChannelConfig& config) FL_NOEXCEPT;
+    bool finished() const FL_NOEXCEPT;
+    RxWaitResult wait(u32 timeout_ms) FL_NOEXCEPT;
+
+    fl::result<u32, DecodeError> decode(const ChipsetTiming4Phase& timing,
+                                        fl::span<u8> out) FL_NOEXCEPT;
+    size_t getRawEdgeTimes(fl::span<EdgeTime> out, size_t offset = 0) FL_NOEXCEPT;
+    bool injectEdges(fl::span<const EdgeTime> edges) FL_NOEXCEPT;
+
+    const RxChannelConfig& config() const FL_NOEXCEPT { return mConfig; }
+
+private:
+    template<typename T, typename... Args>
+    friend fl::shared_ptr<T> fl::make_shared(Args&&... args) FL_NOEXCEPT;
+
+    RxChannel(const RxChannelConfig& config, fl::shared_ptr<RxDevice> device) FL_NOEXCEPT;
+
+    static i32 nextId() FL_NOEXCEPT;
+    static fl::string makeName(i32 id, const fl::string& config_name) FL_NOEXCEPT;
+
+    RxChannel(const RxChannel&) FL_NOEXCEPT = delete;
+    RxChannel& operator=(const RxChannel&) FL_NOEXCEPT = delete;
+    RxChannel(RxChannel&&) FL_NOEXCEPT = delete;
+    RxChannel& operator=(RxChannel&&) FL_NOEXCEPT = delete;
+
+    const i32 mId;
+    fl::string mName;
+    RxChannelConfig mConfig;
+    fl::shared_ptr<RxDevice> mDevice;
+};
+
+}  // namespace fl

--- a/src/fl/channels/rx/config.h
+++ b/src/fl/channels/rx/config.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "fl/channels/rx/types.h"
+#include "fl/stl/cstddef.h"
+#include "fl/stl/noexcept.h"
+#include "fl/stl/optional.h"
+#include "fl/stl/string.h"
+
+namespace fl {
+
+struct RxChannelConfig {
+    fl::string name;
+    int pin = -1;
+    RxBackend backend = RxBackend::PLATFORM_DEFAULT;
+    fl::string affinity;
+
+    size_t edge_capacity = 4096;
+    fl::optional<u32> hz = 40000000;
+    u32 signal_range_min_ns = 100;
+    u32 signal_range_max_ns = 100000;
+    u32 skip_signals = 0;
+    bool start_low = true;
+    bool io_loop_back = false;
+    bool use_dma = false;
+
+    RxChannelConfig() FL_NOEXCEPT = default;
+    explicit RxChannelConfig(int pin_param) FL_NOEXCEPT
+        : pin(pin_param) {}
+    RxChannelConfig(int pin_param, RxBackend backend_param) FL_NOEXCEPT
+        : pin(pin_param)
+        , backend(backend_param) {}
+};
+
+}  // namespace fl

--- a/src/fl/channels/rx/types.h
+++ b/src/fl/channels/rx/types.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "fl/stl/stdint.h"
+#include "fl/stl/noexcept.h"
+
+namespace fl {
+
+enum class RxBackend : u8 {
+    PLATFORM_DEFAULT = 0,  ///< Use the recommended backend for the active platform (currently RMT on ESP32, FlexPWM on Teensy 4.x, native RX on stub/host builds).
+    RMT = 1,               ///< ESP32-only RMT capture backend.
+    ISR = 2,               ///< Platform-neutral interrupt-driven edge capture backend when available.
+    FLEXPWM = 3            ///< Teensy 4.x-only FlexPWM capture backend.
+};
+
+inline const char* toString(RxBackend backend) FL_NOEXCEPT {
+    switch (backend) {
+    case RxBackend::PLATFORM_DEFAULT: return "PLATFORM_DEFAULT";
+    case RxBackend::RMT: return "RMT";
+    case RxBackend::ISR: return "ISR";
+    case RxBackend::FLEXPWM: return "FLEXPWM";
+    }
+    return "UNKNOWN";
+}
+
+}  // namespace fl

--- a/tests/fl/rx_device.cpp
+++ b/tests/fl/rx_device.cpp
@@ -1,6 +1,8 @@
 /// @file rx_device.cpp
 /// @brief Unit tests for RxDevice interface, factory, and EdgeTime packed structure
 
+#include "FastLED.h"
+#include "fl/channels/rx/channel.h"
 #include "fl/rx_device.h"
 #include "fl/stl/cstring.h"
 #include "fl/stl/new.h"
@@ -104,6 +106,46 @@ FL_TEST_CASE("RxDevice - non-stub non-esp32 returns singleton dummy") {
     FL_CHECK(fl::strcmp(dummy1->name(), "dummy") == 0);
     FL_CHECK(fl::strcmp(dummy2->name(), "dummy") == 0);
 #endif
+}
+
+FL_TEST_CASE("RxChannel - create stores config and name") {
+    RxChannelConfig config(6, RxBackend::RMT);
+    config.name = "loopback";
+    config.signal_range_max_ns = 1234;
+
+    auto channel = RxChannel::create(config);
+    FL_REQUIRE(channel != nullptr);
+    FL_CHECK(fl::strcmp(channel->name().c_str(), "loopback") == 0);
+    FL_CHECK(channel->config().pin == 6);
+    FL_CHECK(channel->config().signal_range_max_ns == 1234);
+
+#ifdef FL_IS_STUB
+    FL_CHECK(channel->getPin() == 6);
+    FL_CHECK(fl::strcmp(channel->getEngineName().c_str(), "native") == 0);
+#else
+    FL_CHECK(!channel->getEngineName().empty());
+#endif
+}
+
+FL_TEST_CASE("RxChannel - setConfig updates staged values") {
+    auto channel = RxChannel::create(RxChannelConfig(6, RxBackend::RMT));
+    FL_REQUIRE(channel != nullptr);
+
+    RxChannelConfig updated(7, RxBackend::ISR);
+    updated.name = "updated";
+    updated.edge_capacity = 99;
+    channel->setConfig(updated);
+
+    FL_CHECK(channel->config().pin == 7);
+    FL_CHECK(channel->config().edge_capacity == 99);
+    FL_CHECK(fl::strcmp(channel->name().c_str(), "updated") == 0);
+}
+
+FL_TEST_CASE("CFastLED - addRx creates RxChannel") {
+    RxChannelConfig config(8, RxBackend::PLATFORM_DEFAULT);
+    auto channel = FastLED.addRx(config);
+    FL_REQUIRE(channel != nullptr);
+    FL_CHECK(channel->config().pin == 8);
 }
 
 // ============================================================


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added RxChannel API providing flexible runtime RX device configuration and lifecycle management
  * Introduced RxBackend enum enabling selection of RX capture implementation at runtime
  * Added FastLED.addRx() public API method for creating and registering RX channels with custom configuration
  * Updated example sketches demonstrating new channel-based RX workflow and API usage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->