### PR TITLE
fix(esp32c6): route Serial to HWCDC + non-blocking writes (#2665)

### DIFF
--- a/ci/boards.py
+++ b/ci/boards.py
@@ -804,7 +804,11 @@ ESP32_C6_DEVKITC_1 = Board(
     platform=ESP32_IDF_5_5_1_PIOARDUINO,
     board_build_flash_size="4MB",  # ESP32-C6FH4 actual flash size confirmed by esptool
     board_partitions="huge_app.csv",
-    build_flags=["-funwind-tables"],  # Better stack traces for RISC-V crash decoding
+    build_flags=[
+        "-funwind-tables",  # Better stack traces for RISC-V crash decoding
+        "-DARDUINO_USB_MODE=1",  # Select HWCDC (USB-Serial/JTAG) over OTG
+        "-DARDUINO_USB_CDC_ON_BOOT=1",  # Route Serial to HWCDC. Safe with setTxTimeoutMs(0); see #2668
+    ],
 )
 
 ESP32_S3_DEVKITC_1 = Board(

--- a/examples/AutoResearch/AutoResearch.ino
+++ b/examples/AutoResearch/AutoResearch.ino
@@ -290,6 +290,13 @@ void setup() {
     // Must be called BEFORE Serial.begin()
     init_serial_buffers();
     Serial.begin(115200);
+#if defined(ARDUINO_USB_CDC_ON_BOOT) && ARDUINO_USB_CDC_ON_BOOT
+    // Make HWCDC writes drop instead of block when no host is reading.
+    // Without this, Serial.print() on ESP32-C3/C6/H2 can stall up to ~2s
+    // per call once the TX ring fills with no host draining it.
+    // See FastLED issue #2668 and arduino-esp32 PR #7583.
+    Serial.setTxTimeoutMs(0);
+#endif
     while (!Serial && millis() < SERIAL_TIMEOUT_MS);  // Wait for serial monitor (early exits when connected)
 
     FL_WARN("[SETUP] AutoResearch sketch starting - serial output active");

--- a/platformio.ini
+++ b/platformio.ini
@@ -147,7 +147,8 @@ extra_scripts = pre:ci/ci-flags.py
 [platformio]
 src_dir = examples/Sailboat ; default: examples/AutoResearch/AutoResearch.ino (override with PLATFORMIO_SRC_DIR env var)
 default_envs = esp32s3
-;-D ARDUINO_USB_CDC_ON_BOOT=1  // WAIT ON BOOT ! DANGEROUS
+; ARDUINO_USB_CDC_ON_BOOT lives in per-board build_flags now (ci/boards.py).
+; Safe to enable thanks to Serial.setTxTimeoutMs(0); see issue #2668.
 ; Enable shared build cache to avoid recompiling FastLED library when switching sketches
 ; This dramatically speeds up `bash debug <example>` workflow by reusing compiled objects
 build_cache_dir = .pio/build_cache

--- a/platformio.ini
+++ b/platformio.ini
@@ -69,6 +69,7 @@ board = esp32-c6-devkitc-1
 build_flags =
   ${env:generic-esp.build_flags}
   -D ARDUINO_USB_MODE=1
+  -D ARDUINO_USB_CDC_ON_BOOT=1
   -D CONFIG_PARLIO_TX_ISR_HANDLER_IN_IRAM=1
   -D CONFIG_PARLIO_TX_ISR_CACHE_SAFE=1
   -D PIN_DATA=21

--- a/src/platforms/arduino/io_arduino.hpp
+++ b/src/platforms/arduino/io_arduino.hpp
@@ -15,6 +15,13 @@ namespace platforms {
 // Serial initialization
 void begin(u32 baudRate) FL_NOEXCEPT {
     Serial.begin(baudRate);
+#if defined(ARDUINO_USB_CDC_ON_BOOT) && ARDUINO_USB_CDC_ON_BOOT
+    // ESP32 HWCDC/USBCDC: make writes drop instead of block when no host is reading.
+    // Default is 100ms (HWCDC) / 250ms (USBCDC). Setting to 0 collapses worst-case
+    // stall from ~2s to ~0 when host absent. See FastLED issue #2668 and
+    // arduino-esp32 PR #7583. Safe to call on any Serial that exposes the method.
+    Serial.setTxTimeoutMs(0);
+#endif
 }
 
 // Print functions
@@ -89,6 +96,12 @@ int readLineNative(char delimiter, char* out, int outLen) FL_NOEXCEPT {
 
 // Utility functions
 bool flush(u32 timeoutMs) FL_NOEXCEPT {
+    (void)timeoutMs;
+    // Skip flush when host is absent. On HWCDC, Serial.flush() can spin
+    // indefinitely without a host (arduino-esp32 issue #7554). Returning
+    // true is correct semantics: there is no drained-to-host invariant
+    // we can establish without a host. See FastLED issue #2668.
+    if (!Serial) return true;
     Serial.flush();
     return true;
 }


### PR DESCRIPTION
## Summary

- **Fixes #2665**: ESP32-C6FH4 boards using USB-Serial/JTAG as the only host link had zero visible serial output because `ARDUINO_USB_CDC_ON_BOOT=1` was missing from `ci/boards.py` `ESP32_C6_DEVKITC_1`. With only `ARDUINO_USB_MODE=1` set, `Serial` remained aliased to UART0 (which the FH4 SKU does not expose), so `Serial.print` from `AutoResearch.ino` was invisible and JSON-RPC was unreachable.
- **Partial #2668**: ships the Arduino-side subset of the minimal-surface print contract — non-blocking HWCDC writes via `setTxTimeoutMs(0)` and guarded `flush()` to avoid arduino-esp32 #7554. IDF-side improvements (`usj_emergency.hpp` tier-2 fallback) and host-platform gaps (WASM `write_bytes` hex bug, POSIX `flush()` timeout) are intentionally deferred to a follow-up.
- **Mirrors ESP32-P4 fix** in commit `3ccfe93ac` (issue #2541/#2620) — same root cause and same one-line build-flag fix, with the additional `setTxTimeoutMs(0)` defense the design discussion in #2668 converged on.

## What changed

| File | Change |
|---|---|
| `ci/boards.py` | `ESP32_C6_DEVKITC_1.build_flags`: add `-DARDUINO_USB_MODE=1`, `-DARDUINO_USB_CDC_ON_BOOT=1` |
| `src/platforms/arduino/io_arduino.hpp` | `begin()`: call `Serial.setTxTimeoutMs(0)` when `ARDUINO_USB_CDC_ON_BOOT` is set (HWCDC/USBCDC writes drop instead of stall when host absent). `flush()`: skip when `!Serial` to avoid arduino-esp32 #7554 hang. |
| `examples/AutoResearch/AutoResearch.ino` | `setup()`: `Serial.setTxTimeoutMs(0)` right after `Serial.begin()` — defense in depth for sketches that use raw `Serial.print` rather than `fl::print` |
| `platformio.ini` | Remove the stale `; -D ARDUINO_USB_CDC_ON_BOOT=1 // WAIT ON BOOT ! DANGEROUS` comment — the warning no longer applies with the `setTxTimeoutMs(0)` fix |

Total: **+27 / -2 across 4 files**, no new public API symbols.

## Background

Full design rationale and second-opinion review are in #2668. TL;DR: this collapses HWCDC's worst-case stall from ~2s per write to ~0 when no host is reading, while continuing to deliver every byte when a host is connected. Cites upstream arduino-esp32 PR #7583 which already shipped `tx_timeout=0` as the unplugged default — this PR makes FastLED set it explicitly so behavior is uniform across arduino-esp32 versions.

## Test plan

- [ ] **Hardware test on ESP32-C6FH4 (FH4 SKU, COM9/COM22)** via `bash autoresearch esp32c6 --rmt` (`--parlio` reported broken upstream)
  - Expect: boot banner visible within ~16ms of port open (currently: zero output)
  - Expect: with host disconnected, boot does not stall the LED loop
- [ ] Compile verification on `bash compile esp32s3 --examples AutoResearch` (ensure the `Serial.setTxTimeoutMs(0)` call compiles cleanly under USBCDC too, not just HWCDC)
- [ ] Existing `bash test --cpp` continues to pass

### Verification limitation

I was unable to complete `bash autoresearch esp32c6` end-to-end in this session — the local `fbuild` daemon hangs silently during compile (process in `State: building` with near-zero CPU and no `riscv32-esp-elf-g++` workers spawned). This reproduces even with **all changes reverted**, so it is an unrelated infrastructure issue, not a regression introduced by this PR. The Arduino-side fix here is well-understood from upstream arduino-esp32 PR #7583 and mirrors the already-merged ESP32-P4 fix (commit `3ccfe93ac`). Hardware verification should pass on a clean fbuild environment.

## Follow-up

The remaining items from #2668's minimal-design checklist are deferred to a separate PR:

1. New `src/platforms/esp/32/detail/usj_emergency.hpp` — ROM-level fallback via `usb_serial_jtag_ll_*` inlines (IDF-side path only — needs verification that `hal/usb_serial_jtag_ll.h` is reachable in arduino-esp32 builds, which I started but reverted to keep this PR minimal)
2. `src/platforms/esp/32/detail/io_esp_jtag_or_uart.hpp` — `print()` tier ladder + `flush()` guard for `FL_ESP_USE_IDF_SERIAL=1` builds
3. `src/platforms/wasm/io_wasm.cpp.hpp:62-70` — fix `write_bytes` to emit raw bytes instead of hex text (contract violation)
4. `src/platforms/posix/io_posix.cpp.hpp:63-68` and Windows equivalent — honor `timeoutMs` in `flush()`
5. `tests/fl/stl/cstdio_contract.cpp` — 5-case contract test using the existing injection handler at `src/fl/stl/cstdio.cpp.hpp:44-65`

These are all small, but adding them to this PR would couple a tightly-scoped user-visible bug fix with a broader refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * USB CDC serial enabled by default on select ESP32 board variants (C3, C6, H2).

* **Bug Fixes**
  * Serial output no longer blocks at boot when no host is connected; writes will drop instead of stalling.
  * Flush and transmit behavior improved to avoid indefinite waits when a host is absent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->