### PR TITLE
feat(autoresearch): Animartrix-representative Perlin noise bench (float vs s16x16)

### DIFF
--- a/examples/AutoResearch/AutoResearchAnimartrixBench.h
+++ b/examples/AutoResearch/AutoResearchAnimartrixBench.h
@@ -1,0 +1,126 @@
+// AutoResearchAnimartrixBench.h
+//
+// Animartrix-representative Perlin-noise benchmark: scalar float (`fl::pnoise`)
+// vs s16x16 fixed-point (`fl::perlin_i16_optimized::pnoise2d`).
+//
+// Why Perlin noise: it's the workhorse of every Animartrix effect — every
+// frame, every pixel goes through one or more `pnoise` calls to drive the
+// polar-coordinate field that shapes the pattern. If a fixed-point variant
+// wins here, it wins in Animartrix.
+//
+// Why s16x16 (and not s8x8): Animartrix's fade/lerp/grad inner loops need
+// the precision of Q16.16 to match the float reference. The s8x8 Q8.8
+// type loses too many bits in the multiplications inside the gradient
+// step. This benchmark mirrors what the FastLED tree already ships
+// (`fl/fx/2d/animartrix_detail/perlin_i16_optimized.cpp.hpp`).
+
+#pragma once
+
+#include <FastLED.h>
+#include "fl/fx/2d/animartrix_detail/perlin_float.h"
+#include "fl/fx/2d/animartrix_detail/perlin_i16_optimized.h"
+#include "fl/math/fixed_point/s16x16.h"
+
+namespace autoresearch {
+namespace animartrix_check {
+
+// Volatile sink to defeat dead-code elimination on both the float and
+// the i16 outputs. Same trick the SIMD multiply benchmark uses.
+static volatile int32_t g_animartrix_bench_sink;
+
+struct PerlinBenchResult {
+    int64_t iterations;
+    int64_t pnoise_float_us;   // fl::pnoise(x, y, 0) total wall time
+    int64_t pnoise_i16_us;     // fl::perlin_i16_optimized::pnoise2d total wall time
+    // The same coordinate grid is fed to both versions so the comparison
+    // measures purely the arithmetic cost of float vs i16 fixed-point.
+};
+
+// Sweep a 2D coordinate grid the same way an Animartrix render pass
+// would (one Perlin lookup per output pixel). 16*16 = 256 pixels per
+// outer iter, matching a 16x16 panel — small enough that the compiler
+// won't unroll the world, large enough that any per-iteration fixed
+// overhead is amortized.
+inline PerlinBenchResult runPerlinBenchmark(int iters) {
+    PerlinBenchResult r;
+    r.iterations = iters;
+
+    // Init the i16 implementation's fade lookup table once, off the
+    // benchmark clock. Function-local static so the linter's
+    // static-in-header rule stays happy and C++11's thread-safe init
+    // guarantees a single initialization across calls. The float path
+    // has no equivalent setup.
+    struct FadeLut {
+        int32_t table[257];
+        FadeLut() { fl::perlin_i16_optimized::init_fade_lut(table); }
+    };
+    static const FadeLut fade_lut_holder;  // C++11 magic statics
+    const int32_t* fade_lut = fade_lut_holder.table;
+
+    constexpr int GRID = 16;          // 16x16 pixel pass per iteration
+    constexpr float STEP_F = 0.05f;   // Animartrix-typical pixel step in noise space
+    // Mirror in fixed-point: 0.05 in Q16.16 = 0.05 * 65536 ≈ 3277
+    constexpr int32_t STEP_I = static_cast<int32_t>(0.05f * 65536.0f);
+
+    // ── Float pnoise ──────────────────────────────────────────────
+    {
+        float ax = 0.0f, ay = 0.0f;
+        int32_t sink = 0;
+        uint32_t t0 = micros();
+        for (int it = 0; it < iters; it++) {
+            // Slowly drift the origin across the iter so the compiler
+            // can't pre-compute. Same pattern Animartrix uses (the
+            // origin advances with `time_speed * dt` each frame).
+            ax += 0.011f;
+            ay += 0.013f;
+            for (int row = 0; row < GRID; row++) {
+                float y = ay + row * STEP_F;
+                for (int col = 0; col < GRID; col++) {
+                    float x = ax + col * STEP_F;
+                    float n = fl::pnoise(x, y, 0.0f);
+                    // Map [-1, 1] → int8 the way Animartrix's output
+                    // stage does. Sink to defeat DCE.
+                    sink += static_cast<int32_t>(n * 127.0f);
+                }
+            }
+        }
+        uint32_t t1 = micros();
+        g_animartrix_bench_sink = sink;
+        r.pnoise_float_us = static_cast<int64_t>(t1 - t0);
+    }
+
+    // ── i16 fixed-point pnoise2d ──────────────────────────────────
+    {
+        int32_t ax_i = 0, ay_i = 0;
+        // Q16.16 increment for the slow drift (matches 0.011, 0.013 in float)
+        constexpr int32_t DRIFT_X = static_cast<int32_t>(0.011f * 65536.0f);
+        constexpr int32_t DRIFT_Y = static_cast<int32_t>(0.013f * 65536.0f);
+        int32_t sink = 0;
+        uint32_t t0 = micros();
+        for (int it = 0; it < iters; it++) {
+            ax_i += DRIFT_X;
+            ay_i += DRIFT_Y;
+            for (int row = 0; row < GRID; row++) {
+                int32_t y_i = ay_i + row * STEP_I;
+                for (int col = 0; col < GRID; col++) {
+                    int32_t x_i = ax_i + col * STEP_I;
+                    // pnoise2d_raw returns i32 Q16.16. Scale to int8
+                    // the same way the float path does — divide by
+                    // (HP_ONE / 127) so the magnitudes line up.
+                    int32_t n = fl::perlin_i16_optimized::pnoise2d_raw(
+                        x_i, y_i, fade_lut, fl::PERLIN_NOISE);
+                    sink += n >> 9;   // crude scale; the actual op cost,
+                                       // not the value, is what we measure
+                }
+            }
+        }
+        uint32_t t1 = micros();
+        g_animartrix_bench_sink = sink;
+        r.pnoise_i16_us = static_cast<int64_t>(t1 - t0);
+    }
+
+    return r;
+}
+
+}  // namespace animartrix_check
+}  // namespace autoresearch

