### PR TITLE
perf(parlio): bench encode hot loop with SRAM/PSRAM placements

### DIFF
--- a/examples/AutoResearch/AutoResearch.ino
+++ b/examples/AutoResearch/AutoResearch.ino
@@ -195,6 +195,7 @@
 #include "AutoResearchPlatform.h"
 #include "AutoResearchSimd.h"
 #include "AutoResearchWave8Expand.h"  // boot-time #2526 micro-bench
+#include "AutoResearchParlioEncode.h" // full parlio encode bench (post-byte-LUT)
 
 // ============================================================================
 // Teensy Hardware Watchdog (crash recovery) - DISABLED
@@ -339,6 +340,16 @@ void setup() {
     {
         auto _w8r = autoresearch::wave8_bench::measureWave8Expand();
         autoresearch::wave8_bench::printWave8ExpandResultRom(_w8r);
+    }
+#endif
+
+    // Full PARLIO encode bench (post-byte-LUT, #2526). RPC-driven via
+    // parlioEncodeBenchmark; boot-time bridge gated by FL_BENCH_PARLIO_AT_BOOT
+    // until #2541 testSimd RPC routing is fixed.
+#ifdef FL_BENCH_PARLIO_AT_BOOT
+    {
+        auto _per = autoresearch::parlio_bench::measureParlioEncode();
+        autoresearch::parlio_bench::printParlioEncodeResultRom(_per);
     }
 #endif
     if (simd_failures > 0) {

--- a/examples/AutoResearch/AutoResearchParlioEncode.h
+++ b/examples/AutoResearch/AutoResearchParlioEncode.h
@@ -1,0 +1,247 @@
+/// @file AutoResearchParlioEncode.h
+/// @brief Full PARLIO encode bench for ESP32-P4 (post-byte-LUT, #2526 landed).
+///
+/// Measures the engine's per-byte-position hot path — **16-lane gather +
+/// `wave8Transpose_16` + memcpy 128 B to DMA output** — with the source scratch
+/// and the DMA output each in SRAM or PSRAM (4 combinations). Frame-equivalent
+/// is x768 byte-positions, which matches the 16-channel × 256-LED × 3-byte
+/// production frame size on the attached P4 EV board.
+///
+/// Two questions this bench answers:
+///   1. **Is encode now fast enough for ISR-driven chunked streaming?**
+///      At 800 kHz WS2812B with 16 lanes in parallel, one frame transmits in
+///      `256 * 24 * 1.25 us = 7680 us`. If frame encode < 7680 us, the CPU can
+///      keep ahead of the DMA stream and chunked streaming works.
+///   2. **Is the PSRAM hypothesis (PSRAM is the bottleneck) correct?**
+///      Compare SRAM-scratch / SRAM-output vs PSRAM variants. Prior memory
+///      indicates the P4 L2 cache fully hides PSRAM latency for this access
+///      pattern (×1.00 SRAM vs PSRAM); this rechecks on the byte-LUT version.
+///
+/// Output: `BENCH_PARLIO_*` lines via `esp_rom_printf` -> USB-Serial-JTAG (COM25)
+/// so capture works without the broken testSimd RPC routing (#2541). Gated by
+/// `-DFL_BENCH_PARLIO_AT_BOOT=1` per #2542 — RPC-invokable from
+/// `parlioEncodeBenchmark` in AutoResearchRemote.cpp.
+
+#pragma once
+
+#include "fl/channels/detail/wave8.hpp"
+#include "fl/channels/wave8.h"
+#include "fl/chipsets/led_timing.h"
+#include "fl/stl/bit_cast.h"
+#include "fl/stl/int.h"
+
+#include "fl/stl/cstring.h"  // fl::memcpy / fl::memset
+
+#if defined(ARDUINO_ARCH_ESP32) || defined(ESP_PLATFORM)
+#include <Arduino.h>     // micros()
+#include <esp_heap_caps.h>
+#include <esp_rom_sys.h> // esp_rom_printf -> USB-Serial-JTAG console
+#define FL_PARLIO_BENCH_ENABLED 1
+#else
+#define FL_PARLIO_BENCH_ENABLED 0
+#endif
+
+namespace autoresearch {
+namespace parlio_bench {
+
+struct ParlioEncodeResult {
+    fl::u32 iters;             // byte-positions per measurement
+    fl::u32 lanes;             // 16
+    fl::u32 leds_per_lane;     // 256 (matches the standard P4 test config)
+
+    // Per-byte-position hot loop = 16-lane gather + wave8Transpose_16 + memcpy.
+    // 4 placements of {scratch, output}: SRAM/SRAM, SRAM/PSRAM, PSRAM/SRAM, PSRAM/PSRAM.
+    fl::u32 perpos_ss_us;      // scratch SRAM, output SRAM
+    fl::u32 perpos_sp_us;      // scratch SRAM, output PSRAM
+    fl::u32 perpos_ps_us;      // scratch PSRAM, output SRAM
+    fl::u32 perpos_pp_us;      // scratch PSRAM, output PSRAM
+
+    fl::u32 sink;
+};
+
+#if FL_PARLIO_BENCH_ENABLED
+
+namespace {
+
+// Mirror of the engine's clockless hot loop for one byte-position, 16-lane
+// Wave8 path (parlio_engine.cpp.hpp ≈line 981-994). lane_stride matches the
+// production layout: lane k reads from scratch[k * lane_stride + byte_offset].
+FASTLED_FORCE_INLINE FL_IRAM
+fl::u32 fl_parlio_inner_one_byte_position(const fl::u8 *scratch,
+                                          fl::size_t lane_stride,
+                                          fl::size_t byte_offset,
+                                          const fl::Wave8ByteExpansionLut &byte_lut,
+                                          fl::u8 *output,
+                                          fl::size_t output_idx) {
+    fl::u8 lanes[16];
+    for (fl::size_t lane = 0; lane < 16; lane++) {
+        lanes[lane] = scratch[lane * lane_stride + byte_offset];
+    }
+    fl::u8 transposed[16 * sizeof(fl::Wave8Byte)];
+    fl::wave8Transpose_16(reinterpret_cast<const fl::u8(&)[16]>(lanes), byte_lut,
+                          reinterpret_cast<fl::u8(&)[16 * sizeof(fl::Wave8Byte)]>(transposed));
+    fl::memcpy(output + output_idx, transposed, sizeof(transposed));
+    // Sink to defeat DCE: cheap reduction on a few output bytes.
+    return static_cast<fl::u32>(output[output_idx] ^ output[output_idx + 127]);
+}
+
+// Time one configuration: scratch + output buffers (caller pre-allocates).
+inline fl::u32 fl_parlio_measure(const fl::u8 *scratch, fl::size_t scratch_size,
+                                 fl::u8 *output, fl::size_t output_size,
+                                 const fl::Wave8ByteExpansionLut &byte_lut,
+                                 int iters_byte_positions,
+                                 volatile fl::u32 *sink) {
+    constexpr fl::size_t LANES = 16;
+    constexpr fl::size_t BYTES_PER_LANE = 768; // 256 LEDs × 3
+    const fl::size_t lane_stride = BYTES_PER_LANE;
+    (void)scratch_size;
+    (void)output_size;
+
+    fl::u32 t0 = micros();
+    for (int it = 0; it < iters_byte_positions; ++it) {
+        const fl::size_t byte_offset =
+            static_cast<fl::size_t>(it) % BYTES_PER_LANE;
+        const fl::size_t output_idx =
+            byte_offset * LANES * sizeof(fl::Wave8Byte);
+        *sink ^= fl_parlio_inner_one_byte_position(
+            scratch, lane_stride, byte_offset, byte_lut, output, output_idx);
+    }
+    return micros() - t0;
+}
+
+inline fl::u8 *fl_parlio_alloc(fl::size_t size, bool psram) {
+    return reinterpret_cast<fl::u8 *>(heap_caps_malloc(
+        size,
+        psram ? (MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT)
+              : (MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT)));
+}
+
+} // anonymous namespace
+
+inline ParlioEncodeResult measureParlioEncode(int iters_in = 12000) {
+    ParlioEncodeResult result{};
+    if (iters_in < 1) iters_in = 1;
+    if (iters_in > 200000) iters_in = 200000;
+    result.iters = static_cast<fl::u32>(iters_in);
+    result.lanes = 16;
+    result.leds_per_lane = 256;
+
+    constexpr fl::size_t LANES = 16;
+    constexpr fl::size_t BYTES_PER_LANE = 768;
+    constexpr fl::size_t SCRATCH_BYTES = LANES * BYTES_PER_LANE;        // 12 KB
+    constexpr fl::size_t OUTPUT_BYTES = BYTES_PER_LANE * LANES * sizeof(fl::Wave8Byte); // 96 KB
+
+    fl::ChipsetTiming timing;
+    timing.T1 = 400;
+    timing.T2 = 450;
+    timing.T3 = 400;
+    fl::Wave8BitExpansionLut nib_lut = fl::buildWave8ExpansionLUT(timing);
+    fl::Wave8ByteExpansionLut byte_lut = fl::buildWave8ByteExpansionLUT(nib_lut);
+
+    fl::u8 *scratch_sram = fl_parlio_alloc(SCRATCH_BYTES, /*psram=*/false);
+    fl::u8 *scratch_psram = fl_parlio_alloc(SCRATCH_BYTES, /*psram=*/true);
+    fl::u8 *output_sram = fl_parlio_alloc(OUTPUT_BYTES, /*psram=*/false);
+    fl::u8 *output_psram = fl_parlio_alloc(OUTPUT_BYTES, /*psram=*/true);
+
+    if (!scratch_sram || !scratch_psram || !output_sram || !output_psram) {
+        // Partial alloc failed; bail with zeros so the caller knows.
+        heap_caps_free(scratch_sram);
+        heap_caps_free(scratch_psram);
+        heap_caps_free(output_sram);
+        heap_caps_free(output_psram);
+        return result;
+    }
+
+    // Fill both scratches with representative LED data.
+    for (fl::size_t i = 0; i < SCRATCH_BYTES; ++i) {
+        const fl::u8 v = static_cast<fl::u8>((i * 31 + 7) & 0xFF);
+        scratch_sram[i] = v;
+        scratch_psram[i] = v;
+    }
+    fl::memset(output_sram, 0, OUTPUT_BYTES);
+    fl::memset(output_psram, 0, OUTPUT_BYTES);
+
+    volatile fl::u32 sink = 0;
+
+    // Warm caches / icache.
+    fl_parlio_measure(scratch_sram, SCRATCH_BYTES, output_sram, OUTPUT_BYTES,
+                      byte_lut, 64, &sink);
+
+    // Four placements. Each runs the same iters so totals are comparable.
+    result.perpos_ss_us = fl_parlio_measure(
+        scratch_sram, SCRATCH_BYTES, output_sram, OUTPUT_BYTES,
+        byte_lut, iters_in, &sink);
+    result.perpos_sp_us = fl_parlio_measure(
+        scratch_sram, SCRATCH_BYTES, output_psram, OUTPUT_BYTES,
+        byte_lut, iters_in, &sink);
+    result.perpos_ps_us = fl_parlio_measure(
+        scratch_psram, SCRATCH_BYTES, output_sram, OUTPUT_BYTES,
+        byte_lut, iters_in, &sink);
+    result.perpos_pp_us = fl_parlio_measure(
+        scratch_psram, SCRATCH_BYTES, output_psram, OUTPUT_BYTES,
+        byte_lut, iters_in, &sink);
+
+    result.sink = static_cast<fl::u32>(sink);
+
+    heap_caps_free(scratch_sram);
+    heap_caps_free(scratch_psram);
+    heap_caps_free(output_sram);
+    heap_caps_free(output_psram);
+    return result;
+}
+
+inline void printParlioEncodeResultRom(const ParlioEncodeResult &r) {
+    if (r.iters == 0) {
+        esp_rom_printf("\nBENCH_PARLIO_START (issue #2526 follow-up)\n");
+        esp_rom_printf("BENCH_PARLIO ERROR: heap allocation failed\n");
+        esp_rom_printf("BENCH_PARLIO_END\n\n");
+        return;
+    }
+
+    // Per-byte-position cost (microseconds * 1000 for sub-us precision)
+    const fl::u64 iters64 = r.iters;
+    const fl::u32 ss_ns_per = static_cast<fl::u32>(static_cast<fl::u64>(r.perpos_ss_us) * 1000 / iters64);
+    const fl::u32 sp_ns_per = static_cast<fl::u32>(static_cast<fl::u64>(r.perpos_sp_us) * 1000 / iters64);
+    const fl::u32 ps_ns_per = static_cast<fl::u32>(static_cast<fl::u64>(r.perpos_ps_us) * 1000 / iters64);
+    const fl::u32 pp_ns_per = static_cast<fl::u32>(static_cast<fl::u64>(r.perpos_pp_us) * 1000 / iters64);
+
+    // Frame-equivalent micros: production frame = 768 byte-positions.
+    const fl::u32 ss_frame_us = static_cast<fl::u32>(static_cast<fl::u64>(r.perpos_ss_us) * 768 / iters64);
+    const fl::u32 sp_frame_us = static_cast<fl::u32>(static_cast<fl::u64>(r.perpos_sp_us) * 768 / iters64);
+    const fl::u32 ps_frame_us = static_cast<fl::u32>(static_cast<fl::u64>(r.perpos_ps_us) * 768 / iters64);
+    const fl::u32 pp_frame_us = static_cast<fl::u32>(static_cast<fl::u64>(r.perpos_pp_us) * 768 / iters64);
+
+    // PSRAM-vs-SRAM ratio x100 (>100 means PSRAM is slower)
+    fl::u32 ratio_pp_ss_x100 = (r.perpos_ss_us > 0)
+        ? static_cast<fl::u32>(static_cast<fl::u64>(r.perpos_pp_us) * 100 / r.perpos_ss_us) : 0;
+    fl::u32 ratio_ps_ss_x100 = (r.perpos_ss_us > 0)
+        ? static_cast<fl::u32>(static_cast<fl::u64>(r.perpos_ps_us) * 100 / r.perpos_ss_us) : 0;
+    fl::u32 ratio_sp_ss_x100 = (r.perpos_ss_us > 0)
+        ? static_cast<fl::u32>(static_cast<fl::u64>(r.perpos_sp_us) * 100 / r.perpos_ss_us) : 0;
+
+    // WS2812B 800kHz, 16 lanes in parallel, 256 LEDs * 24 bits * 1.25 us/bit.
+    constexpr fl::u32 WS2812B_FRAME_US = 7680;
+
+    esp_rom_printf("\nBENCH_PARLIO_START (16 lanes x 256 LEDs, byte-LUT, #2526 follow-up)\n");
+    esp_rom_printf("BENCH_PARLIO iters=%u lanes=%u leds=%u sink=%u\n",
+                   r.iters, r.lanes, r.leds_per_lane, r.sink);
+    esp_rom_printf("BENCH_PARLIO perpos_us  ss=%u sp=%u ps=%u pp=%u\n",
+                   r.perpos_ss_us, r.perpos_sp_us, r.perpos_ps_us, r.perpos_pp_us);
+    esp_rom_printf("BENCH_PARLIO perpos_ns_each  ss=%u sp=%u ps=%u pp=%u\n",
+                   ss_ns_per, sp_ns_per, ps_ns_per, pp_ns_per);
+    esp_rom_printf("BENCH_PARLIO frame_equiv_us  ss=%u sp=%u ps=%u pp=%u  ws2812b_tx=%u\n",
+                   ss_frame_us, sp_frame_us, ps_frame_us, pp_frame_us, WS2812B_FRAME_US);
+    esp_rom_printf("BENCH_PARLIO ratio_x100  sp_vs_ss=%u ps_vs_ss=%u pp_vs_ss=%u\n",
+                   ratio_sp_ss_x100, ratio_ps_ss_x100, ratio_pp_ss_x100);
+    esp_rom_printf("BENCH_PARLIO_END\n\n");
+}
+
+#else // !FL_PARLIO_BENCH_ENABLED
+
+inline ParlioEncodeResult measureParlioEncode(int /*iters*/ = 12000) { return {}; }
+inline void printParlioEncodeResultRom(const ParlioEncodeResult & /*r*/) {}
+
+#endif
+
+} // namespace parlio_bench
+} // namespace autoresearch

--- a/examples/AutoResearch/AutoResearchRemote.cpp
+++ b/examples/AutoResearch/AutoResearchRemote.cpp
@@ -31,6 +31,7 @@
 #include "fl/math/simd.h"
 #include "AutoResearchSimd.h"
 #include "AutoResearchWave8Expand.h"  // #2526 wave8ExpandBenchmark RPC
+#include "AutoResearchParlioEncode.h" // parlioEncodeBenchmark RPC (#2526 follow-up)
 #include "fl/system/heap.h"
 #include "fl/chipsets/spi.h"
 #include "fl/channels/config.h"
@@ -1576,9 +1577,17 @@ void AutoResearchRemoteControl::registerFunctions(fl::shared_ptr<AutoResearchSta
         wave8ExpandBenchmark_fn.set("description", "Bench PARLIO Wave8 expansion (#2526): nibble vs byte vs batched LUT, plus full per-byte-position cost (expansion + 16-lane transpose)");
         functions.push_back(wave8ExpandBenchmark_fn);
 
+        fl::json parlioEncodeBenchmark_fn = fl::json::object();
+        parlioEncodeBenchmark_fn.set("name", "parlioEncodeBenchmark");
+        parlioEncodeBenchmark_fn.set("phase", "Phase 4: Utility");
+        parlioEncodeBenchmark_fn.set("args", "[{iterations}] (optional, default 12000, max 200000)");
+        parlioEncodeBenchmark_fn.set("returns", "{success, iters, lanes, leds_per_lane, perpos_ss_us, perpos_sp_us, perpos_ps_us, perpos_pp_us, sink}");
+        parlioEncodeBenchmark_fn.set("description", "Bench full PARLIO encode hot loop (16-lane gather + wave8Transpose_16 + memcpy) with 4 SRAM/PSRAM placements; answers PSRAM hypothesis + ISR-streaming feasibility");
+        functions.push_back(parlioEncodeBenchmark_fn);
+
         fl::json response = fl::json::object();
         response.set("success", true);
-        response.set("totalFunctions", static_cast<int64_t>(23));
+        response.set("totalFunctions", static_cast<int64_t>(24));
         response.set("functions", functions);
         return response;
     });
@@ -1701,6 +1710,38 @@ void AutoResearchRemoteControl::registerFunctions(fl::shared_ptr<AutoResearchSta
         response.set("expand_batched_us", static_cast<int64_t>(r.expand_batched_us));
         response.set("transpose16_nibble_us", static_cast<int64_t>(r.transpose16_nibble_us));
         response.set("transpose16_byte_us", static_cast<int64_t>(r.transpose16_byte_us));
+        response.set("sink", static_cast<int64_t>(r.sink));
+        return response;
+    });
+
+    // Register "parlioEncodeBenchmark" - full PARLIO encode hot-loop bench with
+    // {scratch, output} in SRAM/PSRAM (4 combinations). Answers the PSRAM
+    // hypothesis + ISR-streaming feasibility on the byte-LUT path (#2526
+    // follow-up).
+    mRemote->bind("parlioEncodeBenchmark", [](const fl::json& args) -> fl::json {
+        fl::json response = fl::json::object();
+
+        int iters = 12000;
+        fl::json config;
+        if (args.is_object()) {
+            config = args;
+        } else if (args.is_array() && args.size() >= 1 && args[0].is_object()) {
+            config = args[0];
+        }
+        if (!config.is_null() && config.contains("iterations") && config["iterations"].is_int()) {
+            iters = static_cast<int>(config["iterations"].as_int().value());
+        }
+
+        auto r = autoresearch::parlio_bench::measureParlioEncode(iters);
+
+        response.set("success", r.iters > 0);
+        response.set("iters", static_cast<int64_t>(r.iters));
+        response.set("lanes", static_cast<int64_t>(r.lanes));
+        response.set("leds_per_lane", static_cast<int64_t>(r.leds_per_lane));
+        response.set("perpos_ss_us", static_cast<int64_t>(r.perpos_ss_us));
+        response.set("perpos_sp_us", static_cast<int64_t>(r.perpos_sp_us));
+        response.set("perpos_ps_us", static_cast<int64_t>(r.perpos_ps_us));
+        response.set("perpos_pp_us", static_cast<int64_t>(r.perpos_pp_us));
         response.set("sink", static_cast<int64_t>(r.sink));
         return response;
     });


