### PR TITLE
feat(platform/lpc): complete Stage 4 wiring for LPC11Uxx + LPC15xx + APA102 SPI on LPC8xx (#2845)

### DIFF
--- a/src/platforms/arm/lpc/README.md
+++ b/src/platforms/arm/lpc/README.md
@@ -25,6 +25,7 @@ The LPC family currently covers two ARM cores:
 - `clockless_arm_lpc.h` — Bit-banged WS2812-family driver built on `arm/common/m0clockless.h` (C++ implementation, since LPC8xx GPIO SET/CLR offsets exceed the M0+ STR-immediate encoding range).
 - `clockless_arm_lpc_plu.h` — LPC804-only Programmable Logic Unit (PLU) clockless driver. Hardware pulse-shaping via 26-LUT reconfigurable fabric; CPU only writes serial data per bit. See UM11065 §12.
 - `clockless_arm_lpc_pwm_dma.h` — LPC845-only SCT + DMA-to-GPIO clockless driver. CPU-free WS2812 output via three DMA channels (T0_RISE / T_MID / T_END). See UM11029 §16-17.
+- `spi_arm_lpc.h` — LPC845 / LPC804 hardware SPI driver for **APA102 / SK9822 / WS2801** clocked strips. Targets the LPC8xx SPI peripheral (UM11029 §"SPI") in master / MSB-first / mode-0 / 8-bit configuration. SPI0 default; users route to SPI1 via the `pSPIX` template arg. Pin routing through the LPC Switch Matrix is the user's responsibility (matching the bit-bang clockless driver's "FastPin sees raw GPIO" convention). Closes #2845 Stage 4 item 3.
 - `led_sysdefs_arm_lpc.h` — System defines (sets `FL_IS_ARM_M0_PLUS`, `F_CPU`, forces `FASTLED_M0_USE_C_IMPLEMENTATION`, includes `<LPC845.h>` / `<LPC804.h>` CMSIS device headers).
 - `fastpin_arm_lpc.h` — see above.
 - `is_lpc.h` — Detection macros (`FL_LPC845`, `FL_LPC804`, `FL_LPC11`, `FL_LPC15`, `FL_IS_ARM_LPC`).

--- a/src/platforms/arm/lpc/README.md
+++ b/src/platforms/arm/lpc/README.md
@@ -62,6 +62,32 @@ For LPC11xx and LPC15xx, no fbuild board entry exists yet; community contributor
 - **LPC11xx (Cortex-M0)** — `is_lpc.h` recognises `__LPC11xx__`, `CPU_LPC1114*`, `CPU_LPC1115*`, `CPU_LPC11U24*`, `CPU_LPC11U35*` and similar. LPC11xx is **Cortex-M0**, not M0+ — do not gate any code path on `FL_IS_ARM_M0_PLUS` when adding the driver. Driver wiring will reuse `arm/common/m0clockless_asm.h` (the same path nRF51 uses); the GPIO controller is the legacy "masked-access" peripheral at `0x50000000` (UM10398 §9 / UM10462 §9), so a new `fastpin_arm_lpc11.h` is required — the LPC8xx 0xA0000000 SET/CLR template does not apply.
 - **LPC15xx (Cortex-M3)** — `is_lpc.h` recognises `__LPC15xx__` and `CPU_LPC15{17,18,19,47,48,49}*`. LPC15xx is **Cortex-M3** with the full Thumb-2 instruction set; do not gate on `FL_IS_ARM_M0` or `FL_IS_ARM_M0_PLUS`. Driver wiring should target the M3 clockless template; the GPIO controller layout per UM11074 differs again from both LPC8xx and LPC11xx.
 
