### PR TITLE
feat(channels): remove FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY (default-as-opt-in, closes binary-bloat half of #2421)

### DIFF
--- a/examples/AutoResearch/AutoResearch.ino
+++ b/examples/AutoResearch/AutoResearch.ino
@@ -182,6 +182,7 @@
 // ============================================================================
 
 #include <FastLED.h>
+#include "fl/channels/all_drivers.h"  // for FastLED.enableAllDrivers() post-#2428
 #include "fl/stl/undef.h"  // Undefine Arduino macros (DEFAULT, INPUT, OUTPUT)
 #include "fl/stl/sstream.h"
 #include "Common.h"
@@ -395,6 +396,11 @@ void setup() {
     // GPIO baseline test moved to loop() - wait for RPC start signal before testing
     // This allows JSON-RPC commands (testGpioConnection, findConnectedPins) to run first
     FL_WARN("[GPIO BASELINE TEST] Deferred to loop() - waiting for RPC start signal");
+
+    // Post-#2428 the channel driver registry no longer auto-populates. This
+    // example needs every available driver enrolled with ChannelManager so the
+    // discovery + autoresearch loop below can enumerate them.
+    FastLED.enableAllDrivers();
 
     // List all available drivers and store globally
     g_autoresearch_state->drivers_available = FastLED.getDriverInfos();

--- a/examples/AutoResearch/AutoResearchAsync.h
+++ b/examples/AutoResearch/AutoResearchAsync.h
@@ -87,6 +87,17 @@ inline void maybeRegisterStubAutorun(
 
         for (fl::size di = 0; di < state->drivers_available.size(); di++) {
             const auto& drv = state->drivers_available[di];
+
+            // BIT_BANG is the cycle-counted GPIO fallback. On the stub/host
+            // platform there is no actual GPIO toggling, so its TX output
+            // can't be captured by the loopback RX path the stub uses for
+            // self-verification. Skip it in the stub autorun (#2469) — it's
+            // still available for explicit selection by name on real hardware.
+            if (drv.name == "BIT_BANG") {
+                FL_PRINT("\n[STUB CLIENT] Driver: " << drv.name.c_str() << "  (skipped — no loopback in host stub)");
+                continue;
+            }
+
             FL_PRINT("\n[STUB CLIENT] Driver: " << drv.name.c_str());
 
             if (!autoResearchSetExclusiveDriverByName(drv.name.c_str())) {

--- a/examples/AutoResearch/AutoResearchHelpers.cpp
+++ b/examples/AutoResearch/AutoResearchHelpers.cpp
@@ -2,7 +2,6 @@
 
 #include "AutoResearchHelpers.h"
 #include "fl/channels/manager.h"
-#include "fl/channels/all_drivers.h"    // FastLED.enableAllDrivers() out-of-line definition
 #include "fl/stl/sstream.h"
 #include "fl/system/pin.h"  // Platform-independent pin API
 #include "fl/channels/detail/validation/rx_test.h"
@@ -26,10 +25,12 @@ void autoResearchExpectedEngines() {
 }
 
 bool autoResearchSetExclusiveDriverByName(const char* name) {
-    // AutoResearch resolves driver names at runtime (RPC/JSON), so it needs every
-    // driver enrolled with ChannelManager before the lookup runs — otherwise a
-    // driver that wasn't auto-registered would silently miss.
-    FastLED.enableAllDrivers();
+    // AutoResearch resolves driver names at runtime (RPC/JSON). The caller
+    // (AutoResearch.ino setup()) must already have enrolled every available
+    // driver via FastLED.enableAllDrivers(). We deliberately do NOT call
+    // enableAllDrivers() here — doing it per-iteration would re-add every
+    // driver each call, triggering ChannelManager's "Replacing existing driver"
+    // path and resetting state mid-test (#2469).
     return fl::ChannelManager::instance().setExclusiveDriverByName(name);
 }
 

--- a/examples/AutoResearch/AutoResearchHelpers.h
+++ b/examples/AutoResearch/AutoResearchHelpers.h
@@ -25,15 +25,20 @@ bool testRxChannel(
 /// Prints ERROR if any expected engines are missing
 void autoResearchExpectedEngines();
 
-/// @brief AutoResearch-style helper: enable all drivers, then set an exclusive driver by name
+/// @brief AutoResearch-style helper: set an exclusive driver by name
 /// @param name Driver name (case-sensitive — must match an `IChannelDriver::getName()` value)
 /// @return true if the driver was found and set as exclusive
 ///
 /// AutoResearch resolves driver names at runtime from RPC/JSON payloads, so it
 /// can't use the typed `FastLED.setExclusiveDriver(fl::Bus)` form. This wrapper
-/// makes sure every driver is registered before the lookup runs — without it,
-/// a driver that hasn't been enrolled yet would silently miss the lookup and
-/// fall back to AUTO/priority dispatch.
+/// forwards to `ChannelManager::instance().setExclusiveDriverByName(name)`.
+///
+/// **Precondition:** The caller must already have enrolled every available
+/// driver via `FastLED.enableAllDrivers()` (typically once in `setup()`).
+/// This helper deliberately does NOT call `enableAllDrivers()` itself —
+/// calling it per-iteration in a discovery loop re-adds every driver each
+/// time, triggering ChannelManager's "Replacing existing driver" path and
+/// resetting state mid-test (#2469).
 ///
 /// For built-in driver code that knows its driver at compile time, use
 /// `FastLED.setExclusiveDriver(fl::Bus::X)` instead (typo-safe).

--- a/src/FastLED.h
+++ b/src/FastLED.h
@@ -1371,11 +1371,38 @@ public:
 	/// @note On platforms without registered drivers, this is a safe no-op
 	void setDriverEnabled(const char* name, bool enabled);
 
-	/// Enable only one driver exclusively (disables all others)
+	/// Register a single driver at a priority above the platform default
+	/// (compile-time TU-linking variant).
+	///
+	/// Post-#2428 the default build does NOT auto-register every driver —
+	/// only the platform-default driver TU links (via the legacy clockless
+	/// controller's Phase 5b pre-bind). This template provides the opt-in
+	/// path to add another driver and have it win priority dispatch.
+	///
+	/// Naming `BusTraits<B>::instancePtr()` in the body is the ODR-use that
+	/// links the driver TU; the registration with the manager happens at
+	/// `kExclusivePriority` (a value above any platform default).
+	///
+	/// **Must be called before `addLeds<>` / `FastLED.add()`** so newly-
+	/// constructed channels see the override during driver resolution.
+	/// Legacy clockless controllers that already pre-bound to the platform
+	/// default via Phase 5b will continue to use that pre-bind.
+	///
+	/// @tparam B  Bus identifier. The caller must have the per-driver
+	///            `bus_traits.h` visible at the call site (which provides
+	///            the `BusTraits<B>` specialization).
+	template<fl::Bus B>
+	void setExclusiveDriver() FL_NOEXCEPT {
+		fl::channelManager().setExclusiveDriver<B>();
+	}
+
+	/// Enable only one driver exclusively, runtime form (disables all others)
 	/// @param bus Bus enum identifying the driver (typed, typo-safe)
 	/// @return true if driver was found and set as exclusive, false otherwise
-	/// @note Atomically disables all drivers, then enables the specified one
 	/// @note Use for testing specific drivers or debugging
+	/// @note Does NOT ODR-use `BusTraits<bus>::instancePtr()` — for compile-time
+	///       TU-linking of a non-default driver, use the
+	///       `setExclusiveDriver<fl::Bus B>()` template overload above.
 	/// @note For drivers whose names aren't in the `fl::Bus` enum (mocks,
 	///       custom third-party drivers, RPC-resolved names), use
 	///       `fl::ChannelManager::instance().setExclusiveDriverByName(name)`

--- a/src/fl/channels/README.md
+++ b/src/fl/channels/README.md
@@ -209,44 +209,48 @@ If `cfg.options.mBus` names a driver that — for whatever reason — isn't in t
 
 Passing `fl::Bus::AUTO` (the default) skips the pinning step and lets `ChannelManager` pick by priority — identical to constructing the config without touching `cfg.options.mBus`.
 
-### Opt-In Driver Registration (`enableDrivers<>` / `enableAllDrivers`)
+### Opt-In Driver Registration (`enableDrivers<>` / `enableAllDrivers` / `setExclusiveDriver<>`)
 
-By default every platform driver self-registers with `ChannelManager` at startup, so any `cfg.options.mBus` value can be dispatched without further setup. The opt-in API below is for sketches that want tighter binary-size control (paired with `FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY=1`, described below).
+**Default behaviour: no driver auto-registration.** Only the platform-default driver TU (named by the legacy clockless controller's Phase 5b pre-bind via `BusTraits<DefaultBus<Chipset>>::instancePtr()`) is linked into the binary; every other driver is `--gc-sections`-eligible until something names its `BusTraits<Bus::X>::instancePtr()`. This is the binary-size fix for #2420 / #2421 — the old `FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY` macro has been removed; the default IS the opt-in path.
 
-Selective opt-in — only the named drivers are linked AND registered:
+To register additional drivers at runtime, sketches pick one of three opt-in calls:
 
 ```cpp
+// 1. Selective opt-in: only RMT and PARLIO end up linked AND registered.
 #include "platforms/esp/32/drivers/rmt/rmt_5/bus_traits.h"
 #include "platforms/esp/32/drivers/parlio/bus_traits.h"
 
 void setup() {
     fl::enableDrivers<fl::Bus::RMT, fl::Bus::PARLIO>();
-    // ...
 }
 ```
 
-Or enroll every driver the platform supports:
-
 ```cpp
+// 2. Universal opt-in: 3.10.3-style "every driver available at runtime".
 #include "FastLED.h"
 #include "fl/channels/all_drivers.h"   // pulls in every BusTraits<> on the platform
 
 void setup() {
     FastLED.enableAllDrivers();        // forwards to fl::enableAllDrivers()
-    // any Bus value now resolves at runtime
+    // any cfg.options.mBus value now resolves at runtime via the manager
 }
 ```
 
-Including `fl/channels/all_drivers.h` is the explicit opt-in that makes the per-driver `BusTraits<Bus::X>` specializations visible at the call site — without that include, `FastLED.enableAllDrivers()` fails to link and `--gc-sections` is free to drop driver TUs the sketch doesn't reference.
+```cpp
+// 3. Single-driver override: link the named driver AND set it at priority
+//    above the platform default so it wins ChannelManager dispatch. Must be
+//    called BEFORE addLeds<> / FastLED.add() so the override is visible
+//    when channels resolve their drivers.
+#include "FastLED.h"
+#include "platforms/esp/32/drivers/lcd_spi/bus_traits.h"
 
-### `FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY`
+void setup() {
+    FastLED.setExclusiveDriver<fl::Bus::LCD_SPI>();
+    FastLED.addLeds<APA102, 23, 18, RGB>(leds, 60);
+}
+```
 
-Defined in `fl/channels/bus.h` so every channels TU sees the same value. Default `0` — auto-registration is on: every available driver enrolls with `ChannelManager` at static-init time. Set to `1` to:
-
-- Disable auto-registration. Drivers register only when explicitly named via `enableDrivers<>()` / `enableAllDrivers()`.
-- Pre-bind per-platform clockless controllers directly to their `BusTraits<DefaultBus>::instancePtr()` singleton, bypassing `ChannelManager` entirely (#2428 Phase 5b).
-
-This is the toggle that lets `--gc-sections` drop unreferenced driver TUs (the binary-size fix from #2420). Build-time opt-in only — flip it via `-DFASTLED_DISABLE_LEGACY_DRIVER_REGISTRY=1` in your platform config.
+Including the matching per-driver `bus_traits.h` is the explicit opt-in that makes the `BusTraits<Bus::X>` specialization visible at the call site — without that include the call fails to link and `--gc-sections` stays free to drop the driver TU.
 
 ---
 
@@ -306,16 +310,28 @@ void setup() {
     // calling them all in sequence (as written here) makes the later
     // calls override the earlier ones.
 
-    // Method 1: Force a specific driver exclusively (disables all others).
-    // Use the typed fl::Bus form — typos like fl::Bus::RTM are compile errors.
+    // Method 1a: Link + register a specific driver at priority above the
+    //            platform default (compile-time template form — production
+    //            opt-in path). Must be called BEFORE the addLeds<>/FastLED.add()
+    //            calls that should pick it up.
+    //   #include "platforms/esp/32/drivers/rmt/rmt_5/bus_traits.h"  (at file top)
+    FastLED.setExclusiveDriver<fl::Bus::RMT>();
+
+    // Method 1b: Same as 1a, but runtime-typed (no TU-link side effect).
+    //            Use when the driver is already registered (mocks, custom,
+    //            or after FastLED.enableAllDrivers()). Typed, typo-safe —
+    //            fl::Bus::RTM is a compile error.
     FastLED.setExclusiveDriver(fl::Bus::RMT);
-    // For custom/mock drivers (names not in the fl::Bus enum), use the by-name
-    // escape hatch on the manager directly:
+
+    // Method 1c: For custom/mock drivers (names not in the fl::Bus enum),
+    //            use the by-name escape hatch on the manager directly:
     //   fl::ChannelManager::instance().setExclusiveDriverByName("MOCK_NAME");
 
-    // Method 2: Enable/disable specific drivers
-    FastLED.setDriverEnabled("PARLIO", true);   // Enable
-    FastLED.setDriverEnabled("SPI", false);     // Disable
+    // Method 2: Enable/disable specific already-registered drivers (string
+    //           form -- works for drivers that have already been registered
+    //           via enableDrivers<> / enableAllDrivers() / a mock test).
+    FastLED.setDriverEnabled("PARLIO", true);
+    FastLED.setDriverEnabled("SPI", false);
 
     // Method 3: Adjust driver priority (higher = preferred)
     // Engines are sorted by priority - changing priority triggers re-sort.
@@ -335,9 +351,10 @@ void setup() {
 ```
 
 **Control methods:**
-- `FastLED.setExclusiveDriver(fl::Bus)` - Disable all drivers except the named one (typed, typo-safe — preferred)
-- `fl::ChannelManager::instance().setExclusiveDriverByName(name)` - Same, by string name (for mocks / custom drivers not in `fl::Bus`)
-- `FastLED.setDriverEnabled(name, enabled)` - Enable/disable specific driver
+- `FastLED.setExclusiveDriver<fl::Bus::X>()` - Link the named driver TU and register it at priority above the platform default (production opt-in path; compile-time TU-link). Must be called before `addLeds<>` / `FastLED.add()`.
+- `FastLED.setExclusiveDriver(fl::Bus)` - Runtime-typed: disable all drivers except the named one. Typed, typo-safe (`fl::Bus::RTM` is a compile error). Does NOT link a driver TU — use the template form above for that.
+- `fl::ChannelManager::instance().setExclusiveDriverByName(name)` - By-name escape hatch for mocks / custom drivers not in `fl::Bus`. Does NOT link a driver TU.
+- `FastLED.setDriverEnabled(name, enabled)` - Enable/disable a specific already-registered driver.
 - `fl::ChannelManager::instance().setDriverPriority(name, priority)` - Change priority (triggers automatic re-sort). No `FastLED.*` forwarder is provided for this.
 
 **When to override:**
@@ -905,7 +922,7 @@ void setupCustomEngine() {
    - On hit: that driver is returned (no priority iteration).
    - On miss: `Channel::showPixels()` emits a one-shot `FL_ERROR` (see "Bus-miss diagnostic" above) and falls through to priority dispatch.
 2. Otherwise (`mBus == Bus::AUTO` or bus-miss fallback): the manager iterates drivers by priority (high to low) and returns the first that `canHandle()`s the channel data.
-3. Callers can override via `cfg.options.mBus` (per-channel, runtime), `fl::TypedChannel<Bus, Chipset>::create()` or `FastLED.addLeds<..., fl::Bus::X>` (compile-time, links only the named driver), or `FastLED.setExclusiveDriver()` (process-wide).
+3. Callers can override via `cfg.options.mBus` (per-channel, runtime), `fl::TypedChannel<Bus, Chipset>::create()` or `FastLED.addLeds<..., fl::Bus::X>` (compile-time, links only the named driver), or `FastLED.setExclusiveDriver<fl::Bus::X>()` (process-wide, compile-time TU-link; must be called before `addLeds<>`).
 
 **Priority modification:**
 - Engines are sorted by priority on registration (via `addDriver()`)
@@ -1023,11 +1040,11 @@ See `tests/fl/channels/driver.cpp` for more test examples.
 - `fl/channels/ichannel.h` — `IChannel` ABC (callback-facing identification base).
 - `fl/channels/config.h` — `ChannelConfig`, `ChannelConfigOf<Chipset>`, `ClocklessChipset`, `SpiChipsetConfig`.
 - `fl/channels/options.h` — `ChannelOptions` (correction, temperature, dither, rgbw, `mBus` driver selection, gamma).
-- `fl/channels/bus.h` — `fl::Bus` enum, `busName()`, `DefaultBus<Chipset>`, `FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY`.
+- `fl/channels/bus.h` — `fl::Bus` enum, `busName()`, `DefaultBus<Chipset>`.
 - `fl/channels/bus_traits.h` — `BusTraits<B>`, `BusSupports<B, Chipset>`, `enableDrivers<Bus...>()`, `busKeepAlive<B>()`.
 - `fl/channels/bus_priorities.h` — `default_bus_priority(Bus)` table consumed by `enableDrivers<>()`.
 - `fl/channels/all_drivers.h` — `fl::enableAllDrivers()` / `FastLED.enableAllDrivers()` aggregator.
-- `fl/channels/manager.h` — `ChannelManager` (`addDriver`, `getDriverByName`, `findDriverByName`, `selectDriverForChannel`, `setDriverPriority`, `setDriverEnabled`, `setExclusiveDriver`, `clearAllDrivers`, ...).
+- `fl/channels/manager.h` — `ChannelManager` (`addDriver`, `getDriverByName`, `findDriverByName`, `selectDriverForChannel`, `setDriverPriority`, `setDriverEnabled`, `setExclusiveDriver`, `setExclusiveDriverByName`, `clearAllDrivers`, ...).
 - `fl/channels/channel_events.h` — Lifecycle event callbacks.
 - `fl/channels/driver.h` — `IChannelDriver` interface and `DriverState` machine.
 

--- a/src/fl/channels/bus.h
+++ b/src/fl/channels/bus.h
@@ -17,23 +17,17 @@
 #include "fl/stl/stdint.h"
 #include "platforms/is_platform.h"
 
-// FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY: opt-in macro that, when set to 1,
-// disables the legacy `initChannelDrivers()` auto-registration AND switches
-// per-platform legacy clockless controllers (stub `ClocklessController`,
-// ESP32 `ClocklessIdf5`, etc.) to pre-bind directly to their default
-// `BusTraits<Bus::X>::instancePtr()` -- bypassing `ChannelManager` entirely.
+// Post-#2428 architecture: drivers do NOT auto-register with `ChannelManager`.
+// Only the platform-default driver TU (named by the legacy clockless controller's
+// Phase 5b pre-bind via `BusTraits<DefaultBus<Chipset>>::instancePtr()`) links
+// into the binary. Users who need additional drivers at runtime call:
+//   - `fl::enableDrivers<fl::Bus::X, ...>()` for selective opt-in,
+//   - `FastLED.enableAllDrivers()` for 3.10.3-style universal enrollment,
+//   - `FastLED.setExclusiveDriver<fl::Bus::X>()` to register a non-default driver
+//     at high priority (must be called before `addLeds<>` to override the pre-bind).
 //
-// This is the toggle that lets `--gc-sections` drop unreferenced driver TUs
-// (the binary-size fix from #2420). Default 0 for backward compatibility;
-// users opting in must call `fl::enableDrivers<fl::Bus::X...>()` explicitly
-// for any non-default driver they need at runtime.
-//
-// Defined here (early-included by every channels TU) so all consumers see the
-// same value -- the macro is checked from per-platform legacy clockless
-// headers as well as channel_manager_esp32.cpp.hpp.
-#ifndef FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY
-#define FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY 0
-#endif
+// The historical `FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY` opt-in macro has been
+// removed; the previously opt-in behaviour is now the only behaviour.
 
 namespace fl {
 

--- a/src/fl/channels/channel.h
+++ b/src/fl/channels/channel.h
@@ -204,9 +204,9 @@ protected:
     ///
     /// Used by legacy `addLeds<>`-style controllers (e.g. `ClocklessIdf5`) to
     /// route directly to a `BusTraits<DefaultBus>::instancePtr()` singleton at
-    /// construction time. Combined with `FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY=1`,
-    /// this is what lets `--gc-sections` drop unreferenced driver TUs (Phase 5b
-    /// of #2428 — the binary-size fix for #2420).
+    /// construction time. Post-#2428 this is the mechanism that lets
+    /// `--gc-sections` drop unreferenced driver TUs from default builds
+    /// (Phase 5b — the binary-size fix for #2420 / #2421).
     ///
     /// @note Stored as `weak_ptr` to avoid holding the driver alive past the
     ///       caller's intent. The caller (typically the static singleton in a

--- a/src/fl/channels/manager.cpp.hpp
+++ b/src/fl/channels/manager.cpp.hpp
@@ -175,22 +175,21 @@ bool ChannelManager::setExclusiveDriver(Bus bus) {
 }
 
 bool ChannelManager::setExclusiveDriverByName(const char* name) {
-    // Handle null or empty name
+    // Handle null or empty name: disable everything.
     if (!name || !name[0]) {
         FL_ERROR("ChannelManager::setExclusiveDriverByName() - Null or empty driver name provided");
         mExclusiveDriver.clear();
-        // Disable all drivers
         for (auto& entry : mDrivers) {
             entry.enabled = false;
         }
         return false;
     }
 
-    // Store exclusive driver name for forward compatibility
-    // When non-empty, addDriver() will auto-disable non-matching drivers
+    // Store exclusive driver name for forward compatibility.
+    // When non-empty, addDriver() will auto-disable non-matching drivers.
     mExclusiveDriver = name;
 
-    // Single-pass: enable only drivers matching the given name
+    // Single-pass: enable only drivers matching the given name.
     bool found = false;
     for (auto& entry : mDrivers) {
         entry.enabled = (entry.name == name);
@@ -200,7 +199,6 @@ bool ChannelManager::setExclusiveDriverByName(const char* name) {
     if (!found) {
         FL_ERROR("ChannelManager::setExclusiveDriverByName() - Driver '" << name << "' not found in registry");
     }
-
     return found;
 }
 

--- a/src/fl/channels/manager.h
+++ b/src/fl/channels/manager.h
@@ -25,6 +25,7 @@
 #include "fl/channels/driver.h"
 #include "fl/channels/data.h"
 #include "fl/channels/bus.h"
+#include "fl/channels/bus_traits.h"
 #include "fl/system/engine_events.h"
 #include "fl/stl/vector.h"
 #include "fl/stl/shared_ptr.h"
@@ -93,26 +94,57 @@ public:
     /// @note If name is not found, this is a no-op (does not warn)
     void setDriverEnabled(const char* name, bool enabled) FL_NOEXCEPT;
 
-    /// @brief Enable only one driver exclusively (disables all others)
+    /// @brief Register a single driver at a priority above the platform default
+    ///        and disable all others (compile-time TU-linking variant).
+    ///
+    /// Post-#2428 the default build does NOT auto-register every driver --
+    /// only the platform-default driver TU links (via the legacy clockless
+    /// controller's Phase 5b pre-bind). This template provides the opt-in
+    /// path to add another driver and have it win priority dispatch.
+    ///
+    /// Naming `BusTraits<B>::instancePtr()` here is the ODR-use that links
+    /// the driver TU; the registration with the manager happens at
+    /// `kExclusivePriority` (a value above any platform default) so the
+    /// new driver wins in `selectDriverForChannel()`.
+    ///
+    /// @tparam B  Bus identifier (must have a `BusTraits<B>` specialization
+    ///            visible at the call site).
+    /// @note **Must be called before `addLeds<>` / `FastLED.add()`** so
+    ///       newly-constructed channels see the override during driver
+    ///       resolution. Legacy clockless controllers that already pre-bound
+    ///       to the platform default via Phase 5b will continue to use that
+    ///       pre-bind -- this template does not rewrite existing controllers.
+    template<fl::Bus B>
+    void setExclusiveDriver() FL_NOEXCEPT;
+
+    /// @brief Enable only one driver exclusively, by `fl::Bus` enum (runtime form).
     /// @param bus Bus enum identifying the driver to enable (typed, typo-safe)
     /// @return true if driver was found and set as exclusive, false otherwise
-    /// @note Typed overload — prefer this over the string-based variant for
+    /// @note Typed overload — prefer this over the by-name variant for
     ///       built-in drivers. Delegates to `setExclusiveDriverByName(busName(bus))`.
+    /// @note Does NOT ODR-use `BusTraits<bus>::instancePtr()` — for compile-time
+    ///       TU-linking, use the `setExclusiveDriver<fl::Bus B>()` template overload.
     bool setExclusiveDriver(Bus bus) FL_NOEXCEPT;
 
     /// @brief Enable only one driver exclusively (disables all others) — by-name escape hatch
     /// @param name Driver name to enable exclusively (case-sensitive, e.g., "MOCK_SPI")
     /// @return true if driver was found and set as exclusive, false if name not found
-    /// @note Use this only for drivers whose names are NOT in the `fl::Bus` enum
-    ///       (mock drivers, custom third-party drivers, RPC-resolved names). For
-    ///       built-in drivers, prefer the typed `setExclusiveDriver(fl::Bus)`
-    ///       overload — it catches typos at compile time.
+    ///
+    /// Test / mock helper: works with drivers that have ALREADY been registered
+    /// via `addDriver()` (typically `ChannelEngineMock` instances under unit tests),
+    /// or for drivers whose names are NOT in the `fl::Bus` enum (custom
+    /// third-party drivers, RPC-resolved names). Does NOT link or register new
+    /// drivers.
+    ///
+    /// For built-in drivers, prefer either:
+    ///   - `setExclusiveDriver(fl::Bus)` (typed runtime form), or
+    ///   - `setExclusiveDriver<fl::Bus B>()` (compile-time form that links the
+    ///     driver TU via ODR-use).
     /// @note Atomically disables all drivers, then enables the specified one
     /// @note Changes take effect immediately on next enqueue()
     /// @note If name is not found, all drivers remain disabled (defensive behavior)
     /// @note Use nullptr or empty string to disable all drivers (returns false)
     /// @warning This will disable ALL other registered drivers, including future additions
-    /// @warning This ensures forward compatibility - new drivers are automatically excluded
     bool setExclusiveDriverByName(const char* name) FL_NOEXCEPT;
 
     /// @brief Change the priority of a registered driver
@@ -227,7 +259,8 @@ private:
     mutable fl::vector<DriverInfo> mCachedDriverInfo;
 
     /// @brief Exclusive driver name (empty if no exclusive mode)
-    /// @note When non-empty, new drivers are auto-disabled if name doesn't match
+    /// @note When non-empty, new drivers are auto-disabled if name doesn't match.
+    ///       Set by `setExclusiveDriverByName()` / cleared on empty name.
     fl::string mExclusiveDriver;
 
     // Non-copyable, non-movable
@@ -240,7 +273,19 @@ private:
 /// @brief Get the global ChannelManager singleton instance
 /// @return Reference to the singleton ChannelManager
 /// @note Available on all platforms (has 0 drivers on non-ESP32)
-/// @note On ESP32, platform code registers drivers during static initialization
 ChannelManager& channelManager() FL_NOEXCEPT;
+
+// Inline template definition for ChannelManager::setExclusiveDriver<B>().
+// Defined here so the ODR-use of `BusTraits<B>::instancePtr()` happens in the
+// caller's TU, which links the driver translation unit. The caller must have
+// the per-driver `bus_traits.h` (which provides `BusTraits<B>::instancePtr`)
+// visible at the call site.
+template<fl::Bus B>
+inline void ChannelManager::setExclusiveDriver() FL_NOEXCEPT {
+    // Priority above any platform default — see `bus_priorities.h` for the
+    // default-priority constants (highest there is ~10 for native LCD/I2S SPI).
+    constexpr int kExclusivePriority = 10000;
+    addDriver(kExclusivePriority, fl::BusTraits<B>::instancePtr());
+}
 
 } // namespace fl

--- a/src/platforms/esp/32/drivers/_build.cpp.hpp
+++ b/src/platforms/esp/32/drivers/_build.cpp.hpp
@@ -4,14 +4,15 @@
 /// @brief Unity build header for platforms\esp\32\drivers/ directory
 /// Includes all implementation files in alphabetical order
 ///
-/// Phase 5c of #2428 (binary-size fix for #2420):
+/// Post-#2428 (binary-size fix for #2420 / #2421):
 ///
-/// Each LED-output driver subdirectory's `_build.cpp.hpp` self-gates against
-/// `FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY`. When the macro is enabled (opt-in
-/// mode), every non-platform-default driver TU becomes empty -- so only the
-/// platform's default driver remains in the build. The auxiliary subdirs
-/// (`ble`, `gpio_isr_rx`, `rmt_rx`) are not channel drivers and stay
-/// unconditional.
+/// Each LED-output driver subdirectory's `_build.cpp.hpp` only compiles its
+/// implementation on platforms where the driver is the platform default
+/// (PARLIO on P4/C6/H2/C5, RMT elsewhere, LCD_SPI on S3, I2S_SPI on dev).
+/// All other drivers are pure opt-in via `fl::enableDrivers<fl::Bus::X>()`
+/// or `FastLED.enableAllDrivers()`, which include the driver's `bus_traits.h`
+/// at the call site and ODR-link the TU. The auxiliary subdirs (`ble`,
+/// `gpio_isr_rx`, `rmt_rx`) are not channel drivers and stay unconditional.
 ///
 /// Unconditional aggregator structure (one include per subdir, alphabetical)
 /// is preserved to satisfy the unity-build linter.

--- a/src/platforms/esp/32/drivers/channel_manager_esp32.cpp.hpp
+++ b/src/platforms/esp/32/drivers/channel_manager_esp32.cpp.hpp
@@ -38,16 +38,6 @@
 #include "fl/channels/adapters/spi_channel_adapter.h"
 #include "fl/stl/noexcept.h"
 
-// FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY: when defined to 1, the legacy
-// `initChannelDrivers()` body becomes a no-op. Users opting in must call
-// `fl::enableDrivers<fl::Bus::X...>()` explicitly to register the drivers
-// they actually need -- this is the pathway that lets the linker drop unused
-// driver TUs (#2420 binary-bloat fix). Default is 0 for backward compatibility;
-// Phase 5b of #2428 will flip the default.
-#ifndef FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY
-#define FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY 0
-#endif
-
 // Platform detection for I2S/LCD_SPI drivers
 #include "platforms/esp/is_esp.h"
 
@@ -338,41 +328,16 @@ static void addI2sIfPossible(ChannelManager& manager) FL_NOEXCEPT {
 
 namespace platforms {
 
-/// @brief Initialize channel drivers for ESP32
+/// @brief Initialize channel drivers for ESP32 (no-op, post-#2428).
 ///
-/// Called lazily on first access to ChannelManager::instance().
-/// Registers platform-specific drivers (PARLIO, SPI, UART, RMT) with the bus manager.
-///
-/// Defining `FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY=1` disables this auto-init.
-/// Users opting in must call `fl::enableDrivers<fl::Bus::X...>()` explicitly to
-/// register only the drivers they need -- this is the pathway that lets the
-/// linker drop unused driver TUs (#2420 binary-bloat fix). Phase 5b of #2428
-/// will flip the default; this commit (Phase 5a) just adds the opt-in.
+/// Drivers do NOT auto-register with `ChannelManager`. Only the
+/// platform-default driver TU (named by the legacy clockless controller's
+/// Phase 5b pre-bind via `BusTraits<DefaultBus<Chipset>>::instancePtr()`)
+/// links into the binary. Users who need additional drivers at runtime call
+/// `fl::enableDrivers<fl::Bus::X, ...>()` or `FastLED.enableAllDrivers()`.
 void initChannelDrivers() FL_NOEXCEPT {
-#if FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY
-    // Opt-in mode: skip auto-registration entirely. Users must call
-    // fl::enableDrivers<fl::Bus::X, ...>() to register the drivers they need.
-    FL_DBG("ESP32: Legacy driver auto-init disabled (FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY=1)");
-#else
-    FL_DBG("ESP32: Lazy initialization of channel drivers");
-
-    auto& manager = channelManager();
-
-    // Add drivers in priority order (each function handles platform-specific ifdefs)
-    // CRITICAL: Native SPI drivers (priority 10) registered first, then HW SPI fallback
-    detail::addI2sSpiIfPossible(manager);       // Priority 10 (native I2S parallel SPI, ESP32dev)
-    detail::addLcdSpiIfPossible(manager);       // Priority 10 (native LCD_CAM SPI, ESP32-S3)
-    detail::addSpiHardwareIfPossible(manager);  // Priority 5-9 (unified, true SPI fallback)
-    detail::addParlioIfPossible(manager);       // Priority 4 (clockless)
-    detail::addLcdRgbIfPossible(manager);       // Priority 3 (clockless)
-    detail::addSpiIfPossible(manager);          // Priority 0 (clockless-over-SPI)
-    detail::addUartIfPossible(manager);         // Priority -1 (clockless)
-    detail::addRmtIfPossible(manager);          // Priority 2 (clockless)
-    detail::addLcdClocklessIfPossible(manager); // Priority 1 (clockless, ESP32-S3, replaces misnamed I2S)
-    detail::addI2sIfPossible(manager);          // Priority 1 (clockless, legacy I2S name)
-
-    FL_DBG("ESP32: Channel drivers initialized");
-#endif  // !FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY
+    // Intentionally empty. See `fl::enableDrivers<>()` / `enableAllDrivers()`
+    // for the opt-in registration path.
 }
 
 } // namespace platforms

--- a/src/platforms/esp/32/drivers/i2s/_build.cpp.hpp
+++ b/src/platforms/esp/32/drivers/i2s/_build.cpp.hpp
@@ -2,16 +2,13 @@
 
 /// @file _build.hpp
 /// @brief Unity build header for platforms\esp\32\drivers\i2s/ directory
-/// Includes all implementation files in alphabetical order
 ///
-/// Phase 5c of #2428: I2S is never a platform default (LCD_CAM clockless on
-/// ESP32-S3 is a niche / experimental driver). When the user opts in to
-/// `FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY=1`, this TU becomes empty and the
-/// I2S driver is dropped from the binary.
-
-#include "fl/channels/bus.h"  // brings in FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY
-
-#if !FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY
+/// I2S (LCD_CAM clockless on ESP32-S3) is never a platform default. Post-#2428
+/// the driver impl is always compiled here so that
+/// `fl::enableDrivers<fl::Bus::I2S>()` / `FastLED.enableAllDrivers()` /
+/// `FastLED.setExclusiveDriver<fl::Bus::I2S>()` have the symbols they need to
+/// link. Default builds don't ODR-use any symbol from this driver, so
+/// `--gc-sections` strips the whole TU.
 
 #include "platforms/esp/32/drivers/i2s/channel_driver_i2s.cpp.hpp"
 #include "platforms/esp/32/drivers/i2s/clockless_i2s_esp32.cpp.hpp"
@@ -24,5 +21,3 @@
 
 // BusTraits<Bus::I2S> specialization.
 #include "platforms/esp/32/drivers/i2s/bus_traits.h"
-
-#endif  // !FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY

--- a/src/platforms/esp/32/drivers/i2s_spi/_build.cpp.hpp
+++ b/src/platforms/esp/32/drivers/i2s_spi/_build.cpp.hpp
@@ -3,16 +3,13 @@
 /// @file _build.hpp
 /// @brief Unity build header for platforms\esp\32\drivers\i2s_spi/ directory
 ///
-/// Phase 5c of #2428: I2S_SPI is the platform-default true-SPI driver on
-/// ESP32dev (original ESP32). On dev the driver TU is always compiled
-/// (legacy `addLeds<APA102, ...>` pre-binds to it). On all other ESP32
-/// variants I2S_SPI is an alternate driver, gated by
-/// `FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY`.
-
-#include "fl/channels/bus.h"  // brings in FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY
-#include "platforms/is_platform.h"
-
-#if !FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY || defined(FL_IS_ESP_32DEV)
+/// I2S_SPI is the platform-default true-SPI driver on ESP32dev (original
+/// ESP32). On dev the legacy `addLeds<APA102>` path pre-binds to
+/// `BusTraits<Bus::I2S_SPI>::instancePtr()` which links this TU. The impl
+/// files self-gate on the appropriate hardware / mock macros, so we include
+/// them unconditionally here (host unit tests rely on the mock peripheral
+/// being available) and let `--gc-sections` strip the unused TU on
+/// platforms that don't ODR-use the singleton.
 
 #include "platforms/esp/32/drivers/i2s_spi/channel_driver_i2s_spi.cpp.hpp"
 #include "platforms/esp/32/drivers/i2s_spi/i2s_spi_peripheral_esp.cpp.hpp"
@@ -20,5 +17,3 @@
 
 // BusTraits<Bus::I2S_SPI> specialization.
 #include "platforms/esp/32/drivers/i2s_spi/bus_traits.h"
-
-#endif  // legacy mode OR ESP32dev (default I2S_SPI platform)

--- a/src/platforms/esp/32/drivers/lcd_cam/_build.cpp.hpp
+++ b/src/platforms/esp/32/drivers/lcd_cam/_build.cpp.hpp
@@ -2,15 +2,12 @@
 
 /// @file _build.hpp
 /// @brief Unity build header for platforms\esp\32\drivers\lcd_cam/ directory
-/// Includes all implementation files in alphabetical order
 ///
-/// Phase 5c of #2428: LCD_RGB is never a platform default. When the user
-/// opts in to `FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY=1`, this TU becomes
-/// empty and the LCD_RGB driver is dropped from the binary.
-
-#include "fl/channels/bus.h"  // brings in FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY
-
-#if !FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY
+/// LCD_RGB is never a platform default. Post-#2428 the driver impl is always
+/// compiled here so that `fl::enableDrivers<fl::Bus::LCD_RGB>()` /
+/// `FastLED.enableAllDrivers()` / `FastLED.setExclusiveDriver<fl::Bus::LCD_RGB>()`
+/// have the symbols they need to link. Default builds don't ODR-use any
+/// symbol from this driver, so `--gc-sections` strips the whole TU.
 
 #include "platforms/esp/32/drivers/lcd_cam/channel_driver_lcd_rgb.cpp.hpp"
 #include "platforms/esp/32/drivers/lcd_cam/lcd_rgb_peripheral_esp.cpp.hpp"
@@ -18,5 +15,3 @@
 
 // BusTraits<Bus::LCD_RGB> specialization.
 #include "platforms/esp/32/drivers/lcd_cam/bus_traits.h"
-
-#endif  // !FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY

--- a/src/platforms/esp/32/drivers/lcd_spi/_build.cpp.hpp
+++ b/src/platforms/esp/32/drivers/lcd_spi/_build.cpp.hpp
@@ -3,16 +3,13 @@
 /// @file _build.hpp
 /// @brief Unity build header for platforms\esp\32\drivers\lcd_spi/ directory
 ///
-/// Phase 5c of #2428: LCD_SPI is the platform-default true-SPI driver on
-/// ESP32-S3. On S3 the driver TU is always compiled (legacy
-/// `addLeds<APA102, ...>` pre-binds to it). On all other ESP32 variants
-/// LCD_SPI is an alternate driver, gated by
-/// `FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY`.
-
-#include "fl/channels/bus.h"  // brings in FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY
-#include "platforms/is_platform.h"
-
-#if !FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY || defined(FL_IS_ESP_32S3)
+/// LCD_SPI / LCD_CLOCKLESS use the LCD_CAM peripheral and are the platform
+/// default true-SPI drivers on ESP32-S3. On S3 the legacy `addLeds<APA102>`
+/// path pre-binds to `BusTraits<Bus::LCD_SPI>::instancePtr()` which links
+/// this TU. The impl files self-gate on the appropriate hardware / mock
+/// macros, so we include them unconditionally here (host unit tests rely on
+/// the mock peripheral being available) and let `--gc-sections` strip the
+/// unused TU on platforms that don't ODR-use the singleton.
 
 #include "platforms/esp/32/drivers/lcd_spi/channel_driver_lcd_clockless.cpp.hpp"
 #include "platforms/esp/32/drivers/lcd_spi/channel_driver_lcd_spi.cpp.hpp"
@@ -21,5 +18,3 @@
 
 // BusTraits<Bus::LCD_SPI> + BusTraits<Bus::LCD_CLOCKLESS> specializations.
 #include "platforms/esp/32/drivers/lcd_spi/bus_traits.h"
-
-#endif  // legacy mode OR ESP32-S3 (default LCD_SPI platform)

--- a/src/platforms/esp/32/drivers/parlio/_build.cpp.hpp
+++ b/src/platforms/esp/32/drivers/parlio/_build.cpp.hpp
@@ -2,20 +2,16 @@
 
 /// @file _build.hpp
 /// @brief Unity build header for platforms\esp\32\drivers\parlio/ directory
-/// Includes all implementation files in alphabetical order
 ///
-/// Phase 5c of #2428: PARLIO is the platform-default clockless driver on
-/// ESP32-P4 / C6 / H2 / C5. On those variants the driver TU is always
-/// compiled (legacy `addLeds<NEOPIXEL>` pre-binds to it). On all other
-/// ESP32 variants PARLIO is an alternate driver, gated by
-/// `FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY`.
-
-#include "fl/channels/bus.h"  // brings in FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY
-#include "platforms/is_platform.h"
-
-#if !FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY || \
-    defined(FL_IS_ESP_32P4) || defined(FL_IS_ESP_32C6) || \
-    defined(FL_IS_ESP_32H2) || defined(FL_IS_ESP_32C5)
+/// PARLIO is the platform-default clockless driver on ESP32-P4 / C6 / H2 / C5.
+/// On those variants the legacy clockless controller pre-binds to
+/// `BusTraits<Bus::PARLIO>::instancePtr()` which links this TU. On other
+/// platforms (including host unit tests) the driver impl is also compiled --
+/// the impl files self-gate on the appropriate hardware / mock macros, and
+/// `--gc-sections` strips the unused driver TU when nothing ODR-uses the
+/// singleton. The mock-peripheral file in particular must stay in the host
+/// build so `cleanup_parlio_mock()` (called from `tests/doctest_main.cpp`)
+/// has a definition.
 
 #include "platforms/esp/32/drivers/parlio/channel_driver_parlio.cpp.hpp"
 #include "platforms/esp/32/drivers/parlio/parlio_engine.cpp.hpp"
@@ -24,5 +20,3 @@
 
 // BusTraits<Bus::PARLIO> specialization.
 #include "platforms/esp/32/drivers/parlio/bus_traits.h"
-
-#endif  // legacy mode OR PARLIO-default platform

--- a/src/platforms/esp/32/drivers/rmt/_build.cpp.hpp
+++ b/src/platforms/esp/32/drivers/rmt/_build.cpp.hpp
@@ -4,21 +4,14 @@
 /// @brief Unity build header for platforms/esp/32/drivers/rmt/ directory
 /// Includes all RMT driver implementations
 ///
-/// Phase 5c of #2428: RMT is the platform-default clockless driver on every
-/// ESP32 variant EXCEPT P4 / C6 / H2 / C5 (which default to PARLIO). On
-/// RMT-default platforms this TU is always compiled (legacy
-/// `addLeds<NEOPIXEL>` pre-binds to it). On PARLIO-default platforms RMT
-/// is an alternate driver, gated by `FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY`.
-
-#include "fl/channels/bus.h"  // brings in FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY
-#include "platforms/is_platform.h"
-
-#if !FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY || \
-    !(defined(FL_IS_ESP_32P4) || defined(FL_IS_ESP_32C6) || \
-      defined(FL_IS_ESP_32H2) || defined(FL_IS_ESP_32C5))
+/// RMT is the platform-default clockless driver on every ESP32 variant
+/// EXCEPT P4 / C6 / H2 / C5 (which lack RMT hardware and default to PARLIO).
+/// The legacy clockless controller pre-binds to
+/// `BusTraits<Bus::RMT>::instancePtr()` which links this TU on platforms
+/// where RMT exists. The rmt_4 / rmt_5 sub-aggregators select the correct
+/// impl based on `FASTLED_RMT5` / `FASTLED_ESP32_HAS_RMT`; nothing compiles
+/// on platforms without RMT hardware.
 
 // begin sub directory includes
 #include "platforms/esp/32/drivers/rmt/rmt_4/_build.cpp.hpp"
 #include "platforms/esp/32/drivers/rmt/rmt_5/_build.cpp.hpp"
-
-#endif  // legacy mode OR RMT-default platform

--- a/src/platforms/esp/32/drivers/rmt/rmt_4/idf4_clockless_rmt_esp32.h
+++ b/src/platforms/esp/32/drivers/rmt/rmt_4/idf4_clockless_rmt_esp32.h
@@ -108,17 +108,12 @@ protected:
     }
 
     static fl::shared_ptr<IChannelDriver> getRmtEngine() FL_NOEXCEPT {
-#if FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY
-        // Phase 5c of #2428 (opt-in mode): bypass `ChannelManager` and bind
-        // directly to the `BusTraits<Bus::RMT>` singleton. Naming
+        // Phase 5c of #2428: bypass `ChannelManager` and bind directly to
+        // the `BusTraits<Bus::RMT>` singleton. Naming
         // `BusTraits<Bus::RMT>::instancePtr()` here is the ODR-use that
-        // lets the linker keep ONLY the RMT4 driver TU when the user opts
-        // into `FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY=1` -- the
-        // binary-size fix from #2420.
+        // lets the linker keep ONLY the RMT4 driver TU -- post-#2428 the
+        // ChannelManager-driven registry path is gone.
         return BusTraits<Bus::RMT>::instancePtr();
-#else
-        return ChannelManager::instance().getDriverByName("RMT");
-#endif
     }
 
 };

--- a/src/platforms/esp/32/drivers/rmt/rmt_5/idf5_clockless.h
+++ b/src/platforms/esp/32/drivers/rmt/rmt_5/idf5_clockless.h
@@ -33,19 +33,13 @@ public:
     ClocklessIdf5() FL_NOEXCEPT
         : Channel(makeChipset(), RGB_ORDER, RegistrationMode::DeferRegister)
     {
-#if FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY
-        // Phase 5b of #2428 (opt-in mode): pre-bind to the RMT5 driver
-        // singleton so showPixels() bypasses ChannelManager entirely.
-        // Naming BusTraits<Bus::RMT>::instancePtr() here is the ODR-use
-        // that lets the linker keep ONLY the RMT5 driver TU when the user
-        // opts into FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY=1 -- the
-        // binary-size fix from #2420.
-        // Default mode (macro 0) leaves mDriver unbound so the existing
-        // selectDriverForChannel() path runs each frame -- preserves
-        // backward compat for users registering custom drivers via
-        // ChannelManager.
+        // Phase 5b of #2428: pre-bind to the RMT5 driver singleton so
+        // showPixels() bypasses ChannelManager entirely. Naming
+        // BusTraits<Bus::RMT>::instancePtr() here is the ODR-use that lets
+        // the linker keep ONLY the RMT5 driver TU -- post-#2428 drivers
+        // do not auto-register, so this pre-bind is what links the RMT
+        // singleton on platforms where RMT is the default.
         setDriver(BusTraits<Bus::RMT>::instancePtr());
-#endif
         // Auto-register in the controller draw list (template API expects this)
         addToList();
     }

--- a/src/platforms/esp/32/drivers/spi/_build.cpp.hpp
+++ b/src/platforms/esp/32/drivers/spi/_build.cpp.hpp
@@ -2,20 +2,17 @@
 
 /// @file _build.hpp
 /// @brief Unity build header for platforms\esp\32\drivers\spi/ directory
-/// Includes all implementation files in alphabetical order
 ///
-/// Phase 5c of #2428: the clockless-over-SPI driver is never a platform
-/// default. When the user opts in to `FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY=1`,
-/// this TU becomes empty and the SPI clockless driver is dropped from the
-/// binary.
+/// `Bus::SPI` is the *clockless-over-SPI* driver (WS2812 etc. over the SPI
+/// peripheral, using wave8 encoding). It is never a platform default
+/// (true-SPI chipsets like APA102 / SK9822 / HD108 go through `Bus::I2S_SPI`
+/// on ESP32dev or `Bus::LCD_SPI` on ESP32-S3 instead).
 ///
-/// NOTE: This is `Bus::SPI`, the *clockless* SPI driver (WS2812 etc. over the
-/// SPI peripheral). True-SPI chipsets (APA102, SK9822, HD108) go through
-/// `Bus::I2S_SPI` on ESP32dev or `Bus::LCD_SPI` on ESP32-S3.
-
-#include "fl/channels/bus.h"  // brings in FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY
-
-#if !FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY
+/// Post-#2428 the driver impl is always compiled here so that
+/// `fl::enableDrivers<fl::Bus::SPI>()` / `FastLED.enableAllDrivers()` /
+/// `FastLED.setExclusiveDriver<fl::Bus::SPI>()` have the symbols they need
+/// to link. Default builds don't ODR-use any symbol from this driver, so
+/// `--gc-sections` strips the whole TU.
 
 #include "platforms/esp/32/drivers/spi/channel_driver_spi.cpp.hpp"
 #include "platforms/esp/32/drivers/spi/spi_esp32_init.cpp.hpp"
@@ -25,5 +22,3 @@
 
 // BusTraits<Bus::SPI> specialization.
 #include "platforms/esp/32/drivers/spi/bus_traits.h"
-
-#endif  // !FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY

--- a/src/platforms/esp/32/drivers/spi/idf5_clockless_spi_esp32.h
+++ b/src/platforms/esp/32/drivers/spi/idf5_clockless_spi_esp32.h
@@ -83,17 +83,12 @@ protected:
     }
 
     static fl::shared_ptr<IChannelDriver> getClocklessSpiEngine() FL_NOEXCEPT {
-#if FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY
-        // Phase 5c of #2428 (opt-in mode): bypass `ChannelManager` and bind
-        // directly to the `BusTraits<Bus::SPI>` singleton. Naming
+        // Phase 5c of #2428: bypass `ChannelManager` and bind directly to
+        // the `BusTraits<Bus::SPI>` singleton. Naming
         // `BusTraits<Bus::SPI>::instancePtr()` here is the ODR-use that
-        // lets the linker keep ONLY the SPI clockless driver TU when the
-        // user opts into `FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY=1` -- the
-        // binary-size fix from #2420.
+        // lets the linker keep ONLY the SPI clockless driver TU -- post-#2428
+        // the ChannelManager-driven registry path is gone.
         return BusTraits<Bus::SPI>::instancePtr();
-#else
-        return ChannelManager::instance().getDriverByName("SPI");
-#endif
     }
 };
 }  // namespace fl

--- a/src/platforms/esp/32/drivers/uart/_build.cpp.hpp
+++ b/src/platforms/esp/32/drivers/uart/_build.cpp.hpp
@@ -2,15 +2,12 @@
 
 /// @file _build.hpp
 /// @brief Unity build header for platforms\esp\32\drivers\uart/ directory
-/// Includes all implementation files in alphabetical order
 ///
-/// Phase 5c of #2428: UART is never a platform default. When the user opts
-/// in to `FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY=1`, this TU becomes empty
-/// and the UART driver is dropped from the binary.
-
-#include "fl/channels/bus.h"  // brings in FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY
-
-#if !FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY
+/// UART is never a platform default. Post-#2428 the driver impl is always
+/// compiled here so that `fl::enableDrivers<fl::Bus::UART>()` /
+/// `FastLED.enableAllDrivers()` / `FastLED.setExclusiveDriver<fl::Bus::UART>()`
+/// have the symbols they need to link. Default builds don't ODR-use any
+/// symbol from this driver, so `--gc-sections` strips the whole TU.
 
 #include "platforms/esp/32/drivers/uart/channel_driver_uart.cpp.hpp"
 #include "platforms/esp/32/drivers/uart/uart_peripheral_esp.cpp.hpp"
@@ -18,5 +15,3 @@
 
 // BusTraits<Bus::UART> specialization.
 #include "platforms/esp/32/drivers/uart/bus_traits.h"
-
-#endif  // !FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY

--- a/src/platforms/stub/clockless_channel_stub.h
+++ b/src/platforms/stub/clockless_channel_stub.h
@@ -51,16 +51,13 @@ public:
         // Create channel data with pin and timing configuration
         ChipsetTimingConfig timing = makeTimingConfig<TIMING>();
         mChannelData = ChannelData::create(DATA_PIN, timing);
-#if FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY
-        // Phase 5b of #2428 (opt-in mode): pre-bind to the stub driver
-        // singleton so showPixels() bypasses ChannelManager entirely.
-        // Naming BusTraits<Bus::STUB>::instancePtr() here is the ODR-use
-        // that lets the linker keep ONLY the stub driver TU.
-        // Default mode (macro 0) leaves mDriver unbound so the existing
-        // selectDriverForChannel() path runs each frame -- preserves
-        // backward compat for tests that register custom mock drivers.
+        // Phase 5b of #2428: pre-bind to the stub driver singleton so
+        // showPixels() bypasses ChannelManager entirely. Naming
+        // BusTraits<Bus::STUB>::instancePtr() here is the ODR-use that
+        // lets the linker keep ONLY the stub driver TU -- post-#2428
+        // drivers do not auto-register, so this pre-bind is what links
+        // the stub singleton.
         mDriver = BusTraits<Bus::STUB>::instancePtr();
-#endif
     }
 
     virtual void init() FL_NOEXCEPT override { }
@@ -68,19 +65,15 @@ public:
 protected:
     virtual void showPixels(PixelController<RGB_ORDER>& pixels) FL_NOEXCEPT override
     {
-        // Get driver (lock weak_ptr to shared_ptr)
+        // Phase 5b of #2428: use the pre-bound driver directly. Legacy
+        // `addLeds<>`-style controllers name `BusTraits<Bus::STUB>::instancePtr()`
+        // in their constructor so this is the platform-default stub driver.
+        // For runtime overrides, sketches use `FastLED.add(cfg)` (Channel API)
+        // with `cfg.options.mBus` -- the manager-driven Channel path stays.
         fl::shared_ptr<IChannelDriver> driver = mDriver.lock();
-
-        // If driver is null/expired, select one from ChannelManager
         if (!driver) {
-            driver = ChannelManager::instance().selectDriverForChannel(mChannelData, fl::string());  // Empty affinity
-            if (driver) {
-                // Cache the selected driver as weak_ptr
-                mDriver = driver;
-            } else {
-                FL_ERROR("ClocklessController(stub): No compatible driver found - cannot transmit");
-                return;
-            }
+            FL_ERROR("ClocklessController(stub): No compatible driver found - cannot transmit");
+            return;
         }
 
         // Wait for previous transmission to complete and release buffer

--- a/src/platforms/stub/init_channel_driver.h
+++ b/src/platforms/stub/init_channel_driver.h
@@ -15,34 +15,16 @@
 #include "platforms/stub/clockless_channel_engine_stub.h"
 #include "fl/stl/noexcept.h"
 
-// FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY: when defined to 1, this stub auto-init
-// is a no-op. Users opting in must call `fl::enableDrivers<fl::Bus::STUB>()`
-// explicitly. Default 0 for backward compatibility. See #2428 Phase 5.
-#ifndef FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY
-#define FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY 0
-#endif
-
 namespace fl {
 namespace platforms {
 
-/// @brief Initialize channel drivers for stub platform
+/// @brief Initialize channel drivers for stub platform (no-op).
 ///
-/// Registers ClocklessChannelEngineStub with the ChannelManager so that
-/// the FastLED.add() API (Channel objects) drives stub GPIO simulation and
-/// fires SimEdgeObserver callbacks that NativeRxDevice uses for validation.
-///
-/// Delegates to `BusTraits<Bus::STUB>::instancePtr()` so the singleton is
-/// shared with the new `fl::enableDrivers<Bus::STUB>()` API. Phase 5b will
-/// flip the default of `FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY` to 1.
+/// Post-#2428 the stub platform does not auto-register any driver with
+/// `ChannelManager`. Tests that need the stub driver call
+/// `fl::enableDrivers<Bus::STUB>()` or `FastLED.enableAllDrivers()` directly.
 inline void initChannelDrivers() FL_NOEXCEPT {
-#if FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY
-    // Opt-in mode: skip auto-registration. Users call enableDrivers<Bus::STUB>().
-#else
-    fl::ChannelManager& manager = fl::ChannelManager::instance();
-    // Priority 1 > 0 (the no-op StubChannelDriver registered elsewhere),
-    // so this driver is preferred for clockless channels on the stub platform.
-    manager.addDriver(1, BusTraits<Bus::STUB>::instancePtr());
-#endif  // !FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY
+    // No auto-registration. See `fl::enableDrivers<Bus::STUB>()` for opt-in.
 }
 
 }  // namespace platforms

--- a/src/platforms/stub/spi_channel_stub.h
+++ b/src/platforms/stub/spi_channel_stub.h
@@ -84,14 +84,11 @@ protected:
     }
 
     static fl::shared_ptr<IChannelDriver> getStubSpiEngine() FL_NOEXCEPT {
-#if FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY
-        // Phase 5c of #2428 (opt-in mode): bypass `ChannelManager` and bind
-        // directly to the `BusTraits<Bus::STUB>` singleton -- stub builds
-        // route every clockless/SPI chipset through the same no-op driver.
+        // Phase 5c of #2428: bypass `ChannelManager` and bind directly to
+        // the `BusTraits<Bus::STUB>` singleton. Stub builds route every
+        // clockless/SPI chipset through the same no-op driver. Naming the
+        // singleton here ODR-links the stub driver TU.
         return BusTraits<Bus::STUB>::instancePtr();
-#else
-        return ChannelManager::instance().getDriverByName("SPI");
-#endif
     }
 };
 

--- a/src/platforms/wasm/clockless_channel_wasm.h
+++ b/src/platforms/wasm/clockless_channel_wasm.h
@@ -96,14 +96,11 @@ protected:
     }
 
     static fl::shared_ptr<IChannelDriver> getWasmEngine() FL_NOEXCEPT {
-#if FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY
-        // Phase 5c of #2428 (opt-in mode): bypass `ChannelManager` and bind
-        // directly to the `BusTraits<Bus::STUB>` singleton -- the stub
-        // driver is the platform default for both stub and WASM builds.
+        // Phase 5c of #2428: bypass `ChannelManager` and bind directly to
+        // the `BusTraits<Bus::STUB>` singleton -- the stub driver is the
+        // platform default for both stub and WASM builds. Naming the
+        // singleton here ODR-links the stub driver TU.
         return BusTraits<Bus::STUB>::instancePtr();
-#else
-        return ChannelManager::instance().getDriverByName("STUB");
-#endif
     }
 };
 

--- a/src/platforms/wasm/spi_channel_wasm.h
+++ b/src/platforms/wasm/spi_channel_wasm.h
@@ -79,15 +79,11 @@ protected:
     }
 
     static fl::shared_ptr<IChannelDriver> getWasmSpiEngine() FL_NOEXCEPT {
-#if FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY
-        // Phase 5c of #2428 (opt-in mode): bypass `ChannelManager` and bind
-        // directly to the `BusTraits<Bus::STUB>` singleton. WASM uses the
-        // stub driver for both clockless and SPI chipsets (no real
-        // hardware in the browser).
+        // Phase 5c of #2428: bypass `ChannelManager` and bind directly to
+        // the `BusTraits<Bus::STUB>` singleton. WASM uses the stub driver
+        // for both clockless and SPI chipsets (no real hardware in the
+        // browser). Naming the singleton here ODR-links the stub driver TU.
         return BusTraits<Bus::STUB>::instancePtr();
-#else
-        return ChannelManager::instance().getDriverByName("SPI");
-#endif
     }
 };
 

--- a/tests/doctest_main.cpp
+++ b/tests/doctest_main.cpp
@@ -46,6 +46,7 @@ FL_DISABLE_WARNING_POP
 
 #include "platforms/stub/coroutine_stub.h"  // for cleanup_coroutine_threads(), CoroutineRunner
 #include "platforms/esp/32/drivers/parlio/parlio_peripheral_mock.h"
+#include "fl/channels/all_drivers.h"     // for fl::enableAllDrivers() (post-#2428)
 #include "fl/stl/cstdlib.h"
 #include "fl/stl/shared_ptr.h"
 #include "fl/system/engine_events.h"
@@ -81,6 +82,13 @@ int fl_run_tests(int argc, const char** argv) {
     std::cout << "Pre-initializing CoroutineRunner singleton" << std::endl;
     fl::detail::CoroutineRunner::instance();
     std::cout << "CoroutineRunner singleton pre-initialized successfully" << std::endl;
+
+    // Post-#2428: the channel driver registry no longer auto-populates.
+    // Enable every platform-available driver so legacy `FastLED.addLeds<>()`
+    // AND Channel API `FastLED.add(cfg)` paths both have a driver to dispatch
+    // to on host. Tests that need stricter isolation can call
+    // `manager.clearAllDrivers()` followed by their own `enableDrivers<>()`.
+    fl::enableAllDrivers();
 
     // Run fl_unittest test framework
     fl::test::RunOptions opts = fl::test::parse_args(argc, (const char**)argv);

--- a/tests/fastled_core.cpp
+++ b/tests/fastled_core.cpp
@@ -411,12 +411,19 @@ FL_TEST_CASE("Channel API: Internal ChannelPtr storage prevents dangling") {
     manager.setDriverEnabled("MOCK_STORAGE", false);
 }
 
-FL_TEST_CASE("Legacy API: 4 parallel strips using FastLED.addLeds<>()") {
-    // This test validates that the legacy FastLED.addLeds<>() API works with channel drivers:
-    // - Use template-based FastLED.addLeds<WS2812, PIN>() (no explicit channel creation)
-    // - Set different colors on each strip
-    // - Call FastLED.show()
-    // - Verify driver received all 4 strips with correct data
+FL_TEST_CASE("Channel API: 4 parallel strips via FastLED.add() routes through mock driver") {
+    // Post-#2428 architecture: legacy `FastLED.addLeds<>()` pre-binds to the
+    // platform-default driver (Phase 5b) and bypasses `ChannelManager`, so the
+    // way to route runtime traffic through a custom mock driver is the
+    // explicit Channel API: `FastLED.add(cfg)`. Each `Channel` registered via
+    // that path consults the manager on every show() and picks the highest-
+    // priority driver that `canHandle` the channel data.
+    //
+    // This test validates that workflow with 4 parallel strips:
+    // - Register a mock driver with the manager at high priority
+    // - Create 4 channels via `FastLED.add(ChannelConfig)`
+    // - Call `FastLED.show()`
+    // - Verify the mock received all 4 strips
 
     auto mockEngine = fl::make_shared<ChannelEngineMock>("MOCK_LEGACY");
     mockEngine->reset();
@@ -430,7 +437,6 @@ FL_TEST_CASE("Legacy API: 4 parallel strips using FastLED.addLeds<>()") {
     FL_REQUIRE(registeredEngine != nullptr);
     FL_CHECK(registeredEngine.get() == mockEngine.get());
 
-    // Create 4 LED strips using legacy template API (no affinity, no explicit channel)
     #define NUM_LEDS 60
     #define PIN1 16
     #define PIN2 17
@@ -442,41 +448,34 @@ FL_TEST_CASE("Legacy API: 4 parallel strips using FastLED.addLeds<>()") {
     static CRGB strip3[NUM_LEDS];
     static CRGB strip4[NUM_LEDS];
 
-    // Use legacy API - should automatically use highest priority driver (our mock)
-    FastLED.addLeds<WS2812, PIN1>(strip1, NUM_LEDS);
-    FastLED.addLeds<WS2812, PIN2>(strip2, NUM_LEDS);
-    FastLED.addLeds<WS2812, PIN3>(strip3, NUM_LEDS);
-    FastLED.addLeds<WS2812, PIN4>(strip4, NUM_LEDS);
+    // Channel API: 4 channels routed through the manager.
+    auto timing = fl::makeTimingConfig<fl::TIMING_WS2812_800KHZ>();
+    auto ch1 = FastLED.add(fl::ChannelConfig(PIN1, timing, fl::span<CRGB>(strip1, NUM_LEDS), RGB));
+    auto ch2 = FastLED.add(fl::ChannelConfig(PIN2, timing, fl::span<CRGB>(strip2, NUM_LEDS), RGB));
+    auto ch3 = FastLED.add(fl::ChannelConfig(PIN3, timing, fl::span<CRGB>(strip3, NUM_LEDS), RGB));
+    auto ch4 = FastLED.add(fl::ChannelConfig(PIN4, timing, fl::span<CRGB>(strip4, NUM_LEDS), RGB));
 
-    // Set different colors on each strip (from README example)
     fl::fill_solid(strip1, NUM_LEDS, CRGB::Red);
     fl::fill_solid(strip2, NUM_LEDS, CRGB::Green);
     fl::fill_solid(strip3, NUM_LEDS, CRGB::Blue);
     fl::fill_solid(strip4, NUM_LEDS, CRGB::Yellow);
 
-    // Reset mock counters before show
     mockEngine->reset();
-
-    // Call FastLED.show() - should enqueue all 4 strips
     FastLED.show();
 
-    // Verify driver received all 4 strips
     FL_CHECK(mockEngine->mEnqueueCount == 4);
     FL_CHECK(mockEngine->mShowCount == 1);
     FL_CHECK(mockEngine->mEnqueuedChannels.size() == 0);  // Cleared by show()
 
-    // Verify the channels have the correct data (spot check first LED of each strip)
     FL_CHECK(strip1[0] == CRGB::Red);
     FL_CHECK(strip2[0] == CRGB::Green);
     FL_CHECK(strip3[0] == CRGB::Blue);
     FL_CHECK(strip4[0] == CRGB::Yellow);
 
-    // Verify all LEDs in strip1 are red
     for (int i = 0; i < NUM_LEDS; i++) {
         FL_CHECK(strip1[i] == CRGB::Red);
     }
 
-    // Test second frame with different pattern (rainbow effect from README)
     mockEngine->reset();
     static uint8_t hue = 0;
     for(int i = 0; i < NUM_LEDS; i++) {
@@ -485,15 +484,15 @@ FL_TEST_CASE("Legacy API: 4 parallel strips using FastLED.addLeds<>()") {
         strip3[i] = CHSV(hue + (i * 4) + 128, 255, 255);
         strip4[i] = CHSV(hue + (i * 4) + 192, 255, 255);
     }
-
     FastLED.show();
 
-    // Verify driver received all 4 strips again
     FL_CHECK(mockEngine->mEnqueueCount == 4);
     FL_CHECK(mockEngine->mShowCount == 1);
 
-    // Cleanup - clear all controllers (legacy API doesn't return handles)
-    FastLED.clear(true);  // Clear and deallocate
+    FastLED.remove(ch1);
+    FastLED.remove(ch2);
+    FastLED.remove(ch3);
+    FastLED.remove(ch4);
     manager.removeDriver(mockEngine);
 
     #undef NUM_LEDS

--- a/tests/platforms/shared/active_strip_data/active_strip_data.cpp
+++ b/tests/platforms/shared/active_strip_data/active_strip_data.cpp
@@ -8,18 +8,18 @@
 
 #include "test.h"
 #include "FastLED.h"
+#include "platforms/stub/bus_traits.h"  // for BusTraits<Bus::STUB>
 #include "platforms/shared/active_strip_data/active_strip_data.h"
 #include "platforms/shared/active_strip_tracker/active_strip_tracker.h"
 
 using namespace fl;
 
-FL_TEST_CASE("Stub driver is registered") {
-    // Verify the stub driver is properly registered in ChannelManager
-    auto& manager = fl::ChannelManager::instance();
-    FL_CHECK_GT(manager.getDriverCount(), 0);
-
-    auto stubEngine = manager.getDriverByName("STUB");
-    FL_REQUIRE(stubEngine != nullptr);
+FL_TEST_CASE("Stub driver singleton is reachable") {
+    // Post-#2428 the stub driver is not auto-registered with the manager;
+    // legacy clockless controllers pre-bind to BusTraits<Bus::STUB>::instancePtr()
+    // directly. Verify the singleton is reachable (i.e. the driver TU linked).
+    auto stub = fl::BusTraits<fl::Bus::STUB>::instancePtr();
+    FL_REQUIRE(stub != nullptr);
 }
 
 FL_TEST_CASE("ClocklessController - Basic LED capture with single strip") {


### PR DESCRIPTION
## Summary

Removes `FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY` entirely. The previously **opt-in** "no driver auto-registration" mode is now the only mode. Drivers link only when their `BusTraits<Bus::X>::instance` is named at the call site.

This closes the binary-bloat half of #2421 (and #2420). The architectural choice that #2428 introduced for opt-in users is now the default behaviour for everyone.

Also re-templates `setExclusiveDriver` to take a `fl::Bus` template parameter:

```cpp
FastLED.setExclusiveDriver<fl::Bus::LCD_SPI>();  // links the LCD_SPI driver TU
                                                  // AND registers it above the platform default
```

The string form `setExclusiveDriver(const char*)` is kept as a test/mock helper.

## Empirical: ESP32-S3 stock Blink, no flags

| Build | `firmware.bin` | ChannelEngineRMT | ChannelEngineUART | ChannelDriverLcdSpi | ChannelDriverLcdClockless | ChannelEngineI2S | ChannelEngineSpi |
|---|---:|:---:|:---:|:---:|:---:|:---:|:---:|
| master | 776,624 | ✓ (3) | ✓ (24) | ✓ (13) | ✓ (13) | ✓ (22) | ✓ (75) |
| this PR | **657,008** | **✓ (3)** | — | — | — | — | ~3 (incidental) |

**119 KB recovered with zero source change or build flag.**

## New API surface

```cpp
// Compile-time bus pinning (legacy shape, #2465):
FastLED.addLeds<WS2812, 4, GRB, fl::Bus::RMT>(leds, n);

// Compile-time bus pinning (Channel API, #2451):
fl::TypedChannel<fl::Bus::RMT, fl::ClocklessChipset>::create(cfg);

// Runtime bus selection (#2459):
FastLED.add(cfg);                          // cfg.options.mBus drives dispatch
FastLED.add(fl::Bus::RMT, cfg);            // explicit overload (#2454)

// Driver enrollment:
fl::enableDrivers<fl::Bus::RMT, fl::Bus::PARLIO>();   // selective
FastLED.enableAllDrivers();                            // 3.10.3-style universal

// Single-driver override (NEW template form):
FastLED.setExclusiveDriver<fl::Bus::LCD_SPI>();        // link + register at high priority

// Test/mock helper (kept):
FastLED.setExclusiveDriver("MOCK_NAME");              // disable all others
```

## Files changed

- **`src/fl/channels/bus.h`** — macro definition removed.
- **`src/platforms/esp/32/drivers/channel_manager_esp32.cpp.hpp`** — duplicate guard removed; `initChannelDrivers()` collapsed to a no-op.
- **`src/platforms/esp/32/drivers/_build.cpp.hpp` + per-driver aggregators** — `#if !FASTLED_DISABLE_LEGACY_DRIVER_REGISTRY` gates removed; impl files now always compile so `enableDrivers<>` / `enableAllDrivers()` always link.
- **`src/platforms/esp/32/drivers/rmt/rmt_{4,5}/idf{4,5}_clockless_*.h`, `src/platforms/esp/32/drivers/spi/idf5_clockless_spi_esp32.h`** — Phase 5b pre-bind made unconditional.
- **`src/platforms/stub/*` + `src/platforms/wasm/*`** — same: pre-bind unconditional, init becomes no-op.
- **`src/fl/channels/manager.h` / `manager.cpp.hpp`** — new template `setExclusiveDriver<fl::Bus B>()`; string overload kept; `mExclusiveDriver` field removed (no longer needed).
- **`src/FastLED.h` / `FastLED.cpp.hpp`** — public template `FastLED.setExclusiveDriver<fl::Bus::X>()`; string forwarder kept.
- **`src/fl/channels/README.md`** — sweep of every macro reference + setExclusiveDriver example update.
- **`tests/doctest_main.cpp`** — calls `fl::enableAllDrivers()` at test-suite startup so existing manager-dispatch tests continue to work.
- **`tests/fastled_core.cpp`** — "Legacy API 4 parallel strips" test rewritten to use the Channel API (`FastLED.add(cfg)`). The legacy `addLeds<>` path now pre-binds to the platform default and bypasses the manager, so the mock-injection pattern only works via Channel API.
- **`tests/platforms/shared/active_strip_data/active_strip_data.cpp`** — probes `BusTraits<Bus::STUB>::instancePtr()` directly instead of expecting auto-registration.
- **`examples/AutoResearch/AutoResearch.ino`** — `FastLED.enableAllDrivers()` in `setup()` for the example's driver-enumeration flow.

## Risk

- **Source-breaking** for sketches that relied on the runtime mock pattern (`manager.addDriver(mock); FastLED.addLeds<...>(...); FastLED.show();` expecting `mock->enqueue()` to fire). Such sketches need to migrate to `FastLED.add(ChannelConfig{...})` (Channel API path stays manager-routed) or call `FastLED.enableAllDrivers()` plus `setExclusiveDriver("MOCK")` before `addLeds<>`. The legacy `addLeds<>` pre-binds to the platform-default driver and bypasses the manager — that's the binary-size win.
- **Setting `cfg.options.mBus = fl::Bus::X`** without `enableAllDrivers()` / `enableDrivers<X>()` first emits the one-shot miss diagnostic from #2455/#2460 and falls back to AUTO/priority. Behaviour unchanged from previous opt-in path; new in the default path.

## Test plan

- [x] `bash test --cpp`: 303 / 304 pass. The one failing test (`example-AutoResearch`) is **already failing on master** before this PR (verified by `git checkout master -- ...` + rerun). Not a regression introduced here.
- [x] `bash lint`: clean.
- [x] `bash compile uno --examples Blink --platformio`: passes (AVR C++11 path).
- [x] `bash compile esp32s3 --examples Blink --platformio`: passes; binary drops to **657 KB** vs master's 776 KB; symbol analysis confirms only RMT driver TU linked, all other ESP32-S3 driver TUs (UART / LCD_SPI / LCD_CLOCKLESS / I2S) absent.

## Related

- Closes binary-bloat half of #2421
- Refs #2428 (architecture parent)
- Builds on #2429, #2431, #2435, #2437, #2438, #2441, #2448, #2449, #2450, #2451, #2454, #2458, #2461, #2465

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added type-safe API FastLED.setExclusiveDriver<fl::Bus::X>() and explicit enableAllDrivers()/enableDrivers<> paths; drivers no longer auto-register.

* **Documentation**
  * Channel API docs updated with clearer driver registration and exclusive-selection ordering guidance.

* **Examples**
  * AutoResearch examples updated to enable drivers in setup and skip BIT_BANG during stub autorun.

* **Tests**
  * Unit tests revised to register drivers explicitly and validate the new registration model.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/FastLED/pull/2469)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->