### PR TITLE
chore: TODO note for ESP32-Bit-Pirate + ignore .claude/symbolaudit/ scratch dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,6 +121,7 @@ src/platforms/wasm/compiler/node_modules/
 .claude/pr*_*.json
 .claude/issue_*.md
 .claude/*.log
+.claude/symbolaudit/
 
 # Misc agent/tool transient stdout/stderr captures
 .tmp_*.txt

--- a/TODO.md
+++ b/TODO.md
@@ -42,6 +42,11 @@
   * Arduino test compile
     * https://github.com/hpwit/arduino-test-compile/blob/master/arduino-test-compile.sh
 
+  * Ingest protocol implementations from open-source ESP32-Bit-Pirate
+    * https://github.com/geo-tp/ESP32-Bit-Pirate/wiki/12-USB (starting point: USB)
+    * Goal: harvest reference protocol logic from the project's wiki pages
+      (USB and any other protocol modules they document) for reuse / inspiration
+
 
 # Misc:
 


### PR DESCRIPTION
chore: TODO note for ESP32-Bit-Pirate protocol harvesting + ignore agent scratch dir

Two small unrelated drifts that have been dangling on local `master`
between sessions; bundling them so the working tree stops surfacing
them on every `git status`.

1. **TODO.md** — adds a brief note under the embedded-toolchains
   section pointing at https://github.com/geo-tp/ESP32-Bit-Pirate as
   a reference repo whose wiki documents USB and other low-level
   protocol implementations we may want to harvest from. No code
   change — just a research pointer for future work.

2. **.gitignore** — adds `.claude/symbolaudit/` alongside the other
   `.claude/...` scratch entries. This directory accumulates per-session
   transient artifacts from agent runs (commit message drafts, issue
   bodies in flight, bloat-report JSON dumps, diff snapshots). It
   was never intended to be tracked and has been surfacing as
   untracked noise on every `git status` since the bloat-audit work
   started.

No source / build / test impact.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration and internal documentation to support project development workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->