### PR TITLE
feat(fl/stl): add FL_NO_UNWIND macros, apply to ESP32 unity headers

### DIFF
--- a/src/fl/stl/compiler_control.h
+++ b/src/fl/stl/compiler_control.h
@@ -224,6 +224,133 @@
   #define FL_OPTIMIZATION_LEVEL_O0_END   /* nothing */
 #endif
 
+// =============================================================================
+// FL_NO_UNWIND family — suppress DWARF .eh_frame unwind-table emission
+// =============================================================================
+//
+// Public macros provided by this section:
+//
+//   FL_NO_UNWIND          per-function attribute (place before return type)
+//   FL_NO_UNWIND_BEGIN    start of TU/block-scoped pragma stripping
+//   FL_NO_UNWIND_END      paired with _BEGIN
+//   FL_NO_UNWIND_ACTIVE   query macro: 1 if stripping is active, else 0
+//
+// Why: ~180 KB savings on ESP32-S3 builds where 79% of FDE entries are
+// orphan FDEs left behind after --gc-sections strips dead virtual-dispatch
+// code (see issue #2421).
+//
+// SAFETY: A function compiled with stripped unwind tables cannot be unwound
+// through by the ESP32 panic handler — backtraces stop at that frame and
+// resume at the next frame with valid CFI. Apply only to hot dispatch or
+// driver code where the size win matters; do NOT apply to setup, loop, init,
+// or error-handling paths where a usable backtrace matters.
+//
+// Per-function form:
+//   FL_NO_UNWIND void hot_dispatch() noexcept { ... }
+//
+// TU-level form (preferred for unity-build .cpp.hpp wrappers):
+//   FL_NO_UNWIND_BEGIN
+//   #include "platforms/.../_build.cpp.hpp"
+//   FL_NO_UNWIND_END
+//
+// =============================================================================
+// User control hierarchy (highest priority first)
+// =============================================================================
+//
+//   1. Direct macro override.
+//      Pre-define any of FL_NO_UNWIND / FL_NO_UNWIND_BEGIN / FL_NO_UNWIND_END
+//      before including this header — yours will be respected, the others
+//      will be stubbed to no-op. Pre-define FL_NO_UNWIND_ACTIVE yourself if
+//      you want to assert what your override does.
+//
+//   2. Hard policy override (overrides everything below):
+//        #define FASTLED_FORCE_NO_UNWIND_TABLES 1   // always strip
+//        #define FASTLED_FORCE_UNWIND_TABLES    1   // always preserve
+//      FORCE_NO wins if both are accidentally set.
+//
+//   3. Debug auto-detect — preserve unwind tables when ANY of:
+//        !defined(RELEASE)
+//        !defined(NDEBUG)
+//        defined(FASTLED_TESTING) / FASTLED_FORCE_DBG / FASTLED_DEBUG / FL_DEBUG
+//        on ESP32: CONFIG_ESP_SYSTEM_PANIC_PRINT_BACKTRACE,
+//                  CONFIG_ESP_SYSTEM_PANIC_GDBSTUB,
+//                  CONFIG_ESP_DEBUG_OCDAWARE,
+//                  CONFIG_COMPILER_OPTIMIZATION_DEBUG,
+//                  CONFIG_COMPILER_OPTIMIZATION_NONE,
+//                  CORE_DEBUG_LEVEL >= 3
+//
+//   4. Default (release build, no diagnostic indicators) — strip.
+
+// -----------------------------------------------------------------------------
+// Stage 1: resolve FL_NO_UNWIND_ACTIVE policy (user can pre-define).
+// -----------------------------------------------------------------------------
+#ifndef FL_NO_UNWIND_ACTIVE
+  #if defined(FASTLED_FORCE_NO_UNWIND_TABLES) && FASTLED_FORCE_NO_UNWIND_TABLES
+    // Hard force ON wins over everything below.
+    #define FL_NO_UNWIND_ACTIVE 1
+  #elif defined(FASTLED_FORCE_UNWIND_TABLES) && FASTLED_FORCE_UNWIND_TABLES
+    // Hard force OFF wins over auto-detect.
+    #define FL_NO_UNWIND_ACTIVE 0
+  #elif !defined(RELEASE) \
+        || defined(FASTLED_TESTING) \
+        || defined(FASTLED_FORCE_DBG) \
+        || defined(FASTLED_DEBUG) \
+        || defined(FL_DEBUG) \
+        || !defined(NDEBUG) \
+        || (defined(FL_IS_ESP32) && ( \
+               (defined(CONFIG_ESP_SYSTEM_PANIC_PRINT_BACKTRACE) && CONFIG_ESP_SYSTEM_PANIC_PRINT_BACKTRACE) \
+            || (defined(CONFIG_ESP_SYSTEM_PANIC_GDBSTUB)         && CONFIG_ESP_SYSTEM_PANIC_GDBSTUB) \
+            || (defined(CONFIG_ESP_DEBUG_OCDAWARE)               && CONFIG_ESP_DEBUG_OCDAWARE) \
+            || (defined(CONFIG_COMPILER_OPTIMIZATION_DEBUG)      && CONFIG_COMPILER_OPTIMIZATION_DEBUG) \
+            || (defined(CONFIG_COMPILER_OPTIMIZATION_NONE)       && CONFIG_COMPILER_OPTIMIZATION_NONE) \
+            || (defined(CORE_DEBUG_LEVEL)                        && (CORE_DEBUG_LEVEL >= 3)) \
+           ))
+    // Auto-detect: any debug indicator → preserve.
+    #define FL_NO_UNWIND_ACTIVE 0
+  #else
+    // Release build with no diagnostic indicators → strip.
+    #define FL_NO_UNWIND_ACTIVE 1
+  #endif
+#endif
+
+// -----------------------------------------------------------------------------
+// Stage 2: emit the macros. Each is independently overridable via #ifndef
+// guards, so a user can pre-define just one (e.g. a custom FL_NO_UNWIND_BEGIN
+// that combines push_options with extra pragmas) and we'll stub the rest.
+//
+// The "stripping" expansion is gated to GCC because clang's per-function
+// optimize attribute support is uneven and clang warns about #pragma GCC
+// optimize.
+// -----------------------------------------------------------------------------
+#if FL_NO_UNWIND_ACTIVE && defined(FL_IS_GCC)
+  #ifndef FL_NO_UNWIND
+    #define FL_NO_UNWIND       __attribute__((optimize("no-unwind-tables")))
+  #endif
+  #ifndef FL_NO_UNWIND_BEGIN
+    #define FL_NO_UNWIND_BEGIN _Pragma("GCC push_options") _Pragma("GCC optimize(\"no-unwind-tables\")")
+  #endif
+  #ifndef FL_NO_UNWIND_END
+    #define FL_NO_UNWIND_END   _Pragma("GCC pop_options")
+  #endif
+#else
+  // Policy says preserve, OR we're not on GCC — emit no-ops. If the user
+  // requested stripping but we can't honor it (non-GCC), correct the query
+  // macro so it accurately reflects what's emitted.
+  #ifndef FL_NO_UNWIND
+    #define FL_NO_UNWIND
+  #endif
+  #ifndef FL_NO_UNWIND_BEGIN
+    #define FL_NO_UNWIND_BEGIN
+  #endif
+  #ifndef FL_NO_UNWIND_END
+    #define FL_NO_UNWIND_END
+  #endif
+  #if FL_NO_UNWIND_ACTIVE
+    #undef FL_NO_UNWIND_ACTIVE
+    #define FL_NO_UNWIND_ACTIVE 0
+  #endif
+#endif
+
 // Optimization for exact timing (cycle-accurate code)
 // Disables optimizations that can affect instruction timing predictability.
 // Default level is O2 for balance between performance and timing predictability.

