### PR TITLE
fix(examples): include all_drivers.h in DriverTest TestRunner.h

### DIFF
--- a/examples/SpecialDrivers/ESP/DriverTest/TestRunner.h
+++ b/examples/SpecialDrivers/ESP/DriverTest/TestRunner.h
@@ -16,6 +16,7 @@
 
 #include <Arduino.h>
 #include <FastLED.h>
+#include "fl/channels/all_drivers.h"    // FastLED.enableAllDrivers() body (linker opt-in, see #2428)
 #include "fl/channels/manager.h"        // ChannelManager::setExclusiveDriverByName (by-name escape hatch)
 #include "fl/stl/sstream.h"
 #include "PlatformConfig.h"


### PR DESCRIPTION
## Summary

Fixes ESP32 link failure in `SpecialDrivers/ESP/DriverTest` now surfaced by master CI after #2476 switched `./compile` to fbuild compile-many and added `all` to the esp32 workflow args.

Symptom (from master CI on commit `0bc9b8c3d2`, target esp32s3):

```
ld: ... undefined reference to `_ZN8CFastLED16enableAllDriversEv'
ld: ... in function `_ZN16DriverTestRunner16testSingleDriverEPKc':
main.cpp:(.text._ZN16DriverTestRunner16testSingleDriverEPKc...): undefined reference to `CFastLED::enableAllDrivers()'
collect2: error: ld returned 1 exit status
FAILED: SpecialDrivers/ESP/DriverTest
```

Root cause: `TestRunner.h` calls `FastLED.enableAllDrivers()` (line 271) but never includes `fl/channels/all_drivers.h`, which provides the linker opt-in body for that method (see #2428). Adding the include resolves the unresolved symbol at link.

This is a one-line example-level fix; no library or build-system changes.

## Known follow-up (out of scope)

`Ports/PJRCSpectrumAnalyzer` also now fails on teensy41 (and presumably teensy35/36/40) with:

```
undefined reference to `arm_cfft_radix4_init_q15'
undefined reference to `arm_cfft_radix4_q15'
```

That is a Teensy Audio library / CMSIS-DSP link resolution problem under fbuild compile-many — the math lib (`libarm_cortexM7lfsp_math.a`) isn't being pulled in. It's a fbuild/build-system issue, not an example issue, and warrants a separate investigation.

## Test plan

- [ ] `build_esp32s3` workflow turns green on this branch
- [ ] `build_esp32dev_i2s` workflow turns green on this branch
- [ ] No other targets regress

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Ensured FastLED driver implementation is properly available during testing by correcting internal include dependencies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/FastLED/pull/2477)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->