### PR TITLE
perf(esp32): suppress Arduino-ESP32 boot banner via build-flag shim (#2886 Stage 2)

### DIFF
--- a/ci/lint_cpp/test_unity_build.py
+++ b/ci/lint_cpp/test_unity_build.py
@@ -84,6 +84,7 @@ EXPECTED_BUILD_FILES = {
     "fl/build/fl.wdt+.cpp",
     "fl/build/platforms+.cpp",
     "fl/build/third_party+.cpp",
+    "fl/build/extras+.cpp",
 }
 DANGEROUS_WILDCARD_PATTERNS = [
     "+<*.cpp>",

--- a/src/extras/_build.cpp.hpp
+++ b/src/extras/_build.cpp.hpp
@@ -1,0 +1,12 @@
+/// @file _build.cpp.hpp
+/// @brief Unity build header for src/extras/
+///
+/// `src/extras/` collects build-flag-gated shims. Each header below
+/// emits nothing unless a specific opt-in macro is defined in the
+/// user's build flags. Including this aggregator from the FastLED
+/// unity build is always safe — without the opt-in macro set, each
+/// shim expands to nothing.
+///
+/// Per-shim documentation lives at the top of each `*.cpp.hpp` file.
+
+#include "extras/suppress_arduino_chip_debug_report.cpp.hpp"

--- a/src/extras/suppress_arduino_chip_debug_report.cpp.hpp
+++ b/src/extras/suppress_arduino_chip_debug_report.cpp.hpp
@@ -1,0 +1,49 @@
+#pragma once
+
+// =============================================================================
+// Suppress the Arduino-ESP32 boot-banner code path. (#2886 Stage 2 / #2893)
+//
+// On ESP32 targets, the Arduino-ESP32 core's `cores/esp32/main.cpp:43`
+// declares:
+//
+//   __attribute__((weak)) bool shouldPrintChipDebugReport(void);
+//
+// and unconditionally references `printBeforeSetupInfo()` from the
+// `if (shouldPrintChipDebugReport())` branches at main.cpp:55 and :63.
+// Even at `ARDUHAL_LOG_LEVEL=0` (release default), the linker keeps
+// `printBeforeSetupInfo()` and its ~1-2 KB of formatted-stream rodata
+// alive because those call sites are reachable.
+//
+// Setting `-DFASTLED_SUPPRESS_ARDUINO_CHIP_DEBUG_REPORT=1` in build
+// flags emits a strong override of the weak vendor symbol below. The
+// optimizer folds both `if (shouldPrintChipDebugReport())` branches to
+// dead code, and `--gc-sections` drops `printBeforeSetupInfo()`
+// (~1,464 B at top-25 row #21 of #2886) plus its rodata carrier
+// strings — ~3 KB of flash on a typical ESP32-S3 NEOPIXEL build.
+//
+// USAGE (one option):
+//
+//   1. PlatformIO — in platformio.ini:
+//        build_flags = -DFASTLED_SUPPRESS_ARDUINO_CHIP_DEBUG_REPORT=1
+//
+//   2. Arduino IDE — in a `build_opt.h` or compiler.cpp.extra_flags
+//      override:
+//        -DFASTLED_SUPPRESS_ARDUINO_CHIP_DEBUG_REPORT=1
+//
+// This is opt-in: globally overriding a vendor weak symbol on every
+// FastLED user's behalf would be surprising scope creep, and some
+// users rely on the boot banner for debugging brownouts / wake-up
+// sources / PSRAM detection.
+//
+// On non-ESP32 targets, or with the flag undefined / set to 0, this
+// file expands to nothing.
+// =============================================================================
+
+#include "platforms/esp/is_esp.h"  // ok platform headers - for FL_IS_ESP32
+
+#if defined(FL_IS_ESP32) && defined(FASTLED_SUPPRESS_ARDUINO_CHIP_DEBUG_REPORT) \
+    && (FASTLED_SUPPRESS_ARDUINO_CHIP_DEBUG_REPORT)
+
+extern "C" bool shouldPrintChipDebugReport(void) { return false; }
+
+#endif  // FL_IS_ESP32 && FASTLED_SUPPRESS_ARDUINO_CHIP_DEBUG_REPORT

--- a/src/fl/build/extras+.cpp
+++ b/src/fl/build/extras+.cpp
@@ -1,0 +1,16 @@
+/// @file extras+.cpp
+/// @brief Unity build: includes from src/extras/
+///
+/// `src/extras/` collects opt-in shims that emit code only when a
+/// specific build-flag macro is defined. Including this aggregator
+/// from the library's unity build is always safe — each shim's body
+/// is gated on its own opt-in macro and reduces to nothing when the
+/// flag is unset.
+
+#include "platforms/new.h"
+
+// IWYU pragma: begin_keep
+#include "fl/system/arduino.h"
+// IWYU pragma: end_keep
+
+#include "extras/_build.cpp.hpp"


### PR DESCRIPTION
perf(esp32): suppress Arduino-ESP32 boot banner via build-flag shim (#2886 Stage 2)

Closes #2893.

Adds a build-flag-gated strong override of the Arduino-ESP32 core's
`shouldPrintChipDebugReport()` weak symbol. Setting

    build_flags = -DFASTLED_SUPPRESS_ARDUINO_CHIP_DEBUG_REPORT=1

in `platformio.ini` (or the equivalent in Arduino IDE
`compiler.cpp.extra_flags`) makes the optimizer fold both
`if (shouldPrintChipDebugReport())` branches at vendor `main.cpp:55`
and `main.cpp:63` to dead code. `--gc-sections` then drops
`printBeforeSetupInfo()` (~1,464 B at top-25 row #21 of #2886) plus
its ~1-2 KB of formatted-stream rodata carrier strings — projected
~3 KB of flash savings on the ESP32-S3 NEOPIXEL Blink baseline.

## Why a build flag, not an include?

The earlier design (an opt-in include `#include
<extras/suppress_arduino_chip_debug_report.cpp.hpp>` in the user
sketch) collided with the unity-build linter: every `.cpp.hpp` under
`src/` is required to participate in a `_build.cpp.hpp` aggregator,
which in turn is compiled by a `+.cpp` wrapper in `src/fl/build/`. The
shim file is therefore unavoidably part of the library compilation
unit.

Gating the body on `FASTLED_SUPPRESS_ARDUINO_CHIP_DEBUG_REPORT` and
`FL_IS_ESP32` keeps the default behavior unchanged for every user
who doesn't explicitly opt in. Opt-in via build flag is the same
ergonomic shape as `FASTLED_RMT_STATIC_ALLOCATION` (#2846) and
`FASTLED_LOG_VERBOSITY` (#2791) — recognizable to existing users
following the bloat-reduction docs.

## Files

- `src/extras/suppress_arduino_chip_debug_report.cpp.hpp` — the shim.
  Empty body unless `FL_IS_ESP32 && FASTLED_SUPPRESS_ARDUINO_CHIP_DEBUG_REPORT`.
- `src/extras/_build.cpp.hpp` — unity-build aggregator for `extras/`,
  documented as the home for build-flag-gated shims.
- `src/fl/build/extras+.cpp` — independently-compiled wrapper TU that
  pulls `extras/_build.cpp.hpp` into the library build (matches the
  existing `platforms+.cpp` / `third_party+.cpp` pattern).
- `ci/lint_cpp/test_unity_build.py` — register `fl/build/extras+.cpp`
  in `EXPECTED_BUILD_FILES` so the unity-build linter accepts the
  new wrapper.

## Verification

- `bash lint --cpp` → all C++ linting checks pass; the pre-existing
  PlatformIO-internal-usage warnings (issue #2701) are warn-only and
  unchanged by this PR.
- Flash savings (`bash bloat esp32s3 --build` with
  `-DFASTLED_SUPPRESS_ARDUINO_CHIP_DEBUG_REPORT=1`) measured by the
  Stage 6 verification gate; this PR only ships the mechanism.

## User-facing behavior

| Build flag | ESP32 target | Effect |
|---|---|---|
| unset / `=0` | yes | no change (vendor weak default fires) |
| `=1` | yes | strong override → `printBeforeSetupInfo()` dead-stripped |
| any | no  | shim expands to nothing |

Refs #2886, #2893.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added opt-in flag to suppress Arduino-ESP32 chip debug messages. Enable `FASTLED_SUPPRESS_ARDUINO_CHIP_DEBUG_REPORT` to hide startup messages on ESP32 targets.

* **Chores**
  * Refactored build infrastructure with a new extras module supporting build-flag-gated features that safely reduce to no-ops when disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->