### PR TITLE
feat(watchdog): non-allocating reset/crash classification API + ScopedWatchdog

### DIFF
--- a/ci/lint_cpp/test_unity_build.py
+++ b/ci/lint_cpp/test_unity_build.py
@@ -80,6 +80,7 @@ EXPECTED_BUILD_FILES = {
     "fl/build/fl.test+.cpp",
     "fl/build/fl.ui+.cpp",
     "fl/build/fl.video+.cpp",
+    "fl/build/fl.wdt+.cpp",
     "fl/build/platforms+.cpp",
     "fl/build/third_party+.cpp",
 }

--- a/src/fl/_build.cpp.hpp
+++ b/src/fl/_build.cpp.hpp
@@ -27,3 +27,4 @@
 #include "fl/test/_build.cpp.hpp"
 #include "fl/ui/_build.cpp.hpp"
 #include "fl/video/_build.cpp.hpp"
+#include "fl/wdt/_build.cpp.hpp"

--- a/src/fl/build/fl.wdt+.cpp
+++ b/src/fl/build/fl.wdt+.cpp
@@ -1,0 +1,10 @@
+/// @file fl.wdt+.cpp
+/// @brief Unity build: recursive includes from src/fl/wdt/
+
+#include "platforms/new.h"
+
+// IWYU pragma: begin_keep
+#include "fl/system/arduino.h"
+// IWYU pragma: end_keep
+
+#include "fl/wdt/_build.cpp.hpp"

--- a/src/fl/wdt/_build.cpp.hpp
+++ b/src/fl/wdt/_build.cpp.hpp
@@ -1,0 +1,29 @@
+/// @file _build.cpp.hpp
+/// @brief Unity build header for fl/wdt/ directory.
+///
+/// Includes the platform-agnostic watchdog API helpers (ResetInfo::describe,
+/// ScopedWatchdog ctor/dtor, etc.) plus the per-TU print/delay sink that
+/// ScopedWatchdog's lazy first-init relies on.
+
+#include "fl/log/log.h"
+#include "fl/system/delay.h"
+
+#include "fl/wdt/watchdog.cpp.hpp"
+
+namespace fl {
+namespace platforms {
+
+// Print-sink implementation used by ScopedWatchdog's first-init path. Defined
+// here (in the unity TU) rather than in watchdog.cpp.hpp so that public
+// headers don't pull in fl/log/log.h.
+void scopedWatchdogPrintLine(fl::string_view sv) FL_NOEXCEPT {
+    FL_WARN(sv);
+}
+
+// Wraps fl::delay() — portable across stub/WASM/embedded.
+void scopedWatchdogPause3s() FL_NOEXCEPT {
+    fl::delay(3000);
+}
+
+} // namespace platforms
+} // namespace fl

--- a/src/fl/wdt/watchdog.cpp.hpp
+++ b/src/fl/wdt/watchdog.cpp.hpp
@@ -112,6 +112,17 @@ namespace platforms {
 void scopedWatchdogPrintLine(fl::string_view sv) FL_NOEXCEPT;
 void scopedWatchdogPause3s() FL_NOEXCEPT;
 
+// Counts simultaneously-alive ScopedWatchdog instances. >1 is almost always
+// a programmer error: nested guards mean the lazy-init's timeout argument
+// of the second instance is silently ignored, and timeout semantics across
+// the two scopes become ambiguous. Singleton-style accessor (function-local
+// static) so the counter has well-defined lifetime even if a guard is
+// constructed before main().
+inline int& scopedWatchdogActiveCount() FL_NOEXCEPT {
+    static int count = 0;
+    return count;
+}
+
 // First-init helper, used by ScopedWatchdog's constructor. Runs only once
 // per process. Single-threaded loop() is the canonical caller — no atomics
 // are needed for the guard byte on supported MCUs.
@@ -135,7 +146,7 @@ inline void scopedWatchdogFirstInit(fl::u32 timeout_ms) FL_NOEXCEPT {
         }
         scopedWatchdogPause3s();
     }
-    scopedWatchdogPrintLine(fl::string_view("[FastLED.watchdog] armed via FL_WATCHDOG_AUTOFEED()"));
+    scopedWatchdogPrintLine(fl::string_view("[FastLED.watchdog] armed via FL_WATCHDOG_AUTO()"));
 }
 
 } // namespace platforms
@@ -146,11 +157,34 @@ ScopedWatchdog::ScopedWatchdog(fl::u32 timeout_ms) FL_NOEXCEPT {
         sInitialized = true;
         platforms::scopedWatchdogFirstInit(timeout_ms);
     }
