### PR TITLE
fix(nrf52840): disable LTO on three Adafruit-BSP boards (arm-gnu 15.2 bug) (fixes #2653)

### DIFF
--- a/ci/boards.py
+++ b/ci/boards.py
@@ -848,6 +848,9 @@ ESP32_P4 = Board(
 ADA_FEATHER_NRF52840_SENSE = Board(
     board_name="adafruit_feather_nrf52840_sense",
     platform="nordicnrf52",
+    # See #2653 — arm-gnu 15.2.rel1 + Adafruit BSP LTO offset overflow.
+    build_unflags=["-flto"],
+    build_flags=["-fno-lto"],
 )
 
 # Seeed XIAO BLE Sense (nRF52840) -- community board (issue #2634)
@@ -934,6 +937,9 @@ NRF52840 = Board(
     defines=[
         "FASTLED_USE_COMPILE_TESTS=0",
     ],
+    # See #2653 — arm-gnu 15.2.rel1 + Adafruit BSP LTO offset overflow.
+    build_unflags=["-flto"],
+    build_flags=["-fno-lto"],
     board_build_core="nRF5",  # Ensure correct core directory
 )
 
@@ -952,6 +958,9 @@ SUPERMINI_NRF52840 = Board(
         "TARGET_SUPERMINI_NRF52840",
         "FASTLED_USE_COMPILE_TESTS=0",
     ],
+    # See #2653 — arm-gnu 15.2.rel1 + Adafruit BSP LTO offset overflow.
+    build_unflags=["-flto"],
+    build_flags=["-fno-lto"],
     board_build_core="nRF5",
 )
 


### PR DESCRIPTION
﻿## Summary
- Apply the `-fno-lto` workaround from PR #2642 to three more Adafruit-BSP nRF52840 boards that just crossed the same arm-gnu 15.2.rel1 LTO threshold.
- Unblocks `nrf52840_dk`, `adafruit_feather_nrf52840_sense`, and `nrf52840_supermini` workflows.

## Root cause
Identical signature on all three failing runs:

```
.lto-tmp/cc<random>.s:NNNN: Error: offset out of range
build error: build failed: arm-none-eabi-gcc link failed
lto-wrapper: fatal error: arm-none-eabi-gcc returned 1 exit status
```

The Adafruit BSP at 1.10601.0 brings in enough core code that the LTO-merged TU exceeds Thumb-2 branch reach across function boundaries — exact same toolchain bug PR #2642 documented for `xiaoblesense_adafruit` and PR #2644 mirrored for `xiaoblesense`.

## Scope discipline
- `NICE_NANO_NRF52840` and `NRFMICRO_NRF52840` use the same BSP + toolchain but **currently pass** — left alone (don't disable LTO pre-emptively on green builds; risks size regressions). Re-apply only when they fail.

## Test plan
- [ ] `nrf52840_dk` workflow goes green post-merge.
- [ ] `adafruit_feather_nrf52840_sense` workflow goes green post-merge.
- [ ] `nrf52840_supermini` workflow goes green post-merge.
- [ ] Existing-green `nice_nano_nrf52840`, `nrfmicro_nrf52840` builds remain green.

Fixes #2653

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed compilation errors on three nRF52840-based boards (Adafruit Feather nRF52840 Sense, nRF52840, SuperMini nRF52840) enabling successful project builds and deployment on these platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->