### PR TITLE
fix(rp2040): gate pio_program::used_gpio_ranges on PICO_PIO_VERSION, not SDK ver (Closes #2792)

### DIFF
--- a/src/platforms/arm/rp/rpcommon/pio_gen.h
+++ b/src/platforms/arm/rp/rpcommon/pio_gen.h
@@ -46,13 +46,26 @@ static inline int add_clockless_pio_program(PIO pio, int T1, int T2, int T3) FL_
         .length = sizeof(clockless_pio_instr) / sizeof(clockless_pio_instr[0]),
         .origin = -1,
 #if defined(PICO_SDK_VERSION_MAJOR) && PICO_SDK_VERSION_MAJOR >= 2
-        // pico-sdk 2.x (RP2350) added these. Zero-init preserves the previous
-        // implicit behavior while silencing -Wmissing-field-initializers and
-        // documenting intent: no specific PIO version pinned, no GPIO range
-        // pre-claimed. Revisit if RP2350 SDK starts enforcing used_gpio_ranges
-        // at pio_add_program time. #2727
+        // pico-sdk 2.x added these two fields to `pio_program`. They are
+        // gated by *different* macros in the SDK header — getting the gating
+        // wrong here is what regressed RP2040 builds in #2792 / #2727.
+        //
+        //   * `pio_version` is unconditionally present in 2.x — guard on
+        //     PICO_SDK_VERSION_MAJOR only.
+        //   * `used_gpio_ranges` is per-chip, gated on PICO_PIO_VERSION > 0
+        //     in rp2_common/hardware_pio/include/hardware/pio.h. RP2350
+        //     defines `PICO_PIO_VERSION = 1` so the field exists; RP2040
+        //     defines `PICO_PIO_VERSION = 0` so the field is genuinely
+        //     absent even on the 2.x SDK.
+        //
+        // Zero-init preserves the previous implicit behavior while silencing
+        // -Wmissing-field-initializers and documenting intent: no specific
+        // PIO version pinned, no GPIO range pre-claimed. Revisit if the SDK
+        // starts enforcing `used_gpio_ranges` at pio_add_program time.
         .pio_version = 0,
+    #if defined(PICO_PIO_VERSION) && PICO_PIO_VERSION > 0
         .used_gpio_ranges = 0,
+    #endif
 #endif
     };
     

--- a/src/platforms/arm/rp/rpcommon/spi_hw_2_rp.cpp.hpp
+++ b/src/platforms/arm/rp/rpcommon/spi_hw_2_rp.cpp.hpp
@@ -86,8 +86,15 @@ static inline int add_spi_dual_pio_program(PIO pio) {
         .length = sizeof(spi_dual_pio_instr) / sizeof(spi_dual_pio_instr[0]),
         .origin = -1,
 #if defined(PICO_SDK_VERSION_MAJOR) && PICO_SDK_VERSION_MAJOR >= 2
+        // See pio_gen.h for the full rationale on these two fields.
+        // `pio_version` is unconditionally present in 2.x (gate on SDK
+        // version). `used_gpio_ranges` is per-chip, only present when
+        // PICO_PIO_VERSION > 0 — RP2040 has PICO_PIO_VERSION == 0, so
+        // the field is genuinely absent there even under the 2.x SDK.
         .pio_version = 0,
+    #if defined(PICO_PIO_VERSION) && PICO_PIO_VERSION > 0
         .used_gpio_ranges = 0,
+    #endif
 #endif
     };
 

--- a/src/platforms/arm/rp/rpcommon/spi_hw_4_rp.cpp.hpp
+++ b/src/platforms/arm/rp/rpcommon/spi_hw_4_rp.cpp.hpp
@@ -88,8 +88,15 @@ static inline int add_spi_quad_pio_program(PIO pio) {
         .length = sizeof(spi_quad_pio_instr) / sizeof(spi_quad_pio_instr[0]),
         .origin = -1,
 #if defined(PICO_SDK_VERSION_MAJOR) && PICO_SDK_VERSION_MAJOR >= 2
+        // See pio_gen.h for the full rationale on these two fields.
+        // `pio_version` is unconditionally present in 2.x (gate on SDK
+        // version). `used_gpio_ranges` is per-chip, only present when
+        // PICO_PIO_VERSION > 0 — RP2040 has PICO_PIO_VERSION == 0, so
+        // the field is genuinely absent there even under the 2.x SDK.
         .pio_version = 0,
+    #if defined(PICO_PIO_VERSION) && PICO_PIO_VERSION > 0
         .used_gpio_ranges = 0,
+    #endif
 #endif
     };
 

