### PR TITLE
fix(channels): guard Bus enum against CMSIS UART/SPI/I2S register macros

### DIFF
--- a/src/fl/channels/bus.h
+++ b/src/fl/channels/bus.h
@@ -17,6 +17,22 @@
 #include "fl/stl/stdint.h"
 #include "platforms/is_platform.h"
 
+// Platform CMSIS/Arduino headers (pulled in transitively above) define
+// peripheral pointer macros that collide with our `Bus` enumerator names.
+// Sam3X8E in particular does:
+//     #define UART ((Uart *)0x400E0800U)
+//     #define SPI  ((Spi  *)0x40008000U)
+// Without these undefs, the preprocessor expands those names inside
+// `enum class Bus { ..., SPI, UART, ... }`, producing a syntax error
+// (see FastLED sam3x8e_due CI failure). Push the originals so any
+// downstream TU that needs the register macros keeps working.
+#pragma push_macro("UART")
+#pragma push_macro("SPI")
+#pragma push_macro("I2S")
+#undef UART
+#undef SPI
+#undef I2S
+
 // Post-#2428 architecture: drivers do NOT auto-register with `ChannelManager`.
 // Only the platform-default driver TU (named by the legacy clockless controller's
 // Phase 5b pre-bind via `BusTraits<DefaultBus<Chipset>>::instancePtr()`) links
@@ -174,3 +190,9 @@ FL_STATIC_ASSERT(static_cast<fl::u8>(Bus::STUB) == 13,
                  "Bus changed: add the new value to busName() in this file");  // ok plain enum
 
 }  // namespace fl
+
+// Restore the original platform macros for any downstream code that needs
+// the CMSIS / Arduino register pointers.
+#pragma pop_macro("I2S")
+#pragma pop_macro("SPI")
+#pragma pop_macro("UART")

--- a/src/fl/channels/bus_priorities.h
+++ b/src/fl/channels/bus_priorities.h
@@ -15,6 +15,19 @@
 #include "fl/channels/bus.h"
 #include "fl/stl/stdint.h"
 
+// Platform CMSIS/Arduino headers may define SPI / UART / I2S as register
+// pointer macros (e.g. Sam3X8E: `#define UART ((Uart*)0x400E0800U)`).
+// Those macros expand inside qualified names like `Bus::SPI` below and
+// produce a syntax error. bus.h itself uses push_macro/pop_macro around
+// its enum definition; once bus.h pops the macros are restored. So we
+// must apply the same guard locally here. See fl/channels/bus.h.
+#pragma push_macro("UART")
+#pragma push_macro("SPI")
+#pragma push_macro("I2S")
+#undef UART
+#undef SPI
+#undef I2S
+
 namespace fl {
 
 /// @brief Default priority assigned to a `Bus` when registered with the manager.
@@ -45,3 +58,7 @@ constexpr int default_bus_priority(Bus b) FL_NOEXCEPT {
 }
 
 }  // namespace fl
+
+#pragma pop_macro("I2S")
+#pragma pop_macro("SPI")
+#pragma pop_macro("UART")


### PR DESCRIPTION
## Summary

- Every `sam3x8e_due` and `sam3x8e_due (digix merged)` workflow on master fails before any code is compiled: Atmel CMSIS defines `UART` / `SPI` / `I2S` as bare-name peripheral pointer macros, and `enum class Bus { ..., SPI, I2S, UART, ... }` in `fl/channels/bus.h` is preprocessor-expanded to garbage.
- Fix: wrap the enum definition and the `bus_priorities.h` constexpr lookup with `#pragma push_macro` / `#undef` / `#pragma pop_macro` for the three colliding names. `pop_macro` at the end restores CMSIS's original register macros for downstream TUs.
- No public API change — `fl::Bus::SPI` / `fl::Bus::I2S` / `fl::Bus::UART` still mean exactly what they did.
- ESP32 unaffected (register types there are typedefs, not bare-name macros).

Fixes #2574

## Test plan

- [x] `bash lint` clean (cpp_linting / meson_linting / etc.).
- [x] Host channels test still passes: `bash test fl_channels_bus_traits --cpp`.
- [ ] CI: `sam3x8e_due` and `sam3x8e_due (digix merged)` workflows should now reach actual compilation.

Generated with Claude Code (https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved a critical compatibility issue that affected certain microcontroller platforms (e.g., Sam3X8E), where system-level register macros conflicted with the Bus enumeration's internal names, causing build failures. The library now properly isolates and manages these platform-specific definitions to ensure reliable compilation across all supported hardware architectures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/FastLED/pull/2575?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->