### PR TITLE
feat(lint): ban bare printf/vprintf in src/ + replace last 13 WASM offenders with fl::printf

### DIFF
--- a/ci/lint_cpp/bare_snprintf_checker.py
+++ b/ci/lint_cpp/bare_snprintf_checker.py
@@ -43,6 +43,8 @@ BANNED_FUNCS = (
     "vsprintf",
     "fprintf",
     "vfprintf",
+    "printf",
+    "vprintf",
 )
 
 # Match `<func>(` not preceded by `fl::`, `::`, `.`, or an identifier

--- a/src/fl/system/serial.h
+++ b/src/fl/system/serial.h
@@ -177,7 +177,7 @@ public:
      * Note: Maximum formatted string length is 256 characters.
      */
     template<typename... Args>
-    size_t printf(const char* format, Args... args);
+    size_t printf(const char* format, Args... args);  // ok snprintf — method routes through fl::snprintf at line 284
 
     /**
      * @brief Wait for serial output to complete

--- a/src/platforms/stub/Arduino.h
+++ b/src/platforms/stub/Arduino.h
@@ -188,7 +188,7 @@ struct SerialEmulation {
 
     // Printf-style formatted output (variadic template implementation)
     template<typename... Args>
-    void printf(const char* format, Args... args) FL_NOEXCEPT {
+    void printf(const char* format, Args... args) FL_NOEXCEPT {  // ok snprintf — method routes through fl::printf
         fl::printf(format, args...);
     }
 

--- a/src/platforms/wasm/audio_input_wasm.cpp.hpp
+++ b/src/platforms/wasm/audio_input_wasm.cpp.hpp
@@ -98,7 +98,7 @@ audio::Sample WasmAudioInput::read() {
     mReadBlocks++;
 
     if (mReadBlocks == 1) {
-        printf("WasmAudioInput: First audio block consumed by sketch "
+        fl::printf("WasmAudioInput: First audio block consumed by sketch "
                "(timestamp=%u ms)\n", (unsigned)block.timestamp);
     }
 
@@ -110,7 +110,7 @@ void WasmAudioInput::pushSamples(const fl::i16* samples, int count, fl::u32 time
         static bool warned = false;
         if (!warned) {
             warned = true;
-            printf("WasmAudioInput: pushSamples called but not running - "
+            fl::printf("WasmAudioInput: pushSamples called but not running - "
                    "audio data is being dropped!\n");
         }
         return;
@@ -160,10 +160,10 @@ void WasmAudioInput::flushAccumBuffer() {
     mAccumPos = 0;
 
     if (mPushedBlocks == 1) {
-        printf("WasmAudioInput: First audio block received from JS "
+        fl::printf("WasmAudioInput: First audio block received from JS "
                "(timestamp=%u ms)\n", (unsigned)mAccumTimestamp);
     } else if (mPushedBlocks % 172 == 0) {
-        printf("WasmAudioInput: %u blocks received, %u read, %u dropped\n",
+        fl::printf("WasmAudioInput: %u blocks received, %u read, %u dropped\n",
                (unsigned)mPushedBlocks, (unsigned)mReadBlocks,
                (unsigned)mDroppedBlocks);
     }
@@ -218,7 +218,7 @@ void pushAudioSamples(const fl::i16* samples, int count, fl::u32 timestamp) {
         static bool warned = false;
         if (!warned) {
             warned = true;
-            printf("pushAudioSamples: No WasmAudioInput instance - "
+            fl::printf("pushAudioSamples: No WasmAudioInput instance - "
                    "UIAudio not created yet. Audio data dropped!\n");
         }
         return;

--- a/src/platforms/wasm/fs_wasm.cpp.hpp
+++ b/src/platforms/wasm/fs_wasm.cpp.hpp
@@ -54,6 +54,7 @@
 #include "fl/math/math.h"
 #include "fl/stl/memory.h"
 #include "fl/stl/string.h"
+#include "fl/stl/stdio.h"
 #include "fl/log/log.h"
 #include "fl/stl/mutex.h"
 #include "platforms/wasm/js.h"
@@ -341,7 +342,7 @@ EMSCRIPTEN_KEEPALIVE void fastled_declare_files(const char* jsonStr) {
         fl::string path = file["path"] | fl::string("");
         
         if (size > 0 && !path.empty()) {
-            printf("Declaring file %s with size %d. These will become available as "
+            fl::printf("Declaring file %s with size %d. These will become available as "
                    "File system paths within the app.\n",
                    path.c_str(), size);
             jsDeclareFile(path.c_str(), size);

--- a/src/platforms/wasm/js_bindings.cpp.hpp
+++ b/src/platforms/wasm/js_bindings.cpp.hpp
@@ -183,7 +183,7 @@ EMSCRIPTEN_KEEPALIVE bool hasNewFrameData(fl::u32 lastKnownVersion) {
  */
 EMSCRIPTEN_KEEPALIVE void processUiInput(const char* jsonInput) {
     if (!jsonInput) {
-        printf("Error: Received null UI input\n");
+        fl::printf("Error: Received null UI input\n");
         return;
     }
     
@@ -223,7 +223,7 @@ EMSCRIPTEN_KEEPALIVE void* getStripUpdateData(int stripId, int* dataSize) {
  */
 EMSCRIPTEN_KEEPALIVE void notifyStripAdded(int stripId, int numLeds) {
     // Simple notification - JavaScript will handle the async logic
-    printf("Strip added: ID %d, LEDs %d\n", stripId, numLeds);
+    fl::printf("Strip added: ID %d, LEDs %d\n", stripId, numLeds);
 }
 
 /**
@@ -324,13 +324,13 @@ EMSCRIPTEN_KEEPALIVE void jsFillInMissingScreenMaps(ActiveStripData &active_stri
         const auto &stripData = pair.second;
         const bool has_screen_map = active_strips.hasScreenMap(stripIndex);
         if (!has_screen_map) {
-            printf("Missing screenmap for strip %d\n", stripIndex);
+            fl::printf("Missing screenmap for strip %d\n", stripIndex);
             // okay now generate a screenmap for this strip, let's assume
             // a linear strip with only one row.
             const u32 pixel_count = stripData.size() / 3;
             ScreenMap screenmap(pixel_count);
             if (pixel_count > 255 && Function::isSquare(pixel_count)) {
-                printf("Creating square screenmap for %d\n", pixel_count);
+                fl::printf("Creating square screenmap for %d\n", pixel_count);
                 u32 side = sqrt(pixel_count);
                 // This is a square matrix, let's assume it's a square matrix
                 // and generate a screenmap for it.
@@ -349,7 +349,7 @@ EMSCRIPTEN_KEEPALIVE void jsFillInMissingScreenMaps(ActiveStripData &active_stri
                 // a screenmap for this strip.
                 _jsSetCanvasSize(stripIndex, screenmap);
             } else {
-                printf("Creating linear screenmap for %d\n", pixel_count);
+                fl::printf("Creating linear screenmap for %d\n", pixel_count);
                 ScreenMap screenmap(pixel_count);
                 for (u32 i = 0; i < pixel_count; i++) {
                     screenmap.set(i, {static_cast<float>(i), 0});
@@ -384,12 +384,12 @@ EMSCRIPTEN_KEEPALIVE void jsOnStripAdded(uintptr_t strip, u32 num_leds) {
  * Pure C++ UI Update Function - Simple data processing
  */
 EMSCRIPTEN_KEEPALIVE void updateJs(const char* jsonStr) {
-    printf("updateJs: ENTRY - PURE C++ VERSION - jsonStr=%s\n", jsonStr ? jsonStr : "nullptr");
+    fl::printf("updateJs: ENTRY - PURE C++ VERSION - jsonStr=%s\n", jsonStr ? jsonStr : "nullptr");
     
     // Process UI input using pure C++ function
     ::processUiInput(jsonStr);
     
-    printf("updateJs: EXIT - PURE C++ VERSION\n");
+    fl::printf("updateJs: EXIT - PURE C++ VERSION\n");
 }
 
 /**


### PR DESCRIPTION
## Summary

Closes the long tail of FastLED #2773 item 1.1/1.5 — the printf-family elimination work — by:

1. Extending `ci/lint_cpp/bare_snprintf_checker.py` to ban bare `printf` and `vprintf` (previously only the snprintf/sprintf/fprintf branches were on the list).
2. Replacing 13 bare `printf(…)` call sites in WASM platform code with `fl::printf(…)`.
3. Suppressing 2 false-positive method-declaration sites with `// ok snprintf`.

After this PR, `src/` has zero bare references to the C printf family per the goal in #2886.

## Why

`fl::printf` (defined at `src/fl/stl/stdio.h:37`) formats through `fl::sstream` and avoids pulling newlib's `_vfprintf_r` engine into the binary. Banning the C variants library-wide is the only way to prevent future drift.

## Changes by file

| File | Change |
|---|---|
| `ci/lint_cpp/bare_snprintf_checker.py` | Add `printf`, `vprintf` to `BANNED_FUNCS`. |
| `src/platforms/wasm/audio_input_wasm.cpp.hpp` | 5 sites — lines 101, 113, 163, 166, 221. |
| `src/platforms/wasm/fs_wasm.cpp.hpp` | 1 site (344) + new `#include "fl/stl/stdio.h"`. |
| `src/platforms/wasm/js_bindings.cpp.hpp` | 7 sites — lines 186, 226, 327, 333, 352, 387, 392. |
| `src/fl/system/serial.h` | Suppress declaration at line 180 (body already routes via `fl::snprintf`). |
| `src/platforms/stub/Arduino.h` | Suppress declaration at line 191 (forwards to `fl::printf`). |

## Test plan

- [x] `uv run python ci/lint_cpp/bare_snprintf_checker.py` → 0 violations.
- [x] `bash lint --cpp` → all checks pass.
- [x] `bash bloat esp32s3` → 388,380 B flash unchanged (WASM files are `#ifdef FL_IS_WASM`-gated, so they don't link into ESP32-S3 — bloat metric is identical pre/post by design).
- [ ] `bash test --cpp` could not be run from inside the disposable PR worktree due to a build-system source-path bug filed at #2887. The same diff applied on the main checkout was lint-clean.

## Out of scope

This PR does **not** flip the `FASTLED_LOG_VERBOSITY` default — that's Stage 1 of #2886 and gets its own PR. This PR only enforces "no bare C printf family" so when Stage 1 lands, it doesn't have any FL_WARN sites that secretly reach the C printf engine.

## Related

- **#2886** — meta: ESP32-S3 Blink bloat reduction (parent issue)
- **#2773** — original binary-size meta (closed)
- **#2775** — `fl::snprintf` migration PR (the prereq this PR closes the long tail of)
- **#2887** — source-path bug that blocked test validation from inside this PR's worktree

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded code linting checker to identify and flag additional unsafe C standard library function calls that were previously undetected across the codebase.
  * Standardized internal logging statements across multiple platform-specific implementations and system components to consistently use designated library functions rather than direct standard library calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->