### PR TITLE
chore(lint): move fl/net/network_detector.h to fl/ to match its fl:: namespace

### DIFF
--- a/src/fl/channels/driver.cpp.hpp
+++ b/src/fl/channels/driver.cpp.hpp
@@ -2,7 +2,7 @@
 #include "fl/channels/driver.h"
 #include "fl/channels/detail/wait_spin_budget.h"
 #include "fl/log/log.h"
-#include "fl/net/network_detector.h"
+#include "fl/network_detector.h"
 #include "fl/stl/chrono.h"
 #include "fl/task/executor.h"
 #include "platforms/is_platform.h"

--- a/src/fl/channels/manager.cpp.hpp
+++ b/src/fl/channels/manager.cpp.hpp
@@ -13,7 +13,7 @@
 #include "fl/stl/move.h"
 #include "fl/system/trace.h"
 #include "fl/task/executor.h"
-#include "fl/net/network_detector.h"
+#include "fl/network_detector.h"
 #include "platforms/init_channel_driver.h"
 #include "platforms/is_platform.h"
 #include "fl/stl/noexcept.h"

--- a/src/fl/network_detector.h
+++ b/src/fl/network_detector.h
@@ -1,6 +1,6 @@
 #pragma once
 
-/// @file fl/net/network_detector.h
+/// @file fl/network_detector.h
 /// @brief Cross-platform facade for runtime network activity detection.
 ///
 /// The full implementation lives at


### PR DESCRIPTION
The file lives under `src/fl/net/` but declares `fl::NetworkDetector` (not `fl::net::NetworkDetector`), tripping `SubdirNamespaceChecker` which enforces `src/fl/<subdir>/*.h` -> `namespace fl::<subdir>` and has a "no suppression" policy.

Moving the file to `src/fl/network_detector.h` resolves the lint violation without renaming the class. The real RMT5 implementation at `src/platforms/esp/32/drivers/rmt/rmt_5/network_detector.h` already declares `fl::NetworkDetector`, so this aligns the facade's namespace with its class location.

## Changes

- `src/fl/net/network_detector.h` -> `src/fl/network_detector.h` (98% rename)
- `src/fl/channels/driver.cpp.hpp` — include path updated
- `src/fl/channels/manager.cpp.hpp` — include path updated

No behavior change; namespace and class unchanged. Verified with `bash lint --cpp` (passes — the SubdirNamespaceChecker violation is gone, only pre-existing warn-only PlatformIO-internal-usage warnings remain).

Discovered during AutoResearch testing of the new SIMD ARM-DSP backend on Teensy 4.0 (PR #2808). Unrelated to that work; surfacing here as a clean separate fix.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal module structure reorganization to improve code organization and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->