### PR TITLE
test(parlio): #2548 convert PARLIO streaming validation from boot-time to RPC

### DIFF
--- a/examples/AutoResearch/AutoResearch.ino
+++ b/examples/AutoResearch/AutoResearch.ino
@@ -196,7 +196,7 @@
 #include "AutoResearchSimd.h"
 #include "AutoResearchWave8Expand.h"  // boot-time #2526 micro-bench
 #include "AutoResearchParlioEncode.h" // full parlio encode bench (post-byte-LUT)
-#include "AutoResearchParlioStream.h" // #2548 boot-time PARLIO streaming validation
+#include "AutoResearchParlioStream.h" // #2548 PARLIO streaming validation (RPC-driven)
 
 // ============================================================================
 // Teensy Hardware Watchdog (crash recovery) - DISABLED
@@ -383,16 +383,8 @@ void setup() {
     ss << "[RX SETUP] ✓ RX channel ready for LED autoresearch";
     FL_PRINT(ss.str());
 
-    // ========================================================================
-    // PARLIO streaming validation (#2548 follow-up)
-    // ========================================================================
-    // Exercises the production engine path: 3-buffer ring + txDoneCallback ISR
-    // streaming + BF1 (#2559). Reports PASS/FAIL via esp_rom_printf so it
-    // works on COM25 USB-Serial-JTAG without the broken testSimd RPC routing.
-#ifdef FL_PARLIO_STREAM_VALIDATE_AT_BOOT
-    autoresearch::parlio_stream::validateAtBoot(
-        g_autoresearch_state->pin_tx);
-#endif
+    // PARLIO streaming validation (#2548) is now RPC-driven via the
+    // `parlioStreamValidate` handler registered in AutoResearchRemote.cpp.
 
     // ========================================================================
     // Remote RPC Function Registration (EARLY - before GPIO baseline test)

--- a/examples/AutoResearch/AutoResearchParlioStream.h
+++ b/examples/AutoResearch/AutoResearchParlioStream.h
@@ -1,5 +1,5 @@
 /// @file AutoResearchParlioStream.h
-/// @brief Boot-time PARLIO streaming functional test (#2548 deep-dive follow-up).
+/// @brief PARLIO ISR-streaming functional validation (#2548 deep-dive follow-up).
 ///
 /// Validates the engine's ISR-chunked streaming path on real hardware:
 ///   - Initializes PARLIO with **16 lanes** (forces the engine's 16-lane Wave8
@@ -8,138 +8,143 @@
 ///   - Fills with a known pattern.
 ///   - Calls FastLED.show() — which goes through ParlioEngine's 3-buffer ring
 ///     + txDoneCallback ISR streaming + BF1 encode.
-///   - Measures wall-clock time for show()+wait() to complete.
+///   - Measures wall-clock time for show()+wait() to complete across N back-
+///     to-back frames.
 ///
-/// **Functional pass criterion**: show()+wait() completes < 100 ms. The
-/// expected time is ~2 ms (BF1+pipe4 encode is 1.75 ms/frame, TX is 7.68 ms,
-/// but the engine streams them concurrently so the bottleneck is the slower
-/// of the two — TX). 100 ms gives ~10× margin and catches hangs / stalls.
+/// **Pass criterion**: every show()+wait() completes within `timeoutMs`.
+/// Catches hangs / stalls in the streaming engine.
 ///
-/// Does NOT validate transmitted byte correctness — that needs RX loopback
-/// with a jumper wire (handled by the existing autoresearch --parlio CLI).
-/// Bit-exactness of BF1 is independently covered by the host test in
-/// tests/fl/channels/wave8.cpp added in #2559.
+/// Does NOT validate transmitted byte correctness — that's covered by the host
+/// bit-exactness test in tests/fl/channels/wave8.cpp added in #2559, and by
+/// the RX-loopback path in the existing autoresearch CLI when run with a
+/// jumper wire.
 ///
-/// Reports `BENCH_PARLIO_STREAM_VALIDATE PASS/FAIL` via `esp_rom_printf` to
-/// the USB-Serial-JTAG console (COM25 on the P4 dev board), so it works
-/// without the broken testSimd RPC routing (#2541).
-///
-/// Gated by `-DFL_PARLIO_STREAM_VALIDATE_AT_BOOT=1`. Runs once in setup().
+/// Invoked via the `parlioStreamValidate` JSON-RPC handler registered in
+/// AutoResearchRemote.cpp.
 
 #pragma once
 
 #include "FastLED.h"
 #include "fl/chipsets/chipset_timing_config.h"
 #include "fl/chipsets/led_timing.h"
+#include "fl/stl/int.h"
 #include "fl/stl/span.h"
 #include "fl/stl/vector.h"
 
 #if defined(ARDUINO_ARCH_ESP32) || defined(ESP_PLATFORM)
-#include <Arduino.h>      // micros()
-#include <esp_rom_sys.h>  // esp_rom_printf
+#include <Arduino.h>  // micros()
 #endif
 
 namespace autoresearch {
 namespace parlio_stream {
 
-/// Run at boot AFTER the RX channel is created (RX is unused — kept in the
-/// signature for symmetry with future loopback variants).
+constexpr int kMaxIterations = 16;  // result struct iter timing array fixed size
+
+struct ValidateResult {
+    bool channels_ok;          // true if all PARLIO channels created cleanly
+    bool completed;            // true if every iteration completed within timeout
+    int lanes;                 // PARLIO lane count tested
+    int leds_per_lane;         // LEDs per lane
+    int iterations;            // number of show() iterations run
+    uint32_t per_iter_us[kMaxIterations];  // per-iteration show()+wait() time
+    uint32_t steady_avg_us;    // average of iters 1..N-1 (skips iter 0 setup)
+    int failed_iter;           // index of first iter that exceeded timeout, or -1
+    uint32_t timeout_ms;       // effective timeout passed in
+};
+
+/// @brief Run the PARLIO streaming functional test.
 ///
-/// @param base_tx_pin  First PARLIO TX pin; lanes occupy [base_tx_pin .. base_tx_pin+15]
-inline void validateAtBoot(int base_tx_pin) {
+/// @param base_tx_pin  First PARLIO TX pin; lanes occupy [base_tx_pin .. base_tx_pin+num_lanes-1]
+/// @param num_lanes    Number of PARLIO lanes (1-16). Use 16 to exercise BF1+pipe4.
+/// @param num_leds     LEDs per lane.
+/// @param iterations   Number of back-to-back show()+wait() cycles (capped at kMaxIterations).
+/// @param timeout_ms   Per-iteration timeout. Test fails if any iter exceeds this.
+inline ValidateResult validateParlioStreaming(int base_tx_pin,
+                                              int num_lanes,
+                                              int num_leds,
+                                              int iterations,
+                                              uint32_t timeout_ms) {
+    ValidateResult r{};
+    r.channels_ok = false;
+    r.completed = false;
+    r.lanes = num_lanes;
+    r.leds_per_lane = num_leds;
+    r.iterations = iterations;
+    r.timeout_ms = timeout_ms;
+    r.failed_iter = -1;
+
+    if (iterations < 1) iterations = 1;
+    if (iterations > kMaxIterations) iterations = kMaxIterations;
+    r.iterations = iterations;
+    if (num_lanes < 1 || num_lanes > 16) return r;
+    if (num_leds < 1) return r;
+
 #if defined(ARDUINO_ARCH_ESP32) || defined(ESP_PLATFORM)
-    esp_rom_printf("\nBENCH_PARLIO_STREAM_VALIDATE_START\n");
-
-    constexpr int kNumLanes = 16;
-    constexpr int kNumLEDs = 256;   // matches the canonical bench workload
-    constexpr uint32_t kTimeoutMs = 200;
-
-    // 16 separate CRGB arrays, one per lane — forces the engine's 16-lane
-    // Wave8 dispatch which uses wave8Transpose_16x4_bf1_pipe4.
-    static CRGB leds[kNumLanes][kNumLEDs];
-    for (int lane = 0; lane < kNumLanes; ++lane) {
-        for (int i = 0; i < kNumLEDs; ++i) {
-            // Pattern A: mixed bit positions per byte.
-            leds[lane][i] = CRGB(0xF0, 0x0F, 0xAA);
+    // Reuse a single static heap-resident LED buffer sized for the canonical
+    // worst case (16 lanes × 256 LEDs). Test callers must stay within these
+    // bounds. Static to avoid repeated allocation across RPC calls.
+    constexpr int kMaxLanes = 16;
+    constexpr int kMaxLEDs = 256;
+    if (num_leds > kMaxLEDs) return r;
+    static CRGB leds[kMaxLanes][kMaxLEDs];
+    for (int lane = 0; lane < num_lanes; ++lane) {
+        for (int i = 0; i < num_leds; ++i) {
+            leds[lane][i] = CRGB(0xF0, 0x0F, 0xAA);  // Pattern A (mixed bits)
         }
     }
 
     fl::ChipsetTimingConfig timing =
         fl::makeTimingConfig<fl::TIMING_WS2812B_V5>();
 
-    // Build 16 PARLIO channels on consecutive pins.
     fl::ChannelOptions parlio_opts;
     parlio_opts.mBus = fl::Bus::PARLIO;
 
     fl::vector<fl::shared_ptr<fl::Channel>> channels;
-    bool add_ok = true;
-    for (int lane = 0; lane < kNumLanes; ++lane) {
+    for (int lane = 0; lane < num_lanes; ++lane) {
         fl::ChannelConfig cfg(
             base_tx_pin + lane,
             timing,
-            fl::span<CRGB>(leds[lane], kNumLEDs),
+            fl::span<CRGB>(leds[lane], num_leds),
             RGB,
             parlio_opts);
         auto ch = FastLED.add(cfg);
         if (!ch) {
-            esp_rom_printf("BENCH_PARLIO_STREAM_VALIDATE FAIL  "
-                           "add_channel_failed_at_lane=%d\n", lane);
-            add_ok = false;
-            break;
+            FastLED.clear(ClearFlags::CHANNELS);
+            return r;
         }
         channels.push_back(ch);
     }
+    r.channels_ok = true;
 
-    if (!add_ok) {
-        FastLED.clear(ClearFlags::CHANNELS);
-        esp_rom_printf("BENCH_PARLIO_STREAM_VALIDATE_END\n\n");
-        return;
-    }
-
-    // Run several iterations to make sure streaming repeats cleanly across
-    // back-to-back frames (catches single-frame-only bugs). First iter has
-    // setup overhead; the steady-state cost is the average of iters 2..N.
-    constexpr int kIterations = 5;
-    uint32_t per_iter_us[8] = {0};
     bool ok = true;
-    for (int iter = 0; iter < kIterations; ++iter) {
+    uint32_t steady_total = 0;
+    for (int iter = 0; iter < iterations; ++iter) {
         const uint32_t t0 = micros();
         FastLED.show();
-        FastLED.wait(kTimeoutMs);
+        FastLED.wait(timeout_ms);
         const uint32_t dt = micros() - t0;
-        per_iter_us[iter] = dt;
-        if (dt > kTimeoutMs * 1000u) {
-            esp_rom_printf("BENCH_PARLIO_STREAM_VALIDATE FAIL  "
-                           "iter=%d show_wait_us=%u (timeout=%ums)\n",
-                           iter, static_cast<unsigned>(dt),
-                           static_cast<unsigned>(kTimeoutMs));
+        r.per_iter_us[iter] = dt;
+        if (dt > timeout_ms * 1000u) {
+            r.failed_iter = iter;
             ok = false;
             break;
         }
+        if (iter > 0) steady_total += dt;
     }
 
     FastLED.clear(ClearFlags::CHANNELS);
 
-    if (ok) {
-        // Steady-state average across iters 1..N-1 (skip iter 0 setup overhead).
-        uint32_t steady_total = 0;
-        for (int i = 1; i < kIterations; ++i) steady_total += per_iter_us[i];
-        const uint32_t steady_avg = steady_total / (kIterations - 1);
-        esp_rom_printf("BENCH_PARLIO_STREAM_VALIDATE PASS  lanes=%d leds=%d "
-                       "iters=%d iter0=%u iter1=%u iter2=%u iter3=%u iter4=%u "
-                       "steady_avg_us=%u (WS2812B 16-lane TX=7680us)\n",
-                       kNumLanes, kNumLEDs, kIterations,
-                       static_cast<unsigned>(per_iter_us[0]),
-                       static_cast<unsigned>(per_iter_us[1]),
-                       static_cast<unsigned>(per_iter_us[2]),
-                       static_cast<unsigned>(per_iter_us[3]),
-                       static_cast<unsigned>(per_iter_us[4]),
-                       static_cast<unsigned>(steady_avg));
+    r.completed = ok;
+    if (ok && iterations > 1) {
+        r.steady_avg_us = steady_total / (iterations - 1);
+    } else if (ok) {
+        r.steady_avg_us = r.per_iter_us[0];
     }
-    esp_rom_printf("BENCH_PARLIO_STREAM_VALIDATE_END\n\n");
 #else
     (void)base_tx_pin;
+    (void)timeout_ms;
 #endif
+    return r;
 }
 
 }  // namespace parlio_stream

--- a/examples/AutoResearch/AutoResearchRemote.cpp
+++ b/examples/AutoResearch/AutoResearchRemote.cpp
@@ -32,6 +32,7 @@
 #include "AutoResearchSimd.h"
 #include "AutoResearchWave8Expand.h"  // #2526 wave8ExpandBenchmark RPC
 #include "AutoResearchParlioEncode.h" // parlioEncodeBenchmark RPC (#2526 follow-up)
+#include "AutoResearchParlioStream.h" // parlioStreamValidate RPC (#2548 follow-up)
 #include "fl/system/heap.h"
 #include "fl/chipsets/spi.h"
 #include "fl/channels/config.h"
@@ -1585,9 +1586,17 @@ void AutoResearchRemoteControl::registerFunctions(fl::shared_ptr<AutoResearchSta
         parlioEncodeBenchmark_fn.set("description", "Bench full PARLIO encode hot loop (16-lane gather + wave8Transpose_16 + memcpy) with 4 SRAM/PSRAM placements; answers PSRAM hypothesis + ISR-streaming feasibility");
         functions.push_back(parlioEncodeBenchmark_fn);
 
+        fl::json parlioStreamValidate_fn = fl::json::object();
+        parlioStreamValidate_fn.set("name", "parlioStreamValidate");
+        parlioStreamValidate_fn.set("phase", "Phase 4: Utility");
+        parlioStreamValidate_fn.set("args", "[{numLanes, numLeds, iterations, timeoutMs}] (all optional; defaults 16/256/5/200)");
+        parlioStreamValidate_fn.set("returns", "{success, completed, lanes, leds_per_lane, iterations, perIterUs:[...], steadyAvgUs, failedIter}");
+        parlioStreamValidate_fn.set("description", "Functional test of the PARLIO ISR-chunked streaming engine (#2548). Drives N back-to-back FastLED.show() calls through the production engine (which uses BF1+pipe4 on 16-lane Wave8 since #2559) and verifies all complete within timeout. Catches hangs/stalls.");
+        functions.push_back(parlioStreamValidate_fn);
+
         fl::json response = fl::json::object();
         response.set("success", true);
-        response.set("totalFunctions", static_cast<int64_t>(24));
+        response.set("totalFunctions", static_cast<int64_t>(25));
         response.set("functions", functions);
         return response;
     });
@@ -1711,6 +1720,69 @@ void AutoResearchRemoteControl::registerFunctions(fl::shared_ptr<AutoResearchSta
         response.set("transpose16_nibble_us", static_cast<int64_t>(r.transpose16_nibble_us));
         response.set("transpose16_byte_us", static_cast<int64_t>(r.transpose16_byte_us));
         response.set("sink", static_cast<int64_t>(r.sink));
+        return response;
+    });
+
+    // Register "parlioStreamValidate" - functional test of the production
+    // PARLIO ISR-chunked streaming engine (#2548). Exercises the 16-lane Wave8
+    // path which dispatches to wave8Transpose_16x4_bf1_pipe4 (BF1, #2559).
+    // Drives N back-to-back FastLED.show() cycles and verifies each completes
+    // within timeout. Returns per-iter timing so the host can diagnose stalls.
+    mRemote->bind("parlioStreamValidate", [this](const fl::json& args) -> fl::json {
+        fl::json response = fl::json::object();
+
+        int num_lanes = 16;
+        int num_leds = 256;
+        int iterations = 5;
+        int timeout_ms = 200;
+
+        fl::json config;
+        if (args.is_object()) {
+            config = args;
+        } else if (args.is_array() && args.size() >= 1 && args[0].is_object()) {
+            config = args[0];
+        }
+        if (!config.is_null()) {
+            if (config.contains("numLanes") && config["numLanes"].is_int())
+                num_lanes = static_cast<int>(config["numLanes"].as_int().value());
+            if (config.contains("numLeds") && config["numLeds"].is_int())
+                num_leds = static_cast<int>(config["numLeds"].as_int().value());
+            if (config.contains("iterations") && config["iterations"].is_int())
+                iterations = static_cast<int>(config["iterations"].as_int().value());
+            if (config.contains("timeoutMs") && config["timeoutMs"].is_int())
+                timeout_ms = static_cast<int>(config["timeoutMs"].as_int().value());
+        }
+
+        // Clamp inputs to safe ranges.
+        if (num_lanes < 1) num_lanes = 1;
+        if (num_lanes > 16) num_lanes = 16;
+        if (num_leds < 1) num_leds = 1;
+        if (num_leds > 256) num_leds = 256;
+        if (iterations < 1) iterations = 1;
+        if (iterations > autoresearch::parlio_stream::kMaxIterations) {
+            iterations = autoresearch::parlio_stream::kMaxIterations;
+        }
+        if (timeout_ms < 1) timeout_ms = 1;
+        if (timeout_ms > 5000) timeout_ms = 5000;
+
+        auto r = autoresearch::parlio_stream::validateParlioStreaming(
+            mState->pin_tx, num_lanes, num_leds, iterations,
+            static_cast<uint32_t>(timeout_ms));
+
+        response.set("success", true);
+        response.set("channelsOk", r.channels_ok);
+        response.set("completed", r.completed);
+        response.set("lanes", static_cast<int64_t>(r.lanes));
+        response.set("ledsPerLane", static_cast<int64_t>(r.leds_per_lane));
+        response.set("iterations", static_cast<int64_t>(r.iterations));
+        response.set("steadyAvgUs", static_cast<int64_t>(r.steady_avg_us));
+        response.set("failedIter", static_cast<int64_t>(r.failed_iter));
+        response.set("timeoutMs", static_cast<int64_t>(r.timeout_ms));
+        fl::json per_iter = fl::json::array();
+        for (int i = 0; i < r.iterations; ++i) {
+            per_iter.push_back(static_cast<int64_t>(r.per_iter_us[i]));
+        }
+        response.set("perIterUs", per_iter);
         return response;
     });
 


### PR DESCRIPTION
## Summary

Removes the `FL_PARLIO_STREAM_VALIDATE_AT_BOOT` boot-time hook landed in [#2561](https://github.com/FastLED/FastLED/pull/2561) and re-exposes the same functional test as a JSON-RPC handler `parlioStreamValidate`, matching the convention of the other autoresearch utility benches (`wave8ExpandBenchmark` #2539, `parlioEncodeBenchmark` #2547).

## Why

User requested: *"we don't want this test at boot, we want it rpc selectable"*. The boot-time hook in #2561 was an interim path that worked around the broken testSimd RPC routing (#2541) on P4. RPC is the canonical pattern for autoresearch test invocation.

## API

```jsonc
// Call
{
  "method": "parlioStreamValidate",
  "params": [{
    "numLanes":  16,   // 1..16, default 16  (16 exercises BF1+pipe4 from #2559)
    "numLeds":   256,  // 1..256, default 256
    "iterations": 5,   // 1..kMaxIterations=16, default 5
    "timeoutMs":  200  // 1..5000, default 200
  }]
}

// Response
{
  "success": true,
  "channelsOk": true,     // all PARLIO channels created cleanly
  "completed": true,      // every iteration finished within timeout
  "lanes": 16, "ledsPerLane": 256, "iterations": 5,
  "perIterUs": [23530, 16998, 17000, 16997, 17001],
  "steadyAvgUs": 16999,   // average of iters 1..N-1
  "failedIter": -1,       // index of first iter exceeding timeout, or -1
  "timeoutMs": 200
}
```

## Changes

- `AutoResearchParlioStream.h`: `validateAtBoot()` (`esp_rom_printf`-based) → `validateParlioStreaming()` returning a `ValidateResult` struct. Caller-supplied workload parameters. Static LED buffer to avoid repeated allocation across RPC calls.
- `AutoResearch.ino`: drop the `#ifdef FL_PARLIO_STREAM_VALIDATE_AT_BOOT` boot-time hook (keep the header include for the RPC binding).
- `AutoResearchRemote.cpp`: add `parlioStreamValidate` bind + `discoverFunctions` metadata entry (totalFunctions 24 → 25).

## Test plan

- [x] `bash lint --cpp` clean
- [x] Build + flash on ESP32-P4 v1.3 succeeds; handler is registered
- [ ] On-device RPC invocation blocked on P4 by the pre-existing #2541 (testSimd RPC over UART0 fails because the host connects via COM25 USB-Serial-JTAG, different physical path). Same blocker that already affects `testSimd`, `wave8ExpandBenchmark`, and `parlioEncodeBenchmark`. The handler will be invokable from CI / other platforms once that infra issue is resolved.
- [x] Functional correctness was demonstrated end-to-end via the boot-time variant in #2561 — 5 back-to-back `show()+wait()` iterations, 16-lane × 256-LED WS2812B, all completed within timeout (steady-state ~17 ms/frame, 0 hangs / stalls).

## Files
```
 examples/AutoResearch/AutoResearch.ino           +2 / −12
 examples/AutoResearch/AutoResearchParlioStream.h +91 / −68
 examples/AutoResearch/AutoResearchRemote.cpp     +73 / −1
```

Refs #2548, #2541. Supersedes the boot-time hook from #2561.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Validation functionality now supports configurable parameters (lanes, LEDs, iterations, timeout)
  * Validation results include detailed per-iteration timing measurements
  * New RPC endpoint for validation with optional parameters

* **Refactor**
  * Validation moved from boot-time initialization to RPC-driven approach

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/FastLED/pull/2562?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->