### PR TITLE
feat(platform): LPC11xx (Cortex-M0) family detection scaffold (#2845)

### DIFF
--- a/src/platforms/arm/lpc/is_lpc.h
+++ b/src/platforms/arm/lpc/is_lpc.h
@@ -5,12 +5,17 @@
 // ok no namespace fl
 
 /// @file is_lpc.h
-/// @brief NXP LPC8xx platform detection macros for FastLED
+/// @brief NXP LPC platform detection macros for FastLED
 ///
-/// Detects NXP LPC845 and LPC804 (ARM Cortex-M0+) platforms. Detection uses
-/// the MCUXpresso / CMSIS device-header defines (e.g. CPU_LPC845M301JBD48,
-/// LPC845, LPC804) as well as bare project-level defines that fbuild/PIO
-/// configurations are expected to provide (__LPC845__, __LPC804__).
+/// Detects NXP LPC families:
+///   - LPC8xx (LPC845, LPC804) — ARM Cortex-M0+
+///   - LPC11xx (LPC1114, LPC1115, LPC11U24, LPC11U35) — ARM Cortex-M0
+///     (NOT M0+; the M0 ASM template applies instead of M0+)
+///
+/// Detection uses MCUXpresso / CMSIS device-header defines (e.g.
+/// CPU_LPC845M301JBD48, CPU_LPC1115FBD48) as well as bare project-level defines
+/// that fbuild / PlatformIO configurations are expected to provide
+/// (__LPC845__, __LPC804__, __LPC11xx__).
 
 // LPC845 (ARM Cortex-M0+, 30 MHz, 64KB Flash, 16KB SRAM)
 #if defined(__LPC845__) || defined(LPC845) || defined(LPC845M301) || \
@@ -26,7 +31,27 @@
 #define FL_LPC804
 #endif
 
-// General LPC8xx platform (any LPC8xx variant supported by this port)
-#if defined(FL_LPC845) || defined(FL_LPC804)
+// LPC11xx family (ARM Cortex-M0, up to 50 MHz, classic mbed-era hobbyist
+// parts: LPC1114, LPC1115, LPC11U24, LPC11U35). This is the family
+// detection portion of the FastLED/FastLED#2845 Stage 4 LPC11xx port
+// scaffold — driver wiring is a follow-up. The clockless path will reuse
+// the shared M0 ASM template (src/platforms/arm/common/m0clockless_asm.h,
+// also used by nRF51).
+//
+// IMPORTANT: LPC11xx is Cortex-M0, NOT M0+. Do not let it land in any
+// code path gated on FL_IS_ARM_M0_PLUS — that would mis-encode load/store
+// offsets on parts that lack the M0+ instruction extensions. The led
+// sysdefs follow-up will set FL_IS_ARM_M0 (not M0+) for this family.
+#if defined(__LPC11xx__) || defined(LPC11xx) || \
+    defined(CPU_LPC1114FBD48) || defined(CPU_LPC1114FHN33) || \
+    defined(CPU_LPC1115FBD48) || \
+    defined(CPU_LPC11U24FBD48) || defined(CPU_LPC11U24FHI33) || \
+    defined(CPU_LPC11U35FBD48) || defined(CPU_LPC11U35FHI33) || \
+    defined(CPU_LPC11U35FHN33)
+#define FL_LPC11
+#endif
+
+// General LPC family roll-up (any LPC variant supported by this port)
+#if defined(FL_LPC845) || defined(FL_LPC804) || defined(FL_LPC11)
 #define FL_IS_ARM_LPC
 #endif


### PR DESCRIPTION
## Summary

Stage 4 scaffold from [#2845](https://github.com/FastLED/FastLED/issues/2845). Adds NXP LPC11xx family detection to ``src/platforms/arm/lpc/is_lpc.h``:

- New ``FL_LPC11`` macro keyed on ``__LPC11xx__``, ``LPC11xx``, and CMSIS-style ``CPU_LPC1114*`` / ``CPU_LPC1115*`` / ``CPU_LPC11U24*`` / ``CPU_LPC11U35*`` identifiers.
- ``FL_IS_ARM_LPC`` roll-up extended to include ``FL_LPC11`` so the existing ``is_arm.h`` dispatch picks up LPC11xx as an ARM platform automatically.

## Critical architectural note (also in code comments)

**LPC11xx is Cortex-M0, NOT M0+.** The ``is_lpc.h`` header deliberately does NOT set ``FL_IS_ARM_M0_PLUS`` for ``FL_LPC11`` — the led_sysdefs follow-up will introduce ``FL_IS_ARM_M0`` instead. Mis-defining M0+ on an M0 part causes silent encoding errors in the shared inline-assembly clockless driver (load/store immediate-offset width differs between M0 and M0+).

## Follow-up work (deferred — touches a protected header)

- ``led_sysdefs_arm_lpc.h``: gate ``FL_IS_ARM_M0_PLUS`` on ``FL_LPC845`` / ``FL_LPC804`` only; introduce ``FL_IS_ARM_M0`` for ``FL_LPC11``; pick ``F_CPU = 48000000UL`` for LPC11xx (12 MHz xtal × 4 PLL); include ``LPC11xx.h`` via ``__has_include`` fallback chain.
- ``fastpin_arm_lpc.h`` / ``clockless_arm_lpc.h``: LPC11xx GPIO register layout differs from LPC8xx (uses MASKED_ACCESS instead of SET/CLR at +0x2200/+0x2280). Needs a separate ``clockless_arm_lpc11.h`` that wraps the shared M0 ASM template (``src/platforms/arm/common/m0clockless_asm.h``, also used by nRF51).
- fbuild board definitions for LPC11xx (separate fbuild PR).

This PR is intentionally header-detection-only: the family compiles to a stub on LPC11xx until the follow-up driver lands. Existing LPC8xx builds are unaffected (``FL_LPC845`` / ``FL_LPC804`` detection unchanged).

## Companion PR

[FastLED/fbuild#420](https://github.com/FastLED/fbuild/pull/420) ships the Stage 3 fbuild-side work for LPC8xx (real ``SystemInit`` + expanded vector tables + per-chip mcu_config split).

## Test plan

- [x] Header-only change — does not affect any currently-supported build
- [ ] Verify compile on a real LPC11xx target once the driver follow-up lands (hardware-gated)

Refs [#2845](https://github.com/FastLED/FastLED/issues/2845), [#2836](https://github.com/FastLED/FastLED/issues/2836)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detection support for LPC11xx ARM microcontrollers
* **Improvements**
  * Expanded LPC microcontroller family detection coverage to include additional device variants

<!-- end of auto-generated comment: release notes by coderabbit.ai -->