### PR TITLE
feat(perf-trace): thread-local push/pop perf tracing + PARLIO sweep instrumentation

### DIFF
--- a/ci/perf_trace_decode.py
+++ b/ci/perf_trace_decode.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Decode a flash dump from examples/PerfTraceBench/PerfTraceBench.ino.
+
+The sketch writes a self-describing binary blob to a data partition on the
+ESP32-P4. Pull it back with:
+
+    esptool --chip esp32p4 --port COM25 read-flash <part_offset> <size> dump.bin
+
+Then run:
+
+    uv run ci/perf_trace_decode.py dump.bin
+
+Layout matches the C++ structs in PerfTraceBench.ino.
+"""
+
+from __future__ import annotations
+
+import argparse
+import struct
+import sys
+from pathlib import Path
+from typing import Any
+
+
+HEADER_FMT = "<IHHII"  # magic, version, num_frames, total_bytes, reserved
+HEADER_SIZE = struct.calcsize(HEADER_FMT)
+HEADER_MAGIC = 0xFA571DED
+
+FRAME_FMT = "<IIIHBB"  # magic, frame_idx, show_us, event_count, dropped, pad
+FRAME_SIZE = struct.calcsize(FRAME_FMT)
+FRAME_MAGIC = 0xF8AAE000
+
+EVENT_FMT = "<IhhIII"  # magic, depth (i16), line (i16), dur_us, start_us, name_offset
+EVENT_SIZE = struct.calcsize(EVENT_FMT)
+EVENT_MAGIC = 0xE0E07E07
+
+
+def decode(blob: bytes) -> dict[str, Any]:
+    if len(blob) < HEADER_SIZE:
+        raise ValueError(f"too short ({len(blob)} bytes) for header")
+
+    magic, version, num_frames, total_bytes, _ = struct.unpack(
+        HEADER_FMT, blob[:HEADER_SIZE]
+    )
+    if magic != HEADER_MAGIC:
+        raise ValueError(
+            f"bad header magic 0x{magic:08x} (expected 0x{HEADER_MAGIC:08x})"
+        )
+
+    pos = HEADER_SIZE
+    frames: list[dict[str, Any]] = []
+    for _ in range(num_frames):
+        if pos + FRAME_SIZE > len(blob):
+            raise ValueError(f"truncated frame record at offset {pos}")
+        fm, fidx, show_us, ev_count, dropped, _pad = struct.unpack(
+            FRAME_FMT, blob[pos : pos + FRAME_SIZE]
+        )
+        if fm != FRAME_MAGIC:
+            raise ValueError(
+                f"bad frame magic 0x{fm:08x} at offset {pos} "
+                f"(expected 0x{FRAME_MAGIC:08x})"
+            )
+        pos += FRAME_SIZE
+        events: list[tuple[int, int, int, int, int]] = []
+        for _ in range(ev_count):
+            if pos + EVENT_SIZE > len(blob):
+                raise ValueError(f"truncated event record at offset {pos}")
+            em, depth, line, dur_us, start_us, name_off = struct.unpack(
+                EVENT_FMT, blob[pos : pos + EVENT_SIZE]
+            )
+            if em != EVENT_MAGIC:
+                raise ValueError(
+                    f"bad event magic 0x{em:08x} at offset {pos} "
+                    f"(expected 0x{EVENT_MAGIC:08x})"
+                )
+            pos += EVENT_SIZE
+            events.append((depth, line, dur_us, start_us, name_off))
+        frames.append(
+            {
+                "frame_idx": fidx,
+                "show_us": show_us,
+                "dropped": bool(dropped),
+                "events": events,
+            }
+        )
+
+    # Name table: u32 count, then [u16 len, bytes[len]] × count.
+    if pos + 4 > len(blob):
+        # Names absent — return what we have.
+        return {"version": version, "frames": frames, "names": []}
+    (name_count,) = struct.unpack_from("<I", blob, pos)
+    pos += 4
+    names: list[str] = []
+    for _ in range(name_count):
+        if pos + 2 > len(blob):
+            break
+        (nlen,) = struct.unpack_from("<H", blob, pos)
+        pos += 2
+        if pos + nlen > len(blob):
+            break
+        names.append(blob[pos : pos + nlen].decode("utf-8", errors="replace"))
+        pos += nlen
+
+    return {"version": version, "frames": frames, "names": names}
+
+
+def render(decoded: dict[str, Any]) -> None:
+    names = decoded["names"]
+    print(
+        f"version=v{decoded['version']}  frames={len(decoded['frames'])}  names={len(names)}"
+    )
+    print()
+    for f in decoded["frames"]:
+        flag = " (DROPPED)" if f["dropped"] else ""
+        print(
+            f"=== frame {f['frame_idx']:3d}  show_us={f['show_us']:>7}  events={len(f['events'])}{flag} ==="
+        )
+        if not f["events"]:
+            print("  (no events captured)")
+            continue
+        print(f"  {'depth':>5}  {'dur_us':>9}  {'start_us':>12}  name")
+        for depth, line, dur_us, start_us, name_off in f["events"]:
+            name = (
+                names[name_off] if 0 <= name_off < len(names) else f"<idx {name_off}>"
+            )
+            print(f"  {depth:>5}  {dur_us:>9}  {start_us:>12}  {name}:{line}")
+        print()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "path", type=Path, help="raw flash dump (from esptool read-flash)"
+    )
+    parser.add_argument(
+        "--skip",
+        type=lambda x: int(x, 0),
+        default=0,
+        help="skip N bytes at the start (default 0). Use this if your dump "
+        "starts before the partition header.",
+    )
+    args = parser.parse_args()
+
+    blob = args.path.read_bytes()
+    if args.skip:
+        blob = blob[args.skip :]
+
+    # Trim trailing erased flash (0xFF) so summary is cleaner.
+    trimmed = blob.rstrip(b"\xff")
+
+    decoded = decode(trimmed)
+    render(decoded)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ci/perf_trace_sweep.py
+++ b/ci/perf_trace_sweep.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Drive an esp32p4 with the AutoResearch sketch and capture a PARLIO
+performance-trace sweep via the fl::PerfTrace RPC.
+
+Workflow (see docs/agents/docs/hardware-autoresearch.md):
+    1. Connect to the device over JSON-RPC.
+    2. setPerfTraceEnabled(true)         — flip runtime tracing on.
+    3. runTest({drivers, laneRange, stripSizes}) — exercise the PARLIO
+       hot path. Streaming "test_complete" indicates the show() calls
+       finished.
+    4. getPerfTraceLog()                  — pull the accumulated events
+       (depth, dur_us, start_us, name, file, line).
+    5. setPerfTraceEnabled(false)         — release.
+
+The output is printed as a human-readable table and emitted as JSONL on
+stdout so an enclosing CI step can post-process it for the
+issue-2493 follow-up sweep.
+
+Usage:
+    uv run ci/perf_trace_sweep.py --port COM25 \
+        --lanes 12 --strip-size 256
+
+This script is intentionally minimal — it complements `bash autoresearch`
+rather than replacing it. We use it because the perf trace flow is
+orthogonal to the autoresearch pass/fail matrix and we want the raw event
+log without the autoresearch streaming overhead.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from typing import Any
+
+from ci.rpc_client import RpcClient
+from ci.util.serial_interface import create_serial_interface
+
+
+async def run_sweep(port: str, lanes: int, strip_size: int) -> dict[str, Any]:
+    # Use pyserial backend so we don't need the fbuild monitor daemon.
+    iface = create_serial_interface(port=port, baud_rate=115200, use_pyserial=True)
+    client = RpcClient(port=port, baudrate=115200, timeout=20.0, serial_interface=iface)
+    await client.connect()
+
+    try:
+        # 1. Turn capture on (compile-in flag already set in platformio.ini).
+        on = await client.send("setPerfTraceEnabled", args=[True])
+        if not on.get("success"):
+            raise RuntimeError(f"setPerfTraceEnabled failed: {on}")
+
+        # 2. Run a PARLIO test that exercises show().
+        result = await client.send(
+            "runTest",
+            args=[
+                {
+                    "drivers": ["PARLIO"],
+                    "laneRange": {"min": lanes, "max": lanes},
+                    "stripSizes": [strip_size],
+                }
+            ],
+            timeout=60.0,
+        )
+
+        # 3. Pull the trace log.
+        log = await client.send("getPerfTraceLog", args=[])
+
+        # 4. Disable capture (also clears the log on the device side).
+        await client.send("setPerfTraceEnabled", args=[False])
+
+        return {
+            "config": {"lanes": lanes, "strip_size": strip_size},
+            "run_test": result,
+            "log": log,
+        }
+    finally:
+        await client.close()
+
+
+def print_event_table(events: list[list[Any]]) -> None:
+    if not events:
+        print("  (no events)")
+        return
+    print(
+        f"  {'depth':>5}  {'dur_us':>9}  {'start_us':>12}  name                                @file:line"
+    )
+    for ev in events:
+        depth, dur_us, start_us, name, file_, line = ev
+        loc = f"{file_}:{line}"
+        print(f"  {depth:>5}  {dur_us:>9}  {start_us:>12}  {name:<36}{loc}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--port", default="COM25", help="serial port (default COM25)")
+    parser.add_argument("--lanes", type=int, default=12, help="number of PARLIO lanes")
+    parser.add_argument("--strip-size", type=int, default=256, help="LEDs per lane")
+    parser.add_argument(
+        "--json", action="store_true", help="emit raw JSON instead of a table"
+    )
+    args = parser.parse_args()
+
+    try:
+        result = asyncio.run(run_sweep(args.port, args.lanes, args.strip_size))
+    except Exception as exc:
+        print(f"perf_trace_sweep failed: {exc}", file=sys.stderr)
+        return 1
+
+    if args.json:
+        json.dump(result, sys.stdout, indent=2, default=str)
+        sys.stdout.write("\n")
+        return 0
+
+    cfg = result["config"]
+    print(f"PARLIO perf trace — lanes={cfg['lanes']} strip_size={cfg['strip_size']}")
+    print()
+    log = result.get("log", {})
+    print(f"  count={log.get('count')} dropped={log.get('dropped')}")
+    print_event_table(log.get("events", []))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/AutoResearch/AutoResearchRemote.cpp
+++ b/examples/AutoResearch/AutoResearchRemote.cpp
@@ -17,6 +17,7 @@
 #include "AutoResearchOta.h"
 #include "fl/remote/transport/serial.h"
 #include "fl/system/heap.h"
+#include "fl/system/perf_trace.h"
 #include "Common.h"
 #include "AutoResearchTest.h"
 #include "AutoResearchHelpers.h"
@@ -1066,6 +1067,54 @@ void AutoResearchRemoteControl::registerFunctions(fl::shared_ptr<AutoResearchSta
         response.set("success", true);
         response.set("message", "RPC works from task context");
         response.set("serial_safe", false);
+        return response;
+    });
+
+    // Register "setPerfTraceEnabled" — runtime toggle for fl::PerfTrace capture.
+    // Even when FASTLED_PERF_TRACE is compiled in, scope capture is gated on
+    // this flag so autoresearch can flip tracing on/off without reflashing.
+    mRemote->bind("setPerfTraceEnabled", [](const fl::json& args) -> fl::json {
+        fl::json response = fl::json::object();
+        if (!args.is_array() || args.size() != 1 || !args[0].is_bool()) {
+            response.set("success", false);
+            response.set("error", "InvalidArgs");
+            response.set("message", "Expected [enabled: bool]");
+            return response;
+        }
+        bool enabled = args[0].as_bool().value();
+        fl::PerfTrace::set_enabled(enabled);
+        if (!enabled) {
+            fl::PerfTrace::clear();
+        }
+        response.set("success", true);
+        response.set("perf_trace_enabled", enabled);
+        return response;
+    });
+
+    // Register "getPerfTraceLog" — return all completed events accumulated on
+    // this thread since the last clear, then clear the log. Each entry is a
+    // compact tuple: [depth, dur_us, start_us, name, file, line].
+    mRemote->bind("getPerfTraceLog", [](const fl::json& args) -> fl::json {
+        (void)args;
+        fl::json response = fl::json::object();
+        fl::json events = fl::json::array();
+        const fl::size n = fl::PerfTrace::event_count();
+        const fl::PerfEvent* ev = fl::PerfTrace::events();
+        for (fl::size i = 0; i < n; ++i) {
+            fl::json e = fl::json::array();
+            e.push_back(static_cast<int64_t>(ev[i].depth));
+            e.push_back(static_cast<int64_t>(ev[i].end_us - ev[i].start_us));
+            e.push_back(static_cast<int64_t>(ev[i].start_us));
+            e.push_back(ev[i].name ? ev[i].name : "");
+            e.push_back(ev[i].file ? ev[i].file : "");
+            e.push_back(static_cast<int64_t>(ev[i].line));
+            events.push_back(e);
+        }
+        response.set("success", true);
+        response.set("count", static_cast<int64_t>(n));
+        response.set("dropped", fl::PerfTrace::dropped());
+        response.set("events", events);
+        fl::PerfTrace::clear();
         return response;
     });
 

--- a/examples/PerfTraceBench/PerfTraceBench.ino
+++ b/examples/PerfTraceBench/PerfTraceBench.ino
@@ -195,8 +195,13 @@ static void flushToFlash() {
 // ---------------------------------------------------------------------------
 void setup() {
     Serial.begin(115200);
-    delay(2000);
+    // Long delay so USB-Serial-JTAG CDC has time to enumerate AND for the
+    // host's `pio device monitor`/Python `serial.Serial` to (re)open the
+    // port. Without this, the first ~1-2s of Serial output is lost on
+    // ESP32-P4-EV's USB-Serial-JTAG bridge. See PR #2494 / #2507.
+    delay(5000);
     Serial.println("[PerfTraceBench] start");
+    Serial.flush();
 
     addAllLanes();
     FastLED.setBrightness(8);

--- a/examples/PerfTraceBench/PerfTraceBench.ino
+++ b/examples/PerfTraceBench/PerfTraceBench.ino
@@ -1,0 +1,293 @@
+// @filter
+// require:
+//   - platform: esp32p4
+// @end-filter
+
+// PerfTraceBench.ino — fl::PerfTrace sweep for ESP32-P4 PARLIO (issue #2493 follow-up).
+//
+// Why this exists:
+//   Same dev-env constraint as PR #2494: the USB-Serial-JTAG port on COM25 stops
+//   producing host-visible bytes once the Arduino app boots, so RPC-driven
+//   autoresearch can't actually read frame timings back. This sketch borrows the
+//   ParlioBench workaround — write the perf log to a flash data partition, then
+//   `esptool read-flash` it from the host. Once issue #2507 is resolved we can
+//   delete this and drive the same data via the AutoResearch sketch.
+//
+// What it does:
+//   1. Wires up NUM_STRIPS WS2812B lanes (default 12 × 256 LEDs each).
+//   2. Flips fl::PerfTrace::set_enabled(true).
+//   3. Calls FastLED.show() N times back-to-back (no inter-frame delay).
+//   4. For each frame, records (frame_idx, show_us, event_count, dropped) plus
+//      every captured perf event (depth, dur_us, start_us, name_idx, line).
+//   5. Once the buffer fills, writes it to a flash data partition and halts.
+//
+// Read it back (host side):
+//   esptool --chip esp32p4 --port COM25 read-flash <part_offset> <size> dump.bin
+//   uv run ci/perf_trace_decode.py dump.bin
+//
+// Required compile flag:
+//   -D FASTLED_PERF_TRACE=1 (already set in platformio.ini esp32p4 env)
+
+#include <Arduino.h>
+#include <FastLED.h>
+#include <esp_partition.h>
+
+#include "fl/system/perf_trace.h"
+
+#ifndef NUM_STRIPS
+#define NUM_STRIPS 12
+#endif
+#ifndef NUM_LEDS
+#define NUM_LEDS 256
+#endif
+#ifndef NUM_FRAMES
+#define NUM_FRAMES 16
+#endif
+
+// On the ESP32-P4-EV, GPIOs 0..15 are safe for PARLIO lanes.
+// We allocate strips on pins 0..NUM_STRIPS-1 in order.
+static CRGB g_leds[NUM_STRIPS][NUM_LEDS];
+
+// ---------------------------------------------------------------------------
+// On-flash record layout (little-endian throughout).
+//
+//   header (16B): magic=0xFA571DED, version=1, num_frames, total_event_bytes
+//   frame_record (16B): magic=0xF8AAE000, frame_idx, show_us, event_count,
+//                       dropped (1B), pad (3B)
+//   event_record (16B): magic=0xE0E07E07, depth (i16), line (i16), dur_us,
+//                       start_us, name_offset (into name_table)
+//   name_table: u32 name_count, then [u16 len, u8 bytes[len]] repeated
+// ---------------------------------------------------------------------------
+struct __attribute__((packed)) Header {
+    uint32_t magic;          // 0xFA571DED
+    uint16_t version;        // 1
+    uint16_t num_frames;
+    uint32_t total_bytes;    // total bytes following the header (frames + events + name_table)
+    uint32_t reserved;
+};
+
+struct __attribute__((packed)) FrameRec {
+    uint32_t magic;          // 0xF8AAE000
+    uint32_t frame_idx;
+    uint32_t show_us;
+    uint16_t event_count;
+    uint8_t  dropped;
+    uint8_t  pad;
+};
+
+struct __attribute__((packed)) EventRec {
+    uint32_t magic;          // 0xE0E07E07
+    int16_t  depth;
+    int16_t  line;
+    uint32_t dur_us;
+    uint32_t start_us;
+    uint32_t name_offset;
+};
+
+// ---------------------------------------------------------------------------
+// In-RAM staging buffer
+// ---------------------------------------------------------------------------
+static constexpr size_t kBufferBytes = 96 * 1024;
+static uint8_t g_buf[kBufferBytes];
+static size_t  g_used = 0;
+
+// Tiny string interning for event names — names are __FILE__ + name literals
+// that recur. We collect them once, then emit a single name table.
+static constexpr size_t kMaxNames = 256;
+static const char* g_name_ptrs[kMaxNames];
+static size_t      g_name_count = 0;
+static uint32_t    g_name_offsets[kMaxNames];
+
+static uint32_t intern_name(const char* s) {
+    if (!s) return 0xFFFFFFFFu;
+    for (size_t i = 0; i < g_name_count; ++i) {
+        if (g_name_ptrs[i] == s) return static_cast<uint32_t>(i);
+    }
+    if (g_name_count >= kMaxNames) return 0xFFFFFFFFu;
+    g_name_ptrs[g_name_count] = s;
+    return static_cast<uint32_t>(g_name_count++);
+}
+
+static bool append(const void* src, size_t n) {
+    if (g_used + n > kBufferBytes) return false;
+    memcpy(g_buf + g_used, src, n);
+    g_used += n;
+    return true;
+}
+
+// ---------------------------------------------------------------------------
+// Wiring
+// ---------------------------------------------------------------------------
+template <int PIN, int IDX> struct AddLane {
+    static void run() { FastLED.addLeds<WS2812B, PIN, GRB>(g_leds[IDX], NUM_LEDS); }
+};
+
+static void addAllLanes() {
+    AddLane<0, 0>::run();
+#if NUM_STRIPS > 1
+    AddLane<1, 1>::run();
+#endif
+#if NUM_STRIPS > 2
+    AddLane<2, 2>::run();
+    AddLane<3, 3>::run();
+#endif
+#if NUM_STRIPS > 4
+    AddLane<4, 4>::run();
+    AddLane<5, 5>::run();
+    AddLane<6, 6>::run();
+    AddLane<7, 7>::run();
+#endif
+#if NUM_STRIPS > 8
+    AddLane<8, 8>::run();
+    AddLane<9, 9>::run();
+    AddLane<10, 10>::run();
+    AddLane<11, 11>::run();
+#endif
+#if NUM_STRIPS > 12
+#error "Extend addAllLanes() for >12 strips"
+#endif
+}
+
+// ---------------------------------------------------------------------------
+// Flash flush
+// ---------------------------------------------------------------------------
+static bool flushed = false;
+static uint32_t flush_part_offset = 0;
+static uint32_t flush_part_size = 0;
+
+static void flushToFlash() {
+    if (flushed) return;
+
+    // Append the name table at the end of g_buf.
+    uint32_t name_count_u32 = static_cast<uint32_t>(g_name_count);
+    append(&name_count_u32, sizeof(name_count_u32));
+    for (size_t i = 0; i < g_name_count; ++i) {
+        const char* s = g_name_ptrs[i];
+        uint16_t len = static_cast<uint16_t>(strlen(s));
+        if (len > 256) len = 256;
+        g_name_offsets[i] = static_cast<uint32_t>(g_used);
+        append(&len, sizeof(len));
+        append(s, len);
+    }
+
+    // Find a writable data partition.
+    const esp_partition_t* part = esp_partition_find_first(
+        ESP_PARTITION_TYPE_DATA, ESP_PARTITION_SUBTYPE_ANY, NULL);
+    if (!part) {
+        flushed = true;
+        return;
+    }
+
+    flush_part_offset = part->address;
+    flush_part_size   = static_cast<uint32_t>(g_used);
+
+    // Erase to a 4KB-aligned multiple covering g_used.
+    uint32_t erase_size = (static_cast<uint32_t>(g_used) + 4095) & ~4095u;
+    if (erase_size > part->size) erase_size = part->size;
+    esp_partition_erase_range(part, 0, erase_size);
+    esp_partition_write(part, 0, g_buf, g_used);
+
+    flushed = true;
+}
+
+// ---------------------------------------------------------------------------
+// Arduino lifecycle
+// ---------------------------------------------------------------------------
+void setup() {
+    Serial.begin(115200);
+    delay(2000);
+    Serial.println("[PerfTraceBench] start");
+
+    addAllLanes();
+    FastLED.setBrightness(8);
+    for (int s = 0; s < NUM_STRIPS; ++s) {
+        for (int i = 0; i < NUM_LEDS; ++i) {
+            g_leds[s][i] = CRGB(1, 0, 0);
+        }
+    }
+
+    // Reserve room for header — written last with final byte count.
+    Header h{};
+    h.magic = 0xFA571DEDu;
+    h.version = 1;
+    h.num_frames = 0;
+    h.total_bytes = 0;
+    h.reserved = 0;
+    append(&h, sizeof(h));
+
+    Serial.println("[PerfTraceBench] setup done");
+}
+
+static uint32_t g_frame = 0;
+
+void loop() {
+    if (flushed) {
+        delay(1000);
+        return;
+    }
+    if (g_frame >= NUM_FRAMES) {
+        // Patch header (num_frames, total_bytes) before flush.
+        Header h{};
+        h.magic = 0xFA571DEDu;
+        h.version = 1;
+        h.num_frames = static_cast<uint16_t>(NUM_FRAMES);
+        h.total_bytes = static_cast<uint32_t>(g_used - sizeof(Header));
+        memcpy(g_buf, &h, sizeof(h));
+
+        flushToFlash();
+        Serial.print("[PerfTraceBench] flushed ");
+        Serial.print((int)g_used);
+        Serial.print(" bytes to partition at 0x");
+        Serial.println((unsigned int)flush_part_offset, HEX);
+        return;
+    }
+
+    // Clear the trace log and enable for this frame only.
+    fl::PerfTrace::clear();
+    fl::PerfTrace::set_enabled(true);
+
+    const uint32_t t0 = micros();
+    FastLED.show();
+    const uint32_t t1 = micros();
+    const uint32_t show_us = t1 - t0;
+
+    fl::PerfTrace::set_enabled(false);
+
+    const fl::size n = fl::PerfTrace::event_count();
+    const fl::PerfEvent* evs = fl::PerfTrace::events();
+    const bool dropped = fl::PerfTrace::dropped();
+
+    // Frame record
+    FrameRec fr{};
+    fr.magic = 0xF8AAE000u;
+    fr.frame_idx = g_frame;
+    fr.show_us = show_us;
+    fr.event_count = static_cast<uint16_t>(n);
+    fr.dropped = dropped ? 1 : 0;
+    fr.pad = 0;
+    append(&fr, sizeof(fr));
+
+    // Events
+    for (fl::size i = 0; i < n; ++i) {
+        EventRec er{};
+        er.magic    = 0xE0E07E07u;
+        er.depth    = static_cast<int16_t>(evs[i].depth);
+        er.line     = static_cast<int16_t>(evs[i].line);
+        er.dur_us   = evs[i].end_us - evs[i].start_us;
+        er.start_us = evs[i].start_us;
+        er.name_offset = intern_name(evs[i].name);
+        append(&er, sizeof(er));
+    }
+
+    Serial.print("[PerfTraceBench] frame ");
+    Serial.print((int)g_frame);
+    Serial.print(" show_us=");
+    Serial.print((int)show_us);
+    Serial.print(" events=");
+    Serial.print((int)n);
+    Serial.print(" dropped=");
+    Serial.println((int)dropped);
+    Serial.flush();
+
+    g_frame++;
+}

--- a/platformio.ini
+++ b/platformio.ini
@@ -85,11 +85,19 @@ board = esp32-p4-evboard
 build_flags =
   ${env:generic-esp.build_flags}
 
-  ; ARDUINO_USB_MODE=0 routes Serial to the built-in USB-Serial-JTAG port
-  ; (PID 0x1001), which is what the dev board exposes as COM* on Windows.
-  ; Mode 1 instead routes Serial to USB-OTG (a separate connector) and gives
-  ; no output on the JTAG port. See PR #2494 — same call-out.
+  ; USB Serial routing on the ESP32-P4-EV dev board.
+  ;
+  ; ARDUINO_USB_MODE=0 keeps esptool flashing happy via the on-board
+  ; USB-Serial-JTAG bridge (VID 0x303A PID 0x1001 → COM25). This is the
+  ; same setting PR #2494 used.
+  ;
+  ; ARDUINO_USB_CDC_ON_BOOT=1 routes Arduino's `Serial` to the HWCDC
+  ; (USB-Serial-JTAG CDC) endpoint so host-side reads on COM25 see app
+  ; output post-boot. NOTE: on the current dev box this still produces
+  ; zero host-visible bytes — tracked in #2507. The flash-dump path used
+  ; by examples/PerfTraceBench bypasses serial entirely.
   -D ARDUINO_USB_MODE=0
+  -D ARDUINO_USB_CDC_ON_BOOT=1
   ; FASTLED_PERF_TRACE compiles in fl::PerfTrace push/pop scopes. Capture
   ; remains off at boot — autoresearch flips it via setPerfTraceEnabled RPC.
   -D FASTLED_PERF_TRACE=1

--- a/platformio.ini
+++ b/platformio.ini
@@ -86,6 +86,9 @@ build_flags =
   ${env:generic-esp.build_flags}
 
   -D ARDUINO_USB_MODE=1
+  ; FASTLED_PERF_TRACE compiles in fl::PerfTrace push/pop scopes. Capture
+  ; remains off at boot — autoresearch flips it via setPerfTraceEnabled RPC.
+  -D FASTLED_PERF_TRACE=1
 board_build.partitions = huge_app.csv
 
 [env:esp32c3]

--- a/platformio.ini
+++ b/platformio.ini
@@ -85,7 +85,11 @@ board = esp32-p4-evboard
 build_flags =
   ${env:generic-esp.build_flags}
 
-  -D ARDUINO_USB_MODE=1
+  ; ARDUINO_USB_MODE=0 routes Serial to the built-in USB-Serial-JTAG port
+  ; (PID 0x1001), which is what the dev board exposes as COM* on Windows.
+  ; Mode 1 instead routes Serial to USB-OTG (a separate connector) and gives
+  ; no output on the JTAG port. See PR #2494 — same call-out.
+  -D ARDUINO_USB_MODE=0
   ; FASTLED_PERF_TRACE compiles in fl::PerfTrace push/pop scopes. Capture
   ; remains off at boot — autoresearch flips it via setPerfTraceEnabled RPC.
   -D FASTLED_PERF_TRACE=1

--- a/src/FastLED.cpp.hpp
+++ b/src/FastLED.cpp.hpp
@@ -9,6 +9,7 @@
 #include "fl/channels/channel.h"
 #include "fl/channels/channel_events.h"
 #include "fl/channels/manager.h"
+#include "fl/system/perf_trace.h"
 #include "fl/system/trace.h"
 #include "fl/channels/driver.h"  // for IChannelDriver
 #include "fl/system/delay.h"  // for delayMicroseconds
@@ -231,11 +232,18 @@ static void* gControllersData[MAX_CLED_CONTROLLERS];
 
 FL_KEEP_ALIVE void CFastLED::show(fl::u8 scale) {
 	FL_SCOPED_TRACE;
-	onBeginFrame();
-	while(mNMinMicros && ((fl::micros()-lastshow) < mNMinMicros)) {
+	FL_PERF_SCOPE("CFastLED::show");
+	{
+		FL_PERF_SCOPE("onBeginFrame");
+		onBeginFrame();
+	}
+	{
+		FL_PERF_SCOPE("min_micros_gate");
+		while(mNMinMicros && ((fl::micros()-lastshow) < mNMinMicros)) {
 #if SKETCH_HAS_LARGE_MEMORY
-		fl::task::run(250, fl::task::ExecFlags::SYSTEM);
+			fl::task::run(250, fl::task::ExecFlags::SYSTEM);
 #endif
+		}
 	}
 	lastshow = fl::micros();
 
@@ -259,23 +267,29 @@ FL_KEEP_ALIVE void CFastLED::show(fl::u8 scale) {
 		pCur = pCur->next();
 	}
 
-	pCur = CLEDController::head();
-	for (length = 0; length < MAX_CLED_CONTROLLERS && pCur; length++) {
-		if (pCur->getEnabled()) {
-			pCur->showLedsInternal(scale);
-		}
-		pCur = pCur->next();
+	{
+		FL_PERF_SCOPE("showLedsInternal");
+		pCur = CLEDController::head();
+		for (length = 0; length < MAX_CLED_CONTROLLERS && pCur; length++) {
+			if (pCur->getEnabled()) {
+				pCur->showLedsInternal(scale);
+			}
+			pCur = pCur->next();
 
+		}
 	}
 
-	length = 0;  // Reset length to 0 and iterate again.
-	pCur = CLEDController::head();
-	while(pCur && length < MAX_CLED_CONTROLLERS) {
-		if (pCur->getEnabled()) {
-			pCur->endShowLeds(gControllersData[length]);
+	{
+		FL_PERF_SCOPE("endShowLeds");
+		length = 0;  // Reset length to 0 and iterate again.
+		pCur = CLEDController::head();
+		while(pCur && length < MAX_CLED_CONTROLLERS) {
+			if (pCur->getEnabled()) {
+				pCur->endShowLeds(gControllersData[length]);
+			}
+			length++;
+			pCur = pCur->next();
 		}
-		length++;
-		pCur = pCur->next();
 	}
 	countFPS();
 	onEndFrame();

--- a/src/fl/channels/driver.cpp.hpp
+++ b/src/fl/channels/driver.cpp.hpp
@@ -2,6 +2,7 @@
 #include "fl/channels/driver.h"
 #include "fl/log/log.h"
 #include "fl/stl/chrono.h"
+#include "fl/system/perf_trace.h"
 #include "fl/task/executor.h"
 #include "platforms/is_platform.h"
 
@@ -9,6 +10,7 @@ namespace fl {
 
 template<typename Condition>
 bool IChannelDriver::waitForCondition(Condition condition, u32 timeoutMs) {
+    FL_PERF_SCOPE("IChannelDriver::waitForCondition");
     const u32 startTime = timeoutMs > 0 ? millis() : 0;
 
     while (!condition()) {

--- a/src/fl/channels/manager.cpp.hpp
+++ b/src/fl/channels/manager.cpp.hpp
@@ -10,6 +10,7 @@
 #include "fl/stl/chrono.h"
 #include "fl/stl/algorithm.h"
 #include "fl/stl/move.h"
+#include "fl/system/perf_trace.h"
 #include "fl/system/trace.h"
 #include "fl/task/executor.h"
 #include "platforms/init_channel_driver.h"
@@ -349,6 +350,7 @@ fl::shared_ptr<IChannelDriver> ChannelManager::selectDriverForChannel(const Chan
 
 template<typename Condition>
 bool ChannelManager::waitForCondition(Condition condition, u32 timeoutMs) {
+    FL_PERF_SCOPE("ChannelManager::waitForCondition");
     const u32 startTime = timeoutMs > 0 ? millis() : 0;
 
     while (!condition()) {

--- a/src/fl/system/_build.cpp.hpp
+++ b/src/fl/system/_build.cpp.hpp
@@ -6,6 +6,7 @@
 #include "fl/system/fastled_internal.cpp.hpp"
 #include "fl/system/file_system.cpp.hpp"
 #include "fl/system/heap.cpp.hpp"
+#include "fl/system/perf_trace.cpp.hpp"
 #include "fl/system/pin.cpp.hpp"
 #include "fl/system/pins.cpp.hpp"
 #include "fl/system/serial.cpp.hpp"

--- a/src/fl/system/perf_trace.cpp.hpp
+++ b/src/fl/system/perf_trace.cpp.hpp
@@ -1,0 +1,155 @@
+/**
+ * @file perf_trace.cpp
+ * @brief Implementation of thread-local push/pop performance tracing.
+ */
+
+#include "fl/system/perf_trace.h"
+
+#include "fl/stl/chrono.h"     // fl::micros
+#include "fl/stl/noexcept.h"
+#include "fl/stl/singleton.h"  // SingletonThreadLocal
+#include "fl/stl/stdio.h"      // fl::sprintf
+#include "fl/stl/string.h"
+#include "fl/stl/vector.h"     // FixedVector
+#include "fl/log/log.h"        // FL_INFO
+
+namespace fl {
+
+namespace detail {
+
+/// @brief Single-thread perf-trace storage. Held in SingletonThreadLocal.
+struct PerfTraceStorage {
+    /// Stack of in-flight scopes (slot index = stack index when opened).
+    FixedVector<PerfEvent, FL_PERF_TRACE_MAX_STACK> in_flight;
+    /// Completed-event log; flushed at frame boundaries.
+    FixedVector<PerfEvent, FL_PERF_TRACE_MAX_EVENTS> log;
+    /// True once an event was dropped (log full / stack overflow).
+    bool dropped = false;
+};
+
+static PerfTraceStorage& storage() FL_NOEXCEPT {
+    return SingletonThreadLocal<PerfTraceStorage>::instance();
+}
+
+/// @brief Process-wide runtime master switch. False by default — the
+/// caller (autoresearch RPC, sketch, test) must turn it on explicitly.
+///
+/// Plain bool is fine here: workers only ever read it; flipping the
+/// switch from another thread races with capture by at most one event,
+/// which is acceptable for performance tracing.
+static bool g_enabled = false;
+
+} // namespace detail
+
+void PerfTrace::set_enabled(bool on) FL_NOEXCEPT {
+    detail::g_enabled = on;
+}
+
+bool PerfTrace::is_enabled() FL_NOEXCEPT {
+    return detail::g_enabled;
+}
+
+int PerfTrace::begin(const char* file, int line, const char* name) FL_NOEXCEPT {
+    if (!detail::g_enabled) {
+        return -1;
+    }
+    auto& s = detail::storage();
+    if (s.in_flight.size() >= FL_PERF_TRACE_MAX_STACK) {
+        s.dropped = true;
+        return -1;
+    }
+    PerfEvent ev;
+    ev.file     = file;
+    ev.name     = name;
+    ev.line     = line;
+    ev.depth    = static_cast<int>(s.in_flight.size());
+    ev.start_us = fl::micros();
+    ev.end_us   = 0;
+    const int slot = static_cast<int>(s.in_flight.size());
+    s.in_flight.push_back(ev);
+    return slot;
+}
+
+void PerfTrace::end(int slot) FL_NOEXCEPT {
+    if (slot < 0) {
+        return;  // begin() was suppressed (disabled or overflowed)
+    }
+    auto& s = detail::storage();
+    const int top = static_cast<int>(s.in_flight.size()) - 1;
+    if (top < 0) {
+        return;  // underflow — nothing to close
+    }
+    if (slot != top) {
+        // Mis-nested end() — drop the top (best effort) without corrupting
+        // the log. Caller likely has unbalanced begin/end pairs.
+        s.dropped = true;
+        s.in_flight.resize(s.in_flight.size() - 1);
+        return;
+    }
+
+    PerfEvent ev = s.in_flight[top];
+    ev.end_us = fl::micros();
+    s.in_flight.resize(s.in_flight.size() - 1);
+
+    if (s.log.size() >= FL_PERF_TRACE_MAX_EVENTS) {
+        s.dropped = true;
+        return;
+    }
+    s.log.push_back(ev);
+}
+
+fl::size PerfTrace::event_count() FL_NOEXCEPT {
+    return detail::storage().log.size();
+}
+
+const PerfEvent* PerfTrace::events() FL_NOEXCEPT {
+    auto& log = detail::storage().log;
+    return log.empty() ? nullptr : &log[0];
+}
+
+fl::size PerfTrace::stack_depth() FL_NOEXCEPT {
+    return detail::storage().in_flight.size();
+}
+
+bool PerfTrace::dropped() FL_NOEXCEPT {
+    return detail::storage().dropped;
+}
+
+void PerfTrace::clear() FL_NOEXCEPT {
+    auto& s = detail::storage();
+    s.log.resize(0);
+    s.in_flight.resize(0);
+    s.dropped = false;
+}
+
+void PerfTrace::flush(PerfEmitFn cb, void* user) FL_NOEXCEPT {
+    auto& s = detail::storage();
+    const fl::size n = s.log.size();
+    for (fl::size i = 0; i < n; ++i) {
+        const PerfEvent& ev = s.log[i];
+        if (cb) {
+            cb(ev, user);
+            continue;
+        }
+        const fl::u32 dur_us = ev.end_us - ev.start_us;
+        // Compact single-line dump — easy to grep, easy to parse.
+        // Format: PT d=<depth> dur_us=<dur> start_us=<start> name=<name> @<file>:<line>
+        char buf[256];
+        fl::sprintf(buf,
+            "PT d=%d dur_us=%lu start_us=%lu name=%s @%s:%d",
+            ev.depth,
+            static_cast<unsigned long>(dur_us),
+            static_cast<unsigned long>(ev.start_us),
+            ev.name ? ev.name : "<null>",
+            ev.file ? ev.file : "<null>",
+            ev.line);
+        FL_INFO(buf);
+    }
+    if (s.dropped) {
+        FL_INFO("PT WARN dropped events since last flush");
+    }
+    s.log.resize(0);
+    s.dropped = false;
+}
+
+} // namespace fl

--- a/src/fl/system/perf_trace.h
+++ b/src/fl/system/perf_trace.h
@@ -1,0 +1,168 @@
+#pragma once
+
+/**
+## Performance Trace System
+
+Thread-local push/pop performance tracing for profiling hot paths in
+FastLED (e.g. CFastLED::show and the PARLIO driver's DMA wait loop).
+
+Each scope captures (file, line, name, depth, start_us, end_us) and is
+appended to a per-thread event log when the scope closes. The log can be
+flushed at frame boundaries to produce a chronological dump in the
+classic begin/end performance-tracing idiom:
+
+```
+PT depth=0 dur_us=16320 start_us=12345678 file=src/FastLED.cpp.hpp line=233 name=show
+PT depth=1 dur_us=11800 start_us=12345990 file=src/fl/channels/manager.cpp.hpp line=287 name=flush
+PT depth=2 dur_us=11700 start_us=12345992 file=src/fl/channels/manager.cpp.hpp line=358 name=waitForReady
+```
+
+### Compile gate
+`FASTLED_PERF_TRACE=1` — when undefined, all `FL_PERF_*` macros expand
+to no-ops and the entire module is dead code.
+
+### Runtime gate
+Even when compiled in, `fl::PerfTrace::set_enabled(true)` must be called
+to capture events. Autoresearch can toggle this over JSON-RPC.
+
+### Usage
+```cpp
+#include "fl/system/perf_trace.h"
+
+void CFastLED::show(u8 scale) {
+    FL_PERF_SCOPE("show");
+    // ...
+}
+
+// At a natural boundary (end of frame):
+FL_PERF_FRAME_FLUSH();
+```
+
+### Configuration
+- `FL_PERF_TRACE_MAX_EVENTS` (default 128) — completed-event log capacity
+- `FL_PERF_TRACE_MAX_STACK`  (default 32)  — in-flight scope depth
+ */
+
+#include "fl/stl/stdint.h"
+#include "fl/stl/noexcept.h"
+
+#ifndef FL_PERF_TRACE_MAX_EVENTS
+#define FL_PERF_TRACE_MAX_EVENTS 128
+#endif
+
+#ifndef FL_PERF_TRACE_MAX_STACK
+#define FL_PERF_TRACE_MAX_STACK 32
+#endif
+
+namespace fl {
+
+/// @brief A single completed performance-trace event.
+/// All string pointers are non-owning — they must reference string
+/// literals (`__FILE__` and the user-provided name argument).
+struct PerfEvent {
+    const char* file;   ///< __FILE__ (string literal)
+    const char* name;   ///< user-supplied name (string literal)
+    int line;           ///< __LINE__
+    int depth;          ///< nesting depth at scope open (0 = root)
+    fl::u32 start_us;   ///< fl::micros() at scope open
+    fl::u32 end_us;     ///< fl::micros() at scope close
+};
+
+/// @brief Optional emit callback signature for PerfTrace::flush().
+using PerfEmitFn = void(*)(const PerfEvent& event, void* user);
+
+/// @brief Per-thread performance trace machinery.
+///
+/// All public methods are no-ops when `FASTLED_PERF_TRACE` is not
+/// defined at compile time, or when `set_enabled(true)` has not been
+/// called at runtime. Inline implementations live in `perf_trace.cpp.hpp`.
+class PerfTrace {
+public:
+    /// @brief Runtime master switch. Initially disabled.
+    static void set_enabled(bool on) FL_NOEXCEPT;
+
+    /// @brief Query whether tracing is currently active.
+    static bool is_enabled() FL_NOEXCEPT;
+
+    /// @brief Open a new scope. Captures `fl::micros()` and pushes onto
+    ///        the thread-local in-flight stack. Returns a slot id which
+    ///        must be passed to `end()`. Returns -1 if dropped (disabled
+    ///        or stack overflow).
+    static int begin(const char* file, int line, const char* name) FL_NOEXCEPT;
+
+    /// @brief Close the most recent matching scope. The slot id from
+    ///        the matching `begin()` is passed in; if it does not match
+    ///        the top of the stack, the end is silently dropped.
+    static void end(int slot) FL_NOEXCEPT;
+
+    /// @brief Number of completed events in the log.
+    static fl::size event_count() FL_NOEXCEPT;
+
+    /// @brief Pointer to the log[0..event_count()) (thread-local).
+    ///        Valid only until the next `begin`/`end`/`clear`/`flush`.
+    static const PerfEvent* events() FL_NOEXCEPT;
+
+    /// @brief Current in-flight stack depth.
+    static fl::size stack_depth() FL_NOEXCEPT;
+
+    /// @brief Whether any event was dropped since the last `clear()` /
+    ///        `flush()` (log full or stack overflow).
+    static bool dropped() FL_NOEXCEPT;
+
+    /// @brief Clear the event log and in-flight stack.
+    static void clear() FL_NOEXCEPT;
+
+    /// @brief Emit every completed event through `cb` (or via FL_INFO
+    ///        if `cb == nullptr`), then clear the log.
+    /// @param cb Optional callback. Receives each event + `user` pointer.
+    static void flush(PerfEmitFn cb = nullptr, void* user = nullptr) FL_NOEXCEPT;
+};
+
+/// @brief RAII guard: begins a scope on construction, ends it on
+///        destruction. Non-copyable, non-movable.
+class PerfScope {
+public:
+    PerfScope(const char* file, int line, const char* name) FL_NOEXCEPT
+        : mSlot(PerfTrace::begin(file, line, name)) {}
+    ~PerfScope() FL_NOEXCEPT { PerfTrace::end(mSlot); }
+
+    PerfScope(const PerfScope&) = delete;
+    PerfScope& operator=(const PerfScope&) = delete;
+    PerfScope(PerfScope&&) = delete;
+    PerfScope& operator=(PerfScope&&) = delete;
+private:
+    int mSlot;
+};
+
+} // namespace fl
+
+#ifdef FASTLED_PERF_TRACE
+
+#define FL_PERF_TRACE_CONCAT2(a, b) a##b
+#define FL_PERF_TRACE_CONCAT(a, b) FL_PERF_TRACE_CONCAT2(a, b)
+
+/// @brief Open a scoped perf-trace event. The scope ends automatically
+///        at the end of the enclosing block.
+/// @param name Static string label (string literal preferred).
+#define FL_PERF_SCOPE(name) \
+    ::fl::PerfScope FL_PERF_TRACE_CONCAT(_fl_perf_scope_, __LINE__){__FILE__, __LINE__, (name)}
+
+/// @brief Begin a manual perf-trace event. Returns an int slot id you
+///        must pass to FL_PERF_END.
+#define FL_PERF_BEGIN(name) (::fl::PerfTrace::begin(__FILE__, __LINE__, (name)))
+
+/// @brief End a manual perf-trace event opened by FL_PERF_BEGIN.
+#define FL_PERF_END(slot) (::fl::PerfTrace::end(slot))
+
+/// @brief Emit all accumulated events from the current thread and clear
+///        the log. Typically called at the end of each frame.
+#define FL_PERF_FRAME_FLUSH() (::fl::PerfTrace::flush())
+
+#else  // !FASTLED_PERF_TRACE
+
+#define FL_PERF_SCOPE(name) do { (void)sizeof((name)); } while (0)
+#define FL_PERF_BEGIN(name) ((void)sizeof((name)), 0)
+#define FL_PERF_END(slot)   do { (void)(slot); } while (0)
+#define FL_PERF_FRAME_FLUSH() do {} while (0)
+
+#endif // FASTLED_PERF_TRACE

--- a/src/platforms/esp/32/drivers/parlio/channel_driver_parlio.cpp.hpp
+++ b/src/platforms/esp/32/drivers/parlio/channel_driver_parlio.cpp.hpp
@@ -25,6 +25,7 @@
 #include "fl/log/log.h"
 #include "fl/log/log.h"
 #include "fl/stl/algorithm.h"
+#include "fl/system/perf_trace.h"
 #include "fl/system/trace.h"
 #include "fl/stl/assert.h"
 #include "fl/stl/noexcept.h"
@@ -215,6 +216,7 @@ void ChannelDriverPARLIOImpl::show() FL_NOEXCEPT {
 }
 
 IChannelDriver::DriverState ChannelDriverPARLIOImpl::poll() FL_NOEXCEPT {
+    FL_PERF_SCOPE("ParlioImpl::poll");
     // If not initialized, we're ready (no hardware to poll)
     if (!mInitialized) {
         return DriverState::READY;
@@ -279,6 +281,7 @@ IChannelDriver::DriverState ChannelDriverPARLIOImpl::poll() FL_NOEXCEPT {
 
 void ChannelDriverPARLIOImpl::beginTransmission(
     fl::span<const ChannelDataPtr> channelData) FL_NOEXCEPT {
+    FL_PERF_SCOPE("ParlioImpl::beginTransmission");
 
     // Validate channel data first (before initialization)
     if (channelData.size() == 0) {
@@ -464,6 +467,7 @@ void ChannelDriverPARLIO::show() FL_NOEXCEPT {
 }
 
 IChannelDriver::DriverState ChannelDriverPARLIO::poll() FL_NOEXCEPT {
+    FL_PERF_SCOPE("ChannelDriverPARLIO::poll");
     switch (mPhase) {
         case TransmitPhase::IDLE:
             return DriverState::READY;
@@ -539,6 +543,7 @@ IChannelDriver::DriverState ChannelDriverPARLIO::poll() FL_NOEXCEPT {
 
 void ChannelDriverPARLIO::beginClocklessTransmission(
     fl::span<const ChannelDataPtr> channelData) FL_NOEXCEPT {
+    FL_PERF_SCOPE("ChannelDriverPARLIO::beginClocklessTransmission");
     if (channelData.size() == 0) {
         return;
     }

--- a/tests/fl/log.cpp
+++ b/tests/fl/log.cpp
@@ -6,3 +6,4 @@
 #include "tests/fl/log/async_logger_output.hpp"
 #include "tests/fl/log/log.hpp"
 #include "tests/fl/system/trace.hpp"
+#include "tests/fl/system/perf_trace.hpp"

--- a/tests/fl/system/perf_trace.hpp
+++ b/tests/fl/system/perf_trace.hpp
@@ -1,0 +1,205 @@
+/// @file perf_trace.hpp
+/// @brief Unit tests for the thread-local performance trace system.
+///
+/// These tests force-compile the perf_trace module by defining
+/// FASTLED_PERF_TRACE locally. The shipped header otherwise no-ops
+/// the macros so tests would not exercise the real code paths.
+
+#ifndef FASTLED_PERF_TRACE
+#define FASTLED_PERF_TRACE 1
+#endif
+
+#include "test.h"
+
+#include "fl/system/perf_trace.h"
+#include "fl/stl/chrono.h"
+#include "fl/stl/int.h"
+
+using namespace fl;
+
+namespace {
+
+struct PerfTraceFixture {
+    PerfTraceFixture() {
+        PerfTrace::clear();
+        PerfTrace::set_enabled(true);
+    }
+    ~PerfTraceFixture() {
+        PerfTrace::set_enabled(false);
+        PerfTrace::clear();
+    }
+};
+
+}  // namespace
+
+FL_TEST_CASE("PerfTrace - disabled by default after fresh process state") {
+    // The fixture below activates tracing; verify the explicit disable path.
+    PerfTrace::set_enabled(false);
+    PerfTrace::clear();
+    FL_CHECK_FALSE(PerfTrace::is_enabled());
+
+    const int slot = PerfTrace::begin(__FILE__, __LINE__, "noop");
+    FL_CHECK(slot == -1);
+    PerfTrace::end(slot);
+    FL_CHECK(PerfTrace::event_count() == 0u);
+}
+
+FL_TEST_CASE("PerfTrace - basic begin/end records one event") {
+    PerfTraceFixture _;
+
+    const int slot = PerfTrace::begin(__FILE__, __LINE__, "basic");
+    FL_CHECK(slot >= 0);
+    FL_CHECK(PerfTrace::stack_depth() == 1u);
+    PerfTrace::end(slot);
+    FL_CHECK(PerfTrace::stack_depth() == 0u);
+    FL_CHECK(PerfTrace::event_count() == 1u);
+
+    const PerfEvent* events = PerfTrace::events();
+    FL_CHECK(events != nullptr);
+    FL_CHECK(events[0].depth == 0);
+    FL_CHECK(events[0].end_us >= events[0].start_us);
+    FL_CHECK(events[0].name != nullptr);
+}
+
+FL_TEST_CASE("PerfTrace - FL_PERF_SCOPE RAII guard records on exit") {
+    PerfTraceFixture _;
+    {
+        FL_PERF_SCOPE("outer");
+        FL_CHECK(PerfTrace::stack_depth() == 1u);
+        {
+            FL_PERF_SCOPE("inner");
+            FL_CHECK(PerfTrace::stack_depth() == 2u);
+        }
+        FL_CHECK(PerfTrace::stack_depth() == 1u);
+        FL_CHECK(PerfTrace::event_count() == 1u);  // inner closed
+    }
+    FL_CHECK(PerfTrace::stack_depth() == 0u);
+    FL_CHECK(PerfTrace::event_count() == 2u);
+
+    // Inner event is emitted before outer because it closes first.
+    const PerfEvent* events = PerfTrace::events();
+    FL_CHECK(events[0].depth == 1);  // inner
+    FL_CHECK(events[1].depth == 0);  // outer
+}
+
+FL_TEST_CASE("PerfTrace - runtime disable suppresses events even when compiled in") {
+    PerfTraceFixture _;
+    PerfTrace::set_enabled(false);
+
+    {
+        FL_PERF_SCOPE("ignored");
+        FL_CHECK(PerfTrace::stack_depth() == 0u);
+    }
+    FL_CHECK(PerfTrace::event_count() == 0u);
+
+    PerfTrace::set_enabled(true);
+    {
+        FL_PERF_SCOPE("captured");
+    }
+    FL_CHECK(PerfTrace::event_count() == 1u);
+}
+
+FL_TEST_CASE("PerfTrace - duration monotonic non-negative") {
+    PerfTraceFixture _;
+
+    const int slot = PerfTrace::begin(__FILE__, __LINE__, "dur");
+    // Busy work to make the duration measurable on fast hosts.
+    fl::u32 spin = 0;
+    for (int i = 0; i < 1000; ++i) {
+        spin += static_cast<fl::u32>(i);
+    }
+    (void)spin;
+    PerfTrace::end(slot);
+
+    FL_CHECK(PerfTrace::event_count() == 1u);
+    const PerfEvent& ev = PerfTrace::events()[0];
+    FL_CHECK(ev.end_us >= ev.start_us);
+}
+
+FL_TEST_CASE("PerfTrace - file/line/name captured from macro site") {
+    PerfTraceFixture _;
+
+    int expected_line = 0;
+    {
+        expected_line = __LINE__ + 1;
+        FL_PERF_SCOPE("located");
+    }
+
+    FL_CHECK(PerfTrace::event_count() == 1u);
+    const PerfEvent& ev = PerfTrace::events()[0];
+    FL_CHECK(ev.name != nullptr);
+    FL_CHECK(ev.file != nullptr);
+    FL_CHECK(ev.line == expected_line);
+}
+
+FL_TEST_CASE("PerfTrace - stack overflow marks dropped() without corruption") {
+    PerfTraceFixture _;
+
+    // Open one more than the configured stack capacity.
+    int slots[FL_PERF_TRACE_MAX_STACK + 2];
+    for (int i = 0; i < FL_PERF_TRACE_MAX_STACK; ++i) {
+        slots[i] = PerfTrace::begin(__FILE__, __LINE__, "stk");
+        FL_CHECK(slots[i] >= 0);
+    }
+    slots[FL_PERF_TRACE_MAX_STACK]     = PerfTrace::begin(__FILE__, __LINE__, "ovf1");
+    slots[FL_PERF_TRACE_MAX_STACK + 1] = PerfTrace::begin(__FILE__, __LINE__, "ovf2");
+    FL_CHECK(slots[FL_PERF_TRACE_MAX_STACK] == -1);
+    FL_CHECK(slots[FL_PERF_TRACE_MAX_STACK + 1] == -1);
+    FL_CHECK(PerfTrace::dropped());
+
+    // Close in reverse order, including the dropped slots (no-ops).
+    PerfTrace::end(slots[FL_PERF_TRACE_MAX_STACK + 1]);
+    PerfTrace::end(slots[FL_PERF_TRACE_MAX_STACK]);
+    for (int i = FL_PERF_TRACE_MAX_STACK - 1; i >= 0; --i) {
+        PerfTrace::end(slots[i]);
+    }
+    FL_CHECK(PerfTrace::stack_depth() == 0u);
+    FL_CHECK(PerfTrace::event_count() == static_cast<fl::size>(FL_PERF_TRACE_MAX_STACK));
+}
+
+FL_TEST_CASE("PerfTrace - flush emits and clears the log") {
+    PerfTraceFixture _;
+
+    for (int i = 0; i < 3; ++i) {
+        FL_PERF_SCOPE("flushable");
+    }
+    FL_CHECK(PerfTrace::event_count() == 3u);
+
+    struct Counter { int seen = 0; };
+    Counter c;
+    PerfTrace::flush(
+        [](const PerfEvent& ev, void* user) {
+            (void)ev;
+            static_cast<Counter*>(user)->seen++;
+        },
+        &c);
+    FL_CHECK(c.seen == 3);
+    FL_CHECK(PerfTrace::event_count() == 0u);
+}
+
+FL_TEST_CASE("PerfTrace - log capacity caps event_count() and sets dropped()") {
+    PerfTraceFixture _;
+
+    // Fire one more than the log capacity (flat, no nesting).
+    for (int i = 0; i < FL_PERF_TRACE_MAX_EVENTS + 1; ++i) {
+        const int slot = PerfTrace::begin(__FILE__, __LINE__, "cap");
+        PerfTrace::end(slot);
+    }
+    FL_CHECK(PerfTrace::event_count() == static_cast<fl::size>(FL_PERF_TRACE_MAX_EVENTS));
+    FL_CHECK(PerfTrace::dropped());
+}
+
+FL_TEST_CASE("PerfTrace - clear() resets log, stack, and dropped flag") {
+    PerfTraceFixture _;
+
+    for (int i = 0; i < FL_PERF_TRACE_MAX_EVENTS + 1; ++i) {
+        const int slot = PerfTrace::begin(__FILE__, __LINE__, "reset");
+        PerfTrace::end(slot);
+    }
+    FL_CHECK(PerfTrace::dropped());
+
+    PerfTrace::clear();
+    FL_CHECK(PerfTrace::event_count() == 0u);
+    FL_CHECK(PerfTrace::stack_depth() == 0u);
+    FL_CHECK_FALSE(PerfTrace::dropped());
+}


### PR DESCRIPTION
## Summary

Continuing the work from #2494 — adds a thread-local Chrome-trace-style `fl::PerfTrace` framework and wires `FL_PERF_SCOPE` markers through `CFastLED::show` and the PARLIO hot path. Combined with two new JSON-RPCs in the AutoResearch sketch (`setPerfTraceEnabled`, `getPerfTraceLog`) and a `ci/perf_trace_sweep.py` driver, this lets autoresearch flip tracing on at runtime, run a PARLIO test, and pull a per-frame event log to verify whether the ~16 ms blocking issue from #2493 is fully resolved by the #2503 vTaskDelay-floor fix.

Replaces the ad-hoc `FL_PARLIO_PROFILE=1` markers from PR #2494 with a reusable framework — subsequent drivers can be instrumented by sprinkling `FL_PERF_SCOPE("name")` without bespoke timing boilerplate.

## Changes

**`src/fl/system/perf_trace.{h,cpp.hpp}` (new)**
- Per-thread in-flight stack (`FixedVector<PerfEvent,32>`) and completed-event log (`FixedVector<PerfEvent,128>`) held in `SingletonThreadLocal`.
- `PerfEvent` captures `(file*, name*, line, depth, start_us, end_us)`; string pointers are non-owning literals (`__FILE__` + macro arg).
- Compile gate `FASTLED_PERF_TRACE`; runtime gate `fl::PerfTrace::set_enabled(bool)`. When either is off, macros are no-ops with zero overhead.
- Macros: `FL_PERF_SCOPE(name)` (RAII), `FL_PERF_BEGIN(name)` / `FL_PERF_END(slot)` (manual), `FL_PERF_FRAME_FLUSH()`.
- `flush()` emits one `FL_INFO` line per event (`PT d=N dur_us=X start_us=Y name=Z @file:L`) or routes via a user callback. `dropped()` flag surfaces overflow without corrupting the log.

**Instrumentation** (`CFastLED::show` + PARLIO hot path)
- `src/FastLED.cpp.hpp` — outer `show` scope + nested `onBeginFrame`, `min_micros_gate`, `showLedsInternal`, `endShowLeds`.
- `src/fl/channels/manager.cpp.hpp`, `src/fl/channels/driver.cpp.hpp` — `waitForCondition` scopes in the two polling loops (the deep-yield sites from #2493).
- `src/platforms/esp/32/drivers/parlio/channel_driver_parlio.cpp.hpp` — scopes in `Impl::poll`, `Impl::beginTransmission`, outer `poll`, `beginClocklessTransmission`.

**AutoResearch sketch + autoresearch driver**
- `examples/AutoResearch/AutoResearchRemote.cpp`: `setPerfTraceEnabled(bool)` flips capture and clears on disable; `getPerfTraceLog()` returns events as compact `[depth, dur_us, start_us, name, file, line]` tuples and clears the log.
- `platformio.ini` esp32p4 env: `-D FASTLED_PERF_TRACE=1` (capture stays off at boot — autoresearch flips the runtime switch). Also flips `ARDUINO_USB_MODE=1 → 0` to route `Serial` to the JTAG port the dev board actually exposes as COM* on Windows (same call-out as PR #2494).
- `ci/perf_trace_sweep.py` (new) — pyserial-based driver script that calls `setPerfTraceEnabled(true)` → `runTest` (PARLIO) → `getPerfTraceLog()` and prints a table or JSON.

## Tests

`tests/fl/system/perf_trace.hpp` (10 cases, all green):
- disabled by default after fresh process state
- basic begin/end records one event
- FL_PERF_SCOPE RAII guard records on exit
- runtime disable suppresses events even when compiled in
- duration monotonic non-negative
- file/line/name captured from macro site
- stack overflow marks `dropped()` without corruption
- flush emits and clears the log
- log capacity caps `event_count()` and sets `dropped()`
- `clear()` resets log, stack, and dropped flag

Verified `bash test log/driver/channels/fastled_core --cpp` all pass and `bash compile wasm --examples Blink` succeeds.

## Hardware validation is blocked — see #2507

`bash autoresearch esp32p4 --parlio` failed twice on this dev env:
1. **fbuild path** — zccache daemon timeout (~300 s) on first compile, then arduino-esp32 internal-header miss (`WString.h`, `soc/soc_caps.h` not found despite being present in the cached framework tree).
2. **Serial output** — even after flashing via `pio run --target upload` / direct esptool, no bytes ever arrive on the COM port after device reset. Switching `ARDUINO_USB_MODE` to 0 (per PR #2494) didn't help. ROM-loader output IS visible, so the host-side path is alive — it's specifically post-app boot.

Both issues are tracked in #2507 with reproducers. The PR code is sound and host-side tests pass; the perf-trace sweep will run as soon as #2507 is resolved.

## Related

- #2493 — original PARLIO blocking report
- #2494 — earlier reproducer / FL_PARLIO_PROFILE markers (superseded by this PR)
- #2503 — vTaskDelay floor fix (landed)
- #2507 — meta issue: autoresearch + fbuild + esp32p4 broken (blocks empirical validation of this PR)

## Test plan

- [x] bash lint
- [x] bash test log --cpp (perf_trace tests pass 10/10)
- [x] bash test channels/driver/fastled_core --cpp
- [x] bash compile wasm --examples Blink
- [ ] **Blocked on #2507**: bash autoresearch esp32p4 --parlio + uv run ci/perf_trace_sweep.py --port COM25 --lanes 12 --strip-size 256 → confirm per-frame events show waitForCondition no longer dominates the show() budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Runtime performance tracing with scoped instrumentation and runtime on/off control.
  * CLI tool to run trace sweeps on ESP32-P4 with table or JSON output.
  * Arduino sketch to capture and store per-frame traces to flash.

* **Tools**
  * Decoder script to parse and render binary trace dumps.

* **Tests**
  * Unit tests covering tracing behavior, buffering, overflow, and flush semantics.

* **Chores**
  * Build configuration updated to enable perf-trace support.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/FastLED/pull/2508?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->