### PR TITLE
refactor(fl/gfx): lazy-init rgb_2_rgbw user function via Singleton<T>

### DIFF
--- a/src/fl/gfx/rgbw.cpp.hpp
+++ b/src/fl/gfx/rgbw.cpp.hpp
@@ -7,6 +7,7 @@
 #include "fl/fastled.h"
 
 #include "fl/gfx/rgbw.h"
+#include "fl/stl/singleton.h"
 
 
 namespace fl {
@@ -113,22 +114,38 @@ void rgb_2_rgbw_white_boosted(u16 w_color_temperature, u8 r,
     *out_w = w;
 }
 
-rgb_2_rgbw_function g_user_function = rgb_2_rgbw_exact;
+// User-installable RGB→RGBW function pointer, held behind a lazily-constructed
+// Singleton<T>. Replaces the previous static-init form
+// (`rgb_2_rgbw_function g_user_function = rgb_2_rgbw_exact`), which forced
+// `rgb_2_rgbw_exact` to be ODR-used at static init even when no caller ever
+// reached the kRGBWUserFunction code path.
+//
+// The Singleton's instance is constructed on first call to set_… or
+// rgb_2_rgbw_user_function below — never at static init. The default value of
+// `fn` is `nullptr`; rgb_2_rgbw_user_function uses `rgb_2_rgbw_exact` as the
+// fallback algorithm when nothing has been installed.
+//
+// See issue #2424 for the broader binary-bloat investigation.
+namespace {
+struct Rgb2RgbwUserState {
+    rgb_2_rgbw_function fn = nullptr;
+};
+} // namespace
 
 void set_rgb_2_rgbw_function(rgb_2_rgbw_function func) {
-    if (func == nullptr) {
-        g_user_function = rgb_2_rgbw_exact;
-        return;
-    }
-    g_user_function = func;
+    fl::Singleton<Rgb2RgbwUserState>::instance().fn = func;
 }
 
 void rgb_2_rgbw_user_function(u16 w_color_temperature, u8 r,
                               u8 g, u8 b, u8 r_scale,
                               u8 g_scale, u8 b_scale, u8 *out_r,
                               u8 *out_g, u8 *out_b, u8 *out_w) {
-    g_user_function(w_color_temperature, r, g, b, r_scale, g_scale, b_scale,
-                    out_r, out_g, out_b, out_w);
+    rgb_2_rgbw_function fn = fl::Singleton<Rgb2RgbwUserState>::instance().fn;
+    if (fn == nullptr) {
+        fn = rgb_2_rgbw_exact;
+    }
+    fn(w_color_temperature, r, g, b, r_scale, g_scale, b_scale,
+       out_r, out_g, out_b, out_w);
 }
 
 void rgbw_partial_reorder(EOrderW w_placement, u8 b0, u8 b1,


### PR DESCRIPTION
## Summary

Replaces the static-init form
```cpp
rgb_2_rgbw_function g_user_function = rgb_2_rgbw_exact;
```
with a lazily-constructed `fl::Singleton<Rgb2RgbwUserState>` wrapper. The Singleton's instance is only constructed on first call to `set_rgb_2_rgbw_function()` or `rgb_2_rgbw_user_function()` — never at static init.

Refs #2424 (recommended source-level cleanup from cross-TU references analysis).

## Empirical impact (be honest)

Measured on `bash compile esp32s3 --examples Blink` (default release, current master):

| Metric | Before | After | Delta |
|---|---:|---:|---:|
| Binary size | 830,272 | 830,304 | **+32 bytes** |
| `.flash.text` | 350,916 | 350,944 | +28 |
| `.flash.rodata` | 385,900 | 385,900 | 0 |
| `rgb_2_rgbw_*` family present in binary | 5 functions | 5 functions | 0 |

**This refactor does NOT shrink the binary.** The 5 `rgb_2_rgbw_*` algorithm functions remain in the binary because `pixel_controller.h:613` calls `rgb_2_rgbw(rgbw_mode, ...)` — a runtime switch over `rgbw_mode` that ODR-uses all 5 algorithm functions regardless of the static-init form. The lazy-init only addresses the *static-init* reference; the runtime-switch reference is unchanged.

The +32 bytes are: Singleton<T>'s init-guard variable + the new null-check fallback in `rgb_2_rgbw_user_function`.

## Why merge anyway

Structural improvements that are independent of binary size:

1. **No static init order dependency** on `rgb_2_rgbw_exact`. The previous form referenced it at static init time; the Singleton form doesn't reference any algorithm function until the first runtime call.
2. **Cleaner override pattern**: `Singleton<Rgb2RgbwUserState>::instance().fn = userFn` is the same Singleton pattern already used elsewhere in `fl/` (e.g. `CFastLED::channels()` uses `Singleton<vector<ChannelPtr>>`).
3. **Removes the special-case `if (func == nullptr)` reset semantics** in `set_rgb_2_rgbw_function` — now `nullptr` simply means "use the lazy default at call time" with no asymmetry.

## What this does NOT fix

The actual binary-size win for the rgbw family would require **per-mode template dispatch** for `loadAndScaleRGBW` so the compiler can statically eliminate the unused branches of the runtime switch. That's a larger refactor and out of scope here. Filed for follow-up consideration in #2424.

## Test plan

- [x] `bash lint --cpp` clean
- [x] `bash test --cpp` 302/302 pass
- [x] `bash compile esp32s3 --examples Blink` succeeds (binary 830,304 bytes)
- [x] Symbol search: `set_rgb_2_rgbw_function` and `rgb_2_rgbw_user_function` still present and callable

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal state management for RGB to RGBW function handling. The public API remains unchanged, ensuring full backward compatibility. This refactoring enhances the reliability and stability of custom function handling in color conversion operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->