### PR TITLE
fix(build): add fast_isr.S to library.json srcFilter so ESP32 RISC-V PIO builds link

### DIFF
--- a/library.json
+++ b/library.json
@@ -63,7 +63,8 @@
             "-<**/*.cpp>",
             "+<fl/build/*.cpp>",
             "+<*.h>",
-            "+<third_party/libhelix_mp3/real/arm/*.S>"
+            "+<third_party/libhelix_mp3/real/arm/*.S>",
+            "+<platforms/esp/32/drivers/gpio_isr_rx/*.S>"
         ],
         "libArchive": true
     }


### PR DESCRIPTION
## Summary

ESP32-P4 (and other ESP32 RISC-V variants compiling `gpio_isr_rx_mcpwm.cpp.hpp`) currently fail to link via PlatformIO on a clean checkout:

```
ld: undefined reference to `gpio_fast_edge_isr`
collect2.exe: error: ld returned 1 exit status
```

The handler is declared in `src/platforms/esp/32/drivers/gpio_isr_rx/gpio_isr_rx_mcpwm.cpp.hpp:69` under `#ifdef __riscv` and implemented in `fast_isr.S`. The `library.json` `srcFilter` overrides PIO's default file selection, and without an explicit entry the `.S` is not assembled.

The fix mirrors the existing pattern for `libhelix_mp3/real/arm/*.S` — a one-line srcFilter addition.

## Test plan

- [ ] `bash compile esp32p4` (or any RISC-V variant) succeeds on a clean checkout
- [ ] Existing host tests still pass (no host-side impact — srcFilter only affects PIO library compilation)
- [ ] No size impact on Xtensa builds (assembly is inside `#ifdef __riscv` and won't be referenced)

## Context

Discovered while attempting to reproduce #2493 on an attached ESP32-P4 — the build couldn't even link until this entry was added. Filing as a standalone fix; the #2493 timing follow-up is a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to enable proper support for ARM assembly and platform-specific GPIO driver components.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/FastLED/pull/2502?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->