### PR TITLE
docs(workflow): add CI Wait Loops section

### DIFF
--- a/agents/docs/workflow.md
+++ b/agents/docs/workflow.md
@@ -43,6 +43,15 @@ Guidelines for how agents should approach work in the FastLED project.
 
 When CodeRabbit posts review comments on a PR, run `/address-reviews` before any `gh pr merge`. The skill fetches open comments, classifies each, applies fixes for valid findings, and replies to threads. The pre-merge hook blocks merge while unresolved CodeRabbit threads remain. Security-critical findings are routed to a human — never auto-fixed. Max 3 iterations per PR; if CodeRabbit keeps asking after three rounds, stop and flag a human reviewer.
 
+## CI Wait Loops
+
+When polling CI on a PR (e.g. inside `/clud-pr-merge` or before `gh pr merge`):
+
+- **FastLED's slowest platform builds take 20–30 minutes** on GitHub Actions runners — one observed: 26m7s on `build / build`. A `until <no pending>; do sleep 30; done` poll therefore sits silent for that long. Tell the user upfront ("this can take up to 30 minutes") so they don't read the silence as a hung shell.
+- **The Claude Code harness blocks leading `sleep N; <cmd>` chains.** Use `until <condition>; do sleep N; done` (sleep inside the loop body), or pass `run_in_background: true` to the Bash tool. For waits longer than ~5 minutes, prefer `ScheduleWakeup` so the conversation isn't held open.
+- **`gh pr checks` returns exit code 1 when any check failed**, even with `--json`. A polled background task that ends with exit 1 may still have produced complete output — read the output file before concluding the poll itself failed.
+- **The `sync` check fails on every PR.** It belongs to the `project-automation` workflow on `pull_request_target` events; the failure is a 404 on "Generate GitHub App token" (the GitHub App isn't installed on the `FastLED` user/org). It does not run on `push` to master, so it won't appear in master's check-runs. Treat it as a known pre-existing infrastructure failure, never a regression.
+
 ## Task Management
 
 1. **Plan First**: Write plan to `agents/tasks/todo.md` with checkable items


### PR DESCRIPTION
## Summary

Documents four agent-facing gotchas observed during `/clud-pr-merge` runs against this repo. All four look like "stalled shell" symptoms to a watching user but are actually expected behaviors that future agents should know how to recognize.

Added as a new **CI Wait Loops** section in `agents/docs/workflow.md` (next to the existing **CodeRabbit Review Loop** section since both concern PR-time waits).

The four findings:
1. Slowest FastLED platform builds take 20–30 minutes on GHA runners (observed 26m7s on `build / build`). Agents should warn the user upfront, not silently poll for half an hour.
2. The Claude Code harness blocks leading `sleep N; <cmd>` patterns. Use `until <check>; do sleep N; done` (sleep inside the body), `run_in_background: true`, or `ScheduleWakeup` for waits >5min.
3. `gh pr checks` returns exit 1 whenever any check failed, even with `--json`. A polled background task that exits 1 may still have produced complete output — read the file before concluding the poll itself failed.
4. The `sync` check fails on every PR (project-automation workflow's GitHub App token 404 because the App isn't installed on the `FastLED` user/org). Pre-existing infrastructure failure, never a regression.

## Test plan
- [x] Doc-only change; no code touched
- [x] Lint passes (markdown-only edit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added CI workflow documentation with practical guidance on polling patterns, expected wait times, exit code handling, and known infrastructure issues.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/FastLED/pull/2556?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->