### PR TITLE
fix(nrf52): honor SPI data rates

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    # Pin to fbuild 2.2.14 — adds Arduino UNO Q / STM32U5 board defaults while
+    # Pin to fbuild 2.2.15 — adds Arduino UNO Q / STM32U5 board defaults while
     # preserving the compile-many stage-2 framework-archive
     # share (FastLED/fbuild#337) which prevents every stage-2 sketch from
     # re-building the framework from scratch (the regression that originally
@@ -15,8 +15,10 @@ dependencies = [
     # (#348), the bounded zccache start-up timeout (#349), and project-lock
     # acquire instrumentation (#350) — together these address the silent
     # esp32c6 hang reported in fbuild#346 and unblock flipping
-    # FASTLED_USE_FBUILD_CI=1 default-on in a follow-up.
-    "fbuild==2.2.14",
+    # FASTLED_USE_FBUILD_CI=1 default-on in a follow-up. Also preserves
+    # quoted Adafruit nRF52 BSP defines in response files, unblocking
+    # nRF52840 builds under fbuild.
+    "fbuild==2.2.15",
     "platformio>=6.1.19,<6.2",
     "python-dateutil",
     "ruff",

--- a/src/platforms/arm/nrf52/README.md
+++ b/src/platforms/arm/nrf52/README.md
@@ -2,6 +2,38 @@
 
 Nordic nRF52 family support.
 
+The maintained backend targets the Adafruit nRF52 / Bluefruit Arduino BSP used
+by FastLED CI. That BSP provides the Nordic SDK headers, FreeRTOS integration,
+SoftDevice support, PWM EasyDMA, and SPIM HAL APIs this backend includes.
+Arduino mbed OS nRF52 boards such as Arduino Nano 33 BLE and Nano 33 BLE Sense
+are not supported by this backend today.
+
+## Clocked SPI LEDs
+
+Clocked chipsets such as APA102, SK9822, and DotStar use the nRF52 SPIM
+peripheral. `DATA_RATE_MHZ()` and `DATA_RATE_KHZ()` are honored by selecting
+the fastest standard nRF52 SPIM rate that does not exceed the requested rate:
+125 kHz, 250 kHz, 500 kHz, 1 MHz, 2 MHz, 4 MHz, or 8 MHz. The default
+`FASTLED_NRF52_SPIM` is `NRF_SPIM0`, so requests above 8 MHz are clamped to
+8 MHz. SPIM3 on nRF52840 can run faster, but this backend does not assume
+SPIM3 because most board pin maps and sketches use SPIM0 by default.
+
+## Clockless LEDs and BLE
+
+WS2812/SK6812-style chipsets use PWM EasyDMA sequence playback. The current
+clockless path uses one PWM arbiter instance by default and a static sequence
+buffer sized by `FASTLED_NRF52_MAXIMUM_PIXELS_PER_STRING` (default 144). BLE
+SoftDevice activity, RAM pressure, and multiple independent clockless strips
+can make large SK6812/WS2812 installations unreliable on nRF52. For BLE-heavy
+applications, prefer clocked LEDs such as APA102/SK9822/DotStar, reduce the
+number of clockless strips, or use a single shorter clockless output.
+
+WS2812/SK6812 LEDs also do not expose a separate update/latch signal. FastLED
+sends the pixel waveform and then leaves the data line idle for the reset time.
+If an application needs precisely scheduled visual updates independent of data
+transfer time, use a clocked LED chipset or schedule the start of `show()` so
+the protocol reset interval lands at the desired update time.
+
 ## Files (quick pass)
 - `fastled_arm_nrf52.h`: Aggregator; includes pin/SPI/clockless and sysdefs.
 - `fastpin_arm_nrf52.h`, `fastpin_arm_nrf52_variants.h`: Pin helpers/variants.

--- a/src/platforms/arm/nrf52/fastspi_arm_nrf52.h
+++ b/src/platforms/arm/nrf52/fastspi_arm_nrf52.h
@@ -59,6 +59,25 @@ namespace fl {
         static u8  s_BufferIndex;
         static u8  s_Buffer[2][2]; // 2x two-byte buffers, allows one buffer currently being sent, and a second one being prepped to send.
 
+        static constexpr u32 spiClockHz() FL_NOEXCEPT {
+            constexpr u32 divider = (_SPI_CLOCK_DIVIDER == 0) ? 1 : _SPI_CLOCK_DIVIDER;
+            return F_CPU / divider;
+        }
+
+        static constexpr nrf_spim_frequency_t spimFrequency() FL_NOEXCEPT {
+            constexpr u32 hz = spiClockHz();
+
+            // nRF52 SPIM supports discrete frequencies. Select the fastest
+            // standard rate that does not exceed the requested FastLED rate.
+            return (hz >= 8000000UL)  ? NRF_SPIM_FREQ_8M :
+                   (hz >= 4000000UL)  ? NRF_SPIM_FREQ_4M :
+                   (hz >= 2000000UL)  ? NRF_SPIM_FREQ_2M :
+                   (hz >= 1000000UL)  ? NRF_SPIM_FREQ_1M :
+                   (hz >= 500000UL)   ? NRF_SPIM_FREQ_500K :
+                   (hz >= 250000UL)   ? NRF_SPIM_FREQ_250K :
+                                        NRF_SPIM_FREQ_125K;
+        }
+
         // This allows saving the configuration of the SPIM instance
         // upon select(), and restoring the configuration upon release().
         struct spim_config {
@@ -146,7 +165,7 @@ namespace fl {
                 );
             nrf_spim_frequency_set(
                 FASTLED_NRF52_SPIM,
-                NRF_SPIM_FREQ_4M // BUGBUG -- use _SPI_CLOCK_DIVIDER to determine frequency
+                spimFrequency()
                 );
             nrf_spim_pins_set(
                 FASTLED_NRF52_SPIM,


### PR DESCRIPTION
﻿## Summary
- bump FastLED's fbuild pin to 2.2.15 so Adafruit nRF52 BSP quoted defines survive response-file builds
- honor DATA_RATE_MHZ() / DATA_RATE_KHZ() on nRF52 hardware SPIM instead of always forcing 4 MHz
- document the current nRF52 backend support boundaries for Adafruit/Bluefruit BSP, mbed OS boards, BLE-heavy clockless output, and WS2812/SK6812 latch timing

## Verification
- uv run python -c "import importlib.metadata as m; print(m.version('fbuild'))" -> 2.2.15
- uv run ci/ci-compile.py nrf52840_dk --examples Blink
- uv run ci/ci-compile.py nrf52840_dk --examples Apa102

Fixes #2697
Addresses #2694
Addresses #2695
Addresses #2696
Addresses #1246
Addresses #1275
Addresses #917
Addresses #1111


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed SPI clock frequency configuration for nRF52 platform LEDs.

* **Documentation**
  * Enhanced nRF52 documentation with guidance on supported hardware, API requirements, and optimal LED configuration for both clocked SPI and clockless BLE scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->