### PR TITLE
ci: switch compile to fbuild compile-many

### DIFF
--- a/ci/compiler/pio.py
+++ b/ci/compiler/pio.py
@@ -9,6 +9,7 @@ Provides a clean interface for building FastLED projects with PlatformIO.
 """
 
 import gc
+import hashlib
 import platform
 import shutil
 import subprocess
@@ -58,6 +59,7 @@ def _init_platformio_build(
     verbose: bool,
     example: str,
     paths: FastLEDPaths,
+    build_dir: Optional[Path] = None,
     additional_defines: Optional[list[str]] = None,
     additional_include_dirs: Optional[list[str]] = None,
     additional_libs: Optional[list[str]] = None,
@@ -70,7 +72,7 @@ def _init_platformio_build(
     uses the same project structure.
     """
     project_root = resolve_project_root()
-    build_dir = project_root / ".build" / "pio" / board.board_name
+    build_dir = build_dir or (project_root / ".build" / "pio" / board.board_name)
 
     if not use_fbuild:
         # Check for and fix corrupted packages before building
@@ -377,7 +379,7 @@ class PioCompiler(Compiler):
 
         # fbuild path: run on main thread for reliable Ctrl+C handling
         if self.use_fbuild:
-            return self._build_fbuild_sync(examples)
+            return self._build_fbuild(examples)
 
         # Acquire the global package lock for the first build (package installation)
 
@@ -415,6 +417,179 @@ class PioCompiler(Compiler):
             for future in futures:
                 future.cancel()
             raise
