### PR TITLE
fix(esp32p4): route Serial to USB-Serial-JTAG so AutoResearch RPC works

### DIFF
--- a/ci/boards.py
+++ b/ci/boards.py
@@ -835,6 +835,14 @@ ESP32_P4 = Board(
     real_board_name="esp32-p4-evboard",
     platform=ESP32_IDF_5_5_1_PIOARDUINO,
     board_partitions="huge_app.csv",
+    # Route Serial → USB-Serial-JTAG (HWCDCSerial) instead of UART0 (pins 37/38).
+    # Without these the AutoResearch firmware listens on UART0 while the host
+    # tool talks to the USB-Serial-JTAG COM port — every RPC write times out.
+    # See #2541.
+    defines=[
+        "ARDUINO_USB_MODE=1",
+        "ARDUINO_USB_CDC_ON_BOOT=1",
+    ],
 )
 
 ADA_FEATHER_NRF52840_SENSE = Board(


### PR DESCRIPTION
## Summary

- Add `ARDUINO_USB_MODE=1` and `ARDUINO_USB_CDC_ON_BOOT=1` to the `ESP32_P4` board definition in `ci/boards.py`
- This wires `Serial` to `HWCDCSerial` on the USB-Serial-JTAG peripheral, matching the COM port the host tools (`fbuild monitor` / `serial_interface.py`) open
- Unblocks every RPC over `bash autoresearch esp32p4 --simd` — `testSimd`, `testSimdBenchmark`, `wave8ExpandBenchmark`, `parlioEncodeBenchmark`

Closes #2541.

## Why

With `CDC On Boot: 0` the firmware was listening on UART0 (pins 37/38) while the host wrote to the USB-Serial-JTAG COM port. Every RPC died with `Write timeout`. The companion `esp_rom_printf` boot-time workaround was the only way to capture measurements.

## Test plan

- [ ] `bash autoresearch esp32p4 --simd --no-fbuild` — expect `testSimd` JSON, not write timeout
- [ ] Boot log shows `CDC On Boot: 1`
- [ ] `measureParlio` returns full encode_us results (unblocks #2540 FL_PRINT migration)

Unblocks #2540 once verified on hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced ESP32_P4 board serial communication configuration to enable USB-based serial output on boot.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->