### PR TITLE
tools(bloat): ship tests/measure_esp32s3_opt_ins.py multi-config audit driver

### DIFF
--- a/agents/docs/binary-size-analysis.md
+++ b/agents/docs/binary-size-analysis.md
@@ -55,6 +55,8 @@ These are the gotchas the wrapper handles for you. They are documented here so t
 
    The user-facing copy of this table — same content, written for end users rather than agents, with platformio.ini snippets — lives at [`docs/SLIM_ESP32S3.md`](../../docs/SLIM_ESP32S3.md). When a new knob lands, update both: this table for the agent reference, and `docs/SLIM_ESP32S3.md` for the user copy.
 
+   To refresh the measured numbers in the SLIM doc, run `uv run python tests/measure_esp32s3_opt_ins.py --config all --out compare.md` — the script builds the ESP32-S3 Blink under each opt-in combo, runs `bash bloat esp32s3` against each ELF, and emits a Markdown comparison table sized to drop straight into the doc. See #2905.
+
 4. **`--nm` is still required.** fbuild's `build_info.json` does not yet carry toolchain paths (`nm_path` / `cppfilt_path`). The wrapper resolves them from PIO packages. fbuild issue #428 tracks the migration to build-info-driven resolution; when that lands, drop the explicit `--nm` path in `ci/bloat.py::run_fbuild_symbols`.
 
 5. **Diff two builds with the existing diff script.** Save two `report.json` files and run `uv run python .claude/symbolaudit/diff.py <old.json> <new.json>` for a per-symbol delta table (added / removed / grew / shrunk). The wrapper does NOT do this automatically; ship a follow-up PR if you need it inline.

