### PR TITLE
fix(rgbww): own profile copy in singleton (meta #2580 A4)

### DIFF
--- a/src/fl/gfx/rgbww.cpp.hpp
+++ b/src/fl/gfx/rgbww.cpp.hpp
@@ -73,19 +73,30 @@ const colorimetric_detail::RgbcctProfile kRgbwwDefaultProfile = {
 };
 
 namespace {
+// Owns a copy of the active profile (see #2580 finding A4, originally
+// CodeRabbit on #2560). The earlier implementation stashed the caller's raw
+// pointer, which became a dangling reference the moment the caller's
+// RgbcctProfile (often a stack local in setup()) went out of scope. We now
+// copy by value; has_profile == false reverts to kRgbwwDefaultProfile.
 struct RgbwwColorimetricState {
-    const colorimetric_detail::RgbcctProfile* profile = nullptr;
+    bool has_profile = false;
+    colorimetric_detail::RgbcctProfile profile{};
 };
 } // namespace
 
 void set_rgbww_colorimetric_profile(const colorimetric_detail::RgbcctProfile* profile) FL_NOEXCEPT {
-    fl::Singleton<RgbwwColorimetricState>::instance().profile = profile;
+    RgbwwColorimetricState& state = fl::Singleton<RgbwwColorimetricState>::instance();
+    if (profile == nullptr) {
+        state.has_profile = false;
+        return;
+    }
+    state.profile = *profile;
+    state.has_profile = true;
 }
 
 const colorimetric_detail::RgbcctProfile* get_rgbww_colorimetric_profile() FL_NOEXCEPT {
-    const colorimetric_detail::RgbcctProfile* p =
-        fl::Singleton<RgbwwColorimetricState>::instance().profile;
-    return p != nullptr ? p : &kRgbwwDefaultProfile;
+    const RgbwwColorimetricState& state = fl::Singleton<RgbwwColorimetricState>::instance();
+    return state.has_profile ? &state.profile : &kRgbwwDefaultProfile;
 }
 
 // User-installable RGB->RGBWW function pointer, held behind a lazy


### PR DESCRIPTION
## Summary

`set_rgbww_colorimetric_profile(const RgbcctProfile* profile)` stored the caller's raw pointer in a singleton. Passing a stack-local `RgbcctProfile` (the natural usage from `setup()`) became a use-after-scope on the next `get_rgbww_colorimetric_profile()` call.

This PR changes the singleton storage to keep an owned copy of the profile (with a `has_profile` flag). `nullptr` still reverts to `kRgbwwDefaultProfile`. The public API signature is unchanged, so no callers break.

Addresses meta-issue #2580 finding **A4** (originally CodeRabbit on #2560 — https://github.com/FastLED/FastLED/pull/2560#discussion_r3328237857).

## Test plan
- [x] `bash lint`
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced internal color profile state management to improve stability and memory safety.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/FastLED/pull/2588?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->