+
+        return futures
+
+    def _build_fbuild(self, examples: list[str]) -> list[Future[SketchResult]]:
+        """Build examples using fbuild, preferring ``ci`` when available."""
+        from ci.util.fbuild_runner import (
+            fbuild_supports_ci,
+            fbuild_supports_compile_many,
+        )
+
+        if fbuild_supports_ci():
+            return self._build_fbuild_ci(examples)
+        if fbuild_supports_compile_many():
+            print(
+                "fbuild ci is unavailable in the installed fbuild; "
+                "falling back to fbuild compile-many."
+            )
+            return self._build_fbuild_compile_many(examples)
+
+        print(
+            "fbuild ci and compile-many are unavailable in the installed fbuild; "
+            "falling back to the legacy serial loop."
+        )
+        return self._build_fbuild_sync(examples)
+
+    def _compile_many_project_dir(self, example: str, index: int) -> Path:
+        """Return the staged project directory for one compile-many sketch."""
+        if index == 0:
+            return self.build_dir
+
+        example_path = Path(example)
+        if example_path.is_absolute():
+            digest = hashlib.sha1(str(example_path).encode("utf-8")).hexdigest()[:12]
+            safe_name = "".join(
+                ch if ch.isalnum() or ch in "._-" else "_" for ch in example_path.name
+            ) or f"example_{index}"
+            return self.build_dir / "compile_many" / f"{safe_name}_{digest}"
+        return self.build_dir / "compile_many" / example_path
+
+    def _stage_fbuild_compile_many_projects(
+        self, examples: list[str]
+    ) -> list[tuple[str, Path]]:
+        """Stage one PlatformIO-compatible project directory per example."""
+        staged_projects: list[tuple[str, Path]] = []
+        for index, example in enumerate(examples):
+            project_dir = self._compile_many_project_dir(example, index)
+            init_result = _init_platformio_build(
+                self.board,
+                self.verbose,
+                example,
+                self.paths,
+                build_dir=project_dir,
+                additional_defines=self.additional_defines,
+                additional_include_dirs=self.additional_include_dirs,
+                additional_libs=self.additional_libs,
+                use_fbuild=True,
+            )
+            if not init_result.success:
+                raise RuntimeError(init_result.output)
+            staged_projects.append((example, project_dir))
+        return staged_projects
+
+    def _build_fbuild_compile_many(
+        self, examples: list[str]
+    ) -> list[Future[SketchResult]]:
+        """Build examples with one ``fbuild compile-many`` invocation."""
+        from ci.util.fbuild_runner import run_fbuild_compile_many
+
+        return self._build_fbuild_batch(
+            examples=examples,
+            command_label="compile-many",
+            run_batch=run_fbuild_compile_many,
+        )
+
+    def _build_fbuild_ci(self, examples: list[str]) -> list[Future[SketchResult]]:
+        """Build examples with one ``fbuild ci`` invocation."""
+        from ci.util.fbuild_runner import run_fbuild_ci
+
+        return self._build_fbuild_batch(
+            examples=examples,
+            command_label="ci",
+            run_batch=run_fbuild_ci,
+        )
+
+    def _build_fbuild_batch(
+        self,
+        examples: list[str],
+        command_label: str,
+        run_batch: Any,
+    ) -> list[Future[SketchResult]]:
+        """Build examples with one batched ``fbuild`` invocation."""
+
+        futures: list[Future[SketchResult]] = []
+
+        try:
+            staged_projects = self._stage_fbuild_compile_many_projects(examples)
+        except Exception as e:
+            for example in examples:
+                future: Future[SketchResult] = Future()
+                future.set_result(
+                    SketchResult(
+                        success=False,
+                        output=f"Failed to stage fbuild {command_label} project: {e}",
+                        build_dir=self.build_dir,
+                        example=example,
+                    )
+                )
+                futures.append(future)
+            print(f"Releasing platform lock: {self.platform_lock.lock_file_path}\n")
+            self.platform_lock.release()
+            return futures
+
+        try:
+            compile_many_result = run_batch(
+                board=self.board.board_name,
+                sketch_project_dirs=[project_dir for _, project_dir in staged_projects],
+                verbose=self.verbose,
+                timeout=1800,
+                quiet=False,
+                log_file=None,
+            )
+            reported = {
+                sketch_result.sketch_dir.resolve(): sketch_result
+                for sketch_result in compile_many_result.sketch_results
+            }
+
+            for example, project_dir in staged_projects:
+                sketch_result = reported.get(project_dir.resolve())
+                if sketch_result is None:
+                    output = (
+                        f"fbuild {command_label} did not report a result for "
+                        f"{project_dir}\n\n{compile_many_result.output}"
+                    )
+                    success = False
+                else:
+                    output = sketch_result.message
+                    if sketch_result.log_path is not None and sketch_result.log_path.exists():
+                        output = sketch_result.log_path.read_text(
+                            encoding="utf-8", errors="ignore"
+                        )
+                    success = sketch_result.success
+
+                if success:
+                    green_color = "\033[32m"
+                    reset_color = "\033[0m"
+                    print(f"{green_color}SUCCESS: {example}{reset_color}")
+                    if generate_build_info_json_from_existing_build(
+                        project_dir, self.board, example
+                    ):
+                        build_info_path = project_dir / f"build_info_{example}.json"
+                        if project_dir != self.build_dir and build_info_path.exists():
+                            shutil.copy2(
+                                build_info_path,
+                                self.build_dir / build_info_path.name,
+                            )
+                else:
+                    red_color = "\033[31m"
+                    reset_color = "\033[0m"
+                    print(f"{red_color}FAILED: {example}{reset_color}")
+
+                future: Future[SketchResult] = Future()
+                future.set_result(
+                    SketchResult(
+                        success=success,
+                        output=output or f"fbuild {command_label}",
+                        build_dir=project_dir,
+                        example=example,
+                    )
+                )
+                futures.append(future)
+        finally:
+            print(f"Releasing platform lock: {self.platform_lock.lock_file_path}\n")
+            self.platform_lock.release()
 
         return futures
 

