### PR TITLE
test(spi): add safety counter guard to ping-pong drain-all loops (#2824)

### DIFF
--- a/tests/platforms/esp/32/drivers/spi/spi_pingpong_pipeline_logic.cpp
+++ b/tests/platforms/esp/32/drivers/spi/spi_pingpong_pipeline_logic.cpp
@@ -251,9 +251,15 @@ FL_TEST_CASE("Ping-pong - all bytes accounted for after drain") {
                                  /*polling=*/false);
 
     m.startFirstDma();
+    // Safety counter mirrors the queue-depth test above: if a future
+    // regression spins the drain loop, fail-fast with a clear assertion
+    // instead of waiting 20 s for the runner watchdog (see #2824).
+    int safety = 1000;
     while (m.anyInFlight() || m.ledBytesRemaining > 0) {
-        m.stepStreaming();
+        if (!m.stepStreaming()) break;
+        if (--safety <= 0) break;
     }
+    FL_CHECK_GT(safety, 0);
     m.drainAll();
 
     FL_CHECK_EQ(m.ledBytesRemaining, (size_t)0);
@@ -271,9 +277,16 @@ FL_TEST_CASE("Ping-pong - polling path drains all bytes") {
                                  /*polling=*/true);
 
     m.startFirstDma();
+    // Safety counter — this is the exact loop that hung at 20 s before #2843
+    // dropped the encodeIdx-based polling branch (see #2824). Keeping the
+    // guard means a future regression of the same shape fails in ms with a
+    // clear assertion, not as a runner-watchdog timeout.
+    int safety = 1000;
     while (m.anyInFlight() || m.ledBytesRemaining > 0) {
-        m.stepStreaming();
+        if (!m.stepStreaming()) break;
+        if (--safety <= 0) break;
     }
+    FL_CHECK_GT(safety, 0);
     m.drainAll();
 
     FL_CHECK_EQ(m.ledBytesRemaining, (size_t)0);


### PR DESCRIPTION
Closes #2824.

## Summary

PR #2843 already shipped the primary fix from this issue (the polling-drain logic bug). This closes out the issue's **Additional defense** recommendation: add the `safety` counter + `stepStreaming()` return-value guard that's already used in the queue-depth test (line 226) to the two drain-all loops that don't yet have it.

Without the guard, a future regression of the same shape would manifest as a 20 s runner-watchdog timeout (the original #2824 symptom). With it, the loop bails after 1000 iterations with a clear `FL_CHECK_GT(safety, 0)` assertion in milliseconds.

## Test cases updated

- `Ping-pong - all bytes accounted for after drain` (line 248)
- `Ping-pong - polling path drains all bytes` (line 268, the original #2824 hang site)

The 1000-iteration cap leaves generous headroom — a 4 KB-capacity strip of 12345 bytes drains in ~25 ping-pong steps; 8000 bytes polling drains in ~16.

## Test plan

- [x] `bash lint --cpp` clean
- [x] `bash test spi_pingpong_pipeline_logic` — 1/1 passed in 1.73 s (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced streaming pipeline tests with safeguards to prevent infinite drain loops and watchdog timeouts, improving test reliability and preventing potential regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->