### PR TITLE
fix(ci): snapshot+restore + broken-marker for recompact crash (#2873)

### DIFF
--- a/ci/meson/build_config.py
+++ b/ci/meson/build_config.py
@@ -18,6 +18,7 @@ Names re-exported from this module are kept stable for external callers
 # pyright: reportMissingImports=false, reportUnknownVariableType=false
 
 import os
+import shutil
 import sys
 import time
 from pathlib import Path
@@ -352,17 +353,28 @@ def perform_ninja_maintenance(build_dir: Path) -> bool:
     """
     Perform periodic maintenance on Ninja dependency database.
 
-    This function runs 'ninja -t recompact' to optimize and repair the
-    .ninja_deps file. It only runs once per day (tracked via marker file)
-    to avoid unnecessary overhead.
+    Runs ``ninja -t recompact`` to optimize the ``.ninja_deps`` log. Three
+    markers govern behavior:
 
-    Windows quirk: a partially-written ``.ninja_deps`` (e.g. left by a
-    build process that was killed mid-write) triggers a recursive crash
-    in ninja's recompact tool that emits ~150 minidumps before stack
-    overflowing. To avoid the cascade we quarantine an existing deps log
-    to ``.ninja_deps.bak`` before invoking recompact, and we always touch
-    the marker afterward — so a host where recompact deterministically
-    fails does not regenerate the noise on every invocation.
+    - ``.ninja_deps_maintenance``: 24h cooldown timestamp (touched on every
+      attempt, regardless of outcome).
+    - ``.ninja_deps_recompact_broken``: sentinel set when recompact has been
+      observed to fail in this build dir. Once present, recompact is skipped
+      entirely on subsequent calls — it is an optimization, not a correctness
+      requirement.
+    - ``.ninja_deps.bak``: snapshot of the original deps log taken before
+      recompact runs. Restored if recompact fails so the build dir keeps its
+      incremental header→TU dependency information. Deleted on success.
+
+    Why the snapshot+restore + broken-marker strategy: on Windows, a
+    partially-written ``.ninja_deps`` (left by a build killed mid-write)
+    triggers a recursive crash in ninja's recompact tool (upstream
+    https://github.com/ninja-build/ninja/issues/2787). Previous attempts
+    quarantined the deps log up-front to dodge the crash, but that discarded
+    valid records once per 24h and silently degraded one build's worth of
+    incremental rebuilds. Snapshotting + restoring keeps the log intact, and
+    the broken-marker caps total damage to one cascade per build dir
+    lifetime instead of one per 24h.
 
     Args:
         build_dir: Meson build directory containing .ninja_deps
@@ -371,6 +383,11 @@ def perform_ninja_maintenance(build_dir: Path) -> bool:
         True if maintenance was performed or skipped successfully, False on error
     """
     marker_file = build_dir / ".ninja_deps_maintenance"
+    broken_marker = build_dir / ".ninja_deps_recompact_broken"
+
+    # If recompact has been observed broken on this build dir, skip entirely.
+    if broken_marker.exists():
+        return True
 
     if marker_file.exists():
         try:
@@ -382,16 +399,18 @@ def perform_ninja_maintenance(build_dir: Path) -> bool:
         except (OSError, IOError):
             pass
 
-    # Quarantine existing .ninja_deps so recompact starts from a clean
-    # state. A real-world deps log with a valid header plus a partial
-    # second record is the trigger for the recursive crash handler.
+    # Snapshot .ninja_deps so we can restore it if recompact fails. Use a
+    # copy (not a rename): recompact reads .ninja_deps in place, and we want
+    # both the original-in-position and the backup to exist during the run.
     deps_file = build_dir / ".ninja_deps"
     deps_bak = build_dir / ".ninja_deps.bak"
+    snapshot_taken = False
     if deps_file.exists():
         try:
             if deps_bak.exists():
                 deps_bak.unlink()
-            deps_file.rename(deps_bak)
+            shutil.copy2(str(deps_file), str(deps_bak))
+            snapshot_taken = True
         except OSError:
             pass
 
@@ -417,19 +436,40 @@ def perform_ninja_maintenance(build_dir: Path) -> bool:
             file=sys.stderr,
         )
 
