### PR TITLE
fix(channels): sync Channel::mSettings from ChannelOptions (meta #2580 A3)

### DIFF
--- a/src/fl/channels/channel.cpp.hpp
+++ b/src/fl/channels/channel.cpp.hpp
@@ -192,6 +192,11 @@ Channel::Channel(const ChipsetVariant& chipset, fl::span<CRGB> leds,
     // Set the LED data array
     setLeds(leds);
 
+    // Sync mSettings from ChannelOptions so the mWhiteCfg variant (and any
+    // other future fields) survives to showPixels(). The setter calls below
+    // are then idempotent overlays on top of the same data.
+    mSettings = options;
+
     // Set color correction/temperature/dither/rgbw from ChannelOptions
     setCorrection(options.mCorrection);
     setTemperature(options.mTemperature);
@@ -218,6 +223,10 @@ Channel::Channel(int pin, const ChipsetTimingConfig& timing, fl::span<CRGB> leds
     // Set the LED data array
     setLeds(leds);
 
+    // Sync mSettings from ChannelOptions so the mWhiteCfg variant survives
+    // to showPixels(). See sibling ChipsetVariant constructor for rationale.
+    mSettings = options;
+
     // Set color correction/temperature/dither/rgbw from ChannelOptions
     setCorrection(options.mCorrection);
     setTemperature(options.mTemperature);
@@ -239,6 +248,9 @@ void Channel::applyConfig(const ChannelConfig& config) {
         mName = config.mName.value();
     }
     setLeds(config.mLeds);
+    // Sync mSettings from incoming options so the mWhiteCfg variant survives
+    // to showPixels(). Setters below are idempotent overlays on the same data.
+    mSettings = config.options;
     setCorrection(config.options.mCorrection);
     setTemperature(config.options.mTemperature);
     setDither(config.options.mDitherMode);


### PR DESCRIPTION
## Summary

`Channel::showPixels()` builds `ReorderingPixelIteratorAny` from `mSettings.rgbw()/rgbww()`, but neither the constructor nor `applyConfig()` ever assigned `mSettings` from the incoming `ChannelOptions`. Any channel configured via `ChannelOptions::mWhiteCfg` therefore silently encoded as plain RGB.

This PR assigns `mSettings = options;` (and `mSettings = config.options;` in `applyConfig`) before the existing `applyWhiteCfg(*this, ...)` calls so the variant survives to `showPixels()`.

Addresses meta-issue #2580 finding **A3** (originally CodeRabbit on #2560 — https://github.com/FastLED/FastLED/pull/2560#discussion_r3328237853).

## Test plan
- [x] `bash lint`
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed white-channel color settings not persisting correctly during pixel display operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/FastLED/pull/2582?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->