### PR TITLE
fix(arm): exclude STM32H7/Giga from interrupts-must-be-off gate

### DIFF
--- a/src/platforms/arm/compile_test.hpp
+++ b/src/platforms/arm/compile_test.hpp
@@ -73,7 +73,17 @@ static void arm_compile_tests() {
 #endif
 
 // Specific ARM variant checks
-#if defined(ARDUINO_ARCH_STM32) || defined(STM32F1)
+//
+// The interrupts-off rule applies to the lower-end STM32 families
+// (F1 @72 MHz, F4 @ ~84-180 MHz on STM32duino) where any ISR mid-write
+// disrupts WS28xx clockless timing. STM32H7 / Giga R1 runs at 480 MHz
+// on the Arduino Mbed core, has cycles to spare during clockless writes,
+// and deliberately sets `FASTLED_ALLOW_INTERRUPTS = 1` in its
+// `led_sysdef_arm_giga.h`. Exclude those targets from the gate so they
+// don't trip on a sane platform choice. See FastLED #2614.
+#if (defined(ARDUINO_ARCH_STM32) || defined(STM32F1)) \
+    && !defined(STM32H7xx) \
+    && !defined(FL_IS_STM32_MBED)
     #if FASTLED_ALLOW_INTERRUPTS != 0
     #error "STM32 platforms should have FASTLED_ALLOW_INTERRUPTS set to 0"
     #endif


### PR DESCRIPTION
﻿## Summary

`stm32h747xi_giga` workflow has been **44/0 fail/success** on master. Every recent run fails at:

```
src/platforms/arm/compile_test.hpp:78:6: error:
    #error "STM32 platforms should have FASTLED_ALLOW_INTERRUPTS set to 0"
```

## Root cause

The gate at line 76 was

```c
#if defined(ARDUINO_ARCH_STM32) || defined(STM32F1)
```

— too broad. It fires for **any** platform that defines `ARDUINO_ARCH_STM32`, which includes the Arduino Giga R1 (STM32H747XI). Giga runs on the Arduino Mbed core at 480 MHz and deliberately sets `FASTLED_ALLOW_INTERRUPTS = 1` in `led_sysdef_arm_giga.h`:

```c
// Default to allowing interrupts
#ifndef FASTLED_ALLOW_INTERRUPTS
#define FASTLED_ALLOW_INTERRUPTS 1
#endif
```

That choice is **correct for H7**: a 480 MHz clockless write has plenty of cycles to tolerate ISR latency, unlike STM32F1 at 72 MHz where any interrupt mid-write disrupts WS28xx timing. The compile-time gate was making a sweeping assumption that's true for STM32F1 / STM32F4 (STM32duino) but wrong for STM32H7 / Giga / Mbed-based STM32s.

Same shape applies to the `FASTLED_USE_PROGMEM != 0` check immediately below — Giga already sets it to 0 (matches the gate today), but the same gate-too-broad concern stands.

## Fix

Narrow the gate to exclude STM32H7 and Mbed-based STM32s:

```diff
-#if defined(ARDUINO_ARCH_STM32) || defined(STM32F1)
+#if (defined(ARDUINO_ARCH_STM32) || defined(STM32F1)) \
+    && !defined(STM32H7xx) \
+    && !defined(FL_IS_STM32_MBED)
```

- `FL_IS_STM32_MBED` is defined in `src/platforms/arm/stm32/is_stm32.h:122-124` for `FL_IS_STM32 && ARDUINO_ARCH_MBED`.
- `STM32H7xx` is a stock CMSIS define.

STM32F1 / STM32F4 builds remain gated (neither exclusion macro is defined for them) so the original safety net stays intact for the families where the interrupts-off rule actually applies.

## Test plan

- [x] Local: `bash test --cpp fl_gfx_rgbww` passes (compile_test.hpp is compiled by host tests).
- [ ] CI `stm32h747xi_giga` workflow: should turn green on next master push that touches `src/**`.
- [ ] CI other STM32 boards (bluepill = STM32F1): should remain gated and pass (their `led_sysdefs` already set `FASTLED_ALLOW_INTERRUPTS = 0`).

## Related

- #2596 — prior `stm32h747xi_giga` fix (SPI.h guard). This `FASTLED_ALLOW_INTERRUPTS` error is what surfaces next once #2596 unblocks the earlier compile step.

Fixes #2614


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced STM32 microcontroller platform compatibility by refining interrupt handling restrictions to apply only to specific lower-end variants, improving support for STM32H7xx series and Arduino Mbed core implementations.

* **Documentation**
  * Added clarification on timing constraints and interrupt handling requirements for affected STM32 microcontroller families.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/FastLED/pull/2615?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->