### PR TITLE
ci(optimization-report): cap stdout dump at 1 MiB to keep GHA runner alive

### DIFF
--- a/ci/optimization_report.py
+++ b/ci/optimization_report.py
@@ -32,7 +32,7 @@ def _env_default_max_bytes() -> int:
     return max(value, 0)
 
 
-def parse_args() -> argparse.Namespace:
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Inspect the GCC -fopt-info-all optimization report for a board."
     )
@@ -48,11 +48,11 @@ def parse_args() -> argparse.Namespace:
             f"env var; set to 0 to disable the cap entirely)."
         ),
     )
-    return parser.parse_args()
+    return parser.parse_args(argv)
 
 
-def main() -> int:
-    args = parse_args()
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
     if args.cwd:
         root_build_dir = args.cwd / ".build"
     else:

--- a/ci/optimization_report.py
+++ b/ci/optimization_report.py
@@ -3,12 +3,30 @@ import sys
 from pathlib import Path
 
 
+# Cap how much of optimization_report.txt we dump to stdout. With -fopt-info-all
+# applied across the full example matrix (~110 sketches on nrf52840_dk), the
+# report file can exceed 100MB. Printing the entire blob to a GitHub Actions
+# log triggers log-buffer limits and an external runner shutdown signal that
+# fails the workflow even though the build itself succeeded — see nrf52840_dk
+# run 26705682371 / 26705682359 (feather + supermini), where the build step
+# succeeded but Optimization Report cancelled at 37s with the runner dying
+# soon after. Cap to the LAST 1 MiB (most-recently emitted optimizer info,
+# which is the most actionable for size-driven debugging).
+MAX_REPORT_BYTES = 1 * 1024 * 1024
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Convert a binary file to ELF using map file."
+        description="Inspect the GCC -fopt-info-all optimization report for a board."
     )
     parser.add_argument("--first", action="store_true", help="Inspect the first board")
     parser.add_argument("--cwd", type=Path, help="Custom working directory")
+    parser.add_argument(
+        "--max-bytes",
+        type=int,
+        default=MAX_REPORT_BYTES,
+        help=f"Cap report tail printed to stdout (default {MAX_REPORT_BYTES} bytes).",
+    )
     return parser.parse_args()
 
 
@@ -37,7 +55,6 @@ def main() -> int:
         else int(input("Enter the number of the board you want to inspect: "))
     )
     board_dir = board_dirs[which]
-    # build_info_json = board_dir / "build_info.json"
     optimization_report = board_dir / "optimization_report.txt"
     if not optimization_report.exists():
         print(
@@ -46,8 +63,32 @@ def main() -> int:
             "The build may not have completed successfully."
         )
         return 0
-    text = optimization_report.read_text(encoding="utf-8", errors="replace")
-    print(text)
+
+    total = optimization_report.stat().st_size
+    max_bytes = max(args.max_bytes, 0)
+
+    if total <= max_bytes or max_bytes == 0:
+        text = optimization_report.read_text(encoding="utf-8", errors="replace")
+        print(text)
+        return 0
+
+    # Tail the file: seek to the cut-off offset, read to end, then snap to the
+    # next line boundary so we don't print a truncated leading line.
+    with optimization_report.open("rb") as fh:
+        fh.seek(total - max_bytes)
+        tail_bytes = fh.read()
+    first_newline = tail_bytes.find(b"\n")
+    if 0 <= first_newline < len(tail_bytes) - 1:
+        tail_bytes = tail_bytes[first_newline + 1 :]
+    tail_text = tail_bytes.decode("utf-8", errors="replace")
+
+    omitted = total - len(tail_bytes)
+    print(
+        f"[optimization_report.py] {optimization_report} is {total} bytes; "
+        f"showing last {len(tail_bytes)} bytes ({omitted} bytes elided to keep "
+        f"the GitHub Actions log under the runner's buffer limit)."
+    )
+    print(tail_text)
     return 0
 
 

--- a/ci/optimization_report.py
+++ b/ci/optimization_report.py
@@ -1,4 +1,5 @@
 import argparse
+import os
 import sys
 from pathlib import Path
 
