### PR TITLE
ci(qemu): install libsdl2-2.0-0 on runner so Espressif QEMU can load (fixes #2639)

### DIFF
--- a/.github/workflows/qemu_docker_template.yml
+++ b/.github/workflows/qemu_docker_template.yml
@@ -42,6 +42,15 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Install QEMU runtime libraries (libSDL2)
+        # The Espressif QEMU binary that fbuild auto-downloads is dynamically
+        # linked against libSDL2-2.0.so.0. ubuntu-latest runners don't ship it,
+        # so QEMU dies with exit 127 (dynamic-linker failure) before any
+        # `-display`/`-nographic` flag can take effect. See FastLED #2639.
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y --no-install-recommends libsdl2-2.0-0
+
       - name: Pin python version
         run: echo "3.11" > .python-version
 


### PR DESCRIPTION
﻿## Summary
- Adds a single `apt-get install -y libsdl2-2.0-0` step to the shared QEMU template `qemu_docker_template.yml`.
- Unblocks all three currently-red ESP32 QEMU workflows (esp32c3, esp32dev, esp32s3) which share this template via `uses:`.

## Root cause
The Espressif QEMU binary that fbuild auto-downloads is dynamically linked against `libSDL2-2.0.so.0`. `ubuntu-latest` doesn't ship that lib by default, so QEMU dies with exit 127 (dynamic-loader failure) before it can process any `-display none` / `-nographic` flag — i.e. the runtime fix has to be at the OS-package level, not the QEMU CLI level.

```
qemu-system-riscv32: error while loading shared libraries:
  libSDL2-2.0.so.0: cannot open shared object file: No such file
QEMU ESP32C3 test-emu failed: failed: QEMU exited with code 127
```

## Why not in fbuild?
fbuild *could* statically link or vendor SDL2 next to the binary, but that requires re-rolling the Espressif QEMU release (or adding a post-extract step) — slow and upstream-driven. On developer machines SDL2 is normally present (Homebrew / MSYS2 / distro). CI runners are the odd one out; a single apt step is the right scope.

## Test plan
- [ ] All three ESP32 QEMU workflows go green on this PR's CI (esp32c3 / esp32dev / esp32s3 — both `Test` and `BlinkParallel` sketch variants).
- [ ] Post-merge, master CI shows the same three workflows green.

Fixes #2639

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by ensuring required runtime dependencies are properly installed in the test environment, preventing execution failures in QEMU-based tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->