### PR TITLE
perf(wave): fastest unrolled-naive 8/16-lane transpose + equivalence tests

### DIFF
--- a/src/fl/channels/detail/wave3.hpp
+++ b/src/fl/channels/detail/wave3.hpp
@@ -139,42 +139,34 @@ void wave3_transpose_4(const Wave3Byte lane_waves[4],
 /// @brief Transpose 8 lanes of Wave3Byte data into interleaved format
 /// @param lane_waves Array of 8 Wave3Byte structures
 /// @param output Output buffer (24 bytes = 8 * 3)
+///
+/// Fully-unrolled naive bit-by-bit transpose — benchmarked (#2524) as the
+/// fastest variant on the ESP32-P4 (RV32), beating a u32 Hacker's-Delight 8x8.
 FASTLED_FORCE_INLINE FL_IRAM FL_OPTIMIZE_FUNCTION
 void wave3_transpose_8(const Wave3Byte lane_waves[8],
                        u8 output[8 * sizeof(Wave3Byte)]) {
-    // For 8 lanes, each symbol produces 8 bytes (1 byte per pulse, 8 pulses per symbol)
-    // Use Hacker's Delight 8x8 transpose like wave8
     for (int symbol_idx = 0; symbol_idx < 3; symbol_idx++) {
-        u8 lane_bytes[8];
-        for (int lane = 0; lane < 8; lane++) {
-            lane_bytes[lane] = lane_waves[lane].data[symbol_idx];
-        }
-
-        u32 x, y, t;
-        isr::memcpy_32(&y, reinterpret_cast<const u32*>(lane_bytes), 1);       // ok reinterpret cast - lanes 0-3
-        isr::memcpy_32(&x, reinterpret_cast<const u32*>(lane_bytes + 4), 1);   // ok reinterpret cast - lanes 4-7
-
-        t = (x ^ (x >> 7)) & 0x00AA00AA;  x = x ^ t ^ (t << 7);
-        t = (x ^ (x >> 14)) & 0x0000CCCC;  x = x ^ t ^ (t << 14);
-        t = (y ^ (y >> 7)) & 0x00AA00AA;  y = y ^ t ^ (t << 7);
-        t = (y ^ (y >> 14)) & 0x0000CCCC;  y = y ^ t ^ (t << 14);
-        t = (x & 0xF0F0F0F0) | ((y >> 4) & 0x0F0F0F0F);
-        y = ((x << 4) & 0xF0F0F0F0) | (y & 0x0F0F0F0F);
-        x = t;
-
-        isr::memcpy_32(reinterpret_cast<u32*>(output + symbol_idx * 8), &y, 1);     // ok reinterpret cast - output byte array to u32
-        isr::memcpy_32(reinterpret_cast<u32*>(output + symbol_idx * 8 + 4), &x, 1); // ok reinterpret cast - output byte array to u32
-
-        // Reverse byte order within symbol block: Hacker's Delight transpose
-        // puts column N at output[N], but bit 7 (MSB) is the first clock pulse
-        // and bit 0 (LSB) is the last. PARLIO sends output[0] first, so without
-        // reversal the waveform is time-reversed (last pulse sent first).
-        u8* blk = output + symbol_idx * 8;
-        u8 tmp;
-        tmp = blk[0]; blk[0] = blk[7]; blk[7] = tmp;
-        tmp = blk[1]; blk[1] = blk[6]; blk[6] = tmp;
-        tmp = blk[2]; blk[2] = blk[5]; blk[5] = tmp;
-        tmp = blk[3]; blk[3] = blk[4]; blk[4] = tmp;
+        const u8 l0 = lane_waves[0].data[symbol_idx];
+        const u8 l1 = lane_waves[1].data[symbol_idx];
+        const u8 l2 = lane_waves[2].data[symbol_idx];
+        const u8 l3 = lane_waves[3].data[symbol_idx];
+        const u8 l4 = lane_waves[4].data[symbol_idx];
+        const u8 l5 = lane_waves[5].data[symbol_idx];
+        const u8 l6 = lane_waves[6].data[symbol_idx];
+        const u8 l7 = lane_waves[7].data[symbol_idx];
+        u8* out = &output[symbol_idx * 8];
+#define FL_W3_PULSE(b) static_cast<u8>(((l7 >> (b)) & 1) << 7 | ((l6 >> (b)) & 1) << 6 | \
+    ((l5 >> (b)) & 1) << 5 | ((l4 >> (b)) & 1) << 4 | ((l3 >> (b)) & 1) << 3 | \
+    ((l2 >> (b)) & 1) << 2 | ((l1 >> (b)) & 1) << 1 | ((l0 >> (b)) & 1))
+        out[0] = FL_W3_PULSE(7);
+        out[1] = FL_W3_PULSE(6);
+        out[2] = FL_W3_PULSE(5);
+        out[3] = FL_W3_PULSE(4);
+        out[4] = FL_W3_PULSE(3);
+        out[5] = FL_W3_PULSE(2);
+        out[6] = FL_W3_PULSE(1);
+        out[7] = FL_W3_PULSE(0);
+#undef FL_W3_PULSE
     }
 }
 
