### PR TITLE
perf(rmt5): no-op free()/freeDMA() under FASTLED_RMT_STATIC_ALLOCATION (#2856 item 3.6)

### DIFF
--- a/src/platforms/esp/32/drivers/rmt/rmt_5/rmt_memory_manager.cpp.hpp
+++ b/src/platforms/esp/32/drivers/rmt/rmt_5/rmt_memory_manager.cpp.hpp
@@ -531,6 +531,16 @@ result<size_t, RmtMemoryError> RmtMemoryManager::allocateRx(u8 channel_id, size_
 }
 
 void RmtMemoryManager::free(u8 channel_id, bool is_tx) FL_NOEXCEPT {
+#if FASTLED_RMT_STATIC_ALLOCATION
+    // Static-allocation mode: the user has asserted no removeLeds() / late
+    // addLeds(). The destructor still calls free() at process end but the
+    // ledger isn't meaningfully tracked, so erasing from the allocations
+    // vector + emitting the FL_LOG_RMT diagnostic is dead work. Skipping it
+    // lets the linker drop fl::vector_inlined::erase + the diagnostic
+    // operator<< chain. See #2856 item 3.6.
+    (void)channel_id;
+    (void)is_tx;
+#else
     ChannelAllocation* alloc = findAllocation(channel_id, is_tx);
     if (!alloc) {
         FL_WARN("RMT " << (is_tx ? "TX" : "RX") << " channel "
@@ -552,6 +562,7 @@ void RmtMemoryManager::free(u8 channel_id, bool is_tx) FL_NOEXCEPT {
             break;
         }
     }
+#endif
 }
 
 void RmtMemoryManager::recordRecoveryAllocation(u8 channel_id, size_t words, bool is_tx) FL_NOEXCEPT {
@@ -741,7 +752,14 @@ bool RmtMemoryManager::allocateDMA(u8 channel_id, bool is_tx) FL_NOEXCEPT {
 }
 
 void RmtMemoryManager::freeDMA(u8 channel_id, bool is_tx) FL_NOEXCEPT {
-#if FASTLED_RMT5_DMA_SUPPORTED
+#if FASTLED_RMT_STATIC_ALLOCATION
+    // Static-allocation mode: see RmtMemoryManager::free() for rationale.
+    // The destructor still reaches this; skipping the mismatch-diagnostic
+    // FL_WARN sites lets the linker drop the operator<< chains. See #2856
+    // item 3.6.
+    (void)channel_id;
+    (void)is_tx;
+#elif FASTLED_RMT5_DMA_SUPPORTED
     if (!mDMAAllocation.allocated) {
         FL_WARN("DMA free called but no DMA allocated");
         return;


### PR DESCRIPTION
## Summary

First PR against meta [#2856](https://github.com/FastLED/FastLED/issues/2856). Implements item 3.6 in its smallest viable form.

Under \`FASTLED_RMT_STATIC_ALLOCATION=1\` (#2846) the user has asserted no \`removeLeds()\` / late \`addLeds()\`. The destructor of \`ChannelEngineRMTImpl\` still calls \`memMgr.free()\` / \`memMgr.freeDMA()\` on every channel at process end, but the ledger isn't meaningfully tracked under static mode so the work is dead — yet it still pulls \`fl::vector_inlined::erase\`, the \`begin\`/\`end\` iterator chain, and the multi-line \`FL_LOG_RMT\` / \`FL_WARN\` \`operator<<\` instantiations into the binary.

Skip both bodies under the macro:

\`\`\`cpp
void RmtMemoryManager::free(u8 channel_id, bool is_tx) FL_NOEXCEPT {
#if FASTLED_RMT_STATIC_ALLOCATION
    (void)channel_id; (void)is_tx;
#else
    // ... existing ledger update + erase loop + FL_LOG_RMT ...
#endif
}
\`\`\`

Default behavior (\`FASTLED_RMT_STATIC_ALLOCATION=0\`) is unchanged.

## Scope vs the rest of meta #2856

This PR ships item **3.6 only**. Items 3.1, 3.2, 3.3, 3.5 are scoped for their own PRs (multi-day / large-blast-radius). Item 3.4 (encoder dedup) was already done in the existing RMT5 architecture before #2856 was filed — the encoder is a runtime virtual on \`IRMT5Peripheral::createEncoder(const ChipsetTiming&, u32)\`, not templated per-chipset. Updating the tracking matrix on #2856 to reflect this.

## Test plan

- [x] \`bash lint --cpp\` — clean
- [x] \`bash test --cpp\` — 310/310 pass (the SPI ping-pong test fixed by #2843 stays green)
- [ ] CI on this PR
- [ ] Map-file audit (via CI artifacts per the methodology in #2856) on a \`FASTLED_RMT_STATIC_ALLOCATION=1\` Blink build to measure the saved bytes

Refs #2856 item 3.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized memory management operations for ESP32 devices when static memory allocation is enabled, reducing runtime overhead and improving system efficiency on embedded platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->