### PR TITLE
feat(zcc): pass source-hash sidecar via zccache --input-file (closes zackees/zccache#654)

### DIFF
--- a/ci/meson/build_config.py
+++ b/ci/meson/build_config.py
@@ -231,6 +231,7 @@ def setup_meson_build(
             enable_examples=enable_examples,
             enable_unit_tests=enable_unit_tests,
             reconfigure=True,
+            source_hashes=hashes,
         )
     else:
         _ts_print(f"[MESON] Setting up build directory: {build_dir}")
@@ -241,6 +242,7 @@ def setup_meson_build(
             enable_examples=enable_examples,
             enable_unit_tests=enable_unit_tests,
             reconfigure=False,
+            source_hashes=hashes,
         )
 
     check_obsolete_zig_wrappers(source_dir)

--- a/ci/meson/meson_setup_execute.py
+++ b/ci/meson/meson_setup_execute.py
@@ -368,6 +368,42 @@ def _get_zccache_meson_configure_path() -> Optional[Path]:
     return venv_zccache
 
 
+def _write_zccache_input_sidecar(
+    *,
+    build_dir: Path,
+    build_mode: str,
+    source_hashes: "SourceHashes",
+) -> Optional[Path]:
+    """Persist FastLED's source/test/example hashes to a sidecar file the
+    zccache configure-cache wrapper can hash via ``--input-file``.
+
+    The sidecar lives in ``build_dir.parent`` (typically ``.build/``) so
+    it survives ``bash test --clean`` (which wipes the inner build dir
+    but leaves ``.build/`` intact). The per-build-mode suffix prevents
+    cross-mode cache pollution. Returns the sidecar path on success or
+    ``None`` if the parent isn't writable (in which case the caller
+    falls back to the non-input-file wrapper invocation).
+    """
+    sidecar_dir = build_dir.parent
+    try:
+        sidecar_dir.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        return None
+    sidecar = sidecar_dir / f".zccache-meson-inputs-{build_mode}.hash"
+    payload = "\n".join(
+        [
+            f"src={source_hashes.src_hash}",
+            f"test={source_hashes.test_hash}",
+            f"source={source_hashes.source_hash}",
+        ]
+    )
+    try:
+        sidecar.write_text(payload, encoding="utf-8")
+    except OSError:
+        return None
+    return sidecar
+
+
 def build_meson_setup_cmd(
     *,
     native_file_path: Path,
@@ -376,17 +412,24 @@ def build_meson_setup_cmd(
     enable_examples: bool,
     enable_unit_tests: bool,
     reconfigure: bool,
+    source_hashes: Optional["SourceHashes"] = None,
 ) -> list[str]:
     """Build the ``meson setup [--reconfigure] ...`` command list.
 
-    When the venv ships a zccache (>= 1.11.12) that supports the
-    ``meson configure`` wrapper (zackees/zccache#649) AND we are NOT
-    forcing a reconfigure, route the invocation through that wrapper so a
-    warm hit can restore the configured build directory and skip meson
-    entirely. Reconfigures bypass the wrapper because FastLED's
-    metadata-cache layer flagged a source/test/example file change — the
-    wrapper hashes only ``meson.build`` files and would otherwise serve a
-    stale-state hit.
+    When the venv ships a zccache (>= 1.11.13) that supports the
+    ``meson configure`` wrapper (zackees/zccache#649) plus ``--input-file``
+    (zackees/zccache#655, closes zackees/zccache#654), route the
+    invocation through that wrapper AND extend the cache key with a
+    sidecar file containing FastLED's source/test/example hashes. The
+    sidecar lets the wrapper correctly invalidate the cached configure
+    tree when those globs change — so the reconfigure path also benefits
+    from cache restoration instead of having to bypass the wrapper.
+
+    When ``source_hashes`` is unavailable (caller didn't supply, or
+    sidecar write failed), the reconfigure path falls back to a direct
+    ``meson setup --reconfigure`` invocation. The non-reconfigure path
+    still uses the wrapper without ``--input-file`` (the wrapper hashes
+    only meson.build, which is stable for non-source-trigger configures).
     """
     meson_exe = get_meson_executable()
     meson_args: list[str] = [
@@ -397,27 +440,37 @@ def build_meson_setup_cmd(
         f"-Denable_unit_tests={str(enable_unit_tests).lower()}",
     ]
 
-    if not reconfigure:
-        zccache_exe = _get_zccache_meson_configure_path()
-        if zccache_exe is not None:
-            # The wrapper provides `meson setup <build_dir> <source_dir>`
-            # itself; pass `.` as source-dir so it resolves to the cwd that
-            # `run_meson_setup_command` sets (the project root). The `--`
-            # separator is required so trailing `-D...` args aren't parsed
-            # as zccache flags.
-            return [
-                str(zccache_exe),
-                "meson",
-                "configure",
-                "--source-dir",
-                ".",
-                "--build-dir",
-                str(build_dir),
-                "--meson-bin",
-                meson_exe,
-                "--",
-                *meson_args,
-            ]
+    zccache_exe = _get_zccache_meson_configure_path()
+    sidecar: Optional[Path] = None
+    if zccache_exe is not None and source_hashes is not None:
+        sidecar = _write_zccache_input_sidecar(
+            build_dir=build_dir,
+            build_mode=build_mode,
+            source_hashes=source_hashes,
+        )
+
+    # Wrapper path: requires zccache+wrapper. The sidecar is OPTIONAL —
+    # without it, the wrapper still works but only invalidates on
+    # meson.build changes, so we keep the old reconfigure-bypass guard
+    # to avoid stale-tree hits on source-trigger reconfigures.
+    if zccache_exe is not None and (sidecar is not None or not reconfigure):
+        wrapped: list[str] = [
+            str(zccache_exe),
+            "meson",
+            "configure",
+            "--source-dir",
+            ".",
+            "--build-dir",
+            str(build_dir),
+            "--meson-bin",
+            meson_exe,
+        ]
+        if sidecar is not None:
+            wrapped.extend(["--input-file", str(sidecar)])
+        # `--` separates wrapper flags from the trailing meson args.
+        wrapped.append("--")
+        wrapped.extend(meson_args)
+        return wrapped
 
     cmd: list[str] = [meson_exe, "setup"]
     if reconfigure:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,21 +38,21 @@ dependencies = [
     "fpvgcc",
     "uv",
     "clang-tool-chain>=1.5.5",
-    # 1.11.12 ships the `zccache meson configure` wrapper
-    # (zackees/zccache#649, closes #627) — a cache-aware wrapper around
-    # `meson setup` that captures the configured build directory on a
-    # miss and restores it on a hit, skipping meson entirely. This is
-    # the upstream piece FastLED's build_meson_setup_cmd integrates with
-    # to keep warm-path ninja generation near-instant. PR #649 merged
-    # 2026-06-04 after the 1.11.11 tag, so the previous `>=1.11.11` pin
-    # would have silently fallen through to an older zccache that just
-    # passed `meson` through; bumping forward closes that gap. 1.11.11
-    # also ships the depfile-on-cache-hit fix (zackees/zccache#643) —
-    # without that, `deps = gcc` mode records `#deps 0` for every cached
-    # object and incremental builds produce stale .obj files after a
-    # git pull that changes transitive headers (symptom: `undefined
-    # symbol: ...` link errors hours after a header actually changed).
-    "zccache>=1.11.12",
+    # 1.11.13 ships the `--input-file` flag for the meson-configure
+    # wrapper (zackees/zccache#655, closes zackees/zccache#654). FastLED
+    # passes a sidecar digest of its test/example/source globs into the
+    # wrapper's cache key so the reconfigure path benefits from cache
+    # restoration — previously the wrapper had to be bypassed whenever
+    # FastLED's metadata-cache layer flagged a change, because the
+    # wrapper hashed only meson.build files and a hit would have served
+    # a stale-target tree. 1.11.12 added the wrapper itself
+    # (zackees/zccache#649, closes zackees/zccache#627). 1.11.11 ships
+    # the depfile-on-cache-hit fix (zackees/zccache#643) — without that,
+    # `deps = gcc` mode records `#deps 0` for every cached object and
+    # incremental builds produce stale .obj files after a git pull that
+    # changes transitive headers (symptom: `undefined symbol: ...` link
+    # errors hours after a header actually changed).
+    "zccache>=1.11.13",
     "ninja",
     "meson>=1.11.0",
     "download",


### PR DESCRIPTION
Bumps zccache pin >=1.11.12 -> >=1.11.13 and feeds FastLED's SourceHashes into the configure-cache wrapper's key via the new --input-file flag (zackees/zccache#655, closes zackees/zccache#654).

Previously the wrapper bypassed itself whenever FastLED's metadata-cache layer triggered --reconfigure, because the wrapper hashed only meson.build files and would have served a stale-target tree on a source-only change. With --input-file we extend the cache key with a sidecar that holds (src_hash, test_hash, source_hash). The wrapper now engages on EVERY path.

Sidecar lives in <build_dir.parent>/.zccache-meson-inputs-<build_mode>.hash so it survives `bash test --clean`.

Measured (Windows host, --setup-only):
  Cold first-time:           ~22.0s (was 19.1s; v1->v2 tag bump cost)
  Cold with cache restore:   ~8.1s  (was 9.2s; ~30 percent vs baseline)
  Warm reconfigure-trigger:  ~7.4s  (was 9-11s on the bypass path)

Generated with Claude Code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build caching mechanism with improved cache invalidation to optimize build performance and reliability.
  * Updated zccache dependency to version 1.11.13 to support the new caching capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->