### PR TITLE
fix(nrf52): unbreak xiaoblesense_adafruit by reusing nrf52840_dk_adafruit variant

### DIFF
--- a/ci/boards.py
+++ b/ci/boards.py
@@ -850,18 +850,39 @@ ADA_FEATHER_NRF52840_SENSE = Board(
     platform="nordicnrf52",
 )
 
+# Seeed XIAO BLE Sense (nRF52840) -- community board (issue #2634)
+# Variant header: https://github.com/adafruit/Adafruit_nRF52_Arduino (no xiao variant)
+# The maxgerhardt nordicnrf52 platform formerly used here points build.variant at a
+# `xiaoblesense_adafruit` directory that does NOT ship in the Adafruit nRF52 BSP
+# at 1.10601.0, so the Adafruit core's `#include "variant.h"` fails. Mirror the
+# SuperMini / nice!nano / nRFMicro pattern from #2422: reuse the Adafruit BSP's
+# `nrf52840_dk_adafruit` board JSON for a valid variant, then let the
+# TARGET_XIAOBLE_NRF52840_SENSE define select the correct fastpin variant block.
 XIAOBLESENSE_ADAFRUIT_NRF52 = Board(
     board_name="xiaoblesense_adafruit",
-    platform="https://github.com/maxgerhardt/platform-nordicnrf52",
-    platform_needs_install=True,  # Install platform package to get the boards
+    real_board_name="nrf52840_dk_adafruit",
+    platform="nordicnrf52",
+    framework="arduino",
+    platform_packages="framework-arduinoadafruitnrf52@^1.10601.0",
+    defines=[
+        "TARGET_XIAOBLE_NRF52840_SENSE",
+        "FASTLED_USE_COMPILE_TESTS=0",
+    ],
+    board_build_core="nRF5",
 )
 
 # Alias: handle common misspelling without the trailing 't'
 XIAOBLESENSE_ADAFRUI_ALIAS = Board(
     board_name="xiaoblesense_adafrui",  # missing 't'
-    real_board_name="xiaoblesense_adafruit",  # map to the correct board name
-    platform="https://github.com/maxgerhardt/platform-nordicnrf52",
-    platform_needs_install=True,
+    real_board_name="nrf52840_dk_adafruit",
+    platform="nordicnrf52",
+    framework="arduino",
+    platform_packages="framework-arduinoadafruitnrf52@^1.10601.0",
+    defines=[
+        "TARGET_XIAOBLE_NRF52840_SENSE",
+        "FASTLED_USE_COMPILE_TESTS=0",
+    ],
+    board_build_core="nRF5",
 )
 
 XIAOBLESENSE_NRF52 = Board(

--- a/src/platforms/arm/nrf52/fastpin_arm_nrf52_variants.h
+++ b/src/platforms/arm/nrf52/fastpin_arm_nrf52_variants.h
@@ -827,7 +827,12 @@
 #endif // defined(ARDUINO_STCT_NRF52_minidev)
 
 
-#if defined(ARDUINO_Seeed_XIAO_nRF52840_Sense)
+// Seeed XIAO BLE Sense — the BSP variant.h normally defines
+// ARDUINO_Seeed_XIAO_nRF52840_Sense.  For CI builds that reuse the
+// Adafruit nrf52840_dk_adafruit BSP variant (see #2634), the TARGET
+// define carries the same pin mapping without requiring the Seeed variant
+// folder to be present in the framework package.
+#if defined(ARDUINO_Seeed_XIAO_nRF52840_Sense) || defined(TARGET_XIAOBLE_NRF52840_SENSE)
     #if defined(__FASTPIN_ARM_NRF52_VARIANT_FOUND)
         #error "Cannot define more than one board at a time"
     #else


### PR DESCRIPTION
## Summary

Unblock CI job `build_xiaoblesense_adafruit` (and its `adafruit_xiaoblesense` workflow). The board was using `https://github.com/maxgerhardt/platform-nordicnrf52`, whose `xiaoblesense_adafruit` board JSON references a `build.variant` directory that the Adafruit nRF52 BSP at 1.10601.0 doesn't ship.

- Switch `XIAOBLESENSE_ADAFRUIT_NRF52` (and its typo-alias) to the stock `nordicnrf52` platform with `framework-arduinoadafruitnrf52@^1.10601.0` and `real_board_name="nrf52840_dk_adafruit"` — a board JSON whose variant actually exists in the framework package.
- Add `TARGET_XIAOBLE_NRF52840_SENSE` define so the existing Seeed XIAO BLE Sense fastpin variant block in `src/platforms/arm/nrf52/fastpin_arm_nrf52_variants.h` fires regardless of which BSP variant directory provided `Arduino.h` — keeping the FastLED-side pin mapping correct for the actual XIAO physical layout.

Same shape as the SuperMini / nice!nano / nRFMicro fixes from #2422 / commit 1a62b13b8.

Closes #2634.

## Failing run before fix

https://github.com/FastLED/FastLED/actions/runs/26698725759/job/78687852124 — `delay.h:28:10: fatal error: variant.h: No such file or directory`.

## Test plan

- [ ] `bash compile xiaoblesense_adafruit --examples Blink` succeeds on Linux CI (Windows local hits a separate Adafruit BSP `ARDUINO_BSP_VERSION` quote-stripping bug in fbuild — out of scope here, affects all Adafruit-BSP nRF52 boards on Windows).
- [ ] `build_xiaoblesense_adafruit` and `adafruit_xiaoblesense` workflows go green.
- [ ] Existing `ARDUINO_Seeed_XIAO_nRF52840_Sense`-keyed variant block continues to work unchanged for users compiling against a BSP that ships the Seeed variant directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Seeed XIAO BLE Sense board configuration for improved build system compatibility
  * Strengthened pin mapping support for Seeed XIAO nRF52840 Sense microcontroller boards

<!-- end of auto-generated comment: release notes by coderabbit.ai -->