### PR TITLE
fix(esp32): provide GpioIsrRx::create stub when FASTLED_RMT5=0

### DIFF
--- a/src/platforms/esp/32/drivers/gpio_isr_rx/gpio_isr_rx.cpp.hpp
+++ b/src/platforms/esp/32/drivers/gpio_isr_rx/gpio_isr_rx.cpp.hpp
@@ -6,7 +6,9 @@
  *
  * This file redirects the GpioIsrRx::create() factory method to the
  * dual-ISR MCPWM implementation on platforms with MCPWM hardware.
- * Returns nullptr on platforms without MCPWM (e.g., ESP32-C3/C2).
+ * Returns nullptr (which the caller wraps as DummyRxDevice) on platforms
+ * without MCPWM (e.g., ESP32-C3/C2) OR without RMT5 (e.g., ESP32-C2,
+ * which lacks the RMT peripheral entirely).
  */
 
 #include "platforms/is_platform.h"
@@ -22,11 +24,19 @@
 #include "platforms/esp/32/feature_flags/enabled.h"
 // IWYU pragma: end_keep
 
+// soc_caps.h is only available under the ESP-IDF tree; only pull it in when
+// we'll actually consult SOC_MCPWM_SUPPORTED (i.e. when FASTLED_RMT5 is on).
 #if FASTLED_RMT5
-
-// Check if this SoC has MCPWM hardware
 #include "soc/soc_caps.h"  // IWYU pragma: keep
-#if defined(SOC_MCPWM_SUPPORTED) && SOC_MCPWM_SUPPORTED
+#endif
+
+// The caller in `src/fl/channels/rx.cpp.hpp` is gated only on `FL_IS_ESP32`
+// and references `GpioIsrRx::create()` unconditionally. We must therefore
+// provide a definition for every ESP32 board — even ones without RMT5 or
+// MCPWM (e.g. ESP32-C2 has neither). The MCPWM-backed path only fires
+// when both gates are positive; everything else falls into the stub.
+// See FastLED #2630.
+#if FASTLED_RMT5 && defined(SOC_MCPWM_SUPPORTED) && SOC_MCPWM_SUPPORTED
 
 // IWYU pragma: begin_keep
 #include "platforms/esp/32/drivers/gpio_isr_rx/gpio_isr_rx_mcpwm.h"
@@ -41,11 +51,13 @@ fl::shared_ptr<GpioIsrRx> GpioIsrRx::create(int pin) FL_NOEXCEPT {
 
 } // namespace fl
 
-#else // !SOC_MCPWM_SUPPORTED
+#else // !FASTLED_RMT5 OR !SOC_MCPWM_SUPPORTED
 
 namespace fl {
 
-// No MCPWM hardware on this SoC - ISR RX not supported
+// No MCPWM hardware (or no RMT5 support) on this SoC — ISR RX not
+// available. Returning null lets the caller substitute DummyRxDevice
+// at runtime rather than failing to link.
 fl::shared_ptr<GpioIsrRx> GpioIsrRx::create(int pin) FL_NOEXCEPT {
     (void)pin;
     return fl::shared_ptr<GpioIsrRx>();
@@ -53,6 +65,5 @@ fl::shared_ptr<GpioIsrRx> GpioIsrRx::create(int pin) FL_NOEXCEPT {
 
 } // namespace fl
 
-#endif // SOC_MCPWM_SUPPORTED
-#endif // FASTLED_RMT5
+#endif // FASTLED_RMT5 && SOC_MCPWM_SUPPORTED
 #endif // FL_IS_ESP32


### PR DESCRIPTION
﻿## Summary

`esp32c2` workflow on master fails linking `examples/Remote/Remote.ino`:

```
fl.channels+.cpp: undefined reference to `fl::GpioIsrRx::create(int)'
collect2: error: ld returned 1 exit status
FAILED: RX
```

## Root cause

`src/fl/channels/rx.cpp.hpp:99` is compiled for any `FL_IS_ESP32` and references `GpioIsrRx::create(pin)` unconditionally. The **definition** in `src/platforms/esp/32/drivers/gpio_isr_rx/gpio_isr_rx.cpp.hpp` was gated on `FASTLED_RMT5` outer + `SOC_MCPWM_SUPPORTED` inner:

```cpp
#if FASTLED_RMT5
    #if SOC_MCPWM_SUPPORTED
        // MCPWM impl
    #else
        // no-op stub returning null
    #endif
#endif  // ← falls off the cliff when FASTLED_RMT5 = 0
```

On ESP32-C2 (low-end RISC-V, **no RMT peripheral at all**), `feature_flags/enabled.h` resolves `FASTLED_RMT5 = 0`. Neither the MCPWM path nor the stub was compiled → symbol undefined → link error.

## Fix

Combine both gates into a single condition so the no-op stub is the fallback for *either* missing piece:

```cpp
#if FASTLED_RMT5 && defined(SOC_MCPWM_SUPPORTED) && SOC_MCPWM_SUPPORTED
    // MCPWM impl
#else
    // no-op stub returning null  (RMT-less OR MCPWM-less chips)
#endif
```

The caller (`rx.cpp.hpp:99-104`) already handles a null return — wraps it as `DummyRxDevice("GPIO ISR RX creation failed")`. Runtime semantics for chips that already worked are unchanged; new behavior on C2 is "feature unavailable at runtime" instead of "build doesn't link". That matches the file's docstring intent ("Returns nullptr on platforms without MCPWM").

`#include "soc/soc_caps.h"` is now only pulled in when `FASTLED_RMT5` is true — it's only available under the ESP-IDF tree when RMT5 is in play.

## Verification

```
$ bash compile esp32c2 --examples Remote
(in progress — verification pending)
```

(I'll merge once `bash compile esp32c2 --examples Remote` reports success, per the loop directive's authorization.)

## Related

- #2623, PR #2625 — sibling esp32c2 failure (AudioFftParity) fixed via `@filter`
- #2629 — broader follow-up to eliminate the `FL_FFT_USE_ESP_DSP` opt-in via `FL_HAS_INCLUDE` probe

Fixes #2630.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced GPIO ISR RX driver reliability and overall hardware compatibility across all ESP32 variants. Improved handling for boards with limited hardware capabilities, particularly ESP32-C2 and ESP32-C3 platforms. The driver now provides more robust and consistently stable performance, reducing potential issues during build and runtime operations across the entire ESP32 ecosystem.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->