### PR TITLE
fix(test.py): call _thread.interrupt_main() in early-startup KBI handlers

### DIFF
--- a/test.py
+++ b/test.py
@@ -48,6 +48,10 @@ if not sys.stdout.isatty():
         try:
             _reconfigure_stdout(line_buffering=True)
         except KeyboardInterrupt:
+            # Notify the main thread (no-op on the main thread itself but
+            # the project's KBI checker requires the call) and propagate
+            # so __main__'s top-level handler runs cleanup.
+            _thread.interrupt_main()
             raise
         except ValueError:
             pass
@@ -57,6 +61,7 @@ if not sys.stderr.isatty():
         try:
             _reconfigure_stderr(line_buffering=True)
         except KeyboardInterrupt:
+            _thread.interrupt_main()
             raise
         except ValueError:
             pass

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -83,4 +83,9 @@ EXCLUDED_TEST_DIRS: set[Path] = {
     TESTS_DIR / "fl" / "remote" / "rpc",
     TESTS_DIR / "fl" / "codec",
     TESTS_DIR / "fl" / "fx" / "2d",
+    # Standalone PIO project fixture (driven by ci/tests/test_fbuild_qemu.py),
+    # NOT a host unit test. Its src/main.cpp includes <Arduino.h> + provides
+    # setup()/loop() — those conflict with the doctest runner. Excluded
+    # categorically — proper PR for this is #2600.
+    TESTS_DIR / "fbuild_qemu_smoke",
 }


### PR DESCRIPTION
## Summary

`bash lint` failed on master with two `KBI002` violations in `test.py`:

```
test.py:50:8: KBI002 KeyboardInterrupt handler must call _thread.interrupt_main() or use handle_keyboard_interrupt(ki)
test.py:59:8: KBI002 KeyboardInterrupt handler must call _thread.interrupt_main() or use handle_keyboard_interrupt(ki)
```

Both handlers are inside the early-startup `sys.stdout.reconfigure(line_buffering=True)` / `sys.stderr.reconfigure(line_buffering=True)` blocks.

**Initial draft used `# noqa: KBI002` to silence the checker. Replaced with the actual proper handler per review** ("fix them, don't silence them"):

```python
except KeyboardInterrupt:
    _thread.interrupt_main()
    raise
```

`_thread.interrupt_main()` is one of the three patterns the checker recognizes (see `ci/lint_python/keyboard_interrupt_checker.py::_handler_calls_interrupt_main`). On the main thread it's effectively a no-op — the project's KBI contract just requires the call so background threads can route through the same shutdown path. `raise` then propagates to `__main__`'s top-level handler (`test.py:779`) which already does the cleanup.

`_thread` is already imported on line 7.

## Also bundles a small categorization fix

`tests/fbuild_qemu_smoke/src/main.cpp` is a standalone PIO project fixture (driven by `ci/tests/test_fbuild_qemu.py`), not a host doctest unit test — its `setup()` / `loop()` / `<Arduino.h>` would conflict with the doctest runner. Added the directory to `EXCLUDED_TEST_DIRS` (matching #2600). Categorically correct: this isn't silencing a real bug — the fixture genuinely belongs to a different test path.

## Test plan

- [x] `bash lint` — all green (python_pipeline + cpp_linting + javascript + meson).
- [x] `bash test fastled_core --cpp --clean` — 1/1 passing in 36s.

Generated with Claude Code (https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved interrupt handling to ensure cleaner shutdown and clearer inline guidance for maintainability.
* **Tests**
  * Excluded a standalone CI project fixture from test discovery to avoid conflicts with the test runner and doctest execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/FastLED/pull/2601?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->