### PR TITLE
chore(deps): bump fbuild 2.2.16 -> 2.2.17 (refs #2700)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,22 +5,27 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    # Pin to fbuild 2.2.15 — adds Arduino UNO Q / STM32U5 board defaults while
-    # preserving the compile-many stage-2 framework-archive
-    # share (FastLED/fbuild#337) which prevents every stage-2 sketch from
+    # Pin to fbuild 2.2.17 — routes ESP32-S3 native deploys through esptool
+    # (FastLED/fbuild#380), which is one of the user-visible failure modes
+    # tracked in FastLED #2700 (fbuild ESP toolchain resolution). The
+    # remaining end-to-end RISC-V helper toolchain provisioning work is
+    # tracked separately upstream as a follow-up to 2.2.17.
+    # Prior pins preserved for context: 2.2.15 added Arduino UNO Q / STM32U5
+    # board defaults and the compile-many stage-2 framework-archive share
+    # (FastLED/fbuild#337) which prevents every stage-2 sketch from
     # re-building the framework from scratch (the regression that originally
     # forced the FASTLED_USE_FBUILD_CI=1 gate to default-off in #2662). Also
-    # picks up the stage-2 jobs split (#336), the real-toolchain stage-2 perf
-    # regression test (#342), the daemon-side fmt-tracing-to-stderr fix
-    # (#348), the bounded zccache start-up timeout (#349), and project-lock
-    # acquire instrumentation (#350) — together these address the silent
-    # esp32c6 hang reported in fbuild#346 and unblock flipping
+    # picked up the stage-2 jobs split (#336), the real-toolchain stage-2
+    # perf regression test (#342), the daemon-side fmt-tracing-to-stderr
+    # fix (#348), the bounded zccache start-up timeout (#349), and
+    # project-lock acquire instrumentation (#350) — together these address
+    # the silent esp32c6 hang reported in fbuild#346 and unblock flipping
     # FASTLED_USE_FBUILD_CI=1 default-on in a follow-up. Also preserves
     # quoted Adafruit nRF52 BSP defines in response files, unblocking
-    # nRF52840 builds under fbuild. Also completes ESP32-C2 framework
-    # skeleton installs and patches the missing touch_sensor_legacy_types.h
+    # nRF52840 builds under fbuild. 2.2.16 completed ESP32-C2 framework
+    # skeleton installs and patched the missing touch_sensor_legacy_types.h
     # no-touch compatibility header (FastLED/fbuild#378).
-    "fbuild==2.2.16",
+    "fbuild==2.2.17",
     "platformio>=6.1.19,<6.2",
     "python-dateutil",
     "ruff",


### PR DESCRIPTION
## Summary
- Bump `fbuild` from 2.2.16 to 2.2.17 (latest) — pulls in [FastLED/fbuild#380](https://github.com/FastLED/fbuild/pull/380), which routes ESP32-S3 native deploys through esptool. That's one of the user-visible failure modes on the ESP32-S3 fbuild path tracked in #2700.
- File an upstream tracking issue, [FastLED/fbuild#401](https://github.com/FastLED/fbuild/issues/401), for the remaining end-to-end work needed to fully close #2700.

## Scope vs #2700

This PR is **partial progress on #2700, not a full fix**. #2700's acceptance criteria require fbuild to:

1. Succeed on `bash compile esp32s3 --examples AutoResearch` without overrides.
2. Build/deploy via `bash autoresearch esp32s3 --lcd …` end-to-end through fbuild only.
3. Emit a clear actionable error when a required ESP toolchain is missing/incompatible, instead of `stream error: error decoding response body`.
4. Carry regression coverage for the cached pioarduino `platform-espressif32` + RISC-V helper toolchain shape.

(1)–(4) all require fbuild source changes (better diagnostic on the streaming build path, and pioarduino `platform.json` end-to-end package enumeration so secondary toolchains like the ULP RISC-V helper aren't silently dropped). Those changes are tracked in **fbuild#401** with the proposed scope and tests outlined.

This PR just lifts the pin so #380's deploy fix lands here and so a future fbuild release containing the #401 work can ride the same review path.

## Verification
- `uv sync --upgrade-package fbuild` → `fbuild==2.2.17` resolved in `uv.lock`.
- `uv run fbuild --version` → `fbuild 2.2.17`.
- No `.py` source touched; this is a dependency pin bump with a refreshed comment.

## Test plan
- [ ] CI green on the existing fbuild-touching suites (`test_fbuild_compile_many`, `test_fbuild_default_selection`, `test_fbuild_qemu`).
- [ ] Local smoke check for any non-ESP32-S3 board still using fbuild (e.g. ESP32-C6) — no regression.
- [ ] Confirm `bash compile esp32s3 …` still fails the same way as in #2700 — i.e. this PR did not silently change that path; the remaining work is genuinely upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `fbuild` dependency to version 2.2.17

<!-- end of auto-generated comment: release notes by coderabbit.ai -->