+
+    // Single-instance enforcement. A second simultaneously-alive ScopedWatchdog
+    // is almost always a bug — the timeout argument here was silently ignored
+    // (only the first instance gets to arm the WDT). Warn once per process so
+    // the developer notices, but still feed so the program survives.
+    int& count = platforms::scopedWatchdogActiveCount();
+    if (count >= 1) {
+        static bool sWarnedOnce = false;
+        if (!sWarnedOnce) {
+            sWarnedOnce = true;
+            platforms::scopedWatchdogPrintLine(fl::string_view(
+                "[FastLED.watchdog] WARN: nested FL_WATCHDOG_AUTO() detected — "
+                "only one scoped guard should be alive at a time"));
+        }
+    }
+    ++count;
+
     Watchdog::instance().feed();
 }
 
 ScopedWatchdog::~ScopedWatchdog() FL_NOEXCEPT {
+    int& count = platforms::scopedWatchdogActiveCount();
+    if (count > 0) --count;
     Watchdog::instance().feed();
+}
+
+int ScopedWatchdog::activeScopeCount() FL_NOEXCEPT {
+    return platforms::scopedWatchdogActiveCount();
 }
 
 } // namespace fl

--- a/src/fl/wdt/watchdog.cpp.hpp
+++ b/src/fl/wdt/watchdog.cpp.hpp
@@ -1,0 +1,156 @@
+// IWYU pragma: private
+
+/// @file fl/wdt/watchdog.cpp.hpp
+/// @brief Platform-agnostic implementations for the unified watchdog API:
+///   - ResetInfo::describe()        Tier 1 human-readable description writer
+///   - ResetInfo::subcauseName()    Tier 1 default (per-platform impls may shadow)
+///   - Watchdog::lastResetInfo()    Tier 1 default (returns {cause, 0, 0})
+///   - ScopedWatchdog ctor/dtor     Tier 1.5 RAII guard
+///
+/// Per FastLED conventions this file is included from exactly one translation
+/// unit (the platform dispatcher includes it after the per-platform
+/// `.impl.hpp`), and is marked `// IWYU pragma: private`.
+
+#include "fl/wdt/watchdog.h"
+
+namespace fl {
+
+// =============================================================================
+// ResetInfo helpers
+// =============================================================================
+
+// Default subcauseName(): empty view. Per-platform richer subcause naming
+// will be wired through a follow-up issue (#2755 tracks the design); for
+// now the empty default works for every backend and describe() handles
+// the subcauseId==0 case by skipping the parenthesized name.
+fl::string_view ResetInfo::subcauseName() const FL_NOEXCEPT {
+    return fl::string_view();
+}
+
+namespace platforms {
+
+// Write `value` as a lowercase hex string into `out`, prefixed with "0x".
+// Returns bytes written (always <= 10, since u32 max is 0xFFFFFFFF = 8 hex
+// digits + 2 prefix chars). Does not write a NUL. Truncates if out is small.
+inline fl::size writeHex(fl::span<char> out, fl::u32 value) FL_NOEXCEPT {
+    char tmp[10];
+    tmp[0] = '0';
+    tmp[1] = 'x';
+    static const char hex[] = "0123456789abcdef";
+    for (int i = 7; i >= 0; --i) {
+        tmp[2 + (7 - i)] = hex[(value >> (i * 4)) & 0xFu];
+    }
+    fl::size n = (out.size() < 10) ? out.size() : 10;
+    for (fl::size i = 0; i < n; ++i) out[i] = tmp[i];
+    return n;
+}
+
+// Copy a string_view into out[]. Returns bytes copied, truncated to out.size().
+inline fl::size writeView(fl::span<char> out, fl::string_view sv) FL_NOEXCEPT {
+    fl::size n = (out.size() < sv.size()) ? out.size() : sv.size();
+    for (fl::size i = 0; i < n; ++i) out[i] = sv[i];
+    return n;
+}
+
+inline fl::size writeChar(fl::span<char> out, char c) FL_NOEXCEPT {
+    if (out.size() == 0) return 0;
+    out[0] = c;
+    return 1;
+}
+
+inline fl::size writeNulIfRoom(fl::span<char> out, fl::size written) FL_NOEXCEPT {
+    if (written < out.size()) out[written] = '\0';
+    return written;
+}
+
+} // namespace platforms
+
+fl::size ResetInfo::describe(fl::span<char> out, bool verbose) const FL_NOEXCEPT {
+    fl::size n = 0;
+    // <cause>
+    n += platforms::writeView(out.subspan(n), causeName());
+    // ( <sub> )  if subcauseId != 0
+    if (subcauseId != 0) {
+        fl::string_view sub = subcauseName();
+        if (sub.size() != 0) {
+            n += platforms::writeView(out.subspan(n), fl::string_view(" ("));
+            n += platforms::writeView(out.subspan(n), sub);
+            n += platforms::writeChar(out.subspan(n), ')');
+        }
+    }
+    if (verbose) {
+        n += platforms::writeView(out.subspan(n), fl::string_view(" raw="));
+        n += platforms::writeHex(out.subspan(n), rawRegister);
+    }
+    return platforms::writeNulIfRoom(out, n);
+}
+
+// =============================================================================
+// Watchdog::lastResetInfo() default — platforms can override
+// =============================================================================
+
+// Default: lift the normalized cause into a ResetInfo, leaving
+// subcauseId/rawRegister at 0. Per-platform richer extraction will be wired
+// through a follow-up to issue #2755 (every backend uses this default for now).
+ResetInfo Watchdog::lastResetInfo() const FL_NOEXCEPT {
+    ResetInfo info{};
+    info.cause = lastResetCause();
+    info.subcauseId = 0;
+    info.rawRegister = 0;
+    return info;
+}
+
+// =============================================================================
+// ScopedWatchdog
+// =============================================================================
+
+namespace platforms {
+
+// Forward-declared in this TU to avoid pulling in fl::print/println headers
+// from a public header. The dispatcher TU includes the necessary print
+// header before this file.
+void scopedWatchdogPrintLine(fl::string_view sv) FL_NOEXCEPT;
+void scopedWatchdogPause3s() FL_NOEXCEPT;
+
+// First-init helper, used by ScopedWatchdog's constructor. Runs only once
+// per process. Single-threaded loop() is the canonical caller — no atomics
+// are needed for the guard byte on supported MCUs.
+inline void scopedWatchdogFirstInit(fl::u32 timeout_ms) FL_NOEXCEPT {
+    Watchdog& wdt = Watchdog::instance();
+    wdt.begin(timeout_ms);
+
+    ResetInfo info = wdt.lastResetInfo();
+    if (info.cause == ResetCause::WATCHDOG ||
+        info.cause == ResetCause::PANIC    ||
+        info.cause == ResetCause::LOCKUP) {
+        char buf[128];
+        fl::size n = info.describe(fl::span<char>(buf, sizeof(buf)), /*verbose=*/true);
+        scopedWatchdogPrintLine(fl::string_view("[FastLED.watchdog] recovered from:"));
+        scopedWatchdogPrintLine(fl::string_view(buf, n));
+
+        if (wdt.hasCrashReport()) {
+            // Hook for Tier 2 platforms. Future revision: also emit a
+            // multi-line CrashReport::describe() result here. For now the
+            // bare cause + raw register is the documented contract.
+        }
+        scopedWatchdogPause3s();
+    }
+    scopedWatchdogPrintLine(fl::string_view("[FastLED.watchdog] armed via FL_WATCHDOG_AUTOFEED()"));
+}
+
+} // namespace platforms
+
+ScopedWatchdog::ScopedWatchdog(fl::u32 timeout_ms) FL_NOEXCEPT {
+    static bool sInitialized = false;
+    if (!sInitialized) {
+        sInitialized = true;
+        platforms::scopedWatchdogFirstInit(timeout_ms);
+    }
+    Watchdog::instance().feed();
+}
+
+ScopedWatchdog::~ScopedWatchdog() FL_NOEXCEPT {
+    Watchdog::instance().feed();
+}
+
+} // namespace fl

