### PR TITLE
feat(channels): addLeds<..., fl::Bus B> trailing parameter (closes #2460)

### DIFF
--- a/src/FastLED.h
+++ b/src/FastLED.h
@@ -970,37 +970,39 @@ public:
 	/// Stubbed out platforms have unique challenges in faking out the SPI based controllers.
 	/// Therefore for these platforms we will always delegate to the WS2812 clockless controller.
 	/// This is fine because the clockless controllers on the stubbed out platforms are fake anyways.
-	template<ESPIChipsets CHIPSET, fl::u8 DATA_PIN, fl::u8 CLOCK_PIN, fl::EOrder RGB_ORDER, fl::u32 SPI_DATA_RATE > ::CLEDController &addLeds(CRGB *data, int nLedsOrOffset, int nLedsIfOffset = 0) {
+	template<ESPIChipsets CHIPSET, fl::u8 DATA_PIN, fl::u8 CLOCK_PIN, fl::EOrder RGB_ORDER, fl::u32 SPI_DATA_RATE, fl::Bus B = fl::Bus::AUTO> ::CLEDController &addLeds(CRGB *data, int nLedsOrOffset, int nLedsIfOffset = 0) {
 		// Instantiate the controller using ClockedChipsetHelper
 		// Always USE WS2812 clockless controller since it's the common path.
-		return addLeds<WS2812, DATA_PIN, RGB_ORDER>(data, nLedsOrOffset, nLedsIfOffset);
+		return addLeds<WS2812, DATA_PIN, RGB_ORDER, B>(data, nLedsOrOffset, nLedsIfOffset);
 	}
 
 	/// Add an SPI based CLEDController instance to the world.
-	template<ESPIChipsets CHIPSET, fl::u8 DATA_PIN, fl::u8 CLOCK_PIN > static ::CLEDController &addLeds(CRGB *data, int nLedsOrOffset, int nLedsIfOffset = 0) {
+	template<ESPIChipsets CHIPSET, fl::u8 DATA_PIN, fl::u8 CLOCK_PIN, fl::Bus B = fl::Bus::AUTO> static ::CLEDController &addLeds(CRGB *data, int nLedsOrOffset, int nLedsIfOffset = 0) {
 		// Always USE WS2812 clockless controller since it's the common path.
-		return addLeds<WS2812, DATA_PIN>(data, nLedsOrOffset, nLedsIfOffset);
+		return addLeds<WS2812, DATA_PIN, B>(data, nLedsOrOffset, nLedsIfOffset);
 	}
 
 
 	// The addLeds function using ChipsetHelper
-	template<ESPIChipsets CHIPSET, fl::u8 DATA_PIN, fl::u8 CLOCK_PIN, fl::EOrder RGB_ORDER>
+	template<ESPIChipsets CHIPSET, fl::u8 DATA_PIN, fl::u8 CLOCK_PIN, fl::EOrder RGB_ORDER, fl::Bus B = fl::Bus::AUTO>
 	::CLEDController& addLeds(CRGB* data, int nLedsOrOffset, int nLedsIfOffset = 0) {
 		// Always USE WS2812 clockless controller since it's the common path.
-		return addLeds<WS2812, DATA_PIN, RGB_ORDER>(data, nLedsOrOffset, nLedsIfOffset);
+		return addLeds<WS2812, DATA_PIN, RGB_ORDER, B>(data, nLedsOrOffset, nLedsIfOffset);
 	}
 
 	#elif FASTLED_SPI_USES_CHANNEL_API
 
 	/// Add an SPI based CLEDController via Channel API.
-	template<ESPIChipsets CHIPSET, fl::u8 DATA_PIN, fl::u8 CLOCK_PIN, fl::EOrder RGB_ORDER, fl::u32 SPI_DATA_RATE>
+	template<ESPIChipsets CHIPSET, fl::u8 DATA_PIN, fl::u8 CLOCK_PIN, fl::EOrder RGB_ORDER, fl::u32 SPI_DATA_RATE, fl::Bus B = fl::Bus::AUTO>
 	::CLEDController &addLeds(CRGB *data, int nLedsOrOffset, int nLedsIfOffset = 0) {
+		fl::busKeepAlive<B>();
 		int nOffset = (nLedsIfOffset > 0) ? nLedsOrOffset : 0;
 		int nLeds = (nLedsIfOffset > 0) ? nLedsIfOffset : nLedsOrOffset;
 		fl::SpiEncoder encoder = fl::SpiEncoder::spiEncoderForChipset(
 			static_cast<fl::SpiChipset>(CHIPSET), SPI_DATA_RATE);
 		fl::SpiChipsetConfig spiCfg(DATA_PIN, CLOCK_PIN, encoder);
 		fl::ChannelConfig config(spiCfg, fl::span<CRGB>(data + nOffset, nLeds), RGB_ORDER);
+		config.options.mBus = B;
 		static fl::ChannelPtr sChannel;
 		if (!sChannel) {
 			sChannel = add(config);
@@ -1009,8 +1011,9 @@ public:
 	}
 
 	/// Add an SPI based CLEDController via Channel API (default RGB order and speed).
-	template<ESPIChipsets CHIPSET, fl::u8 DATA_PIN, fl::u8 CLOCK_PIN>
+	template<ESPIChipsets CHIPSET, fl::u8 DATA_PIN, fl::u8 CLOCK_PIN, fl::Bus B = fl::Bus::AUTO>
 	static ::CLEDController &addLeds(CRGB *data, int nLedsOrOffset, int nLedsIfOffset = 0) {
+		fl::busKeepAlive<B>();
 		int nOffset = (nLedsIfOffset > 0) ? nLedsOrOffset : 0;
 		int nLeds = (nLedsIfOffset > 0) ? nLedsIfOffset : nLedsOrOffset;
 		fl::SpiEncoder encoder = fl::SpiEncoder::spiEncoderForChipset(
@@ -1021,6 +1024,7 @@ public:
 			(static_cast<fl::SpiChipset>(CHIPSET) == fl::SpiChipset::HD108)
 				? GRB : RGB;
 		fl::ChannelConfig config(spiCfg, fl::span<CRGB>(data + nOffset, nLeds), order);
+		config.options.mBus = B;
 		static fl::ChannelPtr sChannel;
 		if (!sChannel) {
 			sChannel = add(config);
@@ -1029,14 +1033,16 @@ public:
 	}
 
 	/// Add an SPI based CLEDController via Channel API (default speed).
-	template<ESPIChipsets CHIPSET, fl::u8 DATA_PIN, fl::u8 CLOCK_PIN, fl::EOrder RGB_ORDER>
+	template<ESPIChipsets CHIPSET, fl::u8 DATA_PIN, fl::u8 CLOCK_PIN, fl::EOrder RGB_ORDER, fl::Bus B = fl::Bus::AUTO>
 	::CLEDController& addLeds(CRGB* data, int nLedsOrOffset, int nLedsIfOffset = 0) {
+		fl::busKeepAlive<B>();
 		int nOffset = (nLedsIfOffset > 0) ? nLedsOrOffset : 0;
 		int nLeds = (nLedsIfOffset > 0) ? nLedsIfOffset : nLedsOrOffset;
 		fl::SpiEncoder encoder = fl::SpiEncoder::spiEncoderForChipset(
 			static_cast<fl::SpiChipset>(CHIPSET));
 		fl::SpiChipsetConfig spiCfg(DATA_PIN, CLOCK_PIN, encoder);
 		fl::ChannelConfig config(spiCfg, fl::span<CRGB>(data + nOffset, nLeds), RGB_ORDER);
+		config.options.mBus = B;
 		static fl::ChannelPtr sChannel;
 		if (!sChannel) {
 			sChannel = add(config);
@@ -1047,7 +1053,8 @@ public:
 	#else
 
 	/// Add an SPI based CLEDController instance to the world (legacy path).
-	template<ESPIChipsets CHIPSET, fl::u8 DATA_PIN, fl::u8 CLOCK_PIN, fl::EOrder RGB_ORDER, fl::u32 SPI_DATA_RATE > ::CLEDController &addLeds(CRGB *data, int nLedsOrOffset, int nLedsIfOffset = 0) {
+	template<ESPIChipsets CHIPSET, fl::u8 DATA_PIN, fl::u8 CLOCK_PIN, fl::EOrder RGB_ORDER, fl::u32 SPI_DATA_RATE, fl::Bus B = fl::Bus::AUTO> ::CLEDController &addLeds(CRGB *data, int nLedsOrOffset, int nLedsIfOffset = 0) {
+		fl::busKeepAlive<B>();
 		// Instantiate the controller using ClockedChipsetHelper
 		typedef ClockedChipsetHelper<CHIPSET, DATA_PIN, CLOCK_PIN> CHIP;
 		FL_STATIC_ASSERT(CHIP::IS_VALID, "Unsupported chipset");
@@ -1057,7 +1064,8 @@ public:
 	}
 
 	/// Add an SPI based CLEDController instance to the world (legacy path).
-	template<ESPIChipsets CHIPSET, fl::u8 DATA_PIN, fl::u8 CLOCK_PIN > static ::CLEDController &addLeds(CRGB *data, int nLedsOrOffset, int nLedsIfOffset = 0) {
+	template<ESPIChipsets CHIPSET, fl::u8 DATA_PIN, fl::u8 CLOCK_PIN, fl::Bus B = fl::Bus::AUTO> static ::CLEDController &addLeds(CRGB *data, int nLedsOrOffset, int nLedsIfOffset = 0) {
+		fl::busKeepAlive<B>();
 		typedef ClockedChipsetHelper<CHIPSET, DATA_PIN, CLOCK_PIN> CHIP;
 		FL_STATIC_ASSERT(CHIP::IS_VALID, "Unsupported chipset");
 		typedef typename CHIP::ControllerType ControllerType;
@@ -1066,8 +1074,9 @@ public:
 	}
 
 	/// Add an SPI based CLEDController instance to the world (legacy path).
-	template<ESPIChipsets CHIPSET, fl::u8 DATA_PIN, fl::u8 CLOCK_PIN, fl::EOrder RGB_ORDER>
+	template<ESPIChipsets CHIPSET, fl::u8 DATA_PIN, fl::u8 CLOCK_PIN, fl::EOrder RGB_ORDER, fl::Bus B = fl::Bus::AUTO>
 	::CLEDController& addLeds(CRGB* data, int nLedsOrOffset, int nLedsIfOffset = 0) {
+		fl::busKeepAlive<B>();
 		typedef ClockedChipsetHelper<CHIPSET, DATA_PIN, CLOCK_PIN> CHIP;
 		FL_STATIC_ASSERT(CHIP::IS_VALID, "Unsupported chipset");
 		typedef typename CHIP::template CONTROLLER_CLASS_WITH_ORDER<RGB_ORDER>::ControllerType ControllerTypeWithOrder;
@@ -1078,16 +1087,16 @@ public:
 
 
 #ifdef SPI_DATA
-	template<ESPIChipsets CHIPSET> static ::CLEDController &addLeds(CRGB *data, int nLedsOrOffset, int nLedsIfOffset = 0) {
-		return addLeds<CHIPSET, SPI_DATA, SPI_CLOCK, RGB>(data, nLedsOrOffset, nLedsIfOffset);
+	template<ESPIChipsets CHIPSET, fl::Bus B = fl::Bus::AUTO> static ::CLEDController &addLeds(CRGB *data, int nLedsOrOffset, int nLedsIfOffset = 0) {
+		return addLeds<CHIPSET, SPI_DATA, SPI_CLOCK, RGB, B>(data, nLedsOrOffset, nLedsIfOffset);
 	}
 
-	template<ESPIChipsets CHIPSET, fl::EOrder RGB_ORDER> static ::CLEDController &addLeds(CRGB *data, int nLedsOrOffset, int nLedsIfOffset = 0) {
-		return addLeds<CHIPSET, SPI_DATA, SPI_CLOCK, RGB_ORDER>(data, nLedsOrOffset, nLedsIfOffset);
+	template<ESPIChipsets CHIPSET, fl::EOrder RGB_ORDER, fl::Bus B = fl::Bus::AUTO> static ::CLEDController &addLeds(CRGB *data, int nLedsOrOffset, int nLedsIfOffset = 0) {
+		return addLeds<CHIPSET, SPI_DATA, SPI_CLOCK, RGB_ORDER, B>(data, nLedsOrOffset, nLedsIfOffset);
 	}
 
-	template<ESPIChipsets CHIPSET, fl::EOrder RGB_ORDER, fl::u32 SPI_DATA_RATE> static ::CLEDController &addLeds(CRGB *data, int nLedsOrOffset, int nLedsIfOffset = 0) {
-		return addLeds<CHIPSET, SPI_DATA, SPI_CLOCK, RGB_ORDER, SPI_DATA_RATE>(data, nLedsOrOffset, nLedsIfOffset);
+	template<ESPIChipsets CHIPSET, fl::EOrder RGB_ORDER, fl::u32 SPI_DATA_RATE, fl::Bus B = fl::Bus::AUTO> static ::CLEDController &addLeds(CRGB *data, int nLedsOrOffset, int nLedsIfOffset = 0) {
+		return addLeds<CHIPSET, SPI_DATA, SPI_CLOCK, RGB_ORDER, SPI_DATA_RATE, B>(data, nLedsOrOffset, nLedsIfOffset);
 	}
 
 #endif
@@ -1124,44 +1133,49 @@ public:
 	/// @{
 
 	/// Add a clockless based CLEDController instance to the world.
-	template<template<fl::u8, fl::EOrder> class CHIPSET, fl::u8 DATA_PIN, fl::EOrder RGB_ORDER>
+	template<template<fl::u8, fl::EOrder> class CHIPSET, fl::u8 DATA_PIN, fl::EOrder RGB_ORDER, fl::Bus B = fl::Bus::AUTO>
 	static ::CLEDController &addLeds(CRGB *data, int nLedsOrOffset, int nLedsIfOffset = 0) {
+		fl::busKeepAlive<B>();
 		static CHIPSET<DATA_PIN, RGB_ORDER> c;
 		return addLedsImpl(&c, data, nLedsOrOffset, nLedsIfOffset);
 	}
 
 	/// Add a clockless based CLEDController instance to the world.
-	template<template<fl::u8, fl::EOrder> class CHIPSET, fl::u8 DATA_PIN>
+	template<template<fl::u8, fl::EOrder> class CHIPSET, fl::u8 DATA_PIN, fl::Bus B = fl::Bus::AUTO>
 	static ::CLEDController &addLeds(CRGB *data, int nLedsOrOffset, int nLedsIfOffset = 0) {
+		fl::busKeepAlive<B>();
 		static CHIPSET<DATA_PIN, RGB> c;
 		return addLedsImpl(&c, data, nLedsOrOffset, nLedsIfOffset);
 	}
 
 	/// Add a clockless based CLEDController instance to the world.
-	template<template<fl::u8> class CHIPSET, fl::u8 DATA_PIN>
+	template<template<fl::u8> class CHIPSET, fl::u8 DATA_PIN, fl::Bus B = fl::Bus::AUTO>
 	static ::CLEDController &addLeds(CRGB *data, int nLedsOrOffset, int nLedsIfOffset = 0) {
+		fl::busKeepAlive<B>();
 		static CHIPSET<DATA_PIN> c;
 		return addLedsImpl(&c, data, nLedsOrOffset, nLedsIfOffset);
 	}
 
-	template<template<fl::u8> class CHIPSET, fl::u8 DATA_PIN>
+	template<template<fl::u8> class CHIPSET, fl::u8 DATA_PIN, fl::Bus B = fl::Bus::AUTO>
 	static ::CLEDController &addLeds(fl::Leds& leds, int nLedsOrOffset, int nLedsIfOffset = 0) {
 		CRGB* rgb = leds;
-		return addLeds<CHIPSET, DATA_PIN>(rgb, nLedsOrOffset, nLedsIfOffset);
+		return addLeds<CHIPSET, DATA_PIN, B>(rgb, nLedsOrOffset, nLedsIfOffset);
 	}
 
 #if defined(__FASTLED_HAS_FIBCC) && (__FASTLED_HAS_FIBCC == 1)
-	template<fl::u8 NUM_LANES, template<fl::u8 DATA_PIN, fl::EOrder RGB_ORDER> class CHIPSET, fl::u8 DATA_PIN, fl::EOrder RGB_ORDER=RGB>
+	template<fl::u8 NUM_LANES, template<fl::u8 DATA_PIN, fl::EOrder RGB_ORDER> class CHIPSET, fl::u8 DATA_PIN, fl::EOrder RGB_ORDER=RGB, fl::Bus B = fl::Bus::AUTO>
 	static ::CLEDController &addLeds(CRGB *data, int nLeds) {
+		fl::busKeepAlive<B>();
 		static fl::__FIBCC<CHIPSET, DATA_PIN, NUM_LANES, RGB_ORDER> c;
 		return addLeds(&c, data, nLeds);
 	}
 #endif
 
 	#ifdef FASTSPI_USE_DMX_SIMPLE
-	template<EClocklessChipsets CHIPSET, fl::u8 DATA_PIN, fl::EOrder RGB_ORDER=RGB>
+	template<EClocklessChipsets CHIPSET, fl::u8 DATA_PIN, fl::EOrder RGB_ORDER=RGB, fl::Bus B = fl::Bus::AUTO>
 	static ::CLEDController &addLeds(CRGB *data, int nLedsOrOffset, int nLedsIfOffset = 0)
 	{
+		fl::busKeepAlive<B>();
 		switch(CHIPSET) {
 			case DMX: { static DMXController<DATA_PIN> controller; return addLeds(&controller, data, nLedsOrOffset, nLedsIfOffset); }
 		}
@@ -1192,15 +1206,17 @@ public:
 	/// @{
 
 	/// Add a 3rd party library based CLEDController instance to the world.
-	template<template<fl::EOrder RGB_ORDER> class CHIPSET, fl::EOrder RGB_ORDER>
+	template<template<fl::EOrder RGB_ORDER> class CHIPSET, fl::EOrder RGB_ORDER, fl::Bus B = fl::Bus::AUTO>
 	static ::CLEDController &addLeds(CRGB *data, int nLedsOrOffset, int nLedsIfOffset = 0) {
+		fl::busKeepAlive<B>();
 		static CHIPSET<RGB_ORDER> c;
 		return addLeds(&c, data, nLedsOrOffset, nLedsIfOffset);
 	}
 
 	/// Add a 3rd party library based CLEDController instance to the world.
-	template<template<fl::EOrder RGB_ORDER> class CHIPSET>
+	template<template<fl::EOrder RGB_ORDER> class CHIPSET, fl::Bus B = fl::Bus::AUTO>
 	static ::CLEDController &addLeds(CRGB *data, int nLedsOrOffset, int nLedsIfOffset = 0) {
+		fl::busKeepAlive<B>();
 		static CHIPSET<RGB> c;
 		return addLeds(&c, data, nLedsOrOffset, nLedsIfOffset);
 	}
@@ -1209,9 +1225,10 @@ public:
 	/// Add a OCTOWS2811 based CLEDController instance to the world.
 	/// @see https://www.pjrc.com/teensy/td_libs_OctoWS2811.html
 	/// @see https://github.com/PaulStoffregen/OctoWS2811
-	template<OWS2811 CHIPSET, fl::EOrder RGB_ORDER>
+	template<OWS2811 CHIPSET, fl::EOrder RGB_ORDER, fl::Bus B = fl::Bus::AUTO>
 	static ::CLEDController &addLeds(CRGB *data, int nLedsOrOffset, int nLedsIfOffset = 0)
 	{
+		fl::busKeepAlive<B>();
 		switch(CHIPSET) {
 			case OCTOWS2811: { static fl::COctoWS2811Controller<RGB_ORDER,WS2811_800kHz> controller; return addLeds(&controller, data, nLedsOrOffset, nLedsIfOffset); }
 			case OCTOWS2811_400: { static fl::COctoWS2811Controller<RGB_ORDER,WS2811_400kHz> controller; return addLeds(&controller, data, nLedsOrOffset, nLedsIfOffset); }
@@ -1224,10 +1241,10 @@ public:
 	/// Add a OCTOWS2811 library based CLEDController instance to the world.
 	/// @see https://www.pjrc.com/teensy/td_libs_OctoWS2811.html
 	/// @see https://github.com/PaulStoffregen/OctoWS2811
-	template<OWS2811 CHIPSET>
+	template<OWS2811 CHIPSET, fl::Bus B = fl::Bus::AUTO>
 	static ::CLEDController &addLeds(CRGB *data, int nLedsOrOffset, int nLedsIfOffset = 0)
 	{
-		return addLeds<CHIPSET,GRB>(data,nLedsOrOffset,nLedsIfOffset);
+		return addLeds<CHIPSET,GRB,B>(data,nLedsOrOffset,nLedsIfOffset);
 	}
 
 #endif
@@ -1236,9 +1253,10 @@ public:
 	/// Add a WS2812Serial library based CLEDController instance to the world.
 	/// @see https://www.pjrc.com/non-blocking-ws2812-led-library/
 	/// @see https://github.com/PaulStoffregen/WS2812Serial
-	template<SWS2812 CHIPSET, int DATA_PIN, fl::EOrder RGB_ORDER>
+	template<SWS2812 CHIPSET, int DATA_PIN, fl::EOrder RGB_ORDER, fl::Bus B = fl::Bus::AUTO>
 	static ::CLEDController &addLeds(CRGB *data, int nLedsOrOffset, int nLedsIfOffset = 0)
 	{
+		fl::busKeepAlive<B>();
 		static CWS2812SerialController<DATA_PIN,RGB_ORDER> controller;
 		return addLeds(&controller, data, nLedsOrOffset, nLedsIfOffset);
 	}
@@ -1247,9 +1265,10 @@ public:
 #ifdef SmartMatrix_h
 	/// Add a SmartMatrix library based CLEDController instance to the world.
 	/// @see https://github.com/pixelmatix/SmartMatrix
-	template<ESM CHIPSET>
+	template<ESM CHIPSET, fl::Bus B = fl::Bus::AUTO>
 	static ::CLEDController &addLeds(CRGB *data, int nLedsOrOffset, int nLedsIfOffset = 0)
 	{
+		fl::busKeepAlive<B>();
 		switch(CHIPSET) {
 			case SMART_MATRIX: { static CSmartMatrixController controller; return addLeds(&controller, data, nLedsOrOffset, nLedsIfOffset); }
 		}
@@ -1282,8 +1301,9 @@ public:
 	/// @{
 
 	/// Add a block based parallel output CLEDController instance to the world.
-	template<EBlockChipsets CHIPSET, int NUM_LANES, fl::EOrder RGB_ORDER>
+	template<EBlockChipsets CHIPSET, int NUM_LANES, fl::EOrder RGB_ORDER, fl::Bus B = fl::Bus::AUTO>
 	static ::CLEDController &addLeds(CRGB *data, int nLedsOrOffset, int nLedsIfOffset = 0) {
+		fl::busKeepAlive<B>();
 		switch(CHIPSET) {
 		#ifdef PORTA_FIRST_PIN
 				case WS2811_PORTA: return addLeds(new fl::InlineBlockClocklessController<NUM_LANES, PORTA_FIRST_PIN, fl::TIMING_WS2811_800KHZ_LEGACY, RGB_ORDER>(), data, nLedsOrOffset, nLedsIfOffset);  // ok bare allocation
@@ -1324,9 +1344,9 @@ public:
 	}
 
 	/// Add a block based parallel output CLEDController instance to the world.
-	template<EBlockChipsets CHIPSET, int NUM_LANES>
+	template<EBlockChipsets CHIPSET, int NUM_LANES, fl::Bus B = fl::Bus::AUTO>
 	static ::CLEDController &addLeds(CRGB *data, int nLedsOrOffset, int nLedsIfOffset = 0) {
-		return addLeds<CHIPSET,NUM_LANES,GRB>(data,nLedsOrOffset,nLedsIfOffset);
+		return addLeds<CHIPSET,NUM_LANES,GRB,B>(data,nLedsOrOffset,nLedsIfOffset);
 	}
 	/// @} Adding parallel output controllers
 #endif

--- a/src/fl/channels/README.md
+++ b/src/fl/channels/README.md
@@ -163,7 +163,17 @@ fl::TypedChannel<fl::Bus::LCD_SPI, fl::ClocklessChipset>::create(cfg);  // compi
 
 `TypedChannel<Bus, Chipset>` lives in `fl/channels/channel_typed.h`. It returns a `ChannelPtr` to the regular non-template runtime `Channel` so callbacks, the draw list, and `ChannelManager` see one channel type.
 
-> **Planned**: `FastLED.addLeds<CHIPSET, PIN, ORDER, fl::Bus::X>(leds, n)` — a trailing default template parameter on the legacy `addLeds<>` shape. See #2460. Not in tree yet.
+**Legacy `addLeds<>` Bus pinning (#2460):** every `FastLED.addLeds<>` variant accepts an optional trailing `fl::Bus B = fl::Bus::AUTO` template parameter. `B = AUTO` (the default) leaves call sites byte-for-byte unchanged; `B != AUTO` ODR-uses `fl::BusTraits<B>::instance` so `--gc-sections` retains the named driver TU.
+
+```cpp
+// Clockless: pin to RMT at compile time.
+FastLED.addLeds<WS2812, 4, GRB, fl::Bus::RMT>(leds, 60);
+
+// SPI: pin to SPI at compile time.
+FastLED.addLeds<APA102, 23, 18, RGB, DATA_RATE_MHZ(12), fl::Bus::SPI>(leds, 60);
+```
+
+The Bus param triggers linker keep-alive in every variant. For the SPI variants on the `FASTLED_SPI_USES_CHANNEL_API` branch, the parameter also populates `cfg.options.mBus = B` so the channel routes through the named driver at runtime. Legacy non-Channel-API controllers keep their platform-default routing and rely on the linker keep-alive alone — for full runtime routing through a specific Bus, prefer `FastLED.add(cfg)` with `cfg.options.mBus = B`.
 
 ### Runtime Bus Selection (non-template `FastLED.add(cfg)`)
 
@@ -193,7 +203,7 @@ void setup() {
 }
 ```
 
-If `cfg.options.mBus` names a driver that — for whatever reason — isn't in the manager's registry, `Channel::showPixels` emits a one-shot `FL_ERROR` listing the resolution options (`fl::enableDrivers<fl::Bus::X>()` or `FastLED.enableAllDrivers()`) and falls back to AUTO/priority dispatch (#2455).
+If `cfg.options.mBus` names a driver that — for whatever reason — isn't in the manager's registry, `Channel::showPixels` emits a one-shot `FL_ERROR` listing the resolution options (`fl::enableDrivers<fl::Bus::X>()`, `FastLED.enableAllDrivers()`, or the legacy `FastLED.addLeds<..., fl::Bus::X>(...)` shape) and falls back to AUTO/priority dispatch (#2455, #2460).
 
 Passing `fl::Bus::AUTO` (the default) skips the pinning step and lets `ChannelManager` pick by priority — identical to constructing the config without touching `cfg.options.mBus`.
 

--- a/src/fl/channels/bus_traits.h
+++ b/src/fl/channels/bus_traits.h
@@ -83,4 +83,39 @@ inline void enableDrivers() FL_NOEXCEPT {
     (void)expand{0, detail::bus_register_one<Buses>()...};
 }
 
+/// @brief Compile-time linker keep-alive hook for a single `fl::Bus`.
+///
+/// Used by the legacy `FastLED.addLeds<..., fl::Bus B>(...)` template path
+/// (see #2460). When `B != Bus::AUTO`, naming `BusTraits<B>::instance` here
+/// is what makes `--gc-sections` retain the named driver's translation unit
+/// even though the legacy controller body never invokes the singleton
+/// directly. The `Bus::AUTO` specialization is a no-op so calls without an
+/// explicit Bus param remain byte-for-byte identical to pre-#2460 code.
+namespace detail {
+
+template<fl::Bus B>
+struct BusKeepAliveImpl {
+    static inline void odr_use() FL_NOEXCEPT {
+        // ODR-use the singleton accessor's address — sufficient to keep
+        // the driver TU alive. We do NOT call `instance()` here because
+        // some platforms construct the driver eagerly inside the Meyers
+        // singleton and we want `Bus::X`-tagged `addLeds<>` to behave as
+        // a pure compile-time annotation (no runtime side effect beyond
+        // the linker keep-alive itself).
+        (void)&BusTraits<B>::instance;
+    }
+};
+
+template<>
+struct BusKeepAliveImpl<fl::Bus::AUTO> {
+    static inline void odr_use() FL_NOEXCEPT {}  // AUTO: no pinning, no ODR-use.
+};
+
+}  // namespace detail
+
+template<fl::Bus B>
+inline void busKeepAlive() FL_NOEXCEPT {
+    detail::BusKeepAliveImpl<B>::odr_use();
+}
+
 }  // namespace fl

--- a/src/fl/channels/channel.cpp.hpp
+++ b/src/fl/channels/channel.cpp.hpp
@@ -341,14 +341,15 @@ void Channel::showPixels(PixelController<RGB, 1, 0xFFFFFFFF> &pixels) {
         (!driver || driver->getName() != busKey)) {
         auto busDriver = ChannelManager::instance().findDriverByName(busKey);
         if (!busDriver) {
-            // Typed Bus miss — emit the actionable hint with the two
-            // currently-shipping remediations. The third option
-            // (`addLeds<..., fl::Bus::X>(...)`) is planned in #2460.
+            // Typed Bus miss — emit the actionable hint with the three
+            // currently-shipping remediations (option 3 added in #2460).
             FL_ERROR("Channel '" << mName << "': Driver '" << busKey
                 << "' wasn't instantiated. Resolve with: "
                 << "(1) fl::enableDrivers<fl::Bus::" << busKey << ">() "
-                << "(links only this driver), or "
-                << "(2) FastLED.enableAllDrivers() (links every driver). "
+                << "(links only this driver), "
+                << "(2) FastLED.enableAllDrivers() (links every driver), or "
+                << "(3) FastLED.addLeds<..., fl::Bus::" << busKey << ">(...) "
+                << "(legacy API; pins Bus + triggers linker keep-alive). "
                 << "Defaulting to AUTO/priority dispatch.");
         } else {
             // Registered, but canHandle() said no — bus/chipset mismatch.

--- a/tests/fl/channels/bus_traits.cpp
+++ b/tests/fl/channels/bus_traits.cpp
@@ -7,6 +7,7 @@
 ///
 /// See issue #2428.
 
+#include "FastLED.h"  // For FastLED.addLeds<..., fl::Bus> tests (#2460)
 #include "fl/channels/bus.h"
 #include "fl/channels/bus_traits.h"
 #include "fl/channels/config.h"  // ClocklessChipset, SpiChipsetConfig
@@ -86,6 +87,63 @@ FL_TEST_CASE("enableDrivers<Bus::STUB>() registers the stub driver with ChannelM
     FL_REQUIRE(stubDriver != nullptr);
     // Identity check: the registered driver must be the BusTraits singleton.
     FL_CHECK(stubDriver.get() == &fl::BusTraits<fl::Bus::STUB>::instance());
+}
+
+// ---------------------------------------------------------------------------
+// #2460 — trailing `fl::Bus B` template parameter on FastLED.addLeds<>
+// ---------------------------------------------------------------------------
+//
+// These cases exercise the new `busKeepAlive<B>()` helper and at least one
+// clockless + one SPI legacy-API call site with `B = fl::Bus::STUB`. On host
+// `Bus::STUB` is the only bus we can name without dragging in real hardware
+// drivers, but the body change is the same for every variant.
+
+FL_TEST_CASE("busKeepAlive<Bus::AUTO>() is a no-op and compiles") {
+    fl::busKeepAlive<fl::Bus::AUTO>();  // AUTO specialization: no ODR-use.
+    // Same identity check as plain `instance()` — proving the AUTO path
+    // did not corrupt state in any way.
+    auto& a = fl::BusTraits<fl::Bus::STUB>::instance();
+    auto& b = fl::BusTraits<fl::Bus::STUB>::instance();
+    FL_CHECK(&a == &b);
+}
+
+FL_TEST_CASE("busKeepAlive<Bus::STUB>() ODR-uses the singleton accessor") {
+    fl::busKeepAlive<fl::Bus::STUB>();
+    // After the keep-alive runs, the singleton must still be valid.
+    auto p = fl::BusTraits<fl::Bus::STUB>::instancePtr();
+    FL_REQUIRE(p != nullptr);
+    FL_CHECK(p.get() == &fl::BusTraits<fl::Bus::STUB>::instance());
+}
+
+FL_TEST_CASE("FastLED.addLeds<WS2812, ..., fl::Bus::STUB> clockless variant compiles") {
+    // Acceptance criterion: clockless variant accepts the trailing Bus param.
+    static CRGB leds[8];
+    auto& ctrl = FastLED.addLeds<WS2812, 2, GRB, fl::Bus::STUB>(leds, 8);
+    (void)ctrl;
+    // Identity check post-instantiation.
+    FL_CHECK(&fl::BusTraits<fl::Bus::STUB>::instance() != nullptr);
+}
+
+FL_TEST_CASE("FastLED.addLeds<APA102, ..., fl::Bus::STUB> SPI variant compiles") {
+    // Acceptance criterion: SPI variant accepts the trailing Bus param.
+    static CRGB leds[8];
+    auto& ctrl = FastLED.addLeds<APA102, 23, 18, RGB, DATA_RATE_MHZ(12), fl::Bus::STUB>(leds, 8);
+    (void)ctrl;
+    FL_CHECK(&fl::BusTraits<fl::Bus::STUB>::instance() != nullptr);
+}
+
+FL_TEST_CASE("FastLED.addLeds<WS2812, ...> default-AUTO call site is unchanged") {
+    // Regression guard: omitting the Bus param must compile and behave as
+    // before #2460 (the AUTO specialization is a no-op).
+    static CRGB leds[8];
+    auto& ctrl = FastLED.addLeds<WS2812, 3, GRB>(leds, 8);
+    (void)ctrl;
+}
+
+FL_TEST_CASE("FastLED.addLeds<APA102, ...> default-AUTO SPI call site is unchanged") {
+    static CRGB leds[8];
+    auto& ctrl = FastLED.addLeds<APA102, 23, 18, RGB, DATA_RATE_MHZ(12)>(leds, 8);
+    (void)ctrl;
 }
 
 FL_TEST_CASE("Legacy initChannelDrivers() and enableDrivers<Bus::STUB>() share singleton (Phase 5a)") {


### PR DESCRIPTION
## Summary

- Adds optional trailing `fl::Bus B = fl::Bus::AUTO` template parameter to every `FastLED.addLeds<>` variant; default-AUTO call sites are byte-for-byte unchanged.
- New `fl::busKeepAlive<B>()` helper (in `src/fl/channels/bus_traits.h`) ODR-uses `BusTraits<B>::instance` when `B != AUTO` so `--gc-sections` retains the named driver TU.
- For the `FASTLED_SPI_USES_CHANNEL_API` SPI variants, the body also sets `config.options.mBus = B` to pin runtime routing through the named driver.
- Runtime miss diagnostic in `channel.cpp.hpp` now lists the third remediation alongside `enableDrivers<>` / `enableAllDrivers()`.

## Issue acceptance criteria (from #2460)

- [x] Every `FastLED.addLeds<>` variant accepts the trailing `fl::Bus B = fl::Bus::AUTO` parameter.
- [x] `B = AUTO` (the default) leaves existing call sites byte-for-byte unchanged.
- [x] `B != AUTO` ODR-uses `fl::BusTraits<B>::instance` so `--gc-sections` keeps only the named driver TU.
- [x] Miss diagnostic in `channel.cpp.hpp` lists the new `addLeds<..., fl::Bus::X>(...)` remediation.
- [x] Tests cover at least one clockless (WS2812) and one SPI (APA102) variant with the new trailing parameter.

## Strategy (hybrid)

- **Channel-API SPI variants** (`FASTLED_SPI_USES_CHANNEL_API` branch): set `cfg.options.mBus = B` to route through the named driver. One-line addition to bodies that already build a `ChannelConfig`.
- **All other variants** (legacy SPI `#else` branch, clockless, FIBCC, OctoWS2811, WS2812Serial, SmartMatrix, Block parallel): emit `fl::busKeepAlive<B>()` for linker keep-alive only; runtime routing stays on the platform default. This avoids retrofitting `setDriver()` into every legacy controller (out-of-scope per the issue's Option B con).

Full README walkthrough added to `src/fl/channels/README.md` under the compile-time bus selection section.

## Test plan

- [x] `bash test --cpp` — 303/303 host tests pass (covers clockless STUB + legacy SPI body changes via new test cases in `tests/fl/channels/bus_traits.cpp`).
- [x] `bash lint` — clean.
- [x] `bash compile uno --examples Blink` — AVR C++11 path compiles cleanly (verifies the C++11-compatible struct-specialization helper).
- [ ] ESP32 platform compile — **blocked by unrelated toolchain cache breakage** (`framework-arduinoespressif32` cache is missing `Arduino.h` / `WString.h` / `soc/soc_caps.h`). The `FASTLED_SPI_USES_CHANNEL_API` body change is a single-line write to the `mBus` field that has been the canonical field since #2461; reviewers may want to verify on their own ESP32 setup.

## Related

- Closes #2460
- Parent: #2459 (already landed as `4afad42d3f`)
- Grandparent: #2428

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended `addLeds()` API across all controller types to accept an optional bus parameter for explicit hardware bus selection and legacy bus pinning support.

* **Documentation**
  * Updated API documentation with new legacy bus pinning configuration guidance and enhanced error diagnostics to resolve driver initialization issues more effectively.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/FastLED/pull/2465)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->