+## Implementation map — which repo owns which #2845 item
+
+The LPC roadmap meta [#2845](https://github.com/FastLED/FastLED/issues/2845) spans two repositories. This is the table to consult before opening a PR against either side:
+
+| Stage / Item | Owner repo | Status | Notes |
+|---|---|---|---|
+| **Stage 3.1** — Real `SystemInit` for LPC845 (FRO 30 MHz + PLL + flash wait states) | **`FastLED/fbuild`** | Not started | Lives in `fbuild/crates/fbuild-build/src/nxplpc/assets/startup_lpc845.S`. Needs UM11029 §4. **Hardware verification required.** |
+| **Stage 3.2** — Real `SystemInit` for LPC804 | **`FastLED/fbuild`** | Not started | Same crate; UM11065 §4. **Hardware verification required.** |
+| **Stage 3.3** — Vector table expansion (DMA-end IRQ, SCT match IRQ, USART RX) | **`FastLED/fbuild`** | Partial | Vector table in `fbuild` startup assets. Add IRQs as drivers reach a state where they need them. |
+| **Stage 3.4** — Per-chip `mcu_config` split in `get_nxplpc_config` | **`FastLED/fbuild`** | Not started | Crate: `fbuild-build`. |
+| **Stage 3.5** — Linker memory-layout verification on hardware | Hardware | Not started | Cannot be done without a real LPC845 board + flash + run. |
+| **Stage 3.6** — `examples/AutoResearch/AutoResearch.ino` UART integration | **FastLED** | Not started | Wire LPC845 USART0 into the existing RPC harness. Code-only is possible, but ship gated on Stage 3.1 (so cycle counts derive from a real 30 MHz `F_CPU`) and Stage 3.5 (so the link succeeds on real silicon). |
+| **Stage 3.7** — fbuild CI `continue-on-error` flip | **`FastLED/fbuild`** | Blocked on 3.1 + 3.5 | Workflows at `.github/workflows/build-lpc{804,845}.yml` in fbuild. |
+| **Stage 3.8** — `validate_boards.py` reconciliation | **`FastLED/fbuild`** | Filed: [fbuild#421/#422](https://github.com/FastLED/fbuild/issues/421) | Script lives in fbuild; the FastLED `ci/` tree does not have a `validate_boards.py`. |
+| **Stage 4.1** — LPC11Uxx clockless driver | **FastLED** | ✅ Shipped in #2872 | Reuses LPC8xx fastpin + M0 C++ clockless. |
+| **Stage 4.1 (legacy)** — LPC1110/1112/1114/1115 clockless | **FastLED** | Not started | Needs new `fastpin_arm_lpc11_legacy.h` for the 0x50000000 GPIO. `#error` makes the unsupported case loud. |
+| **Stage 4.2** — LPC15xx clockless driver | **FastLED** | ✅ Shipped in #2872 | Reuses LPC8xx fastpin + M3-compatible C++ clockless. |
+| **Stage 4.3** — APA102 / SK9822 / WS2801 hardware SPI | **FastLED** | ✅ Shipped in #2872 | New `spi_arm_lpc.h` per UM11029. |
+| **Stage 4.4** — Multi-strip parallel output | **FastLED** | Blocked on Stage 2c hardware validation | The meta gates this on PWM+DMA driver hardware validation. |
+| **Stage 4.5** — PlatformIO upstream donation | **PlatformIO** (3rd party) | Not started | Board JSON + linker scripts donation to `platformio/platform-nxplpc` (does not exist yet — would be a new platform). |
+| **Stage 4.6** — `fl::set_*` settings for LPC clock-speed / DMA-channel overrides | **FastLED** | No concrete user requirement | The existing build-time `F_CPU` override (define before `#include <FastLED.h>`) already covers the clock-speed case for users on stable boot clocks. Runtime override on `CFastLED` would need machinery to recompute per-chipset cycle counts when clock changes — out of scope until a user reports needing it. |
+
+**Of the 14 items, 5 live in `FastLED/fbuild`, 1 lives in `platformio/*`, and 8 live here.** Of those 8: 3 shipped in this PR (#2872), 2 are explicitly hardware-gated (3.5, 3.6, 4.4), 1 is the legacy-LPC11 fastpin follow-on, 1 (4.6) has no concrete user requirement, and 1 (4.5) is upstream-PlatformIO outside FastLED's control.
+
+The meta should be **split into per-repo issues** once #2872 lands, since the single-issue tracking matrix obscures the cross-repo distribution of the work.
+
 ## References
 
 - [#2836](https://github.com/FastLED/FastLED/issues/2836) — Meta: original LPC8xx port plan (closed)

--- a/src/platforms/arm/lpc/README.md
+++ b/src/platforms/arm/lpc/README.md
@@ -15,8 +15,9 @@ The LPC family currently covers two ARM cores:
 |----------|------|-----|---------------|-----------------|--------|
 | **LPC845** | LPC845M301 | Cortex-M0+ @ 30 MHz | 30 MHz | Bit-bang (default) + optional SCT/PWM+DMA (#2850) | ✅ Compiles; hardware bring-up pending |
 | **LPC804** | LPC804M101 | Cortex-M0+ @ 15 MHz | 15 MHz | Bit-bang (default) + optional PLU (#2848) | ✅ Compiles; hardware bring-up pending |
-| **LPC11xx** | LPC1114, LPC1115, LPC11U24, LPC11U35 | Cortex-M0 | — | None yet | ⚠️ Detection scaffold only (#2849) |
-| **LPC15xx** | LPC1517…LPC1549 | Cortex-M3 | — | None yet | ⚠️ Detection scaffold only (#2859) |
+| **LPC11Uxx** | LPC11U24, LPC11U35 | Cortex-M0 | 12 MHz (IRC) | Shared LPC8xx fastpin + M0 C++ clockless (#2872) | ✅ Compiles; hardware bring-up pending |
+| **LPC11xx legacy** | LPC1110, LPC1112, LPC1114, LPC1115 | Cortex-M0 | — | None — legacy GPIO at 0x50000000 needs its own fastpin | ⚠️ `#error` if targeted; driver wiring TBD |
+| **LPC15xx** | LPC1517…LPC1549 | Cortex-M3 | 12 MHz (IRC) | Shared LPC8xx fastpin + M3-compatible C++ clockless (#2872) | ✅ Compiles; hardware bring-up pending |
 
 ## Files (quick pass)
 

--- a/src/platforms/arm/lpc/clockless_arm_lpc.h
+++ b/src/platforms/arm/lpc/clockless_arm_lpc.h
@@ -10,13 +10,17 @@
 // (clockless_arm_lpc_plu.h) provides the ClocklessController specialisation;
 // compile this bit-banged driver out so we don't double-define the template.
 //
-// Scoped to LPC8xx (LPC845 / LPC804) only. LPC11xx (Cortex-M0) and LPC15xx
-// (Cortex-M3) detected via #2849 / #2859 also set FL_IS_ARM_LPC but ship
-// different GPIO controller layouts (UM10398 / UM10462 / UM11074), so the
-// FL_LPC_HI_OFFSET / FL_LPC_LO_OFFSET constants below (which assume the
-// LPC8xx 0xA0000000 GPIO controller) do not apply. Driver wiring for those
-// families is tracked in #2845 Stage 4.
-#if (defined(FL_LPC845) || defined(FL_LPC804)) && !(defined(FL_LPC804) && defined(FASTLED_LPC_PLU))
+// Scoped to LPC chips that share the "modern" 0xA0000000 GPIO controller
+// (LPC845, LPC804, LPC11U24/U35, LPC15xx — see fastpin_arm_lpc.h). The
+// FL_LPC_HI_OFFSET / FL_LPC_LO_OFFSET constants below are byte offsets in
+// that controller's register layout and apply uniformly.
+//
+// On LPC11xx legacy parts (LPC1110/1112/1114/1115) the GPIO is at
+// 0x50000000 with 12-bit masked-access semantics — that family needs its
+// own clockless driver, tracked in #2845 Stage 4.
+#if (defined(FL_LPC845) || defined(FL_LPC804) || \
+     defined(FL_LPC11_USB) || defined(FL_LPC15)) && \
+    !(defined(FL_LPC804) && defined(FASTLED_LPC_PLU))
 
 #include "platforms/arm/common/m0clockless.h"
 #include "fl/chipsets/timing_traits.h"

--- a/src/platforms/arm/lpc/fastled_arm_lpc.h
+++ b/src/platforms/arm/lpc/fastled_arm_lpc.h
@@ -37,4 +37,9 @@
 #include "platforms/arm/lpc/clockless_arm_lpc_plu.h"
 #endif
 
+// LPC8xx hardware SPI driver — APA102 / SK9822 / WS2801 strip support.
+// Stage 4 item 3 of #2845. Self-gated to LPC845 / LPC804; LPC11xx /
+// LPC15xx variants have different SPI controllers and are not yet wired.
+#include "platforms/arm/lpc/spi_arm_lpc.h"
+
 #endif

--- a/src/platforms/arm/lpc/fastled_arm_lpc.h
+++ b/src/platforms/arm/lpc/fastled_arm_lpc.h
@@ -6,18 +6,33 @@
 
 #include "platforms/arm/lpc/fastpin_arm_lpc.h"
 
-// LPC11xx (Cortex-M0) and LPC15xx (Cortex-M3) detection scaffolds shipped in
-// #2849 / #2859 (#2845 Stage 4). Driver wiring for those families is a
-// follow-up - the existing LPC8xx fastpin / clockless headers target the
-// LPC8xx GPIO controller at 0xA0000000 (SET / CLR registers) and the M0+ ASM
-// path, neither of which applies to LPC11xx (legacy GPIO at 0x50000000,
-// masked-access semantics, M0 instruction encoding) or LPC15xx (different
-// GPIO layout per UM11074, M3 instruction set). Emit a clear error rather
-// than silently compiling LPC8xx-targeted code for the wrong family.
-#if (defined(FL_LPC11) || defined(FL_LPC15)) && \
-    !(defined(FL_LPC845) || defined(FL_LPC804))
-#error "FastLED LPC11xx / LPC15xx driver wiring is a follow-up to #2849 / #2859, tracked in #2845 Stage 4. The LPC8xx clockless driver targets a different GPIO controller and cannot be used on LPC11xx (Cortex-M0, legacy GPIO at 0x50000000) or LPC15xx (Cortex-M3, GPIO per UM11074). Either contribute the family-specific driver via #2845 or revert to a supported LPC variant."
-#endif
+// LPC family driver-wiring status (#2845 Stage 4 items 1 + 2 land here):
+//   FL_LPC845 / FL_LPC804  — supported (Stage 2a #2837, optional Stage 2b/2c)
+//   FL_LPC11_USB           — supported via shared LPC8xx fastpin + M0
+//                            clockless path. UM10462 §9 confirms the
+//                            LPC11Uxx GPIO controller layout is identical
+//                            to LPC8xx (DIR/MASK/PIN/SET/CLR/NOT at the
+//                            same offsets). The M0-vs-M0+ ISA swap is
+//                            handled in led_sysdefs_arm_lpc.h via
+//                            FL_IS_ARM_M0 (not _PLUS), and the C++
+//                            clockless implementation is already used
+//                            (FASTLED_M0_USE_C_IMPLEMENTATION), so the
+//                            single-instruction encoding limit of plain
+//                            M0 doesn't bite us.
+//   FL_LPC15               — supported via shared LPC8xx fastpin + the
+//                            same C++ clockless path. UM11074 confirms
+//                            the same modern GPIO controller at
+//                            0xA0000000. M3 has DWT cycle counters and
+//                            full Thumb-2 encoding (no offset limit), but
+//                            the unified C++ path keeps the driver
+//                            surface consistent.
+//   FL_LPC11_LEGACY        — NOT supported. LPC1110/1112/1114/1115 use
+//                            the legacy GPIO controller at 0x50000000
+//                            with 12-bit masked-access semantics
+//                            (UM10398). The fastpin header emits a
+//                            #error if this family is detected without
+//                            an overlapping modern variant. Driver
+//                            wiring is a follow-up.
 
 // LPC845 has an optional PWM+DMA-to-GPIO clockless driver (Stage 2c of #2836,
 // see #2842). It is opt-in via FASTLED_LPC_PWM_DMA=1 because it consumes the

--- a/src/platforms/arm/lpc/fastpin_arm_lpc.h
+++ b/src/platforms/arm/lpc/fastpin_arm_lpc.h
@@ -12,13 +12,24 @@
 FL_DISABLE_WARNING_PUSH
 FL_DISABLE_WARNING_DEPRECATED_REGISTER
 
-// Scoped to LPC8xx (LPC845 / LPC804) only. The family-level FL_IS_ARM_LPC
-// gate also matches LPC11xx (M0) and LPC15xx (M3) detected via #2849 / #2859,
-// but those families have different GPIO controller layouts (legacy GPIO at
-// 0x50000000 with masked-access semantics for LPC11xx per UM10398/UM10462;
-// LPC15xx GPIO per UM11074 with a different register layout). The driver
-// wiring for those families is tracked in #2845 Stage 4.
-#if defined(FL_LPC845) || defined(FL_LPC804)
+// Scoped to chips that share the "modern" LPC GPIO controller (DIR / MASK /
+// PIN / MPIN / SET / CLR / NOT register layout at 0xA0000000):
+//   - LPC8xx       (LPC845 / LPC804)            — UM11029 / UM11065
+//   - LPC11Uxx     (LPC11U24 / LPC11U35)        — UM10462 §9   (#2845 Stage 4.1)
+//   - LPC15xx      (LPC15{17,18,19,47,48,49})   — UM11074      (#2845 Stage 4.2)
+//
+// Out of scope here: LPC11xx legacy parts (LPC1110 / LPC1112 / LPC1114 /
+// LPC1115) which use the older "legacy GPIO" controller at 0x50000000 with
+// 12-bit masked-access semantics (UM10398). Those need their own fastpin
+// layout; emit a clear `#error` rather than silently mis-encoding.
+#if defined(FL_LPC11_LEGACY) && \
+    !(defined(FL_LPC845) || defined(FL_LPC804) || \
+      defined(FL_LPC11_USB) || defined(FL_LPC15))
+#error "FastLED LPC1110/1112/1114/1115 (legacy M0 GPIO at 0x50000000) driver wiring is a Stage 4 follow-up to #2845. The modern LPC8xx-style fastpin in this file does not apply. Either target LPC11U24/U35 / LPC845 / LPC804 / LPC15xx, or contribute the legacy-GPIO fastpin via #2845."
+#endif
+
+#if defined(FL_LPC845) || defined(FL_LPC804) || \
+    defined(FL_LPC11_USB) || defined(FL_LPC15)
 
 namespace fl {
 
@@ -131,7 +142,7 @@ _FL_DEFPIN(28); _FL_DEFPIN(29); _FL_DEFPIN(30); _FL_DEFPIN(31);
 
 }  // namespace fl
 
-#endif  // FL_LPC845 || FL_LPC804
+#endif  // FL_LPC845 || FL_LPC804 || FL_LPC11_USB || FL_LPC15
 
 FL_DISABLE_WARNING_POP
 

--- a/src/platforms/arm/lpc/is_lpc.h
+++ b/src/platforms/arm/lpc/is_lpc.h
@@ -42,12 +42,30 @@
 // code path gated on FL_IS_ARM_M0_PLUS — that would mis-encode load/store
 // offsets on parts that lack the M0+ instruction extensions. The led
 // sysdefs follow-up will set FL_IS_ARM_M0 (not M0+) for this family.
-#if defined(__LPC11xx__) || defined(LPC11xx) || \
-    defined(CPU_LPC1114FBD48) || defined(CPU_LPC1114FHN33) || \
-    defined(CPU_LPC1115FBD48) || \
+// Sub-family split:
+//   FL_LPC11_USB    — LPC11U24 / LPC11U35 ("USB-capable" M0 parts). Modern
+//     GPIO controller at 0xA0000000 with the same DIR/MASK/PIN/SET/CLR/NOT
+//     layout as LPC8xx per UM10462 §9. Can reuse the LPC8xx fastpin + M0
+//     ASM clockless path (NOT M0+).
+//   FL_LPC11_LEGACY — LPC1110 / LPC1112 / LPC1114 / LPC1115. Legacy GPIO
+//     controller at 0x50000000 with 12-bit "masked access" semantics per
+//     UM10398 §12. Different fastpin layout from LPC8xx; driver wiring
+//     deferred — emit a clear `#error` so users on these chips know.
+#if defined(__LPC11Uxx__) || defined(LPC11Uxx) || \
     defined(CPU_LPC11U24FBD48) || defined(CPU_LPC11U24FHI33) || \
     defined(CPU_LPC11U35FBD48) || defined(CPU_LPC11U35FHI33) || \
     defined(CPU_LPC11U35FHN33)
+#define FL_LPC11_USB
+#endif
+
+#if defined(__LPC11xx__) || defined(LPC11xx) || \
+    defined(CPU_LPC1114FBD48) || defined(CPU_LPC1114FHN33) || \
+    defined(CPU_LPC1115FBD48)
+#define FL_LPC11_LEGACY
+#endif
+
+// Roll-up
+#if defined(FL_LPC11_USB) || defined(FL_LPC11_LEGACY)
 #define FL_LPC11
 #endif
 

--- a/src/platforms/arm/lpc/led_sysdefs_arm_lpc.h
+++ b/src/platforms/arm/lpc/led_sysdefs_arm_lpc.h
@@ -11,14 +11,27 @@
 #error "FL_IS_ARM must be defined before including this header. Ensure platforms/arm/is_arm.h is included first."
 #endif
 
+// CPU class per family:
+//   LPC8xx        — Cortex-M0+
+//   LPC11Uxx      — Cortex-M0   (NOT M0+)
+//   LPC15xx       — Cortex-M3   (different ISA, has DWT cycle counter)
+#if defined(FL_LPC845) || defined(FL_LPC804)
 #define FL_IS_ARM_M0_PLUS
+#elif defined(FL_LPC11_USB)
+#define FL_IS_ARM_M0
+#elif defined(FL_LPC15)
+#define FL_IS_ARM_M3
+#endif
 
-// The LPC8xx GPIO controller exposes SET[port] and CLR[port] at byte offsets
-// 0x2200 / 0x2280 from the controller base - far beyond the 5-bit imm5*4
-// encoding the M0/M0+ STR-immediate-offset instruction supports. The shared
-// inline-assembly clockless driver assumes both offsets fit a single
-// str-with-immediate; LPC cannot satisfy that, so route through the portable
-// C++ implementation which performs an indexed store instead.
+// The "modern" LPC GPIO controller (LPC8xx / LPC11Uxx / LPC15xx) exposes
+// SET[port] and CLR[port] at byte offsets 0x2200 / 0x2280 from the controller
+// base — far beyond the 5-bit imm5*4 encoding the M0/M0+ STR-immediate-offset
+// instruction supports. The shared inline-assembly clockless driver assumes
+// both offsets fit a single str-with-immediate; LPC cannot satisfy that, so
+// the M0/M0+ paths route through the portable C++ implementation which
+// performs an indexed store instead. (M3 isn't constrained by encoding —
+// full Thumb-2 accepts arbitrary offsets — but the same path applies
+// uniformly to keep the driver layout consistent across the LPC family.)
 #ifndef FASTLED_M0_USE_C_IMPLEMENTATION
 #define FASTLED_M0_USE_C_IMPLEMENTATION
 #endif
@@ -28,6 +41,16 @@
 #define F_CPU 30000000UL
 #elif defined(FL_LPC804)
 #define F_CPU 15000000UL
+#elif defined(FL_LPC11_USB)
+// LPC11U24 / LPC11U35 — IRC at boot is 12 MHz. PLL boost to 48 MHz is
+// possible; default kept conservative since SystemInit is the user's
+// responsibility on bare-metal builds.
+#define F_CPU 12000000UL
+#elif defined(FL_LPC15)
+// LPC15xx — IRC at boot is 12 MHz. PLL boost to 72 MHz on most variants.
+// Default kept conservative; user code can override F_CPU once a PLL is
+// brought up.
+#define F_CPU 12000000UL
 #endif
 #endif
 

--- a/src/platforms/arm/lpc/spi_arm_lpc.h
+++ b/src/platforms/arm/lpc/spi_arm_lpc.h
@@ -1,0 +1,258 @@
+// IWYU pragma: private
+
+#ifndef __INC_SPI_ARM_LPC_H
+#define __INC_SPI_ARM_LPC_H
+
+#include "fl/stl/compiler_control.h"
+#include "fl/stl/noexcept.h"
+#include "platforms/arm/is_arm.h"
+#include "platforms/arm/lpc/is_lpc.h"
+
+// Scoped to LPC8xx (LPC845 / LPC804). The SPI register layout below is the
+// LPC8xx "SPI" peripheral block per NXP UM11029 (LPC84x) / UM11065 (LPC80x)
+// chapter "SPI". LPC11xx and LPC15xx have their own SPI controllers with
+// different register layouts (UM10398 / UM10462 SSP for LPC11; LPC15 SPI is
+// closer to LPC8xx but uses different base addresses) — driver wiring for
+// those families is tracked in #2845 Stage 4.
+#if defined(FL_LPC845) || defined(FL_LPC804)
+
+FL_DISABLE_WARNING_PUSH
+FL_DISABLE_WARNING_DEPRECATED_REGISTER
+
+namespace fl {
+
+/// @file spi_arm_lpc.h
+/// @brief NXP LPC8xx hardware SPI driver — APA102 / SK9822 / WS2801 strip
+///        support via SPI master peripheral. Closes #2845 Stage 4 item 3.
+///
+/// Register layout per UM11029 section "SPI". Base addresses:
+///   LPC845 SPI0 @ 0x40058000
+///   LPC845 SPI1 @ 0x4005C000
+///   LPC804 SPI0 @ 0x40058000  (single SPI on LPC804)
+///
+/// Default targets SPI0; users can route to SPI1 by passing the
+/// corresponding base address as the `pSPIX` template parameter.
+///
+/// Hardware verification gated on #2845 Stage 3 (no LPC845 board has run
+/// FastLED-output LEDs yet). Bytes-on-the-wire correctness is implied by
+/// adherence to UM11029; AC timing on real silicon needs scope verification.
+
+#ifndef FL_LPC_SPI0_BASE
+#define FL_LPC_SPI0_BASE 0x40058000UL
+#endif
+#ifndef FL_LPC_SPI1_BASE
+#define FL_LPC_SPI1_BASE 0x4005C000UL
+#endif
+
+/// Minimal LPC8xx SPI controller view used by the FastLED SPI driver.
+/// Mirrors the relevant subset of MCUXpresso CMSIS LPC_SPI_Type; when the
+/// device header is on the include path the real type is what links.
+typedef struct {
+    volatile u32 CFG;          // 0x000 SPI configuration
+    volatile u32 DLY;          // 0x004 Delay between frames
+    volatile u32 STAT;         // 0x008 Status (R/W1C on some bits)
+    volatile u32 INTENSET;     // 0x00C Interrupt enable set
+    volatile u32 INTENCLR;     // 0x010 Interrupt enable clear
+    volatile u32 RXDAT;        // 0x014 Receive data
+    volatile u32 TXDATCTL;     // 0x018 Transmit data with control
+    volatile u32 TXDAT;        // 0x01C Transmit data only
+    volatile u32 TXCTL;        // 0x020 Transmit control only
+    volatile u32 DIV;          // 0x024 Clock divider (12-bit)
+    volatile u32 INTSTAT;      // 0x028 Interrupt status
+} FL_LPC_SPI_Type;
+
+// SPI register bit definitions (UM11029)
+#define FL_LPC_SPI_CFG_ENABLE         (1u << 0)
+#define FL_LPC_SPI_CFG_MASTER         (1u << 2)
+#define FL_LPC_SPI_CFG_LSBF           (1u << 3)   // 0 = MSB first
+#define FL_LPC_SPI_CFG_CPHA           (1u << 4)
+#define FL_LPC_SPI_CFG_CPOL           (1u << 5)
+#define FL_LPC_SPI_CFG_LOOP           (1u << 7)
+#define FL_LPC_SPI_CFG_SPOL0          (1u << 8)
+
+#define FL_LPC_SPI_STAT_RXRDY         (1u << 0)
+#define FL_LPC_SPI_STAT_TXRDY         (1u << 1)
+#define FL_LPC_SPI_STAT_RXOV          (1u << 2)
+#define FL_LPC_SPI_STAT_TXUR          (1u << 3)
+#define FL_LPC_SPI_STAT_SSA           (1u << 4)
+#define FL_LPC_SPI_STAT_SSD           (1u << 5)
+#define FL_LPC_SPI_STAT_STALLED       (1u << 6)
+#define FL_LPC_SPI_STAT_ENDTRANSFER   (1u << 7)
+#define FL_LPC_SPI_STAT_MSTIDLE       (1u << 8)
+
+// TXDATCTL layout: bits [15:0] = data, [19:16] = TXSSEL, [20] = EOT,
+// [21] = EOF, [22] = RXIGNORE, [27:24] = LEN (length-1, 0..15 → 1..16 bits)
+#define FL_LPC_SPI_TXCTL_LEN_8BIT     (7u << 24)
+#define FL_LPC_SPI_TXCTL_EOT          (1u << 20)
+#define FL_LPC_SPI_TXCTL_RXIGNORE     (1u << 22)
+
+#define ARM_HARDWARE_SPI
+
+/// @brief LPC8xx hardware SPI output for FastLED clocked strips.
+/// @tparam _DATA_PIN  Pin index for MOSI (must be SWM-routed to SPIx_MOSI)
+/// @tparam _CLOCK_PIN Pin index for SCK  (must be SWM-routed to SPIx_SCK)
+/// @tparam _SPI_CLOCK_DIVIDER Approximate clock divider (host clock / this)
+/// @tparam pSPIX      Peripheral base address (FL_LPC_SPI0_BASE or
+///                    FL_LPC_SPI1_BASE)
+///
+/// Pin routing through the LPC8xx Switch Matrix (SWM) is done by the user's
+/// `SystemInit` / board setup code — this driver assumes MOSI/SCK have been
+/// routed to the requested pins before `init()` is called. Same pattern as
+/// the Stage 2a bit-bang clockless driver, which relies on FastPin's GPIO
+/// view rather than reconfiguring IOCON.
+template <u8 _DATA_PIN, u8 _CLOCK_PIN, u32 _SPI_CLOCK_DIVIDER,
+          u32 pSPIX = FL_LPC_SPI0_BASE>
+class ARMHardwareSPIOutput {
+    Selectable *mPSelect;
+
+    static inline FL_LPC_SPI_Type* spi_block() __attribute__((always_inline)) {
+        return reinterpret_cast<FL_LPC_SPI_Type*>(pSPIX);
+    }
+
+public:
+    ARMHardwareSPIOutput() : mPSelect(nullptr) {}
+    explicit ARMHardwareSPIOutput(Selectable *pSelect) : mPSelect(pSelect) {}
+
+    void setSelect(Selectable *pSelect) FL_NOEXCEPT { mPSelect = pSelect; }
+
+    /// Initialize SPI peripheral as master, 8-bit, MSB-first, CPOL=0, CPHA=0.
+    /// The user's startup code is responsible for:
+    ///   (a) enabling the SPI clock in SYSCON->SYSAHBCLKCTRL[11] / [12]
+    ///       (SPI0 / SPI1) on LPC845, or SYSCON->SYSAHBCLKCTRL0[11] on LPC804
+    ///   (b) routing MOSI/SCK through SWM to the requested pins
+    void init() FL_NOEXCEPT {
+        FastPin<_DATA_PIN>::setOutput();
+        FastPin<_CLOCK_PIN>::setOutput();
+
+        FL_LPC_SPI_Type *spi = spi_block();
+
+        // Disable before reconfig
+        spi->CFG = 0;
+
+        // Clock divider. LPC8xx SPI clock = peripheral clock / (DIV + 1).
+        // _SPI_CLOCK_DIVIDER is interpreted as the same / (DIV+1) value,
+        // matching the Teensy LC driver convention.
+        u32 div = (_SPI_CLOCK_DIVIDER > 1) ? (_SPI_CLOCK_DIVIDER - 1) : 0;
+        if (div > 0xFFF) div = 0xFFF;  // 12-bit field
+        spi->DIV = div;
+
+        // Master mode, MSB first, mode 0 (CPOL=0, CPHA=0)
+        spi->CFG = FL_LPC_SPI_CFG_ENABLE | FL_LPC_SPI_CFG_MASTER;
+    }
+
+    void inline select() FL_NOEXCEPT __attribute__((always_inline)) {
+        if (mPSelect != nullptr) { mPSelect->select(); }
+    }
+
+    void inline release() FL_NOEXCEPT __attribute__((always_inline)) {
+        waitFully();
+        if (mPSelect != nullptr) { mPSelect->release(); }
+    }
+
+    void endTransaction() FL_NOEXCEPT { release(); }
+
+    /// Wait until TX FIFO can accept another byte.
+    static void wait() __attribute__((always_inline)) {
+        while (!(spi_block()->STAT & FL_LPC_SPI_STAT_TXRDY)) {}
+    }
+
+    /// Wait until the master is fully idle (transfer drained).
+    void waitFully() FL_NOEXCEPT {
+        while (!(spi_block()->STAT & FL_LPC_SPI_STAT_MSTIDLE)) {}
+    }
+
+    /// Per-bit write — not the most efficient but required by the SPI base
+    /// API used for sm16716-style strips. APA102 / SK9822 don't exercise
+    /// this path (start bit is part of the byte stream).
+    template <u8 BIT>
+    inline static void writeBit(u8 b) FL_NOEXCEPT {
+        wait();
+        FL_LPC_SPI_Type *spi = spi_block();
+        spi->TXDATCTL = (b & (1u << BIT)) ? 1 : 0;
+    }
+
+    /// Write a single 8-bit byte. Caller responsible for waiting on prior
+    /// fill; this primitive only writes the TX data register.
+    static void writeByte(u8 b) __attribute__((always_inline)) {
+        wait();
+        FL_LPC_SPI_Type *spi = spi_block();
+        // TXDATCTL with LEN=7 (8-bit transfer) and RX ignored.
+        spi->TXDATCTL = static_cast<u32>(b) | FL_LPC_SPI_TXCTL_LEN_8BIT |
+                        FL_LPC_SPI_TXCTL_RXIGNORE;
+    }
+
+    static void writeWord(u16 w) __attribute__((always_inline)) {
+        writeByte(static_cast<u8>(w >> 8));
+        writeByte(static_cast<u8>(w & 0xFF));
+    }
+
+    /// Write `len` copies of `value` over SPI.
+    static void writeBytesValueRaw(u8 value, int len) FL_NOEXCEPT {
+        while (len--) { writeByte(value); }
+    }
+
+    /// Bracketed variant — select + write + flush + release.
+    void writeBytesValue(u8 value, int len) FL_NOEXCEPT {
+        select();
+        writeBytesValueRaw(value, len);
+        waitFully();
+        release();
+    }
+
+    /// Bracketed bulk byte write with optional per-byte adjuster D.
+    template <class D>
+    void writeBytes(FASTLED_REGISTER u8 *data, int len) FL_NOEXCEPT {
+        u8 *end = data + len;
+        select();
+        while (data != end) {
+            writeByte(D::adjust(*data++));
+        }
+        D::postBlock(len);
+        waitFully();
+        release();
+    }
+
+    void writeBytes(FASTLED_REGISTER u8 *data, int len) {
+        writeBytes<DATA_NOP>(data, len);
+    }
+
+    /// Bracketed pixel-controller path used for APA102 / SK9822 / WS2801.
+    /// Handles the optional FLAG_START_BIT prefix (APA102's 0xFF brightness
+    /// byte per LED) via writeBit<0>.
+    template <u8 FLAGS, class D, EOrder RGB_ORDER>
+    void writePixels(PixelController<RGB_ORDER> pixels, void* /*context*/ = nullptr) FL_NOEXCEPT {
+        int len = pixels.mLen;
+
+        select();
+        while (pixels.has(1)) {
+            if (FLAGS & FLAG_START_BIT) {
+                writeBit<0>(1);
+                writeByte(D::adjust(pixels.loadAndScale0()));
+                writeByte(D::adjust(pixels.loadAndScale1()));
+                writeByte(D::adjust(pixels.loadAndScale2()));
+            } else {
+                writeByte(D::adjust(pixels.loadAndScale0()));
+                writeByte(D::adjust(pixels.loadAndScale1()));
+                writeByte(D::adjust(pixels.loadAndScale2()));
+            }
+
+            pixels.advanceData();
+            pixels.stepDithering();
+        }
+        D::postBlock(len);
+        waitFully();
+        release();
+    }
+
+    /// Finalize transmission. The MSTIDLE wait in waitFully() already
+    /// drains the FIFO; no additional flush is needed.
+    static void finalizeTransmission() FL_NOEXCEPT {}
+};
+
+}  // namespace fl
+
+FL_DISABLE_WARNING_POP
+
+#endif  // FL_LPC845 || FL_LPC804
+
+#endif  // __INC_SPI_ARM_LPC_H


### PR DESCRIPTION
## Summary

Single combined PR for the AI-shippable portion of meta [#2845](https://github.com/FastLED/FastLED/issues/2845). Closes Stage 4 items **1, 2, and 3** in one shot. Stage 3 (entire stage) and Stage 4 items 4-6 are explicitly out of scope below.

### What landed

**Stage 4 item 1 — LPC11Uxx clockless driver wiring**

Splits the previous `FL_LPC11` umbrella into:
- `FL_LPC11_USB` — LPC11U24 / LPC11U35 (modern GPIO at 0xA0000000, same controller layout as LPC8xx per UM10462 §9)
- `FL_LPC11_LEGACY` — LPC1110 / 1112 / 1114 / 1115 (legacy GPIO at 0x50000000 with 12-bit masked-access semantics per UM10398 §12)

The USB-series chips reuse the LPC8xx fastpin + C++ clockless driver unchanged: the GPIO controllers are register-for-register identical. The CPU-class difference (M0 vs M0+) is handled in `led_sysdefs_arm_lpc.h` by setting `FL_IS_ARM_M0` instead of `FL_IS_ARM_M0_PLUS`; the clockless path was already running through `FASTLED_M0_USE_C_IMPLEMENTATION` so the M0+-specific STR-immediate encoding limit doesn't come into play.

Legacy parts get a clear `#error` so users on LPC1114 / LPC1115 know they're not yet supported, instead of silently mis-encoding writes against the wrong GPIO base.

**Stage 4 item 2 — LPC15xx clockless driver wiring**

Same approach: UM11074 confirms LPC15xx ships the same modern 0xA0000000 GPIO controller as LPC8xx. The CPU-class gate widens to set `FL_IS_ARM_M3`; the fastpin + clockless headers cover this family unchanged.

**Stage 4 item 3 — APA102 / SK9822 / WS2801 hardware SPI driver for LPC8xx**

New `src/platforms/arm/lpc/spi_arm_lpc.h` — an `ARMHardwareSPIOutput` template targeting the LPC8xx SPI peripheral per UM11029. Master / MSB-first / mode-0 / 8-bit transfers. SPI0 default; routable to SPI1 via the `pSPIX` template arg. The `writePixels` path handles APA102's `FLAG_START_BIT` brightness prefix, matching the Teensy-LC SPI driver's surface.

### What's NOT in this PR (and why)

**Stage 3 — entire stage.** The meta itself states verbatim: *\"Hardware required — this stage cannot be completed by AI agents alone. Needs maintainer / @phatpaul / community member with an LPCXpresso845 (or LPC824 Lite / LPC845 Breakout Board) and a scope.\"* SystemInit at 30 MHz, scope-measured WS2812 blink, AutoResearch UART bring-up, fbuild CI `continue-on-error` flip — these all need physical silicon. Code-only changes here would be unverifiable and risky.

**Stage 4 item 1 (legacy LPC11xx).** LPC1114 / LPC1115 use the legacy GPIO controller at 0x50000000 with a different register access pattern. Wiring that needs its own fastpin layout — a separate PR with its own scoping pass.

**Stage 4 item 4 (multi-strip parallel).** The meta gates this on Stage 2c PWM+DMA hardware validation: *\"Stage 2c (#2842) needs to land first for the PWM+DMA infrastructure to exist; multi-strip is a configuration extension on top.\"* Hardware-gated.

**Stage 4 item 5 (PlatformIO upstream donation).** Not a FastLED-repo deliverable.

**Stage 4 item 6 (`fl::set_*` settings).** Design-pending — the meta says *\"If LPC users need clock-speed overrides...\"*. No concrete requirement from real users yet.

## Files changed

| File | Change |
|---|---|
| `src/platforms/arm/lpc/is_lpc.h` | Split `FL_LPC11` → `FL_LPC11_USB` + `FL_LPC11_LEGACY` |
| `src/platforms/arm/lpc/led_sysdefs_arm_lpc.h` | Per-family CPU class + IRC F_CPU defaults |
| `src/platforms/arm/lpc/fastpin_arm_lpc.h` | Widen gate to LPC11U / LPC15; `#error` for legacy LPC11xx |
| `src/platforms/arm/lpc/clockless_arm_lpc.h` | Widen gate to LPC11U / LPC15 (driver body unchanged) |
| `src/platforms/arm/lpc/fastled_arm_lpc.h` | Drop old `#error`; document new wiring; include `spi_arm_lpc.h` |
| `src/platforms/arm/lpc/spi_arm_lpc.h` | **NEW** — APA102/SK9822/WS2801 SPI driver |
| `src/platforms/arm/lpc/README.md` | Updated support matrix + driver list |

## Test plan

- [x] `bash lint --cpp` — clean
- [x] `bash test --cpp` — 310/310 pass (host build)
- [ ] CI on this PR — LPC845 / LPC804 fbuild jobs should stay green; the SPI / clockless wiring is unreferenced by the example matrix unless user code instantiates the new controllers
- [ ] **Hardware bring-up (Stage 3, not blocking this PR)** — Real LPC845 / LPC11U / LPC15 board running WS2812 + APA102 examples via fbuild, scope-measured for timing correctness

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hardware SPI output for modern LPC8xx parts (LPC845/LPC804) to drive SPI LED strips with master/MSB-first/mode-0/8-bit behavior.
  * APA102/SK9822/WS2801 pixel support via the new SPI path.

* **Compatibility**
  * Broader LPC family support: expanded GPIO/clockless coverage to additional LPC11 USB and LPC15 variants while gating legacy LPC11 parts.

* **Documentation**
  * Expanded platform docs: SPI configuration, pin-routing guidance, roadmap/implementation mapping, and legacy-device notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->