### PR TITLE
fix(third_party/object_fled): cast `size` to int in drawSquare bounds checks (#2726)

### DIFF
--- a/src/third_party/object_fled/src/OjectFLED.cpp.hpp
+++ b/src/third_party/object_fled/src/OjectFLED.cpp.hpp
@@ -673,7 +673,12 @@ void drawSquare(void* leds, uint16_t planeY, uint16_t planeX, int yCorner, int x
 				*((uint8_t*)leds + (yCorner * planeX + x) * 3 + 1) = ((color >> 8) & 0xFF);
 				*((uint8_t*)leds + (yCorner * planeX + x) * 3 + 2) = (color & 0xFF);
 			}
-			if ((yCorner + size >= 0) && (yCorner + size < planeY)) {
+			// FastLED #2726: `size` is uint32_t so `yCorner + size` promotes
+			// to unsigned, making the `>= 0` clause always true (-Wtype-limits)
+			// and breaking the bounds check when yCorner is negative. Cast
+			// `size` to int to keep the arithmetic signed (matches the
+			// for-loop bound `x <= xCorner + (int)size` above).
+			if ((yCorner + (int)size >= 0) && (yCorner + (int)size < planeY)) {
 				*((uint8_t*)leds + ((yCorner + size) * planeX + x) * 3) = ((color >> 16) & 0xFF);
 				*((uint8_t*)leds + ((yCorner + size) * planeX + x) * 3 + 1) = ((color >> 8) & 0xFF);
 				*((uint8_t*)leds + ((yCorner + size) * planeX + x) * 3 + 2) = (color & 0xFF);
@@ -687,7 +692,8 @@ void drawSquare(void* leds, uint16_t planeY, uint16_t planeX, int yCorner, int x
 				*((uint8_t*)leds + (xCorner + y * planeX) * 3 + 1) = ((color >> 8) & 0xFF);
 				*((uint8_t*)leds + (xCorner + y * planeX) * 3 + 2) = (color & 0xFF);
 			}
-			if ((xCorner + size >= 0) && (xCorner + size < planeX)) {
+			// FastLED #2726: same -Wtype-limits fix as the yCorner branch above.
+			if ((xCorner + (int)size >= 0) && (xCorner + (int)size < planeX)) {
 				*((uint8_t*)leds + (xCorner + size + y * planeX) * 3) = ((color >> 16) & 0xFF);
 				*((uint8_t*)leds + (xCorner + size + y * planeX) * 3 + 1) = ((color >> 8) & 0xFF);
 				*((uint8_t*)leds + (xCorner + size + y * planeX) * 3 + 2) = (color & 0xFF);

--- a/src/third_party/object_fled/src/OjectFLED.cpp.hpp
+++ b/src/third_party/object_fled/src/OjectFLED.cpp.hpp
@@ -679,9 +679,9 @@ void drawSquare(void* leds, uint16_t planeY, uint16_t planeX, int yCorner, int x
 			// `size` to int to keep the arithmetic signed (matches the
 			// for-loop bound `x <= xCorner + (int)size` above).
 			if ((yCorner + (int)size >= 0) && (yCorner + (int)size < planeY)) {
-				*((uint8_t*)leds + ((yCorner + size) * planeX + x) * 3) = ((color >> 16) & 0xFF);
-				*((uint8_t*)leds + ((yCorner + size) * planeX + x) * 3 + 1) = ((color >> 8) & 0xFF);
-				*((uint8_t*)leds + ((yCorner + size) * planeX + x) * 3 + 2) = (color & 0xFF);
+				*((uint8_t*)leds + ((yCorner + (int)size) * planeX + x) * 3) = ((color >> 16) & 0xFF);
+				*((uint8_t*)leds + ((yCorner + (int)size) * planeX + x) * 3 + 1) = ((color >> 8) & 0xFF);
+				*((uint8_t*)leds + ((yCorner + (int)size) * planeX + x) * 3 + 2) = (color & 0xFF);
 			}
 		}	//if valid x
 	}	//for x
@@ -694,9 +694,9 @@ void drawSquare(void* leds, uint16_t planeY, uint16_t planeX, int yCorner, int x
 			}
 			// FastLED #2726: same -Wtype-limits fix as the yCorner branch above.
 			if ((xCorner + (int)size >= 0) && (xCorner + (int)size < planeX)) {
-				*((uint8_t*)leds + (xCorner + size + y * planeX) * 3) = ((color >> 16) & 0xFF);
-				*((uint8_t*)leds + (xCorner + size + y * planeX) * 3 + 1) = ((color >> 8) & 0xFF);
-				*((uint8_t*)leds + (xCorner + size + y * planeX) * 3 + 2) = (color & 0xFF);
+				*((uint8_t*)leds + (xCorner + (int)size + y * planeX) * 3) = ((color >> 16) & 0xFF);
+				*((uint8_t*)leds + (xCorner + (int)size + y * planeX) * 3 + 1) = ((color >> 8) & 0xFF);
+				*((uint8_t*)leds + (xCorner + (int)size + y * planeX) * 3 + 2) = (color & 0xFF);
 			}
 		}	//if valid y
 	}	//for y


### PR DESCRIPTION
Closes #2726.

## Summary

`-Wtype-limits` "comparison of unsigned expression in >= 0 is always true" fires on every Teensy 4.x build (teensy40, teensy41, teensy_octoWS2811) at `OjectFLED.cpp.hpp:676` and `:690`.

```cpp
void drawSquare(void* leds, uint16_t planeY, uint16_t planeX,
                int yCorner, int xCorner, uint32_t size, uint32_t color);
//                ^^^ signed             ^^^ unsigned

if ((yCorner + size >= 0) && (yCorner + size < planeY))  // <- always-true >= 0
if ((xCorner + size >= 0) && (xCorner + size < planeX))  // <- same
```

`size` is `uint32_t`, so `yCorner + size` promotes to unsigned via the usual arithmetic conversions and the `>= 0` clause becomes always true.

This is **not just noise** — it silently breaks the bounds check whenever `yCorner` is negative. Instead of the first clause failing (and the draw being skipped), `yCorner + size` wraps to a huge unsigned value that still satisfies `>= 0`, and the second clause `< planeY` ends up doing all the work. Today the negative-corner case happens to be safe because the second clause filters it out, but the first clause was clearly meant as the primary "negative-Y" guard.

## Fix

Cast `size` to `int` in both bounds expressions so the arithmetic stays signed:

```cpp
-if ((yCorner + size >= 0) && (yCorner + size < planeY))
+if ((yCorner + (int)size >= 0) && (yCorner + (int)size < planeY))
```

Matches the convention already used in the same function's for-loop bound (`x <= xCorner + (int)size`).

## Upstream

This is vendored code under `third_party/object_fled/`; the same fix should be PR'd to the upstream `ObjectFLED` repo and pulled back on the next sync.

## Test plan

- [x] `bash lint` clean
- [ ] CI green on teensy40 / teensy41 / teensy_octoWS2811

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected square rendering when coordinates are negative, preventing incorrect bounds calculations. This improves visual correctness and stability when shapes extend outside the visible area, reducing rare clipping and rendering glitches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->