### PR TITLE
chore(deps): bump fbuild to 2.2.4 (fixes teensy41 CMSIS-DSP link)

### DIFF
--- a/.github/workflows/build_adafruit_feather_nrf52840_sense.yml
+++ b/.github/workflows/build_adafruit_feather_nrf52840_sense.yml
@@ -18,6 +18,8 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
+      - 'pyproject.toml'
+      - 'uv.lock'
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_adafruit_xiaoblesense.yml
+++ b/.github/workflows/build_adafruit_xiaoblesense.yml
@@ -18,6 +18,8 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
+      - 'pyproject.toml'
+      - 'uv.lock'
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_apollo3_red.yml
+++ b/.github/workflows/build_apollo3_red.yml
@@ -18,6 +18,8 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
+      - 'pyproject.toml'
+      - 'uv.lock'
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_apollo3_thing_explorable.yml
+++ b/.github/workflows/build_apollo3_thing_explorable.yml
@@ -18,6 +18,8 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
+      - 'pyproject.toml'
+      - 'uv.lock'
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_atmega8a.yml
+++ b/.github/workflows/build_atmega8a.yml
@@ -18,6 +18,8 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
+      - 'pyproject.toml'
+      - 'uv.lock'
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_attiny1604.yml
+++ b/.github/workflows/build_attiny1604.yml
@@ -18,6 +18,8 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
+      - 'pyproject.toml'
+      - 'uv.lock'
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_attiny1616.yml
+++ b/.github/workflows/build_attiny1616.yml
@@ -18,6 +18,8 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
+      - 'pyproject.toml'
+      - 'uv.lock'
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_attiny4313.yml
+++ b/.github/workflows/build_attiny4313.yml
@@ -18,6 +18,8 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
+      - 'pyproject.toml'
+      - 'uv.lock'
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_attiny85.yml
+++ b/.github/workflows/build_attiny85.yml
@@ -18,6 +18,8 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
+      - 'pyproject.toml'
+      - 'uv.lock'
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_attiny88.yml
+++ b/.github/workflows/build_attiny88.yml
@@ -18,6 +18,8 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
+      - 'pyproject.toml'
+      - 'uv.lock'
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_blackpill_stm32f4.yml
+++ b/.github/workflows/build_blackpill_stm32f4.yml
@@ -18,6 +18,8 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
+      - 'pyproject.toml'
+      - 'uv.lock'
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_bluepill.yml
+++ b/.github/workflows/build_bluepill.yml
@@ -18,6 +18,8 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
+      - 'pyproject.toml'
+      - 'uv.lock'
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_clone_and_compile.yml
+++ b/.github/workflows/build_clone_and_compile.yml
@@ -17,6 +17,8 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
+      - 'pyproject.toml'
+      - 'uv.lock'
   # pull_request_target: DISABLED - Security vulnerability through PlatformIO pre-script execution
   # Running on pull_request_target allows execution of malicious Python code
   # Workflow still runs on push to master for validation

--- a/.github/workflows/build_digix.yml
+++ b/.github/workflows/build_digix.yml
@@ -18,6 +18,8 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
+      - 'pyproject.toml'
+      - 'uv.lock'
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_due.yml
+++ b/.github/workflows/build_due.yml
@@ -18,6 +18,8 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
+      - 'pyproject.toml'
+      - 'uv.lock'
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_esp32_i2s_ws2812.yml
+++ b/.github/workflows/build_esp32_i2s_ws2812.yml
@@ -22,6 +22,8 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
+      - 'pyproject.toml'
+      - 'uv.lock'
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_esp32c2.yml
+++ b/.github/workflows/build_esp32c2.yml
@@ -22,6 +22,8 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
+      - 'pyproject.toml'
+      - 'uv.lock'
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_esp32c3.yml
+++ b/.github/workflows/build_esp32c3.yml
@@ -22,6 +22,8 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
+      - 'pyproject.toml'
+      - 'uv.lock'
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_esp32c5.yml
+++ b/.github/workflows/build_esp32c5.yml
@@ -22,6 +22,8 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
+      - 'pyproject.toml'
+      - 'uv.lock'
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_esp32c6.yml
+++ b/.github/workflows/build_esp32c6.yml
@@ -22,6 +22,8 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
+      - 'pyproject.toml'
+      - 'uv.lock'
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_esp32dev.yml
+++ b/.github/workflows/build_esp32dev.yml
@@ -22,6 +22,8 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
+      - 'pyproject.toml'
+      - 'uv.lock'
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_esp32dev_idf3.3.yml
+++ b/.github/workflows/build_esp32dev_idf3.3.yml
@@ -22,6 +22,8 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
+      - 'pyproject.toml'
+      - 'uv.lock'
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_esp32dev_idf4.4.yml
+++ b/.github/workflows/build_esp32dev_idf4.4.yml
@@ -22,6 +22,8 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
+      - 'pyproject.toml'
+      - 'uv.lock'
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_esp32dev_namespace.yml
+++ b/.github/workflows/build_esp32dev_namespace.yml
@@ -22,6 +22,8 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
+      - 'pyproject.toml'
+      - 'uv.lock'
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_esp32h2.yml
+++ b/.github/workflows/build_esp32h2.yml
@@ -22,6 +22,8 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
+      - 'pyproject.toml'
+      - 'uv.lock'
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_esp32p4.yml
+++ b/.github/workflows/build_esp32p4.yml
@@ -22,6 +22,8 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
+      - 'pyproject.toml'
+      - 'uv.lock'
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_esp32s2.yml
+++ b/.github/workflows/build_esp32s2.yml
@@ -22,6 +22,8 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
+      - 'pyproject.toml'
+      - 'uv.lock'
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_esp32s3.yml
+++ b/.github/workflows/build_esp32s3.yml
@@ -22,6 +22,8 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
+      - 'pyproject.toml'
+      - 'uv.lock'
   pull_request:
     branches:
       - master
