### PR TITLE
perf(channels): runtime NetworkDetector-gated yield in waitForCondition (refs #2815)

### DIFF
--- a/src/fl/channels/driver.cpp.hpp
+++ b/src/fl/channels/driver.cpp.hpp
@@ -1,6 +1,7 @@
 
 #include "fl/channels/driver.h"
 #include "fl/log/log.h"
+#include "fl/net/network_detector.h"
 #include "fl/stl/chrono.h"
 #include "fl/task/executor.h"
 #include "platforms/is_platform.h"
@@ -18,17 +19,17 @@ bool IChannelDriver::waitForCondition(Condition condition, u32 timeoutMs) {
             return false;  // Timeout occurred
         }
 
-#if defined(FL_IS_ESP_32P4)
-        // ESP32-P4 has no network stack (no WiFi, no Bluetooth, no lwIP),
-        // so the deep-yield rationale from #2254 doesn't apply. taskYIELD()
-        // avoids the 1-tick (≥1 ms at CONFIG_FREERTOS_HZ=1000) floor that
-        // adds ~8 ms per frame in PARLIO multi-strip workloads (#2493).
-        task::run(0, task::ExecFlags::SYSTEM);
-#else
-        // OS yield only — keeps WiFi/lwIP alive without pumping
-        // tasks or coroutines in the driver polling loop.
-        task::run(250, task::ExecFlags::SYSTEM);
-#endif
+        // Adaptive yield (refs #2815, generalizes the #2493 ESP32-P4 carve-out):
+        // see the matching comment in ChannelManager::waitForCondition for the
+        // full rationale. The deep yield is only needed when a radio is
+        // actually up; otherwise the FreeRTOS tick floor is pure timing drift.
+        if (fl::NetworkDetector::isAnyNetworkActive()) {
+            // Radio active: keep WiFi/lwIP/BT alive with the deep yield.
+            task::run(250, task::ExecFlags::SYSTEM);
+        } else {
+            // No radio: fast yield, no FreeRTOS tick floor.
+            task::run(0, task::ExecFlags::SYSTEM);
+        }
     }
 
     return true;  // Condition met

--- a/src/fl/channels/manager.cpp.hpp
+++ b/src/fl/channels/manager.cpp.hpp
@@ -12,6 +12,7 @@
 #include "fl/stl/move.h"
 #include "fl/system/trace.h"
 #include "fl/task/executor.h"
+#include "fl/net/network_detector.h"
 #include "platforms/init_channel_driver.h"
 #include "platforms/is_platform.h"
 #include "fl/stl/noexcept.h"
@@ -371,17 +372,26 @@ bool ChannelManager::waitForCondition(Condition condition, u32 timeoutMs) {
             return false;  // Timeout occurred
         }
 
-#if defined(FL_IS_ESP_32P4)
-        // ESP32-P4 has no network stack (no WiFi, no Bluetooth, no lwIP),
-        // so the deep-yield rationale from #2254 doesn't apply. taskYIELD()
-        // avoids the 1-tick (≥1 ms at CONFIG_FREERTOS_HZ=1000) floor that
-        // adds ~8 ms per frame in PARLIO multi-strip workloads (#2493).
-        task::run(0, task::ExecFlags::SYSTEM);
-#else
-        // OS yield only — keeps WiFi/lwIP alive without pumping
-        // tasks or coroutines during frame transitions (re-entrancy risk).
-        task::run(250, task::ExecFlags::SYSTEM);
-#endif
+        // Adaptive yield (refs #2815, generalizes the #2493 ESP32-P4 carve-out):
+        //
+        // The 1-tick (>=1 ms at CONFIG_FREERTOS_HZ=1000) floor only exists to
+        // keep WiFi / lwIP / BT controller tasks alive while we are inside the
+        // channel wait loop (#2254). When no radio is actually up, that floor
+        // is pure timing drift -- visible as the regression reported in #2420
+        // and as the per-frame cost the #2493 ESP32-P4 carve-out was avoiding.
+        //
+        // NetworkDetector::isAnyNetworkActive() is the runtime version of the
+        // "is a radio up?" question. On non-ESP32 platforms and on ESP32-P4
+        // (no radio silicon) it folds to a constant `false`, so this is
+        // strictly a perf win for the common single-strip / no-WiFi case
+        // without losing the WiFi-friendly behavior when a radio is active.
+        if (fl::NetworkDetector::isAnyNetworkActive()) {
+            // Radio active: keep WiFi/lwIP/BT alive with the deep yield.
+            task::run(250, task::ExecFlags::SYSTEM);
+        } else {
+            // No radio: fast yield, no FreeRTOS tick floor.
+            task::run(0, task::ExecFlags::SYSTEM);
+        }
     }
 
     return true;  // Condition met

