### PR TITLE
feat(rx): FlexIO RX backend skeleton (Phase 1A of #2764)

### DIFF
--- a/src/fl/channels/rx.cpp.hpp
+++ b/src/fl/channels/rx.cpp.hpp
@@ -19,6 +19,7 @@
 
 #ifdef FL_IS_TEENSY_4X
 // IWYU pragma: begin_keep
+#include "platforms/arm/teensy/teensy4_common/rx_flexio_channel.h"  // ok platform headers
 #include "platforms/arm/teensy/teensy4_common/rx_flexpwm_channel.h" // ok platform headers
 // IWYU pragma: end_keep
 #endif
@@ -110,6 +111,13 @@ fl::shared_ptr<RxDevice> RxDevice::create<RxDeviceType::FLEXPWM>(int pin) FL_NOE
     return fl::make_shared<DummyRxDevice>("FLEXPWM RX not supported on ESP32");
 }
 
+// FLEXIO not available on ESP32 (Teensy 4.x peripheral). See FastLED#2764.
+template <>
+fl::shared_ptr<RxDevice> RxDevice::create<RxDeviceType::FLEXIO>(int pin) FL_NOEXCEPT {
+    (void)pin;
+    return fl::make_shared<DummyRxDevice>("FLEXIO RX not supported on ESP32");
+}
+
 // DEFAULT maps to RMT on ESP32
 template <>
 fl::shared_ptr<RxDevice> RxDevice::create<RxDeviceType::PLATFORM_DEFAULT>(int pin) FL_NOEXCEPT {
@@ -128,6 +136,18 @@ fl::shared_ptr<RxDevice> RxDevice::create<RxDeviceType::FLEXPWM>(int pin) FL_NOE
     return device;
 }
 
+// FLEXIO device specialization for Teensy 4.x — Phase 1A skeleton (FastLED#2764).
+// Returns a real FlexIoRxChannel object whose methods report inactive until
+// Phase 1B lands the FLEXIO1 register programming.
+template <>
+fl::shared_ptr<RxDevice> RxDevice::create<RxDeviceType::FLEXIO>(int pin) FL_NOEXCEPT {
+    auto device = FlexIoRxChannel::create(pin);
+    if (!device) {
+        return fl::make_shared<DummyRxDevice>("FlexIO RX channel creation failed");
+    }
+    return device;
+}
+
 // RMT not available on Teensy
 template <>
 fl::shared_ptr<RxDevice> RxDevice::create<RxDeviceType::RMT>(int pin) FL_NOEXCEPT {
@@ -142,7 +162,8 @@ fl::shared_ptr<RxDevice> RxDevice::create<RxDeviceType::ISR>(int pin) FL_NOEXCEP
     return fl::make_shared<DummyRxDevice>("ISR RX not supported on Teensy");
 }
 
