### PR TITLE
perf(parlio): #2548 pipe4 — 4-position pipelining (+41% vs baseline, 11% under TX)

### DIFF
--- a/src/fl/channels/detail/wave8.hpp
+++ b/src/fl/channels/detail/wave8.hpp
@@ -262,6 +262,40 @@ void wave8_transpose_16x2_pipe2(const Wave8Byte lane_waves_a[16],
     }
 }
 
+/// @brief Pipe4: transpose 16-lane × 4-byte-positions in one fused call.
+///        Bit-identical to four sequential `wave8_transpose_16` calls. Extends
+///        the pipe2 idea to 4 positions — empirically the peak of the curve on
+///        the in-order RV32 P4 core (#2548). pipe2 saved 26% over baseline,
+///        pipe3 36%, **pipe4 41%**, pipe6 regressed to 94% (register spill).
+///        Stays within the 32-GPR budget: 4 × 4 = 16 OR-tree accumulators +
+///        ~8 misc GPRs = ~24 live; pipe6 would push this past 32.
+FASTLED_FORCE_INLINE FL_IRAM FL_OPTIMIZE_FUNCTION
+void wave8_transpose_16x4_pipe4(const Wave8Byte lane_waves_a[16],
+                                const Wave8Byte lane_waves_b[16],
+                                const Wave8Byte lane_waves_c[16],
+                                const Wave8Byte lane_waves_d[16],
+                                u8 output_a[16 * sizeof(Wave8Byte)],
+                                u8 output_b[16 * sizeof(Wave8Byte)],
+                                u8 output_c[16 * sizeof(Wave8Byte)],
+                                u8 output_d[16 * sizeof(Wave8Byte)]) {
+    for (int symbol_idx = 0; symbol_idx < 8; symbol_idx++) {
+        u8 la[16];
+        u8 lb[16];
+        u8 lc[16];
+        u8 ld[16];
+        for (int lane = 0; lane < 16; lane++) {
+            la[lane] = lane_waves_a[lane].symbols[symbol_idx].data;
+            lb[lane] = lane_waves_b[lane].symbols[symbol_idx].data;
+            lc[lane] = lane_waves_c[lane].symbols[symbol_idx].data;
+            ld[lane] = lane_waves_d[lane].symbols[symbol_idx].data;
+        }
+        spread_transpose16_symbol(la, output_a + symbol_idx * 16);
+        spread_transpose16_symbol(lb, output_b + symbol_idx * 16);
+        spread_transpose16_symbol(lc, output_c + symbol_idx * 16);
+        spread_transpose16_symbol(ld, output_d + symbol_idx * 16);
+    }
+}
+
 } // namespace detail
 
 // ============================================================================

--- a/src/fl/channels/wave8.cpp.hpp
+++ b/src/fl/channels/wave8.cpp.hpp
@@ -155,6 +155,37 @@ void wave8Transpose_16x2_pipe2(const u8 (&FL_RESTRICT_PARAM lanes_a)[16],
                                        output_a, output_b);
 }
 
+FL_OPTIMIZE_FUNCTION FL_IRAM
+void wave8Transpose_16x4_pipe4(const u8 (&FL_RESTRICT_PARAM lanes_a)[16],
+                               const u8 (&FL_RESTRICT_PARAM lanes_b)[16],
+                               const u8 (&FL_RESTRICT_PARAM lanes_c)[16],
+                               const u8 (&FL_RESTRICT_PARAM lanes_d)[16],
+                               const Wave8ByteExpansionLut &lut,
+                               u8 (&FL_RESTRICT_PARAM output_a)[16 * sizeof(Wave8Byte)],
+                               u8 (&FL_RESTRICT_PARAM output_b)[16 * sizeof(Wave8Byte)],
+                               u8 (&FL_RESTRICT_PARAM output_c)[16 * sizeof(Wave8Byte)],
+                               u8 (&FL_RESTRICT_PARAM output_d)[16 * sizeof(Wave8Byte)]) {
+    Wave8Byte laneWaveformsA[16];
+    Wave8Byte laneWaveformsB[16];
+    Wave8Byte laneWaveformsC[16];
+    Wave8Byte laneWaveformsD[16];
+    for (int lane = 0; lane < 16; lane++) {
+        detail::wave8_expand_byte(lanes_a[lane], lut, &laneWaveformsA[lane]);
+    }
+    for (int lane = 0; lane < 16; lane++) {
+        detail::wave8_expand_byte(lanes_b[lane], lut, &laneWaveformsB[lane]);
+    }
+    for (int lane = 0; lane < 16; lane++) {
+        detail::wave8_expand_byte(lanes_c[lane], lut, &laneWaveformsC[lane]);
+    }
+    for (int lane = 0; lane < 16; lane++) {
+        detail::wave8_expand_byte(lanes_d[lane], lut, &laneWaveformsD[lane]);
+    }
+    detail::wave8_transpose_16x4_pipe4(laneWaveformsA, laneWaveformsB,
+                                       laneWaveformsC, laneWaveformsD,
+                                       output_a, output_b, output_c, output_d);
+}
+
 // ============================================================================
 // LUT Builder from Timing Data
 // Note: This is not designed to be called from ISR handlers.

