### PR TITLE
perf(wave): spread-LUT bit transpose — ~2x transpose / ~1.24x encode on ESP32-P4

### DIFF
--- a/src/fl/channels/detail/bit_spread_lut.hpp
+++ b/src/fl/channels/detail/bit_spread_lut.hpp
@@ -1,0 +1,77 @@
+/// @file bit_spread_lut.hpp
+/// @brief Shared u32 "spread LUT" bit-matrix transpose primitive (no SIMD, no u64).
+///
+/// Benchmarked (#2533) on the ESP32-P4 (RV32, in-order): ~2× faster than the
+/// unrolled-naive transpose (16-lane 6649→3353 µs = 1.98×; 8-lane 3356→1764 µs
+/// = 1.90×; bit-exact). For each output it computes
+///   acc = OR over 8 lanes of  spread(laneByte) << lane
+/// where `spread()` pre-positions a byte's pulse bits into 8 separate bytes.
+/// All ops are native u32 and independent (no dependency chain, no emulated
+/// u64) — exactly what the in-order core schedules best — and the tiny table is
+/// cache-resident. Used by both wave8 (8 symbols) and wave3 (3 symbols); the
+/// per-symbol op is an 8-bit transpose, identical for both.
+
+#pragma once
+
+#include "fl/stl/compiler_control.h"
+#include "fl/stl/int.h"
+
+namespace fl {
+namespace detail {
+
+/// kSpreadNibble[n] places the 4 bits of nibble n at bit 0 of 4 separate bytes:
+/// byte0 = bit3(n), byte1 = bit2(n), byte2 = bit1(n), byte3 = bit0(n).
+/// A 16-entry literal table (C++11-valid, no constexpr loop, ~64 bytes, cache-
+/// resident). spreadA/spreadB only depend on one nibble each, so this one table
+/// serves both halves.
+constexpr u32 kSpreadNibble[16] = {
+    0x00000000u, 0x01000000u, 0x00010000u, 0x01010000u,
+    0x00000100u, 0x01000100u, 0x00010100u, 0x01010100u,
+    0x00000001u, 0x01000001u, 0x00010001u, 0x01010001u,
+    0x00000101u, 0x01000101u, 0x00010101u, 0x01010101u,
+};
+
+/// Pulses 7,6,5,4 of v (byte j = bit (7-j)). Depends only on the high nibble.
+FASTLED_FORCE_INLINE u32 spreadA(u8 v) { return kSpreadNibble[v >> 4]; }
+/// Pulses 3,2,1,0 of v (byte j = bit (3-j)). Depends only on the low nibble.
+FASTLED_FORCE_INLINE u32 spreadB(u8 v) { return kSpreadNibble[v & 0x0Fu]; }
+
+/// Transpose one symbol of 16 lanes (16 input bytes) into 16 output bytes:
+/// 8 pulses × 2 bytes, low byte = lanes 0-7, high byte = lanes 8-15, pulse
+/// order 7..0 (out[0] = pulse 7 low). Matches the naive layout.
+FASTLED_FORCE_INLINE FL_IRAM FL_OPTIMIZE_FUNCTION
+void spread_transpose16_symbol(const u8 l[16], u8 out[16]) {
+    const u32 aLo = spreadA(l[0]) | spreadA(l[1]) << 1 | spreadA(l[2]) << 2 | spreadA(l[3]) << 3 |
+                    spreadA(l[4]) << 4 | spreadA(l[5]) << 5 | spreadA(l[6]) << 6 | spreadA(l[7]) << 7;
+    const u32 bLo = spreadB(l[0]) | spreadB(l[1]) << 1 | spreadB(l[2]) << 2 | spreadB(l[3]) << 3 |
+                    spreadB(l[4]) << 4 | spreadB(l[5]) << 5 | spreadB(l[6]) << 6 | spreadB(l[7]) << 7;
+    const u32 aHi = spreadA(l[8]) | spreadA(l[9]) << 1 | spreadA(l[10]) << 2 | spreadA(l[11]) << 3 |
+                    spreadA(l[12]) << 4 | spreadA(l[13]) << 5 | spreadA(l[14]) << 6 | spreadA(l[15]) << 7;
+    const u32 bHi = spreadB(l[8]) | spreadB(l[9]) << 1 | spreadB(l[10]) << 2 | spreadB(l[11]) << 3 |
+                    spreadB(l[12]) << 4 | spreadB(l[13]) << 5 | spreadB(l[14]) << 6 | spreadB(l[15]) << 7;
+    out[0] = static_cast<u8>(aLo);        out[1] = static_cast<u8>(aHi);
+    out[2] = static_cast<u8>(aLo >> 8);   out[3] = static_cast<u8>(aHi >> 8);
+    out[4] = static_cast<u8>(aLo >> 16);  out[5] = static_cast<u8>(aHi >> 16);
+    out[6] = static_cast<u8>(aLo >> 24);  out[7] = static_cast<u8>(aHi >> 24);
+    out[8] = static_cast<u8>(bLo);        out[9] = static_cast<u8>(bHi);
+    out[10] = static_cast<u8>(bLo >> 8);  out[11] = static_cast<u8>(bHi >> 8);
+    out[12] = static_cast<u8>(bLo >> 16); out[13] = static_cast<u8>(bHi >> 16);
+    out[14] = static_cast<u8>(bLo >> 24); out[15] = static_cast<u8>(bHi >> 24);
+}
+
+/// Transpose one symbol of 8 lanes (8 input bytes) into 8 output bytes:
+/// 8 pulses × 1 byte (bit L = lane L), pulse order 7..0 (out[0] = pulse 7).
+FASTLED_FORCE_INLINE FL_IRAM FL_OPTIMIZE_FUNCTION
+void spread_transpose8_symbol(const u8 l[8], u8 out[8]) {
+    const u32 a = spreadA(l[0]) | spreadA(l[1]) << 1 | spreadA(l[2]) << 2 | spreadA(l[3]) << 3 |
+                  spreadA(l[4]) << 4 | spreadA(l[5]) << 5 | spreadA(l[6]) << 6 | spreadA(l[7]) << 7;
+    const u32 b = spreadB(l[0]) | spreadB(l[1]) << 1 | spreadB(l[2]) << 2 | spreadB(l[3]) << 3 |
+                  spreadB(l[4]) << 4 | spreadB(l[5]) << 5 | spreadB(l[6]) << 6 | spreadB(l[7]) << 7;
+    out[0] = static_cast<u8>(a);        out[1] = static_cast<u8>(a >> 8);
+    out[2] = static_cast<u8>(a >> 16);  out[3] = static_cast<u8>(a >> 24);
+    out[4] = static_cast<u8>(b);        out[5] = static_cast<u8>(b >> 8);
+    out[6] = static_cast<u8>(b >> 16);  out[7] = static_cast<u8>(b >> 24);
+}
+
+}  // namespace detail
+}  // namespace fl

