### PR TITLE
style(autoresearch): consolidate consecutive identical #if guards (meta #2580 C4)

### DIFF
--- a/examples/AutoResearch/AutoResearchWave8Expand.h
+++ b/examples/AutoResearch/AutoResearchWave8Expand.h
@@ -22,9 +22,7 @@
 #include "fl/stl/int.h"
 
 #if defined(ARDUINO_ARCH_ESP32) || defined(ESP_PLATFORM)
-#include <Arduino.h> // micros()
-#endif
-#if defined(ARDUINO_ARCH_ESP32) || defined(ESP_PLATFORM)
+#include <Arduino.h>     // micros()
 #include <esp_rom_sys.h> // esp_rom_printf -> USB-Serial-JTAG console (#2540)
 #endif
 


### PR DESCRIPTION
## Summary

Two back-to-back `#if defined(ARDUINO_ARCH_ESP32) || defined(ESP_PLATFORM)` blocks in `examples/AutoResearch/AutoResearchWave8Expand.h:24-29` are merged into a single guard. Pure readability cleanup; no semantic change.

Addresses meta-issue #2580 finding **C4** (originally CodeRabbit on #2539 — https://github.com/FastLED/FastLED/pull/2539#pullrequestreview-4392906948).

## Test plan
- [x] `bash lint`
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Minor formatting adjustments to code comments for consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/FastLED/pull/2583?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->