### PR TITLE
fix(test): SPI ping-pong polling-path infinite loop + UBSan overflow

### DIFF
--- a/tests/platforms/esp/32/drivers/spi/spi_pingpong_pipeline_logic.cpp
+++ b/tests/platforms/esp/32/drivers/spi/spi_pingpong_pipeline_logic.cpp
@@ -113,16 +113,18 @@ struct PipelineModel {
         // goes to that same buffer — modeling the ESP-IDF SPI driver where
         // each staging buffer is independently tracked. Encoding always
         // targets the just-freed buffer, never the one still in flight.
+        //
+        // Polling and async share the same drain logic: drain whichever
+        // buffer is currently in flight (A first if both are, mirroring the
+        // ESP-IDF FIFO). The previous polling branch used `encodeIdx & 1`,
+        // which alternated between A and B independently of which one was
+        // actually in flight — that produced spurious "drain B" steps when
+        // only A had been queued, and the resulting infinite loop manifested
+        // as a UBSan signed-integer-overflow on `++completedCount`
+        // (refs the test failure on this file at line 126).
         int drainedBuf = -1;
-        if (usePolling) {
-            int lastBuf = (encodeIdx - 1) & 1;
-            if (lastBuf == 0) { transAInFlight = false; drainedBuf = 0; }
-            else              { transBInFlight = false; drainedBuf = 1; }
-        } else {
-            // FIFO: A completes before B if both are in flight.
-            if (transAInFlight)      { transAInFlight = false; drainedBuf = 0; }
-            else if (transBInFlight) { transBInFlight = false; drainedBuf = 1; }
-        }
+        if (transAInFlight)      { transAInFlight = false; drainedBuf = 0; }
+        else if (transBInFlight) { transBInFlight = false; drainedBuf = 1; }
         ++completedCount;
 
         // Refill the just-freed buffer when more data remains.


### PR DESCRIPTION
## Summary

Fixes the \`spi_pingpong_pipeline_logic\` test failure that has been blocking unrelated PRs (e.g. #2840, and previously surfaced in #2838's local builds).

\`stepStreaming\`'s polling branch derived the just-drained buffer from \`encodeIdx & 1\`, which alternates A/B independently of which buffer was actually in flight. In polling mode \`startFirstDma()\` only queues A, so:

\`\`\`
step 1: alternation says "drain A" → matches reality (transA=true)
step 2: alternation says "drain B" → transB was never queued, no-op,
        but refill still encodes a B chunk and sets transB=true → now
        BOTH A and B in flight, violating polling's "1-in-flight"
        invariant.
\`\`\`

After \`ledBytesRemaining\` hits 0, \`encodeIdx\` stops advancing (no refill happens), so the alternation gets stuck pointing at whichever buffer isn't in flight. \`anyInFlight()\` stays true forever and the test loop spins, incrementing \`++completedCount\` until UBSan trips on signed-int overflow at line 126. That's the "signed integer overflow: 2147483647 + 1" failure mode CI has been hitting.

## Fix

Drop the \`encodeIdx\`-based polling branch entirely and share the async drain logic — drain whichever buffer is actually in flight (A first, mirroring the ESP-IDF FIFO). The polling path's distinguishing behavior is already captured in \`startFirstDma()\`'s pre-queue decision (line 92); \`stepStreaming\` doesn't need to know the mode.

## Test plan

- [x] \`bash test --cpp\` — 227/227 pass (previously 226/227)
- [x] \`bash test spi_pingpong_pipeline_logic --debug\` — clean UBSan output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a critical bug in the SPI driver pipeline buffer management that could cause infinite loops or integer overflow errors during streaming operations. The fix enhances reliability and prevents potential system crashes by ensuring deterministic and correct buffer selection during high-throughput SPI data transfers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->