-// DEFAULT maps to FLEXPWM on Teensy 4.x
+// DEFAULT maps to FLEXPWM on Teensy 4.x (intentionally NOT switched to FLEXIO yet
+// — that ships in a separate PR after Phase 3 verification per FastLED#2764).
 template <>
 fl::shared_ptr<RxDevice> RxDevice::create<RxDeviceType::PLATFORM_DEFAULT>(int pin) FL_NOEXCEPT {
     return RxDevice::create<RxDeviceType::FLEXPWM>(pin);
@@ -165,6 +186,14 @@ fl::shared_ptr<RxDevice> RxDevice::create<RxDeviceType::ISR>(int pin) FL_NOEXCEP
 // FLEXPWM device specialization (native stub for host/desktop testing)
 template <>
 fl::shared_ptr<RxDevice> RxDevice::create<RxDeviceType::FLEXPWM>(int pin) FL_NOEXCEPT {
+    return NativeRxDevice::create(pin);
+}
+
+// FLEXIO device specialization (native stub for host/desktop testing). Same
+// NativeRxDevice fallback as the other backends so host-stub tests can exercise
+// `RxBackend::FLEXIO` against the synthetic capture buffer.
+template <>
+fl::shared_ptr<RxDevice> RxDevice::create<RxDeviceType::FLEXIO>(int pin) FL_NOEXCEPT {
     return NativeRxDevice::create(pin);
 }
 
@@ -193,6 +222,13 @@ fl::shared_ptr<RxDevice> RxDevice::create<RxDeviceType::ISR>(int pin) FL_NOEXCEP
 // FLEXPWM device specialization (dummy for unsupported platforms)
 template <>
 fl::shared_ptr<RxDevice> RxDevice::create<RxDeviceType::FLEXPWM>(int pin) FL_NOEXCEPT {
+    (void)pin;  // Suppress unused parameter warning
+    return RxDevice::createDummy();
+}
+
+// FLEXIO device specialization (dummy for unsupported platforms)
+template <>
+fl::shared_ptr<RxDevice> RxDevice::create<RxDeviceType::FLEXIO>(int pin) FL_NOEXCEPT {
     (void)pin;  // Suppress unused parameter warning
     return RxDevice::createDummy();
 }

--- a/src/fl/channels/rx.h
+++ b/src/fl/channels/rx.h
@@ -164,7 +164,8 @@ enum class RxDeviceType : u8 {
     PLATFORM_DEFAULT = 0,  ///< Platform default (RMT on ESP32, FLEXPWM on Teensy 4.x)
     ISR = 1,      ///< GPIO ISR-based receiver (ESP32)
     RMT = 2,      ///< RMT-based receiver (ESP32)
-    FLEXPWM = 3   ///< FlexPWM input-capture receiver (Teensy 4.x)
+    FLEXPWM = 3,  ///< FlexPWM input-capture receiver (Teensy 4.x)
+    FLEXIO = 4    ///< FlexIO shifter-based receiver (Teensy 4.x, FLEXIO1; see FastLED#2764)
 };
 
 /**
@@ -178,6 +179,7 @@ inline const char* toString(RxDeviceType type) FL_NOEXCEPT {
     case RxDeviceType::ISR:     return "ISR";
     case RxDeviceType::RMT:     return "RMT";
     case RxDeviceType::FLEXPWM: return "FLEXPWM";
+    case RxDeviceType::FLEXIO:  return "FLEXIO";
     }
     return "UNKNOWN";
 }

--- a/src/fl/channels/rx/channel.cpp.hpp
+++ b/src/fl/channels/rx/channel.cpp.hpp
@@ -30,6 +30,8 @@ static fl::shared_ptr<RxDevice> createBackendDevice(const RxChannelConfig& confi
         return RxDevice::create<RxDeviceType::ISR>(config.pin);
     case RxBackend::FLEXPWM:
         return RxDevice::create<RxDeviceType::FLEXPWM>(config.pin);
+    case RxBackend::FLEXIO:
+        return RxDevice::create<RxDeviceType::FLEXIO>(config.pin);
     }
     return RxDevice::create<RxDeviceType::PLATFORM_DEFAULT>(config.pin);
 }

--- a/src/fl/channels/rx/types.h
+++ b/src/fl/channels/rx/types.h
@@ -9,7 +9,8 @@ enum class RxBackend : u8 {
     PLATFORM_DEFAULT = 0,  ///< Use the recommended backend for the active platform (currently RMT on ESP32, FlexPWM on Teensy 4.x, native RX on stub/host builds).
     RMT = 1,               ///< ESP32-only RMT capture backend.
     ISR = 2,               ///< Platform-neutral interrupt-driven edge capture backend when available.
-    FLEXPWM = 3            ///< Teensy 4.x-only FlexPWM capture backend.
+    FLEXPWM = 3,           ///< Teensy 4.x-only FlexPWM capture backend.
+    FLEXIO = 4             ///< Teensy 4.x-only FlexIO capture backend (FLEXIO1; FLEXIO2 is owned by the TX driver). See FastLED#2764.
 };
 
 inline const char* toString(RxBackend backend) FL_NOEXCEPT {
@@ -18,6 +19,7 @@ inline const char* toString(RxBackend backend) FL_NOEXCEPT {
     case RxBackend::RMT: return "RMT";
     case RxBackend::ISR: return "ISR";
     case RxBackend::FLEXPWM: return "FLEXPWM";
+    case RxBackend::FLEXIO: return "FLEXIO";
     }
     return "UNKNOWN";
 }

--- a/src/platforms/arm/teensy/teensy4_common/_build.cpp.hpp
+++ b/src/platforms/arm/teensy/teensy4_common/_build.cpp.hpp
@@ -8,6 +8,7 @@
 #include "platforms/arm/teensy/teensy4_common/clockless_objectfled.cpp.hpp"
 #include "platforms/arm/teensy/teensy4_common/flexpwm_rx_channel.cpp.hpp"
 #include "platforms/arm/teensy/teensy4_common/init_channel_driver_mxrt1062.cpp.hpp"
+#include "platforms/arm/teensy/teensy4_common/rx_flexio_channel.cpp.hpp"
 #include "platforms/arm/teensy/teensy4_common/rx_flexpwm_channel.cpp.hpp"
 #include "platforms/arm/teensy/teensy4_common/spi_hw_2_mxrt1062.cpp.hpp"
 #include "platforms/arm/teensy/teensy4_common/spi_hw_4_mxrt1062.cpp.hpp"

--- a/src/platforms/arm/teensy/teensy4_common/rx_flexio_channel.cpp.hpp
+++ b/src/platforms/arm/teensy/teensy4_common/rx_flexio_channel.cpp.hpp
@@ -1,0 +1,136 @@
+/// @file rx_flexio_channel.cpp.hpp
+/// @brief Teensy 4.x FlexIO shifter-based RX implementation skeleton
+///
+/// **Phase 1A — skeleton only** (FastLED#2764). This file lands the C++ class
+/// structure, the factory, and the full `RxDevice` method surface so that:
+///
+///   1. The `RxBackend::FLEXIO` dispatcher path links cleanly on Teensy 4.
+///   2. The AutoResearch JSON-RPC harness can already reference the backend
+///      (`flexioRxBenchmark`, `runSingleTest` selection) without waiting for
+///      the hardware programming to land.
+///   3. Host-stub builds compile and unit tests can construct the object,
+///      ensuring the public API surface is stable before Phase 1B touches the
+///      FLEXIO1 registers.
+///
+/// Every method currently returns a safe placeholder (failure for `begin`,
+/// empty / `WAIT_FAILED` for the data path methods). Calling code that
+/// inspects return values will correctly treat the channel as inactive.
+///
+/// **Phase 1B (next PR in the #2764 series) wires up:**
+///   - FLEXIO1 pin-mapping table (Teensy GPIO → FLEXIO1 pin index via IOMUXC)
+///   - 1 shifter in RX mode + 1 timer in dual-8-bit-counter / edge-capture mode
+///   - eDMA channel + DMAMUX source plumbing
+///   - The actual capture buffer → edge-time decoder
+///
+/// Phase 1B will keep the public API identical, so consumers of this header
+/// don't need to change.
+
+#pragma once
+
+// IWYU pragma: private
+
+#include "platforms/arm/teensy/is_teensy.h"
+
+#if defined(FL_IS_TEENSY_4X)
+
+#define FASTLED_INTERNAL
+#include "fl/system/fastled.h"
+#include "platforms/arm/teensy/teensy4_common/rx_flexio_channel.h"
+
+#include "fl/log/log.h"
+#include "fl/stl/result.h"
+
+namespace fl {
+
+namespace {
+
+// ---------------------------------------------------------------------------
+// FlexIO RX implementation (Phase 1A skeleton)
+// ---------------------------------------------------------------------------
+class FlexIoRxChannelImpl : public FlexIoRxChannel {
+  public:
+    explicit FlexIoRxChannelImpl(int pin) : mPin(pin) {}
+    ~FlexIoRxChannelImpl() override = default;
+
+    bool begin(const RxConfig &config) override;
+    bool finished() const override;
+    RxWaitResult wait(u32 timeout_ms) override;
+    fl::result<u32, DecodeError> decode(const ChipsetTiming4Phase &timing,
+                                        fl::span<u8> out) override;
+    size_t getRawEdgeTimes(fl::span<EdgeTime> out,
+                           size_t offset = 0) override;
+    const char *name() const override { return "FLEXIO"; }
+    int getPin() const override { return mPin; }
+    bool injectEdges(fl::span<const EdgeTime> edges) override;
+
+  private:
+    int mPin = -1;
+};
+
+bool FlexIoRxChannelImpl::begin(const RxConfig &config) {
+    (void)config;
+    // Phase 1B will configure FLEXIO1 shifter + timer + DMA here.
+    FL_WARN("[FlexIO RX] begin() called but Phase 1B FLEXIO1 register "
+            "programming is not yet implemented (pin "
+            << mPin << "). See FastLED#2764.");
+    return false;
+}
+
+bool FlexIoRxChannelImpl::finished() const {
+    // Skeleton: nothing is ever running, so report "not active" via
+    // finished()==false (the channel never claims completion of a capture
+    // it didn't perform).
+    return false;
+}
+
+RxWaitResult FlexIoRxChannelImpl::wait(u32 timeout_ms) {
+    (void)timeout_ms;
+    // Skeleton: no hardware capture in progress yet → report TIMEOUT so
+    // callers fall out of their wait loops cleanly. Phase 1B replaces this
+    // with a real DMA-completion or eventfd-style wait.
+    return RxWaitResult::TIMEOUT;
+}
+
+fl::result<u32, DecodeError>
+FlexIoRxChannelImpl::decode(const ChipsetTiming4Phase &timing,
+                            fl::span<u8> out) {
+    (void)timing;
+    (void)out;
+    // Skeleton: no captured data yet → report no bytes decoded.
+    return fl::result<u32, DecodeError>::success(0u);
+}
+
+size_t FlexIoRxChannelImpl::getRawEdgeTimes(fl::span<EdgeTime> out,
+                                            size_t offset) {
+    (void)out;
+    (void)offset;
+    // Skeleton: no captures available; subsequent Phase 1B replaces this
+    // with a copy from the DMA capture buffer once the hardware is up.
+    return 0u;
+}
+
+bool FlexIoRxChannelImpl::injectEdges(fl::span<const EdgeTime> edges) {
+    (void)edges;
+    // Skeleton: edge injection is used by host-stub tests and by the
+    // bench fixture that synthesizes a known signal. Phase 1B wires this
+    // through a software edge buffer that the decoder can consume.
+    return false;
+}
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+//
+// Phase 1A accepts any pin — the FLEXIO1 mux validation lands in Phase 1B
+// alongside the pin-mapping table. Returning a real (but inert) object means
+// the dispatcher won't fall back to DummyRxDevice while we iterate on the
+// hardware programming.
+fl::shared_ptr<FlexIoRxChannel> FlexIoRxChannel::create(int pin) {
+    return fl::make_shared<FlexIoRxChannelImpl>(pin);
+}
+
+} // namespace fl
+
+#endif // FL_IS_TEENSY_4X

--- a/src/platforms/arm/teensy/teensy4_common/rx_flexio_channel.h
+++ b/src/platforms/arm/teensy/teensy4_common/rx_flexio_channel.h
@@ -1,0 +1,61 @@
+/// @file rx_flexio_channel.h
+/// @brief Teensy 4.x FlexIO shifter-based RX driver skeleton for WS2812-like signals
+///
+/// Phase 1A — skeleton only. Public API surface that unblocks the FastLED#2764
+/// Phase 2 RPC harness (`flexioRxBenchmark`) and the Phase 3 ObjectFLED loopback
+/// verification. The actual FLEXIO1 register programming + DMAMUX/eDMA wiring
+/// lands in the follow-up Phase 1B PR.
+
+#pragma once
+
+// IWYU pragma: private
+
+#include "platforms/arm/teensy/is_teensy.h"
+
+#if defined(FL_IS_TEENSY_4X)
+
+#include "fl/channels/rx.h"
+#include "fl/stl/shared_ptr.h"
+#include "fl/stl/noexcept.h"
+
+namespace fl {
+
+/// @brief FlexIO shifter-based RX device for Teensy 4.x
+///
+/// Targets the iMXRT1062 **FLEXIO1** peripheral. FLEXIO2 is owned by FastLED's
+/// existing WS2812 TX driver (`flexio_driver.h`), and FLEXIO3 has fewer mapped
+/// GPIO pins on Teensy 4.0, so FLEXIO1 is the chosen RX host.
+///
+/// Design intent (per FastLED#2764):
+/// - 1 shifter configured in RX mode
+/// - 1 timer in edge-capture / dual-8-bit-counter mode driving the shifter
+/// - eDMA channel + DMAMUX source mirroring the FlexPWM RX driver pattern
+/// - Pin restrictions: only Teensy GPIO pins that mux to a FLEXIO1 pin index
+class FlexIoRxChannel : public RxDevice {
+  public:
+    /// Factory method
+    /// @param pin GPIO pin number for receiving signals
+    /// @return Shared pointer to FlexIoRxChannel, or nullptr if pin has no FLEXIO1 mapping
+    static fl::shared_ptr<FlexIoRxChannel> create(int pin) FL_NOEXCEPT;
+
+    // RxDevice interface
+    bool begin(const RxConfig &config) FL_NOEXCEPT override;
+    bool finished() const FL_NOEXCEPT override;
+    RxWaitResult wait(u32 timeout_ms) FL_NOEXCEPT override;
+    fl::result<u32, DecodeError> decode(const ChipsetTiming4Phase &timing,
+                                        fl::span<u8> out) override FL_NOEXCEPT;
+    size_t getRawEdgeTimes(fl::span<EdgeTime> out,
+                           size_t offset = 0) override FL_NOEXCEPT;
+    const char *name() const override;
+    int getPin() const FL_NOEXCEPT override;
+    bool injectEdges(fl::span<const EdgeTime> edges) FL_NOEXCEPT override;
+
+  protected:
+    friend class fl::shared_ptr<FlexIoRxChannel>;
+    FlexIoRxChannel() = default;
+    ~FlexIoRxChannel() override = default;
+};
+
+} // namespace fl
+
+#endif // FL_IS_TEENSY_4X


### PR DESCRIPTION
## Summary

Phase 1A of [#2764](https://github.com/FastLED/FastLED/issues/2764) — lands the public API surface for the Teensy 4.x FlexIO RX backend without touching FLEXIO1 hardware programming yet.

Splits Phase 1 of the parent issue into two reviewable PRs:
- **1A (this PR):** stable API surface — enums, dispatcher, skeleton driver, platform specializations
- **1B (next PR):** FLEXIO1 pin-mapping table, shifter + timer config, DMAMUX/eDMA wiring, capture-buffer → edge-time decoder

This split unblocks Phase 2 (the RPC `flexioRxBenchmark` harness can already select `RxBackend::FLEXIO`) and Phase 3 (the ObjectFLED loopback test can wire up the backend) without coupling them to the hardware bring-up cycle.

## Diff at a glance

| File | Change |
|---|---|
| `src/fl/channels/rx/types.h` | Added `RxBackend::FLEXIO = 4` + `toString()` mapping |
| `src/fl/channels/rx.h` | Added `RxDeviceType::FLEXIO = 4` + `toString()` mapping |
| `src/fl/channels/rx/channel.cpp.hpp` | Dispatcher case for `RxBackend::FLEXIO` |
| `src/fl/channels/rx.cpp.hpp` | Per-platform `RxDevice::create<FLEXIO>` specializations (Teensy 4 → real, Stub → NativeRxDevice, ESP32 → dummy, other → dummy). `PLATFORM_DEFAULT` on Teensy stays on FLEXPWM. |
| `src/platforms/arm/teensy/teensy4_common/rx_flexio_channel.h` | New `FlexIoRxChannel` class |
| `src/platforms/arm/teensy/teensy4_common/rx_flexio_channel.cpp.hpp` | Skeleton impl — all `RxDevice` methods return safe placeholders (`TIMEOUT`/`success(0)`/empty/false) so callers correctly treat the channel as inactive |
| `src/platforms/arm/teensy/teensy4_common/_build.cpp.hpp` | Wired into the unity build |

## Why the skeleton-first split

The FlexPWM RX driver (the reference design) is 776 lines of register programming. Doing the full FlexIO RX port + verification in one PR would:
- Couple API design review with hardware bring-up debugging
- Block Phase 2/3 progress on hardware iteration cycles
- Make the diff hard to review (small protocol changes hidden in large register listings)

Splitting at the API boundary means:
- This PR is a stable interface review — clear what's exposed, easy to spot regressions
- Phase 1B's diff is *only* hardware programming, easier to bring up and bisect
- Phase 2's RPC harness already has a real `RxBackend::FLEXIO` enum to call against

## Behavior on each platform

- **Teensy 4.0 / 4.1:** `RxDevice::create<RxDeviceType::FLEXIO>(pin)` returns a real `FlexIoRxChannel` whose methods report inactive — `begin()` returns `false` with a `FL_WARN` referencing #2764, `wait()` returns `TIMEOUT`, `decode()` returns `success(0)`, `getRawEdgeTimes()` returns 0, `injectEdges()` returns false
- **Host stub:** routes to `NativeRxDevice` (same as the other RX backends) so host-stub tests can exercise `RxBackend::FLEXIO` against the synthetic capture buffer
- **ESP32:** `DummyRxDevice` with message `"FLEXIO RX not supported on ESP32"`
- **Other platforms:** `DummyRxDevice` via `createDummy()` singleton

`PLATFORM_DEFAULT` on Teensy 4.x **deliberately still resolves to FLEXPWM** — the default switch waits until Phase 3 verifies the end-to-end loopback, per the parent-issue plan.

## Verification

- ✅ Host C++ tests pass (226/226)
- ✅ C++ lint clean (`bash lint --cpp`)
- ✅ Teensy 4.0 release build clean for `examples/AutoResearch` via fbuild (~1m 07s)
- ✅ The dev-bench Teensy 4.0 AutoResearch sketch + RPC harness was confirmed alive (96+ min uptime, `findConnectedPins` returns GPIO 3↔4, `drivers` lists FLEX_IO + SPI_UNIFIED + OBJECT_FLED + BIT_BANG) before this change; selection of the new backend remains opt-in (explicit `RxBackend::FLEXIO`)

## Refs

- Parent issue: #2764
- Reference driver this mirrors: `src/platforms/arm/teensy/teensy4_common/rx_flexpwm_channel.{h,cpp.hpp}`
- FlexIO TX peripheral owner (so we know to use FLEXIO1 not FLEXIO2): `src/platforms/arm/teensy/teensy4_common/drivers/flexio/flexio_driver.h:2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added FLEXIO receiver backend support for Teensy 4.x platforms as a Phase 1A skeleton implementation.
  * FLEXIO backend can now be selected and dispatched, with placeholder functionality pending full hardware integration in Phase 1B.
  
* **Documentation**
  * Updated platform documentation to clarify Teensy 4.x default receiver settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->