--- a/src/fl/wdt/watchdog.h
+++ b/src/fl/wdt/watchdog.h
@@ -192,8 +192,16 @@ private:
 /// a fresh deadline; destruction feeds it again so the next iteration also
 /// starts fresh.
 ///
-/// Prefer the `FL_WATCHDOG_AUTOFEED(...)` macro below — it stamps a unique
-/// stack variable name so nested guards don't collide.
+/// **Single-instance rule.** Only one `ScopedWatchdog` should be alive at a
+/// time. The class detects nested / overlapping live instances at runtime
+/// and prints a one-shot warning via `fl::println` (the WDT is still fed in
+/// both ctors and dtors so the program keeps running). Two guards on the
+/// same source line are a compile error (the `FL_WATCHDOG_AUTO` macro
+/// stamps the local variable name from `__LINE__`, so a duplicate would
+/// collide).
+///
+/// Prefer the `FL_WATCHDOG_AUTO(...)` macro below — it stamps a unique
+/// stack variable name and is the canonical entry point.
 class ScopedWatchdog {
 public:
     /// Default construct with the library default timeout (15 000 ms).
@@ -207,6 +215,11 @@ public:
     /// a clean deadline window.
     ~ScopedWatchdog() FL_NOEXCEPT;
 
+    /// Observability: number of simultaneously-alive ScopedWatchdog instances.
+    /// Used by tests + diagnostics. A value > 1 means a nested-guard
+    /// programmer error was hit; the WDT is still being fed.
+    static int activeScopeCount() FL_NOEXCEPT;
+
     ScopedWatchdog(const ScopedWatchdog&)            FL_NOEXCEPT = delete;
     ScopedWatchdog& operator=(const ScopedWatchdog&) FL_NOEXCEPT = delete;
 };
@@ -214,30 +227,37 @@ public:
 } // namespace fl
 
 // ============================================================================
-// FL_WATCHDOG_AUTOFEED(...) — the canonical zero-setup loop()-top guard.
+// FL_WATCHDOG_AUTO(...) — the canonical zero-setup loop()-top guard.
 //
 // Variadic so the same macro covers both the no-argument default (15 000 ms)
 // and the explicit-timeout form:
 //
 //   void loop() {
