### PR TITLE
feat(ci): PlatformIO-internal-usage linter (warn-only first pass) (refs #2701)

### DIFF
--- a/ci/lint.py
+++ b/ci/lint.py
@@ -28,6 +28,7 @@ from ci.lint.stage_impls import (
 )
 from ci.lint.stages import LintStage
 from ci.lint_meson.run_all_checkers import run_meson_lint
+from ci.lint_platformio.run_all_checkers import run_platformio_lint
 from ci.util.global_interrupt_handler import install_signal_handler, wait_for_cleanup
 
 
@@ -235,6 +236,19 @@ def create_stages(args: LintArgs) -> list[LintStage]:
                 name="meson_linting",
                 display_name="MESON BUILD LINTING",
                 run_fn=run_meson_lint,
+                timeout=30.0,
+            )
+        )
+
+    # PlatformIO-internal-usage stage (issue #2701, warn-only by default).
+    # Runs whenever non-JS-only linting is invoked — repo hygiene check
+    # for build/CI scripts. Skipped via --skip-platformio-check.
+    if not args.js_only and not args.skip_platformio_check:
+        stages.append(
+            LintStage(
+                name="platformio_internal_usage",
+                display_name="PLATFORMIO-INTERNAL-USAGE LINT",
+                run_fn=lambda: run_platformio_lint(),
                 timeout=30.0,
             )
         )

--- a/ci/lint/args_parser.py
+++ b/ci/lint/args_parser.py
@@ -22,6 +22,7 @@ class LintArgs:
     run_tidy: bool = False
     use_rust_cpp_lint: bool = False
     iwyu_fix: bool = False
+    skip_platformio_check: bool = False
     files: list[str] = field(default_factory=lambda: list[str]())
 
 
@@ -122,6 +123,12 @@ Examples:
     )
 
     parser.add_argument(
+        "--skip-platformio-check",
+        action="store_true",
+        help="Skip the PlatformIO-internal-usage checker (issue #2701, warn-only).",
+    )
+
+    parser.add_argument(
         "files",
         nargs="*",
         default=[],
@@ -151,5 +158,6 @@ Examples:
         run_tidy=args.tidy,
         use_rust_cpp_lint=args.rust,
         iwyu_fix=args.fix,
+        skip_platformio_check=args.skip_platformio_check,
         files=files,
     )

--- a/ci/lint_platformio/__init__.py
+++ b/ci/lint_platformio/__init__.py
@@ -1,0 +1,13 @@
+"""Linters that detect internal PlatformIO build usage (issue #2701).
+
+This package enforces the fbuild-only board-build invariant. Internal
+PlatformIO build call sites (``pio run``, ``platformio run``,
+``--backend platformio``, ``--platformio``/``--pio`` flag passing, and
+generated ``platformio.ini`` board staging) are forbidden in
+build/CI code. User-facing references in docs, examples, library
+manifests, and issue templates are explicitly allowed.
+
+See ``ci/lint_platformio/check_no_internal_platformio.py`` for the
+checker and ``run_all_checkers.py`` for the dispatch entrypoint used by
+``bash lint``.
+"""