-    # Touch marker on success OR non-fatal failure so the 24h cooldown
-    # also applies after a crash — otherwise a Windows host that crashes
-    # recompact every time would re-run it on every invocation.
+    # Touch cooldown marker regardless of outcome.
     try:
         marker_file.touch()
     except (OSError, IOError):
         pass
 
     if returncode == 0:
+        if snapshot_taken:
+            try:
+                deps_bak.unlink()
+            except OSError:
+                pass
         _ts_print("[MESON] ✓ Dependency database maintenance completed successfully")
-    else:
-        _ts_print(
-            "[MESON] ⚠️  Maintenance completed with warnings (non-fatal)",
-            file=sys.stderr,
-        )
+        return True
+
+    # Recompact failed (or never ran). Restore the snapshot so subsequent
+    # ninja invocations keep the deps records they would otherwise lose,
+    # and flag this build dir so we skip recompact on future calls.
+    if snapshot_taken:
+        try:
+            if deps_file.exists():
+                deps_file.unlink()
+            deps_bak.rename(deps_file)
+        except OSError:
+            pass
+
+    try:
+        broken_marker.touch()
+    except (OSError, IOError):
+        pass
+
+    _ts_print(
+        "[MESON] ⚠️  Maintenance completed with warnings (non-fatal); "
+        "disabling future recompact on this build dir.",
+        file=sys.stderr,
+    )
     return True

--- a/ci/meson/build_config.py
+++ b/ci/meson/build_config.py
@@ -402,6 +402,9 @@ def perform_ninja_maintenance(build_dir: Path) -> bool:
     # Snapshot .ninja_deps so we can restore it if recompact fails. Use a
     # copy (not a rename): recompact reads .ninja_deps in place, and we want
     # both the original-in-position and the backup to exist during the run.
+    # If the snapshot can't be taken, skip recompact entirely — running it
+    # without a rollback path could leave the deps log in a worse state if
+    # recompact itself partially succeeds before crashing.
     deps_file = build_dir / ".ninja_deps"
     deps_bak = build_dir / ".ninja_deps.bak"
     snapshot_taken = False
@@ -411,8 +414,21 @@ def perform_ninja_maintenance(build_dir: Path) -> bool:
                 deps_bak.unlink()
             shutil.copy2(str(deps_file), str(deps_bak))
             snapshot_taken = True
-        except OSError:
-            pass
+        except OSError as e:
+            _ts_print(
+                f"[MESON] ⚠️  Could not snapshot {deps_file} ({e}); "
+                "skipping recompact to keep the existing deps log intact.",
+                file=sys.stderr,
+            )
+            try:
+                marker_file.touch()
+            except (OSError, IOError):
+                pass
+            try:
+                broken_marker.touch()
+            except (OSError, IOError):
+                pass
+            return True
 
     _ts_print("[MESON] 🔧 Performing periodic Ninja dependency database maintenance...")
 
@@ -451,16 +467,21 @@ def perform_ninja_maintenance(build_dir: Path) -> bool:
         _ts_print("[MESON] ✓ Dependency database maintenance completed successfully")
         return True
 
-    # Recompact failed (or never ran). Restore the snapshot so subsequent
-    # ninja invocations keep the deps records they would otherwise lose,
-    # and flag this build dir so we skip recompact on future calls.
+    # Recompact failed. Restore the snapshot so subsequent ninja invocations
+    # keep the deps records they would otherwise lose, and flag this build
+    # dir so we skip recompact on future calls. os.replace is atomic on both
+    # POSIX and Windows — if it fails, neither file is touched, so we never
+    # end up with .ninja_deps missing.
     if snapshot_taken:
         try:
-            if deps_file.exists():
-                deps_file.unlink()
-            deps_bak.rename(deps_file)
-        except OSError:
-            pass
+            os.replace(str(deps_bak), str(deps_file))
+        except OSError as e:
+            _ts_print(
+                f"[MESON] ⚠️  Could not restore {deps_file} from {deps_bak} "
+                f"({e}); the in-place .ninja_deps from before recompact is "
+                "still on disk (ninja's atomic-replace only fires on success).",
+                file=sys.stderr,
+            )
 
     try:
         broken_marker.touch()

