### PR TITLE
Fix Teensy Audio selection on low-memory boards

### DIFF
--- a/ci/tests/test_sketch_filter.py
+++ b/ci/tests/test_sketch_filter.py
@@ -686,6 +686,43 @@ class TestAudioInputFilter:
             )
 
 
+class TestBeatDetectionFilter:
+    """Test BeatDetection example filter behavior."""
+
+    def test_beat_detection_skips_small_teensy_boards(self) -> None:
+        """BeatDetection uses UIAudio and should skip low-memory Teensy boards."""
+        beat_detection_path = (
+            Path(__file__).parent.parent.parent
+            / "examples"
+            / "BeatDetection"
+            / "BeatDetection.ino"
+        )
+        sketch_filter = parse_filter_from_sketch(beat_detection_path)
+
+        assert sketch_filter is not None, "BeatDetection should have a @filter directive"
+
+        cases = [
+            (
+                Board(board_name="teensy30", platform="teensy", framework="arduino"),
+                True,
+            ),
+            (
+                Board(board_name="teensylc", platform="teensy", framework="arduino"),
+                True,
+            ),
+            (
+                Board(board_name="teensy41", platform="teensy", framework="arduino"),
+                False,
+            ),
+        ]
+
+        for board, should_skip_expected in cases:
+            should_skip, reason = should_skip_sketch(board, sketch_filter)
+            assert should_skip is should_skip_expected, (
+                f"unexpected BeatDetection filter result for {board.board_name}: {reason}"
+            )
+
+
 class TestMemoryTierMatching:
     """Test three-tier memory classification: low < large < huge."""
 

--- a/ci/tests/test_sketch_filter.py
+++ b/ci/tests/test_sketch_filter.py
@@ -645,6 +645,47 @@ class TestPintestFilter:
         assert "atmega8" in reason.lower() or "board" in reason.lower()
 
 
+class TestAudioInputFilter:
+    """Test AudioInput example filter behavior."""
+
+    def test_audio_input_skips_small_teensy_boards(self) -> None:
+        """AudioInput requires Teensy boards with enough RAM for PJRC Audio."""
+        audio_input_path = (
+            Path(__file__).parent.parent.parent
+            / "examples"
+            / "AudioInput"
+            / "AudioInput.ino"
+        )
+        sketch_filter = parse_filter_from_sketch(audio_input_path)
+
+        assert sketch_filter is not None, "AudioInput should have a @filter directive"
+
+        cases = [
+            (
+                Board(board_name="teensy30", platform="teensy", framework="arduino"),
+                True,
+            ),
+            (
+                Board(board_name="teensylc", platform="teensy", framework="arduino"),
+                True,
+            ),
+            (
+                Board(board_name="teensy41", platform="teensy", framework="arduino"),
+                False,
+            ),
+            (
+                Board(board_name="esp32dev", platform="esp32", framework="arduino"),
+                False,
+            ),
+        ]
+
+        for board, should_skip_expected in cases:
+            should_skip, reason = should_skip_sketch(board, sketch_filter)
+            assert should_skip is should_skip_expected, (
+                f"unexpected AudioInput filter result for {board.board_name}: {reason}"
+            )
+
+
 class TestMemoryTierMatching:
     """Test three-tier memory classification: low < large < huge."""
 

--- a/examples/Animartrix/Animartrix.ino
+++ b/examples/Animartrix/Animartrix.ino
@@ -44,6 +44,10 @@ Performence notes @64x64:
 
 #include "FastLED.h"
 
+#if defined(FL_IS_TEENSY)
+// Keep fbuild's library scanner aware of PJRC Audio sources for Teensy.
+#include <Audio.h>
+#endif
 
 // DRAW TIME: 7ms
 

--- a/examples/AnimartrixRing/AnimartrixRing.ino
+++ b/examples/AnimartrixRing/AnimartrixRing.ino
@@ -11,6 +11,11 @@
 // build system
 #include "FastLED.h"
 
+#if defined(FL_IS_TEENSY)
+// Keep fbuild's library scanner aware of PJRC Audio sources for Teensy.
+#include <Audio.h>
+#endif
+
 #include "fl/math/math.h"
 #include "fl/math/screenmap.h"
 #include "fl/ui/ui.h"

