### PR TITLE
fix(palette): convert TColorPalette::operator==/!= to hidden friends (#2724)

### DIFF
--- a/src/fl/gfx/colorutils.h
+++ b/src/fl/gfx/colorutils.h
@@ -483,17 +483,26 @@ class TColorPalette {
 
     operator TColor *() FL_NOEXCEPT { return &(entries[0]); }
 
-    bool operator==(const TColorPalette &rhs) const FL_NOEXCEPT {
-        const TColor *lhs = &(this->entries[0]);
+    // Hidden friends — C++20 deprecates synthesizing a reversed candidate
+    // for member operator==, producing -Wambiguous-reversed-operator at every
+    // call site. Defining the comparison as a non-member friend declared
+    // inside the class body solves that cleanly (found only via ADL on the
+    // palette type, no reverse-candidate synthesis applies). Derived classes
+    // get these for free through ADL on the base, so the prior
+    // `using Base::operator==/!=` injections are no longer needed. #2724
+    friend bool operator==(const TColorPalette &lhs,
+                           const TColorPalette &rhs) FL_NOEXCEPT {
+        const TColor *lhs_entries = &(lhs.entries[0]);
         const TColor *rhs_entries = &(rhs.entries[0]);
-        if (lhs == rhs_entries) {
+        if (lhs_entries == rhs_entries) {
             return true;
         }
-        return fl::memcmp(lhs, rhs_entries, sizeof(entries)) == 0;
+        return fl::memcmp(lhs_entries, rhs_entries, sizeof(lhs.entries)) == 0;
     }
 
-    bool operator!=(const TColorPalette &rhs) const FL_NOEXCEPT {
-        return !(*this == rhs);
+    friend bool operator!=(const TColorPalette &lhs,
+                           const TColorPalette &rhs) FL_NOEXCEPT {
+        return !(lhs == rhs);
     }
 
   protected:
@@ -515,9 +524,9 @@ class TCRGBPalette : public TColorPalette<CRGB, Size> {
     using Base = TColorPalette<CRGB, Size>;
     using Base::Base;
     using Base::entries;
-    using Base::operator!=;
+    // operator== / operator!= are hidden friends on Base (#2724); they reach
+    // derived classes automatically via ADL, so no using-declaration needed.
     using Base::operator=;
-    using Base::operator==;
     using Base::operator[];
     using Base::operator CRGB*;
 
@@ -597,9 +606,9 @@ class CHSVPalette16 : public detail::TColorPalette<CHSV, 16> {
     using Base = detail::TColorPalette<CHSV, 16>;
     using Base::Base;
     using Base::entries;
-    using Base::operator!=;
+    // operator== / operator!= are hidden friends on Base (#2724); they reach
+    // derived classes automatically via ADL, so no using-declaration needed.
     using Base::operator=;
-    using Base::operator==;
     using Base::operator[];
     using Base::operator CHSV*;
 
@@ -633,9 +642,9 @@ class CHSVPalette256 : public detail::TColorPalette<CHSV, 256> {
     using Base = detail::TColorPalette<CHSV, 256>;
     using Base::Base;
     using Base::entries;
-    using Base::operator!=;
+    // operator== / operator!= are hidden friends on Base (#2724); they reach
+    // derived classes automatically via ADL, so no using-declaration needed.
     using Base::operator=;
-    using Base::operator==;
     using Base::operator[];
     using Base::operator CHSV*;
 
@@ -690,9 +699,9 @@ class CRGBPalette16 : public detail::TCRGBPalette<16> {
     using Base = detail::TCRGBPalette<16>;
     using Base::Base;
     using Base::entries;
-    using Base::operator!=;
+    // operator== / operator!= are hidden friends on Base (#2724); they reach
+    // derived classes automatically via ADL, so no using-declaration needed.
     using Base::operator=;
-    using Base::operator==;
     using Base::operator[];
     using Base::operator CRGB*;
 
@@ -910,9 +919,9 @@ class CHSVPalette32 : public detail::TColorPalette<CHSV, 32> {
     using Base = detail::TColorPalette<CHSV, 32>;
     using Base::Base;
     using Base::entries;
-    using Base::operator!=;
+    // operator== / operator!= are hidden friends on Base (#2724); they reach
+    // derived classes automatically via ADL, so no using-declaration needed.
     using Base::operator=;
-    using Base::operator==;
     using Base::operator[];
     using Base::operator CHSV*;
 
@@ -977,9 +986,9 @@ class CRGBPalette32 : public detail::TCRGBPalette<32> {
     using Base = detail::TCRGBPalette<32>;
     using Base::Base;
     using Base::entries;
-    using Base::operator!=;
+    // operator== / operator!= are hidden friends on Base (#2724); they reach
+    // derived classes automatically via ADL, so no using-declaration needed.
     using Base::operator=;
-    using Base::operator==;
     using Base::operator[];
     using Base::operator CRGB*;
 
@@ -1189,9 +1198,9 @@ class CRGBPalette256 : public detail::TCRGBPalette<256> {
     using Base = detail::TCRGBPalette<256>;
     using Base::Base;
     using Base::entries;
-    using Base::operator!=;
+    // operator== / operator!= are hidden friends on Base (#2724); they reach
+    // derived classes automatically via ADL, so no using-declaration needed.
     using Base::operator=;
-    using Base::operator==;
     using Base::operator[];
     using Base::operator CRGB*;
 


### PR DESCRIPTION
Closes #2724.

## Summary

C++20 `-Wambiguous-reversed-operator` fires on every `CRGBPalette/CHSVPalette` equality comparison because the class defined a member `operator==` and C++20 synthesizes a reversed candidate, leading to an ambiguous best-viable-function diagnosis at every call site. Affects every C++20 build (wasm, wasm_compile_test) and will silently become a compile error as the rest of the matrix migrates to `-std=gnu++20`.

## Fix

Convert both `operator==` and `operator!=` on `TColorPalette` to hidden friends — non-member functions declared inside the class body. The friend form is the recommended C++20 idiom: found only via ADL on the palette type, so no reverse-candidate synthesis applies.

```cpp
// Before — member, triggers -Wambiguous-reversed-operator under C++20
bool operator==(const TColorPalette &rhs) const FL_NOEXCEPT { ... }

// After — hidden friend, ADL-only, no rewrite candidate considered
friend bool operator==(const TColorPalette &lhs,
                       const TColorPalette &rhs) FL_NOEXCEPT { ... }
```

Derived classes (`TCRGBPalette<16>`, `CHSVPalette16/32/256`, `CRGBPalette16/32/256`) get these through ADL on the base, so the prior `using Base::operator==/!=` injections become noise. Removed 14 stale using-declarations across the 7 derived palette classes — they would otherwise dangle on a member that no longer exists.

## Why hidden friend and not `= default`

The issue mentioned `bool operator==(const CRGBPalette16&) const = default;` as option 1. That works for `CRGBPalette16` specifically, but every derived class would need the same boilerplate, and `= default` requires the underlying member types to support `operator==` (which `CHSV`/`CRGB` already do, but enforces a coupling). The hidden-friend form fixes it once on the base, scales to every derived palette automatically, and is the canonical C++20 idiom.

## Test plan

- [x] `bash lint` clean
- [x] `bash test fl_gfx_colorutils --cpp` passes
- [ ] CI green on wasm + wasm_compile_test (where `-Wambiguous-reversed-operator` actually fires)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured internal comparison logic for color palettes to improve code organization. No functional changes to end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->