### PR TITLE
WIP perf(parlio): frame-level ping-pong overlap (negative result — does not pipeline; refs #2518)

### DIFF
--- a/examples/AutoResearch/AutoResearchRemote.cpp
+++ b/examples/AutoResearch/AutoResearchRemote.cpp
@@ -1898,6 +1898,21 @@ void AutoResearchRemoteControl::registerFunctions(fl::shared_ptr<AutoResearchSta
             total_sum += tt;
         }
 
+        // PIPELINED timing (no per-frame wait) — this is where the ping-pong
+        // overlap shows. Back-to-back show() lets show(N) encode while frame N-1's
+        // DMA drains in the background, so the steady-state per-frame period
+        // collapses toward max(encode, wire) instead of encode + wire. One wait()
+        // at the end accounts for the final in-flight frame. Compare against
+        // total_avg_us (the serialized show()+wait() period): pipelined < serialized
+        // by ~the wire-drain time confirms the overlap is active.
+        uint32_t pipe_t0 = micros();
+        for (int it = 0; it < iterations; it++) {
+            FastLED.show();
+        }
+        FastLED.wait(5000);
+        uint32_t pipelined_per_frame_us =
+            (micros() - pipe_t0) / static_cast<uint32_t>(iterations);
+
         FastLED.clear(ClearFlags::CHANNELS);
         fl::HeapInfo h_free = fl::getFreeHeap();
 
@@ -1923,6 +1938,7 @@ void AutoResearchRemoteControl::registerFunctions(fl::shared_ptr<AutoResearchSta
         response.set("show_max_us", static_cast<int64_t>(show_max));
         response.set("total_avg_us",
                      static_cast<int64_t>(total_sum / static_cast<uint32_t>(iterations)));
+        response.set("pipelined_per_frame_us", static_cast<int64_t>(pipelined_per_frame_us));
         return response;
     });
 

--- a/examples/AutoResearch/AutoResearchRemote.cpp
+++ b/examples/AutoResearch/AutoResearchRemote.cpp
@@ -1057,6 +1057,9 @@ void AutoResearchRemoteControl::registerFunctions(fl::shared_ptr<AutoResearchSta
         response.set("message", "pong");
         response.set("timestamp", static_cast<int64_t>(now));
         response.set("uptimeMs", static_cast<int64_t>(now));
+        fl::HeapInfo heap = fl::getFreeHeap();
+        response.set("free_sram", static_cast<int64_t>(heap.free_sram));
+        response.set("free_psram", static_cast<int64_t>(heap.free_psram));
         return response;
     });
 
@@ -1795,6 +1798,131 @@ void AutoResearchRemoteControl::registerFunctions(fl::shared_ptr<AutoResearchSta
         }
         response.set("message", msg.str().c_str());
 