--- a/src/fl/net/network_detector.h
+++ b/src/fl/net/network_detector.h
@@ -1,0 +1,76 @@
+#pragma once
+
+/// @file fl/net/network_detector.h
+/// @brief Cross-platform facade for runtime network activity detection.
+///
+/// The full implementation lives at
+/// `src/platforms/esp/32/drivers/rmt/rmt_5/network_detector.h` and only compiles
+/// when `FASTLED_RMT5` is set. This facade exposes a `fl::NetworkDetector` type
+/// with the `isAnyNetworkActive()` accessor on every platform so that
+/// platform-neutral code (such as `fl/channels/manager.cpp.hpp` and
+/// `fl/channels/driver.cpp.hpp`) can perform a single runtime branch without
+/// having to ifdef around the RMT5 gate.
+///
+/// On platforms / build configurations where the real detector is not
+/// available, `isAnyNetworkActive()` returns false. That matches the
+/// pre-existing behavior for ESP32-P4 (which has no radio at all) and for all
+/// non-ESP32 platforms (where the deep-yield rationale from #2254 does not
+/// apply in the first place).
+///
+/// Cost on platforms where the real implementation is present is the ~1-10 us
+/// the ESP-IDF API takes per call (see the detailed docs on the
+/// implementation header). On every other platform the call collapses to a
+/// trivial `return false` and is folded into a constant by the optimizer.
+
+#include "platforms/is_platform.h"
+
+#if defined(FL_IS_ESP32)
+#include "platforms/esp/32/feature_flags/enabled.h"
+#endif
+
+// Use the real RMT5 implementation when available; otherwise fall through to
+// the stub below. The real header is itself wrapped in `#if FASTLED_RMT5`, so
+// including it on RMT4-only / non-ESP32 builds is harmless (the class
+// definition simply disappears).
+#if defined(FL_IS_ESP32) && FASTLED_RMT5
+#include "platforms/esp/32/drivers/rmt/rmt_5/network_detector.h"
+#define FL_NETWORK_DETECTOR_HAS_REAL_IMPL 1
+#else
+#define FL_NETWORK_DETECTOR_HAS_REAL_IMPL 0
+#endif
+
+#if !FL_NETWORK_DETECTOR_HAS_REAL_IMPL
+
+#include "fl/stl/noexcept.h"
+
+namespace fl {
+
+/// @brief Stub NetworkDetector for platforms without the real implementation.
+///
+/// Returns false for every accessor. This is the correct answer on:
+///   - ESP32-P4 (no radio silicon at all)
+///   - Non-ESP32 platforms (no FreeRTOS / WiFi / BT, deep-yield concern N/A)
+///   - ESP32 builds that disable the RMT5 driver (FASTLED_RMT5=0)
+///
+/// Behavior matches the existing FL_IS_ESP_32P4 carve-out in the channel
+/// wait loops (refs #2493, #2815).
+class NetworkDetector {
+  public:
+    static bool isWiFiActive() FL_NOEXCEPT { return false; }
+    static bool isWiFiConnected() FL_NOEXCEPT { return false; }
+    static bool isEthernetActive() FL_NOEXCEPT { return false; }
+    static bool isEthernetConnected() FL_NOEXCEPT { return false; }
+    static bool isBluetoothActive() FL_NOEXCEPT { return false; }
+    static bool isAnyNetworkActive() FL_NOEXCEPT { return false; }
+    static bool isAnyNetworkConnected() FL_NOEXCEPT { return false; }
+
+  private:
+    NetworkDetector() = delete;
+    ~NetworkDetector() = delete;
+    NetworkDetector(const NetworkDetector &) = delete;
+    NetworkDetector &operator=(const NetworkDetector &) = delete;
+};
+
+} // namespace fl
+
+#endif // !FL_NETWORK_DETECTOR_HAS_REAL_IMPL


### PR DESCRIPTION
## Summary

Refs #2815 (Track 2 only).

