### PR TITLE
ci(build_template): cap Symbol Analysis + Optimization Report at 5 min

### DIFF
--- a/.github/workflows/build_template.yml
+++ b/.github/workflows/build_template.yml
@@ -251,6 +251,7 @@ jobs:
       - name: Symbol Analysis
         if: always()
         continue-on-error: true
+        timeout-minutes: 5
         run: |
           # Parse the board name from args (first element)
           python -c "print('${{ inputs.args }}'.split()[0])" > board.txt
@@ -260,6 +261,7 @@ jobs:
       - name: Optimization Report
         if: always()
         continue-on-error: true
+        timeout-minutes: 5
         run: |
           uv run ci/optimization_report.py --first
 


### PR DESCRIPTION
## Summary

Add `timeout-minutes: 5` to the `Symbol Analysis` and `Optimization Report` steps in `build_template.yml`. Both are post-build analysis already marked `continue-on-error: true`, so they should never turn a green build red — but a hang in either script currently kills the entire runner.

## Why

xiaoblesense_adafruit post-merge run [26700835813](https://github.com/FastLED/FastLED/actions/runs/26700835813/job/78693314891) succeeded at every compile step (all 65 example builds green — variant.h / PCA10056 / LTO fixes from #2636 / #2638 / #2642 all worked) but the runner was killed at 04:20 after `ci/optimization_report.py --first` produced no log output for 37 minutes. The underlying script bug (likely fbuild vs PIO artifact-path divergence — `readelf`/`nm`/`objdump` returned exit 1 on the firmware.elf earlier in the same run) is filed separately.

A 5-minute timeout keeps the analysis steps from hanging the job; the build itself still passes when they get skipped.

Refs #2641.

## Test plan

- [ ] Next push to master with a successful build matrix shows `Optimization Report` either completes within 5 min or is marked timed-out without failing the job.
- [ ] `build_xiaoblesense_adafruit` workflow goes green post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow configuration to add timeout limits to analysis steps, improving build efficiency and resource management during the deployment process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->