### PR TITLE
chore(deps): bump fbuild 2.2.4 -> 2.2.5 (fixes teensy41 multiple-definition regression)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,10 +7,13 @@ requires-python = ">=3.11"
 dependencies = [
     # Pin to an fbuild release that includes both Teensy framework library
     # resolution and the Teensy-compatible GCC 11 toolchain fix needed for
-    # teensy40/teensy41. 2.2.4 adds CMSIS-DSP (arm_cortexM7lfsp_math) to
-    # the teensy41 link args so Audio-library FFT examples link cleanly
-    # (FastLED/fbuild#257).
-    "fbuild==2.2.4",
+    # teensy40/teensy41. 2.2.4 added CMSIS-DSP (arm_cortexM7lfsp_math) to
+    # the teensy41 link args (FastLED/fbuild#257), but regressed source
+    # discovery so the bundled FastLED in cores/teensy4/.../libraries was
+    # compiled alongside the local lib, causing multiple-definition link
+    # errors on every example (FastLED/fbuild#263). 2.2.5 fixes that
+    # regression while keeping the CMSIS-DSP fix.
+    "fbuild==2.2.5",
     "platformio>=6.1.19,<6.2",
     "python-dateutil",
     "ruff",


### PR DESCRIPTION
## Summary

fbuild 2.2.5 fixes the source-discovery regression introduced in 2.2.4 (FastLED/fbuild#263) where the bundled FastLED from `cores/teensy4/.../libraries/FastLED/` was being compiled into the build alongside the local FastLED source, breaking every teensy41 example with `multiple definition of CFastLED::CFastLED()` and a long tail of duplicate symbols.

2.2.5 keeps 2.2.4's CMSIS-DSP link-arg fix (FastLED/fbuild#257) so `Ports/PJRCSpectrumAnalyzer` and other Teensy-Audio-FFT examples still link cleanly.

Net effect: combined with #2499 (the `fl::string` include fix), this should fully restore the teensy41 CI workflow after the recent regression cascade.

## Test plan

- [x] Local `uv run fbuild --version` reports `2.2.5`.
- [ ] CI: `teensy41` workflow goes green (fires automatically thanks to the `pyproject.toml`/`uv.lock` path-filter widening in #2500).
- [ ] CI: full matrix unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated `fbuild` build tool dependency to version 2.2.5.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/FastLED/pull/2501?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->