### PR TITLE
fix(net): convert NetworkDetector stub to C++11 nested namespace

### DIFF
--- a/src/fl/net/network_detector.h
+++ b/src/fl/net/network_detector.h
@@ -47,7 +47,8 @@
 
 #include "fl/stl/noexcept.h"
 
-namespace fl::net {
+namespace fl {
+namespace net {
 
 /// @brief Stub NetworkDetector for platforms without the real implementation.
 ///
@@ -75,14 +76,10 @@ class NetworkDetector {
     NetworkDetector &operator=(const NetworkDetector &) FL_NOEXCEPT = delete;
 };
 
-} // namespace fl::net
+} // namespace net
 
-// Back-compat: the existing channel wait sites and the real RMT5 impl both
-// expose the type as fl::NetworkDetector. Keep that name working in the
-// no-real-impl case via a using alias, so this PR is a pure lint fix with
-// no consumer churn.
-namespace fl {
 using NetworkDetector = ::fl::net::NetworkDetector;
+
 } // namespace fl
 
 #endif // !FL_NETWORK_DETECTOR_HAS_REAL_IMPL


### PR DESCRIPTION
## Summary

FastLED targets C++11. `src/fl/net/network_detector.h:50` used C++17 nested-namespace syntax (`namespace fl::net {`), which trips `-Werror=c++17-extensions` on strict host builds.

Expand to the C++11 form `namespace fl { namespace net { ... }}` and fold the trailing single-line using-alias block into the same outer `fl` namespace block — net: -3 LOC.

Flagged by the Stage 2a LPC port agent (#2837) as a pre-existing master failure.

## Test plan
- [x] `bash lint --cpp` clean
- [x] Pre-existing test failures (example-wasm DLL loading) unrelated to this change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code structure reorganization with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->