### PR TITLE
fix(test): deadman watchdog + steal wedged build locks (#2430)

### DIFF
--- a/ci/tests/test_build_lock_wedged_steal.py
+++ b/ci/tests/test_build_lock_wedged_steal.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""
+Tests for BuildLock alive-but-wedged lock stealing.
+
+Companion to test_stale_lock_recovery.py — those tests cover dead-process
+stale locks. This file covers the case where the holding PID is alive but
+has held the lock past _max_hold_seconds() (wedged process not killed by
+its own watchdog). Without the steal, every subsequent build blocks for
+LOCK_TIMEOUT_S (120s) waiting for a process that will never release.
+
+See https://github.com/FastLED/FastLED/issues/2430
+"""
+
+import os
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+import pytest
+
+from ci.util.build_lock import BuildLock
+from ci.util.lock_database import LockDatabase
+
+
+class TestBuildLockWedgedSteal(unittest.TestCase):
+    """Verify alive-but-wedged locks are stolen past max-hold threshold."""
+
+    def setUp(self) -> None:
+        self.temp_dir = Path(tempfile.mkdtemp())
+        self.db_path = self.temp_dir / "test_locks.db"
+        # Tight threshold so we don't have to wait an hour.
+        self._prior_max_hold = os.environ.get("FASTLED_LOCK_MAX_HOLD_S")
+        os.environ["FASTLED_LOCK_MAX_HOLD_S"] = "1"
+
+    def tearDown(self) -> None:
+        import shutil
+
+        if self._prior_max_hold is None:
+            os.environ.pop("FASTLED_LOCK_MAX_HOLD_S", None)
+        else:
+            os.environ["FASTLED_LOCK_MAX_HOLD_S"] = self._prior_max_hold
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def _make_lock_using_test_db(self, name: str = "libfastled_build") -> BuildLock:
+        """Build a BuildLock pointing at our temp test DB.
+
+        BuildLock constructs its DB path from project_root in __init__, so we
+        swap in a test DB after construction to keep the test hermetic.
+        """
+        lock = BuildLock(name)
+        lock._db = LockDatabase(self.db_path)
+        return lock
+
+    @pytest.mark.serial
+    def test_wedged_alive_lock_is_stolen(self) -> None:
+        """Lock held by an alive process past max-hold should be stolen."""
+        lock = self._make_lock_using_test_db()
+
+        # Insert a lock held by THIS process (alive) with an old acquired_at.
+        my_pid = os.getpid()
+        old_time = time.time() - 10.0  # 10s ago, threshold = 1s
+        conn = lock._db._get_connection()
+        try:
+            cursor = conn.cursor()
+            cursor.execute(
+                "INSERT OR REPLACE INTO lock_holders "
+                "(lock_name, owner_pid, lock_mode, operation, hostname, acquired_at) "
+                "VALUES (?, ?, 'write', 'test_wedged', 'localhost', ?)",
+                ("build:libfastled_build", my_pid, old_time),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        # Sanity: holder is still in DB.
+        holders = lock._db.get_lock_info("build:libfastled_build")
+        self.assertEqual(len(holders), 1, "Test setup: holder should be present")
+        self.assertEqual(holders[0]["owner_pid"], my_pid)
+
+        # _check_stale_lock should detect wedged holder and steal it.
+        stolen = lock._check_stale_lock()
+        self.assertTrue(stolen, "Wedged lock past max-hold should be stolen")
+
+        # Holder row should be gone.
+        holders_after = lock._db.get_lock_info("build:libfastled_build")
+        self.assertEqual(
+            len(holders_after), 0, "Wedged holder should be removed from DB"
+        )
+
+    @pytest.mark.serial
+    def test_alive_recent_lock_is_not_stolen(self) -> None:
+        """Lock held by an alive process within max-hold should NOT be stolen."""
+        os.environ["FASTLED_LOCK_MAX_HOLD_S"] = "3600"
+        lock = self._make_lock_using_test_db()
+
+        my_pid = os.getpid()
+        recent_time = time.time() - 2.0  # 2s ago, well under 3600s
+        conn = lock._db._get_connection()
+        try:
+            cursor = conn.cursor()
+            cursor.execute(
+                "INSERT OR REPLACE INTO lock_holders "
+                "(lock_name, owner_pid, lock_mode, operation, hostname, acquired_at) "
+                "VALUES (?, ?, 'write', 'test_recent', 'localhost', ?)",
+                ("build:libfastled_build", my_pid, recent_time),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        stolen = lock._check_stale_lock()
+        self.assertFalse(stolen, "Recent live lock should NOT be stolen")
+
+        holders = lock._db.get_lock_info("build:libfastled_build")
+        self.assertEqual(len(holders), 1, "Recent live holder should remain in DB")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ci/util/build_lock.py
+++ b/ci/util/build_lock.py
@@ -31,6 +31,16 @@ LOCK_TIMEOUT_S: float = 120.0
 # Allows brief lock contention (e.g., concurrent build finishing) to resolve.
 _LOCK_GRACE_S: float = 2.0
 
+# Maximum time a lock may be held by an alive process before we treat it as
+# stale and steal it. The watchdog in test.py force-exits at ~600s (extended
+# to 1200s in CI, up to 2700s for sequential debug builds with sanitizers),
+# so use a value above the highest expected legitimate hold time. If a
+# process has held the lock past this, it's wedged — steal the lock so
+# subsequent runs aren't blocked indefinitely.
+#
+# Override via FASTLED_LOCK_MAX_HOLD_S env var for testing or unusual builds.
+_DEFAULT_MAX_HOLD_S: float = 3600.0  # 60 minutes
+
 
 def _is_process_alive_psutil(pid: int) -> bool:
     """Check if a process is alive using psutil (more reliable than kernel32 on Windows)."""
@@ -123,8 +133,26 @@ class BuildLock:
 
     _stale_lock_warned: bool = False
 
+    @staticmethod
+    def _max_hold_seconds() -> float:
+        """Resolve the max-hold threshold from env or default."""
+        env = os.environ.get("FASTLED_LOCK_MAX_HOLD_S")
+        if env:
+            try:
+                return float(env)
+            except ValueError:
+                pass
+        return _DEFAULT_MAX_HOLD_S
+
     def _check_stale_lock(self) -> bool:
-        """Check if lock is stale (dead process) and remove if stale.
+        """Check if lock is stale and remove if so.
+
+        A lock is treated as stale if either:
+          1. ALL holders have dead PIDs (process crashed), OR
+          2. ANY holder has held the lock past _max_hold_seconds() — even
+             alive-but-wedged processes get stolen so subsequent runs aren't
+             blocked indefinitely. The wedged process gets a deadman force-exit
+             from test.py's watchdog separately.
 
         Uses psutil for process liveness checks (more reliable than kernel32 on Windows).
 
@@ -140,17 +168,33 @@ class BuildLock:
             all_dead = all(
                 not _is_process_alive_psutil(h["owner_pid"]) for h in holders
             )
-            if not all_dead:
+
+            # Check for alive-but-wedged: any holder past max-hold threshold.
+            now = time.time()
+            max_hold = self._max_hold_seconds()
+            wedged_holders = [h for h in holders if (now - h["acquired_at"]) > max_hold]
+
+            if not all_dead and not wedged_holders:
                 return False
 
             if not BuildLock._stale_lock_warned:
                 BuildLock._stale_lock_warned = True
-                dead_pids = [h["owner_pid"] for h in holders]
-                print(
-                    f"Detected stale lock '{self._lock_name}' (dead PIDs: {dead_pids}). Removing..."
-                )
+                if all_dead:
+                    dead_pids = [h["owner_pid"] for h in holders]
+                    print(
+                        f"Detected stale lock '{self._lock_name}' (dead PIDs: {dead_pids}). Removing..."
+                    )
+                else:
+                    parts = [
+                        f"PID {h['owner_pid']} ({(now - h['acquired_at']):.0f}s)"
+                        for h in wedged_holders
+                    ]
+                    print(
+                        f"Detected wedged lock '{self._lock_name}' "
+                        f"(holder(s) past {max_hold:.0f}s max-hold: {', '.join(parts)}). Stealing..."
+                    )
 
-            # Force-break since we already verified all holders are dead
+            # Force-break: either all holders are dead, or one is wedged past max-hold.
             if self._db.force_break(self._lock_name):
                 print(f"Removed stale lock: {self._lock_name}")
                 BuildLock._stale_lock_warned = False
@@ -315,17 +359,36 @@ def libfastled_build_lock(
     if not lock.acquire(timeout=timeout):
         # Include holder info with psutil process details in error message
         holder_info = ""
+        kill_hint = ""
         try:
             holders = lock._db.get_lock_info(lock._lock_name)
             if holders:
                 parts: list[str] = []
+                hint_pids: list[int] = []
                 for h in holders:
                     held_secs = _time.time() - h["acquired_at"]
                     proc_info = _get_process_info(h["owner_pid"])
                     parts.append(
                         f"PID {h['owner_pid']} (held {held_secs:.0f}s, {proc_info})"
                     )
+                    hint_pids.append(h["owner_pid"])
                 holder_info = f". Held by: {', '.join(parts)}"
+                if hint_pids:
+                    pid_csv = ",".join(str(p) for p in hint_pids)
+                    if platform.system() == "Windows":
+                        kill_hint = (
+                            f"\nTip: if the holder appears stuck, run: "
+                            f"taskkill /F /PID {hint_pids[0]}"
+                        )
+                    else:
+                        kill_hint = (
+                            f"\nTip: if the holder appears stuck, run: "
+                            f"kill -9 {pid_csv}"
+                        )
+                    kill_hint += (
+                        "\n     Or clear all stale locks: "
+                        "uv run python -m ci.util.lock_admin --clean-stale"
+                    )
         except KeyboardInterrupt as ki:
             handle_keyboard_interrupt(ki)
             raise
@@ -333,7 +396,8 @@ def libfastled_build_lock(
             pass
         actual_elapsed = _time.time() - lock_start
         raise TimeoutError(
-            f"Failed to acquire libfastled build lock after {actual_elapsed:.0f}s (timeout={timeout:.0f}s){holder_info}"
+            f"Failed to acquire libfastled build lock after {actual_elapsed:.0f}s "
+            f"(timeout={timeout:.0f}s){holder_info}{kill_hint}"
         )
     lock_duration = _time.time() - lock_start
 

--- a/test.py
+++ b/test.py
@@ -31,6 +31,26 @@ _START_TIME = time.time()
 os.chdir(Path(__file__).parent)
 
 
+# When stdout is piped (e.g., `bash test --cpp 2>&1 | tail -15`), Python
+# defaults to block buffering — small writes may not surface until program
+# exit, making background test runs appear to "hang silently" even when
+# they're producing output. Force line buffering so `\n`-terminated output
+# flushes immediately to whatever pipe is reading us.
+#
+# This must run before any imports that touch stdout (e.g., test runners,
+# rich console) so the buffering policy is set on first write.
+if not sys.stdout.isatty():
+    try:
+        sys.stdout.reconfigure(line_buffering=True)  # type: ignore[union-attr]
+    except (AttributeError, ValueError):
+        pass
+if not sys.stderr.isatty():
+    try:
+        sys.stderr.reconfigure(line_buffering=True)  # type: ignore[union-attr]
+    except (AttributeError, ValueError):
+        pass
+
+
 # Ultra-early exit fires BEFORE heavy ci.util.* imports (~318ms savings on cached runs).
 # All ultra-early-exit logic is in ci.early_exit_cache (imported above).
 # typeguard (177ms), psutil (28ms), asyncio (50ms), unittest.mock (65ms) are skipped
@@ -151,15 +171,60 @@ if os.environ.get("GITHUB_ACTIONS"):
     )
 
 
+# Deadman timer fires this many seconds after the primary watchdog if the
+# process is still alive — bypasses any blocked diagnostics in the primary
+# watchdog and unconditionally calls os._exit().
+_DEADMAN_GRACE_S = 60
+
+
+def _release_held_build_locks() -> None:
+    """Best-effort: release any libfastled_build locks held by this PID.
+
+    Called from the watchdog before force-exit so subsequent runs don't
+    block on a stale lock from this hung process.
+    """
+    try:
+        from ci.util.lock_database import get_lock_database  # noqa: PLC0415
+
+        db = get_lock_database()
+        my_pid = os.getpid()
+        for lock in db.list_all_locks():
+            if lock["owner_pid"] == my_pid:
+                try:
+                    db.release(lock["lock_name"], my_pid)
+                except Exception:
+                    pass
+    except Exception:
+        pass
+
+
 def make_watch_dog_thread(
     seconds: int,
 ) -> threading.Thread:  # 60 seconds default timeout
+    def deadman_timer() -> None:
+        # Unconditional second-tier kill: if the primary watchdog gets stuck
+        # in dump_thread_stacks() / psutil queries / blocked I/O, this fires
+        # _DEADMAN_GRACE_S later and exits without running any diagnostics.
+        time.sleep(seconds + _DEADMAN_GRACE_S)
+        if _CANCEL_WATCHDOG.is_set():
+            return
+        try:
+            _release_held_build_locks()
+        except Exception:
+            pass
+        os._exit(3)  # Exit code 3 = deadman fired (primary watchdog also stuck)
+
     def watchdog_timer() -> None:
         time.sleep(seconds)
         if _CANCEL_WATCHDOG.is_set():
             return
 
         warnings.warn(f"Watchdog timer expired after {seconds} seconds.")
+
+        # Release any build locks first, before potentially-blocking diagnostics.
+        # If diagnostics hang, the deadman timer will still force-exit, but the
+        # lock will already be released so subsequent runs aren't blocked.
+        _release_held_build_locks()
 
         dump_thread_stacks()
         ts_print(f"Watchdog timer expired after {seconds} seconds - forcing exit")
@@ -186,6 +251,13 @@ def make_watch_dog_thread(
 
     thr = threading.Thread(target=watchdog_timer, daemon=True, name="WatchdogTimer")
     thr.start()
+
+    # Second-tier deadman: fires at seconds + _DEADMAN_GRACE_S regardless of
+    # whether the primary watchdog blocks.
+    deadman = threading.Thread(
+        target=deadman_timer, daemon=True, name="WatchdogDeadman"
+    )
+    deadman.start()
     return thr
 
 


### PR DESCRIPTION
## Summary

Fixes #2430. `bash test --cpp` could leave a hung Python process holding the `libfastled_build` SQLite lock past the 600s watchdog, blocking every subsequent test invocation for 120s.

## Changes

1. **Deadman watchdog** (`test.py`): a second daemon fires at `_TIMEOUT_EVERYTHING + 60s` and unconditionally calls `os._exit(3)` — the primary watchdog can wedge inside `dump_thread_stacks()`/psutil queries; the deadman bypasses all diagnostics so the process always dies on time.
2. **Lock cleanup before force-exit**: both watchdog tiers release any `libfastled_build` locks held by this PID before exiting.
3. **Steal wedged-but-alive locks** (`build_lock.py`): `_check_stale_lock` now also breaks locks whose holder has held past `FASTLED_LOCK_MAX_HOLD_S` (default 3600s — well above the longest legitimate hold including 2700s sequential debug-sanitizer builds).
4. **Kill hint in lock-timeout error**: platform-aware `taskkill /F /PID N` (Windows) or `kill -9 N` (Unix), plus a pointer to `lock_admin --clean-stale`.
5. **Line-buffered stdout/stderr when piped**: defends against the silent `bash test --cpp 2>&1 | tail -15` zero-byte symptom — when stdout is not a TTY, force line buffering so each `\n`-terminated line surfaces immediately.

## Test plan

- [x] `uv run pytest ci/tests/test_build_lock_wedged_steal.py` — 2 new tests pass (positive + negative wedged-steal cases)
- [x] `uv run pytest ci/tests/test_stale_lock_recovery.py ci/tests/test_lock_database.py ci/tests/test_cache_lock.py` — 32 existing lock tests pass (no regressions)
- [x] `bash lint` — clean
- [x] `bash test --list-tests` — startup smoke test OK
- [ ] CI verifies the watchdog/lock changes don't regress full-run behavior

## Notes on design

- I left `_TIMEOUT_EVERYTHING = 600` and the timeout-bumping logic untouched. The deadman is purely additive insurance.
- The wedged-lock-steal threshold is intentionally generous (3600s) to avoid false positives. The intent is "this can't possibly be legitimate; the holder's watchdog should have fired by now." A wedged process that survives past this threshold is the bug — the steal is the safety net.
- I did not attempt to disable rich/ANSI progress when piped (low-priority item in the issue) — line-buffering is the smaller, safer defensive measure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build lock handling to detect and break long-held ("wedged") processes
  * Enhanced timeout error messages with process information and recovery guidance
  * Strengthened watchdog timeout cleanup mechanisms
  * Added configurable max lock hold duration threshold

* **Tests**
  * Added tests for wedged lock detection and cleanup behavior

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/FastLED/pull/2432)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->