--- a/src/platforms/esp/32/_build.cpp.hpp
+++ b/src/platforms/esp/32/_build.cpp.hpp
@@ -4,6 +4,9 @@
 /// @brief Unity build header for platforms\esp\32/ directory
 /// Includes all implementation files in alphabetical order
 
+#include "fl/stl/compiler_control.h"
+FL_NO_UNWIND_BEGIN
+
 // Root directory implementations (alphabetical order)
 
 // begin current directory includes
@@ -23,3 +26,5 @@
 #include "platforms/esp/32/drivers/_build.cpp.hpp"
 #include "platforms/esp/32/interrupts/_build.cpp.hpp"
 #include "platforms/esp/32/ota/_build.cpp.hpp"
+
+FL_NO_UNWIND_END

--- a/src/platforms/esp/32/drivers/_build.cpp.hpp
+++ b/src/platforms/esp/32/drivers/_build.cpp.hpp
@@ -4,6 +4,9 @@
 /// @brief Unity build header for platforms\esp\32\drivers/ directory
 /// Includes all implementation files in alphabetical order
 
+#include "fl/stl/compiler_control.h"
+FL_NO_UNWIND_BEGIN
+
 // Root directory implementations (alphabetical order)
 
 // begin current directory includes
@@ -23,3 +26,5 @@
 #include "platforms/esp/32/drivers/rmt_rx/_build.cpp.hpp"
 #include "platforms/esp/32/drivers/spi/_build.cpp.hpp"
 #include "platforms/esp/32/drivers/uart/_build.cpp.hpp"