-//       FL_WATCHDOG_AUTOFEED();      // 15 000 ms default
+//       FL_WATCHDOG_AUTO();      // 15 000 ms default
 //       doWork();
 //   }
 //
 //   void loop() {
-//       FL_WATCHDOG_AUTOFEED(5000);  // 5-second timeout
+//       FL_WATCHDOG_AUTO(5000);  // 5-second timeout
 //       doWork();
 //   }
 //
-// The macro stamps a unique local-variable name from __LINE__ so nested
-// scopes (or multiple guards in one function — rare but valid) don't
-// collide. Both construction-time and destruction-time feeds are performed
-// by `fl::ScopedWatchdog`.
+// "AUTO" because this macro does more than just feed: it lazily arms the WDT
+// on first call, prints the prior-boot reset/crash diagnostic, pauses 3 s on
+// a crash so the developer can read the message, and feeds the WDT on both
+// construction AND destruction. Single source-line use; the macro stamps the
+// local variable name from `__LINE__` so two `FL_WATCHDOG_AUTO()` on the same
+// line are a compile error. Two on different lines but simultaneously alive
+// (nested scopes) trigger a one-shot runtime warning — see ScopedWatchdog.
+//
+// Future variants stay grouped under the `FL_WATCHDOG_*` prefix:
+//   FL_WATCHDOG_AUTO_QUIET / FL_WATCHDOG_AUTO_VERBOSE — log-level variants
+//   FL_WATCHDOG_MANUAL                                — non-RAII setup helper
 // ============================================================================
 
 #define FL_WATCHDOG__CONCAT_INNER(a, b) a##b
 #define FL_WATCHDOG__CONCAT(a, b)       FL_WATCHDOG__CONCAT_INNER(a, b)
-#define FL_WATCHDOG_AUTOFEED(...)                                              \
+#define FL_WATCHDOG_AUTO(...)                                                  \
     ::fl::ScopedWatchdog FL_WATCHDOG__CONCAT(_fl_wdt_, __LINE__) { __VA_ARGS__ }
 
 // ============================================================================

--- a/src/fl/wdt/watchdog.h
+++ b/src/fl/wdt/watchdog.h
@@ -35,6 +35,7 @@
 #include "fl/stl/compiler_control.h"   // FL_NORETURN
 #include "fl/stl/span.h"
 #include "fl/stl/function.h"
+#include "fl/stl/string_view.h"        // for resetCauseName() return type
 
 namespace fl {
 
@@ -49,6 +50,57 @@ enum class ResetCause : fl::u8 {
     LOCKUP,
     DEBUGGER,
     PANIC,
+};
+
+/// @brief Return a static-lifetime name for `c` — zero-cost, no allocation.
+///
+/// String literal lives in flash on embedded platforms. Safe to call from any
+/// context (ISR, panic handler, before setup() finishes). Backed by
+/// `fl::string_view` so the result has no destructor and can be passed by
+/// value freely.
+inline fl::string_view resetCauseName(ResetCause c) FL_NOEXCEPT {
+    switch (c) {
+        case ResetCause::POWER_ON:     return fl::string_view("POWER_ON");
+        case ResetCause::BROWNOUT:     return fl::string_view("BROWNOUT");
+        case ResetCause::EXTERNAL_PIN: return fl::string_view("EXTERNAL_PIN");
+        case ResetCause::WATCHDOG:     return fl::string_view("WATCHDOG");
+        case ResetCause::SOFTWARE:     return fl::string_view("SOFTWARE");
+        case ResetCause::LOCKUP:       return fl::string_view("LOCKUP");
+        case ResetCause::DEBUGGER:     return fl::string_view("DEBUGGER");
+        case ResetCause::PANIC:        return fl::string_view("PANIC");
+        case ResetCause::UNKNOWN:
+        default:                       return fl::string_view("UNKNOWN");
+    }
+}
+
+/// @brief Detailed reset information bundling the normalized cause with a
+/// platform-specific subcause id and the raw cause-register value.
+///
+/// `subcauseId` and `rawRegister` are zero on platforms that don't expose
+/// them; on Teensy 4 the subcause distinguishes WDOG3 from WDOG1/2 etc.,
+/// and rawRegister holds the captured `SRC_SRSR` bits.
+struct ResetInfo {
+    ResetCause cause;          ///< Normalized cross-platform enum
+    fl::u8     subcauseId;     ///< Platform-specific subcause id (0 = none)
+    fl::u32    rawRegister;    ///< Raw value of the platform's reset-cause register
+
+    /// Cause name (zero-cost, static string_view).
+    fl::string_view causeName() const FL_NOEXCEPT { return resetCauseName(cause); }
+
+    /// Platform-specific subcause name (zero-cost, static string_view).
+    /// Returns an empty view if `subcauseId == 0` or the platform doesn't
+    /// define names. Per-platform impls extend this via a strong override.
+    fl::string_view subcauseName() const FL_NOEXCEPT;
+
+    /// Write a single-line human-readable description into the caller's
+    /// buffer. Returns the number of bytes written (NOT including any
+    /// trailing NUL, though a NUL is appended if there is room). Truncates
+    /// safely if `out` is too small. Never allocates. Format:
+    ///
+    ///   "<cause>"                          if subcauseId == 0
+    ///   "<cause> (<sub>)"                  if subcauseId != 0 && !verbose
+    ///   "<cause> (<sub>) raw=0x<hex>"      if verbose
+    fl::size describe(fl::span<char> out, bool verbose = false) const FL_NOEXCEPT;
 };
 
 /// @brief ISR-safe C function pointer callback for `onTimeout()`.
@@ -88,6 +140,12 @@ public:
     ResetCause lastResetCause() const FL_NOEXCEPT;
     bool       lastResetWasWatchdog() const FL_NOEXCEPT;
 
+    /// @brief Detailed reset information including platform raw register +
+    /// subcause id. Default implementation returns {lastResetCause(), 0, 0};
+    /// platforms that capture the raw register override with a strong
+    /// definition in their `.impl.hpp`.
+    ResetInfo lastResetInfo() const FL_NOEXCEPT;
+
     fl::u8     persistRead(fl::size idx) const FL_NOEXCEPT;
     void       persistWrite(fl::size idx, fl::u8 v) FL_NOEXCEPT;
 
@@ -124,7 +182,63 @@ private:
     fl::u16 mSafeModeThreshold = 2;
 };
 
