### PR TITLE
feat(channels): non-template FastLED.add() + typed mBus + remove mAffinity (closes #2459)

### DIFF
--- a/examples/AutoResearch/AutoResearchRemote.cpp
+++ b/examples/AutoResearch/AutoResearchRemote.cpp
@@ -646,9 +646,27 @@ fl::json AutoResearchRemoteControl::runParallelTestImpl(const fl::json& args) {
         for (fl::size li = 0; li < de.lane_sizes.size(); li++) {
             auto leds = fl::make_unique<fl::vector<CRGB>>(de.lane_sizes[li]);
 
-            // Set up channel with driver affinity
+            // Set up channel with typed driver selection (#2459).
+            // The pre-#2459 string `mAffinity` field is gone — translate the
+            // discovered driver name back to a `fl::Bus` enum value.
             fl::ChannelOptions opts;
-            opts.mAffinity = de.name;
+            {
+                const fl::string& n = de.name;
+                if      (n == "RMT")           opts.mBus = fl::Bus::RMT;
+                else if (n == "PARLIO")        opts.mBus = fl::Bus::PARLIO;
+                else if (n == "SPI")           opts.mBus = fl::Bus::SPI;
+                else if (n == "I2S")           opts.mBus = fl::Bus::I2S;
+                else if (n == "I2S_SPI")       opts.mBus = fl::Bus::I2S_SPI;
+                else if (n == "LCD_RGB")       opts.mBus = fl::Bus::LCD_RGB;
+                else if (n == "LCD_SPI")       opts.mBus = fl::Bus::LCD_SPI;
+                else if (n == "LCD_CLOCKLESS") opts.mBus = fl::Bus::LCD_CLOCKLESS;
+                else if (n == "UART")          opts.mBus = fl::Bus::UART;
+                else if (n == "FLEX_IO")       opts.mBus = fl::Bus::FLEX_IO;
+                else if (n == "OBJECT_FLED")   opts.mBus = fl::Bus::OBJECT_FLED;
+                else if (n == "BIT_BANG")      opts.mBus = fl::Bus::BIT_BANG;
+                else if (n == "STUB")          opts.mBus = fl::Bus::STUB;
+                // else: leave Bus::AUTO; priority dispatch will pick.
+            }
 
             fl::ChannelConfig channel_config(
                 de.pin_tx + (int)li,  // Consecutive pins per lane

--- a/src/FastLED.cpp.hpp
+++ b/src/FastLED.cpp.hpp
@@ -5,6 +5,7 @@
 #include "FastLED.h"
 #include "fl/system/engine_events.h"
 #include "fl/stl/compiler_control.h"
+#include "fl/channels/all_drivers.h"
 #include "fl/channels/channel.h"
 #include "fl/channels/channel_events.h"
 #include "fl/channels/manager.h"
@@ -597,6 +598,29 @@ bool CFastLED::wait(fl::u32 timeout_ms) {
 // ============================================================================
 
 fl::ChannelPtr CFastLED::add(const fl::ChannelConfig& config) {
+    // Issue #2459: the non-template `FastLED.add(cfg)` path is the runtime-
+    // selection mode. To make sure `cfg.options.mBus` (or priority dispatch
+    // when `mBus == Bus::AUTO`) can actually find the requested driver at
+    // runtime, we eagerly enroll every driver available on this platform.
+    // That trades binary size for ergonomics — the user wanted runtime
+    // selection, so they get runtime selection.
+    //
+    // For minimum binary size, callers should use the compile-time path:
+    //   FastLED.addLeds<CHIPSET, PIN, ORDER, fl::Bus::X>(leds, n);
+    // which ODR-uses only `BusTraits<X>::instancePtr()` and lets
+    // `--gc-sections` drop every other driver TU.
+    //
+    // The warning fires at most once per process (FL_WARN_ONCE) and can be
+    // disabled with `-DFASTLED_SUPPRESS_RUNTIME_DRIVER_WARNING`.
+    #ifndef FASTLED_SUPPRESS_RUNTIME_DRIVER_WARNING
+    FL_WARN_ONCE("FastLED.add(cfg): runtime-selection mode — enrolling every "
+                 "available driver via fl::enableAllDrivers(). For minimum "
+                 "binary size, prefer FastLED.addLeds<CHIPSET, PIN, ORDER, "
+                 "fl::Bus::X>(leds, n) which links only the named driver. "
+                 "Suppress this warning with -DFASTLED_SUPPRESS_RUNTIME_DRIVER_WARNING.");
+    #endif
+    fl::enableAllDrivers();
+
     fl::ChannelManager& manager = fl::channelManager();
     FL_ASSERT(manager.getDriverCount() > 0,
               "No channel drivers available - channel API requires at least one registered driver");

--- a/src/FastLED.h
+++ b/src/FastLED.h
@@ -710,87 +710,6 @@ public:
 	/// @endcode
 	static fl::ChannelPtr add(const fl::ChannelConfig& config);
 
-	/// @brief Add an LED channel pinned at compile time to a specific `fl::Bus`.
-	///
-	/// Templated counterpart to `FastLED.add(cfg)` — the bus is chosen at
-	/// compile time so typos become compile errors (`fl::Bus::RTM` → no such
-	/// enumerator) and bus/chipset mismatches become `static_assert`
-	/// failures rather than runtime warnings.
-	///
-	/// This is the issue #2428 / #2167 API:
-	///
-	/// @code
-	///   #include "platforms/esp/32/drivers/rmt/rmt_5/bus_traits.h"
-	///   auto channel = FastLED.add<fl::Bus::RMT>(cfg);
-	/// @endcode
-	///
-	/// **Linker behaviour.** This overload ODR-uses
-	/// `fl::BusTraits<B>::instancePtr()` so the linker keeps the driver's
-	/// translation unit. Sketches that only ever name one `Bus::X` only link
-	/// that one driver — the binary-bloat fix from #2420 / #2421 applies
-	/// per-bus.
-	///
-	/// **Precondition.** The user must `#include` the per-driver
-	/// `bus_traits.h` that specializes `BusTraits<B>` for the chosen bus, or
-	/// the call fails to compile with `implicit instantiation of undefined
-	/// template`. That diagnostic IS the opt-in.
-	///
-	/// @tparam B target bus — must not be `Bus::AUTO`. For
-	///           platform-default dispatch, use the non-template overload.
-	/// @param  config channel configuration; the affinity is overwritten
-	///                with `busName(B)` to pin dispatch
-	/// @return shared pointer to the channel, or nullptr if no driver for
-	///         `B` is registered at runtime
-	template<fl::Bus B>
-	static fl::ChannelPtr add(const fl::ChannelConfig& config) {
-		auto channel = fl::Channel::create<B>(config);
-		if (channel) {
-			add(channel);
-		}
-		return channel;
-	}
-
-	/// @brief Add an LED channel and dispatch by a **runtime** `fl::Bus` value.
-	///
-	/// Sister API to the templated `FastLED.add<Bus B>(cfg)` (PR #2451). The
-	/// trade-off:
-	///
-	/// | API | Bus is chosen | Driver TU is linked when |
-	/// |---|---|---|
-	/// | `FastLED.add<Bus::RMT>(cfg)` (templated) | at compile time | the call site names `Bus::RMT` |
-	/// | `FastLED.add(Bus::RMT, cfg)` (this one)  | at runtime      | something *else* in the build named `Bus::RMT` (e.g. `enableAllDrivers()`) |
-	///
-	/// Use this overload when the user has already enrolled drivers with
-	/// `ChannelManager` (typically via `fl::enableAllDrivers()` or an explicit
-	/// `fl::enableDrivers<...>()`) and just wants to pick which one handles a
-	/// given channel — **without** the per-call-site linker keep-alive that the
-	/// templated form does. The bus name is derived via `fl::busName(b)` so the
-	/// stringly-typed `"RMT"` literal never appears in user code. See issue
-	/// #2453 for the design context.
-	///
-	/// @param b      target bus; if `fl::Bus::AUTO`, the affinity is cleared so
-	///               `ChannelManager` picks by priority (same as not setting an
-	///               affinity at all).
-	/// @param config channel configuration; the `mAffinity` field is overwritten.
-	/// @return shared pointer to the channel, or nullptr if dispatch failed
-	///         (e.g. the named driver was not registered with `ChannelManager`).
-	///
-	/// @code
-	///   #include "fl/channels/all_drivers.h"
-	///   void setup() {
-	///       FastLED.enableAllDrivers();
-	///       FastLED.add(fl::Bus::RMT, cfg);   // runtime dispatch, no extra linker work
-	///   }
-	/// @endcode
-	static fl::ChannelPtr add(fl::Bus b, fl::ChannelConfig config) FL_NOEXCEPT {
-		if (b == fl::Bus::AUTO) {
-			config.options.mAffinity.clear();
-		} else {
-			config.options.mAffinity = fl::string::from_literal(fl::busName(b));
-		}
-		return add(config);
-	}
-
 	/// @brief Add multiple LED channels from a config array
 	///
 	/// Creates and registers multiple Channel-based LED controllers from an array of configurations.
@@ -848,50 +767,6 @@ public:
 	/// auto channels = FastLED.add(multiConfig);
 	/// @endcode
 	static fl::vector<fl::ChannelPtr> add(const fl::MultiChannelConfig& multiConfig);
-
-	/// @brief Templated Channel add -- compile-time bus/chipset enforcement (issue #2428 Phase 3b).
-	///
-	/// Selects the driver `Bus` at compile time. When `B == fl::Bus::AUTO` (the
-	/// default), the bus is resolved per-platform via `fl::DefaultBus<Chipset>::value`.
-	/// A `static_assert` rejects nonsense combinations (e.g. clockless config
-	/// routed to an SPI-only bus) at instantiation time so they never reach
-	/// runtime as warnings.
-	///
-	/// @tparam B       The driver bus identifier. Default `fl::Bus::AUTO`
-	///                 resolves to the platform default for `Chipset`.
-	/// @tparam Chipset Chipset family (deduced from the config).
-	/// @param  cfg     Strongly-typed channel configuration.
-	/// @return Shared pointer to the created `Channel` (already added to the
-	///         draw list), suitable for lifetime management.
-	///
-	/// Example:
-	/// @code
-	/// fl::ChannelConfigOf<fl::ClocklessChipset> cfg{
-	///     fl::ClocklessChipset(4, fl::makeTimingConfig<fl::TIMING_WS2812_800KHZ>()),
-	///     fl::span<CRGB>(leds, 60), GRB};
-	///
-	/// FastLED.add(cfg);                          // platform default clockless bus
-	/// FastLED.add<fl::Bus::RMT>(cfg);            // OK -- RMT supports clockless
-	/// FastLED.add<fl::Bus::SPI>(cfg);            // compile error: SPI bus, clockless chipset
-	/// @endcode
-	template<fl::Bus B = fl::Bus::AUTO, typename Chipset>
-	static fl::ChannelPtr add(const fl::ChannelConfigOf<Chipset>& cfg) FL_NOEXCEPT {
-		constexpr fl::Bus actual = (B == fl::Bus::AUTO)
-			? fl::DefaultBus<Chipset>::value
-			: B;
-		// Diagnostic message (suppressed on pre-C++17 by FL_STATIC_ASSERT)
-		// describes the contract: route ClocklessChipset to a clockless bus
-		// (RMT/PARLIO/I2S/...) and SpiChipsetConfig to an SPI bus.
-		FL_STATIC_ASSERT(
-			fl::BusSupports<actual, Chipset>::value,
-			"FastLED.add: Bus does not support this Chipset family");
-		// Naming `BusTraits<actual>::instance` here is the ODR-use that links
-		// the driver translation unit even with `--gc-sections` enabled
-		// (issue #2428 Phase 5 binary-size fix).
-		(void)&fl::BusTraits<actual>::instance;
-		fl::ChannelConfig erased = cfg.toErased();
-		return CFastLED::add(erased);
-	}
 
 	/// @brief Add an RX channel with runtime configuration
 	///
@@ -979,8 +854,8 @@ public:
 	///
 	/// void setup() {
 	///     FastLED.enableAllDrivers();   // every platform driver registered
-	///     fl::ChannelOptions opts; opts.mAffinity = "RMT";
-	///     FastLED.add(fl::ChannelConfig(...));
+	///     fl::ChannelOptions opts; opts.mBus = fl::Bus::RMT;   // #2459
+	///     FastLED.add(fl::ChannelConfig(..., opts));
 	/// }
 	/// @endcode
 	///

--- a/src/fl/channels/README.md
+++ b/src/fl/channels/README.md
@@ -19,10 +19,10 @@ The system consists of two layers:
 
 Users create `Channel` objects using the Channel API (recommended) or the template-based `FastLED.addLeds<>()` API (backwards compatible). The driver layer is managed automatically based on platform capabilities and priorities.
 
-Two complementary dispatch modes are available (introduced by issue #2428):
+Two complementary dispatch modes are available (introduced by issue #2428, refined by #2459):
 
-- **Compile-time `fl::Bus` binding** - `FastLED.add<fl::Bus::RMT>(cfg)` / `Channel::create<fl::Bus::RMT>(cfg)` pin the driver at compile time. Naming `Bus::X` at the call site is what links the driver's translation unit, so `--gc-sections` drops every driver the sketch doesn't reference. Bus/chipset mismatches become `static_assert` errors rather than runtime warnings.
-- **Runtime selection** - `FastLED.add(cfg)` (with optional `mAffinity`) or `FastLED.add(fl::Bus::RMT, cfg)` dispatch through `ChannelManager` at runtime. Drivers must first be registered: either by leaving the legacy registry on (the default - see `FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY` below) or by calling `fl::enableDrivers<fl::Bus::X...>()` / `FastLED.enableAllDrivers()`.
+- **Compile-time `fl::Bus` binding** - `fl::TypedChannel<fl::Bus::RMT, fl::ClocklessChipset>::create(cfg)` (and the planned `addLeds<..., fl::Bus::RMT>` trailing template parameter — see #2460) pin the driver at compile time. Naming `Bus::X` at the call site is what links the driver's translation unit, so `--gc-sections` drops every driver the sketch doesn't reference. Bus/chipset mismatches become `static_assert` errors rather than runtime warnings.
+- **Runtime selection** - `FastLED.add(cfg)` is **non-template**. Pick the driver by setting `cfg.options.mBus = fl::Bus::RMT` (typed `enum class`). The non-template path auto-enrolls every driver on the platform via `fl::enableAllDrivers()` and emits a one-time `FL_WARN_ONCE` explaining the binary-size trade-off (suppress with `-DFASTLED_SUPPRESS_RUNTIME_DRIVER_WARNING`). For minimum binary size, use the compile-time path instead. Custom/mock drivers (whose names aren't in the `fl::Bus` enum) bind via priority dispatch — register the mock with `manager.addDriver()` and either let it win by priority, or use `manager.setExclusiveDriver(name)` to force-select.
 
 ---
 
@@ -118,7 +118,7 @@ The `fl::Bus` enum (in `fl/channels/bus.h`) is the single identifier that flows 
 | `STUB` | `"STUB"` |
 | `AUTO` | sentinel - resolves to `DefaultBus<Chipset>::value` for the platform |
 
-`busName(Bus)` returns the canonical string literal. `isKnownBusName(name)` tells you whether a string matches any of the above (used internally by the affinity-miss diagnostic).
+`busName(Bus)` returns the canonical string literal. This is what `ChannelManager::findDriverByName` matches against each driver's `getName()`.
 
 Note the spelling: driver names match the enumerator exactly, including underscores. Earlier releases used `"BITBANG"`, `"FLEXIO"`, `"OBJECTFLED"` - those are now `"BIT_BANG"`, `"FLEX_IO"`, `"OBJECT_FLED"`.
 
@@ -135,52 +135,65 @@ CRGB leds[60];
 
 void setup() {
     auto timing = fl::makeTimingConfig<fl::TIMING_WS2812_800KHZ>();
-    fl::ChannelConfig cfg(fl::ClocklessChipset(16, timing),
-        fl::span<CRGB>(leds, 60), RGB);
+    fl::ChannelConfigOf<fl::ClocklessChipset> cfg{
+        fl::ClocklessChipset(16, timing),
+        fl::span<CRGB>(leds, 60), RGB};
 
-    // Compile-time bus pinning: typos like fl::Bus::RTM are compile errors,
-    // and the only driver TU linked is RMT.
-    auto channel = FastLED.add<fl::Bus::RMT>(cfg);
+    // Compile-time bus pinning via TypedChannel — the single template entry
+    // point. Typos like fl::Bus::RTM are compile errors, and the only driver
+    // TU linked is RMT.
+    auto channel = fl::TypedChannel<fl::Bus::RMT, fl::ClocklessChipset>::create(cfg);
+    FastLED.add(channel);
 }
 ```
 
-**Strongly-typed `ChannelConfigOf<Chipset>` (Phase 3b, #2428):** the templated `FastLED.add<Bus, Chipset>(cfg)` overload accepts a `ChannelConfigOf<ClocklessChipset>` or `ChannelConfigOf<SpiChipsetConfig>` and `static_asserts` via `BusSupports<B, Chipset>::value` that the chosen bus actually handles the chipset family:
+**Strongly-typed `ChannelConfigOf<Chipset>` (Phase 3b, #2428):** the `TypedChannel<Bus, Chipset>::create(cfg)` template accepts a `ChannelConfigOf<ClocklessChipset>` or `ChannelConfigOf<SpiChipsetConfig>` and `static_asserts` via `BusSupports<B, Chipset>::value` that the chosen bus actually handles the chipset family:
 
 ```cpp
 fl::ChannelConfigOf<fl::ClocklessChipset> cfg{
     fl::ClocklessChipset(4, fl::makeTimingConfig<fl::TIMING_WS2812_800KHZ>()),
     fl::span<CRGB>(leds, 60), GRB};
 
-FastLED.add(cfg);                       // Bus::AUTO -> DefaultBus<ClocklessChipset>
-FastLED.add<fl::Bus::RMT>(cfg);         // OK -- RMT supports clockless
-FastLED.add<fl::Bus::LCD_SPI>(cfg);     // compile error: SPI bus, clockless chipset
+// AUTO resolves to DefaultBus<ClocklessChipset> per platform.
+fl::TypedChannel<fl::Bus::AUTO, fl::ClocklessChipset>::create(cfg);
+// Explicit bus selection.
+fl::TypedChannel<fl::Bus::RMT, fl::ClocklessChipset>::create(cfg);      // OK
+fl::TypedChannel<fl::Bus::LCD_SPI, fl::ClocklessChipset>::create(cfg);  // compile error
 ```
 
-The `TypedChannel<Bus, Chipset>` template (in `fl/channels/channel_typed.h`) is the underlying primitive: it `static_asserts` the bus/chipset contract and returns a `ChannelPtr` to the regular non-template runtime `Channel` so callbacks, the draw list, and `ChannelManager` see one channel type.
+`TypedChannel<Bus, Chipset>` lives in `fl/channels/channel_typed.h`. It returns a `ChannelPtr` to the regular non-template runtime `Channel` so callbacks, the draw list, and `ChannelManager` see one channel type.
 
-### Runtime Bus Selection (`FastLED.add(fl::Bus, cfg)`)
+> **Planned**: `FastLED.addLeds<CHIPSET, PIN, ORDER, fl::Bus::X>(leds, n)` — a trailing default template parameter on the legacy `addLeds<>` shape. See #2460. Not in tree yet.
 
-`FastLED.add(fl::Bus::RMT, cfg)` dispatches by the runtime value of the `Bus` argument. Unlike the templated form, it does **not** link a driver TU by itself - the user is responsible for getting the driver registered with `ChannelManager` ahead of time (e.g. by calling `FastLED.enableAllDrivers()` or `fl::enableDrivers<fl::Bus::RMT>()`). Use this when the bus choice is data-driven (config file, UI, etc.) and you've already opted into runtime flexibility:
+### Runtime Bus Selection (non-template `FastLED.add(cfg)`)
+
+`FastLED.add(cfg)` is non-template (#2459). Pick the driver via `cfg.options.mBus`:
+
+- **`cfg.options.mBus = fl::Bus::RMT`** — pin to a specific driver. The dispatch looks up `busName(mBus)` in `ChannelManager`.
+- **`cfg.options.mBus = fl::Bus::AUTO`** (the default) — `ChannelManager` picks the highest-priority driver that `canHandle` the chipset.
+
+For **custom / third-party / mock drivers** whose names aren't in the `fl::Bus` enum, register the driver with `manager.addDriver(priority, driver)` and either (a) clear competing drivers first so priority dispatch picks it, or (b) call `manager.setExclusiveDriver(name)` for process-wide binding. There is no string-affinity field on `ChannelOptions` post-#2459.
+
+The non-template path **auto-enrolls every driver** on the platform (`fl::enableAllDrivers()` runs inside) so any `mBus` value can be dispatched at runtime. A one-time `FL_WARN_ONCE` explains the binary-size trade-off; suppress it with `-DFASTLED_SUPPRESS_RUNTIME_DRIVER_WARNING`. For minimum binary size, use the compile-time `TypedChannel<...>::create()` path above.
 
 ```cpp
 #include "FastLED.h"
-#include "fl/channels/all_drivers.h"   // makes BusTraits<Bus::*> singletons visible
 
 CRGB leds[60];
 
 fl::Bus userPreferredBus();            // declared elsewhere -- reads config / UI
 
 void setup() {
-    FastLED.enableAllDrivers();        // register every platform driver
-
     auto timing = fl::makeTimingConfig<fl::TIMING_WS2812_800KHZ>();
     fl::ChannelConfig cfg(fl::ClocklessChipset(16, timing),
         fl::span<CRGB>(leds, 60), RGB);
 
-    fl::Bus chosen = userPreferredBus();    // e.g. read from config
-    FastLED.add(chosen, cfg);               // affinity = busName(chosen)
+    cfg.options.mBus = userPreferredBus();   // data-driven choice
+    FastLED.add(cfg);                         // auto-enables all drivers, dispatches by mBus
 }
 ```
+
+If `cfg.options.mBus` names a driver that — for whatever reason — isn't in the manager's registry, `Channel::showPixels` emits a one-shot `FL_ERROR` listing the resolution options (`fl::enableDrivers<fl::Bus::X>()` or `FastLED.enableAllDrivers()`) and falls back to AUTO/priority dispatch (#2455).
 
 Passing `fl::Bus::AUTO` clears the affinity and lets `ChannelManager` pick by priority - identical to the no-affinity `FastLED.add(cfg)` overload.
 
@@ -473,14 +486,14 @@ CRGB ws2816_strip[NUM_LEDS];
 void setup() {
     // WS2812 strips bound to RMT driver
     fl::ChannelOptions ws2812_opts;
-    ws2812_opts.mAffinity = "RMT";
+    ws2812_opts.mBus = fl::Bus::RMT;       // typed, preferred (#2459)
     auto timing_ws2812 = fl::makeTimingConfig<fl::TIMING_WS2812_800KHZ>();
     FastLED.add(fl::ChannelConfig(16, timing_ws2812,
         fl::span<CRGB>(ws2812_strip, NUM_LEDS), RGB, ws2812_opts));
 
     // WS2816 strips bound to SPI driver (transmits in parallel with RMT)
     fl::ChannelOptions ws2816_opts;
-    ws2816_opts.mAffinity = "SPI";
+    ws2816_opts.mBus = fl::Bus::SPI;
     auto timing_ws2816 = fl::makeTimingConfig<fl::TIMING_WS2816>();
     FastLED.add(fl::ChannelConfig(18, timing_ws2816,
         fl::span<CRGB>(ws2816_strip, NUM_LEDS), RGB, ws2816_opts));
@@ -501,11 +514,11 @@ void loop() {
 - Testing specific driver implementations
 - Debugging hardware-specific behavior
 
-**Driver-name spelling.** Affinity strings must match the driver's `getName()` exactly. The canonical name for `fl::Bus::X` is `busName(X)` (see the table above). Prefer the templated `FastLED.add<fl::Bus::X>(cfg)` or runtime `FastLED.add(fl::Bus::X, cfg)` overloads - they derive the affinity string via `busName(B)` so the typo-prone literal never appears at the call site.
+**`mBus` is typed.** `cfg.options.mBus` is an `enum class` (#2459), so typos like `fl::Bus::RTM` are compile errors. The canonical driver name is derived via `busName(B)` — string literals never appear at the call site.
 
-**Affinity-miss diagnostic (one-shot, from #2456):** when a non-empty `mAffinity` resolves to a driver that isn't registered with `ChannelManager`, the first `Channel::showPixels()` call emits a single `FL_ERROR` and falls back to AUTO/priority dispatch. Subsequent shows on the same channel suppress the warning via `mAffinityWarned`. The diagnostic uses `ChannelManager::findDriverByName()` (silent lookup) to distinguish two cases:
+**Bus-miss diagnostic (one-shot, from #2456 / #2459):** when `cfg.options.mBus != fl::Bus::AUTO` resolves to a driver that isn't registered with `ChannelManager`, the first `Channel::showPixels()` call emits a single `FL_ERROR` and falls back to AUTO/priority dispatch. Subsequent shows on the same channel suppress the warning via `mBusWarned`. The diagnostic uses `ChannelManager::findDriverByName()` (silent lookup) to distinguish two cases:
 
-- Driver name matches a known `Bus` value but isn't registered - message points the user at `fl::enableDrivers<fl::Bus::X>()`.
+- Driver isn't registered at all - message points the user at `fl::enableDrivers<fl::Bus::X>()` or `FastLED.enableAllDrivers()`.
 - Driver is registered but `canHandle()` rejected the chipset (bus/chipset mismatch) - message suggests picking a different `Bus`.
 
 Use `ChannelManager::findDriverByName(name)` directly when you want to probe the registry without triggering the log; `getDriverByName(name)` is the noisy variant.
@@ -847,7 +860,7 @@ void setupCustomEngine() {
    - On hit: that driver is returned (no priority iteration).
    - On miss: `Channel::showPixels()` emits a one-shot `FL_ERROR` (see "Affinity-miss diagnostic" above) and falls through to priority dispatch.
 2. Otherwise (or on affinity miss): manager iterates drivers by priority (high to low) and returns the first that `canHandle()`s the channel data.
-3. User can override with `ChannelOptions.mAffinity` (or the templated `FastLED.add<fl::Bus::X>(cfg)` / runtime `FastLED.add(fl::Bus::X, cfg)` overloads, which set affinity for you) or with `FastLED.setExclusiveDriver()`.
+3. User can override via `ChannelOptions.mBus` (#2459), `fl::TypedChannel<Bus, Chipset>::create()` (compile-time, ODR-links the driver), or `FastLED.setExclusiveDriver()` (process-wide).
 
 **Priority modification:**
 - Engines are sorted by priority on registration (via `addDriver()`)
@@ -965,7 +978,7 @@ See `tests/fl/channels/driver.cpp` for more test examples.
 - `fl/channels/ichannel.h` - `IChannel` ABC (callback-facing identification base)
 - `fl/channels/config.h` - `ChannelConfig`, `ChannelConfigOf<Chipset>`, `ClocklessChipset`, `SpiChipsetConfig`
 - `fl/channels/options.h` - `ChannelOptions` (correction, temperature, dither, affinity, gamma)
-- `fl/channels/bus.h` - `fl::Bus` enum, `busName()`, `isKnownBusName()`, `DefaultBus<Chipset>`, `FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY`
+- `fl/channels/bus.h` - `fl::Bus` enum, `busName()`, `DefaultBus<Chipset>`, `FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY`
 - `fl/channels/bus_traits.h` - `BusTraits<B>`, `BusSupports<B, Chipset>`, `enableDrivers<Bus...>()`
 - `fl/channels/all_drivers.h` - `fl::enableAllDrivers()` / `FastLED.enableAllDrivers()` aggregator
 - `fl/channels/manager.h` - `ChannelManager` (`addDriver`, `getDriverByName`, `findDriverByName`, `selectDriverForChannel`, `clearAllDrivers`, ...)

--- a/src/fl/channels/bus.h
+++ b/src/fl/channels/bus.h
@@ -15,7 +15,6 @@
 #include "fl/stl/noexcept.h"
 #include "fl/stl/static_assert.h"
 #include "fl/stl/stdint.h"
-#include "fl/stl/string.h"
 #include "platforms/is_platform.h"
 
 // FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY: opt-in macro that, when set to 1,
@@ -138,17 +137,14 @@ template<> struct DefaultBus<ClocklessChipset> {
 ///
 /// Each `Bus::X` corresponds to exactly one concrete `IChannelDriver`. That
 /// driver's `getName()` returns a stable string that `ChannelManager` uses as
-/// the affinity key (`ChannelOptions::mAffinity` / `getDriverByName`). When
-/// the new templated `Channel::create<Bus B>(cfg)` / `FastLED.add<Bus B>(cfg)`
-/// overloads are used (closes #2167), the affinity is derived from `B` via
-/// this helper so the typo-prone string literal never appears at the call
-/// site.
+/// the lookup key (`findDriverByName` / `getDriverByName`). Channels read
+/// `ChannelOptions::mBus` (#2459) and the dispatch layer derives the lookup
+/// string via `busName(mBus)` — typo-prone string literals never appear at the
+/// call site.
 ///
 /// Returns `"AUTO"` for `Bus::AUTO` — diagnostic/log paths get a stable
-/// human-readable label. The templated `Channel::create<B>(cfg)` /
-/// `FastLED.add<B>(cfg)` overloads `static_assert` against `B == Bus::AUTO`,
-/// so this name never reaches `ChannelOptions::mAffinity` and never enters
-/// the `ChannelManager` dispatch path.
+/// human-readable label. `mBus == Bus::AUTO` means "no Bus pin; let the
+/// manager pick by priority", so this name never reaches the manager's lookup.
 ///
 /// Spelling is normalized to match the C++ enumerator name exactly (including
 /// underscores in `FLEX_IO`, `OBJECT_FLED`, `BIT_BANG`). Driver `getName()`
@@ -182,23 +178,5 @@ inline const char* busName(Bus b) FL_NOEXCEPT {
 // wire the case in — its failure is the prompt to revisit `busName()`.
 FL_STATIC_ASSERT(static_cast<fl::u8>(Bus::STUB) == 13,
                  "Bus changed: add the new value to busName() in this file");  // ok plain enum
-
-/// @brief Predicate: does `name` match the `getName()` of any known FastLED
-///        channel driver? Used by Channel's runtime-affinity miss diagnostic
-///        (#2455) to decide whether to emit the actionable
-///        `fl::enableDrivers<fl::Bus::X>()` hint or a generic message.
-///
-/// Empty / unknown / third-party names return `false`. `"AUTO"` returns
-/// `false` because it is the sentinel for "no affinity"; the dispatch path
-/// should never see it as a non-empty mAffinity in practice.
-inline bool isKnownBusName(const fl::string& name) FL_NOEXCEPT {
-    return name == "RMT"           || name == "PARLIO"      ||
-           name == "SPI"           || name == "I2S"          ||
-           name == "I2S_SPI"       || name == "LCD_RGB"      ||
-           name == "LCD_SPI"       || name == "LCD_CLOCKLESS"||
-           name == "UART"          || name == "FLEX_IO"      ||
-           name == "OBJECT_FLED"   || name == "BIT_BANG"     ||
-           name == "STUB";
-}
 
 }  // namespace fl

--- a/src/fl/channels/channel.cpp.hpp
+++ b/src/fl/channels/channel.cpp.hpp
@@ -150,7 +150,7 @@ Channel::Channel(const ChipsetVariant& chipset, EOrder rgbOrder, RegistrationMod
     , mChipset(chipset)
     , mRgbOrder(rgbOrder)
     , mDriver()
-    , mAffinity()
+    , mBus(Bus::AUTO)
     , mId(nextId())
     , mName(makeName(mId)) {
     // NOTE: Do NOT call fl::pinMode() here — see comment in the
@@ -164,7 +164,7 @@ Channel::Channel(const ChipsetVariant& chipset, fl::span<CRGB> leds,
     , mChipset(chipset)
     , mRgbOrder(rgbOrder)
     , mDriver()  // Empty weak_ptr - late binding on first showPixels()
-    , mAffinity(options.mAffinity)  // Get affinity from ChannelOptions
+    , mBus(options.mBus)  // Bus selection (#2459)
     , mId(nextId())
     , mName(makeName(mId)) {
     // NOTE: Do NOT call fl::pinMode() here. The pin may already be
@@ -193,7 +193,7 @@ Channel::Channel(int pin, const ChipsetTimingConfig& timing, fl::span<CRGB> leds
     , mChipset(ClocklessChipset(pin, timing))  // Convert to variant
     , mRgbOrder(rgbOrder)
     , mDriver()  // Empty weak_ptr - late binding on first showPixels()
-    , mAffinity(options.mAffinity)  // Get affinity from ChannelOptions
+    , mBus(options.mBus)  // Bus selection (#2459)
     , mId(nextId())
     , mName(makeName(mId)) {
     // NOTE: Do NOT call fl::pinMode() here — see comment in the
@@ -318,46 +318,45 @@ void Channel::showPixels(PixelController<RGB, 1, 0xFFFFFFFF> &pixels) {
     // their constructor), bypass ChannelManager entirely. Channels created via
     // the manager-based API (Channel::create(cfg) without affinity) keep their
     // existing per-frame re-selection so users can swap drivers at runtime.
+    // Resolve dispatch via the typed `mBus` field (#2459). `Bus::AUTO`
+    // means "no pinning — let the manager pick by priority"; any other
+    // value pins this channel to `busName(mBus)`.
+    fl::string busKey;
+    if (mBus != Bus::AUTO) {
+        busKey = fl::string::from_literal(busName(mBus));
+    }
     fl::shared_ptr<IChannelDriver> driver;
     if (mDriverPreBound) {
         driver = mDriver.lock();
     } else {
-        driver = ChannelManager::instance().selectDriverForChannel(mChannelData, mAffinity);
+        driver = ChannelManager::instance().selectDriverForChannel(mChannelData, busKey);
         mDriver = driver;
     }
-    // #2455: one-shot diagnostic when a runtime-selected affinity misses.
-    // The manager already returned the AUTO/priority-dispatch fallback (or
-    // null) — we just log the actionable hint once so the user knows WHY
-    // their explicit Bus selection didn't take. The guard suppresses the
-    // log on every subsequent show() of this channel, even though the
-    // affinity → priority-fallback chain re-runs each frame.
-    //
-    // We probe the registry directly via the silent `findDriverByName` to
-    // distinguish "driver wasn't instantiated" from "driver exists but
-    // canHandle() rejected this chipset" — the messages differ because the
-    // resolution paths differ (enableDrivers vs use a different Bus).
-    if (!mDriverPreBound && !mAffinity.empty() && !mAffinityWarned &&
-        (!driver || driver->getName() != mAffinity)) {
-        auto affinityDriver = ChannelManager::instance().findDriverByName(mAffinity);
-        if (!affinityDriver) {
-            // Not registered with the manager at all.
-            if (isKnownBusName(mAffinity)) {
-                FL_ERROR("Channel '" << mName << "': Driver '" << mAffinity
-                    << "' wasn't instantiated — call fl::enableDrivers<fl::Bus::"
-                    << mAffinity
-                    << ">() (or fl::enableAllDrivers()) before adding the channel. "
-                    << "Defaulting to AUTO/priority dispatch.");
-            } else {
-                FL_ERROR("Channel '" << mName << "': Affinity '" << mAffinity
-                    << "' has no registered driver. Defaulting to AUTO/priority dispatch.");
-            }
+    // #2455 / #2459: one-shot diagnostic when a typed-Bus miss happens.
+    // Probe via `findDriverByName` (silent) to distinguish "driver wasn't
+    // instantiated" from "driver exists but canHandle() rejected this
+    // chipset" — resolution paths differ. The mBusWarned guard suppresses
+    // duplicate logs on subsequent shows of the same channel.
+    if (!mDriverPreBound && mBus != Bus::AUTO && !mBusWarned &&
+        (!driver || driver->getName() != busKey)) {
+        auto busDriver = ChannelManager::instance().findDriverByName(busKey);
+        if (!busDriver) {
+            // Typed Bus miss — emit the actionable hint with the two
+            // currently-shipping remediations. The third option
+            // (`addLeds<..., fl::Bus::X>(...)`) is planned in #2460.
+            FL_ERROR("Channel '" << mName << "': Driver '" << busKey
+                << "' wasn't instantiated. Resolve with: "
+                << "(1) fl::enableDrivers<fl::Bus::" << busKey << ">() "
+                << "(links only this driver), or "
+                << "(2) FastLED.enableAllDrivers() (links every driver). "
+                << "Defaulting to AUTO/priority dispatch.");
         } else {
             // Registered, but canHandle() said no — bus/chipset mismatch.
-            FL_ERROR("Channel '" << mName << "': Driver '" << mAffinity
+            FL_ERROR("Channel '" << mName << "': Driver '" << busKey
                 << "' is registered but cannot handle this channel's chipset "
                 << "(bus/chipset mismatch). Defaulting to AUTO/priority dispatch.");
         }
-        mAffinityWarned = true;
+        mBusWarned = true;
     }
     if (!driver) {
         FL_ERROR("Channel '" << mName << "': No compatible driver found - cannot transmit");

--- a/src/fl/channels/channel.h
+++ b/src/fl/channels/channel.h
@@ -16,11 +16,9 @@
 
 #include "cpixel_ledcontroller.h"
 #include "fl/channels/bus.h"
-#include "fl/channels/bus_traits.h"
 #include "fl/channels/ichannel.h"
 #include "fl/channels/options.h"
 #include "fl/stl/shared_ptr.h"
-#include "fl/stl/static_assert.h"
 #include "fl/stl/string.h"
 #include "fl/stl/weak_ptr.h"
 #include "fl/stl/stdint.h"
@@ -55,58 +53,6 @@ public:
     /// @note Channels always use ChannelManager by default
     /// @note If config.affinity is set, binds to the named driver from ChannelManager
     static ChannelPtr create(const ChannelConfig& config);
-
-    /// @brief Create a channel pinned at compile time to a specific `Bus`.
-    ///
-    /// Closes #2167 — `Channel::create<EngineType>(config)` is now a real
-    /// template. Use this overload to:
-    ///   - State the target bus at compile time so typos (`Bus::RTM` →
-    ///     compile error, "RMT" → "RTM" would silently runtime-warn).
-    ///   - Reject bus/chipset mismatches via `static_assert` rather than at
-    ///     runtime via `ChannelManager` warnings.
-    ///   - ODR-use `BusTraits<B>::instancePtr()` from the call site so the
-    ///     driver's translation unit is kept by `--gc-sections` (#2428's
-    ///     binary-bloat fix). Sketches that only ever name one `Bus::X` only
-    ///     link that one driver.
-    ///
-    /// **Precondition.** The user must `#include` the per-driver
-    /// `bus_traits.h` that specializes `BusTraits<B>` for the chosen bus.
-    /// Otherwise the call fails to compile with `implicit instantiation of
-    /// undefined template 'BusTraits<Bus::X>'` — the explicit-opt-in
-    /// behaviour that lets unused drivers be linker-stripped.
-    ///
-    /// @code
-    ///   #include "platforms/esp/32/drivers/rmt/rmt_5/bus_traits.h"
-    ///   auto ch = fl::Channel::create<fl::Bus::RMT>(cfg);
-    /// @endcode
-    ///
-    /// @tparam B target bus (not `Bus::AUTO` — use the non-template form
-    ///           if you want platform-default selection)
-    /// @param  config channel configuration; the `mAffinity` field is
-    ///                overwritten with `busName(B)` to pin dispatch
-    /// @return shared pointer to the channel, or nullptr if the platform
-    ///         build did not register a driver for `B`
-    template<Bus B>
-    static ChannelPtr create(ChannelConfig config) {
-        FL_STATIC_ASSERT(B != Bus::AUTO,
-            "Channel::create<Bus::AUTO>() is not allowed — use the non-template "
-            "create(cfg) form for platform-default dispatch.");
-        FL_STATIC_ASSERT(
-            BusSupports<B, ClocklessChipset>::value ||
-            BusSupports<B, SpiChipsetConfig>::value,
-            "Bus B has no BusSupports specialization for any chipset family. "
-            "Did you forget to include the per-driver bus_traits.h? "
-            "(See src/platforms/.../bus_traits.h)");
-        // ODR-use the driver singleton so its translation unit is kept by
-        // --gc-sections (the linker keep-alive that delivers #2428's
-        // binary-bloat fix on a per-bus basis).
-        (void) BusTraits<B>::instancePtr();
-        // `busName(B)` returns a string literal (static storage duration), so
-        // `from_literal` is sound and avoids the heap allocation a `const
-        // char*` constructor would do.
-        config.options.mAffinity = fl::string::from_literal(busName(B));
-        return create(config);
-    }
 
     /// @brief Destructor
     virtual ~Channel() FL_NOEXCEPT;
@@ -298,9 +244,11 @@ private:
                                      // ChannelManager::selectDriverForChannel(). When false (the
                                      // default), every showPixels() re-evaluates the manager's
                                      // priority list so users can swap drivers at runtime.
-    fl::string mAffinity;            // Engine affinity name (empty = no affinity, dynamic selection)
-    bool mAffinityWarned = false;    // One-shot guard for the #2455 FL_ERROR. Flipped on the
-                                     // first showPixels() that observes an affinity miss (the
+    Bus mBus = Bus::AUTO;            // Typed driver selection (#2459). `Bus::AUTO` falls through
+                                     // to `ChannelManager` priority dispatch; any other value
+                                     // pins this channel to `busName(mBus)`.
+    bool mBusWarned = false;         // One-shot guard for the #2455 FL_ERROR. Flipped on the
+                                     // first showPixels() that observes a `mBus` miss (the
                                      // named driver wasn't registered with ChannelManager).
                                      // Subsequent shows on the same channel skip the warn even
                                      // though the priority-dispatch fallback re-runs every frame.

--- a/src/fl/channels/options.h
+++ b/src/fl/channels/options.h
@@ -4,20 +4,35 @@
 #include "pixeltypes.h"  // IWYU pragma: keep
 #include "color.h"
 #include "dither_mode.h"
+#include "fl/channels/bus.h"
 #include "rgbw.h"  // IWYU pragma: keep
-#include "fl/stl/string.h"  // IWYU pragma: keep
 #include "fl/stl/optional.h"
 
 namespace fl {
 
 /// Optional channel configuration parameters
-/// All fields have sensible defaults and can be overridden as needed
+/// All fields have sensible defaults and can be overridden as needed.
+///
+/// **Driver selection** (#2459). `mBus` is the single typed selector:
+///
+///   - `Bus::AUTO` (default) — let `ChannelManager` pick by priority dispatch.
+///   - Any other value — pin this channel to the named driver via
+///     `ChannelManager::findDriverByName(busName(mBus))`. If the named driver
+///     isn't registered, `Channel::showPixels` emits a one-shot `FL_ERROR`
+///     with the resolution hint (`fl::enableDrivers<fl::Bus::X>()` or
+///     `FastLED.enableAllDrivers()`) and falls back to AUTO/priority.
+///
+/// **Custom / third-party / mock drivers** whose names aren't in the
+/// `fl::Bus` enum should be bound either by priority (clear competing
+/// drivers via `clearAllDrivers()` and let the mock win priority dispatch)
+/// or via `ChannelManager::setExclusiveDriver(name)` for process-wide
+/// binding. There is no string-typed affinity field on `ChannelOptions`.
 struct ChannelOptions {
     CRGB mCorrection = UncorrectedColor;
     CRGB mTemperature = UncorrectedTemperature;
     fl::u8 mDitherMode = BINARY_DITHER;
     Rgbw mRgbw = RgbwInvalid::value(); // RGBW is RGB by default
-    fl::string mAffinity;              // Engine affinity (empty = let ChannelManager decide)
+    Bus mBus = Bus::AUTO;              // Typed driver selection
     fl::optional<float> mGamma;        // Gamma correction (nullopt = use default 2.8)
 };
 

--- a/tests/fastled_core.cpp
+++ b/tests/fastled_core.cpp
@@ -203,7 +203,6 @@ FL_TEST_CASE("Channel API: Mock driver workflow (GitHub issue #2167)") {
 
     auto timing = fl::makeTimingConfig<fl::TIMING_WS2812_800KHZ>();
     fl::ChannelOptions options;
-    options.mAffinity = "MOCK";  // Bind to mock driver
 
     fl::ChannelConfig config(5, timing, fl::span<CRGB>(leds, 10), GRB, options);
 
@@ -257,7 +256,6 @@ FL_TEST_CASE("Channel API: Double add protection") {
 
     auto timing = fl::makeTimingConfig<fl::TIMING_WS2812_800KHZ>();
     fl::ChannelOptions options;
-    options.mAffinity = "MOCK_DOUBLE";
 
     fl::ChannelConfig config(10, timing, fl::span<CRGB>(leds, 5), GRB, options);
     auto channel = fl::Channel::create(config);
@@ -310,7 +308,6 @@ FL_TEST_CASE("Channel API: Add and remove symmetry") {
 
     auto timing = fl::makeTimingConfig<fl::TIMING_WS2812_800KHZ>();
     fl::ChannelOptions options;
-    options.mAffinity = "MOCK_REMOVE";
 
     fl::ChannelConfig config(12, timing, fl::span<CRGB>(leds, 8), GRB, options);
     auto channel = fl::Channel::create(config);
@@ -363,7 +360,6 @@ FL_TEST_CASE("Channel API: Internal ChannelPtr storage prevents dangling") {
 
     auto timing = fl::makeTimingConfig<fl::TIMING_WS2812_800KHZ>();
     fl::ChannelOptions options;
-    options.mAffinity = "MOCK_STORAGE";
 
     fl::ChannelConfig config(7, timing, fl::span<CRGB>(leds, 4), GRB, options);
     auto channel = fl::Channel::create(config);
@@ -529,7 +525,6 @@ public:
 static ChannelPtr makeChannel(CRGB* leds, int n) {
     auto timing = makeTimingConfig<TIMING_WS2812_800KHZ>();
     ChannelOptions opts;
-    opts.mAffinity = "STUB_ADD_REMOVE";
     ChannelConfig config(1, timing, fl::span<CRGB>(leds, n), RGB, opts);
     return Channel::create(config);
 }
@@ -1100,7 +1095,6 @@ FL_TEST_CASE("Channel Events: onChannelAdded fires on FastLED.add()") {
     static CRGB leds[10];
     auto timing = makeTimingConfig<TIMING_WS2812_800KHZ>();
     ChannelOptions opts;
-    opts.mAffinity = "EVENT_TEST";
     ChannelConfig config(5, timing, fl::span<CRGB>(leds, 10), GRB, opts);
     auto channel = Channel::create(config);
 
@@ -1135,7 +1129,6 @@ FL_TEST_CASE("Channel Events: onChannelRemoved fires on FastLED.remove()") {
     static CRGB leds[10];
     auto timing = makeTimingConfig<TIMING_WS2812_800KHZ>();
     ChannelOptions opts;
-    opts.mAffinity = "EVENT_TEST";
     ChannelConfig config(5, timing, fl::span<CRGB>(leds, 10), GRB, opts);
     auto channel = Channel::create(config);
     FastLED.add(channel);
@@ -1202,7 +1195,6 @@ FL_TEST_CASE("Channel Events: onChannelEnqueued fires when data is enqueued to d
     fl::fill_solid(leds, 10, CRGB::Green);
     auto timing = makeTimingConfig<TIMING_WS2812_800KHZ>();
     ChannelOptions opts;
-    opts.mAffinity = "EVENT_ENQUEUE_TEST";
     ChannelConfig config(5, timing, fl::span<CRGB>(leds, 10), GRB, opts);
     auto channel = Channel::create(config);
     FastLED.add(channel);
@@ -1296,7 +1288,6 @@ FL_TEST_CASE("Channel Events: Complete lifecycle event sequence") {
         fl::fill_solid(leds1, 10, CRGB::Red);
         auto timing = makeTimingConfig<TIMING_WS2812_800KHZ>();
         ChannelOptions opts;
-        opts.mAffinity = "EVENT_LIFECYCLE_TEST";
         ChannelConfig config1(5, timing, fl::span<CRGB>(leds1, 10), GRB, opts);
         auto channel = Channel::create(config1);
         FL_CHECK(tracker.mCreatedCount == 1);
@@ -1654,8 +1645,13 @@ FL_TEST_CASE("Arduino macro undefs: Comprehensive round-trip test") {
     }
 }
 
-FL_TEST_CASE("Channel API: Affinity binds to low priority driver, empty affinity binds to high priority") {
-    // Create two mock drivers with different priorities
+FL_TEST_CASE("Channel API: Empty affinity binds to high priority driver") {
+    // Create two mock drivers with different priorities. The pre-#2459 version
+    // of this test also covered "mAffinity = LOW_PRIORITY pins to the lower-
+    // priority driver", but with `mAffinity` removed the only way to override
+    // priority dispatch is `setExclusiveDriver`, which leaves persistent state
+    // that pollutes downstream tests. The priority-dispatch half of the
+    // original test is preserved here verbatim.
     auto lowPriorityEngine = fl::make_shared<ChannelEngineMock>("LOW_PRIORITY");
     auto highPriorityEngine = fl::make_shared<ChannelEngineMock>("HIGH_PRIORITY");
     lowPriorityEngine->reset();
@@ -1672,44 +1668,14 @@ FL_TEST_CASE("Channel API: Affinity binds to low priority driver, empty affinity
     FL_REQUIRE(lowEngine != nullptr);
     FL_REQUIRE(highEngine != nullptr);
 
-    // Test 1: Channel WITH affinity="LOW_PRIORITY" should bind to low priority driver
-    {
-        static CRGB leds1[10];
-        fl::fill_solid(leds1, 10, CRGB::Red);
-
-        auto timing = fl::makeTimingConfig<fl::TIMING_WS2812_800KHZ>();
-        fl::ChannelOptions opts;
-        opts.mAffinity = "LOW_PRIORITY";  // Explicit affinity to low priority
-
-        fl::ChannelConfig config(5, timing, fl::span<CRGB>(leds1, 10), GRB, opts);
-        auto channel1 = fl::Channel::create(config);
-        FL_REQUIRE(channel1 != nullptr);
-
-        // Add to FastLED and trigger show
-        FastLED.add(channel1);
-
-        // Reset counters before show
-        lowPriorityEngine->reset();
-        highPriorityEngine->reset();
-
-        FastLED.show();
-
-        // Verify: LOW priority driver should receive data (affinity binding)
-        FL_CHECK(lowPriorityEngine->mEnqueueCount == 1);
-        FL_CHECK(highPriorityEngine->mEnqueueCount == 0);  // Should NOT receive data
-
-        // Cleanup
-        FastLED.remove(channel1);
-    }
-
-    // Test 2: Channel WITHOUT affinity should bind to high priority driver
+    // Channel WITHOUT affinity should bind to high priority driver
     {
         static CRGB leds2[10];
         fl::fill_solid(leds2, 10, CRGB::Green);
 
         auto timing = fl::makeTimingConfig<fl::TIMING_WS2812_800KHZ>();
         fl::ChannelOptions opts;
-        // No affinity set (empty string)
+        // No affinity set
 
         fl::ChannelConfig config(6, timing, fl::span<CRGB>(leds2, 10), GRB, opts);
         auto channel2 = fl::Channel::create(config);
@@ -1835,7 +1801,6 @@ FL_TEST_CASE("Channel API: removeFromDrawList() clears driver weak_ptr") {
 
     auto timing = fl::makeTimingConfig<fl::TIMING_WS2812_800KHZ>();
     fl::ChannelOptions opts;
-    opts.mAffinity = "CLEAR_TEST";  // Set affinity to bind to driver
 
     fl::ChannelConfig config(5, timing, fl::span<CRGB>(leds, 10), GRB, opts);
     auto channel = fl::Channel::create(config);
@@ -1879,7 +1844,6 @@ FL_TEST_CASE("Channel API: Late binding - driver name empty after construction")
 
         auto timing = fl::makeTimingConfig<fl::TIMING_WS2812_800KHZ>();
         fl::ChannelOptions opts;
-        opts.mAffinity = "LATE_BIND_AFFINITY";
 
         fl::ChannelConfig config(5, timing, fl::span<CRGB>(leds1, 10), GRB, opts);
         auto channel = fl::Channel::create(config);

--- a/tests/fl/channels/channel.cpp
+++ b/tests/fl/channels/channel.cpp
@@ -87,7 +87,6 @@ FL_TEST_CASE("Serpentine 2x2 with APA102 encodes pixels in expected byte order")
     SpiEncoder encoder = SpiEncoder::apa102();
     SpiChipsetConfig spiConfig{5, 6, encoder};
     ChannelOptions options;
-    options.mAffinity = "BYTE_CAPTURE_TEST";
 
     ChannelConfig config(spiConfig, fl::span<CRGB>(workspace, NUM_LEDS), RGB, options);
     auto channel = Channel::create(config);
@@ -184,7 +183,6 @@ FL_TEST_CASE("Serpentine 2x2 with WS2812 GRB encodes pixels in expected byte ord
 
     auto timing = makeTimingConfig<TIMING_WS2812_800KHZ>();
     ChannelOptions options;
-    options.mAffinity = "WS2812_BYTE_CAPTURE";
 
     ChannelConfig config(1, timing, fl::span<CRGB>(workspace, NUM_LEDS), GRB, options);
     auto channel = Channel::create(config);
@@ -273,7 +271,6 @@ FL_TEST_CASE("XMap reverse addressing with APA102 encodes pixels in reverse orde
     SpiEncoder encoder = SpiEncoder::apa102();
     SpiChipsetConfig spiConfig{5, 6, encoder};
     ChannelOptions options;
-    options.mAffinity = "XMAP_CAPTURE_TEST";
 
     ChannelConfig config(spiConfig, fl::span<CRGB>(workspace, NUM_LEDS), RGB, options);
     auto channel = Channel::create(config);
@@ -368,7 +365,13 @@ ChannelConfig makeBusTestConfig(fl::span<CRGB> leds) {
 
 }  // namespace
 
-FL_TEST_CASE("Channel::create<Bus::STUB> returns non-null on host") {
+// ============ Typed mBus runtime dispatch (#2459) ============
+// `ChannelOptions::mBus` is the typed primary path for runtime driver
+// selection. The non-template `FastLED.add(cfg)` reads it and dispatches
+// to `busName(mBus)`. `Bus::AUTO` (the default) falls through to the
+// string-affinity escape hatch / priority dispatch.
+
+FL_TEST_CASE("cfg.options.mBus = Bus::STUB binds the STUB driver on host") {
     auto& mgr = freshBusTestManager();
     FL_REQUIRE(mgr.getDriverCount() == 0);
 
@@ -377,11 +380,15 @@ FL_TEST_CASE("Channel::create<Bus::STUB> returns non-null on host") {
 
     CRGB leds[8] = {};
     ChannelConfig cfg = makeBusTestConfig(fl::span<CRGB>(leds, 8));
+    cfg.options.mBus = Bus::STUB;
 
-    auto channel = Channel::create<Bus::STUB>(cfg);
+    auto channel = Channel::create(cfg);
     FL_REQUIRE(channel != nullptr);
+    channel->addToDrawList();
+    channel->showLeds(0);
 
-    // The registered STUB driver must be the BusTraits<Bus::STUB> singleton.
+    FL_CHECK_EQ(channel->getEngineName(), fl::string::from_literal("STUB"));
+
     auto stubDriver = mgr.getDriverByName(fl::string::from_literal("STUB"));
     FL_REQUIRE(stubDriver != nullptr);
     FL_CHECK_EQ(stubDriver.get(), &BusTraits<Bus::STUB>::instance());
@@ -389,7 +396,7 @@ FL_TEST_CASE("Channel::create<Bus::STUB> returns non-null on host") {
     channel->removeFromDrawList();
 }
 
-FL_TEST_CASE("Channel::create<Bus::STUB> overwrites mAffinity and binds STUB driver") {
+FL_TEST_CASE("mBus = Bus::AUTO falls back to priority dispatch") {
     auto& mgr = freshBusTestManager();
     FL_REQUIRE(mgr.getDriverCount() == 0);
 
@@ -397,130 +404,14 @@ FL_TEST_CASE("Channel::create<Bus::STUB> overwrites mAffinity and binds STUB dri
 
     CRGB leds[8] = {};
     ChannelConfig cfg = makeBusTestConfig(fl::span<CRGB>(leds, 8));
-    // Deliberately wrong affinity — template overload must overwrite it.
-    cfg.options.mAffinity = fl::string::from_literal("WRONG");
+    // Leave mBus at default (AUTO).
 
-    auto channel = Channel::create<Bus::STUB>(cfg);
+    auto channel = Channel::create(cfg);
     FL_REQUIRE(channel != nullptr);
-
-    // Trigger a show so the channel selects and caches its driver.
+    channel->addToDrawList();
     channel->showLeds(0);
 
-    // After show the bound engine name must be "STUB", not "WRONG".
-    FL_CHECK_EQ(channel->getEngineName(), fl::string::from_literal("STUB"));
-
-    channel->removeFromDrawList();
-}
-
-FL_TEST_CASE("FastLED.add<Bus::STUB> returns non-null and adds channel to draw list") {
-    auto& mgr = freshBusTestManager();
-    FL_REQUIRE(mgr.getDriverCount() == 0);
-
-    fl::enableAllDrivers();
-
-    CRGB leds[8] = {};
-    ChannelConfig cfg = makeBusTestConfig(fl::span<CRGB>(leds, 8));
-
-    auto channel = FastLED.add<Bus::STUB>(cfg);
-    FL_REQUIRE(channel != nullptr);
-
-    // FastLED.add() must append the channel to the CLEDController draw list.
-    FL_CHECK_TRUE(channel->isInDrawList());
-
-    channel->removeFromDrawList();
-}
-
-FL_TEST_CASE("FastLED.add<Bus::STUB> driver singleton matches BusTraits<Bus::STUB>") {
-    auto& mgr = freshBusTestManager();
-    FL_REQUIRE(mgr.getDriverCount() == 0);
-
-    fl::enableAllDrivers();
-
-    CRGB leds[8] = {};
-    ChannelConfig cfg = makeBusTestConfig(fl::span<CRGB>(leds, 8));
-
-    auto channel = FastLED.add<Bus::STUB>(cfg);
-    FL_REQUIRE(channel != nullptr);
-
-    // Trigger show so the channel binds its driver.
-    channel->showLeds(0);
-
-    FL_CHECK_EQ(channel->getEngineName(), fl::string::from_literal("STUB"));
-
-    auto stubPtr = mgr.getDriverByName(fl::string::from_literal("STUB"));
-    FL_REQUIRE(stubPtr != nullptr);
-    FL_CHECK_EQ(stubPtr.get(), &BusTraits<Bus::STUB>::instance());
-
-    channel->removeFromDrawList();
-}
-
-// ============ Runtime Bus-dispatch overload (#2453) ============
-// FastLED.add(fl::Bus, cfg) — non-templated, runtime-only counterpart to
-// FastLED.add<fl::Bus B>(cfg). Bus passed by value, affinity derived via
-// fl::busName(), no ODR-use of BusTraits<B>::instancePtr(). Lets sketches
-// that called enableAllDrivers() pick the driver by enum at runtime without
-// also paying the per-bus linker keep-alive that the templated form does.
-
-FL_TEST_CASE("FastLED.add(Bus, cfg) dispatches to runtime-selected bus") {
-    auto& mgr = freshBusTestManager();
-    FL_REQUIRE(mgr.getDriverCount() == 0);
-
-    fl::enableAllDrivers();
-
-    CRGB leds[8] = {};
-    ChannelConfig cfg = makeBusTestConfig(fl::span<CRGB>(leds, 8));
-
-    // Variable Bus value — what the runtime overload exists for.
-    Bus b = Bus::STUB;
-    auto channel = FastLED.add(b, cfg);
-    FL_REQUIRE(channel != nullptr);
-    FL_CHECK_TRUE(channel->isInDrawList());
-
-    // Trigger show so the channel binds its driver.
-    channel->showLeds(0);
-    FL_CHECK_EQ(channel->getEngineName(), fl::string::from_literal("STUB"));
-
-    channel->removeFromDrawList();
-}
-
-FL_TEST_CASE("FastLED.add(Bus, cfg) overwrites prior mAffinity") {
-    auto& mgr = freshBusTestManager();
-    FL_REQUIRE(mgr.getDriverCount() == 0);
-
-    fl::enableAllDrivers();
-
-    CRGB leds[8] = {};
-    ChannelConfig cfg = makeBusTestConfig(fl::span<CRGB>(leds, 8));
-    // Deliberately wrong prior affinity — runtime overload must overwrite.
-    cfg.options.mAffinity = fl::string::from_literal("WRONG");
-
-    auto channel = FastLED.add(Bus::STUB, cfg);
-    FL_REQUIRE(channel != nullptr);
-    channel->showLeds(0);
-    FL_CHECK_EQ(channel->getEngineName(), fl::string::from_literal("STUB"));
-
-    channel->removeFromDrawList();
-}
-
-FL_TEST_CASE("FastLED.add(Bus::AUTO, cfg) clears affinity and falls back to priority") {
-    auto& mgr = freshBusTestManager();
-    FL_REQUIRE(mgr.getDriverCount() == 0);
-
-    fl::enableAllDrivers();
-
-    CRGB leds[8] = {};
-    ChannelConfig cfg = makeBusTestConfig(fl::span<CRGB>(leds, 8));
-    // Seed a non-empty affinity so we can prove AUTO clears it.
-    cfg.options.mAffinity = fl::string::from_literal("STUB");
-
-    auto channel = FastLED.add(Bus::AUTO, cfg);
-    FL_REQUIRE(channel != nullptr);
-    FL_CHECK_TRUE(channel->isInDrawList());
-    // On host the only registered drivers from enableAllDrivers() are STUB
-    // and BITBANG. Priority dispatch should land on one of them; we only
-    // assert that dispatch succeeds (driver gets bound) rather than naming
-    // which one wins the priority tie.
-    channel->showLeds(0);
+    // Priority dispatch picks a host driver — either STUB or BIT_BANG.
     auto bound = channel->getEngineName();
     FL_CHECK(bound == fl::string::from_literal("STUB") ||
              bound == fl::string::from_literal("BIT_BANG"));
@@ -529,18 +420,18 @@ FL_TEST_CASE("FastLED.add(Bus::AUTO, cfg) clears affinity and falls back to prio
 }
 
 // ============ Affinity-miss diagnostic (#2455) ============
-// When an affinity is set but the named driver isn't registered with
+// When an mBus target is set but the named driver isn't registered with
 // ChannelManager, Channel::showPixels emits exactly one FL_ERROR with the
 // fl::enableDrivers<fl::Bus::X>() / fl::enableAllDrivers() hint, then falls
 // back to priority dispatch. The mAffinityWarned flag suppresses duplicates
 // on subsequent shows of the same channel.
 
-FL_TEST_CASE("Affinity miss to unregistered known Bus falls back and still renders") {
+FL_TEST_CASE("mBus miss to unregistered known Bus falls back and still renders") {
     auto& mgr = freshBusTestManager();
     FL_REQUIRE(mgr.getDriverCount() == 0);
 
     // Register ONLY the host fallbacks (STUB + BIT_BANG via enableAllDrivers).
-    // We do not register Bus::RMT, so an affinity = "RMT" must miss.
+    // We do not register Bus::RMT, so an mBus = Bus::RMT request must miss.
     fl::enableAllDrivers();
     // Use the silent `findDriverByName` here — `getDriverByName` would emit
     // its own FL_ERROR on miss and pollute any log inspection of the actual
@@ -549,8 +440,8 @@ FL_TEST_CASE("Affinity miss to unregistered known Bus falls back and still rende
 
     CRGB leds[8] = {};
     ChannelConfig cfg = makeBusTestConfig(fl::span<CRGB>(leds, 8));
-    // Forge a runtime affinity for a Bus whose driver is NOT registered.
-    cfg.options.mAffinity = fl::string::from_literal("RMT");
+    // Target a typed Bus whose driver is NOT registered on this host.
+    cfg.options.mBus = fl::Bus::RMT;
 
     auto channel = Channel::create(cfg);
     FL_REQUIRE(channel != nullptr);
@@ -574,31 +465,6 @@ FL_TEST_CASE("Affinity miss to unregistered known Bus falls back and still rende
     // Driver binding is unchanged.
     channel->showLeds(0);
     FL_CHECK(channel->getEngineName() == bound);
-
-    channel->removeFromDrawList();
-}
-
-FL_TEST_CASE("Affinity miss to unknown third-party name still falls back") {
-    auto& mgr = freshBusTestManager();
-    FL_REQUIRE(mgr.getDriverCount() == 0);
-
-    fl::enableAllDrivers();
-
-    CRGB leds[8] = {};
-    ChannelConfig cfg = makeBusTestConfig(fl::span<CRGB>(leds, 8));
-    // Use a name that is NOT one of the canonical Bus names. The diagnostic
-    // should fire but use the generic "no registered driver" message branch
-    // (no fl::Bus::WAT hint).
-    cfg.options.mAffinity = fl::string::from_literal("WAT");
-
-    auto channel = Channel::create(cfg);
-    FL_REQUIRE(channel != nullptr);
-    channel->addToDrawList();
-
-    channel->showLeds(0);
-    auto bound = channel->getEngineName();
-    FL_CHECK(bound == fl::string::from_literal("STUB") ||
-             bound == fl::string::from_literal("BIT_BANG"));
 
     channel->removeFromDrawList();
 }

--- a/tests/fl/channels/channel_typed.cpp
+++ b/tests/fl/channels/channel_typed.cpp
@@ -101,7 +101,7 @@ FL_TEST_CASE("Phase 3b: TypedChannel<Bus::AUTO, ClocklessChipset>::create resolv
     FL_CHECK(channel->isClockless());
 }
 
-FL_TEST_CASE("Phase 3b: FastLED.add<Bus::STUB>(clockless_cfg) compiles and binds channel") {
+FL_TEST_CASE("#2459: TypedChannel<Bus::STUB, ClocklessChipset>::create binds the STUB driver") {
     CRGB workspace[3];
     auto timing = fl::makeTimingConfig<fl::TIMING_WS2812_800KHZ>();
     fl::ChannelConfigOf<fl::ClocklessChipset> cfg{
@@ -109,25 +109,27 @@ FL_TEST_CASE("Phase 3b: FastLED.add<Bus::STUB>(clockless_cfg) compiles and binds
         fl::span<CRGB>(workspace, 3),
         RGB};
 
-    auto channel = FastLED.add<fl::Bus::STUB>(cfg);
+    // Compile-time path: TypedChannel is the single template entry point.
+    auto channel = fl::TypedChannel<fl::Bus::STUB, fl::ClocklessChipset>::create(cfg);
     FL_REQUIRE(channel != nullptr);
     FL_CHECK(channel->isClockless());
     FL_CHECK(channel->getPin() == 8);
 
-    // Cleanup
     channel->removeFromDrawList();
 }
 
-FL_TEST_CASE("Phase 3b: FastLED.add(cfg) defaults to Bus::AUTO on the host (STUB)") {
+FL_TEST_CASE("#2459: runtime FastLED.add(cfg) with cfg.options.mBus = Bus::STUB") {
     CRGB workspace[5];
     auto timing = fl::makeTimingConfig<fl::TIMING_WS2812_800KHZ>();
-    fl::ChannelConfigOf<fl::ClocklessChipset> cfg{
+    fl::ChannelConfigOf<fl::ClocklessChipset> typed_cfg{
         fl::ClocklessChipset(2, timing),
         fl::span<CRGB>(workspace, 5),
         RGB};
 
-    // No explicit Bus -- AUTO resolves to DefaultBus<ClocklessChipset> == Bus::STUB.
-    auto channel = FastLED.add(cfg);
+    // Runtime path: erase, set mBus, dispatch via non-template FastLED.add.
+    fl::ChannelConfig erased = typed_cfg.toErased();
+    erased.options.mBus = fl::Bus::STUB;
+    auto channel = FastLED.add(erased);
     FL_REQUIRE(channel != nullptr);
     FL_CHECK(channel->isClockless());
     FL_CHECK(channel->getPin() == 2);

--- a/tests/fl/channels/driver.cpp
+++ b/tests/fl/channels/driver.cpp
@@ -102,9 +102,7 @@ FL_TEST_CASE("Channel basic operations") {
     CRGB leds[10];
     auto timing = makeTimingConfig<TIMING_WS2812_800KHZ>();
     ChannelOptions options;
-    options.mAffinity = "MOCK_1";  // Match driver name
 
-    // Use affinity to bind to mock driver
     ChannelConfig config(1, timing, fl::span<CRGB>(leds, 10), RGB, options);
     auto channel = Channel::create(config);
 
@@ -128,7 +126,6 @@ FL_TEST_CASE("Channel transmission") {
 
     auto timing = makeTimingConfig<TIMING_WS2812_800KHZ>();
     ChannelOptions options;
-    options.mAffinity = "MOCK_TX";
     ChannelConfig config(1, timing, fl::span<CRGB>(leds, 5), RGB, options);
     auto channel = Channel::create(config);
 
@@ -154,7 +151,6 @@ FL_TEST_CASE("CLEDController direct showLeds flushes channel drivers") {
 
     auto timing = makeTimingConfig<TIMING_WS2812_800KHZ>();
     ChannelOptions options;
-    options.mAffinity = "MOCK_DIRECT_CTL";
     ChannelConfig config(2, timing, fl::span<CRGB>(leds, 5), RGB, options);
     auto channel = Channel::create(config);
 
@@ -180,7 +176,6 @@ FL_TEST_CASE("CLEDController clearLeds flushes cleared channel data") {
 
     auto timing = makeTimingConfig<TIMING_WS2812_800KHZ>();
     ChannelOptions options;
-    options.mAffinity = "MOCK_DIRECT_CLEAR";
     ChannelConfig config(3, timing, fl::span<CRGB>(leds, 5), RGB, options);
     auto channel = Channel::create(config);
 
@@ -209,7 +204,6 @@ FL_TEST_CASE("FastLED.show() with channels") {
 
     auto timing = makeTimingConfig<TIMING_WS2812_800KHZ>();
     ChannelOptions options;
-    options.mAffinity = "MOCK_FASTLED";
     ChannelConfig config(1, timing, fl::span<CRGB>(leds, 5), RGB, options);
     auto channel = Channel::create(config);
 
@@ -248,7 +242,6 @@ FL_TEST_CASE("Channel Engine: 8 channels → exactly 8 enqueues (no accumulation
         fl::fill_solid(leds[i], NUM_LEDS, CRGB::Red);
 
         ChannelOptions opts;
-        opts.mAffinity = "ENQUEUE_TEST_1";
         ChannelConfig config(
             static_cast<int>(i + 1),  // Pin 1-8
             timing,
@@ -302,7 +295,6 @@ FL_TEST_CASE("Channel Engine: Multiple show() calls don't accumulate channels") 
         fl::fill_solid(leds[i], NUM_LEDS, CRGB::Blue);
 
         ChannelOptions opts;
-        opts.mAffinity = "ENQUEUE_TEST_2";
         ChannelConfig config(
             static_cast<int>(i + 10),  // Pin 10-13
             timing,
@@ -359,7 +351,6 @@ FL_TEST_CASE("Channel Engine: Adding/removing channels updates enqueue count cor
 
     auto timing = makeTimingConfig<TIMING_WS2812_800KHZ>();
     ChannelOptions opts;
-    opts.mAffinity = "ENQUEUE_TEST_3";
 
     // Start with 2 channels
     ChannelConfig config1(20, timing, fl::span<CRGB>(leds1, NUM_LEDS), GRB, opts);
@@ -411,7 +402,6 @@ FL_TEST_CASE("Channel Engine: ChannelData isInUse flag managed correctly") {
 
     auto timing = makeTimingConfig<TIMING_WS2812_800KHZ>();
     ChannelOptions opts;
-    opts.mAffinity = "ENQUEUE_TEST_4";
     ChannelConfig config(30, timing, fl::span<CRGB>(leds, NUM_LEDS), RGB, opts);
     auto channel = Channel::create(config);
 
@@ -447,7 +437,6 @@ FL_TEST_CASE("Channel Events: onChannelDataEncoded fires after encoding") {
 
     auto timing = makeTimingConfig<TIMING_WS2812_800KHZ>();
     ChannelOptions opts;
-    opts.mAffinity = "EVENT_ENCODED_TEST";
 
     ChannelConfig config(5, timing, fl::span<CRGB>(leds, NUM_LEDS), GRB, opts);
     auto channel = Channel::create(config);
@@ -498,7 +487,6 @@ FL_TEST_CASE("Channel: Guard against double-encoding within single FastLED.show(
 
     auto timing = makeTimingConfig<TIMING_WS2812_800KHZ>();
     ChannelOptions opts;
-    opts.mAffinity = "DOUBLE_ENCODE_TEST";
 
     ChannelConfig config(5, timing, fl::span<CRGB>(leds, NUM_LEDS), GRB, opts);
     auto channel = Channel::create(config);

--- a/tests/fl/channels/spi_channel.cpp
+++ b/tests/fl/channels/spi_channel.cpp
@@ -271,7 +271,6 @@ FL_TEST_CASE("SPI chipset - mock driver integration") {
     SpiChipsetConfig spiConfig{5, 6, encoder};  // DATA_PIN=5, CLOCK_PIN=6
 
     ChannelOptions options;
-    options.mAffinity = "MOCK_SPI";
     ChannelConfig config(spiConfig, fl::span<CRGB>(leds, NUM_LEDS), RGB, options);
 
     auto channel = Channel::create(config);
@@ -324,7 +323,6 @@ FL_TEST_CASE("SPI chipset - APA102HD mock driver integration") {
     SpiChipsetConfig spiConfig{5, 6, encoder};
 
     ChannelOptions options;
-    options.mAffinity = "MOCK_SPI_HD";
     ChannelConfig config(spiConfig, fl::span<CRGB>(leds, NUM_LEDS), RGB, options);
 
     // Verify it's configured as APA102HD


### PR DESCRIPTION
## Summary

Closes #2459. Collapses the Channel API's compile-time selection layer to one template entry point and one runtime entry point, per the SSOT direction from the design discussion.

**Before** (three templates + a runtime overload + a string field):
- \`Channel::create<Bus B>(cfg)\` (templated, #2451)
- \`FastLED.add<Bus B>(cfg)\` (templated, #2451)
- \`FastLED.add<B = AUTO, Chipset>(ChannelConfigOf<Chipset>)\` (templated, #2449)
- \`FastLED.add(Bus, cfg)\` (runtime, #2454)
- \`ChannelOptions::mAffinity\` (\`fl::string\`)

**After** (one of each):
- \`fl::TypedChannel<B, Chipset>::create(cfg)\` — the single template entry point (already existed; kept).
- \`FastLED.add(cfg)\` — the single runtime entry point. Non-template. Reads \`cfg.options.mBus\`.
- \`ChannelOptions::mBus\` (\`fl::Bus\` enum) — typed, the only affinity field.

## Behaviour changes

### Non-template \`FastLED.add(cfg)\`

- Auto-enrolls every driver on the platform via \`fl::enableAllDrivers()\` so any runtime \`cfg.options.mBus\` value can be dispatched.
- Emits one-shot \`FL_WARN_ONCE\` explaining the binary-size trade-off:

  > FastLED.add(cfg): runtime-selection mode — enrolling every available driver via fl::enableAllDrivers(). For minimum binary size, prefer FastLED.addLeds<CHIPSET, PIN, ORDER, fl::Bus::X>(leds, n) which links only the named driver. Suppress this warning with -DFASTLED_SUPPRESS_RUNTIME_DRIVER_WARNING.

- Suppress macro: \`-DFASTLED_SUPPRESS_RUNTIME_DRIVER_WARNING\`.

### Typed \`mBus\` dispatch

- \`cfg.options.mBus = fl::Bus::RMT\` pins the channel to the RMT driver. The dispatch path calls \`ChannelManager::findDriverByName(busName(mBus))\`.
- \`cfg.options.mBus = fl::Bus::AUTO\` (default) falls through to \`ChannelManager\` priority dispatch.
- On miss, one-shot \`FL_ERROR\` lists the two currently-shipping remediations: \`fl::enableDrivers<fl::Bus::X>()\` or \`FastLED.enableAllDrivers()\`. The third remediation (\`addLeds<..., fl::Bus::X>\`) is deferred to #2460.

### Removed APIs

- \`Channel::create<Bus B>(ChannelConfig)\` (template) — superseded by \`TypedChannel<B, Chipset>::create()\`.
- \`FastLED.add<Bus B>(ChannelConfig)\` (template) — superseded by \`FastLED.add(cfg)\` with \`mBus = B\`.
- \`FastLED.add<B = AUTO, Chipset>(ChannelConfigOf<Chipset>)\` (template) — superseded by \`TypedChannel<B, Chipset>::create()\`.
- \`FastLED.add(Bus, ChannelConfig)\` (runtime) — superseded by \`FastLED.add(cfg)\` with \`mBus = B\`.
- \`ChannelOptions::mAffinity\` (string field) — superseded by \`mBus\`.
- \`fl::isKnownBusName(string)\` (predicate) — no longer needed; dispatch only sees typed-Bus misses now.

## Custom / mock driver binding

The pre-PR pattern was \`opts.mAffinity = \"MOCK\"; FastLED.add(cfg)\`. With no string field, custom drivers bind by:

1. **Priority dispatch** — \`mgr.clearAllDrivers(); mgr.addDriver(prio, mock); FastLED.add(cfg)\` — the mock is the only candidate, priority dispatch picks it.
2. **\`setExclusiveDriver\`** — when multiple competing drivers are registered, \`mgr.setExclusiveDriver(\"MOCK\")\` disables all others.

## Tests

- 11 \`fastled_core\` test cases + 14 channel/driver test cases had \`mAffinity = \"...\"\` lines deleted.
- Two \`channel.cpp\` tests that explicitly verified the \`mAffinity\`/\`mBus\` precedence behaviour were deleted (no precedence anymore).
- Two more were rewritten to use \`mBus\` only.
- One \`fastled_core\` low-priority-binding test lost half its coverage; documented as a gap that a future \`clearExclusiveDriver()\` addition can restore.
- \`examples/AutoResearch/AutoResearchRemote.cpp\` converted its string driver-name lookup to an inline \`fl::Bus\` mapping.

## Diff stats

\`\`\`
13 files changed, 189 insertions(+), 501 deletions(-)
\`\`\`

Net **-312 lines** — the simplification is real.

## Test plan

- [x] \`bash test --cpp\` — 304/304 pass.
- [x] \`bash lint --cpp\` — clean.
- [ ] CI matrix to validate hardware platform builds.

## Related

- #2428 — parent meta-issue (Phase 4 \`mAffinity\` removal was always planned here).
- #2459 — design issue this PR closes.
- #2460 — follow-up: \`addLeds<..., fl::Bus B>\` trailing template parameter.
- #2451 — superseded (templates removed here).
- #2454 — superseded (runtime overload removed here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved channel driver selection with typed bus identification instead of string-based matching.
  * Added one-time warning when using runtime driver selection.

* **API Changes**
  * Removed compile-time bus selection template overloads from Channel API.
  * Updated channel configuration to use typed bus selection field.

* **Documentation**
  * Updated Channels API documentation to reflect typed bus selection model and driver dispatch behavior.

* **Tests**
  * Updated test suite to align with new typed bus selection approach.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/FastLED/pull/2461)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->