### PR TITLE
fix(hooks): use handle_keyboard_interrupt in protect_example_ino

### DIFF
--- a/ci/hooks/protect_example_ino.py
+++ b/ci/hooks/protect_example_ino.py
@@ -35,7 +35,10 @@ OVERRIDE_ENV_VAR = "FL_AGENT_ALLOW_NEW_EXAMPLE"
 def main() -> int:
     try:
         input_data = json.load(sys.stdin)
-    except KeyboardInterrupt:
+    except KeyboardInterrupt as ki:
+        from ci.util.global_interrupt_handler import handle_keyboard_interrupt
+
+        handle_keyboard_interrupt(ki)
         raise
     except json.JSONDecodeError as exc:
         print(


### PR DESCRIPTION
## Summary
\`bash lint\` was failing with \`KBI002\` on \`ci/hooks/protect_example_ino.py:38\`. Switch to the canonical pattern from \`ci/util/boot_wait.py\`:

\`\`\`python
except KeyboardInterrupt as ki:
    from ci.util.global_interrupt_handler import handle_keyboard_interrupt
    handle_keyboard_interrupt(ki)
    raise
\`\`\`

No behaviour change.

## Test plan
- [x] \`bash lint\` passes (was failing with KBI002)
- [x] hook still exits 2 / passes / blocks per existing semantics

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved keyboard interrupt handling in build CI processes for better error management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/FastLED/pull/2550?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->