### PR TITLE
fix(rp): SDK 2.x pio_program init + type-limits + sign-compare hygiene (#2727)

### DIFF
--- a/src/platforms/arm/rp/pin_rp.hpp
+++ b/src/platforms/arm/rp/pin_rp.hpp
@@ -115,7 +115,7 @@ inline u16 analogRead(int pin) FL_NOEXCEPT {
 /// PWM frequency is approximately 244 Hz (system clock / 65536).
 inline void analogWrite(int pin, u16 val) FL_NOEXCEPT {
     // Check if pin supports PWM
-    if (pin >= NUM_BANK0_GPIOS) {
+    if (pin >= static_cast<int>(NUM_BANK0_GPIOS)) {  // #2727 -Wsign-compare
         return;  // Invalid pin for PWM
     }
 
@@ -146,7 +146,7 @@ inline void analogWrite(int pin, u16 val) FL_NOEXCEPT {
 /// PWM frequency is approximately 1.9 Hz @ 125 MHz (system clock / 65536).
 inline void setPwm16(int pin, u16 val) FL_NOEXCEPT {
     // Check if pin supports PWM
-    if (pin >= NUM_BANK0_GPIOS) {
+    if (pin >= static_cast<int>(NUM_BANK0_GPIOS)) {  // #2727 -Wsign-compare
         return;  // Invalid pin for PWM
     }
 
@@ -228,7 +228,7 @@ inline bool needsPwmIsrFallback(int /*pin*/, u32 frequency_hz) {
 /// The PWM output is enabled when analogWrite() or setPwm16() is called.
 inline int setPwmFrequencyNative(int pin, u32 frequency_hz) FL_NOEXCEPT {
     // Validate pin
-    if (pin < 0 || pin >= NUM_BANK0_GPIOS) {
+    if (pin < 0 || pin >= static_cast<int>(NUM_BANK0_GPIOS)) {  // #2727 -Wsign-compare
         return -1;
     }
 
@@ -284,7 +284,7 @@ inline int setPwmFrequencyNative(int pin, u32 frequency_hz) FL_NOEXCEPT {
 /// @param pin GPIO pin number (0-29)
 /// @return Configured frequency in Hz, or 0 if not configured
 inline u32 getPwmFrequencyNative(int pin) FL_NOEXCEPT {
-    if (pin < 0 || pin >= NUM_BANK0_GPIOS) {
+    if (pin < 0 || pin >= static_cast<int>(NUM_BANK0_GPIOS)) {  // #2727 -Wsign-compare
         return 0;
     }
     Rp2040PwmFreq* table = rp_pwm_freq_table();

--- a/src/platforms/arm/rp/rpcommon/pio_gen.h
+++ b/src/platforms/arm/rp/rpcommon/pio_gen.h
@@ -45,6 +45,15 @@ static inline int add_clockless_pio_program(PIO pio, int T1, int T2, int T3) FL_
         .instructions = clockless_pio_instr,
         .length = sizeof(clockless_pio_instr) / sizeof(clockless_pio_instr[0]),
         .origin = -1,
+#if defined(PICO_SDK_VERSION_MAJOR) && PICO_SDK_VERSION_MAJOR >= 2
+        // pico-sdk 2.x (RP2350) added these. Zero-init preserves the previous
+        // implicit behavior while silencing -Wmissing-field-initializers and
+        // documenting intent: no specific PIO version pinned, no GPIO range
+        // pre-claimed. Revisit if RP2350 SDK starts enforcing used_gpio_ranges
+        // at pio_add_program time. #2727
+        .pio_version = 0,
+        .used_gpio_ranges = 0,
+#endif
     };
     
     if (!pio_can_add_program(pio, &clockless_pio_program))

--- a/src/platforms/arm/rp/rpcommon/spi_hw_2_rp.cpp.hpp
+++ b/src/platforms/arm/rp/rpcommon/spi_hw_2_rp.cpp.hpp
@@ -85,6 +85,10 @@ static inline int add_spi_dual_pio_program(PIO pio) {
         .instructions = spi_dual_pio_instr,
         .length = sizeof(spi_dual_pio_instr) / sizeof(spi_dual_pio_instr[0]),
         .origin = -1,
+#if defined(PICO_SDK_VERSION_MAJOR) && PICO_SDK_VERSION_MAJOR >= 2
+        .pio_version = 0,
+        .used_gpio_ranges = 0,
+#endif
     };
 
     if (!pio_can_add_program(pio, &spi_dual_pio_program))

--- a/src/platforms/arm/rp/rpcommon/spi_hw_4_rp.cpp.hpp
+++ b/src/platforms/arm/rp/rpcommon/spi_hw_4_rp.cpp.hpp
@@ -87,6 +87,10 @@ static inline int add_spi_quad_pio_program(PIO pio) {
         .instructions = spi_quad_pio_instr,
         .length = sizeof(spi_quad_pio_instr) / sizeof(spi_quad_pio_instr[0]),
         .origin = -1,
+#if defined(PICO_SDK_VERSION_MAJOR) && PICO_SDK_VERSION_MAJOR >= 2
+        .pio_version = 0,
+        .used_gpio_ranges = 0,
+#endif
     };
 
     if (!pio_can_add_program(pio, &spi_quad_pio_program))
@@ -195,12 +199,16 @@ private:
     bool mTransactionActive;
     bool mInitialized;
 
-    // Configuration
+    // Configuration. Data1/2/3 are i8 so `-1` (the SpiHw4::Config sentinel
+    // for "lane unused") round-trips through the storage and the
+    // `if (mData[1-3]Pin >= 0)` lane-presence checks below work as intended.
+    // Previously these were `u8`, which made the >= 0 checks tautologies
+    // (-Wtype-limits) and silently kept all 4 lanes "active". #2727
     u8 mClockPin;
     u8 mData0Pin;
-    u8 mData1Pin;
-    u8 mData2Pin;
-    u8 mData3Pin;
+    i8 mData1Pin;
+    i8 mData2Pin;
+    i8 mData3Pin;
 
     SPIQuadRP2040(const SPIQuadRP2040&) = delete;
     SPIQuadRP2040& operator=(const SPIQuadRP2040&) = delete;
@@ -225,9 +233,9 @@ SPIQuadRP2040::SPIQuadRP2040(int bus_id, const char* name)
     , mInitialized(false)
     , mClockPin(0)
     , mData0Pin(0)
-    , mData1Pin(0)
-    , mData2Pin(0)
-    , mData3Pin(0) {
+    , mData1Pin(-1)
+    , mData2Pin(-1)
+    , mData3Pin(-1) {
 }
 
 SPIQuadRP2040::~SPIQuadRP2040() {

--- a/src/platforms/arm/rp/rpcommon/spi_hw_8_rp.cpp.hpp
+++ b/src/platforms/arm/rp/rpcommon/spi_hw_8_rp.cpp.hpp
@@ -91,6 +91,10 @@ static inline int add_spi_octal_pio_program(PIO pio) {
         .instructions = spi_octal_pio_instr,
         .length = sizeof(spi_octal_pio_instr) / sizeof(spi_octal_pio_instr[0]),
         .origin = -1,
+#if defined(PICO_SDK_VERSION_MAJOR) && PICO_SDK_VERSION_MAJOR >= 2
+        .pio_version = 0,
+        .used_gpio_ranges = 0,
+#endif
     };
 
     if (!pio_can_add_program(pio, &spi_octal_pio_program))


### PR DESCRIPTION
Closes #2727.

## Summary

Three RP2040/RP2350 warning families fire on every CI build for those boards. None are immediate bugs individually, but together they signal the RP common layer needs a hygiene pass before pico-sdk 2.x lands as the default for RP2350.

## H1. `pio_program` missing initializer for `pio_version` / `used_gpio_ranges`

`pico-sdk 2.x` (RP2350) added `pio_version` and `used_gpio_ranges` to `struct pio_program`. FastLED's four `pio_program` literals omit them, triggering `-Wmissing-field-initializers` and (more dangerously) leaving the new fields zero-initialized by C++ aggregate rules. On RP2350 \"no GPIO range claimed\" could become a runtime failure the moment the SDK starts validating it.

**Fix:** explicitly initialize both new fields to 0 under `#if defined(PICO_SDK_VERSION_MAJOR) && PICO_SDK_VERSION_MAJOR >= 2` guards in all 4 literals:
- `src/platforms/arm/rp/rpcommon/pio_gen.h:48`
- `src/platforms/arm/rp/rpcommon/spi_hw_2_rp.cpp.hpp:88`
- `src/platforms/arm/rp/rpcommon/spi_hw_4_rp.cpp.hpp:90`
- `src/platforms/arm/rp/rpcommon/spi_hw_8_rp.cpp.hpp:94`

Preserves current behavior, silences the warning, and documents the field-init choice in one place to revisit when RP2350-SDK ergonomics solidify.

## H2. `-Wtype-limits` always-true on `mData[1-3]Pin >= 0`

In `spi_hw_4_rp.cpp.hpp` the data-lane pin presence checks read:

```cpp
if (mData1Pin >= 0 && mData2Pin >= 0 && mData3Pin >= 0)
```

But the fields are `u8`, so the comparisons are tautologies. The `SpiHw4::Config` source fields are `i8` with `-1` as the \"unused lane\" sentinel (see `src/platforms/shared/spi_hw_4.h:44-46`), so the intent was clearly \"lane is configured\". **Currently broken:** the storage truncates `-1` to `0xFF` and every lane is treated as active in the quad-mode check.

**Fix:** change `mData1Pin / mData2Pin / mData3Pin` from `u8` to `i8` so `-1` round-trips. Update constructor initializers from `0` to `-1` to match the Config defaults. `mData0Pin` and `mClockPin` stay `u8` (always required, never sentinel-valued). Lane-presence checks now work as intended.

## H3. `-Wsign-compare` in `pin_rp.hpp` (`int pin` vs unsigned `NUM_BANK0_GPIOS`)

Four loop-bound checks in `pin_rp.hpp` compare `int pin` against `NUM_BANK0_GPIOS` (unsigned from pico-sdk). Cast the bound to `int` inline — the cast is exact since `NUM_BANK0_GPIOS` fits in `int` on both RP2040 and RP2350.

## Test plan

- [x] `bash lint` clean
- [ ] CI green on rp2040 / rp2350
- [ ] Verify H2 lane-count regression: a 1-lane SPIQuad config previously silently used 4 lanes; should now correctly skip the quad-mode consecutive-pin requirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed SPI quad mode pin configuration handling for multi-lane data support
  * Enhanced compatibility with Pico SDK version 2 and later releases

* **Refactor**
  * Updated pin validation logic in PWM-related functions
  * Improved struct initialization patterns for better SDK compatibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->