### PR TITLE
perf(parlio): #2548 pipe2 — 2-position pipelining (+26%, BEATS WS2812B TX)

### DIFF
--- a/src/fl/channels/detail/wave8.hpp
+++ b/src/fl/channels/detail/wave8.hpp
@@ -239,6 +239,29 @@ void wave8_transpose_16(const Wave8Byte lane_waves[16],
     }
 }
 
+/// @brief Pipe2: transpose 16-lane × 2-byte-positions in one fused call.
+///        Result is bit-identical to two sequential `wave8_transpose_16` calls;
+///        the win comes from interleaving the two independent OR-trees inside
+///        the symbol loop so the in-order RV32 P4 can fill load-use stall
+///        cycles from position A with ALU ops from position B (and vice versa).
+///        Measured +26% / frame vs sequential calls on P4 v1.3 (#2548).
+FASTLED_FORCE_INLINE FL_IRAM FL_OPTIMIZE_FUNCTION
+void wave8_transpose_16x2_pipe2(const Wave8Byte lane_waves_a[16],
+                                const Wave8Byte lane_waves_b[16],
+                                u8 output_a[16 * sizeof(Wave8Byte)],
+                                u8 output_b[16 * sizeof(Wave8Byte)]) {
+    for (int symbol_idx = 0; symbol_idx < 8; symbol_idx++) {
+        u8 la[16];
+        u8 lb[16];
+        for (int lane = 0; lane < 16; lane++) {
+            la[lane] = lane_waves_a[lane].symbols[symbol_idx].data;
+            lb[lane] = lane_waves_b[lane].symbols[symbol_idx].data;
+        }
+        spread_transpose16_symbol(la, output_a + symbol_idx * 16);
+        spread_transpose16_symbol(lb, output_b + symbol_idx * 16);
+    }
+}
+
 } // namespace detail
 
 // ============================================================================

--- a/src/fl/channels/wave8.cpp.hpp
+++ b/src/fl/channels/wave8.cpp.hpp
@@ -132,6 +132,29 @@ void wave8Transpose_16(const u8 (&FL_RESTRICT_PARAM lanes)[16],
     detail::wave8_transpose_16(laneWaveformSymbols, output);
 }
 
+FL_OPTIMIZE_FUNCTION FL_IRAM
+void wave8Transpose_16x2_pipe2(const u8 (&FL_RESTRICT_PARAM lanes_a)[16],
+                               const u8 (&FL_RESTRICT_PARAM lanes_b)[16],
+                               const Wave8ByteExpansionLut &lut,
+                               u8 (&FL_RESTRICT_PARAM output_a)[16 * sizeof(Wave8Byte)],
+                               u8 (&FL_RESTRICT_PARAM output_b)[16 * sizeof(Wave8Byte)]) {
+    // Expand both positions independently — compiler can interleave the two
+    // loops freely because they share no data.
+    Wave8Byte laneWaveformsA[16];
+    Wave8Byte laneWaveformsB[16];
+    for (int lane = 0; lane < 16; lane++) {
+        detail::wave8_expand_byte(lanes_a[lane], lut, &laneWaveformsA[lane]);
+    }
+    for (int lane = 0; lane < 16; lane++) {
+        detail::wave8_expand_byte(lanes_b[lane], lut, &laneWaveformsB[lane]);
+    }
+    // Symbol-major loop with both transposes inlined back-to-back: the two
+    // OR-trees share no dependencies, so the compiler can interleave them and
+    // fill the in-order pipeline bubbles. See #2548.
+    detail::wave8_transpose_16x2_pipe2(laneWaveformsA, laneWaveformsB,
+                                       output_a, output_b);
+}
+
 // ============================================================================
 // LUT Builder from Timing Data
 // Note: This is not designed to be called from ISR handlers.

