### PR TITLE
perf(esp32): smart yield gate for driver polling loops

### DIFF
--- a/src/platforms/esp/32/coroutine_esp32.impl.hpp
+++ b/src/platforms/esp/32/coroutine_esp32.impl.hpp
@@ -125,7 +125,10 @@ private:
 #endif
 #if SOC_BT_SUPPORTED
         if (esp_bt_controller_get_status != nullptr) {
-            if (esp_bt_controller_get_status() != ESP_BT_CONTROLLER_STATUS_IDLE) {
+            // Match NetworkDetector::isBluetoothActive() — controller is active
+            // only when ENABLED (not merely INITED), so we don't pay the deep
+            // yield for a bt-stack-init'd-but-radio-off configuration.
+            if (esp_bt_controller_get_status() == ESP_BT_CONTROLLER_STATUS_ENABLED) {
                 return true;
             }
         }

--- a/src/platforms/esp/32/coroutine_esp32.impl.hpp
+++ b/src/platforms/esp/32/coroutine_esp32.impl.hpp
@@ -48,6 +48,17 @@ FL_EXTERN_C_BEGIN
 // Weak symbol: resolves to nullptr when WiFi component is not linked
 FL_LINK_WEAK esp_err_t esp_wifi_get_mode(wifi_mode_t *mode);
 #endif
+#ifndef SOC_BT_SUPPORTED
+#define SOC_BT_SUPPORTED 0
+#endif
+#if SOC_BT_SUPPORTED
+#include "esp_bt.h"
+// Weak symbol: resolves to nullptr when BT controller component is not linked.
+// Returning anything other than ESP_BT_CONTROLLER_STATUS_IDLE indicates the
+// controller is initialized/enabled and may have ready BT tasks competing
+// for CPU.
+FL_LINK_WEAK esp_bt_controller_status_t esp_bt_controller_get_status(void);
+#endif
 FL_EXTERN_C_END
 
 namespace fl {
@@ -87,26 +98,36 @@ public:
     }
 
     bool needsDeepYield() const FL_NOEXCEPT override {
-        // Cache WiFi detection — recheck at most once per second.
+        // Cache network-stack detection — recheck at most once per second.
+        // A "deep yield" (vTaskDelay(1) = exactly one FreeRTOS tick) is only
+        // needed when a network stack (WiFi or BT) is active and may have
+        // ready-to-run lower-priority tasks. When neither is active or linked,
+        // a plain taskYIELD() is sufficient and avoids the per-tick cost.
         static TickType_t s_lastCheck = 0;
         static bool s_cached = false;
         TickType_t now = xTaskGetTickCount();
         if ((now - s_lastCheck) >= pdMS_TO_TICKS(1000)) {
             s_lastCheck = now;
-            s_cached = isWiFiActive();
+            s_cached = isNetworkActive();
         }
         return s_cached;
     }
 
 private:
-    static bool isWiFiActive() FL_NOEXCEPT {
+    static bool isNetworkActive() FL_NOEXCEPT {
 #if SOC_WIFI_SUPPORTED
-        if (esp_wifi_get_mode == nullptr) {
-            return false; // WiFi component not linked
+        if (esp_wifi_get_mode != nullptr) {
+            wifi_mode_t mode;
+            if (esp_wifi_get_mode(&mode) == ESP_OK && mode != WIFI_MODE_NULL) {
+                return true;
+            }
         }
-        wifi_mode_t mode;
-        if (esp_wifi_get_mode(&mode) == ESP_OK && mode != WIFI_MODE_NULL) {
-            return true;
+#endif
+#if SOC_BT_SUPPORTED
+        if (esp_bt_controller_get_status != nullptr) {
+            if (esp_bt_controller_get_status() != ESP_BT_CONTROLLER_STATUS_IDLE) {
+                return true;
+            }
         }
 #endif
         return false;

--- a/src/platforms/esp/32/drivers/i2s/i2s_lcd_cam_peripheral_esp.cpp.hpp
+++ b/src/platforms/esp/32/drivers/i2s/i2s_lcd_cam_peripheral_esp.cpp.hpp
@@ -12,6 +12,7 @@
 #if defined(FL_IS_ESP_32S3) && FL_HAS_INCLUDE("esp_lcd_panel_io.h")
 
 #include "platforms/esp/32/drivers/i2s/i2s_lcd_cam_peripheral_esp.h"
+#include "platforms/esp/32/yield_gate.hpp"
 #include "fl/stl/singleton.h"
 #include "fl/stl/noexcept.h"
 #include "fl/log/log.h"
@@ -280,7 +281,9 @@ bool I2sLcdCamPeripheralEsp::waitTransmitDone(u32 timeout_ms) FL_NOEXCEPT {
         return false;
     }
 
-    // Simple polling wait (callback will clear mBusy)
+    // Simple polling wait (callback will clear mBusy). Yield via the
+    // network-aware smart gate: vTaskDelay(1) only when WiFi/BT is active,
+    // taskYIELD() otherwise. See platforms/esp/32/yield_gate.hpp.
     u32 start = (u32)(esp_timer_get_time() / 1000);
     while (mBusy) {
         if (timeout_ms > 0) {
@@ -289,7 +292,7 @@ bool I2sLcdCamPeripheralEsp::waitTransmitDone(u32 timeout_ms) FL_NOEXCEPT {
                 return false;  // Timeout
             }
         }
-        vTaskDelay(1);  // Yield
+        fl::platforms::esp_smart_yield();
     }
     return true;
 }

--- a/src/platforms/esp/32/yield_gate.hpp
+++ b/src/platforms/esp/32/yield_gate.hpp
@@ -7,11 +7,13 @@
 /// FreeRTOS tasks can run. The cheap choice — `taskYIELD()` — only re-runs the
 /// scheduler against equal-or-higher-priority Ready tasks; lower-priority
 /// network tasks (lwIP / WiFi / BT) never get CPU. The traditional fix is
-/// `vTaskDelay(1)`, which Blocks the caller for exactly one FreeRTOS tick
+/// `vTaskDelay(1)`, which Blocks the caller for at least one FreeRTOS tick
 /// and lets the scheduler run anything Ready, including lower-priority tasks.
 ///
-/// `vTaskDelay(1)` costs one full tick (~1 ms on the default 1 kHz tick
-/// rate). On a 60 FPS render budget that's ~6 % of frame time. Paying that
+/// `vTaskDelay(1)` blocks for between 0 and 1 full tick (depending on phase
+/// relative to the next tick interrupt) plus the requested 1 tick — so 1 to 2
+/// ticks of actual wall-clock delay on a system with a 1 kHz tick rate. On a
+/// 60 FPS render budget that's ~6–12 % of frame time per yield. Paying that
 /// when the binary has no network stack linked at all — or when WiFi/BT are
 /// linked but inactive — is wasted overhead.
 ///
@@ -24,10 +26,13 @@
 ///     dead code.
 ///   - Runtime gate: when symbols are linked, the active-mode check is
 ///     cached at 1 Hz inside `CoroutineRuntimeEsp32::needsDeepYield()`, so
-///     per-call cost is a singleton lookup plus one compare.
-///   - Yield magnitude: when the gate fires we use `vTaskDelay(1)` — exactly
-///     one tick by the FreeRTOS contract, regardless of the configured tick
-///     rate. Sub-tick delays are not meaningful in FreeRTOS terms.
+///     hot-path cost is a singleton lookup plus a compare (first call after
+///     boot pays a network-stack probe).
+///   - Yield magnitude: when the gate fires we use `vTaskDelay(1)` — the
+///     minimum delay that releases the caller from the Ready set under
+///     FreeRTOS. Sub-tick requests degenerate to `taskYIELD()` and do not
+///     let lower-priority tasks run; that's the failure mode this helper
+///     exists to avoid.
 ///
 /// Refs: https://github.com/FastLED/FastLED/issues/2493 (latency analysis),
 /// https://github.com/FastLED/FastLED/issues/2254 (the original WiFi
@@ -54,15 +59,15 @@ namespace platforms {
 
 /// @brief Yield to the FreeRTOS scheduler with network-stack awareness.
 ///
-/// When a network stack (WiFi / BT) is active, blocks for exactly one
+/// When a network stack (WiFi / BT) is active, blocks for at least one
 /// FreeRTOS tick so lower-priority network tasks can drain. Otherwise just
 /// `taskYIELD()`, which is sub-microsecond.
 inline void esp_smart_yield() FL_NOEXCEPT {
-    if (fl::ICoroutineRuntime::instance().needsDeepYield()) {
-        // Exactly one tick — the smallest interval that releases the caller
-        // from the Ready set and lets the scheduler dispatch lower-priority
-        // tasks. Sub-tick requests round to taskYIELD() under FreeRTOS, which
-        // is what this branch is trying to avoid.
+    if (fl::platforms::ICoroutineRuntime::instance().needsDeepYield()) {
+        // Minimum tick-granularity delay that releases the caller from the
+        // Ready set, allowing the scheduler to dispatch lower-priority tasks
+        // (lwIP / WiFi / BT). Sub-tick requests degenerate to taskYIELD()
+        // under FreeRTOS, which is exactly what this branch avoids.
         vTaskDelay(1);
     } else {
         taskYIELD();

--- a/src/platforms/esp/32/yield_gate.hpp
+++ b/src/platforms/esp/32/yield_gate.hpp
@@ -1,0 +1,75 @@
+#pragma once
+
+/// @file yield_gate.hpp
+/// @brief Smart yield helper for FastLED ESP32 driver polling loops.
+///
+/// When a driver polls for DMA / peripheral completion it must yield so other
+/// FreeRTOS tasks can run. The cheap choice — `taskYIELD()` — only re-runs the
+/// scheduler against equal-or-higher-priority Ready tasks; lower-priority
+/// network tasks (lwIP / WiFi / BT) never get CPU. The traditional fix is
+/// `vTaskDelay(1)`, which Blocks the caller for exactly one FreeRTOS tick
+/// and lets the scheduler run anything Ready, including lower-priority tasks.
+///
+/// `vTaskDelay(1)` costs one full tick (~1 ms on the default 1 kHz tick
+/// rate). On a 60 FPS render budget that's ~6 % of frame time. Paying that
+/// when the binary has no network stack linked at all — or when WiFi/BT are
+/// linked but inactive — is wasted overhead.
+///
+/// `fl::platforms::esp_smart_yield()` gates the deep yield on a cached check
+/// of whether any network stack is *currently active*:
+///
+///   - Link-time gate: weak symbols on `esp_wifi_get_mode` and
+///     `esp_bt_controller_get_status`. If neither is linked, the check
+///     short-circuits to `false` at link time and the deep-yield branch is
+///     dead code.
+///   - Runtime gate: when symbols are linked, the active-mode check is
+///     cached at 1 Hz inside `CoroutineRuntimeEsp32::needsDeepYield()`, so
+///     per-call cost is a singleton lookup plus one compare.
+///   - Yield magnitude: when the gate fires we use `vTaskDelay(1)` — exactly
+///     one tick by the FreeRTOS contract, regardless of the configured tick
+///     rate. Sub-tick delays are not meaningful in FreeRTOS terms.
+///
+/// Refs: https://github.com/FastLED/FastLED/issues/2493 (latency analysis),
+/// https://github.com/FastLED/FastLED/issues/2254 (the original WiFi
+/// starvation case that motivated the round-up-to-one-tick rule).
+
+#include "platforms/is_platform.h"
+
+#ifdef FL_IS_ESP32
+
+#include "platforms/coroutine_runtime.h"
+#include "fl/stl/noexcept.h"
+
+FL_EXTERN_C_BEGIN
+// IWYU pragma: begin_keep
+#include "freertos/FreeRTOS.h"
+// IWYU pragma: end_keep
+// IWYU pragma: begin_keep
+#include "freertos/task.h"
+// IWYU pragma: end_keep
+FL_EXTERN_C_END
+
+namespace fl {
+namespace platforms {
+
+/// @brief Yield to the FreeRTOS scheduler with network-stack awareness.
+///
+/// When a network stack (WiFi / BT) is active, blocks for exactly one
+/// FreeRTOS tick so lower-priority network tasks can drain. Otherwise just
+/// `taskYIELD()`, which is sub-microsecond.
+inline void esp_smart_yield() FL_NOEXCEPT {
+    if (fl::ICoroutineRuntime::instance().needsDeepYield()) {
+        // Exactly one tick — the smallest interval that releases the caller
+        // from the Ready set and lets the scheduler dispatch lower-priority
+        // tasks. Sub-tick requests round to taskYIELD() under FreeRTOS, which
+        // is what this branch is trying to avoid.
+        vTaskDelay(1);
+    } else {
+        taskYIELD();
+    }
+}
+
+} // namespace platforms
+} // namespace fl
+
+#endif // FL_IS_ESP32


### PR DESCRIPTION
## Summary

Driver polling loops on ESP32 (currently just one: `I2sLcdCamPeripheralEsp::waitTransmitDone`) previously called `vTaskDelay(1)` unconditionally so lower-priority network tasks (lwIP / WiFi / BT) could drain. That costs one full FreeRTOS tick (~1 ms at the default 1 kHz tick rate) per iteration even on headless / no-WiFi builds where no network task exists to yield to.

This PR introduces `fl::platforms::esp_smart_yield()` — an inline helper that gates the deep yield on the existing `ICoroutineRuntime::needsDeepYield()` mechanism. Two layers:

- **Link-time**: weak symbols on `esp_wifi_get_mode` and `esp_bt_controller_get_status`. If neither component is linked, the deep-yield branch is dead code.
- **Runtime**: when symbols are linked, the active-mode check is cached at 1 Hz inside `needsDeepYield()`. Per-call cost is a singleton lookup + one bool compare.

When the gate fires, we use **`vTaskDelay(1)` — exactly one FreeRTOS tick**, the smallest interval that releases the caller from the Ready set so the scheduler can dispatch lower-priority tasks. Sub-tick requests degenerate to `taskYIELD()` under FreeRTOS, which is what the deep-yield path exists to avoid.

## Changes

- `src/platforms/esp/32/coroutine_esp32.impl.hpp`: extend the existing `isWiFiActive()` → `isNetworkActive()` so `needsDeepYield()` now ORs WiFi-mode-active and BT-controller-not-idle. New weak extern for `esp_bt_controller_get_status` under `SOC_BT_SUPPORTED`. Behavior preserved on WiFi-only configurations.
- `src/platforms/esp/32/yield_gate.hpp` (new): the inline `fl::platforms::esp_smart_yield()` helper, with the two-layer-gate rationale and the one-tick yield magnitude reasoning in the header doc.
- `src/platforms/esp/32/drivers/i2s/i2s_lcd_cam_peripheral_esp.cpp.hpp`: the sole FastLED-side `vTaskDelay(1)` poll loop now calls `esp_smart_yield()`.

## Scope notes

- The full `grep` for FastLED-side `vTaskDelay(N)` polling loops with small `N` across `src/platforms/esp/32/drivers/**` returned exactly one site (the I2S LCD_CAM `waitTransmitDone` loop). PARLIO and RMT5 delegate to ESP-IDF's `parlio_tx_unit_wait_all_done` / `rmt_tx_wait_all_done`, which are semaphore-backed inside IDF — no FastLED-side polling to gate.
- The headline ESP32-P4 PARLIO latency reported in #2493 is **not** addressed here; that needs hardware-measured investigation into the IDF wait path. The smart-yield helper is reusable if future drivers introduce poll loops.

## Refs

- Issue [#2493](https://github.com/FastLED/FastLED/issues/2493) (ESP32-P4 PARLIO `FastLED.show()` blocking analysis) — motivating context.
- Issue [#2254](https://github.com/FastLED/FastLED/issues/2254) (original WiFi-starvation root-cause of the round-up-to-one-tick rule).

## Test plan

- [x] `bash compile esp32s3 --examples Blink` — pass
- [x] `bash compile esp32dev --examples Blink` — pass
- [x] `bash compile esp32p4 --examples Blink` — pass
- [x] `bash lint` — clean
- [x] `bash test --cpp` — 304/304 (cached; host tests don't compile ESP-only paths)
- [ ] Hardware validation on ESP32-S3 with I2S LCD_CAM driver (needs hardware — no behavioral change expected on no-network builds; ms-level frame budget improvement on builds without WiFi/BT linked)
- [ ] CI green on branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved ESP32 task scheduling to detect WiFi and Bluetooth activity and use more appropriate yielding during I2S operations.
* **New Features**
  * Added a network-aware yield helper that chooses between light and deep yields based on active network stacks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/FastLED/pull/2497?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->