### PR TITLE
fix(uno_r4_wifi): provide fl::platforms::println impl for Renesas RA

### DIFF
--- a/src/platforms/arm/_build.cpp.hpp
+++ b/src/platforms/arm/_build.cpp.hpp
@@ -9,6 +9,7 @@
 #include "platforms/arm/d51/_build.cpp.hpp"
 #include "platforms/arm/mgm240/_build.cpp.hpp"
 #include "platforms/arm/nrf52/_build.cpp.hpp"
+#include "platforms/arm/renesas/_build.cpp.hpp"
 #include "platforms/arm/rp/_build.cpp.hpp"
 #include "platforms/arm/sam/_build.cpp.hpp"
 #include "platforms/arm/stm32/_build.cpp.hpp"

--- a/src/platforms/arm/renesas/_build.cpp.hpp
+++ b/src/platforms/arm/renesas/_build.cpp.hpp
@@ -1,0 +1,7 @@
+// IWYU pragma: private
+
+/// @file _build.hpp
+/// @brief Unity build header for platforms/arm/renesas/ directory
+/// Includes all implementation files in alphabetical order
+
+#include "platforms/arm/renesas/io_renesas.cpp.hpp"

--- a/src/platforms/arm/renesas/io_renesas.cpp.hpp
+++ b/src/platforms/arm/renesas/io_renesas.cpp.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+// IWYU pragma: private
+#include "platforms/arm/renesas/is_renesas.h"
+
+// ok no namespace fl
+
+// Renesas RA boards (Arduino UNO R4 Minima / WiFi) are Arduino-framework
+// targets; the standard `Serial.print*` API is available. Pulling in
+// platforms/arduino/io_arduino.hpp provides the `fl::platforms::print*`
+// implementations the rest of FastLED links against. Without this file
+// every `uno_r4_wifi` example fails at link with:
+//   undefined reference to `fl::platforms::println(char const*)'
+#ifdef FL_IS_RENESAS
+#include "platforms/arduino/io_arduino.hpp"
+#endif


### PR DESCRIPTION
## Summary

- Every `uno_r4_wifi` example build on master fails at link with:
  ```
  <artificial>:(.text+0x335a): undefined reference to `fl::platforms::println(char const*)'
  ```
- Root cause: `platforms/io.h` declares the platform I/O API in `fl::platforms` namespace. Every other Arduino-framework platform supplies a thin `io_<platform>.cpp.hpp` glue file that includes `platforms/arduino/io_arduino.hpp` (which routes the calls to `Serial.print*`). `platforms/arm/renesas/` had no equivalent — and no `_build.cpp.hpp` under it, and `platforms/arm/_build.cpp.hpp` didn't reference `renesas/` at all. So nothing in `arm/renesas/` was being compiled, and the println declarations had no definitions on Renesas RA targets.
- Same fix would have prevented this on `uno_r4_minima` too (same Renesas RA4M1 chip).

## Fix

- Added `src/platforms/arm/renesas/io_renesas.cpp.hpp` (guarded on `FL_IS_RENESAS`, includes `platforms/arduino/io_arduino.hpp` — mirrors `io_sam.cpp.hpp`).
- Added `src/platforms/arm/renesas/_build.cpp.hpp`.
- Wired `arm/renesas/_build.cpp.hpp` into `arm/_build.cpp.hpp` alphabetically between `nrf52` and `rp`.

## Test plan

- [x] `bash lint` clean (cpp_linting / etc.).
- [x] Host smoke test `bash test fastled_core --cpp` — still passes.
- [ ] CI: `uno_r4_wifi` workflow should now link successfully.
- [ ] (Once a `uno_r4_minima` workflow exists, it'll be picked up too — same Renesas RA4M1 platform.)

Fixes #2578

Generated with Claude Code (https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Renesas ARM platform, enabling FastLED functionality and I/O operations on Renesas RA board targets.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/FastLED/pull/2579?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->