@@ -39,6 +41,8 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
+      - 'pyproject.toml'
+      - 'uv.lock'
 
 jobs:
   build:

--- a/.github/workflows/build_esp32wroom.yml
+++ b/.github/workflows/build_esp32wroom.yml
@@ -22,6 +22,8 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
+      - 'pyproject.toml'
+      - 'uv.lock'
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_esp8266.yml
+++ b/.github/workflows/build_esp8266.yml
@@ -22,6 +22,8 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
+      - 'pyproject.toml'
+      - 'uv.lock'
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_esp_extra_libs.yml
+++ b/.github/workflows/build_esp_extra_libs.yml
@@ -17,6 +17,8 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
+      - 'pyproject.toml'
+      - 'uv.lock'
 
 
 permissions:

--- a/.github/workflows/build_giga_r1.yml
+++ b/.github/workflows/build_giga_r1.yml
@@ -18,6 +18,8 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
+      - 'pyproject.toml'
+      - 'uv.lock'
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -17,6 +17,8 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
+      - 'pyproject.toml'
+      - 'uv.lock'
 permissions:
   contents: read        # Required to checkout code
   actions: read         # Required for artifact operations  

--- a/.github/workflows/build_maple_map.yml
+++ b/.github/workflows/build_maple_map.yml
@@ -18,6 +18,8 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
+      - 'pyproject.toml'
+      - 'uv.lock'
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_mgm240s_thingplusmatter.yml
+++ b/.github/workflows/build_mgm240s_thingplusmatter.yml
@@ -18,6 +18,8 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
+      - 'pyproject.toml'
+      - 'uv.lock'
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_nano_every.yml
+++ b/.github/workflows/build_nano_every.yml
@@ -18,6 +18,8 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
+      - 'pyproject.toml'
+      - 'uv.lock'
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_nrf52840_dk.yml
+++ b/.github/workflows/build_nrf52840_dk.yml
@@ -18,6 +18,8 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
+      - 'pyproject.toml'
+      - 'uv.lock'
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_nrf52840_supermini.yml
+++ b/.github/workflows/build_nrf52840_supermini.yml
@@ -18,6 +18,8 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
+      - 'pyproject.toml'
+      - 'uv.lock'
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_nrf52_xiaoblesense.yml
+++ b/.github/workflows/build_nrf52_xiaoblesense.yml
@@ -18,6 +18,8 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
+      - 'pyproject.toml'
+      - 'uv.lock'
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_nucleo_f429zi.yml
+++ b/.github/workflows/build_nucleo_f429zi.yml
@@ -18,6 +18,8 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
+      - 'pyproject.toml'
+      - 'uv.lock'
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_nucleo_f439zi.yml
+++ b/.github/workflows/build_nucleo_f439zi.yml
@@ -18,6 +18,8 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
+      - 'pyproject.toml'
+      - 'uv.lock'
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_rgbw.yml
+++ b/.github/workflows/build_rgbw.yml
@@ -18,6 +18,8 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
+      - 'pyproject.toml'
+      - 'uv.lock'
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_rp2040.yml
+++ b/.github/workflows/build_rp2040.yml
@@ -18,6 +18,8 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
+      - 'pyproject.toml'
+      - 'uv.lock'
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_rp2350.yml
+++ b/.github/workflows/build_rp2350.yml
@@ -18,6 +18,8 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
+      - 'pyproject.toml'
+      - 'uv.lock'
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_rp2350B.yml
+++ b/.github/workflows/build_rp2350B.yml
@@ -18,6 +18,8 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
+      - 'pyproject.toml'
+      - 'uv.lock'
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_stm103tb.yml
+++ b/.github/workflows/build_stm103tb.yml
@@ -18,6 +18,8 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
+      - 'pyproject.toml'
+      - 'uv.lock'
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_teensy30.yml
+++ b/.github/workflows/build_teensy30.yml
@@ -27,6 +27,8 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
+      - 'pyproject.toml'
+      - 'uv.lock'
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_teensy31.yml
+++ b/.github/workflows/build_teensy31.yml
@@ -27,6 +27,8 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
+      - 'pyproject.toml'
+      - 'uv.lock'
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_teensy32.yml
+++ b/.github/workflows/build_teensy32.yml
@@ -27,6 +27,8 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
+      - 'pyproject.toml'
+      - 'uv.lock'
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_teensy35.yml
+++ b/.github/workflows/build_teensy35.yml
@@ -27,6 +27,8 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
+      - 'pyproject.toml'
+      - 'uv.lock'
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_teensy36.yml
+++ b/.github/workflows/build_teensy36.yml
@@ -27,6 +27,8 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
+      - 'pyproject.toml'
+      - 'uv.lock'
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_teensy40.yml
+++ b/.github/workflows/build_teensy40.yml
@@ -27,6 +27,8 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
+      - 'pyproject.toml'
+      - 'uv.lock'
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_teensy41.yml
+++ b/.github/workflows/build_teensy41.yml
@@ -27,6 +27,8 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
+      - 'pyproject.toml'
+      - 'uv.lock'
   pull_request:
     branches:
       - master
