### PR TITLE
Use the pinned fbuild executable for FastLED builds

### DIFF
--- a/ci/util/fbuild_compiledb.py
+++ b/ci/util/fbuild_compiledb.py
@@ -16,6 +16,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+from ci.util.fbuild_runner import get_fbuild_executable
+
 
 def _candidate_fbuild_release_dirs(
     project_root: Path, build_root: Path, board_name: str
@@ -119,10 +121,17 @@ def ensure_compile_commands(
     # ``build`` subcommand. ``cwd`` is still set so fbuild's config
     # discovery works identically whether the positional is honored or
     # ignored by future fbuild versions.
+    fbuild_exe = get_fbuild_executable()
+    if fbuild_exe is None:
+        print(
+            f"ensure_compile_commands: fbuild executable not found for '{board_name}'",
+            file=sys.stderr,
+        )
+        return None
     try:
         subprocess.run(
             [
-                "fbuild",
+                fbuild_exe,
                 str(project_root),
                 "build",
                 "-e",

--- a/ci/util/fbuild_runner.py
+++ b/ci/util/fbuild_runner.py
@@ -24,6 +24,8 @@ Usage:
 from __future__ import annotations
 
 import io
+import os
+import shutil
 import sys
 import time
 from dataclasses import dataclass
@@ -40,6 +42,24 @@ class FbuildCommandResult:
     success: bool
     output: str
     returncode: int | None = None
+
+
+def get_fbuild_executable() -> str | None:
+    """Resolve the ``fbuild`` executable for the active Python environment.
+
+    Prefer the sibling script next to the current interpreter so ``uv run``
+    reliably uses the version locked in this repo's virtualenv instead of an
+    older global ``fbuild`` earlier on ``PATH``.
+    """
+    script_dir = Path(sys.executable).resolve().parent
+    candidates = [
+        script_dir / "fbuild",
+        script_dir / "fbuild.exe",
+    ]
+    for candidate in candidates:
+        if candidate.exists():
+            return str(candidate)
+    return os.fspath(shutil.which("fbuild")) if shutil.which("fbuild") else None
 
 
 def ensure_fbuild_daemon() -> None:
@@ -82,7 +102,6 @@ def run_fbuild_compile(
     Returns:
         Result containing success flag, return code, and captured output
     """
-    import shutil
     import subprocess
 
     from running_process import RunningProcess
@@ -95,7 +114,7 @@ def run_fbuild_compile(
     print("COMPILING (fbuild)", file=out)
     print("=" * 60, file=out)
 
-    fbuild_exe = shutil.which("fbuild")
+    fbuild_exe = get_fbuild_executable()
     if fbuild_exe is None:
         message = "BUILD FAIL fbuild not found on PATH"
         print(message, file=out)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,9 +5,10 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    # fbuild 2.2.1+ includes Teensy framework library resolution and the
-    # Teensy-compatible GCC 11 toolchain fix needed for teensy40/teensy41.
-    "fbuild>=2.2.1",
+    # Pin to the first published fbuild release that includes both Teensy
+    # framework library resolution and the Teensy-compatible GCC 11 toolchain
+    # fix needed for teensy40/teensy41.
+    "fbuild==2.2.1",
     "platformio>=6.1.19,<6.2",
     "python-dateutil",
     "ruff",


### PR DESCRIPTION
## Summary
- resolve the `fbuild` executable from the active Python environment before falling back to `PATH`
- use that same executable for compile-database generation so static-analysis tooling matches normal builds
- pin FastLED's `fbuild` dependency to `2.2.1`, the first published release with the Teensy library/toolchain fixes

## Verification
- `uv run python -c "from ci.util.fbuild_runner import get_fbuild_executable; import subprocess; exe=get_fbuild_executable(); print(exe); subprocess.run([exe, '--version'], check=True)"`
- `./compile teensy41`

## Notes
- before this change, local builds were picking up `C:\Users\niteris\.local\bin\fbuild.exe` (`2.1.20`) instead of the repo-managed `.venv` `fbuild` (`2.2.1`)
- after this change, `teensy41` gets past the old `SPI.h` failure and proceeds to a later FastLED compile error (`RainbowColors_p` section type conflict), which is a separate issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fbuild executable resolution with enhanced error handling when the tool is unavailable

* **Chores**
  * Pinned fbuild dependency to version 2.2.1 for consistent builds

<!-- end of auto-generated comment: release notes by coderabbit.ai -->