@@ -185,69 +177,47 @@ void wave3_transpose_8(const Wave3Byte lane_waves[8],
 /// @brief Transpose 16 lanes of Wave3Byte data into interleaved format
 /// @param lane_waves Array of 16 Wave3Byte structures
 /// @param output Output buffer (48 bytes = 16 * 3)
+///
+/// Fully-unrolled naive bit-by-bit transpose — benchmarked (#2524) as the
+/// fastest on the ESP32-P4 (RV32), beating two-pass/SWAR. Each 16-lane sample
+/// is 2 output bytes: low = lanes 0-7, high = lanes 8-15.
 FASTLED_FORCE_INLINE FL_IRAM FL_OPTIMIZE_FUNCTION
 void wave3_transpose_16(const Wave3Byte lane_waves[16],
                         u8 output[16 * sizeof(Wave3Byte)]) {
     for (int symbol_idx = 0; symbol_idx < 3; symbol_idx++) {
-        const u8 l0  = lane_waves[0].data[symbol_idx];
-        const u8 l1  = lane_waves[1].data[symbol_idx];
-        const u8 l2  = lane_waves[2].data[symbol_idx];
-        const u8 l3  = lane_waves[3].data[symbol_idx];
-        const u8 l4  = lane_waves[4].data[symbol_idx];
-        const u8 l5  = lane_waves[5].data[symbol_idx];
-        const u8 l6  = lane_waves[6].data[symbol_idx];
-        const u8 l7  = lane_waves[7].data[symbol_idx];
-        const u8 l8  = lane_waves[8].data[symbol_idx];
-        const u8 l9  = lane_waves[9].data[symbol_idx];
+        const u8 l0 = lane_waves[0].data[symbol_idx];
+        const u8 l1 = lane_waves[1].data[symbol_idx];
+        const u8 l2 = lane_waves[2].data[symbol_idx];
+        const u8 l3 = lane_waves[3].data[symbol_idx];
+        const u8 l4 = lane_waves[4].data[symbol_idx];
+        const u8 l5 = lane_waves[5].data[symbol_idx];
+        const u8 l6 = lane_waves[6].data[symbol_idx];
+        const u8 l7 = lane_waves[7].data[symbol_idx];
+        const u8 l8 = lane_waves[8].data[symbol_idx];
+        const u8 l9 = lane_waves[9].data[symbol_idx];
         const u8 l10 = lane_waves[10].data[symbol_idx];
         const u8 l11 = lane_waves[11].data[symbol_idx];
         const u8 l12 = lane_waves[12].data[symbol_idx];
         const u8 l13 = lane_waves[13].data[symbol_idx];
         const u8 l14 = lane_waves[14].data[symbol_idx];
         const u8 l15 = lane_waves[15].data[symbol_idx];
-
         u8* out = &output[symbol_idx * 16];
-
-        // 8 pulses per symbol, 2 bytes per pulse (low byte = lanes 0-7, high byte = lanes 8-15)
-        out[0] = ((l7  >> 7) & 1) << 7 | ((l6  >> 7) & 1) << 6 | ((l5  >> 7) & 1) << 5 | ((l4  >> 7) & 1) << 4 |
-                 ((l3  >> 7) & 1) << 3 | ((l2  >> 7) & 1) << 2 | ((l1  >> 7) & 1) << 1 | ((l0  >> 7) & 1);
-        out[1] = ((l15 >> 7) & 1) << 7 | ((l14 >> 7) & 1) << 6 | ((l13 >> 7) & 1) << 5 | ((l12 >> 7) & 1) << 4 |
-                 ((l11 >> 7) & 1) << 3 | ((l10 >> 7) & 1) << 2 | ((l9  >> 7) & 1) << 1 | ((l8  >> 7) & 1);
-
-        out[2] = ((l7  >> 6) & 1) << 7 | ((l6  >> 6) & 1) << 6 | ((l5  >> 6) & 1) << 5 | ((l4  >> 6) & 1) << 4 |
-                 ((l3  >> 6) & 1) << 3 | ((l2  >> 6) & 1) << 2 | ((l1  >> 6) & 1) << 1 | ((l0  >> 6) & 1);
-        out[3] = ((l15 >> 6) & 1) << 7 | ((l14 >> 6) & 1) << 6 | ((l13 >> 6) & 1) << 5 | ((l12 >> 6) & 1) << 4 |
-                 ((l11 >> 6) & 1) << 3 | ((l10 >> 6) & 1) << 2 | ((l9  >> 6) & 1) << 1 | ((l8  >> 6) & 1);
-
-        out[4] = ((l7  >> 5) & 1) << 7 | ((l6  >> 5) & 1) << 6 | ((l5  >> 5) & 1) << 5 | ((l4  >> 5) & 1) << 4 |
-                 ((l3  >> 5) & 1) << 3 | ((l2  >> 5) & 1) << 2 | ((l1  >> 5) & 1) << 1 | ((l0  >> 5) & 1);
-        out[5] = ((l15 >> 5) & 1) << 7 | ((l14 >> 5) & 1) << 6 | ((l13 >> 5) & 1) << 5 | ((l12 >> 5) & 1) << 4 |
-                 ((l11 >> 5) & 1) << 3 | ((l10 >> 5) & 1) << 2 | ((l9  >> 5) & 1) << 1 | ((l8  >> 5) & 1);
-
-        out[6] = ((l7  >> 4) & 1) << 7 | ((l6  >> 4) & 1) << 6 | ((l5  >> 4) & 1) << 5 | ((l4  >> 4) & 1) << 4 |
-                 ((l3  >> 4) & 1) << 3 | ((l2  >> 4) & 1) << 2 | ((l1  >> 4) & 1) << 1 | ((l0  >> 4) & 1);
-        out[7] = ((l15 >> 4) & 1) << 7 | ((l14 >> 4) & 1) << 6 | ((l13 >> 4) & 1) << 5 | ((l12 >> 4) & 1) << 4 |
-                 ((l11 >> 4) & 1) << 3 | ((l10 >> 4) & 1) << 2 | ((l9  >> 4) & 1) << 1 | ((l8  >> 4) & 1);
-
-        out[8] = ((l7  >> 3) & 1) << 7 | ((l6  >> 3) & 1) << 6 | ((l5  >> 3) & 1) << 5 | ((l4  >> 3) & 1) << 4 |
-                 ((l3  >> 3) & 1) << 3 | ((l2  >> 3) & 1) << 2 | ((l1  >> 3) & 1) << 1 | ((l0  >> 3) & 1);
-        out[9] = ((l15 >> 3) & 1) << 7 | ((l14 >> 3) & 1) << 6 | ((l13 >> 3) & 1) << 5 | ((l12 >> 3) & 1) << 4 |
-                 ((l11 >> 3) & 1) << 3 | ((l10 >> 3) & 1) << 2 | ((l9  >> 3) & 1) << 1 | ((l8  >> 3) & 1);
-
-        out[10] = ((l7  >> 2) & 1) << 7 | ((l6  >> 2) & 1) << 6 | ((l5  >> 2) & 1) << 5 | ((l4  >> 2) & 1) << 4 |
-                  ((l3  >> 2) & 1) << 3 | ((l2  >> 2) & 1) << 2 | ((l1  >> 2) & 1) << 1 | ((l0  >> 2) & 1);
-        out[11] = ((l15 >> 2) & 1) << 7 | ((l14 >> 2) & 1) << 6 | ((l13 >> 2) & 1) << 5 | ((l12 >> 2) & 1) << 4 |
-                  ((l11 >> 2) & 1) << 3 | ((l10 >> 2) & 1) << 2 | ((l9  >> 2) & 1) << 1 | ((l8  >> 2) & 1);
-
-        out[12] = ((l7  >> 1) & 1) << 7 | ((l6  >> 1) & 1) << 6 | ((l5  >> 1) & 1) << 5 | ((l4  >> 1) & 1) << 4 |
-                  ((l3  >> 1) & 1) << 3 | ((l2  >> 1) & 1) << 2 | ((l1  >> 1) & 1) << 1 | ((l0  >> 1) & 1);
-        out[13] = ((l15 >> 1) & 1) << 7 | ((l14 >> 1) & 1) << 6 | ((l13 >> 1) & 1) << 5 | ((l12 >> 1) & 1) << 4 |
-                  ((l11 >> 1) & 1) << 3 | ((l10 >> 1) & 1) << 2 | ((l9  >> 1) & 1) << 1 | ((l8  >> 1) & 1);
-
-        out[14] = ((l7  >> 0) & 1) << 7 | ((l6  >> 0) & 1) << 6 | ((l5  >> 0) & 1) << 5 | ((l4  >> 0) & 1) << 4 |
-                  ((l3  >> 0) & 1) << 3 | ((l2  >> 0) & 1) << 2 | ((l1  >> 0) & 1) << 1 | ((l0  >> 0) & 1);
-        out[15] = ((l15 >> 0) & 1) << 7 | ((l14 >> 0) & 1) << 6 | ((l13 >> 0) & 1) << 5 | ((l12 >> 0) & 1) << 4 |
-                  ((l11 >> 0) & 1) << 3 | ((l10 >> 0) & 1) << 2 | ((l9  >> 0) & 1) << 1 | ((l8  >> 0) & 1);
+#define FL_W3_LO(b) static_cast<u8>(((l7 >> (b)) & 1) << 7 | ((l6 >> (b)) & 1) << 6 | \
+    ((l5 >> (b)) & 1) << 5 | ((l4 >> (b)) & 1) << 4 | ((l3 >> (b)) & 1) << 3 | \
+    ((l2 >> (b)) & 1) << 2 | ((l1 >> (b)) & 1) << 1 | ((l0 >> (b)) & 1))
+#define FL_W3_HI(b) static_cast<u8>(((l15 >> (b)) & 1) << 7 | ((l14 >> (b)) & 1) << 6 | \
+    ((l13 >> (b)) & 1) << 5 | ((l12 >> (b)) & 1) << 4 | ((l11 >> (b)) & 1) << 3 | \
+    ((l10 >> (b)) & 1) << 2 | ((l9 >> (b)) & 1) << 1 | ((l8 >> (b)) & 1))
+        out[0] = FL_W3_LO(7);  out[1] = FL_W3_HI(7);
+        out[2] = FL_W3_LO(6);  out[3] = FL_W3_HI(6);
+        out[4] = FL_W3_LO(5);  out[5] = FL_W3_HI(5);
+        out[6] = FL_W3_LO(4);  out[7] = FL_W3_HI(4);
+        out[8] = FL_W3_LO(3);  out[9] = FL_W3_HI(3);
+        out[10] = FL_W3_LO(2); out[11] = FL_W3_HI(2);
+        out[12] = FL_W3_LO(1); out[13] = FL_W3_HI(1);
+        out[14] = FL_W3_LO(0); out[15] = FL_W3_HI(0);
+#undef FL_W3_LO
+#undef FL_W3_HI
     }
 }
 

