### PR TITLE
perf(parlio) + lint: gate eager-queue to fits-in-ring frames + ban esp_rom_printf

### DIFF
--- a/ci/lint_cpp/esp_rom_printf_checker.py
+++ b/ci/lint_cpp/esp_rom_printf_checker.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Checker for `esp_rom_printf` usage in C/C++ files.
+
+`esp_rom_printf` is a low-level ROM-resident printf intended for very early
+boot diagnostics on ESP32-family chips (before the normal logging
+infrastructure is up). It writes synchronously to the USB-Serial-JTAG
+console and is convenient for boot-time bring-up — but using it from
+regular library code is undesirable for several reasons:
+
+  1. It bypasses FastLED's logging / async-logging facilities (FL_LOG_*,
+     FL_PRINT, FL_WARN), so its output cannot be filtered, redirected,
+     captured, or silenced by users.
+  2. It's blocking on a slow peripheral, making it expensive and unsafe
+     in hot paths or ISR contexts where logging is normally avoided.
+  3. The convention in this codebase is to keep platform-specific I/O
+     gated behind a small number of well-known shim points (the
+     `usb_serial_jtag_esp32_idf` driver, the `io_esp_jtag_or_uart` shim)
+     so it doesn't proliferate into unrelated files.
+
+Banned usage:
+  - `esp_rom_printf(...)` anywhere — call FL_LOG_INFO / FL_WARN / FL_PRINT
+    (or write to Serial / fl::io) instead.
+
+Opt-out:
+  - Append `// ok esp_rom_printf - <reason>` on the same line for genuinely
+    legitimate cases (e.g. the USB-Serial-JTAG driver bootstrap itself,
+    before any logging is initialized).
+"""
+
+import re
+
+from ci.util.check_files import FileContent, FileContentChecker
+from ci.util.paths import PROJECT_ROOT
+
+
+# Pattern to match `esp_rom_printf(...)` calls (function-style, not the name in a comment).
+ESP_ROM_PRINTF_PATTERN = re.compile(r"\besp_rom_printf\s*\(")
+
+# Opt-out marker on the same line. Lower-cased before match.
+OPT_OUT_MARKER = "ok esp_rom_printf"
+
+
+class EspRomPrintfChecker(FileContentChecker):
+    """Reject raw `esp_rom_printf` calls — use FastLED logging instead."""
+
+    def __init__(self):
+        self.violations: dict[str, list[tuple[int, str]]] = {}
+
+    def should_process_file(self, file_path: str) -> bool:
+        """Check if file should be processed."""
+        if not file_path.endswith((".cpp", ".h", ".hpp", ".ino", ".cpp.hpp")):
+            return False
+
+        # Skip third-party code (defines its own printf paths).
+        if "/third_party/" in file_path.replace("\\", "/"):
+            return False
+
+        return True
+
+    def check_file_content(self, file_content: FileContent) -> list[str]:
+        """Check file content for raw esp_rom_printf usage."""
+        violations: list[tuple[int, str]] = []
+        in_multiline_comment = False
+
+        for line_number, line in enumerate(file_content.lines, 1):
+            stripped = line.strip()
+
+            # Track multi-line comment state.
+            if "/*" in line:
+                in_multiline_comment = True
+            if "*/" in line:
+                in_multiline_comment = False
+                continue
+
+            if in_multiline_comment:
+                continue
+
+            if stripped.startswith("//"):
+                continue
+
+            code_part = line.split("//")[0]
+            comment_part = line[len(code_part) :].lower()
+
+            # Fast check before regex.
+            if "esp_rom_printf" not in code_part:
+                continue
+
+            if not ESP_ROM_PRINTF_PATTERN.search(code_part):
+                continue
+
+            # Allow opt-out: `// ok esp_rom_printf - <reason>` on the same line.
+            if OPT_OUT_MARKER in comment_part:
+                continue
+
+            violations.append(
+                (
+                    line_number,
+                    f"Avoid `esp_rom_printf` — use FastLED logging (FL_LOG_INFO, "
+                    f"FL_WARN, FL_PRINT) or fl::io instead: {stripped}\n"
+                    f"      Rationale: esp_rom_printf bypasses FastLED's logging "
+                    f"facilities, blocks on a slow peripheral, and proliferates "
+                    f"platform-specific I/O into general code.\n"
+                    f"      If this call is genuinely required (e.g. early "
+                    f"bootstrap before logging is up), suppress with "
+                    f"`// ok esp_rom_printf - <reason>` on the same line.",
+                )
+            )
+
+        if violations:
+            self.violations[file_content.path] = violations
+
+        return []
+
+
+def main() -> None:
+    """Run esp_rom_printf checker standalone."""
+    import sys
+    from pathlib import Path
+
+    from ci.util.check_files import (
+        MultiCheckerFileProcessor,
+        run_checker_standalone,
+    )
+
+    if len(sys.argv) > 1:
+        file_path = Path(sys.argv[1]).resolve()
+        if not file_path.exists():
+            print(f"Error: File not found: {file_path}")
+            sys.exit(1)
+
+        checker = EspRomPrintfChecker()
+        processor = MultiCheckerFileProcessor()
+        processor.process_files_with_checkers([str(file_path)], [checker])
+
+        if hasattr(checker, "violations") and checker.violations:
+            violations = checker.violations
+            print(
+                f"❌ Found raw esp_rom_printf usage — use FastLED logging instead "
+                f"({len(violations)} file(s)):\n"
+            )
+            for file_path_str, violation_list in violations.items():
+                rel_path = Path(file_path_str).relative_to(PROJECT_ROOT)
+                print(f"{rel_path}:")
+                for line_num, message in violation_list:
+                    print(f"  Line {line_num}: {message}")
+            sys.exit(1)
+        else:
+            print("✅ No raw esp_rom_printf usage found.")
+            sys.exit(0)
+    else:
+        checker = EspRomPrintfChecker()
+        run_checker_standalone(
+            checker,
+            [
+                str(PROJECT_ROOT / "src"),
+                str(PROJECT_ROOT / "examples"),
+                str(PROJECT_ROOT / "tests"),
+            ],
+            "Found raw esp_rom_printf usage — use FastLED logging instead",
+            extensions=[".cpp", ".h", ".hpp", ".ino", ".cpp.hpp"],
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/ci/lint_cpp/run_all_checkers.py
+++ b/ci/lint_cpp/run_all_checkers.py
@@ -38,6 +38,7 @@ from ci.lint_cpp.cpp_hpp_includes_checker import CppHppIncludesChecker
 from ci.lint_cpp.cpp_include_checker import CppIncludeChecker
 from ci.lint_cpp.ctype_global_checker import CtypeGlobalChecker
 from ci.lint_cpp.enum_class_checker import EnumClassChecker
+from ci.lint_cpp.esp_rom_printf_checker import EspRomPrintfChecker
 from ci.lint_cpp.fastled_header_usage_checker import FastLEDHeaderUsageChecker
 from ci.lint_cpp.fl_is_defined_checker import FlIsDefinedChecker
 from ci.lint_cpp.headers_exist_checker import HeadersExistChecker
@@ -181,6 +182,7 @@ def create_checkers(
         AsmJsLocationChecker(),  # Checks EM_JS / EM_ASYNC_JS / EM_ASM live only in *.js.cpp.hpp
         BannedMacrosChecker(),  # Checks for banned preprocessor macros like __has_include
         BuiltinMemcpyChecker(),  # Checks for raw __builtin_memcpy — use FL_BUILTIN_MEMCPY
+        EspRomPrintfChecker(),  # Checks for raw esp_rom_printf — use FastLED logging
         FlIsDefinedChecker(),
         BannedNamespaceChecker(),  # Checks for banned namespace patterns like fl::fl
         SingletonInHeadersChecker(),  # Checks for Singleton<T> in headers (must use SingletonShared<T>)

--- a/examples/AutoResearch/AutoResearchParlioEncode.h
+++ b/examples/AutoResearch/AutoResearchParlioEncode.h
@@ -192,9 +192,9 @@ inline ParlioEncodeResult measureParlioEncode(int iters_in = 12000) {
 
 inline void printParlioEncodeResultRom(const ParlioEncodeResult &r) {
     if (r.iters == 0) {
-        esp_rom_printf("\nBENCH_PARLIO_START (issue #2526 follow-up)\n");
-        esp_rom_printf("BENCH_PARLIO ERROR: heap allocation failed\n");
-        esp_rom_printf("BENCH_PARLIO_END\n\n");
+        esp_rom_printf("\nBENCH_PARLIO_START (issue #2526 follow-up)\n");  // ok esp_rom_printf - boot-time bench output to COM25 (#2541)
+        esp_rom_printf("BENCH_PARLIO ERROR: heap allocation failed\n");  // ok esp_rom_printf - boot-time bench output to COM25 (#2541)
+        esp_rom_printf("BENCH_PARLIO_END\n\n");  // ok esp_rom_printf - boot-time bench output to COM25 (#2541)
         return;
     }
 
@@ -222,18 +222,18 @@ inline void printParlioEncodeResultRom(const ParlioEncodeResult &r) {
     // WS2812B 800kHz, 16 lanes in parallel, 256 LEDs * 24 bits * 1.25 us/bit.
     constexpr fl::u32 WS2812B_FRAME_US = 7680;
 
-    esp_rom_printf("\nBENCH_PARLIO_START (16 lanes x 256 LEDs, byte-LUT, #2526 follow-up)\n");
-    esp_rom_printf("BENCH_PARLIO iters=%u lanes=%u leds=%u sink=%u\n",
+    esp_rom_printf("\nBENCH_PARLIO_START (16 lanes x 256 LEDs, byte-LUT, #2526 follow-up)\n");  // ok esp_rom_printf - boot-time bench output to COM25 (#2541)
+    esp_rom_printf("BENCH_PARLIO iters=%u lanes=%u leds=%u sink=%u\n",  // ok esp_rom_printf - boot-time bench output to COM25 (#2541)
                    r.iters, r.lanes, r.leds_per_lane, r.sink);
-    esp_rom_printf("BENCH_PARLIO perpos_us  ss=%u sp=%u ps=%u pp=%u\n",
+    esp_rom_printf("BENCH_PARLIO perpos_us  ss=%u sp=%u ps=%u pp=%u\n",  // ok esp_rom_printf - boot-time bench output to COM25 (#2541)
                    r.perpos_ss_us, r.perpos_sp_us, r.perpos_ps_us, r.perpos_pp_us);
-    esp_rom_printf("BENCH_PARLIO perpos_ns_each  ss=%u sp=%u ps=%u pp=%u\n",
+    esp_rom_printf("BENCH_PARLIO perpos_ns_each  ss=%u sp=%u ps=%u pp=%u\n",  // ok esp_rom_printf - boot-time bench output to COM25 (#2541)
                    ss_ns_per, sp_ns_per, ps_ns_per, pp_ns_per);
-    esp_rom_printf("BENCH_PARLIO frame_equiv_us  ss=%u sp=%u ps=%u pp=%u  ws2812b_tx=%u\n",
+    esp_rom_printf("BENCH_PARLIO frame_equiv_us  ss=%u sp=%u ps=%u pp=%u  ws2812b_tx=%u\n",  // ok esp_rom_printf - boot-time bench output to COM25 (#2541)
                    ss_frame_us, sp_frame_us, ps_frame_us, pp_frame_us, WS2812B_FRAME_US);
-    esp_rom_printf("BENCH_PARLIO ratio_x100  sp_vs_ss=%u ps_vs_ss=%u pp_vs_ss=%u\n",
+    esp_rom_printf("BENCH_PARLIO ratio_x100  sp_vs_ss=%u ps_vs_ss=%u pp_vs_ss=%u\n",  // ok esp_rom_printf - boot-time bench output to COM25 (#2541)
                    ratio_sp_ss_x100, ratio_ps_ss_x100, ratio_pp_ss_x100);
-    esp_rom_printf("BENCH_PARLIO_END\n\n");
+    esp_rom_printf("BENCH_PARLIO_END\n\n");  // ok esp_rom_printf - boot-time bench output to COM25 (#2541)
 }
 
 #else // !FL_PARLIO_BENCH_ENABLED

--- a/examples/AutoResearch/AutoResearchWave8Expand.h
+++ b/examples/AutoResearch/AutoResearchWave8Expand.h
@@ -187,17 +187,17 @@ inline void printWave8ExpandResultRom(const Wave8ExpandResult &r) {
     fl::u32 t16_nib_frame = static_cast<fl::u32>(static_cast<fl::u64>(r.transpose16_nibble_us) * 768 / iters64);
     fl::u32 t16_byte_frame = static_cast<fl::u32>(static_cast<fl::u64>(r.transpose16_byte_us) * 768 / iters64);
 
-    esp_rom_printf("\nBENCH_EXPAND_START (issue #2526)\n");
-    esp_rom_printf("BENCH_EXPAND iters=%u sink=%u\n", r.iters, r.sink);
-    esp_rom_printf("BENCH_EXPAND expand_only_us  nibble=%u byte=%u batched=%u\n",
+    esp_rom_printf("\nBENCH_EXPAND_START (issue #2526)\n");  // ok esp_rom_printf - boot-time bench output to COM25 (#2541)
+    esp_rom_printf("BENCH_EXPAND iters=%u sink=%u\n", r.iters, r.sink);  // ok esp_rom_printf - boot-time bench output to COM25 (#2541)
+    esp_rom_printf("BENCH_EXPAND expand_only_us  nibble=%u byte=%u batched=%u\n",  // ok esp_rom_printf - boot-time bench output to COM25 (#2541)
                    r.expand_nibble_us, r.expand_byte_us, r.expand_batched_us);
-    esp_rom_printf("BENCH_EXPAND transpose16_us  nibble=%u byte=%u\n",
+    esp_rom_printf("BENCH_EXPAND transpose16_us  nibble=%u byte=%u\n",  // ok esp_rom_printf - boot-time bench output to COM25 (#2541)
                    r.transpose16_nibble_us, r.transpose16_byte_us);
-    esp_rom_printf("BENCH_EXPAND frame_equiv_us  expand_nibble=%u expand_byte=%u t16_nibble=%u t16_byte=%u\n",
+    esp_rom_printf("BENCH_EXPAND frame_equiv_us  expand_nibble=%u expand_byte=%u t16_nibble=%u t16_byte=%u\n",  // ok esp_rom_printf - boot-time bench output to COM25 (#2541)
                    expand_nib_frame, expand_byte_frame, t16_nib_frame, t16_byte_frame);
-    esp_rom_printf("BENCH_EXPAND speedup_x100  expand=%u batched=%u transpose16=%u\n",
+    esp_rom_printf("BENCH_EXPAND speedup_x100  expand=%u batched=%u transpose16=%u\n",  // ok esp_rom_printf - boot-time bench output to COM25 (#2541)
                    spd_byte, spd_batched, spd_t16);
-    esp_rom_printf("BENCH_EXPAND_END\n\n");
+    esp_rom_printf("BENCH_EXPAND_END\n\n");  // ok esp_rom_printf - boot-time bench output to COM25 (#2541)
 }
 
 #else // non-ESP32

--- a/src/platforms/esp/32/detail/io_esp_jtag_or_uart.hpp
+++ b/src/platforms/esp/32/detail/io_esp_jtag_or_uart.hpp
@@ -230,11 +230,11 @@ private:
         if (mUsbSerialJtag.isBuffered()) {
             // Our USB-Serial JTAG driver installed successfully
             mUseUsbSerialJtag = true;
-            esp_rom_printf("EspIO: Using ESP-IDF USB-Serial JTAG driver\n");
+            esp_rom_printf("EspIO: Using ESP-IDF USB-Serial JTAG driver\n");  // ok esp_rom_printf - USB-Serial-JTAG vs ROM-UART selection log (pre-logging)
         } else {
             // USB-Serial JTAG driver failed to install - fall back to UART0
             mUseUsbSerialJtag = false;
-            esp_rom_printf("EspIO: USB-Serial JTAG installation failed - falling back to UART0\n");
+            esp_rom_printf("EspIO: USB-Serial JTAG installation failed - falling back to UART0\n");  // ok esp_rom_printf - USB-Serial-JTAG vs ROM-UART selection log (pre-logging)
         }
 #endif
     }

--- a/src/platforms/esp/32/drivers/parlio/parlio_engine.cpp.hpp
+++ b/src/platforms/esp/32/drivers/parlio/parlio_engine.cpp.hpp
@@ -107,12 +107,17 @@ namespace detail {
 #endif // defined(FL_ESP_PARLIO_HARDWARE_QUEUE_DEPTH)
 
 // #2548: when set, beginTransmission() submits all pre-encoded ring buffers
-// to the IDF TX queue immediately. The IDF holds up to
-// FL_ESP_PARLIO_HARDWARE_QUEUE_DEPTH pending transmits and chains them via
-// hardware DMA descriptors — eliminating the ISR-latency gap between buffers
-// that previously serialized encode→TX within a frame.
+// to the IDF TX queue immediately FOR FRAMES THAT FIT IN THE RING. The IDF
+// holds up to FL_ESP_PARLIO_HARDWARE_QUEUE_DEPTH pending transmits and chains
+// them via hardware DMA descriptors — eliminating the ISR-latency gap between
+// buffers that would otherwise serialize encode→TX within a frame.
 //
-// MEASURED IMPACT (16-lane × 256-LED WS2812B on P4 v1.3):
+// For frames LARGER than the ring (extra-long LED strips), the engine falls
+// back to the chunked-streaming path: txDoneCallback + workerIsrCallback
+// submit + populate buffers one at a time as TX drains, with new chunks
+// encoded on the fly. Both paths coexist; the decision is per-frame.
+//
+// MEASURED IMPACT (16-lane × 256-LED WS2812B on P4 v1.3, fits-in-ring path):
 //   off: total=16 995us  show=9 439us  wait=7 556us  (encode→TX serial)
 //   on : total=12 220us  show=10 605us wait=1 615us  (encode/TX overlap, ~30% faster)
 //
@@ -1933,21 +1938,38 @@ bool ParlioEngine::beginTransmission(const u8* scratchBuffer,
     // background while show() submits buffer 1+ (and any FastLED bookkeeping
     // runs concurrently with TX too).
     //
+    // CRITICAL: only eager-queue when the entire frame is already encoded
+    // (i.e. the frame fit in the engine's 3-buffer ring). For frames larger
+    // than the ring, encoding must continue in the background via the
+    // txDoneCallback → workerIsrCallback streaming path — those need
+    // `mRingCount` to track "buffers waiting to be submitted to IDF", which
+    // gets corrupted if we drain it eagerly. The "ring empty but more data
+    // pending" branch in txDoneCallback would also incorrectly set
+    // `mHardwareIdle = true` while the IDF queue is still draining.
+    //
     // Configurable via FL_PARLIO_EAGER_QUEUE (default ON). See header comment
     // for measured impact and disable instructions.
 #if FL_PARLIO_EAGER_QUEUE
-    while (mIsrContext->mRingCount > 0) {
-        size_t idx = mIsrContext->mRingReadIdx;
-        size_t sz = mRingBuffer->sizes[idx];
-        if (!mPeripheral->transmit(mRingBuffer->ptrs[idx], sz * 8, 0x0000)) {
-            // Best-effort: stop on first failure. txDoneCallback will resubmit
-            // remaining buffers from the engine ring as TX progresses.
-            break;
+    const bool frame_fits_in_ring =
+        (mIsrContext->mNextByteOffset >= mIsrContext->mTotalBytes);
+    if (frame_fits_in_ring) {
+        while (mIsrContext->mRingCount > 0) {
+            size_t idx = mIsrContext->mRingReadIdx;
+            size_t sz = mRingBuffer->sizes[idx];
+            if (!mPeripheral->transmit(mRingBuffer->ptrs[idx], sz * 8, 0x0000)) {
+                // Best-effort: stop on first failure. txDoneCallback will resubmit
+                // remaining buffers from the engine ring as TX progresses.
+                break;
+            }
+            mIsrContext->mRingReadIdx = (mIsrContext->mRingReadIdx + 1) % ParlioRingBuffer3::RING_BUFFER_COUNT;
+            mIsrContext->mRingCount = mIsrContext->mRingCount - 1;
+            FL_MEMORY_BARRIER;
         }
-        mIsrContext->mRingReadIdx = (mIsrContext->mRingReadIdx + 1) % ParlioRingBuffer3::RING_BUFFER_COUNT;
-        mIsrContext->mRingCount = mIsrContext->mRingCount - 1;
-        FL_MEMORY_BARRIER;
     }
+    // else: frame > ring capacity → leave remaining buffers in the engine
+    // ring; the existing chunked-streaming path (txDoneCallback +
+    // workerIsrCallback) will submit them one at a time as TX drains, while
+    // also encoding new chunks on the fly.
 #endif
 
     //=========================================================================

--- a/src/platforms/esp/32/drivers/usb_serial_jtag_esp32_idf.hpp
+++ b/src/platforms/esp/32/drivers/usb_serial_jtag_esp32_idf.hpp
@@ -58,7 +58,7 @@ UsbSerialJtagEsp32::~UsbSerialJtagEsp32() {
 #ifdef FL_HAS_USB_SERIAL_JTAG
     // Only uninstall if WE installed it (don't uninstall Arduino's driver)
     if (mInstalledDriver) {
-        esp_rom_printf("USB-Serial JTAG: Uninstalling driver\n");
+        esp_rom_printf("USB-Serial JTAG: Uninstalling driver\n");  // ok esp_rom_printf - USB-Serial-JTAG driver bootstrap (pre-logging)
         usb_serial_jtag_driver_uninstall();
     }
 #endif
@@ -96,7 +96,7 @@ UsbSerialJtagEsp32& UsbSerialJtagEsp32::operator=(UsbSerialJtagEsp32&& other) FL
 
 bool UsbSerialJtagEsp32::initDriver() FL_NOEXCEPT {
 #ifdef FL_HAS_USB_SERIAL_JTAG
-    esp_rom_printf("\n=== USB-Serial JTAG Driver Init ===\n");
+    esp_rom_printf("\n=== USB-Serial JTAG Driver Init ===\n");  // ok esp_rom_printf - USB-Serial-JTAG driver bootstrap (pre-logging)
 
     // ROBUST DRIVER DETECTION:
     // usb_serial_jtag_is_driver_installed() was added in ESP-IDF 5.4.0
@@ -104,18 +104,18 @@ bool UsbSerialJtagEsp32::initDriver() FL_NOEXCEPT {
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 4, 0)
     // Use usb_serial_jtag_is_driver_installed() to check if driver already exists
     if (usb_serial_jtag_is_driver_installed()) {
-        esp_rom_printf("USB-Serial JTAG: Driver already installed (inherited from Arduino or bootloader)\n");
+        esp_rom_printf("USB-Serial JTAG: Driver already installed (inherited from Arduino or bootloader)\n");  // ok esp_rom_printf - USB-Serial-JTAG driver bootstrap (pre-logging)
         mBuffered = true;
         mInstalledDriver = false;  // We didn't install it, so don't uninstall it
         return true;  // Success: driver is installed and functional
     }
 
     // Driver not installed - install it ourselves
-    esp_rom_printf("USB-Serial JTAG: Driver not detected, installing...\n");
+    esp_rom_printf("USB-Serial JTAG: Driver not detected, installing...\n");  // ok esp_rom_printf - USB-Serial-JTAG driver bootstrap (pre-logging)
 #else
     // ESP-IDF < 5.4.0: No is_driver_installed() function available
     // Attempt to install driver - if it fails with ESP_ERR_INVALID_STATE, driver already installed
-    esp_rom_printf("USB-Serial JTAG: Attempting driver installation...\n");
+    esp_rom_printf("USB-Serial JTAG: Attempting driver installation...\n");  // ok esp_rom_printf - USB-Serial-JTAG driver bootstrap (pre-logging)
 #endif
 
     // Configure USB-Serial JTAG with buffer sizes
@@ -123,30 +123,30 @@ bool UsbSerialJtagEsp32::initDriver() FL_NOEXCEPT {
     usb_config.tx_buffer_size = static_cast<u32>(mConfig.txBufferSize);
     usb_config.rx_buffer_size = static_cast<u32>(mConfig.rxBufferSize);
 
-    esp_rom_printf("USB-Serial JTAG: Installing driver (rx_buf=%d, tx_buf=%d)...\n",
+    esp_rom_printf("USB-Serial JTAG: Installing driver (rx_buf=%d, tx_buf=%d)...\n",  // ok esp_rom_printf - USB-Serial-JTAG driver bootstrap (pre-logging)
                   static_cast<int>(mConfig.rxBufferSize),
                   static_cast<int>(mConfig.txBufferSize));
 
     esp_err_t err = usb_serial_jtag_driver_install(&usb_config);
 
     if (err == ESP_OK) {
-        esp_rom_printf("USB-Serial JTAG: Driver installed successfully!\n");
+        esp_rom_printf("USB-Serial JTAG: Driver installed successfully!\n");  // ok esp_rom_printf - USB-Serial-JTAG driver bootstrap (pre-logging)
         mBuffered = true;
         mInstalledDriver = true;  // We installed it, so we'll uninstall it later
 
         // Add small delay after driver installation (similar to UART)
         vTaskDelay(50 / portTICK_PERIOD_MS);  // 50ms delay
-        esp_rom_printf("USB-Serial JTAG: Post-install delay complete\n");
+        esp_rom_printf("USB-Serial JTAG: Post-install delay complete\n");  // ok esp_rom_printf - USB-Serial-JTAG driver bootstrap (pre-logging)
 
         // Verify installation worked (only if function is available)
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 4, 0)
         if (usb_serial_jtag_is_driver_installed()) {
-            esp_rom_printf("USB-Serial JTAG: Verification OK - buffered mode active\n");
+            esp_rom_printf("USB-Serial JTAG: Verification OK - buffered mode active\n");  // ok esp_rom_printf - USB-Serial-JTAG driver bootstrap (pre-logging)
         } else {
-            esp_rom_printf("WARNING: USB-Serial JTAG verification failed\n");
+            esp_rom_printf("WARNING: USB-Serial JTAG verification failed\n");  // ok esp_rom_printf - USB-Serial-JTAG driver bootstrap (pre-logging)
         }
 #else
-        esp_rom_printf("USB-Serial JTAG: Driver installed (verification not available in IDF < 5.4)\n");
+        esp_rom_printf("USB-Serial JTAG: Driver installed (verification not available in IDF < 5.4)\n");  // ok esp_rom_printf - USB-Serial-JTAG driver bootstrap (pre-logging)
 #endif
 
         return true;
@@ -154,25 +154,25 @@ bool UsbSerialJtagEsp32::initDriver() FL_NOEXCEPT {
 
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 4, 0)
     // Installation failed - will fall back to ROM UART
-    esp_rom_printf("ERROR: USB-Serial JTAG driver installation failed (err=0x%x) - FALLING BACK TO ROM UART\n", err);
+    esp_rom_printf("ERROR: USB-Serial JTAG driver installation failed (err=0x%x) - FALLING BACK TO ROM UART\n", err);  // ok esp_rom_printf - USB-Serial-JTAG driver bootstrap (pre-logging)
     return false;
 #else
     // ESP-IDF < 5.4.0: If installation failed with ESP_ERR_INVALID_STATE, driver is already installed by Arduino
     if (err == ESP_ERR_INVALID_STATE) {
-        esp_rom_printf("USB-Serial JTAG: Driver already installed by Arduino/bootloader\n");
+        esp_rom_printf("USB-Serial JTAG: Driver already installed by Arduino/bootloader\n");  // ok esp_rom_printf - USB-Serial-JTAG driver bootstrap (pre-logging)
         mBuffered = true;
         mInstalledDriver = false;  // We didn't install it, so don't uninstall it
         return true;
     }
 
     // Other errors - fall back to ROM UART
-    esp_rom_printf("ERROR: USB-Serial JTAG driver installation failed (err=0x%x) - FALLING BACK TO ROM UART\n", err);
+    esp_rom_printf("ERROR: USB-Serial JTAG driver installation failed (err=0x%x) - FALLING BACK TO ROM UART\n", err);  // ok esp_rom_printf - USB-Serial-JTAG driver bootstrap (pre-logging)
     return false;
 #endif
 
 #else
     // USB-Serial JTAG not available on this chip - fall back to ROM UART
-    esp_rom_printf("USB-Serial JTAG: Not available on this chip - using ROM UART\n");
+    esp_rom_printf("USB-Serial JTAG: Not available on this chip - using ROM UART\n");  // ok esp_rom_printf - USB-Serial-JTAG driver bootstrap (pre-logging)
     return false;
 #endif
 }
@@ -199,7 +199,7 @@ void UsbSerialJtagEsp32::write(const char* str) FL_NOEXCEPT {
                 src += (size_t)written;
                 remaining -= (size_t)written;
             } else if (written < 0) {
-                esp_rom_printf("ERROR: USB-Serial JTAG write failed (err=%d)\n", written);
+                esp_rom_printf("ERROR: USB-Serial JTAG write failed (err=%d)\n", written);  // ok esp_rom_printf - USB-Serial-JTAG driver bootstrap (pre-logging)
                 break;
             }
             // written == 0: buffer full, will retry after timeout
@@ -270,7 +270,7 @@ void UsbSerialJtagEsp32::writeln(const char* str) FL_NOEXCEPT {
                 src += (size_t)written;
                 remaining -= (size_t)written;
             } else if (written < 0) {
-                esp_rom_printf("ERROR: USB-Serial JTAG writeln failed (err=%d)\n", written);
+                esp_rom_printf("ERROR: USB-Serial JTAG writeln failed (err=%d)\n", written);  // ok esp_rom_printf - USB-Serial-JTAG driver bootstrap (pre-logging)
                 break;
             }
             // written == 0: buffer full after timeout, retry


### PR DESCRIPTION
## Two related changes

### 1 — Engine: gate eager-queue so chunked streaming still works for large frames

[#2565](https://github.com/FastLED/FastLED/pull/2565) turned eager-queue ON by default to overlap encode with TX. That's correct for frames that **fit** in the engine's 3-buffer ring — encoding completes before any TX submit, the loop drains `mRingCount → 0`, IDF chains buffers via DMA descriptors, all good.

But for **larger** frames (long LED strips that exceed the ring's capacity), the engine relies on chunked streaming: `beginTransmission()` encodes one chunk per ring slot, leaves `mNextByteOffset < mTotalBytes`, and expects `txDoneCallback → workerIsrCallback` to encode + submit the rest as TX drains. Eager-queue's drain-to-zero pattern corrupts this:

```
After eager-queue: mRingCount = 0 (engine ring empty) BUT IDF still has buffers in flight.
txDone for buf 0:  sees count==0 AND bytes_transmitted < total
                   → takes "ring empty but more data pending" branch
                   → sets mHardwareIdle = true / mTransmitting = false
                   → ❌ wrong: IDF is currently transmitting buf 1, hardware is NOT idle
```

**Fix**: only fire the eager-queue loop when `mNextByteOffset >= mTotalBytes` (whole frame already encoded). For streaming frames, fall back to one-submit-per-txDone.

Verified on P4 v1.3 16-lane × 256-LED (fits in ring):

```
steady_avg_total = 12 431 µs
steady_avg_show  = 10 817 µs
steady_avg_wait  =  1 613 µs   ← TX still overlaps with show()
```

Same as #2565 — fits-in-ring path preserved, large-frame streaming path no longer trips the broken state machine.

### 2 — Lint: ban raw `esp_rom_printf`

`esp_rom_printf` is a low-level ROM printf intended for very early boot diagnostics. It's been creeping into general code as a workaround for #2541 (testSimd RPC routing on P4). New checker `ci/lint_cpp/esp_rom_printf_checker.py` flags it anywhere in `src/` / `examples/` / `tests/`. Suppress with `// ok esp_rom_printf - <reason>` on the same line.

Applied opt-out comments to **36 existing legitimate uses**:
- `src/platforms/esp/32/drivers/usb_serial_jtag_esp32_idf.hpp` (17) and `detail/io_esp_jtag_or_uart.hpp` (2): bootstrap before logging is up.
- `examples/AutoResearch/AutoResearchParlioEncode.h` (10) and `AutoResearchWave8Expand.h` (7): bench output to COM25 (#2541 workaround).

Smoke-tested: a fake violation in a scratch `.cpp` file is correctly flagged; the same line with the opt-out marker is not.

## Test plan
- [x] `bash lint --cpp` clean (existing legitimate uses are suppressed, no new violations).
- [x] Standalone checker run: zero false positives across the whole tree.
- [x] Smoke test: fake violation correctly flagged; opt-out comment correctly allows.
- [x] Live device (ESP32-P4 v1.3) 16-lane × 256-LED bench shows encode/TX still interleaves with the new gate in place.

## Files
```
 ci/lint_cpp/esp_rom_printf_checker.py                           +165
 ci/lint_cpp/run_all_checkers.py                                 +2
 src/platforms/esp/32/drivers/parlio/parlio_engine.cpp.hpp       +27 / −10
 src/platforms/esp/32/drivers/usb_serial_jtag_esp32_idf.hpp      (suppressions, no logic change)
 src/platforms/esp/32/detail/io_esp_jtag_or_uart.hpp             (suppressions, no logic change)
 examples/AutoResearch/AutoResearchParlioEncode.h                (suppressions, no logic change)
 examples/AutoResearch/AutoResearchWave8Expand.h                 (suppressions, no logic change)
```

Refs #2548, #2565.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced ESP32 USB-Serial JTAG initialization with improved diagnostic logging for backend selection and error detection.
  * Refined PARLIO transmission queue behavior for more efficient frame encoding and transmission.

* **Code Quality**
  * Added new code linter to enforce logging best practices across the codebase.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/FastLED/pull/2581?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->