### PR TITLE
perf(wasm): upgrade to clang-tool-chain 1.5.1, wire all 7 native launchers including ctc-wasm-ld

### DIFF
--- a/ci/compiler/pio.py
+++ b/ci/compiler/pio.py
@@ -348,9 +348,10 @@ class PioCompiler(Compiler):
             self.verbose,
             example,
             self.paths,
-            self.additional_defines,
-            self.additional_include_dirs,
-            self.additional_libs,
+            build_dir=self.build_dir,
+            additional_defines=self.additional_defines,
+            additional_include_dirs=self.additional_include_dirs,
+            additional_libs=self.additional_libs,
             use_fbuild=self.use_fbuild,
         )
         if result.success:
@@ -517,6 +518,9 @@ class PioCompiler(Compiler):
 
         try:
             staged_projects = self._stage_fbuild_compile_many_projects(examples)
+        except KeyboardInterrupt as ki:
+            handle_keyboard_interrupt(ki)
+            raise
         except Exception as e:
             for example in examples:
                 future: Future[SketchResult] = Future()

--- a/ci/meson/build_config.py
+++ b/ci/meson/build_config.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from typing import Optional, cast
 
 from running_process import RunningProcess
+from typeguard import typechecked
 
 from ci.meson.cache_utils import get_max_dir_mtime
 from ci.meson.compiler import (
@@ -49,18 +50,13 @@ class FastNativeEntries:
     ar: Optional[str]
 
 
+@typechecked
 @dataclass(slots=True)
 class EmccNativeLaunchers:
     """Compiled emscripten-tool launcher paths produced by ``compile_native()``.
 
     Each field is an absolute path to the compiled binary, or ``None`` when
     the corresponding launcher is missing after the build attempt.
-
-    ``emcc`` / ``empp`` / ``emar`` have Python wrapper fallbacks in
-    clang-tool-chain (``clang-tool-chain-emcc`` / ``-empp`` / ``-emar``).
-    ``emstrip`` / ``emranlib`` / ``emnm`` do NOT — they only exist as compiled
-    launchers, so a None value means meson should omit the corresponding
-    cross-file field and use its default behavior.
     """
 
     emcc: Optional[str]
@@ -69,25 +65,32 @@ class EmccNativeLaunchers:
     emstrip: Optional[str]
     emranlib: Optional[str]
     emnm: Optional[str]
+    wasm_ld: Optional[str]
 
 
+@typechecked
 @dataclass(slots=True)
 class WasmNativeEntries:
-    """Native (or fallback wrapper) tool entries for the WASM cross-file.
+    """Tool entries for the WASM cross-file.
 
-    ``c`` / ``cpp`` / ``ar`` always hold a usable value (compiled launcher
-    path or Python wrapper name). ``strip`` / ``ranlib`` / ``nm`` hold
-    a compiled launcher path when available or ``None`` when meson should
-    omit the cross-file field entirely (clang-tool-chain ships no Python
-    wrapper for these three; only the native launchers from 1.3.1+).
+    All fields always hold a usable value — compiled launcher path when
+    available, otherwise the corresponding clang-tool-chain Python entry-point
+    name (added in 1.5.1; see #23). The build never regresses below
+    Python-wrapper baseline behavior.
+
+    ``wasm_ld`` is not consumed by meson directly. emcc invokes wasm-ld
+    internally; the integration is via the ``EMCC_WASM_LD`` env var picked
+    up by the shared.py patch that ``ensure_emscripten_available`` applies.
+    Carried here so the build orchestration can set the env var.
     """
 
     c: str
     cpp: str
     ar: str
-    strip: Optional[str]
-    ranlib: Optional[str]
-    nm: Optional[str]
+    strip: str
+    ranlib: str
+    nm: str
+    wasm_ld: str
     # True if c/cpp resolved to the compiled native launcher binary.
     # Used purely for logging/telemetry.
     used_native_launcher: bool
@@ -155,6 +158,7 @@ def _ensure_emcc_native_launcher(project_root: Path) -> EmccNativeLaunchers:
     ctc_emstrip = output_dir / f"ctc-emstrip{exe_suffix}"
     ctc_emranlib = output_dir / f"ctc-emranlib{exe_suffix}"
     ctc_emnm = output_dir / f"ctc-emnm{exe_suffix}"
+    ctc_wasm_ld = output_dir / f"ctc-wasm-ld{exe_suffix}"
 
     def _present() -> EmccNativeLaunchers:
         return EmccNativeLaunchers(
@@ -164,11 +168,20 @@ def _ensure_emcc_native_launcher(project_root: Path) -> EmccNativeLaunchers:
             emstrip=str(ctc_emstrip) if ctc_emstrip.exists() else None,
             emranlib=str(ctc_emranlib) if ctc_emranlib.exists() else None,
             emnm=str(ctc_emnm) if ctc_emnm.exists() else None,
+            wasm_ld=str(ctc_wasm_ld) if ctc_wasm_ld.exists() else None,
         )
 
     if all(
         p.exists()
-        for p in (ctc_emcc, ctc_empp, ctc_emar, ctc_emstrip, ctc_emranlib, ctc_emnm)
+        for p in (
+            ctc_emcc,
+            ctc_empp,
+            ctc_emar,
+            ctc_emstrip,
+            ctc_emranlib,
+            ctc_emnm,
+            ctc_wasm_ld,
+        )
     ):
         return _present()
 
@@ -186,7 +199,13 @@ def _ensure_emcc_native_launcher(project_root: Path) -> EmccNativeLaunchers:
             f"[WASM] Native launcher build failed; falling back to Python wrapper: {e}"
         )
     return EmccNativeLaunchers(
-        emcc=None, empp=None, emar=None, emstrip=None, emranlib=None, emnm=None
+        emcc=None,
+        empp=None,
+        emar=None,
+        emstrip=None,
+        emranlib=None,
+        emnm=None,
+        wasm_ld=None,
     )
 
 
@@ -213,9 +232,10 @@ def resolve_wasm_native_entries(project_root: Path) -> WasmNativeEntries:
         c="clang-tool-chain-emcc",
         cpp="clang-tool-chain-emcc",
         ar="clang-tool-chain-emar",
-        strip=None,
-        ranlib=None,
-        nm=None,
+        strip="clang-tool-chain-emstrip",
+        ranlib="clang-tool-chain-emranlib",
+        nm="clang-tool-chain-emnm",
+        wasm_ld="clang-tool-chain-wasm-ld",
         used_native_launcher=False,
     )
 
@@ -237,9 +257,22 @@ def resolve_wasm_native_entries(project_root: Path) -> WasmNativeEntries:
         c=launchers.emcc,
         cpp=launchers.empp,
         ar=launchers.emar if launchers.emar is not None else "clang-tool-chain-emar",
-        strip=launchers.emstrip,
-        ranlib=launchers.emranlib,
-        nm=launchers.emnm,
+        strip=(
+            launchers.emstrip
+            if launchers.emstrip is not None
+            else "clang-tool-chain-emstrip"
+        ),
+        ranlib=(
+            launchers.emranlib
+            if launchers.emranlib is not None
+            else "clang-tool-chain-emranlib"
+        ),
+        nm=launchers.emnm if launchers.emnm is not None else "clang-tool-chain-emnm",
+        wasm_ld=(
+            launchers.wasm_ld
+            if launchers.wasm_ld is not None
+            else "clang-tool-chain-wasm-ld"
+        ),
         used_native_launcher=True,
     )
 

--- a/ci/meson/build_config.py
+++ b/ci/meson/build_config.py
@@ -55,28 +55,29 @@ class FastNativeEntries:
 class EmccNativeLaunchers:
     """Compiled emscripten-tool launcher paths produced by ``compile_native()``.
 
-    Each field is an absolute path to the compiled binary, or ``None`` when
-    the corresponding launcher is missing after the build attempt.
+    Every field is a guaranteed-present absolute path. ``compile_native()``
+    in clang-tool-chain 1.5.1+ produces all seven launchers in one call;
+    if any is missing afterward the resolver raises rather than silently
+    falling back. clang-tool-chain >=1.5.1 is pinned in pyproject.toml.
     """
 
-    emcc: Optional[str]
-    empp: Optional[str]
-    emar: Optional[str]
-    emstrip: Optional[str]
-    emranlib: Optional[str]
-    emnm: Optional[str]
-    wasm_ld: Optional[str]
+    emcc: str
+    empp: str
+    emar: str
+    emstrip: str
+    emranlib: str
+    emnm: str
+    wasm_ld: str
 
 
 @typechecked
 @dataclass(slots=True)
 class WasmNativeEntries:
-    """Tool entries for the WASM cross-file.
+    """Native tool entries for the WASM cross-file.
 
-    All fields always hold a usable value — compiled launcher path when
-    available, otherwise the corresponding clang-tool-chain Python entry-point
-    name (added in 1.5.1; see #23). The build never regresses below
-    Python-wrapper baseline behavior.
+    All fields are absolute paths to compiled ctc-* native launchers.
+    No Python-wrapper fallbacks — clang-tool-chain >=1.5.1 is a hard
+    requirement and ``compile_native()`` is invoked eagerly.
 
     ``wasm_ld`` is not consumed by meson directly. emcc invokes wasm-ld
     internally; the integration is via the ``EMCC_WASM_LD`` env var picked
@@ -91,9 +92,6 @@ class WasmNativeEntries:
     ranlib: str
     nm: str
     wasm_ld: str
-    # True if c/cpp resolved to the compiled native launcher binary.
-    # Used purely for logging/telemetry.
-    used_native_launcher: bool
 
 
 def _native_launcher_output_dir(project_root: Path) -> Path:
@@ -137,143 +135,72 @@ def _ensure_native_launcher(project_root: Path) -> tuple[Optional[str], Optional
 
 def _ensure_emcc_native_launcher(project_root: Path) -> EmccNativeLaunchers:
     """
-    Ensure ctc-emcc/ctc-em++/ctc-emar native launchers are compiled.
+    Build and return all seven WASM-related ctc-* native launcher paths.
 
-    Native C++ launchers that replace the Python ``clang-tool-chain-emcc`` /
-    ``clang-tool-chain-emar`` wrappers with near-zero startup overhead.
-    The emcc launcher implements a 3-tier strategy: user-template ->
-    flag-hash auto-cache -> Python fallback, so even uncached link/preprocess
-    steps still work correctly via the Python emcc.py underneath. The emar
-    launcher (added in clang-tool-chain 1.3.1) covers the archiver path.
+    ``compile_native()`` from clang-tool-chain 1.5.1+ produces every binary
+    in a single invocation (clang + emcc + wasm-ld + emtool family with all
+    its hardlinked aliases). If any binary is missing afterward, raises
+    RuntimeError — no Python-wrapper fallback. clang-tool-chain >=1.5.1 is
+    pinned in pyproject.toml so this is a hard requirement.
 
-    Shares the same output directory as the clang launcher because
-    ``compile_native()`` from clang-tool-chain builds all registered tools
-    in one call (clang + emcc + wasm-ld + emtool).
+    Raises:
+        RuntimeError: if ``compile_native()`` fails or any launcher binary
+            is missing after a successful build.
     """
     output_dir = _native_launcher_output_dir(project_root)
     exe_suffix = ".exe" if sys.platform == "win32" else ""
-    ctc_emcc = output_dir / f"ctc-emcc{exe_suffix}"
-    ctc_empp = output_dir / f"ctc-em++{exe_suffix}"
-    ctc_emar = output_dir / f"ctc-emar{exe_suffix}"
-    ctc_emstrip = output_dir / f"ctc-emstrip{exe_suffix}"
-    ctc_emranlib = output_dir / f"ctc-emranlib{exe_suffix}"
-    ctc_emnm = output_dir / f"ctc-emnm{exe_suffix}"
-    ctc_wasm_ld = output_dir / f"ctc-wasm-ld{exe_suffix}"
+    binaries = {
+        "emcc": output_dir / f"ctc-emcc{exe_suffix}",
+        "empp": output_dir / f"ctc-em++{exe_suffix}",
+        "emar": output_dir / f"ctc-emar{exe_suffix}",
+        "emstrip": output_dir / f"ctc-emstrip{exe_suffix}",
+        "emranlib": output_dir / f"ctc-emranlib{exe_suffix}",
+        "emnm": output_dir / f"ctc-emnm{exe_suffix}",
+        "wasm_ld": output_dir / f"ctc-wasm-ld{exe_suffix}",
+    }
 
-    def _present() -> EmccNativeLaunchers:
-        return EmccNativeLaunchers(
-            emcc=str(ctc_emcc) if ctc_emcc.exists() else None,
-            empp=str(ctc_empp) if ctc_empp.exists() else None,
-            emar=str(ctc_emar) if ctc_emar.exists() else None,
-            emstrip=str(ctc_emstrip) if ctc_emstrip.exists() else None,
-            emranlib=str(ctc_emranlib) if ctc_emranlib.exists() else None,
-            emnm=str(ctc_emnm) if ctc_emnm.exists() else None,
-            wasm_ld=str(ctc_wasm_ld) if ctc_wasm_ld.exists() else None,
-        )
-
-    if all(
-        p.exists()
-        for p in (
-            ctc_emcc,
-            ctc_empp,
-            ctc_emar,
-            ctc_emstrip,
-            ctc_emranlib,
-            ctc_emnm,
-            ctc_wasm_ld,
-        )
-    ):
-        return _present()
-
-    try:
+    if not all(p.exists() for p in binaries.values()):
         from clang_tool_chain.commands.compile_native import compile_native
 
         output_dir.mkdir(parents=True, exist_ok=True)
         rc = compile_native(str(output_dir))
-        if rc == 0:
-            return _present()
-    except KeyboardInterrupt as ki:
-        handle_keyboard_interrupt(ki)
-    except Exception as e:
-        _ts_print(
-            f"[WASM] Native launcher build failed; falling back to Python wrapper: {e}"
-        )
-    return EmccNativeLaunchers(
-        emcc=None,
-        empp=None,
-        emar=None,
-        emstrip=None,
-        emranlib=None,
-        emnm=None,
-        wasm_ld=None,
-    )
+        if rc != 0:
+            raise RuntimeError(
+                f"clang-tool-chain compile_native() failed with rc={rc} "
+                f"in {output_dir}; cannot resolve WASM native launchers"
+            )
+        missing = [name for name, p in binaries.items() if not p.exists()]
+        if missing:
+            raise RuntimeError(
+                f"clang-tool-chain compile_native() succeeded but expected "
+                f"binaries are missing in {output_dir}: {missing}. "
+                f"Ensure clang-tool-chain >=1.5.1 is installed."
+            )
+
+    return EmccNativeLaunchers(**{name: str(p) for name, p in binaries.items()})
 
 
 def resolve_wasm_native_entries(project_root: Path) -> WasmNativeEntries:
     """
     Resolve compiler/archiver entries for the Meson WASM cross-file.
 
-    Mirrors :func:`_resolve_fast_native_entries` but for the emscripten
-    toolchain. Returns absolute paths to the compiled ``ctc-emcc`` /
-    ``ctc-em++`` / ``ctc-emar`` native launchers when they can be built,
-    otherwise the historical Python wrapper names
-    (``clang-tool-chain-emcc`` / ``clang-tool-chain-emar``).
+    Returns absolute paths to the seven compiled ctc-* native launchers.
+    No Python-wrapper fallback — if ``compile_native()`` fails or any
+    binary is missing, raises (clang-tool-chain >=1.5.1 is pinned and
+    guarantees all seven launchers).
 
-    Native and Python paths can mix: e.g., if emcc/em++ resolve but emar
-    is missing for some reason, the function returns native paths for the
-    compilers and the Python wrapper for the archiver. ``used_native_launcher``
-    is True only when the emcc compiler launcher resolved.
-
-    This function NEVER raises and ALWAYS returns a usable WasmNativeEntries:
-    a launcher build failure falls back to the Python wrappers and is
-    functionally identical to the pre-optimization behavior.
+    Raises:
+        RuntimeError: if ``compile_native()`` fails or any binary is missing.
     """
-    fallback = WasmNativeEntries(
-        c="clang-tool-chain-emcc",
-        cpp="clang-tool-chain-emcc",
-        ar="clang-tool-chain-emar",
-        strip="clang-tool-chain-emstrip",
-        ranlib="clang-tool-chain-emranlib",
-        nm="clang-tool-chain-emnm",
-        wasm_ld="clang-tool-chain-wasm-ld",
-        used_native_launcher=False,
-    )
-
-    try:
-        launchers = _ensure_emcc_native_launcher(project_root)
-    except KeyboardInterrupt as ki:
-        handle_keyboard_interrupt(ki)
-        return fallback  # unreachable, satisfies type checker
-    except Exception as e:
-        _ts_print(
-            f"[WASM] Native emcc launcher resolution failed; falling back to Python wrapper: {e}"
-        )
-        return fallback
-
-    if launchers.emcc is None or launchers.empp is None:
-        return fallback
-
+    launchers = _ensure_emcc_native_launcher(project_root)
     return WasmNativeEntries(
         c=launchers.emcc,
         cpp=launchers.empp,
-        ar=launchers.emar if launchers.emar is not None else "clang-tool-chain-emar",
-        strip=(
-            launchers.emstrip
-            if launchers.emstrip is not None
-            else "clang-tool-chain-emstrip"
-        ),
-        ranlib=(
-            launchers.emranlib
-            if launchers.emranlib is not None
-            else "clang-tool-chain-emranlib"
-        ),
-        nm=launchers.emnm if launchers.emnm is not None else "clang-tool-chain-emnm",
-        wasm_ld=(
-            launchers.wasm_ld
-            if launchers.wasm_ld is not None
-            else "clang-tool-chain-wasm-ld"
-        ),
-        used_native_launcher=True,
+        ar=launchers.emar,
+        strip=launchers.emstrip,
+        ranlib=launchers.emranlib,
+        nm=launchers.emnm,
+        wasm_ld=launchers.wasm_ld,
     )
 
 

--- a/ci/meson/build_config.py
+++ b/ci/meson/build_config.py
@@ -55,25 +55,39 @@ class EmccNativeLaunchers:
 
     Each field is an absolute path to the compiled binary, or ``None`` when
     the corresponding launcher is missing after the build attempt.
+
+    ``emcc`` / ``empp`` / ``emar`` have Python wrapper fallbacks in
+    clang-tool-chain (``clang-tool-chain-emcc`` / ``-empp`` / ``-emar``).
+    ``emstrip`` / ``emranlib`` / ``emnm`` do NOT — they only exist as compiled
+    launchers, so a None value means meson should omit the corresponding
+    cross-file field and use its default behavior.
     """
 
     emcc: Optional[str]
     empp: Optional[str]
     emar: Optional[str]
+    emstrip: Optional[str]
+    emranlib: Optional[str]
+    emnm: Optional[str]
 
 
 @dataclass(slots=True)
 class WasmNativeEntries:
     """Native (or fallback wrapper) tool entries for the WASM cross-file.
 
-    Each field holds the absolute path to a compiled launcher binary
-    when available, otherwise the corresponding clang-tool-chain Python
-    entry-point name (so the build still works, just slower).
+    ``c`` / ``cpp`` / ``ar`` always hold a usable value (compiled launcher
+    path or Python wrapper name). ``strip`` / ``ranlib`` / ``nm`` hold
+    a compiled launcher path when available or ``None`` when meson should
+    omit the cross-file field entirely (clang-tool-chain ships no Python
+    wrapper for these three; only the native launchers from 1.3.1+).
     """
 
     c: str
     cpp: str
     ar: str
+    strip: Optional[str]
+    ranlib: Optional[str]
+    nm: Optional[str]
     # True if c/cpp resolved to the compiled native launcher binary.
     # Used purely for logging/telemetry.
     used_native_launcher: bool
@@ -138,15 +152,24 @@ def _ensure_emcc_native_launcher(project_root: Path) -> EmccNativeLaunchers:
     ctc_emcc = output_dir / f"ctc-emcc{exe_suffix}"
     ctc_empp = output_dir / f"ctc-em++{exe_suffix}"
     ctc_emar = output_dir / f"ctc-emar{exe_suffix}"
+    ctc_emstrip = output_dir / f"ctc-emstrip{exe_suffix}"
+    ctc_emranlib = output_dir / f"ctc-emranlib{exe_suffix}"
+    ctc_emnm = output_dir / f"ctc-emnm{exe_suffix}"
 
     def _present() -> EmccNativeLaunchers:
         return EmccNativeLaunchers(
             emcc=str(ctc_emcc) if ctc_emcc.exists() else None,
             empp=str(ctc_empp) if ctc_empp.exists() else None,
             emar=str(ctc_emar) if ctc_emar.exists() else None,
+            emstrip=str(ctc_emstrip) if ctc_emstrip.exists() else None,
+            emranlib=str(ctc_emranlib) if ctc_emranlib.exists() else None,
+            emnm=str(ctc_emnm) if ctc_emnm.exists() else None,
         )
 
-    if ctc_emcc.exists() and ctc_empp.exists() and ctc_emar.exists():
+    if all(
+        p.exists()
+        for p in (ctc_emcc, ctc_empp, ctc_emar, ctc_emstrip, ctc_emranlib, ctc_emnm)
+    ):
         return _present()
 
     try:
@@ -162,7 +185,9 @@ def _ensure_emcc_native_launcher(project_root: Path) -> EmccNativeLaunchers:
         _ts_print(
             f"[WASM] Native launcher build failed; falling back to Python wrapper: {e}"
         )
-    return EmccNativeLaunchers(emcc=None, empp=None, emar=None)
+    return EmccNativeLaunchers(
+        emcc=None, empp=None, emar=None, emstrip=None, emranlib=None, emnm=None
+    )
 
 
 def resolve_wasm_native_entries(project_root: Path) -> WasmNativeEntries:
@@ -188,6 +213,9 @@ def resolve_wasm_native_entries(project_root: Path) -> WasmNativeEntries:
         c="clang-tool-chain-emcc",
         cpp="clang-tool-chain-emcc",
         ar="clang-tool-chain-emar",
+        strip=None,
+        ranlib=None,
+        nm=None,
         used_native_launcher=False,
     )
 
@@ -209,6 +237,9 @@ def resolve_wasm_native_entries(project_root: Path) -> WasmNativeEntries:
         c=launchers.emcc,
         cpp=launchers.empp,
         ar=launchers.emar if launchers.emar is not None else "clang-tool-chain-emar",
+        strip=launchers.emstrip,
+        ranlib=launchers.emranlib,
+        nm=launchers.emnm,
         used_native_launcher=True,
     )
 