--- a/examples/AutoResearch/AutoResearchRemote.cpp
+++ b/examples/AutoResearch/AutoResearchRemote.cpp
@@ -30,6 +30,7 @@
 #include "fl/task/promise.h"
 #include "fl/math/simd.h"
 #include "AutoResearchSimd.h"
+#include "AutoResearchAnimartrixBench.h"  // animartrixPerlinBench RPC (#2628 follow-up)
 #include "AutoResearchWave8Expand.h"  // #2526 wave8ExpandBenchmark RPC
 #include "AutoResearchParlioEncode.h" // parlioEncodeBenchmark RPC (#2526 follow-up)
 #include "AutoResearchParlioStream.h" // parlioStreamValidate RPC (#2548 follow-up)
@@ -1960,6 +1961,14 @@ void AutoResearchRemoteControl::registerFunctions(fl::shared_ptr<AutoResearchSta
         testSimdBenchmark_fn.set("description", "Benchmark multiply speed: float vs s16x16 vs s16x16x4 SIMD");
         functions.push_back(testSimdBenchmark_fn);
 
+        fl::json animartrixPerlinBench_fn = fl::json::object();
+        animartrixPerlinBench_fn.set("name", "animartrixPerlinBench");
+        animartrixPerlinBench_fn.set("phase", "Phase 4: Utility");
+        animartrixPerlinBench_fn.set("args", "[{iterations}] (optional, default 100, max 10000)");
+        animartrixPerlinBench_fn.set("returns", "{success, iterations, pnoise_calls_per_iter, pnoise_float_us, pnoise_i16_us, speedup_x1000}");
+        animartrixPerlinBench_fn.set("description", "Animartrix-representative Perlin noise bench: scalar float pnoise vs s16x16 fixed-point pnoise2d (16x16 grid per iter, mirrors a real frame). Answers: how much does fixed-point beat float for Animartrix's hot path on this hardware?");
+        functions.push_back(animartrixPerlinBench_fn);
+
         fl::json wave8ExpandBenchmark_fn = fl::json::object();
         wave8ExpandBenchmark_fn.set("name", "wave8ExpandBenchmark");
         wave8ExpandBenchmark_fn.set("phase", "Phase 4: Utility");
@@ -2095,6 +2104,47 @@ void AutoResearchRemoteControl::registerFunctions(fl::shared_ptr<AutoResearchSta
         div.set("u16x16_us", result.div_u16x16_us);
         response.set("div", div);
 
+        return response;
+    });
+
+    // Register "animartrixPerlinBench" - Animartrix-representative Perlin
+    // noise bench: scalar float (fl::pnoise) vs s16x16 fixed-point
+    // (fl::perlin_i16_optimized::pnoise2d). Same workload that drives every
+    // Animartrix frame — one Perlin lookup per output pixel, 16x16 grid
+    // per iteration. Args: {iterations} (optional, default 100).
+    mRemote->bind("animartrixPerlinBench", [](const fl::json& args) -> fl::json {
+        fl::json response = fl::json::object();
+
+        int iters = 100;
+        fl::json config;
+        if (args.is_object()) {
+            config = args;
+        } else if (args.is_array() && args.size() >= 1 && args[0].is_object()) {
+            config = args[0];
+        }
+        if (!config.is_null() && config.contains("iterations") && config["iterations"].is_int()) {
+            iters = static_cast<int>(config["iterations"].as_int().value());
+            if (iters < 1) iters = 1;
+            if (iters > 10000) iters = 10000;
+        }
+
+        auto result = autoresearch::animartrix_check::runPerlinBenchmark(iters);
+
+        response.set("success", true);
+        response.set("iterations", result.iterations);
+        // Workload-per-iter is 16*16 = 256 pnoise calls. Surface this so
+        // the client can compute per-call timings without hardcoding.
+        response.set("pnoise_calls_per_iter", static_cast<int64_t>(256));
+        response.set("pnoise_float_us", result.pnoise_float_us);
+        response.set("pnoise_i16_us", result.pnoise_i16_us);
+        // Speedup expressed as float / i16 (>1 means i16 wins). Computed
+        // host-side too for cross-check; this is just convenience.
+        if (result.pnoise_i16_us > 0) {
+            double speedup = static_cast<double>(result.pnoise_float_us) /
+                             static_cast<double>(result.pnoise_i16_us);
+            // Encode as basis-points (1000ths) to avoid float in the json wire fmt
+            response.set("speedup_x1000", static_cast<int64_t>(speedup * 1000.0));
+        }
         return response;
     });
 


