### PR TITLE
test(simd): add parity contract tests for DSP-ext accelerated u8x16 ops (refs #2628)

### DIFF
--- a/tests/fl/math/simd.cpp
+++ b/tests/fl/math/simd.cpp
@@ -1293,6 +1293,238 @@ FL_TEST_CASE("s0x32x4 × s16x16x4 multiply (Q31 × Q16)") {
 // it routes through one of the DSP-ext intrinsics, and the DSP-ext intrinsics
 // are defined to produce identical bit patterns to their scalar equivalents.
 
+//==============================================================================
+// Contract tests for the u8x16 ops the ARM DSP-ext backend accelerates.
+//
+// Adds parity coverage (refs #2628) for ops that PR #2808's minimal DSP-ext
+// backend wires through UQSUB8 / UHADD8 / UADD16 / packed-byte logicals,
+// plus the scalar-fallback ops the same header still delegates to (avg_round,
+// min, max). The tests verify the contract every backend (noop, x86,
+// xtensa, riscv, ARM-DSP) must honour — driving CI on the host noop /
+// x86 paths, with a free parity oracle for the Teensy cross-compile.
+//==============================================================================
+
+FL_TEST_CASE("sub_sat_u8_16 subtracts without underflow") {
+    uint8_t a[16] = {100, 200, 255,   0,  50,  10, 128, 200, 0, 0, 0, 0, 0, 0, 0, 0};
+    uint8_t b[16] = { 50, 100, 255, 100,  60,  10, 128, 201, 0, 0, 0, 0, 0, 0, 0, 0};
+    uint8_t dst[16];
+
+    auto va = simd::load_u8_16(a);
+    auto vb = simd::load_u8_16(b);
+    auto vr = simd::sub_sat_u8_16(va, vb);
+    simd::store_u8_16(dst, vr);
+
+    FL_REQUIRE(dst[0] == 50);    // 100 - 50
+    FL_REQUIRE(dst[1] == 100);   // 200 - 100
+    FL_REQUIRE(dst[2] == 0);     // 255 - 255
+    FL_REQUIRE(dst[3] == 0);     // 0 - 100 → clamp 0
+    FL_REQUIRE(dst[4] == 0);     // 50 - 60 → clamp 0
+    FL_REQUIRE(dst[5] == 0);     // 10 - 10
+    FL_REQUIRE(dst[6] == 0);     // 128 - 128
+    FL_REQUIRE(dst[7] == 0);     // 200 - 201 → clamp 0
+}
+
+FL_TEST_CASE("avg_u8_16 average (floor / round agreement zone)") {
+    // Inputs deliberately constrained to even sums so that floor and
+    // round-half-up semantics agree on every lane. This sidesteps a real
+    // backend divergence (host SSE uses `_mm_avg_epu8` which rounds while
+    // the noop and ARM DSP-ext path floor) so the contract this test
+    // pins down — symmetric average for matched-parity inputs — is the
+    // intersection the dispatched API must honour. A round-only or
+    // floor-only behavioural test belongs in a backend-specific suite.
+    uint8_t a[16] = {0,  100, 200, 254, 255, 1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21};
+    uint8_t b[16] = {0,  100, 200, 254, 255, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23};
+    uint8_t dst[16];
+
+    auto va = simd::load_u8_16(a);
+    auto vb = simd::load_u8_16(b);
+    auto vr = simd::avg_u8_16(va, vb);
+    simd::store_u8_16(dst, vr);
+
+    FL_REQUIRE(dst[0] == 0);
+    FL_REQUIRE(dst[1] == 100);
+    FL_REQUIRE(dst[2] == 200);
+    FL_REQUIRE(dst[3] == 254);
+    FL_REQUIRE(dst[4] == 255);
+    FL_REQUIRE(dst[5] == 2);     // (1+3)/2 = 2
+    FL_REQUIRE(dst[6] == 4);
+    FL_REQUIRE(dst[7] == 6);
+}
+
+FL_TEST_CASE("avg_round_u8_16 ceiling average") {
+    uint8_t a[16] = {0, 0, 100, 200, 254, 255, 1, 2, 0, 0, 0, 0, 0, 0, 0, 0};
+    uint8_t b[16] = {0, 255, 100, 201, 254, 255, 2, 4, 0, 0, 0, 0, 0, 0, 0, 0};
+    uint8_t dst[16];
+
+    auto va = simd::load_u8_16(a);
+    auto vb = simd::load_u8_16(b);
+    auto vr = simd::avg_round_u8_16(va, vb);
+    simd::store_u8_16(dst, vr);
+
+    FL_REQUIRE(dst[0] == 0);     // (0 + 0 + 1) / 2 = 0
+    FL_REQUIRE(dst[1] == 128);   // (0 + 255 + 1) / 2 = 128 (ceil; vs 127 floor)
+    FL_REQUIRE(dst[2] == 100);   // (100 + 100 + 1) / 2 = 100
+    FL_REQUIRE(dst[3] == 201);   // (200 + 201 + 1) / 2 = 201
+    FL_REQUIRE(dst[4] == 254);   // (254 + 254 + 1) / 2 = 254
+    FL_REQUIRE(dst[5] == 255);   // (255 + 255 + 1) / 2 = 255 — no overflow
+    FL_REQUIRE(dst[6] == 2);     // (1 + 2 + 1) / 2 = 2
+}
+
+FL_TEST_CASE("min_u8_16 elementwise minimum") {
+    uint8_t a[16] = {0, 100, 200, 255,   0, 128, 1, 254, 0, 0, 0, 0, 0, 0, 0, 0};
+    uint8_t b[16] = {1,  50, 200,   0, 255, 127, 2, 254, 0, 0, 0, 0, 0, 0, 0, 0};
+    uint8_t dst[16];
+
+    auto va = simd::load_u8_16(a);
+    auto vb = simd::load_u8_16(b);
+    auto vr = simd::min_u8_16(va, vb);
+    simd::store_u8_16(dst, vr);
+
+    FL_REQUIRE(dst[0] == 0);
+    FL_REQUIRE(dst[1] == 50);
+    FL_REQUIRE(dst[2] == 200);   // equal → either
+    FL_REQUIRE(dst[3] == 0);
+    FL_REQUIRE(dst[4] == 0);
+    FL_REQUIRE(dst[5] == 127);
+    FL_REQUIRE(dst[6] == 1);
+    FL_REQUIRE(dst[7] == 254);   // equal → either
+}
+
+FL_TEST_CASE("max_u8_16 elementwise maximum") {
+    uint8_t a[16] = {0, 100, 200, 255,   0, 128, 1, 254, 0, 0, 0, 0, 0, 0, 0, 0};
+    uint8_t b[16] = {1,  50, 200,   0, 255, 127, 2, 254, 0, 0, 0, 0, 0, 0, 0, 0};
+    uint8_t dst[16];
+
+    auto va = simd::load_u8_16(a);
+    auto vb = simd::load_u8_16(b);
+    auto vr = simd::max_u8_16(va, vb);
+    simd::store_u8_16(dst, vr);
+
+    FL_REQUIRE(dst[0] == 1);
+    FL_REQUIRE(dst[1] == 100);
+    FL_REQUIRE(dst[2] == 200);
+    FL_REQUIRE(dst[3] == 255);
+    FL_REQUIRE(dst[4] == 255);
+    FL_REQUIRE(dst[5] == 128);
+    FL_REQUIRE(dst[6] == 2);
+    FL_REQUIRE(dst[7] == 254);
+}
+
+FL_TEST_CASE("and_u8_16 bitwise AND") {
+    uint8_t a[16] = {0xFF, 0xF0, 0x0F, 0xAA, 0x55, 0x00, 0xC3, 0x3C, 0, 0, 0, 0, 0, 0, 0, 0};
+    uint8_t b[16] = {0xFF, 0x0F, 0xF0, 0xFF, 0xAA, 0xFF, 0x81, 0x18, 0, 0, 0, 0, 0, 0, 0, 0};
+    uint8_t dst[16];
+
+    auto va = simd::load_u8_16(a);
+    auto vb = simd::load_u8_16(b);
+    auto vr = simd::and_u8_16(va, vb);
+    simd::store_u8_16(dst, vr);
+
+    FL_REQUIRE(dst[0] == 0xFF);
+    FL_REQUIRE(dst[1] == 0x00);
+    FL_REQUIRE(dst[2] == 0x00);
+    FL_REQUIRE(dst[3] == 0xAA);
+    FL_REQUIRE(dst[4] == 0x00);
+    FL_REQUIRE(dst[5] == 0x00);
+    FL_REQUIRE(dst[6] == 0x81);
+    FL_REQUIRE(dst[7] == 0x18);
+}
+
+FL_TEST_CASE("or_u8_16 bitwise OR") {
+    uint8_t a[16] = {0xFF, 0xF0, 0x0F, 0xAA, 0x55, 0x00, 0xC3, 0x3C, 0, 0, 0, 0, 0, 0, 0, 0};
+    uint8_t b[16] = {0x00, 0x0F, 0xF0, 0x55, 0xAA, 0x00, 0x18, 0x81, 0, 0, 0, 0, 0, 0, 0, 0};
+    uint8_t dst[16];
+
+    auto va = simd::load_u8_16(a);
+    auto vb = simd::load_u8_16(b);
+    auto vr = simd::or_u8_16(va, vb);
+    simd::store_u8_16(dst, vr);
+
+    FL_REQUIRE(dst[0] == 0xFF);
+    FL_REQUIRE(dst[1] == 0xFF);
+    FL_REQUIRE(dst[2] == 0xFF);
+    FL_REQUIRE(dst[3] == 0xFF);
+    FL_REQUIRE(dst[4] == 0xFF);
+    FL_REQUIRE(dst[5] == 0x00);
+    FL_REQUIRE(dst[6] == 0xDB);  // 0xC3 | 0x18 = 0xDB
+    FL_REQUIRE(dst[7] == 0xBD);  // 0x3C | 0x81 = 0xBD
+}
+
+FL_TEST_CASE("xor_u8_16 bitwise XOR") {
+    uint8_t a[16] = {0xFF, 0xF0, 0xAA, 0x55, 0x00, 0xFF, 0x12, 0x34, 0, 0, 0, 0, 0, 0, 0, 0};
+    uint8_t b[16] = {0x00, 0xF0, 0xAA, 0xAA, 0x00, 0xFF, 0x34, 0x12, 0, 0, 0, 0, 0, 0, 0, 0};
+    uint8_t dst[16];
+
+    auto va = simd::load_u8_16(a);
+    auto vb = simd::load_u8_16(b);
+    auto vr = simd::xor_u8_16(va, vb);
+    simd::store_u8_16(dst, vr);
+
+    FL_REQUIRE(dst[0] == 0xFF);
+    FL_REQUIRE(dst[1] == 0x00);  // a ^ a = 0
+    FL_REQUIRE(dst[2] == 0x00);  // a ^ a = 0
+    FL_REQUIRE(dst[3] == 0xFF);  // 0x55 ^ 0xAA
+    FL_REQUIRE(dst[4] == 0x00);
+    FL_REQUIRE(dst[5] == 0x00);  // 0xFF ^ 0xFF = 0
+    FL_REQUIRE(dst[6] == 0x26);  // 0x12 ^ 0x34
+    FL_REQUIRE(dst[7] == 0x26);  // 0x34 ^ 0x12
+}
+
+FL_TEST_CASE("andnot_u8_16: (~a) & b") {
+    uint8_t a[16] = {0xFF, 0x00, 0xF0, 0x0F, 0xAA, 0x55, 0x12, 0xFF, 0, 0, 0, 0, 0, 0, 0, 0};
+    uint8_t b[16] = {0xAA, 0xAA, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x55, 0, 0, 0, 0, 0, 0, 0, 0};
+    uint8_t dst[16];
+
+    auto va = simd::load_u8_16(a);
+    auto vb = simd::load_u8_16(b);
+    auto vr = simd::andnot_u8_16(va, vb);
+    simd::store_u8_16(dst, vr);
+
+    FL_REQUIRE(dst[0] == 0x00);  // (~0xFF) & 0xAA = 0
+    FL_REQUIRE(dst[1] == 0xAA);  // (~0x00) & 0xAA = 0xAA
+    FL_REQUIRE(dst[2] == 0x0F);  // (~0xF0) & 0xFF = 0x0F
+    FL_REQUIRE(dst[3] == 0xF0);
+    FL_REQUIRE(dst[4] == 0x55);  // (~0xAA) & 0xFF
+    FL_REQUIRE(dst[5] == 0xAA);
+    FL_REQUIRE(dst[6] == 0xED);  // (~0x12) & 0xFF = 0xED
+    FL_REQUIRE(dst[7] == 0x00);  // (~0xFF) & 0x55 = 0
+}
+
+FL_TEST_CASE("add_u16_8 via widen/narrow round-trip (UADD16 contract)") {
+    // The public API doesn't expose load_u16_8/store_u16_8 — every backend
+    // hands `simd_u16x8` back as either a struct, an SSE __m128i, or a
+    // hardware vector register. Verifying add_u16_8 across backends means
+    // round-tripping through widen_*_u8_to_u16 + narrow_u16_to_u8.
+    //
+    // Inputs are constrained to fit in u8 [0..255] both before AND after the
+    // halfword add so the saturating narrow at the end doesn't clamp our
+    // outputs and the test reflects the modular add_u16_8 contract that
+    // UADD16 implements.
+    uint8_t a[16] = { 0, 10, 50, 100, 127, 128, 200, 255, 0, 0, 0, 0, 0, 0, 0, 0};
+    uint8_t b[16] = { 0,  1, 25,  50,   0, 127,  50,   0, 0, 0, 0, 0, 0, 0, 0, 0};
+    uint8_t dst[16];
+
+    auto va = simd::load_u8_16(a);
+    auto vb = simd::load_u8_16(b);
+    auto la = simd::widen_lo_u8_to_u16(va);
+    auto lb = simd::widen_lo_u8_to_u16(vb);
+    auto ha = simd::widen_hi_u8_to_u16(va);
+    auto hb = simd::widen_hi_u8_to_u16(vb);
+    auto sum_lo = simd::add_u16_8(la, lb);
+    auto sum_hi = simd::add_u16_8(ha, hb);
+    auto vr = simd::narrow_u16_to_u8(sum_lo, sum_hi);
+    simd::store_u8_16(dst, vr);
+
+    FL_REQUIRE(dst[0] == 0);
+    FL_REQUIRE(dst[1] == 11);
+    FL_REQUIRE(dst[2] == 75);
+    FL_REQUIRE(dst[3] == 150);
+    FL_REQUIRE(dst[4] == 127);
+    FL_REQUIRE(dst[5] == 255);    // 128 + 127 = 255 — at boundary, no clamp
+    FL_REQUIRE(dst[6] == 250);
+    FL_REQUIRE(dst[7] == 255);
+}
+
 FL_TEST_CASE("DSP-extension SIMD backend: dispatch sanity") {
     // The trampoline must not route the host build through the Teensy DSP-ext
     // file (which requires inline ARM assembly). If it did, compilation would


### PR DESCRIPTION
Refs #2628.

## Summary

PR #2808 wired the minimal ARM Cortex-M DSP-extension SIMD backend (`src/platforms/arm/teensy/simd_arm_dsp.hpp`) and added a dispatch sanity test, but it didn't extend the cross-backend contract suite in `tests/fl/math/simd.cpp`. That left `sub_sat_u8_16`, `avg_u8_16`, `avg_round_u8_16`, `min/max_u8_16`, the four bitwise `*_u8_16` ops, and `add_u16_8` running on every backend without an assertion of their shared semantics.

This adds focused contract tests for each of those ops. They drive CI on the host noop / x86 paths and act as a free parity oracle on the Teensy 3.x / 4.x cross-compile (which dispatches through the DSP-ext header). When the deferred follow-ups in the DSP-ext file (`scale_u8_16` via SMUAD/PKHBT, `min/max_u8_16` via USUB8+SEL, `narrow_u16_to_u8` via USAT16) get filled in, these tests remain unchanged — they verify the **contract**, not the implementation.

## Notable design choices

- **`avg_u8_16`**: inputs constrained to **even-sum pairs** so floor and round-half-up agree on every lane. Host SSE (`_mm_avg_epu8`) rounds while noop and ARM DSP-ext (`UHADD8`) floor — that's a real cross-backend divergence on odd sums that is out of scope here. The constrained test pins down the intersection contract; a floor-only or round-only behavioural assertion belongs in a backend-specific suite.
- **`add_u16_8`**: round-trips through `widen_lo/hi_u8_to_u16` + `narrow_u16_to_u8` rather than touching `simd_u16x8` fields directly, because the public API leaves the type opaque (`__m128i` on SSE, struct on noop / DSP-ext, hardware vector on Xtensa). Inputs clamped to u8 range so the narrow's saturation doesn't obscure the modular `add_u16_8` semantics.

## Tests covered

| Op | DSP-ext implementation | Coverage before | Coverage after |
|---|---|---|---|
| `sub_sat_u8_16` | UQSUB8 x4 | — | ✅ |
| `avg_u8_16` | UHADD8 x4 (floor) | — | ✅ |
| `avg_round_u8_16` | scalar (deferred) | — | ✅ |
| `min_u8_16` | scalar (deferred USUB8+SEL) | — | ✅ |
| `max_u8_16` | scalar (deferred) | — | ✅ |
| `and_u8_16` | 32-bit AND x4 | — | ✅ |
| `or_u8_16` | 32-bit ORR x4 | — | ✅ |
| `xor_u8_16` | 32-bit EOR x4 | — | ✅ |
| `andnot_u8_16` | 32-bit BIC x4 | — | ✅ |
| `add_u16_8` | UADD16 x4 | — | ✅ |

## Test plan

- [x] `bash test fl_math_simd` — 1/1 passed (host noop + x86)
- [x] `bash test --cpp` — 310/310 passed (no regression)
- [x] `bash compile teensy40 --examples AutoResearch` — clean (DSP-ext dispatch path on Cortex-M7)

## Out of scope (deferred to #2628 follow-ups)

- The DSP-ext implementations of `scale_u8_16` (SMUAD-based), `blend_u8_16` (weighted blend), `min/max_u8_16` (USUB8 + SEL with GE flags), and `narrow_u16_to_u8` (USAT16). These remain TODO markers in `simd_arm_dsp.hpp`; the tests added here will validate them automatically once the intrinsics land.
- Resolving the `avg_u8_16` floor/round divergence between x86 and noop/DSP-ext.
- On-device cycles-per-op micro-benchmark on Teensy 4.x — requires hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added extensive test coverage for vector operations including saturation, rounding, and bitwise operations to ensure correctness across hardware platforms and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->