+/// @brief RAII watchdog guard for the canonical `loop()`-top use case.
+///
+/// First construction (per-process) lazily arms the watchdog with the supplied
+/// timeout (default 15 000 ms), prints any prior-boot reset/crash diagnostic
+/// through `fl::println`, and pauses for 3 s on a crash so the developer can
+/// read the message before `loop()` repaints serial output. Construction
+/// feeds the watchdog immediately so the current loop iteration starts with
+/// a fresh deadline; destruction feeds it again so the next iteration also
+/// starts fresh.
+///
+/// Prefer the `FL_WATCHDOG_AUTOFEED(...)` macro below — it stamps a unique
+/// stack variable name so nested guards don't collide.
+class ScopedWatchdog {
+public:
+    /// Default construct with the library default timeout (15 000 ms).
+    ScopedWatchdog() FL_NOEXCEPT : ScopedWatchdog(15000u) {}
+
+    /// Construct with an explicit timeout. Same semantics as the default
+    /// constructor — first-call init, feed on construction.
+    explicit ScopedWatchdog(fl::u32 timeout_ms) FL_NOEXCEPT;
+
+    /// Feed the watchdog at end-of-scope so the next `loop()` iteration has
+    /// a clean deadline window.
+    ~ScopedWatchdog() FL_NOEXCEPT;
+
+    ScopedWatchdog(const ScopedWatchdog&)            FL_NOEXCEPT = delete;
+    ScopedWatchdog& operator=(const ScopedWatchdog&) FL_NOEXCEPT = delete;
+};
+
 } // namespace fl
+
+// ============================================================================
+// FL_WATCHDOG_AUTOFEED(...) — the canonical zero-setup loop()-top guard.
+//
+// Variadic so the same macro covers both the no-argument default (15 000 ms)
+// and the explicit-timeout form:
+//
+//   void loop() {
+//       FL_WATCHDOG_AUTOFEED();      // 15 000 ms default
+//       doWork();
+//   }
+//
+//   void loop() {
+//       FL_WATCHDOG_AUTOFEED(5000);  // 5-second timeout
+//       doWork();
+//   }
+//
+// The macro stamps a unique local-variable name from __LINE__ so nested
+// scopes (or multiple guards in one function — rare but valid) don't
+// collide. Both construction-time and destruction-time feeds are performed
+// by `fl::ScopedWatchdog`.
+// ============================================================================
+
+#define FL_WATCHDOG__CONCAT_INNER(a, b) a##b
+#define FL_WATCHDOG__CONCAT(a, b)       FL_WATCHDOG__CONCAT_INNER(a, b)
+#define FL_WATCHDOG_AUTOFEED(...)                                              \
+    ::fl::ScopedWatchdog FL_WATCHDOG__CONCAT(_fl_wdt_, __LINE__) { __VA_ARGS__ }
 
 // ============================================================================
 // FL_WATCHDOG_* capability macros — defined by the per-platform impl.

--- a/src/platforms/watchdog.impl.cpp.hpp
+++ b/src/platforms/watchdog.impl.cpp.hpp
@@ -70,3 +70,9 @@
     // The api still compiles and runs on every supported MCU.
     #include "platforms/shared/watchdog_noop.hpp"
 #endif
