### PR TITLE
Fix AutoResearch lane limits and LCD chunk sizing

### DIFF
--- a/autoresearch
+++ b/autoresearch
@@ -33,9 +33,11 @@ Driver Selection (optional - omit for GPIO-only mode):
   --rmt               Test RMT (Remote Control) driver
   --spi               Test SPI driver
   --uart              Test UART driver
-  --i2s               Test I2S LCD_CAM driver (ESP32-S3 only)
+  --lcd               Test LCD_CLOCKLESS driver (ESP32-S3 only)
+  --lcd-spi           Test LCD_SPI driver (ESP32-S3 only)
   --lcd-rgb           Test LCD RGB driver (ESP32-P4 only)
-  --all               Test all drivers (equivalent to --parlio --rmt --spi --uart --i2s --lcd-rgb)
+  --object-fled       Test ObjectFLED DMA driver (Teensy 4.x only)
+  --all               Test all drivers
   --simd              Test SIMD operations only (no LED drivers needed)
   --coroutine         Test coroutine/task creation, stop, await (no LED drivers needed)
   --parallel          Test multiple drivers simultaneously (requires 2+ drivers)
@@ -61,7 +63,7 @@ Build System:
   --no-fbuild         Deprecated compatibility flag; ignored because fbuild is always used
 
 Lane Configuration:
-  --lanes N or MIN-MAX      Set lane count or range (e.g., '2' or '1-4')
+  --lanes N or MIN-MAX      Set lane count or range, valid 1-16 (e.g., '2' or '1-4')
   --lane-counts LED1,LED2,... Set per-lane LED counts (e.g., '100,200,300')
 
 Color Configuration:
@@ -85,9 +87,9 @@ Examples:
   bash autoresearch --all                       # Test all drivers
   bash autoresearch --parlio --skip-lint        # Skip linting for faster iteration
   bash autoresearch --all --timeout 120         # Longer timeout
-  bash autoresearch --i2s --lanes 2             # Test I2S with exactly 2 lanes
+  bash autoresearch --lcd --lanes 2             # Test LCD_CLOCKLESS with exactly 2 lanes
   bash autoresearch --parlio --lanes 1-4        # Test PARLIO with 1-4 lanes
-  bash autoresearch --i2s --lane-counts 100,200,300  # Test I2S with 3 lanes (100, 200, 300 LEDs)
+  bash autoresearch --lcd --lane-counts 100,200,300  # Test LCD_CLOCKLESS with 3 lanes (100, 200, 300 LEDs)
   bash autoresearch --rmt --color-pattern ff00aa     # Test RMT with custom color (pink)
   bash autoresearch --parlio                         # Uses fbuild for compile/upload
   bash autoresearch --parlio --lcd-rgb --parallel --lanes 1  # Test PARLIO + LCD_RGB in parallel

--- a/ci/autoresearch/args.py
+++ b/ci/autoresearch/args.py
@@ -154,7 +154,7 @@ Lane Configuration:
     --lanes 2          Test with exactly 2 lanes
     --lanes 1-4        Test with 1 to 4 lanes (tests all combinations)
     --lane-counts 100,200,300  3 lanes with 100, 200, 300 LEDs per lane
-    Default: 1-8 lanes (firmware default)
+    Default: 1 lane; valid range: 1-16 lanes
 
 Color Pattern Configuration:
   Configure custom color pattern for autoresearch testing:
@@ -449,7 +449,7 @@ See Also:
             "--lanes",
             type=str,
             metavar="N or MIN-MAX",
-            help="Lane count: single number (e.g., '2') or range (e.g., '1-4'). Default: 1-8",
+            help="Lane count: single number (e.g., '2') or range (e.g., '1-4'). Valid range: 1-16",
         )
         lane_group.add_argument(
             "--lane-counts",

--- a/ci/autoresearch/phases.py
+++ b/ci/autoresearch/phases.py
@@ -53,6 +53,8 @@ if TYPE_CHECKING:
 # Helpers
 # ============================================================
 
+MAX_AUTORESEARCH_LANES = 16
+
 
 def _is_native_platform(environment: str | None) -> bool:
     """Check if the target is the native/stub (host) platform."""
@@ -338,6 +340,18 @@ def _parse_args_and_build_commands(args: Args) -> RunContext | int:
             "\u2139\ufe0f  Legacy API mode: using WS2812B<PIN> template path (single-lane, pin 0-8)"
         )
 
+    if min_lanes is not None and max_lanes is not None:
+        if min_lanes < 1 or max_lanes < 1 or min_lanes > max_lanes:
+            print(
+                f"\u274c Error: Invalid lane range {min_lanes}-{max_lanes} (expected 1-{MAX_AUTORESEARCH_LANES})"
+            )
+            return 1
+        if max_lanes > MAX_AUTORESEARCH_LANES:
+            print(
+                f"\u274c Error: Lane count must be 1-{MAX_AUTORESEARCH_LANES}, got max {max_lanes}"
+            )
+            return 1
+
     # Parse --lane-counts argument
     per_lane_counts: list[int] | None = None
     if args.lane_counts:
