### PR TITLE
chore(deps): bump fbuild 2.2.17 -> 2.2.18

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,27 +5,40 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    # Pin to fbuild 2.2.17 — routes ESP32-S3 native deploys through esptool
-    # (FastLED/fbuild#380), which is one of the user-visible failure modes
-    # tracked in FastLED #2700 (fbuild ESP toolchain resolution). The
-    # remaining end-to-end RISC-V helper toolchain provisioning work is
-    # tracked separately upstream as a follow-up to 2.2.17.
-    # Prior pins preserved for context: 2.2.15 added Arduino UNO Q / STM32U5
-    # board defaults and the compile-many stage-2 framework-archive share
-    # (FastLED/fbuild#337) which prevents every stage-2 sketch from
-    # re-building the framework from scratch (the regression that originally
-    # forced the FASTLED_USE_FBUILD_CI=1 gate to default-off in #2662). Also
-    # picked up the stage-2 jobs split (#336), the real-toolchain stage-2
-    # perf regression test (#342), the daemon-side fmt-tracing-to-stderr
-    # fix (#348), the bounded zccache start-up timeout (#349), and
-    # project-lock acquire instrumentation (#350) — together these address
-    # the silent esp32c6 hang reported in fbuild#346 and unblock flipping
-    # FASTLED_USE_FBUILD_CI=1 default-on in a follow-up. Also preserves
-    # quoted Adafruit nRF52 BSP defines in response files, unblocking
-    # nRF52840 builds under fbuild. 2.2.16 completed ESP32-C2 framework
-    # skeleton installs and patched the missing touch_sensor_legacy_types.h
-    # no-touch compatibility header (FastLED/fbuild#378).
-    "fbuild==2.2.17",
+    # Pin to fbuild 2.2.18 (released 2026-06-05). 2.2.18 adds the
+    # FastLED #2836 Stage 1 deliverable — LPC804 + LPC845 bare-metal
+    # targets (FastLED/fbuild#419) — plus a batch of vendor-warning
+    # scopings (renesas FSP, nRF52 Adafruit BSP), the
+    # ESP32-S2/S3 USB_VID/USB_PID redef-warning fix
+    # (FastLED/fbuild#413), nested-example build-info parent-dir
+    # creation (FastLED/fbuild#410), a larger CLI Windows stack
+    # reservation, and the SAMD/STM32/ATmega/CH559 test-fixture
+    # coverage that backs the validate_boards reconciliation
+    # tracked at FastLED/fbuild#421/#422. zccache pinned >=1.11.15.
+    # Prior pins preserved for context:
+    #   2.2.17 — routed ESP32-S3 native deploys through esptool
+    #            (FastLED/fbuild#380), one of the user-visible
+    #            failure modes tracked in FastLED #2700.
+    #   2.2.15 — Arduino UNO Q / STM32U5 board defaults; compile-
+    #            many stage-2 framework-archive share
+    #            (FastLED/fbuild#337) that prevents every stage-2
+    #            sketch from re-building the framework from scratch
+    #            (the regression that originally forced
+    #            FASTLED_USE_FBUILD_CI=1 default-off in #2662);
+    #            stage-2 jobs split (#336), real-toolchain stage-2
+    #            perf regression test (#342), daemon-side
+    #            fmt-tracing-to-stderr fix (#348), bounded zccache
+    #            start-up timeout (#349), project-lock acquire
+    #            instrumentation (#350) — together address the
+    #            silent esp32c6 hang reported in fbuild#346 and
+    #            unblock flipping FASTLED_USE_FBUILD_CI=1
+    #            default-on; quoted Adafruit nRF52 BSP defines
+    #            preserved in response files, unblocking nRF52840
+    #            builds under fbuild.
+    #   2.2.16 — completed ESP32-C2 framework skeleton installs
+    #            and patched the missing touch_sensor_legacy_types.h
+    #            no-touch compatibility header (FastLED/fbuild#378).
+    "fbuild==2.2.18",
     "platformio>=6.1.19,<6.2",
     "python-dateutil",
     "ruff",


### PR DESCRIPTION
## Summary

Update fbuild pin to the latest published release ([v2.2.18](https://github.com/FastLED/fbuild/releases/tag/v2.2.18), released 2026-06-05).

## What 2.2.18 brings

- **LPC8xx bare-metal target** ([fbuild#419](https://github.com/FastLED/fbuild/pull/419)) — Stage 1 of the LPC port roadmap (#2836 / #2845, both closed). Makes \`fbuild build lpc845\` / \`fbuild build lpc804\` actually work for the LPC driver code in \`src/platforms/arm/lpc/\`.
- **ESP32-S2/S3 USB_VID/USB_PID redef warnings fixed** ([fbuild#413](https://github.com/FastLED/fbuild/pull/413)) — drops the 149–156 build-warning noise that the ESP-IDF Arduino BSP was emitting on every TinyUSB-enabled build.
- **build_info parent-dir creation for nested example envs** ([fbuild#410](https://github.com/FastLED/fbuild/pull/410)) — fixes the case where \`--examples Fx/FxNoisePalette\` failed to write \`build_info_<env>.json\` because the env-name directory didn't exist.
- **Vendor-warning scopings** — renesas FSP \`-Wno-error=\` demotions scoped to vendor C sources only ([fbuild#412](https://github.com/FastLED/fbuild/pull/412)); nRF52 \`-Wno-array-bounds\` scoped to Adafruit BSP only ([fbuild#414](https://github.com/FastLED/fbuild/pull/414)). Both prevent FastLED-side warnings from being silenced.
- **CLI Windows stack reservation** — larger reserved stack (ce37f03) for sketches with deep template instantiations.
- **Test-fixture coverage** — SAMD (QT Py M0 + Matrix Portal M4), STM32 (F0/L4 gap-tracking), ATmega tracker fixtures, CH559 intel_mcs51 smoke fixture — together back the \`validate_boards\` reconciliation tracked at [fbuild#421/#422](https://github.com/FastLED/fbuild/issues/421).
- **ESP32 daemon error surfacing + platform.json helper toolchains** ([fbuild#402](https://github.com/FastLED/fbuild/pull/402)) — surfaces upstream daemon errors that previously got swallowed into a generic \"build failed\" exit.
- **zccache pin** — bumped to \`>=1.11.15\` ([fbuild#418](https://github.com/FastLED/fbuild/pull/418)).

## Test plan

- [x] \`uv run fbuild --version\` → \`fbuild 2.2.18\`
- [x] pyproject.toml round-trips through \`tomllib.loads\` cleanly
- [x] uv.lock resolved successfully via \`uv lock --upgrade-package fbuild\`

## Related

- [FastLED/fbuild v2.2.18 release](https://github.com/FastLED/fbuild/releases/tag/v2.2.18)
- [FastLED #2845](https://github.com/FastLED/FastLED/issues/2845) (LPC roadmap meta, closed)
- [fbuild#419](https://github.com/FastLED/fbuild/pull/419) (LPC8xx bare-metal Stage 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency to the latest stable version, incorporating bug fixes and improvements from the newer release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->