### PR TITLE
refactor(ci/meson): split build_config.py and runner.py under 1k LOC

### DIFF
--- a/ci/meson/README.md
+++ b/ci/meson/README.md
@@ -24,9 +24,18 @@ The `ci.meson` package is organized into 9 focused modules following a tier-base
 
 ### Tier 3: Core Operations
 
-- **`build_config.py`** (~650 lines) - Build configuration and setup
-  - Types: `CleanupResult` dataclass
-  - Functions: `cleanup_build_artifacts()`, `detect_system_llvm_tools()`, `setup_meson_build()`, `perform_ninja_maintenance()`
+- **`build_config.py`** (~410 lines) - Build configuration orchestrator + re-exports
+  - Functions: `setup_meson_build()`, `perform_ninja_maintenance()`
+  - Backed by smaller modules: `native_launchers.py`, `path_normalization.py`,
+    `meson_markers.py`, `meson_cleanup.py`, `meson_setup_phases.py`,
+    `meson_setup_execute.py`
+
+- **`native_launchers.py`** (~370 lines) - ctc-* native launcher resolution + zccache discovery
+- **`path_normalization.py`** (~275 lines) - zccache strict-path normalization (issue #2378)
+- **`meson_markers.py`** (~280 lines) - per-build marker files + AR optimization patches
+- **`meson_cleanup.py`** (~140 lines) - build artifact cleanup + LLVM tool detection
+- **`meson_setup_phases.py`** (~590 lines) - source hashes, marker reconfigure detection, file-change detection
+- **`meson_setup_execute.py`** (~465 lines) - compiler detect, native file, meson setup execution
 
 - **`compile.py`** (~280 lines) - Compilation execution with IWYU support
   - Functions: `compile_meson()`, `create_error_context_filter()`
@@ -37,13 +46,18 @@ The `ci.meson` package is organized into 9 focused modules following a tier-base
 
 ### Tier 4: Advanced Operations
 
-- **`streaming.py`** (~300 lines) - Parallel streaming compilation and testing
+- **`streaming.py`** (~770 lines) - Parallel streaming compilation and testing
   - Functions: `stream_compile_and_run_tests()`
 
 ### Tier 5: Orchestration
 
-- **`runner.py`** (~450 lines) - Main orchestration and CLI entry point
+- **`runner.py`** (~350 lines) - Main orchestration and CLI entry point
   - Functions: `run_meson_build_and_test()`, `main()`
+  - Backed by: `runner_helpers.py`, `streaming_runner.py`, `sequential_runner.py`
+
+- **`runner_helpers.py`** (~420 lines) - Timing, recovery, cleanup, failure logs
+- **`streaming_runner.py`** (~360 lines) - Streaming compile + parallel test execution
+- **`sequential_runner.py`** (~545 lines) - Per-target compile + direct test invocation
 
 ## Migration Guide
 

--- a/ci/meson/build_config.py
+++ b/ci/meson/build_config.py
@@ -1,1025 +1,96 @@
 #!/usr/bin/env python3
-"""Meson build configuration and setup management for FastLED."""
+"""Meson build configuration and setup orchestration for FastLED.
+
+This module is the public entry point for ``setup_meson_build`` and
+``perform_ninja_maintenance``. The bulk of the setup logic lives in dedicated
+helper modules:
+
+- ``ci.meson.native_launchers``: ctc-* native launcher resolution + zccache
+- ``ci.meson.path_normalization``: zccache strict-path normalization
+- ``ci.meson.meson_markers``: per-build marker files + AR optimization patches
+- ``ci.meson.meson_cleanup``: build artifact cleanup + LLVM tool detection
+- ``ci.meson.meson_setup_phases``: state detection helpers (hashes, markers, file changes)
+- ``ci.meson.meson_setup_execute``: execution helpers (compiler detect, native file, run setup)
+
+Names re-exported from this module are kept stable for external callers
+(``wasm_build``, ``test_runner``, regression tests).
+"""
 # pyright: reportMissingImports=false, reportUnknownVariableType=false
 
-import glob
-import json
 import os
-import platform
-import re
-import shutil
-import subprocess
 import sys
 import time
-from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional, cast
 
 from running_process import RunningProcess
-from typeguard import typechecked
 
-from ci.meson.cache_utils import get_max_dir_mtime
-from ci.meson.compiler import (
-    check_meson_installed,
-    check_meson_version_compatibility,
-    get_compiler_version,
-    get_meson_executable,
-    get_meson_version,
+from ci.meson.compiler import check_meson_version_compatibility
+from ci.meson.meson_cleanup import (
+    CleanupResult,
+    cleanup_build_artifacts,
+    detect_system_llvm_tools,
 )
-from ci.meson.io_utils import atomic_write_text, write_if_different
-from ci.meson.output import print_banner, print_warning
-from ci.meson.test_discovery import get_source_files_hash, get_split_source_hashes
+from ci.meson.meson_markers import (
+    cleanup_stale_meson_lockfile,
+    inject_ar_optimization_patches,
+)
+from ci.meson.meson_setup_execute import (
+    build_meson_setup_cmd,
+    build_setup_env,
+    detect_compiler_and_cache,
+    handle_skip_meson_setup,
+    run_meson_setup_command,
+    write_meson_native_file,
+)
+from ci.meson.meson_setup_phases import (
+    MarkerPaths,
+    check_meson_build_modified,
+    check_obsolete_zig_wrappers,
+    check_reconfigure_markers,
+    compute_source_hashes,
+    detect_example_file_changes,
+    detect_test_file_changes,
+)
+from ci.meson.native_launchers import (
+    EmccNativeLaunchers,
+    FastNativeEntries,
+    WasmNativeEntries,
+    _ensure_emcc_native_launcher,
+    _find_zccache_binary,
+    get_zccache_version,
+    resolve_wasm_native_entries,
+)
+from ci.meson.path_normalization import (
+    _enforce_strict_path_violations,
+    find_strict_path_violations,
+    is_ar_content_preserving_active,
+    normalize_meson_private_include_paths,
+)
 from ci.util.global_interrupt_handler import handle_keyboard_interrupt
 from ci.util.output_formatter import TimestampFormatter
 from ci.util.timestamp_print import ts_print as _ts_print
 
 
-@dataclass
-class CleanupResult:
-    """Result of build artifact cleanup operation."""
-
-    deleted: int
-    failed: int
-    failed_files: list[str]
-
-
-@dataclass(slots=True)
-class FastNativeEntries:
-    cc: Optional[str]
-    cxx: Optional[str]
-    ar: Optional[str]
-
-
-@typechecked
-@dataclass(slots=True)
-class EmccNativeLaunchers:
-    """Compiled emscripten-tool launcher paths produced by ``compile_native()``.
-
-    Every field is a guaranteed-present absolute path. ``compile_native()``
-    in clang-tool-chain 1.5.1+ produces all seven launchers in one call;
-    if any is missing afterward the resolver raises rather than silently
-    falling back. clang-tool-chain >=1.5.1 is pinned in pyproject.toml.
-    """
-
-    emcc: str
-    empp: str
-    emar: str
-    emstrip: str
-    emranlib: str
-    emnm: str
-    wasm_ld: str
-
-
-@typechecked
-@dataclass(slots=True)
-class WasmNativeEntries:
-    """Native tool entries for the WASM cross-file.
-
-    All fields are absolute paths to compiled ctc-* native launchers.
-    No Python-wrapper fallbacks — clang-tool-chain >=1.5.1 is a hard
-    requirement and ``compile_native()`` is invoked eagerly.
-
-    ``wasm_ld`` is not consumed by meson directly. emcc invokes wasm-ld
-    internally; the integration is via the ``EMCC_WASM_LD`` env var picked
-    up by the shared.py patch that ``ensure_emscripten_available`` applies.
-    Carried here so the build orchestration can set the env var.
-    """
-
-    c: str
-    cpp: str
-    ar: str
-    strip: str
-    ranlib: str
-    nm: str
-    wasm_ld: str
-
-
-def _native_launcher_output_dir(project_root: Path) -> Path:
-    """Directory where compiled native launchers live."""
-    return project_root / ".cached" / "clang-native"
-
-
-def _ensure_native_launcher(project_root: Path) -> tuple[Optional[str], Optional[str]]:
-    """
-    Ensure ctc-clang/ctc-clang++ native launchers are compiled.
-
-    The native launcher is a compiled C++ binary that replaces the Python
-    clang-tool-chain wrapper with near-zero startup overhead (~34ms vs ~1200ms).
-    It auto-detects the platform, finds the clang installation, and adds all
-    necessary flags (--target, --sysroot, -stdlib, includes, etc.) automatically.
-
-    Returns:
-        Tuple of (ctc_clang_path, ctc_clangpp_path), or (None, None) on failure.
-    """
-    output_dir = _native_launcher_output_dir(project_root)
-    exe_suffix = ".exe" if sys.platform == "win32" else ""
-    ctc_clang = output_dir / f"ctc-clang{exe_suffix}"
-    ctc_clangpp = output_dir / f"ctc-clang++{exe_suffix}"
-
-    if ctc_clang.exists() and ctc_clangpp.exists():
-        return str(ctc_clang), str(ctc_clangpp)
-
-    try:
-        from clang_tool_chain.commands.compile_native import compile_native
-
-        output_dir.mkdir(parents=True, exist_ok=True)
-        rc = compile_native(str(output_dir))
-        if rc == 0 and ctc_clang.exists() and ctc_clangpp.exists():
-            return str(ctc_clang), str(ctc_clangpp)
-    except KeyboardInterrupt as ki:
-        handle_keyboard_interrupt(ki)
-    except Exception:
-        pass
-    return None, None
-
-
-def _ensure_emcc_native_launcher(project_root: Path) -> EmccNativeLaunchers:
-    """
-    Build and return all seven WASM-related ctc-* native launcher paths.
-
-    ``compile_native()`` from clang-tool-chain 1.5.1+ produces every binary
-    in a single invocation (clang + emcc + wasm-ld + emtool family with all
-    its hardlinked aliases). If any binary is missing afterward, raises
-    RuntimeError — no Python-wrapper fallback. clang-tool-chain >=1.5.1 is
-    pinned in pyproject.toml so this is a hard requirement.
-
-    Raises:
-        RuntimeError: if ``compile_native()`` fails or any launcher binary
-            is missing after a successful build.
-    """
-    output_dir = _native_launcher_output_dir(project_root)
-    exe_suffix = ".exe" if sys.platform == "win32" else ""
-    binaries = {
-        "emcc": output_dir / f"ctc-emcc{exe_suffix}",
-        "empp": output_dir / f"ctc-em++{exe_suffix}",
-        "emar": output_dir / f"ctc-emar{exe_suffix}",
-        "emstrip": output_dir / f"ctc-emstrip{exe_suffix}",
-        "emranlib": output_dir / f"ctc-emranlib{exe_suffix}",
-        "emnm": output_dir / f"ctc-emnm{exe_suffix}",
-        "wasm_ld": output_dir / f"ctc-wasm-ld{exe_suffix}",
-    }
-
-    # Warm-path presence check: one os.scandir() enumerates the whole dir
-    # in ~10-20 ms; 7 individual Path.exists() calls cost ~30 ms each on
-    # Windows NTFS (~240 ms total). Set-membership lookups are O(1).
-    try:
-        present_names: set[str] = {entry.name for entry in os.scandir(output_dir)}
-    except OSError:
-        present_names = set()
-    all_present = all(p.name in present_names for p in binaries.values())
-
-    if not all_present:
-        from clang_tool_chain.commands.compile_native import compile_native
-
-        output_dir.mkdir(parents=True, exist_ok=True)
-        rc = compile_native(str(output_dir))
-        if rc != 0:
-            raise RuntimeError(
-                f"clang-tool-chain compile_native() failed with rc={rc} "
-                f"in {output_dir}; cannot resolve WASM native launchers"
-            )
-        missing = [name for name, p in binaries.items() if not p.exists()]
-        if missing:
-            raise RuntimeError(
-                f"clang-tool-chain compile_native() succeeded but expected "
-                f"binaries are missing in {output_dir}: {missing}. "
-                f"Ensure clang-tool-chain >=1.5.1 is installed."
-            )
-
-    return EmccNativeLaunchers(**{name: str(p) for name, p in binaries.items()})
-
-
-def resolve_wasm_native_entries(project_root: Path) -> WasmNativeEntries:
-    """
-    Resolve compiler/archiver entries for the Meson WASM cross-file.
-
-    Returns absolute paths to the seven compiled ctc-* native launchers.
-    No Python-wrapper fallback — if ``compile_native()`` fails or any
-    binary is missing, raises (clang-tool-chain >=1.5.1 is pinned and
-    guarantees all seven launchers).
-
-    Raises:
-        RuntimeError: if ``compile_native()`` fails or any binary is missing.
-    """
-    launchers = _ensure_emcc_native_launcher(project_root)
-    return WasmNativeEntries(
-        c=launchers.emcc,
-        cpp=launchers.empp,
-        ar=launchers.emar,
-        strip=launchers.emstrip,
-        ranlib=launchers.emranlib,
-        nm=launchers.emnm,
-        wasm_ld=launchers.wasm_ld,
-    )
-
-
-def _find_zccache_binary() -> Optional[str]:
-    """
-    Find the zccache binary for compiler caching.
-
-    zccache is a blazing-fast local compiler cache daemon (43x faster than
-    other caches on warm hits). It works as a drop-in compiler launcher prefix.
-
-    Search order:
-    1. Sibling zccache repo (../zccache/target/{release,debug}) — dev builds
-    2. PATH (via shutil.which)
-    3. Common cargo install locations
-
-    Returns:
-        Path to zccache binary, or None if not found.
-    """
-    suffix = (
-        ".exe"
-        if os.name == "nt" or sys.platform.startswith(("win", "msys", "cygwin"))
-        else ""
-    )
-
-    # Check project .venv first (installed release version)
-    repo_root = Path(__file__).resolve().parent.parent.parent  # ci/meson/ -> repo root
-    venv_candidate = (
-        repo_root
-        / ".venv"
-        / ("Scripts" if os.name == "nt" else "bin")
-        / f"zccache{suffix}"
-    )
-    if venv_candidate.is_file():
-        return str(venv_candidate)
-
-    # Check sibling zccache repo (pick most recently built binary)
-    sibling_zccache = repo_root.parent / "zccache"
-    best: Optional[Path] = None
-    best_mtime: float = 0
-    for profile in ("release", "debug"):
-        candidate = sibling_zccache / "target" / profile / f"zccache{suffix}"
-        if candidate.is_file():
-            mtime = candidate.stat().st_mtime
-            if mtime > best_mtime:
-                best = candidate
-                best_mtime = mtime
-    if best is not None:
-        return str(best)
-
-    # Check PATH
-    path_result = shutil.which("zccache")
-    if path_result:
-        return path_result
-
-    # Check common cargo bin locations
-    for candidate_home in [
-        os.environ.get("CARGO_HOME", ""),
-        os.path.join(os.path.expanduser("~"), ".cargo"),
-    ]:
-        if candidate_home:
-            candidate_path = os.path.join(candidate_home, "bin", f"zccache{suffix}")
-            if os.path.isfile(candidate_path):
-                return candidate_path
-
-    return None
-
-
-def get_zccache_version(zccache_path: Optional[str] = None) -> str:
-    """
-    Get zccache version string for cache invalidation.
-
-    When the zccache version changes, cached compilation artifacts may be
-    incompatible and require a full rebuild.
-
-    Args:
-        zccache_path: Path to zccache binary. If None, auto-detected.
-
-    Returns:
-        Version string (e.g., "zccache 1.0.3") or "" if not available.
-    """
-    if zccache_path is None:
-        zccache_path = _find_zccache_binary()
-    if not zccache_path:
-        return ""
-    try:
-        result = subprocess.run(
-            [zccache_path, "--version"],
-            capture_output=True,
-            text=True,
-            encoding="utf-8",
-            errors="replace",
-            timeout=10,
-        )
-        if result.returncode == 0:
-            return result.stdout.strip()
-        return ""
-    except KeyboardInterrupt as ki:
-        handle_keyboard_interrupt(ki)
-        raise
-    except Exception:
-        return ""
-
-
-def _resolve_fast_native_entries(
-    cache_binary: Optional[str],
-) -> FastNativeEntries:
-    """
-    Resolve native launcher binaries for the Meson native file.
-
-    Uses ctc-clang/ctc-clang++ native launchers which handle all platform-
-    specific flags automatically (--target, --sysroot, -stdlib, includes, etc.)
-    with near-zero startup overhead (~34ms vs ~1200ms for Python wrappers).
-
-    Args:
-        cache_binary: Path to compiler cache binary (zccache),
-            or None to disable caching.
-
-    Returns:
-        FastNativeEntries with cc, cxx, and ar entries for the native file,
-        or all-None fields if resolution fails (falls back to wrappers).
-    """
-    _none = FastNativeEntries(cc=None, cxx=None, ar=None)
-    try:
-        from clang_tool_chain.platform.paths import (
-            find_tool_binary,
-        )
-    except ImportError:
-        return _none
-
-    try:
-        ar_path = str(find_tool_binary("llvm-ar"))
-
-        project_root = Path(__file__).resolve().parent.parent.parent
-        ctc_c, ctc_cpp = _ensure_native_launcher(project_root)
-        if ctc_c is None or ctc_cpp is None:
-            return _none
-
-        def _make_entry(binary: str) -> str:
-            parts: list[str] = []
-            if cache_binary:
-                parts.append(f"'{cache_binary}'")
-            parts.append(f"'{binary}'")
-            return "[" + ", ".join(parts) + "]"
-
-        return FastNativeEntries(
-            cc=_make_entry(ctc_c),
-            cxx=_make_entry(ctc_cpp),
-            ar=f"['{ar_path}']",
-        )
-
-    except KeyboardInterrupt as ki:
-        handle_keyboard_interrupt(ki)
-        return _none  # unreachable, satisfies type checker
-    except Exception:
-        return _none
-
-
-def _resolve_fast_compiler_binary() -> Optional[str]:
-    """
-    Resolve raw clang++ binary path, bypassing the Python entry point wrapper.
-
-    The Python wrapper (clang-tool-chain-cpp.EXE) has ~3.6 second startup
-    overhead. Using the raw binary directly saves this overhead for operations
-    like --version checks.
-
-    Returns:
-        Path to raw clang++ binary, or None if resolution fails.
-    """
-    try:
-        from clang_tool_chain.platform.paths import find_tool_binary
-
-        return str(find_tool_binary("clang++"))
-    except KeyboardInterrupt as ki:
-        handle_keyboard_interrupt(ki)
-        return None  # unreachable, satisfies type checker
-    except Exception:
-        return None
-
-
-def is_ar_content_preserving_active(build_dir: Path) -> bool:
-    """
-    Check if the content-preserving archive optimization is active in build.ninja.
-
-    Returns True if both patches are present:
-    - ar_content_preserving.py wrapper in the STATIC_LINKER command
-    - restat = 1 in the STATIC_LINKER rule
-
-    When this returns True, the BuildOptimizer's DLL fingerprinting is redundant:
-    - ar_content_preserving.py prevents the DLL relink cascade at the source
-    - BuildOptimizer.touch_dlls_if_lib_unchanged() (~5-6s) is no longer needed
-    - BuildOptimizer.save_fingerprints() (~5-6s) is no longer needed
-    - Skipping BuildOptimizer saves ~10-12 seconds per build
-
-    Performance: Uses a module-level cache populated by inject_ar_optimization_patches().
-    When inject_ar_optimization_patches() was called earlier in the same process
-    (which setup_meson_build() does), this function returns immediately from the cache
-    without reading build.ninja (~2ms saved per call).
-
-    Args:
-        build_dir: Meson build directory containing build.ninja
-
-    Returns:
-        True if both ar_content_preserving.py and restat=1 patches are active
-    """
-    # Fast path: check module-level cache populated by inject_ar_optimization_patches().
-    # In the normal code path, setup_meson_build() always calls that function first,
-    # so we get a cache hit here and avoid the build.ninja read (~2ms).
-    build_dir_key = str(build_dir)
-    if build_dir_key in _ar_opt_status_cache:
-        return _ar_opt_status_cache[build_dir_key]
-
-    # Cache miss: read build.ninja and check directly
-    build_ninja = build_dir / "build.ninja"
-    if not build_ninja.exists():
-        return False
-    try:
-        content = build_ninja.read_text(encoding="utf-8")
-        result = "ar_content_preserving.py" in content and "restat = 1" in content
-        _ar_opt_status_cache[build_dir_key] = result
-        return result
-    except OSError:
-        return False
-
-
-# Module-level cache for ar optimization status.
-# Populated by inject_ar_optimization_patches() to avoid repeated build.ninja reads.
-# Key: str(build_dir), Value: bool (True if both patches active)
-_ar_opt_status_cache: dict[str, bool] = {}
-
-
-# Path-bearing compiler flag prefixes that zccache strict path mode validates
-# (issue #2378). All accept an attached path (``-Idir``, ``-isystemdir``, ...)
-# as Meson always emits a single attached token per flag. Order matters: longer
-# prefixes must come first so the regex alternation matches the longest form
-# (``-include-pch`` before ``-include``).
-_STRICT_PATH_FLAG_PREFIXES: tuple[str, ...] = (
-    "-include-pch",
-    "-iframework",
-    "-idirafter",
-    "-isystem",
-    "-imacros",
-    "-include",
-    "-iquote",
-    "-imsvc",
-    "-I",
-    "-F",
-    "/I",
-)
-
-# Path char class excludes ``-`` as the FIRST character so the regex does not
-# mis-match the bare ``"-include-pch"`` token by falling back to the ``-include``
-# alternative + consuming ``-pch`` as the path. Real include paths never begin
-# with a hyphen.
-_STRICT_PATH_FLAG_RE = re.compile(
-    r'(?P<prefix>(?<!\S)"?(?:'
-    + "|".join(re.escape(p) for p in _STRICT_PATH_FLAG_PREFIXES)
-    + r'))(?P<path>[^\s"\-][^\s"]*)(?P<suffix>"?)'
-)
-
-
-def _is_forward_slash_absolute(path: str) -> bool:
-    return path.startswith("/") or re.match(r"^[A-Za-z]:/", path) is not None
-
-
-def _has_dot_components(path: str) -> bool:
-    for part in path.split("/"):
-        if part in (".", ".."):
-            return True
-    return False
-
-
-def normalize_meson_private_include_paths(build_dir: Path) -> bool:
-    """Normalize Meson-emitted path flags for zccache strict path mode.
-
-    Issue #2378 — ``ZCCACHE_STRICT_PATHS=absolute`` rejects path-bearing
-    compiler flags (``-I``, ``-isystem``, ``-iquote``, ``-iframework``,
-    ``-idirafter``, ``-imsvc``, ``-include``, ``-include-pch``, ``-imacros``,
-    ``-F``, ``/I``) that are not absolute, forward-slash, and free of ``.``
-    or ``..`` components.
-
-    Meson emits attached single-token flags like ``"-Ici/meson/native"`` and
-    ``"-I..\\..\\src"`` from subdir and ``implicit_include_directories``
-    behavior; this function rewrites them to canonical absolute forward-slash
-    form in both ``build.ninja`` and ``compile_commands.json``.
-    """
-
-    changed_any = False
-
-    def _replacement(match: re.Match[str]) -> str:
-        prefix, raw_path, suffix = match.groups()
-        normalized = raw_path.replace("\\", "/")
-        if _is_forward_slash_absolute(normalized) and not _has_dot_components(
-            normalized
-        ):
-            absolute = normalized
-        else:
-            absolute = (build_dir / normalized).resolve().as_posix()
-        if absolute == raw_path:
-            return match.group(0)
-        return f"{prefix}{absolute}{suffix}"
-
-    def _normalize_text(content: str) -> str:
-        return _STRICT_PATH_FLAG_RE.sub(_replacement, content)
-
-    build_ninja = build_dir / "build.ninja"
-    if build_ninja.exists():
-        try:
-            content = build_ninja.read_text(encoding="utf-8")
-        except OSError as e:
-            raise RuntimeError(
-                f"Could not read {build_ninja} while normalizing Meson strict paths"
-            ) from e
-        else:
-            normalized = _normalize_text(content)
-            if normalized != content:
-                try:
-                    build_ninja.write_text(normalized, encoding="utf-8")
-                    changed_any = True
-                except OSError as e:
-                    raise RuntimeError(
-                        f"Could not write {build_ninja} after normalizing Meson strict paths"
-                    ) from e
-
-    compile_commands = build_dir / "compile_commands.json"
-    if compile_commands.exists():
-        try:
-            data = json.loads(compile_commands.read_text(encoding="utf-8"))
-        except OSError as e:
-            raise RuntimeError(
-                f"Could not read {compile_commands} while normalizing Meson strict paths"
-            ) from e
-        except json.JSONDecodeError as e:
-            raise RuntimeError(
-                f"Could not parse {compile_commands} while normalizing Meson strict paths"
-            ) from e
-        if isinstance(data, list):
-            changed_json = False
-            for entry in data:
-                if not isinstance(entry, dict):
-                    continue
-                entry_dict = cast(dict[str, object], entry)
-                command = entry_dict.get("command")
-                if not isinstance(command, str):
-                    continue
-                normalized = _normalize_text(command)
-                if normalized != command:
-                    entry_dict["command"] = normalized
-                    changed_json = True
-            if changed_json:
-                try:
-                    compile_commands.write_text(
-                        json.dumps(data, indent=2) + "\n",
-                        encoding="utf-8",
-                    )
-                    changed_any = True
-                except OSError as e:
-                    raise RuntimeError(
-                        f"Could not write {compile_commands} after normalizing Meson strict paths"
-                    ) from e
-
-    return changed_any
-
-
-def find_strict_path_violations(build_dir: Path) -> list[str]:
-    """Return human-readable strict-path violations in ``compile_commands.json``.
-
-    Issue #2378 — every ``-I`` / ``-isystem`` / ``-iquote`` / ``-iframework`` /
-    ``-idirafter`` / ``-imsvc`` / ``-include`` / ``-include-pch`` / ``-imacros``
-    / ``-F`` / ``/I`` path must be absolute, forward-slash, and free of ``.``
-    or ``..`` components. This is the same predicate enforced by
-    ``ZCCACHE_STRICT_PATHS=absolute`` at compile time; checking it ourselves
-    after meson setup lets us fail before ninja schedules any compile work.
-
-    Returns an empty list when the file is missing (a fresh tree) or clean.
-    """
-    cc_json = build_dir / "compile_commands.json"
-    if not cc_json.exists():
-        return []
-    try:
-        data = json.loads(cc_json.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
-        return []
-    if not isinstance(data, list):
-        return []
-
-    violations: list[str] = []
-    for entry in data:
-        if not isinstance(entry, dict):
-            continue
-        entry_dict = cast(dict[str, object], entry)
-        command = entry_dict.get("command")
-        if not isinstance(command, str):
-            continue
-        for match in _STRICT_PATH_FLAG_RE.finditer(command):
-            raw = match.group("path")
-            normalized = raw.replace("\\", "/")
-            if "\\" in raw:
-                violations.append(f"{match.group('prefix').lstrip(chr(34))}{raw}")
-                continue
-            if not _is_forward_slash_absolute(normalized):
-                violations.append(f"{match.group('prefix').lstrip(chr(34))}{raw}")
-                continue
-            if _has_dot_components(normalized):
-                violations.append(f"{match.group('prefix').lstrip(chr(34))}{raw}")
-    return violations
-
-
-def _enforce_strict_path_violations(build_dir: Path) -> None:
-    """Raise loudly when ``compile_commands.json`` still has strict-path offenders.
-
-    The normalizer above is meant to leave no offenders behind; this is the
-    fail-fast guard for issue #2378's "validation step that checks generated
-    compile commands before CI compiles". Any violation here is a bug in the
-    normalizer or a new Meson code-path that emits unnormalized flags.
-    """
-    violations = find_strict_path_violations(build_dir)
-    if not violations:
-        return
-
-    sample = violations[:10]
-    extra = len(violations) - len(sample)
-    lines = [
-        f"[MESON] ZCCACHE_STRICT_PATHS=absolute would reject {len(violations)}"
-        " compile flag(s) in compile_commands.json (issue #2378):",
-    ]
-    lines.extend(f"  {flag}" for flag in sample)
-    if extra > 0:
-        lines.append(f"  ... {extra} more")
-    message = "\n".join(lines)
-    _ts_print(message, file=sys.stderr)
-    raise RuntimeError(message)
-
-
-def cleanup_stale_meson_lockfile(build_dir: Path) -> bool:
-    """Remove a stale ``meson-private/meson.lock`` left by a killed meson process.
-
-    On Windows, meson <= 1.10.x crashed cryptically in ``DirectoryLock.__enter__``
-    when the underlying lockfile open() raised an OSError (e.g., from a stale
-    lockfile left by a killed/abandoned meson process). meson 1.11.0 fixed the
-    crash itself, but the underlying cause — a stale ``meson-private/meson.lock``
-    file — still produces an avoidable setup failure on Windows. Deleting the
-    stale lockfile before invoking ``meson setup`` avoids the failure entirely.
-
-    Args:
-        build_dir: The meson build directory (parent of ``meson-private``).
-
-    Returns:
-        True if a stale lockfile was found and successfully removed, False
-        otherwise (including when no lockfile exists or removal failed).
-    """
-    # Stale lockfile cleanup is intended for the Windows DirectoryLock bug.
-    # On POSIX, meson uses fcntl/flock (advisory) — removing an in-use lockfile
-    # could let a concurrent meson setup bypass the intended lock.
-    if os.name != "nt":
-        return False
-
-    lockfile = build_dir / "meson-private" / "meson.lock"
-    if not lockfile.exists():
-        return False
-    try:
-        lockfile.unlink()
-        _ts_print(f"[MESON] Removed stale lockfile: {lockfile}")
-        return True
-    except KeyboardInterrupt as ki:
-        handle_keyboard_interrupt(ki)
-        raise
-    except OSError as e:
-        # Be tolerant of file-in-use errors on Windows — if removal fails, log
-        # and continue. The caller will hit the original OSError from meson,
-        # which is now visible thanks to the 1.11.0 bump.
-        _ts_print(f"[MESON] Warning: Could not remove stale lockfile {lockfile}: {e}")
-        return False
-
-
-def _write_configuration_markers(
-    *,
-    build_mode_marker: Path,
-    build_mode: str,
-    thin_archive_marker: Path,
-    use_thin_archives: bool,
-    debug_marker: Path,
-    debug: bool,
-    check_marker: Path,
-    check: bool,
-    source_files_marker: Path,
-    current_source_hash: str,
-    current_source_files: list[str],
-    src_files_marker: Path,
-    current_src_hash: str,
-    test_files_marker: Path,
-    current_test_hash: str,
-    compiler_version_marker: Path,
-    current_compiler_version: str,
-    zccache_version_marker: Optional[Path] = None,
-    current_zccache_version: Optional[str] = None,
-    enable_examples_marker: Optional[Path] = None,
-    enable_examples: Optional[bool] = None,
-    enable_unit_tests_marker: Optional[Path] = None,
-    enable_unit_tests: Optional[bool] = None,
-    only_missing: bool = False,
-    verb: str = "Saved",
-) -> None:
-    """Write configuration marker files for cache invalidation.
-
-    Args:
-        only_missing: If True, only write markers that don't exist yet (migration path).
-                      If False, write all markers unconditionally (after meson setup).
-        verb: Display verb for log messages ("Saved" or "Created").
-    """
-    markers: list[tuple[Path, str, str]] = [
-        (build_mode_marker, build_mode, f"build_mode: {build_mode}"),
-        (
-            thin_archive_marker,
-            str(use_thin_archives),
-            f"thin archive: {use_thin_archives}",
-        ),
-        (debug_marker, str(debug), f"debug: {debug}"),
-        (check_marker, str(check), f"check: {check}"),
-        (
-            compiler_version_marker,
-            current_compiler_version,
-            f"compiler version: {current_compiler_version}",
-        ),
-    ]
-
-    # Add optional zccache version marker
-    if zccache_version_marker is not None and current_zccache_version is not None:
-        markers.append(
-            (
-                zccache_version_marker,
-                current_zccache_version,
-                f"zccache version: {current_zccache_version}",
-            )
-        )
-
-    # Add optional enable_examples/enable_unit_tests markers
-    if enable_examples_marker is not None and enable_examples is not None:
-        markers.append(
-            (
-                enable_examples_marker,
-                str(enable_examples),
-                f"enable_examples: {enable_examples}",
-            )
-        )
-    if enable_unit_tests_marker is not None and enable_unit_tests is not None:
-        markers.append(
-            (
-                enable_unit_tests_marker,
-                str(enable_unit_tests),
-                f"enable_unit_tests: {enable_unit_tests}",
-            )
-        )
-
-    for marker_path, value, description in markers:
-        if only_missing and marker_path.exists():
-            continue
-        try:
-            atomic_write_text(marker_path, value)
-            _ts_print(f"[MESON] ✅ {verb} {description}")
-        except (OSError, IOError) as e:
-            _ts_print(f"[MESON] Warning: Could not write {marker_path.name}: {e}")
-
-    # Source files markers: write combined hash (backward compat) and split hashes
-    if current_source_hash:
-        if not only_missing or not source_files_marker.exists():
-            try:
-                atomic_write_text(source_files_marker, current_source_hash)
-                _ts_print(
-                    f"[MESON] ✅ {verb} source/test files hash ({len(current_source_files)} files)"
-                )
-            except (OSError, IOError) as e:
-                _ts_print(f"[MESON] Warning: Could not write source files marker: {e}")
-    # Write split markers for granular change detection
-    if current_src_hash:
-        if not only_missing or not src_files_marker.exists():
-            try:
-                atomic_write_text(src_files_marker, current_src_hash)
-            except (OSError, IOError):
-                pass
-    if current_test_hash:
-        if not only_missing or not test_files_marker.exists():
-            try:
-                atomic_write_text(test_files_marker, current_test_hash)
-            except (OSError, IOError):
-                pass
-
-
-def inject_ar_optimization_patches(build_dir: Path, source_dir: Path) -> bool:
-    """
-    Apply both ar optimization patches to build.ninja in a single read-modify-write.
-
-    Reads build.ninja only ONCE and writes at most ONCE.
-
-    Also populates _ar_opt_status_cache so that a subsequent call to
-    is_ar_content_preserving_active() can return from cache without reading
-    build.ninja a third time. This saves ~4ms per incremental build.
-
-    Patches applied:
-    1. ``restat = 1`` added to STATIC_LINKER rule (enables ninja cascade suppression)
-    2. ar_content_preserving.py wrapper prepended to STATIC_LINKER command
-
-    Args:
-        build_dir: Meson build directory containing build.ninja
-        source_dir: Project source root (parent of ci/)
-
-    Returns:
-        True if both patches are active after this call, False if not applicable
-    """
-    ar_wrapper_script = source_dir / "ci" / "meson" / "ar_content_preserving.py"
-    build_ninja_path = build_dir / "build.ninja"
-
-    if not ar_wrapper_script.exists() or not build_ninja_path.exists():
-        return False
-
-    try:
-        content = build_ninja_path.read_text(encoding="utf-8")
-    except OSError:
-        return False
-
-    if "rule STATIC_LINKER" not in content:
-        return False
-
-    # Idempotency check: if both patches already present, no write needed
-    has_ar_wrapper = ar_wrapper_script.name in content
-    has_restat = "restat = 1" in content
-
-    if has_ar_wrapper and has_restat:
-        _ar_opt_status_cache[str(build_dir)] = True
-        return True
-
-    # Need to apply one or both patches; find the STATIC_LINKER rule block
-    static_linker_pos = content.find("rule STATIC_LINKER")
-    if static_linker_pos == -1:
-        return False
-
-    rule_end = content.find("\n\n", static_linker_pos)
-    if rule_end == -1:
-        rule_end = len(content)
-
-    rule_text = content[static_linker_pos:rule_end]
-    new_rule_text = rule_text
-
-    # Patch 1: restat = 1 (enables ninja cascade suppression after archive)
-    if not has_restat:
-        description_line = " description = Linking static target $out"
-        if description_line in new_rule_text:
-            new_rule_text = new_rule_text.replace(
-                description_line,
-                description_line + "\n restat = 1",
-            )
-
-    # Patch 2: ar_content_preserving.py wrapper (preserves mtime when content unchanged)
-    if not has_ar_wrapper:
-        command_prefix = " command = "
-        if command_prefix in new_rule_text:
-            cmd_start = new_rule_text.find(command_prefix)
-            cmd_line_start = cmd_start + len(command_prefix)
-            cmd_line_end = new_rule_text.find("\n", cmd_line_start)
-            if cmd_line_end == -1:
-                cmd_line_end = len(new_rule_text)
-            original_cmd = new_rule_text[cmd_line_start:cmd_line_end]
-            if "$LINK_ARGS $out $in" in original_cmd:
-                python_exe = sys.executable
-                new_cmd = f'"{python_exe}" "{ar_wrapper_script}" {original_cmd}'
-                new_rule_text = (
-                    new_rule_text[:cmd_line_start]
-                    + new_cmd
-                    + new_rule_text[cmd_line_end:]
-                )
-
-    # Write modified content if anything changed (at most one write)
-    if new_rule_text != rule_text:
-        new_content = content[:static_linker_pos] + new_rule_text + content[rule_end:]
-        try:
-            build_ninja_path.write_text(new_content, encoding="utf-8")
-        except OSError:
-            _ar_opt_status_cache[str(build_dir)] = False
-            return False
-
-    # Verify both patches are now active and populate cache
-    patches_active = (
-        ar_wrapper_script.name in new_rule_text and "restat = 1" in new_rule_text
-    )
-    _ar_opt_status_cache[str(build_dir)] = patches_active
-    return patches_active
-
-
-def cleanup_build_artifacts(build_dir: Path, reason: str) -> dict[str, CleanupResult]:
-    """
-    Clean all build artifacts from a build directory.
-
-    This function centralizes all build artifact cleanup logic and provides
-    consistent failure tracking and reporting. It's designed to be called
-    when debug mode, build mode, or compiler version changes.
-
-    Args:
-        build_dir: Meson build directory to clean
-        reason: Human-readable reason for cleanup (e.g., "debug mode changed")
-
-    Returns:
-        Dictionary mapping artifact type to CleanupResult with deletion stats
-    """
-    _ts_print(f"[MESON] 🗑️  {reason} - cleaning all build artifacts")
-
-    # Artifact types with their file extensions
-    # Format: (display_name, list of glob patterns)
-    artifact_types: list[tuple[str, list[str]]] = [
-        ("object files", ["*.obj", "*.o"]),
-        ("static libraries", ["*.a"]),
-        ("executables", ["*.exe"]),
-        ("precompiled headers", ["*.pch"]),
-        ("Windows static libraries", ["*.lib"]),
-        ("Windows DLLs", ["*.dll"]),
-        ("Linux shared objects", ["*.so"]),
-        ("macOS dynamic libraries", ["*.dylib"]),
-    ]
-
-    results: dict[str, CleanupResult] = {}
-
-    for display_name, patterns in artifact_types:
-        deleted = 0
-        failed = 0
-        failed_files: list[str] = []
-
-        for pattern in patterns:
-            files = glob.glob(str(build_dir / "**" / pattern), recursive=True)
-            for file_path in files:
-                try:
-                    Path(file_path).unlink()
-                    deleted += 1
-                except (OSError, IOError) as e:
-                    failed += 1
-                    failed_files.append(f"{file_path}: {e}")
-
-        results[display_name] = CleanupResult(
-            deleted=deleted, failed=failed, failed_files=failed_files
-        )
-
-    # Build summary message
-    summary_parts: list[str] = []
-    total_failed = 0
-    for display_name, result in results.items():
-        if result.deleted > 0 or result.failed > 0:
-            summary_parts.append(f"{result.deleted} {display_name}")
-            total_failed += result.failed
-
-    if summary_parts:
-        _ts_print(f"[MESON] 🗑️  Deleted {', '.join(summary_parts)}")
-
-    # Report failures if any occurred
-    if total_failed > 0:
-        _ts_print(f"[MESON] ⚠️  Failed to delete {total_failed} files:")
-        for display_name, result in results.items():
-            for failed_file in result.failed_files[:5]:  # Limit to 5 per type
-                _ts_print(f"[MESON]     {failed_file}")
-            if len(result.failed_files) > 5:
-                _ts_print(
-                    f"[MESON]     ... and {len(result.failed_files) - 5} more {display_name}"
-                )
-
-    return results
-
-
-def detect_system_llvm_tools() -> tuple[bool, bool]:
-    """
-    Detect if system has LLD and LLVM-AR that support thin archives.
-
-    Returns:
-        Tuple of (has_lld, has_llvm_ar)
-    """
-    has_lld = False
-    has_llvm_ar = False
-
-    # Check for system lld
-    # Try 'lld' first (created by workflow symlink or available by default)
-    # Then try 'ld.lld' (Linux naming) as fallback
-    for lld_cmd in ["lld", "ld.lld"]:
-        try:
-            result = subprocess.run(
-                [lld_cmd, "--version"],
-                capture_output=True,
-                text=True,
-                encoding="utf-8",
-                errors="replace",
-                timeout=5,
-            )
-            if result.returncode == 0:
-                has_lld = True
-                break
-        except (subprocess.SubprocessError, FileNotFoundError):
-            continue
-
-    # Check for llvm-ar with thin archive support
-    # Try unversioned first, then common versioned variants (llvm-ar-20, llvm-ar-19, etc.)
-    for ar_cmd in ["llvm-ar", "llvm-ar-20", "llvm-ar-19", "llvm-ar-18"]:
-        try:
-            result = subprocess.run(
-                [ar_cmd, "--help"],
-                capture_output=True,
-                encoding="utf-8",
-                errors="replace",
-                timeout=5,
-            )
-            if result.returncode == 0 and "thin" in result.stdout.lower():
-                has_llvm_ar = True
-                break
-        except (subprocess.SubprocessError, FileNotFoundError):
-            continue
-
-    return has_lld, has_llvm_ar
+# Re-exported names — kept here so external callers don't break.
+__all__ = [
+    "CleanupResult",
+    "EmccNativeLaunchers",
+    "FastNativeEntries",
+    "WasmNativeEntries",
+    "_ensure_emcc_native_launcher",
+    "_find_zccache_binary",
+    "cleanup_build_artifacts",
+    "cleanup_stale_meson_lockfile",
+    "detect_system_llvm_tools",
+    "find_strict_path_violations",
+    "get_zccache_version",
+    "inject_ar_optimization_patches",
+    "is_ar_content_preserving_active",
+    "normalize_meson_private_include_paths",
+    "perform_ninja_maintenance",
+    "resolve_wasm_native_entries",
+    "setup_meson_build",
+]
 
 
 def setup_meson_build(
@@ -1028,7 +99,7 @@ def setup_meson_build(
     reconfigure: bool = False,
     debug: bool = False,
     check: bool = False,
-    build_mode: Optional[str] = None,
+    build_mode: "str | None" = None,
     verbose: bool = False,
     enable_examples: bool = True,
     enable_unit_tests: bool = True,
@@ -1053,28 +124,21 @@ def setup_meson_build(
     # Derive build_mode from debug flag if not explicitly provided
     if build_mode is None:
         build_mode = "debug" if debug else "quick"
-
-    # Ensure debug flag matches build_mode for consistency
     if build_mode == "debug":
         debug = True
     elif build_mode in ("quick", "release", "profile"):
         debug = False
-    # Create build directory if it doesn't exist
-    build_dir.mkdir(parents=True, exist_ok=True)
 
-    # Check if already configured
+    build_dir.mkdir(parents=True, exist_ok=True)
     meson_info = build_dir / "meson-info"
     already_configured = meson_info.exists()
 
     force_reconfigure = False
-    compiler_version_changed = False  # Track for late check after compiler detection
+    force_reconfigure_reason: "str | None" = None
+    compiler_version_changed = False
 
-    # ============================================================================
-    # CRITICAL: Check meson version compatibility BEFORE proceeding
-    # ============================================================================
-    # Meson 1.9.x and 1.10.x create INCOMPATIBLE build directories!
-    # A build directory created by one version cannot be used by another version.
-    # If we detect a version mismatch, auto-reconfigure (self-healing).
+    # CRITICAL: Meson 1.9.x and 1.10.x produce incompatible build directories.
+    # If we detect a mismatch, auto-heal by forcing reconfigure + artifact cleanup.
     if already_configured:
         is_compatible, compatibility_message = check_meson_version_compatibility(
             build_dir
@@ -1095,871 +159,102 @@ def setup_meson_build(
                 "[MESON] 🔧 Auto-fix: Forcing reconfiguration with current meson version"
             )
             _ts_print("=" * 80)
-            # Auto-heal: Force reconfigure instead of failing
             force_reconfigure = True
             force_reconfigure_reason = "meson version mismatch (auto-healing)"
-            # Clean build artifacts to ensure clean slate
             cleanup_build_artifacts(build_dir, "Meson version mismatch")
 
-    # ============================================================================
-    # THIN ARCHIVES: ENABLED FOR CLANG-TOOL-CHAIN
-    # ============================================================================
-    #
-    # Background:
-    # -----------
-    # Thin archives (created with `ar crT` or `ar --thin`) store only file paths
-    # instead of embedding object files directly. This provides significant benefits:
-    # - Faster archive creation (no file copying)
-    # - Smaller disk usage (object files not duplicated in archive)
-    # - Faster incremental builds (archive update is just path table change)
-    #
-    # What Are Thin Archives?
-    # -----------------------
-    # Regular archive:  [header][obj1_data][obj2_data][obj3_data]  (~50MB)
-    # Thin archive:     [header][path_to_obj1][path_to_obj2]...    (~50KB)
-    #
-    # Regular archives embed copies of all object files. Thin archives only
-    # store file paths and let the linker read objects from their original
-    # locations. This is safe because build systems control object lifetime.
-    #
-    # Current Implementation:
-    # -----------------------
-    # As of commit 6bbe2725e7, FastLED now uses clang-tool-chain instead of Zig.
-    # The clang-tool-chain package provides LLVM-based tools (clang, lld, llvm-ar)
-    # that fully support thin archives.
-    #
-    # Historical Context:
-    # -------------------
-    # Previously, thin archives were disabled because Zig's bundled linker (lld)
-    # did not support the thin archive format (!<thin> header). This caused link
-    # failures when llvm-ar created thin archives but Zig's lld tried to read them.
-    #
-    # With the migration to clang-tool-chain, all toolchain components (compiler,
-    # linker, archiver) are now from the same LLVM toolchain and fully support
-    # thin archives. There is no longer any compatibility issue.
-    #
-    # Benefits of Re-enabling:
-    # ------------------------
-    # ✓ Faster archive creation (~100-500ms saved for libfastled.a)
-    # ✓ Smaller disk usage (~50MB → ~50KB for libfastled.a, 99% reduction)
-    # ✓ Faster incremental builds (archive update is just path table change)
-    # ✓ No compatibility issues with clang-tool-chain's LLVM toolchain
-    #
-    # Configuration:
-    # --------------
-    # Thin archives are automatically enabled with clang-tool-chain.
-    # They can be manually disabled by setting FASTLED_DISABLE_THIN_ARCHIVES=1
-    # environment variable if needed for debugging or compatibility testing.
-    # ============================================================================
-
+    # Thin archives — enabled for clang-tool-chain LLVM toolchain; off via env var.
     disable_thin_archives = os.environ.get("FASTLED_DISABLE_THIN_ARCHIVES", "0") == "1"
-
-    # Enable thin archives for clang-tool-chain (LLVM-based toolchain)
-    # clang-tool-chain provides llvm-ar and lld that fully support thin archives
     use_thin_archives = not disable_thin_archives
-
-    # ============================================================================
-    # CRITICAL: Check if thin archive configuration has changed
-    # ============================================================================
-    # When Meson is configured, it caches the AR tool path and flags in its
-    # build files. If we previously configured with thin archives enabled but
-    # now have them disabled (or vice versa), we MUST reconfigure Meson.
-    # Otherwise, Meson will continue using the old AR tool/settings.
-    #
-    # We use a marker file to track the last successful thin archive setting.
-    # If it doesn't match the current setting, we force a reconfigure.
-    # ============================================================================
-    thin_archive_marker = build_dir / ".thin_archive_config"
-    source_files_marker = build_dir / ".source_files_hash"
-    src_files_marker = build_dir / ".src_files_hash"
-    test_files_marker = build_dir / ".test_files_hash"
-    debug_marker = build_dir / ".debug_config"
-    check_marker = build_dir / ".check_config"
-    build_mode_marker = build_dir / ".build_mode_config"
-    compiler_version_marker = build_dir / ".compiler_version_config"
-    zccache_version_marker = build_dir / ".zccache_version_config"
-    enable_examples_marker = build_dir / ".enable_examples_config"
-    enable_unit_tests_marker = build_dir / ".enable_unit_tests_config"
-
-    # Pre-compute directory max-mtimes once for all fast-path checks below.
-    # The tests/ directory is needed by BOTH:
-    #   1. The source hash fast-path (src/ + tests/ combined max mtime, ~line 543)
-    #   2. The test discovery fast-path (tests/ max mtime alone, ~line 786)
-    # Without precomputation, tests/ is walked TWICE (~50ms each on Windows = ~100ms wasted).
-    # By computing once here and reusing below, we save ~50ms per incremental build.
-    _max_tests_dir_mtime: float = get_max_dir_mtime(source_dir / "tests")
-
-    # Get current source file hashes (split: src/ and tests/ independently).
-    #
-    # Fast path: if markers are newer than every directory under their respective
-    # trees, no files have been added or removed → use cached hashes without
-    # performing an expensive rglob walk (~200-500ms on large trees).
-    #
-    # Rationale: adding/removing a file always updates the PARENT directory's mtime
-    # on NTFS, ext4, and APFS.  So checking directory mtimes is an O(#dirs) proxy
-    # for the O(#files) rglob.  On a cache hit the walk is skipped entirely; on a
-    # miss we fall back to the full rglob as before.
-    #
-    # Split hashes allow the reconfigure message to report exactly which directory
-    # changed (src/ vs tests/) instead of a generic "source/test files changed".
-    current_src_hash: str = ""
-    current_test_hash: str = ""
-    current_source_hash: str = ""  # combined, for backward-compat marker
-    current_source_files: list[str] = []
-
-    # Try fast-path for src/ hash
-    _max_src_dir_mtime = get_max_dir_mtime(source_dir / "src")
-    if src_files_marker.exists():
-        try:
-            _marker_mtime = src_files_marker.stat().st_mtime
-            if _max_src_dir_mtime <= _marker_mtime:
-                _cached = src_files_marker.read_text(encoding="utf-8").strip()
-                if _cached:
-                    current_src_hash = _cached
-        except OSError:
-            pass
-
-    # Try fast-path for tests/ hash
-    if test_files_marker.exists():
-        try:
-            _marker_mtime = test_files_marker.stat().st_mtime
-            if _max_tests_dir_mtime <= _marker_mtime:
-                _cached = test_files_marker.read_text(encoding="utf-8").strip()
-                if _cached:
-                    current_test_hash = _cached
-        except OSError:
-            pass
-
-    # Fall back to combined hash for backward-compat marker (.source_files_hash)
-    # Also populates split hashes if fast-path missed either one
-    if not current_src_hash or not current_test_hash:
-        _split = get_split_source_hashes(source_dir)
-        if not current_src_hash:
-            current_src_hash = _split.src_hash
-        if not current_test_hash:
-            current_test_hash = _split.tests_hash
-        current_source_files = sorted(_split.src_files + _split.test_files)
-
-    # Compute combined hash for the legacy .source_files_hash marker
-    if source_files_marker.exists():
-        try:
-            _marker_mtime = source_files_marker.stat().st_mtime
-            _max_combined = max(_max_src_dir_mtime, _max_tests_dir_mtime)
-            if _max_combined <= _marker_mtime:
-                _cached = source_files_marker.read_text(encoding="utf-8").strip()
-                if _cached:
-                    current_source_hash = _cached
-        except OSError:
-            pass
-    if not current_source_hash:
-        current_source_hash, current_source_files = get_source_files_hash(source_dir)
-
-    # ============================================================================
-    # CONSOLIDATED MARKER CHECKING
-    # ============================================================================
-    # Instead of printing multiple "forcing reconfigure" messages for each missing
-    # marker, we collect all reasons and print a single consolidated message.
-    # This reduces noise when switching build modes or on first run.
-    # ============================================================================
-    reconfigure_reasons: list[str] = []  # Collect reasons for reconfiguration
-    force_reconfigure_reason: Optional[str] = (
-        None  # Primary reason for forced reconfigure
-    )
-    debug_changed = False
-    build_mode_changed = False
-    last_build_mode: Optional[str] = None
-
-    if already_configured:
-        # ============================================================================
-        # SELF-HEALING: Check for corrupted introspection files marker
-        # ============================================================================
-        # When meson introspect fails due to missing intro-*.json files, the
-        # test discovery code creates this marker to trigger auto-healing.
-        # This typically happens when the build directory is partially created/deleted
-        # or meson setup was interrupted mid-execution.
-        # ============================================================================
-        intro_corruption_marker = build_dir / ".intro_corruption_detected"
-        if intro_corruption_marker.exists():
-            _ts_print("")
-            _ts_print("=" * 80)
-            _ts_print(
-                "[MESON] ⚠️  INTROSPECTION FILE CORRUPTION DETECTED - AUTO-HEALING"
-            )
-            _ts_print("=" * 80)
-            _ts_print("[MESON] Corruption marker detected (created by test discovery)")
-            _ts_print("[MESON]")
-            _ts_print(
-                "[MESON] The build directory has corrupted or missing intro-*.json files."
-            )
-            _ts_print(
-                "[MESON] These files are required for Meson introspection (test discovery, etc)."
-            )
-            _ts_print("[MESON]")
-            _ts_print(
-                "[MESON] 🔧 Auto-fix: Forcing reconfiguration to regenerate intro files"
-            )
-            _ts_print("=" * 80)
-            _ts_print("")
-
-            # Delete the marker file so we don't reconfigure repeatedly
-            try:
-                intro_corruption_marker.unlink()
-                _ts_print("[MESON] ✅ Removed corruption marker")
-            except (OSError, IOError) as e:
-                _ts_print(f"[MESON] Warning: Could not remove corruption marker: {e}")
-
-            # Force reconfigure
-            force_reconfigure = True
-            force_reconfigure_reason = "introspection files corrupted (auto-healing)"
-            reconfigure_reasons.append("introspection files corrupted")
-
-            # Continue to other marker checks (they might also need attention)
-
-        # Check if thin archive setting has changed since last configure
-        if thin_archive_marker.exists():
-            try:
-                last_thin_setting = thin_archive_marker.read_text().strip() == "True"
-                if last_thin_setting != use_thin_archives:
-                    reconfigure_reasons.append(
-                        f"thin archive changed: {last_thin_setting} → {use_thin_archives}"
-                    )
-            except (OSError, IOError):
-                reconfigure_reasons.append("thin archive marker unreadable")
-        else:
-            reconfigure_reasons.append("thin archive marker missing")
-
-        # Check if source/test files have changed since last configure
-        # This detects when files are added or removed, which requires reconfigure
-        # CRITICAL: Test file tracking ensures organize_tests.py runs with current file list
-        # Split check: report exactly which directory changed (src/ vs tests/)
-        _src_changed = False
-        _test_changed = False
-        if current_src_hash:
-            if src_files_marker.exists():
-                try:
-                    if src_files_marker.read_text().strip() != current_src_hash:
-                        _src_changed = True
-                except (OSError, IOError):
-                    _src_changed = True
-            else:
-                _src_changed = True
-        if current_test_hash:
-            if test_files_marker.exists():
-                try:
-                    if test_files_marker.read_text().strip() != current_test_hash:
-                        _test_changed = True
-                except (OSError, IOError):
-                    _test_changed = True
-            else:
-                _test_changed = True
-        # Fall back to combined hash if split markers don't exist yet
-        if not _src_changed and not _test_changed and current_source_hash:
-            if source_files_marker.exists():
-                try:
-                    last_hash = source_files_marker.read_text().strip()
-                    if last_hash != current_source_hash:
-                        _src_changed = True  # can't tell which, assume both
-                        _test_changed = True
-                except (OSError, IOError):
-                    _src_changed = True
-                    _test_changed = True
-            else:
-                _src_changed = True
-                _test_changed = True
-        if _src_changed and _test_changed:
-            reconfigure_reasons.append("source and test files changed")
-        elif _src_changed:
-            reconfigure_reasons.append("source files changed (src/)")
-        elif _test_changed:
-            reconfigure_reasons.append("test files changed (tests/)")
-
-        # Check if debug mode setting has changed since last configure
-        # This is critical because debug mode changes compiler flags (sanitizers, optimization)
-        # Using old object files with different flags causes linker errors
-        # CRITICAL: When debug mode changes, we must delete all object files and archives
-        # because they were compiled with different sanitizer/optimization flags
-        if debug_marker.exists():
-            try:
-                last_debug_setting = debug_marker.read_text().strip() == "True"
-                if last_debug_setting != debug:
-                    reconfigure_reasons.append(
-                        f"debug mode changed: {last_debug_setting} → {debug}"
-                    )
-                    debug_changed = True
-            except (OSError, IOError):
-                reconfigure_reasons.append("debug marker unreadable")
-        else:
-            reconfigure_reasons.append("debug marker missing")
-
-        # Check if IWYU check setting has changed since last configure
-        # When check mode changes, we must reconfigure to update the C++ compiler wrapper
-        if check_marker.exists():
-            try:
-                last_check_setting = check_marker.read_text().strip() == "True"
-                if last_check_setting != check:
-                    reconfigure_reasons.append(
-                        f"IWYU check mode changed: {last_check_setting} → {check}"
-                    )
-            except (OSError, IOError):
-                reconfigure_reasons.append("check marker unreadable")
-        else:
-            reconfigure_reasons.append("check marker missing")
-
-        # Check if build_mode setting has changed since last configure
-        # CRITICAL: This detects quick <-> release transitions which both have debug=False
-        # but have different optimization flags (-O0 vs -O3)
-        # When build_mode changes, we must clean objects to avoid mixing different compiler flags
-        if build_mode_marker.exists():
-            try:
-                last_build_mode = build_mode_marker.read_text().strip()
-                if last_build_mode != build_mode:
-                    reconfigure_reasons.append(
-                        f"build mode changed: {last_build_mode} → {build_mode}"
-                    )
-                    build_mode_changed = True
-            except (OSError, IOError):
-                reconfigure_reasons.append("build_mode marker unreadable")
-        else:
-            reconfigure_reasons.append("build_mode marker missing")
-
-        # Check if enable_examples setting has changed since last configure
-        if enable_examples_marker.exists():
-            try:
-                last_enable_examples = (
-                    enable_examples_marker.read_text().strip() == "True"
-                )
-                if last_enable_examples != enable_examples:
-                    reconfigure_reasons.append(
-                        f"enable_examples changed: {last_enable_examples} → {enable_examples}"
-                    )
-            except (OSError, IOError):
-                reconfigure_reasons.append("enable_examples marker unreadable")
-
-        # Check if enable_unit_tests setting has changed since last configure
-        if enable_unit_tests_marker.exists():
-            try:
-                last_enable_unit_tests = (
-                    enable_unit_tests_marker.read_text().strip() == "True"
-                )
-                if last_enable_unit_tests != enable_unit_tests:
-                    reconfigure_reasons.append(
-                        f"enable_unit_tests changed: {last_enable_unit_tests} → {enable_unit_tests}"
-                    )
-            except (OSError, IOError):
-                reconfigure_reasons.append("enable_unit_tests marker unreadable")
-
-        # Print consolidated reconfigure message if there are any reasons
-        if reconfigure_reasons:
-            force_reconfigure = True
-            force_reconfigure_reason = "configuration markers changed"
-            # For missing markers (common case on first run), use a simpler message
-            missing_markers = [r for r in reconfigure_reasons if "missing" in r]
-            changed_settings = [
-                r
-                for r in reconfigure_reasons
-                if "missing" not in r and "unreadable" not in r
-            ]
-            unreadable_markers = [r for r in reconfigure_reasons if "unreadable" in r]
-
-            if missing_markers and not changed_settings and not unreadable_markers:
-                # All reasons are just missing markers - common on first run or mode switch
-                num_missing = len(missing_markers)
-                _ts_print(
-                    f"[MESON] ℹ️  Build directory needs configuration ({num_missing} marker files missing)"
-                )
-            else:
-                # Mix of reasons - show details
-                _ts_print("[MESON] 🔄 Reconfiguration required:")
-                for reason in reconfigure_reasons:
-                    _ts_print(f"[MESON]     - {reason}")
-
-        # CRITICAL: Delete all object files and archives when debug mode changes
-        # Object files compiled with sanitizers cannot be linked without sanitizer runtime
-        # We must force a complete rebuild with the new compiler flags
-        if debug_changed:
-            cleanup_build_artifacts(build_dir, "Debug mode changed")
-
-        # CRITICAL: Delete all object files and archives when build_mode changes
-        # Object files compiled with different optimization flags cannot be safely mixed
-        # E.g., -O0 vs -O3 produces incompatible object code
-        # Note: last_build_mode is guaranteed to be set if build_mode_changed is True
-        if build_mode_changed:
-            cleanup_build_artifacts(
-                build_dir, f"Build mode changed ({last_build_mode} → {build_mode})"
-            )
-
-    # Check if any meson.build files are newer than build.ninja (requires reconfigure)
-    build_ninja_path = build_dir / "build.ninja"
-    meson_build_modified = False
-    if already_configured and build_ninja_path.exists():
-        try:
-            build_ninja_mtime = build_ninja_path.stat().st_mtime
-            # Check all meson.build files (root + subdirs)
-            meson_build_files = [
-                source_dir / "meson.build",
-                source_dir / "tests" / "meson.build",
-                source_dir / "examples" / "meson.build",
-            ]
-            for meson_file in meson_build_files:
-                if meson_file.exists():
-                    meson_file_mtime = meson_file.stat().st_mtime
-                    if meson_file_mtime > build_ninja_mtime:
-                        _ts_print(
-                            f"[MESON] ⚠️  Detected modified meson.build: {meson_file.relative_to(source_dir)}"
-                        )
-                        _ts_print(
-                            f"[MESON]     File mtime: {meson_file_mtime:.6f} > build.ninja mtime: {build_ninja_mtime:.6f}"
-                        )
-                        meson_build_modified = True
-                        break
-        except (OSError, IOError) as e:
-            _ts_print(f"[MESON] Warning: Could not check meson.build timestamps: {e}")
-            # If we can't check, assume modification to be safe
-            meson_build_modified = True
-
-    # Force reconfigure if meson.build files were modified
-    # Note: The detection message is already printed above, no need for duplicate
-    if meson_build_modified:
-        force_reconfigure = True
-        force_reconfigure_reason = "meson.build modified"
-
-    # Check if test files have been added or removed (requires reconfigure)
-    # This ensures Meson discovers new tests and removes deleted tests
-    #
-    # Fast path: if test_list_cache.txt is newer than every directory in tests/,
-    # no test files have been added or removed → skip the expensive importlib
-    # loading + rglob discovery entirely (~100-200ms savings on cache hit).
-    _test_list_cache_path = build_dir / "test_list_cache.txt"
-    _skip_test_discovery = False
-    if _test_list_cache_path.exists():
-        try:
-            _tlc_mtime = _test_list_cache_path.stat().st_mtime
-            if (
-                _max_tests_dir_mtime <= _tlc_mtime
-            ):  # reuse precomputed value (no 2nd walk)
-                _skip_test_discovery = True  # dirs unchanged → cache still valid
-        except OSError:
-            pass  # Fall through to full discovery on any error
-
-    test_files_changed = False
-    if already_configured and not _skip_test_discovery:
-        try:
-            # Import test discovery functions from tests/ directory
-            # Uses importlib since tests/ is not a Python package
-            import importlib.util
-
-            tests_py_path = source_dir / "tests"
-
-            spec_dt = importlib.util.spec_from_file_location(
-                "discover_tests", tests_py_path / "discover_tests.py"
-            )
-            assert spec_dt is not None and spec_dt.loader is not None
-            mod_dt = importlib.util.module_from_spec(spec_dt)
-            spec_dt.loader.exec_module(mod_dt)
-            discover_test_files = mod_dt.discover_test_files
-
-            spec_tc = importlib.util.spec_from_file_location(
-                "test_config", tests_py_path / "test_config.py"
-            )
-            assert spec_tc is not None and spec_tc.loader is not None
-            mod_tc = importlib.util.module_from_spec(spec_tc)
-            spec_tc.loader.exec_module(mod_tc)
-            EXCLUDED_TEST_FILES = mod_tc.EXCLUDED_TEST_FILES
-            EXCLUDED_TEST_DIRS = mod_tc.EXCLUDED_TEST_DIRS
-
-            # Get current test files
-            tests_dir = source_dir / "tests"
-            current_test_files: list[str] = sorted(
-                discover_test_files(tests_dir, EXCLUDED_TEST_FILES, EXCLUDED_TEST_DIRS)
-            )
-
-            # Check cached test file list
-            # NOTE: We use try-except instead of exists() check to avoid TOCTOU race condition
-            # This is more robust when multiple builds could run concurrently
-            test_list_cache = build_dir / "test_list_cache.txt"
-            cached_test_files: list[str] = []
-            try:
-                with open(test_list_cache, "r") as f:
-                    cached_test_files = [
-                        line.strip()
-                        for line in f
-                        if line.strip() and not line.startswith("#")
-                    ]
-            except FileNotFoundError:
-                # File doesn't exist yet - treat as empty cache
-                cached_test_files = []
-            except (IOError, OSError) as e:
-                # Corrupted or inaccessible - treat as stale
-                _ts_print(f"[MESON] Warning: Could not read test cache: {e}")
-                cached_test_files = []
-
-            # Compare lists
-            if current_test_files != cached_test_files:
-                # Determine what changed
-                added: set[str] = set(current_test_files) - set(cached_test_files)
-                removed: set[str] = set(cached_test_files) - set(current_test_files)
-
-                print_warning("[MESON] ⚠️  Detected test file changes:")
-                if added:
-                    added_list = sorted(added)
-                    if len(added_list) > 10:
-                        # Summarize long lists
-                        print_warning(
-                            f"[MESON]     Added: {len(added_list)} test files"
-                        )
-                        print_warning(
-                            f"[MESON]     (First 10: {', '.join(added_list[:10])}...)"
-                        )
-                    else:
-                        print_warning(f"[MESON]     Added: {', '.join(added_list)}")
-                if removed:
-                    removed_list = sorted(removed)
-                    if len(removed_list) > 10:
-                        print_warning(
-                            f"[MESON]     Removed: {len(removed_list)} test files"
-                        )
-                        print_warning(
-                            f"[MESON]     (First 10: {', '.join(removed_list[:10])}...)"
-                        )
-                    else:
-                        print_warning(f"[MESON]     Removed: {', '.join(removed_list)}")
-
-                test_files_changed = True
-
-                # Update cache atomically using temp file + rename pattern
-                # This prevents torn reads if another process is reading the cache
-                temp_cache = test_list_cache.with_suffix(".tmp")
-                try:
-                    with open(temp_cache, "w") as f:
-                        f.write(
-                            "# Auto-generated test file list cache for Meson reconfiguration\n"
-                        )
-                        f.write(f"# Total tests: {len(current_test_files)}\n")
-                        f.write("# Generated by meson_runner.py\n\n")
-                        for test_file in current_test_files:
-                            f.write(f"{test_file}\n")
-                    # Atomic rename - either completes fully or not at all
-                    temp_cache.replace(test_list_cache)
-                except (OSError, IOError) as e:
-                    _ts_print(
-                        f"[MESON] Warning: Could not update test cache atomically: {e}"
-                    )
-                    # Clean up temp file if it exists
-                    try:
-                        temp_cache.unlink()
-                    except (OSError, IOError):
-                        pass
-            else:
-                # No test file changes detected.
-                # Touch the cache to update its mtime so that the directory-mtime
-                # fast-path can activate on the NEXT run (skipping this discovery).
-                # Without this, the cache stays old and fast-path never fires.
-                try:
-                    test_list_cache.touch()
-                except OSError:
-                    pass  # Non-critical - fast-path just won't fire next run
-
-        except KeyboardInterrupt as ki:
-            handle_keyboard_interrupt(ki)
-            raise
-        except Exception as e:
-            _ts_print(f"[MESON] Warning: Could not check test file changes: {e}")
-            # On error, assume files may have changed to be safe
-            test_files_changed = True
-
-    # Force reconfigure if test files were added or removed
-    # Note: The detection message is already printed above, no need for duplicate
-    if test_files_changed:
-        force_reconfigure = True
-        force_reconfigure_reason = "test files changed"
-
-    # Check if example files have changed (added, removed, or filter annotations modified)
-    # This ensures Meson picks up new examples and respects @filter changes in .ino files
-    example_files_changed = False
-    if already_configured:
-        try:
-            from ci.meson.example_metadata_cache import compute_example_files_hash
-
-            examples_dir = source_dir / "examples"
-            # Cache file location matches where meson.current_build_dir() writes it
-            # in examples/meson.build: .build/meson-quick/examples/example_metadata.cache
-            example_cache_file = build_dir / "examples" / "example_metadata.cache"
-
-            if examples_dir.exists():
-                # Mtime fast-path: if example_cache_file is newer than all directories
-                # in examples/, no files have been added or removed since the last meson
-                # setup → skip the expensive 3-pass rglob + stat() + SHA256 computation.
-                #
-                # Rationale: adding or removing a file always updates the PARENT
-                # directory's mtime on NTFS, ext4, and APFS.  Checking only directory
-                # mtimes is an O(#dirs) proxy for structural changes (~5ms vs ~100ms).
-                #
-                # Limitation: in-place file content modifications update the FILE mtime
-                # but NOT the parent directory mtime, so they will not be detected by
-                # this fast-path.  This is acceptable because modifying existing example
-                # content without adding/removing files is a rare developer activity,
-                # and the next structural change will trigger reconfiguration anyway.
-                _skip_example_hash = False
-                if example_cache_file.exists():
-                    try:
-                        _cache_mtime = example_cache_file.stat().st_mtime
-                        _max_example_dir_mtime = get_max_dir_mtime(examples_dir)
-                        if _max_example_dir_mtime <= _cache_mtime:
-                            _skip_example_hash = True  # No structural changes detected
-                    except OSError:
-                        pass  # Fall through to full hash computation
-
-                if not _skip_example_hash:
-                    current_example_hash = compute_example_files_hash(examples_dir)
-
-                    # Check cached example hash
-                    cached_example_hash = ""
-                    if example_cache_file.exists():
-                        try:
-                            with open(example_cache_file, "r") as f:
-                                cache_data = json.load(f)
-                            cached_example_hash = cache_data.get("hash", "")
-                        except KeyboardInterrupt as ki:
-                            handle_keyboard_interrupt(ki)
-                        except Exception:
-                            cached_example_hash = ""
-
-                    if current_example_hash != cached_example_hash:
-                        print_warning(
-                            "[MESON] \u26a0\ufe0f  Detected example file changes (files added/removed/modified)"
-                        )
-                        example_files_changed = True
-                        # Delete the stale cache so meson.build re-runs discovery
-                        if example_cache_file.exists():
-                            try:
-                                example_cache_file.unlink()
-                            except OSError:
-                                pass
-
-        except KeyboardInterrupt as ki:
-            handle_keyboard_interrupt(ki)
-            raise
-        except Exception as e:
-            _ts_print(f"[MESON] Warning: Could not check example file changes: {e}")
-            example_files_changed = True
-
-    # Force reconfigure if example files changed
-    if example_files_changed:
-        force_reconfigure = True
-        force_reconfigure_reason = "example files changed"
-
-    # Determine if we need to run meson setup/reconfigure
-    # We skip meson setup only if already configured, not explicitly reconfiguring,
-    # AND thin archive/source file settings haven't changed
-    skip_meson_setup = already_configured and not reconfigure and not force_reconfigure
-
-    # Declare native file path early (needed for meson commands)
-    # The native file will be generated later after tool detection
-    native_file_path = build_dir / "meson_native.txt"
-
-    cmd: Optional[list[str]] = None
-    if skip_meson_setup:
-        # Build already configured, check wrappers below (message consolidated below)
-        pass
-    elif already_configured and (reconfigure or force_reconfigure):
-        # Reconfigure existing build (explicitly requested or forced by config change)
-        if force_reconfigure and force_reconfigure_reason:
-            reason = force_reconfigure_reason
-        elif force_reconfigure:
-            reason = "configuration changed"
-        else:
-            reason = "explicitly requested"
-        _ts_print(f"[MESON] Reconfiguring build directory ({reason}): {build_dir}")
-        cmd = [
-            get_meson_executable(),
-            "setup",
-            "--reconfigure",
-            "--native-file",
-            str(native_file_path),
-            str(build_dir),
-        ]
-        # Always pass explicit build_mode to ensure meson uses correct optimization flags
-        cmd.extend([f"-Dbuild_mode={build_mode}"])
-        # Pass enable_examples and enable_unit_tests options
-        cmd.extend([f"-Denable_examples={str(enable_examples).lower()}"])
-        cmd.extend([f"-Denable_unit_tests={str(enable_unit_tests).lower()}"])
-    else:
-        # Initial setup
-        _ts_print(f"[MESON] Setting up build directory: {build_dir}")
-        cmd = [
-            get_meson_executable(),
-            "setup",
-            "--native-file",
-            str(native_file_path),
-            str(build_dir),
-        ]
-        # Always pass explicit build_mode to ensure meson uses correct optimization flags
-        cmd.extend([f"-Dbuild_mode={build_mode}"])
-        # Pass enable_examples and enable_unit_tests options
-        cmd.extend([f"-Denable_examples={str(enable_examples).lower()}"])
-        cmd.extend([f"-Denable_unit_tests={str(enable_unit_tests).lower()}"])
-
-    is_windows = sys.platform.startswith("win") or os.name == "nt"
-
-    # Thin archives configuration (faster builds, smaller disk usage when supported)
-    thin_flag = " --thin" if use_thin_archives else ""
-
-    # Build config summary is shown in toolchain line and mode lines elsewhere
-    # No need for separate config message here
-
-    # Only show thin archives warning when explicitly disabled (rare case)
     if not use_thin_archives and os.environ.get("FASTLED_DISABLE_THIN_ARCHIVES"):
         _ts_print(
             "[MESON] ⚠️  Thin archives DISABLED (FASTLED_DISABLE_THIN_ARCHIVES set)"
         )
 
-    # Check for obsolete zig wrapper artifacts before proceeding
-    # These wrappers were used in the old zig-based compiler system and must be removed
-    meson_dir = source_dir / ".build" / "meson"
-    if meson_dir.exists():
-        obsolete_wrappers = list(meson_dir.glob("zig-*-wrapper.exe"))
-        if obsolete_wrappers:
-            _ts_print("=" * 80)
-            _ts_print("[MESON] ❌ ERROR: Obsolete zig wrapper artifacts detected!")
-            _ts_print("[MESON]")
-            _ts_print(
-                "[MESON] Found old zig-based wrapper executables in .build/meson/ directory:"
-            )
-            for wrapper in obsolete_wrappers:
-                _ts_print(f"[MESON]   - {wrapper.name}")
-            _ts_print("[MESON]")
-            _ts_print(
-                "[MESON] These wrappers are from the old zig-based compiler system"
-            )
-            _ts_print("[MESON] and are no longer compatible with clang-tool-chain.")
-            _ts_print("[MESON]")
-            _ts_print("[MESON] To fix this issue, delete the .build/meson directory:")
-            _ts_print("[MESON]   rm -rf .build/meson")
-            _ts_print("[MESON]")
-            _ts_print("[MESON] Then run your build command again. The system will use")
-            _ts_print("[MESON] clang-tool-chain wrappers instead.")
-            _ts_print("=" * 80)
-            raise RuntimeError(
-                "Obsolete zig wrapper artifacts detected in .build/meson/ directory. "
-                "Delete .build/meson/ directory and try again."
-            )
+    markers = MarkerPaths.for_build_dir(build_dir)
+    hashes = compute_source_hashes(source_dir, markers)
 
-    # Get clang-tool-chain wrapper commands
-    # Use the wrapper commands (clang-tool-chain-c/cpp) instead of raw clang binaries
-    # The wrappers automatically handle GNU ABI setup on Windows
-
-    # Compiler cache detection: zccache or none
-    # zccache is a blazing-fast local compiler cache daemon.
-    # It works as a drop-in compiler launcher prefix.
-    # Skip compiler caching in Docker to avoid daemon startup delay.
-    in_docker = os.environ.get("FASTLED_DOCKER", "0") == "1"
-
-    # Resolve compiler cache binary
-    cache_binary: Optional[str] = None
-    cache_name: Optional[str] = None
-    if not in_docker:
-        zccache_binary = _find_zccache_binary()
-        if zccache_binary:
-            cache_binary = zccache_binary
-            cache_name = "zccache"
-        else:
-            _ts_print(
-                "[MESON] zccache not found, compilation will proceed without caching. To install, run: bash ./install"
-            )
-    else:
-        _ts_print("[MESON] Skipping compiler cache in Docker (startup delay too long)")
-
-    # Always use plain clang-tool-chain wrappers for compiler detection
-    # The cache binary is applied separately in the native file as a launcher prefix
-    clang_wrapper = shutil.which("clang-tool-chain-c")
-    clangxx_wrapper = shutil.which("clang-tool-chain-cpp")
-
-    llvm_ar_wrapper = shutil.which("clang-tool-chain-ar")
-
-    if not clang_wrapper or not clangxx_wrapper or not llvm_ar_wrapper:
-        _ts_print("[MESON] ERROR: clang-tool-chain wrapper commands not found in PATH")
-        _ts_print(
-            "[MESON] Install clang-tool-chain with: uv pip install clang-tool-chain"
-        )
-        _ts_print("[MESON] Missing commands:")
-        if not clang_wrapper:
-            _ts_print("[MESON]   - clang-tool-chain-c")
-        if not clangxx_wrapper:
-            _ts_print("[MESON]   - clang-tool-chain-cpp")
-        if not llvm_ar_wrapper:
-            _ts_print("[MESON]   - clang-tool-chain-ar")
-        raise RuntimeError("clang-tool-chain wrapper commands not available")
-
-    # Get compiler version for consolidated output.
-    # Optimization: Skip subprocess if the compiler binary hasn't changed since we
-    # last recorded its version. We compare the compiler wrapper's mtime against the
-    # compiler_version_marker's mtime: if the marker is NEWER than the binary, the
-    # binary predates the marker → the recorded version is still current.
-    current_compiler_version: str = ""  # initialized here; assigned below
-    _version_from_cache = False
-    _clangxx_path = Path(clangxx_wrapper)
-    if compiler_version_marker.exists() and _clangxx_path.exists():
-        try:
-            _compiler_mtime = _clangxx_path.stat().st_mtime
-            _marker_mtime = compiler_version_marker.stat().st_mtime
-            if _compiler_mtime < _marker_mtime:
-                # Compiler binary predates marker → version is stable → use cache
-                _cached_ver = compiler_version_marker.read_text(
-                    encoding="utf-8"
-                ).strip()
-                if _cached_ver and _cached_ver != "unknown":
-                    current_compiler_version = _cached_ver
-                    _version_from_cache = True
-        except OSError:
-            pass
-    if not _version_from_cache:
-        # PERFORMANCE: Use raw clang++ binary for version check (~60ms vs ~3600ms)
-        _fast_compiler = _resolve_fast_compiler_binary()
-        current_compiler_version = get_compiler_version(
-            _fast_compiler if _fast_compiler else clangxx_wrapper
-        )
-
-    # Get zccache version for cache invalidation.
-    # Optimization: Skip subprocess if the zccache binary hasn't changed since we
-    # last recorded its version.
-    current_zccache_version: str = ""
-    if cache_binary:
-        _zccache_version_from_cache = False
-        _zccache_path = Path(cache_binary)
-        if zccache_version_marker.exists() and _zccache_path.exists():
-            try:
-                _zccache_mtime = _zccache_path.stat().st_mtime
-                _zc_marker_mtime = zccache_version_marker.stat().st_mtime
-                if _zccache_mtime < _zc_marker_mtime:
-                    _cached_zc_ver = zccache_version_marker.read_text(
-                        encoding="utf-8"
-                    ).strip()
-                    if _cached_zc_ver:
-                        current_zccache_version = _cached_zc_ver
-                        _zccache_version_from_cache = True
-            except OSError:
-                pass
-        if not _zccache_version_from_cache:
-            current_zccache_version = get_zccache_version(cache_binary)
-
-    # Consolidated single-line toolchain summary (verbose mode only)
-    # Before: 7 lines of compiler details
-    # After: "Toolchain: clang 21.1.5 + zccache"
-    if verbose:
-        if cache_name:
-            print(f"Toolchain: {current_compiler_version} + {cache_name}")
-        else:
-            print(f"Toolchain: {current_compiler_version}")
-
-    # Late-stage compiler version check (requires compiler detection above)
-    # This check is separate because we need the detected compiler version
+    # Marker-based reconfigure detection (consolidated message + cleanup).
     if already_configured:
-        compiler_version_reason: Optional[str] = None
-        if compiler_version_marker.exists():
+        decision = check_reconfigure_markers(
+            build_dir=build_dir,
+            markers=markers,
+            hashes=hashes,
+            debug=debug,
+            check=check,
+            build_mode=build_mode,
+            enable_examples=enable_examples,
+            enable_unit_tests=enable_unit_tests,
+            use_thin_archives=use_thin_archives,
+        )
+        if decision.force_reconfigure:
+            force_reconfigure = True
+            force_reconfigure_reason = decision.force_reason
+
+    # meson.build files modified after build.ninja → reconfigure.
+    if already_configured and check_meson_build_modified(source_dir, build_dir):
+        force_reconfigure = True
+        force_reconfigure_reason = "meson.build modified"
+
+    # Test files added/removed → reconfigure.
+    if already_configured and detect_test_file_changes(
+        source_dir, build_dir, hashes.max_tests_dir_mtime
+    ):
+        force_reconfigure = True
+        force_reconfigure_reason = "test files changed"
+
+    # Example files added/removed/modified → reconfigure.
+    if already_configured and detect_example_file_changes(source_dir, build_dir):
+        force_reconfigure = True
+        force_reconfigure_reason = "example files changed"
+
+    skip_meson_setup = already_configured and not reconfigure and not force_reconfigure
+    native_file_path = build_dir / "meson_native.txt"
+
+    # Build the meson setup command (or defer it for compiler-version-late reconfigure).
+    cmd: "list[str] | None" = None
+    if skip_meson_setup:
+        pass
+    elif already_configured and (reconfigure or force_reconfigure):
+        reason = (
+            force_reconfigure_reason
+            if (force_reconfigure and force_reconfigure_reason)
+            else (
+                "configuration changed" if force_reconfigure else "explicitly requested"
+            )
+        )
+        _ts_print(f"[MESON] Reconfiguring build directory ({reason}): {build_dir}")
+        cmd = build_meson_setup_cmd(
+            native_file_path=native_file_path,
+            build_dir=build_dir,
+            build_mode=build_mode,
+            enable_examples=enable_examples,
+            enable_unit_tests=enable_unit_tests,
+            reconfigure=True,
+        )
+    else:
+        _ts_print(f"[MESON] Setting up build directory: {build_dir}")
+        cmd = build_meson_setup_cmd(
+            native_file_path=native_file_path,
+            build_dir=build_dir,
+            build_mode=build_mode,
+            enable_examples=enable_examples,
+            enable_unit_tests=enable_unit_tests,
+            reconfigure=False,
+        )
+
+    check_obsolete_zig_wrappers(source_dir)
+
+    compiler = detect_compiler_and_cache(markers, verbose)
+
+    # Late-stage compiler-version check: requires the detected compiler.
+    if already_configured:
+        compiler_version_reason: "str | None" = None
+        if markers.compiler_version.exists():
             try:
-                last_compiler_version = compiler_version_marker.read_text().strip()
-                if last_compiler_version != current_compiler_version:
-                    compiler_version_reason = f"compiler version changed: {last_compiler_version} → {current_compiler_version}"
+                last_compiler_version = markers.compiler_version.read_text().strip()
+                if last_compiler_version != compiler.compiler_version:
+                    compiler_version_reason = f"compiler version changed: {last_compiler_version} → {compiler.compiler_version}"
                     compiler_version_changed = True
             except (OSError, IOError):
                 compiler_version_reason = "compiler version marker unreadable"
@@ -1967,7 +262,6 @@ def setup_meson_build(
             compiler_version_reason = "compiler version marker missing"
 
         if compiler_version_reason:
-            # Only print if we haven't already printed a reconfigure message
             if not force_reconfigure:
                 _ts_print(
                     f"[MESON] 🔄 Reconfiguration required: {compiler_version_reason}"
@@ -1976,20 +270,17 @@ def setup_meson_build(
             force_reconfigure_reason = compiler_version_reason
             skip_meson_setup = False
 
-        # CRITICAL: Delete all object files, archives, and PCH when compiler version changes
-        # Objects compiled with a different compiler version can have incompatible ABI
         if compiler_version_changed:
             cleanup_build_artifacts(build_dir, "Compiler version changed")
 
-        # Late-stage zccache version check (requires cache binary detection above)
-        # When zccache version changes, cached artifacts may be incompatible
-        if current_zccache_version:
-            zccache_version_reason: Optional[str] = None
-            if zccache_version_marker.exists():
+        # Late-stage zccache version check
+        if compiler.zccache_version:
+            zccache_version_reason: "str | None" = None
+            if markers.zccache_version.exists():
                 try:
-                    last_zccache_version = zccache_version_marker.read_text().strip()
-                    if last_zccache_version != current_zccache_version:
-                        zccache_version_reason = f"zccache version changed: {last_zccache_version} → {current_zccache_version}"
+                    last_zccache_version = markers.zccache_version.read_text().strip()
+                    if last_zccache_version != compiler.zccache_version:
+                        zccache_version_reason = f"zccache version changed: {last_zccache_version} → {compiler.zccache_version}"
                 except (OSError, IOError):
                     zccache_version_reason = "zccache version marker unreadable"
             else:
@@ -2005,310 +296,54 @@ def setup_meson_build(
                 skip_meson_setup = False
                 cleanup_build_artifacts(build_dir, "zccache version changed")
 
-        # CRITICAL: If compiler version forced a reconfigure, we need to update cmd
-        # The original cmd assignment was based on pre-compiler-check values
+        # If compiler/zccache version forced reconfigure but we hadn't built a cmd yet
         if force_reconfigure and cmd is None:
             _ts_print(f"[MESON] Reconfiguring build directory: {build_dir}")
-            cmd = [
-                get_meson_executable(),
-                "setup",
-                "--reconfigure",
-                "--native-file",
-                str(native_file_path),
-                str(build_dir),
-            ]
-            cmd.extend([f"-Dbuild_mode={build_mode}"])
-            cmd.extend([f"-Denable_examples={str(enable_examples).lower()}"])
-            cmd.extend([f"-Denable_unit_tests={str(enable_unit_tests).lower()}"])
+            cmd = build_meson_setup_cmd(
+                native_file_path=native_file_path,
+                build_dir=build_dir,
+                build_mode=build_mode,
+                enable_examples=enable_examples,
+                enable_unit_tests=enable_unit_tests,
+                reconfigure=True,
+            )
 
-    # Generate native file for Meson that persists tool configuration across regenerations
-    # When Meson regenerates (e.g., when ninja detects meson.build changes),
-    # environment variables are lost. Native file ensures tools are configured.
-    try:
-        # Use ctc-clang/ctc-clang++ native launchers instead of Python wrappers.
-        # Native launchers handle all platform flags automatically with ~34ms
-        # startup vs ~1200ms for Python wrappers.
-        _fast = _resolve_fast_native_entries(cache_binary)
-        if _fast.cc is not None:
-            c_compiler = _fast.cc
-            cpp_compiler = _fast.cxx
-            ar_tool = _fast.ar
-        else:
-            # Fallback to Python wrappers if raw binary resolution fails
-            c_compiler = f"['{clang_wrapper}']"
-            cpp_compiler = f"['{clangxx_wrapper}']"
-            ar_tool = f"['{llvm_ar_wrapper}']"
+    write_meson_native_file(native_file_path=native_file_path, compiler=compiler)
 
-        # Detect platform for native file
-        is_darwin = sys.platform == "darwin"
+    env = build_setup_env(compiler)
 
-        # Detect CPU architecture
-        machine = platform.machine().lower()
-        if machine in ("x86_64", "amd64"):
-            cpu_family = "x86_64"
-            cpu = "x86_64"
-        elif machine in ("arm64", "aarch64"):
-            cpu_family = "aarch64"
-            cpu = "aarch64"
-        else:
-            cpu_family = "x86_64"  # Default fallback
-            cpu = "x86_64"
-
-        if is_windows:
-            host_system = "windows"
-        elif is_darwin:
-            host_system = "darwin"
-        else:
-            host_system = "linux"
-
-        native_file_content = f"""# ============================================================================
-# Meson Native Build Configuration for FastLED (Auto-generated)
-# ============================================================================
-# This file is auto-generated by meson_runner.py to configure tool paths.
-# It persists across build regenerations when ninja detects meson.build changes.
-#
-# IMPORTANT: LLD linker is forced via -fuse-ld=lld in meson.build link_args.
-# This ensures consistent linker behavior across Windows, Linux, and macOS.
-
-[binaries]
-c = {c_compiler}
-cpp = {cpp_compiler}
-ar = {ar_tool}
-
-[host_machine]
-system = '{host_system}'
-cpu_family = '{cpu_family}'
-cpu = '{cpu}'
-endian = 'little'
-
-[properties]
-# No additional properties needed - compiler flags are in meson.build
-"""
-        native_file_changed = write_if_different(native_file_path, native_file_content)
-
-        if native_file_changed:
-            _ts_print(f"[MESON] Regenerated native file: {native_file_path}")
-    except (OSError, IOError) as e:
-        _ts_print(f"[MESON] Warning: Could not write native file: {e}", file=sys.stderr)
-
-    env = os.environ.copy()
-    if cache_binary:
-        env.setdefault("ZCCACHE_STRICT_PATHS", "absolute")
-
-    # PERFORMANCE: Use raw compiler binaries for env vars when available.
-    # The native file takes precedence over env vars for meson, but these
-    # serve as fallback. Raw binaries avoid ~3.6s Python wrapper overhead.
-    _fast_compiler = _resolve_fast_compiler_binary()
-    if _fast_compiler:
-        try:
-            from clang_tool_chain.platform.paths import find_tool_binary
-
-            _fast_c = str(find_tool_binary("clang"))
-            _fast_ar = str(find_tool_binary("llvm-ar"))
-            env["CC"] = _fast_c
-            env["CXX"] = _fast_compiler
-            env["AR"] = _fast_ar
-        except KeyboardInterrupt as ki:
-            handle_keyboard_interrupt(ki)
-        except Exception:
-            env["CC"] = clang_wrapper
-            env["CXX"] = clangxx_wrapper
-            env["AR"] = llvm_ar_wrapper
-    else:
-        env["CC"] = clang_wrapper
-        env["CXX"] = clangxx_wrapper
-        env["AR"] = llvm_ar_wrapper
-
-    # Compiler cache status already shown in toolchain summary above
-
-    # If we're skipping meson setup (already configured), check for thin archive conflicts
     if skip_meson_setup:
-        # CRITICAL FIX: Check if libfastled.a exists as a thin archive
-        # If we've disabled thin archives but a thin archive exists from a previous build,
-        # we must delete it to force a rebuild. Otherwise the linker will fail.
-        libfastled_a = build_dir / "libfastled.a"
-        if libfastled_a.exists():
-            try:
-                # Read first 8 bytes to check for thin archive magic header
-                with open(libfastled_a, "rb") as f:
-                    header = f.read(8)
-                    is_thin_archive = header == b"!<thin>\n"
-
-                if is_thin_archive and not use_thin_archives:
-                    # Thin archive exists but we've disabled thin archives
-                    # Delete it to force rebuild with regular archive
-                    _ts_print("[MESON] ⚠️  Detected thin archive from previous build")
-                    _ts_print(
-                        "[MESON] 🗑️  Deleting libfastled.a to force rebuild with regular archive"
-                    )
-                    libfastled_a.unlink()
-                elif not is_thin_archive and use_thin_archives:
-                    # Regular archive exists but we've enabled thin archives
-                    # Delete it to force rebuild with thin archive
-                    _ts_print("[MESON] ℹ️  Detected regular archive from previous build")
-                    _ts_print(
-                        "[MESON] 🗑️  Deleting libfastled.a to force rebuild with thin archive"
-                    )
-                    libfastled_a.unlink()
-            except (OSError, IOError) as e:
-                # If we can't read/delete, that's okay - build will handle it
-                _ts_print(f"[MESON] Warning: Could not check/delete libfastled.a: {e}")
-                pass
-
-        # Create missing marker files (migration from older code)
-        _write_configuration_markers(
-            build_mode_marker=build_mode_marker,
-            build_mode=build_mode,
-            thin_archive_marker=thin_archive_marker,
+        handle_skip_meson_setup(
+            build_dir=build_dir,
+            source_dir=source_dir,
             use_thin_archives=use_thin_archives,
-            debug_marker=debug_marker,
+            markers=markers,
+            hashes=hashes,
             debug=debug,
-            check_marker=check_marker,
             check=check,
-            source_files_marker=source_files_marker,
-            current_source_hash=current_source_hash,
-            current_source_files=current_source_files,
-            src_files_marker=src_files_marker,
-            current_src_hash=current_src_hash,
-            test_files_marker=test_files_marker,
-            current_test_hash=current_test_hash,
-            compiler_version_marker=compiler_version_marker,
-            current_compiler_version=current_compiler_version,
-            zccache_version_marker=zccache_version_marker,
-            current_zccache_version=current_zccache_version or None,
-            enable_examples_marker=enable_examples_marker,
+            build_mode=build_mode,
             enable_examples=enable_examples,
-            enable_unit_tests_marker=enable_unit_tests_marker,
             enable_unit_tests=enable_unit_tests,
-            only_missing=True,
-            verb="Created",
+            compiler=compiler,
         )
-
-        # Ensure build.ninja has restat=1 and ar wrapper on STATIC_LINKER rule.
-        # Combined function reads build.ninja once and populates _ar_opt_status_cache,
-        # so a subsequent is_ar_content_preserving_active() call in runner.py is free.
-        inject_ar_optimization_patches(build_dir, source_dir)
-        if normalize_meson_private_include_paths(build_dir):
-            _ts_print(
-                "[MESON] Normalized private include paths for zccache strict mode"
-            )
-        _enforce_strict_path_violations(build_dir)
-
         return True
 
-    # Run meson setup using RunningProcess for proper streaming output
     assert cmd is not None, "cmd should be set when not skipping meson setup"
-    meson_cmd: list[str] = cmd  # Type narrowing for use in nested function
-    print_banner("MESON CONFIGURATION", "⚙️")
-
-    def _run_meson_setup() -> tuple[int, str]:
-        """Run meson setup and return (returncode, stdout)."""
-        proc = RunningProcess(
-            meson_cmd,
-            cwd=source_dir,
-            timeout=600,
-            auto_run=True,
-            check=False,  # We'll check returncode manually
-            env=env,
-            output_formatter=TimestampFormatter(),
-        )
-
-        returncode = cast(int, proc.wait(echo=True))
-        return returncode, str(proc.stdout)
-
-    def _clear_stale_caches() -> None:
-        """Clear stale test metadata caches that may reference deleted files."""
-        _ts_print("[MESON] 🔄 Clearing stale test metadata caches...")
-        cache_files = [
-            build_dir / "tests" / "test_metadata.cache",
-            build_dir / "test_list_cache.txt",
-            source_files_marker,  # Force re-discovery of source files
-        ]
-        for cache_file in cache_files:
-            if cache_file.exists():
-                try:
-                    cache_file.unlink()
-                    _ts_print(f"[MESON]   Deleted: {cache_file.name}")
-                except (OSError, IOError) as e:
-                    _ts_print(
-                        f"[MESON]   Warning: Could not delete {cache_file.name}: {e}"
-                    )
-
-    try:
-        # Remove any stale meson lockfile left by a killed/abandoned meson
-        # process (Windows bug, see issue #2484). No-op if build_dir or
-        # meson-private/ doesn't exist yet.
-        cleanup_stale_meson_lockfile(build_dir)
-        returncode, stdout = _run_meson_setup()
-
-        # Self-healing: If meson setup fails with "does not exist" error,
-        # it's likely due to stale test metadata cache referencing deleted files.
-        # Clear caches and retry once.
-        if returncode != 0 and "does not exist" in stdout:
-            _ts_print(
-                "[MESON] ⚠️  Setup failed due to missing file (stale cache detected)"
-            )
-            _clear_stale_caches()
-            _ts_print("[MESON] 🔄 Retrying meson setup...")
-            cleanup_stale_meson_lockfile(build_dir)
-            returncode, stdout = _run_meson_setup()
-
-        if returncode != 0:
-            _ts_print(
-                f"[MESON] Setup failed with return code {returncode}", file=sys.stderr
-            )
-            return False
-
-        _ts_print(f"[MESON] Setup successful")
-
-        # Write marker files to track settings for future runs
-        _write_configuration_markers(
-            build_mode_marker=build_mode_marker,
-            build_mode=build_mode,
-            thin_archive_marker=thin_archive_marker,
-            use_thin_archives=use_thin_archives,
-            debug_marker=debug_marker,
-            debug=debug,
-            check_marker=check_marker,
-            check=check,
-            source_files_marker=source_files_marker,
-            current_source_hash=current_source_hash,
-            current_source_files=current_source_files,
-            src_files_marker=src_files_marker,
-            current_src_hash=current_src_hash,
-            test_files_marker=test_files_marker,
-            current_test_hash=current_test_hash,
-            compiler_version_marker=compiler_version_marker,
-            current_compiler_version=current_compiler_version,
-            zccache_version_marker=zccache_version_marker,
-            current_zccache_version=current_zccache_version or None,
-            enable_examples_marker=enable_examples_marker,
-            enable_examples=enable_examples,
-            enable_unit_tests_marker=enable_unit_tests_marker,
-            enable_unit_tests=enable_unit_tests,
-            only_missing=False,
-            verb="Saved",
-        )
-
-        # Inject restat=1 and ar wrapper into STATIC_LINKER rule.
-        # Combined function reads build.ninja once and populates _ar_opt_status_cache,
-        # so a subsequent is_ar_content_preserving_active() call in runner.py is free.
-        # Must be called after meson setup so build.ninja exists.
-        inject_ar_optimization_patches(build_dir, source_dir)
-        if normalize_meson_private_include_paths(build_dir):
-            _ts_print(
-                "[MESON] Normalized private include paths for zccache strict mode"
-            )
-        _enforce_strict_path_violations(build_dir)
-
-        return True
-
-    except KeyboardInterrupt as ki:
-        handle_keyboard_interrupt(ki)
-        raise
-    except Exception as e:
-        _ts_print(f"[MESON] Setup failed with exception: {e}", file=sys.stderr)
-        return False
+    return run_meson_setup_command(
+        cmd=cmd,
+        source_dir=source_dir,
+        build_dir=build_dir,
+        env=env,
+        markers=markers,
+        hashes=hashes,
+        debug=debug,
+        check=check,
+        build_mode=build_mode,
+        enable_examples=enable_examples,
+        enable_unit_tests=enable_unit_tests,
+        use_thin_archives=use_thin_archives,
+        compiler=compiler,
+    )
 
 
 def perform_ninja_maintenance(build_dir: Path) -> bool:
@@ -2325,27 +360,21 @@ def perform_ninja_maintenance(build_dir: Path) -> bool:
     Returns:
         True if maintenance was performed or skipped successfully, False on error
     """
-    # Create marker file to track last maintenance time
     marker_file = build_dir / ".ninja_deps_maintenance"
 
-    # Check if maintenance was recently performed (within last 24 hours)
     if marker_file.exists():
         try:
             last_maintenance = marker_file.stat().st_mtime
             time_since_maintenance = time.time() - last_maintenance
             hours_since_maintenance = time_since_maintenance / 3600
-
-            # Skip if maintenance was done within last 24 hours
             if hours_since_maintenance < 24:
                 return True
         except (OSError, IOError):
-            # If we can't read the marker, proceed with maintenance
             pass
 
     _ts_print("[MESON] 🔧 Performing periodic Ninja dependency database maintenance...")
 
     try:
-        # Run ninja -t recompact to optimize dependency database
         repair_proc = RunningProcess(
             ["ninja", "-C", str(build_dir), "-t", "recompact"],
             timeout=60,
@@ -2360,21 +389,16 @@ def perform_ninja_maintenance(build_dir: Path) -> bool:
             _ts_print(
                 "[MESON] ✓ Dependency database maintenance completed successfully"
             )
-
-            # Update marker file timestamp
             try:
                 marker_file.touch()
             except (OSError, IOError):
-                # Not critical if marker update fails
                 pass
-
             return True
-        else:
-            _ts_print(
-                "[MESON] ⚠️  Maintenance completed with warnings (non-fatal)",
-                file=sys.stderr,
-            )
-            return True  # Non-fatal, continue anyway
+        _ts_print(
+            "[MESON] ⚠️  Maintenance completed with warnings (non-fatal)",
+            file=sys.stderr,
+        )
+        return True
 
     except KeyboardInterrupt as ki:
         handle_keyboard_interrupt(ki)
@@ -2384,4 +408,4 @@ def perform_ninja_maintenance(build_dir: Path) -> bool:
             f"[MESON] ⚠️  Maintenance failed with exception: {e} (non-fatal)",
             file=sys.stderr,
         )
-        return True  # Non-fatal, continue anyway
+        return True

--- a/ci/meson/meson_cleanup.py
+++ b/ci/meson/meson_cleanup.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Build artifact cleanup and system LLVM tool detection."""
+
+import glob
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+from ci.util.timestamp_print import ts_print as _ts_print
+
+
+@dataclass
+class CleanupResult:
+    """Result of build artifact cleanup operation."""
+
+    deleted: int
+    failed: int
+    failed_files: list[str]
+
+
+def cleanup_build_artifacts(build_dir: Path, reason: str) -> dict[str, CleanupResult]:
+    """
+    Clean all build artifacts from a build directory.
+
+    This function centralizes all build artifact cleanup logic and provides
+    consistent failure tracking and reporting. It's designed to be called
+    when debug mode, build mode, or compiler version changes.
+
+    Args:
+        build_dir: Meson build directory to clean
+        reason: Human-readable reason for cleanup (e.g., "debug mode changed")
+
+    Returns:
+        Dictionary mapping artifact type to CleanupResult with deletion stats
+    """
+    _ts_print(f"[MESON] 🗑️  {reason} - cleaning all build artifacts")
+
+    # Artifact types with their file extensions
+    # Format: (display_name, list of glob patterns)
+    artifact_types: list[tuple[str, list[str]]] = [
+        ("object files", ["*.obj", "*.o"]),
+        ("static libraries", ["*.a"]),
+        ("executables", ["*.exe"]),
+        ("precompiled headers", ["*.pch"]),
+        ("Windows static libraries", ["*.lib"]),
+        ("Windows DLLs", ["*.dll"]),
+        ("Linux shared objects", ["*.so"]),
+        ("macOS dynamic libraries", ["*.dylib"]),
+    ]
+
+    results: dict[str, CleanupResult] = {}
+
+    for display_name, patterns in artifact_types:
+        deleted = 0
+        failed = 0
+        failed_files: list[str] = []
+
+        for pattern in patterns:
+            files = glob.glob(str(build_dir / "**" / pattern), recursive=True)
+            for file_path in files:
+                try:
+                    Path(file_path).unlink()
+                    deleted += 1
+                except (OSError, IOError) as e:
+                    failed += 1
+                    failed_files.append(f"{file_path}: {e}")
+
+        results[display_name] = CleanupResult(
+            deleted=deleted, failed=failed, failed_files=failed_files
+        )
+
+    # Build summary message
+    summary_parts: list[str] = []
+    total_failed = 0
+    for display_name, result in results.items():
+        if result.deleted > 0 or result.failed > 0:
+            summary_parts.append(f"{result.deleted} {display_name}")
+            total_failed += result.failed
+
+    if summary_parts:
+        _ts_print(f"[MESON] 🗑️  Deleted {', '.join(summary_parts)}")
+
+    # Report failures if any occurred
+    if total_failed > 0:
+        _ts_print(f"[MESON] ⚠️  Failed to delete {total_failed} files:")
+        for display_name, result in results.items():
+            for failed_file in result.failed_files[:5]:  # Limit to 5 per type
+                _ts_print(f"[MESON]     {failed_file}")
+            if len(result.failed_files) > 5:
+                _ts_print(
+                    f"[MESON]     ... and {len(result.failed_files) - 5} more {display_name}"
+                )
+
+    return results
+
+
+def detect_system_llvm_tools() -> tuple[bool, bool]:
+    """
+    Detect if system has LLD and LLVM-AR that support thin archives.
+
+    Returns:
+        Tuple of (has_lld, has_llvm_ar)
+    """
+    has_lld = False
+    has_llvm_ar = False
+
+    # Check for system lld
+    # Try 'lld' first (created by workflow symlink or available by default)
+    # Then try 'ld.lld' (Linux naming) as fallback
+    for lld_cmd in ["lld", "ld.lld"]:
+        try:
+            result = subprocess.run(
+                [lld_cmd, "--version"],
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=5,
+            )
+            if result.returncode == 0:
+                has_lld = True
+                break
+        except (subprocess.SubprocessError, FileNotFoundError):
+            continue
+
+    # Check for llvm-ar with thin archive support
+    # Try unversioned first, then common versioned variants (llvm-ar-20, llvm-ar-19, etc.)
+    for ar_cmd in ["llvm-ar", "llvm-ar-20", "llvm-ar-19", "llvm-ar-18"]:
+        try:
+            result = subprocess.run(
+                [ar_cmd, "--help"],
+                capture_output=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=5,
+            )
+            if result.returncode == 0 and "thin" in result.stdout.lower():
+                has_llvm_ar = True
+                break
+        except (subprocess.SubprocessError, FileNotFoundError):
+            continue
+
+    return has_lld, has_llvm_ar

--- a/ci/meson/meson_markers.py
+++ b/ci/meson/meson_markers.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+"""Configuration marker files and AR optimization patches for Meson builds.
+
+Marker files track per-build-dir state (build mode, debug flag, compiler
+version, source hashes, etc.) so we can detect when a reconfigure is
+required. AR optimization patches edit ``build.ninja`` in-place to apply two
+optimizations to the STATIC_LINKER rule: ``restat=1`` (lets ninja skip the
+relink cascade when the archive is unchanged) and the
+``ar_content_preserving.py`` wrapper (preserves the archive's mtime when
+content is unchanged).
+
+Also contains stale-lockfile cleanup for the Windows DirectoryLock bug.
+"""
+# pyright: reportMissingImports=false, reportUnknownVariableType=false
+
+import os
+import sys
+from pathlib import Path
+from typing import Optional
+
+from ci.meson.io_utils import atomic_write_text
+from ci.meson.path_normalization import _ar_opt_status_cache
+from ci.util.global_interrupt_handler import handle_keyboard_interrupt
+from ci.util.timestamp_print import ts_print as _ts_print
+
+
+def cleanup_stale_meson_lockfile(build_dir: Path) -> bool:
+    """Remove a stale ``meson-private/meson.lock`` left by a killed meson process.
+
+    On Windows, meson <= 1.10.x crashed cryptically in ``DirectoryLock.__enter__``
+    when the underlying lockfile open() raised an OSError (e.g., from a stale
+    lockfile left by a killed/abandoned meson process). meson 1.11.0 fixed the
+    crash itself, but the underlying cause — a stale ``meson-private/meson.lock``
+    file — still produces an avoidable setup failure on Windows. Deleting the
+    stale lockfile before invoking ``meson setup`` avoids the failure entirely.
+
+    Args:
+        build_dir: The meson build directory (parent of ``meson-private``).
+
+    Returns:
+        True if a stale lockfile was found and successfully removed, False
+        otherwise (including when no lockfile exists or removal failed).
+    """
+    # Stale lockfile cleanup is intended for the Windows DirectoryLock bug.
+    # On POSIX, meson uses fcntl/flock (advisory) — removing an in-use lockfile
+    # could let a concurrent meson setup bypass the intended lock.
+    if os.name != "nt":
+        return False
+
+    lockfile = build_dir / "meson-private" / "meson.lock"
+    if not lockfile.exists():
+        return False
+    try:
+        lockfile.unlink()
+        _ts_print(f"[MESON] Removed stale lockfile: {lockfile}")
+        return True
+    except KeyboardInterrupt as ki:
+        handle_keyboard_interrupt(ki)
+        raise
+    except OSError as e:
+        # Be tolerant of file-in-use errors on Windows — if removal fails, log
+        # and continue. The caller will hit the original OSError from meson,
+        # which is now visible thanks to the 1.11.0 bump.
+        _ts_print(f"[MESON] Warning: Could not remove stale lockfile {lockfile}: {e}")
+        return False
+
+
+def _write_configuration_markers(
+    *,
+    build_mode_marker: Path,
+    build_mode: str,
+    thin_archive_marker: Path,
+    use_thin_archives: bool,
+    debug_marker: Path,
+    debug: bool,
+    check_marker: Path,
+    check: bool,
+    source_files_marker: Path,
+    current_source_hash: str,
+    current_source_files: list[str],
+    src_files_marker: Path,
+    current_src_hash: str,
+    test_files_marker: Path,
+    current_test_hash: str,
+    compiler_version_marker: Path,
+    current_compiler_version: str,
+    zccache_version_marker: Optional[Path] = None,
+    current_zccache_version: Optional[str] = None,
+    enable_examples_marker: Optional[Path] = None,
+    enable_examples: Optional[bool] = None,
+    enable_unit_tests_marker: Optional[Path] = None,
+    enable_unit_tests: Optional[bool] = None,
+    only_missing: bool = False,
+    verb: str = "Saved",
+) -> None:
+    """Write configuration marker files for cache invalidation.
+
+    Args:
+        only_missing: If True, only write markers that don't exist yet (migration path).
+                      If False, write all markers unconditionally (after meson setup).
+        verb: Display verb for log messages ("Saved" or "Created").
+    """
+    markers: list[tuple[Path, str, str]] = [
+        (build_mode_marker, build_mode, f"build_mode: {build_mode}"),
+        (
+            thin_archive_marker,
+            str(use_thin_archives),
+            f"thin archive: {use_thin_archives}",
+        ),
+        (debug_marker, str(debug), f"debug: {debug}"),
+        (check_marker, str(check), f"check: {check}"),
+        (
+            compiler_version_marker,
+            current_compiler_version,
+            f"compiler version: {current_compiler_version}",
+        ),
+    ]
+
+    # Add optional zccache version marker
+    if zccache_version_marker is not None and current_zccache_version is not None:
+        markers.append(
+            (
+                zccache_version_marker,
+                current_zccache_version,
+                f"zccache version: {current_zccache_version}",
+            )
+        )
+
+    # Add optional enable_examples/enable_unit_tests markers
+    if enable_examples_marker is not None and enable_examples is not None:
+        markers.append(
+            (
+                enable_examples_marker,
+                str(enable_examples),
+                f"enable_examples: {enable_examples}",
+            )
+        )
+    if enable_unit_tests_marker is not None and enable_unit_tests is not None:
+        markers.append(
+            (
+                enable_unit_tests_marker,
+                str(enable_unit_tests),
+                f"enable_unit_tests: {enable_unit_tests}",
+            )
+        )
+
+    for marker_path, value, description in markers:
+        if only_missing and marker_path.exists():
+            continue
+        try:
+            atomic_write_text(marker_path, value)
+            _ts_print(f"[MESON] ✅ {verb} {description}")
+        except (OSError, IOError) as e:
+            _ts_print(f"[MESON] Warning: Could not write {marker_path.name}: {e}")
+
+    # Source files markers: write combined hash (backward compat) and split hashes
+    if current_source_hash:
+        if not only_missing or not source_files_marker.exists():
+            try:
+                atomic_write_text(source_files_marker, current_source_hash)
+                _ts_print(
+                    f"[MESON] ✅ {verb} source/test files hash ({len(current_source_files)} files)"
+                )
+            except (OSError, IOError) as e:
+                _ts_print(f"[MESON] Warning: Could not write source files marker: {e}")
+    # Write split markers for granular change detection
+    if current_src_hash:
+        if not only_missing or not src_files_marker.exists():
+            try:
+                atomic_write_text(src_files_marker, current_src_hash)
+            except (OSError, IOError):
+                pass
+    if current_test_hash:
+        if not only_missing or not test_files_marker.exists():
+            try:
+                atomic_write_text(test_files_marker, current_test_hash)
+            except (OSError, IOError):
+                pass
+
+
+def inject_ar_optimization_patches(build_dir: Path, source_dir: Path) -> bool:
+    """
+    Apply both ar optimization patches to build.ninja in a single read-modify-write.
+
+    Reads build.ninja only ONCE and writes at most ONCE.
+
+    Also populates _ar_opt_status_cache so that a subsequent call to
+    is_ar_content_preserving_active() can return from cache without reading
+    build.ninja a third time. This saves ~4ms per incremental build.
+
+    Patches applied:
+    1. ``restat = 1`` added to STATIC_LINKER rule (enables ninja cascade suppression)
+    2. ar_content_preserving.py wrapper prepended to STATIC_LINKER command
+
+    Args:
+        build_dir: Meson build directory containing build.ninja
+        source_dir: Project source root (parent of ci/)
+
+    Returns:
+        True if both patches are active after this call, False if not applicable
+    """
+    ar_wrapper_script = source_dir / "ci" / "meson" / "ar_content_preserving.py"
+    build_ninja_path = build_dir / "build.ninja"
+
+    if not ar_wrapper_script.exists() or not build_ninja_path.exists():
+        return False
+
+    try:
+        content = build_ninja_path.read_text(encoding="utf-8")
+    except OSError:
+        return False
+
+    if "rule STATIC_LINKER" not in content:
+        return False
+
+    # Idempotency check: if both patches already present, no write needed
+    has_ar_wrapper = ar_wrapper_script.name in content
+    has_restat = "restat = 1" in content
+
+    if has_ar_wrapper and has_restat:
+        _ar_opt_status_cache[str(build_dir)] = True
+        return True
+
+    # Need to apply one or both patches; find the STATIC_LINKER rule block
+    static_linker_pos = content.find("rule STATIC_LINKER")
+    if static_linker_pos == -1:
+        return False
+
+    rule_end = content.find("\n\n", static_linker_pos)
+    if rule_end == -1:
+        rule_end = len(content)
+
+    rule_text = content[static_linker_pos:rule_end]
+    new_rule_text = rule_text
+
+    # Patch 1: restat = 1 (enables ninja cascade suppression after archive)
+    if not has_restat:
+        description_line = " description = Linking static target $out"
+        if description_line in new_rule_text:
+            new_rule_text = new_rule_text.replace(
+                description_line,
+                description_line + "\n restat = 1",
+            )
+
+    # Patch 2: ar_content_preserving.py wrapper (preserves mtime when content unchanged)
+    if not has_ar_wrapper:
+        command_prefix = " command = "
+        if command_prefix in new_rule_text:
+            cmd_start = new_rule_text.find(command_prefix)
+            cmd_line_start = cmd_start + len(command_prefix)
+            cmd_line_end = new_rule_text.find("\n", cmd_line_start)
+            if cmd_line_end == -1:
+                cmd_line_end = len(new_rule_text)
+            original_cmd = new_rule_text[cmd_line_start:cmd_line_end]
+            if "$LINK_ARGS $out $in" in original_cmd:
+                python_exe = sys.executable
+                new_cmd = f'"{python_exe}" "{ar_wrapper_script}" {original_cmd}'
+                new_rule_text = (
+                    new_rule_text[:cmd_line_start]
+                    + new_cmd
+                    + new_rule_text[cmd_line_end:]
+                )
+
+    # Write modified content if anything changed (at most one write)
+    if new_rule_text != rule_text:
+        new_content = content[:static_linker_pos] + new_rule_text + content[rule_end:]
+        try:
+            build_ninja_path.write_text(new_content, encoding="utf-8")
+        except OSError:
+            _ar_opt_status_cache[str(build_dir)] = False
+            return False
+
+    # Verify both patches are now active and populate cache
+    patches_active = (
+        ar_wrapper_script.name in new_rule_text and "restat = 1" in new_rule_text
+    )
+    _ar_opt_status_cache[str(build_dir)] = patches_active
+    return patches_active

--- a/ci/meson/meson_setup_execute.py
+++ b/ci/meson/meson_setup_execute.py
@@ -1,0 +1,464 @@
+#!/usr/bin/env python3
+"""Execution-side helpers for ``setup_meson_build``.
+
+Companion module to ``meson_setup_phases.py``. Where the phases module
+handles *detection* (hashes, markers, file changes), this module handles
+*execution*: compiler/cache discovery, native-file writing, environment
+construction, the skip-setup branch, and the actual ``meson setup`` call.
+"""
+# pyright: reportMissingImports=false, reportUnknownVariableType=false
+
+import os
+import platform
+import shutil
+import sys
+from pathlib import Path
+from typing import Optional, cast
+
+from running_process import RunningProcess
+
+from ci.meson.compiler import (
+    get_compiler_version,
+    get_meson_executable,
+)
+from ci.meson.io_utils import write_if_different
+from ci.meson.meson_markers import (
+    _write_configuration_markers,
+    cleanup_stale_meson_lockfile,
+    inject_ar_optimization_patches,
+)
+from ci.meson.meson_setup_phases import (
+    CompilerDetection,
+    MarkerPaths,
+    SourceHashes,
+)
+from ci.meson.native_launchers import (
+    _find_zccache_binary,
+    _resolve_fast_compiler_binary,
+    _resolve_fast_native_entries,
+    get_zccache_version,
+)
+from ci.meson.output import print_banner
+from ci.meson.path_normalization import (
+    _enforce_strict_path_violations,
+    normalize_meson_private_include_paths,
+)
+from ci.util.global_interrupt_handler import handle_keyboard_interrupt
+from ci.util.output_formatter import TimestampFormatter
+from ci.util.timestamp_print import ts_print as _ts_print
+
+
+def detect_compiler_and_cache(markers: MarkerPaths, verbose: bool) -> CompilerDetection:
+    """Detect clang-tool-chain wrappers + zccache + version strings.
+
+    Caches the compiler and zccache version strings via marker mtimes so we
+    skip the ~3.6s subprocess unless the binary itself has changed.
+    """
+    in_docker = os.environ.get("FASTLED_DOCKER", "0") == "1"
+
+    cache_binary: Optional[str] = None
+    cache_name: Optional[str] = None
+    if not in_docker:
+        zccache_binary = _find_zccache_binary()
+        if zccache_binary:
+            cache_binary = zccache_binary
+            cache_name = "zccache"
+        else:
+            _ts_print(
+                "[MESON] zccache not found, compilation will proceed without caching. To install, run: bash ./install"
+            )
+    else:
+        _ts_print("[MESON] Skipping compiler cache in Docker (startup delay too long)")
+
+    clang_wrapper = shutil.which("clang-tool-chain-c")
+    clangxx_wrapper = shutil.which("clang-tool-chain-cpp")
+    llvm_ar_wrapper = shutil.which("clang-tool-chain-ar")
+
+    if not clang_wrapper or not clangxx_wrapper or not llvm_ar_wrapper:
+        _ts_print("[MESON] ERROR: clang-tool-chain wrapper commands not found in PATH")
+        _ts_print(
+            "[MESON] Install clang-tool-chain with: uv pip install clang-tool-chain"
+        )
+        _ts_print("[MESON] Missing commands:")
+        if not clang_wrapper:
+            _ts_print("[MESON]   - clang-tool-chain-c")
+        if not clangxx_wrapper:
+            _ts_print("[MESON]   - clang-tool-chain-cpp")
+        if not llvm_ar_wrapper:
+            _ts_print("[MESON]   - clang-tool-chain-ar")
+        raise RuntimeError("clang-tool-chain wrapper commands not available")
+
+    current_compiler_version = ""
+    version_from_cache = False
+    clangxx_path = Path(clangxx_wrapper)
+    if markers.compiler_version.exists() and clangxx_path.exists():
+        try:
+            compiler_mtime = clangxx_path.stat().st_mtime
+            marker_mtime = markers.compiler_version.stat().st_mtime
+            if compiler_mtime < marker_mtime:
+                cached_ver = markers.compiler_version.read_text(
+                    encoding="utf-8"
+                ).strip()
+                if cached_ver and cached_ver != "unknown":
+                    current_compiler_version = cached_ver
+                    version_from_cache = True
+        except OSError:
+            pass
+    if not version_from_cache:
+        fast_compiler = _resolve_fast_compiler_binary()
+        current_compiler_version = get_compiler_version(
+            fast_compiler if fast_compiler else clangxx_wrapper
+        )
+
+    current_zccache_version = ""
+    if cache_binary:
+        zccache_version_from_cache = False
+        zccache_path = Path(cache_binary)
+        if markers.zccache_version.exists() and zccache_path.exists():
+            try:
+                zccache_mtime = zccache_path.stat().st_mtime
+                zc_marker_mtime = markers.zccache_version.stat().st_mtime
+                if zccache_mtime < zc_marker_mtime:
+                    cached_zc_ver = markers.zccache_version.read_text(
+                        encoding="utf-8"
+                    ).strip()
+                    if cached_zc_ver:
+                        current_zccache_version = cached_zc_ver
+                        zccache_version_from_cache = True
+            except OSError:
+                pass
+        if not zccache_version_from_cache:
+            current_zccache_version = get_zccache_version(cache_binary)
+
+    if verbose:
+        if cache_name:
+            print(f"Toolchain: {current_compiler_version} + {cache_name}")
+        else:
+            print(f"Toolchain: {current_compiler_version}")
+
+    return CompilerDetection(
+        clang_wrapper=clang_wrapper,
+        clangxx_wrapper=clangxx_wrapper,
+        llvm_ar_wrapper=llvm_ar_wrapper,
+        cache_binary=cache_binary,
+        cache_name=cache_name,
+        compiler_version=current_compiler_version,
+        zccache_version=current_zccache_version,
+    )
+
+
+def write_meson_native_file(
+    *,
+    native_file_path: Path,
+    compiler: CompilerDetection,
+) -> None:
+    """Generate/update the Meson native file with tool paths + platform info."""
+    try:
+        fast = _resolve_fast_native_entries(compiler.cache_binary)
+        if fast.cc is not None:
+            c_compiler = fast.cc
+            cpp_compiler = fast.cxx
+            ar_tool = fast.ar
+        else:
+            c_compiler = f"['{compiler.clang_wrapper}']"
+            cpp_compiler = f"['{compiler.clangxx_wrapper}']"
+            ar_tool = f"['{compiler.llvm_ar_wrapper}']"
+
+        is_windows = sys.platform.startswith("win") or os.name == "nt"
+        is_darwin = sys.platform == "darwin"
+
+        machine = platform.machine().lower()
+        if machine in ("x86_64", "amd64"):
+            cpu_family = "x86_64"
+            cpu = "x86_64"
+        elif machine in ("arm64", "aarch64"):
+            cpu_family = "aarch64"
+            cpu = "aarch64"
+        else:
+            cpu_family = "x86_64"
+            cpu = "x86_64"
+
+        if is_windows:
+            host_system = "windows"
+        elif is_darwin:
+            host_system = "darwin"
+        else:
+            host_system = "linux"
+
+        native_file_content = f"""# ============================================================================
+# Meson Native Build Configuration for FastLED (Auto-generated)
+# ============================================================================
+# This file is auto-generated by meson_runner.py to configure tool paths.
+# It persists across build regenerations when ninja detects meson.build changes.
+#
+# IMPORTANT: LLD linker is forced via -fuse-ld=lld in meson.build link_args.
+# This ensures consistent linker behavior across Windows, Linux, and macOS.
+
+[binaries]
+c = {c_compiler}
+cpp = {cpp_compiler}
+ar = {ar_tool}
+
+[host_machine]
+system = '{host_system}'
+cpu_family = '{cpu_family}'
+cpu = '{cpu}'
+endian = 'little'
+
+[properties]
+# No additional properties needed - compiler flags are in meson.build
+"""
+        native_file_changed = write_if_different(native_file_path, native_file_content)
+        if native_file_changed:
+            _ts_print(f"[MESON] Regenerated native file: {native_file_path}")
+    except (OSError, IOError) as e:
+        _ts_print(f"[MESON] Warning: Could not write native file: {e}", file=sys.stderr)
+
+
+def build_setup_env(compiler: CompilerDetection) -> dict[str, str]:
+    """Build the environment dict for ``meson setup``.
+
+    Uses raw compiler binaries when resolvable (avoids ~3.6s Python wrapper
+    overhead) but falls back to the wrappers if clang_tool_chain isn't
+    available.
+    """
+    env = os.environ.copy()
+    if compiler.cache_binary:
+        env.setdefault("ZCCACHE_STRICT_PATHS", "absolute")
+
+    fast_compiler = _resolve_fast_compiler_binary()
+    if fast_compiler:
+        try:
+            from clang_tool_chain.platform.paths import find_tool_binary
+
+            fast_c = str(find_tool_binary("clang"))
+            fast_ar = str(find_tool_binary("llvm-ar"))
+            env["CC"] = fast_c
+            env["CXX"] = fast_compiler
+            env["AR"] = fast_ar
+        except KeyboardInterrupt as ki:
+            handle_keyboard_interrupt(ki)
+        except Exception:
+            env["CC"] = compiler.clang_wrapper
+            env["CXX"] = compiler.clangxx_wrapper
+            env["AR"] = compiler.llvm_ar_wrapper
+    else:
+        env["CC"] = compiler.clang_wrapper
+        env["CXX"] = compiler.clangxx_wrapper
+        env["AR"] = compiler.llvm_ar_wrapper
+
+    return env
+
+
+def handle_skip_meson_setup(
+    *,
+    build_dir: Path,
+    source_dir: Path,
+    use_thin_archives: bool,
+    markers: MarkerPaths,
+    hashes: SourceHashes,
+    debug: bool,
+    check: bool,
+    build_mode: str,
+    enable_examples: bool,
+    enable_unit_tests: bool,
+    compiler: CompilerDetection,
+) -> None:
+    """Handle the skip-setup branch: thin archive cleanup + missing markers + ar patches."""
+    libfastled_a = build_dir / "libfastled.a"
+    if libfastled_a.exists():
+        try:
+            with open(libfastled_a, "rb") as f:
+                header = f.read(8)
+                is_thin_archive = header == b"!<thin>\n"
+
+            if is_thin_archive and not use_thin_archives:
+                _ts_print("[MESON] ⚠️  Detected thin archive from previous build")
+                _ts_print(
+                    "[MESON] 🗑️  Deleting libfastled.a to force rebuild with regular archive"
+                )
+                libfastled_a.unlink()
+            elif not is_thin_archive and use_thin_archives:
+                _ts_print("[MESON] ℹ️  Detected regular archive from previous build")
+                _ts_print(
+                    "[MESON] 🗑️  Deleting libfastled.a to force rebuild with thin archive"
+                )
+                libfastled_a.unlink()
+        except (OSError, IOError) as e:
+            _ts_print(f"[MESON] Warning: Could not check/delete libfastled.a: {e}")
+
+    _write_configuration_markers(
+        build_mode_marker=markers.build_mode,
+        build_mode=build_mode,
+        thin_archive_marker=markers.thin_archive,
+        use_thin_archives=use_thin_archives,
+        debug_marker=markers.debug,
+        debug=debug,
+        check_marker=markers.check,
+        check=check,
+        source_files_marker=markers.source_files,
+        current_source_hash=hashes.source_hash,
+        current_source_files=hashes.source_files,
+        src_files_marker=markers.src_files,
+        current_src_hash=hashes.src_hash,
+        test_files_marker=markers.test_files,
+        current_test_hash=hashes.test_hash,
+        compiler_version_marker=markers.compiler_version,
+        current_compiler_version=compiler.compiler_version,
+        zccache_version_marker=markers.zccache_version,
+        current_zccache_version=compiler.zccache_version or None,
+        enable_examples_marker=markers.enable_examples,
+        enable_examples=enable_examples,
+        enable_unit_tests_marker=markers.enable_unit_tests,
+        enable_unit_tests=enable_unit_tests,
+        only_missing=True,
+        verb="Created",
+    )
+
+    inject_ar_optimization_patches(build_dir, source_dir)
+    if normalize_meson_private_include_paths(build_dir):
+        _ts_print("[MESON] Normalized private include paths for zccache strict mode")
+    _enforce_strict_path_violations(build_dir)
+
+
+def build_meson_setup_cmd(
+    *,
+    native_file_path: Path,
+    build_dir: Path,
+    build_mode: str,
+    enable_examples: bool,
+    enable_unit_tests: bool,
+    reconfigure: bool,
+) -> list[str]:
+    """Build the ``meson setup [--reconfigure] ...`` command list."""
+    cmd: list[str] = [
+        get_meson_executable(),
+        "setup",
+    ]
+    if reconfigure:
+        cmd.append("--reconfigure")
+    cmd.extend(
+        [
+            "--native-file",
+            str(native_file_path),
+            str(build_dir),
+            f"-Dbuild_mode={build_mode}",
+            f"-Denable_examples={str(enable_examples).lower()}",
+            f"-Denable_unit_tests={str(enable_unit_tests).lower()}",
+        ]
+    )
+    return cmd
+
+
+def run_meson_setup_command(
+    *,
+    cmd: list[str],
+    source_dir: Path,
+    build_dir: Path,
+    env: dict[str, str],
+    markers: MarkerPaths,
+    hashes: SourceHashes,
+    debug: bool,
+    check: bool,
+    build_mode: str,
+    enable_examples: bool,
+    enable_unit_tests: bool,
+    use_thin_archives: bool,
+    compiler: CompilerDetection,
+) -> bool:
+    """Run ``meson setup``, with one self-healing retry, then persist markers."""
+    print_banner("MESON CONFIGURATION", "⚙️")
+
+    def _run_meson_setup() -> tuple[int, str]:
+        proc = RunningProcess(
+            cmd,
+            cwd=source_dir,
+            timeout=600,
+            auto_run=True,
+            check=False,
+            env=env,
+            output_formatter=TimestampFormatter(),
+        )
+        returncode = cast(int, proc.wait(echo=True))
+        return returncode, str(proc.stdout)
+
+    def _clear_stale_caches() -> None:
+        _ts_print("[MESON] 🔄 Clearing stale test metadata caches...")
+        cache_files = [
+            build_dir / "tests" / "test_metadata.cache",
+            build_dir / "test_list_cache.txt",
+            markers.source_files,
+        ]
+        for cache_file in cache_files:
+            if cache_file.exists():
+                try:
+                    cache_file.unlink()
+                    _ts_print(f"[MESON]   Deleted: {cache_file.name}")
+                except (OSError, IOError) as e:
+                    _ts_print(
+                        f"[MESON]   Warning: Could not delete {cache_file.name}: {e}"
+                    )
+
+    try:
+        cleanup_stale_meson_lockfile(build_dir)
+        returncode, stdout = _run_meson_setup()
+
+        if returncode != 0 and "does not exist" in stdout:
+            _ts_print(
+                "[MESON] ⚠️  Setup failed due to missing file (stale cache detected)"
+            )
+            _clear_stale_caches()
+            _ts_print("[MESON] 🔄 Retrying meson setup...")
+            cleanup_stale_meson_lockfile(build_dir)
+            returncode, stdout = _run_meson_setup()
+
+        if returncode != 0:
+            _ts_print(
+                f"[MESON] Setup failed with return code {returncode}", file=sys.stderr
+            )
+            return False
+
+        _ts_print("[MESON] Setup successful")
+
+        _write_configuration_markers(
+            build_mode_marker=markers.build_mode,
+            build_mode=build_mode,
+            thin_archive_marker=markers.thin_archive,
+            use_thin_archives=use_thin_archives,
+            debug_marker=markers.debug,
+            debug=debug,
+            check_marker=markers.check,
+            check=check,
+            source_files_marker=markers.source_files,
+            current_source_hash=hashes.source_hash,
+            current_source_files=hashes.source_files,
+            src_files_marker=markers.src_files,
+            current_src_hash=hashes.src_hash,
+            test_files_marker=markers.test_files,
+            current_test_hash=hashes.test_hash,
+            compiler_version_marker=markers.compiler_version,
+            current_compiler_version=compiler.compiler_version,
+            zccache_version_marker=markers.zccache_version,
+            current_zccache_version=compiler.zccache_version or None,
+            enable_examples_marker=markers.enable_examples,
+            enable_examples=enable_examples,
+            enable_unit_tests_marker=markers.enable_unit_tests,
+            enable_unit_tests=enable_unit_tests,
+            only_missing=False,
+            verb="Saved",
+        )
+
+        inject_ar_optimization_patches(build_dir, source_dir)
+        if normalize_meson_private_include_paths(build_dir):
+            _ts_print(
+                "[MESON] Normalized private include paths for zccache strict mode"
+            )
+        _enforce_strict_path_violations(build_dir)
+        return True
+
+    except KeyboardInterrupt as ki:
+        handle_keyboard_interrupt(ki)
+        raise
+    except Exception as e:
+        _ts_print(f"[MESON] Setup failed with exception: {e}", file=sys.stderr)
+        return False

--- a/ci/meson/meson_setup_phases.py
+++ b/ci/meson/meson_setup_phases.py
@@ -1,0 +1,593 @@
+#!/usr/bin/env python3
+"""Helper phases for ``setup_meson_build`` orchestration.
+
+These helpers were extracted from ``ci/meson/build_config.py`` so the main
+``setup_meson_build`` orchestrator stays readable and the file stays under
+1000 LOC. Each helper owns one cohesive piece of pre-setup logic — source
+hash detection, marker-based reconfigure detection, file-change detection,
+compiler/cache discovery, native-file generation, and the final meson setup
+invocation.
+"""
+# pyright: reportMissingImports=false, reportUnknownVariableType=false
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+from ci.meson.cache_utils import get_max_dir_mtime
+from ci.meson.meson_cleanup import cleanup_build_artifacts
+from ci.meson.output import print_warning
+from ci.meson.test_discovery import get_source_files_hash, get_split_source_hashes
+from ci.util.global_interrupt_handler import handle_keyboard_interrupt
+from ci.util.timestamp_print import ts_print as _ts_print
+
+
+@dataclass
+class MarkerPaths:
+    """Paths to every per-build marker file we maintain."""
+
+    thin_archive: Path
+    source_files: Path
+    src_files: Path
+    test_files: Path
+    debug: Path
+    check: Path
+    build_mode: Path
+    compiler_version: Path
+    zccache_version: Path
+    enable_examples: Path
+    enable_unit_tests: Path
+
+    @classmethod
+    def for_build_dir(cls, build_dir: Path) -> "MarkerPaths":
+        return cls(
+            thin_archive=build_dir / ".thin_archive_config",
+            source_files=build_dir / ".source_files_hash",
+            src_files=build_dir / ".src_files_hash",
+            test_files=build_dir / ".test_files_hash",
+            debug=build_dir / ".debug_config",
+            check=build_dir / ".check_config",
+            build_mode=build_dir / ".build_mode_config",
+            compiler_version=build_dir / ".compiler_version_config",
+            zccache_version=build_dir / ".zccache_version_config",
+            enable_examples=build_dir / ".enable_examples_config",
+            enable_unit_tests=build_dir / ".enable_unit_tests_config",
+        )
+
+
+@dataclass
+class SourceHashes:
+    """Source file hashes computed once per setup invocation."""
+
+    src_hash: str
+    test_hash: str
+    source_hash: str
+    source_files: list[str]
+    max_tests_dir_mtime: float
+
+
+@dataclass
+class ReconfigureDecision:
+    """Outcome of marker-based reconfigure detection."""
+
+    reasons: list[str] = field(default_factory=list)
+    force_reconfigure: bool = False
+    force_reason: Optional[str] = None
+    debug_changed: bool = False
+    build_mode_changed: bool = False
+    last_build_mode: Optional[str] = None
+
+
+@dataclass
+class CompilerDetection:
+    """Result of compiler wrapper + cache binary detection."""
+
+    clang_wrapper: str
+    clangxx_wrapper: str
+    llvm_ar_wrapper: str
+    cache_binary: Optional[str]
+    cache_name: Optional[str]
+    compiler_version: str
+    zccache_version: str
+
+
+def compute_source_hashes(source_dir: Path, markers: MarkerPaths) -> SourceHashes:
+    """Compute src/, tests/, and combined source-file hashes.
+
+    Uses directory mtimes as a fast structural-change proxy so we can skip
+    the expensive rglob walk when nothing was added or removed. The tests/
+    directory mtime is also returned so the caller can reuse it for the
+    test_list_cache fast-path.
+    """
+    max_tests_dir_mtime = get_max_dir_mtime(source_dir / "tests")
+    current_src_hash = ""
+    current_test_hash = ""
+    current_source_hash = ""
+    current_source_files: list[str] = []
+
+    max_src_dir_mtime = get_max_dir_mtime(source_dir / "src")
+    if markers.src_files.exists():
+        try:
+            marker_mtime = markers.src_files.stat().st_mtime
+            if max_src_dir_mtime <= marker_mtime:
+                cached = markers.src_files.read_text(encoding="utf-8").strip()
+                if cached:
+                    current_src_hash = cached
+        except OSError:
+            pass
+
+    if markers.test_files.exists():
+        try:
+            marker_mtime = markers.test_files.stat().st_mtime
+            if max_tests_dir_mtime <= marker_mtime:
+                cached = markers.test_files.read_text(encoding="utf-8").strip()
+                if cached:
+                    current_test_hash = cached
+        except OSError:
+            pass
+
+    if not current_src_hash or not current_test_hash:
+        split = get_split_source_hashes(source_dir)
+        if not current_src_hash:
+            current_src_hash = split.src_hash
+        if not current_test_hash:
+            current_test_hash = split.tests_hash
+        current_source_files = sorted(split.src_files + split.test_files)
+
+    if markers.source_files.exists():
+        try:
+            marker_mtime = markers.source_files.stat().st_mtime
+            max_combined = max(max_src_dir_mtime, max_tests_dir_mtime)
+            if max_combined <= marker_mtime:
+                cached = markers.source_files.read_text(encoding="utf-8").strip()
+                if cached:
+                    current_source_hash = cached
+        except OSError:
+            pass
+    if not current_source_hash:
+        current_source_hash, current_source_files = get_source_files_hash(source_dir)
+
+    return SourceHashes(
+        src_hash=current_src_hash,
+        test_hash=current_test_hash,
+        source_hash=current_source_hash,
+        source_files=current_source_files,
+        max_tests_dir_mtime=max_tests_dir_mtime,
+    )
+
+
+def check_reconfigure_markers(
+    *,
+    build_dir: Path,
+    markers: MarkerPaths,
+    hashes: SourceHashes,
+    debug: bool,
+    check: bool,
+    build_mode: str,
+    enable_examples: bool,
+    enable_unit_tests: bool,
+    use_thin_archives: bool,
+) -> ReconfigureDecision:
+    """Inspect marker files and decide whether to reconfigure.
+
+    Returns a decision struct capturing every reason found so the caller
+    can print a single consolidated message instead of one per marker.
+    """
+    decision = ReconfigureDecision()
+
+    # SELF-HEALING: introspection corruption marker
+    intro_corruption_marker = build_dir / ".intro_corruption_detected"
+    if intro_corruption_marker.exists():
+        _ts_print("")
+        _ts_print("=" * 80)
+        _ts_print("[MESON] ⚠️  INTROSPECTION FILE CORRUPTION DETECTED - AUTO-HEALING")
+        _ts_print("=" * 80)
+        _ts_print("[MESON] Corruption marker detected (created by test discovery)")
+        _ts_print("[MESON]")
+        _ts_print(
+            "[MESON] The build directory has corrupted or missing intro-*.json files."
+        )
+        _ts_print(
+            "[MESON] These files are required for Meson introspection (test discovery, etc)."
+        )
+        _ts_print("[MESON]")
+        _ts_print(
+            "[MESON] 🔧 Auto-fix: Forcing reconfiguration to regenerate intro files"
+        )
+        _ts_print("=" * 80)
+        _ts_print("")
+        try:
+            intro_corruption_marker.unlink()
+            _ts_print("[MESON] ✅ Removed corruption marker")
+        except (OSError, IOError) as e:
+            _ts_print(f"[MESON] Warning: Could not remove corruption marker: {e}")
+        decision.force_reconfigure = True
+        decision.force_reason = "introspection files corrupted (auto-healing)"
+        decision.reasons.append("introspection files corrupted")
+
+    # Thin archive marker
+    if markers.thin_archive.exists():
+        try:
+            last_thin_setting = markers.thin_archive.read_text().strip() == "True"
+            if last_thin_setting != use_thin_archives:
+                decision.reasons.append(
+                    f"thin archive changed: {last_thin_setting} → {use_thin_archives}"
+                )
+        except (OSError, IOError):
+            decision.reasons.append("thin archive marker unreadable")
+    else:
+        decision.reasons.append("thin archive marker missing")
+
+    # Source/test file hash markers
+    _src_changed = False
+    _test_changed = False
+    if hashes.src_hash:
+        if markers.src_files.exists():
+            try:
+                if markers.src_files.read_text().strip() != hashes.src_hash:
+                    _src_changed = True
+            except (OSError, IOError):
+                _src_changed = True
+        else:
+            _src_changed = True
+    if hashes.test_hash:
+        if markers.test_files.exists():
+            try:
+                if markers.test_files.read_text().strip() != hashes.test_hash:
+                    _test_changed = True
+            except (OSError, IOError):
+                _test_changed = True
+        else:
+            _test_changed = True
+    if not _src_changed and not _test_changed and hashes.source_hash:
+        if markers.source_files.exists():
+            try:
+                last_hash = markers.source_files.read_text().strip()
+                if last_hash != hashes.source_hash:
+                    _src_changed = True
+                    _test_changed = True
+            except (OSError, IOError):
+                _src_changed = True
+                _test_changed = True
+        else:
+            _src_changed = True
+            _test_changed = True
+    if _src_changed and _test_changed:
+        decision.reasons.append("source and test files changed")
+    elif _src_changed:
+        decision.reasons.append("source files changed (src/)")
+    elif _test_changed:
+        decision.reasons.append("test files changed (tests/)")
+
+    # Debug marker
+    if markers.debug.exists():
+        try:
+            last_debug_setting = markers.debug.read_text().strip() == "True"
+            if last_debug_setting != debug:
+                decision.reasons.append(
+                    f"debug mode changed: {last_debug_setting} → {debug}"
+                )
+                decision.debug_changed = True
+        except (OSError, IOError):
+            decision.reasons.append("debug marker unreadable")
+    else:
+        decision.reasons.append("debug marker missing")
+
+    # Check marker
+    if markers.check.exists():
+        try:
+            last_check_setting = markers.check.read_text().strip() == "True"
+            if last_check_setting != check:
+                decision.reasons.append(
+                    f"IWYU check mode changed: {last_check_setting} → {check}"
+                )
+        except (OSError, IOError):
+            decision.reasons.append("check marker unreadable")
+    else:
+        decision.reasons.append("check marker missing")
+
+    # Build mode marker
+    if markers.build_mode.exists():
+        try:
+            decision.last_build_mode = markers.build_mode.read_text().strip()
+            if decision.last_build_mode != build_mode:
+                decision.reasons.append(
+                    f"build mode changed: {decision.last_build_mode} → {build_mode}"
+                )
+                decision.build_mode_changed = True
+        except (OSError, IOError):
+            decision.reasons.append("build_mode marker unreadable")
+    else:
+        decision.reasons.append("build_mode marker missing")
+
+    # enable_examples marker
+    if markers.enable_examples.exists():
+        try:
+            last_enable_examples = markers.enable_examples.read_text().strip() == "True"
+            if last_enable_examples != enable_examples:
+                decision.reasons.append(
+                    f"enable_examples changed: {last_enable_examples} → {enable_examples}"
+                )
+        except (OSError, IOError):
+            decision.reasons.append("enable_examples marker unreadable")
+
+    # enable_unit_tests marker
+    if markers.enable_unit_tests.exists():
+        try:
+            last_enable_unit_tests = (
+                markers.enable_unit_tests.read_text().strip() == "True"
+            )
+            if last_enable_unit_tests != enable_unit_tests:
+                decision.reasons.append(
+                    f"enable_unit_tests changed: {last_enable_unit_tests} → {enable_unit_tests}"
+                )
+        except (OSError, IOError):
+            decision.reasons.append("enable_unit_tests marker unreadable")
+
+    if decision.reasons:
+        decision.force_reconfigure = True
+        if not decision.force_reason:
+            decision.force_reason = "configuration markers changed"
+        missing_markers = [r for r in decision.reasons if "missing" in r]
+        changed_settings = [
+            r for r in decision.reasons if "missing" not in r and "unreadable" not in r
+        ]
+        unreadable_markers = [r for r in decision.reasons if "unreadable" in r]
+
+        if missing_markers and not changed_settings and not unreadable_markers:
+            num_missing = len(missing_markers)
+            _ts_print(
+                f"[MESON] ℹ️  Build directory needs configuration ({num_missing} marker files missing)"
+            )
+        else:
+            _ts_print("[MESON] 🔄 Reconfiguration required:")
+            for reason in decision.reasons:
+                _ts_print(f"[MESON]     - {reason}")
+
+    if decision.debug_changed:
+        cleanup_build_artifacts(build_dir, "Debug mode changed")
+    if decision.build_mode_changed:
+        cleanup_build_artifacts(
+            build_dir,
+            f"Build mode changed ({decision.last_build_mode} → {build_mode})",
+        )
+
+    return decision
+
+
+def check_meson_build_modified(source_dir: Path, build_dir: Path) -> bool:
+    """Return True if any meson.build is newer than build.ninja."""
+    build_ninja_path = build_dir / "build.ninja"
+    if not build_ninja_path.exists():
+        return False
+    try:
+        build_ninja_mtime = build_ninja_path.stat().st_mtime
+        meson_build_files = [
+            source_dir / "meson.build",
+            source_dir / "tests" / "meson.build",
+            source_dir / "examples" / "meson.build",
+        ]
+        for meson_file in meson_build_files:
+            if meson_file.exists():
+                meson_file_mtime = meson_file.stat().st_mtime
+                if meson_file_mtime > build_ninja_mtime:
+                    _ts_print(
+                        f"[MESON] ⚠️  Detected modified meson.build: {meson_file.relative_to(source_dir)}"
+                    )
+                    _ts_print(
+                        f"[MESON]     File mtime: {meson_file_mtime:.6f} > build.ninja mtime: {build_ninja_mtime:.6f}"
+                    )
+                    return True
+    except (OSError, IOError) as e:
+        _ts_print(f"[MESON] Warning: Could not check meson.build timestamps: {e}")
+        return True
+    return False
+
+
+def detect_test_file_changes(
+    source_dir: Path, build_dir: Path, max_tests_dir_mtime: float
+) -> bool:
+    """Return True when discovered test files differ from the cached list."""
+    test_list_cache_path = build_dir / "test_list_cache.txt"
+    skip_test_discovery = False
+    if test_list_cache_path.exists():
+        try:
+            tlc_mtime = test_list_cache_path.stat().st_mtime
+            if max_tests_dir_mtime <= tlc_mtime:
+                skip_test_discovery = True
+        except OSError:
+            pass
+
+    if skip_test_discovery:
+        return False
+
+    try:
+        import importlib.util
+
+        tests_py_path = source_dir / "tests"
+
+        spec_dt = importlib.util.spec_from_file_location(
+            "discover_tests", tests_py_path / "discover_tests.py"
+        )
+        assert spec_dt is not None and spec_dt.loader is not None
+        mod_dt = importlib.util.module_from_spec(spec_dt)
+        spec_dt.loader.exec_module(mod_dt)
+        discover_test_files = mod_dt.discover_test_files
+
+        spec_tc = importlib.util.spec_from_file_location(
+            "test_config", tests_py_path / "test_config.py"
+        )
+        assert spec_tc is not None and spec_tc.loader is not None
+        mod_tc = importlib.util.module_from_spec(spec_tc)
+        spec_tc.loader.exec_module(mod_tc)
+        EXCLUDED_TEST_FILES = mod_tc.EXCLUDED_TEST_FILES
+        EXCLUDED_TEST_DIRS = mod_tc.EXCLUDED_TEST_DIRS
+
+        tests_dir = source_dir / "tests"
+        current_test_files: list[str] = sorted(
+            discover_test_files(tests_dir, EXCLUDED_TEST_FILES, EXCLUDED_TEST_DIRS)
+        )
+
+        test_list_cache = build_dir / "test_list_cache.txt"
+        cached_test_files: list[str] = []
+        try:
+            with open(test_list_cache, "r") as f:
+                cached_test_files = [
+                    line.strip()
+                    for line in f
+                    if line.strip() and not line.startswith("#")
+                ]
+        except FileNotFoundError:
+            cached_test_files = []
+        except (IOError, OSError) as e:
+            _ts_print(f"[MESON] Warning: Could not read test cache: {e}")
+            cached_test_files = []
+
+        if current_test_files != cached_test_files:
+            added: set[str] = set(current_test_files) - set(cached_test_files)
+            removed: set[str] = set(cached_test_files) - set(current_test_files)
+
+            print_warning("[MESON] ⚠️  Detected test file changes:")
+            if added:
+                added_list = sorted(added)
+                if len(added_list) > 10:
+                    print_warning(f"[MESON]     Added: {len(added_list)} test files")
+                    print_warning(
+                        f"[MESON]     (First 10: {', '.join(added_list[:10])}...)"
+                    )
+                else:
+                    print_warning(f"[MESON]     Added: {', '.join(added_list)}")
+            if removed:
+                removed_list = sorted(removed)
+                if len(removed_list) > 10:
+                    print_warning(
+                        f"[MESON]     Removed: {len(removed_list)} test files"
+                    )
+                    print_warning(
+                        f"[MESON]     (First 10: {', '.join(removed_list[:10])}...)"
+                    )
+                else:
+                    print_warning(f"[MESON]     Removed: {', '.join(removed_list)}")
+
+            temp_cache = test_list_cache.with_suffix(".tmp")
+            try:
+                with open(temp_cache, "w") as f:
+                    f.write(
+                        "# Auto-generated test file list cache for Meson reconfiguration\n"
+                    )
+                    f.write(f"# Total tests: {len(current_test_files)}\n")
+                    f.write("# Generated by meson_runner.py\n\n")
+                    for test_file in current_test_files:
+                        f.write(f"{test_file}\n")
+                temp_cache.replace(test_list_cache)
+            except (OSError, IOError) as e:
+                _ts_print(
+                    f"[MESON] Warning: Could not update test cache atomically: {e}"
+                )
+                try:
+                    temp_cache.unlink()
+                except (OSError, IOError):
+                    pass
+            return True
+        # No changes — touch cache so directory-mtime fast-path activates next run.
+        try:
+            test_list_cache.touch()
+        except OSError:
+            pass
+        return False
+
+    except KeyboardInterrupt as ki:
+        handle_keyboard_interrupt(ki)
+        raise
+    except Exception as e:
+        _ts_print(f"[MESON] Warning: Could not check test file changes: {e}")
+        return True
+
+
+def detect_example_file_changes(source_dir: Path, build_dir: Path) -> bool:
+    """Return True when ``examples/`` files have been added/removed/modified."""
+    try:
+        from ci.meson.example_metadata_cache import compute_example_files_hash
+
+        examples_dir = source_dir / "examples"
+        example_cache_file = build_dir / "examples" / "example_metadata.cache"
+
+        if not examples_dir.exists():
+            return False
+
+        skip_example_hash = False
+        if example_cache_file.exists():
+            try:
+                cache_mtime = example_cache_file.stat().st_mtime
+                max_example_dir_mtime = get_max_dir_mtime(examples_dir)
+                if max_example_dir_mtime <= cache_mtime:
+                    skip_example_hash = True
+            except OSError:
+                pass
+
+        if skip_example_hash:
+            return False
+
+        current_example_hash = compute_example_files_hash(examples_dir)
+        cached_example_hash = ""
+        if example_cache_file.exists():
+            try:
+                with open(example_cache_file, "r") as f:
+                    cache_data = json.load(f)
+                cached_example_hash = cache_data.get("hash", "")
+            except KeyboardInterrupt as ki:
+                handle_keyboard_interrupt(ki)
+            except Exception:
+                cached_example_hash = ""
+
+        if current_example_hash != cached_example_hash:
+            print_warning(
+                "[MESON] ⚠️  Detected example file changes (files added/removed/modified)"
+            )
+            if example_cache_file.exists():
+                try:
+                    example_cache_file.unlink()
+                except OSError:
+                    pass
+            return True
+        return False
+
+    except KeyboardInterrupt as ki:
+        handle_keyboard_interrupt(ki)
+        raise
+    except Exception as e:
+        _ts_print(f"[MESON] Warning: Could not check example file changes: {e}")
+        return True
+
+
+def check_obsolete_zig_wrappers(source_dir: Path) -> None:
+    """Fail loudly when the legacy ``.build/meson/zig-*-wrapper.exe`` files exist."""
+    meson_dir = source_dir / ".build" / "meson"
+    if not meson_dir.exists():
+        return
+    obsolete_wrappers = list(meson_dir.glob("zig-*-wrapper.exe"))
+    if not obsolete_wrappers:
+        return
+    _ts_print("=" * 80)
+    _ts_print("[MESON] ❌ ERROR: Obsolete zig wrapper artifacts detected!")
+    _ts_print("[MESON]")
+    _ts_print(
+        "[MESON] Found old zig-based wrapper executables in .build/meson/ directory:"
+    )
+    for wrapper in obsolete_wrappers:
+        _ts_print(f"[MESON]   - {wrapper.name}")
+    _ts_print("[MESON]")
+    _ts_print("[MESON] These wrappers are from the old zig-based compiler system")
+    _ts_print("[MESON] and are no longer compatible with clang-tool-chain.")
+    _ts_print("[MESON]")
+    _ts_print("[MESON] To fix this issue, delete the .build/meson directory:")
+    _ts_print("[MESON]   rm -rf .build/meson")
+    _ts_print("[MESON]")
+    _ts_print("[MESON] Then run your build command again. The system will use")
+    _ts_print("[MESON] clang-tool-chain wrappers instead.")
+    _ts_print("=" * 80)
+    raise RuntimeError(
+        "Obsolete zig wrapper artifacts detected in .build/meson/ directory. "
+        "Delete .build/meson/ directory and try again."
+    )

--- a/ci/meson/native_launchers.py
+++ b/ci/meson/native_launchers.py
@@ -1,0 +1,369 @@
+#!/usr/bin/env python3
+"""Native launcher resolution for Meson native files and WASM cross-files.
+
+Resolves compiled ``ctc-*`` native launcher binaries produced by
+``clang_tool_chain.commands.compile_native``. Native launchers replace the
+Python ``clang-tool-chain-*`` wrappers with ~34ms startup vs ~1200ms, saving
+multiple seconds during meson setup (which probes the compiler ~10 times).
+
+Also provides zccache binary discovery for the compiler cache integration.
+"""
+# pyright: reportMissingImports=false, reportUnknownVariableType=false
+
+import os
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from typeguard import typechecked
+
+from ci.util.global_interrupt_handler import handle_keyboard_interrupt
+
+
+@dataclass(slots=True)
+class FastNativeEntries:
+    cc: Optional[str]
+    cxx: Optional[str]
+    ar: Optional[str]
+
+
+@typechecked
+@dataclass(slots=True)
+class EmccNativeLaunchers:
+    """Compiled emscripten-tool launcher paths produced by ``compile_native()``.
+
+    Every field is a guaranteed-present absolute path. ``compile_native()``
+    in clang-tool-chain 1.5.1+ produces all seven launchers in one call;
+    if any is missing afterward the resolver raises rather than silently
+    falling back. clang-tool-chain >=1.5.1 is pinned in pyproject.toml.
+    """
+
+    emcc: str
+    empp: str
+    emar: str
+    emstrip: str
+    emranlib: str
+    emnm: str
+    wasm_ld: str
+
+
+@typechecked
+@dataclass(slots=True)
+class WasmNativeEntries:
+    """Native tool entries for the WASM cross-file.
+
+    All fields are absolute paths to compiled ctc-* native launchers.
+    No Python-wrapper fallbacks — clang-tool-chain >=1.5.1 is a hard
+    requirement and ``compile_native()`` is invoked eagerly.
+
+    ``wasm_ld`` is not consumed by meson directly. emcc invokes wasm-ld
+    internally; the integration is via the ``EMCC_WASM_LD`` env var picked
+    up by the shared.py patch that ``ensure_emscripten_available`` applies.
+    Carried here so the build orchestration can set the env var.
+    """
+
+    c: str
+    cpp: str
+    ar: str
+    strip: str
+    ranlib: str
+    nm: str
+    wasm_ld: str
+
+
+def _native_launcher_output_dir(project_root: Path) -> Path:
+    """Directory where compiled native launchers live."""
+    return project_root / ".cached" / "clang-native"
+
+
+def _ensure_native_launcher(project_root: Path) -> tuple[Optional[str], Optional[str]]:
+    """
+    Ensure ctc-clang/ctc-clang++ native launchers are compiled.
+
+    The native launcher is a compiled C++ binary that replaces the Python
+    clang-tool-chain wrapper with near-zero startup overhead (~34ms vs ~1200ms).
+    It auto-detects the platform, finds the clang installation, and adds all
+    necessary flags (--target, --sysroot, -stdlib, includes, etc.) automatically.
+
+    Returns:
+        Tuple of (ctc_clang_path, ctc_clangpp_path), or (None, None) on failure.
+    """
+    output_dir = _native_launcher_output_dir(project_root)
+    exe_suffix = ".exe" if sys.platform == "win32" else ""
+    ctc_clang = output_dir / f"ctc-clang{exe_suffix}"
+    ctc_clangpp = output_dir / f"ctc-clang++{exe_suffix}"
+
+    if ctc_clang.exists() and ctc_clangpp.exists():
+        return str(ctc_clang), str(ctc_clangpp)
+
+    try:
+        from clang_tool_chain.commands.compile_native import compile_native
+
+        output_dir.mkdir(parents=True, exist_ok=True)
+        rc = compile_native(str(output_dir))
+        if rc == 0 and ctc_clang.exists() and ctc_clangpp.exists():
+            return str(ctc_clang), str(ctc_clangpp)
+    except KeyboardInterrupt as ki:
+        handle_keyboard_interrupt(ki)
+    except Exception:
+        pass
+    return None, None
+
+
+def _ensure_emcc_native_launcher(project_root: Path) -> EmccNativeLaunchers:
+    """
+    Build and return all seven WASM-related ctc-* native launcher paths.
+
+    ``compile_native()`` from clang-tool-chain 1.5.1+ produces every binary
+    in a single invocation (clang + emcc + wasm-ld + emtool family with all
+    its hardlinked aliases). If any binary is missing afterward, raises
+    RuntimeError — no Python-wrapper fallback. clang-tool-chain >=1.5.1 is
+    pinned in pyproject.toml so this is a hard requirement.
+
+    Raises:
+        RuntimeError: if ``compile_native()`` fails or any launcher binary
+            is missing after a successful build.
+    """
+    output_dir = _native_launcher_output_dir(project_root)
+    exe_suffix = ".exe" if sys.platform == "win32" else ""
+    binaries = {
+        "emcc": output_dir / f"ctc-emcc{exe_suffix}",
+        "empp": output_dir / f"ctc-em++{exe_suffix}",
+        "emar": output_dir / f"ctc-emar{exe_suffix}",
+        "emstrip": output_dir / f"ctc-emstrip{exe_suffix}",
+        "emranlib": output_dir / f"ctc-emranlib{exe_suffix}",
+        "emnm": output_dir / f"ctc-emnm{exe_suffix}",
+        "wasm_ld": output_dir / f"ctc-wasm-ld{exe_suffix}",
+    }
+
+    # Warm-path presence check: one os.scandir() enumerates the whole dir
+    # in ~10-20 ms; 7 individual Path.exists() calls cost ~30 ms each on
+    # Windows NTFS (~240 ms total). Set-membership lookups are O(1).
+    try:
+        present_names: set[str] = {entry.name for entry in os.scandir(output_dir)}
+    except OSError:
+        present_names = set()
+    all_present = all(p.name in present_names for p in binaries.values())
+
+    if not all_present:
+        from clang_tool_chain.commands.compile_native import compile_native
+
+        output_dir.mkdir(parents=True, exist_ok=True)
+        rc = compile_native(str(output_dir))
+        if rc != 0:
+            raise RuntimeError(
+                f"clang-tool-chain compile_native() failed with rc={rc} "
+                f"in {output_dir}; cannot resolve WASM native launchers"
+            )
+        missing = [name for name, p in binaries.items() if not p.exists()]
+        if missing:
+            raise RuntimeError(
+                f"clang-tool-chain compile_native() succeeded but expected "
+                f"binaries are missing in {output_dir}: {missing}. "
+                f"Ensure clang-tool-chain >=1.5.1 is installed."
+            )
+
+    return EmccNativeLaunchers(**{name: str(p) for name, p in binaries.items()})
+
+
+def resolve_wasm_native_entries(project_root: Path) -> WasmNativeEntries:
+    """
+    Resolve compiler/archiver entries for the Meson WASM cross-file.
+
+    Returns absolute paths to the seven compiled ctc-* native launchers.
+    No Python-wrapper fallback — if ``compile_native()`` fails or any
+    binary is missing, raises (clang-tool-chain >=1.5.1 is pinned and
+    guarantees all seven launchers).
+
+    Raises:
+        RuntimeError: if ``compile_native()`` fails or any binary is missing.
+    """
+    launchers = _ensure_emcc_native_launcher(project_root)
+    return WasmNativeEntries(
+        c=launchers.emcc,
+        cpp=launchers.empp,
+        ar=launchers.emar,
+        strip=launchers.emstrip,
+        ranlib=launchers.emranlib,
+        nm=launchers.emnm,
+        wasm_ld=launchers.wasm_ld,
+    )
+
+
+def _find_zccache_binary() -> Optional[str]:
+    """
+    Find the zccache binary for compiler caching.
+
+    zccache is a blazing-fast local compiler cache daemon (43x faster than
+    other caches on warm hits). It works as a drop-in compiler launcher prefix.
+
+    Search order:
+    1. Sibling zccache repo (../zccache/target/{release,debug}) — dev builds
+    2. PATH (via shutil.which)
+    3. Common cargo install locations
+
+    Returns:
+        Path to zccache binary, or None if not found.
+    """
+    suffix = (
+        ".exe"
+        if os.name == "nt" or sys.platform.startswith(("win", "msys", "cygwin"))
+        else ""
+    )
+
+    # Check project .venv first (installed release version)
+    repo_root = Path(__file__).resolve().parent.parent.parent  # ci/meson/ -> repo root
+    venv_candidate = (
+        repo_root
+        / ".venv"
+        / ("Scripts" if os.name == "nt" else "bin")
+        / f"zccache{suffix}"
+    )
+    if venv_candidate.is_file():
+        return str(venv_candidate)
+
+    # Check sibling zccache repo (pick most recently built binary)
+    sibling_zccache = repo_root.parent / "zccache"
+    best: Optional[Path] = None
+    best_mtime: float = 0
+    for profile in ("release", "debug"):
+        candidate = sibling_zccache / "target" / profile / f"zccache{suffix}"
+        if candidate.is_file():
+            mtime = candidate.stat().st_mtime
+            if mtime > best_mtime:
+                best = candidate
+                best_mtime = mtime
+    if best is not None:
+        return str(best)
+
+    # Check PATH
+    path_result = shutil.which("zccache")
+    if path_result:
+        return path_result
+
+    # Check common cargo bin locations
+    for candidate_home in [
+        os.environ.get("CARGO_HOME", ""),
+        os.path.join(os.path.expanduser("~"), ".cargo"),
+    ]:
+        if candidate_home:
+            candidate_path = os.path.join(candidate_home, "bin", f"zccache{suffix}")
+            if os.path.isfile(candidate_path):
+                return candidate_path
+
+    return None
+
+
+def get_zccache_version(zccache_path: Optional[str] = None) -> str:
+    """
+    Get zccache version string for cache invalidation.
+
+    When the zccache version changes, cached compilation artifacts may be
+    incompatible and require a full rebuild.
+
+    Args:
+        zccache_path: Path to zccache binary. If None, auto-detected.
+
+    Returns:
+        Version string (e.g., "zccache 1.0.3") or "" if not available.
+    """
+    if zccache_path is None:
+        zccache_path = _find_zccache_binary()
+    if not zccache_path:
+        return ""
+    try:
+        result = subprocess.run(
+            [zccache_path, "--version"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=10,
+        )
+        if result.returncode == 0:
+            return result.stdout.strip()
+        return ""
+    except KeyboardInterrupt as ki:
+        handle_keyboard_interrupt(ki)
+        raise
+    except Exception:
+        return ""
+
+
+def _resolve_fast_native_entries(
+    cache_binary: Optional[str],
+) -> FastNativeEntries:
+    """
+    Resolve native launcher binaries for the Meson native file.
+
+    Uses ctc-clang/ctc-clang++ native launchers which handle all platform-
+    specific flags automatically (--target, --sysroot, -stdlib, includes, etc.)
+    with near-zero startup overhead (~34ms vs ~1200ms for Python wrappers).
+
+    Args:
+        cache_binary: Path to compiler cache binary (zccache),
+            or None to disable caching.
+
+    Returns:
+        FastNativeEntries with cc, cxx, and ar entries for the native file,
+        or all-None fields if resolution fails (falls back to wrappers).
+    """
+    _none = FastNativeEntries(cc=None, cxx=None, ar=None)
+    try:
+        from clang_tool_chain.platform.paths import (
+            find_tool_binary,
+        )
+    except ImportError:
+        return _none
+
+    try:
+        ar_path = str(find_tool_binary("llvm-ar"))
+
+        project_root = Path(__file__).resolve().parent.parent.parent
+        ctc_c, ctc_cpp = _ensure_native_launcher(project_root)
+        if ctc_c is None or ctc_cpp is None:
+            return _none
+
+        def _make_entry(binary: str) -> str:
+            parts: list[str] = []
+            if cache_binary:
+                parts.append(f"'{cache_binary}'")
+            parts.append(f"'{binary}'")
+            return "[" + ", ".join(parts) + "]"
+
+        return FastNativeEntries(
+            cc=_make_entry(ctc_c),
+            cxx=_make_entry(ctc_cpp),
+            ar=f"['{ar_path}']",
+        )
+
+    except KeyboardInterrupt as ki:
+        handle_keyboard_interrupt(ki)
+        return _none  # unreachable, satisfies type checker
+    except Exception:
+        return _none
+
+
+def _resolve_fast_compiler_binary() -> Optional[str]:
+    """
+    Resolve raw clang++ binary path, bypassing the Python entry point wrapper.
+
+    The Python wrapper (clang-tool-chain-cpp.EXE) has ~3.6 second startup
+    overhead. Using the raw binary directly saves this overhead for operations
+    like --version checks.
+
+    Returns:
+        Path to raw clang++ binary, or None if resolution fails.
+    """
+    try:
+        from clang_tool_chain.platform.paths import find_tool_binary
+
+        return str(find_tool_binary("clang++"))
+    except KeyboardInterrupt as ki:
+        handle_keyboard_interrupt(ki)
+        return None  # unreachable, satisfies type checker
+    except Exception:
+        return None

--- a/ci/meson/path_normalization.py
+++ b/ci/meson/path_normalization.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+"""Path normalization and validation for zccache strict mode (issue #2378).
+
+Meson emits attached path-bearing compiler flags like ``-Ici/meson/native`` and
+``-I..\\..\\src``. ``ZCCACHE_STRICT_PATHS=absolute`` rejects any such flag that
+is not absolute, forward-slash, and free of ``.``/``..`` components. We rewrite
+them to canonical absolute forward-slash form in ``build.ninja`` and
+``compile_commands.json`` so cache hit rates stay high and CI fails fast on
+violations.
+
+Also exports the AR optimization status check used by the runner.
+"""
+# pyright: reportUnknownVariableType=false
+
+import json
+import re
+import sys
+from pathlib import Path
+from typing import cast
+
+from ci.util.timestamp_print import ts_print as _ts_print
+
+
+# Module-level cache for ar optimization status.
+# Populated by inject_ar_optimization_patches() to avoid repeated build.ninja reads.
+# Key: str(build_dir), Value: bool (True if both patches active)
+_ar_opt_status_cache: dict[str, bool] = {}
+
+
+# Path-bearing compiler flag prefixes that zccache strict path mode validates
+# (issue #2378). All accept an attached path (``-Idir``, ``-isystemdir``, ...)
+# as Meson always emits a single attached token per flag. Order matters: longer
+# prefixes must come first so the regex alternation matches the longest form
+# (``-include-pch`` before ``-include``).
+_STRICT_PATH_FLAG_PREFIXES: tuple[str, ...] = (
+    "-include-pch",
+    "-iframework",
+    "-idirafter",
+    "-isystem",
+    "-imacros",
+    "-include",
+    "-iquote",
+    "-imsvc",
+    "-I",
+    "-F",
+    "/I",
+)
+
+# Path char class excludes ``-`` as the FIRST character so the regex does not
+# mis-match the bare ``"-include-pch"`` token by falling back to the ``-include``
+# alternative + consuming ``-pch`` as the path. Real include paths never begin
+# with a hyphen.
+_STRICT_PATH_FLAG_RE = re.compile(
+    r'(?P<prefix>(?<!\S)"?(?:'
+    + "|".join(re.escape(p) for p in _STRICT_PATH_FLAG_PREFIXES)
+    + r'))(?P<path>[^\s"\-][^\s"]*)(?P<suffix>"?)'
+)
+
+
+def is_ar_content_preserving_active(build_dir: Path) -> bool:
+    """
+    Check if the content-preserving archive optimization is active in build.ninja.
+
+    Returns True if both patches are present:
+    - ar_content_preserving.py wrapper in the STATIC_LINKER command
+    - restat = 1 in the STATIC_LINKER rule
+
+    When this returns True, the BuildOptimizer's DLL fingerprinting is redundant:
+    - ar_content_preserving.py prevents the DLL relink cascade at the source
+    - BuildOptimizer.touch_dlls_if_lib_unchanged() (~5-6s) is no longer needed
+    - BuildOptimizer.save_fingerprints() (~5-6s) is no longer needed
+    - Skipping BuildOptimizer saves ~10-12 seconds per build
+
+    Performance: Uses a module-level cache populated by inject_ar_optimization_patches().
+    When inject_ar_optimization_patches() was called earlier in the same process
+    (which setup_meson_build() does), this function returns immediately from the cache
+    without reading build.ninja (~2ms saved per call).
+
+    Args:
+        build_dir: Meson build directory containing build.ninja
+
+    Returns:
+        True if both ar_content_preserving.py and restat=1 patches are active
+    """
+    # Fast path: check module-level cache populated by inject_ar_optimization_patches().
+    # In the normal code path, setup_meson_build() always calls that function first,
+    # so we get a cache hit here and avoid the build.ninja read (~2ms).
+    build_dir_key = str(build_dir)
+    if build_dir_key in _ar_opt_status_cache:
+        return _ar_opt_status_cache[build_dir_key]
+
+    # Cache miss: read build.ninja and check directly
+    build_ninja = build_dir / "build.ninja"
+    if not build_ninja.exists():
+        return False
+    try:
+        content = build_ninja.read_text(encoding="utf-8")
+        result = "ar_content_preserving.py" in content and "restat = 1" in content
+        _ar_opt_status_cache[build_dir_key] = result
+        return result
+    except OSError:
+        return False
+
+
+def _is_forward_slash_absolute(path: str) -> bool:
+    return path.startswith("/") or re.match(r"^[A-Za-z]:/", path) is not None
+
+
+def _has_dot_components(path: str) -> bool:
+    for part in path.split("/"):
+        if part in (".", ".."):
+            return True
+    return False
+
+
+def normalize_meson_private_include_paths(build_dir: Path) -> bool:
+    """Normalize Meson-emitted path flags for zccache strict path mode.
+
+    Issue #2378 — ``ZCCACHE_STRICT_PATHS=absolute`` rejects path-bearing
+    compiler flags (``-I``, ``-isystem``, ``-iquote``, ``-iframework``,
+    ``-idirafter``, ``-imsvc``, ``-include``, ``-include-pch``, ``-imacros``,
+    ``-F``, ``/I``) that are not absolute, forward-slash, and free of ``.``
+    or ``..`` components.
+
+    Meson emits attached single-token flags like ``"-Ici/meson/native"`` and
+    ``"-I..\\..\\src"`` from subdir and ``implicit_include_directories``
+    behavior; this function rewrites them to canonical absolute forward-slash
+    form in both ``build.ninja`` and ``compile_commands.json``.
+    """
+
+    changed_any = False
+
+    def _replacement(match: re.Match[str]) -> str:
+        prefix, raw_path, suffix = match.groups()
+        normalized = raw_path.replace("\\", "/")
+        if _is_forward_slash_absolute(normalized) and not _has_dot_components(
+            normalized
+        ):
+            absolute = normalized
+        else:
+            absolute = (build_dir / normalized).resolve().as_posix()
+        if absolute == raw_path:
+            return match.group(0)
+        return f"{prefix}{absolute}{suffix}"
+
+    def _normalize_text(content: str) -> str:
+        return _STRICT_PATH_FLAG_RE.sub(_replacement, content)
+
+    build_ninja = build_dir / "build.ninja"
+    if build_ninja.exists():
+        try:
+            content = build_ninja.read_text(encoding="utf-8")
+        except OSError as e:
+            raise RuntimeError(
+                f"Could not read {build_ninja} while normalizing Meson strict paths"
+            ) from e
+        else:
+            normalized = _normalize_text(content)
+            if normalized != content:
+                try:
+                    build_ninja.write_text(normalized, encoding="utf-8")
+                    changed_any = True
+                except OSError as e:
+                    raise RuntimeError(
+                        f"Could not write {build_ninja} after normalizing Meson strict paths"
+                    ) from e
+
+    compile_commands = build_dir / "compile_commands.json"
+    if compile_commands.exists():
+        try:
+            data = json.loads(compile_commands.read_text(encoding="utf-8"))
+        except OSError as e:
+            raise RuntimeError(
+                f"Could not read {compile_commands} while normalizing Meson strict paths"
+            ) from e
+        except json.JSONDecodeError as e:
+            raise RuntimeError(
+                f"Could not parse {compile_commands} while normalizing Meson strict paths"
+            ) from e
+        if isinstance(data, list):
+            changed_json = False
+            for entry in data:
+                if not isinstance(entry, dict):
+                    continue
+                entry_dict = cast(dict[str, object], entry)
+                command = entry_dict.get("command")
+                if not isinstance(command, str):
+                    continue
+                normalized = _normalize_text(command)
+                if normalized != command:
+                    entry_dict["command"] = normalized
+                    changed_json = True
+            if changed_json:
+                try:
+                    compile_commands.write_text(
+                        json.dumps(data, indent=2) + "\n",
+                        encoding="utf-8",
+                    )
+                    changed_any = True
+                except OSError as e:
+                    raise RuntimeError(
+                        f"Could not write {compile_commands} after normalizing Meson strict paths"
+                    ) from e
+
+    return changed_any
+
+
+def find_strict_path_violations(build_dir: Path) -> list[str]:
+    """Return human-readable strict-path violations in ``compile_commands.json``.
+
+    Issue #2378 — every ``-I`` / ``-isystem`` / ``-iquote`` / ``-iframework`` /
+    ``-idirafter`` / ``-imsvc`` / ``-include`` / ``-include-pch`` / ``-imacros``
+    / ``-F`` / ``/I`` path must be absolute, forward-slash, and free of ``.``
+    or ``..`` components. This is the same predicate enforced by
+    ``ZCCACHE_STRICT_PATHS=absolute`` at compile time; checking it ourselves
+    after meson setup lets us fail before ninja schedules any compile work.
+
+    Returns an empty list when the file is missing (a fresh tree) or clean.
+    """
+    cc_json = build_dir / "compile_commands.json"
+    if not cc_json.exists():
+        return []
+    try:
+        data = json.loads(cc_json.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return []
+    if not isinstance(data, list):
+        return []
+
+    violations: list[str] = []
+    for entry in data:
+        if not isinstance(entry, dict):
+            continue
+        entry_dict = cast(dict[str, object], entry)
+        command = entry_dict.get("command")
+        if not isinstance(command, str):
+            continue
+        for match in _STRICT_PATH_FLAG_RE.finditer(command):
+            raw = match.group("path")
+            normalized = raw.replace("\\", "/")
+            if "\\" in raw:
+                violations.append(f"{match.group('prefix').lstrip(chr(34))}{raw}")
+                continue
+            if not _is_forward_slash_absolute(normalized):
+                violations.append(f"{match.group('prefix').lstrip(chr(34))}{raw}")
+                continue
+            if _has_dot_components(normalized):
+                violations.append(f"{match.group('prefix').lstrip(chr(34))}{raw}")
+    return violations
+
+
+def _enforce_strict_path_violations(build_dir: Path) -> None:
+    """Raise loudly when ``compile_commands.json`` still has strict-path offenders.
+
+    The normalizer above is meant to leave no offenders behind; this is the
+    fail-fast guard for issue #2378's "validation step that checks generated
+    compile commands before CI compiles". Any violation here is a bug in the
+    normalizer or a new Meson code-path that emits unnormalized flags.
+    """
+    violations = find_strict_path_violations(build_dir)
+    if not violations:
+        return
+
+    sample = violations[:10]
+    extra = len(violations) - len(sample)
+    lines = [
+        f"[MESON] ZCCACHE_STRICT_PATHS=absolute would reject {len(violations)}"
+        " compile flag(s) in compile_commands.json (issue #2378):",
+    ]
+    lines.extend(f"  {flag}" for flag in sample)
+    if extra > 0:
+        lines.append(f"  ... {extra} more")
+    message = "\n".join(lines)
+    _ts_print(message, file=sys.stderr)
+    raise RuntimeError(message)

--- a/ci/meson/runner.py
+++ b/ci/meson/runner.py
@@ -1,457 +1,104 @@
 #!/usr/bin/env python3
-"""Meson build system runner for FastLED tests."""
+"""Meson build system runner for FastLED tests.
+
+This module is the top-level orchestrator. The execution paths and helpers
+have been split into focused modules:
+
+- ``ci.meson.runner_helpers``: timing aggregation, stale-build recovery,
+  build-dir cleanup with locked-file handling, failure-log writers, and
+  zccache session bootstrap.
+- ``ci.meson.streaming_runner``: parallel compile + execute path.
+- ``ci.meson.sequential_runner``: per-target compile + direct executable
+  invocation path used for single-test runs.
+
+This file owns the entry point ``run_meson_build_and_test`` and the CLI.
+"""
 
 import argparse
 import glob
 import os
-import re
-import shutil
-import subprocess
 import sys
-import threading
 import time
-import uuid
 from pathlib import Path
-from typing import Optional, cast
-
-from running_process import RunningProcess
+from typing import Optional
 
 from ci.meson.build_config import (
-    _find_zccache_binary,
-    cleanup_build_artifacts,
     perform_ninja_maintenance,
     setup_meson_build,
 )
 from ci.meson.build_optimizer import make_build_optimizer
 from ci.meson.build_timer import BuildTimer
-from ci.meson.cache_utils import save_test_result_state
-from ci.meson.compile import (
-    CompileResult,
-    _is_compilation_error,
-    compile_meson,
-    is_stale_build_error,
-)
-from ci.meson.compiler import check_meson_installed, get_meson_executable
-from ci.meson.output import print_banner, print_error, print_info, print_success
+from ci.meson.compiler import check_meson_installed
 from ci.meson.phase_tracker import PhaseTracker
-from ci.meson.streaming import StreamingResult, TestResult, stream_compile_and_run_tests
-from ci.meson.test_discovery import get_fuzzy_test_candidates
+from ci.meson.runner_helpers import _safe_rmtree, _start_zccache_session
+from ci.meson.sequential_runner import (
+    DirectTestContext,
+    SequentialCompileContext,
+    run_direct_test,
+    run_sequential_compile,
+)
+from ci.meson.streaming_runner import StreamingContext, run_streaming_path
 from ci.meson.test_execution import MesonTestResult, run_meson_test
 from ci.util.build_lock import libfastled_build_lock
-from ci.util.global_interrupt_handler import handle_keyboard_interrupt
-from ci.util.output_formatter import TimestampFormatter
 from ci.util.timestamp_print import ts_print as _ts_print
 
 
-def _apply_phase_timing(
-    result: MesonTestResult, build_timer: BuildTimer
-) -> MesonTestResult:
-    """Apply phase timing data from BuildTimer to MesonTestResult."""
-    build_timer.calculate_phases()
-    result.meson_setup_time = build_timer.meson_setup_time
-    result.ninja_maintenance_time = build_timer.ninja_maintenance_time
-    result.compile_time = build_timer.compile_time
-    result.test_execution_time = build_timer.test_execution_time
-    return result
+def _setup_sanitizer_env(source_dir: Path, verbose: bool) -> None:
+    """Configure ASan/LSan options for debug builds via clang-tool-chain."""
+    from clang_tool_chain import (
+        prepare_sanitizer_environment,  # noqa: PLC0415 - lazy: ~60ms on non-debug
+    )
 
+    sanitizer_flags = ["-fsanitize=address"]
+    sanitizer_env = prepare_sanitizer_environment(
+        base_env=os.environ.copy(),
+        compiler_flags=sanitizer_flags,
+    )
+    os.environ.update(sanitizer_env)
 
-def _apply_compile_sub_phases(
-    result: MesonTestResult, sub_phases: dict[str, float]
-) -> None:
-    """Calculate compile sub-phase durations from timestamps and set on result."""
-    if not sub_phases:
-        return
-
-    compile_start = sub_phases.get("compile_start")
-    core_done = sub_phases.get("core_done")
-    example_link_start = sub_phases.get("example_link_start")
-    test_link_start = sub_phases.get("test_link_start")
-    compile_done = sub_phases.get("compile_done")
-
-    if compile_start and core_done:
-        result.compile_core_time = core_done - compile_start
-    if core_done and compile_done:
-        # Object compilation = time between core_done and whichever linking starts first
-        link_start = None
-        if example_link_start and test_link_start:
-            link_start = min(example_link_start, test_link_start)
-        elif example_link_start:
-            link_start = example_link_start
-        elif test_link_start:
-            link_start = test_link_start
-
-        if link_start:
-            result.compile_objects_time = link_start - core_done
+    lsan_suppressions = source_dir / "tests" / "lsan_suppressions.txt"
+    if lsan_suppressions.exists():
+        existing_lsan = os.environ.get("LSAN_OPTIONS", "")
+        suppression_opt = f"suppressions={lsan_suppressions}"
+        if existing_lsan:
+            os.environ["LSAN_OPTIONS"] = f"{existing_lsan}:{suppression_opt}"
         else:
-            # No linking phases detected — all time after core is object compilation
-            result.compile_objects_time = compile_done - core_done
+            os.environ["LSAN_OPTIONS"] = suppression_opt
 
-    if example_link_start and compile_done:
-        # Example linking = from example_link_start to test_link_start (or compile_done)
-        end = test_link_start if test_link_start else compile_done
-        result.compile_example_link_time = end - example_link_start
-    if test_link_start and compile_done:
-        result.compile_test_link_time = compile_done - test_link_start
+    if verbose:
+        symbolizer_path = sanitizer_env.get("ASAN_SYMBOLIZER_PATH")
+        if symbolizer_path:
+            _ts_print(f"[MESON] Set ASAN_SYMBOLIZER_PATH={symbolizer_path}")
 
 
-def _recover_stale_build(
-    source_dir: Path,
-    build_dir: Path,
-    debug: bool,
-    check: bool,
-    build_mode: str,
-    verbose: bool,
-    enable_examples: bool = True,
-) -> bool:
+def _resolve_test_name_candidates(
+    build_dir: Path, test_name: str
+) -> tuple[str, str, list[str]]:
+    """Compute (primary, fallback, fuzzy) candidate names for a requested test.
+
+    The primary is the most specific guess; the fallback is the next-best
+    guess; the fuzzy list comes from globbing build_dir/tests/ for partial
+    matches. Each is matched against meson target names later.
     """
-    Attempt to recover from a stale build state.
-
-    This is called when compilation fails due to missing/renamed/deleted files.
-    It cleans stale Ninja deps, clears metadata caches, and forces Meson
-    reconfiguration so the next compilation attempt has a fresh build graph.
-
-    Args:
-        source_dir: Project root directory
-        build_dir: Meson build directory
-        debug: Debug mode flag
-        check: IWYU check flag
-        build_mode: Build mode string
-        verbose: Verbose output flag
-
-    Returns:
-        True if recovery setup succeeded (caller should retry compilation),
-        False if recovery failed
-    """
-    _ts_print("=" * 80)
-    _ts_print("[MESON] 🔧 SELF-HEALING: Stale build state detected - auto-recovering")
-    _ts_print("=" * 80)
-    _ts_print("[MESON] This typically happens when files are renamed or deleted.")
-    _ts_print("[MESON] Cleaning stale dependencies and reconfiguring...")
-
-    try:
-        # Step 1: Clean stale ninja deps using ninja -t cleandead
-        ninja_exe = shutil.which("ninja") or str(
-            Path(sys.prefix) / "Scripts" / "ninja.EXE"
-        )
-        try:
-            result = subprocess.run(
-                [ninja_exe, "-C", str(build_dir), "-t", "cleandead"],
-                capture_output=True,
-                text=True,
-                timeout=60,
-            )
-            if result.returncode == 0:
-                _ts_print(
-                    f"[MESON] 🗑️  Cleaned stale Ninja outputs: {result.stdout.strip()}"
-                )
-        except KeyboardInterrupt as ki:
-            handle_keyboard_interrupt(ki)
-            raise
-        except Exception as e:
-            _ts_print(f"[MESON] Warning: ninja cleandead failed: {e}")
-
-        # Step 2: Delete .ninja_deps to force full dependency re-scan
-        ninja_deps = build_dir / ".ninja_deps"
-        if ninja_deps.exists():
-            try:
-                ninja_deps.unlink()
-                _ts_print("[MESON] 🗑️  Deleted stale .ninja_deps")
-            except OSError as e:
-                _ts_print(f"[MESON] Warning: Could not delete .ninja_deps: {e}")
-
-        # Step 3: Clear metadata caches
-        cache_files = [
-            build_dir / "src_metadata.cache",
-            build_dir / "test_list_cache.txt",
-            build_dir / ".source_files_hash",
-            build_dir / "tests" / "test_metadata.cache",
-            build_dir / "example_metadata.cache",
-        ]
-        for cache_file in cache_files:
-            if cache_file.exists():
-                try:
-                    cache_file.unlink()
-                    _ts_print(f"[MESON] 🗑️  Deleted cache: {cache_file.name}")
-                except OSError as e:
-                    _ts_print(
-                        f"[MESON] Warning: Could not delete {cache_file.name}: {e}"
-                    )
-
-        # Step 4: Clean build artifacts (stale .obj files referencing old headers)
-        cleanup_build_artifacts(build_dir, "Stale build recovery")
-
-        # Step 5: Force Meson reconfiguration
-        _ts_print("[MESON] 🔄 Forcing Meson reconfiguration...")
-        success = setup_meson_build(
-            source_dir,
-            build_dir,
-            reconfigure=True,
-            debug=debug,
-            check=check,
-            build_mode=build_mode,
-            verbose=verbose,
-            enable_examples=enable_examples,
-            enable_unit_tests=True,
-        )
-
-        if success:
-            _ts_print("[MESON] ✅ Self-healing reconfiguration complete")
-            _ts_print("[MESON] 🔄 Retrying compilation...")
-        else:
-            _ts_print("[MESON] ❌ Self-healing reconfiguration failed")
-
-        return success
-
-    except KeyboardInterrupt as ki:
-        handle_keyboard_interrupt(ki)
-        raise
-    except Exception as e:
-        _ts_print(f"[MESON] ❌ Self-healing failed with exception: {e}")
-        return False
-
-
-def _purge_trash(trash_dir: Path) -> None:
-    """Purge unlocked files from .trash directory."""
-    if not trash_dir.exists():
-        return
-    for item in list(trash_dir.iterdir()):
-        try:
-            if item.is_file():
-                item.unlink()
-            elif item.is_dir():
-                shutil.rmtree(item)
-        except PermissionError:
-            pass  # Still locked, skip
-
-
-def _kill_zombie_zccache(build_dir: Path) -> None:
-    """Kill zccache processes whose CWD is inside build_dir.
-
-    When ninja is interrupted, zccache.exe wrappers can survive because they
-    communicate through a daemon and are not direct children of ninja. Their
-    CWD remains set to the build directory, which on Windows holds a kernel
-    handle that prevents directory deletion.
-    """
-    if sys.platform != "win32":
-        return
-    try:
-        import psutil  # noqa: PLC0415 - lazy import, only needed on Windows cleanup
-    except ImportError:
-        return
-    build_str = str(build_dir.resolve())
-    killed = 0
-    for proc in psutil.process_iter(["pid", "name"]):
-        try:
-            name = proc.info["name"] or ""
-            if "zccache" not in name.lower() or "daemon" in name.lower():
-                continue
-            cwd = proc.cwd()
-            if cwd and (cwd == build_str or cwd.startswith(build_str + os.sep)):
-                proc.kill()
-                killed += 1
-        except (psutil.NoSuchProcess, psutil.AccessDenied, OSError):
-            continue
-    if killed:
-        _ts_print(
-            f"[MESON] 🧹 Killed {killed} zombie zccache process(es) holding build directory"
-        )
-        time.sleep(0.5)  # Brief wait for Windows to release handles
-
-
-def _safe_rmtree(build_dir: Path) -> None:
-    """Remove build directory, relocating locked files to .trash/ for later cleanup."""
-    # Kill zombie zccache processes that may hold CWD handles on the build dir
-    _kill_zombie_zccache(build_dir)
-
-    trash_dir = build_dir.parent / ".trash"
-    # Purge any previously trashed files that are now unlocked
-    _purge_trash(trash_dir)
-
-    locked_files: list[str] = []
-
-    def _on_exc(func, path, exc):  # noqa: ARG001
-        """Handle locked files by renaming them into .trash/."""
-        p = Path(path)
-        trash_dir.mkdir(parents=True, exist_ok=True)
-        trash_name = f"{uuid.uuid4().hex[:8]}-{p.name}"
-        trash_path = trash_dir / trash_name
-        try:
-            p.rename(trash_path)
-            locked_files.append(p.name)
-        except (PermissionError, OSError):
-            locked_files.append(f"{p.name} (unmovable)")
-
-    if sys.version_info >= (3, 12):
-        shutil.rmtree(build_dir, onexc=_on_exc)
+    test_name_lower = test_name.lower()
+    if test_name_lower.startswith("test_"):
+        meson_test_name = test_name_lower
+        fallback_test_name = test_name_lower[5:]
     else:
-        shutil.rmtree(build_dir, onerror=lambda f, p, e: _on_exc(f, p, e[1]))
+        meson_test_name = f"test_{test_name_lower}"
+        fallback_test_name = test_name_lower
 
-    # If the directory still exists (some files couldn't be moved), try once more
-    if build_dir.exists():
-        try:
-            shutil.rmtree(build_dir)
-        except OSError:
-            _ts_print(f"[MESON] ⚠️  Some locked files moved to {trash_dir}")
-            for name in locked_files:
-                _ts_print(f"  - {name}")
+    fuzzy_candidates: list[str] = []
+    tests_dir = build_dir / "tests"
+    if tests_dir.exists():
+        exe_pattern = f"*{test_name_lower}*.exe"
+        matches = glob.glob(str(tests_dir / exe_pattern))
+        for match_path in matches:
+            exe_name = Path(match_path).stem
+            if exe_name not in [meson_test_name, fallback_test_name]:
+                fuzzy_candidates.append(exe_name)
 
-
-def _write_failure_log(
-    log_dir: Optional[Path], name: str, suffix: str, content: str
-) -> None:
-    """Write a failure log file to the log_failures directory.
-
-    Args:
-        log_dir: Directory to write to (None = no-op)
-        name: Test name (will be sanitized for filename)
-        suffix: 'compile' or 'run'
-        content: Log content
-    """
-    if log_dir is None:
-        return
-    log_dir.mkdir(parents=True, exist_ok=True)
-    safe_name = name.replace(":", "_").replace("/", "_").replace("\\", "_")
-    log_path = log_dir / f"{safe_name}_{suffix}.log"
-    with open(log_path, "w", encoding="utf-8", errors="replace") as f:
-        f.write(content)
-
-
-def _extract_compile_failures(compile_output: str) -> dict[str, str]:
-    """Extract per-target compilation failures from ninja output.
-
-    Parses FAILED: lines to identify which targets had errors and collects
-    the associated error output. Handles timestamped output (e.g., "7.59 FAILED: ...")
-    and [code=N] prefixes.
-
-    Returns:
-        Dict mapping target name to error output text.
-    """
-    failures: dict[str, str] = {}
-    lines = compile_output.splitlines()
-    i = 0
-    while i < len(lines):
-        line = lines[i]
-        if "FAILED:" in line:
-            # Extract target name from path like "tests/fl_async.dll.p/fl/async.cpp.o"
-            target = line.split("FAILED:", 1)[1].strip()
-            # Strip optional [code=N] prefix
-            target = re.sub(r"^\[code=\d+\]\s*", "", target)
-            m = re.match(r"tests[/\\]([^.]+)\.", target)
-            test_name = m.group(1) if m else "unknown"
-
-            # Collect error lines until next FAILED or ninja stop
-            error_lines = [line]
-            i += 1
-            while i < len(lines):
-                if "FAILED:" in lines[i] or (
-                    "ninja:" in lines[i] and "build stopped" in lines[i]
-                ):
-                    break
-                error_lines.append(lines[i])
-                i += 1
-
-            existing = failures.get(test_name, "")
-            failures[test_name] = existing + "\n".join(error_lines) + "\n"
-        else:
-            i += 1
-
-    return failures
-
-
-def _write_testlog_failures(build_dir: Path, log_dir: Path) -> None:
-    """Parse testlog.txt and write per-test failure logs.
-
-    Args:
-        build_dir: Meson build directory (contains meson-logs/testlog.txt)
-        log_dir: Directory to write failure logs to
-    """
-    from ci.meson.testlog_parser import parse_testlog
-
-    testlog = build_dir / "meson-logs" / "testlog.txt"
-    entries = parse_testlog(testlog)
-    for entry in entries:
-        if "exit status 0" in entry.result:
-            continue
-        content = f"# Test: {entry.test_name}\n"
-        content += f"# Result: {entry.result}\n"
-        content += f"# Duration: {entry.duration}\n\n"
-        if entry.stdout:
-            content += "--- stdout ---\n" + entry.stdout + "\n\n"
-        if entry.stderr:
-            content += "--- stderr ---\n" + entry.stderr + "\n"
-        safe_name = entry.test_name.replace(":", "_").replace("/", "_")
-        _write_failure_log(log_dir, safe_name, "run", content)
-
-
-def _start_zccache_session(build_dir: Path) -> None:
-    """Start a zccache session with logging to the build directory.
-
-    Sets ZCCACHE_SESSION_ID in os.environ so all subsequent compiler
-    invocations through zccache use this session and get logged.
-    The session auto-cleans up via PID monitoring when the process exits.
-
-    Also sets ZCCACHE_LINK_DEPLOY_CMD so zccache invokes
-    `clang-tool-chain-libdeploy` after each cache-miss link. This
-    materializes runtime DLLs next to the linked binary (on Windows
-    these otherwise don't get deployed because the native ctc-clang++
-    trampoline skips Python post-link hooks) and lets zccache's
-    side-effect scanner bundle them into the cached artifact set —
-    fixing flaky error-126 DLL load failures under parallel test
-    execution. See https://github.com/FastLED/FastLED/issues/2329.
-    """
-    # Set the deploy hook regardless of zccache binary availability —
-    # zccache reads it from client env if set, and it's a no-op otherwise.
-    if "ZCCACHE_LINK_DEPLOY_CMD" not in os.environ:
-        os.environ["ZCCACHE_LINK_DEPLOY_CMD"] = "clang-tool-chain-libdeploy"
-    os.environ.setdefault("ZCCACHE_STRICT_PATHS", "absolute")
-
-    zccache_bin = _find_zccache_binary()
-    if not zccache_bin:
-        return
-
-    # Log file goes in the build directory
-    build_dir.mkdir(parents=True, exist_ok=True)
-    log_path = build_dir / "zccache-session.log"
-    journal_path = build_dir / "zccache-session.jsonl"
-
-    try:
-        result = subprocess.run(
-            [
-                zccache_bin,
-                "session-start",
-                "--stats",
-                "--log",
-                str(log_path),
-                "--journal",
-                str(journal_path),
-            ],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-        if result.returncode == 0:
-            import json
-            import re
-
-            output = result.stdout.strip()
-            try:
-                data = json.loads(output)
-                session_id = str(data["session_id"])
-            except (json.JSONDecodeError, KeyError):
-                # Windows paths with backslashes break json.loads.
-                # Extract session_id with regex as fallback.
-                m = re.search(r'"session_id"\s*:\s*"([^"]+)"', output)
-                if m:
-                    session_id = m.group(1)
-                else:
-                    session_id = output
-            os.environ["ZCCACHE_SESSION_ID"] = session_id
-            _ts_print(f"[ZCCACHE] Session {session_id} started, log: {log_path}")
-    except KeyboardInterrupt as ki:
-        handle_keyboard_interrupt(ki)
-        raise
-    except Exception:
-        pass  # Non-fatal — build proceeds without session logging
+    return meson_test_name, fallback_test_name, fuzzy_candidates
 
 
 def run_meson_build_and_test(
@@ -487,16 +134,12 @@ def run_meson_build_and_test(
         MesonTestResult with success status, duration, and test counts
     """
     start_time = time.time()
-
-    # Initialize build timer for phase tracking
     build_timer = BuildTimer()
     build_timer.start()
 
-    # Determine build mode: explicit build_mode parameter takes precedence over debug flag
     if build_mode is None:
         build_mode = "debug" if debug else "quick"
 
-    # Validate build_mode
     if build_mode not in ["quick", "debug", "release", "profile"]:
         _ts_print(
             f"[MESON] Error: Invalid build_mode '{build_mode}'. Must be 'quick', 'debug', 'release', or 'profile'",
@@ -510,16 +153,10 @@ def run_meson_build_and_test(
             num_tests_failed=0,
         )
 
-    # Construct mode-specific build directory
-    # This enables caching libfastled.a per mode when source unchanged but flags differ
-    # Example: .build/meson-quick, .build/meson-debug, .build/meson-release
-    original_build_dir = build_dir
+    # Mode-specific build dir lets libfastled.a cache per mode when source is
+    # unchanged but compiler flags differ (e.g. .build/meson-quick vs ...-debug).
     build_dir = build_dir.parent / f"{build_dir.name}-{build_mode}"
 
-    # Build dir and mode info is consolidated in setup_meson_build output
-    # No need for separate verbose messages here
-
-    # Check if Meson is installed
     if not check_meson_installed():
         _ts_print("[MESON] Error: Meson build system is not installed", file=sys.stderr)
         _ts_print("[MESON] Install with: pip install meson ninja", file=sys.stderr)
@@ -531,68 +168,23 @@ def run_meson_build_and_test(
             num_tests_failed=0,
         )
 
-    # Clean if requested
     if clean and build_dir.exists():
         _ts_print(f"[MESON] Cleaning build directory: {build_dir}")
         _safe_rmtree(build_dir)
 
-    # Setup build
-    # Pass debug=True when build_mode is "debug" to enable sanitizers and full symbols
-    # Also pass explicit build_mode to ensure proper cache invalidation on mode changes
     use_debug = build_mode == "debug"
-
-    # Configure ASan/LSan options for debug mode using clang-tool-chain's API
-    # This automatically:
-    # - Sets ASAN_OPTIONS with optimal settings (fast_unwind_on_malloc=0:symbolize=1)
-    # - Sets LSAN_OPTIONS with optimal settings
-    # - Sets ASAN_SYMBOLIZER_PATH to llvm-symbolizer from clang-tool-chain
-    # The API only injects settings when sanitizers are detected in compiler flags
     if use_debug:
-        # Get sanitizer-configured environment from clang-tool-chain
-        # Pass compiler flags so the API knows sanitizers are active
-        from clang_tool_chain import (
-            prepare_sanitizer_environment,  # noqa: PLC0415 - lazy: ~60ms saved on non-debug paths
-        )
-
-        sanitizer_flags = ["-fsanitize=address"]
-        sanitizer_env = prepare_sanitizer_environment(
-            base_env=os.environ.copy(),
-            compiler_flags=sanitizer_flags,
-        )
-        # Update current environment with sanitizer settings
-        os.environ.update(sanitizer_env)
-
-        # Add LSAN suppression file for known false positives (pthread library leaks)
-        lsan_suppressions = source_dir / "tests" / "lsan_suppressions.txt"
-        if lsan_suppressions.exists():
-            existing_lsan = os.environ.get("LSAN_OPTIONS", "")
-            suppression_opt = f"suppressions={lsan_suppressions}"
-            if existing_lsan:
-                os.environ["LSAN_OPTIONS"] = f"{existing_lsan}:{suppression_opt}"
-            else:
-                os.environ["LSAN_OPTIONS"] = suppression_opt
-
-        if verbose:
-            symbolizer_path = sanitizer_env.get("ASAN_SYMBOLIZER_PATH")
-            if symbolizer_path:
-                _ts_print(f"[MESON] Set ASAN_SYMBOLIZER_PATH={symbolizer_path}")
+        _setup_sanitizer_env(source_dir, verbose)
 
     _ts_print(f"Preparing build ({build_mode} mode)...")
-
-    # Start a zccache session so all compiler invocations are logged
     _start_zccache_session(build_dir)
 
-    # Initialize phase tracker for error diagnostics
     phase_tracker = PhaseTracker(build_dir, build_mode)
     phase_tracker.set_phase("CONFIGURE")
 
-    # Always configure Meson with examples enabled to avoid expensive
-    # reconfigure (~9s) when switching between unit-only and full modes.
-    # Example exclusion is handled at compile time (target selection) and
-    # test time (suite filtering via exclude_suites), not at configure time.
-
+    # Always configure with examples enabled — example exclusion is handled at
+    # compile-time (target selection) + test-time (suite filter), not configure-time.
     _ts_print("[MESON] Configuring build (compiler probes may take 20-30s)...")
-
     if not setup_meson_build(
         source_dir,
         build_dir,
@@ -612,639 +204,63 @@ def run_meson_build_and_test(
             num_tests_failed=0,
         )
 
-    # Checkpoint: Meson configuration complete
     build_timer.checkpoint("meson_setup_done")
-
-    # Perform periodic maintenance on Ninja dependency database (once per day)
-    # This helps prevent .ninja_deps corruption and keeps builds fast
     perform_ninja_maintenance(build_dir)
-
-    # Checkpoint: Ninja maintenance complete
     build_timer.checkpoint("ninja_maintenance_done")
 
-    # Note: PCH dependency tracking is handled automatically by Ninja via depfiles.
-    # The compile_pch.py wrapper ensures depfiles reference the .pch output correctly,
-    # and Ninja loads these dependencies into .ninja_deps database (897 headers tracked).
-    # No manual staleness checking needed - Ninja rebuilds PCH when any dependency changes.
-
-    # Convert test name to executable name (convert to lowercase to match Meson target naming)
-    # Support both test_*.exe and *.exe naming patterns with fallback
-    # Try test_<name> first (for tests like test_async.cpp), then fallback to <name> (for async.cpp)
+    # Resolve test name candidates (only when a specific test was requested).
     meson_test_name: Optional[str] = None
     fallback_test_name: Optional[str] = None
     fuzzy_candidates: list[str] = []
     if test_name:
-        # Convert to lowercase to match Meson target naming convention
-        test_name_lower = test_name.lower()
+        meson_test_name, fallback_test_name, fuzzy_candidates = (
+            _resolve_test_name_candidates(build_dir, test_name)
+        )
 
-        # Check if test name already starts with "test_"
-        if test_name_lower.startswith("test_"):
-            # Already has test_ prefix, try as-is first, then without prefix as fallback
-            meson_test_name = test_name_lower
-            # Fallback: strip test_ prefix to try bare name
-            fallback_test_name = test_name_lower[5:]  # Remove "test_" prefix
-        else:
-            # Try with test_ prefix first, then fallback to without prefix
-            meson_test_name = f"test_{test_name_lower}"
-            fallback_test_name = test_name_lower
-
-        # Build fuzzy candidate list using meson introspect after setup
-        # This handles patterns like fl_async.exe when user specifies "async"
-        # Note: We'll populate this after meson setup, since introspect requires
-        # a configured build directory
-        # For now, try legacy file-based approach as fallback
-        tests_dir = build_dir / "tests"
-        if tests_dir.exists():
-            # Look for executables matching *<name>*
-            exe_pattern = f"*{test_name_lower}*.exe"
-            matches = glob.glob(str(tests_dir / exe_pattern))
-            # Extract just the executable name without path and extension
-            for match_path in matches:
-                exe_name = Path(match_path).stem  # Remove .exe extension
-                # Add to candidates if not already in primary/fallback
-                if exe_name not in [meson_test_name, fallback_test_name]:
-                    fuzzy_candidates.append(exe_name)
-
-    # Compile and test with build lock to prevent conflicts with example builds
-    # STREAMING MODE: When no specific test requested, use stream_compile_and_run_tests()
-    # for parallel compilation + execution
     use_streaming = not meson_test_name
-
-    # Create build optimizer for DLL relink suppression via binary fingerprinting.
-    # Only used in streaming mode (all-tests run), where the 328-DLL relink cascade
-    # from zccache mtime updates causes the biggest performance penalty.
+    # BuildOptimizer suppresses the 328-DLL relink cascade; only worth it for
+    # the streaming all-tests path, where the cascade hurts most.
     build_optimizer = make_build_optimizer(build_dir) if use_streaming else None
 
     try:
-        with libfastled_build_lock():  # uses LOCK_TIMEOUT_S default
+        with libfastled_build_lock():
             if use_streaming:
-                # STREAMING EXECUTION PATH
-                # Compile and run tests in parallel - as soon as a test finishes linking,
-                # it's immediately executed while other tests continue compiling
-                if verbose:
-                    _ts_print(
-                        "[MESON] Using streaming execution (compile + test in parallel)"
-                    )
-
-                # Dict to capture per-test output for failure logging
-                _failed_test_outputs: dict[str, str] = {}
-
-                # Create test callback for streaming execution
-                # Prepare environment with fastled shared lib dir on PATH
-                _streaming_env = os.environ.copy()
-                _fastled_lib_dir = str(build_dir / "ci" / "meson" / "native")
-                if os.name == "nt":
-                    # Add fastled.dll dir + clang toolchain runtime dirs
-                    # (libwinpthread-1.dll etc.) so DLLs load without MSYS2
-                    from clang_tool_chain import get_runtime_dll_paths
-
-                    _extra_dirs = os.pathsep.join(
-                        [_fastled_lib_dir] + get_runtime_dll_paths()
-                    )
-                    _streaming_env["PATH"] = (
-                        _extra_dirs + os.pathsep + _streaming_env.get("PATH", "")
-                    )
-                else:
-                    _streaming_env["LD_LIBRARY_PATH"] = (
-                        _fastled_lib_dir
-                        + os.pathsep
-                        + _streaming_env.get("LD_LIBRARY_PATH", "")
-                    )
-
-                # Lock for thread-safe writes to _failed_test_outputs from
-                # parallel worker threads.
-                _failed_outputs_lock = threading.Lock()
-
-                # Track running subprocesses so they can be killed on halt.
-                _active_procs: set[RunningProcess] = set()
-                _active_procs_lock = threading.Lock()
-
-                def test_callback(test_path: Path) -> TestResult:
-                    """Run a single test executable and return TestResult.
-
-                    Output is always captured silently (echo=False) so that the
-                    caller can print it sequentially on the main thread, avoiding
-                    interleaved output when tests run in parallel.
-                    """
-                    try:
-                        # Handle shared library tests (.dll/.so/.dylib): use runner to load them
-                        if test_path.suffix.lower() in (".dll", ".so", ".dylib"):
-                            runner_suffix = ".exe" if os.name == "nt" else ""
-                            if test_path.parent.name == "tests":
-                                runner = build_dir / "tests" / f"runner{runner_suffix}"
-                            else:
-                                runner = (
-                                    build_dir
-                                    / "examples"
-                                    / f"example_runner{runner_suffix}"
-                                )
-                            if not runner.exists():
-                                return TestResult(
-                                    success=False,
-                                    output=f"[MESON] ⚠️  Runner not found: {runner}",
-                                )
-                            cmd = [str(runner), str(test_path)]
-                        else:
-                            cmd = [str(test_path)]
-
-                        # Inject test file filter into subprocess env if the
-                        # streaming layer attached one (os.environ was already
-                        # copied into _streaming_env before the filter was set).
-                        env = _streaming_env
-                        file_filter = getattr(test_callback, "_test_file_filter", None)
-                        if file_filter:
-                            env = dict(_streaming_env)
-                            env["FL_TEST_FILE_FILTER"] = file_filter
-
-                        # Use environment with fastled shared lib dir and ASAN_OPTIONS
-                        proc = RunningProcess(
-                            cmd,
-                            cwd=source_dir,  # Run from project root
-                            timeout=600,  # 10 minute timeout per test
-                            auto_run=True,
-                            check=False,
-                            env=env,
-                            output_formatter=TimestampFormatter(),
-                        )
-
-                        # Register so the process can be killed on halt.
-                        with _active_procs_lock:
-                            _active_procs.add(proc)
-                        try:
-                            # Always capture silently — caller prints sequentially
-                            returncode = proc.wait(echo=False)
-                        finally:
-                            with _active_procs_lock:
-                                _active_procs.discard(proc)
-                        captured = str(proc.stdout)
-
-                        # Enhanced error detection for streaming tests
-                        if returncode != 0:
-                            # Store output for end-of-run failure summary
-                            with _failed_outputs_lock:
-                                _failed_test_outputs[test_path.stem] = captured
-
-                        return TestResult(success=returncode == 0, output=captured)
-
-                    except KeyboardInterrupt as ki:
-                        handle_keyboard_interrupt(ki)
-                        return TestResult(
-                            success=False,
-                            output="[MESON] Test interrupted by user",
-                        )
-                    except Exception as e:
-                        return TestResult(
-                            success=False,
-                            output=f"[MESON] Test execution error: {e}",
-                        )
-
-                def _kill_active_procs() -> None:
-                    """Kill all running test subprocesses (called on halt)."""
-                    with _active_procs_lock:
-                        for p in list(_active_procs):
-                            try:
-                                p.kill()
-                            except KeyboardInterrupt as ki:
-                                handle_keyboard_interrupt(ki)
-                            except Exception:
-                                pass
-
-                setattr(test_callback, "kill_all", _kill_active_procs)
-
-                # Determine compile timeout based on build mode
-                # Debug builds with ASAN are significantly slower, especially on Windows CI
-                # Default: 10 minutes (600s), Debug: 45 minutes (2700s)
-                compile_timeout = 2700 if use_debug else 600
-
-                # Determine compile target: build everything (tests + examples) in
-                # a single Ninja invocation when examples are included, or just
-                # default targets (unit tests only) when examples are excluded.
-                include_examples = not (
-                    exclude_suites and "fastled:examples" in exclude_suites
-                )
-                compile_target = "all-with-examples" if include_examples else None
-
-                # PROACTIVE CHECK: Verify the all-with-examples target exists
-                # in build.ninja before trying to compile it. The marker file
-                # (.enable_examples_config) can get desynchronized from the
-                # actual build configuration, causing "target not found" errors.
-                if compile_target == "all-with-examples":
-                    build_ninja = build_dir / "build.ninja"
-                    if build_ninja.exists():
-                        try:
-                            content = build_ninja.read_text(encoding="utf-8")
-                            if "all-with-examples" not in content:
-                                _ts_print(
-                                    "[MESON] ⚠️  Target 'all-with-examples' missing from build.ninja"
-                                )
-                                _ts_print(
-                                    "[MESON] 🔄 Forcing reconfiguration with enable_examples=true..."
-                                )
-                                setup_meson_build(
-                                    source_dir,
-                                    build_dir,
-                                    reconfigure=True,
-                                    debug=use_debug,
-                                    check=check,
-                                    build_mode=build_mode,
-                                    verbose=verbose,
-                                    enable_examples=True,
-                                    enable_unit_tests=True,
-                                )
-                        except (OSError, IOError):
-                            pass  # If we can't read it, let compilation try and fail
-
-                # Run streaming compilation and testing
-                sr = stream_compile_and_run_tests(
+                ctx = StreamingContext(
+                    source_dir=source_dir,
                     build_dir=build_dir,
-                    test_callback=test_callback,
-                    target=compile_target,
+                    use_debug=use_debug,
+                    check=check,
+                    build_mode=build_mode,
                     verbose=verbose,
-                    compile_timeout=compile_timeout,
-                    build_optimizer=build_optimizer,
+                    exclude_suites=exclude_suites,
                     test_file_filter=test_file_filter,
+                    log_failures=log_failures,
+                    start_time=start_time,
                     build_timer=build_timer,
+                    build_optimizer=build_optimizer,
                 )
+                return run_streaming_path(ctx)
 
-                # SELF-HEALING: If compilation failed due to stale build state,
-                # recover and retry once
-                if not sr.success and is_stale_build_error(sr.compile_output):
-                    if _recover_stale_build(
-                        source_dir,
-                        build_dir,
-                        use_debug,
-                        check,
-                        build_mode,
-                        verbose,
-                        enable_examples=True,
-                    ):
-                        # Retry compilation after recovery
-                        sr = stream_compile_and_run_tests(
-                            build_dir=build_dir,
-                            test_callback=test_callback,
-                            target=compile_target,
-                            verbose=verbose,
-                            compile_timeout=compile_timeout,
-                            build_optimizer=build_optimizer,
-                            test_file_filter=test_file_filter,
-                            build_timer=build_timer,
-                        )
+            seq_ctx = SequentialCompileContext(
+                source_dir=source_dir,
+                build_dir=build_dir,
+                build_mode=build_mode,
+                verbose=verbose,
+                test_name=test_name,
+                meson_test_name=meson_test_name,
+                fallback_test_name=fallback_test_name,
+                fuzzy_candidates=fuzzy_candidates,
+                log_failures=log_failures,
+                start_time=start_time,
+                build_timer=build_timer,
+                phase_tracker=phase_tracker,
+            )
+            compile_outcome = run_sequential_compile(seq_ctx)
+            if not compile_outcome.success:
+                assert compile_outcome.error_result is not None
+                return compile_outcome.error_result
+            meson_test_name = compile_outcome.meson_test_name
 
-                # Save binary fingerprints of libfastled.a and all DLLs after a
-                # successful build so future runs can suppress unnecessary relinking.
-                if sr.success and build_optimizer is not None:
-                    build_optimizer.save_fingerprints(build_dir)
-
-                duration = time.time() - start_time
-                num_tests_run = sr.num_passed + sr.num_failed
-
-                # FALLBACK: If no tests were run during streaming (e.g., everything already compiled),
-                # fall back to running all tests via Meson test runner
-                # Show simplified message instead of detailed "0/0" breakdown
-                if num_tests_run == 0 and sr.success:
-                    if verbose:
-                        print_info(
-                            "[MESON] Build up-to-date, running existing tests..."
-                        )
-                    # Record compile_done before test fallback
-                    build_timer.checkpoint("compile_done")
-
-                    # Note: run_meson_test already prints the RUNNING TESTS banner
-                    result = run_meson_test(
-                        build_dir,
-                        test_name=None,
-                        verbose=verbose,
-                        exclude_suites=exclude_suites,
-                    )
-
-                    # Propagate full timing into result so the summary table
-                    # shows setup/compile/test phases instead of just test duration
-                    build_timer.checkpoint("test_execution_done")
-                    build_timer.calculate_phases()
-                    test_only_duration = result.duration
-                    result.duration = time.time() - start_time
-                    result.meson_setup_time = build_timer.meson_setup_time
-                    result.ninja_maintenance_time = build_timer.ninja_maintenance_time
-                    result.compile_time = build_timer.compile_time
-                    result.test_execution_time = test_only_duration
-
-                    # Calculate compile sub-phase durations from timestamps
-                    _apply_compile_sub_phases(result, sr.compile_sub_phases)
-                    # Write per-test failure logs from testlog.txt
-                    if not result.success and log_failures is not None:
-                        _write_testlog_failures(build_dir, log_failures)
-                    return result
-
-                if not sr.success:
-                    print_error(
-                        f"[MESON] ❌ Some tests failed ({sr.num_passed}/{num_tests_run} tests in {duration:.2f}s)"
-                    )
-                    # Snapshot under lock — workers may still be running
-                    # after executor.shutdown(wait=False).
-                    with _failed_outputs_lock:
-                        _failed_snapshot = dict(_failed_test_outputs)
-
-                    # Print captured error outputs to console
-                    if _failed_snapshot:
-                        print_error(f"\n{'=' * 80}")
-                        print_error(
-                            f"[MESON] Test failure details ({len(_failed_snapshot)} tests):"
-                        )
-                        print_error(f"{'=' * 80}")
-                        for tname, output in _failed_snapshot.items():
-                            print_error(f"\n--- {tname} ---")
-                            for line in output.splitlines()[-30:]:
-                                print_error(f"  {line}")
-                        print_error(f"{'=' * 80}")
-                    # Write failure logs
-                    if log_failures is not None:
-                        if num_tests_run == 0:
-                            # Compilation failed (no tests ran) — write per-target compile logs
-                            per_target = _extract_compile_failures(sr.compile_output)
-                            if per_target:
-                                for tname, output in per_target.items():
-                                    _write_failure_log(
-                                        log_failures, tname, "compile", output
-                                    )
-                            else:
-                                # Couldn't parse per-target; write full output
-                                _write_failure_log(
-                                    log_failures,
-                                    "compile",
-                                    "compile",
-                                    sr.compile_output,
-                                )
-                        else:
-                            # Tests ran and some failed — write per-test run logs
-                            for tname, output in _failed_snapshot.items():
-                                _write_failure_log(log_failures, tname, "run", output)
-                    return MesonTestResult(
-                        success=False,
-                        duration=duration,
-                        num_tests_run=num_tests_run,
-                        num_tests_passed=sr.num_passed,
-                        num_tests_failed=sr.num_failed,
-                        failed_test_names=sr.failed_names,
-                    )
-
-                # Print timing breakdown
-                _ts_print(build_timer.format_table())
-
-                print_success(
-                    f"✅ All tests passed ({sr.num_passed}/{num_tests_run} in {duration:.2f}s)"
-                )
-                result = MesonTestResult(
-                    success=True,
-                    duration=duration,
-                    num_tests_run=num_tests_run,
-                    num_tests_passed=sr.num_passed,
-                    num_tests_failed=sr.num_failed,
-                )
-                result = _apply_phase_timing(result, build_timer)
-                _apply_compile_sub_phases(result, sr.compile_sub_phases)
-                return result
-
-            else:
-                # TRADITIONAL SEQUENTIAL PATH
-                # Used for specific test requests
-                compile_target: Optional[str] = None
-                if meson_test_name:
-                    compile_target = meson_test_name
-
-                # Try target resolution with fallback - suppress all output during discovery
-                # to avoid confusing users with internal target name guessing
-                targets_to_try = [compile_target]
-                if fallback_test_name and fallback_test_name != compile_target:
-                    targets_to_try.append(fallback_test_name)
-
-                # Build the full list of candidates up front so we can try quietly
-                if test_name:
-                    # Get fuzzy candidates early
-                    fuzzy_candidates = (
-                        get_fuzzy_test_candidates(build_dir, test_name)
-                        if not fuzzy_candidates
-                        else fuzzy_candidates
-                    )
-                    # Add fuzzy candidates not already in the list
-                    for c in fuzzy_candidates:
-                        if c not in targets_to_try:
-                            targets_to_try.append(c)
-
-                # Add path-qualified variants for disambiguation.
-                # Meson supports "subdir/target" format to resolve ambiguous names
-                # (e.g., "tests/fastled" disambiguates from the library "fastled").
-                path_qualified: list[str] = []
-                for candidate in targets_to_try:
-                    if candidate and "/" not in candidate:
-                        # Try tests/<name> and tests/profile/<name>
-                        for prefix in ["tests/", "tests/profile/"]:
-                            qualified = f"{prefix}{candidate}"
-                            if (
-                                qualified not in targets_to_try
-                                and qualified not in path_qualified
-                            ):
-                                path_qualified.append(qualified)
-                targets_to_try.extend(path_qualified)
-
-                # Show build stage banner before compilation starts
-                # WARNING: This build progress reporting is essential for user feedback!
-                #   Do NOT suppress this message - it provides:
-                #   1. Build mode visibility (quick/debug/release)
-                #   2. Stage progression (users know compilation has started)
-                #   3. Context for subsequent build messages (libraries, PCH, tests)
-                _ts_print(f"[BUILD] Building FastLED engine ({build_mode} mode)...")
-
-                # When there are multiple candidates, run all in quiet mode
-                # Only show banner once with final resolved target
-                has_fallbacks = len(targets_to_try) > 1
-                compilation_success = False
-                successful_target: Optional[str] = None
-                last_error_output: str = ""
-                last_result: Optional[CompileResult] = (
-                    None  # Track last result for error reporting
-                )
-                all_suppressed_errors: list[
-                    str
-                ] = []  # Collect validation errors from all attempts
-
-                for candidate in targets_to_try:
-                    # Track compilation phase for error diagnostics
-                    phase_tracker.set_phase(
-                        "COMPILE",
-                        test_name=test_name,
-                        target=candidate,
-                        path="sequential",
-                    )
-
-                    # Use quiet mode when there are fallbacks (suppress failure noise)
-                    result = compile_meson(
-                        build_dir,
-                        target=candidate,
-                        quiet=has_fallbacks,
-                        verbose=verbose,
-                    )
-                    last_result = result  # Save for error reporting
-                    compilation_success = result.success
-                    if compilation_success:
-                        # Track link phase for successful compilation
-                        phase_tracker.set_phase(
-                            "LINK",
-                            test_name=test_name,
-                            target=candidate,
-                            path="sequential",
-                        )
-
-                        successful_target = candidate
-                        compile_target = candidate
-                        # Strip path prefix for executable lookup: meson_test_name is used
-                        # to find binaries in build_dir/tests/, so "tests/fastled" → "fastled"
-                        meson_test_name = (
-                            candidate.removeprefix("tests/") if candidate else candidate
-                        )
-                        break
-                    last_error_output = result.error_output
-                    # Collect suppressed validation errors (capped at 5 per attempt)
-                    all_suppressed_errors.extend(result.suppressed_errors)
-
-                # Checkpoint: Compilation complete (successful or not)
-                build_timer.checkpoint("compile_done")
-
-                # Show the final result after target resolution
-                if compilation_success and has_fallbacks:
-                    print_banner("Compile", "📦", verbose=verbose)
-                    print(f"Compiling: {successful_target}")
-                    # Note: Don't print "Compilation successful" - redundant before Running phase
-
-                if not compilation_success:
-                    # SMART ERROR DETECTION: Check for saved compilation error
-                    last_error_file = (
-                        build_dir.parent / "meson-state" / "last-compilation-error.txt"
-                    )
-                    phase_data = phase_tracker.get_phase()
-                    phase_name = (
-                        phase_data.get("phase", "COMPILE") if phase_data else "COMPILE"
-                    )
-
-                    # Display header with phase context
-                    print_error(f"\n[MESON] ❌ Build FAILED during {phase_name} phase")
-                    print_error("=" * 80)
-
-                    # Always show full log path prominently if available
-                    if last_result and last_result.error_log_file:
-                        print_error(f"[MESON] 📄 Full compilation log:")
-                        print_error(f"[MESON]    {last_result.error_log_file}")
-                        print_error("")
-
-                    # Try to show error snippet from saved file or directly from log
-                    error_snippet_shown = False
-
-                    if last_error_file.exists():
-                        # Show saved error snippet with metadata
-                        with open(last_error_file, "r", encoding="utf-8") as f:
-                            error_context = f.read()
-                            # Print with error line highlighting
-                            for line in error_context.splitlines():
-                                if _is_compilation_error(line):
-                                    print_error(f"\033[91m{line}\033[0m")  # Red
-                                else:
-                                    print_error(line)
-                        error_snippet_shown = True
-
-                    elif (
-                        last_result
-                        and last_result.error_log_file
-                        and last_result.error_log_file.exists()
-                    ):
-                        # Fallback: read last 50 error lines directly from log file
-                        print_error("[MESON] 🔍 Error excerpt from compilation log:")
-                        print_error("")
-                        try:
-                            with open(
-                                last_result.error_log_file, "r", encoding="utf-8"
-                            ) as f:
-                                log_lines = f.readlines()
-                                # Find error lines and show context
-                                error_lines = [
-                                    (i, line.rstrip())
-                                    for i, line in enumerate(log_lines)
-                                    if _is_compilation_error(line)
-                                ]
-                                if error_lines:
-                                    # Show last error with context (up to 10 lines)
-                                    last_error_idx = error_lines[-1][0]
-                                    start_idx = max(0, last_error_idx - 5)
-                                    end_idx = min(len(log_lines), last_error_idx + 5)
-                                    for line in log_lines[start_idx:end_idx]:
-                                        line = line.rstrip()
-                                        if _is_compilation_error(line):
-                                            print_error(f"\033[91m{line}\033[0m")  # Red
-                                        else:
-                                            print_error(line)
-                                    error_snippet_shown = True
-                        except KeyboardInterrupt as ki:
-                            handle_keyboard_interrupt(ki)
-                            raise
-                        except Exception as e:
-                            print_error(f"[MESON] ⚠️  Could not read error log: {e}")
-
-                    if error_snippet_shown:
-                        print_error("=" * 80)
-                    else:
-                        # No error snippet available - show legacy diagnostics
-                        # SELF-HEALING DIAGNOSTICS: Show validation errors that were suppressed during fallback
-                        if all_suppressed_errors:
-                            print_error(
-                                "[MESON] Self-healing triggered - showing suppressed validation errors:"
-                            )
-                            for err in all_suppressed_errors[
-                                :5
-                            ]:  # Cap at 5 total (already capped per-attempt)
-                                print_error(f"  {err}")
-                            print_error("")
-
-                        # Print diagnostic: show what was tried and why it failed
-                        print_error(
-                            f"[MESON] Compilation failed for test '{test_name}'"
-                        )
-                        if has_fallbacks:
-                            tried = ", ".join(str(t) for t in targets_to_try)
-                            print_error(f"[MESON] Tried targets: {tried}")
-                        # Show the last meson error if it's informative (e.g., ambiguous target)
-                        if last_error_output:
-                            for line in last_error_output.splitlines():
-                                if "ERROR:" in line or "Can't invoke target" in line:
-                                    print_error(f"[MESON] {line.strip()}")
-                                    break
-                        print_error("=" * 80)
-
-                    # Write compilation failure log
-                    if log_failures is not None:
-                        compile_content = last_error_output
-                        if (
-                            last_result
-                            and last_result.error_log_file
-                            and last_result.error_log_file.exists()
-                        ):
-                            try:
-                                compile_content = last_result.error_log_file.read_text(
-                                    encoding="utf-8", errors="replace"
-                                )
-                            except OSError:
-                                pass
-                        _write_failure_log(
-                            log_failures,
-                            test_name or "unknown",
-                            "compile",
-                            compile_content,
-                        )
-
-                    return MesonTestResult(
-                        success=False,
-                        duration=time.time() - start_time,
-                        num_tests_run=0,
-                        num_tests_passed=0,
-                        num_tests_failed=0,
-                    )
     except TimeoutError as e:
         _ts_print(f"[MESON] {e}", file=sys.stderr)
         return MesonTestResult(
@@ -1255,8 +271,7 @@ def run_meson_build_and_test(
             num_tests_failed=0,
         )
 
-    # In IWYU check mode, we only compile (to run static analysis)
-    # Skip test execution and return success after successful compilation
+    # IWYU check mode only compiles for static analysis; skip test execution.
     if check:
         duration = time.time() - start_time
         _ts_print(
@@ -1270,305 +285,24 @@ def run_meson_build_and_test(
             num_tests_failed=0,
         )
 
-    # Run tests (traditional path only - streaming already ran tests above)
-    # When a specific test is requested, run the executable directly
-    # to avoid meson test discovery issues
     if meson_test_name:
-        # Find the test executable or DLL
-        # Tests can be either:
-        # 1. A copied runner .exe (e.g., fl_async.exe) - legacy naming
-        # 2. A DLL loaded by the shared runner.exe (e.g., fl_fixed_point_s16x16.dll)
-        # 3. A profile test in tests/profile/ subdirectory
-        test_cmd: list[str] = []
-        _artifact_path: Optional[Path] = None  # Tracked for test_result_cache update
-
-        # Check for profile tests (in tests/profile/ subdirectory)
-        # Profile tests can have any name (not just profile_* prefix)
-        profile_exe_path = build_dir / "tests" / "profile" / f"{meson_test_name}.exe"
-        if profile_exe_path.exists():
-            test_cmd = [str(profile_exe_path)]
-            _artifact_path = profile_exe_path
-        else:
-            # Try Unix variant (no .exe extension)
-            profile_exe_unix = build_dir / "tests" / "profile" / meson_test_name
-            if profile_exe_unix.exists():
-                test_cmd = [str(profile_exe_unix)]
-                _artifact_path = profile_exe_unix
-
-        # If not a profile test, check standard locations
-        if not test_cmd:
-            test_exe_path = build_dir / "tests" / f"{meson_test_name}.exe"
-            if test_exe_path.exists():
-                # Found copied runner .exe (may be a copy of runner.exe that auto-loads the DLL)
-                test_cmd = [str(test_exe_path)]
-                # Prefer DLL as artifact_path: DLL changes with test code; .exe is a runner copy
-                _dll_candidate = build_dir / "tests" / f"{meson_test_name}.dll"
-                _artifact_path = (
-                    _dll_candidate if _dll_candidate.exists() else test_exe_path
-                )
-
-        if not test_cmd:
-            # Try Unix variant (no .exe extension)
-            test_exe_unix = build_dir / "tests" / meson_test_name
-            if test_exe_unix.exists():
-                test_cmd = [str(test_exe_unix)]
-                _artifact_path = test_exe_unix
-            else:
-                # Try DLL-based test architecture: runner + test.dll/.so/.dylib
-                # On Windows: runner.exe + test.dll
-                # On Linux: runner + test.so
-                # On macOS: runner + test.dylib
-                runner_name = "runner.exe" if os.name == "nt" else "runner"
-                runner_exe = build_dir / "tests" / runner_name
-
-                if not runner_exe.exists():
-                    # Try compiling the runner target
-                    _runner_result = compile_meson(
-                        build_dir, target="runner", quiet=True, verbose=verbose
-                    )
-
-                if runner_exe.exists():
-                    # Try each shared library extension
-                    for ext in (".dll", ".so", ".dylib"):
-                        candidate = build_dir / "tests" / f"{meson_test_name}{ext}"
-                        if candidate.exists():
-                            test_cmd = [str(runner_exe), str(candidate)]
-                            _artifact_path = candidate
-                            break
-
-        if not test_cmd:
-            _ts_print(
-                f"[MESON] Error: test executable not found for: {meson_test_name}",
-                file=sys.stderr,
+        return run_direct_test(
+            DirectTestContext(
+                source_dir=source_dir,
+                build_dir=build_dir,
+                meson_test_name=meson_test_name,
+                build_mode=build_mode,
+                verbose=verbose,
+                log_failures=log_failures,
+                start_time=start_time,
+                build_timer=build_timer,
+                phase_tracker=phase_tracker,
             )
-            return MesonTestResult(
-                success=False,
-                duration=time.time() - start_time,
-                num_tests_run=0,
-                num_tests_passed=0,
-                num_tests_failed=0,
-            )
-
-        print_banner("Test", "▶️", verbose=verbose)
-        print(f"Running: {meson_test_name}")
-
-        # Track execution phase for error diagnostics
-        phase_tracker.set_phase("EXECUTE", test_name=meson_test_name, path="sequential")
-
-        # Run the test executable directly
-        try:
-            # Ensure fastled shared library is discoverable at runtime
-            test_env = os.environ.copy()
-            fastled_lib_dir = str(build_dir / "ci" / "meson" / "native")
-            if os.name == "nt":
-                from clang_tool_chain import get_runtime_dll_paths
-
-                _extra = os.pathsep.join([fastled_lib_dir] + get_runtime_dll_paths())
-                test_env["PATH"] = _extra + os.pathsep + test_env.get("PATH", "")
-            else:
-                test_env["LD_LIBRARY_PATH"] = (
-                    fastled_lib_dir + os.pathsep + test_env.get("LD_LIBRARY_PATH", "")
-                )
-            # Set runner watchdog timeout to match meson slow test timeout (60s)
-            if "FASTLED_TEST_TIMEOUT" not in test_env:
-                test_env["FASTLED_TEST_TIMEOUT"] = "60"
-            # Disable crash handler in debug mode on Windows - ASAN's vectored
-            # exception handler conflicts with our crash handler (causes deadlock)
-            if build_mode == "debug" and os.name == "nt":
-                test_env["FASTLED_DISABLE_CRASH_HANDLER"] = "1"
-            proc = RunningProcess(
-                test_cmd,
-                cwd=source_dir,  # Run from project root
-                timeout=600,  # 10 minute timeout
-                auto_run=True,
-                check=False,
-                env=test_env,
-                output_formatter=TimestampFormatter(),
-            )
-
-            # Profile tests always echo output (they produce benchmark reports)
-            # Regular tests only echo in verbose mode
-            is_profile_test = _artifact_path and "profile" in str(_artifact_path)
-            echo_callback = verbose or is_profile_test
-            test_start = time.time()
-            returncode = cast(int, proc.wait(echo=bool(echo_callback)))
-            test_duration = time.time() - test_start
-            duration = time.time() - start_time
-
-            # Checkpoint: Test execution complete
-            build_timer.checkpoint("test_execution_done")
-
-            if returncode != 0:
-                # Phase-aware error message
-                phase_data = phase_tracker.get_phase()
-
-                if phase_data and phase_data["phase"] == "EXECUTE":
-                    print_error(
-                        f"[MESON] ❌ Test FAILED during execution (exit code {returncode})"
-                    )
-                    print_error(f"[MESON] Test: {meson_test_name}")
-
-                    # Write test output to error log file (for ALL failures)
-                    compile_errors_dir = build_dir.parent / "compile-errors"
-                    compile_errors_dir.mkdir(exist_ok=True)
-                    test_name_slug = meson_test_name.replace("test_", "").replace(
-                        "/", "_"
-                    )
-                    error_log_path = compile_errors_dir / f"{test_name_slug}.log"
-
-                    with open(error_log_path, "w", encoding="utf-8") as f:
-                        f.write(f"# Test: {meson_test_name}\n")
-                        f.write(f"# Exit code: {returncode}\n")
-                        f.write(f"# Full test output below:\n\n")
-                        f.write("--- Test Output ---\n\n")
-                        f.write(str(proc.stdout))
-
-                    print_error(f"[MESON] 📄 Full test output: {error_log_path}")
-
-                    # Enhanced crash detection: Check if doctest actually ran
-                    # Doctest prints patterns like "test cases:", "assertions:", "[doctest]"
-                    stdout_lower = str(proc.stdout).lower()
-                    has_doctest_output = any(
-                        pattern in stdout_lower
-                        for pattern in [
-                            "test cases:",
-                            "assertions:",
-                            "[doctest]",
-                            "test case failed",
-                        ]
-                    )
-
-                    has_watchdog_timeout = (
-                        "internal timeout watchdog triggered" in stdout_lower
-                    )
-
-                    if returncode == 1 and not proc.stdout.strip():
-                        # No output at all - immediate crash
-                        print_error(f"[MESON] ⚠️  No output - possible crash at startup")
-                    elif (
-                        returncode == 1
-                        and has_watchdog_timeout
-                        and not has_doctest_output
-                    ):
-                        # Watchdog killed the process before doctest ran
-                        print_error(
-                            f"[MESON] ⚠️  Test killed by internal timeout watchdog (exceeded time limit)"
-                        )
-                        print_error(
-                            f"[MESON] 💡 This is a timeout, not a crash. Consider adding to slow_tests in tests/meson.build"
-                        )
-                    elif returncode == 1 and not has_doctest_output:
-                        # Has output but no doctest execution - initialization failure
-                        print_error(
-                            f"[MESON] ⚠️  Test failed during initialization (before doctest ran)"
-                        )
-
-                        # Filter stderr/stdout for error messages (case insensitive)
-                        error_lines = [
-                            line.strip()
-                            for line in str(proc.stdout).splitlines()
-                            if "error" in line.lower() and line.strip()
-                        ]
-
-                        if error_lines:
-                            print_error(f"[MESON] 🔍 Error messages found in output:")
-                            # Show up to 10 error lines
-                            for error_line in error_lines[:10]:
-                                print_error(f"[MESON]    {error_line}")
-                            if len(error_lines) > 10:
-                                print_error(
-                                    f"[MESON]    ... ({len(error_lines) - 10} more error(s))"
-                                )
-
-                        print_error(f"[MESON] 💡 Possible causes:")
-                        print_error(
-                            f"[MESON]    - Static initialization failure (global object constructor crash)"
-                        )
-                        print_error(
-                            f"[MESON]    - Test registration issue (FL_TEST_CASE macro problem)"
-                        )
-                        print_error(
-                            f"[MESON]    - DLL loading failure (missing dependency or symbol)"
-                        )
-                        print_error(
-                            f"[MESON]    - All test cases disabled with #if 0 (check test file)"
-                        )
-                else:
-                    phase_name = (
-                        phase_data.get("phase", "UNKNOWN") if phase_data else "UNKNOWN"
-                    )
-                    print_error(
-                        f"[MESON] ❌ Build FAILED during {phase_name} phase (exit code {returncode})"
-                    )
-
-                # Show test output for failures (even if not verbose)
-                if not verbose and proc.stdout:
-                    print_error("[MESON] Test output:")
-                    for line in str(proc.stdout).splitlines()[-50:]:  # Last 50 lines
-                        _ts_print(f"  {line}")
-                if _artifact_path is not None:
-                    save_test_result_state(
-                        build_dir, meson_test_name, _artifact_path, passed=False
-                    )
-                # Write test run failure log
-                if log_failures is not None and meson_test_name:
-                    _write_failure_log(
-                        log_failures, meson_test_name, "run", str(proc.stdout)
-                    )
-                return MesonTestResult(
-                    success=False,
-                    duration=duration,
-                    num_tests_run=1,
-                    num_tests_passed=0,
-                    num_tests_failed=1,
-                    failed_test_names=[meson_test_name] if meson_test_name else [],
-                )
-
-            # Clear phase tracking on success
-            phase_tracker.clear()
-
-            if _artifact_path is not None:
-                save_test_result_state(
-                    build_dir, meson_test_name, _artifact_path, passed=True
-                )
-            build_duration = duration - test_duration
-
-            # Print timing breakdown
-            _ts_print(build_timer.format_table())
-
-            print_success(
-                f"✅ All tests passed (1/1 in {test_duration:.2f}s, build: {build_duration:.1f}s)"
-            )
-            result = MesonTestResult(
-                success=True,
-                duration=duration,
-                num_tests_run=1,
-                num_tests_passed=1,
-                num_tests_failed=0,
-            )
-            return _apply_phase_timing(result, build_timer)
-
-        except KeyboardInterrupt as ki:
-            handle_keyboard_interrupt(ki)
-            raise
-        except Exception as e:
-            duration = time.time() - start_time
-            _ts_print(
-                f"[MESON] Test execution failed with exception: {e}",
-                file=sys.stderr,
-            )
-            return MesonTestResult(
-                success=False,
-                duration=duration,
-                num_tests_run=1,
-                num_tests_passed=0,
-                num_tests_failed=1,
-            )
-    else:
-        # No specific test - use Meson's test runner for all tests
-        return run_meson_test(
-            build_dir, test_name=None, verbose=verbose, exclude_suites=exclude_suites
         )
+
+    return run_meson_test(
+        build_dir, test_name=None, verbose=verbose, exclude_suites=exclude_suites
+    )
 
 
 def main() -> None:

--- a/ci/meson/runner_helpers.py
+++ b/ci/meson/runner_helpers.py
@@ -1,0 +1,422 @@
+#!/usr/bin/env python3
+"""Helper functions for the Meson build runner.
+
+Extracted from ``ci/meson/runner.py`` to keep the main orchestrator under
+1000 LOC. Includes timing aggregation, stale-build recovery, build-dir
+cleanup with locked-file handling, failure-log writers, and zccache session
+bootstrap.
+"""
+
+import os
+import re
+import shutil
+import subprocess
+import sys
+import time
+import uuid
+from pathlib import Path
+from typing import Optional
+
+from ci.meson.build_config import cleanup_build_artifacts, setup_meson_build
+from ci.meson.build_timer import BuildTimer
+from ci.meson.native_launchers import _find_zccache_binary
+from ci.meson.test_execution import MesonTestResult
+from ci.util.global_interrupt_handler import handle_keyboard_interrupt
+from ci.util.timestamp_print import ts_print as _ts_print
+
+
+def _apply_phase_timing(
+    result: MesonTestResult, build_timer: BuildTimer
+) -> MesonTestResult:
+    """Apply phase timing data from BuildTimer to MesonTestResult."""
+    build_timer.calculate_phases()
+    result.meson_setup_time = build_timer.meson_setup_time
+    result.ninja_maintenance_time = build_timer.ninja_maintenance_time
+    result.compile_time = build_timer.compile_time
+    result.test_execution_time = build_timer.test_execution_time
+    return result
+
+
+def _apply_compile_sub_phases(
+    result: MesonTestResult, sub_phases: dict[str, float]
+) -> None:
+    """Calculate compile sub-phase durations from timestamps and set on result."""
+    if not sub_phases:
+        return
+
+    compile_start = sub_phases.get("compile_start")
+    core_done = sub_phases.get("core_done")
+    example_link_start = sub_phases.get("example_link_start")
+    test_link_start = sub_phases.get("test_link_start")
+    compile_done = sub_phases.get("compile_done")
+
+    if compile_start and core_done:
+        result.compile_core_time = core_done - compile_start
+    if core_done and compile_done:
+        link_start = None
+        if example_link_start and test_link_start:
+            link_start = min(example_link_start, test_link_start)
+        elif example_link_start:
+            link_start = example_link_start
+        elif test_link_start:
+            link_start = test_link_start
+
+        if link_start:
+            result.compile_objects_time = link_start - core_done
+        else:
+            result.compile_objects_time = compile_done - core_done
+
+    if example_link_start and compile_done:
+        end = test_link_start if test_link_start else compile_done
+        result.compile_example_link_time = end - example_link_start
+    if test_link_start and compile_done:
+        result.compile_test_link_time = compile_done - test_link_start
+
+
+def _recover_stale_build(
+    source_dir: Path,
+    build_dir: Path,
+    debug: bool,
+    check: bool,
+    build_mode: str,
+    verbose: bool,
+    enable_examples: bool = True,
+) -> bool:
+    """
+    Attempt to recover from a stale build state.
+
+    This is called when compilation fails due to missing/renamed/deleted files.
+    It cleans stale Ninja deps, clears metadata caches, and forces Meson
+    reconfiguration so the next compilation attempt has a fresh build graph.
+
+    Args:
+        source_dir: Project root directory
+        build_dir: Meson build directory
+        debug: Debug mode flag
+        check: IWYU check flag
+        build_mode: Build mode string
+        verbose: Verbose output flag
+
+    Returns:
+        True if recovery setup succeeded (caller should retry compilation),
+        False if recovery failed
+    """
+    _ts_print("=" * 80)
+    _ts_print("[MESON] 🔧 SELF-HEALING: Stale build state detected - auto-recovering")
+    _ts_print("=" * 80)
+    _ts_print("[MESON] This typically happens when files are renamed or deleted.")
+    _ts_print("[MESON] Cleaning stale dependencies and reconfiguring...")
+
+    try:
+        # Step 1: Clean stale ninja deps using ninja -t cleandead
+        ninja_exe = shutil.which("ninja") or str(
+            Path(sys.prefix) / "Scripts" / "ninja.EXE"
+        )
+        try:
+            result = subprocess.run(
+                [ninja_exe, "-C", str(build_dir), "-t", "cleandead"],
+                capture_output=True,
+                text=True,
+                timeout=60,
+            )
+            if result.returncode == 0:
+                _ts_print(
+                    f"[MESON] 🗑️  Cleaned stale Ninja outputs: {result.stdout.strip()}"
+                )
+        except KeyboardInterrupt as ki:
+            handle_keyboard_interrupt(ki)
+            raise
+        except Exception as e:
+            _ts_print(f"[MESON] Warning: ninja cleandead failed: {e}")
+
+        # Step 2: Delete .ninja_deps to force full dependency re-scan
+        ninja_deps = build_dir / ".ninja_deps"
+        if ninja_deps.exists():
+            try:
+                ninja_deps.unlink()
+                _ts_print("[MESON] 🗑️  Deleted stale .ninja_deps")
+            except OSError as e:
+                _ts_print(f"[MESON] Warning: Could not delete .ninja_deps: {e}")
+
+        # Step 3: Clear metadata caches
+        cache_files = [
+            build_dir / "src_metadata.cache",
+            build_dir / "test_list_cache.txt",
+            build_dir / ".source_files_hash",
+            build_dir / "tests" / "test_metadata.cache",
+            build_dir / "example_metadata.cache",
+        ]
+        for cache_file in cache_files:
+            if cache_file.exists():
+                try:
+                    cache_file.unlink()
+                    _ts_print(f"[MESON] 🗑️  Deleted cache: {cache_file.name}")
+                except OSError as e:
+                    _ts_print(
+                        f"[MESON] Warning: Could not delete {cache_file.name}: {e}"
+                    )
+
+        # Step 4: Clean build artifacts (stale .obj files referencing old headers)
+        cleanup_build_artifacts(build_dir, "Stale build recovery")
+
+        # Step 5: Force Meson reconfiguration
+        _ts_print("[MESON] 🔄 Forcing Meson reconfiguration...")
+        success = setup_meson_build(
+            source_dir,
+            build_dir,
+            reconfigure=True,
+            debug=debug,
+            check=check,
+            build_mode=build_mode,
+            verbose=verbose,
+            enable_examples=enable_examples,
+            enable_unit_tests=True,
+        )
+
+        if success:
+            _ts_print("[MESON] ✅ Self-healing reconfiguration complete")
+            _ts_print("[MESON] 🔄 Retrying compilation...")
+        else:
+            _ts_print("[MESON] ❌ Self-healing reconfiguration failed")
+
+        return success
+
+    except KeyboardInterrupt as ki:
+        handle_keyboard_interrupt(ki)
+        raise
+    except Exception as e:
+        _ts_print(f"[MESON] ❌ Self-healing failed with exception: {e}")
+        return False
+
+
+def _purge_trash(trash_dir: Path) -> None:
+    """Purge unlocked files from .trash directory."""
+    if not trash_dir.exists():
+        return
+    for item in list(trash_dir.iterdir()):
+        try:
+            if item.is_file():
+                item.unlink()
+            elif item.is_dir():
+                shutil.rmtree(item)
+        except PermissionError:
+            pass  # Still locked, skip
+
+
+def _kill_zombie_zccache(build_dir: Path) -> None:
+    """Kill zccache processes whose CWD is inside build_dir.
+
+    When ninja is interrupted, zccache.exe wrappers can survive because they
+    communicate through a daemon and are not direct children of ninja. Their
+    CWD remains set to the build directory, which on Windows holds a kernel
+    handle that prevents directory deletion.
+    """
+    if sys.platform != "win32":
+        return
+    try:
+        import psutil  # noqa: PLC0415 - lazy import, only needed on Windows cleanup
+    except ImportError:
+        return
+    build_str = str(build_dir.resolve())
+    killed = 0
+    for proc in psutil.process_iter(["pid", "name"]):
+        try:
+            name = proc.info["name"] or ""
+            if "zccache" not in name.lower() or "daemon" in name.lower():
+                continue
+            cwd = proc.cwd()
+            if cwd and (cwd == build_str or cwd.startswith(build_str + os.sep)):
+                proc.kill()
+                killed += 1
+        except (psutil.NoSuchProcess, psutil.AccessDenied, OSError):
+            continue
+    if killed:
+        _ts_print(
+            f"[MESON] 🧹 Killed {killed} zombie zccache process(es) holding build directory"
+        )
+        time.sleep(0.5)  # Brief wait for Windows to release handles
+
+
+def _safe_rmtree(build_dir: Path) -> None:
+    """Remove build directory, relocating locked files to .trash/ for later cleanup."""
+    _kill_zombie_zccache(build_dir)
+    trash_dir = build_dir.parent / ".trash"
+    _purge_trash(trash_dir)
+
+    locked_files: list[str] = []
+
+    def _on_exc(func, path, exc):  # noqa: ARG001
+        """Handle locked files by renaming them into .trash/."""
+        p = Path(path)
+        trash_dir.mkdir(parents=True, exist_ok=True)
+        trash_name = f"{uuid.uuid4().hex[:8]}-{p.name}"
+        trash_path = trash_dir / trash_name
+        try:
+            p.rename(trash_path)
+            locked_files.append(p.name)
+        except (PermissionError, OSError):
+            locked_files.append(f"{p.name} (unmovable)")
+
+    if sys.version_info >= (3, 12):
+        shutil.rmtree(build_dir, onexc=_on_exc)
+    else:
+        shutil.rmtree(build_dir, onerror=lambda f, p, e: _on_exc(f, p, e[1]))
+
+    if build_dir.exists():
+        try:
+            shutil.rmtree(build_dir)
+        except OSError:
+            _ts_print(f"[MESON] ⚠️  Some locked files moved to {trash_dir}")
+            for name in locked_files:
+                _ts_print(f"  - {name}")
+
+
+def _write_failure_log(
+    log_dir: Optional[Path], name: str, suffix: str, content: str
+) -> None:
+    """Write a failure log file to the log_failures directory.
+
+    Args:
+        log_dir: Directory to write to (None = no-op)
+        name: Test name (will be sanitized for filename)
+        suffix: 'compile' or 'run'
+        content: Log content
+    """
+    if log_dir is None:
+        return
+    log_dir.mkdir(parents=True, exist_ok=True)
+    safe_name = name.replace(":", "_").replace("/", "_").replace("\\", "_")
+    log_path = log_dir / f"{safe_name}_{suffix}.log"
+    with open(log_path, "w", encoding="utf-8", errors="replace") as f:
+        f.write(content)
+
+
+def _extract_compile_failures(compile_output: str) -> dict[str, str]:
+    """Extract per-target compilation failures from ninja output.
+
+    Parses FAILED: lines to identify which targets had errors and collects
+    the associated error output. Handles timestamped output (e.g., "7.59 FAILED: ...")
+    and [code=N] prefixes.
+
+    Returns:
+        Dict mapping target name to error output text.
+    """
+    failures: dict[str, str] = {}
+    lines = compile_output.splitlines()
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        if "FAILED:" in line:
+            target = line.split("FAILED:", 1)[1].strip()
+            target = re.sub(r"^\[code=\d+\]\s*", "", target)
+            m = re.match(r"tests[/\\]([^.]+)\.", target)
+            test_name = m.group(1) if m else "unknown"
+
+            error_lines = [line]
+            i += 1
+            while i < len(lines):
+                if "FAILED:" in lines[i] or (
+                    "ninja:" in lines[i] and "build stopped" in lines[i]
+                ):
+                    break
+                error_lines.append(lines[i])
+                i += 1
+
+            existing = failures.get(test_name, "")
+            failures[test_name] = existing + "\n".join(error_lines) + "\n"
+        else:
+            i += 1
+
+    return failures
+
+
+def _write_testlog_failures(build_dir: Path, log_dir: Path) -> None:
+    """Parse testlog.txt and write per-test failure logs.
+
+    Args:
+        build_dir: Meson build directory (contains meson-logs/testlog.txt)
+        log_dir: Directory to write failure logs to
+    """
+    from ci.meson.testlog_parser import parse_testlog
+
+    testlog = build_dir / "meson-logs" / "testlog.txt"
+    entries = parse_testlog(testlog)
+    for entry in entries:
+        if "exit status 0" in entry.result:
+            continue
+        content = f"# Test: {entry.test_name}\n"
+        content += f"# Result: {entry.result}\n"
+        content += f"# Duration: {entry.duration}\n\n"
+        if entry.stdout:
+            content += "--- stdout ---\n" + entry.stdout + "\n\n"
+        if entry.stderr:
+            content += "--- stderr ---\n" + entry.stderr + "\n"
+        safe_name = entry.test_name.replace(":", "_").replace("/", "_")
+        _write_failure_log(log_dir, safe_name, "run", content)
+
+
+def _start_zccache_session(build_dir: Path) -> None:
+    """Start a zccache session with logging to the build directory.
+
+    Sets ZCCACHE_SESSION_ID in os.environ so all subsequent compiler
+    invocations through zccache use this session and get logged.
+    The session auto-cleans up via PID monitoring when the process exits.
+
+    Also sets ZCCACHE_LINK_DEPLOY_CMD so zccache invokes
+    `clang-tool-chain-libdeploy` after each cache-miss link. This
+    materializes runtime DLLs next to the linked binary (on Windows
+    these otherwise don't get deployed because the native ctc-clang++
+    trampoline skips Python post-link hooks) and lets zccache's
+    side-effect scanner bundle them into the cached artifact set —
+    fixing flaky error-126 DLL load failures under parallel test
+    execution. See https://github.com/FastLED/FastLED/issues/2329.
+    """
+    if "ZCCACHE_LINK_DEPLOY_CMD" not in os.environ:
+        os.environ["ZCCACHE_LINK_DEPLOY_CMD"] = "clang-tool-chain-libdeploy"
+    os.environ.setdefault("ZCCACHE_STRICT_PATHS", "absolute")
+
+    zccache_bin = _find_zccache_binary()
+    if not zccache_bin:
+        return
+
+    build_dir.mkdir(parents=True, exist_ok=True)
+    log_path = build_dir / "zccache-session.log"
+    journal_path = build_dir / "zccache-session.jsonl"
+
+    try:
+        result = subprocess.run(
+            [
+                zccache_bin,
+                "session-start",
+                "--stats",
+                "--log",
+                str(log_path),
+                "--journal",
+                str(journal_path),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode == 0:
+            import json
+
+            output = result.stdout.strip()
+            try:
+                data = json.loads(output)
+                session_id = str(data["session_id"])
+            except (json.JSONDecodeError, KeyError):
+                # Windows paths with backslashes break json.loads.
+                # Extract session_id with regex as fallback.
+                m = re.search(r'"session_id"\s*:\s*"([^"]+)"', output)
+                if m:
+                    session_id = m.group(1)
+                else:
+                    session_id = output
+            os.environ["ZCCACHE_SESSION_ID"] = session_id
+            _ts_print(f"[ZCCACHE] Session {session_id} started, log: {log_path}")
+    except KeyboardInterrupt as ki:
+        handle_keyboard_interrupt(ki)
+        raise
+    except Exception:
+        pass  # Non-fatal — build proceeds without session logging

--- a/ci/meson/sequential_runner.py
+++ b/ci/meson/sequential_runner.py
@@ -1,0 +1,546 @@
+#!/usr/bin/env python3
+"""Sequential compile + direct test execution paths.
+
+Extracted from ``ci/meson/runner.py``. The sequential path is used when a
+specific test is requested by name: we compile that one target (with fuzzy
+fallback resolution), then either skip to IWYU-check exit or invoke the
+resulting test executable directly. ``meson test`` is bypassed to avoid
+its target-discovery layer for single-test runs.
+"""
+
+import os
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional, cast
+
+from running_process import RunningProcess
+
+from ci.meson.build_timer import BuildTimer
+from ci.meson.cache_utils import save_test_result_state
+from ci.meson.compile import CompileResult, _is_compilation_error, compile_meson
+from ci.meson.output import print_banner, print_error, print_success
+from ci.meson.phase_tracker import PhaseTracker
+from ci.meson.runner_helpers import _apply_phase_timing, _write_failure_log
+from ci.meson.test_discovery import get_fuzzy_test_candidates
+from ci.meson.test_execution import MesonTestResult
+from ci.util.global_interrupt_handler import handle_keyboard_interrupt
+from ci.util.output_formatter import TimestampFormatter
+from ci.util.timestamp_print import ts_print as _ts_print
+
+
+@dataclass
+class SequentialCompileContext:
+    """Parameters for the sequential compile path."""
+
+    source_dir: Path
+    build_dir: Path
+    build_mode: str
+    verbose: bool
+    test_name: Optional[str]
+    meson_test_name: Optional[str]
+    fallback_test_name: Optional[str]
+    fuzzy_candidates: list[str]
+    log_failures: Optional[Path]
+    start_time: float
+    build_timer: BuildTimer
+    phase_tracker: PhaseTracker
+
+
+@dataclass
+class SequentialCompileResult:
+    """Outcome of the sequential compile attempt.
+
+    On success, ``meson_test_name`` is the resolved target name to launch.
+    On failure, ``error_result`` is the MesonTestResult to return immediately.
+    """
+
+    success: bool
+    meson_test_name: Optional[str] = None
+    error_result: Optional[MesonTestResult] = None
+
+
+def _resolve_compile_candidates(ctx: SequentialCompileContext) -> list[str]:
+    """Compose the ordered candidate list to try compiling."""
+    compile_target = ctx.meson_test_name
+    targets_to_try: list[str] = [compile_target] if compile_target else []
+    if ctx.fallback_test_name and ctx.fallback_test_name != compile_target:
+        targets_to_try.append(ctx.fallback_test_name)
+
+    fuzzy = ctx.fuzzy_candidates
+    if ctx.test_name and not fuzzy:
+        fuzzy = get_fuzzy_test_candidates(ctx.build_dir, ctx.test_name)
+    for c in fuzzy:
+        if c not in targets_to_try:
+            targets_to_try.append(c)
+
+    # Path-qualified variants for disambiguation: "tests/<name>", "tests/profile/<name>"
+    path_qualified: list[str] = []
+    for candidate in targets_to_try:
+        if candidate and "/" not in candidate:
+            for prefix in ["tests/", "tests/profile/"]:
+                qualified = f"{prefix}{candidate}"
+                if qualified not in targets_to_try and qualified not in path_qualified:
+                    path_qualified.append(qualified)
+    targets_to_try.extend(path_qualified)
+    return targets_to_try
+
+
+def _print_compile_failure(
+    *,
+    ctx: SequentialCompileContext,
+    last_result: Optional[CompileResult],
+    last_error_output: str,
+    has_fallbacks: bool,
+    targets_to_try: list[str],
+    all_suppressed_errors: list[str],
+) -> None:
+    """Print the failure header + error excerpt + diagnostics for a failed compile."""
+    last_error_file = (
+        ctx.build_dir.parent / "meson-state" / "last-compilation-error.txt"
+    )
+    phase_data = ctx.phase_tracker.get_phase()
+    phase_name = phase_data.get("phase", "COMPILE") if phase_data else "COMPILE"
+
+    print_error(f"\n[MESON] ❌ Build FAILED during {phase_name} phase")
+    print_error("=" * 80)
+
+    if last_result and last_result.error_log_file:
+        print_error(f"[MESON] 📄 Full compilation log:")
+        print_error(f"[MESON]    {last_result.error_log_file}")
+        print_error("")
+
+    error_snippet_shown = False
+
+    if last_error_file.exists():
+        with open(last_error_file, "r", encoding="utf-8") as f:
+            error_context = f.read()
+            for line in error_context.splitlines():
+                if _is_compilation_error(line):
+                    print_error(f"\033[91m{line}\033[0m")
+                else:
+                    print_error(line)
+        error_snippet_shown = True
+
+    elif (
+        last_result
+        and last_result.error_log_file
+        and last_result.error_log_file.exists()
+    ):
+        print_error("[MESON] 🔍 Error excerpt from compilation log:")
+        print_error("")
+        try:
+            with open(last_result.error_log_file, "r", encoding="utf-8") as f:
+                log_lines = f.readlines()
+                error_lines = [
+                    (i, line.rstrip())
+                    for i, line in enumerate(log_lines)
+                    if _is_compilation_error(line)
+                ]
+                if error_lines:
+                    last_error_idx = error_lines[-1][0]
+                    start_idx = max(0, last_error_idx - 5)
+                    end_idx = min(len(log_lines), last_error_idx + 5)
+                    for line in log_lines[start_idx:end_idx]:
+                        line = line.rstrip()
+                        if _is_compilation_error(line):
+                            print_error(f"\033[91m{line}\033[0m")
+                        else:
+                            print_error(line)
+                    error_snippet_shown = True
+        except KeyboardInterrupt as ki:
+            handle_keyboard_interrupt(ki)
+            raise
+        except Exception as e:
+            print_error(f"[MESON] ⚠️  Could not read error log: {e}")
+
+    if error_snippet_shown:
+        print_error("=" * 80)
+    else:
+        if all_suppressed_errors:
+            print_error(
+                "[MESON] Self-healing triggered - showing suppressed validation errors:"
+            )
+            for err in all_suppressed_errors[:5]:
+                print_error(f"  {err}")
+            print_error("")
+
+        print_error(f"[MESON] Compilation failed for test '{ctx.test_name}'")
+        if has_fallbacks:
+            tried = ", ".join(str(t) for t in targets_to_try)
+            print_error(f"[MESON] Tried targets: {tried}")
+        if last_error_output:
+            for line in last_error_output.splitlines():
+                if "ERROR:" in line or "Can't invoke target" in line:
+                    print_error(f"[MESON] {line.strip()}")
+                    break
+        print_error("=" * 80)
+
+
+def run_sequential_compile(
+    ctx: SequentialCompileContext,
+) -> SequentialCompileResult:
+    """Run the sequential compile path (target resolution + compile + diagnostics)."""
+    targets_to_try = _resolve_compile_candidates(ctx)
+
+    _ts_print(f"[BUILD] Building FastLED engine ({ctx.build_mode} mode)...")
+
+    has_fallbacks = len(targets_to_try) > 1
+    compilation_success = False
+    successful_target: Optional[str] = None
+    last_error_output = ""
+    last_result: Optional[CompileResult] = None
+    all_suppressed_errors: list[str] = []
+    resolved_meson_test_name = ctx.meson_test_name
+
+    for candidate in targets_to_try:
+        ctx.phase_tracker.set_phase(
+            "COMPILE",
+            test_name=ctx.test_name,
+            target=candidate,
+            path="sequential",
+        )
+        result = compile_meson(
+            ctx.build_dir,
+            target=candidate,
+            quiet=has_fallbacks,
+            verbose=ctx.verbose,
+        )
+        last_result = result
+        compilation_success = result.success
+        if compilation_success:
+            ctx.phase_tracker.set_phase(
+                "LINK",
+                test_name=ctx.test_name,
+                target=candidate,
+                path="sequential",
+            )
+            successful_target = candidate
+            resolved_meson_test_name = (
+                candidate.removeprefix("tests/") if candidate else candidate
+            )
+            break
+        last_error_output = result.error_output
+        all_suppressed_errors.extend(result.suppressed_errors)
+
+    ctx.build_timer.checkpoint("compile_done")
+
+    if compilation_success and has_fallbacks:
+        print_banner("Compile", "📦", verbose=ctx.verbose)
+        print(f"Compiling: {successful_target}")
+
+    if compilation_success:
+        return SequentialCompileResult(
+            success=True, meson_test_name=resolved_meson_test_name
+        )
+
+    _print_compile_failure(
+        ctx=ctx,
+        last_result=last_result,
+        last_error_output=last_error_output,
+        has_fallbacks=has_fallbacks,
+        targets_to_try=targets_to_try,
+        all_suppressed_errors=all_suppressed_errors,
+    )
+
+    if ctx.log_failures is not None:
+        compile_content = last_error_output
+        if (
+            last_result
+            and last_result.error_log_file
+            and last_result.error_log_file.exists()
+        ):
+            try:
+                compile_content = last_result.error_log_file.read_text(
+                    encoding="utf-8", errors="replace"
+                )
+            except OSError:
+                pass
+        _write_failure_log(
+            ctx.log_failures,
+            ctx.test_name or "unknown",
+            "compile",
+            compile_content,
+        )
+
+    return SequentialCompileResult(
+        success=False,
+        error_result=MesonTestResult(
+            success=False,
+            duration=time.time() - ctx.start_time,
+            num_tests_run=0,
+            num_tests_passed=0,
+            num_tests_failed=0,
+        ),
+    )
+
+
+@dataclass
+class DirectTestContext:
+    """Parameters for direct test executable invocation."""
+
+    source_dir: Path
+    build_dir: Path
+    meson_test_name: str
+    build_mode: str
+    verbose: bool
+    log_failures: Optional[Path]
+    start_time: float
+    build_timer: BuildTimer
+    phase_tracker: PhaseTracker
+
+
+def _resolve_test_command(
+    build_dir: Path, meson_test_name: str, verbose: bool
+) -> tuple[list[str], Optional[Path]]:
+    """Find the test executable / DLL and return (cmd, artifact_path).
+
+    Returns ([], None) if no executable could be located.
+    """
+    # Profile tests (tests/profile/) — any name (not just profile_* prefix)
+    profile_exe_path = build_dir / "tests" / "profile" / f"{meson_test_name}.exe"
+    if profile_exe_path.exists():
+        return [str(profile_exe_path)], profile_exe_path
+    profile_exe_unix = build_dir / "tests" / "profile" / meson_test_name
+    if profile_exe_unix.exists():
+        return [str(profile_exe_unix)], profile_exe_unix
+
+    # Copied runner .exe (e.g. fl_async.exe) — DLL preferred as artifact
+    test_exe_path = build_dir / "tests" / f"{meson_test_name}.exe"
+    if test_exe_path.exists():
+        dll_candidate = build_dir / "tests" / f"{meson_test_name}.dll"
+        artifact = dll_candidate if dll_candidate.exists() else test_exe_path
+        return [str(test_exe_path)], artifact
+
+    # Unix bare-name variant
+    test_exe_unix = build_dir / "tests" / meson_test_name
+    if test_exe_unix.exists():
+        return [str(test_exe_unix)], test_exe_unix
+
+    # DLL-based architecture: shared runner + test.{dll,so,dylib}
+    runner_name = "runner.exe" if os.name == "nt" else "runner"
+    runner_exe = build_dir / "tests" / runner_name
+    if not runner_exe.exists():
+        compile_meson(build_dir, target="runner", quiet=True, verbose=verbose)
+    if runner_exe.exists():
+        for ext in (".dll", ".so", ".dylib"):
+            candidate = build_dir / "tests" / f"{meson_test_name}{ext}"
+            if candidate.exists():
+                return [str(runner_exe), str(candidate)], candidate
+
+    return [], None
+
+
+def _make_direct_test_env(
+    source_dir: Path, build_dir: Path, build_mode: str
+) -> dict[str, str]:
+    """Build env for the direct test subprocess (PATH/LD_LIBRARY_PATH + ASAN)."""
+    test_env = os.environ.copy()
+    fastled_lib_dir = str(build_dir / "ci" / "meson" / "native")
+    if os.name == "nt":
+        from clang_tool_chain import get_runtime_dll_paths
+
+        extra = os.pathsep.join([fastled_lib_dir] + get_runtime_dll_paths())
+        test_env["PATH"] = extra + os.pathsep + test_env.get("PATH", "")
+    else:
+        test_env["LD_LIBRARY_PATH"] = (
+            fastled_lib_dir + os.pathsep + test_env.get("LD_LIBRARY_PATH", "")
+        )
+    if "FASTLED_TEST_TIMEOUT" not in test_env:
+        test_env["FASTLED_TEST_TIMEOUT"] = "60"
+    # ASAN's vectored exception handler conflicts with our crash handler on Windows.
+    if build_mode == "debug" and os.name == "nt":
+        test_env["FASTLED_DISABLE_CRASH_HANDLER"] = "1"
+    # source_dir intentionally unused — kept for signature symmetry
+    _ = source_dir
+    return test_env
+
+
+def _print_direct_test_failure(
+    ctx: DirectTestContext,
+    proc: RunningProcess,
+    returncode: int,
+) -> None:
+    """Print phase-aware failure messages + write error log for a failed direct test."""
+    phase_data = ctx.phase_tracker.get_phase()
+
+    if phase_data and phase_data["phase"] == "EXECUTE":
+        print_error(f"[MESON] ❌ Test FAILED during execution (exit code {returncode})")
+        print_error(f"[MESON] Test: {ctx.meson_test_name}")
+
+        compile_errors_dir = ctx.build_dir.parent / "compile-errors"
+        compile_errors_dir.mkdir(exist_ok=True)
+        test_name_slug = ctx.meson_test_name.replace("test_", "").replace("/", "_")
+        error_log_path = compile_errors_dir / f"{test_name_slug}.log"
+
+        with open(error_log_path, "w", encoding="utf-8") as f:
+            f.write(f"# Test: {ctx.meson_test_name}\n")
+            f.write(f"# Exit code: {returncode}\n")
+            f.write(f"# Full test output below:\n\n")
+            f.write("--- Test Output ---\n\n")
+            f.write(str(proc.stdout))
+
+        print_error(f"[MESON] 📄 Full test output: {error_log_path}")
+
+        stdout_lower = str(proc.stdout).lower()
+        has_doctest_output = any(
+            pattern in stdout_lower
+            for pattern in [
+                "test cases:",
+                "assertions:",
+                "[doctest]",
+                "test case failed",
+            ]
+        )
+        has_watchdog_timeout = "internal timeout watchdog triggered" in stdout_lower
+
+        if returncode == 1 and not proc.stdout.strip():
+            print_error("[MESON] ⚠️  No output - possible crash at startup")
+        elif returncode == 1 and has_watchdog_timeout and not has_doctest_output:
+            print_error(
+                "[MESON] ⚠️  Test killed by internal timeout watchdog (exceeded time limit)"
+            )
+            print_error(
+                "[MESON] 💡 This is a timeout, not a crash. Consider adding to slow_tests in tests/meson.build"
+            )
+        elif returncode == 1 and not has_doctest_output:
+            print_error(
+                "[MESON] ⚠️  Test failed during initialization (before doctest ran)"
+            )
+            error_lines = [
+                line.strip()
+                for line in str(proc.stdout).splitlines()
+                if "error" in line.lower() and line.strip()
+            ]
+            if error_lines:
+                print_error("[MESON] 🔍 Error messages found in output:")
+                for error_line in error_lines[:10]:
+                    print_error(f"[MESON]    {error_line}")
+                if len(error_lines) > 10:
+                    print_error(
+                        f"[MESON]    ... ({len(error_lines) - 10} more error(s))"
+                    )
+            print_error("[MESON] 💡 Possible causes:")
+            print_error(
+                "[MESON]    - Static initialization failure (global object constructor crash)"
+            )
+            print_error(
+                "[MESON]    - Test registration issue (FL_TEST_CASE macro problem)"
+            )
+            print_error(
+                "[MESON]    - DLL loading failure (missing dependency or symbol)"
+            )
+            print_error(
+                "[MESON]    - All test cases disabled with #if 0 (check test file)"
+            )
+    else:
+        phase_name = phase_data.get("phase", "UNKNOWN") if phase_data else "UNKNOWN"
+        print_error(
+            f"[MESON] ❌ Build FAILED during {phase_name} phase (exit code {returncode})"
+        )
+
+    if not ctx.verbose and proc.stdout:
+        print_error("[MESON] Test output:")
+        for line in str(proc.stdout).splitlines()[-50:]:
+            _ts_print(f"  {line}")
+
+
+def run_direct_test(ctx: DirectTestContext) -> MesonTestResult:
+    """Locate and execute a single test executable; return its MesonTestResult."""
+    test_cmd, artifact_path = _resolve_test_command(
+        ctx.build_dir, ctx.meson_test_name, ctx.verbose
+    )
+
+    if not test_cmd:
+        _ts_print(
+            f"[MESON] Error: test executable not found for: {ctx.meson_test_name}",
+            file=sys.stderr,
+        )
+        return MesonTestResult(
+            success=False,
+            duration=time.time() - ctx.start_time,
+            num_tests_run=0,
+            num_tests_passed=0,
+            num_tests_failed=0,
+        )
+
+    print_banner("Test", "▶️", verbose=ctx.verbose)
+    print(f"Running: {ctx.meson_test_name}")
+    ctx.phase_tracker.set_phase(
+        "EXECUTE", test_name=ctx.meson_test_name, path="sequential"
+    )
+
+    try:
+        test_env = _make_direct_test_env(ctx.source_dir, ctx.build_dir, ctx.build_mode)
+        proc = RunningProcess(
+            test_cmd,
+            cwd=ctx.source_dir,
+            timeout=600,
+            auto_run=True,
+            check=False,
+            env=test_env,
+            output_formatter=TimestampFormatter(),
+        )
+        is_profile_test = artifact_path and "profile" in str(artifact_path)
+        echo_callback = ctx.verbose or is_profile_test
+        test_start = time.time()
+        returncode = cast(int, proc.wait(echo=bool(echo_callback)))
+        test_duration = time.time() - test_start
+        duration = time.time() - ctx.start_time
+        ctx.build_timer.checkpoint("test_execution_done")
+
+        if returncode != 0:
+            _print_direct_test_failure(ctx, proc, returncode)
+            if artifact_path is not None:
+                save_test_result_state(
+                    ctx.build_dir, ctx.meson_test_name, artifact_path, passed=False
+                )
+            if ctx.log_failures is not None and ctx.meson_test_name:
+                _write_failure_log(
+                    ctx.log_failures, ctx.meson_test_name, "run", str(proc.stdout)
+                )
+            return MesonTestResult(
+                success=False,
+                duration=duration,
+                num_tests_run=1,
+                num_tests_passed=0,
+                num_tests_failed=1,
+                failed_test_names=[ctx.meson_test_name] if ctx.meson_test_name else [],
+            )
+
+        ctx.phase_tracker.clear()
+        if artifact_path is not None:
+            save_test_result_state(
+                ctx.build_dir, ctx.meson_test_name, artifact_path, passed=True
+            )
+        build_duration = duration - test_duration
+        _ts_print(ctx.build_timer.format_table())
+        print_success(
+            f"✅ All tests passed (1/1 in {test_duration:.2f}s, build: {build_duration:.1f}s)"
+        )
+        result = MesonTestResult(
+            success=True,
+            duration=duration,
+            num_tests_run=1,
+            num_tests_passed=1,
+            num_tests_failed=0,
+        )
+        return _apply_phase_timing(result, ctx.build_timer)
+
+    except KeyboardInterrupt as ki:
+        handle_keyboard_interrupt(ki)
+        raise
+    except Exception as e:
+        duration = time.time() - ctx.start_time
+        _ts_print(
+            f"[MESON] Test execution failed with exception: {e}",
+            file=sys.stderr,
+        )
+        return MesonTestResult(
+            success=False,
+            duration=duration,
+            num_tests_run=1,
+            num_tests_passed=0,
+            num_tests_failed=1,
+        )

--- a/ci/meson/streaming_runner.py
+++ b/ci/meson/streaming_runner.py
@@ -1,0 +1,362 @@
+#!/usr/bin/env python3
+"""Streaming execution path for ``run_meson_build_and_test``.
+
+Extracted from ``ci/meson/runner.py``. Runs ``stream_compile_and_run_tests``
+which compiles + executes tests in parallel — as soon as a test finishes
+linking it's launched while other tests are still compiling.
+
+This module owns the streaming-specific concerns: a test-callback closure
+that captures per-test output (so failures can be summarized at the end),
+zombie-process tracking, the proactive ``all-with-examples`` target check,
+stale-build recovery retry, and the no-tests-ran fallback.
+"""
+
+import os
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from running_process import RunningProcess
+
+from ci.meson.build_config import setup_meson_build
+from ci.meson.build_optimizer import BuildOptimizer
+from ci.meson.build_timer import BuildTimer
+from ci.meson.compile import is_stale_build_error
+from ci.meson.output import print_error, print_info, print_success
+from ci.meson.runner_helpers import (
+    _apply_compile_sub_phases,
+    _apply_phase_timing,
+    _extract_compile_failures,
+    _recover_stale_build,
+    _write_failure_log,
+    _write_testlog_failures,
+)
+from ci.meson.streaming import TestResult, stream_compile_and_run_tests
+from ci.meson.test_execution import MesonTestResult, run_meson_test
+from ci.util.global_interrupt_handler import handle_keyboard_interrupt
+from ci.util.output_formatter import TimestampFormatter
+from ci.util.timestamp_print import ts_print as _ts_print
+
+
+@dataclass
+class StreamingContext:
+    """Parameters needed by the streaming execution path."""
+
+    source_dir: Path
+    build_dir: Path
+    use_debug: bool
+    check: bool
+    build_mode: str
+    verbose: bool
+    exclude_suites: Optional[list[str]]
+    test_file_filter: Optional[str]
+    log_failures: Optional[Path]
+    start_time: float
+    build_timer: BuildTimer
+    build_optimizer: Optional[BuildOptimizer]
+
+
+def _make_streaming_env(source_dir: Path, build_dir: Path) -> dict[str, str]:
+    """Build the environment dict for streamed test subprocesses.
+
+    Adds the fastled shared lib directory + clang toolchain runtime DLLs to
+    PATH (Windows) or LD_LIBRARY_PATH (POSIX) so DLLs load without MSYS2.
+    """
+    streaming_env = os.environ.copy()
+    fastled_lib_dir = str(build_dir / "ci" / "meson" / "native")
+    if os.name == "nt":
+        from clang_tool_chain import get_runtime_dll_paths
+
+        extra_dirs = os.pathsep.join([fastled_lib_dir] + get_runtime_dll_paths())
+        streaming_env["PATH"] = extra_dirs + os.pathsep + streaming_env.get("PATH", "")
+    else:
+        streaming_env["LD_LIBRARY_PATH"] = (
+            fastled_lib_dir + os.pathsep + streaming_env.get("LD_LIBRARY_PATH", "")
+        )
+    # source_dir is intentionally unused — only the build_dir matters for
+    # DLL lookup, but the parameter is kept for symmetry with the rest of
+    # the streaming context.
+    _ = source_dir
+    return streaming_env
+
+
+def _check_all_with_examples_target(ctx: StreamingContext) -> None:
+    """Verify ``all-with-examples`` is in build.ninja; reconfigure if not.
+
+    The marker file can desynchronize from the actual build configuration,
+    so we reconfigure proactively to avoid a "target not found" error.
+    """
+    build_ninja = ctx.build_dir / "build.ninja"
+    if not build_ninja.exists():
+        return
+    try:
+        content = build_ninja.read_text(encoding="utf-8")
+        if "all-with-examples" not in content:
+            _ts_print("[MESON] ⚠️  Target 'all-with-examples' missing from build.ninja")
+            _ts_print("[MESON] 🔄 Forcing reconfiguration with enable_examples=true...")
+            setup_meson_build(
+                ctx.source_dir,
+                ctx.build_dir,
+                reconfigure=True,
+                debug=ctx.use_debug,
+                check=ctx.check,
+                build_mode=ctx.build_mode,
+                verbose=ctx.verbose,
+                enable_examples=True,
+                enable_unit_tests=True,
+            )
+    except (OSError, IOError):
+        pass
+
+
+def _streaming_no_tests_fallback(
+    ctx: StreamingContext,
+    sr,
+) -> MesonTestResult:
+    """When streaming reported success but ran 0 tests, fall back to ``meson test``."""
+    if ctx.verbose:
+        print_info("[MESON] Build up-to-date, running existing tests...")
+    ctx.build_timer.checkpoint("compile_done")
+
+    result = run_meson_test(
+        ctx.build_dir,
+        test_name=None,
+        verbose=ctx.verbose,
+        exclude_suites=ctx.exclude_suites,
+    )
+
+    ctx.build_timer.checkpoint("test_execution_done")
+    ctx.build_timer.calculate_phases()
+    test_only_duration = result.duration
+    result.duration = time.time() - ctx.start_time
+    result.meson_setup_time = ctx.build_timer.meson_setup_time
+    result.ninja_maintenance_time = ctx.build_timer.ninja_maintenance_time
+    result.compile_time = ctx.build_timer.compile_time
+    result.test_execution_time = test_only_duration
+
+    _apply_compile_sub_phases(result, sr.compile_sub_phases)
+    if not result.success and ctx.log_failures is not None:
+        _write_testlog_failures(ctx.build_dir, ctx.log_failures)
+    return result
+
+
+def _handle_streaming_failure(
+    ctx: StreamingContext,
+    sr,
+    failed_outputs: dict[str, str],
+    failed_outputs_lock: threading.Lock,
+    duration: float,
+    num_tests_run: int,
+) -> MesonTestResult:
+    """Print failure details and write logs after the streaming path failed."""
+    print_error(
+        f"[MESON] ❌ Some tests failed ({sr.num_passed}/{num_tests_run} tests in {duration:.2f}s)"
+    )
+    # Snapshot under lock — workers may still be running after shutdown(wait=False).
+    with failed_outputs_lock:
+        failed_snapshot = dict(failed_outputs)
+
+    if failed_snapshot:
+        print_error(f"\n{'=' * 80}")
+        print_error(f"[MESON] Test failure details ({len(failed_snapshot)} tests):")
+        print_error(f"{'=' * 80}")
+        for tname, output in failed_snapshot.items():
+            print_error(f"\n--- {tname} ---")
+            for line in output.splitlines()[-30:]:
+                print_error(f"  {line}")
+        print_error(f"{'=' * 80}")
+
+    if ctx.log_failures is not None:
+        if num_tests_run == 0:
+            per_target = _extract_compile_failures(sr.compile_output)
+            if per_target:
+                for tname, output in per_target.items():
+                    _write_failure_log(ctx.log_failures, tname, "compile", output)
+            else:
+                _write_failure_log(
+                    ctx.log_failures,
+                    "compile",
+                    "compile",
+                    sr.compile_output,
+                )
+        else:
+            for tname, output in failed_snapshot.items():
+                _write_failure_log(ctx.log_failures, tname, "run", output)
+
+    return MesonTestResult(
+        success=False,
+        duration=duration,
+        num_tests_run=num_tests_run,
+        num_tests_passed=sr.num_passed,
+        num_tests_failed=sr.num_failed,
+        failed_test_names=sr.failed_names,
+    )
+
+
+def run_streaming_path(ctx: StreamingContext) -> MesonTestResult:
+    """Execute the streaming compile + test path and return the aggregated result."""
+    if ctx.verbose:
+        _ts_print("[MESON] Using streaming execution (compile + test in parallel)")
+
+    failed_test_outputs: dict[str, str] = {}
+    streaming_env = _make_streaming_env(ctx.source_dir, ctx.build_dir)
+    failed_outputs_lock = threading.Lock()
+
+    active_procs: set[RunningProcess] = set()
+    active_procs_lock = threading.Lock()
+
+    def test_callback(test_path: Path) -> TestResult:
+        """Run a single test executable and return TestResult.
+
+        Output is always captured silently (echo=False) so that the caller
+        can print it sequentially on the main thread, avoiding interleaved
+        output when tests run in parallel.
+        """
+        try:
+            if test_path.suffix.lower() in (".dll", ".so", ".dylib"):
+                runner_suffix = ".exe" if os.name == "nt" else ""
+                if test_path.parent.name == "tests":
+                    runner = ctx.build_dir / "tests" / f"runner{runner_suffix}"
+                else:
+                    runner = (
+                        ctx.build_dir / "examples" / f"example_runner{runner_suffix}"
+                    )
+                if not runner.exists():
+                    return TestResult(
+                        success=False,
+                        output=f"[MESON] ⚠️  Runner not found: {runner}",
+                    )
+                cmd = [str(runner), str(test_path)]
+            else:
+                cmd = [str(test_path)]
+
+            env = streaming_env
+            file_filter = getattr(test_callback, "_test_file_filter", None)
+            if file_filter:
+                env = dict(streaming_env)
+                env["FL_TEST_FILE_FILTER"] = file_filter
+
+            proc = RunningProcess(
+                cmd,
+                cwd=ctx.source_dir,
+                timeout=600,
+                auto_run=True,
+                check=False,
+                env=env,
+                output_formatter=TimestampFormatter(),
+            )
+
+            with active_procs_lock:
+                active_procs.add(proc)
+            try:
+                returncode = proc.wait(echo=False)
+            finally:
+                with active_procs_lock:
+                    active_procs.discard(proc)
+            captured = str(proc.stdout)
+
+            if returncode != 0:
+                with failed_outputs_lock:
+                    failed_test_outputs[test_path.stem] = captured
+
+            return TestResult(success=returncode == 0, output=captured)
+
+        except KeyboardInterrupt as ki:
+            handle_keyboard_interrupt(ki)
+            return TestResult(
+                success=False,
+                output="[MESON] Test interrupted by user",
+            )
+        except Exception as e:
+            return TestResult(
+                success=False,
+                output=f"[MESON] Test execution error: {e}",
+            )
+
+    def _kill_active_procs() -> None:
+        """Kill all running test subprocesses (called on halt)."""
+        with active_procs_lock:
+            for p in list(active_procs):
+                try:
+                    p.kill()
+                except KeyboardInterrupt as ki:
+                    handle_keyboard_interrupt(ki)
+                except Exception:
+                    pass
+
+    setattr(test_callback, "kill_all", _kill_active_procs)
+
+    # Debug builds with ASAN are significantly slower (esp. Windows CI).
+    compile_timeout = 2700 if ctx.use_debug else 600
+
+    include_examples = not (
+        ctx.exclude_suites and "fastled:examples" in ctx.exclude_suites
+    )
+    compile_target = "all-with-examples" if include_examples else None
+
+    if compile_target == "all-with-examples":
+        _check_all_with_examples_target(ctx)
+
+    sr = stream_compile_and_run_tests(
+        build_dir=ctx.build_dir,
+        test_callback=test_callback,
+        target=compile_target,
+        verbose=ctx.verbose,
+        compile_timeout=compile_timeout,
+        build_optimizer=ctx.build_optimizer,
+        test_file_filter=ctx.test_file_filter,
+        build_timer=ctx.build_timer,
+    )
+
+    # SELF-HEALING: stale-build recovery + retry once
+    if not sr.success and is_stale_build_error(sr.compile_output):
+        if _recover_stale_build(
+            ctx.source_dir,
+            ctx.build_dir,
+            ctx.use_debug,
+            ctx.check,
+            ctx.build_mode,
+            ctx.verbose,
+            enable_examples=True,
+        ):
+            sr = stream_compile_and_run_tests(
+                build_dir=ctx.build_dir,
+                test_callback=test_callback,
+                target=compile_target,
+                verbose=ctx.verbose,
+                compile_timeout=compile_timeout,
+                build_optimizer=ctx.build_optimizer,
+                test_file_filter=ctx.test_file_filter,
+                build_timer=ctx.build_timer,
+            )
+
+    if sr.success and ctx.build_optimizer is not None:
+        ctx.build_optimizer.save_fingerprints(ctx.build_dir)
+
+    duration = time.time() - ctx.start_time
+    num_tests_run = sr.num_passed + sr.num_failed
+
+    if num_tests_run == 0 and sr.success:
+        return _streaming_no_tests_fallback(ctx, sr)
+
+    if not sr.success:
+        return _handle_streaming_failure(
+            ctx, sr, failed_test_outputs, failed_outputs_lock, duration, num_tests_run
+        )
+
+    _ts_print(ctx.build_timer.format_table())
+    print_success(
+        f"✅ All tests passed ({sr.num_passed}/{num_tests_run} in {duration:.2f}s)"
+    )
+    result = MesonTestResult(
+        success=True,
+        duration=duration,
+        num_tests_run=num_tests_run,
+        num_tests_passed=sr.num_passed,
+        num_tests_failed=sr.num_failed,
+    )
+    result = _apply_phase_timing(result, ctx.build_timer)
+    _apply_compile_sub_phases(result, sr.compile_sub_phases)
+    return result


### PR DESCRIPTION
## Summary

Two source files in ``ci/meson/`` were well over the 1k LOC line:
- ``build_config.py``: 2387 LOC
- ``runner.py``: 1615 LOC

Both were procedural monoliths that had been growing without clear seams.
Split each into focused modules behind unchanged public APIs:

### build_config.py (2387 -> 411)
- ``native_launchers.py`` (~370) - ctc-* native launcher resolution + zccache discovery
- ``path_normalization.py`` (~275) - zccache strict-path normalization (issue #2378)
- ``meson_markers.py`` (~280) - per-build marker files + AR optimization patches
- ``meson_cleanup.py`` (~140) - build artifact cleanup + LLVM tool detection
- ``meson_setup_phases.py`` (~590) - source hashes, marker reconfigure detection, file-change detection
- ``meson_setup_execute.py`` (~465) - compiler detect, native file, setup execution, skip-setup branch

### runner.py (1615 -> 349)
- ``runner_helpers.py`` (~420) - timing aggregation, stale-build recovery, build-dir cleanup with locked-file handling, failure logs, zccache session bootstrap
- ``streaming_runner.py`` (~360) - parallel compile + test execution path
- ``sequential_runner.py`` (~545) - per-target compile + direct executable invocation

### Public API preserved
``build_config.py`` re-exports every previously-public symbol via an
``__all__`` list so external callers stay working unchanged:
- ``wasm_build.py``
- ``ci/util/test_runner.py``
- ``ci/util/meson_runner.py``
- ``ci/util/meson_example_runner.py``
- ``ci/tests/test_meson_private_include_normalization.py``
- ``ci/tests/test_wasm_warm_path_perf.py``
- ``test.py``

Every file in ``ci/meson/`` is now under 1k LOC (largest remaining is
``compile.py`` at 857). README updated to reflect the new module map.

## Test plan
- [x] All 309 C++ tests pass (``bash test --cpp``, ~62s)
- [x] All 8 meson-related Python tests pass (path normalization + strict paths)
- [x] Lint clean (``bash lint``)
- [x] Public-API imports verified: ``setup_meson_build``, ``perform_ninja_maintenance``, ``cleanup_stale_meson_lockfile``, ``find_strict_path_violations``, ``normalize_meson_private_include_paths``, ``resolve_wasm_native_entries``, ``_find_zccache_binary``, ``cleanup_build_artifacts``, ``_ensure_emcc_native_launcher``

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Build Improvements**
  * Refactored CI/Meson build infrastructure into a modular, maintainable architecture.
  * Added native compiler launcher optimization for faster build startup times.
  * Implemented intelligent stale-build detection and automatic recovery.

* **Performance Enhancements**
  * Enabled parallel test execution and streaming results for quicker feedback.
  * Integrated compiler caching and archive optimization for faster compilation.

* **Reliability**
  * Improved error reporting and diagnostics for failed builds and tests.
  * Enhanced path handling and build state tracking to prevent configuration mismatches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->