### PR TITLE
fix(examples): filter RGBWW to memory>=large (AVR overflows by 46KB)

### DIFF
--- a/examples/RGBWW/RGBWW.ino
+++ b/examples/RGBWW/RGBWW.ino
@@ -1,6 +1,14 @@
 // FL_AGENT_ALLOW_NEW_EXAMPLE — first example sketch for the 5-channel
 // RGB + warm-W + cool-W path landed in PR #2560 (issue #2558).
 //
+// @filter: (memory is large)
+//
+// Pulls in the full Channels API plus the colorimetric RGB→RGBWW solvers;
+// total code size is ~54 KB on AVR (overflows attiny85's 8 KB and uno's
+// 32 KB flash). Restrict CI compile matrix to boards with >= "large"
+// memory tier (Apollo3 / nRF52 / SAMD21+ / SAMD51 / STM32F4+ /
+// teensy 3.5+ / teensy 4.x / ESP32 / native / web / rp2040).
+//
 // Add the following to platformio.ini for full colorimetric output:
 //     build_flags =
 //         -DFASTLED_RGBW_COLORIMETRIC=1     ; provides the underlying math


### PR DESCRIPTION
## Summary

- `examples/RGBWW/RGBWW.ino` (new in #2560) ships without an `@filter`, so CI tries to compile it on every board. It pulls in the Channels API + colorimetric RGB→RGBWW solvers — ~54 KB total, which **overflows attiny85's 8 KB flash by 46,396 bytes** and won't fit on uno (32 KB) either.
- Affected workflows on master: `attiny85`, `attiny88`, `attiny1604`, `attiny1616`, `atmega8a`, plus the corresponding size guards (`check_uno_size`, `attiny85_binary_size`).
- Adds `// @filter: (memory is large)` to the .ino — matches the existing pattern used by `examples/Animartrix` and `examples/AnimartrixRing` for similarly heavy examples.

## Verified

Drove `sketch_filter.parse_filter_from_sketch` + `should_skip_sketch` against representative boards:

| Board                              | Tier  | Result |
|------------------------------------|-------|--------|
| attiny85                           | tiny  | SKIP   |
| attiny88                           | tiny  | SKIP   |
| uno                                | low   | SKIP   |
| apollo3_red                        | large | BUILD  |
| adafruit_feather_nrf52840_sense    | large | BUILD  |
| esp32dev                           | huge  | BUILD  |
| teensy41                           | huge  | BUILD  |

`bash lint` clean.

Fixes #2572

Generated with Claude Code (https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced the RGBWW example documentation with additional notes regarding memory constraints and board compatibility requirements for compilation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/FastLED/pull/2573?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->