### PR TITLE
perf(esp32): add fl::sort_small for bounded containers; cut ClocklessIdf5 bloat

### DIFF
--- a/src/fl/channels/manager.cpp.hpp
+++ b/src/fl/channels/manager.cpp.hpp
@@ -133,8 +133,9 @@ void ChannelManager::addDriver(int priority, fl::shared_ptr<IChannelDriver> driv
 
     // Sort drivers by priority descending (higher values first) after each insertion
     // Higher priority values = higher precedence (e.g., priority 50 selected over priority 10)
-    // Only 1-4 drivers expected, so sorting on insert is negligible
-    fl::sort(mDrivers.begin(), mDrivers.end());
+    // Only 1-4 drivers expected — sort_small skips the quicksort_impl
+    // instantiation entirely (see #2907 for the bloat motivation).
+    fl::sort_small(mDrivers.begin(), mDrivers.end());
 }
 
 bool ChannelManager::removeDriver(fl::shared_ptr<IChannelDriver> driver) {
@@ -246,8 +247,9 @@ bool ChannelManager::setDriverPriority(const fl::string& name, int priority) {
         return false;
     }
 
-    // Re-sort drivers by priority (descending: higher values first)
-    fl::sort(mDrivers.begin(), mDrivers.end());
+    // Re-sort drivers by priority (descending: higher values first).
+    // 1-4 drivers expected here too — sort_small avoids the quicksort body.
+    fl::sort_small(mDrivers.begin(), mDrivers.end());
 
     FL_DBG("ChannelManager: Engine list re-sorted after priority change");
     return true;

--- a/src/fl/stl/algorithm.h
+++ b/src/fl/stl/algorithm.h
@@ -595,6 +595,34 @@ void stable_sort(Iterator first, Iterator last) FL_NOEXCEPT {
     stable_sort(first, last, [](const value_type& a, const value_type& b) { return a < b; });
 }
 
+// Direct call to insertion sort — meant for call sites with statically
+// bounded input (typically <= 16-32 elements). Skips the runtime fall-through
+// inside `quicksort_impl`, so the compiler does NOT instantiate the
+// quicksort + partition + heap_sort body at all. Per-instantiation savings
+// land in the function symbol that anchors the static-init chain
+// (`ClocklessIdf5` on ESP32-S3). See #2886 / #2907.
+//
+// Use `sort_small` when:
+//   - the container's max size is bounded by construction (e.g. fl::vector_inlined<T, N>)
+//     and N is small (rule of thumb: <= 32);
+//   - O(n^2) worst-case is acceptable.
+//
+// Use `fl::sort` (quicksort) when the container is unbounded or large.
+template <typename Iterator, typename Compare>
+void sort_small(Iterator first, Iterator last, Compare comp) FL_NOEXCEPT {
+    if (first == last || first + 1 == last) {
+        return;  // Already sorted or empty
+    }
+    detail::insertion_sort(first, last, comp);
+}
+
+template <typename Iterator>
+void sort_small(Iterator first, Iterator last) FL_NOEXCEPT {
+    typedef typename fl::remove_reference<decltype(*first)>::type value_type;
+    sort_small(first, last,
+        [](const value_type& a, const value_type& b) { return a < b; });
+}
+
 // Shuffle function with custom random generator (Fisher-Yates shuffle)
 template <typename Iterator, typename RandomGenerator>
 void shuffle(Iterator first, Iterator last, RandomGenerator& g) FL_NOEXCEPT {

--- a/src/platforms/esp/32/drivers/rmt/rmt_5/channel_driver_rmt.cpp.hpp
+++ b/src/platforms/esp/32/drivers/rmt/rmt_5/channel_driver_rmt.cpp.hpp
@@ -354,12 +354,15 @@ class ChannelEngineRMTImpl : public ChannelEngineRMT {
             mAllocationFailed = false;
         }
 
-        // Sort: smallest strips first (helps async parallelism)
+        // Sort: smallest strips first (helps async parallelism).
+        // Container is bounded at 16 by construction (fl::vector_inlined<T, 16>),
+        // so use sort_small to avoid instantiating quicksort_impl in the
+        // ClocklessIdf5 transitive closure — see #2907.
         fl::vector_inlined<ChannelDataPtr, 16> sorted;
         for (const auto& data : channelData) {
             sorted.push_back(data);
         }
-        fl::sort(sorted.begin(), sorted.end(), [](const ChannelDataPtr& a, const ChannelDataPtr& b) FL_NOEXCEPT {
+        fl::sort_small(sorted.begin(), sorted.end(), [](const ChannelDataPtr& a, const ChannelDataPtr& b) FL_NOEXCEPT {
             return a->getSize() > b->getSize();  // Reverse order for back-to-front processing
         });
 


### PR DESCRIPTION
perf(esp32): add fl::sort_small for bounded containers; cut ClocklessIdf5 bloat

Closes #2907.

Adds `fl::sort_small` — a public template that delegates directly to
`fl::detail::insertion_sort` and skips the runtime fall-through inside
`fl::detail::quicksort_impl`. Migrates three call sites in the
`ClocklessIdf5` ctor transitive closure to use it.

## Why this is a real win

`fl::sort` at `src/fl/stl/algorithm.h:564` dispatches to
`detail::quicksort_impl`, which contains:

```cpp
if (last - first <= 16) {
    insertion_sort(first, last, comp);
    return;
}
Iterator pivot = partition(first, last, comp);
quicksort_impl(first, pivot, comp);
quicksort_impl(pivot + 1, last, comp);
```

The bound is a runtime check, not `constexpr`. Per-template-parameter
instantiation of `fl::sort` therefore emits the whole quicksort +
partition + median-of-three + heap_sort body even when the call site
provably operates on a bounded container ≤ 16 elements. The
non-insertion-sort body is dead code for those call sites.

`fl::sort_small` calls `detail::insertion_sort` directly, so the
quicksort body is never instantiated for call sites that opt in. The
new template guards an empty-or-single-element fast path to match the
existing `fl::sort` precondition.

## Migrated call sites (all in ClocklessIdf5 transitive closure)

| Site | Container | Bound | Why bounded |
|---|---|---:|---|
| `src/fl/channels/manager.cpp.hpp:137` | `mDrivers` | 4 | "Only 1-4 drivers expected" per existing comment |
| `src/fl/channels/manager.cpp.hpp:251` | `mDrivers` | 4 | same — re-sort after priority change |
| `src/platforms/esp/32/drivers/rmt/rmt_5/channel_driver_rmt.cpp.hpp:362` | `fl::vector_inlined<ChannelDataPtr, 16>` | 16 | inline-capacity template parameter |

All three are reachable from `BusTraits<Bus::RMT>::registerWithManager()`
(called at `idf5_clockless.h:45`), which is the entry point that
anchors the 48,694 B map-derived attribution to `ClocklessIdf5` in
the 2026-06-06 measured audit (see #2886 audit comment).

## Out of scope (deferred follow-ups)

Seven other `fl::sort` sites exist in `src/` that also operate on
small bounded containers, but they're either outside the
`ClocklessIdf5` transitive closure or in alternate drivers
(parlio/uart). Migration is a one-line follow-up per site; deferred so
the measured savings here are clearly attributable to the
`ClocklessIdf5` closure.

## Expected savings

Conservative estimate: 1-3 KB per template instantiation of the
eliminated quicksort body. Across the three sites (each is a distinct
`Compare` type → distinct instantiation), expected total reduction is
3-9 KB on the ESP32-S3 NEOPIXEL Blink build.

The Stage 6 regression gate (`tests/test_esp32s3_bloat_regression.py`,
baseline = `350568`) will validate the measurement on this PR's CI
run. If the build comes in lower, a follow-up commit lowers the
baseline file in the same PR.

## Verification

- `bash lint --cpp` → all C++ linting checks pass.
- Behavior preserved: `fl::sort_small` has the same semantic contract
  as `fl::sort` (same return = nothing, same compare-by-<, same
  in-place mutation, idempotent on already-sorted input). Only O()
  characteristics change: O(n²) worst case instead of O(n log n) —
  fine when n is bounded.
- The 3 migrated sites all operate on ≤ 16-element containers per the
  table above.

Refs #2886, #2907, #2904, #2906.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized sorting operations across channel and driver management to improve performance characteristics when working with small collections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->