### PR TITLE
fix(ci/clean-worktrees): suppress DCT002 on shutil.rmtree onerror tuple

### DIFF
--- a/ci/clean-worktrees.py
+++ b/ci/clean-worktrees.py
@@ -234,9 +234,14 @@ def remove_worktree(wt: Path) -> RemovalResult:
 def _rmtree_onerror(
     func: Callable[..., Any],
     path: str,
-    exc_info: tuple[type[BaseException], BaseException, TracebackType],
+    exc_info: tuple[type[BaseException], BaseException, TracebackType],  # noqa: DCT002
 ) -> None:
-    """shutil.rmtree onerror callback: clear read-only and retry once."""
+    """shutil.rmtree onerror callback: clear read-only and retry once.
+
+    The 3-tuple signature is Python's documented `shutil.rmtree(onerror=...)`
+    contract — replacing with a dataclass would break that interface, so the
+    DCT002 complexity warning is suppressed here.
+    """
     try:
         os.chmod(path, stat.S_IWUSR | stat.S_IRUSR)
         func(path)


### PR DESCRIPTION
Tiny follow-up to PRs #2796 + #2807 (both just merged this loop iteration).

The PlatformIO/DCT002 linter from #2807 now runs against the codebase and flags \`_rmtree_onerror(func, path, exc_info)\` in #2796's \`ci/clean-worktrees.py\` because of its 3-tuple type annotation on \`exc_info\`. But that signature is Python's documented \`shutil.rmtree(onerror=...)\` callback contract — replacing it with a dataclass would break that interface.

Suppress with a \`# noqa: DCT002\` and document the why so a future reader doesn't try to "fix" it.

Unblocks the stop hook lint stage that started failing after #2807 landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced internal documentation clarity in development tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->