### PR TITLE
feat(channels): gate driver aggregator + pre-bind remaining legacy clockless (Phase 5c of #2428)

### DIFF
--- a/src/platforms/esp/32/drivers/_build.cpp.hpp
+++ b/src/platforms/esp/32/drivers/_build.cpp.hpp
@@ -3,6 +3,18 @@
 /// @file _build.hpp
 /// @brief Unity build header for platforms\esp\32\drivers/ directory
 /// Includes all implementation files in alphabetical order
+///
+/// Phase 5c of #2428 (binary-size fix for #2420):
+///
+/// Each LED-output driver subdirectory's `_build.cpp.hpp` self-gates against
+/// `FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY`. When the macro is enabled (opt-in
+/// mode), every non-platform-default driver TU becomes empty -- so only the
+/// platform's default driver remains in the build. The auxiliary subdirs
+/// (`ble`, `gpio_isr_rx`, `rmt_rx`) are not channel drivers and stay
+/// unconditional.
+///
+/// Unconditional aggregator structure (one include per subdir, alphabetical)
+/// is preserved to satisfy the unity-build linter.
 
 #include "fl/stl/compiler_control.h"
 FL_NO_UNWIND_BEGIN

--- a/src/platforms/esp/32/drivers/i2s/_build.cpp.hpp
+++ b/src/platforms/esp/32/drivers/i2s/_build.cpp.hpp
@@ -3,6 +3,15 @@
 /// @file _build.hpp
 /// @brief Unity build header for platforms\esp\32\drivers\i2s/ directory
 /// Includes all implementation files in alphabetical order
+///
+/// Phase 5c of #2428: I2S is never a platform default (LCD_CAM clockless on
+/// ESP32-S3 is a niche / experimental driver). When the user opts in to
+/// `FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY=1`, this TU becomes empty and the
+/// I2S driver is dropped from the binary.
+
+#include "fl/channels/bus.h"  // brings in FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY
+
+#if !FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY
 
 #include "platforms/esp/32/drivers/i2s/channel_driver_i2s.cpp.hpp"
 #include "platforms/esp/32/drivers/i2s/clockless_i2s_esp32.cpp.hpp"
@@ -15,3 +24,5 @@
 
 // BusTraits<Bus::I2S> specialization.
 #include "platforms/esp/32/drivers/i2s/bus_traits.h"
+
+#endif  // !FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY

--- a/src/platforms/esp/32/drivers/i2s_spi/_build.cpp.hpp
+++ b/src/platforms/esp/32/drivers/i2s_spi/_build.cpp.hpp
@@ -2,6 +2,17 @@
 
 /// @file _build.hpp
 /// @brief Unity build header for platforms\esp\32\drivers\i2s_spi/ directory
+///
+/// Phase 5c of #2428: I2S_SPI is the platform-default true-SPI driver on
+/// ESP32dev (original ESP32). On dev the driver TU is always compiled
+/// (legacy `addLeds<APA102, ...>` pre-binds to it). On all other ESP32
+/// variants I2S_SPI is an alternate driver, gated by
+/// `FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY`.
+
+#include "fl/channels/bus.h"  // brings in FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY
+#include "platforms/is_platform.h"
+
+#if !FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY || defined(FL_IS_ESP_32DEV)
 
 #include "platforms/esp/32/drivers/i2s_spi/channel_driver_i2s_spi.cpp.hpp"
 #include "platforms/esp/32/drivers/i2s_spi/i2s_spi_peripheral_esp.cpp.hpp"
@@ -9,3 +20,5 @@
 
 // BusTraits<Bus::I2S_SPI> specialization.
 #include "platforms/esp/32/drivers/i2s_spi/bus_traits.h"
+
+#endif  // legacy mode OR ESP32dev (default I2S_SPI platform)

--- a/src/platforms/esp/32/drivers/lcd_cam/_build.cpp.hpp
+++ b/src/platforms/esp/32/drivers/lcd_cam/_build.cpp.hpp
@@ -3,6 +3,14 @@
 /// @file _build.hpp
 /// @brief Unity build header for platforms\esp\32\drivers\lcd_cam/ directory
 /// Includes all implementation files in alphabetical order
+///
+/// Phase 5c of #2428: LCD_RGB is never a platform default. When the user
+/// opts in to `FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY=1`, this TU becomes
+/// empty and the LCD_RGB driver is dropped from the binary.
+
+#include "fl/channels/bus.h"  // brings in FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY
+
+#if !FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY
 
 #include "platforms/esp/32/drivers/lcd_cam/channel_driver_lcd_rgb.cpp.hpp"
 #include "platforms/esp/32/drivers/lcd_cam/lcd_rgb_peripheral_esp.cpp.hpp"
@@ -10,3 +18,5 @@
 
 // BusTraits<Bus::LCD_RGB> specialization.
 #include "platforms/esp/32/drivers/lcd_cam/bus_traits.h"
+
+#endif  // !FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY

--- a/src/platforms/esp/32/drivers/lcd_spi/_build.cpp.hpp
+++ b/src/platforms/esp/32/drivers/lcd_spi/_build.cpp.hpp
@@ -2,6 +2,17 @@
 
 /// @file _build.hpp
 /// @brief Unity build header for platforms\esp\32\drivers\lcd_spi/ directory
+///
+/// Phase 5c of #2428: LCD_SPI is the platform-default true-SPI driver on
+/// ESP32-S3. On S3 the driver TU is always compiled (legacy
+/// `addLeds<APA102, ...>` pre-binds to it). On all other ESP32 variants
+/// LCD_SPI is an alternate driver, gated by
+/// `FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY`.
+
+#include "fl/channels/bus.h"  // brings in FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY
+#include "platforms/is_platform.h"
+
+#if !FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY || defined(FL_IS_ESP_32S3)
 
 #include "platforms/esp/32/drivers/lcd_spi/channel_driver_lcd_clockless.cpp.hpp"
 #include "platforms/esp/32/drivers/lcd_spi/channel_driver_lcd_spi.cpp.hpp"
@@ -10,3 +21,5 @@
 
 // BusTraits<Bus::LCD_SPI> + BusTraits<Bus::LCD_CLOCKLESS> specializations.
 #include "platforms/esp/32/drivers/lcd_spi/bus_traits.h"
+
+#endif  // legacy mode OR ESP32-S3 (default LCD_SPI platform)

--- a/src/platforms/esp/32/drivers/parlio/_build.cpp.hpp
+++ b/src/platforms/esp/32/drivers/parlio/_build.cpp.hpp
@@ -3,6 +3,19 @@
 /// @file _build.hpp
 /// @brief Unity build header for platforms\esp\32\drivers\parlio/ directory
 /// Includes all implementation files in alphabetical order
+///
+/// Phase 5c of #2428: PARLIO is the platform-default clockless driver on
+/// ESP32-P4 / C6 / H2 / C5. On those variants the driver TU is always
+/// compiled (legacy `addLeds<NEOPIXEL>` pre-binds to it). On all other
+/// ESP32 variants PARLIO is an alternate driver, gated by
+/// `FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY`.
+
+#include "fl/channels/bus.h"  // brings in FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY
+#include "platforms/is_platform.h"
+
+#if !FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY || \
+    defined(FL_IS_ESP_32P4) || defined(FL_IS_ESP_32C6) || \
+    defined(FL_IS_ESP_32H2) || defined(FL_IS_ESP_32C5)
 
 #include "platforms/esp/32/drivers/parlio/channel_driver_parlio.cpp.hpp"
 #include "platforms/esp/32/drivers/parlio/parlio_engine.cpp.hpp"
@@ -11,3 +24,5 @@
 
 // BusTraits<Bus::PARLIO> specialization.
 #include "platforms/esp/32/drivers/parlio/bus_traits.h"
+
+#endif  // legacy mode OR PARLIO-default platform

--- a/src/platforms/esp/32/drivers/rmt/_build.cpp.hpp
+++ b/src/platforms/esp/32/drivers/rmt/_build.cpp.hpp
@@ -3,7 +3,22 @@
 /// @file _build.hpp
 /// @brief Unity build header for platforms/esp/32/drivers/rmt/ directory
 /// Includes all RMT driver implementations
+///
+/// Phase 5c of #2428: RMT is the platform-default clockless driver on every
+/// ESP32 variant EXCEPT P4 / C6 / H2 / C5 (which default to PARLIO). On
+/// RMT-default platforms this TU is always compiled (legacy
+/// `addLeds<NEOPIXEL>` pre-binds to it). On PARLIO-default platforms RMT
+/// is an alternate driver, gated by `FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY`.
 
-// Subdirectory implementations (alphabetical order)
+#include "fl/channels/bus.h"  // brings in FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY
+#include "platforms/is_platform.h"
+
+#if !FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY || \
+    !(defined(FL_IS_ESP_32P4) || defined(FL_IS_ESP_32C6) || \
+      defined(FL_IS_ESP_32H2) || defined(FL_IS_ESP_32C5))
+
+// begin sub directory includes
 #include "platforms/esp/32/drivers/rmt/rmt_4/_build.cpp.hpp"
 #include "platforms/esp/32/drivers/rmt/rmt_5/_build.cpp.hpp"
+
+#endif  // legacy mode OR RMT-default platform

--- a/src/platforms/esp/32/drivers/rmt/rmt_4/idf4_clockless_rmt_esp32.h
+++ b/src/platforms/esp/32/drivers/rmt/rmt_4/idf4_clockless_rmt_esp32.h
@@ -37,10 +37,12 @@
 #include "crgb.h"
 #include "eorder.h"
 #include "pixel_iterator.h"
+#include "fl/channels/bus.h"
 #include "fl/channels/data.h"
 #include "fl/channels/driver.h"
 #include "fl/channels/manager.h"
 #include "platforms/esp/32/core/fastpin_esp32.h"
+#include "platforms/esp/32/drivers/rmt/rmt_4/bus_traits.h"
 #include "fl/chipsets/timing_traits.h"
 #include "fl/stl/noexcept.h"
 #include "fl/stl/static_assert.h"
@@ -106,7 +108,17 @@ protected:
     }
 
     static fl::shared_ptr<IChannelDriver> getRmtEngine() FL_NOEXCEPT {
+#if FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY
+        // Phase 5c of #2428 (opt-in mode): bypass `ChannelManager` and bind
+        // directly to the `BusTraits<Bus::RMT>` singleton. Naming
+        // `BusTraits<Bus::RMT>::instancePtr()` here is the ODR-use that
+        // lets the linker keep ONLY the RMT4 driver TU when the user opts
+        // into `FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY=1` -- the
+        // binary-size fix from #2420.
+        return BusTraits<Bus::RMT>::instancePtr();
+#else
         return ChannelManager::instance().getDriverByName("RMT");
+#endif
     }
 
 };

