### PR TITLE
fix(esp32): centralize ESP_CACHE_MSYNC_FLAG_DIR_C2M compat shim

### DIFF
--- a/src/platforms/esp/32/drivers/lcd_spi/lcd_spi_peripheral_esp.cpp.hpp
+++ b/src/platforms/esp/32/drivers/lcd_spi/lcd_spi_peripheral_esp.cpp.hpp
@@ -35,6 +35,13 @@
 #define FL_HAS_ESP_CACHE_MSYNC 0
 #endif
 
+// Backfills `ESP_CACHE_MSYNC_FLAG_DIR_C2M = 0` on IDF < 5.2 (the flag was
+// added in 5.2; older esp_cache_msync() defaulted to that direction). See
+// FastLED #2619: previously rmt_5/rmt5_peripheral_esp.cpp.hpp owned this
+// shim and lcd_spi relied on unity-build include order putting rmt_5
+// first, which broke esp_extra_libs.
+#include "platforms/esp/esp_cache_compat.h"
+
 #ifndef LCD_SPI_PSRAM_ALIGNMENT
 #define LCD_SPI_PSRAM_ALIGNMENT 64
 #endif

--- a/src/platforms/esp/32/drivers/rmt/rmt_5/rmt5_peripheral_esp.cpp.hpp
+++ b/src/platforms/esp/32/drivers/rmt/rmt_5/rmt5_peripheral_esp.cpp.hpp
@@ -42,15 +42,11 @@ FL_EXTERN_C_BEGIN
 // IWYU pragma: end_keep
 FL_EXTERN_C_END
 
-// ESP-IDF 5.2+ compatibility: ESP_CACHE_MSYNC_FLAG_DIR_C2M
-// In ESP-IDF < 5.2, esp_cache_msync() defaults to C2M (cache-to-memory) direction
-// In ESP-IDF 5.2+, the direction flag was added to be explicit
-#include "platforms/esp/esp_version.h"
-#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 2, 0)
-    #ifndef ESP_CACHE_MSYNC_FLAG_DIR_C2M
-        #define ESP_CACHE_MSYNC_FLAG_DIR_C2M 0  // Default behavior in < 5.2
-    #endif
-#endif
+// ESP-IDF 5.2+ compatibility: ESP_CACHE_MSYNC_FLAG_DIR_C2M.
+// Centralized so every driver gets the same shim regardless of unity-build
+// include order. See FastLED #2619 for the lcd_spi / rmt5 ordering bug that
+// motivated extracting this.
+#include "platforms/esp/esp_cache_compat.h"
 
 // FL_MEMORY_BARRIER for ISR synchronization
 #include "fl/stl/compiler_control.h"

--- a/src/platforms/esp/esp_cache_compat.h
+++ b/src/platforms/esp/esp_cache_compat.h
@@ -1,0 +1,27 @@
+#pragma once
+
+// IWYU pragma: private
+
+// ok no namespace fl  — preprocessor-only header (no declarations to scope).
+
+// ESP-IDF esp_cache_msync() flag compatibility shim.
+//
+// `ESP_CACHE_MSYNC_FLAG_DIR_C2M` (cache-to-memory direction) was added in
+// ESP-IDF 5.2. Prior versions of `esp_cache_msync()` defaulted to the C2M
+// direction without taking an explicit flag, so backfilling the macro to
+// `0` (no extra flag bits) preserves the same runtime behavior under the
+// new call signature.
+//
+// Centralized here so every driver that calls `esp_cache_msync(... , ...,
+// ESP_CACHE_MSYNC_FLAG_DIR_C2M)` gets the same shim. Per-driver duplicates
+// drift out of sync the first time a unity-build include order shifts and
+// one file is preprocessed before the file that owned the shim — that
+// failure mode is what motivated this file (see FastLED #2619).
+
+#include "platforms/esp/esp_version.h"
+
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 2, 0)
+    #ifndef ESP_CACHE_MSYNC_FLAG_DIR_C2M
+        #define ESP_CACHE_MSYNC_FLAG_DIR_C2M 0  // Default direction on IDF < 5.2
+    #endif
+#endif


### PR DESCRIPTION
﻿## Summary

`esp_extra_libs` has been failing on every recent master push with:

```
src/platforms/esp/32/drivers/lcd_spi/lcd_spi_peripheral_esp.cpp.hpp:364:
  error: 'ESP_CACHE_MSYNC_FLAG_DIR_C2M' was not declared in this scope
  364 |                         ESP_CACHE_MSYNC_FLAG_DIR_C2M);

note: it was later defined here
  rmt/rmt_5/rmt5_peripheral_esp.cpp.hpp:51:
    #define ESP_CACHE_MSYNC_FLAG_DIR_C2M 0
```

## Root cause

`rmt5_peripheral_esp.cpp.hpp` owned the ESP-IDF < 5.2 compat shim that backfills `ESP_CACHE_MSYNC_FLAG_DIR_C2M = 0` (the flag was added upstream in IDF 5.2; older `esp_cache_msync()` defaulted to the C2M direction so 0 = no-op preserves semantics). `lcd_spi_peripheral_esp.cpp.hpp` uses the same macro at line 364 but **did not include the shim** — it was relying on unity-build preprocessing rmt_5 first.

When the unity-build include order put lcd_spi ahead of rmt_5, the macro was undefined at the point of use → build broke. The gcc note in the error makes this explicit: *"it was later defined here"*.

## Fix

Extract the shim into a new shared header `src/platforms/esp/esp_cache_compat.h`:

```cpp
#pragma once
// IWYU pragma: private
// ok no namespace fl  — preprocessor-only header (no declarations to scope).

#include "platforms/esp/esp_version.h"

#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 2, 0)
    #ifndef ESP_CACHE_MSYNC_FLAG_DIR_C2M
        #define ESP_CACHE_MSYNC_FLAG_DIR_C2M 0
    #endif
#endif
```

Both consumers (`rmt5_peripheral_esp.cpp.hpp` and `lcd_spi_peripheral_esp.cpp.hpp`) now include it instead of carrying their own (lcd_spi previously carried zero copies — that was the bug). Future ESP drivers using `esp_cache_msync()` get the shim for free.

Behavior unchanged on IDF 5.2+ — the shim is gated on version and becomes a no-op.

## Test plan

- [x] `bash test --cpp fl_gfx_rgbww` — passes (sanity-check that the host build still compiles).
- [x] `bash lint --cpp` — clean (`PlatformsFlNamespaceChecker` satisfied via the `// ok no namespace fl` marker since the file is preprocessor-only).
- [ ] CI `esp_extra_libs` workflow turns green on the next push that touches `src/platforms/esp/**`.
- [ ] Spot-check: `Build ESP32-S3` and other ESP32 workflows that include the lcd_spi driver continue to compile (the shim is identical content, just centralized).

Fixes #2619.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated ESP-IDF version-specific compatibility definitions for PSRAM cache synchronization across multiple ESP32 peripheral driver implementations into a centralized compatibility header, eliminating code duplication.

* **Chores**
  * Extended backward compatibility support for older ESP-IDF versions (prior to 5.2.0) by centralizing version-conditional flag definitions in the ESP32 platform layer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->