### PR TITLE
chore(fl): move ui.h aggregator into fl/ui/ subdirectory

### DIFF
--- a/examples/Animartrix/Animartrix.ino
+++ b/examples/Animartrix/Animartrix.ino
@@ -54,7 +54,7 @@ Performence notes @64x64:
 #include "fl/fx/fx_engine.h"
 
 #include "fl/fx/2d/animartrix.hpp"
-#include "fl/ui.h"
+#include "fl/ui/ui.h"
 #include "fl/audio/audio_processor.h"
 #include "fl/audio/detector/vibe.h"
 

--- a/examples/AnimartrixRing/AnimartrixRing.ino
+++ b/examples/AnimartrixRing/AnimartrixRing.ino
@@ -13,7 +13,7 @@
 
 #include "fl/math/math.h"
 #include "fl/math/screenmap.h"
-#include "fl/ui.h"
+#include "fl/ui/ui.h"
 #include "fl/math/math.h"
 #include "fl/fx/2d/animartrix.hpp"
 #include "fl/audio/audio_processor.h"

--- a/examples/AnimartrixRing/audio_reactive.h
+++ b/examples/AnimartrixRing/audio_reactive.h
@@ -4,7 +4,7 @@
 #include "FastLED.h"
 #include "fl/audio/audio_processor.h"
 #include "fl/fx/fx_engine.h"
