### PR TITLE
docs(cpp): enforce Public Settings Pattern for global setters

### DIFF
--- a/.claude/agents/architecture-reviewer-agent.md
+++ b/.claude/agents/architecture-reviewer-agent.md
@@ -20,6 +20,7 @@ Before starting, read `agents/docs/cpp-standards.md` for:
 - Sparse Platform Dispatch Pattern
 - **Three-suffix dispatch convention** — `<component>.impl.cpp.hpp` (router in `src/platforms/`), `<component>_<platform>.impl.hpp` (per-family fragment), `<component>_noop.hpp` (no-op fallback in `src/platforms/shared/`, literal `_noop` suffix only)
 - **Component capability macros** — `FL_<COMPONENT>_HAS_<FEATURE>` / `FL_<COMPONENT>_<NUMERIC>`. Always spell out the component name; no acronym aliases (e.g. `FL_WATCHDOG_*`, **NOT** `FL_WDT_*`).
+- **Public Settings Pattern** — new global configuration setters MUST be exposed on `CFastLED` (`FastLED.setX()`), with a thin `inline` delegator to a `fl::set_x()` free function. Free-function-only global setters are an architectural violation.
 
 ## Platform Dispatch Architectural Checks
 
@@ -97,6 +98,14 @@ Search for these patterns:
 - Changed function signatures
 - Changed enum values
 - Renamed types without aliases
+
+**Public Settings Pattern enforcement** (HIGH severity):
+- For every new public function declaration in `src/fl/**/*.h` whose name matches `^set_|^enable_|^disable_|^use_` and that mutates library-wide / global / namespace-scope state:
+  - Grep `src/FastLED.h` for a `CFastLED` method that delegates to it.
+  - If no wrapper exists, flag as **HIGH severity architectural violation** with this language:
+    > "New global setter `fl::<name>` lacks a `CFastLED::<wrapperName>()` wrapper. The documented user-facing API for library-wide configuration is `FastLED.setX(...)`, not `fl::set_x(...)`. Add an `inline` one-liner on `CFastLED` that delegates to this free function (see exemplar `CFastLED::setPowerModel` in `src/FastLED.h:1455` → `fl::set_power_model`). Rationale: `agents/docs/cpp-standards.md` → 'Public Settings Pattern'."
+- Grandfathered exceptions (do NOT flag for these names alone): `fl::set_rgbw_colorimetric_profile`, `fl::set_input_gamut`.
+- Rule does not apply to: helpers, constructors, factories, per-object configuration, anonymous-namespace / `fl::detail::` internals, functions that only mutate caller-owned objects (e.g. `fl::fill_solid(span, color)`).
 
 ### 4. Check Dependency Direction
 

--- a/.claude/agents/architecture-reviewer-agent.md
+++ b/.claude/agents/architecture-reviewer-agent.md
@@ -104,7 +104,7 @@ Search for these patterns:
   - Grep `src/FastLED.h` for a `CFastLED` method that delegates to it.
   - If no wrapper exists, flag as **HIGH severity architectural violation** with this language:
     > "New global setter `fl::<name>` lacks a `CFastLED::<wrapperName>()` wrapper. The documented user-facing API for library-wide configuration is `FastLED.setX(...)`, not `fl::set_x(...)`. Add an `inline` one-liner on `CFastLED` that delegates to this free function (see exemplar `CFastLED::setPowerModel` in `src/FastLED.h:1455` → `fl::set_power_model`). Rationale: `agents/docs/cpp-standards.md` → 'Public Settings Pattern'."