--- a/src/fl/channels/detail/wave8.hpp
+++ b/src/fl/channels/detail/wave8.hpp
@@ -183,62 +183,37 @@ void wave8_transpose_4(const Wave8Byte lane_waves[4],
 /// @brief Transpose 8 lanes of Wave8Byte data into interleaved format
 /// @param lane_waves Array of 8 Wave8Byte structures
 /// @param output Output buffer (64 bytes)
+///
+/// Fully-unrolled naive bit-by-bit transpose. Benchmarked (#2524) as the
+/// fastest variant on the ESP32-P4 (RV32): 3336 vs 4680 us/frame for a u32
+/// Hacker's-Delight 8x8 — the compiler turns these independent shift/or ops
+/// into tight code, beating the latency-bound delta-swap chain on an in-order
+/// core. Each symbol is an 8-lane x 8-pulse bit matrix.
 FASTLED_FORCE_INLINE FL_IRAM FL_OPTIMIZE_FUNCTION
 void wave8_transpose_8(const Wave8Byte lane_waves[8],
                        u8 output[8 * sizeof(Wave8Byte)]) {
-    // Each symbol (Wave8Bit) has 8 pulses
-    // With 8 lanes, we produce 8 bytes per symbol (1 pulse per byte × 8 lanes)
-    // Output format: [L7_P7, L6_P7, ..., L0_P7, L7_P6, L6_P6, ..., L0_P6, ...]
-    //
-    // This implementation uses the Hacker's Delight 8x8 bit matrix transpose algorithm
-    // for optimal performance. For 8 lanes, this is the perfect fit since the output is
-    // exactly 8 bits wide (one bit per lane).
-
-    // Process each of the 8 symbols (Wave8Bit structures)
     for (int symbol_idx = 0; symbol_idx < 8; symbol_idx++) {
-        // Load 8 lane bytes for this symbol into a temporary array
-        u8 lane_bytes[8];
-        for (int lane = 0; lane < 8; lane++) {
-            lane_bytes[lane] = lane_waves[lane].symbols[symbol_idx].data;
-        }
-
-        // Apply Hacker's Delight 8x8 transpose algorithm inline
-        // This transposes the 8x8 bit matrix in ~6 XOR-shift operations
-        u32 x, y, t;
-
-        // Load the array and pack it into x and y (little-endian)
-        // Use ISR-safe memcpy32 for aligned 32-bit loads
-        isr::memcpy_32(&y, fl::bit_cast_ptr<const u32>(lane_bytes), 1);      // lanes 0-3
-        isr::memcpy_32(&x, fl::bit_cast_ptr<const u32>(lane_bytes + 4), 1);  // lanes 4-7
-
-        // Pre-transform x
-        t = (x ^ (x >> 7)) & 0x00AA00AA;  x = x ^ t ^ (t << 7);
-        t = (x ^ (x >> 14)) & 0x0000CCCC;  x = x ^ t ^ (t << 14);
-
-        // Pre-transform y
-        t = (y ^ (y >> 7)) & 0x00AA00AA;  y = y ^ t ^ (t << 7);
-        t = (y ^ (y >> 14)) & 0x0000CCCC;  y = y ^ t ^ (t << 14);
-
-        // Final transform
-        t = (x & 0xF0F0F0F0) | ((y >> 4) & 0x0F0F0F0F);
-        y = ((x << 4) & 0xF0F0F0F0) | (y & 0x0F0F0F0F);
-        x = t;
-
-        // Store result directly to output (little-endian)
-        // Use ISR-safe memcpy32 for aligned 32-bit stores
-        isr::memcpy_32(fl::bit_cast_ptr<u32>(output + symbol_idx * 8), &y, 1);
-        isr::memcpy_32(fl::bit_cast_ptr<u32>(output + symbol_idx * 8 + 4), &x, 1);
-
-        // Reverse byte order within symbol block: Hacker's Delight transpose
-        // puts column N at output[N], but bit 7 (MSB) is the first clock pulse
-        // and bit 0 (LSB) is the last. PARLIO sends output[0] first, so without
-        // reversal the waveform is time-reversed (last pulse sent first).
-        u8* blk = output + symbol_idx * 8;
-        u8 tmp;
-        tmp = blk[0]; blk[0] = blk[7]; blk[7] = tmp;
-        tmp = blk[1]; blk[1] = blk[6]; blk[6] = tmp;
-        tmp = blk[2]; blk[2] = blk[5]; blk[5] = tmp;
-        tmp = blk[3]; blk[3] = blk[4]; blk[4] = tmp;
+        const u8 l0 = lane_waves[0].symbols[symbol_idx].data;
+        const u8 l1 = lane_waves[1].symbols[symbol_idx].data;
+        const u8 l2 = lane_waves[2].symbols[symbol_idx].data;
+        const u8 l3 = lane_waves[3].symbols[symbol_idx].data;
+        const u8 l4 = lane_waves[4].symbols[symbol_idx].data;
+        const u8 l5 = lane_waves[5].symbols[symbol_idx].data;
+        const u8 l6 = lane_waves[6].symbols[symbol_idx].data;
+        const u8 l7 = lane_waves[7].symbols[symbol_idx].data;
+        u8* out = &output[symbol_idx * 8];
+#define FL_W8_PULSE(b) static_cast<u8>(((l7 >> (b)) & 1) << 7 | ((l6 >> (b)) & 1) << 6 | \
+    ((l5 >> (b)) & 1) << 5 | ((l4 >> (b)) & 1) << 4 | ((l3 >> (b)) & 1) << 3 | \
+    ((l2 >> (b)) & 1) << 2 | ((l1 >> (b)) & 1) << 1 | ((l0 >> (b)) & 1))
+        out[0] = FL_W8_PULSE(7);
+        out[1] = FL_W8_PULSE(6);
+        out[2] = FL_W8_PULSE(5);
+        out[3] = FL_W8_PULSE(4);
+        out[4] = FL_W8_PULSE(3);
+        out[5] = FL_W8_PULSE(2);
+        out[6] = FL_W8_PULSE(1);
+        out[7] = FL_W8_PULSE(0);
+#undef FL_W8_PULSE
     }
 }
 