+
+// Platform-agnostic helpers (ResetInfo::describe(), ScopedWatchdog ctor/dtor,
+// print/delay sinks for the lazy first-init path) are emitted by
+// `src/fl/wdt/_build.cpp.hpp` — included from the regular fl/ unity build,
+// not from here. Including `.cpp.hpp` files outside the unity build is a
+// hard ban per agents/docs/cpp-standards.md.

--- a/tests/fl/wdt/watchdog.cpp
+++ b/tests/fl/wdt/watchdog.cpp
@@ -191,3 +191,114 @@ FL_TEST_CASE("fl::Watchdog — isInSafeMode trips at threshold") {
     dog.markCleanShutdown();
     FL_CHECK_FALSE(dog.isInSafeMode());
 }
+
+// =============================================================================
+// New API tests (issue #2755): resetCauseName + ResetInfo + ScopedWatchdog
+// =============================================================================
+
+FL_TEST_CASE("fl::resetCauseName — every enum value maps to a non-empty static view") {
+    FL_CHECK_EQ(fl::resetCauseName(ResetCause::UNKNOWN),      fl::string_view("UNKNOWN"));
+    FL_CHECK_EQ(fl::resetCauseName(ResetCause::POWER_ON),     fl::string_view("POWER_ON"));
+    FL_CHECK_EQ(fl::resetCauseName(ResetCause::BROWNOUT),     fl::string_view("BROWNOUT"));
+    FL_CHECK_EQ(fl::resetCauseName(ResetCause::EXTERNAL_PIN), fl::string_view("EXTERNAL_PIN"));
+    FL_CHECK_EQ(fl::resetCauseName(ResetCause::WATCHDOG),     fl::string_view("WATCHDOG"));
+    FL_CHECK_EQ(fl::resetCauseName(ResetCause::SOFTWARE),     fl::string_view("SOFTWARE"));
+    FL_CHECK_EQ(fl::resetCauseName(ResetCause::LOCKUP),       fl::string_view("LOCKUP"));
+    FL_CHECK_EQ(fl::resetCauseName(ResetCause::DEBUGGER),     fl::string_view("DEBUGGER"));
+    FL_CHECK_EQ(fl::resetCauseName(ResetCause::PANIC),        fl::string_view("PANIC"));
+}
+
+FL_TEST_CASE("fl::ResetInfo::describe — terse format without subcause or verbose flag") {
+    ResetInfo info{};
+    info.cause = ResetCause::WATCHDOG;
+    info.subcauseId = 0;
+    info.rawRegister = 0xDEADBEEFu;
+
+    char buf[64];
+    fl::size n = info.describe(fl::span<char>(buf, sizeof(buf)), /*verbose=*/false);
+    FL_CHECK_EQ(n, fl::size{8});  // "WATCHDOG"
+    FL_CHECK_EQ(fl::string_view(buf, n), fl::string_view("WATCHDOG"));
+}
+
+FL_TEST_CASE("fl::ResetInfo::describe — verbose appends raw=0x...") {
+    ResetInfo info{};
+    info.cause = ResetCause::WATCHDOG;
+    info.subcauseId = 0;
+    info.rawRegister = 0x000000FFu;
+
+    char buf[64];
+    fl::size n = info.describe(fl::span<char>(buf, sizeof(buf)), /*verbose=*/true);
+    // "WATCHDOG raw=0x000000ff" = 8 + 5 + 10 = 23 chars
+    FL_CHECK_EQ(fl::string_view(buf, n), fl::string_view("WATCHDOG raw=0x000000ff"));
+}
+
+FL_TEST_CASE("fl::ResetInfo::describe — writes NUL when buffer has room") {
+    ResetInfo info{};
+    info.cause = ResetCause::POWER_ON;
+    char buf[32] = { 'X', 'X', 'X', 'X', 'X', 'X', 'X', 'X', 0, };
+    fl::size n = info.describe(fl::span<char>(buf, sizeof(buf)), false);
+    FL_CHECK_EQ(buf[n], '\0');
+}
+
+FL_TEST_CASE("fl::ResetInfo::describe — truncates safely when buffer is too small") {
+    ResetInfo info{};
+    info.cause = ResetCause::EXTERNAL_PIN;
+    char buf[5];  // "EXTERNAL_PIN" needs 12, way more than 5
+    fl::size n = info.describe(fl::span<char>(buf, sizeof(buf)), false);
+    FL_CHECK_EQ(n, fl::size{5});  // Filled the buffer
+    FL_CHECK_EQ(fl::string_view(buf, n), fl::string_view("EXTER"));
+}
+
+FL_TEST_CASE("fl::ResetInfo::describe — zero-sized buffer returns 0, no UB") {
+    ResetInfo info{};
+    info.cause = ResetCause::WATCHDOG;
+    fl::size n = info.describe(fl::span<char>(nullptr, 0), true);
+    FL_CHECK_EQ(n, fl::size{0});
+}
+
+FL_TEST_CASE("fl::Watchdog::lastResetInfo — default returns {cause, 0, 0}") {
+    Watchdog& dog = Watchdog::instance();
+    dog.clearCrashReport();
+    dog.markCleanShutdown();
+    ResetInfo info = dog.lastResetInfo();
+    // On the stub, lastResetCause() returns POWER_ON by default.
+    FL_CHECK(info.cause == ResetCause::POWER_ON || info.cause == ResetCause::WATCHDOG);
+    FL_CHECK_EQ(info.subcauseId, fl::u8{0});
+    FL_CHECK_EQ(info.rawRegister, fl::u32{0});
+}
+
+FL_TEST_CASE("fl::ScopedWatchdog — feeds on construction and destruction") {
+    Watchdog& dog = Watchdog::instance();
+    dog.markCleanShutdown();
+    dog.clearCrashReport();
+    dog.begin(500);
+    // A bare scope here; constructor + destructor both feed. We can't
+    // observe the feed directly through the API, but if the WDT was not
+    // re-fed by the destructor the next loop iteration would race. Smoke
+    // test: construct + destroy a guard, then sleep for under the timeout
+    // and verify the dog did not fire.
+    {
+        ScopedWatchdog guard;  // default 15000ms — overrides our 500ms begin
+        fl::this_thread::sleep_for(fl::chrono::milliseconds(50));  // ok sleep for
+    }
+    // The guard re-armed at 15000ms in firstInit, so the dog is fine here.
+    FL_CHECK_FALSE(dog.lastResetWasWatchdog());
+}
+
+FL_TEST_CASE("fl::ScopedWatchdog — explicit timeout ctor compiles and feeds") {
+    Watchdog& dog = Watchdog::instance();
+    dog.markCleanShutdown();
+    {
+        ScopedWatchdog guard(20000u);  // explicit 20s
+    }
+    FL_CHECK_FALSE(dog.lastResetWasWatchdog());
+}
+
+FL_TEST_CASE("FL_WATCHDOG_AUTOFEED macro — no-arg and arg forms both compile") {
+    // Compile-time check that the macro expands correctly. The variable
+    // name is stamped from __LINE__, so two on separate lines don't collide.
+    FL_WATCHDOG_AUTOFEED();
+    FL_WATCHDOG_AUTOFEED(5000);
+    FL_WATCHDOG_AUTOFEED(2000u);
+    FL_CHECK(true);  // Always passes if it compiled
+}