@@ -349,9 +363,9 @@ def _parse_args_and_build_commands(args: Args) -> RunContext | int:
             if any(c <= 0 for c in per_lane_counts):
                 print("\u274c Error: All lane counts must be positive integers")
                 return 1
-            if len(per_lane_counts) < 1 or len(per_lane_counts) > 8:
+            if len(per_lane_counts) < 1 or len(per_lane_counts) > MAX_AUTORESEARCH_LANES:
                 print(
-                    f"\u274c Error: Lane count must be 1-8, got {len(per_lane_counts)} lanes"
+                    f"\u274c Error: Lane count must be 1-{MAX_AUTORESEARCH_LANES}, got {len(per_lane_counts)} lanes"
                 )
                 return 1
         except ValueError:

--- a/ci/tests/test_autoresearch_phases.py
+++ b/ci/tests/test_autoresearch_phases.py
@@ -280,6 +280,31 @@ class TestParseArgsAndBuildCommands:
         assert len(result.json_rpc_commands) == 2
         assert result.json_rpc_commands[0]["method"] == "setLaneSizes"
 
+    def test_lane_counts_accepts_16_lanes(self, fake_project_dir: Path) -> None:
+        args = _make_args(
+            lane_counts=",".join(["100"] * 16),
+            project_dir=fake_project_dir,
+        )
+        result = _parse_args_and_build_commands(args)
+        assert isinstance(result, RunContext)
+        assert result.json_rpc_commands[0]["method"] == "setLaneSizes"
+        assert result.json_rpc_commands[0]["params"] == [[100] * 16]
+
+    def test_lane_counts_rejects_17_lanes(self, fake_project_dir: Path) -> None:
+        args = _make_args(
+            lane_counts=",".join(["100"] * 17),
+            project_dir=fake_project_dir,
+        )
+        result = _parse_args_and_build_commands(args)
+        assert isinstance(result, int)
+        assert result == 1
+
+    def test_lanes_rejects_above_16(self, fake_project_dir: Path) -> None:
+        args = _make_args(lanes="17", project_dir=fake_project_dir)
+        result = _parse_args_and_build_commands(args)
+        assert isinstance(result, int)
+        assert result == 1
+
     def test_color_pattern(self, fake_project_dir: Path) -> None:
         args = _make_args(color_pattern="ff00aa", project_dir=fake_project_dir)
         result = _parse_args_and_build_commands(args)

--- a/examples/AutoResearch/AutoResearch.ino
+++ b/examples/AutoResearch/AutoResearch.ino
@@ -150,11 +150,11 @@
 //    // #define JUST_I2S     // Test only I2S LCD_CAM driver (ESP32-S3 only)
 //    - Default: Test all available drivers (RMT, SPI, PARLIO, UART, I2S)
 //
-// 2. LANE RANGE (1-8 lanes):
+// 2. LANE RANGE (1-16 lanes):
 //    - Uncomment to override lane range:
 //    // #define MIN_LANES 1  // Minimum number of lanes to test
-//    // #define MAX_LANES 8  // Maximum number of lanes to test
-//    - Default: MIN_LANES=1, MAX_LANES=8 (tests all lane counts)
+//    // #define MAX_LANES 16  // Maximum number of lanes to test
+//    - Default: MIN_LANES=1, MAX_LANES=16 (tests all lane counts)
 //    - Each lane has decreasing LED count: Lane 0=base, Lane 1=base-1, ..., Lane N=base-N
 //    - Multi-lane RX autoresearch: Only Lane 0 is validated (hardware limitation)
 //
@@ -165,7 +165,7 @@
 //    - Default: Test both small (10 LEDs) and large (300 LEDs) strips
 //
 // TEST MATRIX SIZE:
-// - Full matrix: 3 drivers × 8 lane counts × 2 strip sizes = 48 test cases
+// - Full matrix: 3 drivers × 16 lane counts × 2 strip sizes = 96 test cases
 // - Use defines above to narrow scope for faster debugging
 //
 // EXAMPLES:

