### PR TITLE
feat(channels): runtime FastLED.add(fl::Bus, cfg) dispatch (closes #2453)

### DIFF
--- a/src/FastLED.h
+++ b/src/FastLED.h
@@ -750,6 +750,47 @@ public:
 		return channel;
 	}
 
+	/// @brief Add an LED channel and dispatch by a **runtime** `fl::Bus` value.
+	///
+	/// Sister API to the templated `FastLED.add<Bus B>(cfg)` (PR #2451). The
+	/// trade-off:
+	///
+	/// | API | Bus is chosen | Driver TU is linked when |
+	/// |---|---|---|
+	/// | `FastLED.add<Bus::RMT>(cfg)` (templated) | at compile time | the call site names `Bus::RMT` |
+	/// | `FastLED.add(Bus::RMT, cfg)` (this one)  | at runtime      | something *else* in the build named `Bus::RMT` (e.g. `enableAllDrivers()`) |
+	///
+	/// Use this overload when the user has already enrolled drivers with
+	/// `ChannelManager` (typically via `fl::enableAllDrivers()` or an explicit
+	/// `fl::enableDrivers<...>()`) and just wants to pick which one handles a
+	/// given channel — **without** the per-call-site linker keep-alive that the
+	/// templated form does. The bus name is derived via `fl::busName(b)` so the
+	/// stringly-typed `"RMT"` literal never appears in user code. See issue
+	/// #2453 for the design context.
+	///
+	/// @param b      target bus; if `fl::Bus::AUTO`, the affinity is cleared so
+	///               `ChannelManager` picks by priority (same as not setting an
+	///               affinity at all).
+	/// @param config channel configuration; the `mAffinity` field is overwritten.
+	/// @return shared pointer to the channel, or nullptr if dispatch failed
+	///         (e.g. the named driver was not registered with `ChannelManager`).
+	///
+	/// @code
+	///   #include "fl/channels/all_drivers.h"
+	///   void setup() {
+	///       FastLED.enableAllDrivers();
+	///       FastLED.add(fl::Bus::RMT, cfg);   // runtime dispatch, no extra linker work
+	///   }
+	/// @endcode
+	static fl::ChannelPtr add(fl::Bus b, fl::ChannelConfig config) FL_NOEXCEPT {
+		if (b == fl::Bus::AUTO) {
+			config.options.mAffinity.clear();
+		} else {
+			config.options.mAffinity = fl::string::from_literal(fl::busName(b));
+		}
+		return add(config);
+	}
+
 	/// @brief Add multiple LED channels from a config array
 	///
 	/// Creates and registers multiple Channel-based LED controllers from an array of configurations.

--- a/tests/fl/channels/channel.cpp
+++ b/tests/fl/channels/channel.cpp
@@ -453,3 +453,77 @@ FL_TEST_CASE("FastLED.add<Bus::STUB> driver singleton matches BusTraits<Bus::STU
 
     channel->removeFromDrawList();
 }
+
+// ============ Runtime Bus-dispatch overload (#2453) ============
+// FastLED.add(fl::Bus, cfg) — non-templated, runtime-only counterpart to
+// FastLED.add<fl::Bus B>(cfg). Bus passed by value, affinity derived via
+// fl::busName(), no ODR-use of BusTraits<B>::instancePtr(). Lets sketches
+// that called enableAllDrivers() pick the driver by enum at runtime without
+// also paying the per-bus linker keep-alive that the templated form does.
+
+FL_TEST_CASE("FastLED.add(Bus, cfg) dispatches to runtime-selected bus") {
+    auto& mgr = freshBusTestManager();
+    FL_REQUIRE(mgr.getDriverCount() == 0);
+
+    fl::enableAllDrivers();
+
+    CRGB leds[8] = {};
+    ChannelConfig cfg = makeBusTestConfig(fl::span<CRGB>(leds, 8));
+
+    // Variable Bus value — what the runtime overload exists for.
+    Bus b = Bus::STUB;
+    auto channel = FastLED.add(b, cfg);
+    FL_REQUIRE(channel != nullptr);
+    FL_CHECK_TRUE(channel->isInDrawList());
+
+    // Trigger show so the channel binds its driver.
+    channel->showLeds(0);
+    FL_CHECK_EQ(channel->getEngineName(), fl::string::from_literal("STUB"));
+
+    channel->removeFromDrawList();
+}
+
+FL_TEST_CASE("FastLED.add(Bus, cfg) overwrites prior mAffinity") {
+    auto& mgr = freshBusTestManager();
+    FL_REQUIRE(mgr.getDriverCount() == 0);
+
+    fl::enableAllDrivers();
+
+    CRGB leds[8] = {};
+    ChannelConfig cfg = makeBusTestConfig(fl::span<CRGB>(leds, 8));
+    // Deliberately wrong prior affinity — runtime overload must overwrite.
+    cfg.options.mAffinity = fl::string::from_literal("WRONG");
+
+    auto channel = FastLED.add(Bus::STUB, cfg);
+    FL_REQUIRE(channel != nullptr);
+    channel->showLeds(0);
+    FL_CHECK_EQ(channel->getEngineName(), fl::string::from_literal("STUB"));
+
+    channel->removeFromDrawList();
+}
+
+FL_TEST_CASE("FastLED.add(Bus::AUTO, cfg) clears affinity and falls back to priority") {
+    auto& mgr = freshBusTestManager();
+    FL_REQUIRE(mgr.getDriverCount() == 0);
+
+    fl::enableAllDrivers();
+
+    CRGB leds[8] = {};
+    ChannelConfig cfg = makeBusTestConfig(fl::span<CRGB>(leds, 8));
+    // Seed a non-empty affinity so we can prove AUTO clears it.
+    cfg.options.mAffinity = fl::string::from_literal("STUB");
+
+    auto channel = FastLED.add(Bus::AUTO, cfg);
+    FL_REQUIRE(channel != nullptr);
+    FL_CHECK_TRUE(channel->isInDrawList());
+    // On host the only registered drivers from enableAllDrivers() are STUB
+    // and BITBANG. Priority dispatch should land on one of them; we only
+    // assert that dispatch succeeds (driver gets bound) rather than naming
+    // which one wins the priority tie.
+    channel->showLeds(0);
+    auto bound = channel->getEngineName();
+    FL_CHECK(bound == fl::string::from_literal("STUB") ||
+             bound == fl::string::from_literal("BITBANG"));
+
+    channel->removeFromDrawList();
+}


