### PR TITLE
refactor(channels): extract showPixels cold-path errors + gate addDriver capStr build (#2773 iter 3)

### DIFF
--- a/src/fl/channels/channel.cpp.hpp
+++ b/src/fl/channels/channel.cpp.hpp
@@ -333,6 +333,50 @@ void writeUCS7604(fl::vector_psram<u8>* data, PixelIterator& pixelIterator,
                   mode, wire_current, is_rgbw, gamma8.get());
 }
 
+// Out-of-line cold-path diagnostic emitters for Channel::showPixels (#2773).
+// Each multi-line `FL_ERROR(... << ... << ...)` chain in showPixels was
+// inlining ~10 `operator<<` instantiations into the hot path, all behind
+// one-shot guards (`mBusWarned`, `mDisabledDriverWarned`) that fire at
+// most once per channel lifetime. Marking the helpers `noinline` keeps
+// the operator-chain code out of showPixels' prologue/epilogue while
+// preserving the exact diagnostic output. Symbol-level data: showPixels
+// was 4243 B before the split.
+__attribute__((noinline)) static void emitTypedBusNotInstantiatedError(
+    const fl::string& name, const fl::string& busKey) FL_NOEXCEPT {
+    FL_ERROR("Channel '" << name << "': Driver '" << busKey
+        << "' wasn't instantiated. Resolve with: "
+        << "(1) fl::enableDrivers<fl::Bus::" << busKey << ">() "
+        << "(links only this driver), "
+        << "(2) FastLED.enableAllDrivers() (links every driver), or "
+        << "(3) FastLED.addLeds<..., fl::Bus::" << busKey << ">(...) "
+        << "(legacy API; pins Bus + triggers linker keep-alive). "
+        << "Defaulting to AUTO/priority dispatch.");
+}
+
+__attribute__((noinline)) static void emitTypedBusChipsetMismatchError(
+    const fl::string& name, const fl::string& busKey) FL_NOEXCEPT {
+    FL_ERROR("Channel '" << name << "': Driver '" << busKey
+        << "' is registered but cannot handle this channel's chipset "
+        << "(bus/chipset mismatch). Defaulting to AUTO/priority dispatch.");
+}
+
+__attribute__((noinline)) static void emitDisabledDriverError(
+    const fl::string& name, const fl::string& driverName,
+    const fl::string& exclusive) FL_NOEXCEPT {
+    if (!exclusive.empty()) {
+        FL_ERROR("Channel '" << name << "': bound driver '" << driverName
+            << "' is currently DISABLED by exclusive-driver selection '"
+            << exclusive << "'. Frame will be silently dropped. "
+            << "Resolve with: FastLED.enableDrivers<fl::Bus::"
+            << driverName << ">() or FastLED.enableAllDrivers().");
+    } else {
+        FL_ERROR("Channel '" << name << "': bound driver '" << driverName
+            << "' is currently DISABLED. Frame will be silently dropped. "
+            << "Resolve with: FastLED.enableDrivers<fl::Bus::"
+            << driverName << ">() or FastLED.enableAllDrivers().");
+    }
+}
+
 } // anonymous namespace
 
 void Channel::showPixels(PixelController<RGB, 1, 0xFFFFFFFF> &pixels) {
@@ -385,19 +429,10 @@ void Channel::showPixels(PixelController<RGB, 1, 0xFFFFFFFF> &pixels) {
         if (!busDriver) {
             // Typed Bus miss — emit the actionable hint with the three
             // currently-shipping remediations (option 3 added in #2460).
-            FL_ERROR("Channel '" << mName << "': Driver '" << busKey
-                << "' wasn't instantiated. Resolve with: "
-                << "(1) fl::enableDrivers<fl::Bus::" << busKey << ">() "
-                << "(links only this driver), "
-                << "(2) FastLED.enableAllDrivers() (links every driver), or "
-                << "(3) FastLED.addLeds<..., fl::Bus::" << busKey << ">(...) "
-                << "(legacy API; pins Bus + triggers linker keep-alive). "
-                << "Defaulting to AUTO/priority dispatch.");
+            emitTypedBusNotInstantiatedError(mName, busKey);
         } else {
             // Registered, but canHandle() said no — bus/chipset mismatch.
-            FL_ERROR("Channel '" << mName << "': Driver '" << busKey
-                << "' is registered but cannot handle this channel's chipset "
-                << "(bus/chipset mismatch). Defaulting to AUTO/priority dispatch.");
+            emitTypedBusChipsetMismatchError(mName, busKey);
         }
         mBusWarned = true;
     }
@@ -514,20 +549,9 @@ void Channel::showPixels(PixelController<RGB, 1, 0xFFFFFFFF> &pixels) {
     auto status = ChannelManager::instance().driverStatus(driverName);
     if (status == ChannelManager::DriverStatus::STATUS_DISABLED) {
         if (!mDisabledDriverWarned) {
-            const fl::string& exclusive =
-                ChannelManager::instance().exclusiveDriverName();
-            if (!exclusive.empty()) {
-                FL_ERROR("Channel '" << mName << "': bound driver '" << driverName
-                    << "' is currently DISABLED by exclusive-driver selection '"
-                    << exclusive << "'. Frame will be silently dropped. "
-                    << "Resolve with: FastLED.enableDrivers<fl::Bus::"
-                    << driverName << ">() or FastLED.enableAllDrivers().");
-            } else {
-                FL_ERROR("Channel '" << mName << "': bound driver '" << driverName
-                    << "' is currently DISABLED. Frame will be silently dropped. "
-                    << "Resolve with: FastLED.enableDrivers<fl::Bus::"
-                    << driverName << ">() or FastLED.enableAllDrivers().");
-            }
+            emitDisabledDriverError(
+                mName, driverName,
+                ChannelManager::instance().exclusiveDriverName());
             mDisabledDriverWarned = true;
         }
         // Skip the enqueue — the data wouldn't be sent anyway, and dropping

--- a/src/fl/channels/manager.cpp.hpp
+++ b/src/fl/channels/manager.cpp.hpp
@@ -107,7 +107,12 @@ void ChannelManager::addDriver(int priority, fl::shared_ptr<IChannelDriver> driv
 
     mDrivers.push_back({priority, driver, engineName, enabled});
 
-    // Build capability string for debug output
+    // Build capability string for debug output. Gate the entire block
+    // behind FASTLED_HAS_DBG because the capStr exists ONLY for the
+    // FL_DBG below — on release builds (FASTLED_HAS_DBG=0) it was dead
+    // code that still built `fl::string` and ran two branches. (#2773
+    // memory-hunt iter 3.)
+#if FASTLED_HAS_DBG
     IChannelDriver::Capabilities caps = driver->getCapabilities();
     fl::string capStr;
     if (caps.supportsClockless) {
@@ -122,6 +127,7 @@ void ChannelManager::addDriver(int priority, fl::shared_ptr<IChannelDriver> driv
     }
 
     FL_DBG("ChannelManager: Added driver '" << engineName.c_str() << "' (priority " << priority << ", caps: " << capStr.c_str() << ")");
+#endif
 
     // Sort drivers by priority descending (higher values first) after each insertion
     // Higher priority values = higher precedence (e.g., priority 50 selected over priority 10)


### PR DESCRIPTION
## Summary

Two more applications of the noinline-helper pattern from iter 2 (PR #2826), targeting the next two FastLED-owned hot symbols on the esp32dev Blink build.

### Channel::showPixels (4243 B → expected ~3000 B)

Three multi-line `FL_ERROR(... << ...)` chains in showPixels, each behind a one-shot guard (`mBusWarned`, `mDisabledDriverWarned`), were inlining ~10 \`operator<<\` instantiations into the path that runs *every frame*:

- typed-Bus-not-instantiated diagnostic (#2455 / #2459)
- typed-Bus-chipset-mismatch diagnostic
- disabled-driver silent-drop diagnostic (#2517)

Moved into three `noinline static` helpers in the existing anonymous namespace just above showPixels:

- \`emitTypedBusNotInstantiatedError(name, busKey)\`
- \`emitTypedBusChipsetMismatchError(name, busKey)\`
- \`emitDisabledDriverError(name, driverName, exclusive)\`

Pure code motion — same rodata, same FL_ERROR severity, same one-shot guard semantics.

### ChannelManager::addDriver (2367 B)

The capability-string builder (\`capStr\`) at the bottom of addDriver existed *only* to populate the trailing FL_DBG line. On release builds (\`FASTLED_HAS_DBG == 0\`) FL_DBG is no-op, but the \`fl::string\` allocation and the two branch-checks still ran and still emitted code. Wrap the whole block in \`#if FASTLED_HAS_DBG\`.

- On default ESP32 builds (\`SKETCH_HAS_LARGE_MEMORY\` → \`FASTLED_HAS_DBG=1\`): no-op.
- On \`-DFASTLED_LOG_VERBOSITY=0\` / \`-DFASTLED_DISABLE_DBG=1\` builds: removes the dead code entirely.

## Verification status

My local fbuild esp32dev infrastructure is currently broken (zccache daemon won't start — all native + ESP32 builds fail with \`zccache[err]: cannot connect to daemon\`), so size measurements rely on CI. The pattern is the *same* one that landed in iter 2 (PR #2826: createChannel −28%, already merged on master with no regressions); this PR extends the same mechanical refactor to two adjacent symbols.

## Test plan

- [ ] esp32dev_binary_size workflow — authoritative size measurement (now that the fbuild symbolizer fix from PR #2823 is in master).
- [ ] Host \`fl::channels\` unit tests still pass (showPixels diagnostic guards exercised by tests/fl/channels/channel.cpp).
- [ ] No diagnostic message changes — strings are textually identical to the pre-extraction versions.

Refs #2773 (memory-hunt loop, iter 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized diagnostic logging performance by streamlining error reporting paths.
  * Improved build efficiency with conditional compilation for debug capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->