### PR TITLE
fix(stl/variant): emplace<T>() returns T& not T*

### DIFF
--- a/src/fl/stl/variant.h
+++ b/src/fl/stl/variant.h
@@ -99,7 +99,7 @@ class FL_ALIGN_AS_T(max_align<Types...>::value) variant {
     emplace(Args &&...args) FL_NOEXCEPT {
         reset();
         construct<T>(fl::forward<Args>(args)...);
-        return ptr<T>();
+        return *ptr<T>();
     }
 
     void reset() FL_NOEXCEPT {


### PR DESCRIPTION
## Summary

`fl::variant::emplace<T>(Args&&...)` is declared to return `T&` but the body was `return ptr<T>();` (where `ptr<T>()` returns `T*`). The mismatch was latent because emplace had no in-tree users — the error surfaced the moment something actually called it (in my case, while attempting #2773 item 1.4):

```
src/fl/stl/variant.h:102:22: error: invalid initialization of non-const reference of type
'fl::enable_if<true, fl::UartEsp32&>::type' {aka 'fl::UartEsp32&'} from an rvalue of type
'fl::UartEsp32*'
```

One-character fix: dereference the pointer.

## Tests

- [x] `bash test variant --cpp` — 1/1 passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a return value issue in a utility function to properly align with its declared return type, ensuring correct behavior for library users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->