### PR TITLE
chore(deps): bump fbuild 2.2.9 -> 2.2.11 + re-normalize meson private includes per compile

### DIFF
--- a/ci/meson/compile.py
+++ b/ci/meson/compile.py
@@ -164,6 +164,30 @@ def compile_meson(
     # correctly, leaving the PCH stale even though headers changed.
     _invalidate_stale_pchs(build_dir)
 
+    # Re-normalize strict-path include flags before every compile (#2378).
+    # Meson setup already normalizes once, but ninja can regenerate
+    # build.ninja silently when meson.build files change — that regeneration
+    # re-introduces the relative + backslash `-Ici/meson/native\fastled.dll.p`
+    # form that zccache's --strict-paths=absolute rejects. Running the
+    # normalizer here costs ~5-20 ms and is idempotent when nothing changed.
+    from ci.meson.build_config import normalize_meson_private_include_paths
+
+    try:
+        normalize_meson_private_include_paths(build_dir)
+    except KeyboardInterrupt as ki:
+        # Ctrl-C during normalization — propagate cleanly so the watchdog
+        # and signal-handler chain runs to completion (KBI001).
+        handle_keyboard_interrupt(ki)
+        raise
+    except Exception as e:
+        # Non-fatal: if the normalizer fails for any reason, fall through
+        # to the compile — the worst case is the original zccache strict-
+        # paths error surfaces, which is still better than silently breaking
+        # the build at the normalize step.
+        _ts_print(
+            f"[MESON] ⚠️  Pre-compile normalize_meson_private_include_paths failed: {e}"
+        )
+
     if target:
         cmd.append(target)
         if not quiet:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,10 +5,17 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    # Pin to an fbuild release with the Teensy 4.x SPI shadowing-filter fix
-    # (FastLED/fbuild#284, closes FastLED/FastLED#2365) on top of the prior
-    # Teensy framework-library and ESP32-P4 path/source discovery fixes.
-    "fbuild==2.2.9",
+    # Pin to fbuild 2.2.11 — content of 2.2.10 republished with the full
+    # wheel set (win_amd64 + manylinux_x86_64 were missing from 2.2.10's
+    # PyPI upload). Bundles SAMD51 `cores/arduino` fallback + include-path
+    # injection (FastLED/fbuild#319/#320), nRF52 nRF52DK->pca10056 variant
+    # alias (FastLED/fbuild#321/#322), board JSON tinyuf2 partition rename
+    # + cmsis_dsp_lib validator whitelist (FastLED/fbuild#318), and
+    # daemon.rs subprocess-spawn lint annotations (FastLED/fbuild#317).
+    # Together these unblock Build SAMD51J, Build nRF52840 DK, and reduce
+    # Validate Boards drift from 39 boards to 14 (configuration-choice
+    # remainder pending maintainer review).
+    "fbuild==2.2.11",
     "platformio>=6.1.19,<6.2",
     "python-dateutil",
     "ruff",


### PR DESCRIPTION
﻿## Summary

Bumps `fbuild` pin from **2.2.9 → 2.2.11** and re-normalizes meson private-include paths before each compile (defense against ninja silent regen of build.ninja).

## fbuild 2.2.9 → 2.2.11

2.2.11 republishes 2.2.10's content with the **full wheel set**. 2.2.10's PyPI upload was missing `win_amd64` and `manylinux_x86_64` — effectively unusable on Windows and Linux x64. Content otherwise identical. Brings in:

- **SAMD51** `cores/arduino` fallback + include-path injection (FastLED/fbuild#319 + #320). `Build SAMD51J` was 100% red.
- **nRF52** `nRF52DK → pca10056` variant alias for the Adafruit framework (FastLED/fbuild#321 + #322). `Build nRF52840 DK` was 100% red.
- **Board JSON** tinyuf2 partition rename (18 Adafruit boards) + 4d_systems `esp_sr_16.csv → default_16MB.csv` + `cmsis_dsp_lib` validator whitelist (FastLED/fbuild#318). `Validate Boards` drift drops 39 → 14 (remainder is configuration-choice drift, separate maintainer review).
- **daemon.rs** `Command::new` subprocess-spawn lint annotations (FastLED/fbuild#317). Unblocked every PR's `Lint subprocess spawns` check.

## ci/meson/compile.py: re-normalize strict-path includes before each build

zccache's `--strict-paths=absolute` rejects relative + backslash include flags. `normalize_meson_private_include_paths` is already called once at meson setup, **but ninja silently regenerates `build.ninja` when build files change between compiles** — that regeneration re-introduces the relative form (e.g. `-Ici/meson/native\fastled.dll.p`), and the next compile dies with:

```
zccache: -I flag `-Ici/meson/native\fastled.dll.p` violates
--strict-paths=absolute (expected forward-slash absolute path).
```

The Stop hook has surfaced this 3-4 times this session.

Fix: call the normalizer at the top of `compile_meson`, right after `_invalidate_stale_pchs`. Costs ~5-20 ms and is idempotent when nothing changed. KBI001-compliant — the `KeyboardInterrupt` handler calls `handle_keyboard_interrupt(ki)` before re-raising; module already imports it at line 25.

## Test plan

- [x] `uv sync` resolves `fbuild==2.2.11` cleanly on Windows.
- [x] `bash lint` — clean.
- [ ] CI workflows that were stale-red awaiting this bump should re-trigger and turn green: `Build SAMD51J`, `Build nRF52840 DK`, `check_teensy41_size`, `linux_native`, the size workflows (now via `--backend platformio` per #2605 + `build_info.json` per #297).
- [ ] `Validate Boards` (in fbuild repo CI) should drop from 39 → 14 drift items, confirming the board JSON cleanup landed.

Refs FastLED/fbuild#297, #298, #300, #303, #304, #305, #317, #318, #319, #320, #321, #322; FastLED #2378 (zccache strict-paths origin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build process reliability with enhanced error handling during include path normalization. Non-critical normalization failures no longer interrupt compilation; the build continues while critical issues are properly handled and reported.

* **Chores**
  * Updated fbuild build tool dependency from version 2.2.9 to 2.2.11, which includes various upstream fixes and enhancements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/FastLED/pull/2617?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->