### PR TITLE
perf(lint): cut single-file lint hook latency by ~40%

### DIFF
--- a/ci/iwyu_wrapper.py
+++ b/ci/iwyu_wrapper.py
@@ -44,6 +44,30 @@ def find_iwyu_binary() -> str | None:
     return None
 
 
+def _resolve_fast_native_cxx(compiler_path: str) -> str:
+    """Swap a slow Python-wrapped C++ driver for the cached native launcher.
+
+    The `clang-tool-chain-cpp` Python entry point pays ~828ms of interpreter
+    startup before clang even runs (per the meson native-file optimization,
+    repo memory 2026-03-07). The repo's build system pre-compiles a native
+    launcher at `.cached/clang-native/ctc-clang++.exe` that avoids this
+    overhead (~100ms vs ~1068ms for the same `-E -v` stdlib probe).
+
+    If the cached native launcher exists and the requested driver is the
+    slow Python wrapper, return the cached path. Otherwise, return the
+    original path unchanged.
+    """
+    name = Path(compiler_path).name.lower()
+    if "clang-tool-chain-cpp" not in name and "clang-tool-chain-c-msvc" not in name:
+        return compiler_path
+    repo_root = Path(__file__).resolve().parent.parent
+    suffix = ".exe" if sys.platform == "win32" else ""
+    cached = repo_root / ".cached" / "clang-native" / f"ctc-clang++{suffix}"
+    if cached.is_file():
+        return str(cached)
+    return compiler_path
+
+
 def get_compiler_include_paths(compiler_path: str) -> list[str]:
     """
     Extract C++ stdlib include paths from the compiler.
@@ -51,11 +75,12 @@ def get_compiler_include_paths(compiler_path: str) -> list[str]:
     This queries the compiler for its default include search paths
     and returns them as a list of -I flags for IWYU.
     """
