### PR TITLE
fix(wasm): map FastLED DWARF source paths

### DIFF
--- a/ci/meson/rglob.py
+++ b/ci/meson/rglob.py
@@ -53,7 +53,7 @@ def main() -> None:
             continue
 
         if exclude_path is None or exclude_path not in path_str:
-            print(str(p))
+            print(path_str)
 
 
 if __name__ == "__main__":

--- a/ci/meson/src_metadata_cache.py
+++ b/ci/meson/src_metadata_cache.py
@@ -20,11 +20,22 @@ import argparse
 import hashlib
 import json
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 
 
 CACHE_FILENAME = "src_metadata.cache"
 CACHE_VERSION = 2
+
+
+@dataclass(frozen=True)
+class CacheEntry:
+    """Validated source metadata cache contents."""
+
+    version: int
+    hash: str
+    timestamp: float
+    metadata: str
 
 
 def compute_src_files_hash(src_dir: Path, pattern: str = "*.cpp") -> str:
@@ -60,7 +71,7 @@ def compute_src_files_hash(src_dir: Path, pattern: str = "*.cpp") -> str:
     return hashlib.sha256(hash_str.encode()).hexdigest()
 
 
-def load_cache(build_dir: Path) -> dict[str, str | float] | None:
+def load_cache(build_dir: Path) -> CacheEntry | None:
     """
     Load cached source metadata from build directory.
 
@@ -68,7 +79,7 @@ def load_cache(build_dir: Path) -> dict[str, str | float] | None:
         build_dir: Meson build directory (e.g., .build/meson-quick/)
 
     Returns:
-        Cache dictionary with keys: hash, timestamp, metadata
+        Cache entry with version, hash, timestamp, and metadata
         None if cache doesn't exist or is invalid
     """
     cache_file = build_dir / CACHE_FILENAME
@@ -86,7 +97,14 @@ def load_cache(build_dir: Path) -> dict[str, str | float] | None:
         if cache["version"] != CACHE_VERSION:
             return None
 
-        return cache
+        return CacheEntry(
+            version=int(cache["version"]),
+            hash=str(cache["hash"]),
+            timestamp=float(cache["timestamp"]),
+            metadata=str(cache["metadata"]),
+        )
+    except KeyboardInterrupt:
+        raise
     except (json.JSONDecodeError, OSError):
         return None
 
@@ -178,20 +196,18 @@ def main() -> None:
             sys.exit(1)
 
         # Load cached metadata
-        cache: dict[str, str | float] | None = load_cache(args.build_dir)
+        cache = load_cache(args.build_dir)
         if cache is None:
             # Cache miss - exit with failure, no output
             sys.exit(1)
-        assert cache is not None
 
         # Compute current hash
         current_hash = compute_src_files_hash(args.src_dir, args.pattern)
 
         # Check if hash matches
-        if cache["hash"] == current_hash:
+        if cache.hash == current_hash:
             # Cache hit - output cached metadata and exit success
-            metadata_str: str = str(cache["metadata"])
-            print(metadata_str)
+            print(cache.metadata)
             sys.exit(0)
         else:
             # Cache invalid - exit with failure, no output

--- a/ci/meson/src_metadata_cache.py
+++ b/ci/meson/src_metadata_cache.py
@@ -24,6 +24,7 @@ from pathlib import Path
 
 
 CACHE_FILENAME = "src_metadata.cache"
+CACHE_VERSION = 2
 
 
 def compute_src_files_hash(src_dir: Path, pattern: str = "*.cpp") -> str:
@@ -79,8 +80,10 @@ def load_cache(build_dir: Path) -> dict[str, str | float] | None:
             cache = json.load(f)
 
         # Validate cache structure
-        required_keys = ["hash", "timestamp", "metadata"]
+        required_keys = ["version", "hash", "timestamp", "metadata"]
         if not all(key in cache for key in required_keys):
+            return None
+        if cache["version"] != CACHE_VERSION:
             return None
 
         return cache
