### PR TITLE
fix(esp32c3): gate fast_isr.S on __riscv_atomic, not bare __riscv

### DIFF
--- a/src/platforms/esp/32/drivers/gpio_isr_rx/fast_isr.S
+++ b/src/platforms/esp/32/drivers/gpio_isr_rx/fast_isr.S
@@ -46,7 +46,14 @@
  * - Critical for achieving <20 cycle target
  */
 
-#ifdef __riscv  // Only compile for RISC-V platforms (ESP32-C6)
+// The fast ISR uses RV32A lr.w/sc.w atomics for the circular-buffer
+// index update. Only compile on RISC-V cores that ship the A extension
+// (ESP32-C6 / H2 / C5 / P4 — RV32IMAC+). ESP32-C3 and C2 are RV32IMC
+// and would fail the assembler with `extension 'zalrsc' required`.
+// The companion C++ glue in gpio_isr_rx_mcpwm.cpp.hpp already gates on
+// SOC_MCPWM_SUPPORTED, which excludes C3/C2 — this aligns the assembly
+// with that gate.
+#if defined(__riscv) && defined(__riscv_atomic)
 
 // ============================================================================
 // Section Placement
@@ -181,4 +188,4 @@ gpio_fast_edge_isr:
 
 .size gpio_fast_edge_isr, .-gpio_fast_edge_isr
 
-#endif // __riscv
+#endif // __riscv && __riscv_atomic


### PR DESCRIPTION
## Summary

- Every `esp32c3` example build on master fails at:
  ```
  fast_isr.S:150: Error: unrecognized opcode 'lr.w t0,(t4)', extension 'zalrsc' required
  fast_isr.S:160: Error: unrecognized opcode 'sc.w t5,t1,(t4)', extension 'zalrsc' required
  ```
- Root cause: the file is gated only by `#ifdef __riscv`, which matches every Espressif RISC-V chip — including ESP32-C3 / C2 (RV32IMC, no atomic extension). The companion C++ glue `gpio_isr_rx_mcpwm.cpp.hpp` already excludes those chips via `SOC_MCPWM_SUPPORTED` (C3/C2 lack MCPWM), so the assembly was the only file leaking into those builds.
- Fix: require `__riscv_atomic` (GCC's standard predefine for the A extension) alongside `__riscv`. C6 / H2 / C5 / P4 (RV32IMAC+) still compile the fast ISR; C3 / C2 cleanly skip it.

Fixes #2576

## Test plan

- [x] `bash lint` clean (cpp_linting / etc.).
- [ ] CI: every `esp32c3` workflow should now reach actual compilation.
- [ ] Sanity: `esp32c6` / `esp32h2` / `esp32p4` workflows must continue to include the fast ISR (no regression).

Generated with Claude Code (https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GPIO interrupt handler compatibility detection for ESP32 platforms to ensure proper functionality only on supported hardware cores.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/FastLED/pull/2577?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->