### PR TITLE
fix(stm32): guard fastspi <SPI.h> include on FASTLED_ALL_PINS_HARDWARE_SPI

### DIFF
--- a/src/platforms/arm/stm32/fastspi_arm_stm32.h
+++ b/src/platforms/arm/stm32/fastspi_arm_stm32.h
@@ -4,8 +4,14 @@
 
 #ifndef FASTLED_FORCE_SOFTWARE_SPI
 
-// Check if STM32 HAL is available
-#if defined(HAL_SPI_MODULE_ENABLED)
+// Check if STM32 HAL is available AND the user has explicitly opted into
+// hardware SPI. Pulling in Arduino's `<SPI.h>` unconditionally on HAL
+// detection breaks STM32H7 / Giga R1 builds where the Arduino mbed-os
+// core does NOT auto-resolve `<SPI.h>` from PlatformIO's lib finder
+// (`fastspi_arm_stm32.h:11: fatal error: SPI.h: No such file or directory`).
+// Users who want STM32 hardware SPI define `FASTLED_ALL_PINS_HARDWARE_SPI`
+// and add `SPI` to their `lib_deps` — same pattern as ESP8266 (#2570).
+#if defined(HAL_SPI_MODULE_ENABLED) && defined(FASTLED_ALL_PINS_HARDWARE_SPI)
     #define FASTLED_STM32_USE_HAL 1
     // IWYU pragma: begin_keep
     #include <SPI.h>


### PR DESCRIPTION
## Summary

- Every `stm32h747xi_giga` (Arduino Giga R1) build on master fails with `fastspi_arm_stm32.h:11:14: fatal error: SPI.h: No such file or directory`.
- Root cause: the STM32H7 / Giga's `stm32_hal_conf.h` defines `HAL_SPI_MODULE_ENABLED`, so `fastspi_arm_stm32.h` does `#include <SPI.h>`. But the Arduino mbed-os core that drives the Giga doesn't auto-resolve `<SPI.h>` via PIO's lib finder — `SPI` must be listed in `lib_deps`, and it isn't.
- Fix: same pattern as my earlier ESP8266 fix (#2570) — also require `FASTLED_ALL_PINS_HARDWARE_SPI` before pulling in the HAL path. Default builds get bitbang. Users who want STM32 hardware SPI define the macro AND add `SPI` to their `lib_deps`. One-line change in `src/platforms/arm/stm32/fastspi_arm_stm32.h`.

Fixes #2595

## Test plan

- [x] `bash lint` clean.
- [ ] CI: `stm32h747xi_giga` workflow should compile every example past the include error.
- [ ] No regression on other STM32 boards (the default path that drops to bitbang is what end-users on stock STM32F* configs already get when `SPI` isn't in their lib_deps).

Generated with Claude Code (https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* STM32 HAL builds now require explicit opt-in to use hardware SPI; default behavior is software SPI fallback.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/FastLED/pull/2596?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->