### PR TITLE
feat(watchdog): real per-platform hardware impls for ALL platforms (#2731 Phase 2)

### DIFF
--- a/src/platforms/apollo3/watchdog_apollo3.impl.hpp
+++ b/src/platforms/apollo3/watchdog_apollo3.impl.hpp
@@ -1,0 +1,115 @@
+// IWYU pragma: private
+
+/// @file platforms/apollo3/watchdog_apollo3.impl.hpp
+/// @brief Apollo3 (SparkFun Artemis) watchdog implementation.
+///
+/// `am_hal_wdt_*` from AmbiqSuite SDK. LFRC-clocked (~1 kHz). Reset cause
+/// from `RSTGEN->STAT`. Persist storage in-RAM only; Phase 3 follow-up can
+/// move it to internal flash via `am_hal_flash_*`.
+
+#include "fl/wdt/watchdog.h"
+
+// IWYU pragma: begin_keep
+#include <am_mcu_apollo.h>   // ok include — AmbiqSuite SDK
+// IWYU pragma: end_keep
+
+#define FL_WATCHDOG_HAS_HARDWARE
+#define FL_WATCHDOG_PERSIST_BYTES 8
+#define FL_WATCHDOG_MAX_TIMEOUT_MS 250000u
+
+namespace fl {
+namespace platforms {
+
+struct Apollo3WatchdogState {
+    fl::u8     persist[FL_WATCHDOG_PERSIST_BYTES] = {0};
+    fl::u16    crash_count = 0;
+    bool       armed = false;
+    ResetCause cached_cause = ResetCause::UNKNOWN;
+    bool       cause_cached = false;
+};
+
+inline Apollo3WatchdogState& apollo3WatchdogState() {
+    static Apollo3WatchdogState s{};  // okay static in header — single-TU `.impl.hpp`
+    return s;
+}
+
+} // namespace platforms
+
+Watchdog& Watchdog::instance() FL_NOEXCEPT {
+    static Watchdog sInstance;
+    return sInstance;
+}
+
+void Watchdog::begin(fl::u32 timeout_ms) FL_NOEXCEPT {
+    if (timeout_ms == 0) timeout_ms = 1000;
+    if (timeout_ms > FL_WATCHDOG_MAX_TIMEOUT_MS) timeout_ms = FL_WATCHDOG_MAX_TIMEOUT_MS;
+    // LFRC ticks at ~1 kHz so `ui32ResetCount` in ms ≈ timeout in counts.
+    am_hal_wdt_config_t cfg = {};
+    cfg.ui32Config = AM_HAL_WDT_LFRC_CLK_DEFAULT | AM_HAL_WDT_ENABLE_RESET;
+    cfg.ui16InterruptCount = 0;
+    cfg.ui16ResetCount = static_cast<fl::u16>((timeout_ms > 65535u) ? 65535u : timeout_ms);
+    am_hal_wdt_init(&cfg);
+    am_hal_wdt_start();
+    platforms::apollo3WatchdogState().armed = true;
+}
+
+void Watchdog::feed() FL_NOEXCEPT {
+    am_hal_wdt_restart();
+}
+
+void Watchdog::disable() FL_NOEXCEPT {
+    am_hal_wdt_halt();
+    platforms::apollo3WatchdogState().armed = false;
+}
+
+ResetCause Watchdog::lastResetCause() const FL_NOEXCEPT {
+    // Apollo3 cause detection from RSTGEN->STAT is deferred — the AmbiqSuite
+    // SDK signature wants a `uint32_t*` and translating each `AM_HAL_RESET_*`
+    // bit needs hardware verification. Tracked as a Phase 3 follow-up. For
+    // now we report UNKNOWN; the crash counter still increments correctly on
+    // any reset via persist storage that survives Phase 3's flash backing.
+    return ResetCause::UNKNOWN;
+}
+
+bool Watchdog::lastResetWasWatchdog() const FL_NOEXCEPT {
+    return lastResetCause() == ResetCause::WATCHDOG;
+}
+
+fl::u8 Watchdog::persistRead(fl::size idx) const FL_NOEXCEPT {
+    if (idx >= FL_WATCHDOG_PERSIST_BYTES) return 0;
+    return platforms::apollo3WatchdogState().persist[idx];
+}
+void Watchdog::persistWrite(fl::size idx, fl::u8 v) FL_NOEXCEPT {
+    if (idx >= FL_WATCHDOG_PERSIST_BYTES) return;
+    platforms::apollo3WatchdogState().persist[idx] = v;
+}
+
+fl::u16 Watchdog::consecutiveCrashCount() const FL_NOEXCEPT {
+    (void)lastResetCause();
+    return platforms::apollo3WatchdogState().crash_count;
+}
+void Watchdog::markCleanShutdown() FL_NOEXCEPT { platforms::apollo3WatchdogState().crash_count = 0; }
+bool Watchdog::isInSafeMode() const FL_NOEXCEPT { return consecutiveCrashCount() >= mSafeModeThreshold; }
+fl::u16 Watchdog::safeModeThreshold() const FL_NOEXCEPT { return mSafeModeThreshold; }
+void    Watchdog::setSafeModeThreshold(fl::u16 t) FL_NOEXCEPT { mSafeModeThreshold = t; }
+
+FL_NORETURN void Watchdog::reboot() FL_NOEXCEPT {
+    am_hal_reset_control(AM_HAL_RESET_CONTROL_SWPOR, 0);
+    while (true) {}
+}
+
+bool Watchdog::onTimeout(WatchdogTimeoutCallback, void*) FL_NOEXCEPT { return false; }
+bool Watchdog::onTimeout(fl::function<void()>) FL_NOEXCEPT { return false; }
+bool Watchdog::setPauseOnDebug(bool) FL_NOEXCEPT { return false; }
+bool Watchdog::writeCrashLog(fl::span<const fl::u8>) FL_NOEXCEPT { return false; }
+fl::size Watchdog::readCrashLog(fl::span<fl::u8>) const FL_NOEXCEPT { return 0; }
+bool Watchdog::rebootIntoBootloader() FL_NOEXCEPT { return false; }
+
+bool Watchdog::setWindow(fl::u32, fl::u32) FL_NOEXCEPT { return false; }
+bool Watchdog::hasCrashReport() const FL_NOEXCEPT { return false; }
+WatchdogCrashReport Watchdog::readCrashReport() const FL_NOEXCEPT {
+    WatchdogCrashReport r{}; r.valid = false; r.fault_type = ""; return r;
+}
+void Watchdog::clearCrashReport() FL_NOEXCEPT {}
+
+} // namespace fl

--- a/src/platforms/apollo3/watchdog_apollo3.impl.hpp
+++ b/src/platforms/apollo3/watchdog_apollo3.impl.hpp
@@ -63,12 +63,37 @@ void Watchdog::disable() FL_NOEXCEPT {
 }
 
 ResetCause Watchdog::lastResetCause() const FL_NOEXCEPT {
-    // Apollo3 cause detection from RSTGEN->STAT is deferred — the AmbiqSuite
-    // SDK signature wants a `uint32_t*` and translating each `AM_HAL_RESET_*`
-    // bit needs hardware verification. Tracked as a Phase 3 follow-up. For
-    // now we report UNKNOWN; the crash counter still increments correctly on
-    // any reset via persist storage that survives Phase 3's flash backing.
-    return ResetCause::UNKNOWN;
+    auto& s = platforms::apollo3WatchdogState();
+    if (!s.cause_cached) {
+        // Read the Apollo3 reset status register directly. `RSTGEN->STAT`
+        // exposes one bit per reset source per the Apollo3 datasheet:
+        //   bit 0  EXRSTAT  external pin
+        //   bit 1  PORSTAT  power-on reset
+        //   bit 2  BORSTAT  brown-out reset
+        //   bit 3  SWRSTAT  software reset (AIRCR SYSRESETREQ)
+        //   bit 4  POIRSTAT power-on initialized (software POR)
+        //   bit 5  DBGRSTAT debugger reset
+        //   bit 6  POISTAT  power-on initiated
+        //   bit 7  WDRSTAT  watchdog timer
+        // "Specific first" priority puts watchdog above the generic POR/BOR
+        // bits because the latter are often also set after a watchdog reset.
+        const fl::u32 stat = RSTGEN->STAT;
+        ResetCause cause = ResetCause::UNKNOWN;
+        if      (stat & (1u << 7)) cause = ResetCause::WATCHDOG;
+        else if (stat & (1u << 3)) cause = ResetCause::SOFTWARE;
+        else if (stat & (1u << 4)) cause = ResetCause::SOFTWARE;
+        else if (stat & (1u << 5)) cause = ResetCause::DEBUGGER;
+        else if (stat & (1u << 2)) cause = ResetCause::BROWNOUT;
+        else if (stat & (1u << 0)) cause = ResetCause::EXTERNAL_PIN;
+        else if (stat & (1u << 1)) cause = ResetCause::POWER_ON;
+        else if (stat & (1u << 6)) cause = ResetCause::POWER_ON;
+        s.cached_cause = cause;
+        s.cause_cached = true;
+        if (cause == ResetCause::WATCHDOG && s.crash_count < 0xFFFF) {
+            s.crash_count++;
+        }
+    }
+    return s.cached_cause;
 }
 
 bool Watchdog::lastResetWasWatchdog() const FL_NOEXCEPT {

--- a/src/platforms/apollo3/watchdog_apollo3.impl.hpp
+++ b/src/platforms/apollo3/watchdog_apollo3.impl.hpp
@@ -87,6 +87,13 @@ ResetCause Watchdog::lastResetCause() const FL_NOEXCEPT {
         else if (stat & (1u << 0)) cause = ResetCause::EXTERNAL_PIN;
         else if (stat & (1u << 1)) cause = ResetCause::POWER_ON;
         else if (stat & (1u << 6)) cause = ResetCause::POWER_ON;
+        // RSTGEN->STAT bits are sticky across resets. Writing 1 to the
+        // matching CLRSTAT bit clears them so the NEXT boot sees only
+        // its own reset cause and the crash counter isn't inflated by
+        // stale bits. (AmbiqSuite's `am_hal_reset_status_clear()` does
+        // the same — we write the register directly to avoid pulling in
+        // an additional HAL header.)
+        RSTGEN->CLRSTAT = 1u;
         s.cached_cause = cause;
         s.cause_cached = true;
         if (cause == ResetCause::WATCHDOG && s.crash_count < 0xFFFF) {

--- a/src/platforms/arm/k20/watchdog_k20.impl.hpp
+++ b/src/platforms/arm/k20/watchdog_k20.impl.hpp
@@ -1,0 +1,157 @@
+// IWYU pragma: private
+
+/// @file platforms/arm/k20/watchdog_k20.impl.hpp
+/// @brief Teensy 3.x (K20/K66/KL26) watchdog implementation.
+///
+/// Direct `WDOG` register access via the Kinetis SDK. **Configuration is
+/// one-shot** within ~256 bus cycles of the unlock sequence; conventionally
+/// done from `startup_early_hook()` before `main()`. Since we cannot reliably
+/// intercept that hook without conflicting with sketches that override it,
+/// `begin()` only refreshes the prescaler/timeout values via the unlock
+/// window — if Teensyduino's default `startup_early_hook()` already wrote
+/// `ALLOWUPDATE`, this works. Otherwise `begin()` is a no-op.
+///
+/// Reset cause from `RCM_SRS0`/`RCM_SRS1`. Persist storage is in-RAM only;
+/// Phase 3 follow-up can move it to a custom `.noinit` SRAM section.
+
+#include "fl/wdt/watchdog.h"
+
+// IWYU pragma: begin_keep
+#include <kinetis.h>   // ok include — WDOG / RCM register macros
+// IWYU pragma: end_keep
+
+#define FL_WATCHDOG_HAS_HARDWARE
+#define FL_WATCHDOG_PERSIST_BYTES 8
+#define FL_WATCHDOG_MAX_TIMEOUT_MS 60000u
+
+namespace fl {
+namespace platforms {
+
+struct K20WatchdogState {
+    fl::u8     persist[FL_WATCHDOG_PERSIST_BYTES] = {0};
+    fl::u16    crash_count = 0;
+    bool       armed = false;
+    ResetCause cached_cause = ResetCause::UNKNOWN;
+    bool       cause_cached = false;
+};
+
+inline K20WatchdogState& k20WatchdogState() {
+    static K20WatchdogState s{};  // okay static in header — single-TU `.impl.hpp`
+    return s;
+}
+
+// Translate RCM_SRS0/SRS1 to fl::ResetCause. K20/K66 priority: most-specific first.
+inline ResetCause translateRcmSrs(fl::u8 srs0, fl::u8 srs1) {
+    (void)srs1;  // SRS1 bits (LOCKUP/SW/MDM_AP/SACKERR) handled below
+    if (srs0 & 0x20) return ResetCause::WATCHDOG;       // RCM_SRS0_WDOG
+    if (srs0 & 0x02) return ResetCause::BROWNOUT;       // RCM_SRS0_LVD
+    if (srs0 & 0x40) return ResetCause::EXTERNAL_PIN;   // RCM_SRS0_PIN
+    if (srs0 & 0x80) return ResetCause::POWER_ON;       // RCM_SRS0_POR
+    if (srs1 & 0x02) return ResetCause::LOCKUP;         // RCM_SRS1_LOCKUP
+    if (srs1 & 0x04) return ResetCause::SOFTWARE;       // RCM_SRS1_SW
+    if (srs1 & 0x08) return ResetCause::DEBUGGER;       // RCM_SRS1_MDM_AP
+    return ResetCause::UNKNOWN;
+}
+
+inline void k20UnlockAndConfigureWdog(fl::u32 timeout_ms) {
+    // Standard Kinetis WDOG unlock sequence: write 0xC520 then 0xD928 to
+    // WDOG_UNLOCK within bus-clock window. Then exactly ONE write to
+    // WDOG_STCTRLH is permitted before lockout. We program LPO-clocked
+    // (~1 kHz) so timeout_ms ≈ TOVAL count.
+    __disable_irq();
+    WDOG_UNLOCK = 0xC520;
+    WDOG_UNLOCK = 0xD928;
+    // Two NOPs per the reference manual to satisfy the timing requirement.
+    __asm__ volatile ("nop");
+    __asm__ volatile ("nop");
+    fl::u32 toval = timeout_ms;
+    if (toval == 0) toval = 1;
+    WDOG_TOVALH = static_cast<fl::u16>((toval >> 16) & 0xFFFF);
+    WDOG_TOVALL = static_cast<fl::u16>(toval & 0xFFFF);
+    // STCTRLH: ALLOWUPDATE | WDOGEN | LPO clock
+    WDOG_STCTRLH = 0x01D1;
+    __enable_irq();
+}
+
+} // namespace platforms
+
+Watchdog& Watchdog::instance() FL_NOEXCEPT {
+    static Watchdog sInstance;
+    return sInstance;
+}
+
+void Watchdog::begin(fl::u32 timeout_ms) FL_NOEXCEPT {
+    if (timeout_ms == 0) timeout_ms = 1000;
+    if (timeout_ms > FL_WATCHDOG_MAX_TIMEOUT_MS) timeout_ms = FL_WATCHDOG_MAX_TIMEOUT_MS;
+    platforms::k20UnlockAndConfigureWdog(timeout_ms);
+    platforms::k20WatchdogState().armed = true;
+}
+
+void Watchdog::feed() FL_NOEXCEPT {
+    // Refresh sequence: 0xA602 then 0xB480 with interrupts disabled.
+    __disable_irq();
+    WDOG_REFRESH = 0xA602;
+    WDOG_REFRESH = 0xB480;
+    __enable_irq();
+}
+
+void Watchdog::disable() FL_NOEXCEPT {
+    // K20 WDOG is one-shot configurable. We cannot reliably disable mid-run.
+    // Document the limitation: post-disable() the watchdog still ticks. The
+    // caller must continue feeding it or accept a reset.
+}
+
+ResetCause Watchdog::lastResetCause() const FL_NOEXCEPT {
+    auto& s = platforms::k20WatchdogState();
+    if (!s.cause_cached) {
+        s.cached_cause = platforms::translateRcmSrs(RCM_SRS0, RCM_SRS1);
+        s.cause_cached = true;
+        if (s.cached_cause == ResetCause::WATCHDOG && s.crash_count < 0xFFFF) {
+            s.crash_count++;
+        }
+    }
+    return s.cached_cause;
+}
+
+bool Watchdog::lastResetWasWatchdog() const FL_NOEXCEPT {
+    return lastResetCause() == ResetCause::WATCHDOG;
+}
+
+fl::u8 Watchdog::persistRead(fl::size idx) const FL_NOEXCEPT {
+    if (idx >= FL_WATCHDOG_PERSIST_BYTES) return 0;
+    return platforms::k20WatchdogState().persist[idx];
+}
+void Watchdog::persistWrite(fl::size idx, fl::u8 v) FL_NOEXCEPT {
+    if (idx >= FL_WATCHDOG_PERSIST_BYTES) return;
+    platforms::k20WatchdogState().persist[idx] = v;
+}
+
+fl::u16 Watchdog::consecutiveCrashCount() const FL_NOEXCEPT {
+    (void)lastResetCause();
+    return platforms::k20WatchdogState().crash_count;
+}
+void Watchdog::markCleanShutdown() FL_NOEXCEPT { platforms::k20WatchdogState().crash_count = 0; }
+bool Watchdog::isInSafeMode() const FL_NOEXCEPT { return consecutiveCrashCount() >= mSafeModeThreshold; }
+fl::u16 Watchdog::safeModeThreshold() const FL_NOEXCEPT { return mSafeModeThreshold; }
+void    Watchdog::setSafeModeThreshold(fl::u16 t) FL_NOEXCEPT { mSafeModeThreshold = t; }
+
+FL_NORETURN void Watchdog::reboot() FL_NOEXCEPT {
+    SCB_AIRCR = 0x05FA0004;
+    while (true) {}
+}
+
+bool Watchdog::onTimeout(WatchdogTimeoutCallback, void*) FL_NOEXCEPT { return false; }
+bool Watchdog::onTimeout(fl::function<void()>) FL_NOEXCEPT { return false; }
+bool Watchdog::setPauseOnDebug(bool) FL_NOEXCEPT { return false; }
+bool Watchdog::writeCrashLog(fl::span<const fl::u8>) FL_NOEXCEPT { return false; }
+fl::size Watchdog::readCrashLog(fl::span<fl::u8>) const FL_NOEXCEPT { return 0; }
+bool Watchdog::rebootIntoBootloader() FL_NOEXCEPT { return false; }
+
+bool Watchdog::setWindow(fl::u32, fl::u32) FL_NOEXCEPT { return false; }
+bool Watchdog::hasCrashReport() const FL_NOEXCEPT { return false; }
+WatchdogCrashReport Watchdog::readCrashReport() const FL_NOEXCEPT {
+    WatchdogCrashReport r{}; r.valid = false; r.fault_type = ""; return r;
+}
+void Watchdog::clearCrashReport() FL_NOEXCEPT {}
+
+} // namespace fl

--- a/src/platforms/arm/mgm240/watchdog_mgm240.impl.hpp
+++ b/src/platforms/arm/mgm240/watchdog_mgm240.impl.hpp
@@ -1,0 +1,147 @@
+// IWYU pragma: private
+
+/// @file platforms/arm/mgm240/watchdog_mgm240.impl.hpp
+/// @brief MGM240 (Silicon Labs EFR32MG24, Arduino Nano Matter) watchdog impl.
+///
+/// `WDOG0` via `em_wdog.h` from the Gecko SDK. **Avoid `WDOG1`** — it may be
+/// claimed by the Matter / OpenThread stack on radio-enabled builds.
+///
+/// Reset cause from `EMU->RSTCAUSE`. Persist storage in-RAM only; Phase 3
+/// follow-up can move it to BURAM / RETREG / NVM3.
+
+#include "fl/wdt/watchdog.h"
+
+// IWYU pragma: begin_keep
+#include <em_wdog.h>   // ok include — SiLabs Gecko SDK
+#include <em_emu.h>    // ok include — EMU->RSTCAUSE
+// IWYU pragma: end_keep
+
+#define FL_WATCHDOG_HAS_HARDWARE
+#define FL_WATCHDOG_PERSIST_BYTES 8
+#define FL_WATCHDOG_MAX_TIMEOUT_MS 32000u
+
+namespace fl {
+namespace platforms {
+
+struct Mgm240WatchdogState {
+    fl::u8     persist[FL_WATCHDOG_PERSIST_BYTES] = {0};
+    fl::u16    crash_count = 0;
+    bool       armed = false;
+    ResetCause cached_cause = ResetCause::UNKNOWN;
+    bool       cause_cached = false;
+};
+
+inline Mgm240WatchdogState& mgm240WatchdogState() {
+    static Mgm240WatchdogState s{};  // okay static in header — single-TU `.impl.hpp`
+    return s;
+}
+
+inline ResetCause translateMgm240RstCause(fl::u32 cause) {
+    // EFR32MG24 EMU_RSTCAUSE bits per reference manual.
+    if (cause & EMU_RSTCAUSE_WDOG0)  return ResetCause::WATCHDOG;
+    if (cause & EMU_RSTCAUSE_LOCKUP) return ResetCause::LOCKUP;
+    if (cause & EMU_RSTCAUSE_SYSREQ) return ResetCause::SOFTWARE;
+    if (cause & EMU_RSTCAUSE_PIN)    return ResetCause::EXTERNAL_PIN;
+    if (cause & EMU_RSTCAUSE_POR)    return ResetCause::POWER_ON;
+    return ResetCause::UNKNOWN;
+}
+
+// Map ms timeout to nearest `WDOG_PeriodSel_TypeDef`. LFRCO ~32.768 kHz; the
+// period field is power-of-two counts: 9 (256 cycles ≈ 8 ms) up through
+// 17 (65536 cycles ≈ 2 s) and beyond. Pick smallest period >= requested.
+inline WDOG_PeriodSel_TypeDef mgm240PickPeriod(fl::u32 ms) {
+    if (ms <=    8) return wdogPeriod_9;
+    if (ms <=   16) return wdogPeriod_16;
+    if (ms <=   32) return wdogPeriod_32;
+    if (ms <=   64) return wdogPeriod_64;
+    if (ms <=  125) return wdogPeriod_128;
+    if (ms <=  250) return wdogPeriod_256;
+    if (ms <=  500) return wdogPeriod_512;
+    if (ms <= 1000) return wdogPeriod_1k;
+    if (ms <= 2000) return wdogPeriod_2k;
+    if (ms <= 4000) return wdogPeriod_4k;
+    if (ms <= 8000) return wdogPeriod_8k;
+    if (ms <=16000) return wdogPeriod_16k;
+    return wdogPeriod_32k;
+}
+
+} // namespace platforms
+
+Watchdog& Watchdog::instance() FL_NOEXCEPT {
+    static Watchdog sInstance;
+    return sInstance;
+}
+
+void Watchdog::begin(fl::u32 timeout_ms) FL_NOEXCEPT {
+    if (timeout_ms == 0) timeout_ms = 1000;
+    if (timeout_ms > FL_WATCHDOG_MAX_TIMEOUT_MS) timeout_ms = FL_WATCHDOG_MAX_TIMEOUT_MS;
+    WDOG_Init_TypeDef init = WDOG_INIT_DEFAULT;
+    init.perSel = platforms::mgm240PickPeriod(timeout_ms);
+    WDOGn_Init(DEFAULT_WDOG, &init);
+    platforms::mgm240WatchdogState().armed = true;
+}
+
+void Watchdog::feed() FL_NOEXCEPT {
+    WDOGn_Feed(DEFAULT_WDOG);
+}
+
+void Watchdog::disable() FL_NOEXCEPT {
+    WDOGn_Enable(DEFAULT_WDOG, false);
+    platforms::mgm240WatchdogState().armed = false;
+}
+
+ResetCause Watchdog::lastResetCause() const FL_NOEXCEPT {
+    auto& s = platforms::mgm240WatchdogState();
+    if (!s.cause_cached) {
+        s.cached_cause = platforms::translateMgm240RstCause(EMU_ResetCauseGet());
+        EMU_ResetCauseClear();
+        s.cause_cached = true;
+        if (s.cached_cause == ResetCause::WATCHDOG && s.crash_count < 0xFFFF) {
+            s.crash_count++;
+        }
+    }
+    return s.cached_cause;
+}
+
+bool Watchdog::lastResetWasWatchdog() const FL_NOEXCEPT {
+    return lastResetCause() == ResetCause::WATCHDOG;
+}
+
+fl::u8 Watchdog::persistRead(fl::size idx) const FL_NOEXCEPT {
+    if (idx >= FL_WATCHDOG_PERSIST_BYTES) return 0;
+    return platforms::mgm240WatchdogState().persist[idx];
+}
+void Watchdog::persistWrite(fl::size idx, fl::u8 v) FL_NOEXCEPT {
+    if (idx >= FL_WATCHDOG_PERSIST_BYTES) return;
+    platforms::mgm240WatchdogState().persist[idx] = v;
+}
+
+fl::u16 Watchdog::consecutiveCrashCount() const FL_NOEXCEPT {
+    (void)lastResetCause();
+    return platforms::mgm240WatchdogState().crash_count;
+}
+void Watchdog::markCleanShutdown() FL_NOEXCEPT { platforms::mgm240WatchdogState().crash_count = 0; }
+bool Watchdog::isInSafeMode() const FL_NOEXCEPT { return consecutiveCrashCount() >= mSafeModeThreshold; }
+fl::u16 Watchdog::safeModeThreshold() const FL_NOEXCEPT { return mSafeModeThreshold; }
+void    Watchdog::setSafeModeThreshold(fl::u16 t) FL_NOEXCEPT { mSafeModeThreshold = t; }
+
+FL_NORETURN void Watchdog::reboot() FL_NOEXCEPT {
+    NVIC_SystemReset();
+    while (true) {}
+}
+
+bool Watchdog::onTimeout(WatchdogTimeoutCallback, void*) FL_NOEXCEPT { return false; }
+bool Watchdog::onTimeout(fl::function<void()>) FL_NOEXCEPT { return false; }
+bool Watchdog::setPauseOnDebug(bool) FL_NOEXCEPT { return false; }
+bool Watchdog::writeCrashLog(fl::span<const fl::u8>) FL_NOEXCEPT { return false; }
+fl::size Watchdog::readCrashLog(fl::span<fl::u8>) const FL_NOEXCEPT { return 0; }
+bool Watchdog::rebootIntoBootloader() FL_NOEXCEPT { return false; }
+
+bool Watchdog::setWindow(fl::u32, fl::u32) FL_NOEXCEPT { return false; }
+bool Watchdog::hasCrashReport() const FL_NOEXCEPT { return false; }
+WatchdogCrashReport Watchdog::readCrashReport() const FL_NOEXCEPT {
+    WatchdogCrashReport r{}; r.valid = false; r.fault_type = ""; return r;
+}
+void Watchdog::clearCrashReport() FL_NOEXCEPT {}
+
+} // namespace fl

--- a/src/platforms/arm/mgm240/watchdog_mgm240.impl.hpp
+++ b/src/platforms/arm/mgm240/watchdog_mgm240.impl.hpp
@@ -18,7 +18,9 @@
 
 #define FL_WATCHDOG_HAS_HARDWARE
 #define FL_WATCHDOG_PERSIST_BYTES 8
-#define FL_WATCHDOG_MAX_TIMEOUT_MS 32000u
+// Largest WDOG_PeriodSel_TypeDef (`wdogPeriod_256k` ≈ 262145 cycles) at the
+// LFRCO's 32.768 kHz gives a ~8.00 s ceiling.
+#define FL_WATCHDOG_MAX_TIMEOUT_MS 8000u
 
 namespace fl {
 namespace platforms {
@@ -46,23 +48,42 @@ inline ResetCause translateMgm240RstCause(fl::u32 cause) {
     return ResetCause::UNKNOWN;
 }
 
-// Map ms timeout to nearest `WDOG_PeriodSel_TypeDef`. LFRCO ~32.768 kHz; the
-// period field is power-of-two counts: 9 (256 cycles ≈ 8 ms) up through
-// 17 (65536 cycles ≈ 2 s) and beyond. Pick smallest period >= requested.
+// Map ms timeout to the smallest `WDOG_PeriodSel_TypeDef` whose tick count
+// satisfies the request. Per the Gecko SDK / EFR32MG24 reference, the enum
+// values are clock-cycle counts on the watchdog source clock (LFRCO ≈ 32.768
+// kHz). Conversion: ms ≈ cycles * 1000 / 32768.
+//
+//   wdogPeriod_9    =      9 cycles ≈ 0.3 ms
+//   wdogPeriod_17   =     17 cycles ≈ 0.5 ms
+//   wdogPeriod_33   =     33 cycles ≈ 1.0 ms
+//   wdogPeriod_65   =     65 cycles ≈ 2.0 ms
+//   wdogPeriod_129  =    129 cycles ≈ 3.9 ms
+//   wdogPeriod_257  =    257 cycles ≈ 7.8 ms
+//   wdogPeriod_513  =    513 cycles ≈ 15.6 ms
+//   wdogPeriod_1k   =   1025 cycles ≈ 31 ms
+//   wdogPeriod_2k   =   2049 cycles ≈ 63 ms
+//   wdogPeriod_4k   =   4097 cycles ≈ 125 ms
+//   wdogPeriod_8k   =   8193 cycles ≈ 250 ms
+//   wdogPeriod_16k  =  16385 cycles ≈ 500 ms
+//   wdogPeriod_32k  =  32769 cycles ≈ 1000 ms
+//   wdogPeriod_64k  =  65537 cycles ≈ 2000 ms
+//   wdogPeriod_128k = 131073 cycles ≈ 4000 ms
+//   wdogPeriod_256k = 262145 cycles ≈ 8000 ms
 inline WDOG_PeriodSel_TypeDef mgm240PickPeriod(fl::u32 ms) {
-    if (ms <=    8) return wdogPeriod_9;
-    if (ms <=   16) return wdogPeriod_16;
-    if (ms <=   32) return wdogPeriod_32;
-    if (ms <=   64) return wdogPeriod_64;
-    if (ms <=  125) return wdogPeriod_128;
-    if (ms <=  250) return wdogPeriod_256;
-    if (ms <=  500) return wdogPeriod_512;
-    if (ms <= 1000) return wdogPeriod_1k;
-    if (ms <= 2000) return wdogPeriod_2k;
-    if (ms <= 4000) return wdogPeriod_4k;
-    if (ms <= 8000) return wdogPeriod_8k;
-    if (ms <=16000) return wdogPeriod_16k;
-    return wdogPeriod_32k;
+    if (ms <=    1) return wdogPeriod_33;
+    if (ms <=    2) return wdogPeriod_65;
+    if (ms <=    4) return wdogPeriod_129;
+    if (ms <=    8) return wdogPeriod_257;
+    if (ms <=   16) return wdogPeriod_513;
+    if (ms <=   31) return wdogPeriod_1k;
+    if (ms <=   63) return wdogPeriod_2k;
+    if (ms <=  125) return wdogPeriod_4k;
+    if (ms <=  250) return wdogPeriod_8k;
+    if (ms <=  500) return wdogPeriod_16k;
+    if (ms <= 1000) return wdogPeriod_32k;
+    if (ms <= 2000) return wdogPeriod_64k;
+    if (ms <= 4000) return wdogPeriod_128k;
+    return wdogPeriod_256k;
 }
 
 } // namespace platforms

--- a/src/platforms/arm/mxrt1062/watchdog_mxrt1062.impl.hpp
+++ b/src/platforms/arm/mxrt1062/watchdog_mxrt1062.impl.hpp
@@ -23,8 +23,12 @@
 #define FL_WATCHDOG_HAS_HARDWARE
 #define FL_WATCHDOG_PERSIST_BYTES 16
 #define FL_WATCHDOG_MAX_TIMEOUT_MS 128000u
-#define FL_WATCHDOG_HAS_PRE_TIMEOUT_IRQ
-#define FL_WATCHDOG_HAS_WINDOW_MODE
+// NOTE: WDT_T4 / RTWDOG technically exposes pre-timeout IRQ + windowed mode,
+// but our Tier-1/2 wrappers (`onTimeout()`, `setWindow()`) currently return
+// false on this platform. Capability macros must match runtime behavior, so
+// we deliberately do NOT advertise `FL_WATCHDOG_HAS_PRE_TIMEOUT_IRQ` /
+// `FL_WATCHDOG_HAS_WINDOW_MODE` until those wrappers are implemented in a
+// follow-up.
 
 namespace fl {
 namespace platforms {

--- a/src/platforms/arm/mxrt1062/watchdog_mxrt1062.impl.hpp
+++ b/src/platforms/arm/mxrt1062/watchdog_mxrt1062.impl.hpp
@@ -1,0 +1,159 @@
+// IWYU pragma: private
+
+/// @file platforms/arm/mxrt1062/watchdog_mxrt1062.impl.hpp
+/// @brief Teensy 4.x (iMXRT1062) watchdog implementation.
+///
+/// Uses `WDT_T4<WDT3>` (RTWDOG) from the bundled Teensyduino `Watchdog_t4.h`
+/// library. **WDOG1/WDOG2 are intentionally NOT used** — they're configured
+/// by the ROM/bootloader and resetting through them can interact with the
+/// MKL02 bootloader chip in ways the previous attempt (see
+/// `AutoResearch.ino:204-214`) discovered the hard way.
+///
+/// Reset cause from `SRC_SRSR`. Persist storage is in-RAM only for now;
+/// Phase 3 follow-up will move it to OCRAM2 retained region (above
+/// `CrashReport` at `0x2027FF80`) for soft-reset survival.
+
+#include "fl/wdt/watchdog.h"
+
+// IWYU pragma: begin_keep
+#include <Watchdog_t4.h>   // ok include — bundled Teensyduino library
+#include <imxrt.h>         // ok include — SRC_SRSR register
+// IWYU pragma: end_keep
+
+#define FL_WATCHDOG_HAS_HARDWARE
+#define FL_WATCHDOG_PERSIST_BYTES 16
+#define FL_WATCHDOG_MAX_TIMEOUT_MS 128000u
+#define FL_WATCHDOG_HAS_PRE_TIMEOUT_IRQ
+#define FL_WATCHDOG_HAS_WINDOW_MODE
+
+namespace fl {
+namespace platforms {
+
+struct Mxrt1062WatchdogState {
+    fl::u8     persist[FL_WATCHDOG_PERSIST_BYTES] = {0};
+    fl::u16    crash_count = 0;
+    bool       armed = false;
+    fl::u32    armed_timeout_ms = 0;
+    ResetCause cached_cause = ResetCause::UNKNOWN;
+    bool       cause_cached = false;
+};
+
+inline Mxrt1062WatchdogState& mxrt1062WatchdogState() {
+    static Mxrt1062WatchdogState s{};  // okay static in header — single-TU `.impl.hpp`
+    return s;
+}
+
+inline WDT_T4<WDT3>& mxrt1062Wdt() {
+    static WDT_T4<WDT3> w;  // okay static in header — single-TU `.impl.hpp`
+    return w;
+}
+
+inline ResetCause translateSrcSrsr(fl::u32 srsr) {
+    // Bits per iMXRT1062 reference manual. Priority: most-specific first.
+    if (srsr & (1u << 16)) return ResetCause::WATCHDOG;      // WDOG3_RST_B
+    if (srsr & (1u << 7))  return ResetCause::WATCHDOG;      // WDOG_RST_B (WDOG1/2)
+    if (srsr & (1u << 4))  return ResetCause::LOCKUP;        // LOCKUP_SYSRESETREQ
+    if (srsr & (1u << 8))  return ResetCause::DEBUGGER;      // JTAG_SW_RST
+    if (srsr & (1u << 5))  return ResetCause::EXTERNAL_PIN;  // IPP_USER_RESET_B
+    if (srsr & (1u << 0))  return ResetCause::POWER_ON;      // POR
+    return ResetCause::UNKNOWN;
+}
+
+} // namespace platforms
+
+Watchdog& Watchdog::instance() FL_NOEXCEPT {
+    static Watchdog sInstance;
+    return sInstance;
+}
+
+void Watchdog::begin(fl::u32 timeout_ms) FL_NOEXCEPT {
+    // WDT_T4 minimum is 500 ms; clamp.
+    if (timeout_ms < 500) timeout_ms = 500;
+    if (timeout_ms > FL_WATCHDOG_MAX_TIMEOUT_MS) timeout_ms = FL_WATCHDOG_MAX_TIMEOUT_MS;
+    auto& s = platforms::mxrt1062WatchdogState();
+    WDT_timings_t cfg;
+    cfg.timeout = static_cast<float>(timeout_ms) / 1000.0f;
+    platforms::mxrt1062Wdt().begin(cfg);
+    s.armed = true;
+    s.armed_timeout_ms = timeout_ms;
+}
+
+void Watchdog::feed() FL_NOEXCEPT {
+    platforms::mxrt1062Wdt().feed();
+}
+
+void Watchdog::disable() FL_NOEXCEPT {
+    // WDT_T4 / RTWDOG cannot be cleanly disabled once armed (CS write-protect).
+    // The honest action is to keep feeding it from a background context, but
+    // we have nowhere to do that from a Tier-0 disable(). Document the
+    // limitation: post-disable() the watchdog still ticks. Subsequent
+    // feed() calls still work; if the caller wanted to stop monitoring it
+    // should also stop calling feed() — but in that case the WDT will fire.
+    // We do NOT clear armed because the watchdog is in fact still armed.
+}
+
+ResetCause Watchdog::lastResetCause() const FL_NOEXCEPT {
+    auto& s = platforms::mxrt1062WatchdogState();
+    if (!s.cause_cached) {
+        s.cached_cause = platforms::translateSrcSrsr(SRC_SRSR);
+        s.cause_cached = true;
+        if (s.cached_cause == ResetCause::WATCHDOG && s.crash_count < 0xFFFF) {
+            s.crash_count++;
+        }
+    }
+    return s.cached_cause;
+}
+
+bool Watchdog::lastResetWasWatchdog() const FL_NOEXCEPT {
+    return lastResetCause() == ResetCause::WATCHDOG;
+}
+
+fl::u8 Watchdog::persistRead(fl::size idx) const FL_NOEXCEPT {
+    if (idx >= FL_WATCHDOG_PERSIST_BYTES) return 0;
+    return platforms::mxrt1062WatchdogState().persist[idx];
+}
+
+void Watchdog::persistWrite(fl::size idx, fl::u8 v) FL_NOEXCEPT {
+    if (idx >= FL_WATCHDOG_PERSIST_BYTES) return;
+    platforms::mxrt1062WatchdogState().persist[idx] = v;
+}
+
+fl::u16 Watchdog::consecutiveCrashCount() const FL_NOEXCEPT {
+    (void)lastResetCause();
+    return platforms::mxrt1062WatchdogState().crash_count;
+}
+
+void Watchdog::markCleanShutdown() FL_NOEXCEPT {
+    platforms::mxrt1062WatchdogState().crash_count = 0;
+}
+
+bool Watchdog::isInSafeMode() const FL_NOEXCEPT {
+    return consecutiveCrashCount() >= mSafeModeThreshold;
+}
+
+fl::u16 Watchdog::safeModeThreshold() const FL_NOEXCEPT { return mSafeModeThreshold; }
+void    Watchdog::setSafeModeThreshold(fl::u16 t) FL_NOEXCEPT { mSafeModeThreshold = t; }
+
+FL_NORETURN void Watchdog::reboot() FL_NOEXCEPT {
+    SCB_AIRCR = 0x05FA0004;  // SYSRESETREQ with VECTKEY
+    while (true) {}
+}
+
+bool Watchdog::onTimeout(WatchdogTimeoutCallback, void*) FL_NOEXCEPT { return false; }
+bool Watchdog::onTimeout(fl::function<void()>) FL_NOEXCEPT { return false; }
+bool Watchdog::setPauseOnDebug(bool) FL_NOEXCEPT { return false; }
+bool Watchdog::writeCrashLog(fl::span<const fl::u8>) FL_NOEXCEPT { return false; }
+fl::size Watchdog::readCrashLog(fl::span<fl::u8>) const FL_NOEXCEPT { return 0; }
+bool Watchdog::rebootIntoBootloader() FL_NOEXCEPT { return false; }
+
+bool Watchdog::setWindow(fl::u32, fl::u32) FL_NOEXCEPT { return false; }
+bool Watchdog::hasCrashReport() const FL_NOEXCEPT { return false; }
+WatchdogCrashReport Watchdog::readCrashReport() const FL_NOEXCEPT {
+    WatchdogCrashReport r{};
+    r.valid = false;
+    r.fault_type = "";
+    return r;
+}
+void Watchdog::clearCrashReport() FL_NOEXCEPT {}
+
+} // namespace fl

--- a/src/platforms/arm/nrf52/watchdog_nrf52.impl.hpp
+++ b/src/platforms/arm/nrf52/watchdog_nrf52.impl.hpp
@@ -1,0 +1,134 @@
+// IWYU pragma: private
+
+/// @file platforms/arm/nrf52/watchdog_nrf52.impl.hpp
+/// @brief nRF52 (Adafruit BSP) watchdog implementation.
+///
+/// `NRF_WDT` registers — 32 kHz LFCLK with 32-bit CRV; range ~1 ms to 36 h.
+/// Cannot be stopped once started. Reset cause from `NRF_POWER->RESETREAS`.
+///
+/// **GPREGRET caution:** The Adafruit nRF52 bootloader uses specific sentinel
+/// values in `NRF_POWER->GPREGRET` (`0x57`, `0xA8`, `0x4e`, `0x90`, `0xB0`)
+/// for DFU mode signaling. We use the user `persist` API for general state
+/// and intentionally do NOT touch GPREGRET here to avoid conflicts.
+
+#include "fl/wdt/watchdog.h"
+
+// IWYU pragma: begin_keep
+#include <nrf.h>   // ok include — NRF_WDT, NRF_POWER
+// IWYU pragma: end_keep
+
+#define FL_WATCHDOG_HAS_HARDWARE
+#define FL_WATCHDOG_PERSIST_BYTES 8
+#define FL_WATCHDOG_MAX_TIMEOUT_MS 600000u   // 10 min — well under 36 h ceiling
+
+namespace fl {
+namespace platforms {
+
+struct Nrf52WatchdogState {
+    fl::u8     persist[FL_WATCHDOG_PERSIST_BYTES] = {0};
+    fl::u16    crash_count = 0;
+    bool       armed = false;
+    ResetCause cached_cause = ResetCause::UNKNOWN;
+    bool       cause_cached = false;
+};
+
+inline Nrf52WatchdogState& nrf52WatchdogState() {
+    static Nrf52WatchdogState s{};  // okay static in header — single-TU `.impl.hpp`
+    return s;
+}
+
+inline ResetCause translateNrf52ResetReas(fl::u32 r) {
+    // POWER->RESETREAS bits; multiple may be set — most-specific wins.
+    if (r & 0x00000002u) return ResetCause::WATCHDOG;       // DOG
+    if (r & 0x00000004u) return ResetCause::SOFTWARE;       // SREQ
+    if (r & 0x00000008u) return ResetCause::LOCKUP;         // LOCKUP
+    if (r & 0x00000001u) return ResetCause::EXTERNAL_PIN;   // RESETPIN
+    if (r == 0)          return ResetCause::POWER_ON;       // all zero = POR
+    return ResetCause::UNKNOWN;
+}
+
+} // namespace platforms
+
+Watchdog& Watchdog::instance() FL_NOEXCEPT {
+    static Watchdog sInstance;
+    return sInstance;
+}
+
+void Watchdog::begin(fl::u32 timeout_ms) FL_NOEXCEPT {
+    if (timeout_ms == 0) timeout_ms = 1000;
+    if (timeout_ms > FL_WATCHDOG_MAX_TIMEOUT_MS) timeout_ms = FL_WATCHDOG_MAX_TIMEOUT_MS;
+    if (NRF_WDT->RUNSTATUS == 0) {
+        // CRV = (timeout_sec * 32768) - 1, computed from ms with rounding.
+        NRF_WDT->CRV = ((static_cast<fl::u64>(timeout_ms) * 32768u + 999u) / 1000u) - 1u;
+        NRF_WDT->RREN = 1u;            // enable reload register 0
+        NRF_WDT->CONFIG = 1u;           // run during CPU sleep, pause in debug
+        NRF_WDT->TASKS_START = 1u;
+    }
+    platforms::nrf52WatchdogState().armed = true;
+}
+
+void Watchdog::feed() FL_NOEXCEPT {
+    NRF_WDT->RR[0] = 0x6E524635u;  // WDT_RR_RR_Reload magic
+}
+
+void Watchdog::disable() FL_NOEXCEPT {
+    // nRF52 WDT cannot be disabled once started. Document and no-op.
+}
+
+ResetCause Watchdog::lastResetCause() const FL_NOEXCEPT {
+    auto& s = platforms::nrf52WatchdogState();
+    if (!s.cause_cached) {
+        s.cached_cause = platforms::translateNrf52ResetReas(NRF_POWER->RESETREAS);
+        // RESETREAS is sticky; write-1-to-clear so the next boot sees a
+        // clean value.
+        NRF_POWER->RESETREAS = 0xFFFFFFFFu;
+        s.cause_cached = true;
+        if (s.cached_cause == ResetCause::WATCHDOG && s.crash_count < 0xFFFF) {
+            s.crash_count++;
+        }
+    }
+    return s.cached_cause;
+}
+
+bool Watchdog::lastResetWasWatchdog() const FL_NOEXCEPT {
+    return lastResetCause() == ResetCause::WATCHDOG;
+}
+
+fl::u8 Watchdog::persistRead(fl::size idx) const FL_NOEXCEPT {
+    if (idx >= FL_WATCHDOG_PERSIST_BYTES) return 0;
+    return platforms::nrf52WatchdogState().persist[idx];
+}
+void Watchdog::persistWrite(fl::size idx, fl::u8 v) FL_NOEXCEPT {
+    if (idx >= FL_WATCHDOG_PERSIST_BYTES) return;
+    platforms::nrf52WatchdogState().persist[idx] = v;
+}
+
+fl::u16 Watchdog::consecutiveCrashCount() const FL_NOEXCEPT {
+    (void)lastResetCause();
+    return platforms::nrf52WatchdogState().crash_count;
+}
+void Watchdog::markCleanShutdown() FL_NOEXCEPT { platforms::nrf52WatchdogState().crash_count = 0; }
+bool Watchdog::isInSafeMode() const FL_NOEXCEPT { return consecutiveCrashCount() >= mSafeModeThreshold; }
+fl::u16 Watchdog::safeModeThreshold() const FL_NOEXCEPT { return mSafeModeThreshold; }
+void    Watchdog::setSafeModeThreshold(fl::u16 t) FL_NOEXCEPT { mSafeModeThreshold = t; }
+
+FL_NORETURN void Watchdog::reboot() FL_NOEXCEPT {
+    NVIC_SystemReset();
+    while (true) {}
+}
+
+bool Watchdog::onTimeout(WatchdogTimeoutCallback, void*) FL_NOEXCEPT { return false; }
+bool Watchdog::onTimeout(fl::function<void()>) FL_NOEXCEPT { return false; }
+bool Watchdog::setPauseOnDebug(bool) FL_NOEXCEPT { return false; }
+bool Watchdog::writeCrashLog(fl::span<const fl::u8>) FL_NOEXCEPT { return false; }
+fl::size Watchdog::readCrashLog(fl::span<fl::u8>) const FL_NOEXCEPT { return 0; }
+bool Watchdog::rebootIntoBootloader() FL_NOEXCEPT { return false; }
+
+bool Watchdog::setWindow(fl::u32, fl::u32) FL_NOEXCEPT { return false; }
+bool Watchdog::hasCrashReport() const FL_NOEXCEPT { return false; }
+WatchdogCrashReport Watchdog::readCrashReport() const FL_NOEXCEPT {
+    WatchdogCrashReport r{}; r.valid = false; r.fault_type = ""; return r;
+}
+void Watchdog::clearCrashReport() FL_NOEXCEPT {}
+
+} // namespace fl

--- a/src/platforms/arm/rp/watchdog_rp.impl.hpp
+++ b/src/platforms/arm/rp/watchdog_rp.impl.hpp
@@ -78,9 +78,11 @@ void Watchdog::feed() FL_NOEXCEPT {
 }
 
 void Watchdog::disable() FL_NOEXCEPT {
-    // Pico SDK's `watchdog_disable()` inhibits the count but the underlying
-    // enable bit remains set. Honest action: stop feeding from this layer
-    // and document that the SDK provides no clean teardown.
+    // Pico SDK's `watchdog_disable()` clears WATCHDOG_CTRL_ENABLE_BITS, which
+    // halts the counter. Subsequent `feed()` calls are still safe (they only
+    // write LOAD).
+    watchdog_disable();
+    platforms::rpWatchdogState().armed = false;
 }
 
 ResetCause Watchdog::lastResetCause() const FL_NOEXCEPT {

--- a/src/platforms/arm/rp/watchdog_rp.impl.hpp
+++ b/src/platforms/arm/rp/watchdog_rp.impl.hpp
@@ -1,0 +1,154 @@
+// IWYU pragma: private
+
+/// @file platforms/arm/rp/watchdog_rp.impl.hpp
+/// @brief RP2040 / RP2350 watchdog implementation.
+///
+/// Pico SDK `hardware/watchdog.h` for begin/feed/disable. Reset cause via
+/// `watchdog_caused_reboot()` (+ `VREG_AND_CHIP_RESET` on RP2040,
+/// `POWMAN.CHIP_RESET` on RP2350 for richer cause detection).
+///
+/// **Persist storage** uses `watchdog_hw->scratch[0..3]` (16 bytes) — the
+/// SDK reserves `scratch[4..7]` for bootrom magic / `reset_usb_boot()`.
+/// Survives soft resets, NOT power cycles. RP2350 adds VBAT-backed
+/// `POWMAN.SCRATCH[0..7]` which Phase 3 can use for power-cycle survival.
+///
+/// `rebootIntoBootloader()` calls `reset_usb_boot()` — the bootrom-supported
+/// path to UF2 mode without touching BOOTSEL pin physically.
+
+#include "fl/wdt/watchdog.h"
+#include "platforms/arm/rp/is_rp.h"
+
+// IWYU pragma: begin_keep
+#include <hardware/watchdog.h>   // ok include — Pico SDK
+#include <hardware/structs/watchdog.h>  // ok include — scratch[0..7]
+#include <pico/bootrom.h>        // ok include — reset_usb_boot()
+// IWYU pragma: end_keep
+
+#define FL_WATCHDOG_HAS_HARDWARE
+#define FL_WATCHDOG_PERSIST_BYTES 16   // scratch[0..3] = 4 x 32-bit = 16 bytes
+#define FL_WATCHDOG_HAS_BOOTLOADER_REBOOT
+
+#if defined(FL_IS_RP2350)
+#define FL_WATCHDOG_MAX_TIMEOUT_MS 16777u
+#else
+#define FL_WATCHDOG_MAX_TIMEOUT_MS 8388u
+#endif
+
+namespace fl {
+namespace platforms {
+
+struct RpWatchdogState {
+    fl::u16    crash_count = 0;
+    bool       armed = false;
+    ResetCause cached_cause = ResetCause::UNKNOWN;
+    bool       cause_cached = false;
+};
+
+inline RpWatchdogState& rpWatchdogState() {
+    static RpWatchdogState s{};  // okay static in header — single-TU `.impl.hpp`
+    return s;
+}
+
+inline ResetCause rpDetectResetCause() {
+    if (watchdog_caused_reboot()) return ResetCause::WATCHDOG;
+    // RP2040 / RP2350 chip reset register read; the SDK exposes
+    // `watchdog_enable_caused_reboot()` to distinguish but we already
+    // covered the WDT case. Default to POWER_ON for first-boot heuristics.
+    return ResetCause::POWER_ON;
+}
+
+} // namespace platforms
+
+Watchdog& Watchdog::instance() FL_NOEXCEPT {
+    static Watchdog sInstance;
+    return sInstance;
+}
+
+void Watchdog::begin(fl::u32 timeout_ms) FL_NOEXCEPT {
+    if (timeout_ms == 0) timeout_ms = 1000;
+    if (timeout_ms > FL_WATCHDOG_MAX_TIMEOUT_MS) timeout_ms = FL_WATCHDOG_MAX_TIMEOUT_MS;
+    // Second arg `pause_on_debug` defaults to true — useful in dev so a
+    // debugger session doesn't reset the chip during a breakpoint.
+    watchdog_enable(timeout_ms, true);
+    platforms::rpWatchdogState().armed = true;
+}
+
+void Watchdog::feed() FL_NOEXCEPT {
+    watchdog_update();
+}
+
+void Watchdog::disable() FL_NOEXCEPT {
+    // Pico SDK's `watchdog_disable()` inhibits the count but the underlying
+    // enable bit remains set. Honest action: stop feeding from this layer
+    // and document that the SDK provides no clean teardown.
+}
+
+ResetCause Watchdog::lastResetCause() const FL_NOEXCEPT {
+    auto& s = platforms::rpWatchdogState();
+    if (!s.cause_cached) {
+        s.cached_cause = platforms::rpDetectResetCause();
+        s.cause_cached = true;
+        if (s.cached_cause == ResetCause::WATCHDOG && s.crash_count < 0xFFFF) {
+            s.crash_count++;
+        }
+    }
+    return s.cached_cause;
+}
+
+bool Watchdog::lastResetWasWatchdog() const FL_NOEXCEPT {
+    return lastResetCause() == ResetCause::WATCHDOG;
+}
+
+fl::u8 Watchdog::persistRead(fl::size idx) const FL_NOEXCEPT {
+    if (idx >= FL_WATCHDOG_PERSIST_BYTES) return 0;
+    // Pack 4 bytes per scratch register, little-endian.
+    fl::u32 word = watchdog_hw->scratch[idx >> 2];
+    return static_cast<fl::u8>((word >> ((idx & 0x3) * 8)) & 0xFF);
+}
+
+void Watchdog::persistWrite(fl::size idx, fl::u8 v) FL_NOEXCEPT {
+    if (idx >= FL_WATCHDOG_PERSIST_BYTES) return;
+    fl::u32 mask = static_cast<fl::u32>(0xFFu) << ((idx & 0x3) * 8);
+    fl::u32 word = watchdog_hw->scratch[idx >> 2] & ~mask;
+    word |= static_cast<fl::u32>(v) << ((idx & 0x3) * 8);
+    watchdog_hw->scratch[idx >> 2] = word;
+}
+
+fl::u16 Watchdog::consecutiveCrashCount() const FL_NOEXCEPT {
+    (void)lastResetCause();
+    return platforms::rpWatchdogState().crash_count;
+}
+void Watchdog::markCleanShutdown() FL_NOEXCEPT { platforms::rpWatchdogState().crash_count = 0; }
+bool Watchdog::isInSafeMode() const FL_NOEXCEPT { return consecutiveCrashCount() >= mSafeModeThreshold; }
+fl::u16 Watchdog::safeModeThreshold() const FL_NOEXCEPT { return mSafeModeThreshold; }
+void    Watchdog::setSafeModeThreshold(fl::u16 t) FL_NOEXCEPT { mSafeModeThreshold = t; }
+
+FL_NORETURN void Watchdog::reboot() FL_NOEXCEPT {
+    watchdog_reboot(0, 0, 0);  // pc=0, sp=0, delay=0 — immediate
+    while (true) {}
+}
+
+bool Watchdog::onTimeout(WatchdogTimeoutCallback, void*) FL_NOEXCEPT { return false; }
+bool Watchdog::onTimeout(fl::function<void()>) FL_NOEXCEPT { return false; }
+bool Watchdog::setPauseOnDebug(bool) FL_NOEXCEPT {
+    // Already set on begin() — caller would need to re-begin() to change it.
+    return false;
+}
+bool Watchdog::writeCrashLog(fl::span<const fl::u8>) FL_NOEXCEPT { return false; }
+fl::size Watchdog::readCrashLog(fl::span<fl::u8>) const FL_NOEXCEPT { return 0; }
+
+bool Watchdog::rebootIntoBootloader() FL_NOEXCEPT {
+    // Force BOOTSEL/UF2 mode. Arg 0 = no LED activity GPIO mask, arg 0 =
+    // both USB MSC and PICOBOOT interfaces enabled.
+    reset_usb_boot(0, 0);
+    return true;  // Should be unreachable, but contract is satisfied.
+}
+
+bool Watchdog::setWindow(fl::u32, fl::u32) FL_NOEXCEPT { return false; }
+bool Watchdog::hasCrashReport() const FL_NOEXCEPT { return false; }
+WatchdogCrashReport Watchdog::readCrashReport() const FL_NOEXCEPT {
+    WatchdogCrashReport r{}; r.valid = false; r.fault_type = ""; return r;
+}
+void Watchdog::clearCrashReport() FL_NOEXCEPT {}
+
+} // namespace fl

--- a/src/platforms/arm/samd/watchdog_samd.impl.hpp
+++ b/src/platforms/arm/samd/watchdog_samd.impl.hpp
@@ -1,0 +1,130 @@
+// IWYU pragma: private
+
+/// @file platforms/arm/samd/watchdog_samd.impl.hpp
+/// @brief SAMD21 / SAMD51 watchdog implementation via Adafruit SleepyDog.
+///
+/// Uses the well-tested `Adafruit_SleepyDog` library which handles the SAMD
+/// WDT register sync-busy waits, GCLK setup, and timeout rounding
+/// (SAMD WDT only supports power-of-two timeouts in the 8 ms .. 16 s range).
+///
+/// Reset cause from `PM->RCAUSE` (SAMD21) / `RSTC->RCAUSE` (SAMD51) is
+/// translated by the SleepyDog `Watchdog.resetCause()` extension where
+/// available; otherwise we read the register directly.
+///
+/// Persist storage is in-RAM; Phase 3 follow-up can move it to SAMD51
+/// SmartEEPROM or to FlashStorage for SAMD21.
+
+#include "fl/wdt/watchdog.h"
+
+// IWYU pragma: begin_keep
+#include <Adafruit_SleepyDog.h>   // ok include — Adafruit watchdog wrapper
+// IWYU pragma: end_keep
+
+#define FL_WATCHDOG_HAS_HARDWARE
+#define FL_WATCHDOG_PERSIST_BYTES 8
+#define FL_WATCHDOG_MAX_TIMEOUT_MS 16000u
+
+namespace fl {
+namespace platforms {
+
+struct SamdWatchdogState {
+    fl::u8     persist[FL_WATCHDOG_PERSIST_BYTES] = {0};
+    fl::u16    crash_count = 0;
+    bool       armed = false;
+    ResetCause cached_cause = ResetCause::UNKNOWN;
+    bool       cause_cached = false;
+};
+
+inline SamdWatchdogState& samdWatchdogState() {
+    static SamdWatchdogState s{};  // okay static in header — single-TU `.impl.hpp`
+    return s;
+}
+
+} // namespace platforms
+
+Watchdog& Watchdog::instance() FL_NOEXCEPT {
+    static Watchdog sInstance;
+    return sInstance;
+}
+
+void Watchdog::begin(fl::u32 timeout_ms) FL_NOEXCEPT {
+    if (timeout_ms == 0) timeout_ms = 1000;
+    if (timeout_ms > FL_WATCHDOG_MAX_TIMEOUT_MS) timeout_ms = FL_WATCHDOG_MAX_TIMEOUT_MS;
+    ::Watchdog.enable(static_cast<int>(timeout_ms));
+    platforms::samdWatchdogState().armed = true;
+}
+
+void Watchdog::feed() FL_NOEXCEPT {
+    ::Watchdog.reset();
+}
+
+void Watchdog::disable() FL_NOEXCEPT {
+    ::Watchdog.disable();
+    platforms::samdWatchdogState().armed = false;
+}
+
+ResetCause Watchdog::lastResetCause() const FL_NOEXCEPT {
+    auto& s = platforms::samdWatchdogState();
+    if (!s.cause_cached) {
+        // Adafruit_SleepyDog's resetCause(): 0=POR, 1=BOD12, 2=BOD33,
+        // 4=external pin, 5=WDT, 6=system reset request, 7=backup.
+        int rc = ::Watchdog.resetCause();
+        switch (rc) {
+            case 5:  s.cached_cause = ResetCause::WATCHDOG; break;
+            case 6:  s.cached_cause = ResetCause::SOFTWARE; break;
+            case 4:  s.cached_cause = ResetCause::EXTERNAL_PIN; break;
+            case 1:
+            case 2:  s.cached_cause = ResetCause::BROWNOUT; break;
+            case 0:  s.cached_cause = ResetCause::POWER_ON; break;
+            default: s.cached_cause = ResetCause::UNKNOWN; break;
+        }
+        s.cause_cached = true;
+        if (s.cached_cause == ResetCause::WATCHDOG && s.crash_count < 0xFFFF) {
+            s.crash_count++;
+        }
+    }
+    return s.cached_cause;
+}
+
+bool Watchdog::lastResetWasWatchdog() const FL_NOEXCEPT {
+    return lastResetCause() == ResetCause::WATCHDOG;
+}
+
+fl::u8 Watchdog::persistRead(fl::size idx) const FL_NOEXCEPT {
+    if (idx >= FL_WATCHDOG_PERSIST_BYTES) return 0;
+    return platforms::samdWatchdogState().persist[idx];
+}
+void Watchdog::persistWrite(fl::size idx, fl::u8 v) FL_NOEXCEPT {
+    if (idx >= FL_WATCHDOG_PERSIST_BYTES) return;
+    platforms::samdWatchdogState().persist[idx] = v;
+}
+
+fl::u16 Watchdog::consecutiveCrashCount() const FL_NOEXCEPT {
+    (void)lastResetCause();
+    return platforms::samdWatchdogState().crash_count;
+}
+void Watchdog::markCleanShutdown() FL_NOEXCEPT { platforms::samdWatchdogState().crash_count = 0; }
+bool Watchdog::isInSafeMode() const FL_NOEXCEPT { return consecutiveCrashCount() >= mSafeModeThreshold; }
+fl::u16 Watchdog::safeModeThreshold() const FL_NOEXCEPT { return mSafeModeThreshold; }
+void    Watchdog::setSafeModeThreshold(fl::u16 t) FL_NOEXCEPT { mSafeModeThreshold = t; }
+
+FL_NORETURN void Watchdog::reboot() FL_NOEXCEPT {
+    NVIC_SystemReset();
+    while (true) {}
+}
+
+bool Watchdog::onTimeout(WatchdogTimeoutCallback, void*) FL_NOEXCEPT { return false; }
+bool Watchdog::onTimeout(fl::function<void()>) FL_NOEXCEPT { return false; }
+bool Watchdog::setPauseOnDebug(bool) FL_NOEXCEPT { return false; }
+bool Watchdog::writeCrashLog(fl::span<const fl::u8>) FL_NOEXCEPT { return false; }
+fl::size Watchdog::readCrashLog(fl::span<fl::u8>) const FL_NOEXCEPT { return 0; }
+bool Watchdog::rebootIntoBootloader() FL_NOEXCEPT { return false; }
+
+bool Watchdog::setWindow(fl::u32, fl::u32) FL_NOEXCEPT { return false; }
+bool Watchdog::hasCrashReport() const FL_NOEXCEPT { return false; }
+WatchdogCrashReport Watchdog::readCrashReport() const FL_NOEXCEPT {
+    WatchdogCrashReport r{}; r.valid = false; r.fault_type = ""; return r;
+}
+void Watchdog::clearCrashReport() FL_NOEXCEPT {}
+
+} // namespace fl

--- a/src/platforms/arm/stm32/watchdog_stm32.impl.hpp
+++ b/src/platforms/arm/stm32/watchdog_stm32.impl.hpp
@@ -1,0 +1,122 @@
+// IWYU pragma: private
+
+/// @file platforms/arm/stm32/watchdog_stm32.impl.hpp
+/// @brief STM32 watchdog implementation — IWDG (Independent Watchdog).
+///
+/// Uses the LSI-clocked IWDG (~32 kHz, ±50%). Range ~125 µs to 32 s.
+/// Cannot be stopped once started. Reset cause from `RCC->CSR` (F1/F4/L4/
+/// G0/G4) or `RCC->RSR` (H7).
+///
+/// **STM32duino dependency:** Uses HAL `IWDG_HandleTypeDef` directly via
+/// the LL/HAL headers exposed through `stm32_def.h` in the Arduino_Core_STM32
+/// installation. The mbed-OS variants (Giga R1, Portenta) have a different
+/// watchdog wrapper that this impl does NOT cover — falls back to noop on
+/// those builds.
+///
+/// Persist storage is in-RAM only; Phase 3 follow-up can move it to RTC
+/// backup registers (`RTC->BKPxR`) for VBAT-backed power-cycle survival.
+
+#include "fl/wdt/watchdog.h"
+
+// IWYU pragma: begin_keep
+#include <IWatchdog.h>   // ok include — STM32duino bundled watchdog wrapper
+// IWYU pragma: end_keep
+
+#define FL_WATCHDOG_HAS_HARDWARE
+#define FL_WATCHDOG_PERSIST_BYTES 8
+#define FL_WATCHDOG_MAX_TIMEOUT_MS 32000u
+
+namespace fl {
+namespace platforms {
+
+struct Stm32WatchdogState {
+    fl::u8     persist[FL_WATCHDOG_PERSIST_BYTES] = {0};
+    fl::u16    crash_count = 0;
+    bool       armed = false;
+    ResetCause cached_cause = ResetCause::UNKNOWN;
+    bool       cause_cached = false;
+};
+
+inline Stm32WatchdogState& stm32WatchdogState() {
+    static Stm32WatchdogState s{};  // okay static in header — single-TU `.impl.hpp`
+    return s;
+}
+
+} // namespace platforms
+
+Watchdog& Watchdog::instance() FL_NOEXCEPT {
+    static Watchdog sInstance;
+    return sInstance;
+}
+
+void Watchdog::begin(fl::u32 timeout_ms) FL_NOEXCEPT {
+    if (timeout_ms == 0) timeout_ms = 1000;
+    if (timeout_ms > FL_WATCHDOG_MAX_TIMEOUT_MS) timeout_ms = FL_WATCHDOG_MAX_TIMEOUT_MS;
+    // STM32duino IWatchdog takes microseconds.
+    IWatchdog.begin(static_cast<fl::u32>(timeout_ms) * 1000u);
+    platforms::stm32WatchdogState().armed = true;
+}
+
+void Watchdog::feed() FL_NOEXCEPT {
+    IWatchdog.reload();
+}
+
+void Watchdog::disable() FL_NOEXCEPT {
+    // IWDG cannot be stopped once started. No-op.
+}
+
+ResetCause Watchdog::lastResetCause() const FL_NOEXCEPT {
+    auto& s = platforms::stm32WatchdogState();
+    if (!s.cause_cached) {
+        // IWatchdog::isReset() returns true if the previous reset was IWDG.
+        s.cached_cause = IWatchdog.isReset() ? ResetCause::WATCHDOG : ResetCause::POWER_ON;
+        s.cause_cached = true;
+        if (s.cached_cause == ResetCause::WATCHDOG && s.crash_count < 0xFFFF) {
+            s.crash_count++;
+        }
+    }
+    return s.cached_cause;
+}
+
+bool Watchdog::lastResetWasWatchdog() const FL_NOEXCEPT {
+    return lastResetCause() == ResetCause::WATCHDOG;
+}
+
+fl::u8 Watchdog::persistRead(fl::size idx) const FL_NOEXCEPT {
+    if (idx >= FL_WATCHDOG_PERSIST_BYTES) return 0;
+    return platforms::stm32WatchdogState().persist[idx];
+}
+void Watchdog::persistWrite(fl::size idx, fl::u8 v) FL_NOEXCEPT {
+    if (idx >= FL_WATCHDOG_PERSIST_BYTES) return;
+    platforms::stm32WatchdogState().persist[idx] = v;
+}
+
+fl::u16 Watchdog::consecutiveCrashCount() const FL_NOEXCEPT {
+    (void)lastResetCause();
+    return platforms::stm32WatchdogState().crash_count;
+}
+void Watchdog::markCleanShutdown() FL_NOEXCEPT { platforms::stm32WatchdogState().crash_count = 0; }
+bool Watchdog::isInSafeMode() const FL_NOEXCEPT { return consecutiveCrashCount() >= mSafeModeThreshold; }
+fl::u16 Watchdog::safeModeThreshold() const FL_NOEXCEPT { return mSafeModeThreshold; }
+void    Watchdog::setSafeModeThreshold(fl::u16 t) FL_NOEXCEPT { mSafeModeThreshold = t; }
+
+FL_NORETURN void Watchdog::reboot() FL_NOEXCEPT {
+    NVIC_SystemReset();
+    while (true) {}
+}
+
+bool Watchdog::onTimeout(WatchdogTimeoutCallback, void*) FL_NOEXCEPT { return false; }
+bool Watchdog::onTimeout(fl::function<void()>) FL_NOEXCEPT { return false; }
+bool Watchdog::setPauseOnDebug(bool) FL_NOEXCEPT { return false; }
+bool Watchdog::writeCrashLog(fl::span<const fl::u8>) FL_NOEXCEPT { return false; }
+fl::size Watchdog::readCrashLog(fl::span<fl::u8>) const FL_NOEXCEPT { return 0; }
+bool Watchdog::rebootIntoBootloader() FL_NOEXCEPT { return false; }
+
+bool Watchdog::setWindow(fl::u32, fl::u32) FL_NOEXCEPT { return false; }
+bool Watchdog::hasCrashReport() const FL_NOEXCEPT { return false; }
+WatchdogCrashReport Watchdog::readCrashReport() const FL_NOEXCEPT {
+    WatchdogCrashReport r{}; r.valid = false; r.fault_type = ""; return r;
+}
+void Watchdog::clearCrashReport() FL_NOEXCEPT {}
+
+} // namespace fl

--- a/src/platforms/arm/stm32/watchdog_stm32.impl.hpp
+++ b/src/platforms/arm/stm32/watchdog_stm32.impl.hpp
@@ -68,10 +68,52 @@ void Watchdog::disable() FL_NOEXCEPT {
 ResetCause Watchdog::lastResetCause() const FL_NOEXCEPT {
     auto& s = platforms::stm32WatchdogState();
     if (!s.cause_cached) {
-        // IWatchdog::isReset() returns true if the previous reset was IWDG.
-        s.cached_cause = IWatchdog.isReset() ? ResetCause::WATCHDOG : ResetCause::POWER_ON;
+        // Read the RCC reset-cause register. STM32 H7 uses `RCC->RSR`,
+        // every other family in scope (F1/F4/F7/L4/G0/G4) uses `RCC->CSR`.
+        // The flag-bit layout is consistent across the families we cover.
+        #if defined(FL_IS_STM32_H7)
+            const fl::u32 csr = RCC->RSR;
+        #else
+            const fl::u32 csr = RCC->CSR;
+        #endif
+
+        // Bit positions per STM32 reference manuals. "Specific first"
+        // priority: WDT before brown-out, brown-out before generic POR.
+        ResetCause cause = ResetCause::UNKNOWN;
+        #ifdef RCC_CSR_IWDGRSTF
+            if      (csr & RCC_CSR_IWDGRSTF) cause = ResetCause::WATCHDOG;
+        #endif
+        #ifdef RCC_CSR_WWDGRSTF
+            else if (csr & RCC_CSR_WWDGRSTF) cause = ResetCause::WATCHDOG;
+        #endif
+        #ifdef RCC_CSR_SFTRSTF
+            else if (csr & RCC_CSR_SFTRSTF)  cause = ResetCause::SOFTWARE;
+        #endif
+        #ifdef RCC_CSR_BORRSTF
+            else if (csr & RCC_CSR_BORRSTF)  cause = ResetCause::BROWNOUT;
+        #endif
+        #ifdef RCC_CSR_PINRSTF
+            else if (csr & RCC_CSR_PINRSTF)  cause = ResetCause::EXTERNAL_PIN;
+        #endif
+        #ifdef RCC_CSR_LPWRRSTF
+            else if (csr & RCC_CSR_LPWRRSTF) cause = ResetCause::UNKNOWN;
+        #endif
+        #ifdef RCC_CSR_PORRSTF
+            else if (csr & RCC_CSR_PORRSTF)  cause = ResetCause::POWER_ON;
+        #endif
+
+        // STM32 reset flags are sticky — clear them so the NEXT boot only
+        // sees its own cause. RMVF (Remove flags) bit is in CSR/RSR; the
+        // exact name varies slightly across families.
+        #if defined(RCC_CSR_RMVF)
+            RCC->CSR |= RCC_CSR_RMVF;
+        #elif defined(RCC_RSR_RMVF)
+            RCC->RSR |= RCC_RSR_RMVF;
+        #endif
+
+        s.cached_cause = cause;
         s.cause_cached = true;
-        if (s.cached_cause == ResetCause::WATCHDOG && s.crash_count < 0xFFFF) {
+        if (cause == ResetCause::WATCHDOG && s.crash_count < 0xFFFF) {
             s.crash_count++;
         }
     }

--- a/src/platforms/avr/watchdog_avr.impl.hpp
+++ b/src/platforms/avr/watchdog_avr.impl.hpp
@@ -1,0 +1,180 @@
+// IWYU pragma: private
+
+/// @file platforms/avr/watchdog_avr.impl.hpp
+/// @brief AVR watchdog implementation (ATmega328P/2560/ATtiny85 and friends).
+///
+/// Backed by `<avr/wdt.h>` and `MCUSR` for cause detection. Max timeout 8 s
+/// (the hardware ceiling). Persist storage is in-RAM only; Phase 3 follow-up
+/// can move it to AVR EEPROM (`<avr/eeprom.h>`) with appropriate wear-leveling.
+///
+/// **CRITICAL — `WDRF` boot-loop fix:** After a watchdog reset, `WDRF` stays
+/// set in `MCUSR` and the WDT stays armed at the minimum interval (16 ms).
+/// If the sketch doesn't `wdt_disable()` before that 16 ms passes, the board
+/// loops forever. Optiboot clears this; older bootloaders do NOT, and ATtiny
+/// has no Optiboot. We install a `.init3` constructor that runs before
+/// `main()`/`setup()` to clear `MCUSR` and disable the WDT, then capture the
+/// reset cause for `lastResetCause()` to report.
+
+#include "fl/wdt/watchdog.h"
+
+// IWYU pragma: begin_keep
+#include <avr/wdt.h>     // ok include — AVR-specific WDT API
+#include <avr/io.h>      // ok include — MCUSR
+// IWYU pragma: end_keep
+
+#define FL_WATCHDOG_HAS_HARDWARE
+#define FL_WATCHDOG_PERSIST_BYTES 8
+#define FL_WATCHDOG_MAX_TIMEOUT_MS 8000u
+
+namespace fl {
+namespace platforms {
+
+// Captured copy of MCUSR before we cleared it in .init3. Set in the
+// constructor below, read by lastResetCause().
+extern fl::u8 sAvrCapturedMcusr;
+fl::u8 sAvrCapturedMcusr = 0;
+
+struct AvrWatchdogState {
+    fl::u8     persist[FL_WATCHDOG_PERSIST_BYTES] = {0};
+    fl::u16    crash_count = 0;
+    bool       armed = false;
+    ResetCause cached_cause = ResetCause::UNKNOWN;
+    bool       cause_cached = false;
+};
+
+inline AvrWatchdogState& avrWatchdogState() {
+    static AvrWatchdogState s{};  // okay static in header — single-TU `.impl.hpp`
+    return s;
+}
+
+// Translate AVR `MCUSR` bits to fl::ResetCause. Priority order matches the
+// historical "specific first" reading of the register: WDRF wins over PORF
+// because the latter is often co-set after a watchdog reset.
+inline ResetCause translateAvrMcusr(fl::u8 mcusr) {
+    if (mcusr & (1 << WDRF))  return ResetCause::WATCHDOG;
+    if (mcusr & (1 << BORF))  return ResetCause::BROWNOUT;
+    if (mcusr & (1 << EXTRF)) return ResetCause::EXTERNAL_PIN;
+    if (mcusr & (1 << PORF))  return ResetCause::POWER_ON;
+    return ResetCause::UNKNOWN;
+}
+
+// Convert a millisecond timeout to the closest `WDTO_*` constant. The AVR
+// watchdog only supports a discrete set; pick the smallest constant whose
+// timeout is >= the requested timeout (or the maximum if exceeded).
+inline fl::u8 timeoutToWdtoConstant(fl::u32 ms) {
+    if (ms <=   15) return WDTO_15MS;
+    if (ms <=   30) return WDTO_30MS;
+    if (ms <=   60) return WDTO_60MS;
+    if (ms <=  120) return WDTO_120MS;
+    if (ms <=  250) return WDTO_250MS;
+    if (ms <=  500) return WDTO_500MS;
+    if (ms <= 1000) return WDTO_1S;
+    if (ms <= 2000) return WDTO_2S;
+    if (ms <= 4000) return WDTO_4S;
+    return WDTO_8S;
+}
+
+// `.init3` constructor: runs after the C runtime has zeroed BSS but before
+// `main()`. Captures MCUSR for later cause reporting, then clears it and
+// disables the WDT so a post-WDT-reset boot cannot loop forever.
+__attribute__((naked, used, section(".init3")))
+inline void fastled_watchdog_init3() {
+    sAvrCapturedMcusr = MCUSR;
+    MCUSR = 0;
+    wdt_disable();
+}
+
+} // namespace platforms
+
+// `Watchdog::instance()` is defined here so the function-local static lives in
+// exactly one TU per program (avoiding Teensy 3.x `__cxa_guard` ABI conflicts —
+// not strictly an issue on AVR but kept for consistency with sibling impls).
+Watchdog& Watchdog::instance() FL_NOEXCEPT {
+    static Watchdog sInstance;
+    return sInstance;
+}
+
+void Watchdog::begin(fl::u32 timeout_ms) FL_NOEXCEPT {
+    if (timeout_ms == 0) timeout_ms = 1000;
+    if (timeout_ms > FL_WATCHDOG_MAX_TIMEOUT_MS) timeout_ms = FL_WATCHDOG_MAX_TIMEOUT_MS;
+    wdt_enable(platforms::timeoutToWdtoConstant(timeout_ms));
+    platforms::avrWatchdogState().armed = true;
+}
+
+void Watchdog::feed() FL_NOEXCEPT {
+    wdt_reset();
+}
+
+void Watchdog::disable() FL_NOEXCEPT {
+    wdt_disable();
+    platforms::avrWatchdogState().armed = false;
+}
+
+ResetCause Watchdog::lastResetCause() const FL_NOEXCEPT {
+    auto& s = platforms::avrWatchdogState();
+    if (!s.cause_cached) {
+        s.cached_cause = platforms::translateAvrMcusr(platforms::sAvrCapturedMcusr);
+        s.cause_cached = true;
+        if (s.cached_cause == ResetCause::WATCHDOG && s.crash_count < 0xFFFF) {
+            s.crash_count++;
+        }
+    }
+    return s.cached_cause;
+}
+
+bool Watchdog::lastResetWasWatchdog() const FL_NOEXCEPT {
+    return lastResetCause() == ResetCause::WATCHDOG;
+}
+
+fl::u8 Watchdog::persistRead(fl::size idx) const FL_NOEXCEPT {
+    if (idx >= FL_WATCHDOG_PERSIST_BYTES) return 0;
+    return platforms::avrWatchdogState().persist[idx];
+}
+
+void Watchdog::persistWrite(fl::size idx, fl::u8 v) FL_NOEXCEPT {
+    if (idx >= FL_WATCHDOG_PERSIST_BYTES) return;
+    platforms::avrWatchdogState().persist[idx] = v;
+}
+
+fl::u16 Watchdog::consecutiveCrashCount() const FL_NOEXCEPT {
+    (void)lastResetCause();
+    return platforms::avrWatchdogState().crash_count;
+}
+
+void Watchdog::markCleanShutdown() FL_NOEXCEPT {
+    platforms::avrWatchdogState().crash_count = 0;
+}
+
+bool Watchdog::isInSafeMode() const FL_NOEXCEPT {
+    return consecutiveCrashCount() >= mSafeModeThreshold;
+}
+
+fl::u16 Watchdog::safeModeThreshold() const FL_NOEXCEPT { return mSafeModeThreshold; }
+void    Watchdog::setSafeModeThreshold(fl::u16 t) FL_NOEXCEPT { mSafeModeThreshold = t; }
+
+FL_NORETURN void Watchdog::reboot() FL_NOEXCEPT {
+    // Force a watchdog-driven software reset.
+    wdt_enable(WDTO_15MS);
+    while (true) {}
+}
+
+// Tier 1/2 — not implemented on AVR (no pre-timeout IRQ wired, no flash
+// crash log, no bootloader-reboot path that wouldn't risk bricking).
+bool Watchdog::onTimeout(WatchdogTimeoutCallback, void*) FL_NOEXCEPT { return false; }
+bool Watchdog::onTimeout(fl::function<void()>) FL_NOEXCEPT { return false; }
+bool Watchdog::setPauseOnDebug(bool) FL_NOEXCEPT { return false; }
+bool Watchdog::writeCrashLog(fl::span<const fl::u8>) FL_NOEXCEPT { return false; }
+fl::size Watchdog::readCrashLog(fl::span<fl::u8>) const FL_NOEXCEPT { return 0; }
+bool Watchdog::rebootIntoBootloader() FL_NOEXCEPT { return false; }
+
+bool                Watchdog::setWindow(fl::u32, fl::u32) FL_NOEXCEPT { return false; }
+bool                Watchdog::hasCrashReport() const FL_NOEXCEPT { return false; }
+WatchdogCrashReport Watchdog::readCrashReport() const FL_NOEXCEPT {
+    WatchdogCrashReport r{};
+    r.valid = false;
+    r.fault_type = "";
+    return r;
+}
+void                Watchdog::clearCrashReport() FL_NOEXCEPT {}
+
+} // namespace fl

--- a/src/platforms/avr/watchdog_avr.impl.hpp
+++ b/src/platforms/avr/watchdog_avr.impl.hpp
@@ -62,10 +62,12 @@ inline ResetCause translateAvrMcusr(fl::u8 mcusr) {
 // watchdog only supports a discrete set; pick the smallest constant whose
 // timeout is >= the requested timeout (or the maximum if exceeded).
 inline fl::u8 timeoutToWdtoConstant(fl::u32 ms) {
-    if (ms <=   15) return WDTO_15MS;
-    if (ms <=   30) return WDTO_30MS;
-    if (ms <=   60) return WDTO_60MS;
-    if (ms <=  120) return WDTO_120MS;
+    // Use the actual AVR watchdog prescaler bucket boundaries:
+    // WDTO_15MS=16ms, WDTO_30MS=32ms, WDTO_60MS=64ms, WDTO_120MS=125ms.
+    if (ms <=   16) return WDTO_15MS;
+    if (ms <=   32) return WDTO_30MS;
+    if (ms <=   64) return WDTO_60MS;
+    if (ms <=  125) return WDTO_120MS;
     if (ms <=  250) return WDTO_250MS;
     if (ms <=  500) return WDTO_500MS;
     if (ms <= 1000) return WDTO_1S;
@@ -77,7 +79,14 @@ inline fl::u8 timeoutToWdtoConstant(fl::u32 ms) {
 // `.init3` constructor: runs after the C runtime has zeroed BSS but before
 // `main()`. Captures MCUSR for later cause reporting, then clears it and
 // disables the WDT so a post-WDT-reset boot cannot loop forever.
-__attribute__((naked, used, section(".init3")))
+//
+// NOTE: We deliberately do NOT mark this `naked`. `naked` functions are not
+// intended to hold ordinary C/C++ statements — GCC still needs to manage
+// register/stack expectations around the assignments and the `wdt_disable()`
+// call, and the result is fragile across optimization/toolchain versions.
+// A normal `.init3` hook works correctly here because `.init3` runs after
+// `.init2` (BSS zeroed, stack set up).
+__attribute__((used, section(".init3")))
 inline void fastled_watchdog_init3() {
     sAvrCapturedMcusr = MCUSR;
     MCUSR = 0;

--- a/src/platforms/avr/watchdog_avr.impl.hpp
+++ b/src/platforms/avr/watchdog_avr.impl.hpp
@@ -31,8 +31,13 @@ namespace platforms {
 
 // Captured copy of MCUSR before we cleared it in .init3. Set in the
 // constructor below, read by lastResetCause().
+//
+// CRITICAL: This MUST live in `.noinit` (no initializer, no `= 0`). avr-libc's
+// `.init4` step clears `.bss` and copies `.data`, which runs AFTER our `.init3`
+// hook. Any `.bss`/`.data` placement would clobber the captured MCUSR before
+// `lastResetCause()` could read it. `.noinit` is excluded from that step.
 extern fl::u8 sAvrCapturedMcusr;
-fl::u8 sAvrCapturedMcusr = 0;
+__attribute__((section(".noinit"))) fl::u8 sAvrCapturedMcusr;
 
 struct AvrWatchdogState {
     fl::u8     persist[FL_WATCHDOG_PERSIST_BYTES] = {0};

--- a/src/platforms/watchdog.impl.cpp.hpp
+++ b/src/platforms/watchdog.impl.cpp.hpp
@@ -37,6 +37,7 @@
 #include "platforms/is_platform.h"
 #include "platforms/esp/is_esp.h"
 #include "platforms/wasm/is_wasm.h"
+#include "fl/stl/has_include.h"
 
 #if defined(FL_IS_WASM)
     #include "platforms/wasm/watchdog_wasm.impl.hpp"
@@ -44,23 +45,23 @@
     #include "platforms/stub/watchdog_stub.impl.hpp"
 #elif defined(FL_IS_ESP32)
     #include "platforms/esp/32/watchdog_esp32.impl.hpp"
-#elif defined(FL_IS_TEENSY_4X) && __has_include(<Watchdog_t4.h>)
+#elif defined(FL_IS_TEENSY_4X) && FL_HAS_INCLUDE(<Watchdog_t4.h>)
     #include "platforms/arm/mxrt1062/watchdog_mxrt1062.impl.hpp"
-#elif (defined(FL_IS_TEENSY_3X) || defined(FL_IS_TEENSY_LC)) && __has_include(<kinetis.h>)
+#elif (defined(FL_IS_TEENSY_3X) || defined(FL_IS_TEENSY_LC)) && FL_HAS_INCLUDE(<kinetis.h>)
     #include "platforms/arm/k20/watchdog_k20.impl.hpp"
-#elif (defined(FL_IS_RP2040) || defined(FL_IS_RP2350)) && __has_include(<hardware/watchdog.h>)
+#elif (defined(FL_IS_RP2040) || defined(FL_IS_RP2350)) && FL_HAS_INCLUDE(<hardware/watchdog.h>)
     #include "platforms/arm/rp/watchdog_rp.impl.hpp"
-#elif defined(FL_IS_NRF52) && __has_include(<nrf.h>)
+#elif defined(FL_IS_NRF52) && FL_HAS_INCLUDE(<nrf.h>)
     #include "platforms/arm/nrf52/watchdog_nrf52.impl.hpp"
-#elif defined(FL_IS_STM32) && __has_include(<IWatchdog.h>)
+#elif defined(FL_IS_STM32) && FL_HAS_INCLUDE(<IWatchdog.h>)
     #include "platforms/arm/stm32/watchdog_stm32.impl.hpp"
-#elif (defined(FL_IS_SAMD21) || defined(FL_IS_SAMD51)) && __has_include(<Adafruit_SleepyDog.h>)
+#elif (defined(FL_IS_SAMD21) || defined(FL_IS_SAMD51)) && FL_HAS_INCLUDE(<Adafruit_SleepyDog.h>)
     #include "platforms/arm/samd/watchdog_samd.impl.hpp"
-#elif defined(FL_IS_APOLLO3) && __has_include(<am_mcu_apollo.h>)
+#elif defined(FL_IS_APOLLO3) && FL_HAS_INCLUDE(<am_mcu_apollo.h>)
     #include "platforms/apollo3/watchdog_apollo3.impl.hpp"
-#elif defined(FL_IS_SILABS_MGM240) && __has_include(<em_wdog.h>)
+#elif defined(FL_IS_SILABS_MGM240) && FL_HAS_INCLUDE(<em_wdog.h>)
     #include "platforms/arm/mgm240/watchdog_mgm240.impl.hpp"
-#elif defined(FL_IS_AVR) && __has_include(<avr/wdt.h>)
+#elif defined(FL_IS_AVR) && FL_HAS_INCLUDE(<avr/wdt.h>)
     #include "platforms/avr/watchdog_avr.impl.hpp"
 #else
     // Fallback: no real or emulated WDT available — all methods are no-ops.

--- a/src/platforms/watchdog.impl.cpp.hpp
+++ b/src/platforms/watchdog.impl.cpp.hpp
@@ -23,6 +23,15 @@
 ///   - MGM240           → `platforms/arm/mgm240/watchdog_mgm240.impl.hpp` (em_wdog)
 ///   - AVR              → `platforms/avr/watchdog_avr.impl.hpp` (avr/wdt.h + .init3 fix)
 ///   - Other            → `platforms/shared/watchdog_noop.hpp` (no-op fallback)
+///
+/// **Library availability guards:** Some platform impls depend on third-party
+/// Arduino libraries (Watchdog_t4, IWatchdog, Adafruit_SleepyDog, am_mcu_apollo,
+/// em_wdog) that may not be installed in every build configuration. We gate
+/// each such route with `__has_include(<header>)` so that when the optional
+/// library is missing the dispatcher falls through to the noop fallback rather
+/// than breaking the compile. User code that calls the watchdog API still
+/// works (as a no-op) — opt back into hardware behavior by installing the
+/// matching library.
 
 // Platform detection headers
 #include "platforms/is_platform.h"
@@ -35,26 +44,28 @@
     #include "platforms/stub/watchdog_stub.impl.hpp"
 #elif defined(FL_IS_ESP32)
     #include "platforms/esp/32/watchdog_esp32.impl.hpp"
-#elif defined(FL_IS_TEENSY_4X)
+#elif defined(FL_IS_TEENSY_4X) && __has_include(<Watchdog_t4.h>)
     #include "platforms/arm/mxrt1062/watchdog_mxrt1062.impl.hpp"
-#elif defined(FL_IS_TEENSY_3X) || defined(FL_IS_TEENSY_LC)
+#elif (defined(FL_IS_TEENSY_3X) || defined(FL_IS_TEENSY_LC)) && __has_include(<kinetis.h>)
     #include "platforms/arm/k20/watchdog_k20.impl.hpp"
-#elif defined(FL_IS_RP2040) || defined(FL_IS_RP2350)
+#elif (defined(FL_IS_RP2040) || defined(FL_IS_RP2350)) && __has_include(<hardware/watchdog.h>)
     #include "platforms/arm/rp/watchdog_rp.impl.hpp"
-#elif defined(FL_IS_NRF52)
+#elif defined(FL_IS_NRF52) && __has_include(<nrf.h>)
     #include "platforms/arm/nrf52/watchdog_nrf52.impl.hpp"
-#elif defined(FL_IS_STM32)
+#elif defined(FL_IS_STM32) && __has_include(<IWatchdog.h>)
     #include "platforms/arm/stm32/watchdog_stm32.impl.hpp"
-#elif defined(FL_IS_SAMD21) || defined(FL_IS_SAMD51)
+#elif (defined(FL_IS_SAMD21) || defined(FL_IS_SAMD51)) && __has_include(<Adafruit_SleepyDog.h>)
     #include "platforms/arm/samd/watchdog_samd.impl.hpp"
-#elif defined(FL_IS_APOLLO3)
+#elif defined(FL_IS_APOLLO3) && __has_include(<am_mcu_apollo.h>)
     #include "platforms/apollo3/watchdog_apollo3.impl.hpp"
-#elif defined(FL_IS_SILABS_MGM240)
+#elif defined(FL_IS_SILABS_MGM240) && __has_include(<em_wdog.h>)
     #include "platforms/arm/mgm240/watchdog_mgm240.impl.hpp"
-#elif defined(FL_IS_AVR)
+#elif defined(FL_IS_AVR) && __has_include(<avr/wdt.h>)
     #include "platforms/avr/watchdog_avr.impl.hpp"
 #else
     // Fallback: no real or emulated WDT available — all methods are no-ops.
+    // Reached when the platform isn't supported OR when the optional Arduino
+    // library backing this platform isn't installed (see header note above).
     // The api still compiles and runs on every supported MCU.
     #include "platforms/shared/watchdog_noop.hpp"
 #endif

--- a/src/platforms/watchdog.impl.cpp.hpp
+++ b/src/platforms/watchdog.impl.cpp.hpp
@@ -9,17 +9,22 @@
 /// `src/platforms/` root, `#include`d from exactly one translation unit, selects
 /// the platform fragment via `is_*.h` macros and falls back to `_noop.hpp`.
 ///
-/// **Phase 1 platforms:**
-///   - Host / stub  → `platforms/stub/watchdog_stub.impl.hpp` (real thread timer)
-///   - WASM         → `platforms/wasm/watchdog_wasm.impl.hpp` (emscripten timer)
-///   - ESP32 family → `platforms/esp/32/watchdog_esp32.impl.hpp` (wraps existing
-///                    fl::watchdog_setup() / ESP-IDF TWDT)
-///   - All others   → `platforms/shared/watchdog_noop.hpp`
-///
-/// Per-platform hardware impls for Teensy, RP, nRF52, STM32, SAMD, AVR,
-/// Apollo3, MGM240 are tracked as Phase 2..5 in FastLED#2731.
+/// Platform coverage:
+///   - Host / stub      → `platforms/stub/watchdog_stub.impl.hpp` (thread timer)
+///   - WASM             → `platforms/wasm/watchdog_wasm.impl.hpp` (routes to noop)
+///   - ESP32 family     → `platforms/esp/32/watchdog_esp32.impl.hpp` (wraps fl::watchdog_setup)
+///   - Teensy 4 (T4.x)  → `platforms/arm/mxrt1062/watchdog_mxrt1062.impl.hpp` (WDT_T4<WDT3>)
+///   - Teensy 3 (T3.x)  → `platforms/arm/k20/watchdog_k20.impl.hpp` (direct WDOG regs)
+///   - RP2040 / RP2350  → `platforms/arm/rp/watchdog_rp.impl.hpp` (Pico SDK)
+///   - nRF52            → `platforms/arm/nrf52/watchdog_nrf52.impl.hpp` (NRF_WDT)
+///   - STM32            → `platforms/arm/stm32/watchdog_stm32.impl.hpp` (IWDG)
+///   - SAMD21 / SAMD51  → `platforms/arm/samd/watchdog_samd.impl.hpp` (SleepyDog)
+///   - Apollo3          → `platforms/apollo3/watchdog_apollo3.impl.hpp` (am_hal_wdt)
+///   - MGM240           → `platforms/arm/mgm240/watchdog_mgm240.impl.hpp` (em_wdog)
+///   - AVR              → `platforms/avr/watchdog_avr.impl.hpp` (avr/wdt.h + .init3 fix)
+///   - Other            → `platforms/shared/watchdog_noop.hpp` (no-op fallback)
 
-// Platform detection headers — only include those we dispatch on.
+// Platform detection headers
 #include "platforms/is_platform.h"
 #include "platforms/esp/is_esp.h"
 #include "platforms/wasm/is_wasm.h"
@@ -30,8 +35,26 @@
     #include "platforms/stub/watchdog_stub.impl.hpp"
 #elif defined(FL_IS_ESP32)
     #include "platforms/esp/32/watchdog_esp32.impl.hpp"
+#elif defined(FL_IS_TEENSY_4X)
+    #include "platforms/arm/mxrt1062/watchdog_mxrt1062.impl.hpp"
+#elif defined(FL_IS_TEENSY_3X) || defined(FL_IS_TEENSY_LC)
+    #include "platforms/arm/k20/watchdog_k20.impl.hpp"
+#elif defined(FL_IS_RP2040) || defined(FL_IS_RP2350)
+    #include "platforms/arm/rp/watchdog_rp.impl.hpp"
+#elif defined(FL_IS_NRF52)
+    #include "platforms/arm/nrf52/watchdog_nrf52.impl.hpp"
+#elif defined(FL_IS_STM32)
+    #include "platforms/arm/stm32/watchdog_stm32.impl.hpp"
+#elif defined(FL_IS_SAMD21) || defined(FL_IS_SAMD51)
+    #include "platforms/arm/samd/watchdog_samd.impl.hpp"
+#elif defined(FL_IS_APOLLO3)
+    #include "platforms/apollo3/watchdog_apollo3.impl.hpp"
+#elif defined(FL_IS_SILABS_MGM240)
+    #include "platforms/arm/mgm240/watchdog_mgm240.impl.hpp"
+#elif defined(FL_IS_AVR)
+    #include "platforms/avr/watchdog_avr.impl.hpp"
 #else
     // Fallback: no real or emulated WDT available — all methods are no-ops.
-    // Per-platform hardware impls will be added incrementally in #2731 follow-ups.
+    // The api still compiles and runs on every supported MCU.
     #include "platforms/shared/watchdog_noop.hpp"
 #endif


### PR DESCRIPTION
## Summary

Phase 2 of #2731 — closes the request for **all platforms in one squashed PR**. Every supported MCU now has its own `watchdog_<platform>.impl.hpp` wired into the dispatcher; the previous Phase 1 (#2738) landed only host/stub/ESP32.

## Per-platform coverage

| Platform | Implementation | Persist | Notes |
|---|---|---|---|
| **AVR** (atmega/attiny) | `avr/wdt.h` + **`.init3` MCUSR=0 + wdt_disable() boot-loop fix** | in-RAM (8B) | Captures MCUSR pre-clear for cause reporting; without `.init3` fix, post-WDT-reset AVRs loop forever on Optiboot-less variants |
| **Teensy 4.x (iMXRT1062)** | `WDT_T4<WDT3>` (RTWDOG) — bundled Teensyduino | in-RAM (16B) | NEVER touches WDOG1/WDOG2 (bootloader chip risk); fixes the AutoResearch bricking documented at `AutoResearch.ino:204-214` |
| **Teensy 3.x / LC** (K20/K66/KL26) | Direct `WDOG` register unlock + config | in-RAM (8B) | One-shot-after-unlock; LPO-clocked timeout in ms |
| **RP2040 / RP2350** | Pico SDK `hardware/watchdog.h`; `reset_usb_boot()` for `rebootIntoBootloader()` | `watchdog_hw->scratch[0..3]` (16B) | Never touches reserved `scratch[4..7]`; `pause_on_debug` enabled by default |
| **nRF52** | `NRF_WDT` registers; CRV from ms | in-RAM (8B) | Does NOT touch GPREGRET (reserved for Adafruit bootloader DFU sentinels) |
| **STM32** | `IWatchdog.h` (STM32duino bundled) | in-RAM (8B) | LSI-clocked IWDG; range up to 32 s |
| **SAMD21 / SAMD51** | `Adafruit_SleepyDog` library | in-RAM (8B) | Library handles sync-busy waits + power-of-two timeout rounding |
| **Apollo3** | `am_hal_wdt_*` (AmbiqSuite SDK) | in-RAM (8B) | Reset cause deferred to Phase 3 (SDK type dance) |
| **MGM240 (EFR32MG24)** | `WDOG0` via Gecko SDK `em_wdog.h` | in-RAM (8B) | Avoids `WDOG1` (Matter/OpenThread may claim it) |
| ESP32 family | (unchanged from #2738) | in-RAM (16B) | TWDT + real `esp_task_wdt_deinit()` teardown |
| Host stub | (unchanged from #2738) | in-RAM (16B) | Thread-backed deadline timer; 15/15 tests pass |
| WASM | routes to noop | n/a | Phase 3 emscripten timer integration |

## Tier coverage per platform

Every platform implements full **Tier 0** (begin/feed/disable/lastResetCause/persist*/consecutiveCrashCount/markCleanShutdown/isInSafeMode/reboot). Tier 1/2 methods that aren't hardware-verified return `false` per the documented contract; the capability macros (`FL_WATCHDOG_HAS_*`) tell user code what's actually supported per platform.

## Persist storage strategy

In-RAM on every new platform — explicitly NOT flash/EEPROM in Phase 2. This keeps the user API stable today; Phase 3 will move each platform to its best-fit backing (RP `scratch[0..3]` already there, Teensy 4 OCRAM2 retained, nRF52 InternalFS, AVR EEPROM with wear awareness, SAMD51 SmartEEPROM, etc.) without changing any user-visible API.

## Why some Tier 1/2 are `false` everywhere

`onTimeout()` (both overloads), `setPauseOnDebug()`, `writeCrashLog()`, `setWindow()`, crash report — these need per-platform fault-handler integration that has board-specific risks I can't verify without hardware. Returning `false` is the documented contract for "this platform doesn't support this method"; user code that checks the return value works portably and can opt into platform-specific features via the `FL_WATCHDOG_HAS_*` macros.

## Verification

- `bash test fl_wdt_watchdog --debug` → 15/15 host stub tests pass under ASAN/UBSAN
- `bash lint --cpp` → clean
- CI will exercise the host + WASM + ESP32 platform compiles automatically. Per-platform hardware compile / runtime validation depends on the CI matrix for each board.

## References

- #2731 — design (closed, reopened by goal directive for "all platforms in one PR")
- #2738 — Phase 1 (merged in `c2faf92e`)
- #2732 — conventions PR (`_noop.hpp` + Type 3 `FL_<COMPONENT>_HAS_*` macros)
- #2744 — Phase 2 tracker (this PR supersedes it — will close)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Watchdog support added across many MCUs (Apollo3, Teensy/Kinetis, nRF52, RP2040, i.MX RT, STM32, SAMD21/51, Silabs MGM240, AVR): start/feed/reboot, reset-cause detection, small persistent bytes, consecutive-crash counters, and configurable safe-mode thresholds.

* **Chores**
  * Platform selection now detects optional platform/library availability and falls back gracefully when absent.

* **Notes**
  * Advanced features (timeout callbacks, crash logs/reports, window mode, pause-on-debug, bootloader reboot) are stubbed or reported unsupported on several platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->