### PR TITLE
fix: ship wasm json inspector css

### DIFF
--- a/ci/esbuild_frontend.py
+++ b/ci/esbuild_frontend.py
@@ -116,6 +116,16 @@ def _compute_dir_hash(directory: Path) -> str:
     return digest.hexdigest()
 
 
+def _has_required_static_dist_assets(dist_dir: Path) -> bool:
+    return all(
+        path.is_file()
+        for path in (
+            dist_dir / "index.css",
+            dist_dir / "modules" / "utils" / "json_inspector.css",
+        )
+    )
+
+
 def _run_esbuild(args: list[str]) -> None:
     esbuild = install_esbuild()
     result = subprocess.run(
@@ -136,7 +146,10 @@ def build_dist() -> Path:
     source_mtime = _get_source_mtime(FRONTEND_DIR)
     if dist_dir.exists() and marker.exists():
         try:
-            if float(marker.read_text(encoding="utf-8").strip()) >= source_mtime:
+            if (
+                float(marker.read_text(encoding="utf-8").strip()) >= source_mtime
+                and _has_required_static_dist_assets(dist_dir)
+            ):
                 return dist_dir
         except ValueError:
             pass
@@ -177,6 +190,10 @@ def build_dist() -> Path:
     )
     (dist_dir / "index.html").write_text(index_html, encoding="utf-8")
     _copy_file(FRONTEND_DIR / "index.css", dist_dir / "index.css")
+    _copy_file(
+        FRONTEND_DIR / "modules" / "utils" / "json_inspector.css",
+        dist_dir / "modules" / "utils" / "json_inspector.css",
+    )
     _copy_file(
         FRONTEND_DIR / "modules" / "audio" / "audio_worklet_processor.js",
         dist_dir / "audio_worklet_processor.js",

--- a/src/platforms/wasm/compiler/index.html
+++ b/src/platforms/wasm/compiler/index.html
@@ -150,26 +150,26 @@
         </div>
     </div>
 
+    <!-- JSON Inspector Popup -->
+    <div class="inspector-popup-overlay" id="inspector-popup-overlay"></div>
+    <div class="inspector-popup" id="json-inspector-popup">
+        <div class="inspector-header">
+            <span class="inspector-title">JSON UI Inspector</span>
+            <button class="inspector-close" id="inspector-close-btn">&times;</button>
+        </div>
+        <div class="inspector-content">
+            <div class="inspector-controls">
+                <button id="inspector-clear">Clear</button>
+                <button id="inspector-pause">Pause</button>
+                <span class="event-counter">Events: <span id="event-count">0</span></span>
+            </div>
+            <div class="inspector-log" id="inspector-log"></div>
+        </div>
+    </div>
+
     <!-- Main application entry point — Vite bundles this -->
     <script type="module" src="./app.ts"></script>
 
 </body>
-
-<!-- JSON Inspector Popup -->
-<div class="inspector-popup-overlay" id="inspector-popup-overlay"></div>
-<div class="inspector-popup" id="json-inspector-popup">
-    <div class="inspector-header">
-        <span class="inspector-title">JSON UI Inspector</span>
-        <button class="inspector-close" id="inspector-close-btn">&times;</button>
-    </div>
-    <div class="inspector-content">
-        <div class="inspector-controls">
-            <button id="inspector-clear">Clear</button>
-            <button id="inspector-pause">Pause</button>
-            <span class="event-counter">Events: <span id="event-count">0</span></span>
-        </div>
-        <div class="inspector-log" id="inspector-log"></div>
-    </div>
-</div>
 
 </html>


### PR DESCRIPTION
## Summary
- copy the JSON inspector stylesheet into the wasm frontend dist output
- invalidate stale frontend dist caches when the imported inspector CSS is missing
- move the JSON inspector popup markup inside `<body>` so generated HTML is valid

## Verification
- frontend build smoke: `inspector_css=True`, `inspector_after_body=False`, `app_js=True`, `worker_js=True`
- `git diff --check`
