### PR TITLE
feat(spi,esp32): pre-queue alternate-buffer SPI chunk for >680-LED strips (refs #2304)

### DIFF
--- a/src/platforms/esp/32/drivers/spi/channel_driver_spi.cpp.hpp
+++ b/src/platforms/esp/32/drivers/spi/channel_driver_spi.cpp.hpp
@@ -1479,6 +1479,52 @@ void ChannelEngineSpi::startFirstDma() FL_NOEXCEPT {
         mPipeline.mDmaInFlight = true;
         mPipeline.mEncodeIdx = 1; // Next encode goes to buffer B
         mPipeline.mPhase = DmaPipelineState::STREAMING;
+
+        // Back-to-back DMA streaming (issue #2304):
+        //
+        // For long strips (>~680 LEDs) the encoded SPI data spans more than one
+        // staging buffer. The naive approach (queue chunk A, wait, queue B,
+        // wait, ...) leaves the SPI line idle for the poll() latency between
+        // chunks. Under RTOS contention that gap can exceed WS2812B's ~50µs
+        // reset threshold and trigger a visible refresh.
+        //
+        // Fix: when async DMA is available, pre-encode and pre-queue the
+        // second chunk right away so the SPI ISR transitions directly from
+        // transA -> transB without host involvement. ESP-IDF's
+        // spi_device_queue_trans permits multiple in-flight transactions
+        // (dev_config.queue_size = 4 already in place); we cap at 2 to keep
+        // the pipeline shallow and predictable.
+        //
+        // ESP32-C6 split-polling path: spi_device_polling_start only allows
+        // one in-flight polling transaction at a time, so we keep the
+        // existing single-queue behaviour there. The C6 still benefits from
+        // the encode/wait overlap but cannot get the ISR-chained gap-free
+        // behaviour without an ESP-IDF API change.
+        if (!kSpiUsePolling && ch->ledBytesRemaining > 0) {
+            size_t encoded_b = encodeChunk(ch, ch->stagingB, ch->stagingCapacity);
+            if (encoded_b > 0) {
+                spi_transaction_t* transB = &ch->transB;
+                fl::memset(transB, 0, sizeof(*transB));
+                transB->length = encoded_b * 8;
+                transB->tx_buffer = ch->stagingB;
+
+                if (ch->numLanes >= 4) {
+                    transB->flags = SPI_TRANS_MODE_QIO;
+                } else if (ch->numLanes >= 2) {
+                    transB->flags = SPI_TRANS_MODE_DIO;
+                }
+
+                esp_err_t retB = spiStart(ch->spi_device, transB);
+                if (retB == ESP_OK) {
+                    ch->transBInFlight = true;
+                    mPipeline.mEncodeIdx = 2; // Both A and B queued
+                } else {
+                    // Pre-queue failed but A is already in flight; let the
+                    // pipeline fall back to one-chunk-at-a-time refill.
+                    FL_WARN("ChannelEngineSpi: startFirstDma pre-queue B failed: " << retB);
+                }
+            }
+        }
     } else {
         FL_WARN("ChannelEngineSpi: startFirstDma spiStart failed: " << ret);
         ch->transmissionComplete = true;
@@ -1499,8 +1545,15 @@ IChannelDriver::DriverState ChannelEngineSpi::advancePipeline() FL_NOEXCEPT {
             return DriverState::READY;
         }
 
-        // Check if current DMA is complete
-        if (mPipeline.mDmaInFlight) {
+        // "Any chunk in flight" — refreshed each iteration. Tracks the real
+        // state of both transA and transB so that pre-queued back-to-back
+        // chunks are accounted for (issue #2304).
+        bool anyInFlight = ch->transAInFlight || ch->transBInFlight;
+
+        // Check if a DMA has completed. In async mode this drains the next
+        // completed transaction from ESP-IDF's FIFO queue; in polling mode
+        // it ends the current (single) polling transaction.
+        if (anyInFlight) {
             spi_transaction_t* completed = nullptr;
             esp_err_t ret = spiCheckDone(ch->spi_device, &completed);
             if (ret != ESP_OK) {
@@ -1516,10 +1569,16 @@ IChannelDriver::DriverState ChannelEngineSpi::advancePipeline() FL_NOEXCEPT {
                 if (completed == &ch->transA) ch->transAInFlight = false;
                 else if (completed == &ch->transB) ch->transBInFlight = false;
             }
-            mPipeline.mDmaInFlight = false;
+            // Re-evaluate after draining one completion
+            anyInFlight = ch->transAInFlight || ch->transBInFlight;
+            mPipeline.mDmaInFlight = anyInFlight;
         }
 
-        // Encode and queue next chunk if data remains
+        // Encode and queue next chunk if data remains. After the back-to-back
+        // pre-queue in startFirstDma(), this fires on each subsequent
+        // completion and refills the buffer that just freed up — keeping
+        // two transactions in the SPI ISR's queue so it can chain them
+        // gap-free.
         if (ch->ledBytesRemaining > 0) {
             int bufIdx = mPipeline.mEncodeIdx & 1;
             u8* buffer = (bufIdx == 0) ? ch->stagingA : ch->stagingB;
@@ -1545,8 +1604,9 @@ IChannelDriver::DriverState ChannelEngineSpi::advancePipeline() FL_NOEXCEPT {
             return DriverState::DRAINING;
         }
 
-        // No more data to encode
-        if (mPipeline.mDmaInFlight) {
+        // No more data to encode — drain any chunks still in flight before
+        // marking the channel complete.
+        if (anyInFlight) {
             mPipeline.mPhase = DmaPipelineState::COMPLETING;
             return DriverState::DRAINING;
         }

--- a/src/platforms/esp/32/drivers/spi/channel_driver_spi.cpp.hpp
+++ b/src/platforms/esp/32/drivers/spi/channel_driver_spi.cpp.hpp
@@ -1501,6 +1501,14 @@ void ChannelEngineSpi::startFirstDma() FL_NOEXCEPT {
         // the encode/wait overlap but cannot get the ISR-chained gap-free
         // behaviour without an ESP-IDF API change.
         if (!kSpiUsePolling && ch->ledBytesRemaining > 0) {
+            // Save source state so we can roll back if the SPI driver refuses
+            // to queue transB. encodeChunk() advances ch->ledSource /
+            // ch->ledBytesRemaining as a side-effect, so a failure here would
+            // otherwise drop the chunk we just consumed instead of letting the
+            // refill loop retry it on the next poll() iteration.
+            const u8* savedSource = ch->ledSource;
+            size_t savedRemaining = ch->ledBytesRemaining;
+
             size_t encoded_b = encodeChunk(ch, ch->stagingB, ch->stagingCapacity);
             if (encoded_b > 0) {
                 spi_transaction_t* transB = &ch->transB;
@@ -1519,8 +1527,12 @@ void ChannelEngineSpi::startFirstDma() FL_NOEXCEPT {
                     ch->transBInFlight = true;
                     mPipeline.mEncodeIdx = 2; // Both A and B queued
                 } else {
-                    // Pre-queue failed but A is already in flight; let the
-                    // pipeline fall back to one-chunk-at-a-time refill.
+                    // Pre-queue failed but A is already in flight. Roll back
+                    // the source pointer so the refill loop re-encodes this
+                    // chunk into B once A completes instead of truncating the
+                    // stream after A.
+                    ch->ledSource = savedSource;
+                    ch->ledBytesRemaining = savedRemaining;
                     FL_WARN("ChannelEngineSpi: startFirstDma pre-queue B failed: " << retB);
                 }
             }

--- a/tests/platforms/esp/32/drivers/spi/spi_pingpong_pipeline_logic.cpp
+++ b/tests/platforms/esp/32/drivers/spi/spi_pingpong_pipeline_logic.cpp
@@ -1,0 +1,305 @@
+// ok standalone
+/// @file spi_pingpong_pipeline_logic.cpp
+/// @brief Host-side state-machine tests for the back-to-back DMA chunk
+///        streaming added in #2304.
+///
+/// The real driver in `src/platforms/esp/32/drivers/spi/channel_driver_spi.cpp.hpp`
+/// only compiles under ESP-IDF, so this test models the buffer/transaction
+/// rotation logic in plain C++ and verifies the invariants we care about:
+///
+///   1. After startFirstDma() in async mode, BOTH stagingA and stagingB are
+///      queued for any strip whose encoded payload exceeds a single staging
+///      buffer (the > ~680-LED case the issue cites).
+///   2. For strips that fit in one chunk, only A is queued.
+///   3. The refill-on-completion loop refills the buffer that just freed up
+///      (ping-pong) and keeps two transactions in the SPI ISR's queue as long
+///      as data remains.
+///   4. The pipeline never lets fewer than 2 chunks be queued while data
+///      remains and never queues more than 2.
+///   5. Final drain waits for both outstanding transactions before marking the
+///      channel complete.
+///
+/// These tests do NOT exercise real SPI hardware; on-device byte equality and
+/// inter-chunk timing must be validated via `bash autoresearch --spi`.
+
+#include "fl/stl/cstddef.h"
+#include "fl/stl/stdint.h"
+#include "test.h"
+
+FL_TEST_FILE(FL_FILEPATH) {
+
+using namespace fl;
+
+namespace spi_pingpong_pipeline_logic_test {
+
+/// Mirror of the relevant fields from
+/// ChannelEngineSpi::SpiChannelState / DmaPipelineState. Only the fields the
+/// pre-queue + refill state machine touches are modelled.
+struct PipelineModel {
+    // Source data state
+    size_t ledBytesRemaining;
+    size_t stagingCapacity;       // SPI bytes per staging buffer
+    size_t bytesPerLedByte;       // wave8 expansion factor (8 for WS2812)
+
+    // Transaction tracking
+    bool transAInFlight;
+    bool transBInFlight;
+    int  encodeIdx;               // Next buffer to encode into; bit 0 selects A/B
+
+    // Completion bookkeeping
+    int  completedCount;
+    int  queuedCount;
+
+    // Platform flag: true on ESP32-C6 (split polling, max 1 in flight)
+    bool usePolling;
+
+    static PipelineModel make(size_t bytes, size_t capacity, bool polling) {
+        PipelineModel m{};
+        m.ledBytesRemaining = bytes;
+        m.stagingCapacity   = capacity;
+        m.bytesPerLedByte   = 8;
+        m.transAInFlight    = false;
+        m.transBInFlight    = false;
+        m.encodeIdx         = 0;
+        m.completedCount    = 0;
+        m.queuedCount       = 0;
+        m.usePolling        = polling;
+        return m;
+    }
+
+    /// Encode one chunk into the selected buffer; advance LED state.
+    /// Returns the number of SPI bytes "encoded" (0 if no data left).
+    size_t encodeChunk(int /*bufIdx*/) {
+        if (ledBytesRemaining == 0) return 0;
+        const size_t max_led_bytes = stagingCapacity / bytesPerLedByte;
+        const size_t to_encode = (ledBytesRemaining < max_led_bytes)
+                                     ? ledBytesRemaining
+                                     : max_led_bytes;
+        ledBytesRemaining -= to_encode;
+        return to_encode * bytesPerLedByte;
+    }
+
+    /// Mirrors the new startFirstDma() logic from the driver.
+    void startFirstDma() {
+        size_t encodedA = encodeChunk(0);
+        if (encodedA == 0) return;
+        transAInFlight = true;
+        encodeIdx = 1;
+        ++queuedCount;
+
+        // Back-to-back pre-queue: only on async (non-polling) path AND only
+        // when more data remains for this channel.
+        if (!usePolling && ledBytesRemaining > 0) {
+            size_t encodedB = encodeChunk(1);
+            if (encodedB > 0) {
+                transBInFlight = true;
+                encodeIdx = 2;
+                ++queuedCount;
+            }
+        }
+    }
+
+    bool anyInFlight() const { return transAInFlight || transBInFlight; }
+
+    /// Mirrors a single STREAMING-phase step:
+    ///   * drain one completion (FIFO order: A before B in async; current
+    ///     buffer in polling),
+    ///   * refill the freed buffer if more data remains.
+    /// Returns true if a step occurred (work done or completion drained).
+    bool stepStreaming() {
+        if (!anyInFlight()) return false;
+
+        // Drain one completion (FIFO: A queued first completes first).
+        if (usePolling) {
+            int lastBuf = (encodeIdx - 1) & 1;
+            if (lastBuf == 0) transAInFlight = false;
+            else              transBInFlight = false;
+        } else {
+            // FIFO: A completes before B if both are in flight.
+            if (transAInFlight)      transAInFlight = false;
+            else if (transBInFlight) transBInFlight = false;
+        }
+        ++completedCount;
+
+        // Refill the just-freed buffer when more data remains.
+        if (ledBytesRemaining > 0) {
+            int bufIdx = encodeIdx & 1;
+            size_t encoded = encodeChunk(bufIdx);
+            if (encoded > 0) {
+                if (bufIdx == 0) transAInFlight = true;
+                else             transBInFlight = true;
+                ++encodeIdx;
+                ++queuedCount;
+            }
+        }
+        return true;
+    }
+
+    /// Drain all remaining in-flight transactions (mirrors COMPLETING phase).
+    void drainAll() {
+        while (anyInFlight()) {
+            if (transAInFlight) transAInFlight = false;
+            else if (transBInFlight) transBInFlight = false;
+            ++completedCount;
+        }
+    }
+};
+
+// ---------------------------------------------------------------------------
+// Invariant: small strip that fits in one chunk → only A is queued.
+// ---------------------------------------------------------------------------
+FL_TEST_CASE("Ping-pong - single-chunk strip queues only A (async)") {
+    // 100 LEDs * 3 channels = 300 LED bytes; wave8 → 2400 SPI bytes; fits in 16 KB.
+    auto m = PipelineModel::make(/*bytes=*/300, /*capacity=*/16 * 1024,
+                                 /*polling=*/false);
+    m.startFirstDma();
+
+    CHECK_TRUE(m.transAInFlight);
+    FL_CHECK_FALSE(m.transBInFlight);
+    FL_CHECK_EQ(m.queuedCount, 1);
+    FL_CHECK_EQ(m.ledBytesRemaining, (size_t)0);
+}
+
+// ---------------------------------------------------------------------------
+// Invariant: long strip pre-queues BOTH A and B in startFirstDma() (async).
+// ---------------------------------------------------------------------------
+FL_TEST_CASE("Ping-pong - long strip pre-queues both A and B (async)") {
+    // 1000 LEDs * 3 = 3000 LED bytes; wave8 → 24000 SPI bytes; needs 2 chunks
+    // of 16 KB. This is the >~680-LED regression case from issue #2304.
+    auto m = PipelineModel::make(/*bytes=*/3000, /*capacity=*/16 * 1024,
+                                 /*polling=*/false);
+    m.startFirstDma();
+
+    CHECK_TRUE(m.transAInFlight);
+    CHECK_TRUE(m.transBInFlight);
+    FL_CHECK_EQ(m.queuedCount, 2);
+    // Both chunks already encoded → no LED bytes left.
+    FL_CHECK_EQ(m.ledBytesRemaining, (size_t)0);
+}
+
+// ---------------------------------------------------------------------------
+// Invariant: polling path (ESP32-C6) keeps the old single-in-flight behavior.
+// ---------------------------------------------------------------------------
+FL_TEST_CASE("Ping-pong - polling path queues only A even on long strip") {
+    auto m = PipelineModel::make(/*bytes=*/3000, /*capacity=*/16 * 1024,
+                                 /*polling=*/true);
+    m.startFirstDma();
+
+    CHECK_TRUE(m.transAInFlight);
+    FL_CHECK_FALSE(m.transBInFlight);
+    FL_CHECK_EQ(m.queuedCount, 1);
+}
+
+// ---------------------------------------------------------------------------
+// Invariant: for very long strips (3+ chunks), the refill loop keeps 2
+// transactions in flight at all times until the last chunk is queued.
+// ---------------------------------------------------------------------------
+FL_TEST_CASE("Ping-pong - refill loop maintains two in flight on 3-chunk strip") {
+    // 6000 LED bytes / (16384/8 = 2048 bytes per chunk) = 2.93 → 3 chunks.
+    auto m = PipelineModel::make(/*bytes=*/6000, /*capacity=*/16 * 1024,
+                                 /*polling=*/false);
+    m.startFirstDma();
+    // After pre-queue, A+B queued (=2), C still pending (2000 LED bytes left).
+    FL_CHECK_EQ(m.queuedCount, 2);
+    CHECK_TRUE(m.transAInFlight);
+    CHECK_TRUE(m.transBInFlight);
+    FL_CHECK_EQ(m.ledBytesRemaining, (size_t)6000 - 2 * 2048);
+
+    // First completion (transA): drain + refill into A. Now A and B both in
+    // flight again, and ledBytesRemaining == 0 (3rd chunk filled A).
+    bool stepped = m.stepStreaming();
+    CHECK_TRUE(stepped);
+    FL_CHECK_EQ(m.queuedCount, 3);
+    CHECK_TRUE(m.anyInFlight());
+    FL_CHECK_EQ(m.ledBytesRemaining, (size_t)0);
+}
+
+// ---------------------------------------------------------------------------
+// Invariant: refill never queues more than 2 chunks ahead of the consumer.
+// Hard cap is enforced by the buffer count (only A and B exist).
+// ---------------------------------------------------------------------------
+FL_TEST_CASE("Ping-pong - queue depth never exceeds 2") {
+    auto m = PipelineModel::make(/*bytes=*/24000, /*capacity=*/16 * 1024,
+                                 /*polling=*/false);
+    m.startFirstDma();
+
+    // Drive the pipeline to completion, checking at every step that we never
+    // exceed queue_size = 2 (the physical buffer cap).
+    int safety = 100;
+    while (m.anyInFlight() || m.ledBytesRemaining > 0) {
+        int inFlight = (m.transAInFlight ? 1 : 0) + (m.transBInFlight ? 1 : 0);
+        CHECK_TRUE(inFlight <= 2);
+        if (!m.stepStreaming()) break;
+        if (--safety <= 0) break;
+    }
+    FL_CHECK_GT(safety, 0);                 // didn't loop forever
+    FL_CHECK_EQ(m.ledBytesRemaining, (size_t)0);
+}
+
+// ---------------------------------------------------------------------------
+// Invariant: every byte of LED data is eventually transmitted (no chunk
+// drop) and the queued/completed counters match at the end.
+// ---------------------------------------------------------------------------
+FL_TEST_CASE("Ping-pong - all bytes accounted for after drain") {
+    const size_t TOTAL_BYTES = 12345;  // odd number, forces partial last chunk
+    auto m = PipelineModel::make(TOTAL_BYTES, /*capacity=*/4 * 1024,
+                                 /*polling=*/false);
+
+    m.startFirstDma();
+    while (m.anyInFlight() || m.ledBytesRemaining > 0) {
+        m.stepStreaming();
+    }
+    m.drainAll();
+
+    FL_CHECK_EQ(m.ledBytesRemaining, (size_t)0);
+    FL_CHECK_EQ(m.queuedCount, m.completedCount);
+    FL_CHECK_GT(m.queuedCount, 1);   // multi-chunk strip → at least 2 queued
+}
+
+// ---------------------------------------------------------------------------
+// Invariant: polling path drains correctly too (one in flight at a time, but
+// all bytes still get sent).
+// ---------------------------------------------------------------------------
+FL_TEST_CASE("Ping-pong - polling path drains all bytes") {
+    const size_t TOTAL_BYTES = 8000;
+    auto m = PipelineModel::make(TOTAL_BYTES, /*capacity=*/4 * 1024,
+                                 /*polling=*/true);
+
+    m.startFirstDma();
+    while (m.anyInFlight() || m.ledBytesRemaining > 0) {
+        m.stepStreaming();
+    }
+    m.drainAll();
+
+    FL_CHECK_EQ(m.ledBytesRemaining, (size_t)0);
+    FL_CHECK_EQ(m.queuedCount, m.completedCount);
+    // Polling path: only ever 1 in flight at a time.
+    // queuedCount == number of chunks == ceil(TOTAL_BYTES / (capacity/8))
+    const size_t bytes_per_chunk = (4 * 1024) / 8;
+    const size_t expected_chunks =
+        (TOTAL_BYTES + bytes_per_chunk - 1) / bytes_per_chunk;
+    FL_CHECK_EQ((size_t)m.queuedCount, expected_chunks);
+}
+
+// ---------------------------------------------------------------------------
+// Regression: the issue's specific repro — 680-LED boundary.
+// 680 LEDs * 3 channels = 2040 LED bytes; wave8 → 16320 SPI bytes; just under
+// 16 KB. 681 LEDs goes over the single-chunk limit.
+// ---------------------------------------------------------------------------
+FL_TEST_CASE("Ping-pong - 680-LED boundary regression (#2304)") {
+    // 680 LEDs RGB → 2040 LED bytes → 16320 SPI bytes → fits in 16 KB
+    auto small = PipelineModel::make(/*bytes=*/2040, /*capacity=*/16 * 1024,
+                                     /*polling=*/false);
+    small.startFirstDma();
+    FL_CHECK_EQ(small.queuedCount, 1);  // single chunk, no pre-queue needed
+
+    // 681 LEDs RGB → 2043 LED bytes → 16344 SPI bytes → needs 2 chunks
+    auto big = PipelineModel::make(/*bytes=*/2043, /*capacity=*/16 * 1024,
+                                   /*polling=*/false);
+    big.startFirstDma();
+    FL_CHECK_EQ(big.queuedCount, 2);  // pre-queues both A and B
+}
+
+} // namespace spi_pingpong_pipeline_logic_test
+
+} // FL_TEST_FILE

--- a/tests/platforms/esp/32/drivers/spi/spi_pingpong_pipeline_logic.cpp
+++ b/tests/platforms/esp/32/drivers/spi/spi_pingpong_pipeline_logic.cpp
@@ -282,19 +282,20 @@ FL_TEST_CASE("Ping-pong - polling path drains all bytes") {
 }
 
 // ---------------------------------------------------------------------------
-// Regression: the issue's specific repro — 680-LED boundary.
-// 680 LEDs * 3 channels = 2040 LED bytes; wave8 → 16320 SPI bytes; just under
-// 16 KB. 681 LEDs goes over the single-chunk limit.
+// Regression: the issue's specific repro — chunk-boundary behaviour around
+// the >~680-LED case. A 16 KB staging buffer with wave8 expansion holds
+// exactly 2048 LED bytes (≈ 682 RGB LEDs). 682-LED strips fit in a single
+// chunk; 683+ LED strips need two and must trigger the pre-queue path.
 // ---------------------------------------------------------------------------
-FL_TEST_CASE("Ping-pong - 680-LED boundary regression (#2304)") {
-    // 680 LEDs RGB → 2040 LED bytes → 16320 SPI bytes → fits in 16 KB
-    auto small = PipelineModel::make(/*bytes=*/2040, /*capacity=*/16 * 1024,
+FL_TEST_CASE("Ping-pong - 682-LED boundary regression (#2304)") {
+    // 682 LEDs RGB → 2046 LED bytes → 16368 SPI bytes → still fits in 16 KB
+    auto small = PipelineModel::make(/*bytes=*/2046, /*capacity=*/16 * 1024,
                                      /*polling=*/false);
     small.startFirstDma();
     FL_CHECK_EQ(small.queuedCount, 1);  // single chunk, no pre-queue needed
 
-    // 681 LEDs RGB → 2043 LED bytes → 16344 SPI bytes → needs 2 chunks
-    auto big = PipelineModel::make(/*bytes=*/2043, /*capacity=*/16 * 1024,
+    // 683 LEDs RGB → 2049 LED bytes → 16392 SPI bytes → needs 2 chunks
+    auto big = PipelineModel::make(/*bytes=*/2049, /*capacity=*/16 * 1024,
                                    /*polling=*/false);
     big.startFirstDma();
     FL_CHECK_EQ(big.queuedCount, 2);  // pre-queues both A and B

--- a/tests/platforms/esp/32/drivers/spi/spi_pingpong_pipeline_logic.cpp
+++ b/tests/platforms/esp/32/drivers/spi/spi_pingpong_pipeline_logic.cpp
@@ -109,25 +109,28 @@ struct PipelineModel {
     bool stepStreaming() {
         if (!anyInFlight()) return false;
 
-        // Drain one completion (FIFO: A queued first completes first).
+        // Drain one completion. Record which buffer freed up so the refill
+        // goes to that same buffer — modeling the ESP-IDF SPI driver where
+        // each staging buffer is independently tracked. Encoding always
+        // targets the just-freed buffer, never the one still in flight.
+        int drainedBuf = -1;
         if (usePolling) {
             int lastBuf = (encodeIdx - 1) & 1;
-            if (lastBuf == 0) transAInFlight = false;
-            else              transBInFlight = false;
+            if (lastBuf == 0) { transAInFlight = false; drainedBuf = 0; }
+            else              { transBInFlight = false; drainedBuf = 1; }
         } else {
             // FIFO: A completes before B if both are in flight.
-            if (transAInFlight)      transAInFlight = false;
-            else if (transBInFlight) transBInFlight = false;
+            if (transAInFlight)      { transAInFlight = false; drainedBuf = 0; }
+            else if (transBInFlight) { transBInFlight = false; drainedBuf = 1; }
         }
         ++completedCount;
 
         // Refill the just-freed buffer when more data remains.
-        if (ledBytesRemaining > 0) {
-            int bufIdx = encodeIdx & 1;
-            size_t encoded = encodeChunk(bufIdx);
+        if (ledBytesRemaining > 0 && drainedBuf >= 0) {
+            size_t encoded = encodeChunk(drainedBuf);
             if (encoded > 0) {
-                if (bufIdx == 0) transAInFlight = true;
-                else             transBInFlight = true;
+                if (drainedBuf == 0) transAInFlight = true;
+                else                 transBInFlight = true;
                 ++encodeIdx;
                 ++queuedCount;
             }


### PR DESCRIPTION
## Summary

Closes the inter-chunk SPI gap that opens when a long WS2812B strip (>~680 LEDs) splits into multiple DMA transactions. The naive ping-pong (queue A → wait → queue B → wait → …) lets the SPI line idle for the host-task latency between chunks. Under RTOS contention that gap can exceed WS2812B's ~50 µs reset threshold and trigger a visible refresh on the strip.

Refs #2304. Hardware byte-equality + on-device timing validation deferred (call-out below).

## What changed

\`src/platforms/esp/32/drivers/spi/channel_driver_spi.cpp.hpp\`:

- **\`startFirstDma()\`** — when async-DMA is in use AND the encoded payload exceeds a single staging buffer, pre-encode and pre-queue buffer B immediately after queuing A. ESP-IDF's SPI driver permits multiple in-flight transactions (`dev_config.queue_size = 4` was already in place); the ISR now transitions A → B without any host involvement, eliminating the inter-chunk gap. Cap is 2 in flight to keep the pipeline shallow and predictable.
- **\`advancePipeline()\`** — in-flight detector switched from the single \`mPipeline.mDmaInFlight\` bool to \`transAInFlight || transBInFlight\` (refreshed per iteration). When one chunk completes and data remains, the just-freed buffer is refilled and re-queued, maintaining 2-in-flight as long as there's payload.
- **ESP32-C6 split-polling path** (\`kSpiUsePolling = true\`) preserved: \`spi_device_polling_start\` only allows one in-flight polling transaction at a time. C6 keeps single-queue behavior; benefits from the encode/wait overlap but cannot get ISR-chained gap-free streaming without an ESP-IDF API change. Documented inline.

## Tests added

\`tests/platforms/esp/32/drivers/spi/spi_pingpong_pipeline_logic.cpp\` (new, ~305 lines) — host-side state-machine tests with no ESP-IDF dependency. Models the buffer-rotation invariants in plain C++ and verifies:

1. Both A and B are queued for long strips in async mode
2. Only A is queued for one-chunk strips
3. Refill-on-completion is ping-pong (whichever finishes first gets refilled)
4. At most 2 chunks in flight while data remains
5. Final drain waits for BOTH outstanding before marking the channel complete

## Test plan

- [x] Host-side state-machine tests (the file above)
- [ ] **On-device byte equality** with the old single-queue behavior — deferred. Needs a real ESP32 + ≥1000-LED WS2812B strip.
- [ ] **On-device inter-chunk timing under RTOS contention** — the original symptom (>50µs gap triggering refresh) needs to be verified gone on hardware.
  Both via \`bash autoresearch --spi\` on hardware. Next iteration.

## Process note

The agent that drafted this PR was interrupted mid-stream when its \`bash test --clean\` (running from main checkout instead of the worktree) collided with stop-hook lock contention. The file deltas above are its pre-interruption work product, verified clean in the worktree at \`feat/2304-spi-dma-pingpong\`; main checkout was reverted of the leaked untracked test file. Recovered manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced gaps and fixed overlap for long ESP32 LED strips by improving the SPI DMA streaming pipeline and ensuring correct transition/completion behavior (issue `#2304`).
  * Harmonized async vs polling behaviors so transfers are queued and completed reliably.

* **Tests**
  * Added unit tests validating ping-pong DMA queueing, refill/drain sequences, queue-depth limits, byte accounting, polling vs async paths, and the `#2304` regression.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->