### PR TITLE
perf: combined #2856 items 3.1 + 3.2 + 3.3 + 3.5 (single PR per /clud-pr workflow)

### DIFF
--- a/src/fl/log/log.h
+++ b/src/fl/log/log.h
@@ -175,6 +175,17 @@ const char *fastled_file_offset(const char *file) FL_NOEXCEPT;
 #define FL_WARN_FMT(X) FL_WARN(X)
 #define FL_WARN_FMT_IF(COND, MSG) FL_WARN_IF(COND, MSG)
 
+// FL_WARN_LIT: Minimal-overhead variant for literal-only messages. Bypasses
+// the fl::sstream + operator<< chain that FL_WARN inlines at every call
+// site, and drops the `__FILE__(__LINE__): WARN:` prefix (the literal
+// itself should identify the origin, e.g. "[RMT] ..."). Use at well-known
+// WARN sites where the message is a fixed string and the byte budget
+// matters. See FastLED #2856 item 3.2. The non-literal FL_WARN remains
+// available for sites that need operator<< formatting or the file/line
+// prefix.
+#define FL_WARN_LIT(LITERAL) fl::println(LITERAL)
+#define FL_LOG_LIT(LITERAL) fl::println(LITERAL)
+
 // FL_WARN_EVERY: Rate-limited warning that prints at most once per interval
 // Uses static timestamp to track last print time - throttles output in tight loops
 #define FL_WARN_EVERY(MILLIS, X) do { \
@@ -193,6 +204,8 @@ const char *fastled_file_offset(const char *file) FL_NOEXCEPT;
 #define FL_WARN_FMT(X) do { } while(0)
 #define FL_WARN_FMT_IF(COND, MSG) do { } while(0)
 #define FL_WARN_EVERY(MILLIS, X) do { } while(0)
+#define FL_WARN_LIT(LITERAL) do { } while(0)
+#define FL_LOG_LIT(LITERAL) do { } while(0)
 #endif
 #endif
 

