### PR TITLE
refactor(stdio): route libFastLED.a printf through fl::snprintf + lint guard (#2773 item 1.1 + 1.5)

### DIFF
--- a/ci/lint_cpp/bare_snprintf_checker.py
+++ b/ci/lint_cpp/bare_snprintf_checker.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+# pyright: reportUnknownMemberType=false
+"""Checker that bans bare C `::snprintf` / `::printf` / `::sprintf` / etc.
+
+Rationale (FastLED #2773 item 1.1 / 1.5): newlib's `snprintf` pulls
+`_svfprintf_r` (~11 KB) into the binary. The fl::snprintf template in
+`fl/stl/stdio.h` formats integers/strings through `fl::sstream`, which
+the linker can dead-strip and which doesn't transitively pull the full
+C `printf` engine.
+
+`libFastLED.a` is the half of the binary we control, so this checker
+enforces the discipline only there. ESP-IDF / mbed / mbedtls etc. can
+still use the C printf engine; this rule just stops FastLED from
+*adding* to their pull-in count.
+
+Suppression:
+- Add `// ok snprintf` at end of line to whitelist a specific call.
+- `fl/stl/stdio.h`, `fl/stl/cstdio.h`, and the lint checker itself are
+  always exempt.
+"""
+
+import re
+
+from ci.util.check_files import FileContent, FileContentChecker
+from ci.util.paths import PROJECT_ROOT
+
+
+SRC_ROOT = PROJECT_ROOT / "src"
+
+# Whitelisted files inside src/ that legitimately need the C symbols
+# (the fl:: shim itself; the cstdio compat header).
+EXEMPT_FILES = (
+    "fl/stl/stdio.h",
+    "fl/stl/stdio.cpp.hpp",
+    "fl/stl/cstdio.h",
+    "fl/stl/cstdio.cpp.hpp",
+)
+
+BANNED_FUNCS = (
+    "snprintf",
+    "sprintf",
+    "vsnprintf",
+    "vsprintf",
+    "fprintf",
+    "vfprintf",
+)
+
+# Match `<func>(` not preceded by `fl::`, `::`, `.`, or an identifier
+# character. Examples that match:
+#   snprintf(buf, ...)
+# Examples that DO NOT match:
+#   fl::snprintf(...)
+#   ::snprintf(...)        (explicit global qualification, allowed)
+#   obj.snprintf(...)
+#   my_snprintf(...)
+_BANNED_PATTERN = re.compile(
+    r"(?<![A-Za-z0-9_:.\b])(" + "|".join(BANNED_FUNCS) + r")\s*\("
+)
+_SUPPRESS = "// ok snprintf"
+
+
+class BareSnprintfChecker(FileContentChecker):
+    """Bans bare C printf-family calls inside src/ (FastLED #2773 item 1.5)."""
+
+    def __init__(self):
+        self.violations: dict[str, list[tuple[int, str]]] = {}
+
+    def should_process_file(self, file_path: str) -> bool:
+        # Only src/.
+        if not file_path.startswith(str(SRC_ROOT)):
+            return False
+        if not file_path.endswith((".cpp", ".h", ".hpp")):
+            return False
+        norm = file_path.replace("\\", "/")
+        # Skip the shim itself.
+        for exempt in EXEMPT_FILES:
+            if norm.endswith(exempt):
+                return False
+        # Skip third-party upstream code — we don't control these sources.
+        if "/third_party/" in norm:
+            return False
+        # Skip host-only unit-test watchdog scaffolding. These files are HOST
+        # test infrastructure (apple/posix/win) and never link into ESP32
+        # firmware, so the binary-size argument doesn't apply.
+        if norm.endswith("/run_unit_test.hpp"):
+            return False
+        return True
+
+    def check_file_content(self, file_content: FileContent) -> list[str]:
+        violations: list[tuple[int, str]] = []
+        in_block_comment = False
+
+        for line_number, line in enumerate(file_content.lines, 1):
+            stripped = line.strip()
+
+            # Track /* ... */ blocks (single-line case handled by the slice below).
+            if in_block_comment:
+                if "*/" in line:
+                    in_block_comment = False
+                continue
+            if "/*" in line and "*/" not in line:
+                in_block_comment = True
+                continue
+
+            if stripped.startswith("//"):
+                continue
+            if _SUPPRESS in line:
+                continue
+
+            # Strip trailing // comment so we don't match inside a comment.
+            code = line.split("//")[0]
+            if _BANNED_PATTERN.search(code):
+                violations.append((line_number, line.rstrip()))
+
+        if violations:
+            self.violations[file_content.path] = violations
+
+        return []
+
+
+def main() -> None:
+    from ci.util.check_files import run_checker_standalone
+
+    checker = BareSnprintfChecker()
+    run_checker_standalone(
+        checker,
+        [str(SRC_ROOT)],
+        "Found bare C ::snprintf/::printf family call in src/ "
+        "(use fl::snprintf — see FastLED #2773 item 1.1)",
+        extensions=[".cpp", ".h", ".hpp"],
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/ci/lint_cpp/run_all_checkers.py
+++ b/ci/lint_cpp/run_all_checkers.py
@@ -26,6 +26,7 @@ from ci.lint_cpp.banned_headers_checker import (
 from ci.lint_cpp.banned_macros_checker import BannedMacrosChecker
 from ci.lint_cpp.banned_namespace_checker import BannedNamespaceChecker
 from ci.lint_cpp.bare_allocation_checker import BareAllocationChecker
+from ci.lint_cpp.bare_snprintf_checker import BareSnprintfChecker
 from ci.lint_cpp.bare_using_checker import BareUsingChecker
 from ci.lint_cpp.builtin_memcpy_checker import BuiltinMemcpyChecker
 
@@ -197,6 +198,7 @@ def create_checkers(
         SingletonInHeadersChecker(),  # Checks for Singleton<T> in headers (must use SingletonShared<T>)
         SpanFromPointerChecker(),  # Checks for span<T>(container.data(), container.size()) → span<T>(container)
         BareAllocationChecker(),  # Checks for bare new/delete/malloc/free — use fl::unique_ptr/fl::shared_ptr
+        BareSnprintfChecker(),  # Bans bare C ::snprintf/::printf/::sprintf in src/ — use fl::snprintf (#2773 item 1.5)
         SleepForChecker(),  # Checks for sleep_for() — bypasses async runner, use fl::yield/fl::async_run
         ThreadLocalKeywordChecker(),  # Checks for thread_local keyword — use fl::SingletonThreadLocal<T>::instance()
         BannedDefineChecker(),  # Checks for wrong #if patterns (e.g., #if ESP32 → #ifdef ESP32)

--- a/src/fl/net/http/chunked_encoding.cpp.hpp
+++ b/src/fl/net/http/chunked_encoding.cpp.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "fl/net/http/chunked_encoding.h"
+#include "fl/stl/stdio.h"  // fl::snprintf — avoids _svfprintf_r (#2773 item 1.1)
 #include "fl/stl/string.h"
 // Note: fl/stl/cstdio.h intentionally NOT included — workaround for
 // zackees/zccache#619 (Windows PCH path-spelling drift). Dead include.
@@ -178,14 +179,14 @@ size_t ChunkedWriter::chunkOverhead(size_t dataLen) {
     // Overhead: hex-digits + "\r\n" + data + "\r\n"
     // Count hex digits needed
     char sizeHex[32];
-    int hexLen = snprintf(sizeHex, sizeof(sizeHex), "%zx", dataLen);
+    int hexLen = fl::snprintf(sizeHex, sizeof(sizeHex), "%zx", dataLen);
     return static_cast<size_t>(hexLen) + 2 + dataLen + 2; // hex + \r\n + data + \r\n
 }
 
 size_t ChunkedWriter::writeChunk(fl::span<const u8> data, fl::span<u8> out) {
     // Format: <size-hex>\r\n<data>\r\n
     char sizeHex[32];
-    int hexLen = snprintf(sizeHex, sizeof(sizeHex), "%zx\r\n", data.size());
+    int hexLen = fl::snprintf(sizeHex, sizeof(sizeHex), "%zx\r\n", data.size());
     size_t totalNeeded = static_cast<size_t>(hexLen) + data.size() + 2;
     if (out.size() < totalNeeded) {
         return 0;

--- a/src/fl/net/http/stream_client.cpp.hpp
+++ b/src/fl/net/http/stream_client.cpp.hpp
@@ -3,6 +3,7 @@
 #ifdef FASTLED_HAS_NETWORKING
 
 #include "fl/net/http/stream_client.h"
+#include "fl/stl/stdio.h"  // fl::snprintf — avoids _svfprintf_r (#2773 item 1.1)
 #include "fl/stl/string.h"
 #include "fl/stl/stdint.h"
 #include "fl/stl/chrono.h"
@@ -112,7 +113,7 @@ bool HttpStreamClient::sendHttpRequestHeader() {
     if (mPort != 80) {
         header.append(":");
         char portStr[8];
-        snprintf(portStr, sizeof(portStr), "%u", mPort);
+        fl::snprintf(portStr, sizeof(portStr), "%u", mPort);
         header.append(portStr);
     }
     header.append("\r\n");

--- a/src/fl/stl/asio/http/server.cpp.hpp
+++ b/src/fl/stl/asio/http/server.cpp.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "fl/stl/asio/http/server.h"
+#include "fl/stl/stdio.h"  // fl::snprintf — avoids _svfprintf_r (#2773 item 1.1)
 #include "fl/task/executor.h"
 #include "platforms/esp/is_esp.h"  // ok platform headers - for FL_IS_ESP32  // IWYU pragma: keep
 
@@ -719,7 +720,7 @@ int Server::handle_esp_request(void* raw_req) {
     // Send response using Response::to_string() which serializes to HTTP format
     // Use esp_http_server APIs to send the response parts
     char status_str[32];
-    snprintf(status_str, sizeof(status_str), "%d", resp.mStatusCode);
+    fl::snprintf(status_str, sizeof(status_str), "%d", resp.mStatusCode);
     httpd_resp_set_status(req, status_str);
 
     for (auto it = resp.mHeaders.begin(); it != resp.mHeaders.end(); ++it) {

--- a/src/fl/stl/asio/ip/tcp.cpp.hpp
+++ b/src/fl/stl/asio/ip/tcp.cpp.hpp
@@ -13,6 +13,7 @@
 
 #include "fl/stl/asio/ip/tcp.h"
 #include "fl/stl/noexcept.h"
+#include "fl/stl/stdio.h"  // fl::snprintf — avoids _svfprintf_r (#2773 item 1.1)
 
 // Ensure MSG_NOSIGNAL is available (not defined on Windows/macOS)
 #ifndef MSG_NOSIGNAL
@@ -192,7 +193,7 @@ error_code socket::connect(const endpoint &ep) {
     hints.ai_protocol = IPPROTO_TCP;
 
     char portStr[16];
-    snprintf(portStr, sizeof(portStr), "%u", ep.port);
+    fl::snprintf(portStr, sizeof(portStr), "%u", ep.port);
 
     int ret = getaddrinfo(ep.host.c_str(), portStr, &hints, &result);
     if (ret != 0 || result == nullptr) {

--- a/src/platforms/esp/32/ota/ota_impl.cpp.hpp
+++ b/src/platforms/esp/32/ota/ota_impl.cpp.hpp
@@ -39,6 +39,7 @@
 #include "fl/stl/cstring.h"  // ok include - for string functions
 
 // FastLED headers
+#include "fl/stl/stdio.h"  // fl::snprintf — avoids _svfprintf_r (#2773 item 1.1)
 #include "fl/stl/string.h"
 #include "fl/log/log.h"
 #include "fl/log/log.h"
@@ -930,7 +931,7 @@ private:
 
         // Convert to hex string
         for (size_t i = 0; i < 32 && i * 2 + 1 < len; i++) {
-            snprintf(nonce + i * 2, 3, "%02x", hash[i]);
+            fl::snprintf(nonce + i * 2, 3, "%02x", hash[i]);
         }
     }
 
@@ -949,7 +950,7 @@ private:
         // Convert password hash to hex
         char pass_hash_hex[65];
         for (int i = 0; i < 32; i++) {
-            snprintf(pass_hash_hex + i * 2, 3, "%02x", pass_hash[i]);
+            fl::snprintf(pass_hash_hex + i * 2, 3, "%02x", pass_hash[i]);
         }
         pass_hash_hex[64] = '\0';
 
@@ -963,13 +964,13 @@ private:
         // Convert derived key to hex
         char derived_key_hex[65];
         for (int i = 0; i < 32; i++) {
-            snprintf(derived_key_hex + i * 2, 3, "%02x", derived_key[i]);
+            fl::snprintf(derived_key_hex + i * 2, 3, "%02x", derived_key[i]);
         }
         derived_key_hex[64] = '\0';
 
         // Compute expected response: SHA256(derived_key_hex:nonce:cnonce)
         char auth_string[256];
-        snprintf(auth_string, sizeof(auth_string), "%s:%s:%s",
+        fl::snprintf(auth_string, sizeof(auth_string), "%s:%s:%s",
                 derived_key_hex, nonce, cnonce);
 
         unsigned char expected_hash[32];
@@ -978,7 +979,7 @@ private:
 
         char expected_response[65];
         for (int i = 0; i < 32; i++) {
-            snprintf(expected_response + i * 2, 3, "%02x", expected_hash[i]);
+            fl::snprintf(expected_response + i * 2, 3, "%02x", expected_hash[i]);
         }
         expected_response[64] = '\0';
 
@@ -1142,7 +1143,7 @@ private:
 
         char computed_md5[33];
         for (int i = 0; i < 16; i++) {
-            snprintf(computed_md5 + i * 2, 3, "%02x", md5_hash[i]);
+            fl::snprintf(computed_md5 + i * 2, 3, "%02x", md5_hash[i]);
         }
         computed_md5[32] = '\0';
 
@@ -1275,7 +1276,7 @@ private:
                 self->mOtaNonce = nonce;
 
                 char auth_response[128];
-                snprintf(auth_response, sizeof(auth_response), "AUTH %s", nonce);
+                fl::snprintf(auth_response, sizeof(auth_response), "AUTH %s", nonce);
                 lwip_sendto(self->mOtaUdpSocket, auth_response, strlen(auth_response), 0,
                       (struct sockaddr*)&client_addr, client_len);
                 FL_DBG("OTA: Sent AUTH challenge");


### PR DESCRIPTION
## Summary

Items **1.1** and **1.5** from the ESP32-S3 binary-size meta tracker (#2773). Replaces 12 bare `::snprintf` call sites in `libFastLED.a` sources with `fl::snprintf` (which already exists in `src/fl/stl/stdio.h`) and adds a lint check that prevents regressions.

## Source changes

| File | Sites |
|---|---|
| `src/platforms/esp/32/ota/ota_impl.cpp.hpp` | 7 — hex hashing + auth string formatting |
| `src/fl/net/http/chunked_encoding.cpp.hpp` | 2 |
| `src/fl/net/http/stream_client.cpp.hpp` | 1 |
| `src/fl/stl/asio/ip/tcp.cpp.hpp` | 1 |
| `src/fl/stl/asio/http/server.cpp.hpp` | 1 |

After this change, `xtensa-esp32s3-elf-nm -A libFastLED.a | grep ' U '` no longer shows any printf-family undefined symbol — only `log_printf` (ESP-IDF logger) remains.

## ⚠️ Honest measurement: ~0 B firmware.bin delta on Blink

| Build | `firmware.bin` |
|---|---:|
| master baseline (per #2773) | 673,504 B |
| this branch | 673,840 B |

`_svfprintf_r` (11,118 B) survives because 24+ ESP-IDF archives independently pull the C printf engine — `libbt`, `libconsole`, `libesp_http_client`, `libesp_http_server`, `libespressif__esp_matter` (36 refs), `libmbedcrypto`, `libmbedx509`, etc. `libFastLED.a` is no longer one of them, but eliminating one pull source out of ~25 doesn't move the linker's decision on this sketch.

**#2773 item 1.1's claim of ~11 KB savings was incomplete** — it accounted only for the FastLED reference. Will append corrected analysis to #2773 in a comment.

## Why merge anyway

1. **Sets up `BareSnprintfChecker`** (item 1.5) — prevents any future FastLED code from re-adding the C printf reference. When the ESP-IDF side eventually catches up (or when running on builds where some of those archives aren't pulled), the savings will land automatically.
2. **`fl::snprintf` is faster** than newlib's `_svfprintf_r` for the format specifiers FastLED actually uses (`%d`/`%u`/`%s`/`%02x`/`%zx`) — no `va_list` walking, no per-`%`-token state machine.
3. **Hygiene**: gives us one consistent printf API across `libFastLED.a`.

## New lint check

`ci/lint_cpp/bare_snprintf_checker.py`:
- Bans `snprintf|sprintf|vsnprintf|vsprintf|fprintf|vfprintf` inside `src/` unless prefixed with `fl::` / `::` / member-accessed.
- Skips the `fl/stl/stdio` / `fl/stl/cstdio` shim itself.
- Skips `src/third_party/` (we don't control upstream).
- Skips `src/platforms/{apple,posix,win}/run_unit_test.hpp` — host-only watchdog scaffolding that never links into ESP32 firmware.
- Suppression `// ok snprintf` for the one-off cases that ever need it.

## Tests

- [x] `bash test fastled_core --cpp` — passes (host tests use `fl::stl/string` not `fl::stl/stdio` shim, unaffected)
- [x] `bash compile esp32s3 --examples Blink --platformio` — succeeds, 673,840 B
- [x] `uv run python ci/lint_cpp/bare_snprintf_checker.py` — clean on src/

## Test plan

- [ ] CI runs the new checker as part of `bash lint --cpp`
- [ ] CodeRabbit / human reviewer agrees the 0 B delta is OK given the regression-guard value

Refs: #2773 #2473 #2421

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added new C++ code quality linting tool to the development infrastructure.

* **Refactor**
  * Updated internal string formatting implementations across network and platform modules for improved consistency and safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->