### PR TITLE
feat(channels): pre-bind legacy clockless to BusTraits singleton (Phase 5b of #2428)

### DIFF
--- a/src/fl/channels/bus.h
+++ b/src/fl/channels/bus.h
@@ -15,6 +15,24 @@
 #include "fl/stl/stdint.h"
 #include "platforms/is_platform.h"
 
+// FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY: opt-in macro that, when set to 1,
+// disables the legacy `initChannelDrivers()` auto-registration AND switches
+// per-platform legacy clockless controllers (stub `ClocklessController`,
+// ESP32 `ClocklessIdf5`, etc.) to pre-bind directly to their default
+// `BusTraits<Bus::X>::instancePtr()` -- bypassing `ChannelManager` entirely.
+//
+// This is the toggle that lets `--gc-sections` drop unreferenced driver TUs
+// (the binary-size fix from #2420). Default 0 for backward compatibility;
+// users opting in must call `fl::enableDrivers<fl::Bus::X...>()` explicitly
+// for any non-default driver they need at runtime.
+//
+// Defined here (early-included by every channels TU) so all consumers see the
+// same value -- the macro is checked from per-platform legacy clockless
+// headers as well as channel_manager_esp32.cpp.hpp.
+#ifndef FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY
+#define FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY 0
+#endif
+
 namespace fl {
 
 // Forward declarations. The chipset family types live in fl/channels/config.h,

--- a/src/fl/channels/channel.cpp.hpp
+++ b/src/fl/channels/channel.cpp.hpp
@@ -313,8 +313,18 @@ void Channel::showPixels(PixelController<RGB, 1, 0xFFFFFFFF> &pixels) {
         FL_WARN("Channel '" << mName << "': Engine became READY after waiting");
     }
 
-    auto driver = ChannelManager::instance().selectDriverForChannel(mChannelData, mAffinity);
-    mDriver = driver;
+    // Phase 5b of #2428: if the driver was pre-bound via setDriver() (legacy
+    // addLeds<>-style controllers naming BusTraits<Bus::X>::instancePtr() in
+    // their constructor), bypass ChannelManager entirely. Channels created via
+    // the manager-based API (Channel::create(cfg) without affinity) keep their
+    // existing per-frame re-selection so users can swap drivers at runtime.
+    fl::shared_ptr<IChannelDriver> driver;
+    if (mDriverPreBound) {
+        driver = mDriver.lock();
+    } else {
+        driver = ChannelManager::instance().selectDriverForChannel(mChannelData, mAffinity);
+        mDriver = driver;
+    }
     if (!driver) {
         FL_ERROR("Channel '" << mName << "': No compatible driver found - cannot transmit");
         return;

--- a/src/fl/channels/channel.h
+++ b/src/fl/channels/channel.h
@@ -193,6 +193,23 @@ protected:
     /// @note Does not set LED data or channel options - caller must do that
     Channel(const ChipsetVariant& chipset, EOrder rgbOrder, RegistrationMode mode);
 
+    /// @brief Pre-bind a driver, bypassing `ChannelManager::selectDriverForChannel()`
+    ///        on every subsequent `showPixels()` call.
+    ///
+    /// Used by legacy `addLeds<>`-style controllers (e.g. `ClocklessIdf5`) to
+    /// route directly to a `BusTraits<DefaultBus>::instancePtr()` singleton at
+    /// construction time. Combined with `FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY=1`,
+    /// this is what lets `--gc-sections` drop unreferenced driver TUs (Phase 5b
+    /// of #2428 — the binary-size fix for #2420).
+    ///
+    /// @note Stored as `weak_ptr` to avoid holding the driver alive past the
+    ///       caller's intent. The caller (typically the static singleton in a
+    ///       BusTraits) owns the strong reference.
+    void setDriver(fl::shared_ptr<IChannelDriver> driver) FL_NOEXCEPT {
+        mDriver = driver;
+        mDriverPreBound = true;
+    }
+
 private:
     /// @brief Private constructor (use create() factory method)
     /// @param chipset Chipset configuration (clockless or SPI)
@@ -219,6 +236,11 @@ private:
     ChipsetVariant mChipset;         // Chipset configuration (clockless or SPI)
     EOrder mRgbOrder;
     fl::weak_ptr<IChannelDriver> mDriver;  // Weak reference to driver (prevents dangling pointers)
+    bool mDriverPreBound = false;    // True if setDriver() was called (legacy addLeds<> path).
+                                     // When true, showPixels() uses mDriver directly and skips
+                                     // ChannelManager::selectDriverForChannel(). When false (the
+                                     // default), every showPixels() re-evaluates the manager's
+                                     // priority list so users can swap drivers at runtime.
     fl::string mAffinity;            // Engine affinity name (empty = no affinity, dynamic selection)
     const i32 mId;
     fl::string mName;               // User-specified or auto-generated name

--- a/src/platforms/esp/32/drivers/rmt/rmt_5/idf5_clockless.h
+++ b/src/platforms/esp/32/drivers/rmt/rmt_5/idf5_clockless.h
@@ -10,11 +10,13 @@
 #define FL_CLOCKLESS_CONTROLLER_DEFINED 1
 
 #include "eorder.h"
+#include "fl/channels/bus.h"
 #include "fl/channels/channel.h"
 #include "fl/channels/config.h"
 #include "fl/chipsets/timing_traits.h"
 #include "fl/stl/noexcept.h"
 #include "fl/stl/static_assert.h"
+#include "platforms/esp/32/drivers/rmt/rmt_5/bus_traits.h"
 
 namespace fl {
 template <int DATA_PIN, typename TIMING, EOrder RGB_ORDER = RGB, int XTRA0 = 0, bool FLIP = false, int WAIT_TIME = 280>
@@ -31,6 +33,19 @@ public:
     ClocklessIdf5() FL_NOEXCEPT
         : Channel(makeChipset(), RGB_ORDER, RegistrationMode::DeferRegister)
     {
+#if FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY
+        // Phase 5b of #2428 (opt-in mode): pre-bind to the RMT5 driver
+        // singleton so showPixels() bypasses ChannelManager entirely.
+        // Naming BusTraits<Bus::RMT>::instancePtr() here is the ODR-use
+        // that lets the linker keep ONLY the RMT5 driver TU when the user
+        // opts into FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY=1 -- the
+        // binary-size fix from #2420.
+        // Default mode (macro 0) leaves mDriver unbound so the existing
+        // selectDriverForChannel() path runs each frame -- preserves
+        // backward compat for users registering custom drivers via
+        // ChannelManager.
+        setDriver(BusTraits<Bus::RMT>::instancePtr());
+#endif
         // Auto-register in the controller draw list (template API expects this)
         addToList();
     }

--- a/src/platforms/stub/clockless_channel_stub.h
+++ b/src/platforms/stub/clockless_channel_stub.h
@@ -12,6 +12,7 @@
 #include "eorder.h"
 #include "fl/stl/compiler_control.h"
 #include "fl/chipsets/timing_traits.h"
+#include "fl/channels/bus.h"
 #include "fl/channels/data.h"
 #include "fl/channels/driver.h"
 #include "fl/channels/manager.h"
@@ -20,6 +21,7 @@
 #include "fl/system/log.h"
 #include "fl/stl/vector.h"
 #include "platforms/shared/active_strip_tracker/active_strip_tracker.h"
+#include "platforms/stub/bus_traits.h"
 #include "platforms/stub/stub_gpio.h"
 #include "fl/stl/noexcept.h"
 
@@ -49,6 +51,16 @@ public:
         // Create channel data with pin and timing configuration
         ChipsetTimingConfig timing = makeTimingConfig<TIMING>();
         mChannelData = ChannelData::create(DATA_PIN, timing);
+#if FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY
+        // Phase 5b of #2428 (opt-in mode): pre-bind to the stub driver
+        // singleton so showPixels() bypasses ChannelManager entirely.
+        // Naming BusTraits<Bus::STUB>::instancePtr() here is the ODR-use
+        // that lets the linker keep ONLY the stub driver TU.
+        // Default mode (macro 0) leaves mDriver unbound so the existing
+        // selectDriverForChannel() path runs each frame -- preserves
+        // backward compat for tests that register custom mock drivers.
+        mDriver = BusTraits<Bus::STUB>::instancePtr();
+#endif
     }
 
     virtual void init() FL_NOEXCEPT override { }


### PR DESCRIPTION
## Summary

Phase 5b of #2428. Lays the foundation for the binary-bloat fix from #2420 / #2421. Adds an opt-in `ChannelManager`-bypass for legacy `addLeds<>`-style controllers, gated behind `FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY=1` so default behavior is unchanged.

## Mechanism

**1. `Channel::setDriver(shared_ptr<IChannelDriver>)`** — new protected setter that records a pre-bound driver AND sets `mDriverPreBound = true`.

**2. `Channel::showPixels()`** — when `mDriverPreBound` is true, uses the cached `mDriver` directly and bypasses `ChannelManager::selectDriverForChannel()`. When false (the default for `Channel::create(cfg)`-created channels), the existing per-frame manager re-selection runs as before — preserves the *swap drivers at runtime by changing priorities* contract that the `Channel API: Non-affinity channel re-binds when driver priorities swap` test depends on.

**3. Per-platform legacy clockless controllers pre-bind their default Bus's driver in their constructor**, gated by the new opt-in macro:

- `src/platforms/esp/32/drivers/rmt/rmt_5/idf5_clockless.h` → `Bus::RMT`
- `src/platforms/stub/clockless_channel_stub.h` → `Bus::STUB`

Naming `BusTraits<Bus::X>::instancePtr()` here is the ODR-use that lets the linker keep ONLY the platform-default driver TU when the user enables the macro. Combined with future per-driver opt-in aggregator gating (Phase 5c), this delivers the binary-size fix from #2420.

**4. `FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY` defined centrally** in `fl/channels/bus.h` (default 0) so all consumers see the same value.

## Phase 5c (next, not in this PR)

- Gate `_build.cpp.hpp` aggregators by the macro so unused driver TUs aren't compiled.
- Wire up other ESP32 legacy clockless paths (RMT4, ClocklessSPI fallback, ClocklessBlocking fallback).
- Measure binary size on the #2420 reproducer (expect ~783 KB → ~344 KB on NEOPIXEL ESP32-S3).

## Verification

- `bash lint` clean.
- `bash test fastled_core --debug --clean` — passes 46/46 in isolation, proving the manager re-selection contract is preserved.
- `bash test --cpp` full suite shows pre-existing test-order flakes inherited from master HEAD (`fastled_core: Channel API: Non-affinity channel re-binds` and a few stl tests). **All affected tests pass when run in isolation.** Verified by stashing my changes and re-running on bare master HEAD — same `fastled_core` failure shows up. None of the failures are caused by this PR.
- `mDriverPreBound` default-initialized to `false`, so `Channel::create(cfg)` behavior is byte-for-byte identical to pre-PR.

## Test plan

- [x] Singleton-identity preserved (Phase 5a regression test still passes).
- [x] Manager re-selection contract preserved (fastled_core isolated pass).
- [x] Default behavior unchanged (macro 0 → original code paths).
- [ ] Phase 5c will exercise `FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY=1` and measure binary size.

## Related

- Tracked in #2428.
- Builds on Phase 5a (#2438) which unified the legacy auto-init with the BusTraits singletons.
- Sets up Phase 5c which delivers the actual binary-bloat fix from #2420.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Optimization**
  * Added support for driver pre-binding to improve channel initialization performance in supported configurations.
  * Introduced optional compile-time toggle to enable direct driver path selection, reducing unnecessary re-selection overhead.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/FastLED/pull/2441)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->