--- a/examples/AutoResearch/AutoResearchRemote.cpp
+++ b/examples/AutoResearch/AutoResearchRemote.cpp
@@ -1428,7 +1428,7 @@ void AutoResearchRemoteControl::registerFunctions(fl::shared_ptr<AutoResearchSta
         setLaneRange_fn.set("phase", "Phase 2: Configuration");
         setLaneRange_fn.set("args", "[minLanes, maxLanes]");
         setLaneRange_fn.set("returns", "{success, minLanes, maxLanes, testCases}");
-        setLaneRange_fn.set("description", "Configure lane range (1-8)");
+        setLaneRange_fn.set("description", "Configure lane range (1-16)");
         functions.push_back(setLaneRange_fn);
 
         fl::json setStripSizes_fn = fl::json::object();

--- a/examples/AutoResearch/AutoResearchTest.h
+++ b/examples/AutoResearch/AutoResearchTest.h
@@ -48,8 +48,8 @@ struct TestContext {
     const char* timing_name;      ///< Timing name (e.g., "WS2812B-V5")
     const char* rx_type_name;     ///< RX device type name (e.g., "RMT", "ISR")
     const char* pattern_name;     ///< Pattern name (e.g., "Pattern A (R=0xF0...)")
-    int lane_count;               ///< Total number of lanes (1-8)
-    int lane_index;               ///< Current lane index (0-7)
+    int lane_count;               ///< Total number of lanes (1-16)
+    int lane_index;               ///< Current lane index (0-15)
     int base_strip_size;          ///< Base strip size (10 or 300 LEDs)
     int num_leds;                 ///< Number of LEDs in this lane
     int pin_number;               ///< TX pin number for this lane

--- a/src/fl/channels/validation.cpp.hpp
+++ b/src/fl/channels/validation.cpp.hpp
@@ -28,16 +28,16 @@ SingleTestResult runSingleValidationTest(const SingleTestConfig& config) {
         return result;
     }
 
-    // Validate lane count (1-8 lanes)
+    // Validate lane count (1-16 lanes)
     if (config.lane_sizes.empty()) {
         result.success = false;
         result.error_message = "Lane count must be at least 1";
         return result;
     }
 
-    if (config.lane_sizes.size() > 8) {
+    if (config.lane_sizes.size() > 16) {
         result.success = false;
-        result.error_message = "Lane count cannot exceed 8";
+        result.error_message = "Lane count cannot exceed 16";
         return result;
     }
 

--- a/src/platforms/esp/32/drivers/lcd_spi/channel_driver_lcd_clockless.cpp.hpp
+++ b/src/platforms/esp/32/drivers/lcd_spi/channel_driver_lcd_clockless.cpp.hpp
@@ -368,21 +368,16 @@ bool ChannelDriverLcdClockless::beginTransmission(
         requestedChunkInputBytes = maxSize;
     }
 
-    // Pick numChunks so chunkInputBytes = maxSize / numChunks is exact (the
-    // remainder must be 0). Walk numChunks upward from
-    // ceil(maxSize / requested) until we hit a divisor; in the worst case we
-    // fall back to numChunks = maxSize (single-byte chunks). For typical LED
-    // counts (powers of two × 3 bytes per RGB pixel) the loop terminates in
-    // a couple of iterations.
+    // Keep the initial chunk count from the requested size, then round the
+    // chunk size up to cover maxSize. Do not walk numChunks upward looking for
+    // an exact divisor: awkward frame sizes just above the default chunk size
+    // would otherwise collapse into many much smaller ISR-driven chunks.
     size_t numChunks =
         (maxSize + requestedChunkInputBytes - 1) / requestedChunkInputBytes;
     if (numChunks == 0) {
         numChunks = 1;
     }
-    while (numChunks < maxSize && (maxSize % numChunks) != 0) {
-        ++numChunks;
-    }
-    size_t chunkInputBytes = maxSize / numChunks;
+    size_t chunkInputBytes = (maxSize + numChunks - 1) / numChunks;
     if (chunkInputBytes == 0) {
         chunkInputBytes = maxSize;
     }

--- a/tests/fl/channels/validation.cpp
+++ b/tests/fl/channels/validation.cpp
@@ -56,14 +56,17 @@ FL_TEST_CASE("Invalid lane count - 0 lanes") {
     FL_CHECK(result.error_message.has_value());
 }
 
-FL_TEST_CASE("Invalid lane count - more than 8 lanes") {
+FL_TEST_CASE("Invalid lane count - more than 16 lanes") {
     SingleTestConfig config = makeBasicConfig();
-    config.lane_sizes = {100, 100, 100, 100, 100, 100, 100, 100, 100}; // 9 lanes
+    config.lane_sizes = {
+        100, 100, 100, 100, 100, 100, 100, 100, 100,
+        100, 100, 100, 100, 100, 100, 100, 100}; // 17 lanes
 
     SingleTestResult result = runSingleValidationTest(config);
 
     FL_CHECK_FALSE(result.success);
     FL_CHECK(result.error_message.has_value());
+    FL_CHECK(result.error_message.value() == "Lane count cannot exceed 16");
 }
 
 FL_TEST_CASE("Multiple iterations") {
@@ -150,14 +153,16 @@ FL_TEST_CASE("Invalid pattern - empty") {
     FL_CHECK(result.error_message.has_value());
 }
 
-FL_TEST_CASE("Large lane count - 8 lanes (maximum allowed)") {
+FL_TEST_CASE("Large lane count - 16 lanes (maximum allowed)") {
     SingleTestConfig config = makeBasicConfig();
-    config.lane_sizes = {100, 100, 100, 100, 100, 100, 100, 100}; // 8 lanes
+    config.lane_sizes = {
+        100, 100, 100, 100, 100, 100, 100, 100,
+        100, 100, 100, 100, 100, 100, 100, 100}; // 16 lanes
 
     SingleTestResult result = runSingleValidationTest(config);
 
     FL_CHECK(result.success);
-    FL_CHECK(result.lane_count == 8);
+    FL_CHECK(result.lane_count == 16);
 }
 
 } // FL_TEST_FILE

--- a/tests/platforms/esp/32/drivers/lcd_spi/channel_driver_lcd_clockless.cpp
+++ b/tests/platforms/esp/32/drivers/lcd_spi/channel_driver_lcd_clockless.cpp
@@ -85,6 +85,16 @@ ChannelDataPtr createClocklessChannelData(int pin, size_t numLeds) {
     return ChannelData::create(pin, timing, fl::move(data));
 }
 
+ChannelDataPtr createClocklessChannelDataBytes(int pin, size_t numBytes) {
+    auto timing = makeTimingConfig<TIMING_WS2812_800KHZ>();
+    fl::vector_psram<u8> data;
+    data.resize(numBytes);
+    for (size_t i = 0; i < numBytes; i++) {
+        data[i] = static_cast<u8>(i % 256);
+    }
+    return ChannelData::create(pin, timing, fl::move(data));
+}
+
 } // anonymous namespace
 
 //=============================================================================
@@ -195,6 +205,31 @@ FL_TEST_CASE("ChannelDriverLcdClockless - multi-chunk") {
     mock.simulateTransmitComplete();
     FL_CHECK(driver.poll() == IChannelDriver::DriverState::READY);
     FL_CHECK(mock.getTransmitCount() == 3);
+}
+
+FL_TEST_CASE("ChannelDriverLcdClockless - awkward chunk size rounds up") {
+    resetMockState();
+    auto peripheral = createMockPeripheral();
+    ChannelDriverLcdClockless driver(peripheral);
+    auto &mock = LcdSpiPeripheralMock::instance();
+
+    driver.setChunkInputBytesForTest(1024);
+
+    auto data = createClocklessChannelDataBytes(5, 1025);
+    driver.enqueue(data);
+    driver.show();
+
+    FL_CHECK(mock.getTransmitCount() == 1);
+
+    mock.simulateTransmitComplete();
+    FL_CHECK(driver.poll() == IChannelDriver::DriverState::READY);
+    FL_CHECK(mock.getTransmitCount() == 2);
+
+    const auto &history = mock.getTransmitHistory();
+    FL_REQUIRE(history.size() == 2);
+    const size_t dmaBytesPerInputByte = 16 * sizeof(Wave3Byte);
+    FL_CHECK(history[0].size_bytes == 513 * dmaBytesPerInputByte);
+    FL_CHECK(history[1].size_bytes == 512 * dmaBytesPerInputByte);
 }
 
 //=============================================================================


### PR DESCRIPTION
## Summary

- Fixes #2688 by preserving the initial LCD_CLOCKLESS chunk count derived from the requested chunk size, then rounding chunk size up instead of searching for an exact divisor.
- Fixes #2687 by aligning AutoResearch lane-count validation on the already-supported 1-16 lane range across host validation, CLI parsing, tests, docs, and wrapper help.
- Adds focused regressions for awkward LCD chunk sizing and 16-lane AutoResearch validation.

## Verification

- `uv run python -m pytest ci/tests/test_autoresearch_phases.py -v` - 47 passed
- `bash test --cpp tests/fl/channels/validation.cpp` - passed
- `bash test --cpp tests/platforms/esp/32/drivers/lcd_spi/channel_driver_lcd_clockless.cpp` - passed
- `git diff --check` - clean
- Attempted `bash autoresearch esp32s3 --lcd --upload-port COM22 --lanes 16 --strip-sizes 256 --skip-lint --timeout 180 --verbose` on the attached ESP32-S3 without `--no-filter`; fbuild stalled during compile before upload/serial verification. Compiler processes stopped advancing CPU time and were cleaned up. Related filter issue filed separately: #2690.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded lane support from 8 to 16 lanes across AutoResearch and LCD drivers.

* **Bug Fixes**
  * Simplified and improved DMA chunk sizing logic for better efficiency.

* **Documentation**
  * Updated help text, examples, and test matrix documentation to reflect 16-lane maximum support.

* **Tests**
  * Added validation tests for 16-lane constraints and DMA chunk sizing edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->