### PR TITLE
fix(ci): merge root platformio.ini build_flags into synthesised PIO env (#2664)

### DIFF
--- a/ci/compiler/build_config.py
+++ b/ci/compiler/build_config.py
@@ -30,6 +30,65 @@ def _get_project_root() -> Path:
     return _PROJECT_ROOT
 
 
+def get_root_platformio_build_flags(board_name: str, project_root: Path) -> list[str]:
+    """Read the root ``platformio.ini`` and return ``build_flags`` for the
+    matching ``[env:<board_name>]`` section, with ``extends`` and ``[env]``
+    inheritance resolved.
+
+    This exists to fix issue #2664: ``bash compile --backend platformio``
+    synthesises a fresh PIO project at ``.build/pio/<env>/platformio.ini``
+    from ``ci/boards.py`` and was silently discarding ``build_flags`` defined
+    in the user's root ``platformio.ini``. Anyone editing the root file
+    reasonably expects those flags to take effect; without this merge step
+    they vanish, producing subtle "flags work under fbuild but not under
+    --backend=platformio" bugs.
+
+    Behaviour:
+    - Returns an empty list if the root ``platformio.ini`` is missing,
+      malformed, or has no matching ``[env:<board_name>]`` section.
+    - Substitution variables like ``${env:generic-esp.build_flags}`` and
+      ``extends = env:generic-esp`` are resolved using the existing
+      :class:`PlatformIOIni` parser, which already implements PlatformIO's
+      inheritance semantics.
+    - Never raises: parse errors are swallowed and logged so that a broken
+      root file cannot block a build.
+
+    Args:
+        board_name: The PlatformIO env name (e.g. ``"esp32c6"``). Matches
+            ``[env:<board_name>]`` in the root ini.
+        project_root: FastLED project root containing ``platformio.ini``.
+
+    Returns:
+        Ordered list of build_flags strings, or ``[]`` when nothing applies.
+    """
+    root_ini = project_root / "platformio.ini"
+    if not root_ini.exists():
+        return []
+
+    try:
+        # Local import to avoid a circular import at module load.
+        from ci.compiler.platformio_ini import PlatformIOIni
+
+        pio_ini = PlatformIOIni.parseFile(root_ini)
+        parsed = pio_ini.parsed
+        env = parsed.environments.get(board_name)
+        if env is None:
+            return []
+        # `parsed` already has extends + [env] inheritance applied, and
+        # ${env:...} substitutions resolved (see _resolve_list_variables in
+        # ci/compiler/platformio_ini.py).
+        return list(env.build_flags)
+    except KeyboardInterrupt as ki:
+        handle_keyboard_interrupt(ki)
+        raise
+    except Exception as e:
+        # Never let a malformed root platformio.ini block a build.
+        print(
+            f"Warning: failed to read root platformio.ini for env '{board_name}': {e}"
+        )
+        return []
+
+
 def generate_build_info_json_from_existing_build(
     build_dir: Path, board: "Board", example: Optional[str] = None
 ) -> bool:

--- a/ci/compiler/pio.py
+++ b/ci/compiler/pio.py
@@ -30,6 +30,7 @@ from ci.boards import Board, create_board
 from ci.compiler.build_config import (
     apply_board_specific_config,
     generate_build_info_json_from_existing_build,
+    get_root_platformio_build_flags,
 )
 from ci.compiler.build_utils import (
     create_building_banner,
@@ -143,6 +144,21 @@ def _init_platformio_build(
     except Exception:
         # Non-fatal: continue without optimization artifacts if path resolution fails
         pass
+
+    # Merge any per-env build_flags the user has declared in the root
+    # platformio.ini (issue #2664). Without this step, flags in
+    # [env:<board>].build_flags of the root file are silently discarded
+    # when bash compile --backend platformio synthesises a fresh project
+    # from ci/boards.py. Board flags come first, root flags are appended,
+    # so root values take precedence per PlatformIO's "last wins" semantics
+    # for repeated -D / linker flags.
+    root_build_flags = get_root_platformio_build_flags(board.board_name, project_root)
+    if root_build_flags:
+        print(
+            f"Merging {len(root_build_flags)} build_flag(s) from root "
+            f"platformio.ini [env:{board.board_name}]: {root_build_flags}"
+        )
+        board_with_sketch_include.build_flags.extend(root_build_flags)
 
     # Apply board-specific configuration
     if not apply_board_specific_config(

--- a/ci/tests/test_root_platformio_flag_merge.py
+++ b/ci/tests/test_root_platformio_flag_merge.py
@@ -1,0 +1,103 @@
+"""Tests for ``get_root_platformio_build_flags`` (issue #2664).
+
+The ``bash compile --backend platformio`` path synthesises a fresh PIO
+project from ``ci/boards.py`` and historically discarded any
+``[env:<board>].build_flags`` defined in the user's root ``platformio.ini``.
+``get_root_platformio_build_flags`` reads the root file and returns those
+flags so ``_init_platformio_build`` in ``ci/compiler/pio.py`` can append
+them to the synthesised env.
+"""
+
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from ci.compiler.build_config import get_root_platformio_build_flags
+
+
+class TestRootPlatformioBuildFlagsMerge(unittest.TestCase):
+    """Exercise the root-platformio.ini → synthesised-env flag bridge."""
+
+    def _write_root_ini(self, root: Path, body: str) -> None:
+        (root / "platformio.ini").write_text(body)
+
+    def test_missing_file_returns_empty(self) -> None:
+        with TemporaryDirectory() as tmp:
+            self.assertEqual(
+                get_root_platformio_build_flags("esp32c6", Path(tmp)),
+                [],
+            )
+
+    def test_no_matching_env_returns_empty(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self._write_root_ini(
+                root,
+                "[env:uno]\nplatform = atmelavr\nbuild_flags = -DUNO_ONLY\n",
+            )
+            self.assertEqual(
+                get_root_platformio_build_flags("esp32c6", root),
+                [],
+            )
+
+    def test_direct_build_flags_returned(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self._write_root_ini(
+                root,
+                """[env:esp32c6]
+platform = espressif32
+build_flags =
+    -D ARDUINO_USB_MODE=1
+    -D ARDUINO_USB_CDC_ON_BOOT=1
+    -D PIN_DATA=21
+""",
+            )
+            flags = get_root_platformio_build_flags("esp32c6", root)
+            self.assertIn("-D ARDUINO_USB_MODE=1", flags)
+            self.assertIn("-D ARDUINO_USB_CDC_ON_BOOT=1", flags)
+            self.assertIn("-D PIN_DATA=21", flags)
+
+    def test_extends_inheritance_is_resolved(self) -> None:
+        """A child env that ``extends`` a base env inherits the base's flags."""
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self._write_root_ini(
+                root,
+                """[env:generic-esp]
+platform = espressif32
+build_flags =
+    -DDEBUG
+    -DCORE_DEBUG_LEVEL=5
+
+[env:esp32c6]
+extends = env:generic-esp
+build_flags =
+    ${env:generic-esp.build_flags}
+    -D ARDUINO_USB_CDC_ON_BOOT=1
+""",
+            )
+            flags = get_root_platformio_build_flags("esp32c6", root)
+            # Base flags must appear...
+            self.assertIn("-DDEBUG", flags)
+            self.assertIn("-DCORE_DEBUG_LEVEL=5", flags)
+            # ...alongside the child's own additions.
+            self.assertIn("-D ARDUINO_USB_CDC_ON_BOOT=1", flags)
+
+    def test_malformed_file_returns_empty(self) -> None:
+        """A broken root ini must never block a build — it returns []."""
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            # Duplicate section + no header — configparser will raise.
+            self._write_root_ini(
+                root,
+                "= = = not actually ini = = =\n[env:esp32c6\nbuild_flags = -DX\n",
+            )
+            self.assertEqual(
+                get_root_platformio_build_flags("esp32c6", root),
+                [],
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #2664.

## Summary

`bash compile --backend platformio` synthesises a fresh PIO project at `.build/pio/<env>/platformio.ini` from `ci/boards.py` and was silently discarding `build_flags` declared in the user's root `platformio.ini`. Anyone editing `[env:<board>].build_flags` at the project root reasonably expects those flags to take effect; without this merge they silently vanish, producing subtle "flags work under fbuild but not under `--backend=platformio`" bugs (e.g. a missing ESP32-C6 USB-CDC routing flag → silent device, ~1h debug for the issue reporter).

## Option chosen: 1 (merge)

Per the issue's "Proposed fix" list, option 1 ("Merge root `[env:<board>].build_flags` into the synthesised PIO config") was straightforward to implement here because the codebase already has a `PlatformIOIni` parser (`ci/compiler/platformio_ini.py`) that resolves `extends =` and `${env:...}` substitutions. No need to rewrite the synthesizer or change Board semantics.

Option 2 (`extends = ../../../platformio.ini::env:<board>`) was rejected: the synthesised file is written under `.build/pio/<env>/` after package URLs have been rewritten to local `file://` paths, and a hard `extends` pointing at the original root file would re-introduce raw URLs and reorder cache optimisation. Option 3 (docs only) wasn't necessary because option 1 was small.

## Files changed

- **`ci/compiler/build_config.py`** — new module-level helper `get_root_platformio_build_flags(board_name, project_root)`. Reads the root `platformio.ini`, resolves inheritance via the existing `PlatformIOIni` parser, returns the matching env's `build_flags` (or `[]` for missing file / no match / parse error — never raises).
- **`ci/compiler/pio.py`** — `_init_platformio_build()` calls the helper and appends the returned flags onto the cloned board's `build_flags` right before `apply_board_specific_config()` writes the synthesised ini. This sits next to the existing `-Wl,-Map,…` and `-fopt-info-all=…` augmentation block, which is the canonical place build_flags are extended for the synthesised env.
- **`ci/tests/test_root_platformio_flag_merge.py`** — 5 unit tests covering: missing root file, no matching `[env:<board>]`, direct flags, `extends` + `${env:...}` substitution, malformed input.

## Ordering / precedence

Board flags first, root flags appended. PlatformIO's "last wins" semantics for repeated `-D` / linker flags mean the root file effectively overrides the Board — which is what the issue reporter expects, since they're editing the obvious file.

## Test plan

- [x] `uv run pytest ci/tests/test_root_platformio_flag_merge.py ci/tests/test_board_to_platformio_ini.py -v` → 8 passed
- [x] `bash lint` → all phases green (python_pipeline, cpp_linting, javascript_linting, meson_linting)
- [ ] Manual repro by issue reporter: add `-DSOME_FLAG=1` to `[env:esp32c6]` in root `platformio.ini`, run `bash compile esp32c6 --examples AutoResearch --backend platformio`, confirm `SOME_FLAG` appears in `.build/pio/esp32c6/platformio.ini` and in the compiled firmware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now specify custom build flags in the project's root `platformio.ini` configuration file, which will be properly resolved and merged during the build process.

* **Tests**
  * Added comprehensive test coverage for build flag merging scenarios, including inheritance resolution and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->