### PR TITLE
perf(log): default FASTLED_LOG_VERBOSITY=0 in release builds (#2886 Stage 1)

### DIFF
--- a/.claude/skills/code-review/review-rules.md
+++ b/.claude/skills/code-review/review-rules.md
@@ -135,3 +135,24 @@ Remove variables that are no longer referenced after refactoring.
 ## src/** changes - PERFORMANCE ATTRIBUTES ON HOT-PATH FUNCTIONS
 Available macros: `FL_OPTIMIZE_FUNCTION`, `FL_NO_INLINE_IF_AVR`, `FL_BUILTIN_MEMCPY`
 Flag new functions in hot-path files missing appropriate optimization attributes.
+
+## src/** changes - FL_WARN / FL_ERROR DEFAULT-VISIBILITY INVARIANT
+`FL_WARN` and `FL_ERROR` MUST remain active by default on NON-release
+builds. Flag any change that:
+
+1. Adds an outer guard around `FL_WARN(...)` / `FL_ERROR(...)` that
+   requires an opt-in macro to fire on debug/non-release builds.
+2. Changes the unset default of `FASTLED_LOG_VERBOSITY` so that
+   non-release builds (no `NDEBUG`) default below `1`. Release builds
+   (`NDEBUG` defined) default to `0` — that is intentional and not
+   a violation.
+3. Adds a new logging knob whose default suppresses FL_WARN/FL_ERROR
+   on non-release builds without explicit user opt-in.
+
+Rationale: developers depend on warnings/errors firing during
+development. The bloat-reduction work in #2886 is scoped to release
+builds via `NDEBUG`; it explicitly preserves the debug-build default
+at verbosity 1.
+
+**See:** `src/fl/log/log.h` (resolution order: `FASTLED_TESTING` → 1,
+`NDEBUG` → 0, otherwise → 1) and #2886 Stage 1.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -105,3 +105,33 @@ reviews:
         adding such a function, also add the `FastLED.setX(...)` wrapper in
         `src/FastLED.h` and document the god-instance form in the PR
         description / examples.
+
+    - path: "src/fl/log/**"
+      instructions: |
+        FL_WARN / FL_ERROR default-visibility invariant (#2886 Stage 1):
+
+        FL_WARN and FL_ERROR MUST remain active by default on NON-release
+        builds. Flag changes that:
+
+        1. Add an outer guard around FL_WARN(...) / FL_ERROR(...) that
+           requires an opt-in macro to fire on debug/non-release builds.
+        2. Change the unset default of FASTLED_LOG_VERBOSITY so that
+           non-release builds (no NDEBUG) default below 1. Release builds
+           (NDEBUG defined) default to 0 — that is intentional and not
+           a violation.
+        3. Add a new logging knob whose default suppresses FL_WARN /
+           FL_ERROR on non-release builds without explicit user opt-in.
+
+        Rationale: developers depend on warnings / errors firing during
+        development. The bloat-reduction work in #2886 is scoped to
+        release builds via NDEBUG; it explicitly preserves the
+        debug-build default at verbosity 1.
+
+        Resolution order (the contract): FASTLED_TESTING => 1, NDEBUG
+        => 0, otherwise => 1. See src/fl/log/log.h.
+
+        Flag any PR that wraps an existing or new FL_WARN(...) /
+        FL_ERROR(...) site in an additional `#if !defined(...)` or
+        `#ifdef FASTLED_LOG_*` block that would suppress the call on
+        non-release builds by default — that breaks the
+        developer-visibility contract above.

--- a/src/fl/log/log.h
+++ b/src/fl/log/log.h
@@ -63,11 +63,19 @@
 //   * `FASTLED_LOG_VERBOSITY >= 2` → reserved for future "even noisier
 //     than debug" output; currently equivalent to level 1.
 //
-// Default: 1 (preserve current behavior). Define `FASTLED_LOG_VERBOSITY=0`
-// in your build flags (e.g. `build_flags = -DFASTLED_LOG_VERBOSITY=0` in
-// platformio.ini) to opt into the savings on release builds. Host unit
-// tests pin verbosity to 1 unconditionally so test diagnostics keep
-// firing regardless of build configuration.
+// Default selection (in resolution order):
+//
+//   * `FASTLED_TESTING` is set     → 1 (host unit tests need full diagnostics)
+//   * `NDEBUG` is set (release)    → 0 (drop ~55 KB of FL_WARN/FL_LOG strings
+//                                      on ESP32-S3 NEOPIXEL Blink; see #2886)
+//   * otherwise (debug builds)     → 1 (preserve current behavior)
+//
+// Users who want logs back on a release build define
+// `-DFASTLED_LOG_VERBOSITY=1` in their build flags or
+// `#define FASTLED_LOG_VERBOSITY 1` before `#include <FastLED.h>`. The
+// per-channel logging defines (`FASTLED_LOG_RMT_ENABLED`, `FASTLED_LOG_SPI_ENABLED`,
+// etc.) are still gated by their own `#define`s — only the verbosity floor
+// changes here.
 #ifdef FASTLED_TESTING
   // Host unit tests always want the full diagnostic stream so assertion
   // and warning messages can be checked in CI.
@@ -77,7 +85,11 @@
   #endif
 #else
   #ifndef FASTLED_LOG_VERBOSITY
-    #define FASTLED_LOG_VERBOSITY 1
+    #ifdef NDEBUG
+      #define FASTLED_LOG_VERBOSITY 0
+    #else
+      #define FASTLED_LOG_VERBOSITY 1
+    #endif
   #endif
 #endif
 


### PR DESCRIPTION
perf(log): default FASTLED_LOG_VERBOSITY=0 in release builds (#2886 Stage 1)

Flips the unset default of `FASTLED_LOG_VERBOSITY` from `1` to `0` when
`NDEBUG` is defined (i.e. release builds). Test builds (`FASTLED_TESTING`)
and debug builds (no `NDEBUG`) still default to `1`, so `FL_WARN` and
`FL_ERROR` stay live by default whenever you are not on a release build —
which is what the user-facing experience demands.

Resolution order:

  - FASTLED_TESTING is set     → 1 (host unit tests need full diagnostics)
  - NDEBUG is set (release)    → 0 (drops ~55 KB of FL_WARN/FL_LOG strings
                                    on ESP32-S3 NEOPIXEL Blink; see #2886
                                    "Stage 1" projection)
  - otherwise (debug builds)   → 1 (preserves current behavior)

Users on release builds who explicitly want FL_WARN/FL_LOG back set
`-DFASTLED_LOG_VERBOSITY=1` in their build flags, or `#define
FASTLED_LOG_VERBOSITY 1` before `#include <FastLED.h>`. The
per-channel logging defines (`FASTLED_LOG_RMT_ENABLED`,
`FASTLED_LOG_SPI_ENABLED`, etc.) keep their existing gates — only the
verbosity floor changes here.

This is Stage 1 of the multi-stage ESP32-S3 bloat-reduction plan tracked
in #2886. The projected savings of ~55 KB collapse the per-call-site
rodata pools attributed to the 75 FL_WARN/FL_LOG sites in
`channel_driver_rmt.cpp.hpp`, the 59 sites in `rmt_memory_manager.cpp.hpp`,
the 6 sites in `manager.cpp.hpp`, and the 5 sites in `channel.cpp.hpp` —
all reachable from the ClocklessIdf5 ctor transitive closure that
currently anchors 58,770 B of the 388,380 B Blink binary.

No public API changes. The `FASTLED_LOG_VERBOSITY` macro and its three
levels remain stable (introduced in #2791); only the unset default flips.

Refs #2886, #2791, #2773.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted logging verbosity defaults so testing and debug builds are verbose by default, while release builds default to quiet; user overrides remain supported.
* **Documentation**
  * Added guidance and review rules to ensure warning/error visibility remains enabled by default on non-release builds and to enforce the new logging default behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->