### PR TITLE
feat(channels): add fl::Bus enum + BusTraits foundation (Phase 1 of #2428)

### DIFF
--- a/src/fl/channels/bus.h
+++ b/src/fl/channels/bus.h
@@ -1,0 +1,80 @@
+#pragma once
+
+/// @file bus.h
+/// @brief Compile-time identifier for an LED channel transmission bus.
+///
+/// `fl::Bus` is the single source of truth for which low-level driver
+/// implementation handles a channel. The same value drives:
+///   - Compile-time template binding (`Channel<Bus::X, Chipset>`).
+///   - Per-platform default selection (`DefaultBus<Chipset>::value`).
+///   - Opt-in runtime registry enrollment (`enableDrivers<Bus::X...>()`).
+///
+/// Drivers link only when their `Bus` value is named somewhere in the
+/// translation unit graph. See issue #2428.
+
+#include "fl/stl/stdint.h"
+#include "platforms/is_platform.h"
+
+namespace fl {
+
+// Forward declarations. The chipset family types live in fl/channels/config.h,
+// but DefaultBus<Chipset> only needs the type identity, not the layout.
+struct ClocklessChipset;
+struct SpiChipsetConfig;
+
+/// @brief Driver identifier for compile-time bus selection.
+///
+/// The values are deliberately named after the underlying peripheral so a single
+/// identifier (`Bus::RMT`, `Bus::PARLIO`, etc.) flows through both the
+/// template-binding API surface and the runtime registry overrides.
+enum class Bus : fl::u8 {
+    AUTO = 0,        ///< Sentinel: defer to `DefaultBus<Chipset>::value`.
+    RMT,             ///< ESP32 RMT peripheral (all ESP32 variants).
+    PARLIO,          ///< ESP32-P4/C6/H2/C5 parallel I/O peripheral.
+    SPI,             ///< Generic SPI clockless driver.
+    I2S,             ///< ESP32-S3 LCD_CAM via legacy I80 bus (clockless).
+    I2S_SPI,         ///< Original ESP32 native I2S parallel SPI (true SPI chipsets).
+    LCD_RGB,         ///< ESP32-P4 LCD RGB peripheral (parallel clockless).
+    LCD_SPI,         ///< ESP32-S3 LCD_CAM SPI driver (true SPI chipsets).
+    LCD_CLOCKLESS,   ///< ESP32-S3 LCD_CAM clockless driver (replaces misnamed I2S).
+    UART,            ///< ESP32 UART driver via wave8 framing.
+    FLEX_IO,         ///< Teensy 4.x FlexIO2 driver.
+    OBJECT_FLED,     ///< Teensy 4.x ObjectFLED driver.
+    BIT_BANG,        ///< Portable bit-bang fallback driver.
+    STUB,            ///< Native/host/test stub driver.
+};
+
+/// @brief Per-platform default bus for a given chipset family.
+///
+/// Specialize this for each `(platform, Chipset)` pair so that a template
+/// instantiation like `Channel<DefaultBus<ClocklessChipset>::value, ClocklessChipset>`
+/// resolves to the platform's preferred driver without an explicit `Bus` parameter.
+///
+/// Specializations are scoped by platform `FL_IS_*` macros (see
+/// `platforms/is_platform.h`). Platforms without a channel-driver implementation
+/// for a given chipset family intentionally have no specialization, which causes
+/// a clear "incomplete type" compile error if the templated API is called there.
+template<typename Chipset> struct DefaultBus;
+
+// ---------------------------------------------------------------------------
+// Per-platform DefaultBus<Chipset> specializations
+// ---------------------------------------------------------------------------
+//
+// Each specialization sets `value` to the Bus identifier whose driver TU should
+// be linked when the user does not name a bus explicitly. Phase 1 wires up host
+// (stub) only; subsequent phases will add ESP32 / Teensy / etc. as their
+// per-driver `BusTraits` specializations land.
+
+#if defined(FL_IS_STUB) || defined(FL_IS_WASM)
+
+template<> struct DefaultBus<ClocklessChipset> {
+    static constexpr Bus value = Bus::STUB;
+};
+
+template<> struct DefaultBus<SpiChipsetConfig> {
+    static constexpr Bus value = Bus::STUB;
+};
+
+#endif
+
+}  // namespace fl

--- a/src/fl/channels/bus_traits.h
+++ b/src/fl/channels/bus_traits.h
@@ -1,0 +1,47 @@
+#pragma once
+
+/// @file bus_traits.h
+/// @brief Per-driver traits keyed on `fl::Bus`.
+///
+/// Each concrete driver provides a specialization of `BusTraits<Bus::X>`
+/// (typically in a `bus_traits.h` adjacent to the driver header). The
+/// specialization carries:
+///   - `using Driver = ...;`        the concrete driver class.
+///   - `static Driver& instance();` Meyers singleton accessor.
+///   - One or more `BusSupports<Bus::X, Chipset>` `true_type` specializations
+///     declaring which chipset families the driver can handle.
+///
+/// Naming `BusTraits<Bus::X>::instance()` anywhere in the program is what
+/// causes the linker to keep the driver's translation unit. If no template
+/// instantiation references it, the driver TU is dead-stripped. See #2428.
+
+#include "fl/channels/bus.h"
+#include "fl/stl/type_traits.h"
+
+namespace fl {
+
+/// @brief Primary template — intentionally undefined.
+///
+/// Specializations live next to each driver under
+/// `src/platforms/.../<driver>/bus_traits.h`. Naming an unsupported bus value
+/// (e.g. `BusTraits<Bus::PARLIO>::instance()` on a platform without PARLIO)
+/// produces an "implicit instantiation of undefined template" diagnostic.
+template<fl::Bus B> struct BusTraits;
+
+/// @brief Capability check: does bus `B` accept chipset family `Chipset`?
+///
+/// Defaults to `false_type`. Each driver's `bus_traits.h` adds `true_type`
+/// specializations for the chipset families it supports, e.g.
+///
+/// @code
+/// template<> struct BusSupports<Bus::PARLIO, ClocklessChipset> : fl::true_type {};
+/// template<> struct BusSupports<Bus::SPI,    SpiChipsetConfig>  : fl::true_type {};
+/// @endcode
+///
+/// `Channel<B, Chipset>` and `add<B>()` use this in a `static_assert` to reject
+/// nonsense combinations (e.g. driving an SPI chipset over a clockless-only bus)
+/// at compile time rather than at runtime.
+template<fl::Bus B, typename Chipset>
+struct BusSupports : fl::false_type {};
+
+}  // namespace fl

--- a/src/platforms/stub/bus_traits.h
+++ b/src/platforms/stub/bus_traits.h
@@ -1,0 +1,40 @@
+#pragma once
+
+// IWYU pragma: private
+
+/// @file bus_traits.h
+/// @brief `BusTraits<Bus::STUB>` specialization for native/host/test builds.
+///
+/// Phase 1 canary — proves the trait machinery resolves end-to-end on the host
+/// build. The driver implementation lives in
+/// `platforms/stub/clockless_channel_engine_stub.h`.
+
+#include "fl/channels/bus.h"
+#include "fl/channels/bus_traits.h"
+#include "fl/channels/config.h"  // ClocklessChipset
+#include "fl/stl/singleton.h"
+#include "fl/stl/type_traits.h"
+#include "platforms/is_platform.h"
+
+#if defined(FL_IS_STUB) || defined(FL_IS_WASM)
+
+#include "platforms/stub/clockless_channel_engine_stub.h"
+
+namespace fl {
+
+template<> struct BusTraits<Bus::STUB> {
+    using Driver = fl::stub::ClocklessChannelEngineStub;
+
+    /// @brief Singleton accessor — naming this is what links the driver TU.
+    /// Uses SingletonShared so a single instance is shared across DLL boundaries
+    /// (matters on Windows where per-DLL static locals would otherwise diverge).
+    static Driver& instance() FL_NOEXCEPT {
+        return SingletonShared<Driver>::instance();
+    }
+};
+
+template<> struct BusSupports<Bus::STUB, ClocklessChipset> : fl::true_type {};
+
+}  // namespace fl
+
+#endif  // FL_IS_STUB || FL_IS_WASM

--- a/tests/fl/channels/bus_traits.cpp
+++ b/tests/fl/channels/bus_traits.cpp
@@ -1,0 +1,67 @@
+/// @file bus_traits.cpp
+/// @brief Phase 1 sanity test for fl::Bus + BusTraits foundational types.
+///
+/// Verifies that the new compile-time bus identifier and per-driver trait
+/// machinery resolves cleanly on the host build, and that the stub canary
+/// specialization satisfies the chipset-capability contract.
+///
+/// See issue #2428.
+
+#include "fl/channels/bus.h"
+#include "fl/channels/bus_traits.h"
+#include "fl/channels/config.h"  // ClocklessChipset, SpiChipsetConfig
+#include "fl/channels/driver.h"  // IChannelDriver
+#include "fl/stl/stdint.h"
+#include "fl/stl/string.h"
+#include "platforms/is_platform.h"
+#include "platforms/stub/bus_traits.h"
+#include "test.h"
+
+FL_TEST_FILE(FL_FILEPATH) {
+
+using namespace fl;
+
+// Compile-time invariants — these enforce the design at the type system level.
+// Failure to compile these is a Phase 1 regression.
+
+FL_STATIC_ASSERT(static_cast<fl::u8>(fl::Bus::AUTO) == 0,
+                 "Bus::AUTO must be the zero/default sentinel");
+FL_STATIC_ASSERT(static_cast<fl::u8>(fl::Bus::RMT) != static_cast<fl::u8>(fl::Bus::PARLIO),
+                 "Bus enum values must be distinct");
+FL_STATIC_ASSERT(sizeof(fl::Bus) == 1,
+                 "Bus underlying type should be u8 to keep ChannelOptions cheap");
+
+// DefaultBus<Chipset> resolves on the host (FL_IS_STUB is set under tests).
+FL_STATIC_ASSERT(fl::DefaultBus<fl::ClocklessChipset>::value == fl::Bus::STUB,
+                 "Host default clockless bus should be STUB");
+FL_STATIC_ASSERT(fl::DefaultBus<fl::SpiChipsetConfig>::value == fl::Bus::STUB,
+                 "Host default SPI bus should be STUB");
+
+// Capability traits: BusSupports defaults to false_type for unknown pairs and is
+// true_type for the stub clockless specialization.
+FL_STATIC_ASSERT(fl::BusSupports<fl::Bus::STUB, fl::ClocklessChipset>::value,
+                 "Stub bus must support clockless chipsets");
+FL_STATIC_ASSERT(!fl::BusSupports<fl::Bus::STUB, fl::SpiChipsetConfig>::value,
+                 "Stub bus does not (yet) support SPI chipsets");
+FL_STATIC_ASSERT(!fl::BusSupports<fl::Bus::RMT, fl::SpiChipsetConfig>::value,
+                 "Bus values without specializations must default to false_type");
+
+FL_TEST_CASE("BusTraits<Bus::STUB>::instance returns a stable singleton") {
+    auto& a = fl::BusTraits<fl::Bus::STUB>::instance();
+    auto& b = fl::BusTraits<fl::Bus::STUB>::instance();
+    FL_CHECK(&a == &b);
+}
+
+FL_TEST_CASE("BusTraits<Bus::STUB>::Driver implements IChannelDriver contract") {
+    using Driver = fl::BusTraits<fl::Bus::STUB>::Driver;
+    fl::IChannelDriver* iface = &fl::BusTraits<fl::Bus::STUB>::instance();
+    FL_REQUIRE(iface != nullptr);
+    FL_CHECK(iface->getName() == fl::string::from_literal("STUB"));
+    FL_CHECK(iface->getCapabilities().supportsClockless);
+    FL_CHECK_FALSE(iface->getCapabilities().supportsSpi);
+    // Cast back to concrete type to exercise the alias.
+    Driver* concrete = static_cast<Driver*>(iface);
+    FL_CHECK(concrete != nullptr);
+}
+
+}  // FL_TEST_FILE


### PR DESCRIPTION
## Summary

Phase 1 of the compile-time channel-bus binding work tracked in #2428. Purely additive foundation: introduces `fl::Bus`, `BusTraits<B>`, `BusSupports<B, Chipset>`, and `DefaultBus<Chipset>`. No existing code changes; no behavior changes.

## What's in this PR

- `src/fl/channels/bus.h` - `enum class Bus : fl::u8` with values for every planned driver (RMT, PARLIO, SPI, I2S, I2S_SPI, LCD_RGB, LCD_SPI, LCD_CLOCKLESS, UART, FLEX_IO, OBJECT_FLED, BIT_BANG, STUB) plus `Bus::AUTO` sentinel for `DefaultBus<Chipset>::value` resolution. Includes host-only `DefaultBus<ClocklessChipset>` / `DefaultBus<SpiChipsetConfig>` specializations -> `Bus::STUB`.
- `src/fl/channels/bus_traits.h` - `BusTraits<B>` primary template (undefined, so naming an unsupported bus is a compile error) and `BusSupports<B, Chipset>` capability trait (default `false_type`).
- `src/platforms/stub/bus_traits.h` - canary `BusTraits<Bus::STUB>` specialization wired to `ClocklessChannelEngineStub` via `SingletonShared<Driver>` (cross-DLL safe).
- `tests/fl/channels/bus_traits.cpp` - compile-time invariants via `FL_STATIC_ASSERT` plus runtime checks of the singleton + `IChannelDriver` contract.

## Why

NEOPIXEL-only ESP32-S3 sketches grew **344 KB → 783 KB** between 3.10.3 and master because every driver self-registers with `ChannelManager` via `IChannelDriver` virtual dispatch, defeating `--gc-sections`. See #2421 (root cause), #2420 (original report), #2406 (Teensy form), #2167 (channel API templating ask).

This phase lays the type-system foundation. Drivers will only link when their `Bus` value is named — that mechanism (templated `Channel<B, Chipset>` + `add<Bus>(cfg)` + `enableDrivers<Bus...>()`) lands in subsequent PRs (Phases 2-5).

## Verification

- `bash lint` clean.
- `bash test bus_traits` passes (1/1).
- `bash test --cpp` passes (303/303) — additive change does not regress.
- C++11 idioms throughout (`FL_STATIC_ASSERT`, `fl::true_type`/`false_type`, `fl::is_same<>::value`) per project floor in `meson.build:5`.

## Test plan

- [x] Phase 1 unit test exercises the trait machinery on the host build.
- [x] Full host suite green.
- [ ] Phase 2 will add per-driver `BusTraits` specializations across ESP32 and Teensy 4.x and verify on those targets.

## Related

- Tracked in #2428.
- Root cause: #2421, #2420.
- Adjacent: #2406 (Teensy DMA buffer overflow), #2167 (channel API template request), #2424 (closed - cross-TU cleanup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added foundational LED channel bus transmission infrastructure with support for multiple hardware bus types (RMT, PARLIO, SPI, I2S, LCD, UART, and others).
  * Implemented platform-specific and chipset-specific bus driver traits for hardware abstraction and driver registry enrollment.
  * Added comprehensive compile-time and runtime tests for bus infrastructure.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/FastLED/pull/2429)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->