### PR TITLE
style(autoresearch): rename _w8r local to w8r (meta #2580 C3)

### DIFF
--- a/examples/AutoResearch/AutoResearch.ino
+++ b/examples/AutoResearch/AutoResearch.ino
@@ -339,8 +339,8 @@ void setup() {
     // testSimd RPC routing on P4 is fixed (#2541).
 #ifdef FL_BENCH_WAVE8_AT_BOOT
     {
-        auto _w8r = autoresearch::wave8_bench::measureWave8Expand();
-        autoresearch::wave8_bench::printWave8ExpandResultRom(_w8r);
+        auto w8r = autoresearch::wave8_bench::measureWave8Expand();
+        autoresearch::wave8_bench::printWave8ExpandResultRom(w8r);
     }
 #endif
 


### PR DESCRIPTION
## Summary

Local variable `_w8r` in `examples/AutoResearch/AutoResearch.ino` used a leading underscore. Renamed to `w8r`.

Two-line rename inside the existing `#ifdef FL_BENCH_WAVE8_AT_BOOT` block.

Addresses meta-issue #2580 finding **C3** (originally CodeRabbit on #2539 — https://github.com/FastLED/FastLED/pull/2539#pullrequestreview-4392906948).

## Test plan
- [x] `bash lint`
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Minor internal code cleanup in example files.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/FastLED/pull/2584?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->