### PR TITLE
chore(esp32): eliminate runtime esp_rom_printf call sites

### DIFF
--- a/examples/AutoResearch/AutoResearchParlioEncode.h
+++ b/examples/AutoResearch/AutoResearchParlioEncode.h
@@ -17,9 +17,9 @@
 ///      indicates the P4 L2 cache fully hides PSRAM latency for this access
 ///      pattern (×1.00 SRAM vs PSRAM); this rechecks on the byte-LUT version.
 ///
-/// Output: `BENCH_PARLIO_*` lines via `esp_rom_printf` -> USB-Serial-JTAG (COM25)
-/// so capture works without depending on the testSimd RPC routing (#2541).
 /// **Invocation:** RPC-only via `parlioEncodeBenchmark` in AutoResearchRemote.cpp.
+/// The result struct is JSON-serialized by the RPC handler; this header no
+/// longer prints directly.
 ///
 /// Current implementation times the production BF1 pipe4 encode path and skips
 /// PSRAM-only placements when PSRAM is not present.
@@ -38,7 +38,6 @@
 #if defined(ARDUINO_ARCH_ESP32) || defined(ESP_PLATFORM)
 #include <Arduino.h>     // micros()
 #include <esp_heap_caps.h>
-#include <esp_rom_sys.h> // esp_rom_printf -> USB-Serial-JTAG console
 #define FL_PARLIO_BENCH_ENABLED 1
 #else
 #define FL_PARLIO_BENCH_ENABLED 0
@@ -263,59 +262,9 @@ inline ParlioEncodeResult measureParlioEncode(int iters_in = 12000) {
     return result;
 }
 
-inline void printParlioEncodeResultRom(const ParlioEncodeResult &r) {
-    if (r.iters == 0) {
-        esp_rom_printf("\nBENCH_PARLIO_START (issue #2526 follow-up)\n");  // ok esp_rom_printf - boot-time bench output to COM25 (#2541)
-        esp_rom_printf("BENCH_PARLIO ERROR: heap allocation failed\n");  // ok esp_rom_printf - boot-time bench output to COM25 (#2541)
-        esp_rom_printf("BENCH_PARLIO_END\n\n");  // ok esp_rom_printf - boot-time bench output to COM25 (#2541)
-        return;
-    }
-
-    // Per-byte-position cost (microseconds * 1000 for sub-us precision)
-    const fl::u64 iters64 = r.iters;
-    const fl::u32 ss_ns_per = static_cast<fl::u32>(static_cast<fl::u64>(r.perpos_ss_us) * 1000 / iters64);
-    const fl::u32 sp_ns_per = static_cast<fl::u32>(static_cast<fl::u64>(r.perpos_sp_us) * 1000 / iters64);
-    const fl::u32 ps_ns_per = static_cast<fl::u32>(static_cast<fl::u64>(r.perpos_ps_us) * 1000 / iters64);
-    const fl::u32 pp_ns_per = static_cast<fl::u32>(static_cast<fl::u64>(r.perpos_pp_us) * 1000 / iters64);
-
-    // Frame-equivalent micros: production frame = 768 byte-positions.
-    const fl::u32 ss_frame_us = static_cast<fl::u32>(static_cast<fl::u64>(r.perpos_ss_us) * 768 / iters64);
-    const fl::u32 sp_frame_us = static_cast<fl::u32>(static_cast<fl::u64>(r.perpos_sp_us) * 768 / iters64);
-    const fl::u32 ps_frame_us = static_cast<fl::u32>(static_cast<fl::u64>(r.perpos_ps_us) * 768 / iters64);
-    const fl::u32 pp_frame_us = static_cast<fl::u32>(static_cast<fl::u64>(r.perpos_pp_us) * 768 / iters64);
-
-    // PSRAM-vs-SRAM ratio x100 (>100 means PSRAM is slower)
-    fl::u32 ratio_pp_ss_x100 = (r.perpos_ss_us > 0)
-        ? static_cast<fl::u32>(static_cast<fl::u64>(r.perpos_pp_us) * 100 / r.perpos_ss_us) : 0;
-    fl::u32 ratio_ps_ss_x100 = (r.perpos_ss_us > 0)
-        ? static_cast<fl::u32>(static_cast<fl::u64>(r.perpos_ps_us) * 100 / r.perpos_ss_us) : 0;
-    fl::u32 ratio_sp_ss_x100 = (r.perpos_ss_us > 0)
-        ? static_cast<fl::u32>(static_cast<fl::u64>(r.perpos_sp_us) * 100 / r.perpos_ss_us) : 0;
-
-    // WS2812B 800kHz, 16 lanes in parallel, 256 LEDs * 24 bits * 1.25 us/bit.
-    constexpr fl::u32 WS2812B_FRAME_US = 7680;
-
-    esp_rom_printf("\nBENCH_PARLIO_START (16 lanes x 256 LEDs, byte-LUT, #2526 follow-up)\n");  // ok esp_rom_printf - boot-time bench output to COM25 (#2541)
-    esp_rom_printf("BENCH_PARLIO iters=%u lanes=%u leds=%u sink=%u\n",  // ok esp_rom_printf - boot-time bench output to COM25 (#2541)
-                   r.iters, r.lanes, r.leds_per_lane, r.sink);
-    esp_rom_printf("BENCH_PARLIO psram scratch=%u output=%u\n",  // ok esp_rom_printf - boot-time bench output to COM25 (#2541)
-                   r.scratch_psram_ok ? 1u : 0u,
-                   r.output_psram_ok ? 1u : 0u);
-    esp_rom_printf("BENCH_PARLIO perpos_us  ss=%u sp=%u ps=%u pp=%u\n",  // ok esp_rom_printf - boot-time bench output to COM25 (#2541)
-                   r.perpos_ss_us, r.perpos_sp_us, r.perpos_ps_us, r.perpos_pp_us);
-    esp_rom_printf("BENCH_PARLIO perpos_ns_each  ss=%u sp=%u ps=%u pp=%u\n",  // ok esp_rom_printf - boot-time bench output to COM25 (#2541)
-                   ss_ns_per, sp_ns_per, ps_ns_per, pp_ns_per);
-    esp_rom_printf("BENCH_PARLIO frame_equiv_us  ss=%u sp=%u ps=%u pp=%u  ws2812b_tx=%u\n",  // ok esp_rom_printf - boot-time bench output to COM25 (#2541)
-                   ss_frame_us, sp_frame_us, ps_frame_us, pp_frame_us, WS2812B_FRAME_US);
-    esp_rom_printf("BENCH_PARLIO ratio_x100  sp_vs_ss=%u ps_vs_ss=%u pp_vs_ss=%u\n",  // ok esp_rom_printf - boot-time bench output to COM25 (#2541)
-                   ratio_sp_ss_x100, ratio_ps_ss_x100, ratio_pp_ss_x100);
-    esp_rom_printf("BENCH_PARLIO_END\n\n");  // ok esp_rom_printf - boot-time bench output to COM25 (#2541)
-}
-
 #else // !FL_PARLIO_BENCH_ENABLED
 
 inline ParlioEncodeResult measureParlioEncode(int /*iters*/ = 12000) { return {}; }
