### PR TITLE
docs(esp32): ship tools/sdkconfig_for_smallest_fastled.defaults overlay (#2886 Stage 3)

### DIFF
--- a/agents/docs/binary-size-analysis.md
+++ b/agents/docs/binary-size-analysis.md
@@ -42,7 +42,16 @@ These are the gotchas the wrapper handles for you. They are documented here so t
 
 2. **Map-derived synthesis is what makes the report useful.** fbuild PR #427 parses `.rodata.<owner>.str1.<N>` input-section names and attributes those bytes to the owning function. Without it, the single biggest contributor on ESP32-S3 Blink (the NEOPIXEL chipset ctor's `FL_WARN`/`FL_LOG` string pool, ~58 KB / 15 %) appears as anonymous bytes against `main.cpp.o` and there's no way to chase it. The `source: "map-derived"` field on each symbol tags rows whose attribution came from this synthesis pass; treat them with the same trust as `source: "nm"` rows.
 
-3. **The dominant flash lever on ESP32-S3 is `FASTLED_LOG_VERBOSITY=0`.** FastLED PR #2791 introduced this build-time knob. Setting it (define before `#include <FastLED.h>`) collapses ~43-58 KB of FL_WARN string pool with zero behaviour change for users who don't need release-mode logging. **Always check whether this knob is set before chasing other optimisations — it's a single define that dominates everything else.**
+3. **The dominant flash lever on ESP32-S3 is `FASTLED_LOG_VERBOSITY=0`.** FastLED PR #2791 introduced this build-time knob. Setting it (define before `#include <FastLED.h>`) collapses ~43-58 KB of FL_WARN string pool with zero behaviour change for users who don't need release-mode logging. **Always check whether this knob is set before chasing other optimisations — it's a single define that dominates everything else.** Since #2890 (Stage 1 of #2886), the default flips to `0` automatically when `NDEBUG` is set (release builds).
+
+   ### Release-build flash savers (in order of impact)
+
+   | Lever | How to enable | Savings | Source |
+   |---|---|---:|---|
+   | `FASTLED_LOG_VERBOSITY=0` | Now the release default (NDEBUG); explicit `-DFASTLED_LOG_VERBOSITY=1` to restore | ~43-58 KB | #2791 + #2890 |
+   | `tools/sdkconfig_for_smallest_fastled.defaults` | `board_build.sdkconfig_defaults` in `platformio.ini`; disables coredump, IDF log, bootloader log, panic-print | ~10-15 KB | #2895 (Stage 3) |
+   | `-DFASTLED_SUPPRESS_ARDUINO_CHIP_DEBUG_REPORT=1` | `build_flags`; strong-overrides the Arduino-ESP32 boot-banner gate | ~3 KB | #2894 (Stage 2) |
+   | `-DFASTLED_RMT_STATIC_ALLOCATION=1` | `build_flags`; for sketches that init LEDs in `setup()` and never remove | ~22-43 KB | #2846 |
 
 4. **`--nm` is still required.** fbuild's `build_info.json` does not yet carry toolchain paths (`nm_path` / `cppfilt_path`). The wrapper resolves them from PIO packages. fbuild issue #428 tracks the migration to build-info-driven resolution; when that lands, drop the explicit `--nm` path in `ci/bloat.py::run_fbuild_symbols`.
 

--- a/tools/sdkconfig_for_smallest_fastled.defaults
+++ b/tools/sdkconfig_for_smallest_fastled.defaults
@@ -1,0 +1,69 @@
+# =============================================================================
+# sdkconfig_for_smallest_fastled.defaults
+#
+# FastLED Stage 3 / #2895 — opt-in ESP-IDF sdkconfig overlay for users who
+# want to drop ~10-15 KB of release-build flash on a typical ESP32 LED strip.
+#
+# USAGE — in your platformio.ini, layer this on top of your own defaults:
+#
+#   [env:esp32s3]
+#   platform = espressif32
+#   board = esp32-s3-devkitm-1
+#   framework = arduino
+#   board_build.sdkconfig_defaults =
+#       sdkconfig.defaults
+#       ${platformio.packages_dir}/framework-arduinoespressif32/tools/sdkconfig.defaults.esp32s3
+#       ${PROJECT_LIBDEPS_DIR}/${PIOENV}/FastLED/tools/sdkconfig_for_smallest_fastled.defaults
+#
+# (The exact path under `PROJECT_LIBDEPS_DIR` depends on how PIO resolves
+# library installs in your project. Substitute the absolute path if needed.)
+#
+# Each line below is grounded against the top-25 symbol table in #2886.
+# Conservative entries are uncommented; situational ones live below the
+# fold and require an explicit opt-in.
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# Conservative knobs — safe defaults for any deployed LED installation
+# -----------------------------------------------------------------------------
+
+# Disable coredump-to-flash. Eliminates symbols #18
+# (esp_core_dump_do_write_elf_pass, 1,835 B) and #25
+# (esp_core_dump_get_task_regs_dump, 1,103 B) plus ~5 KB of tail symbols in
+# libespcoredump.a. LED installations are headless; nobody retrieves a
+# coredump from the flash partition anyway. Re-enable explicitly if you
+# actively post-mortem crashes.
+# Projected savings: ~8 KB.
+CONFIG_ESP_COREDUMP_ENABLE_TO_FLASH=n
+
+# Drop the ESP-IDF runtime log infrastructure. Independent of FastLED's
+# FL_WARN/FL_LOG path — that's governed separately by FASTLED_LOG_VERBOSITY
+# (Stage 1 of #2886). Eliminates symbol #19 (diag_log_add, 1,604 B) and
+# ~1-2 KB of IDF log format strings scattered through
+# libespressif__esp_diagnostics, libesp_diagnostics, and libheap.
+# Projected savings: ~3 KB.
+CONFIG_LOG_DEFAULT_LEVEL=ESP_LOG_NONE
+
+# Silence the bootloader's per-stage progress messages. The strings live
+# in flash regardless of whether the bootloader actually runs them at
+# boot — a deployed installation has no console.
+# Projected savings: ~1 KB.
+CONFIG_BOOTLOADER_LOG_LEVEL_NONE=y
+
+# Switch the panic handler from "reboot with backtrace" to "halt with
+# minimal state dump". On a release LED installation a panic-time reboot
+# loop is more disruptive than a halt; the smaller code path also drops
+# the panic-time formatter strings.
+# Projected savings: ~1-2 KB.
+CONFIG_ESP_SYSTEM_PANIC_PRINT_HALT=y
+
+# -----------------------------------------------------------------------------
+# Situational knobs — uncomment ONLY if you know your project doesn't need them
+# -----------------------------------------------------------------------------
+
+# CONFIG_BT_ENABLED=n
+#   Disables the Bluetooth stack entirely. On projects that currently
+#   have BT on (the default for many esp32-s3 board configs), flipping
+#   this knob can drop another ~15 KB on top of the conservative set
+#   above. SAFE ONLY IF your sketch and dependencies do not use BLE/BT.
+#   Most FastLED LED-strip sketches don't.


### PR DESCRIPTION
docs(esp32): ship `tools/sdkconfig_for_smallest_fastled.defaults` overlay (#2886 Stage 3)

Closes #2895.

Adds a documented, opt-in ESP-IDF sdkconfig overlay that users plug into
`board_build.sdkconfig_defaults`. Drops ~10-15 KB of release-build flash
on a typical ESP32 LED installation by disabling IDF components that a
deployed strip never uses:

| Knob | Eliminates | Savings |
|---|---|---:|
| `CONFIG_ESP_COREDUMP_ENABLE_TO_FLASH=n` | libespcoredump (top-25 rows #18 + #25, ~3 KB symbols + ~5 KB tail) | ~8 KB |
| `CONFIG_LOG_DEFAULT_LEVEL=ESP_LOG_NONE`  | libesp_diagnostics + IDF log strings (top-25 row #19) | ~3 KB |
| `CONFIG_BOOTLOADER_LOG_LEVEL_NONE=y`     | bootloader-stage UART chatter | ~1 KB |
| `CONFIG_ESP_SYSTEM_PANIC_PRINT_HALT=y`   | panic-time backtrace formatter | ~1-2 KB |

`CONFIG_BT_ENABLED=n` is shipped commented-out (~15 KB extra when the
project currently has BT on) — users uncomment when they know their
sketch doesn't touch BLE/BT.

## Files

- `tools/sdkconfig_for_smallest_fastled.defaults` — the overlay
  itself, with inline per-knob comments grounding each line in the
  #2886 top-25 attribution.
- `agents/docs/binary-size-analysis.md` — adds a "Release-build flash
  savers (in order of impact)" table that lists this overlay
  alongside the FASTLED_LOG_VERBOSITY default (#2890), the boot-banner
  shim (#2894), and FASTLED_RMT_STATIC_ALLOCATION (#2846). Single
  reference point for what knobs exist and how to enable them.

## Why a user-side overlay, not a library-side default

`sdkconfig` is consumed by the ESP-IDF build before any FastLED TU is
compiled. FastLED cannot mutate IDF defaults from a library; the
deliverable here is therefore a *shippable overlay file* the user
points `board_build.sdkconfig_defaults` at, plus documentation that
tells them which lines map to which savings.

## User integration

```
[env:esp32s3]
board_build.sdkconfig_defaults =
    sdkconfig.defaults
    ${platformio.packages_dir}/framework-arduinoespressif32/tools/sdkconfig.defaults.esp32s3
    ${PROJECT_LIBDEPS_DIR}/${PIOENV}/FastLED/tools/sdkconfig_for_smallest_fastled.defaults
```

(See the file's header for the full snippet; `PROJECT_LIBDEPS_DIR`
resolution varies by PIO project layout.)

## Verification

- `bash lint --cpp` → C++ linting passes (this PR is docs-only;
  pre-existing PlatformIO-internal-usage warnings unchanged).
- Per-project flash deltas are user-side measurements; the projection
  table in `binary-size-analysis.md` cites the #2886 top-25 baseline
  attribution for each line.

Refs #2886, #2895.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced flash optimization guidance for ESP32-S3 with a ranked reference table of build-time configuration options, showing each option's approximate flash savings and original sources.

* **New Features**
  * Added a configuration template resource with documented settings to help reduce release-build flash usage on ESP32-S3 devices through optional, stackable configuration layers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->