### PR TITLE
fix(wave8): correct pulse-to-bit mapping in 2-lane BF1 transpose

### DIFF
--- a/src/fl/channels/detail/wave8.hpp
+++ b/src/fl/channels/detail/wave8.hpp
@@ -408,8 +408,11 @@ void wave8_transpose_4_bf1(const u8 lanes[4],
 
 /// @brief BF1 for 2-lane Wave8. Output: 8 symbols × 2 bytes = 16 bytes. Each
 ///        byte packs 4 pulses × 2 lanes bit-interleaved (lane 1 in even bit
-///        positions, lane 0 in odd). High byte holds MSB pulses (0..3), low
-///        byte holds LSB pulses (4..7).
+///        positions, lane 0 in odd). High byte (`output[s*2 + 0]`) holds
+///        bf1-pulse indices 0..3 with q=0 → pulse 3 and q=3 → pulse 0; low
+///        byte holds bf1-pulse indices 4..7 with q=0 → pulse 7 and q=3 →
+///        pulse 4. Layout matches `wave8_transpose_2`'s LUT-based packing
+///        (see FL_WAVE8_SPREAD_TO_16 / kTranspose4_16_LUT).
 FASTLED_FORCE_INLINE FL_IRAM FL_OPTIMIZE_FUNCTION
 void wave8_transpose_2_bf1(const u8 lanes[2],
                            u8 W0, u8 W1,
@@ -429,8 +432,14 @@ void wave8_transpose_2_bf1(const u8 lanes[2],
         u8 byte_hi = 0;
         u8 byte_lo = 0;
         for (int q = 0; q < 4; ++q) {
-            const int p_hi = q;
-            const int p_lo = q + 4;
+            // Reference `wave8_transpose_2` lands chipset-byte bit (4+q) at
+            // high-byte bit position (2*q) for lane 1 (even) / (2*q+1) for
+            // lane 0 (odd). Chipset-byte bit (4+q) corresponds to bf1
+            // pulse index (3 - q) because bf1 numbers pulse p ↔ chipset bit
+            // (7 - p). Similarly the low byte uses chipset bits 0..3, which
+            // map to bf1 pulses 7..4.
+            const int p_hi = 3 - q;
+            const int p_lo = 7 - q;
             const u8 m0_p_hi = static_cast<u8>(m0_mask[p_hi] & 1u);
             const u8 d_p_hi  = static_cast<u8>(d_mask[p_hi] & 1u);
             const u8 m0_p_lo = static_cast<u8>(m0_mask[p_lo] & 1u);


### PR DESCRIPTION
## Summary

- The property test `wave8Transpose_2_bf1 == wave8Transpose_2 (random)` (`tests/fl/channels/wave8.cpp:1087`) has been red on every master run since #2568 merged.
- Root cause: `wave8_transpose_2_bf1` packs each output byte with q=0..3 mapping to bf1-pulse indices `p_hi = q` / `p_lo = q+4`. The LUT-based reference `wave8_transpose_2` (via `FL_WAVE8_SPREAD_TO_16` / `kTranspose4_16_LUT`) lands chipset-byte bits at the **reversed** order inside each output byte:
  - high byte: q=0 → pulse 3, q=3 → pulse 0
  - low byte: q=0 → pulse 7, q=3 → pulse 4
- The original code produced bit-reversed bytes. Confirmed by hand-trace for `lanes={0xAB, 0xCD}` with W0=0xE0, W1=0xF8: before fix `byte[1] = 0x03` (bit-reversed of `0xC0`); after fix `byte[1] = 0xC0` matches the reference exactly.
- One-file fix: switch to `p_hi = 3 - q`, `p_lo = 7 - q`. The 4-lane and 8-lane BF1 implementations are unaffected.

## Test plan

- [x] `bash test fl_channels_wave8 --cpp` — passes (was red on master)
- [x] `bash test fl_channels_wave8 --debug` — passes with ASAN/UBSAN/LSAN
- [x] `bash lint` — clean

Generated with Claude Code (https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected internal implementation logic and updated documentation to align with system specifications.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/FastLED/pull/2571?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->