### PR TITLE
fix rgbww.cpp.hpp compile error when using colorimetric rgbw branch

### DIFF
--- a/src/fl/gfx/rgbww.cpp.hpp
+++ b/src/fl/gfx/rgbww.cpp.hpp
@@ -205,7 +205,7 @@ inline float compute_eta_from_input(const colorimetric_detail::RgbcctProfile& pr
     // primaries — exactly the regression flagged on this PR.
     EtaSourceMatrixCache& cache =
         fl::Singleton<EtaSourceMatrixCache>::instance();
-    const colorimetric_detail::DiodeProfile& wp = profile.warm_path;
+    const fl::DiodeProfile& wp = profile.warm_path;
     const bool key_changed =
         !cache.initialized ||
         !xy_equal(cache.xy_r, wp.input_xy_r) ||


### PR DESCRIPTION
Following up from reddit post, fixes the compile-time error when the colorimetric rgbw flag is enabled 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal code improvements.

---

**Note:** This release contains internal maintenance updates with no visible changes to end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->