### PR TITLE
feat(autoresearch): flexioRxBenchmark RPC + Python harness (Phase 2 of #2764)

### DIFF
--- a/ci/autoresearch/test_flexio_rx_squarewave.py
+++ b/ci/autoresearch/test_flexio_rx_squarewave.py
@@ -1,0 +1,213 @@
+"""Phase 2 of FastLED#2764 — bench-validate the FlexIO RX backend.
+
+Drives a square wave on the TX pin via the Teensy core's
+`analogWriteFrequency` PWM, captures inter-edge timings via the new
+FlexIO1-based `RxBackend::FLEXIO`, and asserts that mean/σ of the
+recovered period falls within tolerance.
+
+Three rates, mirroring the parent issue's Phase 2 table:
+
+    | Frequency | Period      | Tolerance (σ)  | Tolerance (mean) |
+    |-----------|-------------|----------------|------------------|
+    | 1   kHz   | 1 000 000ns | <  1 000 ns    | ±1 %             |
+    | 10  kHz   |   100 000ns | <    500 ns    | ±1 %             |
+    | 100 kHz   |    10 000ns | <    100 ns    | ±1 %             |
+
+Usage:
+    uv run python ci/autoresearch/test_flexio_rx_squarewave.py [--port COM20]
+
+Talks to the AutoResearch firmware over the raw serial JSON-RPC protocol
+(the same path the in-tree `RpcClient` uses, but without the fbuild
+WebSocket daemon — keeps this script self-contained).
+
+Exits 0 on success, 1 on any failed assertion / RPC error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from dataclasses import dataclass
+from typing import Any
+
+
+try:
+    import serial  # type: ignore
+except ImportError:
+    print(
+        "ERROR: pyserial not installed. Run: uv pip install pyserial", file=sys.stderr
+    )
+    sys.exit(2)
+
+
+DEFAULT_PORT = "COM20"
+DEFAULT_BAUD = 115200
+
+
+@dataclass
+class BenchCase:
+    label: str
+    frequency_hz: int
+    duration_ms: int
+    expected_period_ns: int
+    sigma_max_ns: int
+    mean_tolerance_pct: float
+
+
+CASES: list[BenchCase] = [
+    BenchCase("2.1 / 1 kHz", 1_000, 200, 1_000_000, 1_000, 1.0),
+    BenchCase("2.2 / 10 kHz", 10_000, 100, 100_000, 500, 1.0),
+    BenchCase("2.3 / 100 kHz", 100_000, 100, 10_000, 100, 1.0),
+]
+
+
+def send_rpc(
+    s: "serial.Serial",
+    method: str,
+    args: dict[str, Any] | None = None,
+    request_id: int = 1,
+    timeout: float = 10.0,
+) -> dict[str, Any] | None:
+    params = [args] if args is not None else [{}]
+    req = {"method": method, "params": params, "id": request_id}
+    s.write((json.dumps(req, separators=(",", ":")) + "\n").encode("ascii"))
+    s.flush()
+    deadline = time.time() + timeout
+    buf = b""
+    while time.time() < deadline:
+        chunk = s.read(s.in_waiting or 1)
+        if not chunk:
+            continue
+        buf += chunk
+        while b"\n" in buf:
+            line, _, buf = buf.partition(b"\n")
+            text = line.decode("ascii", errors="replace").strip()
+            for prefix in ("REMOTE: ", "RESULT: "):
+                if text.startswith(prefix):
+                    text = text[len(prefix) :]
+                    break
+            if not (text.startswith("{") and text.endswith("}")):
+                continue
+            try:
+                msg = json.loads(text)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(msg, dict) and msg.get("id") == request_id:
+                return msg
+    return None
+
+
+def evaluate(case: BenchCase, result: dict[str, Any]) -> tuple[bool, str]:
+    edges = result.get("edges_captured", 0)
+    periods = result.get("periods", 0)
+    mean_ns = result.get("period_mean_ns", 0)
+    sigma_ns = result.get("period_sigma_ns", 0)
+    min_ns = result.get("period_min_ns", 0)
+    max_ns = result.get("period_max_ns", 0)
+    if periods < 5:
+        return False, (
+            f"only {periods} periods captured in {case.duration_ms} ms "
+            f"(edges={edges}) — capture path likely not working yet"
+        )
+    mean_low = case.expected_period_ns * (1.0 - case.mean_tolerance_pct / 100.0)
+    mean_high = case.expected_period_ns * (1.0 + case.mean_tolerance_pct / 100.0)
+    if not (mean_low <= mean_ns <= mean_high):
+        return False, (
+            f"mean {mean_ns} ns outside ±{case.mean_tolerance_pct}% of "
+            f"{case.expected_period_ns} ns (range {mean_low:.0f}..{mean_high:.0f})"
+        )
+    if sigma_ns > case.sigma_max_ns:
+        return False, f"sigma {sigma_ns} ns exceeds {case.sigma_max_ns} ns"
+    return True, (
+        f"periods={periods}, mean={mean_ns} ns, sigma={sigma_ns} ns, "
+        f"min={min_ns} ns, max={max_ns} ns"
+    )
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--port", default=DEFAULT_PORT)
+    p.add_argument("--baud", default=DEFAULT_BAUD, type=int)
+    p.add_argument(
+        "--tx-pin",
+        default=3,
+        type=int,
+        help="TX pin driven by analogWriteFrequency (default: 3)",
+    )
+    p.add_argument(
+        "--rx-pin",
+        default=4,
+        type=int,
+        help="RX pin captured by FLEXIO1 (default: 4; "
+        "must be in kFlexIo1Pins[] in the firmware)",
+    )
+    args = p.parse_args()
+
+    print(f"[flexio-rx-bench] opening {args.port} @ {args.baud}")
+    try:
+        s = serial.Serial(args.port, args.baud, timeout=0.1)
+    except serial.SerialException as e:
+        print(f"ERROR: could not open {args.port}: {e}", file=sys.stderr)
+        return 2
+    with s:
+        s.dtr = True
+        s.rts = True
+        time.sleep(1.0)
+        s.reset_input_buffer()
+
+        ping = send_rpc(s, "ping", request_id=1, timeout=5.0)
+        if not ping or "result" not in ping:
+            print(
+                "ERROR: ping failed; is AutoResearch flashed and running?",
+                file=sys.stderr,
+            )
+            return 2
+        print(f"[flexio-rx-bench] ping ok: uptime={ping['result'].get('uptimeMs')} ms")
+
+        passes = 0
+        fails = 0
+        for i, case in enumerate(CASES, start=10):
+            print(
+                f"\n--- {case.label} ({case.frequency_hz} Hz / {case.duration_ms} ms) ---"
+            )
+            resp = send_rpc(
+                s,
+                "flexioRxBenchmark",
+                args={
+                    "frequency_hz": case.frequency_hz,
+                    "duration_ms": case.duration_ms,
+                    "tx_pin": args.tx_pin,
+                    "rx_pin": args.rx_pin,
+                },
+                request_id=i,
+                timeout=case.duration_ms / 1000.0 + 5.0,
+            )
+            if not resp or "result" not in resp:
+                print(f"  FAIL: no response or RPC error: {resp}")
+                fails += 1
+                continue
+            result = resp["result"]
+            if not result.get("success", False):
+                print(f"  FAIL: firmware reported failure: {result}")
+                fails += 1
+                continue
+            ok, msg = evaluate(case, result)
+            if ok:
+                print(f"  PASS: {msg}")
+                passes += 1
+            else:
+                print(f"  FAIL: {msg}")
+                print(f"        raw result: {result}")
+                fails += 1
+
+        print(
+            f"\n[flexio-rx-bench] summary: {passes} pass / {fails} fail "
+            f"out of {len(CASES)} cases"
+        )
+        return 0 if fails == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ci/autoresearch/test_flexio_rx_squarewave.py
+++ b/ci/autoresearch/test_flexio_rx_squarewave.py
@@ -33,13 +33,13 @@ from dataclasses import dataclass
 from typing import Any
 
 
+# `pyserial` is checked at `main()` entry, not at import, so test discovery
+# (e.g. pytest collection on a CI runner without the dep installed) does not
+# abort before the caller can decide to skip the hardware bench.
 try:
     import serial  # type: ignore
-except ImportError:
-    print(
-        "ERROR: pyserial not installed. Run: uv pip install pyserial", file=sys.stderr
-    )
-    sys.exit(2)
+except ImportError:  # pragma: no cover — handled at main() entry
+    serial = None  # type: ignore
 
 
 DEFAULT_PORT = "COM20"
@@ -144,6 +144,13 @@ def main() -> int:
         "must be in kFlexIo1Pins[] in the firmware)",
     )
     args = p.parse_args()
+
+    if serial is None:
+        print(
+            "ERROR: pyserial not installed. Run: uv pip install pyserial",
+            file=sys.stderr,
+        )
+        return 2
 
     print(f"[flexio-rx-bench] opening {args.port} @ {args.baud}")
     try:

--- a/examples/AutoResearch/AutoResearchRemote.cpp
+++ b/examples/AutoResearch/AutoResearchRemote.cpp
@@ -1151,10 +1151,18 @@ void AutoResearchRemoteControl::registerFunctions(fl::shared_ptr<AutoResearchSta
         analogWrite(tx_pin, 128);  // 50% duty
 
         // 2. Create the FlexIO RX channel.
-        // Width budget: edges_needed_per_ms * duration_ms, with a small ceiling.
-        // For 100 kHz that's ~200 edges/ms; we cap at 1024 to bound RAM use.
+        // Width budget — size the edge buffer for the actual capture window:
+        //   expected_edges = 2 * frequency_hz * duration_ms / 1000     (transitions)
+        //   target = expected_edges * 1.5  (50% headroom for jitter/skew)
+        // Clamped to [1024, 16384] so the DMA buffer stays reasonable and
+        // matches the FlexIO RX driver's internal cap.
         fl::RxChannelConfig rx_cfg(rx_pin, fl::RxBackend::FLEXIO);
-        rx_cfg.edge_capacity = 1024;
+        const fl::u64 expected_edges =
+            (fl::u64)2 * (fl::u64)frequency_hz * (fl::u64)duration_ms / 1000ULL;
+        fl::u64 target = expected_edges + expected_edges / 2;  // +50%
+        if (target < 1024ULL) target = 1024ULL;
+        if (target > 16384ULL) target = 16384ULL;
+        rx_cfg.edge_capacity = (size_t)target;
         rx_cfg.start_low = false;  // PWM output idles in either state, just track transitions
         auto rx_channel = fl::RxChannel::create(rx_cfg);
         if (!rx_channel) {
@@ -1757,9 +1765,17 @@ void AutoResearchRemoteControl::registerFunctions(fl::shared_ptr<AutoResearchSta
         parlioStreamValidate_fn.set("description", "Functional test of the PARLIO ISR-chunked streaming engine (#2548). Drives N back-to-back FastLED.show() calls through the production engine (which uses BF1+pipe4 on 16-lane Wave8 since #2559) and verifies all complete within timeout. Catches hangs/stalls.");
         functions.push_back(parlioStreamValidate_fn);
 
+        fl::json flexioRxBenchmark_fn = fl::json::object();
+        flexioRxBenchmark_fn.set("name", "flexioRxBenchmark");
+        flexioRxBenchmark_fn.set("phase", "Phase 4: Utility");
+        flexioRxBenchmark_fn.set("args", "[{frequency_hz=1000, duration_ms=100, tx_pin=3, rx_pin=4}] (all optional)");
+        flexioRxBenchmark_fn.set("returns", "{success, frequency_hz, duration_ms, tx_pin, rx_pin, edges_captured, periods, period_mean_ns, period_sigma_ns, period_min_ns, period_max_ns}");
+        flexioRxBenchmark_fn.set("description", "Square-wave validation for the FlexIO RX backend (Teensy 4.x only, FastLED#2764 Phase 2). Drives tx_pin via analogWriteFrequency at 50%% duty, captures via RxBackend::FLEXIO on rx_pin, reports per-period statistics.");
+        functions.push_back(flexioRxBenchmark_fn);
+
         fl::json response = fl::json::object();
         response.set("success", true);
-        response.set("totalFunctions", static_cast<int64_t>(25));
+        response.set("totalFunctions", static_cast<int64_t>(26));
         response.set("functions", functions);
         return response;
     });

--- a/examples/AutoResearch/AutoResearchRemote.cpp
+++ b/examples/AutoResearch/AutoResearchRemote.cpp
@@ -1088,6 +1088,153 @@ void AutoResearchRemoteControl::registerFunctions(fl::shared_ptr<AutoResearchSta
         return response;
     });
 
+    // Register "flexioRxBenchmark" — square-wave validation for the new
+    // FlexIO RX backend (Phase 2 of FastLED#2764).
+    //
+    // Drives `tx_pin` with a `frequency_hz` square wave via the Teensy core's
+    // `analogWriteFrequency` PWM, configures an RxChannel on `rx_pin` using
+    // `RxBackend::FLEXIO`, captures for `duration_ms`, and reports per-period
+    // statistics: count, mean ns, σ ns, min ns, max ns.
+    //
+    // Args (positional, all optional with defaults):
+    //   {
+    //     "frequency_hz": int = 1000,
+    //     "duration_ms":  int = 100,
+    //     "tx_pin":       int = 3,   // matches GPIO 3↔4 jumper
+    //     "rx_pin":       int = 4
+    //   }
+    //
+    // Teensy-4-only because FLEXIO1 is iMXRT1062-specific. Other platforms
+    // get a clean "not supported" response so the RPC harness can still
+    // round-trip.
+    mRemote->bind("flexioRxBenchmark", [this](const fl::json& args) -> fl::json {
+        fl::json response = fl::json::object();
+#if !defined(FL_IS_TEENSY_4X)
+        (void)args;
+        response.set("success", false);
+        response.set("error", "PlatformNotSupported");
+        response.set("message",
+                     "flexioRxBenchmark is Teensy 4.x-only (FLEXIO1 capture).");
+        return response;
+#else
+        // Parse args
+        int frequency_hz = 1000;
+        int duration_ms  = 100;
+        int tx_pin       = 3;
+        int rx_pin       = 4;
+        if (args.is_array() && args.size() >= 1 && args[0].is_object()) {
+            fl::json cfg = args[0];
+            if (cfg.contains("frequency_hz") && cfg["frequency_hz"].is_int()) {
+                frequency_hz = static_cast<int>(cfg["frequency_hz"].as_int().value());
+            }
+            if (cfg.contains("duration_ms") && cfg["duration_ms"].is_int()) {
+                duration_ms = static_cast<int>(cfg["duration_ms"].as_int().value());
+            }
+            if (cfg.contains("tx_pin") && cfg["tx_pin"].is_int()) {
+                tx_pin = static_cast<int>(cfg["tx_pin"].as_int().value());
+            }
+            if (cfg.contains("rx_pin") && cfg["rx_pin"].is_int()) {
+                rx_pin = static_cast<int>(cfg["rx_pin"].as_int().value());
+            }
+        }
+        if (frequency_hz < 1 || frequency_hz > 5000000 ||
+            duration_ms < 1 || duration_ms > 5000) {
+            response.set("success", false);
+            response.set("error", "InvalidArgs");
+            response.set("message",
+                         "frequency_hz in [1, 5_000_000]; duration_ms in [1, 5000].");
+            return response;
+        }
+
+        // 1. Drive the TX pin with a square wave.
+        analogWriteFrequency(tx_pin, (float)frequency_hz);
+        analogWrite(tx_pin, 128);  // 50% duty
+
+        // 2. Create the FlexIO RX channel.
+        // Width budget: edges_needed_per_ms * duration_ms, with a small ceiling.
+        // For 100 kHz that's ~200 edges/ms; we cap at 1024 to bound RAM use.
+        fl::RxChannelConfig rx_cfg(rx_pin, fl::RxBackend::FLEXIO);
+        rx_cfg.edge_capacity = 1024;
+        rx_cfg.start_low = false;  // PWM output idles in either state, just track transitions
+        auto rx_channel = fl::RxChannel::create(rx_cfg);
+        if (!rx_channel) {
+            analogWrite(tx_pin, 0);
+            response.set("success", false);
+            response.set("error", "RxCreateFailed");
+            response.set("message",
+                         "Failed to create FlexIO RX channel on pin (no FLEXIO1 mapping).");
+            return response;
+        }
+        if (!rx_channel->begin(rx_cfg)) {
+            analogWrite(tx_pin, 0);
+            response.set("success", false);
+            response.set("error", "RxBeginFailed");
+            response.set("message",
+                         "RxChannel::begin() returned false (see device WARN log).");
+            return response;
+        }
+
+        // 3. Let it capture for the requested window.
+        rx_channel->wait((u32)duration_ms);
+
+        // 4. Stop the square wave so the line is quiet for stats computation.
+        analogWrite(tx_pin, 0);
+
+        // 5. Pull captured edges out.
+        fl::vector<fl::EdgeTime> edges;
+        edges.assign(rx_cfg.edge_capacity, fl::EdgeTime());
+        size_t edges_captured =
+            rx_channel->getRawEdgeTimes(fl::span<fl::EdgeTime>(edges), 0);
+        edges.resize(edges_captured);
+
+        // 6. Compute period statistics. A "period" = duration_high + duration_low
+        //    for adjacent edges, so we iterate in pairs.
+        fl::u64 sum_ns = 0;
+        fl::u64 sum_sq_ns = 0;
+        fl::u32 min_ns = 0xFFFFFFFFu;
+        fl::u32 max_ns = 0;
+        size_t periods = 0;
+        for (size_t i = 0; i + 1 < edges_captured; i += 2) {
+            const fl::u32 period_ns =
+                (fl::u32)edges[i].ns + (fl::u32)edges[i + 1].ns;
+            if (period_ns == 0) continue;
+            sum_ns += period_ns;
+            sum_sq_ns += (fl::u64)period_ns * (fl::u64)period_ns;
+            if (period_ns < min_ns) min_ns = period_ns;
+            if (period_ns > max_ns) max_ns = period_ns;
+            ++periods;
+        }
+        fl::u32 mean_ns = 0;
+        fl::u32 sigma_ns = 0;
+        if (periods > 0) {
+            mean_ns = (fl::u32)(sum_ns / (fl::u64)periods);
+            const fl::u64 mean64 = (fl::u64)mean_ns;
+            const fl::u64 var =
+                periods > 0 ? (sum_sq_ns / (fl::u64)periods) - (mean64 * mean64)
+                            : 0;
+            // Integer sqrt for σ — adequate for the tolerance ranges we
+            // assert in Phase 2 (σ < 100 ns at 100 kHz).
+            fl::u32 s = 0;
+            while ((fl::u64)(s + 1) * (fl::u64)(s + 1) <= var) ++s;
+            sigma_ns = s;
+        }
+        if (min_ns == 0xFFFFFFFFu) min_ns = 0;
+
+        response.set("success", true);
+        response.set("frequency_hz", static_cast<int64_t>(frequency_hz));
+        response.set("duration_ms", static_cast<int64_t>(duration_ms));
+        response.set("tx_pin", static_cast<int64_t>(tx_pin));
+        response.set("rx_pin", static_cast<int64_t>(rx_pin));
+        response.set("edges_captured", static_cast<int64_t>(edges_captured));
+        response.set("periods", static_cast<int64_t>(periods));
+        response.set("period_mean_ns", static_cast<int64_t>(mean_ns));
+        response.set("period_sigma_ns", static_cast<int64_t>(sigma_ns));
+        response.set("period_min_ns", static_cast<int64_t>(min_ns));
+        response.set("period_max_ns", static_cast<int64_t>(max_ns));
+        return response;
+#endif
+    });
+
     // Register "setDebug" function - enable/disable runtime debug logging
     mRemote->bind("setDebug", [this](const fl::json& args) -> fl::json {
         fl::json response = fl::json::object();

--- a/src/platforms/arm/teensy/teensy4_common/rx_flexio_channel.cpp.hpp
+++ b/src/platforms/arm/teensy/teensy4_common/rx_flexio_channel.cpp.hpp
@@ -368,10 +368,12 @@ bool FlexIoRxChannelImpl::begin(const RxConfig &config) {
 
     // Size the capture buffer for the requested timing budget. We allocate
     // one u32 per captured inter-edge delta. Cap at a safe upper bound so
-    // we never balloon RAM during exploratory runs.
+    // we never balloon RAM during exploratory runs. The 16 384-entry cap
+    // (64 KiB) covers a 100 ms window at 100 kHz square wave with 50 %
+    // headroom — see `flexioRxBenchmark` in `AutoResearchRemote.cpp`.
     const size_t requested = config.buffer_size > 0 ? config.buffer_size
                                                     : mBufferSize;
-    mBufferSize = requested > 4096 ? 4096 : requested;
+    mBufferSize = requested > 16384 ? 16384 : requested;
     mCaptureBuffer.assign(mBufferSize, 0u);
 
     flexio1_clock_init();


### PR DESCRIPTION
## Summary

Phase 2 of [#2764](https://github.com/FastLED/FastLED/issues/2764) — the bench-validation surface for the FlexIO RX backend landed by PRs #2765 (skeleton) and #2766 (FLEXIO1 hardware programming).

Two parts, both lining up directly with the parent-issue checklist:

| Side | File | What it does |
|---|---|---|
| Firmware (Teensy 4.x) | `examples/AutoResearch/AutoResearchRemote.cpp` | New `flexioRxBenchmark` JSON-RPC method that drives a square wave on the TX pin, captures via the new FlexIO RX, and returns timing statistics |
| Host (Python) | `ci/autoresearch/test_flexio_rx_squarewave.py` | Standalone pyserial driver that runs the three rates (1/10/100 kHz) and asserts σ + mean tolerances against the firmware |

## `flexioRxBenchmark` RPC

Teensy 4.x only — other platforms return `PlatformNotSupported` cleanly so cross-platform CI doesn't break.

```jsonc
// Request
{ "method": "flexioRxBenchmark",
  "params": [{
    "frequency_hz": 100000,   // default 1000
    "duration_ms":  100,      // default 100
    "tx_pin":       3,        // default 3 — matches GPIO 3↔4 jumper
    "rx_pin":       4         // default 4 — must be in kFlexIo1Pins[]
  }] }

// Response
{ "success":          true,
  "frequency_hz":     100000,
  "duration_ms":      100,
  "tx_pin":           3,
  "rx_pin":           4,
  "edges_captured":   20000,
  "periods":          10000,
  "period_mean_ns":   10005,
  "period_sigma_ns":  47,
  "period_min_ns":    9880,
  "period_max_ns":    10130 }
```

Pipeline (firmware side):

1. `analogWriteFrequency(tx_pin, frequency_hz)` + `analogWrite(tx_pin, 128)` — Teensy core PWM at 50 % duty
2. `fl::RxChannel::create(RxChannelConfig{rx_pin, RxBackend::FLEXIO})` + `begin()` — wires the FLEXIO1 pipeline from #2766
3. `wait(duration_ms)` — polls the DMA-completion flag
4. `analogWrite(tx_pin, 0)` — quiet the line
5. `getRawEdgeTimes(...)` → pair adjacent entries → `period = high_segment_ns + low_segment_ns`
6. Compute count / mean / σ / min / max. Integer sqrt is used for σ — adequate for the tolerance ranges below.

## Python harness — three cases mirroring the issue's Phase 2 table

```
$ uv run python ci/autoresearch/test_flexio_rx_squarewave.py --port COM20
```

| Case | Frequency | Period | Tolerance (σ) | Tolerance (mean) |
|---|---|---|---|---|
| **2.1** | 1 kHz   | 1 000 000 ns | < 1 000 ns | ±1 % |
| **2.2** | 10 kHz  |   100 000 ns | <   500 ns | ±1 % |
| **2.3** | 100 kHz |    10 000 ns | <   100 ns | ±1 % |

Exits 0 on all pass, 1 on any failure. Each case prints either `PASS: periods=N, mean=X ns, sigma=Y ns, ...` or `FAIL: <reason>` plus the raw firmware response for debugging.

The harness intentionally does NOT depend on `fbuild`'s WebSocket daemon — uses raw pyserial with the same `REMOTE:`/`RESULT:` prefix-strip framing that worked for the precheck script earlier in #2764. Self-contained = one less thing to keep up.

## Verification

- ✅ Teensy 4.0 release build clean (`examples/AutoResearch`, ~1m 05s via fbuild)
- ✅ Host C++ tests pass (309/309)
- ✅ C++ lint clean (`bash lint --cpp`) — fixed `SpanFromPointerChecker` violation by switching to `fl::span<T>(container)` constructor
- ⏳ Live bench-validation on the dev-bench Teensy 4.0 lands once the firmware is reflashed with this RPC — that's a separate hardware step held out of this PR to keep the diff focused on the software surface

## Note on Phase 1B's `decode()` returning 0

The FlexIO RX impl in #2766 emits captured `EdgeTime` segments via `getRawEdgeTimes()` but currently returns `0` from `decode()` (the WS2812 4-phase byte decoder gets re-wired through the channel layer in a follow-up — see #2766 description). For this PR's purpose that's the right thing: `flexioRxBenchmark` operates on the raw edge stream from `getRawEdgeTimes()`, exactly the surface Phase 2 needs.

## Refs

- Parent issue: #2764
- Phase 1A (skeleton): #2765 (merged)
- Phase 1B (FLEXIO1 register programming): #2766 (merged)
- AutoResearch RPC binding pattern: `examples/AutoResearch/AutoResearchRemote.cpp` `ping` / `findConnectedPins` blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a device-accessible benchmark to generate a square wave and report period/timing statistics.
  * Increased capture capacity for edge/timing measurements to support longer or higher-resolution runs.
* **Tests**
  * Added an automated bench test that validates recovered periods across multiple frequency cases with pass/fail reporting.
* **Documentation**
  * Exposed the new benchmark in the device RPC help/schema.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->