### PR TITLE
refactor(autoresearch): gate runSimdTests() behind FL_RUN_SIMD_TESTS_AT_BOOT

### DIFF
--- a/examples/AutoResearch/AutoResearch.ino
+++ b/examples/AutoResearch/AutoResearch.ino
@@ -331,7 +331,18 @@ void setup() {
     // ========================================================================
     // SIMD AutoResearch
     // ========================================================================
-    int simd_failures = autoresearch::simd_check::runSimdTests();
+    // SIMD validation suite is RPC-driven (testSimd, registered in
+    // AutoResearchRemote.cpp). NOT computed at boot by default — flip
+    // -DFL_RUN_SIMD_TESTS_AT_BOOT=1 to run once at startup as a bridge until
+    // the testSimd RPC routing on P4 is fixed (#2541).
+#ifdef FL_RUN_SIMD_TESTS_AT_BOOT
+    {
+        int simd_failures = autoresearch::simd_check::runSimdTests();
+        if (simd_failures > 0) {
+            FL_ERROR("SIMD autoresearch failed - " << simd_failures << " test(s) failed");
+        }
+    }
+#endif
 
     // #2526 expansion micro-bench is RPC-driven (wave8ExpandBenchmark, registered
     // in AutoResearchRemote.cpp). NOT computed at boot by default — flip
@@ -353,9 +364,6 @@ void setup() {
         autoresearch::parlio_bench::printParlioEncodeResultRom(_per);
     }
 #endif
-    if (simd_failures > 0) {
-        FL_ERROR("SIMD autoresearch failed - " << simd_failures << " test(s) failed");
-    }
 
     // ========================================================================
     // RX Channel Setup


### PR DESCRIPTION
## Summary

- Stop running the 85-test SIMD validation suite unconditionally on every boot of the AutoResearch example
- Gate the boot-time call behind `-DFL_RUN_SIMD_TESTS_AT_BOOT=1` (off by default), mirroring `FL_BENCH_WAVE8_AT_BOOT` / `FL_BENCH_PARLIO_AT_BOOT` from #2539
- `runSimdTests()` itself is unchanged; the existing `testSimd` RPC handler in `AutoResearchRemote.cpp` remains the canonical invocation path

Closes #2542.

## Why

Every boot of AutoResearch was paying ~50–100 ms + log dump for a validation suite already callable on demand via RPC. Same anti-pattern PR #2539 fixed for the wave8 expansion bench.

## Test plan

- [ ] Compile AutoResearch for esp32p4 — SIMD tests should NOT run at boot
- [ ] Compile with `-DFL_RUN_SIMD_TESTS_AT_BOOT=1` — SIMD tests SHOULD run at boot (bridge mode)
- [ ] `testSimd` RPC call still works (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Behavior Changes**
  * SIMD validation tests now run only on explicit RPC request; startup execution available via configuration flag.
  * PARLIO encode benchmarking removed from startup; accessible through RPC only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->