### PR TITLE
chore(gitignore): ignore Claude Code per-session scratch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,6 +114,16 @@ src/platforms/wasm/compiler/node_modules/
 .claude/settings.local.json
 .claude/worktrees/
 .claude/scheduled_tasks.lock
+
+# Claude Code per-session scratch (PR review fetches, CI logs, issue drafts)
+.claude/cr-*.json
+.claude/pr*-*.json
+.claude/pr*_*.json
+.claude/issue_*.md
+.claude/*.log
+
+# Misc agent/tool transient stdout/stderr captures
+.tmp_*.txt
 ci/lint_cpp_rs/target/
 
 # AutoResearch transient logs


### PR DESCRIPTION
## Summary
- Add `.gitignore` patterns for Claude Code per-session scratch under `.claude/` (PR review fetches like `cr-*.json` / `pr*-*.json`, issue drafts, and `*.log` captures).
- Also ignore stray `.tmp_*.txt` stdout/stderr captures left behind by tool runs in the repo root.

These files were repeatedly showing up as untracked noise in `git status` after agent runs — none of them are project artifacts, they're regenerated on demand from GitHub.

## Test plan
- [x] `git status` is clean after the change with a fresh set of `.claude/cr-2797.json` etc. present locally
- [x] Existing `.claude/settings.local.json`, `.claude/worktrees/`, `.claude/scheduled_tasks.lock` rules untouched
- [ ] (CI) lint/test still pass — no source changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal project housekeeping configurations to improve file management during development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->