### PR TITLE
feat(rgbw): expose LutInterp choice + LUT memory accessor + error-floor tests

### DIFF
--- a/src/fl/gfx/rgbw.cpp.hpp
+++ b/src/fl/gfx/rgbw.cpp.hpp
@@ -328,19 +328,31 @@ struct LutStateHolder {
     const DiodeProfile* built_for = nullptr;
     int built_cct = 0;
     int requested_grid_n = 0;
+    RgbwLutInterp requested_interp = RgbwLutInterp::Hermite;
     bool enabled = false;
 };
+
+inline colorimetric_detail::LutInterp to_internal_interp(
+    RgbwLutInterp i) FL_NOEXCEPT {
+    return (i == RgbwLutInterp::Hermite)
+        ? colorimetric_detail::LutInterp::Hermite
+        : colorimetric_detail::LutInterp::Bilinear;
+}
 
 inline void rebuild_lut_if_stale(LutStateHolder& s, int cct) FL_NOEXCEPT {
     if (!s.enabled || s.requested_grid_n <= 0) return;
     const DiodeProfile* active = get_rgbw_colorimetric_profile();
     const int override_cct = resolve_cct_override(active, cct);
+    const colorimetric_detail::LutInterp interp =
+        to_internal_interp(s.requested_interp);
     if (s.table && s.built_for == active && s.built_cct == override_cct
-        && s.table->N == s.requested_grid_n) {
+        && s.table->N == s.requested_grid_n
+        && s.table->interp == interp) {
         return;  // up-to-date
     }
     s.table = fl::make_unique<colorimetric_detail::LutTable>(
-        colorimetric_detail::build_lut(get_cache(cct), s.requested_grid_n));
+        colorimetric_detail::build_lut(get_cache(cct), s.requested_grid_n,
+                                       interp));
     s.built_for = active;
     s.built_cct = override_cct;
 }
@@ -450,16 +462,22 @@ void rgb_2_rgbw_colorimetric_boosted(u16 w_color_temperature, u8 r,
     *out_w = colorimetric_detail::quantize_u8(rgbw[3]);
 }
 
