### PR TITLE
refactor(autoresearch): adopt unified watchdog API + move boot diagnostic into platform impl

### DIFF
--- a/examples/AutoResearch/AutoResearch.ino
+++ b/examples/AutoResearch/AutoResearch.ino
@@ -183,9 +183,7 @@
 
 #include <FastLED.h>
 #include "fl/channels/all_drivers.h"  // for FastLED.enableAllDrivers() post-#2428
-#if defined(FL_IS_ESP32)
-#include "platforms/esp/32/watchdog_esp32.h"
-#endif
+#include "fl/wdt/watchdog.h"  // FL_WATCHDOG_AUTO() — unified cross-platform WDT guard
 #include "fl/stl/undef.h"  // Undefine Arduino macros (DEFAULT, INPUT, OUTPUT)
 #include "fl/stl/sstream.h"
 #include "Common.h"
@@ -202,16 +200,18 @@
 #include "AutoResearchParlioStream.h" // #2548 PARLIO streaming validation (RPC-driven)
 
 // ============================================================================
-// Teensy Hardware Watchdog (crash recovery) - DISABLED
+// Hardware Watchdog (crash recovery)
 // ============================================================================
-// TODO: WDOG3 (RTWDOG) initialization causes immediate reset loop on
-// iMXRT1062, bricking the Teensy. Needs investigation into correct
-// unlock/configure sequence before enabling. The Teensy core does not
-// touch WDOG3 at startup, so the issue is in our init code.
+// Use the unified cross-platform fl::Watchdog API via the FL_WATCHDOG_AUTO()
+// macro at the top of loop(). It lazily arms the WDT on first call, prints
+// the prior-boot reset/crash diagnostic, pauses 3 s on a crash so the
+// developer can read the message, and feeds the WDT on both ctor and dtor.
+// Works portably across ESP32 / Teensy 4 / Teensy 3 / RP2040 / nRF52 /
+// STM32 / SAMD / Apollo3 / MGM240 / AVR (the noop fallback on platforms
+// without a real WDT keeps the call safe).
 //
-// For now, watchdog is disabled. The primary fix is the FlexPWM RX
-// gap-aware decoder which should prevent the crash that motivated
-// the watchdog in the first place.
+// The previous `fl::watchdog_setup(...)` prototype is superseded by
+// `fl::Watchdog::instance().begin()` and the FL_WATCHDOG_AUTO() macro.
 
 // ============================================================================
 // Configuration
