### PR TITLE
fix(fl/sensors): make Button::clicked() transient instead of sticky-true

### DIFF
--- a/src/fl/sensors/button.cpp.hpp
+++ b/src/fl/sensors/button.cpp.hpp
@@ -59,10 +59,14 @@ Button::Button(int pin, ButtonStrategy strategy)
 void Button::Listener::onEndFrame() {
     const bool pressed_curr_frame = mOwner->mButton.isPressed();
     const bool pressed_last_frame = mOwner->mPressedLastFrame;
-    const bool changed_this_frame = pressed_curr_frame != pressed_last_frame;
+    // Rising edge of isPressed() == one click event for this frame.
+    // mClickedThisFrame must reflect only the current frame's transition;
+    // callers (UIDropdown::Listener, UIButton::clickedCount edge counter)
+    // rely on clicked() being transient, not latched.
+    const bool clicked_this_frame = pressed_curr_frame && !pressed_last_frame;
     mOwner->mPressedLastFrame = pressed_curr_frame;
-    if (changed_this_frame && pressed_curr_frame) {
-        mOwner->mClickedThisFrame = true;
+    mOwner->mClickedThisFrame = clicked_this_frame;
+    if (clicked_this_frame) {
         mOwner->mOnClickCallbacks.invoke();
     }
 }


### PR DESCRIPTION
## Summary

Post-merge expert review of PR #2419 surfaced one real bug in the merged code, plus a related pre-existing bug. Both share a single root cause in `Button::Listener::onEndFrame`, fixed here.

## The bug

`Button::Listener::onEndFrame` only ever set `mClickedThisFrame = true` (on a press rising edge) and **never cleared it**. So `Button::clicked()` (which returns `mClickedThisFrame`) became permanently true after the very first press for the entire lifetime of the `Button`.

The in-source comment at `src/fl/sensors/button.h:102` already documented the intended semantic:

```cpp
bool mClickedThisFrame = false;  // This is true if clicked this frame.
```

But the implementation was sticky, not transient.

## Impact

Two call sites poll `IButtonInput::clicked()` across frames and silently relied on transient semantics:

1. **`UIDropdown::Listener::onBeginFrame`** (`src/fl/ui/dropdown.cpp.hpp:29`, pre-existing) —
   ```cpp
   if (owner.mNextButton && owner.mNextButton->clicked()) {
       owner.nextOption();
   }
   ```
   After the first press of a `Button` attached via `addNextButton()`, this would call `nextOption()` **every frame indefinitely**, advancing the dropdown nonstop.

2. **`UIButton::Listener::onBeginFrame` edge-detection counter** (added in #2419, `src/fl/ui/button.cpp.hpp`) — the rising-edge counter for `clickedCount()` would increment exactly **once** per `UIButton` lifetime, regardless of how many real-button presses occurred, because `clicked()` never falls back to false to allow another rising edge.

## Fix

In `Button::Listener::onEndFrame`, write `mClickedThisFrame` unconditionally each frame as `(pressed_curr_frame && !pressed_last_frame)`. This restores the documented transient semantic without changing the `mOnClickCallbacks.invoke()` behavior (still fires once per press transition).

## Why this didn't show up in CI

There are no host-side unit tests for `Button` / `UIButton::clickedCount()` / `UIDropdown::nextOption()` polling in `tests/`. The bug only manifests on real hardware where a physical button can be pressed across multiple frames.

## Test plan

- [x] `bash lint` clean
- [x] `bash test --cpp` 302/302 passed (no regressions)
- [ ] Manual hardware verification with a real `Button` attached via `addRealButton()` / `addNextButton()` is recommended after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected button click detection to register clicks only when a button transitions from released to pressed state, preventing duplicate click events during a single press and improving input handling reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->