### PR TITLE
fix(test.py): suppress KBI002 on pre-imports reconfigure blocks

### DIFF
--- a/test.py
+++ b/test.py
@@ -47,7 +47,9 @@ if not sys.stdout.isatty():
     if callable(_reconfigure_stdout):
         try:
             _reconfigure_stdout(line_buffering=True)
-        except KeyboardInterrupt:
+        except KeyboardInterrupt:  # noqa: KBI002
+            # Pre-imports startup path — handle_keyboard_interrupt() isn't
+            # available yet (it's imported below at line 80). Bare re-raise.
             raise
         except ValueError:
             pass
@@ -56,7 +58,8 @@ if not sys.stderr.isatty():
     if callable(_reconfigure_stderr):
         try:
             _reconfigure_stderr(line_buffering=True)
-        except KeyboardInterrupt:
+        except KeyboardInterrupt:  # noqa: KBI002
+            # See note above on the stdout block — helper not yet imported.
             raise
         except ValueError:
             pass


### PR DESCRIPTION
## Summary

The stop-hook lint flagged two KBI002 violations at \`test.py:50\` and \`:59\` — the \`except KeyboardInterrupt: raise\` blocks I added in #2587 for CodeRabbit don't satisfy the KBI checker (which wants \`_thread.interrupt_main()\` or \`handle_keyboard_interrupt(ki)\`).

The honest answer is \`# noqa: KBI002\` with an explanatory comment: those two blocks run **before** \`from ci.util.global_interrupt_handler import handle_keyboard_interrupt\` at line 80, so the helper isn't available yet. Inlining \`import _thread; _thread.interrupt_main()\` would also re-schedule the same interrupt we're already handling on the main thread — a no-op that just adds clutter. The bare re-raise is correct for this microsecond-wide startup window.

## Test plan
- [x] \`bash lint\` clean (was failing on these two lines before)
- [ ] CI: \`unit tests linux\` etc. unchanged (test.py path unaffected)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code quality compliance in test configuration files.

*No user-facing changes.*

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/FastLED/pull/2607?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->