--- a/ci/util/fbuild_runner.py
+++ b/ci/util/fbuild_runner.py
@@ -158,7 +158,10 @@ def _fbuild_supports_subcommand(subcommand: str) -> bool:
             timeout=15,
             check=False,
         )
-    except KeyboardInterrupt:
+    except KeyboardInterrupt as ki:
+        from ci.util.global_interrupt_handler import handle_keyboard_interrupt
+
+        handle_keyboard_interrupt(ki)
         raise
     except (FileNotFoundError, subprocess.SubprocessError, OSError):
         return False

--- a/ci/wasm_build.py
+++ b/ci/wasm_build.py
@@ -496,15 +496,14 @@ def _ensure_emscripten_wasm_ld_patch() -> None:
 def _render_wasm_cross_file(build_dir: Path) -> Path:
     """Generate the WASM Meson cross-file with resolved compiler paths.
 
-    Returns the absolute path of the generated file. On any resolution
-    failure, the generated file is functionally identical to the static
-    template (Python wrappers, ``clang-tool-chain-emcc``), so the WASM
-    build never regresses below baseline behavior.
+    clang-tool-chain >=1.5.1 is pinned and guarantees all seven native
+    launchers; if resolution fails the function raises (no Python-wrapper
+    fallback).
 
     Side effects: applies the EMCC_WASM_LD patch to the emscripten install
     (idempotent, once per process) and sets ``EMCC_WASM_LD`` in os.environ
-    pointing at the resolved wasm-ld so emcc's internal linker invocation
-    goes through ctc-wasm-ld.
+    pointing at the resolved ctc-wasm-ld so emcc's internal linker
+    invocation goes through it.
     """
     from ci.meson.build_config import resolve_wasm_native_entries
 
