### PR TITLE
perf(parlio): #2548 verify ISR streaming + add opt-in eager-queue (encode/TX overlap)

### DIFF
--- a/examples/AutoResearch/AutoResearchParlioStream.h
+++ b/examples/AutoResearch/AutoResearchParlioStream.h
@@ -46,8 +46,12 @@ struct ValidateResult {
     int lanes;                 // PARLIO lane count tested
     int leds_per_lane;         // LEDs per lane
     int iterations;            // number of show() iterations run
-    uint32_t per_iter_us[kMaxIterations];  // per-iteration show()+wait() time
-    uint32_t steady_avg_us;    // average of iters 1..N-1 (skips iter 0 setup)
+    uint32_t per_iter_us[kMaxIterations];  // per-iteration show()+wait() total time
+    uint32_t per_iter_show_us[kMaxIterations];  // per-iter show() return time (pre-encode + submit)
+    uint32_t per_iter_wait_us[kMaxIterations];  // per-iter wait() time (TX completion)
+    uint32_t steady_avg_us;        // average total of iters 1..N-1 (skips iter 0 setup)
+    uint32_t steady_avg_show_us;   // average show() time of iters 1..N-1
+    uint32_t steady_avg_wait_us;   // average wait() time of iters 1..N-1
     int failed_iter;           // index of first iter that exceeded timeout, or -1
     uint32_t timeout_ms;       // effective timeout passed in
 };