+        return response;
+    });
+
+    // Register "measureParlio" - allocate an N-lane PARLIO setup, measure the
+    // internal-SRAM delta around the DMA ring allocation, and time show().
+    // Validates the PARLIO DMA buffer-sizing fix (#2519): per-lane sizing keeps
+    // the ring small (~37KB for 12x256) instead of the pre-fix ~590KB, which
+    // would not even fit in this board's free internal SRAM.
+    mRemote->bind("measureParlio", [this](const fl::json& args) -> fl::json {
+        fl::json response = fl::json::object();
+        int lanes = 12, leds = 256, iterations = 20;
+        fl::json cfg;
+        if (args.is_object()) {
+            cfg = args;
+        } else if (args.is_array() && args.size() >= 1 && args[0].is_object()) {
+            cfg = args[0];
+        }
+        if (!cfg.is_null()) {
+            if (cfg.contains("lanes") && cfg["lanes"].is_int()) {
+                lanes = static_cast<int>(cfg["lanes"].as_int().value());
+            }
+            if (cfg.contains("leds") && cfg["leds"].is_int()) {
+                leds = static_cast<int>(cfg["leds"].as_int().value());
+            }
+            if (cfg.contains("iterations") && cfg["iterations"].is_int()) {
+                iterations = static_cast<int>(cfg["iterations"].as_int().value());
+            }
+        }
+        if (lanes < 1 || lanes > 16 || leds < 1 || leds > 2048 || iterations < 1) {
+            response.set("success", false);
+            response.set("error", "InvalidArgs");
+            response.set("message", "lanes 1-16, leds 1-2048, iterations>=1");
+            return response;
+        }
+        if (!autoResearchSetExclusiveDriverByName("PARLIO")) {
+            response.set("success", false);
+            response.set("error", "DriverSetupFailed");
+            response.set("message", "Failed to set PARLIO exclusive");
+            return response;
+        }
+
+        fl::HeapInfo h_idle = fl::getFreeHeap();
+
+        fl::vector<fl::unique_ptr<fl::vector<CRGB>>> led_arrays;
+        fl::vector<fl::ChannelPtr> channels;
+        for (int li = 0; li < lanes; li++) {
+            auto buf = fl::make_unique<fl::vector<CRGB>>(leds);
+            for (int i = 0; i < leds; i++) {
+                (*buf)[i] = CRGB(0x10, 0x20, 0x40);
+            }
+            fl::ChannelOptions opts;
+            opts.mBus = fl::Bus::PARLIO;
+            fl::ChannelConfig channel_config(
+                mState->pin_tx + li,
+                fl::makeTimingConfig<fl::TIMING_WS2812B_V5>(),
+                fl::span<CRGB>(buf->data(), buf->size()),
+                RGB,
+                opts
+            );
+            auto ch = FastLED.add(channel_config);
+            if (!ch) {
+                FastLED.clear(ClearFlags::CHANNELS);
+                response.set("success", false);
+                response.set("error", "ChannelCreationFailed");
+                fl::sstream m;
+                m << "lane " << li << " add failed (free_sram=" << h_idle.free_sram << ")";
+                response.set("message", m.str().c_str());
+                return response;
+            }
+            channels.push_back(ch);
+            led_arrays.push_back(fl::move(buf));
+        }
+
+        // Warmup show allocates the DMA ring buffer.
+        FastLED.show();
+        FastLED.wait(5000);
+        fl::HeapInfo h_alloc = fl::getFreeHeap();
+
+        uint32_t show_min = 0xFFFFFFFFu;
+        uint32_t show_max = 0;
+        uint32_t show_sum = 0;
+        uint32_t total_sum = 0;
+        for (int it = 0; it < iterations; it++) {
+            uint32_t t0 = micros();
+            FastLED.show();
+            uint32_t t1 = micros();
+            FastLED.wait(5000);
+            uint32_t t2 = micros();
+            uint32_t s = t1 - t0;
+            uint32_t tt = t2 - t0;
+            if (s < show_min) {
+                show_min = s;
+            }
+            if (s > show_max) {
+                show_max = s;
+            }
+            show_sum += s;
+            total_sum += tt;
+        }
+
+        FastLED.clear(ClearFlags::CHANNELS);
+        fl::HeapInfo h_free = fl::getFreeHeap();
+
+        int64_t alloc_bytes =
+            static_cast<int64_t>(h_idle.free_sram) - static_cast<int64_t>(h_alloc.free_sram);
+        int64_t alloc_psram_bytes =
+            static_cast<int64_t>(h_idle.free_psram) - static_cast<int64_t>(h_alloc.free_psram);
+
+        response.set("success", true);
+        response.set("lanes", static_cast<int64_t>(lanes));
+        response.set("leds_per_lane", static_cast<int64_t>(leds));
+        response.set("iterations", static_cast<int64_t>(iterations));
+        response.set("free_sram_idle", static_cast<int64_t>(h_idle.free_sram));
+        response.set("free_sram_allocated", static_cast<int64_t>(h_alloc.free_sram));
+        response.set("free_sram_after_free", static_cast<int64_t>(h_free.free_sram));
+        response.set("alloc_sram_bytes", alloc_bytes);
+        response.set("free_psram_idle", static_cast<int64_t>(h_idle.free_psram));
+        response.set("free_psram_allocated", static_cast<int64_t>(h_alloc.free_psram));
+        response.set("alloc_psram_bytes", alloc_psram_bytes);
+        response.set("show_min_us", static_cast<int64_t>(show_min));
+        response.set("show_avg_us",
+                     static_cast<int64_t>(show_sum / static_cast<uint32_t>(iterations)));
+        response.set("show_max_us", static_cast<int64_t>(show_max));
+        response.set("total_avg_us",
+                     static_cast<int64_t>(total_sum / static_cast<uint32_t>(iterations)));
         return response;
     });
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -86,6 +86,7 @@ build_flags =
   ${env:generic-esp.build_flags}
 
   -D ARDUINO_USB_MODE=1
