### PR TITLE
ci(size): pin binary-size checks to --backend platformio (unblock master)

### DIFF
--- a/.github/workflows/build_template_binary_size.yml
+++ b/.github/workflows/build_template_binary_size.yml
@@ -41,7 +41,7 @@ jobs:
         run: pip install uv
 
       - name: Check Compiled Program Size for ${{ inputs.board }}
-        run: uv run ci/ci-check-compiled-size.py ${{ inputs.board }} --max-size ${{ inputs.max_size }} --example Blink ${{ inputs.extra_args }}
+        run: uv run ci/ci-check-compiled-size.py ${{ inputs.board }} --backend platformio --max-size ${{ inputs.max_size }} --example Blink ${{ inputs.extra_args }}
 
       - name: Inspect Binary
         if: always()
@@ -62,7 +62,7 @@ jobs:
           uv run ci/symbol_analysis_runner.py --board ${{ inputs.board }} --example Blink --skip-on-failure
 
       - name: Check Compiled Program Size for ${{ inputs.board }} (Apa102)
-        run: uv run ci/ci-check-compiled-size.py ${{ inputs.board }} --max-size ${{ inputs.max_size_apa102 }} --example Apa102 ${{ inputs.extra_args }}
+        run: uv run ci/ci-check-compiled-size.py ${{ inputs.board }} --backend platformio --max-size ${{ inputs.max_size_apa102 }} --example Apa102 ${{ inputs.extra_args }}
 
       - name: Inspect Binary
         if: always()
@@ -84,7 +84,7 @@ jobs:
 
       - name: Check Compiled Program Size for ${{ inputs.board }} (Apa102 with HD Color Mixing)
         if: inputs.board == 'attiny85'
-        run: uv run ci/ci-check-compiled-size.py ${{ inputs.board }} --example Apa102 ${{ inputs.extra_args }} --defines FASTLED_HD_COLOR_MIXING=1
+        run: uv run ci/ci-check-compiled-size.py ${{ inputs.board }} --backend platformio --example Apa102 ${{ inputs.extra_args }} --defines FASTLED_HD_COLOR_MIXING=1
 
       - name: Inspect Binary (HD Color Mixing)
         if: inputs.board == 'attiny85'


### PR DESCRIPTION
## Summary

All 9 binary-size workflows have been red on master for ~5 weeks. Root cause is two fbuild deficiencies, both now filed upstream:

- [FastLED/fbuild#297](https://github.com/FastLED/fbuild/issues/297) - fbuild does not emit `build_info_<example>.json`, so `ci/compiled_size.py` cannot find it (the visible "build_info.json not found" CI error).
- [FastLED/fbuild#304](https://github.com/FastLED/fbuild/issues/304) - fbuild links framework `.o` files directly instead of archiving them, so unused ISR symbols (e.g. `Tone.cpp` on attiny85) get pulled in, inflating Blink by +10.1% (342 bytes). Even after #297 lands, the budget is already exceeded.

Both fixes are real work on the fbuild Rust crates. While they land, this PR threads `--backend platformio` through the three `uv run ci/ci-check-compiled-size.py` invocations in `build_template_binary_size.yml`. PlatformIO already emits `build_info_<example>.json` and already archives framework objects, so both deficiencies are sidestepped.

Affected workflows that should go green again:
`attiny85_binary_size`, `check_uno_size`, `check_teensy30/31/32/35/36/41/LC_size`, `check_bluepill_size`.

## Revert plan

When fbuild ships fixes for #297 and #304, delete the three `--backend platformio` tokens added by this PR.

## Test plan

- [ ] CI: `attiny85_binary_size` turns green
- [ ] CI: `check_uno_size` turns green
- [ ] CI: at least one `check_teensy*_size` turns green
- [ ] CI: `check_bluepill_size` turns green

Companion meta-issue: filed against fbuild as a debuggability ask is FastLED/fbuild#305 (would have caught this regression ~5 weeks earlier).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal CI/CD workflow configuration for binary size validation steps.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/FastLED/pull/2605?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->