@@ -118,18 +122,30 @@ inline ValidateResult validateParlioStreaming(int base_tx_pin,
 
     bool ok = true;
     uint32_t steady_total = 0;
+    uint32_t steady_show_total = 0;
+    uint32_t steady_wait_total = 0;
     for (int iter = 0; iter < iterations; ++iter) {
         const uint32_t t0 = micros();
         FastLED.show();
+        const uint32_t t_show = micros();
         FastLED.wait(timeout_ms);
-        const uint32_t dt = micros() - t0;
+        const uint32_t t1 = micros();
+        const uint32_t show_us = t_show - t0;
+        const uint32_t wait_us = t1 - t_show;
+        const uint32_t dt = t1 - t0;
         r.per_iter_us[iter] = dt;
+        r.per_iter_show_us[iter] = show_us;
+        r.per_iter_wait_us[iter] = wait_us;
         if (dt > timeout_ms * 1000u) {
             r.failed_iter = iter;
             ok = false;
             break;
         }
-        if (iter > 0) steady_total += dt;
+        if (iter > 0) {
+            steady_total += dt;
+            steady_show_total += show_us;
+            steady_wait_total += wait_us;
+        }
     }
 
     FastLED.clear(ClearFlags::CHANNELS);
@@ -137,8 +153,12 @@ inline ValidateResult validateParlioStreaming(int base_tx_pin,
     r.completed = ok;
     if (ok && iterations > 1) {
         r.steady_avg_us = steady_total / (iterations - 1);
+        r.steady_avg_show_us = steady_show_total / (iterations - 1);
+        r.steady_avg_wait_us = steady_wait_total / (iterations - 1);
     } else if (ok) {
         r.steady_avg_us = r.per_iter_us[0];
+        r.steady_avg_show_us = r.per_iter_show_us[0];
+        r.steady_avg_wait_us = r.per_iter_wait_us[0];
     }
 #else
     (void)base_tx_pin;

--- a/examples/AutoResearch/AutoResearchRemote.cpp
+++ b/examples/AutoResearch/AutoResearchRemote.cpp
@@ -1776,13 +1776,21 @@ void AutoResearchRemoteControl::registerFunctions(fl::shared_ptr<AutoResearchSta
         response.set("ledsPerLane", static_cast<int64_t>(r.leds_per_lane));
         response.set("iterations", static_cast<int64_t>(r.iterations));
         response.set("steadyAvgUs", static_cast<int64_t>(r.steady_avg_us));
+        response.set("steadyAvgShowUs", static_cast<int64_t>(r.steady_avg_show_us));
+        response.set("steadyAvgWaitUs", static_cast<int64_t>(r.steady_avg_wait_us));
         response.set("failedIter", static_cast<int64_t>(r.failed_iter));
         response.set("timeoutMs", static_cast<int64_t>(r.timeout_ms));
         fl::json per_iter = fl::json::array();
+        fl::json per_iter_show = fl::json::array();
+        fl::json per_iter_wait = fl::json::array();
         for (int i = 0; i < r.iterations; ++i) {
             per_iter.push_back(static_cast<int64_t>(r.per_iter_us[i]));
+            per_iter_show.push_back(static_cast<int64_t>(r.per_iter_show_us[i]));
+            per_iter_wait.push_back(static_cast<int64_t>(r.per_iter_wait_us[i]));
         }
         response.set("perIterUs", per_iter);
+        response.set("perIterShowUs", per_iter_show);
+        response.set("perIterWaitUs", per_iter_wait);
         return response;
     });
 

--- a/src/platforms/esp/32/drivers/parlio/parlio_engine.cpp.hpp
+++ b/src/platforms/esp/32/drivers/parlio/parlio_engine.cpp.hpp
@@ -26,6 +26,7 @@
 #include "platforms/esp/32/drivers/parlio/parlio_debug.h"
 #include "platforms/esp/32/drivers/parlio/parlio_ring_buffer.h"
 #include "fl/system/delay.h"
+
 #include "fl/log/log.h"
 #include "fl/log/log.h"
 #include "fl/log/log.h"
@@ -104,6 +105,17 @@ namespace detail {
 #ifndef FL_ESP_PARLIO_HARDWARE_QUEUE_DEPTH
 #define FL_ESP_PARLIO_HARDWARE_QUEUE_DEPTH 3
 #endif // defined(FL_ESP_PARLIO_HARDWARE_QUEUE_DEPTH)
+
+// #2548 EXPERIMENTAL: when set, beginTransmission() submits all pre-encoded
+// ring buffers to the IDF TX queue immediately (relying on hardware DMA-
+// descriptor chaining to avoid the ISR-latency gap between buffers). Cuts
+// frame time from 17ms to 12ms on 16-lane × 256-LED WS2812B (encode/TX
+// overlap), but requires per-chipset RX-loopback validation to confirm
+// the IDF chains buffers without a >5µs gap (which would corrupt WS2812
+// signal timing). Default OFF — see comment in beginTransmission().
+#ifndef FL_PARLIO_EAGER_QUEUE
+#define FL_PARLIO_EAGER_QUEUE 0
+#endif
 
 // Worker function is now called directly from txDoneCallback (no timer needed)
 // This eliminates the 50µs periodic timer overhead
@@ -1861,6 +1873,7 @@ bool ParlioEngine::beginTransmission(const u8* scratchBuffer,
     // The ESP32 PARLIO hardware requires a disable/enable cycle to reset its DMA state
     // machine. Without this, consecutive transmissions with the same config silently fail
     // (DMA doesn't start, TX produces no output, RX captures 0 bytes).
+    // Measured cost: ~25-30 µs (negligible).
     if (mTxUnitEnabled) {
         FL_LOG_PARLIO("PARLIO_TX: Disabling peripheral for re-enable cycle");
         mPeripheral->disable();
@@ -1903,6 +1916,36 @@ bool ParlioEngine::beginTransmission(const u8* scratchBuffer,
         return false;
     }
     FL_LOG_PARLIO("PARLIO_TX: First buffer submitted successfully - transmission started");
+
+    // #2548 EXPERIMENTAL: Eager-queue additional pre-encoded buffers to the IDF
+    // TX queue, so the hardware can chain them via DMA descriptors instead of
+    // waiting for an ISR-latency gap between txDone and next-submit.
+    //
+    // MEASURED IMPACT (16-lane × 256-LED WS2812B on P4 v1.3):
+    //   default off: total=16 995us  show=9 439us  wait=7 556us  (encode→TX serial)
+    //   eager on   : total=12 220us  show=10 605us wait=1 615us  (encode/TX overlap)
+    //
+    // WARNING: gated OFF by default because the IDF queue chaining behaviour
+    // for parlio_tx_unit is not guaranteed to be gap-free on all IDF versions.
+    // A gap > ~5µs between queued buffers would corrupt WS2812 timing (reset
+    // latch fires mid-frame). Validated correct TIMING on the bench but not
+    // OUTPUT correctness — needs RX-loopback validation per chipset.
+    //
+    // Enable with `-DFL_PARLIO_EAGER_QUEUE=1` once validated on your hardware.
+#if FL_PARLIO_EAGER_QUEUE
+    while (mIsrContext->mRingCount > 0) {
+        size_t idx = mIsrContext->mRingReadIdx;
+        size_t sz = mRingBuffer->sizes[idx];
+        if (!mPeripheral->transmit(mRingBuffer->ptrs[idx], sz * 8, 0x0000)) {
+            // Best-effort: stop on first failure. txDoneCallback will resubmit
+            // remaining buffers from the engine ring as TX progresses.
+            break;
+        }
+        mIsrContext->mRingReadIdx = (mIsrContext->mRingReadIdx + 1) % ParlioRingBuffer3::RING_BUFFER_COUNT;
+        mIsrContext->mRingCount = mIsrContext->mRingCount - 1;
+        FL_MEMORY_BARRIER;
+    }
+#endif
 
     //=========================================================================
     // Worker function now called directly from txDoneCallback (one-shot pattern)


### PR DESCRIPTION
## Summary

User asked: *\"verify that the esp32p4 encoder for parlio for the byte encoding and transposers is ISR stream chunking and that almost all of the frame time is waiting for the led parlio driver at 16x256 to finish. the encoding time should now be interleaved with the transmission time like we had it before\"*

Instrumented + verified. **Result: encoding is NOT interleaved with TX on master today.**

## Verification (16-lane × 256-LED WS2812B on P4 v1.3)

Added `perIterShowUs[]` / `perIterWaitUs[]` / `steadyAvgShowUs` / `steadyAvgWaitUs` to `parlioStreamValidate` to time `FastLED.show()` and `FastLED.wait()` separately:

| metric | master baseline | with `FL_PARLIO_EAGER_QUEUE=1` |
|---|---:|---:|
| `steady_avg_total_us` | 16 995 | **12 220** (-28 %) |
| `steady_avg_show_us` | 9 439 (encode + driver, before TX) | 10 605 |
| `steady_avg_wait_us` | 7 556 (TX, matches 7 680 µs floor) | **1 615** |

On master, `wait_us` ≈ full TX time = encoding and TX are **serial**, not interleaved. With eager-queue enabled, `wait_us` drops to ~1.6 ms — TX runs in the background during `show()`'s remaining work, exactly matching the user's stated expectation.

## Root cause

`ParlioEngine::beginTransmission()` pre-fills ALL ring buffers (encoding the full frame) *before* submitting any. It then submits exactly the first buffer to the IDF queue and relies on `txDoneCallback` to submit subsequent buffers. Even though `FL_ESP_PARLIO_HARDWARE_QUEUE_DEPTH = 3` would let the IDF chain multiple transmits via hardware DMA descriptors, the engine never exercises this. The result is `encode → submit → tx → ISR → submit → tx → done` — serial within a frame.

## Fix (opt-in)

Added `FL_PARLIO_EAGER_QUEUE` build flag. When set, `beginTransmission()` loops through all pre-encoded ring buffers *after* the first submit and queues each into the IDF TX queue. The IDF holds up to 3 pending transmits and chains them via DMA descriptors with no inter-buffer ISR-latency gap.

## Why default OFF

The IDF queue chaining behaviour for `parlio_tx_unit` is not guaranteed to be gap-free across all IDF versions — a gap > ~5 µs between queued buffers would corrupt WS2812 timing (50 µs reset latch fires mid-frame). This validates the *timing* in the bench but NOT the *output byte sequence* on the wire. The original `calculateBufferByteCount()` comment warned about this exact ~20 µs gap.

**To enable**: `-DFL_PARLIO_EAGER_QUEUE=1` after validating with a logic analyzer or RX-loopback for the target chipset.

## Test plan
- [x] `bash lint --cpp` clean
- [x] Build + flash on ESP32-P4 v1.3 with `FL_PARLIO_EAGER_QUEUE=0` (default): functional test passes, baseline timing
- [x] Build + flash on ESP32-P4 v1.3 with `FL_PARLIO_EAGER_QUEUE=1`: functional test still passes (no hangs), timing drops 17 → 12 ms
- [ ] **NOT YET DONE: per-chipset RX-loopback validation of the output bytes when eager-queue is on** — needs a jumper-wired rig

## Files
```
 src/platforms/esp/32/drivers/parlio/parlio_engine.cpp.hpp +43
 examples/AutoResearch/AutoResearchParlioStream.h          +28 / -4
 examples/AutoResearch/AutoResearchRemote.cpp              +8
```

Refs #2548, #2541.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Timing measurements now include granular show/wait operation breakdowns alongside overall metrics
  * Steady-state performance data expanded with separate show and wait operation metrics

* **Refactor**
  * Transmission queue handling optimized with new compile-time configurable enhancement option for reduced transmit gaps

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/FastLED/pull/2564?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->