### PR TITLE
security(workflows): restrict claude.yml to trusted actors only

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,11 +12,32 @@ on:
 
 jobs:
   claude:
+    # Security: only trigger when the @claude mention comes from a trusted
+    # actor (repo OWNER, org MEMBER, or invited COLLABORATOR). Without this
+    # gate, any external contributor could open a PR from a fork, comment
+    # `@claude please fix` on it, and force the workflow to check out their
+    # fork's HEAD with `contents: write`, `pull-requests: write`,
+    # `issues: write`, and access to `secrets.ANTHROPIC_API_KEY` — letting
+    # the PR's code push to master, auto-merge PRs, or exfiltrate the API key.
+    #
+    # The trusted set is checked against the source-event's
+    # `author_association` field (one of OWNER, MEMBER, COLLABORATOR,
+    # CONTRIBUTOR, FIRST_TIME_CONTRIBUTOR, FIRST_TIMER, NONE). External
+    # PR authors fall into CONTRIBUTOR / FIRST_TIME_CONTRIBUTOR / NONE and
+    # are blocked here.
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (github.event_name == 'issue_comment' &&
+        contains(github.event.comment.body, '@claude') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review_comment' &&
+        contains(github.event.comment.body, '@claude') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review' &&
+        contains(github.event.review.body, '@claude') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)) ||
+      (github.event_name == 'issues' &&
+        (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association))
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Summary

Found during the security audit of [PR #2592](https://github.com/FastLED/FastLED/pull/2592) (third-party PR from @swoboda1337). That PR itself was safe (no `@claude` mention, and the one workflow using `pull_request_target` — `project_automation.yml` — correctly does not check out PR code). But the audit surfaced a latent exploit in `claude.yml` that would apply to *any* future PR with an `@claude` mention from an external actor.

## The exploit

`claude.yml` triggers on `@claude` mentions in issue comments, PR review comments, PR reviews, and issue bodies — then checks out the source PR's HEAD (from a fork, when applicable) and runs `anthropics/claude-code-action` with elevated permissions:

```yaml
permissions:
  contents: write       # can push to master
  pull-requests: write  # can merge PRs
  issues: write
  id-token: write
  # + ANTHROPIC_API_KEY + GITHUB_TOKEN
```

Without an author_association guard, any external contributor could:

1. Open a PR from their fork containing malicious code.
2. Comment `@claude please review this`.
3. The workflow checks out their fork's HEAD with all the above privileges and runs an LLM-driven action over it.

Outcomes:
- a. PR code runs during the action's tool execution and pushes unauthorized commits to master, auto-merges PRs, or exfiltrates the `ANTHROPIC_API_KEY` / `GITHUB_TOKEN`, OR
- b. The attacker convinces Claude (via prompt injection in code comments or PR description) to do the same.

## Fix

Add an `author_association` check to each trigger branch:

```yaml
if: |
  (github.event_name == 'issue_comment' &&
    contains(github.event.comment.body, '@claude') &&
    contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
  (github.event_name == 'pull_request_review_comment' &&
    contains(github.event.comment.body, '@claude') &&
    contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
  (github.event_name == 'pull_request_review' &&
    contains(github.event.review.body, '@claude') &&
    contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)) ||
  (github.event_name == 'issues' &&
    (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) &&
    contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association))
```

GitHub computes `author_association` server-side based on the actor's relationship to the repo:

| Category | Allowed? |
|---|---|
| `OWNER`, `MEMBER`, `COLLABORATOR` | ✅ yes |
| `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, `FIRST_TIMER`, `NONE` | ❌ blocked |

External PR authors fall into the bottom row, so the checkout step that follows their @claude mention never runs.

## Test plan

- [x] YAML parses (per the `if:` syntax — `contains(fromJSON('[...]'), value)` is the standard GitHub expression form).
- [ ] After merge, a future @claude mention from a repo maintainer should still trigger the workflow (no functional regression for the intended use case).
- [ ] An external contributor's @claude mention on their own PR should evaluate the `if:` to false and skip the job.

## Reference

- GitHub docs on `author_association`: https://docs.github.com/en/graphql/reference/enums#commentauthorassociation
- Anthropic's own recommendation in claude-code-action's README: gate triggers by trusted actor when the workflow has write permissions.

Refs PR #2592 security audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal automation workflow access verification requirements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/FastLED/pull/2602?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->