### PR TITLE
fix(meson): move zccache wrapping to build.ninja post-patch (#2714)

### DIFF
--- a/ci/meson/meson_markers.py
+++ b/ci/meson/meson_markers.py
@@ -276,3 +276,89 @@ def inject_ar_optimization_patches(build_dir: Path, source_dir: Path) -> bool:
     )
     _ar_opt_status_cache[str(build_dir)] = patches_active
     return patches_active
+
+
+# Ninja rules whose ``command =`` line should be prepended with zccache.
+# STATIC_LINKER is intentionally excluded — it is already wrapped by
+# ar_content_preserving.py (see ``inject_ar_optimization_patches``).
+_ZCCACHE_TARGET_RULES: tuple[str, ...] = (
+    "cpp_COMPILER",
+    "cpp_LINKER",
+    "c_COMPILER",
+    "c_LINKER",
+)
+
+
+def inject_zccache_wrapping(build_dir: Path, zccache_path: Optional[str]) -> bool:
+    """
+    Prepend ``zccache`` to the compile/link rule commands in ``build.ninja``.
+
+    The meson native file emits the BARE compiler (``ctc-clang++.exe``) so
+    that meson's configure-phase probes (``-xc++ -E -v -`` etc.) run against
+    a compiler that meson can parse. This helper applies the zccache
+    wrapping to the build-phase commands as a post-patch on the generated
+    ``build.ninja``, so caching behaviour is preserved.
+
+    Reads ``build.ninja`` once and writes at most once. Idempotent: if the
+    rule commands already start with the zccache path, nothing is written.
+
+    Args:
+        build_dir: Meson build directory containing ``build.ninja``.
+        zccache_path: Absolute path to the zccache binary, or ``None`` to
+            skip wrapping (e.g. in Docker where caching is disabled).
+
+    Returns:
+        True if wrapping is active (or zccache is None and no wrapping was
+        requested), False on read/write error or when ``build.ninja`` is
+        missing. See issue #2714.
+    """
+    if zccache_path is None:
+        return True
+
+    build_ninja_path = build_dir / "build.ninja"
+    if not build_ninja_path.exists():
+        return False
+
+    try:
+        content = build_ninja_path.read_text(encoding="utf-8")
+    except OSError:
+        return False
+
+    # Use forward slashes so the prefix matches whatever path style meson
+    # emitted (meson normalises paths to forward slashes in some cases).
+    # The actual quoting in build.ninja uses backslashes on Windows; we
+    # use a substring search that doesn't care about quote style.
+    zccache_quoted = f'"{zccache_path}"'
+
+    new_content = content
+    for rule_name in _ZCCACHE_TARGET_RULES:
+        rule_marker = f"rule {rule_name}\n"
+        rule_pos = new_content.find(rule_marker)
+        if rule_pos == -1:
+            continue
+        # Find the command line inside this rule block.
+        block_end = new_content.find("\n\n", rule_pos)
+        if block_end == -1:
+            block_end = len(new_content)
+        cmd_prefix = " command = "
+        cmd_start = new_content.find(cmd_prefix, rule_pos, block_end)
+        if cmd_start == -1:
+            continue
+        value_start = cmd_start + len(cmd_prefix)
+        # Idempotency: if the command already starts with the zccache path,
+        # nothing to do for this rule.
+        existing_value = new_content[value_start:block_end]
+        if existing_value.startswith(zccache_quoted + " "):
+            continue
+        new_content = (
+            new_content[:value_start] + zccache_quoted + " " + new_content[value_start:]
+        )
+
+    if new_content == content:
+        return True
+
+    try:
+        build_ninja_path.write_text(new_content, encoding="utf-8")
+    except OSError:
+        return False
+    return True

--- a/ci/meson/meson_markers.py
+++ b/ci/meson/meson_markers.py
@@ -321,14 +321,21 @@ def inject_zccache_wrapping(build_dir: Path, zccache_path: Optional[str]) -> boo
 
     try:
         content = build_ninja_path.read_text(encoding="utf-8")
+    except KeyboardInterrupt as ki:
+        handle_keyboard_interrupt(ki)
+        raise
     except OSError:
         return False
 