--- a/src/fl/channels/wave8.h
+++ b/src/fl/channels/wave8.h
@@ -138,6 +138,24 @@ void wave8Transpose_16x2_pipe2(
     u8 (&FL_RESTRICT_PARAM output_a)[16 * sizeof(Wave8Byte)],
     u8 (&FL_RESTRICT_PARAM output_b)[16 * sizeof(Wave8Byte)]);
 
+/// @brief Pipe4: transpose 16-lane × 4-byte-positions (#2548).
+///        Bit-identical to four sequential `wave8Transpose_16` calls. Peak of
+///        the cross-position ILP curve on RV32 P4 — pipe2 = +26%, pipe3 = +36%,
+///        **pipe4 = +41%** vs baseline (9 651 → 6 822 µs/frame). pipe6 / pipe8
+///        regress to 94% (32-GPR budget exceeded → compiler spills).
+///        Measured **11% UNDER the 7 680 µs WS2812B TX target** — comfortable
+///        margin for ISR-chunked streaming.
+void wave8Transpose_16x4_pipe4(
+    const u8 (&FL_RESTRICT_PARAM lanes_a)[16],
+    const u8 (&FL_RESTRICT_PARAM lanes_b)[16],
+    const u8 (&FL_RESTRICT_PARAM lanes_c)[16],
+    const u8 (&FL_RESTRICT_PARAM lanes_d)[16],
+    const Wave8ByteExpansionLut &lut,
+    u8 (&FL_RESTRICT_PARAM output_a)[16 * sizeof(Wave8Byte)],
+    u8 (&FL_RESTRICT_PARAM output_b)[16 * sizeof(Wave8Byte)],
+    u8 (&FL_RESTRICT_PARAM output_c)[16 * sizeof(Wave8Byte)],
+    u8 (&FL_RESTRICT_PARAM output_d)[16 * sizeof(Wave8Byte)]);
+
 // Untranspose functions (for testing - reverse the transpose operation)
 void wave8Untranspose_2(
     const u8 (&FL_RESTRICT_PARAM transposed)[2 * sizeof(Wave8Byte)],

--- a/src/platforms/esp/32/drivers/parlio/parlio_engine.cpp.hpp
+++ b/src/platforms/esp/32/drivers/parlio/parlio_engine.cpp.hpp
@@ -971,14 +971,40 @@ ParlioEngine::populateDmaBuffer(u8* outputBuffer,
                         : 0;
                 }
 
-                // #2548 pipe2: when a second byte position fits, run the
-                // 2-position fused transpose. Bit-identical to two sequential
-                // wave8Transpose_16 calls, but interleaves the two independent
-                // OR-trees so the in-order RV32 P4 fills load-use stalls from
-                // position A with ALU ops from position B. Measured 9655 →
-                // 7625 µs/frame (+26%) on P4 v1.3 16-lane × 256-LED.
-                if (byteOffset + 1 < byteCount
-                    && outputIdx + 2 * blockSize <= outputBufferCapacity) {
+                // #2548 cross-position ILP dispatch (best variant wins by
+                // remaining-byte count):
+                //   ≥4 remaining → pipe4 (+41% over baseline, peak of curve)
+                //   ≥2 remaining → pipe2 (+26%, ships in #2555)
+                //   else         → single (+3.5% over pre-L2, ships in #2553)
+                // Bit-identical to running wave8Transpose_16 byte-by-byte;
+                // the win is the in-order RV32 P4 filling its load-use stall
+                // cycles with independent ALU ops from the parallel positions.
+                if (byteOffset + 3 < byteCount
+                    && outputIdx + 4 * blockSize <= outputBufferCapacity) {
+                    u8 lanes_b[16];
+                    u8 lanes_c[16];
+                    u8 lanes_d[16];
+                    for (size_t lane = 0; lane < 16; lane++) {
+                        const u8 *base = mScratchBuffer + lane * mLaneStride + startByte;
+                        const bool active = (lane < mActualChannels);
+                        lanes_b[lane] = active ? base[byteOffset + 1] : 0;
+                        lanes_c[lane] = active ? base[byteOffset + 2] : 0;
+                        lanes_d[lane] = active ? base[byteOffset + 3] : 0;
+                    }
+                    fl::wave8Transpose_16x4_pipe4(
+                        reinterpret_cast<const u8(&)[16]>(lanes_a), // ok reinterpret cast - array reference type conversion
+                        reinterpret_cast<const u8(&)[16]>(lanes_b), // ok reinterpret cast - array reference type conversion
+                        reinterpret_cast<const u8(&)[16]>(lanes_c), // ok reinterpret cast - array reference type conversion
+                        reinterpret_cast<const u8(&)[16]>(lanes_d), // ok reinterpret cast - array reference type conversion
+                        mWave8ByteLut,
+                        *reinterpret_cast<u8(*)[16 * sizeof(Wave8Byte)]>(outputBuffer + outputIdx),                      // ok reinterpret cast - direct write to DMA buffer (#2548)
+                        *reinterpret_cast<u8(*)[16 * sizeof(Wave8Byte)]>(outputBuffer + outputIdx + blockSize),          // ok reinterpret cast - direct write to DMA buffer (#2548)
+                        *reinterpret_cast<u8(*)[16 * sizeof(Wave8Byte)]>(outputBuffer + outputIdx + 2 * blockSize),      // ok reinterpret cast - direct write to DMA buffer (#2548)
+                        *reinterpret_cast<u8(*)[16 * sizeof(Wave8Byte)]>(outputBuffer + outputIdx + 3 * blockSize));     // ok reinterpret cast - direct write to DMA buffer (#2548)
+                    outputIdx += 4 * blockSize;
+                    byteOffset += 3;  // outer loop also does ++byteOffset → net +4
+                } else if (byteOffset + 1 < byteCount
+                           && outputIdx + 2 * blockSize <= outputBufferCapacity) {
                     u8 lanes_b[16];
                     for (size_t lane = 0; lane < 16; lane++) {
                         lanes_b[lane] = (lane < mActualChannels)

--- a/tests/fl/channels/wave8.cpp
+++ b/tests/fl/channels/wave8.cpp
@@ -978,4 +978,56 @@ FL_TEST_CASE("wave8Transpose_16x2_pipe2 == two sequential wave8Transpose_16 (ran
     }
 }
 
+FL_TEST_CASE("wave8Transpose_16x4_pipe4 == four sequential wave8Transpose_16 (random)") {
+    // #2548: the 4-position fused pipe4 path must be bit-identical to running
+    // wave8Transpose_16 four times on the same inputs. Confirms that scaling
+    // the cross-position interleaving from 2 to 4 still preserves semantics.
+    ChipsetTiming timing;
+    timing.T1 = 400;
+    timing.T2 = 450;
+    timing.T3 = 400;
+    Wave8BitExpansionLut nib_lut = buildWave8ExpansionLUT(timing);
+    Wave8ByteExpansionLut byte_lut = buildWave8ByteExpansionLUT(nib_lut);
+
+    u32 seed = 0x9ABCDEF0u;
+    for (int round = 0; round < 500; round++) {
+        u8 lanes_a[16];
+        u8 lanes_b[16];
+        u8 lanes_c[16];
+        u8 lanes_d[16];
+        for (int l = 0; l < 16; l++) {
+            seed = seed * 1664525u + 1013904223u;
+            lanes_a[l] = static_cast<u8>(seed >> 24);
+            seed = seed * 1664525u + 1013904223u;
+            lanes_b[l] = static_cast<u8>(seed >> 24);
+            seed = seed * 1664525u + 1013904223u;
+            lanes_c[l] = static_cast<u8>(seed >> 24);
+            seed = seed * 1664525u + 1013904223u;
+            lanes_d[l] = static_cast<u8>(seed >> 24);
+        }
+        u8 ref_a[16 * sizeof(Wave8Byte)];
+        u8 ref_b[16 * sizeof(Wave8Byte)];
+        u8 ref_c[16 * sizeof(Wave8Byte)];
+        u8 ref_d[16 * sizeof(Wave8Byte)];
+        u8 got_a[16 * sizeof(Wave8Byte)];
+        u8 got_b[16 * sizeof(Wave8Byte)];
+        u8 got_c[16 * sizeof(Wave8Byte)];
+        u8 got_d[16 * sizeof(Wave8Byte)];
+
+        wave8Transpose_16(lanes_a, byte_lut, ref_a);
+        wave8Transpose_16(lanes_b, byte_lut, ref_b);
+        wave8Transpose_16(lanes_c, byte_lut, ref_c);
+        wave8Transpose_16(lanes_d, byte_lut, ref_d);
+        wave8Transpose_16x4_pipe4(lanes_a, lanes_b, lanes_c, lanes_d, byte_lut,
+                                  got_a, got_b, got_c, got_d);
+
+        for (int i = 0; i < 16 * static_cast<int>(sizeof(Wave8Byte)); i++) {
+            FL_REQUIRE(got_a[i] == ref_a[i]);
+            FL_REQUIRE(got_b[i] == ref_b[i]);
+            FL_REQUIRE(got_c[i] == ref_c[i]);
+            FL_REQUIRE(got_d[i] == ref_d[i]);
+        }
+    }
+}
+
 } // FL_TEST_FILE


### PR DESCRIPTION
## Summary

Extends [pipe2 (#2555)](https://github.com/FastLED/FastLED/pull/2555) to the **empirical peak** of the cross-position ILP curve. Adds `wave8Transpose_16x4_pipe4()` and updates the engine's 16-lane Wave8 dispatch ladder to prefer 4 positions, falling back to 2 positions, then 1.

Bench sweep on the [`perf/parlio-l1l2l3`](https://github.com/FastLED/FastLED/tree/perf/parlio-l1l2l3) bench branch:

| variant | µs / frame | speedup | vs WS2812B TX (7 680 µs) |
|---|---:|---:|---:|
| baseline (pre-L2 memcpy) | 9 651 | 1.00× | +1 971 µs over |
| L2 ([#2553](https://github.com/FastLED/FastLED/pull/2553))  | 9 305 | +3.8 % | +1 625 µs over |
| pipe2 ([#2555](https://github.com/FastLED/FastLED/pull/2555))| 7 633 | +26.6 % | −47 µs UNDER |
| pipe3 | 7 091 | +36.1 % | −589 µs UNDER |
| **pipe4 (this PR)** | **6 823** | **+41.5 %** | **−857 µs UNDER (−11.2 %)** ✓ |
| pipe6 | 10 240 | -6 % | regressed — register spill cliff |
| pipe8 | 10 203 | -6 % | same spill ceiling |

The curve cleanly bounds the optimum. pipe4 sits inside the 32-GPR budget (4 × 4 OR-tree accumulators = 16 GPRs + ~8 misc = ~24 live); pipe6 pushes to ~32 and the compiler spills, snapping the win away.

### Engine dispatch ladder (16-lane Wave8 path)

```
  ≥4 remaining + space for 4 blocks → wave8Transpose_16x4_pipe4
  ≥2 remaining + space for 2 blocks → wave8Transpose_16x2_pipe2
  otherwise                          → wave8Transpose_16 (single)
```

Bit-identical results across all three paths — each variant is just a tighter interleaving of the same underlying `wave8Transpose_16` dataflow.

## Test plan
- [x] Host bit-exactness: new `tests/fl/channels/wave8.cpp` case (500 random seeds × 4 positions, byte-by-byte equality vs four sequential `wave8Transpose_16` calls)
- [ ] Host: `bash test wave8` skipped — pre-existing wave8_spi linker error on master (undefined `rgb_2_rgbw_colorimetric` from #2545 / #2554) blocks the shared `fastled.dll` build. The pipe4-specific test passes when compiled in isolation. Unblock once the master link is fixed.
- [x] Device (ESP32-P4 v1.3): boot-time bench times the `wave8Transpose_16x4_pipe4` symbol linked from production `libfastled` and reports **6 823 µs/frame** — exactly matches the bench-branch measurement
- [x] `bash lint --cpp` clean
- [ ] CI: full matrix (will run on this PR)

## Files
```
 src/fl/channels/detail/wave8.hpp                                +34
 src/fl/channels/wave8.h                                         +18
 src/fl/channels/wave8.cpp.hpp                                   +31
 src/platforms/esp/32/drivers/parlio/parlio_engine.cpp.hpp       +34 / −8
 tests/fl/channels/wave8.cpp                                     +52
```

## Combined chain (L2 + pipe2 + pipe4)

| baseline | this stack | saved | speedup |
|---:|---:|---:|---:|
| 9 651 µs/frame | **6 823 µs/frame** | **2 828 µs/frame** | **+41.5 %** |

ISR-chunked streaming on single-core single-Wave8 P4 now has a comfortable ~857 µs / frame safety margin under the WS2812B 16-lane TX budget. No need for #2527 (dual-core) or #2523 (WaveN/Wave4) — those become pure latency / safety-margin enhancements on top of this stack.

Refs #2548 (already closed as resolved by L2 + pipe2 — this PR adds extra headroom).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new optimized waveform transposition function for enhanced data processing capabilities.

* **Tests**
  * Added unit test validating the new transposition function across multiple independent input scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/FastLED/pull/2557?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->