### PR TITLE
feat(platform): LPC845 bit-bang clockless driver (Stage 2a of #2836)

### DIFF
--- a/src/led_sysdefs.h
+++ b/src/led_sysdefs.h
@@ -22,7 +22,9 @@
 /// @file led_sysdefs.h
 /// Determines which platform system definitions to include
 
-#if defined(NRF51) || defined(__RFduino__) || defined (__Simblee__)
+#if defined(FL_IS_ARM_LPC)
+#include "platforms/arm/lpc/led_sysdefs_arm_lpc.h"  // ok platform headers
+#elif defined(NRF51) || defined(__RFduino__) || defined (__Simblee__)
 #include "platforms/arm/nrf51/led_sysdefs_arm_nrf51.h"  // ok platform headers
 #elif defined(NRF52_SERIES) || defined(NRF52840_XXAA)
 #include "platforms/arm/nrf52/led_sysdefs_arm_nrf52.h"  // ok platform headers

--- a/src/platforms.h
+++ b/src/platforms.h
@@ -2,14 +2,18 @@
 
 #include "fastled_config.h"
 
-
+// Pull in ARM-family detection so platform-routed FL_IS_ARM_* defines are
+// visible before the dispatcher below.
+#include "platforms/arm/is_arm.h"  // ok platform headers
 
 
 /// @file platforms.h
 /// Determines which platforms headers to include
 
 
-#if defined(NRF51)
+#if defined(FL_IS_ARM_LPC)
+#include "platforms/arm/lpc/fastled_arm_lpc.h"  // ok platform headers
+#elif defined(NRF51)
 #include "platforms/arm/nrf51/fastled_arm_nrf51.h"  // ok platform headers
 #elif defined(NRF52_SERIES)
 #include "platforms/arm/nrf52/fastled_arm_nrf52.h"  // ok platform headers

--- a/src/platforms/arm/is_arm.h
+++ b/src/platforms/arm/is_arm.h
@@ -14,6 +14,9 @@
 
 // Include platform-specific detection headers
 // IWYU pragma: begin_keep
+#include "lpc/is_lpc.h"
+// IWYU pragma: end_keep
+// IWYU pragma: begin_keep
 #include "nrf52/is_nrf52.h"
 // IWYU pragma: end_keep
 // IWYU pragma: begin_keep
@@ -68,6 +71,8 @@
     defined(__SAMD21E17A__) || defined(__SAMD21E18A__) || \
     /* Microchip SAMD51/SAME51 */ \
     defined(__SAMD51G19A__) || defined(__SAMD51J19A__) || \
-    defined(__SAME51J19A__) || defined(__SAMD51P19A__) || defined(__SAMD51P20A__)
+    defined(__SAME51J19A__) || defined(__SAMD51P19A__) || defined(__SAMD51P20A__) || \
+    /* NXP LPC8xx (LPC845 / LPC804 Cortex-M0+) - defined by lpc/is_lpc.h */ \
+    defined(FL_IS_ARM_LPC)
 #define FL_IS_ARM
 #endif  // ARM platform detection

--- a/src/platforms/arm/lpc/clockless_arm_lpc.h
+++ b/src/platforms/arm/lpc/clockless_arm_lpc.h
@@ -1,0 +1,82 @@
+// IWYU pragma: private
+
+#ifndef __INC_CLOCKLESS_ARM_LPC_H
+#define __INC_CLOCKLESS_ARM_LPC_H
+
+#include "platforms/arm/is_arm.h"
+#include "platforms/arm/lpc/is_lpc.h"
+
+#if defined(FL_IS_ARM_LPC)
+
+#include "platforms/arm/common/m0clockless.h"
+#include "fl/chipsets/timing_traits.h"
+#include "fl/stl/noexcept.h"
+#include "eorder.h"
+
+namespace fl {
+
+#define FL_CLOCKLESS_CONTROLLER_DEFINED 1
+
+// Byte offsets from FastPin<>::port() (which points at LPC_GPIO->PIN[0]) to
+// the SET / CLR registers used by the shared M0 clockless C++ implementation.
+//   PIN[0]   @ controller base + 0x2100  (port base for FastPin)
+//   SET[0]   @ controller base + 0x2200  -> +0x100 from PIN[0]
+//   CLR[0]   @ controller base + 0x2280  -> +0x180 from PIN[0]
+#define FL_LPC_HI_OFFSET 0x100
+#define FL_LPC_LO_OFFSET 0x180
+
+template <u8 DATA_PIN, typename TIMING, EOrder RGB_ORDER = RGB,
+          int XTRA0 = 0, bool FLIP = false, int WAIT_TIME = 280>
+class ClocklessController : public CPixelLEDController<RGB_ORDER> {
+    typedef typename FastPin<DATA_PIN>::port_ptr_t data_ptr_t;
+    typedef typename FastPin<DATA_PIN>::port_t     data_t;
+
+    data_t     mPinMask;
+    data_ptr_t mPort;
+    CMinWait<WAIT_TIME> mWait;
+
+public:
+    virtual void init() FL_NOEXCEPT {
+        FastPin<DATA_PIN>::setOutput();
+        mPinMask = FastPin<DATA_PIN>::mask();
+        mPort    = FastPin<DATA_PIN>::port();
+    }
+
+    virtual u16 getMaxRefreshRate() const { return 400; }
+
+    virtual void showPixels(PixelController<RGB_ORDER>& pixels) FL_NOEXCEPT {
+        mWait.wait();
+        cli();
+        if (!showRGBInternal(pixels)) {
+            sei();
+            delayMicroseconds(WAIT_TIME);
+            cli();
+            showRGBInternal(pixels);
+        }
+        sei();
+        mWait.mark();
+    }
+
+    static u32 showRGBInternal(PixelController<RGB_ORDER> pixels) FL_NOEXCEPT {
+        struct M0ClocklessData data;
+        data.d[0] = pixels.d[0];
+        data.d[1] = pixels.d[1];
+        data.d[2] = pixels.d[2];
+        data.s[0] = pixels.mColorAdjustment.premixed[0];
+        data.s[1] = pixels.mColorAdjustment.premixed[1];
+        data.s[2] = pixels.mColorAdjustment.premixed[2];
+        data.e[0] = pixels.e[0];
+        data.e[1] = pixels.e[1];
+        data.e[2] = pixels.e[2];
+        data.adj  = pixels.mAdvance;
+
+        typename FastPin<DATA_PIN>::port_ptr_t portBase = FastPin<DATA_PIN>::port();
+        return showLedData<FL_LPC_HI_OFFSET, FL_LPC_LO_OFFSET, TIMING, RGB_ORDER, WAIT_TIME>(
+            portBase, FastPin<DATA_PIN>::mask(), pixels.mData, pixels.mLen, &data);
+    }
+};
+
+}  // namespace fl
+
+#endif  // FL_IS_ARM_LPC
+#endif  // __INC_CLOCKLESS_ARM_LPC_H

--- a/src/platforms/arm/lpc/fastled_arm_lpc.h
+++ b/src/platforms/arm/lpc/fastled_arm_lpc.h
@@ -1,0 +1,10 @@
+// IWYU pragma: private
+
+// ok no namespace fl
+#ifndef __INC_FASTLED_ARM_LPC_H
+#define __INC_FASTLED_ARM_LPC_H
+
+#include "platforms/arm/lpc/fastpin_arm_lpc.h"
+#include "platforms/arm/lpc/clockless_arm_lpc.h"
+
+#endif

--- a/src/platforms/arm/lpc/fastpin_arm_lpc.h
+++ b/src/platforms/arm/lpc/fastpin_arm_lpc.h
@@ -1,0 +1,132 @@
+// IWYU pragma: private
+
+// ok no namespace fl
+#ifndef __INC_FASTPIN_ARM_LPC_H
+#define __INC_FASTPIN_ARM_LPC_H
+
+#include "fl/stl/compiler_control.h"
+#include "fl/system/fastpin_base.h"
+#include "platforms/arm/is_arm.h"
+#include "platforms/arm/lpc/is_lpc.h"
+
+FL_DISABLE_WARNING_PUSH
+FL_DISABLE_WARNING_DEPRECATED_REGISTER
+
+#if defined(FL_IS_ARM_LPC)
+
+namespace fl {
+
+// Minimal LPC8xx GPIO controller view used by the FastPin templates. The
+// MCUXpresso CMSIS device header defines an equivalent LPC_GPIO_Type; when
+// that header is on the include path (i.e. inside led_sysdefs_arm_lpc.h via
+// <LPC845.h>) the real struct is what code links against. This local mirror
+// is only consulted when the device header could not be located, which is
+// useful for host-side IDE introspection.
+#ifndef FL_LPC_GPIO_BASE
+#define FL_LPC_GPIO_BASE 0xA0000000UL
+#endif
+
+typedef struct {
+    volatile u8  B[2][32];         // 0x0000 byte-pin access
+    volatile u32 W[2][32];         // 0x1000 word-pin access (0x80 bytes per port)
+    volatile u32 RESERVED0[1024 - 256];
+    volatile u32 DIR[2];           // 0x2000
+    volatile u32 RESERVED1[30];
+    volatile u32 MASK[2];          // 0x2080
+    volatile u32 RESERVED2[30];
+    volatile u32 PIN[2];           // 0x2100
+    volatile u32 RESERVED3[30];
+    volatile u32 MPIN[2];          // 0x2180
+    volatile u32 RESERVED4[30];
+    volatile u32 SET[2];           // 0x2200
+    volatile u32 RESERVED5[30];
+    volatile u32 CLR[2];           // 0x2280
+    volatile u32 RESERVED6[30];
+    volatile u32 NOT[2];           // 0x2300
+    volatile u32 RESERVED7[30];
+    volatile u32 DIRSET[2];        // 0x2380
+    volatile u32 RESERVED8[30];
+    volatile u32 DIRCLR[2];        // 0x2400
+    volatile u32 RESERVED9[30];
+    volatile u32 DIRNOT[2];        // 0x2480
+} FL_LPC_GPIO_Type;
+
+// Use the CMSIS-supplied LPC_GPIO pointer when available; fall back to our
+// own typed pointer when only the local struct is in scope.
+#ifndef LPC_GPIO
+#define LPC_GPIO ((FL_LPC_GPIO_Type*)FL_LPC_GPIO_BASE)
+#endif
+
+// FastPin template for LPC8xx pins. PORT0 is the only port populated on
+// LPC845/LPC804 packages currently supported.
+template <u8 PIN, u32 _MASK>
+class _ARMPIN : public ValidPinBase {
+public:
+    typedef volatile u32* port_ptr_t;
+    typedef u32           port_t;
+
+    inline static void setOutput() __attribute__((always_inline)) {
+        LPC_GPIO->DIRSET[0] = _MASK;
+    }
+    inline static void setInput() __attribute__((always_inline)) {
+        LPC_GPIO->DIRCLR[0] = _MASK;
+    }
+
+    inline static void hi() __attribute__((always_inline)) {
+        LPC_GPIO->SET[0] = _MASK;
+    }
+    inline static void lo() __attribute__((always_inline)) {
+        LPC_GPIO->CLR[0] = _MASK;
+    }
+    inline static void set(FASTLED_REGISTER port_t val) __attribute__((always_inline)) {
+        LPC_GPIO->PIN[0] = val;
+    }
+
+    inline static void strobe() __attribute__((always_inline)) { toggle(); toggle(); }
+    inline static void toggle() __attribute__((always_inline)) { LPC_GPIO->NOT[0] = _MASK; }
+
+    inline static void hi(FASTLED_REGISTER port_ptr_t /*port*/) __attribute__((always_inline)) { hi(); }
+    inline static void lo(FASTLED_REGISTER port_ptr_t /*port*/) __attribute__((always_inline)) { lo(); }
+    inline static void fastset(FASTLED_REGISTER port_ptr_t port, FASTLED_REGISTER port_t val) __attribute__((always_inline)) {
+        *port = val;
+    }
+
+    inline static port_t hival() __attribute__((always_inline)) { return LPC_GPIO->PIN[0] |  _MASK; }
+    inline static port_t loval() __attribute__((always_inline)) { return LPC_GPIO->PIN[0] & ~_MASK; }
+    // Expose PIN[0] as the "port" so the clockless C++ driver can derive the
+    // SET / CLR offsets at compile time (it uses HI_OFFSET / LO_OFFSET as
+    // byte offsets from this pointer).
+    inline static port_ptr_t port()  __attribute__((always_inline)) { return &LPC_GPIO->PIN[0]; }
+    inline static port_ptr_t sport() __attribute__((always_inline)) { return &LPC_GPIO->SET[0]; }
+    inline static port_ptr_t cport() __attribute__((always_inline)) { return &LPC_GPIO->CLR[0]; }
+    inline static port_t     mask()  __attribute__((always_inline)) { return _MASK; }
+
+    inline static bool isset() __attribute__((always_inline)) {
+        return (LPC_GPIO->PIN[0] & _MASK) != 0;
+    }
+};
+
+#define _FL_DEFPIN(PIN) template<> class FastPin<PIN> : public _ARMPIN<PIN, (1u << (PIN))> {};
+
+// LPC845 (HVQFN48 / HVQFN33 / TSSOP20) and LPC804 expose PIO0_0..PIO0_31.
+// Pin availability per package is enforced by hardware; the template just
+// instantiates the full 32-pin grid and the linker keeps only what is used.
+#define MAX_PIN 31
+_FL_DEFPIN(0);  _FL_DEFPIN(1);  _FL_DEFPIN(2);  _FL_DEFPIN(3);
+_FL_DEFPIN(4);  _FL_DEFPIN(5);  _FL_DEFPIN(6);  _FL_DEFPIN(7);
+_FL_DEFPIN(8);  _FL_DEFPIN(9);  _FL_DEFPIN(10); _FL_DEFPIN(11);
+_FL_DEFPIN(12); _FL_DEFPIN(13); _FL_DEFPIN(14); _FL_DEFPIN(15);
+_FL_DEFPIN(16); _FL_DEFPIN(17); _FL_DEFPIN(18); _FL_DEFPIN(19);
+_FL_DEFPIN(20); _FL_DEFPIN(21); _FL_DEFPIN(22); _FL_DEFPIN(23);
+_FL_DEFPIN(24); _FL_DEFPIN(25); _FL_DEFPIN(26); _FL_DEFPIN(27);
+_FL_DEFPIN(28); _FL_DEFPIN(29); _FL_DEFPIN(30); _FL_DEFPIN(31);
+
+#define HAS_HARDWARE_PIN_SUPPORT
+
+}  // namespace fl
+
+#endif  // FL_IS_ARM_LPC
+
+FL_DISABLE_WARNING_POP
+
+#endif  // __INC_FASTPIN_ARM_LPC_H

--- a/src/platforms/arm/lpc/int.h
+++ b/src/platforms/arm/lpc/int.h
@@ -1,0 +1,9 @@
+// ok no namespace fl
+#pragma once
+
+// IWYU pragma: private
+
+// LPC8xx (Cortex-M0+) shares the standard 32-bit ARM integer typedefs.
+// Delegate to the shared ARM int.h so future divergence (e.g. if a specific
+// LPC toolchain needs different short/long widths) has a single place to land.
+#include "platforms/arm/int.h"

--- a/src/platforms/arm/lpc/is_lpc.h
+++ b/src/platforms/arm/lpc/is_lpc.h
@@ -1,0 +1,32 @@
+#pragma once
+
+// IWYU pragma: private
+
+// ok no namespace fl
+
+/// @file is_lpc.h
+/// @brief NXP LPC8xx platform detection macros for FastLED
+///
+/// Detects NXP LPC845 and LPC804 (ARM Cortex-M0+) platforms. Detection uses
+/// the MCUXpresso / CMSIS device-header defines (e.g. CPU_LPC845M301JBD48,
+/// LPC845, LPC804) as well as bare project-level defines that fbuild/PIO
+/// configurations are expected to provide (__LPC845__, __LPC804__).
+
+// LPC845 (ARM Cortex-M0+, 30 MHz, 64KB Flash, 16KB SRAM)
+#if defined(__LPC845__) || defined(LPC845) || defined(LPC845M301) || \
+    defined(CPU_LPC845M301JBD48) || defined(CPU_LPC845M301JBD64) || \
+    defined(CPU_LPC845M301JHI33) || defined(CPU_LPC845M301JHI48)
+#define FL_LPC845
+#endif
+
+// LPC804 (ARM Cortex-M0+, 15 MHz, 32KB Flash, 4KB SRAM, integrated PLU)
+#if defined(__LPC804__) || defined(LPC804) || defined(LPC804M101) || \
+    defined(CPU_LPC804M101JDH20) || defined(CPU_LPC804M101JDH24) || \
+    defined(CPU_LPC804M101JHI33)
+#define FL_LPC804
+#endif
+
+// General LPC8xx platform (any LPC8xx variant supported by this port)
+#if defined(FL_LPC845) || defined(FL_LPC804)
+#define FL_IS_ARM_LPC
+#endif

--- a/src/platforms/arm/lpc/led_sysdefs_arm_lpc.h
+++ b/src/platforms/arm/lpc/led_sysdefs_arm_lpc.h
@@ -1,0 +1,73 @@
+// IWYU pragma: private
+
+// ok no namespace fl
+#ifndef __INC_LED_SYSDEFS_ARM_LPC_H
+#define __INC_LED_SYSDEFS_ARM_LPC_H
+
+#include "platforms/arm/lpc/is_lpc.h"
+#include "platforms/arm/is_arm.h"
+
+#ifndef FL_IS_ARM
+#error "FL_IS_ARM must be defined before including this header. Ensure platforms/arm/is_arm.h is included first."
+#endif
+
+#define FL_IS_ARM_M0_PLUS
+
+// The LPC8xx GPIO controller exposes SET[port] and CLR[port] at byte offsets
+// 0x2200 / 0x2280 from the controller base - far beyond the 5-bit imm5*4
+// encoding the M0/M0+ STR-immediate-offset instruction supports. The shared
+// inline-assembly clockless driver assumes both offsets fit a single
+// str-with-immediate; LPC cannot satisfy that, so route through the portable
+// C++ implementation which performs an indexed store instead.
+#ifndef FASTLED_M0_USE_C_IMPLEMENTATION
+#define FASTLED_M0_USE_C_IMPLEMENTATION
+#endif
+
+#ifndef F_CPU
+#if defined(FL_LPC845)
+#define F_CPU 30000000UL
+#elif defined(FL_LPC804)
+#define F_CPU 15000000UL
+#endif
+#endif
+
+#ifndef VARIANT_MCK
+#define VARIANT_MCK F_CPU
+#endif
+
+#ifndef FASTLED_ALLOW_INTERRUPTS
+#define FASTLED_ALLOW_INTERRUPTS 1
+#endif
+
+#ifndef FASTLED_USE_PROGMEM
+#define FASTLED_USE_PROGMEM 0
+#endif
+
+#define FASTLED_SPI_BYTE_ONLY
+
+#include "fl/stl/stdint.h"
+
+typedef volatile fl::u32 RoReg;
+typedef volatile fl::u32 RwReg;
+typedef fl::u32          prog_uint32_t;
+typedef fl::u8           boolean;
+
+#define PROGMEM
+#define NO_PROGMEM
+#define NEED_CXX_BITS
+
+// CMSIS device header from MCUXpresso SDK provides __disable_irq / __enable_irq
+// via core_cm0plus.h. Some integrations only pull in the SoC header (e.g.
+// LPC845.h / LPC804.h), which transitively includes the core header.
+// IWYU pragma: begin_keep
+#if defined(FL_LPC845)
+#include <LPC845.h>
+#elif defined(FL_LPC804)
+#include <LPC804.h>
+#endif
+// IWYU pragma: end_keep
+
+#define cli() __disable_irq()
+#define sei() __enable_irq()
+
+#endif


### PR DESCRIPTION
## Summary

Stage 2a of the NXP LPC8xx FastLED port (meta issue #2836).

Adds a bit-banged WS2812 clockless driver for **LPC845** (Cortex-M0+ @ 30 MHz) and **LPC804** (Cortex-M0+ @ 15 MHz), templated on the existing shared `m0clockless` driver used by Teensy LC (KL26Z) and nRF51.

### New files (`src/platforms/arm/lpc/`)

| File | Purpose |
|------|---------|
| `is_lpc.h` | Detects `__LPC845__` / `__LPC804__` / `CPU_LPC845*` / `CPU_LPC804*` defines from the MCUXpresso CMSIS device headers; emits `FL_LPC845`, `FL_LPC804`, `FL_IS_ARM_LPC`. |
| `int.h` | Delegates to the shared ARM 32-bit integer typedefs (`src/platforms/arm/int.h`). |
| `led_sysdefs_arm_lpc.h` | Defines `F_CPU` per chip (30 MHz / 15 MHz), `FL_IS_ARM_M0_PLUS`, `cli()`/`sei()` via `__disable_irq`/`__enable_irq`, and includes `<LPC845.h>` / `<LPC804.h>` for `LPC_GPIO`. |
| `fastpin_arm_lpc.h` | PIO0_0..PIO0_31 mapped onto `LPC_GPIO->SET[0]` / `CLR[0]` / `DIRSET[0]` / `DIRCLR[0]` / `NOT[0]` / `PIN[0]`. |
| `clockless_arm_lpc.h` | WS2812 controller; calls into the shared `showLedData<HI_OFFSET, LO_OFFSET, ...>` template. |
| `fastled_arm_lpc.h` | Aggregator. |

### Dispatcher wiring

- `src/platforms/arm/is_arm.h` includes `lpc/is_lpc.h` and adds `FL_IS_ARM_LPC` to the `FL_IS_ARM` umbrella.
- `src/led_sysdefs.h` routes `FL_IS_ARM_LPC` to `led_sysdefs_arm_lpc.h`.
- `src/platforms.h` routes `FL_IS_ARM_LPC` to `fastled_arm_lpc.h` (and now includes `is_arm.h` first so the LPC detection runs before the dispatch chain).

### Design decisions

1. **Uses the portable C++ implementation of `m0clockless` (`FASTLED_M0_USE_C_IMPLEMENTATION`) instead of the inline-ASM one.** The LPC8xx GPIO controller places `SET[0]` at +0x2200 and `CLR[0]` at +0x2280 from the controller base, which is beyond the 5-bit `imm5*4` encoding the M0+ `STR Rt, [Rn, #imm]` instruction supports (max byte offset = 124). The inline-asm template's `"I"` constraint cannot encode those offsets in a single-instruction store. The C++ version performs an indexed store (`port[off/4] = bitmask`) and handles arbitrary byte offsets at zero cost.
2. **`FastPin<>::port()` returns `&LPC_GPIO->PIN[0]`**, with `HI_OFFSET = 0x100` (relative to `PIN[0]`, this is `SET[0]`) and `LO_OFFSET = 0x180` (which is `CLR[0]`). The C++ clockless driver consumes these as compile-time template parameters.
3. **`FL_LPC845` is gated via `__LPC845__` or the `CPU_LPC845*` defines** from the MCUXpresso `LPC845.h` CMSIS device header - that is what the NXP SDK ships.

### Scope

- **Stage 2a only**: bit-bang WS2812. No PLU driver (Stage 2b, LPC804) or PWM+DMA driver (Stage 2c, LPC845) here.
- **Cross-compile validation depends on Stage 1** (fbuild toolchain), which is a separate repo / separate PR. **Draft until Stage 1 lands.**
- **No new `.ino`** under `examples/` - per the meta issue, Blink validation goes through existing examples once Stage 1 lands. AutoResearch is the canonical scratch target for live-device testing.

### What was verified from this side

- `bash lint --cpp`: all checks pass on the new LPC files (and the modified dispatchers).
- LPC code is gated by `defined(FL_IS_ARM_LPC)` / `defined(__LPC845__)` / `defined(__LPC804__)` so host builds are inert.
- Host build of `FastLED.h` with `FASTLED_STUB_IMPL` (no LPC defines present) compiles cleanly with the new files on the include path.

### What was NOT verified (and why)

- **No hardware bring-up**: cross-compile requires Stage 1 fbuild support that does not yet exist. Once Stage 1 lands, the recommended validation sequence is `examples/Blink` then `examples/AutoResearch` on an LPC845 dev board.
- **Pre-existing master regression observed during `bash test --cpp`**: `src/fl/net/network_detector.h:50` uses `namespace fl::net {` (C++17 nested namespace syntax) under `-Werror=c++17-extensions`. The failure is identical on pristine master (verified via `git stash`). Out of scope for this PR; flagged here for visibility.

## Test plan

- [ ] Stage 1 (fbuild) lands and exposes an `lpc845` platform target.
- [ ] `bash compile lpc845 --examples Blink` compiles clean.
- [ ] Hardware: WS2812 strip driven from PIO0_4 on an LPC845-BRK dev board renders correctly at 30 MHz CPU (T1/T2/T3 should round-trip cleanly given the shared `m0clockless_c` cycle math).
- [ ] LPC804 path: same verification at 15 MHz (timing is tighter - flag any T1/T2/T3 rounding issues).

Refs #2836.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Added support for ARM LPC8xx microcontroller platforms (LPC845, LPC804)
* FastLED can now control addressable LEDs on LPC-based boards with hardware GPIO and precise timing control
* Includes platform-specific configuration optimized for LPC microcontrollers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->