### PR TITLE
fix(lint): wrap freertos system headers in IWYU pragma block

### DIFF
--- a/src/platforms/esp/32/drivers/lcd_spi/channel_driver_lcd_clockless.cpp.hpp
+++ b/src/platforms/esp/32/drivers/lcd_spi/channel_driver_lcd_clockless.cpp.hpp
@@ -34,8 +34,10 @@
 #include "platforms/memory_barrier.h"
 
 #if defined(FL_IS_ESP32) && !defined(FASTLED_STUB_IMPL)
+// IWYU pragma: begin_keep
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
+// IWYU pragma: end_keep
 #endif
 
 // Include ESP peripheral for factory function


### PR DESCRIPTION
## Summary

- `IwyuPragmaBlockChecker` was flagging two unwrapped system includes in `src/platforms/esp/32/drivers/lcd_spi/channel_driver_lcd_clockless.cpp.hpp` (introduced by a recent LCD/clockless update on master)
- Added `// IWYU pragma: begin_keep` / `end_keep` around the `freertos/FreeRTOS.h` + `freertos/task.h` pair inside the existing `#if defined(FL_IS_ESP32) && !defined(FASTLED_STUB_IMPL)` guard
- No change to the include set or behavior — just silences the linter

## Test plan

- [x] `bash lint` clean
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal build configuration improvement to ensure proper header management during compilation. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->