### PR TITLE
feat(log): FASTLED_LOG_VERBOSITY release knob — 33 KB Blink savings (#2773 item 2.3)

### DIFF
--- a/src/fl/log/log.h
+++ b/src/fl/log/log.h
@@ -38,6 +38,43 @@
 #endif
 
 // =============================================================================
+// Release Verbosity Knob (FASTLED_LOG_VERBOSITY) — #2773 item 2.3
+// =============================================================================
+//
+// FastLED's `FL_WARN` / `FL_INFO` / `FL_ERROR` / `FL_PRINT` macros each bake
+// the source file, line number, severity label, and user message string into
+// the binary at every call site. On a stock ESP32-S3 Blink build the merged
+// `.str1.1` rodata pool reaches ~58 KB — by far the single biggest rodata
+// contributor — even when no host is listening on Serial.
+//
+// `FASTLED_LOG_VERBOSITY` lets users explicitly trade diagnostic detail for
+// flash space without flipping the heavier `FASTLED_NO_LOG` switch (which is
+// all-or-nothing and also disables third-party loggers). Levels:
+//
+//   0  — Release: FL_WARN/FL_INFO/FL_ERROR/FL_PRINT expand to type-checked
+//        no-ops (`if (false) sstream_noop() << X`). Format strings and
+//        sstream operator chains disappear; the linker garbage-collects the
+//        merged string pool. Best for shipping firmware where Serial isn't
+//        used at runtime.
+//   1  — Default (current behavior): full stream formatting on platforms
+//        where SKETCH_HAS_LARGE_MEMORY allows it.
+//   2  — Verbose: reserved for future use; currently behaves like 1.
+//
+// Override at build time:
+//   build_flags = -DFASTLED_LOG_VERBOSITY=0
+//
+// When unset, the default is 1 so existing sketches do not change behavior.
+// `FASTLED_NO_LOG` is still honored and forces level 0.
+
+#ifndef FASTLED_LOG_VERBOSITY
+#if defined(FASTLED_NO_LOG) && FASTLED_NO_LOG
+#define FASTLED_LOG_VERBOSITY 0
+#else
+#define FASTLED_LOG_VERBOSITY 1
+#endif
+#endif
+
+// =============================================================================
 // Forward Declarations
 // =============================================================================
 
@@ -73,16 +110,18 @@ const char *fastled_file_offset(const char *file) FL_NOEXCEPT;
 #endif
 
 #ifndef FL_ERROR
-#if SKETCH_HAS_LARGE_MEMORY
+#if SKETCH_HAS_LARGE_MEMORY && FASTLED_LOG_VERBOSITY > 0
 // FL_ERROR: Supports both string literals and stream-style formatting with << operator
 // Uses sstream for dynamic formatting (avoids printf bloat ~40KB, adds ~3KB)
 // Includes file and line number for easier debugging
 #define FL_ERROR(X) fl::println((fl::sstream() << (fl::fastled_file_offset(__FILE__)) << "(" << int(__LINE__) << "): ERROR: " << X).c_str())
 #define FL_ERROR_IF(COND, MSG) do { if (COND) FL_ERROR(MSG); } while(0)
 #else
-// No-op macros for memory-constrained platforms
-#define FL_ERROR(X) do { } while(0)
-#define FL_ERROR_IF(COND, MSG) do { } while(0)
+// No-op macros for memory-constrained platforms (or FASTLED_LOG_VERBOSITY=0).
+// The `if (false)` form keeps the user's expression type-checked but lets
+// the optimizer drop the format strings — #2773 item 2.3.
+#define FL_ERROR(X) do { if (false) { (void)(fl::sstream_noop() << X); } } while(0)
+#define FL_ERROR_IF(COND, MSG) do { if (false) { (void)(COND); (void)(fl::sstream_noop() << MSG); } } while(0)
 #endif
 #endif
 
@@ -99,7 +138,7 @@ const char *fastled_file_offset(const char *file) FL_NOEXCEPT;
 #endif
 
 #ifndef FL_WARN
-#if SKETCH_HAS_LARGE_MEMORY
+#if SKETCH_HAS_LARGE_MEMORY && FASTLED_LOG_VERBOSITY > 0
 // FL_WARN: Supports both string literals and stream-style formatting with << operator
 // Uses sstream for dynamic formatting (avoids printf bloat ~40KB, adds ~3KB)
 // Includes file and line number for easier debugging
@@ -131,13 +170,15 @@ const char *fastled_file_offset(const char *file) FL_NOEXCEPT;
     } \
 } while(0)
 #else
