### PR TITLE
fix(ci,channels): restore fbuild + 330KB esp32 size budget (refs #2773)

### DIFF
--- a/.github/workflows/build_template_binary_size.yml
+++ b/.github/workflows/build_template_binary_size.yml
@@ -41,7 +41,7 @@ jobs:
         run: pip install uv
 
       - name: Check Compiled Program Size for ${{ inputs.board }}
-        run: uv run ci/ci-check-compiled-size.py ${{ inputs.board }} --backend platformio --max-size ${{ inputs.max_size }} --example Blink ${{ inputs.extra_args }}
+        run: uv run ci/ci-check-compiled-size.py ${{ inputs.board }} --max-size ${{ inputs.max_size }} --example Blink ${{ inputs.extra_args }}
 
       - name: Inspect Binary
         if: always()
@@ -62,7 +62,7 @@ jobs:
           uv run ci/symbol_analysis_runner.py --board ${{ inputs.board }} --example Blink --skip-on-failure
 
       - name: Check Compiled Program Size for ${{ inputs.board }} (Apa102)
-        run: uv run ci/ci-check-compiled-size.py ${{ inputs.board }} --backend platformio --max-size ${{ inputs.max_size_apa102 }} --example Apa102 ${{ inputs.extra_args }}
+        run: uv run ci/ci-check-compiled-size.py ${{ inputs.board }} --max-size ${{ inputs.max_size_apa102 }} --example Apa102 ${{ inputs.extra_args }}
 
       - name: Inspect Binary
         if: always()
@@ -84,7 +84,7 @@ jobs:
 
       - name: Check Compiled Program Size for ${{ inputs.board }} (Apa102 with HD Color Mixing)
         if: inputs.board == 'attiny85'
-        run: uv run ci/ci-check-compiled-size.py ${{ inputs.board }} --backend platformio --example Apa102 ${{ inputs.extra_args }} --defines FASTLED_HD_COLOR_MIXING=1
+        run: uv run ci/ci-check-compiled-size.py ${{ inputs.board }} --example Apa102 ${{ inputs.extra_args }} --defines FASTLED_HD_COLOR_MIXING=1
 
       - name: Inspect Binary (HD Color Mixing)
         if: inputs.board == 'attiny85'

--- a/.github/workflows/check_esp32_size.yml
+++ b/.github/workflows/check_esp32_size.yml
@@ -23,5 +23,5 @@ jobs:
     uses: ./.github/workflows/build_template_binary_size.yml
     with:
       board: esp32dev
-      max_size: 700000
-      max_size_apa102: 700000
+      max_size: 330000
+      max_size_apa102: 330000

--- a/src/fl/channels/channel.cpp.hpp
+++ b/src/fl/channels/channel.cpp.hpp
@@ -512,7 +512,7 @@ void Channel::showPixels(PixelController<RGB, 1, 0xFFFFFFFF> &pixels) {
     // disable re-emits the diagnostic.
     fl::string driverName = driver->getName();
     auto status = ChannelManager::instance().driverStatus(driverName);
-    if (status == ChannelManager::DriverStatus::DISABLED) {
+    if (status == ChannelManager::DriverStatus::STATUS_DISABLED) {
         if (!mDisabledDriverWarned) {
             const fl::string& exclusive =
                 ChannelManager::instance().exclusiveDriverName();
@@ -534,7 +534,7 @@ void Channel::showPixels(PixelController<RGB, 1, 0xFFFFFFFF> &pixels) {
         // it here matches the existing behaviour (rather than leaving stale
         // bytes in the driver's pending queue across an enable/disable flip).
         return;
-    } else if (status == ChannelManager::DriverStatus::ENABLED) {
+    } else if (status == ChannelManager::DriverStatus::STATUS_ENABLED) {
         // Reset the one-shot guard so a future disable re-emits the diagnostic.
         mDisabledDriverWarned = false;
     }

--- a/src/fl/channels/manager.cpp.hpp
+++ b/src/fl/channels/manager.cpp.hpp
@@ -266,8 +266,8 @@ ChannelManager::DriverStatus ChannelManager::driverStatus(const fl::string& name
     }
     for (const auto& entry : mDrivers) {
         if (entry.name == name) {
-            return entry.enabled ? DriverStatus::ENABLED
-                                  : DriverStatus::DISABLED;
+            return entry.enabled ? DriverStatus::STATUS_ENABLED
+                                  : DriverStatus::STATUS_DISABLED;
         }
     }
     return DriverStatus::NOT_REGISTERED;

--- a/src/fl/channels/manager.h
+++ b/src/fl/channels/manager.h
@@ -162,15 +162,19 @@ public:
     bool isDriverEnabled(const char* name) const FL_NOEXCEPT;
 
     /// @brief Registration status of a driver by name (silent lookup)
+    /// @note Values are prefixed (`STATUS_*`) because Arduino-ESP32's
+    ///       `esp32-hal-gpio.h` defines `#define DISABLED 0x00` for pinMode
+    ///       and would textually rewrite the unprefixed labels at every call
+    ///       site (`DriverStatus::DISABLED` -> `DriverStatus::0x00`).
     enum class DriverStatus {
-        NOT_REGISTERED,  ///< No driver with that name is registered
-        DISABLED,        ///< Driver is registered but disabled
-        ENABLED,         ///< Driver is registered and enabled
+        NOT_REGISTERED,    ///< No driver with that name is registered
+        STATUS_DISABLED,   ///< Driver is registered but disabled
+        STATUS_ENABLED,    ///< Driver is registered and enabled
     };
 
     /// @brief Look up a driver's registration status without logging on miss.
     /// @param name Driver name (case-sensitive)
-    /// @return DriverStatus tri-state (NOT_REGISTERED / DISABLED / ENABLED)
+    /// @return DriverStatus tri-state (NOT_REGISTERED / STATUS_DISABLED / STATUS_ENABLED)
     /// @note Companion to `findDriverByName()` — same silent-on-miss behavior.
     ///       Used by `Channel::showPixels()` to detect the #2517 silent-drop
     ///       case (enqueued data routed to a disabled / unregistered driver).

--- a/tests/fl/channels/channel.cpp
+++ b/tests/fl/channels/channel.cpp
@@ -540,7 +540,7 @@ FL_TEST_CASE("[#2517] Disabled driver: enqueue is suppressed (would-be silent dr
     auto fakeDriver = fl::make_shared<CountingFakeDriver>("PARLIO_TEST");
     mgr.addDriver(9000, fakeDriver);
     FL_REQUIRE(mgr.driverStatus(fl::string::from_literal("PARLIO_TEST"))
-               == ChannelManager::DriverStatus::ENABLED);
+               == ChannelManager::DriverStatus::STATUS_ENABLED);
 
     CRGB leds[4] = {};
     auto channel = Channel::create(makeSilentDropTestConfig(fl::span<CRGB>(leds, 4)));
@@ -563,7 +563,7 @@ FL_TEST_CASE("[#2517] Disabled driver: enqueue is suppressed (would-be silent dr
     // driver via its cached `mDriver` weak_ptr being valid.
     mgr.setExclusiveDriverByName("DOES_NOT_EXIST");
     FL_CHECK(mgr.driverStatus(fl::string::from_literal("PARLIO_TEST"))
-             == ChannelManager::DriverStatus::DISABLED);
+             == ChannelManager::DriverStatus::STATUS_DISABLED);
     FL_CHECK_EQ(mgr.exclusiveDriverName(),
                 fl::string::from_literal("DOES_NOT_EXIST"));
 


### PR DESCRIPTION
## Summary

Per #2773: continue memory hunting / reduction. This restores the two CI changes that were workarounds for now-fixed fbuild issues, so the eh_frame stripping + 330 KB historical high-water mark are both back in force.

- **Workflow**: drop the three `--backend platformio` flags pinned by #2605 (fbuild defaults again, restoring the ~169 KB `.eh_frame` strip) and revert #2790's `max_size 330000 → 700000` bump. The size test will now fail at the historical ceiling — which is the regression signal #2773 wants visible again.
- **Source**: fix a master-blocking compile error from #2795. The new `enum class DriverStatus { DISABLED, ENABLED }` in `fl/channels/manager.h` is textually rewritten by Arduino-ESP32's `#define DISABLED 0x00` (esp32-hal-gpio.h:59) on every sketch that pulls in Arduino.h before `manager.h` — which is every esp32 sketch. Rename to `STATUS_DISABLED` / `STATUS_ENABLED` and update the 4 callers (`channel.cpp.hpp`, `manager.cpp.hpp`, `tests/fl/channels/channel.cpp`). Master's `esp32dev_binary_size` is currently red on this on every push.

## Why fbuild is safe again

| Original blocker | Status | Closed in |
|---|---|---|
| fbuild#297 (no `build_info_<env>.json` emitter) | ✅ CLOSED | fbuild PR 309 → fbuild 2.2.10 |
| fbuild#304 (framework `.o`'s not archived → ISR pull-in) | ✅ CLOSED | fbuild PR 306 → fbuild 2.2.10 |

We pin `fbuild==2.2.17` in `pyproject.toml`, so both fixes ship.

## Local verification

```
$ uv run python -m ci.ci-compile esp32dev --examples Blink
…
✅ Compilation succeeded (fbuild) [99.6s]
SUCCESS: Blink
✅ Generated build_info_Blink.json at .build/pio/esp32dev/build_info_Blink.json

$ uv run python ci/ci-check-compiled-size.py esp32dev --max-size 330000 --example Blink --no-build
esp32dev size 640228 is greater than max size 330000
::error::Compiled size exceeds maximum allowed size
```

The fbuild backend emits `build_info_Blink.json` with the full `aliases` block (nm, c++filt, objdump, addr2line, …) that `symbol_analysis_runner.py` consumes, so the downstream symbolizer/symbol-analysis steps in the workflow keep working.

## Test plan

- [x] Local fbuild build succeeds on esp32dev for Blink (640228 B firmware text+data).
- [x] `build_info_Blink.json` lands at the expected path with `aliases` populated.
- [x] `ci-check-compiled-size.py --max-size 330000` exits non-zero at 640228 > 330000 (expected red — drives further memory-reduction work in #2773).
- [x] `bash test channel --cpp` passes after the enum rename.
- [ ] `esp32dev_binary_size` CI run on this PR (this PR's own workflow run is the authoritative check that the symbolizer pipeline is intact end-to-end on Ubuntu).
- [ ] Other `*_binary_size` workflows (attiny85, teensy*, bluepill) still pass under fbuild + their historical max_size.

Refs #2773 (memory hunting / minimal-size invariant), supersedes the platformio-backend pin (#2605) and the 700 KB ceiling bump (#2790) now that the upstream fbuild blockers are closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved macro-name collision issue affecting Arduino-ESP32 platform compatibility.
  
* **Chores**
  * Tightened binary size validation limits in CI/CD workflows.
  * Updated build validation configurations for stricter quality checks.
  * Synchronized test assertions with internal naming updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->