### PR TITLE
fix(watchdog/apollo3): drop non-existent RSTGEN::CLRSTAT + correct STAT bits (Closes #2787)

### DIFF
--- a/src/platforms/apollo3/watchdog_apollo3.impl.hpp
+++ b/src/platforms/apollo3/watchdog_apollo3.impl.hpp
@@ -66,34 +66,38 @@ ResetCause Watchdog::lastResetCause() const FL_NOEXCEPT {
     auto& s = platforms::apollo3WatchdogState();
     if (!s.cause_cached) {
         // Read the Apollo3 reset status register directly. `RSTGEN->STAT`
-        // exposes one bit per reset source per the Apollo3 datasheet:
-        //   bit 0  EXRSTAT  external pin
-        //   bit 1  PORSTAT  power-on reset
-        //   bit 2  BORSTAT  brown-out reset
-        //   bit 3  SWRSTAT  software reset (AIRCR SYSRESETREQ)
-        //   bit 4  POIRSTAT power-on initialized (software POR)
-        //   bit 5  DBGRSTAT debugger reset
-        //   bit 6  POISTAT  power-on initiated
-        //   bit 7  WDRSTAT  watchdog timer
-        // "Specific first" priority puts watchdog above the generic POR/BOR
-        // bits because the latter are often also set after a watchdog reset.
+        // bit layout per the SparkFun Arduino_Apollo3 CMSIS header
+        // (RSTGEN_Type::STAT_b in apollo3.h) — every field is `(SBL)`,
+        // meaning the Secondary Boot Loader latches it at boot:
+        //   bit 0   EXRSTAT  external pin
+        //   bit 1   PORSTAT  power-on reset
+        //   bit 2   BORSTAT  brown-out reset (general)
+        //   bit 3   SWRSTAT  SW POR or AIRCR SYSRESETREQ
+        //   bit 4   POIRSTAT software POI reset
+        //   bit 5   DBGRSTAT debugger reset
+        //   bit 6   WDRSTAT  watchdog timer
+        //   bit 7   BOUSTAT  unregulated-supply brown-out
+        //   bit 8   BOCSTAT  core-regulator brown-out
+        //   bit 9   BOFSTAT  memory-regulator brown-out
+        //   bit 10  BOBSTAT  BLE/burst-regulator brown-out
+        // "Specific first" priority puts watchdog above the generic
+        // POR/BOR bits because the latter are often also set after a
+        // watchdog reset. All BO* variants map to BROWNOUT.
         const fl::u32 stat = RSTGEN->STAT;
         ResetCause cause = ResetCause::UNKNOWN;
-        if      (stat & (1u << 7)) cause = ResetCause::WATCHDOG;
-        else if (stat & (1u << 3)) cause = ResetCause::SOFTWARE;
-        else if (stat & (1u << 4)) cause = ResetCause::SOFTWARE;
-        else if (stat & (1u << 5)) cause = ResetCause::DEBUGGER;
-        else if (stat & (1u << 2)) cause = ResetCause::BROWNOUT;
-        else if (stat & (1u << 0)) cause = ResetCause::EXTERNAL_PIN;
-        else if (stat & (1u << 1)) cause = ResetCause::POWER_ON;
-        else if (stat & (1u << 6)) cause = ResetCause::POWER_ON;
-        // RSTGEN->STAT bits are sticky across resets. Writing 1 to the
-        // matching CLRSTAT bit clears them so the NEXT boot sees only
-        // its own reset cause and the crash counter isn't inflated by
-        // stale bits. (AmbiqSuite's `am_hal_reset_status_clear()` does
-        // the same — we write the register directly to avoid pulling in
-        // an additional HAL header.)
-        RSTGEN->CLRSTAT = 1u;
+        if      (stat & (1u << 6))                       cause = ResetCause::WATCHDOG;
+        else if (stat & (1u << 3))                       cause = ResetCause::SOFTWARE;
+        else if (stat & (1u << 4))                       cause = ResetCause::SOFTWARE;
+        else if (stat & (1u << 5))                       cause = ResetCause::DEBUGGER;
+        else if (stat & ((1u << 2) | (1u << 7) | (1u << 8) | (1u << 9) | (1u << 10)))
+                                                         cause = ResetCause::BROWNOUT;
+        else if (stat & (1u << 0))                       cause = ResetCause::EXTERNAL_PIN;
+        else if (stat & (1u << 1))                       cause = ResetCause::POWER_ON;
+        // `RSTGEN->STAT` bits are SBL-latched and remain set for the
+        // lifetime of this boot — there is no software-clearable
+        // mirror register on Apollo3. Re-reads are prevented by the
+        // `cause_cached` flag above, so the watchdog crash counter
+        // cannot be inflated by stale bits across calls.
         s.cached_cause = cause;
         s.cause_cached = true;
         if (cause == ResetCause::WATCHDOG && s.crash_count < 0xFFFF) {


### PR DESCRIPTION
## Summary

Fixes both Apollo3 workflows (\`build_apollo3_red.yml\` and \`build_apollo3_thing_explorable.yml\`) that were red on master with:

\`\`\`
src/platforms/apollo3/watchdog_apollo3.impl.hpp:96:17: error:
  'struct RSTGEN_Type' has no member named 'CLRSTAT'
\`\`\`

Closes #2787. Continues the README badge sweep started in #2779 / #2780 (AVR) / #2785 (STM32 GIGA).

## What's broken

Two bugs in \`src/platforms/apollo3/watchdog_apollo3.impl.hpp\` against the SparkFun Arduino_Apollo3 v2.2.1 CMSIS layout of \`RSTGEN_Type\` (defined in \`apollo3.h\`):

1. **Compile error** — line 96 wrote \`RSTGEN->CLRSTAT = 1u;\`, but \`RSTGEN_Type\` has no \`CLRSTAT\` member. The struct contains \`CFG\`, \`SWPOI\`, \`SWPOR\`, \`TPIURST\`, \`INTEN\`/\`INTSTAT\`/\`INTCLR\`/\`INTSET\` (BODH brown-out interrupt only), and \`STAT\` — and there is no clear register for \`STAT\`. Every \`STAT_b\` field is \`(SBL)\`-tagged: the Secondary Boot Loader latches it at boot and software cannot clear it.

2. **Runtime bug (latent)** — the bit-position table in the comment and the \`if/else\` chain had bits 6 and 7 wrong:

| Bit | Code said | Actual hardware (\`STAT_b\` in CMSIS) |
|---|---|---|
| 6 | \`POISTAT\` POR-init   | **\`WDRSTAT\` watchdog** |
| 7 | \`WDRSTAT\` watchdog   | **\`BOUSTAT\` unregulated brown-out** |

So \`if (stat & (1u << 7)) cause = WATCHDOG\` was actually reading the unregulated-brownout bit, and \`else if (stat & (1u << 6)) cause = POWER_ON\` was reading the watchdog bit. Had this ever compiled, \`lastResetWasWatchdog()\` would never have returned true after a real watchdog reset, and would have falsely reported watchdog after an unregulated brown-out. The CLRSTAT compile failure inadvertently protected callers from shipping broken behavior.

## What this PR changes

\`src/platforms/apollo3/watchdog_apollo3.impl.hpp\`:
- Remove the impossible \`RSTGEN->CLRSTAT = 1u;\` write. Re-read protection is already provided by the \`cause_cached\` flag in \`Apollo3WatchdogState\`, so the watchdog crash counter cannot inflate from stale bits.
- Re-derive the bit-position table from \`RSTGEN_Type::STAT_b\` in \`apollo3.h\` and update both the comment and the \`if/else\` conditions.
- Map all Apollo3 brown-out variants (general \`BORSTAT\` bit 2, unregulated \`BOUSTAT\` bit 7, core-regulator \`BOCSTAT\` bit 8, memory-regulator \`BOFSTAT\` bit 9, BLE/burst \`BOBSTAT\` bit 10) to \`ResetCause::BROWNOUT\` so every flavor of brown-out reports consistently.

## Test plan

Local verification with \`bash compile\` was blocked by a separate Windows-only fbuild toolchain cache issue (arm-none-eabi-gcc 9.2.1 cache for the SparkFun Apollo3 build missing \`as.exe\`). The failure fires inside the Arduino_Apollo3 core's \`itoa.c\` before any FastLED translation unit is compiled, and other arm-none-eabi-gcc boards in the same workspace (\`stm32f103c8\`, \`nucleo_f429zi\`, etc.) compile cleanly — i.e. unrelated to this change.

**This PR's CI on apollo3_red / apollo3_thing_explorable is the authoritative verification.** The compile error being fixed is unambiguous (\`RSTGEN_Type\` has no \`CLRSTAT\` member), and this PR removes the exact line that produced it; the bit-position corrections are verified by inspection against the CMSIS header.

\`bash lint\` clean.

## Scope

- [x] Closes #2787 — both Apollo3 workflows.
- [ ] Remaining red badges from the README sweep: \`rp2040\`, \`check_esp32_size\`, \`check_teensy41_size\`, \`uno AVR8JS Test\`. Each will be filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced reset-cause detection with improved bit-mapping logic to accurately identify watchdog resets, brown-out detection events, power-on resets, external resets, debugger resets, and software-triggered resets. Now provides more precise diagnostic information for system troubleshooting and debugging.
  * Optimized reset-status handling by removing unnecessary sticky-bit clearing operations, resulting in reduced complexity and improved system efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->