### PR TITLE
chore(deps): bump zccache 1.11.9 -> 1.11.11 (partial fix for zackees/zccache#637)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,17 @@ dependencies = [
     "fpvgcc",
     "uv",
     "clang-tool-chain>=1.5.5",
-    "zccache>=1.11.9",
+    # 1.11.11 ships the partial fix for zackees/zccache#637 (Windows daemon
+    # thundering-herd spawn race): PR #639 turns the post-bind "Access is
+    # denied" PermissionDenied / AddrInUse / AlreadyExists into a clean
+    # "deferring to existing daemon" INFO + exit 0 (no more spurious ERROR
+    # log entries when the loser-of-bind exits), and PR #641 adds the
+    # pre-bind probe wedge that short-circuits any second-wave spawn before
+    # the depgraph load when a lock file is present (covers most of the 277
+    # spawn cascade observed in the original repro). The remaining
+    # first-wave collapse tracked in zackees/zccache#640 (ArcSwap<DepGraph>
+    # refactor — meaningful work, not blocking).
+    "zccache>=1.11.11",
     "ninja",
     "meson>=1.11.0",
     "download",


### PR DESCRIPTION
Bumps the FastLED floor for zccache from `>=1.11.9` to `>=1.11.11`. Picks up the partial fix for the Windows daemon thundering-herd spawn race I reported in [zackees/zccache#637](https://github.com/zackees/zccache/issues/637).

## What 1.11.11 ships

- **zackees/zccache#639** — post-bind `Access is denied` / `AddrInUse` / `AlreadyExists` are now treated as "deferring to existing daemon" (`INFO` + `exit 0`) instead of `ERROR`. Spurious failure entries in the daemon lifecycle log disappear.
- **zackees/zccache#641** — pre-bind probe wedge. Before any heavy init (defender banner, lock-file write, depgraph load), a freshly-spawned daemon reads the lock file, verifies the recorded PID is alive, and tries a 500 ms IPC connect. If all three succeed, it exits 0 cleanly without loading the depgraph. Covers the second-wave spawn pressure (any spawn after the first daemon won the bind and wrote the lock file).

## What's still pending

- **zackees/zccache#640** — first-wave collapse (multiple parallel build-tool clients all racing on initial spawn before any lock file exists). Needs a meaningful `ArcSwap<DepGraph>` refactor so the bind can land first and the accept loop can start immediately while the graph loads asynchronously. The zccache author's words: *"a meaningful refactor (server-side audit + thread-safe `set_dep_graph` post-bind)"*. Not blocking us; we'll pick it up in a follow-up bump when it ships.

## Local verification

- `uv sync --refresh` installs 1.11.11 cleanly (Windows + Python 3.13).
- After `zccache stop`, the next spawn logs `reason: "initial-start"` (not `replaced-comm-error`) and successfully migrates the depgraph from v4 to v5 with a graceful cold-start fallback.
- `bash test fl_task_promise --debug --clean` passes 1/1 in 92.85s with zero daemon-side errors.

## What this prevents

The original repro on master with 1.11.10 had 277 daemon-spawn log files in a 3-hour window and 126 `replaced-comm-error` events — the symptom upstream was test DLLs failing to load with Windows error code 126 because `fastled.dll` was being linked with `--allow-shlib-undefined` after the daemon dropped mid-build. 1.11.11 should remove most of those errors; the residual first-wave race is tracked in #640 and doesn't produce silently-corrupt DLLs anymore because the loser-of-bind now exits cleanly instead of dying mid-handshake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Dependencies**
  * Updated zccache to version 1.11.11 with improvements to daemon spawn and lock-file handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->