### PR TITLE
feat(ci-compile): add --backend={fbuild,platformio} switch

### DIFF
--- a/ci/ci-compile.py
+++ b/ci/ci-compile.py
@@ -343,6 +343,7 @@ def main() -> int:
             global_cache_dir=config.global_cache_dir,
             skip_filters=config.skip_filters,
             no_parallel=config.no_parallel,
+            backend=config.backend,
         )
 
     # Auto-detect Docker availability if neither --docker nor --local is specified
@@ -386,6 +387,7 @@ def main() -> int:
                 global_cache_dir=config.global_cache_dir,
                 skip_filters=config.skip_filters,
                 no_parallel=config.no_parallel,
+                backend=config.backend,
             )
 
     # Handle Docker compilation mode
@@ -487,6 +489,8 @@ def main() -> int:
         if config.merged_bin and config.output_path:
             merged_bin_output = config.output_path
 
+        from ci.compiler.argument_parser import BuildBackend
+
         result = compile_board_examples(
             board=board,
             examples=examples,
@@ -498,6 +502,7 @@ def main() -> int:
             extra_packages=config.extra_packages if config.extra_packages else None,
             max_failures=config.max_failures,
             skip_filters=config.skip_filters,
+            use_fbuild=(config.backend == BuildBackend.FBUILD),
         )
 
         if not result.ok:

--- a/ci/compiler/argument_parser.py
+++ b/ci/compiler/argument_parser.py
@@ -19,6 +19,13 @@ class WorkflowType(Enum):
     WASM = "wasm"
 
 
+class BuildBackend(Enum):
+    """Compilation backend selection (fbuild vs PlatformIO's `pio run`)."""
+
+    FBUILD = "fbuild"
+    PLATFORMIO = "platformio"
+
+
 @dataclass(frozen=True)
 class CompilationConfig:
     """Immutable compilation configuration with validation."""
@@ -54,6 +61,9 @@ class CompilationConfig:
 
     # Info options
     build_info: Optional[Path] = None  # Output file path for build info JSON
+
+    # Build backend selection (default fbuild; --backend=platformio forces `pio run`)
+    backend: BuildBackend = BuildBackend.FBUILD
 
     def validate(self) -> list[str]:
         """Validate configuration and return list of error messages."""
@@ -269,6 +279,32 @@ class CompilationArgumentParser:
             help="Override global PlatformIO cache directory path (for testing)",
         )
 
+        # Build backend selection. Default is fbuild (fast, incremental).
+        # --backend=platformio / --platformio / --pio forces `pio run` (slower,
+        # but exercises the PlatformIO-native build for size/compat comparison).
+        parser.add_argument(
+            "--backend",
+            choices=[b.value for b in BuildBackend],
+            default=BuildBackend.FBUILD.value,
+            help="Select build backend: 'fbuild' (default, fast) or 'platformio' "
+            "(runs `pio run` for a PlatformIO-native build). Use 'platformio' "
+            "to compare against fbuild output or reproduce PlatformIO-only "
+            "size/link behavior.",
+        )
+        parser.add_argument(
+            "--platformio",
+            "--pio",
+            dest="platformio_backend",
+            action="store_true",
+            help="Shortcut for --backend=platformio (force PlatformIO `pio run`).",
+        )
+        parser.add_argument(
+            "--fbuild",
+            dest="fbuild_backend",
+            action="store_true",
+            help="Shortcut for --backend=fbuild (default).",
+        )
+
         return parser
 
     def _build_config(self, args: argparse.Namespace) -> CompilationConfig:
@@ -290,6 +326,19 @@ class CompilationArgumentParser:
             else []
         )
 
+        # Resolve build backend. Precedence (last wins among explicit flags):
+        #   --fbuild  -> fbuild
+        #   --platformio / --pio -> platformio
+        #   --backend=<value>  -> <value> (explicit takes precedence over shortcuts
+        #       only if also passed; argparse has no easy "was flag passed" signal
+        #       for choices with a default, so we honor the shortcut if set, else
+        #       the --backend value).
+        backend = BuildBackend(args.backend)
+        if getattr(args, "platformio_backend", False):
+            backend = BuildBackend.PLATFORMIO
+        if getattr(args, "fbuild_backend", False):
+            backend = BuildBackend.FBUILD
+
         return CompilationConfig(
             boards=boards,
             examples=examples,
@@ -310,6 +359,7 @@ class CompilationArgumentParser:
             build_info=Path(args.build_info)
             if hasattr(args, "build_info") and args.build_info
             else None,
+            backend=backend,
         )
 
     def _resolve_boards(self, board_spec: Optional[str]) -> list[Board]:

--- a/ci/compiler/compilation_orchestrator.py
+++ b/ci/compiler/compilation_orchestrator.py
@@ -20,6 +20,8 @@ from ci.compiler.pio import FastLEDPaths, PioCompiler
 from ci.util.global_interrupt_handler import handle_keyboard_interrupt
 
 
