### PR TITLE
ci: enforce zccache strict path validation (closes #2378)

### DIFF
--- a/ci/meson/build_config.py
+++ b/ci/meson/build_config.py
@@ -431,8 +431,33 @@ def is_ar_content_preserving_active(build_dir: Path) -> bool:
 _ar_opt_status_cache: dict[str, bool] = {}
 
 
-_MESON_PRIVATE_INCLUDE_RE = re.compile(
-    r'(?P<prefix>(?<!\S)"?-I)(?P<path>[^"\s]+\.p)(?P<suffix>"?)'
+# Path-bearing compiler flag prefixes that zccache strict path mode validates
+# (issue #2378). All accept an attached path (``-Idir``, ``-isystemdir``, ...)
+# as Meson always emits a single attached token per flag. Order matters: longer
+# prefixes must come first so the regex alternation matches the longest form
+# (``-include-pch`` before ``-include``).
+_STRICT_PATH_FLAG_PREFIXES: tuple[str, ...] = (
+    "-include-pch",
+    "-iframework",
+    "-idirafter",
+    "-isystem",
+    "-imacros",
+    "-include",
+    "-iquote",
+    "-imsvc",
+    "-I",
+    "-F",
+    "/I",
+)
+
+# Path char class excludes ``-`` as the FIRST character so the regex does not
+# mis-match the bare ``"-include-pch"`` token by falling back to the ``-include``
+# alternative + consuming ``-pch`` as the path. Real include paths never begin
+# with a hyphen.
+_STRICT_PATH_FLAG_RE = re.compile(
+    r'(?P<prefix>(?<!\S)"?(?:'
+    + "|".join(re.escape(p) for p in _STRICT_PATH_FLAG_PREFIXES)
+    + r'))(?P<path>[^\s"\-][^\s"]*)(?P<suffix>"?)'
 )
 
 
@@ -440,15 +465,36 @@ def _is_forward_slash_absolute(path: str) -> bool:
     return path.startswith("/") or re.match(r"^[A-Za-z]:/", path) is not None
 
 
+def _has_dot_components(path: str) -> bool:
+    for part in path.split("/"):
+        if part in (".", ".."):
+            return True
+    return False
+
+
 def normalize_meson_private_include_paths(build_dir: Path) -> bool:
-    """Normalize Meson's private ``-I*.p`` scratch includes for zccache strict mode."""
+    """Normalize Meson-emitted path flags for zccache strict path mode.
+
+    Issue #2378 — ``ZCCACHE_STRICT_PATHS=absolute`` rejects path-bearing
+    compiler flags (``-I``, ``-isystem``, ``-iquote``, ``-iframework``,
+    ``-idirafter``, ``-imsvc``, ``-include``, ``-include-pch``, ``-imacros``,
+    ``-F``, ``/I``) that are not absolute, forward-slash, and free of ``.``
+    or ``..`` components.
+
+    Meson emits attached single-token flags like ``"-Ici/meson/native"`` and
+    ``"-I..\\..\\src"`` from subdir and ``implicit_include_directories``
+    behavior; this function rewrites them to canonical absolute forward-slash
+    form in both ``build.ninja`` and ``compile_commands.json``.
+    """
 
     changed_any = False
 
     def _replacement(match: re.Match[str]) -> str:
         prefix, raw_path, suffix = match.groups()
         normalized = raw_path.replace("\\", "/")
-        if _is_forward_slash_absolute(normalized):
+        if _is_forward_slash_absolute(normalized) and not _has_dot_components(
+            normalized
+        ):
             absolute = normalized
         else:
             absolute = (build_dir / normalized).resolve().as_posix()
@@ -457,7 +503,7 @@ def normalize_meson_private_include_paths(build_dir: Path) -> bool:
         return f"{prefix}{absolute}{suffix}"
 
     def _normalize_text(content: str) -> str:
-        return _MESON_PRIVATE_INCLUDE_RE.sub(_replacement, content)
+        return _STRICT_PATH_FLAG_RE.sub(_replacement, content)
 
     build_ninja = build_dir / "build.ninja"
     if build_ninja.exists():
@@ -516,6 +562,76 @@ def normalize_meson_private_include_paths(build_dir: Path) -> bool:
                     ) from e
 
     return changed_any
+
+
+def find_strict_path_violations(build_dir: Path) -> list[str]:
+    """Return human-readable strict-path violations in ``compile_commands.json``.
+
+    Issue #2378 — every ``-I`` / ``-isystem`` / ``-iquote`` / ``-iframework`` /
+    ``-idirafter`` / ``-imsvc`` / ``-include`` / ``-include-pch`` / ``-imacros``
+    / ``-F`` / ``/I`` path must be absolute, forward-slash, and free of ``.``
+    or ``..`` components. This is the same predicate enforced by
+    ``ZCCACHE_STRICT_PATHS=absolute`` at compile time; checking it ourselves
+    after meson setup lets us fail before ninja schedules any compile work.
+
+    Returns an empty list when the file is missing (a fresh tree) or clean.
+    """
+    cc_json = build_dir / "compile_commands.json"
+    if not cc_json.exists():
+        return []
+    try:
+        data = json.loads(cc_json.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return []
+    if not isinstance(data, list):
+        return []
+
+    violations: list[str] = []
+    for entry in data:
+        if not isinstance(entry, dict):
+            continue
+        entry_dict = cast(dict[str, object], entry)
+        command = entry_dict.get("command")
+        if not isinstance(command, str):
+            continue
+        for match in _STRICT_PATH_FLAG_RE.finditer(command):
+            raw = match.group("path")
+            normalized = raw.replace("\\", "/")
+            if "\\" in raw:
+                violations.append(f"{match.group('prefix').lstrip(chr(34))}{raw}")
+                continue
+            if not _is_forward_slash_absolute(normalized):
+                violations.append(f"{match.group('prefix').lstrip(chr(34))}{raw}")
+                continue
+            if _has_dot_components(normalized):
+                violations.append(f"{match.group('prefix').lstrip(chr(34))}{raw}")
+    return violations
+
+
+def _enforce_strict_path_violations(build_dir: Path) -> None:
+    """Raise loudly when ``compile_commands.json`` still has strict-path offenders.
+
+    The normalizer above is meant to leave no offenders behind; this is the
+    fail-fast guard for issue #2378's "validation step that checks generated
+    compile commands before CI compiles". Any violation here is a bug in the
+    normalizer or a new Meson code-path that emits unnormalized flags.
+    """
+    violations = find_strict_path_violations(build_dir)
+    if not violations:
+        return
+
+    sample = violations[:10]
+    extra = len(violations) - len(sample)
+    lines = [
+        f"[MESON] ZCCACHE_STRICT_PATHS=absolute would reject {len(violations)}"
+        " compile flag(s) in compile_commands.json (issue #2378):",
+    ]
+    lines.extend(f"  {flag}" for flag in sample)
+    if extra > 0:
+        lines.append(f"  ... {extra} more")
+    message = "\n".join(lines)
+    _ts_print(message, file=sys.stderr)
+    raise RuntimeError(message)
 
 
 def cleanup_stale_meson_lockfile(build_dir: Path) -> bool:
@@ -2067,6 +2183,7 @@ endian = 'little'
             _ts_print(
                 "[MESON] Normalized private include paths for zccache strict mode"
             )
+        _enforce_strict_path_violations(build_dir)
 
         return True
 
@@ -2173,6 +2290,7 @@ endian = 'little'
             _ts_print(
                 "[MESON] Normalized private include paths for zccache strict mode"
             )
+        _enforce_strict_path_violations(build_dir)
 
         return True
 

--- a/ci/tests/test_meson_private_include_normalization.py
+++ b/ci/tests/test_meson_private_include_normalization.py
@@ -7,7 +7,10 @@ import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
-from ci.meson.build_config import normalize_meson_private_include_paths
+from ci.meson.build_config import (
+    find_strict_path_violations,
+    normalize_meson_private_include_paths,
+)
 
 
 class TestMesonPrivateIncludeNormalization(unittest.TestCase):
@@ -54,6 +57,144 @@ class TestMesonPrivateIncludeNormalization(unittest.TestCase):
             command = normalized_commands[0]["command"]
             self.assertIn(f"-I{native_private}", command)
             self.assertIn(f'"-I{test_private}"', command)
+
+    def test_normalizes_non_dot_p_and_attached_strict_path_flags(self) -> None:
+        """Issue #2378: all path-bearing flags (not just ``-I*.p``) must be
+        rewritten to absolute forward-slash form with no dot components."""
+        with TemporaryDirectory() as temp_dir:
+            build_dir = Path(temp_dir)
+            compile_commands = build_dir / "compile_commands.json"
+
+            offending = (
+                "clang++ "
+                # implicit_include_directories=true emits target subdir + project src dir
+                '"-I." "-I..\\..\\src" "-I..\\..\\tests" '
+                # subdir() emits relative + backslash spellings
+                '"-Ici/meson/native" "-I..\\..\\ci\\meson\\native" '
+                # absolute path with /. component
+                '"-IC:/Users/niteris/dev/fastled7/." '
+                # other strict-path flag families
+                '"-isystem..\\..\\third_party/include" '
+                '"-iquotetests" '
+                '"-include..\\..\\src/forced.h" '
+                '"-include-pchci/meson/native/pch.h.pch" '
+                '"-imacros..\\..\\src/macros.h" '
+                # forward-slash absolute with no dot components — already canonical
+                "-IC:/already/canonical"
+            )
+            compile_commands.write_text(
+                json.dumps(
+                    [
+                        {
+                            "directory": str(build_dir),
+                            "command": offending,
+                            "file": "src/main.cpp",
+                        }
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            self.assertTrue(normalize_meson_private_include_paths(build_dir))
+            data = json.loads(compile_commands.read_text(encoding="utf-8"))
+            normalized = data[0]["command"]
+
+            self.assertNotIn("\\", normalized)
+            for offender in (
+                '"-I."',
+                '"-Ici/meson/native"',
+                '"-IC:/Users/niteris/dev/fastled7/."',
+                '"-iquotetests"',
+            ):
+                self.assertNotIn(offender, normalized)
+
+            # Already-canonical absolute flag must be left untouched.
+            self.assertIn("-IC:/already/canonical", normalized)
+
+    def test_does_not_rewrite_bare_include_pch_token(self) -> None:
+        """The bare ``-include-pch`` flag (with the path in the next token) must
+        not be miscaptured by falling back from the ``-include-pch`` prefix to
+        the shorter ``-include`` prefix + treating ``-pch`` as the attached path.
+        This was the regression that produced ``-includeC:/.../-pch`` artifacts.
+        """
+        with TemporaryDirectory() as temp_dir:
+            build_dir = Path(temp_dir)
+            compile_commands = build_dir / "compile_commands.json"
+            original = (
+                'clang++ "-include-pch" "C:/abs/forward/slash/pch.h.pch" '
+                '"-include-pchC:/attached/pch.h.pch" -c foo.cpp'
+            )
+            compile_commands.write_text(
+                json.dumps(
+                    [
+                        {
+                            "directory": str(build_dir),
+                            "command": original,
+                            "file": "foo.cpp",
+                        }
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            normalize_meson_private_include_paths(build_dir)
+            normalized = json.loads(compile_commands.read_text(encoding="utf-8"))[0][
+                "command"
+            ]
+
+            self.assertIn('"-include-pch"', normalized)
+            self.assertNotIn("-includeC:", normalized)
+            self.assertNotIn("/-pch", normalized)
+
+
+class TestFindStrictPathViolations(unittest.TestCase):
+    """Issue #2378 — pre-compile gate that mirrors the zccache strict check."""
+
+    def test_returns_empty_for_missing_compile_commands(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            self.assertEqual(find_strict_path_violations(Path(temp_dir)), [])
+
+    def test_returns_empty_for_canonical_paths(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            build_dir = Path(temp_dir)
+            (build_dir / "compile_commands.json").write_text(
+                json.dumps(
+                    [
+                        {
+                            "directory": str(build_dir),
+                            "command": (
+                                'clang++ "-IC:/a/b" "-isystemC:/x/y" '
+                                '"-iquoteC:/p/q" -c foo.cpp'
+                            ),
+                            "file": "foo.cpp",
+                        }
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            self.assertEqual(find_strict_path_violations(build_dir), [])
+
+    def test_reports_backslash_relative_and_dot_paths(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            build_dir = Path(temp_dir)
+            (build_dir / "compile_commands.json").write_text(
+                json.dumps(
+                    [
+                        {
+                            "directory": str(build_dir),
+                            "command": (
+                                'clang++ "-I..\\..\\src" "-Itests" '
+                                '"-IC:/Users/x/." "-isystemC:/abs/canonical" '
+                                "-c foo.cpp"
+                            ),
+                            "file": "foo.cpp",
+                        }
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            violations = find_strict_path_violations(build_dir)
+            self.assertEqual(len(violations), 3)
 
 
 if __name__ == "__main__":

--- a/ci/wasm_build.py
+++ b/ci/wasm_build.py
@@ -70,10 +70,29 @@ def get_meson_executable() -> str:
 
 
 def _normalize_meson_private_paths(build_dir: Path) -> None:
-    from ci.meson.build_config import normalize_meson_private_include_paths
+    from ci.meson.build_config import (
+        find_strict_path_violations,
+        normalize_meson_private_include_paths,
+    )
 
     if normalize_meson_private_include_paths(build_dir):
         print("[WASM] Normalized private include paths for strict path mode")
+
+    violations = find_strict_path_violations(build_dir)
+    if violations:
+        sample = violations[:10]
+        extra = len(violations) - len(sample)
+        lines = [
+            "[WASM] ZCCACHE_STRICT_PATHS=absolute would reject"
+            f" {len(violations)} compile flag(s) in"
+            " compile_commands.json (issue #2378):",
+        ]
+        lines.extend(f"  {flag}" for flag in sample)
+        if extra > 0:
+            lines.append(f"  ... {extra} more")
+        message = "\n".join(lines)
+        print(message)
+        raise RuntimeError(message)
 
 
 def _cleanup_stale_meson_lockfile(build_dir: Path) -> None:


### PR DESCRIPTION
## Summary
- Generalize the Meson compile-flag normalizer beyond ``-I*.p`` to every strict-path-bearing flag (``-I``, ``-isystem``, ``-iquote``, ``-iframework``, ``-idirafter``, ``-imsvc``, ``-include``, ``-include-pch``, ``-imacros``, ``-F``, ``/I``), and strip ``/.`` / ``/..`` components.
- Add a pre-compile gate (``find_strict_path_violations`` / ``_enforce_strict_path_violations``) called from ``setup_meson_build()`` and the WASM ``_normalize_meson_private_paths`` shim — raises before any compile work is scheduled if ``compile_commands.json`` still has offenders.
- Fix a regex-backtracking bug that would mis-rewrite the bare ``"-include-pch"`` token to ``"-includeC:/.../-pch"`` by falling back from the ``-include-pch`` alternative to ``-include`` and consuming ``-pch`` as the path.

## Context
- Issue #2378 closes out the work to enable ``ZCCACHE_STRICT_PATHS=absolute`` end-to-end.
- ``ZCCACHE_STRICT_PATHS`` env var is already set in both ``ci/meson/runner.py`` and ``ci/meson/build_config.py`` (left in place).
- ``zccache>=1.9.0`` is already pinned in ``pyproject.toml`` (well above the 1.3.7 baseline that introduced ``--strict-paths``).
- The Meson include-path validator at ``ci/tests/test_meson_include_paths.py`` continues to gate CI via the existing pytest run.

## Test plan
- [x] ``uv run pytest ci/tests/test_meson_include_paths.py ci/tests/test_meson_private_include_normalization.py -v`` — 8 passed
- [x] ``uv run pytest ci/tests/`` (excluding pre-existing unrelated failures) — 313 passed, 39 skipped
- [x] ``bash lint ci/meson/build_config.py ci/tests/test_meson_private_include_normalization.py ci/wasm_build.py`` — no new violations
- [x] Confirmed pre-compile gate fires on synthetic offenders (added regression tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced build path validation to detect and prevent invalid path formats during compilation.
  * Added stricter compliance checks for generated build commands with fail-fast validation to catch path issues earlier and provide detailed error messages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/FastLED/pull/2504?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->