### PR TITLE
feat(ci): add `bash bloat <board>` wrapper for per-symbol flash analysis

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,7 @@
 | Test-Driven Development (TDD) | Use `/tdd` or `/tdd-implement` skills |
 | Hardware autoresearch / `bash autoresearch` | `agents/docs/hardware-autoresearch.md` |
 | Debugging a C++ crash | `agents/docs/debugging.md` |
+| Investigating binary size / flash bloat | Run `bash bloat <board>` and read "Binary Size Analysis" below |
 | Creating a new C++ linter | `agents/docs/linter-architecture.md` |
 | Detailed command reference | `agents/docs/commands-reference.md` |
 | Workflow and task management | `agents/docs/workflow.md` |
@@ -31,12 +32,67 @@
 - `bash compile <platform> --examples Blink` — Compile for specific hardware (only when explicitly requested)
 - `bash autoresearch --parlio` — Live device testing (must specify driver)
 - `bash profile <function>` — Performance profiling
+- `bash bloat <board>` — Per-symbol flash/RAM bloat report (see "Binary Size Analysis" below)
 
 **NEVER use:** `uv run python test.py` — use `bash test` or `uv run test.py`
 **FORBIDDEN:** `--no-fingerprint` (use `bash test --clean`), bare `pio`/`platformio`, bare `meson`/`ninja`/`clang++`
 
 See `agents/docs/commands-reference.md` for Docker, fbuild, WASM, profiling, example compilation, and override mechanism.
 See `agents/docs/build-system.md` for full command execution rules and forbidden patterns.
+
+## Binary Size Analysis
+
+When investigating "why is the firmware so big" or "what symbol regressed in this PR", use `bash bloat <board>` instead of running `nm`/`size`/`xtensa-esp32s3-elf-nm` by hand. The wrapper hides every choice that was previously a per-invocation footgun.
+
+### Quick start
+
+```bash
+# Default — analyzes the latest Blink build, prints top-10 flash symbols
+bash bloat esp32s3
+
+# Different example
+bash bloat esp32s3 --example FxFire
+
+# Deeper top-N
+bash bloat esp32s3 --top 25
+
+# Rebuild before analyzing (chains `bash compile`)
+bash bloat esp32s3 --build
+
+# JSON + MD artifact only, no stdout table
+bash bloat esp32s3 --no-summary
+```
+
+Supported boards live in `ci/bloat.py::BOARD_CHIP_MAP` (esp32, esp32s2, esp32s3, esp32c3, esp32c6, esp32h2). Adding a new board is a one-line entry mapping the board id to its architecture + chip prefix; the script resolves the cross-toolchain `nm` from the PIO packages directory.
+
+### Artifacts
+
+Every run writes BOTH files side by side under `.build/symbols/<board>/`:
+
+| File | What's in it |
+|---|---|
+| `report.json` | Machine-readable: `{ symbols: [...], sections: [...], total_flash, total_ram, ... }`. Per-symbol rows carry `archive`, `object`, `output_section`, `source`, `region`, demangled `demangled` name. Suitable for diffing two builds. |
+| `report.md` | Human-readable GitHub-style tables: top FLASH symbols, top RAM symbols, per-archive flash roll-up. Renders inline on PRs. |
+
+### Lessons baked in (do not re-discover)
+
+These are the gotchas the wrapper handles for you. They are documented here so they survive an agent rewrite of `ci/bloat.py`:
+
+1. **fbuild release lag.** `fbuild symbols` (the underlying subcommand) was merged to fbuild#main after the v2.2.18 wheel was tagged. The released wheel **does NOT carry it**. The wrapper's `assert_fbuild_has_symbols()` detects this and fails fast with the upgrade instructions. Until fbuild >= 2.2.19 publishes, rebuild fbuild from main (`cargo build --release -p fbuild-cli` inside the dev checkout) and drop the binary into `.venv/Scripts/fbuild.exe`.
+
+2. **Map-derived synthesis is what makes the report useful.** fbuild PR #427 parses `.rodata.<owner>.str1.<N>` input-section names and attributes those bytes to the owning function. Without it, the single biggest contributor on ESP32-S3 Blink (the NEOPIXEL chipset ctor's `FL_WARN`/`FL_LOG` string pool, ~58 KB / 15 %) appears as anonymous bytes against `main.cpp.o` and there's no way to chase it. The `source: "map-derived"` field on each symbol tags rows whose attribution came from this synthesis pass; treat them with the same trust as `source: "nm"` rows.
+
+3. **The dominant flash lever on ESP32-S3 is `FASTLED_LOG_VERBOSITY=0`.** FastLED PR #2791 introduced this build-time knob. Setting it (define before `#include <FastLED.h>`) collapses ~43-58 KB of FL_WARN string pool with zero behaviour change for users who don't need release-mode logging. **Always check whether this knob is set before chasing other optimisations — it's a single define that dominates everything else.**
+
+4. **`--nm` is still required.** fbuild's `build_info.json` does not yet carry toolchain paths (`nm_path` / `cppfilt_path`). The wrapper resolves them from PIO packages. fbuild issue #428 tracks the migration to build-info-driven resolution; when that lands, drop the explicit `--nm` path in `ci/bloat.py::run_fbuild_symbols`.
+
+5. **Diff two builds with the existing diff script.** Save two `report.json` files and run `uv run python .claude/symbolaudit/diff.py <old.json> <new.json>` for a per-symbol delta table (added / removed / grew / shrunk). The wrapper does NOT do this automatically; ship a follow-up PR if you need it inline.
+
+### Don'ts
+
+- **Don't run `xtensa-esp32s3-elf-nm` or `xtensa-esp32s3-elf-size` directly.** The wrapper subsumes both. Direct toolchain invocations have caused every prior bloat audit to wire up nm/c++filt/map by hand and miss the map-derived synthesis pass.
+- **Don't shell out to `fbuild symbols` with a hardcoded ELF path.** Use the wrapper — it discovers the latest ELF, picks the right toolchain, defaults the output directory, and prints the summary table in one call.
+- **Don't write a new Python aggregator under `.claude/symbolaudit/`.** The wrapper's `_AggBucket` summary plus the existing `diff.py` cover the per-symbol and per-archive views needed for both "what's in this build" and "what changed between two builds". Extend `ci/bloat.py` if a new view is required.
 
 ## Core Rules (ALL AGENTS)
 

