### PR TITLE
fix(nrf52): defer PCA10056 pin map for TARGET_XIAOBLE_NRF52840_SENSE

### DIFF
--- a/src/platforms/arm/nrf52/fastpin_arm_nrf52_variants.h
+++ b/src/platforms/arm/nrf52/fastpin_arm_nrf52_variants.h
@@ -15,9 +15,10 @@
 // to the OR-chain when introducing new community-board variants. See #2422
 // for the original report and #2626 for the redefinition bug.
 #undef __FASTLED_NRF52_USER_TARGET_OVERRIDE
-#if defined(TARGET_SUPERMINI_NRF52840) || \
-    defined(TARGET_NICE_NANO_V2)      || \
-    defined(TARGET_NRFMICRO)
+#if defined(TARGET_SUPERMINI_NRF52840)    || \
+    defined(TARGET_NICE_NANO_V2)          || \
+    defined(TARGET_NRFMICRO)              || \
+    defined(TARGET_XIAOBLE_NRF52840_SENSE)
     #define __FASTLED_NRF52_USER_TARGET_OVERRIDE
 #endif
 


### PR DESCRIPTION
## Summary

Follow-up to #2636. The xiaoblesense_adafruit board now reuses the `nrf52840_dk_adafruit` BSP variant (which defines `ARDUINO_NRF52840_PCA10056`). The post-merge master build [26700041082](https://github.com/FastLED/FastLED/actions/runs/26700041082) failed with:

\`\`\`
fastpin_arm_nrf52_variants.h:857:10: error: #error "Cannot define more than one board at a time"
fastpin_arm_nrf52_variants.h:48:26: error: redefinition of 'class fl::FastPin<0>'
... (and ~30 more redefinitions)
\`\`\`

Both the PCA10056 variant block and the new TARGET_XIAOBLE block were firing.

Same shape as PR #2627 (which fixed the same collision for SuperMini / nice!nano / nRFMicro). Add `TARGET_XIAOBLE_NRF52840_SENSE` to the `__FASTLED_NRF52_USER_TARGET_OVERRIDE` OR-chain so the PCA10056 block stands down when the XIAO target is set.

Closes the regression introduced by #2636.

## Test plan

- [ ] `build_xiaoblesense_adafruit` job on master is green after merge
- [ ] `adafruit_xiaoblesense` workflow on master is green after merge
- [ ] Existing SuperMini / nice!nano / nRFMicro builds remain green (no semantic change to their guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for XIAOBLE NRF52840 Sense hardware platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->