--- a/src/fl/channels/detail/wave3.hpp
+++ b/src/fl/channels/detail/wave3.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "fl/channels/wave3.h"
+#include "fl/channels/detail/bit_spread_lut.hpp"
 #include "fl/stl/compiler_control.h"
 #include "fl/stl/isr/memcpy.h"
 
@@ -140,33 +141,17 @@ void wave3_transpose_4(const Wave3Byte lane_waves[4],
 /// @param lane_waves Array of 8 Wave3Byte structures
 /// @param output Output buffer (24 bytes = 8 * 3)
 ///
-/// Fully-unrolled naive bit-by-bit transpose — benchmarked (#2524) as the
-/// fastest variant on the ESP32-P4 (RV32), beating a u32 Hacker's-Delight 8x8.
+/// Spread-LUT transpose (#2533): ~1.9× faster than the unrolled naive on the
+/// ESP32-P4 (RV32), bit-exact. See bit_spread_lut.hpp. (wave3 = 3 symbols.)
 FASTLED_FORCE_INLINE FL_IRAM FL_OPTIMIZE_FUNCTION
 void wave3_transpose_8(const Wave3Byte lane_waves[8],
                        u8 output[8 * sizeof(Wave3Byte)]) {
     for (int symbol_idx = 0; symbol_idx < 3; symbol_idx++) {
-        const u8 l0 = lane_waves[0].data[symbol_idx];
-        const u8 l1 = lane_waves[1].data[symbol_idx];
-        const u8 l2 = lane_waves[2].data[symbol_idx];
-        const u8 l3 = lane_waves[3].data[symbol_idx];
-        const u8 l4 = lane_waves[4].data[symbol_idx];
-        const u8 l5 = lane_waves[5].data[symbol_idx];
-        const u8 l6 = lane_waves[6].data[symbol_idx];
-        const u8 l7 = lane_waves[7].data[symbol_idx];
-        u8* out = &output[symbol_idx * 8];
-#define FL_W3_PULSE(b) static_cast<u8>(((l7 >> (b)) & 1) << 7 | ((l6 >> (b)) & 1) << 6 | \
-    ((l5 >> (b)) & 1) << 5 | ((l4 >> (b)) & 1) << 4 | ((l3 >> (b)) & 1) << 3 | \
-    ((l2 >> (b)) & 1) << 2 | ((l1 >> (b)) & 1) << 1 | ((l0 >> (b)) & 1))
-        out[0] = FL_W3_PULSE(7);
-        out[1] = FL_W3_PULSE(6);
-        out[2] = FL_W3_PULSE(5);
-        out[3] = FL_W3_PULSE(4);
-        out[4] = FL_W3_PULSE(3);
-        out[5] = FL_W3_PULSE(2);
-        out[6] = FL_W3_PULSE(1);
-        out[7] = FL_W3_PULSE(0);
-#undef FL_W3_PULSE
+        u8 l[8];
+        for (int lane = 0; lane < 8; lane++) {
+            l[lane] = lane_waves[lane].data[symbol_idx];
+        }
+        spread_transpose8_symbol(l, output + symbol_idx * 8);
     }
 }
 
