### PR TITLE
fix(test.py): satisfy ty type checker on sys.stdout/stderr.reconfigure

### DIFF
--- a/test.py
+++ b/test.py
@@ -40,15 +40,22 @@ os.chdir(Path(__file__).parent)
 # This must run before any imports that touch stdout (e.g., test runners,
 # rich console) so the buffering policy is set on first write.
 if not sys.stdout.isatty():
-    try:
-        sys.stdout.reconfigure(line_buffering=True)  # type: ignore[union-attr]
-    except (AttributeError, ValueError):
-        pass
+    # `reconfigure` is on io.TextIOWrapper but not the abstract TextIO type
+    # that sys.stdout is typed as. getattr+callable keeps this type-safe across
+    # mypy/pyright/ty without needing per-checker `# ignore` comments.
+    _reconfigure_stdout = getattr(sys.stdout, "reconfigure", None)
+    if callable(_reconfigure_stdout):
+        try:
+            _reconfigure_stdout(line_buffering=True)
+        except ValueError:
+            pass
 if not sys.stderr.isatty():
-    try:
-        sys.stderr.reconfigure(line_buffering=True)  # type: ignore[union-attr]
-    except (AttributeError, ValueError):
-        pass
+    _reconfigure_stderr = getattr(sys.stderr, "reconfigure", None)
+    if callable(_reconfigure_stderr):
+        try:
+            _reconfigure_stderr(line_buffering=True)
+        except ValueError:
+            pass
 
 
 # Ultra-early exit fires BEFORE heavy ci.util.* imports (~318ms savings on cached runs).


### PR DESCRIPTION
## Summary

The Stop hook's `bash lint` (which runs the Astral `ty` type checker) flagged two errors in `test.py` left by an earlier session:

```
test.py:44:9: error[unresolved-attribute] Attribute `reconfigure` is not defined on `TextIO` in union `TextIO | Any`
test.py:49:9: error[unresolved-attribute] Attribute `reconfigure` is not defined on `TextIO` in union `TextIO | Any`
```

`reconfigure` exists on `io.TextIOWrapper` (the concrete class) but not on the abstract `TextIO` type that `sys.stdout`/`sys.stderr` are declared as. The existing `# type: ignore[union-attr]` comment is mypy-syntax and isn't honored by `ty`.

## Change

Use `getattr(sys.std*, "reconfigure", None) + callable(...)` — type-safe across mypy / pyright / ty without per-checker ignore comments. Drop the now-redundant `AttributeError` catch (the `callable` check makes it impossible). `ValueError` handling kept for invalid kwargs at runtime.

```python
# Before
sys.stdout.reconfigure(line_buffering=True)  # type: ignore[union-attr]

# After
_reconfigure_stdout = getattr(sys.stdout, "reconfigure", None)
if callable(_reconfigure_stdout):
    try:
        _reconfigure_stdout(line_buffering=True)
    except ValueError:
        pass
```

## Verification

- `bash lint` — `ty` now passes (diagnostics count 8 → 6, remaining 6 are pre-existing `os.system` deprecation warnings in `ci/` scripts, unrelated)
- No behavior change — same line-buffering policy applied when stdout/stderr are piped


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of output buffering initialization with a safer, more reliable configuration approach.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/FastLED/pull/2544?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->