-#include "fl/ui.h"
+#include "fl/ui/ui.h"
 
 struct AudioReactive {
     fl::shared_ptr<fl::audio::Processor> processor;

--- a/examples/Audio/Audio.ino
+++ b/examples/Audio/Audio.ino
@@ -11,7 +11,7 @@ void setup() {}
 void loop() {}
 #else
 
-#include "fl/ui.h"
+#include "fl/ui/ui.h"
 
 #define NUM_LEDS 180
 #define LEDS_PER_SEGMENT 60

--- a/examples/Audio/advanced/advanced.h
+++ b/examples/Audio/advanced/advanced.h
@@ -7,7 +7,7 @@
 
 
 
-#include "fl/ui.h"
+#include "fl/ui/ui.h"
 #include "fl/audio/audio.h"
 #include "fl/fft.h"
 #include "fl/math/xymap.h"

--- a/examples/Audio/simple/simple.h
+++ b/examples/Audio/simple/simple.h
@@ -32,7 +32,7 @@ all the UI elements you see below.
 #include "fl/math/math.h"
 #include "fl/gfx/raster.h"
 #include "fl/math/time_alpha.h"
-#include "fl/ui.h"
+#include "fl/ui/ui.h"
 #include "fl/gfx/xypath.h"
 #include "fl/stl/compiler_control.h"
 #include "fl/fx/time.h"

--- a/examples/AudioUrl/AudioUrl.ino
+++ b/examples/AudioUrl/AudioUrl.ino
@@ -12,7 +12,7 @@
 
 #include <FastLED.h>
 #include "fl/asset/asset.h"
-#include "fl/ui.h"
+#include "fl/ui/ui.h"
 #include "fl/stl/url.h"
 
 #define NUM_LEDS 64

--- a/examples/BeatDetection/BeatDetection.ino
+++ b/examples/BeatDetection/BeatDetection.ino
@@ -14,7 +14,7 @@ void loop() {}
 #else
 
 #include "fl/audio/audio_processor.h"
-#include "fl/ui.h"
+#include "fl/ui/ui.h"
 
 // LED Configuration
 #define NUM_LEDS 60

--- a/examples/Blur2d/Blur2d.ino
+++ b/examples/Blur2d/Blur2d.ino
@@ -15,7 +15,7 @@
 #include <Arduino.h>
 #include <FastLED.h>
 
-#include "fl/ui.h"
+#include "fl/ui/ui.h"
 #include "fl/math/xymap.h"
 
 

--- a/examples/Chromancer/Chromancer.ino
+++ b/examples/Chromancer/Chromancer.ino
@@ -34,7 +34,7 @@
 #include "fl/math/screenmap.h"
 #include "fl/math/math.h"
 #include "fl/stl/json.h"
-#include "fl/ui.h"
+#include "fl/ui/ui.h"
 #include "fl/stl/map.h"
 
 #include "fl/stl/string.h"

--- a/examples/Codec/Codec.ino
+++ b/examples/Codec/Codec.ino
@@ -6,7 +6,7 @@
 
 #include <FastLED.h>
 #include "fl/system/sketch_macros.h"
-#include "fl/ui.h"
+#include "fl/ui/ui.h"
 #include "fl/stl/string.h"
 
 #include "fl/math/xymap.h"

--- a/examples/Downscale/Downscale.h
+++ b/examples/Downscale/Downscale.h
@@ -21,7 +21,7 @@ all the UI elements you see below.
 #include "fl/math/math.h"
 #include "fl/gfx/raster.h"
 #include "fl/math/time_alpha.h"
-#include "fl/ui.h"
+#include "fl/ui/ui.h"
 #include "fl/gfx/xypath.h"
 #include "fl/fx/time.h"
 

--- a/examples/ElPanelReactive/ElPanelReactive.ino
+++ b/examples/ElPanelReactive/ElPanelReactive.ino
@@ -18,7 +18,7 @@
 #include "el_panel.h"
 #include "fl/math/filter/filter.h"
 #include "fl/math/math.h"
-#include "fl/ui.h"
+#include "fl/ui/ui.h"
 
 // ---------------------------------------------------------------------------
 // UI

--- a/examples/FireCylinder/FireCylinder.h
+++ b/examples/FireCylinder/FireCylinder.h
@@ -34,7 +34,7 @@ with colors transitioning from black to red/yellow/white (or other palettes).
 // 5. The time dimension adds continuous variation to make the fire look dynamic
 
 #include "FastLED.h"     // Main FastLED library for controlling LEDs
-#include "fl/ui.h"       // UI components for the FastLED web compiler (sliders, buttons, etc.)
+#include "fl/ui/ui.h"       // UI components for the FastLED web compiler (sliders, buttons, etc.)
 #include "fl/math/xymap.h"    // Mapping between 1D LED array and 2D coordinates
 #include "fl/fx/time.h"     // Time manipulation utilities for animations
 

--- a/examples/FireMatrix/FireMatrix.h
+++ b/examples/FireMatrix/FireMatrix.h
@@ -39,7 +39,7 @@ void loop() {}
 #else
 
 #include "FastLED.h"     // Main FastLED library for controlling LEDs
-#include "fl/ui.h"       // UI components for the FastLED web compiler (sliders, etc.)
+#include "fl/ui/ui.h"       // UI components for the FastLED web compiler (sliders, etc.)
 #include "fl/math/xymap.h"    // Mapping between 1D LED array and 2D coordinates
 #include "fl/fx/time.h"     // Time manipulation utilities
 

--- a/examples/FlowField/FlowField.ino
+++ b/examples/FlowField/FlowField.ino
@@ -21,7 +21,7 @@
 // fluid-like patterns from color emitters.
 
 #include <FastLED.h>
-#include "fl/ui.h"
+#include "fl/ui/ui.h"
 #include "fl/fx/2d/flowfield.h"
 
 // -- Matrix config --

--- a/examples/Fx/FxEngine/FxEngine.ino
+++ b/examples/Fx/FxEngine/FxEngine.ino
@@ -17,7 +17,7 @@
 #include "fl/fx/2d/noisepalette.h"
 #include "fl/fx/2d/animartrix.hpp"
 #include "fl/fx/fx_engine.h"
-#include "fl/ui.h"
+#include "fl/ui/ui.h"
 
 #define LED_PIN 2
 #define BRIGHTNESS 96

--- a/examples/Fx/FxNoisePlusPalette/FxNoisePlusPalette.ino
+++ b/examples/Fx/FxNoisePlusPalette/FxNoisePlusPalette.ino
@@ -12,7 +12,7 @@
 
 #include <FastLED.h>
 #include "fl/fx/2d/noisepalette.h"
-#include "fl/ui.h"
+#include "fl/ui/ui.h"
 
 #define LED_PIN 3
 #define BRIGHTNESS 96

--- a/examples/Fx/FxNoiseRing/FxNoiseRing.ino
+++ b/examples/Fx/FxNoiseRing/FxNoiseRing.ino
@@ -22,7 +22,7 @@
 #include "noisegen.h"
 #include "fl/math/screenmap.h"
 #include "fl/stl/span.h"
-#include "fl/ui.h"
+#include "fl/ui/ui.h"
 #include "fl/sensors/pir.h"
 #include "fl/stl/sstream.h"
 #include "fl/stl/assert.h"

--- a/examples/Fx/FxSdCard/FxSdCard.ino
+++ b/examples/Fx/FxSdCard/FxSdCard.ino
@@ -18,7 +18,7 @@
 #include "fl/fx/fx_engine.h"
 #include "fl/fx/video.h"
 #include "fl/system/file_system.h"
-#include "fl/ui.h"
+#include "fl/ui/ui.h"
 #include "fl/math/screenmap.h"
 #include "fl/system/file_system.h"
 

--- a/examples/Fx/FxWave2d/wavefx.cpp
+++ b/examples/Fx/FxWave2d/wavefx.cpp
@@ -25,7 +25,7 @@ which are blended together to create complex visual effects.
 
 #include "fl/math/math.h"  // Math helper functions and macros
 #include "fl/math/time_alpha.h"   // Time-based alpha/transition effects
-#include "fl/ui.h"           // UI components for the FastLED web compiler
+#include "fl/ui/ui.h"           // UI components for the FastLED web compiler
 #include "fl/fx/2d/blend.h"  // 2D blending effects between layers
 #include "fl/fx/2d/wave.h"   // 2D wave simulation
 

--- a/examples/Fx/Particles1d/Particles1d.h
+++ b/examples/Fx/Particles1d/Particles1d.h
@@ -14,7 +14,7 @@
 
 #include "fl/fx/1d/particles.h"
 #include "fl/math/screenmap.h"
-#include "fl/ui.h"
+#include "fl/ui/ui.h"
 
 
 #define NUM_LEDS 210

--- a/examples/LuminescentGrand/LuminescentGrand.ino
+++ b/examples/LuminescentGrand/LuminescentGrand.ino
@@ -31,7 +31,7 @@
 #include "arduino/ui_state.h"
 #include "shared/dprint.h"
 #include "fl/system/log.h"
-#include "fl/ui.h"
+#include "fl/ui/ui.h"
 #include "fl/stl/compiler_control.h"
 
 // Spoof the midi library so it thinks it's running on an arduino.

--- a/examples/LuminescentGrand/arduino/LedRopeTCL.cpp
+++ b/examples/LuminescentGrand/arduino/LedRopeTCL.cpp
@@ -7,7 +7,7 @@
 #include <Arduino.h>
 #include "FastLED.h"
 #include "fl/system/log.h"
-#include "fl/ui.h"
+#include "fl/ui/ui.h"
 #include "fl/math/math.h"
 
 #include "../shared/color.h"

--- a/examples/LuminescentGrand/arduino/buttons.h
+++ b/examples/LuminescentGrand/arduino/buttons.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <Arduino.h>
-#include "fl/ui.h"
+#include "fl/ui/ui.h"
 #include "fl/system/log.h"
 #include "fl/system/delay.h"
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -85,7 +85,7 @@ Tips:
 ### WASM (browser demos + JSON UI)
 
 - `examples/wasm/` and related WASM-focused examples run in the browser
-- The JSON UI system enables sliders, buttons, and other controls (see `src/platforms/wasm` and `src/fl/ui.h`)
+- The JSON UI system enables sliders, buttons, and other controls (see `src/platforms/wasm` and `src/fl/ui/ui.h`)
 - Typical flow: build to WebAssembly, serve the app, and interact via the browser UI
 
 ---
@@ -273,7 +273,7 @@ FastLED now supports flexible `@filter` directives in `.ino` sketch files for co
 
 - Many examples are deliberately small; for more reusable building blocks, see `src/fl/` and `src/fx/`
 - Prefer `fl::` containers, views (`fl::span`), and graphics helpers for portability and quality
-- For UI/remote control on capable targets, use the JSON UI elements (see `src/fl/ui.h`) and WASM bridge (`src/platforms/wasm`)
+- For UI/remote control on capable targets, use the JSON UI elements (see `src/fl/ui/ui.h`) and WASM bridge (`src/platforms/wasm`)
 
 ---
 

--- a/examples/Sailboat/Sailboat.ino
+++ b/examples/Sailboat/Sailboat.ino
@@ -15,7 +15,7 @@
 #include "fl/chipsets/chipset_timing_config.h"
 #include "fl/fx/1d/perlin_particle_punch.h"
 #include "fl/fx/fx_engine.h"
-#include "fl/ui.h"
+#include "fl/ui/ui.h"
 
 
 // ---------------------------------------------------------------------------

--- a/examples/Wave/Wave.h
+++ b/examples/Wave/Wave.h
@@ -16,7 +16,7 @@ all the UI elements you see below.
 */
 
 #include "fl/math/math.h"
-#include "fl/ui.h"
+#include "fl/ui/ui.h"
 #include "fl/math/wave/wave_simulation.h"
 #include <Arduino.h>
 #include <FastLED.h>

--- a/examples/Wave2d/Wave2d.h
+++ b/examples/Wave2d/Wave2d.h
@@ -23,7 +23,7 @@ This will compile and preview the sketch in the browser, and enable
 all the UI elements you see below.
 */
 
-#include "fl/ui.h"
+#include "fl/ui/ui.h"
 #include "fl/fx/2d/wave.h"
 #include <Arduino.h>
 #include <FastLED.h>

--- a/examples/XYPath/complex.h
+++ b/examples/XYPath/complex.h
@@ -20,7 +20,7 @@ all the UI elements you see below.
 #include "fl/math/math.h"
 #include "fl/gfx/raster.h"
 #include "fl/math/time_alpha.h"
-#include "fl/ui.h"
+#include "fl/ui/ui.h"
 #include "fl/gfx/xypath.h"
 #include "fl/fx/time.h"
 

--- a/examples/XYPath/direct.h
+++ b/examples/XYPath/direct.h
@@ -20,7 +20,7 @@ all the UI elements you see below.
 #include "fl/math/math.h"
 #include "fl/gfx/raster.h"
 #include "fl/math/time_alpha.h"
-#include "fl/ui.h"
+#include "fl/ui/ui.h"
 #include "fl/gfx/xypath.h"
 #include "fl/fx/time.h"
 #include "fl/gfx/leds.h"

--- a/examples/XYPath/simple.h
+++ b/examples/XYPath/simple.h
@@ -20,7 +20,7 @@ all the UI elements you see below.
 #include "fl/math/math.h"
 #include "fl/gfx/raster.h"
 #include "fl/math/time_alpha.h"
-#include "fl/ui.h"
+#include "fl/ui/ui.h"
 #include "fl/gfx/xypath.h"
 #include "fl/fx/time.h"
 

--- a/examples/wasm/wasm_impl.h
+++ b/examples/wasm/wasm_impl.h
@@ -18,7 +18,7 @@
 #include "fl/fx/fx_engine.h"
 
 #include "fl/fx/2d/animartrix.hpp"
-#include "fl/ui.h"
+#include "fl/ui/ui.h"
 
 
 

--- a/src/FastLED.h
+++ b/src/FastLED.h
@@ -166,7 +166,7 @@
 
 #include "fl/audio/input.h"
 #include "fl/audio/audio_processor.h"
-#include "fl/ui.h"  // for UIAudio (needed for CFastLED::add(UIAudio&) overload)
+#include "fl/ui/ui.h"  // for UIAudio (needed for CFastLED::add(UIAudio&) overload)
 
 // ============================================================================
 // C STRING FUNCTION USING DECLARATIONS
@@ -1627,7 +1627,7 @@ extern CFastLED FastLED;
 
 #include "fl/channels/spi.h"  // SPI device and multi-lane SPI support (1-16 lanes)
 
-#include "fl/ui.h"  // Provides UIButton, UISlider, UICheckbox, UINumberField and UITitle, UIDescription, UIHelp, UIGroup.
+#include "fl/ui/ui.h"  // Provides UIButton, UISlider, UICheckbox, UINumberField and UITitle, UIDescription, UIHelp, UIGroup.
 using fl::UITitle;
 using fl::UIDescription;
 using fl::UIHelp;

--- a/src/README.md
+++ b/src/README.md
@@ -173,7 +173,7 @@ void render_frame() {
 
 ```cpp
 #include <FastLED.h>
-#include "fl/ui.h"
+#include "fl/ui/ui.h"
 
 UISlider brightness("Brightness", 128, 0, 255);
 UICheckbox enabled("Enabled", true);

--- a/src/fl/README.md
+++ b/src/fl/README.md
@@ -929,7 +929,7 @@ FastLED includes a JSON‑driven UI layer that can expose controls (sliders, but
 
 - **Key headers and switches**
   - `platforms/ui_defs.h`: controls `FASTLED_USE_JSON_UI` (defaults to 1 on WASM, 0 elsewhere).
-  - `fl/ui.h`: C++ UI element classes (UISlider, UIButton, UICheckbox, UINumberField, UIDropdown, UITitle, UIDescription, UIHelp, UIAudio, UIGroup).
+  - `fl/ui/ui.h`: C++ UI element classes (UISlider, UIButton, UICheckbox, UINumberField, UIDropdown, UITitle, UIDescription, UIHelp, UIAudio, UIGroup).
   - `platforms/shared/ui/json/ui_manager.h`: platform‑agnostic JSON UI manager that integrates with `EngineEvents`.
   - `platforms/shared/ui/json/readme.md`: implementation guide and JSON protocol.
 
@@ -952,7 +952,7 @@ FastLED includes a JSON‑driven UI layer that can expose controls (sliders, but
 
   ```cpp
   #include <FastLED.h>
-  #include "fl/ui.h"
+  #include "fl/ui/ui.h"
 
   UISlider brightness("Brightness", 128, 0, 255);
   UICheckbox enabled("Enabled", true);

--- a/src/fl/audio/audio_manager.cpp.hpp
+++ b/src/fl/audio/audio_manager.cpp.hpp
@@ -2,7 +2,7 @@
 #include "fl/audio/input.h"
 #include "fl/stl/singleton.h"
 #include "fl/system/log.h"
-#include "fl/ui.h"
+#include "fl/ui/ui.h"
 
 namespace fl {
 namespace audio {

--- a/src/fl/sensors/button.cpp.hpp
+++ b/src/fl/sensors/button.cpp.hpp
@@ -2,7 +2,7 @@
 
 #include "fl/stl/stdint.h"
 
-#include "fl/ui.h"
+#include "fl/ui/ui.h"
 
 #include "fl/stl/assert.h"
 #include "fl/sensors/button.h"

--- a/src/fl/sensors/button.h
+++ b/src/fl/sensors/button.h
@@ -6,7 +6,7 @@
 #include "fl/stl/shared_ptr.h"
 #include "fl/system/engine_events.h"
 #include "fl/sensors/digital_pin.h"
-#include "fl/ui.h"  // For IButtonInput
+#include "fl/ui/ui.h"  // For IButtonInput
 #include "fl/stl/noexcept.h"
 
 namespace fl {

--- a/src/fl/sensors/digital_pin.cpp.hpp
+++ b/src/fl/sensors/digital_pin.cpp.hpp
@@ -1,7 +1,7 @@
 
 #include "fl/stl/stdint.h"
 
-#include "fl/ui.h"
+#include "fl/ui/ui.h"
 #include "fl/stl/shared_ptr.h"  // For make_shared
 
 #include "fl/sensors/digital_pin.h"

--- a/src/fl/sensors/pir.h
+++ b/src/fl/sensors/pir.h
@@ -3,7 +3,7 @@
 #include "fl/stl/stdint.h"
 
 #include "fl/sensors/digital_pin.h"
-#include "fl/ui.h"
+#include "fl/ui/ui.h"
 #include "fl/math/time_alpha.h"
 
 namespace fl {

--- a/src/fl/sensors/potentiometer.cpp.hpp
+++ b/src/fl/sensors/potentiometer.cpp.hpp
@@ -1,6 +1,6 @@
 #include "fl/stl/stdint.h"
 #include "platforms/is_platform.h"
-#include "fl/ui.h"
+#include "fl/ui/ui.h"
 #include "fl/stl/assert.h"
 #include "fl/sensors/potentiometer.h"
 #include "fl/system/pin.h"

--- a/src/fl/sensors/ui_button_integration.cpp.hpp
+++ b/src/fl/sensors/ui_button_integration.cpp.hpp
@@ -3,7 +3,7 @@
 /// @brief UIButton/UIDropdown <-> Button integration via IButtonInput interface.
 /// Compiled in fl.sensors+ to keep concrete Button out of fl.cpp link chain.
 
-#include "fl/ui.h"
+#include "fl/ui/ui.h"
 #include "fl/sensors/button.h"
 
 namespace fl {

--- a/src/fl/ui/ui.h
+++ b/src/fl/ui/ui.h
@@ -1,10 +1,10 @@
 #pragma once
 
-/// @file fl/ui.h
+/// @file fl/ui/ui.h
 /// @brief Aggregator header for the fl/ui/ family of per-element UI types.
 ///
 /// Each UI type lives in its own header under fl/ui/. This file re-exports
-/// them so existing consumers that include "fl/ui.h" continue to work.
+/// them so consumers can include the entire UI surface with one include.
 
 #include "fl/ui/audio.h"
 #include "fl/ui/button.h"

--- a/tests/fl/audio_url.cpp
+++ b/tests/fl/audio_url.cpp
@@ -2,7 +2,7 @@
 // Tests that UIAudio with a URL properly serializes the URL field
 // in the JSON UI output on the stub platform.
 
-#include "fl/ui.h"
+#include "fl/ui/ui.h"
 #include "fl/stl/json.h"
 #include "fl/system/log.h"
 #include "fl/stl/url.h"

--- a/tests/fl/ui/ui.cpp
+++ b/tests/fl/ui/ui.cpp
@@ -1,7 +1,7 @@
 // g++ --std=c++11 test.cpp
 
 
-#include "fl/ui.h"
+#include "fl/ui/ui.h"
 #include "platforms/shared/ui/json/ui.h"
 #include "platforms/shared/ui/json/ui_internal.h"
 #include "platforms/shared/ui/json/number_field.h"


### PR DESCRIPTION
## Summary
- Relocate `src/fl/ui.h` → `src/fl/ui/ui.h` so the aggregator lives beside the per-element headers it re-exports
- Update all 44 consumers (examples, src, tests, docs) to use the new include path — no backward-compat shim
- Move `tests/fl/ui.cpp` → `tests/fl/ui/ui.cpp` to satisfy `TestPathStructureChecker`'s source-path mirror requirement

## Motivation
First step in cleaning up the loose `.h` files at the root of `src/fl/`. The aggregator naturally belongs inside the directory it aggregates.

## Test plan
- [x] `bash test --cpp --clean` — 303/303 tests pass
- [x] `bash lint --cpp` — clean (TestPathStructureChecker happy after test rename)
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated UI library header includes across examples, source files, tests, and documentation to align with the reorganized library structure. All functionality remains unchanged.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/FastLED/pull/2439)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->