+    fast_compiler = _resolve_fast_native_cxx(compiler_path)
     try:
         # Query compiler for its include paths
         # Using -E (preprocess only), -x c++ (C++ mode), -v (verbose), - (stdin)
         result = subprocess.run(
-            [compiler_path, "-E", "-x", "c++", "-v", "-"],
+            [fast_compiler, "-E", "-x", "c++", "-v", "-"],
             input="",
             capture_output=True,
             text=True,

--- a/ci/lint_cpp/test_include_paths_checker.py
+++ b/ci/lint_cpp/test_include_paths_checker.py
@@ -38,36 +38,70 @@ TESTS_DIR = str(PROJECT_ROOT / "tests").replace("\\", "/")
 # Pattern to extract include path from #include "..." statements
 _INCLUDE_PATTERN = re.compile(r'^\s*#\s*include\s+"([^"]+)"')
 
-# Top-level headers in tests/ that are unambiguous (no directory prefix needed).
-# These live directly in tests/ and have no counterpart in src/.
-_ALLOWED_BARE_TEST_HEADERS: frozenset[str] = frozenset(
-    p.name
-    for p in (PROJECT_ROOT / "tests").iterdir()
-    if p.is_file() and p.suffix in (".h", ".hpp")
-)
+# Filesystem scans below are deferred to first-use. Walking tests/ recursively
+# costs ~314ms at module import, which is paid by every single-file lint —
+# even when the file being linted is not under tests/ and this checker is a
+# no-op for it. Lazy init keeps the import cheap.
+_allowed_bare_test_headers_cache: frozenset[str] | None = None
+_allowed_bare_src_headers_cache: frozenset[str] | None = None
+_allowed_bare_includes_cache: frozenset[str] | None = None
+_all_test_filenames_cache: frozenset[str] | None = None
 
-# Top-level headers in src/ that are unambiguous (legacy compatibility).
-# These live directly in src/ (e.g., FastLED.h, crgb.h) and have no
-# counterpart in tests/.
-_ALLOWED_BARE_SRC_HEADERS: frozenset[str] = frozenset(
-    p.name
-    for p in (PROJECT_ROOT / "src").iterdir()
-    if p.is_file() and p.suffix in (".h", ".hpp")
-)
 
-# Union of all allowed bare (no-directory) includes.
-_ALLOWED_BARE_INCLUDES: frozenset[str] = (
-    _ALLOWED_BARE_TEST_HEADERS | _ALLOWED_BARE_SRC_HEADERS
-)
+def _allowed_bare_test_headers() -> frozenset[str]:
+    """Top-level headers in tests/ that are unambiguous (no dir prefix needed)."""
+    global _allowed_bare_test_headers_cache
+    if _allowed_bare_test_headers_cache is None:
+        _allowed_bare_test_headers_cache = frozenset(
+            p.name
+            for p in (PROJECT_ROOT / "tests").iterdir()
+            if p.is_file() and p.suffix in (".h", ".hpp")
+        )
+    return _allowed_bare_test_headers_cache
 
-# All filenames that exist somewhere inside tests/ (recursively).
-# A bare include is only flagged if the filename is found here — otherwise
-# it's probably a system or SDK header (e.g., <stdint.h>, <initializer_list>).
-_ALL_TEST_FILENAMES: frozenset[str] = frozenset(
-    p.name
-    for p in (PROJECT_ROOT / "tests").rglob("*")
-    if p.is_file() and p.suffix in (".h", ".hpp", ".cpp.hpp")
-)
+
+def _allowed_bare_src_headers() -> frozenset[str]:
+    """Top-level headers in src/ that are unambiguous (legacy compatibility).
+
+    These live directly in src/ (e.g., FastLED.h, crgb.h) and have no
+    counterpart in tests/.
+    """
+    global _allowed_bare_src_headers_cache
+    if _allowed_bare_src_headers_cache is None:
+        _allowed_bare_src_headers_cache = frozenset(
+            p.name
+            for p in (PROJECT_ROOT / "src").iterdir()
+            if p.is_file() and p.suffix in (".h", ".hpp")
+        )
+    return _allowed_bare_src_headers_cache
+
+
+def _allowed_bare_includes() -> frozenset[str]:
+    """Union of allowed bare (no-directory) includes."""
+    global _allowed_bare_includes_cache
+    if _allowed_bare_includes_cache is None:
+        _allowed_bare_includes_cache = (
+            _allowed_bare_test_headers() | _allowed_bare_src_headers()
+        )
+    return _allowed_bare_includes_cache
+
+
+def _all_test_filenames() -> frozenset[str]:
+    """All filenames that exist somewhere inside tests/ (recursively).
+
+    A bare include is only flagged if the filename is found here — otherwise
+    it's probably a system or SDK header (e.g., <stdint.h>, <initializer_list>).
+    Recursive scan is the dominant cost (~314ms); cached after first use.
+    """
+    global _all_test_filenames_cache
+    if _all_test_filenames_cache is None:
+        _all_test_filenames_cache = frozenset(
+            p.name
+            for p in (PROJECT_ROOT / "tests").rglob("*")
+            if p.is_file() and p.suffix in (".h", ".hpp", ".cpp.hpp")
+        )
+    return _all_test_filenames_cache
+
 
 # Valid directory prefixes for qualified includes (src-relative or test-relative).
 _VALID_PREFIXES = (
@@ -162,13 +196,13 @@ class TestIncludePathsChecker(FileContentChecker):
             # 3) Bare filename — allowed only for known top-level headers
             #    or system/SDK headers that don't exist in tests/.
             if _is_bare_filename(include_path):
-                if include_path in _ALLOWED_BARE_INCLUDES:
+                if include_path in _allowed_bare_includes():
                     continue
                 # Only flag if this filename actually exists somewhere in tests/
                 # (i.e., it's a test-local header).  System/SDK headers like
                 # stdint.h, initializer_list, esp_err.h are NOT in tests/ and
                 # are silently allowed.
-                if include_path not in _ALL_TEST_FILENAMES:
+                if include_path not in _all_test_filenames():
                     continue
                 violations.append(
                     (


### PR DESCRIPTION
## Summary

Two independent perf fixes for the \`lint-on-save.py\` hook (and any single-file lint), measured on Windows:

| Layer | Before | After | Speedup |
|---|---|---|---|
| \`iwyu_wrapper.py\` (raw IWYU run) | 1697ms | 371ms | **4.6×** |
| \`ci/lint.py --strict\` | 3833ms | 2235ms | 1.7× |
| \`lint-on-save.py\` (the actual hook cost) | **3977ms** | **2347ms** | **1.7×** |
| \`run_all_checkers.py\` (cold import) | 819ms | 634ms | 1.3× |

Per Edit/Write, this saves ~1.6 seconds. Compounding on a refactor that touches 30+ files: ~50 seconds back.

## Commits

### 1. \`perf(ci/iwyu): swap slow Python wrapper for cached native ctc-clang++\`

\`ci/iwyu_wrapper.py:get_compiler_include_paths()\` invokes the C++ driver with \`-E -v\` to discover stdlib include paths on every IWYU run. Today it forwards \`clang-tool-chain-cpp\` (the Python entry point), which pays ~828ms of interpreter startup before clang even runs.

The build system already pre-compiles a native launcher at \`.cached/clang-native/ctc-clang++.exe\` (via \`_ensure_native_launcher\` in \`ci/meson/build_config.py\`). When present, it replaces the Python wrapper with negligible startup overhead.

Adds \`_resolve_fast_native_cxx()\` which swaps the slow driver for the cached native launcher when available. Falls back to the original path otherwise. No new dependency.

### 2. \`perf(lint): lazy-load tests/ filesystem scan in test_include_paths_checker\`

\`ci/lint_cpp/test_include_paths_checker.py\` ran \`(PROJECT_ROOT / "tests").rglob("*")\` at module-import time to build a filename allowlist (~314ms). Because \`run_all_checkers.py\` imports it unconditionally, **every** single-file lint paid that cost — even for src/ files where this checker is a no-op.

Wraps the three module-level frozensets in cached lazy accessors. The scan only runs if/when the checker actually inspects an include line that needs it.

## Test plan

- [x] \`bash lint\` passes
- [x] Manual benchmark: \`echo '{"tool_input":{"file_path":"tests/fl/system/pin.cpp"}}' | uv run ci/hooks/lint-on-save.py\` measured before/after
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized the C++ build pipeline by introducing faster native compiler resolution that leverages precompiled cached launchers when available, reducing compilation overhead.
  * Refactored include path validation checker to use lazy initialization with intelligent caching, reducing unnecessary filesystem operations and improving tool startup performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->