-inline void printParlioEncodeResultRom(const ParlioEncodeResult & /*r*/) {}
 
 #endif
 

--- a/examples/AutoResearch/AutoResearchWave8Expand.h
+++ b/examples/AutoResearch/AutoResearchWave8Expand.h
@@ -6,8 +6,8 @@
 /// production cost (expansion + 16-lane transpose) for both LUTs.
 ///
 /// **Invocation:** RPC-only. Call via the `wave8ExpandBenchmark` handler
-/// registered in AutoResearchRemote.cpp. Output uses `esp_rom_printf` because
-/// `FL_PRINT` doesn't currently reach COM25 on P4 (see #2540/#2541).
+/// registered in AutoResearchRemote.cpp. The result struct is JSON-serialized
+/// by the RPC handler; this header no longer prints directly.
 
 #pragma once
 
@@ -19,7 +19,6 @@
 
 #if defined(ARDUINO_ARCH_ESP32) || defined(ESP_PLATFORM)
 #include <Arduino.h>     // micros()
-#include <esp_rom_sys.h> // esp_rom_printf -> USB-Serial-JTAG console (#2540)
 #endif
 
 namespace autoresearch {
@@ -162,42 +161,9 @@ inline Wave8ExpandResult measureWave8Expand(int iters_in = 30000) {
     return result;
 }
 
-/// Optional helper that prints the result via esp_rom_printf (reaches COM25
-/// on P4 today). Used only by the gated boot-time bridge; the RPC handler
-/// JSON-serializes the struct directly. Will be retired in favor of FL_PRINT
-/// once the routing in #2541 is fixed (see #2540).
-inline void printWave8ExpandResultRom(const Wave8ExpandResult &r) {
-    const fl::u64 iters64 = (r.iters > 0) ? r.iters : 1;
-
-    fl::u32 spd_byte = (r.expand_byte_us > 0)
-        ? static_cast<fl::u32>(static_cast<fl::u64>(r.expand_nibble_us) * 100 / r.expand_byte_us) : 0;
-    fl::u32 spd_batched = (r.expand_batched_us > 0)
-        ? static_cast<fl::u32>(static_cast<fl::u64>(r.expand_nibble_us) * 100 / r.expand_batched_us) : 0;
-    fl::u32 spd_t16 = (r.transpose16_byte_us > 0)
-        ? static_cast<fl::u32>(static_cast<fl::u64>(r.transpose16_nibble_us) * 100 / r.transpose16_byte_us) : 0;
-
-    fl::u32 expand_nib_frame = static_cast<fl::u32>(static_cast<fl::u64>(r.expand_nibble_us) * 768 / iters64);
-    fl::u32 expand_byte_frame = static_cast<fl::u32>(static_cast<fl::u64>(r.expand_byte_us) * 768 / iters64);
-    fl::u32 t16_nib_frame = static_cast<fl::u32>(static_cast<fl::u64>(r.transpose16_nibble_us) * 768 / iters64);
-    fl::u32 t16_byte_frame = static_cast<fl::u32>(static_cast<fl::u64>(r.transpose16_byte_us) * 768 / iters64);
-
-    esp_rom_printf("\nBENCH_EXPAND_START (issue #2526)\n");  // ok esp_rom_printf - boot-time bench output to COM25 (#2541)
-    esp_rom_printf("BENCH_EXPAND iters=%u sink=%u\n", r.iters, r.sink);  // ok esp_rom_printf - boot-time bench output to COM25 (#2541)
-    esp_rom_printf("BENCH_EXPAND expand_only_us  nibble=%u byte=%u batched=%u\n",  // ok esp_rom_printf - boot-time bench output to COM25 (#2541)
-                   r.expand_nibble_us, r.expand_byte_us, r.expand_batched_us);
-    esp_rom_printf("BENCH_EXPAND transpose16_us  nibble=%u byte=%u\n",  // ok esp_rom_printf - boot-time bench output to COM25 (#2541)
-                   r.transpose16_nibble_us, r.transpose16_byte_us);
-    esp_rom_printf("BENCH_EXPAND frame_equiv_us  expand_nibble=%u expand_byte=%u t16_nibble=%u t16_byte=%u\n",  // ok esp_rom_printf - boot-time bench output to COM25 (#2541)
-                   expand_nib_frame, expand_byte_frame, t16_nib_frame, t16_byte_frame);
-    esp_rom_printf("BENCH_EXPAND speedup_x100  expand=%u batched=%u transpose16=%u\n",  // ok esp_rom_printf - boot-time bench output to COM25 (#2541)
-                   spd_byte, spd_batched, spd_t16);
-    esp_rom_printf("BENCH_EXPAND_END\n\n");  // ok esp_rom_printf - boot-time bench output to COM25 (#2541)
-}
-
 #else // non-ESP32
 
 inline Wave8ExpandResult measureWave8Expand(int /*iters*/ = 30000) { return {}; }
-inline void printWave8ExpandResultRom(const Wave8ExpandResult & /*r*/) {}
 
 #endif
 

--- a/src/platforms/esp/32/detail/io_esp_jtag_or_uart.hpp
+++ b/src/platforms/esp/32/detail/io_esp_jtag_or_uart.hpp
@@ -8,6 +8,7 @@
 
 #include "platforms/esp/is_esp.h"
 
+#include "fl/log/log.h"  // FL_PRINT (used by reportInitDiagnosticsIfNeeded)
 #include "fl/stl/compiler_control.h"
 #include "fl/stl/singleton.h"
 #include "platforms/esp/32/drivers/uart_esp32.h"
@@ -65,6 +66,7 @@ public:
 
     // Print string to serial
     void print(const char* str) FL_NOEXCEPT {
+        reportInitDiagnosticsIfNeeded();
 #if FL_ESP_HAS_USB_SERIAL_JTAG
         if (mUseUsbSerialJtag) {
             mUsbSerialJtag.write(str);
@@ -78,6 +80,7 @@ public:
 
     // Print string with newline to serial
     void println(const char* str) FL_NOEXCEPT {
+        reportInitDiagnosticsIfNeeded();
 #if FL_ESP_HAS_USB_SERIAL_JTAG
         if (mUseUsbSerialJtag) {
             mUsbSerialJtag.writeln(str);
@@ -211,6 +214,7 @@ private:
     UartEsp32 mUart;       // UART driver (UART0 with console-specific configuration)
     int mPeekByte;         // Cached peek byte
     bool mHasPeek;         // True if peek byte is valid
+    bool mDiagnosticsReported;  // true once the one-shot init diagnostic ran
 
     // Constructor: Initialize drivers with runtime detection
     EspIO()
@@ -221,21 +225,44 @@ private:
 #endif
           mUart(UartConfig::reliable(UartPort::UART0)),
           mPeekByte(-1),
-          mHasPeek(false) {
+          mHasPeek(false),
+          mDiagnosticsReported(false) {
 
 #if FL_ESP_HAS_USB_SERIAL_JTAG
-        // Runtime detection: Prefer USB-Serial JTAG if available and working
-        // The drivers already print their status during initialization
+        // Runtime detection: Prefer USB-Serial JTAG if available and working.
+        // The chosen backend and the JTAG init outcome are surfaced via
+        // reportInitDiagnosticsIfNeeded() on the first user-facing print —
+        // FL_PRINT here would re-enter the in-progress singleton.
+        mUseUsbSerialJtag = mUsbSerialJtag.isBuffered();
+#endif
+    }
 
-        if (mUsbSerialJtag.isBuffered()) {
-            // Our USB-Serial JTAG driver installed successfully
-            mUseUsbSerialJtag = true;
-            esp_rom_printf("EspIO: Using ESP-IDF USB-Serial JTAG driver\n");  // ok esp_rom_printf - USB-Serial-JTAG vs ROM-UART selection log (pre-logging)
-        } else {
-            // USB-Serial JTAG driver failed to install - fall back to UART0
-            mUseUsbSerialJtag = false;
-            esp_rom_printf("EspIO: USB-Serial JTAG installation failed - falling back to UART0\n");  // ok esp_rom_printf - USB-Serial-JTAG vs ROM-UART selection log (pre-logging)
+    // Emit a one-shot human-readable summary of the boot-time backend choice
+    // and the USB-Serial JTAG init outcome. Called from the first user-facing
+    // print/println — guaranteed to run after EspIO construction completes,
+    // so FL_PRINT (which dispatches back through this singleton) is safe.
+    void reportInitDiagnosticsIfNeeded() FL_NOEXCEPT {
+        if (mDiagnosticsReported) {
+            return;
         }
+        mDiagnosticsReported = true;
+#if FL_ESP_HAS_USB_SERIAL_JTAG
+        const char* backend = mUseUsbSerialJtag ? "USB-JTAG" : "UART0";
+        const char* outcome = nullptr;
+        switch (mUsbSerialJtag.initOutcome()) {
+            case UsbSerialJtagEsp32::InitOutcome::kNotInitialized:      outcome = "NotInitialized"; break;
+            case UsbSerialJtagEsp32::InitOutcome::kPreInstalled:        outcome = "PreInstalled"; break;
+            case UsbSerialJtagEsp32::InitOutcome::kInstalledOk:         outcome = "InstalledOk"; break;
+            case UsbSerialJtagEsp32::InitOutcome::kInstalledUnverified: outcome = "InstalledUnverified"; break;
+            case UsbSerialJtagEsp32::InitOutcome::kInstallFailed:       outcome = "InstallFailed"; break;
+            case UsbSerialJtagEsp32::InitOutcome::kVerificationFailed:  outcome = "VerificationFailed"; break;
+            case UsbSerialJtagEsp32::InitOutcome::kNotAvailable:        outcome = "NotAvailable"; break;
+        }
+        FL_PRINT("EspIO: backend=" << backend
+                 << " usb_jtag_outcome=" << outcome
+                 << " err=" << static_cast<int>(mUsbSerialJtag.initError()));
+#else
+        FL_PRINT("EspIO: backend=UART0 (USB-Serial JTAG not compiled)");
 #endif
     }
 

--- a/src/platforms/esp/32/drivers/lcd_spi/lcd_spi_peripheral_esp.cpp.hpp
+++ b/src/platforms/esp/32/drivers/lcd_spi/lcd_spi_peripheral_esp.cpp.hpp
@@ -102,7 +102,9 @@ LcdSpiPeripheralEsp::LcdSpiPeripheralEsp() FL_NOEXCEPT
     : mInitialized(false), mConfig(), mI80Bus(nullptr), mPanelIo(nullptr),
       mCompleteSem(nullptr), mCallback(nullptr), mUserCtx(nullptr),
       mBusy(false), mPendingTransmits(0), mLastTransmitSize(0),
-      mOwner(LcdSpiOwnerDriver::NONE) {}
+      mOwner(LcdSpiOwnerDriver::NONE),
+      mLastWaitForSlotTimeout(false),
+      mLastPanelIoRecreateError(ESP_OK), mLastTxColorError(ESP_OK) {}
 
 LcdSpiPeripheralEsp::~LcdSpiPeripheralEsp() { deinitialize(); }
 
@@ -348,7 +350,10 @@ bool FL_IRAM LcdSpiPeripheralEsp::transmitInternal(
             }
         } else {
             if (xSemaphoreTake(mCompleteSem, pdMS_TO_TICKS(2000)) != pdTRUE) {
-                esp_rom_printf("LcdSpiPeripheralEsp: Timed out waiting for previous transmit to complete\n");  // ok esp_rom_printf - FL_IRAM transmit() context, FL_WARN unsafe
+                // Latch — LoggingInIramChecker forbids FL_WARN anywhere in an
+                // FL_IRAM function, even on a branch that's provably task-only.
+                // Reported from waitTransmitDone() in task context.
+                mLastWaitForSlotTimeout = true;
                 mBusy = false;
                 return false;
             }
@@ -395,7 +400,9 @@ bool FL_IRAM LcdSpiPeripheralEsp::transmitInternal(
         esp_err_t err =
             esp_lcd_new_panel_io_i80(mI80Bus, &io_config, &mPanelIo);
         if (err != ESP_OK) {
-            esp_rom_printf("LcdSpiPeripheralEsp: Failed to recreate panel IO: %d\n", static_cast<int>(err));  // ok esp_rom_printf - FL_IRAM transmit() context, FL_WARN unsafe
+            // Latch — transmit() can be entered from ISR context. Reported
+            // from waitTransmitDone() in task context.
+            mLastPanelIoRecreateError = err;
             return false;
         }
     }
@@ -426,7 +433,9 @@ bool FL_IRAM LcdSpiPeripheralEsp::transmitInternal(
             mPendingTransmits = mPendingTransmits - 1;
         }
         mBusy = mPendingTransmits > 0;
-        esp_rom_printf("LcdSpiPeripheralEsp: tx_color failed: %d\n", static_cast<int>(err));  // ok esp_rom_printf - FL_IRAM transmit() context, FL_WARN unsafe
+        // Latch — transmit() can be entered from ISR context. Reported
+        // from waitTransmitDone() in task context.
+        mLastTxColorError = err;
         return false;
     }
 
@@ -456,6 +465,22 @@ bool LcdSpiPeripheralEsp::waitTransmitDone(u32 timeout_ms) FL_NOEXCEPT {
         }
     }
     mBusy = false;
+
+    // Drain errors latched by the FL_IRAM transmit path. Safe here — this
+    // function is task-only (xSemaphoreTake above would fail configASSERT
+    // from ISR context).
+    if (mLastWaitForSlotTimeout) {
+        FL_WARN("LcdSpiPeripheralEsp: timed out waiting for previous transmit to complete");
+        mLastWaitForSlotTimeout = false;
+    }
+    if (mLastPanelIoRecreateError != ESP_OK) {
+        FL_WARN("LcdSpiPeripheralEsp: panel IO recreate failed: " << static_cast<int>(mLastPanelIoRecreateError));
+        mLastPanelIoRecreateError = ESP_OK;
+    }
+    if (mLastTxColorError != ESP_OK) {
+        FL_WARN("LcdSpiPeripheralEsp: tx_color failed: " << static_cast<int>(mLastTxColorError));
+        mLastTxColorError = ESP_OK;
+    }
     return true;
 }
 

--- a/src/platforms/esp/32/drivers/lcd_spi/lcd_spi_peripheral_esp.cpp.hpp
+++ b/src/platforms/esp/32/drivers/lcd_spi/lcd_spi_peripheral_esp.cpp.hpp
@@ -263,6 +263,13 @@ void LcdSpiPeripheralEsp::teardownLocked() FL_NOEXCEPT {
     mPendingTransmits = 0;
     mLastTransmitSize = 0;
     mOwner = LcdSpiOwnerDriver::NONE;
+
+    // Clear latched errors so a new session (e.g. owner-driver change #2270)
+    // starts clean and a stale error doesn't surface from the next
+    // session's first waitTransmitDone().
+    mLastWaitForSlotTimeout = false;
+    mLastPanelIoRecreateError = ESP_OK;
+    mLastTxColorError = ESP_OK;
 }
 
 void LcdSpiPeripheralEsp::deinitialize() FL_NOEXCEPT {

--- a/src/platforms/esp/32/drivers/lcd_spi/lcd_spi_peripheral_esp.h
+++ b/src/platforms/esp/32/drivers/lcd_spi/lcd_spi_peripheral_esp.h
@@ -102,6 +102,14 @@ class LcdSpiPeripheralEsp : public ILcdSpiPeripheral {
     volatile size_t mPendingTransmits;
     size_t mLastTransmitSize;
     LcdSpiOwnerDriver mOwner; ///< Tracks which driver owns the singleton (#2270).
+
+    // Latched errors from the FL_IRAM transmit path. transmit() may be called
+    // from ISR context (see ChannelDriverLcdClockless::isrChunkDone), so direct
+    // FL_WARN there is unsafe (LoggingInIramChecker forbids it). waitTransmitDone()
+    // drains and reports these in task context.
+    volatile bool mLastWaitForSlotTimeout;
+    volatile esp_err_t mLastPanelIoRecreateError;
+    volatile esp_err_t mLastTxColorError;
 };
 
 } // namespace detail

--- a/src/platforms/esp/32/drivers/usb_serial_jtag_esp32.h
+++ b/src/platforms/esp/32/drivers/usb_serial_jtag_esp32.h
@@ -159,12 +159,36 @@ public:
      */
     bool isBuffered() const FL_NOEXCEPT { return mBuffered; }
 
+    /**
+     * @brief Outcome of the constructor's driver-install attempt
+     *
+     * Records what happened during initDriver() so callers (notably EspIO)
+     * can surface a single human-readable diagnostic once the normal logging
+     * sink is up — the install runs inside the singleton constructor where
+     * FL_PRINT would re-enter the in-progress singleton.
+     */
+    enum class InitOutcome : u8 {
+        kNotInitialized = 0,
+        kPreInstalled,          ///< driver was already installed (Arduino/bootloader)
+        kInstalledOk,           ///< we installed and verified the driver
+        kInstalledUnverified,   ///< we installed, verification API unavailable (IDF<5.4)
+        kInstallFailed,         ///< usb_serial_jtag_driver_install returned non-OK
+        kVerificationFailed,    ///< installed but is_driver_installed() returned false
+        kNotAvailable,          ///< chip lacks USB-Serial JTAG support
+    };
+
+    InitOutcome initOutcome() const FL_NOEXCEPT { return mInitOutcome; }
+    // esp_err_t == int32_t. Returns ESP_OK (0) unless initOutcome() == kInstallFailed.
+    i32 initError() const FL_NOEXCEPT { return mInitError; }
+
 private:
     UsbSerialJtagConfig mConfig;  // Configuration parameters
     bool mBuffered;               // true if driver installed, false if using ROM fallback
     bool mInstalledDriver;        // true if WE installed the driver (vs inherited from Arduino)
     bool mHasPeek;                // true if available() cached one byte
     u8 mPeekByte;                 // cached byte from the non-blocking availability probe
+    InitOutcome mInitOutcome;     // recorded constructor outcome (see InitOutcome)
+    i32 mInitError;               // esp_err_t from driver_install on kInstallFailed
     static constexpr size_t kRxCacheSize = 64;
     u8 mRxCache[kRxCacheSize];    // bytes prefetched by available()
     size_t mRxCacheRead;          // read index into mRxCache

--- a/src/platforms/esp/32/drivers/usb_serial_jtag_esp32_idf.hpp
+++ b/src/platforms/esp/32/drivers/usb_serial_jtag_esp32_idf.hpp
@@ -6,6 +6,7 @@
 #ifdef FL_IS_ESP32
 
 #include "usb_serial_jtag_esp32.h"
+#include "fl/log/log.h"  // FL_WARN
 #include "fl/stl/assert.h"
 #include "fl/stl/noexcept.h"
 #include "platforms/esp/esp_version.h"
@@ -51,6 +52,8 @@ UsbSerialJtagEsp32::UsbSerialJtagEsp32(const UsbSerialJtagConfig& config)
     , mInstalledDriver(false)
     , mHasPeek(false)
     , mPeekByte(0)
+    , mInitOutcome(InitOutcome::kNotInitialized)
+    , mInitError(0)
     , mRxCacheRead(0)
     , mRxCacheCount(0) {
 
@@ -62,7 +65,6 @@ UsbSerialJtagEsp32::~UsbSerialJtagEsp32() {
 #ifdef FL_HAS_USB_SERIAL_JTAG
     // Only uninstall if WE installed it (don't uninstall Arduino's driver)
     if (mInstalledDriver) {
-        esp_rom_printf("USB-Serial JTAG: Uninstalling driver\n");  // ok esp_rom_printf - USB-Serial-JTAG driver bootstrap (pre-logging)
         usb_serial_jtag_driver_uninstall();
     }
 #endif
@@ -74,6 +76,8 @@ UsbSerialJtagEsp32::UsbSerialJtagEsp32(UsbSerialJtagEsp32&& other) FL_NOEXCEPT
     , mInstalledDriver(other.mInstalledDriver)
     , mHasPeek(other.mHasPeek)
     , mPeekByte(other.mPeekByte)
+    , mInitOutcome(other.mInitOutcome)
+    , mInitError(other.mInitError)
     , mRxCacheRead(other.mRxCacheRead)
     , mRxCacheCount(other.mRxCacheCount) {
     for (size_t i = 0; i < kRxCacheSize; ++i) {
@@ -103,6 +107,8 @@ UsbSerialJtagEsp32& UsbSerialJtagEsp32::operator=(UsbSerialJtagEsp32&& other) FL
         mInstalledDriver = other.mInstalledDriver;
         mHasPeek = other.mHasPeek;
         mPeekByte = other.mPeekByte;
+        mInitOutcome = other.mInitOutcome;
+        mInitError = other.mInitError;
         mRxCacheRead = other.mRxCacheRead;
         mRxCacheCount = other.mRxCacheCount;
         for (size_t i = 0; i < kRxCacheSize; ++i) {
@@ -121,27 +127,22 @@ UsbSerialJtagEsp32& UsbSerialJtagEsp32::operator=(UsbSerialJtagEsp32&& other) FL
 }
 
 bool UsbSerialJtagEsp32::initDriver() FL_NOEXCEPT {
+    // NOTE: this runs from the UsbSerialJtagEsp32 / EspIO singleton
+    // constructor — FL_PRINT would re-enter the in-progress singleton. All
+    // outcome state is recorded in mInitOutcome / mInitError; EspIO surfaces
+    // a single human-readable diagnostic once the normal logging sink is up.
 #ifdef FL_HAS_USB_SERIAL_JTAG
-    esp_rom_printf("\n=== USB-Serial JTAG Driver Init ===\n");  // ok esp_rom_printf - USB-Serial-JTAG driver bootstrap (pre-logging)
-
     // ROBUST DRIVER DETECTION:
     // usb_serial_jtag_is_driver_installed() was added in ESP-IDF 5.4.0
     // For earlier versions, we attempt to install and handle errors
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 4, 0)
     // Use usb_serial_jtag_is_driver_installed() to check if driver already exists
     if (usb_serial_jtag_is_driver_installed()) {
-        esp_rom_printf("USB-Serial JTAG: Driver already installed (inherited from Arduino or bootloader)\n");  // ok esp_rom_printf - USB-Serial-JTAG driver bootstrap (pre-logging)
         mBuffered = true;
         mInstalledDriver = false;  // We didn't install it, so don't uninstall it
+        mInitOutcome = InitOutcome::kPreInstalled;
         return true;  // Success: driver is installed and functional
     }
-
-    // Driver not installed - install it ourselves
-    esp_rom_printf("USB-Serial JTAG: Driver not detected, installing...\n");  // ok esp_rom_printf - USB-Serial-JTAG driver bootstrap (pre-logging)
-#else
-    // ESP-IDF < 5.4.0: No is_driver_installed() function available
-    // Attempt to install driver - if it fails with ESP_ERR_INVALID_STATE, driver already installed
-    esp_rom_printf("USB-Serial JTAG: Attempting driver installation...\n");  // ok esp_rom_printf - USB-Serial-JTAG driver bootstrap (pre-logging)
 #endif
 
     // Configure USB-Serial JTAG with buffer sizes
@@ -149,30 +150,24 @@ bool UsbSerialJtagEsp32::initDriver() FL_NOEXCEPT {
     usb_config.tx_buffer_size = static_cast<u32>(mConfig.txBufferSize);
     usb_config.rx_buffer_size = static_cast<u32>(mConfig.rxBufferSize);
 
-    esp_rom_printf("USB-Serial JTAG: Installing driver (rx_buf=%d, tx_buf=%d)...\n",  // ok esp_rom_printf - USB-Serial-JTAG driver bootstrap (pre-logging)
-                  static_cast<int>(mConfig.rxBufferSize),
-                  static_cast<int>(mConfig.txBufferSize));
-
     esp_err_t err = usb_serial_jtag_driver_install(&usb_config);
 
     if (err == ESP_OK) {
-        esp_rom_printf("USB-Serial JTAG: Driver installed successfully!\n");  // ok esp_rom_printf - USB-Serial-JTAG driver bootstrap (pre-logging)
         mBuffered = true;
         mInstalledDriver = true;  // We installed it, so we'll uninstall it later
 
         // Add small delay after driver installation (similar to UART)
         vTaskDelay(50 / portTICK_PERIOD_MS);  // 50ms delay
-        esp_rom_printf("USB-Serial JTAG: Post-install delay complete\n");  // ok esp_rom_printf - USB-Serial-JTAG driver bootstrap (pre-logging)
 
         // Verify installation worked (only if function is available)
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 4, 0)
         if (usb_serial_jtag_is_driver_installed()) {
-            esp_rom_printf("USB-Serial JTAG: Verification OK - buffered mode active\n");  // ok esp_rom_printf - USB-Serial-JTAG driver bootstrap (pre-logging)
+            mInitOutcome = InitOutcome::kInstalledOk;
         } else {
-            esp_rom_printf("WARNING: USB-Serial JTAG verification failed\n");  // ok esp_rom_printf - USB-Serial-JTAG driver bootstrap (pre-logging)
+            mInitOutcome = InitOutcome::kVerificationFailed;
         }
 #else
-        esp_rom_printf("USB-Serial JTAG: Driver installed (verification not available in IDF < 5.4)\n");  // ok esp_rom_printf - USB-Serial-JTAG driver bootstrap (pre-logging)
+        mInitOutcome = InitOutcome::kInstalledUnverified;
 #endif
 
         return true;
@@ -180,25 +175,27 @@ bool UsbSerialJtagEsp32::initDriver() FL_NOEXCEPT {
 
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 4, 0)
     // Installation failed - will fall back to ROM UART
-    esp_rom_printf("ERROR: USB-Serial JTAG driver installation failed (err=0x%x) - FALLING BACK TO ROM UART\n", err);  // ok esp_rom_printf - USB-Serial-JTAG driver bootstrap (pre-logging)
+    mInitOutcome = InitOutcome::kInstallFailed;
+    mInitError = static_cast<i32>(err);
     return false;
 #else
     // ESP-IDF < 5.4.0: If installation failed with ESP_ERR_INVALID_STATE, driver is already installed by Arduino
     if (err == ESP_ERR_INVALID_STATE) {
-        esp_rom_printf("USB-Serial JTAG: Driver already installed by Arduino/bootloader\n");  // ok esp_rom_printf - USB-Serial-JTAG driver bootstrap (pre-logging)
         mBuffered = true;
         mInstalledDriver = false;  // We didn't install it, so don't uninstall it
+        mInitOutcome = InitOutcome::kPreInstalled;
         return true;
     }
 
     // Other errors - fall back to ROM UART
-    esp_rom_printf("ERROR: USB-Serial JTAG driver installation failed (err=0x%x) - FALLING BACK TO ROM UART\n", err);  // ok esp_rom_printf - USB-Serial-JTAG driver bootstrap (pre-logging)
+    mInitOutcome = InitOutcome::kInstallFailed;
+    mInitError = static_cast<i32>(err);
     return false;
 #endif
 
 #else
     // USB-Serial JTAG not available on this chip - fall back to ROM UART
-    esp_rom_printf("USB-Serial JTAG: Not available on this chip - using ROM UART\n");  // ok esp_rom_printf - USB-Serial-JTAG driver bootstrap (pre-logging)
+    mInitOutcome = InitOutcome::kNotAvailable;
     return false;
 #endif
 }
@@ -225,7 +222,7 @@ void UsbSerialJtagEsp32::write(const char* str) FL_NOEXCEPT {
                 src += (size_t)written;
                 remaining -= (size_t)written;
             } else if (written < 0) {
-                esp_rom_printf("ERROR: USB-Serial JTAG write failed (err=%d)\n", written);  // ok esp_rom_printf - USB-Serial-JTAG driver bootstrap (pre-logging)
+                FL_WARN("USB-Serial JTAG write failed: err=" << written);
                 break;
             }
             // written == 0: buffer full, will retry after timeout
@@ -296,7 +293,7 @@ void UsbSerialJtagEsp32::writeln(const char* str) FL_NOEXCEPT {
                 src += (size_t)written;
                 remaining -= (size_t)written;
             } else if (written < 0) {
-                esp_rom_printf("ERROR: USB-Serial JTAG writeln failed (err=%d)\n", written);  // ok esp_rom_printf - USB-Serial-JTAG driver bootstrap (pre-logging)
+                FL_WARN("USB-Serial JTAG writeln failed: err=" << written);
                 break;
             }
             // written == 0: buffer full after timeout, retry


### PR DESCRIPTION
## Summary

Removes every runtime `esp_rom_printf` site under `examples/AutoResearch` and `src/platforms/esp`, replacing each with a FastLED-owned mechanism. The `EspRomPrintfChecker` and its tests are unchanged — only the runtime offenders go.

Acceptance criterion from the issue:
```
rg -n 'esp_rom_printf\(' examples/AutoResearch src/platforms/esp -g '*.h' -g '*.hpp' -g '*.cpp'
```
returns empty on this branch.

## Per-file change

- **`examples/AutoResearch/AutoResearch{Wave8Expand,ParlioEncode}.h`** — delete `printXxxResultRom` helpers entirely. They are dead code; no caller exists anywhere in the repo. The RPC handlers JSON-serialize the result struct directly, and the boot-time ROM-printf bridge was a stopgap for #2540/#2541 that is no longer needed now that #2541 has landed.
- **`src/platforms/esp/32/drivers/usb_serial_jtag_esp32{,_idf.hpp}`** — the 16 driver-bootstrap esp_rom_printf calls ran inside the singleton constructor, where FL_PRINT would re-enter the in-progress singleton. Replaced with a `UsbSerialJtagEsp32::InitOutcome` enum recorded in a member field + `initOutcome()` / `initError()` getters. The two non-bootstrap runtime errors in `write()` / `writeln()` become FL_WARN directly (task context).
- **`src/platforms/esp/32/detail/io_esp_jtag_or_uart.hpp`** — drop the 2 backend-selection esp_rom_printf lines from the EspIO constructor; backend state is already in `mUseUsbSerialJtag`. Adds `reportInitDiagnosticsIfNeeded()` invoked at the top of `print()` / `println()` which emits a one-shot FL_PRINT summary (`EspIO: backend=USB-JTAG usb_jtag_outcome=InstalledOk err=0`) once construction has completed and FL_PRINT is safe.
- **`src/platforms/esp/32/drivers/lcd_spi/lcd_spi_peripheral_esp.{h,cpp.hpp}`** — the 3 esp_rom_printf calls lived in an FL_IRAM function that may be entered from ISR context. `LoggingInIramChecker` forbids FL_WARN inside FL_IRAM functions, so direct replacement is not possible. Latch each failure into `mLast{WaitForSlotTimeout,PanelIoRecreateError,TxColorError}` and drain via FL_WARN from `waitTransmitDone()` — task-only, since `xSemaphoreTake` would configASSERT from ISR.

## Resolution of the two open questions in the issue

The issue listed two unanswered architectural decisions. Per user direction:

1. **USB-Serial JTAG bootstrap diagnostics** → **defer via status getter** (implemented as `UsbSerialJtagEsp32::InitOutcome` + `EspIO::reportInitDiagnosticsIfNeeded`).
2. **Tighten `EspRomPrintfChecker` to forbid `// ok esp_rom_printf` in runtime source** → **out of scope for this PR**, left as a follow-up if marker creep becomes a problem.

## Test plan

- [x] `bash lint` — green (Python + C++ checkers + JS).
- [x] `bash test --cpp` — 309/309 host tests passed.
- [ ] CI: ESP32 platform compile matrix (deferred to PR CI; all changed files are ESP32-gated).
- [x] `rg -n 'esp_rom_printf\(' examples/AutoResearch src/platforms/esp -g '*.h' -g '*.hpp' -g '*.cpp'` returns empty.

Closes #2699

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exposed richer USB‑Serial JTAG initialization diagnostics for visibility.
  * Benchmarks updated to be RPC-only with results JSON‑serialized by the RPC handler.

* **Bug Fixes**
  * Deferred diagnostics until first print to avoid unsafe interrupt‑context logging.
  * LCD SPI now latches transmit errors in IRAM context and reports them safely from task context.
  * Replaced direct ROM console prints with structured logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->