-    # Use forward slashes so the prefix matches whatever path style meson
-    # emitted (meson normalises paths to forward slashes in some cases).
-    # The actual quoting in build.ninja uses backslashes on Windows; we
-    # use a substring search that doesn't care about quote style.
-    zccache_quoted = f'"{zccache_path}"'
+    # Normalize zccache_path to forward slashes so the idempotency check
+    # works regardless of whether the input path uses backslashes (Windows
+    # ``Path.__str__()``) or forward slashes (Meson normalisation). Meson
+    # emits forward slashes in ``build.ninja`` even on Windows, so we
+    # inject the normalized form and compare against it. Without this, a
+    # second invocation with a backslashed input path would not match the
+    # already-injected forward-slash prefix and would double-wrap.
+    zccache_path_normalized = zccache_path.replace("\\", "/")
+    zccache_quoted = f'"{zccache_path_normalized}"'
 
     new_content = content
     for rule_name in _ZCCACHE_TARGET_RULES:
@@ -359,6 +366,9 @@ def inject_zccache_wrapping(build_dir: Path, zccache_path: Optional[str]) -> boo
 
     try:
         build_ninja_path.write_text(new_content, encoding="utf-8")
+    except KeyboardInterrupt as ki:
+        handle_keyboard_interrupt(ki)
+        raise
     except OSError:
         return False
     return True