--- a/examples/Audio/Audio.ino
+++ b/examples/Audio/Audio.ino
@@ -6,6 +6,11 @@
 
 #include <FastLED.h>
 
+#if defined(FL_IS_TEENSY)
+// Keep fbuild's library scanner aware of PJRC Audio sources for Teensy.
+#include <Audio.h>
+#endif
+
 #if !SKETCH_HAS_LARGE_MEMORY
 void setup() {}
 void loop() {}

--- a/examples/AudioInput/AudioInput.ino
+++ b/examples/AudioInput/AudioInput.ino
@@ -1,4 +1,4 @@
-// @filter: (platform is teensy) or (platform is esp32)
+// @filter: ((platform is teensy) and (memory is large)) or (platform is esp32)
 
 // I2S Audio Input Example
 // This example demonstrates using I2S audio input to control FastLED strips

--- a/examples/AudioInput/TeensyAudioInput.h
+++ b/examples/AudioInput/TeensyAudioInput.h
@@ -4,6 +4,9 @@
 
 #pragma once
 
+// Keep fbuild's library scanner aware of PJRC Audio sources for Teensy.
+#include <Audio.h>
+
 #include "fl/audio/audio_input.h"
 
 // ============================================================================

--- a/examples/AudioReactive/AudioReactive.ino
+++ b/examples/AudioReactive/AudioReactive.ino
@@ -5,6 +5,11 @@
 
 #include "FastLED.h"
 
+#if defined(FL_IS_TEENSY)
+// Keep fbuild's library scanner aware of PJRC Audio sources for Teensy.
+#include <Audio.h>
+#endif
+
 #define NUM_LEDS 60
 #define LED_PIN 2
 

--- a/examples/AudioUrl/AudioUrl.ino
+++ b/examples/AudioUrl/AudioUrl.ino
@@ -11,6 +11,11 @@
 //   fastled
 
 #include <FastLED.h>
+#if defined(FL_IS_TEENSY)
+// Keep fbuild's library scanner aware of PJRC Audio sources for Teensy.
+#include <Audio.h>
+#endif
+
 #include "fl/asset/asset.h"
 #include "fl/ui/ui.h"
 #include "fl/stl/url.h"

--- a/examples/BeatDetection/BeatDetection.ino
+++ b/examples/BeatDetection/BeatDetection.ino
@@ -5,7 +5,14 @@
 /// Demonstrates beat detection using the Processor facade.
 /// Visualizes beats and tempo on an LED strip - flashes on beat detection.
 
+// @filter: (memory is large)
+
 #include <FastLED.h>
+
+#if defined(FL_IS_TEENSY)
+// Keep fbuild's library scanner aware of PJRC Audio sources for Teensy.
+#include <Audio.h>
+#endif
 
 #if !SKETCH_HAS_LARGE_MEMORY
 // Platform does not have enough memory

--- a/examples/ElPanelReactive/ElPanelReactive.ino
+++ b/examples/ElPanelReactive/ElPanelReactive.ino
@@ -15,6 +15,11 @@
 // @filter: (mem is large)
 
 #include <FastLED.h>
+#if defined(FL_IS_TEENSY)
+// Keep fbuild's library scanner aware of PJRC Audio sources for Teensy.
+#include <Audio.h>
+#endif
+
 #include "el_panel.h"
 #include "fl/math/filter/filter.h"
 #include "fl/math/math.h"

--- a/examples/Sailboat/Sailboat.ino
+++ b/examples/Sailboat/Sailboat.ino
@@ -11,6 +11,11 @@
 
 #include <FastLED.h>
 
+#if defined(FL_IS_TEENSY)
+// Keep fbuild's library scanner aware of PJRC Audio sources for Teensy.
+#include <Audio.h>
+#endif
+
 #include "fl/channels/config.h"
 #include "fl/chipsets/chipset_timing_config.h"
 #include "fl/fx/1d/perlin_particle_punch.h"

--- a/src/fl/audio/audio_input.cpp.hpp
+++ b/src/fl/audio/audio_input.cpp.hpp
@@ -15,23 +15,16 @@
 
 // First check for Teensy (before Arduino, since Teensy is Arduino-compatible)
 // IWYU pragma: begin_keep
-#include "platforms/arm/teensy/is_teensy.h" // ok platform headers
+#include "platforms/arm/teensy/audio_input_teensy_config.h" // ok platform headers
 // IWYU pragma: end_keep
