### PR TITLE
chore(deps): bump zccache floor to >=1.11.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "fpvgcc",
     "uv",
     "clang-tool-chain>=1.5.2",
-    "zccache>=1.9.0",
+    "zccache>=1.11.7",
     "ninja",
     "meson>=1.11.0",
     "download",


### PR DESCRIPTION
## Summary
- zccache 1.11.7 (https://github.com/zackees/zccache/releases/tag/1.11.7) ships the fix for FastLED#2539 / zccache#449: a stale `.obj` could be returned for unity-build TUs (e.g. `fl.channels+.cpp`) after a transitive `.cpp.hpp` was modified, producing linker errors like `undefined symbol: fl::buildWave8ByteExpansionLUT(...)` until a forced `--clean` rebuild.
- Root cause was a read/write `artifact_key` divergence in the zccache depgraph: the cache-check path computed the key from the *previously-captured* transitive include set while the post-compile write path used the freshly-scanned set. A coincidentally matching older artifact could be served as stale content.
- zccache 1.11.7 fixes this by treating any hash drift in `last_file_hashes` as `HeadersChanged`, forcing a recompile + re-scan instead of returning a `Hit` with a stale-prediction key. Details: https://github.com/zackees/zccache/pull/450.

## Test plan
- [x] zccache 1.11.7 published on PyPI (https://pypi.org/project/zccache/1.11.7/).
- [x] zccache CI green across 26 checks on the fix PR + release PR.
- [ ] FastLED CI on this PR confirms `uv pip install` resolves to zccache 1.11.7.
- [ ] After merge: `bash test wave8 --cpp` no longer needs `--clean` after `.cpp.hpp` edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project dependency versions to ensure compatibility and stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/FastLED/pull/2549?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->