### PR TITLE
feat(watchdog): Phase 1 — unified fl::Watchdog API + host/stub/ESP32 impls

### DIFF
--- a/src/FastLED.cpp.hpp
+++ b/src/FastLED.cpp.hpp
@@ -725,6 +725,10 @@ fl::ChannelEvents& CFastLED::channelEvents() {
 	return fl::ChannelEvents::instance();
 }
 
+fl::Watchdog& CFastLED::watchdog() {
+	return fl::Watchdog::instance();
+}
+
 // ============================================================================
 // CFastLED audio method implementations - thin trampolines to AudioManager
 // ============================================================================

--- a/src/FastLED.h
+++ b/src/FastLED.h
@@ -160,6 +160,7 @@
 
 #include "fl/channels/channel.h"
 #include "fl/channels/channel_events.h"
+#include "fl/wdt/watchdog.h"  // for fl::Watchdog (FastLED.watchdog() accessor)
 #include "fl/channels/manager.h"
 #include "fl/channels/config.h"  // for ChannelConfig, MultiChannelConfig
 #include "fl/channels/bus.h"          // for fl::Bus, fl::DefaultBus (Phase 3b, #2428)
@@ -643,6 +644,22 @@ public:
 	/// int id = FastLED.channelEvents().onChannelCreated.add([](const fl::IChannel& ch) { ... });
 	/// @endcode
 	static fl::ChannelEvents& channelEvents();
+
+	/// @brief Access the unified cross-platform watchdog timer.
+	/// @return Reference to the Watchdog singleton
+	/// @note See fl/wdt/watchdog.h and FastLED#2731. Tier 0 surface is universal.
+	/// @code
+	/// void setup() {
+	///     FastLED.watchdog().begin(15000);  // arm with 15s timeout
+	///     if (FastLED.watchdog().isInSafeMode()) { while (true) {} }
+	/// }
+	/// void loop() {
+	///     doWork();
+	///     FastLED.watchdog().feed();
+	///     FastLED.watchdog().markCleanShutdown();
+	/// }
+	/// @endcode
+	static fl::Watchdog& watchdog();
 
 	/// @name Manual Engine Events
 	/// When FASTLED_MANUAL_ENGINE_EVENTS is defined, these methods allow manual control of engine events.

--- a/src/fl/wdt/watchdog.h
+++ b/src/fl/wdt/watchdog.h
@@ -1,0 +1,143 @@
+#pragma once
+
+/// @file fl/wdt/watchdog.h
+/// @brief Unified cross-platform Watchdog Timer API for FastLED.
+///
+/// Accessed via the FastLED god-object: `FastLED.watchdog()`.
+///
+/// See FastLED#2731 for the full design rationale and per-platform capability matrix.
+///
+/// **Three tiers:**
+///   - Tier 0 — universal (every supported platform, incl. AVR)
+///   - Tier 1 — pre-reset callback, pause-on-debug, flash crash log, bootloader reboot
+///   - Tier 2 — window mode, decoded CrashReport
+///
+/// **Naming:** spelled-out (`watchdog`, not `wdt`). Macros: `FL_WATCHDOG_*`, not `FL_WDT_*`.
+///
+/// **Usage:**
+/// @code
+/// void setup() {
+///     FastLED.watchdog().begin(15000);
+///     if (FastLED.watchdog().isInSafeMode()) {
+///         // skip LED init, wait for new firmware
+///         while (true) {}
+///     }
+/// }
+/// void loop() {
+///     doWork();
+///     FastLED.watchdog().feed();          // after the dangerous work
+///     FastLED.watchdog().markCleanShutdown();
+/// }
+/// @endcode
+
+#include "fl/stl/stdint.h"
+#include "fl/stl/noexcept.h"
+#include "fl/stl/compiler_control.h"   // FL_NORETURN
+#include "fl/stl/span.h"
+#include "fl/stl/function.h"
+
+namespace fl {
+
+/// @brief Cause of the previous boot. Call once early in setup().
+enum class ResetCause : fl::u8 {
+    UNKNOWN = 0,
+    POWER_ON,
+    BROWNOUT,
+    EXTERNAL_PIN,
+    WATCHDOG,
+    SOFTWARE,
+    LOCKUP,
+    DEBUGGER,
+    PANIC,
+};
+
+/// @brief ISR-safe C function pointer callback for `onTimeout()`.
+using WatchdogTimeoutCallback = void(*)(void* user_data);
+
+/// @brief Decoded crash report (Tier 2).
+struct WatchdogCrashReport {
+    bool        valid;
+    fl::u32     pc;
+    fl::u32     lr;
+    fl::u32     psr;
+    fl::u32     fault_status;
+    fl::u32     fault_address;
+    const char* fault_type;
+};
+
+/// @brief Unified cross-platform watchdog interface.
+///
+/// Singleton accessed through `FastLED.watchdog()` or `fl::Watchdog::instance()`.
+class Watchdog {
+public:
+    // Singleton — defined here in the public header so every TU that includes
+    // it can resolve the call without needing access to the platform impl.
+    static Watchdog& instance() FL_NOEXCEPT {
+        static Watchdog sInstance;
+        return sInstance;
+    }
+
+    // ========== Tier 0 — universal ==========
+
+    void       begin(fl::u32 timeout_ms) FL_NOEXCEPT;
+    void       feed() FL_NOEXCEPT;
+    void       disable() FL_NOEXCEPT;
+
+    ResetCause lastResetCause() const FL_NOEXCEPT;
+    bool       lastResetWasWatchdog() const FL_NOEXCEPT;
+
+    fl::u8     persistRead(fl::size idx) const FL_NOEXCEPT;
+    void       persistWrite(fl::size idx, fl::u8 v) FL_NOEXCEPT;
+
+    fl::u16    consecutiveCrashCount() const FL_NOEXCEPT;
+    void       markCleanShutdown() FL_NOEXCEPT;
+    bool       isInSafeMode() const FL_NOEXCEPT;
+    fl::u16    safeModeThreshold() const FL_NOEXCEPT;
+    void       setSafeModeThreshold(fl::u16 threshold) FL_NOEXCEPT;
+
+    FL_NORETURN void reboot() FL_NOEXCEPT;
+
+    // ========== Tier 1 — most platforms ==========
+
+    bool       onTimeout(WatchdogTimeoutCallback cb, void* user_data = nullptr) FL_NOEXCEPT;
+    bool       onTimeout(fl::function<void()> cb) FL_NOEXCEPT;
+    bool       setPauseOnDebug(bool pause) FL_NOEXCEPT;
+    bool       writeCrashLog(fl::span<const fl::u8> payload) FL_NOEXCEPT;
+    fl::size   readCrashLog(fl::span<fl::u8> out) const FL_NOEXCEPT;
+    bool       rebootIntoBootloader() FL_NOEXCEPT;
+
+    // ========== Tier 2 — advanced platforms ==========
+
+    bool                setWindow(fl::u32 window_min_ms, fl::u32 window_max_ms) FL_NOEXCEPT;
+    bool                hasCrashReport() const FL_NOEXCEPT;
+    WatchdogCrashReport readCrashReport() const FL_NOEXCEPT;
+    void                clearCrashReport() FL_NOEXCEPT;
+
+private:
+    Watchdog() FL_NOEXCEPT = default;
+    ~Watchdog() FL_NOEXCEPT = default;
+    Watchdog(const Watchdog&) FL_NOEXCEPT = delete;
+    Watchdog& operator=(const Watchdog&) FL_NOEXCEPT = delete;
+
+    fl::u16 mSafeModeThreshold = 2;
+};
+
+} // namespace fl
+
+// ============================================================================
+// FL_WATCHDOG_* capability macros — defined by the per-platform impl.
+// The noop fallback defines NONE of the boolean flags and defaults numerics to 0.
+// User code may #ifdef on the boolean flags or static_assert on the numerics.
+// ============================================================================
+//
+//   #define FL_WATCHDOG_HAS_HARDWARE          // 1 wherever a real or emulated WDT runs
+//   #define FL_WATCHDOG_PERSIST_BYTES N       // small persistent buffer size, >= 8
+//   #define FL_WATCHDOG_HAS_PRE_TIMEOUT_IRQ   // pre-reset callback honored at HW level
+//   #define FL_WATCHDOG_HAS_WINDOW_MODE       // setWindow() honored
+//   #define FL_WATCHDOG_HAS_CRASH_REPORT      // hasCrashReport()/readCrashReport() honored
+//   #define FL_WATCHDOG_HAS_BOOTLOADER_REBOOT // rebootIntoBootloader() honored
+//   #define FL_WATCHDOG_MAX_TIMEOUT_MS N      // upper bound, in ms
+//
+// The Tier 0 surface is always callable; Tier 1/2 methods return false on
+// platforms whose impl does not honor them, so user code that checks the
+// return value works portably.

--- a/src/fl/wdt/watchdog.h
+++ b/src/fl/wdt/watchdog.h
@@ -70,12 +70,14 @@ struct WatchdogCrashReport {
 /// Singleton accessed through `FastLED.watchdog()` or `fl::Watchdog::instance()`.
 class Watchdog {
 public:
-    // Singleton — defined here in the public header so every TU that includes
-    // it can resolve the call without needing access to the platform impl.
-    static Watchdog& instance() FL_NOEXCEPT {
-        static Watchdog sInstance;
-        return sInstance;
-    }
+    // Singleton accessor — DECLARATION ONLY. The function-local `static
+    // Watchdog` must live in a `.cpp.hpp` / `.impl.hpp` TU (one definition,
+    // one guard variable) so the Teensy 3.x `__cxa_guard` ABI conflict does
+    // not pull a guarded singleton path into every TU that includes
+    // FastLED.h. See `agents/docs/cpp-standards.md` → "Header rules:
+    // function-local statics with non-trivial constructors are forbidden in
+    // `src/**/*.h`."
+    static Watchdog& instance() FL_NOEXCEPT;
 
     // ========== Tier 0 — universal ==========
 

--- a/src/platforms/_build.cpp.hpp
+++ b/src/platforms/_build.cpp.hpp
@@ -12,6 +12,7 @@
 #include "platforms/debug_setup.cpp.hpp"
 #include "platforms/ota.cpp.hpp"
 #include "platforms/stub_main.cpp.hpp"
+#include "platforms/watchdog.impl.cpp.hpp" // ok include cpp.hpp
 
 // begin sub directory includes
 #include "platforms/adafruit/_build.cpp.hpp"

--- a/src/platforms/esp/32/watchdog_esp32.h
+++ b/src/platforms/esp/32/watchdog_esp32.h
@@ -45,9 +45,12 @@ void watchdog_setup(u32 timeout_ms = 5000,
                     void* user_data = nullptr) FL_NOEXCEPT;
 
 /// @brief Tear down the ESP32 task watchdog.
-/// @note Real TWDT deinit via `esp_task_wdt_deinit()`. Safely guarded against
-///       being called before the FreeRTOS scheduler is running.
+/// @return true if teardown succeeded (TWDT is now disabled and callbacks
+///         cleared); false if `esp_task_wdt_deinit()` failed (e.g., other
+///         tasks still subscribed, scheduler not running, or already
+///         deinitialized — in any of those cases the TWDT remains active).
+/// @note Wraps `esp_task_wdt_deinit()` and propagates its return.
 /// @note Used by `fl::Watchdog::disable()` to honor the Tier-0 disable contract.
-void watchdog_disable() FL_NOEXCEPT;
+bool watchdog_disable() FL_NOEXCEPT;
 
 } // namespace fl

--- a/src/platforms/esp/32/watchdog_esp32.h
+++ b/src/platforms/esp/32/watchdog_esp32.h
@@ -44,4 +44,10 @@ void watchdog_setup(u32 timeout_ms = 5000,
                     watchdog_callback_t callback = nullptr,
                     void* user_data = nullptr) FL_NOEXCEPT;
 
+/// @brief Tear down the ESP32 task watchdog.
+/// @note Real TWDT deinit via `esp_task_wdt_deinit()`. Safely guarded against
+///       being called before the FreeRTOS scheduler is running.
+/// @note Used by `fl::Watchdog::disable()` to honor the Tier-0 disable contract.
+void watchdog_disable() FL_NOEXCEPT;
+
 } // namespace fl

