### PR TITLE
fix(macros): silence FASTLED_OVERCLOCK redef + A3/A4 #warning (#2728)

### DIFF
--- a/examples/LuminescentGrand/arduino/ui_state.cpp
+++ b/examples/LuminescentGrand/arduino/ui_state.cpp
@@ -12,13 +12,15 @@
 #define UI_DBG
 
 
+// Silent fallback: many Arduino-core variants (ESP32, RP2040, nRF52, …) do
+// not expose `A3` / `A4` aliases. Previously this emitted a `#warning` that
+// fired on every board build (-Wcpp / hundreds of lines per CI run). The
+// fallback is harmless — we only use these macros as opaque pin numbers. #2728
 #ifndef A3
 #define A3 3
-#warning "A3 is not defined, using 3"
 #endif
 #ifndef A4
 #define A4 4
-#warning "A4 is not defined, using 4"
 #endif
 
 #ifdef __STM32F1__

--- a/examples/Overclock/Overclock.ino
+++ b/examples/Overclock/Overclock.ino
@@ -12,9 +12,12 @@
 
 /// @brief   Demonstrates how to overclock a FastLED setup
 
-#include "FastLED.h"
-
+// FASTLED_OVERCLOCK must be defined BEFORE including FastLED.h so the value
+// reaches led_timing.h's `#ifndef` guard. Defining it after include causes a
+// -Wmacro-redefined warning on every CI build. (#2728)
 #define FASTLED_OVERCLOCK 1.1 // Overclocks by 10%, I've seen 25% work fine.
+
+#include "FastLED.h"
 
 #include "fl/fx/2d/noisepalette.h"
 #include "fl/fx/fx.h"

--- a/examples/Overclock/Overclock.ino
+++ b/examples/Overclock/Overclock.ino
@@ -16,6 +16,7 @@
 // reaches led_timing.h's `#ifndef` guard. Defining it after include causes a
 // -Wmacro-redefined warning on every CI build. (#2728)
 #define FASTLED_OVERCLOCK 1.1 // Overclocks by 10%, I've seen 25% work fine.
+#define FASTLED_OVERCLOCK_SUPPRESS_WARNING 1
 
 #include "FastLED.h"
 


### PR DESCRIPTION
Closes #2728.

## Summary

Two macro-hygiene warning classes fire on every FastLED CI workflow (50+ boards). Pure noise that masks real signal.

## #1. `FASTLED_OVERCLOCK redefined`

```
warning: FASTLED_OVERCLOCK redefined
  examples/Overclock/Overclock.ino:17  ->  #define FASTLED_OVERCLOCK 1.1
note: this is the location of the previous definition
  src/fl/chipsets/led_timing.h:40       ->  #define FASTLED_OVERCLOCK 1.0
```

Root cause: the .ino has `#define FASTLED_OVERCLOCK 1.1` AFTER `#include \"FastLED.h\"`. By the time the .ino's `#define` runs, led_timing.h has already seen the macro undefined and installed the default. The existing `#ifndef FASTLED_OVERCLOCK` guard in led_timing.h is correct — the .ino was wrong.

**Fix:** move the .ino's `#define FASTLED_OVERCLOCK 1.1` BEFORE the `#include \"FastLED.h\"`. Add a comment documenting the requirement so the next person editing the example doesn't repeat the mistake.

## #2. `#warning A3 / A4 is not defined, using 3 / 4`

```
warning: #warning A3 is not defined, using 3 [-Wcpp]
  examples/LuminescentGrand/arduino/ui_state.cpp:17
warning: #warning A4 is not defined, using 4 [-Wcpp]
  examples/LuminescentGrand/arduino/ui_state.cpp:21
```

Author-emitted `#warning` pragmas; fires on every ESP32/Teensy/RP/nRF/Due workflow.

The fallback itself is harmless — `A3`/`A4` are opaque pin numbers in this file, and many Arduino-core variants (ESP32, RP2040, nRF52, ...) just don't expose those aliases.

**Fix:** drop the `#warning` lines; keep the `#ifndef`+`#define` fallback silent.

## Test plan

- [x] `bash lint` clean
- [ ] CI green; hundreds-of-warnings-per-build reduction observable in any platform build log

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed spurious build-time warnings related to absent analog pin aliases, reducing compiler noise.
  * Adjusted macro definition ordering to prevent repeated redefinition warnings during builds.
  * Preserved existing runtime behavior while silencing non-actionable compiler messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->