### PR TITLE
fix(nrf52): defer PCA10056 pin map when community TARGET_* override is set

### DIFF
--- a/.github/workflows/build_nrf52840_supermini.yml
+++ b/.github/workflows/build_nrf52840_supermini.yml
@@ -5,6 +5,7 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - master

--- a/src/platforms/arm/nrf52/fastpin_arm_nrf52_variants.h
+++ b/src/platforms/arm/nrf52/fastpin_arm_nrf52_variants.h
@@ -7,6 +7,20 @@
 // use this to determine if found variant or not (avoid multiple boards at once)
 #undef __FASTPIN_ARM_NRF52_VARIANT_FOUND
 
+// Sentinel: set when the user (or ci/boards.py) has opted in to a community
+// board via TARGET_*. These boards reuse a stock Adafruit BSP (typically
+// nrf52840_dk_adafruit), which injects its own ARDUINO_NRF52840_* macro. The
+// sentinel lets the BSP-default pin-map blocks below defer to the explicit
+// TARGET_* block so the user's override always wins. Add new TARGET_* macros
+// to the OR-chain when introducing new community-board variants. See #2422
+// for the original report and #2626 for the redefinition bug.
+#undef __FASTLED_NRF52_USER_TARGET_OVERRIDE
+#if defined(TARGET_SUPERMINI_NRF52840) || \
+    defined(TARGET_NICE_NANO_V2)      || \
+    defined(TARGET_NRFMICRO)
+    #define __FASTLED_NRF52_USER_TARGET_OVERRIDE
+#endif
+
 
 //
 // BOARD_PIN can be either the pin portion of a port.pin, or the combined NRF_GPIO_PIN_MAP() number.
@@ -346,14 +360,13 @@
 
 // Adafruit Bluefruit on nRF52840DK PCA10056
 // From https://www.adafruit.com/package_adafruit_index.json
-// Community boards (SuperMini / nice!nano v2 / nRFMicro) reuse the
-// nrf52840_dk_adafruit BSP, which auto-defines ARDUINO_NRF52840_PCA10056.
-// When one of those TARGET_* overrides is in scope, defer to its dedicated
-// block below instead of using the PCA10056 pin map (see issue #2422).
-#if defined (ARDUINO_NRF52840_PCA10056) && \
-    !defined(TARGET_SUPERMINI_NRF52840) && \
-    !defined(TARGET_NICE_NANO_V2) && \
-    !defined(TARGET_NRFMICRO)
+// Community boards reuse the nrf52840_dk_adafruit BSP, which auto-defines
+// ARDUINO_NRF52840_PCA10056. When the user opted into one of those community
+// variants via a TARGET_* macro, defer to its dedicated block below instead
+// of running the PCA10056 pin map. Why guard in the header instead of issuing
+// -UARDUINO_NRF52840_PCA10056 from ci/boards.py: a header-side guard also
+// works for non-PIO builds where the user sets TARGET_* by hand.
+#if defined (ARDUINO_NRF52840_PCA10056) && !defined(__FASTLED_NRF52_USER_TARGET_OVERRIDE)
     #if defined(__FASTPIN_ARM_NRF52_VARIANT_FOUND)
         #error "Cannot define more than one board at a time"
     #else

--- a/src/platforms/arm/nrf52/fastpin_arm_nrf52_variants.h
+++ b/src/platforms/arm/nrf52/fastpin_arm_nrf52_variants.h
@@ -346,13 +346,20 @@
 
 // Adafruit Bluefruit on nRF52840DK PCA10056
 // From https://www.adafruit.com/package_adafruit_index.json
-#if defined (ARDUINO_NRF52840_PCA10056)
+// Community boards (SuperMini / nice!nano v2 / nRFMicro) reuse the
+// nrf52840_dk_adafruit BSP, which auto-defines ARDUINO_NRF52840_PCA10056.
+// When one of those TARGET_* overrides is in scope, defer to its dedicated
+// block below instead of using the PCA10056 pin map (see issue #2422).
+#if defined (ARDUINO_NRF52840_PCA10056) && \
+    !defined(TARGET_SUPERMINI_NRF52840) && \
+    !defined(TARGET_NICE_NANO_V2) && \
+    !defined(TARGET_NRFMICRO)
     #if defined(__FASTPIN_ARM_NRF52_VARIANT_FOUND)
         #error "Cannot define more than one board at a time"
     #else
         #define __FASTPIN_ARM_NRF52_VARIANT_FOUND
     #endif
-    
+
     #if defined(USE_ARDUINO_PIN_NUMBERING)
         #error "Define of `USE_ARDUINO_PIN_NUMBERING` has known errors in pin mapping -- select different mapping"
     #elif defined(FASTLED_NRF52_USE_ARDUINO_UNO_R3_HEADER_PIN_NUMBERING)


### PR DESCRIPTION
## Summary
- `SUPERMINI_NRF52840`, `NICE_NANO_NRF52840`, and `NRFMICRO_NRF52840` all reuse the `nrf52840_dk_adafruit` BSP via `ci/boards.py`, so the Adafruit BSP auto-defines `ARDUINO_NRF52840_PCA10056` alongside the community `TARGET_*` override.
- Both pin-map blocks then defined `fl::FastPin<0..>`, tripping the `#error "Cannot define more than one board at a time"` guard plus C++ redefinition diagnostics — see the [pre-fix CI run](https://github.com/FastLED/FastLED/actions/runs/26698725780).
- Gate the `ARDUINO_NRF52840_PCA10056` block on a single `__FASTLED_NRF52_USER_TARGET_OVERRIDE` sentinel (set when any `TARGET_*` is in scope) so the explicit user override wins over the BSP-supplied default. No behavior change for any board that does **not** set one of the three `TARGET_*` macros.

Closes #2626.

## Test plan
- [x] `bash compile supermini_nrf52840 --examples Blink` — gets past the FastPin redefinition error this PR targets.
- [x] `bash lint` clean.
- [x] CI: `nrf52840_supermini` triggered on this branch ([run 26699376709](https://github.com/FastLED/FastLED/actions/runs/26699376709)) confirms the FastPin redefinition is resolved — compilation now completes and the build proceeds to the LTO link phase, where it hits a pre-existing **`Error: offset out of range`** (binary too large for ARM Thumb branch range). That size/link failure is **out of scope** for this PR per the loop instructions ("don't fix the boards failing size checks"); the supermini workflow will remain red on size until size is addressed separately, but the underlying compile bug this PR targets is verifiably fixed.
- [x] CI: `nrf52840_dk` / `nrf52_xiaoblesense` failures are a different fbuild-side `variant.h: No such file or directory` bug tracked separately (#2631, #2633). `adafruit_feather_nrf52840_sense` also fails on the same size/link issue (#2632 closed as a size failure).

## Reviewer follow-ups addressed
Pushed an iteration commit collapsing the three inline `!defined(TARGET_*)` guards into a single `__FASTLED_NRF52_USER_TARGET_OVERRIDE` sentinel after second-opinion review flagged the hand-maintained allowlist as a maintenance smell. Now adding a new community-board `TARGET_*` requires extending exactly one OR-chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)