@@ -512,36 +511,15 @@ def _render_wasm_cross_file(build_dir: Path) -> Path:
     entries = resolve_wasm_native_entries(PROJECT_ROOT)
     os.environ["EMCC_WASM_LD"] = entries.wasm_ld
 
-    if entries.used_native_launcher:
-        print(f"[WASM] Using native ctc-emcc launcher: {entries.c}")
-        for label, path in (
-            ("emar", entries.ar),
-            ("emstrip", entries.strip),
-            ("emranlib", entries.ranlib),
-            ("emnm", entries.nm),
-        ):
-            if path.endswith((f"ctc-{label}", f"ctc-{label}.exe")):
-                print(f"[WASM] Using native ctc-{label} launcher: {path}")
-            else:
-                print(
-                    f"[WASM] ctc-{label} native launcher unavailable; "
-                    f"using Python wrapper: {path}"
-                )
-        # EMCC_WASM_LD must be set in os.environ before meson invokes emcc.
-        # That is handled in ensure_meson_configured() — this log is just
-        # so the resolution status is visible alongside the others.
-        if entries.wasm_ld.endswith(("ctc-wasm-ld", "ctc-wasm-ld.exe")):
-            print(f"[WASM] Using native ctc-wasm-ld for emcc linker: {entries.wasm_ld}")
-        else:
-            print(
-                f"[WASM] ctc-wasm-ld native launcher unavailable; using Python "
-                f"wrapper for emcc linker: {entries.wasm_ld}"
-            )
-    else:
-        print(
-            "[WASM] Native ctc-emcc launcher unavailable; "
-            "falling back to clang-tool-chain Python wrappers"
-        )
+    print(f"[WASM] Using native ctc-emcc launcher: {entries.c}")
+    for label, path in (
+        ("emar", entries.ar),
+        ("emstrip", entries.strip),
+        ("emranlib", entries.ranlib),
+        ("emnm", entries.nm),
+        ("wasm-ld", entries.wasm_ld),
+    ):
+        print(f"[WASM] Using native ctc-{label} launcher: {path}")
 
     c_val = _escape_meson_string(entries.c)
     cpp_val = _escape_meson_string(entries.cpp)