--- a/src/platforms/esp/32/watchdog_esp32.impl.hpp
+++ b/src/platforms/esp/32/watchdog_esp32.impl.hpp
@@ -111,17 +111,13 @@ void Watchdog::feed() FL_NOEXCEPT {
 }
 
 void Watchdog::disable() FL_NOEXCEPT {
-    // TWDT teardown requires the FreeRTOS scheduler to be running and careful
-    // sequencing across cores (delete each subscribed task, then deinit). The
-    // current `fl::watchdog_setup()` shim is one-shot install with no
-    // matching teardown entry point. Rather than silently letting the WDT
-    // fire after a documented `disable()`, re-arm the backend with the
-    // maximum supported timeout so any caller polling for life still has the
-    // longest possible window before reset. Real teardown is tracked in
-    // #2731 Phase 2 alongside esp_task_wdt_deinit() integration.
+    // Real TWDT teardown via `fl::watchdog_disable()` (added alongside this
+    // change in watchdog_esp32_idf{4,5}.hpp) — wraps `esp_task_wdt_deinit()`
+    // and is safely guarded against being called before the FreeRTOS
+    // scheduler is running. Honors the Tier-0 contract: after disable(), the
+    // watchdog truly does not fire on the registered idle task.
     auto& s = platforms::esp32WatchdogState();
-    if (!s.armed) return;
-    fl::watchdog_setup(FL_WATCHDOG_MAX_TIMEOUT_MS);
+    fl::watchdog_disable();
     s.armed = false;
     s.armed_timeout_ms = 0;
 }

--- a/src/platforms/esp/32/watchdog_esp32.impl.hpp
+++ b/src/platforms/esp/32/watchdog_esp32.impl.hpp
@@ -1,0 +1,168 @@
+// IWYU pragma: private
+
+/// @file platforms/esp/32/watchdog_esp32.impl.hpp
+/// @brief ESP32 watchdog implementation for the unified fl::Watchdog API.
+///
+/// Wraps the existing `fl::watchdog_setup()` entry point (already implemented
+/// in src/platforms/esp/32/watchdog_esp32.{h,cpp.hpp} and the IDF v4/v5
+/// sub-impls). The existing weak-symbol panic override and USB-CDC disconnect
+/// behavior — which fix the Windows phantom-COM-port bug — are preserved
+/// verbatim.
+///
+/// **Tier 0 surface** is fully supported via the TWDT and `esp_reset_reason()`.
+/// Persist storage falls back to in-RAM (NOT crash-resistant) for now — Phase 2
+/// will move it to `RTC_NOINIT_ATTR` on variants that have RTC slow memory and
+/// `__NOINIT_ATTR` on ESP32-P4 which has no RTC slow memory.
+///
+/// **Tier 1** — onTimeout(C-pointer) wires through to the existing
+/// `watchdog_callback_t` slot. Other Tier 1 methods return false.
+///
+/// **Tier 2** — not implemented; tracked in #2731.
+
+#include "fl/wdt/watchdog.h"
+#include "platforms/esp/32/watchdog_esp32.h"
+
+extern "C" {
+#include "esp_system.h"   // esp_reset_reason()
+#include "esp_idf_version.h"
+}
+
+#define FL_WATCHDOG_HAS_HARDWARE
+#define FL_WATCHDOG_PERSIST_BYTES 16
+#define FL_WATCHDOG_MAX_TIMEOUT_MS 60000u
+#define FL_WATCHDOG_HAS_PRE_TIMEOUT_IRQ
+
+namespace fl {
+namespace platforms {
+
+struct Esp32WatchdogState {
+    fl::u8  persist[FL_WATCHDOG_PERSIST_BYTES] = {0};
+    fl::u16 crash_count = 0;
+    bool    armed = false;
+    ResetCause cached_cause = ResetCause::UNKNOWN;
+    bool    cause_cached = false;
+};
+
+inline Esp32WatchdogState& esp32WatchdogState() {
+    static Esp32WatchdogState s{};  // okay static in header — this `.impl.hpp` is included from exactly one TU (the dispatcher)
+    return s;
+}
+
+inline ResetCause translateEsp32ResetReason(esp_reset_reason_t r) {
+    switch (r) {
+        case ESP_RST_POWERON:  return ResetCause::POWER_ON;
+        case ESP_RST_EXT:      return ResetCause::EXTERNAL_PIN;
+        case ESP_RST_SW:       return ResetCause::SOFTWARE;
+        case ESP_RST_PANIC:    return ResetCause::PANIC;
+        case ESP_RST_INT_WDT:  return ResetCause::WATCHDOG;
+        case ESP_RST_TASK_WDT: return ResetCause::WATCHDOG;
+        case ESP_RST_WDT:      return ResetCause::WATCHDOG;
+        case ESP_RST_BROWNOUT: return ResetCause::BROWNOUT;
+        case ESP_RST_DEEPSLEEP:
+        case ESP_RST_SDIO:
+        default:               return ResetCause::UNKNOWN;
+    }
+}
+
+} // namespace platforms
+
+// `Watchdog::instance()` defined in fl/wdt/watchdog.h — every TU resolves it
+// there. Rest of the API is defined non-inline here; this header is only
+// included from the dispatcher in one TU.
+
+void Watchdog::begin(fl::u32 timeout_ms) FL_NOEXCEPT {
+    if (timeout_ms == 0) timeout_ms = 1000;
+    if (timeout_ms > FL_WATCHDOG_MAX_TIMEOUT_MS) timeout_ms = FL_WATCHDOG_MAX_TIMEOUT_MS;
+    auto& s = platforms::esp32WatchdogState();
+    fl::watchdog_setup(timeout_ms);
+    s.armed = true;
+}
+
+void Watchdog::feed() FL_NOEXCEPT {
+    // ESP32 framework auto-feeds via idle-task monitoring (see watchdog_esp32_idf{4,5}.hpp).
+    // No-op here; loop() liveness alone keeps the TWDT happy.
+}
+
+void Watchdog::disable() FL_NOEXCEPT {
+    // No-op for now; TWDT deinit requires the FreeRTOS scheduler running and
+    // careful sequencing. Tracked in #2731.
+}
+
+ResetCause Watchdog::lastResetCause() const FL_NOEXCEPT {
+    auto& s = platforms::esp32WatchdogState();
+    if (!s.cause_cached) {
+        s.cached_cause = platforms::translateEsp32ResetReason(esp_reset_reason());
+        s.cause_cached = true;
+        if (s.cached_cause == ResetCause::WATCHDOG || s.cached_cause == ResetCause::PANIC) {
+            if (s.crash_count < 0xFFFF) s.crash_count++;
+        }
+    }
+    return s.cached_cause;
+}
+
+bool Watchdog::lastResetWasWatchdog() const FL_NOEXCEPT {
+    return lastResetCause() == ResetCause::WATCHDOG;
+}
+
+fl::u8 Watchdog::persistRead(fl::size idx) const FL_NOEXCEPT {
+    if (idx >= FL_WATCHDOG_PERSIST_BYTES) return 0;
+    return platforms::esp32WatchdogState().persist[idx];
+}
+
+void Watchdog::persistWrite(fl::size idx, fl::u8 v) FL_NOEXCEPT {
+    if (idx >= FL_WATCHDOG_PERSIST_BYTES) return;
+    platforms::esp32WatchdogState().persist[idx] = v;
+}
+
+fl::u16 Watchdog::consecutiveCrashCount() const FL_NOEXCEPT {
+    // Side-effect: ensure cached_cause has bumped the counter at least once
+    (void)lastResetCause();
+    return platforms::esp32WatchdogState().crash_count;
+}
+
+void Watchdog::markCleanShutdown() FL_NOEXCEPT {
+    platforms::esp32WatchdogState().crash_count = 0;
+}
+
+bool Watchdog::isInSafeMode() const FL_NOEXCEPT {
+    return consecutiveCrashCount() >= mSafeModeThreshold;
+}
+
+fl::u16 Watchdog::safeModeThreshold() const FL_NOEXCEPT { return mSafeModeThreshold; }
+void    Watchdog::setSafeModeThreshold(fl::u16 t) FL_NOEXCEPT { mSafeModeThreshold = t; }
+
+FL_NORETURN void Watchdog::reboot() FL_NOEXCEPT {
+    esp_restart();
+    while (true) {}
+}
+
+bool Watchdog::onTimeout(WatchdogTimeoutCallback cb, void* user_data) FL_NOEXCEPT {
+    // Tier 1 hookup: re-init the watchdog with a callback bound. We don't
+    // know the timeout the user passed earlier, so use the existing 5000 ms
+    // default if begin() hasn't been called yet.
+    fl::watchdog_setup(5000, cb, user_data);
+    return true;
+}
+
+bool Watchdog::onTimeout(fl::function<void()> /*cb*/) FL_NOEXCEPT {
+    // fl::function trampoline requires allocator-safe storage; deferred to
+    // a follow-up PR. Tier 1 C-pointer path above remains usable.
+    return false;
+}
+
+bool Watchdog::setPauseOnDebug(bool /*pause*/) FL_NOEXCEPT { return false; }
+bool Watchdog::writeCrashLog(fl::span<const fl::u8> /*payload*/) FL_NOEXCEPT { return false; }
+fl::size Watchdog::readCrashLog(fl::span<fl::u8> /*out*/) const FL_NOEXCEPT { return 0; }
+bool Watchdog::rebootIntoBootloader() FL_NOEXCEPT { return false; }
+
+bool                Watchdog::setWindow(fl::u32, fl::u32) FL_NOEXCEPT { return false; }
+bool                Watchdog::hasCrashReport() const FL_NOEXCEPT { return false; }
+WatchdogCrashReport Watchdog::readCrashReport() const FL_NOEXCEPT {
+    WatchdogCrashReport r{};
+    r.valid = false;
+    r.fault_type = "";
+    return r;
+}
+void                Watchdog::clearCrashReport() FL_NOEXCEPT {}
+
+} // namespace fl

