### PR TITLE
fix(fl): address CodeRabbit follow-up findings from PR #2414

### DIFF
--- a/src/fl/channels/rx.cpp.hpp
+++ b/src/fl/channels/rx.cpp.hpp
@@ -85,7 +85,7 @@ namespace fl {
 
 // RMT device specialization for ESP32
 template <>
-fl::shared_ptr<RxDevice> RxDevice::create<RxDeviceType::RMT>(int pin) {
+fl::shared_ptr<RxDevice> RxDevice::create<RxDeviceType::RMT>(int pin) FL_NOEXCEPT {
     auto device = RmtRxChannel::create(pin);
     if (!device) {
         return fl::make_shared<DummyRxDevice>("RMT RX channel creation failed");
@@ -95,7 +95,7 @@ fl::shared_ptr<RxDevice> RxDevice::create<RxDeviceType::RMT>(int pin) {
 
 // ISR device specialization for ESP32
 template <>
-fl::shared_ptr<RxDevice> RxDevice::create<RxDeviceType::ISR>(int pin) {
+fl::shared_ptr<RxDevice> RxDevice::create<RxDeviceType::ISR>(int pin) FL_NOEXCEPT {
     auto device = GpioIsrRx::create(pin);
     if (!device) {
         return fl::make_shared<DummyRxDevice>("GPIO ISR RX creation failed");
@@ -105,14 +105,14 @@ fl::shared_ptr<RxDevice> RxDevice::create<RxDeviceType::ISR>(int pin) {
 
 // FLEXPWM not available on ESP32
 template <>
-fl::shared_ptr<RxDevice> RxDevice::create<RxDeviceType::FLEXPWM>(int pin) {
+fl::shared_ptr<RxDevice> RxDevice::create<RxDeviceType::FLEXPWM>(int pin) FL_NOEXCEPT {
     (void)pin;
     return fl::make_shared<DummyRxDevice>("FLEXPWM RX not supported on ESP32");
 }
 
 // DEFAULT maps to RMT on ESP32
 template <>
-fl::shared_ptr<RxDevice> RxDevice::create<RxDeviceType::PLATFORM_DEFAULT>(int pin) {
+fl::shared_ptr<RxDevice> RxDevice::create<RxDeviceType::PLATFORM_DEFAULT>(int pin) FL_NOEXCEPT {
     return RxDevice::create<RxDeviceType::RMT>(pin);
 }
 
@@ -120,7 +120,7 @@ fl::shared_ptr<RxDevice> RxDevice::create<RxDeviceType::PLATFORM_DEFAULT>(int pi
 
 // FLEXPWM device specialization for Teensy 4.x
 template <>
-fl::shared_ptr<RxDevice> RxDevice::create<RxDeviceType::FLEXPWM>(int pin) {
+fl::shared_ptr<RxDevice> RxDevice::create<RxDeviceType::FLEXPWM>(int pin) FL_NOEXCEPT {
     auto device = FlexPwmRxChannel::create(pin);
     if (!device) {
         return fl::make_shared<DummyRxDevice>("FlexPWM RX channel creation failed");
@@ -130,21 +130,21 @@ fl::shared_ptr<RxDevice> RxDevice::create<RxDeviceType::FLEXPWM>(int pin) {
 
 // RMT not available on Teensy
 template <>
-fl::shared_ptr<RxDevice> RxDevice::create<RxDeviceType::RMT>(int pin) {
+fl::shared_ptr<RxDevice> RxDevice::create<RxDeviceType::RMT>(int pin) FL_NOEXCEPT {
     (void)pin;
     return fl::make_shared<DummyRxDevice>("RMT RX not supported on Teensy");
 }
 
 // ISR not available on Teensy
 template <>
-fl::shared_ptr<RxDevice> RxDevice::create<RxDeviceType::ISR>(int pin) {
+fl::shared_ptr<RxDevice> RxDevice::create<RxDeviceType::ISR>(int pin) FL_NOEXCEPT {
     (void)pin;
     return fl::make_shared<DummyRxDevice>("ISR RX not supported on Teensy");
 }
 
 // DEFAULT maps to FLEXPWM on Teensy 4.x
 template <>
-fl::shared_ptr<RxDevice> RxDevice::create<RxDeviceType::PLATFORM_DEFAULT>(int pin) {
+fl::shared_ptr<RxDevice> RxDevice::create<RxDeviceType::PLATFORM_DEFAULT>(int pin) FL_NOEXCEPT {
     return RxDevice::create<RxDeviceType::FLEXPWM>(pin);
 }
 
@@ -178,28 +178,28 @@ fl::shared_ptr<RxDevice> RxDevice::create<RxDeviceType::PLATFORM_DEFAULT>(int pi
 
 // RMT device specialization (dummy for non-ESP32, non-stub)
 template <>
-fl::shared_ptr<RxDevice> RxDevice::create<RxDeviceType::RMT>(int pin) {
+fl::shared_ptr<RxDevice> RxDevice::create<RxDeviceType::RMT>(int pin) FL_NOEXCEPT {
     (void)pin;  // Suppress unused parameter warning
     return RxDevice::createDummy();
 }
 
 // ISR device specialization (dummy for non-ESP32, non-stub)
 template <>
-fl::shared_ptr<RxDevice> RxDevice::create<RxDeviceType::ISR>(int pin) {
+fl::shared_ptr<RxDevice> RxDevice::create<RxDeviceType::ISR>(int pin) FL_NOEXCEPT {
     (void)pin;  // Suppress unused parameter warning
     return RxDevice::createDummy();
 }
 
 // FLEXPWM device specialization (dummy for unsupported platforms)
 template <>
-fl::shared_ptr<RxDevice> RxDevice::create<RxDeviceType::FLEXPWM>(int pin) {
+fl::shared_ptr<RxDevice> RxDevice::create<RxDeviceType::FLEXPWM>(int pin) FL_NOEXCEPT {
     (void)pin;  // Suppress unused parameter warning
     return RxDevice::createDummy();
 }
 
 // DEFAULT maps to RMT on unsupported platforms (returns dummy)
 template <>
-fl::shared_ptr<RxDevice> RxDevice::create<RxDeviceType::PLATFORM_DEFAULT>(int pin) {
+fl::shared_ptr<RxDevice> RxDevice::create<RxDeviceType::PLATFORM_DEFAULT>(int pin) FL_NOEXCEPT {
     return RxDevice::create<RxDeviceType::RMT>(pin);
 }
 

--- a/src/fl/sensors/ui_button_integration.cpp.hpp
+++ b/src/fl/sensors/ui_button_integration.cpp.hpp
@@ -8,13 +8,13 @@
 
 namespace fl {
 
-void UIButton::addRealButton(fl::shared_ptr<IButtonInput> button) {
+void UIButton::addRealButton(fl::shared_ptr<IButtonInput> button) FL_NOEXCEPT {
     // Stored directly; no concrete-type dependency. Caller may pass any
     // IButtonInput implementation (Button, mock, etc.).
     mButtonInput = button;
 }
 
-void UIDropdown::addNextButton(int pin) {
+void UIDropdown::addNextButton(int pin) FL_NOEXCEPT {
     mNextButton = fl::make_shared<Button>(pin);
 }
 

--- a/src/fl/ui/button.cpp.hpp
+++ b/src/fl/ui/button.cpp.hpp
@@ -10,12 +10,25 @@ UIButton::UIButton(const char *name) FL_NOEXCEPT : mImpl(name), mListener(this) 
 
 UIButton::~UIButton() FL_NOEXCEPT {}
 
+int UIButton::clickedCount() const FL_NOEXCEPT {
+    return mImpl.clickedCount() + mListener.realButtonClickCount();
+}
+
 void UIButton::Listener::onBeginFrame() FL_NOEXCEPT {
     bool clicked_this_frame = mOwner->clicked();
     bool pressed_this_frame = mOwner->isPressed();
 
     // Check the real button if one is attached (via IButtonInput interface)
     if (mOwner->mButtonInput) {
+        // Edge-detect rising transitions of mButtonInput->clicked() so
+        // clickedCount() reflects real-button presses on platforms where
+        // UIButtonImpl::clickedCount() is a no-op stub.
+        const bool real_clicked = mOwner->mButtonInput->clicked();
+        if (real_clicked && !mRealButtonClickedLastFrame) {
+            ++mRealButtonClickCount;
+        }
+        mRealButtonClickedLastFrame = real_clicked;
+
         if (mOwner->mButtonInput->isPressed()) {
             clicked_this_frame = true;
             pressed_this_frame = true;

--- a/src/fl/ui/button.h
+++ b/src/fl/ui/button.h
@@ -60,7 +60,7 @@ class UIButton : public UIElement {
         }
         return false;
     }
-    int clickedCount() const FL_NOEXCEPT { return mImpl.clickedCount(); }
+    int clickedCount() const FL_NOEXCEPT;
     operator bool() const FL_NOEXCEPT { return clicked(); }
     bool value() const FL_NOEXCEPT { return clicked(); }
 
@@ -139,20 +139,25 @@ class UIButton : public UIElement {
             added = true;
         }
         void onBeginFrame() FL_NOEXCEPT override;
+        int realButtonClickCount() const FL_NOEXCEPT { return mRealButtonClickCount; }
 
       private:
         UIButton *mOwner;
         bool added = false;
         bool mClickedLastFrame = false;
         bool mPressedLastFrame = false;
+        bool mRealButtonClickedLastFrame = false;
+        int mRealButtonClickCount = 0;
     };
 
   private:
     function_list<void(UIButton &)> mCallbacks;
     function_list<void()> mPressCallbacks;
     function_list<void()> mReleaseCallbacks;
-    Listener mListener;
     fl::shared_ptr<IButtonInput> mButtonInput;
+    // Declared last so it is destroyed first and removes itself from
+    // EngineEvents before mButtonInput / callback lists are torn down.
+    Listener mListener;
 };
 
 FASTLED_UI_DEFINE_OPERATORS(UIButton)


### PR DESCRIPTION
## Summary

Follow-up to #2414, addressing the three CodeRabbit findings the prior commits in that PR deferred to a human reviewer.

- **`src/fl/channels/rx.cpp.hpp`** — Append `FL_NOEXCEPT` to all twelve `RxDevice::create<>` out-of-class definitions in the `FL_IS_ESP32`, `FL_IS_TEENSY_4X`, and `#else` fallback blocks so they match the `FL_NOEXCEPT`-qualified declarations in `rx.h`. Stub block was already correct. (C++17 requires matching exception specs between declarations and definitions of explicit template specializations — currently latent because `FL_NOEXCEPT` expands to nothing, but becomes a hard compile error the moment that macro is switched on for any platform.)
- **`src/fl/ui/button.h` + `button.cpp.hpp`** —
  - `clickedCount()` no longer ignores `mButtonInput`. The `Listener` now edge-detects rising transitions of `mButtonInput->clicked()`, increments a local counter, and `clickedCount()` returns `mImpl.clickedCount() + mListener.realButtonClickCount()`. Restores parity with `clicked()` / `isPressed()`, which already fall back to `mButtonInput`.
  - Move `mListener` to be the **last** private member so it is destroyed first and unregisters from `EngineEvents` before `mButtonInput` and the callback lists are torn down. Fixes a destruction-order hazard where `Listener::onBeginFrame()` could observe a half-destroyed `UIButton`.
- **`src/fl/sensors/ui_button_integration.cpp.hpp`** — Append `FL_NOEXCEPT` to the `UIButton::addRealButton` and `UIDropdown::addNextButton` out-of-class definitions to match their declarations.

## Test plan

- [x] `bash lint` — clean
- [x] `bash test --cpp` — 302/302 passed
- [ ] CI green on master after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved real button click detection to ensure all physical button presses are properly registered and counted.

* **Chores**
  * Enhanced exception safety specifications across button and device creation functions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->