### PR TITLE
fix(build,windows): work around zccache#619 PCH path-spelling drift

### DIFF
--- a/ci/meson/shared/meson.build
+++ b/ci/meson/shared/meson.build
@@ -36,12 +36,25 @@ shared_defines = ['-DFASTLED_USE_PROGMEM=0']
 
 # meson.project_source_root() on Windows returns native backslashes
 # (e.g. C:\Users\...). Normalize it once and compose every derived path via
-# '/' so paths are absolute + forward-slash + spelled identically everywhere.
+# literal '/' string concatenation so paths are absolute + forward-slash +
+# spelled identically everywhere.
+#
+# Why NOT meson's `/` path-join operator: on Windows it emits the native
+# separator (backslash) regardless of how its operands are spelled. So
+# `path_norm_root / 'src'` ends up as `C:/Users/.../fastled3\src` — a
+# single backslash injected mid-path. clang/zccache pass that `-I` flag
+# through verbatim, then when `#include "fl/stl/cstdio.h"` resolves
+# against it the resulting include path becomes `C:/.../fastled3\src/fl/
+# stl/cstdio.h` with mixed separators. The PCH canonicalizes one slash
+# spelling; the test TU sees another; `#pragma once` fails to dedupe and
+# the user sees `error: redefinition of 'LogLevel'`. Reproduced and root-
+# caused on 2026-06-02 against `bash test --cpp` after merging #2683 and
+# #2684. Literal `+ '/' +` concatenation keeps everything forward-slash.
 path_norm_root = meson.project_source_root().replace('\\', '/')
 
 # Canonical absolute forward-slash -I args for the four project-wide
 # include roots. Use these everywhere instead of redeclaring.
 path_norm_I_root   = '-I' + path_norm_root
-path_norm_I_src    = '-I' + path_norm_root / 'src'
-path_norm_I_tests  = '-I' + path_norm_root / 'tests'
-path_norm_I_stub   = '-I' + path_norm_root / 'src/platforms/stub'
+path_norm_I_src    = '-I' + path_norm_root + '/src'
+path_norm_I_tests  = '-I' + path_norm_root + '/tests'
+path_norm_I_stub   = '-I' + path_norm_root + '/src/platforms/stub'

--- a/src/fl/net/http/chunked_encoding.cpp.hpp
+++ b/src/fl/net/http/chunked_encoding.cpp.hpp
@@ -2,7 +2,8 @@
 
 #include "fl/net/http/chunked_encoding.h"
 #include "fl/stl/string.h"
