### PR TITLE
fix(rpc): value-init args_tuple in JsonArgConverter early-returns (#2722)

### DIFF
--- a/src/fl/remote/rpc/json_arg_converter.h
+++ b/src/fl/remote/rpc/json_arg_converter.h
@@ -73,7 +73,10 @@ public:
 
     static fl::tuple<args_tuple, TypeConversionResult> convert(const json& jsonArgs) {
         TypeConversionResult result;
-        args_tuple tuple;
+        // Value-init so the early-return branches below (not an array,
+        // arg-count mismatch) don't return an indeterminate tuple —
+        // convertArgs() is the only writer and runs after the bail-outs. #2722
+        args_tuple tuple{};
 
         if (!jsonArgs.is_array()) {
             result.setError("arguments must be a JSON array");
@@ -133,7 +136,10 @@ public:
 
     static fl::tuple<args_tuple, TypeConversionResult> convert(const json& jsonArgs) {
         TypeConversionResult result;
-        args_tuple tuple;
+        // Value-init so the early-return branches below (not an array,
+        // arg-count mismatch) don't return an indeterminate tuple —
+        // convertArgs() is the only writer and runs after the bail-outs. #2722
+        args_tuple tuple{};
 
         if (!jsonArgs.is_array()) {
             result.setError("arguments must be a JSON array");


### PR DESCRIPTION
Closes #2722.

## Summary

`-Wmaybe-uninitialized` fires on 7 boards (Arduino Due / SAM3X8E, RP2040, RP2350, Adafruit Feather nRF52840 Sense, Adafruit XIAO BLE Sense, nRF52840 DK, XIAO BLE Sense nRF52) because `JsonArgConverter::convert()` early-returns with the tuple before `convertArgs()` has written to it. The default ctor leaves `head`/`tail` (and nested tuple members) indeterminate, so the subsequent move/copy reads indeterminate memory — UB. On AVR/ARM this becomes garbage pointer values handed to RPC handlers.

## Fix

One-line in two places (both `R(Args...)` and `R()` specializations):

```cpp
-args_tuple tuple;
+args_tuple tuple{};
```

Value-initialization makes the bail-out branches (not-an-array, arg-count mismatch) return a defined tuple regardless of whether `convertArgs` ran. Cost: zero — at the type system level it just forces the implicit value-init the compiler should have been doing.

## Why this and not also hardening `fl::tuple`'s default ctor

The issue suggested also hardening `fl::tuple` to value-init by default. That's a strictly larger blast radius (every existing `fl::tuple<T...> t;` would change behavior) and risks performance regressions in hot paths that intentionally use the uninitialized form. The targeted fix here addresses the actual call sites that triggered the warnings; if we later decide `fl::tuple{}` should be the default semantics, that's a separate, scoped change.

## Test plan

- [x] `bash lint` clean
- [x] `bash test fl_chipsets_timing_traits --cpp` passes (closest test to the touched path)
- [ ] CI green on the 7 affected boards (Due, RP2040, RP2350, 4x nRF52)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling reliability in JSON RPC argument conversion by ensuring proper initialization during validation checks, reducing potential edge cases in malformed request handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->