@@ -249,82 +224,50 @@ void wave8_transpose_8(const Wave8Byte lane_waves[8],
 /// @brief Transpose 16 lanes of Wave8Byte data into interleaved format
 /// @param lane_waves Array of 16 Wave8Byte structures
 /// @param output Output buffer (128 bytes)
-/// @note Fully unrolled implementation for 8x performance improvement
+///
+/// Fully-unrolled naive bit-by-bit transpose. Benchmarked (#2524) as the
+/// fastest variant on the ESP32-P4 (RV32): 6595 vs 10524 us/frame for a
+/// two-pass (two 8x8 via u32) decomposition, and faster than a u64 SWAR. The
+/// compiler schedules these independent shift/or ops better than a
+/// latency-bound delta-swap chain on an in-order core. Each 16-lane sample is
+/// 2 output bytes: low = lanes 0-7, high = lanes 8-15.
 FASTLED_FORCE_INLINE FL_IRAM FL_OPTIMIZE_FUNCTION
 void wave8_transpose_16(const Wave8Byte lane_waves[16],
                         u8 output[16 * sizeof(Wave8Byte)]) {
-    // Fully unrolled version: Eliminates all loop overhead
-    // Process each of 8 symbols with explicit pulse extraction
-    // Achieves ~8x speedup over generic baseline (1,300 vs 10,000 cycles)
-
     for (int symbol_idx = 0; symbol_idx < 8; symbol_idx++) {
-        // Load all 16 lane bytes for this symbol
-        const u8 l0  = lane_waves[0].symbols[symbol_idx].data;
-        const u8 l1  = lane_waves[1].symbols[symbol_idx].data;
-        const u8 l2  = lane_waves[2].symbols[symbol_idx].data;
-        const u8 l3  = lane_waves[3].symbols[symbol_idx].data;
-        const u8 l4  = lane_waves[4].symbols[symbol_idx].data;
-        const u8 l5  = lane_waves[5].symbols[symbol_idx].data;
-        const u8 l6  = lane_waves[6].symbols[symbol_idx].data;
-        const u8 l7  = lane_waves[7].symbols[symbol_idx].data;
-        const u8 l8  = lane_waves[8].symbols[symbol_idx].data;
-        const u8 l9  = lane_waves[9].symbols[symbol_idx].data;
+        const u8 l0 = lane_waves[0].symbols[symbol_idx].data;
+        const u8 l1 = lane_waves[1].symbols[symbol_idx].data;
+        const u8 l2 = lane_waves[2].symbols[symbol_idx].data;
+        const u8 l3 = lane_waves[3].symbols[symbol_idx].data;
+        const u8 l4 = lane_waves[4].symbols[symbol_idx].data;
+        const u8 l5 = lane_waves[5].symbols[symbol_idx].data;
+        const u8 l6 = lane_waves[6].symbols[symbol_idx].data;
+        const u8 l7 = lane_waves[7].symbols[symbol_idx].data;
+        const u8 l8 = lane_waves[8].symbols[symbol_idx].data;
+        const u8 l9 = lane_waves[9].symbols[symbol_idx].data;
         const u8 l10 = lane_waves[10].symbols[symbol_idx].data;
         const u8 l11 = lane_waves[11].symbols[symbol_idx].data;
         const u8 l12 = lane_waves[12].symbols[symbol_idx].data;
         const u8 l13 = lane_waves[13].symbols[symbol_idx].data;
         const u8 l14 = lane_waves[14].symbols[symbol_idx].data;
         const u8 l15 = lane_waves[15].symbols[symbol_idx].data;
-
         u8* out = &output[symbol_idx * 16];
-
-        // Pulse 7 (bit 7): out[0] = lanes 0-7 (low byte), out[1] = lanes 8-15 (high byte)
-        out[0] = ((l7  >> 7) & 1) << 7 | ((l6  >> 7) & 1) << 6 | ((l5  >> 7) & 1) << 5 | ((l4  >> 7) & 1) << 4 |
-                 ((l3  >> 7) & 1) << 3 | ((l2  >> 7) & 1) << 2 | ((l1  >> 7) & 1) << 1 | ((l0  >> 7) & 1);
-        out[1] = ((l15 >> 7) & 1) << 7 | ((l14 >> 7) & 1) << 6 | ((l13 >> 7) & 1) << 5 | ((l12 >> 7) & 1) << 4 |
-                 ((l11 >> 7) & 1) << 3 | ((l10 >> 7) & 1) << 2 | ((l9  >> 7) & 1) << 1 | ((l8  >> 7) & 1);
-
-        // Pulse 6 (bit 6): out[2] = lanes 0-7 (low byte), out[3] = lanes 8-15 (high byte)
-        out[2] = ((l7  >> 6) & 1) << 7 | ((l6  >> 6) & 1) << 6 | ((l5  >> 6) & 1) << 5 | ((l4  >> 6) & 1) << 4 |
-                 ((l3  >> 6) & 1) << 3 | ((l2  >> 6) & 1) << 2 | ((l1  >> 6) & 1) << 1 | ((l0  >> 6) & 1);
-        out[3] = ((l15 >> 6) & 1) << 7 | ((l14 >> 6) & 1) << 6 | ((l13 >> 6) & 1) << 5 | ((l12 >> 6) & 1) << 4 |
-                 ((l11 >> 6) & 1) << 3 | ((l10 >> 6) & 1) << 2 | ((l9  >> 6) & 1) << 1 | ((l8  >> 6) & 1);
-
-        // Pulse 5 (bit 5): out[4] = lanes 0-7 (low byte), out[5] = lanes 8-15 (high byte)
-        out[4] = ((l7  >> 5) & 1) << 7 | ((l6  >> 5) & 1) << 6 | ((l5  >> 5) & 1) << 5 | ((l4  >> 5) & 1) << 4 |
-                 ((l3  >> 5) & 1) << 3 | ((l2  >> 5) & 1) << 2 | ((l1  >> 5) & 1) << 1 | ((l0  >> 5) & 1);
-        out[5] = ((l15 >> 5) & 1) << 7 | ((l14 >> 5) & 1) << 6 | ((l13 >> 5) & 1) << 5 | ((l12 >> 5) & 1) << 4 |
-                 ((l11 >> 5) & 1) << 3 | ((l10 >> 5) & 1) << 2 | ((l9  >> 5) & 1) << 1 | ((l8  >> 5) & 1);
-
-        // Pulse 4 (bit 4): out[6] = lanes 0-7 (low byte), out[7] = lanes 8-15 (high byte)
-        out[6] = ((l7  >> 4) & 1) << 7 | ((l6  >> 4) & 1) << 6 | ((l5  >> 4) & 1) << 5 | ((l4  >> 4) & 1) << 4 |
-                 ((l3  >> 4) & 1) << 3 | ((l2  >> 4) & 1) << 2 | ((l1  >> 4) & 1) << 1 | ((l0  >> 4) & 1);
-        out[7] = ((l15 >> 4) & 1) << 7 | ((l14 >> 4) & 1) << 6 | ((l13 >> 4) & 1) << 5 | ((l12 >> 4) & 1) << 4 |
-                 ((l11 >> 4) & 1) << 3 | ((l10 >> 4) & 1) << 2 | ((l9  >> 4) & 1) << 1 | ((l8  >> 4) & 1);
-
-        // Pulse 3 (bit 3): out[8] = lanes 0-7 (low byte), out[9] = lanes 8-15 (high byte)
-        out[8] = ((l7  >> 3) & 1) << 7 | ((l6  >> 3) & 1) << 6 | ((l5  >> 3) & 1) << 5 | ((l4  >> 3) & 1) << 4 |
-                 ((l3  >> 3) & 1) << 3 | ((l2  >> 3) & 1) << 2 | ((l1  >> 3) & 1) << 1 | ((l0  >> 3) & 1);
-        out[9] = ((l15 >> 3) & 1) << 7 | ((l14 >> 3) & 1) << 6 | ((l13 >> 3) & 1) << 5 | ((l12 >> 3) & 1) << 4 |
-                 ((l11 >> 3) & 1) << 3 | ((l10 >> 3) & 1) << 2 | ((l9  >> 3) & 1) << 1 | ((l8  >> 3) & 1);
-
-        // Pulse 2 (bit 2): out[10] = lanes 0-7 (low byte), out[11] = lanes 8-15 (high byte)
-        out[10] = ((l7  >> 2) & 1) << 7 | ((l6  >> 2) & 1) << 6 | ((l5  >> 2) & 1) << 5 | ((l4  >> 2) & 1) << 4 |
-                  ((l3  >> 2) & 1) << 3 | ((l2  >> 2) & 1) << 2 | ((l1  >> 2) & 1) << 1 | ((l0  >> 2) & 1);
-        out[11] = ((l15 >> 2) & 1) << 7 | ((l14 >> 2) & 1) << 6 | ((l13 >> 2) & 1) << 5 | ((l12 >> 2) & 1) << 4 |
-                  ((l11 >> 2) & 1) << 3 | ((l10 >> 2) & 1) << 2 | ((l9  >> 2) & 1) << 1 | ((l8  >> 2) & 1);
-
-        // Pulse 1 (bit 1): out[12] = lanes 0-7 (low byte), out[13] = lanes 8-15 (high byte)
-        out[12] = ((l7  >> 1) & 1) << 7 | ((l6  >> 1) & 1) << 6 | ((l5  >> 1) & 1) << 5 | ((l4  >> 1) & 1) << 4 |
-                  ((l3  >> 1) & 1) << 3 | ((l2  >> 1) & 1) << 2 | ((l1  >> 1) & 1) << 1 | ((l0  >> 1) & 1);
-        out[13] = ((l15 >> 1) & 1) << 7 | ((l14 >> 1) & 1) << 6 | ((l13 >> 1) & 1) << 5 | ((l12 >> 1) & 1) << 4 |
-                  ((l11 >> 1) & 1) << 3 | ((l10 >> 1) & 1) << 2 | ((l9  >> 1) & 1) << 1 | ((l8  >> 1) & 1);
-
-        // Pulse 0 (bit 0): out[14] = lanes 0-7 (low byte), out[15] = lanes 8-15 (high byte)
-        out[14] = ((l7  >> 0) & 1) << 7 | ((l6  >> 0) & 1) << 6 | ((l5  >> 0) & 1) << 5 | ((l4  >> 0) & 1) << 4 |
-                  ((l3  >> 0) & 1) << 3 | ((l2  >> 0) & 1) << 2 | ((l1  >> 0) & 1) << 1 | ((l0  >> 0) & 1);
-        out[15] = ((l15 >> 0) & 1) << 7 | ((l14 >> 0) & 1) << 6 | ((l13 >> 0) & 1) << 5 | ((l12 >> 0) & 1) << 4 |
-                  ((l11 >> 0) & 1) << 3 | ((l10 >> 0) & 1) << 2 | ((l9  >> 0) & 1) << 1 | ((l8  >> 0) & 1);
+#define FL_W8_LO(b) static_cast<u8>(((l7 >> (b)) & 1) << 7 | ((l6 >> (b)) & 1) << 6 | \
+    ((l5 >> (b)) & 1) << 5 | ((l4 >> (b)) & 1) << 4 | ((l3 >> (b)) & 1) << 3 | \
+    ((l2 >> (b)) & 1) << 2 | ((l1 >> (b)) & 1) << 1 | ((l0 >> (b)) & 1))
+#define FL_W8_HI(b) static_cast<u8>(((l15 >> (b)) & 1) << 7 | ((l14 >> (b)) & 1) << 6 | \
+    ((l13 >> (b)) & 1) << 5 | ((l12 >> (b)) & 1) << 4 | ((l11 >> (b)) & 1) << 3 | \
+    ((l10 >> (b)) & 1) << 2 | ((l9 >> (b)) & 1) << 1 | ((l8 >> (b)) & 1))
+        out[0] = FL_W8_LO(7);  out[1] = FL_W8_HI(7);
+        out[2] = FL_W8_LO(6);  out[3] = FL_W8_HI(6);
+        out[4] = FL_W8_LO(5);  out[5] = FL_W8_HI(5);
+        out[6] = FL_W8_LO(4);  out[7] = FL_W8_HI(4);
+        out[8] = FL_W8_LO(3);  out[9] = FL_W8_HI(3);
+        out[10] = FL_W8_LO(2); out[11] = FL_W8_HI(2);
+        out[12] = FL_W8_LO(1); out[13] = FL_W8_HI(1);
+        out[14] = FL_W8_LO(0); out[15] = FL_W8_HI(0);
+#undef FL_W8_LO
+#undef FL_W8_HI
     }
 }
 

