### PR TITLE
fix(nrf52): unbreak xiaoblesense (no-suffix) — variant.h not found (fixes #2643)

### DIFF
--- a/.github/workflows/build_nrf52_xiaoblesense.yml
+++ b/.github/workflows/build_nrf52_xiaoblesense.yml
@@ -5,6 +5,7 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - master

--- a/ci/boards.py
+++ b/ci/boards.py
@@ -895,9 +895,26 @@ XIAOBLESENSE_ADAFRUI_ALIAS = Board(
 
 XIAOBLESENSE_NRF52 = Board(
     board_name="xiaoblesense",
-    real_board_name="xiaoble_adafruit",
-    platform="https://github.com/maxgerhardt/platform-nordicnrf52",
-    platform_needs_install=True,
+    # Mirror the XIAOBLESENSE_ADAFRUIT_NRF52 fix from #2634 / #2636 — the
+    # maxgerhardt platform's `xiaoble_adafruit` board JSON points build.variant
+    # at a variant directory that doesn't exist in Adafruit BSP 1.10601.0, so
+    # the Adafruit core's `#include "variant.h"` fails. Reuse the stock
+    # `nrf52840_dk_adafruit` variant (which IS shipped) and let
+    # TARGET_XIAOBLE_NRF52840_SENSE route through the existing Seeed XIAO BLE
+    # Sense fastpin variant block. See FastLED #2643.
+    real_board_name="nrf52840_dk_adafruit",
+    platform="nordicnrf52",
+    framework="arduino",
+    platform_packages="framework-arduinoadafruitnrf52@^1.10601.0",
+    defines=[
+        "TARGET_XIAOBLE_NRF52840_SENSE",
+        "FASTLED_USE_COMPILE_TESTS=0",
+    ],
+    # Same arm-gnu 15.2.rel1 LTO offset-overflow workaround as the sister
+    # boards (see #2641).
+    build_unflags=["-flto"],
+    build_flags=["-fno-lto"],
+    board_build_core="nRF5",
 )
 
 # Correct nRF52840 DK board definition


### PR DESCRIPTION
﻿## Summary
- Apply PR #2636's fix shape to the sister `xiaoblesense` board (no `_adafruit` suffix).
- Routes through the stock Adafruit BSP 1.10601.0 + `nrf52840_dk_adafruit` variant + `TARGET_XIAOBLE_NRF52840_SENSE` define, same as the merged sister.
- Carries the matching arm-gnu 15.2.rel1 LTO workaround from PR #2642.

## Root cause
`XIAOBLESENSE_NRF52` in `ci/boards.py` still pointed at the maxgerhardt nordicnrf52 platform with `real_board_name="xiaoble_adafruit"`. Adafruit BSP 1.10601.0 ships no `variants/xiaoble_adafruit/` directory, so the Adafruit core's `#include "variant.h"` (from `Uart.h`, `delay.h`) fails on every example.

```
cores/nRF5/Uart.h:27:10: fatal error: variant.h: No such file or directory
cores/nRF5/delay.h:28:10: fatal error: variant.h: No such file or directory
```

Failing run: [26700353359](https://github.com/FastLED/FastLED/actions/runs/26700353359) on master @ `1d9a638`.

## Fix
Mirror `XIAOBLESENSE_ADAFRUIT_NRF52` (PR #2636): point `real_board_name` at the shipped `nrf52840_dk_adafruit` variant, set the BSP package + framework, add `TARGET_XIAOBLE_NRF52840_SENSE` for the existing FastLED fastpin variant block, and include the same `-fno-lto` LTO workaround from PR #2642.

No FastLED source changes needed — the fastpin variant block is already in place from PR #2636 / #2638.

## Test plan
- [ ] Linux CI: `nrf52_xiaoblesense` workflow goes green post-merge.
- [ ] (Windows local hits the same separate Adafruit BSP `ARDUINO_BSP_VERSION` quote-stripping fbuild bug noted in PR #2636 — out of scope here, affects all Adafruit-BSP nRF52 boards on Windows.)

Fixes #2643

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added manual workflow dispatch capability for nRF52 Xiaoblesense builds.
  * Updated nRF52 Xiaoblesense board configuration with platform package updates and compiler compatibility adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->