### PR TITLE
feat(hooks): block spurious new example .ino creation

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -18,6 +18,11 @@
           {
             "type": "command",
             "command": "d=$PWD; while [ \"$d\" != / ] && [ ! -f \"$d/pyproject.toml\" ]; do d=$(dirname \"$d\"); done; [ -f \"$d/pyproject.toml\" ] && cd \"$d\" && ! grep -q '^<<<<<<< ' pyproject.toml && exec uv run python ci/hooks/check_test_file_pairing.py || { echo 'FastLED hook skipped: pyproject.toml missing or has unresolved merge conflict markers' >&2; exit 0; }"
+          },
+          {
+            "type": "command",
+            "command": "d=$PWD; while [ \"$d\" != / ] && [ ! -f \"$d/pyproject.toml\" ]; do d=$(dirname \"$d\"); done; [ -f \"$d/pyproject.toml\" ] && cd \"$d\" && ! grep -q '^<<<<<<< ' pyproject.toml && exec uv run python ci/hooks/protect_example_ino.py || { echo 'FastLED hook skipped: pyproject.toml missing or has unresolved merge conflict markers' >&2; exit 0; }",
+            "timeout": 10
           }
         ]
       },

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,12 @@ See `agents/docs/build-system.md` for full command execution rules and forbidden
 ### Error Fixing Policy
 - **Fix ALL encountered errors immediately**, even pre-existing ones unrelated to your current task
 
+### Examples Policy
+- **Keep the `examples/` tree minimal.** Do NOT create new one-off `.ino` sketches to try out functionality.
+- **Test new functionality in `examples/AutoResearch/AutoResearch.ino`** — that is the canonical scratch target for live/device testing.
+- A `PreToolUse` hook (`ci/hooks/protect_example_ino.py`) **blocks creation of any new `.ino` under `examples/`**. Editing an existing `.ino` is always allowed.
+- **Override (only when a genuinely new example is required):** prepend a comment containing the `FL_AGENT_ALLOW_NEW_EXAMPLE` directive to the file (e.g. `// FL_AGENT_ALLOW_NEW_EXAMPLE`), or launch with the `FL_AGENT_ALLOW_NEW_EXAMPLE=1` env var.
+
 ### Command Execution
 - **Always use bash wrapper scripts** (`bash test`, `bash compile`, `bash lint`, `bash autoresearch`)
 - **Stay in project root** — never `cd` to subdirectories