--- a/tests/fl/channels/wave3.cpp
+++ b/tests/fl/channels/wave3.cpp
@@ -1,0 +1,81 @@
+/// @file wave3.cpp
+/// @brief #2524: the optimized two-pass (8x8) wave3 lane transposes must be
+/// bit-for-bit identical to a ground-truth naive transpose (8-lane and
+/// 16-lane), across edge + random inputs.
+
+#include "fl/channels/wave3.h"
+#include "fl/channels/detail/wave3.hpp"
+#include "fl/stl/cstring.h"
+#include "test.h"
+
+FL_TEST_FILE(FL_FILEPATH) {
+
+using namespace fl;
+
+FL_TEST_CASE("wave3 transpose_8/_16 == naive (random + edge)") {
+    // 8-lane: out[sym*8 + k] is pulse (7-k); bit `lane` = lane's bit (7-k).
+    auto naive8 = [](const Wave3Byte in[8], u8 out[8 * sizeof(Wave3Byte)]) {
+        for (int s = 0; s < 3; s++) {
+            for (int k = 0; k < 8; k++) {
+                int b = 7 - k;
+                int byte = 0;
+                for (int l = 0; l < 8; l++) {
+                    byte |= ((in[l].data[s] >> b) & 1) << l;
+                }
+                out[s * 8 + k] = static_cast<u8>(byte);
+            }
+        }
+    };
+    // 16-lane: out[sym*16 + (7-b)*2] = lanes 0-7 (low), +1 = lanes 8-15 (high).
+    auto naive16 = [](const Wave3Byte in[16], u8 out[16 * sizeof(Wave3Byte)]) {
+        for (int s = 0; s < 3; s++) {
+            for (int b = 0; b < 8; b++) {
+                int lo = 0;
+                int hi = 0;
+                for (int l = 0; l < 8; l++) {
+                    lo |= ((in[l].data[s] >> b) & 1) << l;
+                    hi |= ((in[l + 8].data[s] >> b) & 1) << l;
+                }
+                out[s * 16 + (7 - b) * 2] = static_cast<u8>(lo);
+                out[s * 16 + (7 - b) * 2 + 1] = static_cast<u8>(hi);
+            }
+        }
+    };
+
+    u32 seed = 0x13579BDFu;
+    for (int round = 0; round < 400; round++) {
+        Wave3Byte w3[16];
+        for (int l = 0; l < 16; l++) {
+            for (int s = 0; s < 3; s++) {
+                u8 v;
+                if (round == 0) {
+                    v = 0x00;
+                } else if (round == 1) {
+                    v = 0xFF;
+                } else if (round == 2) {
+                    v = static_cast<u8>((l & 1) ? 0xAA : 0x55);
+                } else {
+                    seed = seed * 1664525u + 1013904223u;
+                    v = static_cast<u8>(seed >> 24);
+                }
+                w3[l].data[s] = v;
+            }
+        }
+        u8 got[16 * sizeof(Wave3Byte)];
+        u8 exp[16 * sizeof(Wave3Byte)];
+
+        fl::detail::wave3_transpose_8(w3, got);
+        naive8(w3, exp);
+        for (int i = 0; i < 8 * static_cast<int>(sizeof(Wave3Byte)); i++) {
+            FL_REQUIRE(got[i] == exp[i]);
+        }
+
+        fl::detail::wave3_transpose_16(w3, got);
+        naive16(w3, exp);
+        for (int i = 0; i < 16 * static_cast<int>(sizeof(Wave3Byte)); i++) {
+            FL_REQUIRE(got[i] == exp[i]);
+        }
+    }
+}
+
+} // FL_TEST_FILE

