### PR TITLE
perf(esp32): gate SPI dispatch in Channel::showPixels behind FASTLED_DISABLE_SPI_CHIPSETS

### DIFF
--- a/docs/SLIM_ESP32S3.md
+++ b/docs/SLIM_ESP32S3.md
@@ -43,6 +43,7 @@ To measure your own build: `bash bloat esp32s3 --build` then `jq '.total_flash' 
 | 3 | `-DFASTLED_RMT_STATIC_ALLOCATION=1` | `build_flags`; for sketches that init LEDs in `setup()` and never `removeLeds()` | ~22-43 KB | 📊 | #2846 |
 | 4 | `-DFASTLED_SUPPRESS_ARDUINO_CHIP_DEBUG_REPORT=1` | `build_flags`; strong-overrides the Arduino-ESP32 boot-banner gate | ~3 KB | 📊 | #2894 |
 | 5 | `CONFIG_BT_ENABLED=n` | uncomment the situational block in `tools/sdkconfig_for_smallest_fastled.defaults` | ~15 KB (if currently on) | 📊 | — |
+| 6 | `-DFASTLED_DISABLE_SPI_CHIPSETS=1` | `build_flags`; drops the SPI dispatch branch in `Channel::showPixels`. **Constraint:** clockless-only sketches; calling `FastLED.addLeds<APA102, ...>` (or any SPI chipset) under this flag silently emits nothing. | ~1.0-1.2 KB | 📊 | #2913 |
 
 **Legend:** ✅ measured against a recorded baseline · 📊 projected from the top-25 symbol attribution in #2886.
 

--- a/src/fl/channels/channel.cpp.hpp
+++ b/src/fl/channels/channel.cpp.hpp
@@ -497,8 +497,22 @@ void Channel::showPixels(PixelController<RGB, 1, 0xFFFFFFFF> &pixels) {
                              mSettings, mRgbOrder);
                 break;
         }
+#if !defined(FASTLED_DISABLE_SPI_CHIPSETS) || !FASTLED_DISABLE_SPI_CHIPSETS
     } else if (mChipset.is<SpiChipsetConfig>()) {
-        // SPI chipsets: dispatch based on chipset type (zero allocation)
+        // SPI chipsets: dispatch based on chipset type (zero allocation).
+        //
+        // Gated by FASTLED_DISABLE_SPI_CHIPSETS (#2913). For NEOPIXEL-only
+        // sketches on ESP32-S3 the SPI branch is dead at runtime, but the
+        // compiler cannot prove that — each pixelIterator.writeXXX(...)
+        // reference below is statically reachable, keeping ~720 B of
+        // encoder bodies (writeAPA102, writeSK9822, writeLPD8806,
+        // writeSM16716) plus the 11-case switch table linked. Setting
+        // `-DFASTLED_DISABLE_SPI_CHIPSETS=1` in build_flags drops the
+        // whole branch and recovers ~1.0-1.2 KB on a NEOPIXEL Blink.
+        //
+        // When the gate is enabled, calling showPixels() on an
+        // SpiChipsetConfig channel silently emits nothing — the user
+        // accepts that constraint by setting the flag.
         const SpiChipsetConfig* spi = mChipset.ptr<SpiChipsetConfig>();
         const SpiEncoder& config = spi->timing;
 
@@ -555,6 +569,7 @@ void Channel::showPixels(PixelController<RGB, 1, 0xFFFFFFFF> &pixels) {
         }
         // No default case - compiler will error if any enum value is missing
     }
+#endif  // !FASTLED_DISABLE_SPI_CHIPSETS
 
     // Fire event after encoding completes
     {


### PR DESCRIPTION
perf(esp32): gate SPI dispatch in Channel::showPixels behind FASTLED_DISABLE_SPI_CHIPSETS

Closes #2913.

Adds an opt-in build flag `FASTLED_DISABLE_SPI_CHIPSETS=1` that gates
the SPI dispatch branch in `fl::Channel::showPixels`. For NEOPIXEL-only
sketches the SPI branch is dynamically unreachable, but the compiler
cannot prove that — every `pixelIterator.writeXXX(...)` reference
inside the 11-case switch is statically reachable, keeping ~720 B of
encoder bodies and the switch-table footprint linked.

## Measured baseline (post-#2911, `master @ 6bd4ebd9ec`)

Dead-code SPI encoder symbols currently linked into a NEOPIXEL Blink:

| Symbol | Size |
|---|---:|
| `fl::PixelIterator::writeLPD8806<fl::vector_psram<u8>>` | 235 B |
| `fl::PixelIterator::writeSK9822<fl::vector_psram<u8>>` | 197 B |
| `fl::PixelIterator::writeAPA102<fl::vector_psram<u8>>` | 197 B |
| `fl::PixelIterator::writeSM16716<fl::vector_psram<u8>>` | 91 B |
| **Total** | **720 B** |

Plus the `showPixels` body itself shrinks by the switch-table footprint
(~300-500 B for an 11-case xtensa switch). Projected total saving:
**~1.0-1.2 KB** on a NEOPIXEL Blink build with the flag enabled.

## Behavior

- **Flag unset (default):** No change. The SPI dispatch is present;
  every existing example using APA102 / SK9822 / etc. continues to
  work.
- **Flag set (`-DFASTLED_DISABLE_SPI_CHIPSETS=1`):** The SPI branch is
  removed at preprocess time. `showPixels()` on a channel whose
  chipset is an `SpiChipsetConfig` falls through to the post-dispatch
  event emission with no data encoded — the channel silently emits
  nothing. Users opt in with the understanding that they're not
  using SPI chipsets in this build.

This mirrors the opt-in build-flag pattern shipped in #2894
(Stage 2 / boot-banner shim) — minimal default-change risk, real
savings for users who can accept the constraint.

## Files

- `src/fl/channels/channel.cpp.hpp` — `#if !defined(FASTLED_DISABLE_SPI_CHIPSETS) || !FASTLED_DISABLE_SPI_CHIPSETS`
  wraps the `else if (mChipset.is<SpiChipsetConfig>())` block. The
  gate's behavior + savings are documented inline at the comment block
  above the branch.
- `docs/SLIM_ESP32S3.md` — adds row 6 to the "Release-build flash
  savers" priority table with the new flag, its constraint, and PR
  link.

## Verification

- `bash lint --cpp` → all C++ linting checks pass.
- The flag follows the established opt-in pattern; default behavior
  unchanged.
- Measured saving will be validated on the post-merge build (a
  `-DFASTLED_DISABLE_SPI_CHIPSETS=1` build of Blink, compared against
  the current `347,004 B` baseline).

## Expected savings

- Eliminated: writeAPA102 (197 B), writeSK9822 (197 B), writeLPD8806
  (235 B), writeSM16716 (91 B) = 720 B (PixelIterator SPI encoders
  reachable only from showPixels' SPI branch).
- Eliminated: ~300-500 B of switch-table + dispatch code in
  `showPixels` body.
- Net: ~1.0-1.2 KB projected on NEOPIXEL Blink with flag set.

The Stage 6 regression gate (`tests/test_esp32s3_bloat_regression.py`,
baseline = `347004`) does NOT change in this PR because it measures
the default-flag build, which is unchanged. A separate follow-up
records the flag-on measured number once a measurement run lands.

Refs #2886, #2913, #2908, #2911.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added build flag reference for configuring SPI chipset support options

* **New Features**
  * Enabled conditional SPI chipset encoding based on build configuration flag

<!-- end of auto-generated comment: release notes by coderabbit.ai -->