### PR TITLE
refactor(filesystem): isolate SD impl in its own TU so the linker tree-shakes it (removes FASTLED_USE_SDCARD macro from #2778)

### DIFF
--- a/ci/lint_cpp/test_unity_build.py
+++ b/ci/lint_cpp/test_unity_build.py
@@ -76,6 +76,7 @@ EXPECTED_BUILD_FILES = {
     "fl/build/fl.sensors+.cpp",
     "fl/build/fl.stl+.cpp",
     "fl/build/fl.system+.cpp",
+    "fl/build/fl.system.sd+.cpp",
     "fl/build/fl.task+.cpp",
     "fl/build/fl.test+.cpp",
     "fl/build/fl.ui+.cpp",

--- a/src/fl/build/fl.system.sd+.cpp
+++ b/src/fl/build/fl.system.sd+.cpp
@@ -1,0 +1,18 @@
+/// @file fl.system.sd+.cpp
+/// @brief Unity build entry-point for SD-card support, split out of
+/// `fl.system+.cpp` so the linker can drop the entire SD chain
+/// (`libSD.a`, `libFS.a`, Arduino's `VFSImpl`, ~16 KB on ESP32-S3)
+/// when the user never calls `FileSystem::beginSd()`.
+///
+/// Replaces the earlier `FASTLED_USE_SDCARD` macro-gate (#2778 v1) —
+/// no user opt-in required.
+///
+/// See FastLED #2773 item 1.2 and `fl/system/sd/file_system_sd.cpp.hpp`.
+
+#include "platforms/new.h"
+
+// IWYU pragma: begin_keep
+#include "fl/system/arduino.h"
+// IWYU pragma: end_keep
+
+#include "fl/system/sd/_build.cpp.hpp"

--- a/src/fl/system/file_system.cpp.hpp
+++ b/src/fl/system/file_system.cpp.hpp
@@ -4,35 +4,22 @@
 #include "fl/stl/vector.h"
 #include "fl/math/math.h"
 
-#ifdef FASTLED_TESTING
-// Test filesystem implementation that maps to real hard drive
-// IWYU pragma: begin_keep
-#include "platforms/stub/fs_stub.hpp" // ok platform headers
-// IWYU pragma: end_keep
-#define FASTLED_HAS_SDCARD 1
-#elif defined(FL_IS_WASM)
-// IWYU pragma: begin_keep
-#include "platforms/wasm/fs_wasm.h" // ok platform headers
-// IWYU pragma: end_keep
-#define FASTLED_HAS_SDCARD 1
-#elif defined(FASTLED_USE_SDCARD) && FL_HAS_INCLUDE(<SD.h>) && FL_HAS_INCLUDE(<fs.h>)
-// Include Arduino SD card implementation only when the user opts in by
-// defining FASTLED_USE_SDCARD. Auto-detecting `<SD.h>` on the include
-// path causes PlatformIO LDF to link libSD.a + libFS.a + Arduino's
-// VFSImpl unconditionally — ~14 KB of dead code (and pulls newlib's
-// _svfprintf_r via VFSFileImpl) for sketches that never call
-// FileSystem::beginSd(). See FastLED #2773 item 1.2 for the chain.
+// NOTE: SD card support (FileSystem::beginSd and make_sdcard_filesystem)
+// lives in a SEPARATE translation unit at
+// `src/fl/system/sd/file_system_sd.cpp.hpp`, compiled into
+// `fl.system.sd+.cpp.o` via `src/fl/build/fl.system.sd+.cpp`.
 //
-// Migration: sketches that need SD support add
-//     #define FASTLED_USE_SDCARD
-// before #include <FastLED.h>. Without this define, FileSystem::beginSd()
-// returns false (the weak NullFileSystem fallback in file_system.cpp.hpp
-// below kicks in).
-#include "platforms/fs_sdcard_arduino.hpp"
-#define FASTLED_HAS_SDCARD 1
-#else
-#define FASTLED_HAS_SDCARD 0
-#endif
+// This split lets the linker tree-shake the entire SD chain (libSD.a,
+// libFS.a, Arduino's VFSImpl, the printf engine VFSFileImpl drags in
+// via snprintf) AUTOMATICALLY when the user never calls
+// `FileSystem::beginSd()` — no FASTLED_USE_SDCARD opt-in required, and
+// the macro that the earlier macro-gate PR (#2778 v1) shipped is
+// removed by this PR. See FastLED #2773 item 1.2 and the SD TU header
+// for the mechanism.
+//
+// All other FileSystem methods (begin, openRead, readText, ...) and the
+// NullFileSystem stub stay here, so existing sketches that use only
+// `FileSystem::begin(platform_filesystem)` are unaffected.
 
 #include "fl/stl/json.h"
 #include "fl/math/screenmap.h"
@@ -98,14 +85,12 @@ class NullFileSystem : public FsImpl {
 };
 
 
-bool FileSystem::beginSd(int cs_pin) {
-    mFs = make_sdcard_filesystem(cs_pin);
-    if (!mFs) {
-        return false;
-    }
-    mFs->begin();
-    return true;
-}
+// FileSystem::beginSd() is intentionally NOT defined in this TU. The
+// definition lives in `fl/system/sd/file_system_sd.cpp.hpp` which is
+// compiled into its own `.o` (`fl.system.sd+.cpp.o`). The linker only
+// pulls that `.o` when the user actually calls `fs.beginSd(...)`,
+// keeping all SD library code (~15 KB on ESP32-S3) out of sketches that
+// don't use it. See FastLED #2773 item 1.2.
 
 bool FileSystem::begin(FsImplPtr platform_filesystem) {
     mFs = platform_filesystem;
@@ -214,16 +199,7 @@ bool FileSystem::readText(const char *path, fl::string *out) {
 
 } // namespace fl
 
-namespace fl {
-
-#if !FASTLED_HAS_SDCARD
-// Weak fallback implementation when SD library is not available
-FL_LINK_WEAK FsImplPtr make_sdcard_filesystem(int cs_pin) {
-    FASTLED_UNUSED(cs_pin);
-    fl::shared_ptr<NullFileSystem> ptr = fl::make_shared<NullFileSystem>();
-    FsImplPtr out = ptr;
-    return out;
-}
-#endif
-
-} // namespace fl
+// `make_sdcard_filesystem(int cs_pin)` is defined in the separate SD TU
+// (`fl/system/sd/file_system_sd.cpp.hpp`). When the SD TU is not linked
+// (the user never calls `fs.beginSd()`), the symbol is also dead-stripped
+// alongside `FileSystem::beginSd` itself.

--- a/src/fl/system/sd/_build.cpp.hpp
+++ b/src/fl/system/sd/_build.cpp.hpp
@@ -1,0 +1,9 @@
+/// @file fl/system/sd/_build.cpp.hpp
+/// @brief Unity-build aggregate for SD-card support. Pulled in only by
+/// `src/fl/build/fl.system.sd+.cpp` — never by the parent
+/// `src/fl/system/_build.cpp.hpp`. That separation is what lets the
+/// linker tree-shake the entire SD chain (libSD.a, libFS.a, Arduino's
+/// VFSImpl, ~16 KB on ESP32-S3) when the user never calls
+/// `FileSystem::beginSd()`. See FastLED #2773 item 1.2.
+
+#include "fl/system/sd/file_system_sd.cpp.hpp"

--- a/src/fl/system/sd/file_system_sd.cpp.hpp
+++ b/src/fl/system/sd/file_system_sd.cpp.hpp
@@ -1,0 +1,77 @@
+/// @file fl/system/sd/file_system_sd.cpp.hpp
+/// @brief SD-card support split off from `file_system.cpp.hpp` so the
+/// linker can tree-shake the entire SD chain when nobody calls
+/// `FileSystem::beginSd()`.
+///
+/// Mechanism: this TU is compiled into its own `.o` file
+/// (`fl.system.sd+.cpp.o`, via `src/fl/build/fl.system.sd+.cpp`).
+/// `FileSystem::beginSd(int)` and `make_sdcard_filesystem(int)` are the
+/// only symbols this TU defines. The linker only pulls the `.o` into
+/// the final binary when one of those symbols is referenced — i.e.
+/// when the user's sketch actually calls `fs.beginSd(cs_pin)`. Sketches
+/// that only use `FileSystem::begin(platform_filesystem)` (or that
+/// don't touch `FileSystem` at all) see `fl.system.sd+.cpp.o` dropped
+/// outright, taking `libSD.a` / `libFS.a` / Arduino's `VFSImpl` chain
+/// (~16 KB on ESP32-S3 NEOPIXEL Blink) with it.
+///
+/// This replaces the earlier `FASTLED_USE_SDCARD` macro-gate
+/// (#2778 v1) — no user opt-in required, the linker handles it.
+///
+/// See FastLED #2773 item 1.2 for the original audit.
+
+#include "fl/system/file_system.h"
+#include "fl/stl/has_include.h"
+#include "fl/log/log.h"
+
+#ifdef FASTLED_TESTING
+// Stub filesystem maps to the host's real disk (for unit tests).
+// `make_sdcard_filesystem` strong impl lives in
+// `platforms/stub/fs_stub.cpp.hpp` (part of `platforms+.cpp.o`).
+// IWYU pragma: begin_keep
+#include "platforms/stub/fs_stub.hpp" // ok platform headers
+// IWYU pragma: end_keep
+#define FASTLED_HAS_SDCARD_IMPL 1
+
+#elif defined(FL_IS_WASM)
+// WASM filesystem backs onto the browser. `make_sdcard_filesystem`
+// strong impl lives in `platforms/wasm/fs_wasm.cpp.hpp`.
+// IWYU pragma: begin_keep
+#include "platforms/wasm/fs_wasm.h" // ok platform headers
+// IWYU pragma: end_keep
+#define FASTLED_HAS_SDCARD_IMPL 1
+
+#elif FL_HAS_INCLUDE(<SD.h>) && FL_HAS_INCLUDE(<fs.h>)
+// Arduino SD library is on the include path. `fs_sdcard_arduino.hpp`
+// provides an `inline` `make_sdcard_filesystem` definition that uses
+// the real Arduino `SD`/`FS` libraries. Pulling those into
+// `fl.system.sd+.cpp.o` is fine — the linker only links this TU when
+// the user calls beginSd, so non-SD sketches see none of it.
+#include "platforms/fs_sdcard_arduino.hpp"
+#define FASTLED_HAS_SDCARD_IMPL 1
+
+#else
+#define FASTLED_HAS_SDCARD_IMPL 0
+#endif
+
+namespace fl {
+
+#if !FASTLED_HAS_SDCARD_IMPL
+// Weak fallback when no platform-specific SD implementation is
+// available in the build environment. Returns nullptr so
+// `FileSystem::beginSd()` cleanly returns `false`.
+FL_LINK_WEAK FsImplPtr make_sdcard_filesystem(int cs_pin) {
+    FASTLED_UNUSED(cs_pin);
+    return FsImplPtr();
+}
+#endif
+
+bool FileSystem::beginSd(int cs_pin) {
+    mFs = make_sdcard_filesystem(cs_pin);
+    if (!mFs) {
+        return false;
+    }
+    mFs->begin();
+    return true;
+}
+
+} // namespace fl

--- a/src/fl/system/sd/file_system_sd.h
+++ b/src/fl/system/sd/file_system_sd.h
@@ -1,0 +1,13 @@
+#pragma once
+
+/// @file fl/system/sd/file_system_sd.h
+/// @brief Header pair for `file_system_sd.cpp.hpp`. The actual SD-card
+/// API surface lives in `fl/system/file_system.h` —
+/// `FileSystem::beginSd(int)` and `make_sdcard_filesystem(int)` are
+/// declared there. This header exists only to satisfy the
+/// `CppHppHeaderPairChecker` lint rule (every `.cpp.hpp` needs a
+/// matching `.h` next to it). The SD implementation is split into its
+/// own translation unit so the linker can dead-strip it when nobody
+/// calls `beginSd`. See `file_system_sd.cpp.hpp` for the mechanism.
+
+#include "fl/system/file_system.h"  // IWYU pragma: export


### PR DESCRIPTION
## Summary

Follow-up to #2778. Replaces the `FASTLED_USE_SDCARD` macro-gate that
landed there with a **structural split** — the linker now tree-shakes
SD code automatically, no user opt-in required.

Implements the redesign requested on the closed branch of #2778
([\"redesign this so that the symbols can be tree shaken out\"](https://github.com/FastLED/FastLED/pull/2778)).

## Why the macro wasn't the right answer

The first version of #2778 required every SD-using sketch to add
\`#define FASTLED_USE_SDCARD\` before \`<FastLED.h>\`. The reviewer pushed
back: the linker should handle this automatically. Root cause was
structural — \`FileSystem::beginSd\` and \`make_sdcard_filesystem\` lived
in \`fl.system+.cpp.o\` alongside the rest of \`FileSystem\`, so the linker
had to keep the whole TU alive and dragged the SD/VFS/printf chain
along regardless of whether any user code actually called \`beginSd\`.

## The structural fix

Move \`FileSystem::beginSd(int)\` and the \`make_sdcard_filesystem(int)\`
weak-fallback / strong-overrides into a **new sub-aggregate**:

\`\`\`
src/fl/build/fl.system.sd+.cpp        # unity entry point (its own .o)
src/fl/system/sd/_build.cpp.hpp       # subdirectory aggregator
src/fl/system/sd/file_system_sd.h     # header pair
src/fl/system/sd/file_system_sd.cpp.hpp   # actual impl
\`\`\`

The unity-build glob auto-discovers the new \`fl.system.sd+.cpp\` and
compiles it to its own \`.o\` archive member of \`libFastLED.a\`. The
parent \`fl/system/_build.cpp.hpp\` does NOT need to include
\`sd/_build.cpp.hpp\` — per the unity-build linter's
recursive-build rule (\`ci/lint_cpp/test_unity_build.py:189\`), the
recursive entry point covers the subdirectory independently.

## How the linker tree-shakes it now

- **Sketch calls \`fs.beginSd(4)\`** → linker has unresolved
  \`FileSystem::beginSd\` → scans \`libFastLED.a\` → finds it in
  \`fl.system.sd+.cpp.o\` → pulls that \`.o\` → SD library + \`vtable\` for
  \`VFSImpl\` + the \`_svfprintf_r\` printf chain come along. **Works.**
- **Sketch doesn't call \`beginSd\`** → no unresolved symbol → no archive
  pull → \`fl.system.sd+.cpp.o\` stays out of the link → the entire SD
  chain (\`libSD.a\`, \`libFS.a\`, \`VFSImpl\`, ~16 KB on ESP32-S3) is dropped.
  **No macros, no opt-in, no user-visible change.**

Same mechanism the other split unity aggregates use (e.g. \`fl/channels/\`'s
\`detail/\`, \`rx/\`, \`spi/\` subdirs are split via the same recursive-build
pattern, just within \`fl.channels+\`).

## Removes the macro from #2778

This PR removes the \`FASTLED_USE_SDCARD\` conditional that landed in
#2778. Migration: **none**.

- Existing sketches that defined \`FASTLED_USE_SDCARD\` keep working
  (the macro is now no-op but harmless).
- Sketches that didn't define it but called \`beginSd\` (which was a
  silent no-op in #2778's version) now work correctly again.
- Sketches that never touch SD see no change beyond ~16 KB savings.

## Measured (ESP32-S3, Blink.ino, PIO + IDF 5.4 + xtensa-esp-elf-gcc 14.2.0)

| Build | \`firmware.bin\` | Δ |
|---|---:|---:|
| pre-#2778 master | 673,402 B | — |
| #2778 macro-gate (current master) | 657,680 B | −15,722 B |
| this PR (structural split) | **657,392 B** | **−16,010 B vs pre-#2778** |

A small additional 288 B over the macro-gate version, but the headline
win is **removing the user-facing macro requirement** while keeping the
~16 KB savings.

## Verification

- [x] \`bash test fl_system_file_system\` — 1/1 pass (this test calls
      \`fs.beginSd(5)\`, exercising the linked SD TU path).
- [x] \`bash compile esp32s3 --examples Blink --platformio\` — clean build.
- [x] \`firmware.bin\`: 657,392 B.
- [x] \`nm firmware.elf | grep VFSImpl\` → empty.
- [x] \`grep \"libFastLED.a(fl.system.sd+.cpp.o)\" firmware.map\` → empty
      (the SD \`.o\` was not pulled).
- [x] \`bash lint --cpp\` — clean (includes \`EXPECTED_BUILD_FILES\`
      update in \`ci/lint_cpp/test_unity_build.py\`).
- [ ] CI green.

## Files

| File | Status | Purpose |
|---|---|---|
| \`src/fl/build/fl.system.sd+.cpp\` | new | Unity-build entry point for the SD \`.o\` |
| \`src/fl/system/sd/_build.cpp.hpp\` | new | Subdirectory aggregator |
| \`src/fl/system/sd/file_system_sd.h\` | new | Header pair (satisfies \`CppHppHeaderPairChecker\`) |
| \`src/fl/system/sd/file_system_sd.cpp.hpp\` | new | The SD impl moved here |
| \`src/fl/system/file_system.cpp.hpp\` | modified | Removed \`FASTLED_USE_SDCARD\` gate, removed SD bits |
| \`ci/lint_cpp/test_unity_build.py\` | modified | Added \`fl/build/fl.system.sd+.cpp\` to \`EXPECTED_BUILD_FILES\` |

Issue: https://github.com/FastLED/FastLED/issues/2773
Supersedes the macro-gate in #2778.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured SD-card support into a dedicated compilation unit to enable linker-based tree-shaking, reducing binary size and memory footprint when SD functionality is not utilized. The public FileSystem API remains unchanged and fully functional.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->