--- a/tests/fl/channels/wave8.cpp
+++ b/tests/fl/channels/wave8.cpp
@@ -4,6 +4,7 @@
 /// Tests the wave transpose functionality used for multi-lane LED protocols.
 
 #include "fl/channels/wave8.h"
+#include "fl/channels/detail/wave8.hpp"
 #include "fl/stl/cstring.h"
 #include "test.h"
 #include "fl/chipsets/led_timing.h"
@@ -857,6 +858,63 @@ FL_TEST_CASE("wave8Untranspose_16_distinct_patterns") {
         for (int symbol = 0; symbol < 8; symbol++) {
             uint8_t expected = (symbol == (7 - set_bit)) ? 0xFF : 0x00;
             FL_REQUIRE(untransposed[lane * 8 + symbol] == expected);
+        }
+    }
+}
+
+// #2524: the optimized two-pass (8x8) transposes must be bit-identical to a
+// ground-truth naive transpose across random inputs (the known-answer tests
+// above only cover specific patterns).
+FL_TEST_CASE("wave8 transpose_8/_16 == naive (random)") {
+    auto naive8 = [](const Wave8Byte in[8], u8 out[8 * sizeof(Wave8Byte)]) {
+        for (int s = 0; s < 8; s++) {
+            for (int k = 0; k < 8; k++) {
+                int b = 7 - k;
+                int byte = 0;
+                for (int l = 0; l < 8; l++) {
+                    byte |= ((in[l].symbols[s].data >> b) & 1) << l;
+                }
+                out[s * 8 + k] = static_cast<u8>(byte);
+            }
+        }
+    };
+    auto naive16 = [](const Wave8Byte in[16], u8 out[16 * sizeof(Wave8Byte)]) {
+        for (int s = 0; s < 8; s++) {
+            for (int b = 0; b < 8; b++) {
+                int lo = 0;
+                int hi = 0;
+                for (int l = 0; l < 8; l++) {
+                    lo |= ((in[l].symbols[s].data >> b) & 1) << l;
+                    hi |= ((in[l + 8].symbols[s].data >> b) & 1) << l;
+                }
+                out[s * 16 + (7 - b) * 2] = static_cast<u8>(lo);
+                out[s * 16 + (7 - b) * 2 + 1] = static_cast<u8>(hi);
+            }
+        }
+    };
+
+    u32 seed = 0xABCDEF01u;
+    for (int round = 0; round < 400; round++) {
+        Wave8Byte w8[16];
+        for (int l = 0; l < 16; l++) {
+            for (int s = 0; s < 8; s++) {
+                seed = seed * 1664525u + 1013904223u;
+                w8[l].symbols[s].data = static_cast<u8>(seed >> 24);
+            }
+        }
+        u8 got[16 * sizeof(Wave8Byte)];
+        u8 exp[16 * sizeof(Wave8Byte)];
+
+        fl::detail::wave8_transpose_8(w8, got);
+        naive8(w8, exp);
+        for (int i = 0; i < 8 * static_cast<int>(sizeof(Wave8Byte)); i++) {
+            FL_REQUIRE(got[i] == exp[i]);
+        }
+
+        fl::detail::wave8_transpose_16(w8, got);
+        naive16(w8, exp);
+        for (int i = 0; i < 16 * static_cast<int>(sizeof(Wave8Byte)); i++) {
+            FL_REQUIRE(got[i] == exp[i]);
         }
     }
 }