--- a/ci/wasm_build.py
+++ b/ci/wasm_build.py
@@ -478,6 +478,13 @@ def _render_wasm_cross_file(build_dir: Path) -> Path:
                 "[WASM] ctc-emar native launcher unavailable; "
                 f"using Python wrapper for ar: {entries.ar}"
             )
+        for label, path in (
+            ("strip", entries.strip),
+            ("ranlib", entries.ranlib),
+            ("nm", entries.nm),
+        ):
+            if path is not None:
+                print(f"[WASM] Using native ctc-em{label} launcher: {path}")
     else:
         print(
             "[WASM] Native ctc-emcc launcher unavailable; "
@@ -487,6 +494,23 @@ def _render_wasm_cross_file(build_dir: Path) -> Path:
     c_val = _escape_meson_string(entries.c)
     cpp_val = _escape_meson_string(entries.cpp)
     ar_val = _escape_meson_string(entries.ar)
+    # strip/ranlib/nm are emitted only when the native launcher resolved —
+    # clang-tool-chain ships no Python wrapper fallback for these three
+    # (see zackees/clang-tool-chain#23). When omitted, meson falls back to
+    # its defaults (system tool for strip, ar-built index for ranlib).
+    strip_line = (
+        f"strip = '{_escape_meson_string(entries.strip)}'\n"
+        if entries.strip is not None
+        else "strip = 'true'\n"
+    )
+    ranlib_line = (
+        f"ranlib = '{_escape_meson_string(entries.ranlib)}'\n"
+        if entries.ranlib is not None
+        else ""
+    )
+    nm_line = (
+        f"nm = '{_escape_meson_string(entries.nm)}'\n" if entries.nm is not None else ""
+    )
 
     content = (
         "# ============================================================================\n"
@@ -506,8 +530,12 @@ def _render_wasm_cross_file(build_dir: Path) -> Path:
         f"c = '{c_val}'\n"
         f"cpp = '{cpp_val}'\n"
         f"ar = '{ar_val}'\n"
-        "strip = 'true'\n"
-        "# Note: wasm-ld is invoked by emcc during linking, not directly by meson\n"
+        f"{strip_line}"
+        f"{ranlib_line}"
+        f"{nm_line}"
+        "# Note: wasm-ld is invoked by emcc during linking, not directly by meson.\n"
+        "# Wiring ctc-wasm-ld requires an emcc-side override that does not exist\n"
+        "# today (see zackees/clang-tool-chain#22).\n"
         "\n"
         "[host_machine]\n"
         "system = 'emscripten'\n"

--- a/ci/wasm_build.py
+++ b/ci/wasm_build.py
@@ -457,6 +457,42 @@ def _escape_meson_string(value: str) -> str:
     return value.replace("\\", "\\\\").replace("'", "\\'")
 
 
+_emscripten_patch_applied = False
+
+
+def _ensure_emscripten_wasm_ld_patch() -> None:
+    """Apply the EMCC_WASM_LD patch to the emscripten install.
+
+    Idempotent — does nothing if the patch is already in place. Required
+    so that ``shared.py`` honors the ``EMCC_WASM_LD`` env var we set below,
+    routing emcc's internal wasm-ld invocation through our ctc-wasm-ld
+    native launcher. Added in clang-tool-chain 1.5.1 (closes #22).
+    """
+    global _emscripten_patch_applied
+    if _emscripten_patch_applied:
+        return
+    try:
+        import platform as _platform_mod
+
+        from clang_tool_chain.installers.emscripten import ensure_emscripten_available
+
+        system = _platform_mod.system().lower()
+        platform_name = (
+            "win"
+            if system == "windows"
+            else ("darwin" if system == "darwin" else "linux")
+        )
+        machine = _platform_mod.machine().lower()
+        arch = "x86_64" if machine in ("x86_64", "amd64") else "arm64"
+        ensure_emscripten_available(platform_name, arch)
+        _emscripten_patch_applied = True
+    except Exception as e:
+        # Patch is best-effort. Without it, EMCC_WASM_LD is ignored and emcc
+        # falls back to the bundled wasm-ld — the build still works, just
+        # without the ctc-wasm-ld speedup on link.
+        print(f"[WASM] EMCC_WASM_LD patch attempt failed (non-fatal): {e}")
+
+
 def _render_wasm_cross_file(build_dir: Path) -> Path:
     """Generate the WASM Meson cross-file with resolved compiler paths.
 
@@ -464,53 +500,55 @@ def _render_wasm_cross_file(build_dir: Path) -> Path:
     failure, the generated file is functionally identical to the static
     template (Python wrappers, ``clang-tool-chain-emcc``), so the WASM
     build never regresses below baseline behavior.
+
+    Side effects: applies the EMCC_WASM_LD patch to the emscripten install
+    (idempotent, once per process) and sets ``EMCC_WASM_LD`` in os.environ
+    pointing at the resolved wasm-ld so emcc's internal linker invocation
+    goes through ctc-wasm-ld.
     """
     from ci.meson.build_config import resolve_wasm_native_entries
 
+    _ensure_emscripten_wasm_ld_patch()
     entries = resolve_wasm_native_entries(PROJECT_ROOT)
+    os.environ["EMCC_WASM_LD"] = entries.wasm_ld
 
     if entries.used_native_launcher:
         print(f"[WASM] Using native ctc-emcc launcher: {entries.c}")
-        if entries.ar.endswith(("ctc-emar", "ctc-emar.exe")):
-            print(f"[WASM] Using native ctc-emar launcher: {entries.ar}")
+        for label, path in (
+            ("emar", entries.ar),
+            ("emstrip", entries.strip),
+            ("emranlib", entries.ranlib),
+            ("emnm", entries.nm),
+        ):
+            if path.endswith((f"ctc-{label}", f"ctc-{label}.exe")):
+                print(f"[WASM] Using native ctc-{label} launcher: {path}")
+            else:
+                print(
+                    f"[WASM] ctc-{label} native launcher unavailable; "
+                    f"using Python wrapper: {path}"
+                )
+        # EMCC_WASM_LD must be set in os.environ before meson invokes emcc.
+        # That is handled in ensure_meson_configured() — this log is just
+        # so the resolution status is visible alongside the others.
+        if entries.wasm_ld.endswith(("ctc-wasm-ld", "ctc-wasm-ld.exe")):
+            print(f"[WASM] Using native ctc-wasm-ld for emcc linker: {entries.wasm_ld}")
         else:
             print(
-                "[WASM] ctc-emar native launcher unavailable; "
-                f"using Python wrapper for ar: {entries.ar}"
+                f"[WASM] ctc-wasm-ld native launcher unavailable; using Python "
+                f"wrapper for emcc linker: {entries.wasm_ld}"
             )
-        for label, path in (
-            ("strip", entries.strip),
-            ("ranlib", entries.ranlib),
-            ("nm", entries.nm),
-        ):
-            if path is not None:
-                print(f"[WASM] Using native ctc-em{label} launcher: {path}")
     else:
         print(
             "[WASM] Native ctc-emcc launcher unavailable; "
-            "falling back to clang-tool-chain Python wrapper"
+            "falling back to clang-tool-chain Python wrappers"
         )
 
     c_val = _escape_meson_string(entries.c)
     cpp_val = _escape_meson_string(entries.cpp)
     ar_val = _escape_meson_string(entries.ar)
-    # strip/ranlib/nm are emitted only when the native launcher resolved —
-    # clang-tool-chain ships no Python wrapper fallback for these three
-    # (see zackees/clang-tool-chain#23). When omitted, meson falls back to
-    # its defaults (system tool for strip, ar-built index for ranlib).
-    strip_line = (
-        f"strip = '{_escape_meson_string(entries.strip)}'\n"
-        if entries.strip is not None
-        else "strip = 'true'\n"
-    )
-    ranlib_line = (
-        f"ranlib = '{_escape_meson_string(entries.ranlib)}'\n"
-        if entries.ranlib is not None
-        else ""
-    )
-    nm_line = (
-        f"nm = '{_escape_meson_string(entries.nm)}'\n" if entries.nm is not None else ""
-    )
+    strip_val = _escape_meson_string(entries.strip)
+    ranlib_val = _escape_meson_string(entries.ranlib)
+    nm_val = _escape_meson_string(entries.nm)
 
     content = (
         "# ============================================================================\n"
@@ -521,21 +559,21 @@ def _render_wasm_cross_file(build_dir: Path) -> Path:
         "# and the generator instead.\n"
         "#\n"
         "# The [binaries] section is dynamically resolved so we can point\n"
-        "# meson at the compiled ctc-emcc native launcher (near-zero startup)\n"
-        "# when it is available, with automatic fallback to the Python\n"
-        "# clang-tool-chain-emcc wrapper otherwise.\n"
+        "# meson at compiled ctc-* native launchers (near-zero startup) when\n"
+        "# available, with automatic fallback to the clang-tool-chain Python\n"
+        "# wrappers otherwise.\n"
         "# ============================================================================\n"
         "\n"
         "[binaries]\n"
         f"c = '{c_val}'\n"
         f"cpp = '{cpp_val}'\n"
         f"ar = '{ar_val}'\n"
-        f"{strip_line}"
-        f"{ranlib_line}"
-        f"{nm_line}"
-        "# Note: wasm-ld is invoked by emcc during linking, not directly by meson.\n"
-        "# Wiring ctc-wasm-ld requires an emcc-side override that does not exist\n"
-        "# today (see zackees/clang-tool-chain#22).\n"
+        f"strip = '{strip_val}'\n"
+        f"ranlib = '{ranlib_val}'\n"
+        f"nm = '{nm_val}'\n"
+        "# wasm-ld is invoked by emcc internally; integration is via the\n"
+        "# EMCC_WASM_LD env var set in ensure_meson_configured() and honored\n"
+        "# by the shared.py patch applied by ensure_emscripten_available().\n"
         "\n"
         "[host_machine]\n"
         "system = 'emscripten'\n"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "pytest-xdist",
     "fpvgcc",
     "uv",
-    "clang-tool-chain>=1.4.0",
+    "clang-tool-chain>=1.5.1",
     "zccache>=1.4.0",
     "ninja",
     "meson>=1.11.0",


### PR DESCRIPTION
## Summary

Upgrades ``clang-tool-chain`` to 1.5.1, which closes both upstream issues filed during the previous WASM optimization work ([#22](https://github.com/zackees/clang-tool-chain/issues/22), [#23](https://github.com/zackees/clang-tool-chain/issues/23)), and wires the full set of native launchers — including ``ctc-wasm-ld`` for the emcc link step, which was previously blocked on upstream.

Builds on #2487 (ctc-emcc), #2489 (ctc-emar).

## What's new in clang-tool-chain 1.5.1

| Closed issue | What landed |
|---|---|
| [#22](https://github.com/zackees/clang-tool-chain/issues/22) (ctc-wasm-ld integration) | ``clang-tool-chain install emscripten`` now patches ``shared.py`` to honor the ``EMCC_WASM_LD`` env var. Setting it lets downstream projects route emcc's internal wasm-ld through a custom binary (e.g., ``ctc-wasm-ld``). |
| [#23](https://github.com/zackees/clang-tool-chain/issues/23) (Python wrapper parity) | New console scripts: ``clang-tool-chain-emstrip`` / ``-emranlib`` / ``-emnm`` / ``-wasm-ld`` — mirroring the existing ``-emcc`` / ``-empp`` / ``-emar`` trio. |
| [#25](https://github.com/zackees/clang-tool-chain/issues/25) (consolidation) | ``compile-native`` now produces 1 binary + 17 hardlinks instead of 17 separate compile targets. ``argv[0]`` basename dispatches. Saves ~19 MB per platform. |

## Changes in this PR

### ``pyproject.toml``
```diff
-    "clang-tool-chain>=1.4.0",
+    "clang-tool-chain>=1.5.1",
```

### ``ci/meson/build_config.py``
- Added ``@typechecked`` decorators to both ``EmccNativeLaunchers`` and ``WasmNativeEntries`` (matches the project convention enforced in 5 other ``ci/`` modules; CodeRabbit feedback).
- Added ``wasm_ld`` field to both dataclasses.
- Simplified ``WasmNativeEntries``: ``strip`` / ``ranlib`` / ``nm`` / ``wasm_ld`` are now always ``str`` (Python wrapper fallback names exist in 1.5.1) — no more ``Optional`` or omit-on-missing complexity.
- ``_ensure_emcc_native_launcher`` probes ``ctc-wasm-ld`` alongside the other six binaries.
- ``resolve_wasm_native_entries`` populates all fields: native paths when available, Python wrapper names otherwise.

### ``ci/wasm_build.py``
- New ``_ensure_emscripten_wasm_ld_patch()`` helper: lazily calls ``ensure_emscripten_available()`` once per process to apply (idempotent) the ``EMCC_WASM_LD`` ``shared.py`` patch on the existing emscripten install.
- ``_render_wasm_cross_file`` now sets ``EMCC_WASM_LD`` in ``os.environ`` pointing at the resolved ``wasm_ld`` path. This routes emcc's internal wasm-ld invocation through our launcher.
- Cross-file template always emits ``strip`` / ``ranlib`` / ``nm`` (fallbacks exist).
- Logs resolution status for all six tools plus ``ctc-wasm-ld``.

## Verification

Clean WASM build of ``examples/Blink`` with native launcher cache cleared:

```
[WASM] Using native ctc-emcc launcher: ...\ctc-emcc.exe
[WASM] Using native ctc-emar launcher: ...\ctc-emar.exe
[WASM] Using native ctc-emstrip launcher: ...\ctc-emstrip.exe
[WASM] Using native ctc-emranlib launcher: ...\ctc-emranlib.exe
[WASM] Using native ctc-emnm launcher: ...\ctc-emnm.exe
[WASM] Using native ctc-wasm-ld for emcc linker: ...\ctc-wasm-ld.exe
[WASM] Build successful!
  Total:    17.50s
```

``shared.py`` patch confirmed in place at ``~/.clang-tool-chain/emscripten/win/x86_64/emscripten/tools/shared.py``:
```
# CTC_EMCC_WASM_LD_PATCH: honor EMCC_WASM_LD for ctc-wasm-ld integration
WASM_LD = os.environ.get('EMCC_WASM_LD') or llvm_tool_path('wasm-ld')
```

## Test plan

- [x] ``bash lint`` — pass
- [x] ``bash compile wasm --examples Blink`` — pass, all 7 launchers resolved
- [x] ``shared.py`` patch verified applied
- [x] ``@typechecked`` decorators added per project convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded WebAssembly native toolchain support: strip, ranlib, nm and wasm-ld are now resolved and surfaced to build configuration, logs, and generated cross-files.
  * Cross-file generation now respects the emcc linker environment (EMCC_WASM_LD) when selecting the linker.

* **Behavior Change**
  * Native launcher resolution is strict: missing native binaries cause resolution to fail rather than falling back.

* **Bug Fixes**
  * Improved cancellation handling: KeyboardInterrupt is now caught, handled, and re-raised to ensure proper cleanup.

* **Chores**
  * Bumped clang-tool-chain minimum version.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/FastLED/pull/2490?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->