@@ -12,7 +13,23 @@ from pathlib import Path
 # succeeded but Optimization Report cancelled at 37s with the runner dying
 # soon after. Cap to the LAST 1 MiB (most-recently emitted optimizer info,
 # which is the most actionable for size-driven debugging).
-MAX_REPORT_BYTES = 1 * 1024 * 1024
+#
+# Override via FL_OPT_REPORT_MAX_BYTES env var (set to 0 to disable the cap)
+# or the --max-bytes flag. Long-term, this script should print only a summary
+# and let the workflow upload optimization_report.txt as a build artifact for
+# devs to download — tracked as a follow-up.
+DEFAULT_MAX_REPORT_BYTES = 1 * 1024 * 1024
+
+
+def _env_default_max_bytes() -> int:
+    raw = os.environ.get("FL_OPT_REPORT_MAX_BYTES")
+    if raw is None:
+        return DEFAULT_MAX_REPORT_BYTES
+    try:
+        value = int(raw)
+    except ValueError:
+        return DEFAULT_MAX_REPORT_BYTES
+    return max(value, 0)
 
 
 def parse_args() -> argparse.Namespace:
@@ -24,8 +41,12 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--max-bytes",
         type=int,
-        default=MAX_REPORT_BYTES,
-        help=f"Cap report tail printed to stdout (default {MAX_REPORT_BYTES} bytes).",
+        default=_env_default_max_bytes(),
+        help=(
+            f"Cap report tail printed to stdout (default "
+            f"{DEFAULT_MAX_REPORT_BYTES} bytes; override via FL_OPT_REPORT_MAX_BYTES "
+            f"env var; set to 0 to disable the cap entirely)."
+        ),
     )
     return parser.parse_args()
 


### PR DESCRIPTION
## Summary
- `-fopt-info-all` writes a per-board optimization report. Across the full example matrix (~110 sketches on nrf52840_dk + the other Adafruit-BSP boards), the report routinely exceeds **100 MB**.
- The **Optimization Report** step in `build_template.yml` dumps the entire file to the GitHub Actions log via `print(text)`. This overruns the runner's log buffer and triggers an external **runner shutdown signal**.
- Symptom: the build step succeeds, several post-build analytics steps succeed, then Optimization Report cancels at ~37s and the runner dies; downstream cleanup steps stay pending and the workflow is marked **FAILURE** despite the build being **green**.

Verified failures on master SHA `a302c1ba`:
- nrf52840_supermini [run 26705682359](https://github.com/FastLED/FastLED/actions/runs/26705682359) — build SUCCESS at 08:51:29, Optimization Report cancelled 08:55:02
- adafruit_feather_nrf52840_sense [run 26705682371](https://github.com/FastLED/FastLED/actions/runs/26705682371) — same pattern, build SUCCESS at 08:51:29, Optimization Report cancelled 08:55:02

## Fix
- Default to printing the **last 1 MiB** of the report (most-recently-emitted optimizer info, which is the most useful slice for size-driven debugging).
- `--max-bytes 0` opts back into the full dump for local use.
- Tail is snapped to the next line boundary so the output doesn't lead with a half-line.
- Prints a one-line announcement up front showing the total size and how many bytes were elided.

## Counterpart to PR #2655
#2655 added `timeout-minutes: 5` to Symbol Analysis + Optimization Report, but couldn't help when the runner shutdown arrives **faster than** the step timeout (the log-buffer overrun is faster than 5 minutes).

## Test plan
- [ ] CI passes for the affected nRF52840 workflows once this lands on master.
- [ ] Existing local `uv run ci/optimization_report.py --first --cwd /tmp/some/build` still produces useful output for normal-sized reports (the cap is only enforced when the report exceeds 1 MiB).

Refs #2641, #2653.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optimization reports output is now capped at a configurable limit, displaying the tail portion when truncated
  * Added --max-bytes CLI flag and FL_OPT_REPORT_MAX_BYTES environment variable to customize the default report size (0 disables the cap)
  * Invalid or missing env values fall back to a sane default; negative values are treated as zero
  * Truncated reports include a summary showing total size, bytes displayed, and bytes omitted; CLI help text clarified for inspection use
<!-- end of auto-generated comment: release notes by coderabbit.ai -->