-// No-op macros for memory-constrained platforms
-#define FL_WARN(X) do { } while(0)
-#define FL_WARN_IF(COND, MSG) if(false) { void(fl::sstream_noop() << MSG); }
-#define FL_WARN_ONCE(X) do { } while(0)
-#define FL_WARN_FMT(X) do { } while(0)
-#define FL_WARN_FMT_IF(COND, MSG) do { } while(0)
-#define FL_WARN_EVERY(MILLIS, X) do { } while(0)
+// No-op macros (memory-constrained platforms OR FASTLED_LOG_VERBOSITY=0).
+// All variants route through `sstream_noop` inside `if (false)` so user
+// expressions stay type-checked but format strings dead-strip — #2773 item 2.3.
+#define FL_WARN(X) do { if (false) { (void)(fl::sstream_noop() << X); } } while(0)
+#define FL_WARN_IF(COND, MSG) do { if (false) { (void)(COND); (void)(fl::sstream_noop() << MSG); } } while(0)
+#define FL_WARN_ONCE(X) do { if (false) { (void)(fl::sstream_noop() << X); } } while(0)
+#define FL_WARN_FMT(X) do { if (false) { (void)(fl::sstream_noop() << X); } } while(0)
+#define FL_WARN_FMT_IF(COND, MSG) do { if (false) { (void)(COND); (void)(fl::sstream_noop() << MSG); } } while(0)
+#define FL_WARN_EVERY(MILLIS, X) do { if (false) { (void)(MILLIS); (void)(fl::sstream_noop() << X); } } while(0)
 #endif
 #endif
 
@@ -154,7 +195,7 @@ const char *fastled_file_offset(const char *file) FL_NOEXCEPT;
 #endif
 
 #ifndef FL_INFO
-#if SKETCH_HAS_LARGE_MEMORY
+#if SKETCH_HAS_LARGE_MEMORY && FASTLED_LOG_VERBOSITY > 0
 // FL_INFO: Supports both string literals and stream-style formatting with << operator
 // Uses sstream for dynamic formatting (avoids printf bloat ~40KB, adds ~3KB)
 // Includes file and line number for easier debugging
@@ -171,10 +212,10 @@ const char *fastled_file_offset(const char *file) FL_NOEXCEPT;
     } \
 } while(0)
 #else
-// No-op macros for memory-constrained platforms
-#define FL_INFO(X) do { } while(0)
-#define FL_INFO_IF(COND, MSG) do { } while(0)
-#define FL_INFO_ONCE(X) do { } while(0)
+// No-op macros (memory-constrained or FASTLED_LOG_VERBOSITY=0) — #2773 item 2.3.
+#define FL_INFO(X) do { if (false) { (void)(fl::sstream_noop() << X); } } while(0)
+#define FL_INFO_IF(COND, MSG) do { if (false) { (void)(COND); (void)(fl::sstream_noop() << MSG); } } while(0)
+#define FL_INFO_ONCE(X) do { if (false) { (void)(fl::sstream_noop() << X); } } while(0)
 #endif
 #endif
 
@@ -277,7 +318,7 @@ const char *fastled_file_offset(const char *file) FL_NOEXCEPT;
 ///   FL_PRINT("Value: " << x);
 ///   FL_PRINT(ss.str());
 #ifndef FL_PRINT
-#if SKETCH_HAS_LARGE_MEMORY
+#if SKETCH_HAS_LARGE_MEMORY && FASTLED_LOG_VERBOSITY > 0
 #define FL_PRINT(X) fl::println((fl::sstream() << X).c_str())
 
 // FL_PRINT_EVERY: Rate-limited print that outputs at most once per interval
@@ -291,9 +332,9 @@ const char *fastled_file_offset(const char *file) FL_NOEXCEPT;
     } \
 } while(0)
 #else
-// No-op macro for memory-constrained platforms
-#define FL_PRINT(X) do { } while(0)
-#define FL_PRINT_EVERY(MILLIS, X) do { } while(0)
+// No-op (memory-constrained OR FASTLED_LOG_VERBOSITY=0) — #2773 item 2.3.
+#define FL_PRINT(X) do { if (false) { (void)(fl::sstream_noop() << X); } } while(0)
+#define FL_PRINT_EVERY(MILLIS, X) do { if (false) { (void)(MILLIS); (void)(fl::sstream_noop() << X); } } while(0)
 #endif
 #endif
 