-#include "fl/stl/cstdio.h"
+// Note: fl/stl/cstdio.h intentionally NOT included — workaround for
+// zackees/zccache#619 (Windows PCH path-spelling drift). Dead include.
 #include "fl/stl/cstdlib.h"
 
 namespace fl {

--- a/src/fl/net/http/stream_client.cpp.hpp
+++ b/src/fl/net/http/stream_client.cpp.hpp
@@ -6,7 +6,9 @@
 #include "fl/stl/string.h"
 #include "fl/stl/stdint.h"
 #include "fl/stl/chrono.h"
-#include "fl/stl/cstdio.h"
+// Note: fl/stl/cstdio.h intentionally NOT included — workaround for
+// zackees/zccache#619 (Windows PCH path-spelling drift). This TU doesn't
+// reference any cstdio.h symbol directly; the include was dead.
 #include "fl/stl/thread.h"
 #include "fl/stl/noexcept.h"
 namespace fl {

--- a/src/fl/net/http/stream_server.cpp.hpp
+++ b/src/fl/net/http/stream_server.cpp.hpp
@@ -6,7 +6,8 @@
 #include "fl/stl/string.h"
 #include "fl/stl/stdint.h"
 #include "fl/log/log.h"
-#include "fl/stl/cstdio.h"
+// Note: fl/stl/cstdio.h intentionally NOT included — workaround for
+// zackees/zccache#619 (Windows PCH path-spelling drift). Dead include.
 #include "fl/stl/noexcept.h"
 namespace fl {
 namespace net {

--- a/src/fl/remote/transport/serial.h
+++ b/src/fl/remote/transport/serial.h
@@ -9,7 +9,12 @@
 #include "fl/stl/int.h"
 #include "fl/stl/cctype.h"
 #include "fl/stl/chrono.h"
-#include "fl/stl/cstdio.h"
+// Note: fl/stl/cstdio.h intentionally NOT included directly — workaround
+// for zackees/zccache#619 (Windows PCH path-spelling drift). Reachable
+// transitively via fl/stl/strstream.h -> fl/stl/ostream.h -> cstdio.h
+// further below in this file, which is the same canonicalized path the
+// PCH uses. Symbols this header consumes (fl::println, fl::available,
+// fl::read, fl::readLine) stay in scope through that chain.
 #include "fl/stl/cstring.h"
 #include "fl/stl/function.h"
 #include "fl/stl/optional.h"

--- a/src/fl/stl/istream.h
+++ b/src/fl/stl/istream.h
@@ -6,9 +6,16 @@
 #include "fl/system/sketch_macros.h"
 #include "fl/stl/int.h"
 
-// Include cstdio for I/O functions
-#include "fl/stl/cstdio.h"
+// Note: fl/stl/cstdio.h intentionally NOT included directly — workaround
+// for zackees/zccache#619 (Windows PCH path-spelling drift defeats
+// `#pragma once` across the PCH boundary). istream.h only needs one
+// cstdio.h symbol — `fl::available()` — so forward-declare it here
+// and let consumers that need the full cstdio API include it themselves.
 #include "fl/stl/noexcept.h"
+
+namespace fl {
+    int available() FL_NOEXCEPT;
+}
 
 namespace fl {
 

--- a/src/fl/system/engine_events.cpp.hpp
+++ b/src/fl/system/engine_events.cpp.hpp
@@ -1,6 +1,8 @@
 #include "fl/system/engine_events.h"
 #include "fl/stl/int.h"
-#include "fl/stl/cstdio.h"  // for printf debug
+// Note: fl/stl/cstdio.h intentionally NOT included — workaround for
+// zackees/zccache#619 (Windows PCH path-spelling drift). The comment
+// above said "for printf debug" but no printf-debug call survived.
 #include "fl/stl/noexcept.h"
 
 

--- a/src/platforms/esp/32/drivers/lcd_spi/channel_driver_lcd_clockless.cpp.hpp
+++ b/src/platforms/esp/32/drivers/lcd_spi/channel_driver_lcd_clockless.cpp.hpp
@@ -280,7 +280,9 @@ bool FL_IRAM ChannelDriverLcdClockless::isrChunkDone(void *panel_io,
     if (!self->mPeripheral->transmit(buf, dmaBytes)) {
         ctx.mStreamComplete = true;
         self->mBusy = false;
+#ifndef FASTLED_STUB_IMPL
         esp_rom_printf("ChannelDriverLcdClockless: ISR transmit failed\n");  // ok esp_rom_printf - IRAM ISR context, FL_WARN unsafe here
+#endif
     }
 
     return false;

--- a/tests/fl/channels/channel_manager.cpp
+++ b/tests/fl/channels/channel_manager.cpp
@@ -18,7 +18,14 @@
 #include "fl/stl/span.h"
 #include "fl/stl/allocator.h"
 #include "fl/stl/string.h"
-#include "fl/stl/cstdio.h"
+// Note: `fl/stl/cstdio.h` intentionally NOT included directly.
+// Workaround for zackees/zccache#619 — on Windows, the same physical
+// cstdio.h header gets two different canonical path spellings (one via
+// the PCH, one via the consumer TU's direct include) and `#pragma once`
+// fails to dedupe across the PCH boundary, surfacing as
+// "error: redefinition of 'LogLevel'" etc. The PCH reaches cstdio.h
+// transitively via ostream.h, so the symbols stay in scope; this file
+// doesn't reference any cstdio.h symbol directly anyway.
 
 FL_TEST_FILE(FL_FILEPATH) {
 

--- a/tests/fl/font/truetype.cpp
+++ b/tests/fl/font/truetype.cpp
@@ -1,5 +1,8 @@
 #include "test.h"
-#include "fl/stl/cstdio.h"
+// Note: fl/stl/cstdio.h intentionally NOT included — workaround for
+// zackees/zccache#619 (Windows PCH path-spelling drift defeats #pragma
+// once across the PCH boundary). The PCH provides cstdio.h transitively;
+// this TU doesn't use any cstdio.h symbol directly.
 #include "fl/stl/vector.h"
 #include "fl/stl/memory.h"
 

--- a/tests/fl/gfx/blur.cpp
+++ b/tests/fl/gfx/blur.cpp
@@ -8,7 +8,11 @@
 #include "fl/gfx/crgb16.h"
 #include "fl/math/xymap.h"
 #include "fl/stl/chrono.h"
-#include "fl/stl/cstdio.h"
+// Note: fl/stl/cstdio.h intentionally NOT included — workaround for
+// zackees/zccache#619 (Windows PCH path-spelling drift defeats #pragma
+// once across the PCH boundary). The PCH provides cstdio.h transitively
+// via ostream.h, so the symbols this test uses (fl::print etc.) stay in
+// scope.
 #include "fl/stl/stdio.h"
 
 using namespace fl;

--- a/tests/fl/gfx/perf_primitives.hpp
+++ b/tests/fl/gfx/perf_primitives.hpp
@@ -4,7 +4,9 @@
 #include "test.h"
 #include "fl/gfx/gfx.h"
 #include "fl/stl/chrono.h"
-#include "fl/stl/cstdio.h"
+// Note: fl/stl/cstdio.h intentionally NOT included — workaround for
+// zackees/zccache#619 (Windows PCH path-spelling drift). PCH provides
+// cstdio.h transitively.
 #include "fl/math/fixed_point/s16x16.h"
 
 // Performance benchmark for 2D graphics primitives.

--- a/tests/fl/stl/stdio.cpp
+++ b/tests/fl/stl/stdio.cpp
@@ -1,7 +1,10 @@
 #include "test.h"
 #include "fl/stl/compiler_control.h"
 #include "fl/stl/int.h"
-#include "fl/stl/cstdio.h"
+// Note: fl/stl/cstdio.h intentionally NOT included directly — workaround
+// for zackees/zccache#619 (Windows PCH path-spelling drift). ostream.h
+// below pulls cstdio.h in transitively via the same path the PCH uses,
+// so all fl::print/println/flush/write_bytes symbols stay in scope.
 #include "fl/stl/cstring.h"
 #include "fl/stl/function.h"
 #include "fl/stl/ostream.h"

--- a/tests/timeout_watchdog.h
+++ b/tests/timeout_watchdog.h
@@ -26,7 +26,11 @@
 #define TIMEOUT_WATCHDOG_H
 
 #include "crash_handler.h"  // IWYU pragma: keep
-#include "fl/stl/cstdio.h"  // IWYU pragma: keep
+// Note: fl/stl/cstdio.h intentionally NOT included — workaround for
+// zackees/zccache#619 (Windows PCH path-spelling drift defeats #pragma
+// once across the PCH boundary). cstdio.h reaches every test TU via the
+// PCH (test_pch.h -> ostream.h -> cstdio.h); this header doesn't use
+// any cstdio.h symbol directly.
 #include "fl/stl/cstdlib.h"  // IWYU pragma: keep
 #include "fl/stl/cstring.h"  // IWYU pragma: keep
 #include "fl/stl/atomic.h"


### PR DESCRIPTION
## Summary

Targets the Windows-only \`bash test --cpp\` failure that has been blocking the Stop hook after PRs #2683 / #2684. The host-build was failing with \"error: redefinition of 'LogLevel'\" for a wide swath of TUs (channel_manager, blur, stdio, perf_primitives, font/truetype, several src/ headers) because the same physical \`fl/stl/cstdio.h\` got two different canonical path spellings — one via the PCH, one via the consumer TU's direct include — and \`#pragma once\` failed to dedupe across the PCH boundary.

## Root cause

Filed upstream as **[zackees/zccache#619](https://github.com/zackees/zccache/issues/619)**: clang on Windows joins an \`-I\` root with a relative include using a literal backslash separator (\`src\fl/stl/cstdio.h\`), and the resulting spelling drifts between PCH-build-time and consumer-TU-time when any include path also carries spelling inconsistency. zccache already has \`StrictPathsMode::Consistent\` that catches exactly this, but it's off by default.

## What this PR changes (until the upstream fix lands)

1. **\`ci/meson/shared/meson.build\`** — fixes one upstream contributor in our own build: replace meson's \`/\` path-join operator (which emits the native separator on Windows even when the operands are forward-slash spelled) with literal \`+ '/' +\` concatenation. This cleans up the \`-I\` flags zccache sees, and is a correct change independent of the upstream work.

2. **Six \`src/\` files** — remove redundant direct \`#include \"fl/stl/cstdio.h\"\` lines:
   - \`fl/net/http/chunked_encoding.cpp.hpp\`, \`fl/net/http/stream_client.cpp.hpp\`, \`fl/net/http/stream_server.cpp.hpp\`, \`fl/system/engine_events.cpp.hpp\` — dead includes (0 cstdio.h symbols referenced).
   - \`fl/remote/transport/serial.h\` — uses 4 cstdio symbols (\`fl::println\`, \`fl::available\`, \`fl::read\`, \`fl::readLine\`); keeps relying on the \`strstream.h -> ostream.h -> cstdio.h\` transitive chain already in scope.
   - \`fl/stl/istream.h\` — uses just \`fl::available\`; forward-declares it locally instead of pulling all of cstdio.h.

3. **Six \`tests/\` files** — same fix: remove the redundant direct include. PCH reaches cstdio.h transitively via \`ostream.h\` so test TUs that genuinely use cstdio.h symbols (blur.cpp, stdio.cpp, perf_primitives.hpp) keep working.

4. **\`src/platforms/esp/32/drivers/lcd_spi/channel_driver_lcd_clockless.cpp.hpp\`** — gate the \`esp_rom_printf\` call that PR #2684 added under \`#ifndef FASTLED_STUB_IMPL\`. The host stub doesn't have \`esp_rom_printf\` declared.

Each workaround comment references **zackees/zccache#619** so future maintainers can revert these once the upstream fix lands.

## Test plan
- [x] \`bash test --cpp\` -> **249/249 passed** on Windows host with zccache 1.11.9 + clang 21.1.5.
- [x] \`bash lint\` clean (no new violations introduced by this PR).
- [x] Diff is minimal: 73 insertions / 17 deletions across 14 files. No public API change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Fixed Windows build system path normalization to ensure consistent forward-slash formatting in include paths.
  * Optimized header include patterns across multiple modules to improve build reliability on Windows platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->