### PR TITLE
chore(fbuild): bump pin to 2.2.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,15 +5,10 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    # Pin to an fbuild release that includes both Teensy framework library
-    # resolution and the Teensy-compatible GCC 11 toolchain fix needed for
-    # teensy40/teensy41. 2.2.4 added CMSIS-DSP (arm_cortexM7lfsp_math) to
-    # the teensy41 link args (FastLED/fbuild#257), but regressed source
-    # discovery so the bundled FastLED in cores/teensy4/.../libraries was
-    # compiled alongside the local lib, causing multiple-definition link
-    # errors on every example (FastLED/fbuild#263). 2.2.5 fixes that
-    # regression while keeping the CMSIS-DSP fix.
-    "fbuild==2.2.5",
+    # Pin to an fbuild release that includes the Teensy framework library
+    # fixes from 2.2.5 and the ESP32-P4 path/source discovery fixes needed by
+    # AutoResearch and PARLIO validation (FastLED/fbuild#273).
+    "fbuild==2.2.7",
     "platformio>=6.1.19,<6.2",
     "python-dateutil",
     "ruff",


### PR DESCRIPTION
﻿## Summary
- bump FastLED's tracked fbuild dependency pin from 2.2.5 to 2.2.7
- update the dependency comment to call out the ESP32-P4 path/source discovery fixes from FastLED/fbuild#273
- note: uv.lock is ignored by this repo, so the tracked PR surface is pyproject.toml

Fixes #2514.

## Verification
- uvx --refresh --from fbuild==2.2.7 python -c "import fbuild; print(getattr(fbuild, '__version__', 'unknown'))"
- uv run python -c "import fbuild; print(getattr(fbuild, '__version__', 'unknown'))"
- git diff --check
- bash compile esp32p4 --examples AutoResearch --no-filter

## Release references
- FastLED/fbuild#273
- FastLED/fbuild#276
- FastLED/fbuild#277
- https://github.com/FastLED/fbuild/releases/tag/v2.2.7
- https://github.com/FastLED/fbuild/actions/runs/26556177174


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a project build dependency to a newer stable version.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/FastLED/pull/2516?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->