--- a/ci/meson/meson_setup_execute.py
+++ b/ci/meson/meson_setup_execute.py
@@ -27,6 +27,7 @@ from ci.meson.meson_markers import (
     _write_configuration_markers,
     cleanup_stale_meson_lockfile,
     inject_ar_optimization_patches,
+    inject_zccache_wrapping,
 )
 from ci.meson.meson_setup_phases import (
     CompilerDetection,
@@ -153,9 +154,16 @@ def write_meson_native_file(
     native_file_path: Path,
     compiler: CompilerDetection,
 ) -> None:
-    """Generate/update the Meson native file with tool paths + platform info."""
+    """Generate/update the Meson native file with tool paths + platform info.
+
+    The compiler entries point at the BARE ctc-clang/ctc-clang++ binaries.
+    zccache wrapping is applied later as a post-patch on ``build.ninja`` via
+    ``inject_zccache_wrapping`` so the meson configure-phase probes (e.g.
+    ``-xc++ -E -v -``) run against the bare compiler and complete in <1s
+    instead of timing out under zccache. See issue #2714.
+    """
     try:
-        fast = _resolve_fast_native_entries(compiler.cache_binary)
+        fast = _resolve_fast_native_entries()
         if fast.cc is not None:
             c_compiler = fast.cc
             cpp_compiler = fast.cxx
@@ -317,6 +325,7 @@ def handle_skip_meson_setup(
     )
 
     inject_ar_optimization_patches(build_dir, source_dir)
+    inject_zccache_wrapping(build_dir, compiler.cache_binary)
     if normalize_meson_private_include_paths(build_dir):
         _ts_print("[MESON] Normalized private include paths for zccache strict mode")
     _enforce_strict_path_violations(build_dir)
@@ -628,6 +637,7 @@ def run_meson_setup_command(
         )
 
         inject_ar_optimization_patches(build_dir, source_dir)
+        inject_zccache_wrapping(build_dir, compiler.cache_binary)
         if normalize_meson_private_include_paths(build_dir):
             _ts_print(
                 "[MESON] Normalized private include paths for zccache strict mode"

--- a/ci/meson/meson_setup_execute.py
+++ b/ci/meson/meson_setup_execute.py
@@ -325,7 +325,14 @@ def handle_skip_meson_setup(
     )
 
     inject_ar_optimization_patches(build_dir, source_dir)
-    inject_zccache_wrapping(build_dir, compiler.cache_binary)
+    if compiler.cache_binary and not inject_zccache_wrapping(
+        build_dir, compiler.cache_binary
+    ):
+        _ts_print(
+            f"[MESON] Warning: Failed to inject zccache wrapping into build.ninja "
+            f"(build_dir={build_dir}, zccache={compiler.cache_binary})",
+            file=sys.stderr,
+        )
     if normalize_meson_private_include_paths(build_dir):
         _ts_print("[MESON] Normalized private include paths for zccache strict mode")
     _enforce_strict_path_violations(build_dir)
@@ -637,7 +644,14 @@ def run_meson_setup_command(
         )
 
         inject_ar_optimization_patches(build_dir, source_dir)
-        inject_zccache_wrapping(build_dir, compiler.cache_binary)
+        if compiler.cache_binary and not inject_zccache_wrapping(
+            build_dir, compiler.cache_binary
+        ):
+            _ts_print(
+                f"[MESON] Warning: Failed to inject zccache wrapping into build.ninja "
+                f"(build_dir={build_dir}, zccache={compiler.cache_binary})",
+                file=sys.stderr,
+            )
         if normalize_meson_private_include_paths(build_dir):
             _ts_print(
                 "[MESON] Normalized private include paths for zccache strict mode"

--- a/ci/meson/native_launchers.py
+++ b/ci/meson/native_launchers.py
@@ -293,9 +293,7 @@ def get_zccache_version(zccache_path: Optional[str] = None) -> str:
         return ""
 
 
-def _resolve_fast_native_entries(
-    cache_binary: Optional[str],
-) -> FastNativeEntries:
+def _resolve_fast_native_entries() -> FastNativeEntries:
     """
     Resolve native launcher binaries for the Meson native file.
 
@@ -303,9 +301,18 @@ def _resolve_fast_native_entries(
     specific flags automatically (--target, --sysroot, -stdlib, includes, etc.)
     with near-zero startup overhead (~34ms vs ~1200ms for Python wrappers).
 
-    Args:
-        cache_binary: Path to compiler cache binary (zccache),
-            or None to disable caching.
+    Note: zccache wrapping is intentionally NOT applied here. The meson
+    configure phase runs probes like ``<cc> -xc++ -E -v -`` to scan the
+    compiler's include search paths and capabilities. zccache (and other
+    full-path compiler caches that meson does not recognise — see
+    ``mesonbuild/envconfig.py:BinaryTable.parse_entry`` which only strips
+    the literal strings ``'ccache'`` / ``'sccache'``) wraps those probes
+    and causes them to hang or return non-parseable output, leading to
+    "No include directory found" warnings followed by failing capability
+    probes. Instead, zccache is applied as a post-patch on the generated
+    ``build.ninja`` via ``inject_zccache_wrapping`` — probes run against
+    the bare compiler, build runs through zccache as before. See issue
+    #2714.
 
     Returns:
         FastNativeEntries with cc, cxx, and ar entries for the native file,
@@ -327,16 +334,9 @@ def _resolve_fast_native_entries(
         if ctc_c is None or ctc_cpp is None:
             return _none
 
-        def _make_entry(binary: str) -> str:
-            parts: list[str] = []
-            if cache_binary:
-                parts.append(f"'{cache_binary}'")
-            parts.append(f"'{binary}'")
-            return "[" + ", ".join(parts) + "]"
-
         return FastNativeEntries(
-            cc=_make_entry(ctc_c),
-            cxx=_make_entry(ctc_cpp),
+            cc=f"['{ctc_c}']",
+            cxx=f"['{ctc_cpp}']",
             ar=f"['{ar_path}']",
         )
 

--- a/ci/meson/native_launchers.py
+++ b/ci/meson/native_launchers.py
@@ -334,10 +334,18 @@ def _resolve_fast_native_entries() -> FastNativeEntries:
         if ctc_c is None or ctc_cpp is None:
             return _none
 
+        # Escape any single quotes in the path so the generated Meson
+        # list-of-strings remains valid even if a path happens to contain
+        # one. Paths under ``.cached/clang-native/`` are extremely unlikely
+        # to contain ``'`` in practice, but defensive escaping costs nothing
+        # and avoids a hard-to-debug native-file parse error.
+        def _q(p: str) -> str:
+            return p.replace("'", "\\'")
+
         return FastNativeEntries(
-            cc=f"['{ctc_c}']",
-            cxx=f"['{ctc_cpp}']",
-            ar=f"['{ar_path}']",
+            cc=f"['{_q(ctc_c)}']",
+            cxx=f"['{_q(ctc_cpp)}']",
+            ar=f"['{_q(ar_path)}']",
         )
 
     except KeyboardInterrupt as ki:


### PR DESCRIPTION
## Summary

Fixes #2714. The meson in-place reconfigure hangs / fails on Windows because the configure-phase compiler probe (`<cc> -xc++ -E -v -`) runs wrapped in zccache, which hangs >90s on some boxes (the bug reporter's environment included). Closes #2714.

## Root cause

The meson native file emitted compiler entries of the form `[zccache.exe, ctc-clang++.exe]`. Meson's `BinaryTable.parse_entry` (`mesonbuild/envconfig.py:465-470`) only strips the literal strings `ccache` / `sccache` from the head of a compiler list, so the full-path zccache survived `get_exelist(ccache=False)` (`compilers/mixins/gnu.py:401`) and the probe ran wrapped. On the reporter's box (and reproduced here) that wrapped probe hung indefinitely instead of the bare compiler's <1s, producing `No include directory found` warnings followed by failing capability probes (`Compiler does not support -std=c++11`) and an aborted setup.

Full investigation: https://github.com/FastLED/FastLED/issues/2714#issuecomment-4630543119

## Fix

Split configure-phase and build-phase responsibility:

1. **`ci/meson/native_launchers.py`** - `_resolve_fast_native_entries` now emits the BARE `ctc-clang` / `ctc-clang++` entries. The `cache_binary` parameter is removed. Meson sees what it can parse, so probes run natively.
2. **`ci/meson/meson_markers.py`** - new `inject_zccache_wrapping(build_dir, zccache_path)` helper, sibling to the existing `inject_ar_optimization_patches`. After the setup step produces `build.ninja`, it rewrites the `cpp_COMPILER`, `cpp_LINKER`, `c_COMPILER`, `c_LINKER` rule command lines to prepend the zccache binary. `STATIC_LINKER` is intentionally excluded since it is already wrapped by `ar_content_preserving.py`. Idempotent, read-once / write-at-most-once, same pattern as the existing helper.
3. **`ci/meson/meson_setup_execute.py`** - both call sites of `inject_ar_optimization_patches` (`handle_skip_meson_setup` and `run_meson_setup_command`) gain a paired `inject_zccache_wrapping(build_dir, compiler.cache_binary)` call.

Build-phase behaviour is unchanged: zccache still wraps every compile and link command. Only the configure-phase probes now run against the bare compiler. The existing `zccache_version` marker (`build_config.py:279-299`) continues to force reconfigure on zccache upgrades, which then re-runs the post-patch with the new path.

## Files touched

```
 ci/meson/meson_markers.py           | 86 +++++++++++++++++++++++++++++++++++++
 ci/meson/meson_setup_execute.py     | 14 +++++-
 ci/meson/native_launchers.py        | 30 ++++++-------
 3 files changed, 113 insertions(+), 17 deletions(-)
```

## Before / after (Windows 10, bug reporter's environment)

| Phase | Before | After |
|------|-------|------|
| Configure probe `<cc> -xc++ -E -v -` | hangs >90s, killed | <1s (bare `ctc-clang++.exe`) |
| Configure phase total | aborts with `C++ Compiler does not support -std=c++11` | 0.78s, `-std=c++11: YES` |
| In-place reconfigure on test-file change (the exact bug scenario) | fails | 1.13s configure, full run 50s, 309/309 pass |
| `build.ninja` `cpp_COMPILER` rule | unchanged | zccache wrapping applied via post-patch |

Note: the bug reporter's box also has a separate pre-existing zccache-daemon-health issue (daemon-side `recv timed out after 300s` for every compile) that is independent of this fix. Verification above was performed with `FASTLED_DOCKER=1` to bypass zccache and isolate the configure-phase fix; the configure phase itself works identically with and without zccache.

## Test plan

- [x] Wipe `.build/meson-quick`, run `bash test --cpp` - configure completes <1s, full run 50s, 309/309 pass
- [x] Modify a test-file content (the bug-triggering scenario per the original report) and re-run `bash test --cpp` - the build system auto-detects test changes, reconfigures in 1.13s, then 309/309 pass
- [x] Inspect generated `build.ninja` - `cpp_COMPILER` and `cpp_LINKER` rules carry `zccache.exe` prefix; `STATIC_LINKER` retains its `ar_content_preserving.py` wrapper untouched
- [x] Inspect `meson-log.txt` - no `No include directory found` warnings; `-std=c++11: YES`
- [x] `bash lint` passes
- [ ] CI verification - Linux / macOS builds (this fix is platform-agnostic; the zccache wrapping path is shared)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved Meson build integration to apply compiler-caching wrapping to generated build files after setup, and to resolve native launcher entries against the bare toolchain so configure probes run correctly.
* **Bug Fixes**
  * Prevented double-wrapping of cache paths across platforms and emit warnings when cache wrapping cannot be applied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->