### PR TITLE
build: bump meson floor to >=1.11.0 (fixes Windows DirectoryLock crash)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "clang-tool-chain>=1.2.9",
     "zccache>=1.4.0",
     "ninja",
-    "meson>=1.10.0",
+    "meson>=1.11.0",
     "download",
     "playwright",
     "httpx",


### PR DESCRIPTION
## Summary

Bumps the meson floor in `pyproject.toml` from `>=1.10.0` to `>=1.11.0`.

meson 1.9.x and 1.10.x have a Windows-only bug in `DirectoryLock.__enter__` where a missing `raise` in the `except OSError` block causes a cryptic `AttributeError: 'NoneType' object has no attribute 'fileno'` crash instead of surfacing the real underlying `OSError`. This blocks the WASM build pipeline on Windows.

Upstream fix landed in [mesonbuild/meson@fb6db407](https://github.com/mesonbuild/meson/commit/fb6db407) ("utils: make .wraplock optional", 2025-08-26), first released in meson 1.11.0.

| meson version | DirectoryLock OSError handler |
| -------- | ----------------------------- |
| 1.9.x    | buggy |
| 1.10.x   | buggy |
| 1.11.0+ | fixed |

Closes #2482

## Test plan

- [ ] `pip install fastled` (or `pip install meson`) now pulls meson >=1.11.0
- [ ] On Windows, when an underlying lockfile `OSError` occurs, the real error is surfaced instead of the misleading `NoneType` AttributeError

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build system dependency version to maintain compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/FastLED/pull/2483?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->