### PR TITLE
perf(gamma): use fl::s16x16::pow for Gamma8 LUT + applyGamma_video; drop __ieee754_pow

### DIFF
--- a/src/fl/gfx/colorutils.cpp.hpp
+++ b/src/fl/gfx/colorutils.cpp.hpp
@@ -8,6 +8,7 @@
 #include "fl/stl/int.h"
 #include "platforms/is_platform.h"
 #include "fl/math/math.h"
+#include "fl/math/fixed_point.h"  // for fl::s16x16 — used by applyGamma_video
 #include "fl/stl/stdint.h"
 
 #include "fl/system/fastled.h"
@@ -1287,12 +1288,22 @@ void nblendPaletteTowardPalette(CRGBPalette16 &current, CRGBPalette16 &target,
 }
 
 fl::u8 applyGamma_video(fl::u8 brightness, float gamma) {
-    float orig;
-    float adj;
-    orig = (float)(brightness) / (255.0);
-    adj = pow(orig, gamma) * (255.0);
-    fl::u8 result = (fl::u8)(adj);
-    if ((brightness > 0) && (result == 0)) {
+    // Fixed-point path (s16x16) avoids pulling `__ieee754_pow` (libm,
+    // ~2.7 KB) into release builds — see #2886 / #2910. Matches the
+    // gamma8 LUT generator's approach in src/fl/math/ease.cpp.hpp.
+    if (brightness == 0) {
+        return 0;
+    }
+    constexpr fl::s16x16 inv_255_fp(1.0f / 255.0f);
+    const fl::s16x16 gamma_fp(gamma);
+    const fl::s16x16 x = static_cast<i32>(brightness) * inv_255_fp;  // [0, 1]
+    const fl::s16x16 r = fl::s16x16::pow(x, gamma_fp);                // (0, 1]
+    // Scale to u8 [0, 255] with round-half-up:
+    //   result = ((u32)raw * 255 + 0x8000) >> 16
+    const fl::u32 scaled =
+        (static_cast<fl::u32>(r.raw()) * 255u + 0x8000u) >> 16;
+    fl::u8 result = static_cast<fl::u8>(scaled > 255u ? 255u : scaled);
+    if (result == 0) {
         result = 1; // never gamma-adjust a positive number down to zero
     }
     return result;

--- a/src/fl/math/ease.cpp.hpp
+++ b/src/fl/math/ease.cpp.hpp
@@ -354,9 +354,29 @@ class Gamma8Impl : public Gamma8 {
 public:
     explicit Gamma8Impl(float gamma) {
         mLut[0] = 0;
+        // Compute the 256-entry u16 gamma LUT in fixed-point so we don't
+        // pull `__ieee754_pow` (libm, ~2.7 KB) into release builds — the
+        // double-precision pow chain dominates the top-9 bytes attributed
+        // to libm in the post-#2908 ESP32-S3 NEOPIXEL Blink audit
+        // (see #2886 / #2910).
+        //
+        // `s16x16` is 16-integer + 16-fractional bits. The exp2_fp /
+        // log2_fp implementation it uses for `pow` is a pure integer LUT
+        // (no libm dependency). The only float operation kept is the
+        // one-shot `s16x16(gamma)` conversion of the public float gamma
+        // parameter (one fmul + cast — pulls only `__mulsf3` / `__fixsfsi`
+        // helpers, both << 100 B).
+        const fl::s16x16 gamma_fp(gamma);
+        constexpr fl::s16x16 inv_255_fp(1.0f / 255.0f);
         for (int i = 1; i < 256; ++i) {
-            double v = fl::pow(static_cast<double>(i) / 255.0, static_cast<double>(gamma)) * 65535.0;
-            mLut[i] = static_cast<u16>(fl::round(v));
+            const fl::s16x16 x = static_cast<i32>(i) * inv_255_fp;  // [0, 1]
+            const fl::s16x16 r = fl::s16x16::pow(x, gamma_fp);      // (0, 1]
+            // r.raw() is the s16x16 raw with FRAC_BITS=16, range [0, 65536].
+            // Scale to u16 [0, 65535] with round-half-up:
+            //   result = ((u32)raw * 65535 + 0x8000) >> 16
+            const fl::u32 scaled =
+                (static_cast<fl::u32>(r.raw()) * 65535u + 0x8000u) >> 16;
+            mLut[i] = static_cast<u16>(scaled > 65535u ? 65535u : scaled);
         }
     }
 


### PR DESCRIPTION
perf(gamma): use fl::s16x16::pow for Gamma8 LUT + applyGamma_video; drop __ieee754_pow

Closes #2910.

Replaces `fl::pow(double, double)` with `fl::s16x16::pow` (integer
fixed-point) in the two FastLED-owned callers that pull `__ieee754_pow`
(libm, 2,723 B in the post-#2908 audit) into release builds.

## What changes

| File | Site | Before | After |
|---|---|---|---|
| `src/fl/math/ease.cpp.hpp` | `Gamma8Impl::Gamma8Impl(float)` | `fl::pow(double, double)` per LUT entry | one `fl::s16x16(gamma)` ctor + per-entry `fl::s16x16::pow` |
| `src/fl/gfx/colorutils.cpp.hpp` | `applyGamma_video(u8, float)` | bare `pow(orig, gamma)` (float args → double) | `fl::s16x16::pow` |

`fl::s16x16::pow` is implemented as `exp2_fp(exp * log2_fp(base))`
where `exp2_fp` and `log2_fp` are pure integer LUT-based
implementations — zero libm dependency. The chain is broken at the
ctor / function entry: the public API still takes `float gamma`, but
that float is converted once to `fl::s16x16` via the constexpr ctor
(one fmul + cast → `__mulsf3` + `__fixsfsi`, both << 100 B).

## Precision sanity-check

- `Gamma8Impl` LUT is u16-valued. `s16x16` has 16 fractional bits
  (~1.5×10⁻⁵ resolution) — well above the LUT's 16-bit output
  resolution.
- `applyGamma_video` is u8 → u8. Same story.
- Result is computed in [0, 1] then scaled to u16 / u8 with
  round-half-up via integer math:
  `((raw_u32 * scale) + 0x8000) >> 16`.

## Why s16x16 is enough

`s16x16` is 16 integer + 16 fractional bits — range ~[-32768, 32767].
- Gamma values are typically in [1.0, 4.0]: fits with massive headroom.
- `(i/255)` is in [0, 1]: stored as raw [0, 65536].
- Intermediate `exp * log2_fp(base)` for `base ∈ (0, 1]` and `exp ∈
  [1, 4]`: `log2(base) ∈ [-∞, 0]`, but `s16x16::log2_fp` clamps
  small inputs. The product stays in s16x16 range.
- `exp2_fp(...)` returns [0, ~1] for the gamma case → fits.

## Out of scope

- `third_party/cq_kernel/fft_precision.h` — third-party FFT macro-driven.
- `third_party/stb/truetype/stb_truetype.cpp.hpp` — third-party font rasterizer.
- `fl::pow` fixed-point template specializations — different overloads, not affected.

## Verification

- `bash lint --cpp` → all C++ linting checks pass.
- `bash test --cpp fl/gfx/gamma_lut` could not be run from the disposable
  PR worktree due to the known meson source-path bug at #2887. The
  same diff applied to the main checkout will run on CI's
  `unit tests linux` job.
- Behavior preserved (modulo ±1 LSB rounding from fixed-point vs
  double): `Gamma8Impl` LUT entries should match the original within
  rounding precision; `applyGamma_video` preserves the
  "never-down-to-zero" invariant via explicit `result == 0 → 1`.

## Expected savings

- Eliminated: `__ieee754_pow` (2,723 B).
- Eliminated: any related double-math symbols only reachable via this path.
- Added: `__mulsf3`, `__fixsfsi` (<< 100 B each — likely already
  linked by other float math sites).
- Net: projected ~2-2.5 KB on the ESP32-S3 NEOPIXEL Blink build.

The Stage 6 regression gate (`tests/test_esp32s3_bloat_regression.py`,
baseline = `350127`) validates the measurement on this PR's CI run. A
follow-up commit lowers the baseline file accordingly.

Refs #2886, #2910, #2908, #2909.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Optimized gamma correction calculations in color utilities and image processing operations. These internal improvements enhance efficiency and consistency in color adjustments while maintaining identical visual output. The changes ensure reliable handling of color processing operations and brightness adjustments with consistent behavior across all scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->