### PR TITLE
fix(esp32p4): route legacy clockless controllers through PARLIO

### DIFF
--- a/src/platforms/esp/32/core/fastled_esp32.h
+++ b/src/platforms/esp/32/core/fastled_esp32.h
@@ -23,6 +23,10 @@
 #include "platforms/esp/32/drivers/rmt/clockless_rmt_esp32.h"
 #endif
 
+#if FASTLED_ESP32_HAS_PARLIO
+#include "platforms/esp/32/drivers/parlio/clockless_parlio_esp32.h"
+#endif
+
 #if FASTLED_ESP32_HAS_CLOCKLESS_SPI
 #include "platforms/esp/32/drivers/spi/idf5_clockless_spi_esp32.h"
 #endif

--- a/src/platforms/esp/32/drivers/parlio/clockless_parlio_esp32.h
+++ b/src/platforms/esp/32/drivers/parlio/clockless_parlio_esp32.h
@@ -1,0 +1,46 @@
+#pragma once
+
+// IWYU pragma: private
+
+#include "platforms/esp/32/feature_flags/enabled.h"
+
+#if FASTLED_ESP32_HAS_PARLIO
+
+#define FL_CLOCKLESS_CONTROLLER_DEFINED 1
+
+#include "eorder.h"
+#include "fl/channels/bus.h"
+#include "fl/channels/channel.h"
+#include "fl/channels/config.h"
+#include "fl/chipsets/timing_traits.h"
+#include "fl/stl/noexcept.h"
+#include "fl/stl/static_assert.h"
+#include "platforms/esp/32/drivers/parlio/bus_traits.h"
+
+namespace fl {
+
+template <int DATA_PIN, typename TIMING, EOrder RGB_ORDER = RGB, int XTRA0 = 0, bool FLIP = false, int WAIT_TIME = 280>
+class ClocklessPARLIO : public Channel
+{
+    FL_STATIC_ASSERT(FastPin<DATA_PIN>::validpin(), "This pin has been marked as an invalid pin, common reasons includes it being a ground pin, read only, or too noisy (e.g. hooked up to the uart).");
+
+    static ChipsetVariant makeChipset() FL_NOEXCEPT {
+        return ClocklessChipset(DATA_PIN, makeTimingConfig<TIMING>());
+    }
+
+public:
+    ClocklessPARLIO() FL_NOEXCEPT
+        : Channel(makeChipset(), RGB_ORDER, RegistrationMode::DeferRegister)
+    {
+        BusTraits<Bus::PARLIO>::registerWithManager();
+        setDriver(BusTraits<Bus::PARLIO>::instancePtr());
+        addToList();
+    }
+
+    void init() FL_NOEXCEPT override { }
+    u16 getMaxRefreshRate() const FL_NOEXCEPT override { return 800; }
+};
+
+}  // namespace fl
+
+#endif  // FASTLED_ESP32_HAS_PARLIO

--- a/src/platforms/esp/clockless.h
+++ b/src/platforms/esp/clockless.h
@@ -35,6 +35,14 @@ namespace fl {
   using ClocklessController = ClocklessI2S<DATA_PIN, TIMING, RGB_ORDER, XTRA0, FLIP, WAIT_TIME>;
   #define FL_CLOCKLESS_CONTROLLER_DEFINED 1
 
+#elif FASTLED_ESP32_HAS_PARLIO && \
+      (defined(FL_IS_ESP_32P4) || defined(FL_IS_ESP_32C6) || \
+       defined(FL_IS_ESP_32H2) || defined(FL_IS_ESP_32C5))
+  // PARLIO is the clockless default on ESP32-P4/C6/H2/C5.
+  template <int DATA_PIN, typename TIMING, EOrder RGB_ORDER = RGB, int XTRA0 = 0, bool FLIP = false, int WAIT_TIME = 280>
+  using ClocklessController = ClocklessPARLIO<DATA_PIN, TIMING, RGB_ORDER, XTRA0, FLIP, WAIT_TIME>;
+  #define FL_CLOCKLESS_CONTROLLER_DEFINED 1
+
 #elif FASTLED_ESP32_HAS_RMT && !defined(FASTLED_ESP32_USE_CLOCKLESS_SPI)
   // RMT is preferred default for ESP32 (best performance, most features)
   // Use ClocklessIdf4 (ESP-IDF 4.x) or ClocklessIdf5 (ESP-IDF 5.x) based on FASTLED_RMT5


### PR DESCRIPTION
## Summary
- add a legacy ClocklessPARLIO wrapper that registers and pre-binds the PARLIO channel driver
- make ESP32-P4/C6/H2/C5 select PARLIO for legacy clockless addLeds<> controllers before falling back to RMT
- include the PARLIO wrapper from the ESP32 platform header

## Root cause
On ESP32-P4, DefaultBus<ClocklessChipset> already says PARLIO, but the legacy ClocklessController alias still picked RMT whenever RMT hardware was present. In sketches that call FastLED.setExclusiveDriver(PARLIO) and then legacy FastLED.addLeds<WS2812B, PIN, ...>(), the manager stored PARLIO as exclusive before PARLIO had been registered. The later RMT registration was auto-disabled by exclusive mode, leaving no enabled driver to transmit queued channel data at frame end.

Fixes #2513.
Requires the fbuild release+bump tracked in #2514 for the fbuild-backed verification path.

## Verification
- git diff --check
- uv run python ci/ci-compile.py esp32p4 --examples Blink --no-filter --backend platformio
- uv run python ci/ci-compile.py esp32p4 --examples AutoResearch --no-filter --backend platformio

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added LED control driver support for ESP32-P4, ESP32-C6, ESP32-H2, and ESP32-C5 microcontrollers, delivering optimized hardware compatibility and enhanced performance on these newer ESP32 variants.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/FastLED/pull/2515?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->