### PR TITLE
fix(test.py): catch KeyboardInterrupt before ValueError in reconfigure blocks (meta #2580 D1)

### DIFF
--- a/test.py
+++ b/test.py
@@ -47,6 +47,8 @@ if not sys.stdout.isatty():
     if callable(_reconfigure_stdout):
         try:
             _reconfigure_stdout(line_buffering=True)
+        except KeyboardInterrupt:
+            raise
         except ValueError:
             pass
 if not sys.stderr.isatty():
@@ -54,6 +56,8 @@ if not sys.stderr.isatty():
     if callable(_reconfigure_stderr):
         try:
             _reconfigure_stderr(line_buffering=True)
+        except KeyboardInterrupt:
+            raise
         except ValueError:
             pass
 


### PR DESCRIPTION
## Summary

`test.py:48-51` and `:55-58` (try/except around `_reconfigure_stdout` and `_reconfigure_stderr`) caught `ValueError` but not `KeyboardInterrupt`. Per the repo Python guideline (followed elsewhere in the same file at `:205-210`, `:227-230`, `:257-259`), `KeyboardInterrupt` must be re-raised before any other except.

Both blocks updated to catch `KeyboardInterrupt` first.

Addresses meta-issue #2580 finding **D1** (originally CodeRabbit on #2544 — https://github.com/FastLED/FastLED/pull/2544#discussion_r3327136503).

## Test plan
- [x] `bash lint`
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed keyboard interrupt handling to ensure Ctrl+C works properly during startup IO configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/FastLED/pull/2587?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->