### PR TITLE
fix(ci): probe fbuild compile-many via SUB --help (unbreaks CI fast path)

### DIFF
--- a/.github/workflows/build_template.yml
+++ b/.github/workflows/build_template.yml
@@ -64,6 +64,11 @@ jobs:
         uses: FastLED/fbuild/.github/actions/setup@main
         with:
           cache-key-extra: ${{ steps.fbuild_board.outputs.name }}-${{ hashFiles('platformio.ini', 'library.json', 'pyproject.toml', 'uv.lock') }}
+          # Binary install cache is intentionally board-independent — every
+          # job in this repo's board matrix shares the same fbuild binary,
+          # so key the install cache solely on the fbuild pin in pyproject.
+          # The action ignores this input on older revisions (no-op).
+          install-cache-key-extra: ${{ hashFiles('pyproject.toml') }}
 
       - name: Install Platform
         if: inputs.platform != ''

--- a/ci/compiler/pio.py
+++ b/ci/compiler/pio.py
@@ -537,6 +537,11 @@ class PioCompiler(Compiler):
             self.platform_lock.release()
             return futures
 
+        import time
+
+        from ci.util.fbuild_runner import _parse_size_info_from_log
+
+        batch_start = time.monotonic()
         try:
             compile_many_result = run_batch(
                 board=self.board.board_name,
@@ -551,6 +556,9 @@ class PioCompiler(Compiler):
                 for sketch_result in compile_many_result.sketch_results
             }
 
+            success_count = 0
+            fail_count = 0
+            per_sketch_secs: list[float] = []
             for example, project_dir in staged_projects:
                 sketch_result = reported.get(project_dir.resolve())
                 if sketch_result is None:
@@ -559,6 +567,10 @@ class PioCompiler(Compiler):
                         f"{project_dir}\n\n{compile_many_result.output}"
                     )
                     success = False
+                    stage = "?"
+                    build_secs = 0.0
+                    flash_str: str | None = None
+                    ram_str: str | None = None
                 else:
                     output = sketch_result.message
                     if (
@@ -569,11 +581,37 @@ class PioCompiler(Compiler):
                             encoding="utf-8", errors="ignore"
                         )
                     success = sketch_result.success
+                    stage = sketch_result.stage
+                    build_secs = sketch_result.build_time_secs
+                    flash_str, ram_str = _parse_size_info_from_log(
+                        sketch_result.log_path
+                    )
 
+                # Normalized per-sketch summary line. The serial path emits
+                # `build succeeded in Xs (flash: N bytes, ram: M bytes)` from
+                # fbuild + `Compilation succeeded (fbuild) [Xs]` from FastLED.
+                # Compile-many never sees those per-sketch lines (fbuild only
+                # prints one aggregate table), so reconstruct an equivalent
+                # line per sketch from the parsed result + per-sketch log.
+                # Sizes come from the same fbuild `Flash:`/`RAM:` lines the
+                # serial path renders, just kept in fbuild's display units
+                # (e.g. "2.75KB") rather than re-converted to bytes — the
+                # signal is "did flash/ram change?", not the literal value.
+                size_part = ""
+                if flash_str is not None and ram_str is not None:
+                    size_part = f" (flash: {flash_str}, ram: {ram_str})"
+                elif flash_str is not None:
+                    size_part = f" (flash: {flash_str})"
+                stage_tag = f"[{stage}]" if stage != "?" else "[?]"
                 if success:
+                    success_count += 1
                     green_color = "\033[32m"
                     reset_color = "\033[0m"
-                    print(f"{green_color}SUCCESS: {example}{reset_color}")
+                    print(
+                        f"{green_color}SUCCESS: {example}  "
+                        f"build succeeded in {build_secs:.1f}s{size_part} {stage_tag}"
+                        f"{reset_color}"
+                    )
                     if generate_build_info_json_from_existing_build(
                         project_dir, self.board, example
                     ):
@@ -584,9 +622,16 @@ class PioCompiler(Compiler):
                                 self.build_dir / build_info_path.name,
                             )
                 else:
+                    fail_count += 1
                     red_color = "\033[31m"
                     reset_color = "\033[0m"
-                    print(f"{red_color}FAILED: {example}{reset_color}")
+                    print(
+                        f"{red_color}FAILED:  {example}  "
+                        f"build failed in {build_secs:.1f}s {stage_tag}"
+                        f"{reset_color}"
+                    )
+
+                per_sketch_secs.append(build_secs)
 
                 future: Future[SketchResult] = Future()
                 future.set_result(
@@ -598,6 +643,27 @@ class PioCompiler(Compiler):
                     )
                 )
                 futures.append(future)