--- a/src/platforms/esp/32/watchdog_esp32.impl.hpp
+++ b/src/platforms/esp/32/watchdog_esp32.impl.hpp
@@ -35,12 +35,33 @@ extern "C" {
 namespace fl {
 namespace platforms {
 
+// Persist layout: user payload occupies bytes [0, kUserStart);
+// the trailing 2 bytes of persist[] hold the consecutive crash_count.
+// When persist[] moves to RTC_NOINIT_ATTR / __NOINIT_ATTR in Phase 2 (#2731),
+// crash_count will then survive real resets automatically without further code
+// change.
 struct Esp32WatchdogState {
-    fl::u8  persist[FL_WATCHDOG_PERSIST_BYTES] = {0};
-    fl::u16 crash_count = 0;
-    bool    armed = false;
+    static constexpr fl::size kCrashCountBytes = 2;
+    static constexpr fl::size kUserBytes =
+        FL_WATCHDOG_PERSIST_BYTES > kCrashCountBytes
+            ? (FL_WATCHDOG_PERSIST_BYTES - kCrashCountBytes)
+            : 0;
+
+    fl::u8     persist[FL_WATCHDOG_PERSIST_BYTES] = {0};
+    bool       armed = false;
+    fl::u32    armed_timeout_ms = 0;
     ResetCause cached_cause = ResetCause::UNKNOWN;
-    bool    cause_cached = false;
+    bool       cause_cached = false;
+
+    fl::u16 load_crash_count() const {
+        // Little-endian read from the tail of persist[].
+        return static_cast<fl::u16>(persist[kUserBytes])
+             | (static_cast<fl::u16>(persist[kUserBytes + 1]) << 8);
+    }
+    void store_crash_count(fl::u16 v) {
+        persist[kUserBytes]     = static_cast<fl::u8>(v & 0xFF);
+        persist[kUserBytes + 1] = static_cast<fl::u8>((v >> 8) & 0xFF);
+    }
 };
 
 inline Esp32WatchdogState& esp32WatchdogState() {
@@ -66,14 +87,20 @@ inline ResetCause translateEsp32ResetReason(esp_reset_reason_t r) {
 
 } // namespace platforms
 
-// `Watchdog::instance()` defined in fl/wdt/watchdog.h — every TU resolves it
-// there. Rest of the API is defined non-inline here; this header is only
-// included from the dispatcher in one TU.
+// `Watchdog::instance()` is defined here (and in every sibling `.impl.hpp` /
+// the noop) so the function-local static lives in exactly one TU per program.
+// Avoids the Teensy 3.x `__cxa_guard` ABI conflict that a header-side
+// definition would impose on every TU including FastLED.h.
+Watchdog& Watchdog::instance() FL_NOEXCEPT {
+    static Watchdog sInstance;
+    return sInstance;
+}
 
 void Watchdog::begin(fl::u32 timeout_ms) FL_NOEXCEPT {
     if (timeout_ms == 0) timeout_ms = 1000;
     if (timeout_ms > FL_WATCHDOG_MAX_TIMEOUT_MS) timeout_ms = FL_WATCHDOG_MAX_TIMEOUT_MS;
     auto& s = platforms::esp32WatchdogState();
+    s.armed_timeout_ms = timeout_ms;
     fl::watchdog_setup(timeout_ms);
     s.armed = true;
 }
@@ -84,8 +111,19 @@ void Watchdog::feed() FL_NOEXCEPT {
 }
 
 void Watchdog::disable() FL_NOEXCEPT {
-    // No-op for now; TWDT deinit requires the FreeRTOS scheduler running and
-    // careful sequencing. Tracked in #2731.
+    // TWDT teardown requires the FreeRTOS scheduler to be running and careful
+    // sequencing across cores (delete each subscribed task, then deinit). The
+    // current `fl::watchdog_setup()` shim is one-shot install with no
+    // matching teardown entry point. Rather than silently letting the WDT
+    // fire after a documented `disable()`, re-arm the backend with the
+    // maximum supported timeout so any caller polling for life still has the
+    // longest possible window before reset. Real teardown is tracked in
+    // #2731 Phase 2 alongside esp_task_wdt_deinit() integration.
+    auto& s = platforms::esp32WatchdogState();
+    if (!s.armed) return;
+    fl::watchdog_setup(FL_WATCHDOG_MAX_TIMEOUT_MS);
+    s.armed = false;
+    s.armed_timeout_ms = 0;
 }
 
 ResetCause Watchdog::lastResetCause() const FL_NOEXCEPT {
@@ -94,7 +132,9 @@ ResetCause Watchdog::lastResetCause() const FL_NOEXCEPT {
         s.cached_cause = platforms::translateEsp32ResetReason(esp_reset_reason());
         s.cause_cached = true;
         if (s.cached_cause == ResetCause::WATCHDOG || s.cached_cause == ResetCause::PANIC) {
-            if (s.crash_count < 0xFFFF) s.crash_count++;
+            fl::u16 cc = s.load_crash_count();
+            if (cc < 0xFFFF) ++cc;
+            s.store_crash_count(cc);
         }
     }
     return s.cached_cause;
@@ -105,23 +145,25 @@ bool Watchdog::lastResetWasWatchdog() const FL_NOEXCEPT {
 }
 
 fl::u8 Watchdog::persistRead(fl::size idx) const FL_NOEXCEPT {
-    if (idx >= FL_WATCHDOG_PERSIST_BYTES) return 0;
+    // User-visible persist region is the leading kUserBytes; the trailing
+    // bytes hold the serialized crash_count and are NOT exposed.
+    if (idx >= platforms::Esp32WatchdogState::kUserBytes) return 0;
     return platforms::esp32WatchdogState().persist[idx];
 }
 
 void Watchdog::persistWrite(fl::size idx, fl::u8 v) FL_NOEXCEPT {
-    if (idx >= FL_WATCHDOG_PERSIST_BYTES) return;
+    if (idx >= platforms::Esp32WatchdogState::kUserBytes) return;
     platforms::esp32WatchdogState().persist[idx] = v;
 }
 
 fl::u16 Watchdog::consecutiveCrashCount() const FL_NOEXCEPT {
     // Side-effect: ensure cached_cause has bumped the counter at least once
     (void)lastResetCause();
-    return platforms::esp32WatchdogState().crash_count;
+    return platforms::esp32WatchdogState().load_crash_count();
 }
 
 void Watchdog::markCleanShutdown() FL_NOEXCEPT {
-    platforms::esp32WatchdogState().crash_count = 0;
+    platforms::esp32WatchdogState().store_crash_count(0);
 }
 
 bool Watchdog::isInSafeMode() const FL_NOEXCEPT {
@@ -137,10 +179,15 @@ FL_NORETURN void Watchdog::reboot() FL_NOEXCEPT {
 }
 
 bool Watchdog::onTimeout(WatchdogTimeoutCallback cb, void* user_data) FL_NOEXCEPT {
-    // Tier 1 hookup: re-init the watchdog with a callback bound. We don't
-    // know the timeout the user passed earlier, so use the existing 5000 ms
-    // default if begin() hasn't been called yet.
-    fl::watchdog_setup(5000, cb, user_data);
+    // Tier 1 hookup: re-init the watchdog with a callback bound. Reuse the
+    // timeout that begin() armed earlier — registering a callback must not
+    // silently shorten the watchdog window. If begin() hasn't been called,
+    // fall back to the documented default (5000 ms).
+    auto& s = platforms::esp32WatchdogState();
+    fl::u32 timeout_ms = s.armed_timeout_ms != 0 ? s.armed_timeout_ms : 5000u;
+    fl::watchdog_setup(timeout_ms, cb, user_data);
+    s.armed = true;
+    s.armed_timeout_ms = timeout_ms;
     return true;
 }
 

--- a/src/platforms/esp/32/watchdog_esp32.impl.hpp
+++ b/src/platforms/esp/32/watchdog_esp32.impl.hpp
@@ -111,15 +111,19 @@ void Watchdog::feed() FL_NOEXCEPT {
 }
 
 void Watchdog::disable() FL_NOEXCEPT {
-    // Real TWDT teardown via `fl::watchdog_disable()` (added alongside this
-    // change in watchdog_esp32_idf{4,5}.hpp) — wraps `esp_task_wdt_deinit()`
-    // and is safely guarded against being called before the FreeRTOS
-    // scheduler is running. Honors the Tier-0 contract: after disable(), the
-    // watchdog truly does not fire on the registered idle task.
+    // Real TWDT teardown via `fl::watchdog_disable()` (wraps
+    // `esp_task_wdt_deinit()` and is safely guarded against being called
+    // before the FreeRTOS scheduler is running). Only clear the local armed
+    // state if teardown actually succeeded — if `esp_task_wdt_deinit()`
+    // returned non-OK (other tasks still subscribed, already deinitialized)
+    // the TWDT is still active, so reporting "disabled" would lie. Leaving
+    // `armed`/`armed_timeout_ms` intact also means a subsequent `begin()`
+    // can reason about its prior state.
     auto& s = platforms::esp32WatchdogState();
-    fl::watchdog_disable();
-    s.armed = false;
-    s.armed_timeout_ms = 0;
+    if (fl::watchdog_disable()) {
+        s.armed = false;
+        s.armed_timeout_ms = 0;
+    }
 }
 
 ResetCause Watchdog::lastResetCause() const FL_NOEXCEPT {

--- a/src/platforms/esp/32/watchdog_esp32_idf4.hpp
+++ b/src/platforms/esp/32/watchdog_esp32_idf4.hpp
@@ -166,6 +166,12 @@ void watchdog_setup(u32 timeout_ms,
     log_watchdog_status(timeout_ms, callback);
 }
 
+void watchdog_disable() FL_NOEXCEPT {
+    deinit_existing_watchdog();
+    detail::s_user_callback = nullptr;
+    detail::s_user_data = nullptr;
+}
+
 } // namespace fl
 
 // ============================================================================

--- a/src/platforms/esp/32/watchdog_esp32_idf4.hpp
+++ b/src/platforms/esp/32/watchdog_esp32_idf4.hpp
@@ -115,11 +115,16 @@ void handle_system_reset(const char* handler_name) FL_NOEXCEPT {
 
 namespace {
 
-// Deinitializes existing watchdog if scheduler is running
-void deinit_existing_watchdog() FL_NOEXCEPT {
-    if (xTaskGetSchedulerState() == taskSCHEDULER_RUNNING) {
-        esp_task_wdt_deinit();
+// Deinitializes existing watchdog if scheduler is running.
+// Returns true on successful deinit (or if no deinit is needed because the
+// scheduler isn't running), false if `esp_task_wdt_deinit()` reported an
+// error (e.g., other tasks still subscribed, already deinitialized).
+bool deinit_existing_watchdog() FL_NOEXCEPT {
+    if (xTaskGetSchedulerState() != taskSCHEDULER_RUNNING) {
+        return true;
     }
+    esp_err_t err = esp_task_wdt_deinit();
+    return err == ESP_OK;
 }
 
 // Initializes watchdog with specified timeout
@@ -157,7 +162,9 @@ void watchdog_setup(u32 timeout_ms,
     detail::s_user_callback = callback;
     detail::s_user_data = user_data;
 
-    deinit_existing_watchdog();
+    // Best-effort deinit before re-init; failure here is non-fatal because
+    // we're about to overwrite the configuration anyway.
+    (void)deinit_existing_watchdog();
 
     if (!init_task_watchdog(timeout_ms)) {
         return;
@@ -166,10 +173,13 @@ void watchdog_setup(u32 timeout_ms,
     log_watchdog_status(timeout_ms, callback);
 }
 
-void watchdog_disable() FL_NOEXCEPT {
-    deinit_existing_watchdog();
+bool watchdog_disable() FL_NOEXCEPT {
+    if (!deinit_existing_watchdog()) {
+        return false;
+    }
     detail::s_user_callback = nullptr;
     detail::s_user_data = nullptr;
+    return true;
 }
 
 } // namespace fl

--- a/src/platforms/esp/32/watchdog_esp32_idf5.hpp
+++ b/src/platforms/esp/32/watchdog_esp32_idf5.hpp
@@ -118,11 +118,17 @@ static void watchdog_shutdown_handler_v5(void) FL_NOEXCEPT {
 
 namespace {
 
-// Deinitializes existing watchdog if scheduler is running
-void deinit_existing_watchdog() FL_NOEXCEPT {
-    if (xTaskGetSchedulerState() == taskSCHEDULER_RUNNING) {
-        esp_task_wdt_deinit();
+// Deinitializes existing watchdog if scheduler is running.
+// Returns true on successful deinit (or if no deinit is needed because the
+// scheduler isn't running), false if `esp_task_wdt_deinit()` reported an
+// error (e.g., other tasks still subscribed, already deinitialized).
+bool deinit_existing_watchdog() FL_NOEXCEPT {
+    if (xTaskGetSchedulerState() != taskSCHEDULER_RUNNING) {
+        // Nothing to tear down — the TWDT cannot have been armed.
+        return true;
     }
+    esp_err_t err = esp_task_wdt_deinit();
+    return err == ESP_OK;
 }
 
 // Initializes watchdog with specified timeout
@@ -167,7 +173,9 @@ void watchdog_setup(u32 timeout_ms,
     // This is the proper ESP-IDF v5.0+ API for pre-reset cleanup
     esp_register_shutdown_handler(watchdog_shutdown_handler_v5);
 
-    deinit_existing_watchdog();
+    // Best-effort deinit before re-init; failure here is non-fatal because
+    // we're about to overwrite the configuration anyway.
+    (void)deinit_existing_watchdog();
 
     if (!init_task_watchdog(timeout_ms)) {
         return;
@@ -176,10 +184,15 @@ void watchdog_setup(u32 timeout_ms,
     log_watchdog_status(timeout_ms, callback);
 }
 
-void watchdog_disable() FL_NOEXCEPT {
-    deinit_existing_watchdog();
+bool watchdog_disable() FL_NOEXCEPT {
+    if (!deinit_existing_watchdog()) {
+        // TWDT is still active — leave the user callback bound so it still
+        // fires on timeout.
+        return false;
+    }
     detail::s_user_callback = nullptr;
     detail::s_user_data = nullptr;
+    return true;
 }
 
 } // namespace fl

--- a/src/platforms/esp/32/watchdog_esp32_idf5.hpp
+++ b/src/platforms/esp/32/watchdog_esp32_idf5.hpp
@@ -176,6 +176,12 @@ void watchdog_setup(u32 timeout_ms,
     log_watchdog_status(timeout_ms, callback);
 }
 
+void watchdog_disable() FL_NOEXCEPT {
+    deinit_existing_watchdog();
+    detail::s_user_callback = nullptr;
+    detail::s_user_data = nullptr;
+}
+
 } // namespace fl
 
 #endif // FL_IS_ESP32

--- a/src/platforms/shared/watchdog_noop.hpp
+++ b/src/platforms/shared/watchdog_noop.hpp
@@ -1,0 +1,87 @@
+// IWYU pragma: private
+
+/// @file platforms/shared/watchdog_noop.hpp
+/// @brief No-op watchdog fallback for platforms without a real or emulated WDT.
+///
+/// Follows the FastLED `_noop.hpp` convention (see agents/docs/cpp-standards.md
+/// "No-op Fallback"): inline functions, `fl::platforms::` namespace, bodies
+/// return inert defaults — never assert, throw, or log.
+///
+/// This file is included by `src/platforms/watchdog.impl.cpp.hpp` in the
+/// dispatcher's `#else` branch. It also provides default zero/false values for
+/// every `FL_WATCHDOG_*` numeric capability macro so user code that reads
+/// them compiles unconditionally.
+
+#include "fl/wdt/watchdog.h"
+
+// ----------------------------------------------------------------------------
+// Capability macros — defaults for the noop platform.
+// Boolean flags are NOT defined (so #ifdef FL_WATCHDOG_HAS_* is false).
+// Numerics get a sensible zero/default value.
+// ----------------------------------------------------------------------------
+
+#ifndef FL_WATCHDOG_PERSIST_BYTES
+#define FL_WATCHDOG_PERSIST_BYTES 0
+#endif
+
+#ifndef FL_WATCHDOG_MAX_TIMEOUT_MS
+#define FL_WATCHDOG_MAX_TIMEOUT_MS 0
+#endif
+
+namespace fl {
+
+// Non-inline definitions — this header is `// IWYU pragma: private` and only
+// included from `platforms/watchdog.impl.cpp.hpp` in the dispatcher's TU, so
+// each method is defined exactly once across the program.
+//
+// `Watchdog::instance()` itself is a static-inline in `fl/wdt/watchdog.h` so
+// every TU that includes the public header can resolve the call without
+// pulling in the platform impl.
+
+// ---- Tier 0 ----
+
+void       Watchdog::begin(fl::u32 /*timeout_ms*/) FL_NOEXCEPT {}
+void       Watchdog::feed() FL_NOEXCEPT {}
+void       Watchdog::disable() FL_NOEXCEPT {}
+
+ResetCause Watchdog::lastResetCause() const FL_NOEXCEPT { return ResetCause::UNKNOWN; }
+bool       Watchdog::lastResetWasWatchdog() const FL_NOEXCEPT { return false; }
+
+fl::u8     Watchdog::persistRead(fl::size /*idx*/) const FL_NOEXCEPT { return 0; }
+void       Watchdog::persistWrite(fl::size /*idx*/, fl::u8 /*v*/) FL_NOEXCEPT {}
+
+fl::u16    Watchdog::consecutiveCrashCount() const FL_NOEXCEPT { return 0; }
+void       Watchdog::markCleanShutdown() FL_NOEXCEPT {}
+bool       Watchdog::isInSafeMode() const FL_NOEXCEPT { return false; }
+fl::u16    Watchdog::safeModeThreshold() const FL_NOEXCEPT { return mSafeModeThreshold; }
+void       Watchdog::setSafeModeThreshold(fl::u16 t) FL_NOEXCEPT { mSafeModeThreshold = t; }
+
+// reboot() is FL_NORETURN — even on noop, we must spin forever so the
+// signature contract holds. Using a loop instead of abort() so we don't
+// require <cstdlib> from a header used on bare-metal AVR.
+FL_NORETURN void Watchdog::reboot() FL_NOEXCEPT {
+    while (true) {}
+}
+
+// ---- Tier 1 ----
+
+bool       Watchdog::onTimeout(WatchdogTimeoutCallback /*cb*/, void* /*ud*/) FL_NOEXCEPT { return false; }
+bool       Watchdog::onTimeout(fl::function<void()> /*cb*/) FL_NOEXCEPT { return false; }
+bool       Watchdog::setPauseOnDebug(bool /*pause*/) FL_NOEXCEPT { return false; }
+bool       Watchdog::writeCrashLog(fl::span<const fl::u8> /*payload*/) FL_NOEXCEPT { return false; }
+fl::size   Watchdog::readCrashLog(fl::span<fl::u8> /*out*/) const FL_NOEXCEPT { return 0; }
+bool       Watchdog::rebootIntoBootloader() FL_NOEXCEPT { return false; }
+
+// ---- Tier 2 ----
+
+bool                Watchdog::setWindow(fl::u32, fl::u32) FL_NOEXCEPT { return false; }
+bool                Watchdog::hasCrashReport() const FL_NOEXCEPT { return false; }
+WatchdogCrashReport Watchdog::readCrashReport() const FL_NOEXCEPT {
+    WatchdogCrashReport r{};
+    r.valid = false;
+    r.fault_type = "";
+    return r;
+}
+void                Watchdog::clearCrashReport() FL_NOEXCEPT {}
+
+} // namespace fl

--- a/src/platforms/shared/watchdog_noop.hpp
+++ b/src/platforms/shared/watchdog_noop.hpp
@@ -34,9 +34,14 @@ namespace fl {
 // included from `platforms/watchdog.impl.cpp.hpp` in the dispatcher's TU, so
 // each method is defined exactly once across the program.
 //
-// `Watchdog::instance()` itself is a static-inline in `fl/wdt/watchdog.h` so
-// every TU that includes the public header can resolve the call without
-// pulling in the platform impl.
+// `Watchdog::instance()` is also defined here (and in every sibling
+// `.impl.hpp`) so the function-local static lives in exactly one TU per
+// program — keeps Teensy 3.x clear of the `__cxa_guard` ABI conflict.
+
+Watchdog& Watchdog::instance() FL_NOEXCEPT {
+    static Watchdog sInstance;
+    return sInstance;
+}
 
 // ---- Tier 0 ----
 

--- a/src/platforms/stub/watchdog_stub.impl.hpp
+++ b/src/platforms/stub/watchdog_stub.impl.hpp
@@ -17,10 +17,12 @@
 ///   - FL_WATCHDOG_PERSIST_BYTES = 16
 ///   - FL_WATCHDOG_MAX_TIMEOUT_MS = 600000
 ///   - FL_WATCHDOG_HAS_PRE_TIMEOUT_IRQ   (callback fires from timer thread)
-///   - FL_WATCHDOG_HAS_WINDOW_MODE
 ///   - FL_WATCHDOG_HAS_CRASH_REPORT       (synthesized — no real fault frame)
 ///
-/// `FL_WATCHDOG_HAS_BOOTLOADER_REBOOT` is intentionally NOT defined.
+/// `FL_WATCHDOG_HAS_WINDOW_MODE` and `FL_WATCHDOG_HAS_BOOTLOADER_REBOOT` are
+/// intentionally NOT defined — the stub does not model windowed-feed
+/// violations and there is no bootloader to reboot into. `setWindow()` returns
+/// false; `rebootIntoBootloader()` returns false.
 
 #include "fl/wdt/watchdog.h"
 #include "fl/stl/atomic.h"
@@ -33,7 +35,6 @@
 #define FL_WATCHDOG_PERSIST_BYTES 16
 #define FL_WATCHDOG_MAX_TIMEOUT_MS 600000u
 #define FL_WATCHDOG_HAS_PRE_TIMEOUT_IRQ
-#define FL_WATCHDOG_HAS_WINDOW_MODE
 #define FL_WATCHDOG_HAS_CRASH_REPORT
 
 namespace fl {
@@ -65,6 +66,14 @@ inline StubWatchdogPersist& stubWatchdogPersist() {
 }
 
 // State shared between fl::Watchdog methods and the timer thread.
+//
+// `reset_was_watchdog`, `fired`, and `software_reboot` are written from the
+// worker thread and read/cleared from API calls; they must be atomic to avoid
+// data races (and the same races flaking the tests under TSAN-like builds).
+//
+// `software_reboot` is kept separate from `reset_was_watchdog` so an
+// intentional `reboot()` is reported as `ResetCause::SOFTWARE` and is not
+// counted as a watchdog crash.
 struct StubWatchdogState {
     fl::mutex                              mu;
     fl::atomic<bool>                       enabled;
@@ -74,14 +83,15 @@ struct StubWatchdogState {
     WatchdogTimeoutCallback                cb;
     void*                                  cb_user;
     fl::function<void()>                   cb_fn;
-    bool                                   reset_was_watchdog;
-    bool                                   fired;
+    fl::atomic<bool>                       reset_was_watchdog;
+    fl::atomic<bool>                       fired;
+    fl::atomic<bool>                       software_reboot;
     fl::thread                             worker;
 
     StubWatchdogState()
         : enabled(false), stop(false), timeout_ms(0),
           cb(nullptr), cb_user(nullptr),
-          reset_was_watchdog(false), fired(false) {}
+          reset_was_watchdog(false), fired(false), software_reboot(false) {}
 
     ~StubWatchdogState() {
         stop.store(true);
@@ -94,14 +104,27 @@ inline StubWatchdogState& stubWatchdogState() {
     return s;
 }
 
+// Worker-thread side of a watchdog timeout: bump the crash counter and flag
+// the reset as watchdog-induced. Does NOT mark `software_reboot`.
 inline void stubWatchdogReset() {
     auto& p = stubWatchdogPersist();
     p.magic = StubWatchdogPersist::kMagic;
     if (p.crash_count < 0xFFFF) p.crash_count++;
 
     auto& s = stubWatchdogState();
-    s.reset_was_watchdog = true;
-    s.fired = true;
+    s.reset_was_watchdog.store(true);
+    s.fired.store(true);
+}
+
+// Explicit `Watchdog::reboot()` path: mark the reset as SOFTWARE without
+// bumping crash_count or setting the watchdog-induced flag. Real-hardware
+// platforms similarly distinguish ESP_RST_SW from ESP_RST_TASK_WDT.
+inline void stubWatchdogSoftwareReboot() {
+    auto& p = stubWatchdogPersist();
+    p.magic = StubWatchdogPersist::kMagic;
+
+    auto& s = stubWatchdogState();
+    s.software_reboot.store(true);
 }
 
 inline void stubWatchdogTimerLoop() {
@@ -146,9 +169,14 @@ inline void stubWatchdogEnsureWorker() {
 } // namespace platforms
 
 // ---- fl::Watchdog method definitions ----
-// `Watchdog::instance()` is defined in the public header so every TU can
-// resolve the call. The rest are defined non-inline here; this header is
-// only included from the dispatcher in one TU, so each method is emitted once.
+// `Watchdog::instance()` is defined here (and in every sibling `.impl.hpp` /
+// the noop) so the function-local static lives in exactly one TU per program.
+// Avoids the Teensy 3.x `__cxa_guard` ABI conflict that a header-side
+// definition would impose on every TU including FastLED.h.
+Watchdog& Watchdog::instance() FL_NOEXCEPT {
+    static Watchdog sInstance;
+    return sInstance;
+}
 
 void Watchdog::begin(fl::u32 timeout_ms) FL_NOEXCEPT {
     if (timeout_ms == 0) timeout_ms = 1;
@@ -175,11 +203,16 @@ void Watchdog::disable() FL_NOEXCEPT {
 
 ResetCause Watchdog::lastResetCause() const FL_NOEXCEPT {
     auto& s = platforms::stubWatchdogState();
-    return s.reset_was_watchdog ? ResetCause::WATCHDOG : ResetCause::POWER_ON;
+    // Watchdog-induced reset takes precedence over a software reboot, but
+    // never get conflated: a clean `reboot()` reports SOFTWARE, a timeout
+    // reports WATCHDOG, and a fresh process reports POWER_ON.
+    if (s.reset_was_watchdog.load()) return ResetCause::WATCHDOG;
+    if (s.software_reboot.load())    return ResetCause::SOFTWARE;
+    return ResetCause::POWER_ON;
 }
 
 bool Watchdog::lastResetWasWatchdog() const FL_NOEXCEPT {
-    return platforms::stubWatchdogState().reset_was_watchdog;
+    return platforms::stubWatchdogState().reset_was_watchdog.load();
 }
 
 fl::u8 Watchdog::persistRead(fl::size idx) const FL_NOEXCEPT {
@@ -213,7 +246,9 @@ void Watchdog::setSafeModeThreshold(fl::u16 t) FL_NOEXCEPT {
 }
 
 FL_NORETURN void Watchdog::reboot() FL_NOEXCEPT {
-    platforms::stubWatchdogReset();
+    // Intentional software reboot — does NOT bump crash_count and does NOT
+    // mark the reset as watchdog-induced.
+    platforms::stubWatchdogSoftwareReboot();
     while (true) {}
 }
 
@@ -237,19 +272,29 @@ bool Watchdog::writeCrashLog(fl::span<const fl::u8> /*payload*/) FL_NOEXCEPT { r
 fl::size Watchdog::readCrashLog(fl::span<fl::u8> /*out*/) const FL_NOEXCEPT { return 0; }
 bool Watchdog::rebootIntoBootloader() FL_NOEXCEPT { return false; }
 
-bool Watchdog::setWindow(fl::u32 /*min*/, fl::u32 /*max*/) FL_NOEXCEPT { return true; }
+bool Watchdog::setWindow(fl::u32 /*min*/, fl::u32 /*max*/) FL_NOEXCEPT {
+    // Stub does NOT model windowed feeds (no min/max enforcement in feed() or
+    // the timer loop). Returning false matches FL_WATCHDOG_HAS_WINDOW_MODE
+    // not being defined and keeps user code that checks the return value
+    // honest.
+    return false;
+}
 bool Watchdog::hasCrashReport() const FL_NOEXCEPT {
-    return platforms::stubWatchdogState().reset_was_watchdog;
+    return platforms::stubWatchdogState().reset_was_watchdog.load();
 }
 WatchdogCrashReport Watchdog::readCrashReport() const FL_NOEXCEPT {
     WatchdogCrashReport r{};
-    r.valid = platforms::stubWatchdogState().reset_was_watchdog;
+    r.valid = platforms::stubWatchdogState().reset_was_watchdog.load();
     r.fault_type = r.valid ? "WatchdogTimeout (stub)" : "";
     return r;
 }
 void Watchdog::clearCrashReport() FL_NOEXCEPT {
-    platforms::stubWatchdogState().reset_was_watchdog = false;
-    platforms::stubWatchdogState().fired = false;
+    // Clear ONLY the watchdog-crash state — `software_reboot` is independent
+    // bookkeeping and must not be silently reset, otherwise lastResetCause()
+    // would flip back to POWER_ON after a clean reboot+clear sequence.
+    auto& s = platforms::stubWatchdogState();
+    s.reset_was_watchdog.store(false);
+    s.fired.store(false);
 }
 
 } // namespace fl

--- a/src/platforms/stub/watchdog_stub.impl.hpp
+++ b/src/platforms/stub/watchdog_stub.impl.hpp
@@ -1,0 +1,255 @@
+// IWYU pragma: private
+
+/// @file platforms/stub/watchdog_stub.impl.hpp
+/// @brief Host/stub watchdog implementation for unit tests.
+///
+/// Provides a fully working `fl::Watchdog` for the host build using a
+/// thread-backed deadline timer. The stub never std::abort()s the test
+/// process — host unit tests verify reset behavior by observing the callback
+/// firing and the crash counter incrementing. Real-hardware process
+/// termination is not simulated.
+///
+/// Persist storage is backed by a 16-byte in-process buffer that survives
+/// across Watchdog::reboot()/feed() cycles within a single test process.
+///
+/// Capability macros defined here:
+///   - FL_WATCHDOG_HAS_HARDWARE          (host build counts as "has WDT")
+///   - FL_WATCHDOG_PERSIST_BYTES = 16
+///   - FL_WATCHDOG_MAX_TIMEOUT_MS = 600000
+///   - FL_WATCHDOG_HAS_PRE_TIMEOUT_IRQ   (callback fires from timer thread)
+///   - FL_WATCHDOG_HAS_WINDOW_MODE
+///   - FL_WATCHDOG_HAS_CRASH_REPORT       (synthesized — no real fault frame)
+///
+/// `FL_WATCHDOG_HAS_BOOTLOADER_REBOOT` is intentionally NOT defined.
+
+#include "fl/wdt/watchdog.h"
+#include "fl/stl/atomic.h"
+#include "fl/stl/chrono.h"
+#include "fl/stl/cstring.h"
+#include "fl/stl/mutex.h"
+#include "fl/stl/thread.h"
+
+#define FL_WATCHDOG_HAS_HARDWARE
+#define FL_WATCHDOG_PERSIST_BYTES 16
+#define FL_WATCHDOG_MAX_TIMEOUT_MS 600000u
+#define FL_WATCHDOG_HAS_PRE_TIMEOUT_IRQ
+#define FL_WATCHDOG_HAS_WINDOW_MODE
+#define FL_WATCHDOG_HAS_CRASH_REPORT
+
+namespace fl {
+namespace platforms {
+
+// Persistent storage layout — survives within a single process. Magic word at
+// the front separates first-run garbage from genuine persisted state.
+struct StubWatchdogPersist {
+    static constexpr fl::u32 kMagic = 0xFA57DDADu;
+    fl::u32 magic;
+    fl::u16 crash_count;
+    fl::u8  safe_mode_threshold;
+    fl::u8  user[FL_WATCHDOG_PERSIST_BYTES];
+
+    void reset_if_unmagic() {
+        if (magic != kMagic) {
+            magic = kMagic;
+            crash_count = 0;
+            safe_mode_threshold = 2;
+            fl::memset(user, 0, sizeof(user));
+        }
+    }
+};
+
+inline StubWatchdogPersist& stubWatchdogPersist() {
+    static StubWatchdogPersist s{};  // okay static in header — single-TU `.impl.hpp`
+    s.reset_if_unmagic();
+    return s;
+}
+
+// State shared between fl::Watchdog methods and the timer thread.
+struct StubWatchdogState {
+    fl::mutex                              mu;
+    fl::atomic<bool>                       enabled;
+    fl::atomic<bool>                       stop;
+    fl::atomic<fl::u32>                    timeout_ms;
+    fl::chrono::steady_clock::time_point   deadline;
+    WatchdogTimeoutCallback                cb;
+    void*                                  cb_user;
+    fl::function<void()>                   cb_fn;
+    bool                                   reset_was_watchdog;
+    bool                                   fired;
+    fl::thread                             worker;
+
+    StubWatchdogState()
+        : enabled(false), stop(false), timeout_ms(0),
+          cb(nullptr), cb_user(nullptr),
+          reset_was_watchdog(false), fired(false) {}
+
+    ~StubWatchdogState() {
+        stop.store(true);
+        if (worker.joinable()) worker.join();
+    }
+};
+
+inline StubWatchdogState& stubWatchdogState() {
+    static StubWatchdogState s{};  // okay static in header — single-TU `.impl.hpp`
+    return s;
+}
+
+inline void stubWatchdogReset() {
+    auto& p = stubWatchdogPersist();
+    p.magic = StubWatchdogPersist::kMagic;
+    if (p.crash_count < 0xFFFF) p.crash_count++;
+
+    auto& s = stubWatchdogState();
+    s.reset_was_watchdog = true;
+    s.fired = true;
+}
+
+inline void stubWatchdogTimerLoop() {
+    auto& s = stubWatchdogState();
+    while (!s.stop.load()) {
+        // Host-only watchdog timer thread; not part of async-scheduler pumping.
+        fl::this_thread::sleep_for(fl::chrono::milliseconds(10)); // ok sleep for
+        if (!s.enabled.load()) continue;
+        fl::chrono::steady_clock::time_point dl;
+        {
+            fl::lock_guard<fl::mutex> g(s.mu);
+            dl = s.deadline;
+        }
+        if (fl::chrono::steady_clock::now() >= dl) {
+            WatchdogTimeoutCallback cb;
+            void* user;
+            fl::function<void()> cb_fn_copy;
+            {
+                fl::lock_guard<fl::mutex> g(s.mu);
+                cb = s.cb;
+                user = s.cb_user;
+                cb_fn_copy = s.cb_fn;
+                s.enabled.store(false);
+            }
+            if (cb) cb(user);
+            if (cb_fn_copy) cb_fn_copy();
+            stubWatchdogReset();
+            // Don't exit the loop — stay alive so subsequent begin() calls
+            // re-arm correctly. `enabled` is already false.
+        }
+    }
+}
+
+inline void stubWatchdogEnsureWorker() {
+    auto& s = stubWatchdogState();
+    fl::lock_guard<fl::mutex> g(s.mu);
+    if (!s.worker.joinable()) {
+        s.worker = fl::thread(stubWatchdogTimerLoop);
+    }
+}
+
+} // namespace platforms
+
+// ---- fl::Watchdog method definitions ----
+// `Watchdog::instance()` is defined in the public header so every TU can
+// resolve the call. The rest are defined non-inline here; this header is
+// only included from the dispatcher in one TU, so each method is emitted once.
+
+void Watchdog::begin(fl::u32 timeout_ms) FL_NOEXCEPT {
+    if (timeout_ms == 0) timeout_ms = 1;
+    if (timeout_ms > FL_WATCHDOG_MAX_TIMEOUT_MS) timeout_ms = FL_WATCHDOG_MAX_TIMEOUT_MS;
+    platforms::stubWatchdogEnsureWorker();
+    auto& s = platforms::stubWatchdogState();
+    fl::lock_guard<fl::mutex> g(s.mu);
+    s.timeout_ms.store(timeout_ms);
+    s.deadline = fl::chrono::steady_clock::now() + fl::chrono::milliseconds(timeout_ms);
+    s.enabled.store(true);
+}
+
+void Watchdog::feed() FL_NOEXCEPT {
+    auto& s = platforms::stubWatchdogState();
+    if (!s.enabled.load()) return;
+    fl::lock_guard<fl::mutex> g(s.mu);
+    s.deadline = fl::chrono::steady_clock::now() + fl::chrono::milliseconds(s.timeout_ms.load());
+}
+
+void Watchdog::disable() FL_NOEXCEPT {
+    auto& s = platforms::stubWatchdogState();
+    s.enabled.store(false);
+}
+
+ResetCause Watchdog::lastResetCause() const FL_NOEXCEPT {
+    auto& s = platforms::stubWatchdogState();
+    return s.reset_was_watchdog ? ResetCause::WATCHDOG : ResetCause::POWER_ON;
+}
+
+bool Watchdog::lastResetWasWatchdog() const FL_NOEXCEPT {
+    return platforms::stubWatchdogState().reset_was_watchdog;
+}
+
+fl::u8 Watchdog::persistRead(fl::size idx) const FL_NOEXCEPT {
+    if (idx >= FL_WATCHDOG_PERSIST_BYTES) return 0;
+    return platforms::stubWatchdogPersist().user[idx];
+}
+
+void Watchdog::persistWrite(fl::size idx, fl::u8 v) FL_NOEXCEPT {
+    if (idx >= FL_WATCHDOG_PERSIST_BYTES) return;
+    platforms::stubWatchdogPersist().user[idx] = v;
+}
+
+fl::u16 Watchdog::consecutiveCrashCount() const FL_NOEXCEPT {
+    return platforms::stubWatchdogPersist().crash_count;
+}
+
+void Watchdog::markCleanShutdown() FL_NOEXCEPT {
+    platforms::stubWatchdogPersist().crash_count = 0;
+}
+
+bool Watchdog::isInSafeMode() const FL_NOEXCEPT {
+    return platforms::stubWatchdogPersist().crash_count >= mSafeModeThreshold;
+}
+
+fl::u16 Watchdog::safeModeThreshold() const FL_NOEXCEPT {
+    return mSafeModeThreshold;
+}
+
+void Watchdog::setSafeModeThreshold(fl::u16 t) FL_NOEXCEPT {
+    mSafeModeThreshold = t;
+}
+
+FL_NORETURN void Watchdog::reboot() FL_NOEXCEPT {
+    platforms::stubWatchdogReset();
+    while (true) {}
+}
+
+bool Watchdog::onTimeout(WatchdogTimeoutCallback cb, void* user_data) FL_NOEXCEPT {
+    auto& s = platforms::stubWatchdogState();
+    fl::lock_guard<fl::mutex> g(s.mu);
+    s.cb = cb;
+    s.cb_user = user_data;
+    return true;
+}
+
+bool Watchdog::onTimeout(fl::function<void()> cb) FL_NOEXCEPT {
+    auto& s = platforms::stubWatchdogState();
+    fl::lock_guard<fl::mutex> g(s.mu);
+    s.cb_fn = cb;
+    return true;
+}
+
+bool Watchdog::setPauseOnDebug(bool /*pause*/) FL_NOEXCEPT { return true; }
+bool Watchdog::writeCrashLog(fl::span<const fl::u8> /*payload*/) FL_NOEXCEPT { return false; }
+fl::size Watchdog::readCrashLog(fl::span<fl::u8> /*out*/) const FL_NOEXCEPT { return 0; }
+bool Watchdog::rebootIntoBootloader() FL_NOEXCEPT { return false; }
+
+bool Watchdog::setWindow(fl::u32 /*min*/, fl::u32 /*max*/) FL_NOEXCEPT { return true; }
+bool Watchdog::hasCrashReport() const FL_NOEXCEPT {
+    return platforms::stubWatchdogState().reset_was_watchdog;
+}
+WatchdogCrashReport Watchdog::readCrashReport() const FL_NOEXCEPT {
+    WatchdogCrashReport r{};
+    r.valid = platforms::stubWatchdogState().reset_was_watchdog;
+    r.fault_type = r.valid ? "WatchdogTimeout (stub)" : "";
+    return r;
+}
+void Watchdog::clearCrashReport() FL_NOEXCEPT {
+    platforms::stubWatchdogState().reset_was_watchdog = false;
+    platforms::stubWatchdogState().fired = false;
+}
+
+} // namespace fl

--- a/src/platforms/stub/watchdog_stub.impl.hpp
+++ b/src/platforms/stub/watchdog_stub.impl.hpp
@@ -42,17 +42,25 @@ namespace platforms {
 
 // Persistent storage layout — survives within a single process. Magic word at
 // the front separates first-run garbage from genuine persisted state.
+//
+// `crash_count` is touched by both the watchdog timer thread (bumped in
+// stubWatchdogReset()) and the test thread (read in consecutiveCrashCount() /
+// isInSafeMode(), zeroed in markCleanShutdown()) — promote it to atomic so
+// TSAN doesn't flag a data race and the safe-mode / crash-counter assertions
+// don't flake. The remaining persist fields are only mutated from the test
+// thread (or under s.mu via reset_if_unmagic on first construction), so they
+// stay plain memory.
 struct StubWatchdogPersist {
     static constexpr fl::u32 kMagic = 0xFA57DDADu;
     fl::u32 magic;
-    fl::u16 crash_count;
+    fl::atomic<fl::u16> crash_count;
     fl::u8  safe_mode_threshold;
     fl::u8  user[FL_WATCHDOG_PERSIST_BYTES];
 
     void reset_if_unmagic() {
         if (magic != kMagic) {
             magic = kMagic;
-            crash_count = 0;
+            crash_count.store(0);
             safe_mode_threshold = 2;
             fl::memset(user, 0, sizeof(user));
         }
@@ -106,10 +114,20 @@ inline StubWatchdogState& stubWatchdogState() {
 
 // Worker-thread side of a watchdog timeout: bump the crash counter and flag
 // the reset as watchdog-induced. Does NOT mark `software_reboot`.
+//
+// `crash_count` is incremented via a saturating CAS loop so concurrent
+// markCleanShutdown() resets are not lost and the counter never rolls over
+// from 0xFFFF back to 0.
 inline void stubWatchdogReset() {
     auto& p = stubWatchdogPersist();
     p.magic = StubWatchdogPersist::kMagic;
-    if (p.crash_count < 0xFFFF) p.crash_count++;
+    fl::u16 current = p.crash_count.load();
+    while (current < 0xFFFF) {
+        if (p.crash_count.compare_exchange_weak(current, static_cast<fl::u16>(current + 1))) {
+            break;
+        }
+        // current was reloaded by compare_exchange_weak — retry.
+    }
 
     auto& s = stubWatchdogState();
     s.reset_was_watchdog.store(true);
@@ -226,15 +244,15 @@ void Watchdog::persistWrite(fl::size idx, fl::u8 v) FL_NOEXCEPT {
 }
 
 fl::u16 Watchdog::consecutiveCrashCount() const FL_NOEXCEPT {
-    return platforms::stubWatchdogPersist().crash_count;
+    return platforms::stubWatchdogPersist().crash_count.load();
 }
 
 void Watchdog::markCleanShutdown() FL_NOEXCEPT {
-    platforms::stubWatchdogPersist().crash_count = 0;
+    platforms::stubWatchdogPersist().crash_count.store(0);
 }
 
 bool Watchdog::isInSafeMode() const FL_NOEXCEPT {
-    return platforms::stubWatchdogPersist().crash_count >= mSafeModeThreshold;
+    return platforms::stubWatchdogPersist().crash_count.load() >= mSafeModeThreshold;
 }
 
 fl::u16 Watchdog::safeModeThreshold() const FL_NOEXCEPT {

--- a/src/platforms/wasm/watchdog_wasm.impl.hpp
+++ b/src/platforms/wasm/watchdog_wasm.impl.hpp
@@ -1,0 +1,17 @@
+// IWYU pragma: private
+// ok no namespace fl — pure routing header, delegates everything to watchdog_noop.hpp
+
+/// @file platforms/wasm/watchdog_wasm.impl.hpp
+/// @brief WASM watchdog implementation.
+///
+/// **Status: Phase 1 — routes to the shared no-op fallback.**
+///
+/// The WASM build has emulated ISR / timer infrastructure
+/// (`coroutine_runtime_wasm.impl.hpp`, `isr.h`) that can support a real
+/// emulated WDT, with `localStorage` / IDBFS backing the persist storage.
+/// That work is tracked in FastLED#2731 as a Phase 1.5 follow-up — it needs
+/// careful design around the JS event-loop integration to avoid blocking the
+/// browser tab. For now we fall through to the no-op so WASM builds compile
+/// and run.
+
+#include "platforms/shared/watchdog_noop.hpp"

--- a/src/platforms/watchdog.impl.cpp.hpp
+++ b/src/platforms/watchdog.impl.cpp.hpp
@@ -1,0 +1,37 @@
+// IWYU pragma: private
+// ok no namespace fl — this is a platform-dispatch router, not a code file
+
+/// @file platforms/watchdog.impl.cpp.hpp
+/// @brief Single dispatcher for fl::Watchdog platform implementations.
+///
+/// Follows the FastLED `.impl.cpp.hpp` convention (see agents/docs/cpp-standards.md
+/// "Naming convention (future standard)"): one file per component, lives in
+/// `src/platforms/` root, `#include`d from exactly one translation unit, selects
+/// the platform fragment via `is_*.h` macros and falls back to `_noop.hpp`.
+///
+/// **Phase 1 platforms:**
+///   - Host / stub  → `platforms/stub/watchdog_stub.impl.hpp` (real thread timer)
+///   - WASM         → `platforms/wasm/watchdog_wasm.impl.hpp` (emscripten timer)
+///   - ESP32 family → `platforms/esp/32/watchdog_esp32.impl.hpp` (wraps existing
+///                    fl::watchdog_setup() / ESP-IDF TWDT)
+///   - All others   → `platforms/shared/watchdog_noop.hpp`
+///
+/// Per-platform hardware impls for Teensy, RP, nRF52, STM32, SAMD, AVR,
+/// Apollo3, MGM240 are tracked as Phase 2..5 in FastLED#2731.
+
+// Platform detection headers — only include those we dispatch on.
+#include "platforms/is_platform.h"
+#include "platforms/esp/is_esp.h"
+#include "platforms/wasm/is_wasm.h"
+
+#if defined(FL_IS_WASM)
+    #include "platforms/wasm/watchdog_wasm.impl.hpp"
+#elif defined(FASTLED_STUB_IMPL) || defined(FL_IS_STUB)
+    #include "platforms/stub/watchdog_stub.impl.hpp"
+#elif defined(FL_IS_ESP32)
+    #include "platforms/esp/32/watchdog_esp32.impl.hpp"
+#else
+    // Fallback: no real or emulated WDT available — all methods are no-ops.
+    // Per-platform hardware impls will be added incrementally in #2731 follow-ups.
+    #include "platforms/shared/watchdog_noop.hpp"
+#endif

--- a/tests/fl/wdt/watchdog.cpp
+++ b/tests/fl/wdt/watchdog.cpp
@@ -10,6 +10,7 @@
 #define FASTLED_STUB_WATCHDOG_NO_ABORT 1
 
 #include "fl/wdt/watchdog.h"
+#include "fl/stl/atomic.h"
 #include "fl/stl/chrono.h"
 #include "fl/stl/thread.h"
 #include "test.h"
@@ -30,17 +31,33 @@ FL_TEST_CASE("fl::Watchdog — Tier 0 begin/feed/disable doesn't crash") {
     dog.disable();
 }
 
+// Mirrors `FL_WATCHDOG_PERSIST_BYTES` from `platforms/stub/watchdog_stub.impl.hpp`.
+// The capability macro is only defined inside the impl TU (it's `// IWYU
+// pragma: private`), so the test holds a single-source mirror here so the
+// boundary asserts derive from the contract value rather than a magic
+// literal. If the stub's persist size ever changes, this constant must be
+// updated to match.
+static constexpr fl::size kStubPersistBytes = 16;
+
 FL_TEST_CASE("fl::Watchdog — persist read/write within bounds") {
     Watchdog& dog = Watchdog::instance();
+    // Derive indices from the contract so this test guards the actual
+    // boundary at `idx == kStubPersistBytes`, not a magic constant.
+    constexpr fl::size kLastValid = kStubPersistBytes - 1;
     dog.persistWrite(0, 0xAB);
-    dog.persistWrite(7, 0xCD);
+    dog.persistWrite(kLastValid, 0xCD);
     FL_CHECK_EQ(dog.persistRead(0), 0xAB);
-    FL_CHECK_EQ(dog.persistRead(7), 0xCD);
+    FL_CHECK_EQ(dog.persistRead(kLastValid), 0xCD);
 }
 
 FL_TEST_CASE("fl::Watchdog — persist read/write out of bounds is safe") {
     Watchdog& dog = Watchdog::instance();
-    dog.persistWrite(9999, 0xFF);   // ignored
+    // First invalid index is exactly the boundary — exercises the off-by-one
+    // edge that magic indices like `9999` would silently skip.
+    constexpr fl::size kFirstInvalid = kStubPersistBytes;
+    dog.persistWrite(kFirstInvalid, 0xFF);   // ignored
+    FL_CHECK_EQ(dog.persistRead(kFirstInvalid), 0);
+    dog.persistWrite(9999, 0xFF);            // far out-of-bounds also ignored
     FL_CHECK_EQ(dog.persistRead(9999), 0);
 }
 
@@ -91,9 +108,12 @@ FL_TEST_CASE("fl::Watchdog — Tier 1 surface, flash and bootloader return false
     FL_CHECK_FALSE(dog.rebootIntoBootloader());
 }
 
-FL_TEST_CASE("fl::Watchdog — Tier 2 setWindow returns true on stub") {
+FL_TEST_CASE("fl::Watchdog — Tier 2 setWindow returns false on stub (no window-mode support)") {
+    // Stub does not implement windowed-feed enforcement — `setWindow()` must
+    // return false to match `FL_WATCHDOG_HAS_WINDOW_MODE` NOT being defined,
+    // so user code that branches on the return value behaves correctly.
     Watchdog& dog = Watchdog::instance();
-    FL_CHECK(dog.setWindow(10, 1000));
+    FL_CHECK_FALSE(dog.setWindow(10, 1000));
 }
 
 FL_TEST_CASE("fl::Watchdog — Tier 2 crash report API surface") {
@@ -109,9 +129,12 @@ FL_TEST_CASE("fl::Watchdog — timeout fires callback and increments crash count
     dog.markCleanShutdown();
     dog.clearCrashReport();
 
-    static volatile bool fired = false;
-    fired = false;
-    dog.onTimeout([](void*) { fired = true; }, nullptr);
+    // `fired` is written from the stub's worker thread and read here on the
+    // test thread; `volatile` does NOT provide cross-thread atomicity, so use
+    // fl::atomic<bool>.
+    static fl::atomic<bool> fired;
+    fired.store(false);
+    dog.onTimeout([](void*) { fired.store(true); }, nullptr);
 
     dog.begin(50);
 
@@ -119,7 +142,7 @@ FL_TEST_CASE("fl::Watchdog — timeout fires callback and increments crash count
     // expiry + run the callback + bump the counter.
     fl::this_thread::sleep_for(fl::chrono::milliseconds(300));  // ok sleep for
 
-    FL_CHECK(fired);
+    FL_CHECK(fired.load());
     FL_CHECK(dog.consecutiveCrashCount() >= 1);
     FL_CHECK(dog.lastResetWasWatchdog());
 
@@ -133,9 +156,11 @@ FL_TEST_CASE("fl::Watchdog — feeding before timeout prevents fire") {
     dog.clearCrashReport();
     fl::u16 baseline = dog.consecutiveCrashCount();
 
-    static volatile bool fired = false;
-    fired = false;
-    dog.onTimeout([](void*) { fired = true; }, nullptr);
+    // Same rationale as the previous test case — cross-thread flag must be
+    // atomic, not volatile.
+    static fl::atomic<bool> fired;
+    fired.store(false);
+    dog.onTimeout([](void*) { fired.store(true); }, nullptr);
 
     dog.begin(200);
     for (int i = 0; i < 10; ++i) {
@@ -144,7 +169,7 @@ FL_TEST_CASE("fl::Watchdog — feeding before timeout prevents fire") {
     }
     dog.disable();
 
-    FL_CHECK_FALSE(fired);
+    FL_CHECK_FALSE(fired.load());
     FL_CHECK_EQ(dog.consecutiveCrashCount(), baseline);
 }
 

--- a/tests/fl/wdt/watchdog.cpp
+++ b/tests/fl/wdt/watchdog.cpp
@@ -1,0 +1,168 @@
+// ok cpp include
+//
+// Unit tests for fl::Watchdog (the unified cross-platform watchdog API).
+// Runs against the stub host implementation (`platforms/stub/watchdog_stub.impl.hpp`).
+//
+// FASTLED_STUB_WATCHDOG_NO_ABORT is set so the timeout path doesn't kill the
+// test runner — instead it bumps the crash counter and returns, which is
+// exactly what we need to verify safe-mode behavior.
+
+#define FASTLED_STUB_WATCHDOG_NO_ABORT 1
+
+#include "fl/wdt/watchdog.h"
+#include "fl/stl/chrono.h"
+#include "fl/stl/thread.h"
+#include "test.h"
+
+using namespace fl;
+
+FL_TEST_CASE("fl::Watchdog — singleton accessor returns same instance") {
+    Watchdog& a = Watchdog::instance();
+    Watchdog& b = Watchdog::instance();
+    FL_CHECK_EQ(&a, &b);
+}
+
+FL_TEST_CASE("fl::Watchdog — Tier 0 begin/feed/disable doesn't crash") {
+    Watchdog& dog = Watchdog::instance();
+    dog.disable();
+    dog.begin(10000);
+    dog.feed();
+    dog.disable();
+}
+
+FL_TEST_CASE("fl::Watchdog — persist read/write within bounds") {
+    Watchdog& dog = Watchdog::instance();
+    dog.persistWrite(0, 0xAB);
+    dog.persistWrite(7, 0xCD);
+    FL_CHECK_EQ(dog.persistRead(0), 0xAB);
+    FL_CHECK_EQ(dog.persistRead(7), 0xCD);
+}
+
+FL_TEST_CASE("fl::Watchdog — persist read/write out of bounds is safe") {
+    Watchdog& dog = Watchdog::instance();
+    dog.persistWrite(9999, 0xFF);   // ignored
+    FL_CHECK_EQ(dog.persistRead(9999), 0);
+}
+
+FL_TEST_CASE("fl::Watchdog — safe-mode threshold default is 2") {
+    Watchdog& dog = Watchdog::instance();
+    FL_CHECK_EQ(dog.safeModeThreshold(), 2);
+}
+
+FL_TEST_CASE("fl::Watchdog — setSafeModeThreshold updates the threshold") {
+    Watchdog& dog = Watchdog::instance();
+    dog.setSafeModeThreshold(5);
+    FL_CHECK_EQ(dog.safeModeThreshold(), 5);
+    dog.setSafeModeThreshold(2);   // restore
+}
+
+FL_TEST_CASE("fl::Watchdog — markCleanShutdown resets crash counter") {
+    Watchdog& dog = Watchdog::instance();
+    dog.markCleanShutdown();
+    FL_CHECK_EQ(dog.consecutiveCrashCount(), 0);
+    FL_CHECK_FALSE(dog.isInSafeMode());
+}
+
+FL_TEST_CASE("fl::Watchdog — Tier 1 onTimeout C-callback registers") {
+    Watchdog& dog = Watchdog::instance();
+    static int fired = 0;
+    fired = 0;
+    bool ok = dog.onTimeout([](void* ud) {
+        *static_cast<int*>(ud) = 42;
+    }, &fired);
+    FL_CHECK(ok);
+}
+
+FL_TEST_CASE("fl::Watchdog — Tier 1 onTimeout fl::function overload registers") {
+    Watchdog& dog = Watchdog::instance();
+    bool ok = dog.onTimeout(fl::function<void()>([]() { /* nothing */ }));
+    FL_CHECK(ok);
+}
+
+FL_TEST_CASE("fl::Watchdog — Tier 1 surface, flash and bootloader return false on stub") {
+    Watchdog& dog = Watchdog::instance();
+    // setPauseOnDebug returns true on stub
+    FL_CHECK(dog.setPauseOnDebug(true));
+    // writeCrashLog / readCrashLog not backed by stub flash → false / 0
+    fl::u8 buf[4] = {0};
+    FL_CHECK_FALSE(dog.writeCrashLog(fl::span<const fl::u8>(buf, 4)));
+    FL_CHECK_EQ(dog.readCrashLog(fl::span<fl::u8>(buf, 4)), fl::size{0});
+    // No bootloader-reboot path on host
+    FL_CHECK_FALSE(dog.rebootIntoBootloader());
+}
+
+FL_TEST_CASE("fl::Watchdog — Tier 2 setWindow returns true on stub") {
+    Watchdog& dog = Watchdog::instance();
+    FL_CHECK(dog.setWindow(10, 1000));
+}
+
+FL_TEST_CASE("fl::Watchdog — Tier 2 crash report API surface") {
+    Watchdog& dog = Watchdog::instance();
+    dog.clearCrashReport();
+    FL_CHECK_FALSE(dog.hasCrashReport());
+    WatchdogCrashReport r = dog.readCrashReport();
+    FL_CHECK_FALSE(r.valid);
+}
+
+FL_TEST_CASE("fl::Watchdog — timeout fires callback and increments crash counter") {
+    Watchdog& dog = Watchdog::instance();
+    dog.markCleanShutdown();
+    dog.clearCrashReport();
+
+    static volatile bool fired = false;
+    fired = false;
+    dog.onTimeout([](void*) { fired = true; }, nullptr);
+
+    dog.begin(50);
+
+    // Wait long enough for the stub timer thread (10 ms tick) to detect
+    // expiry + run the callback + bump the counter.
+    fl::this_thread::sleep_for(fl::chrono::milliseconds(300));  // ok sleep for
+
+    FL_CHECK(fired);
+    FL_CHECK(dog.consecutiveCrashCount() >= 1);
+    FL_CHECK(dog.lastResetWasWatchdog());
+
+    dog.clearCrashReport();
+    dog.markCleanShutdown();
+}
+
+FL_TEST_CASE("fl::Watchdog — feeding before timeout prevents fire") {
+    Watchdog& dog = Watchdog::instance();
+    dog.markCleanShutdown();
+    dog.clearCrashReport();
+    fl::u16 baseline = dog.consecutiveCrashCount();
+
+    static volatile bool fired = false;
+    fired = false;
+    dog.onTimeout([](void*) { fired = true; }, nullptr);
+
+    dog.begin(200);
+    for (int i = 0; i < 10; ++i) {
+        fl::this_thread::sleep_for(fl::chrono::milliseconds(50));  // ok sleep for
+        dog.feed();
+    }
+    dog.disable();
+
+    FL_CHECK_FALSE(fired);
+    FL_CHECK_EQ(dog.consecutiveCrashCount(), baseline);
+}
+
+FL_TEST_CASE("fl::Watchdog — isInSafeMode trips at threshold") {
+    Watchdog& dog = Watchdog::instance();
+    dog.markCleanShutdown();
+    dog.setSafeModeThreshold(2);
+
+    // Synthesize crashes via direct timeouts.
+    for (int i = 0; i < 2; ++i) {
+        dog.onTimeout([](void*) {}, nullptr);
+        dog.begin(30);
+        fl::this_thread::sleep_for(fl::chrono::milliseconds(200));  // ok sleep for
+    }
+
+    FL_CHECK(dog.consecutiveCrashCount() >= 2);
+    FL_CHECK(dog.isInSafeMode());
+
+    dog.markCleanShutdown();
+    FL_CHECK_FALSE(dog.isInSafeMode());
+}


### PR DESCRIPTION
## Summary

Phase 1 of the unified cross-platform watchdog API designed in #2731.

Lands the **API surface** + **host-testable stub impl** + **ESP32 refactor** of the existing `fl::watchdog_setup()`. All other platforms route through the no-op fallback (`src/platforms/shared/watchdog_noop.hpp`) — their hardware impls are tracked as follow-ups in #2731.

## What's in this PR

- **Public header** `src/fl/wdt/watchdog.h` — full Tier 0 + Tier 1 + Tier 2 API surface
- **Singleton accessor** `FastLED.watchdog()` matching the existing `FastLED.channelEvents()` pattern
- **Dispatcher** `src/platforms/watchdog.impl.cpp.hpp` (matches `coroutine.impl.cpp.hpp` style)
- **No-op fallback** `src/platforms/shared/watchdog_noop.hpp` (matches `memory_noop.hpp` / `pin_noop.hpp` style — codified in #2732)
- **Stub impl** `src/platforms/stub/watchdog_stub.impl.hpp` — thread-backed deadline timer, full Tier 0 + onTimeout support; never `std::abort()`s the test process so unit tests can verify safe-mode behavior end-to-end
- **WASM impl** `src/platforms/wasm/watchdog_wasm.impl.hpp` — currently routes to no-op (emscripten timer integration is its own follow-up)
- **ESP32 impl** `src/platforms/esp/32/watchdog_esp32.impl.hpp` — wraps the existing `fl::watchdog_setup()` entry point; preserves the IDF v4/v5 weak-symbol panic override + USB-CDC disconnect that fixes the Windows phantom-COM-port bug
- **Tests** `tests/fl/wdt/watchdog.cpp` — 15 cases covering Tier 0 + Tier 1, including timeout-fires + feed-prevents-fire + safe-mode-trips-at-threshold

## What's NOT in this PR

Per-platform hardware implementations for Teensy 4 (`WDT_T4<WDT3>`), Teensy 3.x (K20 register code), RP2040/RP2350 (`hardware/watchdog.h` + scratch[0..3]), nRF52 (`NRF_WDT` + GPREGRET), STM32 (IWDG + RTC BKP), SAMD21/51 (WDT peripheral + SmartEEPROM), AVR (`avr/wdt.h` + EEPROM + `.init3` MCUSR fix), Apollo3 (`am_hal_wdt_*`), MGM240 (`em_wdog.h`), and the WASM emscripten-emulated impl. These are tracked as Phase 2..5 in #2731.

**All of those platforms compile cleanly** in this PR — they route through the no-op fallback. User code that calls `FastLED.watchdog().begin(15000)` works everywhere; on unsupported platforms it's a no-op that lets the sketch keep running.

## Test plan

- [x] `bash test fl_wdt_watchdog --debug` — 15/15 pass on host stub impl (sanitizers enabled)
- [x] `bash lint --cpp` — clean (no banned-header, FL_NOEXCEPT, static-in-header, or sleep-for violations)
- [ ] CI: native build + WASM build + ESP32 platform compile + AVR/Teensy compile (all route through unchanged paths or no-op)
- [ ] Hardware verification per platform — deferred to Phase 2 follow-ups in #2731

## References

- Issue #2731 — full design rationale, per-platform capability matrix, naming notes
- Conventions PR #2732 — codified the `_noop.hpp` and `FL_<COMPONENT>_HAS_*` patterns this PR uses

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a unified Watchdog API accessible from the main singleton: configurable timeout, pre-timeout callbacks, persistent bytes, reset-cause reporting, safe-mode thresholding, crash-report access, and reboot controls (behavior varies by platform).

* **Platform Support**
  * Platform implementations for ESP32, WASM routing, host stub, and a no-op fallback so behavior degrades gracefully.

* **Tests**
  * New unit tests for lifecycle, persistence, callbacks, crash counting, safe-mode, and stub semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->