### PR TITLE
chore: bump zccache pin to >=1.11.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "fpvgcc",
     "uv",
     "clang-tool-chain>=1.5.5",
-    "zccache>=1.11.8",
+    "zccache>=1.11.9",
     "ninja",
     "meson>=1.11.0",
     "download",


### PR DESCRIPTION
Picks up the zccache \`analyze\` / \`kv\` dispatch fix from [zackees/zccache#507](https://github.com/zackees/zccache/pull/507). \`soldr cache report\` (which shells out to \`zccache analyze\`) now produces an actual rollup again, and \`zccache kv\` is reachable from the CLI. Both subcommands previously fell through to wrap-mode and surfaced \`daemon error: failed to run compiler: program not found\` even on \`--help\`.

\`uv.lock\` is gitignored in this repo, so the pin floor change is all that's needed to nudge consumers to \`>=1.11.9\` on the next install/lock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a dependency to the latest patch version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->