### PR TITLE
refactor(esp/io): compile-time-select UART vs USB-Serial-JTAG (−3.2 KB on ESP32-S3 Blink, #2773 item 1.4)

### DIFF
--- a/src/platforms/esp/32/detail/io_esp_jtag_or_uart.hpp
+++ b/src/platforms/esp/32/detail/io_esp_jtag_or_uart.hpp
@@ -24,6 +24,45 @@
 #define FL_ESP_HAS_USB_SERIAL_JTAG 0
 #endif
 
+// Compile-time selection of the active console backend.
+//
+// Previously EspIO held BOTH UartEsp32 AND UsbSerialJtagEsp32 as direct
+// members and runtime-probed which one was buffered. The linker had to
+// keep both drivers (and the ESP-IDF JTAG driver they pull in) alive
+// because both were reachable from every print/read/write/flush path —
+// ~2-3 KB of dead weight when only one backend is actually used. See
+// FastLED #2773 item 1.4.
+//
+// New rule: pick ONE backend at compile time. The unused driver is
+// dead code and gets dropped by `--gc-sections`. The choice mirrors
+// Arduino-ESP32's existing `ARDUINO_USB_CDC_ON_BOOT` convention:
+//
+//   * ARDUINO_USB_CDC_ON_BOOT=1 (Arduino routes Serial through USB
+//     Serial-JTAG)     → EspIO uses UsbSerialJtagEsp32.
+//   * otherwise (Arduino-default UART0 console, or non-Arduino ESP-IDF
+//     build)            → EspIO uses UartEsp32.
+//
+// Explicit overrides for the rare case where a user wants a different
+// backend than what their Arduino board config implies:
+//
+//   * `#define FASTLED_ESP_FORCE_UART_SERIAL`        → forces UART.
+//   * `#define FASTLED_ESP_FORCE_USB_SERIAL_JTAG`    → forces JTAG.
+//
+// Both macros are honored only when JTAG hardware is available; on
+// chips without JTAG (`FL_ESP_HAS_USB_SERIAL_JTAG == 0`) the choice is
+// fixed to UART.
+#if !FL_ESP_HAS_USB_SERIAL_JTAG
+#define FL_ESP_IO_USE_USB_SERIAL_JTAG 0
+#elif defined(FASTLED_ESP_FORCE_UART_SERIAL)
+#define FL_ESP_IO_USE_USB_SERIAL_JTAG 0
+#elif defined(FASTLED_ESP_FORCE_USB_SERIAL_JTAG)
+#define FL_ESP_IO_USE_USB_SERIAL_JTAG 1
+#elif defined(ARDUINO_USB_CDC_ON_BOOT) && ARDUINO_USB_CDC_ON_BOOT
+#define FL_ESP_IO_USE_USB_SERIAL_JTAG 1
+#else
+#define FL_ESP_IO_USE_USB_SERIAL_JTAG 0
+#endif
+
 namespace fl {
 namespace platforms {
 
@@ -67,42 +106,18 @@ public:
     // Print string to serial
     void print(const char* str) FL_NOEXCEPT {
         reportInitDiagnosticsIfNeeded();
-#if FL_ESP_HAS_USB_SERIAL_JTAG
-        if (mUseUsbSerialJtag) {
-            mUsbSerialJtag.write(str);
-        } else {
-            mUart.write(str);
-        }
-#else
-        mUart.write(str);
-#endif
+        mDriver.write(str);
     }
 
     // Print string with newline to serial
     void println(const char* str) FL_NOEXCEPT {
         reportInitDiagnosticsIfNeeded();
-#if FL_ESP_HAS_USB_SERIAL_JTAG
-        if (mUseUsbSerialJtag) {
-            mUsbSerialJtag.writeln(str);
-        } else {
-            mUart.writeln(str);
-        }
-#else
-        mUart.writeln(str);
-#endif
+        mDriver.writeln(str);
     }
 
     // Check input availability
     int available() FL_NOEXCEPT {
-#if FL_ESP_HAS_USB_SERIAL_JTAG
-        if (mUseUsbSerialJtag) {
-            return mUsbSerialJtag.available();
-        } else {
-            return mUart.available();
-        }
-#else
-        return mUart.available();
-#endif
+        return mDriver.available();
     }
 
     // Peek at next character without removing it
@@ -110,14 +125,7 @@ public:
         if (mHasPeek) {
             return mPeekByte;
         }
-
-        // Read next byte and cache it
-#if FL_ESP_HAS_USB_SERIAL_JTAG
-        mPeekByte = mUseUsbSerialJtag ? mUsbSerialJtag.read() : mUart.read();
-#else
-        mPeekByte = mUart.read();
-#endif
-
+        mPeekByte = mDriver.read();
         if (mPeekByte != -1) {
             mHasPeek = true;
         }
@@ -126,130 +134,91 @@ public:
 
     // Read single character
     int read() FL_NOEXCEPT {
-        // Return peeked byte if available
         if (mHasPeek) {
             mHasPeek = false;
             return mPeekByte;
         }
-
-#if FL_ESP_HAS_USB_SERIAL_JTAG
-        return mUseUsbSerialJtag ? mUsbSerialJtag.read() : mUart.read();
-#else
-        return mUart.read();
-#endif
+        return mDriver.read();
     }
 
     // Write raw bytes to serial (binary data)
     size_t writeBytes(const u8* buffer, size_t size) FL_NOEXCEPT {
-#if FL_ESP_HAS_USB_SERIAL_JTAG
-        if (mUseUsbSerialJtag) {
-            return mUsbSerialJtag.write(buffer, size);
-        } else {
-            return mUart.write(buffer, size);
-        }
-#else
-        return mUart.write(buffer, size);
-#endif
+        return mDriver.write(buffer, size);
     }
 
     // Flush TX buffer and wait for transmission to complete
     bool flush(u32 timeoutMs = 1000) FL_NOEXCEPT {
-#if FL_ESP_HAS_USB_SERIAL_JTAG
-        if (mUseUsbSerialJtag) {
-            return mUsbSerialJtag.flush(timeoutMs);
-        } else {
-            return mUart.flush(timeoutMs);
-        }
-#else
-        return mUart.flush(timeoutMs);
-#endif
+        return mDriver.flush(timeoutMs);
     }
 
     // Check if serial is ready
     bool isReady() const FL_NOEXCEPT {
-#if FL_ESP_HAS_USB_SERIAL_JTAG
-        return mUseUsbSerialJtag ? mUsbSerialJtag.isBuffered() : mUart.isBuffered();
-#else
-        return mUart.isBuffered();
-#endif
+        return mDriver.isBuffered();
     }
 
     // Check if using buffered mode (for testing/diagnostics)
     bool isBufferedMode() const FL_NOEXCEPT {
-#if FL_ESP_HAS_USB_SERIAL_JTAG
-        return mUseUsbSerialJtag ? mUsbSerialJtag.isBuffered() : mUart.isBuffered();
-#else
-        return mUart.isBuffered();
-#endif
+        return mDriver.isBuffered();
     }
 
-    // Get reference to underlying UART driver (for advanced use)
-    // Note: May throw if USB-Serial JTAG is active instead
-    UartEsp32& getUart() FL_NOEXCEPT {
-#if FL_ESP_HAS_USB_SERIAL_JTAG
-        FL_ASSERT(!mUseUsbSerialJtag, "Cannot get UART driver - using USB-Serial JTAG instead");
-#endif
-        return mUart;
+    // Compile-time: which backend is the active one in this build?
+    static constexpr bool isUsingUsbSerialJtag() FL_NOEXCEPT {
+        return FL_ESP_IO_USE_USB_SERIAL_JTAG;
     }
 
-#if FL_ESP_HAS_USB_SERIAL_JTAG
-    // Get reference to USB-Serial JTAG driver (for advanced use)
-    // Note: May throw if UART is active instead
+#if FL_ESP_IO_USE_USB_SERIAL_JTAG
+    // Get reference to USB-Serial JTAG driver (for advanced use).
+    // Available only when this build was configured with the JTAG backend.
     UsbSerialJtagEsp32& getUsbSerialJtag() FL_NOEXCEPT {
-        FL_ASSERT(mUseUsbSerialJtag, "Cannot get USB-Serial JTAG driver - using UART instead");
-        return mUsbSerialJtag;
+        return mDriver;
     }
-
-    // Check if currently using USB-Serial JTAG
-    bool isUsingUsbSerialJtag() const FL_NOEXCEPT {
-        return mUseUsbSerialJtag;
+#else
+    // Get reference to underlying UART driver (for advanced use).
+    // Available only when this build was configured with the UART backend.
+    UartEsp32& getUart() FL_NOEXCEPT {
+        return mDriver;
     }
 #endif
 
 private:
-#if FL_ESP_HAS_USB_SERIAL_JTAG
-    UsbSerialJtagEsp32 mUsbSerialJtag;  // USB-Serial JTAG driver (ESP32-S3/C3/C6/H2 only)
-    bool mUseUsbSerialJtag;             // true if USB-Serial JTAG active
+#if FL_ESP_IO_USE_USB_SERIAL_JTAG
+    // Single driver member chosen at compile time. The OTHER driver's
+    // code is dead and dropped by `--gc-sections`. See the comment block
+    // at the top of this file (#2773 item 1.4).
+    using ActiveDriver = UsbSerialJtagEsp32;
+    static UsbSerialJtagConfig defaultConfig() FL_NOEXCEPT {
+        return UsbSerialJtagConfig::defaults();
+    }
+#else
+    using ActiveDriver = UartEsp32;
+    static UartConfig defaultConfig() FL_NOEXCEPT {
+        return UartConfig::reliable(UartPort::UART0);
+    }
 #endif
-    UartEsp32 mUart;       // UART driver (UART0 with console-specific configuration)
-    int mPeekByte;         // Cached peek byte
-    bool mHasPeek;         // True if peek byte is valid
-    bool mDiagnosticsReported;  // true once the one-shot init diagnostic ran
 
-    // Constructor: Initialize drivers with runtime detection
+    ActiveDriver mDriver;            // The one backend selected at compile time.
+    int mPeekByte;                   // Cached peek byte
+    bool mHasPeek;                   // True if peek byte is valid
+    bool mDiagnosticsReported;       // true once the one-shot init diagnostic ran
+
+    // Constructor: initialize the single chosen driver.
     EspIO()
-        :
-#if FL_ESP_HAS_USB_SERIAL_JTAG
-          mUsbSerialJtag(UsbSerialJtagConfig::defaults()),
-          mUseUsbSerialJtag(false),  // Start false, detect below
-#endif
-          mUart(UartConfig::reliable(UartPort::UART0)),
+        : mDriver(defaultConfig()),
           mPeekByte(-1),
           mHasPeek(false),
-          mDiagnosticsReported(false) {
+          mDiagnosticsReported(false) {}
 
-#if FL_ESP_HAS_USB_SERIAL_JTAG
-        // Runtime detection: Prefer USB-Serial JTAG if available and working.
-        // The chosen backend and the JTAG init outcome are surfaced via
-        // reportInitDiagnosticsIfNeeded() on the first user-facing print —
-        // FL_PRINT here would re-enter the in-progress singleton.
-        mUseUsbSerialJtag = mUsbSerialJtag.isBuffered();
-#endif
-    }
-
-    // Emit a one-shot human-readable summary of the boot-time backend choice
-    // and the USB-Serial JTAG init outcome. Called from the first user-facing
-    // print/println — guaranteed to run after EspIO construction completes,
-    // so FL_PRINT (which dispatches back through this singleton) is safe.
+    // Emit a one-shot human-readable summary of the compile-time backend
+    // choice on the first user-facing print/println.
     void reportInitDiagnosticsIfNeeded() FL_NOEXCEPT {
         if (mDiagnosticsReported) {
             return;
         }
         mDiagnosticsReported = true;
-#if FL_ESP_HAS_USB_SERIAL_JTAG
-        const char* backend = mUseUsbSerialJtag ? "USB-JTAG" : "UART0";
+#if FL_ESP_IO_USE_USB_SERIAL_JTAG
+        const char* backend = "USB-JTAG";
         const char* outcome = nullptr;
-        switch (mUsbSerialJtag.initOutcome()) {
+        switch (mDriver.initOutcome()) {
             case UsbSerialJtagEsp32::InitOutcome::kNotInitialized:      outcome = "NotInitialized"; break;
             case UsbSerialJtagEsp32::InitOutcome::kPreInstalled:        outcome = "PreInstalled"; break;
             case UsbSerialJtagEsp32::InitOutcome::kInstalledOk:         outcome = "InstalledOk"; break;
@@ -260,9 +229,10 @@ private:
         }
         FL_PRINT("EspIO: backend=" << backend
                  << " usb_jtag_outcome=" << outcome
-                 << " err=" << static_cast<int>(mUsbSerialJtag.initError()));
+                 << " err=" << static_cast<int>(mDriver.initError()));
 #else
-        FL_PRINT("EspIO: backend=UART0 (USB-Serial JTAG not compiled)");
+        FL_PRINT("EspIO: backend=UART0 (compile-time choice; "
+                 "#define FASTLED_ESP_FORCE_USB_SERIAL_JTAG to switch)");
 #endif
     }
 


### PR DESCRIPTION
## Summary

`EspIO` used to hold both `UartEsp32` AND `UsbSerialJtagEsp32` as
direct non-template members and runtime-probed which one was active.
The linker had to keep both drivers (plus the ESP-IDF JTAG driver each
pulls in) alive because both were reachable from every
read/write/print call site — **~3 KB of dead weight when only one
backend is in use**.

This PR replaces the runtime probe with a compile-time selection so
the unused driver's code is dead and gets dropped by `--gc-sections`.

Implements item **1.4** of #2773.

## How the choice is made (no new user macro for common case)

The selection mirrors Arduino-ESP32's existing `ARDUINO_USB_CDC_ON_BOOT`
convention:

| Build config | Backend |
|---|---|
| `ARDUINO_USB_CDC_ON_BOOT=1` (Arduino routes Serial through USB-JTAG) | `UsbSerialJtagEsp32` |
| `ARDUINO_USB_CDC_ON_BOOT=0` (default — UART0 console) | `UartEsp32` |
| Non-Arduino ESP-IDF build | `UartEsp32` |
| Chip without USB-Serial-JTAG (ESP32, S2, etc.) | `UartEsp32` (forced) |

Explicit overrides for the rare case where a user wants a different
backend than their board config implies:

```cpp
#define FASTLED_ESP_FORCE_UART_SERIAL        // forces UART
#define FASTLED_ESP_FORCE_USB_SERIAL_JTAG    // forces JTAG
```

Both are honored only when JTAG hardware is available; on chips
without JTAG the choice is fixed to UART.

## Mechanism

`EspIO` now has a single `ActiveDriver mDriver` member (typedef to the
chosen driver), every method just calls `mDriver.write/read/flush`
without a runtime branch. The other driver's class isn't even named in
this build's `EspIO` instantiation, so its code is unreachable and
`--gc-sections` drops it.

This is the same shape `Channel::showPixels` uses for its
brightness/gamma/RGBW codepath selection (compile-time selection via
`if constexpr` — see #2773 item 2.1 for the planned variant).

## Measured (ESP32-S3, examples/Blink/Blink.ino, PIO + IDF 5.4)

| Build                          | `firmware.bin` | Δ |
|--------------------------------|---------------:|---:|
| master (\`8c87cbfddb\`, both drivers) | 657,392 B | — |
| this PR (UART-only default)    | **654,192 B**  | **−3,200 B** |

Verification:

```bash
xtensa-esp32s3-elf-nm firmware.elf | grep "fl::UsbSerialJtag"
# empty after this PR — JTAG wrapper code is gone

xtensa-esp32s3-elf-nm firmware.elf | grep usb_serial_jtag | wc -l
# 2,765 B → 1,472 B (the residual is Arduino-ESP32 boot code that
# touches the JTAG peripheral regardless, not FastLED)
```

## API impact

**No breaking changes for normal users.** `fl::print`/`fl::println` etc.
unchanged — still go through `EspIO`, which now uses one backend
instead of two.

Two minor surface changes for power users that previously called the
accessors directly:

- `EspIO::isUsingUsbSerialJtag()` is now `constexpr` (compile-time
  answer instead of runtime). Existing callers don't need to change.
- `EspIO::getUart()` is available only in UART builds;
  `EspIO::getUsbSerialJtag()` only in JTAG builds. Previously both
  were always available but asserted at runtime — same effective
  semantics, enforced earlier (link time vs `FL_ASSERT`).

## Test plan

- [x] `bash lint --cpp` — clean.
- [x] `bash compile esp32s3 --examples Blink --platformio` — builds clean.
- [x] `firmware.bin`: 657,392 → 654,192 (−3,200 B).
- [x] `nm firmware.elf | grep fl::UsbSerialJtag` — empty.
- [x] `nm firmware.elf | grep usb_serial_jtag` total: 2,765 → 1,472 B
      (−1,293 B; residual is Arduino-ESP32 boot code).
- [ ] CI green.

Issue: https://github.com/FastLED/FastLED/issues/2773

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * ESP32 serial backend selection now determined at compile-time instead of runtime probing.
  * Configuration macros available to force specific backend (UART or USB-Serial JTAG) selection.
  * Enhanced diagnostics reporting for serial backend initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->