@@ -178,46 +163,18 @@ void wave3_transpose_8(const Wave3Byte lane_waves[8],
 /// @param lane_waves Array of 16 Wave3Byte structures
 /// @param output Output buffer (48 bytes = 16 * 3)
 ///
-/// Fully-unrolled naive bit-by-bit transpose — benchmarked (#2524) as the
-/// fastest on the ESP32-P4 (RV32), beating two-pass/SWAR. Each 16-lane sample
-/// is 2 output bytes: low = lanes 0-7, high = lanes 8-15.
+/// Spread-LUT transpose (#2533): ~1.9× faster than the unrolled naive on the
+/// ESP32-P4 (RV32), bit-exact. See bit_spread_lut.hpp. Each 16-lane sample is 2
+/// output bytes: low = lanes 0-7, high = lanes 8-15. (wave3 = 3 symbols.)
 FASTLED_FORCE_INLINE FL_IRAM FL_OPTIMIZE_FUNCTION
 void wave3_transpose_16(const Wave3Byte lane_waves[16],
                         u8 output[16 * sizeof(Wave3Byte)]) {
     for (int symbol_idx = 0; symbol_idx < 3; symbol_idx++) {
-        const u8 l0 = lane_waves[0].data[symbol_idx];
-        const u8 l1 = lane_waves[1].data[symbol_idx];
-        const u8 l2 = lane_waves[2].data[symbol_idx];
-        const u8 l3 = lane_waves[3].data[symbol_idx];
-        const u8 l4 = lane_waves[4].data[symbol_idx];
-        const u8 l5 = lane_waves[5].data[symbol_idx];
-        const u8 l6 = lane_waves[6].data[symbol_idx];
-        const u8 l7 = lane_waves[7].data[symbol_idx];
-        const u8 l8 = lane_waves[8].data[symbol_idx];
-        const u8 l9 = lane_waves[9].data[symbol_idx];
-        const u8 l10 = lane_waves[10].data[symbol_idx];
-        const u8 l11 = lane_waves[11].data[symbol_idx];
-        const u8 l12 = lane_waves[12].data[symbol_idx];
-        const u8 l13 = lane_waves[13].data[symbol_idx];
-        const u8 l14 = lane_waves[14].data[symbol_idx];
-        const u8 l15 = lane_waves[15].data[symbol_idx];
-        u8* out = &output[symbol_idx * 16];
-#define FL_W3_LO(b) static_cast<u8>(((l7 >> (b)) & 1) << 7 | ((l6 >> (b)) & 1) << 6 | \
-    ((l5 >> (b)) & 1) << 5 | ((l4 >> (b)) & 1) << 4 | ((l3 >> (b)) & 1) << 3 | \
-    ((l2 >> (b)) & 1) << 2 | ((l1 >> (b)) & 1) << 1 | ((l0 >> (b)) & 1))
-#define FL_W3_HI(b) static_cast<u8>(((l15 >> (b)) & 1) << 7 | ((l14 >> (b)) & 1) << 6 | \
-    ((l13 >> (b)) & 1) << 5 | ((l12 >> (b)) & 1) << 4 | ((l11 >> (b)) & 1) << 3 | \
-    ((l10 >> (b)) & 1) << 2 | ((l9 >> (b)) & 1) << 1 | ((l8 >> (b)) & 1))
-        out[0] = FL_W3_LO(7);  out[1] = FL_W3_HI(7);
-        out[2] = FL_W3_LO(6);  out[3] = FL_W3_HI(6);
-        out[4] = FL_W3_LO(5);  out[5] = FL_W3_HI(5);
-        out[6] = FL_W3_LO(4);  out[7] = FL_W3_HI(4);
-        out[8] = FL_W3_LO(3);  out[9] = FL_W3_HI(3);
-        out[10] = FL_W3_LO(2); out[11] = FL_W3_HI(2);
-        out[12] = FL_W3_LO(1); out[13] = FL_W3_HI(1);
-        out[14] = FL_W3_LO(0); out[15] = FL_W3_HI(0);
-#undef FL_W3_LO
-#undef FL_W3_HI
+        u8 l[16];
+        for (int lane = 0; lane < 16; lane++) {
+            l[lane] = lane_waves[lane].data[symbol_idx];
+        }
+        spread_transpose16_symbol(l, output + symbol_idx * 16);
     }
 }
 

