### PR TITLE
fix(teensy4): empty FL_PROGMEM in null_progmem.h fallback (closes #2436 regression)

### DIFF
--- a/src/platforms/null_progmem.h
+++ b/src/platforms/null_progmem.h
@@ -11,8 +11,20 @@
 #endif
 
 #if !defined(FL_PROGMEM)
+// Teensy 4.x (`__IMXRT1062__`) workaround: Teensy core defines `PROGMEM` as
+// `__attribute__((section(".progmem")))`, which causes GCC to emit "section
+// type conflict" errors when a single translation unit contains FL_PROGMEM
+// variables of different types (e.g. `CRGB`, `i32`, `float`) — see the
+// fl.fx+ unity build that aggregates `colorpalettes.h`, `sin32.h`, and
+// `mic_response_data.h`. Teensy 4 has a unified linear address space and
+// places `const` data in `.rodata` (flash) automatically via the linker
+// script, so the section attribute is unnecessary on this platform.
+// Mirrors the same special case in `fastled_progmem.h` so it applies
+// regardless of which inclusion path defines FL_PROGMEM first.
+#if defined(__IMXRT1062__)
+#define FL_PROGMEM
 // Ensure PROGMEM is available before using it
-#if defined(PROGMEM)
+#elif defined(PROGMEM)
 #define FL_PROGMEM PROGMEM
 #if defined(FL_IS_AVR)
 // IWYU pragma: begin_keep


### PR DESCRIPTION
## Summary

- `teensy41` builds were failing again at HEAD with the same `'RainbowColors_p' causes a section type conflict with 'fl::sinCosPairedLut'` GCC error that PR #2436 (commit 19a01a37d4) had supposedly fixed.
- Root cause: the previous fix only patched the `FASTLED_USE_PROGMEM == 1` branch of `src/fastled_progmem.h`. When that branch isn't reached (e.g. when `fastled_progmem.h` is first included before `led_sysdefs_arm_mxrt1062.h` sets `FASTLED_USE_PROGMEM`), the header falls back to `platforms/null_progmem.h`, which unconditionally set `#define FL_PROGMEM PROGMEM`. On Teensy 4, Teensy core's `PROGMEM` is `__attribute__((section(".progmem")))`, which re-introduces the section-type conflict in the `fl.fx+` unity build.
- Fix: mirror the Teensy 4 special case from `fastled_progmem.h` into `null_progmem.h` so `FL_PROGMEM` is empty on `__IMXRT1062__` regardless of which inclusion path defines it first.

## Reproducer (master)

```
$ bash compile teensy41 --examples Blink
...
colorpalettes.h:23:35: error: 'RainbowColors_p' causes a section
                              type conflict with 'fl::sinCosPairedLut'
```

## Test plan

- [x] `bash compile teensy41 --examples Blink` — section-type conflict is gone, all 600+ TUs compile cleanly. (A separate Windows-only linker cmdline length issue surfaces during link — filed as FastLED/fbuild#234; unrelated to this PROGMEM fix and harmless to Linux CI.)
- [x] `bash lint` — clean
- [x] `bash test --cpp` — exit 0 (host build unaffected by this change)
- [ ] CI teensy41 build — final end-to-end verification (runs on Ubuntu, no cmdline-length issue there)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved compilation errors on Teensy 4.x boards caused by type conflicts in memory variable definitions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/FastLED/pull/2463)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->