--- a/src/fl/channels/wave8.h
+++ b/src/fl/channels/wave8.h
@@ -124,6 +124,20 @@ void wave8Transpose_16(
     const Wave8ByteExpansionLut &lut,
     u8 (&FL_RESTRICT_PARAM output)[16 * sizeof(Wave8Byte)]);
 
+/// @brief Pipe2: transpose 16-lane × 2-byte-positions (#2548).
+///        Bit-identical to two sequential `wave8Transpose_16` calls. Internally
+///        interleaves the two independent OR-trees inside the symbol loop so
+///        the in-order RV32 P4 can fill load-use stalls from position A with
+///        ALU ops from position B. Measured 9655 → 7625 µs/frame (+26%) on
+///        P4 v1.3 (16-lane × 256-LED, byte-LUT path) — first variant to beat
+///        the 7680 µs WS2812B 16-lane TX target.
+void wave8Transpose_16x2_pipe2(
+    const u8 (&FL_RESTRICT_PARAM lanes_a)[16],
+    const u8 (&FL_RESTRICT_PARAM lanes_b)[16],
+    const Wave8ByteExpansionLut &lut,
+    u8 (&FL_RESTRICT_PARAM output_a)[16 * sizeof(Wave8Byte)],
+    u8 (&FL_RESTRICT_PARAM output_b)[16 * sizeof(Wave8Byte)]);
+
 // Untranspose functions (for testing - reverse the transpose operation)
 void wave8Untranspose_2(
     const u8 (&FL_RESTRICT_PARAM transposed)[2 * sizeof(Wave8Byte)],

--- a/src/platforms/esp/32/drivers/parlio/parlio_engine.cpp.hpp
+++ b/src/platforms/esp/32/drivers/parlio/parlio_engine.cpp.hpp
@@ -964,16 +964,41 @@ ParlioEngine::populateDmaBuffer(u8* outputBuffer,
                                     *reinterpret_cast<u8(*)[8 * sizeof(Wave8Byte)]>(outputBuffer + outputIdx)); // ok reinterpret cast - direct write to DMA buffer (#2548 L2)
                 outputIdx += blockSize;
             } else if (mDataWidth == 16) {
-                u8 lanes[16];
+                u8 lanes_a[16];
                 for (size_t lane = 0; lane < 16; lane++) {
-                    lanes[lane] = (lane < mActualChannels)
+                    lanes_a[lane] = (lane < mActualChannels)
                         ? mScratchBuffer[lane * mLaneStride + startByte + byteOffset]
                         : 0;
                 }
 
-                fl::wave8Transpose_16(reinterpret_cast<const u8(&)[16]>(lanes), mWave8ByteLut, // ok reinterpret cast - array reference type conversion
-                                     *reinterpret_cast<u8(*)[16 * sizeof(Wave8Byte)]>(outputBuffer + outputIdx)); // ok reinterpret cast - direct write to DMA buffer (#2548 L2)
-                outputIdx += blockSize;
+                // #2548 pipe2: when a second byte position fits, run the
+                // 2-position fused transpose. Bit-identical to two sequential
+                // wave8Transpose_16 calls, but interleaves the two independent
+                // OR-trees so the in-order RV32 P4 fills load-use stalls from
+                // position A with ALU ops from position B. Measured 9655 →
+                // 7625 µs/frame (+26%) on P4 v1.3 16-lane × 256-LED.
+                if (byteOffset + 1 < byteCount
+                    && outputIdx + 2 * blockSize <= outputBufferCapacity) {
+                    u8 lanes_b[16];
+                    for (size_t lane = 0; lane < 16; lane++) {
+                        lanes_b[lane] = (lane < mActualChannels)
+                            ? mScratchBuffer[lane * mLaneStride + startByte + byteOffset + 1]
+                            : 0;
+                    }
+                    fl::wave8Transpose_16x2_pipe2(
+                        reinterpret_cast<const u8(&)[16]>(lanes_a), // ok reinterpret cast - array reference type conversion
+                        reinterpret_cast<const u8(&)[16]>(lanes_b), // ok reinterpret cast - array reference type conversion
+                        mWave8ByteLut,
+                        *reinterpret_cast<u8(*)[16 * sizeof(Wave8Byte)]>(outputBuffer + outputIdx),                  // ok reinterpret cast - direct write to DMA buffer (#2548)
+                        *reinterpret_cast<u8(*)[16 * sizeof(Wave8Byte)]>(outputBuffer + outputIdx + blockSize));     // ok reinterpret cast - direct write to DMA buffer (#2548)
+                    outputIdx += 2 * blockSize;
+                    byteOffset += 1;  // outer loop also does ++byteOffset → net +2
+                } else {
+                    fl::wave8Transpose_16(
+                        reinterpret_cast<const u8(&)[16]>(lanes_a), mWave8ByteLut, // ok reinterpret cast - array reference type conversion
+                        *reinterpret_cast<u8(*)[16 * sizeof(Wave8Byte)]>(outputBuffer + outputIdx)); // ok reinterpret cast - direct write to DMA buffer (#2548 L2)
+                    outputIdx += blockSize;
+                }
             } else {
                 // Invalid data width - should never happen (validated in initialize())
                 outputBytesWritten = outputIdx;

--- a/tests/fl/channels/wave8.cpp
+++ b/tests/fl/channels/wave8.cpp
@@ -941,4 +941,41 @@ FL_TEST_CASE("wave8 transpose_8/_16 == naive (random)") {
     }
 }
 
