### PR TITLE
Pin fbuild 2.2.16 for ESP32-C2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,8 +17,10 @@ dependencies = [
     # esp32c6 hang reported in fbuild#346 and unblock flipping
     # FASTLED_USE_FBUILD_CI=1 default-on in a follow-up. Also preserves
     # quoted Adafruit nRF52 BSP defines in response files, unblocking
-    # nRF52840 builds under fbuild.
-    "fbuild==2.2.15",
+    # nRF52840 builds under fbuild. Also completes ESP32-C2 framework
+    # skeleton installs and patches the missing touch_sensor_legacy_types.h
+    # no-touch compatibility header (FastLED/fbuild#378).
+    "fbuild==2.2.16",
     "platformio>=6.1.19,<6.2",
     "python-dateutil",
     "ruff",


### PR DESCRIPTION
## Summary
- Pin FastLED CI tooling to `fbuild==2.2.16`.
- This pulls in FastLED/fbuild#378, which completes ESP32-C2 skeleton SDK installs and adds the ESP32-C2 no-touch compatibility header needed by Arduino-ESP32.

Fixes #2637

## Verification
- `uv sync --upgrade-package fbuild`
- Confirmed local venv reports `fbuild==2.2.16`.
- Ran ESP32-C2 Blink through the FastLED compile setup on an isolated fbuild daemon port; the 2.2.16 daemon generated `.build/pio/esp32c2/.fbuild/build/esp32c2/release/firmware.elf` and `firmware.bin`.
- Local note: the wrapper command timed out/noisily in this workstation because another unrelated fbuild daemon was active on the default port, so CI should be the clean signal for the command exit path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated a core dependency to the latest patch release to address minor stability and compatibility issues. No functional changes to features or public APIs; other configuration and dependencies remain unchanged. This is a low-risk maintenance update intended to keep the project secure and stable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->