### PR TITLE
feat(lint): ban raw C printf-family in src/ — use fl::snprintf (#2773 item 1.5)

### DIFF
--- a/ci/lint_cpp/cstdio_printf_checker.py
+++ b/ci/lint_cpp/cstdio_printf_checker.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""Checker for raw `<cstdio>` printf-family calls in FastLED sources.
+
+Calling C's `snprintf` / `printf` / `fprintf` / `vfprintf` / `vsnprintf`
+family from anywhere inside `libFastLED.a` pulls newlib's `_svfprintf_r`
+(~11 KB on xtensa-esp-elf) and its integer-only fallback `_svfiprintf_r`
+(~7 KB) into the binary. On ESP32-S3 builds that's ~36 KB of printf
+machinery across the float and integer variants — see
+https://github.com/FastLED/FastLED/issues/2473 and the audit in
+https://github.com/FastLED/FastLED/issues/2473#issuecomment-4628287075.
+
+FastLED ships its own template-based formatter at
+`src/fl/stl/stdio.h:659` (`fl::snprintf`, `fl::printf`, etc.) that
+routes through `fl::sstream`. The `fl::` variants are faster than
+newlib for the integer/string cases we actually use, don't pull the
+libc printf engine, and are the canonical FastLED API.
+
+Banned in `src/`:
+  - bare `snprintf(...)`, `sprintf(...)`, `printf(...)`, `fprintf(...)`,
+    `vfprintf(...)`, `vsnprintf(...)`, `vprintf(...)`, `vsprintf(...)`,
+    `vfiprintf(...)`, `vsnprintf_s(...)`, `snprintf_s(...)`
+  - global-scope explicit `::snprintf(...)` etc.
+
+Allowed:
+  - `fl::snprintf(...)`, `fl::printf(...)`, etc. (the FastLED wrappers)
+  - any `Object.snprintf(...)` / `pointer->snprintf(...)` member call
+    (none such exist in standard libraries; included for completeness)
+
+Excluded paths:
+  - `src/fl/stl/stdio.{h,hpp}` and `src/fl/stl/cstdio.*` — that's where
+    the wrappers are defined; they have to reference the C API at the
+    implementation boundary.
+  - `src/third_party/**` — third-party code defines its own printf
+    conventions.
+
+Opt-out:
+  - Append `// ok cstdio - <reason>` on the same line for genuine
+    boundary cases (e.g., a platform-specific implementation that has
+    to call into a vendor-supplied formatter).
+"""
+
+import re
+
+from ci.util.check_files import FileContent, FileContentChecker
+from ci.util.paths import PROJECT_ROOT
+
+
+# Pattern to find candidate C printf-family call sites.
+# Acceptance/rejection of each match is then decided by inspecting the
+# preceding text via `_is_allowed_prefix`.
+PRINTF_FAMILY = r"snprintf|sprintf|printf|fprintf|vfprintf|vsnprintf|vprintf|vsprintf|vfiprintf|vsnprintf_s|snprintf_s"
+PRINTF_CALL_PATTERN = re.compile(r"\b(" + PRINTF_FAMILY + r")\s*\(")
+
+
+_BANNED_NAMESPACES = ("std::",)  # plus root `::` handled separately
+_NAME_PREFIX_RE = re.compile(r"([A-Za-z_][A-Za-z_0-9]*)::$")
+
+
+def _is_allowed_prefix(line: str, match_start: int) -> bool:
+    """Return True if the printf-family call at `match_start` is one we
+    explicitly allow.
+
+    Allowed prefixes:
+      - `fl::printf(...)` — the FastLED template wrapper.
+      - `SerialPort::printf(...)` / `MyClass::snprintf(...)` — any
+        user-defined class method definition or qualified call. Member
+        functions never drag in newlib regardless of name.
+      - `obj.printf(...)` / `ptr->printf(...)` — member access.
+      - identifier-prefixed names like `my_snprintf(...)` — defensive
+        guard, since `\\b` already handles sub-word boundaries.
+
+    Banned prefixes:
+      - bare `printf(...)`, no prefix.
+      - `::printf(...)` — explicit global C namespace.
+      - `std::snprintf(...)` — explicit C++ std namespace (still routes
+        through newlib on xtensa-esp-elf).
+    """
+    prefix = line[:match_start]
+    rstripped = prefix.rstrip()
+
+    # Member access — always allowed.
+    if rstripped.endswith(".") or rstripped.endswith("->"):
+        return True
+
+    # Identifier-prefixed (defensive — `\b` should already cover this).
+    if rstripped and (rstripped[-1].isalnum() or rstripped[-1] == "_"):
+        return True
+
+    # Banned: explicit `std::` namespace.
+    for ns in _BANNED_NAMESPACES:
+        if rstripped.endswith(ns):
+            return False
+
+    # Banned: explicit root `::` namespace, with no name before it.
+    if rstripped.endswith("::"):
+        # Find the identifier before `::`, if any.
+        m = _NAME_PREFIX_RE.search(rstripped)
+        if m:
+            # Some identifier owns this `printf` — user-defined class
+            # method, allowed.
+            return True
+        # No identifier — bare `::printf`, root-namespace C call.
+        return False
+
+    # Otherwise (e.g., bare `printf(`) — banned.
+    return False
+
+
+# Opt-out marker on the same line. Lower-cased before match.
+OPT_OUT_MARKER = "ok cstdio"
+
+
+class CstdioPrintfChecker(FileContentChecker):
+    """Reject raw C printf-family calls — use the `fl::` template wrappers."""
+
+    def __init__(self):
+        self.violations: dict[str, list[tuple[int, str]]] = {}
+
+    def should_process_file(self, file_path: str) -> bool:
+        """Check if file should be processed."""
+        if not file_path.endswith((".cpp", ".h", ".hpp", ".ino", ".cpp.hpp")):
+            return False
+
+        normalized = file_path.replace("\\", "/")
+
+        # Skip third-party code (defines its own conventions).
+        if "/third_party/" in normalized:
+            return False
+
+        # Skip the FastLED wrapper TUs themselves — they have to bridge
+        # at the C-API boundary.
+        if "/fl/stl/stdio.h" in normalized or "/fl/stl/stdio.hpp" in normalized:
+            return False
+        if "/fl/stl/cstdio." in normalized:
+            return False
+
+        # Skip host-only platforms — they don't link newlib, so the printf
+        # engine isn't an embedded-bloat concern there.
+        host_only_paths = (
+            "/platforms/wasm/",  # Emscripten libc, console-write
+            "/platforms/posix/",  # Host test runner
+            "/platforms/apple/",  # Host test runner
+            "/platforms/win/",  # Host test runner
+            "/platforms/stub/",  # Host test stub
+        )
+        for path in host_only_paths:
+            if path in normalized:
+                return False
+
+        return True
+
+    def check_file_content(self, file_content: FileContent) -> list[str]:
+        """Check file content for raw C printf-family calls."""
+        violations: list[tuple[int, str]] = []
+        in_multiline_comment = False
+
+        for line_number, line in enumerate(file_content.lines, 1):
+            stripped = line.strip()
+
+            # Track multi-line comment state.
+            if "/*" in line and "*/" not in line:
+                in_multiline_comment = True
+                continue
+            if in_multiline_comment:
+                if "*/" in line:
+                    in_multiline_comment = False
+                continue
+
+            # Skip single-line comments.
+            if stripped.startswith("//"):
+                continue
+            # Skip preprocessor includes — `#include <cstdio>` etc.
+            if stripped.startswith("#"):
+                continue
+
+            code_part = line.split("//")[0]
+            comment_part = line[len(code_part) :].lower()
+
+            # Allow opt-out: `// ok cstdio - <reason>` on the same line.
+            if OPT_OUT_MARKER in comment_part:
+                continue
+
+            for match in PRINTF_CALL_PATTERN.finditer(code_part):
+                if _is_allowed_prefix(code_part, match.start()):
+                    continue
+                func = match.group(1)
+                violations.append(
+                    (
+                        line_number,
+                        f"Avoid C `{func}` — use `fl::{func}` (from "
+                        f"`fl/stl/stdio.h`) to avoid newlib's `_svfprintf_r` "
+                        f"(~11 KB on ESP32 builds). See #2473 / #2773.\n"
+                        f"      Offending line: {stripped}\n"
+                        f"      If you genuinely need the C API at a platform "
+                        f"boundary, suppress with `// ok cstdio - <reason>` "
+                        f"on the same line.",
+                    )
+                )
+
+        if violations:
+            self.violations[file_content.path] = violations
+
+        return []
+
+
+def main() -> None:
+    """Run cstdio printf-family checker standalone."""
+    import sys
+    from pathlib import Path
+
+    from ci.util.check_files import (
+        MultiCheckerFileProcessor,
+        run_checker_standalone,
+    )
+
+    if len(sys.argv) > 1:
+        file_path = Path(sys.argv[1]).resolve()
+        if not file_path.exists():
+            print(f"Error: File not found: {file_path}")
+            sys.exit(1)
+
+        checker = CstdioPrintfChecker()
+        processor = MultiCheckerFileProcessor()
+        processor.process_files_with_checkers([str(file_path)], [checker])
+
+        if hasattr(checker, "violations") and checker.violations:
+            violations = checker.violations
+            print(
+                f"❌ Found raw C printf-family usage — use the `fl::` "
+                f"wrappers from `fl/stl/stdio.h` instead "
+                f"({len(violations)} file(s)):\n"
+            )
+            for file_path_str, violation_list in violations.items():
+                rel_path = Path(file_path_str).relative_to(PROJECT_ROOT)
+                print(f"{rel_path}:")
+                for line_num, message in violation_list:
+                    print(f"  Line {line_num}: {message}")
+            sys.exit(1)
+        else:
+            print("✅ No raw C printf-family usage found.")
+            sys.exit(0)
+    else:
+        checker = CstdioPrintfChecker()
+        run_checker_standalone(
+            checker,
+            [str(PROJECT_ROOT / "src")],
+            "Found raw C printf-family usage — use `fl::snprintf` / "
+            "`fl::printf` (from `fl/stl/stdio.h`) instead",
+            extensions=[".cpp", ".h", ".hpp", ".ino", ".cpp.hpp"],
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/ci/lint_cpp/run_all_checkers.py
+++ b/ci/lint_cpp/run_all_checkers.py
@@ -37,6 +37,7 @@ from ci.lint_cpp.check_using_namespace import UsingNamespaceChecker
 from ci.lint_cpp.cpp_hpp_header_pair_checker import CppHppHeaderPairChecker
 from ci.lint_cpp.cpp_hpp_includes_checker import CppHppIncludesChecker
 from ci.lint_cpp.cpp_include_checker import CppIncludeChecker
+from ci.lint_cpp.cstdio_printf_checker import CstdioPrintfChecker
 from ci.lint_cpp.ctype_global_checker import CtypeGlobalChecker
 from ci.lint_cpp.enum_class_checker import EnumClassChecker
 from ci.lint_cpp.esp_rom_printf_checker import EspRomPrintfChecker
@@ -218,6 +219,7 @@ def create_checkers(
         FastLEDHeaderUsageChecker(),
         StdintTypeChecker(),  # Covers all src/ (excludes third_party/ internally)
         CtypeGlobalChecker(),  # Checks for global-scope ctype functions (use fl:: variants)
+        CstdioPrintfChecker(),  # Checks for raw C printf-family — use fl::snprintf / fl::printf (#2773 item 1.5)
         SimdIntrinsicsChecker(),  # Checks for direct platform SIMD intrinsics — use fl::simd
         PragmaOnceChecker(),  # Checks headers have #pragma once, .cpp files don't
     ]

--- a/ci/lint_cpp/test_cstdio_printf_checker.py
+++ b/ci/lint_cpp/test_cstdio_printf_checker.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Unit tests for CstdioPrintfChecker."""
+
+import unittest
+
+from ci.lint_cpp.cstdio_printf_checker import CstdioPrintfChecker
+from ci.util.check_files import FileContent
+
+
+_SRC_PATH = "src/fl/example.cpp"
+_THIRD_PARTY_PATH = "src/third_party/TJpg/driver.cpp.hpp"
+_STDIO_H_PATH = "src/fl/stl/stdio.h"
+_CSTDIO_H_PATH = "src/fl/stl/cstdio.h"
+_WASM_PATH = "src/platforms/wasm/audio_input_wasm.cpp.hpp"
+_POSIX_PATH = "src/platforms/posix/run_unit_test.hpp"
+_STUB_PATH = "src/platforms/stub/Arduino.h"
+
+
+def _violations(code: str, path: str = _SRC_PATH) -> list[tuple[int, str]]:
+    checker = CstdioPrintfChecker()
+    if not checker.should_process_file(path):
+        return []
+    file_content = FileContent(path=path, content=code, lines=code.splitlines())
+    checker.check_file_content(file_content)
+    return checker.violations.get(path, [])
+
+
+class TestCstdioPrintfChecker(unittest.TestCase):
+    # --- Banned forms ------------------------------------------------------
+
+    def test_bare_snprintf_is_banned(self) -> None:
+        self.assertEqual(len(_violations('snprintf(buf, 8, "%d", x);')), 1)
+
+    def test_bare_printf_is_banned(self) -> None:
+        self.assertEqual(len(_violations('printf("hi\\n");')), 1)
+
+    def test_bare_fprintf_is_banned(self) -> None:
+        self.assertEqual(len(_violations('fprintf(stderr, "boom %d", code);')), 1)
+
+    def test_explicit_root_namespace_is_banned(self) -> None:
+        self.assertEqual(len(_violations('::printf("bad\\n");')), 1)
+
+    def test_explicit_std_namespace_is_banned(self) -> None:
+        self.assertEqual(len(_violations("std::snprintf(buf, n, fmt, x);")), 1)
+
+    def test_all_family_members_caught(self) -> None:
+        for func in (
+            "snprintf",
+            "sprintf",
+            "printf",
+            "fprintf",
+            "vfprintf",
+            "vsnprintf",
+            "vprintf",
+            "vsprintf",
+        ):
+            with self.subTest(func=func):
+                self.assertEqual(
+                    len(_violations(f"{func}(args);")),
+                    1,
+                    f"{func} should be flagged",
+                )
+
+    # --- Allowed forms -----------------------------------------------------
+
+    def test_fl_snprintf_is_allowed(self) -> None:
+        self.assertEqual(len(_violations('fl::snprintf(buf, 8, "%d", x);')), 0)
+
+    def test_fl_printf_is_allowed(self) -> None:
+        self.assertEqual(len(_violations('fl::printf("hi\\n");')), 0)
+
+    def test_member_dot_call_is_allowed(self) -> None:
+        self.assertEqual(len(_violations('Serial.printf("x");')), 0)
+
+    def test_member_arrow_call_is_allowed(self) -> None:
+        self.assertEqual(len(_violations('ptr->printf("x");')), 0)
+
+    def test_user_class_qualified_call_is_allowed(self) -> None:
+        # `SerialPort::printf(...)` — user-defined class method, not libc.
+        self.assertEqual(
+            len(_violations("inline size_t SerialPort::printf(const char* fmt) {")),
+            0,
+        )
+
+    def test_user_class_qualified_snprintf_is_allowed(self) -> None:
+        self.assertEqual(len(_violations("size_t MyLogger::snprintf(char* buf) {")), 0)
+
+    def test_function_declaration_with_type_prefix_is_allowed(self) -> None:
+        # `void printf(...)` as a member declaration inside a class body.
+        self.assertEqual(
+            len(_violations("    void printf(const char* fmt, Args... args);")), 0
+        )
+
+    def test_substring_not_matched(self) -> None:
+        # `my_snprintf` shares a suffix with `snprintf` but \b prevents
+        # a sub-word match.
+        self.assertEqual(len(_violations('my_snprintf(buf, n, "%d", x);')), 0)
+
+    # --- Comment / preprocessor handling -----------------------------------
+
+    def test_single_line_comments_are_ignored(self) -> None:
+        self.assertEqual(len(_violations('// snprintf(buf, n, "x");')), 0)
+        self.assertEqual(len(_violations('int x = 1; // snprintf(buf, n, "x");')), 0)
+
+    def test_multiline_comments_are_ignored(self) -> None:
+        self.assertEqual(len(_violations("/*\nsnprintf(buf, n, fmt);\n*/")), 0)
+
+    def test_include_directives_are_ignored(self) -> None:
+        self.assertEqual(len(_violations("#include <cstdio>")), 0)
+        # Even if a macro-like include text contains the word.
+        self.assertEqual(len(_violations("#define USE_PRINTF 1")), 0)
+
+    def test_opt_out_marker_skips_line(self) -> None:
+        self.assertEqual(
+            len(_violations("snprintf(buf, n, fmt); // ok cstdio - boundary case")),
+            0,
+        )
+
+    # --- Path exclusions ---------------------------------------------------
+
+    def test_third_party_is_excluded(self) -> None:
+        self.assertEqual(
+            len(_violations('snprintf(buf, n, "x");', _THIRD_PARTY_PATH)), 0
+        )
+
+    def test_stdio_wrapper_header_is_excluded(self) -> None:
+        self.assertEqual(
+            len(_violations('int x = snprintf(buf, n, "x");', _STDIO_H_PATH)), 0
+        )
+
+    def test_cstdio_wrapper_header_is_excluded(self) -> None:
+        self.assertEqual(
+            len(_violations('int x = snprintf(buf, n, "x");', _CSTDIO_H_PATH)), 0
+        )
+
+    def test_wasm_platform_is_excluded(self) -> None:
+        # Emscripten libc handles printf without newlib's _svfprintf_r.
+        self.assertEqual(len(_violations('printf("wasm call");', _WASM_PATH)), 0)
+
+    def test_posix_host_runner_is_excluded(self) -> None:
+        self.assertEqual(
+            len(_violations('fprintf(stderr, "host\\n");', _POSIX_PATH)),
+            0,
+        )
+
+    def test_stub_platform_is_excluded(self) -> None:
+        self.assertEqual(len(_violations('printf("stub call");', _STUB_PATH)), 0)
+
+    # --- Format specifier coverage ----------------------------------------
+
+    def test_width_and_precision_specifiers_caught(self) -> None:
+        self.assertEqual(len(_violations('snprintf(buf, 3, "%02x", b);')), 1)
+        self.assertEqual(len(_violations('snprintf(buf, n, "%.2f", v);')), 1)
+
+    def test_zx_size_t_specifier_caught(self) -> None:
+        self.assertEqual(len(_violations('snprintf(buf, n, "%zx", len);')), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds `CstdioPrintfChecker` to the unified `ci/lint_cpp/` pipeline that
fails CI on direct C `snprintf` / `printf` / `sprintf` / `fprintf` /
`vfprintf` / `vsnprintf` / `vprintf` / `vsprintf` / `vfiprintf` calls
inside `src/`. Implements item **1.5** of the binary-size meta-issue:
#2773 — the regression guard for the cleanup landed in #2774.

Each such call drags newlib's `_svfprintf_r` (~11 KB on xtensa-esp-elf)
into `libFastLED.a`. The repo already ships `fl::snprintf` and
`fl::printf` at `src/fl/stl/stdio.h:659` which route through
`fl::sstream` and don't need the libc engine.

> **Depends on #2774** — based on `feat/2773-eliminate-c-snprintf` so
> the linter validates against clean code. If rebased on master before
> #2774 merges, the linter would fail on the 12 pre-existing call sites
> that PR migrates. After #2774 merges, this PR can be retargeted to
> `master`.

## Allowed forms (covered by tests)

- `fl::snprintf(...)`, `fl::printf(...)` — the FastLED wrappers.
- `obj.printf(...)`, `ptr->printf(...)` — member access.
- `SerialPort::printf(...)`, `MyClass::snprintf(...)` — user-defined
  class methods (qualified by an identifier other than `std`).
- `void printf(const char* fmt, ...)` inside a class body — function
  declarations / definitions (the prefix ends with a type, not `::`).
- `my_snprintf(...)` — sub-word matches (defensive; `\b` already covers).

## Banned forms (covered by tests)

- bare `snprintf(...)`, `printf(...)`, `fprintf(...)`, etc.
- explicit `::printf(...)` — root-namespace C call.
- explicit `std::snprintf(...)` — C++ std namespace (still newlib).

## Excluded paths (don't link newlib)

- `src/third_party/**` — third-party code defines its own conventions.
- `src/fl/stl/stdio.{h,hpp}` + `src/fl/stl/cstdio.*` — wrapper TUs that
  bridge at the C-API boundary.
- `src/platforms/wasm/**` — Emscripten libc, console-write.
- `src/platforms/{posix,apple,win}/**` — host-only test runners.
- `src/platforms/stub/**` — host-only stub.

## Opt-out

Append `// ok cstdio - <reason>` on the same line for genuine
platform-boundary cases.

## Test plan

- [x] 26 unit tests (`ci/lint_cpp/test_cstdio_printf_checker.py`): every
      allowed/banned/opt-out/exclusion case → 26/26 pass.
- [x] Standalone runner against entire \`src/\`: zero violations after
      \#2774's migration.
- [x] Full `bash lint` pipeline: clean.
- [x] Registered in `ci/lint_cpp/run_all_checkers.py` under the `src`
      scope alongside the existing `CtypeGlobalChecker` (same shape: ban
      C free-function APIs that have `fl::` template wrappers).
- [ ] CI green.

## Files

- **`ci/lint_cpp/cstdio_printf_checker.py`** — the checker, ~190 lines
  including module-level docstring with rationale and \`#2473\` /
  \`#2773\` cross-links.
- **`ci/lint_cpp/test_cstdio_printf_checker.py`** — 26 unit tests
  matching the existing `test_banned_macros_checker.py` shape.
- **`ci/lint_cpp/run_all_checkers.py`** — two-line registration
  (import + scope insertion).

Issue: https://github.com/FastLED/FastLED/issues/2773

🤖 Generated with [Claude Code](https://claude.com/claude-code)