### PR TITLE
feat(channels): templated Channel::create<Bus B>() / FastLED.add<Bus B>() (#2428, closes #2167)

### DIFF
--- a/src/FastLED.h
+++ b/src/FastLED.h
@@ -710,6 +710,46 @@ public:
 	/// @endcode
 	static fl::ChannelPtr add(const fl::ChannelConfig& config);
 
+	/// @brief Add an LED channel pinned at compile time to a specific `fl::Bus`.
+	///
+	/// Templated counterpart to `FastLED.add(cfg)` — the bus is chosen at
+	/// compile time so typos become compile errors (`fl::Bus::RTM` → no such
+	/// enumerator) and bus/chipset mismatches become `static_assert`
+	/// failures rather than runtime warnings.
+	///
+	/// This is the issue #2428 / #2167 API:
+	///
+	/// @code
+	///   #include "platforms/esp/32/drivers/rmt/rmt_5/bus_traits.h"
+	///   auto channel = FastLED.add<fl::Bus::RMT>(cfg);
+	/// @endcode
+	///
+	/// **Linker behaviour.** This overload ODR-uses
+	/// `fl::BusTraits<B>::instancePtr()` so the linker keeps the driver's
+	/// translation unit. Sketches that only ever name one `Bus::X` only link
+	/// that one driver — the binary-bloat fix from #2420 / #2421 applies
+	/// per-bus.
+	///
+	/// **Precondition.** The user must `#include` the per-driver
+	/// `bus_traits.h` that specializes `BusTraits<B>` for the chosen bus, or
+	/// the call fails to compile with `implicit instantiation of undefined
+	/// template`. That diagnostic IS the opt-in.
+	///
+	/// @tparam B target bus — must not be `Bus::AUTO`. For
+	///           platform-default dispatch, use the non-template overload.
+	/// @param  config channel configuration; the affinity is overwritten
+	///                with `busName(B)` to pin dispatch
+	/// @return shared pointer to the channel, or nullptr if no driver for
+	///         `B` is registered at runtime
+	template<fl::Bus B>
+	static fl::ChannelPtr add(const fl::ChannelConfig& config) {
+		auto channel = fl::Channel::create<B>(config);
+		if (channel) {
+			add(channel);
+		}
+		return channel;
+	}
+
 	/// @brief Add multiple LED channels from a config array
 	///
 	/// Creates and registers multiple Channel-based LED controllers from an array of configurations.

--- a/src/fl/channels/bus.h
+++ b/src/fl/channels/bus.h
@@ -12,6 +12,8 @@
 /// Drivers link only when their `Bus` value is named somewhere in the
 /// translation unit graph. See issue #2428.
 
+#include "fl/stl/noexcept.h"
+#include "fl/stl/static_assert.h"
 #include "fl/stl/stdint.h"
 #include "platforms/is_platform.h"
 
@@ -130,5 +132,55 @@ template<> struct DefaultBus<ClocklessChipset> {
 // pick explicitly between Bus::BIT_BANG and any future hardware-SPI bus.
 
 #endif
+
+/// @brief Canonical driver-name string for a `Bus` value.
+///
+/// Each `Bus::X` corresponds to exactly one concrete `IChannelDriver`. That
+/// driver's `getName()` returns a stable string that `ChannelManager` uses as
+/// the affinity key (`ChannelOptions::mAffinity` / `getDriverByName`). When
+/// the new templated `Channel::create<Bus B>(cfg)` / `FastLED.add<Bus B>(cfg)`
+/// overloads are used (closes #2167), the affinity is derived from `B` via
+/// this helper so the typo-prone string literal never appears at the call
+/// site.
+///
+/// Returns `"AUTO"` for `Bus::AUTO` — diagnostic/log paths get a stable
+/// human-readable label. The templated `Channel::create<B>(cfg)` /
+/// `FastLED.add<B>(cfg)` overloads `static_assert` against `B == Bus::AUTO`,
+/// so this name never reaches `ChannelOptions::mAffinity` and never enters
+/// the `ChannelManager` dispatch path.
+///
+/// Note: the spelling matches the driver's `getName()` exactly, including
+/// where the enum's snake_case differs from the driver's name
+/// (`Bus::FLEX_IO` → `"FLEXIO"`, `Bus::OBJECT_FLED` → `"OBJECTFLED"`,
+/// `Bus::BIT_BANG` → `"BITBANG"`). Mismatches would silently break
+/// affinity-based dispatch, so this table is the single source of truth.
+///
+/// **Lifetime.** Every returned pointer is to a string literal, so it has
+/// static storage duration — safe to feed to `fl::string::from_literal()`.
+inline const char* busName(Bus b) FL_NOEXCEPT {
+    switch (b) {
+        case Bus::AUTO:          return "AUTO";
+        case Bus::RMT:           return "RMT";
+        case Bus::PARLIO:        return "PARLIO";
+        case Bus::SPI:           return "SPI";
+        case Bus::I2S:           return "I2S";
+        case Bus::I2S_SPI:       return "I2S_SPI";
+        case Bus::LCD_RGB:       return "LCD_RGB";
+        case Bus::LCD_SPI:       return "LCD_SPI";
+        case Bus::LCD_CLOCKLESS: return "LCD_CLOCKLESS";
+        case Bus::UART:          return "UART";
+        case Bus::FLEX_IO:       return "FLEXIO";
+        case Bus::OBJECT_FLED:   return "OBJECTFLED";
+        case Bus::BIT_BANG:      return "BITBANG";
+        case Bus::STUB:          return "STUB";
+    }
+    return "";  // unreachable — silences -Wreturn-type on toolchains that miss the exhaustive switch
+}
+
+// Drift-prevention: if a new `Bus` enumerator is added, the switch above must
+// gain a case. Update this assertion to the new last enumerator after you
+// wire the case in — its failure is the prompt to revisit `busName()`.
+FL_STATIC_ASSERT(static_cast<fl::u8>(Bus::STUB) == 13,
+                 "Bus changed: add the new value to busName() in this file");  // ok plain enum
 
 }  // namespace fl

--- a/src/fl/channels/channel.h
+++ b/src/fl/channels/channel.h
@@ -15,8 +15,13 @@
 #include "fl/stl/noexcept.h"
 
 #include "cpixel_ledcontroller.h"
+#include "fl/channels/bus.h"
+#include "fl/channels/bus_traits.h"
 #include "fl/channels/ichannel.h"
+#include "fl/channels/options.h"
 #include "fl/stl/shared_ptr.h"
+#include "fl/stl/static_assert.h"
+#include "fl/stl/string.h"
 #include "fl/stl/weak_ptr.h"
 #include "fl/stl/stdint.h"
 #include "fl/channels/config.h"
@@ -50,6 +55,58 @@ public:
     /// @note Channels always use ChannelManager by default
     /// @note If config.affinity is set, binds to the named driver from ChannelManager
     static ChannelPtr create(const ChannelConfig& config);
+
+    /// @brief Create a channel pinned at compile time to a specific `Bus`.
+    ///
+    /// Closes #2167 — `Channel::create<EngineType>(config)` is now a real
+    /// template. Use this overload to:
+    ///   - State the target bus at compile time so typos (`Bus::RTM` →
+    ///     compile error, "RMT" → "RTM" would silently runtime-warn).
+    ///   - Reject bus/chipset mismatches via `static_assert` rather than at
+    ///     runtime via `ChannelManager` warnings.
+    ///   - ODR-use `BusTraits<B>::instancePtr()` from the call site so the
+    ///     driver's translation unit is kept by `--gc-sections` (#2428's
+    ///     binary-bloat fix). Sketches that only ever name one `Bus::X` only
+    ///     link that one driver.
+    ///
+    /// **Precondition.** The user must `#include` the per-driver
+    /// `bus_traits.h` that specializes `BusTraits<B>` for the chosen bus.
+    /// Otherwise the call fails to compile with `implicit instantiation of
+    /// undefined template 'BusTraits<Bus::X>'` — the explicit-opt-in
+    /// behaviour that lets unused drivers be linker-stripped.
+    ///
+    /// @code
+    ///   #include "platforms/esp/32/drivers/rmt/rmt_5/bus_traits.h"
+    ///   auto ch = fl::Channel::create<fl::Bus::RMT>(cfg);
+    /// @endcode
+    ///
+    /// @tparam B target bus (not `Bus::AUTO` — use the non-template form
+    ///           if you want platform-default selection)
+    /// @param  config channel configuration; the `mAffinity` field is
+    ///                overwritten with `busName(B)` to pin dispatch
+    /// @return shared pointer to the channel, or nullptr if the platform
+    ///         build did not register a driver for `B`
+    template<Bus B>
+    static ChannelPtr create(ChannelConfig config) {
+        FL_STATIC_ASSERT(B != Bus::AUTO,
+            "Channel::create<Bus::AUTO>() is not allowed — use the non-template "
+            "create(cfg) form for platform-default dispatch.");
+        FL_STATIC_ASSERT(
+            BusSupports<B, ClocklessChipset>::value ||
+            BusSupports<B, SpiChipsetConfig>::value,
+            "Bus B has no BusSupports specialization for any chipset family. "
+            "Did you forget to include the per-driver bus_traits.h? "
+            "(See src/platforms/.../bus_traits.h)");
+        // ODR-use the driver singleton so its translation unit is kept by
+        // --gc-sections (the linker keep-alive that delivers #2428's
+        // binary-bloat fix on a per-bus basis).
+        (void) BusTraits<B>::instancePtr();
+        // `busName(B)` returns a string literal (static storage duration), so
+        // `from_literal` is sound and avoids the heap allocation a `const
+        // char*` constructor would do.
+        config.options.mAffinity = fl::string::from_literal(busName(B));
+        return create(config);
+    }
 
     /// @brief Destructor
     virtual ~Channel() FL_NOEXCEPT;

--- a/tests/fl/channels/channel.cpp
+++ b/tests/fl/channels/channel.cpp
@@ -1,20 +1,27 @@
 /// @file tests/fl/channels/channels.cpp
-/// @brief Test suite for Channel API with addressing and color order
+/// @brief Test suite for Channel API with addressing, color order, and
+///        Bus-templated create<B>()/FastLED.add<B>() overloads (#2428/#2167)
 
+#include "FastLED.h"
+#include "fl/channels/all_drivers.h"
+#include "fl/channels/bus.h"
+#include "fl/channels/bus_traits.h"
 #include "fl/channels/channel.h"
+#include "fl/channels/data.h"
+#include "fl/channels/driver.h"
+#include "fl/channels/manager.h"
+#include "fl/chipsets/chipset_timing_config.h"
+#include "fl/gfx/fill.h"
+#include "fl/math/screenmap.h"
 #include "fl/math/xymap.h"
 #include "fl/math/xmap.h"
-#include "fl/math/screenmap.h"
-#include "fl/stl/span.h"
-#include "fl/test/fltest.h"
-#include "fl/channels/driver.h"
-#include "fl/channels/data.h"
-#include "fl/channels/manager.h"
-#include "fl/stl/vector.h"
-#include "fl/stl/shared_ptr.h"
-#include "fl/gfx/fill.h"
-#include "fl/chipsets/chipset_timing_config.h"
 #include "fl/stl/scope_exit.h"
+#include "fl/stl/shared_ptr.h"
+#include "fl/stl/span.h"
+#include "fl/stl/string.h"
+#include "fl/stl/vector.h"
+#include "fl/test/fltest.h"
+#include "platforms/stub/bus_traits.h"
 
 using namespace fl;
 
@@ -336,4 +343,113 @@ FL_TEST_CASE("XMap reverse addressing with APA102 encodes pixels in reverse orde
             FL_CHECK_EQ(encodedBytes[ledStart + 15], 0xFF);  // Red
         }
     }