--- a/src/platforms/esp/32/drivers/spi/_build.cpp.hpp
+++ b/src/platforms/esp/32/drivers/spi/_build.cpp.hpp
@@ -3,6 +3,19 @@
 /// @file _build.hpp
 /// @brief Unity build header for platforms\esp\32\drivers\spi/ directory
 /// Includes all implementation files in alphabetical order
+///
+/// Phase 5c of #2428: the clockless-over-SPI driver is never a platform
+/// default. When the user opts in to `FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY=1`,
+/// this TU becomes empty and the SPI clockless driver is dropped from the
+/// binary.
+///
+/// NOTE: This is `Bus::SPI`, the *clockless* SPI driver (WS2812 etc. over the
+/// SPI peripheral). True-SPI chipsets (APA102, SK9822, HD108) go through
+/// `Bus::I2S_SPI` on ESP32dev or `Bus::LCD_SPI` on ESP32-S3.
+
+#include "fl/channels/bus.h"  // brings in FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY
+
+#if !FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY
 
 #include "platforms/esp/32/drivers/spi/channel_driver_spi.cpp.hpp"
 #include "platforms/esp/32/drivers/spi/spi_esp32_init.cpp.hpp"
@@ -12,3 +25,5 @@
 
 // BusTraits<Bus::SPI> specialization.
 #include "platforms/esp/32/drivers/spi/bus_traits.h"
