### PR TITLE
fix(test): rgbww profile API — assert by-value contract, not pointer identity

### DIFF
--- a/tests/fl/gfx/rgbww.cpp
+++ b/tests/fl/gfx/rgbww.cpp
@@ -185,7 +185,15 @@ FL_TEST_CASE("rgbww colorimetric profile get/set API") {
     custom.warm_path.lum_w = 0.5f;  // arbitrary distinguishing value
     set_rgbww_colorimetric_profile(&custom);
     const colorimetric_detail::RgbcctProfile* after = get_rgbww_colorimetric_profile();
-    FL_CHECK(after == &custom);
+    // By-value contract (#2580 A4 / CodeRabbit on #2560): set_* copies the
+    // profile into singleton-owned storage; get_* returns a pointer to that
+    // owned copy, never the caller's address. Asserting pointer identity
+    // with &custom would re-introduce the dangling-pointer bug — verify the
+    // value flowed through and that the pointer is distinct from both the
+    // caller's stack address and the default profile.
+    FL_CHECK(after != nullptr);
+    FL_CHECK(after != &custom);
+    FL_CHECK(after != &kRgbwwDefaultProfile);
     FL_CHECK_CLOSE(after->warm_path.lum_w, 0.5f, 1e-6f);
 
     set_rgbww_colorimetric_profile(nullptr);


### PR DESCRIPTION
## Summary

`fl_gfx_rgbww` was failing on master at `tests/fl/gfx/rgbww.cpp:188`:

```
FAIL: rgbww colorimetric profile get/set API at ../../tests/fl/gfx/rgbww.cpp:179
  ../../tests/fl/gfx/rgbww.cpp:188: after == &custom
```

The test was asserting pointer identity with the caller's address. PR #2580 (CodeRabbit finding A4 from #2560) deliberately changed `set_/get_rgbww_colorimetric_profile()` to copy by value into singleton-owned storage — fixing a real dangling-pointer bug (callers commonly pass `&local_var` from `setup()`). The test was never updated.

If the old `after == &caller_ptr` assertion were to pass now, it would mean the dangling-pointer behavior had been reintroduced.

Updated to assert the by-value contract:

```cpp
FL_CHECK(after != nullptr);
FL_CHECK(after != &custom);              // distinct from caller's address
FL_CHECK(after != &kRgbwwDefaultProfile); // set() actually took effect
FL_CHECK_CLOSE(after->warm_path.lum_w, 0.5f, 1e-6f);
```

These assertions test what the implementation actually promises and catch a regression to the dangling-pointer behavior (`after != &custom` fails if anyone re-stashes the caller's pointer).

## Test plan

- [x] `bash test fl_gfx_rgbww --cpp` — passes (was red).
- [x] `bash test fl_gfx_rgbww --debug` — passes with ASAN/UBSAN/LSAN (per Test Failure Debug Policy).

Fixes #2603

Generated with Claude Code (https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test assertions for the colorimetric profile API to properly validate pointer ownership behavior and ensure the returned profile is distinct from stack-allocated and constant memory addresses.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/FastLED/pull/2604?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->