### PR TITLE
chore(deps): bump zccache pin 1.11.14 -> 1.11.15

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ dependencies = [
     # incremental builds produce stale .obj files after a git pull that
     # changes transitive headers (symptom: `undefined symbol: ...` link
     # errors hours after a header actually changed).
-    "zccache>=1.11.14",
+    "zccache>=1.11.15",
     "ninja",
     "meson>=1.11.0",
     "download",


### PR DESCRIPTION
**Draft — depends on zackees/zccache#671 landing first.**

zccache 1.11.15 is the first release to ship the daemon-wedge recovery from zackees/zccache#669:

- Layer A — wrap path detects daemon wedge via 90s configurable recv timeout, force-kills the wedged daemon, falls back to ephemeral compile so the build completes
- Layer B — same wedge detection on ephemeral paths (fast-fail)
- Layer C — `IpcListener::accept()` on Windows no longer silently shrinks the named-pipe pool on transient OS errors

## Why force the minimum to 1.11.15

This repo's current pin (`>=1.11.14`) lets new contributors land on a baseline that wedges reliably on Windows under heavy parallel-build load (~670 TUs reproduces it within ~1h of daemon uptime — see zackees/zccache#666). The recovery layers from #669 only ship in 1.11.15.

`>=1.11.15` still allows 1.11.x and 1.12.x; it just forbids the known-broken-on-Windows 1.11.14.

## Order of operations

1. zackees/zccache#671 merges → CI auto-publishes 1.11.15 to PyPI
2. This PR's draft is marked ready
3. `uv lock` regenerates `uv.lock` locally (or CI does it on this branch)
4. Squash-merge

## Sister PR

FastLED/fbuild has the same `>=1.11.14` pin and needs an identical bump.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated internal dependencies to latest compatible versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->