--- a/ci/lint_platformio/check_no_internal_platformio.py
+++ b/ci/lint_platformio/check_no_internal_platformio.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""Checker for forbidden internal PlatformIO build invocations (issue #2701).
+
+FastLED board builds use fbuild exclusively. Internal/CI build code
+must not shell out to PlatformIO. This checker flags:
+
+  * ``pio run`` invocations as a build step
+  * ``platformio run`` / ``platformio --version`` invocations
+  * Argparse acceptance or passing of ``--platformio`` / ``--pio``
+  * Argparse acceptance or passing of ``--backend platformio``
+  * Generation/staging of ``platformio.ini`` files as a build artifact
+
+User-facing references stay allowed via the ALLOWED_PATH_FRAGMENTS
+allowlist (README/install docs, ``examples/`` comments, ``library.json``
+/ ``library.properties``, issue templates, etc.).
+
+The checker is in WARN MODE — it reports violations but ``run_platformio_lint``
+returns ``True`` by default so the linter does not gate CI red while the
+follow-up sweep PR removes existing call sites. To promote the checker
+to error-on-violation, pass ``warn_only=False`` (or set the
+``FASTLED_LINT_PLATFORMIO_ERROR`` env var to ``1``).
+"""
+
+from __future__ import annotations
+
+import re
+
+from ci.util.check_files import FileContent, FileContentChecker
+
+
+# --- Allowlist -------------------------------------------------------------
+#
+# Paths (substring match, normalized to forward slashes) where PlatformIO
+# references are intentional and out of scope for the fbuild-only rule.
+#
+# Categories:
+#   * User-facing docs (README, install instructions, examples/*)
+#   * The PlatformIO library manifest (library.json / library.properties)
+#   * Issue templates (.github/ISSUE_TEMPLATE/)
+#   * The linter itself (this file documents the patterns it forbids)
+#   * Backend comparison harness (ci/check_backend_flag_drift.py — when
+#     it lands; intentionally calls both backends side-by-side)
+#   * .git internal data
+#
+# NOTE: This is intentionally permissive. The point of the warn-mode first
+# pass is to surface the current state of internal PlatformIO usage so the
+# follow-up sweep PR has a punchlist.
+ALLOWED_PATH_FRAGMENTS: tuple[str, ...] = (
+    # Linter itself
+    "ci/lint_platformio/",
+    # The backend-comparison harness (planned, may not exist yet on master)
+    "ci/check_backend_flag_drift.py",
+    # User-facing docs
+    "/README.md",
+    "/docs/",
+    # User examples — comments are allowed to mention PlatformIO usage
+    "/examples/",
+    # PlatformIO library manifest surface (this IS the PIO consumer API)
+    "/library.json",
+    "/library.properties",
+    # GitHub issue templates
+    "/.github/ISSUE_TEMPLATE/",
+    # Pull request templates
+    "/.github/PULL_REQUEST_TEMPLATE",
+    # Git internals (worktree metadata, packed refs)
+    "/.git/",
+    # Claude harness configuration (not part of the build/CI surface). Match
+    # only direct subdirs of the project root, NOT the worktree path itself
+    # (worktrees live under `<repo>/.claude/worktrees/<branch>/...` and need
+    # to be scanned just like the canonical checkout).
+    "ci/hooks/",
+    ".claude/agents/",
+    ".claude/hooks/",
+    ".claude/skills/",
+    ".claude/settings.json",
+    ".claude/settings.local.json",
+    ".claude/commands/",
+    ".claude/teensy",  # worktree-resident log files (.claude/teensy*_ci.log)
+    "/.claude.log",
+    # Agents docs intentionally document the (forbidden) historical patterns
+    "/agents/docs/",
+    "/agents/tasks/",
+    "/agents/tests.md",
+    "/agents/ci.md",
+    "/agents/examples.md",
+    # Hardware-autoresearch doc references PlatformIO env names for users
+    "agents/docs/hardware-autoresearch.md",
+    # Lessons / notes
+    "/CLAUDE.md",
+    # Wiki submodule (user-facing)
+    "/wiki/",
+    # Build artifacts and caches
+    "/.build/",
+    "/.pio/",
+    "/.cache/",
+    "/build_info",  # build_info.json files
+    # Docker README mentions PIO for users
+    "ci/docker_utils/README.md",
+    "ci/docker_utils/task.md",
+)
+
+
+def _is_path_allowed(file_path: str) -> bool:
+    """Return True if file_path is in the allowlist (substring match)."""
+    normalized = file_path.replace("\\", "/")
+    return any(fragment in normalized for fragment in ALLOWED_PATH_FRAGMENTS)
+
+
+# --- Forbidden patterns ----------------------------------------------------
+#
+# Each entry is (compiled regex, human-readable category, fix-hint).
+#
+# Patterns are line-scoped (no multiline) and intentionally narrow so that:
+#   * Comments that quote the forbidden patterns *as documentation* are NOT
+#     flagged (we check for shell-style command position, not mere mention).
+#   * Allowlisted contexts still catch the literal pattern in source — the
+#     allowlist filters by path, not by line content.
+#
+# A line is skipped if it looks like an in-source comment (#, //) — pure
+# documentation/explanation of the rule itself should not self-flag.
+#
+# NOTE: The patterns intentionally do NOT use word-boundary `\b` after
+# `--pio` because `--platformio` also matches and we want to flag both.
+# Each pattern is tested independently with `re.search`.
+
+_PATTERNS: tuple[tuple[re.Pattern[str], str, str], ...] = (
+    # `pio run` as a builder invocation
+    (
+        re.compile(r"\bpio\s+run\b"),
+        "pio_run",
+        "Forbidden: `pio run` as build invocation. Use fbuild instead.",
+    ),
+    # `platformio run` as a builder invocation
+    (
+        re.compile(r"\bplatformio\s+run\b"),
+        "platformio_run",
+        "Forbidden: `platformio run` as build invocation. Use fbuild instead.",
+    ),
+    # `platformio --version` (PIO availability probe in CI)
+    (
+        re.compile(r"\bplatformio\s+--version\b"),
+        "platformio_version_probe",
+        "Forbidden: `platformio --version` probe. Internal build no longer requires PlatformIO.",
+    ),
+    # `--backend platformio` flag passing/acceptance
+    (
+        re.compile(r"--backend[\s=]+platformio\b"),
+        "backend_platformio_flag",
+        "Forbidden: `--backend platformio`. fbuild is the only supported backend.",
+    ),
+    # `--platformio` flag (legacy bash compile/ci-compile path selector)
+    (
+        re.compile(r"(?<![\w-])--platformio(?![\w-])"),
+        "platformio_flag",
+        "Forbidden: `--platformio` flag. Drop the PlatformIO backend path.",
+    ),
+    # `--pio` flag (legacy short form)
+    (
+        re.compile(r"(?<![\w-])--pio(?![\w-])"),
+        "pio_flag",
+        "Forbidden: `--pio` flag. Drop the PlatformIO backend path.",
+    ),
+)
+
+
+# Lines that look like in-file comments quoting the forbidden patterns
+# (e.g. doc strings inside this checker itself). We skip those rather than
+# blanket-allowlisting the file — keeps the checker honest about its own
+# source.
+_COMMENT_PREFIXES: tuple[str, ...] = ("#", "//", "*", "<!--", "/*")
+
+
+def _line_is_comment(line: str) -> bool:
+    stripped = line.lstrip()
+    return any(stripped.startswith(prefix) for prefix in _COMMENT_PREFIXES)
+
+
+# File extensions considered "build/CI code" where internal PIO usage is
+# forbidden. Other files (e.g. .cpp, .h) are skipped — board source code is
+# never expected to drive PlatformIO directly, and matching there produces
+# false positives on enum names like `BackendPlatformio`.
+_BUILD_CODE_SUFFIXES: tuple[str, ...] = (
+    ".py",
+    ".yml",
+    ".yaml",
+    ".sh",
+    ".bash",
+    ".ps1",
+    ".cmd",
+    ".bat",
+    ".toml",
+    ".cfg",
+    ".ini",  # to catch generated platformio.ini emitters
+    ".md",  # internal docs (agents/) excluded via allowlist; CI docs are not
+)
+
+
+class NoInternalPlatformIOChecker(FileContentChecker):
+    """Flags internal PlatformIO build invocations outside the allowlist."""
+
+    def __init__(self) -> None:
+        self.violations: dict[str, list[tuple[int, str]]] = {}
+
+    def should_process_file(self, file_path: str) -> bool:
+        normalized = file_path.replace("\\", "/")
+        if not normalized.endswith(_BUILD_CODE_SUFFIXES):
+            return False
+        if _is_path_allowed(normalized):
+            return False
+        return True
+
+    def check_file_content(self, file_content: FileContent) -> list[str]:
+        for line_number, line in enumerate(file_content.lines, 1):
+            if _line_is_comment(line):
+                continue
+            for pattern, category, hint in _PATTERNS:
+                if pattern.search(line):
+                    self.violations.setdefault(file_content.path, []).append(
+                        (line_number, f"[{category}] {hint}  >> {line.strip()}")
+                    )
+                    # one violation per line is enough
+                    break
+        return []

--- a/ci/lint_platformio/run_all_checkers.py
+++ b/ci/lint_platformio/run_all_checkers.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""PlatformIO-internal-usage linting (issue #2701).
+
+Walks the repo, applies ``NoInternalPlatformIOChecker``, and prints any
+violations.
+
+WARN MODE (default): exits 0 even if violations are found. The companion
+sweep PR will remove the violating call sites; until then we don't want
+the linter to gate CI red.
+
+To run as an error gate (CI green = no violations):
+  - Pass ``--error`` on the CLI, OR
+  - Set ``FASTLED_LINT_PLATFORMIO_ERROR=1`` in the env
+
+To dump the current punchlist:
+  uv run python ci/lint_platformio/run_all_checkers.py --list-violations
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+from ci.lint_platformio.check_no_internal_platformio import (
+    NoInternalPlatformIOChecker,
+)
+from ci.util.check_files import FileContentChecker, MultiCheckerFileProcessor
+
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+# Directories never walked. Cuts a huge amount of I/O on caches/build artifacts.
+_SKIP_DIRS: frozenset[str] = frozenset(
+    {
+        ".build",
+        ".pio",
+        ".cache",
+        ".venv",
+        "node_modules",
+        "__pycache__",
+        ".mypy_cache",
+        ".ruff_cache",
+        "build",
+        "dist",
+        # Don't recurse into sibling worktrees from the canonical checkout —
+        # they get linted on their own when active.
+        "worktrees",
+    }
+)
+
+
+# Files of interest. We only care about build/CI code paths.
+_INTEREST_SUFFIXES: tuple[str, ...] = (
+    ".py",
+    ".yml",
+    ".yaml",
+    ".sh",
+    ".bash",
+    ".ps1",
+    ".cmd",
+    ".bat",
+    ".toml",
+    ".cfg",
+    ".ini",
+    ".md",
+)
+
+
+def _collect_files(root: Path) -> list[str]:
+    """Walk the repo and collect files of interest, pruning skip dirs."""
+    files: list[str] = []
+    for dirpath, dirnames, filenames in os.walk(root):
+        # In-place prune
+        dirnames[:] = [
+            d for d in dirnames if d not in _SKIP_DIRS and not d.startswith(".build")
+        ]
+        for name in filenames:
+            if name.endswith(_INTEREST_SUFFIXES):
+                files.append(os.path.join(dirpath, name))
+    files.sort()
+    return files
+
+
+def _collect_violations(
+    checkers: list[FileContentChecker],
+) -> dict[str, list[tuple[int, str]]]:
+    all_violations: dict[str, list[tuple[int, str]]] = {}
+    for checker in checkers:
+        violations: dict[str, list[tuple[int, str]]] | None = getattr(
+            checker, "violations", None
+        )
+        if violations:
+            for path, issues in violations.items():
+                all_violations.setdefault(path, []).extend(issues)
+    return all_violations
+
+
+def _print_violations(violations: dict[str, list[tuple[int, str]]]) -> int:
+    total = 0
+    for path, issues in sorted(violations.items()):
+        try:
+            rel = str(Path(path).relative_to(PROJECT_ROOT))
+        except ValueError:
+            rel = path
+        rel = rel.replace("\\", "/")
+        print(f"\n{rel}:")
+        for line_no, msg in sorted(issues):
+            print(f"  Line {line_no}: {msg}")
+            total += 1
+    return total
+
+
+def run_platformio_lint(warn_only: bool | None = None) -> bool:
+    """Run the PlatformIO-internal-usage checker.
+
+    Args:
+        warn_only: If True, always return True (warn mode). If False,
+            return False when violations exist (error mode). If None,
+            consult ``FASTLED_LINT_PLATFORMIO_ERROR`` (defaults to warn).
+
+    Returns:
+        True if clean OR warn-only mode is active.
+    """
+    if warn_only is None:
+        warn_only = os.environ.get("FASTLED_LINT_PLATFORMIO_ERROR", "") != "1"
+
+    files = _collect_files(PROJECT_ROOT)
+    if not files:
+        return True
+
+    checkers: list[FileContentChecker] = [NoInternalPlatformIOChecker()]
+    processor = MultiCheckerFileProcessor()
+    processor.process_files_with_checkers(files, checkers)
+
+    violations = _collect_violations(checkers)
+    if not violations:
+        print("✅ PlatformIO-internal-usage check: no violations")
+        return True
+
+    total = sum(len(v) for v in violations.values())
+    mode_label = "WARN" if warn_only else "ERROR"
+    print(f"\n{'=' * 80}")
+    print(
+        f"[PlatformIO-internal-usage] {mode_label} mode — "
+        f"found {total} violation(s) in {len(violations)} file(s):"
+    )
+    print("=" * 80)
+    _print_violations(violations)
+    print(f"\n{'=' * 80}")
+
+    if warn_only:
+        print(
+            f"⚠️  PlatformIO-internal-usage: {total} violation(s) (warn-only — "
+            f"not failing CI). See issue #2701."
+        )
+        print("=" * 80)
+        return True
+
+    print(f"❌ PlatformIO-internal-usage: {total} violation(s) (gating).")
+    print("=" * 80)
+    return False
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Lint for forbidden internal PlatformIO build usage (issue #2701).",
+    )
+    parser.add_argument(
+        "--error",
+        action="store_true",
+        help="Fail (exit 1) if any violation is found. Default is warn-only.",
+    )
+    parser.add_argument(
+        "--list-violations",
+        action="store_true",
+        help="Alias for the default behavior: print the current violation punchlist.",
+    )
+    args = parser.parse_args()
+
+    # --list-violations is the default warn-mode behavior; alias for clarity.
+    warn_only = not args.error
+    ok = run_platformio_lint(warn_only=warn_only)
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Adds a new lint rule that flags forbidden **internal** PlatformIO build invocations in build/CI code, per [#2701](https://github.com/FastLED/FastLED/issues/2701). FastLED board builds should now use fbuild exclusively; this checker prevents new internal `pio run` / `--backend platformio` call sites from being introduced while the companion sweep PR removes the existing ones.

This PR ships **just the linter** (refs, not closes #2701). The sweep half — removing the ~17 existing call sites the linter flags — is a separate follow-up so reviewers can vet each removal individually.

## What the linter detects

`ci/lint_platformio/check_no_internal_platformio.py` flags these patterns in `.py`, `.yml`, `.yaml`, `.sh`, `.bash`, `.ps1`, `.cmd`, `.bat`, `.toml`, `.cfg`, `.ini`, and `.md` files:

| Pattern | Category | Example |
|---|---|---|
| `pio run` | `pio_run` | `cd ci/kitchensink && pio run` |
| `platformio run` | `platformio_run` | `uv run platformio run` |
| `platformio --version` | `platformio_version_probe` | `uv run platformio --version` |
| `--backend platformio` / `--backend=platformio` | `backend_platformio_flag` | `ci/ci-check-compiled-size.py --backend platformio` |
| `--platformio` | `platformio_flag` | argparse `add_argument("--platformio", ...)` |
| `--pio` | `pio_flag` | argparse `add_argument("--pio", ...)` |

Lines that look like in-file comments (`#`, `//`, `*`, `<!--`, `/*`) are skipped so the checker doesn't self-flag when it documents its own patterns.

## Allowlist policy

Paths where PlatformIO references are intentional and out of scope:

- **User-facing docs**: `README.md`, `/docs/`, `/agents/docs/`
- **Examples**: `/examples/` (sketch comments + READMEs)
- **PlatformIO library manifest** (this *is* the PIO consumer API): `/library.json`, `/library.properties`
- **Issue templates**: `/.github/ISSUE_TEMPLATE/`, `/.github/PULL_REQUEST_TEMPLATE`
- **Planned backend-comparison harness**: `ci/check_backend_flag_drift.py` (intentionally calls both backends side-by-side)
- **The linter itself**: `ci/lint_platformio/`
- **Build artifacts & caches**: `.build/`, `.pio/`, `.cache/`
- **Wiki submodule**, **git internals**, **Claude harness config**, **sibling worktrees**

The allowlist is intentionally permissive — the point of the warn-mode first pass is to surface the current state, not litigate edge cases.

## Warn-only mode

The linter is in **WARN MODE** by default — the stage prints violations and the punchlist, but exits 0 so CI stays green while the existing call sites are removed.

To run as a gate (after the sweep PR lands):

```
uv run python ci/lint_platformio/run_all_checkers.py --error
# or
FASTLED_LINT_PLATFORMIO_ERROR=1 bash lint
```

## Sample output

`bash lint` now reports (17 violations across 10 files):

```
================================================================================
[PlatformIO-internal-usage] WARN mode — found 17 violation(s) in 10 file(s):
================================================================================

.github/workflows/build_clone_and_compile.yml:
  Line 52: [platformio_run] Forbidden: `platformio run` as build invocation. Use fbuild instead.  >> run: uv run platformio run

.github/workflows/build_esp_extra_libs.yml:
  Line 50: [pio_run] Forbidden: `pio run` as build invocation. Use fbuild instead.  >> cd ci/kitchensink && pio run

.github/workflows/build_template.yml:
  Line 80: [platformio_version_probe] Forbidden: `platformio --version` probe. ...

.github/workflows/build_template_binary_size.yml:
  Line 44: [backend_platformio_flag] Forbidden: `--backend platformio`. fbuild is the only supported backend.
  Line 65: [backend_platformio_flag] ...
  Line 87: [backend_platformio_flag] ...

ci/boards.py:
  Line 51: [pio_run] ...
ci/build_docker_image_pio.py:
  Line 623: [pio_run] ...
ci/compiler/argument_parser.py:
  Lines 23, 290, 295 (--platformio), 296 (--pio), 299
ci/compiler/compilation_orchestrator.py:
  Lines 58, 117
ci/compiler/pio.py:
  Line 70
ci/debug_attached.py:
  Line 258

⚠️  PlatformIO-internal-usage: 17 violation(s) (warn-only — not failing CI). See issue #2701.
```

The stage shows up in the `bash lint` execution summary:

```
Linter Name               |                 Duration
--------------------------+-------------------------
python_pipeline           |                       4s
cpp_linting               |                      22s
javascript_linting        |                      29s
meson_linting             |                       1s
platformio_internal_usage |                       1s
```

## Wired into `bash lint`

- New stage `platformio_internal_usage` in `ci/lint.py` `create_stages()` — runs whenever non-JS-only linting is invoked, in parallel with the other stages.
- New CLI flag `--skip-platformio-check` (mirrors `--skip-meson`).
- Standalone runner: `uv run python ci/lint_platformio/run_all_checkers.py [--error|--list-violations]`.

## What's in the follow-up sweep PR

Once the call sites the linter currently flags are removed (delete `--platformio`/`--pio` in `ci/compiler/argument_parser.py`, drop `--backend platformio` from the workflow YAMLs, etc.), the linter can be promoted to error mode by either:

1. Flipping the default of `run_platformio_lint(warn_only=False)` in `ci/lint_platformio/run_all_checkers.py`, OR
2. Setting `FASTLED_LINT_PLATFORMIO_ERROR=1` in CI workflows.

The 17 current violations are the sweep punchlist.

## Test plan

- [x] `bash lint` runs the new stage and prints the 17-violation punchlist without failing
- [x] Standalone `uv run python ci/lint_platformio/run_all_checkers.py` lists violations (exit 0)
- [x] Standalone with `--error` flag exits 1 when violations exist
- [x] `--skip-platformio-check` is wired through `args_parser.py`
- [ ] CI green on this PR (no new violations introduced; existing violations don't gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new linting stage that detects forbidden PlatformIO internal usages in CI and build-related files, running in warn-only mode by default.

* **Chores**
  * Added `--skip-platformio-check` CLI flag to skip the new linting stage.
  * The check can be configured to enforce as a gating error when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->