-- No grandfathered exceptions. Bare `fl::` global setters introduced without a `CFastLED` wrapper — including `fl::set_input_gamut` (#2710) — are HIGH-severity violations and must be wrapped before merge.
+- Strict for new code. A small transitional allowlist (`GRANDFATHERED_NAMES` in `ci/lint_cpp/public_settings_pattern_checker.py`) exempts a handful of legacy bare setters (`fl::set_input_gamut` #2710, `fl::enable_rgbw_colorimetric_lut`, `fl::set_rgbww_colorimetric_profile`) until their wrappers land. Entries are removed as each name is wrapped; new additions do NOT get grandfathered.
 - Rule does not apply to: helpers, constructors, factories, per-object configuration, anonymous-namespace / `fl::detail::` internals, functions that only mutate caller-owned objects (e.g. `fl::fill_solid(span, color)`).
 
 ### 4. Check Dependency Direction

--- a/.claude/agents/architecture-reviewer-agent.md
+++ b/.claude/agents/architecture-reviewer-agent.md
@@ -104,7 +104,7 @@ Search for these patterns:
   - Grep `src/FastLED.h` for a `CFastLED` method that delegates to it.
   - If no wrapper exists, flag as **HIGH severity architectural violation** with this language:
     > "New global setter `fl::<name>` lacks a `CFastLED::<wrapperName>()` wrapper. The documented user-facing API for library-wide configuration is `FastLED.setX(...)`, not `fl::set_x(...)`. Add an `inline` one-liner on `CFastLED` that delegates to this free function (see exemplar `CFastLED::setPowerModel` in `src/FastLED.h:1455` → `fl::set_power_model`). Rationale: `agents/docs/cpp-standards.md` → 'Public Settings Pattern'."
-- Grandfathered exceptions (do NOT flag for these names alone): `fl::set_rgbw_colorimetric_profile`, `fl::set_input_gamut`.
+- No grandfathered exceptions. Bare `fl::` global setters introduced without a `CFastLED` wrapper — including `fl::set_input_gamut` (#2710) — are HIGH-severity violations and must be wrapped before merge.
 - Rule does not apply to: helpers, constructors, factories, per-object configuration, anonymous-namespace / `fl::detail::` internals, functions that only mutate caller-owned objects (e.g. `fl::fill_solid(span, color)`).
 
 ### 4. Check Dependency Direction

--- a/.claude/commands/code_review.md
+++ b/.claude/commands/code_review.md
@@ -291,6 +291,56 @@ void validateHardware() {
 - For new files: Fix immediately by asking user to rename
 - For existing files: Create GitHub issue or ask user if they want to rename now
 
+### src/** changes - PUBLIC SETTINGS PATTERN (god-instance enforcement)
+
+**Core Principle**: New global / library-wide configuration setters MUST be exposed on `CFastLED` (`FastLED.setX(...)`), not as bare `fl::set_*` free functions. The free function may exist for ADL/testability, but the documented entry point is the god instance.
+
+**Exemplar** (`src/FastLED.h:1455`):
+```cpp
+inline void setPowerModel(const PowerModelRGB& model) {
+    set_power_model(model);  // delegates to fl::set_power_model
+}
+```
+
+**Rules**:
+1. ❌ **NEVER add a new public `fl::set_*` / `fl::enable_*` / `fl::disable_*` / `fl::use_*` free function that mutates library-wide state without a matching `CFastLED::setX()` wrapper.**
+   - ❌ Bad (PR diff adds only):
+     ```cpp
+     // src/fl/gfx/rgbw.h
+     namespace fl { void set_input_gamut(DiodeProfile*, InputGamut) noexcept; }
+     ```
+   - ✅ Good (PR diff adds BOTH):
+     ```cpp
+     // src/fl/gfx/rgbw.h
+     namespace fl { void set_input_gamut(DiodeProfile*, InputGamut) noexcept; }
+     // src/FastLED.h, near setPowerModel
+     inline void setInputGamut(fl::DiodeProfile* p, fl::InputGamut g) FL_NOEXCEPT {
+         fl::set_input_gamut(p, g);
+     }
+     ```
+2. ✅ **The wrapper is a thin `inline` delegator** — no logic, validation, or error handling embedded.
+3. ✅ **Examples, README, and PR descriptions** should call `FastLED.setX(...)`, never `fl::set_x(...)`.
+
+**Grandfathered Exceptions** (predate the rule — do not flag for these names alone):
+- `fl::set_rgbw_colorimetric_profile`
+- `fl::set_input_gamut` (#2710)
+
+These should be wrapped opportunistically, but their bare existence does not block the PR they appear in.
+
+**Does NOT apply to**:
+- Helpers, constructors, factories (not "setters of global state")
+- Per-object / per-strip configuration on the object's own API
+- Functions that only mutate caller-owned objects (`fl::fill_solid(span, color)`)
+- `fl::detail::` / anonymous-namespace internals
+
+**Check Process**:
+1. Scan the diff for new public function declarations in `src/fl/**/*.h` whose name matches `^set_|^enable_|^disable_|^use_`.
+2. For each match, check whether the function mutates a namespace-scope / static / global variable (look at the implementation in the matching `.cpp.hpp`).
+3. If yes and the name isn't grandfathered: grep `src/FastLED.h` for a `CFastLED` method whose body mentions that free function. If none, **flag as HIGH severity** and either:
+   - Add the wrapper inline in the same diff (if the change is small), or
+   - Ask the user to add it before merge.
+4. Reference: `agents/docs/cpp-standards.md` → "Public Settings Pattern".
+
 ### src/** changes - SIGNED INTEGER OVERFLOW (UNDEFINED BEHAVIOR)
 
 **Core Principle**: Signed integer arithmetic that can overflow is undefined behavior in C++. Compilers exploit this for optimization, causing silent miscompilation. All potentially-overflowing arithmetic on signed types (`i8`, `i16`, `i32`) must be performed in the corresponding unsigned type, then cast back.
@@ -701,6 +751,7 @@ FL_TEST_CASE("my test") {
   - Unused variables after refactoring: N
   - Missing performance attributes: N
   - DMA/poll wait loops missing yield: N
+  - Public Settings Pattern violations (bare fl::set_* without CFastLED wrapper): N
   - Other: N
 - Violations fixed: N
 - User confirmations needed: N

--- a/.claude/commands/code_review.md
+++ b/.claude/commands/code_review.md
@@ -321,11 +321,7 @@ inline void setPowerModel(const PowerModelRGB& model) {
 2. ✅ **The wrapper is a thin `inline` delegator** — no logic, validation, or error handling embedded.
 3. ✅ **Examples, README, and PR descriptions** should call `FastLED.setX(...)`, never `fl::set_x(...)`.
 
-**Grandfathered Exceptions** (predate the rule — do not flag for these names alone):
-- `fl::set_rgbw_colorimetric_profile`
-- `fl::set_input_gamut` (#2710)
-
-These should be wrapped opportunistically, but their bare existence does not block the PR they appear in.
+**No Grandfathered Exceptions.** Every public global setter under `fl::` must ship with a `CFastLED` wrapper in the same PR. Bare functions added without one — including `fl::set_input_gamut` (#2710) — block the PR.
 
 **Does NOT apply to**:
 - Helpers, constructors, factories (not "setters of global state")
@@ -336,7 +332,7 @@ These should be wrapped opportunistically, but their bare existence does not blo
 **Check Process**:
 1. Scan the diff for new public function declarations in `src/fl/**/*.h` whose name matches `^set_|^enable_|^disable_|^use_`.
 2. For each match, check whether the function mutates a namespace-scope / static / global variable (look at the implementation in the matching `.cpp.hpp`).
-3. If yes and the name isn't grandfathered: grep `src/FastLED.h` for a `CFastLED` method whose body mentions that free function. If none, **flag as HIGH severity** and either:
+3. If yes: grep `src/FastLED.h` for a `CFastLED` method whose body mentions that free function. If none, **flag as HIGH severity** and either:
    - Add the wrapper inline in the same diff (if the change is small), or
    - Ask the user to add it before merge.
 4. Reference: `agents/docs/cpp-standards.md` → "Public Settings Pattern".

--- a/.claude/commands/code_review.md
+++ b/.claude/commands/code_review.md
@@ -321,7 +321,7 @@ inline void setPowerModel(const PowerModelRGB& model) {
 2. ✅ **The wrapper is a thin `inline` delegator** — no logic, validation, or error handling embedded.
 3. ✅ **Examples, README, and PR descriptions** should call `FastLED.setX(...)`, never `fl::set_x(...)`.
 
-**No Grandfathered Exceptions.** Every public global setter under `fl::` must ship with a `CFastLED` wrapper in the same PR. Bare functions added without one — including `fl::set_input_gamut` (#2710) — block the PR.
+**Strict for new code; transitional allowlist for legacy names only.** Every *new* public global setter under `fl::` must ship with a `CFastLED` wrapper in the same PR. A small transitional allowlist (`GRANDFATHERED_NAMES` in `ci/lint_cpp/public_settings_pattern_checker.py`) exempts pre-existing bare setters (e.g. `fl::set_input_gamut` #2710) until their wrappers land. Entries are removed as each name is wrapped; new additions block the PR.
 
 **Does NOT apply to**:
 - Helpers, constructors, factories (not "setters of global state")

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -2,6 +2,9 @@ reviews:
   request_changes_workflow: true
   pre_merge_checks:
     enabled: true
+
+  # Per-path natural-language review instructions.
+  # See https://docs.coderabbit.ai/getting-started/configure-coderabbit
   path_instructions:
     - path: "src/platforms/*.impl.cpp.hpp"
       instructions: |
@@ -49,3 +52,56 @@ reviews:
         statics with non-trivial constructors (Teensy 3.x `__cxa_guard` conflict), or
         the `.cpp.hpp` / `.impl.hpp` content patterns. If function definitions are
         needed, they belong in `.cpp.hpp` or `.impl.hpp` files.
+    - path: "src/fl/**/*.h"
+      instructions: |
+        FastLED Public Settings Pattern (see agents/docs/cpp-standards.md):
+
+        Any NEW public free function in the fl:: namespace whose name matches
+        `^set_|^enable_|^disable_|^use_` AND that mutates library-wide /
+        global / namespace-scope state MUST also be exposed as a method on
+        the `CFastLED` god instance in `src/FastLED.h`.
+
+        The CFastLED method is a thin `inline` one-liner that delegates to
+        the fl:: free function — that is the canonical pattern. Exemplar:
+        `CFastLED::setPowerModel` (FastLED.h:1455) → `fl::set_power_model`.
+
+        Flag as HIGH severity when a PR adds a `fl::set_*` / `fl::enable_*` /
+        `fl::disable_*` / `fl::use_*` public declaration WITHOUT a matching
+        `CFastLED::setX()` wrapper in `src/FastLED.h`. The fix is to add the
+        wrapper in the same PR; the user-facing documented call site should
+        be `FastLED.setX(...)`, never `fl::set_x(...)`.
+
+        Grandfathered exceptions (do NOT flag for these names alone):
+          - fl::set_rgbw_colorimetric_profile
+          - fl::set_input_gamut (issue #2710)
+        These are tracked for backfill; new additions do not get grandfathered.
+
+        Does NOT apply to: helpers, constructors, factories, functions that
+        only mutate caller-owned objects (e.g. fl::fill_solid(span, color)),
+        per-object/per-strip configuration on the object's own API, or
+        anything under fl::detail:: / anonymous namespaces.
+
+    - path: "src/FastLED.h"
+      instructions: |
+        FastLED Public Settings Pattern (see agents/docs/cpp-standards.md):
+
+        New `CFastLED` methods that configure library-wide state SHOULD be
+        thin `inline` delegators to a free function in `fl::` namespace
+        (testability + ADL), not embed configuration logic inline.
+
+        Exemplar pattern (FastLED.h:1455):
+          inline void setPowerModel(const PowerModelRGB& m) {
+              set_power_model(m);
+          }
+
+        Flag CFastLED setters that embed non-trivial logic instead of
+        delegating to a fl:: free function.
+
+    - path: "src/fl/gfx/**"
+      instructions: |
+        Color / colorimetric profile setters that affect default behavior
+        for all strips (e.g. set_rgbw_colorimetric_profile, set_input_gamut)
+        MUST be wrapped on CFastLED per the Public Settings Pattern. If
+        adding such a function, also add the `FastLED.setX(...)` wrapper in
+        `src/FastLED.h` and document the god-instance form in the PR
+        description / examples.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -71,10 +71,10 @@ reviews:
         wrapper in the same PR; the user-facing documented call site should
         be `FastLED.setX(...)`, never `fl::set_x(...)`.
 
-        Grandfathered exceptions (do NOT flag for these names alone):
-          - fl::set_rgbw_colorimetric_profile
-          - fl::set_input_gamut (issue #2710)
-        These are tracked for backfill; new additions do not get grandfathered.
+        No grandfathered exceptions: every public global setter under
+        `fl::` must have a `CFastLED` wrapper. Functions added without one
+        — including bare `fl::set_input_gamut` (#2710) and any future
+        additions — must be wrapped in the same PR.
 
         Does NOT apply to: helpers, constructors, factories, functions that
         only mutate caller-owned objects (e.g. fl::fill_solid(span, color)),

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,7 @@
 |------|------|
 | Writing/editing C++ code | `agents/docs/cpp-standards.md` |
 | Creating an API wrapper type | `agents/docs/cpp-standards.md` → "API Object Pattern" |
+| Adding a global setting / configuration knob | `agents/docs/cpp-standards.md` → "Public Settings Pattern" (new setters go on `CFastLED`, not as bare `fl::set_*` free functions) |
 | Writing/editing Python code | `agents/docs/python-standards.md` |
 | Editing meson.build files | `agents/docs/build-system.md` |
 | Running tests, Docker, WASM, QEMU | `agents/docs/testing-commands.md` |
@@ -83,6 +84,7 @@ See `agents/docs/build-system.md` for full command execution rules and forbidden
 
 ### Code Standards
 - **C++**: See `agents/docs/cpp-standards.md` (span convention, DMA patterns, naming, macros)
+- **C++ public settings**: New global setters MUST go on `CFastLED` (`FastLED.setX()`), not as bare `fl::set_*` free functions — see `agents/docs/cpp-standards.md` → "Public Settings Pattern"
 - **JavaScript**: Run `bash lint --js` after modifying JS files
 
 ### Code Review Rule

--- a/agents/docs/cpp-standards.md
+++ b/agents/docs/cpp-standards.md
@@ -259,12 +259,12 @@ class CFastLED {
 2. ✅ **The wrapper is a `inline` one-liner that delegates** — no logic, no validation, no error handling. The free function holds all behavior.
 3. ✅ **Per-object configuration (e.g. one strip's diode profile, one controller's correction) MAY live on the per-object API.** This rule targets *library-wide / process-wide / default-profile* state.
 4. ✅ **Documentation, examples, and PR descriptions reference the god-instance form.** The free function is an implementation detail.
-5. ⚠️ **Grandfathered offenders** (free-function-only, predate this rule): `fl::set_rgbw_colorimetric_profile`, `fl::set_input_gamut` (#2710). New code MUST wrap; existing offenders should be wrapped opportunistically.
+5. ⚠️ **No grandfathered offenders.** Every public global setter under `fl::` must ship with a `CFastLED` wrapper. Bare functions added without one — including `fl::set_input_gamut` (#2710) — must be wrapped before merge.
 
 **Check Process**:
 1. For every new public function in `src/fl/**/*.h` whose name matches `^set_|^enable_|^disable_|^use_` and that mutates a static / global / namespace-scope variable, grep `src/FastLED.h` for a `CFastLED` method that delegates to it.
 2. If none exists: violation — add the wrapper in the same PR.
-3. Enforced by `ci/lint_cpp/` (rule TBD) with the grandfathered names allowlisted.
+3. Enforced by `ci/lint_cpp/` (rule TBD). No allowlist — every match must wrap.
 
 **Where the rule does NOT apply**:
 - Helpers, constructors, factory functions — these are not setters of global state.

--- a/agents/docs/cpp-standards.md
+++ b/agents/docs/cpp-standards.md
@@ -259,12 +259,12 @@ class CFastLED {
 2. ✅ **The wrapper is a `inline` one-liner that delegates** — no logic, no validation, no error handling. The free function holds all behavior.
 3. ✅ **Per-object configuration (e.g. one strip's diode profile, one controller's correction) MAY live on the per-object API.** This rule targets *library-wide / process-wide / default-profile* state.
 4. ✅ **Documentation, examples, and PR descriptions reference the god-instance form.** The free function is an implementation detail.
-5. ⚠️ **No grandfathered offenders.** Every public global setter under `fl::` must ship with a `CFastLED` wrapper. Bare functions added without one — including `fl::set_input_gamut` (#2710) — must be wrapped before merge.
+5. ⚠️ **Strict for new code; transitional allowlist for legacy names only.** Every *new* public global setter under `fl::` must ship with a `CFastLED` wrapper. A small transitional allowlist (`GRANDFATHERED_NAMES` in `ci/lint_cpp/public_settings_pattern_checker.py`) exempts pre-existing bare setters (e.g. `fl::set_input_gamut` #2710, `fl::enable_rgbw_colorimetric_lut`, `fl::set_rgbww_colorimetric_profile`) until their wrappers land. Entries are removed as each name is wrapped — the goal is an empty allowlist. New additions do NOT get grandfathered.
 
 **Check Process**:
 1. For every new public function in `src/fl/**/*.h` whose name matches `^set_|^enable_|^disable_|^use_` and that mutates a static / global / namespace-scope variable, grep `src/FastLED.h` for a `CFastLED` method that delegates to it.
 2. If none exists: violation — add the wrapper in the same PR.
-3. Enforced by `ci/lint_cpp/` (rule TBD). No allowlist — every match must wrap.
+3. Enforced by `ci/lint_cpp/public_settings_pattern_checker.py`. The checker carries a shrinking `GRANDFATHERED_NAMES` allowlist for legacy bare setters; remove a name from the list once its `CFastLED` wrapper is merged.
 
 **Where the rule does NOT apply**:
 - Helpers, constructors, factory functions — these are not setters of global state.

--- a/agents/docs/cpp-standards.md
+++ b/agents/docs/cpp-standards.md
@@ -233,6 +233,44 @@ For a subsystem (e.g., `Watchdog`, `Audio`, `Codec`) that has multi-tier platfor
   - The 'm' prefix clearly distinguishes member variables from local variables and parameters
 - **Follow existing code patterns** and naming conventions
 
+## Public Settings Pattern (Global Configuration via `CFastLED`)
+
+**Core Principle**: Any new global / library-wide configuration setter MUST be exposed as a public method on the `CFastLED` god instance in `src/FastLED.h`. The implementation may live as a free function in the `fl::` namespace for ADL / testability, but the documented user-facing entry point is `FastLED.setX(...)`, not `fl::set_x(...)`.
+
+**Rationale**: `CFastLED` is the discoverable surface — users see `FastLED.setBrightness()`, `FastLED.setMaxRefreshRate()`, `FastLED.setPowerModel()` in every sketch and expect every other knob to live there too. Free-function-only configuration ratchets the API surface into a second, undocumented place that users won't find and that drifts out of sync with the god instance.
+
+**Exemplar** (`src/FastLED.h:1455`):
+```cpp
+// Free function in fl:: namespace — does the work, testable in isolation
+namespace fl { void set_power_model(const PowerModelRGB& m) noexcept; }
+
+// Public entry point on CFastLED — thin delegator, this is what users call
+class CFastLED {
+    inline void setPowerModel(const PowerModelRGB& model) {
+        set_power_model(model);
+    }
+};
+```
+
+**Rules**:
+1. ❌ **NEVER ship a new `fl::set_*` / `fl::enable_*` / `fl::disable_*` / `fl::use_*` free function that mutates library-wide state without a matching `CFastLED::setX()` / `enableX()` wrapper.**
+   - ❌ Bad: `fl::set_input_gamut(&profile, fl::InputGamut::Rec709);` as the documented call site
+   - ✅ Good: `FastLED.setInputGamut(&profile, fl::InputGamut::Rec709);` (god instance), with a `fl::set_input_gamut(...)` free function backing it
+2. ✅ **The wrapper is a `inline` one-liner that delegates** — no logic, no validation, no error handling. The free function holds all behavior.
+3. ✅ **Per-object configuration (e.g. one strip's diode profile, one controller's correction) MAY live on the per-object API.** This rule targets *library-wide / process-wide / default-profile* state.
+4. ✅ **Documentation, examples, and PR descriptions reference the god-instance form.** The free function is an implementation detail.
+5. ⚠️ **Grandfathered offenders** (free-function-only, predate this rule): `fl::set_rgbw_colorimetric_profile`, `fl::set_input_gamut` (#2710). New code MUST wrap; existing offenders should be wrapped opportunistically.
+
+**Check Process**:
+1. For every new public function in `src/fl/**/*.h` whose name matches `^set_|^enable_|^disable_|^use_` and that mutates a static / global / namespace-scope variable, grep `src/FastLED.h` for a `CFastLED` method that delegates to it.
+2. If none exists: violation — add the wrapper in the same PR.
+3. Enforced by `ci/lint_cpp/` (rule TBD) with the grandfathered names allowlisted.
+
+**Where the rule does NOT apply**:
+- Helpers, constructors, factory functions — these are not setters of global state.
+- Functions in `fl::` that operate on caller-owned objects without touching global state (`fl::fill_solid(span, color)`).
+- Internal `fl::detail::` / anonymous-namespace functions — not public API.
+
 ## Singleton-Stored Configuration: Own by Value, Never by Borrowed Pointer
 
 **Core Principle**: Any public `fl::set_*` API that stores a configuration profile / settings object in process-wide (or static / namespace-scope) state MUST **store by value** (copy / move) and never retain a caller-owned pointer. The parameter SHOULD be `const T&` (or `T&&`); a `const T*` parameter is permitted **only** as a signal for nullable-reset (`nullptr` means "revert to default") and only if the implementation copies the pointed-to value into a value-typed slot on non-null and clears that slot on null. Storing the raw pointer (`sActive = profile`) is always a deterministic use-after-scope bug when callers pass a stack temporary like `auto p = make_profile(); fl::set_x(&p); /* p goes out of scope */`.

--- a/ci/lint_cpp/public_settings_pattern_checker.py
+++ b/ci/lint_cpp/public_settings_pattern_checker.py
@@ -1,0 +1,455 @@
+#!/usr/bin/env python3
+# pyright: reportUnknownMemberType=false
+"""Checker to enforce the Public Settings Pattern for global configuration setters.
+
+Every new public free function in `src/fl/**/*.h` whose name matches the regex
+`^(set|enable|disable|use)_[a-z]` and that is declared at namespace scope
+(inside `namespace fl {` at depth 1 — NOT inside a class, NOT in an anonymous
+namespace, NOT in `fl::detail::` or any sub-namespace) MUST have a matching
+`CFastLED::setX()` / `enableX()` / `disableX()` wrapper in `src/FastLED.h`
+that delegates to it.
+
+Why: `CFastLED` (the `FastLED` god instance) is the documented, discoverable
+user API surface. Free-function-only global setters ratchet configuration knobs
+into an undocumented second location that users won't find and that drifts out
+of sync with the god instance.
+
+Exemplar (`src/FastLED.h:1455`):
+    // Free function — does the work
+    namespace fl { void set_power_model(const PowerModelRGB& m) noexcept; }
+
+    // CFastLED wrapper — what users call
+    class CFastLED {
+        inline void setPowerModel(const PowerModelRGB& model) {
+            set_power_model(model);
+        }
+    };
+
+Carve-outs (NOT flagged):
+  - Functions in `fl::detail::`, `fl::isr::`, or any sub-namespace (depth > 1).
+  - Functions inside anonymous `namespace { }` blocks.
+  - Functions inside class/struct bodies (per-object setters, not global state).
+  - Function pointer setters where the first parameter is a function-pointer type
+    (e.g. `set_rgb_2_rgbw_function(func)`).
+  - Per-object mutators: first parameter is a non-const pointer/reference to a
+    user-defined (non-fundamental) type — heuristic for per-object config.
+  - Lines in `// comments` or `/* ... */` blocks.
+  - Lines with suppression `// nolint` or `// ok public_settings`.
+
+Allowlist (grandfathered pre-rule offenders — do NOT flag):
+  - `set_rgbw_colorimetric_profile`  (wrapped in PR #2715; allowlist is
+    defence-in-depth for when the wrapper grep heuristic might miss it)
+  - `set_input_gamut`                (allowlisted until a wrapper is shipped)
+
+Scope: `src/fl/**/*.h` only (NOT third_party, NOT detail subdirs).
+"""
+
+import re
+
+from ci.util.check_files import FileContent, FileContentChecker
+from ci.util.paths import PROJECT_ROOT
+
+
+# ---------------------------------------------------------------------------
+# Grandfathered allowlist — names that predate the rule.
+# These are NOT flagged regardless of wrapper presence.
+# Remove an entry only after its CFastLED wrapper is merged and the grep
+# heuristic has been verified to catch it cleanly.
+# ---------------------------------------------------------------------------
+GRANDFATHERED_NAMES: frozenset[str] = frozenset(
+    [
+        "set_rgbw_colorimetric_profile",  # Wrapped in PR #2715
+        "set_input_gamut",  # Grandfathered; wrapper planned
+        # Added in #2545 (colorimetric RGBW LUT). Wrappers planned.
+        "enable_rgbw_colorimetric_lut",
+        "disable_rgbw_colorimetric_lut",
+        # Added in #2558 (RGBWW pipeline). Wrapper planned.
+        "set_rgbww_colorimetric_profile",
+    ]
+)
+
+# ---------------------------------------------------------------------------
+# Additional carve-outs: function-pointer installer pattern.
+# These names set a *callback*, not a global scalar/object.  The syntactic
+# heuristic (first-param-is-non-fundamental) doesn't catch function pointers
+# cleanly, so we name them explicitly.  Revisit if real violations slip through.
+# ---------------------------------------------------------------------------
+FUNCTION_POINTER_SETTERS: frozenset[str] = frozenset(
+    [
+        "set_rgb_2_rgbw_function",
+        "set_rgb_2_rgbww_function",
+    ]
+)
+
+# ---------------------------------------------------------------------------
+# Pre-compiled regexes
+# ---------------------------------------------------------------------------
+
+# Declaration-like line: starts with a return type word, then a name that
+# matches the pattern.  We require the function name to start the
+# `(set|enable|disable|use)_[a-z]` pattern.
+_SETTER_DECL = re.compile(
+    r"^"
+    r"(?:(?:inline|static|virtual|explicit|constexpr|FL_NOEXCEPT|FASTLED_FORCE_INLINE)\s+)*"  # optional qualifiers
+    r"(?:[\w:]+(?:<[^>]*>)?(?:\s*[*&])?\s+)+"  # return type (e.g. "void ", "bool ", "int ")
+    r"(?P<name>(set|enable|disable|use)_[a-z][a-zA-Z0-9_]*)"  # the setter name
+    r"\s*\("  # open paren
+)
+
+# Matches "namespace <name>" — named namespace opening
+_NAMED_NS = re.compile(r"^\s*namespace\s+(\w+)\s*\{")
+
+# Matches anonymous namespace "namespace {" (no name)
+_ANON_NS = re.compile(r"^\s*namespace\s*\{")
+
+# Suppression on the same line
+_SUPPRESSION = re.compile(r"//\s*(nolint|ok\s+public_settings)\b", re.IGNORECASE)
+
+# Fundamental C++ types — used to distinguish per-object vs global setters.
+# If the FIRST parameter starts with one of these, it's a scalar/global setter
+# candidate.  If it's a user-defined type pointer/ref, it's per-object.
+_FUNDAMENTAL_TYPES = frozenset(
+    [
+        "bool",
+        "char",
+        "short",
+        "int",
+        "long",
+        "float",
+        "double",
+        "void",
+        "unsigned",
+        "signed",
+        "u8",
+        "u16",
+        "u32",
+        "u64",
+        "s8",
+        "s16",
+        "s32",
+        "s64",
+        "uint8_t",
+        "uint16_t",
+        "uint32_t",
+        "uint64_t",
+        "int8_t",
+        "int16_t",
+        "int32_t",
+        "int64_t",
+        "size_t",
+        "ssize_t",
+        "ptrdiff_t",
+    ]
+)
+
+# Matches first parameter extraction from a declaration line.
+# Captures: full param list inside parens (simplified — single-line only).
+_PARAM_LIST = re.compile(r"\(([^)]*)\)")
+
+
+def _load_fastled_h() -> str:
+    """Load the content of src/FastLED.h for cross-file wrapper checks."""
+    fastled_h = PROJECT_ROOT / "src" / "FastLED.h"
+    try:
+        return fastled_h.read_text(encoding="utf-8")
+    except OSError:
+        return ""
+
+
+def _is_wrapped_in_fastled_h(func_name: str, fastled_h_content: str) -> bool:
+    """Return True if *func_name* appears inside the body of a CFastLED method
+    in FastLED.h.
+
+    Heuristic: we search for any non-comment, non-include line in FastLED.h
+    that contains the function name as a bare word (not the #include line).
+    This is intentionally permissive — false negatives (missing wrappers) are
+    what we want to catch; false positives (spurious "found") are benign.
+    """
+    if not fastled_h_content:
+        return False
+
+    pattern = re.compile(r"\b" + re.escape(func_name) + r"\b")
+    for line in fastled_h_content.splitlines():
+        stripped = line.strip()
+        # Skip the include line that brings in the header defining this function
+        if stripped.startswith("#include"):
+            continue
+        # Skip comment-only lines
+        if stripped.startswith("//") or stripped.startswith("*"):
+            continue
+        if pattern.search(line):
+            return True
+    return False
+
+
+def _is_per_object_setter(decl_line: str) -> bool:
+    """Return True if the declaration looks like a per-object mutator.
+
+    Heuristic: if the first parameter is a non-const pointer (*) or non-const
+    reference (&) to a non-fundamental type (i.e. a struct/class), the function
+    is likely mutating an object the caller owns, not global state.
+
+    Examples that return True (per-object — skip):
+        void set_input_gamut(DiodeProfile* obj, InputGamut g)
+        void set_color(CRGB& out, uint8_t r, uint8_t g, uint8_t b)
+
+    Examples that return False (global state — flag):
+        void set_power_model(const PowerModelRGB& model)
+        void enable_rgbw_colorimetric_lut(int grid_n)
+    """
+    m = _PARAM_LIST.search(decl_line)
+    if not m:
+        return False
+    params_raw = m.group(1).strip()
+    if not params_raw:
+        return False  # no params → global setter (e.g. disable_foo())
+
+    # Split off the first parameter (stop at first comma that is not inside <>)
+    depth = 0
+    first_param: list[str] = []
+    for ch in params_raw:
+        if ch == "<":
+            depth += 1
+        elif ch == ">":
+            depth -= 1
+        elif ch == "," and depth == 0:
+            break
+        first_param.append(ch)
+    first_param_str = "".join(first_param).strip()
+
+    # Check for a non-const pointer or reference to user-defined type.
+    # Pattern: optional "const", type tokens, then * or &, then optional name.
+    # If "const" appears before the *, it is read-only — treat as global.
+    # Function pointer parameters look like: `ret_type (*name)(args)` — skip too.
+    if "(*" in first_param_str:
+        return False  # function pointer — handled by FUNCTION_POINTER_SETTERS
+
+    has_non_const_ptr_or_ref = False
+    stripped_fp = first_param_str
+
+    # Remove trailing parameter name (last word token)
+    tokens = stripped_fp.split()
+    # Check if last token is likely a name (no *, &, :, <)
+    if tokens and re.match(r"^[a-zA-Z_]\w*$", tokens[-1]):
+        tokens = tokens[:-1]
+    param_type_str = " ".join(tokens)
+
+    # If "const" is in the type tokens *before* the * or &, it is read-only
+    is_const = "const" in param_type_str
+    has_ptr_or_ref = "*" in param_type_str or "&" in param_type_str
+
+    if has_ptr_or_ref and not is_const:
+        # Check if the base type is fundamental
+        # Strip *, &, and const to get the base type word
+        base = re.sub(r"[*&\s]", " ", param_type_str)
+        base = base.replace("const", "").strip()
+        base_tokens = base.split()
+        if base_tokens:
+            base_type = base_tokens[0].lstrip(":").split("::")[-1]
+            if base_type not in _FUNDAMENTAL_TYPES:
+                has_non_const_ptr_or_ref = True
+
+    return has_non_const_ptr_or_ref
+
+
+class PublicSettingsPatternChecker(FileContentChecker):
+    """Checker that flags fl::set_*/enable_*/disable_*/use_* free functions
+    declared at namespace scope in src/fl/**/*.h without a CFastLED wrapper
+    in src/FastLED.h.
+    """
+
+    def __init__(self) -> None:
+        self.violations: dict[str, list[tuple[int, str]]] = {}
+        # Load FastLED.h content once at construction time.
+        self._fastled_h_content: str = _load_fastled_h()
+
+    def should_process_file(self, file_path: str) -> bool:
+        normalized = file_path.replace("\\", "/")
+
+        # Only header files
+        if not normalized.endswith(".h"):
+            return False
+
+        # Only inside src/fl/ (absolute or relative paths)
+        if "/src/fl/" not in normalized and not normalized.startswith("src/fl/"):
+            return False
+
+        # Exclude third_party
+        if "/third_party/" in normalized:
+            return False
+
+        # Exclude .cpp.hpp pseudo-headers (they're implementation files)
+        if normalized.endswith(".cpp.hpp"):
+            return False
+
+        return True
+
+    def check_file_content(self, file_content: FileContent) -> list[str]:
+        """Scan a src/fl/ header for unwrapped global setter declarations."""
+        # Fast skip: if none of the trigger prefixes appear, bail immediately
+        content = file_content.content
+        if not any(kw in content for kw in ("set_", "enable_", "disable_", "use_")):
+            return []
+
+        violations: list[tuple[int, str]] = []
+        in_multiline_comment = False
+
+        # Scope stack: each entry is a string describing the scope kind:
+        #   "fl"        — inside `namespace fl { ` (the target scope)
+        #   "ns_sub"    — inside a named sub-namespace (fl::detail, fl::isr, …)
+        #   "ns_anon"   — inside anonymous `namespace { `
+        #   "class"     — inside a class/struct body
+        #   "other"     — any other brace block (enum, function body, if, …)
+        #
+        # We push ONE entry per `{` and pop ONE per `}`.  This correctly
+        # handles enums, inline functions, conditionals, etc.
+        scope_stack: list[str] = []
+
+        def _classify_open(code_line: str) -> str:
+            """Classify what kind of scope a `{`-bearing line opens."""
+            # Named namespace?
+            ns_m = _NAMED_NS.match(code_line)
+            if ns_m:
+                name = ns_m.group(1)
+                # Is the immediately enclosing scope "fl"?
+                if scope_stack == ["fl"] or scope_stack == []:
+                    # Top-level: "fl" itself or a first-level sub-namespace
+                    if name == "fl":
+                        return "fl"
+                    # Anything else at top level is a non-fl namespace
+                    return "ns_sub"
+                else:
+                    # Nested under something — always a sub-namespace
+                    return "ns_sub"
+            # Anonymous namespace?
+            if _ANON_NS.match(code_line):
+                return "ns_anon"
+            # class/struct (not a forward declaration)?
+            if re.search(r"\b(class|struct)\b", code_line):
+                if not re.search(r"\b(class|struct)\b\s+\w+\s*;", code_line):
+                    return "class"
+            # Everything else (enum body, function body, if block, …)
+            return "other"
+
+        for line_number, line in enumerate(file_content.lines, 1):
+            stripped = line.strip()
+
+            # ---- multi-line comment tracking ----
+            if "/*" in line:
+                in_multiline_comment = True
+            if "*/" in line:
+                in_multiline_comment = False
+                continue
+            if in_multiline_comment:
+                continue
+
+            # Skip single-line comment lines
+            if stripped.startswith("//"):
+                continue
+
+            # Strip inline comment for code analysis
+            code = line.split("//")[0]
+
+            opens = code.count("{")
+            closes = code.count("}")
+
+            # Push one scope entry per opening brace.
+            # When multiple braces appear on one line (rare but valid, e.g.
+            # `namespace fl { namespace detail {`), classify only the first
+            # opening brace against the line and treat any extras as "other".
+            if opens > 0:
+                first_kind = _classify_open(code.strip())
+                scope_stack.append(first_kind)
+                for _ in range(opens - 1):
+                    scope_stack.append("other")
+
+            # Pop one scope entry per closing brace.
+            for _ in range(closes):
+                if scope_stack:
+                    scope_stack.pop()
+
+            # ---- check if we're at fl:: root scope (after brace updates) ----
+            # The ONLY valid scope stack for a free function in `namespace fl`
+            # is exactly `["fl"]`.  Any deeper nesting (class, sub-namespace,
+            # anonymous namespace, enum body) disqualifies the line.
+            if scope_stack != ["fl"]:
+                continue
+
+            # Skip preprocessor directives
+            if stripped.startswith("#"):
+                continue
+
+            # ---- check for a setter declaration ----
+            code_stripped = code.strip()
+            if not code_stripped:
+                continue
+
+            # Fast pre-check before regex
+            has_trigger = any(
+                kw in code_stripped for kw in ("set_", "enable_", "disable_", "use_")
+            )
+            if not has_trigger:
+                continue
+
+            m = _SETTER_DECL.match(code_stripped)
+            if not m:
+                continue
+
+            func_name = m.group("name")
+
+            # Suppression comment on same line
+            if _SUPPRESSION.search(line):
+                continue
+
+            # Allowlist: grandfathered offenders
+            if func_name in GRANDFATHERED_NAMES:
+                continue
+
+            # Carve-out: function-pointer installers
+            if func_name in FUNCTION_POINTER_SETTERS:
+                continue
+
+            # Carve-out: per-object setters (non-const ptr/ref first param)
+            if _is_per_object_setter(code_stripped):
+                continue
+
+            # Cross-file check: is this function name used inside FastLED.h?
+            if _is_wrapped_in_fastled_h(func_name, self._fastled_h_content):
+                continue
+
+            # Convert snake_case to camelCase for the suggested wrapper name
+            parts = func_name.split("_")
+            wrapper_name = parts[0] + "".join(p.capitalize() for p in parts[1:])
+
+            violation_msg = (
+                f"fl::{func_name}(...) declared here is a public global setter "
+                f"but has no CFastLED::{wrapper_name}() wrapper in src/FastLED.h. "
+                f"New global setters must follow the Public Settings Pattern — add "
+                f"an `inline` one-liner on CFastLED that delegates to this free "
+                f"function. See exemplar at src/FastLED.h:1455 "
+                f"(setPowerModel -> fl::set_power_model) and the rule at "
+                f"agents/docs/cpp-standards.md -> 'Public Settings Pattern'."
+            )
+            violations.append((line_number, violation_msg))
+
+        if violations:
+            self.violations[file_content.path] = violations
+
+        return []  # Violations stored internally
+
+
+def main() -> None:
+    """Run public_settings_pattern checker standalone."""
+    from ci.util.check_files import run_checker_standalone
+
+    checker = PublicSettingsPatternChecker()
+    run_checker_standalone(
+        checker,
+        [str(PROJECT_ROOT / "src" / "fl")],
+        "Found fl:: global setters without CFastLED wrappers (Public Settings Pattern)",
+        extensions=[".h"],
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/ci/lint_cpp/run_all_checkers.py
+++ b/ci/lint_cpp/run_all_checkers.py
@@ -61,6 +61,7 @@ from ci.lint_cpp.pch_file_checker import check as check_pch_files
 from ci.lint_cpp.platform_includes_checker import PlatformIncludesChecker
 from ci.lint_cpp.platform_pragma_checker import PlatformPragmaChecker
 from ci.lint_cpp.pragma_once_checker import PragmaOnceChecker
+from ci.lint_cpp.public_settings_pattern_checker import PublicSettingsPatternChecker
 from ci.lint_cpp.raw_noexcept_checker import RawNoexceptChecker
 from ci.lint_cpp.raw_pragma_checker import RawPragmaChecker
 from ci.lint_cpp.reinterpret_cast_checker import ReinterpretCastChecker
@@ -275,6 +276,7 @@ def create_checkers(
         # causes cascading ambiguity with fl::detail, fl::simd, etc.
         EnumClassChecker(),  # Checks for plain enum — use enum class for type safety
         NoexceptSpecialMembersChecker(),  # Checks special member functions have FL_NOEXCEPT
+        PublicSettingsPatternChecker(),  # Checks fl::set_*/enable_*/disable_*/use_* free functions have CFastLED wrappers
     ]
 
     # lib8tion/ directory checkers with STRICT enforcement

--- a/ci/lint_cpp/test_public_settings_pattern_checker.py
+++ b/ci/lint_cpp/test_public_settings_pattern_checker.py
@@ -1,0 +1,549 @@
+#!/usr/bin/env python3
+"""Unit tests for PublicSettingsPatternChecker.
+
+Tests cover:
+  - File filtering (should_process_file)
+  - Positive cases: violations that SHOULD be flagged
+  - Negative cases: valid patterns that MUST NOT be flagged
+  - Grandfathered allowlist (pre-existing offenders)
+  - Carve-outs (per-object setters, function-pointer installers, sub-namespaces)
+  - Comment exemptions (single-line, multi-line)
+  - Suppression tokens (// nolint, // ok public_settings)
+  - Cross-file wrapper check (functions referenced in a fake FastLED.h)
+  - Edge cases
+
+Helper convention:
+  _violations(code, fastled_h="") → list[tuple[int, str]]
+  Returns the list of (line_number, message) pairs the checker records for `code`.
+"""
+
+import unittest
+
+from ci.lint_cpp.public_settings_pattern_checker import (
+    GRANDFATHERED_NAMES,
+    PublicSettingsPatternChecker,
+    _is_per_object_setter,
+    _is_wrapped_in_fastled_h,
+)
+from ci.util.check_files import FileContent
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_FL_PATH = "src/fl/config/my_module.h"
+_THIRD_PARTY_PATH = "src/fl/third_party/some_lib.h"
+_NON_FL_PATH = "src/platforms/esp32/driver.h"
+_TESTS_PATH = "tests/fl/test_module.cpp"
+
+
+def _make(
+    code: str,
+    path: str = _FL_PATH,
+    fastled_h: str = "",
+) -> tuple[PublicSettingsPatternChecker, FileContent]:
+    """Build a checker with an injected (fake) FastLED.h and a FileContent."""
+    checker = PublicSettingsPatternChecker.__new__(PublicSettingsPatternChecker)
+    checker.violations = {}
+    checker._fastled_h_content = fastled_h
+    lines = code.splitlines()
+    fc = FileContent(path=path, content=code, lines=lines)
+    return checker, fc
+
+
+def _violations(
+    code: str,
+    path: str = _FL_PATH,
+    fastled_h: str = "",
+) -> list[tuple[int, str]]:
+    """Run the checker on *code* and return violations for *path*."""
+    checker, fc = _make(code, path, fastled_h)
+    if not checker.should_process_file(path):
+        return []
+    checker.check_file_content(fc)
+    return checker.violations.get(path, [])
+
+
+# ---------------------------------------------------------------------------
+# File filtering
+# ---------------------------------------------------------------------------
+
+
+class TestShouldProcessFile(unittest.TestCase):
+    def _checker(self) -> PublicSettingsPatternChecker:
+        c = PublicSettingsPatternChecker.__new__(PublicSettingsPatternChecker)
+        c.violations = {}
+        c._fastled_h_content = ""
+        return c
+
+    def test_fl_header_accepted(self) -> None:
+        c = self._checker()
+        self.assertTrue(c.should_process_file("src/fl/config/module.h"))
+
+    def test_fl_header_absolute_accepted(self) -> None:
+        c = self._checker()
+        self.assertTrue(c.should_process_file("C:/dev/fastled/src/fl/gfx/rgbw.h"))
+
+    def test_third_party_rejected(self) -> None:
+        c = self._checker()
+        self.assertFalse(c.should_process_file("src/fl/third_party/some_lib.h"))
+
+    def test_non_fl_src_rejected(self) -> None:
+        c = self._checker()
+        self.assertFalse(c.should_process_file("src/platforms/esp32/driver.h"))
+
+    def test_tests_directory_rejected(self) -> None:
+        c = self._checker()
+        self.assertFalse(c.should_process_file("tests/fl/test_module.cpp"))
+
+    def test_cpp_file_rejected(self) -> None:
+        c = self._checker()
+        self.assertFalse(c.should_process_file("src/fl/module.cpp"))
+
+    def test_cpp_hpp_rejected(self) -> None:
+        c = self._checker()
+        self.assertFalse(c.should_process_file("src/fl/module.cpp.hpp"))
+
+    def test_hpp_file_rejected(self) -> None:
+        # Only .h files are checked — .hpp is excluded
+        c = self._checker()
+        self.assertFalse(c.should_process_file("src/fl/module.hpp"))
+
+    def test_windows_backslash_paths_accepted(self) -> None:
+        c = self._checker()
+        self.assertTrue(c.should_process_file("C:\\dev\\fastled\\src\\fl\\module.h"))
+
+
+# ---------------------------------------------------------------------------
+# Positive cases — SHOULD flag
+# ---------------------------------------------------------------------------
+
+
+class TestShouldFlag(unittest.TestCase):
+    """Functions that must be reported as violations."""
+
+    def test_simple_global_setter_no_wrapper(self) -> None:
+        code = "namespace fl {\nvoid set_my_option(int val);\n}"
+        v = _violations(code)
+        self.assertEqual(len(v), 1)
+        self.assertIn("set_my_option", v[0][1])
+        self.assertEqual(v[0][0], 2)  # line 2
+
+    def test_enable_global_no_wrapper(self) -> None:
+        code = "namespace fl {\nbool enable_some_feature(int level);\n}"
+        v = _violations(code)
+        self.assertEqual(len(v), 1)
+        self.assertIn("enable_some_feature", v[0][1])
+
+    def test_disable_global_no_wrapper(self) -> None:
+        code = "namespace fl {\nvoid disable_some_feature();\n}"
+        v = _violations(code)
+        self.assertEqual(len(v), 1)
+        self.assertIn("disable_some_feature", v[0][1])
+
+    def test_use_global_no_wrapper(self) -> None:
+        code = "namespace fl {\nvoid use_new_algorithm(bool on);\n}"
+        v = _violations(code)
+        self.assertEqual(len(v), 1)
+        self.assertIn("use_new_algorithm", v[0][1])
+
+    def test_violation_message_suggests_wrapper_name(self) -> None:
+        code = "namespace fl {\nvoid set_my_option(int val);\n}"
+        v = _violations(code)
+        # Message must name both the free function and the camelCase wrapper
+        self.assertIn("setMyOption", v[0][1])
+        self.assertIn("CFastLED", v[0][1])
+
+    def test_multiple_violations_in_one_file(self) -> None:
+        code = (
+            "namespace fl {\nvoid set_option_a(int x);\nbool enable_mode_b(bool y);\n}"
+        )
+        v = _violations(code)
+        self.assertEqual(len(v), 2)
+
+    def test_fl_noexcept_decorated_setter_flagged(self) -> None:
+        """FL_NOEXCEPT attribute must not suppress the violation."""
+        code = "namespace fl {\nvoid set_bright(int v) FL_NOEXCEPT;\n}"
+        v = _violations(code)
+        self.assertEqual(len(v), 1)
+
+    def test_setter_with_const_ref_param_flagged(self) -> None:
+        """const ref first param is read-only — not per-object; should flag."""
+        code = "namespace fl {\nvoid set_model(const PowerModel& m);\n}"
+        v = _violations(code)
+        self.assertEqual(len(v), 1)
+
+    def test_no_params_setter_flagged(self) -> None:
+        """Zero-param setter that disables something — global state."""
+        code = "namespace fl {\nvoid disable_feature();\n}"
+        v = _violations(code)
+        self.assertEqual(len(v), 1)
+
+
+# ---------------------------------------------------------------------------
+# Negative cases — must NOT flag
+# ---------------------------------------------------------------------------
+
+
+class TestShouldNotFlag(unittest.TestCase):
+    """Patterns that must not produce any violations."""
+
+    def test_function_not_matching_pattern_skipped(self) -> None:
+        code = "namespace fl {\nvoid do_something(int v);\n}"
+        self.assertEqual(len(_violations(code)), 0)
+
+    def test_class_member_setter_skipped(self) -> None:
+        """Methods on a class/struct are per-object, not global."""
+        code = "namespace fl {\nstruct Foo {\n    void set_color(int c);\n};\n}"
+        self.assertEqual(len(_violations(code)), 0)
+
+    def test_getter_not_flagged(self) -> None:
+        code = "namespace fl {\nint get_brightness();\n}"
+        self.assertEqual(len(_violations(code)), 0)
+
+    def test_sub_namespace_depth_not_flagged(self) -> None:
+        """Functions inside fl::detail:: must be ignored."""
+        code = "namespace fl {\nnamespace detail {\nvoid set_internal(int x);\n}\n}"
+        self.assertEqual(len(_violations(code)), 0)
+
+    def test_anonymous_namespace_not_flagged(self) -> None:
+        """Functions inside anonymous namespaces are file-local."""
+        code = "namespace fl {\nnamespace {\nvoid set_hidden(int x);\n}\n}"
+        self.assertEqual(len(_violations(code)), 0)
+
+    def test_no_namespace_context_not_flagged(self) -> None:
+        """Free functions not inside namespace fl are skipped."""
+        code = "void set_something(int v);\n"
+        self.assertEqual(len(_violations(code)), 0)
+
+    def test_wrapper_in_fastled_h_suppresses_violation(self) -> None:
+        """Function referenced in FastLED.h must not be flagged."""
+        fake_fastled_h = (
+            "class CFastLED {\n"
+            "    inline void setSomething(int v) { fl::set_something(v); }\n"
+            "};\n"
+        )
+        code = "namespace fl {\nvoid set_something(int val);\n}"
+        self.assertEqual(len(_violations(code, fastled_h=fake_fastled_h)), 0)
+
+    def test_enum_body_does_not_confuse_scope(self) -> None:
+        """An enum class inside namespace fl must not break scope tracking."""
+        code = (
+            "namespace fl {\n"
+            "enum class Mode { kA, kB };\n"
+            "void set_something(int v);\n"  # still in namespace fl, should flag
+            "}"
+        )
+        v = _violations(code)
+        self.assertEqual(len(v), 1)
+        self.assertIn("set_something", v[0][1])
+
+    def test_plain_enum_body_does_not_confuse_scope(self) -> None:
+        """A plain `enum { }` must not pop the fl namespace prematurely."""
+        code = (
+            "namespace fl {\n"
+            "enum { kFoo = 0, kBar = 1 };\n"
+            "void set_brightness(int v);\n"  # still in fl, should flag
+            "}"
+        )
+        v = _violations(code)
+        self.assertEqual(len(v), 1)
+        self.assertIn("set_brightness", v[0][1])
+
+    def test_function_body_inline_does_not_confuse_scope(self) -> None:
+        """An inline function definition must not interfere with ns tracking."""
+        code = (
+            "namespace fl {\n"
+            "inline void helper() { do_work(); }\n"
+            "void set_brightness(int v);\n"  # still in fl
+            "}"
+        )
+        v = _violations(code)
+        self.assertEqual(len(v), 1)
+
+    def test_nested_sub_namespace_with_return_to_fl(self) -> None:
+        """After a sub-namespace closes, we should be back in fl scope."""
+        code = (
+            "namespace fl {\n"
+            "namespace isr {\n"
+            "void set_isr_mode(int x);\n"  # in fl::isr — NOT flagged
+            "}\n"
+            "void set_global_thing(int y);\n"  # back in fl — FLAGGED
+            "}"
+        )
+        v = _violations(code)
+        self.assertEqual(len(v), 1)
+        self.assertIn("set_global_thing", v[0][1])
+
+    def test_empty_file(self) -> None:
+        self.assertEqual(len(_violations("")), 0)
+
+    def test_file_without_setter_keywords(self) -> None:
+        code = "namespace fl {\nvoid do_work();\n}"
+        self.assertEqual(len(_violations(code)), 0)
+
+
+# ---------------------------------------------------------------------------
+# Grandfathered allowlist
+# ---------------------------------------------------------------------------
+
+
+class TestGrandfatheredAllowlist(unittest.TestCase):
+    def test_set_rgbw_colorimetric_profile_not_flagged(self) -> None:
+        code = (
+            "namespace fl {\n"
+            "void set_rgbw_colorimetric_profile(const DiodeProfile* p) FL_NOEXCEPT;\n"
+            "}"
+        )
+        self.assertEqual(len(_violations(code)), 0)
+
+    def test_set_input_gamut_not_flagged(self) -> None:
+        code = (
+            "namespace fl {\n"
+            "void set_input_gamut(DiodeProfile* p, InputGamut g) FL_NOEXCEPT;\n"
+            "}"
+        )
+        self.assertEqual(len(_violations(code)), 0)
+
+    def test_enable_rgbw_colorimetric_lut_not_flagged(self) -> None:
+        code = (
+            "namespace fl {\n"
+            "bool enable_rgbw_colorimetric_lut(int grid_n) FL_NOEXCEPT;\n"
+            "}"
+        )
+        self.assertEqual(len(_violations(code)), 0)
+
+    def test_disable_rgbw_colorimetric_lut_not_flagged(self) -> None:
+        code = "namespace fl {\nvoid disable_rgbw_colorimetric_lut() FL_NOEXCEPT;\n}"
+        self.assertEqual(len(_violations(code)), 0)
+
+    def test_set_rgbww_colorimetric_profile_not_flagged(self) -> None:
+        code = (
+            "namespace fl {\n"
+            "void set_rgbww_colorimetric_profile(const RgbcctProfile* p) FL_NOEXCEPT;\n"
+            "}"
+        )
+        self.assertEqual(len(_violations(code)), 0)
+
+    def test_allowlist_frozenset_contains_expected_names(self) -> None:
+        """Sanity-check the allowlist has the expected names."""
+        self.assertIn("set_rgbw_colorimetric_profile", GRANDFATHERED_NAMES)
+        self.assertIn("set_input_gamut", GRANDFATHERED_NAMES)
+        self.assertIn("enable_rgbw_colorimetric_lut", GRANDFATHERED_NAMES)
+        self.assertIn("disable_rgbw_colorimetric_lut", GRANDFATHERED_NAMES)
+        self.assertIn("set_rgbww_colorimetric_profile", GRANDFATHERED_NAMES)
+
+
+# ---------------------------------------------------------------------------
+# Per-object setter carve-outs
+# ---------------------------------------------------------------------------
+
+
+class TestPerObjectSetterCarveout(unittest.TestCase):
+    """_is_per_object_setter() and the checker integration."""
+
+    def test_non_const_ptr_first_param_is_per_object(self) -> None:
+        # Non-const pointer to user type → per-object, not flagged
+        line = "void set_input_gamut(DiodeProfile* obj, InputGamut g);"
+        self.assertTrue(_is_per_object_setter(line))
+
+    def test_const_ref_first_param_is_not_per_object(self) -> None:
+        # const ref → read-only → global setter candidate
+        line = "void set_power_model(const PowerModel& m);"
+        self.assertFalse(_is_per_object_setter(line))
+
+    def test_fundamental_int_first_param_not_per_object(self) -> None:
+        line = "bool enable_lut(int grid_n);"
+        self.assertFalse(_is_per_object_setter(line))
+
+    def test_no_params_not_per_object(self) -> None:
+        line = "void disable_lut();"
+        self.assertFalse(_is_per_object_setter(line))
+
+    def test_non_const_ref_user_type_is_per_object(self) -> None:
+        line = "void set_color(CRGB& out, int r, int g, int b);"
+        self.assertTrue(_is_per_object_setter(line))
+
+    def test_per_object_not_flagged_by_checker(self) -> None:
+        """A non-const ptr first param must NOT produce a violation."""
+        code = "namespace fl {\nvoid set_diode(DiodeProfile* p, int v);\n}"
+        self.assertEqual(len(_violations(code)), 0)
+
+
+# ---------------------------------------------------------------------------
+# Function-pointer setter carve-outs
+# ---------------------------------------------------------------------------
+
+
+class TestFunctionPointerCarveout(unittest.TestCase):
+    def test_set_rgb_2_rgbw_function_not_flagged(self) -> None:
+        code = (
+            "namespace fl {\n"
+            "void set_rgb_2_rgbw_function(rgb_2_rgbw_function func) FL_NOEXCEPT;\n"
+            "}"
+        )
+        self.assertEqual(len(_violations(code)), 0)
+
+    def test_set_rgb_2_rgbww_function_not_flagged(self) -> None:
+        code = (
+            "namespace fl {\n"
+            "void set_rgb_2_rgbww_function(rgb_2_rgbww_function func) FL_NOEXCEPT;\n"
+            "}"
+        )
+        self.assertEqual(len(_violations(code)), 0)
+
+
+# ---------------------------------------------------------------------------
+# Comment exemptions
+# ---------------------------------------------------------------------------
+
+
+class TestCommentExemptions(unittest.TestCase):
+    def test_single_line_comment_ignored(self) -> None:
+        code = "namespace fl {\n// void set_my_option(int val);\n}"
+        self.assertEqual(len(_violations(code)), 0)
+
+    def test_multiline_comment_block_ignored(self) -> None:
+        code = "namespace fl {\n/*\n * void set_my_option(int val);\n */\n}"
+        self.assertEqual(len(_violations(code)), 0)
+
+    def test_inline_comment_does_not_suppress(self) -> None:
+        """The setter is in code; comment appended after — still flagged."""
+        code = "namespace fl {\nvoid set_my_option(int val); // some note\n}"
+        self.assertEqual(len(_violations(code)), 1)
+
+
+# ---------------------------------------------------------------------------
+# Suppression tokens
+# ---------------------------------------------------------------------------
+
+
+class TestSuppressionTokens(unittest.TestCase):
+    def test_nolint_suppresses(self) -> None:
+        code = "namespace fl {\nvoid set_my_option(int val); // nolint\n}"
+        self.assertEqual(len(_violations(code)), 0)
+
+    def test_ok_public_settings_suppresses(self) -> None:
+        code = "namespace fl {\nvoid set_my_option(int val); // ok public_settings\n}"
+        self.assertEqual(len(_violations(code)), 0)
+
+    def test_suppression_case_insensitive(self) -> None:
+        code = "namespace fl {\nvoid set_my_option(int val); // NOLINT\n}"
+        self.assertEqual(len(_violations(code)), 0)
+
+    def test_suppression_does_not_bleed_to_next_line(self) -> None:
+        code = (
+            "namespace fl {\n"
+            "void set_option_a(int v); // nolint\n"
+            "void set_option_b(int v);\n"
+            "}"
+        )
+        v = _violations(code)
+        self.assertEqual(len(v), 1)
+        self.assertIn("set_option_b", v[0][1])
+
+
+# ---------------------------------------------------------------------------
+# Cross-file wrapper check (_is_wrapped_in_fastled_h)
+# ---------------------------------------------------------------------------
+
+
+class TestCrossFileWrapperCheck(unittest.TestCase):
+    def test_function_in_fastled_h_body_passes(self) -> None:
+        fastled_h = (
+            "class CFastLED {\n"
+            "    inline void setThing(int v) { fl::set_thing(v); }\n"
+            "};\n"
+        )
+        self.assertTrue(_is_wrapped_in_fastled_h("set_thing", fastled_h))
+
+    def test_function_only_in_include_comment_not_wrapped(self) -> None:
+        """#include lines must not count as wrappers."""
+        fastled_h = '#include "fl/thing.h"  // set_thing declared here\n'
+        self.assertFalse(_is_wrapped_in_fastled_h("set_thing", fastled_h))
+
+    def test_function_name_in_comment_not_wrapped(self) -> None:
+        fastled_h = "// call set_thing to configure\n"
+        self.assertFalse(_is_wrapped_in_fastled_h("set_thing", fastled_h))
+
+    def test_empty_fastled_h_not_wrapped(self) -> None:
+        self.assertFalse(_is_wrapped_in_fastled_h("set_thing", ""))
+
+    def test_partial_name_not_matched(self) -> None:
+        fastled_h = "fl::set_thingamajig(v);\n"
+        self.assertFalse(_is_wrapped_in_fastled_h("set_thing", fastled_h))
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases(unittest.TestCase):
+    def test_multiple_namespaces_on_one_line(self) -> None:
+        """namespace fl { namespace detail { on one line is a sub-namespace."""
+        code = "namespace fl { namespace detail {\nvoid set_internal(int x);\n}}\n"
+        # set_internal is in fl::detail — must NOT be flagged
+        self.assertEqual(len(_violations(code)), 0)
+
+    def test_forward_struct_decl_not_class_body(self) -> None:
+        """struct Foo; (forward decl) must not push a class scope."""
+        code = "namespace fl {\nstruct PowerModel;\nvoid set_model(int v);\n}"
+        v = _violations(code)
+        self.assertEqual(len(v), 1)
+
+    def test_class_with_inline_body_resets_after_close(self) -> None:
+        """After a class body closes we should be back at fl scope."""
+        code = (
+            "namespace fl {\n"
+            "struct Cfg {\n"
+            "    void set_pin(int p);\n"  # inside class — NOT flagged
+            "};\n"
+            "void set_global_setting(int v);\n"  # back in fl — FLAGGED
+            "}"
+        )
+        v = _violations(code)
+        self.assertEqual(len(v), 1)
+        self.assertIn("set_global_setting", v[0][1])
+
+    def test_line_number_in_violation(self) -> None:
+        code = "// header\nnamespace fl {\n\nvoid set_my_thing(int v);\n}"
+        v = _violations(code)
+        self.assertEqual(len(v), 1)
+        self.assertEqual(v[0][0], 4)  # declaration is on line 4
+
+    def test_real_rgbww_header_shape(self) -> None:
+        """Simulate rgbww.h: forward-decl sub-ns then fl:: free functions."""
+        code = (
+            "namespace fl {\n"
+            "namespace colorimetric_detail {\n"
+            "struct RgbcctProfile;\n"
+            "}\n"
+            "enum class RGBWW_MODE : int { kA, kB };\n"
+            "enum { kDefaultCct = 2700 };\n"
+            "struct Rgbww { int warm; };\n"
+            "void set_rgb_2_rgbww_function(rgb_2_rgbww_function func);\n"  # FP setter
+            "void set_rgbww_colorimetric_profile(const RgbcctProfile* p);\n"  # allowlist
+            "}"
+        )
+        # Both should be exempted: one via FUNCTION_POINTER_SETTERS, one via allowlist
+        v = _violations(code)
+        self.assertEqual(len(v), 0)
+
+    def test_real_rgbw_header_shape(self) -> None:
+        """Simulate rgbw.h: grandfathered setters inside namespace fl."""
+        code = (
+            "namespace fl {\n"
+            "void set_rgbw_colorimetric_profile(const DiodeProfile* p) FL_NOEXCEPT;\n"
+            "bool enable_rgbw_colorimetric_lut(int grid_n) FL_NOEXCEPT;\n"
+            "void disable_rgbw_colorimetric_lut() FL_NOEXCEPT;\n"
+            "void set_rgb_2_rgbw_function(rgb_2_rgbw_function func) FL_NOEXCEPT;\n"
+            "}"
+        )
+        v = _violations(code)
+        self.assertEqual(len(v), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/FastLED.h
+++ b/src/FastLED.h
@@ -1584,6 +1584,32 @@ public:
 
 	/// @} Power Model Configuration
 
+	/// @name RGBW Colorimetric Configuration
+	/// God-instance wrappers around `fl::set_rgbw_colorimetric_profile` /
+	/// `fl::get_rgbw_colorimetric_profile`. See
+	/// `agents/docs/cpp-standards.md` → "Public Settings Pattern" for the
+	/// rule that global setters live here, not as bare `fl::` free functions.
+	/// @{
+
+	/// Install a user-supplied RGBW diode chromaticity profile for the
+	/// colorimetric modes. The pointer is stored — caller must keep the
+	/// `DiodeProfile` alive for as long as a colorimetric mode is active.
+	/// No-op when `FASTLED_RGBW_COLORIMETRIC` is undefined.
+	/// @param profile pointer to a caller-owned `fl::DiodeProfile`, or `nullptr` to revert to `kRgbwDefaultProfile`.
+	/// @code
+	/// FastLED.setRgbwColorimetricProfile(&my_profile);
+	/// @endcode
+	inline void setRgbwColorimetricProfile(const fl::DiodeProfile* profile) FL_NOEXCEPT {
+		fl::set_rgbw_colorimetric_profile(profile);
+	}
+
+	/// Currently active RGBW colorimetric profile (defaults to `&fl::kRgbwDefaultProfile`).
+	inline const fl::DiodeProfile* getRgbwColorimetricProfile() const FL_NOEXCEPT {
+		return fl::get_rgbw_colorimetric_profile();
+	}
+
+	/// @} RGBW Colorimetric Configuration
+
 	/// Update all our controllers with the current led colors, using the passed in brightness
 	/// @param scale the brightness value to use in place of the stored value
 	void show(fl::u8 scale);


### PR DESCRIPTION
## Motivation

Triggered by PR #2711, which added `fl::set_input_gamut(...)` as a bare free function — following the pre-existing pattern of `fl::set_rgbw_colorimetric_profile`. Neither has a `FastLED.setX()` god-instance entry point, so users discover and document the wrong call site (the `fl::` free function), and the library's public surface drifts out of sync with the documented exemplar (`FastLED.setPowerModel` → `fl::set_power_model`, `src/FastLED.h:1455`).

The codebase has the correct pattern (`setPowerModel`), but it wasn't written down. AI agents and humans both followed the unwrapped neighbor instead. This PR writes the rule down and adds enforcement at four layers so the drift stops.

## Six-layer enforcement plan (this PR does layers 1–4)

| Layer | What | Status |
|-------|------|--------|
| 1. Documentation | `agents/docs/cpp-standards.md` → "Public Settings Pattern" | done in this PR |
| 1b. Index | `CLAUDE.md` table + Code Standards section pointer | done in this PR |
| 2. AI review | `.coderabbit.yaml` `path_instructions` for `src/fl/**/*.h`, `src/FastLED.h`, `src/fl/gfx/**` | done in this PR |
| 3a. Architecture review | `architecture-reviewer-agent` system prompt | done in this PR |
| 3b. Slash command | `/code_review` checklist + summary counter | done in this PR |
| 4. Backfill exemplar | `CFastLED::setRgbwColorimetricProfile` + getter | done in this PR |
| 4b. Backfill `setInputGamut` | wait for PR #2711 to land OR fold into #2711 | follow-up |
| 5. Lint check | `cpp-linter-builder-agent` writes a syntactic check | dispatching in background |

## What the rule says

> New library-wide configuration setters (`fl::set_*`, `fl::enable_*`, `fl::disable_*`, `fl::use_*` that mutate global / namespace-scope / static state) MUST be exposed on the `CFastLED` god instance as a thin `inline` delegator. The free function may exist for ADL / testability; the documented user-facing entry point is `FastLED.setX(...)`.

**Grandfathered** (predate the rule — do not flag for these names alone):
- `fl::set_rgbw_colorimetric_profile` — wrapped in this PR
- `fl::set_input_gamut` (#2710) — to be wrapped when #2711 lands (or folded into #2711)

## Changes

- **`agents/docs/cpp-standards.md`** — New "Public Settings Pattern" section with rules, the `setPowerModel` exemplar, grandfathered allowlist, and a "doesn't apply to" carve-out for helpers / per-object config / `fl::detail::`.
- **`CLAUDE.md`** — Adds a row to the task table and a bullet under Code Standards so agents see the rule on entry.
- **`.coderabbit.yaml`** — Adds `path_instructions` blocks teaching CodeRabbit to flag bare new `fl::set_*` free functions in `src/fl/**/*.h` that lack a `CFastLED` wrapper. Also covers `src/FastLED.h` (delegate-don't-embed) and `src/fl/gfx/**` (where the recent offender lives). Grandfathered names called out by name.
- **`.claude/agents/architecture-reviewer-agent.md`** — Adds a "Public Settings Pattern enforcement" subsection under API Surface, with HIGH severity and the canned violation language.
- **`.claude/commands/code_review.md`** — New rule block before "SIGNED INTEGER OVERFLOW", plus a "Public Settings Pattern violations" counter in the violations summary.
- **`src/FastLED.h`** — Adds `#include "fl/gfx/rgbw.h"` and a "RGBW Colorimetric Configuration" group on `CFastLED` containing `setRgbwColorimetricProfile(const fl::DiodeProfile*)` and `getRgbwColorimetricProfile()`. Both are thin `inline` delegators to the existing free functions in `fl::`, matching the `setPowerModel` exemplar exactly.

## Test plan

- [x] `bash lint` clean (all four pipelines).
- [ ] CI green (host + WASM + platform compile).
- [ ] CodeRabbit's pre-merge review picks up the new `path_instructions` and applies them.
- [ ] Follow-up: after #2711 lands (or as a fold-in), add `FastLED.setInputGamut(...)` and update #2711's body/examples to recommend the god-instance call.
- [ ] Follow-up: cpp-linter-builder-agent dispatched in background to write the syntactic check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added RGBW colorimetric profile configuration support via two new public methods for managing diode color profiles.

* **Chores**
  * Updated code review standards and linting infrastructure to enforce consistency in global configuration API design.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->