### PR TITLE
ci(meson): opt in to ZCCACHE_PROBE_BYPASS=1 for configure-phase probes (#2739)

### DIFF
--- a/ci/meson/runner_helpers.py
+++ b/ci/meson/runner_helpers.py
@@ -374,6 +374,13 @@ def _start_zccache_session(build_dir: Path) -> None:
     if "ZCCACHE_LINK_DEPLOY_CMD" not in os.environ:
         os.environ["ZCCACHE_LINK_DEPLOY_CMD"] = "clang-tool-chain-libdeploy"
     os.environ.setdefault("ZCCACHE_STRICT_PATHS", "absolute")
+    # Opt in to zccache's CLI-side probe-bypass fast-path for meson
+    # configure-phase try-compiles (zackees/zccache#625, #633, #636 — bench
+    # in #636 shows 7-10s saved per configure run). Not a disable: per-call
+    # routing, only sub-4 KiB single-source no-PCH no-@rsp invocations
+    # bypass; production TUs continue to use the cache. setdefault keeps any
+    # user override intact; older zccache without this env var ignores it.
+    os.environ.setdefault("ZCCACHE_PROBE_BYPASS", "1")
 
     zccache_bin = _find_zccache_binary()
     if not zccache_bin:


### PR DESCRIPTION
## Summary

Closes #2739. Adds `os.environ.setdefault("ZCCACHE_PROBE_BYPASS", "1")` next to the existing `ZCCACHE_STRICT_PATHS` opt-in in `_start_zccache_session()`. This opts FastLED in to zccache's CLI-side fast-path for meson configure-phase try-compile probes.

## Bench (from zackees/zccache#636)

Unique-probe workload, 0% cache hit (probes are fresh paths so the cache only pays per-invocation overhead with nothing to amortise):

| Mode | Cold | Warm/probe | vs bare |
|:-----|----:|----------:|--------:|
| Bare | 0.96 s | 47 ms | — |
| zccache cache (default) | 4.92 s | 102 ms | 2.2× slower |
| zccache `PROBE_BYPASS=1` | 1.34 s | **60 ms** | 1.3× slower |

With ~200 probes per FastLED meson configure run, expected saving is on the order of **7–10s per configure**.

## Safety

- **Not a disable.** Per zackees/zccache#633, the routing decision is per-invocation. Production `.cpp` TUs that exceed the 4 KiB heuristic, use PCH, or take an `@rsp` continue to use the cached path normally. Only probe-shape invocations bypass.
- **Forward-compatible.** Older zccache that doesn't recognise the env var ignores it (no error, no behaviour change).
- **`setdefault`** keeps an existing user override intact.

## Path correction vs the issue

The issue pinned the canonical location as `ci/meson/runner.py:406`, but that file was refactored since the issue was filed — `_start_zccache_session` now lives in `ci/meson/runner_helpers.py` (422 lines, well under any LOC guard). The fix is otherwise the exact one-line addition the issue specified.

## Tests / lint

- `bash lint` — green (Python pipeline + C++ + JS + meson + platformio-internal-usage all completed)
- No new tests added: the change is a setdefault on a runtime env var consumed by zccache; behaviour is observable through the existing build / test runs, and the bench data in #636 already documents the perf delta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI build performance by enabling faster caching mechanisms during Meson builds, which may result in quicker compilation times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->