### PR TITLE
fix(esp32-s3): LCD_CLOCKLESS chunk-ISR IRAM/ISR-safety + equal-chunk (#2647 WIP)

### DIFF
--- a/examples/AutoResearch/AutoResearchRemote.cpp
+++ b/examples/AutoResearch/AutoResearchRemote.cpp
@@ -159,10 +159,10 @@ fl::json AutoResearchRemoteControl::runSingleTestImpl(const fl::json& args) {
     }
 
     fl::json lane_sizes_json = config["laneSizes"];
-    if (lane_sizes_json.size() == 0 || lane_sizes_json.size() > 8) {
+    if (lane_sizes_json.size() == 0 || lane_sizes_json.size() > 16) {
         response.set("success", false);
         response.set("error", "InvalidLaneCount");
-        response.set("message", "laneSizes must have 1-8 elements");
+        response.set("message", "laneSizes must have 1-16 elements");
         return response;
     }
 

--- a/src/platforms/esp/32/drivers/lcd_spi/channel_driver_lcd_clockless.cpp.hpp
+++ b/src/platforms/esp/32/drivers/lcd_spi/channel_driver_lcd_clockless.cpp.hpp
@@ -191,7 +191,10 @@ IChannelDriver::DriverState ChannelDriverLcdClockless::poll() FL_NOEXCEPT {
 // Encoding — wave3 or wave8 transpose into u16 DMA words
 //=============================================================================
 
-size_t ChannelDriverLcdClockless::encodeChunk(
+// FL_IRAM matches the declaration in channel_driver_lcd_clockless.h — this
+// function is invoked from isrChunkDone() and MUST live in IRAM so it can
+// execute while flash cache is suspended (NVS, SPI flash ops).
+size_t FL_IRAM ChannelDriverLcdClockless::encodeChunk(
     fl::span<const ChannelDataPtr> channels, u16 *output,
     size_t startByte, size_t byteCount) FL_NOEXCEPT {
     size_t outputIdx = 0; // bytes written
@@ -238,7 +241,13 @@ size_t ChannelDriverLcdClockless::encodeChunk(
 // ISR Callback
 //=============================================================================
 
-bool ChannelDriverLcdClockless::isrChunkDone(void *panel_io,
+// FL_IRAM matches the declaration in channel_driver_lcd_clockless.h — this
+// callback runs in ISR context and MUST live in IRAM so it can execute while
+// flash cache is suspended. Without it, a concurrent flash operation (NVS
+// commit, esp_flash_erase_region, etc.) keeps the ISR stalled past the 300 ms
+// interrupt watchdog window and the device panics with "Interrupt wdt timeout
+// on CPU1" in ISR context.
+bool FL_IRAM ChannelDriverLcdClockless::isrChunkDone(void *panel_io,
                                               const void *edata,
                                               void *user_ctx) FL_NOEXCEPT {
     (void)panel_io;
@@ -465,7 +474,11 @@ fl::shared_ptr<IChannelDriver> createLcdClocklessEngine() FL_NOEXCEPT {
         void freeBuffer(u16 *b) FL_NOEXCEPT override {
             detail::LcdSpiPeripheralEsp::instance().freeBuffer(b);
         }
-        bool transmit(const u16 *b, size_t s) FL_NOEXCEPT override {
+        // FL_IRAM: forwarded into LcdSpiPeripheralEsp::transmit() from
+        // isrChunkDone (ISR context). The thunk must live in IRAM too —
+        // marking only the target is not enough because the vtable dispatch
+        // jumps here first.
+        bool FL_IRAM transmit(const u16 *b, size_t s) FL_NOEXCEPT override {
             return detail::LcdSpiPeripheralEsp::instance().transmit(b, s);
         }
         bool waitTransmitDone(u32 t) FL_NOEXCEPT override {

--- a/src/platforms/esp/32/drivers/lcd_spi/channel_driver_lcd_clockless.cpp.hpp
+++ b/src/platforms/esp/32/drivers/lcd_spi/channel_driver_lcd_clockless.cpp.hpp
@@ -347,11 +347,41 @@ bool ChannelDriverLcdClockless::beginTransmission(
         mOutputBytesPerInputByte = 16 * sizeof(Wave8Byte); // 128
     }
 
-    // Chunk sizing
-    size_t chunkInputBytes =
+    // Chunk sizing.
+    //
+    // The LCD I80 peripheral wrapper (LcdSpiPeripheralEsp::transmit) tears
+    // down and recreates the ESP-IDF panel_io handle whenever the
+    // transaction size changes — its GDMA descriptor chain is sized per
+    // transaction. The teardown calls esp_lcd_panel_io_del, which lives in
+    // flash; performing it from isrChunkDone (ISR context) deadlocks the
+    // chip with "Interrupt wdt timeout on CPU1" if any concurrent flash
+    // op has suspended the cache. To keep every ISR-driven transmit at the
+    // same size, we round the requested chunk size up so chunkInputBytes
+    // evenly divides maxSize — the resulting (slightly larger) chunks all
+    // carry the same DMA byte count.
+    size_t requestedChunkInputBytes =
         mChunkInputBytesOverride > 0 ? mChunkInputBytesOverride
                                      : kDefaultChunkInputBytes;
-    if (chunkInputBytes > maxSize) {
+    if (requestedChunkInputBytes > maxSize) {
+        requestedChunkInputBytes = maxSize;
+    }
+
+    // Pick numChunks so chunkInputBytes = maxSize / numChunks is exact (the
+    // remainder must be 0). Walk numChunks upward from
+    // ceil(maxSize / requested) until we hit a divisor; in the worst case we
+    // fall back to numChunks = maxSize (single-byte chunks). For typical LED
+    // counts (powers of two × 3 bytes per RGB pixel) the loop terminates in
+    // a couple of iterations.
+    size_t numChunks =
+        (maxSize + requestedChunkInputBytes - 1) / requestedChunkInputBytes;
+    if (numChunks == 0) {
+        numChunks = 1;
+    }
+    while (numChunks < maxSize && (maxSize % numChunks) != 0) {
+        ++numChunks;
+    }
+    size_t chunkInputBytes = maxSize / numChunks;
+    if (chunkInputBytes == 0) {
         chunkInputBytes = maxSize;
     }
 

--- a/src/platforms/esp/32/drivers/lcd_spi/channel_driver_lcd_clockless.h
+++ b/src/platforms/esp/32/drivers/lcd_spi/channel_driver_lcd_clockless.h
@@ -91,7 +91,11 @@ class ChannelDriverLcdClockless : public IChannelDriver {
     /// @param startByte First source byte index
     /// @param byteCount Number of source bytes to encode
     /// @return Number of DMA bytes written
-    size_t encodeChunk(fl::span<const ChannelDataPtr> channels,
+    ///
+    /// ⚠️ HOT PATH — called from ISR context. MUST live in IRAM so it can
+    /// execute while flash cache is suspended (NVS writes, SPI flash erase,
+    /// etc.). Without FL_IRAM the ISR stalls and the interrupt watchdog trips.
+    size_t FL_IRAM encodeChunk(fl::span<const ChannelDataPtr> channels,
                        u16 *output, size_t startByte,
                        size_t byteCount) FL_NOEXCEPT;
 
@@ -102,7 +106,13 @@ class ChannelDriverLcdClockless : public IChannelDriver {
     // ISR callback
     //=========================================================================
 
-    static bool isrChunkDone(void *panel_io, const void *edata,
+    /// @brief ISR callback invoked by LCD I80 peripheral on chunk transmit done
+    /// ⚠️ ISR CONTEXT — MUST be in IRAM. Without FL_IRAM the callback's code
+    /// lives in flash; when flash cache is suspended (NVS commit, SPI flash
+    /// erase, etc.) the ISR cannot execute, interrupts stay disabled past the
+    /// 300 ms interrupt watchdog window, and the device panics with "Interrupt
+    /// wdt timeout on CPU1" in ISR context.
+    static bool FL_IRAM isrChunkDone(void *panel_io, const void *edata,
                              void *user_ctx) FL_NOEXCEPT;
 
     //=========================================================================

--- a/src/platforms/esp/32/drivers/lcd_spi/channel_driver_lcd_clockless.h
+++ b/src/platforms/esp/32/drivers/lcd_spi/channel_driver_lcd_clockless.h
@@ -71,10 +71,14 @@ class ChannelDriverLcdClockless : public IChannelDriver {
 
     static constexpr size_t kRingBufferCount = 3;
 
-    /// Default: ~30 LEDs per chunk for clockless (3 bytes/LED).
-    /// wave3: 90 bytes * 48 = 4.3KB per DMA slot → 13KB total ring.
-    /// wave8: 90 bytes * 128 = 11.5KB per DMA slot → 34.5KB total ring.
-    static constexpr size_t kDefaultChunkInputBytes = 90;
+    /// Default: 1024 bytes per chunk for clockless (3 bytes/LED ≈ 341 LEDs).
+    ///
+    /// The chunked-streaming ISR re-arm path currently emits garbled data
+    /// past the first chunk (#2647 follow-up). Until that is fixed, pick a
+    /// chunk size big enough that a typical RGB frame fits in one chunk so
+    /// the ISR re-arm path is never taken. Worst-case memory for
+    /// 16-lane wave8: 1024 × 128 × 3 buffers = 384 KB in PSRAM.
+    static constexpr size_t kDefaultChunkInputBytes = 1024;
 
     /// Override chunk input bytes for testing (0 = use default).
     void setChunkInputBytesForTest(size_t bytes) FL_NOEXCEPT {

--- a/src/platforms/esp/32/drivers/lcd_spi/lcd_spi_peripheral_esp.cpp.hpp
+++ b/src/platforms/esp/32/drivers/lcd_spi/lcd_spi_peripheral_esp.cpp.hpp
@@ -294,7 +294,7 @@ void LcdSpiPeripheralEsp::freeBuffer(u16 *buffer) FL_NOEXCEPT {
 // Transmission
 //=============================================================================
 
-bool LcdSpiPeripheralEsp::transmit(const u16 *buffer,
+bool FL_IRAM LcdSpiPeripheralEsp::transmit(const u16 *buffer,
                                    size_t size_bytes) FL_NOEXCEPT {
     if (!mInitialized || mI80Bus == nullptr) {
         return false;
@@ -302,15 +302,34 @@ bool LcdSpiPeripheralEsp::transmit(const u16 *buffer,
 
     // Block until previous DMA is truly complete. The semaphore is
     // primed during initialize() so the first call returns immediately.
-    // This is stronger than the old non-blocking drain — it guarantees
-    // the I80 bus has fully processed the previous transaction before
-    // we submit a new one.
+    //
+    // ISR safety: when ChannelDriverLcdClockless::isrChunkDone re-arms the
+    // next chunk from the on_color_trans_done callback, transmit() runs in
+    // interrupt context. lcd_spi_flush_ready() already did xSemaphoreGiveFromISR
+    // *before* invoking our user callback, so the take is guaranteed to be
+    // non-blocking — but we MUST use the FromISR variant because the regular
+    // xSemaphoreTake() asserts (configASSERT) when called from ISR.
     if (mCompleteSem) {
-        if (xSemaphoreTake(mCompleteSem, pdMS_TO_TICKS(2000)) != pdTRUE) {
-            FL_WARN("LcdSpiPeripheralEsp: Timed out waiting for previous "
-                    "transmit to complete");
-            mBusy = false;
-            return false;
+        if (xPortInIsrContext()) {
+            BaseType_t hpw = pdFALSE;
+            if (xSemaphoreTakeFromISR(mCompleteSem, &hpw) != pdTRUE) {
+                // Semaphore should always be available here because
+                // lcd_spi_flush_ready already gave it before invoking our
+                // callback. If not, abort the re-arm — the next CPU-side
+                // transmit() will pick up where we left off.
+                mBusy = false;
+                return false;
+            }
+            if (hpw) {
+                portYIELD_FROM_ISR();
+            }
+        } else {
+            if (xSemaphoreTake(mCompleteSem, pdMS_TO_TICKS(2000)) != pdTRUE) {
+                FL_WARN("LcdSpiPeripheralEsp: Timed out waiting for previous "
+                        "transmit to complete");
+                mBusy = false;
+                return false;
+            }
         }
     }
 

--- a/src/platforms/esp/32/drivers/lcd_spi/lcd_spi_peripheral_esp.cpp.hpp
+++ b/src/platforms/esp/32/drivers/lcd_spi/lcd_spi_peripheral_esp.cpp.hpp
@@ -349,7 +349,13 @@ bool FL_IRAM LcdSpiPeripheralEsp::transmit(const u16 *buffer,
         esp_lcd_panel_io_i80_config_t io_config = {};
         io_config.cs_gpio_num = GPIO_NUM_NC;
         io_config.pclk_hz = mConfig.clock_hz;
-        io_config.trans_queue_depth = 1;
+        // trans_queue_depth=2: ChannelDriverLcdClockless::isrChunkDone calls
+        // back into tx_color() from on_color_trans_done. With depth=1 the
+        // currently-running transaction has not been retired from the I80
+        // queue yet, so the re-arm blocks waiting for a queue slot — from
+        // ISR context — and trips the interrupt watchdog. Depth=2 leaves
+        // a free slot for the ISR-driven re-arm.
+        io_config.trans_queue_depth = 2;
         io_config.dc_levels = {
             .dc_idle_level = 0,
             .dc_cmd_level = 0,

--- a/src/platforms/esp/32/drivers/lcd_spi/lcd_spi_peripheral_esp.h
+++ b/src/platforms/esp/32/drivers/lcd_spi/lcd_spi_peripheral_esp.h
@@ -14,8 +14,8 @@
 #if defined(FL_IS_ESP_32S3) && FL_HAS_INCLUDE("esp_lcd_panel_io.h")
 
 #include "platforms/esp/32/drivers/lcd_spi/ilcd_spi_peripheral.h"
+#include "fl/stl/compiler_control.h"  // FL_IRAM, FL_EXTERN_C_BEGIN
 #include "fl/stl/noexcept.h"
-#include "fl/stl/compiler_control.h"
 #include "esp_lcd_panel_io.h"
 
 FL_EXTERN_C_BEGIN
@@ -51,7 +51,10 @@ class LcdSpiPeripheralEsp : public ILcdSpiPeripheral {
     u16 *allocateBuffer(size_t size_bytes) FL_NOEXCEPT override;
     void freeBuffer(u16 *buffer) FL_NOEXCEPT override;
 
-    bool transmit(const u16 *buffer, size_t size_bytes) FL_NOEXCEPT override;
+    // FL_IRAM: ChannelDriverLcdClockless::isrChunkDone re-arms the next
+    // chunk from ISR context, so transmit() must be IRAM-resident to survive
+    // a flash-cache stall (NVS commit, SPI flash erase, etc.).
+    bool FL_IRAM transmit(const u16 *buffer, size_t size_bytes) FL_NOEXCEPT override;
     bool waitTransmitDone(u32 timeout_ms) FL_NOEXCEPT override;
     bool isBusy() const FL_NOEXCEPT override;
 


### PR DESCRIPTION
## Summary

Defense-in-depth fixes plus a chunk-sizing workaround for the LCD_CLOCKLESS ISR-driven chunked DMA path discussed in #2647. With this PR the typical-frame case (RGB frames that fit in a single DMA chunk) now passes the autoresearch RX-loopback matrix on a XIAO ESP32-S3; the multi-chunk corruption (chunks 2..N of an ISR-driven stream) is tracked separately as a #2647 follow-up.

## Commits

- `7bfb1bb53f` — `fix(esp32-s3): make LCD_CLOCKLESS chunk-ISR path IRAM/ISR-safe`
  - Mark `isrChunkDone`, `encodeChunk`, `LcdSpiPeripheralEsp::transmit`, and the `EspWrapper::transmit` thunk `FL_IRAM` (matches the PARLIO `workerIsrCallback` convention).
  - Route `LcdSpiPeripheralEsp::transmit`'s completion-semaphore take through `xSemaphoreTakeFromISR` when `xPortInIsrContext()`, keeping the existing 2 s blocking take on the task path.
  - Bump `runSingleTest`'s `laneSizes` upper bound 8 → 16 so autoresearch can exercise the full LCD_CAM 16-bit bus.
- `821fd8919a` — `fix(esp32-s3): force LCD_CLOCKLESS chunks to equal DMA size`
  - Pick `numChunks` so `maxSize / numChunks` is exact, preventing the variable-size last chunk that forces an ISR-time `esp_lcd_panel_io_del` + `esp_lcd_new_panel_io_i80` round-trip.
- `eb59d1b491` — `fix(esp32-s3): bump LCD I80 trans_queue_depth 1 → 2 (#2647 IWDT fix)`
  - With `trans_queue_depth=1` the ISR-driven re-arm in `isrChunkDone` blocked waiting for a free queue slot — from ISR context — and tripped the 300 ms watchdog. Depth = 2 leaves room for the re-arm.
- `8d791ad125` — `fix(esp32-s3): default LCD_CLOCKLESS chunk to 1024 B (workaround for #2647 corruption)`
  - Bump `kDefaultChunkInputBytes` 90 → 1024 so a typical RGB frame (≤ 341 LEDs/lane) fits in one DMA chunk and the still-broken ISR re-arm path is never exercised. Worst-case ring-buffer PSRAM for 16-lane wave8: 1024 × 128 × 3 = 384 KB (XIAO ESP32-S3 has 8 MB PSRAM).

## Status

- Builds clean for `esp32s3`; CI green for all configured platforms.
- Hardware-verified on Seeed XIAO ESP32-S3 (GPIO 1 → GPIO 2 jumper):
  ```
  bash autoresearch esp32s3 --lcd --upload-port COM<x> --lanes 16 --strip-sizes 256 --skip-lint
  TEST LCD_CLOCKLESS lanes=16 leds=4096 PASS 1694ms
  Tests: 4/4 passed
  ```
- Known limitation (tracked as a #2647 follow-up): the chunked-streaming ISR re-arm path still emits 87–92 % corrupted bytes for chunks 2..N when a frame is split across multiple DMA chunks. The 1024 B default keeps typical RGB frames inside a single chunk; users running very long strips on many lanes that would force multi-chunk streaming should track that follow-up rather than relying on this driver path.

## Test plan

- [x] Hardware: `bash autoresearch esp32s3 --lcd --upload-port COM<x> --lanes 16 --strip-sizes 256 --skip-lint` completes with `TEST_COMPLETED_EXIT_OK` — verified.
- [x] Host: `tests/platforms/esp/32/drivers/lcd_spi/channel_driver_lcd_clockless.cpp` mocks keep passing (CI: unit tests linux ✓).
- [ ] No regression in `--lanes 1..8 --strip-sizes 100,300` (smaller, previously-tested matrix) — recommended sanity check; not run in this PR but the kDefaultChunkInputBytes bump to 1024 only enlarges the single-chunk regime, so smaller frames remain in single-chunk mode and should be unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
