### PR TITLE
feat(platform/lpc): scope LPC8xx driver code to LPC8xx-only (#2865)

### DIFF
--- a/src/platforms/arm/is_arm.h
+++ b/src/platforms/arm/is_arm.h
@@ -72,7 +72,11 @@
     /* Microchip SAMD51/SAME51 */ \
     defined(__SAMD51G19A__) || defined(__SAMD51J19A__) || \
     defined(__SAME51J19A__) || defined(__SAMD51P19A__) || defined(__SAMD51P20A__) || \
-    /* NXP LPC8xx (LPC845 / LPC804 Cortex-M0+) - defined by lpc/is_lpc.h */ \
+    /* NXP LPC family - defined by lpc/is_lpc.h:                          \
+     *   LPC8xx  (LPC845 / LPC804)         - Cortex-M0+, driver wired (#2837) \
+     *   LPC11xx (LPC1114/1115/U24/U35)    - Cortex-M0,  detection only (#2849) \
+     *   LPC15xx (LPC15{17..49})           - Cortex-M3,  detection only (#2859) \
+     * Driver wiring for LPC11xx / LPC15xx is tracked in #2845 Stage 4. */ \
     defined(FL_IS_ARM_LPC)
 #define FL_IS_ARM
 #endif  // ARM platform detection

--- a/src/platforms/arm/lpc/clockless_arm_lpc.h
+++ b/src/platforms/arm/lpc/clockless_arm_lpc.h
@@ -9,7 +9,14 @@
 // When the PLU opt-in is set on an LPC804 build, the dedicated PLU driver
 // (clockless_arm_lpc_plu.h) provides the ClocklessController specialisation;
 // compile this bit-banged driver out so we don't double-define the template.
-#if defined(FL_IS_ARM_LPC) && !(defined(FL_LPC804) && defined(FASTLED_LPC_PLU))
+//
+// Scoped to LPC8xx (LPC845 / LPC804) only. LPC11xx (Cortex-M0) and LPC15xx
+// (Cortex-M3) detected via #2849 / #2859 also set FL_IS_ARM_LPC but ship
+// different GPIO controller layouts (UM10398 / UM10462 / UM11074), so the
+// FL_LPC_HI_OFFSET / FL_LPC_LO_OFFSET constants below (which assume the
+// LPC8xx 0xA0000000 GPIO controller) do not apply. Driver wiring for those
+// families is tracked in #2845 Stage 4.
+#if (defined(FL_LPC845) || defined(FL_LPC804)) && !(defined(FL_LPC804) && defined(FASTLED_LPC_PLU))
 
 #include "platforms/arm/common/m0clockless.h"
 #include "fl/chipsets/timing_traits.h"
@@ -81,5 +88,5 @@ public:
 
 }  // namespace fl
 
-#endif  // FL_IS_ARM_LPC && !(FL_LPC804 && FASTLED_LPC_PLU)
+#endif  // (FL_LPC845 || FL_LPC804) && !(FL_LPC804 && FASTLED_LPC_PLU)
 #endif  // __INC_CLOCKLESS_ARM_LPC_H

--- a/src/platforms/arm/lpc/fastled_arm_lpc.h
+++ b/src/platforms/arm/lpc/fastled_arm_lpc.h
@@ -6,6 +6,19 @@
 
 #include "platforms/arm/lpc/fastpin_arm_lpc.h"
 
+// LPC11xx (Cortex-M0) and LPC15xx (Cortex-M3) detection scaffolds shipped in
+// #2849 / #2859 (#2845 Stage 4). Driver wiring for those families is a
+// follow-up - the existing LPC8xx fastpin / clockless headers target the
+// LPC8xx GPIO controller at 0xA0000000 (SET / CLR registers) and the M0+ ASM
+// path, neither of which applies to LPC11xx (legacy GPIO at 0x50000000,
+// masked-access semantics, M0 instruction encoding) or LPC15xx (different
+// GPIO layout per UM11074, M3 instruction set). Emit a clear error rather
+// than silently compiling LPC8xx-targeted code for the wrong family.
+#if (defined(FL_LPC11) || defined(FL_LPC15)) && \
+    !(defined(FL_LPC845) || defined(FL_LPC804))
+#error "FastLED LPC11xx / LPC15xx driver wiring is a follow-up to #2849 / #2859, tracked in #2845 Stage 4. The LPC8xx clockless driver targets a different GPIO controller and cannot be used on LPC11xx (Cortex-M0, legacy GPIO at 0x50000000) or LPC15xx (Cortex-M3, GPIO per UM11074). Either contribute the family-specific driver via #2845 or revert to a supported LPC variant."
+#endif
+
 // LPC845 has an optional PWM+DMA-to-GPIO clockless driver (Stage 2c of #2836,
 // see #2842). It is opt-in via FASTLED_LPC_PWM_DMA=1 because it consumes the
 // SCT plus 3 DMA channels - a global resource users may want for other

