### PR TITLE
fix(remote): restore fl/stl/cstdio.h include in transport/serial.h (teensy CI red)

### DIFF
--- a/src/fl/remote/transport/serial.h
+++ b/src/fl/remote/transport/serial.h
@@ -9,12 +9,16 @@
 #include "fl/stl/int.h"
 #include "fl/stl/cctype.h"
 #include "fl/stl/chrono.h"
-// Note: fl/stl/cstdio.h intentionally NOT included directly — workaround
-// for zackees/zccache#619 (Windows PCH path-spelling drift). Reachable
-// transitively via fl/stl/strstream.h -> fl/stl/ostream.h -> cstdio.h
-// further below in this file, which is the same canonicalized path the
-// PCH uses. Symbols this header consumes (fl::println, fl::available,
-// fl::read, fl::readLine) stay in scope through that chain.
+// fl/stl/cstdio.h is REQUIRED here: this header calls fl::available,
+// fl::read, fl::readLine, and fl::println, all declared in cstdio.h. PR
+// #2685 tried to drop this include and rely on a strstream.h -> ostream.h
+// -> cstdio.h transitive chain to work around zackees/zccache#619
+// (Windows PCH path-spelling drift), but strstream.h does NOT include
+// ostream.h, so the chain is broken on every non-PCH build (teensy,
+// every Arduino ARM/AVR target, etc.) — see issue #2647-style follow-up.
+// The Windows PCH dedup issue is fixed by the meson.build path
+// normalization that landed in the same PR.
+#include "fl/stl/cstdio.h"
 #include "fl/stl/cstring.h"
 #include "fl/stl/function.h"
 #include "fl/stl/optional.h"


### PR DESCRIPTION
## Summary

- Re-add direct `#include \"fl/stl/cstdio.h\"` in `src/fl/remote/transport/serial.h` that PR #2685 removed.
- That removal relied on a transitive chain (`strstream.h → ostream.h → cstdio.h`) that doesn't exist — `strstream.h` never includes `ostream.h`, so `fl::available`, `fl::read`, `fl::readLine`, `fl::println` are out of scope on every non-PCH build (all teensy variants, every Arduino ARM/AVR target).

## CI symptom (post-#2685, master sha `1a347e9c0e`)

Every teensy variant fails on every example with:
```
fl/remote/transport/serial.h:68:40: error: 'available' is not a member of 'fl'
fl/remote/transport/serial.h:69:29: error: 'read'      is not a member of 'fl'
fl/remote/transport/serial.h:80:16: error: 'readLine'  is not a member of 'fl'
```
Confirmed across `teensy30/31/32/35/36/40/41/41_ofled/LC/octoWS2811` runs.

## Why the workaround was wrong

The Windows PCH path-spelling dedup issue is genuinely fixed by the `meson.build` path-normalization in PR #2685 (replacing meson's `/` join with literal `'+ '/' +'`). Removing the direct include was unnecessary belt-and-suspenders that traded the Windows host-build failure for an all-teensy CI failure.

## Test plan

- [x] `bash compile teensy41 --examples Apa102` — build succeeded in 129.6s (no errors, ELF + HEX produced)
- [ ] CI green across all teensy variants on the merged commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal header file dependencies to improve code organization and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->