### PR TITLE
fix(channels): skip vTaskDelay(1) floor in wait-loop on ESP32-P4 (#2493 follow-up)

### DIFF
--- a/src/fl/channels/driver.cpp.hpp
+++ b/src/fl/channels/driver.cpp.hpp
@@ -3,6 +3,7 @@
 #include "fl/log/log.h"
 #include "fl/stl/chrono.h"
 #include "fl/task/executor.h"
+#include "platforms/is_platform.h"
 
 namespace fl {
 
@@ -17,9 +18,17 @@ bool IChannelDriver::waitForCondition(Condition condition, u32 timeoutMs) {
             return false;  // Timeout occurred
         }
 
+#if defined(FL_IS_ESP_32P4)
+        // ESP32-P4 has no network stack (no WiFi, no Bluetooth, no lwIP),
+        // so the deep-yield rationale from #2254 doesn't apply. taskYIELD()
+        // avoids the 1-tick (≥1 ms at CONFIG_FREERTOS_HZ=1000) floor that
+        // adds ~8 ms per frame in PARLIO multi-strip workloads (#2493).
+        task::run(0, task::ExecFlags::SYSTEM);
+#else
         // OS yield only — keeps WiFi/lwIP alive without pumping
         // tasks or coroutines in the driver polling loop.
         task::run(250, task::ExecFlags::SYSTEM);
+#endif
     }
 
     return true;  // Condition met

--- a/src/fl/channels/manager.cpp.hpp
+++ b/src/fl/channels/manager.cpp.hpp
@@ -13,6 +13,7 @@
 #include "fl/system/trace.h"
 #include "fl/task/executor.h"
 #include "platforms/init_channel_driver.h"
+#include "platforms/is_platform.h"
 #include "fl/stl/noexcept.h"
 
 namespace fl {
@@ -357,9 +358,17 @@ bool ChannelManager::waitForCondition(Condition condition, u32 timeoutMs) {
             return false;  // Timeout occurred
         }
 
+#if defined(FL_IS_ESP_32P4)
+        // ESP32-P4 has no network stack (no WiFi, no Bluetooth, no lwIP),
+        // so the deep-yield rationale from #2254 doesn't apply. taskYIELD()
+        // avoids the 1-tick (≥1 ms at CONFIG_FREERTOS_HZ=1000) floor that
+        // adds ~8 ms per frame in PARLIO multi-strip workloads (#2493).
+        task::run(0, task::ExecFlags::SYSTEM);
+#else
         // OS yield only — keeps WiFi/lwIP alive without pumping
         // tasks or coroutines during frame transitions (re-entrancy risk).
         task::run(250, task::ExecFlags::SYSTEM);
+#endif
     }
 
     return true;  // Condition met


### PR DESCRIPTION
## Summary

- ESP32-P4 `FastLED.show()` was spending ~8 ms per frame in `vTaskDelay(1)` calls inside `ChannelManager::waitForCondition` and `IChannelDriver::waitForCondition` — accounting for the ~16.7 ms/frame regression reported in #2493 for 12×256 PARLIO multi-strip workloads.
- The 1 ms floor (rounded up from `task::run(250, SYSTEM)` at `coroutine_esp32.impl.hpp:65-86`) was added to keep WiFi/lwIP alive during I2S waits per #2254. **P4 has no WiFi, no Bluetooth, no lwIP** — the rationale doesn't apply.
- This PR replaces the call with `task::run(0, SYSTEM)` (→ `taskYIELD()`) under `#if defined(FL_IS_ESP_32P4)`. All other platforms keep the existing behavior.

## Root cause walk

```
FastLED.show()
 └─ ChannelManager::waitForReady()                  manager.cpp.hpp:402
     └─ waitForCondition()                          manager.cpp.hpp:349
         └─ task::run(250, SYSTEM)                  manager.cpp.hpp:362  ◄── per iter
             └─ pumpCoroutines(250)                 coroutine_esp32.impl.hpp:62
                 ├─ tick_period_us = 1_000_000 / CONFIG_FREERTOS_HZ
                 │                 = 1_000          (P4 ships 1 kHz)
                 ├─ ticks = 250 / 1000 = 0
                 ├─ if (ticks == 0) ticks = 1;
                 └─ vTaskDelay(1)                   = 1 ms minimum sleep
```

For 12 strips × 256 WS2812B: DMA drain ≈ 7.7 ms, wait-loop polls once per ms → ~8 iterations × 1 ms ≈ 8 ms wasted on top of DMA → total ≈ 16 ms. Matches #2493 reported timing exactly.

## Expected impact

| Workload | Before | After |
|---|---|---|
| P4, 12×256 PARLIO `FastLED.show()` | ~16.7 ms | ~7.7 ms (DMA only) |
| Other platforms | unchanged | unchanged |

## Test plan

- [x] Host tests pass: `bash test tests/fl/channels/manager.cpp --debug`, `bash test tests/fl/channels/channel_manager.cpp --debug`, `bash test tests/fl/channels/driver.cpp --debug`
- [ ] Verify on real ESP32-P4 hardware that `FastLED.show()` time for a 12×256 PARLIO sketch drops to ~8 ms (was ~16.7 ms per #2493)
- [ ] Verify Xtensa builds (ESP32-S3, etc.) still gate the deep-yield path (no behavior change expected)
- [ ] No regression in #2254 I2S websocket starvation on S3 (different platform, code path unchanged)

## Context

#2493 was closed by #2498 (8d4e8ef3f), which addressed the driver-registration symptom (LEDs not pushing data). That commit did not touch the wait-loop timing path. This PR addresses the residual timing issue called out in the issue thread by @zackees (P4 doesn't need the deep yield).

Discovered while looking at #2493 on attached hardware. The companion build-system PR is #2502 (library.json srcFilter for `fast_isr.S`), needed to even link P4 builds on a clean tree.

Refs: #2493, #2254, #2420, #2498, #2502

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized polling behavior for platform-specific performance. Different hardware platforms now implement tailored yielding strategies to improve responsiveness and efficiency during channel operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/FastLED/pull/2503?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->