### PR TITLE
Move RX interface under fl/channels

### DIFF
--- a/src/FastLED.h
+++ b/src/FastLED.h
@@ -141,7 +141,7 @@
 // Convenience includes for sketch inclusion
 #include "fl/task/executor.h"
 #include "fl/system/sketch_macros.h"
-#include "fl/rx_device.h"
+#include "fl/channels/rx.h"
 #include "fl/stl/array.h"
 #include "fl/stl/vector.h"
 #include "fl/stl/cstring.h"

--- a/src/fl/_build.cpp.hpp
+++ b/src/fl/_build.cpp.hpp
@@ -10,7 +10,6 @@
 #include "fl/fastled_internal.cpp.hpp"
 #include "fl/fltest.cpp.hpp"
 #include "fl/id_tracker.cpp.hpp"
-#include "fl/rx_device.cpp.hpp"
 #include "fl/static_constexpr_defs.cpp.hpp"
 #include "fl/str_ui.cpp.hpp"
 #include "fl/time_alpha.cpp.hpp"

--- a/src/fl/build/fl.cpp
+++ b/src/fl/build/fl.cpp
@@ -11,7 +11,6 @@
 #include "fl/fastled_internal.cpp.hpp"
 #include "fl/fltest.cpp.hpp"
 #include "fl/id_tracker.cpp.hpp"
-#include "fl/rx_device.cpp.hpp"
 #include "fl/static_constexpr_defs.cpp.hpp"
 #include "fl/str_ui.cpp.hpp"
 #include "fl/time_alpha.cpp.hpp"

--- a/src/fl/channels/rx.h
+++ b/src/fl/channels/rx.h
@@ -1,5 +1,5 @@
-/// @file rx_device.h
-/// @brief Common interface for RX devices (cross-platform)
+/// @file rx.h
+/// @brief Common RX interfaces and shared types
 
 #pragma once
 
@@ -8,6 +8,8 @@
 #include "fl/stl/result.h"
 #include "fl/stl/cstddef.h"
 #include "fl/stl/noexcept.h"
