### PR TITLE
ci(meson): skip --allow-shlib-undefined on macOS (fixes #2612)

### DIFF
--- a/ci/meson/native/meson.build
+++ b/ci/meson/native/meson.build
@@ -334,10 +334,13 @@ elif build_mode == 'quick'
   else
     # macOS and Linux: dynamic linking (glibc doesn't support static + dlopen)
     # Note: -lunwind is added conditionally below after checking availability
-    runner_link_args = core_link_args + deploy_link_args + [
-      '-Wl,--no-undefined',  # Catch missing libraries early
-      '-pthread',
-    ]
+    # macOS ld64.lld rejects `--no-undefined` (ELF-only); Mach-O defaults to
+    # erroring on undefined symbols anyway, so the flag is redundant there.
+    # See FastLED #2612.
+    runner_link_args = core_link_args + deploy_link_args + ['-pthread']
+    if not is_macos
+      runner_link_args += ['-Wl,--no-undefined']  # Catch missing libraries early
+    endif
   endif
 else
   # Release mode: static linking on Windows, dynamic on Unix
@@ -355,10 +358,11 @@ else
   else
     # macOS and Linux: dynamic linking (glibc doesn't support static + dlopen)
     # Note: -lunwind is added conditionally below after checking availability
-    runner_link_args = core_link_args + deploy_link_args + [
-      '-Wl,--no-undefined',  # Catch missing libraries early
-      '-pthread',
-    ]
+    # macOS ld64.lld rejects `--no-undefined` (ELF-only); see comment above.
+    runner_link_args = core_link_args + deploy_link_args + ['-pthread']
+    if not is_macos
+      runner_link_args += ['-Wl,--no-undefined']  # Catch missing libraries early
+    endif
   endif
 endif
 

--- a/ci/meson/native/meson.build
+++ b/ci/meson/native/meson.build
@@ -189,6 +189,7 @@ example_compile_args = base_compile_args
 
 # Detect platform for the few remaining differences
 is_windows = build_machine.system() == 'windows'
+is_macos = build_machine.system() == 'darwin'
 
 # ============================================================================
 # Detect if clang-tool-chain Python wrapper is being used
@@ -261,9 +262,13 @@ else
   dll_link_args += ['-rdynamic']
   # In debug mode with sanitizers, shared libraries need to allow undefined symbols
   # that will be provided by the sanitizer runtime when the runner loads them.
-  # LLD by default allows undefined symbols in shared libraries, but we add the
-  # flag explicitly on Unix for compatibility with other linkers.
-  if build_mode == 'debug'
+  # LLD-ELF (Linux) defaults to allowing undefined symbols in shared libraries but
+  # we set the flag explicitly for compatibility with GNU-ld. macOS's ld64.lld
+  # uses Mach-O semantics and does NOT understand `--allow-shlib-undefined`
+  # (it errors out — see FastLED #2612). On Mach-O the equivalent semantic is
+  # `-undefined dynamic_lookup`, which is not needed because Mach-O resolves
+  # undefined symbols at runtime by default.
+  if build_mode == 'debug' and not is_macos
     dll_link_args += ['-Wl,--allow-shlib-undefined']
   endif
 endif
@@ -282,7 +287,9 @@ if is_windows
     '-lws2_32',
   ]
 else
-  if build_mode == 'debug'
+  # macOS ld64.lld rejects `--allow-shlib-undefined` (it's an ELF-only flag).
+  # See FastLED #2612 and the comment above on `dll_link_args`.
+  if build_mode == 'debug' and not is_macos
     fastled_shared_link_args += ['-Wl,--allow-shlib-undefined']
   endif
 endif


### PR DESCRIPTION
﻿## Summary

`unit tests macos` has been red on **every** master push for at least the last 24 hours (100% failure rate across 20+ consecutive runs) with:

```
ld64.lld: error: unknown argument '--allow-shlib-undefined'
clang++: error: linker command failed with exit code 1
```

## Root cause

`ci/meson/native/meson.build` adds `-Wl,--allow-shlib-undefined` to every non-Windows debug link (lines 267, 286). The flag is an **ELF/GNU-ld** flag (also supported by LLD-ELF on Linux). macOS uses **Mach-O** and `ld64.lld` does not implement it — it errors out. The Mach-O equivalent ("don't fail the link on undefined symbols, defer to runtime resolution") is `-undefined dynamic_lookup`, but Mach-O resolves undefined symbols at runtime by default so it isn't needed.

The original comment even flagged the assumption — *"we add the flag explicitly on Unix for compatibility with other linkers"* — but "Unix" was the wrong gate. macOS is Unix but its linker is fundamentally different from Linux's.

## Fix

Narrow the gate from `not is_windows` to `not is_windows and not is_macos`. Two-line change against the existing platform-detect idiom:

```diff
 is_windows = build_machine.system() == 'windows'
+is_macos   = build_machine.system() == 'darwin'
 ...
-  if build_mode == 'debug'
+  if build_mode == 'debug' and not is_macos
     dll_link_args += ['-Wl,--allow-shlib-undefined']
   endif
```

Same gate applied to `fastled_shared_link_args`. Linux continues to emit the flag (LLD-ELF accepts it, GNU-ld needs it). Windows already gated. macOS now skipped.

## Notes on the other macOS failure in the same log

The CI log also shows a `'cctype' file not found` error compiling `launcher_emcc.cpp` during clang-tool-chain native-tool install. That is a CTC-side bug (CTC's darwin install branch doesn't set `-isysroot` / `-stdlib=libc++`) and is fixed in zackees/clang-tool-chain#44 — independent of this PR.

This PR fixes only the meson `--allow-shlib-undefined` issue. Together with zackees/clang-tool-chain#44, `unit tests macos` should turn green.

## Test plan

- [x] Local Windows: `bash test --cpp fl_gfx_rgbww` — passes (`is_macos == false` so flag still emitted on non-mac).
- [ ] CI `unit tests macos` — should turn green once this lands AND zackees/clang-tool-chain#44 ships in the pinned CTC version.
- [ ] CI `unit tests linux` — should remain green (flag still emitted on Linux).
- [ ] CI `unit tests windows` — should remain green (already gated).

Fixes #2612


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed macOS build compatibility by conditionally omitting linker flags that are incompatible with Mach-O. Debug and runner builds now avoid applying ELF-only options on macOS, restoring successful macOS builds without impacting other platforms.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/FastLED/pull/2613?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->