### PR DESCRIPTION
## Summary

Adds `parlioEncodeBenchmark` (RPC handler + boot-time bridge via `FL_BENCH_PARLIO_AT_BOOT`) that replicates the engine's per-byte-position hot loop and times it across SRAM/PSRAM placements for both scratch and output. Mirrors the pattern from #2539's `wave8ExpandBenchmark`.

This is a measurement tool — no production code path changes.

## Why
The byte-LUT (#2526/#2539) shipped, and the open question was:
1. Is the encode now fast enough for ISR-driven chunked streaming?
2. Is PSRAM still part of the bottleneck story?

## Measured on ESP32-P4 v1.3 (16-lane × 256-LED config, 12,000 byte-positions)

```
perpos_us     ss=150804 sp=149812 ps=149931 pp=149815
perpos_ns     ss=12567  sp=12484  ps=12494  pp=12484
frame_equiv   ss=9651   sp=9587   ps=9595   pp=9588
ratio_x100    sp/ss=99  ps/ss=99  pp/ss=99
ws2812b_tx_us=7680
```

- **PSRAM hypothesis denied**: all four placements within ~0.7% (L2 cache fully hides PSRAM latency). Matches the prior session's ×1.00 measurement; do not chase PSRAM theories.
- **ISR streaming not yet feasible**: encode 9.65 ms vs TX 7.68 ms per frame — CPU is ~26% slower than DMA. Need encode ≤ 7.68 ms (ideally ≤ 6 ms with margin).
- **Recommended next lever**: dual-core encode (#2527) — should push encode → ~5.4 ms, comfortably under TX.

Full analysis posted to #2526.

## Test plan
- [x] Lint clean
- [x] Builds + boots on ESP32-P4 via PlatformIO
- [x] BENCH_PARLIO numbers captured on COM25 (above)
- [x] Boot-time call gated `#ifdef FL_BENCH_PARLIO_AT_BOOT` (off by default)
- [x] RPC handler registered (will be invokable once #2541 routing fix lands)

Refs #2526, #2527 (dual-core, the recommended next lever), #2525, #2523, #2541


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added PARLIO encoding benchmarking for ESP32-P4 with optional boot-time measurement capability
  * New remote RPC endpoint for performance analysis providing detailed timing metrics across multiple memory placements
  * Includes per-iteration and frame-level timing comparisons between SRAM and PSRAM configurations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/FastLED/pull/2547?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->