### PR TITLE
ci(nrf52): disable LTO on xiaoblesense_adafruit to dodge arm-gnu 15.2 LTO bug

### DIFF
--- a/ci/boards.py
+++ b/ci/boards.py
@@ -868,6 +868,11 @@ XIAOBLESENSE_ADAFRUIT_NRF52 = Board(
         "TARGET_XIAOBLE_NRF52840_SENSE",
         "FASTLED_USE_COMPILE_TESTS=0",
     ],
+    # CI-unblock for #2641: arm-gnu 15.2.rel1 + Adafruit nRF52 BSP + LTO
+    # produces thousands of "offset out of range" assembler errors in the
+    # LTO-temp output. Disable LTO until the toolchain interaction is fixed.
+    build_unflags=["-flto"],
+    build_flags=["-fno-lto"],
     board_build_core="nRF5",
 )
 
@@ -882,6 +887,9 @@ XIAOBLESENSE_ADAFRUI_ALIAS = Board(
         "TARGET_XIAOBLE_NRF52840_SENSE",
         "FASTLED_USE_COMPILE_TESTS=0",
     ],
+    # See #2641 — LTO disabled to dodge arm-gnu 15.2.rel1 offset-overflow bug.
+    build_unflags=["-flto"],
+    build_flags=["-fno-lto"],
     board_build_core="nRF5",
 )
 


### PR DESCRIPTION
## Summary

CI-unblock for xiaoblesense_adafruit. After #2636 (variant.h) and #2638 (PCA10056 guard) shipped, the post-merge build still failed — but on a different, pre-existing toolchain bug: arm-gnu 15.2.rel1 + Adafruit nRF52 BSP + LTO emits thousands of "offset out of range" assembler errors in LTO-temp output (see [run 26700353292](https://github.com/FastLED/FastLED/actions/runs/26700353292/job/78692051129)).

This bug affects `supermini_nrf52840` and presumably the other nRF52840 Adafruit-BSP boards too. Filed as #2641 for the proper toolchain investigation.

Workaround: add `build_unflags=["-flto"]` + `build_flags=["-fno-lto"]` to `XIAOBLESENSE_ADAFRUIT_NRF52` and the typo-alias entry in `ci/boards.py`. CI goes green now; #2641 tracks the toolchain root cause and broader rollout of the workaround.

Refs #2634, #2636, #2638. Partial #2641.

## Test plan

- [ ] `build_xiaoblesense_adafruit` job on master is green post-merge
- [ ] `adafruit_xiaoblesense` workflow on master is green post-merge
- [ ] Other nRF52840 boards continue at their current state (this PR doesn't touch them)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration for nRF52 boards (XIAOBLESENSE_ADAFRUIT_NRF52 and XIAOBLESENSE_ADAFRUI_ALIAS) with modified compiler settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->