### PR TITLE
fix(net): move NetworkDetector stub into fl::net namespace (#2817 lint follow-up)

### DIFF
--- a/src/fl/net/network_detector.h
+++ b/src/fl/net/network_detector.h
@@ -47,7 +47,7 @@
 
 #include "fl/stl/noexcept.h"
 
-namespace fl {
+namespace fl::net {
 
 /// @brief Stub NetworkDetector for platforms without the real implementation.
 ///
@@ -75,6 +75,14 @@ class NetworkDetector {
     NetworkDetector &operator=(const NetworkDetector &) FL_NOEXCEPT = delete;
 };
 
+} // namespace fl::net
+
+// Back-compat: the existing channel wait sites and the real RMT5 impl both
+// expose the type as fl::NetworkDetector. Keep that name working in the
+// no-real-impl case via a using alias, so this PR is a pure lint fix with
+// no consumer churn.
+namespace fl {
+using NetworkDetector = ::fl::net::NetworkDetector;
 } // namespace fl
 
 #endif // !FL_NETWORK_DETECTOR_HAS_REAL_IMPL


### PR DESCRIPTION
## Summary

Tiny lint follow-up to #2817. `SubdirNamespaceChecker` requires headers in `src/fl/<subdir>/` to declare `namespace fl::<subdir>` - the cross-platform stub in `src/fl/net/network_detector.h` (added by #2817) was declaring its `NetworkDetector` class in `namespace fl`, triggering one persistent violation.

Move the stub into `namespace fl::net` and add a `using` alias in `namespace fl` so the existing consumers (`fl::NetworkDetector::isAnyNetworkActive()` in `fl/channels/manager.cpp.hpp` and `fl/channels/driver.cpp.hpp`) keep compiling without any churn.

The real RMT5 implementation lives in `namespace fl` at its own header (`platforms/esp/32/drivers/rmt/rmt_5/network_detector.h`) and is unaffected by this change.

## Diff

```cpp
-namespace fl {
+namespace fl::net {

 class NetworkDetector { /* stub: all returns false */ };

-} // namespace fl
+} // namespace fl::net
+
+// Back-compat: keep `fl::NetworkDetector` as a usable name in the
+// no-real-impl case.
+namespace fl {
+using NetworkDetector = ::fl::net::NetworkDetector;
+} // namespace fl
```

## Test plan

- [x] `bash lint --cpp` - all C++ linting checks pass (was 1 violation on master, now 0).
- [x] Pure rename + alias, no behavior change. The stub class's body and `static` accessors are identical.

## Cross-references

- Follow-up cleanup to #2817 (already merged).
- Refs #2815 umbrella.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code organization improvements to better structure existing functionality without affecting user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->