### PR TITLE
feat(channels): add fl::enableAllDrivers() one-shot driver enrollment (#2428)

### DIFF
--- a/src/FastLED.h
+++ b/src/FastLED.h
@@ -829,6 +829,37 @@ public:
 	/// @endcode
 	static fl::shared_ptr<fl::audio::Processor> add(fl::UIAudio& uiAudio);
 
+	/// @brief Enroll every channel driver available on this platform with `ChannelManager`.
+	///
+	/// Convenience forwarder to `fl::enableAllDrivers()` (defined in
+	/// `fl/channels/all_drivers.h`). Use this to restore 3.10.3-style runtime
+	/// driver flexibility — every driver is registered, any affinity string
+	/// resolves at runtime.
+	///
+	/// **Linker note (issue #2428).** This member's body lives in
+	/// `fl/channels/all_drivers.h`. Including that header is what makes the
+	/// per-platform `BusTraits<Bus::X>::instance()` singletons visible at the
+	/// call site so the linker keeps their translation units. If a sketch
+	/// never calls `FastLED.enableAllDrivers()`, `--gc-sections` drops the
+	/// inline body and every driver TU it references — the binary-bloat fix
+	/// from #2420 / #2421 is preserved.
+	///
+	/// Example:
+	/// @code
+	/// #include "FastLED.h"
+	/// #include "fl/channels/all_drivers.h"
+	///
+	/// void setup() {
+	///     FastLED.enableAllDrivers();   // every platform driver registered
+	///     fl::ChannelOptions opts; opts.mAffinity = "RMT";
+	///     FastLED.add(fl::ChannelConfig(...));
+	/// }
+	/// @endcode
+	///
+	/// @note Calling without including `fl/channels/all_drivers.h` produces a
+	///       linker error — the include is the explicit opt-in.
+	static void enableAllDrivers();
+
 	/// @brief Remove a channel from the LED controller list
 	///
 	/// Removes the channel from the active controller list so it will no longer

--- a/src/fl/channels/all_drivers.h
+++ b/src/fl/channels/all_drivers.h
@@ -1,0 +1,159 @@
+#pragma once
+
+/// @file all_drivers.h
+/// @brief One-shot include + helper that enrolls every channel driver
+///        available on the current platform into `ChannelManager`.
+///
+/// In the default build, FastLED no longer eagerly registers every driver with
+/// `ChannelManager` (see issue #2428 — Phase 4 / Phase 5). Drivers are linked
+/// only when their `BusTraits<fl::Bus::X>::instance()` is named, which lets
+/// `--gc-sections` drop unreferenced driver TUs.
+///
+/// Sketches that want the 3.10.3-style behaviour (every driver registered, any
+/// affinity string resolves at runtime) can opt back in with one line:
+///
+/// @code
+///   #include "fl/channels/all_drivers.h"
+///   void setup() {
+///       FastLED.enableAllDrivers();      // or: fl::enableAllDrivers();
+///       FastLED.add(cfg_with_affinity);  // ChannelManager picks the driver
+///   }
+/// @endcode
+///
+/// Including this header pulls in every per-driver `bus_traits.h` that is
+/// reachable on the current platform, which makes the corresponding
+/// `BusTraits<Bus::X>` specializations visible at the call site. The helper
+/// then expands a single `enableDrivers<...>()` call covering them all.
+///
+/// This file is the canonical "kitchen-sink" driver bundle. Sketches that want
+/// only a subset should call `fl::enableDrivers<fl::Bus::X, fl::Bus::Y>()`
+/// directly after including the matching `bus_traits.h` headers.
+
+#include "fl/channels/bus.h"
+#include "fl/channels/bus_traits.h"
+#include "fl/stl/compiler_control.h"
+#include "fl/system/fastled.h"
+#include "platforms/is_platform.h"
+
+#if defined(FL_IS_ESP32)
+// Pulled in here so the per-bus guards below see the FASTLED_ESP32_HAS_*
+// macros at the call site.
+#include "platforms/esp/32/feature_flags/enabled.h"  // ok platform headers // IWYU pragma: keep
+#endif
+
+// ---------------------------------------------------------------------------
+// Always-on drivers
+// ---------------------------------------------------------------------------
+
+#include "platforms/shared/bitbang/bus_traits.h"  // ok platform headers // IWYU pragma: keep
+
+// ---------------------------------------------------------------------------
+// Host / native / WASM
+// ---------------------------------------------------------------------------
+
+#if defined(FL_IS_STUB) || defined(FL_IS_WASM)
+#include "platforms/stub/bus_traits.h"  // ok platform headers // IWYU pragma: keep
+#endif
+
+// ---------------------------------------------------------------------------
+// ESP32 family
+// ---------------------------------------------------------------------------
+
+#if defined(FL_IS_ESP32)
+
+// Each per-driver bus_traits.h applies its own `FASTLED_ESP32_HAS_*` /
+// `FASTLED_RMT5` guard internally, so the include is unconditional here.
+#include "platforms/esp/32/drivers/i2s/bus_traits.h"        // ok platform headers // IWYU pragma: keep
+#include "platforms/esp/32/drivers/i2s_spi/bus_traits.h"    // ok platform headers // IWYU pragma: keep
+#include "platforms/esp/32/drivers/lcd_cam/bus_traits.h"    // ok platform headers // IWYU pragma: keep
+#include "platforms/esp/32/drivers/lcd_spi/bus_traits.h"    // ok platform headers // IWYU pragma: keep
+#include "platforms/esp/32/drivers/parlio/bus_traits.h"     // ok platform headers // IWYU pragma: keep
+#include "platforms/esp/32/drivers/rmt/rmt_4/bus_traits.h"  // ok platform headers // IWYU pragma: keep
+#include "platforms/esp/32/drivers/rmt/rmt_5/bus_traits.h"  // ok platform headers // IWYU pragma: keep
+#include "platforms/esp/32/drivers/spi/bus_traits.h"        // ok platform headers // IWYU pragma: keep
+#include "platforms/esp/32/drivers/uart/bus_traits.h"       // ok platform headers // IWYU pragma: keep
+
+#endif  // FL_IS_ESP32
+
+// ---------------------------------------------------------------------------
+// Teensy 4.x
+// ---------------------------------------------------------------------------
+
+#if defined(FL_IS_TEENSY_4X)
+#include "platforms/arm/teensy/teensy4_common/drivers/objectfled/bus_traits.h"  // ok platform headers // IWYU pragma: keep
+#include "platforms/arm/teensy/teensy4_common/drivers/flexio/bus_traits.h"      // ok platform headers // IWYU pragma: keep
+#endif
+
+namespace fl {
+
+/// @brief Register every channel driver available on this platform with
+///        `ChannelManager`, restoring 3.10.3-style runtime driver selection.
+///
+/// This is the convenience counterpart to `fl::enableDrivers<Bus...>()`. It
+/// expands to a fold over the platform-appropriate `Bus` set so that:
+///
+///   - Each driver's translation unit is linked (its `BusTraits<B>::instance()`
+///     is ODR-used).
+///   - Each driver is registered with `ChannelManager` at its default priority,
+///     allowing `Channel::create(cfg)` to dispatch by affinity / priority at
+///     runtime.
+///
+/// The helper is idempotent — `BusTraits<B>::registerWithManager()` deduplicates
+/// by name on the manager side, so calling it more than once is safe.
+///
+/// **Performance vs. binary size.** Calling this brings every driver TU into
+/// the link, which is exactly what the default build avoids (see #2428 for the
+/// motivation). Only call it when you actually need runtime flexibility.
+inline void enableAllDrivers() FL_NOEXCEPT {
+    enableDrivers<
+        Bus::BIT_BANG
+#if defined(FL_IS_STUB) || defined(FL_IS_WASM)
+        , Bus::STUB
+#endif
+#if defined(FL_IS_ESP32) && FASTLED_ESP32_HAS_RMT
+        , Bus::RMT
+#endif
+#if defined(FL_IS_ESP32) && FASTLED_ESP32_HAS_PARLIO
+        , Bus::PARLIO
+#endif
+#if defined(FL_IS_ESP32) && FASTLED_ESP32_HAS_CLOCKLESS_SPI
+        , Bus::SPI
+#endif
+#if defined(FL_IS_ESP32) && FASTLED_ESP32_HAS_I2S_LCD_CAM
+        , Bus::I2S
+#endif
+#if defined(FL_IS_ESP32) && FASTLED_ESP32_HAS_I2S
+        , Bus::I2S_SPI
+#endif
+#if defined(FL_IS_ESP32) && FASTLED_ESP32_HAS_LCD_RGB
+        , Bus::LCD_RGB
+#endif
+#if defined(FL_IS_ESP32) && FASTLED_ESP32_HAS_LCD_SPI
+        , Bus::LCD_SPI
+        , Bus::LCD_CLOCKLESS
+#endif
+#if defined(FL_IS_ESP32) && FASTLED_ESP32_HAS_UART
+        , Bus::UART
+#endif
+#if defined(FL_IS_TEENSY_4X)
+        , Bus::OBJECT_FLED
+        , Bus::FLEX_IO
+#endif
+    >();
+}
+
+}  // namespace fl
+
+/// @brief Out-of-line definition of the `CFastLED::enableAllDrivers()` member
+///        declared in `FastLED.h`.
+///
+/// Defined here so that calling `FastLED.enableAllDrivers()` requires the user
+/// to `#include "fl/channels/all_drivers.h"` — which is what brings the
+/// per-platform `BusTraits<Bus::X>` specializations into scope. Without that
+/// include the call fails to link, preserving the binary-bloat fix from #2428.
+///
+/// Marked `inline` so multiple translation units that include this header
+/// don't produce duplicate-symbol linker errors.
+inline void CFastLED::enableAllDrivers() {
+    fl::enableAllDrivers();
+}

--- a/tests/fl/channels/all_drivers.cpp
+++ b/tests/fl/channels/all_drivers.cpp
@@ -1,0 +1,102 @@
+/// @file all_drivers.cpp
+/// @brief Sanity test for fl::enableAllDrivers() on the host build.
+///
+/// `fl::enableAllDrivers()` is the convenience helper introduced for issue
+/// #2428: it registers every driver visible on the current platform with
+/// `ChannelManager`, restoring 3.10.3-style runtime driver flexibility for
+/// users who opt back in.
+///
+/// On the host (FL_IS_STUB) the only buses with actual `BusTraits<>`
+/// specializations are `Bus::STUB` (the host-only stub driver) and
+/// `Bus::BIT_BANG` (always-on portable fallback). After calling
+/// `enableAllDrivers()` both must be findable in the manager registry and
+/// must be the same singleton instances exposed by `BusTraits<B>::instance()`.
+///
+/// `ChannelManager` is a process-singleton, so every test case begins by
+/// clearing the registry and asserting it is empty — otherwise a later case
+/// could pass purely on residue from an earlier one (e.g. the "forwards"
+/// test would succeed even if `FastLED.enableAllDrivers()` were a no-op).
+
+#include "fl/channels/all_drivers.h"
+#include "fl/channels/bus.h"
+#include "fl/channels/bus_traits.h"
+#include "fl/channels/manager.h"
+#include "fl/stl/string.h"
+#include "test.h"
+
+FL_TEST_FILE(FL_FILEPATH) {
+
+using namespace fl;
+
+namespace {
+
+// Reset the shared singleton so each case starts from a known-empty registry.
+// Returns the manager reference for convenience.
+fl::ChannelManager& freshManager() {
+    auto& mgr = fl::ChannelManager::instance();
+    mgr.clearAllDrivers();
+    return mgr;
+}
+
+}  // namespace
+
+FL_TEST_CASE("enableAllDrivers() registers Bus::STUB and Bus::BIT_BANG on host") {
+    auto& mgr = freshManager();
+    FL_REQUIRE(mgr.getDriverCount() == 0);
+
+    fl::enableAllDrivers();
+
+    // Bus::BIT_BANG is always-on (no platform guard) and must register on
+    // every build, including the host test runner. The driver's getName()
+    // returns "BITBANG" (no underscore) — the manager keys on that string.
+    auto bitbang = mgr.getDriverByName(fl::string::from_literal("BITBANG"));
+    FL_REQUIRE(bitbang != nullptr);
+    FL_CHECK(bitbang.get() == &fl::BusTraits<fl::Bus::BIT_BANG>::instance());
+
+    // Bus::STUB is host-only — guarded by FL_IS_STUB / FL_IS_WASM in
+    // all_drivers.h. Tests run with FL_IS_STUB defined, so it must register.
+    auto stub = mgr.getDriverByName(fl::string::from_literal("STUB"));
+    FL_REQUIRE(stub != nullptr);
+    FL_CHECK(stub.get() == &fl::BusTraits<fl::Bus::STUB>::instance());
+}
+
+FL_TEST_CASE("FastLED.enableAllDrivers() forwards to fl::enableAllDrivers()") {
+    auto& mgr = freshManager();
+    FL_REQUIRE(mgr.getDriverCount() == 0);
+
+    // Drive the member-function entry point on an empty registry. If the
+    // member did nothing, the lookups below would return null because the
+    // precondition above guarantees no prior registration leaked in.
+    FastLED.enableAllDrivers();
+
+    auto bitbang = mgr.getDriverByName(fl::string::from_literal("BITBANG"));
+    FL_REQUIRE(bitbang != nullptr);
+    FL_CHECK(bitbang.get() == &fl::BusTraits<fl::Bus::BIT_BANG>::instance());
+
+    auto stub = mgr.getDriverByName(fl::string::from_literal("STUB"));
+    FL_REQUIRE(stub != nullptr);
+    FL_CHECK(stub.get() == &fl::BusTraits<fl::Bus::STUB>::instance());
+}
+
+FL_TEST_CASE("enableAllDrivers() is idempotent") {
+    auto& mgr = freshManager();
+    FL_REQUIRE(mgr.getDriverCount() == 0);
+
+    fl::enableAllDrivers();
+    auto count_after_first = mgr.getDriverCount();
+    FL_REQUIRE(count_after_first > 0);  // at least BIT_BANG + STUB on host
+
+    fl::enableAllDrivers();
+    auto count_after_second = mgr.getDriverCount();
+
+    // Manager replaces by name on duplicate `addDriver`, so a second call
+    // must leave the count unchanged.
+    FL_CHECK(count_after_first == count_after_second);
+
+    // The driver identities must not change either — same singletons.
+    auto bitbang = mgr.getDriverByName(fl::string::from_literal("BITBANG"));
+    FL_REQUIRE(bitbang != nullptr);
+    FL_CHECK(bitbang.get() == &fl::BusTraits<fl::Bus::BIT_BANG>::instance());
+}
+
+}  // FL_TEST_FILE


### PR DESCRIPTION
## Summary

Adds the convenience helper called out in #2428's "Runtime-flexible mode (opt-in)" section:

```cpp
#include \"fl/channels/all_drivers.h\"
void setup() {
    FastLED.enableAllDrivers();      // or fl::enableAllDrivers();
    FastLED.add(cfg_with_affinity);  // ChannelManager picks the driver
}
```

This complements the existing \`fl::enableDrivers<Bus...>()\` API (PR #2437) by giving sketches a single call that enrolls every driver visible on the current platform — restoring 3.10.3-style runtime driver flexibility for users who want it.

## Why this is safe for the binary-bloat fix from #2420 / #2421

- Every per-platform \`bus_traits.h\` is now reachable from one header (\`fl/channels/all_drivers.h\`).
- The bus list inside \`enableAllDrivers()\` is gated by the same \`FASTLED_ESP32_HAS_*\` / \`FL_IS_*\` flags each driver uses, so we never name a \`Bus::X\` whose specialization isn't defined on the current target.
- \`CFastLED::enableAllDrivers()\` is declared in \`FastLED.h\` but **defined inline inside \`all_drivers.h\`**. Calling it without including the header produces a linker error — the include is the explicit opt-in. Sketches that never call it cause \`--gc-sections\` to drop the inline body and every driver TU it would have referenced.

## What's in the PR

- \`src/fl/channels/all_drivers.h\` — aggregator + \`fl::enableAllDrivers()\` + out-of-line \`CFastLED::enableAllDrivers()\` definition.
- \`src/FastLED.h\` — declaration of the \`CFastLED::enableAllDrivers()\` member with usage docs pointing at the header.
- \`tests/fl/channels/all_drivers.cpp\` — host tests covering:
  - registration of \`Bus::BIT_BANG\` (always-on) and \`Bus::STUB\` (host-only),
  - \`FastLED.enableAllDrivers()\` forwarder identity,
  - idempotency (replace-by-name on the manager side).

## Issue #2428 status

Per the issue author's own status check in the comments, the outstanding items are:
- **Phase 3b** — templatize \`Channel<Bus, Chipset>\` / \`ChannelConfig<Chipset>\` (\"API ergonomics polish that can ship later\").
- **Phase 5 finale** — drop the unconditional \`_build.cpp.hpp\` driver aggregator (\"highest-value remaining work\").

This PR addresses the \"Runtime-flexible mode\" convenience helper from the issue (additive, non-breaking) and unblocks any future Phase 5 work that wants to gate the aggregator: users who actually need the kitchen-sink behaviour now have a one-line opt-in.

## Test plan

- [x] \`bash test all_drivers --cpp\` — new tests pass.
- [x] \`bash test --cpp\` — full host suite (170/170 passed).
- [x] \`bash lint --cpp\` — clean.
- [ ] CI to validate hardware platform builds (ESP32 / Teensy 4.x / etc.) — header-only change, but worth letting matrix run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added enableAllDrivers() to initialize all available channel drivers in one call; idempotent and safe to call repeatedly.
* **Tests**
  * New tests verify driver registration, singleton identity, idempotency, and that the public convenience method forwards correctly.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/FastLED/pull/2448)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->