### PR TITLE
fix(teensy4): empty FL_PROGMEM to avoid GCC section type conflict

### DIFF
--- a/src/fastled_progmem.h
+++ b/src/fastled_progmem.h
@@ -54,7 +54,22 @@
 #endif
 
 /// PROGMEM keyword for storage
+///
+/// Teensy 4.x (`__IMXRT1062__`) workaround: Teensy core defines `PROGMEM` as
+/// `__attribute__((section(".progmem")))`, which causes GCC to emit "section
+/// type conflict" errors when a single translation unit contains FL_PROGMEM
+/// variables of different types (e.g. `CRGB`, `float`, `i32`) — see the
+/// fl.fx+ unity build that aggregates `colorpalettes.h`, `sin32.h`, and
+/// `mic_response_data.h`. Teensy 4 has a unified linear address space and
+/// places `const` data in `.rodata` (flash) automatically via the linker
+/// script, so the section attribute is unnecessary on this platform.
+/// Emitting empty `FL_PROGMEM` keeps user code that uses Arduino's `PROGMEM`
+/// directly unaffected.
+#if defined(__IMXRT1062__)
+#define FL_PROGMEM
+#else
 #define FL_PROGMEM                PROGMEM
+#endif
 
 
 /// @name PROGMEM Read Functions


### PR DESCRIPTION
## Summary

Special-case `FL_PROGMEM` to expand to nothing on Teensy 4.x (`__IMXRT1062__`). Resolves a long-standing CI failure on the `teensy41` workflow.

Surfaced during PR #2435 review per @zackees — splitting into a follow-up because it's pre-existing and unrelated to that PR's IChannel changes.

## Background

Teensy 4.x core defines `PROGMEM` as `__attribute__((section(".progmem")))`. GCC raises **"section type conflict"** errors when a single translation unit declares variables of different types with conflicting section attributes. The `fl.fx+.cpp` unity build aggregates several headers that declare PROGMEM data of different types:

- `colorpalettes.h` — `RainbowColors_p` (`CRGB[]`)
- `fl/math/sin32.h` — `sinCosPairedLut` (`i32[]`)
- `fl/audio/mic_response_data.h` — `kMicResponseFreqs` (`float[]`)

Sample failure (master, every commit since at least `ebb48e610f`):

```
colorpalettes.h:23:35: error: 'RainbowColors_p' causes a section type conflict
                              with 'fl::sinCosPairedLut'
sin32.h:22:29:        error: 'fl::sinCosPairedLut' causes a section type conflict
                              with 'fl::audio::kMicResponseFreqs'
```

`teensy41` has been failing on master for the last 5+ commits with this error: [2f7d1332](https://github.com/FastLED/FastLED/actions/runs/25614266421), [8a339fc4](https://github.com/FastLED/FastLED/actions/runs/25614202059), [68106e80](https://github.com/FastLED/FastLED/actions/runs/25613387325), [ebb48e61](https://github.com/FastLED/FastLED/actions/runs/25464475553), [6d3b4d4c](https://github.com/FastLED/FastLED/actions/runs/25380494794) — all the same root cause.

## Why this fix is safe

Teensy 4 has a unified linear address space (Cortex-M7, IMXRT1062 with 2 MB flash + 1 MB RAM). The Teensy linker script places `const` data in `.rodata` automatically — flash placement does not require the `PROGMEM` section attribute. The attribute is the **sole cause** of the conflict.

Emitting empty `FL_PROGMEM` only affects FastLED-internal declarations. User code that uses Arduino's `PROGMEM` macro directly is unaffected — the upstream `PROGMEM` macro is unchanged.

## Diff

`src/fastled_progmem.h`:

```diff
 /// PROGMEM keyword for storage
+#if defined(__IMXRT1062__)
+#define FL_PROGMEM
+#else
 #define FL_PROGMEM                PROGMEM
+#endif
```

(Plus an explanatory comment block; full diff in the commit.)

## Verification

- `bash lint` clean.
- `bash test --cpp` passes 303/303 (host build unaffected — `__IMXRT1062__` not defined on host).
- The actual `teensy41` build will run in CI on this PR — that's the load-bearing verification.

## Related

- Surfaced during PR #2435 (Phase 3a of #2428).
- Affected platform: `__IMXRT1062__` (Teensy 4.0, Teensy 4.1, Teensy MicroMod).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed compilation errors on Teensy 4.x microcontroller boards when program memory variables were used.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/FastLED/pull/2436)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->