### PR TITLE
docs(channels): post-#2461 README accuracy sweep

### DIFF
--- a/src/fl/channels/README.md
+++ b/src/fl/channels/README.md
@@ -195,7 +195,7 @@ void setup() {
 
 If `cfg.options.mBus` names a driver that — for whatever reason — isn't in the manager's registry, `Channel::showPixels` emits a one-shot `FL_ERROR` listing the resolution options (`fl::enableDrivers<fl::Bus::X>()` or `FastLED.enableAllDrivers()`) and falls back to AUTO/priority dispatch (#2455).
 
-Passing `fl::Bus::AUTO` clears the affinity and lets `ChannelManager` pick by priority - identical to the no-affinity `FastLED.add(cfg)` overload.
+Passing `fl::Bus::AUTO` (the default) skips the pinning step and lets `ChannelManager` pick by priority — identical to constructing the config without touching `cfg.options.mBus`.
 
 ### Opt-In Driver Registration (`enableDrivers<>` / `enableAllDrivers`)
 
@@ -856,11 +856,11 @@ void setupCustomEngine() {
 - Priority values are just integers - no predefined ranges required
 
 **Engine selection (`ChannelManager::selectDriverForChannel`):**
-1. If `affinity` is non-empty, manager does a silent `findDriverByName(affinity)` lookup first.
+1. `Channel::showPixels()` derives a bus key from `cfg.options.mBus` (`busName(mBus)`) and passes it as the `affinity` string argument to `selectDriverForChannel`. When `mBus != Bus::AUTO`, the manager does a silent `findDriverByName(busKey)` lookup first.
    - On hit: that driver is returned (no priority iteration).
-   - On miss: `Channel::showPixels()` emits a one-shot `FL_ERROR` (see "Affinity-miss diagnostic" above) and falls through to priority dispatch.
-2. Otherwise (or on affinity miss): manager iterates drivers by priority (high to low) and returns the first that `canHandle()`s the channel data.
-3. User can override via `ChannelOptions.mBus` (#2459), `fl::TypedChannel<Bus, Chipset>::create()` (compile-time, ODR-links the driver), or `FastLED.setExclusiveDriver()` (process-wide).
+   - On miss: `Channel::showPixels()` emits a one-shot `FL_ERROR` (see "Bus-miss diagnostic" above) and falls through to priority dispatch.
+2. Otherwise (`mBus == Bus::AUTO` or bus-miss fallback): manager iterates drivers by priority (high to low) and returns the first that `canHandle()`s the channel data.
+3. User can override via `ChannelOptions::mBus` (#2459, runtime), `fl::TypedChannel<Bus, Chipset>::create()` (compile-time, ODR-links only the named driver), or `FastLED.setExclusiveDriver()` (process-wide).
 
 **Priority modification:**
 - Engines are sorted by priority on registration (via `addDriver()`)
@@ -973,11 +973,11 @@ See `tests/fl/channels/driver.cpp` for more test examples.
 ## Reference
 
 **Headers:**
-- `fl/channels/channel.h` - `Channel` class, non-template `create(cfg)` and templated `create<Bus B>(cfg)` factories
+- `fl/channels/channel.h` - `Channel` class, non-template `create(cfg)` factory (the only `Channel::create` form post-#2459; compile-time bus pinning lives on `TypedChannel`)
 - `fl/channels/channel_typed.h` - `TypedChannel<Bus, Chipset>` (Phase 3b compile-time bus/chipset enforcement)
 - `fl/channels/ichannel.h` - `IChannel` ABC (callback-facing identification base)
 - `fl/channels/config.h` - `ChannelConfig`, `ChannelConfigOf<Chipset>`, `ClocklessChipset`, `SpiChipsetConfig`
-- `fl/channels/options.h` - `ChannelOptions` (correction, temperature, dither, affinity, gamma)
+- `fl/channels/options.h` - `ChannelOptions` (correction, temperature, dither, rgbw, `mBus` driver selection, gamma)
 - `fl/channels/bus.h` - `fl::Bus` enum, `busName()`, `DefaultBus<Chipset>`, `FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY`
 - `fl/channels/bus_traits.h` - `BusTraits<B>`, `BusSupports<B, Chipset>`, `enableDrivers<Bus...>()`
 - `fl/channels/all_drivers.h` - `fl::enableAllDrivers()` / `FastLED.enableAllDrivers()` aggregator


### PR DESCRIPTION
## Summary

After #2461 landed (non-template \`FastLED.add()\` + typed \`mBus\` + \`mAffinity\` removal), I had a sub-agent audit the channels README for any spots that still described the old API shape.

The README was mostly already accurate (because the in-flight #2461 edits caught the main cases), but four small leftovers remained:

1. \"Passing \`fl::Bus::AUTO\` **clears the affinity**\" → reworded to \"**skips the pinning step**\" — matches the now-typed \`mBus\` field, not the deleted \`mAffinity\` string.
2. **Engine selection** dispatch-flow bullet list — rewrote to show that \`Channel::showPixels()\` derives the bus key from \`cfg.options.mBus\` via \`busName(mBus)\` before passing it to \`selectDriverForChannel\`. Fixed the \"Affinity-miss diagnostic\" cross-reference to match the actual section title \"Bus-miss diagnostic\".
3. **Reference → \`channel.h\`** — dropped the false \"non-template \`create(cfg)\` **and templated \`create<Bus B>(cfg)\` factories**\" claim. Only the non-template form survives post-#2461; compile-time bus pinning lives on \`TypedChannel\`.
4. **Reference → \`options.h\`** — replaced \"affinity\" with \"\`mBus\` driver selection\" and added \"rgbw\" to the field summary.

## Verified clean (no fixes needed)

The sub-agent's grep confirmed zero remaining stale references in the README:
- No \`FastLED.add<Bus::X>(cfg)\`, \`FastLED.add(Bus::X, cfg)\`, or \`Channel::create<Bus::X>(cfg)\` examples.
- No \`mAffinity\` or \`isKnownBusName()\` mentions.
- The compile-time vs runtime mode narrative (lines 22-25) accurately describes both paths.
- \`FastLED.add(cfg)\` description correctly notes the auto-\`enableAllDrivers()\` + \`FL_WARN_ONCE\` behaviour with \`FASTLED_SUPPRESS_RUNTIME_DRIVER_WARNING\`.
- Engine Affinity example uses \`opts.mBus = fl::Bus::RMT\` / \`fl::Bus::SPI\`.
- Custom/mock driver section correctly directs users to \`manager.addDriver(...)\` + \`clearAllDrivers()\` / \`setExclusiveDriver(name)\`.
- The \"planned\" callout for \`addLeds<..., fl::Bus B>\` (#2460) is appropriately framed.

## Test plan

- [x] \`bash lint --cpp\` — clean.
- [x] No code changes; only \`src/fl/channels/README.md\` (+7 / −7).

## Files changed (1)

- \`src/fl/channels/README.md\`

## Related

- #2459 / #2461 — the API simplification this PR documents.
- #2428 — parent meta-issue.
- #2460 — follow-up \`addLeds<..., fl::Bus B>\` (referenced in the README as planned).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated channel driver selection documentation to clarify runtime behavior and selection priorities.
  * Refined documentation describing the engine selection flow.
  * Corrected API reference documentation for channel factory methods.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/FastLED/pull/2462)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->