### PR TITLE
feat(parlio): land c6 streaming diagnostics

### DIFF
--- a/ci/autoresearch/driver_sweep.py
+++ b/ci/autoresearch/driver_sweep.py
@@ -519,7 +519,7 @@ def main() -> int:
     port: str = args.port or ""
     if not port:
         print("Auto-detecting serial port...")
-        result = auto_detect_upload_port(None)
+        result = auto_detect_upload_port("esp32c6")
         if not result.ok:
             print("ERROR: No USB serial port found. Plug in the device or use --port.")
             return 1

--- a/ci/autoresearch/driver_sweep.py
+++ b/ci/autoresearch/driver_sweep.py
@@ -519,7 +519,7 @@ def main() -> int:
     port: str = args.port or ""
     if not port:
         print("Auto-detecting serial port...")
-        result = auto_detect_upload_port()
+        result = auto_detect_upload_port(None)
         if not result.ok:
             print("ERROR: No USB serial port found. Plug in the device or use --port.")
             return 1

--- a/ci/autoresearch/phases.py
+++ b/ci/autoresearch/phases.py
@@ -603,9 +603,10 @@ async def _resolve_port_and_environment(ctx: RunContext) -> int | None:
 
     upload_port = args.upload_port
     if not upload_port:
+        expected_environment = None if is_teensy else ctx.final_environment
         max_wait_s = 60
         poll_interval_s = 1.0
-        result = auto_detect_upload_port()
+        result = auto_detect_upload_port(expected_environment=expected_environment)
         if not result.ok:
             if is_teensy:
                 print(f"\n{Fore.YELLOW}{'=' * 60}")
@@ -619,7 +620,9 @@ async def _resolve_port_and_environment(ctx: RunContext) -> int | None:
             last_msg_at = 0.0
             while time.monotonic() < deadline:
                 time.sleep(poll_interval_s)