+
+FL_NO_UNWIND_END

--- a/tests/fl/stl/compiler_control.cpp
+++ b/tests/fl/stl/compiler_control.cpp
@@ -62,6 +62,24 @@ static int o0_sum(int a, int b) {
 }
 FL_OPTIMIZATION_LEVEL_O0_END
 
+// Test helper: per-function FL_NO_UNWIND attribute
+FL_NO_UNWIND
+static int no_unwind_sum(int a, int b) {
+    return a + b;
+}
+
+// Test helper: TU-block FL_NO_UNWIND_BEGIN/_END
+FL_NO_UNWIND_BEGIN
+static int no_unwind_block_sum(int a, int b) {
+    return a + b;
+}
+static int no_unwind_block_loop() {
+    int sum = 0;
+    for (int i = 0; i < 5; i++) sum += i;
+    return sum;
+}
+FL_NO_UNWIND_END
+
 // Test helper: Weak linkage function
 FL_LINK_WEAK int weak_function() {
     return 42;
@@ -792,6 +810,39 @@ FL_TEST_CASE("fl::deprecated_template_function") {
 
     FL_CHECK_EQ(newTemplateFunction(5), 15);
     FL_CHECK_EQ(newTemplateFunction(3.0), 9.0);
+}
+
+FL_TEST_CASE("FL_NO_UNWIND family") {
+    FL_SUBCASE("FL_NO_UNWIND_ACTIVE is defined to 0 or 1") {
+        // Must be a usable preprocessor value (some build configs check it).
+        FL_CHECK(FL_NO_UNWIND_ACTIVE == 0 || FL_NO_UNWIND_ACTIVE == 1);
+    }
+
+    FL_SUBCASE("per-function FL_NO_UNWIND attribute compiles and runs") {
+        FL_CHECK_EQ(no_unwind_sum(7, 8), 15);
+    }
+
+    FL_SUBCASE("TU-level FL_NO_UNWIND_BEGIN/_END compiles and runs") {
+        FL_CHECK_EQ(no_unwind_block_sum(10, 20), 30);
+        FL_CHECK_EQ(no_unwind_block_loop(), 0 + 1 + 2 + 3 + 4);
+    }
+
+    FL_SUBCASE("FL_NO_UNWIND macros are always defined (even when no-op)") {
+        // All three must expand to something — should compile in any context.
+        FL_NO_UNWIND_BEGIN
+        int x = 42;
+        FL_NO_UNWIND_END
+        FL_CHECK_EQ(x, 42);
+    }
+
+    FL_SUBCASE("nested FL_NO_UNWIND_BEGIN/_END blocks") {
+        FL_NO_UNWIND_BEGIN
+        FL_NO_UNWIND_BEGIN
+        int x = 1;
+        FL_NO_UNWIND_END
+        FL_NO_UNWIND_END
+        FL_CHECK_EQ(x, 1);
+    }
 }
 
 } // FL_TEST_FILE


