### PR TITLE
fix(examples): restrict AudioFftParity to ESP32 boards with esp_dsp

### DIFF
--- a/examples/AudioFftParity/AudioFftParity.ino
+++ b/examples/AudioFftParity/AudioFftParity.ino
@@ -1,3 +1,10 @@
+// @filter: (board is esp32dev) or (board is esp32s3) or (board is esp32c3) or (board is esp32c6) or (board is esp32p4) or (board is esp32wroom)
+//
+// Restrict to ESP32 boards that ship esp_dsp.h in their PlatformIO toolchain
+// bundle. esp32c2 / esp32s2 / esp32h2 / esp32c5 don't include esp_dsp, so the
+// `#define FL_FFT_USE_ESP_DSP 1` below causes a "esp_dsp.h: No such file"
+// fatal error there. See FastLED #2623.
+
 /// @file AudioFftParity.ino
 /// @brief Sanity test for the ESP-DSP real-FFT backend in fl::audio::fft.
 ///


### PR DESCRIPTION
﻿## Summary

`esp32c2` workflow on master has been failing every build with:

```
lib/FastLED/fl/audio/fft/fft_backend.h:101:10:
  fatal error: esp_dsp.h: No such file or directory
FAILED: AudioFftParity
```

## Root cause

`examples/AudioFftParity/AudioFftParity.ino:26` deliberately enables the ESP-DSP backend it's there to test:

```cpp
#define FL_FFT_USE_ESP_DSP 1
```

`fft_backend.h:99-107` then `#include "esp_dsp.h"` unconditionally on any `FL_IS_ESP32` board. But **esp_dsp isn't shipped in every ESP32 toolchain bundle** — ESP32-C2 (and likely S2/H2/C5) don't have it. The example had no `@filter`, so the CI matrix tried it on every ESP32 variant.

## Fix

Add an `@filter` to restrict to the boards that DO ship `esp_dsp.h`:

```cpp
// @filter: (board is esp32dev) or (board is esp32s3) or (board is esp32c3)
//      or (board is esp32c6) or (board is esp32p4) or (board is esp32wroom)
```

Other boards skip cleanly. The example's own docstring already documents `esp32s3` as the canonical target — the filter codifies what was already informal.

## Verification

```
$ bash compile esp32c2 --examples AudioFftParity
SKIPPED 1 example(s) due to @filter constraints:
  - AudioFftParity: doesn't match required board=...

$ bash compile esp32s3 --examples AudioFftParity
(in progress — supported boards unchanged by filter content)
```

## Out of scope

The same workflow run also surfaces a separate `RX` (Remote) link failure on esp32c2:

```
undefined reference to `fl::GpioIsrRx::create(int)'
```

That's its own bug — fl::RxDevice's template instantiation isn't pulling in the GpioIsrRx implementation. Filed-separately territory; not in this PR.

Fixes #2623.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the AudioFftParity example sketch with board compatibility information, specifying supported ESP32 variants and documenting limitations on other ESP32 models.

* **Chores**
  * Added build configuration filters to prevent compilation errors on unsupported ESP32 targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->