### PR TITLE
ci(pio): make -fopt-info-all opt-in per board (default OFF)

### DIFF
--- a/ci/boards.py
+++ b/ci/boards.py
@@ -79,6 +79,13 @@ class Board:
     extra_scripts: list[str] | None = (
         None  # Custom build scripts to run (e.g., ['pre:script.py'] for pre-build hooks)
     )
+    # Opt-in for GCC -fopt-info-all -> optimization_report.txt. Default OFF
+    # because the file accumulates across every example in the matrix and can
+    # exceed 100 MB on no-LTO boards with a large sketch set (nrf52840 with
+    # the Adafruit BSP would overrun the GHA log buffer and shut the runner
+    # down — see PR #2658). Set True when the board's workflow genuinely
+    # needs the optimization-info dump for size/perf debugging.
+    generate_optimization_report: bool = False
 
     def __post_init__(self) -> None:
         # Check if framework is set, warn and auto-set to arduino if missing (except for native/stub platforms)

--- a/ci/compiler/pio.py
+++ b/ci/compiler/pio.py
@@ -111,30 +111,32 @@ def _init_platformio_build(
     if additional_include_dirs:
         merged_include_dirs.extend(additional_include_dirs)
 
-    # Optimization report generation is available but OFF by default
-    # To enable optimization reports, add these flags to your board configuration:
-    # - "-fopt-info-all=optimization_report.txt" for detailed optimization info
-    # - "-Wl,-Map,firmware.map" for memory map analysis
+    # Optimization report (`-fopt-info-all`) is OPT-IN per board because the
+    # report file accumulates across every example in the matrix and can
+    # exceed 100 MB on no-LTO platforms — that overwhelmed the GHA log
+    # buffer and shut down the nrf52840 runners (see PR #2658 for the
+    # downstream cap and PR opening this gate). Set
+    # `generate_optimization_report=True` on the Board to opt in.
     #
-    # Note: The infrastructure is in place to support optimization reports when needed
-
-    # Always generate optimization artifacts into the board build directory
-    # Use absolute paths to ensure GCC/LD write into a known location even when the
-    # working directory changes inside PlatformIO builds.
+    # The linker map (`-Wl,-Map,firmware.map`) stays unconditional; it's a
+    # small per-example file and is consumed by size-analysis tooling.
     try:
-        opt_report_path = (build_dir / "optimization_report.txt").resolve()
-        # GCC writes reports relative to the current working directory; provide absolute path
-
-        # ESP32-C2 and AVR platforms cannot work with -fopt-info-all, suppress it for these platforms
-        if board.board_name != "esp32c2" and board.platform != "atmelavr":
-            board_with_sketch_include.build_flags.append(
-                f"-fopt-info-all={opt_report_path.as_posix()}"
-            )
-
         # Generate linker map in the board build directory using absolute path
         # (relative paths are unreliable — the linker CWD varies across PIO versions)
         map_path = (build_dir / "firmware.map").resolve()
         board_with_sketch_include.build_flags.append(f"-Wl,-Map,{map_path.as_posix()}")
+
+        # ESP32-C2 and AVR platforms cannot work with -fopt-info-all even when
+        # opted in — preserve the original suppression list.
+        if (
+            getattr(board, "generate_optimization_report", False)
+            and board.board_name != "esp32c2"
+            and board.platform != "atmelavr"
+        ):
+            opt_report_path = (build_dir / "optimization_report.txt").resolve()
+            board_with_sketch_include.build_flags.append(
+                f"-fopt-info-all={opt_report_path.as_posix()}"
+            )
     except KeyboardInterrupt as ki:
         handle_keyboard_interrupt(ki)
         raise


### PR DESCRIPTION
## Summary
- `ci/compiler/pio.py` currently injects `-fopt-info-all=<board>/optimization_report.txt` for every board (except esp32c2 + atmelavr) unconditionally. The flag is APPEND-mode and writes to a single per-board file shared across every example in the matrix.
- For slow-link (no-LTO) boards with the full example matrix — nrf52840 + Adafruit BSP runs ~110 examples × ~25-96 source files × hundreds of opt-info lines per TU — the file routinely exceeds 100 MB.
- When `build_template.yml`'s Optimization Report step then dumps that file to the GHA log via `ci/optimization_report.py --first`, the per-step log buffer overruns and the runner gets shutdown mid-step. That's the root cause of the nrf52840 "build succeeds but workflow marked failure" pattern. PR #2658 capped the log-side dump at 1 MiB as a stop-gap; this PR closes the **source-side** hole.

## Changes
- Add `Board.generate_optimization_report: bool = False` (default OFF).
- `ci/compiler/pio.py` only adds the `-fopt-info-all=...` flag when the board opts in (and still respects the existing esp32c2 / atmelavr suppression).
- The linker map (`-Wl,-Map,firmware.map`) stays unconditional — it's a small per-example file and is consumed by size-analysis tooling.

## Behavior preservation
- **Opted-in boards** (currently none): Optimization Report step works exactly as today.
- **Other boards**: the report file simply doesn't exist; `ci/optimization_report.py --first` already handles that case gracefully (prints `No optimization report found for board '<name>'` and exits 0). No workflow change needed.
- Boards that need the report for size/perf debugging can opt in with one line: `generate_optimization_report=True` on the `Board(...)` definition.

## Why no board is opted in by default
The only consumer of `optimization_report.txt` is the workflow's display step — no automated tooling processes it. Boards that genuinely need optimizer notes for debugging can opt in selectively (one example doesn't trigger the >100MB overrun; a per-board single-sketch CI does).

## Test plan
- [x] Smoke: `Board(...)` defaults to `generate_optimization_report=False`; `Board(..., generate_optimization_report=True)` round-trips correctly.
- [ ] CI passes on this branch (PR build path).
- [ ] After merge, master CI for nrf52840_dk + nrf52_xiaoblesense workflows turn green — exactly the goal condition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added opt-in board configuration to enable optimization report generation. Users can now selectively generate detailed optimization artifacts on a per-board basis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->