### PR TITLE
perf(esp32): gate UCS7604 clockless cases in Channel::showPixels behind FASTLED_DISABLE_UCS7604

### DIFF
--- a/docs/SLIM_ESP32S3.md
+++ b/docs/SLIM_ESP32S3.md
@@ -44,6 +44,7 @@ To measure your own build: `bash bloat esp32s3 --build` then `jq '.total_flash' 
 | 4 | `-DFASTLED_SUPPRESS_ARDUINO_CHIP_DEBUG_REPORT=1` | `build_flags`; strong-overrides the Arduino-ESP32 boot-banner gate | ~3 KB | 📊 | #2894 |
 | 5 | `CONFIG_BT_ENABLED=n` | uncomment the situational block in `tools/sdkconfig_for_smallest_fastled.defaults` | ~15 KB (if currently on) | 📊 | — |
 | 6 | `-DFASTLED_DISABLE_SPI_CHIPSETS=1` | `build_flags`; drops the SPI dispatch branch in `Channel::showPixels`. **Constraint:** clockless-only sketches; calling `FastLED.addLeds<APA102, ...>` (or any SPI chipset) under this flag silently emits nothing. | ~1.0-1.2 KB | 📊 | #2913 |
+| 7 | `-DFASTLED_DISABLE_UCS7604=1` | `build_flags`; drops the UCS7604 cases in `Channel::showPixels`'s clockless switch. **Constraint:** WS2812-only sketches; calling `FastLED.addLeds<UCS7604, ...>` under this flag silently emits nothing. | ~400-600 B | 📊 | #2920 |
 
 **Legend:** ✅ measured against a recorded baseline · 📊 projected from the top-25 symbol attribution in #2886.
 

--- a/src/fl/channels/channel.cpp.hpp
+++ b/src/fl/channels/channel.cpp.hpp
@@ -490,12 +490,23 @@ void Channel::showPixels(PixelController<RGB, 1, 0xFFFFFFFF> &pixels) {
             case ClocklessEncoder::CLOCKLESS_ENCODER_WS2812:
                 pixelIterator.writeWS2812(&data);
                 break;
+#if !defined(FASTLED_DISABLE_UCS7604) || !FASTLED_DISABLE_UCS7604
+            // Gated by FASTLED_DISABLE_UCS7604 (#2920). For WS2812-only
+            // sketches the UCS7604 case is dead at runtime, but each
+            // `writeUCS7604(...)` reference is statically reachable,
+            // keeping the encoder bodies linked. Setting
+            // `-DFASTLED_DISABLE_UCS7604=1` drops the case + the
+            // `encodeUCS7604_16bit_RGB` / `encodeUCS7604_16bit_RGBW`
+            // template instantiations (~400-600 B). When the gate is
+            // enabled, calling showPixels() on a UCS7604 channel
+            // silently emits nothing.
             case ClocklessEncoder::CLOCKLESS_ENCODER_UCS7604_8BIT:
             case ClocklessEncoder::CLOCKLESS_ENCODER_UCS7604_16BIT:
             case ClocklessEncoder::CLOCKLESS_ENCODER_UCS7604_16BIT_1600:
                 writeUCS7604(&data, pixelIterator, clockless->encoder,
                              mSettings, mRgbOrder);
                 break;
+#endif  // !FASTLED_DISABLE_UCS7604
         }
 #if !defined(FASTLED_DISABLE_SPI_CHIPSETS) || !FASTLED_DISABLE_SPI_CHIPSETS
     } else if (mChipset.is<SpiChipsetConfig>()) {


### PR DESCRIPTION
Closes #2920. Mirrors #2914's SPI dispatch gate for the UCS7604 clockless cases. Opt-in build flag drops ~400-600 B on WS2812-only NEOPIXEL Blink builds. Default behavior unchanged; regression-gate baseline unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional compile-time flag to reduce flash memory usage by disabling UCS7604 LED support.

* **Documentation**
  * Updated build options guide with new flash-saving configuration flag and its constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->