### PR TITLE
fix(ci): force --backend=platformio for binary-size guards (unblocks ~10 size workflows)

### DIFF
--- a/.github/workflows/build_template_binary_size.yml
+++ b/.github/workflows/build_template_binary_size.yml
@@ -40,8 +40,16 @@ jobs:
       - name: Install UV
         run: pip install uv
 
+      # NOTE: Force --backend=platformio for size checks. Since commit
+      # f215b56b8 ("ci: make fbuild the default for board builds"), the
+      # default builder is fbuild. fbuild does not yet emit the per-build
+      # build_info.json metadata that ci/compiled_size.py + inspect_*.py +
+      # symbol_analysis_runner.py all depend on (see FastLED/fbuild#297).
+      # Until fbuild gains an equivalent emitter, the size pipeline must
+      # build via `pio` so `pio project metadata --json-output` produces
+      # build_info_<example>.json.
       - name: Check Compiled Program Size for ${{ inputs.board }}
-        run: uv run ci/ci-check-compiled-size.py ${{ inputs.board }} --max-size ${{ inputs.max_size }} --example Blink ${{ inputs.extra_args }}
+        run: uv run ci/ci-check-compiled-size.py ${{ inputs.board }} --max-size ${{ inputs.max_size }} --example Blink --backend=platformio ${{ inputs.extra_args }}
 
       - name: Inspect Binary
         if: always()
@@ -62,7 +70,7 @@ jobs:
           uv run ci/symbol_analysis_runner.py --board ${{ inputs.board }} --example Blink --skip-on-failure
 
       - name: Check Compiled Program Size for ${{ inputs.board }} (Apa102)
-        run: uv run ci/ci-check-compiled-size.py ${{ inputs.board }} --max-size ${{ inputs.max_size_apa102 }} --example Apa102 ${{ inputs.extra_args }}
+        run: uv run ci/ci-check-compiled-size.py ${{ inputs.board }} --max-size ${{ inputs.max_size_apa102 }} --example Apa102 --backend=platformio ${{ inputs.extra_args }}
 
       - name: Inspect Binary
         if: always()
@@ -84,7 +92,7 @@ jobs:
 
       - name: Check Compiled Program Size for ${{ inputs.board }} (Apa102 with HD Color Mixing)
         if: inputs.board == 'attiny85'
-        run: uv run ci/ci-check-compiled-size.py ${{ inputs.board }} --example Apa102 ${{ inputs.extra_args }} --defines FASTLED_HD_COLOR_MIXING=1
+        run: uv run ci/ci-check-compiled-size.py ${{ inputs.board }} --example Apa102 --backend=platformio ${{ inputs.extra_args }} --defines FASTLED_HD_COLOR_MIXING=1
 
       - name: Inspect Binary (HD Color Mixing)
         if: inputs.board == 'attiny85'


### PR DESCRIPTION
## Summary

- Every binary-size guard on master is failing with `FileNotFoundError: build_info.json not found for board '<board>'`. Affected: `check_uno_size`, `attiny85_binary_size`, all `check_teensy*_size`, `check_stm32f103c8_bluepill_size`, `esp32dev_binary_size`, `teensy41_binary_size` — ~10 README badges.
- Root cause: `f215b56b8` made fbuild the default backend. `build_info_<example>.json` is only produced by `ci/compiler/build_config.py::generate_build_info_json_from_existing_build`, which shells out to `pio project metadata --json-output` — i.e. only on PlatformIO. fbuild has no equivalent emitter yet (tracked at FastLED/fbuild#297).
- Fix: append `--backend=platformio` to the three `ci-check-compiled-size.py` invocations in `.github/workflows/build_template_binary_size.yml`. `ci-check-compiled-size.py` passes unknown args through to `ci.ci-compile` via `parse_known_args`, which already understands `--backend=platformio`. One file, ~3 line edits + an explanatory comment.

## Reverting later

Once fbuild#297 lands and the fbuild floor bumps, the three `--backend=platformio` flags can be removed in one follow-up PR.

## Test plan

- [x] `bash lint` clean.
- [ ] CI: every `check_*_size` / `*_binary_size` workflow should compile via PIO again and find `build_info_<example>.json`.

Fixes #2590

Generated with Claude Code (https://claude.com/claude-code)