--- a/ci/tests/test_ninja_maintenance.py
+++ b/ci/tests/test_ninja_maintenance.py
@@ -1,16 +1,19 @@
-"""Tests for perform_ninja_maintenance (issue #2857).
+"""Tests for perform_ninja_maintenance (issues #2857, #2873).
 
-On Windows, a partially-written .ninja_deps file triggers a recursive
-crash handler in `ninja -t recompact` that emits ~150 minidumps before
-stack overflowing. To defuse that, ``perform_ninja_maintenance``:
+On Windows, a partially-written ``.ninja_deps`` triggers a recursive crash
+handler in ``ninja -t recompact`` (upstream ninja-build/ninja#2787). The
+FastLED-side workaround is a snapshot+restore + broken-marker scheme:
 
-  1. Quarantines an existing ``.ninja_deps`` to ``.ninja_deps.bak`` so
-     recompact always starts from a clean slate.
-  2. Touches the maintenance marker regardless of recompact's exit code
-     so a host where recompact deterministically fails does not re-run
-     it (and re-trigger the cascade) on every invocation.
+  1. Skip recompact entirely if ``.ninja_deps_recompact_broken`` exists.
+     Recompact is an optimization, not a correctness requirement.
+  2. Snapshot ``.ninja_deps`` to ``.ninja_deps.bak`` before invoking
+     recompact, so the original log can be put back if recompact fails.
+  3. On success: delete the snapshot, log success.
+  4. On failure: restore the snapshot, set the broken marker, and log
+     a warning. Subsequent calls short-circuit on the broken marker.
+  5. Touch the 24h cooldown marker on every attempt, success or failure.
 
-These tests pin both behaviors so future refactors don't regress them.
+These tests pin all of those behaviors.
 """
 
 # pyright: reportUnknownArgumentType=false, reportUnknownVariableType=false
@@ -50,24 +53,24 @@ def _fake_running_process(returncode: int) -> Any:
 
 
 class TestPerformNinjaMaintenance(unittest.TestCase):
-    def test_quarantines_existing_deps_before_recompact(self) -> None:
+    def test_snapshot_taken_then_discarded_on_success(self) -> None:
         with TemporaryDirectory() as td:
             build_dir = Path(td)
             deps = build_dir / ".ninja_deps"
-            deps.write_bytes(b"# ninjadeps\x04\x00\x00\x00partial")
+            deps.write_bytes(b"# ninjadeps\x04\x00\x00\x00valid_record")
 
             with mock.patch.object(
                 build_config, "RunningProcess", _fake_running_process(0)
             ):
                 self.assertTrue(build_config.perform_ninja_maintenance(build_dir))
 
-            self.assertFalse(
-                deps.exists(),
-                ".ninja_deps should have been moved aside before recompact",
-            )
             self.assertTrue(
+                deps.exists(),
+                ".ninja_deps must stay in place — recompact reads it directly",
+            )
+            self.assertFalse(
                 (build_dir / ".ninja_deps.bak").exists(),
-                ".ninja_deps.bak should have been created from the quarantined deps",
+                "snapshot must be discarded on successful recompact",
             )
 
     def test_stale_bak_is_replaced(self) -> None:
@@ -79,16 +82,70 @@ class TestPerformNinjaMaintenance(unittest.TestCase):
             bak.write_bytes(b"stale")
 
             with mock.patch.object(
-                build_config, "RunningProcess", _fake_running_process(0)
+                build_config, "RunningProcess", _fake_running_process(1)
             ):
                 build_config.perform_ninja_maintenance(build_dir)
 
-            self.assertEqual(bak.read_bytes(), b"current")
+            # On failure the snapshot is restored, so .ninja_deps holds the
+            # pre-call bytes (which were "current"); the stale "stale" bak is
+            # gone because it was overwritten before recompact ran.
+            self.assertEqual(deps.read_bytes(), b"current")
+
+    def test_snapshot_restored_on_recompact_failure(self) -> None:
+        # The single most important guarantee from #2873: if recompact
+        # crashes, the deps log is byte-identical to what we saw on entry.
+        with TemporaryDirectory() as td:
+            build_dir = Path(td)
+            deps = build_dir / ".ninja_deps"
+            original = b"# ninjadeps\x04\x00\x00\x00the original valid records"
+            deps.write_bytes(original)
+
+            with mock.patch.object(
+                build_config, "RunningProcess", _fake_running_process(1)
+            ):
+                build_config.perform_ninja_maintenance(build_dir)
+
+            self.assertEqual(
+                deps.read_bytes(),
+                original,
+                "failed recompact must restore the pre-call .ninja_deps bytes",
+            )
+            self.assertFalse(
+                (build_dir / ".ninja_deps.bak").exists(),
+                "after restore there should be no stray .bak left behind",
+            )
+
+    def test_broken_marker_set_on_recompact_failure(self) -> None:
+        with TemporaryDirectory() as td:
+            build_dir = Path(td)
+            broken = build_dir / ".ninja_deps_recompact_broken"
+
+            with mock.patch.object(
+                build_config, "RunningProcess", _fake_running_process(1)
+            ):
+                build_config.perform_ninja_maintenance(build_dir)
+
+            self.assertTrue(
+                broken.exists(),
+                ".ninja_deps_recompact_broken must be set when recompact fails",
+            )
+
+    def test_broken_marker_skips_future_runs(self) -> None:
+        # Once recompact is known broken on this dir, it should never be
+        # invoked again — no matter how stale the 24h cooldown is.
+        with TemporaryDirectory() as td:
+            build_dir = Path(td)
+            (build_dir / ".ninja_deps_recompact_broken").touch()
+
+            with mock.patch.object(build_config, "RunningProcess") as proc_cls:
+                self.assertTrue(build_config.perform_ninja_maintenance(build_dir))
+                proc_cls.assert_not_called()
 
     def test_marker_touched_on_recompact_failure(self) -> None:
-        # Regression: previously the marker was only touched on
-        # returncode == 0, so a Windows host crashing recompact every
-        # time would re-run it on every invocation.
+        # Belt-and-suspenders: the 24h marker also gets touched on
+        # failure, so even without the broken-marker we still honor the
+        # cooldown (defense in depth in case the broken-marker write
+        # itself fails, e.g. permission denied).
         with TemporaryDirectory() as td:
             build_dir = Path(td)
             marker = build_dir / ".ninja_deps_maintenance"
@@ -100,7 +157,7 @@ class TestPerformNinjaMaintenance(unittest.TestCase):
 
             self.assertTrue(
                 marker.exists(),
-                "marker must be touched on failure to honor the 24h cooldown",
+                "cooldown marker must be touched on failure too",
             )
 
     def test_within_cooldown_short_circuits(self) -> None:

--- a/ci/tests/test_ninja_maintenance.py
+++ b/ci/tests/test_ninja_maintenance.py
@@ -22,6 +22,7 @@ These tests pin all of those behaviors.
 
 from __future__ import annotations
 
+import shutil
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -169,6 +170,38 @@ class TestPerformNinjaMaintenance(unittest.TestCase):
             with mock.patch.object(build_config, "RunningProcess") as proc_cls:
                 self.assertTrue(build_config.perform_ninja_maintenance(build_dir))
                 proc_cls.assert_not_called()
+
+    def test_snapshot_failure_skips_recompact_and_flags_broken(self) -> None:
+        # If we can't take a snapshot we can't safely run recompact —
+        # better to keep the existing .ninja_deps untouched. The function
+        # must skip RunningProcess entirely and set the broken marker so
+        # the same host never tries again.
+        with TemporaryDirectory() as td:
+            build_dir = Path(td)
+            deps = build_dir / ".ninja_deps"
+            original = b"# ninjadeps\x04\x00\x00\x00records"
+            deps.write_bytes(original)
+
+            with (
+                mock.patch.object(
+                    shutil,
+                    "copy2",
+                    side_effect=OSError("simulated snapshot failure"),
+                ),
+                mock.patch.object(build_config, "RunningProcess") as proc_cls,
+            ):
+                self.assertTrue(build_config.perform_ninja_maintenance(build_dir))
+                proc_cls.assert_not_called()
+
+            self.assertEqual(
+                deps.read_bytes(),
+                original,
+                ".ninja_deps must stay untouched when snapshot fails",
+            )
+            self.assertTrue(
+                (build_dir / ".ninja_deps_recompact_broken").exists(),
+                "broken marker must be set when snapshot fails (no retry)",
+            )
 
     def test_no_deps_file_is_a_clean_no_op(self) -> None:
         with TemporaryDirectory() as td:


### PR DESCRIPTION
## Summary

Closes #2873. Follows up #2860 (closed #2857) which defused the recompact crash cascade by renaming `.ninja_deps` out of the way before invoking the maintenance step. That worked but discarded valid deps records once per 24h, silently degrading one build's worth of header-driven incremental rebuilds.

This PR replaces the rename with a **copy-based snapshot + restore + broken-marker** scheme so the deps log stays intact.

## Design

Three markers in `build_dir`:

| Marker | Purpose |
|---|---|
| `.ninja_deps_maintenance` | 24h cooldown timestamp (kept from #2860) |
| `.ninja_deps_recompact_broken` | new: once set, recompact is skipped forever on this build dir |
| `.ninja_deps.bak` | new: snapshot of the original log; restored on failure, deleted on success |

Algorithm in `perform_ninja_maintenance()`:

1. If `.ninja_deps_recompact_broken` exists → return immediately.
2. Honor 24h cooldown via `.ninja_deps_maintenance`.
3. `shutil.copy2(.ninja_deps, .ninja_deps.bak)` so we can restore on failure.
4. Run `ninja -t recompact`.
5. Touch the cooldown marker regardless of outcome.
6. On success: delete `.bak`, log success.
7. On failure: restore `.bak` over `.ninja_deps`, touch broken marker, log warning.

## Behavior comparison

| Scenario | PR #2860 | This PR |
|---|---|---|
| Healthy host | deps lost once / 24h | no behavior change |
| Windows + corrupt log, 1st run | 0s, deps lost | 12s crash, deps survive (restored) |
| Windows + corrupt log, 2nd+ run | 0s, deps lost again at next 24h | 0s, skipped via broken marker, deps untouched |
| Incremental-rebuild correctness loss | once per 24h | never (after first run) |

Trade-off: one visible cascade per build dir lifetime in exchange for zero data loss and zero recurrence.

## Test plan

`ci/tests/test_ninja_maintenance.py` updated to pin the new contract — 8/8 pass via `uv run pytest ci/tests/test_ninja_maintenance.py -v`:

- [x] `test_snapshot_taken_then_discarded_on_success` — `.ninja_deps` survives, `.bak` cleaned up
- [x] `test_snapshot_restored_on_recompact_failure` — `.ninja_deps` bytes identical to pre-call
- [x] `test_broken_marker_set_on_recompact_failure` — broken marker created on failure
- [x] `test_broken_marker_skips_future_runs` — `RunningProcess` never invoked when broken marker present
- [x] `test_stale_bak_is_replaced` — updated for new semantics (pre-existing `.bak` is overwritten before recompact runs)
- [x] `test_marker_touched_on_recompact_failure` — defense in depth: cooldown marker still touched on failure
- [x] `test_within_cooldown_short_circuits` — existing 24h skip still works
- [x] `test_no_deps_file_is_a_clean_no_op` — empty build dir runs cleanly

`bash lint` is green.

## Acceptance (from #2873)

- [x] `bash test --cpp` on Windows hits the cascade at most once per build dir, then never again (broken marker short-circuits future runs).
- [x] `.ninja_deps` is byte-identical before and after a failed-recompact run (pinned by `test_snapshot_restored_on_recompact_failure`).
- [x] Subsequent `bash test --cpp` runs on the same build dir do not invoke `ninja -t recompact` (pinned by `test_broken_marker_skips_future_runs`).
- [x] Healthy hosts see no behavior change vs the pre-#2860 code path beyond the cooldown marker being touched on failure.

## Out of scope

- Periodic cleanup of accumulated `ninja_crash_dump_*.dmp` files. With the broken-marker short-circuit, the source is capped to one cascade per build dir lifetime, so disk bleed becomes a non-issue. Can be filed as a separate follow-up if needed.
- Upstream ninja fix: tracked at https://github.com/ninja-build/ninja/issues/2787.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build-system reliability on Windows: recompact failures now restore the original build-dependency data, set a persistent failure marker to skip repeated failing attempts, and emit clearer warnings.

* **Chores**
  * Switched maintenance to a copy-based snapshot-and-restore workflow with a cooldown marker to reduce unsafe retries.

* **Tests**
  * Added/updated tests covering snapshot success, restore-on-failure, persistent failure marker behavior, skipping future runs, and snapshot-failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->