### PR TITLE
ci(esp32dev_size): bump max_size 330000 → 700000 to unblock master (Closes #2608)

### DIFF
--- a/.github/workflows/check_esp32_size.yml
+++ b/.github/workflows/check_esp32_size.yml
@@ -23,5 +23,5 @@ jobs:
     uses: ./.github/workflows/build_template_binary_size.yml
     with:
       board: esp32dev
-      max_size: 330000
-      max_size_apa102: 330000
+      max_size: 700000
+      max_size_apa102: 700000


### PR DESCRIPTION
## Summary

Fixes the `esp32dev_binary_size` workflow that has been red on master with `esp32dev size 635768 is greater than max size 330000` for ~6 days (100% failure rate across 30+ runs). Per the recommendation in #2608, this picks option A: bump the budget to reflect platformio-backend reality, then recalibrate downward later when fbuild can be re-enabled.

Closes #2608. Also clears one of the red badges tracked in #2779.

## Why 330 KB no longer fits

Per #2608 root cause, three things piled on top of the 2025-08-15 ceiling (set when stock build was ~320 KB):

1. The Channel API landed (~70 KB structural cost, #2473).
2. #2605 pinned all binary-size checks to `--backend platformio` to dodge fbuild's missing `build_info.json` (fbuild#297) and link bloat (fbuild#304). PlatformIO does NOT strip `.eh_frame`, so we lose the ~169 KB savings that fbuild provided.
3. Arduino-ESP32 framework itself grew with subsequent releases.

Current stock Blink build via `--backend platformio` is **635,768 B** vs. the 330,000 B ceiling — a +305 KB delta (+93%).

## What this PR changes

`.github/workflows/check_esp32_size.yml`:

\`\`\`diff
-      max_size: 330000
-      max_size_apa102: 330000
+      max_size: 700000
+      max_size_apa102: 700000
\`\`\`

700 KB = current 635 KB + ~10% headroom. Both budgets bumped equally because the build template runs both Blink and Apa102 size checks against the same backend; the framework cost dominates both.

## Tradeoff

Per #2608: this loses regression-detection sensitivity until the fbuild backend can be restored (fbuild#297 + #304 + revert #2605), at which point a follow-up issue will recalibrate this budget downward to the actual fbuild-backend size.

## Test plan

- [x] Workflow YAML change only — no `bash lint`/`bash test` touchpoint.
- [ ] This PR's own `esp32dev_binary_size` CI run is the authoritative verification (the previous step was failing at 635 KB > 330 KB; with the bumped ceiling the same compile should pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated binary size limits for ESP32 builds to accommodate larger firmware images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->