### PR TITLE
fix(wasm_build): explicit KeyboardInterrupt re-raise (meta #2580 D2)

### DIFF
--- a/ci/wasm_build.py
+++ b/ci/wasm_build.py
@@ -505,6 +505,8 @@ def _ensure_emscripten_wasm_ld_patch() -> None:
         arch = "x86_64" if machine in ("x86_64", "amd64") else "arm64"
         ensure_emscripten_available(platform_name, arch)
         _emscripten_patch_applied = True
+    except KeyboardInterrupt:
+        raise
     except Exception as e:
         # Patch is best-effort. Without it, EMCC_WASM_LD is ignored and emcc
         # falls back to the bundled wasm-ld — the build still works, just


### PR DESCRIPTION
## Summary

`ci/wasm_build.py` `_ensure_emscripten_wasm_ld_patch` wraps `ensure_emscripten_available()` in `try: ... except Exception as e: ...`. While `KeyboardInterrupt` is not `Exception` (so Ctrl-C does propagate), the repo guideline is to make the re-raise explicit. Added an `except KeyboardInterrupt: raise` clause ahead of the broad handler.

Addresses meta-issue #2580 finding **D2** (originally CodeRabbit on #2490 — https://github.com/FastLED/FastLED/pull/2490#discussion_r3263743117).

## Test plan
- [x] `bash lint`
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebAssembly build process to properly respond to user interrupts (Ctrl+C), enabling clean build cancellation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/FastLED/pull/2586?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->