### PR TITLE
fix(palette): explicit Rule of 5 on detail::TCRGBPalette<N> (#2725)

### DIFF
--- a/src/fl/gfx/colorutils.h
+++ b/src/fl/gfx/colorutils.h
@@ -523,6 +523,14 @@ class TCRGBPalette : public TColorPalette<CRGB, Size> {
 
     TCRGBPalette() FL_NOEXCEPT {}
 
+    // Explicit Rule of 5 — the user-defined ctors below otherwise force the
+    // copy-assign / destructor to be implicitly-declared, which C++11+
+    // deprecates (-Wdeprecated-copy, ~472 hits across teensy30/31/40/41/LC).
+    // Mirrors what CRGBPalette16 already does at lines 699-701. #2725
+    TCRGBPalette(const TCRGBPalette &) FL_NOEXCEPT = default;
+    TCRGBPalette &operator=(const TCRGBPalette &) FL_NOEXCEPT = default;
+    ~TCRGBPalette() FL_NOEXCEPT = default;
+
     TCRGBPalette(const TColorPalette<CHSV, Size> &rhs) FL_NOEXCEPT {
         Base::copyConverted(rhs.entries);
     }


### PR DESCRIPTION
Closes #2725.

## Summary

`-Wdeprecated-copy` fires on `TCRGBPalette<16>::operator=` because the class declares user-defined conversion ctors / assignment operators (taking `TColorPalette<CHSV, Size>` or `const CHSV(&)[Size]`) without also explicitly declaring the same-type copy ctor / copy assign / dtor. C++11+ deprecates relying on the implicit copy-assignment in that case; ~472 hits across teensy30/31/40/41/LC builds.

## Fix

Add explicit `= default` declarations for the Rule of 5 on `detail::TCRGBPalette<N>`:

```cpp
TCRGBPalette(const TCRGBPalette&) FL_NOEXCEPT = default;
TCRGBPalette& operator=(const TCRGBPalette&) FL_NOEXCEPT = default;
~TCRGBPalette() FL_NOEXCEPT = default;
```

Mirrors what `CRGBPalette16` (colorutils.h:707-709), `CRGBPalette32`, `CRGBPalette256`, `CHSVPalette16/32/256` already do at the derived level. The base `TColorPalette` is fine — it explicitly declares its own copy ctor + copy assign with bodies.

## Test plan

- [x] `bash lint` clean
- [x] `bash test fl_gfx_colorutils --cpp` passes
- [ ] CI green on teensy30/31/40/41/LC (where -Wdeprecated-copy fires)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code quality and standards compliance for color palette handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->