+
+#endif  // !FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY

--- a/src/platforms/esp/32/drivers/spi/idf5_clockless_spi_esp32.h
+++ b/src/platforms/esp/32/drivers/spi/idf5_clockless_spi_esp32.h
@@ -14,6 +14,7 @@
 #include "crgb.h"
 #include "eorder.h"
 #include "pixel_iterator.h"
+#include "fl/channels/bus.h"
 #include "fl/channels/data.h"
 #include "fl/channels/driver.h"
 #include "fl/channels/manager.h"
@@ -21,6 +22,7 @@
 #include "fl/log/log.h"
 #include "fl/stl/noexcept.h"
 #include "fl/stl/static_assert.h"
+#include "platforms/esp/32/drivers/spi/bus_traits.h"
 
 namespace fl {
 template <int DATA_PIN, typename TIMING, EOrder RGB_ORDER = RGB, int XTRA0 = 0, bool FLIP = false, int WAIT_TIME = 5>
@@ -81,7 +83,17 @@ protected:
     }
 
     static fl::shared_ptr<IChannelDriver> getClocklessSpiEngine() FL_NOEXCEPT {
+#if FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY
+        // Phase 5c of #2428 (opt-in mode): bypass `ChannelManager` and bind
+        // directly to the `BusTraits<Bus::SPI>` singleton. Naming
+        // `BusTraits<Bus::SPI>::instancePtr()` here is the ODR-use that
+        // lets the linker keep ONLY the SPI clockless driver TU when the
+        // user opts into `FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY=1` -- the
+        // binary-size fix from #2420.
+        return BusTraits<Bus::SPI>::instancePtr();
+#else
         return ChannelManager::instance().getDriverByName("SPI");
+#endif
     }
 };
 }  // namespace fl

