### PR TITLE
ci: gate compile-many opt-in via FASTLED_USE_FBUILD_CI=1 (urgent — unbreaks master)

### DIFF
--- a/ci/compiler/pio.py
+++ b/ci/compiler/pio.py
@@ -424,25 +424,45 @@ class PioCompiler(Compiler):
         return futures
 
     def _build_fbuild(self, examples: list[str]) -> list[Future[SketchResult]]:
-        """Build examples using fbuild, preferring ``ci`` when available."""
+        """Build examples using fbuild, preferring ``ci`` when available.
+
+        compile-many / ``fbuild ci`` are gated behind ``FASTLED_USE_FBUILD_CI``
+        because today they re-build the framework from scratch in every
+        stage-2 sketch dir (FastLED/fbuild#335). On uno that's a ~7 min run
+        vs. ~3.5 min serial; on teensy41/esp32s3 (larger framework) it
+        blows past the 30 min batch timeout — see the runs that landed on
+        master commits d2a025441e / 63e0241808 / fa147ae894. Default off
+        until fbuild#335 ships a shared framework cache; set
+        ``FASTLED_USE_FBUILD_CI=1`` to opt in (e.g. for local timing
+        experiments against the architectural fix once it lands).
+        """
+        import os
+
         from ci.util.fbuild_runner import (
             fbuild_supports_ci,
             fbuild_supports_compile_many,
         )
 
-        if fbuild_supports_ci():
-            return self._build_fbuild_ci(examples)
-        if fbuild_supports_compile_many():
-            print(
-                "fbuild ci is unavailable in the installed fbuild; "
-                "falling back to fbuild compile-many."
-            )
-            return self._build_fbuild_compile_many(examples)
-
-        print(
-            "fbuild ci and compile-many are unavailable in the installed fbuild; "
-            "falling back to the legacy serial loop."
+        opt_in = os.environ.get("FASTLED_USE_FBUILD_CI", "").lower() in (
+            "1",
+            "true",
+            "yes",
+            "on",
         )
+        if opt_in:
+            if fbuild_supports_ci():
+                return self._build_fbuild_ci(examples)
+            if fbuild_supports_compile_many():
+                print(
+                    "fbuild ci is unavailable in the installed fbuild; "
+                    "falling back to fbuild compile-many."
+                )
+                return self._build_fbuild_compile_many(examples)
+            print(
+                "FASTLED_USE_FBUILD_CI=1 was set but fbuild ci/compile-many "
+                "are unavailable in the installed fbuild; falling back to "
+                "the legacy serial loop."
+            )
         return self._build_fbuild_sync(examples)
 
     def _compile_many_project_dir(self, example: str, index: int) -> Path:

--- a/ci/tests/test_fbuild_compile_many.py
+++ b/ci/tests/test_fbuild_compile_many.py
@@ -168,6 +168,12 @@ def test_pio_compiler_build_prefers_ci_results(
     other_log = other_project / "compile_many.log"
     other_log.write_text("demo ok", encoding="utf-8")
 
+    # compile-many is gated behind FASTLED_USE_FBUILD_CI in
+    # PioCompiler._build_fbuild (FastLED/fbuild#335). Opt in here so the
+    # ci-results path actually runs in this test; without the env var
+    # the dispatch falls through to the legacy serial loop and the
+    # mocked run_fbuild_ci below would never be called.
+    monkeypatch.setenv("FASTLED_USE_FBUILD_CI", "1")
     monkeypatch.setattr(fbuild_runner, "fbuild_supports_ci", lambda: True)
     monkeypatch.setattr(fbuild_runner, "fbuild_supports_compile_many", lambda: True)
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary

- #2661 merged at 14:00 UTC enabled fbuild compile-many for the first time. The subsequent post-merge CI runs immediately showed it as a hard regression on master:
  - uno (small framework): ~3.5 min serial → ~7 min compile-many
  - teensy41 / esp32s3 (large framework): finished serial → **30 min** \`BUILD FAIL Process timed out\`
- Root cause is upstream [FastLED/fbuild#335](https://github.com/FastLED/fbuild/issues/335): each stage-2 sketch lives in its own project dir (\`.build/pio/<board>/compile_many/<name>/\`) and therefore gets its own \`.fbuild\` build dir, so the framework archive stage-1 builds in the root dir is invisible — every stage-2 worker re-builds the framework from scratch. The bigger the framework, the worse the regression.
- Until fbuild#335 lands a shared framework cache, gate the compile-many dispatch behind \`FASTLED_USE_FBUILD_CI=1\` so the default behaviour is the known-good legacy serial loop. Everything else from #2661 (\`SUB --help\` probe fix, normalized per-sketch output, install-cache wiring, workflow input) stays active and useful — only the dispatch is gated.

Set \`FASTLED_USE_FBUILD_CI=1\` locally to opt back in (handy for timing experiments against the architectural fix once it lands).

## Test plan

- [x] Inline pytest test updated to set \`FASTLED_USE_FBUILD_CI=1\` so it still exercises the compile-many dispatch path
- [ ] Post-merge: confirm uno / teensy41 / esp32s3 wall times return to pre-#2661 master levels

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable compilation mode selection through environment variables, enabling use of advanced CI-based build methods with automatic fallback to standard compilation.

* **Tests**
  * Enhanced CI build testing to properly exercise and validate CI compilation paths when enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->