### PR TITLE
feat(ci): standardized per-platform smoke-sketch manifest (refs #2411)

### DIFF
--- a/ci/standardized_smoke_sketches.py
+++ b/ci/standardized_smoke_sketches.py
@@ -6,24 +6,29 @@ The manifest at ``tests/platforms/_standard/SMOKE_SKETCHES.txt`` is the
 canonical list of FastLED example sketches that EVERY supported board must
 compile in CI. Per-board overrides remain under ``tests/platforms/<board>/``.
 
-The format is intentionally trivial — one example name per line, ``#`` for
-comments, blank lines ignored — so any consumer (Python, bash, shell scripts,
+The format is intentionally trivial - one example name per line, ``#`` for
+comments, blank lines ignored - so any consumer (Python, bash, shell scripts,
 GitHub Actions) can parse it without pulling in YAML/TOML dependencies.
 
 Typical usage::
 
     from ci.standardized_smoke_sketches import load_smoke_sketches
-    for sketch in load_smoke_sketches():
+    for sketch in load_smoke_sketches(None):
         # feed to ci-compile.py / fbuild / pio_compile / arduino-cli ...
         ...
 
 Per-board filtering (e.g. ``AudioFftParity`` is ESP32-only) is handled by the
-existing ``@filter`` directives inside each ``.ino`` — this loader stays
+existing ``@filter`` directives inside each ``.ino`` - this loader stays
 platform-agnostic on purpose.
 """
 
+import sys
 from dataclasses import dataclass
 from pathlib import Path
+
+from typeguard import typechecked
+
+from ci.util.global_interrupt_handler import handle_keyboard_interrupt
 
 
 # Repo-relative location of the manifest. Kept as a module-level constant so
@@ -31,6 +36,7 @@ from pathlib import Path
 MANIFEST_RELATIVE_PATH = "tests/platforms/_standard/SMOKE_SKETCHES.txt"
 
 
+@typechecked
 @dataclass(frozen=True)
 class SmokeSketch:
     """A single entry from the standardized smoke-sketch manifest.
@@ -55,19 +61,19 @@ def _project_root() -> Path:
     return Path(__file__).resolve().parent.parent
 
 
-def manifest_path(project_root: Path | None = None) -> Path:
+def manifest_path(project_root: Path | None) -> Path:
     """Return the absolute path to the smoke-sketch manifest.
 
     Args:
-        project_root: Optional override (used by tests). Defaults to the
-            FastLED repo root inferred from this file's location.
+        project_root: Repo root override (used by tests). Pass ``None`` to
+            use the FastLED repo root inferred from this file's location.
     """
     root = project_root if project_root is not None else _project_root()
     return root / MANIFEST_RELATIVE_PATH
 
 
 def load_smoke_sketches_detailed(
-    project_root: Path | None = None,
+    project_root: Path | None,
 ) -> list[SmokeSketch]:
     """Parse the manifest and return entries with line-number metadata.
 
@@ -75,7 +81,8 @@ def load_smoke_sketches_detailed(
     comments are supported (``Blink  # basic clockless``).
 
     Args:
-        project_root: Optional override (used by tests).
+        project_root: Repo root override (used by tests). Pass ``None`` to
+            use the FastLED repo root inferred from this file's location.
 
     Returns:
         List of :class:`SmokeSketch` entries in manifest order.
@@ -97,7 +104,7 @@ def load_smoke_sketches_detailed(
                 continue
             if line in seen:
                 # Duplicate names would silently double-compile the same
-                # sketch — surface this as a hard error so the manifest
+                # sketch - surface this as a hard error so the manifest
                 # stays the single source of truth.
                 raise ValueError(
                     f"Duplicate smoke sketch '{line}' on line {lineno} of {path}"
@@ -108,20 +115,24 @@ def load_smoke_sketches_detailed(
     return entries
 
 
-def load_smoke_sketches(project_root: Path | None = None) -> list[str]:
+def load_smoke_sketches(project_root: Path | None) -> list[str]:
     """Return just the sketch names from the manifest, in manifest order.
 
     Convenience wrapper around :func:`load_smoke_sketches_detailed` for
     callers (e.g. shell pipelines) that don't need line-number metadata.
 
     Args:
-        project_root: Optional override (used by tests).
+        project_root: Repo root override (used by tests). Pass ``None`` to
+            use the FastLED repo root inferred from this file's location.
     """
-    return [entry.name for entry in load_smoke_sketches_detailed(project_root)]
+    names: list[str] = []
+    for entry in load_smoke_sketches_detailed(project_root):
+        names.append(entry.name)
+    return names
 
 
 def _main() -> int:
-    """CLI entry point — prints the smoke-sketch names, one per line.
+    """CLI entry point - prints the smoke-sketch names, one per line.
 
     Sample invocations::
 
@@ -129,8 +140,11 @@ def _main() -> int:
         bash compile esp32dev --examples $(uv run python ci/standardized_smoke_sketches.py | tr '\\n' ' ')
     """
     try:
-        for name in load_smoke_sketches():
+        for name in load_smoke_sketches(None):
             print(name)
+    except KeyboardInterrupt as ki:
+        handle_keyboard_interrupt(ki)
+        return 130
     except FileNotFoundError as exc:
         print(f"ERROR: {exc}")
         return 1
@@ -141,6 +155,4 @@ def _main() -> int:
 
 
 if __name__ == "__main__":
-    import sys
-
     sys.exit(_main())

--- a/ci/standardized_smoke_sketches.py
+++ b/ci/standardized_smoke_sketches.py
@@ -1,0 +1,146 @@
+"""Reader for the standardized per-platform smoke-sketch manifest.
+
+Issue: https://github.com/FastLED/FastLED/issues/2411 (Part A).
+
+The manifest at ``tests/platforms/_standard/SMOKE_SKETCHES.txt`` is the
+canonical list of FastLED example sketches that EVERY supported board must
+compile in CI. Per-board overrides remain under ``tests/platforms/<board>/``.
+
+The format is intentionally trivial — one example name per line, ``#`` for
+comments, blank lines ignored — so any consumer (Python, bash, shell scripts,
+GitHub Actions) can parse it without pulling in YAML/TOML dependencies.
+
+Typical usage::
+
+    from ci.standardized_smoke_sketches import load_smoke_sketches
+    for sketch in load_smoke_sketches():
+        # feed to ci-compile.py / fbuild / pio_compile / arduino-cli ...
+        ...
+
+Per-board filtering (e.g. ``AudioFftParity`` is ESP32-only) is handled by the
+existing ``@filter`` directives inside each ``.ino`` — this loader stays
+platform-agnostic on purpose.
+"""
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+# Repo-relative location of the manifest. Kept as a module-level constant so
+# CI tooling can reference it without re-deriving the path.
+MANIFEST_RELATIVE_PATH = "tests/platforms/_standard/SMOKE_SKETCHES.txt"
+
+
+@dataclass(frozen=True)
+class SmokeSketch:
+    """A single entry from the standardized smoke-sketch manifest.
+
+    Attributes:
+        name: Example name as it appears in the manifest (e.g. ``"Blink"``).
+              Resolves to ``examples/<name>/`` under the project root.
+        manifest_line: 1-indexed line number in the manifest the entry came
+              from. Useful for error messages.
+    """
+
+    name: str
+    manifest_line: int
+
+
+def _project_root() -> Path:
+    """Return the FastLED project root.
+
+    The reader lives at ``ci/standardized_smoke_sketches.py``; the repo root
+    is the parent of ``ci/``.
+    """
+    return Path(__file__).resolve().parent.parent
+
+
+def manifest_path(project_root: Path | None = None) -> Path:
+    """Return the absolute path to the smoke-sketch manifest.
+
+    Args:
+        project_root: Optional override (used by tests). Defaults to the
+            FastLED repo root inferred from this file's location.
+    """
+    root = project_root if project_root is not None else _project_root()
+    return root / MANIFEST_RELATIVE_PATH
+
+
+def load_smoke_sketches_detailed(
+    project_root: Path | None = None,
+) -> list[SmokeSketch]:
+    """Parse the manifest and return entries with line-number metadata.
+
+    Comments (``#`` to end of line) and blank lines are skipped. Inline
+    comments are supported (``Blink  # basic clockless``).
+
+    Args:
+        project_root: Optional override (used by tests).
+
+    Returns:
+        List of :class:`SmokeSketch` entries in manifest order.
+
+    Raises:
+        FileNotFoundError: If the manifest file does not exist.
+    """
+    path = manifest_path(project_root)
+    if not path.is_file():
+        raise FileNotFoundError(f"Standardized smoke-sketch manifest not found: {path}")
+
+    entries: list[SmokeSketch] = []
+    seen: set[str] = set()
+    with path.open("r", encoding="utf-8") as fh:
+        for lineno, raw in enumerate(fh, start=1):
+            # Strip inline comments and surrounding whitespace.
+            line = raw.split("#", 1)[0].strip()
+            if not line:
+                continue
+            if line in seen:
+                # Duplicate names would silently double-compile the same
+                # sketch — surface this as a hard error so the manifest
+                # stays the single source of truth.
+                raise ValueError(
+                    f"Duplicate smoke sketch '{line}' on line {lineno} of {path}"
+                )
+            seen.add(line)
+            entries.append(SmokeSketch(name=line, manifest_line=lineno))
+
+    return entries
+
+
+def load_smoke_sketches(project_root: Path | None = None) -> list[str]:
+    """Return just the sketch names from the manifest, in manifest order.
+
+    Convenience wrapper around :func:`load_smoke_sketches_detailed` for
+    callers (e.g. shell pipelines) that don't need line-number metadata.
+
+    Args:
+        project_root: Optional override (used by tests).
+    """
+    return [entry.name for entry in load_smoke_sketches_detailed(project_root)]
+
+
+def _main() -> int:
+    """CLI entry point — prints the smoke-sketch names, one per line.
+
+    Sample invocations::
+
+        uv run python ci/standardized_smoke_sketches.py
+        bash compile esp32dev --examples $(uv run python ci/standardized_smoke_sketches.py | tr '\\n' ' ')
+    """
+    try:
+        for name in load_smoke_sketches():
+            print(name)
+    except FileNotFoundError as exc:
+        print(f"ERROR: {exc}")
+        return 1
+    except ValueError as exc:
+        print(f"ERROR: {exc}")
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(_main())

--- a/ci/tests/test_standardized_smoke_sketches.py
+++ b/ci/tests/test_standardized_smoke_sketches.py
@@ -25,8 +25,8 @@ from ci.standardized_smoke_sketches import (
 
 def test_live_manifest_exists() -> None:
     """The canonical manifest must exist at the documented path."""
-    assert manifest_path().is_file(), (
-        f"Manifest missing at {manifest_path()} (expected at {MANIFEST_RELATIVE_PATH})"
+    assert manifest_path(None).is_file(), (
+        f"Manifest missing at {manifest_path(None)} (expected at {MANIFEST_RELATIVE_PATH})"
     )
 
 
@@ -36,7 +36,7 @@ def test_live_manifest_contains_canonical_sketches() -> None:
     If a future change replaces one of these, this test should be updated in
     the same commit so the contract change is explicit.
     """
-    names = load_smoke_sketches()
+    names = load_smoke_sketches(None)
     expected = {"Blink", "XYMatrix", "Apa102", "AudioFftParity"}
     missing = expected - set(names)
     assert not missing, (
@@ -49,7 +49,7 @@ def test_live_manifest_entries_resolve_to_existing_examples() -> None:
     """Every entry must point at an existing examples/<name>/ directory."""
     root = Path(__file__).resolve().parent.parent.parent
     examples_dir = root / "examples"
-    for entry in load_smoke_sketches_detailed():
+    for entry in load_smoke_sketches_detailed(None):
         example_dir = examples_dir / entry.name
         assert example_dir.is_dir(), (
             f"Smoke-sketch '{entry.name}' (manifest line {entry.manifest_line}) "

--- a/ci/tests/test_standardized_smoke_sketches.py
+++ b/ci/tests/test_standardized_smoke_sketches.py
@@ -1,0 +1,122 @@
+"""Tests for the standardized smoke-sketch manifest reader.
+
+Issue: https://github.com/FastLED/FastLED/issues/2411 (Part A).
+"""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from ci.standardized_smoke_sketches import (
+    MANIFEST_RELATIVE_PATH,
+    SmokeSketch,
+    load_smoke_sketches,
+    load_smoke_sketches_detailed,
+    manifest_path,
+)
+
+
+# ---------------------------------------------------------------------------
+# Live manifest sanity checks — these run against the actual file checked into
+# the repo so a malformed commit fails CI before the manifest is consumed.
+# ---------------------------------------------------------------------------
+
+
+def test_live_manifest_exists() -> None:
+    """The canonical manifest must exist at the documented path."""
+    assert manifest_path().is_file(), (
+        f"Manifest missing at {manifest_path()} (expected at {MANIFEST_RELATIVE_PATH})"
+    )
+
+
+def test_live_manifest_contains_canonical_sketches() -> None:
+    """The four canonical sketches from #2411 must be present.
+
+    If a future change replaces one of these, this test should be updated in
+    the same commit so the contract change is explicit.
+    """
+    names = load_smoke_sketches()
+    expected = {"Blink", "XYMatrix", "Apa102", "AudioFftParity"}
+    missing = expected - set(names)
+    assert not missing, (
+        f"Canonical smoke sketches missing from manifest: {sorted(missing)}. "
+        f"Got: {names}"
+    )
+
+
+def test_live_manifest_entries_resolve_to_existing_examples() -> None:
+    """Every entry must point at an existing examples/<name>/ directory."""
+    root = Path(__file__).resolve().parent.parent.parent
+    examples_dir = root / "examples"
+    for entry in load_smoke_sketches_detailed():
+        example_dir = examples_dir / entry.name
+        assert example_dir.is_dir(), (
+            f"Smoke-sketch '{entry.name}' (manifest line {entry.manifest_line}) "
+            f"does not resolve to an existing example directory: {example_dir}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Parser behaviour — driven against synthetic manifests in tmp dirs so we can
+# exercise edge cases without touching the live file.
+# ---------------------------------------------------------------------------
+
+
+def _write_manifest(tmp_root: Path, body: str) -> Path:
+    manifest = tmp_root / MANIFEST_RELATIVE_PATH
+    manifest.parent.mkdir(parents=True, exist_ok=True)
+    manifest.write_text(body, encoding="utf-8")
+    return manifest
+
+
+def test_parser_skips_blank_lines_and_comments() -> None:
+    body = """# leading comment
+# another comment
+
+Blink
+
+  # indented comment
+XYMatrix
+"""
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        _write_manifest(root, body)
+        assert load_smoke_sketches(root) == ["Blink", "XYMatrix"]
+
+
+def test_parser_strips_inline_comments_and_whitespace() -> None:
+    body = "Blink  # basic clockless\n  XYMatrix\t# 2D matrix\n"
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        _write_manifest(root, body)
+        assert load_smoke_sketches(root) == ["Blink", "XYMatrix"]
+
+
+def test_parser_records_manifest_line_numbers() -> None:
+    body = "# header\n\nBlink\nXYMatrix\n"
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        _write_manifest(root, body)
+        entries = load_smoke_sketches_detailed(root)
+        assert entries == [
+            SmokeSketch(name="Blink", manifest_line=3),
+            SmokeSketch(name="XYMatrix", manifest_line=4),
+        ]
+
+
+def test_parser_rejects_duplicates() -> None:
+    body = "Blink\nXYMatrix\nBlink\n"
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        _write_manifest(root, body)
+        with pytest.raises(ValueError, match="Duplicate smoke sketch 'Blink'"):
+            load_smoke_sketches(root)
+
+
+def test_parser_raises_when_manifest_missing() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        # Note: no manifest written.
+        with pytest.raises(FileNotFoundError):
+            load_smoke_sketches(root)

--- a/tests/platforms/_standard/SMOKE_SKETCHES.txt
+++ b/tests/platforms/_standard/SMOKE_SKETCHES.txt
@@ -1,0 +1,43 @@
+# Standardized per-platform smoke sketches (refs #2411, Part A)
+#
+# This file is the canonical list of sketches that EVERY supported board must
+# compile in CI. The set is intentionally small and representative — one sketch
+# per "category" of FastLED feature surface, chosen to catch the most common
+# regression classes across all backends (fbuild, PlatformIO, arduino-cli):
+#
+#   Blink             — basic clockless one-pixel sanity (no APIs beyond
+#                       FastLED.addLeds + .show()). If this fails, the toolchain
+#                       can't link the simplest FastLED program.
+#
+#   XYMatrix          — 2D matrix wiring + XY helper. Exercises XYMap, the
+#                       most common 2D abstraction.
+#
+#   Apa102            — clocked SPI chipset + 8-bit gamma/palette code. Picked
+#                       over Apa102HD because Apa102 has the smaller exclusion
+#                       set (only stm32f103cb is filtered out) and matches the
+#                       "PROGMEM gradient/palette tables" intent in #2411.
+#
+#   AudioFftParity    — exercises FFT / sin LUT paths. ESP32-only by its own
+#                       @filter directive (esp_dsp.h availability — see #2623);
+#                       on non-ESP32 boards the existing sketch_filter machinery
+#                       will skip it cleanly. The slot is reserved here so when
+#                       a cross-platform FFT-parity sketch lands later it can
+#                       replace this entry without churning every CI consumer.
+#
+# Format: one example name per line. Lines starting with '#' and blank lines
+# are ignored. Each name resolves to examples/<name>/. Per-board skipping is
+# governed by the @filter directives inside each .ino — this manifest stays
+# platform-agnostic on purpose.
+#
+# Per-board *overrides* (additional or replacement smoke sketches) continue to
+# live under tests/platforms/<board>/ as today.
+#
+# Consumed by: ci/standardized_smoke_sketches.py
+#
+# Part B (opt-in PlatformIO comparison job in build_template.yml) is deferred
+# to a follow-up PR; this manifest is the prerequisite that unblocks it.
+
+Blink
+XYMatrix
+Apa102
+AudioFftParity


### PR DESCRIPTION
## Summary

Implements **Part A** of #2411: a canonical, platform-agnostic list of FastLED example sketches that EVERY supported board must compile in CI. This is the prerequisite the opt-in PlatformIO comparison job (Part B) will read from.

Files added:

- `tests/platforms/_standard/SMOKE_SKETCHES.txt` — the manifest itself (plain text, one example name per line, `#` comments, blank lines ignored).
- `ci/standardized_smoke_sketches.py` — a tiny reader (`load_smoke_sketches()`, `load_smoke_sketches_detailed()`, `manifest_path()`) plus a CLI entry point that prints the list, suitable for shell pipelines.
- `ci/tests/test_standardized_smoke_sketches.py` — 8 tests covering parser edge cases plus three live-manifest sanity checks (manifest exists, contains the canonical four, every entry resolves to an existing `examples/<name>/` directory).

## Canonical sketches in the manifest

| Sketch | Why it's in the set |
|---|---|
| `Blink` | Basic clockless one-pixel sanity. If this fails, the toolchain can't link the simplest FastLED program. |
| `XYMatrix` | 2D matrix wiring + `XYMap` — the most common 2D abstraction. |
| `Apa102` | Clocked SPI chipset + 8-bit gamma / palette code. Picked over `Apa102HD` because `Apa102` has the smaller exclusion set (only `stm32f103cb` is filtered out via `@filter`) and matches the "PROGMEM gradient/palette tables" intent in the issue. |
| `AudioFftParity` | FFT / sin LUT path. ESP32-only by its own `@filter` (`esp_dsp.h` availability — see #2623); on non-ESP32 boards the existing `sketch_filter` machinery skips it cleanly. The slot is reserved here so a future cross-platform FFT-parity sketch can replace this entry without churning every CI consumer. |

Per-board skipping continues to be driven by the existing `@filter` directives inside each `.ino` — the manifest itself stays platform-agnostic on purpose. Per-board overrides / additional smoke sketches remain under `tests/platforms/<board>/` as today.

## Sample invocation

```bash
$ uv run python ci/standardized_smoke_sketches.py
Blink
XYMatrix
Apa102
AudioFftParity

# Shell-pipeline consumer (illustrative):
$ bash compile esp32dev --examples $(uv run python ci/standardized_smoke_sketches.py | tr '\n' ' ')
```

Python consumers:

```python
from ci.standardized_smoke_sketches import load_smoke_sketches
for sketch in load_smoke_sketches():
    ...  # feed to ci-compile.py / fbuild / pio_compile / arduino-cli
```

## Not in scope (deferred)

- **Part B from #2411** — the opt-in `also_build_with_platformio` input on `.github/workflows/build_template.yml` and the per-backend pass/fail summary. This PR is the prerequisite; the workflow side lands in a follow-up.
- **CI matrix shape** — no changes to the default per-PR build matrix. Existing per-board build runs are unchanged.
- **Part C (agent docs update)** — also deferred to the Part B follow-up so the "diagnosing fbuild-only failures" docs section can reference both pieces.

## Test plan

- [x] `uv run python -m pytest ci/tests/test_standardized_smoke_sketches.py -v` — 8/8 pass locally (covers parser comments / blank lines / inline comments / duplicate rejection / missing-manifest error, plus live-manifest sanity).
- [x] `bash lint` — clean (ruff + ty + cpp_linting + javascript_linting + meson_linting).
- [x] `uv run python ci/standardized_smoke_sketches.py` — prints the four canonical names, one per line.
- [ ] CI: GitHub Actions on this PR.

Refs #2411.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage validating the canonical smoke-sketch manifest, that entries resolve to example sketches, and parser behaviors (skips blanks/comments, strips inline comments, records line numbers, rejects duplicates, errors on missing manifest).

* **Chores**
  * Introduced a standardized smoke-sketch manifest for CI across platforms and a small CLI to list the canonical sketches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->