### PR TITLE
perf(channels): gate addDriver capStr builder behind FASTLED_HAS_DBG (#2773 iter 6)

### DIFF
--- a/src/fl/channels/manager.cpp.hpp
+++ b/src/fl/channels/manager.cpp.hpp
@@ -107,7 +107,14 @@ void ChannelManager::addDriver(int priority, fl::shared_ptr<IChannelDriver> driv
 
     mDrivers.push_back({priority, driver, engineName, enabled});
 
-    // Build capability string for debug output
+    // Build capability string for debug output. Gate the entire block behind
+    // FASTLED_HAS_DBG because the `capStr` exists ONLY to feed the FL_DBG
+    // line below. On release builds (FASTLED_HAS_DBG=0 — i.e. the default
+    // SKETCH_HAS_LARGE_MEMORY=0 path AND any -DFASTLED_LOG_VERBOSITY=0
+    // opt-in build via the gating in fl/log/log.h) the FL_DBG itself is a
+    // no-op, but without this guard the `fl::string capStr` allocation +
+    // two `if` branches still emitted code. See #2773 item 2.3 follow-up.
+#if FASTLED_HAS_DBG
     IChannelDriver::Capabilities caps = driver->getCapabilities();
     fl::string capStr;
     if (caps.supportsClockless) {
@@ -122,6 +129,7 @@ void ChannelManager::addDriver(int priority, fl::shared_ptr<IChannelDriver> driv
     }
 
     FL_DBG("ChannelManager: Added driver '" << engineName.c_str() << "' (priority " << priority << ", caps: " << capStr.c_str() << ")");
+#endif
 
     // Sort drivers by priority descending (higher values first) after each insertion
     // Higher priority values = higher precedence (e.g., priority 50 selected over priority 10)


### PR DESCRIPTION
## Summary

The capability-string builder in `ChannelManager::addDriver` exists only to feed the trailing `FL_DBG(\"...caps: \" << capStr.c_str() ...)` line. On `FASTLED_HAS_DBG=0` builds (default `SKETCH_HAS_LARGE_MEMORY=0` path AND any `-DFASTLED_LOG_VERBOSITY=0` opt-in build), `FL_DBG` itself already expands to `do { if (false) {...} } while (0)`, but the `fl::string capStr` allocation, two `if` branches, and the `if (capStr.empty()) capStr = \"NONE\"` fallback above it still emitted code — the optimizer wasn't reliably DCE'ing them through the `if (false)` form.

Wrapping the whole block in `#if FASTLED_HAS_DBG` makes the elision explicit so the linker drops it without depending on DCE behavior. Same approach attempted on a previously-closed parallel PR (#2832); reopening it standalone with a fresh measurement against current master.

## Measured on ESP32-S3 Blink (PlatformIO + IDF 5.4)

| Build | `firmware.bin` | Δ |
|---|---:|---:|
| master (default verbosity) | 661,408 B | — |
| this PR (default verbosity) | 661,408 B | **0** |
| master + `-DFASTLED_LOG_VERBOSITY=0` | 616,848 B | — |
| this PR + `-DFASTLED_LOG_VERBOSITY=0` | 616,384 B | **−464 B** |

Zero risk at default (the gate is true when `FASTLED_HAS_DBG=1`, so the inside-the-#if code is identical to today). The −464 B on the opt-in slim build is real because the `fl::string` ops above the FL_DBG were being kept by the compiler even though FL_DBG itself was a no-op.

Refs: #2773

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized debug code compilation to reduce binary size when debug features are disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->