--- a/ci/tests/test_fbuild_compile_many.py
+++ b/ci/tests/test_fbuild_compile_many.py
@@ -1,0 +1,242 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from ci.boards import Board
+from ci.compiler.pio import PioCompiler
+from ci.util import cpu_count as cpu_count_module
+from ci.util import fbuild_runner
+
+
+def test_cpu_count_no_longer_caps_on_github_actions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("GITHUB_ACTIONS", "true")
+    monkeypatch.delenv("NO_PARALLEL", raising=False)
+    monkeypatch.setattr(cpu_count_module.os, "cpu_count", lambda: 8)
+
+    assert cpu_count_module.cpu_count() == 8
+
+
+def test_run_fbuild_ci_uses_expected_command_and_parses_results(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    output = "\n".join(
+        [
+            "compile-many results:",
+            "  [stage1] OK (1.25s) C:\\tmp\\sketch1  log=C:\\tmp\\sketch1\\compile_many.log  built",
+            "  [stage2] FAIL (0.75s) C:\\tmp\\sketch2  log=-  build error",
+        ]
+    )
+
+    class FakeRunningProcess:
+        last_cmd: list[str] | None = None
+
+        def __init__(
+            self,
+            cmd: list[str],
+            timeout: int,
+            auto_run: bool,
+            capture: bool,
+        ) -> None:
+            assert auto_run is False
+            assert capture is True
+            assert timeout == 1800
+            FakeRunningProcess.last_cmd = cmd
+            self.stdout = output
+            self.returncode = 0
+
+        def start(self) -> None:
+            pass
+
+        def wait(self, echo: bool) -> int:
+            assert echo is True
+            return 0
+
+    monkeypatch.setattr(fbuild_runner, "get_fbuild_executable", lambda: "fbuild.exe")
+    monkeypatch.setattr(fbuild_runner, "cpu_count", lambda: 8)
+    monkeypatch.setenv("GITHUB_ACTIONS", "true")
+    monkeypatch.delenv("FASTLED_FRAMEWORK_JOBS", raising=False)
+    monkeypatch.delenv("FASTLED_SKETCH_JOBS", raising=False)
+    monkeypatch.setattr("running_process.RunningProcess", FakeRunningProcess)
+
+    result = fbuild_runner.run_fbuild_ci(
+        board="uno",
+        sketch_project_dirs=[Path("sketch1"), Path("sketch2")],
+        verbose=True,
+        timeout=1800,
+        quiet=False,
+        log_file=None,
+    )
+
+    assert result.success is True
+    assert FakeRunningProcess.last_cmd == [
+        "fbuild.exe",
+        "ci",
+        "--board",
+        "uno",
+        "--framework-jobs",
+        "1",
+        "--sketch-jobs",
+        "2",
+        "-v",
+        "sketch1",
+        "sketch2",
+    ]
+    assert len(result.sketch_results) == 2
+    assert result.sketch_results[0].success is True
+    assert result.sketch_results[0].stage == "stage1"
+    assert result.sketch_results[0].sketch_dir == Path("C:\\tmp\\sketch1")
+    assert result.sketch_results[1].success is False
+    assert result.sketch_results[1].log_path is None
+    assert result.sketch_results[1].message == "build error"
+
+
+def test_run_fbuild_ci_fails_when_output_is_partially_unparseable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeRunningProcess:
+        def __init__(
+            self,
+            cmd: list[str],
+            timeout: int,
+            auto_run: bool,
+            capture: bool,
+        ) -> None:
+            assert cmd[1] == "ci"
+            assert timeout == 1800
+            assert auto_run is False
+            assert capture is True
+            self.stdout = "\n".join(
+                [
+                    "compile-many results:",
+                    "  [stage1] OK (1.25s) C:\\tmp\\sketch1  log=-  built",
+                    "  weird output format",
+                ]
+            )
+            self.returncode = 0
+
+        def start(self) -> None:
+            pass
+
+        def wait(self, echo: bool) -> int:
+            assert echo is True
+            return 0
+
+    monkeypatch.setattr(fbuild_runner, "get_fbuild_executable", lambda: "fbuild.exe")
+    monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
+    monkeypatch.delenv("FASTLED_FRAMEWORK_JOBS", raising=False)
+    monkeypatch.delenv("FASTLED_SKETCH_JOBS", raising=False)
+    monkeypatch.setattr("running_process.RunningProcess", FakeRunningProcess)
+
+    result = fbuild_runner.run_fbuild_ci(
+        board="uno",
+        sketch_project_dirs=[Path("sketch1"), Path("sketch2")],
+        verbose=False,
+        timeout=1800,
+        quiet=False,
+        log_file=None,
+    )
+
+    assert result.success is False
+    assert result.returncode == 0
+    assert result.sketch_results == []
+    assert "weird output format" in result.output
+
+
+def test_pio_compiler_build_prefers_ci_results(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    compiler = PioCompiler(
+        board=Board(board_name="uno"),
+        verbose=False,
+        global_cache_dir=tmp_path / "cache",
+        use_fbuild=True,
+    )
+    compiler.build_dir = tmp_path / "board"
+    compiler.build_dir.mkdir(parents=True, exist_ok=True)
+
+    root_project = compiler.build_dir
+    other_project = compiler.build_dir / "compile_many" / "Demo"
+    root_project.mkdir(parents=True, exist_ok=True)
+    other_project.mkdir(parents=True, exist_ok=True)
+
+    root_log = root_project / "compile_many.log"
+    root_log.write_text("root ok", encoding="utf-8")
+    other_log = other_project / "compile_many.log"
+    other_log.write_text("demo ok", encoding="utf-8")
+
+    monkeypatch.setattr(fbuild_runner, "fbuild_supports_ci", lambda: True)
+    monkeypatch.setattr(fbuild_runner, "fbuild_supports_compile_many", lambda: True)
+    monkeypatch.setattr(
+        compiler,
+        "_stage_fbuild_compile_many_projects",
+        lambda examples: [("Blink", root_project), ("Demo", other_project)],
+    )
+
+    def fake_run_ci(
+        board: str,
+        sketch_project_dirs: list[Path],
+        verbose: bool,
+        timeout: float,
+        quiet: bool,
+        log_file: object,
+    ) -> fbuild_runner.FbuildCompileManyResult:
+        assert board == "uno"
+        assert sketch_project_dirs == [root_project, other_project]
+        assert verbose is False
+        assert timeout == 1800
+        assert quiet is False
+        assert log_file is None
+        return fbuild_runner.FbuildCompileManyResult(
+            success=True,
+            output="ci output",
+            returncode=0,
+            sketch_results=[
+                fbuild_runner.FbuildCompileManySketchResult(
+                    sketch_dir=root_project,
+                    success=True,
+                    stage="stage1",
+                    build_time_secs=1.0,
+                    log_path=root_log,
+                    message="ok",
+                ),
+                fbuild_runner.FbuildCompileManySketchResult(
+                    sketch_dir=other_project,
+                    success=True,
+                    stage="stage2",
+                    build_time_secs=0.5,
+                    log_path=other_log,
+                    message="ok",
+                ),
+            ],
+        )
+
+    monkeypatch.setattr(fbuild_runner, "run_fbuild_ci", fake_run_ci)
+
+    def fake_generate_build_info(build_dir: Path, board: Board, example: str) -> bool:
+        (build_dir / f"build_info_{example}.json").write_text(
+            '{"ok": true}', encoding="utf-8"
+        )
+        return True
+
+    monkeypatch.setattr(
+        "ci.compiler.pio.generate_build_info_json_from_existing_build",
+        fake_generate_build_info,
+    )
+
+    releases: list[str] = []
+    monkeypatch.setattr(compiler.platform_lock, "release", lambda: releases.append("x"))
+
+    futures = compiler.build(["Blink", "Demo"])
+    results = [future.result() for future in futures]
+
+    assert [result.example for result in results] == ["Blink", "Demo"]
+    assert results[0].success is True
+    assert results[0].output == "root ok"
+    assert results[1].success is True
+    assert results[1].output == "demo ok"
+    assert releases == ["x"]
+    assert (compiler.build_dir / "build_info_Demo.json").exists()

--- a/ci/util/cpu_count.py
+++ b/ci/util/cpu_count.py
@@ -4,8 +4,6 @@ import os
 def cpu_count() -> int:
     """Get the number of CPUs."""
     # Force sequential execution if NO_PARALLEL is set
-    if "GITHUB_ACTIONS" in os.environ:
-        return 1
     no_parallel = os.environ.get("NO_PARALLEL", "0") in ["1", "true", "True"]
     if no_parallel:
         return 1

--- a/ci/util/fbuild_runner.py
+++ b/ci/util/fbuild_runner.py
@@ -24,14 +24,20 @@ Usage:
 from __future__ import annotations
 
 import io
+import os
+import re
 import shutil
 import sys
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from functools import lru_cache
 from pathlib import Path
 from typing import IO, Any, cast
 
 from fbuild import Daemon, connect_daemon
+from typeguard import typechecked
+
+from ci.util.cpu_count import cpu_count
 
 
 @dataclass
@@ -41,6 +47,36 @@ class FbuildCommandResult:
     success: bool
     output: str
     returncode: int | None = None
+
+
+@typechecked
+@dataclass
+class FbuildCompileManySketchResult:
+    """Result for one sketch reported by ``fbuild compile-many``."""
+
+    sketch_dir: Path
+    success: bool
+    stage: str
+    build_time_secs: float
+    log_path: Path | None
+    message: str
+
+
+@typechecked
+@dataclass
+class FbuildCompileManyResult(FbuildCommandResult):
+    """Result for an ``fbuild compile-many`` invocation."""
+
+    sketch_results: list[FbuildCompileManySketchResult] = field(default_factory=list)
+
+
+_COMPILE_MANY_RESULT_RE = re.compile(
+    r"^\s+\[(?P<stage>stage1|stage2)\]\s+"
+    r"(?P<status>OK|FAIL)\s+"
+    r"\((?P<secs>[0-9.]+)s\)\s+"
+    r"(?P<sketch>.*?)\s{2}log="
+    r"(?P<log>.*?)\s{2}(?P<message>.*)$"
+)
 
 
 def get_fbuild_executable() -> str | None:
@@ -73,6 +109,94 @@ def _get_output(quiet: bool, log_file: IO[str] | None) -> IO[str]:
     if quiet:
         return io.StringIO()  # discard
     return sys.stdout
+
+
+def _get_env_job_count(name: str) -> int | None:
+    """Read a positive integer job override from the environment."""
+    raw_value = os.environ.get(name)
+    if raw_value is None:
+        return None
+    try:
+        value = int(raw_value)
+    except ValueError:
+        print(f"Warning: ignoring invalid {name}={raw_value!r}; expected integer")
+        return None
+    if value < 1:
+        print(f"Warning: ignoring invalid {name}={raw_value!r}; expected >= 1")
+        return None
+    return value
+
+
+def default_fbuild_framework_jobs() -> int:
+    """Default stage-1 parallelism for batched ``fbuild`` sketch builds."""
+    return _get_env_job_count("FASTLED_FRAMEWORK_JOBS") or 1
+
+
+def default_fbuild_sketch_jobs() -> int:
+    """Default stage-2 parallelism for batched ``fbuild`` sketch builds."""
+    env_override = _get_env_job_count("FASTLED_SKETCH_JOBS")
+    if env_override is not None:
+        return env_override
+    cpus = cpu_count()
+    if os.environ.get("GITHUB_ACTIONS") == "true":
+        return min(cpus, 2)
+    return cpus
+
+
+def _fbuild_supports_subcommand(subcommand: str) -> bool:
+    """Return whether the active fbuild executable exposes ``subcommand``."""
+    import subprocess
+
+    fbuild_exe = get_fbuild_executable()
+    if fbuild_exe is None:
+        return False
+    try:
+        proc = subprocess.run(
+            [fbuild_exe, "help", subcommand],
+            capture_output=True,
+            text=True,
+            timeout=15,
+            check=False,
+        )
+    except KeyboardInterrupt:
+        raise
+    except (FileNotFoundError, subprocess.SubprocessError, OSError):
+        return False
+    return proc.returncode == 0
+
+
+@lru_cache(maxsize=1)
+def fbuild_supports_ci() -> bool:
+    """Return whether the active fbuild executable exposes ``ci``."""
+    return _fbuild_supports_subcommand("ci")
+
+
+@lru_cache(maxsize=1)
+def fbuild_supports_compile_many() -> bool:
+    """Return whether the active fbuild executable exposes ``compile-many``."""
+    return _fbuild_supports_subcommand("compile-many")
+
+
+def _parse_compile_many_results(output: str) -> list[FbuildCompileManySketchResult]:
+    """Extract per-sketch results from ``fbuild compile-many`` output."""
+    results: list[FbuildCompileManySketchResult] = []
+    for line in output.splitlines():
+        match = _COMPILE_MANY_RESULT_RE.match(line)
+        if match is None:
+            continue
+        log_path_raw = match.group("log")
+        log_path = None if log_path_raw == "-" else Path(log_path_raw)
+        results.append(
+            FbuildCompileManySketchResult(
+                sketch_dir=Path(match.group("sketch")),
+                success=match.group("status") == "OK",
+                stage=match.group("stage"),
+                build_time_secs=float(match.group("secs")),
+                log_path=log_path,
+                message=match.group("message"),
+            )
+        )
+    return results
 
 
 def run_fbuild_compile(
@@ -178,6 +302,155 @@ def run_fbuild_compile(
         success=success,
         output=output,
         returncode=returncode,
+    )
+
+
+def _run_fbuild_batch_command(
+    command_name: str,
+    board: str,
+    sketch_project_dirs: list[Path],
+    verbose: bool,
+    timeout: float,
+    quiet: bool,
+    log_file: IO[str] | None,
+) -> FbuildCompileManyResult:
+    """Compile many sketches with one batched ``fbuild`` invocation."""
+    import subprocess
+
+    from running_process import RunningProcess
+
+    if not sketch_project_dirs:
+        raise ValueError("sketch_project_dirs must not be empty")
+
+    out = _get_output(quiet, log_file)
+    print("=" * 60, file=out)
+    print(f"COMPILING MANY (fbuild {command_name})", file=out)
+    print("=" * 60, file=out)
+
+    fbuild_exe = get_fbuild_executable()
+    if fbuild_exe is None:
+        message = "BUILD FAIL fbuild not found on PATH"
+        print(message, file=out)
+        return FbuildCompileManyResult(success=False, output=message)
+
+    framework_jobs = default_fbuild_framework_jobs()
+    sketch_jobs = default_fbuild_sketch_jobs()
+    cmd: list[str] = [
+        fbuild_exe,
+        command_name,
+        "--board",
+        board,
+        "--framework-jobs",
+        str(framework_jobs),
+        "--sketch-jobs",
+        str(sketch_jobs),
+    ]
+    if verbose:
+        cmd.append("-v")
+    cmd.extend(str(path) for path in sketch_project_dirs)
+
+    print(f"Running: {subprocess.list2cmdline(cmd)}", file=out)
+    print(file=out)
+
+    t0 = time.monotonic()
+    try:
+        process = RunningProcess(
+            cmd,
+            timeout=int(timeout),
+            auto_run=False,
+            capture=True,
+        )
+        process.start()
+        returncode = cast(
+            int, process.wait(echo=bool(not quiet or log_file is not None))
+        )
+        output = str(process.stdout)
+        sketch_results = _parse_compile_many_results(output)
+        success = returncode == 0
+        expected_results = len(sketch_project_dirs)
+        if success and len(sketch_results) != expected_results:
+            message = (
+                f"BUILD FAIL {command_name} returned 0 but parsed "
+                f"{len(sketch_results)}/{expected_results} per-sketch results "
+                "from stdout (output format drift?)"
+            )
+            print(message, file=out)
+            return FbuildCompileManyResult(
+                success=False,
+                output=output,
+                returncode=returncode,
+            )
+    except KeyboardInterrupt as ki:
+        from ci.util.global_interrupt_handler import handle_keyboard_interrupt
+
+        print(f"\nKeyboardInterrupt: Stopping {command_name}")
+        handle_keyboard_interrupt(ki)
+        raise
+    except subprocess.TimeoutExpired:
+        elapsed = time.monotonic() - t0
+        message = f"BUILD FAIL timeout after {elapsed:.1f}s"
+        print(message, file=out)
+        return FbuildCompileManyResult(success=False, output=message)
+    except Exception as e:
+        message = f"BUILD FAIL {e}"
+        print(message, file=out)
+        return FbuildCompileManyResult(success=False, output=message)
+
+    elapsed = time.monotonic() - t0
+    if quiet:
+        status = "ok" if success else "FAIL"
+        print(f"BUILD {status} {elapsed:.1f}s")
+    else:
+        if success:
+            print(f"\nCompilation succeeded (fbuild {command_name}) [{elapsed:.1f}s]\n")
+        else:
+            print(f"\nCompilation failed (fbuild {command_name}) [{elapsed:.1f}s]\n")
+
+    return FbuildCompileManyResult(
+        success=success,
+        output=output,
+        returncode=returncode,
+        sketch_results=sketch_results,
+    )
+
+
+def run_fbuild_ci(
+    board: str,
+    sketch_project_dirs: list[Path],
+    verbose: bool,
+    timeout: float,
+    quiet: bool,
+    log_file: IO[str] | None,
+) -> FbuildCompileManyResult:
+    """Compile many sketches with one ``fbuild ci`` invocation."""
+    return _run_fbuild_batch_command(
+        "ci",
+        board,
+        sketch_project_dirs,
+        verbose,
+        timeout,
+        quiet,
+        log_file,
+    )
+
+
+def run_fbuild_compile_many(
+    board: str,
+    sketch_project_dirs: list[Path],
+    verbose: bool,
+    timeout: float,
+    quiet: bool,
+    log_file: IO[str] | None,
+) -> FbuildCompileManyResult:
+    """Compile many sketches with one ``fbuild compile-many`` invocation."""
+    return _run_fbuild_batch_command(
+        "compile-many",
+        board,
+        sketch_project_dirs,
+        verbose,
+        timeout,
+        quiet,
+        log_file,
     )
 
 


### PR DESCRIPTION
## Summary
- switch the fbuild-backed ./compile path to use a single fbuild compile-many invocation when the installed fbuild supports it
- stage one build project per example for compile-many, parse per-sketch results, and retain the legacy serial loop as a fallback until a released fbuild exposes the new subcommand
- remove the GITHUB_ACTIONS CPU-count short-circuit and add tests for the new wrapper/job defaults and compile-many integration

## Testing
- uv run pytest ci/tests/test_fbuild_compile_many.py ci/tests/test_fbuild_default_selection.py -q
- uv run ruff check ci/util/cpu_count.py ci/util/fbuild_runner.py ci/compiler/pio.py ci/tests/test_fbuild_compile_many.py

Closes #2470.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Batched "compile-many" build mode that stages isolated per-example project directories and runs a single aggregated build, producing per-example results and logs.

* **Improvements**
  * CPU/job defaults and detection refined; clearer per-example SUCCESS/FAILED output, per-sketch log substitution, generation/copying of per-example build_info artifacts, and safer platform lock handling with fallbacks to legacy paths.

* **Tests**
  * New tests for compile-many parsing, failure handling, job calculations, and end-to-end build integration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/FastLED/pull/2476)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->