--- a/src/platforms/arm/rp/rpcommon/spi_hw_8_rp.cpp.hpp
+++ b/src/platforms/arm/rp/rpcommon/spi_hw_8_rp.cpp.hpp
@@ -92,8 +92,15 @@ static inline int add_spi_octal_pio_program(PIO pio) {
         .length = sizeof(spi_octal_pio_instr) / sizeof(spi_octal_pio_instr[0]),
         .origin = -1,
 #if defined(PICO_SDK_VERSION_MAJOR) && PICO_SDK_VERSION_MAJOR >= 2
+        // See pio_gen.h for the full rationale on these two fields.
+        // `pio_version` is unconditionally present in 2.x (gate on SDK
+        // version). `used_gpio_ranges` is per-chip, only present when
+        // PICO_PIO_VERSION > 0 — RP2040 has PICO_PIO_VERSION == 0, so
+        // the field is genuinely absent there even under the 2.x SDK.
         .pio_version = 0,
+    #if defined(PICO_PIO_VERSION) && PICO_PIO_VERSION > 0
         .used_gpio_ranges = 0,
+    #endif
 #endif
     };
 


### PR DESCRIPTION
## Summary

Fixes the \`build_rp2040.yml\` workflow that was red on master with:

\`\`\`
src/platforms/arm/rp/rpcommon/pio_gen.h:57:5: error:
  'pio_program' has no non-static data member named 'used_gpio_ranges'
\`\`\`

Closes #2792. Continues the README badge sweep started in #2779 / #2780 (AVR) / #2785 (STM32 GIGA) / #2788 (Apollo3).

## What's broken

\`pio_gen.h\` was zero-initializing two pico-sdk 2.x fields (\`pio_version\` and \`used_gpio_ranges\`) behind a single guard:

\`\`\`cpp
#if defined(PICO_SDK_VERSION_MAJOR) && PICO_SDK_VERSION_MAJOR >= 2
    .pio_version = 0,
    .used_gpio_ranges = 0,
#endif
\`\`\`

But \`used_gpio_ranges\` is gated by a *different* macro in the SDK header — per-chip, not per-SDK:

\`\`\`c
// pico-sdk/src/rp2_common/hardware_pio/include/hardware/pio.h
typedef struct pio_program {
    const uint16_t *instructions;
    uint8_t length;
    int8_t origin;
    uint8_t pio_version;
#if PICO_PIO_VERSION > 0
    uint8_t used_gpio_ranges;
#endif
} pio_program_t;
\`\`\`

RP2040 defines \`PICO_PIO_VERSION = 0\` (field genuinely absent). RP2350 defines \`PICO_PIO_VERSION = 1\` (field present). So RP2350 / RP2350B builds happened to stay green; RP2040 broke because the designated initializer references a member that doesn't exist on this chip.

## What this PR changes

Split the guard so each field is gated by its correct condition:

\`\`\`cpp
#if defined(PICO_SDK_VERSION_MAJOR) && PICO_SDK_VERSION_MAJOR >= 2
    .pio_version = 0,
    #if defined(PICO_PIO_VERSION) && PICO_PIO_VERSION > 0
        .used_gpio_ranges = 0,
    #endif
#endif
\`\`\`

Comment block updated to explain both gates and reference #2792 + the original #2727 follow-up that introduced the workaround.

## Test plan

Local verification was blocked by a separate Windows-only fbuild toolchain cache issue (arduino-pico 4.5.3 \`memmap_default.ld\` missing from \`~/.fbuild/prod/cache/platforms/earlephilhower-arduino-pico/...\`); the failure fires at the linker-script-template stage on \`rp2040\`, \`rp2350\`, and \`rp2350B\` alike — *before* any FastLED translation unit is compiled — so the compile-stage diff cannot be exercised on this workstation.

**PR CI on rp2040 / rp2350 / rp2350B is the authoritative verification.** The diff is logically correct by inspection against the SDK header: RP2040 (\`PICO_PIO_VERSION = 0\`) now omits the \`used_gpio_ranges\` initializer (was the bug); RP2350/RP2350B (\`PICO_PIO_VERSION = 1\`) still include it (no regression vs the green baseline).

\`bash lint\` clean.

## Scope

- [x] Closes #2792 — \`build_rp2040.yml\`.
- [ ] Remaining red from the sweep: \`check_esp32_size\`, \`check_teensy41_size\`, \`uno AVR8JS Test\`, \`unit tests windows\`. Each will be filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PIO-related initialization to ensure compatibility with SDK 2.x and across RP hardware variants.

* **Documentation**
  * Expanded comments clarifying conditional initialization behavior and differences across SDK versions and targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->