### PR TITLE
fix(addressor): see human replies when detecting resolved threads

### DIFF
--- a/ci/tools/coderabbit_addressor.py
+++ b/ci/tools/coderabbit_addressor.py
@@ -120,6 +120,10 @@ def _repo_slug() -> str:
 
 
 def fetch_comments(pr: int) -> list[Comment]:
+    # Returns ALL review comments on the PR (both CodeRabbit and human),
+    # because _is_resolved needs to see human replies to detect that a
+    # CodeRabbit thread has been addressed. Top-level filtering to
+    # CodeRabbit-authored threads happens in plan().
     repo = _repo_slug()
     out = _run_gh(["api", f"repos/{repo}/pulls/{pr}/comments", "--paginate"])
     raw = cast(list[dict[str, Any]], json.loads(out))
@@ -127,8 +131,6 @@ def fetch_comments(pr: int) -> list[Comment]:
     for c in raw:
         user = cast(dict[str, Any], c.get("user") or {})
         author = cast(str, user.get("login", ""))
-        if author not in CODERABBIT_LOGINS:
-            continue
         comments.append(
             Comment(
                 id=int(c["id"]),
@@ -159,7 +161,9 @@ def _is_resolved(comment: Comment, all_comments: list[Comment]) -> bool:
 
 def plan(pr: int) -> dict[str, Any]:
     comments = fetch_comments(pr)
-    top_level = [c for c in comments if c.in_reply_to is None]
+    top_level = [
+        c for c in comments if c.in_reply_to is None and c.author in CODERABBIT_LOGINS
+    ]
     buckets: dict[str, list[dict[str, Any]]] = {
         "valid-fix": [],
         "style": [],


### PR DESCRIPTION
## Summary
- `ci/tools/coderabbit_addressor.py` `fetch_comments` was dropping every non-CodeRabbit review comment. `_is_resolved` then tried to detect resolution by finding the latest reply in a thread and checking that its author was not CodeRabbit — but the human reply that would satisfy that check had already been filtered out, so the heuristic could never mark any thread resolved.
- Net effect: the local pre-merge hook (`ci/hooks/check_pr_merge_reviews.py`) blocked PR merges even after every CodeRabbit thread had been substantively addressed, replied to, and marked resolved on GitHub.
- Fix: keep all review comments in `fetch_comments` (CodeRabbit + human) and apply the CodeRabbit-author filter only in `plan()`, where it is needed to restrict the *top-level* threads we walk. `_is_resolved` then sees human replies and resolves threads correctly.

## Why now
This bug is currently blocking the merge of PR #2537 (the example-`.ino` guard hook), where both CodeRabbit threads are substantively addressed and confirmed but the local hook still reports them unresolved.

## Test plan
- [x] `uv run python ci/tools/coderabbit_addressor.py 2537 --check` now exits 0 (previously exited 1).
- [x] `--plan` for PR #2537 puts the two existing CodeRabbit threads in their classifier-correct buckets (`false-positive` / [empty after this fix the second one too once a human reply lands]); `valid-fix` and `security-flag` buckets are empty when threads are genuinely resolved.
- [x] `bash lint` clean.
- [x] No behavior change to `--reply`; no schema change to the JSON `--plan` output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal CI tooling to enhance comment processing efficiency in development workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/FastLED/pull/2543?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->