+
+            # Total wall-clock and parallelism factor. The fbuild_runner step
+            # already prints `Compilation succeeded (fbuild ci) [Xs]` with
+            # the same wall time, but it lands BEFORE the per-sketch lines
+            # (fbuild prints its summary as soon as the subprocess exits).
+            # Re-emit a final-line total here so the bottom-of-log reader
+            # sees the wall clock right after the per-sketch summary, with
+            # an explicit parallelism factor so it's obvious when stage 2
+            # actually fanned out vs. ran serially.
+            batch_wall = time.monotonic() - batch_start
+            sum_per_sketch = sum(per_sketch_secs)
+            sketches_n = max(1, len(staged_projects))
+            speedup = sum_per_sketch / batch_wall if batch_wall > 0 else 1.0
+            print(
+                f"\nfbuild {command_label} total wall-clock: {batch_wall:.1f}s "
+                f"across {sketches_n} sketches "
+                f"(sum-of-per-sketch={sum_per_sketch:.1f}s, "
+                f"parallelism={speedup:.2f}x, "
+                f"avg-wall={batch_wall / sketches_n:.2f}s/sketch, "
+                f"ok={success_count}, fail={fail_count})\n"
+            )
         finally:
             print(f"Releasing platform lock: {self.platform_lock.lock_file_path}\n")
             self.platform_lock.release()

