### PR TITLE
chore(deps): bump zccache 1.11.17 -> 1.11.18

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,14 @@ dependencies = [
     "fpvgcc",
     "uv",
     "clang-tool-chain>=1.5.5",
+    # 1.11.18 (released 2026-06-06): drops the misleading
+    # "daemon-CLI protocol version mismatch" hint from the
+    # user-facing `lost connection to daemon (no response)` error.
+    # The hint was written before the thundering-herd fix (#674,
+    # 1.11.16) and pipe-pool wedge fix (#669, 1.11.15) landed and
+    # pointed users at a cause that is wrong in practice. New copy
+    # is centralized in `util::LOST_CONNECTION_MSG` and points users
+    # at `zccache status` first (zackees/zccache#678).
     # 1.11.17 (released 2026-06-06): docs-only release that surfaces the
     # ZCCACHE_PATH_REMAP env var in `zccache --help` (zackees/zccache#676).
     # 1.11.16 (released 2026-06-06): adaptive daemon-spawn wait keyed on
@@ -84,7 +92,7 @@ dependencies = [
     # incremental builds produce stale .obj files after a git pull that
     # changes transitive headers (symptom: `undefined symbol: ...` link
     # errors hours after a header actually changed).
-    "zccache>=1.11.17",
+    "zccache>=1.11.18",
     "ninja",
     "meson>=1.11.0",
     "download",


### PR DESCRIPTION
chore(deps): bump zccache 1.11.17 -> 1.11.18

Picks up zackees/zccache#678 — drops the misleading "Often a
daemon-CLI protocol version mismatch — try `zccache stop`" hint from
the user-facing `lost connection to daemon (no response)` error
message. That text was written before the thundering-herd
(zackees/zccache#674) and pipe-pool (zackees/zccache#669) fixes
landed in 1.11.16 / 1.11.15; with those gone the remaining real
causes are an external `zccache stop`/kill mid-request or a daemon
crash, neither of which is "protocol version mismatch".

The new copy is centralized in `util::LOST_CONNECTION_MSG`, points
users at `zccache status` first, then a stop+retry recovery. All 7
user-facing call sites (`cache_ops`, `daemon`, `session` ×3,
`status`, `wrap/ipc` ×2) now share the single constant.

Local verification:

```
.venv/Scripts/zccache.exe --version
zccache 1.11.18
```

Refs zackees/zccache#678.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a core dependency to improve connection error handling and provide clearer guidance during connection issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->