### PR TITLE
fix(channels): include fl/stl/string.h in config.h (fixes teensy41 CI)

### DIFF
--- a/src/fl/channels/config.h
+++ b/src/fl/channels/config.h
@@ -13,6 +13,7 @@
 #include "fl/gfx/eorder.h"
 #include "fl/channels/options.h"
 #include "fl/stl/optional.h"
+#include "fl/stl/string.h"  // fl::string must be complete for Optional<fl::string> below  // IWYU pragma: keep
 #include "color.h"  // IWYU pragma: keep
 #include "dither_mode.h"  // IWYU pragma: keep
 #include "fl/stl/noexcept.h"


### PR DESCRIPTION
## Summary

- **Bug**: `ChannelConfig::mName` is declared as `fl::optional<fl::string>` — a data member that requires a complete `fl::string` type to lay out (via `Optional<T>`'s internal `fl::variant<T, Empty>` calling `sizeof(T)` and `alignof(T)`). `config.h` only included `fl/stl/optional.h`, which forward-declares `fl::string` but never defines it.
- **Why teensy41 specifically**: Most platforms transitively pick up `fl/stl/string.h` through an earlier include in their chain, so the bug stays latent. The teensy41 include order doesn't, and every example in the teensy41 workflow has been failing for **over a month** with the same diagnostic:
  ```
  fl/stl/type_traits.h:927:18: error: invalid application of
      '__alignof__' to incomplete type 'fl::string'
  ```
  (61+ consecutive failing runs going back to mid-April, per `gh run list --workflow=teensy41`.)
- **Fix**: Add `#include \"fl/stl/string.h\"` to `config.h` with `IWYU pragma: keep` so the linter doesn't strip it on the assumption that only a forward declaration is needed.

## Test plan

- [x] `bash lint --cpp` passes (IWYU pragma block check).
- [ ] CI: teensy41 workflow goes green (was the only blocker).
- [ ] CI: full matrix passes (other platforms shouldn't be affected — they already get `fl::string` complete via their include chain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Minor internal header file update to ensure proper type resolution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/FastLED/pull/2499?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->