### PR TITLE
fix(esp32c6): reject USB serial pins for LED output

### DIFF
--- a/examples/AutoResearch/AutoResearchParlioStream.h
+++ b/examples/AutoResearch/AutoResearchParlioStream.h
@@ -40,6 +40,17 @@ namespace parlio_stream {
 
 constexpr int kMaxIterations = 16;  // result struct iter timing array fixed size
 
+inline bool isFastLedOutputPinValid(int pin) {
+    if (pin < 0 || pin >= 64) {
+        return false;
+    }
+#if defined(_FL_VALID_PIN_MASK)
+    return (_FL_VALID_PIN_MASK & (1ULL << pin)) != 0;
+#else
+    return true;
+#endif
+}
+
 struct ValidateResult {
     bool channels_ok;          // true if all PARLIO channels created cleanly
     bool completed;            // true if every iteration completed within timeout
@@ -105,8 +116,13 @@ inline ValidateResult validateParlioStreaming(int base_tx_pin,
 
     fl::vector<fl::shared_ptr<fl::Channel>> channels;
     for (int lane = 0; lane < num_lanes; ++lane) {
+        const int tx_pin = base_tx_pin + lane;
+        if (!isFastLedOutputPinValid(tx_pin)) {
+            FastLED.clear(ClearFlags::CHANNELS);
+            return r;
+        }
         fl::ChannelConfig cfg(
-            base_tx_pin + lane,
+            tx_pin,
             timing,
             fl::span<CRGB>(leds[lane], num_leds),
             RGB,

--- a/src/platforms/esp/32/core/fastpin_esp32.h
+++ b/src/platforms/esp/32/core/fastpin_esp32.h
@@ -131,8 +131,10 @@ public:
 
 #elif defined(FL_IS_ESP_32C6)
 
-// GPIO 20-22, 24-26 used by default for SPI flash.
-#define FASTLED_UNUSABLE_PIN_MASK (0ULL |  _FL_BIT(24) | _FL_BIT(25) | _FL_BIT(26) | _FL_BIT(28) | _FL_BIT(29) | _FL_BIT(30))
+// GPIO 12/13 are native USB D-/D+ on ESP32-C6 USB-Serial/JTAG boards; using
+// them as FastLED outputs can sever the active serial/upload connection.
+// GPIO 24-26 and 28-30 are reserved/unusable on ESP32-C6 packages.
+#define FASTLED_UNUSABLE_PIN_MASK (0ULL | _FL_BIT(12) | _FL_BIT(13) | _FL_BIT(24) | _FL_BIT(25) | _FL_BIT(26) | _FL_BIT(28) | _FL_BIT(29) | _FL_BIT(30))
 
 #elif defined(FL_IS_ESP_32P4)
 // 55 GPIO pins. ESPIDF defines all pins as valid.
@@ -173,6 +175,11 @@ public:
 #define _FL_VALID_PIN_MASK (u64(SOC_GPIO_VALID_OUTPUT_GPIO_MASK) & ~FASTLED_UNUSABLE_PIN_MASK)
 
 #define _FL_PIN_VALID(PIN) ((_FL_VALID_PIN_MASK & (1ULL << PIN)) != 0)
+
+#if defined(FL_IS_ESP_32C6)
+FL_STATIC_ASSERT(!_FL_PIN_VALID(12), "ESP32-C6 GPIO12 is USB D- and must be invalid for FastLED output");
+FL_STATIC_ASSERT(!_FL_PIN_VALID(13), "ESP32-C6 GPIO13 is USB D+ and must be invalid for FastLED output");
+#endif
 
 #define _FL_DEFPIN(PIN) template <> class FastPin<PIN> : public _ESPPIN<PIN, ((u32)1 << (PIN % 32)), _FL_PIN_VALID(PIN)> {};
 

--- a/src/platforms/esp/32/drivers/parlio/channel_driver_parlio.cpp.hpp
+++ b/src/platforms/esp/32/drivers/parlio/channel_driver_parlio.cpp.hpp
@@ -25,6 +25,7 @@
 #include "fl/log/log.h"
 #include "fl/log/log.h"
 #include "fl/stl/algorithm.h"
+#include "fl/system/fastpin.h"
 #include "fl/system/trace.h"
 #include "fl/stl/assert.h"
 #include "fl/stl/noexcept.h"
@@ -35,6 +36,21 @@
 #endif // defined(FL_ESP_PARLIO_MAX_LEDS_PER_CHANNEL)
 
 namespace fl {
+
+namespace {
+
+inline bool isValidParlioOutputPin(int pin) FL_NOEXCEPT {
+    if (pin < 0 || pin >= 64) {
+        return false;
+    }
+#if defined(_FL_VALID_PIN_MASK)
+    return (_FL_VALID_PIN_MASK & (1ULL << pin)) != 0;
+#else
+    return true;
+#endif
+}
+
+} // namespace
 
 //=============================================================================
 // Constructors / Destructors - Implementation Class
@@ -306,6 +322,12 @@ void ChannelDriverPARLIOImpl::beginTransmission(
     fl::vector<int> pins;
     for (size_t i = 0; i < channel_count; i++) {
         int pin = channelData[i]->getPin();
+        if (!isValidParlioOutputPin(pin)) {
+            FL_WARN("PARLIO: Invalid output GPIO "
+                    << pin
+                    << " for this ESP32 target; refusing to configure PARLIO");
+            return;
+        }
         pins.push_back(pin);
     }
 


### PR DESCRIPTION
## Summary
- mark ESP32-C6 GPIO12/GPIO13 invalid in the FastPin mask because they are native USB D-/D+
- reject invalid output GPIOs in the PARLIO channel driver before configuring `data_gpio_nums[]`
- make AutoResearch `parlioStreamValidate` fail channel creation before adding C6 pin maps that include GPIO12/GPIO13

Closes #2677

## Validation
- `git diff --check`
- `PLATFORMIO_SRC_DIR=$PWD\examples\AutoResearch pio run -e esp32c6`
- uploaded AutoResearch to ESP32-C6 on COM9
- RPC hardware check on COM9: set TX base to GPIO0, ran `parlioStreamValidate` with 16 lanes/256 LEDs/2 iterations/1000 ms; result returned `channelsOk=false`, `completed=false`; follow-up `status` RPC succeeded and COM9 remained enumerated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pin validation for PARLIO output pins to prevent invalid configurations.
  * Enhanced ESP32-C6 pin mask validation to properly exclude USB communication pins (GPIO12/13).
  * Added validation checks during initialization to warn and skip setup for invalid pins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->