### PR TITLE
feat(platform): LPC15xx (Cortex-M3) family detection scaffold (#2845 Stage 4 item 2)

### DIFF
--- a/src/platforms/arm/lpc/is_lpc.h
+++ b/src/platforms/arm/lpc/is_lpc.h
@@ -51,7 +51,37 @@
 #define FL_LPC11
 #endif
 
+// LPC15xx family (ARM Cortex-M3, up to 72 MHz, SCT/PLU on some variants:
+// LPC1517, LPC1518, LPC1519, LPC1547, LPC1548, LPC1549). This is the
+// family detection portion of the FastLED/FastLED#2845 Stage 4 LPC15xx
+// port scaffold — driver wiring is a follow-up.
+//
+// IMPORTANT: LPC15xx is Cortex-M3, NOT M0 / M0+. The M3 has a barrel
+// shifter and the full Thumb-2 instruction set, so the clockless driver
+// can target tighter cycle counts than the M0 / M0+ ASM template
+// permits. Do not gate this family on FL_IS_ARM_M0 or FL_IS_ARM_M0_PLUS
+// — the M0 template's load/store offset encoding restrictions do not
+// apply. The follow-up driver will key on FL_IS_ARM_LPC + an M3-class
+// path. The shared M3 clockless template (src/platforms/arm/common/
+// m3_clockless_asm.h if present, or a new file alongside it) is the
+// right entry point.
+#if defined(__LPC15xx__) || defined(LPC15xx) || \
+    defined(CPU_LPC1517JBD48) || defined(CPU_LPC1517JBD64) || \
+    defined(CPU_LPC1518JBD48) || defined(CPU_LPC1518JBD64) || \
+    defined(CPU_LPC1518JBD100) || \
+    defined(CPU_LPC1519JBD48) || defined(CPU_LPC1519JBD64) || \
+    defined(CPU_LPC1519JBD100) || \
+    defined(CPU_LPC1547JBD48) || defined(CPU_LPC1547JBD64) || \
+    defined(CPU_LPC1547JBD100) || \
+    defined(CPU_LPC1548JBD48) || defined(CPU_LPC1548JBD64) || \
+    defined(CPU_LPC1548JBD100) || \
+    defined(CPU_LPC1549JBD48) || defined(CPU_LPC1549JBD64) || \
+    defined(CPU_LPC1549JBD100)
+#define FL_LPC15
+#endif
+
 // General LPC family roll-up (any LPC variant supported by this port)
-#if defined(FL_LPC845) || defined(FL_LPC804) || defined(FL_LPC11)
+#if defined(FL_LPC845) || defined(FL_LPC804) || defined(FL_LPC11) || \
+    defined(FL_LPC15)
 #define FL_IS_ARM_LPC
 #endif


### PR DESCRIPTION
## Summary

Stage 4 item 2 from #2845. Mirrors the LPC11xx scaffold (#2849) for the LPC15xx (Cortex-M3) family. Pure header-detection scaffold — adds an `FL_LPC15` macro and rolls it into `FL_IS_ARM_LPC` so the existing `is_arm.h` dispatch picks LPC15xx up automatically. Driver wiring (`led_sysdefs_arm_lpc15.h`, `fastpin_arm_lpc15.h`, M3-class clockless) is a follow-up.

## Critical architectural note (also in the code comments)

LPC15xx is **Cortex-M3**, not M0 / M0+. The M3 has a barrel shifter and the full Thumb-2 instruction set, so this family must NOT be gated on `FL_IS_ARM_M0` or `FL_IS_ARM_M0_PLUS` — the M0 ASM template's load/store offset encoding restrictions do not apply, and the follow-up clockless driver should target an M3-class path (tighter cycle counts than M0+ permits).

## Detected variants

- LPC1517 / LPC1518 / LPC1519 (M3, USART/SPI/I2C)
- LPC1547 / LPC1548 / LPC1549 (M3, adds CAN + USB)

Common MCUXpresso / CMSIS CPU_* identifiers plus bare-project `__LPC15xx__` / `LPC15xx` defines.

## Files

| File | Change |
|---|---|
| `src/platforms/arm/lpc/is_lpc.h` | +31 lines: `FL_LPC15` block + roll-up extension |

## Test plan

- [x] `bash lint --cpp` passes (no new violations).
- [x] Header-only; existing LPC8xx / LPC11xx detection unchanged.
- [ ] CI confirms no regressions on existing platforms.

## Cross-references

- Refs #2845 (Stage 4 item 2)
- Pattern follows #2849 (LPC11xx scaffold)
- Refs #2836 (parent meta), #2831 (origin discussion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the LPC15xx (Cortex-M3) microcontroller family, enabling proper platform detection and initialization for this processor variant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->