### PR TITLE
refactor(rmt5): extract createChannel recovery sstream into noinline helpers (#2773 item 2.2 partial, −1820B)

### DIFF
--- a/src/platforms/esp/32/drivers/rmt/rmt_5/channel_driver_rmt.cpp.hpp
+++ b/src/platforms/esp/32/drivers/rmt/rmt_5/channel_driver_rmt.cpp.hpp
@@ -381,6 +381,60 @@ class ChannelEngineRMTImpl : public ChannelEngineRMT {
     /// @brief Release a channel (marks as available for reuse)
     void releaseChannel(ChannelState *channel) FL_NOEXCEPT;
 
+    /// @brief Out-of-line diagnostic emitters (#2773 item 2.2).
+    /// Both messages are ~15 lines of multi-line literal + integer
+    /// interpolation, and live only on the cold recovery / failure paths of
+    /// createChannel. Keeping them inside createChannel bloated the function
+    /// to ~6.3 KB because every `operator<<` instantiation got inlined.
+    /// Splitting into `noinline` helpers moves those instantiations into
+    /// their own (also cold-path) functions so `--gc-sections` can keep
+    /// them tiny, and createChannel shrinks proportionally.
+    __attribute__((noinline)) void emitRecoveryWarning(
+        size_t original_symbols, size_t reduced_symbols,
+        size_t external_words) FL_NOEXCEPT {
+        fl::sstream msg;
+        msg << "\n========================================\n"
+            << "RMT ALLOCATION RECOVERY - ACTION REQUIRED\n"
+            << "========================================\n"
+            << "FastLED detected external RMT memory usage!\n"
+            << "  Expected: " << original_symbols << " symbols available\n"
+            << "  Actual: " << reduced_symbols << " symbols available\n"
+            << "  External usage: ~" << external_words << " words\n"
+            << "\n"
+            << "To prevent future recovery attempts, add this to setup():\n"
+            << "----------------------------------------\n"
+            << "  auto& rmtMgr = fl::RmtMemoryManager::instance();\n"
+            << "  rmtMgr.reserveExternalMemory(" << external_words << ", 0);\n"
+            << "----------------------------------------\n"
+            << "\n"
+            << "FastLED will continue with reduced buffer size.\n"
+            << "Performance may be degraded during WiFi/network activity.\n"
+            << "========================================";
+        FL_WARN(msg.str());
+    }
+
+    __attribute__((noinline)) void emitAllocationFailureError(
+        size_t retry_count, size_t original_symbols, size_t min_symbols,
+        int pin) FL_NOEXCEPT {
+        fl::sstream msg;
+        msg << "\n========================================\n"
+            << "RMT CHANNEL ALLOCATION FAILED\n"
+            << "========================================\n"
+            << "FastLED could not allocate RMT channel after " << retry_count << " retry attempts\n"
+            << "  Platform: " << CONFIG_IDF_TARGET << "\n"
+            << "  Requested: " << original_symbols << " symbols\n"
+            << "  Minimum attempted: " << min_symbols << " symbols\n"
+            << "\n"
+            << "Possible causes:\n"
+            << "  1. External code is using all RMT channels\n"
+            << "  2. RMT hardware failure\n"
+            << "  3. Insufficient RMT memory for platform\n"
+            << "\n"
+            << "LEDs on pin " << pin << " will NOT work!\n"
+            << "========================================";
+        FL_ERROR(msg.str());
+    }
+
     /// @brief Create new RMT channel with given configuration
     /// @param dataSize Size of LED data in bytes (0 = use default buffer size)
     /// @return true if channel created successfully
@@ -667,25 +721,7 @@ class ChannelEngineRMTImpl : public ChannelEngineRMT {
 
                     // Show recovery warning with user action guidance
                     if (!mRecoveryWarningShown) {
-                        fl::sstream msg;
-                        msg << "\n========================================\n"
-                            << "RMT ALLOCATION RECOVERY - ACTION REQUIRED\n"
-                            << "========================================\n"
-                            << "FastLED detected external RMT memory usage!\n"
-                            << "  Expected: " << original_symbols << " symbols available\n"
-                            << "  Actual: " << reduced_symbols << " symbols available\n"
-                            << "  External usage: ~" << external_words << " words\n"
-                            << "\n"
-                            << "To prevent future recovery attempts, add this to setup():\n"
-                            << "----------------------------------------\n"
-                            << "  auto& rmtMgr = fl::RmtMemoryManager::instance();\n"
-                            << "  rmtMgr.reserveExternalMemory(" << external_words << ", 0);\n"
-                            << "----------------------------------------\n"
-                            << "\n"
-                            << "FastLED will continue with reduced buffer size.\n"
-                            << "Performance may be degraded during WiFi/network activity.\n"
-                            << "========================================";
-                        FL_WARN(msg.str());
+                        emitRecoveryWarning(original_symbols, reduced_symbols, external_words);
                         mRecoveryWarningShown = true;
                     }
 
@@ -706,23 +742,8 @@ class ChannelEngineRMTImpl : public ChannelEngineRMT {
 
             // If recovery failed, show detailed error
             if (!recovery_succeeded) {
-                fl::sstream msg;
-                msg << "\n========================================\n"
-                    << "RMT CHANNEL ALLOCATION FAILED\n"
-                    << "========================================\n"
-                    << "FastLED could not allocate RMT channel after " << retry_count << " retry attempts\n"
-                    << "  Platform: " << CONFIG_IDF_TARGET << "\n"
-                    << "  Requested: " << original_symbols << " symbols\n"
-                    << "  Minimum attempted: " << min_symbols << " symbols\n"
-                    << "\n"
-                    << "Possible causes:\n"
-                    << "  1. External code is using all RMT channels\n"
-                    << "  2. RMT hardware failure\n"
-                    << "  3. Insufficient RMT memory for platform\n"
-                    << "\n"
-                    << "LEDs on pin " << static_cast<int>(pin) << " will NOT work!\n"
-                    << "========================================";
-                FL_ERROR(msg.str());
+                emitAllocationFailureError(retry_count, original_symbols,
+                                           min_symbols, static_cast<int>(pin));
 
                 state->channel = nullptr;
                 memMgr.free(state->memoryChannelId, true);


### PR DESCRIPTION
## Summary

`fl::ChannelEngineRMTImpl::createChannel` was **6351 B** on the esp32dev Blink build — the largest FastLED-owned symbol in the binary per the #2773 batch-2 audit. Two of its cold paths each built a ~15-line `fl::sstream` with multi-integer interpolation (recovery success + allocation failure messages); every `operator<<` instantiation was being textually inlined into createChannel.

Move both into `__attribute__((noinline))` member helpers. Pure code motion — same rodata, same FL_WARN/FL_ERROR severity, same on-the-wire output.

## Size measurements (fbuild esp32dev release Blink)

| Symbol | Before | After | Delta |
|---|---:|---:|---:|
| `ChannelEngineRMTImpl::createChannel` | **6351 B** | **4531 B** | **−1820 B (−28%)** |
| `ChannelEngineRMTImpl::emitRecoveryWarning` (new) | — | 752 B | +752 B |
| `ChannelEngineRMTImpl::emitAllocationFailureError` (new) | — | 798 B | +798 B |
| **firmware.bin total** | **791,263 B** | **791,035 B** | **−228 B** |

The full multi-line texts are preserved (no diagnostic loss); the win is operator<< code no longer duplicated through createChannel's prologue/epilogue. The two helpers are cold-path, so `--gc-sections` keeps them tucked away from the hot allocation/encoder-creation block.

This is the first surgical pass at #2773 item 2.2. The full static/dynamic split (using a static-init thread-local so `--gc-sections` can drop the dynamic hot-plug body entirely) remains pending and tracks separately.

## Test plan

- [x] fbuild compile of esp32dev Blink succeeds; createChannel symbol shrinks as measured above.
- [ ] CI build + size workflow for esp32dev — authoritative confirmation, gated on PR #2823's symbolizer fix landing first so the size report is read from the right ELF.
- [ ] Host tests for `fl::channels`.

Refs #2773 (memory-hunt loop, iter 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal error message handling in the ESP32 RMT driver module to improve code organization and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->