### PR TITLE
perf(wave8): byte-indexed expansion LUT (#2526) — 1.66x on ESP32-P4

### DIFF
--- a/examples/AutoResearch/AutoResearch.ino
+++ b/examples/AutoResearch/AutoResearch.ino
@@ -194,6 +194,7 @@
 #include "AutoResearchAsync.h"
 #include "AutoResearchPlatform.h"
 #include "AutoResearchSimd.h"
+#include "AutoResearchWave8Expand.h"  // boot-time #2526 micro-bench
 
 // ============================================================================
 // Teensy Hardware Watchdog (crash recovery) - DISABLED
@@ -329,6 +330,9 @@ void setup() {
     // SIMD AutoResearch
     // ========================================================================
     int simd_failures = autoresearch::simd_check::runSimdTests();
+
+    // #2526 expansion micro-bench: prints via esp_rom_printf -> USB-JTAG console.
+    autoresearch::wave8_bench::runWave8ExpandBenchmark();
     if (simd_failures > 0) {
         FL_ERROR("SIMD autoresearch failed - " << simd_failures << " test(s) failed");
     }

--- a/examples/AutoResearch/AutoResearch.ino
+++ b/examples/AutoResearch/AutoResearch.ino
@@ -331,8 +331,16 @@ void setup() {
     // ========================================================================
     int simd_failures = autoresearch::simd_check::runSimdTests();
 
-    // #2526 expansion micro-bench: prints via esp_rom_printf -> USB-JTAG console.
-    autoresearch::wave8_bench::runWave8ExpandBenchmark();
+    // #2526 expansion micro-bench is RPC-driven (wave8ExpandBenchmark, registered
+    // in AutoResearchRemote.cpp). NOT computed at boot by default — flip
+    // -DFL_BENCH_WAVE8_AT_BOOT=1 to run once at startup as a bridge until the
+    // testSimd RPC routing on P4 is fixed (#2541).
+#ifdef FL_BENCH_WAVE8_AT_BOOT
+    {
+        auto _w8r = autoresearch::wave8_bench::measureWave8Expand();
+        autoresearch::wave8_bench::printWave8ExpandResultRom(_w8r);
+    }
+#endif
     if (simd_failures > 0) {
         FL_ERROR("SIMD autoresearch failed - " << simd_failures << " test(s) failed");
     }

--- a/examples/AutoResearch/AutoResearchRemote.cpp
+++ b/examples/AutoResearch/AutoResearchRemote.cpp
@@ -30,6 +30,7 @@
 #include "fl/task/promise.h"
 #include "fl/math/simd.h"
 #include "AutoResearchSimd.h"
+#include "AutoResearchWave8Expand.h"  // #2526 wave8ExpandBenchmark RPC
 #include "fl/system/heap.h"
 #include "fl/chipsets/spi.h"
 #include "fl/channels/config.h"
@@ -1567,9 +1568,17 @@ void AutoResearchRemoteControl::registerFunctions(fl::shared_ptr<AutoResearchSta
         testSimdBenchmark_fn.set("description", "Benchmark multiply speed: float vs s16x16 vs s16x16x4 SIMD");
         functions.push_back(testSimdBenchmark_fn);
 
+        fl::json wave8ExpandBenchmark_fn = fl::json::object();
+        wave8ExpandBenchmark_fn.set("name", "wave8ExpandBenchmark");
+        wave8ExpandBenchmark_fn.set("phase", "Phase 4: Utility");
+        wave8ExpandBenchmark_fn.set("args", "[{iterations}] (optional, default 30000, max 200000)");
+        wave8ExpandBenchmark_fn.set("returns", "{success, iterations, expand_nibble_us, expand_byte_us, expand_batched_us, transpose16_nibble_us, transpose16_byte_us, sink}");
+        wave8ExpandBenchmark_fn.set("description", "Bench PARLIO Wave8 expansion (#2526): nibble vs byte vs batched LUT, plus full per-byte-position cost (expansion + 16-lane transpose)");
+        functions.push_back(wave8ExpandBenchmark_fn);
+
         fl::json response = fl::json::object();
         response.set("success", true);
-        response.set("totalFunctions", static_cast<int64_t>(22));
+        response.set("totalFunctions", static_cast<int64_t>(23));
         response.set("functions", functions);
         return response;
     });
@@ -1662,6 +1671,37 @@ void AutoResearchRemoteControl::registerFunctions(fl::shared_ptr<AutoResearchSta
         div.set("u16x16_us", result.div_u16x16_us);
         response.set("div", div);
 
+        return response;
+    });
+
+    // Register "wave8ExpandBenchmark" - PARLIO Wave8 expansion bench (#2526).
+    // Compares nibble-LUT vs byte-LUT vs batched byte-LUT, and times the full
+    // per-byte-position cost (expansion + 16-lane transpose) for both LUTs.
+    // Args: {iterations} (optional, default 30000, max 200000)
+    mRemote->bind("wave8ExpandBenchmark", [](const fl::json& args) -> fl::json {
+        fl::json response = fl::json::object();
+
+        int iters = 30000;
+        fl::json config;
+        if (args.is_object()) {
+            config = args;
+        } else if (args.is_array() && args.size() >= 1 && args[0].is_object()) {
+            config = args[0];
+        }
+        if (!config.is_null() && config.contains("iterations") && config["iterations"].is_int()) {
+            iters = static_cast<int>(config["iterations"].as_int().value());
+        }
+
+        auto r = autoresearch::wave8_bench::measureWave8Expand(iters);
+
+        response.set("success", true);
+        response.set("iterations", static_cast<int64_t>(r.iters));
+        response.set("expand_nibble_us", static_cast<int64_t>(r.expand_nibble_us));
+        response.set("expand_byte_us", static_cast<int64_t>(r.expand_byte_us));
+        response.set("expand_batched_us", static_cast<int64_t>(r.expand_batched_us));
+        response.set("transpose16_nibble_us", static_cast<int64_t>(r.transpose16_nibble_us));
+        response.set("transpose16_byte_us", static_cast<int64_t>(r.transpose16_byte_us));
+        response.set("sink", static_cast<int64_t>(r.sink));
         return response;
     });
 

--- a/examples/AutoResearch/AutoResearchWave8Expand.h
+++ b/examples/AutoResearch/AutoResearchWave8Expand.h
@@ -1,12 +1,17 @@
 /// @file AutoResearchWave8Expand.h
-/// @brief Boot-time micro-benchmark for the Wave8 expansion (#2526).
+/// @brief Wave8 expansion micro-benchmark for #2526.
 ///
-/// Compares the current nibble-LUT expansion against the byte-indexed (256x8)
-/// LUT proposed in #2526, plus a batched-byte variant (S3). Output goes through
-/// esp_rom_printf so it reaches the USB-Serial-JTAG console (= COM25) at boot
-/// — the testSimd RPC path is currently blocked by a UART0-vs-USB-JTAG routing
-/// issue on P4 (CDC On Boot = 0; see #2536/#2538). Capturing boot serial on
-/// COM25 sidesteps that.
+/// Compares the nibble-LUT expansion path against the byte-indexed (256x8)
+/// LUT and a batched-byte variant (S3), AND times the full per-byte-position
+/// production cost (expansion + 16-lane transpose) for both LUTs.
+///
+/// **Invocation:** intended to be called via the `wave8ExpandBenchmark` RPC
+/// (registered in AutoResearchRemote.cpp). Not computed at boot by default.
+/// Build with `-DFL_BENCH_WAVE8_AT_BOOT=1` to also fire once at setup() —
+/// that's a bridge until the testSimd RPC routing on P4 is fixed (#2541), at
+/// which point the bench is purely RPC-driven. Boot-time output uses
+/// `esp_rom_printf` because `FL_PRINT` doesn't currently reach COM25 on P4
+/// (see #2540/#2541).
 
 #pragma once
 
@@ -17,22 +22,43 @@
 #include "fl/stl/int.h"
 
 #if defined(ARDUINO_ARCH_ESP32) || defined(ESP_PLATFORM)
-#include <Arduino.h>     // micros()
-#include <esp_rom_sys.h> // esp_rom_printf -> USB-Serial-JTAG console
-#define FL_BENCH_PRINTF esp_rom_printf
-#define FL_BENCH_ENABLED 1
-#else
-#define FL_BENCH_ENABLED 0
+#include <Arduino.h> // micros()
+#endif
+#if defined(ARDUINO_ARCH_ESP32) || defined(ESP_PLATFORM)
+#include <esp_rom_sys.h> // esp_rom_printf -> USB-Serial-JTAG console (#2540)
 #endif
 
 namespace autoresearch {
 namespace wave8_bench {
 
-#if FL_BENCH_ENABLED
+struct Wave8ExpandResult {
+    fl::u32 iters;
+    // Expansion in isolation (the #2526 strategies side-by-side).
+    fl::u32 expand_nibble_us;     // current production
+    fl::u32 expand_byte_us;       // S1: byte-indexed 256x8 LUT
+    fl::u32 expand_batched_us;    // S3: byte LUT, load-all-then-store-all
+    // Full per-byte-position cost (expansion + 16-lane transpose). This is
+    // what the parlio engine actually pays per byte-position * 768/frame.
+    fl::u32 transpose16_nibble_us;
+    fl::u32 transpose16_byte_us;
+    fl::u32 sink;
+};
 
-inline void runWave8ExpandBenchmark() {
-    // Representative WS2812B-ish timing (ratios that yield non-degenerate
-    // expansion patterns; the absolute values don't matter for this micro-bench).
+#if defined(ARDUINO_ARCH_ESP32) || defined(ESP_PLATFORM)
+
+/// Pure compute: builds both LUTs, runs all five timed paths, returns numbers.
+/// No printing — the caller (RPC handler or boot-time bridge) decides.
+inline Wave8ExpandResult measureWave8Expand(int iters_in = 30000) {
+    Wave8ExpandResult result{};
+    if (iters_in < 1) {
+        iters_in = 1;
+    }
+    if (iters_in > 200000) {
+        iters_in = 200000;
+    }
+    result.iters = static_cast<fl::u32>(iters_in);
+
+    // Representative WS2812B-ish timing; absolutes don't matter for the bench.
     fl::ChipsetTiming timing;
     timing.T1 = 400;
     timing.T2 = 450;
@@ -41,97 +67,143 @@ inline void runWave8ExpandBenchmark() {
     fl::Wave8BitExpansionLut nibLut = fl::buildWave8ExpansionLUT(timing);
     fl::Wave8ByteExpansionLut byteLut = fl::buildWave8ByteExpansionLUT(nibLut);
 
-    // 16 lane inputs, mixed values; output buffer matches the production
-    // wave8Transpose_16() stack layout (16 Wave8Byte = 128 bytes).
     fl::u8 lanes[16];
     for (int i = 0; i < 16; ++i) {
         lanes[i] = static_cast<fl::u8>(i * 17 + 3);
     }
     fl::Wave8Byte out[16];
-
     volatile fl::u32 sink = 0;
-
-    // One iter == one "byte-position" of encode = 16 lane expansions.
-    // Production encodes 768 byte-positions per frame (256 LEDs * 3 channels).
-    // Pick ITERS large enough that micros() jitter is <1% (~hundreds of ms total).
-    const int ITERS = 30000; // 30000 * 16 = 480,000 expansions per measurement
 
     // Warm caches / icache.
     for (int i = 0; i < 16; ++i) {
         fl::detail::wave8_convert_byte_to_wave8byte(lanes[i], nibLut, &out[i]);
         fl::detail::wave8_expand_byte(lanes[i], byteLut, &out[i]);
     }
+    fl::u8 transposed[16 * sizeof(fl::Wave8Byte)];
+    fl::wave8Transpose_16(reinterpret_cast<const fl::u8(&)[16]>(lanes), nibLut,
+                          reinterpret_cast<fl::u8(&)[16 * sizeof(fl::Wave8Byte)]>(transposed));
+    fl::wave8Transpose_16(reinterpret_cast<const fl::u8(&)[16]>(lanes), byteLut,
+                          reinterpret_cast<fl::u8(&)[16 * sizeof(fl::Wave8Byte)]>(transposed));
 
-    // --- Nibble path (current production) ---
-    fl::u32 t0 = micros();
-    for (int it = 0; it < ITERS; ++it) {
-        lanes[0] = static_cast<fl::u8>(it);
-        lanes[8] = static_cast<fl::u8>(~it);
-        for (int i = 0; i < 16; ++i) {
-            fl::detail::wave8_convert_byte_to_wave8byte(lanes[i], nibLut, &out[i]);
+    const int iters = iters_in;
+
+    // --- Expansion only: nibble (current production path) ---
+    {
+        fl::u32 t0 = micros();
+        for (int it = 0; it < iters; ++it) {
+            lanes[0] = static_cast<fl::u8>(it);
+            lanes[8] = static_cast<fl::u8>(~it);
+            for (int i = 0; i < 16; ++i) {
+                fl::detail::wave8_convert_byte_to_wave8byte(lanes[i], nibLut, &out[i]);
+            }
+            sink ^= out[0].symbols[0].data ^ out[15].symbols[7].data;
         }
-        sink ^= out[0].symbols[0].data ^ out[15].symbols[7].data;
+        result.expand_nibble_us = micros() - t0;
     }
-    fl::u32 nibble_us = micros() - t0;
 
-    // --- Byte-LUT path (S1: byte-indexed 256x8) ---
-    t0 = micros();
-    for (int it = 0; it < ITERS; ++it) {
-        lanes[0] = static_cast<fl::u8>(it);
-        lanes[8] = static_cast<fl::u8>(~it);
-        for (int i = 0; i < 16; ++i) {
-            fl::detail::wave8_expand_byte(lanes[i], byteLut, &out[i]);
+    // --- Expansion only: byte-LUT (S1) ---
+    {
+        fl::u32 t0 = micros();
+        for (int it = 0; it < iters; ++it) {
+            lanes[0] = static_cast<fl::u8>(it);
+            lanes[8] = static_cast<fl::u8>(~it);
+            for (int i = 0; i < 16; ++i) {
+                fl::detail::wave8_expand_byte(lanes[i], byteLut, &out[i]);
+            }
+            sink ^= out[0].symbols[0].data ^ out[15].symbols[7].data;
         }
-        sink ^= out[0].symbols[0].data ^ out[15].symbols[7].data;
+        result.expand_byte_us = micros() - t0;
     }
-    fl::u32 byte_us = micros() - t0;
 
-    // --- Batched byte path (S3: load-all-then-store-all, ILP) ---
-    t0 = micros();
-    for (int it = 0; it < ITERS; ++it) {
-        lanes[0] = static_cast<fl::u8>(it);
-        lanes[8] = static_cast<fl::u8>(~it);
-        fl::u32 lo[16];
-        fl::u32 hi[16];
-        for (int i = 0; i < 16; ++i) {
-            const fl::u32 *src = fl::bit_cast_ptr<const fl::u32>(&byteLut.lut[lanes[i]]);
-            lo[i] = src[0];
-            hi[i] = src[1];
+    // --- Expansion only: batched byte-LUT (S3: load-all-then-store-all) ---
+    {
+        fl::u32 t0 = micros();
+        for (int it = 0; it < iters; ++it) {
+            lanes[0] = static_cast<fl::u8>(it);
+            lanes[8] = static_cast<fl::u8>(~it);
+            fl::u32 lo[16];
+            fl::u32 hi[16];
+            for (int i = 0; i < 16; ++i) {
+                const fl::u32 *src = fl::bit_cast_ptr<const fl::u32>(&byteLut.lut[lanes[i]]);
+                lo[i] = src[0];
+                hi[i] = src[1];
+            }
+            for (int i = 0; i < 16; ++i) {
+                fl::u32 *dst = fl::bit_cast_ptr<fl::u32>(&out[i]);
+                dst[0] = lo[i];
+                dst[1] = hi[i];
+            }
+            sink ^= out[0].symbols[0].data ^ out[15].symbols[7].data;
         }
-        for (int i = 0; i < 16; ++i) {
-            fl::u32 *dst = fl::bit_cast_ptr<fl::u32>(&out[i]);
-            dst[0] = lo[i];
-            dst[1] = hi[i];
-        }
-        sink ^= out[0].symbols[0].data ^ out[15].symbols[7].data;
+        result.expand_batched_us = micros() - t0;
     }
-    fl::u32 batched_us = micros() - t0;
 
-    // Frame-equivalent micros: per-frame is 768 byte-positions vs our ITERS.
-    fl::u32 nibble_frame_us = static_cast<fl::u32>(static_cast<fl::u64>(nibble_us) * 768 / ITERS);
-    fl::u32 byte_frame_us = static_cast<fl::u32>(static_cast<fl::u64>(byte_us) * 768 / ITERS);
-    fl::u32 batched_frame_us = static_cast<fl::u32>(static_cast<fl::u64>(batched_us) * 768 / ITERS);
+    // --- Full per-byte-position (expansion + 16-lane transpose), nibble path ---
+    {
+        fl::u32 t0 = micros();
+        for (int it = 0; it < iters; ++it) {
+            lanes[0] = static_cast<fl::u8>(it);
+            lanes[8] = static_cast<fl::u8>(~it);
+            fl::wave8Transpose_16(reinterpret_cast<const fl::u8(&)[16]>(lanes), nibLut,
+                                  reinterpret_cast<fl::u8(&)[16 * sizeof(fl::Wave8Byte)]>(transposed));
+            sink ^= transposed[0] ^ transposed[127];
+        }
+        result.transpose16_nibble_us = micros() - t0;
+    }
 
-    // Speedups as percentage * 100 (integer math, avoid floats in esp_rom_printf).
-    fl::u32 spd_byte_x100 = (byte_us > 0)
-        ? static_cast<fl::u32>(static_cast<fl::u64>(nibble_us) * 100 / byte_us) : 0;
-    fl::u32 spd_batched_x100 = (batched_us > 0)
-        ? static_cast<fl::u32>(static_cast<fl::u64>(nibble_us) * 100 / batched_us) : 0;
+    // --- Full per-byte-position (expansion + 16-lane transpose), byte-LUT path ---
+    {
+        fl::u32 t0 = micros();
+        for (int it = 0; it < iters; ++it) {
+            lanes[0] = static_cast<fl::u8>(it);
+            lanes[8] = static_cast<fl::u8>(~it);
+            fl::wave8Transpose_16(reinterpret_cast<const fl::u8(&)[16]>(lanes), byteLut,
+                                  reinterpret_cast<fl::u8(&)[16 * sizeof(fl::Wave8Byte)]>(transposed));
+            sink ^= transposed[0] ^ transposed[127];
+        }
+        result.transpose16_byte_us = micros() - t0;
+    }
 
-    FL_BENCH_PRINTF("\nBENCH_EXPAND_START (issue #2526)\n");
-    FL_BENCH_PRINTF("BENCH_EXPAND iters=%d  nibble_us=%u byte_us=%u batched_us=%u  sink=%u\n",
-                    ITERS, nibble_us, byte_us, batched_us,
-                    static_cast<fl::u32>(sink));
-    FL_BENCH_PRINTF("BENCH_EXPAND frame_equiv_us  nibble=%u byte=%u batched=%u\n",
-                    nibble_frame_us, byte_frame_us, batched_frame_us);
-    FL_BENCH_PRINTF("BENCH_EXPAND speedup_x100  byte_vs_nibble=%u batched_vs_nibble=%u\n",
-                    spd_byte_x100, spd_batched_x100);
-    FL_BENCH_PRINTF("BENCH_EXPAND_END\n\n");
+    result.sink = static_cast<fl::u32>(sink);
+    return result;
 }
 
-#else  // !FL_BENCH_ENABLED
+/// Optional helper that prints the result via esp_rom_printf (reaches COM25
+/// on P4 today). Used only by the gated boot-time bridge; the RPC handler
+/// JSON-serializes the struct directly. Will be retired in favor of FL_PRINT
+/// once the routing in #2541 is fixed (see #2540).
+inline void printWave8ExpandResultRom(const Wave8ExpandResult &r) {
+    const fl::u64 iters64 = (r.iters > 0) ? r.iters : 1;
 
-inline void runWave8ExpandBenchmark() { /* no-op on non-ESP32 */ }
+    fl::u32 spd_byte = (r.expand_byte_us > 0)
+        ? static_cast<fl::u32>(static_cast<fl::u64>(r.expand_nibble_us) * 100 / r.expand_byte_us) : 0;
+    fl::u32 spd_batched = (r.expand_batched_us > 0)
+        ? static_cast<fl::u32>(static_cast<fl::u64>(r.expand_nibble_us) * 100 / r.expand_batched_us) : 0;
+    fl::u32 spd_t16 = (r.transpose16_byte_us > 0)
+        ? static_cast<fl::u32>(static_cast<fl::u64>(r.transpose16_nibble_us) * 100 / r.transpose16_byte_us) : 0;
+
+    fl::u32 expand_nib_frame = static_cast<fl::u32>(static_cast<fl::u64>(r.expand_nibble_us) * 768 / iters64);
+    fl::u32 expand_byte_frame = static_cast<fl::u32>(static_cast<fl::u64>(r.expand_byte_us) * 768 / iters64);
+    fl::u32 t16_nib_frame = static_cast<fl::u32>(static_cast<fl::u64>(r.transpose16_nibble_us) * 768 / iters64);
+    fl::u32 t16_byte_frame = static_cast<fl::u32>(static_cast<fl::u64>(r.transpose16_byte_us) * 768 / iters64);
+
+    esp_rom_printf("\nBENCH_EXPAND_START (issue #2526)\n");
+    esp_rom_printf("BENCH_EXPAND iters=%u sink=%u\n", r.iters, r.sink);
+    esp_rom_printf("BENCH_EXPAND expand_only_us  nibble=%u byte=%u batched=%u\n",
+                   r.expand_nibble_us, r.expand_byte_us, r.expand_batched_us);
+    esp_rom_printf("BENCH_EXPAND transpose16_us  nibble=%u byte=%u\n",
+                   r.transpose16_nibble_us, r.transpose16_byte_us);
+    esp_rom_printf("BENCH_EXPAND frame_equiv_us  expand_nibble=%u expand_byte=%u t16_nibble=%u t16_byte=%u\n",
+                   expand_nib_frame, expand_byte_frame, t16_nib_frame, t16_byte_frame);
+    esp_rom_printf("BENCH_EXPAND speedup_x100  expand=%u batched=%u transpose16=%u\n",
+                   spd_byte, spd_batched, spd_t16);
+    esp_rom_printf("BENCH_EXPAND_END\n\n");
+}
+
+#else // non-ESP32
+
+inline Wave8ExpandResult measureWave8Expand(int /*iters*/ = 30000) { return {}; }
+inline void printWave8ExpandResultRom(const Wave8ExpandResult & /*r*/) {}
 
 #endif
 

--- a/examples/AutoResearch/AutoResearchWave8Expand.h
+++ b/examples/AutoResearch/AutoResearchWave8Expand.h
@@ -1,0 +1,139 @@
+/// @file AutoResearchWave8Expand.h
+/// @brief Boot-time micro-benchmark for the Wave8 expansion (#2526).
+///
+/// Compares the current nibble-LUT expansion against the byte-indexed (256x8)
+/// LUT proposed in #2526, plus a batched-byte variant (S3). Output goes through
+/// esp_rom_printf so it reaches the USB-Serial-JTAG console (= COM25) at boot
+/// — the testSimd RPC path is currently blocked by a UART0-vs-USB-JTAG routing
+/// issue on P4 (CDC On Boot = 0; see #2536/#2538). Capturing boot serial on
+/// COM25 sidesteps that.
+
+#pragma once
+
+#include "fl/channels/detail/wave8.hpp"
+#include "fl/channels/wave8.h"
+#include "fl/chipsets/led_timing.h"
+#include "fl/stl/bit_cast.h"
+#include "fl/stl/int.h"
+
+#if defined(ARDUINO_ARCH_ESP32) || defined(ESP_PLATFORM)
+#include <Arduino.h>     // micros()
+#include <esp_rom_sys.h> // esp_rom_printf -> USB-Serial-JTAG console
+#define FL_BENCH_PRINTF esp_rom_printf
+#define FL_BENCH_ENABLED 1
+#else
+#define FL_BENCH_ENABLED 0
+#endif
+
+namespace autoresearch {
+namespace wave8_bench {
+
+#if FL_BENCH_ENABLED
+
+inline void runWave8ExpandBenchmark() {
+    // Representative WS2812B-ish timing (ratios that yield non-degenerate
+    // expansion patterns; the absolute values don't matter for this micro-bench).
+    fl::ChipsetTiming timing;
+    timing.T1 = 400;
+    timing.T2 = 450;
+    timing.T3 = 400;
+
+    fl::Wave8BitExpansionLut nibLut = fl::buildWave8ExpansionLUT(timing);
+    fl::Wave8ByteExpansionLut byteLut = fl::buildWave8ByteExpansionLUT(nibLut);
+
+    // 16 lane inputs, mixed values; output buffer matches the production
+    // wave8Transpose_16() stack layout (16 Wave8Byte = 128 bytes).
+    fl::u8 lanes[16];
+    for (int i = 0; i < 16; ++i) {
+        lanes[i] = static_cast<fl::u8>(i * 17 + 3);
+    }
+    fl::Wave8Byte out[16];
+
+    volatile fl::u32 sink = 0;
+
+    // One iter == one "byte-position" of encode = 16 lane expansions.
+    // Production encodes 768 byte-positions per frame (256 LEDs * 3 channels).
+    // Pick ITERS large enough that micros() jitter is <1% (~hundreds of ms total).
+    const int ITERS = 30000; // 30000 * 16 = 480,000 expansions per measurement
+
+    // Warm caches / icache.
+    for (int i = 0; i < 16; ++i) {
+        fl::detail::wave8_convert_byte_to_wave8byte(lanes[i], nibLut, &out[i]);
+        fl::detail::wave8_expand_byte(lanes[i], byteLut, &out[i]);
+    }
+
+    // --- Nibble path (current production) ---
+    fl::u32 t0 = micros();
+    for (int it = 0; it < ITERS; ++it) {
+        lanes[0] = static_cast<fl::u8>(it);
+        lanes[8] = static_cast<fl::u8>(~it);
+        for (int i = 0; i < 16; ++i) {
+            fl::detail::wave8_convert_byte_to_wave8byte(lanes[i], nibLut, &out[i]);
+        }
+        sink ^= out[0].symbols[0].data ^ out[15].symbols[7].data;
+    }
+    fl::u32 nibble_us = micros() - t0;
+
+    // --- Byte-LUT path (S1: byte-indexed 256x8) ---
+    t0 = micros();
+    for (int it = 0; it < ITERS; ++it) {
+        lanes[0] = static_cast<fl::u8>(it);
+        lanes[8] = static_cast<fl::u8>(~it);
+        for (int i = 0; i < 16; ++i) {
+            fl::detail::wave8_expand_byte(lanes[i], byteLut, &out[i]);
+        }
+        sink ^= out[0].symbols[0].data ^ out[15].symbols[7].data;
+    }
+    fl::u32 byte_us = micros() - t0;
+
+    // --- Batched byte path (S3: load-all-then-store-all, ILP) ---
+    t0 = micros();
+    for (int it = 0; it < ITERS; ++it) {
+        lanes[0] = static_cast<fl::u8>(it);
+        lanes[8] = static_cast<fl::u8>(~it);
+        fl::u32 lo[16];
+        fl::u32 hi[16];
+        for (int i = 0; i < 16; ++i) {
+            const fl::u32 *src = fl::bit_cast_ptr<const fl::u32>(&byteLut.lut[lanes[i]]);
+            lo[i] = src[0];
+            hi[i] = src[1];
+        }
+        for (int i = 0; i < 16; ++i) {
+            fl::u32 *dst = fl::bit_cast_ptr<fl::u32>(&out[i]);
+            dst[0] = lo[i];
+            dst[1] = hi[i];
+        }
+        sink ^= out[0].symbols[0].data ^ out[15].symbols[7].data;
+    }
+    fl::u32 batched_us = micros() - t0;
+
+    // Frame-equivalent micros: per-frame is 768 byte-positions vs our ITERS.
+    fl::u32 nibble_frame_us = static_cast<fl::u32>(static_cast<fl::u64>(nibble_us) * 768 / ITERS);
+    fl::u32 byte_frame_us = static_cast<fl::u32>(static_cast<fl::u64>(byte_us) * 768 / ITERS);
+    fl::u32 batched_frame_us = static_cast<fl::u32>(static_cast<fl::u64>(batched_us) * 768 / ITERS);
+
+    // Speedups as percentage * 100 (integer math, avoid floats in esp_rom_printf).
+    fl::u32 spd_byte_x100 = (byte_us > 0)
+        ? static_cast<fl::u32>(static_cast<fl::u64>(nibble_us) * 100 / byte_us) : 0;
+    fl::u32 spd_batched_x100 = (batched_us > 0)
+        ? static_cast<fl::u32>(static_cast<fl::u64>(nibble_us) * 100 / batched_us) : 0;
+
+    FL_BENCH_PRINTF("\nBENCH_EXPAND_START (issue #2526)\n");
+    FL_BENCH_PRINTF("BENCH_EXPAND iters=%d  nibble_us=%u byte_us=%u batched_us=%u  sink=%u\n",
+                    ITERS, nibble_us, byte_us, batched_us,
+                    static_cast<fl::u32>(sink));
+    FL_BENCH_PRINTF("BENCH_EXPAND frame_equiv_us  nibble=%u byte=%u batched=%u\n",
+                    nibble_frame_us, byte_frame_us, batched_frame_us);
+    FL_BENCH_PRINTF("BENCH_EXPAND speedup_x100  byte_vs_nibble=%u batched_vs_nibble=%u\n",
+                    spd_byte_x100, spd_batched_x100);
+    FL_BENCH_PRINTF("BENCH_EXPAND_END\n\n");
+}
+
+#else  // !FL_BENCH_ENABLED
+
+inline void runWave8ExpandBenchmark() { /* no-op on non-ESP32 */ }
+
+#endif
+
+} // namespace wave8_bench
+} // namespace autoresearch

--- a/src/fl/channels/detail/wave8.hpp
+++ b/src/fl/channels/detail/wave8.hpp
@@ -60,6 +60,20 @@ void wave8_convert_byte_to_wave8byte(u8 byte_value,
                   1); // 4 bytes = 1 x uint32_t
 }
 
+/// @brief Byte-indexed expansion (#2526): one indexed 8-byte copy.
+///
+/// Single lookup (no >>4/mask, no second index) into the 256×8 byte LUT;
+/// bit-identical to wave8_convert_byte_to_wave8byte(). ~half the index/issue
+/// work for the same memory traffic — the win on the in-order RV32 core.
+FASTLED_FORCE_INLINE FL_IRAM FL_OPTIMIZE_FUNCTION
+void wave8_expand_byte(u8 byte_value,
+                       const Wave8ByteExpansionLut &lut,
+                       Wave8Byte *output) {
+    isr::memcpy_32(fl::bit_cast_ptr<u32>(output),
+                  fl::bit_cast_ptr<const u32>(&lut.lut[byte_value]),
+                  2); // 8 bytes = 2 x uint32_t
+}
+
 // ============================================================================
 // 2-Lane Transposition Helper Macro
 // ============================================================================

--- a/src/fl/channels/wave8.cpp.hpp
+++ b/src/fl/channels/wave8.cpp.hpp
@@ -86,6 +86,53 @@ void wave8Transpose_16(const u8 (&FL_RESTRICT_PARAM lanes)[16],
 }
 
 // ============================================================================
+// Byte-LUT overloads (#2526): cheaper expansion, same DMA output.
+// ============================================================================
+
+FL_OPTIMIZE_FUNCTION FL_IRAM
+void wave8Transpose_2(const u8 (&FL_RESTRICT_PARAM lanes)[2],
+                      const Wave8ByteExpansionLut &lut,
+                      u8 (&FL_RESTRICT_PARAM output)[2 * sizeof(Wave8Byte)]) {
+    Wave8Byte laneWaveformSymbols[2];
+    detail::wave8_expand_byte(lanes[0], lut, &laneWaveformSymbols[0]);
+    detail::wave8_expand_byte(lanes[1], lut, &laneWaveformSymbols[1]);
+    detail::wave8_transpose_2(laneWaveformSymbols, output);
+}
+
+FL_OPTIMIZE_FUNCTION FL_IRAM
+void wave8Transpose_4(const u8 (&FL_RESTRICT_PARAM lanes)[4],
+                      const Wave8ByteExpansionLut &lut,
+                      u8 (&FL_RESTRICT_PARAM output)[4 * sizeof(Wave8Byte)]) {
+    Wave8Byte laneWaveformSymbols[4];
+    for (int lane = 0; lane < 4; lane++) {
+        detail::wave8_expand_byte(lanes[lane], lut, &laneWaveformSymbols[lane]);
+    }
+    detail::wave8_transpose_4(laneWaveformSymbols, output);
+}
+
+FL_OPTIMIZE_FUNCTION FL_IRAM
+void wave8Transpose_8(const u8 (&FL_RESTRICT_PARAM lanes)[8],
+                      const Wave8ByteExpansionLut &lut,
+                      u8 (&FL_RESTRICT_PARAM output)[8 * sizeof(Wave8Byte)]) {
+    Wave8Byte laneWaveformSymbols[8];
+    for (int lane = 0; lane < 8; lane++) {
+        detail::wave8_expand_byte(lanes[lane], lut, &laneWaveformSymbols[lane]);
+    }
+    detail::wave8_transpose_8(laneWaveformSymbols, output);
+}
+
+FL_OPTIMIZE_FUNCTION FL_IRAM
+void wave8Transpose_16(const u8 (&FL_RESTRICT_PARAM lanes)[16],
+                       const Wave8ByteExpansionLut &lut,
+                       u8 (&FL_RESTRICT_PARAM output)[16 * sizeof(Wave8Byte)]) {
+    Wave8Byte laneWaveformSymbols[16];
+    for (int lane = 0; lane < 16; lane++) {
+        detail::wave8_expand_byte(lanes[lane], lut, &laneWaveformSymbols[lane]);
+    }
+    detail::wave8_transpose_16(laneWaveformSymbols, output);
+}
+
+// ============================================================================
 // LUT Builder from Timing Data
 // Note: This is not designed to be called from ISR handlers.
 // ============================================================================
@@ -148,6 +195,22 @@ Wave8BitExpansionLut buildWave8ExpansionLUT(const ChipsetTiming &timing) {
     }
 
     return lut;
+}
+
+// Byte-indexed expansion LUT (#2526). Entry b = high-nibble expansion in
+// symbols[0..3] + low-nibble expansion in symbols[4..7], matching
+// wave8_convert_byte_to_wave8byte() exactly (so the byte path is bit-identical).
+Wave8ByteExpansionLut buildWave8ByteExpansionLUT(const Wave8BitExpansionLut &nibble) {
+    Wave8ByteExpansionLut out;
+    for (int b = 0; b < 256; ++b) {
+        const Wave8Bit *hi = nibble.lut[(b >> 4) & 0xF];
+        const Wave8Bit *lo = nibble.lut[b & 0xF];
+        for (int i = 0; i < 4; ++i) {
+            out.lut[b].symbols[i] = hi[i];
+            out.lut[b].symbols[i + 4] = lo[i];
+        }
+    }
+    return out;
 }
 
 // ============================================================================

--- a/src/fl/channels/wave8.h
+++ b/src/fl/channels/wave8.h
@@ -46,6 +46,17 @@ struct FL_ALIGNAS(8) Wave8BitExpansionLut {
     Wave8Bit lut[16][4]; // nibble -> 4 Wave8Bit (4 bytes per nibble)
 };
 
+/// @brief Byte-indexed expansion LUT (#2526): 256 entries × 8 bytes = 2 KB.
+///
+/// Maps a full input byte directly to its 8 Wave8Bit pulse symbols, so the hot
+/// expansion is a single indexed 8-byte copy instead of two nibble lookups +
+/// two 4-byte copies. Same total memory traffic, ~half the index/issue work —
+/// the win on the in-order RV32 core (which is issue-bound here, not bandwidth-
+/// bound). Keep this in internal SRAM (not PSRAM) so the lookup stays fast.
+struct FL_ALIGNAS(8) Wave8ByteExpansionLut {
+    Wave8Byte lut[256]; // byte -> 8 Wave8Bit (8 bytes per byte)
+};
+
 /// @brief Build a Wave8BitExpansionLut from chipset timing data
 ///
 /// Converts three-phase LED timing (T1, T2, T3) into a nibble lookup table
@@ -58,6 +69,13 @@ struct FL_ALIGNAS(8) Wave8BitExpansionLut {
 /// @param timing ChipsetTiming struct containing T1, T2, T3 in nanoseconds
 /// @return Populated Wave8BitExpansionLut lookup table (64 bytes)
 Wave8BitExpansionLut buildWave8ExpansionLUT(const ChipsetTiming &timing);
+
+/// @brief Build a byte-indexed expansion LUT (#2526) from the nibble LUT.
+///
+/// Entry b is the concatenation of the high-nibble expansion (symbols[0..3])
+/// and the low-nibble expansion (symbols[4..7]) — bit-identical to what
+/// wave8_convert_byte_to_wave8byte() produces. Not for ISR use.
+Wave8ByteExpansionLut buildWave8ByteExpansionLUT(const Wave8BitExpansionLut &nibble);
 
 // Forward declaration for inline function (implementation in detail/wave8.hpp)
 void wave8(u8 lane,
@@ -83,6 +101,27 @@ void wave8Transpose_8(
 void wave8Transpose_16(
     const u8 (&FL_RESTRICT_PARAM lanes)[16],
     const Wave8BitExpansionLut &lut,
+    u8 (&FL_RESTRICT_PARAM output)[16 * sizeof(Wave8Byte)]);
+
+// Byte-LUT overloads (#2526): same semantics, faster expansion path.
+void wave8Transpose_2(
+    const u8 (&FL_RESTRICT_PARAM lanes)[2],
+    const Wave8ByteExpansionLut &lut,
+    u8 (&FL_RESTRICT_PARAM output)[2 * sizeof(Wave8Byte)]);
+
+void wave8Transpose_4(
+    const u8 (&FL_RESTRICT_PARAM lanes)[4],
+    const Wave8ByteExpansionLut &lut,
+    u8 (&FL_RESTRICT_PARAM output)[4 * sizeof(Wave8Byte)]);
+
+void wave8Transpose_8(
+    const u8 (&FL_RESTRICT_PARAM lanes)[8],
+    const Wave8ByteExpansionLut &lut,
+    u8 (&FL_RESTRICT_PARAM output)[8 * sizeof(Wave8Byte)]);
+
+void wave8Transpose_16(
+    const u8 (&FL_RESTRICT_PARAM lanes)[16],
+    const Wave8ByteExpansionLut &lut,
     u8 (&FL_RESTRICT_PARAM output)[16 * sizeof(Wave8Byte)]);
 
 // Untranspose functions (for testing - reverse the transpose operation)

--- a/src/platforms/esp/32/drivers/parlio/parlio_engine.cpp.hpp
+++ b/src/platforms/esp/32/drivers/parlio/parlio_engine.cpp.hpp
@@ -922,7 +922,7 @@ ParlioEngine::populateDmaBuffer(u8* outputBuffer,
                     : 0;
 
                 Wave8Byte wave8_output;
-                fl::detail::wave8_convert_byte_to_wave8byte(byte_value, mWave8Lut, &wave8_output);
+                fl::detail::wave8_expand_byte(byte_value, mWave8ByteLut, &wave8_output);
 
                 // MSB bit packing: Wave8Bit stores pulses MSB-first, PARLIO MSB packing required
                 // (Hardware validation confirms MSB packing is correct for Wave8 format)
@@ -945,7 +945,7 @@ ParlioEngine::populateDmaBuffer(u8* outputBuffer,
                     : 0;
 
                 u8 transposed[2 * sizeof(Wave8Byte)];
-                fl::wave8Transpose_2(reinterpret_cast<const u8(&)[2]>(lanes), mWave8Lut, // ok reinterpret cast - array reference type conversion
+                fl::wave8Transpose_2(reinterpret_cast<const u8(&)[2]>(lanes), mWave8ByteLut, // ok reinterpret cast - array reference type conversion
                                     reinterpret_cast<u8(&)[2 * sizeof(Wave8Byte)]>(transposed)); // ok reinterpret cast - array reference type conversion
 
                 fl::memcpy(outputBuffer + outputIdx, transposed, blockSize);
@@ -959,7 +959,7 @@ ParlioEngine::populateDmaBuffer(u8* outputBuffer,
                 }
 
                 u8 transposed[4 * sizeof(Wave8Byte)];
-                fl::wave8Transpose_4(reinterpret_cast<const u8(&)[4]>(lanes), mWave8Lut, // ok reinterpret cast - array reference type conversion
+                fl::wave8Transpose_4(reinterpret_cast<const u8(&)[4]>(lanes), mWave8ByteLut, // ok reinterpret cast - array reference type conversion
                                     reinterpret_cast<u8(&)[4 * sizeof(Wave8Byte)]>(transposed)); // ok reinterpret cast - array reference type conversion
 
                 fl::memcpy(outputBuffer + outputIdx, transposed, blockSize);
@@ -973,7 +973,7 @@ ParlioEngine::populateDmaBuffer(u8* outputBuffer,
                 }
 
                 u8 transposed[8 * sizeof(Wave8Byte)];
-                fl::wave8Transpose_8(reinterpret_cast<const u8(&)[8]>(lanes), mWave8Lut, // ok reinterpret cast - array reference type conversion
+                fl::wave8Transpose_8(reinterpret_cast<const u8(&)[8]>(lanes), mWave8ByteLut, // ok reinterpret cast - array reference type conversion
                                     reinterpret_cast<u8(&)[8 * sizeof(Wave8Byte)]>(transposed)); // ok reinterpret cast - array reference type conversion
 
                 fl::memcpy(outputBuffer + outputIdx, transposed, blockSize);
@@ -987,7 +987,7 @@ ParlioEngine::populateDmaBuffer(u8* outputBuffer,
                 }
 
                 u8 transposed[16 * sizeof(Wave8Byte)];
-                fl::wave8Transpose_16(reinterpret_cast<const u8(&)[16]>(lanes), mWave8Lut, // ok reinterpret cast - array reference type conversion
+                fl::wave8Transpose_16(reinterpret_cast<const u8(&)[16]>(lanes), mWave8ByteLut, // ok reinterpret cast - array reference type conversion
                                      reinterpret_cast<u8(&)[16 * sizeof(Wave8Byte)]>(transposed)); // ok reinterpret cast - array reference type conversion
 
                 fl::memcpy(outputBuffer + outputIdx, transposed, blockSize);
@@ -1421,6 +1421,8 @@ bool ParlioEngine::initialize(size_t dataWidth,
     }
     // Always build wave8 LUT (needed as fallback and for SPI mode)
     mWave8Lut = buildWave8ExpansionLUT(chipsetTiming);
+    // #2526: also build the byte-indexed LUT used by the hot encode path.
+    mWave8ByteLut = buildWave8ByteExpansionLUT(mWave8Lut);
     mEncodingMode = EncodingMode::CLOCKLESS;
 
     // Configure peripheral (constructor handles -1 filling for unused pins)

--- a/src/platforms/esp/32/drivers/parlio/parlio_engine.h
+++ b/src/platforms/esp/32/drivers/parlio/parlio_engine.h
@@ -295,6 +295,9 @@ private:
 
     // Wave8 lookup table (used for clockless encoding)
     fl::Wave8BitExpansionLut mWave8Lut;
+    // Byte-indexed expansion LUT (#2526): 2 KB, 1 lookup per byte → ~1.7x
+    // faster expansion on ESP32-P4 vs the nibble path; built from mWave8Lut.
+    fl::Wave8ByteExpansionLut mWave8ByteLut;
 
     // Wave3 lookup table and state (used when chipset timing is wave3-eligible)
     fl::Wave3BitExpansionLut mWave3Lut;

--- a/tests/fl/channels/wave8.cpp
+++ b/tests/fl/channels/wave8.cpp
@@ -78,6 +78,28 @@ FL_TEST_CASE("convertToWave8Bit") {
     }
 }
 
+FL_TEST_CASE("buildWave8ByteExpansionLUT matches nibble path for all 256 bytes") {
+    // #2526: the byte-indexed LUT expansion must be bit-identical to the
+    // nibble-LUT expansion for every possible input byte.
+    ChipsetTiming timing;
+    timing.T1 = 250;
+    timing.T2 = 500;
+    timing.T3 = 250;
+
+    Wave8BitExpansionLut nibble = buildWave8ExpansionLUT(timing);
+    Wave8ByteExpansionLut byteLut = buildWave8ByteExpansionLUT(nibble);
+
+    for (int b = 0; b < 256; ++b) {
+        Wave8Byte ref;   // nibble path (current production)
+        Wave8Byte got;   // byte path (#2526)
+        detail::wave8_convert_byte_to_wave8byte(static_cast<u8>(b), nibble, &ref);
+        detail::wave8_expand_byte(static_cast<u8>(b), byteLut, &got);
+        for (int s = 0; s < 8; ++s) {
+            FL_REQUIRE(got.symbols[s].data == ref.symbols[s].data);
+        }
+    }
+}
+
 FL_TEST_CASE("wave8Transpose_4_all_ones_and_zeros") {
     // Build LUT where bit0 = all LOW, bit1 = all HIGH
     ChipsetTiming timing;


### PR DESCRIPTION
## Summary

Implements the byte-indexed expansion LUT proposed in #2526 — the "wider lookups, fewer stores" strategy from the deep-dive comment. Replaces the two nibble lookups in the hot PARLIO encode path with a single indexed 8-byte copy, same bit-exact output, ~half the per-byte index work.

## Why this works
Expansion runs **16 lanes × 768 byte-positions = 12,288×/frame** and was dominated by **index arithmetic + issue width on the in-order RV32 core**, not memory bandwidth. Cutting the per-byte instruction count from ~11 to ~6 (no `>>4`/mask, no second index, single 8-byte load/store pair) is the right shape for that bottleneck — same independent-ops lesson that made the spread-LUT transpose win on this core.

## Changes
- `Wave8ByteExpansionLut` (256×8 = 2 KB) + `buildWave8ByteExpansionLUT(nibble)` builder.
- `detail::wave8_expand_byte()` — single indexed 8-byte copy, `FORCE_INLINE FL_IRAM`.
- Byte-LUT overloads of `wave8Transpose_{2,4,8,16}`; PARLIO engine holds `mWave8ByteLut` alongside `mWave8Lut` and routes **all 5 hot expansion call sites** through it (single-lane + 2/4/8/16-lane multi-lane).
- Host equivalence test: `buildWave8ByteExpansionLUT_matches_nibble_path` checks all 256 input bytes are bit-identical to the nibble path.
- Boot-time micro-bench in AutoResearch (`AutoResearchWave8Expand.h`) prints via `esp_rom_printf` → USB-Serial-JTAG console so results are capturable on COM25 without the broken testSimd RPC (see #2536/#2538).

## Measured on real ESP32-P4 (revision v1.3)
```
iters=30000  nibble_us=350170 byte_us=210419 batched_us=198682
frame_equiv_us  nibble=8964 byte=5386 batched=5086
speedup_x100    byte_vs_nibble=166  batched_vs_nibble=176
```
- **Byte-LUT: 1.66×** (40% time reduction)
- **Batched byte-LUT: 1.76×** (43% time reduction)

At expansion ~55% of encode, this predicts **~1.28× full encode_us** — matching the prediction posted on #2526.

## Test plan
- [x] Host: `bash test wave8 --cpp` (all wave8 tests including new equivalence test pass)
- [x] Host: `bash test parlio_driver --cpp` (parlio path still passes)
- [x] Lint: `bash lint --cpp` clean (incl. the strict NativePlatformDefinesChecker / UsingNamespaceFlInExamplesChecker)
- [x] Device: builds + flashes + boots on ESP32-P4 via PlatformIO (`bash autoresearch esp32p4 --simd --no-fbuild`)
- [x] Device: BENCH_EXPAND numbers captured on COM25 boot (1.66×/1.76× as above)

Refs #2526, #2524 (umbrella), #2533 (spread-LUT transpose precedent), #2538 (P4 PIE backend / serial-routing context for the bench output workaround)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an on-device Wave8 performance benchmark for ESP32, accessible at boot (optional) and via a new remote RPC, reporting multiple expansion/transpose timings.

* **Refactor**
  * Introduced a byte-indexed expansion path and precomputed lookup to speed up Wave8 encoding; runtime engine now uses the faster path for clockless output.

* **Tests**
  * Added unit tests validating byte-indexed expansion matches the previous nibble-based output.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/FastLED/pull/2539?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->