### PR DESCRIPTION
## Summary

Adds `FL_NO_UNWIND` / `FL_NO_UNWIND_BEGIN` / `FL_NO_UNWIND_END` macros and applies the TU-level pair to both ESP32 unity-build headers. Targets the binary-size half of #2421 by suppressing GCC unwind-table emission for the FastLED ESP32 driver code, with a debug-aware gate so panic backtraces stay intact in development builds.

Closes part of #2421. Related: #2420.

## Why

Symbol-level analysis of @nomakewan's reproducer build (`master#ea5d8ec`, ESP32-S3, NEOPIXEL, 35 LEDs) showed `libFastLED.a` contributing **180 KB of `.eh_frame`** — half of the entire `.flash.rodata` section. A direct count of FDE entries showed:

- 16,773 total FDEs in the binary
- **13,272 (79.1%) are orphan FDEs** covering zero-byte ranges — left behind by GNU LD when `--gc-sections` strips dead virtual-dispatch code but fails to cull the corresponding `.eh_frame` entry
- Only 21% point to live code

Full breakdown: https://github.com/FastLED/FastLED/issues/2421#issuecomment-4356403093

`FL_NOEXCEPT` does not suppress this — `noexcept` is a language contract, `.eh_frame` is a codegen artifact controlled by `-fasynchronous-unwind-tables` (default ON in GCC, used by panic handlers / debuggers / profilers, not just C++ exceptions).

## What changed

- `src/fl/stl/compiler_control.h` (+89): three new macros following the same pattern as the existing `FL_DISABLE_WARNING_PUSH/POP` and `FL_BEGIN_OPTIMIZE_FOR_EXACT_TIMING` blocks
- `src/platforms/esp/32/_build.cpp.hpp` (+5): wrap entire unity TU with `FL_NO_UNWIND_BEGIN`/`_END`
- `src/platforms/esp/32/drivers/_build.cpp.hpp` (+5): same

## Gating logic — preserves backtraces by default

The macros are **no-ops (preserve `.eh_frame`) whenever** any of these are set:

**FastLED debug indicators:** `!RELEASE`, `FASTLED_TESTING`, `FASTLED_FORCE_DBG`, `FASTLED_DEBUG`, `FL_DEBUG`, `!NDEBUG`

**ESP32 sdkconfig (only when `FL_IS_ESP32` is defined):**
- `CONFIG_ESP_SYSTEM_PANIC_PRINT_BACKTRACE` (ESP-IDF default ON)
- `CONFIG_ESP_SYSTEM_PANIC_GDBSTUB`
- `CONFIG_ESP_DEBUG_OCDAWARE`
- `CONFIG_COMPILER_OPTIMIZATION_DEBUG` / `CONFIG_COMPILER_OPTIMIZATION_NONE`

**Arduino-ESP32 verbosity:** `CORE_DEBUG_LEVEL >= 3`

**User overrides (last word):** `FASTLED_FORCE_UNWIND_TABLES` (force-keep) / `FASTLED_FORCE_NO_UNWIND_TABLES` (force-strip)

This means the size win has to be **opted into** with `-DFASTLED_FORCE_NO_UNWIND_TABLES` in `build_flags`. The default behavior on the reporter's exact build (`CORE_DEBUG_LEVEL=3` + ESP-IDF default panic backtrace) is **no change** — backtraces are preserved, binary size is unchanged from current master. Users who want the ~180 KB win pay for it explicitly.