### PR DESCRIPTION
Adds `animartrixPerlinBench` RPC that drives the same Perlin noise workload Animartrix runs every frame, in two implementations:

- `fl::pnoise(x, y, 0.0f)` — the scalar float reference at `src/fl/fx/2d/animartrix_detail/perlin_float.h`
- `fl::perlin_i16_optimized::pnoise2d_raw(...)` — the s16x16 Q16.16 fixed-point variant at `src/fl/fx/2d/animartrix_detail/perlin_i16_optimized.cpp.hpp`

Both versions are exercised on the same 16×16 coordinate grid per iteration (256 pnoise calls/iter), with a slow per-iter drift in the noise space the way Animartrix's `time_speed` does. Result includes per-implementation total wall time, total call count, and a server-computed speedup ratio (encoded as basis-points to avoid float on the JSON wire format).

## Motivation

The existing `testSimdBenchmark` measures microbenchmarks of single ops (add, mul, div) on synthetic data. Per-element packed-SIMD wins there look dramatic (22× for s16x16 add on Cortex-M7 ARM-DSP per #2808) but **don't generalize to real Animartrix frame times** because most Animartrix work is not packed SIMD — it's scalar float `pnoise`. This bench measures the **actual Animartrix hot path**, so the speedup it reports is the realistic upper bound for any Animartrix-on-fixed-point port.

## Invocation

Via RPC client (`ci/rpc_client.py`):

```python
RpcClient.send("animartrixPerlinBench", {"iterations": 200})
```

Returns:

```json
{
  "success": true,
  "iterations": 200,
  "pnoise_calls_per_iter": 256,
  "pnoise_float_us": <int>,
  "pnoise_i16_us": <int>,
  "speedup_x1000": <int>
}
```

## Status

Code is complete and pushed. Hardware verification on Teensy 4.0 attempted in the originating session but the AutoResearch sketch's USB Serial setup on Teensy never emits its `[SETUP]` banner — appears to be a separate AutoResearch-on-Teensy infra issue (no CI workflow exercises AutoResearch on Teensy today). Bench is correct against the host build and the ESP32-S3 path; Teensy validation is a follow-up.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Perlin noise performance benchmark that compares floating-point and fixed-point implementations, returning execution timing and speedup metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->