--- a/tests/fl/wdt/watchdog.cpp
+++ b/tests/fl/wdt/watchdog.cpp
@@ -294,11 +294,28 @@ FL_TEST_CASE("fl::ScopedWatchdog — explicit timeout ctor compiles and feeds") 
     FL_CHECK_FALSE(dog.lastResetWasWatchdog());
 }
 
-FL_TEST_CASE("FL_WATCHDOG_AUTOFEED macro — no-arg and arg forms both compile") {
+FL_TEST_CASE("FL_WATCHDOG_AUTO macro — no-arg and arg forms both compile") {
     // Compile-time check that the macro expands correctly. The variable
     // name is stamped from __LINE__, so two on separate lines don't collide.
-    FL_WATCHDOG_AUTOFEED();
-    FL_WATCHDOG_AUTOFEED(5000);
-    FL_WATCHDOG_AUTOFEED(2000u);
+    FL_WATCHDOG_AUTO();
+    FL_WATCHDOG_AUTO(5000);
+    FL_WATCHDOG_AUTO(2000u);
     FL_CHECK(true);  // Always passes if it compiled
+}
+
+FL_TEST_CASE("fl::ScopedWatchdog — nesting detection counter") {
+    // Validates the single-instance enforcement: the active-scope counter
+    // increments on construction and decrements on destruction so that a
+    // nested guard can be detected via the warning path.
+    int baseline = ScopedWatchdog::activeScopeCount();
+    {
+        ScopedWatchdog outer;
+        FL_CHECK_EQ(ScopedWatchdog::activeScopeCount(), baseline + 1);
+        {
+            ScopedWatchdog inner;  // triggers the WARN one-shot
+            FL_CHECK_EQ(ScopedWatchdog::activeScopeCount(), baseline + 2);
+        }
+        FL_CHECK_EQ(ScopedWatchdog::activeScopeCount(), baseline + 1);
+    }
+    FL_CHECK_EQ(ScopedWatchdog::activeScopeCount(), baseline);
 }


### PR DESCRIPTION
## Summary

Implements the design from #2755 — adds a normalized, **allocation-free, no-destructor** classification API on top of the existing `fl::Watchdog` so users no longer need bit-twiddling on platform-specific reset-cause registers. Also adds a zero-setup `FL_WATCHDOG_AUTOFEED()` macro that drops a RAII guard at the top of `loop()`.

## Public API surface added

```cpp
// Tier 0 — zero-cost static names, backed by string literals in flash
fl::string_view fl::resetCauseName(ResetCause c) noexcept;

// Tier 1 — bundled cause + platform raw register + describe() to caller buffer
struct fl::ResetInfo {
    ResetCause cause;
    fl::u8     subcauseId;
    fl::u32    rawRegister;
    fl::string_view causeName() const noexcept;
    fl::string_view subcauseName() const noexcept;
    fl::size describe(fl::span<char> out, bool verbose = false) const noexcept;
};
fl::ResetInfo fl::Watchdog::lastResetInfo() const noexcept;

// Tier 1.5 — RAII guard for loop()-top use
class fl::ScopedWatchdog {
public:
    ScopedWatchdog() noexcept;                          // 15 000 ms default
    explicit ScopedWatchdog(fl::u32 timeout_ms) noexcept;
    ~ScopedWatchdog() noexcept;
};

// Variadic macro — same name handles both forms
#define FL_WATCHDOG_AUTOFEED(...) \
    ::fl::ScopedWatchdog FL_WATCHDOG__CONCAT(_fl_wdt_, __LINE__) { __VA_ARGS__ }
```

Usage replaces the 8-line bit-twiddle in `AutoResearch.ino` with one line:

```cpp
void loop() {
    FL_WATCHDOG_AUTOFEED();   // feeds on construction, lazily arms on first call,
                              // prints prior reset/crash info + waits 3 s on crash
    doWork();                 // destructor feeds again at end-of-scope
}
```

`ScopedWatchdog` feeds the watchdog on **both** construction and destruction so a loop iteration starts with a fresh deadline AND the next iteration also starts fresh. The first construction per process lazily arms the WDT, prints any prior-boot reset/crash diagnostic via `fl::println`, and pauses 3 s on a crash so the developer can read the message before `loop()` repaints serial.

## Why `fl::span<char>` (caller-owned buffer) and not `fl::string` (allocating)

The user requirement was *"fl::string which doesn't allocate memory, nor destruct the memory."* The closest existing types map cleanly:
- `fl::string_view` — non-owning view, no allocation, no destructor → used for fixed enum names (Tier 0)
- `fl::span<char>` — caller-owned buffer, no allocation, no destructor → used for dynamic content via `describe(out, verbose)` (Tier 1, 2)
- This is the `snprintf`-style pattern: caller controls capacity, method returns bytes written, truncation is safe, zero allocation

## Tests

10 new test cases in `tests/fl/wdt/watchdog.cpp`:
- `fl::resetCauseName` maps every enum value to a non-empty static view
- `describe()` — terse format, verbose format, NUL termination, truncation safety, zero-sized buffer
- `lastResetInfo()` default returns `{lastResetCause(), 0, 0}`
- `ScopedWatchdog` feeds on construction and destruction
- `FL_WATCHDOG_AUTOFEED()` / `FL_WATCHDOG_AUTOFEED(timeout)` both compile

All existing watchdog tests + new tests pass on the host stub.

## Unity-build / build-system wiring

Following the existing `fl/X/` convention:
- `src/fl/wdt/watchdog.cpp.hpp` — implementations (`ResetInfo::describe`, `ScopedWatchdog` ctor/dtor)
- `src/fl/wdt/_build.cpp.hpp` — unity build aggregator + print/delay sinks
- `src/fl/build/fl.wdt+.cpp` — top-level unity TU entry
- `src/fl/_build.cpp.hpp` — wired in the new `fl/wdt/` subdir
- `ci/lint_cpp/test_unity_build.py` — registered `fl.wdt+.cpp` in `EXPECTED_BUILD_FILES`

The dispatcher (`src/platforms/watchdog.impl.cpp.hpp`) is unchanged — platform impls still live in their `.impl.hpp` files. The new TU only adds the platform-agnostic helpers.

## Phase 2 follow-ups (tracked in #2755)

- Per-platform `lastResetInfo()` extraction:
  - Teensy 4 — `SRC_SRSR` bits → `subcauseId` (0=WDOG3, 1=WDOG1/2, 2=LOCKUP, …) + raw register
  - ESP32 — `esp_reset_reason()` already structured; just lift it
  - AVR — `MCUSR` bit → subcauseId
  - … etc per #2755 subcause map
- `WatchdogCrashReport::describe()` for the Tier 2 fault frame (multi-line)
- `CrashReport::platformDetails()` Tier Max escape hatch (returns `void*` to platform-defined struct)

## References

- Design issue: #2755
- Previous watchdog PR (bare-register WDOG3 fix): #2753
- Original API design: #2731

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded watchdog API with richer reset diagnostics (cause, subcause, raw register) and a ResetInfo describe() API
  * Added RAII watchdog guard that auto-feeds, reports recoveries, detects nesting, and exposes active-scope count
  * Added convenience macro to instantiate the automatic watchdog guard

* **Tests**
  * Added comprehensive tests for reset naming, describe() formatting/truncation, auto-feeding semantics, macro usage, and nesting behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->