-bool enable_rgbw_colorimetric_lut(int grid_n) FL_NOEXCEPT {
+bool enable_rgbw_colorimetric_lut(int grid_n,
+                                  RgbwLutInterp interp) FL_NOEXCEPT {
     if (grid_n < 4) grid_n = 4;
     if (grid_n > 256) grid_n = 256;
     LutStateHolder& s = fl::Singleton<LutStateHolder>::instance();
     s.enabled = true;
     s.requested_grid_n = grid_n;
+    s.requested_interp = interp;
     // Force a rebuild on next colorimetric call.
     s.built_for = nullptr;
     s.built_cct = -1;
     return true;
+}
+
+bool enable_rgbw_colorimetric_lut(int grid_n) FL_NOEXCEPT {
+    return enable_rgbw_colorimetric_lut(grid_n, RgbwLutInterp::Hermite);
 }
 
 void disable_rgbw_colorimetric_lut() FL_NOEXCEPT {
@@ -467,6 +485,7 @@ void disable_rgbw_colorimetric_lut() FL_NOEXCEPT {
     s.enabled = false;
     s.table.reset();  // unique_ptr destructor frees the cells storage
     s.requested_grid_n = 0;
+    s.requested_interp = RgbwLutInterp::Hermite;
     s.built_for = nullptr;
     s.built_cct = 0;
 }
@@ -484,6 +503,10 @@ bool rgbw_colorimetric_lut_enabled() FL_NOEXCEPT {
 namespace { void invalidate_colorimetric_caches_for(const DiodeProfile*) FL_NOEXCEPT {} }
 
 // Stub APIs for the LUT/CCT/RGBCCT path — no-ops when colorimetric is off.
+bool enable_rgbw_colorimetric_lut(int /*grid_n*/,
+                                  RgbwLutInterp /*interp*/) FL_NOEXCEPT {
+    return false;
+}
 bool enable_rgbw_colorimetric_lut(int /*grid_n*/) FL_NOEXCEPT { return false; }
 void disable_rgbw_colorimetric_lut() FL_NOEXCEPT {}
 bool rgbw_colorimetric_lut_enabled() FL_NOEXCEPT { return false; }

--- a/src/fl/gfx/rgbw.h
+++ b/src/fl/gfx/rgbw.h
@@ -113,14 +113,35 @@ void set_rgbw_colorimetric_profile(const DiodeProfile* profile) FL_NOEXCEPT;
 // Currently active profile (defaults to &kRgbwDefaultProfile).
 const DiodeProfile* get_rgbw_colorimetric_profile() FL_NOEXCEPT;
 
+// Interpolation scheme used by the colorimetric LUT (#2720). Bilinear stores
+// 4 channel values per grid cell (8 B/cell at i16 quantization) — cheapest in
+// flash/RAM. Hermite additionally stores ∂/∂t_x and ∂/∂t_y per channel
+// (24 B/cell, 3x storage) and reaches lower error at the same grid size,
+// enabling small grids (N=8..16) on memory-constrained targets.
+enum class RgbwLutInterp : u8 {
+    Bilinear = 0,
+    Hermite = 1,
+};
+
 // Enable the 2D + 1D factored LUT path (issue #2545 Phase 2). When enabled,
-// the colorimetric modes use a bilinear-interpolated LUT instead of solving
-// per pixel. Available whenever FASTLED_RGBW_COLORIMETRIC=1 — no separate
+// the colorimetric modes use an interpolated LUT instead of solving per pixel.
+// Available whenever FASTLED_RGBW_COLORIMETRIC=1 — no separate
 // FASTLED_RGBW_COLORIMETRIC_LUT flag exists; gc-sections drops the LUT path
-// for sketches that never call this. `grid_n` controls the LUT edge length
-// (8 KB at N=32, ~2 KB at N=16, ~32 KB at N=64). LUT is rebuilt whenever
-// the active profile or CCT changes. Returns false on allocation failure
-// (or always false when FASTLED_RGBW_COLORIMETRIC is undefined).
+// for sketches that never call this. `grid_n` is clamped to [4, 256] and
+// controls the LUT edge length. LUT is rebuilt whenever the active profile,
+// CCT, grid size, or interp scheme changes. Returns false on allocation
+// failure (or always false when FASTLED_RGBW_COLORIMETRIC is undefined).
+//
+// Memory cost = grid_n * grid_n * (interp == Hermite ? 24 : 8) bytes:
+//   N=8   ->  Bilinear   512 B / Hermite  1 536 B
+//   N=16  ->  Bilinear 2 048 B / Hermite  6 144 B
+//   N=32  ->  Bilinear 8 192 B / Hermite 24 576 B
+//   N=64  ->  Bilinear 32 KB  / Hermite ~96 KB
+//
+// The single-arg overload preserves source compatibility and forwards to
+// RgbwLutInterp::Hermite (the historical default since #2707).
+bool enable_rgbw_colorimetric_lut(int grid_n,
+                                  RgbwLutInterp interp) FL_NOEXCEPT;
 bool enable_rgbw_colorimetric_lut(int grid_n) FL_NOEXCEPT;
 
 // Free the LUT and revert colorimetric calls to the closed-form solver.
@@ -128,6 +149,18 @@ void disable_rgbw_colorimetric_lut() FL_NOEXCEPT;
 
 // Returns true if the LUT path is currently active.
 bool rgbw_colorimetric_lut_enabled() FL_NOEXCEPT;
+
+// Compile-time memory-cost accessor. Mirrors the storage math used by the
+// LUT builder so users can size their RAM/flash budget before calling
+// enable_rgbw_colorimetric_lut(). Returns 0 for grid_n < 1.
+constexpr unsigned long rgbw_colorimetric_lut_memory_bytes(
+    int grid_n, RgbwLutInterp interp) FL_NOEXCEPT {
+    return (grid_n < 1)
+        ? 0UL
+        : static_cast<unsigned long>(grid_n)
+            * static_cast<unsigned long>(grid_n)
+            * (interp == RgbwLutInterp::Hermite ? 24UL : 8UL);
+}
 
 enum {
     kRGBWDefaultColorTemp = 6000,

--- a/src/fl/gfx/rgbw.h
+++ b/src/fl/gfx/rgbw.h
@@ -152,14 +152,18 @@ bool rgbw_colorimetric_lut_enabled() FL_NOEXCEPT;
 
 // Compile-time memory-cost accessor. Mirrors the storage math used by the
 // LUT builder so users can size their RAM/flash budget before calling
-// enable_rgbw_colorimetric_lut(). Returns 0 for grid_n < 1.
+// enable_rgbw_colorimetric_lut(). The runtime API clamps grid_n to [4, 256],
+// so this helper applies the same clamp so callers do not under-estimate
+// for grid_n < 4 or over-estimate for grid_n > 256. Returns 0 for grid_n < 1.
 constexpr unsigned long rgbw_colorimetric_lut_memory_bytes(
     int grid_n, RgbwLutInterp interp) FL_NOEXCEPT {
     return (grid_n < 1)
         ? 0UL
-        : static_cast<unsigned long>(grid_n)
-            * static_cast<unsigned long>(grid_n)
-            * (interp == RgbwLutInterp::Hermite ? 24UL : 8UL);
+        : (static_cast<unsigned long>(
+                  grid_n < 4 ? 4 : (grid_n > 256 ? 256 : grid_n))
+            * static_cast<unsigned long>(
+                  grid_n < 4 ? 4 : (grid_n > 256 ? 256 : grid_n))
+            * (interp == RgbwLutInterp::Hermite ? 24UL : 8UL));
 }
 
 enum {

--- a/src/platforms/esp/32/drivers/lcd_spi/channel_driver_lcd_clockless.cpp.hpp
+++ b/src/platforms/esp/32/drivers/lcd_spi/channel_driver_lcd_clockless.cpp.hpp
@@ -34,8 +34,10 @@
 #include "platforms/memory_barrier.h"
 
 #if defined(FL_IS_ESP32) && !defined(FASTLED_STUB_IMPL)
+// IWYU pragma: begin_keep
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
+// IWYU pragma: end_keep
 #endif
 
 // Include ESP peripheral for factory function

--- a/tests/fl/gfx/rgbw_colorimetric.cpp
+++ b/tests/fl/gfx/rgbw_colorimetric.cpp
@@ -1019,15 +1019,20 @@ struct Sample {
 };
 
 inline int sample_sweep(Sample* out) {
+    // Map step v in [0,6] to a u8 in [15, 255] without overflow.
+    // Sequence: {15, 55, 95, 135, 175, 215, 255}.
+    auto bucket = [](int v) -> u8 {
+        return static_cast<u8>(15 + (240 * v) / 6);
+    };
     int n = 0;
     for (int r = 0; r <= 6; ++r) {
         for (int g = 0; g <= 6; ++g) {
             for (int b = 0; b <= 6; ++b) {
                 if ((r | g | b) == 0) continue;
                 Sample& s = out[n++];
-                s.r = static_cast<u8>(r * 42 + 15);  // {15,57,99,141,183,225,255-ish}
-                s.g = static_cast<u8>(g * 42 + 15);
-                s.b = static_cast<u8>(b * 42 + 15);
+                s.r = bucket(r);
+                s.g = bucket(g);
+                s.b = bucket(b);
             }
         }
     }

--- a/tests/fl/gfx/rgbw_colorimetric.cpp
+++ b/tests/fl/gfx/rgbw_colorimetric.cpp
@@ -20,6 +20,7 @@
 
 #include "fl/gfx/rgbw.h"
 #include "fl/gfx/rgbw_colorimetric.h"
+#include "fl/stl/static_assert.h"
 
 using namespace fl;
 using namespace fl::colorimetric_detail;
@@ -979,4 +980,169 @@ FL_TEST_CASE("out-of-hull sRGB blue: FastLED projects to match reference (#2708)
         const int d = abs_diff(fl_q[k], ref_q[k]);
         FL_CHECK(d <= 1);
     }
+}
+
+
+// ===== LUT error-floor regression tests (#2720) =============================
+// Asserts a maximum per-channel byte-delta between the LUT path and the
+// closed-form solver across a chromaticity sweep, at each (interp, grid_n)
+// combination. Catches regressions in build_lut / lookup_lut that would
+// inflate interpolation error without breaking other tests.
+//
+// Thresholds are intentionally generous against current behavior — measured
+// max deltas leave room (typically 2-3x) so the tests don't flap on minor
+// numerical adjustments to the solver, but tighten the moment something
+// goes seriously wrong (wrong basis, wrong stride, sign-flipped slope,
+// off-by-one cell indexing, lost quantization precision).
+//
+// `lut_max_delta_vs_closed_form` is the helper everything else builds on;
+// it returns the worst per-channel delta over a fixed 7x7x7 RGB sweep
+// (excluding pure black). Callers pick the (interp, grid_n) tuple and
+// the budget.
+
+namespace lut_error_floor {
+
+// Detect whether the library was built with FASTLED_RGBW_COLORIMETRIC.
+// enable_rgbw_colorimetric_lut returns false in the stub build.
+inline bool colorimetric_linked() {
+    const bool ok = enable_rgbw_colorimetric_lut(8);
+    disable_rgbw_colorimetric_lut();
+    return ok;
+}
+
+// 7^3 - 1 = 342 in-gamut samples. Skips (0,0,0) since both paths short-circuit
+// to (0,0,0,0) without touching the solver.
+struct Sample {
+    u8 r, g, b;
+    u8 closed_form[4];
+    u8 lut_path[4];
+};
+
+inline int sample_sweep(Sample* out) {
+    int n = 0;
+    for (int r = 0; r <= 6; ++r) {
+        for (int g = 0; g <= 6; ++g) {
+            for (int b = 0; b <= 6; ++b) {
+                if ((r | g | b) == 0) continue;
+                Sample& s = out[n++];
+                s.r = static_cast<u8>(r * 42 + 15);  // {15,57,99,141,183,225,255-ish}
+                s.g = static_cast<u8>(g * 42 + 15);
+                s.b = static_cast<u8>(b * 42 + 15);
+            }
+        }
+    }
+    return n;
+}
+
+inline int lut_max_delta_vs_closed_form(RgbwLutInterp interp, int grid_n) {
+    static Sample samples[343];
+    const int n = sample_sweep(samples);
+
+    // Pass 1: closed-form path (LUT disabled — dispatch falls through to
+    // solve_strict_subgamut).
+    disable_rgbw_colorimetric_lut();
+    for (int i = 0; i < n; ++i) {
+        rgb_2_rgbw(RGBW_MODE::kRGBWColorimetric, kRGBWDefaultColorTemp,
+                   samples[i].r, samples[i].g, samples[i].b, 255, 255, 255,
+                   &samples[i].closed_form[0], &samples[i].closed_form[1],
+                   &samples[i].closed_form[2], &samples[i].closed_form[3]);
+    }
+
+    // Pass 2: LUT path at the requested (interp, grid_n).
+    const bool ok = enable_rgbw_colorimetric_lut(grid_n, interp);
+    FL_CHECK(ok);
+    for (int i = 0; i < n; ++i) {
+        rgb_2_rgbw(RGBW_MODE::kRGBWColorimetric, kRGBWDefaultColorTemp,
+                   samples[i].r, samples[i].g, samples[i].b, 255, 255, 255,
+                   &samples[i].lut_path[0], &samples[i].lut_path[1],
+                   &samples[i].lut_path[2], &samples[i].lut_path[3]);
+    }
+    disable_rgbw_colorimetric_lut();
+
+    int max_delta = 0;
+    for (int i = 0; i < n; ++i) {
+        for (int k = 0; k < 4; ++k) {
+            const int a = samples[i].closed_form[k];
+            const int b = samples[i].lut_path[k];
+            const int d = a > b ? a - b : b - a;
+            if (d > max_delta) max_delta = d;
+        }
+    }
+    return max_delta;
+}
+
+} // namespace lut_error_floor
+
+
+FL_TEST_CASE("LUT memory accessor matches stride math") {
+    FL_STATIC_ASSERT(rgbw_colorimetric_lut_memory_bytes(8, RgbwLutInterp::Bilinear) == 512UL, "bilinear N=8");
+    FL_STATIC_ASSERT(rgbw_colorimetric_lut_memory_bytes(8, RgbwLutInterp::Hermite) == 1536UL, "hermite N=8");
+    FL_STATIC_ASSERT(rgbw_colorimetric_lut_memory_bytes(16, RgbwLutInterp::Bilinear) == 2048UL, "bilinear N=16");
+    FL_STATIC_ASSERT(rgbw_colorimetric_lut_memory_bytes(16, RgbwLutInterp::Hermite) == 6144UL, "hermite N=16");
+    FL_STATIC_ASSERT(rgbw_colorimetric_lut_memory_bytes(32, RgbwLutInterp::Bilinear) == 8192UL, "bilinear N=32");
+    FL_STATIC_ASSERT(rgbw_colorimetric_lut_memory_bytes(32, RgbwLutInterp::Hermite) == 24576UL, "hermite N=32");
+    FL_STATIC_ASSERT(rgbw_colorimetric_lut_memory_bytes(64, RgbwLutInterp::Bilinear) == 32768UL, "bilinear N=64");
+    FL_STATIC_ASSERT(rgbw_colorimetric_lut_memory_bytes(64, RgbwLutInterp::Hermite) == 98304UL, "hermite N=64");
+    // Degenerate input: 0 grid_n -> 0 bytes (no allocation).
+    FL_STATIC_ASSERT(rgbw_colorimetric_lut_memory_bytes(0, RgbwLutInterp::Hermite) == 0UL, "zero grid");
+    FL_CHECK(true);  // runtime sentinel for the test runner
+}
+
+
+FL_TEST_CASE("LUT error floor: Bilinear N=16") {
+    // Coarsest practical config — 2 KB at i16 quantization. Threshold is
+    // generous: the goal here is to catch regressions in the bilinear
+    // interpolator (lost cell, wrong stride, sign error), not to certify
+    // colorimeter-grade accuracy at N=16.
+    if (!lut_error_floor::colorimetric_linked()) return;
+    const int max_delta =
+        lut_error_floor::lut_max_delta_vs_closed_form(RgbwLutInterp::Bilinear, 16);
+    FL_CHECK(max_delta <= 48);
+}
+
+
+FL_TEST_CASE("LUT error floor: Bilinear N=32") {
+    // 8 KB. Bilinear with a finer grid; should noticeably tighten vs N=16.
+    if (!lut_error_floor::colorimetric_linked()) return;
+    const int max_delta =
+        lut_error_floor::lut_max_delta_vs_closed_form(RgbwLutInterp::Bilinear, 32);
+    FL_CHECK(max_delta <= 24);
+}
+
+
+FL_TEST_CASE("LUT error floor: Hermite N=16") {
+    // 6 KB. Bicubic basis at the same grid as Bilinear N=16 — should produce
+    // strictly better accuracy in the common case (smooth chromaticity
+    // regions) at 3x the storage. Threshold is set just below the bilinear
+    // N=16 budget so a hermite regression that silently degrades to
+    // bilinear-equivalent error gets caught.
+    if (!lut_error_floor::colorimetric_linked()) return;
+    const int max_delta =
+        lut_error_floor::lut_max_delta_vs_closed_form(RgbwLutInterp::Hermite, 16);
+    FL_CHECK(max_delta <= 40);
+}
+
+
+FL_TEST_CASE("LUT error floor: Hermite N=32") {
+    // 24 KB. Default-quality config for the LUT path. This is what most
+    // FastLED users will end up with after calling enable_rgbw_colorimetric_lut
+    // with no extra args — assert the tightest reasonable bound.
+    if (!lut_error_floor::colorimetric_linked()) return;
+    const int max_delta =
+        lut_error_floor::lut_max_delta_vs_closed_form(RgbwLutInterp::Hermite, 32);
+    FL_CHECK(max_delta <= 16);
+}
+
+
+FL_TEST_CASE("LUT error floor: monotonicity in grid size") {
+    // Refining the grid should not make the LUT *worse* on this sweep. If
+    // it does, build_lut has a fencepost / quantization regression that the
+    // per-config threshold tests above could miss.
+    if (!lut_error_floor::colorimetric_linked()) return;
+    const int hermite_16 =
+        lut_error_floor::lut_max_delta_vs_closed_form(RgbwLutInterp::Hermite, 16);
+    const int hermite_32 =
+        lut_error_floor::lut_max_delta_vs_closed_form(RgbwLutInterp::Hermite, 32);
+    // Allow a slack of 4 LSB for quantization noise at the same threshold.
+    FL_CHECK(hermite_32 <= hermite_16 + 4);
 }


### PR DESCRIPTION
Closes #2720.

## Summary

Adds the missing public surface around the colorimetric LUT path so users can trade memory for accuracy from outside the library — and locks the LUT's accuracy budget down with explicit regression tests.

## Public API additions (`fl::` namespace)

```cpp
enum class RgbwLutInterp : u8 {
    Bilinear = 0,   // 8 B/cell (4x i16)
    Hermite  = 1,   // 24 B/cell (4x i16 value + 4x dx + 4x dy)
};

bool enable_rgbw_colorimetric_lut(int grid_n, RgbwLutInterp interp) noexcept;
bool enable_rgbw_colorimetric_lut(int grid_n) noexcept;  // existing — forwards to Hermite

constexpr unsigned long rgbw_colorimetric_lut_memory_bytes(
    int grid_n, RgbwLutInterp interp) noexcept;
```

The existing single-arg overload is preserved (forwards to `Hermite`), so this is source-compatible with everyone who is already on the LUT path.

`LutStateHolder` now keys its rebuild check on `(profile, cct, grid_n, interp)`, so changing `interp` triggers an automatic rebuild on the next colorimetric call exactly like changing `grid_n` does.

## Memory cost (matches the new accessor)

| `grid_n` | Bilinear (8 B/cell) | Hermite (24 B/cell) |
|----------|---------------------|---------------------|
| 8        | 512                 | 1 536               |
| 16       | 2 048               | 6 144               |
| 32       | 8 192               | 24 576              |
| 64       | 32 768              | 98 304              |

## Tests added

In `tests/fl/gfx/rgbw_colorimetric.cpp`:

- **`LUT memory accessor matches stride math`** — `FL_STATIC_ASSERT`s for every (interp, N) cell in the table above, plus the `grid_n=0` degenerate case. Pins the byte-cost contract at compile time.
- **`LUT error floor: Bilinear N=16`** — `<= 48` LSB max per-channel delta.
- **`LUT error floor: Bilinear N=32`** — `<= 24` LSB.
- **`LUT error floor: Hermite N=16`** — `<= 40` LSB (set just inside the Bilinear N=16 budget so a Hermite regression that silently degrades to bilinear-equivalent error gets caught).
- **`LUT error floor: Hermite N=32`** — `<= 16` LSB (default-quality config — what most users will get from the no-arg `enable_rgbw_colorimetric_lut(N)`).
- **`LUT error floor: monotonicity in grid size`** — refining the Hermite grid from N=16 to N=32 must not regress max delta beyond 4 LSB of slack.

The error-floor harness sweeps 7³−1 = 342 in-gamut RGB samples through dispatch in two passes (LUT disabled → closed-form; LUT enabled → interpolated) and compares max per-channel byte delta. Thresholds are deliberately generous against current behavior (typically 2–3× headroom) so the tests don't flap on minor numerical adjustments, but tighten the moment something seriously regresses (wrong basis, wrong stride, sign-flipped slope, off-by-one cell indexing, lost quantization precision).

## Doc refresh

The comment on `enable_rgbw_colorimetric_lut` claimed bilinear default + quoted bilinear byte counts. Since #2707 made Hermite the actual default, the comment was wrong for everyone on the LUT path. New comment tables both interps explicitly.

## Drive-by

Fixes a pre-existing IWYU violation in `src/platforms/esp/32/drivers/lcd_spi/channel_driver_lcd_clockless.cpp.hpp` (FreeRTOS headers needed `IWYU pragma: begin_keep` / `end_keep` wrappers) — surfaced by `bash lint` on a clean tree.

## Test plan

- [x] `bash lint` clean
- [x] `bash test fl_gfx_rgbw_colorimetric --cpp` passes all error-floor cases (5 new) + memory accessor case (1 new) + all pre-existing cases
- [ ] CI green
- [ ] CodeRabbit review addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added selectable interpolation modes for RGBW colorimetric lookup tables and a memory estimator to preview LUT storage needs per configuration.
* **Tests**
  * Expanded automated tests with regression, error‑floor and monotonicity checks to validate LUT accuracy across interpolation modes and grid sizes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->