### PR TITLE
fix(esp32): add OTA path component dependencies (app_update, mdns)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,6 @@ idf_component_register(SRCS ${FastLED_SRCS}
                        INCLUDE_DIRS "src"
                        REQUIRES arduino-esp32 esp_driver_i2s esp_driver_mcpwm esp_driver_rmt
                                 esp_http_server esp_lcd driver esp_mm esp_wifi esp_netif
-                                app_update mdns)
+                                app_update)
 
 project(FastLED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ file(GLOB_RECURSE FastLED_SRCS "src/*.cpp")
 idf_component_register(SRCS ${FastLED_SRCS}
                        INCLUDE_DIRS "src"
                        REQUIRES arduino-esp32 esp_driver_i2s esp_driver_mcpwm esp_driver_rmt
-                                esp_http_server esp_lcd driver esp_mm esp_wifi esp_netif)
+                                esp_http_server esp_lcd driver esp_mm esp_wifi esp_netif
+                                app_update mdns)
 
 project(FastLED)

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -5,6 +5,12 @@ dependencies:
     version: "^1.2.0"
     rules:
       - if: "target == esp32p4"
+  # Used by the ESP32 OTA path (mdns.h), which only compiles on IDF < 6 with
+  # WiFi (FL_ESP_OTA_SUPPORTED excludes ESP32-H2 and ESP32-P4).
+  espressif/mdns:
+    version: "^1.2.0"
+    rules:
+      - if: "idf_version < 6.0.0 && target not in [esp32h2, esp32p4]"
 
 # Re-include src/fl/build/ which DEFAULT_EXCLUDE's **/build/**/* otherwise strips.
 files:

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -5,8 +5,6 @@ dependencies:
     version: "^1.2.0"
     rules:
       - if: "target == esp32p4"
-  # Used by the ESP32 OTA path (mdns.h), which only compiles on IDF < 6 with
-  # WiFi (FL_ESP_OTA_SUPPORTED excludes ESP32-H2 and ESP32-P4).
   espressif/mdns:
     version: "^1.2.0"
     rules:


### PR DESCRIPTION
The ESP32 OTA implementation (`ota_impl.cpp.hpp`, gated by `FL_ESP_OTA_SUPPORTED`) includes `esp_ota_ops.h` and `mdns.h`, but the component's requirements didn't declare the components that provide them. As a result, building FastLED as a managed ESP-IDF component on ESP-IDF 5 fails at configure time:

```
fatal error: esp_ota_ops.h: No such file or directory
```

### Changes

- **`app_update`** added to `idf_component_register(REQUIRES ...)` — built-in IDF component that provides `esp_ota_ops.h`. Available on all targets, so it can be required unconditionally (the OTA code itself stays gated).
- **`espressif/mdns`** added to `idf_component.yml` as a conditional dependency (`idf_version < 6.0.0 && target not in [esp32h2, esp32p4]`) — provides `mdns.h`. Declared in the manifest (not `REQUIRES`) so it is only pulled, and only required, where the OTA path actually compiles; this avoids breaking targets like ESP32-P4 where mdns isn't applicable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to include additional system components
  * Added conditional dependency management for enhanced compatibility with specific platform versions and hardware targets

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/FastLED/pull/2592?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->