### PR TITLE
chore(deps): bump clang-tool-chain to >=1.5.2 (Windows zccache em++/emcc hotfix)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "pytest-xdist",
     "fpvgcc",
     "uv",
-    "clang-tool-chain>=1.5.1",
+    "clang-tool-chain>=1.5.2",
     "zccache>=1.4.0",
     "ninja",
     "meson>=1.11.0",


### PR DESCRIPTION
## Summary

Bumps the floor from ``>=1.5.1`` to ``>=1.5.2`` to pick up the upstream hotfix for [zackees/clang-tool-chain#29](https://github.com/zackees/clang-tool-chain/issues/29) (closed) — which we filed after the 1.5.1 upgrade in #2490.

## The bug 1.5.2 fixes

In 1.5.1 on Windows, ``clang-tool-chain-em-cpp`` / ``-emcc`` / ``-zccache-em-cpp`` / ``-zccache-emcc`` all failed with:

```
zccache: failed to run em++.py: %1 is not a valid Win32 application. (os error 193)
```

The baked ``profile.json`` pointed at ``.py`` script paths; Windows ``CreateProcess`` can't exec a Python script directly. The native ``ctc-em++`` launcher (which we use) was unaffected, but the wrapper was unusable on Windows.

## The fix (three layers in 1.5.2)

1. ``profile.py``: bake ``.bat`` paths on Windows, shebang scripts on POSIX.
2. ``zccache_shim._resolve_tool_path``: rewrite stale ``.py`` paths to sibling ``.bat`` at exec time on Windows — **existing 1.5.0 / 1.5.1 installs auto-recover without a reinstall.**
3. ``exec_via_zccache``: set ``EM_CONFIG`` / ``EMSCRIPTEN`` env and skip host-ABI flag injection for ``emcc`` / ``em++`` / ``wasm-ld``.

## Why bump even though we use the native launcher

FastLED wires the native ``ctc-em++`` (40 ms warm) so we didn't hit the wrapper bug. But:

- The broken wrapper could be picked up by other downstream tooling that resolves via ``shutil.which``.
- Closing the floor protects anyone who clones FastLED's venv setup and uses the Python entry points elsewhere.
- 1.5.2 is a pure hotfix — no API changes, no risk.

## Verification

| Tool | 1.5.1 (before) | 1.5.2 (after) |
|---|--:|--:|
| ``clang-tool-chain-em-cpp`` | rc=1, error 193 ❌ | **743 ms, rc=0** ✅ |
| ``ctc-em++`` native | 40 ms ✅ | 40 ms ✅ (unchanged) |
| WASM Blink build | 1.71 s ✅ | **1.54 s** ✅ |
| ``bash lint`` | green ✅ | green ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project dependency version constraint.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/FastLED/pull/2491?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->