+FL_TEST_CASE("wave8Transpose_16x2_pipe2 == two sequential wave8Transpose_16 (random)") {
+    // #2548: the 2-position fused pipe2 path must be bit-identical to running
+    // wave8Transpose_16 twice on the same inputs. Validates that the internal
+    // OR-tree interleaving does not change the result.
+    ChipsetTiming timing;
+    timing.T1 = 400;
+    timing.T2 = 450;
+    timing.T3 = 400;
+    Wave8BitExpansionLut nib_lut = buildWave8ExpansionLUT(timing);
+    Wave8ByteExpansionLut byte_lut = buildWave8ByteExpansionLUT(nib_lut);
+
+    u32 seed = 0x12345678u;
+    for (int round = 0; round < 1000; round++) {
+        u8 lanes_a[16];
+        u8 lanes_b[16];
+        for (int l = 0; l < 16; l++) {
+            seed = seed * 1664525u + 1013904223u;
+            lanes_a[l] = static_cast<u8>(seed >> 24);
+            seed = seed * 1664525u + 1013904223u;
+            lanes_b[l] = static_cast<u8>(seed >> 24);
+        }
+        u8 ref_a[16 * sizeof(Wave8Byte)];
+        u8 ref_b[16 * sizeof(Wave8Byte)];
+        u8 got_a[16 * sizeof(Wave8Byte)];
+        u8 got_b[16 * sizeof(Wave8Byte)];
+
+        wave8Transpose_16(lanes_a, byte_lut, ref_a);
+        wave8Transpose_16(lanes_b, byte_lut, ref_b);
+        wave8Transpose_16x2_pipe2(lanes_a, lanes_b, byte_lut, got_a, got_b);
+
+        for (int i = 0; i < 16 * static_cast<int>(sizeof(Wave8Byte)); i++) {
+            FL_REQUIRE(got_a[i] == ref_a[i]);
+            FL_REQUIRE(got_b[i] == ref_b[i]);
+        }
+    }
+}
+
 } // FL_TEST_FILE


### PR DESCRIPTION
## Summary

Adds `wave8Transpose_16x2_pipe2()` — a fused 2-position transpose that processes two consecutive byte positions in lockstep, interleaving their two independent OR-trees inside the symbol-major loop. Bit-identical to two sequential `wave8Transpose_16` calls; the win comes from giving the in-order RV32 P4 enough independent ALU work to fill load-use stall cycles.

