### PR TITLE
perf(wasm): bump clang-tool-chain to 1.4.0 and wire ctc-emar native launcher

### DIFF
--- a/ci/meson/build_config.py
+++ b/ci/meson/build_config.py
@@ -50,6 +50,19 @@ class FastNativeEntries:
 
 
 @dataclass(slots=True)
+class EmccNativeLaunchers:
+    """Compiled emscripten-tool launcher paths produced by ``compile_native()``.
+
+    Each field is an absolute path to the compiled binary, or ``None`` when
+    the corresponding launcher is missing after the build attempt.
+    """
+
+    emcc: Optional[str]
+    empp: Optional[str]
+    emar: Optional[str]
+
+
+@dataclass(slots=True)
 class WasmNativeEntries:
     """Native (or fallback wrapper) tool entries for the WASM cross-file.
 
@@ -105,9 +118,7 @@ def _ensure_native_launcher(project_root: Path) -> tuple[Optional[str], Optional
     return None, None
 
 
-def _ensure_emcc_native_launcher(
-    project_root: Path,
-) -> tuple[Optional[str], Optional[str], Optional[str]]:
+def _ensure_emcc_native_launcher(project_root: Path) -> EmccNativeLaunchers:
     """
     Ensure ctc-emcc/ctc-em++/ctc-emar native launchers are compiled.
 
