### PR TITLE
feat(channels): introduce IChannel ABC base for ChannelEvents (Phase 3a of #2428)

### DIFF
--- a/src/FastLED.h
+++ b/src/FastLED.h
@@ -636,7 +636,7 @@ public:
 	/// @return Reference to the ChannelEvents singleton
 	/// @note Use to register callbacks for channel lifecycle events
 	/// @code
-	/// int id = FastLED.channelEvents().onChannelCreated.add([](const fl::Channel& ch) { ... });
+	/// int id = FastLED.channelEvents().onChannelCreated.add([](const fl::IChannel& ch) { ... });
 	/// @endcode
 	static fl::ChannelEvents& channelEvents();
 

--- a/src/fl/channels/README.md
+++ b/src/fl/channels/README.md
@@ -175,13 +175,13 @@ void setup() {
     auto& events = FastLED.channelEvents();
 
     // Called when channel is created
-    events.onChannelCreated.add([](const fl::Channel& ch) {
+    events.onChannelCreated.add([](const fl::IChannel& ch) {
         Serial.printf("Channel created: %s\n", ch.name().c_str());
     });
 
     // Called when channel data is enqueued to driver
-    events.onChannelEnqueued.add([](const fl::Channel& ch, const fl::string& driver) {
-        Serial.printf("%s → %s\n", ch.name().c_str(), driver.c_str());
+    events.onChannelEnqueued.add([](const fl::IChannel& ch, const fl::string& driver) {
+        Serial.printf("%s -> %s\n", ch.name().c_str(), driver.c_str());
     });
 
     // Create channel (triggers onChannelCreated)

--- a/src/fl/channels/channel.h
+++ b/src/fl/channels/channel.h
@@ -15,6 +15,7 @@
 #include "fl/stl/noexcept.h"
 
 #include "cpixel_ledcontroller.h"
+#include "fl/channels/ichannel.h"
 #include "fl/stl/shared_ptr.h"
 #include "fl/stl/weak_ptr.h"
 #include "fl/stl/stdint.h"
@@ -36,8 +37,12 @@ FASTLED_SHARED_PTR(ChannelData);
 ///        but with timing and pin information.
 ///
 /// Provides access to LED channel functionality for driving LED strips.
-/// RGB_ORDER is set to RGB - reordering is handled internally by the Channel
-class Channel: public CPixelLEDController<RGB> {
+/// RGB_ORDER is set to RGB - reordering is handled internally by the Channel.
+///
+/// Inherits `IChannel` so `ChannelEvents` callbacks (and other consumers that
+/// only need to identify a channel) can take a non-template reference even
+/// after `Channel<Bus, Chipset>` becomes templated in Phase 3b. See #2428.
+class Channel: public CPixelLEDController<RGB>, public IChannel {
 public:
     /// @brief Create a new channel with optional affinity binding
     /// @param config Channel configuration (includes optional affinity for driver selection)
@@ -51,11 +56,11 @@ public:
 
     /// @brief Get the channel ID
     /// @return Channel ID (always increments, starts at 0)
-    i32 id() const { return mId; }
+    i32 id() const override { return mId; }
 
     /// @brief Get the channel name
     /// @return Channel name (user-specified or auto-generated "Channel_<id>")
-    const fl::string& name() const { return mName; }
+    const fl::string& name() const override { return mName; }
 
     /// @brief Get the pin number for this channel (data pin)
     /// @return Pin number

--- a/src/fl/channels/channel_events.h
+++ b/src/fl/channels/channel_events.h
@@ -1,10 +1,11 @@
 #pragma once
 
 #include "fl/stl/function.h"
+#include "fl/stl/string.h"  // IWYU pragma: keep
 
 namespace fl {
 
-class Channel;
+class IChannel;
 class IChannelDriver;  // IWYU pragma: keep
 class ChannelData;
 struct ChannelConfig;
@@ -17,12 +18,12 @@ struct ChannelConfig;
 /// Usage:
 /// @code
 /// // Add a listener
-/// int id = FastLED.channelEvents().onChannelCreated.add([](const Channel& ch) {
+/// int id = FastLED.channelEvents().onChannelCreated.add([](const IChannel& ch) {
 ///     FL_DBG("Channel created: " << ch.name());
 /// });
 ///
 /// // Add with priority (higher priority executes first)
-/// int id2 = FastLED.channelEvents().onChannelCreated.add([](const Channel& ch) {
+/// int id2 = FastLED.channelEvents().onChannelCreated.add([](const IChannel& ch) {
 ///     FL_DBG("High priority listener");
 /// }, 100);
 ///
@@ -34,40 +35,44 @@ struct ChannelConfig;
 /// - Past tense (Created, Added, Configured, Removed, Enqueued): fired after the action
 /// - "Begin" prefix (BeginDestroy, BeginShow): fired before the action
 /// - "End" prefix (EndShow): fired after a bracketed action
+///
+/// Callbacks receive `const IChannel&` so the same listener works regardless
+/// of which `Channel<Bus, Chipset>` instantiation produced the event. See
+/// `fl/channels/ichannel.h` and issue #2428.
 struct ChannelEvents {
     static ChannelEvents& instance();
 
     // -- Lifecycle events --
 
     /// Fired after a Channel is constructed via Channel::create()
-    fl::function_list<void(const Channel&)> onChannelCreated;
+    fl::function_list<void(const IChannel&)> onChannelCreated;
 
     /// Fired at the start of ~Channel(), before members are torn down
-    fl::function_list<void(const Channel&)> onChannelBeginDestroy;
+    fl::function_list<void(const IChannel&)> onChannelBeginDestroy;
 
     // -- FastLED list events --
 
     /// Fired after a Channel is added to FastLED's controller list
-    fl::function_list<void(const Channel&)> onChannelAdded;
+    fl::function_list<void(const IChannel&)> onChannelAdded;
 
     /// Fired after a Channel is removed from FastLED's controller list
-    fl::function_list<void(const Channel&)> onChannelRemoved;
+    fl::function_list<void(const IChannel&)> onChannelRemoved;
 
     // -- Configuration events --
 
     /// Fired after applyConfig() reconfigures a Channel
-    fl::function_list<void(const Channel&, const ChannelConfig&)> onChannelConfigured;
+    fl::function_list<void(const IChannel&, const ChannelConfig&)> onChannelConfigured;
 
     // -- Rendering events --
 
     /// Fired after pixel data is encoded into byte stream (before enqueuing)
     /// Second parameter is the encoded channel data
     /// @note This event fires after writeWS2812/writeAPA102/etc. encoding completes
-    fl::function_list<void(const Channel&, const ChannelData&)> onChannelDataEncoded;
+    fl::function_list<void(const IChannel&, const ChannelData&)> onChannelDataEncoded;
 
     /// Fired after channel data is enqueued to a driver
     /// Second parameter is the driver name (empty string for unnamed drivers)
-    fl::function_list<void(const Channel&, const fl::string& driverName)> onChannelEnqueued;
+    fl::function_list<void(const IChannel&, const fl::string& driverName)> onChannelEnqueued;
 };
 
 }  // namespace fl

--- a/src/fl/channels/ichannel.h
+++ b/src/fl/channels/ichannel.h
@@ -1,0 +1,43 @@
+#pragma once
+
+/// @file ichannel.h
+/// @brief Type-erased base for the templated `Channel<Bus, Chipset>` family.
+///
+/// `IChannel` is the non-template polymorphic anchor that `ChannelEvents`
+/// callbacks and other consumers receive. Concrete channels (today: `Channel`;
+/// after Phase 3b: `Channel<Bus, Chipset>`) inherit from this base so a single
+/// callback signature works regardless of which template instantiation produced
+/// the channel.
+///
+/// The surface is intentionally minimal — only the identifiers callbacks need
+/// to distinguish one channel from another. Anything richer should be on the
+/// concrete `Channel` class. See issue #2428.
+
+#include "fl/stl/noexcept.h"
+#include "fl/stl/stdint.h"
+#include "fl/stl/string.h"  // IWYU pragma: keep
+
+namespace fl {
+
+/// @brief Polymorphic identification base for any channel in the system.
+class IChannel {
+public:
+    virtual ~IChannel() FL_NOEXCEPT = default;
+
+    /// @brief Stable monotonically-assigned identifier (starts at 0).
+    virtual i32 id() const = 0;
+
+    /// @brief User-specified or auto-generated name (e.g. "Channel_3").
+    virtual const fl::string& name() const = 0;
+
+protected:
+    IChannel() FL_NOEXCEPT = default;
+
+    // Non-copyable, non-movable -- concrete channels are owned by shared_ptr.
+    IChannel(const IChannel&) FL_NOEXCEPT = delete;
+    IChannel& operator=(const IChannel&) FL_NOEXCEPT = delete;
+    IChannel(IChannel&&) FL_NOEXCEPT = delete;
+    IChannel& operator=(IChannel&&) FL_NOEXCEPT = delete;
+};
+
+}  // namespace fl

--- a/test.py
+++ b/test.py
@@ -192,8 +192,14 @@ def _release_held_build_locks() -> None:
             if lock["owner_pid"] == my_pid:
                 try:
                     db.release(lock["lock_name"], my_pid)
+                except KeyboardInterrupt as ki:
+                    handle_keyboard_interrupt(ki)
+                    raise
                 except Exception:
                     pass
+    except KeyboardInterrupt as ki:
+        handle_keyboard_interrupt(ki)
+        raise
     except Exception:
         pass
 
@@ -210,6 +216,9 @@ def make_watch_dog_thread(
             return
         try:
             _release_held_build_locks()
+        except KeyboardInterrupt as ki:
+            handle_keyboard_interrupt(ki)
+            raise
         except Exception:
             pass
         os._exit(3)  # Exit code 3 = deadman fired (primary watchdog also stuck)

--- a/tests/fastled_core.cpp
+++ b/tests/fastled_core.cpp
@@ -974,7 +974,7 @@ struct EventTracker {
     int mConfiguredCount = 0;
     int mEnqueuedCount = 0;
     fl::string mLastEngineName;
-    const Channel* mLastChannel = nullptr;
+    const IChannel* mLastChannel = nullptr;
 
     void reset() {
         mCreatedCount = 0;
@@ -987,32 +987,32 @@ struct EventTracker {
         mLastChannel = nullptr;
     }
 
-    void onCreated(const Channel& ch) {
+    void onCreated(const IChannel& ch) {
         mCreatedCount++;
         mLastChannel = &ch;
     }
 
-    void onBeginDestroy(const Channel& ch) {
+    void onBeginDestroy(const IChannel& ch) {
         mBeginDestroyCount++;
         mLastChannel = &ch;
     }
 
-    void onAdded(const Channel& ch) {
+    void onAdded(const IChannel& ch) {
         mAddedCount++;
         mLastChannel = &ch;
     }
 
-    void onRemoved(const Channel& ch) {
+    void onRemoved(const IChannel& ch) {
         mRemovedCount++;
         mLastChannel = &ch;
     }
 
-    void onConfigured(const Channel& ch, const ChannelConfig&) {
+    void onConfigured(const IChannel& ch, const ChannelConfig&) {
         mConfiguredCount++;
         mLastChannel = &ch;
     }
 
-    void onEnqueued(const Channel& ch, const fl::string& engineName) {
+    void onEnqueued(const IChannel& ch, const fl::string& engineName) {
         mEnqueuedCount++;
         mLastChannel = &ch;
         mLastEngineName = engineName;
@@ -1037,7 +1037,7 @@ FL_TEST_CASE("Channel Events: onChannelCreated fires on Channel::create()") {
     auto& events = ChannelEvents::instance();
 
     // Add listener
-    int listenerId = events.onChannelCreated.add([&tracker](const Channel& ch) {
+    int listenerId = events.onChannelCreated.add([&tracker](const IChannel& ch) {
         tracker.onCreated(ch);
     });
 
@@ -1062,7 +1062,7 @@ FL_TEST_CASE("Channel Events: onChannelBeginDestroy fires on channel destruction
     auto& events = ChannelEvents::instance();
 
     // Add listener
-    int listenerId = events.onChannelBeginDestroy.add([&tracker](const Channel& ch) {
+    int listenerId = events.onChannelBeginDestroy.add([&tracker](const IChannel& ch) {
         tracker.onBeginDestroy(ch);
     });
 
@@ -1092,7 +1092,7 @@ FL_TEST_CASE("Channel Events: onChannelAdded fires on FastLED.add()") {
     mgr.addDriver(3000, driver);
 
     // Add listener
-    int listenerId = events.onChannelAdded.add([&tracker](const Channel& ch) {
+    int listenerId = events.onChannelAdded.add([&tracker](const IChannel& ch) {
         tracker.onAdded(ch);
     });
 
@@ -1127,7 +1127,7 @@ FL_TEST_CASE("Channel Events: onChannelRemoved fires on FastLED.remove()") {
     mgr.addDriver(3001, driver);
 
     // Add listener
-    int listenerId = events.onChannelRemoved.add([&tracker](const Channel& ch) {
+    int listenerId = events.onChannelRemoved.add([&tracker](const IChannel& ch) {
         tracker.onRemoved(ch);
     });
 
@@ -1159,7 +1159,7 @@ FL_TEST_CASE("Channel Events: onChannelConfigured fires on applyConfig()") {
     auto& events = ChannelEvents::instance();
 
     // Add listener
-    int listenerId = events.onChannelConfigured.add([&tracker](const Channel& ch, const ChannelConfig& cfg) {
+    int listenerId = events.onChannelConfigured.add([&tracker](const IChannel& ch, const ChannelConfig& cfg) {
         tracker.onConfigured(ch, cfg);
     });
 
@@ -1193,7 +1193,7 @@ FL_TEST_CASE("Channel Events: onChannelEnqueued fires when data is enqueued to d
     mgr.addDriver(3003, mockEngine);
 
     // Add listener
-    int listenerId = events.onChannelEnqueued.add([&tracker](const Channel& ch, const fl::string& engineName) {
+    int listenerId = events.onChannelEnqueued.add([&tracker](const IChannel& ch, const fl::string& engineName) {
         tracker.onEnqueued(ch, engineName);
     });
 
@@ -1229,15 +1229,15 @@ FL_TEST_CASE("Channel Events: Multiple listeners with priority ordering") {
     fl::vector<int> callOrder;
 
     // Add listeners with different priorities (higher priority = called first)
-    int id1 = events.onChannelCreated.add([&callOrder](const Channel&) {
+    int id1 = events.onChannelCreated.add([&callOrder](const IChannel&) {
         callOrder.push_back(1);
     }, 10);  // Low priority
 
-    int id2 = events.onChannelCreated.add([&callOrder](const Channel&) {
+    int id2 = events.onChannelCreated.add([&callOrder](const IChannel&) {
         callOrder.push_back(2);
     }, 100);  // High priority
 
-    int id3 = events.onChannelCreated.add([&callOrder](const Channel&) {
+    int id3 = events.onChannelCreated.add([&callOrder](const IChannel&) {
         callOrder.push_back(3);
     }, 50);  // Medium priority
 
@@ -1268,22 +1268,22 @@ FL_TEST_CASE("Channel Events: Complete lifecycle event sequence") {
     mgr.addDriver(3004, mockEngine);
 
     // Add all listeners
-    int createdId = events.onChannelCreated.add([&tracker](const Channel& ch) {
+    int createdId = events.onChannelCreated.add([&tracker](const IChannel& ch) {
         tracker.onCreated(ch);
     });
-    int addedId = events.onChannelAdded.add([&tracker](const Channel& ch) {
+    int addedId = events.onChannelAdded.add([&tracker](const IChannel& ch) {
         tracker.onAdded(ch);
     });
-    int configuredId = events.onChannelConfigured.add([&tracker](const Channel& ch, const ChannelConfig& cfg) {
+    int configuredId = events.onChannelConfigured.add([&tracker](const IChannel& ch, const ChannelConfig& cfg) {
         tracker.onConfigured(ch, cfg);
     });
-    int enqueuedId = events.onChannelEnqueued.add([&tracker](const Channel& ch, const fl::string& engineName) {
+    int enqueuedId = events.onChannelEnqueued.add([&tracker](const IChannel& ch, const fl::string& engineName) {
         tracker.onEnqueued(ch, engineName);
     });
-    int removedId = events.onChannelRemoved.add([&tracker](const Channel& ch) {
+    int removedId = events.onChannelRemoved.add([&tracker](const IChannel& ch) {
         tracker.onRemoved(ch);
     });
-    int destroyId = events.onChannelBeginDestroy.add([&tracker](const Channel& ch) {
+    int destroyId = events.onChannelBeginDestroy.add([&tracker](const IChannel& ch) {
         tracker.onBeginDestroy(ch);
     });
 

--- a/tests/fl/channels/driver.cpp
+++ b/tests/fl/channels/driver.cpp
@@ -456,7 +456,7 @@ FL_TEST_CASE("Channel Events: onChannelDataEncoded fires after encoding") {
     bool eventFired = false;
     size_t encodedDataSize = 0;
     auto& events = ChannelEvents::instance();
-    int listenerId = events.onChannelDataEncoded.add([&](const Channel& ch, const ChannelData& chData) {
+    int listenerId = events.onChannelDataEncoded.add([&](const IChannel& ch, const ChannelData& chData) {
         eventFired = true;
         encodedDataSize = chData.getData().size();
         FL_CHECK(&ch == channel.get());  // Verify channel reference is correct
@@ -507,7 +507,7 @@ FL_TEST_CASE("Channel: Guard against double-encoding within single FastLED.show(
     // Track how many times encoding happens
     int encodeCount = 0;
     auto& events = ChannelEvents::instance();
-    int listenerId = events.onChannelDataEncoded.add([&](const Channel&, const ChannelData&) {
+    int listenerId = events.onChannelDataEncoded.add([&](const IChannel&, const ChannelData&) {
         encodeCount++;
     });
 

--- a/tests/fl/chipsets/ucs7604.cpp
+++ b/tests/fl/chipsets/ucs7604.cpp
@@ -1213,7 +1213,7 @@ FL_TEST_CASE("UCS7604 channel preamble in encoded data") {
     fl::vector_psram<u8> capturedData;
     auto& events = ChannelEvents::instance();
     int listenerId = events.onChannelDataEncoded.add(
-        [&](const Channel& ch, const ChannelData& chData) {
+        [&](const IChannel& ch, const ChannelData& chData) {
             if (&ch == channel.get()) {
                 eventFired = true;
                 const auto& data = chData.getData();
@@ -1281,7 +1281,7 @@ FL_TEST_CASE("WS2812 channel produces no UCS7604 preamble") {
     fl::vector_psram<u8> capturedData;
     auto& events = ChannelEvents::instance();
     int listenerId = events.onChannelDataEncoded.add(
-        [&](const Channel& ch, const ChannelData& chData) {
+        [&](const IChannel& ch, const ChannelData& chData) {
             if (&ch == channel.get()) {
                 const auto& data = chData.getData();
                 capturedData.assign(data.begin(), data.end());


### PR DESCRIPTION
## Summary

Phase 3a of #2428. Adds a non-template polymorphic anchor `fl::IChannel` so `ChannelEvents` callbacks keep working after `Channel<Bus, Chipset>` becomes a template in Phase 3b. Pure API surface refactor — no behavior changes.

**Stacked on #2431** (Phase 2). Re-target to `master` after Phase 2 merges.

## What's in this PR

### New file: `src/fl/channels/ichannel.h`
Minimal ABC with virtual `id()` and `name()`, FL_NOEXCEPT special members, non-copyable/movable. Holds the public surface that any callback might reasonably want to identify a channel.

### `Channel` now derives from `IChannel`
Multiple inheritance: `class Channel: public CPixelLEDController<RGB>, public IChannel`. Existing `id()` / `name()` accessors marked `override`. No behavior change — the methods already returned the same types.

### `ChannelEvents` callbacks take `IChannel`
- `function_list<void(const Channel&, ...)>` -> `function_list<void(const IChannel&, ...)>` for all 7 event types.
- Callsites in `channel.cpp.hpp` that fire events (`events.onChannelCreated(*channel)` etc.) work unchanged thanks to the implicit `Channel*` -> `IChannel*` upcast.

### Tests + docs migrated
- `tests/fastled_core.cpp` `EventTracker::mLastChannel` typed as `const IChannel*`; methods take `const IChannel&`. Pointer-identity comparison `tracker.mLastChannel == channel.get()` works because `Channel` inherits from `IChannel`.
- 15 lambdas in `fastled_core.cpp` + 2 in `fl/channels/driver.cpp` + 2 in `fl/chipsets/ucs7604.cpp` updated to `const IChannel&`.
- `README.md` and `FastLED.h` docstring examples refreshed.

### Bonus: fixes pre-existing KBI lint failures in `test.py`
The test-lock fix from #2432 introduced three `try: ... except Exception: pass` blocks at `test.py:186, 193, 211` without `KeyboardInterrupt` handlers, which the `KeyboardInterrupt handler checks` linter rejects. Added the standard `except KeyboardInterrupt as ki: handle_keyboard_interrupt(ki); raise` clause before each `except Exception`. Surfaced because my changes invalidated the lint cache; per project policy fix-when-encountered.

## Why

Foundation step for Phase 3b (templatize `ChannelConfig<Chipset>` and `Channel<Bus, Chipset>`). Once Channel becomes templated, the event system needs a non-template type to take. Adding the `IChannel` ABC now lets Phase 3b focus purely on the templatization without simultaneously re-plumbing events.

## Verification

- `bash lint` clean.
- `bash test --cpp` passes (286/286).
- ChannelEvents test cases verify the pointer-identity comparison still works through the upcast.
- C++11-clean throughout (no `auto` deduction tricks, `FL_NOEXCEPT` everywhere per project convention).

## Test plan

- [x] All host tests pass.
- [x] EventTracker pointer-identity checks pass after IChannel migration.
- [ ] Phase 3b will exercise `Channel<B, Chipset>` deriving from IChannel the same way.

## Related

- Stacked on #2431 (Phase 2) which is stacked on now-merged #2429 (Phase 1).
- Tracked in #2428.
- Test infra fix that surfaced the KBI failures: #2430/#2432.

🤖 Generated with [Claude Code](https://claude.com/claude-code)