### PR DESCRIPTION
## Summary

Closes #2453. Adds the missing runtime counterpart to the templated \`FastLED.add<fl::Bus B>(cfg)\` form from #2451:

\`\`\`cpp
#include \"fl/channels/all_drivers.h\"

void setup() {
    FastLED.enableAllDrivers();         // PR #2448
    FastLED.add(fl::Bus::RMT, cfg);     // ← new: runtime dispatch by enum
}
\`\`\`

| API | Bus chosen | Driver TU linked when |
|---|---|---|
| \`FastLED.add<Bus::RMT>(cfg)\` (templated, PR #2451) | at compile time | the call site names \`Bus::RMT\` |
| **\`FastLED.add(Bus::RMT, cfg)\` (this PR)** | **at runtime** | **something else in the build named \`Bus::RMT\`** (e.g. \`enableAllDrivers()\`) |

## What changed

- New \`static fl::ChannelPtr add(fl::Bus, fl::ChannelConfig)\` member on \`CFastLED\` in \`src/FastLED.h\`.
- Sets \`cfg.options.mAffinity = fl::busName(b)\` so \`ChannelManager\` dispatches by name (the strings match each driver's \`getName()\` exactly via the table in \`bus.h\`).
- \`Bus::AUTO\` clears \`mAffinity\` so the manager falls back to priority dispatch — same contract as not setting an affinity at all.

## Why this preserves the binary-bloat fix

The implementation deliberately does **not** name \`BusTraits<B>::instance()\` or \`instancePtr()\`. That means this overload contributes zero per-call-site linker keep-alive. Sketches that don't otherwise reference a bus's traits still let \`--gc-sections\` drop the driver — the binary-bloat fix from #2420 / #2421 is preserved end to end.

The driver gets linked only if something else in the build names that bus:
- \`fl::enableAllDrivers()\` (PR #2448) — names everything available on the platform.
- \`fl::enableDrivers<Bus::X, ...>()\` — names a subset.
- The templated \`FastLED.add<Bus::X>(cfg)\` (PR #2451) — names a single bus.

## Tests

Three new host-side cases in \`tests/fl/channels/channel.cpp\`:

- \`FastLED.add(Bus::STUB, cfg)\` lands on the STUB driver (verified via \`channel->getEngineName()\` after \`showLeds()\`).
- The overload overwrites prior \`mAffinity\` strings.
- \`FastLED.add(Bus::AUTO, cfg)\` clears affinity → priority-dispatch fallback (channel still binds to a registered driver on the host).

## Test plan

- [x] \`bash test channel --cpp\` — 1/1 pass.
- [x] \`bash test --cpp\` — 304/304 pass (full host suite after the three #2428 merges from earlier today).
- [x] \`bash lint --cpp\` — clean.
- [ ] CI matrix to validate hardware platform builds — header-only change.

## Reviewer

Code-reviewed by the c-cpp-expert-agent before commit. Verified:
- No ODR-use of \`BusTraits<B>::instance/instancePtr\` (binary-bloat fix preserved).
- \`fl::busName(b)\` returns static-storage string literals (safe for \`from_literal\`).
- \`Bus::AUTO\` mapping is consistent with the legacy empty-affinity contract.
- Overload resolution unambiguous against the six other \`CFastLED::add\` overloads (unique 2-arg signature, \`Bus\` first param).
- \`FL_NOEXCEPT\` annotation added for consistency with the templated counterpart at L877.

## Related

- #2428 — parent meta-issue (Phase 4 still has \`mAffinity\` → \`fl::Bus\` field conversion as remaining cleanup).
- #2167 — closed by #2451.
- #2448 — \`enableAllDrivers()\` (merged).
- #2449 — full Phase 3b \`TypedChannel<Bus, Chipset>\` (merged).
- #2450 — Phase 5c aggregator gating (merged).
- #2451 — templated \`FastLED.add<Bus B>\` (merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new channel configuration method supporting runtime bus selection, enabling explicit driver specification with automatic fallback to compatible drivers.

* **Tests**
  * Added comprehensive test coverage for the new runtime bus selection functionality across multiple configuration scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/FastLED/pull/2454)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->