### PR TITLE
perf(esp32): gate FASTLED_ASSERT diagnostic on FASTLED_LOG_RUNTIME_ENABLED

### DIFF
--- a/src/platforms/esp/esp_assert.h
+++ b/src/platforms/esp/esp_assert.h
@@ -2,6 +2,7 @@
 
 // IWYU pragma: private
 
+#include "fl/log/log.h"  // for FASTLED_LOG_RUNTIME_ENABLED
 #include "fl/stl/strstream.h"
 #include "fl/stl/noexcept.h"
 
@@ -10,9 +11,23 @@ namespace fl {
     void println(const char* str) FL_NOEXCEPT;
 }
 
+// Gate the entire macro body on FASTLED_LOG_RUNTIME_ENABLED so release
+// builds (NDEBUG → FASTLED_LOG_VERBOSITY=0 per #2890) don't emit the
+// per-call-site `fl::sstream` chain + `fl::println` call. This matches
+// the standard C `<assert.h>` behavior under NDEBUG: the macro becomes
+// `((void)0)` and the condition expression is not evaluated. Sketches
+// must therefore not put side effects in assertion conditions
+// (already best practice). See #2923 / #2886.
+#if FASTLED_LOG_RUNTIME_ENABLED
 #define FASTLED_ASSERT(x, MSG)                                                 \
     do {                                                                       \
         if (!(x)) {                                                            \
             fl::println((fl::sstream() << "FASTLED ASSERT FAILED: " << MSG).c_str());  \
         }                                                                      \
     } while (0)
+#else
+// `sizeof((x), (MSG), 0)` keeps the expression syntactically validated
+// (catches typos at compile time) without evaluating it at runtime.
+#define FASTLED_ASSERT(x, MSG)                                                 \
+    do { (void)sizeof((void)(x), (void)(MSG), 0); } while (0)
+#endif


### PR DESCRIPTION
Closes #2923. Wraps the body of FASTLED_ASSERT in src/platforms/esp/esp_assert.h on FASTLED_LOG_RUNTIME_ENABLED. Matches C <assert.h> NDEBUG semantics; eliminates ~1-2 KB of per-call-site sstream chain bloat in release builds.

The cross-platform fallback and WASM variants are already correctly gated; only the ESP32 variant lacked the gate.

Refs #2886, #2918.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced assertion handling for ESP platform with configurable runtime behavior. When enabled, assertions now display detailed failure messages; when disabled, they optimize for production by validating code syntax at compile-time without runtime overhead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->