### PR TITLE
fix(boards): case-insensitive fallback in create_board (#2779 attiny1604/1616 builds)

### DIFF
--- a/ci/boards.py
+++ b/ci/boards.py
@@ -1321,6 +1321,19 @@ def create_board(board_name: str, no_project_options: bool = False) -> Board:
                 board = candidate
                 break
 
+        # Case-insensitive fallback: some boards registered in `_BOARD_MAP`
+        # use camelCase (`ATtiny1604`, `ATtiny1616`) while CI workflows and
+        # docs frequently spell them lowercase. Resolving by lowercase
+        # before falling through to a generic Board avoids
+        # `UndefinedEnvPlatformError` at PlatformIO env-resolution time
+        # (FastLED #2779).
+        if board is None:
+            target = board_name.lower()
+            for candidate in ALL:
+                if candidate.board_name.lower() == target:
+                    board = candidate
+                    break
+
         if board is None:
             # No match found - create generic board without special overrides
             # Assume platformio will know what to do with it


### PR DESCRIPTION
## Summary

CI workflows and most build invocations spell tinyAVR-1 boards in
lowercase (\`attiny1604\`, \`attiny1616\`) while the \`Board\` definitions
in \`ci/boards.py:1057, 1068\` register them in camelCase (\`ATtiny1604\`,
\`ATtiny1616\`). \`create_board()\` did a single case-sensitive
\`_BOARD_MAP[board_name]\` lookup and, on miss, fell straight through to
a generic \`Board(...)\` without a \`platform=\` field. The result at PIO
env-resolution time:

\`\`\`
UndefinedEnvPlatformError: Please specify platform for 'attiny1604' environment
\`\`\`

That's two of the twelve workflows tracked in #2779 — specifically the
\`attiny1604\` and \`attiny1616\` rows in the Arduino/AVR family table.
The ATmega8/ATmega 4809 watchdog-symbol failures from the same issue
were already fixed in master (capability guard at
\`watchdog_avr.impl.hpp:25-50\` falls back to \`watchdog_noop.hpp\` when
\`MCUSR\` / \`WDRF\` / \`WDTO_8S\` aren't declared).

## Fix

Between the existing direct-match lookup and the
reverse-\`real_board_name\` alias lookup and the generic-Board fallback,
add a third try: case-insensitive \`board_name.lower()\` comparison
against every registered \`Board\`. Preserves backward compatibility for
callers that use the canonical camelCase spelling and resolves the
lowercase form to the correct \`Board\` object (with platform, framework,
MCU, partitions, etc. all intact).

## Verification

| Board (as passed) | Before | After |
|---|---|---|
| \`bash compile attiny1604\` | ❌ \`UndefinedEnvPlatformError\` | ✅ SUCCESS |
| \`bash compile attiny1616\` | ❌ \`UndefinedEnvPlatformError\` | ✅ SUCCESS |
| \`bash compile ATtiny1604\` | ✅ SUCCESS (unchanged) | ✅ SUCCESS |
| \`bash compile ATtiny1616\` | ✅ SUCCESS (unchanged) | ✅ SUCCESS |
| \`bash compile atmega8a\` | ✅ SUCCESS (unchanged) | ✅ SUCCESS |
| \`bash compile nano_every\` | ✅ SUCCESS (unchanged) | ✅ SUCCESS |
| \`bash compile rp2040\` | ✅ SUCCESS (unchanged) | ✅ SUCCESS |

## Test plan

- [x] \`bash lint\` — clean.
- [x] \`bash compile attiny1604 --examples Blink --platformio\` — SUCCESS.
- [x] \`bash compile attiny1616 --examples Blink --platformio\` — SUCCESS.
- [x] All previously-working board names still work (no regression).
- [ ] CI green on the README-listed \`attiny1604\` and \`attiny1616\`
      workflows once this lands.

## Scope note

This PR fixes only the **board-name resolution** half of #2779. The other
workflows in that issue's table:

| Workflow | Status |
|---|---|
| \`atmega8a\`, \`nano_every\` (AVR family) | Already fixed in master (watchdog capability guard) |
| \`attiny1604\`, \`attiny1616\` | **Fixed by this PR** |
| \`apollo3_red\`, \`apollo3_thing_explorable\` | Addressed by #2788 (watchdog/apollo3 fix); may need re-check |
| \`stm32h747xi_giga\` | Addressed by #2785 (STM32 GIGA core detection) |
| \`rp2040\` | Verified building successfully on master |
| Aggregate / size checks | Out of scope of board-name fix |

If the remaining workflows in #2779 are still red after this lands,
they're independent bugs and worth their own targeted fixes.

Issue: https://github.com/FastLED/FastLED/issues/2779

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced board name resolution with case-insensitive matching fallback to reduce PlatformIO environment resolution failures when exact board name matches are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->