### PR TITLE
chore(examples/RX): rename RxDevice terminology to RxChannel

### DIFF
--- a/examples/RX/RX.ino
+++ b/examples/RX/RX.ino
@@ -22,7 +22,7 @@
 ///   - ESP32 (all variants: classic, S3, C3, C6, etc.)
 ///
 /// run with (in fastled repo)
-//    bash debug RX --expect "TX Pin: GPIO 0" --expect "RX Pin: GPIO 1" --expect "RX Device: RMT" --fail-on ERROR
+//    bash debug RX --expect "TX Pin: GPIO 0" --expect "RX Pin: GPIO 1" --expect "RX Backend: RMT" --fail-on ERROR
 
 #include <FastLED.h>
 #include "fl/stl/singleton.h"
@@ -63,7 +63,7 @@ const fl::array<PinToggle, 6> TEST_PATTERN = {{
 // Global State
 // ============================================================================
 
-fl::shared_ptr<fl::RxChannel>& rxDeviceSingleton() {
+fl::shared_ptr<fl::RxChannel>& rxChannelSingleton() {
     return fl::Singleton<fl::shared_ptr<fl::RxChannel>>::instance();
 }
 
@@ -83,7 +83,7 @@ void setup() {
     FL_WARN("Platform: ESP32");
     FL_WARN("TX Pin: GPIO " << PIN_TX);
     FL_WARN("RX Pin: GPIO " << PIN_RX);
-    FL_WARN("RX Device: " << (RX_BACKEND == fl::RxBackend::RMT ? "RMT" : "ISR"));
+    FL_WARN("RX Backend: " << (RX_BACKEND == fl::RxBackend::RMT ? "RMT" : "ISR"));
     FL_WARN("LOOP BACK MODE: " << loop_back_mode);
 
     // Sanity check: Verify jumper wire connection when TX and RX are different pins
@@ -122,7 +122,7 @@ void setup() {
     }
 
     // Test RX channel functionality
-    if (!testRxDevice(rx_test, PIN_TX)) {
+    if (!testRxChannelSanity(rx_test, PIN_TX)) {
         halt.error("RX channel sanity check failed - RX not working");
         return;
     }
@@ -132,8 +132,8 @@ void setup() {
     // Use 1MHz resolution to allow longer timeouts (40MHz = ~819us max, 1MHz = ~32ms max)
     FL_WARN("Creating main RX channel...");
     fl::RxChannelConfig main_channel_config(PIN_RX, RX_BACKEND);
-    rxDeviceSingleton() = FastLED.addRx(main_channel_config);
-    if (!rxDeviceSingleton()) {
+    rxChannelSingleton() = FastLED.addRx(main_channel_config);
+    if (!rxChannelSingleton()) {
         halt.error("Failed to create main RX channel");
         return;
     }
@@ -160,13 +160,13 @@ void loop() {
 
     // Execute toggles and capture data
     FL_WARN("[TEST] Initializing RX channel and executing toggles...");
-    auto& rx_device = rxDeviceSingleton();
-    rx_device->setConfig(config);
-    executeToggles(*rx_device, TEST_PATTERN, PIN_TX, WAIT_TIMEOUT_MS);
+    auto& rx_channel = rxChannelSingleton();
+    rx_channel->setConfig(config);
+    executeToggles(*rx_channel, TEST_PATTERN, PIN_TX, WAIT_TIMEOUT_MS);
 
     // Wait for capture completion
     FL_WARN("[TEST] Waiting for capture (timeout: " << WAIT_TIMEOUT_MS << "ms)...");
-    auto wait_result = rx_device->wait(WAIT_TIMEOUT_MS);
+    auto wait_result = rx_channel->wait(WAIT_TIMEOUT_MS);
 
     if (wait_result == fl::RxWaitResult::TIMEOUT) {
         FL_ERROR("Timeout waiting for data");
@@ -177,7 +177,7 @@ void loop() {
 
         // Get edge timings
         fl::array<fl::EdgeTime, EDGE_BUFFER_SIZE> edge_buffer;
-        size_t edge_count = rx_device->getRawEdgeTimes(edge_buffer);
+        size_t edge_count = rx_channel->getRawEdgeTimes(edge_buffer);
 
         // Validate edge timing against expected pattern
         const uint32_t TOLERANCE_PERCENT = 15;  // ±15% tolerance for timing jitter

--- a/examples/RX/test.cpp
+++ b/examples/RX/test.cpp
@@ -44,9 +44,9 @@ void executeToggles(fl::RxChannel& rx,
     digitalWrite(pin_tx, config.start_low ? LOW : HIGH);
     fl::delayMicroseconds(100);  // Allow pin to settle
 
-    // Initialize RX device
+    // Initialize RX channel
     if (!rx.begin(config)) {
-        FL_ERROR("Failed to initialize RX device");
+        FL_ERROR("Failed to initialize RX channel");
         return;
     }
 
@@ -149,7 +149,7 @@ bool validateEdgeTiming(fl::span<const fl::EdgeTime> edges,
     } else if (edge_count >= 5) {
         FL_WARN("[TEST] ✓ PASS: Captured " << edge_count << " edges with proper alternation");
         FL_WARN("[TEST] ✓ PASS: All timing values match expected pattern within tolerance");
-        FL_WARN("[TEST] ✓ RX device working correctly!");
+        FL_WARN("[TEST] ✓ RX channel working correctly!");
         return true;
     } else {
         FL_WARN("WARNING: Only captured " << edge_count << " edges (expected >=5)");
@@ -157,17 +157,17 @@ bool validateEdgeTiming(fl::span<const fl::EdgeTime> edges,
     }
 }
 
-bool testRxDevice(fl::shared_ptr<fl::RxChannel> rx, int pin_tx) {
-    FL_WARN("Testing RX device with low-frequency pattern...");
+bool testRxChannelSanity(fl::shared_ptr<fl::RxChannel> rx, int pin_tx) {
+    FL_WARN("Testing RX channel with low-frequency pattern...");
 
     if (!rx) {
-        FL_ERROR("Failed to test RX device - null device provided");
+        FL_ERROR("Failed to test RX channel - null channel provided");
         return false;
     }
 
     int pin_rx = rx->getPin();
 
-    // Configure RX device for low-frequency test
+    // Configure RX channel for low-frequency test
     fl::RxChannelConfig config(pin_rx);
     config.signal_range_min_ns = 100;       // 100ns glitch filter
     config.signal_range_max_ns = 30000000;  // 30ms idle timeout (ESP-IDF RMT limit: 32767000ns)
@@ -180,7 +180,7 @@ bool testRxDevice(fl::shared_ptr<fl::RxChannel> rx, int pin_tx) {
     delay(10);  // Allow pin to settle
 
     if (!rx->begin(config)) {
-        FL_ERROR("Failed to initialize RX device");
+        FL_ERROR("Failed to initialize RX channel");
         return false;
     }
 
@@ -200,9 +200,9 @@ bool testRxDevice(fl::shared_ptr<fl::RxChannel> rx, int pin_tx) {
     auto wait_result = rx->wait(100);
 
     if (wait_result == fl::RxWaitResult::TIMEOUT) {
-        FL_ERROR("RX device test FAILED - timeout waiting for data");
+        FL_ERROR("RX channel test FAILED - timeout waiting for data");
         FL_ERROR("  No edges captured within 100ms");
-        FL_ERROR("  This suggests the RX device cannot read from GPIO " << pin_rx);
+        FL_ERROR("  This suggests the RX channel cannot read from GPIO " << pin_rx);
         return false;
     }
 
@@ -211,7 +211,7 @@ bool testRxDevice(fl::shared_ptr<fl::RxChannel> rx, int pin_tx) {
     size_t edge_count = rx->getRawEdgeTimes(edge_buffer);
 
     if (edge_count < 3) {
-        FL_ERROR("RX device test FAILED - insufficient edges captured");
+        FL_ERROR("RX channel test FAILED - insufficient edges captured");
         FL_ERROR("  Expected at least 3 edges, got " << edge_count);
         FL_ERROR("  Pin loopback may not be working correctly");
         return false;
@@ -228,12 +228,12 @@ bool testRxDevice(fl::shared_ptr<fl::RxChannel> rx, int pin_tx) {
     }
 
     if (timing_ok) {
-        FL_WARN("✓ RX device test PASSED");
+        FL_WARN("✓ RX channel test PASSED");
         FL_WARN("  Captured " << edge_count << " edges");
         FL_WARN("  Timing appears correct (~10ms per edge)");
         return true;
     } else {
-        FL_WARN("✓ RX device test PASSED (with timing warnings)");
+        FL_WARN("✓ RX channel test PASSED (with timing warnings)");
         FL_WARN("  Captured " << edge_count << " edges");
         FL_WARN("  Timing may be affected by system load");
         return true;  // Still pass - we got edges

--- a/examples/RX/test.h
+++ b/examples/RX/test.h
@@ -4,7 +4,7 @@
 #include "fl/channels/rx/channel.h"
 
 /**
- * @brief Pin toggle instruction for RX device testing
+ * @brief Pin toggle instruction for RX channel testing
  */
 struct PinToggle {
     bool is_high;       // Pin state (HIGH or LOW)
@@ -24,17 +24,17 @@ struct PinToggle {
 bool verifyJumperWire(int pin_tx, int pin_rx);
 
 /**
- * @brief Test RX device functionality with low-frequency pattern
+ * @brief Test RX channel functionality with low-frequency pattern
  *
- * Validates the given RX device can capture edge transitions by generating
+ * Validates the given RX channel can capture edge transitions by generating
  * a simple test pattern (HIGH/LOW toggles) and verifying the captured
  * timing data matches expectations.
  *
- * @param rx Shared pointer to the RX device to test
+ * @param rx Shared pointer to the RX channel to test
  * @param pin_tx TX pin number to toggle
- * @return true if RX device captures expected edges, false otherwise
+ * @return true if RX channel captures expected edges, false otherwise
  */
-bool testRxDevice(fl::shared_ptr<fl::RxChannel> rx, int pin_tx);
+bool testRxChannelSanity(fl::shared_ptr<fl::RxChannel> rx, int pin_tx);
 
 /**
  * @brief Execute pin toggles and initialize RX channel for capture


### PR DESCRIPTION
## Summary
- Aligns identifiers and log strings in the `RX` example with the public `fl::RxChannel` API introduced in b22324b3eb (Add public RxChannel API under fl/channels/rx) and b42e28c3f0 (Move RX interface under fl/channels).
- `rxDeviceSingleton()` → `rxChannelSingleton()`, `testRxDevice()` → `testRxChannelSanity()`.
- Log string `"RX Device: ..."` → `"RX Backend: ..."` (and the matching `bash debug RX --expect` comment at the top of the sketch).
- No behavior change — pure naming cleanup so the example matches the API it's demonstrating.

## Test plan
- [ ] `bash compile esp32s3 --examples RX` (once CI is green, this will exercise the rename on real hardware toolchain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated RX example debug output labeling and renamed test function for clarity and consistency.

* **Documentation**
  * Updated RX documentation to reflect consistent naming conventions throughout examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->