### PR TITLE
fix: stream ESP32-S3 LCD clockless chunks

### DIFF
--- a/ci/autoresearch/build_driver.py
+++ b/ci/autoresearch/build_driver.py
@@ -1,4 +1,4 @@
-"""Build driver abstraction for autoresearch — fbuild default with legacy PlatformIO."""
+"""Build driver abstraction for autoresearch with fbuild-only board builds."""
 
 from __future__ import annotations
 
@@ -11,9 +11,8 @@ from typing import IO, Protocol, runtime_checkable
 class BuildDriver(Protocol):
     """Abstract build system driver for compile + deploy.
 
-    Two implementations:
-      - FbuildDriver (default for all board builds)
-      - PlatformIODriver (deprecated legacy implementation)
+    AutoResearch board builds use FbuildDriver. PlatformIODriver is retained
+    only for direct legacy imports, not for normal driver selection.
     """
 
     @property
@@ -53,9 +52,10 @@ class FbuildDriver:
         environment: str | None,
         timeout: float = 1800,
     ) -> bool:
-        from ci.util.pio_package_client import ensure_packages_installed
-
-        return ensure_packages_installed(build_dir, environment, timeout=int(timeout))
+        # fbuild owns package/toolchain resolution during build/deploy. Running
+        # the PlatformIO package helper here reintroduces the legacy backend and
+        # can hang before fbuild gets a chance to resolve its own inputs.
+        return True
 
     def deploy(
         self,
@@ -144,19 +144,16 @@ class PlatformIODriver:
 def select_build_driver(
     _environment: str | None,
     _use_fbuild_flag: bool,
-    no_fbuild_flag: bool,
+    _no_fbuild_flag: bool,
 ) -> BuildDriver:
     """Select the appropriate build driver.
 
-    Default is fbuild. `--no-fbuild` selects the legacy PlatformIODriver as a
-    fallback when the fbuild zccache daemon is broken (used by AI agents who
-    need a working build path without depending on fbuild's daemon).
+    fbuild is always selected for AutoResearch board builds. Deprecated
+    compatibility flags are accepted by the parser but ignored here.
 
     Args:
         _environment: Reserved for future per-board overrides; currently unused.
         _use_fbuild_flag: Deprecated compatibility parameter; ignored.
-        no_fbuild_flag: When True, select PlatformIODriver instead of fbuild.
+        _no_fbuild_flag: Deprecated compatibility parameter; ignored.
     """
-    if no_fbuild_flag:
-        return PlatformIODriver()
     return FbuildDriver()

--- a/ci/autoresearch/phases.py
+++ b/ci/autoresearch/phases.py
@@ -572,8 +572,15 @@ def _parse_args_and_build_commands(args: Args) -> RunContext | int:
 
     sketch_path = build_dir / "examples" / "AutoResearch"
     if not sketch_path.exists():
-        print(f"\u274c Error: AutoResearch sketch not found at {sketch_path}")
-        return 1
+        staged_sketch_path = build_dir / "src" / "sketch"
+        if staged_sketch_path.exists():
+            sketch_path = staged_sketch_path
+        else:
+            print(
+                "\u274c Error: AutoResearch sketch not found at "
+                f"{sketch_path} or {staged_sketch_path}"
+            )
+            return 1
 
     os.environ["PLATFORMIO_SRC_DIR"] = str(sketch_path)
 

--- a/ci/tests/test_autoresearch_phases.py
+++ b/ci/tests/test_autoresearch_phases.py
@@ -9,6 +9,7 @@ Tests the refactored phase decomposition:
 """
 
 import asyncio
+import os
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -156,6 +157,14 @@ def fake_project_dir(tmp_path: Path) -> Path:
     """Create a minimal PlatformIO project structure."""
     (tmp_path / "platformio.ini").write_text("[env:esp32s3]\n")
     (tmp_path / "examples" / "AutoResearch").mkdir(parents=True)
+    return tmp_path
+
+
+@pytest.fixture
+def staged_project_dir(tmp_path: Path) -> Path:
+    """Create a minimal staged fbuild project structure."""
+    (tmp_path / "platformio.ini").write_text("[env:esp32s3]\n")
+    (tmp_path / "src" / "sketch").mkdir(parents=True)
     return tmp_path
 
 
@@ -325,6 +334,18 @@ class TestParseArgsAndBuildCommands:
         result = _parse_args_and_build_commands(args)
         assert isinstance(result, int)
         assert result == 1
+
+    def test_staged_project_dir_uses_src_sketch(
+        self, staged_project_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("PLATFORMIO_SRC_DIR", raising=False)
+        args = _make_args(project_dir=staged_project_dir)
+        result = _parse_args_and_build_commands(args)
+        assert isinstance(result, RunContext)
+        assert result.build_dir == staged_project_dir
+        assert os.environ["PLATFORMIO_SRC_DIR"] == str(
+            staged_project_dir / "src" / "sketch"
+        )
 
     def test_lcd_forces_esp32s3(self, fake_project_dir: Path) -> None:
         args = _make_args(parlio=False, lcd=True, project_dir=fake_project_dir)

--- a/ci/tests/test_fbuild_default_selection.py
+++ b/ci/tests/test_fbuild_default_selection.py
@@ -68,6 +68,22 @@ def test_autoresearch_always_selects_fbuild() -> None:
     assert isinstance(driver, FbuildDriver)
 
 
+def test_autoresearch_fbuild_install_packages_does_not_call_platformio(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """fbuild AutoResearch lets fbuild resolve packages during deploy."""
+
+    def fail_if_called(*_args: Any, **_kwargs: Any) -> bool:
+        raise AssertionError("PlatformIO package helper should not be called")
+
+    monkeypatch.setattr(
+        "ci.util.pio_package_client.ensure_packages_installed",
+        fail_if_called,
+    )
+
+    assert FbuildDriver().install_packages(Path("."), "esp32s3") is True
+
+
 def test_autoresearch_parse_args_warns_for_deprecated_fbuild_flags(
     capsys: pytest.CaptureFixture[str],
 ) -> None:

--- a/ci/tests/test_sketch_filter.py
+++ b/ci/tests/test_sketch_filter.py
@@ -699,7 +699,9 @@ class TestBeatDetectionFilter:
         )
         sketch_filter = parse_filter_from_sketch(beat_detection_path)
 
-        assert sketch_filter is not None, "BeatDetection should have a @filter directive"
+        assert sketch_filter is not None, (
+            "BeatDetection should have a @filter directive"
+        )
 
         cases = [
             (
@@ -721,6 +723,51 @@ class TestBeatDetectionFilter:
             assert should_skip is should_skip_expected, (
                 f"unexpected BeatDetection filter result for {board.board_name}: {reason}"
             )
+
+
+class TestAutoResearchFilter:
+    """Test AutoResearch example board filtering."""
+
+    def test_autoresearch_filter_parsing(self) -> None:
+        from ci.compiler.board_example_utils import get_example_ino_path
+
+        sketch_filter = parse_filter_from_sketch(get_example_ino_path("AutoResearch"))
+
+        assert sketch_filter is not None, "AutoResearch should have a @filter directive"
+        assert sketch_filter.require == {
+            "board": ["esp32s3", "esp32c6", "esp32p4", "teensy41", "teensy40"]
+        }
+        assert sketch_filter.exclude == {"memory": ["low"]}
+
+    @pytest.mark.parametrize(
+        "board_name",
+        ["esp32s3", "esp32c6", "esp32p4", "teensy40", "teensy41"],
+    )
+    def test_autoresearch_supported_boards_compile(self, board_name: str) -> None:
+        from ci.boards import create_board
+        from ci.compiler.board_example_utils import should_skip_example_for_board
+
+        should_skip, reason = should_skip_example_for_board(
+            create_board(board_name), "AutoResearch"
+        )
+
+        assert not should_skip, (
+            f"{board_name} should pass AutoResearch filter: {reason}"
+        )
+
+    @pytest.mark.parametrize("board_name", ["esp32dev", "uno", "teensylc"])
+    def test_autoresearch_incompatible_boards_stay_filtered(
+        self, board_name: str
+    ) -> None:
+        from ci.boards import create_board
+        from ci.compiler.board_example_utils import should_skip_example_for_board
+
+        should_skip, reason = should_skip_example_for_board(
+            create_board(board_name), "AutoResearch"
+        )
+
+        assert should_skip, f"{board_name} should not pass AutoResearch filter"
+        assert reason
 
 
 class TestMemoryTierMatching:

--- a/examples/AutoResearch/AutoResearch.ino
+++ b/examples/AutoResearch/AutoResearch.ino
@@ -1,6 +1,6 @@
 // @filter
 // require:
-//   - platform: esp32s3,esp32c6,esp32p4,teensy41,teensy40
+//   - board: esp32s3,esp32c6,esp32p4,teensy41,teensy40
 // exclude:
 //   - memory: low
 // @end-filter

--- a/src/platforms/esp/32/drivers/lcd_spi/channel_driver_lcd_clockless.cpp.hpp
+++ b/src/platforms/esp/32/drivers/lcd_spi/channel_driver_lcd_clockless.cpp.hpp
@@ -31,6 +31,12 @@
 #include "fl/task/executor.h"
 #include "fl/stl/cstring.h"
 #include "fl/stl/noexcept.h"
+#include "platforms/memory_barrier.h"
+
+#if defined(FL_IS_ESP32) && !defined(FASTLED_STUB_IMPL)
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#endif
 
 // Include ESP peripheral for factory function
 #if defined(FL_IS_ESP_32S3)
@@ -58,6 +64,7 @@ ChannelDriverLcdClockless::ChannelDriverLcdClockless(
       mEnqueuedChannels(), mTransmittingChannels(),
       mRingBuffers{nullptr, nullptr, nullptr}, mRingCapacity(0),
       mNumLanes(0), mBusy(false), mIsrCtx(), mChunkInputBytesOverride(0),
+      mWorkerTaskHandle(nullptr), mWorkerStop(false), mWorkerRunning(false),
       mUseWave3(true), mWave3Lut(), mWave8Lut(), mClockHz(0),
       mOutputBytesPerInputByte(0) {
     mIsrCtx.reset();
@@ -77,6 +84,7 @@ ChannelDriverLcdClockless::~ChannelDriverLcdClockless() {
                     "freeing ring buffers anyway");
         }
     }
+    stopWorkerTask();
     freeRingBuffers();
 }
 
@@ -112,6 +120,166 @@ bool ChannelDriverLcdClockless::allocateRingBuffers(
     }
     mRingCapacity = slotCapacityBytes;
     return true;
+}
+
+//=============================================================================
+// Worker Task
+//=============================================================================
+
+bool ChannelDriverLcdClockless::ensureWorkerTask() FL_NOEXCEPT {
+#if defined(FL_IS_ESP32) && !defined(FASTLED_STUB_IMPL)
+    if (mWorkerTaskHandle != nullptr) {
+        return true;
+    }
+
+    mWorkerStop = false;
+    mWorkerRunning = false;
+
+    TaskHandle_t handle = nullptr;
+    UBaseType_t priority =
+        (configMAX_PRIORITIES > 2) ? (configMAX_PRIORITIES - 2) : 1;
+    BaseType_t ok = xTaskCreate(workerTaskEntry, "fl_lcd_clk",
+                                4096, this, priority, &handle);
+    if (ok != pdPASS || handle == nullptr) {
+        mWorkerTaskHandle = nullptr;
+        return false;
+    }
+
+    mWorkerTaskHandle = static_cast<void *>(handle);
+    return true;
+#else
+    return true;
+#endif
+}
+
+void ChannelDriverLcdClockless::stopWorkerTask() FL_NOEXCEPT {
+#if defined(FL_IS_ESP32) && !defined(FASTLED_STUB_IMPL)
+    TaskHandle_t handle = static_cast<TaskHandle_t>(mWorkerTaskHandle);
+    if (handle == nullptr) {
+        return;
+    }
+
+    mWorkerStop = true;
+    xTaskNotifyGive(handle);
+
+    for (int i = 0; i < 100 && mWorkerTaskHandle != nullptr; i++) {
+        vTaskDelay(pdMS_TO_TICKS(1));
+    }
+
+    if (mWorkerTaskHandle != nullptr) {
+        vTaskDelete(static_cast<TaskHandle_t>(mWorkerTaskHandle));
+        mWorkerTaskHandle = nullptr;
+        mWorkerRunning = false;
+    }
+#else
+    mWorkerStop = true;
+    mWorkerTaskHandle = nullptr;
+    mWorkerRunning = false;
+#endif
+}
+
+void ChannelDriverLcdClockless::workerTaskEntry(void *arg) FL_NOEXCEPT {
+#if defined(FL_IS_ESP32) && !defined(FASTLED_STUB_IMPL)
+    auto *self = static_cast<ChannelDriverLcdClockless *>(arg);
+    if (self == nullptr) {
+        vTaskDelete(nullptr);
+        return;
+    }
+
+    self->mWorkerRunning = true;
+    for (;;) {
+        ulTaskNotifyTake(pdTRUE, portMAX_DELAY);
+        if (self->mWorkerStop) {
+            break;
+        }
+        self->processWorkerQueue();
+    }
+
+    self->mWorkerRunning = false;
+    self->mWorkerTaskHandle = nullptr;
+    vTaskDelete(nullptr);
+#else
+    (void)arg;
+#endif
+}
+
+bool ChannelDriverLcdClockless::notifyWorker() FL_NOEXCEPT {
+#if defined(FL_IS_ESP32) && !defined(FASTLED_STUB_IMPL)
+    TaskHandle_t handle = static_cast<TaskHandle_t>(mWorkerTaskHandle);
+    if (handle == nullptr) {
+        return false;
+    }
+
+    xTaskNotifyGive(handle);
+    return true;
+#else
+    processWorkerQueue();
+    return true;
+#endif
+}
+
+bool ChannelDriverLcdClockless::notifyWorkerFromIsr() FL_NOEXCEPT {
+#if defined(FL_IS_ESP32) && !defined(FASTLED_STUB_IMPL)
+    TaskHandle_t handle = static_cast<TaskHandle_t>(mWorkerTaskHandle);
+    if (handle == nullptr) {
+        return false;
+    }
+
+    BaseType_t higherPriorityTaskWoken = pdFALSE;
+    vTaskNotifyGiveFromISR(handle, &higherPriorityTaskWoken);
+    return higherPriorityTaskWoken == pdTRUE;
+#else
+    processWorkerQueue();
+    return false;
+#endif
+}
+
+bool ChannelDriverLcdClockless::submitChunk(size_t chunkIndex,
+                                            bool waitForSlot) FL_NOEXCEPT {
+    size_t ringIdx = chunkIndex % kRingBufferCount;
+    size_t startByte = chunkIndex * mIsrCtx.mChunkInputBytes;
+    u16 *buf = mRingBuffers[ringIdx];
+    if (buf == nullptr) {
+        return false;
+    }
+
+    size_t dmaBytes = encodeChunk(mTransmittingChannels, buf, startByte,
+                                  mIsrCtx.mChunkInputBytes);
+
+    FL_MEMORY_BARRIER;
+
+    if (waitForSlot) {
+        return mPeripheral->transmit(buf, dmaBytes);
+    }
+    return mPeripheral->queueTransmit(buf, dmaBytes);
+}
+
+void ChannelDriverLcdClockless::processWorkerQueue() FL_NOEXCEPT {
+    IsrContext &ctx = mIsrCtx;
+
+    while (mBusy && !ctx.mStreamComplete && !ctx.mStreamError) {
+        size_t submitted = ctx.mSubmittedChunks;
+        size_t completed = ctx.mCompletedChunks;
+
+        if (submitted >= ctx.mTotalChunks) {
+            break;
+        }
+
+        if (submitted > completed &&
+            (submitted - completed) >= 2) {
+            break;
+        }
+
+        if (!submitChunk(submitted, false)) {
+            ctx.mStreamError = true;
+            ctx.mStreamComplete = true;
+            mBusy = false;
+            break;
+        }
+
+        ctx.mSubmittedChunks = submitted + 1;
+        FL_MEMORY_BARRIER;
+    }
 }
 
 //=============================================================================
@@ -168,15 +336,20 @@ IChannelDriver::DriverState ChannelDriverLcdClockless::poll() FL_NOEXCEPT {
         return DriverState::READY;
     }
 
+#if !defined(FL_IS_ESP32) || defined(FASTLED_STUB_IMPL)
+    processWorkerQueue();
+#endif
+
     bool streamDone = mIsrCtx.mStreamComplete;
     bool peripheralIdle = mPeripheral && !mPeripheral->isBusy();
 
     // Only declare complete when the ISR has signaled all chunks are done.
     // peripheralIdle alone is insufficient: between the first DMA send and
     // the ISR callback registration, the peripheral can briefly appear idle.
-    if (streamDone && peripheralIdle) {
+    if ((streamDone && peripheralIdle) || mIsrCtx.mStreamError) {
         mBusy = false;
         mIsrCtx.mStreamComplete = false;
+        mIsrCtx.mStreamError = false;
         for (auto &channel : mTransmittingChannels) {
             channel->setInUse(false);
         }
@@ -191,9 +364,9 @@ IChannelDriver::DriverState ChannelDriverLcdClockless::poll() FL_NOEXCEPT {
 // Encoding — wave3 or wave8 transpose into u16 DMA words
 //=============================================================================
 
-// FL_IRAM matches the declaration in channel_driver_lcd_clockless.h — this
-// function is invoked from isrChunkDone() and MUST live in IRAM so it can
-// execute while flash cache is suspended (NVS, SPI flash ops).
+// FL_IRAM matches the declaration in channel_driver_lcd_clockless.h. Keep the
+// encoder IRAM-safe because worker wake-up is triggered by the LCD ISR and this
+// code is part of the time-critical refill path.
 size_t FL_IRAM ChannelDriverLcdClockless::encodeChunk(
     fl::span<const ChannelDataPtr> channels, u16 *output,
     size_t startByte, size_t byteCount) FL_NOEXCEPT {
@@ -256,33 +429,16 @@ bool FL_IRAM ChannelDriverLcdClockless::isrChunkDone(void *panel_io,
     auto *self = static_cast<ChannelDriverLcdClockless *>(user_ctx);
     IsrContext &ctx = self->mIsrCtx;
 
-    if (ctx.mNextByteOffset >= ctx.mTotalBytes) {
+    ctx.mCompletedChunks = ctx.mCompletedChunks + 1;
+
+    if (ctx.mCompletedChunks >= ctx.mTotalChunks) {
         ctx.mStreamComplete = true;
         self->mBusy = false;
         return false;
     }
 
-    size_t writeIdx = ctx.mRingWriteIdx;
-    u16 *buf = self->mRingBuffers[writeIdx];
-
-    size_t bytesRemaining = ctx.mTotalBytes - ctx.mNextByteOffset;
-    size_t chunkBytes = ctx.mChunkInputBytes;
-    if (chunkBytes > bytesRemaining) {
-        chunkBytes = bytesRemaining;
-    }
-
-    size_t dmaBytes = self->encodeChunk(self->mTransmittingChannels, buf,
-                                        ctx.mNextByteOffset, chunkBytes);
-
-    ctx.mNextByteOffset += chunkBytes;
-    ctx.mRingWriteIdx = (writeIdx + 1) % kRingBufferCount;
-
-    if (!self->mPeripheral->transmit(buf, dmaBytes)) {
-        ctx.mStreamComplete = true;
-        self->mBusy = false;
-#ifndef FASTLED_STUB_IMPL
-        esp_rom_printf("ChannelDriverLcdClockless: ISR transmit failed\n");  // ok esp_rom_printf - IRAM ISR context, FL_WARN unsafe here
-#endif
+    if (ctx.mSubmittedChunks < ctx.mTotalChunks) {
+        return self->notifyWorkerFromIsr();
     }
 
     return false;
@@ -301,6 +457,11 @@ bool ChannelDriverLcdClockless::beginTransmission(
     if (channels.size() > 16) {
         FL_WARN("ChannelDriverLcdClockless: too many channels ("
                 << channels.size() << "), max 16 supported");
+        return false;
+    }
+
+    if (!ensureWorkerTask()) {
+        FL_WARN("ChannelDriverLcdClockless: worker task creation failed");
         return false;
     }
 
@@ -351,16 +512,10 @@ bool ChannelDriverLcdClockless::beginTransmission(
 
     // Chunk sizing.
     //
-    // The LCD I80 peripheral wrapper (LcdSpiPeripheralEsp::transmit) tears
-    // down and recreates the ESP-IDF panel_io handle whenever the
-    // transaction size changes — its GDMA descriptor chain is sized per
-    // transaction. The teardown calls esp_lcd_panel_io_del, which lives in
-    // flash; performing it from isrChunkDone (ISR context) deadlocks the
-    // chip with "Interrupt wdt timeout on CPU1" if any concurrent flash
-    // op has suspended the cache. To keep every ISR-driven transmit at the
-    // same size, we round the requested chunk size up so chunkInputBytes
-    // evenly divides maxSize — the resulting (slightly larger) chunks all
-    // carry the same DMA byte count.
+    // The LCD I80 peripheral wrapper tears down and recreates the ESP-IDF
+    // panel_io handle whenever the transaction size changes. Keep every chunk
+    // at the same DMA byte count so the worker never needs to recreate panel IO
+    // while a stream is active.
     size_t requestedChunkInputBytes =
         mChunkInputBytesOverride > 0 ? mChunkInputBytesOverride
                                      : kDefaultChunkInputBytes;
@@ -369,9 +524,9 @@ bool ChannelDriverLcdClockless::beginTransmission(
     }
 
     // Keep the initial chunk count from the requested size, then round the
-    // chunk size up to cover maxSize. Do not walk numChunks upward looking for
-    // an exact divisor: awkward frame sizes just above the default chunk size
-    // would otherwise collapse into many much smaller ISR-driven chunks.
+    // chunk size up to cover maxSize. Every submitted LCD transaction uses this
+    // rounded byte count; the last chunk zero-fills past the real source bytes
+    // so ESP-IDF panel IO never has to be recreated mid-stream.
     size_t numChunks =
         (maxSize + requestedChunkInputBytes - 1) / requestedChunkInputBytes;
     if (numChunks == 0) {
@@ -448,25 +603,15 @@ bool ChannelDriverLcdClockless::beginTransmission(
     mIsrCtx.reset();
     mIsrCtx.mTotalBytes = maxSize;
     mIsrCtx.mChunkInputBytes = chunkInputBytes;
+    mIsrCtx.mTotalChunks = numChunks;
 
     for (const auto &channel : channels) {
         channel->setInUse(true);
     }
 
-    // Encode first chunk
-    size_t firstChunkBytes = chunkInputBytes;
-    if (firstChunkBytes > maxSize) {
-        firstChunkBytes = maxSize;
-    }
-
-    size_t firstDmaBytes = encodeChunk(channels, mRingBuffers[0], 0,
-                                       firstChunkBytes);
-
-    mIsrCtx.mNextByteOffset = firstChunkBytes;
-    mIsrCtx.mRingWriteIdx = 1;
-
     mBusy = true;
-    if (!mPeripheral->transmit(mRingBuffers[0], firstDmaBytes)) {
+
+    if (!submitChunk(0, true)) {
         mBusy = false;
         for (const auto &channel : channels) {
             channel->setInUse(false);
@@ -474,6 +619,9 @@ bool ChannelDriverLcdClockless::beginTransmission(
         FL_WARN("ChannelDriverLcdClockless: Initial transmit failed");
         return false;
     }
+    mIsrCtx.mSubmittedChunks = 1;
+
+    notifyWorker();
 
     return true;
 }
@@ -501,12 +649,15 @@ fl::shared_ptr<IChannelDriver> createLcdClocklessEngine() FL_NOEXCEPT {
         void freeBuffer(u16 *b) FL_NOEXCEPT override {
             detail::LcdSpiPeripheralEsp::instance().freeBuffer(b);
         }
-        // FL_IRAM: forwarded into LcdSpiPeripheralEsp::transmit() from
-        // isrChunkDone (ISR context). The thunk must live in IRAM too —
-        // marking only the target is not enough because the vtable dispatch
-        // jumps here first.
+        // FL_IRAM: forwarded into LcdSpiPeripheralEsp::transmit(); keep the
+        // thunk IRAM-safe because the shared peripheral also services LCD_SPI
+        // ISR re-arm paths.
         bool FL_IRAM transmit(const u16 *b, size_t s) FL_NOEXCEPT override {
             return detail::LcdSpiPeripheralEsp::instance().transmit(b, s);
+        }
+        bool FL_IRAM queueTransmit(const u16 *b,
+                                   size_t s) FL_NOEXCEPT override {
+            return detail::LcdSpiPeripheralEsp::instance().queueTransmit(b, s);
         }
         bool waitTransmitDone(u32 t) FL_NOEXCEPT override {
             return detail::LcdSpiPeripheralEsp::instance().waitTransmitDone(t);

--- a/src/platforms/esp/32/drivers/lcd_spi/channel_driver_lcd_clockless.cpp.hpp
+++ b/src/platforms/esp/32/drivers/lcd_spi/channel_driver_lcd_clockless.cpp.hpp
@@ -346,7 +346,14 @@ IChannelDriver::DriverState ChannelDriverLcdClockless::poll() FL_NOEXCEPT {
     // Only declare complete when the ISR has signaled all chunks are done.
     // peripheralIdle alone is insufficient: between the first DMA send and
     // the ISR callback registration, the peripheral can briefly appear idle.
-    if ((streamDone && peripheralIdle) || mIsrCtx.mStreamError) {
+    //
+    // Require peripheralIdle on the error path as well: queueTransmit() keeps
+    // up to two LCD transactions in flight, so a failed follow-up submission
+    // can leave an earlier chunk still completing asynchronously in
+    // LcdSpiPeripheralEsp. Clearing mIsrCtx and releasing the channels before
+    // that final ISR callback would let the stale callback poke into a torn-
+    // down or newly-started stream.
+    if ((streamDone || mIsrCtx.mStreamError) && peripheralIdle) {
         mBusy = false;
         mIsrCtx.mStreamComplete = false;
         mIsrCtx.mStreamError = false;

--- a/src/platforms/esp/32/drivers/lcd_spi/channel_driver_lcd_clockless.h
+++ b/src/platforms/esp/32/drivers/lcd_spi/channel_driver_lcd_clockless.h
@@ -18,8 +18,8 @@
 ///
 /// ## ISR-Driven Chunked DMA
 ///
-/// Same architecture as ChannelDriverLcdSpi — 3-buffer ring, ISR callback
-/// transposes next chunk (~1-2 µs) and submits immediately.
+/// Uses a 3-buffer ring. The ISR records chunk completion and wakes a worker
+/// task; the worker encodes and submits follow-up chunks outside ISR context.
 /// See issue #2258 for design details.
 
 #pragma once
@@ -73,11 +73,8 @@ class ChannelDriverLcdClockless : public IChannelDriver {
 
     /// Default: 1024 bytes per chunk for clockless (3 bytes/LED ≈ 341 LEDs).
     ///
-    /// The chunked-streaming ISR re-arm path currently emits garbled data
-    /// past the first chunk (#2647 follow-up). Until that is fixed, pick a
-    /// chunk size big enough that a typical RGB frame fits in one chunk so
-    /// the ISR re-arm path is never taken. Worst-case memory for
-    /// 16-lane wave8: 1024 × 128 × 3 buffers = 384 KB in PSRAM.
+    /// Worst-case memory for 16-lane wave8 is
+    /// 1024 * 128 * 3 buffers = 384 KB in PSRAM.
     static constexpr size_t kDefaultChunkInputBytes = 1024;
 
     /// Override chunk input bytes for testing (0 = use default).
@@ -105,6 +102,13 @@ class ChannelDriverLcdClockless : public IChannelDriver {
 
     void freeRingBuffers() FL_NOEXCEPT;
     bool allocateRingBuffers(size_t slotCapacityBytes) FL_NOEXCEPT;
+    bool submitChunk(size_t chunkIndex, bool waitForSlot) FL_NOEXCEPT;
+    void processWorkerQueue() FL_NOEXCEPT;
+    bool ensureWorkerTask() FL_NOEXCEPT;
+    void stopWorkerTask() FL_NOEXCEPT;
+    bool notifyWorker() FL_NOEXCEPT;
+    bool notifyWorkerFromIsr() FL_NOEXCEPT;
+    static void workerTaskEntry(void *arg) FL_NOEXCEPT;
 
     //=========================================================================
     // ISR callback
@@ -125,18 +129,22 @@ class ChannelDriverLcdClockless : public IChannelDriver {
 
     struct IsrContext {
         volatile bool mStreamComplete;
-        volatile size_t mNextByteOffset;
-        volatile size_t mRingWriteIdx;
+        volatile bool mStreamError;
+        volatile size_t mSubmittedChunks;
+        volatile size_t mCompletedChunks;
 
         size_t mTotalBytes;
         size_t mChunkInputBytes;
+        size_t mTotalChunks;
 
         void reset() FL_NOEXCEPT {
             mStreamComplete = false;
-            mNextByteOffset = 0;
-            mRingWriteIdx = 0;
+            mStreamError = false;
+            mSubmittedChunks = 0;
+            mCompletedChunks = 0;
             mTotalBytes = 0;
             mChunkInputBytes = 0;
+            mTotalChunks = 0;
         }
     };
 
@@ -156,6 +164,9 @@ class ChannelDriverLcdClockless : public IChannelDriver {
     volatile bool mBusy;
     IsrContext mIsrCtx;
     size_t mChunkInputBytesOverride;
+    void *mWorkerTaskHandle;
+    volatile bool mWorkerStop;
+    volatile bool mWorkerRunning;
 
     // Encoding state (set during beginTransmission, stable during ISR)
     bool mUseWave3;

--- a/src/platforms/esp/32/drivers/lcd_spi/channel_driver_lcd_spi.cpp.hpp
+++ b/src/platforms/esp/32/drivers/lcd_spi/channel_driver_lcd_spi.cpp.hpp
@@ -425,6 +425,9 @@ fl::shared_ptr<IChannelDriver> createLcdSpiEngine() FL_NOEXCEPT {
         bool transmit(const u16 *b, size_t s) FL_NOEXCEPT override {
             return detail::LcdSpiPeripheralEsp::instance().transmit(b, s);
         }
+        bool queueTransmit(const u16 *b, size_t s) FL_NOEXCEPT override {
+            return detail::LcdSpiPeripheralEsp::instance().queueTransmit(b, s);
+        }
         bool waitTransmitDone(u32 t) FL_NOEXCEPT override {
             return detail::LcdSpiPeripheralEsp::instance().waitTransmitDone(t);
         }

--- a/src/platforms/esp/32/drivers/lcd_spi/ilcd_spi_peripheral.h
+++ b/src/platforms/esp/32/drivers/lcd_spi/ilcd_spi_peripheral.h
@@ -97,6 +97,10 @@ class ILcdSpiPeripheral {
     // Transmission
     virtual bool transmit(const u16 *buffer,
                           size_t size_bytes) FL_NOEXCEPT = 0;
+    virtual bool queueTransmit(const u16 *buffer,
+                               size_t size_bytes) FL_NOEXCEPT {
+        return transmit(buffer, size_bytes);
+    }
     virtual bool waitTransmitDone(u32 timeout_ms) FL_NOEXCEPT = 0;
     virtual bool isBusy() const FL_NOEXCEPT = 0;
 

--- a/src/platforms/esp/32/drivers/lcd_spi/lcd_spi_peripheral_esp.cpp.hpp
+++ b/src/platforms/esp/32/drivers/lcd_spi/lcd_spi_peripheral_esp.cpp.hpp
@@ -61,7 +61,10 @@ bool IRAM_ATTR lcd_spi_flush_ready(
     void *user_ctx) { // ok no noexcept — matches friend decl
     LcdSpiPeripheralEsp *self =
         static_cast<LcdSpiPeripheralEsp *>(user_ctx);
-    self->mBusy = false;
+    if (self->mPendingTransmits > 0) {
+        self->mPendingTransmits = self->mPendingTransmits - 1;
+    }
+    self->mBusy = self->mPendingTransmits > 0;
 
     // Signal completion semaphore
     BaseType_t xHigherPriorityTaskWoken = pdFALSE;
@@ -98,7 +101,7 @@ LcdSpiPeripheralEsp &LcdSpiPeripheralEsp::instance() FL_NOEXCEPT {
 LcdSpiPeripheralEsp::LcdSpiPeripheralEsp() FL_NOEXCEPT
     : mInitialized(false), mConfig(), mI80Bus(nullptr), mPanelIo(nullptr),
       mCompleteSem(nullptr), mCallback(nullptr), mUserCtx(nullptr),
-      mBusy(false), mLastTransmitSize(0),
+      mBusy(false), mPendingTransmits(0), mLastTransmitSize(0),
       mOwner(LcdSpiOwnerDriver::NONE) {}
 
 LcdSpiPeripheralEsp::~LcdSpiPeripheralEsp() { deinitialize(); }
@@ -255,6 +258,7 @@ void LcdSpiPeripheralEsp::teardownLocked() FL_NOEXCEPT {
     }
     mInitialized = false;
     mBusy = false;
+    mPendingTransmits = 0;
     mLastTransmitSize = 0;
     mOwner = LcdSpiOwnerDriver::NONE;
 }
@@ -303,12 +307,24 @@ void LcdSpiPeripheralEsp::freeBuffer(u16 *buffer) FL_NOEXCEPT {
 
 bool FL_IRAM LcdSpiPeripheralEsp::transmit(const u16 *buffer,
                                    size_t size_bytes) FL_NOEXCEPT {
+    return transmitInternal(buffer, size_bytes, true);
+}
+
+bool FL_IRAM LcdSpiPeripheralEsp::queueTransmit(const u16 *buffer,
+                                                size_t size_bytes) FL_NOEXCEPT {
+    return transmitInternal(buffer, size_bytes, false);
+}
+
+bool FL_IRAM LcdSpiPeripheralEsp::transmitInternal(
+    const u16 *buffer, size_t size_bytes, bool wait_for_slot) FL_NOEXCEPT {
     if (!mInitialized || mI80Bus == nullptr) {
         return false;
     }
 
-    // Block until previous DMA is truly complete. The semaphore is
-    // primed during initialize() so the first call returns immediately.
+    // Block until a previous DMA slot is free when the caller requested
+    // serialized transmit() semantics. queueTransmit() deliberately skips this
+    // wait so LCD_CLOCKLESS can keep ESP-IDF's queue depth of 2 filled with an
+    // already-encoded next chunk.
     //
     // ISR safety: when ChannelDriverLcdClockless::isrChunkDone re-arms the
     // next chunk from the on_color_trans_done callback, transmit() runs in
@@ -316,7 +332,7 @@ bool FL_IRAM LcdSpiPeripheralEsp::transmit(const u16 *buffer,
     // *before* invoking our user callback, so the take is guaranteed to be
     // non-blocking — but we MUST use the FromISR variant because the regular
     // xSemaphoreTake() asserts (configASSERT) when called from ISR.
-    if (mCompleteSem) {
+    if (wait_for_slot && mCompleteSem) {
         if (xPortInIsrContext()) {
             BaseType_t hpw = pdFALSE;
             if (xSemaphoreTakeFromISR(mCompleteSem, &hpw) != pdTRUE) {
@@ -347,6 +363,9 @@ bool FL_IRAM LcdSpiPeripheralEsp::transmit(const u16 *buffer,
     // Recreating panel_io is cheap (descriptor alloc + config) and does
     // not touch the I80 bus GPIO routing.
     if (size_bytes != mLastTransmitSize && mPanelIo != nullptr) {
+        if (mPendingTransmits > 0) {
+            return false;
+        }
         esp_lcd_panel_io_del(mPanelIo);
         mPanelIo = nullptr;
     }
@@ -395,6 +414,7 @@ bool FL_IRAM LcdSpiPeripheralEsp::transmit(const u16 *buffer,
     }
 #endif
 
+    mPendingTransmits = mPendingTransmits + 1;
     mBusy = true;
     mLastTransmitSize = size_bytes;
 
@@ -402,7 +422,10 @@ bool FL_IRAM LcdSpiPeripheralEsp::transmit(const u16 *buffer,
         esp_lcd_panel_io_tx_color(mPanelIo, 0x2C, buffer, size_bytes);
 
     if (err != ESP_OK) {
-        mBusy = false;
+        if (mPendingTransmits > 0) {
+            mPendingTransmits = mPendingTransmits - 1;
+        }
+        mBusy = mPendingTransmits > 0;
         esp_rom_printf("LcdSpiPeripheralEsp: tx_color failed: %d\n", static_cast<int>(err));  // ok esp_rom_printf - FL_IRAM transmit() context, FL_WARN unsafe
         return false;
     }
@@ -415,17 +438,30 @@ bool LcdSpiPeripheralEsp::waitTransmitDone(u32 timeout_ms) FL_NOEXCEPT {
         return false;
     }
 
-    TickType_t ticks = (timeout_ms == 0)
-                           ? portMAX_DELAY
-                           : pdMS_TO_TICKS(timeout_ms);
-    if (xSemaphoreTake(mCompleteSem, ticks) == pdTRUE) {
-        mBusy = false;
-        return true;
+    const TickType_t timeout_ticks =
+        (timeout_ms == 0) ? portMAX_DELAY : pdMS_TO_TICKS(timeout_ms);
+    TickType_t start = xTaskGetTickCount();
+
+    while (mPendingTransmits > 0) {
+        TickType_t ticks = timeout_ticks;
+        if (timeout_ticks != portMAX_DELAY) {
+            TickType_t elapsed = xTaskGetTickCount() - start;
+            if (elapsed >= timeout_ticks) {
+                return false;
+            }
+            ticks = timeout_ticks - elapsed;
+        }
+        if (xSemaphoreTake(mCompleteSem, ticks) != pdTRUE) {
+            return false;
+        }
     }
-    return false;
+    mBusy = false;
+    return true;
 }
 
-bool LcdSpiPeripheralEsp::isBusy() const FL_NOEXCEPT { return mBusy; }
+bool LcdSpiPeripheralEsp::isBusy() const FL_NOEXCEPT {
+    return mBusy || mPendingTransmits > 0;
+}
 
 //=============================================================================
 // Callback

--- a/src/platforms/esp/32/drivers/lcd_spi/lcd_spi_peripheral_esp.h
+++ b/src/platforms/esp/32/drivers/lcd_spi/lcd_spi_peripheral_esp.h
@@ -55,6 +55,7 @@ class LcdSpiPeripheralEsp : public ILcdSpiPeripheral {
     // chunk from ISR context, so transmit() must be IRAM-resident to survive
     // a flash-cache stall (NVS commit, SPI flash erase, etc.).
     bool FL_IRAM transmit(const u16 *buffer, size_t size_bytes) FL_NOEXCEPT override;
+    bool FL_IRAM queueTransmit(const u16 *buffer, size_t size_bytes) FL_NOEXCEPT override;
     bool waitTransmitDone(u32 timeout_ms) FL_NOEXCEPT override;
     bool isBusy() const FL_NOEXCEPT override;
 
@@ -87,6 +88,8 @@ class LcdSpiPeripheralEsp : public ILcdSpiPeripheral {
     /// singleton. Called from deinitialize() and from initialize() when
     /// the owning driver changes (issue #2270).
     void teardownLocked() FL_NOEXCEPT;
+    bool FL_IRAM transmitInternal(const u16 *buffer, size_t size_bytes,
+                                  bool wait_for_slot) FL_NOEXCEPT;
 
     bool mInitialized;
     LcdSpiConfig mConfig;
@@ -96,6 +99,7 @@ class LcdSpiPeripheralEsp : public ILcdSpiPeripheral {
     void *mCallback;
     void *mUserCtx;
     volatile bool mBusy;
+    volatile size_t mPendingTransmits;
     size_t mLastTransmitSize;
     LcdSpiOwnerDriver mOwner; ///< Tracks which driver owns the singleton (#2270).
 };

--- a/tests/platforms/esp/32/drivers/lcd_spi/channel_driver_lcd_clockless.cpp
+++ b/tests/platforms/esp/32/drivers/lcd_spi/channel_driver_lcd_clockless.cpp
@@ -95,6 +95,17 @@ ChannelDataPtr createClocklessChannelDataBytes(int pin, size_t numBytes) {
     return ChannelData::create(pin, timing, fl::move(data));
 }
 
+fl::vector<u16> collectTransmitWords() {
+    const auto &history = LcdSpiPeripheralMock::instance().getTransmitHistory();
+    fl::vector<u16> combined;
+    for (const auto &record : history) {
+        for (const auto &word : record.buffer_copy) {
+            combined.push_back(word);
+        }
+    }
+    return combined;
+}
+
 } // anonymous namespace
 
 //=============================================================================
@@ -200,7 +211,7 @@ FL_TEST_CASE("ChannelDriverLcdClockless - multi-chunk") {
     driver.enqueue(data);
     driver.show();
 
-    FL_CHECK(mock.getTransmitCount() == 1);
+    FL_CHECK(mock.getTransmitCount() == 2);
 
     mock.simulateTransmitComplete();
     FL_CHECK(driver.poll() == IChannelDriver::DriverState::READY);
@@ -219,7 +230,7 @@ FL_TEST_CASE("ChannelDriverLcdClockless - awkward chunk size rounds up") {
     driver.enqueue(data);
     driver.show();
 
-    FL_CHECK(mock.getTransmitCount() == 1);
+    FL_CHECK(mock.getTransmitCount() == 2);
 
     mock.simulateTransmitComplete();
     FL_CHECK(driver.poll() == IChannelDriver::DriverState::READY);
@@ -229,7 +240,46 @@ FL_TEST_CASE("ChannelDriverLcdClockless - awkward chunk size rounds up") {
     FL_REQUIRE(history.size() == 2);
     const size_t dmaBytesPerInputByte = 16 * sizeof(Wave3Byte);
     FL_CHECK(history[0].size_bytes == 513 * dmaBytesPerInputByte);
-    FL_CHECK(history[1].size_bytes == 512 * dmaBytesPerInputByte);
+    FL_CHECK(history[1].size_bytes == 513 * dmaBytesPerInputByte);
+}
+
+FL_TEST_CASE("ChannelDriverLcdClockless - default multi-chunk 400 LED fidelity") {
+    fl::vector<u16> reference;
+    {
+        resetMockState();
+        auto peripheral = createMockPeripheral();
+        ChannelDriverLcdClockless driver(peripheral);
+        auto &mock = LcdSpiPeripheralMock::instance();
+
+        driver.setChunkInputBytesForTest(4096);
+        auto data = createClocklessChannelData(5, 400);
+        driver.enqueue(data);
+        driver.show();
+        FL_CHECK(mock.getTransmitCount() == 1);
+        mock.simulateTransmitComplete();
+        FL_CHECK(driver.poll() == IChannelDriver::DriverState::READY);
+        reference = collectTransmitWords();
+    }
+
+    resetMockState();
+    auto peripheral = createMockPeripheral();
+    ChannelDriverLcdClockless driver(peripheral);
+    auto &mock = LcdSpiPeripheralMock::instance();
+
+    auto data = createClocklessChannelData(5, 400);
+    driver.enqueue(data);
+    driver.show();
+
+    FL_CHECK(mock.getTransmitCount() == 2);
+    mock.simulateTransmitComplete();
+    FL_CHECK(driver.poll() == IChannelDriver::DriverState::READY);
+    FL_CHECK(mock.getTransmitCount() == 2);
+
+    fl::vector<u16> chunked = collectTransmitWords();
+    FL_REQUIRE(chunked.size() == reference.size());
+    for (size_t i = 0; i < reference.size(); i++) {
+        FL_CHECK(chunked[i] == reference[i]);
+    }
 }
 
 //=============================================================================
@@ -334,15 +384,15 @@ FL_TEST_CASE("ChannelDriverLcdClockless - error mid-stream") {
     driver.enqueue(data);
     driver.show();
 
-    FL_CHECK(mock.getTransmitCount() == 1);
+    FL_CHECK(mock.getTransmitCount() == 2);
 
     mock.setTransmitFailure(true);
     mock.simulateTransmitComplete();
+    FL_CHECK(mock.getTransmitCount() == 2);
 
     // ISR tried chunk 2 but transmit failed → abort
     FL_CHECK(driver.poll() == IChannelDriver::DriverState::READY);
 }
-
 //=============================================================================
 // Empty enqueue
 //=============================================================================


### PR DESCRIPTION
## Summary
- enables AutoResearch selection for ESP32-S3/C6/P4 and Teensy by filtering on `board:` instead of `platform:`
- keeps AutoResearch board builds on the fbuild-only path and avoids PlatformIO package installation during fbuild builds
- streams LCD_CLOCKLESS chunks from a worker task while keeping the ESP LCD SPI queue filled, with padded fixed-size chunk transactions
- adds regression coverage for AutoResearch filters, staged fbuild project dirs, fbuild-only selection, and LCD chunk fidelity

## Tests
- `uv run python -m pytest ci/tests/test_autoresearch_phases.py ci/tests/test_fbuild_default_selection.py ci/tests/test_sketch_filter.py ci/tests/test_filter_examples.py -q` (`130 passed`)
- `bash test --cpp tests/platforms/esp/32/drivers/lcd_spi/channel_driver_lcd_clockless.cpp`
- `bash test --cpp tests/platforms/esp/32/drivers/lcd_spi/channel_driver_lcd_spi.cpp`
- `git diff --check`
- fbuild compiled staged ESP32-S3 AutoResearch firmware and produced `firmware.bin` / `firmware.elf`

## Hardware Validation
Blocked before serial AutoResearch results: fbuild deploy hangs while writing ESP partitions after the bootloader write succeeds. Tracked upstream as FastLED/fbuild#379.

Closes #2690
Closes #2693

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added queued/non-blocking LCD transmit support for more reliable multi-chunk DMA transfers.

* **Improvements**
  * LCD driver reworked for worker-backed chunk submission and better DMA handling, improving display stability and throughput.
  * AutoResearch builds now use the fbuild path for package resolution (avoids invoking the legacy package helper).
  * Sketch selection supports a staged src/sketch fallback and example filter now selects by board.

* **Tests**
  * New and updated tests cover staged projects, fbuild install behavior, filtering, and LCD chunking fidelity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->