--- a/tests/measure_esp32s3_opt_ins.py
+++ b/tests/measure_esp32s3_opt_ins.py
@@ -1,0 +1,323 @@
+"""Multi-config ESP32-S3 NEOPIXEL Blink bloat audit driver (FastLED #2905).
+
+Builds the ESP32-S3 Blink under each release-mode opt-in combo from
+#2886 (baseline, +Stage 2 boot-banner shim, +Stage 3 sdkconfig
+overlay, +Stage 4 RMT static allocation, and the full "stack"), runs
+`bash bloat esp32s3` against each ELF, and emits a Markdown comparison
+table.
+
+The output table maps 1:1 onto rows 1-4 of the
+`docs/SLIM_ESP32S3.md` priority table; a follow-up doc PR feeds the
+table into the doc to flip the 📊 status flags to ✅.
+
+USAGE
+
+    uv run python tests/measure_esp32s3_opt_ins.py
+    uv run python tests/measure_esp32s3_opt_ins.py --config stage2
+    uv run python tests/measure_esp32s3_opt_ins.py --config all --out compare.md
+    uv run python tests/measure_esp32s3_opt_ins.py --keep-platformio-ini-backup
+
+Exits 0 on success. Exits 1 if any requested config's build / bloat
+run fails. Exits 2 on infrastructure failure (missing platformio.ini,
+missing bash compile, etc.).
+
+The script's first action is to back up `platformio.ini` to
+`platformio.ini.bak` and install signal handlers so a Ctrl-C mid-run
+restores the file before exit. The build / bloat invocations go
+through the same `bash compile` / `bash bloat` wrappers the rest of
+the project uses; no direct `pio`/`platformio` calls.
+
+Run from the FastLED project root.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import signal
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+PLATFORMIO_INI = PROJECT_ROOT / "platformio.ini"
+PLATFORMIO_INI_BACKUP = PROJECT_ROOT / "platformio.ini.bak"
+REPORT_JSON = PROJECT_ROOT / ".build" / "symbols" / "esp32s3" / "report.json"
+OVERLAY_PATH = "tools/sdkconfig_for_smallest_fastled.defaults"
+
+
+@dataclass(frozen=True)
+class OptInConfig:
+    """One opt-in combo to measure.
+
+    Attributes:
+        name: short name (e.g. "stage2"); also the doc-row key.
+        label: human-readable description shown in the comparison table.
+        build_flags: extra -D flags to append into [env:esp32s3]'s
+            build_flags. May be empty.
+        overlay: True iff sdkconfig_for_smallest_fastled.defaults must
+            be appended to board_build.sdkconfig_defaults.
+    """
+
+    name: str
+    label: str
+    build_flags: tuple[str, ...]
+    overlay: bool
+
+
+CONFIGS: dict[str, OptInConfig] = {
+    "baseline": OptInConfig(
+        name="baseline",
+        label="Stage 1 only (NDEBUG default — `FASTLED_LOG_VERBOSITY=0`)",
+        build_flags=(),
+        overlay=False,
+    ),
+    "stage2": OptInConfig(
+        name="stage2",
+        label="+ Stage 2 (`FASTLED_SUPPRESS_ARDUINO_CHIP_DEBUG_REPORT=1`)",
+        build_flags=("-DFASTLED_SUPPRESS_ARDUINO_CHIP_DEBUG_REPORT=1",),
+        overlay=False,
+    ),
+    "stage3": OptInConfig(
+        name="stage3",
+        label="+ Stage 3 (`tools/sdkconfig_for_smallest_fastled.defaults` overlay)",
+        build_flags=(),
+        overlay=True,
+    ),
+    "stage4": OptInConfig(
+        name="stage4",
+        label="+ Stage 4 (`FASTLED_RMT_STATIC_ALLOCATION=1`)",
+        build_flags=("-DFASTLED_RMT_STATIC_ALLOCATION=1",),
+        overlay=False,
+    ),
+    "stack": OptInConfig(
+        name="stack",
+        label="Full SLIM TL;DR stack (Stages 2 + 3 + 4)",
+        build_flags=(
+            "-DFASTLED_SUPPRESS_ARDUINO_CHIP_DEBUG_REPORT=1",
+            "-DFASTLED_RMT_STATIC_ALLOCATION=1",
+        ),
+        overlay=True,
+    ),
+}
+
+
+def backup_platformio_ini() -> None:
+    if not PLATFORMIO_INI.is_file():
+        print(
+            f"measure-opt-ins: platformio.ini not found at {PLATFORMIO_INI}",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    shutil.copyfile(PLATFORMIO_INI, PLATFORMIO_INI_BACKUP)
+
+
+def restore_platformio_ini(keep_backup: bool) -> None:
+    if PLATFORMIO_INI_BACKUP.is_file():
+        shutil.copyfile(PLATFORMIO_INI_BACKUP, PLATFORMIO_INI)
+        if not keep_backup:
+            PLATFORMIO_INI_BACKUP.unlink()
+
+
+def patch_platformio_ini(cfg: OptInConfig) -> None:
+    """Inject cfg's build_flags / overlay into the [env:esp32s3] block.
+
+    This is a targeted regex patch — we don't fully re-parse INI
+    because PlatformIO's flavor of INI carries continuation lines and
+    `${var.x}` interpolations that configparser mangles. The regex
+    target is the literal `[env:esp32s3]` header through the next
+    `[env:` header (or EOF), which is well-defined in practice.
+    """
+    text = PLATFORMIO_INI.read_text(encoding="utf-8")
+    block_re = re.compile(r"(\[env:esp32s3\][^\[]*?)(?=\n\[env:|\Z)", re.DOTALL)
+    match = block_re.search(text)
+    if not match:
+        print(
+            "measure-opt-ins: could not locate [env:esp32s3] block in platformio.ini",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    block = match.group(1)
+    if cfg.build_flags:
+        extra = "\n    " + "\n    ".join(cfg.build_flags)
+        if "build_flags =" in block:
+            block = re.sub(
+                r"(build_flags\s*=)",
+                r"\1" + extra,
+                block,
+                count=1,
+            )
+        else:
+            block = block.rstrip() + "\nbuild_flags =" + extra + "\n"
+    if cfg.overlay:
+        line = f"board_build.sdkconfig_defaults = {OVERLAY_PATH}\n"
+        if "board_build.sdkconfig_defaults" in block:
+            block = re.sub(
+                r"board_build\.sdkconfig_defaults\s*=.*",
+                line.rstrip(),
+                block,
+            )
+        else:
+            block = block.rstrip() + "\n" + line
+    new_text = text[: match.start()] + block + text[match.end() :]
+    PLATFORMIO_INI.write_text(new_text, encoding="utf-8")
+
+
+def run_compile(example: str) -> bool:
+    cmd = ["bash", "compile", "esp32s3", "--examples", example, "--platformio"]
+    print(f"measure-opt-ins: $ {' '.join(cmd)}", flush=True)
+    return subprocess.run(cmd, cwd=PROJECT_ROOT).returncode == 0
+
+
+def run_bloat() -> bool:
+    cmd = ["bash", "bloat", "esp32s3", "--no-summary"]
+    print(f"measure-opt-ins: $ {' '.join(cmd)}", flush=True)
+    return subprocess.run(cmd, cwd=PROJECT_ROOT).returncode == 0
+
+
+def read_total_flash() -> int | None:
+    if not REPORT_JSON.is_file():
+        return None
+    data = json.loads(REPORT_JSON.read_text(encoding="utf-8"))
+    return int(data["total_flash"])
+
+
+def archive_report(cfg: OptInConfig) -> Path:
+    dst = REPORT_JSON.with_name(f"report.{cfg.name}.json")
+    shutil.copyfile(REPORT_JSON, dst)
+    return dst
+
+
+def measure_one(cfg: OptInConfig, example: str) -> int | None:
+    """Build + bloat one config; return total_flash or None on failure."""
+    print(f"\n=== measure-opt-ins: config {cfg.name} ({cfg.label}) ===", flush=True)
+    restore_platformio_ini(keep_backup=True)
+    patch_platformio_ini(cfg)
+    if not run_compile(example):
+        print(f"measure-opt-ins: compile failed for {cfg.name}", file=sys.stderr)
+        return None
+    if not run_bloat():
+        print(f"measure-opt-ins: bloat run failed for {cfg.name}", file=sys.stderr)
+        return None
+    total = read_total_flash()
+    if total is None:
+        print(
+            f"measure-opt-ins: report.json missing after {cfg.name} bloat run",
+            file=sys.stderr,
+        )
+        return None
+    archived = archive_report(cfg)
+    print(
+        f"measure-opt-ins: {cfg.name} total_flash = {total:,} B "
+        f"(report archived: {archived.relative_to(PROJECT_ROOT).as_posix()})",
+        flush=True,
+    )
+    return total
+
+
+def format_table(results: dict[str, int]) -> str:
+    baseline = results.get("baseline")
+    lines = [
+        "| Config | Label | total_flash | Δ vs baseline | Δ vs previous |",
+        "|---|---|---:|---:|---:|",
+    ]
+    prev: int | None = None
+    for name, cfg in CONFIGS.items():
+        if name not in results:
+            continue
+        total = results[name]
+        dvb = "" if baseline is None else f"{total - baseline:+,} B"
+        dvp = "" if prev is None else f"{total - prev:+,} B"
+        lines.append(f"| `{name}` | {cfg.label} | {total:,} B | {dvb} | {dvp} |")
+        prev = total
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--config",
+        default="all",
+        help=(
+            "Comma-separated list of configs to run, or `all`. Available: "
+            + ", ".join(CONFIGS.keys())
+        ),
+    )
+    parser.add_argument(
+        "--example",
+        default="Blink",
+        help="Example sketch to build (default: Blink).",
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=None,
+        help="If set, write the Markdown comparison table to this path.",
+    )
+    parser.add_argument(
+        "--keep-platformio-ini-backup",
+        action="store_true",
+        help="Keep platformio.ini.bak around after the run (default: delete on success).",
+    )
+    args = parser.parse_args()
+
+    if args.config == "all":
+        requested = list(CONFIGS.keys())
+    else:
+        requested = [c.strip() for c in args.config.split(",") if c.strip()]
+        for name in requested:
+            if name not in CONFIGS:
+                print(
+                    f"measure-opt-ins: unknown config '{name}'. Available: "
+                    + ", ".join(CONFIGS.keys()),
+                    file=sys.stderr,
+                )
+                return 2
+
+    backup_platformio_ini()
+
+    def _restore_and_exit(*_: object) -> None:
+        restore_platformio_ini(keep_backup=args.keep_platformio_ini_backup)
+        sys.exit(130)
+
+    signal.signal(signal.SIGINT, _restore_and_exit)
+    if hasattr(signal, "SIGTERM"):
+        signal.signal(signal.SIGTERM, _restore_and_exit)
+
+    results: dict[str, int] = {}
+    failed: list[str] = []
+    try:
+        for name in requested:
+            total = measure_one(CONFIGS[name], args.example)
+            if total is None:
+                failed.append(name)
+            else:
+                results[name] = total
+    finally:
+        restore_platformio_ini(keep_backup=args.keep_platformio_ini_backup)
+
+    print()
+    print("=== Measured comparison ===")
+    table = format_table(results)
+    print(table)
+
+    if args.out is not None:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(table, encoding="utf-8")
+        print(f"measure-opt-ins: wrote table to {args.out}")
+
+    if failed:
+        print(
+            f"measure-opt-ins: FAIL — config(s) failed to measure: {', '.join(failed)}",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
tools(bloat): ship tests/measure_esp32s3_opt_ins.py multi-config audit driver

Closes #2905.

Ships a CLI driver that builds the ESP32-S3 NEOPIXEL Blink under each
release-mode opt-in combo from #2886, runs `bash bloat esp32s3`
against each ELF, and emits a Markdown comparison table sized to drop
straight into the priority table in `docs/SLIM_ESP32S3.md`.

The script is the bridge between the SLIM doc's projected (📊)
entries and the measured (✅) ones. A follow-up doc PR runs the
script, captures the table, and flips 📊 → ✅ for the rows backed by
measurement.

## What ships

| File | Role |
|---|---|
| `tests/measure_esp32s3_opt_ins.py` | Multi-config audit driver. CLI: `--config {baseline\|stage2\|stage3\|stage4\|stack\|all}`, `--example Blink`, `--out compare.md`, `--keep-platformio-ini-backup`. |
| `agents/docs/binary-size-analysis.md` | One-line pointer to the script so future agents / users know how to refresh the doc's measurements. |

## Config matrix

| Config | build_flags addition | sdkconfig overlay | Source SLIM row |
|---|---|---|---|
| `baseline` | (none) | (user default) | row 1 — Stage 1 (NDEBUG default) |
| `stage2`   | `-DFASTLED_SUPPRESS_ARDUINO_CHIP_DEBUG_REPORT=1` | (user default) | row 4 |
| `stage3`   | (none) | `+ tools/sdkconfig_for_smallest_fastled.defaults` | row 2 |
| `stage4`   | `-DFASTLED_RMT_STATIC_ALLOCATION=1` | (user default) | row 3 |
| `stack`    | Stages 2 + 3 + 4 all enabled | overlay applied | SLIM TL;DR snippet |

## Safety properties

- **Backup / restore.** First action backs up `platformio.ini` →
  `platformio.ini.bak`. SIGINT / SIGTERM handlers restore the file
  before exit; `finally:` block restores on any other exit path.
  The backup is deleted on clean exit unless
  `--keep-platformio-ini-backup` is set.
- **Targeted regex patch, not full INI re-parse.** PlatformIO's
  flavor of INI carries continuation lines and `${var.x}`
  interpolations that `configparser` mangles. The script only patches
  the `[env:esp32s3]` block via a regex that matches up to the next
  `[env:` header (or EOF) — well-defined in practice.
- **Per-config report archival.** Each config's `report.json` gets
  copied to `report.<config>.json` in the same dir, so the per-symbol
  data is preserved for `.claude/symbolaudit/diff.py` comparisons.

## Verification

- `bash lint` → all linters pass (Python via ruff + ty, C++, JS).
  The 6 pre-existing `ty` warnings about `os.system` are in unrelated
  CI scripts; not introduced by this PR.
- The script's first-pass logic was reviewed against the actual
  `[env:esp32s3]` block in `platformio.ini` (extends `env:generic-esp`,
  carries `board_build.flash_size`, `board_build.partitions`,
  `build_flags`). The regex correctly identifies the block boundary.
- Running the script end-to-end on a real machine produces the
  comparison table that the follow-up doc PR consumes; that run
  isn't in this PR because it's a separate measurement step
  (~16 min for 5 configs × ~3-4 min each).

## Out of scope

- **The follow-up doc PR** that runs the script and flips 📊 → ✅
  rows in `docs/SLIM_ESP32S3.md`.
- **Ratcheting `tests/data/esp32s3_bloat_baseline.txt`** — the gate
  baseline only tightens when a measured saving lands in `src/`, not
  when a user-side build flag delivers the savings.
- **CI integration** of the multi-config measurement. Initial scope
  is a developer-facing local tool.

Refs #2886, #2905, #2904, #2900, #2898.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated binary size analysis guide with detailed instructions and command examples for measuring and comparing performance across different build configurations.

* **Tests**
  * Added automated measurement tool for evaluating ESP32-S3 binary sizes across multiple build-time configurations, generating comparison tables with delta analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->