## Why opt-in is the right default

A wrapped function shows `???` in `esp32_exception_decoder` output. For a release build of a single-purpose installation that just blinks LEDs, that's an acceptable trade for 180 KB; for a development build or a customer-facing product where crash diagnostics matter, it isn't. Defaulting to "preserve" is the conservative choice.

## Why `compiler_control.h` and not a new `codegen.h`

The original spec proposed `src/fl/stl/codegen.h`, but `src/fl/stl/compiler_control.h` already hosts every other `_Pragma`-based macro pair in the codebase (`FL_DISABLE_WARNING_PUSH/POP`, `FL_BEGIN_OPTIMIZE_FOR_EXACT_TIMING/_END`, `FL_OPTIMIZATION_LEVEL_O3_BEGIN/_END`). Same shape, same conventions, same compiler-detection macros (`FL_IS_GCC`, `FL_GCC_VERSION`, `FL_STRINGIFY`) — so the natural home was here, not a parallel new file.

## Why just `optimize("no-unwind-tables")` and not also `no-asynchronous-unwind-tables`

`-fno-unwind-tables` is the strictly stronger GCC flag and implies `-fno-asynchronous-unwind-tables`. The redundant pair is a common belt-and-suspenders pattern in tutorials but adds nothing on GCC. One flag is enough. (Discussion: https://github.com/FastLED/FastLED/issues/2421#issuecomment-4357768687.)

## Why the GCC-only gate (and not clang)

`#pragma GCC optimize` is accepted by clang but emits an "unknown pragma" warning at minimum, and clang's per-function optimize attribute support is uneven (well-known caveats with LTO and template instantiation). Restricting to `FL_IS_GCC` keeps clang builds clean.

## Verification

- `bash lint` — clean
- `bash test --cpp` — 302/302 host tests pass (~107s)
- `bash compile esp32s3 --examples Blink` — succeeds (~437s), produces 810.81 KB firmware.bin (default mode, backtraces preserved — exactly as designed)
- Pragma compiles without warning under Xtensa GCC 13.2 from pioarduino's `toolchain-xtensa-esp-elf`

## Test plan

- [x] Lint clean
- [x] Host tests (302/302) pass
- [x] ESP32-S3 default-mode compile succeeds, binary unchanged from current master
- [ ] **Need community verification**: build with `-DFASTLED_FORCE_NO_UNWIND_TABLES` and confirm ~180 KB savings
- [ ] **Need community verification**: panic-decode a forced crash inside `Channel::showPixels` in default mode (backtrace should be intact) and in opt-in mode (frame should show `???`, downstream frames should still resolve)
- [ ] @nomakewan if you're up for it, retest your #2420 sketch with this branch + `-DFASTLED_FORCE_NO_UNWIND_TABLES` in `build_flags` and report the new binary size

## What this does NOT fix

This PR addresses ONE half of #2421 (the binary bloat). It does NOT fix:

- The per-`show()` `vTaskDelay(1)` timing regression (separate `FASTLED_TIGHT_TIMING` proposal in #2421)
- The unconditional driver compilation in `_build.cpp.hpp` (per-driver feature gates, ~125 KB more savings)
- The cross-TU references that pull in `fl.audio` / `fl.remote` / `fl.net` / `fl.fx` / `fl.gfx` for one symbol each (will be a follow-up issue)

Those land in subsequent PRs against #2421.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added build-time controls to optionally suppress unwind table emission on embedded builds, reducing binary size.
  * Applied those controls across platform unity-builds so the setting consistently affects aggregated implementation files.
  * Backtrace/debug builds automatically preserve unwind information; unsupported toolchains remain unaffected and can no-op the controls.

* **Tests**
  * Added tests verifying the new unwind-control behavior and safe usage when the controls are no-ops.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->