+  -D ARDUINO_USB_CDC_ON_BOOT=1
 board_build.partitions = huge_app.csv
 
 [env:esp32c3]

--- a/src/platforms/esp/32/drivers/parlio/parlio_buffer_calc.h
+++ b/src/platforms/esp/32/drivers/parlio/parlio_buffer_calc.h
@@ -194,8 +194,8 @@ struct ParlioBufferCalculator {
     ///
     /// Algorithm:
     /// 1. Calculate LEDs per buffer: maxLedsPerChannel / numRingBuffers
-    /// 2. Convert to input bytes: LEDs × 3 bytes/LED × mDataWidth (multi-lane)
-    /// 3. Apply wave8 expansion (8:1 ratio): input_bytes × outputBytesPerInputByte()
+    /// 2. Convert to per-lane input bytes: LEDs × 3 bytes/LED
+    /// 3. Apply PARLIO expansion: input_bytes × outputBytesPerInputByte()
     /// 4. Add reset padding bytes (only to last buffer in stream)
     /// 5. Add safety margin for boundary checks
     /// 6. Result is DMA buffer capacity per ring buffer
@@ -216,7 +216,10 @@ struct ParlioBufferCalculator {
         // (hardware limitation). This gap corrupts WS2812 signal timing and
         // causes bit-shift errors in all LEDs after the transition point.
         // By fitting all data in one buffer, we avoid transitions entirely.
-        size_t totalInputBytes = maxLedsPerChannel * 3 * mDataWidth;
+        // The engine streams byte positions across all lanes. Its input byte
+        // count is therefore bytes per lane, while outputBytesPerInputByte()
+        // already accounts for mDataWidth during waveform transposition.
+        size_t totalInputBytes = maxLedsPerChannel * 3;
         size_t fullFrameDmaSize = dmaBufferSize(totalInputBytes, reset_us);
 
         if (fullFrameDmaSize + safetyMargin <= perBufferCap) {
@@ -227,7 +230,7 @@ struct ParlioBufferCalculator {
         // Full frame doesn't fit - fall back to streaming with multiple ring buffers.
         // This path has the ~20µs DMA gap between buffers (unavoidable hardware limitation).
         size_t ledsPerBuffer = (maxLedsPerChannel + numRingBuffers - 1) / numRingBuffers;
-        size_t inputBytesPerBuffer = ledsPerBuffer * 3 * mDataWidth;
+        size_t inputBytesPerBuffer = ledsPerBuffer * 3;
         size_t dmaBufferCapacity = dmaBufferSize(inputBytesPerBuffer, reset_us);
 
         if (dmaBufferCapacity > perBufferCap) {

--- a/src/platforms/esp/32/drivers/parlio/parlio_engine.cpp.hpp
+++ b/src/platforms/esp/32/drivers/parlio/parlio_engine.cpp.hpp
@@ -200,8 +200,9 @@ calculateBufferByteCount(const BufferPopulationParams& params) FL_NOEXCEPT {
     size_t bytes_per_buffer = (params.totalBytes + effective_ring_count - 1)
                               / effective_ring_count;
 
-    // LED boundary alignment constant: 3 bytes (RGB) × lane count
-    size_t bytes_per_led_all_lanes = 3 * params.dataWidth;
+    // LED boundary alignment constant. totalBytes is bytes per lane, so one
+    // LED boundary is 3 RGB bytes; output expansion accounts for dataWidth.
+    size_t bytes_per_led_all_lanes = 3;
 
     // Calculate maximum input bytes that fit in one buffer
     // (reuse calc object from above to avoid duplication)
@@ -715,9 +716,6 @@ ParlioEngine::workerIsrCallback(void *user_data) FL_NOEXCEPT {
         return;  // No data to process
     }
 
-    // Zero output buffer (ISR-safe memset)
-    fl::isr::memset_zero(outputBuffer, self->mRingBufferCapacity);
-
     // Generate waveform data
     size_t outputBytesWritten = 0;
     if (!self->populateDmaBuffer(outputBuffer, self->mRingBufferCapacity,
@@ -819,8 +817,9 @@ ParlioEngine::populateDmaBuffer(u8* outputBuffer,
             return false;
         }
 
-        // Buffer is already pre-zeroed by caller (fl::isr::memset_zero)
-        // Just advance the index to skip over the front padding region
+        if (front_padding_total > 0) {
+            fl::isr::memset_zero(outputBuffer + outputIdx, front_padding_total);
+        }
         outputIdx += front_padding_total;
     }
 
@@ -1022,7 +1021,7 @@ ParlioEngine::populateDmaBuffer(u8* outputBuffer,
             return false;
         }
 
-        // Buffer is already pre-zeroed by caller, just advance index
+        fl::isr::memset_zero(outputBuffer + outputIdx, back_padding_total);
         outputIdx += back_padding_total;
     }
 
@@ -1045,7 +1044,7 @@ ParlioEngine::populateDmaBuffer(u8* outputBuffer,
         }
 
         // Append all-zero bytes (LOW signal for reset duration)
-        // Buffer is already pre-zeroed by caller, so we just advance the index
+        fl::isr::memset_zero(outputBuffer + outputIdx, reset_padding_bytes);
         outputIdx += reset_padding_bytes;
     }
 
@@ -1200,10 +1199,6 @@ ParlioEngine::populateNextDMABuffer() FL_NOEXCEPT {
     if (mIsrContext->mNextByteOffset + byte_count > mIsrContext->mTotalBytes) {
         byte_count = mIsrContext->mTotalBytes - mIsrContext->mNextByteOffset;
     }
-
-    // Zero output buffer to prevent garbage data from previous use
-    // Use ISR-safe memset since this function may be called from workerIsr()
-    fl::isr::memset_zero(outputBuffer, mRingBufferCapacity);
 
     // Generate waveform data using helper function
     size_t outputBytesWritten = 0;

--- a/src/platforms/esp/32/drivers/parlio/parlio_engine.cpp.hpp
+++ b/src/platforms/esp/32/drivers/parlio/parlio_engine.cpp.hpp
@@ -301,7 +301,9 @@ ParlioEngine::ParlioEngine() FL_NOEXCEPT
       mLaneStride(0),
       mErrorOccurred(false),
       mTxUnitEnabled(false),
-      mMaxLedsPerChannel(0) {
+      mMaxLedsPerChannel(0),
+      mActiveSlot(0),
+      mOverlapArmed(false) {
     FL_LOG_PARLIO("PARLIO_INIT: Constructor entered");
 }
 
@@ -1738,7 +1740,14 @@ bool ParlioEngine::beginTransmission(const u8* scratchBuffer,
     // The ESP-IDF PARLIO driver's internal DMA queue may still have the last buffer
     // queued even after our ISR context shows mStreamComplete=true. Without this,
     // consecutive transmissions with the same config fail silently (0 bytes output).
-    if (mTxUnitEnabled) {
+    //
+    // PING-PONG OVERLAP (Approach A): when the previous frame used the single-
+    // full-frame fast path (mOverlapArmed), its sole in-flight buffer occupies the
+    // OTHER ping-pong slot, so we DEFER this drain until after encoding frame N
+    // into mActiveSlot. That overlaps encode(N) with wire(N-1). When not armed
+    // (first frame, or previous frame used the streaming path) we drain here
+    // first, exactly as before.
+    if (mTxUnitEnabled && !mOverlapArmed) {
         mPeripheral->waitAllDone(100);  // 100ms timeout - should be near-instant
     }
 
@@ -1793,9 +1802,14 @@ bool ParlioEngine::beginTransmission(const u8* scratchBuffer,
     mErrorOccurred = false;
     mIsrContext->mTransmitting = false; // Will be set to true after first buffer submitted
 
-    // Initialize ring buffer indices and count
-    mIsrContext->mRingReadIdx = 0;
-    mIsrContext->mRingWriteIdx = 0;
+    // Initialize ring buffer indices and count.
+    // Ping-pong: encoding (and the first submit) begin at mActiveSlot rather than
+    // a hardcoded slot 0. For the single-full-frame path this selects the slot NOT
+    // currently in flight. For the streaming path mActiveSlot is always 0 (it is
+    // never advanced unless a single-frame completes), so this is a no-op there and
+    // the buffer layout/shape is byte-identical to before.
+    mIsrContext->mRingReadIdx = mActiveSlot;
+    mIsrContext->mRingWriteIdx = mActiveSlot;
     mIsrContext->mRingCount = 0;
     mIsrContext->mRingError = false;
     mIsrContext->mHardwareIdle = false;
@@ -1814,10 +1828,23 @@ bool ParlioEngine::beginTransmission(const u8* scratchBuffer,
     mIsrContext->mDebugLastTxDoneTime = 0;
     mIsrContext->mDebugLastWorkerIsrTime = 0;
 
-    // Pre-populate ring buffers (fill all buffers if possible)
+    // Pre-populate ring buffers (fill all buffers if possible).
     FL_LOG_PARLIO("PARLIO_TX: Pre-populating ring buffers - mScratchBuffer=" << (void*)mScratchBuffer << " stride=" << mLaneStride);
-    while (hasRingSpace() && populateNextDMABuffer()) {
-        // Buffer populated into ring
+    //
+    // PING-PONG SAFETY: the FIRST buffer is encoded into mActiveSlot, which is the
+    // slot a prior single-frame transmission is NOT using, so it is always safe to
+    // encode it before draining. If more bytes remain after this first buffer we are
+    // on the STREAMING path, where subsequent buffers wrap through every slot and
+    // could collide with the still-in-flight buffer. In that case honor the deferred
+    // drain NOW -- before populating any further buffer -- which restores the exact
+    // original drain-first ordering for streaming.
+    bool more_data = (hasRingSpace() && populateNextDMABuffer());
+    if (more_data && mTxUnitEnabled && mOverlapArmed) {
+        mPeripheral->waitAllDone(100);  // 100ms timeout - should be near-instant
+        mOverlapArmed = false;  // Drained early; the pre-submit deferred drain is now a no-op
+    }
+    while (more_data && hasRingSpace()) {
+        more_data = populateNextDMABuffer();  // Buffer populated into ring
     }
 
     // Get actual number of buffers populated
@@ -1836,6 +1863,18 @@ bool ParlioEngine::beginTransmission(const u8* scratchBuffer,
         FL_LOG_PARLIO("PARLIO: No buffers populated - cannot start transmission");
         mErrorOccurred = true;
         return false;
+    }
+
+    // DEFERRED DRAIN (ping-pong overlap): if we skipped the top-of-function drain
+    // because the previous frame used the single-full-frame fast path (mOverlapArmed),
+    // frame N has now been fully ENCODED into mActiveSlot while frame N-1 was still on
+    // the wire in the OTHER slot -- that is the encode(N)/wire(N-1) overlap. Drain it
+    // here, BEFORE the disable/enable cycle below: parlio_tx_unit_disable() aborts any
+    // in-flight DMA, so frame N-1 must be fully on the wire first. (Streaming frames
+    // already drained inside the populate loop and cleared mOverlapArmed, so this is a
+    // no-op for them -- identical to the original drain-first ordering.)
+    if (mTxUnitEnabled && mOverlapArmed) {
+        mPeripheral->waitAllDone(100);  // 100ms timeout - should be near-instant
     }
 
     // CRITICAL: Always disable and re-enable the PARLIO peripheral between transmissions.
@@ -1857,11 +1896,24 @@ bool ParlioEngine::beginTransmission(const u8* scratchBuffer,
     mTxUnitEnabled = true;
     FL_LOG_PARLIO("PARLIO_TX: Peripheral enabled successfully");
 
+    // The first buffer to submit lives in mActiveSlot (the ping-pong slot we
+    // encoded into). Capture it now; everything below is expressed relative to it
+    // so the streaming path (mActiveSlot==0) is byte-identical to the old code.
+    size_t first_slot = mActiveSlot;
+    size_t next_read_idx = (first_slot + 1) % ParlioRingBuffer3::RING_BUFFER_COUNT;
+
+    // Detect the single-full-frame fast path: the whole frame fit in ONE buffer
+    // (populateNextDMABuffer consumed all source bytes in one call). Only this
+    // path participates in frame-level ping-pong overlap; the multi-chunk
+    // streaming path falls back to the original drain-first behavior.
+    bool is_single_frame = (buffers_populated == 1 &&
+                            mIsrContext->mNextByteOffset >= mIsrContext->mTotalBytes);
+
     // Queue first buffer to start transmission
     FL_LOG_PARLIO("PARLIO: Starting ISR-based streaming | first_buffer_size="
-           << mRingBuffer->sizes[0] << " | buffers_ready=" << buffers_populated);
+           << mRingBuffer->sizes[first_slot] << " | buffers_ready=" << buffers_populated);
 
-    size_t first_buffer_size = mRingBuffer->sizes[0];
+    size_t first_buffer_size = mRingBuffer->sizes[first_slot];
     FL_LOG_PARLIO("PARLIO_TX: Starting transmission - first_buffer=" << first_buffer_size << " bytes, buffers_ready=" << buffers_populated);
 
     // CRITICAL FIX: Mark transmission started BEFORE submitting buffer
@@ -1870,20 +1922,35 @@ bool ParlioEngine::beginTransmission(const u8* scratchBuffer,
 
     // CRITICAL FIX (Iteration 2): Advance read index BEFORE submitting first buffer
     // This prevents race condition where txDone fires before index is advanced
-    // Root cause: If txDone fires with read_idx=0, it calculates wrong completed_buffer_idx
-    mIsrContext->mRingReadIdx = 1;
+    // Root cause: If txDone fires before read_idx is advanced past first_slot, it
+    // calculates the wrong completed_buffer_idx.
+    mIsrContext->mRingReadIdx = next_read_idx;
     mIsrContext->mRingCount = buffers_populated - 1;
     FL_MEMORY_BARRIER;
 
-    if (!mPeripheral->transmit(mRingBuffer->ptrs[0], first_buffer_size * 8, 0x0000)) {
+    if (!mPeripheral->transmit(mRingBuffer->ptrs[first_slot], first_buffer_size * 8, 0x0000)) {
         FL_LOG_PARLIO("PARLIO: Failed to queue first buffer");
         mIsrContext->mTransmitting = false;  // Rollback flag on error
-        mIsrContext->mRingReadIdx = 0;  // Rollback index on error
+        mIsrContext->mRingReadIdx = first_slot;  // Rollback index on error
         mIsrContext->mRingCount = buffers_populated;  // Rollback count on error
+        mOverlapArmed = false;  // Force the next frame to drain-first after an error
         mErrorOccurred = true;
         return false;
     }
     FL_LOG_PARLIO("PARLIO_TX: First buffer submitted successfully - transmission started");
+
+    // Ping-pong bookkeeping (post-submit, frame N is now in flight in first_slot):
+    //  - single-frame fast path: flip mActiveSlot to the other slot so frame N+1
+    //    encodes there while frame N drains, and arm the deferred-drain overlap.
+    //  - streaming path: pin mActiveSlot back to 0 and disarm, so the next frame
+    //    drains-first and starts at slot 0 exactly like the original logic.
+    if (is_single_frame) {
+        mActiveSlot ^= 1;       // 0 <-> 1
+        mOverlapArmed = true;
+    } else {
+        mActiveSlot = 0;
+        mOverlapArmed = false;
+    }
 
     //=========================================================================
     // Worker function now called directly from txDoneCallback (one-shot pattern)

--- a/src/platforms/esp/32/drivers/parlio/parlio_engine.h
+++ b/src/platforms/esp/32/drivers/parlio/parlio_engine.h
@@ -335,6 +335,20 @@ private:
     // Maximum LEDs per channel used to size ring buffers
     // Used to detect when ring buffers need reallocation (new test has more LEDs)
     size_t mMaxLedsPerChannel;
+
+    // Frame-level ping-pong slot (0/1) for the single-full-frame fast path.
+    // beginTransmission() encodes frame N into mActiveSlot while frame N-1 is
+    // still draining from the other slot, then flips. Distinct slots guarantee
+    // we never encode into an in-flight DMA buffer. Only used when the whole
+    // frame fits in one ring buffer; the multi-chunk streaming path ignores it.
+    size_t mActiveSlot;
+
+    // True iff the previously-submitted frame used the single-full-frame fast
+    // path (exactly one buffer, occupying the OTHER ping-pong slot). Only then
+    // is it safe to encode frame N before draining frame N-1, because the sole
+    // in-flight buffer is guaranteed to be the slot we are NOT writing to. The
+    // streaming path clears this so the next frame drains-first (unchanged).
+    bool mOverlapArmed;
 };
 
 } // namespace detail

--- a/tests/platforms/esp/32/drivers/parlio/parlio_driver.cpp
+++ b/tests/platforms/esp/32/drivers/parlio/parlio_driver.cpp
@@ -2090,9 +2090,9 @@ FL_TEST_CASE("ParlioBufferCalculator - calculateRingBufferCapacity") {
     FL_SUBCASE("10 LEDs, 4 lanes, 3 ring buffers, no reset") {
         ParlioBufferCalculator calc{4};
         size_t capacity = calc.calculateRingBufferCapacity(10, 0, 3);
-        // Full frame fits in one buffer: dmaBufferSize(120, 0) + 128
-        // = (32 + 120*32 + 0) + 128 = 3872 + 128 = 4000
-        FL_CHECK(capacity == 4000);
+        // Full frame fits in one buffer: dmaBufferSize(30, 0) + 128
+        // = (32 + 30*32 + 0) + 128 = 992 + 128 = 1120
+        FL_CHECK(capacity == 1120);
     }
 
     FL_SUBCASE("single LED, single lane, 3 ring buffers") {
@@ -2107,6 +2107,16 @@ FL_TEST_CASE("ParlioBufferCalculator - calculateRingBufferCapacity") {
         // Full frame fits in one buffer: dmaBufferSize(9000, 280) + 128
         // = (8 + 9000*8 + 280) + 128 = 72288 + 128 = 72416
         FL_CHECK(capacity == 72416);
+    }
+
+    FL_SUBCASE("256 LEDs, 16-lane Wave3, 280us reset") {
+        ParlioBufferCalculator calc(16, true, 2400000);
+        size_t capacity = calc.calculateRingBufferCapacity(256, 280, 3,
+                                                           FASTLED_PARLIO_MAX_RING_BUFFER_TOTAL_BYTES_PSRAM);
+        // Full frame fits in one buffer using per-lane input bytes:
+        // dmaBufferSize(768, 280) + 128
+        // = (48 + 768*48 + 84) + 128 = 36996 + 128 = 37124
+        FL_CHECK(capacity == 37124);
     }
 }
 


### PR DESCRIPTION
**Draft / do-not-merge.** Scaffolds Approach A from #2518 (frame-level ping-pong double-buffer) AND documents the hardware finding that it does **not** deliver the projected speedup, with the identified root cause.

## What this does
- `parlio_engine`: encode frame N into the inactive ping-pong slot while frame N-1 drains, reusing **2 of the 3 already-allocated** full-frame DMA buffers (**zero new memory**). Guarded by `mOverlapArmed` so only the single-full-frame fast path overlaps; the multi-chunk streaming path is byte-identical to before. Safety: frame N never encodes into the in-flight buffer.
- `examples/AutoResearch`: adds a `measureParlio` `pipelined_per_frame_us` metric (tight `show()` loop, single drain) to measure overlap directly, plus `free_sram`/`free_psram` on `ping`.

## Hardware result (ESP32-P4, 16×256, debug build) — NO speedup
```
pipelined_per_frame_us = 31772   ==   total_avg_us (serialized show+wait) = 31772
show_avg_us = 25449 (encode)     wait/wire ≈ 6.3ms
```
Every `show()` still costs encode(~25ms)+wire(~6ms). Frame N-1's DMA is **not** draining during frame N's encode, so the ping-pong buffers don't pipeline.

## Root cause
`beginTransmission()` performs a **mandatory per-frame `disable()/enable()`** of the PARLIO peripheral ("required to reset the DMA state machine; without it consecutive transmissions silently fail"). That teardown serializes frames at the hardware level — N-1 cannot keep transmitting while N is reconfigured. **Ping-pong buffering alone cannot overcome this.**

## Implications for #2518
- The earlier "+24%" projection for Approach A is **not realized**; the current single-buffer path is effectively the practical maximum for the present driver structure + memory.
- Real frame-level overlap needs a deeper change: avoid/relax the per-frame `disable()/enable()` so the peripheral can pipeline (or make the encoder faster via SIMD/2nd core). Tracked in #2518.

## Validation status
- Compiles (host + P4). No regression: 60+ `show()` iterations stable, identical memory.
- ⚠️ WS2812 **signal** correctness NOT validated — the EV board's RX loopback (GPIO5→6) is not wired. Required before any merge.

Stacks on #2519 (PARLIO buffer-sizing fix) and the autoresearch P4 enablement branch.