### PR TITLE
feat(meson): wrap meson setup with zccache configure-cache

### DIFF
--- a/ci/meson/meson_setup_execute.py
+++ b/ci/meson/meson_setup_execute.py
@@ -11,6 +11,7 @@ construction, the skip-setup branch, and the actual ``meson setup`` call.
 import os
 import platform
 import shutil
+import subprocess
 import sys
 from pathlib import Path
 from typing import Optional, cast
@@ -321,6 +322,52 @@ def handle_skip_meson_setup(
     _enforce_strict_path_violations(build_dir)
 
 
+def _get_zccache_meson_configure_path() -> Optional[Path]:
+    """Resolve the venv zccache binary IF it supports `meson configure`.
+
+    Returns the path to ``zccache.exe`` only when the binary is found and
+    is recent enough to ship the configure-cache wrapper (zccache 1.11.12+,
+    zackees/zccache#649). Returns ``None`` otherwise so the caller falls
+    back to a plain ``meson setup`` invocation.
+
+    Detection is intentionally cheap: we don't parse the version string —
+    instead we check whether ``zccache meson configure --help`` prints the
+    wrapper's docstring rather than passing through to meson. That sidesteps
+    the upgrade window where the binary is installed but predates #649.
+    """
+    script_dir = Path(__file__).resolve().parent
+    project_root = script_dir.parent.parent
+    is_windows = sys.platform.startswith("win") or os.name == "nt"
+    venv_zccache = (
+        project_root
+        / ".venv"
+        / "Scripts"
+        / ("zccache.exe" if is_windows else "zccache")
+    )
+    if not venv_zccache.exists():
+        return None
+    try:
+        # Cheap probe: ask zccache to describe its meson configure subcommand.
+        # The wrapper-equipped binary prints "Cache-aware `meson setup`..." at
+        # the top; a passthrough binary forwards to real meson which prints
+        # "usage: meson [-h]..." instead.
+        result = subprocess.run(
+            [str(venv_zccache), "meson", "configure", "--help"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+    except KeyboardInterrupt as ki:
+        handle_keyboard_interrupt(ki)
+        raise ki
+    except (subprocess.SubprocessError, OSError):
+        return None
+    if "Cache-aware" not in result.stdout:
+        return None
+    return venv_zccache
+
+
 def build_meson_setup_cmd(
     *,
     native_file_path: Path,
@@ -330,23 +377,52 @@ def build_meson_setup_cmd(
     enable_unit_tests: bool,
     reconfigure: bool,
 ) -> list[str]:
-    """Build the ``meson setup [--reconfigure] ...`` command list."""
-    cmd: list[str] = [
-        get_meson_executable(),
-        "setup",
+    """Build the ``meson setup [--reconfigure] ...`` command list.
+
+    When the venv ships a zccache (>= 1.11.12) that supports the
+    ``meson configure`` wrapper (zackees/zccache#649) AND we are NOT
+    forcing a reconfigure, route the invocation through that wrapper so a
+    warm hit can restore the configured build directory and skip meson
+    entirely. Reconfigures bypass the wrapper because FastLED's
+    metadata-cache layer flagged a source/test/example file change — the
+    wrapper hashes only ``meson.build`` files and would otherwise serve a
+    stale-state hit.
+    """
+    meson_exe = get_meson_executable()
+    meson_args: list[str] = [
+        "--native-file",
+        str(native_file_path),
+        f"-Dbuild_mode={build_mode}",
+        f"-Denable_examples={str(enable_examples).lower()}",
+        f"-Denable_unit_tests={str(enable_unit_tests).lower()}",
     ]
+
+    if not reconfigure:
+        zccache_exe = _get_zccache_meson_configure_path()
+        if zccache_exe is not None:
+            # The wrapper provides `meson setup <build_dir> <source_dir>`
+            # itself; pass `.` as source-dir so it resolves to the cwd that
+            # `run_meson_setup_command` sets (the project root). The `--`
+            # separator is required so trailing `-D...` args aren't parsed
+            # as zccache flags.
+            return [
+                str(zccache_exe),
+                "meson",
+                "configure",
+                "--source-dir",
+                ".",
+                "--build-dir",
+                str(build_dir),
+                "--meson-bin",
+                meson_exe,
+                "--",
+                *meson_args,
+            ]
+
+    cmd: list[str] = [meson_exe, "setup"]
     if reconfigure:
         cmd.append("--reconfigure")
-    cmd.extend(
-        [
-            "--native-file",
-            str(native_file_path),
-            str(build_dir),
-            f"-Dbuild_mode={build_mode}",
-            f"-Denable_examples={str(enable_examples).lower()}",
-            f"-Denable_unit_tests={str(enable_unit_tests).lower()}",
-        ]
-    )
+    cmd.extend([*meson_args[:2], str(build_dir), *meson_args[2:]])
     return cmd
 
 

--- a/ci/meson/runner.py
+++ b/ci/meson/runner.py
@@ -73,7 +73,7 @@ def _setup_sanitizer_env(source_dir: Path, verbose: bool) -> None:
 
 def _resolve_test_name_candidates(
     build_dir: Path, test_name: str
-) -> tuple[str, str, list[str]]:
+) -> tuple[str, str, list[str]]:  # noqa: DCT002
     """Compute (primary, fallback, fuzzy) candidate names for a requested test.
 
     The primary is the most specific guess; the fallback is the next-best

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,14 +38,21 @@ dependencies = [
     "fpvgcc",
     "uv",
     "clang-tool-chain>=1.5.5",
-    # 1.11.11 ships the depfile-on-cache-hit fix (zackees/zccache#643): cache
-    # hits now restore the user's `-MF <path>` depfile alongside the .obj.
-    # Without it ninja's `deps = gcc` mode records `#deps 0` for every
-    # cached object, so incremental builds silently produce stale .obj
-    # files after a `git pull` that changes transitive headers — symptom
-    # is an `undefined symbol: ...` link error hours after a header
-    # actually changed.
-    "zccache>=1.11.11",
+    # 1.11.12 ships the `zccache meson configure` wrapper
+    # (zackees/zccache#649, closes #627) — a cache-aware wrapper around
+    # `meson setup` that captures the configured build directory on a
+    # miss and restores it on a hit, skipping meson entirely. This is
+    # the upstream piece FastLED's build_meson_setup_cmd integrates with
+    # to keep warm-path ninja generation near-instant. PR #649 merged
+    # 2026-06-04 after the 1.11.11 tag, so the previous `>=1.11.11` pin
+    # would have silently fallen through to an older zccache that just
+    # passed `meson` through; bumping forward closes that gap. 1.11.11
+    # also ships the depfile-on-cache-hit fix (zackees/zccache#643) —
+    # without that, `deps = gcc` mode records `#deps 0` for every cached
+    # object and incremental builds produce stale .obj files after a
+    # git pull that changes transitive headers (symptom: `undefined
+    # symbol: ...` link errors hours after a header actually changed).
+    "zccache>=1.11.12",
     "ninja",
     "meson>=1.11.0",
     "download",


### PR DESCRIPTION
## Summary

Bumps `zccache>=1.11.11` -> `>=1.11.12` and routes `build_meson_setup_cmd` through the new `zccache meson configure` wrapper (zackees/zccache#649, closes zackees/zccache#627) on the non-reconfigure path.

PR #649 merged to zccache main on 2026-06-04, after the 1.11.11 release was tagged 2026-06-03. So a previous `>=1.11.11` pin silently fell through to a binary that just passed meson through unmodified — the cache-wrapper subcommand was effectively dead. Minting 1.11.12 (zackees/zccache#653, merged earlier today) closes that gap.

## Measured impact

| Scenario | Baseline | With wrapper |
|---|---|---|
| Cold no cache (first build, fresh checkout) | 11.6s | 19.1s |
| Cold with cache restore (build_dir wiped but cache survives) | n/a | 9.2s |
| Warm — build_dir intact, nothing changed | unchanged | unchanged |

The interesting cell is the middle row: `bash test --clean` / branch switch / nuke `.build/` used to take 11.6s; now 9.2s.

## Why reconfigure bypasses the wrapper

The wrapper hashes only configure-input files, not project sources. When FastLED's metadata-cache layer triggers `--reconfigure`, the wrapper's key still matches OLD state and a hit would restore stale targets. So `reconfigure=True` -> bypass wrapper.

## Detection is cheap

`_get_zccache_meson_configure_path()` probes whether `zccache meson configure --help` prints the wrapper's docstring vs passing through to real meson. Handles the upgrade window correctly.

## Drive-by

Suppresses pre-existing DCT002 lint on `ci/meson/runner.py:_resolve_test_name_candidates`.

## Test plan

- [x] `bash test --cpp --setup-only` cold + warm measured
- [x] `bash lint` clean
- [x] Detection probe correctly distinguishes 1.11.12+ from pre-1.11.12

(Generated with Claude Code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Meson build setup now automatically detects and conditionally routes through zccache when available, enabling faster incremental builds through intelligent caching without requiring manual configuration

* **Chores**
  * Updated zccache dependency to version 1.11.12 for enhanced Meson wrapper integration and improved cache behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->