### PR TITLE
chore(deps): bump fbuild 2.2.11 -> 2.2.12 for nrf52 alias fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,17 +5,19 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    # Pin to fbuild 2.2.11 — content of 2.2.10 republished with the full
-    # wheel set (win_amd64 + manylinux_x86_64 were missing from 2.2.10's
-    # PyPI upload). Bundles SAMD51 `cores/arduino` fallback + include-path
-    # injection (FastLED/fbuild#319/#320), nRF52 nRF52DK->pca10056 variant
-    # alias (FastLED/fbuild#321/#322), board JSON tinyuf2 partition rename
-    # + cmsis_dsp_lib validator whitelist (FastLED/fbuild#318), and
-    # daemon.rs subprocess-spawn lint annotations (FastLED/fbuild#317).
-    # Together these unblock Build SAMD51J, Build nRF52840 DK, and reduce
-    # Validate Boards drift from 39 boards to 14 (configuration-choice
-    # remainder pending maintainer review).
-    "fbuild==2.2.11",
+    # Pin to fbuild 2.2.12 — adds the nRF52 variant include-path alias
+    # (FastLED/fbuild#325/#326), MCU-aware linker-script alias for the
+    # PIO-named nrf52_xxaa.ld with globbed highest-version SoftDevice
+    # script (FastLED/fbuild#327/#328 — also fingerprints the resolved
+    # linker basename into Nrf52FingerprintMetadata so fast-path keys
+    # invalidate when the alias moves between actual files), and a
+    # release-auto CI fix bypassing soldr's corrupted cargo-zigbuild
+    # bin cache (FastLED/fbuild#331/#332). Together these unblock
+    # Build nRF52840 DK and Build nRF52 XIAO BLE Sense workflows by
+    # making fbuild find `variants/pca10056/` and
+    # `variants/Seeed_XIAO_nRF52840_Sense/` for board JSONs that track
+    # PIO/sandeepmistry upstream naming.
+    "fbuild==2.2.12",
     "platformio>=6.1.19,<6.2",
     "python-dateutil",
     "ruff",


### PR DESCRIPTION
## Summary
- Pin `fbuild==2.2.12` so the build picks up the nRF52 PIO -> Adafruit alias resolution fixes that landed in fbuild master since 2.2.11.
- 2.2.12 was just published to PyPI ([release run](https://github.com/FastLED/fbuild/actions/runs/26702568523)) after the soldr/cargo-zigbuild cache bypass in [fbuild#332](https://github.com/FastLED/fbuild/pull/332) unblocked the publish workflow.

### What 2.2.12 fixes
- **Variant include path** ([fbuild#326](https://github.com/FastLED/fbuild/pull/326), closes fbuild#325) — the nrf52 orchestrator now reuses the alias-resolved `variant_dir` from `Nrf52Cores::get_variant_dir` for include paths, so board JSONs that track PIO/sandeepmistry upstream naming (`variant = "nRF52DK"`, `variant = "Seeed_XIAO_nRF52840_Sense"`, etc.) find Adafruit's actual directories instead of failing with `fatal error: variant.h: No such file or directory` from `cores/nRF5/{Uart,delay}.h`. Unblocks `Build nRF52840 DK` and `Build nRF52 XIAO BLE Sense`.
- **Linker script alias** ([fbuild#328](https://github.com/FastLED/fbuild/pull/328), closes fbuild#327) — `Nrf52Cores::get_linker_script(name, mcu)` now resolves PIO-named `nrf52_xxaa.ld` to whichever `nrf52840_s140_v{N}.ld` / `nrf52832_s132_v{N}.ld` Adafruit's BSP actually shipped, picking the highest available `_v{N}` via directory glob so a future BSP bump from v6 -> v7 doesn't silently regress. The resolved linker basename is now hashed into `Nrf52FingerprintMetadata.linker_script` so the fast-path key invalidates when alias resolution moves between files (CodeRabbit review catch).
- **Release-auto unblock** ([fbuild#332](https://github.com/FastLED/fbuild/pull/332), closes fbuild#331) — direct `cargo zigbuild` (pip-installed wrapper) bypasses soldr's bin cache that was serving a corrupted `cargo-zigbuild-0.22.3` binary and silently breaking every release. Without this, 2.2.12 could not ship.

Closes #2631 (Build nRF52840 DK).
Closes #2633 (Build nRF52 XIAO BLE Sense).

`adafruit_feather_nrf52840_sense` remains red on the unrelated size/LTO `offset out of range` link failure — explicitly out of scope per loop instructions; tracking issue #2632 was closed for the same reason. `supermini`/`nice_nano`/`nrfmicro` were already unblocked at the compile stage by #2627 but still fail on size for the same LTO reason — likewise out of scope.

## Test plan
- [ ] CI: `nrf52840_dk` workflow turns green on this branch.
- [ ] CI: `nrf52_xiaoblesense` workflow turns green on this branch (the xiaoblesense LTO disable from #2642 + this variant fix both required).
- [ ] CI: all non-nrf workflows unaffected (fbuild bump only touches the nrf52 orchestrator path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated fbuild dependency to version 2.2.12, incorporating bug fixes and improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->