The production engine (`ParlioEngine::populateDmaBuffer`, 16-lane Wave8 path) now dispatches to pipe2 when a second byte position fits, falling back to single-position `wave8Transpose_16` for the tail when `byteCount` is odd.

## Measured speedup (ESP32-P4 v1.3, 16-lane × 256 LEDs Wave8, 12 000 byte-positions)

Two stable runs, captured live via the [`perf/parlio-l1l2l3`](https://github.com/FastLED/FastLED/tree/perf/parlio-l1l2l3) boot-time bench harness (COM25 USB-Serial-JTAG):

| variant | µs / frame | vs baseline | gap to TX (7 680 µs) |
|---|---:|---:|---:|
| baseline (pre-L2 memcpy)  | 9 652 | 1.00× | +1 972 µs over |
| L2 alone ([#2553](https://github.com/FastLED/FastLED/pull/2553))   | 9 305 | +3.8% | +1 625 µs over |
| **pipe2 (this PR)**       | **7 625 / 7 633** | **+26.6 %** | **−47 / −55 µs UNDER TX** ✓ |

**This is the first variant to cross the WS2812B 16-lane TX threshold on single-core, single-Wave8.** Closes the [#2548](https://github.com/FastLED/FastLED/issues/2548) ISR-streaming gap without #2527 (dual-core) or #2523 (WaveN).

## Why pipe2 wins (and why none of 7 prior variants found it)

Phase 0 cycle-counter instrumentation ([#2548 comment](https://github.com/FastLED/FastLED/issues/2548#issuecomment-4580944497)) showed transpose running at ~5.6 cyc/op vs the 1-cyc/op theoretical max — ~80 % of cycles were bubbles (load-use stalls + OR-tree dependency chains). Interleaving an independent OR-tree from the adjacent byte position lets the compiler fill those bubbles.

Pipe2 is the **only** variant that attacks **cross-position** ILP — the prior 7 (L1, L2, L3, L4-byte, L4-nibble, L7, fused_v2) all attacked the **within-position** critical path. Pipe2 is orthogonal to the generalized RV32 rule (don't trade arithmetic for memory; don't exceed the 32-GPR budget): register pressure and load/arith ratios stay within budget; pipe2 just doubles the independent work the in-order core can choose from per cycle.

## Bit-exactness

- New host test `wave8Transpose_16x2_pipe2 == two sequential wave8Transpose_16` runs 1 000 random seeds × 256 output bytes × 2 positions — byte-by-byte equality (`tests/fl/channels/wave8.cpp`).
- Live device validation: bench harness times the SAME `wave8Transpose_16x2_pipe2` symbol now linked from `libfastled` and reports the same 7 633 µs/frame on the device.

## Test plan
- [x] Host: `bash test wave8` — clean (new pipe2 case + all existing wave8Transpose_* cases pass)
- [x] Host: `bash lint --cpp` — clean
- [x] Device (ESP32-P4 v1.3): 2 stable runs (Δ ≤ 0.1 %) confirm pipe2 = ~7 630 µs/frame in production
- [ ] CI: full matrix (will run on this PR)

## Files

```
 src/fl/channels/detail/wave8.hpp                                +23
 src/fl/channels/wave8.h                                         +14
 src/fl/channels/wave8.cpp.hpp                                   +23
 src/platforms/esp/32/drivers/parlio/parlio_engine.cpp.hpp       +30 / −5
 tests/fl/channels/wave8.cpp                                     +37
```

Refs #2548. Builds on #2553 (L2 direct write, already on master). Together the two changes deliver **+26 % encode speedup** = **2 020 µs / frame saved**, putting single-core single-Wave8 encode 0.7 % UNDER the WS2812B TX budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced dual-lane transposition optimization for parallel I/O encoding, delivering improved throughput for concurrent lane processing while maintaining bit-identical output characteristics.

* **Chores**
  * Added comprehensive test coverage with 1000 randomized validation cases to verify dual-lane transposition correctness and consistency across diverse input patterns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/FastLED/pull/2555?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->