Replaces the compile-time `#if defined(FL_IS_ESP_32P4)` carve-out in the channels wait loops with a runtime `fl::NetworkDetector::isAnyNetworkActive()` check. When no radio is up, the wait collapses to a fast `fl::yield()` path (no FreeRTOS tick floor). When a radio *is* up, the existing deep yield is preserved so WiFi / lwIP / BT controller tasks don't starve (#2254).

This generalizes the #2493 ESP32-P4 carve-out into the actual condition that motivates it ("is a radio actually running?"), removing the platform-specific branch entirely.

## Before / after

```cpp
// Before -- compile-time, ESP32-P4 only:
#if defined(FL_IS_ESP_32P4)
    task::run(0, task::ExecFlags::SYSTEM);
#else
    task::run(250, task::ExecFlags::SYSTEM);
#endif

// After -- runtime, every platform:
if (fl::NetworkDetector::isAnyNetworkActive()) {
    task::run(250, task::ExecFlags::SYSTEM);  // keep WiFi/lwIP/BT alive
} else {
    task::run(0, task::ExecFlags::SYSTEM);    // fast yield, no tick floor
}
```

## Why this fixes the #2420 regression

`task::run(250, SYSTEM)` resolves to `pumpCoroutines(1000)` -> `vTaskDelay(>=1 tick)`, which on FreeRTOS at `CONFIG_FREERTOS_HZ=1000` is a **>= 1 ms floor** per spin iteration. For a sketch with no `WiFi.begin()` and a 35-LED WS2812B burst (~1 ms transmit), that floor doubles per-frame cost and accumulates as the timing drift reported in #2420. The runtime check skips the floor whenever no radio is actually running.

## Track 1 deferred

Track 1 (per-driver ISR-completion semaphore -- block on the driver's DMA-done callback instead of polling) is a larger refactor that touches every `IChannelDriver` and its peripheral plumbing (RMT5, PARLIO, LCD_SPI, I2S_SPI, LCD_CAM, LCD_RGB). It is **deferred to a follow-up PR**.

## #2493 carve-out removal

The `#if FL_IS_ESP_32P4` branch added in #2503 to mitigate the PARLIO 16.7 ms show() block (#2493) becomes unnecessary -- `NetworkDetector::isAnyNetworkActive()` returns `false` on ESP32-P4 (no radio silicon), so P4 still takes the fast path. The platform-specific carve-out is removed.

## NetworkDetector facade

The real `fl::NetworkDetector` implementation lives at `src/platforms/esp/32/drivers/rmt/rmt_5/network_detector.h` and is gated by `FASTLED_RMT5`. To make it callable from platform-neutral `fl/channels/` code without circular includes, a small facade is added at `src/fl/net/network_detector.h` that:

- delegates to the real RMT5 implementation when `FASTLED_RMT5 == 1`
- provides a stub `isAnyNetworkActive() { return false; }` everywhere else, matching the pre-existing ESP32-P4 / non-ESP32 behavior

On platforms where the real detector is unavailable, the call folds to a constant `false` and the optimizer collapses the runtime branch.

## Files changed (3)

- `src/fl/channels/manager.cpp.hpp` -- `ChannelManager::waitForCondition` template
- `src/fl/channels/driver.cpp.hpp` -- `IChannelDriver::waitForCondition` template
- `src/fl/net/network_detector.h` -- new cross-platform facade header (NEW)

## Test plan

- [x] `bash lint` clean
- [x] `bash test --cpp channel` passes (channel tests compile and run with the new runtime branch on host stub builds)
- [ ] On-hardware timing verification on ESP32-S3 (no WiFi) -- the #2420 reporter's 2500 ms sequence should now complete within ~+/-10 ms (deferred to validators)
- [ ] On-hardware verification on ESP32-S3 (WiFi connected) that lwIP throughput does not regress vs. master (the #2254 websocket scenario)
- [ ] On-hardware verification on ESP32-P4 PARLIO that the existing #2493 behavior is preserved (the runtime detector returns false on P4, so the fast path is unchanged)

Note: The two pre-existing test failures in this repo's master tip (`spi_pingpong_pipeline_logic` UBSAN overflow at line 126, and a related dependency-load failure for `spi_peripheral`) are unrelated to this PR -- both predate it and reproduce on master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced system resource management with adaptive yielding that responds to network activity
  * Improved timing accuracy and efficiency across all network scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->