@@ -49,6 +51,8 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
+      - 'pyproject.toml'
+      - 'uv.lock'
 
 jobs:
   build:

--- a/.github/workflows/build_teensy41_ofled.yml
+++ b/.github/workflows/build_teensy41_ofled.yml
@@ -27,6 +27,8 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
+      - 'pyproject.toml'
+      - 'uv.lock'
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_teensyLC.yml
+++ b/.github/workflows/build_teensyLC.yml
@@ -27,6 +27,8 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
+      - 'pyproject.toml'
+      - 'uv.lock'
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_teensy_octo.yml
+++ b/.github/workflows/build_teensy_octo.yml
@@ -27,6 +27,8 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
+      - 'pyproject.toml'
+      - 'uv.lock'
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_uno.yml
+++ b/.github/workflows/build_uno.yml
@@ -19,6 +19,8 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
+      - 'pyproject.toml'
+      - 'uv.lock'
   pull_request:
     branches:
       - master
@@ -32,6 +34,8 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
+      - 'pyproject.toml'
+      - 'uv.lock'
 
 jobs:
   build:

--- a/.github/workflows/build_uno_r4_wifif.yml
+++ b/.github/workflows/build_uno_r4_wifif.yml
@@ -18,6 +18,8 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
+      - 'pyproject.toml'
+      - 'uv.lock'
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_wasm.yml
+++ b/.github/workflows/build_wasm.yml
@@ -18,6 +18,8 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
+      - 'pyproject.toml'
+      - 'uv.lock'
   pull_request:
     branches:
       - master
@@ -31,6 +33,8 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
+      - 'pyproject.toml'
+      - 'uv.lock'
 
 permissions:
   contents: read        # Required to checkout code

--- a/.github/workflows/build_wasm_compilers.yml
+++ b/.github/workflows/build_wasm_compilers.yml
@@ -18,6 +18,8 @@ on:
         - 'platformio.ini'
         - 'library.json'
         - 'library.properties'
+        - 'pyproject.toml'
+        - 'uv.lock'
 permissions:
   contents: read        # Required to checkout code
   actions: read         # Required for artifact operations  

--- a/.github/workflows/build_yun.yml
+++ b/.github/workflows/build_yun.yml
@@ -18,6 +18,8 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
+      - 'pyproject.toml'
+      - 'uv.lock'
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "fpvgcc",
     "uv",
     "clang-tool-chain>=1.5.2",
-    "zccache>=1.4.0",
+    "zccache>=1.9.0",
     "ninja",
     "meson>=1.11.0",
     "download",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,8 +7,10 @@ requires-python = ">=3.11"
 dependencies = [
     # Pin to an fbuild release that includes both Teensy framework library
     # resolution and the Teensy-compatible GCC 11 toolchain fix needed for
-    # teensy40/teensy41.
-    "fbuild==2.2.3",
+    # teensy40/teensy41. 2.2.4 adds CMSIS-DSP (arm_cortexM7lfsp_math) to
+    # the teensy41 link args so Audio-library FFT examples link cleanly
+    # (FastLED/fbuild#257).
+    "fbuild==2.2.4",
     "platformio>=6.1.19,<6.2",
     "python-dateutil",
     "ruff",


### PR DESCRIPTION
## Summary

fbuild 2.2.4 wires `-larm_cortexM7lfsp_math` into the teensy41 link args, resolving the `undefined reference to arm_cfft_radix4_init_q15` / `arm_cfft_radix4_q15` link errors that have been killing `Ports/PJRCSpectrumAnalyzer` (and any other Teensy-Audio-FFT-using example) in the teensy41 workflow.

See: FastLED/fbuild#257.

Combined with #2499 (which fixed the `fl::string`-incomplete compile error in `fl/channels/config.h`), this should fully restore the teensy41 CI workflow after ~60 consecutive failing runs going back to mid-April.

## Test plan

- [x] `bash test --cpp` (host) — all 248 unit tests pass on fbuild 2.2.4.
- [ ] CI: teensy41 workflow goes green.
- [ ] CI: full matrix unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated pinned dependencies: fbuild → 2.2.4 and zccache → >=1.9.0.
  * Expanded CI trigger rules so build workflows also run when project dependency/lock metadata change, ensuring builds run on dependency updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/FastLED/pull/2500?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->