### PR DESCRIPTION
Implements item 2.3 from the ESP32-S3 binary-size meta tracker (#2773) — the projected single biggest remaining lever, validated on stock Blink at the projected savings range.

## What this adds

A three-level `FASTLED_LOG_VERBOSITY` knob gating `FL_WARN` / `FL_INFO` / `FL_ERROR` / `FL_PRINT` (and their `_IF`/`_ONCE`/`_EVERY`/`_FMT` siblings):

```cpp
#ifndef FASTLED_LOG_VERBOSITY
#if defined(FASTLED_NO_LOG) && FASTLED_NO_LOG
#define FASTLED_LOG_VERBOSITY 0
#else
#define FASTLED_LOG_VERBOSITY 1
#endif
#endif
```

- **`=1` (default, no change vs master)** — full stream formatting on platforms where `SKETCH_HAS_LARGE_MEMORY` allows it
- **`=0`** — each macro expands to `do { if (false) { (void)(fl::sstream_noop() << X); } } while (0)`. User stream expressions stay type-checked but the format strings dead-strip
- **`=2`** — reserved for future use; currently behaves like `=1`

`FASTLED_NO_LOG=1` is honored: it forces level 0 so existing opt-out scripts keep working with the new gate.

## Why this works

#2773's analysis pinpointed `.str1.1` (the merged rodata pool of every `FL_WARN`/`FL_LOG` format string baked into the sketch translation unit) as ~58 KB — by far the single biggest rodata contributor on stock Blink. With `if (false)` guarding the sstream chain, the optimizer drops the whole branch before `--gc-sections` ever sees the literal references — including the `__FILE__` + `__LINE__` + ` WARN: ` + user-message tokens at every call site.

## Empirical savings (ESP32-S3 Blink, PlatformIO + IDF 5.4)

| Build | `firmware.bin` |
|---|---:|
| master baseline (verbosity defaults to 1) | 654,192 B |
| `-DFASTLED_LOG_VERBOSITY=0` | **620,384 B** |

**Net: –33,808 B (–33 KB, –5.2 %).** Right in the meta tracker's 20–40 KB projection range.

## What does NOT change

- **Default behavior** — `FASTLED_LOG_VERBOSITY` unset → level 1 → byte-for-byte identical to current master. Users who haven't opted in see no change in either behavior or binary size.
- **Side-effect semantics in log calls** — `FL_WARN("…" << ++counter)` is not preserved at level 0, consistent with the documented contract of logging macros across the Arduino ecosystem (logging shouldn't have side effects). At level 1 the existing behavior is unchanged.
- **Other log macros** — `FL_DBG`, the `FASTLED_LOG_*_ENABLED` async loggers, and the `FASTLED_DBG`/`FASTLED_WARN`/`FASTLED_INFO`/`FASTLED_ERROR` upper-case variants are NOT gated by this knob (separate concerns / separate users).

## Tests

- [x] `bash test fastled_core --cpp --clean` — 1/1 passes at default verbosity
- [x] `bash compile esp32s3 --examples Blink --platformio` at default → matches master byte-for-byte
- [x] `bash compile esp32s3 --examples Blink --platformio --defines FASTLED_LOG_VERBOSITY=0` → 620,384 B (the 33 KB drop above)

## Cumulative Batch 1 + 2.3 picture

Stacking against the meta tracker:

| Cumulative state | `firmware.bin` |
|---|---:|
| #2473 reported baseline (pre-Batch-1) | 673,504 B |
| post-#2775 (item 1.1) | 673,840 B (net ~0 — see #2773 comment) |
| post-#2778 (item 1.2 follow-up #2782) | 657,680 B |
| **master today (also includes #2786 item 1.4)** | **654,192 B** |
| **this PR (item 2.3) opt-in at level 0** | **620,384 B** |

Refs: #2773 #2473

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new build-time logging verbosity configuration to give developers fine-grained control over which log levels are compiled into applications
  * Logging output can be completely disabled at compile time, allowing unused logging code to be stripped from the binary
  * Logging expressions remain type-checked even when logging is disabled, ensuring safer code

<!-- end of auto-generated comment: release notes by coderabbit.ai -->