### PR TITLE
fix(watchdog/avr): mark .init3 hook __attribute__((naked)) so it falls through (Closes #2798)

### DIFF
--- a/src/platforms/avr/watchdog_avr.impl.hpp
+++ b/src/platforms/avr/watchdog_avr.impl.hpp
@@ -108,21 +108,27 @@ inline fl::u8 timeoutToWdtoConstant(fl::u32 ms) {
     return WDTO_8S;
 }
 
-// `.init3` constructor: runs after the C runtime has zeroed BSS but before
-// `main()`. Captures MCUSR for later cause reporting, then clears it and
-// disables the WDT so a post-WDT-reset boot cannot loop forever.
+// `.init3` hook: runs after the C runtime has zeroed BSS but before `main()`.
+// Captures MCUSR for later cause reporting, then clears it and disables the
+// WDT so a post-WDT-reset boot cannot loop forever.
 //
-// NOTE: We deliberately do NOT mark this `naked`. `naked` functions are not
-// intended to hold ordinary C/C++ statements — GCC still needs to manage
-// register/stack expectations around the assignments and the `wdt_disable()`
-// call, and the result is fragile across optimization/toolchain versions.
-// A normal `.init3` hook works correctly here because `.init3` runs after
-// `.init2` (BSS zeroed, stack set up).
-__attribute__((used, section(".init3")))
-inline void fastled_watchdog_init3() {
+// **MUST be `naked`.** `.init3` is not a function call site — the linker
+// concatenates this code inline between `.init2` and `.init4`, and there is
+// no return address on the stack when it runs. A non-`naked` function emits
+// a prologue/epilogue ending in `ret`, which on AVR pops two bytes of
+// uninitialized SRAM and jumps there, hanging the chip before `setup()` can
+// run. This is the canonical avr-libc pattern for clearing `MCUSR` /
+// `WDT` in `.init3`; see issue #2798 for the AVR8JS regression that proved
+// out the previous non-naked version. The three statements below compile
+// to bare `STS`/inline-asm sequences with no stack temps, so `naked` is
+// safe — and is in fact the only correct choice for code placed in `.initN`.
+__attribute__((naked, used, section(".init3")))
+void fastled_watchdog_init3() {
     sAvrCapturedMcusr = MCUSR;
     MCUSR = 0;
     wdt_disable();
+    // Intentionally no `ret`: the linker concatenates `.init3` directly into
+    // the boot init chain and execution falls through to `.init4`.
 }
 
 } // namespace platforms

--- a/src/platforms/avr/watchdog_avr.impl.hpp
+++ b/src/platforms/avr/watchdog_avr.impl.hpp
@@ -108,9 +108,11 @@ inline fl::u8 timeoutToWdtoConstant(fl::u32 ms) {
     return WDTO_8S;
 }
 
-// `.init3` hook: runs after the C runtime has zeroed BSS but before `main()`.
-// Captures MCUSR for later cause reporting, then clears it and disables the
-// WDT so a post-WDT-reset boot cannot loop forever.
+// `.init3` hook: runs before avr-libc's `.init4` BSS/data initialization
+// and before `main()`. Captures MCUSR for later cause reporting, then clears
+// it and disables the WDT so a post-WDT-reset boot cannot loop forever.
+// (See the `sAvrCapturedMcusr` declaration above for why that variable must
+// stay in `.noinit` — `.init4` would otherwise wipe it after we capture.)
 //
 // **MUST be `naked`.** `.init3` is not a function call site — the linker
 // concatenates this code inline between `.init2` and `.init4`, and there is


### PR DESCRIPTION
## Summary

Fixes the \`uno AVR8JS Test\` workflow that has been red on master at every commit since #2745 (\"watchdog Phase 2\") merged. Closes #2798.

Continues the README badge sweep: #2780 (AVR family) / #2785 (STM32 GIGA) / #2788 (Apollo3) / #2793 (RP2040).

## What's broken

\`fastled_watchdog_init3()\` in \`src/platforms/avr/watchdog_avr.impl.hpp\` was attributed \`section(\".init3\"), used\` but **not** \`naked\`. GCC therefore emits a standard function prologue/epilogue ending in \`ret\`.

But \`.init3\` is not a function call site — the linker concatenates this code inline into the AVR boot init chain between \`.init2\` (BSS clear) and \`.init4\` (data copy), and there is no return address on the stack when it runs. The \`ret\` pops two bytes of uninitialized SRAM and jumps there, hanging the chip before \`setup()\` ever executes.

**Symptom**: avr8js's 30 s emulator run for the \`Test\` sketch never produces \`Test loop\` (or even \`Test setup starting\`), because the firmware is dead before the first \`Serial.println\`.

**Bisect**: Green at \`c2faf92e\` (before #2745). Red at every commit since.

## What this PR changes

Add \`__attribute__((naked))\` to the \`.init3\` hook (the avr-libc-canonical pattern for clearing \`MCUSR\` + \`wdt_disable()\` at boot), drop the now-incompatible \`inline\` keyword, and rewrite the comment block to explain that:

- \`.init3\` *must* be \`naked\` — code placed there falls through to \`.init4\`, it does not return.
- The three statements the hook performs (\`MCUSR\` capture, \`MCUSR = 0\`, \`wdt_disable()\`) compile to plain \`STS\` / inline-asm sequences with no stack temps, so the general \"naked is fragile across toolchains\" concern doesn't apply here.

The prior comment justifying *not* using \`naked\` was a general worry — for this specific body, naked is the only correct choice.

## Test plan

Local regression guard with \`bash compile\` on every classic + modern AVR board in the README sweep:

\`\`\`
PASS  uno          (classic-AVR — uses the .init3 hook now)
PASS  attiny85     (classic-AVR — uses the .init3 hook now)
PASS  attiny88     (classic-AVR — uses the .init3 hook now)
PASS  attiny4313   (classic-AVR — uses the .init3 hook now)
PASS  atmega8a     (megaAVR / no classic symbols — noop fallback)
PASS  nano_every   (megaAVR-0 — noop fallback)
PASS  ATtiny1604   (tinyAVR-1 — noop fallback)
PASS  ATtiny1616   (tinyAVR-1 — noop fallback)
\`\`\`

Runtime verification of the actual fix requires the avr8js emulator, which only runs on CI. **PR CI on \`uno AVR8JS Test\` is the authoritative check.**

\`bash lint\` clean.

## Scope

- [x] Closes #2798 — \`uno AVR8JS Test\` should reach \`Test loop!\` and pass.
- [ ] Remaining red badges from the README sweep: \`check_esp32_size\`, \`check_teensy41_size\`, \`unit tests windows\`. Each will be filed separately. The top-level \`build\` aggregate should clear once the per-board workflows go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved watchdog initialization on AVR platforms to use a startup-safe low-level form, enhancing boot reliability while preserving existing behavior and public APIs.
* **Documentation**
  * Updated internal docs to reflect the new startup implementation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->