### PR TITLE
perf(meson): adopt zccache 1.11.14 --no-walk for explicit meson.build input set

### DIFF
--- a/ci/meson/meson_setup_execute.py
+++ b/ci/meson/meson_setup_execute.py
@@ -14,7 +14,7 @@ import shutil
 import subprocess
 import sys
 from pathlib import Path
-from typing import Optional, cast
+from typing import NamedTuple, Optional, cast
 
 from running_process import RunningProcess
 
@@ -322,18 +322,51 @@ def handle_skip_meson_setup(
     _enforce_strict_path_violations(build_dir)
 
 
-def _get_zccache_meson_configure_path() -> Optional[Path]:
+# FastLED's full set of meson.build files, relative to the source dir
+# (the project root). Listed explicitly so the wrapper can be invoked
+# with `--no-walk` and avoid the recursive `--source-dir` traversal
+# whose dominant cost was walking `.venv/` (~100k Python files, ~5s
+# cold-with-cache). Keep this list in sync with `find . -name meson.build`
+# (excluding scratch/worktree copies). See zackees/zccache#659.
+FASTLED_MESON_BUILD_FILES: tuple[str, ...] = (
+    "meson.build",
+    "tests/meson.build",
+    "tests/profile/meson.build",
+    "examples/meson.build",
+    "ci/meson/native/meson.build",
+    "ci/meson/shared/meson.build",
+    "ci/meson/wasm/meson.build",
+)
+
+
+class ZccacheCapability(NamedTuple):
+    """Result of probing the venv zccache binary.
+
+    ``path`` — absolute path to the binary.
+    ``supports_no_walk`` — True when the binary's ``meson configure``
+    subcommand accepts ``--no-walk`` (zccache 1.11.14+,
+    zackees/zccache#660). Older wrappers (1.11.12 / 1.11.13) still work,
+    they just walk ``--source-dir`` and pay the directory-traversal cost
+    on every invocation.
+    """
+
+    path: Path
+    supports_no_walk: bool
+
+
+def _get_zccache_meson_configure_path() -> Optional[ZccacheCapability]:
     """Resolve the venv zccache binary IF it supports `meson configure`.
 
-    Returns the path to ``zccache.exe`` only when the binary is found and
-    is recent enough to ship the configure-cache wrapper (zccache 1.11.12+,
+    Returns a ``ZccacheCapability`` only when the binary is found and is
+    recent enough to ship the configure-cache wrapper (zccache 1.11.12+,
     zackees/zccache#649). Returns ``None`` otherwise so the caller falls
     back to a plain ``meson setup`` invocation.
 
     Detection is intentionally cheap: we don't parse the version string —
-    instead we check whether ``zccache meson configure --help`` prints the
-    wrapper's docstring rather than passing through to meson. That sidesteps
-    the upgrade window where the binary is installed but predates #649.
+    instead we read ``zccache meson configure --help`` and look for the
+    wrapper's docstring (any wrapper-equipped binary) plus the ``--no-walk``
+    flag name (1.11.14+). That sidesteps the upgrade window where the
+    binary is installed but predates a flag we want to use.
     """
     script_dir = Path(__file__).resolve().parent
     project_root = script_dir.parent.parent
@@ -365,7 +398,10 @@ def _get_zccache_meson_configure_path() -> Optional[Path]:
         return None
     if "Cache-aware" not in result.stdout:
         return None
-    return venv_zccache
+    return ZccacheCapability(
+        path=venv_zccache,
+        supports_no_walk="--no-walk" in result.stdout,
+    )
 
 
 def _write_zccache_input_sidecar(
@@ -425,11 +461,20 @@ def build_meson_setup_cmd(
     tree when those globs change — so the reconfigure path also benefits
     from cache restoration instead of having to bypass the wrapper.
 
+    When the wrapper is 1.11.14+ (zackees/zccache#660), pass ``--no-walk``
+    plus an explicit ``--input-file`` for each of FastLED's known
+    meson.build paths (see ``FASTLED_MESON_BUILD_FILES``). This skips
+    the wrapper's recursive ``--source-dir`` walk entirely — that walk
+    was dominated by ``.venv/`` traversal (~100k Python files, ~5s on
+    cold-with-cache) and is pure overhead given we already enumerate
+    the input set.
+
     When ``source_hashes`` is unavailable (caller didn't supply, or
     sidecar write failed), the reconfigure path falls back to a direct
     ``meson setup --reconfigure`` invocation. The non-reconfigure path
-    still uses the wrapper without ``--input-file`` (the wrapper hashes
-    only meson.build, which is stable for non-source-trigger configures).
+    still uses the wrapper without the sidecar (the wrapper hashes
+    meson.build either way, which is stable for non-source-trigger
+    configures).
     """
     meson_exe = get_meson_executable()
     meson_args: list[str] = [
@@ -440,9 +485,9 @@ def build_meson_setup_cmd(
         f"-Denable_unit_tests={str(enable_unit_tests).lower()}",
     ]
 
-    zccache_exe = _get_zccache_meson_configure_path()
+    capability = _get_zccache_meson_configure_path()
     sidecar: Optional[Path] = None
-    if zccache_exe is not None and source_hashes is not None:
+    if capability is not None and source_hashes is not None:
         sidecar = _write_zccache_input_sidecar(
             build_dir=build_dir,
             build_mode=build_mode,
@@ -453,9 +498,9 @@ def build_meson_setup_cmd(
     # without it, the wrapper still works but only invalidates on
     # meson.build changes, so we keep the old reconfigure-bypass guard
     # to avoid stale-tree hits on source-trigger reconfigures.
-    if zccache_exe is not None and (sidecar is not None or not reconfigure):
+    if capability is not None and (sidecar is not None or not reconfigure):
         wrapped: list[str] = [
-            str(zccache_exe),
+            str(capability.path),
             "meson",
             "configure",
             "--source-dir",
@@ -465,6 +510,11 @@ def build_meson_setup_cmd(
             "--meson-bin",
             meson_exe,
         ]
+        if capability.supports_no_walk:
+            # 1.11.14+: skip the recursive walk; we enumerate inputs.
+            wrapped.append("--no-walk")
+            for meson_file in FASTLED_MESON_BUILD_FILES:
+                wrapped.extend(["--input-file", meson_file])
         if sidecar is not None:
             wrapped.extend(["--input-file", str(sidecar)])
         # `--` separates wrapper flags from the trailing meson args.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,8 +38,15 @@ dependencies = [
     "fpvgcc",
     "uv",
     "clang-tool-chain>=1.5.5",
-    # 1.11.13 ships the `--input-file` flag for the meson-configure
-    # wrapper (zackees/zccache#655, closes zackees/zccache#654). FastLED
+    # 1.11.14 ships the `--no-walk` flag plus an expanded skip-list for
+    # the meson-configure wrapper (zackees/zccache#660, closes zackees/
+    # zccache#659). With `--no-walk` the wrapper skips its recursive
+    # meson.build discovery walk entirely and trusts the caller's
+    # `--input-file` entries instead. FastLED enumerates its 7 known
+    # meson.build files explicitly, eliminating the ~5s `.venv/`
+    # traversal (~100k Python files) on every cold-with-cache
+    # reconfigure. 1.11.13 shipped the `--input-file` flag
+    # (zackees/zccache#655, closes zackees/zccache#654). FastLED
     # passes a sidecar digest of its test/example/source globs into the
     # wrapper's cache key so the reconfigure path benefits from cache
     # restoration — previously the wrapper had to be bypassed whenever
@@ -52,7 +59,7 @@ dependencies = [
     # incremental builds produce stale .obj files after a git pull that
     # changes transitive headers (symptom: `undefined symbol: ...` link
     # errors hours after a header actually changed).
-    "zccache>=1.11.13",
+    "zccache>=1.11.14",
     "ninja",
     "meson>=1.11.0",
     "download",


### PR DESCRIPTION
## Summary

Pins `zccache>=1.11.14` (zackees/zccache#660) and routes the meson-configure wrapper through the new `--no-walk` flag with an explicit `--input-file` per FastLED meson.build. The wrapper no longer recursively walks `--source-dir`, which on FastLED's tree was dominated by traversing `.venv/` (~100k Python files, ~5s of wall time on cold-with-cache reconfigures).

### Why this is safe

- The 7-entry `FASTLED_MESON_BUILD_FILES` tuple matches the actual set: `find . -name meson.build` (excluding scratch/worktree copies) returns exactly these.
- Cache-key isolation: `--no-walk` mode produces an empty `input_files` map distinct from walked-mode, so 1.11.13 cache entries don't collide with 1.11.14 entries. Pinned upstream by `no_walk_is_keyed_distinctly_from_walked` in zackees/zccache#660.
- Capability detection is a one-shot `--help` grep for the string `--no-walk` — older wrappers (1.11.12 / 1.11.13) keep the previous walk-based behaviour automatically.

### Upstream timeline

| zccache | Wrapper feature | Issue |
|---|---|---|
| 1.11.12 | `meson configure` wrapper itself | zackees/zccache#627 → #649 |
| 1.11.13 | `--input-file` (caller-supplied digest sidecar) | zackees/zccache#654 → #655 |
| 1.11.14 | `--no-walk` + skip-list expansion (`.venv`, `venv`, `.cargo`) | zackees/zccache#659 → #660 |

## Test plan

- [ ] `bash lint` passes
- [ ] `bash test --cpp` smoke (one test in quick mode) — verifies the new wrapper invocation accepts the args and the cache restore path still hits
- [ ] CI matrix passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated zccache dependency to version 1.11.14 for improved build configuration handling.
  * Enhanced build system wrapper detection to support optimized configuration mode, reducing unnecessary recursive file scanning during the build setup process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->