### PR TITLE
fix(build): clean stale meson lockfile before setup

### DIFF
--- a/ci/meson/build_config.py
+++ b/ci/meson/build_config.py
@@ -397,6 +397,38 @@ def normalize_meson_private_include_paths(build_dir: Path) -> bool:
     return changed_any
 
 
+def cleanup_stale_meson_lockfile(build_dir: Path) -> bool:
+    """Remove a stale ``meson-private/meson.lock`` left by a killed meson process.
+
+    On Windows, meson <= 1.10.x crashed cryptically in ``DirectoryLock.__enter__``
+    when the underlying lockfile open() raised an OSError (e.g., from a stale
+    lockfile left by a killed/abandoned meson process). meson 1.11.0 fixed the
+    crash itself, but the underlying cause — a stale ``meson-private/meson.lock``
+    file — still produces an avoidable setup failure on Windows. Deleting the
+    stale lockfile before invoking ``meson setup`` avoids the failure entirely.
+
+    Args:
+        build_dir: The meson build directory (parent of ``meson-private``).
+
+    Returns:
+        True if a stale lockfile was found and successfully removed, False
+        otherwise (including when no lockfile exists or removal failed).
+    """
+    lockfile = build_dir / "meson-private" / "meson.lock"
+    if not lockfile.exists():
+        return False
+    try:
+        lockfile.unlink()
+        _ts_print(f"[MESON] Removed stale lockfile: {lockfile}")
+        return True
+    except OSError as e:
+        # Be tolerant of file-in-use errors on Windows — if removal fails, log
+        # and continue. The caller will hit the original OSError from meson,
+        # which is now visible thanks to the 1.11.0 bump.
+        _ts_print(f"[MESON] Warning: Could not remove stale lockfile {lockfile}: {e}")
+        return False
+
+
 def _write_configuration_markers(
     *,
     build_mode_marker: Path,
@@ -1947,6 +1979,10 @@ endian = 'little'
                     )
 
     try:
+        # Remove any stale meson lockfile left by a killed/abandoned meson
+        # process (Windows bug, see issue #2484). No-op if build_dir or
+        # meson-private/ doesn't exist yet.
+        cleanup_stale_meson_lockfile(build_dir)
         returncode, stdout = _run_meson_setup()
 
         # Self-healing: If meson setup fails with "does not exist" error,
@@ -1958,6 +1994,7 @@ endian = 'little'
             )
             _clear_stale_caches()
             _ts_print("[MESON] 🔄 Retrying meson setup...")
+            cleanup_stale_meson_lockfile(build_dir)
             returncode, stdout = _run_meson_setup()
 
         if returncode != 0:

--- a/ci/meson/build_config.py
+++ b/ci/meson/build_config.py
@@ -414,6 +414,12 @@ def cleanup_stale_meson_lockfile(build_dir: Path) -> bool:
         True if a stale lockfile was found and successfully removed, False
         otherwise (including when no lockfile exists or removal failed).
     """
+    # Stale lockfile cleanup is intended for the Windows DirectoryLock bug.
+    # On POSIX, meson uses fcntl/flock (advisory) — removing an in-use lockfile
+    # could let a concurrent meson setup bypass the intended lock.
+    if os.name != "nt":
+        return False
+
     lockfile = build_dir / "meson-private" / "meson.lock"
     if not lockfile.exists():
         return False
@@ -421,6 +427,9 @@ def cleanup_stale_meson_lockfile(build_dir: Path) -> bool:
         lockfile.unlink()
         _ts_print(f"[MESON] Removed stale lockfile: {lockfile}")
         return True
+    except KeyboardInterrupt as ki:
+        handle_keyboard_interrupt(ki)
+        raise
     except OSError as e:
         # Be tolerant of file-in-use errors on Windows — if removal fails, log
         # and continue. The caller will hit the original OSError from meson,

--- a/ci/wasm_build.py
+++ b/ci/wasm_build.py
@@ -76,6 +76,14 @@ def _normalize_meson_private_paths(build_dir: Path) -> None:
         print("[WASM] Normalized private include paths for strict path mode")
 
 
+def _cleanup_stale_meson_lockfile(build_dir: Path) -> None:
+    """Remove stale meson-private/meson.lock before meson setup (see issue #2484)."""
+    from ci.meson.build_config import cleanup_stale_meson_lockfile
+
+    # Helper logs its own status message; we just call through.
+    cleanup_stale_meson_lockfile(build_dir)
+
+
 # ============================================================================
 # Library fingerprint — skip meson/ninja when source tree hasn't changed
 # ============================================================================
@@ -412,6 +420,8 @@ def _recover_stale_wasm_build(build_dir: Path) -> bool:
             str(build_dir),
             f"-Dbuild_mode={mode}",
         ]
+        # Remove any stale meson lockfile before reconfigure (see issue #2484).
+        _cleanup_stale_meson_lockfile(build_dir)
         result = subprocess.run(cmd, cwd=PROJECT_ROOT)
         if result.returncode == 0:
             _normalize_meson_private_paths(build_dir)
@@ -471,6 +481,8 @@ def ensure_meson_configured(build_dir: Path, mode: str, force: bool = False) -> 
             f"-Dbuild_mode={mode}",
         ]
         print(f"[WASM] Reconfiguring meson (mode: {mode})...")
+        # Remove any stale meson lockfile before reconfigure (see issue #2484).
+        _cleanup_stale_meson_lockfile(build_dir)
         result = subprocess.run(cmd, cwd=PROJECT_ROOT)
         if result.returncode != 0:
             print(f"[WASM] Meson reconfiguration failed (rc {result.returncode})")
@@ -499,6 +511,8 @@ def ensure_meson_configured(build_dir: Path, mode: str, force: bool = False) -> 
         cmd.insert(2, "--reconfigure")
 
     print(f"[WASM] Configuring meson (mode: {mode})...")
+    # Remove any stale meson lockfile before setup (see issue #2484).
+    _cleanup_stale_meson_lockfile(build_dir)
     result = subprocess.run(cmd, cwd=PROJECT_ROOT)
     if result.returncode != 0:
         print(f"[WASM] Meson setup failed with return code {result.returncode}")


### PR DESCRIPTION
## Summary

Closes #2484. Follow-up to #2483 (which bumped the meson floor to 1.11.0 and replaced the cryptic NoneType crash with the real underlying OSError).

On Windows, an abandoned or killed meson process leaves a stale `meson-private/meson.lock` file. The next `meson setup` invocation hits that stale lock and fails — meson 1.11.0 surfaces the error cleanly now, but the failure itself is avoidable.

This patch adds a small helper `cleanup_stale_meson_lockfile()` that removes the stale lockfile before invoking meson setup. The helper is tolerant of file-in-use errors on Windows: on failure it logs and continues, so the caller still sees the real underlying error from meson.

## Call sites

- `ci/meson/build_config.py::setup_meson_build()` — before the main meson setup invocation and before the cache-clear retry.
- `ci/wasm_build.py::ensure_meson_configured()` — both the initial setup and the reconfigure-on-source-change branches.
- `ci/wasm_build.py::_recover_stale_wasm_build()` — before the self-healing reconfigure attempt.

## Test plan

- [x] `bash test --cpp` — all tests pass (304/304)
- [x] `bash lint` — pass
- [x] Manual verification: helper correctly handles (a) missing `meson-private/`, (b) stale lockfile present, (c) lockfile absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved build robustness by automatically removing stale Meson lockfiles before build/setup attempts (Windows-only), and re-running setup when needed. This reduces persistent build failures and makes retry/reconfigure flows more reliable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/FastLED/pull/2486?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->