### PR TITLE
refactor(channels): move enableAllDrivers() body to a TU; rely on --gc-sections

### DIFF
--- a/ci/compiler/pio.py
+++ b/ci/compiler/pio.py
@@ -450,9 +450,13 @@ class PioCompiler(Compiler):
         example_path = Path(example)
         if example_path.is_absolute():
             digest = hashlib.sha1(str(example_path).encode("utf-8")).hexdigest()[:12]
-            safe_name = "".join(
-                ch if ch.isalnum() or ch in "._-" else "_" for ch in example_path.name
-            ) or f"example_{index}"
+            safe_name = (
+                "".join(
+                    ch if ch.isalnum() or ch in "._-" else "_"
+                    for ch in example_path.name
+                )
+                or f"example_{index}"
+            )
             return self.build_dir / "compile_many" / f"{safe_name}_{digest}"
         return self.build_dir / "compile_many" / example_path
 
@@ -553,7 +557,10 @@ class PioCompiler(Compiler):
                     success = False
                 else:
                     output = sketch_result.message
-                    if sketch_result.log_path is not None and sketch_result.log_path.exists():
+                    if (
+                        sketch_result.log_path is not None
+                        and sketch_result.log_path.exists()
+                    ):
                         output = sketch_result.log_path.read_text(
                             encoding="utf-8", errors="ignore"
                         )

--- a/src/FastLED.h
+++ b/src/FastLED.h
@@ -834,23 +834,21 @@ public:
 
 	/// @brief Enroll every channel driver available on this platform with `ChannelManager`.
 	///
-	/// Convenience forwarder to `fl::enableAllDrivers()` (defined in
-	/// `fl/channels/all_drivers.h`). Use this to restore 3.10.3-style runtime
-	/// driver flexibility — every driver is registered, any affinity string
-	/// resolves at runtime.
+	/// Convenience forwarder to `fl::enableAllDrivers()` (defined out-of-line
+	/// in `src/fl/channels/all_drivers.cpp.hpp`, linked into libfastled). Use
+	/// this to restore 3.10.3-style runtime driver flexibility — every driver
+	/// is registered, any affinity string resolves at runtime.
 	///
-	/// **Linker note (issue #2428).** This member's body lives in
-	/// `fl/channels/all_drivers.h`. Including that header is what makes the
-	/// per-platform `BusTraits<Bus::X>::instance()` singletons visible at the
-	/// call site so the linker keeps their translation units. If a sketch
-	/// never calls `FastLED.enableAllDrivers()`, `--gc-sections` drops the
-	/// inline body and every driver TU it references — the binary-bloat fix
-	/// from #2420 / #2421 is preserved.
+	/// **Tree-shaking (issue #2428).** The body lives in a single TU. If a
+	/// sketch never calls `FastLED.enableAllDrivers()`, `-Wl,--gc-sections`
+	/// drops that TU and transitively every `BusTraits<Bus::X>` /
+	/// `registerWithManager()` / driver factory it references — the
+	/// binary-size fix from #2420 / #2421 is preserved structurally, no
+	/// "magic include" required at the call site.
 	///
 	/// Example:
 	/// @code
 	/// #include "FastLED.h"
-	/// #include "fl/channels/all_drivers.h"
 	///
 	/// void setup() {
 	///     FastLED.enableAllDrivers();   // every platform driver registered
@@ -858,9 +856,6 @@ public:
 	///     FastLED.add(fl::ChannelConfig(..., opts));
 	/// }
 	/// @endcode
-	///
-	/// @note Calling without including `fl/channels/all_drivers.h` produces a
-	///       linker error — the include is the explicit opt-in.
 	static void enableAllDrivers();
 
 	/// @brief Remove a channel from the LED controller list

