### PR TITLE
fix(channels): emit FL_ERROR when queued data has no enabled driver (Closes #2517)

### DIFF
--- a/src/fl/channels/channel.cpp.hpp
+++ b/src/fl/channels/channel.cpp.hpp
@@ -500,6 +500,48 @@ void Channel::showPixels(PixelController<RGB, 1, 0xFFFFFFFF> &pixels) {
 
 
 
+    // #2517: detect the silent-drop scenario before enqueuing — if the
+    // resolved driver is registered with ChannelManager but currently
+    // disabled (typically by `FastLED.setExclusiveDriver<OtherBus>()`),
+    // `ChannelManager::onEndFrame()` will skip its `show()` call and the
+    // frame is silently dropped on the floor. Emit an actionable
+    // FL_ERROR so users can diagnose the missing output.
+    //
+    // One-shot via `mDisabledDriverWarned` to avoid per-frame spam.
+    // Reset the latch whenever the driver returns to ENABLED so a later
+    // disable re-emits the diagnostic.
+    fl::string driverName = driver->getName();
+    auto status = ChannelManager::instance().driverStatus(driverName);
+    if (status == ChannelManager::DriverStatus::DISABLED) {
+        if (!mDisabledDriverWarned) {
+            const fl::string& exclusive =
+                ChannelManager::instance().exclusiveDriverName();
+            if (!exclusive.empty()) {
+                FL_ERROR("Channel '" << mName << "': bound driver '" << driverName
+                    << "' is currently DISABLED by exclusive-driver selection '"
+                    << exclusive << "'. Frame will be silently dropped. "
+                    << "Resolve with: FastLED.enableDrivers<fl::Bus::"
+                    << driverName << ">() or FastLED.enableAllDrivers().");
+            } else {
+                FL_ERROR("Channel '" << mName << "': bound driver '" << driverName
+                    << "' is currently DISABLED. Frame will be silently dropped. "
+                    << "Resolve with: FastLED.enableDrivers<fl::Bus::"
+                    << driverName << ">() or FastLED.enableAllDrivers().");
+            }
+            mDisabledDriverWarned = true;
+        }
+        // Skip the enqueue — the data wouldn't be sent anyway, and dropping
+        // it here matches the existing behaviour (rather than leaving stale
+        // bytes in the driver's pending queue across an enable/disable flip).
+        return;
+    } else if (status == ChannelManager::DriverStatus::ENABLED) {
+        // Reset the one-shot guard so a future disable re-emits the diagnostic.
+        mDisabledDriverWarned = false;
+    }
+    // NOT_REGISTERED: driver is not managed by ChannelManager (e.g. a custom
+    // test driver, or one that was removed). Fall through to enqueue and let
+    // the driver decide what to do — this is the historic behaviour.
+
     // Enqueue for transmission (will be sent when driver->show() is called)
     driver->enqueue(mChannelData);
     auto& events = ChannelEvents::instance();

--- a/src/fl/channels/channel.h
+++ b/src/fl/channels/channel.h
@@ -255,6 +255,12 @@ private:
                                      // named driver wasn't registered with ChannelManager).
                                      // Subsequent shows on the same channel skip the warn even
                                      // though the priority-dispatch fallback re-runs every frame.
+    bool mDisabledDriverWarned = false;  // One-shot guard for the #2517 FL_ERROR. Flipped on the
+                                         // first showPixels() that would have enqueued data to a
+                                         // driver disabled by `setExclusiveDriver(...)` (or
+                                         // `setDriverEnabled(name, false)`). Cleared whenever the
+                                         // resolved driver returns to ENABLED so a subsequent
+                                         // disable re-emits the diagnostic.
     const i32 mId;
     fl::string mName;               // User-specified or auto-generated name
     ChannelOptions mSettings;           // Per-channel settings (gamma, rgbw, etc.)

--- a/src/fl/channels/manager.cpp.hpp
+++ b/src/fl/channels/manager.cpp.hpp
@@ -259,6 +259,19 @@ bool ChannelManager::isDriverEnabled(const char* name) const {
     return false;
 }
 
+ChannelManager::DriverStatus ChannelManager::driverStatus(const fl::string& name) const {
+    if (name.empty()) {
+        return DriverStatus::NOT_REGISTERED;
+    }
+    for (const auto& entry : mDrivers) {
+        if (entry.name == name) {
+            return entry.enabled ? DriverStatus::ENABLED
+                                  : DriverStatus::DISABLED;
+        }
+    }
+    return DriverStatus::NOT_REGISTERED;
+}
+
 fl::size ChannelManager::getDriverCount() const {
     return mDrivers.size();
 }

--- a/src/fl/channels/manager.h
+++ b/src/fl/channels/manager.h
@@ -161,6 +161,28 @@ public:
     /// @return true if enabled, false if disabled or not registered
     bool isDriverEnabled(const char* name) const FL_NOEXCEPT;
 
+    /// @brief Registration status of a driver by name (silent lookup)
+    enum class DriverStatus {
+        NOT_REGISTERED,  ///< No driver with that name is registered
+        DISABLED,        ///< Driver is registered but disabled
+        ENABLED,         ///< Driver is registered and enabled
+    };
+
+    /// @brief Look up a driver's registration status without logging on miss.
+    /// @param name Driver name (case-sensitive)
+    /// @return DriverStatus tri-state (NOT_REGISTERED / DISABLED / ENABLED)
+    /// @note Companion to `findDriverByName()` — same silent-on-miss behavior.
+    ///       Used by `Channel::showPixels()` to detect the #2517 silent-drop
+    ///       case (enqueued data routed to a disabled / unregistered driver).
+    DriverStatus driverStatus(const fl::string& name) const FL_NOEXCEPT;
+
+    /// @brief Get the currently-active exclusive-driver selection (if any).
+    /// @return Driver name set via `setExclusiveDriver(...)`, or empty string
+    ///         if no exclusive mode is active.
+    /// @note Diagnostic accessor — used by the #2517 silent-drop FL_ERROR to
+    ///       name the current exclusive-driver setting in its remediation hint.
+    const fl::string& exclusiveDriverName() const FL_NOEXCEPT { return mExclusiveDriver; }
+
     /// @brief Get count of registered drivers (including unnamed ones)
     /// @return Total number of registered drivers
     fl::size getDriverCount() const FL_NOEXCEPT;

--- a/tests/fl/channels/channel.cpp
+++ b/tests/fl/channels/channel.cpp
@@ -468,3 +468,180 @@ FL_TEST_CASE("mBus miss to unregistered known Bus falls back and still renders")
 
     channel->removeFromDrawList();
 }
+
+// ============ #2517 Silent-drop diagnostic ============
+// When a channel's bound driver is disabled (typically by
+// `FastLED.setExclusiveDriver<OtherBus>()`) the previous behaviour was a
+// silent drop in `ChannelManager::onEndFrame()` — the driver still received
+// `enqueue()` calls, but the manager never called `show()` on a disabled
+// driver, so the frame was dropped on the floor with no diagnostic.
+//
+// After the fix, `Channel::showPixels()` short-circuits the enqueue and
+// emits one actionable FL_ERROR per (channel × disable-event), naming the
+// channel, the bound driver, the active exclusive-driver setting (if any),
+// and the `FastLED.enableDrivers<>()` / `FastLED.enableAllDrivers()`
+// remediation. Verification is behavioural — the project log macros don't
+// have a capture hook today, so each test asserts the enqueue did NOT land.
+
+namespace {
+
+/// Minimal fake driver — records every enqueue call so the test can assert
+/// whether a frame was actually queued or silently dropped at the manager
+/// layer.
+class CountingFakeDriver : public IChannelDriver {
+public:
+    explicit CountingFakeDriver(const char* name) : mName(name) {}
+
+    int enqueueCount = 0;
+    int showCount = 0;
+
+    bool canHandle(const ChannelDataPtr& data) const override {
+        (void)data;
+        return true;
+    }
+
+    void enqueue(ChannelDataPtr channelData) override {
+        (void)channelData;
+        ++enqueueCount;
+    }
+
+    void show() override {
+        ++showCount;
+    }
+
+    DriverState poll() override {
+        return DriverState::READY;
+    }
+
+    fl::string getName() const override { return mName; }
+
+    Capabilities getCapabilities() const override {
+        return Capabilities(true, true);
+    }
+
+private:
+    fl::string mName;
+};
+
+/// Minimal WS2812 ChannelConfig on pin 7 with 4 LEDs.
+ChannelConfig makeSilentDropTestConfig(fl::span<CRGB> leds) {
+    auto timing = makeTimingConfig<TIMING_WS2812_800KHZ>();
+    return ChannelConfig(7, timing, leds, RGB);
+}
+
+}  // namespace
+
+FL_TEST_CASE("[#2517] Disabled driver: enqueue is suppressed (would-be silent drop)") {
+    auto& mgr = freshBusTestManager();
+    FL_REQUIRE(mgr.getDriverCount() == 0);
+
+    // Register a fake "PARLIO_TEST" driver — this is the only enabled driver,
+    // so the priority-dispatch path picks it on the first showLeds() call.
+    auto fakeDriver = fl::make_shared<CountingFakeDriver>("PARLIO_TEST");
+    mgr.addDriver(9000, fakeDriver);
+    FL_REQUIRE(mgr.driverStatus(fl::string::from_literal("PARLIO_TEST"))
+               == ChannelManager::DriverStatus::ENABLED);
+
+    CRGB leds[4] = {};
+    auto channel = Channel::create(makeSilentDropTestConfig(fl::span<CRGB>(leds, 4)));
+    FL_REQUIRE(channel != nullptr);
+
+    auto cleanup = fl::make_scope_exit([&]() {
+        channel->removeFromDrawList();
+        mgr.clearAllDrivers();
+    });
+
+    channel->addToDrawList();
+
+    // Frame 1: happy path — driver is enabled, enqueue should land.
+    channel->showLeds(0);
+    FL_CHECK_EQ(fakeDriver->enqueueCount, 1);
+
+    // Now disable PARLIO_TEST exclusively in favor of a name that isn't
+    // registered. All drivers (including PARLIO_TEST) become DISABLED, but
+    // the channel still holds a strong reference to the previously-bound
+    // driver via its cached `mDriver` weak_ptr being valid.
+    mgr.setExclusiveDriverByName("DOES_NOT_EXIST");
+    FL_CHECK(mgr.driverStatus(fl::string::from_literal("PARLIO_TEST"))
+             == ChannelManager::DriverStatus::DISABLED);
+    FL_CHECK_EQ(mgr.exclusiveDriverName(),
+                fl::string::from_literal("DOES_NOT_EXIST"));
+
+    // Frame 2: this used to be the silent drop. After the #2517 fix:
+    //   (a) Channel::showPixels emits FL_ERROR (visible in test output), and
+    //   (b) skips the driver->enqueue() call — so enqueueCount stays at 1.
+    channel->showLeds(0);
+    FL_CHECK_EQ(fakeDriver->enqueueCount, 1);
+
+    // Frame 3: one-shot guard suppresses duplicate per-frame FL_ERROR, but
+    // enqueue is still suppressed — the data still wouldn't be transmitted.
+    channel->showLeds(0);
+    FL_CHECK_EQ(fakeDriver->enqueueCount, 1);
+}
+
+FL_TEST_CASE("[#2517] Normal flush path does NOT trigger the silent-drop FL_ERROR") {
+    auto& mgr = freshBusTestManager();
+    FL_REQUIRE(mgr.getDriverCount() == 0);
+
+    auto fakeDriver = fl::make_shared<CountingFakeDriver>("HAPPY_DRIVER");
+    mgr.addDriver(9000, fakeDriver);
+
+    CRGB leds[4] = {};
+    auto channel = Channel::create(makeSilentDropTestConfig(fl::span<CRGB>(leds, 4)));
+    FL_REQUIRE(channel != nullptr);
+
+    auto cleanup = fl::make_scope_exit([&]() {
+        channel->removeFromDrawList();
+        mgr.clearAllDrivers();
+    });
+
+    channel->addToDrawList();
+
+    // Multiple consecutive happy-path frames — driver stays ENABLED, every
+    // enqueue lands. Behavioural proxy for "no extra FL_ERROR fires": each
+    // frame is faithfully delivered to the driver.
+    channel->showLeds(0);
+    channel->showLeds(0);
+    channel->showLeds(0);
+    FL_CHECK_EQ(fakeDriver->enqueueCount, 3);
+}
+
+FL_TEST_CASE("[#2517] Re-enabling the driver resumes enqueue and re-arms the latch") {
+    auto& mgr = freshBusTestManager();
+    FL_REQUIRE(mgr.getDriverCount() == 0);
+
+    auto fakeDriver = fl::make_shared<CountingFakeDriver>("RECOVERY_DRIVER");
+    mgr.addDriver(9000, fakeDriver);
+
+    CRGB leds[4] = {};
+    auto channel = Channel::create(makeSilentDropTestConfig(fl::span<CRGB>(leds, 4)));
+    FL_REQUIRE(channel != nullptr);
+
+    auto cleanup = fl::make_scope_exit([&]() {
+        channel->removeFromDrawList();
+        mgr.clearAllDrivers();
+    });
+
+    channel->addToDrawList();
+
+    // Happy frame: enqueue lands.
+    channel->showLeds(0);
+    FL_CHECK_EQ(fakeDriver->enqueueCount, 1);
+
+    // Disable: subsequent frame is suppressed.
+    mgr.setDriverEnabled("RECOVERY_DRIVER", false);
+    channel->showLeds(0);
+    FL_CHECK_EQ(fakeDriver->enqueueCount, 1);
+
+    // Re-enable: enqueue resumes.
+    mgr.setDriverEnabled("RECOVERY_DRIVER", true);
+    channel->showLeds(0);
+    FL_CHECK_EQ(fakeDriver->enqueueCount, 2);
+
+    // Disable a second time — the one-shot latch should have been cleared by
+    // the intervening ENABLED frame, so the diagnostic re-arms (we can't
+    // observe the FL_ERROR directly, but the enqueue is still suppressed).
+    mgr.setDriverEnabled("RECOVERY_DRIVER", false);
+    channel->showLeds(0);
+    FL_CHECK_EQ(fakeDriver->enqueueCount, 2);
+}


### PR DESCRIPTION
Closes #2517

## Silent-failure scenario

Before this change, a channel whose bound driver got disabled at runtime
(typically by `FastLED.setExclusiveDriver<OtherBus>()` or
`setDriverEnabled(name, false)`) would still call `driver->enqueue()` every
frame — but `ChannelManager::onEndFrame()` only iterates **enabled** drivers
when invoking `show()`, so the queued bytes were dropped on the floor with
no diagnostic. This is the silent-failure mode the ESP32-P4 PARLIO
no-output bug (#2515) surfaced.

## What changed

- `src/fl/channels/manager.{h,cpp.hpp}` — added two diagnostic accessors:
  - `ChannelManager::driverStatus(name)` returns a tri-state
    `NOT_REGISTERED` / `DISABLED` / `ENABLED` with **no logging on miss**
    (companion to the existing `findDriverByName()` silent lookup).
  - `ChannelManager::exclusiveDriverName()` returns the current
    `setExclusiveDriver(...)` selection (or empty if none).
- `src/fl/channels/channel.{h,cpp.hpp}` — `Channel::showPixels()` now
  consults `driverStatus()` immediately before `driver->enqueue()`:
  - `DISABLED` → emit one-shot `FL_ERROR` naming the channel, the bound
    driver, the active exclusive-driver setting, and the
    `FastLED.enableDrivers<>()` / `FastLED.enableAllDrivers()`
    remediation, then skip the enqueue (data would not transmit anyway).
  - `ENABLED` → clear the one-shot latch (so a later disable re-emits the
    diagnostic), then enqueue as before.
  - `NOT_REGISTERED` → enqueue as before (preserves behaviour for custom
    drivers that bypass the manager).
- New `Channel::mDisabledDriverWarned` latch prevents per-frame log spam —
  the FL_ERROR fires once per channel times disable event.

## Tests added

Three regression tests in `tests/fl/channels/channel.cpp`:

- `[#2517] Disabled driver: enqueue is suppressed (would-be silent drop)` —
  reproduces the issue scenario verbatim: enqueue → `setExclusiveDriverByName("DOES_NOT_EXIST")` → enqueue is suppressed.
- `[#2517] Normal flush path does NOT trigger the silent-drop FL_ERROR` —
  three consecutive happy-path frames, all enqueue (regression guard for
  the "must not trigger on success" acceptance criterion).
- `[#2517] Re-enabling the driver resumes enqueue and re-arms the latch` —
  covers the disable → enable → disable cycle so the one-shot latch is
  proven to be re-armable.

Verification is behavioural — the project log macros don't have a capture
sink today, so each test asserts the fake driver's enqueue counter stops
growing on disable and resumes on enable.

## Test plan

- [x] `bash lint` — passes (cpp + js + python)
- [x] `bash test channel --cpp` — passes (includes the 3 new cases)
- [x] `bash test channel_manager --cpp` — passes (regression guard)
- [x] `bash test --cpp` — 309/309 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Prevented silent frame drops by implementing error diagnostics when drivers are disabled—users now receive actionable error messages instead of experiencing unexplained frame loss.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->