### PR TITLE
chore(deps): bump fbuild 2.2.7 -> 2.2.9 — fixes teensy41 SPI link (#2365)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,10 +5,10 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    # Pin to an fbuild release that includes the Teensy framework library
-    # fixes from 2.2.5 and the ESP32-P4 path/source discovery fixes needed by
-    # AutoResearch and PARLIO validation (FastLED/fbuild#273).
-    "fbuild==2.2.7",
+    # Pin to an fbuild release with the Teensy 4.x SPI shadowing-filter fix
+    # (FastLED/fbuild#284, closes FastLED/FastLED#2365) on top of the prior
+    # Teensy framework-library and ESP32-P4 path/source discovery fixes.
+    "fbuild==2.2.9",
     "platformio>=6.1.19,<6.2",
     "python-dateutil",
     "ruff",


### PR DESCRIPTION
## Summary
Bumps `fbuild` from 2.2.7 to 2.2.9 to pick up the Teensy 4.x SPI shadowing-filter fix in [FastLED/fbuild#286](https://github.com/FastLED/fbuild/pull/286) (closes [FastLED/fbuild#284](https://github.com/FastLED/fbuild/issues/284)).

This unblocks the long-standing `teensy41` CI failure tracked in [#2365](https://github.com/FastLED/FastLED/issues/2365): every Teensy 4.x example was failing at link with `undefined reference to SPIClass::transfer/begin/end/SPI` because fbuild's `filter_framework_libs_shadowed_by_project` was dropping the framework `SPI` library when FastLED shipped any nested `spi.h` (we ship `src/fl/channels/spi.h` and `src/fl/chipsets/spi.h`, both unreachable as `<SPI.h>`). The fbuild fix replaces the recursive header-basename walk with an Arduino-spec-correct top-level walk so only headers actually reachable as `<basename>` from an include root trigger the shadowing filter.

## Test plan
- [x] End-to-end verified locally on Windows: `bash compile teensy41 --examples Blink` failed at link against `fbuild==2.2.7` and now succeeds against the patched fbuild build (SPI.cpp is included in the framework_library_sources set; 152 framework lib sources resolved; SPI count = 1).
- [x] `bash lint` clean
- [ ] CI `teensy41` job goes from red (continuously since at least 2026-05-12) to green

## Closes
- Closes FastLED/FastLED#2365 once teensy41 CI is green on master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build dependency to version 2.2.9, resolving issues with Teensy 4.x SPI operations and ESP32-P4 path discovery.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/FastLED/pull/2551?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->