+# Default when the caller does not pass `use_fbuild=` explicitly. The
+# ci-compile.py CLI now exposes a `--backend` flag that overrides this.
 BOARD_BUILDS_USE_FBUILD = True
 
 
@@ -47,8 +49,16 @@ def compile_board_examples(
     extra_packages: Optional[list[str]] = None,
     max_failures: Optional[int] = None,
     skip_filters: bool = False,
+    use_fbuild: Optional[bool] = None,
 ) -> BoardCompilationResult:
-    """Compile examples for a single board using PioCompiler."""
+    """Compile examples for a single board using PioCompiler.
+
+    Args:
+        use_fbuild: If None, uses BOARD_BUILDS_USE_FBUILD (default True).
+            If True, uses fbuild. If False, uses PlatformIO's `pio run`.
+    """
+    if use_fbuild is None:
+        use_fbuild = BOARD_BUILDS_USE_FBUILD
 
     # Resolve global cache directory immediately for display
     resolved_cache_dir = None
@@ -104,6 +114,8 @@ def compile_board_examples(
             ok=True, sketch_results=[], skipped_examples=skipped_examples
         )
 
+    backend_label = "fbuild" if use_fbuild else "platformio (pio run)"
+    print(f"BUILD BACKEND: {backend_label}")
     print(f"{'=' * 60}")
 
     try:
@@ -114,7 +126,7 @@ def compile_board_examples(
             global_cache_dir=resolved_cache_dir,
             additional_defines=defines,
             additional_libs=extra_packages,
-            use_fbuild=BOARD_BUILDS_USE_FBUILD,
+            use_fbuild=use_fbuild,
         )
 
         # Build all examples - use merged-bin method if requested


### PR DESCRIPTION
## Summary

- Add `--backend={fbuild,platformio}` (default: `fbuild`) to `bash compile` so users can force PlatformIO's native `pio run` backend instead of fbuild.
- Convenience aliases: `--platformio` / `--pio` == `--backend=platformio`; `--fbuild` == `--backend=fbuild` (default).
- Needed to investigate and reproduce #2406 (teensyLC / teensy30 link-time RAM overflow on fbuild path). Lets anyone compare the two backends side-by-side without editing `BOARD_BUILDS_USE_FBUILD`.

## Why

Previously the board-build backend was hardcoded (`BOARD_BUILDS_USE_FBUILD = True` in `compile_board_examples`) with no CLI override. Tracking down #2406 required flipping that constant by hand and rebuilding. The escape hatch also unblocks anyone who needs to keep teensy30/teensyLC green while fbuild upstream fixes land ([FastLED/fbuild#204](https://github.com/FastLED/fbuild/issues/204), [FastLED/fbuild#205](https://github.com/FastLED/fbuild/issues/205)).

Usage:
```bash
bash compile teensylc Blink                      # fbuild (unchanged default)
bash compile teensylc Blink --backend=platformio # force pio run
bash compile teensylc Blink --platformio         # same, shorthand
bash compile teensylc Blink --pio                # same, shorter
```

## Changes

- `ci/compiler/argument_parser.py` — new `BuildBackend` enum; three argparse flags (`--backend`, `--platformio`/`--pio`, `--fbuild`); threads `backend` through `CompilationConfig`.
- `ci/compiler/compilation_orchestrator.py` — `compile_board_examples(..., use_fbuild: Optional[bool] = None)` (defaults to `BOARD_BUILDS_USE_FBUILD`, which is still `True`); prints the active backend label in the compile banner.
- `ci/ci-compile.py` — propagates `config.backend` through the two `CompilationConfig` reconstructions and into `compile_board_examples`.

Default behavior is unchanged: omitting the flag picks fbuild, exactly as before.

## Test plan

- [x] `uv run pytest ci/tests/test_fbuild_default_selection.py` — passes (existing assertion that default stays fbuild still holds).
- [x] `bash compile teensylc Blink --platformio` — successfully builds via `pio run` (RAM 4164 B / 8192, link OK).
- [x] `uv run ci/ci-compile.py --help` — shows the new flags.
- [x] Manual parse-check of flag precedence:
  - `--backend=platformio` → platformio
  - `--platformio` / `--pio` → platformio
  - `--fbuild` → fbuild
  - `--backend=fbuild --platformio` → platformio (shortcut wins, matches last-flag-wins intuition)
- [x] `bash lint ci/compiler/argument_parser.py ci/compiler/compilation_orchestrator.py ci/ci-compile.py` — passes.

## Related

- #2406 — consumer-side tracking of the fbuild teensy30/LC RAM overflow that motivated this switch
- FastLED/fbuild#204 — upstream bug (over-inclusive framework library compilation)
- FastLED/fbuild#205 — upstream feature (Rust-native LDF scanner, zccache-backed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added build-backend selection via CLI (--backend plus --platformio/--pio and --fbuild shortcuts), defaulting to fbuild.
  * Compilation now respects the selected backend and indicates which backend (fbuild or PlatformIO) is used during builds, enabling backend-specific behavior for example board builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->