### PR TITLE
fix(rgbw): zero-init failed cache matrices + drop duplicate comment (meta #2580 B1+B7)

### DIFF
--- a/src/fl/gfx/rgbw_colorimetric.cpp.hpp
+++ b/src/fl/gfx/rgbw_colorimetric.cpp.hpp
@@ -48,14 +48,20 @@ void build_profile_cache(const DiodeProfile* p, int cct_override,
     const bool ok_rgw = invert3x3(P_RGW, cache->P_RGW_inv);
     const bool ok_rbw = invert3x3(P_RBW, cache->P_RBW_inv);
     const bool ok_bgw = invert3x3(P_BGW, cache->P_BGW_inv);
-    // Inverting a singular matrix leaves the destination with whatever
-    // invert3x3 wrote — solvers reading it would silently produce garbage.
-    // Warn once so the user knows their profile has degenerate primaries
-    // (colinear chromaticities, near-zero luminance, etc).
     if (!(ok_rgb && ok_rgw && ok_rbw && ok_bgw)) {
         FL_WARN_ONCE("RGBW colorimetric: profile has degenerate primaries — "
                      "one or more sub-gamut matrix inversions failed. Output "
                      "colors will be incorrect. Check DiodeProfile xy/lum values.");
+        // Zero-init any failed inverse so downstream matvec3() output is
+        // deterministic (zero) rather than UB-valued garbage.
+        auto zero3x3 = [](float m[3][3]) FL_NOEXCEPT {
+            for (int i = 0; i < 3; ++i)
+                for (int j = 0; j < 3; ++j) m[i][j] = 0.0f;
+        };
+        if (!ok_rgb) zero3x3(cache->P_RGB_inv);
+        if (!ok_rgw) zero3x3(cache->P_RGW_inv);
+        if (!ok_rbw) zero3x3(cache->P_RBW_inv);
+        if (!ok_bgw) zero3x3(cache->P_BGW_inv);
     }
 
     matvec3(cache->P_RGB_inv, cache->P_W, cache->d_W);


### PR DESCRIPTION
## Summary

Two related CodeRabbit follow-ups in `src/fl/gfx/rgbw_colorimetric.cpp.hpp`:

- **B1**: `build_profile_cache` warned on `invert3x3` failure but still wrote garbage matrices into `cache->P_*_inv`. Downstream `matvec3()` then produced undefined output. Now zero-inits each failed matrix so output is deterministic (zero) on degenerate profiles.
- **B7**: lines 43-46 and 51-54 were near-identical comment blocks. Removed the second one.

Bundled into one PR because both findings touch the same file.

Addresses meta-issue #2580 findings **B1** (https://github.com/FastLED/FastLED/pull/2552#discussion_r3327685455) and **B7** (https://github.com/FastLED/FastLED/pull/2554#pullrequestreview-4394110629).

## Test plan
- [x] `bash lint`
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed color matrix inversion error handling to ensure deterministic behavior in graphics rendering. When matrix calculations encounter errors, affected values are now properly initialized with defined values instead of remaining undefined, resulting in more stable and consistent graphics performance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/FastLED/pull/2589?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->