-                result = auto_detect_upload_port()
+                result = auto_detect_upload_port(
+                    expected_environment=expected_environment
+                )
                 if result.ok:
                     elapsed = max_wait_s - (deadline - time.monotonic())
                     print(
@@ -637,7 +640,9 @@ async def _resolve_port_and_environment(ctx: RunContext) -> int | None:
                         serial_deadline = time.monotonic() + 15
                         while time.monotonic() < serial_deadline:
                             time.sleep(1.0)
-                            result = auto_detect_upload_port()
+                            result = auto_detect_upload_port(
+                                expected_environment=expected_environment
+                            )
                             if result.ok:
                                 print(
                                     f"\u2705 Teensy serial port detected: {result.selected_port}"

--- a/ci/autoresearch/runner.py
+++ b/ci/autoresearch/runner.py
@@ -100,7 +100,7 @@ async def run(args: Args | None = None) -> int:
         if final_environment:
             upload_port = args.upload_port
             if not upload_port:
-                port_result = auto_detect_upload_port(None)
+                port_result = auto_detect_upload_port(final_environment)
                 if not port_result.ok:
                     print(
                         f"{Fore.RED}\u274c Error: No serial port detected for device decode{Style.RESET_ALL}"

--- a/ci/autoresearch/runner.py
+++ b/ci/autoresearch/runner.py
@@ -100,7 +100,7 @@ async def run(args: Args | None = None) -> int:
         if final_environment:
             upload_port = args.upload_port
             if not upload_port:
-                port_result = auto_detect_upload_port()
+                port_result = auto_detect_upload_port(None)
                 if not port_result.ok:
                     print(
                         f"{Fore.RED}\u274c Error: No serial port detected for device decode{Style.RESET_ALL}"

--- a/ci/boards/esp32-c6-devkitc-1.json
+++ b/ci/boards/esp32-c6-devkitc-1.json
@@ -20,9 +20,9 @@
   ],
   "name": "Espressif ESP32-C6-DevKitC-1",
   "upload": {
-    "flash_size": "8MB",
+    "flash_size": "4MB",
     "maximum_ram_size": 327680,
-    "maximum_size": 8388608,
+    "maximum_size": 4194304,
     "require_upload_port": true,
     "speed": 460800
   },

--- a/ci/debug/validate_port_kill.py
+++ b/ci/debug/validate_port_kill.py
@@ -79,7 +79,7 @@ def main():
     detected: ComportResult | None = None
     if args.auto or not args.port:
         print("Auto-detecting upload port...")
-        detected = auto_detect_upload_port()
+        detected = auto_detect_upload_port(None)
         if detected and detected.ok:
             print(f"✅ Auto-detected: {detected}")
             print()

--- a/ci/debug_attached.py
+++ b/ci/debug_attached.py
@@ -1255,7 +1255,7 @@ def main() -> int:
     # Auto-detect upload port if not specified
     upload_port = args.upload_port
     if not upload_port:
-        result = auto_detect_upload_port(None)
+        result = auto_detect_upload_port(args.environment)
         if not result.ok:
             # Port detection failed - display detailed error and exit
             print(f"{Fore.RED}{'=' * 60}")

--- a/ci/debug_attached.py
+++ b/ci/debug_attached.py
@@ -1255,7 +1255,7 @@ def main() -> int:
     # Auto-detect upload port if not specified
     upload_port = args.upload_port
     if not upload_port:
-        result = auto_detect_upload_port()
+        result = auto_detect_upload_port(None)
         if not result.ok:
             # Port detection failed - display detailed error and exit
             print(f"{Fore.RED}{'=' * 60}")

--- a/ci/tests/test_autoresearch_phases.py
+++ b/ci/tests/test_autoresearch_phases.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from serial.tools.list_ports_common import ListPortInfo
 
 from ci.autoresearch.args import Args
 from ci.autoresearch.build_driver import BuildDriver
@@ -24,6 +25,7 @@ from ci.autoresearch.phases import (
     _run_schema_and_pin_setup,
     _run_tests_or_special_mode,
 )
+from ci.util.port_utils import ChipDetectionResult, auto_detect_upload_port
 
 
 # Module path for patching symbols imported into phases.py
@@ -409,6 +411,64 @@ class TestResolvePortAndEnvironment:
             mock_time.sleep = MagicMock()
             rc = asyncio.run(_resolve_port_and_environment(ctx))
         assert rc == 1
+
+
+class TestAutoDetectUploadPort:
+    """Test USB port detection edge cases used by autoresearch."""
+
+    def test_expected_environment_probe_failure_falls_back_to_descriptor(self) -> None:
+        port = ListPortInfo("COM9")
+        port.description = "USB JTAG/serial debug unit"
+        port.hwid = "USB VID:PID=303A:1001"
+
+        with (
+            patch(
+                "ci.util.port_utils.serial.tools.list_ports.comports",
+                return_value=[port],
+            ),
+            patch(
+                "ci.util.port_utils.detect_attached_chip",
+                return_value=ChipDetectionResult(
+                    ok=False,
+                    chip_type=None,
+                    environment=None,
+                    error_message="probe timed out",
+                ),
+            ) as detect_chip,
+        ):
+            result = auto_detect_upload_port("esp32c6")
+
+        assert result.ok is True
+        assert result.selected_port == "COM9"
+        detect_chip.assert_called_once_with("COM9", timeout=3.0)
+
+    def test_expected_environment_positive_mismatch_fails(self) -> None:
+        port = ListPortInfo("COM9")
+        port.description = "USB JTAG/serial debug unit"
+        port.hwid = "USB VID:PID=303A:1001"
+
+        with (
+            patch(
+                "ci.util.port_utils.serial.tools.list_ports.comports",
+                return_value=[port],
+            ),
+            patch(
+                "ci.util.port_utils.detect_attached_chip",
+                return_value=ChipDetectionResult(
+                    ok=True,
+                    chip_type="ESP32-S3",
+                    environment="esp32s3",
+                    error_message=None,
+                ),
+            ),
+        ):
+            result = auto_detect_upload_port("esp32c6")
+
+        assert result.ok is False
+        assert result.selected_port is None
+        assert "No USB serial port matched expected environment" in (
+            result.error_message or ""
+        )
 
 
 # ============================================================

--- a/ci/tests/test_autoresearch_phases.py
+++ b/ci/tests/test_autoresearch_phases.py
@@ -334,7 +334,9 @@ class TestResolvePortAndEnvironment:
         ctx.args = _make_args(upload_port=None)
         mock_result = MagicMock(ok=True, selected_port="COM5")
         with (
-            patch(f"{_PATCH_MOD}.auto_detect_upload_port", return_value=mock_result),
+            patch(
+                f"{_PATCH_MOD}.auto_detect_upload_port", return_value=mock_result
+            ) as auto_detect,
             patch(
                 f"{_PATCH_MOD}.select_build_driver", return_value=_make_mock_driver()
             ),
@@ -346,6 +348,29 @@ class TestResolvePortAndEnvironment:
             rc = asyncio.run(_resolve_port_and_environment(ctx))
         assert rc is None
         assert ctx.upload_port == "COM5"
+        assert ctx.final_environment == "esp32s3"
+        auto_detect.assert_called_once_with(expected_environment="esp32s3")
+
+    def test_auto_detect_port_uses_requested_environment(self) -> None:
+        ctx = _make_ctx(upload_port=None, final_environment="esp32c6")
+        ctx.args = _make_args(upload_port=None, environment="esp32c6")
+        mock_result = MagicMock(ok=True, selected_port="COM9")
+        with (
+            patch(
+                f"{_PATCH_MOD}.auto_detect_upload_port", return_value=mock_result
+            ) as auto_detect,
+            patch(
+                f"{_PATCH_MOD}.select_build_driver", return_value=_make_mock_driver()
+            ),
+            patch(
+                "ci.util.pio_package_daemon.get_default_environment",
+                return_value=None,
+            ),
+        ):
+            rc = asyncio.run(_resolve_port_and_environment(ctx))
+        assert rc is None
+        assert ctx.upload_port == "COM9"
+        auto_detect.assert_called_once_with(expected_environment="esp32c6")
 
     def test_cli_upload_port(self) -> None:
         ctx = _make_ctx(upload_port=None)

--- a/ci/util/port_utils.py
+++ b/ci/util/port_utils.py
@@ -66,7 +66,7 @@ class ComportResult:
     all_ports: list[ListPortInfo] = field(default_factory=lambda: [])
 
 
-def auto_detect_upload_port(expected_environment: str | None = None) -> ComportResult:
+def auto_detect_upload_port(expected_environment: str | None) -> ComportResult:
     """Auto-detect the upload port from available serial ports.
 
     Only considers USB devices - filters out Bluetooth and other non-USB ports.
@@ -133,9 +133,11 @@ def auto_detect_upload_port(expected_environment: str | None = None) -> ComportR
     esp_environments = {env.lower() for env in CHIP_TO_ENVIRONMENT.values()}
     if expected_env in esp_environments:
         probe_notes: list[str] = []
+        saw_positive_detection = False
         for port in usb_ports:
             chip_result = detect_attached_chip(port.device, timeout=3.0)
             if chip_result.ok:
+                saw_positive_detection = True
                 detected_env = chip_result.environment or "unknown"
                 probe_notes.append(
                     f"{port.device}: {chip_result.chip_type} ({detected_env})"
@@ -152,17 +154,19 @@ def auto_detect_upload_port(expected_environment: str | None = None) -> ComportR
                     f"{port.device}: detection failed ({chip_result.error_message})"
                 )
 
-        expected_chip = environment_to_chip(expected_env) or expected_environment
-        return ComportResult(
-            ok=False,
-            selected_port=None,
-            error_message=(
-                f"No USB serial port matched expected environment "
-                f"'{expected_environment}' ({expected_chip}). Probed: "
-                + "; ".join(probe_notes)
-            ),
-            all_ports=all_ports,
-        )
+        if saw_positive_detection:
+            expected_chip = environment_to_chip(expected_env) or expected_environment
+            return ComportResult(
+                ok=False,
+                selected_port=None,
+                error_message=(
+                    f"No USB serial port matched expected environment "
+                    f"'{expected_environment}' ({expected_chip}). Probed: "
+                    + "; ".join(probe_notes)
+                ),
+                all_ports=all_ports,
+            )
+        # Probe was inconclusive; fall through to the USB descriptor heuristic.
 
     # Select best USB port (prefer ESP32/Arduino chips if available)
     selected_port = None

--- a/ci/util/port_utils.py
+++ b/ci/util/port_utils.py
@@ -66,7 +66,7 @@ class ComportResult:
     all_ports: list[ListPortInfo] = field(default_factory=lambda: [])
 
 
-def auto_detect_upload_port() -> ComportResult:
+def auto_detect_upload_port(expected_environment: str | None = None) -> ComportResult:
     """Auto-detect the upload port from available serial ports.
 
     Only considers USB devices - filters out Bluetooth and other non-USB ports.
@@ -126,6 +126,41 @@ def auto_detect_upload_port() -> ComportResult:
             ok=False,
             selected_port=None,
             error_message=f"No USB serial ports found (only {types_str} ports detected)",
+            all_ports=all_ports,
+        )
+
+    expected_env = expected_environment.lower() if expected_environment else None
+    esp_environments = {env.lower() for env in CHIP_TO_ENVIRONMENT.values()}
+    if expected_env in esp_environments:
+        probe_notes: list[str] = []
+        for port in usb_ports:
+            chip_result = detect_attached_chip(port.device, timeout=3.0)
+            if chip_result.ok:
+                detected_env = chip_result.environment or "unknown"
+                probe_notes.append(
+                    f"{port.device}: {chip_result.chip_type} ({detected_env})"
+                )
+                if detected_env.lower() == expected_env:
+                    return ComportResult(
+                        ok=True,
+                        selected_port=port.device,
+                        error_message=None,
+                        all_ports=all_ports,
+                    )
+            else:
+                probe_notes.append(
+                    f"{port.device}: detection failed ({chip_result.error_message})"
+                )
+
+        expected_chip = environment_to_chip(expected_env) or expected_environment
+        return ComportResult(
+            ok=False,
+            selected_port=None,
+            error_message=(
+                f"No USB serial port matched expected environment "
+                f"'{expected_environment}' ({expected_chip}). Probed: "
+                + "; ".join(probe_notes)
+            ),
             all_ports=all_ports,
         )
 
@@ -478,4 +513,13 @@ def chip_to_environment(chip_type: str) -> str | None:
         if chip_upper.startswith(known_chip.upper()):
             return env
 
+    return None
+
+
+def environment_to_chip(environment: str) -> str | None:
+    """Map a PlatformIO environment name to its base ESP chip type."""
+    env_lower = environment.lower()
+    for chip_type, env in CHIP_TO_ENVIRONMENT.items():
+        if env.lower() == env_lower:
+            return chip_type
     return None

--- a/examples/AutoResearch/AutoResearch.ino
+++ b/examples/AutoResearch/AutoResearch.ino
@@ -183,6 +183,9 @@
 
 #include <FastLED.h>
 #include "fl/channels/all_drivers.h"  // for FastLED.enableAllDrivers() post-#2428
+#if defined(FL_IS_ESP32)
+#include "platforms/esp/32/watchdog_esp32.h"
+#endif
 #include "fl/stl/undef.h"  // Undefine Arduino macros (DEFAULT, INPUT, OUTPUT)
 #include "fl/stl/sstream.h"
 #include "Common.h"
@@ -215,7 +218,12 @@
 // ============================================================================
 
 // Serial port timeout (milliseconds) - wait for serial monitor to attach
-#define SERIAL_TIMEOUT_MS 120000  // 120 seconds
+static constexpr uint32_t SERIAL_TIMEOUT_MS = 120000;  // 120 seconds
+#if defined(FL_IS_ESP_32S3) || defined(FL_IS_ESP_32C3) || defined(FL_IS_ESP_32C6) || defined(FL_IS_ESP_32H2) || defined(CONFIG_IDF_TARGET_ESP32P4)
+static constexpr uint32_t AUTORESEARCH_SERIAL_WAIT_MS = 2000;
+#else
+static constexpr uint32_t AUTORESEARCH_SERIAL_WAIT_MS = SERIAL_TIMEOUT_MS;
+#endif
 
 const fl::RxBackend RX_BACKEND = fl::RxBackend::PLATFORM_DEFAULT;
 
@@ -299,9 +307,13 @@ void setup() {
     // kept as defense-in-depth for sketches that bypass fl::serial_begin.
     Serial.setTxTimeoutMs(0);  // ok serial - platform-specific TX timeout, no fl:: equivalent
 #endif
-    while (!fl::serial_ready() && millis() < SERIAL_TIMEOUT_MS);  // Wait for serial monitor (early exits when connected)
+    uint32_t serial_wait_start = millis();
+    while (!fl::serial_ready() && (millis() - serial_wait_start) < AUTORESEARCH_SERIAL_WAIT_MS);  // Wait for serial monitor (early exits when connected)
 
     FL_WARN("[SETUP] AutoResearch sketch starting - serial output active");
+#if defined(FL_IS_ESP32)
+    fl::watchdog_setup(15000);
+#endif
 
     // Initialize RX buffer dynamically (uses PSRAM if available, falls back to heap)
     g_rx_buffer_storage.resize(RX_BUFFER_SIZE);

--- a/examples/AutoResearch/AutoResearchParlioEncode.h
+++ b/examples/AutoResearch/AutoResearchParlioEncode.h
@@ -20,6 +20,9 @@
 /// Output: `BENCH_PARLIO_*` lines via `esp_rom_printf` -> USB-Serial-JTAG (COM25)
 /// so capture works without depending on the testSimd RPC routing (#2541).
 /// **Invocation:** RPC-only via `parlioEncodeBenchmark` in AutoResearchRemote.cpp.
+///
+/// Current implementation times the production BF1 pipe4 encode path and skips
+/// PSRAM-only placements when PSRAM is not present.
 
 #pragma once
 
@@ -49,13 +52,15 @@ struct ParlioEncodeResult {
     fl::u32 lanes;             // 16
     fl::u32 leds_per_lane;     // 256 (matches the standard P4 test config)
 
-    // Per-byte-position hot loop = 16-lane gather + wave8Transpose_16 + memcpy.
+    // Per-byte-position hot loop = 16-lane gather + BF1 pipe4 direct encode.
     // 4 placements of {scratch, output}: SRAM/SRAM, SRAM/PSRAM, PSRAM/SRAM, PSRAM/PSRAM.
     fl::u32 perpos_ss_us;      // scratch SRAM, output SRAM
     fl::u32 perpos_sp_us;      // scratch SRAM, output PSRAM
     fl::u32 perpos_ps_us;      // scratch PSRAM, output SRAM
     fl::u32 perpos_pp_us;      // scratch PSRAM, output PSRAM
 
+    bool scratch_psram_ok;
+    bool output_psram_ok;
     fl::u32 sink;
 };
 
@@ -67,22 +72,54 @@ namespace {
 // Wave8 path (parlio_engine.cpp.hpp ≈line 981-994). lane_stride matches the
 // production layout: lane k reads from scratch[k * lane_stride + byte_offset].
 FASTLED_FORCE_INLINE FL_IRAM
-fl::u32 fl_parlio_inner_one_byte_position(const fl::u8 *scratch,
-                                          fl::size_t lane_stride,
-                                          fl::size_t byte_offset,
-                                          const fl::Wave8ByteExpansionLut &byte_lut,
-                                          fl::u8 *output,
-                                          fl::size_t output_idx) {
+fl::u32 fl_parlio_inner_one_byte_position_bf1(const fl::u8 *scratch,
+                                              fl::size_t lane_stride,
+                                              fl::size_t byte_offset,
+                                              const fl::Wave8ByteExpansionLut &byte_lut,
+                                              fl::u8 *output,
+                                              fl::size_t output_idx) {
     fl::u8 lanes[16];
     for (fl::size_t lane = 0; lane < 16; lane++) {
         lanes[lane] = scratch[lane * lane_stride + byte_offset];
     }
-    fl::u8 transposed[16 * sizeof(fl::Wave8Byte)];
-    fl::wave8Transpose_16(reinterpret_cast<const fl::u8(&)[16]>(lanes), byte_lut,
-                          reinterpret_cast<fl::u8(&)[16 * sizeof(fl::Wave8Byte)]>(transposed));
-    fl::memcpy(output + output_idx, transposed, sizeof(transposed));
-    // Sink to defeat DCE: cheap reduction on a few output bytes.
+    fl::wave8Transpose_16_bf1(
+        reinterpret_cast<const fl::u8(&)[16]>(lanes), byte_lut,
+        *reinterpret_cast<fl::u8(*)[16 * sizeof(fl::Wave8Byte)]>(output + output_idx));
     return static_cast<fl::u32>(output[output_idx] ^ output[output_idx + 127]);
+}
+
+FASTLED_FORCE_INLINE FL_IRAM
+fl::u32 fl_parlio_inner_four_byte_positions_bf1_pipe4(const fl::u8 *scratch,
+                                                      fl::size_t lane_stride,
+                                                      fl::size_t byte_offset,
+                                                      const fl::Wave8ByteExpansionLut &byte_lut,
+                                                      fl::u8 *output) {
+    fl::u8 lanes_a[16];
+    fl::u8 lanes_b[16];
+    fl::u8 lanes_c[16];
+    fl::u8 lanes_d[16];
+    for (fl::size_t lane = 0; lane < 16; lane++) {
+        const fl::u8 *base = scratch + lane * lane_stride + byte_offset;
+        lanes_a[lane] = base[0];
+        lanes_b[lane] = base[1];
+        lanes_c[lane] = base[2];
+        lanes_d[lane] = base[3];
+    }
+
+    constexpr fl::size_t BLOCK_SIZE = 16 * sizeof(fl::Wave8Byte);
+    fl::u8 *out_a = output + byte_offset * BLOCK_SIZE;
+    fl::wave8Transpose_16x4_bf1_pipe4(
+        reinterpret_cast<const fl::u8(&)[16]>(lanes_a),
+        reinterpret_cast<const fl::u8(&)[16]>(lanes_b),
+        reinterpret_cast<const fl::u8(&)[16]>(lanes_c),
+        reinterpret_cast<const fl::u8(&)[16]>(lanes_d),
+        byte_lut,
+        *reinterpret_cast<fl::u8(*)[BLOCK_SIZE]>(out_a),
+        *reinterpret_cast<fl::u8(*)[BLOCK_SIZE]>(out_a + BLOCK_SIZE),
+        *reinterpret_cast<fl::u8(*)[BLOCK_SIZE]>(out_a + 2 * BLOCK_SIZE),
+        *reinterpret_cast<fl::u8(*)[BLOCK_SIZE]>(out_a + 3 * BLOCK_SIZE));
+
+    return static_cast<fl::u32>(out_a[0] ^ out_a[BLOCK_SIZE * 4 - 1]);
 }
 
 // Time one configuration: scratch + output buffers (caller pre-allocates).
@@ -104,14 +141,22 @@ inline fl::u32 fl_parlio_measure(const fl::u8 *scratch, fl::size_t scratch_size,
         return 0u;
     }
 
+    constexpr fl::size_t BLOCK_SIZE = LANES * sizeof(fl::Wave8Byte);
     fl::u32 t0 = micros();
-    for (int it = 0; it < iters_byte_positions; ++it) {
+    int it = 0;
+    while (it < iters_byte_positions) {
         const fl::size_t byte_offset =
             static_cast<fl::size_t>(it) % BYTES_PER_LANE;
-        const fl::size_t output_idx =
-            byte_offset * LANES * sizeof(fl::Wave8Byte);
-        *sink ^= fl_parlio_inner_one_byte_position(
-            scratch, lane_stride, byte_offset, byte_lut, output, output_idx);
+        if (byte_offset + 3 < BYTES_PER_LANE && it + 3 < iters_byte_positions) {
+            *sink ^= fl_parlio_inner_four_byte_positions_bf1_pipe4(
+                scratch, lane_stride, byte_offset, byte_lut, output);
+            it += 4;
+        } else {
+            const fl::size_t output_idx = byte_offset * BLOCK_SIZE;
+            *sink ^= fl_parlio_inner_one_byte_position_bf1(
+                scratch, lane_stride, byte_offset, byte_lut, output, output_idx);
+            it += 1;
+        }
     }
     return micros() - t0;
 }
@@ -146,27 +191,39 @@ inline ParlioEncodeResult measureParlioEncode(int iters_in = 12000) {
     fl::Wave8ByteExpansionLut byte_lut = fl::buildWave8ByteExpansionLUT(nib_lut);
 
     fl::u8 *scratch_sram = fl_parlio_alloc(SCRATCH_BYTES, /*psram=*/false);
-    fl::u8 *scratch_psram = fl_parlio_alloc(SCRATCH_BYTES, /*psram=*/true);
     fl::u8 *output_sram = fl_parlio_alloc(OUTPUT_BYTES, /*psram=*/false);
-    fl::u8 *output_psram = fl_parlio_alloc(OUTPUT_BYTES, /*psram=*/true);
 
-    if (!scratch_sram || !scratch_psram || !output_sram || !output_psram) {
-        // Partial alloc failed; bail with zeros so the caller knows.
+    if (!scratch_sram || !output_sram) {
         heap_caps_free(scratch_sram);
-        heap_caps_free(scratch_psram);
         heap_caps_free(output_sram);
-        heap_caps_free(output_psram);
+        result.iters = 0;
         return result;
     }
 
-    // Fill both scratches with representative LED data.
+    fl::u8 *scratch_psram = fl_parlio_alloc(SCRATCH_BYTES, /*psram=*/true);
+    fl::u8 *output_psram = fl_parlio_alloc(OUTPUT_BYTES, /*psram=*/true);
+    result.scratch_psram_ok = scratch_psram != nullptr;
+    result.output_psram_ok = output_psram != nullptr;
+
+    if (!scratch_psram) {
+        scratch_psram = scratch_sram;
+    }
+    if (!output_psram) {
+        output_psram = output_sram;
+    }
+
+    // Fill scratch buffers with representative LED data.
     for (fl::size_t i = 0; i < SCRATCH_BYTES; ++i) {
         const fl::u8 v = static_cast<fl::u8>((i * 31 + 7) & 0xFF);
         scratch_sram[i] = v;
-        scratch_psram[i] = v;
+        if (result.scratch_psram_ok) {
+            scratch_psram[i] = v;
+        }
     }
     fl::memset(output_sram, 0, OUTPUT_BYTES);
-    fl::memset(output_psram, 0, OUTPUT_BYTES);
+    if (result.output_psram_ok) {
+        fl::memset(output_psram, 0, OUTPUT_BYTES);
+    }
 
     volatile fl::u32 sink = 0;
 
@@ -174,26 +231,35 @@ inline ParlioEncodeResult measureParlioEncode(int iters_in = 12000) {
     fl_parlio_measure(scratch_sram, SCRATCH_BYTES, output_sram, OUTPUT_BYTES,
                       byte_lut, 64, &sink);
 
-    // Four placements. Each runs the same iters so totals are comparable.
     result.perpos_ss_us = fl_parlio_measure(
         scratch_sram, SCRATCH_BYTES, output_sram, OUTPUT_BYTES,
         byte_lut, iters_in, &sink);
-    result.perpos_sp_us = fl_parlio_measure(
-        scratch_sram, SCRATCH_BYTES, output_psram, OUTPUT_BYTES,
-        byte_lut, iters_in, &sink);
-    result.perpos_ps_us = fl_parlio_measure(
-        scratch_psram, SCRATCH_BYTES, output_sram, OUTPUT_BYTES,
-        byte_lut, iters_in, &sink);
-    result.perpos_pp_us = fl_parlio_measure(
-        scratch_psram, SCRATCH_BYTES, output_psram, OUTPUT_BYTES,
-        byte_lut, iters_in, &sink);
+    if (result.output_psram_ok) {
+        result.perpos_sp_us = fl_parlio_measure(
+            scratch_sram, SCRATCH_BYTES, output_psram, OUTPUT_BYTES,
+            byte_lut, iters_in, &sink);
+    }
+    if (result.scratch_psram_ok) {
+        result.perpos_ps_us = fl_parlio_measure(
+            scratch_psram, SCRATCH_BYTES, output_sram, OUTPUT_BYTES,
+            byte_lut, iters_in, &sink);
+    }
+    if (result.scratch_psram_ok && result.output_psram_ok) {
+        result.perpos_pp_us = fl_parlio_measure(
+            scratch_psram, SCRATCH_BYTES, output_psram, OUTPUT_BYTES,
+            byte_lut, iters_in, &sink);
+    }
 
     result.sink = static_cast<fl::u32>(sink);
 
     heap_caps_free(scratch_sram);
-    heap_caps_free(scratch_psram);
+    if (result.scratch_psram_ok) {
+        heap_caps_free(scratch_psram);
+    }
     heap_caps_free(output_sram);
-    heap_caps_free(output_psram);
+    if (result.output_psram_ok) {
+        heap_caps_free(output_psram);
+    }
     return result;
 }
 
@@ -232,6 +298,9 @@ inline void printParlioEncodeResultRom(const ParlioEncodeResult &r) {
     esp_rom_printf("\nBENCH_PARLIO_START (16 lanes x 256 LEDs, byte-LUT, #2526 follow-up)\n");  // ok esp_rom_printf - boot-time bench output to COM25 (#2541)
     esp_rom_printf("BENCH_PARLIO iters=%u lanes=%u leds=%u sink=%u\n",  // ok esp_rom_printf - boot-time bench output to COM25 (#2541)
                    r.iters, r.lanes, r.leds_per_lane, r.sink);
+    esp_rom_printf("BENCH_PARLIO psram scratch=%u output=%u\n",  // ok esp_rom_printf - boot-time bench output to COM25 (#2541)
+                   r.scratch_psram_ok ? 1u : 0u,
+                   r.output_psram_ok ? 1u : 0u);
     esp_rom_printf("BENCH_PARLIO perpos_us  ss=%u sp=%u ps=%u pp=%u\n",  // ok esp_rom_printf - boot-time bench output to COM25 (#2541)
                    r.perpos_ss_us, r.perpos_sp_us, r.perpos_ps_us, r.perpos_pp_us);
     esp_rom_printf("BENCH_PARLIO perpos_ns_each  ss=%u sp=%u ps=%u pp=%u\n",  // ok esp_rom_printf - boot-time bench output to COM25 (#2541)

--- a/examples/AutoResearch/AutoResearchParlioStream.h
+++ b/examples/AutoResearch/AutoResearchParlioStream.h
@@ -31,6 +31,10 @@
 #include "fl/stl/span.h"
 #include "fl/stl/vector.h"
 
+#if defined(ESP32) && FASTLED_ESP32_HAS_PARLIO
+#include "platforms/esp/32/drivers/parlio/parlio_engine.h"
+#endif
+
 #if defined(ARDUINO_ARCH_ESP32) || defined(ESP_PLATFORM)
 #include <Arduino.h>  // micros()
 #endif
@@ -39,6 +43,7 @@ namespace autoresearch {
 namespace parlio_stream {
 
 constexpr int kMaxIterations = 16;  // result struct iter timing array fixed size
+constexpr int kMaxLanes = 16;
 
 inline bool isFastLedOutputPinValid(int pin) {
     if (pin < 0 || pin >= 64) {
@@ -54,8 +59,11 @@ inline bool isFastLedOutputPinValid(int pin) {
 struct ValidateResult {
     bool channels_ok;          // true if all PARLIO channels created cleanly
     bool completed;            // true if every iteration completed within timeout
+    int base_tx_pin;           // first PARLIO TX pin used
+    bool explicit_tx_pins;     // true when caller supplied a non-contiguous pin map
     int lanes;                 // PARLIO lane count tested
     int leds_per_lane;         // LEDs per lane
+    int tx_pins[kMaxLanes];    // effective pin per lane
     int iterations;            // number of show() iterations run
     uint32_t per_iter_us[kMaxIterations];  // per-iteration show()+wait() total time
     uint32_t per_iter_show_us[kMaxIterations];  // per-iter show() return time (pre-encode + submit)
@@ -63,8 +71,16 @@ struct ValidateResult {
     uint32_t steady_avg_us;        // average total of iters 1..N-1 (skips iter 0 setup)
     uint32_t steady_avg_show_us;   // average show() time of iters 1..N-1
     uint32_t steady_avg_wait_us;   // average wait() time of iters 1..N-1
+    uint32_t tx_done_count;        // PARLIO txDone ISR calls from final metrics
+    uint32_t worker_isr_count;     // PARLIO worker ISR calls from final metrics
+    uint32_t underrun_count;       // ring-empty-with-bytes-pending events
+    uint32_t ring_count;           // final PARLIO ring occupancy
+    uint32_t bytes_total;          // final engine total source bytes
+    uint32_t bytes_transmitted;    // final engine transmitted source bytes
     int failed_iter;           // index of first iter that exceeded timeout, or -1
     uint32_t timeout_ms;       // effective timeout passed in
+    bool ring_error;           // true if PARLIO flagged ring accounting/buffer error
+    bool hardware_idle;        // true if hardware went idle before stream completed
 };
 
 /// @brief Run the PARLIO streaming functional test.
@@ -74,31 +90,45 @@ struct ValidateResult {
 /// @param num_leds     LEDs per lane.
 /// @param iterations   Number of back-to-back show()+wait() cycles (capped at kMaxIterations).
 /// @param timeout_ms   Per-iteration timeout. Test fails if any iter exceeds this.
+/// @param tx_pins      Optional explicit per-lane pins. If null, uses contiguous base_tx_pin+lane.
 inline ValidateResult validateParlioStreaming(int base_tx_pin,
                                               int num_lanes,
                                               int num_leds,
                                               int iterations,
-                                              uint32_t timeout_ms) {
+                                              uint32_t timeout_ms,
+                                              const int* tx_pins = nullptr) {
     ValidateResult r{};
     r.channels_ok = false;
     r.completed = false;
+    r.explicit_tx_pins = tx_pins != nullptr;
+    r.base_tx_pin = base_tx_pin;
     r.lanes = num_lanes;
     r.leds_per_lane = num_leds;
     r.iterations = iterations;
     r.timeout_ms = timeout_ms;
     r.failed_iter = -1;
+    for (int lane = 0; lane < kMaxLanes; ++lane) {
+        r.tx_pins[lane] = -1;
+    }
 
     if (iterations < 1) iterations = 1;
     if (iterations > kMaxIterations) iterations = kMaxIterations;
     r.iterations = iterations;
+    if (!tx_pins && base_tx_pin < 0) return r;
     if (num_lanes < 1 || num_lanes > 16) return r;
     if (num_leds < 1) return r;
+    if (tx_pins) {
+        base_tx_pin = tx_pins[0];
+        r.base_tx_pin = base_tx_pin;
+        for (int lane = 0; lane < num_lanes; ++lane) {
+            if (tx_pins[lane] < 0) return r;
+        }
+    }
 
 #if defined(ARDUINO_ARCH_ESP32) || defined(ESP_PLATFORM)
     // Reuse a single static heap-resident LED buffer sized for the canonical
     // worst case (16 lanes × 256 LEDs). Test callers must stay within these
     // bounds. Static to avoid repeated allocation across RPC calls.
-    constexpr int kMaxLanes = 16;
     constexpr int kMaxLEDs = 256;
     if (num_leds > kMaxLEDs) return r;
     static CRGB leds[kMaxLanes][kMaxLEDs];
@@ -114,9 +144,12 @@ inline ValidateResult validateParlioStreaming(int base_tx_pin,
     fl::ChannelOptions parlio_opts;
     parlio_opts.mBus = fl::Bus::PARLIO;
 
+    FastLED.clear(ClearFlags::CHANNELS);
+
     fl::vector<fl::shared_ptr<fl::Channel>> channels;
     for (int lane = 0; lane < num_lanes; ++lane) {
-        const int tx_pin = base_tx_pin + lane;
+        const int tx_pin = tx_pins ? tx_pins[lane] : (base_tx_pin + lane);
+        r.tx_pins[lane] = tx_pin;
         if (!isFastLedOutputPinValid(tx_pin)) {
             FastLED.clear(ClearFlags::CHANNELS);
             return r;
@@ -165,6 +198,20 @@ inline ValidateResult validateParlioStreaming(int base_tx_pin,
     }
 
     FastLED.clear(ClearFlags::CHANNELS);
+
+#if defined(ESP32) && FASTLED_ESP32_HAS_PARLIO
+    {
+        auto metrics = fl::detail::ParlioEngine::getInstance().getDebugMetrics();
+        r.tx_done_count = metrics.mTxDoneCount;
+        r.worker_isr_count = metrics.mWorkerIsrCount;
+        r.underrun_count = metrics.mUnderrunCount;
+        r.ring_count = metrics.mRingCount;
+        r.bytes_total = metrics.mBytesTotal;
+        r.bytes_transmitted = metrics.mBytesTransmitted;
+        r.ring_error = metrics.mRingError;
+        r.hardware_idle = metrics.mHardwareIdle;
+    }
+#endif
 
     r.completed = ok;
     if (ok && iterations > 1) {

--- a/examples/AutoResearch/AutoResearchRemote.cpp
+++ b/examples/AutoResearch/AutoResearchRemote.cpp
@@ -1730,6 +1730,13 @@ void AutoResearchRemoteControl::registerFunctions(fl::shared_ptr<AutoResearchSta
     // within timeout. Returns per-iter timing so the host can diagnose stalls.
     mRemote->bind("parlioStreamValidate", [this](const fl::json& args) -> fl::json {
         fl::json response = fl::json::object();
+        auto invalidArgs = [](const char* message) -> fl::json {
+            fl::json error = fl::json::object();
+            error.set("success", false);
+            error.set("error", "InvalidArgs");
+            error.set("message", message);
+            return error;
+        };
 
         int num_lanes = 16;
         int num_leds = 256;
@@ -1738,6 +1745,7 @@ void AutoResearchRemoteControl::registerFunctions(fl::shared_ptr<AutoResearchSta
         int base_tx_pin = mState->pin_tx;
         int tx_pins[autoresearch::parlio_stream::kMaxLanes];
         bool has_tx_pins = false;
+        bool num_lanes_provided = false;
         for (int i = 0; i < autoresearch::parlio_stream::kMaxLanes; ++i) {
             tx_pins[i] = -1;
         }
@@ -1751,32 +1759,48 @@ void AutoResearchRemoteControl::registerFunctions(fl::shared_ptr<AutoResearchSta
         if (!config.is_null()) {
             if (config.contains("baseTxPin") && config["baseTxPin"].is_int())
                 base_tx_pin = static_cast<int>(config["baseTxPin"].as_int().value());
-            if (config.contains("numLanes") && config["numLanes"].is_int())
+            if (config.contains("numLanes")) {
+                if (!config["numLanes"].is_int()) {
+                    return invalidArgs("numLanes must be an integer");
+                }
                 num_lanes = static_cast<int>(config["numLanes"].as_int().value());
+                num_lanes_provided = true;
+            }
             if (config.contains("numLeds") && config["numLeds"].is_int())
                 num_leds = static_cast<int>(config["numLeds"].as_int().value());
             if (config.contains("iterations") && config["iterations"].is_int())
                 iterations = static_cast<int>(config["iterations"].as_int().value());
             if (config.contains("timeoutMs") && config["timeoutMs"].is_int())
                 timeout_ms = static_cast<int>(config["timeoutMs"].as_int().value());
-            if (config.contains("txPins") && config["txPins"].is_array()) {
-                int parsed_lanes = 0;
+            if (config.contains("txPins")) {
+                if (!config["txPins"].is_array()) {
+                    return invalidArgs("txPins must be an integer array");
+                }
+                if (!num_lanes_provided) {
+                    return invalidArgs("txPins requires numLanes");
+                }
+                if (num_lanes < 1 ||
+                    num_lanes > autoresearch::parlio_stream::kMaxLanes) {
+                    return invalidArgs("numLanes out of range for txPins");
+                }
+
                 const fl::json pins = config["txPins"];
-                for (size_t i = 0;
-                     i < pins.size() && i < autoresearch::parlio_stream::kMaxLanes;
-                     ++i) {
+                if (pins.size() != static_cast<size_t>(num_lanes)) {
+                    return invalidArgs("txPins length must match numLanes");
+                }
+
+                for (int i = 0; i < num_lanes; ++i) {
                     if (!pins[i].is_int()) {
-                        continue;
+                        return invalidArgs("txPins entries must be integers");
                     }
-                    tx_pins[parsed_lanes++] = static_cast<int>(pins[i].as_int().value());
-                }
-                if (parsed_lanes > 0) {
-                    has_tx_pins = true;
-                    if (!(config.contains("numLanes") && config["numLanes"].is_int())) {
-                        num_lanes = parsed_lanes;
+                    int64_t pin_value = pins[i].as_int().value();
+                    if (pin_value < 0 || pin_value >= 64) {
+                        return invalidArgs("txPins entries must be in range 0..63");
                     }
-                    base_tx_pin = tx_pins[0];
+                    tx_pins[i] = static_cast<int>(pin_value);
                 }
+                has_tx_pins = true;
+                base_tx_pin = tx_pins[0];
             }
         }
 

--- a/examples/AutoResearch/AutoResearchRemote.cpp
+++ b/examples/AutoResearch/AutoResearchRemote.cpp
@@ -1582,15 +1582,15 @@ void AutoResearchRemoteControl::registerFunctions(fl::shared_ptr<AutoResearchSta
         parlioEncodeBenchmark_fn.set("name", "parlioEncodeBenchmark");
         parlioEncodeBenchmark_fn.set("phase", "Phase 4: Utility");
         parlioEncodeBenchmark_fn.set("args", "[{iterations}] (optional, default 12000, max 200000)");
-        parlioEncodeBenchmark_fn.set("returns", "{success, iters, lanes, leds_per_lane, perpos_ss_us, perpos_sp_us, perpos_ps_us, perpos_pp_us, sink}");
-        parlioEncodeBenchmark_fn.set("description", "Bench full PARLIO encode hot loop (16-lane gather + wave8Transpose_16 + memcpy) with 4 SRAM/PSRAM placements; answers PSRAM hypothesis + ISR-streaming feasibility");
+        parlioEncodeBenchmark_fn.set("returns", "{success, iters, lanes, leds_per_lane, scratchPsramOk, outputPsramOk, perpos_ss_us, perpos_sp_us, perpos_ps_us, perpos_pp_us, frame_ss_us, frame_sp_us, frame_ps_us, frame_pp_us, sink}");
+        parlioEncodeBenchmark_fn.set("description", "Bench full PARLIO encode hot loop (16-lane gather + BF1 pipe4 direct encode) with SRAM and optional PSRAM placements; answers PSRAM hypothesis + ISR-streaming feasibility");
         functions.push_back(parlioEncodeBenchmark_fn);
 
         fl::json parlioStreamValidate_fn = fl::json::object();
         parlioStreamValidate_fn.set("name", "parlioStreamValidate");
         parlioStreamValidate_fn.set("phase", "Phase 4: Utility");
-        parlioStreamValidate_fn.set("args", "[{numLanes, numLeds, iterations, timeoutMs}] (all optional; defaults 16/256/5/200)");
-        parlioStreamValidate_fn.set("returns", "{success, completed, lanes, leds_per_lane, iterations, perIterUs:[...], steadyAvgUs, failedIter}");
+        parlioStreamValidate_fn.set("args", "[{baseTxPin, txPins, numLanes, numLeds, iterations, timeoutMs}] (all optional; txPins overrides contiguous baseTxPin)");
+        parlioStreamValidate_fn.set("returns", "{success, completed, baseTxPin, txPins, lanes, leds_per_lane, iterations, perIterUs:[...], steadyAvgUs, failedIter, underrunCount, txDoneCount, workerIsrCount, ringError, hardwareIdle}");
         parlioStreamValidate_fn.set("description", "Functional test of the PARLIO ISR-chunked streaming engine (#2548). Drives N back-to-back FastLED.show() calls through the production engine (which uses BF1+pipe4 on 16-lane Wave8 since #2559) and verifies all complete within timeout. Catches hangs/stalls.");
         functions.push_back(parlioStreamValidate_fn);
 
@@ -1735,6 +1735,12 @@ void AutoResearchRemoteControl::registerFunctions(fl::shared_ptr<AutoResearchSta
         int num_leds = 256;
         int iterations = 5;
         int timeout_ms = 200;
+        int base_tx_pin = mState->pin_tx;
+        int tx_pins[autoresearch::parlio_stream::kMaxLanes];
+        bool has_tx_pins = false;
+        for (int i = 0; i < autoresearch::parlio_stream::kMaxLanes; ++i) {
+            tx_pins[i] = -1;
+        }
 
         fl::json config;
         if (args.is_object()) {
@@ -1743,6 +1749,8 @@ void AutoResearchRemoteControl::registerFunctions(fl::shared_ptr<AutoResearchSta
             config = args[0];
         }
         if (!config.is_null()) {
+            if (config.contains("baseTxPin") && config["baseTxPin"].is_int())
+                base_tx_pin = static_cast<int>(config["baseTxPin"].as_int().value());
             if (config.contains("numLanes") && config["numLanes"].is_int())
                 num_lanes = static_cast<int>(config["numLanes"].as_int().value());
             if (config.contains("numLeds") && config["numLeds"].is_int())
@@ -1751,9 +1759,29 @@ void AutoResearchRemoteControl::registerFunctions(fl::shared_ptr<AutoResearchSta
                 iterations = static_cast<int>(config["iterations"].as_int().value());
             if (config.contains("timeoutMs") && config["timeoutMs"].is_int())
                 timeout_ms = static_cast<int>(config["timeoutMs"].as_int().value());
+            if (config.contains("txPins") && config["txPins"].is_array()) {
+                int parsed_lanes = 0;
+                const fl::json pins = config["txPins"];
+                for (size_t i = 0;
+                     i < pins.size() && i < autoresearch::parlio_stream::kMaxLanes;
+                     ++i) {
+                    if (!pins[i].is_int()) {
+                        continue;
+                    }
+                    tx_pins[parsed_lanes++] = static_cast<int>(pins[i].as_int().value());
+                }
+                if (parsed_lanes > 0) {
+                    has_tx_pins = true;
+                    if (!(config.contains("numLanes") && config["numLanes"].is_int())) {
+                        num_lanes = parsed_lanes;
+                    }
+                    base_tx_pin = tx_pins[0];
+                }
+            }
         }
 
         // Clamp inputs to safe ranges.
+        if (base_tx_pin < 0) base_tx_pin = 0;
         if (num_lanes < 1) num_lanes = 1;
         if (num_lanes > 16) num_lanes = 16;
         if (num_leds < 1) num_leds = 1;
@@ -1766,12 +1794,25 @@ void AutoResearchRemoteControl::registerFunctions(fl::shared_ptr<AutoResearchSta
         if (timeout_ms > 5000) timeout_ms = 5000;
 
         auto r = autoresearch::parlio_stream::validateParlioStreaming(
-            mState->pin_tx, num_lanes, num_leds, iterations,
-            static_cast<uint32_t>(timeout_ms));
+            base_tx_pin, num_lanes, num_leds, iterations,
+            static_cast<uint32_t>(timeout_ms),
+            has_tx_pins ? tx_pins : nullptr);
 
         response.set("success", true);
         response.set("channelsOk", r.channels_ok);
         response.set("completed", r.completed);
+        response.set("baseTxPin", static_cast<int64_t>(r.base_tx_pin));
+        int last_tx_pin = r.base_tx_pin + r.lanes - 1;
+        if (r.explicit_tx_pins) {
+            for (int i = r.lanes - 1; i >= 0; --i) {
+                if (r.tx_pins[i] >= 0) {
+                    last_tx_pin = r.tx_pins[i];
+                    break;
+                }
+            }
+        }
+        response.set("lastTxPin", static_cast<int64_t>(last_tx_pin));
+        response.set("explicitTxPins", r.explicit_tx_pins);
         response.set("lanes", static_cast<int64_t>(r.lanes));
         response.set("ledsPerLane", static_cast<int64_t>(r.leds_per_lane));
         response.set("iterations", static_cast<int64_t>(r.iterations));
@@ -1780,6 +1821,19 @@ void AutoResearchRemoteControl::registerFunctions(fl::shared_ptr<AutoResearchSta
         response.set("steadyAvgWaitUs", static_cast<int64_t>(r.steady_avg_wait_us));
         response.set("failedIter", static_cast<int64_t>(r.failed_iter));
         response.set("timeoutMs", static_cast<int64_t>(r.timeout_ms));
+        response.set("txDoneCount", static_cast<int64_t>(r.tx_done_count));
+        response.set("workerIsrCount", static_cast<int64_t>(r.worker_isr_count));
+        response.set("underrunCount", static_cast<int64_t>(r.underrun_count));
+        response.set("ringCount", static_cast<int64_t>(r.ring_count));
+        response.set("bytesTotal", static_cast<int64_t>(r.bytes_total));
+        response.set("bytesTransmitted", static_cast<int64_t>(r.bytes_transmitted));
+        response.set("ringError", r.ring_error);
+        response.set("hardwareIdle", r.hardware_idle);
+        fl::json response_tx_pins = fl::json::array();
+        for (int i = 0; i < r.lanes; ++i) {
+            response_tx_pins.push_back(static_cast<int64_t>(r.tx_pins[i]));
+        }
+        response.set("txPins", response_tx_pins);
         fl::json per_iter = fl::json::array();
         fl::json per_iter_show = fl::json::array();
         fl::json per_iter_wait = fl::json::array();
@@ -1818,10 +1872,23 @@ void AutoResearchRemoteControl::registerFunctions(fl::shared_ptr<AutoResearchSta
         response.set("iters", static_cast<int64_t>(r.iters));
         response.set("lanes", static_cast<int64_t>(r.lanes));
         response.set("leds_per_lane", static_cast<int64_t>(r.leds_per_lane));
+        response.set("scratchPsramOk", r.scratch_psram_ok);
+        response.set("outputPsramOk", r.output_psram_ok);
         response.set("perpos_ss_us", static_cast<int64_t>(r.perpos_ss_us));
         response.set("perpos_sp_us", static_cast<int64_t>(r.perpos_sp_us));
         response.set("perpos_ps_us", static_cast<int64_t>(r.perpos_ps_us));
         response.set("perpos_pp_us", static_cast<int64_t>(r.perpos_pp_us));
+        if (r.iters > 0) {
+            constexpr fl::u32 kFrameBytePositions = 256 * 3;
+            response.set("frame_ss_us", static_cast<int64_t>(
+                static_cast<fl::u64>(r.perpos_ss_us) * kFrameBytePositions / r.iters));
+            response.set("frame_sp_us", static_cast<int64_t>(
+                static_cast<fl::u64>(r.perpos_sp_us) * kFrameBytePositions / r.iters));
+            response.set("frame_ps_us", static_cast<int64_t>(
+                static_cast<fl::u64>(r.perpos_ps_us) * kFrameBytePositions / r.iters));
+            response.set("frame_pp_us", static_cast<int64_t>(
+                static_cast<fl::u64>(r.perpos_pp_us) * kFrameBytePositions / r.iters));
+        }
         response.set("sink", static_cast<int64_t>(r.sink));
         return response;
     });

--- a/src/platforms/esp/32/drivers/_build.cpp.hpp
+++ b/src/platforms/esp/32/drivers/_build.cpp.hpp
@@ -23,6 +23,8 @@
 #include "platforms/esp/32/drivers/channel_manager_esp32.cpp.hpp"
 #include "platforms/esp/32/drivers/cled.cpp.hpp"
 #include "platforms/esp/32/drivers/spi_hw_manager_esp32.cpp.hpp"
+#include "platforms/esp/32/drivers/uart_esp32_idf.hpp"
+#include "platforms/esp/32/drivers/usb_serial_jtag_esp32_idf.hpp"
 
 // begin sub directory includes
 #include "platforms/esp/32/drivers/ble/_build.cpp.hpp"

--- a/src/platforms/esp/32/drivers/lcd_spi/channel_driver_lcd_clockless.cpp.hpp
+++ b/src/platforms/esp/32/drivers/lcd_spi/channel_driver_lcd_clockless.cpp.hpp
@@ -280,7 +280,6 @@ bool FL_IRAM ChannelDriverLcdClockless::isrChunkDone(void *panel_io,
     if (!self->mPeripheral->transmit(buf, dmaBytes)) {
         ctx.mStreamComplete = true;
         self->mBusy = false;
-        FL_WARN("ChannelDriverLcdClockless: ISR transmit failed");
     }
 
     return false;

--- a/src/platforms/esp/32/drivers/lcd_spi/lcd_spi_peripheral_esp.cpp.hpp
+++ b/src/platforms/esp/32/drivers/lcd_spi/lcd_spi_peripheral_esp.cpp.hpp
@@ -332,8 +332,6 @@ bool FL_IRAM LcdSpiPeripheralEsp::transmit(const u16 *buffer,
             }
         } else {
             if (xSemaphoreTake(mCompleteSem, pdMS_TO_TICKS(2000)) != pdTRUE) {
-                FL_WARN("LcdSpiPeripheralEsp: Timed out waiting for previous "
-                        "transmit to complete");
                 mBusy = false;
                 return false;
             }
@@ -377,8 +375,6 @@ bool FL_IRAM LcdSpiPeripheralEsp::transmit(const u16 *buffer,
         esp_err_t err =
             esp_lcd_new_panel_io_i80(mI80Bus, &io_config, &mPanelIo);
         if (err != ESP_OK) {
-            FL_WARN("LcdSpiPeripheralEsp: Failed to recreate panel IO: "
-                    << err);
             return false;
         }
     }
@@ -405,7 +401,6 @@ bool FL_IRAM LcdSpiPeripheralEsp::transmit(const u16 *buffer,
 
     if (err != ESP_OK) {
         mBusy = false;
-        FL_WARN("LcdSpiPeripheralEsp: tx_color failed: " << err);
         return false;
     }
 

--- a/src/platforms/esp/32/drivers/parlio/channel_driver_parlio.cpp.hpp
+++ b/src/platforms/esp/32/drivers/parlio/channel_driver_parlio.cpp.hpp
@@ -638,4 +638,26 @@ void ChannelDriverPARLIO::beginSingleSpiChannel(const ChannelDataPtr& channelDat
     }
 }
 
+ParlioDebugMetrics getParlioDebugMetrics() FL_NOEXCEPT {
+    const detail::ParlioDebugMetrics engine_metrics =
+        detail::ParlioEngine::getInstance().getDebugMetrics();
+    ParlioDebugMetrics metrics = {};
+    metrics.mStartTimeUs = engine_metrics.mStartTimeUs;
+    metrics.mEndTimeUs = engine_metrics.mEndTimeUs;
+    metrics.mIsrCount = engine_metrics.mIsrCount;
+    metrics.mChunksQueued = engine_metrics.mChunksQueued;
+    metrics.mChunksCompleted = engine_metrics.mChunksCompleted;
+    metrics.mBytesTotal = engine_metrics.mBytesTotal;
+    metrics.mBytesTransmitted = engine_metrics.mBytesTransmitted;
+    metrics.mTxDoneCount = engine_metrics.mTxDoneCount;
+    metrics.mWorkerIsrCount = engine_metrics.mWorkerIsrCount;
+    metrics.mUnderrunCount = engine_metrics.mUnderrunCount;
+    metrics.mRingCount = engine_metrics.mRingCount;
+    metrics.mErrorCode = engine_metrics.mErrorCode;
+    metrics.mRingError = engine_metrics.mRingError;
+    metrics.mHardwareIdle = engine_metrics.mHardwareIdle;
+    metrics.mTransmissionActive = engine_metrics.mTransmissionActive;
+    return metrics;
+}
+
 } // namespace fl

--- a/src/platforms/esp/32/drivers/parlio/channel_driver_parlio.h
+++ b/src/platforms/esp/32/drivers/parlio/channel_driver_parlio.h
@@ -652,7 +652,13 @@ struct ParlioDebugMetrics {
     u32 mChunksCompleted; ///< Number of chunks that completed transmission
     u32 mBytesTotal;      ///< Total bytes expected to transmit
     u32 mBytesTransmitted; ///< Total bytes actually transmitted
+    u32 mTxDoneCount;      ///< Number of PARLIO TX-done callbacks observed
+    u32 mWorkerIsrCount;   ///< Number of worker ISR refills observed
+    u32 mUnderrunCount;    ///< Number of ring underruns observed
+    u32 mRingCount;        ///< Current number of queued ring buffers
     u32 mErrorCode;        ///< ESP-IDF error code (0 = success)
+    bool mRingError;       ///< True if ring accounting detected an error
+    bool mHardwareIdle;    ///< True if hardware is idle while streaming is pending
     bool mTransmissionActive;   ///< True if transmission is in progress
 };
 

--- a/src/platforms/esp/32/drivers/parlio/parlio_debug.h
+++ b/src/platforms/esp/32/drivers/parlio/parlio_debug.h
@@ -23,7 +23,13 @@ struct ParlioDebugMetrics {
     u32 mChunksCompleted;
     u32 mBytesTotal;
     u32 mBytesTransmitted;
+    u32 mTxDoneCount;
+    u32 mWorkerIsrCount;
+    u32 mUnderrunCount;
+    u32 mRingCount;
     u32 mErrorCode;
+    bool mRingError;
+    bool mHardwareIdle;
     bool mTransmissionActive;
 };
 

--- a/src/platforms/esp/32/drivers/parlio/parlio_engine.cpp.hpp
+++ b/src/platforms/esp/32/drivers/parlio/parlio_engine.cpp.hpp
@@ -254,13 +254,12 @@ calculateBufferByteCount(const BufferPopulationParams& params) FL_NOEXCEPT {
     // Calculate maximum input bytes that fit in one buffer
     // (reuse calc object from above to avoid duplication)
     size_t reset_padding = calc.resetPaddingBytes(params.resetUs);
-    size_t available_capacity = params.ringBufferCapacity - reset_padding;
-    size_t max_input_bytes_per_buffer = available_capacity / expansionFactor;
-
-    // Reduce max by one LED boundary to prevent exact-capacity overflow
-    if (max_input_bytes_per_buffer >= bytes_per_led_all_lanes) {
-        max_input_bytes_per_buffer -= bytes_per_led_all_lanes;
+    size_t fixed_overhead = calc.boundaryPaddingBytes() + reset_padding;
+    if (fixed_overhead >= params.ringBufferCapacity) {
+        return 0;
     }
+    size_t available_capacity = params.ringBufferCapacity - fixed_overhead;
+    size_t max_input_bytes_per_buffer = available_capacity / expansionFactor;
 
     // CRITICAL: If ALL data fits in one buffer, use single buffer to avoid DMA gap.
     // The PARLIO peripheral has a ~20µs gap between DMA buffer transitions
@@ -573,6 +572,11 @@ ParlioEngine::txDoneCallback(void* tx_unit,
     // caused 35-byte overflow when reset padding was present (9035 vs 9000 bytes).
     // Solution: Use pre-tracked input_sizes[] that excludes reset padding.
     size_t input_bytes = self->mRingBuffer->input_sizes[completed_buffer_idx];
+    if (ctx->mBytesTransmitted + input_bytes > ctx->mTotalBytes) {
+        input_bytes = (ctx->mBytesTransmitted < ctx->mTotalBytes)
+                          ? (ctx->mTotalBytes - ctx->mBytesTransmitted)
+                          : 0;
+    }
     ctx->mBytesTransmitted += input_bytes;
     ctx->mCurrentByte += input_bytes;
     ctx->mChunksCompleted++;
@@ -592,6 +596,9 @@ ParlioEngine::txDoneCallback(void* tx_unit,
             // All data transmitted - mark transmission complete
             ctx->mStreamComplete = true;
             ctx->mTransmitting = false;
+            ctx->mTransmissionActive = false;
+            ctx->mHardwareIdle = false;
+            ctx->mEndTimeUs = ctx->mDebugLastTxDoneTime;
 
             // SAFETY CHECK: Detect byte overflow (tolerate small overflows from LED rounding)
             // Flag overflow for debugging, but don't prevent completion
@@ -610,7 +617,6 @@ ParlioEngine::txDoneCallback(void* tx_unit,
         // Ring empty but more data pending - call worker function directly
         ctx->mHardwareIdle = true; // Signal that hardware needs restart
         ctx->mUnderrunCount = ctx->mUnderrunCount + 1;
-        ctx->mTransmitting = false; // Hardware is idle, not transmitting
 
         // ONE-SHOT PATTERN: Call worker function directly to populate next buffer
         // This eliminates the 50µs periodic timer overhead

--- a/src/platforms/esp/32/drivers/parlio/parlio_engine.cpp.hpp
+++ b/src/platforms/esp/32/drivers/parlio/parlio_engine.cpp.hpp
@@ -39,6 +39,7 @@
 #include "platforms/esp/32/drivers/parlio/parlio_peripheral_mock.h"
 #else
 #include "platforms/esp/32/drivers/parlio/parlio_peripheral_esp.h"
+#include "esp_heap_caps.h"
 #endif
 
 // All ESP-IDF dependencies have been abstracted through IParlioPeripheral interface
@@ -62,6 +63,29 @@ fl::detail::IParlioPeripheral* getParlioPeripheral() FL_NOEXCEPT {
         return &fl::detail::ParlioPeripheralESP::instance();
         FL_LOG_PARLIO("PARLIO_INIT: Using ESP peripheral (real hardware)");
     #endif
+}
+
+bool parlioDmaPsramAvailable() FL_NOEXCEPT {
+#ifdef FASTLED_STUB_IMPL
+    return false;
+#else
+    constexpr uint32_t caps = MALLOC_CAP_SPIRAM | MALLOC_CAP_DMA | MALLOC_CAP_8BIT;
+    return heap_caps_get_largest_free_block(caps) > 0;
+#endif
+}
+
+bool parlioCanAllocateInternalDmaRing(size_t bytes_per_buffer, size_t buffer_count) FL_NOEXCEPT {
+#ifdef FASTLED_STUB_IMPL
+    (void)bytes_per_buffer;
+    (void)buffer_count;
+    return true;
+#else
+    const size_t aligned_size = ((bytes_per_buffer + 63) / 64) * 64;
+    const size_t required_total = aligned_size * buffer_count;
+    constexpr uint32_t caps = MALLOC_CAP_DMA | MALLOC_CAP_8BIT;
+    return heap_caps_get_largest_free_block(caps) >= aligned_size &&
+           heap_caps_get_free_size(caps) >= required_total;
+#endif
 }
 
 } // anonymous namespace
@@ -585,6 +609,7 @@ ParlioEngine::txDoneCallback(void* tx_unit,
 
         // Ring empty but more data pending - call worker function directly
         ctx->mHardwareIdle = true; // Signal that hardware needs restart
+        ctx->mUnderrunCount = ctx->mUnderrunCount + 1;
         ctx->mTransmitting = false; // Hardware is idle, not transmitting
 
         // ONE-SHOT PATTERN: Call worker function directly to populate next buffer
@@ -1131,6 +1156,15 @@ bool ParlioEngine::allocateRingBuffers() FL_NOEXCEPT {
 
     u8* buffers[3] = {nullptr, nullptr, nullptr};
 
+    if (!parlioDmaPsramAvailable() &&
+        !parlioCanAllocateInternalDmaRing(mRingBufferCapacity,
+                                          ParlioRingBuffer3::RING_BUFFER_COUNT)) {
+        FL_LOG_PARLIO("PARLIO: Insufficient DMA heap for "
+                      << ParlioRingBuffer3::RING_BUFFER_COUNT
+                      << " ring buffers of " << mRingBufferCapacity << " bytes");
+        return false;
+    }
+
     // Allocate all 3 buffers via peripheral interface (handles DMA requirements)
     for (size_t i = 0; i < 3; i++) {
         buffers[i] = mPeripheral->allocateDmaBuffer(mRingBufferCapacity);
@@ -1324,9 +1358,11 @@ bool ParlioEngine::initialize(size_t dataWidth,
 
             // Recalculate ring buffer capacity for larger LED count
             ParlioBufferCalculator calc(mDataWidth, mUseWave3, mClockFreqHz); // ok no noexcept
+            const bool psram_cap_available = parlioDmaPsramAvailable();
             size_t raw_capacity = calc.calculateRingBufferCapacity(
                 maxLedsPerChannel, mResetUs, ParlioRingBuffer3::RING_BUFFER_COUNT,
-                FASTLED_PARLIO_MAX_RING_BUFFER_TOTAL_BYTES_PSRAM);
+                psram_cap_available ? FASTLED_PARLIO_MAX_RING_BUFFER_TOTAL_BYTES_PSRAM
+                                     : FASTLED_PARLIO_MAX_RING_BUFFER_TOTAL_BYTES);
             size_t new_capacity = ((raw_capacity + 63) / 64) * 64;
 
             if (new_capacity > mRingBufferCapacity) {
@@ -1334,12 +1370,14 @@ bool ParlioEngine::initialize(size_t dataWidth,
                 // Release old ring buffers before allocating new ones
                 mRingBuffer.reset();
                 if (!allocateRingBuffers()) {
-                    // PSRAM-sized allocation failed, retry with SRAM cap
-                    raw_capacity = calc.calculateRingBufferCapacity(
-                        maxLedsPerChannel, mResetUs, ParlioRingBuffer3::RING_BUFFER_COUNT,
-                        FASTLED_PARLIO_MAX_RING_BUFFER_TOTAL_BYTES);
-                    mRingBufferCapacity = ((raw_capacity + 63) / 64) * 64;
-                    if (!allocateRingBuffers()) {
+                    if (psram_cap_available) {
+                        // PSRAM-sized allocation failed, retry with SRAM cap
+                        raw_capacity = calc.calculateRingBufferCapacity(
+                            maxLedsPerChannel, mResetUs, ParlioRingBuffer3::RING_BUFFER_COUNT,
+                            FASTLED_PARLIO_MAX_RING_BUFFER_TOTAL_BYTES);
+                        mRingBufferCapacity = ((raw_capacity + 63) / 64) * 64;
+                    }
+                    if (!psram_cap_available || !allocateRingBuffers()) {
                         FL_LOG_PARLIO("PARLIO_INIT: FAILED to reallocate ring buffers");
                         mInitialized = false;
                         return false;
@@ -1368,7 +1406,7 @@ bool ParlioEngine::initialize(size_t dataWidth,
             #else
             ParlioBitPackOrder::FL_PARLIO_MSB,
             #endif
-            true
+            parlioDmaPsramAvailable()
         );
         if (!mPeripheral->initialize(config)) {
             FL_LOG_PARLIO("PARLIO_INIT: FAILED to reinitialize TX unit");
@@ -1469,7 +1507,7 @@ bool ParlioEngine::initialize(size_t dataWidth,
     mEncodingMode = EncodingMode::CLOCKLESS;
 
     // Configure peripheral (constructor handles -1 filling for unused pins)
-    // prefer_psram defaults true: allocator tries PSRAM+DMA first, falls back to internal SRAM
+    const bool psram_cap_available = parlioDmaPsramAvailable();
     // DIAGNOSTIC: Allow compile-time override to LSB mode for waveform inspection
     #ifndef PARLIO_FORCE_LSB_MODE
         #define PARLIO_FORCE_LSB_MODE 0  // Default: use MSB (correct mode)
@@ -1485,7 +1523,7 @@ bool ParlioEngine::initialize(size_t dataWidth,
         #else
         ParlioBitPackOrder::FL_PARLIO_MSB,  // MSB packing required - Wave8 data is MSB-ordered
         #endif
-        true  // prefer_psram: try PSRAM first, fall back to internal SRAM
+        psram_cap_available  // prefer_psram only when DMA-capable PSRAM exists
     );
     FL_LOG_PARLIO("PARLIO_INIT: Config - clock=" << mClockFreqHz << " queue_depth=" << FL_ESP_PARLIO_HARDWARE_QUEUE_DEPTH);
 
@@ -1517,12 +1555,13 @@ bool ParlioEngine::initialize(size_t dataWidth,
     }
     FL_LOG_PARLIO("PARLIO_INIT: ISR callback registered successfully");
 
-    // Calculate ring buffer capacity
-    // Try PSRAM cap first (larger buffers for 5+ channels), fall back to SRAM cap
+    // Calculate ring buffer capacity. Use the PSRAM cap only when a DMA-capable
+    // PSRAM heap exists; C6 has no PSRAM and should go straight to the SRAM cap.
     ParlioBufferCalculator calc(mDataWidth, mUseWave3, mClockFreqHz);
     size_t raw_capacity = calc.calculateRingBufferCapacity(
         maxLedsPerChannel, mResetUs, ParlioRingBuffer3::RING_BUFFER_COUNT,
-        FASTLED_PARLIO_MAX_RING_BUFFER_TOTAL_BYTES_PSRAM);
+        psram_cap_available ? FASTLED_PARLIO_MAX_RING_BUFFER_TOTAL_BYTES_PSRAM
+                             : FASTLED_PARLIO_MAX_RING_BUFFER_TOTAL_BYTES);
 
     // NEEDS REVIEW!!! are we potentially accessing memory outside of the cache??
     // Please invesatigate
@@ -1535,17 +1574,18 @@ bool ParlioEngine::initialize(size_t dataWidth,
         FL_LOG_PARLIO("PARLIO: Rounded buffer capacity from " << raw_capacity << " to " << mRingBufferCapacity << " bytes (64-byte alignment)");
     }
 
-    // Allocate ring buffers - try PSRAM-sized first, fall back to SRAM-sized
+    // Allocate ring buffers - try PSRAM-sized first only when PSRAM exists.
     FL_LOG_PARLIO("PARLIO_INIT: Allocating ring buffers (capacity=" << mRingBufferCapacity << ")");
     if (!allocateRingBuffers()) {
-        // PSRAM-sized allocation failed, retry with internal SRAM cap
-        FL_LOG_PARLIO("PARLIO_INIT: PSRAM-sized allocation failed, retrying with SRAM cap");
-        raw_capacity = calc.calculateRingBufferCapacity(
-            maxLedsPerChannel, mResetUs, ParlioRingBuffer3::RING_BUFFER_COUNT,
-            FASTLED_PARLIO_MAX_RING_BUFFER_TOTAL_BYTES);
-        mRingBufferCapacity = ((raw_capacity + 63) / 64) * 64;
+        if (psram_cap_available) {
+            FL_LOG_PARLIO("PARLIO_INIT: PSRAM-sized allocation failed, retrying with SRAM cap");
+            raw_capacity = calc.calculateRingBufferCapacity(
+                maxLedsPerChannel, mResetUs, ParlioRingBuffer3::RING_BUFFER_COUNT,
+                FASTLED_PARLIO_MAX_RING_BUFFER_TOTAL_BYTES);
+            mRingBufferCapacity = ((raw_capacity + 63) / 64) * 64;
+        }
 
-        if (!allocateRingBuffers()) {
+        if (!psram_cap_available || !allocateRingBuffers()) {
             FL_LOG_PARLIO("PARLIO_INIT: FAILED to allocate ring buffers");
             mPeripheral->deinitialize(); // Clean up TX unit so re-init can succeed
             mPeripheral = nullptr;
@@ -1639,7 +1679,7 @@ bool ParlioEngine::initializeSpi(const fl::vector<int>& pins,
         FL_ESP_PARLIO_HARDWARE_QUEUE_DEPTH,
         65534,
         ParlioBitPackOrder::FL_PARLIO_MSB,
-        true  // prefer_psram
+        parlioDmaPsramAvailable()
     );
 
     if (!mPeripheral->initialize(config)) {
@@ -1660,19 +1700,22 @@ bool ParlioEngine::initializeSpi(const fl::vector<int>& pins,
     // Calculate ring buffer capacity (SPI expansion: 4:1)
     // Each input byte produces 4 DMA bytes
     ParlioBufferCalculator calc{mDataWidth};
+    const bool psram_cap_available = parlioDmaPsramAvailable();
     size_t raw_capacity = calc.calculateRingBufferCapacity(
         maxLedsEquivalent, 0, ParlioRingBuffer3::RING_BUFFER_COUNT,
-        FASTLED_PARLIO_MAX_RING_BUFFER_TOTAL_BYTES_PSRAM);
+        psram_cap_available ? FASTLED_PARLIO_MAX_RING_BUFFER_TOTAL_BYTES_PSRAM
+                             : FASTLED_PARLIO_MAX_RING_BUFFER_TOTAL_BYTES);
     mRingBufferCapacity = ((raw_capacity + 63) / 64) * 64;
 
     if (!allocateRingBuffers()) {
-        // Try SRAM-sized
-        raw_capacity = calc.calculateRingBufferCapacity(
-            maxLedsEquivalent, 0, ParlioRingBuffer3::RING_BUFFER_COUNT,
-            FASTLED_PARLIO_MAX_RING_BUFFER_TOTAL_BYTES);
-        mRingBufferCapacity = ((raw_capacity + 63) / 64) * 64;
+        if (psram_cap_available) {
+            raw_capacity = calc.calculateRingBufferCapacity(
+                maxLedsEquivalent, 0, ParlioRingBuffer3::RING_BUFFER_COUNT,
+                FASTLED_PARLIO_MAX_RING_BUFFER_TOTAL_BYTES);
+            mRingBufferCapacity = ((raw_capacity + 63) / 64) * 64;
+        }
 
-        if (!allocateRingBuffers()) {
+        if (!psram_cap_available || !allocateRingBuffers()) {
             FL_WARN("PARLIO_SPI: Failed to allocate ring buffers");
             mPeripheral->deinitialize();
             mPeripheral = nullptr;
@@ -1844,6 +1887,7 @@ bool ParlioEngine::beginTransmission(const u8* scratchBuffer,
     mIsrContext->mRingCount = 0;
     mIsrContext->mRingError = false;
     mIsrContext->mHardwareIdle = false;
+    mIsrContext->mUnderrunCount = 0;
     mIsrContext->mNextByteOffset = 0;
 
     // Initialize counters
@@ -2134,7 +2178,13 @@ ParlioDebugMetrics ParlioEngine::getDebugMetrics() const FL_NOEXCEPT {
     metrics.mChunksCompleted = mIsrContext->mChunksCompleted;
     metrics.mBytesTotal = mIsrContext->mTotalBytes;
     metrics.mBytesTransmitted = mIsrContext->mBytesTransmitted;
+    metrics.mTxDoneCount = mIsrContext->mDebugTxDoneCount;
+    metrics.mWorkerIsrCount = mIsrContext->mDebugWorkerIsrCount;
+    metrics.mUnderrunCount = mIsrContext->mUnderrunCount;
+    metrics.mRingCount = mIsrContext->mRingCount;
     metrics.mErrorCode = mErrorOccurred ? 1 : 0;
+    metrics.mRingError = mIsrContext->mRingError;
+    metrics.mHardwareIdle = mIsrContext->mHardwareIdle;
     metrics.mTransmissionActive = mIsrContext->mTransmissionActive;
 
     return metrics;

--- a/src/platforms/esp/32/drivers/parlio/parlio_isr_context.h
+++ b/src/platforms/esp/32/drivers/parlio/parlio_isr_context.h
@@ -69,6 +69,7 @@ struct FL_ALIGNAS(64) ParlioIsrContext {
     volatile size_t mRingCount;      // 0-3 (distinguishes full vs empty)
     volatile bool mRingError;
     volatile bool mHardwareIdle;
+    volatile u32 mUnderrunCount;     // Ring emptied while source bytes remained
     volatile size_t mNextByteOffset; // Next byte offset in source data (Worker function updates)
 
     // === Non-Volatile Fields (read after barrier only) ===
@@ -89,7 +90,7 @@ struct FL_ALIGNAS(64) ParlioIsrContext {
     ParlioIsrContext() FL_NOEXCEPT
         : mStreamComplete(false), mTransmitting(false), mCurrentByte(0),
           mRingReadIdx(0), mRingWriteIdx(0), mRingCount(0), mRingError(false),
-          mHardwareIdle(false), mNextByteOffset(0),
+          mHardwareIdle(false), mUnderrunCount(0), mNextByteOffset(0),
           mTotalBytes(0), mNumLanes(0), mIsrCount(0),
           mBytesTransmitted(0), mChunksCompleted(0),
           mTransmissionActive(false), mEndTimeUs(0),

--- a/src/platforms/esp/32/drivers/usb_serial_jtag_esp32.h
+++ b/src/platforms/esp/32/drivers/usb_serial_jtag_esp32.h
@@ -163,6 +163,8 @@ private:
     UsbSerialJtagConfig mConfig;  // Configuration parameters
     bool mBuffered;               // true if driver installed, false if using ROM fallback
     bool mInstalledDriver;        // true if WE installed the driver (vs inherited from Arduino)
+    bool mHasPeek;                // true if available() cached one byte
+    u8 mPeekByte;                 // cached byte from the non-blocking availability probe
 
     // Helper: Initialize USB-Serial JTAG driver (called by constructor)
     bool initDriver() FL_NOEXCEPT;

--- a/src/platforms/esp/32/drivers/usb_serial_jtag_esp32.h
+++ b/src/platforms/esp/32/drivers/usb_serial_jtag_esp32.h
@@ -165,9 +165,14 @@ private:
     bool mInstalledDriver;        // true if WE installed the driver (vs inherited from Arduino)
     bool mHasPeek;                // true if available() cached one byte
     u8 mPeekByte;                 // cached byte from the non-blocking availability probe
+    static constexpr size_t kRxCacheSize = 64;
+    u8 mRxCache[kRxCacheSize];    // bytes prefetched by available()
+    size_t mRxCacheRead;          // read index into mRxCache
+    size_t mRxCacheCount;         // number of valid cached bytes
 
     // Helper: Initialize USB-Serial JTAG driver (called by constructor)
     bool initDriver() FL_NOEXCEPT;
+    void fillRxCache() FL_NOEXCEPT;
 };
 
 } // namespace fl

--- a/src/platforms/esp/32/drivers/usb_serial_jtag_esp32_idf.hpp
+++ b/src/platforms/esp/32/drivers/usb_serial_jtag_esp32_idf.hpp
@@ -50,7 +50,9 @@ UsbSerialJtagEsp32::UsbSerialJtagEsp32(const UsbSerialJtagConfig& config)
     , mBuffered(false)
     , mInstalledDriver(false)
     , mHasPeek(false)
-    , mPeekByte(0) {
+    , mPeekByte(0)
+    , mRxCacheRead(0)
+    , mRxCacheCount(0) {
 
     // Initialize driver
     initDriver();
@@ -71,12 +73,19 @@ UsbSerialJtagEsp32::UsbSerialJtagEsp32(UsbSerialJtagEsp32&& other) FL_NOEXCEPT
     , mBuffered(other.mBuffered)
     , mInstalledDriver(other.mInstalledDriver)
     , mHasPeek(other.mHasPeek)
-    , mPeekByte(other.mPeekByte) {
+    , mPeekByte(other.mPeekByte)
+    , mRxCacheRead(other.mRxCacheRead)
+    , mRxCacheCount(other.mRxCacheCount) {
+    for (size_t i = 0; i < kRxCacheSize; ++i) {
+        mRxCache[i] = other.mRxCache[i];
+    }
     // Mark other as invalid (prevent double-uninstall)
     other.mBuffered = false;
     other.mInstalledDriver = false;
     other.mHasPeek = false;
     other.mPeekByte = 0;
+    other.mRxCacheRead = 0;
+    other.mRxCacheCount = 0;
 }
 
 UsbSerialJtagEsp32& UsbSerialJtagEsp32::operator=(UsbSerialJtagEsp32&& other) FL_NOEXCEPT {
@@ -94,12 +103,19 @@ UsbSerialJtagEsp32& UsbSerialJtagEsp32::operator=(UsbSerialJtagEsp32&& other) FL
         mInstalledDriver = other.mInstalledDriver;
         mHasPeek = other.mHasPeek;
         mPeekByte = other.mPeekByte;
+        mRxCacheRead = other.mRxCacheRead;
+        mRxCacheCount = other.mRxCacheCount;
+        for (size_t i = 0; i < kRxCacheSize; ++i) {
+            mRxCache[i] = other.mRxCache[i];
+        }
 
         // Mark other as invalid
         other.mBuffered = false;
         other.mInstalledDriver = false;
         other.mHasPeek = false;
         other.mPeekByte = 0;
+        other.mRxCacheRead = 0;
+        other.mRxCacheCount = 0;
     }
     return *this;
 }
@@ -305,19 +321,8 @@ int UsbSerialJtagEsp32::available() FL_NOEXCEPT {
         return 0;  // Driver not installed, no data available
     }
 
-    if (mHasPeek) {
-        return 1;
-    }
-
-    u8 c = 0;
-    int len = usb_serial_jtag_read_bytes(&c, 1, 0);  // timeout=0 (non-blocking)
-    if (len == 1) {
-        mPeekByte = c;
-        mHasPeek = true;
-        return 1;
-    }
-
-    return 0;
+    fillRxCache();
+    return static_cast<int>(mRxCacheCount + (mHasPeek ? 1 : 0));
 #else
     return 0;
 #endif
@@ -334,6 +339,13 @@ int UsbSerialJtagEsp32::read() FL_NOEXCEPT {
         return static_cast<int>(mPeekByte);
     }
 
+    if (mRxCacheCount > 0) {
+        u8 c = mRxCache[mRxCacheRead];
+        mRxCacheRead = (mRxCacheRead + 1) % kRxCacheSize;
+        mRxCacheCount--;
+        return static_cast<int>(c);
+    }
+
     u8 c = 0;
     int len = usb_serial_jtag_read_bytes(&c, 1, 0);  // timeout=0 (non-blocking)
 
@@ -344,6 +356,36 @@ int UsbSerialJtagEsp32::read() FL_NOEXCEPT {
     }
 #else
     return -1;
+#endif
+}
+
+void UsbSerialJtagEsp32::fillRxCache() FL_NOEXCEPT {
+#ifdef FL_HAS_USB_SERIAL_JTAG
+    if (!mBuffered) {
+        return;
+    }
+
+    while (mRxCacheCount < kRxCacheSize) {
+        size_t write_idx = (mRxCacheRead + mRxCacheCount) % kRxCacheSize;
+        size_t contiguous = kRxCacheSize - write_idx;
+        size_t free_count = kRxCacheSize - mRxCacheCount;
+        if (contiguous > free_count) {
+            contiguous = free_count;
+        }
+
+        int len = usb_serial_jtag_read_bytes(
+            &mRxCache[write_idx],
+            static_cast<uint32_t>(contiguous),
+            0);
+        if (len <= 0) {
+            return;
+        }
+
+        mRxCacheCount += static_cast<size_t>(len);
+        if (static_cast<size_t>(len) < contiguous) {
+            return;
+        }
+    }
 #endif
 }
 

--- a/src/platforms/esp/32/drivers/usb_serial_jtag_esp32_idf.hpp
+++ b/src/platforms/esp/32/drivers/usb_serial_jtag_esp32_idf.hpp
@@ -48,7 +48,9 @@ namespace fl {
 UsbSerialJtagEsp32::UsbSerialJtagEsp32(const UsbSerialJtagConfig& config)
     : mConfig(config)
     , mBuffered(false)
-    , mInstalledDriver(false) {
+    , mInstalledDriver(false)
+    , mHasPeek(false)
+    , mPeekByte(0) {
 
     // Initialize driver
     initDriver();
@@ -67,10 +69,14 @@ UsbSerialJtagEsp32::~UsbSerialJtagEsp32() {
 UsbSerialJtagEsp32::UsbSerialJtagEsp32(UsbSerialJtagEsp32&& other) FL_NOEXCEPT
     : mConfig(other.mConfig)
     , mBuffered(other.mBuffered)
-    , mInstalledDriver(other.mInstalledDriver) {
+    , mInstalledDriver(other.mInstalledDriver)
+    , mHasPeek(other.mHasPeek)
+    , mPeekByte(other.mPeekByte) {
     // Mark other as invalid (prevent double-uninstall)
     other.mBuffered = false;
     other.mInstalledDriver = false;
+    other.mHasPeek = false;
+    other.mPeekByte = 0;
 }
 
 UsbSerialJtagEsp32& UsbSerialJtagEsp32::operator=(UsbSerialJtagEsp32&& other) FL_NOEXCEPT {
@@ -86,10 +92,14 @@ UsbSerialJtagEsp32& UsbSerialJtagEsp32::operator=(UsbSerialJtagEsp32&& other) FL
         mConfig = other.mConfig;
         mBuffered = other.mBuffered;
         mInstalledDriver = other.mInstalledDriver;
+        mHasPeek = other.mHasPeek;
+        mPeekByte = other.mPeekByte;
 
         // Mark other as invalid
         other.mBuffered = false;
         other.mInstalledDriver = false;
+        other.mHasPeek = false;
+        other.mPeekByte = 0;
     }
     return *this;
 }
@@ -295,10 +305,18 @@ int UsbSerialJtagEsp32::available() FL_NOEXCEPT {
         return 0;  // Driver not installed, no data available
     }
 
-    // USB-Serial JTAG doesn't have a direct "get buffered data length" API
-    // We can try a non-blocking read with len=0 to check, but that's not standard
-    // For now, return 0 (not implemented)
-    // TODO: Check if there's a better way to query RX buffer status
+    if (mHasPeek) {
+        return 1;
+    }
+
+    u8 c = 0;
+    int len = usb_serial_jtag_read_bytes(&c, 1, 0);  // timeout=0 (non-blocking)
+    if (len == 1) {
+        mPeekByte = c;
+        mHasPeek = true;
+        return 1;
+    }
+
     return 0;
 #else
     return 0;
@@ -309,6 +327,11 @@ int UsbSerialJtagEsp32::read() FL_NOEXCEPT {
 #ifdef FL_HAS_USB_SERIAL_JTAG
     if (!mBuffered) {
         return -1;  // Driver not installed, cannot read
+    }
+
+    if (mHasPeek) {
+        mHasPeek = false;
+        return static_cast<int>(mPeekByte);
     }
 
     u8 c = 0;

--- a/src/platforms/esp/32/io_esp.cpp.hpp
+++ b/src/platforms/esp/32/io_esp.cpp.hpp
@@ -15,6 +15,12 @@
 #ifndef FL_ESP_USE_IDF_SERIAL
     #if !FL_HAS_INCLUDE(<Arduino.h>)
         #define FL_ESP_USE_IDF_SERIAL 1  // Arduino not available - use ESP-IDF
+    #elif (defined(FL_IS_ESP_32S3) || defined(FL_IS_ESP_32C3) || \
+           defined(FL_IS_ESP_32C6) || defined(FL_IS_ESP_32H2) || \
+           defined(FL_IS_ESP_32P4)) && defined(ARDUINO_USB_MODE) && \
+           ARDUINO_USB_MODE && \
+           (!defined(ARDUINO_USB_CDC_ON_BOOT) || !ARDUINO_USB_CDC_ON_BOOT)
+        #define FL_ESP_USE_IDF_SERIAL 1  // Arduino Serial is UART0; use USB-Serial-JTAG
     #else
         #define FL_ESP_USE_IDF_SERIAL 0  // Arduino available - use Arduino Serial by default
     #endif


### PR DESCRIPTION
## Summary
- replay the locally checked-out PARLIO work onto current `origin/master`
- add C6-aware PARLIO DMA/PSRAM sizing, underrun/debug metrics, and AutoResearch RPC reporting
- extend AutoResearch PARLIO stream validation with strict explicit `txPins` handling and encode benchmark PSRAM availability fields
- fix C6 hardware-loop support issues found during review: environment-aware port fallback, USB-Serial-JTAG RX availability buffering, exported PARLIO metrics, and ISR underrun/completion accounting

## Validation
- `git diff --check`
- `uv run pytest ci/tests/test_autoresearch_phases.py` (44 passed)
- `PLATFORMIO_SRC_DIR=$PWD\examples\AutoResearch pio run -e esp32c6`
- uploaded AutoResearch to ESP32-C6 on COM9 with `pio run -e esp32c6 -t upload --upload-port COM9`
- RPC smoke tests on COM9:
  - 1/2/4/8/16-lane `parlioStreamValidate`, 8 LEDs/lane: all completed; 16-lane case returned `bytesTotal=24`, `bytesTransmitted=24`, `txDoneCount=1`, `ringError=false`, `hardwareIdle=false`
  - repeated 16-lane, 128 LEDs/lane: completed with `bytesTotal=384`, `bytesTransmitted=384`, `ringError=false`
  - 16-lane, 256 LEDs/lane, 3 iterations: completed with `bytesTotal=768`, `bytesTransmitted=768`, `txDoneCount=3`, `workerIsrCount=2`, `underrunCount=2`, `ringError=false`, `hardwareIdle=false`
  - follow-up `ping` RPC succeeded after every large-frame stream test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Environment-aware upload-port detection for more accurate device selection
  * Expanded PARLIO diagnostics, streaming outputs and benchmark timing/PSRAM reporting
  * Shorter serial wait on recent ESP32 variants and improved startup logging

* **Bug Fixes**
  * More reliable USB-serial availability and reads via improved RX caching
  * Better detection fallbacks when chip probing is inconclusive

* **Tests**
  * Tightened and expanded auto-detection unit tests

* **Chores**
  * Reduced ESP32-C6 CI flash/firmware size specs
  * Removed several noisy warning logs during serial/LCD transmit failures
<!-- end of auto-generated comment: release notes by coderabbit.ai -->