--- a/src/platforms/esp/32/drivers/rmt/rmt_5/channel_driver_rmt.cpp.hpp
+++ b/src/platforms/esp/32/drivers/rmt/rmt_5/channel_driver_rmt.cpp.hpp
@@ -140,6 +140,15 @@ class ChannelEngineRMTImpl : public ChannelEngineRMT {
     }
 
     ~ChannelEngineRMTImpl() override {
+        // The destructor body (drain-wait + per-channel cleanup loop +
+        // FL_WARN timeout diagnostic + FL_LOG_RMT trailer) is a cold path —
+        // only reached at process end. Move it into an FL_NO_INLINE helper
+        // so its operator<< instantiations + cleanup loop body don't
+        // contribute to icache footprint. #2856 item 3.1.
+        destructorCleanup();
+    }
+
+    FL_NO_INLINE void destructorCleanup() FL_NOEXCEPT {
         // Wait for all active transmissions to complete (with timeout)
         // Must wait for READY (not just !BUSY) since poll() can return DRAINING
         int timeout_iterations = 100000; // 10 seconds at 100us per iteration
@@ -150,7 +159,7 @@ class ChannelEngineRMTImpl : public ChannelEngineRMT {
             state = poll();
         }
         if (timeout_iterations == 0) {
-            FL_WARN("ChannelEngineRMT destructor timeout - forcing cleanup");
+            FL_WARN_LIT("[RMT] ChannelEngineRMT destructor timeout - forcing cleanup");
         }
 
         // Get memory manager reference
@@ -552,8 +561,17 @@ class ChannelEngineRMTImpl : public ChannelEngineRMT {
         // Get memory manager reference
         auto &memMgr = RmtMemoryManager::instance();
 
-        // Get current Network state for memory allocation
+        // Get current Network state for memory allocation.
+        // Under FASTLED_RMT_STATIC_ALLOCATION the user has asserted no
+        // network during LED transmission, so this resolves to a compile-
+        // time constant — the linker then drops the entire NetworkDetector
+        // singleton + WiFi-state-reading chain from the binary. See #2856
+        // item 3.3.
+#if FASTLED_RMT_STATIC_ALLOCATION
+        constexpr bool networkActive = false;
+#else
         bool networkActive = NetworkDetector::isAnyNetworkActive();
+#endif
 
         // ============================================================================
         // DMA ALLOCATION POLICY - ESP32-S3 TX/RX Conflict Avoidance

--- a/src/platforms/esp/32/drivers/rmt/rmt_5/channel_driver_rmt.cpp.hpp
+++ b/src/platforms/esp/32/drivers/rmt/rmt_5/channel_driver_rmt.cpp.hpp
@@ -599,10 +599,11 @@ class ChannelEngineRMTImpl : public ChannelEngineRMT {
 
         // STEP 1: Try DMA channel creation (first channel only on ESP32-S3)
         if (tryDMA && dataSize > 0) {
-            // Allocate memory from memory manager (DMA bypasses on-chip memory)
-            auto alloc_result = memMgr.allocateTx(
-                state->memoryChannelId, true, networkActive); // true = use DMA
-            if (!alloc_result.ok()) {
+            // Allocate memory from memory manager (DMA bypasses on-chip memory).
+            // Status-code variant avoids result<> ABI at call site (#2856 item 3.5).
+            size_t dma_alloc_words = 0;
+            if (!memMgr.tryAllocateTx(state->memoryChannelId, true,
+                                       networkActive, dma_alloc_words)) {
                 FL_WARN("Memory manager TX allocation failed for DMA channel "
                         << static_cast<int>(state->memoryChannelId));
                 return false;
@@ -687,10 +688,11 @@ class ChannelEngineRMTImpl : public ChannelEngineRMT {
         }
 
         // STEP 2: Create non-DMA channel (either DMA not attempted, failed, or
-        // disabled) Allocate memory from memory manager (double-buffer policy)
-        auto alloc_result = memMgr.allocateTx(state->memoryChannelId, false,
-                                              networkActive); // false = non-DMA
-        if (!alloc_result.ok()) {
+        // disabled) Allocate memory from memory manager (double-buffer policy).
+        // Status-code variant avoids result<> ABI at call site (#2856 item 3.5).
+        fl::size mem_block_symbols = 0;
+        if (!memMgr.tryAllocateTx(state->memoryChannelId, false,
+                                   networkActive, mem_block_symbols)) {
             // Memory allocation failed - this can happen when:
             // 1. External RMT users (USB CDC, etc.) consume memory
             // 2. Too many non-DMA channels requested
@@ -706,8 +708,6 @@ class ChannelEngineRMTImpl : public ChannelEngineRMT {
             FL_WARN("  DMA channels in use: " << memMgr.getDMAChannelsInUse() << "/1");
             return false;
         }
-
-        fl::size mem_block_symbols = alloc_result.value();
 
         // Apply previously discovered memory reduction offset (from self-healing)
         // This prevents re-running the progressive retry on every allocation

--- a/src/platforms/esp/32/drivers/rmt/rmt_5/rmt_memory_manager.cpp.hpp
+++ b/src/platforms/esp/32/drivers/rmt/rmt_5/rmt_memory_manager.cpp.hpp
@@ -530,6 +530,26 @@ result<size_t, RmtMemoryError> RmtMemoryManager::allocateRx(u8 channel_id, size_
     return result<size_t, RmtMemoryError>::success(words_needed);
 }
 
+bool RmtMemoryManager::tryAllocateTx(u8 channel_id, bool use_dma, bool networkActive,
+                                      size_t& out_words) FL_NOEXCEPT {
+    auto r = allocateTx(channel_id, use_dma, networkActive);
+    if (r.ok()) {
+        out_words = r.value();
+        return true;
+    }
+    return false;
+}
+
+bool RmtMemoryManager::tryAllocateRx(u8 channel_id, size_t symbols, bool use_dma,
+                                      size_t& out_words) FL_NOEXCEPT {
+    auto r = allocateRx(channel_id, symbols, use_dma);
+    if (r.ok()) {
+        out_words = r.value();
+        return true;
+    }
+    return false;
+}
+
 void RmtMemoryManager::free(u8 channel_id, bool is_tx) FL_NOEXCEPT {
 #if FASTLED_RMT_STATIC_ALLOCATION
     // Static-allocation mode: the user has asserted no removeLeds() / late

--- a/src/platforms/esp/32/drivers/rmt/rmt_5/rmt_memory_manager.h
+++ b/src/platforms/esp/32/drivers/rmt/rmt_5/rmt_memory_manager.h
@@ -171,6 +171,21 @@ public:
     /// the DRAM buffer size, NOT on-chip RMT memory.
     result<size_t, RmtMemoryError> allocateRx(u8 channel_id, size_t symbols, bool use_dma = false) FL_NOEXCEPT;
 
+    /// @brief Status-code variant of allocateTx (no error discriminator).
+    /// @return true on success, writing the allocated word count to out_words.
+    ///
+    /// Saves the result<>-ABI overhead at call sites that treat all
+    /// allocation failures the same — i.e. log + return false. The full
+    /// error-bearing API (allocateTx) is retained for callers that need
+    /// to distinguish CHANNEL_ALREADY_ALLOCATED vs INSUFFICIENT_TX_MEMORY.
+    /// See #2856 item 3.5.
+    bool tryAllocateTx(u8 channel_id, bool use_dma, bool networkActive,
+                       size_t& out_words) FL_NOEXCEPT;
+
+    /// @brief Status-code variant of allocateRx. See tryAllocateTx for rationale.
+    bool tryAllocateRx(u8 channel_id, size_t symbols, bool use_dma,
+                       size_t& out_words) FL_NOEXCEPT;
+
     /// @brief Free allocated memory for a channel
     /// @param channel_id RMT channel ID
     /// @param is_tx true for TX channel, false for RX channel

--- a/src/platforms/esp/32/drivers/rmt_rx/rmt_rx_channel.cpp.hpp
+++ b/src/platforms/esp/32/drivers/rmt_rx/rmt_rx_channel.cpp.hpp
@@ -572,8 +572,9 @@ class RmtRxChannelImpl : public RmtRxChannel {
         auto &memMgr = RmtMemoryManager::instance();
         mMemoryChannelId = static_cast<u8>(128 + (mPin & 0x7F));
         constexpr u32 kMinRxSymbols = 64;  // Minimum RX buffer size
-        auto alloc_result = memMgr.allocateRx(mMemoryChannelId, kMinRxSymbols, false);
-        if (alloc_result.ok()) {
+        // Status-code variant (#2856 item 3.5) — call site only needs success/fail.
+        size_t alloc_words = 0;
+        if (memMgr.tryAllocateRx(mMemoryChannelId, kMinRxSymbols, false, alloc_words)) {
             mMemoryRegistered = true;
             FL_LOG_RX("RMT RX pre-registered with memory manager in constructor (channel_id="
                       << static_cast<int>(mMemoryChannelId) << ")");
@@ -781,9 +782,10 @@ class RmtRxChannelImpl : public RmtRxChannel {
             // bypasses the on-chip RX pool (DMA uses DRAM). Without this,
             // larger mem_block_symbols values (e.g., 1024 for DMA) would
             // exceed ESP32-S3's 192-word dedicated RX pool and fail.
-            auto alloc_result = memMgr.allocateRx(
-                mMemoryChannelId, rx_config.mem_block_symbols, mUseDma);
-            if (!alloc_result.ok()) {
+            // Status-code variant (#2856 item 3.5).
+            size_t rx_alloc_words = 0;
+            if (!memMgr.tryAllocateRx(mMemoryChannelId, rx_config.mem_block_symbols,
+                                       mUseDma, rx_alloc_words)) {
                 FL_WARN("RMT RX memory allocation failed for channel "
                         << static_cast<int>(mMemoryChannelId));
                 return false;

--- a/src/platforms/shared/mock/esp/32/drivers/rmt5_support_stubs.h
+++ b/src/platforms/shared/mock/esp/32/drivers/rmt5_support_stubs.h
@@ -96,6 +96,14 @@ public:
     static fl::size calculateMemoryBlocks(bool) FL_NOEXCEPT { return 2; }
 
     AllocationResult allocateTx(u8, bool, bool) FL_NOEXCEPT { return AllocationResult{}; }
+    bool tryAllocateTx(u8, bool, bool, fl::size& out_words) FL_NOEXCEPT {
+        out_words = 64;
+        return true;
+    }
+    bool tryAllocateRx(u8, fl::size, bool, fl::size& out_words) FL_NOEXCEPT {
+        out_words = 64;
+        return true;
+    }
     void free(u8, bool) FL_NOEXCEPT {}  // ok bare allocation
     void recordRecoveryAllocation(u8, fl::size, bool) FL_NOEXCEPT {}
     bool isDMAAvailable() FL_NOEXCEPT { return false; }


### PR DESCRIPTION
## Summary

**Single combined PR** for meta [#2856](https://github.com/FastLED/FastLED/issues/2856), per the /clud-pr workflow's \"one PR per task\" rule. Items 3.6 (#2861) was already merged separately before this consolidation; item 3.4 was already in master before #2856 was filed.

This PR addresses items **3.1, 3.2, 3.3, and 3.5**:

### Item 3.1 — Cold-helper split of \`ChannelEngineRMTImpl::~dtor\`

The destructor body (drain-wait + per-channel cleanup loop + FL_WARN timeout diagnostic + FL_LOG_RMT trailer) is a cold path — only reached at process end. Move it into an \`FL_NO_INLINE destructorCleanup()\` helper so its operator<< instantiations + the multi-line cleanup loop body don't contribute to icache footprint in the steady-state code that calls into the engine. Same pattern that worked for #2773 items 2.1 (PR #2830), 2.2 (PR #2838), 2.5 (PR #2840).

### Item 3.2 — \`FL_WARN_LIT\` / \`FL_LOG_LIT\` macros for literal-only sites

Each \`FL_WARN(literal)\` bakes an \`fl::sstream\` + \`operator<<\` chain for the file/line prefix + the literal at every call site. For sites that pass nothing but a literal string, that's pure overhead vs a single \`fl::println\` call.

Add \`FL_WARN_LIT(literal)\` / \`FL_LOG_LIT(literal)\` macros: route literal-only messages through \`fl::println\` directly, dropping the file/line prefix. The literal carries its own \`\"[RMT]\"\` prefix to partially compensate. The non-literal \`FL_WARN\` remains available for sites that need operator<< formatting or the file/line prefix.

Migrates the destructor timeout warning as a first proof-of-concept. Other call sites can move to \`FL_WARN_LIT\` incrementally.

This is a **bounded, first step** toward the full printf-style log backend described in #2856 item 3.2. The full backend (\`fl::printf(\"fmt\", args...)\`) is multi-day work; this PR introduces the literal-only fast path as a stable building block. Subsequent PRs can add the printf API and bulk-migrate remaining sites.

### Item 3.3 — Skip \`NetworkDetector\` under \`FASTLED_RMT_STATIC_ALLOCATION\`

\`ChannelEngineRMT::createChannel\` calls \`NetworkDetector::isAnyNetworkActive()\` on every allocation to choose network-mode vs idle-mode buffer sizing. Under \`FASTLED_RMT_STATIC_ALLOCATION\` (#2846) the user has asserted no network during LED transmission, so this resolves to constexpr \`false\`. The linker then drops the \`NetworkDetector\` singleton + WiFi-state-reading chain from the binary.

This is the most impactful piece of #2856 item 3.3 that can land safely. The full static-bind addLeds<>() refactor (touching every example) is deferred.

### Item 3.5 — \`tryAllocateTx\` / \`tryAllocateRx\` status-code variants

(Same content as the closed #2862, cherry-picked into this single combined PR.) Adds bool-returning wrappers around the \`result<>\`-bearing \`allocateTx\`/\`allocateRx\` for the 4 internal callsites that don't need the specific error code. \`result<>\`-bearing API retained for tests + public callers.

## What's NOT in this PR

The /clud-pr stop-hook flagged that #2856 was multi-PR; this PR consolidates. But three pieces of work in the meta are genuinely sprint-sized refactors that cannot safely land in one PR session:

- **Full Level B template-trait refactor** of \`Channel::showPixels\` — requires \`ChannelEngineRMTImpl<bool kStatic>\` class template, \`kIsStaticInit\` thread-local, audit of every example's \`addLeds<>\` instantiation. Design RFC at [#2773 comment 4636464324](https://github.com/FastLED/FastLED/issues/2773#issuecomment-4636464324).
- **Full printf-style log backend** — requires new \`fl::printf(\"fmt\", args...)\` API surface + bulk migration of ~hundreds of FL_WARN/FL_LOG_RMT sites.
- **Full static-bind path for boot-time \`addLeds<>()\`** — largest blast radius, touches every example.

The minimal real wins from each (this PR) are landed; the architectural refactors are documented in #2856's tracking matrix as deferred.

## Test plan

- [x] \`bash lint --cpp\` — clean
- [x] \`bash test --cpp\` — 310/310 pass
- [ ] CI on this PR
- [ ] Map-file audit via CI artifacts on a \`FASTLED_RMT_STATIC_ALLOCATION=1\` build (item 3.3 NetworkDetector trim is gated on this)

Refs #2856.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored RMT driver memory allocation patterns with updated status-code handling for DMA and non-DMA configurations.
  * Enhanced logging system with new literal-only macros.
  * Updated memory manager allocation APIs for consistency across platform implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->