### PR TITLE
feat(watchdog): Teensy 4 bare-register WDOG3 impl, hardware-verified

### DIFF
--- a/examples/AutoResearch/AutoResearch.ino
+++ b/examples/AutoResearch/AutoResearch.ino
@@ -312,15 +312,37 @@ void setup() {
 
     FL_WARN("[SETUP] AutoResearch sketch starting - serial output active");
 
-    // Unified cross-platform watchdog (FastLED#2731) is wired through the
-    // FastLED.watchdog() accessor. On ESP32 we keep the existing
-    // fl::watchdog_setup() behavior (universally validated). On Teensy 4
-    // the bare-register WDOG3 path needs more hardware iteration before
-    // it's safe to arm here by default — the unified API still compiles
-    // and is available for sketches that opt in.
-#if defined(FL_IS_ESP32)
-    FastLED.watchdog().begin(15000);
+    // Diagnostic: dump reset cause + bundled CrashReport so we can tell
+    // HardFault vs WDOG3 vs PIN vs POR. Direct register access — `imxrt.h`
+    // is already pulled by FastLED.h on Teensy 4.
+#if defined(FL_IS_TEENSY_4X) && defined(__IMXRT1062__)
+    {
+        const uint32_t srsr = SRC_SRSR;
+        Serial.printf("[boot] SRC_SRSR = 0x%08lx\n", (unsigned long)srsr);
+        if (srsr & (1u << 7))  Serial.println("[boot]   WDOG3_RST_B (RTWDOG fired)");
+        if (srsr & (1u << 0))  Serial.println("[boot]   POR (power-on reset)");
+        if (srsr & (1u << 4))  Serial.println("[boot]   LOCKUP_SYSRESETREQ (HardFault SYSRESETREQ)");
+        if (srsr & (1u << 5))  Serial.println("[boot]   IPP_USER_RESET_B (external pin)");
+        if (srsr & (1u << 8))  Serial.println("[boot]   JTAG/SW reset");
+        // Write-1-to-clear so next boot sees only its own cause.
+        SRC_SRSR = srsr;
+        if (CrashReport) {
+            Serial.println("[boot] *** CrashReport present from previous boot: ***");
+            Serial.print(CrashReport);
+            Serial.println("[boot] *** end CrashReport ***");
+        } else {
+            Serial.println("[boot] no CrashReport from previous boot");
+        }
+        Serial.flush();
+    }
 #endif
+
+    // Unified cross-platform watchdog (FastLED#2731). Arm at 15 s.
+    FastLED.watchdog().begin(15000);
+    if (FastLED.watchdog().lastResetWasWatchdog()) {
+        FL_WARN("[recovery] previous boot was killed by watchdog — crash#"
+                << static_cast<int>(FastLED.watchdog().consecutiveCrashCount()));
+    }
 
     // Initialize RX buffer dynamically (uses PSRAM if available, falls back to heap)
     g_rx_buffer_storage.resize(RX_BUFFER_SIZE);
@@ -501,13 +523,11 @@ void loop() {
         while (true) { /* deliberate hang */ }
     }
 
-    // Feed + markCleanShutdown only on platforms where we armed in setup().
-    // On platforms where begin() was a no-op, these are also no-ops, but
-    // gating keeps the intent explicit.
-#if defined(FL_IS_ESP32)
+    // Feed the watchdog at the end of every loop iteration. On platforms
+    // where begin() was a no-op the feed is also a no-op, so this is
+    // unconditional.
     FastLED.watchdog().feed();
     FastLED.watchdog().markCleanShutdown();
-#endif
 
     // Run GPIO baseline test once after device is ready (allows JSON-RPC to be operational first)
     // This test is informational only - we continue regardless of pass/fail

--- a/examples/AutoResearch/AutoResearch.ino
+++ b/examples/AutoResearch/AutoResearch.ino
@@ -293,6 +293,60 @@ using RemoteControlSingleton = fl::Singleton<AutoResearchRemoteControl>;
 uint32_t frame_counter = 0;
 
 
+#if defined(FL_IS_TEENSY_4X) && defined(__IMXRT1062__)
+// =============================================================================
+// CRITICAL: WDOG3 (RTWDOG) startup-early-hook recovery (FastLED#2731)
+// =============================================================================
+// The iMXRT1062 RTWDOG (WDOG3) is enabled by default at chip reset with
+// TOVAL = 0x400 LPO ticks ≈ 32 ms. The Teensy 4 core does NOT disable it in
+// startup.c — most sketches happen to be fast enough or stay in WAIT mode
+// where WDOG3 stops counting, so it never bites in practice.
+//
+// But if a previous run armed WDOG3 with a short timeout, or if any
+// peripheral init takes longer than 32 ms, the chip enters a reset loop
+// where the new sketch can't even complete USB enumeration. Symptom: red
+// LED double-blink + "Unknown USB Device (Device Descriptor Request Failed)".
+//
+// `startup_early_hook` is a weak symbol in Teensyduino's startup.c that runs
+// very early in ResetHandler2(), before main() and before ITCM is even
+// initialized. Overriding it here disables WDOG3 BEFORE any other code can
+// observe a reset. Must be in FLASHMEM (ITCM not ready yet).
+extern "C" FLASHMEM void startup_early_hook(void) {
+    // Enable the WDOG3 clock gate (CCM_CCGR5 bits 4-5) so the WDOG3
+    // peripheral registers are addressable. Per imxrt.h comment:
+    // "WDOG3 requires CCM_CCGR5_WDOG3".
+    CCM_CCGR5 |= CCM_CCGR5_WDOG3(3);
+
+    // Unlock RTWDOG with the 32-bit key (works because CS.CMD32EN=1 at reset).
+    WDOG3_CNT = 0xD928C520u;
+
+    // Wait for the unlock window to open. Bounded spin — if for any reason
+    // the unlock never lands, we'd rather continue and let the WDOG bite
+    // than hang here forever.
+    {
+        volatile uint32_t spin = 0;
+        while (!(WDOG3_CS & WDOG_CS_ULK)) {
+            if (++spin > 200000u) break;
+        }
+    }
+
+    // Disable: clear EN, keep CMD32EN+UPDATE+CLK(LPO) so future arms work.
+    // Set TOVAL to max so even if the disable doesn't take, we have ~524 sec
+    // before any reset can occur.
+    WDOG3_TOVAL = 0xFFFFu;
+    WDOG3_WIN = 0;
+    WDOG3_CS = WDOG_CS_CMD32EN | WDOG_CS_UPDATE | WDOG_CS_CLK(1);  // EN=0
+
+    // Wait for reconfigure complete (bounded).
+    {
+        volatile uint32_t spin = 0;
+        while (!(WDOG3_CS & WDOG_CS_RCS)) {
+            if (++spin > 200000u) break;
+        }
+    }
+}
+#endif
+
 void setup() {
     // Initialize serial buffers with platform-specific configuration
     // Must be called BEFORE Serial.begin()

--- a/examples/AutoResearch/AutoResearch.ino
+++ b/examples/AutoResearch/AutoResearch.ino
@@ -525,7 +525,13 @@ void loop() {
     if (g_autoresearch_state->deliberate_hang_requested) {
         FL_WARN("[deliberateHang] entering forced-hang loop NOW");
         delay(200);  // give Serial TX FIFO time to flush
+        // noInterrupts() is an Arduino-only macro; guard it so the host stub
+        // build (which compiles this .ino for the unit-test framework) doesn't
+        // hit an undeclared identifier. On host the while(1) below still spins
+        // and prevents feed(), which is the actual hang we want to test.
+#if !defined(FL_IS_STUB) && !defined(FL_IS_WASM)
         noInterrupts();
+#endif
         while (true) { /* deliberate hang */ }
     }
 

--- a/examples/AutoResearch/AutoResearch.ino
+++ b/examples/AutoResearch/AutoResearch.ino
@@ -318,31 +318,37 @@ void setup() {
 #if defined(FL_IS_TEENSY_4X) && defined(__IMXRT1062__)
     {
         const uint32_t srsr = SRC_SRSR;
-        Serial.printf("[boot] SRC_SRSR = 0x%08lx\n", (unsigned long)srsr);
-        if (srsr & (1u << 7))  Serial.println("[boot]   WDOG3_RST_B (RTWDOG fired)");
-        if (srsr & (1u << 0))  Serial.println("[boot]   POR (power-on reset)");
-        if (srsr & (1u << 4))  Serial.println("[boot]   LOCKUP_SYSRESETREQ (HardFault SYSRESETREQ)");
-        if (srsr & (1u << 5))  Serial.println("[boot]   IPP_USER_RESET_B (external pin)");
-        if (srsr & (1u << 8))  Serial.println("[boot]   JTAG/SW reset");
+        Serial.print("[boot] SRC_SRSR = 0x");  // ok serial - boot diagnostic, Teensy 4 only
+        Serial.println(srsr, HEX);             // ok serial - boot diagnostic, Teensy 4 only
+        if (srsr & (1u << 7))  Serial.println("[boot]   WDOG3_RST_B (RTWDOG fired)");  // ok serial - boot diagnostic
+        if (srsr & (1u << 0))  Serial.println("[boot]   POR (power-on reset)");  // ok serial - boot diagnostic
+        if (srsr & (1u << 4))  Serial.println("[boot]   LOCKUP_SYSRESETREQ (HardFault SYSRESETREQ)");  // ok serial - boot diagnostic
+        if (srsr & (1u << 5))  Serial.println("[boot]   IPP_USER_RESET_B (external pin)");  // ok serial - boot diagnostic
+        if (srsr & (1u << 8))  Serial.println("[boot]   JTAG/SW reset");  // ok serial - boot diagnostic
         // Write-1-to-clear so next boot sees only its own cause.
         SRC_SRSR = srsr;
         if (CrashReport) {
-            Serial.println("[boot] *** CrashReport present from previous boot: ***");
-            Serial.print(CrashReport);
-            Serial.println("[boot] *** end CrashReport ***");
+            Serial.println("[boot] *** CrashReport present from previous boot: ***");  // ok serial - boot diagnostic
+            Serial.print(CrashReport);  // ok serial - bundled Teensy CrashReport, no fl:: equivalent
+            Serial.println("[boot] *** end CrashReport ***");  // ok serial - boot diagnostic
         } else {
-            Serial.println("[boot] no CrashReport from previous boot");
+            Serial.println("[boot] no CrashReport from previous boot");  // ok serial - boot diagnostic
         }
-        Serial.flush();
+        Serial.flush();  // ok serial - boot diagnostic flush
     }
 #endif
 
-    // Unified cross-platform watchdog (FastLED#2731). Arm at 15 s.
+    // Unified cross-platform watchdog (FastLED#2731). DEBUG: gated to ESP32
+    // only while we bisect why the Teensy 4 boot is failing — the diagnostic
+    // prints above run unconditionally, so if Teensy enumerates USB cleanly
+    // now we know begin() is the trigger and SRC_SRSR will reveal the cause.
+#if defined(FL_IS_ESP32)
     FastLED.watchdog().begin(15000);
     if (FastLED.watchdog().lastResetWasWatchdog()) {
         FL_WARN("[recovery] previous boot was killed by watchdog — crash#"
                 << static_cast<int>(FastLED.watchdog().consecutiveCrashCount()));
     }
+#endif
 
     // Initialize RX buffer dynamically (uses PSRAM if available, falls back to heap)
     g_rx_buffer_storage.resize(RX_BUFFER_SIZE);
@@ -523,11 +529,12 @@ void loop() {
         while (true) { /* deliberate hang */ }
     }
 
-    // Feed the watchdog at the end of every loop iteration. On platforms
-    // where begin() was a no-op the feed is also a no-op, so this is
-    // unconditional.
+    // DEBUG: gated to ESP32 while we bisect Teensy 4 boot. If feed() also
+    // touches WDOG3 registers without armed state it could be the culprit.
+#if defined(FL_IS_ESP32)
     FastLED.watchdog().feed();
     FastLED.watchdog().markCleanShutdown();
+#endif
 
     // Run GPIO baseline test once after device is ready (allows JSON-RPC to be operational first)
     // This test is informational only - we continue regardless of pass/fail

--- a/examples/AutoResearch/AutoResearch.ino
+++ b/examples/AutoResearch/AutoResearch.ino
@@ -312,23 +312,15 @@ void setup() {
 
     FL_WARN("[SETUP] AutoResearch sketch starting - serial output active");
 
-    // Unified cross-platform watchdog (FastLED#2731). 15 s timeout matches
-    // the AutoResearch test budget. On Teensy 4 / Teensy 3 / RP / nRF52 /
-    // STM32 / SAMD / AVR / Apollo3 / MGM240 this is a real hardware WDT;
-    // on platforms without an impl (or with their optional library missing)
-    // this is a no-op via the FL_HAS_INCLUDE fallback. ESP32 also keeps its
-    // existing fl::watchdog_setup() wiring via the same accessor.
+    // Unified cross-platform watchdog (FastLED#2731) is wired through the
+    // FastLED.watchdog() accessor. On ESP32 we keep the existing
+    // fl::watchdog_setup() behavior (universally validated). On Teensy 4
+    // the bare-register WDOG3 path needs more hardware iteration before
+    // it's safe to arm here by default — the unified API still compiles
+    // and is available for sketches that opt in.
+#if defined(FL_IS_ESP32)
     FastLED.watchdog().begin(15000);
-    if (FastLED.watchdog().isInSafeMode()) {
-        FL_WARN("[SAFE MODE] previous boots crashed — LED peripheral disabled");
-        // Hang here forever WITHOUT feeding the watchdog so the board
-        // stays USB-recoverable and a new firmware upload can rescue it.
-        while (true) { fl::task::run(); }
-    }
-    if (FastLED.watchdog().lastResetWasWatchdog()) {
-        FL_WARN("[recovery] previous boot was killed by watchdog — crash#"
-                << static_cast<int>(FastLED.watchdog().consecutiveCrashCount()));
-    }
+#endif
 
     // Initialize RX buffer dynamically (uses PSRAM if available, falls back to heap)
     g_rx_buffer_storage.resize(RX_BUFFER_SIZE);
@@ -509,12 +501,13 @@ void loop() {
         while (true) { /* deliberate hang */ }
     }
 
-    // Feed the watchdog. We do this AFTER the dangerous work (task::run +
-    // GPIO baseline below) succeeded. If anything wedged above, this line
-    // is never reached, the watchdog fires, and the board resets into
-    // safe-mode recovery on the next boot.
+    // Feed + markCleanShutdown only on platforms where we armed in setup().
+    // On platforms where begin() was a no-op, these are also no-ops, but
+    // gating keeps the intent explicit.
+#if defined(FL_IS_ESP32)
     FastLED.watchdog().feed();
     FastLED.watchdog().markCleanShutdown();
+#endif
 
     // Run GPIO baseline test once after device is ready (allows JSON-RPC to be operational first)
     // This test is informational only - we continue regardless of pass/fail

--- a/examples/AutoResearch/AutoResearch.ino
+++ b/examples/AutoResearch/AutoResearch.ino
@@ -311,9 +311,24 @@ void setup() {
     while (!fl::serial_ready() && (millis() - serial_wait_start) < AUTORESEARCH_SERIAL_WAIT_MS);  // Wait for serial monitor (early exits when connected)
 
     FL_WARN("[SETUP] AutoResearch sketch starting - serial output active");
-#if defined(FL_IS_ESP32)
-    fl::watchdog_setup(15000);
-#endif
+
+    // Unified cross-platform watchdog (FastLED#2731). 15 s timeout matches
+    // the AutoResearch test budget. On Teensy 4 / Teensy 3 / RP / nRF52 /
+    // STM32 / SAMD / AVR / Apollo3 / MGM240 this is a real hardware WDT;
+    // on platforms without an impl (or with their optional library missing)
+    // this is a no-op via the FL_HAS_INCLUDE fallback. ESP32 also keeps its
+    // existing fl::watchdog_setup() wiring via the same accessor.
+    FastLED.watchdog().begin(15000);
+    if (FastLED.watchdog().isInSafeMode()) {
+        FL_WARN("[SAFE MODE] previous boots crashed — LED peripheral disabled");
+        // Hang here forever WITHOUT feeding the watchdog so the board
+        // stays USB-recoverable and a new firmware upload can rescue it.
+        while (true) { fl::task::run(); }
+    }
+    if (FastLED.watchdog().lastResetWasWatchdog()) {
+        FL_WARN("[recovery] previous boot was killed by watchdog — crash#"
+                << static_cast<int>(FastLED.watchdog().consecutiveCrashCount()));
+    }
 
     // Initialize RX buffer dynamically (uses PSRAM if available, falls back to heap)
     g_rx_buffer_storage.resize(RX_BUFFER_SIZE);
@@ -477,6 +492,29 @@ void loop() {
     for (int i = 0; i < 100; i++) {
         fl::task::run();
     }
+
+    // ========================================================================
+    // Watchdog autoresearch trigger (FastLED#2731) — when the host RPC sends
+    // `deliberateHang`, the handler flips this flag. We let one more pass of
+    // task::run() drain the response queue so the host sees the ACK, then
+    // we disable interrupts (so no async machinery can keep the WDT happy)
+    // and spin forever. The next watchdog tick must fire and reset the chip.
+    // The host's recovery test passes if the device re-enumerates afterward
+    // and is reflashable.
+    // ========================================================================
+    if (g_autoresearch_state->deliberate_hang_requested) {
+        FL_WARN("[deliberateHang] entering forced-hang loop NOW");
+        delay(200);  // give Serial TX FIFO time to flush
+        noInterrupts();
+        while (true) { /* deliberate hang */ }
+    }
+
+    // Feed the watchdog. We do this AFTER the dangerous work (task::run +
+    // GPIO baseline below) succeeded. If anything wedged above, this line
+    // is never reached, the watchdog fires, and the board resets into
+    // safe-mode recovery on the next boot.
+    FastLED.watchdog().feed();
+    FastLED.watchdog().markCleanShutdown();
 
     // Run GPIO baseline test once after device is ready (allows JSON-RPC to be operational first)
     // This test is informational only - we continue regardless of pass/fail

--- a/examples/AutoResearch/AutoResearch.ino
+++ b/examples/AutoResearch/AutoResearch.ino
@@ -392,17 +392,16 @@ void setup() {
     }
 #endif
 
-    // Unified cross-platform watchdog (FastLED#2731). DEBUG: gated to ESP32
-    // only while we bisect why the Teensy 4 boot is failing — the diagnostic
-    // prints above run unconditionally, so if Teensy enumerates USB cleanly
-    // now we know begin() is the trigger and SRC_SRSR will reveal the cause.
-#if defined(FL_IS_ESP32)
+    // Unified cross-platform watchdog (FastLED#2731). Arm with a generous
+    // 15-second timeout that matches the AutoResearch test budget. On
+    // Teensy 4 the bare-register WDOG3 begin() path now relies on the
+    // `startup_early_hook` above having pre-disabled WDOG3, so re-arming
+    // here goes through a clean unlock → write → RCS-wait sequence.
     FastLED.watchdog().begin(15000);
     if (FastLED.watchdog().lastResetWasWatchdog()) {
         FL_WARN("[recovery] previous boot was killed by watchdog — crash#"
                 << static_cast<int>(FastLED.watchdog().consecutiveCrashCount()));
     }
-#endif
 
     // Initialize RX buffer dynamically (uses PSRAM if available, falls back to heap)
     g_rx_buffer_storage.resize(RX_BUFFER_SIZE);
@@ -589,12 +588,12 @@ void loop() {
         while (true) { /* deliberate hang */ }
     }
 
-    // DEBUG: gated to ESP32 while we bisect Teensy 4 boot. If feed() also
-    // touches WDOG3 registers without armed state it could be the culprit.
-#if defined(FL_IS_ESP32)
+    // Feed the watchdog at the end of every loop iteration. On platforms
+    // where begin() was a no-op the feed is also a no-op. The mark-clean
+    // shutdown zeros the consecutive-crash counter so a transient hang
+    // doesn't eventually push the board into safe mode.
     FastLED.watchdog().feed();
     FastLED.watchdog().markCleanShutdown();
-#endif
 
     // Run GPIO baseline test once after device is ready (allows JSON-RPC to be operational first)
     // This test is informational only - we continue regardless of pass/fail

--- a/examples/AutoResearch/AutoResearch.ino
+++ b/examples/AutoResearch/AutoResearch.ino
@@ -316,6 +316,10 @@ extern "C" FLASHMEM void startup_early_hook(void) {
     // peripheral registers are addressable. Per imxrt.h comment:
     // "WDOG3 requires CCM_CCGR5_WDOG3".
     CCM_CCGR5 |= CCM_CCGR5_WDOG3(3);
+    // Ensure the CCM store is visible to the peripheral bus before
+    // touching WDOG3.
+    __asm__ volatile ("dsb" ::: "memory");
+    __asm__ volatile ("isb" ::: "memory");
 
     // Unlock RTWDOG with the 32-bit key (works because CS.CMD32EN=1 at reset).
     WDOG3_CNT = 0xD928C520u;
@@ -374,11 +378,14 @@ void setup() {
         const uint32_t srsr = SRC_SRSR;
         Serial.print("[boot] SRC_SRSR = 0x");  // ok serial - boot diagnostic, Teensy 4 only
         Serial.println(srsr, HEX);             // ok serial - boot diagnostic, Teensy 4 only
-        if (srsr & (1u << 7))  Serial.println("[boot]   WDOG3_RST_B (RTWDOG fired)");  // ok serial - boot diagnostic
-        if (srsr & (1u << 0))  Serial.println("[boot]   POR (power-on reset)");  // ok serial - boot diagnostic
-        if (srsr & (1u << 4))  Serial.println("[boot]   LOCKUP_SYSRESETREQ (HardFault SYSRESETREQ)");  // ok serial - boot diagnostic
-        if (srsr & (1u << 5))  Serial.println("[boot]   IPP_USER_RESET_B (external pin)");  // ok serial - boot diagnostic
-        if (srsr & (1u << 8))  Serial.println("[boot]   JTAG/SW reset");  // ok serial - boot diagnostic
+        // Bit positions from imxrt.h SRC_SRSR_*_B macros (not hardcoded
+        // shifts, which were all wrong in an earlier version of this file).
+        if (srsr & SRC_SRSR_WDOG3_RST_B)        Serial.println("[boot]   WDOG3_RST_B (RTWDOG fired)");        // ok serial - boot diagnostic
+        if (srsr & SRC_SRSR_WDOG_RST_B)         Serial.println("[boot]   WDOG_RST_B (WDOG1/2 fired)");        // ok serial - boot diagnostic
+        if (srsr & SRC_SRSR_IPP_RESET_B)        Serial.println("[boot]   POR (power-on reset)");              // ok serial - boot diagnostic
+        if (srsr & SRC_SRSR_LOCKUP_SYSRESETREQ) Serial.println("[boot]   LOCKUP_SYSRESETREQ (HardFault)");    // ok serial - boot diagnostic
+        if (srsr & SRC_SRSR_IPP_USER_RESET_B)   Serial.println("[boot]   IPP_USER_RESET_B (external pin)");  // ok serial - boot diagnostic
+        if (srsr & SRC_SRSR_JTAG_SW_RST)        Serial.println("[boot]   JTAG/SW reset");                    // ok serial - boot diagnostic
         // Write-1-to-clear so next boot sees only its own cause.
         SRC_SRSR = srsr;
         if (CrashReport) {

--- a/examples/AutoResearch/AutoResearchRemote.cpp
+++ b/examples/AutoResearch/AutoResearchRemote.cpp
@@ -1005,6 +1005,22 @@ void AutoResearchRemoteControl::registerFunctions(fl::shared_ptr<AutoResearchSta
         return response;
     });
 
+    // Register "deliberateHang" - force an infinite loop with interrupts
+    // disabled to validate the unified Watchdog implementation (#2731).
+    // The watchdog should fire within its configured timeout, reset the
+    // device, and let the bootloader become reachable again.
+    // Returns success BEFORE hanging so the caller sees the ACK; the hang
+    // begins in the next iteration of the loop.
+    mRemote->bind("deliberateHang", [this](const fl::json& args) -> fl::json {
+        (void)args;
+        FL_WARN("[deliberateHang] watchdog test: spinning forever in 200 ms");
+        mState->deliberate_hang_requested = true;
+        fl::json response = fl::json::object();
+        response.set("success", true);
+        response.set("message", "device will hang after RPC returns; watchdog should reset within configured timeout");
+        return response;
+    });
+
     // Register "drivers" function - list available drivers
     mRemote->bind("drivers", [this](const fl::json& args) -> fl::json {
         fl::json drivers = fl::json::array();

--- a/examples/AutoResearch/AutoResearchRemote.h
+++ b/examples/AutoResearch/AutoResearchRemote.h
@@ -46,6 +46,7 @@ struct AutoResearchState {
     bool net_server_active = false;  // Network server autoresearch active
     bool net_client_active = false;  // Network client autoresearch active
     bool ble_server_active = false;  // BLE GATT server autoresearch active
+    bool deliberate_hang_requested = false;  // Watchdog autoresearch hang trigger (#2731)
 };
 
 /// @brief Print JSON directly to Serial, bypassing fl::println and ScopedLogDisable

--- a/src/platforms/arm/k20/watchdog_k20.impl.hpp
+++ b/src/platforms/arm/k20/watchdog_k20.impl.hpp
@@ -58,7 +58,13 @@ inline void k20UnlockAndConfigureWdog(fl::u32 timeout_ms) {
     // WDOG_UNLOCK within bus-clock window. Then exactly ONE write to
     // WDOG_STCTRLH is permitted before lockout. We program LPO-clocked
     // (~1 kHz) so timeout_ms ≈ TOVAL count.
-    __disable_irq();
+    //
+    // PRIMASK save/restore so a caller that already had IRQs disabled
+    // doesn't get them surprise-re-enabled. Naked __disable_irq() pair
+    // would lose the prior PRIMASK state.
+    fl::u32 primask;
+    __asm__ volatile ("mrs %0, primask" : "=r" (primask));
+    __asm__ volatile ("cpsid i" ::: "memory");
     WDOG_UNLOCK = 0xC520;
     WDOG_UNLOCK = 0xD928;
     // Two NOPs per the reference manual to satisfy the timing requirement.
@@ -68,9 +74,12 @@ inline void k20UnlockAndConfigureWdog(fl::u32 timeout_ms) {
     if (toval == 0) toval = 1;
     WDOG_TOVALH = static_cast<fl::u16>((toval >> 16) & 0xFFFF);
     WDOG_TOVALL = static_cast<fl::u16>(toval & 0xFFFF);
-    // STCTRLH: ALLOWUPDATE | WDOGEN | LPO clock
+    // STCTRLH: ALLOWUPDATE | WDOGEN | STOPEN | WAITEN | LPO clock = 0x01D1.
+    // The STOPEN + WAITEN bits keep the WDT counting when the CPU enters
+    // STOP / WAIT modes — without them the WDT would pause and the
+    // caller's feed() cadence would be unsafe across low-power transitions.
     WDOG_STCTRLH = 0x01D1;
-    __enable_irq();
+    __asm__ volatile ("msr primask, %0" :: "r" (primask) : "memory");
 }
 
 } // namespace platforms
@@ -89,10 +98,14 @@ void Watchdog::begin(fl::u32 timeout_ms) FL_NOEXCEPT {
 
 void Watchdog::feed() FL_NOEXCEPT {
     // Refresh sequence: 0xA602 then 0xB480 with interrupts disabled.
-    __disable_irq();
+    // PRIMASK save/restore so a caller that already had IRQs disabled
+    // doesn't get them surprise-re-enabled (e.g. feed() from inside an ISR).
+    fl::u32 primask;
+    __asm__ volatile ("mrs %0, primask" : "=r" (primask));
+    __asm__ volatile ("cpsid i" ::: "memory");
     WDOG_REFRESH = 0xA602;
     WDOG_REFRESH = 0xB480;
-    __enable_irq();
+    __asm__ volatile ("msr primask, %0" :: "r" (primask) : "memory");
 }
 
 void Watchdog::disable() FL_NOEXCEPT {

--- a/src/platforms/arm/mxrt1062/watchdog_mxrt1062.impl.hpp
+++ b/src/platforms/arm/mxrt1062/watchdog_mxrt1062.impl.hpp
@@ -127,22 +127,23 @@ void Watchdog::begin(fl::u32 timeout_ms) FL_NOEXCEPT {
     WDOG3_TOVAL = toval;
     WDOG3_WIN   = 0;   // No window mode — feeds at any time are valid.
 
-    // Configure CS:
+    // Configure CS. Per iMXRT1062 RM 65.6.1, the STOP/WAIT/DBG bits mean
+    // "enabled in stop/wait/debug mode", i.e. setting them keeps the WDT
+    // counting in those modes. We deliberately leave all three clear so a
+    // debugger session pauses the watchdog (developer-friendly) and so any
+    // CPU power-down also pauses it.
     //  - EN        = 1  → enable RTWDOG
     //  - CMD32EN   = 1  → keep 32-bit unlock/refresh keying (matches the
     //                     CNT writes we use)
     //  - UPDATE    = 1  → allow future reconfigures via the unlock sequence
     //  - PRES      = 1  → /256 prescaler → 8 ms per TOVAL count
-    //  - CLK = 0b01    → LPO clock source (32 kHz, low-power, runs in wait/stop)
-    //  - WAIT/STOP/DBG → leave at reset defaults (continue counting in WAIT
-    //                    and STOP; stop in DEBUG so a debugger session
-    //                    doesn't reset the chip during a breakpoint).
+    //  - CLK = 0b01     → LPO clock source (~32 kHz)
+    //  - STOP/WAIT/DBG = 0 → pause in stop/wait/debug modes
     WDOG3_CS = WDOG_CS_EN
              | WDOG_CS_CMD32EN
              | WDOG_CS_UPDATE
              | WDOG_CS_PRES
-             | WDOG_CS_CLK(1)
-             | WDOG_CS_DBG;
+             | WDOG_CS_CLK(1);
 
     // Wait for the reconfigure to take effect (also bounded).
     {

--- a/src/platforms/arm/mxrt1062/watchdog_mxrt1062.impl.hpp
+++ b/src/platforms/arm/mxrt1062/watchdog_mxrt1062.impl.hpp
@@ -119,7 +119,7 @@ void Watchdog::begin(fl::u32 timeout_ms) FL_NOEXCEPT {
 
     // PRIMASK save/restore — see feed() for rationale (works correctly when
     // called from a context that already had IRQs disabled).
-    uint32_t primask;
+    fl::u32 primask;
     __asm__ volatile ("mrs %0, primask" : "=r" (primask));
     __asm__ volatile ("cpsid i" ::: "memory");
 
@@ -187,7 +187,7 @@ void Watchdog::feed() FL_NOEXCEPT {
     // re-enable interrupts when feed() is called from a context that had
     // them disabled (e.g. an ISR). __disable_irq()/__enable_irq() would
     // unconditionally re-enable, which is unsafe in nested-IRQ-off paths.
-    uint32_t primask;
+    fl::u32 primask;
     __asm__ volatile ("mrs %0, primask" : "=r" (primask));
     __asm__ volatile ("cpsid i" ::: "memory");
     WDOG3_CNT = platforms::kRtwdogRefreshKey;
@@ -204,7 +204,7 @@ void Watchdog::disable() FL_NOEXCEPT {
 
     // Save+restore PRIMASK so callers that already had IRQs off aren't
     // surprised by them coming back on.
-    uint32_t primask;
+    fl::u32 primask;
     __asm__ volatile ("mrs %0, primask" : "=r" (primask));
     __asm__ volatile ("cpsid i" ::: "memory");
 

--- a/src/platforms/arm/mxrt1062/watchdog_mxrt1062.impl.hpp
+++ b/src/platforms/arm/mxrt1062/watchdog_mxrt1062.impl.hpp
@@ -108,7 +108,11 @@ void Watchdog::begin(fl::u32 timeout_ms) FL_NOEXCEPT {
     if (toval == 0)         toval = 1;
     if (toval > 0xFFFFu)    toval = 0xFFFFu;
 
-    __disable_irq();
+    // PRIMASK save/restore — see feed() for rationale (works correctly when
+    // called from a context that already had IRQs disabled).
+    uint32_t primask;
+    __asm__ volatile ("mrs %0, primask" : "=r" (primask));
+    __asm__ volatile ("cpsid i" ::: "memory");
 
     // 32-bit unlock key (atomic store; relies on CS.CMD32EN=1, which is the
     // RTWDOG reset default and which we restore in the CS write below).
@@ -120,7 +124,10 @@ void Watchdog::begin(fl::u32 timeout_ms) FL_NOEXCEPT {
     {
         fl::u32 spin = 0;
         while (!(WDOG3_CS & WDOG_CS_ULK)) {
-            if (++spin > 1000000u) { __enable_irq(); return; }
+            if (++spin > 1000000u) {
+                __asm__ volatile ("msr primask, %0" :: "r" (primask) : "memory");
+                return;
+            }
         }
     }
 
@@ -161,21 +168,56 @@ void Watchdog::begin(fl::u32 timeout_ms) FL_NOEXCEPT {
 }
 
 void Watchdog::feed() FL_NOEXCEPT {
-    // 32-bit refresh key. Interrupts off so an ISR can't tear the write.
-    __disable_irq();
+    // 32-bit refresh key. Save+restore PRIMASK so we don't accidentally
+    // re-enable interrupts when feed() is called from a context that had
+    // them disabled (e.g. an ISR). __disable_irq()/__enable_irq() would
+    // unconditionally re-enable, which is unsafe in nested-IRQ-off paths.
+    uint32_t primask;
+    __asm__ volatile ("mrs %0, primask" : "=r" (primask));
+    __asm__ volatile ("cpsid i" ::: "memory");
     WDOG3_CNT = platforms::kRtwdogRefreshKey;
-    __enable_irq();
+    __asm__ volatile ("msr primask, %0" :: "r" (primask) : "memory");
 }
 
 void Watchdog::disable() FL_NOEXCEPT {
-    // RTWDOG cannot be cleanly disabled once armed and locked. To honor the
-    // Tier-0 contract conservatively, reconfigure with the maximum supported
-    // timeout so calling code that documents "watchdog disabled" still has
-    // the longest possible window before reset. Real teardown isn't possible
-    // without violating the CS write-protect after the first config.
+    // RTWDOG can be re-configured with CS.EN=0 via the unlock sequence as
+    // long as CS.UPDATE was 1 in the previous config (which our begin()
+    // always sets). Run the same unlock-then-CS pattern as begin() but
+    // write CS with EN=0.
     auto& s = platforms::mxrt1062WatchdogState();
     if (!s.armed) return;
-    begin(FL_WATCHDOG_MAX_TIMEOUT_MS);
+
+    // Save+restore PRIMASK so callers that already had IRQs off aren't
+    // surprised by them coming back on.
+    uint32_t primask;
+    __asm__ volatile ("mrs %0, primask" : "=r" (primask));
+    __asm__ volatile ("cpsid i" ::: "memory");
+
+    WDOG3_CNT = platforms::kRtwdogUnlockKey;
+    {
+        fl::u32 spin = 0;
+        while (!(WDOG3_CS & WDOG_CS_ULK)) {
+            if (++spin > 1000000u) {
+                __asm__ volatile ("msr primask, %0" :: "r" (primask) : "memory");
+                return;
+            }
+        }
+    }
+
+    WDOG3_TOVAL = 0xFFFFu;
+    WDOG3_WIN   = 0;
+    // EN = 0 → disable. Keep CMD32EN + UPDATE so a future begin() can re-arm.
+    WDOG3_CS = WDOG_CS_CMD32EN | WDOG_CS_UPDATE | WDOG_CS_CLK(1);
+
+    {
+        fl::u32 spin = 0;
+        while (!(WDOG3_CS & WDOG_CS_RCS)) {
+            if (++spin > 1000000u) break;
+        }
+    }
+
+    __asm__ volatile ("msr primask, %0" :: "r" (primask) : "memory");
+
     s.armed = false;
     s.armed_timeout_ms = 0;
 }

--- a/src/platforms/arm/mxrt1062/watchdog_mxrt1062.impl.hpp
+++ b/src/platforms/arm/mxrt1062/watchdog_mxrt1062.impl.hpp
@@ -71,13 +71,17 @@ inline Mxrt1062WatchdogState& mxrt1062WatchdogState() {
 }
 
 inline ResetCause translateSrcSrsr(fl::u32 srsr) {
-    // Bits per iMXRT1062 reference manual. Priority: most-specific first.
-    if (srsr & (1u << 16)) return ResetCause::WATCHDOG;      // WDOG3_RST_B
-    if (srsr & (1u << 7))  return ResetCause::WATCHDOG;      // WDOG_RST_B (WDOG1/2)
-    if (srsr & (1u << 4))  return ResetCause::LOCKUP;        // LOCKUP_SYSRESETREQ
-    if (srsr & (1u << 8))  return ResetCause::DEBUGGER;      // JTAG_SW_RST
-    if (srsr & (1u << 5))  return ResetCause::EXTERNAL_PIN;  // IPP_USER_RESET_B
-    if (srsr & (1u << 0))  return ResetCause::POWER_ON;      // POR
+    // Bit positions from imxrt.h (which matches the iMXRT1062 reference
+    // manual and NXP MCUXpresso SDK SRC_SRSR_*_SHIFT). Earlier hand-coded
+    // shifts were all wrong (off by 1-9 bits in different places) so
+    // lastResetCause() reported UNKNOWN for nearly every real reset cause.
+    // Priority: most-specific first.
+    if (srsr & SRC_SRSR_WDOG3_RST_B)        return ResetCause::WATCHDOG;
+    if (srsr & SRC_SRSR_WDOG_RST_B)         return ResetCause::WATCHDOG;
+    if (srsr & SRC_SRSR_LOCKUP_SYSRESETREQ) return ResetCause::LOCKUP;
+    if (srsr & SRC_SRSR_JTAG_SW_RST)        return ResetCause::DEBUGGER;
+    if (srsr & SRC_SRSR_IPP_USER_RESET_B)   return ResetCause::EXTERNAL_PIN;
+    if (srsr & SRC_SRSR_IPP_RESET_B)        return ResetCause::POWER_ON;
     return ResetCause::UNKNOWN;
 }
 
@@ -100,6 +104,11 @@ void Watchdog::begin(fl::u32 timeout_ms) FL_NOEXCEPT {
     // The previous WDOG3 init attempt (AutoResearch.ino TODO at lines 204-214)
     // almost certainly missed this. CCGR=3 → clock always on.
     CCM_CCGR5 |= CCM_CCGR5_WDOG3(3);
+    // Per iMXRT1062 RM, ensure the CCM clock-gate store is visible to the
+    // peripheral bus before the first WDOG3 access. NXP MCUXpresso's CCM
+    // driver inserts these barriers after every CCGR write.
+    __asm__ volatile ("dsb" ::: "memory");
+    __asm__ volatile ("isb" ::: "memory");
 
     // Convert ms to TOVAL counts. With LPO (~32 kHz) and /256 prescaler
     // (CS.PRES set) the tick rate is 125 Hz → 8 ms per count. Clamp to the
@@ -156,11 +165,17 @@ void Watchdog::begin(fl::u32 timeout_ms) FL_NOEXCEPT {
     {
         fl::u32 spin = 0;
         while (!(WDOG3_CS & WDOG_CS_RCS)) {
-            if (++spin > 1000000u) { __enable_irq(); return; }
+            if (++spin > 1000000u) {
+                __asm__ volatile ("msr primask, %0" :: "r" (primask) : "memory");
+                return;
+            }
         }
     }
 
-    __enable_irq();
+    // Restore the caller's prior PRIMASK state (NOT __enable_irq() — that
+    // would unconditionally re-enable interrupts even if the caller had
+    // them disabled before invoking begin()).
+    __asm__ volatile ("msr primask, %0" :: "r" (primask) : "memory");
 
     auto& s = platforms::mxrt1062WatchdogState();
     s.armed = true;

--- a/src/platforms/arm/mxrt1062/watchdog_mxrt1062.impl.hpp
+++ b/src/platforms/arm/mxrt1062/watchdog_mxrt1062.impl.hpp
@@ -92,6 +92,15 @@ void Watchdog::begin(fl::u32 timeout_ms) FL_NOEXCEPT {
     if (timeout_ms == 0) timeout_ms = 1000;
     if (timeout_ms > FL_WATCHDOG_MAX_TIMEOUT_MS) timeout_ms = FL_WATCHDOG_MAX_TIMEOUT_MS;
 
+    // *** Enable the WDOG3 CCM clock gate FIRST. ***
+    //
+    // imxrt.h calls this out explicitly: "WDOG3 requires CCM_CCGR5_WDOG3".
+    // Writes to WDOG3_* registers when the clock gate is off either get
+    // silently ignored or cause a bus fault → HardFault → instant reset.
+    // The previous WDOG3 init attempt (AutoResearch.ino TODO at lines 204-214)
+    // almost certainly missed this. CCGR=3 → clock always on.
+    CCM_CCGR5 |= CCM_CCGR5_WDOG3(3);
+
     // Convert ms to TOVAL counts. With LPO (~32 kHz) and /256 prescaler
     // (CS.PRES set) the tick rate is 125 Hz → 8 ms per count. Clamp to the
     // 16-bit register range.
@@ -106,7 +115,14 @@ void Watchdog::begin(fl::u32 timeout_ms) FL_NOEXCEPT {
     WDOG3_CNT = platforms::kRtwdogUnlockKey;
     // Wait for the unlock window to open. The RM allows up to ~32 LPO ticks;
     // at 32 kHz that's ~1 ms, far longer than the bus stores below take.
-    while (!(WDOG3_CS & WDOG_CS_ULK)) { /* spin */ }
+    // Bounded spin to avoid an infinite loop if the unlock never lands
+    // (e.g. CCM clock gate didn't get enabled for some reason).
+    {
+        fl::u32 spin = 0;
+        while (!(WDOG3_CS & WDOG_CS_ULK)) {
+            if (++spin > 1000000u) { __enable_irq(); return; }
+        }
+    }
 
     WDOG3_TOVAL = toval;
     WDOG3_WIN   = 0;   // No window mode — feeds at any time are valid.
@@ -128,8 +144,13 @@ void Watchdog::begin(fl::u32 timeout_ms) FL_NOEXCEPT {
              | WDOG_CS_CLK(1)
              | WDOG_CS_DBG;
 
-    // Wait for the reconfigure to take effect.
-    while (!(WDOG3_CS & WDOG_CS_RCS)) { /* spin */ }
+    // Wait for the reconfigure to take effect (also bounded).
+    {
+        fl::u32 spin = 0;
+        while (!(WDOG3_CS & WDOG_CS_RCS)) {
+            if (++spin > 1000000u) { __enable_irq(); return; }
+        }
+    }
 
     __enable_irq();
 

--- a/src/platforms/arm/mxrt1062/watchdog_mxrt1062.impl.hpp
+++ b/src/platforms/arm/mxrt1062/watchdog_mxrt1062.impl.hpp
@@ -3,35 +3,58 @@
 /// @file platforms/arm/mxrt1062/watchdog_mxrt1062.impl.hpp
 /// @brief Teensy 4.x (iMXRT1062) watchdog implementation.
 ///
-/// Uses `WDT_T4<WDT3>` (RTWDOG) from the bundled Teensyduino `Watchdog_t4.h`
-/// library. **WDOG1/WDOG2 are intentionally NOT used** — they're configured
-/// by the ROM/bootloader and resetting through them can interact with the
-/// MKL02 bootloader chip in ways the previous attempt (see
+/// **Bare-metal WDOG3 (RTWDOG) register access — no third-party library.**
+/// Uses the iMXRT1062 RTWDOG peripheral via the register defines in `<imxrt.h>`
+/// from the Teensyduino core. WDOG1/WDOG2 are intentionally NOT used — they're
+/// configured by the ROM/bootloader and resetting through them can interact
+/// with the MKL02 bootloader chip in ways the previous attempt (see
 /// `AutoResearch.ino:204-214`) discovered the hard way.
 ///
-/// Reset cause from `SRC_SRSR`. Persist storage is in-RAM only for now;
-/// Phase 3 follow-up will move it to OCRAM2 retained region (above
-/// `CrashReport` at `0x2027FF80`) for soft-reset survival.
+/// **Register sequence (per iMXRT1062 reference manual, RTWDOG chapter):**
+///
+/// Reconfigure: write the 32-bit unlock key `0xD928C520` to `WDOG3_CNT`
+/// (this requires `CS.CMD32EN=1`, which is the reset default). Wait for
+/// `CS.ULK` to become 1, then program `TOVAL`/`WIN`, then write a new `CS`
+/// that includes `CS.UPDATE` (to allow future reconfigures) and `CS.EN`.
+/// Finally wait for `CS.RCS` to confirm the reconfigure completed.
+///
+/// Refresh: write the 32-bit refresh key `0xB480A602` to `WDOG3_CNT`.
+///
+/// Both sequences run with interrupts disabled — the unlock-to-write window
+/// must complete within 16 bus clocks on the M7. At 600 MHz that's ample
+/// time for the few stores below, but an ISR firing mid-sequence would
+/// blow the window and either no-op or hang.
+///
+/// **Timing math:** LPO clock is 32 kHz nominal. We enable the /256 prescaler
+/// (`CS.PRES`) so each TOVAL count is 8 ms. Max TOVAL is 0xFFFF → 524 sec
+/// ceiling. We clamp `FL_WATCHDOG_MAX_TIMEOUT_MS` to 120 s for sanity.
+///
+/// Reset cause from `SRC_SRSR`. Persist storage is in-RAM only; Phase 3 can
+/// move it to the OCRAM2 retained region above `CrashReport` at `0x2027FF80`.
 
 #include "fl/wdt/watchdog.h"
 
 // IWYU pragma: begin_keep
-#include <Watchdog_t4.h>   // ok include — bundled Teensyduino library
-#include <imxrt.h>         // ok include — SRC_SRSR register
+#include <imxrt.h>   // ok include — RTWDOG / SRC register defines from Teensyduino core
 // IWYU pragma: end_keep
 
 #define FL_WATCHDOG_HAS_HARDWARE
 #define FL_WATCHDOG_PERSIST_BYTES 16
-#define FL_WATCHDOG_MAX_TIMEOUT_MS 128000u
-// NOTE: WDT_T4 / RTWDOG technically exposes pre-timeout IRQ + windowed mode,
-// but our Tier-1/2 wrappers (`onTimeout()`, `setWindow()`) currently return
-// false on this platform. Capability macros must match runtime behavior, so
-// we deliberately do NOT advertise `FL_WATCHDOG_HAS_PRE_TIMEOUT_IRQ` /
-// `FL_WATCHDOG_HAS_WINDOW_MODE` until those wrappers are implemented in a
-// follow-up.
+#define FL_WATCHDOG_MAX_TIMEOUT_MS 120000u
 
 namespace fl {
 namespace platforms {
+
+// RTWDOG (WDOG3) magic keys per iMXRT1062 reference manual.
+//
+// The two 16-bit halves of the 32-bit unlock key:
+//   high: 0xD928
+//   low:  0xC520
+// When `CS.CMD32EN=1` (the reset default) the single 32-bit store below is
+// atomic to the WDT and replaces the two-word sequence used by older Kinetis
+// WDOGs.
+static constexpr fl::u32 kRtwdogUnlockKey  = 0xD928C520u;
+static constexpr fl::u32 kRtwdogRefreshKey = 0xB480A602u;
 
 struct Mxrt1062WatchdogState {
     fl::u8     persist[FL_WATCHDOG_PERSIST_BYTES] = {0};
@@ -45,11 +68,6 @@ struct Mxrt1062WatchdogState {
 inline Mxrt1062WatchdogState& mxrt1062WatchdogState() {
     static Mxrt1062WatchdogState s{};  // okay static in header — single-TU `.impl.hpp`
     return s;
-}
-
-inline WDT_T4<WDT3>& mxrt1062Wdt() {
-    static WDT_T4<WDT3> w;  // okay static in header — single-TU `.impl.hpp`
-    return w;
 }
 
 inline ResetCause translateSrcSrsr(fl::u32 srsr) {
@@ -71,35 +89,82 @@ Watchdog& Watchdog::instance() FL_NOEXCEPT {
 }
 
 void Watchdog::begin(fl::u32 timeout_ms) FL_NOEXCEPT {
-    // WDT_T4 minimum is 500 ms; clamp.
-    if (timeout_ms < 500) timeout_ms = 500;
+    if (timeout_ms == 0) timeout_ms = 1000;
     if (timeout_ms > FL_WATCHDOG_MAX_TIMEOUT_MS) timeout_ms = FL_WATCHDOG_MAX_TIMEOUT_MS;
+
+    // Convert ms to TOVAL counts. With LPO (~32 kHz) and /256 prescaler
+    // (CS.PRES set) the tick rate is 125 Hz → 8 ms per count. Clamp to the
+    // 16-bit register range.
+    fl::u32 toval = timeout_ms / 8u;
+    if (toval == 0)         toval = 1;
+    if (toval > 0xFFFFu)    toval = 0xFFFFu;
+
+    __disable_irq();
+
+    // 32-bit unlock key (atomic store; relies on CS.CMD32EN=1, which is the
+    // RTWDOG reset default and which we restore in the CS write below).
+    WDOG3_CNT = platforms::kRtwdogUnlockKey;
+    // Wait for the unlock window to open. The RM allows up to ~32 LPO ticks;
+    // at 32 kHz that's ~1 ms, far longer than the bus stores below take.
+    while (!(WDOG3_CS & WDOG_CS_ULK)) { /* spin */ }
+
+    WDOG3_TOVAL = toval;
+    WDOG3_WIN   = 0;   // No window mode — feeds at any time are valid.
+
+    // Configure CS:
+    //  - EN        = 1  → enable RTWDOG
+    //  - CMD32EN   = 1  → keep 32-bit unlock/refresh keying (matches the
+    //                     CNT writes we use)
+    //  - UPDATE    = 1  → allow future reconfigures via the unlock sequence
+    //  - PRES      = 1  → /256 prescaler → 8 ms per TOVAL count
+    //  - CLK = 0b01    → LPO clock source (32 kHz, low-power, runs in wait/stop)
+    //  - WAIT/STOP/DBG → leave at reset defaults (continue counting in WAIT
+    //                    and STOP; stop in DEBUG so a debugger session
+    //                    doesn't reset the chip during a breakpoint).
+    WDOG3_CS = WDOG_CS_EN
+             | WDOG_CS_CMD32EN
+             | WDOG_CS_UPDATE
+             | WDOG_CS_PRES
+             | WDOG_CS_CLK(1)
+             | WDOG_CS_DBG;
+
+    // Wait for the reconfigure to take effect.
+    while (!(WDOG3_CS & WDOG_CS_RCS)) { /* spin */ }
+
+    __enable_irq();
+
     auto& s = platforms::mxrt1062WatchdogState();
-    WDT_timings_t cfg;
-    cfg.timeout = static_cast<float>(timeout_ms) / 1000.0f;
-    platforms::mxrt1062Wdt().begin(cfg);
     s.armed = true;
     s.armed_timeout_ms = timeout_ms;
 }
 
 void Watchdog::feed() FL_NOEXCEPT {
-    platforms::mxrt1062Wdt().feed();
+    // 32-bit refresh key. Interrupts off so an ISR can't tear the write.
+    __disable_irq();
+    WDOG3_CNT = platforms::kRtwdogRefreshKey;
+    __enable_irq();
 }
 
 void Watchdog::disable() FL_NOEXCEPT {
-    // WDT_T4 / RTWDOG cannot be cleanly disabled once armed (CS write-protect).
-    // The honest action is to keep feeding it from a background context, but
-    // we have nowhere to do that from a Tier-0 disable(). Document the
-    // limitation: post-disable() the watchdog still ticks. Subsequent
-    // feed() calls still work; if the caller wanted to stop monitoring it
-    // should also stop calling feed() — but in that case the WDT will fire.
-    // We do NOT clear armed because the watchdog is in fact still armed.
+    // RTWDOG cannot be cleanly disabled once armed and locked. To honor the
+    // Tier-0 contract conservatively, reconfigure with the maximum supported
+    // timeout so calling code that documents "watchdog disabled" still has
+    // the longest possible window before reset. Real teardown isn't possible
+    // without violating the CS write-protect after the first config.
+    auto& s = platforms::mxrt1062WatchdogState();
+    if (!s.armed) return;
+    begin(FL_WATCHDOG_MAX_TIMEOUT_MS);
+    s.armed = false;
+    s.armed_timeout_ms = 0;
 }
 
 ResetCause Watchdog::lastResetCause() const FL_NOEXCEPT {
     auto& s = platforms::mxrt1062WatchdogState();
     if (!s.cause_cached) {
         s.cached_cause = platforms::translateSrcSrsr(SRC_SRSR);
+        // SRSR bits are sticky across resets — write-1-to-clear so the next
+        // boot only sees its own cause.
+        SRC_SRSR = SRC_SRSR;
         s.cause_cached = true;
         if (s.cached_cause == ResetCause::WATCHDOG && s.crash_count < 0xFFFF) {
             s.crash_count++;

--- a/src/platforms/arm/nrf52/watchdog_nrf52.impl.hpp
+++ b/src/platforms/arm/nrf52/watchdog_nrf52.impl.hpp
@@ -61,7 +61,12 @@ void Watchdog::begin(fl::u32 timeout_ms) FL_NOEXCEPT {
         // CRV = (timeout_sec * 32768) - 1, computed from ms with rounding.
         NRF_WDT->CRV = ((static_cast<fl::u64>(timeout_ms) * 32768u + 999u) / 1000u) - 1u;
         NRF_WDT->RREN = 1u;            // enable reload register 0
-        NRF_WDT->CONFIG = 1u;           // run during CPU sleep, pause in debug
+        // CONFIG: bit 0 SLEEP (1 = run during CPU sleep), bit 3 HALT
+        // (1 = pause when debugger has halted the CPU, developer-friendly).
+        // Previously we wrote 1u which left HALT=0 → watchdog kept counting
+        // through a debugger break and reset the chip mid-debug. Same class
+        // of bit-semantic inversion that bit us on Teensy 4's WDOG_CS_DBG.
+        NRF_WDT->CONFIG = (1u << 0) | (1u << 3);
         NRF_WDT->TASKS_START = 1u;
     }
     platforms::nrf52WatchdogState().armed = true;

--- a/src/platforms/arm/stm32/watchdog_stm32.impl.hpp
+++ b/src/platforms/arm/stm32/watchdog_stm32.impl.hpp
@@ -17,6 +17,7 @@
 /// backup registers (`RTC->BKPxR`) for VBAT-backed power-cycle survival.
 
 #include "fl/wdt/watchdog.h"
+#include "platforms/arm/stm32/is_stm32.h"
 
 // IWYU pragma: begin_keep
 #include <IWatchdog.h>   // ok include — STM32duino bundled watchdog wrapper

--- a/src/platforms/watchdog.impl.cpp.hpp
+++ b/src/platforms/watchdog.impl.cpp.hpp
@@ -45,7 +45,7 @@
     #include "platforms/stub/watchdog_stub.impl.hpp"
 #elif defined(FL_IS_ESP32)
     #include "platforms/esp/32/watchdog_esp32.impl.hpp"
-#elif defined(FL_IS_TEENSY_4X) && FL_HAS_INCLUDE(<Watchdog_t4.h>)
+#elif defined(FL_IS_TEENSY_4X) && FL_HAS_INCLUDE(<imxrt.h>)
     #include "platforms/arm/mxrt1062/watchdog_mxrt1062.impl.hpp"
 #elif (defined(FL_IS_TEENSY_3X) || defined(FL_IS_TEENSY_LC)) && FL_HAS_INCLUDE(<kinetis.h>)
     #include "platforms/arm/k20/watchdog_k20.impl.hpp"


### PR DESCRIPTION
## Summary

Bare-register WDOG3 (RTWDOG) implementation for Teensy 4.x — no third-party library dependency. Hardware-verified end-to-end on a real Teensy 4.0:

```
deliberateHang RPC → device disables interrupts → spins forever
   → WDT fires after the configured 15 s timeout
   → SYSRESETREQ → chip reset
   → MKL02 boot chip keeps HalfKay USB recoverable → iMXRT re-boots from FLASH
   → AutoResearch runs setup() again → device fully responsive
   → Repeated twice end-to-end to confirm
```

Replaces the previous `tonton81/WDT_T4` library wrapper (which would have needed `lib_deps` plumbing in `platformio.ini`) with direct iMXRT1062 RTWDOG register access through `<imxrt.h>` (already bundled with the Teensy core).

## Highlights

- `src/platforms/arm/mxrt1062/watchdog_mxrt1062.impl.hpp` — full Tier 0 surface on bare registers
- `examples/AutoResearch/AutoResearch.ino` — `startup_early_hook` override that neutralizes the default-enabled WDOG3 (TOVAL=0x400 ≈ 32 ms) before `main()` runs, plus a `deliberateHang` RPC handler that lets the host validate the WDT-reset path
- Sibling fixes for the same bug-classes on other platforms surfaced by the cross-platform audit:
  - **K20 (Teensy 3.x)** — `feed()` and the WDOG-unlock helper now save/restore PRIMASK instead of naked `__disable_irq()/__enable_irq()` that would surprise-re-enable IRQs from an already-IRQ-off caller
  - **nRF52** — `NRF_WDT->CONFIG` was being written as `1u` with a comment claiming "pause in debug" — actually that left HALT=0, so the WDT kept counting through debugger breakpoints. Fixed to `(1 << 0) | (1 << 3)` (SLEEP=1, HALT=1) for true pause-on-debug.

## Code review

Four parallel expert agents reviewed every aspect of the WDOG3 path before merge:

1. **Register-level RTWDOG sequence** — found a **P0 CRITICAL** bug: `translateSrcSrsr` was using hardcoded shifts that were off by 1–9 bits in different places, so `lastResetWasWatchdog()` returned false after every WDOG3 reset and the recovery / crash-counter path was completely dead. Fixed by using the `SRC_SRSR_*_B` named macros from `<imxrt.h>` (which agree with NXP MCUXpresso SDK).
2. **ISR safety + memory model** — found a **HIGH** bug: `begin()` had been migrated to PRIMASK save/restore for the entry path, but the two success/timeout exits still called `__enable_irq()` which would unconditionally re-enable interrupts even when the caller had them off. Fixed to `msr primask, %0`. Also flagged a **MEDIUM** missing-DSB-after-CCM-gate-write — added `dsb` + `isb` after every CCM_CCGR5 store per the iMXRT1062 RM.
3. **Startup-hook linkage** — verified in the built ELF (`firmware.elf`) that `startup_early_hook` was LTO-inlined into `ResetHandler2` and lives in `.text.code` (FLASH at VMA `0x60001412`), exactly where it needs to be. No bugs.
4. **Cross-platform WDT consistency** — surfaced the K20 PRIMASK clobber and the nRF52 HALT inversion above; gave the other six platforms (RP, STM32, SAMD, MGM240, Apollo3, AVR, ESP32, stub, WASM, shared/noop) a clean bill.

## File changes (12 commits squash-merged)

| Phase | Commits | What |
|---|---|---|
| Initial bare-register impl | 1 | New `src/platforms/arm/mxrt1062/watchdog_mxrt1062.impl.hpp` with `WDT_T4` library replaced |
| Boot-trigger gate | 1 | `examples/AutoResearch/AutoResearch.ino` `deliberateHang` RPC + Tier-0 `FastLED.watchdog().begin(15000)` integration |
| CCM clock-gate enable + bounded spins | 1 | `CCM_CCGR5 |= CCM_CCGR5_WDOG3(3)` before any WDOG3 register access |
| Lint fixes (Serial.println suppressors, `is_stm32.h` include) | 1 | Boot-diagnostic prints need `// ok serial -` per the example-serial-checker |
| `startup_early_hook` WDOG3 disable | 1 | Neutralizes the default-enabled WDOG3 before main() so a slow setup() doesn't get bitten |
| Re-enable arming for Teensy 4 after startup hook landed | 1 | `FastLED.watchdog().begin(15000)` and `feed()` no longer gated to ESP32-only |
| `WDOG_CS_DBG` bit inversion | 1 | Set DBG=0 (pause in debug — developer-friendly) not 1 (run in debug) |
| Proper `disable()` + PRIMASK save/restore in `feed()` | 1 | First round of PRIMASK migration |
| P0 SRSR bits / HIGH PRIMASK in begin() / MEDIUM DSB barrier / nRF52 HALT / K20 PRIMASK | 1 | Agent-found round of fixes |
| `fl::u32` not `uint32_t` for PRIMASK locals | 1 | StdintTypeChecker fix |
| `noInterrupts()` host-stub gate | 1 | `#if !defined(FL_IS_STUB) && !defined(FL_IS_WASM)` so the unit-test DLL build compiles |
| Stray-file cleanup | 1 | Removed a `-r` file accidentally committed by a shell tool |

## Test plan

- [x] `bash compile teensy41 --examples AutoResearch` — clean compile
- [x] `bash test fl_wdt_watchdog --debug` — 15/15 host stub tests pass under ASAN/UBSAN
- [x] `bash lint --cpp` — clean
- [x] **Hardware verification on Teensy 4.0** — flashed, deliberateHang RPC triggered the noInterrupts/while(1) hang path, WDT fired after the configured 15 s, chip reset, USB re-enumerated, device was reflashable. Cycle repeated twice for confirmation.

## Follow-ups (not blocking)

- `Watchdog::onTimeout(fl::function<void()>)` overload — currently returns false on Teensy 4 (allocator-safe trampoline TBD)
- Persistent crash counter / safe-mode flag backing for Teensy 4 → OCRAM2 retained region above `CrashReport` at `0x2027FF80` (right now persist storage is in-RAM only)
- Non-allocating reset/crash classification API — separate design issue being filed alongside this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added boot diagnostics for Teensy 4 including reset cause reporting and crash information.
  * Added RPC endpoint for deliberate watchdog testing.

* **Bug Fixes**
  * Fixed watchdog initialization to prevent reset-loop issues on Teensy 4.
  * Improved watchdog interrupt state preservation across ARM platforms.
  * Enhanced debug halt behavior for nRF52 watchdog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->