### PR TITLE
Fix project sync sparse workflow import

### DIFF
--- a/ci/github_project_sync.py
+++ b/ci/github_project_sync.py
@@ -20,13 +20,10 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any
 
-from typeguard import typechecked
-
 
 VALID_OWNER_TYPES = {"organization", "user"}
 
 
-@typechecked
 @dataclass
 class FieldOption:
     """Resolved field and option IDs for a single-select project field."""
@@ -35,7 +32,6 @@ class FieldOption:
     option_id: str
 
 
-@typechecked
 @dataclass
 class Config:
     """Configuration parsed from environment variables."""


### PR DESCRIPTION
## Summary
- remove the `typeguard` runtime dependency from `ci/github_project_sync.py`
- keep the project automation script runnable from the workflow's sparse `ci` checkout without installing the full CI dependency set

## Validation
- `python -m unittest ci.tests.test_github_project_sync`
- `python -m ruff check ci/github_project_sync.py ci/tests/test_github_project_sync.py`
- import check with `typeguard` deliberately blocked

Root cause: `project_automation.yml` checks out only `ci/` and runs the sync script directly, so the script cannot assume the repository's Python dependency set is installed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the `typeguard` runtime type-checking dependency to streamline the project and reduce runtime overhead while maintaining application functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->