--- a/ci/hooks/protect_example_ino.py
+++ b/ci/hooks/protect_example_ino.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""
+PreToolUse hook for Write: prevent spurious creation of new example .ino files.
+
+The examples/ tree should stay minimal. Agents tend to spin up new one-off
+.ino sketches to test functionality; instead, new functionality should be
+exercised inside the existing examples/AutoResearch/AutoResearch.ino sketch
+(the canonical scratch target for live/device testing).
+
+This hook blocks the creation of a NEW .ino file anywhere under examples/.
+Editing an existing .ino (the file already exists on disk) is always allowed.
+
+Override (FL_* directive, same convention as the other FastLED hooks):
+  1. In-content directive — prepend a comment containing FL_AGENT_ALLOW_NEW_EXAMPLE
+     to the file you are writing. This documents the deliberate intent in the file
+     itself. Example first line:
+         // FL_AGENT_ALLOW_NEW_EXAMPLE
+  2. Environment variable — launch Claude with FL_AGENT_ALLOW_NEW_EXAMPLE=1.
+
+Exit codes:
+- 0: Allow the write
+- 2: Block the write (error message sent to agent)
+"""
+
+import json
+import os
+import sys
+
+
+OVERRIDE_TOKEN = "FL_AGENT_ALLOW_NEW_EXAMPLE"
+
+
+def main() -> int:
+    try:
+        input_data = json.load(sys.stdin)
+    except json.JSONDecodeError:
+        return 0
+
+    tool_name = input_data.get("tool_name", "")
+    if tool_name != "Write":
+        return 0
+
+    tool_input = input_data.get("tool_input", {})
+    file_path = tool_input.get("file_path", "")
+    if not file_path:
+        return 0
+
+    # Environment override (human escape hatch, consistent with other hooks).
+    if os.environ.get(OVERRIDE_TOKEN) in ("1", "true", "True", "TRUE"):
+        return 0
+
+    # In-content directive override: agent prepends the FL_* directive.
+    content = tool_input.get("content", "") or ""
+    if OVERRIDE_TOKEN in content:
+        return 0
+
+    # Normalize to forward slashes.
+    file_path = file_path.replace("\\", "/")
+
+    # Project root = directory two levels above this hook (ci/hooks/ -> root).
+    project_root = os.path.dirname(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    ).replace("\\", "/")
+
+    if file_path.startswith(project_root):
+        rel_path = file_path[len(project_root) :].lstrip("/")
+    else:
+        norm_file = os.path.normpath(file_path).replace("\\", "/")
+        norm_root = os.path.normpath(project_root).replace("\\", "/")
+        if norm_file.startswith(norm_root):
+            rel_path = norm_file[len(norm_root) :].lstrip("/")
+        else:
+            # Outside the project root — not our concern.
+            return 0
+
+    # Only guard .ino files under examples/.
+    if not rel_path.startswith("examples/") or not rel_path.endswith(".ino"):
+        return 0
+
+    # If the file already exists, this is an edit/overwrite — always allowed.
+    full_path = os.path.join(project_root, rel_path)
+    if os.path.exists(full_path):
+        return 0
+
+    error_lines = [
+        f"BLOCKED: Creating a new example sketch '{rel_path}'.",
+        "",
+        "The examples/ tree is kept intentionally minimal. New one-off .ino",
+        "sketches should NOT be created to test functionality.",
+        "",
+        "What to do instead:",
+        "  Exercise new functionality inside the existing scratch sketch:",
+        "      examples/AutoResearch/AutoResearch.ino",
+        "  That is the canonical target for testing new functionality.",
+        "",
+        "If you genuinely need a brand-new example, force creation with the FL_* directive:",
+        f"  1. Prepend a comment containing {OVERRIDE_TOKEN} to the file content, e.g.:",
+        f"         // {OVERRIDE_TOKEN}",
+        f"  2. Or launch Claude with the env var: {OVERRIDE_TOKEN}=1",
+    ]
+    print("\n".join(error_lines), file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ci/hooks/protect_example_ino.py
+++ b/ci/hooks/protect_example_ino.py
@@ -35,8 +35,14 @@ OVERRIDE_ENV_VAR = "FL_AGENT_ALLOW_NEW_EXAMPLE"
 def main() -> int:
     try:
         input_data = json.load(sys.stdin)
-    except json.JSONDecodeError:
-        return 0
+    except KeyboardInterrupt:
+        raise
+    except json.JSONDecodeError as exc:
+        print(
+            f"protect_example_ino: invalid hook payload: {exc}",
+            file=sys.stderr,
+        )
+        return 2
 
     tool_name = input_data.get("tool_name", "")
     if tool_name != "Write":
@@ -51,9 +57,20 @@ def main() -> int:
     if os.environ.get(OVERRIDE_ENV_VAR) in ("1", "true", "True", "TRUE"):
         return 0
 
-    # In-content directive override: agent prepends the FL_* directive.
+    # In-content directive override: agent prepends the FL_* directive as a
+    # leading comment. Restrict to the first non-empty line (and require it to
+    # be a comment) so the token cannot accidentally bypass the hook by merely
+    # appearing somewhere in the file body.
     content = tool_input.get("content", "") or ""
-    if OVERRIDE_ENV_VAR in content:
+    first_non_empty_line = ""
+    for line in content.splitlines():
+        if line.strip():
+            first_non_empty_line = line.strip()
+            break
+    if (
+        first_non_empty_line.startswith("//")
+        and OVERRIDE_ENV_VAR in first_non_empty_line
+    ):
         return 0
 
     # Normalize to forward slashes.

--- a/ci/hooks/protect_example_ino.py
+++ b/ci/hooks/protect_example_ino.py
@@ -27,7 +27,9 @@ import os
 import sys
 
 
-OVERRIDE_TOKEN = "FL_AGENT_ALLOW_NEW_EXAMPLE"
+# Doubles as an environment variable AND an in-content directive token
+# (the Write tool has no command string to prepend the env var to).
+OVERRIDE_ENV_VAR = "FL_AGENT_ALLOW_NEW_EXAMPLE"
 
 
 def main() -> int:
@@ -46,12 +48,12 @@ def main() -> int:
         return 0
 
     # Environment override (human escape hatch, consistent with other hooks).
-    if os.environ.get(OVERRIDE_TOKEN) in ("1", "true", "True", "TRUE"):
+    if os.environ.get(OVERRIDE_ENV_VAR) in ("1", "true", "True", "TRUE"):
         return 0
 
     # In-content directive override: agent prepends the FL_* directive.
     content = tool_input.get("content", "") or ""
-    if OVERRIDE_TOKEN in content:
+    if OVERRIDE_ENV_VAR in content:
         return 0
 
     # Normalize to forward slashes.
@@ -94,9 +96,9 @@ def main() -> int:
         "  That is the canonical target for testing new functionality.",
         "",
         "If you genuinely need a brand-new example, force creation with the FL_* directive:",
-        f"  1. Prepend a comment containing {OVERRIDE_TOKEN} to the file content, e.g.:",
-        f"         // {OVERRIDE_TOKEN}",
-        f"  2. Or launch Claude with the env var: {OVERRIDE_TOKEN}=1",
+        f"  1. Prepend a comment containing {OVERRIDE_ENV_VAR} to the file content, e.g.:",
+        f"         // {OVERRIDE_ENV_VAR}",
+        f"  2. Or launch Claude with the env var: {OVERRIDE_ENV_VAR}=1",
     ]
     print("\n".join(error_lines), file=sys.stderr)
     return 2


### PR DESCRIPTION
## Summary
- Add `ci/hooks/protect_example_ino.py`, a `PreToolUse` Write hook that blocks creating a **new** `.ino` file anywhere under `examples/`. Editing an existing `.ino` is always allowed.
- Wire it into `.claude/settings.json` under the `Write` matcher (same pyproject-root/conflict-marker wrapper as the other hooks).
- Document the policy in `CLAUDE.md`: keep `examples/` minimal; test new functionality in `examples/AutoResearch/AutoResearch.ino`.

## Why
Agents tend to spin up one-off `.ino` sketches to try things out, bloating the examples tree. This adds friction so new functionality is exercised in the canonical scratch sketch instead.

## Override (FL_* directive)
Follows the existing `FL_AGENT_ALLOW_*` convention used by `protect_platform_headers.py` and `check_forbidden_commands.py`. To force creation of a genuinely-new example:
- Prepend a comment containing `FL_AGENT_ALLOW_NEW_EXAMPLE` to the file content (e.g. `// FL_AGENT_ALLOW_NEW_EXAMPLE`), or
- Launch with env var `FL_AGENT_ALLOW_NEW_EXAMPLE=1`.

## Test plan
- [x] New `.ino` under `examples/`, no directive → blocked (exit 2) with guidance
- [x] New `.ino` with in-content directive → allowed
- [x] New `.ino` with env-var override → allowed
- [x] Overwrite of existing `.ino` (e.g. AutoResearch) → allowed
- [x] New non-`.ino` file under `examples/` → allowed
- [x] `.ino` outside `examples/` → allowed
- [x] `bash lint` clean; `.claude/settings.json` valid JSON with hook wired

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an examples management policy describing a minimal canonical examples set and rules for editing examples.

* **Chores**
  * Added a pre-write validation hook (configured in settings) that blocks creation of new example files under examples/ unless explicitly overridden via an environment flag or in-file directive; edits to existing examples remain allowed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/FastLED/pull/2537?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->