### PR TITLE
fix(rgbw): align test reference_profile luminances with #2730 verification session

### DIFF
--- a/src/platforms/arm/stm32/watchdog_stm32.impl.hpp
+++ b/src/platforms/arm/stm32/watchdog_stm32.impl.hpp
@@ -17,6 +17,7 @@
 /// backup registers (`RTC->BKPxR`) for VBAT-backed power-cycle survival.
 
 #include "fl/wdt/watchdog.h"
+#include "platforms/arm/stm32/is_stm32.h"
 
 // IWYU pragma: begin_keep
 #include <IWatchdog.h>   // ok include — STM32duino bundled watchdog wrapper

--- a/tests/fl/gfx/rgbw_colorimetric.cpp
+++ b/tests/fl/gfx/rgbw_colorimetric.cpp
@@ -877,10 +877,12 @@ inline DiodeProfile reference_profile() {
     p.xy_g[0] = 0.1379f; p.xy_g[1] = 0.7480f;
     p.xy_b[0] = 0.1295f; p.xy_b[1] = 0.0663f;
     p.xy_w[0] = 0.3299f; p.xy_w[1] = 0.3582f;
-    // Luminance ratios from MAX_Y / MAX_Y["W"] in the reference.
-    p.lum_r = 149.658631f / 1511.803150f;
-    p.lum_g = 563.961804f / 1511.803150f;
-    p.lum_b = 129.540105f / 1511.803150f;
+    // Luminance ratios from MAX_Y / MAX_Y["W"] in the reference. Values
+    // sourced from the testBenchRgbwProfile verification session published
+    // in issue #2730 (Sub-Gamut + LP_Legacy session CSVs).
+    p.lum_r = 154.670592f / 1543.643989f;
+    p.lum_g = 566.278306f / 1543.643989f;
+    p.lum_b = 129.649350f / 1543.643989f;
     p.lum_w = 1.0f;
     p.nominal_cct = 6500;
     p.input_xy_r[0] = 0.6400f;  p.input_xy_r[1] = 0.3300f;


### PR DESCRIPTION
Closes #2730.

## Summary

Issue #2730 published an updated `testBenchRgbwProfile` from a fresh Sub-Gamut + LP_Legacy verification session (CSVs linked in the issue). The xy primaries and white chromaticity are unchanged; only the calibrated per-channel relative luminances move:

| Channel | Before | After |
|---|---|---|
| `lum_r` | `149.658631 / 1511.803150` | `154.670592 / 1543.643989` |
| `lum_g` | `563.961804 / 1511.803150` | `566.278306 / 1543.643989` |
| `lum_b` | `129.540105 / 1511.803150` | `129.649350 / 1543.643989` |

`lum_w` stays at `1.0f` by convention, and `nominal_cct` / `input_xy_*` are untouched (those are exercised by separate tests around CCT shift + source-space behavior — keeping them stable here avoids conflating the calibration refresh with those concerns).

## Drive-by

`src/platforms/arm/stm32/watchdog_stm32.impl.hpp` references `FL_IS_STM32_H7` but did not `#include "platforms/arm/stm32/is_stm32.h"`. `bash lint`'s `IsHeaderIncludeChecker` correctly flagged it; fixed by adding the include in the same form every other STM32 file in this directory uses.

## Test plan

- [x] `bash test fl_gfx_rgbw_colorimetric --cpp` — all cases still pass (including the strict-subgamut + LP_Legacy ground-truth tolerance of 24/255).
- [x] `bash lint --cpp` — clean.
- [ ] CI green.
- [ ] CodeRabbit review addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated STM32 watchdog implementation compatibility.
  * Refined color test reference calibration values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->