### PR TITLE
fix(addressor): treat any human reply as resolution, not just latest

### DIFF
--- a/ci/tools/coderabbit_addressor.py
+++ b/ci/tools/coderabbit_addressor.py
@@ -148,15 +148,15 @@ def fetch_comments(pr: int) -> list[Comment]:
 
 
 def _is_resolved(comment: Comment, all_comments: list[Comment]) -> bool:
-    # Resolution heuristic: a non-CodeRabbit author replied in-thread since
-    # the last CodeRabbit message. Proper GraphQL "resolved" state is also
-    # honored via the review-thread API but needs a heavier call — start
-    # with the reply heuristic and evolve if false positives show up.
-    replies = [c for c in all_comments if c.in_reply_to == comment.id]
-    if not replies:
-        return False
-    latest = max(replies, key=lambda c: c.id)
-    return latest.author not in CODERABBIT_LOGINS
+    # Resolution heuristic: any non-CodeRabbit author has replied in-thread.
+    # CodeRabbit acknowledgement replies that arrive after a human reply
+    # (e.g. "thanks for the update") must not un-resolve the thread, so we
+    # cannot use "latest reply is human" — CodeRabbit consistently gets the
+    # last word a few seconds later.
+    for c in all_comments:
+        if c.in_reply_to == comment.id and c.author not in CODERABBIT_LOGINS:
+            return True
+    return False
 
 
 def plan(pr: int) -> dict[str, Any]:


### PR DESCRIPTION
## Summary
The previous `_is_resolved` heuristic asked "is the **latest** reply from a non-CodeRabbit author?" CodeRabbit consistently auto-acknowledges human replies ~20 seconds later ("thanks for the update — the changes ... look exactly right"), which re-introduces itself as the most recent author and flips the heuristic back to *unresolved* even though the human did address the thread.

Switch the heuristic to: **a thread is resolved if any non-CodeRabbit author has replied in it**, regardless of CodeRabbit's follow-up ack.

## Why this matters
This is the same root cause as PR #2543 (which restored visibility of human replies), but with one more failure mode. PR #2543's `--auto` merged immediately on a stale head (no required checks) and squashed only the first fix in — this missing commit is the second half. Without it, the merge-guard hook still falsely blocks PR merges whenever CodeRabbit acknowledges a human's "Fixed in <sha>" reply.

## Test plan
- [x] Verified against both real cases: thread `3326467103` on PR #2537 (CodeRabbit ack'd after human) and thread `3327121742` on PR #2543 (same pattern) — both now correctly classified as resolved.
- [x] `bash lint` clean.
- [x] No schema or interface changes — only the internal `_is_resolved` implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resolution detection for review comments. CodeRabbit now correctly marks a review comment as resolved when any human reply exists in the thread, rather than only checking the most recent reply.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/FastLED/pull/2546?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->