### PR TITLE
fix(build): compile cleanly as a standalone ESP-IDF component

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,10 +4,7 @@
 
 cmake_minimum_required(VERSION 3.5)
 
-# Collect all source files (unity-build entry points live in src/fl/build/).
-# Use GLOB_RECURSE because file(GLOB) does not walk subdirectories and `**`
-# is not a recursive wildcard in CMake -- the previous non-recursive pattern
-# returned an empty list, leaving the component CONFIG_ONLY.
+# Collect all source files
 file(GLOB_RECURSE FastLED_SRCS "src/*.cpp")
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ file(GLOB_RECURSE FastLED_SRCS "src/*.cpp")
 # Register the component with ESP-IDF
 idf_component_register(SRCS ${FastLED_SRCS}
                        INCLUDE_DIRS "src"
-                       REQUIRES arduino-esp32 esp_driver_rmt esp_lcd driver esp_mm esp_wifi esp_netif)
+                       REQUIRES arduino-esp32 esp_driver_i2s esp_driver_mcpwm esp_driver_rmt
+                                esp_http_server esp_lcd driver esp_mm esp_wifi esp_netif)
 
 project(FastLED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,8 +4,11 @@
 
 cmake_minimum_required(VERSION 3.5)
 
-# Collect all source files
-file(GLOB FastLED_SRCS "src/**/*.cpp")
+# Collect all source files (unity-build entry points live in src/fl/build/).
+# Use GLOB_RECURSE because file(GLOB) does not walk subdirectories and `**`
+# is not a recursive wildcard in CMake -- the previous non-recursive pattern
+# returned an empty list, leaving the component CONFIG_ONLY.
+file(GLOB_RECURSE FastLED_SRCS "src/*.cpp")
 
 
 

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -5,3 +5,11 @@ dependencies:
     version: "^1.2.0"
     rules:
       - if: "target == esp32p4"
+
+# The IDF Component Manager strips any directory called `build/` via its
+# hardcoded DEFAULT_EXCLUDE (`**/build/**/*`). The unity-build entry .cpp
+# files live in `src/fl/build/`, so without re-including them the fetched
+# component has zero compilable sources and registers as CONFIG_ONLY.
+files:
+  include:
+    - "src/fl/build/**/*"

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -6,10 +6,7 @@ dependencies:
     rules:
       - if: "target == esp32p4"
 
-# The IDF Component Manager strips any directory called `build/` via its
-# hardcoded DEFAULT_EXCLUDE (`**/build/**/*`). The unity-build entry .cpp
-# files live in `src/fl/build/`, so without re-including them the fetched
-# component has zero compilable sources and registers as CONFIG_ONLY.
+# Re-include src/fl/build/ which DEFAULT_EXCLUDE's **/build/**/* otherwise strips.
 files:
   include:
     - "src/fl/build/**/*"


### PR DESCRIPTION
Three independent build-system bugs prevent FastLED from compiling when consumed
as a managed ESP-IDF component.

## 1. Unity-entry sources stripped from the fetched component

The IDF Component Manager filters the fetched git tree through a hardcoded
`DEFAULT_EXCLUDE` list in `idf_component_tools/file_tools.py`, which contains
`**/build/**/*`. That glob matches `src/fl/build/` -- the directory holding
every unity-build entry `.cpp` file -- and silently drops it from the
distributed tree.

Fix: add a `files.include` rule to `idf_component.yml`. Manifest `include`
patterns run last in the filter pipeline and re-add paths after the defaults
strip them, so a single rule restores the unity entries without disabling any
other default filtering.

## 2. CMakeLists glob did not collect any sources

`file(GLOB FastLED_SRCS "src/**/*.cpp")` matched zero files because CMake's
`file(GLOB)` is not recursive and `**` is not a wildcard. With 1. above
fixed, the unity entries are present on disk but the glob still found
nothing, so `idf_component_register` registered FastLED as `CONFIG_ONLY` and
IDF skipped compilation entirely -- producing undefined references for
every FastLED symbol at link time.

Fix: switch to `file(GLOB_RECURSE ... "src/*.cpp")`.

## 3. Missing `REQUIRES` for I2S, MCPWM, and HTTP server components

FastLED's audio module includes `<driver/i2s_std.h>` (needs
`esp_driver_i2s`), the `gpio_isr_rx` driver includes `<driver/mcpwm_cap.h>`
(needs `esp_driver_mcpwm`), and the `fl/stl/asio/http/server` module
includes `<esp_http_server.h>` (needs `esp_http_server`). None of these
components were listed in `REQUIRES`, so when FastLED was compiled in the
IDF component scope their headers were out of scope and the unity TUs hit
fatal include errors.

Fix: add the three components to `REQUIRES`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration and system dependencies to improve component integration and coverage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/FastLED/pull/2511?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->