### PR TITLE
fix(autoresearch): validate buffer sizes in fl_parlio_measure (meta #2580 C1)

### DIFF
--- a/examples/AutoResearch/AutoResearchParlioEncode.h
+++ b/examples/AutoResearch/AutoResearchParlioEncode.h
@@ -27,6 +27,7 @@
 #include "fl/channels/detail/wave8.hpp"
 #include "fl/channels/wave8.h"
 #include "fl/chipsets/led_timing.h"
+#include "fl/log/log.h"  // FL_WARN
 #include "fl/stl/bit_cast.h"
 #include "fl/stl/int.h"
 
@@ -94,8 +95,15 @@ inline fl::u32 fl_parlio_measure(const fl::u8 *scratch, fl::size_t scratch_size,
     constexpr fl::size_t LANES = 16;
     constexpr fl::size_t BYTES_PER_LANE = 768; // 256 LEDs × 3
     const fl::size_t lane_stride = BYTES_PER_LANE;
-    (void)scratch_size;
-    (void)output_size;
+
+    const fl::size_t required_scratch = LANES * BYTES_PER_LANE;
+    const fl::size_t required_output = BYTES_PER_LANE * LANES * sizeof(fl::Wave8Byte);
+    if (scratch_size < required_scratch || output_size < required_output) {
+        FL_WARN("fl_parlio_measure: undersized buffer "
+                "(scratch=" << scratch_size << " need=" << required_scratch
+                << ", output=" << output_size << " need=" << required_output << ")");
+        return 0u;
+    }
 
     fl::u32 t0 = micros();
     for (int it = 0; it < iters_byte_positions; ++it) {


### PR DESCRIPTION
## Summary

`fl_parlio_measure` ignored its `scratch_size`/`output_size` parameters (`(void)`-cast) but the inner loop indexes `scratch[lane*768+offset]` (requires 16*768 bytes) and `output[offset*16*sizeof(Wave8Byte)+127]`. An undersized buffer silently corrupted memory.

Adds an early-return + `FL_WARN` (or equivalent) with the required sizes; drops the `(void)` casts.

Addresses meta-issue #2580 finding **C1** (originally CodeRabbit on #2547 — https://github.com/FastLED/FastLED/pull/2547#pullrequestreview-4393287852).

## Test plan
- [x] `bash lint`
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved buffer validation in measurement operations to properly check provided buffer sizes and log warnings when insufficient capacity is detected, preventing incomplete measurements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/FastLED/pull/2585?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->