--- a/src/fl/channels/detail/wave8.hpp
+++ b/src/fl/channels/detail/wave8.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "fl/channels/wave8.h"
+#include "fl/channels/detail/bit_spread_lut.hpp"
 #include "fl/stl/compiler_control.h"
 #include "fl/stl/isr/memcpy.h"
 #include "fl/stl/bit_cast.h"
@@ -184,36 +185,17 @@ void wave8_transpose_4(const Wave8Byte lane_waves[4],
 /// @param lane_waves Array of 8 Wave8Byte structures
 /// @param output Output buffer (64 bytes)
 ///
-/// Fully-unrolled naive bit-by-bit transpose. Benchmarked (#2524) as the
-/// fastest variant on the ESP32-P4 (RV32): 3336 vs 4680 us/frame for a u32
-/// Hacker's-Delight 8x8 — the compiler turns these independent shift/or ops
-/// into tight code, beating the latency-bound delta-swap chain on an in-order
-/// core. Each symbol is an 8-lane x 8-pulse bit matrix.
+/// Spread-LUT transpose (#2533): ~1.90× faster than the unrolled naive on the
+/// ESP32-P4 (RV32) — 3356→1764 us/frame, bit-exact. See bit_spread_lut.hpp.
 FASTLED_FORCE_INLINE FL_IRAM FL_OPTIMIZE_FUNCTION
 void wave8_transpose_8(const Wave8Byte lane_waves[8],
                        u8 output[8 * sizeof(Wave8Byte)]) {
     for (int symbol_idx = 0; symbol_idx < 8; symbol_idx++) {
-        const u8 l0 = lane_waves[0].symbols[symbol_idx].data;
-        const u8 l1 = lane_waves[1].symbols[symbol_idx].data;
-        const u8 l2 = lane_waves[2].symbols[symbol_idx].data;
-        const u8 l3 = lane_waves[3].symbols[symbol_idx].data;
-        const u8 l4 = lane_waves[4].symbols[symbol_idx].data;
-        const u8 l5 = lane_waves[5].symbols[symbol_idx].data;
-        const u8 l6 = lane_waves[6].symbols[symbol_idx].data;
-        const u8 l7 = lane_waves[7].symbols[symbol_idx].data;
-        u8* out = &output[symbol_idx * 8];
-#define FL_W8_PULSE(b) static_cast<u8>(((l7 >> (b)) & 1) << 7 | ((l6 >> (b)) & 1) << 6 | \
-    ((l5 >> (b)) & 1) << 5 | ((l4 >> (b)) & 1) << 4 | ((l3 >> (b)) & 1) << 3 | \
-    ((l2 >> (b)) & 1) << 2 | ((l1 >> (b)) & 1) << 1 | ((l0 >> (b)) & 1))
-        out[0] = FL_W8_PULSE(7);
-        out[1] = FL_W8_PULSE(6);
-        out[2] = FL_W8_PULSE(5);
-        out[3] = FL_W8_PULSE(4);
-        out[4] = FL_W8_PULSE(3);
-        out[5] = FL_W8_PULSE(2);
-        out[6] = FL_W8_PULSE(1);
-        out[7] = FL_W8_PULSE(0);
-#undef FL_W8_PULSE
+        u8 l[8];
+        for (int lane = 0; lane < 8; lane++) {
+            l[lane] = lane_waves[lane].symbols[symbol_idx].data;
+        }
+        spread_transpose8_symbol(l, output + symbol_idx * 8);
     }
 }
 