--- a/src/platforms/esp/32/drivers/uart/_build.cpp.hpp
+++ b/src/platforms/esp/32/drivers/uart/_build.cpp.hpp
@@ -3,6 +3,14 @@
 /// @file _build.hpp
 /// @brief Unity build header for platforms\esp\32\drivers\uart/ directory
 /// Includes all implementation files in alphabetical order
+///
+/// Phase 5c of #2428: UART is never a platform default. When the user opts
+/// in to `FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY=1`, this TU becomes empty
+/// and the UART driver is dropped from the binary.
+
+#include "fl/channels/bus.h"  // brings in FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY
+
+#if !FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY
 
 #include "platforms/esp/32/drivers/uart/channel_driver_uart.cpp.hpp"
 #include "platforms/esp/32/drivers/uart/uart_peripheral_esp.cpp.hpp"
@@ -10,3 +18,5 @@
 
 // BusTraits<Bus::UART> specialization.
 #include "platforms/esp/32/drivers/uart/bus_traits.h"
+
+#endif  // !FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY

--- a/src/platforms/stub/spi_channel_stub.h
+++ b/src/platforms/stub/spi_channel_stub.h
@@ -10,11 +10,13 @@
 #include "eorder.h"
 #include "fl/stl/compiler_control.h"
 #include "fl/chipsets/timing_traits.h"
+#include "fl/channels/bus.h"
 #include "fl/channels/data.h"
 #include "fl/channels/driver.h"
 #include "fl/channels/manager.h"
 #include "pixel_iterator.h"
 #include "fl/log/log.h"
+#include "platforms/stub/bus_traits.h"
 #include "fl/stl/noexcept.h"
 
 namespace fl {
@@ -82,7 +84,14 @@ protected:
     }
 
     static fl::shared_ptr<IChannelDriver> getStubSpiEngine() FL_NOEXCEPT {
+#if FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY
+        // Phase 5c of #2428 (opt-in mode): bypass `ChannelManager` and bind
+        // directly to the `BusTraits<Bus::STUB>` singleton -- stub builds
+        // route every clockless/SPI chipset through the same no-op driver.
+        return BusTraits<Bus::STUB>::instancePtr();
+#else
         return ChannelManager::instance().getDriverByName("SPI");
+#endif
     }
 };
 

