### PR TITLE
fix(esp32/lcd_spi): explicit r-m-w on volatile mNextByteOffset (#2723)

### DIFF
--- a/src/platforms/esp/32/drivers/lcd_spi/channel_driver_lcd_spi.cpp.hpp
+++ b/src/platforms/esp/32/drivers/lcd_spi/channel_driver_lcd_spi.cpp.hpp
@@ -253,7 +253,11 @@ bool ChannelDriverLcdSpi::isrChunkDone(void *panel_io, const void *edata,
     self->transposeToWords(self->mTransmittingChannels, buf,
                            ctx.mNextByteOffset, chunkBytes);
 
-    ctx.mNextByteOffset += chunkBytes;
+    // Explicit read-modify-write — `mNextByteOffset` is volatile (ISR/main
+    // memory model, see channel_driver_lcd_spi.h:117-130). C++20 deprecates
+    // compound assignment on volatile (-Wvolatile); C++23 makes it a hard
+    // error. #2723
+    ctx.mNextByteOffset = ctx.mNextByteOffset + chunkBytes;
     ctx.mRingWriteIdx = (writeIdx + 1) % kRingBufferCount;
 
     // Submit this chunk for DMA


### PR DESCRIPTION
Closes #2723.

## Summary

`-Wvolatile` fires on `src/platforms/esp/32/drivers/lcd_spi/channel_driver_lcd_spi.cpp.hpp:256`:

```cpp
warning: compound assignment with volatile-qualified left operand is deprecated [-Wvolatile]
  ctx.mNextByteOffset += chunkBytes;
```

C++20 deprecates this; C++23 makes it a hard error. ESP-IDF 5.x is already shipping with GCC 14 and the FastLED matrix is moving toward C++23/26, so this needs to land before the toolchain default crosses that line.

## Fix

`mNextByteOffset` is legitimately volatile — it's the ISR/main-thread memory model documented at `channel_driver_lcd_spi.h:117-130` (ISR writes, main thread reads after detecting `mStreamComplete`). Dropping the qualifier is the wrong fix.

The right fix is the explicit read-modify-write the warning is asking for:

```cpp
-ctx.mNextByteOffset += chunkBytes;
+ctx.mNextByteOffset = ctx.mNextByteOffset + chunkBytes;
```

Same code-gen, same memory semantics, no warning, no future C++23 break.

The other `volatile` field writes in this TU (`mStreamComplete`, `mRingWriteIdx`) already use plain `=` (line 257 even pre-stages `writeIdx` into a local), so no other sites need fixing.

## Test plan

- [x] `bash lint` clean
- [ ] CI green on `esp32s3` (where LCD-SPI driver actually compiles in)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of LCD SPI display communication on ESP32 devices through corrected interrupt memory handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->