### PR TITLE
refactor(autoresearch): remove FL_*_AT_BOOT boot bridges entirely (RPC-only)

### DIFF
--- a/examples/AutoResearch/AutoResearch.ino
+++ b/examples/AutoResearch/AutoResearch.ino
@@ -328,42 +328,11 @@ void setup() {
     ss << "  RX Buffer Size: " << RX_BUFFER_SIZE << " bytes";
     FL_PRINT(ss.str());
 
-    // ========================================================================
-    // SIMD AutoResearch
-    // ========================================================================
-    // SIMD validation suite is RPC-driven (testSimd, registered in
-    // AutoResearchRemote.cpp). NOT computed at boot by default — flip
-    // -DFL_RUN_SIMD_TESTS_AT_BOOT=1 to run once at startup as a bridge until
-    // the testSimd RPC routing on P4 is fixed (#2541).
-#ifdef FL_RUN_SIMD_TESTS_AT_BOOT
-    {
-        int simd_failures = autoresearch::simd_check::runSimdTests();
-        if (simd_failures > 0) {
-            FL_ERROR("SIMD autoresearch failed - " << simd_failures << " test(s) failed");
-        }
-    }
-#endif
-
-    // #2526 expansion micro-bench is RPC-driven (wave8ExpandBenchmark, registered
-    // in AutoResearchRemote.cpp). NOT computed at boot by default — flip
-    // -DFL_BENCH_WAVE8_AT_BOOT=1 to run once at startup as a bridge until the
-    // testSimd RPC routing on P4 is fixed (#2541).
-#ifdef FL_BENCH_WAVE8_AT_BOOT
-    {
-        auto w8r = autoresearch::wave8_bench::measureWave8Expand();
-        autoresearch::wave8_bench::printWave8ExpandResultRom(w8r);
-    }
-#endif
-
-    // Full PARLIO encode bench (post-byte-LUT, #2526). RPC-driven via
-    // parlioEncodeBenchmark; boot-time bridge gated by FL_BENCH_PARLIO_AT_BOOT
-    // until #2541 testSimd RPC routing is fixed.
-#ifdef FL_BENCH_PARLIO_AT_BOOT
-    {
-        auto _per = autoresearch::parlio_bench::measureParlioEncode();
-        autoresearch::parlio_bench::printParlioEncodeResultRom(_per);
-    }
-#endif
+    // SIMD validation suite, Wave8 expansion micro-bench, and full PARLIO
+    // encode bench are RPC-driven — invoke via the `testSimd`,
+    // `wave8ExpandBenchmark`, and `parlioEncodeBenchmark` handlers in
+    // AutoResearchRemote.cpp. Do not add boot-time invocation blocks here;
+    // if RPC routing is broken on a platform, fix the routing (see #2541).
 
     // ========================================================================
     // RX Channel Setup

--- a/examples/AutoResearch/AutoResearchParlioEncode.h
+++ b/examples/AutoResearch/AutoResearchParlioEncode.h
@@ -18,9 +18,8 @@
 ///      pattern (×1.00 SRAM vs PSRAM); this rechecks on the byte-LUT version.
 ///
 /// Output: `BENCH_PARLIO_*` lines via `esp_rom_printf` -> USB-Serial-JTAG (COM25)
-/// so capture works without the broken testSimd RPC routing (#2541). Gated by
-/// `-DFL_BENCH_PARLIO_AT_BOOT=1` per #2542 — RPC-invokable from
-/// `parlioEncodeBenchmark` in AutoResearchRemote.cpp.
+/// so capture works without depending on the testSimd RPC routing (#2541).
+/// **Invocation:** RPC-only via `parlioEncodeBenchmark` in AutoResearchRemote.cpp.
 
 #pragma once
 

--- a/examples/AutoResearch/AutoResearchWave8Expand.h
+++ b/examples/AutoResearch/AutoResearchWave8Expand.h
@@ -5,13 +5,9 @@
 /// LUT and a batched-byte variant (S3), AND times the full per-byte-position
 /// production cost (expansion + 16-lane transpose) for both LUTs.
 ///
-/// **Invocation:** intended to be called via the `wave8ExpandBenchmark` RPC
-/// (registered in AutoResearchRemote.cpp). Not computed at boot by default.
-/// Build with `-DFL_BENCH_WAVE8_AT_BOOT=1` to also fire once at setup() —
-/// that's a bridge until the testSimd RPC routing on P4 is fixed (#2541), at
-/// which point the bench is purely RPC-driven. Boot-time output uses
-/// `esp_rom_printf` because `FL_PRINT` doesn't currently reach COM25 on P4
-/// (see #2540/#2541).
+/// **Invocation:** RPC-only. Call via the `wave8ExpandBenchmark` handler
+/// registered in AutoResearchRemote.cpp. Output uses `esp_rom_printf` because
+/// `FL_PRINT` doesn't currently reach COM25 on P4 (see #2540/#2541).
 
 #pragma once
 


### PR DESCRIPTION
## Summary

Follow-up to #2618. Delete the `#ifdef FL_RUN_SIMD_TESTS_AT_BOOT` / `FL_BENCH_WAVE8_AT_BOOT` / `FL_BENCH_PARLIO_AT_BOOT` invocation blocks from `examples/AutoResearch/AutoResearch.ino`. The SIMD validation suite, Wave8 expansion bench, and PARLIO encode bench are now invoked exclusively via their RPC handlers in `AutoResearchRemote.cpp`:

- `testSimd` -> `autoresearch::simd_check::runSimdTests()`
- `wave8ExpandBenchmark` -> `autoresearch::wave8_bench::measureWave8Expand()`
- `parlioEncodeBenchmark` -> `autoresearch::parlio_bench::measureParlioEncode()`

## Why

Per maintainer feedback on #2618: opt-in "bridge" macros leave scaffolding that future edits quietly reactivate, defeating the whole point of moving validation/bench code off `setup()`. The RPC layer is the canonical invocation rail; if RPC routing is broken on a platform (e.g. the ESP32-P4 Serial misroute fixed in #2620), fix the routing — don't re-add a boot-time bridge.

Also updates the file-level doc comments in `AutoResearchWave8Expand.h` and `AutoResearchParlioEncode.h` to drop references to the now-removed boot macros and state RPC-only invocation.

## Test plan

- [ ] Compile AutoResearch for esp32p4 — boot path stays lean; no SIMD/Wave8/PARLIO bench output at startup
- [ ] `testSimd` / `wave8ExpandBenchmark` / `parlioEncodeBenchmark` RPC calls still work (no change to handlers)
- [ ] `grep -r FL_RUN_SIMD_TESTS_AT_BOOT examples/AutoResearch` returns nothing
- [ ] `grep -r FL_BENCH_WAVE8_AT_BOOT examples/AutoResearch` returns nothing
- [ ] `grep -r FL_BENCH_PARLIO_AT_BOOT examples/AutoResearch` returns nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Benchmarks (SIMD validation suite, Wave8 expansion, and PARLIO encode) no longer execute automatically at startup. They are now exclusively invoked on-demand via remote procedure calls.
  * Updated documentation to reflect the new benchmark invocation method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->