### PR TITLE
refactor(channels): trampoline enableAllDrivers platform bundles

### DIFF
--- a/src/FastLED.cpp.hpp
+++ b/src/FastLED.cpp.hpp
@@ -552,6 +552,10 @@ void delay_at_max_brightness_for_power(fl::u16 ms)
 // Channel Bus Manager Controls
 // ============================================================================
 
+void CFastLED::enableAllDrivers() {
+	fl::enableAllDrivers();
+}
+
 void CFastLED::setDriverEnabled(const char* name, bool enabled) {
 	fl::ChannelManager& manager = fl::channelManager();
 	manager.setDriverEnabled(name, enabled);

--- a/src/FastLED.h
+++ b/src/FastLED.h
@@ -834,23 +834,21 @@ public:
 
 	/// @brief Enroll every channel driver available on this platform with `ChannelManager`.
 	///
-	/// Convenience forwarder to `fl::enableAllDrivers()` (defined in
-	/// `fl/channels/all_drivers.h`). Use this to restore 3.10.3-style runtime
-	/// driver flexibility — every driver is registered, any affinity string
-	/// resolves at runtime.
+	/// Convenience forwarder to `fl::enableAllDrivers()` (defined out-of-line
+	/// in `src/platforms/channel_drivers.impl.cpp.hpp`, linked into libfastled). Use
+	/// this to restore 3.10.3-style runtime driver flexibility — every driver
+	/// is registered, any affinity string resolves at runtime.
 	///
-	/// **Linker note (issue #2428).** This member's body lives in
-	/// `fl/channels/all_drivers.h`. Including that header is what makes the
-	/// per-platform `BusTraits<Bus::X>::instance()` singletons visible at the
-	/// call site so the linker keeps their translation units. If a sketch
-	/// never calls `FastLED.enableAllDrivers()`, `--gc-sections` drops the
-	/// inline body and every driver TU it references — the binary-bloat fix
-	/// from #2420 / #2421 is preserved.
+	/// **Tree-shaking (issue #2428).** The body lives in a single TU. If a
+	/// sketch never calls `FastLED.enableAllDrivers()`, `-Wl,--gc-sections`
+	/// drops that TU and transitively every `BusTraits<Bus::X>` /
+	/// `registerWithManager()` / driver factory it references — the
+	/// binary-size fix from #2420 / #2421 is preserved structurally, no
+	/// "magic include" required at the call site.
 	///
 	/// Example:
 	/// @code
 	/// #include "FastLED.h"
-	/// #include "fl/channels/all_drivers.h"
 	///
 	/// void setup() {
 	///     FastLED.enableAllDrivers();   // every platform driver registered
@@ -858,9 +856,6 @@ public:
 	///     FastLED.add(fl::ChannelConfig(..., opts));
 	/// }
 	/// @endcode
-	///
-	/// @note Calling without including `fl/channels/all_drivers.h` produces a
-	///       linker error — the include is the explicit opt-in.
 	static void enableAllDrivers();
 
 	/// @brief Remove a channel from the LED controller list

--- a/src/fl/channels/README.md
+++ b/src/fl/channels/README.md
@@ -228,13 +228,17 @@ void setup() {
 ```cpp
 // 2. Universal opt-in: 3.10.3-style "every driver available at runtime".
 #include "FastLED.h"
-#include "fl/channels/all_drivers.h"   // pulls in every BusTraits<> on the platform
 
 void setup() {
     FastLED.enableAllDrivers();        // forwards to fl::enableAllDrivers()
     // any cfg.options.mBus value now resolves at runtime via the manager
 }
 ```
+
+> `FastLED.enableAllDrivers()` is defined in `libfastled` (no extra include
+> needed). `-Wl,--gc-sections` drops the call graph — every driver TU it
+> references — when no sketch calls it, so the opt-in remains zero-cost
+> for sketches that don't need it.
 
 ```cpp
 // 3. Single-driver override: link the named driver AND set it at priority
@@ -1043,7 +1047,7 @@ See `tests/fl/channels/driver.cpp` for more test examples.
 - `fl/channels/bus.h` — `fl::Bus` enum, `busName()`, `DefaultBus<Chipset>`.
 - `fl/channels/bus_traits.h` — `BusTraits<B>`, `BusSupports<B, Chipset>`, `enableDrivers<Bus...>()`, `busKeepAlive<B>()`.
 - `fl/channels/bus_priorities.h` — `default_bus_priority(Bus)` table consumed by `enableDrivers<>()`.
-- `fl/channels/all_drivers.h` — `fl::enableAllDrivers()` / `FastLED.enableAllDrivers()` aggregator.
+- `fl/channels/all_drivers.h` — declaration header for `fl::enableAllDrivers()` / `FastLED.enableAllDrivers()`. The body lives in `platforms/channel_drivers.impl.cpp.hpp`, linked into libfastled; `--gc-sections` handles the tree-shaking.
 - `fl/channels/manager.h` — `ChannelManager` (`addDriver`, `getDriverByName`, `findDriverByName`, `selectDriverForChannel`, `setDriverPriority`, `setDriverEnabled`, `setExclusiveDriver`, `setExclusiveDriverByName`, `clearAllDrivers`, ...).
 - `fl/channels/channel_events.h` — Lifecycle event callbacks.
 - `fl/channels/driver.h` — `IChannelDriver` interface and `DriverState` machine.

--- a/src/fl/channels/all_drivers.h
+++ b/src/fl/channels/all_drivers.h
@@ -1,159 +1,36 @@
 #pragma once
 
 /// @file all_drivers.h
-/// @brief One-shot include + helper that enrolls every channel driver
-///        available on the current platform into `ChannelManager`.
+/// @brief Declaration of `fl::enableAllDrivers()` — enrolls every channel
+///        driver available on the current platform into `ChannelManager`.
 ///
-/// In the default build, FastLED no longer eagerly registers every driver with
-/// `ChannelManager` (see issue #2428 — Phase 4 / Phase 5). Drivers are linked
-/// only when their `BusTraits<fl::Bus::X>::instance()` is named, which lets
-/// `--gc-sections` drop unreferenced driver TUs.
+/// The definition lives out-of-line in
+/// `platforms/channel_drivers.impl.cpp.hpp` (linked into `libfastled`), so
+/// calling `FastLED.enableAllDrivers()` or `fl::enableAllDrivers()` no longer
+/// requires any "magic include" at the call site — `<FastLED.h>` is enough.
 ///
-/// Sketches that want the 3.10.3-style behaviour (every driver registered, any
-/// affinity string resolves at runtime) can opt back in with one line:
-///
-/// @code
-///   #include "fl/channels/all_drivers.h"
-///   void setup() {
-///       FastLED.enableAllDrivers();      // or: fl::enableAllDrivers();
-///       FastLED.add(cfg_with_affinity);  // ChannelManager picks the driver
-///   }
-/// @endcode
-///
-/// Including this header pulls in every per-driver `bus_traits.h` that is
-/// reachable on the current platform, which makes the corresponding
-/// `BusTraits<Bus::X>` specializations visible at the call site. The helper
-/// then expands a single `enableDrivers<...>()` call covering them all.
-///
-/// This file is the canonical "kitchen-sink" driver bundle. Sketches that want
-/// only a subset should call `fl::enableDrivers<fl::Bus::X, fl::Bus::Y>()`
-/// directly after including the matching `bus_traits.h` headers.
+/// **Tree-shaking.** `-Wl,--gc-sections` (the default for every embedded
+/// toolchain FastLED supports) drops the `enableAllDrivers()` TU when no
+/// sketch references it. That transitively drops every
+/// `BusTraits<B>::registerWithManager()` / `instancePtr()` and each platform
+/// driver's factory — the binary-size fix from #2428 is preserved
+/// structurally rather than by convention. Including this header is
+/// harmless but no longer required.
 
-#include "fl/channels/bus.h"
-#include "fl/channels/bus_traits.h"
 #include "fl/stl/compiler_control.h"
-#include "fl/system/fastled.h"
-#include "platforms/is_platform.h"
-
-#if defined(FL_IS_ESP32)
-// Pulled in here so the per-bus guards below see the FASTLED_ESP32_HAS_*
-// macros at the call site.
-#include "platforms/esp/32/feature_flags/enabled.h"  // ok platform headers // IWYU pragma: keep
-#endif
-
-// ---------------------------------------------------------------------------
-// Always-on drivers
-// ---------------------------------------------------------------------------
-
-#include "platforms/shared/bitbang/bus_traits.h"  // ok platform headers // IWYU pragma: keep
-
-// ---------------------------------------------------------------------------
-// Host / native / WASM
-// ---------------------------------------------------------------------------
-
-#if defined(FL_IS_STUB) || defined(FL_IS_WASM)
-#include "platforms/stub/bus_traits.h"  // ok platform headers // IWYU pragma: keep
-#endif
-
-// ---------------------------------------------------------------------------
-// ESP32 family
-// ---------------------------------------------------------------------------
-
-#if defined(FL_IS_ESP32)
-
-// Each per-driver bus_traits.h applies its own `FASTLED_ESP32_HAS_*` /
-// `FASTLED_RMT5` guard internally, so the include is unconditional here.
-#include "platforms/esp/32/drivers/i2s/bus_traits.h"        // ok platform headers // IWYU pragma: keep
-#include "platforms/esp/32/drivers/i2s_spi/bus_traits.h"    // ok platform headers // IWYU pragma: keep
-#include "platforms/esp/32/drivers/lcd_cam/bus_traits.h"    // ok platform headers // IWYU pragma: keep
-#include "platforms/esp/32/drivers/lcd_spi/bus_traits.h"    // ok platform headers // IWYU pragma: keep
-#include "platforms/esp/32/drivers/parlio/bus_traits.h"     // ok platform headers // IWYU pragma: keep
-#include "platforms/esp/32/drivers/rmt/rmt_4/bus_traits.h"  // ok platform headers // IWYU pragma: keep
-#include "platforms/esp/32/drivers/rmt/rmt_5/bus_traits.h"  // ok platform headers // IWYU pragma: keep
-#include "platforms/esp/32/drivers/spi/bus_traits.h"        // ok platform headers // IWYU pragma: keep
-#include "platforms/esp/32/drivers/uart/bus_traits.h"       // ok platform headers // IWYU pragma: keep
-
-#endif  // FL_IS_ESP32
-
-// ---------------------------------------------------------------------------
-// Teensy 4.x
-// ---------------------------------------------------------------------------
-
-#if defined(FL_IS_TEENSY_4X)
-#include "platforms/arm/teensy/teensy4_common/drivers/objectfled/bus_traits.h"  // ok platform headers // IWYU pragma: keep
-#include "platforms/arm/teensy/teensy4_common/drivers/flexio/bus_traits.h"      // ok platform headers // IWYU pragma: keep
-#endif
 
 namespace fl {
 
 /// @brief Register every channel driver available on this platform with
 ///        `ChannelManager`, restoring 3.10.3-style runtime driver selection.
 ///
-/// This is the convenience counterpart to `fl::enableDrivers<Bus...>()`. It
-/// expands to a fold over the platform-appropriate `Bus` set so that:
+/// Convenience counterpart to `fl::enableDrivers<Bus...>()`. Idempotent —
+/// `BusTraits<B>::registerWithManager()` deduplicates by name on the manager
+/// side, so calling more than once is safe.
 ///
-///   - Each driver's translation unit is linked (its `BusTraits<B>::instance()`
-///     is ODR-used).
-///   - Each driver is registered with `ChannelManager` at its default priority,
-///     allowing `Channel::create(cfg)` to dispatch by affinity / priority at
-///     runtime.
-///
-/// The helper is idempotent — `BusTraits<B>::registerWithManager()` deduplicates
-/// by name on the manager side, so calling it more than once is safe.
-///
-/// **Performance vs. binary size.** Calling this brings every driver TU into
-/// the link, which is exactly what the default build avoids (see #2428 for the
-/// motivation). Only call it when you actually need runtime flexibility.
-inline void enableAllDrivers() FL_NOEXCEPT {
-    enableDrivers<
-        Bus::BIT_BANG
-#if defined(FL_IS_STUB) || defined(FL_IS_WASM)
-        , Bus::STUB
-#endif
-#if defined(FL_IS_ESP32) && FASTLED_ESP32_HAS_RMT
-        , Bus::RMT
-#endif
-#if defined(FL_IS_ESP32) && FASTLED_ESP32_HAS_PARLIO
-        , Bus::PARLIO
-#endif
-#if defined(FL_IS_ESP32) && FASTLED_ESP32_HAS_CLOCKLESS_SPI
-        , Bus::SPI
-#endif
-#if defined(FL_IS_ESP32) && FASTLED_ESP32_HAS_I2S_LCD_CAM
-        , Bus::I2S
-#endif
-#if defined(FL_IS_ESP32) && FASTLED_ESP32_HAS_I2S
-        , Bus::I2S_SPI
-#endif
-#if defined(FL_IS_ESP32) && FASTLED_ESP32_HAS_LCD_RGB
-        , Bus::LCD_RGB
-#endif
-#if defined(FL_IS_ESP32) && FASTLED_ESP32_HAS_LCD_SPI
-        , Bus::LCD_SPI
-        , Bus::LCD_CLOCKLESS
-#endif
-#if defined(FL_IS_ESP32) && FASTLED_ESP32_HAS_UART
-        , Bus::UART
-#endif
-#if defined(FL_IS_TEENSY_4X)
-        , Bus::OBJECT_FLED
-        , Bus::FLEX_IO
-#endif
-    >();
-}
+/// **Performance vs. binary size.** Calling this brings every driver TU
+/// into the link, which is exactly what the default build avoids (see
+/// #2428). Only call when you actually need runtime driver flexibility.
+void enableAllDrivers() FL_NOEXCEPT;
 
 }  // namespace fl
-
-/// @brief Out-of-line definition of the `CFastLED::enableAllDrivers()` member
-///        declared in `FastLED.h`.
-///
-/// Defined here so that calling `FastLED.enableAllDrivers()` requires the user
-/// to `#include "fl/channels/all_drivers.h"` — which is what brings the
-/// per-platform `BusTraits<Bus::X>` specializations into scope. Without that
-/// include the call fails to link, preserving the binary-bloat fix from #2428.
-///
-/// Marked `inline` so multiple translation units that include this header
-/// don't produce duplicate-symbol linker errors.
-inline void CFastLED::enableAllDrivers() {
-    fl::enableAllDrivers();
-}

--- a/src/platforms/_build.cpp.hpp
+++ b/src/platforms/_build.cpp.hpp
@@ -6,6 +6,7 @@
 // Root directory implementations (alphabetical order)
 
 // begin current directory includes
+#include "platforms/channel_drivers.impl.cpp.hpp" // ok include cpp.hpp
 #include "platforms/compile_test.cpp.hpp"
 #include "platforms/coroutine.impl.cpp.hpp" // ok include cpp.hpp
 #include "platforms/debug_setup.cpp.hpp"

--- a/src/platforms/arm/teensy/channel_drivers_teensy.impl.hpp
+++ b/src/platforms/arm/teensy/channel_drivers_teensy.impl.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+// IWYU pragma: private
+
+/// @file channel_drivers_teensy.impl.hpp
+/// @brief Teensy channel-driver fragment for `fl::enableAllDrivers()`.
+
+#include "fl/channels/bus.h"
+#include "fl/channels/bus_traits.h"
+#include "fl/stl/compiler_control.h"
+#include "platforms/arm/teensy/is_teensy.h"
+#include "platforms/shared/bitbang/bus_traits.h"  // ok platform headers // IWYU pragma: keep
+
+#if defined(FL_IS_TEENSY_4X)
+#include "platforms/arm/teensy/teensy4_common/drivers/flexio/bus_traits.h"      // ok platform headers // IWYU pragma: keep
+#include "platforms/arm/teensy/teensy4_common/drivers/objectfled/bus_traits.h"  // ok platform headers // IWYU pragma: keep
+#endif
+
+namespace fl {
+namespace platforms {
+
+inline void enableAllChannelDrivers() FL_NOEXCEPT {
+    fl::enableDrivers<
+        fl::Bus::BIT_BANG
+#if defined(FL_IS_TEENSY_4X)
+        , fl::Bus::FLEX_IO
+        , fl::Bus::OBJECT_FLED
+#endif
+    >();
+}
+
+}  // namespace platforms
+}  // namespace fl

--- a/src/platforms/channel_drivers.impl.cpp.hpp
+++ b/src/platforms/channel_drivers.impl.cpp.hpp
@@ -1,0 +1,40 @@
+// IWYU pragma: private
+
+/// @file platforms/channel_drivers.impl.cpp.hpp
+/// @brief Platform dispatch for the `fl::enableAllDrivers()` driver bundle.
+///
+/// This router is the only place that needs the per-platform `BusTraits<Bus::X>`
+/// specializations visible. It includes exactly one platform fragment, so every
+/// per-driver `bus_traits.h` is pulled in here, not at the user's call site.
+/// Platforms without an explicit fragment use the null implementation, which
+/// gives the public API an empty definition without registering any drivers.
+///
+/// Tree-shaking: when a sketch never calls `FastLED.enableAllDrivers()` or
+/// `fl::enableAllDrivers()`, `-Wl,--gc-sections` drops this TU's text section,
+/// which transitively drops every `BusTraits<B>::registerWithManager()`,
+/// `BusTraits<B>::instancePtr()`, and each platform driver's factory
+/// (`ChannelEngineRMT::create()`, `createI2sEngine()`, ...). The
+/// binary-size fix from #2428 is preserved structurally rather than by
+/// convention - no "magic include" required at the call site.
+
+#include "fl/channels/all_drivers.h"
+
+#include "platforms/is_platform.h"
+
+#if defined(FL_IS_ESP32)
+#include "platforms/esp/32/channel_drivers_esp32.impl.hpp"
+#elif defined(FL_IS_TEENSY_4X)
+#include "platforms/arm/teensy/channel_drivers_teensy.impl.hpp"
+#elif defined(FL_IS_STUB) || defined(FL_IS_WASM)
+#include "platforms/stub/channel_drivers_stub.impl.hpp"
+#else
+#include "platforms/shared/channel_drivers_null.impl.hpp"
+#endif
+
+namespace fl {
+
+void enableAllDrivers() FL_NOEXCEPT {
+    platforms::enableAllChannelDrivers();
+}
+
+}  // namespace fl

--- a/src/platforms/esp/32/channel_drivers_esp32.impl.hpp
+++ b/src/platforms/esp/32/channel_drivers_esp32.impl.hpp
@@ -1,0 +1,61 @@
+#pragma once
+
+// IWYU pragma: private
+
+/// @file channel_drivers_esp32.impl.hpp
+/// @brief ESP32 channel-driver fragment for `fl::enableAllDrivers()`.
+
+#include "fl/channels/bus.h"
+#include "fl/channels/bus_traits.h"
+#include "fl/stl/compiler_control.h"
+#include "platforms/esp/32/feature_flags/enabled.h"
+#include "platforms/shared/bitbang/bus_traits.h"  // ok platform headers // IWYU pragma: keep
+
+// Each per-driver bus_traits.h applies its own `FASTLED_ESP32_HAS_*` /
+// `FASTLED_RMT5` guard internally, so the include is unconditional here.
+#include "platforms/esp/32/drivers/i2s/bus_traits.h"        // ok platform headers // IWYU pragma: keep
+#include "platforms/esp/32/drivers/i2s_spi/bus_traits.h"    // ok platform headers // IWYU pragma: keep
+#include "platforms/esp/32/drivers/lcd_cam/bus_traits.h"    // ok platform headers // IWYU pragma: keep
+#include "platforms/esp/32/drivers/lcd_spi/bus_traits.h"    // ok platform headers // IWYU pragma: keep
+#include "platforms/esp/32/drivers/parlio/bus_traits.h"     // ok platform headers // IWYU pragma: keep
+#include "platforms/esp/32/drivers/rmt/rmt_4/bus_traits.h"  // ok platform headers // IWYU pragma: keep
+#include "platforms/esp/32/drivers/rmt/rmt_5/bus_traits.h"  // ok platform headers // IWYU pragma: keep
+#include "platforms/esp/32/drivers/spi/bus_traits.h"        // ok platform headers // IWYU pragma: keep
+#include "platforms/esp/32/drivers/uart/bus_traits.h"       // ok platform headers // IWYU pragma: keep
+
+namespace fl {
+namespace platforms {
+
+inline void enableAllChannelDrivers() FL_NOEXCEPT {
+    fl::enableDrivers<
+        fl::Bus::BIT_BANG
+#if FASTLED_ESP32_HAS_RMT
+        , fl::Bus::RMT
+#endif
+#if FASTLED_ESP32_HAS_PARLIO
+        , fl::Bus::PARLIO
+#endif
+#if FASTLED_ESP32_HAS_CLOCKLESS_SPI
+        , fl::Bus::SPI
+#endif
+#if FASTLED_ESP32_HAS_I2S_LCD_CAM
+        , fl::Bus::I2S
+#endif
+#if FASTLED_ESP32_HAS_I2S
+        , fl::Bus::I2S_SPI
+#endif
+#if FASTLED_ESP32_HAS_LCD_RGB
+        , fl::Bus::LCD_RGB
+#endif
+#if FASTLED_ESP32_HAS_LCD_SPI
+        , fl::Bus::LCD_SPI
+        , fl::Bus::LCD_CLOCKLESS
+#endif
+#if FASTLED_ESP32_HAS_UART
+        , fl::Bus::UART
+#endif
+    >();
+}
+
+}  // namespace platforms
+}  // namespace fl

--- a/src/platforms/shared/channel_drivers_null.impl.hpp
+++ b/src/platforms/shared/channel_drivers_null.impl.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+// IWYU pragma: private
+
+/// @file channel_drivers_null.impl.hpp
+/// @brief Null channel-driver fragment for `fl::enableAllDrivers()`.
+
+#include "fl/stl/compiler_control.h"
+
+namespace fl {
+namespace platforms {
+
+inline void enableAllChannelDrivers() FL_NOEXCEPT {}
+
+}  // namespace platforms
+}  // namespace fl

--- a/src/platforms/stub/channel_drivers_stub.impl.hpp
+++ b/src/platforms/stub/channel_drivers_stub.impl.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+// IWYU pragma: private
+
+/// @file channel_drivers_stub.impl.hpp
+/// @brief Stub/WASM channel-driver fragment for `fl::enableAllDrivers()`.
+
+#include "fl/channels/bus.h"
+#include "fl/channels/bus_traits.h"
+#include "fl/stl/compiler_control.h"
+#include "platforms/shared/bitbang/bus_traits.h"  // ok platform headers // IWYU pragma: keep
+#include "platforms/stub/bus_traits.h"            // ok platform headers // IWYU pragma: keep
+
+namespace fl {
+namespace platforms {
+
+inline void enableAllChannelDrivers() FL_NOEXCEPT {
+    fl::enableDrivers<fl::Bus::BIT_BANG, fl::Bus::STUB>();
+}
+
+}  // namespace platforms
+}  // namespace fl

--- a/tests/fl/channels/all_drivers.cpp
+++ b/tests/fl/channels/all_drivers.cpp
@@ -9,19 +9,23 @@
 /// On the host (FL_IS_STUB) the only buses with actual `BusTraits<>`
 /// specializations are `Bus::STUB` (the host-only stub driver) and
 /// `Bus::BIT_BANG` (always-on portable fallback). After calling
-/// `enableAllDrivers()` both must be findable in the manager registry and
-/// must be the same singleton instances exposed by `BusTraits<B>::instance()`.
+/// `enableAllDrivers()` both must be findable in the manager registry with
+/// the expected names and capabilities.
 ///
 /// `ChannelManager` is a process-singleton, so every test case begins by
-/// clearing the registry and asserting it is empty — otherwise a later case
-/// could pass purely on residue from an earlier one (e.g. the "forwards"
-/// test would succeed even if `FastLED.enableAllDrivers()` were a no-op).
+/// clearing the registry and asserting it is empty. Otherwise a later case
+/// could pass purely on residue from an earlier one.
 
 #include "fl/channels/all_drivers.h"
 #include "fl/channels/bus.h"
 #include "fl/channels/bus_traits.h"
 #include "fl/channels/manager.h"
 #include "fl/stl/string.h"
+#include "platforms/is_platform.h"
+#include "platforms/shared/bitbang/bus_traits.h"  // BusTraits<Bus::BIT_BANG>
+#if defined(FL_IS_STUB) || defined(FL_IS_WASM)
+#include "platforms/stub/bus_traits.h"  // BusTraits<Bus::STUB>
+#endif
 #include "test.h"
 
 FL_TEST_FILE(FL_FILEPATH) {
@@ -38,6 +42,22 @@ fl::ChannelManager& freshManager() {
     return mgr;
 }
 
+void checkHostDriversRegistered(fl::ChannelManager& mgr) {
+    auto bitbang = mgr.getDriverByName(fl::string::from_literal("BIT_BANG"));
+    FL_REQUIRE(bitbang != nullptr);
+    FL_CHECK(bitbang->getName() == fl::string::from_literal("BIT_BANG"));
+    auto bitbangCaps = bitbang->getCapabilities();
+    FL_CHECK(bitbangCaps.supportsClockless);
+    FL_CHECK(bitbangCaps.supportsSpi);
+
+    auto stub = mgr.getDriverByName(fl::string::from_literal("STUB"));
+    FL_REQUIRE(stub != nullptr);
+    FL_CHECK(stub->getName() == fl::string::from_literal("STUB"));
+    auto stubCaps = stub->getCapabilities();
+    FL_CHECK(stubCaps.supportsClockless);
+    FL_CHECK(!stubCaps.supportsSpi);
+}
+
 }  // namespace
 
 FL_TEST_CASE("enableAllDrivers() registers Bus::STUB and Bus::BIT_BANG on host") {
@@ -46,18 +66,7 @@ FL_TEST_CASE("enableAllDrivers() registers Bus::STUB and Bus::BIT_BANG on host")
 
     fl::enableAllDrivers();
 
-    // Bus::BIT_BANG is always-on (no platform guard) and must register on
-    // every build, including the host test runner. The driver's getName()
-    // returns "BIT_BANG" — same spelling as the C++ enumerator.
-    auto bitbang = mgr.getDriverByName(fl::string::from_literal("BIT_BANG"));
-    FL_REQUIRE(bitbang != nullptr);
-    FL_CHECK(bitbang.get() == &fl::BusTraits<fl::Bus::BIT_BANG>::instance());
-
-    // Bus::STUB is host-only — guarded by FL_IS_STUB / FL_IS_WASM in
-    // all_drivers.h. Tests run with FL_IS_STUB defined, so it must register.
-    auto stub = mgr.getDriverByName(fl::string::from_literal("STUB"));
-    FL_REQUIRE(stub != nullptr);
-    FL_CHECK(stub.get() == &fl::BusTraits<fl::Bus::STUB>::instance());
+    checkHostDriversRegistered(mgr);
 }
 
 FL_TEST_CASE("FastLED.enableAllDrivers() forwards to fl::enableAllDrivers()") {
@@ -69,13 +78,7 @@ FL_TEST_CASE("FastLED.enableAllDrivers() forwards to fl::enableAllDrivers()") {
     // precondition above guarantees no prior registration leaked in.
     FastLED.enableAllDrivers();
 
-    auto bitbang = mgr.getDriverByName(fl::string::from_literal("BIT_BANG"));
-    FL_REQUIRE(bitbang != nullptr);
-    FL_CHECK(bitbang.get() == &fl::BusTraits<fl::Bus::BIT_BANG>::instance());
-
-    auto stub = mgr.getDriverByName(fl::string::from_literal("STUB"));
-    FL_REQUIRE(stub != nullptr);
-    FL_CHECK(stub.get() == &fl::BusTraits<fl::Bus::STUB>::instance());
+    checkHostDriversRegistered(mgr);
 }
 
 FL_TEST_CASE("enableAllDrivers() is idempotent") {
@@ -92,11 +95,7 @@ FL_TEST_CASE("enableAllDrivers() is idempotent") {
     // Manager replaces by name on duplicate `addDriver`, so a second call
     // must leave the count unchanged.
     FL_CHECK(count_after_first == count_after_second);
-
-    // The driver identities must not change either — same singletons.
-    auto bitbang = mgr.getDriverByName(fl::string::from_literal("BIT_BANG"));
-    FL_REQUIRE(bitbang != nullptr);
-    FL_CHECK(bitbang.get() == &fl::BusTraits<fl::Bus::BIT_BANG>::instance());
+    checkHostDriversRegistered(mgr);
 }
 
 }  // FL_TEST_FILE


### PR DESCRIPTION
## Summary

Supersedes #2478 with a single squashed commit.

- moves `fl::enableAllDrivers()` out of `all_drivers.h` and into the platform unity build
- uses the repo's sparse dispatch convention: `platforms/channel_drivers.impl.cpp.hpp` is the include-once router, and platform-owned `*.impl.hpp` fragments provide ESP32, Teensy 4.x, stub/WASM, plus a null fallthrough implementation
- keeps the fallthrough platform as an empty no-op definition, so unsupported platforms do not implicitly register `BIT_BANG`
- keeps `FastLED.enableAllDrivers()` callable from `<FastLED.h>` without the old magic include requirement
- updates host tests to assert registry behavior instead of comparing `BusTraits` function-local singleton addresses across DLL boundaries

## Verification

- [x] `python -m ci.lint_cpp.impl_hpp_includes_checker`
- [x] `python -m ci.lint_cpp.cpp_hpp_includes_checker`
- [x] `python -m ci.lint_cpp.iwyu_pragma_check`
- [x] `bash lint --cpp`
- [x] `bash test fl_channels_all_drivers --debug`
- [x] `bash test --cpp --force` - 304/304 passing
- [ ] `bash lint` - not clean locally due pre-existing Python KeyboardInterrupt checker findings in `ci/compiler/pio.py` and `ci/util/fbuild_runner.py`
- [ ] `bash compile --no-interactive --local --max-failures 1 esp32s3 SpecialDrivers/ESP/DriverTest` - timed out locally after 30 minutes with no useful output before timeout

## Notes

This keeps the tree-shaking strategy from #2478, but routes the per-platform `bus_traits.h` include list through the existing `.impl.cpp.hpp` trampoline pattern and its special linting rules. The final router branch now lands on `platforms/shared/channel_drivers_null.impl.hpp`, whose `enableAllChannelDrivers()` body is intentionally empty.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified `FastLED.enableAllDrivers()` usage—header inclusion no longer required
  * Updated guides reflect streamlined approach to enabling all channel drivers

* **Refactor**
  * Improved binary efficiency: `enableAllDrivers()` now incurs zero binary size cost when unused through compiler optimization

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/FastLED/pull/2480)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->