### PR TITLE
feat(channels): unify singletons + opt-in disable macro (Phase 5a of #2428)

### DIFF
--- a/src/platforms/esp/32/drivers/channel_manager_esp32.cpp.hpp
+++ b/src/platforms/esp/32/drivers/channel_manager_esp32.cpp.hpp
@@ -28,6 +28,8 @@
 #include "platforms/is_platform.h"
 #ifdef FL_IS_ESP32
 
+#include "fl/channels/bus.h"
+#include "fl/channels/bus_traits.h"
 #include "fl/channels/manager.h"
 #include "fl/system/log.h"
 #include "platforms/esp/32/feature_flags/enabled.h"
@@ -36,61 +38,68 @@
 #include "fl/channels/adapters/spi_channel_adapter.h"
 #include "fl/stl/noexcept.h"
 
+// FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY: when defined to 1, the legacy
+// `initChannelDrivers()` body becomes a no-op. Users opting in must call
+// `fl::enableDrivers<fl::Bus::X...>()` explicitly to register the drivers
+// they actually need -- this is the pathway that lets the linker drop unused
+// driver TUs (#2420 binary-bloat fix). Default is 0 for backward compatibility;
+// Phase 5b of #2428 will flip the default.
+#ifndef FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY
+#define FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY 0
+#endif
+
 // Platform detection for I2S/LCD_SPI drivers
 #include "platforms/esp/is_esp.h"
 
-// Include concrete driver implementations
+// Include per-driver bus_traits.h (each is internally guarded by its
+// FASTLED_ESP32_HAS_* macro and degrades to an empty header when the
+// corresponding driver is not enabled on this platform). The bus_traits
+// headers transitively include the concrete driver headers we need.
 #if FASTLED_ESP32_HAS_PARLIO
 // IWYU pragma: begin_keep
-#include "parlio/channel_driver_parlio.h"
+#include "parlio/bus_traits.h"
 // IWYU pragma: end_keep
 #endif
 #if FASTLED_ESP32_HAS_CLOCKLESS_SPI
 // IWYU pragma: begin_keep
-#include "spi/channel_driver_spi.h"
+#include "spi/bus_traits.h"
 // IWYU pragma: end_keep
 #endif
 #if FASTLED_ESP32_HAS_UART
 // IWYU pragma: begin_keep
-#include "uart/channel_driver_uart.h"
-// IWYU pragma: end_keep
-// IWYU pragma: begin_keep
-#include "uart/uart_peripheral_esp.h"
+#include "uart/bus_traits.h"
 // IWYU pragma: end_keep
 #endif
 #if FASTLED_ESP32_HAS_RMT
 // Include the appropriate RMT driver (RMT4 or RMT5) based on platform
 #if FASTLED_ESP32_RMT5_ONLY_PLATFORM || FASTLED_RMT5
 // IWYU pragma: begin_keep
-#include "rmt/rmt_5/channel_driver_rmt.h"
+#include "rmt/rmt_5/bus_traits.h"
 // IWYU pragma: end_keep
 #else
 // IWYU pragma: begin_keep
-#include "rmt/rmt_4/channel_driver_rmt4.h"
+#include "rmt/rmt_4/bus_traits.h"
 // IWYU pragma: end_keep
 #endif
 #endif  // FASTLED_ESP32_HAS_RMT
 #if FASTLED_ESP32_HAS_LCD_RGB
 // IWYU pragma: begin_keep
-#include "lcd_cam/channel_driver_lcd_rgb.h"
+#include "lcd_cam/bus_traits.h"
 // IWYU pragma: end_keep
 #endif
 #if FASTLED_ESP32_HAS_I2S_LCD_CAM
 // IWYU pragma: begin_keep
-#include "i2s/channel_driver_i2s.h"
+#include "i2s/bus_traits.h"
 // IWYU pragma: end_keep
 #endif
 #if FASTLED_ESP32_HAS_I2S
 // IWYU pragma: begin_keep
-#include "i2s_spi/channel_driver_i2s_spi.h"
+#include "i2s_spi/bus_traits.h"
 // IWYU pragma: end_keep
 #endif
 #if FASTLED_ESP32_HAS_LCD_SPI
 // IWYU pragma: begin_keep
-#include "lcd_spi/channel_driver_lcd_spi.h"
-// IWYU pragma: end_keep
-// IWYU pragma: begin_keep
-#include "lcd_spi/channel_driver_lcd_clockless.h"
+#include "lcd_spi/bus_traits.h"
 // IWYU pragma: end_keep
 #endif
 
@@ -187,12 +196,17 @@ static void addSpiHardwareIfPossible(ChannelManager& manager) FL_NOEXCEPT {
     }
 }
 