@@ -102,7 +105,12 @@ def save_cache(build_dir: Path, src_hash: str, metadata: str) -> None:
     cache_file = build_dir / CACHE_FILENAME
     build_dir.mkdir(parents=True, exist_ok=True)
 
-    cache = {"hash": src_hash, "timestamp": time.time(), "metadata": metadata}
+    cache = {
+        "version": CACHE_VERSION,
+        "hash": src_hash,
+        "timestamp": time.time(),
+        "metadata": metadata,
+    }
 
     with open(cache_file, "w", encoding="utf-8") as f:
         json.dump(cache, f, indent=2)

--- a/ci/meson/src_metadata_cache.py
+++ b/ci/meson/src_metadata_cache.py
@@ -21,13 +21,17 @@ import hashlib
 import json
 import sys
 from dataclasses import dataclass
+from os import stat_result
 from pathlib import Path
+
+from typeguard import typechecked
 
 
 CACHE_FILENAME = "src_metadata.cache"
 CACHE_VERSION = 2
 
 
+@typechecked
 @dataclass(frozen=True)
 class CacheEntry:
     """Validated source metadata cache contents."""
@@ -38,7 +42,7 @@ class CacheEntry:
     metadata: str
 
 
-def compute_src_files_hash(src_dir: Path, pattern: str = "*.cpp") -> str:
+def compute_src_files_hash(src_dir: Path, pattern: str) -> str:
     """
     Compute a hash of all source file metadata (path + mtime + size).
 
@@ -59,8 +63,6 @@ def compute_src_files_hash(src_dir: Path, pattern: str = "*.cpp") -> str:
     hash_input: list[str] = []
     for f in source_files:
         if f.is_file():
-            from os import stat_result
-
             stat: stat_result = f.stat()
             rel_path: str = f.relative_to(src_dir).as_posix()
             # Include path, mtime, and size in hash
@@ -134,7 +136,7 @@ def save_cache(build_dir: Path, src_hash: str, metadata: str) -> None:
         json.dump(cache, f, indent=2)
 
 
-def main() -> None:
+def main(argv: list[str] | None = None) -> None:
     """Main entry point for source metadata cache operations."""
     parser = argparse.ArgumentParser(
         description="Manage source metadata cache for Meson build system"
@@ -177,7 +179,7 @@ def main() -> None:
         help="File pattern to match (default: *.cpp)",
     )
 
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     # Validate arguments based on operation
     if args.invalidate:

--- a/ci/tests/test_wasm_flags.py
+++ b/ci/tests/test_wasm_flags.py
@@ -27,7 +27,8 @@ def test_lib_fast_debug_flags_map_fastled_src_to_dwarf_prefix() -> None:
 def test_lib_quick_flags_do_not_emit_dwarf_prefix_maps() -> None:
     flags = wasm_flags.get_lib_compile_flags_dict("quick")["compiler_flags"]
 
-    assert not any(flag.startswith("-ffile-prefix-map=") for flag in flags)
+    for flag in flags:
+        assert not flag.startswith("-ffile-prefix-map="), flag
 
 
 def test_rglob_outputs_forward_slashes(tmp_path: Path) -> None:

--- a/ci/tests/test_wasm_flags.py
+++ b/ci/tests/test_wasm_flags.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+from ci import wasm_flags
+
+
+def test_lib_debug_flags_map_fastled_src_to_dwarf_prefix() -> None:
+    flags = wasm_flags.get_lib_compile_flags_dict("debug")["compiler_flags"]
+    source_root = (wasm_flags.PROJECT_ROOT / "src").resolve()
+
+    assert f"-ffile-prefix-map={source_root.as_posix()}=fastledsource" in flags
+    if str(source_root) != source_root.as_posix():
+        assert f"-ffile-prefix-map={source_root}=fastledsource" in flags
+    assert "-ffile-prefix-map=/=sketchsource/" not in flags
+
+
+def test_lib_fast_debug_flags_map_fastled_src_to_dwarf_prefix() -> None:
+    flags = wasm_flags.get_lib_compile_flags_dict("fast_debug")["compiler_flags"]
+    source_root = (wasm_flags.PROJECT_ROOT / "src").resolve()
+
+    assert f"-ffile-prefix-map={source_root.as_posix()}=fastledsource" in flags
+
+
+def test_lib_quick_flags_do_not_emit_dwarf_prefix_maps() -> None:
+    flags = wasm_flags.get_lib_compile_flags_dict("quick")["compiler_flags"]
+
+    assert not any(flag.startswith("-ffile-prefix-map=") for flag in flags)
+
+
+def test_rglob_outputs_forward_slashes(tmp_path: Path) -> None:
+    source_dir = tmp_path / "src"
+    nested = source_dir / "platforms" / "shared"
+    nested.mkdir(parents=True)
+    (nested / "demo.cpp").write_text("int demo = 0;\n", encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(wasm_flags.PROJECT_ROOT / "ci" / "meson" / "rglob.py"),
+            str(source_dir),
+            "*.cpp",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert "\\" not in result.stdout
+    assert "/platforms/shared/demo.cpp" in result.stdout

--- a/ci/wasm_flags.py
+++ b/ci/wasm_flags.py
@@ -20,13 +20,14 @@ import argparse
 import sys
 import tomllib
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 
 PROJECT_ROOT = Path(__file__).parent.parent
 BUILD_FLAGS_TOML = (
     PROJECT_ROOT / "src" / "platforms" / "wasm" / "compiler" / "build_flags.toml"
 )
+DEBUG_PATH_MAP_MODES = {"debug", "fast_debug"}
 
 
 def _load_toml() -> dict[str, Any]:
@@ -35,6 +36,46 @@ def _load_toml() -> dict[str, Any]:
         raise FileNotFoundError(f"Build flags TOML not found: {BUILD_FLAGS_TOML}")
     with open(BUILD_FLAGS_TOML, "rb") as f:
         return tomllib.load(f)
+
+
+def _dwarf_config(config: dict[str, Any]) -> dict[str, Any]:
+    dwarf = config.get("dwarf", {})
+    if isinstance(dwarf, dict):
+        return cast(dict[str, Any], dwarf)
+    return {}
+
+
+def _dwarf_prefix(dwarf: dict[str, Any], key: str, default: str) -> str:
+    value = dwarf.get(key, default)
+    if not isinstance(value, str) or not value.strip():
+        value = default
+    return value.replace("\\", "/").strip("/")
+
+
+def _path_prefix_variants(path: Path) -> list[str]:
+    resolved = path.resolve()
+    variants = [resolved.as_posix()]
+    native = str(resolved)
+    if native != variants[0]:
+        variants.append(native)
+    return variants
+
+
+def _file_prefix_map_flags(from_path: Path, to_prefix: str) -> list[str]:
+    normalized_prefix = to_prefix.replace("\\", "/").strip("/")
+    return [
+        f"-ffile-prefix-map={path_prefix}={normalized_prefix}"
+        for path_prefix in _path_prefix_variants(from_path)
+    ]
+
+
+def _lib_dwarf_prefix_map_flags(config: dict[str, Any], mode: str) -> list[str]:
+    if mode not in DEBUG_PATH_MAP_MODES:
+        return []
+
+    dwarf = _dwarf_config(config)
+    fastled_prefix = _dwarf_prefix(dwarf, "fastled_prefix", "fastledsource")
+    return _file_prefix_map_flags(PROJECT_ROOT / "src", fastled_prefix)
 
 
 def get_lib_compile_flags_dict(mode: str = "quick") -> dict[str, list[str]]:
@@ -64,6 +105,8 @@ def get_lib_compile_flags_dict(mode: str = "quick") -> dict[str, list[str]]:
     else:
         compiler_flags.extend(config.get("library", {}).get("compiler_flags", []))
         compiler_flags.extend(build_mode_config.get("flags", []))
+
+    compiler_flags.extend(_lib_dwarf_prefix_map_flags(config, mode))
 
     return {"defines": defines, "compiler_flags": compiler_flags}
 

--- a/ci/wasm_flags.py
+++ b/ci/wasm_flags.py
@@ -63,10 +63,10 @@ def _path_prefix_variants(path: Path) -> list[str]:
 
 def _file_prefix_map_flags(from_path: Path, to_prefix: str) -> list[str]:
     normalized_prefix = to_prefix.replace("\\", "/").strip("/")
-    return [
-        f"-ffile-prefix-map={path_prefix}={normalized_prefix}"
-        for path_prefix in _path_prefix_variants(from_path)
-    ]
+    flags: list[str] = []
+    for path_prefix in _path_prefix_variants(from_path):
+        flags.append(f"-ffile-prefix-map={path_prefix}={normalized_prefix}")
+    return flags
 
 
 def _lib_dwarf_prefix_map_flags(config: dict[str, Any], mode: str) -> list[str]:

--- a/src/platforms/wasm/compiler/build_flags.toml
+++ b/src/platforms/wasm/compiler/build_flags.toml
@@ -391,12 +391,12 @@ dwarf_prefix = "dwarfsource"                    # Prefix for generic dwarf-resol
 # Debug file naming
 dwarf_filename = "fastled.wasm.dwarf"           # Name of separate DWARF debug info file
 
-# File prefix mapping for source path resolution in debug info
-# This controls how absolute paths in the compilation environment are mapped to
-# relative paths in the debug information for consistent debugging experience
-# Format: -ffile-prefix-map=FROM=TO
-file_prefix_map_from = "/"                      # Map from root path
-file_prefix_map_to = "sketchsource/"            # Map to sketch source prefix
+# File prefix mapping for source path resolution in debug info.
+# ci/wasm_flags.py synthesizes known-root maps for FastLED library compiles:
+#   <repo>/src -> fastled_prefix
+# Build drivers that know the user sketch and Emscripten roots should map:
+#   <sketch> -> sketch_prefix
+#   <emsdk>  -> dwarf_prefix/emsdk
 
 [strict_mode]
 # ================================================================================================


### PR DESCRIPTION
## Summary
- synthesize debug/fast_debug -ffile-prefix-map flags for FastLED library sources from the known repo src root to the configured fastledsource prefix
- normalize Meson-discovered source paths to forward slashes and invalidate old source metadata caches that may contain native Windows separators
- remove the old Unix-root sketch prefix-map guidance from build_flags.toml and document the generated known-root maps
- add focused tests for wasm flag emission and source discovery path normalization

Refs zackees/fastled-wasm#130.

## Tests
- uv run pytest ci/tests/test_wasm_flags.py -q
- uv run ruff check ci/wasm_flags.py ci/meson/rglob.py ci/meson/src_metadata_cache.py ci/tests/test_wasm_flags.py
- uv run ruff format --check ci/wasm_flags.py ci/meson/rglob.py ci/meson/src_metadata_cache.py ci/tests/test_wasm_flags.py
- uv run pyright ci/wasm_flags.py ci/meson/rglob.py ci/meson/src_metadata_cache.py
- uv run python ci/wasm_flags.py --target lib_compile --mode debug | Select-String -Pattern ffile-prefix-map
- uv run python ci/wasm_flags.py --target lib_compile --mode quick | Select-String -Pattern ffile-prefix-map

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * DWARF source-path mapping for WebAssembly debug/fast_debug builds.
  * Versioned build cache for safer, compatible caching.

* **Bug Fixes**
  * Tooling output normalized to use forward slashes for consistent path formatting.

* **Tests**
  * Added tests for compilation flags, DWARF mapping behavior, and path-handling in tooling.

* **Documentation**
  * Updated DWARF configuration guidance to reflect dynamic prefix mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->