--- a/src/platforms/wasm/clockless_channel_wasm.h
+++ b/src/platforms/wasm/clockless_channel_wasm.h
@@ -11,6 +11,7 @@
 #include "eorder.h"
 #include "fl/stl/compiler_control.h"
 #include "fl/chipsets/timing_traits.h"
+#include "fl/channels/bus.h"
 #include "fl/channels/data.h"
 #include "fl/channels/driver.h"
 #include "fl/channels/manager.h"
@@ -18,6 +19,7 @@
 #include "pixel_iterator.h"
 #include "fl/log/log.h"
 #include "platforms/shared/active_strip_tracker/active_strip_tracker.h"
+#include "platforms/stub/bus_traits.h"
 #include "fl/stl/noexcept.h"
 
 namespace fl {
@@ -94,7 +96,14 @@ protected:
     }
 
     static fl::shared_ptr<IChannelDriver> getWasmEngine() FL_NOEXCEPT {
+#if FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY
+        // Phase 5c of #2428 (opt-in mode): bypass `ChannelManager` and bind
+        // directly to the `BusTraits<Bus::STUB>` singleton -- the stub
+        // driver is the platform default for both stub and WASM builds.
+        return BusTraits<Bus::STUB>::instancePtr();
+#else
         return ChannelManager::instance().getDriverByName("STUB");
+#endif
     }
 };
 

--- a/src/platforms/wasm/spi_channel_wasm.h
+++ b/src/platforms/wasm/spi_channel_wasm.h
@@ -10,11 +10,13 @@
 #include "eorder.h"
 #include "fl/stl/compiler_control.h"
 #include "fl/chipsets/timing_traits.h"
+#include "fl/channels/bus.h"
 #include "fl/channels/data.h"
 #include "fl/channels/driver.h"
 #include "fl/channels/manager.h"
 #include "pixel_iterator.h"
 #include "fl/log/log.h"
+#include "platforms/stub/bus_traits.h"
 #include "fl/stl/noexcept.h"
 
 namespace fl {
@@ -77,7 +79,15 @@ protected:
     }
 
     static fl::shared_ptr<IChannelDriver> getWasmSpiEngine() FL_NOEXCEPT {
+#if FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY
+        // Phase 5c of #2428 (opt-in mode): bypass `ChannelManager` and bind
+        // directly to the `BusTraits<Bus::STUB>` singleton. WASM uses the
+        // stub driver for both clockless and SPI chipsets (no real
+        // hardware in the browser).
+        return BusTraits<Bus::STUB>::instancePtr();
+#else
         return ChannelManager::instance().getDriverByName("SPI");
+#endif
     }
 };
 


### PR DESCRIPTION
## Summary

Phase 5c of #2428 completes the binary-size fix from #2420 by:

1. **Gating per-driver ESP32 `_build.cpp.hpp` aggregators** against `FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY`. When the macro is enabled (opt-in), only the per-platform **default** driver TUs compile; all other driver TUs become empty.
2. **Pre-binding the remaining legacy clockless controllers** to their default `BusTraits<Bus::X>::instancePtr()` singleton — mirroring what 5b did for RMT5 / stub. Covers RMT4 (`idf4_clockless_rmt_esp32.h`), ESP32 clockless-over-SPI (`idf5_clockless_spi_esp32.h`), WASM clockless + SPI, and host stub SPI.

`ClocklessBlockingGeneric` (pure CPU bitbang) does not use a Channel/Driver and is intentionally untouched.

Default behavior is byte-for-byte unchanged: with the macro at its default value of `0`, every driver TU still compiles and registers exactly as before.

## Per-platform default routing

| Variant | Default clockless | Default true-SPI |
|---|---|---|
| ESP32-P4 / C6 / H2 / C5 | `Bus::PARLIO` | unspecified |
| ESP32-S3 | `Bus::RMT` | `Bus::LCD_SPI` |
| ESP32dev | `Bus::RMT` | `Bus::I2S_SPI` |
| Other ESP32 | `Bus::RMT` | unspecified |