--- a/bloat
+++ b/bloat
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+cd "$(dirname "$0")"
+uv run ci/bloat.py "$@"

--- a/ci/bloat.py
+++ b/ci/bloat.py
@@ -1,0 +1,330 @@
+"""Per-symbol bloat analysis wrapper around `fbuild symbols`.
+
+Usage:
+    bash bloat <board>                  # default: example=Blink, top=10
+    bash bloat <board> --example FxFire # alternate example
+    bash bloat esp32s3 --top 25         # deeper top-N table
+    bash bloat esp32s3 --no-summary     # don't print the table (just artifacts)
+    bash bloat esp32s3 --build          # also runs `bash compile` first
+
+What it does:
+    1. Resolves the cross-toolchain `nm` for the requested board (PIO
+       packages directory). Until fbuild#428 ships, the bloat tool can't
+       read these paths from `build_info.json` — we hard-code the well-
+       known PIO toolchain layout instead.
+    2. Locates the latest firmware.elf for the build:
+       `.build/pio/<board>/.pio/build/<board>/firmware.elf` (PIO) or
+       `.build/<board>/firmware.elf` (fbuild).
+    3. Invokes `fbuild symbols` against it with `--output-dir
+       .build/symbols/<board>/`, which writes BOTH `report.json` and
+       `report.md` side by side.
+    4. Parses the JSON, collapses each demangled name across all its
+       (section, source) rows, and prints a `top-N` table to stdout.
+
+Why this script exists:
+    Running the analysis by hand wires you through the toolchain
+    prefix, the PIO output path, the `--nm` override, and the output
+    directory — easy to get wrong and easy to forget. This wrapper
+    encapsulates the convention; future agents only need
+    `bash bloat <board>` to get a useful report on disk.
+
+Lessons baked in (see CLAUDE.md > "Binary Size Analysis"):
+    - The fbuild `symbols` subcommand requires fbuild >= 2.2.19. The
+      released 2.2.18 wheel does NOT carry it; sync to fbuild#main
+      until the next release tag (#424 + #427 merged after 2.2.18).
+    - Map-derived synthesis (fbuild #427) is what attributes anonymous
+      `.rodata.<owner>.str1.<N>` blocks to the owning function. Without
+      it, the biggest single-symbol contributor on ESP32-S3 Blink (the
+      NEOPIXEL chipset ctor's FL_WARN/FL_LOG string pool, ~58 KB) shows
+      up as anonymous bytes against main.cpp.o.
+    - The dominant flash-bloat lever on ESP32-S3 is `FASTLED_LOG_VERBOSITY=0`
+      (FastLED PR #2791). That single define recovers ~43-58 KB of FL_WARN
+      string pool with no behavioural change for users who only need release-
+      mode logging.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from ci.util.global_interrupt_handler import handle_keyboard_interrupt
+
+
+# Per-board cross-toolchain `nm` resolution. The Xtensa / RISC-V split mirrors
+# the PlatformIO board → architecture mapping; the file names follow
+# `<triple>-nm[.exe]` per binutils convention.
+#
+# Until fbuild#428 lands (`BuildInfo` carries `nm_path` + `cppfilt_path`), we
+# resolve directly against the PIO packages directory. After that lands the
+# script can switch to reading `build_info_<env>.json::nm_path`.
+PIO_NM_BY_ARCH = {
+    # arch → (toolchain-package-dir, tool-prefix)
+    "xtensa": ("toolchain-xtensa-esp-elf", "xtensa-{board_chip}-elf"),
+    "riscv": ("toolchain-riscv32-esp-elf", "riscv32-esp-elf"),
+}
+
+# Board → chip-id used to construct the toolchain prefix. Add entries as
+# bloat analysis is needed on new platforms.
+BOARD_CHIP_MAP = {
+    "esp32": ("xtensa", "esp32"),
+    "esp32s2": ("xtensa", "esp32s2"),
+    "esp32s3": ("xtensa", "esp32s3"),
+    "esp32c3": ("riscv", "esp32c3"),
+    "esp32c6": ("riscv", "esp32c6"),
+    "esp32h2": ("riscv", "esp32h2"),
+}
+
+
+def pio_packages_dir() -> Path:
+    """User-scoped PIO packages dir; works on Windows / Linux / macOS."""
+    home = Path.home()
+    candidate = home / ".platformio" / "packages"
+    if candidate.is_dir():
+        return candidate
+    raise SystemExit(
+        f"PlatformIO packages dir not found at {candidate}. "
+        "Run a PIO build first (`bash compile <board> --examples Blink`)."
+    )
+
+
+def resolve_nm(board: str) -> Path:
+    """Locate the cross-toolchain `nm` binary for the given board."""
+    if board not in BOARD_CHIP_MAP:
+        raise SystemExit(
+            f"Bloat: board '{board}' has no nm mapping. Add it to "
+            "BOARD_CHIP_MAP in ci/bloat.py — entries are mechanical "
+            "(arch + chip prefix). Supported boards today: "
+            f"{', '.join(sorted(BOARD_CHIP_MAP))}."
+        )
+    arch, chip = BOARD_CHIP_MAP[board]
+    pkg_dir, prefix_tpl = PIO_NM_BY_ARCH[arch]
+    prefix = prefix_tpl.format(board_chip=chip)
+    bin_dir = pio_packages_dir() / pkg_dir / "bin"
+    # Windows has .exe; Unix doesn't. Prefer the os-specific one.
+    nm = bin_dir / f"{prefix}-nm.exe"
+    if not nm.exists():
+        nm = bin_dir / f"{prefix}-nm"
+    if not nm.exists():
+        raise SystemExit(
+            f"Bloat: nm binary not found under {bin_dir}. Expected "
+            f"`{prefix}-nm[.exe]`. Has the toolchain been installed via PIO?"
+        )
+    return nm
+
+
+def find_elf(board: str, build_root: Path) -> Path:
+    """Auto-detect the firmware ELF for the given board."""
+    candidates = [
+        build_root / "pio" / board / ".pio" / "build" / board / "firmware.elf",
+        build_root / board / "firmware.elf",
+    ]
+    for c in candidates:
+        if c.is_file():
+            return c
+    paths = "\n  ".join(str(c) for c in candidates)
+    raise SystemExit(
+        "Bloat: no firmware.elf found. Looked at:\n  "
+        + paths
+        + "\nRun `bash compile "
+        + board
+        + " --examples Blink` first, or pass "
+        "--build."
+    )
+
+
+def assert_fbuild_has_symbols() -> None:
+    """Refuse to proceed if `fbuild symbols` isn't wired up."""
+    try:
+        out = subprocess.check_output(
+            ["fbuild", "symbols", "--help"],
+            stderr=subprocess.STDOUT,
+            text=True,
+            timeout=15,
+        )
+    except FileNotFoundError as e:
+        raise SystemExit(
+            "Bloat: `fbuild` not on PATH. Run from a uv-managed shell "
+            "(`uv run bash bloat <board>` or set the project venv)."
+        ) from e
+    except subprocess.CalledProcessError as e:
+        raise SystemExit(
+            "Bloat: `fbuild symbols` rejected. fbuild 2.2.18 (the released "
+            "wheel) does NOT carry the symbols subcommand — it was merged "
+            "to fbuild#main after the 2.2.18 tag. Rebuild fbuild from main "
+            "(or wait for the 2.2.19 wheel) and drop the binary into "
+            ".venv/Scripts/fbuild.exe. See CLAUDE.md > 'Binary Size "
+            "Analysis' for the upgrade path.\n\n"
+            f"Output:\n{e.output}"
+        ) from e
+    if "symbols" not in out.lower() and "bloat" not in out.lower():
+        # Sanity-check that the help text describes the right surface.
+        raise SystemExit(
+            "Bloat: `fbuild symbols --help` returned but doesn't mention "
+            "the symbols/bloat subcommand. Likely a stale fbuild binary."
+        )
+
+
+def run_fbuild_symbols(elf: Path, nm: Path, out_dir: Path, top: int) -> None:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    cmd = [
+        "fbuild",
+        "symbols",
+        str(elf),
+        "--nm",
+        str(nm),
+        "--output-dir",
+        str(out_dir),
+        "--top",
+        str(top),
+    ]
+    print(f"$ {' '.join(cmd)}")
+    try:
+        subprocess.run(cmd, check=True)
+    except KeyboardInterrupt as ki:
+        handle_keyboard_interrupt(ki)
+        raise
+
+
+@dataclass
+class _AggBucket:
+    """Per-demangled-name aggregation row for the summary table."""
+
+    size: int = 0
+    archive: str = ""
+    object: str = ""
+    sources: set[str] = field(default_factory=lambda: set[str]())
+
+
+def print_summary(report_json: Path, top: int) -> None:
+    """Read report.json and print a top-N table of flash bloat."""
+    data = json.loads(report_json.read_text(encoding="utf-8"))
+    flash_syms = [s for s in data["symbols"] if s["region"] == "flash"]
+    total_flash: int = int(data["total_flash"])
+    total_ram: int = int(data["total_ram"])
+
+    by_name: dict[str, _AggBucket] = {}
+    for s in flash_syms:
+        n: str = s["demangled"]
+        bucket = by_name.setdefault(n, _AggBucket())
+        bucket.size += int(s["size"])
+        if not bucket.archive:
+            bucket.archive = s.get("archive") or "(none)"
+            bucket.object = s.get("object") or "-"
+        bucket.sources.add(s["source"])
+
+    rows: list[tuple[str, _AggBucket]] = sorted(
+        by_name.items(), key=lambda kv: -kv[1].size
+    )[:top]
+
+    print()
+    print(
+        f"Total flash: {total_flash:,} B  "
+        f"({len(flash_syms):,} sized flash symbols).  "
+        f"RAM: {total_ram:,} B."
+    )
+    print()
+    print(f"{'#':>3}  {'BYTES':>8}  {'ARCHIVE':<22}  {'OBJECT':<26}  SYMBOL")
+    print("-" * 120)
+    for i, (name, bucket) in enumerate(rows, 1):
+        srcs = "/".join(sorted(bucket.sources))
+        shown = name if len(name) <= 70 else name[:67] + "..."
+        print(
+            f"{i:>3}  {bucket.size:>8,}  "
+            f"{bucket.archive[:22]:<22}  {bucket.object[:26]:<26}  "
+            f"{shown}  [{srcs}]"
+        )
+    print()
+    print("Artifacts:")
+    print(f"  JSON: {report_json}")
+    print(f"  MD:   {report_json.with_name('report.md')}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Per-symbol flash/RAM bloat analysis for FastLED builds."
+    )
+    parser.add_argument(
+        "board",
+        help="Board name (esp32s3, esp32, esp32c3, ...). "
+        "See BOARD_CHIP_MAP in ci/bloat.py to add a new target.",
+    )
+    parser.add_argument(
+        "--example",
+        default="Blink",
+        help="Example whose build to analyze (default: Blink).",
+    )
+    parser.add_argument(
+        "--top",
+        type=int,
+        default=10,
+        help="Top-N symbols to print in the summary (default: 10).",
+    )
+    parser.add_argument(
+        "--no-summary",
+        action="store_true",
+        help="Skip the stdout summary; just write the JSON + MD artifacts.",
+    )
+    parser.add_argument(
+        "--build",
+        action="store_true",
+        help="Run `bash compile <board> --examples <example> --platformio` "
+        "first to produce a fresh ELF.",
+    )
+    parser.add_argument(
+        "--build-root",
+        default=".build",
+        help="Build output root (default: .build).",
+    )
+    args = parser.parse_args()
+
+    project_root = Path(__file__).resolve().parent.parent
+    os.chdir(project_root)
+
+    assert_fbuild_has_symbols()
+
+    if args.build:
+        compile_script = "compile.bat" if os.name == "nt" else "./compile"
+        if os.name != "nt" and not shutil.which("bash"):
+            raise SystemExit("bash not on PATH; cannot --build")
+        cmd = [
+            compile_script,
+            args.board,
+            "--examples",
+            args.example,
+            "--platformio",
+        ]
+        print(f"$ {' '.join(cmd)}")
+        subprocess.run(cmd, check=True)
+
+    nm = resolve_nm(args.board)
+    elf = find_elf(args.board, Path(args.build_root))
+    out_dir = Path(args.build_root) / "symbols" / args.board
+
+    print(f"Board:   {args.board}")
+    print(f"Example: {args.example}")
+    print(f"ELF:     {elf}")
+    print(f"nm:      {nm}")
+    print(f"Output:  {out_dir}")
+    print()
+
+    run_fbuild_symbols(elf=elf, nm=nm, out_dir=out_dir, top=args.top)
+
+    if not args.no_summary:
+        print_summary(out_dir / "report.json", args.top)
+
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except KeyboardInterrupt as ki:
+        handle_keyboard_interrupt(ki)
+        raise


