### PR TITLE
ci(avr8js): restart fbuild daemon + cap step at 8 min (fixes #2645)

### DIFF
--- a/.github/workflows/avr8js_docker_template.yml
+++ b/.github/workflows/avr8js_docker_template.yml
@@ -89,11 +89,24 @@ jobs:
         # --halt-on-error catches panics and avr-libc aborts early.
         # --expect asserts setup() actually ran before we declared success.
         # Output is tee'd into avr8js_output.log for artifact upload.
+        #
+        # Daemon restart + step timeout — FastLED#2645. After ci-compile.py
+        # invokes `fbuild build`, the daemon is left in whatever state the
+        # build ended in; on the avr8js path that state has been making
+        # `/api/test-emu` requests hang for 30 minutes before a
+        # connection-idle error. Restarting brings up a fresh daemon for
+        # the avr8js request, and the step-level timeout caps the bleed
+        # while the upstream fbuild bug is being chased.
+        timeout-minutes: 8
         run: |
           set -o pipefail
           uv run ci/ci-compile.py ${{ inputs.platform }} \
             --examples ${{ inputs.sketch }} \
             --verbose
+          echo "::group::fbuild daemon restart (FastLED#2645)"
+          uv run fbuild daemon restart || true
+          uv run fbuild daemon status || true
+          echo "::endgroup::"
           uv run fbuild test-emu \
             --emulator avr8js \
             --environment ${{ inputs.platform }} \
@@ -102,6 +115,20 @@ jobs:
             --halt-on-error "PANIC|ABORT|assert" \
             --expect "Test setup starting" \
             .build/pio/${{ inputs.platform }} 2>&1 | tee avr8js_output.log
+        shell: bash
+
+      - name: Dump fbuild daemon diagnostics on failure
+        # If test-emu hangs/fails, capture the daemon's view of the world
+        # so the next debugging cycle has real evidence (FastLED#2645).
+        if: failure() && steps.test_emu.conclusion == 'failure'
+        run: |
+          {
+            echo "=== fbuild daemon status ==="
+            uv run fbuild daemon status || true
+            echo
+            echo "=== fbuild daemon log tail ==="
+            uv run fbuild show daemon --lines 200 || true
+          } | tee -a avr8js_output.log
         shell: bash
 
       - name: Display emulator output


### PR DESCRIPTION
## Summary

- After `ci-compile.py` invokes `fbuild build`, the daemon is left in whatever state the build ended in. On the avr8js path that state has been making `/api/test-emu` hang silently for 30 minutes before failing with `daemon error: request failed: error sending request for url (http://127.0.0.1:8765/api/test-emu)`. Restart the daemon between `ci-compile.py` and `fbuild test-emu` to start the avr8js request from a known-clean daemon.
- Add `timeout-minutes: 8` so the step fails fast instead of burning a 30 min runner minute floor per push.
- On failure, dump `fbuild daemon status` and tail the daemon log into the existing `avr8js_output.log` artifact so the next iteration has real evidence (today's failures upload a single 104-byte error line).

Closes #2645. Refs FastLED/fbuild#291, #292, #130.

## Scope

- **Only** `.github/workflows/avr8js_docker_template.yml` is touched. The QEMU templates use the same `fbuild test-emu` pipeline but are green today (run 26700714508) — leave them alone to avoid regression risk.

## Test plan

- [ ] `uno_avr8js_test` workflow goes green on this PR (or, if the daemon-restart doesn't unblock the upstream hang, fails inside 8 min with daemon-status + daemon-log evidence attached for the next iteration).
- [ ] No QEMU workflows touched / regressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced test automation workflow with added timeout protection for emulator tests.
  * Improved diagnostic logging to capture daemon status and logs when emulator tests fail, aiding troubleshooting efforts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->