### PR TITLE
docs(agents): orchestrated sub-agent carve-out for `bash test`

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,7 @@ See `agents/docs/workflow.md` for full workflow orchestration and task managemen
 - **Verify before done** — prove it works with tests, logs, demonstrations
 - **Test simplicity**: Keep tests simple, avoid mocks. See `agents/tests.md`
 - **TDD for features/bugs**: Use `/tdd` (guided cycle) or `/tdd-implement` (full feature). Write tests FIRST.
+- **Orchestrated sub-agents skip `bash test`** — when a sub-agent is one step of a multi-step plan, the orchestrator runs `bash test --cpp` once at the end (the `Stop` hook covers this for free). Per-step sub-agents run `bash lint` only. See `agents/tests.md` → "Orchestrated Sub-Agent Carve-Out". The orchestrator must say so explicitly in the dispatch prompt.
 
 ## Core Principles
 

--- a/agents/docs/workflow.md
+++ b/agents/docs/workflow.md
@@ -13,6 +13,7 @@ Guidelines for how agents should approach work in the FastLED project.
 - Offload research, exploration, and parallel analysis to subagents
 - For complex problems, throw more compute at it via subagents
 - One task per subagent for focused execution
+- **Orchestrated sub-agents must NOT each run `bash test`** — running the full test suite N times across N steps is pure waste. Per-step sub-agents run `bash lint` only; the orchestrator runs `bash test --cpp` ONCE at the end (the `Stop` hook does this for free when files changed). The orchestrator MUST explicitly suspend the test mandate in the dispatch prompt. Full rule: `agents/tests.md` → "Orchestrated Sub-Agent Carve-Out".
 
 ## 3. Self-Improvement Loop
 - After ANY correction from the user: update `agents/tasks/lessons.md` with the pattern

--- a/agents/tests.md
+++ b/agents/tests.md
@@ -46,6 +46,23 @@
 
 **FAILURE TO FOLLOW THESE REQUIREMENTS WILL RESULT IN BROKEN CODE SUBMISSIONS.**
 
+### 🔁 Orchestrated Sub-Agent Carve-Out
+
+**The `bash test` mandate above does NOT apply when a sub-agent is dispatched as one step of a larger multi-step orchestration.**
+
+When the orchestrator (the parent agent) delegates a single step of a 3+ step plan to a sub-agent — e.g., "move file X, sweep includes, commit" as part of a 9-step refactor — that sub-agent MUST:
+
+- **Run `bash lint` only.** It is fast and catches missing-include errors.
+- **Skip `bash test --cpp` / `bash test`.** Per-step test runs across N sub-agents = N redundant compiles of the same codebase. The test pass should run ONCE.
+- **Trust the orchestrator** to run `bash test --cpp` once at the end before pushing. The `Stop` hook (`ci/hooks/check-on-stop.py`) also runs it automatically when files changed during the session, so the orchestrator gets it for free.
+
+**How a sub-agent knows it is orchestrated:** the dispatcher's prompt explicitly says so (e.g., "you are step N of an M-step plan; do not run `bash test`"). If the prompt does not say this, fall back to the standard mandate above and run `bash test`.
+
+**Orchestrator responsibilities:**
+- State explicitly in each sub-agent prompt that the test mandate is suspended for this step.
+- Run `bash test --cpp` once after the final step's commit, before pushing the branch / opening the PR.
+- If the final test pass fails, identify which step's commit broke it (via `git bisect` or `git log`) and dispatch a fix.
+
 ---
 
 ## Test Assertion Macros


### PR DESCRIPTION
## Summary

When the orchestrator delegates one step of a multi-step plan to a sub-agent, the standard \`agents/tests.md\` mandate to \`bash test\` before completion creates redundant work — the same codebase gets compiled and tested N times across N sub-agents. This PR carves out an exception: orchestrated sub-agents run \`bash lint\` only, and the orchestrator runs \`bash test --cpp\` once at the end (the \`Stop\` hook also runs it for free when files changed).

Discovered the hard way: a 9-step refactor with per-step \`bash test\` would have spent ~8 redundant test cycles. After this rule, only the final cycle runs.

## Changes

- \`agents/tests.md\` — new "🔁 Orchestrated Sub-Agent Carve-Out" section right after the existing mandate. Suspends \`bash test\` for orchestrated steps; assigns the once-at-end run to the orchestrator. Notes how a sub-agent recognizes the orchestrated mode (dispatcher prompt must say so).
- \`CLAUDE.md\` — one-line pointer in the Workflow section.
- \`agents/docs/workflow.md\` — bullet added under "Subagent Strategy".

## Test plan

- [x] Plain text docs change; no code paths affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated workflow guidelines for orchestrated multi-step agent plans
  * Sub-agents perform linting only; orchestrator runs full tests once at plan completion
  * Reduces redundant test suite execution across multiple steps

<!-- end of auto-generated comment: release notes by coderabbit.ai -->