-#ifndef FASTLED_USES_TEENSY_AUDIO_INPUT
-  #if defined(FL_IS_TEENSY)
-    #define FASTLED_USES_TEENSY_AUDIO_INPUT 1
-  #else
-    #define FASTLED_USES_TEENSY_AUDIO_INPUT 0
-  #endif
-#endif
 
 #ifndef FASTLED_USES_ARDUINO_AUDIO_INPUT
   #if defined(FL_IS_ESP32) && !defined(FL_IS_ESP8266)
     #define FASTLED_USES_ARDUINO_AUDIO_INPUT 0
   #elif defined(FL_IS_WASM)
     #define FASTLED_USES_ARDUINO_AUDIO_INPUT 0
-  #elif FASTLED_USES_TEENSY_AUDIO_INPUT
-    // Teensy uses its own audio implementation, not generic Arduino
+  #elif defined(FL_IS_TEENSY)
+    // Teensy uses the PJRC Audio backend when enabled, never generic Arduino I2S.
     #define FASTLED_USES_ARDUINO_AUDIO_INPUT 0
   #elif FL_HAS_INCLUDE(<Arduino.h>)
     #define FASTLED_USES_ARDUINO_AUDIO_INPUT 1
@@ -64,7 +57,10 @@
 // Include platform-specific audio input implementation
 // IWYU pragma: begin_keep
 #if FASTLED_USES_TEENSY_AUDIO_INPUT
-#include "platforms/arm/teensy/audio_input_teensy.h" // ok platform headers
+#define FASTLED_TEENSY_AUDIO_INPUT_HEADER                                    \
+    "platforms/arm/teensy/audio_input_teensy.h"
+#include FASTLED_TEENSY_AUDIO_INPUT_HEADER
+#undef FASTLED_TEENSY_AUDIO_INPUT_HEADER
 #elif FASTLED_USES_ARDUINO_AUDIO_INPUT
 #include "platforms/arduino/audio_input.hpp" // ok platform headers
 #elif FASTLED_USES_ESP32_AUDIO_INPUT

--- a/src/platforms/arm/teensy/_build.cpp.hpp
+++ b/src/platforms/arm/teensy/_build.cpp.hpp
@@ -7,7 +7,13 @@
 // Root directory implementations (alphabetical order)
 
 // begin current directory includes
-#include "platforms/arm/teensy/audio_input_teensy.cpp.hpp"
+#include "platforms/arm/teensy/audio_input_teensy_config.h"
+#if FASTLED_USES_TEENSY_AUDIO_INPUT
+#define FASTLED_TEENSY_AUDIO_INPUT_IMPL                                      \
+    "platforms/arm/teensy/audio_input_teensy.cpp.hpp"
+#include FASTLED_TEENSY_AUDIO_INPUT_IMPL
+#undef FASTLED_TEENSY_AUDIO_INPUT_IMPL
+#endif
 #include "platforms/arm/teensy/init_teensy4.cpp.hpp"
 #include "platforms/arm/teensy/semaphore_teensy.cpp.hpp"
 

--- a/src/platforms/arm/teensy/audio_input_teensy.h
+++ b/src/platforms/arm/teensy/audio_input_teensy.h
@@ -9,17 +9,16 @@
 #include "fl/stl/vector.h"
 #include "fl/stl/span.h"
 #include "fl/stl/shared_ptr.h"
-#include "platforms/arm/teensy/is_teensy.h"
+#include "platforms/arm/teensy/audio_input_teensy_config.h"
 
 // Detect Teensy Audio Library availability
-#if defined(FL_IS_TEENSY) && FL_HAS_INCLUDE(<Audio.h>)
-#define TEENSY_AUDIO_LIBRARY_AVAILABLE 1
+#if TEENSY_AUDIO_LIBRARY_AVAILABLE
 // IWYU pragma: begin_keep
-#include <Audio.h>  // ok include
+#define FASTLED_TEENSY_AUDIO_LIBRARY_HEADER <Audio.h>
+#include FASTLED_TEENSY_AUDIO_LIBRARY_HEADER
+#undef FASTLED_TEENSY_AUDIO_LIBRARY_HEADER
 #include "fl/stl/noexcept.h"
 // IWYU pragma: end_keep
