### PR TITLE
fix(ci): symbol pipeline reads fbuild artifacts + nm parses every line (refs #2773)

### DIFF
--- a/ci/compiler/build_config.py
+++ b/ci/compiler/build_config.py
@@ -2,7 +2,7 @@
 
 import json
 from pathlib import Path
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 from running_process import EndOfStream, RunningProcess
 
@@ -89,6 +89,61 @@ def get_root_platformio_build_flags(board_name: str, project_root: Path) -> list
         return []
 
 
+def _override_prog_path_for_fbuild(
+    build_dir: Path, data: dict[str, dict[str, Any]], board: "Board"
+) -> None:
+    """If fbuild produced a fresher ELF than PlatformIO's `prog_path`,
+    rewrite the path to point at the fbuild artifact so symbol/size
+    analysis reads the build we just produced — not whatever an older
+    `pio run` left in `.pio/build/<env>/`.
+
+    No-op when the fbuild directory is absent (pure PlatformIO build),
+    when the PIO ELF is newer (PIO was the active backend), or when the
+    metadata blob has no recognisable environment entry.
+    """
+    fbuild_root = build_dir / ".fbuild" / "build"
+    if not fbuild_root.is_dir():
+        return
+
+    if not data:
+        return
+
+    env_name = board.board_name if board.board_name in data else next(iter(data), None)
+    if env_name is None:
+        return
+    env = data[env_name]
+
+    fbuild_elf = fbuild_root / env_name / "release" / "firmware.elf"
+    if not fbuild_elf.exists():
+        return
+
+    current_prog_raw = env.get("prog_path")
+    if isinstance(current_prog_raw, str) and current_prog_raw:
+        current_prog = Path(current_prog_raw)
+        # Only override when fbuild's ELF is strictly newer (or PIO's is
+        # missing). A successful `pio run` that beats the most recent
+        # fbuild run should win.
+        if current_prog.exists():
+            try:
+                if current_prog.stat().st_mtime >= fbuild_elf.stat().st_mtime:
+                    return
+            except OSError:
+                pass
+
+    fbuild_elf_str = str(fbuild_elf.resolve())
+    env["prog_path"] = fbuild_elf_str
+    fbuild_bin = fbuild_elf.with_suffix(".bin")
+    if fbuild_bin.exists() and "prog_size" in env:
+        try:
+            env["prog_size"] = fbuild_bin.stat().st_size
+        except OSError:
+            pass
+    print(
+        f"  Pointed prog_path at fbuild artifact: {fbuild_elf_str} "
+        f"(was {current_prog_raw!r})"
+    )
+
+
 def generate_build_info_json_from_existing_build(
     build_dir: Path, board: "Board", example: Optional[str] = None
 ) -> bool:
@@ -155,6 +210,19 @@ def generate_build_info_json_from_existing_build(
         try:
             metadata_output = "".join(metadata_lines)
             data = json.loads(metadata_output)
+
+            # When the build was driven by fbuild (which writes its ELF to
+            # `<build_dir>/.fbuild/build/<env>/release/firmware.elf`), the
+            # `prog_path` we just got from `pio project metadata` still
+            # points at the PlatformIO output path under `.pio/build/<env>/`.
+            # That `.pio/` ELF is whatever an older `pio run` left there
+            # (often empty or stale), so downstream symbol/size analysis
+            # would silently analyze the wrong binary. Detect the fresher
+            # fbuild ELF and rewrite `prog_path` to it so the consumers
+            # (ci/symbol_analysis_runner.py, ci/inspect_elf.py,
+            # ci/compiled_size.py firmware.bin fallback) see the build we
+            # just made.
+            _override_prog_path_for_fbuild(build_dir, data, board)
 
             # Add tool aliases for symbol analysis and debugging
             insert_tool_aliases(data)

--- a/ci/util/symbol_analysis.py
+++ b/ci/util/symbol_analysis.py
@@ -117,13 +117,19 @@ def run_command(cmd: str) -> str:
     """Run a command and return stdout"""
     try:
         proc = RunningProcess(cmd, shell=True, auto_run=True, timeout=30)
-        output = ""
         from running_process import EndOfStream
 
+        # `get_next_line` strips the trailing newline. Re-add it so callers
+        # that `output.split("\n")` actually get one entry per line rather
+        # than a single mega-line that no parser can split on whitespace
+        # (the cause of "nm: 1 symbols" on toolchains like xtensa-esp-elf
+        # whose nm prints many hundreds of lines).
+        output_lines: list[str] = []
         while line := proc.get_next_line(timeout=30):
             if isinstance(line, EndOfStream):
                 break
-            output += str(line)
+            output_lines.append(str(line))
+        output = "\n".join(output_lines)
         exit_code = proc.wait()
         if exit_code != 0:
             print(f"Error running command: {cmd}")


### PR DESCRIPTION
## Summary

Two related defects in the size/symbol pipeline that together meant the post-build symbolizer was effectively running on the wrong file with the wrong parser whenever fbuild was the backend. Both are now visibly affecting #2773 memory-hunting work — we couldn't see the top symbols at all until this fix.

### 1. `prog_path` stale under fbuild backend

fbuild writes `firmware.elf` to `<build_dir>/.fbuild/build/<env>/release/` but `pio project metadata --json-output` (what `generate_build_info_json_from_existing_build` shells out to) reports the **PlatformIO** path at `<build_dir>/.pio/build/<env>/firmware.elf`. That `.pio/` file is whatever an older `pio run` left behind — often hours stale, sometimes missing — so `symbol_analysis_runner`, `inspect_elf`, etc. silently analysed the wrong binary.

**Fix** (`ci/compiler/build_config.py`): after metadata is parsed, detect the fresher fbuild ELF and rewrite `prog_path` (and `prog_size` if the sibling `.bin` is present). No-op when `.fbuild/` is absent (pure PlatformIO) or when the PIO ELF is newer (user just ran `pio run`).

### 2. `run_command` ate the newlines between nm/readelf rows

`RunningProcess.get_next_line` strips trailing `\n`. The old code did `output += str(line)`, producing one mega-line that `output.split(\"\n\")` then split into one entry. On xtensa-esp-elf that meant `nm: 1 symbols` regardless of the real symbol count — the entire symbol-analysis report was running on the first whitespace tokens of a single concatenated nm row.

**Fix** (`ci/util/symbol_analysis.py`): re-join with `\n` so the downstream parser sees one symbol per line.

## Why it matters for #2773

Before this PR the symbol analysis was producing useless reports:
```
SYMBOL SOURCES:
  nm: 1 symbols
  nm-a: 1 symbols
```

After this PR:
```
$ xtensa-esp32-elf-nm --print-size --size-sort --reverse-sort -C firmware.elf | head
40106898 00002ca5 T _vfprintf_r
4010380c 00002bca T _svfprintf_r
400eca84 000018cf W fl::ChannelEngineRMTImpl::createChannel(...)     ← #2773 item 2.2
400e0e18 00001093 T fl::Channel::showPixels(...)                     ← #2773 item 2.1
400eb7c0 00000ba6 T fl::RmtMemoryManager::allocateTx(...)            ← #2773 item 2.5
400ef190 00000b0e W fl::ChannelEngineRMTImpl::reconfigureForNetwork()
```

— exactly the batch-2 architectural targets the issue calls out, and now visible from CI for the first time.

## Test plan

- [x] `uv run ci/symbol_analysis_runner.py --board esp32dev --example Blink` after a fresh `fbuild`-backed compile now reads the fbuild ELF and reports the full symbol table.
- [ ] CI: any size workflow that uses fbuild will now run symbol analysis on the right file (this PR's own `esp32dev_binary_size` run is the authoritative check).

Refs #2773 (memory hunting infrastructure — needed before further batch-2 attacks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed output line parsing in symbol analysis tooling to correctly preserve line boundaries.
  * Enhanced build artifact detection to ensure analysis tools consume the most recent compiled binary from the build pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->