### PR TITLE
ci: post-#2773-loop infra sweep (Closes #2852, #2853, #2854, #2855)

### DIFF
--- a/ci/compiler/build_config.py
+++ b/ci/compiler/build_config.py
@@ -97,9 +97,16 @@ def _override_prog_path_for_fbuild(
     analysis reads the build we just produced — not whatever an older
     `pio run` left in `.pio/build/<env>/`.
 
+    fbuild emits to `.fbuild/build/<env>/<release|debug>/firmware.elf`,
+    where the subdir is picked by build mode (`fbuild build` defaults to
+    `release/`; `fbuild build --quick` lands in `debug/`). We probe both
+    candidates and pick whichever ELF is newer — that way `--quick`
+    builds get the same staleness override the default mode does.
+
     No-op when the fbuild directory is absent (pure PlatformIO build),
-    when the PIO ELF is newer (PIO was the active backend), or when the
-    metadata blob has no recognisable environment entry.
+    when the PIO ELF is newer than all fbuild candidates (PIO was the
+    active backend), or when the metadata blob has no recognisable
+    environment entry.
     """
     fbuild_root = build_dir / ".fbuild" / "build"
     if not fbuild_root.is_dir():
@@ -113,9 +120,20 @@ def _override_prog_path_for_fbuild(
         return
     env = data[env_name]
 
-    fbuild_elf = fbuild_root / env_name / "release" / "firmware.elf"
-    if not fbuild_elf.exists():
+    # fbuild lays out artifacts under <env>/<release|debug>/firmware.elf.
+    # `fbuild build`           -> release/
+    # `fbuild build --release` -> release/
+    # `fbuild build --quick`   -> debug/
+    # Pick whichever variant is newer so users running --quick still get
+    # a fresh staleness override (Closes #2852).
+    fbuild_elf_candidates = [
+        fbuild_root / env_name / "release" / "firmware.elf",
+        fbuild_root / env_name / "debug" / "firmware.elf",
+    ]
+    existing = [c for c in fbuild_elf_candidates if c.exists()]
+    if not existing:
         return
+    fbuild_elf = max(existing, key=lambda p: p.stat().st_mtime)
 
     current_prog_raw = env.get("prog_path")
     if isinstance(current_prog_raw, str) and current_prog_raw:

--- a/ci/lint_cpp/bare_noinline_checker.py
+++ b/ci/lint_cpp/bare_noinline_checker.py
@@ -11,13 +11,23 @@ toolchain (e.g. CI's WASM/Windows host tests) can quietly lose the
 exists to prevent (the hot/cold split collapses back into the inlined
 hot path).
 
-Suppression: add `// ok noinline` at end of line. Two source paths are
+Suppression: add `// ok noinline` at end of line. Five source paths are
 exempt as a matter of course:
 
 - `fl/stl/compiler_control.h` — where the `FL_NO_INLINE` macro is
   defined; the bare attribute appears inside the macro body itself.
+- `fl/stl/compiler_control.cpp.hpp` — sibling of the above.
 - `src/third_party/` — upstream code we don't control.
 - the lint checker itself.
+- `src/platforms/arm/nrf52/led_sysdefs_arm_nrf52.h` — uses
+  `__attribute__((used, noinline))` on a linker keep-alive function;
+  the `used` attribute has no FL_NO_INLINE equivalent. The file is
+  hard-gated to nrf52 ARM builds (never flows through MSVC), so the
+  MSVC-drift risk the lint guards against does not apply here.
+- `src/platforms/arm/teensy/coroutine_teensy.impl.hpp` — uses
+  `__attribute__((naked, noinline, used))` on the ARM context-switch
+  trampoline; `naked` is required for the inline-asm prologue and has
+  no portable FL_ equivalent. Same ARM-only gate as the nrf52 case.
 """
 
 import re
@@ -28,20 +38,31 @@ from ci.util.paths import PROJECT_ROOT
 
 SRC_ROOT = PROJECT_ROOT / "src"
 
-# Whitelisted files inside src/ that legitimately use the bare attribute
-# (the macro shim itself; it expands to the bare attribute).
+# Whitelisted files inside src/ that legitimately use the bare attribute.
+# See the module docstring for rationale on each entry.
 EXEMPT_FILES = (
     "fl/stl/compiler_control.h",
     "fl/stl/compiler_control.cpp.hpp",
+    "platforms/arm/nrf52/led_sysdefs_arm_nrf52.h",
+    "platforms/arm/teensy/coroutine_teensy.impl.hpp",
 )
 
-# Match `__attribute__((noinline))` or `__attribute__ ((noinline))` or
-# `__declspec(noinline)`. We allow internal whitespace around the inner
-# `noinline` keyword and around the outer parens but require the rest
-# of the syntax to be intact so we don't false-positive on unrelated
-# tokens.
+# Match `__attribute__((noinline))`, `__attribute__ ((noinline))`, and
+# *compound* attribute lists that include `noinline` as one element —
+# e.g. `__attribute__((naked, noinline, used))` or
+# `__attribute__((used, noinline))` (#2854). The MSVC-drift risk the
+# lint exists to prevent applies identically to the compound forms; the
+# only reason they don't bite today is that the call sites happen to be
+# on ARM platforms that never flow through MSVC. That's a fragile
+# invariant — better to require an explicit `// ok noinline`
+# suppression on those sites so the intent is greppable.
+#
+# Compound matching is implemented with a `noinline` keyword anchored
+# inside the outer `__attribute__((...))` parens; `[^)]*` keeps the
+# match local to a single attribute list so we don't accidentally span
+# multiple lines or sibling attribute groups.
 _BANNED_PATTERN = re.compile(
-    r"__attribute__\s*\(\s*\(\s*noinline\s*\)\s*\)"
+    r"__attribute__\s*\(\s*\([^)]*\bnoinline\b[^)]*\)\s*\)"
     r"|"
     r"__declspec\s*\(\s*noinline\s*\)"
 )

--- a/ci/tests/test_fbuild_compile_many.py
+++ b/ci/tests/test_fbuild_compile_many.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import os
+import sys
 from pathlib import Path
 
 import pytest
@@ -33,6 +35,7 @@ def test_run_fbuild_ci_uses_expected_command_and_parses_results(
 
     class FakeRunningProcess:
         last_cmd: list[str] | None = None
+        last_env: dict[str, str] | None = None
 
         def __init__(
             self,
@@ -40,11 +43,13 @@ def test_run_fbuild_ci_uses_expected_command_and_parses_results(
             timeout: int,
             auto_run: bool,
             capture: bool,
+            env: dict[str, str] | None = None,
         ) -> None:
             assert auto_run is False
             assert capture is True
             assert timeout == 1800
             FakeRunningProcess.last_cmd = cmd
+            FakeRunningProcess.last_env = env
             self.stdout = output
             self.returncode = 0
 
@@ -72,6 +77,13 @@ def test_run_fbuild_ci_uses_expected_command_and_parses_results(
     )
 
     assert result.success is True
+    # #2853: ensure the env passed to RunningProcess has the venv's
+    # Scripts dir prepended to PATH so fbuild's internal helper-tool
+    # lookups (zccache etc.) don't race a stale system-PATH copy.
+    assert FakeRunningProcess.last_env is not None
+    venv_scripts = str(Path(sys.executable).resolve().parent)
+    actual_path = FakeRunningProcess.last_env.get("PATH", "")
+    assert actual_path.split(os.pathsep, 1)[0].lower() == venv_scripts.lower()
     assert FakeRunningProcess.last_cmd == [
         "fbuild.exe",
         "ci",
@@ -104,11 +116,14 @@ def test_run_fbuild_ci_fails_when_output_is_partially_unparseable(
             timeout: int,
             auto_run: bool,
             capture: bool,
+            env: dict[str, str] | None = None,
         ) -> None:
             assert cmd[1] == "ci"
             assert timeout == 1800
             assert auto_run is False
             assert capture is True
+            # #2853: env should be present and have venv Scripts on PATH.
+            assert env is not None
             self.stdout = "\n".join(
                 [
                     "compile-many results:",

--- a/ci/tests/test_override_prog_path_for_fbuild.py
+++ b/ci/tests/test_override_prog_path_for_fbuild.py
@@ -1,0 +1,105 @@
+"""Unit tests for the fbuild prog_path staleness override (#2852)."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+from ci.boards import create_board
+from ci.compiler.build_config import _override_prog_path_for_fbuild
+
+
+def _touch(path: Path, mtime: float) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"\x7fELF")
+    os.utime(path, (mtime, mtime))
+    return path
+
+
+def _build_data(prog_path: str | None) -> dict[str, dict[str, Any]]:
+    inner: dict[str, Any] = {}
+    if prog_path is not None:
+        inner["prog_path"] = prog_path
+    return {"esp32dev": inner}
+
+
+def test_picks_release_when_only_release_exists(tmp_path: Path) -> None:
+    """`fbuild build` (default) writes release/ — must be picked up."""
+    release_elf = _touch(
+        tmp_path / ".fbuild" / "build" / "esp32dev" / "release" / "firmware.elf",
+        mtime=2000.0,
+    )
+    data = _build_data(
+        prog_path=str(tmp_path / ".pio" / "build" / "esp32dev" / "firmware.elf")
+    )
+    _override_prog_path_for_fbuild(tmp_path, data, create_board("esp32dev"))
+
+    assert data["esp32dev"]["prog_path"] == str(release_elf.resolve())
+
+
+def test_picks_debug_when_only_debug_exists(tmp_path: Path) -> None:
+    """`fbuild build --quick` writes debug/ — must be picked up (#2852)."""
+    debug_elf = _touch(
+        tmp_path / ".fbuild" / "build" / "esp32dev" / "debug" / "firmware.elf",
+        mtime=2000.0,
+    )
+    data = _build_data(
+        prog_path=str(tmp_path / ".pio" / "build" / "esp32dev" / "firmware.elf")
+    )
+    _override_prog_path_for_fbuild(tmp_path, data, create_board("esp32dev"))
+
+    assert data["esp32dev"]["prog_path"] == str(debug_elf.resolve())
+
+
+def test_picks_newer_when_both_exist(tmp_path: Path) -> None:
+    """When both release/ and debug/ exist, pick the newer one (#2852)."""
+    _touch(
+        tmp_path / ".fbuild" / "build" / "esp32dev" / "release" / "firmware.elf",
+        mtime=1000.0,
+    )
+    debug_elf = _touch(
+        tmp_path / ".fbuild" / "build" / "esp32dev" / "debug" / "firmware.elf",
+        mtime=2000.0,
+    )
+    data = _build_data(
+        prog_path=str(tmp_path / ".pio" / "build" / "esp32dev" / "firmware.elf")
+    )
+    _override_prog_path_for_fbuild(tmp_path, data, create_board("esp32dev"))
+
+    assert data["esp32dev"]["prog_path"] == str(debug_elf.resolve())
+
+
+def test_no_op_when_fbuild_root_missing(tmp_path: Path) -> None:
+    """Pure PlatformIO builds (no .fbuild/) must leave prog_path alone."""
+    original = str(tmp_path / ".pio" / "build" / "esp32dev" / "firmware.elf")
+    data = _build_data(prog_path=original)
+    _override_prog_path_for_fbuild(tmp_path, data, create_board("esp32dev"))
+
+    assert data["esp32dev"]["prog_path"] == original
+
+
+def test_no_op_when_pio_elf_is_newer(tmp_path: Path) -> None:
+    """If the user just ran `pio run` after an old fbuild, PIO wins."""
+    _touch(
+        tmp_path / ".fbuild" / "build" / "esp32dev" / "release" / "firmware.elf",
+        mtime=1000.0,
+    )
+    pio_elf = _touch(
+        tmp_path / ".pio" / "build" / "esp32dev" / "firmware.elf",
+        mtime=2000.0,
+    )
+    data = _build_data(prog_path=str(pio_elf))
+    _override_prog_path_for_fbuild(tmp_path, data, create_board("esp32dev"))
+
+    assert data["esp32dev"]["prog_path"] == str(pio_elf)
+
+
+def test_no_op_when_neither_fbuild_elf_exists(tmp_path: Path) -> None:
+    """An empty .fbuild/build/<env>/ tree must not override prog_path."""
+    (tmp_path / ".fbuild" / "build" / "esp32dev").mkdir(parents=True)
+    original = str(tmp_path / ".pio" / "build" / "esp32dev" / "firmware.elf")
+    data = _build_data(prog_path=original)
+    _override_prog_path_for_fbuild(tmp_path, data, create_board("esp32dev"))
+
+    assert data["esp32dev"]["prog_path"] == original

--- a/ci/util/fbuild_runner.py
+++ b/ci/util/fbuild_runner.py
@@ -97,6 +97,38 @@ def get_fbuild_executable() -> str | None:
     return shutil.which("fbuild")
 
 
+def fbuild_subprocess_env() -> dict[str, str]:
+    """Build an env dict with the venv's Scripts dir prepended to PATH.
+
+    Why this exists (#2853): fbuild internally shells out to helper tools
+    like ``zccache`` via plain PATH resolution. If the user has another
+    ``zccache.exe`` earlier on the system PATH (e.g.
+    ``C:\\tools\\python13\\Scripts\\zccache.exe`` from a globally
+    installed ``clang-tool-chain``), it can race with the venv-installed
+    one and produce cross-version daemon corruption — the symptom that
+    motivated #2853 (5 GB daemon balloons, locked named pipes, "daemon
+    started but not accepting connections after 10s").
+
+    Building the env here ensures any tool fbuild's Rust binary resolves
+    via PATH picks the venv copy first. This mirrors what
+    ``get_fbuild_executable()`` already does for ``fbuild`` itself —
+    extending the same hygiene to its dependencies.
+    """
+    env = os.environ.copy()
+    venv_scripts = Path(sys.executable).resolve().parent
+    if venv_scripts.is_dir():
+        path_sep = os.pathsep
+        existing_path = env.get("PATH", "")
+        # Only prepend if not already first — avoids unbounded growth on
+        # repeated invocations.
+        existing_head = existing_path.split(path_sep, 1)[0] if existing_path else ""
+        if existing_head.lower() != str(venv_scripts).lower():
+            env["PATH"] = str(venv_scripts) + (
+                path_sep + existing_path if existing_path else ""
+            )
+    return env
+
+
 def ensure_fbuild_daemon() -> None:
     """Ensure the fbuild daemon is running."""
     Daemon.ensure_running()
@@ -318,6 +350,7 @@ def run_fbuild_compile(
             timeout=int(timeout),
             auto_run=False,
             capture=True,
+            env=fbuild_subprocess_env(),
         )
         process.start()
         returncode = cast(
@@ -412,6 +445,7 @@ def _run_fbuild_batch_command(
             timeout=int(timeout),
             auto_run=False,
             capture=True,
+            env=fbuild_subprocess_env(),
         )
         process.start()
         returncode = cast(


### PR DESCRIPTION
## Summary

Three small infrastructure cleanups bundled as one PR per the meta sweep #2855. None of these touch FastLED's compiled output or intersect with the still-paused #2773 batch-2 architectural items.

## Closes #2852 — fbuild prog_path override misses `--quick` (debug/) builds

`_override_prog_path_for_fbuild` (landed in #2823 for the default release-mode case) silently no-ops when the user ran `fbuild build --quick` because fbuild lays the artifact down at `<env>/debug/firmware.elf`, not `release/`. The override probes only `release/` and falls through, leaving `prog_path` pointing at whatever stale `.pio/build/<env>/firmware.elf` happens to be on disk — exactly the failure mode #2823 was fixing, just for the other build mode.

**Fix:** probe both `release/` and `debug/`, pick whichever ELF is newer. Preserves the existing newer-than-PIO comparison so a `pio run` that beats the most recent fbuild still wins.

**Tests:** six new unit tests in `ci/tests/test_override_prog_path_for_fbuild.py` covering the matrix: release-only, debug-only, both-exist-newer-wins, no fbuild dir, PIO-newer-wins, empty fbuild tree.

## Closes #2853 — prefer venv-installed `zccache` (Windows daemon corruption)

fbuild's Rust binary internally shells out to `zccache` via plain PATH resolution. On Windows it's common to have **two** `zccache.exe` on PATH — one in the project venv and one global (e.g. from `clang-tool-chain`). When their versions diverge, the two daemons race for the shared named pipe (`\.\pipe\zccache-<user>`) and corrupt state. Symptoms observed this session: 5 GB daemon RAM, `all pipe instances busy after 50 retries`, `daemon started but not accepting connections after 10s` preventing recovery.

**Fix:** add `fbuild_subprocess_env()` to `ci/util/fbuild_runner.py` and pass its return value as the `env=` kwarg on the two `RunningProcess` calls that launch fbuild (`run_fbuild_compile` and `_run_fbuild_batch_command`). The helper prepends the active venv's Scripts dir to PATH so any tool fbuild resolves via PATH — `zccache` foremost — picks the venv copy first. Mirrors what `get_fbuild_executable()` already does for `fbuild` itself.

**Tests:** two existing `FakeRunningProcess` mocks gained an `env` kwarg; the first asserts that PATH begins with the venv Scripts dir so the contract can't silently regress.

## Closes #2854 — `bare_noinline_checker` regex misses compound attributes

`__attribute__((naked, noinline, used))` and similar compound forms silently passed the new lint because its regex required `noinline` to be the only attribute inside the parens. Same MSVC-drift risk applies to the compound forms — they only escape the lint because the two existing call sites are nrf52 / teensy ARM code that never flows through MSVC. Fragile invariant.

**Fix:** harden the regex to match `noinline` anywhere inside the `__attribute__(( ... ))` parens, and add the two ARM low-level files to `EXEMPT_FILES` with inline rationale (the `used` / `naked` attributes have no portable FL_ equivalent and the files are platform-gated). The `// ok noinline` suppression escape hatch remains the right answer for any future case.

## Closes #2855

Meta-issue tracking all three above.

## Verification

- `bash lint` — clean (only pre-existing PlatformIO-internal-usage warn-only #2701).
- `uv run ci/lint_cpp/bare_noinline_checker.py` — clean after the EXEMPT_FILES extension.
- `uv run pytest ci/tests/test_fbuild_compile_many.py ci/tests/test_root_platformio_flag_merge.py ci/tests/test_override_prog_path_for_fbuild.py ci/tests/test_check_backend_flag_drift.py` — 25 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Build system now intelligently handles both release and debug mode artifacts, selecting the newer version when both exist.
  * Improved subprocess environment configuration to ensure build tools resolve to the correct versions.

* **Tests**
  * Added comprehensive test coverage for build artifact selection behavior.
  * Enhanced CI environment propagation tests.

* **Refactor**
  * Updated code linting configuration for ARM platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->