### PR TITLE
perf(rmt5): tryAllocateTx/tryAllocateRx status-code variants (#2856 item 3.5)

### DIFF
--- a/src/platforms/esp/32/drivers/rmt/rmt_5/channel_driver_rmt.cpp.hpp
+++ b/src/platforms/esp/32/drivers/rmt/rmt_5/channel_driver_rmt.cpp.hpp
@@ -599,10 +599,11 @@ class ChannelEngineRMTImpl : public ChannelEngineRMT {
 
         // STEP 1: Try DMA channel creation (first channel only on ESP32-S3)
         if (tryDMA && dataSize > 0) {
-            // Allocate memory from memory manager (DMA bypasses on-chip memory)
-            auto alloc_result = memMgr.allocateTx(
-                state->memoryChannelId, true, networkActive); // true = use DMA
-            if (!alloc_result.ok()) {
+            // Allocate memory from memory manager (DMA bypasses on-chip memory).
+            // Status-code variant avoids result<> ABI at call site (#2856 item 3.5).
+            size_t dma_alloc_words = 0;
+            if (!memMgr.tryAllocateTx(state->memoryChannelId, true,
+                                       networkActive, dma_alloc_words)) {
                 FL_WARN("Memory manager TX allocation failed for DMA channel "
                         << static_cast<int>(state->memoryChannelId));
                 return false;
@@ -687,10 +688,11 @@ class ChannelEngineRMTImpl : public ChannelEngineRMT {
         }
 
         // STEP 2: Create non-DMA channel (either DMA not attempted, failed, or
-        // disabled) Allocate memory from memory manager (double-buffer policy)
-        auto alloc_result = memMgr.allocateTx(state->memoryChannelId, false,
-                                              networkActive); // false = non-DMA
-        if (!alloc_result.ok()) {
+        // disabled) Allocate memory from memory manager (double-buffer policy).
+        // Status-code variant avoids result<> ABI at call site (#2856 item 3.5).
+        fl::size mem_block_symbols = 0;
+        if (!memMgr.tryAllocateTx(state->memoryChannelId, false,
+                                   networkActive, mem_block_symbols)) {
             // Memory allocation failed - this can happen when:
             // 1. External RMT users (USB CDC, etc.) consume memory
             // 2. Too many non-DMA channels requested
@@ -706,8 +708,6 @@ class ChannelEngineRMTImpl : public ChannelEngineRMT {
             FL_WARN("  DMA channels in use: " << memMgr.getDMAChannelsInUse() << "/1");
             return false;
         }
-
-        fl::size mem_block_symbols = alloc_result.value();
 
         // Apply previously discovered memory reduction offset (from self-healing)
         // This prevents re-running the progressive retry on every allocation

--- a/src/platforms/esp/32/drivers/rmt/rmt_5/rmt_memory_manager.cpp.hpp
+++ b/src/platforms/esp/32/drivers/rmt/rmt_5/rmt_memory_manager.cpp.hpp
@@ -530,6 +530,26 @@ result<size_t, RmtMemoryError> RmtMemoryManager::allocateRx(u8 channel_id, size_
     return result<size_t, RmtMemoryError>::success(words_needed);
 }
 
+bool RmtMemoryManager::tryAllocateTx(u8 channel_id, bool use_dma, bool networkActive,
+                                      size_t& out_words) FL_NOEXCEPT {
+    auto r = allocateTx(channel_id, use_dma, networkActive);
+    if (r.ok()) {
+        out_words = r.value();
+        return true;
+    }
+    return false;
+}
+
+bool RmtMemoryManager::tryAllocateRx(u8 channel_id, size_t symbols, bool use_dma,
+                                      size_t& out_words) FL_NOEXCEPT {
+    auto r = allocateRx(channel_id, symbols, use_dma);
+    if (r.ok()) {
+        out_words = r.value();
+        return true;
+    }
+    return false;
+}
+
 void RmtMemoryManager::free(u8 channel_id, bool is_tx) FL_NOEXCEPT {
     ChannelAllocation* alloc = findAllocation(channel_id, is_tx);
     if (!alloc) {

--- a/src/platforms/esp/32/drivers/rmt/rmt_5/rmt_memory_manager.h
+++ b/src/platforms/esp/32/drivers/rmt/rmt_5/rmt_memory_manager.h
@@ -171,6 +171,21 @@ public:
     /// the DRAM buffer size, NOT on-chip RMT memory.
     result<size_t, RmtMemoryError> allocateRx(u8 channel_id, size_t symbols, bool use_dma = false) FL_NOEXCEPT;
 
+    /// @brief Status-code variant of allocateTx (no error discriminator).
+    /// @return true on success, writing the allocated word count to out_words.
+    ///
+    /// Saves the result<>-ABI overhead at call sites that treat all
+    /// allocation failures the same — i.e. log + return false. The full
+    /// error-bearing API (allocateTx) is retained for callers that need
+    /// to distinguish CHANNEL_ALREADY_ALLOCATED vs INSUFFICIENT_TX_MEMORY.
+    /// See #2856 item 3.5.
+    bool tryAllocateTx(u8 channel_id, bool use_dma, bool networkActive,
+                       size_t& out_words) FL_NOEXCEPT;
+
+    /// @brief Status-code variant of allocateRx. See tryAllocateTx for rationale.
+    bool tryAllocateRx(u8 channel_id, size_t symbols, bool use_dma,
+                       size_t& out_words) FL_NOEXCEPT;
+
     /// @brief Free allocated memory for a channel
     /// @param channel_id RMT channel ID
     /// @param is_tx true for TX channel, false for RX channel

--- a/src/platforms/esp/32/drivers/rmt_rx/rmt_rx_channel.cpp.hpp
+++ b/src/platforms/esp/32/drivers/rmt_rx/rmt_rx_channel.cpp.hpp
@@ -572,8 +572,9 @@ class RmtRxChannelImpl : public RmtRxChannel {
         auto &memMgr = RmtMemoryManager::instance();
         mMemoryChannelId = static_cast<u8>(128 + (mPin & 0x7F));
         constexpr u32 kMinRxSymbols = 64;  // Minimum RX buffer size
-        auto alloc_result = memMgr.allocateRx(mMemoryChannelId, kMinRxSymbols, false);
-        if (alloc_result.ok()) {
+        // Status-code variant (#2856 item 3.5) — call site only needs success/fail.
+        size_t alloc_words = 0;
+        if (memMgr.tryAllocateRx(mMemoryChannelId, kMinRxSymbols, false, alloc_words)) {
             mMemoryRegistered = true;
             FL_LOG_RX("RMT RX pre-registered with memory manager in constructor (channel_id="
                       << static_cast<int>(mMemoryChannelId) << ")");
@@ -781,9 +782,10 @@ class RmtRxChannelImpl : public RmtRxChannel {
             // bypasses the on-chip RX pool (DMA uses DRAM). Without this,
             // larger mem_block_symbols values (e.g., 1024 for DMA) would
             // exceed ESP32-S3's 192-word dedicated RX pool and fail.
-            auto alloc_result = memMgr.allocateRx(
-                mMemoryChannelId, rx_config.mem_block_symbols, mUseDma);
-            if (!alloc_result.ok()) {
+            // Status-code variant (#2856 item 3.5).
+            size_t rx_alloc_words = 0;
+            if (!memMgr.tryAllocateRx(mMemoryChannelId, rx_config.mem_block_symbols,
+                                       mUseDma, rx_alloc_words)) {
                 FL_WARN("RMT RX memory allocation failed for channel "
                         << static_cast<int>(mMemoryChannelId));
                 return false;

--- a/src/platforms/shared/mock/esp/32/drivers/rmt5_support_stubs.h
+++ b/src/platforms/shared/mock/esp/32/drivers/rmt5_support_stubs.h
@@ -96,6 +96,14 @@ public:
     static fl::size calculateMemoryBlocks(bool) FL_NOEXCEPT { return 2; }
 
     AllocationResult allocateTx(u8, bool, bool) FL_NOEXCEPT { return AllocationResult{}; }
+    bool tryAllocateTx(u8, bool, bool, fl::size& out_words) FL_NOEXCEPT {
+        out_words = 64;
+        return true;
+    }
+    bool tryAllocateRx(u8, fl::size, bool, fl::size& out_words) FL_NOEXCEPT {
+        out_words = 64;
+        return true;
+    }
     void free(u8, bool) FL_NOEXCEPT {}  // ok bare allocation
     void recordRecoveryAllocation(u8, fl::size, bool) FL_NOEXCEPT {}
     bool isDMAAvailable() FL_NOEXCEPT { return false; }


### PR DESCRIPTION
## Summary

Second PR against meta [#2856](https://github.com/FastLED/FastLED/issues/2856). Implements item 3.5.

The existing \`allocateTx\` / \`allocateRx\` return \`result<size_t, RmtMemoryError>\` — a sum type with discriminator + payload. At the **4 internal callers** inside the RMT5 driver chain (\`ChannelEngineRMT::createChannel\` × 2, \`RmtRxChannelImpl::ctor\` + \`begin\`) the specific error code is never read; callers just log + return false on any failure.

Add \`tryAllocateTx\` / \`tryAllocateRx\` wrappers returning \`bool\` + \`size_t&\` out parameter. The \`result<>\`-bearing API is retained for callers that need error fidelity (tests, future callers, the public surface).

Migrated the 4 internal sites to the new API. Mock \`RmtMemoryManager\` (\`rmt5_support_stubs.h\`) gets matching always-succeeds stubs so the host test build links.

## Stack vs the rest of meta #2856

This is the second PR (after #2861, item 3.6). Status of the remaining items:
- **3.1** Level B template-trait refactor of \`Channel::showPixels\` — deferred to dedicated multi-day PR; design RFC already at #2773 comment 4636464324.
- **3.2** Printf-style log backend — deferred to dedicated multi-day PR; requires new \`fl::printf\` API surface + bulk migration of FL_WARN sites.
- **3.3** Static-bind path for boot-time \`addLeds<>()\` — deferred to dedicated multi-day PR; needs full audit of every \`addLeds<>\` instantiation in every example.
- **3.4** RMT5 encoder dedup — **already done** in master before #2856 was filed (the encoder is a runtime virtual on \`IRMT5Peripheral\`, not templated per-chipset). Updating the tracking matrix on #2856 to reflect this.
- **3.6** Fixed-size ledger under \`FASTLED_RMT_STATIC_ALLOCATION\` — shipped in #2861.

The clud-pr skill's \"one PR per task\" rule conflicts with #2856 being a meta covering 6 architecturally-separate items. The split chosen here: ship the bounded items (3.5, 3.6) immediately as their own PRs, defer the multi-day items (3.1, 3.2, 3.3) for explicit follow-up rather than landing speculative scaffolding.

## Test plan

- [x] \`bash lint --cpp\` — clean
- [x] \`bash test --cpp\` — 310/310 pass
- [ ] CI on this PR
- [ ] Map-file audit (via CI artifacts per #2856 methodology) on a default Blink build to confirm the result<> footprint at the 4 callsites shrinks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal memory allocation handling for ESP32 RMT drivers to improve code consistency and reliability across transmit and receive channels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->