### PR TITLE
feat(stl): FL_NO_INLINE portable macro + cold-helper split for showPixels (#2773 item 2.1)

### DIFF
--- a/ci/lint_cpp/bare_noinline_checker.py
+++ b/ci/lint_cpp/bare_noinline_checker.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+# pyright: reportUnknownMemberType=false
+"""Checker banning bare `__attribute__((noinline))` and `__declspec(noinline)` in `src/`.
+
+Rationale: FastLED ships an `FL_NO_INLINE` macro in
+`fl/stl/compiler_control.h` that expands to the right syntax for GCC,
+Clang, and MSVC. Bare `__attribute__((noinline))` is GCC/Clang-only and
+silently no-ops under MSVC, so a host build that flows through the MSVC
+toolchain (e.g. CI's WASM/Windows host tests) can quietly lose the
+`noinline` semantics — exactly the kind of regression #2773 item 2.1
+exists to prevent (the hot/cold split collapses back into the inlined
+hot path).
+
+Suppression: add `// ok noinline` at end of line. Two source paths are
+exempt as a matter of course:
+
+- `fl/stl/compiler_control.h` — where the `FL_NO_INLINE` macro is
+  defined; the bare attribute appears inside the macro body itself.
+- `src/third_party/` — upstream code we don't control.
+- the lint checker itself.
+"""
+
+import re
+
+from ci.util.check_files import FileContent, FileContentChecker
+from ci.util.paths import PROJECT_ROOT
+
+
+SRC_ROOT = PROJECT_ROOT / "src"
+
+# Whitelisted files inside src/ that legitimately use the bare attribute
+# (the macro shim itself; it expands to the bare attribute).
+EXEMPT_FILES = (
+    "fl/stl/compiler_control.h",
+    "fl/stl/compiler_control.cpp.hpp",
+)
+
+# Match `__attribute__((noinline))` or `__attribute__ ((noinline))` or
+# `__declspec(noinline)`. We allow internal whitespace around the inner
+# `noinline` keyword and around the outer parens but require the rest
+# of the syntax to be intact so we don't false-positive on unrelated
+# tokens.
+_BANNED_PATTERN = re.compile(
+    r"__attribute__\s*\(\s*\(\s*noinline\s*\)\s*\)"
+    r"|"
+    r"__declspec\s*\(\s*noinline\s*\)"
+)
+_SUPPRESS = "// ok noinline"
+
+
+class BareNoInlineChecker(FileContentChecker):
+    """Bans bare `noinline` compiler attributes in src/ (#2773 item 2.1 follow-up)."""
+
+    def __init__(self):
+        self.violations: dict[str, list[tuple[int, str]]] = {}
+
+    def should_process_file(self, file_path: str) -> bool:
+        if not file_path.startswith(str(SRC_ROOT)):
+            return False
+        if not file_path.endswith((".cpp", ".h", ".hpp")):
+            return False
+        norm = file_path.replace("\\", "/")
+        for exempt in EXEMPT_FILES:
+            if norm.endswith(exempt):
+                return False
+        # Upstream third-party code: not our syntax to enforce.
+        if "/third_party/" in norm:
+            return False
+        return True
+
+    def check_file_content(self, file_content: FileContent) -> list[str]:
+        violations: list[tuple[int, str]] = []
+        in_block_comment = False
+
+        for line_number, line in enumerate(file_content.lines, 1):
+            stripped = line.strip()
+
+            if in_block_comment:
+                if "*/" in line:
+                    in_block_comment = False
+                continue
+            if "/*" in line and "*/" not in line:
+                in_block_comment = True
+                continue
+
+            if stripped.startswith("//"):
+                continue
+            if _SUPPRESS in line:
+                continue
+
+            code = line.split("//")[0]
+            if _BANNED_PATTERN.search(code):
+                violations.append((line_number, line.rstrip()))
+
+        if violations:
+            self.violations[file_content.path] = violations
+        return []
+
+
+def main() -> None:
+    from ci.util.check_files import run_checker_standalone
+
+    checker = BareNoInlineChecker()
+    run_checker_standalone(
+        checker,
+        [str(SRC_ROOT)],
+        "Found bare `__attribute__((noinline))` / `__declspec(noinline)` "
+        "in src/ — use `FL_NO_INLINE` from fl/stl/compiler_control.h "
+        "instead (FastLED #2773 item 2.1 follow-up).",
+        extensions=[".cpp", ".h", ".hpp"],
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/ci/lint_cpp/run_all_checkers.py
+++ b/ci/lint_cpp/run_all_checkers.py
@@ -26,6 +26,7 @@ from ci.lint_cpp.banned_headers_checker import (
 from ci.lint_cpp.banned_macros_checker import BannedMacrosChecker
 from ci.lint_cpp.banned_namespace_checker import BannedNamespaceChecker
 from ci.lint_cpp.bare_allocation_checker import BareAllocationChecker
+from ci.lint_cpp.bare_noinline_checker import BareNoInlineChecker
 from ci.lint_cpp.bare_snprintf_checker import BareSnprintfChecker
 from ci.lint_cpp.bare_using_checker import BareUsingChecker
 from ci.lint_cpp.builtin_memcpy_checker import BuiltinMemcpyChecker
@@ -199,6 +200,7 @@ def create_checkers(
         SpanFromPointerChecker(),  # Checks for span<T>(container.data(), container.size()) → span<T>(container)
         BareAllocationChecker(),  # Checks for bare new/delete/malloc/free — use fl::unique_ptr/fl::shared_ptr
         BareSnprintfChecker(),  # Bans bare C ::snprintf/::printf/::sprintf in src/ — use fl::snprintf (#2773 item 1.5)
+        BareNoInlineChecker(),  # Bans bare __attribute__((noinline)) in src/ — use FL_NO_INLINE (#2773 item 2.1 follow-up)
         SleepForChecker(),  # Checks for sleep_for() — bypasses async runner, use fl::yield/fl::async_run
         ThreadLocalKeywordChecker(),  # Checks for thread_local keyword — use fl::SingletonThreadLocal<T>::instance()
         BannedDefineChecker(),  # Checks for wrong #if patterns (e.g., #if ESP32 → #ifdef ESP32)

--- a/src/fl/channels/channel.cpp.hpp
+++ b/src/fl/channels/channel.cpp.hpp
@@ -335,6 +335,61 @@ void writeUCS7604(fl::vector_psram<u8>* data, PixelIterator& pixelIterator,
 
 } // anonymous namespace
 
+/// @brief Cold fallback for the non-pre-bound driver path. Handles dynamic
+///        `ChannelManager::selectDriverForChannel` lookup AND the
+///        bus-key-miss diagnostic chain. Hoisted out of `showPixels` so the
+///        hot legacy `addLeds<>` path stays compact — see #2773 item 2.1.
+///
+/// Marked `noinline` (via `FL_NOINLINE`) so the compiler doesn't fold the
+/// cold body back into `showPixels`. The whole helper is reachable only
+/// when `mDriverPreBound == false`, which on stock Blink is never true —
+/// LTO can use that across the call site to keep the cold body off the
+/// hot icache line.
+FL_NO_INLINE
+fl::shared_ptr<IChannelDriver> Channel::resolveDynamicDriver() {
+    // Build busKey only when we actually need it (mBus != AUTO).
+    fl::string busKey;
+    if (mBus != Bus::AUTO) {
+        busKey = fl::string::from_literal(busName(mBus));
+    }
+
+    fl::shared_ptr<IChannelDriver> driver =
+        ChannelManager::instance().selectDriverForChannel(mChannelData, busKey);
+    mDriver = driver;
+
+    // #2455 / #2459: one-shot diagnostic when a typed-Bus miss happens.
+    // Probe via `findDriverByName` (silent) to distinguish "driver wasn't
+    // instantiated" from "driver exists but canHandle() rejected this
+    // chipset" — resolution paths differ. The mBusWarned guard suppresses
+    // duplicate logs on subsequent shows of the same channel.
+    if (mBus != Bus::AUTO && !mBusWarned &&
+        (!driver || driver->getName() != busKey)) {
+        auto busDriver = ChannelManager::instance().findDriverByName(busKey);
+        if (!busDriver) {
+            // Typed Bus miss — emit the actionable hint with the three
+            // currently-shipping remediations (option 3 added in #2460).
+            FL_ERROR("Channel '" << mName << "': Driver '" << busKey
+                << "' wasn't instantiated. Resolve with: "
+                << "(1) fl::enableDrivers<fl::Bus::" << busKey << ">() "
+                << "(links only this driver), "
+                << "(2) FastLED.enableAllDrivers() (links every driver), or "
+                << "(3) FastLED.addLeds<..., fl::Bus::" << busKey << ">(...) "
+                << "(legacy API; pins Bus + triggers linker keep-alive). "
+                << "Defaulting to AUTO/priority dispatch.");
+        } else {
+            // Registered, but canHandle() said no — bus/chipset mismatch.
+            FL_ERROR("Channel '" << mName << "': Driver '" << busKey
+                << "' is registered but cannot handle this channel's chipset "
+                << "(bus/chipset mismatch). Defaulting to AUTO/priority dispatch.");
+        }
+        mBusWarned = true;
+    }
+    if (!driver) {
+        FL_ERROR("Channel '" << mName << "': No compatible driver found - cannot transmit");
+    }
+    return driver;
+}
+
 void Channel::showPixels(PixelController<RGB, 1, 0xFFFFFFFF> &pixels) {
     FL_SCOPED_TRACE;
 
@@ -360,50 +415,28 @@ void Channel::showPixels(PixelController<RGB, 1, 0xFFFFFFFF> &pixels) {
     // their constructor), bypass ChannelManager entirely. Channels created via
     // the manager-based API (Channel::create(cfg) without affinity) keep their
     // existing per-frame re-selection so users can swap drivers at runtime.
-    // Resolve dispatch via the typed `mBus` field (#2459). `Bus::AUTO`
-    // means "no pinning — let the manager pick by priority"; any other
-    // value pins this channel to `busName(mBus)`.
-    fl::string busKey;
-    if (mBus != Bus::AUTO) {
-        busKey = fl::string::from_literal(busName(mBus));
-    }
+    //
+    // **Fast path (#2773 item 2.1):** the legacy `addLeds<NEOPIXEL>` flow is
+    // by far the hot per-frame path on stock Blink. It needs no busKey
+    // construction, no dynamic driver lookup, no busKey-miss diagnostics,
+    // and no fallback `FL_ERROR` reporting — the driver was already pre-bound
+    // in the controller's constructor. Pulling all of that boilerplate out
+    // of `showPixels` lets the compiler keep the hot path compact and lets
+    // the slow path's `fl::string` ops / `ChannelManager::selectDriverForChannel`
+    // / diagnostic literals tree-shake on the slow-path branch's coldness.
     fl::shared_ptr<IChannelDriver> driver;
     if (mDriverPreBound) {
         driver = mDriver.lock();
-    } else {
-        driver = ChannelManager::instance().selectDriverForChannel(mChannelData, busKey);
-        mDriver = driver;
-    }
-    // #2455 / #2459: one-shot diagnostic when a typed-Bus miss happens.
-    // Probe via `findDriverByName` (silent) to distinguish "driver wasn't
-    // instantiated" from "driver exists but canHandle() rejected this
-    // chipset" — resolution paths differ. The mBusWarned guard suppresses
-    // duplicate logs on subsequent shows of the same channel.
-    if (!mDriverPreBound && mBus != Bus::AUTO && !mBusWarned &&
-        (!driver || driver->getName() != busKey)) {
-        auto busDriver = ChannelManager::instance().findDriverByName(busKey);
-        if (!busDriver) {
-            // Typed Bus miss — emit the actionable hint with the three
-            // currently-shipping remediations (option 3 added in #2460).
-            FL_ERROR("Channel '" << mName << "': Driver '" << busKey
-                << "' wasn't instantiated. Resolve with: "
-                << "(1) fl::enableDrivers<fl::Bus::" << busKey << ">() "
-                << "(links only this driver), "
-                << "(2) FastLED.enableAllDrivers() (links every driver), or "
-                << "(3) FastLED.addLeds<..., fl::Bus::" << busKey << ">(...) "
-                << "(legacy API; pins Bus + triggers linker keep-alive). "
-                << "Defaulting to AUTO/priority dispatch.");
-        } else {
-            // Registered, but canHandle() said no — bus/chipset mismatch.
-            FL_ERROR("Channel '" << mName << "': Driver '" << busKey
-                << "' is registered but cannot handle this channel's chipset "
-                << "(bus/chipset mismatch). Defaulting to AUTO/priority dispatch.");
+        if (!driver) {
+            // Pre-bound driver got destroyed (singleton shutdown, etc.). Silent
+            // bail — this is unrecoverable from showPixels.
+            return;
         }
-        mBusWarned = true;
-    }
-    if (!driver) {
-        FL_ERROR("Channel '" << mName << "': No compatible driver found - cannot transmit");
-        return;
+    } else {
+        driver = resolveDynamicDriver();
+        if (!driver) {
+            return;
+        }
     }
 
     // Build pixel iterator with optional addressing transformation

--- a/src/fl/channels/channel.h
+++ b/src/fl/channels/channel.h
@@ -199,6 +199,18 @@ protected:
     /// @note Does not set LED data or channel options - caller must do that
     Channel(const ChipsetVariant& chipset, EOrder rgbOrder, RegistrationMode mode);
 
+private:
+    /// @brief Cold slow-path helper for `showPixels()` when the driver was
+    ///        NOT pre-bound via `setDriver()`. Handles dynamic
+    ///        `ChannelManager::selectDriverForChannel()` lookup AND the
+    ///        bus-key-miss diagnostics (#2455 / #2459).
+    ///
+    /// Marked `FL_NO_INLINE` so the legacy `addLeds<>` hot path stays compact —
+    /// see #2773 item 2.1. Returns `nullptr` on a hard miss (caller should
+    /// silently bail).
+    FL_NO_INLINE fl::shared_ptr<IChannelDriver> resolveDynamicDriver();
+protected:
+
     /// @brief Pre-bind a driver, bypassing `ChannelManager::selectDriverForChannel()`
     ///        on every subsequent `showPixels()` call.
     ///

--- a/src/fl/gfx/blur.cpp.hpp
+++ b/src/fl/gfx/blur.cpp.hpp
@@ -503,7 +503,7 @@ template <> struct conv1ch<4> {
 
 // AVR noinline per-channel pass for CRGB (no alpha).
 template <int R>
-__attribute__((noinline)) FL_OPTIMIZE_FUNCTION
+FL_NO_INLINE FL_OPTIMIZE_FUNCTION
 static void apply_pass_1ch(const CRGB *pad, CRGB *out, int count, int stride) {
     constexpr int shift = (R == 0) ? 0 : 8;
     for (int i = 0; i < count; ++i) {
@@ -517,7 +517,7 @@ static void apply_pass_1ch(const CRGB *pad, CRGB *out, int count, int stride) {
 
 // AVR noinline per-channel pass for CRGB with alpha dim.
 template <int R>
-__attribute__((noinline)) FL_OPTIMIZE_FUNCTION
+FL_NO_INLINE FL_OPTIMIZE_FUNCTION
 static void apply_pass_alpha_1ch(const CRGB *pad, CRGB *out, int count,
                                   int stride, alpha8 alpha) {
     constexpr int shift = (R == 0) ? 0 : 8;
@@ -536,7 +536,7 @@ static void apply_pass_alpha_1ch(const CRGB *pad, CRGB *out, int count,
 
 // AVR noinline per-channel pass for CRGB with alpha16 dim.
 template <int R>
-__attribute__((noinline)) FL_OPTIMIZE_FUNCTION
+FL_NO_INLINE FL_OPTIMIZE_FUNCTION
 static void apply_pass_alpha_1ch(const CRGB *pad, CRGB *out, int count,
                                   int stride, alpha16 alpha) {
     constexpr int shift = (R == 0) ? 0 : 8;

--- a/src/fl/math/memmove.h
+++ b/src/fl/math/memmove.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "platforms/is_platform.h"
+#include "fl/stl/compiler_control.h"  // FL_NO_INLINE
 
 ///////////////////////////////////////////////////////////////////////
 ///
@@ -12,8 +13,8 @@
 #if defined(FL_IS_AVR) || defined(FASTLED_DOXYGEN)
 extern "C" {
 void * memmove8( void * dst, const void * src, fl::u16 num );  ///< Faster alternative to memmove() on AVR
-void * memcpy8 ( void * dst, const void * src, fl::u16 num )  __attribute__ ((noinline));  ///< Faster alternative to memcpy() on AVR
-void * memset8 ( void * ptr, fl::u8 value, fl::u16 num ) __attribute__ ((noinline)) ;  ///< Faster alternative to memset() on AVR
+void * memcpy8 ( void * dst, const void * src, fl::u16 num )  FL_NO_INLINE;  ///< Faster alternative to memcpy() on AVR
+void * memset8 ( void * ptr, fl::u8 value, fl::u16 num ) FL_NO_INLINE ;  ///< Faster alternative to memset() on AVR
 }
 #else
 #include "fl/stl/cstring.h"

--- a/src/fl/stl/compiler_control.h
+++ b/src/fl/stl/compiler_control.h
@@ -330,6 +330,23 @@
   #define FL_NO_INLINE_IF_AVR
 #endif
 
+// Unconditional "do not inline this function" attribute, portable across
+// GCC/Clang/MSVC. Prefer this over a bare `__attribute__((noinline))` in
+// `src/` — a lint check in `ci/lint_cpp/bare_noinline_checker.py` enforces
+// the use of the macro so the GCC-only syntax doesn't sneak in.
+//
+// Typical use: cold helpers extracted out of a hot path so the compiler
+// can't fold them back via inline expansion. Pair with the lint guard.
+//
+// Usage: FL_NO_INLINE void coldHelper() { ... }
+#if defined(FL_IS_GCC) || defined(FL_IS_CLANG)
+  #define FL_NO_INLINE __attribute__((noinline))
+#elif defined(FL_IS_WIN_MSVC)
+  #define FL_NO_INLINE __declspec(noinline)
+#else
+  #define FL_NO_INLINE
+#endif
+
 // Mark functions to run during C++ static initialization (before main())
 // Used for auto-registration of platform-specific implementations
 #if defined(FL_IS_GCC) || defined(FL_IS_CLANG)

--- a/src/platforms/arm/stm32/fastspi_arm_stm32.h
+++ b/src/platforms/arm/stm32/fastspi_arm_stm32.h
@@ -309,7 +309,7 @@ public:
 
     // Write pixels with color order and optional flags
     template <u8 FLAGS, class D, EOrder RGB_ORDER>
-    __attribute__((noinline))
+    FL_NO_INLINE
     void writePixels(PixelController<RGB_ORDER> pixels, void* context = nullptr) FL_NOEXCEPT {
         select();
         int len = pixels.mLen;

--- a/src/platforms/esp/32/core/fastspi_esp32_arduino.h
+++ b/src/platforms/esp/32/core/fastspi_esp32_arduino.h
@@ -232,7 +232,7 @@ public:
 	// write a block of uint8_ts out in groups of three.  len is the total number of uint8_ts to write out.  The template
 	// parameters indicate how many uint8_ts to skip at the beginning of each grouping, as well as a class specifying a per
 	// byte of data modification to be made.  (See DATA_NOP above)
-	template <u8 FLAGS, class D, EOrder RGB_ORDER>  __attribute__((noinline)) FL_NOEXCEPT void writePixels(PixelController<RGB_ORDER> pixels, void* context) {
+	template <u8 FLAGS, class D, EOrder RGB_ORDER>  FL_NO_INLINE FL_NOEXCEPT void writePixels(PixelController<RGB_ORDER> pixels, void* context) {
 		#if FASTLED_ESP32_SPI_BULK_TRANSFER
 		select();
 		int len = pixels.mLen;

--- a/src/platforms/esp/32/core/fastspi_esp32_idf.h
+++ b/src/platforms/esp/32/core/fastspi_esp32_idf.h
@@ -247,7 +247,7 @@ public:
     }
 
     template <u8 FLAGS, class D, EOrder RGB_ORDER>
-    __attribute__((noinline)) void writePixels(PixelController<RGB_ORDER> pixels, void* context) {
+    FL_NO_INLINE void writePixels(PixelController<RGB_ORDER> pixels, void* context) {
         #if FASTLED_ESP32_SPI_BULK_TRANSFER
         select();
         int len = pixels.mLen;

--- a/src/platforms/esp/32/drivers/rmt/rmt_4/channel_driver_rmt4.h
+++ b/src/platforms/esp/32/drivers/rmt/rmt_4/channel_driver_rmt4.h
@@ -281,7 +281,7 @@ private:
     // reordering on Xtensa (l32r: literal placed after use)
     // ═══════════════════════════════════════════════════════════════════════════
 
-    static __attribute__((noinline)) IRAM_ATTR void handleInterrupt(void* arg) FL_NOEXCEPT {
+    static FL_NO_INLINE IRAM_ATTR void handleInterrupt(void* arg) FL_NOEXCEPT {
         // Main ISR dispatcher
         auto* driver = static_cast<ChannelEngineRMT4Impl*>(arg);
 
@@ -329,7 +329,7 @@ private:
         }
     }
 
-    __attribute__((noinline)) IRAM_ATTR void onThresholdInterrupt(int channelNum) FL_NOEXCEPT {
+    FL_NO_INLINE IRAM_ATTR void onThresholdInterrupt(int channelNum) FL_NOEXCEPT {
         // Threshold interrupt: Half of the RMT buffer has been transmitted
         ChannelState* state = findChannelByNumber(channelNum);
         if (state == nullptr || !state->inUse) {
@@ -340,7 +340,7 @@ private:
         fillNextBuffer(state, true);
     }
 
-    __attribute__((noinline)) IRAM_ATTR void onTxDoneInterrupt(int channelNum) FL_NOEXCEPT {
+    FL_NO_INLINE IRAM_ATTR void onTxDoneInterrupt(int channelNum) FL_NOEXCEPT {
         // TX done interrupt: Transmission is complete on this channel
         ChannelState* state = findChannelByNumber(channelNum);
         if (state == nullptr || !state->inUse) {
@@ -371,7 +371,7 @@ private:
         state->transmissionComplete = true;
     }
 
-    __attribute__((noinline)) IRAM_ATTR void fillNextBuffer(ChannelState* state, bool checkTime) FL_NOEXCEPT {
+    FL_NO_INLINE IRAM_ATTR void fillNextBuffer(ChannelState* state, bool checkTime) FL_NOEXCEPT {
         // Fill the next half of the RMT double-buffer with pixel data
         if (!state) {
             return;
@@ -421,7 +421,7 @@ private:
         state->memPtr = pItem;
     }
 
-    static __attribute__((noinline)) IRAM_ATTR void convertByteToRMT(
+    static FL_NO_INLINE IRAM_ATTR void convertByteToRMT(
         u8 byteval,
         const rmt_item32_t& zero,
         const rmt_item32_t& one,
@@ -452,7 +452,7 @@ private:
         pItem[7].val = tmp[7];
     }
 
-    static __attribute__((noinline)) IRAM_ATTR void tx_start(ChannelState* state) FL_NOEXCEPT {
+    static FL_NO_INLINE IRAM_ATTR void tx_start(ChannelState* state) FL_NOEXCEPT {
         // Start RMT transmission by setting hardware flag
         if (!state) {
             return;
@@ -533,7 +533,7 @@ private:
 #endif
     }
 
-    __attribute__((noinline)) IRAM_ATTR ChannelState* findChannelByNumber(int channelNum) FL_NOEXCEPT {
+    FL_NO_INLINE IRAM_ATTR ChannelState* findChannelByNumber(int channelNum) FL_NOEXCEPT {
         // Linear search through active channels
         for (auto& state : mChannels) {
             if (state.inUse && state.channel == channelNum) {

--- a/src/platforms/esp/32/drivers/rmt/rmt_5/channel_driver_rmt.cpp.hpp
+++ b/src/platforms/esp/32/drivers/rmt/rmt_5/channel_driver_rmt.cpp.hpp
@@ -389,7 +389,7 @@ class ChannelEngineRMTImpl : public ChannelEngineRMT {
     /// Splitting into `noinline` helpers moves those instantiations into
     /// their own (also cold-path) functions so `--gc-sections` can keep
     /// them tiny, and createChannel shrinks proportionally.
-    __attribute__((noinline)) void emitRecoveryWarning(
+    FL_NO_INLINE void emitRecoveryWarning(
         size_t original_symbols, size_t reduced_symbols,
         size_t external_words) FL_NOEXCEPT {
         fl::sstream msg;
@@ -413,7 +413,7 @@ class ChannelEngineRMTImpl : public ChannelEngineRMT {
         FL_WARN(msg.str());
     }
 
-    __attribute__((noinline)) void emitAllocationFailureError(
+    FL_NO_INLINE void emitAllocationFailureError(
         size_t retry_count, size_t original_symbols, size_t min_symbols,
         int pin) FL_NOEXCEPT {
         fl::sstream msg;

--- a/src/platforms/esp/8266/fastspi_esp8266.h
+++ b/src/platforms/esp/8266/fastspi_esp8266.h
@@ -141,7 +141,7 @@ public:
 	// write a block of uint8_ts out in groups of three.  len is the total number of uint8_ts to write out.  The template
 	// parameters indicate how many uint8_ts to skip at the beginning of each grouping, as well as a class specifying a per
 	// byte of data modification to be made.  (See DATA_NOP above)
-	template <u8 FLAGS, class D, EOrder RGB_ORDER>  __attribute__((noinline)) FL_NOEXCEPT void writePixels(PixelController<RGB_ORDER> pixels, void* context = nullptr) {
+	template <u8 FLAGS, class D, EOrder RGB_ORDER>  FL_NO_INLINE FL_NOEXCEPT void writePixels(PixelController<RGB_ORDER> pixels, void* context = nullptr) {
 		select();
 		int len = pixels.mLen;
 		while(pixels.has(1)) {

--- a/src/platforms/shared/spi_bitbang/generic_software_spi.h
+++ b/src/platforms/shared/spi_bitbang/generic_software_spi.h
@@ -375,7 +375,7 @@ public:
 	/// @tparam D Per-byte modifier class, e.g. ::DATA_NOP
 	/// @tparam RGB_ORDER the rgb ordering for the LED data (e.g. what order red, green, and blue data is written out in)
 	/// @param pixels a ::PixelController with the LED data and modifier options
-	template <fl::u8 FLAGS, class D, EOrder RGB_ORDER>  __attribute__((noinline)) FL_NOEXCEPT void writePixels(PixelController<RGB_ORDER> pixels, void* context = nullptr) {
+	template <fl::u8 FLAGS, class D, EOrder RGB_ORDER>  FL_NO_INLINE FL_NOEXCEPT void writePixels(PixelController<RGB_ORDER> pixels, void* context = nullptr) {
 		FASTLED_UNUSED(context);
 		select();
 		int len = pixels.mLen;


### PR DESCRIPTION
## Summary

Two coupled changes from #2773 item 2.1's punch list:

1. **Portable `FL_NO_INLINE` macro + lint guard** — sweep 12 bare `__attribute__((noinline))` uses in `src/` to the portable macro, add a lint check (`ci/lint_cpp/bare_noinline_checker.py`) that prevents future regressions.
2. **`Channel::showPixels` cold-helper split** — extract `resolveDynamicDriver()` so the hot legacy `addLeds<>` path stays compact.

User feedback that prompted #1: *"we should FL_NO_INLINE, and add a lint for `__attribute__((noinline))` so we don't have this again"*.

## Why the macro

The bare `__attribute__((noinline))` form silently no-ops under MSVC, so a host build through the Windows toolchain (CI's WASM/host tests) loses the `noinline` semantics — exactly the kind of latent regression #2773 item 2.1 needs to prevent. The hot/cold split this PR introduces collapses back into the hot path if any future change strips the attribute on one toolchain.

## Why the showPixels split

The meta tracker described 2.1 as an "iterator scaling" issue. Disassembling the current 3.8 KB `Channel::showPixels` showed the bulk is per-frame **driver-resolution boilerplate**, not iterator code: `fl::string busKey` construction, slow `selectDriverForChannel` path, three formatted `FL_ERROR` stream chains for the typed-Bus-miss hints, etc.

On stock Blink (legacy `addLeds<NEOPIXEL>` → `ClocklessIdf5` constructor pre-binds the driver), `mDriverPreBound == true` and the entire dynamic-resolution + diagnostic block is dead-at-runtime but linked. Extracting it into a `FL_NO_INLINE resolveDynamicDriver()` helper gives the compiler the seam it needs to keep the hot path compact.

## Measured on ESP32-S3 Blink (PlatformIO + IDF 5.4)

| Build | `firmware.bin` |
|---|---:|
| master (pre-this-PR) | 659,920 B |
| this PR (default verbosity) | 659,776 B |
| this PR + `-DFASTLED_LOG_VERBOSITY=0` | 616,144 B |

Net default delta: **−144 B**. Much smaller than the original ~3 KB projection — confirms the meta-issue's assumption that the slow path "dead-strips" on legacy builds was off (LTO + `-Og` doesn't lift the cold body on its own; the explicit hot/cold split gives the compiler the seam it needs). The `-DFASTLED_LOG_VERBOSITY=0` path is unchanged — verifying no regression on the opt-in slim build.

The architectural cleanup is **load-bearing for the next iterations**: once `resolveDynamicDriver` is its own function, follow-up work can extract the diagnostic strings entirely behind a verbosity gate without touching the hot path, and the slow path can be moved to a separate TU and gated for tree-shaking.

## Lint guard (item 2.1 follow-up)

`ci/lint_cpp/bare_noinline_checker.py`:
- Bans `__attribute__((noinline))` and `__declspec(noinline)` in `src/`
- Exempts the macro shim itself (`fl/stl/compiler_control.{h,cpp.hpp}`)
- Exempts `src/third_party/` (upstream code we don't control)
- Suppression: `// ok noinline` at end of line

Migrated all 12 existing call sites:

| File | Sites |
|---|---|
| `src/fl/gfx/blur.cpp.hpp` | 3 |
| `src/fl/math/memmove.h` | 2 (AVR-only `memcpy8`/`memset8`) |
| `src/platforms/arm/stm32/fastspi_arm_stm32.h` | 1 |
| `src/platforms/esp/32/core/fastspi_esp32_arduino.h` | 1 |
| `src/platforms/esp/32/core/fastspi_esp32_idf.h` | 1 |
| `src/platforms/esp/32/drivers/rmt/rmt_4/channel_driver_rmt4.h` | 7 |
| `src/platforms/esp/32/drivers/rmt/rmt_5/channel_driver_rmt.cpp.hpp` | 2 |
| `src/platforms/esp/8266/fastspi_esp8266.h` | 1 |
| `src/platforms/shared/spi_bitbang/generic_software_spi.h` | 1 |

Plus `#include \"fl/stl/compiler_control.h\"` added to `src/fl/math/memmove.h` (the only file that wasn't pulling it in transitively).

## Tests

- [x] `bash compile esp32s3 --examples Blink --platformio` — succeeds, 659,776 B
- [x] `bash compile esp32s3 --examples Blink --platformio --defines FASTLED_LOG_VERBOSITY=0` — 616,144 B (identical to master at the same flag)
- [x] `uv run python ci/lint_cpp/bare_noinline_checker.py` — clean on src/ after the migration

Refs: #2773 #2473 #2421

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved Channel driver resolution by separating dynamic driver selection into a dedicated helper, optimizing the fast path for legacy controllers.
  * Standardized compiler directives across the codebase using a new portable `FL_NO_INLINE` macro for better cross-platform compatibility.

* **Chores**
  * Added linter enforcement to ensure consistent use of the `FL_NO_INLINE` macro instead of bare compiler-specific directives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->