### PR TITLE
chore(deps): bump zccache floor to >=1.11.8 (critical)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "fpvgcc",
     "uv",
     "clang-tool-chain>=1.5.2",
-    "zccache>=1.11.7",
+    "zccache>=1.11.8",
     "ninja",
     "meson>=1.11.0",
     "download",


### PR DESCRIPTION
## Summary

Maintainer flagged 1.11.8 as a critical update. Bumps the floor in \`pyproject.toml\` from \`>=1.11.7\` → \`>=1.11.8\`.

Likely contains the fix for the cross-clone cache-pollution bug filed earlier today as [zackees/zccache#474](https://github.com/zackees/zccache/issues/474) — cached \`.obj\`s returned to a second sibling clone embedded absolute paths from the first clone, breaking \`bash test --cpp\` with redefinition errors against unrelated checkouts (\`fastled9\` vs \`fastled10\`).

## Test plan
- [x] \`uv sync\` clean
- [x] \`.venv/Scripts/zccache.exe --version\` → \`zccache 1.11.8\`
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project dependencies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/FastLED/pull/2616?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->