### PR TITLE
chore(ci): bump fbuild to 2.2.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,8 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    # Pin to fbuild 2.2.13 — adds the compile-many stage-2 framework-archive
+    # Pin to fbuild 2.2.14 — adds Arduino UNO Q / STM32U5 board defaults while
+    # preserving the compile-many stage-2 framework-archive
     # share (FastLED/fbuild#337) which prevents every stage-2 sketch from
     # re-building the framework from scratch (the regression that originally
     # forced the FASTLED_USE_FBUILD_CI=1 gate to default-off in #2662). Also
@@ -15,7 +16,7 @@ dependencies = [
     # acquire instrumentation (#350) — together these address the silent
     # esp32c6 hang reported in fbuild#346 and unblock flipping
     # FASTLED_USE_FBUILD_CI=1 default-on in a follow-up.
-    "fbuild==2.2.13",
+    "fbuild==2.2.14",
     "platformio>=6.1.19,<6.2",
     "python-dateutil",
     "ruff",


### PR DESCRIPTION
## Summary
- bump the pinned fbuild dependency from 2.2.13 to 2.2.14
- align the source dependency with the lockfile's 2.2.14 fbuild entry
- pull in the released Arduino UNO Q / STM32U5 board defaults from FastLED/fbuild#367

## Context
The Arduino UNO Q source support landed in FastLED, but the native fbuild workflow resolves .venv/bin/fbuild from the pinned PyPI package. Version 2.2.13 does not contain the new built-in board defaults, so CI can still fail with unknown board 'arduino_uno_q'. Version 2.2.14 includes the merged fbuild UNO Q support from FastLED/fbuild#365.

Refs #2674
Refs FastLED/fbuild#363
Refs FastLED/fbuild#364
Refs FastLED/fbuild#365
Refs FastLED/fbuild#367

## Verification
- uv run fbuild --version
- uv run python ci\\ci-compile.py arduino_uno_q --examples Blink,Apa102 --no-interactive --no-parallel --local --backend fbuild --log-failures .build\\uno_q_fbuild_failures --max-failures 1
- git diff --check
- uv run python -m pytest ci\\lint_cpp\\test_native_platform_defines_checker.py ci\\lint_cpp\\test_is_header_include_checker.py -q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a build system dependency to the latest version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->