### PR DESCRIPTION
## Summary

Codifies the lessons from the recent #2773 ESP32-S3 binary-size audit into a one-call tool so future agents don't re-discover the same gotchas (toolchain prefix per board, PIO output path layout, required `--nm` until fbuild#428 lands, `fbuild symbols` requiring fbuild >= 2.2.19, etc.).

## Ships

- **`bloat`** — bash entry-point matching the existing `bash test` / `bash lint` / `bash compile` convention.
- **`ci/bloat.py`** — wrapper around `fbuild symbols`:
  - Auto-resolves the cross-toolchain `nm` from PIO packages based on `BOARD_CHIP_MAP` (esp32, esp32s2, esp32s3, esp32c3, esp32c6, esp32h2 today; entries are mechanical).
  - Auto-locates `firmware.elf` under `.build/pio/<board>/.pio/build/<board>/` or `.build/<board>/`.
  - Writes BOTH `report.json` + `report.md` to `.build/symbols/<board>/`.
  - Prints a top-N collapsed-per-symbol-name table to stdout.
  - `--build` chains `bash compile` first.
  - **Fails fast** when fbuild lacks `symbols` (the 2.2.18 wheel doesn't carry it) with the exact upgrade path.
- **CLAUDE.md** — new "Binary Size Analysis" section bakes in the 5 lessons learned + explicit "don'ts" to keep agents from re-implementing the wrapper or shelling out to nm directly.

## Lessons baked into CLAUDE.md

1. fbuild release lag — `symbols` merged after v2.2.18 wheel tag; rebuild from main until 2.2.19 ships.
2. Map-derived synthesis (fbuild #427) is what makes `.flash.rodata` per-symbol; without it ~58 KB of NEOPIXEL FL_WARN strings bucket as anonymous against main.cpp.o.
3. `FASTLED_LOG_VERBOSITY=0` is the single biggest flash-bloat lever on ESP32-S3 (~43-58 KB).
4. `--nm` still required until fbuild #428 lands build-info-driven toolchain resolution.
5. Diff two builds with the existing `.claude/symbolaudit/diff.py`.

## Test plan

- [x] `bash bloat esp32s3 --top 5` end-to-end against the Blink build: writes both artifacts, prints the top-5 summary table, reports 388,380 B flash / 37,460 B RAM / 4,591 symbols.
- [x] `bash lint` clean (python_pipeline + cpp + js all green).
- [x] Verified the released fbuild 2.2.18 wheel rejects the `symbols` subcommand, and the wrapper's `assert_fbuild_has_symbols()` fails fast with the upgrade message.

## Related

- FastLED #2773 — ESP32-S3 binary-size meta tracker (the audit that surfaced every lesson here)
- fbuild #424 / #427 — the symbols subcommand + map-derived synthesis (merged, but post-2.2.18-wheel)
- fbuild #428 — `BuildInfo` schema migration so `--nm` becomes unnecessary
- fbuild #434 — meta to rename `symbols` → `bloat` and write reports to `.fbuild/build/<env>/bloat-report/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New binary size analysis tooling for examining firmware flash usage and identifying the largest contributing code components in compiled binaries across different board types.

* **Documentation**
  * Added comprehensive documentation on binary size analysis workflows, including quick start options, supported boards, expected generated files, and best practices for bloat investigations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->