### PR TITLE
feat(channels): per-driver BusTraits specializations + DefaultBus (Phase 2 of #2428)

### DIFF
--- a/src/fl/channels/bus.h
+++ b/src/fl/channels/bus.h
@@ -61,9 +61,7 @@ template<typename Chipset> struct DefaultBus;
 // ---------------------------------------------------------------------------
 //
 // Each specialization sets `value` to the Bus identifier whose driver TU should
-// be linked when the user does not name a bus explicitly. Phase 1 wires up host
-// (stub) only; subsequent phases will add ESP32 / Teensy / etc. as their
-// per-driver `BusTraits` specializations land.
+// be linked when the user does not name a bus explicitly.
 
 #if defined(FL_IS_STUB) || defined(FL_IS_WASM)
 
@@ -74,6 +72,44 @@ template<> struct DefaultBus<ClocklessChipset> {
 template<> struct DefaultBus<SpiChipsetConfig> {
     static constexpr Bus value = Bus::STUB;
 };
+
+#elif defined(FL_IS_ESP32)
+
+// ESP32-P4 / C6 / H2 / C5 -- PARLIO is the highest-priority clockless driver.
+// ESP32-dev / S2 / S3 -- RMT is the recommended clockless default.
+// Mirrors the priority order used by channel_manager_esp32.cpp.hpp.
+#if defined(FL_IS_ESP_32P4) || defined(FL_IS_ESP_32C6) || \
+    defined(FL_IS_ESP_32H2) || defined(FL_IS_ESP_32C5)
+template<> struct DefaultBus<ClocklessChipset> {
+    static constexpr Bus value = Bus::PARLIO;
+};
+#else
+template<> struct DefaultBus<ClocklessChipset> {
+    static constexpr Bus value = Bus::RMT;
+};
+#endif
+
+// True SPI chipsets (APA102, SK9822, HD108): pick the platform-native parallel
+// SPI driver. ESP32-S3 uses LCD_SPI; original ESP32 uses I2S_SPI; other variants
+// are intentionally undefined so users get a clear "specify Bus::X explicitly"
+// error rather than a silent wrong default.
+#if defined(FL_IS_ESP_32S3)
+template<> struct DefaultBus<SpiChipsetConfig> {
+    static constexpr Bus value = Bus::LCD_SPI;
+};
+#elif defined(FL_IS_ESP_32DEV)
+template<> struct DefaultBus<SpiChipsetConfig> {
+    static constexpr Bus value = Bus::I2S_SPI;
+};
+#endif
+
+#elif defined(FL_IS_TEENSY_4X)
+
+template<> struct DefaultBus<ClocklessChipset> {
+    static constexpr Bus value = Bus::OBJECT_FLED;
+};
+// SpiChipsetConfig default for Teensy 4.x is intentionally unspecified -- users
+// pick explicitly between Bus::BIT_BANG and any future hardware-SPI bus.
 
 #endif
 

--- a/src/platforms/arm/teensy/teensy4_common/drivers/flexio/_build.cpp.hpp
+++ b/src/platforms/arm/teensy/teensy4_common/drivers/flexio/_build.cpp.hpp
@@ -5,3 +5,6 @@
 
 #include "platforms/arm/teensy/teensy4_common/drivers/flexio/channel_engine_flexio.cpp.hpp"
 #include "platforms/arm/teensy/teensy4_common/drivers/flexio/flexio_driver.cpp.hpp"
+
+// BusTraits<Bus::FLEX_IO> specialization.
+#include "platforms/arm/teensy/teensy4_common/drivers/flexio/bus_traits.h"

--- a/src/platforms/arm/teensy/teensy4_common/drivers/flexio/bus_traits.h
+++ b/src/platforms/arm/teensy/teensy4_common/drivers/flexio/bus_traits.h
@@ -1,0 +1,35 @@
+#pragma once
+
+// IWYU pragma: private
+
+/// @file bus_traits.h
+/// @brief BusTraits<Bus::FLEX_IO> specialization for Teensy 4.x FlexIO2 driver.
+
+#include "fl/stl/compiler_control.h"
+#include "platforms/is_platform.h"
+
+#if defined(FL_IS_TEENSY_4X)
+
+#include "fl/channels/bus.h"
+#include "fl/channels/bus_traits.h"
+#include "fl/channels/config.h"
+#include "fl/stl/shared_ptr.h"
+#include "fl/stl/type_traits.h"
+#include "platforms/arm/teensy/teensy4_common/drivers/flexio/channel_engine_flexio.h"
+
+namespace fl {
+
+template<> struct BusTraits<Bus::FLEX_IO> {
+    using Driver = ChannelEngineFlexIO;
+
+    static Driver& instance() FL_NOEXCEPT {
+        static fl::shared_ptr<Driver> gHolder = fl::make_shared<Driver>();
+        return *gHolder;
+    }
+};
+
+template<> struct BusSupports<Bus::FLEX_IO, ClocklessChipset> : fl::true_type {};
+
+}  // namespace fl
+
+#endif  // FL_IS_TEENSY_4X

--- a/src/platforms/arm/teensy/teensy4_common/drivers/objectfled/_build.cpp.hpp
+++ b/src/platforms/arm/teensy/teensy4_common/drivers/objectfled/_build.cpp.hpp
@@ -5,3 +5,6 @@
 
 #include "platforms/arm/teensy/teensy4_common/drivers/objectfled/channel_engine_objectfled.cpp.hpp"
 #include "platforms/arm/teensy/teensy4_common/drivers/objectfled/objectfled_peripheral_real.cpp.hpp"
+
+// BusTraits<Bus::OBJECT_FLED> specialization.
+#include "platforms/arm/teensy/teensy4_common/drivers/objectfled/bus_traits.h"

--- a/src/platforms/arm/teensy/teensy4_common/drivers/objectfled/bus_traits.h
+++ b/src/platforms/arm/teensy/teensy4_common/drivers/objectfled/bus_traits.h
@@ -1,0 +1,35 @@
+#pragma once
+
+// IWYU pragma: private
+
+/// @file bus_traits.h
+/// @brief BusTraits<Bus::OBJECT_FLED> specialization for Teensy 4.x ObjectFLED.
+
+#include "fl/stl/compiler_control.h"
+#include "platforms/is_platform.h"
+
+#if defined(FL_IS_TEENSY_4X)
+
+#include "fl/channels/bus.h"
+#include "fl/channels/bus_traits.h"
+#include "fl/channels/config.h"
+#include "fl/stl/shared_ptr.h"
+#include "fl/stl/type_traits.h"
+#include "platforms/arm/teensy/teensy4_common/drivers/objectfled/channel_engine_objectfled.h"
+
+namespace fl {
+
+template<> struct BusTraits<Bus::OBJECT_FLED> {
+    using Driver = ChannelEngineObjectFLED;
+
+    static Driver& instance() FL_NOEXCEPT {
+        static fl::shared_ptr<Driver> gHolder = fl::make_shared<Driver>();
+        return *gHolder;
+    }
+};
+
+template<> struct BusSupports<Bus::OBJECT_FLED, ClocklessChipset> : fl::true_type {};
+
+}  // namespace fl
+
+#endif  // FL_IS_TEENSY_4X

--- a/src/platforms/esp/32/drivers/i2s/_build.cpp.hpp
+++ b/src/platforms/esp/32/drivers/i2s/_build.cpp.hpp
@@ -12,3 +12,6 @@
 #include "platforms/esp/32/drivers/i2s/i2s_lcd_cam_peripheral_mock.cpp.hpp"
 
 #include "platforms/esp/32/drivers/i2s/wave8_encoder_i2s.cpp.hpp"
+
+// BusTraits<Bus::I2S> specialization.
+#include "platforms/esp/32/drivers/i2s/bus_traits.h"

--- a/src/platforms/esp/32/drivers/i2s/bus_traits.h
+++ b/src/platforms/esp/32/drivers/i2s/bus_traits.h
@@ -1,0 +1,47 @@
+#pragma once
+
+// IWYU pragma: private
+
+/// @file bus_traits.h
+/// @brief BusTraits<Bus::I2S> specialization for ESP32-S3 LCD_CAM (I2S mode).
+///
+/// Confusing legacy name: this driver uses the LCD_CAM peripheral in I2S mode
+/// to drive clockless LED strips on ESP32-S3. The "I2S" name is retained here
+/// for backward compatibility — the actual modern S3 clockless LCD_CAM driver
+/// lives at `Bus::LCD_CLOCKLESS`.
+
+#include "fl/stl/compiler_control.h"
+#include "platforms/is_platform.h"
+
+#if defined(FL_IS_ESP32)
+#include "platforms/esp/32/feature_flags/enabled.h"
+#endif
+
+#if defined(FL_IS_ESP32) && FASTLED_ESP32_HAS_I2S_LCD_CAM
+
+#include "fl/channels/bus.h"
+#include "fl/channels/bus_traits.h"
+#include "fl/channels/config.h"
+#include "fl/channels/driver.h"
+#include "fl/stl/shared_ptr.h"
+#include "fl/stl/type_traits.h"
+#include "platforms/esp/32/drivers/i2s/channel_driver_i2s.h"
+
+namespace fl {
+
+// createI2sEngine() is declared in channel_driver_i2s.h (included above).
+
+template<> struct BusTraits<Bus::I2S> {
+    using Driver = IChannelDriver;  // factory returns abstract base
+
+    static Driver& instance() FL_NOEXCEPT {
+        static fl::shared_ptr<Driver> gHolder = createI2sEngine();
+        return *gHolder;
+    }
+};
+
+template<> struct BusSupports<Bus::I2S, ClocklessChipset> : fl::true_type {};
+
+}  // namespace fl
+
+#endif  // FL_IS_ESP32 && FASTLED_ESP32_HAS_I2S_LCD_CAM

--- a/src/platforms/esp/32/drivers/i2s_spi/_build.cpp.hpp
+++ b/src/platforms/esp/32/drivers/i2s_spi/_build.cpp.hpp
@@ -6,3 +6,6 @@
 #include "platforms/esp/32/drivers/i2s_spi/channel_driver_i2s_spi.cpp.hpp"
 #include "platforms/esp/32/drivers/i2s_spi/i2s_spi_peripheral_esp.cpp.hpp"
 #include "platforms/esp/32/drivers/i2s_spi/i2s_spi_peripheral_mock.cpp.hpp"
+
+// BusTraits<Bus::I2S_SPI> specialization.
+#include "platforms/esp/32/drivers/i2s_spi/bus_traits.h"

--- a/src/platforms/esp/32/drivers/i2s_spi/bus_traits.h
+++ b/src/platforms/esp/32/drivers/i2s_spi/bus_traits.h
@@ -1,0 +1,45 @@
+#pragma once
+
+// IWYU pragma: private
+
+/// @file bus_traits.h
+/// @brief BusTraits<Bus::I2S_SPI> for ESP32-dev native I2S parallel SPI.
+///
+/// Drives true SPI chipsets (APA102, SK9822, HD108) via the original ESP32's
+/// I2S parallel mode. ESP32-S3 uses Bus::LCD_SPI instead.
+
+#include "fl/stl/compiler_control.h"
+#include "platforms/is_platform.h"
+
+#if defined(FL_IS_ESP32)
+#include "platforms/esp/32/feature_flags/enabled.h"
+#endif
+
+#if defined(FL_IS_ESP32) && FASTLED_ESP32_HAS_I2S
+
+#include "fl/channels/bus.h"
+#include "fl/channels/bus_traits.h"
+#include "fl/channels/config.h"
+#include "fl/channels/driver.h"
+#include "fl/stl/shared_ptr.h"
+#include "fl/stl/type_traits.h"
+#include "platforms/esp/32/drivers/i2s_spi/channel_driver_i2s_spi.h"
+
+namespace fl {
+
+// createI2sSpiEngine() is declared in channel_driver_i2s_spi.h (included above).
+
+template<> struct BusTraits<Bus::I2S_SPI> {
+    using Driver = IChannelDriver;
+
+    static Driver& instance() FL_NOEXCEPT {
+        static fl::shared_ptr<Driver> gHolder = createI2sSpiEngine();
+        return *gHolder;
+    }
+};
+
+template<> struct BusSupports<Bus::I2S_SPI, SpiChipsetConfig> : fl::true_type {};
+
+}  // namespace fl
+
+#endif  // FL_IS_ESP32 && FASTLED_ESP32_HAS_I2S

--- a/src/platforms/esp/32/drivers/lcd_cam/_build.cpp.hpp
+++ b/src/platforms/esp/32/drivers/lcd_cam/_build.cpp.hpp
@@ -7,3 +7,6 @@
 #include "platforms/esp/32/drivers/lcd_cam/channel_driver_lcd_rgb.cpp.hpp"
 #include "platforms/esp/32/drivers/lcd_cam/lcd_rgb_peripheral_esp.cpp.hpp"
 #include "platforms/esp/32/drivers/lcd_cam/lcd_rgb_peripheral_mock.cpp.hpp"
+
+// BusTraits<Bus::LCD_RGB> specialization.
+#include "platforms/esp/32/drivers/lcd_cam/bus_traits.h"

--- a/src/platforms/esp/32/drivers/lcd_cam/bus_traits.h
+++ b/src/platforms/esp/32/drivers/lcd_cam/bus_traits.h
@@ -1,0 +1,42 @@
+#pragma once
+
+// IWYU pragma: private
+
+/// @file bus_traits.h
+/// @brief BusTraits<Bus::LCD_RGB> specialization for ESP32-P4 RGB LCD driver.
+
+#include "fl/stl/compiler_control.h"
+#include "platforms/is_platform.h"
+
+#if defined(FL_IS_ESP32)
+#include "platforms/esp/32/feature_flags/enabled.h"
+#endif
+
+#if defined(FL_IS_ESP32) && FASTLED_ESP32_HAS_LCD_RGB
+
+#include "fl/channels/bus.h"
+#include "fl/channels/bus_traits.h"
+#include "fl/channels/config.h"
+#include "fl/channels/driver.h"
+#include "fl/stl/shared_ptr.h"
+#include "fl/stl/type_traits.h"
+#include "platforms/esp/32/drivers/lcd_cam/channel_driver_lcd_rgb.h"
+
+namespace fl {
+
+// createLcdRgbEngine() is declared in channel_driver_lcd_rgb.h (included above).
+
+template<> struct BusTraits<Bus::LCD_RGB> {
+    using Driver = IChannelDriver;
+
+    static Driver& instance() FL_NOEXCEPT {
+        static fl::shared_ptr<Driver> gHolder = createLcdRgbEngine();
+        return *gHolder;
+    }
+};
+
+template<> struct BusSupports<Bus::LCD_RGB, ClocklessChipset> : fl::true_type {};
+
+}  // namespace fl
+
+#endif  // FL_IS_ESP32 && FASTLED_ESP32_HAS_LCD_RGB

--- a/src/platforms/esp/32/drivers/lcd_spi/_build.cpp.hpp
+++ b/src/platforms/esp/32/drivers/lcd_spi/_build.cpp.hpp
@@ -7,3 +7,6 @@
 #include "platforms/esp/32/drivers/lcd_spi/channel_driver_lcd_spi.cpp.hpp"
 #include "platforms/esp/32/drivers/lcd_spi/lcd_spi_peripheral_esp.cpp.hpp"
 #include "platforms/esp/32/drivers/lcd_spi/lcd_spi_peripheral_mock.cpp.hpp"
+
+// BusTraits<Bus::LCD_SPI> + BusTraits<Bus::LCD_CLOCKLESS> specializations.
+#include "platforms/esp/32/drivers/lcd_spi/bus_traits.h"

--- a/src/platforms/esp/32/drivers/lcd_spi/bus_traits.h
+++ b/src/platforms/esp/32/drivers/lcd_spi/bus_traits.h
@@ -1,0 +1,60 @@
+#pragma once
+
+// IWYU pragma: private
+
+/// @file bus_traits.h
+/// @brief BusTraits<Bus::LCD_SPI> + BusTraits<Bus::LCD_CLOCKLESS> for ESP32-S3.
+///
+/// Both buses share the LCD_CAM I80 peripheral on ESP32-S3 — LCD_SPI drives
+/// true SPI chipsets (APA102 etc.) and LCD_CLOCKLESS drives clockless chipsets
+/// (WS2812 etc.). They live in the same header because they share the same
+/// `FASTLED_ESP32_HAS_LCD_SPI` feature flag and platform.
+
+#include "fl/stl/compiler_control.h"
+#include "platforms/is_platform.h"
+
+#if defined(FL_IS_ESP32)
+#include "platforms/esp/32/feature_flags/enabled.h"
+#endif
+
+#if defined(FL_IS_ESP32) && FASTLED_ESP32_HAS_LCD_SPI
+
+#include "fl/channels/bus.h"
+#include "fl/channels/bus_traits.h"
+#include "fl/channels/config.h"
+#include "fl/channels/driver.h"
+#include "fl/stl/shared_ptr.h"
+#include "fl/stl/type_traits.h"
+#include "platforms/esp/32/drivers/lcd_spi/channel_driver_lcd_clockless.h"
+#include "platforms/esp/32/drivers/lcd_spi/channel_driver_lcd_spi.h"
+
+namespace fl {
+
+// createLcdSpiEngine() and createLcdClocklessEngine() are declared in the
+// driver headers included above.
+
+template<> struct BusTraits<Bus::LCD_SPI> {
+    using Driver = IChannelDriver;
+
+    static Driver& instance() FL_NOEXCEPT {
+        static fl::shared_ptr<Driver> gHolder = createLcdSpiEngine();
+        return *gHolder;
+    }
+};
+
+template<> struct BusSupports<Bus::LCD_SPI, SpiChipsetConfig> : fl::true_type {};
+
+template<> struct BusTraits<Bus::LCD_CLOCKLESS> {
+    using Driver = IChannelDriver;
+
+    static Driver& instance() FL_NOEXCEPT {
+        static fl::shared_ptr<Driver> gHolder = createLcdClocklessEngine();
+        return *gHolder;
+    }
+};
+
+template<> struct BusSupports<Bus::LCD_CLOCKLESS, ClocklessChipset> : fl::true_type {};
+
+}  // namespace fl
+
+#endif  // FL_IS_ESP32 && FASTLED_ESP32_HAS_LCD_SPI

--- a/src/platforms/esp/32/drivers/parlio/_build.cpp.hpp
+++ b/src/platforms/esp/32/drivers/parlio/_build.cpp.hpp
@@ -8,3 +8,6 @@
 #include "platforms/esp/32/drivers/parlio/parlio_engine.cpp.hpp"
 #include "platforms/esp/32/drivers/parlio/parlio_peripheral_esp.cpp.hpp"
 #include "platforms/esp/32/drivers/parlio/parlio_peripheral_mock.cpp.hpp"
+
+// BusTraits<Bus::PARLIO> specialization.
+#include "platforms/esp/32/drivers/parlio/bus_traits.h"

--- a/src/platforms/esp/32/drivers/parlio/bus_traits.h
+++ b/src/platforms/esp/32/drivers/parlio/bus_traits.h
@@ -1,0 +1,39 @@
+#pragma once
+
+// IWYU pragma: private
+
+/// @file bus_traits.h
+/// @brief BusTraits<Bus::PARLIO> specialization for ESP32-P4/C6/H2/C5.
+
+#include "fl/stl/compiler_control.h"
+#include "platforms/is_platform.h"
+
+#if defined(FL_IS_ESP32)
+#include "platforms/esp/32/feature_flags/enabled.h"
+#endif
+
+#if defined(FL_IS_ESP32) && FASTLED_ESP32_HAS_PARLIO
+
+#include "fl/channels/bus.h"
+#include "fl/channels/bus_traits.h"
+#include "fl/channels/config.h"
+#include "fl/stl/shared_ptr.h"
+#include "fl/stl/type_traits.h"
+#include "platforms/esp/32/drivers/parlio/channel_driver_parlio.h"
+
+namespace fl {
+
+template<> struct BusTraits<Bus::PARLIO> {
+    using Driver = ChannelDriverPARLIO;
+
+    static Driver& instance() FL_NOEXCEPT {
+        static fl::shared_ptr<Driver> gHolder = fl::make_shared<Driver>();
+        return *gHolder;
+    }
+};
+
+template<> struct BusSupports<Bus::PARLIO, ClocklessChipset> : fl::true_type {};
+
+}  // namespace fl
+
+#endif  // FL_IS_ESP32 && FASTLED_ESP32_HAS_PARLIO

--- a/src/platforms/esp/32/drivers/rmt/rmt_4/_build.cpp.hpp
+++ b/src/platforms/esp/32/drivers/rmt/rmt_4/_build.cpp.hpp
@@ -5,3 +5,6 @@
 /// Includes all implementation files in alphabetical order
 
 #include "platforms/esp/32/drivers/rmt/rmt_4/channel_driver_rmt4.cpp.hpp"
+
+// BusTraits<Bus::RMT> specialization (RMT4 path, mutually exclusive with RMT5).
+#include "platforms/esp/32/drivers/rmt/rmt_4/bus_traits.h"

--- a/src/platforms/esp/32/drivers/rmt/rmt_4/bus_traits.h
+++ b/src/platforms/esp/32/drivers/rmt/rmt_4/bus_traits.h
@@ -1,0 +1,44 @@
+#pragma once
+
+// IWYU pragma: private
+
+/// @file bus_traits.h
+/// @brief BusTraits<Bus::RMT> specialization for the ESP-IDF 4.x RMT4 driver.
+///
+/// Mutually exclusive with the RMT5 specialization in
+/// `platforms/esp/32/drivers/rmt/rmt_5/bus_traits.h` — the platform's
+/// `FASTLED_RMT5` flag determines which TU compiles, so only one definition
+/// is ever produced for `BusTraits<Bus::RMT>`.
+
+#include "fl/stl/compiler_control.h"
+#include "platforms/is_platform.h"
+
+#if defined(FL_IS_ESP32)
+#include "platforms/esp/32/feature_flags/enabled.h"
+#endif
+
+#if defined(FL_IS_ESP32) && FASTLED_ESP32_HAS_RMT && !FASTLED_ESP32_RMT5_ONLY_PLATFORM && !FASTLED_RMT5
+
+#include "fl/channels/bus.h"
+#include "fl/channels/bus_traits.h"
+#include "fl/channels/config.h"
+#include "fl/stl/shared_ptr.h"
+#include "fl/stl/type_traits.h"
+#include "platforms/esp/32/drivers/rmt/rmt_4/channel_driver_rmt4.h"
+
+namespace fl {
+
+template<> struct BusTraits<Bus::RMT> {
+    using Driver = ChannelEngineRMT4;
+
+    static Driver& instance() FL_NOEXCEPT {
+        static fl::shared_ptr<Driver> gHolder = ChannelEngineRMT4::create();
+        return *gHolder;
+    }
+};
+
+template<> struct BusSupports<Bus::RMT, ClocklessChipset> : fl::true_type {};
+
+}  // namespace fl
+
+#endif  // FL_IS_ESP32 && FASTLED_ESP32_HAS_RMT && RMT4 path

--- a/src/platforms/esp/32/drivers/rmt/rmt_5/_build.cpp.hpp
+++ b/src/platforms/esp/32/drivers/rmt/rmt_5/_build.cpp.hpp
@@ -11,3 +11,6 @@
 #include "platforms/esp/32/drivers/rmt/rmt_5/rmt5_controller_lowlevel.cpp.hpp"
 #include "platforms/esp/32/drivers/rmt/rmt_5/rmt5_peripheral_esp.cpp.hpp"
 #include "platforms/esp/32/drivers/rmt/rmt_5/rmt_memory_manager.cpp.hpp"
+
+// BusTraits<Bus::RMT> specialization (header-only, included for parse + ODR-keep).
+#include "platforms/esp/32/drivers/rmt/rmt_5/bus_traits.h"

--- a/src/platforms/esp/32/drivers/rmt/rmt_5/bus_traits.h
+++ b/src/platforms/esp/32/drivers/rmt/rmt_5/bus_traits.h
@@ -1,0 +1,40 @@
+#pragma once
+
+// IWYU pragma: private
+
+/// @file bus_traits.h
+/// @brief BusTraits<Bus::RMT> specialization for the ESP-IDF 5.x RMT5 driver.
+
+#include "fl/stl/compiler_control.h"
+#include "platforms/is_platform.h"
+
+#if defined(FL_IS_ESP32)
+#include "platforms/esp/32/feature_flags/enabled.h"
+#endif
+
+#if defined(FL_IS_ESP32) && FASTLED_ESP32_HAS_RMT && (FASTLED_ESP32_RMT5_ONLY_PLATFORM || FASTLED_RMT5)
+
+#include "fl/channels/bus.h"
+#include "fl/channels/bus_traits.h"
+#include "fl/channels/config.h"
+#include "fl/stl/shared_ptr.h"
+#include "fl/stl/type_traits.h"
+#include "platforms/esp/32/drivers/rmt/rmt_5/channel_driver_rmt.h"
+
+namespace fl {
+
+template<> struct BusTraits<Bus::RMT> {
+    using Driver = ChannelEngineRMT;
+
+    /// @brief Lazy singleton — naming this is what links the RMT5 TU.
+    static Driver& instance() FL_NOEXCEPT {
+        static fl::shared_ptr<Driver> gHolder = ChannelEngineRMT::create();
+        return *gHolder;
+    }
+};
+
+template<> struct BusSupports<Bus::RMT, ClocklessChipset> : fl::true_type {};
+
+}  // namespace fl
+
+#endif  // FL_IS_ESP32 && FASTLED_ESP32_HAS_RMT && RMT5 path

--- a/src/platforms/esp/32/drivers/spi/_build.cpp.hpp
+++ b/src/platforms/esp/32/drivers/spi/_build.cpp.hpp
@@ -9,3 +9,6 @@
 #include "platforms/esp/32/drivers/spi/spi_hw_1_esp32.cpp.hpp"
 #include "platforms/esp/32/drivers/spi/spi_peripheral_esp.cpp.hpp"
 #include "platforms/esp/32/drivers/spi/spi_platform_esp32.cpp.hpp"
+
+// BusTraits<Bus::SPI> specialization.
+#include "platforms/esp/32/drivers/spi/bus_traits.h"

--- a/src/platforms/esp/32/drivers/spi/bus_traits.h
+++ b/src/platforms/esp/32/drivers/spi/bus_traits.h
@@ -1,0 +1,44 @@
+#pragma once
+
+// IWYU pragma: private
+
+/// @file bus_traits.h
+/// @brief BusTraits<Bus::SPI> specialization for the clockless-over-SPI driver.
+///
+/// Despite the bus name, this driver implements clockless protocols (WS2812,
+/// SK6812, etc.) using SPI hardware as a precise bit-pulse generator. It does
+/// NOT drive true SPI chipsets like APA102 (those go through Bus::I2S_SPI on
+/// ESP32-dev or Bus::LCD_SPI on ESP32-S3).
+
+#include "fl/stl/compiler_control.h"
+#include "platforms/is_platform.h"
+
+#if defined(FL_IS_ESP32)
+#include "platforms/esp/32/feature_flags/enabled.h"
+#endif
+
+#if defined(FL_IS_ESP32) && FASTLED_ESP32_HAS_CLOCKLESS_SPI
+
+#include "fl/channels/bus.h"
+#include "fl/channels/bus_traits.h"
+#include "fl/channels/config.h"
+#include "fl/stl/shared_ptr.h"
+#include "fl/stl/type_traits.h"
+#include "platforms/esp/32/drivers/spi/channel_driver_spi.h"
+
+namespace fl {
+
+template<> struct BusTraits<Bus::SPI> {
+    using Driver = ChannelEngineSpi;
+
+    static Driver& instance() FL_NOEXCEPT {
+        static fl::shared_ptr<Driver> gHolder = fl::make_shared<Driver>();
+        return *gHolder;
+    }
+};
+
+template<> struct BusSupports<Bus::SPI, ClocklessChipset> : fl::true_type {};
+
+}  // namespace fl
+
+#endif  // FL_IS_ESP32 && FASTLED_ESP32_HAS_CLOCKLESS_SPI

--- a/src/platforms/esp/32/drivers/uart/_build.cpp.hpp
+++ b/src/platforms/esp/32/drivers/uart/_build.cpp.hpp
@@ -7,3 +7,6 @@
 #include "platforms/esp/32/drivers/uart/channel_driver_uart.cpp.hpp"
 #include "platforms/esp/32/drivers/uart/uart_peripheral_esp.cpp.hpp"
 #include "platforms/esp/32/drivers/uart/wave8_encoder_uart.cpp.hpp"
+
+// BusTraits<Bus::UART> specialization.
+#include "platforms/esp/32/drivers/uart/bus_traits.h"

--- a/src/platforms/esp/32/drivers/uart/bus_traits.h
+++ b/src/platforms/esp/32/drivers/uart/bus_traits.h
@@ -1,0 +1,49 @@
+#pragma once
+
+// IWYU pragma: private
+
+/// @file bus_traits.h
+/// @brief BusTraits<Bus::UART> specialization for the ESP32 UART wave8 driver.
+
+#include "fl/stl/compiler_control.h"
+#include "platforms/is_platform.h"
+
+#if defined(FL_IS_ESP32)
+#include "platforms/esp/32/feature_flags/enabled.h"
+#endif
+
+#if defined(FL_IS_ESP32) && FASTLED_ESP32_HAS_UART
+
+#include "fl/channels/bus.h"
+#include "fl/channels/bus_traits.h"
+#include "fl/channels/config.h"
+#include "fl/stl/shared_ptr.h"
+#include "fl/stl/type_traits.h"
+#include "platforms/esp/32/drivers/uart/channel_driver_uart.h"
+#include "platforms/esp/32/drivers/uart/uart_peripheral_esp.h"
+
+namespace fl {
+
+template<> struct BusTraits<Bus::UART> {
+    using Driver = ChannelEngineUART;
+
+    /// @brief Constructs the UART peripheral and driver lazily on first call.
+    /// Holding both shared_ptrs in a single struct keeps their lifetimes paired.
+    static Driver& instance() FL_NOEXCEPT {
+        struct Holder {
+            fl::shared_ptr<UartPeripheralEsp> peripheral;
+            fl::shared_ptr<Driver> driver;
+            Holder() FL_NOEXCEPT
+                : peripheral(fl::make_shared<UartPeripheralEsp>()),
+                  driver(fl::make_shared<Driver>(peripheral)) {}
+        };
+        static Holder gHolder;
+        return *gHolder.driver;
+    }
+};
+
+template<> struct BusSupports<Bus::UART, ClocklessChipset> : fl::true_type {};
+
+}  // namespace fl
+
+#endif  // FL_IS_ESP32 && FASTLED_ESP32_HAS_UART

--- a/src/platforms/shared/bitbang/_build.cpp.hpp
+++ b/src/platforms/shared/bitbang/_build.cpp.hpp
@@ -4,3 +4,6 @@
 /// @brief Unity build header for platforms/shared/bitbang/ directory
 
 #include "platforms/shared/bitbang/bitbang_channel_driver.cpp.hpp"
+
+// BusTraits<Bus::BIT_BANG> specialization.
+#include "platforms/shared/bitbang/bus_traits.h"

--- a/src/platforms/shared/bitbang/bus_traits.h
+++ b/src/platforms/shared/bitbang/bus_traits.h
@@ -1,0 +1,34 @@
+#pragma once
+
+// IWYU pragma: private
+
+/// @file bus_traits.h
+/// @brief BusTraits<Bus::BIT_BANG> specialization for the portable bit-bang driver.
+///
+/// `BitBangChannelDriver` is the universal fallback — any platform with GPIO
+/// can drive both clockless and SPI LED strips by bit-banging. Supports up to
+/// 8 parallel pins via `DigitalMultiWrite8`.
+
+#include "fl/stl/compiler_control.h"
+#include "fl/channels/bus.h"
+#include "fl/channels/bus_traits.h"
+#include "fl/channels/config.h"
+#include "fl/stl/shared_ptr.h"
+#include "fl/stl/type_traits.h"
+#include "platforms/shared/bitbang/bitbang_channel_driver.h"
+
+namespace fl {
+
+template<> struct BusTraits<Bus::BIT_BANG> {
+    using Driver = BitBangChannelDriver;
+
+    static Driver& instance() FL_NOEXCEPT {
+        static fl::shared_ptr<Driver> gHolder = fl::make_shared<Driver>();
+        return *gHolder;
+    }
+};
+
+template<> struct BusSupports<Bus::BIT_BANG, ClocklessChipset> : fl::true_type {};
+template<> struct BusSupports<Bus::BIT_BANG, SpiChipsetConfig>  : fl::true_type {};
+
+}  // namespace fl


### PR DESCRIPTION
## Summary

Phase 2 of the compile-time channel-bus binding work tracked in #2428. Adds `BusTraits<Bus::X>` specializations for all 13 first-party channel drivers (ESP32 + Teensy 4.x + shared bit-bang) and per-platform `DefaultBus<Chipset>` specializations.

**Stacked on top of #2429** (Phase 1: `fl::Bus` enum + foundational traits). Re-target this PR's base to `master` once #2429 merges.

## What's in this PR

### 13 per-driver `bus_traits.h` (1 per driver subdirectory)

| Bus | Driver | Path |
|---|---|---|
| `Bus::RMT` (RMT5) | `ChannelEngineRMT` | `platforms/esp/32/drivers/rmt/rmt_5/bus_traits.h` |
| `Bus::RMT` (RMT4) | `ChannelEngineRMT4` | `platforms/esp/32/drivers/rmt/rmt_4/bus_traits.h` |
| `Bus::PARLIO` | `ChannelDriverPARLIO` | `platforms/esp/32/drivers/parlio/bus_traits.h` |
| `Bus::SPI` | `ChannelEngineSpi` | `platforms/esp/32/drivers/spi/bus_traits.h` |
| `Bus::I2S` | `IChannelDriver` (factory) | `platforms/esp/32/drivers/i2s/bus_traits.h` |
| `Bus::I2S_SPI` | `IChannelDriver` (factory) | `platforms/esp/32/drivers/i2s_spi/bus_traits.h` |
| `Bus::LCD_RGB` | `IChannelDriver` (factory) | `platforms/esp/32/drivers/lcd_cam/bus_traits.h` |
| `Bus::LCD_SPI` + `Bus::LCD_CLOCKLESS` | `IChannelDriver` (factory) | `platforms/esp/32/drivers/lcd_spi/bus_traits.h` |
| `Bus::UART` | `ChannelEngineUART` (with peripheral) | `platforms/esp/32/drivers/uart/bus_traits.h` |
| `Bus::FLEX_IO` | `ChannelEngineFlexIO` | `platforms/arm/teensy/teensy4_common/drivers/flexio/bus_traits.h` |
| `Bus::OBJECT_FLED` | `ChannelEngineObjectFLED` | `platforms/arm/teensy/teensy4_common/drivers/objectfled/bus_traits.h` |
| `Bus::BIT_BANG` | `BitBangChannelDriver` | `platforms/shared/bitbang/bus_traits.h` |

Each `bus_traits.h` is wired into the sibling `_build.cpp.hpp` aggregator so it parses during the platform compile. The headers are otherwise dormant — nothing names `BusTraits<Bus::X>::instance()` yet (Phase 3 will), so the lazy singletons stay uninstantiated.

### `DefaultBus<Chipset>` per-platform specializations in `src/fl/channels/bus.h`

- ESP32-P4 / C6 / H2 / C5 clockless → `Bus::PARLIO` (matches priority 4 in `channel_manager_esp32.cpp.hpp`).
- Other ESP32 variants clockless → `Bus::RMT`.
- ESP32-S3 SPI → `Bus::LCD_SPI`.
- ESP32-dev SPI → `Bus::I2S_SPI`.
- Teensy 4.x clockless → `Bus::OBJECT_FLED`.
- Other platforms intentionally leave `DefaultBus<SpiChipsetConfig>` undefined so the templated API surfaces a clear "specify Bus::X explicitly" compile error.

### Pattern detail

All `instance()` accessors use a Meyers singleton holding a `fl::shared_ptr<Driver>` — the existing `create*Engine()` factories or `make_shared<Driver>` calls are reused unchanged. Naming `BusTraits<Bus::X>::instance()` from any TU is what causes the linker to keep that driver's TU alive (the tree-shaking lever Phase 4/5 will pull).

C++11-clean throughout (no `auto` template params, no fold expressions, no variable templates).

## Why

Foundation for the templated `Channel<Bus, Chipset>` and `add<Bus>(cfg)` API ratified in #2428 — drivers will only link when their `Bus` value is named. Eliminates the 344 KB → 783 KB binary bloat from #2421 / #2420 (Phase 5) and makes bus/chipset mismatches compile errors.

## Verification

- `bash lint` clean.
- `bash test --cpp` passes (221/221).
- ESP32 / Teensy compilation deferred to Phase 3+ — the new headers are dormant in this PR (no template instantiations name them yet), so adding them to `_build.cpp.hpp` only verifies they parse, not that the singletons run correctly. Phase 3 will exercise them through `Channel<B, Chipset>::showPixels()`.

## Note on flaky test infrastructure

While running verification I hit the issue filed as #2430 — a previous test process held the `libfastled_build` SQLite lock for 800+ seconds, blocking new runs for 120 s. Worked around by `taskkill`. The test results above are from a clean run after recovery.

## Test plan

- [x] Phase 1 unit test (`tests/fl/channels/bus_traits.cpp`) still passes.
- [x] No regressions in host suite.
- [ ] Phase 3 will exercise `BusTraits<Bus::STUB>::instance().enqueue(...)` end-to-end via the templated `Channel<>::showPixels()`.
- [ ] Phase 5 will compile NEOPIXEL ESP32-S3 sketch and measure binary size delta.

## Related

- Stacked on #2429 (Phase 1).
- Tracked in #2428.
- Root cause: #2421, #2420.
- Test infra issue surfaced during this work: #2430.

🤖 Generated with [Claude Code](https://claude.com/claude-code)