### PR TITLE
fix(net): use nested namespace fl { namespace net { ... }} (pre-C++17)

### DIFF
--- a/src/fl/net/network_detector.h
+++ b/src/fl/net/network_detector.h
@@ -47,7 +47,8 @@
 
 #include "fl/stl/noexcept.h"
 
-namespace fl::net {
+namespace fl {
+namespace net {
 
 /// @brief Stub NetworkDetector for platforms without the real implementation.
 ///
@@ -75,7 +76,8 @@ class NetworkDetector {
     NetworkDetector &operator=(const NetworkDetector &) FL_NOEXCEPT = delete;
 };
 
-} // namespace fl::net
+} // namespace net
+} // namespace fl
 
 // Back-compat: the existing channel wait sites and the real RMT5 impl both
 // expose the type as fl::NetworkDetector. Keep that name working in the


### PR DESCRIPTION
PR #2829 (`fix(net): move NetworkDetector stub into fl::net namespace`) used the C++17 nested namespace definition syntax `namespace fl::net {`, which fails under FastLED's `-Werror,-Wc++17-extensions` build flag:

```
src/fl/net/network_detector.h:50:13: error: nested namespace definition is a C++17 extension; define each namespace separately [-Werror,-Wc++17-extensions]
   50 | namespace fl::net {
      |             ^~~~~
```

The diagnostic fires on every compilation unit that transitively includes this header — `fl/channels/manager.cpp.hpp`, `fl/channels/driver.cpp.hpp`, plus every example DLL that ends up pulling channels through normal FastLED include chains. Quick mode `bash test --cpp` aborts the build after the first ~30 TUs hit this.

This PR converts the single offending namespace declaration to the equivalent pre-C++17 nested form:

```diff
-namespace fl::net {
+namespace fl {
+namespace net {
 ...
-} // namespace fl::net
+} // namespace net
+} // namespace fl
```

Class location, `using NetworkDetector = ::fl::net::NetworkDetector;` alias in `namespace fl`, and all consumer references are unchanged. Pure syntax fix.

## Verification

- `bash lint --cpp` — passes (the SubdirNamespaceChecker that #2829 was solving still passes; the file still uses `namespace fl::net` semantically, just with the older syntax)
- `bash test --cpp` — build no longer aborts at this header; build completes through to the test-run phase

Discovered while running `bash test --cpp` after the (unrelated) zccache 1.11.15 bump landed and unblocked the daemon-wedge issue from #666. Surfacing as a separate clean fix.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code organization and namespace structure for better maintainability. Backward compatibility preserved for existing APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->