@@ -225,49 +207,21 @@ void wave8_transpose_8(const Wave8Byte lane_waves[8],
 /// @param lane_waves Array of 16 Wave8Byte structures
 /// @param output Output buffer (128 bytes)
 ///
-/// Fully-unrolled naive bit-by-bit transpose. Benchmarked (#2524) as the
-/// fastest variant on the ESP32-P4 (RV32): 6595 vs 10524 us/frame for a
-/// two-pass (two 8x8 via u32) decomposition, and faster than a u64 SWAR. The
-/// compiler schedules these independent shift/or ops better than a
-/// latency-bound delta-swap chain on an in-order core. Each 16-lane sample is
-/// 2 output bytes: low = lanes 0-7, high = lanes 8-15.
+/// Spread-LUT transpose (#2533): ~1.98× faster than the unrolled naive on the
+/// ESP32-P4 (RV32) — 6649→3353 us/frame, bit-exact. Two-pass (two 8x8 via u32),
+/// u64 SWAR, and Hacker's-Delight all lost to this on the in-order core; the
+/// winning shape is independent table-lookup + shift + OR-reduce (native u32,
+/// no dependency chain). See bit_spread_lut.hpp. Each 16-lane sample is 2 output
+/// bytes: low = lanes 0-7, high = lanes 8-15.
 FASTLED_FORCE_INLINE FL_IRAM FL_OPTIMIZE_FUNCTION
 void wave8_transpose_16(const Wave8Byte lane_waves[16],
                         u8 output[16 * sizeof(Wave8Byte)]) {
     for (int symbol_idx = 0; symbol_idx < 8; symbol_idx++) {
-        const u8 l0 = lane_waves[0].symbols[symbol_idx].data;
-        const u8 l1 = lane_waves[1].symbols[symbol_idx].data;
-        const u8 l2 = lane_waves[2].symbols[symbol_idx].data;
-        const u8 l3 = lane_waves[3].symbols[symbol_idx].data;
-        const u8 l4 = lane_waves[4].symbols[symbol_idx].data;
-        const u8 l5 = lane_waves[5].symbols[symbol_idx].data;
-        const u8 l6 = lane_waves[6].symbols[symbol_idx].data;
-        const u8 l7 = lane_waves[7].symbols[symbol_idx].data;
-        const u8 l8 = lane_waves[8].symbols[symbol_idx].data;
-        const u8 l9 = lane_waves[9].symbols[symbol_idx].data;
-        const u8 l10 = lane_waves[10].symbols[symbol_idx].data;
-        const u8 l11 = lane_waves[11].symbols[symbol_idx].data;
-        const u8 l12 = lane_waves[12].symbols[symbol_idx].data;
-        const u8 l13 = lane_waves[13].symbols[symbol_idx].data;
-        const u8 l14 = lane_waves[14].symbols[symbol_idx].data;
-        const u8 l15 = lane_waves[15].symbols[symbol_idx].data;
-        u8* out = &output[symbol_idx * 16];
-#define FL_W8_LO(b) static_cast<u8>(((l7 >> (b)) & 1) << 7 | ((l6 >> (b)) & 1) << 6 | \
-    ((l5 >> (b)) & 1) << 5 | ((l4 >> (b)) & 1) << 4 | ((l3 >> (b)) & 1) << 3 | \
-    ((l2 >> (b)) & 1) << 2 | ((l1 >> (b)) & 1) << 1 | ((l0 >> (b)) & 1))
-#define FL_W8_HI(b) static_cast<u8>(((l15 >> (b)) & 1) << 7 | ((l14 >> (b)) & 1) << 6 | \
-    ((l13 >> (b)) & 1) << 5 | ((l12 >> (b)) & 1) << 4 | ((l11 >> (b)) & 1) << 3 | \
-    ((l10 >> (b)) & 1) << 2 | ((l9 >> (b)) & 1) << 1 | ((l8 >> (b)) & 1))
-        out[0] = FL_W8_LO(7);  out[1] = FL_W8_HI(7);
-        out[2] = FL_W8_LO(6);  out[3] = FL_W8_HI(6);
-        out[4] = FL_W8_LO(5);  out[5] = FL_W8_HI(5);
-        out[6] = FL_W8_LO(4);  out[7] = FL_W8_HI(4);
-        out[8] = FL_W8_LO(3);  out[9] = FL_W8_HI(3);
-        out[10] = FL_W8_LO(2); out[11] = FL_W8_HI(2);
-        out[12] = FL_W8_LO(1); out[13] = FL_W8_HI(1);
-        out[14] = FL_W8_LO(0); out[15] = FL_W8_HI(0);
-#undef FL_W8_LO
-#undef FL_W8_HI
+        u8 l[16];
+        for (int lane = 0; lane < 16; lane++) {
+            l[lane] = lane_waves[lane].symbols[symbol_idx].data;
+        }
+        spread_transpose16_symbol(l, output + symbol_idx * 16);
     }
 }
 