-#else
-#define TEENSY_AUDIO_LIBRARY_AVAILABLE 0
 #endif
 
 namespace fl {

--- a/src/platforms/arm/teensy/audio_input_teensy_config.h
+++ b/src/platforms/arm/teensy/audio_input_teensy_config.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "fl/stl/has_include.h"
+#include "platforms/arm/teensy/is_teensy.h"
+
+// Teensy LC and Teensy 3.0 do not have enough RAM for the PJRC Audio
+// library's static DMA buffers in normal FastLED example builds.
+#if !defined(FASTLED_USES_TEENSY_AUDIO_INPUT)
+  #if defined(FL_IS_TEENSY) && !defined(FL_IS_TEENSY_LC) &&                  \
+      !defined(FL_IS_TEENSY_30) && FL_HAS_INCLUDE(<Audio.h>)
+    #define FASTLED_USES_TEENSY_AUDIO_INPUT 1
+  #else
+    #define FASTLED_USES_TEENSY_AUDIO_INPUT 0
+  #endif
+#endif
+
+#if !defined(TEENSY_AUDIO_LIBRARY_AVAILABLE)
+  #if FASTLED_USES_TEENSY_AUDIO_INPUT && defined(FL_IS_TEENSY) &&            \
+      FL_HAS_INCLUDE(<Audio.h>)
+    #define TEENSY_AUDIO_LIBRARY_AVAILABLE 1
+  #else
+    #define TEENSY_AUDIO_LIBRARY_AVAILABLE 0
+  #endif
+#endif

--- a/src/platforms/audio.h
+++ b/src/platforms/audio.h
@@ -2,11 +2,11 @@
 #pragma once
 
 #include "fl/stl/has_include.h"
-#include "platforms/arm/teensy/is_teensy.h"
+#include "platforms/arm/teensy/audio_input_teensy_config.h"
 
 // Check for Teensy with Audio Library first
 #if !defined(FASTLED_HAS_AUDIO_INPUT)
-  #if defined(FL_IS_TEENSY) && FL_HAS_INCLUDE(<Audio.h>)
+  #if FASTLED_USES_TEENSY_AUDIO_INPUT && TEENSY_AUDIO_LIBRARY_AVAILABLE
     #define FASTLED_HAS_AUDIO_INPUT 1
   #endif
 #endif


### PR DESCRIPTION
Fixes #2406.

## Summary
- Add a central Teensy audio configuration header that disables PJRC Audio input on Teensy LC and Teensy 3.0 by default.
- Hide optional Teensy Audio includes behind macro includes so fbuild does not pull PJRC `libraries/Audio` into low-memory builds while normal compiler behavior is preserved when the feature is enabled.
- Keep Teensy off the generic Arduino I2S backend.
- Filter the `AudioInput` example to large-memory Teensy boards and ESP32.
- Add a sketch-filter regression test for the `AudioInput` board selection.

## Validation
- `uv run pytest ci/tests/test_sketch_filter.py -q` -> 68 passed.
- `bash compile --no-interactive --no-parallel --max-failures 1 --backend=fbuild teensy30 AnalogOutput` -> pass, flash 29.65 KB / 128 KB, RAM 4.06 KB / 16 KB.
- `bash compile --no-interactive --no-parallel --max-failures 1 --backend=fbuild teensylc Blink` -> pass, flash 38.51 KB / 62 KB, RAM 4.48 KB / 8 KB.
- Final fbuild compile databases for those two repro builds contain no `libraries/Audio` entries.
- Final map files show `.dmabuffers` reduced to `0xf8` on Teensy 3.0 and `0xc0` on Teensy LC.
- `bash compile --no-interactive --no-parallel --max-failures 1 --backend=fbuild teensylc all` -> 30/30 selected examples passed.
- `bash compile --no-interactive --no-parallel --max-failures 1 --backend=fbuild teensy30 all` -> 31/32 wrapper-level successes; `WS2816` hit a transient fbuild daemon stream error, and a direct fbuild retry of the generated WS2816 build exited 0 with no RAM overflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Refined Teensy audio input detection with improved board-specific filtering (memory-aware) and clearer Teensy/library availability handling.

* **Examples**
  * Updated several example sketches to include Teensy audio headers conditionally so the build scanner recognizes PJRC Audio sources.

* **Tests**
  * Added tests validating audio-input filter behavior across multiple Teensy and ESP32 board variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->