+}
+
+// ============ Bus-template API tests (#2428 / #2167) ============
+// Verify Channel::create<Bus::STUB>(cfg) and FastLED.add<Bus::STUB>(cfg)
+// on the host build (FL_IS_STUB).  Tests run against the real STUB driver —
+// no mocks needed.
+
+namespace {
+
+/// Reset ChannelManager to a known-empty state and return its reference.
+/// Required before each bus-template test so prior registrations don't leak.
+ChannelManager& freshBusTestManager() {
+    auto& mgr = ChannelManager::instance();
+    mgr.clearAllDrivers();
+    return mgr;
+}
+
+/// Minimal WS2812 ChannelConfig on pin 4 with 8 LEDs.
+ChannelConfig makeBusTestConfig(fl::span<CRGB> leds) {
+    auto timing = makeTimingConfig<TIMING_WS2812_800KHZ>();
+    return ChannelConfig(4, timing, leds, RGB);
+}
+
+}  // namespace
+
+FL_TEST_CASE("Channel::create<Bus::STUB> returns non-null on host") {
+    auto& mgr = freshBusTestManager();
+    FL_REQUIRE(mgr.getDriverCount() == 0);
+
+    fl::enableAllDrivers();
+    FL_REQUIRE(mgr.getDriverCount() > 0);
+
+    CRGB leds[8] = {};
+    ChannelConfig cfg = makeBusTestConfig(fl::span<CRGB>(leds, 8));
+
+    auto channel = Channel::create<Bus::STUB>(cfg);
+    FL_REQUIRE(channel != nullptr);
+
+    // The registered STUB driver must be the BusTraits<Bus::STUB> singleton.
+    auto stubDriver = mgr.getDriverByName(fl::string::from_literal("STUB"));
+    FL_REQUIRE(stubDriver != nullptr);
+    FL_CHECK_EQ(stubDriver.get(), &BusTraits<Bus::STUB>::instance());
+
+    channel->removeFromDrawList();
+}
+
+FL_TEST_CASE("Channel::create<Bus::STUB> overwrites mAffinity and binds STUB driver") {
+    auto& mgr = freshBusTestManager();
+    FL_REQUIRE(mgr.getDriverCount() == 0);
+
+    fl::enableAllDrivers();
+
+    CRGB leds[8] = {};
+    ChannelConfig cfg = makeBusTestConfig(fl::span<CRGB>(leds, 8));
+    // Deliberately wrong affinity — template overload must overwrite it.
+    cfg.options.mAffinity = fl::string::from_literal("WRONG");
+
+    auto channel = Channel::create<Bus::STUB>(cfg);
+    FL_REQUIRE(channel != nullptr);
+
+    // Trigger a show so the channel selects and caches its driver.
+    channel->showLeds(0);
+
+    // After show the bound engine name must be "STUB", not "WRONG".
+    FL_CHECK_EQ(channel->getEngineName(), fl::string::from_literal("STUB"));
+
+    channel->removeFromDrawList();
+}
+
+FL_TEST_CASE("FastLED.add<Bus::STUB> returns non-null and adds channel to draw list") {
+    auto& mgr = freshBusTestManager();
+    FL_REQUIRE(mgr.getDriverCount() == 0);
+
+    fl::enableAllDrivers();
+
+    CRGB leds[8] = {};
+    ChannelConfig cfg = makeBusTestConfig(fl::span<CRGB>(leds, 8));
+
+    auto channel = FastLED.add<Bus::STUB>(cfg);
+    FL_REQUIRE(channel != nullptr);
+
+    // FastLED.add() must append the channel to the CLEDController draw list.
+    FL_CHECK_TRUE(channel->isInDrawList());
+
+    channel->removeFromDrawList();
+}
+
+FL_TEST_CASE("FastLED.add<Bus::STUB> driver singleton matches BusTraits<Bus::STUB>") {
+    auto& mgr = freshBusTestManager();
+    FL_REQUIRE(mgr.getDriverCount() == 0);
+
+    fl::enableAllDrivers();
+
+    CRGB leds[8] = {};
+    ChannelConfig cfg = makeBusTestConfig(fl::span<CRGB>(leds, 8));
+
+    auto channel = FastLED.add<Bus::STUB>(cfg);
+    FL_REQUIRE(channel != nullptr);
+
+    // Trigger show so the channel binds its driver.
+    channel->showLeds(0);
+
+    FL_CHECK_EQ(channel->getEngineName(), fl::string::from_literal("STUB"));
+
+    auto stubPtr = mgr.getDriverByName(fl::string::from_literal("STUB"));
+    FL_REQUIRE(stubPtr != nullptr);
+    FL_CHECK_EQ(stubPtr.get(), &BusTraits<Bus::STUB>::instance());
+
+    channel->removeFromDrawList();
 }


