### PR TITLE
fix(watchdog/avr): gate hardware impl behind classic-AVR symbol presence (refs #2779)

### DIFF
--- a/src/platforms/avr/watchdog_avr.impl.hpp
+++ b/src/platforms/avr/watchdog_avr.impl.hpp
@@ -22,6 +22,33 @@
 #include <avr/io.h>      // ok include — MCUSR
 // IWYU pragma: end_keep
 
+// Capability gate. The implementation below assumes the classic-AVR symbol
+// surface (`MCUSR` + `WDRF`/`BORF`/`EXTRF`/`PORF` reset-cause bits, and the
+// extended `WDTO_8S` timeout constant). That surface is present on the bulk
+// of the AVR line — ATmega328P, ATmega2560, ATtiny85, ATtiny88, ATtiny4313,
+// etc. — but is **not** universal:
+//
+//   * **ATmega8 / ATmega8A** — the original ATmega8 caps the WDT prescaler
+//     at `WDTO_2S`; `WDTO_4S` and `WDTO_8S` are not defined. Reset cause is
+//     reported via `MCUCSR` (different name) on these older parts.
+//   * **megaAVR-0 / tinyAVR-1 series** (ATmega4809 a.k.a. nano_every,
+//     ATtiny1604, ATtiny1616, etc.) — these use the new RSTCTRL peripheral
+//     for reset cause and the new WDT peripheral via `WDT.CTRLA`. None of
+//     `MCUSR`, `WDRF`, `EXTRF`, `PORF`, or `WDTO_8S` are declared on these
+//     chips. The avr-libc `<avr/wdt.h>` shim exists but the legacy symbols
+//     do not.
+//
+// When the required symbols aren't all present we fall back to the platform-
+// agnostic no-op watchdog so the firmware still links. Real hardware WDT
+// support for the megaAVR-0 / tinyAVR-1 / ATmega8 families can be added
+// later as separate per-family impls without changing the dispatcher.
+#if !(defined(WDTO_8S) && defined(MCUSR) && defined(WDRF) && \
+      defined(BORF) && defined(EXTRF) && defined(PORF))
+
+#include "platforms/shared/watchdog_noop.hpp"
+
+#else  // classic-AVR symbol surface available — full hardware implementation
+
 #define FL_WATCHDOG_HAS_HARDWARE
 #define FL_WATCHDOG_PERSIST_BYTES 8
 #define FL_WATCHDOG_MAX_TIMEOUT_MS 8000u
@@ -192,3 +219,5 @@ WatchdogCrashReport Watchdog::readCrashReport() const FL_NOEXCEPT {
 void                Watchdog::clearCrashReport() FL_NOEXCEPT {}
 
 } // namespace fl
+
+#endif  // classic-AVR symbol surface available


### PR DESCRIPTION
## Summary

Fix the AVR watchdog hardware impl regression that broke 4 README-listed builds: `atmega8a`, `nano_every`, `attiny1604`, `attiny1616`. These chips do not declare the classic-AVR symbols (\`MCUSR\`, \`WDRF\`, \`BORF\`, \`EXTRF\`, \`PORF\`, \`WDTO_8S\`) that the new per-platform watchdog impl assumed were universal.

Introduced by commit \`ca09808\` — _\"feat(watchdog): real per-platform hardware impls for ALL platforms (#2731 Phase 2) (#2745)\"_.

## What the fix does

Adds a single capability gate at the top of \`src/platforms/avr/watchdog_avr.impl.hpp\`:

\`\`\`cpp
#if !(defined(WDTO_8S) && defined(MCUSR) && defined(WDRF) && \
      defined(BORF) && defined(EXTRF) && defined(PORF))
  #include \"platforms/shared/watchdog_noop.hpp\"
#else
  // ... existing hardware implementation ...
#endif
\`\`\`

When the required classic-AVR symbols aren't all present, the file falls back to the platform-agnostic no-op watchdog (already used by every platform without hardware WDT). Net effect: the firmware links and runs on every AVR chip; \`Watchdog\` calls become no-ops on the chips without the symbol surface, instead of being compile-time hard errors.

Real hardware WDT support for the megaAVR-0 / tinyAVR-1 and ATmega8 families can land later as separate per-family impls — that's a feature addition; this PR is purely a build-unbreak.

## Affected chip families

| Family | Symbols present | Behavior after fix |
|---|---|---|
| ATmega328P, 2560, etc. (classic AVR) | yes | unchanged — full hardware impl |
| ATtiny85 / 88 / 4313 (classic ATtiny) | yes | unchanged — full hardware impl |
| ATmega8 / 8A (original ATmega8) | no (caps at WDTO_2S, uses MCUCSR) | noop fallback |
| ATmega4809 a.k.a. nano_every (megaAVR-0) | no (RSTCTRL peripheral) | noop fallback |
| ATtiny1604 / 1616 (tinyAVR-1) | no (RSTCTRL peripheral) | noop fallback |

## Test plan

Verified locally with \`bash compile\` (per CLAUDE.md). 4 previously-broken boards + 4 previously-working AVR boards as a regression guard:

\`\`\`
PASS  atmega8a       (previously broken — uses noop fallback now)
PASS  nano_every     (previously broken — uses noop fallback now)
PASS  ATtiny1604     (previously broken — uses noop fallback now)
PASS  ATtiny1616     (previously broken — uses noop fallback now)
PASS  uno            (still uses full hardware impl)
PASS  attiny85       (still uses full hardware impl)
PASS  attiny88       (still uses full hardware impl)
PASS  attiny4313     (still uses full hardware impl)
\`\`\`

\`bash lint\` clean.

## Scope

- [x] Refs #2779 — partial fix; closes the 4 AVR-family build failures.
- [ ] The other 8 README badges flagged in #2779 (\`apollo3_red\`, \`apollo3_thing_explorable\`, \`rp2040\`, \`stm32h747xi_giga\`, \`check_esp32_size\`, \`check_teensy41_size\`, \`build\`, \`uno AVR8JS Test\`) have independent root causes and will be addressed in follow-up PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced AVR platform compatibility by adding conditional watchdog support. The firmware now builds successfully on additional AVR chip families (megaAVR-0, tinyAVR-1) with automatic fallback to a no-op mode when hardware watchdog support is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->