### PR TITLE
chore(deps): bump zccache 1.11.15 -> 1.11.17

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,18 @@ dependencies = [
     "fpvgcc",
     "uv",
     "clang-tool-chain>=1.5.5",
+    # 1.11.17 (released 2026-06-06): docs-only release that surfaces the
+    # ZCCACHE_PATH_REMAP env var in `zccache --help` (zackees/zccache#676).
+    # 1.11.16 (released 2026-06-06): adaptive daemon-spawn wait keyed on
+    # lockfile PID (zackees/zccache#674, closes #673) — eliminates the
+    # thundering-herd "daemon started but not accepting connections after
+    # 10s" wedge that hit our `clud-pr` parallel builds.
+    # 1.11.15 (released 2026-06-06): pipe-pool depletion + compile-path
+    # wedge recovery (zackees/zccache#669, refs #666) — daemon stopped
+    # responding after ~1h uptime on Windows during heavy concurrent
+    # compile load. Bumping to >=1.11.17 captures both fixes; the
+    # "lost connection to daemon (no response)" symptom we hit during
+    # the recent FastLED bloat-audit worktree builds maps to #673.
     # 1.11.14 ships the `--no-walk` flag plus an expanded skip-list for
     # the meson-configure wrapper (zackees/zccache#660, closes zackees/
     # zccache#659). With `--no-walk` the wrapper skips its recursive
@@ -72,7 +84,7 @@ dependencies = [
     # incremental builds produce stale .obj files after a git pull that
     # changes transitive headers (symptom: `undefined symbol: ...` link
     # errors hours after a header actually changed).
-    "zccache>=1.11.15",
+    "zccache>=1.11.17",
     "ninja",
     "meson>=1.11.0",
     "download",


### PR DESCRIPTION
chore(deps): bump zccache 1.11.15 -> 1.11.17

Brings in two upstream fixes that map directly to symptoms hit during
the recent `clud-pr` parallel-build worktree iterations:

- **1.11.16** — adaptive daemon-spawn wait keyed on lockfile PID
  (zackees/zccache#674, closes #673). Fixes the thundering-herd
  "daemon started but not accepting connections after 10s" wedge
  that surfaced as `zccache[err][R]: lost connection to daemon (no
  response)` during heavy parallel build jobs. The bundled error
  message hint about "daemon-CLI protocol version mismatch" was
  misleading — the real cause is the daemon hangup during the herd
  window.
- **1.11.17** — docs-only release that surfaces `ZCCACHE_PATH_REMAP`
  in `zccache --help` (zackees/zccache#676).

The wedge-recovery work that landed in 1.11.15 (zackees/zccache#669
refs #666) is the previous pin floor; the new floor at 1.11.17 picks
up the thundering-herd fix on top.

Verified locally:

```
.venv/Scripts/zccache.exe --version
zccache 1.11.17
```

Refs zackees/zccache#673, #674.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated zccache dependency to version 1.11.17, which includes improved daemon wait behavior keyed on lockfile PID and path remapping enhancements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->