### PR TITLE
docs(esp32): add CONFIG_NEWLIB_NANO_FORMAT=y to Stage 3 sdkconfig overlay (~20-30 KB)

### DIFF
--- a/agents/docs/binary-size-analysis.md
+++ b/agents/docs/binary-size-analysis.md
@@ -49,7 +49,7 @@ These are the gotchas the wrapper handles for you. They are documented here so t
    | Lever | How to enable | Savings | Source |
    |---|---|---:|---|
    | `FASTLED_LOG_VERBOSITY=0` | Now the release default (NDEBUG); explicit `-DFASTLED_LOG_VERBOSITY=1` to restore | ~43-58 KB | #2791 + #2890 |
-   | `tools/sdkconfig_for_smallest_fastled.defaults` | `board_build.sdkconfig_defaults` in `platformio.ini`; disables coredump, IDF log, bootloader log, panic-print | ~10-15 KB | #2895 (Stage 3) |
+   | `tools/sdkconfig_for_smallest_fastled.defaults` | `board_build.sdkconfig_defaults` in `platformio.ini`; disables coredump, IDF log, bootloader log, panic-print + **switches newlib to nano printf (#2915 — biggest single lever)** | ~30-45 KB | #2895 + #2915 (Stage 3) |
    | `-DFASTLED_SUPPRESS_ARDUINO_CHIP_DEBUG_REPORT=1` | `build_flags`; strong-overrides the Arduino-ESP32 boot-banner gate | ~3 KB | #2894 (Stage 2) |
    | `-DFASTLED_RMT_STATIC_ALLOCATION=1` | `build_flags`; for sketches that init LEDs in `setup()` and never remove | ~22-43 KB | #2846 |
 

--- a/docs/SLIM_ESP32S3.md
+++ b/docs/SLIM_ESP32S3.md
@@ -39,7 +39,7 @@ To measure your own build: `bash bloat esp32s3 --build` then `jq '.total_flash' 
 | # | Lever | How to enable | Savings | Status | PR |
 |---:|---|---|---:|:---:|---|
 | 1 | `FASTLED_LOG_VERBOSITY=0` | **Default on release builds** (NDEBUG); `-DFASTLED_LOG_VERBOSITY=1` to restore | **−37,812 B measured** (388,380 → 350,568 B on 824cb5c0e3) | ✅ | #2890 |
-| 2 | `tools/sdkconfig_for_smallest_fastled.defaults` | `board_build.sdkconfig_defaults` in `platformio.ini` | ~10-15 KB | 📊 | #2896 |
+| 2 | `tools/sdkconfig_for_smallest_fastled.defaults` | `board_build.sdkconfig_defaults` in `platformio.ini`. **Includes `CONFIG_NEWLIB_NANO_FORMAT=y`** which drops the standard newlib printf cluster — see Stage 3 detail below. | ~30-45 KB | 📊 | #2896 + #2915 |
 | 3 | `-DFASTLED_RMT_STATIC_ALLOCATION=1` | `build_flags`; for sketches that init LEDs in `setup()` and never `removeLeds()` | ~22-43 KB | 📊 | #2846 |
 | 4 | `-DFASTLED_SUPPRESS_ARDUINO_CHIP_DEBUG_REPORT=1` | `build_flags`; strong-overrides the Arduino-ESP32 boot-banner gate | ~3 KB | 📊 | #2894 |
 | 5 | `CONFIG_BT_ENABLED=n` | uncomment the situational block in `tools/sdkconfig_for_smallest_fastled.defaults` | ~15 KB (if currently on) | 📊 | — |
@@ -66,16 +66,19 @@ Row 1 is empirically confirmed by the 2026-06-06 audit (see the [#2886 audit com
 
 ### 2. `tools/sdkconfig_for_smallest_fastled.defaults`
 
-**Mechanism:** ESP-IDF sdkconfig overlay applied via `board_build.sdkconfig_defaults`. The overlay flips four knobs:
+**Mechanism:** ESP-IDF sdkconfig overlay applied via `board_build.sdkconfig_defaults`. The overlay flips five knobs:
 
 | Knob | Disables | Savings |
 |---|---|---:|
+| `CONFIG_NEWLIB_NANO_FORMAT=y` | standard newlib printf cluster (`_vfprintf_r`, `_svfprintf_r`, `_svfiprintf_r`, `_vfiprintf_r`, `_dtoa_r`, `get_arg$isra$0`) | **~20-30 KB** |
 | `CONFIG_ESP_COREDUMP_ENABLE_TO_FLASH=n` | libespcoredump (top-25 rows #18 + #25) | ~8 KB |
 | `CONFIG_LOG_DEFAULT_LEVEL=ESP_LOG_NONE` | libesp_diagnostics + IDF log strings (row #19) | ~3 KB |
 | `CONFIG_BOOTLOADER_LOG_LEVEL_NONE=y` | bootloader-stage UART chatter | ~1 KB |
 | `CONFIG_ESP_SYSTEM_PANIC_PRINT_HALT=y` | panic-time backtrace formatter | ~1-2 KB |
 
 The overlay file at [`../tools/sdkconfig_for_smallest_fastled.defaults`](../tools/sdkconfig_for_smallest_fastled.defaults) carries the full per-knob commentary inline.
+
+**`CONFIG_NEWLIB_NANO_FORMAT=y` constraint:** nano printf has no `%f` / `%lf` / `%lld` / positional-arg support. Sketches that print floating-point values via printf will see literal format specifiers in the output instead of the formatted number. Most LED installations don't print floats; if yours does, either drop the overlay entirely or layer your own sdkconfig overlay AFTER FastLED's with `CONFIG_NEWLIB_NANO_FORMAT=n` to override.
 
 **`CONFIG_BT_ENABLED=n`** is shipped as a commented-out situational block — uncomment only if your sketch doesn't use BLE/BT (another ~15 KB).
 

--- a/tools/sdkconfig_for_smallest_fastled.defaults
+++ b/tools/sdkconfig_for_smallest_fastled.defaults
@@ -57,6 +57,24 @@ CONFIG_BOOTLOADER_LOG_LEVEL_NONE=y
 # Projected savings: ~1-2 KB.
 CONFIG_ESP_SYSTEM_PANIC_PRINT_HALT=y
 
+# Switch newlib to nano printf/scanf variants. This is BY FAR the
+# largest single lever in the overlay — the standard newlib printf
+# cluster (`_vfprintf_r`, `_svfprintf_r`, `_svfiprintf_r`, `_vfiprintf_r`,
+# `_dtoa_r`, `get_arg$isra$0` copies) collectively eats ~45 KB on the
+# ESP32-S3 NEOPIXEL Blink baseline (#2886 audit). Nano newlib drops
+# that cluster by 50-70%.
+#
+# CONSTRAINT: nano printf has no `%f` / `%lf` / `%lld` / positional-arg
+# support. Sketches that print floating-point values via printf will
+# see literal format specifiers in the output instead of the formatted
+# number. Most LED installations don't print floats; if yours does:
+#   - drop this overlay entirely, OR
+#   - layer your own sdkconfig overlay AFTER FastLED's with
+#     `CONFIG_NEWLIB_NANO_FORMAT=n` to override.
+#
+# Projected savings: ~20-30 KB.
+CONFIG_NEWLIB_NANO_FORMAT=y
+
 # -----------------------------------------------------------------------------
 # Situational knobs — uncomment ONLY if you know your project doesn't need them
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
docs(esp32): add CONFIG_NEWLIB_NANO_FORMAT=y to Stage 3 sdkconfig overlay

Closes #2915.

Adds the biggest missing single lever to the Stage 3 overlay file
shipped in #2896. The standard newlib printf cluster — `_vfprintf_r`
(11.3 KB), `_svfprintf_r` (11.1 KB), `_svfiprintf_r` (7.3 KB),
`_vfiprintf_r` (7.3 KB), `_dtoa_r` (3.2 KB), `get_arg$isra$0` copies
(4.9 KB cumulative) — collectively eats **~45 KB** on the post-#2911
ESP32-S3 NEOPIXEL Blink baseline (the largest non-FastLED cluster in
the audit). Nano newlib drops it by 50-70%.

## Why this was missed

The Stage 3 overlay #2896 targeted four sub-1.5 KB symbol clusters
(coredump, IDF diag log, bootloader chatter, panic formatter) but
left the dominant ~45 KB libc printf cluster unattended. Adding
`CONFIG_NEWLIB_NANO_FORMAT=y` is a one-line config flip that's a
larger lever than every other Stage 3 knob combined.

## The constraint

Nano newlib printf has no `%f` / `%lf` / `%lld` / positional-arg
support. Sketches that print floating-point values via printf will
see literal format specifiers in the output instead of the formatted
number. For LED installations this is rarely an issue — strip
control code doesn't typically log floats. For sketches that DO need
extended formats, the user either drops the overlay entirely or
layers their own sdkconfig with `CONFIG_NEWLIB_NANO_FORMAT=n` after
FastLED's.

## Files

- `tools/sdkconfig_for_smallest_fastled.defaults` — new entry with
  inline constraint documentation, placed in the "Conservative knobs"
  section (it qualifies because most LED installations don't print
  floats).
- `docs/SLIM_ESP32S3.md` — row 2 of the priority table updated from
  `~10-15 KB` → `~30-45 KB`. Stage 3 detail section's knob table
  expanded from 4 → 5 rows with the nano-newlib entry at the top,
  plus a new constraint sidebar.
- `agents/docs/binary-size-analysis.md` — agent-facing copy of the
  priority table mirrors the SLIM doc update.

## Verification

- `bash lint --cpp` → all C++ linting checks pass (this PR doesn't
  touch C++).
- The overlay file remains opt-in (users must wire it into
  `board_build.sdkconfig_defaults` themselves). Default behavior is
  unchanged for users who haven't already chosen the overlay.
- Measured savings will be validated on a follow-up build with the
  overlay applied. Expected: ~20-30 KB drop in `total_flash` vs
  current baseline (`347,004 B`).

## Expected savings

- Pre-overlay (Stage 1 only): 347,004 B (current measured baseline).
- Post-overlay (Stages 1+3 with nano printf):
  ≈ 347,004 - 25,000 = ~322,000 B (projected).
- Gap to #2886 end-goal (280,000 B): ~42 KB remaining,
  most of which lives in #2856 (structural meta).

The Stage 6 regression gate baseline does NOT change in this PR
(the default-flag build is unchanged). A follow-up PR records the
measured number after a build with the overlay applied.

Refs #2886, #2915, #2896, #2906.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated flash optimization documentation with improved memory savings estimates (up to 30-45 KB).
  * Added guidance for an optional configuration overlay that further reduces flash usage through a lightweight printf implementation.
  * Documented limitations of this optimization for floating-point and positional formatting, with override instructions for users who need these features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->