### PR TITLE
chore: tidy master (ignore failures/, advance wiki submodule)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,6 @@ src/platforms/wasm/compiler/node_modules/
 
 # AutoResearch transient logs
 .autoresearch_last.log
+
+# Compile failure logs (./compile --log-failures failures)
+failures/


### PR DESCRIPTION
## Summary
- Add `failures/` to `.gitignore` — it's a CI-only artifact directory emitted by `./compile --log-failures failures` (see `.github/workflows/build_template.yml:152`). Local `bash compile` runs were leaving a `failures/<example>.log` file in the working tree.
- Advance the `wiki` submodule to `dc2896b8` to pick up an upstream wiki fix:
  - `dc2896b Fix serial baud rate calculations in Interrupt problems wiki page`

## Test plan
- [x] `git status` clean after both commits
- [x] No source code changes; CI should be a no-op
- [ ] Verify CI green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to ignore compile failure logs
  * Updated documentation references

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/FastLED/pull/2563?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->