### PR TITLE
refactor(channels): typed FastLED.setExclusiveDriver(fl::Bus) (#2471)

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,8 +244,9 @@ void loop() {
 > **Platform Support**: API is available on all platforms for code compatibility. Full functionality (multi-driver switching) is **ESP32-only**. Non-ESP32 platforms have safe no-op implementations.
 
 ```cpp
-// Force RMT driver exclusively (disables SPI, PARLIO, and future drivers)
-FastLED.setExclusiveDriver("RMT");
+// Force RMT driver exclusively (disables SPI, PARLIO, and future drivers).
+// Typed fl::Bus form — fl::Bus::RTM would be a compile error.
+FastLED.setExclusiveDriver(fl::Bus::RMT);
 
 // Or selectively enable/disable
 FastLED.setDriverEnabled("SPI", false);    // Disable SPI
@@ -863,8 +864,9 @@ All methods are accessed via the global `FastLED` object (ESP32 only):
 FastLED.setDriverEnabled("RMT", true);      // Enable RMT driver
 FastLED.setDriverEnabled("SPI", false);     // Disable SPI driver
 
-// Enable only one driver (disables all others, including future drivers)
-FastLED.setExclusiveDriver("RMT");          // Use only RMT
+// Enable only one driver (disables all others, including future drivers).
+// Typed: fl::Bus::RTM would be a compile error.
+FastLED.setExclusiveDriver(fl::Bus::RMT);   // Use only RMT
 
 // Query driver state
 bool rmtEnabled = FastLED.isDriverEnabled("RMT");
@@ -887,7 +889,7 @@ for (const auto& driver : drivers) {
 ```cpp
 void setup() {
     // Test with only RMT to isolate driver issues
-    FastLED.setExclusiveDriver("RMT");
+    FastLED.setExclusiveDriver(fl::Bus::RMT);
     FastLED.addLeds<WS2812, PIN, GRB>(leds, NUM_LEDS);
 }
 ```
@@ -906,10 +908,10 @@ void setup() {
 void loop() {
     if (WiFi.status() == WL_CONNECTED) {
         // Use RMT when Wi-Fi is active (more interrupt-tolerant)
-        FastLED.setExclusiveDriver("RMT");
+        FastLED.setExclusiveDriver(fl::Bus::RMT);
     } else {
         // Use faster SPI when Wi-Fi is off
-        FastLED.setExclusiveDriver("SPI");
+        FastLED.setExclusiveDriver(fl::Bus::SPI);
     }
 
     // Your LED code...

--- a/examples/AutoResearch/AutoResearchAsync.h
+++ b/examples/AutoResearch/AutoResearchAsync.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "AutoResearchRemote.h"
+#include "AutoResearchHelpers.h"  // autoResearchSetExclusiveDriverByName
 #include "fl/task/task.h"
 #include "fl/task/executor.h"
 
@@ -88,7 +89,7 @@ inline void maybeRegisterStubAutorun(
             const auto& drv = state->drivers_available[di];
             FL_PRINT("\n[STUB CLIENT] Driver: " << drv.name.c_str());
 
-            if (!FastLED.setExclusiveDriver(drv.name.c_str())) {
+            if (!autoResearchSetExclusiveDriverByName(drv.name.c_str())) {
                 FL_ERROR("[STUB CLIENT] Failed to activate driver: " << drv.name.c_str());
                 grand_total++;  // count as a failure
                 continue;

--- a/examples/AutoResearch/AutoResearchHelpers.cpp
+++ b/examples/AutoResearch/AutoResearchHelpers.cpp
@@ -1,6 +1,8 @@
 // AutoResearchHelpers.cpp - Helper function implementations
 
 #include "AutoResearchHelpers.h"
+#include "fl/channels/manager.h"
+#include "fl/channels/all_drivers.h"    // FastLED.enableAllDrivers() out-of-line definition
 #include "fl/stl/sstream.h"
 #include "fl/system/pin.h"  // Platform-independent pin API
 #include "fl/channels/detail/validation/rx_test.h"
@@ -23,6 +25,14 @@ void autoResearchExpectedEngines() {
     fl::validation::printEngineValidation();
 }
 
+bool autoResearchSetExclusiveDriverByName(const char* name) {
+    // AutoResearch resolves driver names at runtime (RPC/JSON), so it needs every
+    // driver enrolled with ChannelManager before the lookup runs — otherwise a
+    // driver that wasn't auto-registered would silently miss.
+    FastLED.enableAllDrivers();
+    return fl::ChannelManager::instance().setExclusiveDriverByName(name);
+}
+
 void testDriver(
     const char* driver_name,
     const fl::NamedTimingConfig& timing_config,
@@ -36,8 +46,10 @@ void testDriver(
     fl::RxDeviceType rx_type,
     fl::DriverTestResult& result) {
 
-    // Set this driver as exclusive for testing
-    if (!FastLED.setExclusiveDriver(driver_name)) {
+    // Set this driver as exclusive for testing. AutoResearch resolves driver
+    // names at runtime, so we use the by-name helper (auto-enables all
+    // drivers first to ensure the lookup succeeds).
+    if (!autoResearchSetExclusiveDriverByName(driver_name)) {
         FL_ERROR("Failed to set " << driver_name << " as exclusive driver");
         result.skipped = true;
         return;

--- a/examples/AutoResearch/AutoResearchHelpers.h
+++ b/examples/AutoResearch/AutoResearchHelpers.h
@@ -25,6 +25,20 @@ bool testRxChannel(
 /// Prints ERROR if any expected engines are missing
 void autoResearchExpectedEngines();
 
+/// @brief AutoResearch-style helper: enable all drivers, then set an exclusive driver by name
+/// @param name Driver name (case-sensitive — must match an `IChannelDriver::getName()` value)
+/// @return true if the driver was found and set as exclusive
+///
+/// AutoResearch resolves driver names at runtime from RPC/JSON payloads, so it
+/// can't use the typed `FastLED.setExclusiveDriver(fl::Bus)` form. This wrapper
+/// makes sure every driver is registered before the lookup runs — without it,
+/// a driver that hasn't been enrolled yet would silently miss the lookup and
+/// fall back to AUTO/priority dispatch.
+///
+/// For built-in driver code that knows its driver at compile time, use
+/// `FastLED.setExclusiveDriver(fl::Bus::X)` instead (typo-safe).
+bool autoResearchSetExclusiveDriverByName(const char* name);
+
 /// @brief Test a specific driver with given timing configuration
 /// @param driver_name Driver name to test
 /// @param timing_config Named timing configuration (includes timing and name)

--- a/examples/AutoResearch/AutoResearchRemote.cpp
+++ b/examples/AutoResearch/AutoResearchRemote.cpp
@@ -285,8 +285,8 @@ fl::json AutoResearchRemoteControl::runSingleTestImpl(const fl::json& args) {
 
     uint32_t start_ms = millis();
 
-    // Set driver as exclusive
-    if (!FastLED.setExclusiveDriver(driver_name.c_str())) {
+    // Set driver as exclusive (by-name path: driver_name comes from RPC)
+    if (!autoResearchSetExclusiveDriverByName(driver_name.c_str())) {
         response.set("success", false);
         response.set("error", "DriverSetupFailed");
         fl::sstream msg;
@@ -1688,9 +1688,9 @@ void AutoResearchRemoteControl::registerFunctions(fl::shared_ptr<AutoResearchSta
             }
         }
 
-        // Set exclusive driver if requested
+        // Set exclusive driver if requested (by-name path: requested_driver from RPC)
         if (!requested_driver.empty()) {
-            if (!FastLED.setExclusiveDriver(requested_driver.c_str())) {
+            if (!autoResearchSetExclusiveDriverByName(requested_driver.c_str())) {
                 response.set("success", false);
                 response.set("error", "DriverSetupFailed");
                 fl::sstream msg;

--- a/examples/Sailboat/Sailboat.ino
+++ b/examples/Sailboat/Sailboat.ino
@@ -80,7 +80,7 @@ fl::ScreenMap screenMap =
 // ---------------------------------------------------------------------------
 void setup() {
     Serial.begin(115200);
-    //FastLED.setExclusiveDriver("SPI");
+    //FastLED.setExclusiveDriver(fl::Bus::SPI);
     fl::ChannelOptions opts;
     opts.mCorrection = TypicalLEDStrip;
     auto timing = fl::makeTimingConfig<fl::TIMING_WS2812_800KHZ>();

--- a/examples/SpecialDrivers/ESP/DriverTest/TestRunner.h
+++ b/examples/SpecialDrivers/ESP/DriverTest/TestRunner.h
@@ -16,6 +16,7 @@
 
 #include <Arduino.h>
 #include <FastLED.h>
+#include "fl/channels/manager.h"        // ChannelManager::setExclusiveDriverByName (by-name escape hatch)
 #include "fl/stl/sstream.h"
 #include "PlatformConfig.h"
 
@@ -261,8 +262,13 @@ private:
         ss << LINE_SEP;
         Serial.print(ss.str().c_str());
 
-        // Attempt to set this driver as exclusive
-        if (!FastLED.setExclusiveDriver(driverName)) {
+        // Attempt to set this driver as exclusive. `driverName` is a runtime
+        // string (the test iterates over discovered drivers by name), so we use
+        // the by-name escape hatch on ChannelManager rather than the typed
+        // FastLED.setExclusiveDriver(fl::Bus) overload. Make sure every driver
+        // is enrolled first so the lookup can succeed.
+        FastLED.enableAllDrivers();
+        if (!fl::ChannelManager::instance().setExclusiveDriverByName(driverName)) {
             Serial.print("  [SKIP] Could not set ");
             Serial.print(driverName);
             Serial.println(" as exclusive driver (not available)");

--- a/release_notes.md
+++ b/release_notes.md
@@ -137,14 +137,16 @@ FastLED 3.10.4 (Next Release)
       * Optimize for specific scenarios (RMT for flexibility, SPI for speed, PARLIO for maximum throughput)
     * **API Methods** (accessed via global `FastLED` object, **full functionality ESP32-only**, safe no-op stubs on other platforms):
       * `FastLED.setDriverEnabled(name, enabled)` - Enable/disable specific driver by name
-      * `FastLED.setExclusiveDriver(name)` - Enable only one driver, disable all others (forward-compatible)
+      * `FastLED.setExclusiveDriver(fl::Bus)` - Enable only one driver, disable all others (typed, typo-safe; forward-compatible)
+      * For mocks / custom drivers (names not in `fl::Bus`), use `fl::ChannelManager::instance().setExclusiveDriverByName(name)`
       * `FastLED.isDriverEnabled(name)` - Query if a driver is currently enabled
       * `FastLED.getDriverCount()` - Get total number of registered drivers
       * `FastLED.getDriverInfo()` - Get full state of all drivers (name, priority, enabled state)
     * **Complete Example**:
       ```cpp
-      // Force RMT driver only (disables SPI, PARLIO, and any future drivers)
-      FastLED.setExclusiveDriver("RMT");
+      // Force RMT driver only (disables SPI, PARLIO, and any future drivers).
+      // Typed: fl::Bus::RTM would be a compile error.
+      FastLED.setExclusiveDriver(fl::Bus::RMT);
 
       // Or selectively enable/disable
       FastLED.setDriverEnabled("SPI", false);    // Disable SPI
@@ -167,7 +169,7 @@ FastLED 3.10.4 (Next Release)
     * **Forward-compatible**: `setExclusiveDriver()` automatically disables future drivers, ensuring predictable behavior
     * **Automatic fallback**: If highest-priority driver fails, manager automatically tries next priority
     * **ESP32 integration**: Drivers auto-register with names during platform initialization
-    * **Example Sketch**: See `examples/AutoResearch/AutoResearch.ino` for usage with `FastLED.setExclusiveDriver("RMT")`
+    * **Example Sketch**: See `examples/AutoResearch/AutoResearch.ino` for usage with `FastLED.setExclusiveDriver(fl::Bus::RMT)`
     * Unit tested with comprehensive test suite (18 test cases covering priority, fallback, runtime control)
   * **ESP32 SPI Chipsets No Longer Hardcoded to Specific Pins**: Use any GPIO pins for SPI-based LEDs (all ESP32 variants)
     * Previously forced to use VSPI/HSPI pins - now fully flexible via GPIO matrix

--- a/src/FastLED.cpp.hpp
+++ b/src/FastLED.cpp.hpp
@@ -557,9 +557,9 @@ void CFastLED::setDriverEnabled(const char* name, bool enabled) {
 	manager.setDriverEnabled(name, enabled);
 }
 
-bool CFastLED::setExclusiveDriver(const char* name) {
+bool CFastLED::setExclusiveDriver(fl::Bus bus) {
 	fl::ChannelManager& manager = fl::channelManager();
-	return manager.setExclusiveDriver(name);
+	return manager.setExclusiveDriver(bus);
 }
 
 bool CFastLED::isDriverEnabled(const char* name) const {

--- a/src/FastLED.h
+++ b/src/FastLED.h
@@ -1372,11 +1372,15 @@ public:
 	void setDriverEnabled(const char* name, bool enabled);
 
 	/// Enable only one driver exclusively (disables all others)
-	/// @param name Driver name to enable exclusively (case-sensitive, e.g., "RMT", "SPI", "PARLIO")
-	/// @return true if driver was found and set as exclusive, false if name not found
+	/// @param bus Bus enum identifying the driver (typed, typo-safe)
+	/// @return true if driver was found and set as exclusive, false otherwise
 	/// @note Atomically disables all drivers, then enables the specified one
 	/// @note Use for testing specific drivers or debugging
-	bool setExclusiveDriver(const char* name);
+	/// @note For drivers whose names aren't in the `fl::Bus` enum (mocks,
+	///       custom third-party drivers, RPC-resolved names), use
+	///       `fl::ChannelManager::instance().setExclusiveDriverByName(name)`
+	///       directly.
+	bool setExclusiveDriver(fl::Bus bus);
 
 	/// Check if a driver is enabled by name
 	/// @param name Driver name to query (case-sensitive)

--- a/src/fl/channels/README.md
+++ b/src/fl/channels/README.md
@@ -184,7 +184,7 @@ The Bus parameter triggers linker keep-alive in every variant. For the SPI varia
 - **`cfg.options.mBus = fl::Bus::RMT`** — pin to a specific driver. The dispatch looks up `busName(mBus)` in `ChannelManager`.
 - **`cfg.options.mBus = fl::Bus::AUTO`** (the default) — `ChannelManager` picks the highest-priority driver that `canHandle` the chipset.
 
-For **custom / third-party / mock drivers** whose names aren't in the `fl::Bus` enum, register the driver with `manager.addDriver(priority, driver)` and either (a) clear competing drivers first so priority dispatch picks it, or (b) call `manager.setExclusiveDriver(name)` for process-wide binding.
+For **custom / third-party / mock drivers** whose names aren't in the `fl::Bus` enum, register the driver with `manager.addDriver(priority, driver)` and either (a) clear competing drivers first so priority dispatch picks it, or (b) call `manager.setExclusiveDriverByName(name)` for process-wide binding (the by-name escape hatch — `manager.setExclusiveDriver(fl::Bus)` is the typed form for built-in drivers).
 
 The non-template path **auto-enrolls every driver** on the platform (`fl::enableAllDrivers()` runs inside) so any `mBus` value can be dispatched at runtime. A one-time `FL_WARN_ONCE` explains the binary-size trade-off; suppress it with `-DFASTLED_SUPPRESS_RUNTIME_DRIVER_WARNING`. For minimum binary size, use the compile-time `TypedChannel<...>::create()` path above.
 
@@ -306,8 +306,12 @@ void setup() {
     // calling them all in sequence (as written here) makes the later
     // calls override the earlier ones.
 
-    // Method 1: Force a specific driver exclusively (disables all others)
-    FastLED.setExclusiveDriver("RMT");
+    // Method 1: Force a specific driver exclusively (disables all others).
+    // Use the typed fl::Bus form — typos like fl::Bus::RTM are compile errors.
+    FastLED.setExclusiveDriver(fl::Bus::RMT);
+    // For custom/mock drivers (names not in the fl::Bus enum), use the by-name
+    // escape hatch on the manager directly:
+    //   fl::ChannelManager::instance().setExclusiveDriverByName("MOCK_NAME");
 
     // Method 2: Enable/disable specific drivers
     FastLED.setDriverEnabled("PARLIO", true);   // Enable
@@ -331,7 +335,8 @@ void setup() {
 ```
 
 **Control methods:**
-- `FastLED.setExclusiveDriver(name)` - Disable all drivers except the named one
+- `FastLED.setExclusiveDriver(fl::Bus)` - Disable all drivers except the named one (typed, typo-safe — preferred)
+- `fl::ChannelManager::instance().setExclusiveDriverByName(name)` - Same, by string name (for mocks / custom drivers not in `fl::Bus`)
 - `FastLED.setDriverEnabled(name, enabled)` - Enable/disable specific driver
 - `fl::ChannelManager::instance().setDriverPriority(name, priority)` - Change priority (triggers automatic re-sort). No `FastLED.*` forwarder is provided for this.
 

--- a/src/fl/channels/manager.cpp.hpp
+++ b/src/fl/channels/manager.cpp.hpp
@@ -170,10 +170,14 @@ void ChannelManager::setDriverEnabled(const char* name, bool enabled) {
     }
 }
 
-bool ChannelManager::setExclusiveDriver(const char* name) {
+bool ChannelManager::setExclusiveDriver(Bus bus) {
+    return setExclusiveDriverByName(busName(bus));
+}
+
+bool ChannelManager::setExclusiveDriverByName(const char* name) {
     // Handle null or empty name
     if (!name || !name[0]) {
-        FL_ERROR("ChannelManager::setExclusiveDriver() - Null or empty driver name provided");
+        FL_ERROR("ChannelManager::setExclusiveDriverByName() - Null or empty driver name provided");
         mExclusiveDriver.clear();
         // Disable all drivers
         for (auto& entry : mDrivers) {
@@ -194,7 +198,7 @@ bool ChannelManager::setExclusiveDriver(const char* name) {
     }
 
     if (!found) {
-        FL_ERROR("ChannelManager::setExclusiveDriver() - Driver '" << name << "' not found in registry");
+        FL_ERROR("ChannelManager::setExclusiveDriverByName() - Driver '" << name << "' not found in registry");
     }
 
     return found;

--- a/src/fl/channels/manager.h
+++ b/src/fl/channels/manager.h
@@ -24,6 +24,7 @@
 
 #include "fl/channels/driver.h"
 #include "fl/channels/data.h"
+#include "fl/channels/bus.h"
 #include "fl/system/engine_events.h"
 #include "fl/stl/vector.h"
 #include "fl/stl/shared_ptr.h"
@@ -93,15 +94,26 @@ public:
     void setDriverEnabled(const char* name, bool enabled) FL_NOEXCEPT;
 
     /// @brief Enable only one driver exclusively (disables all others)
-    /// @param name Driver name to enable exclusively (case-sensitive, e.g., "RMT", "SPI", "PARLIO")
+    /// @param bus Bus enum identifying the driver to enable (typed, typo-safe)
+    /// @return true if driver was found and set as exclusive, false otherwise
+    /// @note Typed overload — prefer this over the string-based variant for
+    ///       built-in drivers. Delegates to `setExclusiveDriverByName(busName(bus))`.
+    bool setExclusiveDriver(Bus bus) FL_NOEXCEPT;
+
+    /// @brief Enable only one driver exclusively (disables all others) — by-name escape hatch
+    /// @param name Driver name to enable exclusively (case-sensitive, e.g., "MOCK_SPI")
     /// @return true if driver was found and set as exclusive, false if name not found
+    /// @note Use this only for drivers whose names are NOT in the `fl::Bus` enum
+    ///       (mock drivers, custom third-party drivers, RPC-resolved names). For
+    ///       built-in drivers, prefer the typed `setExclusiveDriver(fl::Bus)`
+    ///       overload — it catches typos at compile time.
     /// @note Atomically disables all drivers, then enables the specified one
     /// @note Changes take effect immediately on next enqueue()
     /// @note If name is not found, all drivers remain disabled (defensive behavior)
     /// @note Use nullptr or empty string to disable all drivers (returns false)
     /// @warning This will disable ALL other registered drivers, including future additions
     /// @warning This ensures forward compatibility - new drivers are automatically excluded
-    bool setExclusiveDriver(const char* name) FL_NOEXCEPT;
+    bool setExclusiveDriverByName(const char* name) FL_NOEXCEPT;
 
     /// @brief Change the priority of a registered driver
     /// @param name Driver name (case-sensitive, e.g., "RMT", "SPI", "PARLIO")

--- a/src/fl/channels/options.h
+++ b/src/fl/channels/options.h
@@ -25,7 +25,7 @@ namespace fl {
 /// **Custom / third-party / mock drivers** whose names aren't in the
 /// `fl::Bus` enum should be bound either by priority (clear competing
 /// drivers via `clearAllDrivers()` and let the mock win priority dispatch)
-/// or via `ChannelManager::setExclusiveDriver(name)` for process-wide
+/// or via `ChannelManager::setExclusiveDriverByName(name)` for process-wide
 /// binding. There is no string-typed affinity field on `ChannelOptions`.
 struct ChannelOptions {
     CRGB mCorrection = UncorrectedColor;

--- a/tests/fl/channels/spi_channel.cpp
+++ b/tests/fl/channels/spi_channel.cpp
@@ -256,7 +256,7 @@ FL_TEST_CASE("SPI chipset - mock driver integration") {
     manager.addDriver(1000, mockEngine);
 
     // Set mock driver as exclusive (disables all other drivers)
-    bool exclusive = manager.setExclusiveDriver("MOCK_SPI");
+    bool exclusive = manager.setExclusiveDriverByName("MOCK_SPI");
     FL_REQUIRE(exclusive);
 
     // Create LED array and set pixel data
@@ -308,7 +308,7 @@ FL_TEST_CASE("SPI chipset - APA102HD mock driver integration") {
     manager.addDriver(1000, mockEngine);
 
     // Set mock driver as exclusive (disables all other drivers)
-    bool exclusive = manager.setExclusiveDriver("MOCK_SPI_HD");
+    bool exclusive = manager.setExclusiveDriverByName("MOCK_SPI_HD");
     FL_REQUIRE(exclusive);
 
     // Create LED array and set pixel data
@@ -422,7 +422,7 @@ FL_TEST_CASE("ChannelManager - predicate filtering (clockless rejected)") {
     manager.addDriver(1000, mockSpiEngine);
 
     // Set mock driver as exclusive (disables all other drivers)
-    bool exclusive = manager.setExclusiveDriver("MOCK_SPI_TEST1");
+    bool exclusive = manager.setExclusiveDriverByName("MOCK_SPI_TEST1");
     FL_REQUIRE(exclusive);
 
     // Create clockless ChannelData
@@ -452,7 +452,7 @@ FL_TEST_CASE("ChannelManager - predicate filtering (SPI accepted)") {
     manager.addDriver(1000, mockSpiEngine);
 
     // Set mock driver as exclusive (disables all other drivers)
-    bool exclusive = manager.setExclusiveDriver("MOCK_SPI_TEST2");
+    bool exclusive = manager.setExclusiveDriverByName("MOCK_SPI_TEST2");
     FL_REQUIRE(exclusive);
 
     // Create SPI ChannelData
@@ -585,7 +585,7 @@ FL_TEST_CASE("APA102 channel routes through ChannelManager") {
     auto mock = fl::make_shared<SpiCaptureMock>("APA102_ROUTE_TEST");
     ChannelManager& manager = ChannelManager::instance();
     manager.addDriver(1000, mock);
-    bool exclusive = manager.setExclusiveDriver("APA102_ROUTE_TEST");
+    bool exclusive = manager.setExclusiveDriverByName("APA102_ROUTE_TEST");
     FL_REQUIRE(exclusive);
 
     const int NUM_LEDS = 5;
@@ -644,7 +644,7 @@ FL_TEST_CASE("SK9822 channel routes through ChannelManager") {
     auto mock = fl::make_shared<SpiCaptureMock>("SK9822_ROUTE_TEST");
     ChannelManager& manager = ChannelManager::instance();
     manager.addDriver(1000, mock);
-    bool exclusive = manager.setExclusiveDriver("SK9822_ROUTE_TEST");
+    bool exclusive = manager.setExclusiveDriverByName("SK9822_ROUTE_TEST");
     FL_REQUIRE(exclusive);
 
     const int NUM_LEDS = 3;
@@ -682,7 +682,7 @@ FL_TEST_CASE("WS2801 channel routes through ChannelManager") {
     auto mock = fl::make_shared<SpiCaptureMock>("WS2801_ROUTE_TEST");
     ChannelManager& manager = ChannelManager::instance();
     manager.addDriver(1000, mock);
-    bool exclusive = manager.setExclusiveDriver("WS2801_ROUTE_TEST");
+    bool exclusive = manager.setExclusiveDriverByName("WS2801_ROUTE_TEST");
     FL_REQUIRE(exclusive);
 
     const int NUM_LEDS = 4;
@@ -713,7 +713,7 @@ FL_TEST_CASE("Multiple SPI channels share ChannelManager") {
     auto mock = fl::make_shared<SpiCaptureMock>("MULTI_SPI_TEST");
     ChannelManager& manager = ChannelManager::instance();
     manager.addDriver(1000, mock);
-    bool exclusive = manager.setExclusiveDriver("MULTI_SPI_TEST");
+    bool exclusive = manager.setExclusiveDriverByName("MULTI_SPI_TEST");
     FL_REQUIRE(exclusive);
 
     const int NUM_LEDS = 3;
@@ -771,7 +771,7 @@ FL_TEST_CASE("SPI channel rejected by clockless-only driver") {
     // Register clockless at higher priority, SPI at lower
     manager.addDriver(2000, clocklessMock);
     manager.addDriver(1000, spiMock);
-    manager.setExclusiveDriver("CLOCKLESS_ONLY"); // disable all
+    manager.setExclusiveDriverByName("CLOCKLESS_ONLY"); // disable all
     manager.setDriverEnabled("CLOCKLESS_ONLY", true);
     manager.setDriverEnabled("SPI_FALLBACK_TEST", true);
 
@@ -915,7 +915,7 @@ FL_TEST_CASE("P9813 channel routes with flag byte encoding") {
     auto mock = fl::make_shared<SpiCaptureMock>("P9813_ROUTE_TEST");
     ChannelManager& manager = ChannelManager::instance();
     manager.addDriver(1000, mock);
-    bool exclusive = manager.setExclusiveDriver("P9813_ROUTE_TEST");
+    bool exclusive = manager.setExclusiveDriverByName("P9813_ROUTE_TEST");
     FL_REQUIRE(exclusive);
 
     const int NUM_LEDS = 2;
@@ -966,7 +966,7 @@ FL_TEST_CASE("LPD8806 channel routes with MSB-set encoding") {
     auto mock = fl::make_shared<SpiCaptureMock>("LPD8806_ROUTE_TEST");
     ChannelManager& manager = ChannelManager::instance();
     manager.addDriver(1000, mock);
-    bool exclusive = manager.setExclusiveDriver("LPD8806_ROUTE_TEST");
+    bool exclusive = manager.setExclusiveDriverByName("LPD8806_ROUTE_TEST");
     FL_REQUIRE(exclusive);
 
     const int NUM_LEDS = 3;
@@ -1010,7 +1010,7 @@ FL_TEST_CASE("LPD6803 channel routes with 16-bit 5-5-5 encoding") {
     auto mock = fl::make_shared<SpiCaptureMock>("LPD6803_ROUTE_TEST");
     ChannelManager& manager = ChannelManager::instance();
     manager.addDriver(1000, mock);
-    bool exclusive = manager.setExclusiveDriver("LPD6803_ROUTE_TEST");
+    bool exclusive = manager.setExclusiveDriverByName("LPD6803_ROUTE_TEST");
     FL_REQUIRE(exclusive);
 
     const int NUM_LEDS = 2;
@@ -1053,7 +1053,7 @@ FL_TEST_CASE("SM16716 channel routes with RGB encoding") {
     auto mock = fl::make_shared<SpiCaptureMock>("SM16716_ROUTE_TEST");
     ChannelManager& manager = ChannelManager::instance();
     manager.addDriver(1000, mock);
-    bool exclusive = manager.setExclusiveDriver("SM16716_ROUTE_TEST");
+    bool exclusive = manager.setExclusiveDriverByName("SM16716_ROUTE_TEST");
     FL_REQUIRE(exclusive);
 
     const int NUM_LEDS = 2;
@@ -1092,7 +1092,7 @@ FL_TEST_CASE("DOTSTAR channel produces APA102-compatible encoding") {
     auto mock = fl::make_shared<SpiCaptureMock>("DOTSTAR_ENCODE_TEST");
     ChannelManager& manager = ChannelManager::instance();
     manager.addDriver(1000, mock);
-    bool exclusive = manager.setExclusiveDriver("DOTSTAR_ENCODE_TEST");
+    bool exclusive = manager.setExclusiveDriverByName("DOTSTAR_ENCODE_TEST");
     FL_REQUIRE(exclusive);
 
     const int NUM_LEDS = 3;


### PR DESCRIPTION
Closes #2471.

## Summary

- `FastLED.setExclusiveDriver(const char*)` → `FastLED.setExclusiveDriver(fl::Bus)`. The public facade is now typed and typo-safe — `fl::Bus::RTM` is a compile error.
- `ChannelManager::setExclusiveDriver(const char*)` renamed to `ChannelManager::setExclusiveDriverByName(const char*)` — kept for mocks / custom / RPC-resolved drivers, but the name signals it's the escape hatch.
- New `ChannelManager::setExclusiveDriver(fl::Bus)` overload delegates to the by-name form via `busName(b)`.
- AutoResearch's 4 runtime-string callers route through a new `autoResearchSetExclusiveDriverByName()` helper that calls `FastLED.enableAllDrivers()` first (RPC paths can't assume drivers are pre-enrolled).
- 13 mock-test call sites in `tests/fl/channels/spi_channel.cpp` switch from `manager.setExclusiveDriver(...)` to `manager.setExclusiveDriverByName(...)`.
- DriverTest example switches to the same auto-enable + by-name pattern.
- README.md / src/fl/channels/README.md / release_notes.md / options.h docs updated.

## Why

The string form silently accepted typos that the typed `fl::Bus` enum catches at compile time. Removing it outright would have broken 17 legitimate callers (mocks + RPC-resolved names), so the fix is to split by intent: the public facade is typed-only; the by-name escape hatch lives one level down on `ChannelManager`.

## Test plan

- [x] `bash test --cpp` — 304/304 passed (two transient flakes — `fl_audio`, `fl_log` — pass on rerun and in `--debug`; unrelated to this refactor).
- [x] `bash lint` — clean
- [x] SPI mock test suite still validates correctly via `manager.setExclusiveDriverByName(...)`.
- [x] AutoResearch host build links (verified `autoResearchSetExclusiveDriverByName()` properly pulls in `FastLED.enableAllDrivers()` via `fl/channels/all_drivers.h`).

## Backward compatibility

This is a source-breaking change for any user who called `FastLED.setExclusiveDriver(\"RMT\")` with a literal string. Migration:

| Before | After |
|---|---|
| `FastLED.setExclusiveDriver(\"RMT\")` | `FastLED.setExclusiveDriver(fl::Bus::RMT)` |
| `FastLED.setExclusiveDriver(some_runtime_str)` | `fl::ChannelManager::instance().setExclusiveDriverByName(some_runtime_str)` (after `FastLED.enableAllDrivers()`) |
| `manager.setExclusiveDriver(\"MOCK\")` | `manager.setExclusiveDriverByName(\"MOCK\")` |

All in-tree callers in this PR have been migrated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Breaking Changes**
  * Exclusive driver selection API updated from string-based to typed enum for improved compile-time safety.
  * Custom drivers and non-standard driver names now use a dedicated by-name helper method.

* **Documentation**
  * Updated examples and API reference to reflect new typed driver selection API.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/FastLED/pull/2472)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->