### PR DESCRIPTION
## Summary

Adds the Bus-templated APIs explicitly called out in issue #2428's Phase 3b *and* closes #2167 (which asked for \`Channel::create<EngineType>(config)\` to be a real template). Additive — no breaking changes to existing call sites.

\`\`\`cpp
#include \"platforms/esp/32/drivers/rmt/rmt_5/bus_traits.h\"
auto ch = fl::Channel::create<fl::Bus::RMT>(cfg);
// or:
auto ch = FastLED.add<fl::Bus::RMT>(cfg);

// Mismatches caught at compile time:
FastLED.add<fl::Bus::RTM>(cfg);       // ❌ no enumerator
FastLED.add<fl::Bus::AUTO>(cfg);       // ❌ static_assert: use non-template form
FastLED.add<fl::Bus::SOME_HYPOTHETICAL>(cfg); // ❌ no BusSupports specialization
\`\`\`

## How it preserves the binary-bloat fix

The template body does \`(void) BusTraits<B>::instancePtr();\`. That ODR-uses the singleton's storage, so \`--gc-sections\` keeps the driver's translation unit. Sketches that only ever name one \`Bus::X\` link only that one driver — the per-bus version of the fix from #2420 / #2421.

If the user calls \`FastLED.add<fl::Bus::RMT>(cfg)\` without including \`platforms/esp/32/drivers/rmt/rmt_5/bus_traits.h\`, the compile fails with \`implicit instantiation of undefined template 'BusTraits<Bus::RMT>'\`. That diagnostic IS the explicit opt-in.

## What's in the PR

- \`src/fl/channels/bus.h\` — \`busName(Bus)\` switch + drift-prevention \`FL_STATIC_ASSERT\` on the last enumerator. Single source of truth for the \`Bus → driver getName()\` mapping. Includes the \"no underscore\" trio (\`Bus::FLEX_IO\` → \`\"FLEXIO\"\`, \`Bus::OBJECT_FLED\` → \`\"OBJECTFLED\"\`, \`Bus::BIT_BANG\` → \`\"BITBANG\"\`).
- \`src/fl/channels/channel.h\` — \`template<Bus B> static ChannelPtr create(ChannelConfig)\` with the two \`FL_STATIC_ASSERT\` guards.
- \`src/FastLED.h\` — \`template<fl::Bus B> static fl::ChannelPtr add(const fl::ChannelConfig& config)\` forwarder to \`Channel::create<B>\`.
- \`tests/fl/channels/channel.cpp\` — host tests for both overloads exercising the stub bus, the affinity-overwrite path, the channel-registration path, and driver-identity match against \`BusTraits<Bus::STUB>::instance()\`.

## Test plan

- [x] \`bash test channel --cpp\` — 1/1 pass.
- [x] \`bash test --cpp\` — 181/181 pass.
- [x] \`bash lint --cpp\` — clean.
- [ ] CI matrix to validate hardware platform builds (ESP32 / Teensy / etc.) — header-only change.

## Issue #2428 remaining items

Per the issue author's status comment, what's left after this merges:
- \`mAffinity\` field type conversion from \`fl::string\` to \`fl::Bus\` (Phase 4 cleanup).
- Templatizing \`ChannelConfig<Chipset>\` and \`Channel<Bus, Chipset>\` for full compile-time chipset/bus pair checking (the bigger Phase 3b refactor — ~17 files).
- Phase 5 finale — drop the unconditional \`_build.cpp.hpp\` driver aggregator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added compile-time channel-to-bus routing so channels can be pinned to a specific bus, ensuring driver affinity is set deterministically and validated at compile time.

* **Tests**
  * Expanded tests to verify bus-pinned channel creation, driver binding, affinity overriding, and integration with the draw list.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/FastLED/pull/2451)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->