+// Each addXxxIfPossible delegates to BusTraits<Bus::X>::instancePtr() so the
+// legacy auto-init path and the new fl::enableDrivers<>() opt-in API share the
+// SAME singleton driver instance. Without this unification, calling
+// enableDrivers<Bus::PARLIO>() after the legacy auto-init created a *second*
+// PARLIO driver instance, which then tried to claim the PARLIO peripheral
+// twice. Phase 4 documented this caveat; Phase 5a (this commit) fixes it.
+
 /// @brief Add PARLIO driver if supported by platform
 static void addParlioIfPossible(ChannelManager& manager) FL_NOEXCEPT {
 #if FASTLED_ESP32_HAS_PARLIO
-    // ESP32-C6: Fixed by explicitly setting clk_in_gpio_num = -1 (Iteration 2)
-    // This tells the driver to use internal clock source instead of external GPIO 0
-    manager.addDriver(PRIORITY_PARLIO, fl::make_shared<ChannelDriverPARLIO>());
+    manager.addDriver(PRIORITY_PARLIO, BusTraits<Bus::PARLIO>::instancePtr());
     FL_DBG("ESP32: Added PARLIO driver (priority " << PRIORITY_PARLIO << ")");
 #else
     (void)manager;  // Suppress unused parameter warning
@@ -202,7 +216,7 @@ static void addParlioIfPossible(ChannelManager& manager) FL_NOEXCEPT {
 /// @brief Add LCD RGB driver if supported by platform
 static void addLcdRgbIfPossible(ChannelManager& manager) FL_NOEXCEPT {
 #if FASTLED_ESP32_HAS_LCD_RGB
-    auto driver = createLcdRgbEngine();
+    auto driver = BusTraits<Bus::LCD_RGB>::instancePtr();
     if (driver) {
         manager.addDriver(PRIORITY_LCD_RGB, driver);
         FL_DBG("ESP32: Added LCD_RGB driver (priority " << PRIORITY_LCD_RGB << ")");
@@ -217,7 +231,7 @@ static void addLcdRgbIfPossible(ChannelManager& manager) FL_NOEXCEPT {
 /// @brief Add SPI driver if supported by platform
 static void addSpiIfPossible(ChannelManager& manager) FL_NOEXCEPT {
 #if FASTLED_ESP32_HAS_CLOCKLESS_SPI
-    manager.addDriver(PRIORITY_SPI, fl::make_shared<ChannelEngineSpi>());
+    manager.addDriver(PRIORITY_SPI, BusTraits<Bus::SPI>::instancePtr());
     FL_DBG("ESP32: Added SPI driver (priority " << PRIORITY_SPI << ")");
 #else
     (void)manager;  // Suppress unused parameter warning
@@ -227,12 +241,11 @@ static void addSpiIfPossible(ChannelManager& manager) FL_NOEXCEPT {
 /// @brief Add UART driver if supported by platform
 static void addUartIfPossible(ChannelManager& manager) FL_NOEXCEPT {
 #if FASTLED_ESP32_HAS_UART
-    // UART driver uses wave8 encoding adapted for UART framing
-    // Available on all ESP32 variants (C3, S3, C6, H2, P4) with ESP-IDF 4.0+
-    // Uses automatic start/stop bit insertion for efficient waveform generation
-    auto peripheral = fl::make_shared<UartPeripheralEsp>();
-    auto driver = fl::make_shared<ChannelEngineUART>(peripheral);
-    manager.addDriver(PRIORITY_UART, driver);
+    // UART driver uses wave8 encoding adapted for UART framing.
+    // Available on all ESP32 variants (C3, S3, C6, H2, P4) with ESP-IDF 4.0+.
+    // BusTraits<Bus::UART>::instancePtr() also constructs the UartPeripheralEsp
+    // dependency inside its UartBusHolder.
+    manager.addDriver(PRIORITY_UART, BusTraits<Bus::UART>::instancePtr());
     FL_DBG("ESP32: Added UART driver (priority " << PRIORITY_UART << ")");
 #else
     (void)manager;  // Suppress unused parameter warning
@@ -242,12 +255,13 @@ static void addUartIfPossible(ChannelManager& manager) FL_NOEXCEPT {
 /// @brief Add RMT driver if supported by platform
 static void addRmtIfPossible(ChannelManager& manager) FL_NOEXCEPT {
 #if FASTLED_ESP32_HAS_RMT
-    // Create RMT driver using the appropriate driver (RMT4 or RMT5)
+    // BusTraits<Bus::RMT> resolves to ChannelEngineRMT (RMT5) or
+    // ChannelEngineRMT4 depending on the build path; the right header is
+    // pulled in transitively via the bus_traits.h include above.
+    auto driver = BusTraits<Bus::RMT>::instancePtr();
     #if FASTLED_ESP32_RMT5_ONLY_PLATFORM || FASTLED_RMT5
-    auto driver = fl::ChannelEngineRMT::create();
     const char* version = "RMT5";
     #else
-    auto driver = fl::ChannelEngineRMT4::create();
     const char* version = "RMT4";
     #endif
 
@@ -261,7 +275,7 @@ static void addRmtIfPossible(ChannelManager& manager) FL_NOEXCEPT {
 /// @brief Add I2S_SPI driver if supported by platform (ESP32dev true SPI)
 static void addI2sSpiIfPossible(ChannelManager& manager) FL_NOEXCEPT {
 #if FASTLED_ESP32_HAS_I2S
-    auto driver = createI2sSpiEngine();
+    auto driver = BusTraits<Bus::I2S_SPI>::instancePtr();
     if (driver) {
         manager.addDriver(PRIORITY_I2S_SPI, driver);
         FL_DBG("ESP32: Added I2S_SPI driver (priority " << PRIORITY_I2S_SPI << ")");
@@ -276,7 +290,7 @@ static void addI2sSpiIfPossible(ChannelManager& manager) FL_NOEXCEPT {
 /// @brief Add LCD_SPI driver if supported by platform (ESP32-S3 true SPI)
 static void addLcdSpiIfPossible(ChannelManager& manager) FL_NOEXCEPT {
 #if FASTLED_ESP32_HAS_LCD_SPI
-    auto driver = createLcdSpiEngine();
+    auto driver = BusTraits<Bus::LCD_SPI>::instancePtr();
     if (driver) {
         manager.addDriver(PRIORITY_LCD_SPI, driver);
         FL_DBG("ESP32-S3: Added LCD_SPI driver (priority " << PRIORITY_LCD_SPI << ")");
@@ -291,7 +305,7 @@ static void addLcdSpiIfPossible(ChannelManager& manager) FL_NOEXCEPT {
 /// @brief Add LCD_CAM clockless driver if supported (ESP32-S3, replaces misnamed I2S)
 static void addLcdClocklessIfPossible(ChannelManager& manager) FL_NOEXCEPT {
 #if FASTLED_ESP32_HAS_LCD_SPI
-    auto driver = createLcdClocklessEngine();
+    auto driver = BusTraits<Bus::LCD_CLOCKLESS>::instancePtr();
     if (driver) {
         manager.addDriver(PRIORITY_LCD_CLOCKLESS, driver);
         FL_DBG("ESP32-S3: Added LCD_CLOCKLESS driver (priority " << PRIORITY_LCD_CLOCKLESS << ")");
@@ -306,9 +320,9 @@ static void addLcdClocklessIfPossible(ChannelManager& manager) FL_NOEXCEPT {
 /// @brief Add I2S LCD_CAM driver if supported by platform
 static void addI2sIfPossible(ChannelManager& manager) FL_NOEXCEPT {
 #if FASTLED_ESP32_HAS_I2S_LCD_CAM
-    // I2S LCD_CAM driver uses LCD_CAM peripheral via I80 bus (ESP32-S3 only)
-    // Experimental driver - uses transpose encoding for parallel LED output
-    auto driver = createI2sEngine();
+    // I2S LCD_CAM driver uses LCD_CAM peripheral via I80 bus (ESP32-S3 only).
+    // Experimental driver - uses transpose encoding for parallel LED output.
+    auto driver = BusTraits<Bus::I2S>::instancePtr();
     if (driver) {
         manager.addDriver(PRIORITY_I2S, driver);
         FL_DBG("ESP32-S3: Added I2S LCD_CAM driver (priority " << PRIORITY_I2S << ")");
@@ -328,7 +342,18 @@ namespace platforms {
 ///
 /// Called lazily on first access to ChannelManager::instance().
 /// Registers platform-specific drivers (PARLIO, SPI, UART, RMT) with the bus manager.
+///
+/// Defining `FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY=1` disables this auto-init.
+/// Users opting in must call `fl::enableDrivers<fl::Bus::X...>()` explicitly to
+/// register only the drivers they need -- this is the pathway that lets the
+/// linker drop unused driver TUs (#2420 binary-bloat fix). Phase 5b of #2428
+/// will flip the default; this commit (Phase 5a) just adds the opt-in.
 void initChannelDrivers() FL_NOEXCEPT {
+#if FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY
+    // Opt-in mode: skip auto-registration entirely. Users must call
+    // fl::enableDrivers<fl::Bus::X, ...>() to register the drivers they need.
+    FL_DBG("ESP32: Legacy driver auto-init disabled (FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY=1)");
+#else
     FL_DBG("ESP32: Lazy initialization of channel drivers");
 
     auto& manager = channelManager();
@@ -347,6 +372,7 @@ void initChannelDrivers() FL_NOEXCEPT {
     detail::addI2sIfPossible(manager);          // Priority 1 (clockless, legacy I2S name)
 
     FL_DBG("ESP32: Channel drivers initialized");
+#endif  // !FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY
 }
 
 } // namespace platforms

--- a/src/platforms/stub/init_channel_driver.h
+++ b/src/platforms/stub/init_channel_driver.h
@@ -11,8 +11,16 @@
 #include "fl/channels/manager.h"
 #include "fl/channels/channel.h"
 #include "fl/stl/shared_ptr.h"
+#include "platforms/stub/bus_traits.h"
 #include "platforms/stub/clockless_channel_engine_stub.h"
 #include "fl/stl/noexcept.h"
+
+// FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY: when defined to 1, this stub auto-init
+// is a no-op. Users opting in must call `fl::enableDrivers<fl::Bus::STUB>()`
+// explicitly. Default 0 for backward compatibility. See #2428 Phase 5.
+#ifndef FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY
+#define FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY 0
+#endif
 
 namespace fl {
 namespace platforms {
@@ -22,17 +30,19 @@ namespace platforms {
 /// Registers ClocklessChannelEngineStub with the ChannelManager so that
 /// the FastLED.add() API (Channel objects) drives stub GPIO simulation and
 /// fires SimEdgeObserver callbacks that NativeRxDevice uses for validation.
+///
+/// Delegates to `BusTraits<Bus::STUB>::instancePtr()` so the singleton is
+/// shared with the new `fl::enableDrivers<Bus::STUB>()` API. Phase 5b will
+/// flip the default of `FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY` to 1.
 inline void initChannelDrivers() FL_NOEXCEPT {
+#if FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY
+    // Opt-in mode: skip auto-registration. Users call enableDrivers<Bus::STUB>().
+#else
     fl::ChannelManager& manager = fl::ChannelManager::instance();
-
-    // Register the stub clockless driver with priority 1.
     // Priority 1 > 0 (the no-op StubChannelDriver registered elsewhere),
     // so this driver is preferred for clockless channels on the stub platform.
-    static fl::stub::ClocklessChannelEngineStub stubEngine;  // ok static in header
-    // Cast to base so make_shared_no_tracking creates shared_ptr<IChannelDriver>
-    fl::IChannelDriver& driverRef = stubEngine;
-    auto sharedDriver = fl::make_shared_no_tracking(driverRef);
-    manager.addDriver(1, sharedDriver);
+    manager.addDriver(1, BusTraits<Bus::STUB>::instancePtr());
+#endif  // !FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY
 }
 
 }  // namespace platforms

--- a/tests/fl/channels/bus_traits.cpp
+++ b/tests/fl/channels/bus_traits.cpp
@@ -88,4 +88,25 @@ FL_TEST_CASE("enableDrivers<Bus::STUB>() registers the stub driver with ChannelM
     FL_CHECK(stubDriver.get() == &fl::BusTraits<fl::Bus::STUB>::instance());
 }
 
+FL_TEST_CASE("Legacy initChannelDrivers() and enableDrivers<Bus::STUB>() share singleton (Phase 5a)") {
+    // Phase 5a guarantee: the legacy auto-init path and the new opt-in
+    // enableDrivers<Bus::X>() API register the same singleton instance.
+    // Before Phase 5a, the legacy `initChannelDrivers()` constructed a fresh
+    // ClocklessChannelEngineStub via `fl::make_shared_no_tracking(stubEngine)`,
+    // distinct from the BusTraits singleton.
+    auto& mgr = fl::ChannelManager::instance();
+    // The legacy auto-init runs lazily on first ChannelManager::instance() call;
+    // accessing instance() above guaranteed it ran. Verify the registered driver
+    // identity matches the BusTraits singleton.
+    auto registered = mgr.getDriverByName(fl::string::from_literal("STUB"));
+    FL_REQUIRE(registered != nullptr);
+    FL_CHECK(registered.get() == &fl::BusTraits<fl::Bus::STUB>::instance());
+    // Calling enableDrivers explicitly must not change the registered driver
+    // identity -- the manager replaces by name with the same singleton.
+    fl::enableDrivers<fl::Bus::STUB>();
+    auto registered2 = mgr.getDriverByName(fl::string::from_literal("STUB"));
+    FL_REQUIRE(registered2 != nullptr);
+    FL_CHECK(registered2.get() == &fl::BusTraits<fl::Bus::STUB>::instance());
+}
+
 }  // FL_TEST_FILE


### PR DESCRIPTION
## Summary

Phase 5a of #2428. Two changes, both backward-compatible (default behavior unchanged):

1. **Unify legacy auto-init with the new BusTraits singletons** — fixes the duplication caveat documented in Phase 4 (#2437).
2. **Add `FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY` opt-in macro** — sets up Phase 5b (the actual binary-bloat fix). Default 0, no behavior change.

## Change 1: Singleton unification

Pre-Phase-5a, `addParlioIfPossible()` etc. in `channel_manager_esp32.cpp.hpp` constructed fresh driver instances via `fl::make_shared<ChannelDriverPARLIO>()`, distinct from the singleton owned by `BusTraits<Bus::PARLIO>`. Calling `fl::enableDrivers<fl::Bus::PARLIO>()` after the legacy auto-init created a *second* PARLIO driver that tried to claim the PARLIO peripheral concurrently.

All 9 `addXxxIfPossible()` helpers now delegate to `BusTraits<Bus::X>::instancePtr()`. The legacy and new APIs share the same singleton — `mgr.getDriverByName(\"PARLIO\")` returns the same `shared_ptr` whether you reach it via auto-init or explicit `enableDrivers`.

Same change applied to `src/platforms/stub/init_channel_driver.h`.

The unified-SPI hardware adapter (`SpiHw1` via `SpiChannelEngineAdapter`) is intentionally *not* unified — it has no `Bus` enum value because it wraps a runtime-discovered set of controllers. Stays on its existing path.

## Change 2: `FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY`

When defined to 1, `initChannelDrivers()` becomes a no-op (on both ESP32 and stub). Users opting in must call `fl::enableDrivers<fl::Bus::X...>()` explicitly. **This is the pathway that lets the linker drop unused driver TUs** (#2420 binary-bloat fix). Default 0 — behavior unchanged in this PR.

## Phase 5b (next, not in this PR) will

- Flip the default of `FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY` to 1.
- Retarget the legacy `addLeds<>` clockless path to call `BusTraits<DefaultBus<ClocklessChipset>::value>::instance()` directly, bypassing `ChannelManager::selectDriverForChannel()` so no manager drivers need to be registered for legacy sketches.
- Gate the `_build.cpp.hpp` driver aggregator behind the same flag so unused driver TUs don't link.
- Measure binary size on the #2420 reproducer (NEOPIXEL on ESP32-S3 — expect ~783 KB → ~344 KB).

## New regression test

`tests/fl/channels/bus_traits.cpp` adds `\"Legacy initChannelDrivers() and enableDrivers<Bus::STUB>() share singleton\"` — would have failed pre-5a (legacy registered a different instance than the BusTraits singleton). Verifies pointer identity in both directions.

## Verification

- `bash lint` clean.
- `bash test --cpp` passes **303/303**.
- New singleton-identity test passes.
- Default behavior byte-for-byte unchanged on ESP32 and stub auto-init paths.

## Test plan

- [x] Host tests pass.
- [x] Singleton-identity test verifies the unification directly.
- [ ] CI verifies all platforms still build and behave identically (default macro 0).
- [ ] Phase 5b will exercise `FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY=1` and measure binary size.

## Related

- Tracked in #2428.
- Phase 4 (#2437) merged 2026-05-10 — laid the `enableDrivers<>` API; this PR removes its singleton-duplication caveat.
- Phase 5b will deliver the actual binary-bloat fix from #2420 / #2421.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added opt-in configuration to disable legacy driver auto-registration via new macro.

* **Refactor**
  * Unified driver registration system across platform implementations for consistency.
  * Improved driver initialization to use singleton pattern across legacy and modern driver APIs.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/FastLED/pull/2438)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->