### PR TITLE
feat(lint): enforce Public Settings Pattern for fl:: global setters (layer 5)

### DIFF
--- a/ci/lint_cpp/public_settings_pattern_checker.py
+++ b/ci/lint_cpp/public_settings_pattern_checker.py
@@ -206,7 +206,7 @@ def _is_per_object_setter(decl_line: str) -> bool:
 
     # Split off the first parameter (stop at first comma that is not inside <>)
     depth = 0
-    first_param = []
+    first_param: list[str] = []
     for ch in params_raw:
         if ch == "<":
             depth += 1

--- a/ci/lint_cpp/public_settings_pattern_checker.py
+++ b/ci/lint_cpp/public_settings_pattern_checker.py
@@ -1,0 +1,455 @@
+#!/usr/bin/env python3
+# pyright: reportUnknownMemberType=false
+"""Checker to enforce the Public Settings Pattern for global configuration setters.
+
+Every new public free function in `src/fl/**/*.h` whose name matches the regex
+`^(set|enable|disable|use)_[a-z]` and that is declared at namespace scope
+(inside `namespace fl {` at depth 1 — NOT inside a class, NOT in an anonymous
+namespace, NOT in `fl::detail::` or any sub-namespace) MUST have a matching
+`CFastLED::setX()` / `enableX()` / `disableX()` wrapper in `src/FastLED.h`
+that delegates to it.
+
+Why: `CFastLED` (the `FastLED` god instance) is the documented, discoverable
+user API surface. Free-function-only global setters ratchet configuration knobs
+into an undocumented second location that users won't find and that drifts out
+of sync with the god instance.
+
+Exemplar (`src/FastLED.h:1455`):
+    // Free function — does the work
+    namespace fl { void set_power_model(const PowerModelRGB& m) noexcept; }
+
+    // CFastLED wrapper — what users call
+    class CFastLED {
+        inline void setPowerModel(const PowerModelRGB& model) {
+            set_power_model(model);
+        }
+    };
+
+Carve-outs (NOT flagged):
+  - Functions in `fl::detail::`, `fl::isr::`, or any sub-namespace (depth > 1).
+  - Functions inside anonymous `namespace { }` blocks.
+  - Functions inside class/struct bodies (per-object setters, not global state).
+  - Function pointer setters where the first parameter is a function-pointer type
+    (e.g. `set_rgb_2_rgbw_function(func)`).
+  - Per-object mutators: first parameter is a non-const pointer/reference to a
+    user-defined (non-fundamental) type — heuristic for per-object config.
+  - Lines in `// comments` or `/* ... */` blocks.
+  - Lines with suppression `// nolint` or `// ok public_settings`.
+
+Allowlist (grandfathered pre-rule offenders — do NOT flag):
+  - `set_rgbw_colorimetric_profile`  (wrapped in PR #2715; allowlist is
+    defence-in-depth for when the wrapper grep heuristic might miss it)
+  - `set_input_gamut`                (allowlisted until a wrapper is shipped)
+
+Scope: `src/fl/**/*.h` only (NOT third_party, NOT detail subdirs).
+"""
+
+import re
+
+from ci.util.check_files import FileContent, FileContentChecker
+from ci.util.paths import PROJECT_ROOT
+
+
+# ---------------------------------------------------------------------------
+# Grandfathered allowlist — names that predate the rule.
+# These are NOT flagged regardless of wrapper presence.
+# Remove an entry only after its CFastLED wrapper is merged and the grep
+# heuristic has been verified to catch it cleanly.
+# ---------------------------------------------------------------------------
+GRANDFATHERED_NAMES: frozenset[str] = frozenset(
+    [
+        "set_rgbw_colorimetric_profile",  # Wrapped in PR #2715
+        "set_input_gamut",  # Grandfathered; wrapper planned
+        # Added in #2545 (colorimetric RGBW LUT). Wrappers planned.
+        "enable_rgbw_colorimetric_lut",
+        "disable_rgbw_colorimetric_lut",
+        # Added in #2558 (RGBWW pipeline). Wrapper planned.
+        "set_rgbww_colorimetric_profile",
+    ]
+)
+
+# ---------------------------------------------------------------------------
+# Additional carve-outs: function-pointer installer pattern.
+# These names set a *callback*, not a global scalar/object.  The syntactic
+# heuristic (first-param-is-non-fundamental) doesn't catch function pointers
+# cleanly, so we name them explicitly.  Revisit if real violations slip through.
+# ---------------------------------------------------------------------------
+FUNCTION_POINTER_SETTERS: frozenset[str] = frozenset(
+    [
+        "set_rgb_2_rgbw_function",
+        "set_rgb_2_rgbww_function",
+    ]
+)
+
+# ---------------------------------------------------------------------------
+# Pre-compiled regexes
+# ---------------------------------------------------------------------------
+
+# Declaration-like line: starts with a return type word, then a name that
+# matches the pattern.  We require the function name to start the
+# `(set|enable|disable|use)_[a-z]` pattern.
+_SETTER_DECL = re.compile(
+    r"^"
+    r"(?:(?:inline|static|virtual|explicit|constexpr|FL_NOEXCEPT|FASTLED_FORCE_INLINE)\s+)*"  # optional qualifiers
+    r"(?:[\w:]+(?:<[^>]*>)?(?:\s*[*&])?\s+)+"  # return type (e.g. "void ", "bool ", "int ")
+    r"(?P<name>(set|enable|disable|use)_[a-z][a-zA-Z0-9_]*)"  # the setter name
+    r"\s*\("  # open paren
+)
+
+# Matches "namespace <name>" — named namespace opening
+_NAMED_NS = re.compile(r"^\s*namespace\s+(\w+)\s*\{")
+
+# Matches anonymous namespace "namespace {" (no name)
+_ANON_NS = re.compile(r"^\s*namespace\s*\{")
+
+# Suppression on the same line
+_SUPPRESSION = re.compile(r"//\s*(nolint|ok\s+public_settings)\b", re.IGNORECASE)
+
+# Fundamental C++ types — used to distinguish per-object vs global setters.
+# If the FIRST parameter starts with one of these, it's a scalar/global setter
+# candidate.  If it's a user-defined type pointer/ref, it's per-object.
+_FUNDAMENTAL_TYPES = frozenset(
+    [
+        "bool",
+        "char",
+        "short",
+        "int",
+        "long",
+        "float",
+        "double",
+        "void",
+        "unsigned",
+        "signed",
+        "u8",
+        "u16",
+        "u32",
+        "u64",
+        "s8",
+        "s16",
+        "s32",
+        "s64",
+        "uint8_t",
+        "uint16_t",
+        "uint32_t",
+        "uint64_t",
+        "int8_t",
+        "int16_t",
+        "int32_t",
+        "int64_t",
+        "size_t",
+        "ssize_t",
+        "ptrdiff_t",
+    ]
+)
+
+# Matches first parameter extraction from a declaration line.
+# Captures: full param list inside parens (simplified — single-line only).
+_PARAM_LIST = re.compile(r"\(([^)]*)\)")
+
+
+def _load_fastled_h() -> str:
+    """Load the content of src/FastLED.h for cross-file wrapper checks."""
+    fastled_h = PROJECT_ROOT / "src" / "FastLED.h"
+    try:
+        return fastled_h.read_text(encoding="utf-8")
+    except OSError:
+        return ""
+
+
+def _is_wrapped_in_fastled_h(func_name: str, fastled_h_content: str) -> bool:
+    """Return True if *func_name* appears inside the body of a CFastLED method
+    in FastLED.h.
+
+    Heuristic: we search for any non-comment, non-include line in FastLED.h
+    that contains the function name as a bare word (not the #include line).
+    This is intentionally permissive — false negatives (missing wrappers) are
+    what we want to catch; false positives (spurious "found") are benign.
+    """
+    if not fastled_h_content:
+        return False
+
+    pattern = re.compile(r"\b" + re.escape(func_name) + r"\b")
+    for line in fastled_h_content.splitlines():
+        stripped = line.strip()
+        # Skip the include line that brings in the header defining this function
+        if stripped.startswith("#include"):
+            continue
+        # Skip comment-only lines
+        if stripped.startswith("//") or stripped.startswith("*"):
+            continue
+        if pattern.search(line):
+            return True
+    return False
+
+
+def _is_per_object_setter(decl_line: str) -> bool:
+    """Return True if the declaration looks like a per-object mutator.
+
+    Heuristic: if the first parameter is a non-const pointer (*) or non-const
+    reference (&) to a non-fundamental type (i.e. a struct/class), the function
+    is likely mutating an object the caller owns, not global state.
+
+    Examples that return True (per-object — skip):
+        void set_input_gamut(DiodeProfile* obj, InputGamut g)
+        void set_color(CRGB& out, uint8_t r, uint8_t g, uint8_t b)
+
+    Examples that return False (global state — flag):
+        void set_power_model(const PowerModelRGB& model)
+        void enable_rgbw_colorimetric_lut(int grid_n)
+    """
+    m = _PARAM_LIST.search(decl_line)
+    if not m:
+        return False
+    params_raw = m.group(1).strip()
+    if not params_raw:
+        return False  # no params → global setter (e.g. disable_foo())
+
+    # Split off the first parameter (stop at first comma that is not inside <>)
+    depth = 0
+    first_param = []
+    for ch in params_raw:
+        if ch == "<":
+            depth += 1
+        elif ch == ">":
+            depth -= 1
+        elif ch == "," and depth == 0:
+            break
+        first_param.append(ch)
+    first_param_str = "".join(first_param).strip()
+
+    # Check for a non-const pointer or reference to user-defined type.
+    # Pattern: optional "const", type tokens, then * or &, then optional name.
+    # If "const" appears before the *, it is read-only — treat as global.
+    # Function pointer parameters look like: `ret_type (*name)(args)` — skip too.
+    if "(*" in first_param_str:
+        return False  # function pointer — handled by FUNCTION_POINTER_SETTERS
+
+    has_non_const_ptr_or_ref = False
+    stripped_fp = first_param_str
+
+    # Remove trailing parameter name (last word token)
+    tokens = stripped_fp.split()
+    # Check if last token is likely a name (no *, &, :, <)
+    if tokens and re.match(r"^[a-zA-Z_]\w*$", tokens[-1]):
+        tokens = tokens[:-1]
+    param_type_str = " ".join(tokens)
+
+    # If "const" is in the type tokens *before* the * or &, it is read-only
+    is_const = "const" in param_type_str
+    has_ptr_or_ref = "*" in param_type_str or "&" in param_type_str
+
+    if has_ptr_or_ref and not is_const:
+        # Check if the base type is fundamental
+        # Strip *, &, and const to get the base type word
+        base = re.sub(r"[*&\s]", " ", param_type_str)
+        base = base.replace("const", "").strip()
+        base_tokens = base.split()
+        if base_tokens:
+            base_type = base_tokens[0].lstrip(":").split("::")[-1]
+            if base_type not in _FUNDAMENTAL_TYPES:
+                has_non_const_ptr_or_ref = True
+
+    return has_non_const_ptr_or_ref
+
+
+class PublicSettingsPatternChecker(FileContentChecker):
+    """Checker that flags fl::set_*/enable_*/disable_*/use_* free functions
+    declared at namespace scope in src/fl/**/*.h without a CFastLED wrapper
+    in src/FastLED.h.
+    """
+
+    def __init__(self) -> None:
+        self.violations: dict[str, list[tuple[int, str]]] = {}
+        # Load FastLED.h content once at construction time.
+        self._fastled_h_content: str = _load_fastled_h()
+
+    def should_process_file(self, file_path: str) -> bool:
+        normalized = file_path.replace("\\", "/")
+
+        # Only header files
+        if not normalized.endswith(".h"):
+            return False
+
+        # Only inside src/fl/ (absolute or relative paths)
+        if "/src/fl/" not in normalized and not normalized.startswith("src/fl/"):
+            return False
+
+        # Exclude third_party
+        if "/third_party/" in normalized:
+            return False
+
+        # Exclude .cpp.hpp pseudo-headers (they're implementation files)
+        if normalized.endswith(".cpp.hpp"):
+            return False
+
+        return True
+
+    def check_file_content(self, file_content: FileContent) -> list[str]:
+        """Scan a src/fl/ header for unwrapped global setter declarations."""
+        # Fast skip: if none of the trigger prefixes appear, bail immediately
+        content = file_content.content
+        if not any(kw in content for kw in ("set_", "enable_", "disable_", "use_")):
+            return []
+
+        violations: list[tuple[int, str]] = []
+        in_multiline_comment = False
+
+        # Scope stack: each entry is a string describing the scope kind:
+        #   "fl"        — inside `namespace fl { ` (the target scope)
+        #   "ns_sub"    — inside a named sub-namespace (fl::detail, fl::isr, …)
+        #   "ns_anon"   — inside anonymous `namespace { `
+        #   "class"     — inside a class/struct body
+        #   "other"     — any other brace block (enum, function body, if, …)
+        #
+        # We push ONE entry per `{` and pop ONE per `}`.  This correctly
+        # handles enums, inline functions, conditionals, etc.
+        scope_stack: list[str] = []
+
+        def _classify_open(code_line: str) -> str:
+            """Classify what kind of scope a `{`-bearing line opens."""
+            # Named namespace?
+            ns_m = _NAMED_NS.match(code_line)
+            if ns_m:
+                name = ns_m.group(1)
+                # Is the immediately enclosing scope "fl"?
+                if scope_stack == ["fl"] or scope_stack == []:
+                    # Top-level: "fl" itself or a first-level sub-namespace
+                    if name == "fl":
+                        return "fl"
+                    # Anything else at top level is a non-fl namespace
+                    return "ns_sub"
+                else:
+                    # Nested under something — always a sub-namespace
+                    return "ns_sub"
+            # Anonymous namespace?
+            if _ANON_NS.match(code_line):
+                return "ns_anon"
+            # class/struct (not a forward declaration)?
+            if re.search(r"\b(class|struct)\b", code_line):
+                if not re.search(r"\b(class|struct)\b\s+\w+\s*;", code_line):
+                    return "class"
+            # Everything else (enum body, function body, if block, …)
+            return "other"
+
+        for line_number, line in enumerate(file_content.lines, 1):
+            stripped = line.strip()
+
+            # ---- multi-line comment tracking ----
+            if "/*" in line:
+                in_multiline_comment = True
+            if "*/" in line:
+                in_multiline_comment = False
+                continue
+            if in_multiline_comment:
+                continue
+
+            # Skip single-line comment lines
+            if stripped.startswith("//"):
+                continue
+
+            # Strip inline comment for code analysis
+            code = line.split("//")[0]
+
+            opens = code.count("{")
+            closes = code.count("}")
+
+            # Push one scope entry per opening brace.
+            # When multiple braces appear on one line (rare but valid, e.g.
+            # `namespace fl { namespace detail {`), classify only the first
+            # opening brace against the line and treat any extras as "other".
+            if opens > 0:
+                first_kind = _classify_open(code.strip())
+                scope_stack.append(first_kind)
+                for _ in range(opens - 1):
+                    scope_stack.append("other")
+
+            # Pop one scope entry per closing brace.
+            for _ in range(closes):
+                if scope_stack:
+                    scope_stack.pop()
+
+            # ---- check if we're at fl:: root scope (after brace updates) ----
+            # The ONLY valid scope stack for a free function in `namespace fl`
+            # is exactly `["fl"]`.  Any deeper nesting (class, sub-namespace,
+            # anonymous namespace, enum body) disqualifies the line.
+            if scope_stack != ["fl"]:
+                continue
+
+            # Skip preprocessor directives
+            if stripped.startswith("#"):
+                continue
+
+            # ---- check for a setter declaration ----
+            code_stripped = code.strip()
+            if not code_stripped:
+                continue
+
+            # Fast pre-check before regex
+            has_trigger = any(
+                kw in code_stripped for kw in ("set_", "enable_", "disable_", "use_")
+            )
+            if not has_trigger:
+                continue
+
+            m = _SETTER_DECL.match(code_stripped)
+            if not m:
+                continue
+
+            func_name = m.group("name")
+
+            # Suppression comment on same line
+            if _SUPPRESSION.search(line):
+                continue
+
+            # Allowlist: grandfathered offenders
+            if func_name in GRANDFATHERED_NAMES:
+                continue
+
+            # Carve-out: function-pointer installers
+            if func_name in FUNCTION_POINTER_SETTERS:
+                continue
+
+            # Carve-out: per-object setters (non-const ptr/ref first param)
+            if _is_per_object_setter(code_stripped):
+                continue
+
+            # Cross-file check: is this function name used inside FastLED.h?
+            if _is_wrapped_in_fastled_h(func_name, self._fastled_h_content):
+                continue
+
+            # Convert snake_case to camelCase for the suggested wrapper name
+            parts = func_name.split("_")
+            wrapper_name = parts[0] + "".join(p.capitalize() for p in parts[1:])
+
+            violation_msg = (
+                f"fl::{func_name}(...) declared here is a public global setter "
+                f"but has no CFastLED::{wrapper_name}() wrapper in src/FastLED.h. "
+                f"New global setters must follow the Public Settings Pattern — add "
+                f"an `inline` one-liner on CFastLED that delegates to this free "
+                f"function. See exemplar at src/FastLED.h:1455 "
+                f"(setPowerModel -> fl::set_power_model) and the rule at "
+                f"agents/docs/cpp-standards.md -> 'Public Settings Pattern'."
+            )
+            violations.append((line_number, violation_msg))
+
+        if violations:
+            self.violations[file_content.path] = violations
+
+        return []  # Violations stored internally
+
+
+def main() -> None:
+    """Run public_settings_pattern checker standalone."""
+    from ci.util.check_files import run_checker_standalone
+
+    checker = PublicSettingsPatternChecker()
+    run_checker_standalone(
+        checker,
+        [str(PROJECT_ROOT / "src" / "fl")],
+        "Found fl:: global setters without CFastLED wrappers (Public Settings Pattern)",
+        extensions=[".h"],
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/ci/lint_cpp/run_all_checkers.py
+++ b/ci/lint_cpp/run_all_checkers.py
@@ -61,6 +61,7 @@ from ci.lint_cpp.pch_file_checker import check as check_pch_files
 from ci.lint_cpp.platform_includes_checker import PlatformIncludesChecker
 from ci.lint_cpp.platform_pragma_checker import PlatformPragmaChecker
 from ci.lint_cpp.pragma_once_checker import PragmaOnceChecker
+from ci.lint_cpp.public_settings_pattern_checker import PublicSettingsPatternChecker
 from ci.lint_cpp.raw_noexcept_checker import RawNoexceptChecker
 from ci.lint_cpp.raw_pragma_checker import RawPragmaChecker
 from ci.lint_cpp.reinterpret_cast_checker import ReinterpretCastChecker
@@ -275,6 +276,7 @@ def create_checkers(
         # causes cascading ambiguity with fl::detail, fl::simd, etc.
         EnumClassChecker(),  # Checks for plain enum — use enum class for type safety
         NoexceptSpecialMembersChecker(),  # Checks special member functions have FL_NOEXCEPT
+        PublicSettingsPatternChecker(),  # Checks fl::set_*/enable_*/disable_*/use_* free functions have CFastLED wrappers
     ]
 
     # lib8tion/ directory checkers with STRICT enforcement

--- a/ci/lint_cpp/test_public_settings_pattern_checker.py
+++ b/ci/lint_cpp/test_public_settings_pattern_checker.py
@@ -1,0 +1,549 @@
+#!/usr/bin/env python3
+"""Unit tests for PublicSettingsPatternChecker.
+
+Tests cover:
+  - File filtering (should_process_file)
+  - Positive cases: violations that SHOULD be flagged
+  - Negative cases: valid patterns that MUST NOT be flagged
+  - Grandfathered allowlist (pre-existing offenders)
+  - Carve-outs (per-object setters, function-pointer installers, sub-namespaces)
+  - Comment exemptions (single-line, multi-line)
+  - Suppression tokens (// nolint, // ok public_settings)
+  - Cross-file wrapper check (functions referenced in a fake FastLED.h)
+  - Edge cases
+
+Helper convention:
+  _violations(code, fastled_h="") → list[tuple[int, str]]
+  Returns the list of (line_number, message) pairs the checker records for `code`.
+"""
+
+import unittest
+
+from ci.lint_cpp.public_settings_pattern_checker import (
+    GRANDFATHERED_NAMES,
+    PublicSettingsPatternChecker,
+    _is_per_object_setter,
+    _is_wrapped_in_fastled_h,
+)
+from ci.util.check_files import FileContent
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_FL_PATH = "src/fl/config/my_module.h"
+_THIRD_PARTY_PATH = "src/fl/third_party/some_lib.h"
+_NON_FL_PATH = "src/platforms/esp32/driver.h"
+_TESTS_PATH = "tests/fl/test_module.cpp"
+
+
+def _make(
+    code: str,
+    path: str = _FL_PATH,
+    fastled_h: str = "",
+) -> tuple[PublicSettingsPatternChecker, FileContent]:
+    """Build a checker with an injected (fake) FastLED.h and a FileContent."""
+    checker = PublicSettingsPatternChecker.__new__(PublicSettingsPatternChecker)
+    checker.violations = {}
+    checker._fastled_h_content = fastled_h
+    lines = code.splitlines()
+    fc = FileContent(path=path, content=code, lines=lines)
+    return checker, fc
+
+
+def _violations(
+    code: str,
+    path: str = _FL_PATH,
+    fastled_h: str = "",
+) -> list[tuple[int, str]]:
+    """Run the checker on *code* and return violations for *path*."""
+    checker, fc = _make(code, path, fastled_h)
+    if not checker.should_process_file(path):
+        return []
+    checker.check_file_content(fc)
+    return checker.violations.get(path, [])
+
+
+# ---------------------------------------------------------------------------
+# File filtering
+# ---------------------------------------------------------------------------
+
+
+class TestShouldProcessFile(unittest.TestCase):
+    def _checker(self) -> PublicSettingsPatternChecker:
+        c = PublicSettingsPatternChecker.__new__(PublicSettingsPatternChecker)
+        c.violations = {}
+        c._fastled_h_content = ""
+        return c
+
+    def test_fl_header_accepted(self) -> None:
+        c = self._checker()
+        self.assertTrue(c.should_process_file("src/fl/config/module.h"))
+
+    def test_fl_header_absolute_accepted(self) -> None:
+        c = self._checker()
+        self.assertTrue(c.should_process_file("C:/dev/fastled/src/fl/gfx/rgbw.h"))
+
+    def test_third_party_rejected(self) -> None:
+        c = self._checker()
+        self.assertFalse(c.should_process_file("src/fl/third_party/some_lib.h"))
+
+    def test_non_fl_src_rejected(self) -> None:
+        c = self._checker()
+        self.assertFalse(c.should_process_file("src/platforms/esp32/driver.h"))
+
+    def test_tests_directory_rejected(self) -> None:
+        c = self._checker()
+        self.assertFalse(c.should_process_file("tests/fl/test_module.cpp"))
+
+    def test_cpp_file_rejected(self) -> None:
+        c = self._checker()
+        self.assertFalse(c.should_process_file("src/fl/module.cpp"))
+
+    def test_cpp_hpp_rejected(self) -> None:
+        c = self._checker()
+        self.assertFalse(c.should_process_file("src/fl/module.cpp.hpp"))
+
+    def test_hpp_file_rejected(self) -> None:
+        # Only .h files are checked — .hpp is excluded
+        c = self._checker()
+        self.assertFalse(c.should_process_file("src/fl/module.hpp"))
+
+    def test_windows_backslash_paths_accepted(self) -> None:
+        c = self._checker()
+        self.assertTrue(c.should_process_file("C:\\dev\\fastled\\src\\fl\\module.h"))
+
+
+# ---------------------------------------------------------------------------
+# Positive cases — SHOULD flag
+# ---------------------------------------------------------------------------
+
+
+class TestShouldFlag(unittest.TestCase):
+    """Functions that must be reported as violations."""
+
+    def test_simple_global_setter_no_wrapper(self) -> None:
+        code = "namespace fl {\nvoid set_my_option(int val);\n}"
+        v = _violations(code)
+        self.assertEqual(len(v), 1)
+        self.assertIn("set_my_option", v[0][1])
+        self.assertEqual(v[0][0], 2)  # line 2
+
+    def test_enable_global_no_wrapper(self) -> None:
+        code = "namespace fl {\nbool enable_some_feature(int level);\n}"
+        v = _violations(code)
+        self.assertEqual(len(v), 1)
+        self.assertIn("enable_some_feature", v[0][1])
+
+    def test_disable_global_no_wrapper(self) -> None:
+        code = "namespace fl {\nvoid disable_some_feature();\n}"
+        v = _violations(code)
+        self.assertEqual(len(v), 1)
+        self.assertIn("disable_some_feature", v[0][1])
+
+    def test_use_global_no_wrapper(self) -> None:
+        code = "namespace fl {\nvoid use_new_algorithm(bool on);\n}"
+        v = _violations(code)
+        self.assertEqual(len(v), 1)
+        self.assertIn("use_new_algorithm", v[0][1])
+
+    def test_violation_message_suggests_wrapper_name(self) -> None:
+        code = "namespace fl {\nvoid set_my_option(int val);\n}"
+        v = _violations(code)
+        # Message must name both the free function and the camelCase wrapper
+        self.assertIn("setMyOption", v[0][1])
+        self.assertIn("CFastLED", v[0][1])
+
+    def test_multiple_violations_in_one_file(self) -> None:
+        code = (
+            "namespace fl {\nvoid set_option_a(int x);\nbool enable_mode_b(bool y);\n}"
+        )
+        v = _violations(code)
+        self.assertEqual(len(v), 2)
+
+    def test_fl_noexcept_decorated_setter_flagged(self) -> None:
+        """FL_NOEXCEPT attribute must not suppress the violation."""
+        code = "namespace fl {\nvoid set_bright(int v) FL_NOEXCEPT;\n}"
+        v = _violations(code)
+        self.assertEqual(len(v), 1)
+
+    def test_setter_with_const_ref_param_flagged(self) -> None:
+        """const ref first param is read-only — not per-object; should flag."""
+        code = "namespace fl {\nvoid set_model(const PowerModel& m);\n}"
+        v = _violations(code)
+        self.assertEqual(len(v), 1)
+
+    def test_no_params_setter_flagged(self) -> None:
+        """Zero-param setter that disables something — global state."""
+        code = "namespace fl {\nvoid disable_feature();\n}"
+        v = _violations(code)
+        self.assertEqual(len(v), 1)
+
+
+# ---------------------------------------------------------------------------
+# Negative cases — must NOT flag
+# ---------------------------------------------------------------------------
+
+
+class TestShouldNotFlag(unittest.TestCase):
+    """Patterns that must not produce any violations."""
+
+    def test_function_not_matching_pattern_skipped(self) -> None:
+        code = "namespace fl {\nvoid do_something(int v);\n}"
+        self.assertEqual(len(_violations(code)), 0)
+
+    def test_class_member_setter_skipped(self) -> None:
+        """Methods on a class/struct are per-object, not global."""
+        code = "namespace fl {\nstruct Foo {\n    void set_color(int c);\n};\n}"
+        self.assertEqual(len(_violations(code)), 0)
+
+    def test_getter_not_flagged(self) -> None:
+        code = "namespace fl {\nint get_brightness();\n}"
+        self.assertEqual(len(_violations(code)), 0)
+
+    def test_sub_namespace_depth_not_flagged(self) -> None:
+        """Functions inside fl::detail:: must be ignored."""
+        code = "namespace fl {\nnamespace detail {\nvoid set_internal(int x);\n}\n}"
+        self.assertEqual(len(_violations(code)), 0)
+
+    def test_anonymous_namespace_not_flagged(self) -> None:
+        """Functions inside anonymous namespaces are file-local."""
+        code = "namespace fl {\nnamespace {\nvoid set_hidden(int x);\n}\n}"
+        self.assertEqual(len(_violations(code)), 0)
+
+    def test_no_namespace_context_not_flagged(self) -> None:
+        """Free functions not inside namespace fl are skipped."""
+        code = "void set_something(int v);\n"
+        self.assertEqual(len(_violations(code)), 0)
+
+    def test_wrapper_in_fastled_h_suppresses_violation(self) -> None:
+        """Function referenced in FastLED.h must not be flagged."""
+        fake_fastled_h = (
+            "class CFastLED {\n"
+            "    inline void setSomething(int v) { fl::set_something(v); }\n"
+            "};\n"
+        )
+        code = "namespace fl {\nvoid set_something(int val);\n}"
+        self.assertEqual(len(_violations(code, fastled_h=fake_fastled_h)), 0)
+
+    def test_enum_body_does_not_confuse_scope(self) -> None:
+        """An enum class inside namespace fl must not break scope tracking."""
+        code = (
+            "namespace fl {\n"
+            "enum class Mode { kA, kB };\n"
+            "void set_something(int v);\n"  # still in namespace fl, should flag
+            "}"
+        )
+        v = _violations(code)
+        self.assertEqual(len(v), 1)
+        self.assertIn("set_something", v[0][1])
+
+    def test_plain_enum_body_does_not_confuse_scope(self) -> None:
+        """A plain `enum { }` must not pop the fl namespace prematurely."""
+        code = (
+            "namespace fl {\n"
+            "enum { kFoo = 0, kBar = 1 };\n"
+            "void set_brightness(int v);\n"  # still in fl, should flag
+            "}"
+        )
+        v = _violations(code)
+        self.assertEqual(len(v), 1)
+        self.assertIn("set_brightness", v[0][1])
+
+    def test_function_body_inline_does_not_confuse_scope(self) -> None:
+        """An inline function definition must not interfere with ns tracking."""
+        code = (
+            "namespace fl {\n"
+            "inline void helper() { do_work(); }\n"
+            "void set_brightness(int v);\n"  # still in fl
+            "}"
+        )
+        v = _violations(code)
+        self.assertEqual(len(v), 1)
+
+    def test_nested_sub_namespace_with_return_to_fl(self) -> None:
+        """After a sub-namespace closes, we should be back in fl scope."""
+        code = (
+            "namespace fl {\n"
+            "namespace isr {\n"
+            "void set_isr_mode(int x);\n"  # in fl::isr — NOT flagged
+            "}\n"
+            "void set_global_thing(int y);\n"  # back in fl — FLAGGED
+            "}"
+        )
+        v = _violations(code)
+        self.assertEqual(len(v), 1)
+        self.assertIn("set_global_thing", v[0][1])
+
+    def test_empty_file(self) -> None:
+        self.assertEqual(len(_violations("")), 0)
+
+    def test_file_without_setter_keywords(self) -> None:
+        code = "namespace fl {\nvoid do_work();\n}"
+        self.assertEqual(len(_violations(code)), 0)
+
+
+# ---------------------------------------------------------------------------
+# Grandfathered allowlist
+# ---------------------------------------------------------------------------
+
+
+class TestGrandfatheredAllowlist(unittest.TestCase):
+    def test_set_rgbw_colorimetric_profile_not_flagged(self) -> None:
+        code = (
+            "namespace fl {\n"
+            "void set_rgbw_colorimetric_profile(const DiodeProfile* p) FL_NOEXCEPT;\n"
+            "}"
+        )
+        self.assertEqual(len(_violations(code)), 0)
+
+    def test_set_input_gamut_not_flagged(self) -> None:
+        code = (
+            "namespace fl {\n"
+            "void set_input_gamut(DiodeProfile* p, InputGamut g) FL_NOEXCEPT;\n"
+            "}"
+        )
+        self.assertEqual(len(_violations(code)), 0)
+
+    def test_enable_rgbw_colorimetric_lut_not_flagged(self) -> None:
+        code = (
+            "namespace fl {\n"
+            "bool enable_rgbw_colorimetric_lut(int grid_n) FL_NOEXCEPT;\n"
+            "}"
+        )
+        self.assertEqual(len(_violations(code)), 0)
+
+    def test_disable_rgbw_colorimetric_lut_not_flagged(self) -> None:
+        code = "namespace fl {\nvoid disable_rgbw_colorimetric_lut() FL_NOEXCEPT;\n}"
+        self.assertEqual(len(_violations(code)), 0)
+
+    def test_set_rgbww_colorimetric_profile_not_flagged(self) -> None:
+        code = (
+            "namespace fl {\n"
+            "void set_rgbww_colorimetric_profile(const RgbcctProfile* p) FL_NOEXCEPT;\n"
+            "}"
+        )
+        self.assertEqual(len(_violations(code)), 0)
+
+    def test_allowlist_frozenset_contains_expected_names(self) -> None:
+        """Sanity-check the allowlist has the expected names."""
+        self.assertIn("set_rgbw_colorimetric_profile", GRANDFATHERED_NAMES)
+        self.assertIn("set_input_gamut", GRANDFATHERED_NAMES)
+        self.assertIn("enable_rgbw_colorimetric_lut", GRANDFATHERED_NAMES)
+        self.assertIn("disable_rgbw_colorimetric_lut", GRANDFATHERED_NAMES)
+        self.assertIn("set_rgbww_colorimetric_profile", GRANDFATHERED_NAMES)
+
+
+# ---------------------------------------------------------------------------
+# Per-object setter carve-outs
+# ---------------------------------------------------------------------------
+
+
+class TestPerObjectSetterCarveout(unittest.TestCase):
+    """_is_per_object_setter() and the checker integration."""
+
+    def test_non_const_ptr_first_param_is_per_object(self) -> None:
+        # Non-const pointer to user type → per-object, not flagged
+        line = "void set_input_gamut(DiodeProfile* obj, InputGamut g);"
+        self.assertTrue(_is_per_object_setter(line))
+
+    def test_const_ref_first_param_is_not_per_object(self) -> None:
+        # const ref → read-only → global setter candidate
+        line = "void set_power_model(const PowerModel& m);"
+        self.assertFalse(_is_per_object_setter(line))
+
+    def test_fundamental_int_first_param_not_per_object(self) -> None:
+        line = "bool enable_lut(int grid_n);"
+        self.assertFalse(_is_per_object_setter(line))
+
+    def test_no_params_not_per_object(self) -> None:
+        line = "void disable_lut();"
+        self.assertFalse(_is_per_object_setter(line))
+
+    def test_non_const_ref_user_type_is_per_object(self) -> None:
+        line = "void set_color(CRGB& out, int r, int g, int b);"
+        self.assertTrue(_is_per_object_setter(line))
+
+    def test_per_object_not_flagged_by_checker(self) -> None:
+        """A non-const ptr first param must NOT produce a violation."""
+        code = "namespace fl {\nvoid set_diode(DiodeProfile* p, int v);\n}"
+        self.assertEqual(len(_violations(code)), 0)
+
+
+# ---------------------------------------------------------------------------
+# Function-pointer setter carve-outs
+# ---------------------------------------------------------------------------
+
+
+class TestFunctionPointerCarveout(unittest.TestCase):
+    def test_set_rgb_2_rgbw_function_not_flagged(self) -> None:
+        code = (
+            "namespace fl {\n"
+            "void set_rgb_2_rgbw_function(rgb_2_rgbw_function func) FL_NOEXCEPT;\n"
+            "}"
+        )
+        self.assertEqual(len(_violations(code)), 0)
+
+    def test_set_rgb_2_rgbww_function_not_flagged(self) -> None:
+        code = (
+            "namespace fl {\n"
+            "void set_rgb_2_rgbww_function(rgb_2_rgbww_function func) FL_NOEXCEPT;\n"
+            "}"
+        )
+        self.assertEqual(len(_violations(code)), 0)
+
+
+# ---------------------------------------------------------------------------
+# Comment exemptions
+# ---------------------------------------------------------------------------
+
+
+class TestCommentExemptions(unittest.TestCase):
+    def test_single_line_comment_ignored(self) -> None:
+        code = "namespace fl {\n// void set_my_option(int val);\n}"
+        self.assertEqual(len(_violations(code)), 0)
+
+    def test_multiline_comment_block_ignored(self) -> None:
+        code = "namespace fl {\n/*\n * void set_my_option(int val);\n */\n}"
+        self.assertEqual(len(_violations(code)), 0)
+
+    def test_inline_comment_does_not_suppress(self) -> None:
+        """The setter is in code; comment appended after — still flagged."""
+        code = "namespace fl {\nvoid set_my_option(int val); // some note\n}"
+        self.assertEqual(len(_violations(code)), 1)
+
+
+# ---------------------------------------------------------------------------
+# Suppression tokens
+# ---------------------------------------------------------------------------
+
+
+class TestSuppressionTokens(unittest.TestCase):
+    def test_nolint_suppresses(self) -> None:
+        code = "namespace fl {\nvoid set_my_option(int val); // nolint\n}"
+        self.assertEqual(len(_violations(code)), 0)
+
+    def test_ok_public_settings_suppresses(self) -> None:
+        code = "namespace fl {\nvoid set_my_option(int val); // ok public_settings\n}"
+        self.assertEqual(len(_violations(code)), 0)
+
+    def test_suppression_case_insensitive(self) -> None:
+        code = "namespace fl {\nvoid set_my_option(int val); // NOLINT\n}"
+        self.assertEqual(len(_violations(code)), 0)
+
+    def test_suppression_does_not_bleed_to_next_line(self) -> None:
+        code = (
+            "namespace fl {\n"
+            "void set_option_a(int v); // nolint\n"
+            "void set_option_b(int v);\n"
+            "}"
+        )
+        v = _violations(code)
+        self.assertEqual(len(v), 1)
+        self.assertIn("set_option_b", v[0][1])
+
+
+# ---------------------------------------------------------------------------
+# Cross-file wrapper check (_is_wrapped_in_fastled_h)
+# ---------------------------------------------------------------------------
+
+
+class TestCrossFileWrapperCheck(unittest.TestCase):
+    def test_function_in_fastled_h_body_passes(self) -> None:
+        fastled_h = (
+            "class CFastLED {\n"
+            "    inline void setThing(int v) { fl::set_thing(v); }\n"
+            "};\n"
+        )
+        self.assertTrue(_is_wrapped_in_fastled_h("set_thing", fastled_h))
+
+    def test_function_only_in_include_comment_not_wrapped(self) -> None:
+        """#include lines must not count as wrappers."""
+        fastled_h = '#include "fl/thing.h"  // set_thing declared here\n'
+        self.assertFalse(_is_wrapped_in_fastled_h("set_thing", fastled_h))
+
+    def test_function_name_in_comment_not_wrapped(self) -> None:
+        fastled_h = "// call set_thing to configure\n"
+        self.assertFalse(_is_wrapped_in_fastled_h("set_thing", fastled_h))
+
+    def test_empty_fastled_h_not_wrapped(self) -> None:
+        self.assertFalse(_is_wrapped_in_fastled_h("set_thing", ""))
+
+    def test_partial_name_not_matched(self) -> None:
+        fastled_h = "fl::set_thingamajig(v);\n"
+        self.assertFalse(_is_wrapped_in_fastled_h("set_thing", fastled_h))
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases(unittest.TestCase):
+    def test_multiple_namespaces_on_one_line(self) -> None:
+        """namespace fl { namespace detail { on one line is a sub-namespace."""
+        code = "namespace fl { namespace detail {\nvoid set_internal(int x);\n}}\n"
+        # set_internal is in fl::detail — must NOT be flagged
+        self.assertEqual(len(_violations(code)), 0)
+
+    def test_forward_struct_decl_not_class_body(self) -> None:
+        """struct Foo; (forward decl) must not push a class scope."""
+        code = "namespace fl {\nstruct PowerModel;\nvoid set_model(int v);\n}"
+        v = _violations(code)
+        self.assertEqual(len(v), 1)
+
+    def test_class_with_inline_body_resets_after_close(self) -> None:
+        """After a class body closes we should be back at fl scope."""
+        code = (
+            "namespace fl {\n"
+            "struct Cfg {\n"
+            "    void set_pin(int p);\n"  # inside class — NOT flagged
+            "};\n"
+            "void set_global_setting(int v);\n"  # back in fl — FLAGGED
+            "}"
+        )
+        v = _violations(code)
+        self.assertEqual(len(v), 1)
+        self.assertIn("set_global_setting", v[0][1])
+
+    def test_line_number_in_violation(self) -> None:
+        code = "// header\nnamespace fl {\n\nvoid set_my_thing(int v);\n}"
+        v = _violations(code)
+        self.assertEqual(len(v), 1)
+        self.assertEqual(v[0][0], 4)  # declaration is on line 4
+
+    def test_real_rgbww_header_shape(self) -> None:
+        """Simulate rgbww.h: forward-decl sub-ns then fl:: free functions."""
+        code = (
+            "namespace fl {\n"
+            "namespace colorimetric_detail {\n"
+            "struct RgbcctProfile;\n"
+            "}\n"
+            "enum class RGBWW_MODE : int { kA, kB };\n"
+            "enum { kDefaultCct = 2700 };\n"
+            "struct Rgbww { int warm; };\n"
+            "void set_rgb_2_rgbww_function(rgb_2_rgbww_function func);\n"  # FP setter
+            "void set_rgbww_colorimetric_profile(const RgbcctProfile* p);\n"  # allowlist
+            "}"
+        )
+        # Both should be exempted: one via FUNCTION_POINTER_SETTERS, one via allowlist
+        v = _violations(code)
+        self.assertEqual(len(v), 0)
+
+    def test_real_rgbw_header_shape(self) -> None:
+        """Simulate rgbw.h: grandfathered setters inside namespace fl."""
+        code = (
+            "namespace fl {\n"
+            "void set_rgbw_colorimetric_profile(const DiodeProfile* p) FL_NOEXCEPT;\n"
+            "bool enable_rgbw_colorimetric_lut(int grid_n) FL_NOEXCEPT;\n"
+            "void disable_rgbw_colorimetric_lut() FL_NOEXCEPT;\n"
+            "void set_rgb_2_rgbw_function(rgb_2_rgbw_function func) FL_NOEXCEPT;\n"
+            "}"
+        )
+        v = _violations(code)
+        self.assertEqual(len(v), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Adds `ci/lint_cpp/public_settings_pattern_checker.py` — a new `FileContentChecker` that enforces the **Public Settings Pattern** documented in `agents/docs/cpp-standards.md` → "Public Settings Pattern (Global Configuration via `CFastLED`)"
- Registers it in the `fl` scope in `ci/lint_cpp/run_all_checkers.py` so it runs automatically via `bash lint --cpp`
- 63 unit tests in `ci/lint_cpp/test_public_settings_pattern_checker.py`; all pass; `bash lint --cpp` exits clean

This is **layer 5** of the six-layer enforcement plan introduced in PR #2715 (docs, CodeRabbit, architecture-reviewer-agent, /code_review skill, backfill wrappers, **syntactic check ← this PR**).

## What it flags

Every public free function in `src/fl/**/*.h` matching `^(set|enable|disable|use)_[a-z]` that is declared at `namespace fl` root scope and has **no** corresponding call-site in `src/FastLED.h` (i.e. no `CFastLED` wrapper method that delegates to it).

Violation message example:
```
fl::set_my_option(...) declared here is a public global setter but has no
CFastLED::setMyOption() wrapper in src/FastLED.h. New global setters must
follow the Public Settings Pattern — add an `inline` one-liner on CFastLED
that delegates to this free function. See exemplar at src/FastLED.h:1455
(setPowerModel -> fl::set_power_model).
```

Suppression: `// nolint` or `// ok public_settings` on the declaration line.

## Carve-outs (not flagged)

| Pattern | Reason |
|---------|--------|
| `fl::detail::*`, `fl::isr::*`, any sub-namespace | Not public `fl::` API |
| Anonymous `namespace { }` | File-local, not public |
| Class/struct member functions | Per-object, not global state |
| `set_rgb_2_rgbw_function`, `set_rgb_2_rgbww_function` | Function-pointer installers (explicit allowlist) |
| Non-const ptr/ref to user-defined type as first param | Per-object mutator heuristic |

## Grandfathered allowlist (seeded from PR #2715 description)

These predate the rule and are NOT flagged:
- `set_rgbw_colorimetric_profile` — wrapped in PR #2715; allowlist is defence-in-depth
- `set_input_gamut` — grandfathered; wrapper planned
- `enable_rgbw_colorimetric_lut` — added in #2545; wrapper planned
- `disable_rgbw_colorimetric_lut` — added in #2545; wrapper planned
- `set_rgbww_colorimetric_profile` — added in #2558; wrapper planned

## Implementation notes

The scope tracker uses a **per-`{` scope stack** (not a simple brace depth counter). This correctly handles enum bodies, inline function definitions, and nested namespaces without false namespace pops — a bug that would occur with the naive counter approach (verified by tracing `src/fl/gfx/rgbww.h` where `enum { kDefaultCct = 2700 }` closes before `set_rgbww_colorimetric_profile` is declared).

`src/FastLED.h` is loaded once at checker `__init__` time; the wrapper lookup is a word-boundary regex scan that skips `#include` lines and pure comment lines.

## Test plan

- [x] 63 unit tests covering: file filtering, positive violations, negative carve-outs, grandfathered allowlist, per-object heuristic, function-pointer carve-out, comment exemptions, suppression tokens, cross-file wrapper check, edge cases (enum bodies, inline functions, nested namespaces, scope recovery after sub-namespace closes)
- [x] `bash lint --cpp` passes clean on the full codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)