+#include "fl/stl/shared_ptr.h"
+#include "fl/stl/span.h"
 
 namespace fl {
 

--- a/src/fl/channels/rx/_build.cpp.hpp
+++ b/src/fl/channels/rx/_build.cpp.hpp
@@ -1,4 +1,5 @@
 /// @file _build.hpp
 /// @brief Unity build header for fl/channels/rx directory
 
+#include "fl/channels/rx/device.cpp.hpp"
 #include "fl/channels/rx/channel.cpp.hpp"

--- a/src/fl/channels/rx/channel.h
+++ b/src/fl/channels/rx/channel.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "fl/channels/rx/config.h"
-#include "fl/rx_device.h"
+#include "fl/channels/rx.h"
 #include "fl/stl/compiler_control.h"
 #include "fl/stl/noexcept.h"
 #include "fl/stl/shared_ptr.h"

--- a/src/fl/channels/rx/device.cpp.hpp
+++ b/src/fl/channels/rx/device.cpp.hpp
@@ -1,8 +1,8 @@
-/// @file rx_device.cpp
+/// @file device.cpp.hpp
 /// @brief Implementation of RxDevice factory
 
 #include "platforms/is_platform.h"
-#include "fl/rx_device.h"
+#include "fl/channels/rx.h"
 // IWYU pragma: begin_keep
 #include "platforms/shared/rx_device_dummy.h"  // ok platform headers
 // IWYU pragma: end_keep // ok platform headers

--- a/src/platforms/arm/teensy/teensy4_common/flexpwm_rx_channel.h
+++ b/src/platforms/arm/teensy/teensy4_common/flexpwm_rx_channel.h
@@ -9,7 +9,7 @@
 
 #if defined(FL_IS_TEENSY_4X)
 
-#include "fl/rx_device.h"
+#include "fl/channels/rx.h"
 #include "fl/stl/shared_ptr.h"
 #include "fl/stl/noexcept.h"
 

--- a/src/platforms/arm/teensy/teensy4_common/rx_flexpwm_channel.h
+++ b/src/platforms/arm/teensy/teensy4_common/rx_flexpwm_channel.h
@@ -9,7 +9,7 @@
 
 #if defined(FL_IS_TEENSY_4X)
 
-#include "fl/rx_device.h"
+#include "fl/channels/rx.h"
 #include "fl/stl/shared_ptr.h"
 #include "fl/stl/noexcept.h"
 

--- a/src/platforms/esp/32/drivers/gpio_isr_rx/README.md
+++ b/src/platforms/esp/32/drivers/gpio_isr_rx/README.md
@@ -170,7 +170,7 @@ Key `RxConfig` parameters:
 ## Usage
 
 ```cpp
-#include "fl/rx_device.h"
+#include "fl/channels/rx.h"
 
 // Pin must be configured before use
 pinMode(1, INPUT);

--- a/src/platforms/esp/32/drivers/gpio_isr_rx/gpio_isr_rx.h
+++ b/src/platforms/esp/32/drivers/gpio_isr_rx/gpio_isr_rx.h
@@ -14,7 +14,7 @@
 #include "fl/stl/shared_ptr.h"
 #include "fl/stl/span.h"
 #include "fl/stl/result.h"
-#include "fl/rx_device.h"
+#include "fl/channels/rx.h"
 #include "fl/stl/noexcept.h"
 
 namespace fl {

--- a/src/platforms/esp/32/drivers/gpio_isr_rx/gpio_isr_rx_mcpwm.h
+++ b/src/platforms/esp/32/drivers/gpio_isr_rx/gpio_isr_rx_mcpwm.h
@@ -13,7 +13,7 @@
 #pragma once
 
 #include "fl/stl/shared_ptr.h"  // IWYU pragma: keep
-#include "fl/rx_device.h"
+#include "fl/channels/rx.h"
 #include "fl/stl/noexcept.h"
 
 namespace fl {

--- a/src/platforms/esp/32/drivers/rmt_rx/rmt_rx_channel.h
+++ b/src/platforms/esp/32/drivers/rmt_rx/rmt_rx_channel.h
@@ -14,7 +14,7 @@
 #include "fl/stl/array.h"
 #include "fl/stl/iterator.h"
 #include "fl/stl/result.h"
-#include "fl/rx_device.h"
+#include "fl/channels/rx.h"
 #include "fl/stl/noexcept.h"
 
 // RMT symbol is a 32-bit value (union with duration0/level0/duration1/level1 bitfields)

--- a/src/platforms/shared/rx_device_dummy.h
+++ b/src/platforms/shared/rx_device_dummy.h
@@ -5,7 +5,7 @@
 
 // IWYU pragma: private
 
-#include "fl/rx_device.h"
+#include "fl/channels/rx.h"
 #include "fl/system/log.h"
 #include "fl/system/log.h"
 #include "fl/stl/assert.h"

--- a/src/platforms/shared/rx_device_native.cpp.hpp
+++ b/src/platforms/shared/rx_device_native.cpp.hpp
@@ -9,7 +9,7 @@
 #ifdef FL_IS_STUB
 
 #include "platforms/stub/stub_gpio.h"
-#include "fl/rx_device.h"
+#include "fl/channels/rx.h"
 #include "fl/system/log.h"
 #include "fl/system/log.h"
 #include "fl/system/log.h"

--- a/src/platforms/shared/rx_device_native.h
+++ b/src/platforms/shared/rx_device_native.h
@@ -17,7 +17,7 @@
 
 // IWYU pragma: private
 
-#include "fl/rx_device.h"
+#include "fl/channels/rx.h"
 #include "fl/stl/shared_ptr.h"
 #include "fl/stl/vector.h"
 #include "fl/stl/noexcept.h"

--- a/src/platforms/stub/stub_gpio.h
+++ b/src/platforms/stub/stub_gpio.h
@@ -22,7 +22,7 @@
 #include "fl/stl/span.h"
 #include "fl/stl/function.h"
 #include "fl/chipsets/chipset_timing_config.h"
-#include "fl/rx_device.h"  // for fl::EdgeTime
+#include "fl/channels/rx.h"  // for fl::EdgeTime
 #include "fl/stl/noexcept.h"
 
 namespace fl {

--- a/tests/fl/rx_device.cpp
+++ b/tests/fl/rx_device.cpp
@@ -3,7 +3,7 @@
 
 #include "FastLED.h"
 #include "fl/channels/rx/channel.h"
-#include "fl/rx_device.h"
+#include "fl/channels/rx.h"
 #include "fl/stl/cstring.h"
 #include "fl/stl/new.h"
 #include "fl/stl/stdint.h"

--- a/tests/platforms/esp/32/drivers/uart/channel_driver_uart.cpp
+++ b/tests/platforms/esp/32/drivers/uart/channel_driver_uart.cpp
@@ -14,7 +14,7 @@
 #include "fl/channels/driver.h"
 #include "fl/chipsets/chipset_timing_config.h"
 #include "fl/system/delay.h"
-#include "fl/rx_device.h"
+#include "fl/channels/rx.h"
 #include "fl/stl/cstddef.h"
 #include "fl/stl/move.h"
 #include "fl/stl/new.h"


### PR DESCRIPTION
## Summary
- move the public RX interface header to `fl/channels/rx.h`
- keep the RX implementation in `fl/channels/rx/device.cpp.hpp`
- update include sites and unity build wiring to match the new layout

## Verification
- `g++ -std=gnu++17 -Isrc -fsyntax-only` with `#include fl/channels/rx.h` and `#include fl/channels/rx/channel.h`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated RX channel/device API under a unified RX header, updating public include surface.
* **Documentation**
  * Updated RX header docs and usage examples to reflect the new umbrella RX header.
* **Tests**
  * Updated tests and test drivers to use the new RX header.
* **Chores**
  * Adjusted build aggregation to include the RX device implementation in the rx build unit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->