### PR TITLE
fix(esp32): build cleanly on ESP-IDF 6

### DIFF
--- a/src/platforms/esp/32/audio/devices/idf5_i2s_context.hpp
+++ b/src/platforms/esp/32/audio/devices/idf5_i2s_context.hpp
@@ -16,6 +16,7 @@
 #include "fl/log/log.h"
 #include "fl/audio/audio_input.h"
 #include "fl/stl/noexcept.h"
+#include "platforms/esp/esp_version.h"
 
 #define I2S_INTR_ALLOC_FLAGS 0
 
@@ -125,9 +126,15 @@ I2SContext make_context(const audio::ConfigI2S &config) FL_NOEXCEPT {
 I2SContext i2s_audio_init(const audio::ConfigI2S &config) FL_NOEXCEPT {
     I2SContext ctx = make_context(config);
 
-    // Create I2S channel configuration with DMA buffer settings
+    // Create I2S channel configuration with DMA buffer settings.
+    // ESP-IDF 6 removed the i2s_port_t enum; i2s_chan_config_t::id is now int.
+#if ESP_IDF_VERSION_6_OR_HIGHER
+    i2s_chan_config_t chan_cfg = I2S_CHANNEL_DEFAULT_CONFIG(
+        config.mI2sNum, I2S_ROLE_MASTER);
+#else
     i2s_chan_config_t chan_cfg = I2S_CHANNEL_DEFAULT_CONFIG(
         static_cast<i2s_port_t>(config.mI2sNum), I2S_ROLE_MASTER);
+#endif
     chan_cfg.dma_desc_num = AUDIO_DMA_BUFFER_COUNT;
     chan_cfg.dma_frame_num = I2S_AUDIO_BUFFER_LEN;
 

--- a/src/platforms/esp/32/audio/devices/idf5_i2s_context.hpp
+++ b/src/platforms/esp/32/audio/devices/idf5_i2s_context.hpp
@@ -126,8 +126,7 @@ I2SContext make_context(const audio::ConfigI2S &config) FL_NOEXCEPT {
 I2SContext i2s_audio_init(const audio::ConfigI2S &config) FL_NOEXCEPT {
     I2SContext ctx = make_context(config);
 
-    // Create I2S channel configuration with DMA buffer settings.
-    // ESP-IDF 6 removed the i2s_port_t enum; i2s_chan_config_t::id is now int.
+    // Create I2S channel configuration with DMA buffer settings
 #if ESP_IDF_VERSION_6_OR_HIGHER
     i2s_chan_config_t chan_cfg = I2S_CHANNEL_DEFAULT_CONFIG(
         config.mI2sNum, I2S_ROLE_MASTER);

--- a/src/platforms/esp/32/audio/devices/idf5_pdm_context.hpp
+++ b/src/platforms/esp/32/audio/devices/idf5_pdm_context.hpp
@@ -14,6 +14,7 @@
 #include "fl/stl/int.h"
 #include "fl/stl/noexcept.h"
 #include "fl/log/log.h"
+#include "platforms/esp/esp_version.h"
 
 namespace fl {
 namespace esp_pdm {
@@ -31,9 +32,15 @@ PDMContext pdm_audio_init(const audio::ConfigPdm &config) FL_NOEXCEPT {
     int pin_din = config.mPinDin;
     u16 sample_rate = config.mSampleRate;
 
-    // Create I2S channel configuration with DMA buffer settings
+    // Create I2S channel configuration with DMA buffer settings.
+    // ESP-IDF 6 removed the i2s_port_t enum; i2s_chan_config_t::id is now int.
+#if ESP_IDF_VERSION_6_OR_HIGHER
+    i2s_chan_config_t chan_cfg = I2S_CHANNEL_DEFAULT_CONFIG(
+        config.mI2sNum, I2S_ROLE_MASTER);
+#else
     i2s_chan_config_t chan_cfg = I2S_CHANNEL_DEFAULT_CONFIG(
         static_cast<i2s_port_t>(config.mI2sNum), I2S_ROLE_MASTER);
+#endif
     chan_cfg.dma_desc_num = AUDIO_DMA_BUFFER_COUNT;
     chan_cfg.dma_frame_num = I2S_AUDIO_BUFFER_LEN;
 

--- a/src/platforms/esp/32/audio/devices/idf5_pdm_context.hpp
+++ b/src/platforms/esp/32/audio/devices/idf5_pdm_context.hpp
@@ -32,8 +32,7 @@ PDMContext pdm_audio_init(const audio::ConfigPdm &config) FL_NOEXCEPT {
     int pin_din = config.mPinDin;
     u16 sample_rate = config.mSampleRate;
 
-    // Create I2S channel configuration with DMA buffer settings.
-    // ESP-IDF 6 removed the i2s_port_t enum; i2s_chan_config_t::id is now int.
+    // Create I2S channel configuration with DMA buffer settings
 #if ESP_IDF_VERSION_6_OR_HIGHER
     i2s_chan_config_t chan_cfg = I2S_CHANNEL_DEFAULT_CONFIG(
         config.mI2sNum, I2S_ROLE_MASTER);

--- a/src/platforms/esp/32/drivers/gpio_isr_rx/mcpwm_timer.cpp.hpp
+++ b/src/platforms/esp/32/drivers/gpio_isr_rx/mcpwm_timer.cpp.hpp
@@ -52,7 +52,13 @@ using fl::u32;
 #include "esp_log.h"
 #include "soc/mcpwm_struct.h"
 #include "hal/mcpwm_ll.h"
+#include "platforms/esp/esp_version.h"
+#if ESP_IDF_VERSION_6_OR_HIGHER
+// ESP-IDF 6 relocated mcpwm_periph.h from soc/ to hal/.
+#include "hal/mcpwm_periph.h"
+#else
 #include "soc/mcpwm_periph.h"
+#endif
 // IWYU pragma: end_keep
 
 // Note: Functions are declared extern "C" in header - no namespace wrapping here

--- a/src/platforms/esp/32/drivers/gpio_isr_rx/mcpwm_timer.cpp.hpp
+++ b/src/platforms/esp/32/drivers/gpio_isr_rx/mcpwm_timer.cpp.hpp
@@ -54,7 +54,6 @@ using fl::u32;
 #include "hal/mcpwm_ll.h"
 #include "platforms/esp/esp_version.h"
 #if ESP_IDF_VERSION_6_OR_HIGHER
-// ESP-IDF 6 relocated mcpwm_periph.h from soc/ to hal/.
 #include "hal/mcpwm_periph.h"
 #else
 #include "soc/mcpwm_periph.h"
@@ -239,11 +238,7 @@ int mcpwm_timer_init(DualIsrContext* ctx, int gpio_pin) FL_NOEXCEPT {
         ESP_LOGI(MCPWM_TIMER_TAG, "Timer resolution verified: %lu Hz (12.5 ns per tick)", actual_resolution);
     }
 
-    // Step 2: Create capture channel and connect to GPIO.
-    // ESP-IDF 6 trimmed mcpwm_capture_channel_config_t::flags down to
-    // {pos_edge, neg_edge, invert_cap_signal}; pull_up/pull_down/io_loop_back
-    // were removed (use gpio_set_pull_mode() etc. if needed). All three were
-    // already 0 here, so just drop them on IDF 6.
+    // Step 2: Create capture channel and connect to GPIO
     mcpwm_capture_channel_config_t channel_config = {
         .gpio_num = gpio_pin,
         .prescale = 1,  // No prescaling - capture at full timer resolution

--- a/src/platforms/esp/32/drivers/gpio_isr_rx/mcpwm_timer.cpp.hpp
+++ b/src/platforms/esp/32/drivers/gpio_isr_rx/mcpwm_timer.cpp.hpp
@@ -239,17 +239,25 @@ int mcpwm_timer_init(DualIsrContext* ctx, int gpio_pin) FL_NOEXCEPT {
         ESP_LOGI(MCPWM_TIMER_TAG, "Timer resolution verified: %lu Hz (12.5 ns per tick)", actual_resolution);
     }
 
-    // Step 2: Create capture channel and connect to GPIO
+    // Step 2: Create capture channel and connect to GPIO.
+    // ESP-IDF 6 trimmed mcpwm_capture_channel_config_t::flags down to
+    // {pos_edge, neg_edge, invert_cap_signal}; pull_up/pull_down/io_loop_back
+    // were removed (use gpio_set_pull_mode() etc. if needed). All three were
+    // already 0 here, so just drop them on IDF 6.
     mcpwm_capture_channel_config_t channel_config = {
         .gpio_num = gpio_pin,
         .prescale = 1,  // No prescaling - capture at full timer resolution
         .flags = {
             .pos_edge = 1,  // Capture on positive edges
             .neg_edge = 1,  // Capture on negative edges
+#if !ESP_IDF_VERSION_6_OR_HIGHER
             .pull_up = 0,   // No internal pull-up
             .pull_down = 0, // No internal pull-down
+#endif
             .invert_cap_signal = 0,  // No inversion
+#if !ESP_IDF_VERSION_6_OR_HIGHER
             .io_loop_back = 0,       // No loopback
+#endif
         }
     };
 

--- a/src/platforms/esp/32/drivers/i2s/i2s_lcd_cam_peripheral_esp.cpp.hpp
+++ b/src/platforms/esp/32/drivers/i2s/i2s_lcd_cam_peripheral_esp.cpp.hpp
@@ -133,8 +133,9 @@ bool I2sLcdCamPeripheralEsp::initialize(const I2sLcdCamConfig& config) FL_NOEXCE
     // Create I80 bus configuration
     esp_lcd_i80_bus_config_t bus_config = {};
     bus_config.clk_src = LCD_CLK_SRC_PLL160M;
-    bus_config.dc_gpio_num = 0;  // Not used for LED driving
-    bus_config.wr_gpio_num = 0;  // Not used for LED driving
+    // ESP-IDF 6 made gpio_num_t strictly typed; explicit cast needed.
+    bus_config.dc_gpio_num = static_cast<gpio_num_t>(0);  // Not used for LED driving
+    bus_config.wr_gpio_num = static_cast<gpio_num_t>(0);  // Not used for LED driving
     bus_config.bus_width = 16;
     bus_config.max_transfer_bytes = config.max_transfer_bytes;
 
@@ -152,9 +153,9 @@ bool I2sLcdCamPeripheralEsp::initialize(const I2sLcdCamConfig& config) FL_NOEXCE
     // Data GPIO pins
     for (int i = 0; i < 16; i++) {
         if (i < config.num_lanes) {
-            bus_config.data_gpio_nums[i] = config.data_gpios[i];
+            bus_config.data_gpio_nums[i] = static_cast<gpio_num_t>(config.data_gpios[i]);
         } else {
-            bus_config.data_gpio_nums[i] = 0;  // Unused pins set to 0
+            bus_config.data_gpio_nums[i] = static_cast<gpio_num_t>(0);  // Unused pins set to 0
         }
     }
 
@@ -167,7 +168,7 @@ bool I2sLcdCamPeripheralEsp::initialize(const I2sLcdCamConfig& config) FL_NOEXCE
 
     // Create panel IO configuration
     esp_lcd_panel_io_i80_config_t io_config = {};
-    io_config.cs_gpio_num = -1;  // No CS pin
+    io_config.cs_gpio_num = GPIO_NUM_NC;  // No CS pin
     io_config.pclk_hz = config.pclk_hz > 0 ? config.pclk_hz : FASTLED_ESP32S3_I2S_CLOCK_HZ;
     io_config.trans_queue_depth = 1;
     io_config.dc_levels = {

--- a/src/platforms/esp/32/drivers/i2s/i2s_lcd_cam_peripheral_esp.cpp.hpp
+++ b/src/platforms/esp/32/drivers/i2s/i2s_lcd_cam_peripheral_esp.cpp.hpp
@@ -133,7 +133,6 @@ bool I2sLcdCamPeripheralEsp::initialize(const I2sLcdCamConfig& config) FL_NOEXCE
     // Create I80 bus configuration
     esp_lcd_i80_bus_config_t bus_config = {};
     bus_config.clk_src = LCD_CLK_SRC_PLL160M;
-    // ESP-IDF 6 made gpio_num_t strictly typed; explicit cast needed.
     bus_config.dc_gpio_num = static_cast<gpio_num_t>(0);  // Not used for LED driving
     bus_config.wr_gpio_num = static_cast<gpio_num_t>(0);  // Not used for LED driving
     bus_config.bus_width = 16;

--- a/src/platforms/esp/32/drivers/lcd_spi/lcd_spi_peripheral_esp.cpp.hpp
+++ b/src/platforms/esp/32/drivers/lcd_spi/lcd_spi_peripheral_esp.cpp.hpp
@@ -160,15 +160,16 @@ bool LcdSpiPeripheralEsp::initialize(const LcdSpiConfig &config) FL_NOEXCEPT {
     // dummy (matching i2s_lcd_cam_peripheral_esp.cpp.hpp convention).
     // NOTE: GPIO 0 is a strapping pin — if your board uses GPIO 0 for
     // boot-mode selection, set dc_gpio in LcdSpiConfig to an unused pin.
+    // ESP-IDF 6 made gpio_num_t strictly typed; explicit casts needed.
     if (config.dc_gpio >= 0) {
-        bus_config.dc_gpio_num = config.dc_gpio;
+        bus_config.dc_gpio_num = static_cast<gpio_num_t>(config.dc_gpio);
     } else {
-        bus_config.dc_gpio_num = 0;
+        bus_config.dc_gpio_num = static_cast<gpio_num_t>(0);
         FL_WARN("LcdSpiPeripheralEsp: dc_gpio not set, defaulting to "
                 "GPIO 0 (strapping pin). Set LcdSpiConfig::dc_gpio to "
                 "an unused pin to avoid boot issues.");
     }
-    bus_config.wr_gpio_num = config.clock_gpio; // PCLK as SPI clock
+    bus_config.wr_gpio_num = static_cast<gpio_num_t>(config.clock_gpio); // PCLK as SPI clock
     bus_config.bus_width = 16;
     bus_config.max_transfer_bytes = config.max_transfer_bytes;
 
@@ -184,11 +185,11 @@ bool LcdSpiPeripheralEsp::initialize(const LcdSpiConfig &config) FL_NOEXCEPT {
 
     for (int i = 0; i < 16; i++) {
         if (i < config.num_lanes) {
-            bus_config.data_gpio_nums[i] = config.data_gpios[i];
+            bus_config.data_gpio_nums[i] = static_cast<gpio_num_t>(config.data_gpios[i]);
         } else {
             // I80 bus requires valid GPIOs for all bus_width pins.
             // Use GPIO 0 for unused lanes (matches I2S LCD_CAM convention).
-            bus_config.data_gpio_nums[i] = 0;
+            bus_config.data_gpio_nums[i] = static_cast<gpio_num_t>(0);
         }
     }
 
@@ -328,7 +329,7 @@ bool LcdSpiPeripheralEsp::transmit(const u16 *buffer,
 
     if (mPanelIo == nullptr) {
         esp_lcd_panel_io_i80_config_t io_config = {};
-        io_config.cs_gpio_num = -1;
+        io_config.cs_gpio_num = GPIO_NUM_NC;
         io_config.pclk_hz = mConfig.clock_hz;
         io_config.trans_queue_depth = 1;
         io_config.dc_levels = {

--- a/src/platforms/esp/32/drivers/lcd_spi/lcd_spi_peripheral_esp.cpp.hpp
+++ b/src/platforms/esp/32/drivers/lcd_spi/lcd_spi_peripheral_esp.cpp.hpp
@@ -160,7 +160,6 @@ bool LcdSpiPeripheralEsp::initialize(const LcdSpiConfig &config) FL_NOEXCEPT {
     // dummy (matching i2s_lcd_cam_peripheral_esp.cpp.hpp convention).
     // NOTE: GPIO 0 is a strapping pin — if your board uses GPIO 0 for
     // boot-mode selection, set dc_gpio in LcdSpiConfig to an unused pin.
-    // ESP-IDF 6 made gpio_num_t strictly typed; explicit casts needed.
     if (config.dc_gpio >= 0) {
         bus_config.dc_gpio_num = static_cast<gpio_num_t>(config.dc_gpio);
     } else {

--- a/src/platforms/esp/32/drivers/rmt/rmt_5/rmt5_peripheral_esp.cpp.hpp
+++ b/src/platforms/esp/32/drivers/rmt/rmt_5/rmt5_peripheral_esp.cpp.hpp
@@ -160,14 +160,13 @@ bool Rmt5PeripheralESPImpl::createTxChannel(const Rmt5ChannelConfig& config,
     esp_config.flags.invert_out = config.invert_out ? 1U : 0U;
     esp_config.flags.with_dma = config.with_dma ? 1U : 0U;
 #if !ESP_IDF_VERSION_6_OR_HIGHER
-    // ESP-IDF 6 removed rmt_tx_channel_config_t::flags::io_od_mode and
-    // ::io_loop_back. Both were already 0 here; on IDF 6 the defaults match,
-    // so we just skip the assignments.
-    //
+    // GPIO configuration flags:
     // io_od_mode=0: Push-pull output (not open-drain)
     esp_config.flags.io_od_mode = 0;
-    // io_loop_back=0: external loop via jumper, not internal loopback (which
-    // could reconfigure GPIO in ways that break subsequent TX).
+
+    // io_loop_back: Internal loopback mode (routes TX output back to RX input internally)
+    // Setting to 0 because we use physical jumper cable, not internal loopback.
+    // With io_loop_back=1, ESP-IDF may reconfigure GPIO in ways that break subsequent TX.
     esp_config.flags.io_loop_back = 0;
 #endif
     esp_config.intr_priority = config.intr_priority;

--- a/src/platforms/esp/32/drivers/rmt/rmt_5/rmt5_peripheral_esp.cpp.hpp
+++ b/src/platforms/esp/32/drivers/rmt/rmt_5/rmt5_peripheral_esp.cpp.hpp
@@ -159,14 +159,17 @@ bool Rmt5PeripheralESPImpl::createTxChannel(const Rmt5ChannelConfig& config,
     esp_config.trans_queue_depth = config.trans_queue_depth;
     esp_config.flags.invert_out = config.invert_out ? 1U : 0U;
     esp_config.flags.with_dma = config.with_dma ? 1U : 0U;
-    // GPIO configuration flags:
+#if !ESP_IDF_VERSION_6_OR_HIGHER
+    // ESP-IDF 6 removed rmt_tx_channel_config_t::flags::io_od_mode and
+    // ::io_loop_back. Both were already 0 here; on IDF 6 the defaults match,
+    // so we just skip the assignments.
+    //
     // io_od_mode=0: Push-pull output (not open-drain)
     esp_config.flags.io_od_mode = 0;
-
-    // io_loop_back: Internal loopback mode (routes TX output back to RX input internally)
-    // Setting to 0 because we use physical jumper cable, not internal loopback.
-    // With io_loop_back=1, ESP-IDF may reconfigure GPIO in ways that break subsequent TX.
+    // io_loop_back=0: external loop via jumper, not internal loopback (which
+    // could reconfigure GPIO in ways that break subsequent TX).
     esp_config.flags.io_loop_back = 0;
+#endif
     esp_config.intr_priority = config.intr_priority;
 
     // NOTE: Removed gpio_reset_pin() call - ESP-IDF rmt_new_tx_channel() handles GPIO configuration

--- a/src/platforms/esp/32/drivers/rmt_rx/rmt_rx_channel.cpp.hpp
+++ b/src/platforms/esp/32/drivers/rmt_rx/rmt_rx_channel.cpp.hpp
@@ -762,21 +762,16 @@ class RmtRxChannelImpl : public RmtRxChannel {
         // ESP32-S3 has a hardware limitation where TX GPIO output stops when RX
         // is actively receiving on a different GPIO. With loopback enabled,
         // TX output is routed both to the GPIO AND internally to RX.
-#if ESP_IDF_VERSION_6_OR_HIGHER
-        // ESP-IDF 6 removed io_loop_back from rmt_rx_channel_config_t::flags.
-        // Internal loopback is no longer settable through the driver; callers
-        // that need it must route via the GPIO matrix manually.
-        if (mIoLoopBack) {
-            FL_WARN("[RMT RX] io_loop_back requested but not supported on ESP-IDF 6+ "
-                    "(field removed); proceeding without internal loopback on GPIO "
-                    << static_cast<int>(mPin));
-        }
-#else
+        //
+        // ESP-IDF 6 removed the explicit io_loop_back flag because loopback is
+        // now implicit: configuring the same GPIO as both TX output and RX input
+        // routes the signal internally automatically.
+#if !ESP_IDF_VERSION_6_OR_HIGHER
         rx_config.flags.io_loop_back = mIoLoopBack ? 1 : 0;
-        if (mIoLoopBack) {
-            FL_WARN("[RMT RX] Internal loopback enabled (io_loop_back=1) on GPIO " << static_cast<int>(mPin));
-        }
 #endif
+        if (mIoLoopBack) {
+            FL_WARN("[RMT RX] Internal loopback enabled on GPIO " << static_cast<int>(mPin));
+        }
 
         // Note: RX channel is already registered with RmtMemoryManager in constructor
         // to ensure TX channels can detect RX presence before they are created.

--- a/src/platforms/esp/32/drivers/rmt_rx/rmt_rx_channel.cpp.hpp
+++ b/src/platforms/esp/32/drivers/rmt_rx/rmt_rx_channel.cpp.hpp
@@ -762,10 +762,21 @@ class RmtRxChannelImpl : public RmtRxChannel {
         // ESP32-S3 has a hardware limitation where TX GPIO output stops when RX
         // is actively receiving on a different GPIO. With loopback enabled,
         // TX output is routed both to the GPIO AND internally to RX.
+#if ESP_IDF_VERSION_6_OR_HIGHER
+        // ESP-IDF 6 removed io_loop_back from rmt_rx_channel_config_t::flags.
+        // Internal loopback is no longer settable through the driver; callers
+        // that need it must route via the GPIO matrix manually.
+        if (mIoLoopBack) {
+            FL_WARN("[RMT RX] io_loop_back requested but not supported on ESP-IDF 6+ "
+                    "(field removed); proceeding without internal loopback on GPIO "
+                    << static_cast<int>(mPin));
+        }
+#else
         rx_config.flags.io_loop_back = mIoLoopBack ? 1 : 0;
         if (mIoLoopBack) {
             FL_WARN("[RMT RX] Internal loopback enabled (io_loop_back=1) on GPIO " << static_cast<int>(mPin));
         }
+#endif
 
         // Note: RX channel is already registered with RmtMemoryManager in constructor
         // to ensure TX channels can detect RX presence before they are created.

--- a/src/platforms/esp/32/drivers/rmt_rx/rmt_rx_channel.cpp.hpp
+++ b/src/platforms/esp/32/drivers/rmt_rx/rmt_rx_channel.cpp.hpp
@@ -762,15 +762,11 @@ class RmtRxChannelImpl : public RmtRxChannel {
         // ESP32-S3 has a hardware limitation where TX GPIO output stops when RX
         // is actively receiving on a different GPIO. With loopback enabled,
         // TX output is routed both to the GPIO AND internally to RX.
-        //
-        // ESP-IDF 6 removed the explicit io_loop_back flag because loopback is
-        // now implicit: configuring the same GPIO as both TX output and RX input
-        // routes the signal internally automatically.
 #if !ESP_IDF_VERSION_6_OR_HIGHER
         rx_config.flags.io_loop_back = mIoLoopBack ? 1 : 0;
 #endif
         if (mIoLoopBack) {
-            FL_WARN("[RMT RX] Internal loopback enabled on GPIO " << static_cast<int>(mPin));
+            FL_WARN("[RMT RX] Internal loopback enabled (io_loop_back=1) on GPIO " << static_cast<int>(mPin));
         }
 
         // Note: RX channel is already registered with RmtMemoryManager in constructor

--- a/src/platforms/esp/32/ota/ota_impl.cpp.hpp
+++ b/src/platforms/esp/32/ota/ota_impl.cpp.hpp
@@ -14,7 +14,11 @@
 // OTA support detection flag
 // OTA requires IDF 4.0+ for HTTP server and OTA APIs
 // ESP32-H2 and ESP32-P4 lack WiFi hardware
-#if ESP_IDF_VERSION_4_OR_HIGHER && !defined(FL_IS_ESP_32H2) && !defined(FL_IS_ESP_32P4)
+// ESP-IDF 6 deprecated mbedtls's direct SHA256/MD5 APIs (moved to
+// mbedtls/private/) in favor of PSA crypto; until this implementation is
+// ported to psa_hash_*, OTA is disabled on IDF 6+.
+#if ESP_IDF_VERSION_4_OR_HIGHER && !ESP_IDF_VERSION_6_OR_HIGHER \
+    && !defined(FL_IS_ESP_32H2) && !defined(FL_IS_ESP_32P4)
 #define FL_ESP_OTA_SUPPORTED
 #endif
 

--- a/src/platforms/esp/32/ota/ota_impl.cpp.hpp
+++ b/src/platforms/esp/32/ota/ota_impl.cpp.hpp
@@ -14,9 +14,6 @@
 // OTA support detection flag
 // OTA requires IDF 4.0+ for HTTP server and OTA APIs
 // ESP32-H2 and ESP32-P4 lack WiFi hardware
-// ESP-IDF 6 deprecated mbedtls's direct SHA256/MD5 APIs (moved to
-// mbedtls/private/) in favor of PSA crypto; until this implementation is
-// ported to psa_hash_*, OTA is disabled on IDF 6+.
 #if ESP_IDF_VERSION_4_OR_HIGHER && !ESP_IDF_VERSION_6_OR_HIGHER \
     && !defined(FL_IS_ESP_32H2) && !defined(FL_IS_ESP_32P4)
 #define FL_ESP_OTA_SUPPORTED


### PR DESCRIPTION
Master doesnt currently compile against ESP-IDF 6.0. Hit these
testing FastLED with ESPHome on IDF 6, all in the bundled glob-built
ESP32 sources. Each fix is gated on `ESP_IDF_VERSION_6_OR_HIGHER`;
IDF 5 and earlier are unchanged.

### Changes

- **`mcpwm_periph.h` relocation** — IDF 6 moved this header from `soc/`
  to `hal/`. (`drivers/gpio_isr_rx/mcpwm_timer.cpp.hpp`)
- **`i2s_port_t` removal** — IDF 6 dropped the enum; `i2s_chan_config_t::id`
  is now `int`. Pass `config.mI2sNum` (already int) directly on IDF 6.
  (`audio/devices/idf5_i2s_context.hpp`, `audio/devices/idf5_pdm_context.hpp`)
- **OTA disabled on IDF 6** — `ota_impl.cpp.hpp` uses `mbedtls_sha256_*`
  / `mbedtls_md_*` across ~10 call sites. mbedtls 3.6 / IDF 6 moved
  these to `mbedtls/private/` and recommends PSA as the public API.
  Gate `FL_ESP_OTA_SUPPORTED` off on IDF 6 for now; a proper port to
  `psa_hash_*` is a separate change.
- **Removed driver-config flags** — IDF 6 trimmed
  `mcpwm_capture_channel_config_t::flags` (no more `pull_up`/`pull_down`/
  `io_loop_back`) and the RMT TX/RX flag structs (no more `io_od_mode`/
  `io_loop_back`). All were being set to 0 / inert. Loopback is now
  implicit on IDF 6 — same-GPIO TX+RX routes internally without the flag.
- **`gpio_num_t` strict typing** — IDF 6 stops implicit `int` →
  `gpio_num_t`. Add `static_cast<gpio_num_t>(...)` for the LCD_CAM /
  LCD_SPI bus configs; use `GPIO_NUM_NC` for "no pin" instead of `-1`.
  (`drivers/i2s/i2s_lcd_cam_peripheral_esp.cpp.hpp`,
  `drivers/lcd_spi/lcd_spi_peripheral_esp.cpp.hpp`)

### Testing

Compiled via ESPHome on IDF 6.0.1 and 5.5.4 with arduino-esp32 as
managed component for esp32dev and esp32s3.

### Follow-up

PSA-crypto port for `ota_impl.cpp.hpp` to re-enable OTA on IDF 6.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ESP32 platform drivers to improve hardware compatibility across different IDF versions.
  * Enhanced audio device initialization for I2S and PDM configurations.
  * Adjusted GPIO and RMT peripheral channel settings for optimal hardware integration.
  * Refined OTA functionality conditions for targeted platform support.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/FastLED/pull/2509?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->