### PR TITLE
chore(deps): bump zccache 1.3.7 -> 1.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "fpvgcc",
     "uv",
     "clang-tool-chain>=1.2.9",
-    "zccache>=1.3.7",
+    "zccache>=1.4.0",
     "ninja",
     "meson>=1.10.0",
     "download",

--- a/test.py
+++ b/test.py
@@ -192,8 +192,14 @@ def _release_held_build_locks() -> None:
             if lock["owner_pid"] == my_pid:
                 try:
                     db.release(lock["lock_name"], my_pid)
+                except KeyboardInterrupt as ki:
+                    handle_keyboard_interrupt(ki)
+                    raise
                 except Exception:
                     pass
+    except KeyboardInterrupt as ki:
+        handle_keyboard_interrupt(ki)
+        raise
     except Exception:
         pass
 
@@ -210,6 +216,9 @@ def make_watch_dog_thread(
             return
         try:
             _release_held_build_locks()
+        except KeyboardInterrupt as ki:
+            handle_keyboard_interrupt(ki)
+            raise
         except Exception:
             pass
         os._exit(3)  # Exit code 3 = deadman fired (primary watchdog also stuck)


### PR DESCRIPTION
## Summary

Upgrades the `zccache` compile cache from `>=1.3.7` to `>=1.4.0`. zccache 1.4.0 is the latest release on PyPI (published 2026-05-10).

## Changes

- `pyproject.toml`: dependency pin `zccache>=1.3.7` -> `zccache>=1.4.0`.
- `test.py`: fixes pre-existing KBI checker violations at lines 186/193/211 that the lint pipeline encountered while building this branch — same fix pattern as the IChannel work, adds the standard `except KeyboardInterrupt as ki: handle_keyboard_interrupt(ki); raise` clause before each `except Exception:` in the watchdog's lock-release path.

`uv.lock` is gitignored, so only `pyproject.toml` and `test.py` are tracked here. CI / local `uv sync` will resolve `zccache>=1.4.0` from PyPI on next install.

## Verification

- `uv sync` resolves to `zccache 1.4.0` (`.venv/Scripts/zccache.exe --version` confirms).
- `bash lint` clean.
- `bash test --cpp` passes **303/303** (full build + run, no regressions).

## Test plan

- [x] Local lint clean.
- [x] Local host test suite passes 303/303.
- [ ] CI matrix builds across platforms with new zccache version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated zccache dependency to version 1.4.0 or later.

* **Bug Fixes**
  * Enhanced keyboard interrupt handling to ensure proper signal propagation during lock operations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/FastLED/pull/2434)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->