### PR TITLE
fix(esp8266): guard SPI dispatch on FASTLED_ALL_PINS_HARDWARE_SPI

### DIFF
--- a/src/platforms/spi_output_template.h
+++ b/src/platforms/spi_output_template.h
@@ -22,7 +22,11 @@
 #elif defined(FL_IS_ESP32)
 #include "platforms/esp/32/drivers/spi/spi_output_template.h"
 
-#elif defined(FL_IS_ESP8266)
+#elif defined(FL_IS_ESP8266) && defined(FASTLED_ALL_PINS_HARDWARE_SPI)
+// ESP8266 hardware SPI driver pulls in Arduino <SPI.h>; only route here when
+// the user has opted in via FASTLED_ALL_PINS_HARDWARE_SPI (and added SPI to
+// their platformio.ini lib_deps). Otherwise fall through to the bitbang
+// fallback below — matches Apollo3's pattern.
 #include "platforms/esp/8266/spi_output_template.h"
 
 #elif defined(NRF51)


### PR DESCRIPTION
## Summary

- ESP8266 builds on master fail at `fastspi_esp8266.h:7:10: fatal error: SPI.h: No such file or directory` for every example.
- Root cause: `chipsets.h` unconditionally includes `platforms/spi_output_template.h`, which (since commit 8d524accd, 2026-01-16) routes ESP8266 to its hardware SPI template without the `FASTLED_ALL_PINS_HARDWARE_SPI` guard. The hardware SPI driver `#include <SPI.h>` (Arduino lib) that the ESP8266 PIO env does not pull in.
- Apollo3 in the same dispatch table kept its `FASTLED_ALL_PINS_HARDWARE_SPI` guard; ESP8266 lost it during the centralization.
- Fix: restore parity — only route to the ESP8266 hardware SPI template when the macro is defined. Without it, fall through to the existing bitbang fallback at the bottom of the dispatch (matches pre-refactor behavior, where `fastled_esp8266.h` guarded the include itself).

Fixes #2569

## Test plan

- [x] `bash lint` (cpp_linting / meson_linting / etc.) — clean.
- [ ] Wait for CI to confirm the `esp8622` job (and every example under it) link successfully again.
- [ ] Spot-check: users who explicitly set `-DFASTLED_ALL_PINS_HARDWARE_SPI` still get the hardware SPI driver — same dispatch line, just gated.

Generated with Claude Code (https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced ESP8266 platform SPI output configuration to provide more granular control. Users can now explicitly opt into hardware-accelerated SPI while maintaining a software SPI fallback for compatibility when the hardware-acceleration option is not enabled.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/FastLED/pull/2570?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->