### PR TITLE
chore(deps): bump zccache to >=1.11.11 (depfile-on-cache-hit fix)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,14 @@ dependencies = [
     "fpvgcc",
     "uv",
     "clang-tool-chain>=1.5.5",
-    "zccache>=1.11.9",
+    # 1.11.11 ships the depfile-on-cache-hit fix (zackees/zccache#643): cache
+    # hits now restore the user's `-MF <path>` depfile alongside the .obj.
+    # Without it ninja's `deps = gcc` mode records `#deps 0` for every
+    # cached object, so incremental builds silently produce stale .obj
+    # files after a `git pull` that changes transitive headers — symptom
+    # is an `undefined symbol: ...` link error hours after a header
+    # actually changed.
+    "zccache>=1.11.11",
     "ninja",
     "meson>=1.11.0",
     "download",


### PR DESCRIPTION
## Summary

Bumps the `zccache` floor from 1.11.9 to 1.11.11 to pick up zackees/zccache#644 — cache hits now restore the user's `-MF <path>` depfile alongside the `.obj`.

## Why this matters

Without the upstream fix, the build system reading depfiles consumed an absent file on every zccache hit and recorded **zero** dependencies for the cached object. From that point on, transitive header changes never triggered a rebuild of the affected .obj. Symptom: `undefined symbol: ...` link errors hours after a `git pull` that legitimately modified an included header, with no visible reason for the build to be using stale objects (the host build system's deps database said \"up to date\").

Verified in this very repo: \`-t deps\` on the meson-quick build dir reported \`#deps 0\` for **354 of ~1500 build records** — every single C/C++ object file had no recorded dependencies. The downstream symptom: \`fl_gfx_rgbw_colorimetric.dll\` failed to link with \`undefined symbol: fl::enable_rgbw_colorimetric_lut(int, fl::RgbwLutInterp)\` after #2721 merged on master — the new symbol was added but the cached object was reused.

## Upstream timeline

- Issue: zackees/zccache#643 (with reproducer)
- Fix PR: zackees/zccache#644 (merged @ 5fb9f54)
- Release: zccache 1.11.11 published to PyPI (verified 6 wheels live)

## Test plan

- [x] \`uv sync --refresh-package zccache\` upgrades to 1.11.11 locally
- [x] FastLED unit tests still green (307/307) after the upgrade
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated zccache dependency to improve build correctness and address cache handling edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->