### PR TITLE
fix(parlio): size DMA buffers from per-lane input bytes

### DIFF
--- a/src/platforms/esp/32/drivers/parlio/parlio_buffer_calc.h
+++ b/src/platforms/esp/32/drivers/parlio/parlio_buffer_calc.h
@@ -194,8 +194,8 @@ struct ParlioBufferCalculator {
     ///
     /// Algorithm:
     /// 1. Calculate LEDs per buffer: maxLedsPerChannel / numRingBuffers
-    /// 2. Convert to input bytes: LEDs × 3 bytes/LED × mDataWidth (multi-lane)
-    /// 3. Apply wave8 expansion (8:1 ratio): input_bytes × outputBytesPerInputByte()
+    /// 2. Convert to per-lane input bytes: LEDs × 3 bytes/LED
+    /// 3. Apply PARLIO expansion: input_bytes × outputBytesPerInputByte()
     /// 4. Add reset padding bytes (only to last buffer in stream)
     /// 5. Add safety margin for boundary checks
     /// 6. Result is DMA buffer capacity per ring buffer
@@ -216,7 +216,10 @@ struct ParlioBufferCalculator {
         // (hardware limitation). This gap corrupts WS2812 signal timing and
         // causes bit-shift errors in all LEDs after the transition point.
         // By fitting all data in one buffer, we avoid transitions entirely.
-        size_t totalInputBytes = maxLedsPerChannel * 3 * mDataWidth;
+        // The engine streams byte positions across all lanes. Its input byte
+        // count is therefore bytes per lane, while outputBytesPerInputByte()
+        // already accounts for mDataWidth during waveform transposition.
+        size_t totalInputBytes = maxLedsPerChannel * 3;
         size_t fullFrameDmaSize = dmaBufferSize(totalInputBytes, reset_us);
 
         if (fullFrameDmaSize + safetyMargin <= perBufferCap) {
@@ -227,7 +230,7 @@ struct ParlioBufferCalculator {
         // Full frame doesn't fit - fall back to streaming with multiple ring buffers.
         // This path has the ~20µs DMA gap between buffers (unavoidable hardware limitation).
         size_t ledsPerBuffer = (maxLedsPerChannel + numRingBuffers - 1) / numRingBuffers;
-        size_t inputBytesPerBuffer = ledsPerBuffer * 3 * mDataWidth;
+        size_t inputBytesPerBuffer = ledsPerBuffer * 3;
         size_t dmaBufferCapacity = dmaBufferSize(inputBytesPerBuffer, reset_us);
 
         if (dmaBufferCapacity > perBufferCap) {

--- a/src/platforms/esp/32/drivers/parlio/parlio_engine.cpp.hpp
+++ b/src/platforms/esp/32/drivers/parlio/parlio_engine.cpp.hpp
@@ -200,8 +200,9 @@ calculateBufferByteCount(const BufferPopulationParams& params) FL_NOEXCEPT {
     size_t bytes_per_buffer = (params.totalBytes + effective_ring_count - 1)
                               / effective_ring_count;
 
-    // LED boundary alignment constant: 3 bytes (RGB) × lane count
-    size_t bytes_per_led_all_lanes = 3 * params.dataWidth;
+    // LED boundary alignment constant. totalBytes is bytes per lane, so one
+    // LED boundary is 3 RGB bytes; output expansion accounts for dataWidth.
+    size_t bytes_per_led_all_lanes = 3;
 
     // Calculate maximum input bytes that fit in one buffer
     // (reuse calc object from above to avoid duplication)
@@ -715,9 +716,6 @@ ParlioEngine::workerIsrCallback(void *user_data) FL_NOEXCEPT {
         return;  // No data to process
     }
 
-    // Zero output buffer (ISR-safe memset)
-    fl::isr::memset_zero(outputBuffer, self->mRingBufferCapacity);
-
     // Generate waveform data
     size_t outputBytesWritten = 0;
     if (!self->populateDmaBuffer(outputBuffer, self->mRingBufferCapacity,
@@ -819,8 +817,9 @@ ParlioEngine::populateDmaBuffer(u8* outputBuffer,
             return false;
         }
 
-        // Buffer is already pre-zeroed by caller (fl::isr::memset_zero)
-        // Just advance the index to skip over the front padding region
+        if (front_padding_total > 0) {
+            fl::isr::memset_zero(outputBuffer + outputIdx, front_padding_total);
+        }
         outputIdx += front_padding_total;
     }
 
@@ -1022,7 +1021,7 @@ ParlioEngine::populateDmaBuffer(u8* outputBuffer,
             return false;
         }
 
-        // Buffer is already pre-zeroed by caller, just advance index
+        fl::isr::memset_zero(outputBuffer + outputIdx, back_padding_total);
         outputIdx += back_padding_total;
     }
 
@@ -1045,7 +1044,7 @@ ParlioEngine::populateDmaBuffer(u8* outputBuffer,
         }
 
         // Append all-zero bytes (LOW signal for reset duration)
-        // Buffer is already pre-zeroed by caller, so we just advance the index
+        fl::isr::memset_zero(outputBuffer + outputIdx, reset_padding_bytes);
         outputIdx += reset_padding_bytes;
     }
 
@@ -1200,10 +1199,6 @@ ParlioEngine::populateNextDMABuffer() FL_NOEXCEPT {
     if (mIsrContext->mNextByteOffset + byte_count > mIsrContext->mTotalBytes) {
         byte_count = mIsrContext->mTotalBytes - mIsrContext->mNextByteOffset;
     }
-
-    // Zero output buffer to prevent garbage data from previous use
-    // Use ISR-safe memset since this function may be called from workerIsr()
-    fl::isr::memset_zero(outputBuffer, mRingBufferCapacity);
 
     // Generate waveform data using helper function
     size_t outputBytesWritten = 0;

--- a/tests/platforms/esp/32/drivers/parlio/parlio_driver.cpp
+++ b/tests/platforms/esp/32/drivers/parlio/parlio_driver.cpp
@@ -2090,9 +2090,9 @@ FL_TEST_CASE("ParlioBufferCalculator - calculateRingBufferCapacity") {
     FL_SUBCASE("10 LEDs, 4 lanes, 3 ring buffers, no reset") {
         ParlioBufferCalculator calc{4};
         size_t capacity = calc.calculateRingBufferCapacity(10, 0, 3);
-        // Full frame fits in one buffer: dmaBufferSize(120, 0) + 128
-        // = (32 + 120*32 + 0) + 128 = 3872 + 128 = 4000
-        FL_CHECK(capacity == 4000);
+        // Full frame fits in one buffer: dmaBufferSize(30, 0) + 128
+        // = (32 + 30*32 + 0) + 128 = 992 + 128 = 1120
+        FL_CHECK(capacity == 1120);
     }
 
     FL_SUBCASE("single LED, single lane, 3 ring buffers") {
@@ -2107,6 +2107,16 @@ FL_TEST_CASE("ParlioBufferCalculator - calculateRingBufferCapacity") {
         // Full frame fits in one buffer: dmaBufferSize(9000, 280) + 128
         // = (8 + 9000*8 + 280) + 128 = 72288 + 128 = 72416
         FL_CHECK(capacity == 72416);
+    }
+
+    FL_SUBCASE("256 LEDs, 16-lane Wave3, 280us reset") {
+        ParlioBufferCalculator calc(16, true, 2400000);
+        size_t capacity = calc.calculateRingBufferCapacity(256, 280, 3,
+                                                           FASTLED_PARLIO_MAX_RING_BUFFER_TOTAL_BYTES_PSRAM);
+        // Full frame fits in one buffer using per-lane input bytes:
+        // dmaBufferSize(768, 280) + 128
+        // = (48 + 768*48 + 84) + 128 = 36996 + 128 = 37124
+        FL_CHECK(capacity == 37124);
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes the PARLIO DMA sizing bug found while narrowing #2518. The ring-buffer calculator was treating `maxLedsPerChannel * 3 * dataWidth` as the input byte count, but the engine streams byte positions per lane and `outputBytesPerInputByte()` already includes `dataWidth` during waveform transposition.

For the 12 x 256 WS2812B ESP32-P4 case, that oversized the per-buffer capacity to about 590 KB for a 36,996-byte encoded frame. The hot path then zeroed/populated far more memory than needed before each transmission.

## Changes

- Size PARLIO DMA buffers from per-lane input bytes.
- Align buffer chunking on a per-lane RGB byte boundary (`3`) instead of `3 * dataWidth`.
- Zero only explicit padding regions instead of clearing the whole DMA buffer capacity.
- Update PARLIO calculator tests, including the 256 LED / 16-lane Wave3 case.

## Measurements

ESP32-P4 EV, COM25, 12 lanes x 256 WS2812B, pins `2,27,3,26,4,23,5,22,49,21,50,20`, `FastLED.setMaxRefreshRate(0, false)`, `FastLED.setExclusiveDriver(fl::Bus::PARLIO)`.

Current master baseline from #2518:

```text
show_min_us=24938
show_avg_us=24993
show_max_us=25069
```

Trace before fix:

```text
show_total_us=24987
show_on_begin_us=8879
show_internal_us=3574
show_on_end_frame_us=12429
manager_on_end_show_us=12316
parlio_begin_total_us=10912
parlio_populate_us=10690
parlio_ring_capacity=590144
parlio_first_buffer_bytes=36996
parlio_buffers_populated=1
```

Final production-code measurement after fix:

```text
show_min_us=16963
show_avg_us=16998
show_max_us=17022
samples=40
```

The remaining time is dominated by the current single-buffer design: the next `show()` waits for the previous PARLIO transfer to finish before channel data can be rewritten, then it encodes current frame channel data and builds the next DMA waveform.

## Tests

- `bash test platforms/esp/32/drivers/parlio/parlio_driver --cpp`
- `PLATFORMIO_SRC_DIR=examples/Blink uv run pio run -e esp32p4`
- Hardware timing sketch flashed/read through ESP32-P4 flash data partition because app serial/RPC remains blocked by #2510.

Fixes #2518.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected DMA ring buffer capacity calculations for ESP32 parallel I/O driver.
  * Improved buffer padding and alignment handling during LED data transmission.
  * Enhanced support for larger LED configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/FastLED/pull/2519?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->