Each driver subdir's `_build.cpp.hpp` is unconditional on its default variant(s) and gated by the macro everywhere else. `ble/`, `gpio_isr_rx/`, `rmt_rx/` are non-LED-output drivers and remain unconditional.

## Why the conditional logic lives in each subdir's `_build.cpp.hpp`

The unity-build linter (`ci/lint_cpp/test_unity_build.py`) requires the top-level `_build.cpp.hpp` aggregator to list every subdir alphabetically in a single `// begin sub directory includes` block. Wrapping the parent in `#if` blocks fails the alphabetization check. Pushing the conditional gating into each subdir's `_build.cpp.hpp` keeps the parent linter-clean while still removing the unused TUs from compilation.

## Expected binary-size impact

For the #2420 reproducer (NEOPIXEL-only sketch on ESP32-S3 with `-DFASTLED_DISABLE_LEGACY_DRIVER_REGISTRY=1`):

- **Default (`macro=0`)**: ~783 KB (unchanged from master HEAD).
- **Opt-in (`macro=1`)**: expected to drop toward the **~344 KB** baseline from 3.10.3.

Local ESP32-S3 platform measurement was deferred — the `fbuild` daemon in this worktree environment hung repeatedly (`daemon error: stream error: error decoding response body`, watchdog timeouts). CI will produce the authoritative before/after numbers.

## Verification

- `bash test --cpp` — 303/303 pass on the default (macro=0) build.
- `bash compile wasm --examples Blink` — succeeds.
- `bash lint` — clean (Python, C++, JavaScript, meson).
- New `mDriverPreBound` flag from 5b stays unchanged; default-mode tests don't observe the new code paths.

## Files changed (14)

- `src/platforms/esp/32/drivers/_build.cpp.hpp`
- `src/platforms/esp/32/drivers/i2s/_build.cpp.hpp`
- `src/platforms/esp/32/drivers/i2s_spi/_build.cpp.hpp`
- `src/platforms/esp/32/drivers/lcd_cam/_build.cpp.hpp`
- `src/platforms/esp/32/drivers/lcd_spi/_build.cpp.hpp`
- `src/platforms/esp/32/drivers/parlio/_build.cpp.hpp`
- `src/platforms/esp/32/drivers/rmt/_build.cpp.hpp`
- `src/platforms/esp/32/drivers/rmt/rmt_4/idf4_clockless_rmt_esp32.h`
- `src/platforms/esp/32/drivers/spi/_build.cpp.hpp`
- `src/platforms/esp/32/drivers/spi/idf5_clockless_spi_esp32.h`
- `src/platforms/esp/32/drivers/uart/_build.cpp.hpp`
- `src/platforms/stub/spi_channel_stub.h`
- `src/platforms/wasm/clockless_channel_wasm.h`
- `src/platforms/wasm/spi_channel_wasm.h`

## Constraints honored

- No touch to `src/fl/channels/{channel.h,config.h,_build.cpp.hpp}` — Phase 3b (templatize `ChannelConfig` / `Channel`) is in flight on a parallel branch.
- No new macros introduced; the existing `FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY` from 5a/5b is the sole opt-in flag.

## Test plan

- [ ] CI: verify `bash test --cpp` passes (303/303).
- [ ] CI: `bash compile wasm --examples Blink` passes.
- [ ] CI: `bash compile esp32s3 --examples Blink` passes on **default** macro state — confirms backward compatibility.
- [ ] CI: `bash compile esp32s3 --examples Blink --defines FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY=1` passes and produces a smaller binary (#2420 reproducer).
- [ ] Bin-bloat measurement: confirm the opt-in size drops back toward the ~344 KB 3.10.3 baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved driver loading architecture with optional legacy driver registry disabling. When the legacy registry is disabled, the system uses direct driver instantiation, reducing overhead and binary footprint. Platform-specific default drivers remain available while auxiliary drivers can be selectively excluded.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/FastLED/pull/2450)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->