--- a/src/fl/channels/README.md
+++ b/src/fl/channels/README.md
@@ -228,13 +228,17 @@ void setup() {
 ```cpp
 // 2. Universal opt-in: 3.10.3-style "every driver available at runtime".
 #include "FastLED.h"
-#include "fl/channels/all_drivers.h"   // pulls in every BusTraits<> on the platform
 
 void setup() {
     FastLED.enableAllDrivers();        // forwards to fl::enableAllDrivers()
     // any cfg.options.mBus value now resolves at runtime via the manager
 }
 ```
+
+> `FastLED.enableAllDrivers()` is defined in `libfastled` (no extra include
+> needed). `-Wl,--gc-sections` drops the call graph — every driver TU it
+> references — when no sketch calls it, so the opt-in remains zero-cost
+> for sketches that don't need it.
 
 ```cpp
 // 3. Single-driver override: link the named driver AND set it at priority
@@ -1043,7 +1047,7 @@ See `tests/fl/channels/driver.cpp` for more test examples.
 - `fl/channels/bus.h` — `fl::Bus` enum, `busName()`, `DefaultBus<Chipset>`.
 - `fl/channels/bus_traits.h` — `BusTraits<B>`, `BusSupports<B, Chipset>`, `enableDrivers<Bus...>()`, `busKeepAlive<B>()`.
 - `fl/channels/bus_priorities.h` — `default_bus_priority(Bus)` table consumed by `enableDrivers<>()`.
-- `fl/channels/all_drivers.h` — `fl::enableAllDrivers()` / `FastLED.enableAllDrivers()` aggregator.
+- `fl/channels/all_drivers.h` — declaration header for `fl::enableAllDrivers()` / `FastLED.enableAllDrivers()`. The body lives in `all_drivers.cpp.hpp`, linked into libfastled; `--gc-sections` handles the tree-shaking.
 - `fl/channels/manager.h` — `ChannelManager` (`addDriver`, `getDriverByName`, `findDriverByName`, `selectDriverForChannel`, `setDriverPriority`, `setDriverEnabled`, `setExclusiveDriver`, `setExclusiveDriverByName`, `clearAllDrivers`, ...).
 - `fl/channels/channel_events.h` — Lifecycle event callbacks.
 - `fl/channels/driver.h` — `IChannelDriver` interface and `DriverState` machine.

--- a/src/fl/channels/_build.cpp.hpp
+++ b/src/fl/channels/_build.cpp.hpp
@@ -3,6 +3,7 @@
 /// Includes all implementation files in alphabetical order
 
 // begin current directory includes
+#include "fl/channels/all_drivers.cpp.hpp"
 #include "fl/channels/channel.cpp.hpp"
 #include "fl/channels/channel_events.cpp.hpp"
 #include "fl/channels/config.cpp.hpp"

--- a/src/fl/channels/all_drivers.cpp.hpp
+++ b/src/fl/channels/all_drivers.cpp.hpp
@@ -1,0 +1,118 @@
+/// @file all_drivers.cpp.hpp
+/// @brief Out-of-line definitions for `fl::enableAllDrivers()` and the
+///        `CFastLED::enableAllDrivers()` member.
+///
+/// This translation unit is the ONLY place that needs the per-platform
+/// `BusTraits<Bus::X>` specializations visible — so every per-driver
+/// `bus_traits.h` is pulled in here, not at the user's call site.
+///
+/// Tree-shaking: when a sketch never calls `FastLED.enableAllDrivers()` or
+/// `fl::enableAllDrivers()`, `-Wl,--gc-sections` drops this TU's text section,
+/// which transitively drops every `BusTraits<B>::registerWithManager()`,
+/// `BusTraits<B>::instancePtr()`, and each platform driver's factory
+/// (`ChannelEngineRMT::create()`, `createI2sEngine()`, ...). The
+/// binary-size fix from #2428 is preserved structurally rather than by
+/// convention — no "magic include" required at the call site.
+
+#include "fl/channels/all_drivers.h"
+
+#include "FastLED.h"   // CFastLED class (for the out-of-line member definition)
+#include "fl/channels/bus.h"
+#include "fl/channels/bus_traits.h"
+#include "fl/stl/compiler_control.h"
+#include "platforms/is_platform.h"
+
+#if defined(FL_IS_ESP32)
+// Pulled in here so the per-bus guards below see the FASTLED_ESP32_HAS_*
+// macros at the point of instantiation.
+#include "platforms/esp/32/feature_flags/enabled.h"  // ok platform headers // IWYU pragma: keep
+#endif
+
+// ---------------------------------------------------------------------------
+// Always-on drivers
+// ---------------------------------------------------------------------------
+
+#include "platforms/shared/bitbang/bus_traits.h"  // ok platform headers // IWYU pragma: keep
+
+// ---------------------------------------------------------------------------
+// Host / native / WASM
+// ---------------------------------------------------------------------------
+
+#if defined(FL_IS_STUB) || defined(FL_IS_WASM)
+#include "platforms/stub/bus_traits.h"  // ok platform headers // IWYU pragma: keep
+#endif
+
+// ---------------------------------------------------------------------------
+// ESP32 family
+// ---------------------------------------------------------------------------
+
+#if defined(FL_IS_ESP32)
+
+// Each per-driver bus_traits.h applies its own `FASTLED_ESP32_HAS_*` /
+// `FASTLED_RMT5` guard internally, so the include is unconditional here.
+#include "platforms/esp/32/drivers/i2s/bus_traits.h"        // ok platform headers // IWYU pragma: keep
+#include "platforms/esp/32/drivers/i2s_spi/bus_traits.h"    // ok platform headers // IWYU pragma: keep
+#include "platforms/esp/32/drivers/lcd_cam/bus_traits.h"    // ok platform headers // IWYU pragma: keep
+#include "platforms/esp/32/drivers/lcd_spi/bus_traits.h"    // ok platform headers // IWYU pragma: keep
+#include "platforms/esp/32/drivers/parlio/bus_traits.h"     // ok platform headers // IWYU pragma: keep
+#include "platforms/esp/32/drivers/rmt/rmt_4/bus_traits.h"  // ok platform headers // IWYU pragma: keep
+#include "platforms/esp/32/drivers/rmt/rmt_5/bus_traits.h"  // ok platform headers // IWYU pragma: keep
+#include "platforms/esp/32/drivers/spi/bus_traits.h"        // ok platform headers // IWYU pragma: keep
+#include "platforms/esp/32/drivers/uart/bus_traits.h"       // ok platform headers // IWYU pragma: keep
+
+#endif  // FL_IS_ESP32
+
+// ---------------------------------------------------------------------------
+// Teensy 4.x
+// ---------------------------------------------------------------------------
+
+#if defined(FL_IS_TEENSY_4X)
+#include "platforms/arm/teensy/teensy4_common/drivers/objectfled/bus_traits.h"  // ok platform headers // IWYU pragma: keep
+#include "platforms/arm/teensy/teensy4_common/drivers/flexio/bus_traits.h"      // ok platform headers // IWYU pragma: keep
+#endif
+
+namespace fl {
+
+void enableAllDrivers() FL_NOEXCEPT {
+    enableDrivers<
+        Bus::BIT_BANG
+#if defined(FL_IS_STUB) || defined(FL_IS_WASM)
+        , Bus::STUB
+#endif
+#if defined(FL_IS_ESP32) && FASTLED_ESP32_HAS_RMT
+        , Bus::RMT
+#endif
+#if defined(FL_IS_ESP32) && FASTLED_ESP32_HAS_PARLIO
+        , Bus::PARLIO
+#endif
+#if defined(FL_IS_ESP32) && FASTLED_ESP32_HAS_CLOCKLESS_SPI
+        , Bus::SPI
+#endif
+#if defined(FL_IS_ESP32) && FASTLED_ESP32_HAS_I2S_LCD_CAM
+        , Bus::I2S
+#endif
+#if defined(FL_IS_ESP32) && FASTLED_ESP32_HAS_I2S
+        , Bus::I2S_SPI
+#endif
+#if defined(FL_IS_ESP32) && FASTLED_ESP32_HAS_LCD_RGB
+        , Bus::LCD_RGB
+#endif
+#if defined(FL_IS_ESP32) && FASTLED_ESP32_HAS_LCD_SPI
+        , Bus::LCD_SPI
+        , Bus::LCD_CLOCKLESS
+#endif
+#if defined(FL_IS_ESP32) && FASTLED_ESP32_HAS_UART
+        , Bus::UART
+#endif
+#if defined(FL_IS_TEENSY_4X)
+        , Bus::OBJECT_FLED
+        , Bus::FLEX_IO
+#endif
+    >();
+}
+
+}  // namespace fl
+
+void CFastLED::enableAllDrivers() {
+    fl::enableAllDrivers();
+}

--- a/src/fl/channels/all_drivers.h
+++ b/src/fl/channels/all_drivers.h
@@ -1,159 +1,36 @@
 #pragma once
 
 /// @file all_drivers.h
-/// @brief One-shot include + helper that enrolls every channel driver
-///        available on the current platform into `ChannelManager`.
+/// @brief Declaration of `fl::enableAllDrivers()` — enrolls every channel
+///        driver available on the current platform into `ChannelManager`.
 ///
-/// In the default build, FastLED no longer eagerly registers every driver with
-/// `ChannelManager` (see issue #2428 — Phase 4 / Phase 5). Drivers are linked
-/// only when their `BusTraits<fl::Bus::X>::instance()` is named, which lets
-/// `--gc-sections` drop unreferenced driver TUs.
+/// The definition lives out-of-line in `all_drivers.cpp.hpp` (linked into
+/// `libfastled`), so calling `FastLED.enableAllDrivers()` or
+/// `fl::enableAllDrivers()` no longer requires any "magic include" at the
+/// call site — `<FastLED.h>` is enough.
 ///
-/// Sketches that want the 3.10.3-style behaviour (every driver registered, any
-/// affinity string resolves at runtime) can opt back in with one line:
-///
-/// @code
-///   #include "fl/channels/all_drivers.h"
-///   void setup() {
-///       FastLED.enableAllDrivers();      // or: fl::enableAllDrivers();
-///       FastLED.add(cfg_with_affinity);  // ChannelManager picks the driver
-///   }
-/// @endcode
-///
-/// Including this header pulls in every per-driver `bus_traits.h` that is
-/// reachable on the current platform, which makes the corresponding
-/// `BusTraits<Bus::X>` specializations visible at the call site. The helper
-/// then expands a single `enableDrivers<...>()` call covering them all.
-///
-/// This file is the canonical "kitchen-sink" driver bundle. Sketches that want
-/// only a subset should call `fl::enableDrivers<fl::Bus::X, fl::Bus::Y>()`
-/// directly after including the matching `bus_traits.h` headers.
+/// **Tree-shaking.** `-Wl,--gc-sections` (the default for every embedded
+/// toolchain FastLED supports) drops the `enableAllDrivers()` TU when no
+/// sketch references it. That transitively drops every
+/// `BusTraits<B>::registerWithManager()` / `instancePtr()` and each platform
+/// driver's factory — the binary-size fix from #2428 is preserved
+/// structurally rather than by convention. Including this header is
+/// harmless but no longer required.
 
-#include "fl/channels/bus.h"
-#include "fl/channels/bus_traits.h"
 #include "fl/stl/compiler_control.h"
-#include "fl/system/fastled.h"
-#include "platforms/is_platform.h"
-
-#if defined(FL_IS_ESP32)
-// Pulled in here so the per-bus guards below see the FASTLED_ESP32_HAS_*
-// macros at the call site.
-#include "platforms/esp/32/feature_flags/enabled.h"  // ok platform headers // IWYU pragma: keep
-#endif
-
-// ---------------------------------------------------------------------------
-// Always-on drivers
-// ---------------------------------------------------------------------------
-
-#include "platforms/shared/bitbang/bus_traits.h"  // ok platform headers // IWYU pragma: keep
-
-// ---------------------------------------------------------------------------
-// Host / native / WASM
-// ---------------------------------------------------------------------------
-
-#if defined(FL_IS_STUB) || defined(FL_IS_WASM)
-#include "platforms/stub/bus_traits.h"  // ok platform headers // IWYU pragma: keep
-#endif
-
-// ---------------------------------------------------------------------------
-// ESP32 family
-// ---------------------------------------------------------------------------
-
-#if defined(FL_IS_ESP32)
-
-// Each per-driver bus_traits.h applies its own `FASTLED_ESP32_HAS_*` /
-// `FASTLED_RMT5` guard internally, so the include is unconditional here.
-#include "platforms/esp/32/drivers/i2s/bus_traits.h"        // ok platform headers // IWYU pragma: keep
-#include "platforms/esp/32/drivers/i2s_spi/bus_traits.h"    // ok platform headers // IWYU pragma: keep
-#include "platforms/esp/32/drivers/lcd_cam/bus_traits.h"    // ok platform headers // IWYU pragma: keep
-#include "platforms/esp/32/drivers/lcd_spi/bus_traits.h"    // ok platform headers // IWYU pragma: keep
-#include "platforms/esp/32/drivers/parlio/bus_traits.h"     // ok platform headers // IWYU pragma: keep
-#include "platforms/esp/32/drivers/rmt/rmt_4/bus_traits.h"  // ok platform headers // IWYU pragma: keep
-#include "platforms/esp/32/drivers/rmt/rmt_5/bus_traits.h"  // ok platform headers // IWYU pragma: keep
-#include "platforms/esp/32/drivers/spi/bus_traits.h"        // ok platform headers // IWYU pragma: keep
-#include "platforms/esp/32/drivers/uart/bus_traits.h"       // ok platform headers // IWYU pragma: keep
-
-#endif  // FL_IS_ESP32
-
-// ---------------------------------------------------------------------------
-// Teensy 4.x
-// ---------------------------------------------------------------------------
-
-#if defined(FL_IS_TEENSY_4X)
-#include "platforms/arm/teensy/teensy4_common/drivers/objectfled/bus_traits.h"  // ok platform headers // IWYU pragma: keep
-#include "platforms/arm/teensy/teensy4_common/drivers/flexio/bus_traits.h"      // ok platform headers // IWYU pragma: keep
-#endif
 
 namespace fl {
 
 /// @brief Register every channel driver available on this platform with
 ///        `ChannelManager`, restoring 3.10.3-style runtime driver selection.
 ///
-/// This is the convenience counterpart to `fl::enableDrivers<Bus...>()`. It
-/// expands to a fold over the platform-appropriate `Bus` set so that:
+/// Convenience counterpart to `fl::enableDrivers<Bus...>()`. Idempotent —
+/// `BusTraits<B>::registerWithManager()` deduplicates by name on the manager
+/// side, so calling more than once is safe.
 ///
-///   - Each driver's translation unit is linked (its `BusTraits<B>::instance()`
-///     is ODR-used).
-///   - Each driver is registered with `ChannelManager` at its default priority,
-///     allowing `Channel::create(cfg)` to dispatch by affinity / priority at
-///     runtime.
-///
-/// The helper is idempotent — `BusTraits<B>::registerWithManager()` deduplicates
-/// by name on the manager side, so calling it more than once is safe.
-///
-/// **Performance vs. binary size.** Calling this brings every driver TU into
-/// the link, which is exactly what the default build avoids (see #2428 for the
-/// motivation). Only call it when you actually need runtime flexibility.
-inline void enableAllDrivers() FL_NOEXCEPT {
-    enableDrivers<
-        Bus::BIT_BANG
-#if defined(FL_IS_STUB) || defined(FL_IS_WASM)
-        , Bus::STUB
-#endif
-#if defined(FL_IS_ESP32) && FASTLED_ESP32_HAS_RMT
-        , Bus::RMT
-#endif
-#if defined(FL_IS_ESP32) && FASTLED_ESP32_HAS_PARLIO
-        , Bus::PARLIO
-#endif
-#if defined(FL_IS_ESP32) && FASTLED_ESP32_HAS_CLOCKLESS_SPI
-        , Bus::SPI
-#endif
-#if defined(FL_IS_ESP32) && FASTLED_ESP32_HAS_I2S_LCD_CAM
-        , Bus::I2S
-#endif
-#if defined(FL_IS_ESP32) && FASTLED_ESP32_HAS_I2S
-        , Bus::I2S_SPI
-#endif
-#if defined(FL_IS_ESP32) && FASTLED_ESP32_HAS_LCD_RGB
-        , Bus::LCD_RGB
-#endif
-#if defined(FL_IS_ESP32) && FASTLED_ESP32_HAS_LCD_SPI
-        , Bus::LCD_SPI
-        , Bus::LCD_CLOCKLESS
-#endif
-#if defined(FL_IS_ESP32) && FASTLED_ESP32_HAS_UART
-        , Bus::UART
-#endif
-#if defined(FL_IS_TEENSY_4X)
-        , Bus::OBJECT_FLED
-        , Bus::FLEX_IO
-#endif
-    >();
-}
+/// **Performance vs. binary size.** Calling this brings every driver TU
+/// into the link, which is exactly what the default build avoids (see
+/// #2428). Only call when you actually need runtime driver flexibility.
+void enableAllDrivers() FL_NOEXCEPT;
 
 }  // namespace fl
-
-/// @brief Out-of-line definition of the `CFastLED::enableAllDrivers()` member
-///        declared in `FastLED.h`.
-///
-/// Defined here so that calling `FastLED.enableAllDrivers()` requires the user
-/// to `#include "fl/channels/all_drivers.h"` — which is what brings the
-/// per-platform `BusTraits<Bus::X>` specializations into scope. Without that
-/// include the call fails to link, preserving the binary-bloat fix from #2428.
-///
-/// Marked `inline` so multiple translation units that include this header
-/// don't produce duplicate-symbol linker errors.
-inline void CFastLED::enableAllDrivers() {
-    fl::enableAllDrivers();
-}

--- a/tests/fl/channels/all_drivers.cpp
+++ b/tests/fl/channels/all_drivers.cpp
@@ -22,6 +22,11 @@
 #include "fl/channels/bus_traits.h"
 #include "fl/channels/manager.h"
 #include "fl/stl/string.h"
+#include "platforms/is_platform.h"
+#include "platforms/shared/bitbang/bus_traits.h"  // BusTraits<Bus::BIT_BANG>
+#if defined(FL_IS_STUB) || defined(FL_IS_WASM)
+#include "platforms/stub/bus_traits.h"            // BusTraits<Bus::STUB>
+#endif
 #include "test.h"
 
 FL_TEST_FILE(FL_FILEPATH) {


### PR DESCRIPTION
## Summary

Removes the "magic include" requirement for `FastLED.enableAllDrivers()`. The function's body now lives in a TU (`src/fl/channels/all_drivers.cpp.hpp`) compiled into libfastled instead of `inline` in a header — so calling it is a structural opt-in, not a convention-based one. `-Wl,--gc-sections` does the tree-shaking when sketches don't reference it. Supersedes #2477.

## Why

Master CI was failing on `SpecialDrivers/ESP/DriverTest` because the example called `FastLED.enableAllDrivers()` without `#include "fl/channels/all_drivers.h"`. The fix originally proposed (#2477) was to add the include. But the failure surfaces a deeper architectural issue: the dual-mode design from #2428 puts the function body in a header *only* to force users to remember the include — there's no technical reason it has to be inline.

Every `BusTraits<B>` uses a function-local-static singleton (no constructor-attribute side effects, no namespace-scope eager init). The entire driver call graph is reachable only through `enableAllDrivers() → registerWithManager() → instancePtr() → Driver::create()`. With `-ffunction-sections -fdata-sections -Wl,--gc-sections` — the default on every embedded toolchain FastLED supports (AVR, Teensy ARM, ESP32 Xtensa/RISC-V, WASM via lld) — the linker drops the whole subtree transitively when nothing calls `enableAllDrivers()`. Moving the body to a TU yields the same binary size as the inline-in-header pattern, without the brittle include-or-link-error gotcha.

## Changes

- **New TU `src/fl/channels/all_drivers.cpp.hpp`** holds out-of-line definitions of both `fl::enableAllDrivers()` and `CFastLED::enableAllDrivers()`. Pulls in every per-platform `bus_traits.h` only at the point of instantiation.
- **`src/fl/channels/_build.cpp.hpp`** wires the new TU into the unity build.
- **`src/fl/channels/all_drivers.h`** shrunk from 159 → ~35 lines. Pure declaration header. Existing sketches that included it still build.
- **`src/FastLED.h:835-864`** doxygen rewritten — drop the "Linker note (#2428)" paragraph and the `@note` warning about link errors; add a short tree-shaking note about `--gc-sections`.
- **`src/fl/channels/README.md`** updated.
- **`tests/fl/channels/all_drivers.cpp`** explicitly includes bitbang/stub `bus_traits.h` headers (it directly tests `BusTraits<Bus::BIT_BANG>::instance()` and was previously getting them transitively from `all_drivers.h`).
- **`ci/compiler/pio.py`** incidental ruff line-wrap reformat applied by `bash lint`.

## Verification

- `bash test --cpp` — **188/188 passing** locally.
- `bash lint` — clean.
- Local PIO builds for esp32s3 + teensy41 hit unrelated Windows-env issues on this machine (missing `soc/soc_caps.h` in fbuild cache; path-too-long on link). CI on Linux runners will validate the platform builds.

## What to look for in CI

The architectural claim is "binary size for sketches that don't call `enableAllDrivers()` is unchanged after this refactor." Watch:
- `build_esp32s3` (DriverTest now builds without the band-aid include).
- `build_esp32dev_i2s`.
- `build_teensy41` / `build_teensy40` / `build_teensy36` / `build_teensy35` (DriverTest is esp32-only, but make sure nothing teensy regresses).
- `build_uno` / AVR builds (smallest binary; most sensitive to bloat).
- `build_linux` host tests.

If `Blink` firmware size grows by more than ~64 bytes (symbol-table noise) on any target compared to master, `--gc-sections` failed to drop a TU transitively and we need to investigate before merging.

## Related

- Supersedes #2477 (band-aid include) — closing that PR after this one is open.
- #2428 — original dual-mode design that introduced the inline-in-header pattern.
- #2476 — the CI switch to fbuild compile-many that surfaced the missing-include link failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated driver initialization documentation to reflect implementation location changes and clarified linker tree-shaking behavior for binary size optimization.

* **Refactor**
  * Restructured driver initialization implementation to eliminate explicit include requirements, enabling automatic linker optimization without affecting functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/FastLED/pull/2478)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->