### PR TITLE
refactor(channels): extract Channel::showPixels disabled-driver error into FL_NO_INLINE helper (#2773 follow-up)

### DIFF
--- a/src/fl/channels/channel.cpp.hpp
+++ b/src/fl/channels/channel.cpp.hpp
@@ -114,6 +114,37 @@ class ReorderingPixelIteratorAny {
     const PixelIterator& get() const { return mPixelIterator.get(); }
 };
 
+/// @brief Out-of-line cold-path emitter for the #2517 silent-drop
+/// DISABLED-driver diagnostic in `Channel::showPixels`.
+///
+/// `showPixels` runs every frame, but this diagnostic is gated behind a
+/// one-shot latch (`mDisabledDriverWarned`) and only fires when a bound
+/// driver has been runtime-disabled (typically by
+/// `FastLED.setExclusiveDriver<OtherBus>()`). Inlining the two
+/// alternative FL_ERROR chains was costing ~10 `operator<<`
+/// instantiations in showPixels' prologue/epilogue for code that runs
+/// at most once per channel lifetime. Splitting matches the same
+/// pattern the maintainer adopted for `resolveDynamicDriver()` in PR
+/// #2830 — keep the diagnostic chain in a `FL_NO_INLINE` helper so it
+/// can't fold back into the hot path. (#2773 follow-up to #2832.)
+FL_NO_INLINE
+static void emitDisabledDriverError(const fl::string& channelName,
+                                    const fl::string& driverName,
+                                    const fl::string& exclusive) FL_NOEXCEPT {
+    if (!exclusive.empty()) {
+        FL_ERROR("Channel '" << channelName << "': bound driver '" << driverName
+            << "' is currently DISABLED by exclusive-driver selection '"
+            << exclusive << "'. Frame will be silently dropped. "
+            << "Resolve with: FastLED.enableDrivers<fl::Bus::"
+            << driverName << ">() or FastLED.enableAllDrivers().");
+    } else {
+        FL_ERROR("Channel '" << channelName << "': bound driver '" << driverName
+            << "' is currently DISABLED. Frame will be silently dropped. "
+            << "Resolve with: FastLED.enableDrivers<fl::Bus::"
+            << driverName << ">() or FastLED.enableAllDrivers().");
+    }
+}
+
 }  // anonymous namespace
 
 
@@ -547,20 +578,9 @@ void Channel::showPixels(PixelController<RGB, 1, 0xFFFFFFFF> &pixels) {
     auto status = ChannelManager::instance().driverStatus(driverName);
     if (status == ChannelManager::DriverStatus::STATUS_DISABLED) {
         if (!mDisabledDriverWarned) {
-            const fl::string& exclusive =
-                ChannelManager::instance().exclusiveDriverName();
-            if (!exclusive.empty()) {
-                FL_ERROR("Channel '" << mName << "': bound driver '" << driverName
-                    << "' is currently DISABLED by exclusive-driver selection '"
-                    << exclusive << "'. Frame will be silently dropped. "
-                    << "Resolve with: FastLED.enableDrivers<fl::Bus::"
-                    << driverName << ">() or FastLED.enableAllDrivers().");
-            } else {
-                FL_ERROR("Channel '" << mName << "': bound driver '" << driverName
-                    << "' is currently DISABLED. Frame will be silently dropped. "
-                    << "Resolve with: FastLED.enableDrivers<fl::Bus::"
-                    << driverName << ">() or FastLED.enableAllDrivers().");
-            }
+            emitDisabledDriverError(
+                mName, driverName,
+                ChannelManager::instance().exclusiveDriverName());
             mDisabledDriverWarned = true;
         }
         // Skip the enqueue — the data wouldn't be sent anyway, and dropping


### PR DESCRIPTION
## Summary

Rebased onto master to drop the now-duplicate piece. Original PR had two parts; the maintainer landed half of it in parallel as iter 6 (commit ea96b373b5, `perf(channels): gate addDriver capStr builder behind FASTLED_HAS_DBG`), so only the unique `emitDisabledDriverError` extraction remains.

## What's left

The two-branch `FL_ERROR(... << ...)` chain in `Channel::showPixels` that fires when a bound driver has been runtime-disabled (typically by `FastLED.setExclusiveDriver<OtherBus>()`) was still inlined into the hot path. The branch is one-shot (`mDisabledDriverWarned`) and unreachable in the steady state, so the ~10 `operator<<` instantiations were pure cold-path bloat sitting in `showPixels`' prologue/epilogue.

Moves into an anonymous-namespace helper marked `FL_NO_INLINE` (per the `bare_noinline_checker` introduced in #2830, not bare `__attribute__((noinline))`), matching the shape the maintainer adopted for `resolveDynamicDriver()` in PR #2830.

The closing comment on the original #2832 explicitly flagged this piece as worth a follow-up:

> *The two pieces this PR has that #2830 didn't (`emitDisabledDriverError` and the `#if FASTLED_HAS_DBG` gate on `ChannelManager::addDriver`'s capStr builder) are small enough (~couple hundred bytes) that a rebase round trip isn't worth the churn vs just reopening them in a follow-up.*

## Verification

- `ci/lint_cpp/run_all_checkers.py src/fl/channels/channel.cpp.hpp` clean.
- `ci/lint_cpp/bare_noinline_checker.py` clean — uses `FL_NO_INLINE` (the maintainer's #2830 macro), not bare `__attribute__((noinline))`.
- Same mechanical-extraction pattern already merged via #2826 and #2830.

Refs #2773.

🤖 Updated by Claude Code after rebase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal error handling logic for improved code maintainability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->