### PR DESCRIPTION
## Summary
- Make the wave3/wave8 **8-lane and 16-lane** bit transposes use the empirically-fastest variant on ESP32-P4 (RV32): the fully-unrolled naive bit-by-bit transpose. No SIMD.
- `transpose_8`: switched from the u32 Hacker's-Delight 8×8 primitive to the unrolled naive (**~1.4× faster on RV32**).
- `transpose_16`: kept the unrolled naive (a two-pass "two 8×8 via u32" decomposition was implemented + bit-verified but ran **1.6× slower** on RV32, so it was rejected).
- Adds host unit tests asserting the production transposes are **bit-identical to a ground-truth naive** across edge + 400 random rounds (wave8 + wave3, 8- and 16-lane).

## Why
Fair same-build A/B on ESP32-P4 (RV32), all FORCE_INLINE + O3, 768 calls/frame:

| Lanes | unrolled naive | structured | result |
|---|---|---|---|
| 16 | **6595 µs** | two-pass (u32 8×8) 10524 µs | naive 1.6× |
| 8 | **3336 µs** | Hacker's-Delight u32 8×8 4680 µs | naive 1.4× |

The naive's bit-extracts are independent (compiler/pipeline parallelizes them); the HD/two-pass delta-swap is a latency-bound dependency chain that stalls on an in-order core. Same conclusion on x86. Investigation + data: #2524.

## Test plan
- [x] `bash test wave8` (known-answer + round-trip + new equivalence tests) — pass
- [x] `bash test wave3` (new equivalence test) — pass
- [x] `bash test parlio_driver` (wave3 transpose coverage) — pass
- [x] `bash lint --cpp` — clean

Refs #2524

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored internal signal processing channel implementations with revised computation approaches and optimized operation logic.

* **Tests**
  * Added comprehensive test coverage for signal processing components, featuring randomized input validation scenarios and known-answer testing across hundreds of test configurations to verify implementation correctness.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/FastLED/pull/2532?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->