--- a/src/platforms/arm/lpc/fastpin_arm_lpc.h
+++ b/src/platforms/arm/lpc/fastpin_arm_lpc.h
@@ -12,7 +12,13 @@
 FL_DISABLE_WARNING_PUSH
 FL_DISABLE_WARNING_DEPRECATED_REGISTER
 
-#if defined(FL_IS_ARM_LPC)
+// Scoped to LPC8xx (LPC845 / LPC804) only. The family-level FL_IS_ARM_LPC
+// gate also matches LPC11xx (M0) and LPC15xx (M3) detected via #2849 / #2859,
+// but those families have different GPIO controller layouts (legacy GPIO at
+// 0x50000000 with masked-access semantics for LPC11xx per UM10398/UM10462;
+// LPC15xx GPIO per UM11074 with a different register layout). The driver
+// wiring for those families is tracked in #2845 Stage 4.
+#if defined(FL_LPC845) || defined(FL_LPC804)
 
 namespace fl {
 
@@ -125,7 +131,7 @@ _FL_DEFPIN(28); _FL_DEFPIN(29); _FL_DEFPIN(30); _FL_DEFPIN(31);
 
 }  // namespace fl
 
-#endif  // FL_IS_ARM_LPC
+#endif  // FL_LPC845 || FL_LPC804
 
 FL_DISABLE_WARNING_POP
 


### PR DESCRIPTION
Closes #2865. Follow-up to #2849 (LPC11xx detection) and #2859 (LPC15xx detection); prep work tracked under #2845 Stage 4.

## Summary

- Tighten the `_ARMPIN` template gate in `src/platforms/arm/lpc/fastpin_arm_lpc.h` from `FL_IS_ARM_LPC` to `FL_LPC845 || FL_LPC804`.
- Tighten the bit-banged `ClocklessController` gate in `src/platforms/arm/lpc/clockless_arm_lpc.h` to the same LPC8xx-specific predicate (the existing `FL_LPC804 && FASTLED_LPC_PLU` opt-out is preserved).
- Add a clear `#error` in `src/platforms/arm/lpc/fastled_arm_lpc.h` for `FL_LPC11` / `FL_LPC15` builds, pointing at #2845 Stage 4 as the tracking issue for driver wiring.
- Refresh the LPC family comment block in `src/platforms/arm/is_arm.h` to reflect that LPC8xx, LPC11xx, and LPC15xx are all detected today (with driver scope still LPC8xx-only).

## Why

The current `FL_IS_ARM_LPC` gate is family-level. With #2849 and #2859 having shipped LPC11xx and LPC15xx detection, an `FL_LPC11` or `FL_LPC15` build would silently compile against the LPC8xx GPIO controller layout (`SET[0]` / `CLR[0]` at `0xA0000000`) even though LPC11xx ships the legacy GPIO at `0x50000000` with masked-access semantics (UM10398 §9, UM10462 §9) and LPC15xx ships a different controller again (UM11074). The architecture macros are likewise wrong: LPC11xx is Cortex-M0 (not M0+) and LPC15xx is Cortex-M3.

No platform configuration in-tree currently defines `FL_LPC11` / `FL_LPC15`, so this PR has no behaviour change for shipping LPC8xx builds. It is a latent-bug fix that keeps the next LPC family scaffolds from accidentally activating LPC8xx code paths.

## Out of scope (deliberately)

- `led_sysdefs_arm_lpc.h` updates (FL_IS_ARM_M0 for LPC11xx, F_CPU defaults, CMSIS device headers). `led_sysdefs_*` files are blocked by `protect_platform_headers.py`; the override env var must be set at Claude Code launch.
- New `fastpin_arm_lpc11.h` / `clockless_arm_lpc11.h`. Per the #2845 second comment: "patterns are non-trivial to verify without hardware - prefer the maintainer add these once a board is in hand."

## Test plan

- [x] `bash lint` — clean
- [x] `bash test --cpp` — 310/310 passed (no regressions in LPC8xx unit-test surface area)
- [ ] Confirm no in-tree platform configuration sets `FL_LPC11` / `FL_LPC15` today (verified by issue #2865 description; the gate only fires for explicit user opt-in)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added compile-time guards to prevent unsupported ARM microcontroller variant combinations, with helpful error messages guiding users to correct configurations.

* **Documentation**
  * Enhanced platform detection documentation for ARM microcontroller families, clarifying variant-specific implementation details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->