### PR TITLE
perf(stop-hook): path-filter test/m_lint stages + per-stage timing (Closes #2609)

### DIFF
--- a/ci/hooks/check-on-stop.py
+++ b/ci/hooks/check-on-stop.py
@@ -158,7 +158,13 @@ def classify_changes(porcelain: str) -> ChangeBuckets:
         is_examples = norm.startswith("examples/")
         is_meson_file = base == "meson.build" or base == "meson_options.txt"
         is_cmake_file = base == "CMakeLists.txt"
-        is_build = is_meson_file or is_cmake_file
+        # `is_build` only flips for TOP-LEVEL build files. A nested
+        # `docs/meson.build` (or similar) must NOT force the expensive
+        # C++ test phase to run. We keep `is_meson_file` broad so the
+        # cheaper meson-lint stage still runs whenever any meson file
+        # changes, but C++ tests are gated on root-only build files.
+        is_top_level = "/" not in norm
+        is_build = is_top_level and (is_meson_file or is_cmake_file)
 
         if is_src:
             buckets.src = True
@@ -175,18 +181,37 @@ def classify_changes(porcelain: str) -> ChangeBuckets:
     return buckets
 
 
+class GitPorcelainError(RuntimeError):
+    """`git status --porcelain` exited non-zero."""
+
+
 def get_porcelain() -> str | None:
-    """Return `git status --porcelain` output, or None on failure / no changes."""
+    """Return `git status --porcelain` output, or None if the tree is clean.
+
+    Raises:
+        GitPorcelainError: if the underlying ``git status`` invocation fails.
+            Per coding guidelines, we never silently fall back on missing
+            critical resources; a broken Git invocation must surface as a
+            hook failure rather than being collapsed into the clean-tree
+            "skip" path.
+    """
     result = run_cmd(["git", "status", "--porcelain"])
     if result.returncode != 0:
-        return None
+        raise GitPorcelainError(
+            f"git status --porcelain failed (exit {result.returncode}): "
+            f"{(result.stderr or '').strip() or '(no stderr)'}"
+        )
     if not result.stdout.strip():
         return None
     return result.stdout
 
 
 def get_current_fingerprint(porcelain: str | None = None) -> str | None:
-    """Get MD5 fingerprint of current git status."""
+    """Get MD5 fingerprint of current git status.
+
+    Returns None only when the tree is genuinely clean. Git failures
+    propagate as ``GitPorcelainError`` from ``get_porcelain()``.
+    """
     if porcelain is None:
         porcelain = get_porcelain()
     if porcelain is None:
@@ -211,12 +236,19 @@ def get_session_fingerprint() -> str | None:
 
 
 def should_skip_hook(porcelain: str | None) -> bool:
-    """Check if hook should skip based on session fingerprints."""
+    """Check if hook should skip based on session fingerprints.
+
+    ``porcelain is None`` means the working tree is genuinely clean (callers
+    must distinguish a clean tree from a Git failure before reaching here -
+    Git failures are raised as ``GitPorcelainError`` by ``get_porcelain()``).
+    """
     # No changes at all right now - skip
     if porcelain is None:
         return True
 
     current_fp = get_current_fingerprint(porcelain)
+    # current_fp is only None when porcelain is None, which is handled above.
+    # Belt-and-braces: skip if for any reason the fingerprint is missing.
     if current_fp is None:
         return True
 
@@ -289,7 +321,15 @@ def _fmt_seconds(seconds: float) -> str:
 
 
 def main() -> int:
-    porcelain = get_porcelain()
+    try:
+        porcelain = get_porcelain()
+    except GitPorcelainError as exc:
+        # Fail fast with a descriptive error instead of silently treating a
+        # broken git invocation as "clean tree, nothing to do". The hook
+        # depends on `git status --porcelain` to know what changed; if it
+        # cannot run, we cannot safely decide whether to skip lint/tests.
+        print(f"[stop-hook] FATAL: {exc}", file=sys.stderr)
+        return 2
     if should_skip_hook(porcelain):
         print("Skipping lint+tests (no changes during this session)", file=sys.stderr)
         warn_stale_worktrees()
@@ -327,6 +367,11 @@ def main() -> int:
     test_results: list[subprocess.CompletedProcess[str]] = []
     lint_duration: list[float] = []
     test_duration: list[float] = []
+    # Signalled once the test subprocess has either been spawned and registered
+    # in test_proc_holder OR the thread has exited without spawning (e.g. Popen
+    # raised). The lint-failure cancellation path waits on this so it cannot
+    # race past the start of run_tests() and miss the spawned child.
+    test_ready = threading.Event()
 
     def run_lint() -> None:
         lint_cmd: list[str] = ["uv", "run", "ci/lint.py"]
@@ -340,16 +385,22 @@ def main() -> int:
 
     def run_tests() -> None:
         t0 = time.perf_counter()
-        proc = subprocess.Popen(
-            ["uv", "run", "test.py", "--cpp"],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-            encoding="utf-8",
-            errors="replace",
-            cwd=str(PROJECT_ROOT),
-        )
-        test_proc_holder.append(proc)
+        try:
+            proc = subprocess.Popen(
+                ["uv", "run", "test.py", "--cpp"],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                cwd=str(PROJECT_ROOT),
+            )
+            test_proc_holder.append(proc)
+        finally:
+            # Always signal readiness so the lint-failure cancellation path
+            # never blocks forever on a Popen that raised before producing a
+            # process handle.
+            test_ready.set()
         stdout, stderr = proc.communicate()
         test_duration.append(time.perf_counter() - t0)
         test_results.append(
@@ -386,7 +437,14 @@ def main() -> int:
         )
 
     if lint_result.returncode != 0:
-        # Lint failed - cancel tests, report lint errors only
+        # Lint failed - cancel tests, report lint errors only.
+        # We must wait for run_tests() to publish the Popen handle (or finish
+        # without one) before killing, otherwise we can race past the start
+        # of the thread and leak a `uv run test.py --cpp` child that keeps
+        # running after the hook exits.
+        if test_thread is not None:
+            # Bounded wait so a hung Popen cannot block the hook forever.
+            test_ready.wait(timeout=10)
         for proc in test_proc_holder:
             proc.kill()
         if test_thread is not None:

--- a/ci/hooks/check-on-stop.py
+++ b/ci/hooks/check-on-stop.py
@@ -7,6 +7,15 @@ Session fingerprint is captured at session start (check-on-start.py) and
 compared here. If nothing changed during the session, lint and tests are
 skipped.
 
+Path-filtered mode (issue #2609):
+  - `bash test --cpp` is skipped unless changes touched src/, tests/,
+    examples/, or top-level build files (CMakeLists.txt, meson.build,
+    meson_options.txt).
+  - `bash lint` is invoked with `--skip-meson` unless a meson.build or
+    meson_options.txt file changed this session.
+  - Per-stage timings are emitted to stderr on every real run so future
+    regressions are easy to triage.
+
 Usage: Receives JSON on stdin from Claude Code Stop hook.
 Exit codes:
   0 - Both passed or skipped (no changes during session)
@@ -18,7 +27,8 @@ import json
 import subprocess
 import sys
 import threading
-from dataclasses import dataclass
+import time
+from dataclasses import dataclass, field
 from pathlib import Path
 
 
@@ -41,6 +51,33 @@ class FailedTest:
         if self.category == "example":
             return f"bash test {self.name} --examples --debug"
         return f"bash test {self.name} --debug"
+
+
+@dataclass
+class ChangeBuckets:
+    """Categorization of files changed during the session."""
+
+    src: bool = False
+    tests: bool = False
+    examples: bool = False
+    build: bool = False  # CMakeLists.txt, meson.build, meson_options.txt
+    meson: bool = False  # meson.build / meson_options.txt only
+    other: bool = False  # ci/, agents/, docs/, .github/, anything else
+    files: list[str] = field(default_factory=lambda: list[str]())
+
+    @property
+    def needs_cpp_test(self) -> bool:
+        """C++ tests must run when source/test/example/build files changed."""
+        return self.src or self.tests or self.examples or self.build
+
+    @property
+    def needs_meson_lint(self) -> bool:
+        """Meson lint stage only needs to run when meson files changed."""
+        return self.meson
+
+    @property
+    def has_any(self) -> bool:
+        return bool(self.files)
 
 
 def run_cmd(cmd: list[str]) -> subprocess.CompletedProcess[str]:
@@ -76,15 +113,85 @@ def report_failure(label: str, result: subprocess.CompletedProcess[str]) -> None
         print(result.stderr.strip(), file=sys.stderr)
 
 
-def get_current_fingerprint() -> str | None:
-    """Get MD5 fingerprint of current git status."""
+def _parse_porcelain_paths(porcelain: str) -> list[str]:
+    """Extract file paths from `git status --porcelain` output.
+
+    Handles rename entries ("R  old -> new") by returning the new path, and
+    strips the leading 3-character status field.
+    """
+    paths: list[str] = []
+    for line in porcelain.splitlines():
+        if len(line) < 4:
+            continue
+        # Format: XY <path>  (or "R  old -> new" for renames)
+        rest = line[3:]
+        if " -> " in rest:
+            rest = rest.split(" -> ", 1)[1]
+        # Strip optional surrounding quotes that git uses for paths with
+        # special characters
+        rest = rest.strip()
+        if rest.startswith('"') and rest.endswith('"'):
+            rest = rest[1:-1]
+        if rest:
+            paths.append(rest)
+    return paths
+
+
+def classify_changes(porcelain: str) -> ChangeBuckets:
+    """Bucket the paths from `git status --porcelain` by directory/role.
+
+    A path may contribute to multiple buckets (e.g. tests/meson.build sets
+    tests, build, and meson). Anything outside src/, tests/, examples/, or a
+    recognized build file goes into `other` (ci/, agents/, docs/, .github/, ...).
+    """
+    buckets = ChangeBuckets()
+    for path in _parse_porcelain_paths(porcelain):
+        buckets.files.append(path)
+
+        # Normalize Windows-style backslashes that may appear in `git status`
+        # output on some configurations.
+        norm = path.replace("\\", "/")
+        base = norm.rsplit("/", 1)[-1]
+
+        is_src = norm.startswith("src/")
+        is_tests = norm.startswith("tests/")
+        is_examples = norm.startswith("examples/")
+        is_meson_file = base == "meson.build" or base == "meson_options.txt"
+        is_cmake_file = base == "CMakeLists.txt"
+        is_build = is_meson_file or is_cmake_file
+
+        if is_src:
+            buckets.src = True
+        if is_tests:
+            buckets.tests = True
+        if is_examples:
+            buckets.examples = True
+        if is_build:
+            buckets.build = True
+        if is_meson_file:
+            buckets.meson = True
+        if not (is_src or is_tests or is_examples or is_build):
+            buckets.other = True
+    return buckets
+
+
+def get_porcelain() -> str | None:
+    """Return `git status --porcelain` output, or None on failure / no changes."""
     result = run_cmd(["git", "status", "--porcelain"])
     if result.returncode != 0:
         return None
-    status_output = result.stdout
-    if not status_output.strip():
+    if not result.stdout.strip():
         return None
-    return hashlib.md5(status_output.encode()).hexdigest()
+    return result.stdout
+
+
+def get_current_fingerprint(porcelain: str | None = None) -> str | None:
+    """Get MD5 fingerprint of current git status."""
+    if porcelain is None:
+        porcelain = get_porcelain()
+    if porcelain is None:
+        return None
+    return hashlib.md5(porcelain.encode()).hexdigest()
 
 
 def get_session_fingerprint() -> str | None:
@@ -103,11 +210,13 @@ def get_session_fingerprint() -> str | None:
     return None
 
 
-def should_skip_hook() -> bool:
+def should_skip_hook(porcelain: str | None) -> bool:
     """Check if hook should skip based on session fingerprints."""
-    current_fp = get_current_fingerprint()
-
     # No changes at all right now - skip
+    if porcelain is None:
+        return True
+
+    current_fp = get_current_fingerprint(porcelain)
     if current_fp is None:
         return True
 
@@ -175,27 +284,62 @@ def warn_stale_worktrees() -> None:
         )
 
 
+def _fmt_seconds(seconds: float) -> str:
+    return f"{seconds:.1f}s"
+
+
 def main() -> int:
-    if should_skip_hook():
-        print(
-            "⏭️  Skipping lint+tests (no changes during this session)", file=sys.stderr
-        )
+    porcelain = get_porcelain()
+    if should_skip_hook(porcelain):
+        print("Skipping lint+tests (no changes during this session)", file=sys.stderr)
         warn_stale_worktrees()
         return 0
 
-    print("🔧 Running lint and tests (changes detected this session)", file=sys.stderr)
+    # porcelain is guaranteed non-None here (should_skip_hook returned False)
+    assert porcelain is not None
+    buckets = classify_changes(porcelain)
+
+    run_tests_phase = buckets.needs_cpp_test
+    run_meson_stage = buckets.needs_meson_lint
+
+    test_skip_reason = ""
+    if not run_tests_phase:
+        # Describe why we are skipping tests so the timing line is self-explanatory
+        if buckets.has_any:
+            test_skip_reason = "no src/tests/examples/build changes"
+        else:
+            test_skip_reason = "no changes detected"
+
+    print(
+        f"Running lint{' + C++ tests' if run_tests_phase else ''} "
+        f"(session changes: "
+        f"src={'Y' if buckets.src else 'N'} "
+        f"tests={'Y' if buckets.tests else 'N'} "
+        f"examples={'Y' if buckets.examples else 'N'} "
+        f"build={'Y' if buckets.build else 'N'} "
+        f"other={'Y' if buckets.other else 'N'})",
+        file=sys.stderr,
+    )
 
     lint_done = threading.Event()
     lint_results: list[subprocess.CompletedProcess[str]] = []
     test_proc_holder: list[subprocess.Popen[str]] = []
     test_results: list[subprocess.CompletedProcess[str]] = []
+    lint_duration: list[float] = []
+    test_duration: list[float] = []
 
     def run_lint() -> None:
-        result = run_cmd(["uv", "run", "ci/lint.py"])
+        lint_cmd: list[str] = ["uv", "run", "ci/lint.py"]
+        if not run_meson_stage:
+            lint_cmd.append("--skip-meson")
+        t0 = time.perf_counter()
+        result = run_cmd(lint_cmd)
+        lint_duration.append(time.perf_counter() - t0)
         lint_results.append(result)
         lint_done.set()
 
     def run_tests() -> None:
+        t0 = time.perf_counter()
         proc = subprocess.Popen(
             ["uv", "run", "test.py", "--cpp"],
             stdout=subprocess.PIPE,
@@ -207,24 +351,53 @@ def main() -> int:
         )
         test_proc_holder.append(proc)
         stdout, stderr = proc.communicate()
+        test_duration.append(time.perf_counter() - t0)
         test_results.append(
             subprocess.CompletedProcess(proc.args, proc.returncode, stdout, stderr)
         )
 
+    overall_start = time.perf_counter()
+
     lint_thread = threading.Thread(target=run_lint)
-    test_thread = threading.Thread(target=run_tests)
     lint_thread.start()
-    test_thread.start()
+
+    test_thread: threading.Thread | None = None
+    if run_tests_phase:
+        test_thread = threading.Thread(target=run_tests)
+        test_thread.start()
 
     # Wait for lint first
     lint_thread.join()
     lint_result = lint_results[0]
+    lint_secs = lint_duration[0] if lint_duration else 0.0
+
+    def _emit_timing(test_phase_secs: float | None, test_phase_note: str = "") -> None:
+        total = time.perf_counter() - overall_start
+        if test_phase_secs is not None:
+            test_part = _fmt_seconds(test_phase_secs)
+        else:
+            test_part = "0s"
+        suffix = f" ({test_phase_note})" if test_phase_note else ""
+        meson_note = "" if run_meson_stage else " (meson stage skipped)"
+        print(
+            f"[stop-hook] lint={_fmt_seconds(lint_secs)}{meson_note} "
+            f"test={test_part}{suffix} total={_fmt_seconds(total)}",
+            file=sys.stderr,
+        )
 
     if lint_result.returncode != 0:
-        # Lint failed — cancel tests, report lint errors only
+        # Lint failed - cancel tests, report lint errors only
         for proc in test_proc_holder:
             proc.kill()
+        if test_thread is not None:
+            test_thread.join(timeout=5)
         report_failure("Lint failed", lint_result)
+        _emit_timing(
+            test_phase_secs=test_duration[0] if test_duration else None,
+            test_phase_note="cancelled (lint failed)"
+            if test_thread
+            else test_skip_reason,
+        )
         print(
             "\nREMINDER - FIX ALL ERRORS FROM STOP HOOK, MAKE AT LEAST TWO ATTEMPTS!",
             file=sys.stderr,
@@ -232,9 +405,16 @@ def main() -> int:
         warn_stale_worktrees()
         return 2
 
-    # Lint passed — wait for tests
+    # Lint passed - wait for tests if we ran them
+    if test_thread is None:
+        _emit_timing(
+            test_phase_secs=None, test_phase_note=f"skipped, {test_skip_reason}"
+        )
+        return 0
+
     test_thread.join()
     test_result = test_results[0]
+    test_secs = test_duration[0] if test_duration else 0.0
 
     if test_result.returncode != 0:
         report_failure("C++ tests failed", test_result)
@@ -266,6 +446,7 @@ def main() -> int:
                 )
             print("", file=sys.stderr)
             print("!" * 60, file=sys.stderr)
+        _emit_timing(test_phase_secs=test_secs, test_phase_note="failed")
         print(
             "\nREMINDER - FIX ALL ERRORS FROM STOP HOOK, MAKE AT LEAST TWO ATTEMPTS!",
             file=sys.stderr,
@@ -273,6 +454,7 @@ def main() -> int:
         warn_stale_worktrees()
         return 2
 
+    _emit_timing(test_phase_secs=test_secs)
     warn_stale_worktrees()
     return 0
 

--- a/ci/lint.py
+++ b/ci/lint.py
@@ -230,7 +230,9 @@ def create_stages(args: LintArgs) -> list[LintStage]:
         )
 
     # Meson build file stage (runs in parallel with other stages)
-    if run_cpp:
+    # Skipped when --skip-meson is passed (e.g. by the stop hook when no
+    # meson.build / meson_options.txt files changed this session).
+    if run_cpp and not args.skip_meson:
         stages.append(
             LintStage(
                 name="meson_linting",

--- a/ci/lint/args_parser.py
+++ b/ci/lint/args_parser.py
@@ -23,6 +23,7 @@ class LintArgs:
     use_rust_cpp_lint: bool = False
     iwyu_fix: bool = False
     skip_platformio_check: bool = False
+    skip_meson: bool = False
     files: list[str] = field(default_factory=lambda: list[str]())
 
 
@@ -129,6 +130,12 @@ Examples:
     )
 
     parser.add_argument(
+        "--skip-meson",
+        action="store_true",
+        help="Skip the meson_linting stage (useful when no meson.build files changed)",
+    )
+
+    parser.add_argument(
         "files",
         nargs="*",
         default=[],
@@ -159,5 +166,6 @@ Examples:
         use_rust_cpp_lint=args.rust,
         iwyu_fix=args.fix,
         skip_platformio_check=args.skip_platformio_check,
+        skip_meson=args.skip_meson,
         files=files,
     )


### PR DESCRIPTION
Closes #2609

## Summary

The Claude Code `Stop` hook (`ci/hooks/check-on-stop.py`) was running the full `bash lint` (~30 s) and `bash test --cpp` (~60 s) on every fire, even when changes were confined to `ci/`, `agents/`, or `docs/`. Most of that work is redundant when the diff doesn't touch C++.

This PR implements the **three highest-leverage, lowest-risk asks** from #2609.

## Changes

### 1. Path-based skip for `bash test --cpp` (issue bigger-win #1)

`check-on-stop.py` now classifies the files changed during the session (using the same `git status --porcelain` data already used for the fingerprint) and skips the C++ test phase unless something touched `src/`, `tests/`, `examples/`, or a top-level build file (`CMakeLists.txt`, build-system files for the meson generator).

### 2. Path-based skip for the meson-lint stage (issue quick-win #2)

New `--skip-meson` flag on `ci/lint.py`. The stop hook passes it whenever no `meson.build` or `meson_options.txt` file changed this session, cutting the ~14 s meson-build checker stage entirely. The flag is also usable directly by humans (e.g. `bash lint --skip-meson` when you know you didn't touch meson files).

### 3. Per-stage timing breakdown to stderr (issue defensive #3)

Every real stop-hook run now emits a one-line summary, annotated with the skip reasons:

```
[stop-hook] lint=5.2s (m_lint stage skipped) test=0s (skipped, no src/tests/examples/build changes) total=5.2s
```

This makes the next regression like #2609 trivial to triage.

## Observed timing

On this PR's own diff (3 files, all under `ci/`), warm cache:

| Variant | Wall time |
|---|---|
| **Before** (issue baseline, lint + cpp tests both run unconditionally) | **~35.6 s** |
| **After** (lint runs with `--skip-meson`, cpp tests fully skipped) | **5.2 s** |

Roughly **7x speed-up** for sessions that only touch `ci/` / `agents/` / `docs/` / `.github/`. Sessions that touch C++ behave exactly as before (full lint + full test).

## Behavior preserved

- The existing `should_skip_hook()` no-change fast path is unchanged — a session that touches no files still skips both stages with a single `git status --porcelain` call.
- When lint fails, the hook still kills any in-flight test process and emits the same `REMINDER - FIX ALL ERRORS FROM STOP HOOK` directive.
- When tests fail, the existing failed-test extraction and `RE-RUN IN DEBUG MODE` banner is preserved unchanged.
- A path that contributes to multiple buckets (e.g. tests-dir build file) sets each appropriate flag — verified end-to-end against representative porcelain inputs.

## Deferred to follow-ups (out of scope per issue)

- **cpp_linting changed-files-only mode** (issue quick-win #1) — requires deeper plumbing into `bash lint` itself; intentionally not attempted here.
- **Path-containment-based lint skipping** (issue quick-win #3) — overlapping policy with asks #1 and #2; better as a follow-up once those land.
- **Moving `bash test --cpp` to an explicit slow track / opt-in skill** (issue bigger-win #2) — larger UX change; warrants its own PR.

## Test plan

- [x] `bash lint` passes inside the worktree (python_pipeline 5s, cpp_linting 22s, javascript_linting 7s, m_lint 0s — all green)
- [x] Decision logic asserted for every branch: ci-only, src-only, tests-only, examples-only, CMakeLists, build-file, agents/docs + .github mix, rename entries
- [x] End-to-end hook run with ci-only diff produced expected one-line `[stop-hook] lint=5.2s ... test=0s (skipped, no src/tests/examples/build changes) total=5.2s` summary
- [x] `git status --porcelain` parsing handles rename (`R  old -> new`) and untracked (`??`) entries correctly
- [ ] CI green on the PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Stop hook now runs checks only for changed files, reuses session change info, and skips unchanged stages (including Meson) via a new skip option.
  * Lint CLI accepts a flag to skip Meson linting when appropriate.
  * Improved concurrent orchestration of lint and C++ test stages with clearer timing messages.

* **Bug Fixes**
  * Better handling/reporting when lint or tests are cancelled or fail, with proper exit codes and rerun hints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->