### PR TITLE
fix(autoresearch): route ESP32-P4 fbuild deploy through CLI

### DIFF
--- a/ci/autoresearch/phases.py
+++ b/ci/autoresearch/phases.py
@@ -876,7 +876,7 @@ async def _run_schema_and_pin_setup(ctx: RunContext) -> int | None:
     final_environment = ctx.final_environment
 
     # Validate RPC commands against device schema
-    constrained_platforms = ["esp32c6", "esp32c2", "teensy41", "teensy40"]
+    constrained_platforms = ["esp32c6", "esp32c2", "esp32p4", "teensy41", "teensy40"]
     skip_schema = (
         args.skip_schema or args.quiet or final_environment in constrained_platforms
     )

--- a/ci/util/fbuild_runner.py
+++ b/ci/util/fbuild_runner.py
@@ -559,25 +559,70 @@ def run_fbuild_deploy(
     Returns:
         True if deploy (and optional monitoring) succeeded, False otherwise
     """
+    import subprocess
+
     out = _get_output(quiet, log_file)
     print("=" * 60, file=out)
     print("DEPLOYING (fbuild)", file=out)
     print("=" * 60, file=out)
 
-    ensure_fbuild_daemon()
+    if environment is None:
+        raise ValueError("environment must be specified for fbuild deploy")
+
+    fbuild_exe = get_fbuild_executable()
+    if fbuild_exe is None:
+        print("BUILD+FLASH FAIL fbuild not found on PATH")
+        return False
+
+    cmd: list[str] = [
+        fbuild_exe,
+        str(build_dir),
+        "deploy",
+        "-e",
+        environment,
+    ]
+    if upload_port:
+        cmd.extend(["-p", upload_port])
+    if verbose:
+        cmd.append("-v")
+    if clean:
+        cmd.append("-c")
+    if monitor_after:
+        cmd.append("--monitor")
+
+    env = os.environ.copy()
+    force_restart_daemon = False
+    if environment.lower() == "esp32p4":
+        for name in ("FBUILD_USE_ESPFLASH_VERIFY", "FBUILD_USE_ESPFLASH_WRITE"):
+            if not env.get(name):
+                env[name] = "0"
+                force_restart_daemon = True
+    if force_restart_daemon:
+        subprocess.run(
+            [fbuild_exe, "daemon", "stop"],
+            capture_output=True,
+            text=True,
+            env=env,
+            check=False,
+        )
 
     t0 = time.monotonic()
     try:
-        if environment is None:
-            raise ValueError("environment must be specified for fbuild deploy")
-
-        with connect_daemon(str(build_dir), environment) as conn:
-            success: bool = conn.deploy(
-                port=upload_port,
-                clean=clean,
-                monitor_after=monitor_after,
-                timeout=timeout,
-            )
+        print(f"Running: {subprocess.list2cmdline(cmd)}", file=out)
+        print(file=out)
+        proc = subprocess.run(
+            cmd,
+            timeout=int(timeout),
+            env=env,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            check=False,
+        )
+        if proc.stdout:
+            print(proc.stdout, file=out, end="")
+        returncode = proc.returncode
+        success = returncode == 0
 
         elapsed = time.monotonic() - t0
         if quiet:
@@ -597,6 +642,10 @@ def run_fbuild_deploy(
         print("\nKeyboardInterrupt: Stopping deploy")
         handle_keyboard_interrupt(ki)
         raise
+    except subprocess.TimeoutExpired:
+        elapsed = time.monotonic() - t0
+        print(f"BUILD+FLASH FAIL timeout after {elapsed:.1f}s")
+        return False
     except Exception as e:
         elapsed = time.monotonic() - t0
         print(f"BUILD+FLASH FAIL {e}")


### PR DESCRIPTION
## Summary
- route AutoResearch fbuild deploy through the fbuild CLI so environment variables such as PLATFORMIO_SRC_DIR reach the daemon
- default ESP32-P4 deploys away from the native espflash verify/write path that hangs on the attached ESP32-P4 board
- classify ESP32-P4 as a constrained AutoResearch target so schema validation does not block before the RPC failure can be diagnosed

## Verification
- `uv run python -m py_compile ci\util\fbuild_runner.py ci\autoresearch\phases.py`
- `bash compile esp32p4 --examples AutoResearch --no-filter` with locally built fbuild from FastLED/fbuild#273
- `bash autoresearch esp32p4 --parlio --skip-lint --timeout 10` now builds/deploys AutoResearch and reproduces the reported no-RPC/no-serial failure with invalid serial headers and HP_SYS_HP_WDT_RESET output

Depends on FastLED/fbuild#273 for the ESP32-P4 fbuild include-path fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended esp32p4 platform support in CI build validation
  * Improved firmware deployment with enhanced error handling and local execution

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/FastLED/pull/2512?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->