--- a/ci/tests/test_fbuild_compile_many.py
+++ b/ci/tests/test_fbuild_compile_many.py
@@ -240,3 +240,47 @@ def test_pio_compiler_build_prefers_ci_results(
     assert results[1].output == "demo ok"
     assert releases == ["x"]
     assert (compiler.build_dir / "build_info_Demo.json").exists()
+
+
+def test_fbuild_supports_subcommand_uses_sub_help_form(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Probe must use ``<fbuild> SUB --help`` not ``<fbuild> help SUB``.
+
+    The latter parses ``help`` as the subcommand and ``SUB`` as a positional
+    arg, which fails clap arg validation (exit 2) on any subcommand with a
+    required arg like ``--board``. Until this was fixed, compile-many
+    detection always returned False and CI silently fell back to the
+    legacy serial loop. Regression guard for that bug.
+    """
+    import subprocess
+
+    monkeypatch.setattr(fbuild_runner, "get_fbuild_executable", lambda: "fbuild.exe")
+    fbuild_runner.fbuild_supports_ci.cache_clear()
+    fbuild_runner.fbuild_supports_compile_many.cache_clear()
+
+    captured: list[list[str]] = []
+
+    class FakeProc:
+        returncode = 0
+
+    def fake_run(
+        cmd: list[str], **_kwargs: object
+    ) -> FakeProc:  # pyright: ignore[reportUnusedFunction]
+        captured.append(cmd)
+        return FakeProc()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    assert fbuild_runner.fbuild_supports_ci() is True
+    assert fbuild_runner.fbuild_supports_compile_many() is True
+
+    assert captured == [
+        ["fbuild.exe", "ci", "--help"],
+        ["fbuild.exe", "compile-many", "--help"],
+    ], (
+        "expected `fbuild SUB --help` (clap intercepts, rc=0); "
+        f"got: {captured}. The legacy `fbuild help SUB` form parses 'help' "
+        "as the subcommand and exits 2 on missing required args, which "
+        "silently disables compile-many."
+    )

--- a/ci/util/fbuild_runner.py
+++ b/ci/util/fbuild_runner.py
@@ -189,6 +189,47 @@ def fbuild_supports_compile_many() -> bool:
     return _fbuild_supports_subcommand("compile-many")
 
 
+# Parses size lines emitted into per-sketch fbuild logs. Matches both unit
+# variants the AVR/ESP orchestrators emit:
+#   "Flash: 2.75KB / 31.50KB (8.7%)"
+#   "RAM:   223 bytes / 2.00KB (10.9%)"
+# Returns the leading number+unit (e.g. "2.75KB", "223 bytes") so the caller
+# can render it back without unit conversion.
+_FLASH_SIZE_RE = re.compile(r"^\s*Flash:\s+([0-9.]+(?:\s*KB|\s*MB|\s*bytes))\s*/")
+_RAM_SIZE_RE = re.compile(r"^\s*RAM:\s+([0-9.]+(?:\s*KB|\s*MB|\s*bytes))\s*/")
+
+
+def _parse_size_info_from_log(log_path: Path | None) -> tuple[str | None, str | None]:
+    """Pull the (flash, ram) size strings out of an fbuild per-sketch log.
+
+    Returns (None, None) when the log is missing or doesn't contain the
+    Flash/RAM lines (e.g. a stage-1 fingerprint cache hit prints a shorter
+    log without size info). Callers should gracefully omit size in that case.
+    """
+    if log_path is None or not log_path.exists():
+        return (None, None)
+    try:
+        content = log_path.read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return (None, None)
+    flash: str | None = None
+    ram: str | None = None
+    for line in content.splitlines():
+        if flash is None:
+            m = _FLASH_SIZE_RE.match(line)
+            if m:
+                flash = m.group(1).strip()
+                continue
+        if ram is None:
+            m = _RAM_SIZE_RE.match(line)
+            if m:
+                ram = m.group(1).strip()
+                continue
+        if flash is not None and ram is not None:
+            break
+    return (flash, ram)
+
+
 def _parse_compile_many_results(output: str) -> list[FbuildCompileManySketchResult]:
     """Extract per-sketch results from ``fbuild compile-many`` output."""
     results: list[FbuildCompileManySketchResult] = []

--- a/ci/util/fbuild_runner.py
+++ b/ci/util/fbuild_runner.py
@@ -144,7 +144,16 @@ def default_fbuild_sketch_jobs() -> int:
 
 
 def _fbuild_supports_subcommand(subcommand: str) -> bool:
-    """Return whether the active fbuild executable exposes ``subcommand``."""
+    """Return whether the active fbuild executable exposes ``subcommand``.
+
+    Probes with ``<fbuild> <subcommand> --help`` rather than ``<fbuild> help
+    <subcommand>``: the latter parses ``help`` as the subcommand name and
+    ``<subcommand>`` as a positional arg, which fails clap arg validation
+    (exit 2) on any subcommand with required args like ``--board``. With
+    ``--help`` clap intercepts and prints help with exit 0 regardless of
+    other required args. The old probe silently disabled compile-many on
+    every CI run and forced the legacy serial fallback path.
+    """
     import subprocess
 
     fbuild_exe = get_fbuild_executable()
@@ -152,7 +161,7 @@ def _fbuild_supports_subcommand(subcommand: str) -> bool:
         return False
     try:
         proc = subprocess.run(
-            [fbuild_exe, "help", subcommand],
+            [fbuild_exe, subcommand, "--help"],
             capture_output=True,
             text=True,
             timeout=15,


### PR DESCRIPTION
## Summary

- Every build_*.yml CI run on master has been logging `fbuild ci and compile-many are unavailable in the installed fbuild; falling back to the legacy serial loop` and silently doing per-sketch serial builds instead of using `compile-many`'s stage-2 worker pool.
- Root cause: `_fbuild_supports_subcommand` (ci/util/fbuild_runner.py:146) probed with `<fbuild> help <SUB>`, which clap parses as subcommand=help with `<SUB>` as a positional sketch arg, then rejects with exit 2 on the missing `--board`. Switch to `<fbuild> <SUB> --help`, which clap intercepts and exits 0 regardless of other required args.
- Add a regression guard so the next refactor can't quietly re-disable compile-many.

Fixes #2660. Expected CI win on GitHub Actions (2-core runners, default `sketch_jobs=min(cpus,2)=2`): roughly 2× faster per-board builds, e.g. uno's 108-example run drops from ~3.5 min to ~2 min based on the current per-sketch wall times.

## Test plan

- [x] Local probe against fbuild 2.2.6 returns True for both `ci` and `compile-many`
- [x] Inline pytest regression guard asserts the exact command line emitted
- [ ] One uno CI run with the new branch shows the green path log lines (`Starting compilation...` followed by `compile-many results:` instead of the fallback message)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restored reliable fbuild subcommand detection (fixes CI compile-many fallback).

* **Tests**
  * Added a regression test to lock in the new subcommand-detection behavior.

* **New Features**
  * Enriched build output with per-sketch Flash/RAM size parsing, timing, and success/failed annotations.
  * Added a batch summary showing total wall time, parallelism factor, and ok/fail counts.

* **Chores**
  * Workflow step: added an install-cache key input keyed to project configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->