@@ -372,22 +372,23 @@ void setup() {
 
     // Diagnostic: dump reset cause + bundled CrashReport so we can tell
     // HardFault vs WDOG3 vs PIN vs POR. Direct register access — `imxrt.h`
-    // is already pulled by FastLED.h on Teensy 4.
+    // is already pulled by FastLED.h on Teensy 4. This boot-diagnostic
+    // block is complementary to FL_WATCHDOG_AUTO()'s ResetInfo print: this
+    // one shows individual bit positions + the bundled Teensy CrashReport
+    // (full HardFault stack), while FL_WATCHDOG_AUTO() shows the normalized
+    // cross-platform cause name.
 #if defined(FL_IS_TEENSY_4X) && defined(__IMXRT1062__)
     {
         const uint32_t srsr = SRC_SRSR;
         Serial.print("[boot] SRC_SRSR = 0x");  // ok serial - boot diagnostic, Teensy 4 only
         Serial.println(srsr, HEX);             // ok serial - boot diagnostic, Teensy 4 only
-        // Bit positions from imxrt.h SRC_SRSR_*_B macros (not hardcoded
-        // shifts, which were all wrong in an earlier version of this file).
         if (srsr & SRC_SRSR_WDOG3_RST_B)        Serial.println("[boot]   WDOG3_RST_B (RTWDOG fired)");        // ok serial - boot diagnostic
         if (srsr & SRC_SRSR_WDOG_RST_B)         Serial.println("[boot]   WDOG_RST_B (WDOG1/2 fired)");        // ok serial - boot diagnostic
         if (srsr & SRC_SRSR_IPP_RESET_B)        Serial.println("[boot]   POR (power-on reset)");              // ok serial - boot diagnostic
         if (srsr & SRC_SRSR_LOCKUP_SYSRESETREQ) Serial.println("[boot]   LOCKUP_SYSRESETREQ (HardFault)");    // ok serial - boot diagnostic
         if (srsr & SRC_SRSR_IPP_USER_RESET_B)   Serial.println("[boot]   IPP_USER_RESET_B (external pin)");  // ok serial - boot diagnostic
         if (srsr & SRC_SRSR_JTAG_SW_RST)        Serial.println("[boot]   JTAG/SW reset");                    // ok serial - boot diagnostic
-        // Write-1-to-clear so next boot sees only its own cause.
-        SRC_SRSR = srsr;
+        SRC_SRSR = srsr;  // W1C so next boot sees only its own cause
         if (CrashReport) {
             Serial.println("[boot] *** CrashReport present from previous boot: ***");  // ok serial - boot diagnostic
             Serial.print(CrashReport);  // ok serial - bundled Teensy CrashReport, no fl:: equivalent
@@ -399,16 +400,10 @@ void setup() {
     }
 #endif
 
-    // Unified cross-platform watchdog (FastLED#2731). Arm with a generous
-    // 15-second timeout that matches the AutoResearch test budget. On
-    // Teensy 4 the bare-register WDOG3 begin() path now relies on the
-    // `startup_early_hook` above having pre-disabled WDOG3, so re-arming
-    // here goes through a clean unlock → write → RCS-wait sequence.
-    FastLED.watchdog().begin(15000);
-    if (FastLED.watchdog().lastResetWasWatchdog()) {
-        FL_WARN("[recovery] previous boot was killed by watchdog — crash#"
-                << static_cast<int>(FastLED.watchdog().consecutiveCrashCount()));
-    }
+    // Note: the unified watchdog is armed lazily by FL_WATCHDOG_AUTO() at
+    // the top of loop() — no explicit setup() call needed. See
+    // fl/wdt/watchdog.h. The macro also prints prior-boot reset info via
+    // ResetInfo::describe() and pauses 3 s on crash before reset.
 
     // Initialize RX buffer dynamically (uses PSRAM if available, falls back to heap)
     g_rx_buffer_storage.resize(RX_BUFFER_SIZE);
@@ -567,6 +562,11 @@ void setup() {
 //   - Easy retry logic and error recovery
 
 void loop() {
+    // Unified watchdog guard. First iteration: arms the WDT, prints any
+    // prior-boot reset/crash info, pauses 3 s on a crash. Every iteration:
+    // feeds on construction (now) and again on destruction (end of scope).
+    FL_WATCHDOG_AUTO();
+
     // Aggressively pump async tasks (including JSON-RPC task)
     // This ensures RPC commands are processed frequently even without delay() calls
     for (int i = 0; i < 100; i++) {

--- a/examples/AutoResearch/AutoResearch.ino
+++ b/examples/AutoResearch/AutoResearch.ino
@@ -370,40 +370,13 @@ void setup() {
 
     FL_WARN("[SETUP] AutoResearch sketch starting - serial output active");
 
-    // Diagnostic: dump reset cause + bundled CrashReport so we can tell
-    // HardFault vs WDOG3 vs PIN vs POR. Direct register access — `imxrt.h`
-    // is already pulled by FastLED.h on Teensy 4. This boot-diagnostic
-    // block is complementary to FL_WATCHDOG_AUTO()'s ResetInfo print: this
-    // one shows individual bit positions + the bundled Teensy CrashReport
-    // (full HardFault stack), while FL_WATCHDOG_AUTO() shows the normalized
-    // cross-platform cause name.
-#if defined(FL_IS_TEENSY_4X) && defined(__IMXRT1062__)
-    {
-        const uint32_t srsr = SRC_SRSR;
-        Serial.print("[boot] SRC_SRSR = 0x");  // ok serial - boot diagnostic, Teensy 4 only
-        Serial.println(srsr, HEX);             // ok serial - boot diagnostic, Teensy 4 only
-        if (srsr & SRC_SRSR_WDOG3_RST_B)        Serial.println("[boot]   WDOG3_RST_B (RTWDOG fired)");        // ok serial - boot diagnostic
-        if (srsr & SRC_SRSR_WDOG_RST_B)         Serial.println("[boot]   WDOG_RST_B (WDOG1/2 fired)");        // ok serial - boot diagnostic
-        if (srsr & SRC_SRSR_IPP_RESET_B)        Serial.println("[boot]   POR (power-on reset)");              // ok serial - boot diagnostic
-        if (srsr & SRC_SRSR_LOCKUP_SYSRESETREQ) Serial.println("[boot]   LOCKUP_SYSRESETREQ (HardFault)");    // ok serial - boot diagnostic
-        if (srsr & SRC_SRSR_IPP_USER_RESET_B)   Serial.println("[boot]   IPP_USER_RESET_B (external pin)");  // ok serial - boot diagnostic
-        if (srsr & SRC_SRSR_JTAG_SW_RST)        Serial.println("[boot]   JTAG/SW reset");                    // ok serial - boot diagnostic
-        SRC_SRSR = srsr;  // W1C so next boot sees only its own cause
-        if (CrashReport) {
-            Serial.println("[boot] *** CrashReport present from previous boot: ***");  // ok serial - boot diagnostic
-            Serial.print(CrashReport);  // ok serial - bundled Teensy CrashReport, no fl:: equivalent
-            Serial.println("[boot] *** end CrashReport ***");  // ok serial - boot diagnostic
-        } else {
-            Serial.println("[boot] no CrashReport from previous boot");  // ok serial - boot diagnostic
-        }
-        Serial.flush();  // ok serial - boot diagnostic flush
-    }
-#endif
-
-    // Note: the unified watchdog is armed lazily by FL_WATCHDOG_AUTO() at
-    // the top of loop() — no explicit setup() call needed. See
-    // fl/wdt/watchdog.h. The macro also prints prior-boot reset info via
-    // ResetInfo::describe() and pauses 3 s on crash before reset.
+    // Note: the unified watchdog is armed lazily by FL_WATCHDOG_AUTO() at the
+    // top of loop() — no explicit setup() call needed. The macro prints the
+    // prior-boot reset info via ResetInfo::describe() and pauses 3 s on crash
+    // before the new timer arms. Per-platform boot diagnostics (Teensy 4
+    // SRC_SRSR bit decode + bundled CrashReport, ESP32 panic backtrace, etc.)
+    // are emitted by the platform watchdog impl from Watchdog::begin() — see
+    // src/fl/wdt/watchdog.h and src/platforms/*/watchdog_*.impl.hpp.
 
     // Initialize RX buffer dynamically (uses PSRAM if available, falls back to heap)
     g_rx_buffer_storage.resize(RX_BUFFER_SIZE);

--- a/src/platforms/arm/mxrt1062/watchdog_mxrt1062.impl.hpp
+++ b/src/platforms/arm/mxrt1062/watchdog_mxrt1062.impl.hpp
@@ -92,9 +92,52 @@ Watchdog& Watchdog::instance() FL_NOEXCEPT {
     return sInstance;
 }
 
+namespace platforms {
+
+// First-call boot diagnostic. Prints the SRC_SRSR raw value + decoded bit
+// names and the bundled Teensy `CrashReport` (if present) directly to
+// `Serial`. Runs at most once per process. Called from `Watchdog::begin()`
+// before any WDT writes so the user sees the prior-boot cause before the
+// new WDT timer arms. SRC_SRSR is write-1-to-clear so the next boot reads
+// only its own cause. This used to live behind `#if defined(FL_IS_TEENSY_4X)`
+// in `examples/AutoResearch/AutoResearch.ino`; moving it into the platform
+// impl lets every Teensy 4 sketch get the diagnostic for free by using
+// `FL_WATCHDOG_AUTO()` or `FastLED.watchdog().begin()`.
+inline void mxrt1062PrintBootDiagnosticOnce() {
+    static bool sPrinted = false;  // okay static in header — single-TU `.impl.hpp`
+    if (sPrinted) return;
+    sPrinted = true;
+
+    const fl::u32 srsr = SRC_SRSR;
+    Serial.print("[FastLED.watchdog] SRC_SRSR = 0x");  // ok serial - platform-specific boot diagnostic
+    Serial.println(srsr, HEX);                          // ok serial - platform-specific boot diagnostic
+    if (srsr & SRC_SRSR_WDOG3_RST_B)        Serial.println("[FastLED.watchdog]   WDOG3_RST_B (RTWDOG fired)");        // ok serial
+    if (srsr & SRC_SRSR_WDOG_RST_B)         Serial.println("[FastLED.watchdog]   WDOG_RST_B (WDOG1/2 fired)");        // ok serial
+    if (srsr & SRC_SRSR_IPP_RESET_B)        Serial.println("[FastLED.watchdog]   POR (power-on reset)");              // ok serial
+    if (srsr & SRC_SRSR_LOCKUP_SYSRESETREQ) Serial.println("[FastLED.watchdog]   LOCKUP_SYSRESETREQ (HardFault)");    // ok serial
+    if (srsr & SRC_SRSR_IPP_USER_RESET_B)   Serial.println("[FastLED.watchdog]   IPP_USER_RESET_B (external pin)");   // ok serial
+    if (srsr & SRC_SRSR_JTAG_SW_RST)        Serial.println("[FastLED.watchdog]   JTAG/SW reset");                     // ok serial
+    SRC_SRSR = srsr;  // W1C
+    if (CrashReport) {
+        Serial.println("[FastLED.watchdog] *** CrashReport from previous boot: ***");  // ok serial
+        Serial.print(CrashReport);                                                      // ok serial - bundled Teensy CrashReport
+        Serial.println("[FastLED.watchdog] *** end CrashReport ***");                  // ok serial
+    } else {
+        Serial.println("[FastLED.watchdog] no CrashReport from previous boot");        // ok serial
+    }
+    Serial.flush();  // ok serial - flush the boot diagnostic before WDT arms
+}
+
+} // namespace platforms
+
 void Watchdog::begin(fl::u32 timeout_ms) FL_NOEXCEPT {
     if (timeout_ms == 0) timeout_ms = 1000;
     if (timeout_ms > FL_WATCHDOG_MAX_TIMEOUT_MS) timeout_ms = FL_WATCHDOG_MAX_TIMEOUT_MS;
+
+    // Print the boot diagnostic exactly once per process — before any WDT
+    // writes so the user sees prior-boot cause + CrashReport before the
+    // new timer arms.
+    platforms::mxrt1062PrintBootDiagnosticOnce();
 
     // *** Enable the WDOG3 CCM clock gate FIRST. ***
     //


### PR DESCRIPTION
## Summary

Two cleanups that together complete the migration of `examples/AutoResearch/AutoResearch.ino` to the unified `fl::Watchdog` API + verify the whole stack on real Teensy 4 hardware.

1. **AutoResearch adopts `FL_WATCHDOG_AUTO()`** — one line at the top of `loop()` replaces the ESP32-only `fl::watchdog_setup(15000)` prototype call and the explicit `FastLED.watchdog().begin(...)` + `lastResetWasWatchdog()` recovery block. Works portably across ESP32 / Teensy 4 / Teensy 3 / RP2040 / nRF52 / STM32 / SAMD / Apollo3 / MGM240 / AVR (noop fallback on platforms without a real WDT).

2. **Boot diagnostic moves from user code into the Teensy 4 watchdog impl.** The previous `#if defined(FL_IS_TEENSY_4X)` block in `AutoResearch.ino` that decoded SRC_SRSR bit names and dumped the bundled Teensy `CrashReport` is gone. The same information now prints from `mxrt1062PrintBootDiagnosticOnce()` inside `src/platforms/arm/mxrt1062/watchdog_mxrt1062.impl.hpp`, called once per process from `Watchdog::begin()`. Every Teensy 4 sketch that uses `FL_WATCHDOG_AUTO()` or `FastLED.watchdog().begin()` now gets the diagnostic for free.

## Live-hardware proof on Teensy 4.0

Captured boot serial output after flashing this branch's `firmware.hex`:

```
[SETUP COMPLETE] AutoResearch ready - awaiting JSON-RPC commands
[FastLED.watchdog] SRC_SRSR = 0x1
[FastLED.watchdog]   POR (power-on reset)
[FastLED.watchdog] no CrashReport from previous boot
_build.cpp.hpp(20): WARN: [FastLED.watchdog] armed via FL_WATCHDOG_AUTO()

[GPIO BASELINE TEST] Testing GPIO 1 ??? GPIO 2 connectivity
...
RESULT: {\"type\":\"status\",\"ready\":true,\"uptimeMs\":19176}
```

Each line proves a different piece:

| Line | Proves |
|---|---|
| `[FastLED.watchdog] SRC_SRSR = 0x1` | `mxrt1062PrintBootDiagnosticOnce()` ran from `Watchdog::begin()` — the platform-specific bit decode lives in the API now |
| `POR (power-on reset)` | Bit-name lookup in the Teensy 4 watchdog impl translated `SRC_SRSR_IPP_RESET_B` correctly |
| `no CrashReport from previous boot` | Bundled Teensy `CrashReport` check is gated on its `bool` conversion inside the platform impl |
| `[FastLED.watchdog] armed via FL_WATCHDOG_AUTO()` | `scopedWatchdogFirstInit()` in `src/fl/wdt/_build.cpp.hpp:20` ran — the Tier 1.5 RAII guard is active |
| `uptimeMs: 19176` with WDT timeout = 15 000 | Loop has run for >19 s with no WDT reset → `FL_WATCHDOG_AUTO()`'s ctor + dtor are feeding WDOG3 on every iteration via the bare-register path |

The prefix change from `[boot]` (previous AutoResearch `#ifdef` block) to `[FastLED.watchdog]` (new platform-impl helper) is itself the visible proof that the diagnostic relocated from user code into the API.

## Teensy 4.1 status

Same iMXRT1062 chip, same code path. Live verification on the specific 4.1 board on the dev bench is **deferred** because that board is coated in silicone RTV which appears to be holding the PROGRAM button asserted (cyclic HalfKay re-enumeration every ~6 s) and intermittently disrupting USB enumeration mid-write. Documented in #2760 with the cleanup steps.

## Diff summary

- `examples/AutoResearch/AutoResearch.ino`:
  - Removes ESP32-only `fl::watchdog_setup(15000)` call
  - Removes 30-line `#if defined(FL_IS_TEENSY_4X)` SRC_SRSR + CrashReport block
  - Removes explicit `FastLED.watchdog().begin(15000)` + `lastResetWasWatchdog()` recovery block
  - Adds `FL_WATCHDOG_AUTO()` at top of `loop()` and includes `fl/wdt/watchdog.h` unconditionally
- `src/platforms/arm/mxrt1062/watchdog_mxrt1062.impl.hpp`:
  - Adds `mxrt1062PrintBootDiagnosticOnce()` helper in `fl::platforms` namespace — SRC_SRSR raw + bit names + Teensy CrashReport
  - Calls it from `Watchdog::begin()` before any WDT writes
  - SRC_SRSR is write-1-to-clear so the next boot reads only its own cause

## References

- Unified API: #2731, #2738, #2745, #2756
- Bare-register WDOG3: #2753 (merged)
- Teensy 4.1 hardware follow-up: #2760

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Watchdog now initializes automatically via macro in each loop iteration, reducing manual setup code.
  * Boot diagnostics automatically display previous reset causes and crash logs on startup for easier troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->