@@ -121,10 +132,6 @@ def _ensure_emcc_native_launcher(
     Shares the same output directory as the clang launcher because
     ``compile_native()`` from clang-tool-chain builds all registered tools
     in one call (clang + emcc + wasm-ld + emtool).
-
-    Returns:
-        Tuple of (ctc_emcc_path, ctc_empp_path, ctc_emar_path). Any element
-        is None if that binary is missing after compilation.
     """
     output_dir = _native_launcher_output_dir(project_root)
     exe_suffix = ".exe" if sys.platform == "win32" else ""
@@ -132,11 +139,11 @@ def _ensure_emcc_native_launcher(
     ctc_empp = output_dir / f"ctc-em++{exe_suffix}"
     ctc_emar = output_dir / f"ctc-emar{exe_suffix}"
 
-    def _present() -> tuple[Optional[str], Optional[str], Optional[str]]:
-        return (
-            str(ctc_emcc) if ctc_emcc.exists() else None,
-            str(ctc_empp) if ctc_empp.exists() else None,
-            str(ctc_emar) if ctc_emar.exists() else None,
+    def _present() -> EmccNativeLaunchers:
+        return EmccNativeLaunchers(
+            emcc=str(ctc_emcc) if ctc_emcc.exists() else None,
+            empp=str(ctc_empp) if ctc_empp.exists() else None,
+            emar=str(ctc_emar) if ctc_emar.exists() else None,
         )
 
     if ctc_emcc.exists() and ctc_empp.exists() and ctc_emar.exists():
@@ -155,7 +162,7 @@ def _ensure_emcc_native_launcher(
         _ts_print(
             f"[WASM] Native launcher build failed; falling back to Python wrapper: {e}"
         )
-    return None, None, None
+    return EmccNativeLaunchers(emcc=None, empp=None, emar=None)
 
 
 def resolve_wasm_native_entries(project_root: Path) -> WasmNativeEntries:
@@ -185,7 +192,7 @@ def resolve_wasm_native_entries(project_root: Path) -> WasmNativeEntries:
     )
 
     try:
-        ctc_emcc, ctc_empp, ctc_emar = _ensure_emcc_native_launcher(project_root)
+        launchers = _ensure_emcc_native_launcher(project_root)
     except KeyboardInterrupt as ki:
         handle_keyboard_interrupt(ki)
         return fallback  # unreachable, satisfies type checker
@@ -195,13 +202,13 @@ def resolve_wasm_native_entries(project_root: Path) -> WasmNativeEntries:
         )
         return fallback
 
-    if ctc_emcc is None or ctc_empp is None:
+    if launchers.emcc is None or launchers.empp is None:
         return fallback
 
     return WasmNativeEntries(
-        c=ctc_emcc,
-        cpp=ctc_empp,
-        ar=ctc_emar if ctc_emar is not None else "clang-tool-chain-emar",
+        c=launchers.emcc,
+        cpp=launchers.empp,
+        ar=launchers.emar if launchers.emar is not None else "clang-tool-chain-emar",
         used_native_launcher=True,
     )
 

--- a/ci/meson/build_config.py
+++ b/ci/meson/build_config.py
@@ -107,45 +107,55 @@ def _ensure_native_launcher(project_root: Path) -> tuple[Optional[str], Optional
 
 def _ensure_emcc_native_launcher(
     project_root: Path,
-) -> tuple[Optional[str], Optional[str]]:
+) -> tuple[Optional[str], Optional[str], Optional[str]]:
     """
-    Ensure ctc-emcc/ctc-em++ native launchers are compiled.
+    Ensure ctc-emcc/ctc-em++/ctc-emar native launchers are compiled.
 
-    The emcc launcher is a compiled C++ binary that replaces the Python
-    ``clang-tool-chain-emcc`` wrapper with near-zero startup overhead.
-    It implements a 3-tier strategy: user-template -> flag-hash auto-cache
-    -> Python fallback, so even uncached link/preprocess steps still work
-    correctly via the Python emcc.py underneath.
+    Native C++ launchers that replace the Python ``clang-tool-chain-emcc`` /
+    ``clang-tool-chain-emar`` wrappers with near-zero startup overhead.
+    The emcc launcher implements a 3-tier strategy: user-template ->
+    flag-hash auto-cache -> Python fallback, so even uncached link/preprocess
+    steps still work correctly via the Python emcc.py underneath. The emar
+    launcher (added in clang-tool-chain 1.3.1) covers the archiver path.
 
     Shares the same output directory as the clang launcher because
     ``compile_native()`` from clang-tool-chain builds all registered tools
-    in one call (clang launcher + emcc launcher + wasm-ld launcher).
+    in one call (clang + emcc + wasm-ld + emtool).
 
     Returns:
-        Tuple of (ctc_emcc_path, ctc_empp_path), or (None, None) on failure.
+        Tuple of (ctc_emcc_path, ctc_empp_path, ctc_emar_path). Any element
+        is None if that binary is missing after compilation.
     """
     output_dir = _native_launcher_output_dir(project_root)
     exe_suffix = ".exe" if sys.platform == "win32" else ""
     ctc_emcc = output_dir / f"ctc-emcc{exe_suffix}"
     ctc_empp = output_dir / f"ctc-em++{exe_suffix}"
+    ctc_emar = output_dir / f"ctc-emar{exe_suffix}"
 
-    if ctc_emcc.exists() and ctc_empp.exists():
-        return str(ctc_emcc), str(ctc_empp)
+    def _present() -> tuple[Optional[str], Optional[str], Optional[str]]:
+        return (
+            str(ctc_emcc) if ctc_emcc.exists() else None,
+            str(ctc_empp) if ctc_empp.exists() else None,
+            str(ctc_emar) if ctc_emar.exists() else None,
+        )
+
+    if ctc_emcc.exists() and ctc_empp.exists() and ctc_emar.exists():
+        return _present()
 
     try:
         from clang_tool_chain.commands.compile_native import compile_native
 
         output_dir.mkdir(parents=True, exist_ok=True)
         rc = compile_native(str(output_dir))
-        if rc == 0 and ctc_emcc.exists() and ctc_empp.exists():
-            return str(ctc_emcc), str(ctc_empp)
+        if rc == 0:
+            return _present()
     except KeyboardInterrupt as ki:
         handle_keyboard_interrupt(ki)
     except Exception as e:
         _ts_print(
-            f"[WASM] Native emcc launcher build failed; falling back to Python wrapper: {e}"
+            f"[WASM] Native launcher build failed; falling back to Python wrapper: {e}"
         )
-    return None, None
+    return None, None, None
 
 
 def resolve_wasm_native_entries(project_root: Path) -> WasmNativeEntries:
@@ -154,11 +164,14 @@ def resolve_wasm_native_entries(project_root: Path) -> WasmNativeEntries:
 
     Mirrors :func:`_resolve_fast_native_entries` but for the emscripten
     toolchain. Returns absolute paths to the compiled ``ctc-emcc`` /
-    ``ctc-em++`` native launchers when they can be built, otherwise the
-    historical Python wrapper names ``clang-tool-chain-emcc``.
+    ``ctc-em++`` / ``ctc-emar`` native launchers when they can be built,
+    otherwise the historical Python wrapper names
+    (``clang-tool-chain-emcc`` / ``clang-tool-chain-emar``).
 
-    The archiver always uses the Python ``clang-tool-chain-emar`` wrapper
-    because no native ``ctc-emar`` launcher exists yet.
+    Native and Python paths can mix: e.g., if emcc/em++ resolve but emar
+    is missing for some reason, the function returns native paths for the
+    compilers and the Python wrapper for the archiver. ``used_native_launcher``
+    is True only when the emcc compiler launcher resolved.
 
     This function NEVER raises and ALWAYS returns a usable WasmNativeEntries:
     a launcher build failure falls back to the Python wrappers and is
@@ -172,7 +185,7 @@ def resolve_wasm_native_entries(project_root: Path) -> WasmNativeEntries:
     )
 
     try:
-        ctc_emcc, ctc_empp = _ensure_emcc_native_launcher(project_root)
+        ctc_emcc, ctc_empp, ctc_emar = _ensure_emcc_native_launcher(project_root)
     except KeyboardInterrupt as ki:
         handle_keyboard_interrupt(ki)
         return fallback  # unreachable, satisfies type checker
@@ -188,7 +201,7 @@ def resolve_wasm_native_entries(project_root: Path) -> WasmNativeEntries:
     return WasmNativeEntries(
         c=ctc_emcc,
         cpp=ctc_empp,
-        ar="clang-tool-chain-emar",
+        ar=ctc_emar if ctc_emar is not None else "clang-tool-chain-emar",
         used_native_launcher=True,
     )
 

--- a/ci/wasm_build.py
+++ b/ci/wasm_build.py
@@ -471,6 +471,13 @@ def _render_wasm_cross_file(build_dir: Path) -> Path:
 
     if entries.used_native_launcher:
         print(f"[WASM] Using native ctc-emcc launcher: {entries.c}")
+        if entries.ar.endswith(("ctc-emar", "ctc-emar.exe")):
+            print(f"[WASM] Using native ctc-emar launcher: {entries.ar}")
+        else:
+            print(
+                "[WASM] ctc-emar native launcher unavailable; "
+                f"using Python wrapper for ar: {entries.ar}"
+            )
     else:
         print(
             "[WASM] Native ctc-emcc launcher unavailable; "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "pytest-xdist",
     "fpvgcc",
     "uv",
-    "clang-tool-chain>=1.2.9",
+    "clang-tool-chain>=1.4.0",
     "zccache>=1.4.0",
     "ninja",
     "meson>=1.11.0",


### PR DESCRIPTION
## Summary

Follow-up to #2487. clang-tool-chain 1.3.1 added a native ``ctc-emar`` launcher (along with ``ctc-emranlib`` / ``ctc-emnm`` / ``ctc-emstrip`` aliases via the ``emtool`` TOOL_REGISTRY entry). PR #2487 explicitly noted ``ar`` could not be wired to a native binary because no such launcher existed yet — that gap is now closed.

## Changes

- ``pyproject.toml``: ``clang-tool-chain>=1.2.9`` → ``>=1.4.0``
- ``ci/meson/build_config.py``: ``_ensure_emcc_native_launcher`` now also returns the ``ctc-emar`` path; ``resolve_wasm_native_entries`` wires it into ``WasmNativeEntries.ar``, falling back to the Python ``clang-tool-chain-emar`` wrapper if the native binary is missing for any reason.
- ``ci/wasm_build.py``: log whether ``ctc-emar`` resolved or fell back, so the optimization is visible at build time.

## What else is in 1.4.0 (and why none of it breaks us)

| Version | Change | Impact |
|---------|--------|--------|
| 1.3.1 | New ``emtool`` launcher (ctc-emar + aliases) | ✅ Wired in this PR |
| 1.3.2 | Linux libunwind injection fix | Cosmetic; helps native Linux builds |
| 1.3.3 | macOS strip ``-lunwind`` fix in zccache shim | Cosmetic; helps native macOS builds |
| 1.4.0 | Renamed PyPI entry points ``++`` → ``-cpp`` (e.g. ``clang-tool-chain-em++`` → ``clang-tool-chain-em-cpp``) | **Does NOT affect us** — grepped the codebase, every FastLED reference uses unrenamed names (``clang-tool-chain-cpp``, ``clang-tool-chain-emcc``, ``clang-tool-chain-emar``). The compiled native binary aliases (``ctc-em++.exe``, ``ctc-clang++.exe``) still have ``++`` — unchanged. |

## Benchmark

Single-iteration clean WASM build of ``examples/Blink`` on Windows:

| Variant | Total |
|---------|-------|
| Before (#2487, Python ``clang-tool-chain-emar``) | 61.36s |
| After (native ``ctc-emar.exe``) | **44.41s** (~28% reduction) |

## What's still on the table (not in this PR)

- **``ctc-wasm-ld``** native launcher (also in TOOL_REGISTRY) is invoked by emcc *internally* during link, not directly from the meson cross-file. Wiring it would require passing ``-fuse-ld=<path>`` into the emcc invocation rather than a cross-file change. Separate PR.
- **``ctc-emstrip`` for the cross-file ``strip``** field. We currently use ``strip = 'true'`` (no-op). Switching to actual stripping could regress binary size analysis tooling or change debug behavior — needs an explicit decision, not a drive-by.
- **``ctc-emranlib`` / ``ctc-emnm``**. The meson WASM cross-file does not declare ``ranlib`` or ``nm`` fields, so there is nothing to wire today. If a future change adds them, the launchers are already available.

## Test plan

- [x] ``bash lint`` — pass
- [x] ``bash compile wasm --examples Blink`` — pass, log confirms both ``[WASM] Using native ctc-emcc launcher`` and ``[WASM] Using native ctc-emar launcher``
- [x] ``bash test --cpp`` — pass except for the pre-existing ``fl_channels_all_drivers`` duplicate-symbol linker failure (verified failing on master with these changes stashed)
- [x] Verified no FastLED reference uses any of the 1.4.0 renamed ``++`` PyPI entry points

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Enhanced WebAssembly build flow: unified detection of native emcc/em++/emar launchers, improved "all-or-none" presence checks with safer fallback when native tools are missing, and preference for a native archiver when available while falling back to the wrapper otherwise.

* **Chores**
  * Updated clang-tool-chain dependency requirement to version 1.4.0 or later

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/FastLED/pull/2489?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->