### PR DESCRIPTION
## Summary
Replace the unrolled-naive wave8/wave3 **8- and 16-lane** bit transposes with a u32 **spread-LUT**: `acc = OR over 8 lanes of spread(laneByte) << lane`, where `spread()` pre-positions a byte's pulse bits into 8 separate bytes via a 16-entry literal table. All native u32, independent ops, **no dependency chain / no emulated u64** — the op shape the in-order RV32 schedules best. New shared helper: `src/fl/channels/detail/bit_spread_lut.hpp`.

## Measured on a real ESP32-P4 (RV32), bit-exact vs naive
| | 16-lane | 8-lane |
|---|---|---|
| isolated transpose | 6649 → **3353 µs (1.98×)** | 3356 → **1764 µs (1.90×)** |
| full `encode_us` (256 LEDs) | 14611 → **11744 µs (1.24×)** | 7208 → **5879 µs (1.23×)** |

Correctness: bit-identical to the naive across the host equivalence + known-answer + round-trip tests, and on-device `mismatch=0`. The naive was the proven-correct production transpose, so the WS2812 output is byte-for-byte unchanged.

## Why this beats everything else
Every prior candidate lost to the naive on the in-order P4 — u64 SWAR (0.41×), Hacker's-Delight u32 8×8 (0.71×), two-pass (0.63×), u64-pack template. The spread-LUT is the **first to beat the naive** because it's independent table-lookup + shift + OR-reduce (no dependency chain). Full investigation + on-device benchmark harness (`bash autoresearch --transpose 16`) in #2533.

## Test plan
- [x] `bash test wave8` / `bash test wave3` / `bash test parlio_driver` (bit-exact vs naive) — pass
- [x] `bash lint --cpp` — clean
- [x] On-device `measureParlio` encode_us before/after (P4)

Refs #2533

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated bit-matrix transpose implementations to use lookup table-based helpers for improved code maintainability across channel processing routines.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/FastLED/pull/2534?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->