### PR TITLE
perf(esp32): gate emit* cold helpers on FASTLED_LOG_RUNTIME_ENABLED (~800 B)

### DIFF
--- a/src/platforms/esp/32/drivers/rmt/rmt_5/channel_driver_rmt.cpp.hpp
+++ b/src/platforms/esp/32/drivers/rmt/rmt_5/channel_driver_rmt.cpp.hpp
@@ -404,6 +404,15 @@ class ChannelEngineRMTImpl : public ChannelEngineRMT {
     FL_NO_INLINE void emitRecoveryWarning(
         size_t original_symbols, size_t reduced_symbols,
         size_t external_words) FL_NOEXCEPT {
+        // Gate the entire body on FASTLED_LOG_RUNTIME_ENABLED. In release
+        // builds (NDEBUG → FASTLED_LOG_VERBOSITY=0 per Stage 1) the
+        // FL_WARN(msg.str()) call at the bottom is a no-op, but the
+        // `fl::sstream msg;` construction and 15 `operator<<` chain calls
+        // above happen unconditionally — they have observable side effects
+        // on msg's internal buffer that the optimizer can't prove away.
+        // Gating collapses the FL_NO_INLINE helper to an effectively-empty
+        // function in release (~5 B vs ~410 B). See #2917 / #2886.
+#if FASTLED_LOG_RUNTIME_ENABLED
         fl::sstream msg;
         msg << "\n========================================\n"
             << "RMT ALLOCATION RECOVERY - ACTION REQUIRED\n"
@@ -423,6 +432,11 @@ class ChannelEngineRMTImpl : public ChannelEngineRMT {
             << "Performance may be degraded during WiFi/network activity.\n"
             << "========================================";
         FL_WARN(msg.str());
+#else
+        (void)original_symbols;
+        (void)reduced_symbols;
+        (void)external_words;
+#endif
     }
 
     /// @brief Cold-path recovery loop for failed initial RMT allocations.
@@ -506,6 +520,8 @@ class ChannelEngineRMTImpl : public ChannelEngineRMT {
     FL_NO_INLINE void emitAllocationFailureError(
         size_t retry_count, size_t original_symbols, size_t min_symbols,
         int pin) FL_NOEXCEPT {
+        // Same gating rationale as emitRecoveryWarning above — see #2917.
+#if FASTLED_LOG_RUNTIME_ENABLED
         fl::sstream msg;
         msg << "\n========================================\n"
             << "RMT CHANNEL ALLOCATION FAILED\n"
@@ -523,6 +539,12 @@ class ChannelEngineRMTImpl : public ChannelEngineRMT {
             << "LEDs on pin " << pin << " will NOT work!\n"
             << "========================================";
         FL_ERROR(msg.str());
+#else
+        (void)retry_count;
+        (void)original_symbols;
+        (void)min_symbols;
+        (void)pin;
+#endif
     }
 
     /// @brief Create new RMT channel with given configuration


### PR DESCRIPTION
perf(esp32): gate emitRecoveryWarning + emitAllocationFailureError bodies on FASTLED_LOG_RUNTIME_ENABLED

Closes #2917.

Wraps the bodies of the two `FL_NO_INLINE` cold-path emit helpers in
`fl::ChannelEngineRMTImpl` with `#if FASTLED_LOG_RUNTIME_ENABLED`. In
release builds (NDEBUG → `FASTLED_LOG_VERBOSITY=0` per Stage 1) the
helpers collapse to ~5 B function bodies (parameters cast to `(void)`,
single `ret`), down from ~410-418 B each.

## Why the existing FL_NO_INLINE + FL_WARN pattern wasn't enough

```cpp
FL_NO_INLINE void emitRecoveryWarning(...) FL_NOEXCEPT {
    fl::sstream msg;                          // [1] constructed unconditionally
    msg << "..." << ... << external_words;    // [2] 15 operator<< calls fire
    FL_WARN(msg.str());                       // [3] expands to no-op in release
}
```

In release builds:
- `FL_WARN(X)` expands to `do { if (false) { ... << X; } } while(0)` —
  optimizer DCEs the inner block (`msg.str()` call elided).
- But `fl::sstream msg;` at [1] and `msg << ...` at [2] are **outside**
  the `if (false)` block. They have observable side effects on `msg`'s
  internal buffer (heap allocation, sequential writes), so the optimizer
  keeps the constructor + all 15 `operator<<` calls live in the function
  body.

Result: the FL_NO_INLINE pulled the diagnostic chain out of the
function it was hoisted from (`createChannel`) — into its own symbol
— but the bytes stayed in the binary.

## Measured baseline (post-#2916 ELF, `master @ 5ca722e379`)

| Symbol | Size |
|---|---:|
| `fl::ChannelEngineRMTImpl::emitAllocationFailureError` (`$isra$0`) | 418 B |
| `fl::ChannelEngineRMTImpl::emitRecoveryWarning` (`$isra$0`) | 410 B |
| **Total in scope** | **~828 B** |

Both symbols collapse to ~5 B after this PR.

## Behavior preserved

- **Debug builds (`FASTLED_LOG_VERBOSITY=1`, default for non-NDEBUG):**
  the diagnostic emits exactly as before. Users debugging RMT
  allocation failures still see the multi-line action-required
  message.
- **Release builds (`FASTLED_LOG_VERBOSITY=0`, NDEBUG default since
  #2890):** the helper bodies become empty; the callers in
  `attemptAllocationRecovery` still call them (the call overhead is
  ~5 B / site), but the bodies cost nothing.

The FL_WARN macro itself was always a no-op in release; this PR makes
the body that *built the message* match the macro's release-build
behavior.

## Other emit helpers — audit notes

- `attemptAllocationRecovery` (315 B total): contains its own FL_WARN
  and FL_LOG_RMT calls plus actual retry-loop arithmetic. The
  diagnostic calls go through the standard `FL_WARN` macro which is
  already `do { if (false) { ... } } while(0)` in release — the
  optimizer DCEs the inline chain. The 315 B is the retry-loop body
  + `Rmt5ChannelConfig retry_config(...)` construction; NOT the
  diagnostic emission. Leaving as-is.
- `handleAllocateTxFailure` (63 B): already a `FL_NO_INLINE` cold
  helper at 63 B post-Stage-1 — almost entirely the fallback retry
  body. No further gating needed.

## Out of scope

- Removing the FL_WARN calls from the source. They're useful in debug
  builds; the gate keeps them debug-build-active.
- Auditing every FL_WARN call site in the RMT5 driver — the inline
  ones inside hot function bodies are already collapsed correctly by
  the `if (false)` DCE.

## Verification

- `bash lint --cpp` → all C++ linting checks pass.
- Behavior preserved by construction: the gate is on a build-time
  define that defaults to "diagnostics on" in debug builds.
- Measured saving validated on this PR's CI run via the Stage 6
  regression gate. Expected: `total_flash` drops by ~700-800 B from
  the current baseline of `347,004 B`. A follow-up commit ratchets
  the baseline file in the same PR.

Refs #2886, #2917, #2908, #2911, #2914.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized ESP32 driver diagnostics to reduce overhead when logging is disabled, improving performance on resource-constrained devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->