### PR TITLE
chore(ci): disable scheduled niteris/fastled-compiler-* image rebuilds (#2812 Phase 1)

### DIFF
--- a/.github/workflows/docker_compiler.yml
+++ b/.github/workflows/docker_compiler.yml
@@ -11,9 +11,13 @@ on:
         description: 'Trigger template workflow after base build'
         type: boolean
         default: true
-  schedule:
-    # Base image: once daily at 23:00 UTC (1 hour before smart build at 00:00)
-    - cron: '0 23 * * *'
+  # schedule: disabled per #2812 — the niteris/fastled-compiler-* images
+  # are being decommissioned (fbuild is now the default backend; the PIO
+  # self-poisoning that justified the Docker stop-gap is no longer a
+  # concern). `workflow_dispatch` retained so admin can rebuild on demand
+  # during the transition. Original cron preserved for reference:
+  # schedule:
+  #   - cron: '0 23 * * *'  # daily 23:00 UTC, base image
 
 env:
   BASE_IMAGE: niteris/fastled-compiler-base

--- a/.github/workflows/docker_compiler_avr.yml
+++ b/.github/workflows/docker_compiler_avr.yml
@@ -2,9 +2,10 @@ name: Docker Compiler - AVR
 
 on:
   workflow_dispatch:
-  schedule:
-    # Run every Monday at 00:00 UTC
-    - cron: '0 0 * * 1'
+  # schedule: disabled per #2812 — niteris/fastled-compiler-* images being
+  # decommissioned. `workflow_dispatch` retained for manual rebuild.
+  # schedule:
+  #   - cron: '0 0 * * 1'  # weekly Monday 00:00 UTC
 
 env:
   BASE_IMAGE: niteris/fastled-compiler-base

--- a/.github/workflows/docker_compiler_esp.yml
+++ b/.github/workflows/docker_compiler_esp.yml
@@ -2,9 +2,10 @@ name: Docker Compiler - ESP
 
 on:
   workflow_dispatch:
-  schedule:
-    # Run every Tuesday at 00:00 UTC
-    - cron: '0 0 * * 2'
+  # schedule: disabled per #2812 — niteris/fastled-compiler-* images being
+  # decommissioned. `workflow_dispatch` retained for manual rebuild.
+  # schedule:
+  #   - cron: '0 0 * * 2'  # weekly Tuesday 00:00 UTC
 
 env:
   BASE_IMAGE: niteris/fastled-compiler-base

--- a/.github/workflows/docker_compiler_nrf52.yml
+++ b/.github/workflows/docker_compiler_nrf52.yml
@@ -2,9 +2,10 @@ name: Docker Compiler - NRF52
 
 on:
   workflow_dispatch:
-  schedule:
-    # Run every Thursday at 00:00 UTC
-    - cron: '0 0 * * 4'
+  # schedule: disabled per #2812 — niteris/fastled-compiler-* images being
+  # decommissioned. `workflow_dispatch` retained for manual rebuild.
+  # schedule:
+  #   - cron: '0 0 * * 4'  # weekly Thursday 00:00 UTC
 
 env:
   BASE_IMAGE: niteris/fastled-compiler-base

--- a/.github/workflows/docker_compiler_rp.yml
+++ b/.github/workflows/docker_compiler_rp.yml
@@ -2,9 +2,10 @@ name: Docker Compiler - RP2040
 
 on:
   workflow_dispatch:
-  schedule:
-    # Run every Saturday at 00:00 UTC
-    - cron: '0 0 * * 6'
+  # schedule: disabled per #2812 — niteris/fastled-compiler-* images being
+  # decommissioned. `workflow_dispatch` retained for manual rebuild.
+  # schedule:
+  #   - cron: '0 0 * * 6'  # weekly Saturday 00:00 UTC
 
 env:
   BASE_IMAGE: niteris/fastled-compiler-base

--- a/.github/workflows/docker_compiler_sam.yml
+++ b/.github/workflows/docker_compiler_sam.yml
@@ -2,9 +2,10 @@ name: Docker Compiler - SAM
 
 on:
   workflow_dispatch:
-  schedule:
-    # Run every Sunday at 00:00 UTC
-    - cron: '0 0 * * 0'
+  # schedule: disabled per #2812 — niteris/fastled-compiler-* images being
+  # decommissioned. `workflow_dispatch` retained for manual rebuild.
+  # schedule:
+  #   - cron: '0 0 * * 0'  # weekly Sunday 00:00 UTC
 
 env:
   BASE_IMAGE: niteris/fastled-compiler-base

--- a/.github/workflows/docker_compiler_smart_build.yml
+++ b/.github/workflows/docker_compiler_smart_build.yml
@@ -1,9 +1,10 @@
 name: Docker Compiler Smart Build
 
 on:
-  schedule:
-    # Run every 24 hours at 00:00 UTC
-    - cron: '0 0 * * *'
+  # schedule: disabled per #2812 — niteris/fastled-compiler-* images being
+  # decommissioned. `workflow_dispatch` retained for manual rebuild.
+  # schedule:
+  #   - cron: '0 0 * * *'  # daily 00:00 UTC, smart incremental
   workflow_dispatch:
     inputs:
       limit:

--- a/.github/workflows/docker_compiler_stm32.yml
+++ b/.github/workflows/docker_compiler_stm32.yml
@@ -2,9 +2,10 @@ name: Docker Compiler - STM32
 
 on:
   workflow_dispatch:
-  schedule:
-    # Run every Wednesday at 00:00 UTC
-    - cron: '0 0 * * 3'
+  # schedule: disabled per #2812 — niteris/fastled-compiler-* images being
+  # decommissioned. `workflow_dispatch` retained for manual rebuild.
+  # schedule:
+  #   - cron: '0 0 * * 3'  # weekly Wednesday 00:00 UTC
 
 env:
   BASE_IMAGE: niteris/fastled-compiler-base

--- a/.github/workflows/docker_compiler_teensy.yml
+++ b/.github/workflows/docker_compiler_teensy.yml
@@ -2,9 +2,10 @@ name: Docker Compiler - Teensy
 
 on:
   workflow_dispatch:
-  schedule:
-    # Run every Friday at 00:00 UTC
-    - cron: '0 0 * * 5'
+  # schedule: disabled per #2812 — niteris/fastled-compiler-* images being
+  # decommissioned. `workflow_dispatch` retained for manual rebuild.
+  # schedule:
+  #   - cron: '0 0 * * 5'  # weekly Friday 00:00 UTC
 
 env:
   BASE_IMAGE: niteris/fastled-compiler-base

--- a/.github/workflows/docker_compiler_template.yml
+++ b/.github/workflows/docker_compiler_template.yml
@@ -15,10 +15,10 @@ on:
         description: 'Delay before building platforms (minutes)'
         type: number
         default: 0
-  schedule:
-    # Full build: monthly at 3:00 AM UTC on the 1st of each month
-    # (For daily smart builds, see docker_compiler_smart_build.yml)
-    - cron: '0 3 1 * *'
+  # schedule: disabled per #2812 — niteris/fastled-compiler-* images being
+  # decommissioned. `workflow_dispatch` retained for manual rebuild.
+  # schedule:
+  #   - cron: '0 3 1 * *'  # monthly, 1st @ 03:00 UTC, full platform rebuild
 
 env:
   BASE_IMAGE: niteris/fastled-compiler-base


### PR DESCRIPTION
## Summary

Phase 1 of the compilation-Docker decommission tracked in #2812. Disables the 10 cron-driven \`docker_compiler_*.yml\` workflows that rebuild the \`niteris/fastled-compiler-*\` Docker image family. \`workflow_dispatch\` is retained on each, so admin can still rebuild on demand during the multi-week transition window.

## Why

The \`niteris/fastled-compiler-*\` images were a stop-gap against PlatformIO's self-poisoning behavior (one platform's toolchain install corrupting another's cache). fbuild does not self-poison and has been the default backend in \`ci/ci-compile.py\` for some time (\`--backend fbuild\` default per \`ci/compiler/argument_parser.py:288\`). The Docker wrapper no longer earns its CI cost.

## What this PR changes

Comments out the \`schedule:\` block in 10 workflows, leaving \`workflow_dispatch\` intact:

| File | Was firing | Notes |
|---|---|---|
| \`docker_compiler.yml\` | daily 23:00 UTC | base image \`niteris/fastled-compiler-base\` |
| \`docker_compiler_smart_build.yml\` | daily 00:00 UTC | priority-driven incremental, 5 platforms/run |
| \`docker_compiler_template.yml\` | monthly 1st @ 03:00 UTC | full platform fan-out |
| \`docker_compiler_avr.yml\` | weekly Monday | per-platform standalone |
| \`docker_compiler_esp.yml\` | weekly Tuesday | per-platform standalone |
| \`docker_compiler_stm32.yml\` | weekly Wednesday | per-platform standalone |
| \`docker_compiler_nrf52.yml\` | weekly Thursday | per-platform standalone |
| \`docker_compiler_teensy.yml\` | weekly Friday | per-platform standalone |
| \`docker_compiler_rp.yml\` | weekly Saturday | per-platform standalone |
| \`docker_compiler_sam.yml\` | weekly Sunday | per-platform standalone |

Each disabled \`schedule:\` is preserved verbatim in a comment block right above where it was, with a reference to #2812, so revert is one commented-out block flip per file.

## What this PR does *not* do

- **Does not delete any workflows or images.** Existing Docker Hub images keep working for users of \`bash compile --docker\`, \`bash test --docker\`, and \`bash profile --docker\`. The eventual deletion is Phase 6 of #2812, done manually weeks after the code-side decommission lands.
- **Does not touch \`avr8js_*.yml\` or \`qemu_*.yml\`.** Those are emulator workflows with a JS/qemu runtime dependency, not PIO-isolation wrappers — out of scope.
- **Does not touch \`--docker\` flag plumbing in \`ci-compile.py\`.** That is Phase 2-5, a separate follow-up PR per #2812's plan.
- **Does not update README prose.** The "Docker Compiler Builds" block in README (lines 147-163) will show grayed-out badges (no recent runs) instead of red. Full prose cleanup is bundled into the Phase 2-5 PR.

## Side effect to expect

After merge, the README badges in the "Docker Compiler Builds" section will display "no status" (gray) instead of green or red. This is intentional and signals to readers that the rebuild schedule has stopped, in line with the decommission tracked in #2812.

## Test plan

Pure CI configuration change — no code touched, no local testing applies. Verification is qualitative:

- The YAML files still parse: \`bash lint\` clean (the project's YAML linter is part of \`bash lint\`).
- No workflow now has an active \`schedule:\` block: \`grep '^  schedule:' .github/workflows/docker_compiler*.yml\` returns nothing.
- \`workflow_dispatch:\` still present in all 10 files: 10/10 by grep count.

## Mandatory code-review trigger

Per global CI rules: modifying CI/CD pipelines is a code-review trigger. Flagging explicitly.

## Sequence

- **This PR (Phase 1)**: schedules off. Reversible in one revert.
- **Follow-up PR (Phases 2-5)**: delete \`--docker\` flag, delete Python orchestration, delete the 12 \`docker_compiler_*.yml\` workflows, clean up READMEs / docs. Bundled because half-and-half states (e.g. flag removed but workflows still reference \`niteris/fastled-compiler-*\`) would be intermediate-broken.
- **Phase 6 (manual, weeks later)**: deprecate / delete Docker Hub images.

Refs #2812.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled automated scheduled builds for Docker compiler images across multiple platforms. Manual build triggering remains available upon request.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->