### PR TITLE
chore(ci): add bash clean-worktrees helper + stop-hook nudge

### DIFF
--- a/ci/clean-worktrees.py
+++ b/ci/clean-worktrees.py
@@ -1,0 +1,323 @@
+#!/usr/bin/env python3
+"""Clean up stale agent worktrees under .claude/worktrees/.
+
+Sub-agents dispatched with isolation=worktree create directories under
+``.claude/worktrees/agent-*`` (or other names). Stale worktrees accumulate
+when ``git worktree remove --force`` fails on Windows because files inside
+``.git/`` are marked read-only. This helper:
+
+  - Lists worktrees under ``.claude/worktrees/``
+  - Classifies each as safe (no uncommitted changes, no unpushed commits) or
+    unsafe (would lose work)
+  - Removes safe worktrees, with a Windows fallback that clears the read-only
+    attribute then retries, and a final fallback to ``clud trash --cross-volume``
+  - Runs ``git worktree prune`` to clear stale admin entries
+  - Prints a one-line summary
+
+See FastLED issue #2610.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import stat
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+WORKTREES_DIR = PROJECT_ROOT / ".claude" / "worktrees"
+
+
+@dataclass
+class WorktreeStatus:
+    path: Path
+    safe: bool
+    reason: str  # human-readable explanation of classification
+
+
+@dataclass
+class RemovalResult:
+    path: Path
+    removed: bool
+    method: str  # "git", "git+chmod", "clud-trash", or "skipped"
+    error: str  # empty on success
+
+
+def run_git(
+    args: list[str], cwd: Path | None = None
+) -> subprocess.CompletedProcess[str]:
+    """Run a git command and return the completed process (no raise)."""
+    return subprocess.run(
+        ["git", *args],
+        cwd=str(cwd) if cwd else None,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+    )
+
+
+def directory_size_bytes(path: Path) -> int:
+    """Return total size of files under ``path`` in bytes (best-effort)."""
+    total = 0
+    try:
+        for root, _dirs, files in os.walk(path, followlinks=False):
+            for name in files:
+                fp = Path(root) / name
+                try:
+                    total += fp.stat().st_size
+                except KeyboardInterrupt:
+                    raise
+                except OSError:
+                    # Permission denied, broken symlink, race -- ignore.
+                    continue
+    except KeyboardInterrupt:
+        raise
+    except OSError:
+        pass
+    return total
+
+
+def format_bytes(n: int) -> str:
+    units = ["B", "KB", "MB", "GB", "TB"]
+    size = float(n)
+    for unit in units:
+        if size < 1024 or unit == units[-1]:
+            return f"{size:.1f} {unit}" if unit != "B" else f"{int(size)} {unit}"
+        size /= 1024
+    return f"{n} B"
+
+
+def classify_worktree(wt: Path) -> WorktreeStatus:
+    """Decide whether ``wt`` is safe to delete.
+
+    A worktree is safe iff:
+      - It is a real git working tree (has a ``.git`` file/dir)
+      - ``git status --porcelain`` is empty (no uncommitted changes)
+      - ``git log @{upstream}.. --oneline`` is empty (no unpushed commits),
+        OR there is no upstream and the branch has no commits beyond
+        ``origin/master``.
+
+    A worktree is treated as safe (no work to lose) if it's an orphan
+    directory with no ``.git`` link — those are leftover empty dirs from
+    failed prior cleanups.
+    """
+    if not (wt / ".git").exists():
+        return WorktreeStatus(path=wt, safe=True, reason="orphan directory (no .git)")
+
+    status = run_git(["status", "--porcelain"], cwd=wt)
+    if status.returncode != 0:
+        return WorktreeStatus(
+            path=wt,
+            safe=False,
+            reason=f"git status failed: {status.stderr.strip() or status.stdout.strip()}",
+        )
+    if status.stdout.strip():
+        return WorktreeStatus(path=wt, safe=False, reason="uncommitted changes")
+
+    # Check unpushed commits. Try upstream first.
+    upstream = run_git(["log", "@{upstream}..", "--oneline"], cwd=wt)
+    if upstream.returncode == 0:
+        if upstream.stdout.strip():
+            return WorktreeStatus(
+                path=wt, safe=False, reason="unpushed commits vs upstream"
+            )
+        return WorktreeStatus(path=wt, safe=True, reason="clean, in sync with upstream")
+
+    # No upstream — compare against origin/master.
+    fallback = run_git(["log", "origin/master..", "--oneline"], cwd=wt)
+    if fallback.returncode != 0:
+        return WorktreeStatus(
+            path=wt,
+            safe=False,
+            reason="no upstream and cannot compare to origin/master",
+        )
+    if fallback.stdout.strip():
+        return WorktreeStatus(
+            path=wt,
+            safe=False,
+            reason="no upstream and has commits beyond origin/master",
+        )
+    return WorktreeStatus(
+        path=wt, safe=True, reason="clean, no commits beyond origin/master"
+    )
+
+
+def clear_readonly(path: Path) -> None:
+    """Clear the read-only bit on every file under ``path``.
+
+    Equivalent to ``chmod -R u+w`` on POSIX, and clears the Windows
+    ReadOnly attribute by adding write permission to every file's mode.
+    """
+    for root, dirs, files in os.walk(path, followlinks=False):
+        for name in dirs + files:
+            fp = Path(root) / name
+            try:
+                current = fp.lstat().st_mode
+                os.chmod(fp, current | stat.S_IWUSR)
+            except KeyboardInterrupt:
+                raise
+            except OSError:
+                continue
+
+
+def remove_worktree(wt: Path) -> RemovalResult:
+    """Remove ``wt`` using the three-step Windows-safe strategy."""
+    # Step 1: plain git worktree remove --force
+    first = run_git(["worktree", "remove", "--force", str(wt)], cwd=PROJECT_ROOT)
+    if first.returncode == 0 and not wt.exists():
+        return RemovalResult(path=wt, removed=True, method="git", error="")
+
+    # Step 2: clear read-only attrs, retry
+    if wt.exists():
+        clear_readonly(wt)
+    second = run_git(["worktree", "remove", "--force", str(wt)], cwd=PROJECT_ROOT)
+    if second.returncode == 0 and not wt.exists():
+        return RemovalResult(path=wt, removed=True, method="git+chmod", error="")
+
+    # If git removed the admin entry but the directory remains, fall through
+    # to manual deletion / clud trash.
+    rmtree_error = ""
+    if wt.exists():
+        try:
+            shutil.rmtree(wt, ignore_errors=False, onerror=_rmtree_onerror)
+        except KeyboardInterrupt:
+            raise
+        except OSError as exc:
+            rmtree_error = str(exc)
+        if not wt.exists():
+            run_git(["worktree", "prune"], cwd=PROJECT_ROOT)
+            return RemovalResult(path=wt, removed=True, method="git+rmtree", error="")
+
+    # Step 3: clud trash as last-resort quarantine
+    clud = shutil.which("clud")
+    if clud is None:
+        err = rmtree_error or (second.stderr.strip() or first.stderr.strip())
+        return RemovalResult(
+            path=wt,
+            removed=False,
+            method="failed",
+            error=f"git remove failed and clud not on PATH: {err}",
+        )
+    trash = subprocess.run(
+        [clud, "trash", "--cross-volume", str(wt)],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+    )
+    if trash.returncode == 0:
+        run_git(["worktree", "prune"], cwd=PROJECT_ROOT)
+        return RemovalResult(path=wt, removed=True, method="clud-trash", error="")
+
+    return RemovalResult(
+        path=wt,
+        removed=False,
+        method="failed",
+        error=f"clud trash failed: {trash.stderr.strip() or trash.stdout.strip()}",
+    )
+
+
+def _rmtree_onerror(func, path, exc_info) -> None:  # type: ignore[no-untyped-def]
+    """shutil.rmtree onerror callback: clear read-only and retry once."""
+    try:
+        os.chmod(path, stat.S_IWUSR | stat.S_IRUSR)
+        func(path)
+    except KeyboardInterrupt:
+        raise
+    except OSError:
+        # Let the outer rmtree re-raise on subsequent attempts.
+        pass
+
+
+def list_worktree_paths() -> list[Path]:
+    """Return sorted list of immediate child directories under WORKTREES_DIR."""
+    if not WORKTREES_DIR.exists():
+        return []
+    return sorted(
+        p for p in WORKTREES_DIR.iterdir() if p.is_dir() and not p.is_symlink()
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Clean up stale agent worktrees under .claude/worktrees/",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="List worktrees and their safety status without removing anything.",
+    )
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        help="Remove every worktree, including unsafe ones (dangerous).",
+    )
+    args = parser.parse_args(argv)
+
+    paths = list_worktree_paths()
+    if not paths:
+        print(f"No worktrees found under {WORKTREES_DIR}")
+        return 0
+
+    classifications = [classify_worktree(p) for p in paths]
+    removed = 0
+    skipped = 0
+    failed = 0
+    reclaimed = 0
+
+    for cls in classifications:
+        size = directory_size_bytes(cls.path)
+        target = cls.safe or args.all
+        prefix = "[dry-run] " if args.dry_run else ""
+        action = "REMOVE" if target else "SKIP"
+        print(
+            f"{prefix}{action:6} {cls.path.name:40} "
+            f"({format_bytes(size):>10})  {cls.reason}"
+        )
+
+        if not target:
+            skipped += 1
+            continue
+        if args.dry_run:
+            continue
+
+        result = remove_worktree(cls.path)
+        if result.removed:
+            removed += 1
+            reclaimed += size
+            print(f"         removed via {result.method}")
+        else:
+            failed += 1
+            print(f"         FAILED: {result.error}", file=sys.stderr)
+
+    # Always prune admin entries at the end (cheap and harmless).
+    if not args.dry_run:
+        run_git(["worktree", "prune"], cwd=PROJECT_ROOT)
+
+    summary = (
+        f"\n{removed} removed, {skipped} skipped (unsafe)"
+        f", {format_bytes(reclaimed)} reclaimed"
+    )
+    if failed:
+        summary += f", {failed} failed"
+    if args.dry_run:
+        summary = "\n[dry-run] " + summary.lstrip()
+    print(summary)
+
+    return 0 if failed == 0 else 1
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except KeyboardInterrupt:
+        print("interrupted", file=sys.stderr)
+        sys.exit(130)

--- a/ci/clean-worktrees.py
+++ b/ci/clean-worktrees.py
@@ -27,6 +27,10 @@ import subprocess
 import sys
 from dataclasses import dataclass
 from pathlib import Path
+from types import TracebackType
+from typing import Any, Callable
+
+from ci.util.global_interrupt_handler import handle_keyboard_interrupt
 
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
@@ -48,9 +52,7 @@ class RemovalResult:
     error: str  # empty on success
 
 
-def run_git(
-    args: list[str], cwd: Path | None = None
-) -> subprocess.CompletedProcess[str]:
+def run_git(args: list[str], cwd: Path | None) -> subprocess.CompletedProcess[str]:
     """Run a git command and return the completed process (no raise)."""
     return subprocess.run(
         ["git", *args],
@@ -72,12 +74,14 @@ def directory_size_bytes(path: Path) -> int:
                 fp = Path(root) / name
                 try:
                     total += fp.stat().st_size
-                except KeyboardInterrupt:
+                except KeyboardInterrupt as ki:
+                    handle_keyboard_interrupt(ki)
                     raise
                 except OSError:
                     # Permission denied, broken symlink, race -- ignore.
                     continue
-    except KeyboardInterrupt:
+    except KeyboardInterrupt as ki:
+        handle_keyboard_interrupt(ki)
         raise
     except OSError:
         pass
@@ -161,7 +165,8 @@ def clear_readonly(path: Path) -> None:
             try:
                 current = fp.lstat().st_mode
                 os.chmod(fp, current | stat.S_IWUSR)
-            except KeyboardInterrupt:
+            except KeyboardInterrupt as ki:
+                handle_keyboard_interrupt(ki)
                 raise
             except OSError:
                 continue
@@ -187,7 +192,8 @@ def remove_worktree(wt: Path) -> RemovalResult:
     if wt.exists():
         try:
             shutil.rmtree(wt, ignore_errors=False, onerror=_rmtree_onerror)
-        except KeyboardInterrupt:
+        except KeyboardInterrupt as ki:
+            handle_keyboard_interrupt(ki)
             raise
         except OSError as exc:
             rmtree_error = str(exc)
@@ -225,12 +231,17 @@ def remove_worktree(wt: Path) -> RemovalResult:
     )
 
 
-def _rmtree_onerror(func, path, exc_info) -> None:  # type: ignore[no-untyped-def]
+def _rmtree_onerror(
+    func: Callable[..., Any],
+    path: str,
+    exc_info: tuple[type[BaseException], BaseException, TracebackType],
+) -> None:
     """shutil.rmtree onerror callback: clear read-only and retry once."""
     try:
         os.chmod(path, stat.S_IWUSR | stat.S_IRUSR)
         func(path)
-    except KeyboardInterrupt:
+    except KeyboardInterrupt as ki:
+        handle_keyboard_interrupt(ki)
         raise
     except OSError:
         # Let the outer rmtree re-raise on subsequent attempts.
@@ -241,9 +252,11 @@ def list_worktree_paths() -> list[Path]:
     """Return sorted list of immediate child directories under WORKTREES_DIR."""
     if not WORKTREES_DIR.exists():
         return []
-    return sorted(
-        p for p in WORKTREES_DIR.iterdir() if p.is_dir() and not p.is_symlink()
-    )
+    paths: list[Path] = []
+    for p in WORKTREES_DIR.iterdir():
+        if p.is_dir() and not p.is_symlink():
+            paths.append(p)
+    return sorted(paths)
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -267,7 +280,9 @@ def main(argv: list[str] | None = None) -> int:
         print(f"No worktrees found under {WORKTREES_DIR}")
         return 0
 
-    classifications = [classify_worktree(p) for p in paths]
+    classifications: list[WorktreeStatus] = []
+    for p in paths:
+        classifications.append(classify_worktree(p))
     removed = 0
     skipped = 0
     failed = 0
@@ -318,6 +333,7 @@ def main(argv: list[str] | None = None) -> int:
 if __name__ == "__main__":
     try:
         sys.exit(main())
-    except KeyboardInterrupt:
+    except KeyboardInterrupt as ki:
+        handle_keyboard_interrupt(ki)
         print("interrupted", file=sys.stderr)
         sys.exit(130)

--- a/ci/hooks/check-on-stop.py
+++ b/ci/hooks/check-on-stop.py
@@ -127,21 +127,46 @@ def should_skip_hook() -> bool:
 
 
 def count_stale_worktrees() -> int:
-    """Count directories under .claude/worktrees/ (best-effort, never raises)."""
+    """Count directories under .claude/worktrees/.
+
+    Iterates with an explicit loop so failures surface a descriptive error
+    on stderr (per coding-standards "no silent fallbacks") while still
+    keeping the stop-hook itself non-fatal — the loop body propagates the
+    underlying OSError up.
+    """
     if not WORKTREES_DIR.exists():
         return 0
     try:
-        return sum(
-            1 for p in WORKTREES_DIR.iterdir() if p.is_dir() and not p.is_symlink()
-        )
+        iterator = WORKTREES_DIR.iterdir()
     except KeyboardInterrupt:
+        import _thread
+
+        _thread.interrupt_main()
         raise
-    except OSError:
-        return 0
+    except OSError as exc:
+        raise OSError(
+            f"count_stale_worktrees: cannot iterate {WORKTREES_DIR}: {exc}"
+        ) from exc
+    count = 0
+    for p in iterator:
+        if p.is_dir() and not p.is_symlink():
+            count += 1
+    return count
 
 
 def warn_stale_worktrees() -> None:
-    n = count_stale_worktrees()
+    try:
+        n = count_stale_worktrees()
+    except KeyboardInterrupt:
+        import _thread
+
+        _thread.interrupt_main()
+        raise
+    except OSError as exc:
+        # Don't crash the stop hook on a directory-scan failure, but do
+        # surface the descriptive error so it isn't silently swallowed.
+        print(f"warn_stale_worktrees: {exc}", file=sys.stderr)
+        return
     if n > STALE_WORKTREE_THRESHOLD:
         print(
             f"Note: {n} stale agent worktrees in .claude/worktrees/, "

--- a/ci/hooks/check-on-stop.py
+++ b/ci/hooks/check-on-stop.py
@@ -25,6 +25,8 @@ from pathlib import Path
 SCRIPT_DIR = Path(__file__).parent.resolve()
 PROJECT_ROOT = SCRIPT_DIR.parent.parent
 SESSION_FINGERPRINT_FILE = PROJECT_ROOT / ".cache" / "session_fingerprint.json"
+WORKTREES_DIR = PROJECT_ROOT / ".claude" / "worktrees"
+STALE_WORKTREE_THRESHOLD = 5
 
 
 @dataclass
@@ -124,11 +126,36 @@ def should_skip_hook() -> bool:
     return False
 
 
+def count_stale_worktrees() -> int:
+    """Count directories under .claude/worktrees/ (best-effort, never raises)."""
+    if not WORKTREES_DIR.exists():
+        return 0
+    try:
+        return sum(
+            1 for p in WORKTREES_DIR.iterdir() if p.is_dir() and not p.is_symlink()
+        )
+    except KeyboardInterrupt:
+        raise
+    except OSError:
+        return 0
+
+
+def warn_stale_worktrees() -> None:
+    n = count_stale_worktrees()
+    if n > STALE_WORKTREE_THRESHOLD:
+        print(
+            f"Note: {n} stale agent worktrees in .claude/worktrees/, "
+            "run `bash clean-worktrees` to reclaim space",
+            file=sys.stderr,
+        )
+
+
 def main() -> int:
     if should_skip_hook():
         print(
             "⏭️  Skipping lint+tests (no changes during this session)", file=sys.stderr
         )
+        warn_stale_worktrees()
         return 0
 
     print("🔧 Running lint and tests (changes detected this session)", file=sys.stderr)
@@ -177,6 +204,7 @@ def main() -> int:
             "\nREMINDER - FIX ALL ERRORS FROM STOP HOOK, MAKE AT LEAST TWO ATTEMPTS!",
             file=sys.stderr,
         )
+        warn_stale_worktrees()
         return 2
 
     # Lint passed — wait for tests
@@ -217,8 +245,10 @@ def main() -> int:
             "\nREMINDER - FIX ALL ERRORS FROM STOP HOOK, MAKE AT LEAST TWO ATTEMPTS!",
             file=sys.stderr,
         )
+        warn_stale_worktrees()
         return 2
 
+    warn_stale_worktrees()
     return 0
 
 

--- a/ci/tests/test_clean_worktrees.py
+++ b/ci/tests/test_clean_worktrees.py
@@ -8,12 +8,14 @@ unpushed commits.
 import importlib.util
 import os
 import subprocess
+import sys
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from types import ModuleType
 
 
-def _load_helper():
+def _load_helper() -> ModuleType:
     """Load ci/clean-worktrees.py as a module (filename contains a hyphen)."""
     project_root = Path(__file__).resolve().parent.parent.parent
     src = project_root / "ci" / "clean-worktrees.py"
@@ -21,8 +23,6 @@ def _load_helper():
     assert spec and spec.loader
     mod = importlib.util.module_from_spec(spec)
     # Make the module discoverable by sys.modules so dataclass works.
-    import sys
-
     sys.modules[spec.name] = mod
     spec.loader.exec_module(mod)
     return mod
@@ -56,6 +56,11 @@ class TestClassifyWorktree(unittest.TestCase):
                 p = Path(root) / name
                 try:
                     p.chmod(0o700)
+                except KeyboardInterrupt:
+                    import _thread
+
+                    _thread.interrupt_main()
+                    raise
                 except OSError:
                     pass
         self._tmp.cleanup()

--- a/ci/tests/test_clean_worktrees.py
+++ b/ci/tests/test_clean_worktrees.py
@@ -1,0 +1,149 @@
+"""Tests for ci/clean-worktrees.py safety classification.
+
+Exercises classify_worktree() against a freshly-created git repo so we can
+verify the helper does not delete worktrees with uncommitted changes or
+unpushed commits.
+"""
+
+import importlib.util
+import os
+import subprocess
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+
+def _load_helper():
+    """Load ci/clean-worktrees.py as a module (filename contains a hyphen)."""
+    project_root = Path(__file__).resolve().parent.parent.parent
+    src = project_root / "ci" / "clean-worktrees.py"
+    spec = importlib.util.spec_from_file_location("_clean_worktrees", src)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    # Make the module discoverable by sys.modules so dataclass works.
+    import sys
+
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _git(args: list[str], cwd: Path) -> str:
+    return subprocess.check_output(
+        ["git", *args], cwd=str(cwd), text=True, encoding="utf-8", errors="replace"
+    )
+
+
+def _init_repo(root: Path) -> None:
+    _git(["init", "--initial-branch=master"], root)
+    _git(["config", "user.email", "test@example.com"], root)
+    _git(["config", "user.name", "Test"], root)
+    (root / "README.md").write_text("hi\n")
+    _git(["add", "README.md"], root)
+    _git(["commit", "-m", "init"], root)
+
+
+class TestClassifyWorktree(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = TemporaryDirectory()
+        self.tmp = Path(self._tmp.name)
+        self.helper = _load_helper()
+
+    def tearDown(self) -> None:
+        # On Windows, .git often has read-only objects. Clear them first.
+        for root, dirs, files in os.walk(self.tmp):
+            for name in dirs + files:
+                p = Path(root) / name
+                try:
+                    p.chmod(0o700)
+                except OSError:
+                    pass
+        self._tmp.cleanup()
+
+    def test_orphan_directory_is_safe(self) -> None:
+        orphan = self.tmp / "orphan"
+        orphan.mkdir()
+        status = self.helper.classify_worktree(orphan)
+        self.assertTrue(status.safe)
+        self.assertIn("orphan", status.reason)
+
+    def test_clean_worktree_no_upstream_no_origin_is_unsafe(self) -> None:
+        # Without origin/master to compare against, the helper has no way to
+        # prove the branch has no extra commits — must err on the side of
+        # safety and refuse to delete.
+        parent = self.tmp / "parent"
+        parent.mkdir()
+        _init_repo(parent)
+        wt_path = self.tmp / "wt-clean"
+        _git(["worktree", "add", "-b", "feature", str(wt_path)], parent)
+
+        status = self.helper.classify_worktree(wt_path)
+        self.assertFalse(status.safe)
+        self.assertIn("origin/master", status.reason)
+
+    def test_clean_worktree_with_upstream_is_safe(self) -> None:
+        # Build a parent repo, add a fake origin remote pointing to a bare
+        # clone, push, and create a worktree that tracks the upstream.
+        parent = self.tmp / "parent"
+        parent.mkdir()
+        _init_repo(parent)
+        origin = self.tmp / "origin.git"
+        subprocess.check_call(
+            ["git", "init", "--bare", str(origin)],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        _git(["remote", "add", "origin", str(origin)], parent)
+        _git(["push", "-u", "origin", "master"], parent)
+        wt_path = self.tmp / "wt-tracking"
+        _git(
+            ["worktree", "add", "--track", "-b", "feature", str(wt_path), "master"],
+            parent,
+        )
+        # Set upstream for the new branch.
+        _git(["push", "-u", "origin", "feature"], wt_path)
+
+        status = self.helper.classify_worktree(wt_path)
+        self.assertTrue(
+            status.safe, f"expected safe, got unsafe: reason={status.reason!r}"
+        )
+
+    def test_uncommitted_changes_is_unsafe(self) -> None:
+        parent = self.tmp / "parent"
+        parent.mkdir()
+        _init_repo(parent)
+        wt_path = self.tmp / "wt-dirty"
+        _git(["worktree", "add", "-b", "feature", str(wt_path)], parent)
+        (wt_path / "NEW.txt").write_text("dirty\n")
+
+        status = self.helper.classify_worktree(wt_path)
+        self.assertFalse(status.safe)
+        self.assertIn("uncommitted", status.reason)
+
+    def test_unpushed_commits_no_upstream_is_unsafe(self) -> None:
+        parent = self.tmp / "parent"
+        parent.mkdir()
+        _init_repo(parent)
+        wt_path = self.tmp / "wt-unpushed"
+        _git(["worktree", "add", "-b", "feature", str(wt_path)], parent)
+        # Create a commit beyond origin/master. There is no origin in this
+        # test repo, so classify_worktree should treat that as unsafe.
+        (wt_path / "f.txt").write_text("x\n")
+        _git(["add", "f.txt"], wt_path)
+        _git(["commit", "-m", "extra"], wt_path)
+
+        status = self.helper.classify_worktree(wt_path)
+        self.assertFalse(status.safe)
+
+
+class TestFormatBytes(unittest.TestCase):
+    def test_bytes(self) -> None:
+        helper = _load_helper()
+        self.assertEqual(helper.format_bytes(0), "0 B")
+        self.assertEqual(helper.format_bytes(512), "512 B")
+        self.assertTrue(helper.format_bytes(2048).endswith(" KB"))
+        self.assertTrue(helper.format_bytes(5 * 1024 * 1024).endswith(" MB"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/clean-worktrees
+++ b/clean-worktrees
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+cd "$(dirname "$0")"
+uv run ci/clean-worktrees.py "$@"


### PR DESCRIPTION
## Summary

Adds a Windows-safe cleanup helper for stale agent worktrees under `.claude/worktrees/` plus a stop-hook reminder when they accumulate. Addresses asks 2 and 3 in #2610.

Closes #2610

## What was added

- **`ci/clean-worktrees.py`** — classifies each worktree under `.claude/worktrees/` as *safe* (no uncommitted changes, no unpushed commits) or *unsafe*, then removes safe ones with a three-step strategy:
  1. plain `git worktree remove --force`
  2. on Windows failure (`Invalid argument` from read-only `.git/` objects): clear the read-only attribute on every file (`chmod -R u+w` equivalent that works on Windows), then retry
  3. last-resort fallback: `clud trash --cross-volume` (quarantine via the `clud trash` daemon, per `clud-windows-trash` skill)

  Always runs `git worktree prune` at the end. Flags: `--dry-run`, `--all`.

- **`clean-worktrees`** — thin shell wrapper exposing `bash clean-worktrees` alongside `bash test`, `bash lint`, etc.

- **`ci/hooks/check-on-stop.py`** — when more than 5 stale worktrees exist, emits a one-line nudge to stderr: `Note: <N> stale agent worktrees in .claude/worktrees/, run `bash clean-worktrees` to reclaim space`. Fires on all three exit paths (lint-fail, test-fail, success).

- **`ci/tests/test_clean_worktrees.py`** — covers the safety classification logic (orphan dir, uncommitted changes, unpushed commits without upstream, clean tree with upstream) against real temporary git repos.

## Manual smoke test (this Windows box)

```
$ bash clean-worktrees --dry-run
[dry-run] SKIP   chore-clean-wt              (  677.6 MB)  uncommitted changes
[dry-run] SKIP   fix-channels-error          (    1.4 GB)  unpushed commits vs upstream
[dry-run] REMOVE fix-esp32-size              (       0 B)  orphan directory (no .git)

[dry-run] 0 removed, 2 skipped (unsafe), 0 B reclaimed
```

Live run successfully removed the `fix-esp32-size` orphan directory via the `git+rmtree` path while correctly preserving the two worktrees with real work-in-progress.

## What is NOT addressed

Ask 1 in the issue is harness-level (auto-cleanup of agent worktrees by the Claude Code launcher) and is not actionable from inside the FastLED repo.

## Test plan

- [x] `bash lint` passes
- [x] `uv run pytest ci/tests/test_clean_worktrees.py` — 6/6 pass
- [x] Manual smoke test on Windows: orphan dir removed, dirty/unpushed worktrees correctly skipped
- [ ] Confirm on Linux/macOS that the Windows-specific fallbacks are no-ops (the `git worktree remove --force` succeeds on step 1 there)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CI utility to scan, classify, and safely remove stale agent worktrees (supports preview/dry-run, Windows-aware removal, and final pruning), with summary reporting and nonzero exit on failures
  * Added CI warnings when stale worktree counts exceed a threshold

* **Tests**
  * Added unit tests for worktree safety classification and byte-formatting

* **Chores**
  * Updated shell wrapper to reliably invoke the worktree cleanup utility
<!-- end of auto-generated comment: release notes by coderabbit.ai -->