### PR TITLE
ci(test/windows): reset zccache daemon before test run to mitigate link flake (Closes #2805)

### DIFF
--- a/.github/workflows/template_unit_test.yml
+++ b/.github/workflows/template_unit_test.yml
@@ -56,6 +56,19 @@ jobs:
         run: |
           uv run python ci/lint_cpp/no_using_namespace_fl_in_headers.py
 
+      - name: Reset zccache daemon (Windows flake mitigation, FastLED#2805)
+        if: runner.os == 'Windows'
+        run: |
+          # The zccache daemon's named-pipe IPC drops mid-link under heavy
+          # parallel link load on Windows hosted runners — the daemon's own
+          # diagnostic emits 'lost connection to daemon ... try `zccache stop`'.
+          # Start each Windows job with a known-clean daemon state so the
+          # first wave of test-DLL links doesn't race a stale/partially-
+          # initialized daemon. `|| true` because there may be no daemon to
+          # stop on a fresh runner — that's the desired end state anyway.
+          zccache stop || true
+        shell: bash
+
       - name: Run All Unit Tests
         id: run_tests
         run: |

--- a/agents/docs/build-system.md
+++ b/agents/docs/build-system.md
@@ -184,7 +184,7 @@ clang-tool-chain provides a uniform GNU-style build environment across all platf
 
 ## zccache
 - **NEVER disable zccache**: Do NOT set `ZCCACHE_DISABLE=1` or disable zccache in any way
-  - If zccache fails: Investigate and fix the root cause (e.g., `zccache --stop-server` to reset)
+  - If zccache fails: Investigate and fix the root cause (e.g., `zccache stop` to reset the daemon — see the Windows mitigation in `.github/workflows/template_unit_test.yml`)
   - Never use: `ZCCACHE_DISABLE=1` as a workaround for zccache errors
   - Rationale: zccache provides critical compilation performance optimization - disabling it dramatically slows down builds
 


### PR DESCRIPTION
## Summary

Adds a Windows-only \`zccache stop || true\` step to \`template_unit_test.yml\` between \`./install\` and \`./test\`, mitigating the \`unit tests windows\` link-flake. Closes #2805.

Final unaddressed badge in the README sweep. The earlier ones: ✅ #2780 (AVR), ✅ #2785 (STM32 GIGA), ✅ #2788 (Apollo3), ⏳ #2793 (RP2040), ⏳ #2800 (AVR8JS), ⏳ #2804 (size budgets).

## What's broken

The Windows job is **intermittently** red — same commit class passes some runs and fails others. The failing runs all show the same signature:

\`\`\`
FAILED: [code=1] tests/fl_math_trig8.dll
zccache[err][R]: lost connection to daemon (no response).
    Often a daemon-CLI protocol version mismatch - try \`zccache stop\`
\`\`\`

zccache wraps the linker on Windows. Its named-pipe IPC to the daemon drops mid-link under the heavy ASan-instrumented \`-shared\` link load that FastLED's per-test DLL fan-out produces. The two test DLLs reported each run (\`fl_math_trig8.dll\`, \`fl_math_transform.dll\` this time) aren't consistent across runs — they're just whichever links lose the race to the daemon dropping.

Recent run history confirms the flake pattern (same source class, alternating outcomes):

| Time | SHA | Conclusion |
|---|---|---|
| 09:10 | \`787de450d1\` | ❌ failure |
| 08:50 | \`5d271671d1\` | ❌ failure |
| **08:30** | \`8c87cbfddb\` | ✅ **success** |
| 08:17 | \`a4bdea8458\` | ❌ failure |
| 07:43 | \`d471d94356\` | ❌ failure |
| **07:10** | \`99ddad4487\` | ✅ **success** |
| 06:52 | \`b5e51c3339\` | ❌ failure |

## What this PR changes

One new step in \`.github/workflows/template_unit_test.yml\`, guarded by \`if: runner.os == 'Windows'\`:

\`\`\`yaml
- name: Reset zccache daemon (Windows flake mitigation, FastLED#2805)
  if: runner.os == 'Windows'
  run: |
    zccache stop || true
  shell: bash
\`\`\`

The daemon's own diagnostic explicitly recommends \`zccache stop\` to recover from the connection-drop class of failures. Starting the Windows job with a known-clean daemon state avoids inheriting whatever the \`./install\` step's earlier zccache invocations left behind. \`|| true\` because on a fresh runner there may be no daemon to stop — that's the desired end state anyway.

Linux and macOS jobs are unaffected (the guard skips them).

## What this PR is *not*

This is a **mitigation**, not a guaranteed cure. True daemon-flake-under-load may still occur. If reds persist, follow-ups should consider:

- Pinning a known-good zccache version (the recent \`a27cbff8d0\` bumped to \`>=1.11.11\`)
- Running zccache in daemon-less mode on Windows CI
- Per-job retry on test failure for the Windows runner

## Test plan

Pure CI configuration — local \`bash test\` doesn't exercise hosted-runner daemon behavior. **PR CI on \`unit tests windows\` is the authoritative check**, and because the failure is intermittent the signal is statistical: this PR should raise the green-rate from the current ~30% to substantially higher.

\`bash lint\` clean.

## Mandatory code-review trigger

Per global CI rules: modifying CI/CD pipelines is a code-review trigger. Flagged explicitly.

## Sweep status

After this lands, every README-listed red badge has either a merged fix or an open PR addressing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved Windows unit-test reliability by adding a reset step to ensure a clean test daemon state before running tests.
* **Documentation**
  * Updated build-system guidance to reflect the new recommended reset command and link to the Windows mitigation guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->