### PR TITLE
perf(channels): gate Channel::resolveDynamicDriver behind FASTLED_DISABLE_DYNAMIC_DRIVER

### DIFF
--- a/docs/SLIM_ESP32S3.md
+++ b/docs/SLIM_ESP32S3.md
@@ -45,6 +45,7 @@ To measure your own build: `bash bloat esp32s3 --build` then `jq '.total_flash' 
 | 5 | `CONFIG_BT_ENABLED=n` | uncomment the situational block in `tools/sdkconfig_for_smallest_fastled.defaults` | ~15 KB (if currently on) | 📊 | — |
 | 6 | `-DFASTLED_DISABLE_SPI_CHIPSETS=1` | `build_flags`; drops the SPI dispatch branch in `Channel::showPixels`. **Constraint:** clockless-only sketches; calling `FastLED.addLeds<APA102, ...>` (or any SPI chipset) under this flag silently emits nothing. | ~1.0-1.2 KB | 📊 | #2913 |
 | 7 | `-DFASTLED_DISABLE_UCS7604=1` | `build_flags`; drops the UCS7604 cases in `Channel::showPixels`'s clockless switch. **Constraint:** WS2812-only sketches; calling `FastLED.addLeds<UCS7604, ...>` under this flag silently emits nothing. | ~400-600 B | 📊 | #2920 |
+| 8 | `-DFASTLED_DISABLE_DYNAMIC_DRIVER=1` | `build_flags`; gates out `Channel::resolveDynamicDriver()` and its `ChannelManager::findDriverByName` / `selectDriverForChannel` lookup chain. **Constraint:** legacy `addLeds<>` flow only (every `addLeds<>` flavor pre-binds in its ctor). Channels created via manager-based `Channel::create(cfg)` without pre-binding silently emit nothing. | ~400-900 B | 📊 | #2926 |
 
 **Legend:** ✅ measured against a recorded baseline · 📊 projected from the top-25 symbol attribution in #2886.
 

--- a/src/fl/channels/channel.cpp.hpp
+++ b/src/fl/channels/channel.cpp.hpp
@@ -378,6 +378,13 @@ void writeUCS7604(fl::vector_psram<u8>* data, PixelIterator& pixelIterator,
 /// hot icache line.
 FL_NO_INLINE
 fl::shared_ptr<IChannelDriver> Channel::resolveDynamicDriver() {
+#if defined(FASTLED_DISABLE_DYNAMIC_DRIVER) && FASTLED_DISABLE_DYNAMIC_DRIVER
+    // Body excluded via FASTLED_DISABLE_DYNAMIC_DRIVER (#2926). The
+    // showPixels call site is also gated so this is unreachable; the
+    // empty body lets the linker dead-strip ChannelManager::findDriverByName
+    // and selectDriverForChannel along with this symbol.
+    return {};
+#else
     // Build busKey only when we actually need it (mBus != AUTO).
     fl::string busKey;
     if (mBus != Bus::AUTO) {
@@ -419,6 +426,7 @@ fl::shared_ptr<IChannelDriver> Channel::resolveDynamicDriver() {
         FL_ERROR("Channel '" << mName << "': No compatible driver found - cannot transmit");
     }
     return driver;
+#endif  // !FASTLED_DISABLE_DYNAMIC_DRIVER
 }
 
 void Channel::showPixels(PixelController<RGB, 1, 0xFFFFFFFF> &pixels) {
@@ -464,10 +472,22 @@ void Channel::showPixels(PixelController<RGB, 1, 0xFFFFFFFF> &pixels) {
             return;
         }
     } else {
+#if !defined(FASTLED_DISABLE_DYNAMIC_DRIVER) || !FASTLED_DISABLE_DYNAMIC_DRIVER
         driver = resolveDynamicDriver();
         if (!driver) {
             return;
         }
+#else
+        // Dynamic-driver lookup gated out via FASTLED_DISABLE_DYNAMIC_DRIVER
+        // (#2926). The else branch is dead at runtime for every legacy
+        // `addLeds<>` flavor — those pre-bind their driver in the ctor. The
+        // gate lets `--gc-sections` drop the resolveDynamicDriver body plus
+        // the ChannelManager::findDriverByName / selectDriverForChannel
+        // chain (~400-900 B). Channels created via `Channel::create(cfg)`
+        // without a pre-bound driver silently emit nothing under this flag —
+        // user accepts the constraint.
+        return;
+#endif
     }
 
     // Build pixel iterator with optional addressing transformation


### PR DESCRIPTION
Closes #2926. Opt-in build flag drops the dynamic-driver lookup chain on stock NEOPIXEL Blink (~400-900 B projected). Mirrors #2914 / #2921 pattern.

Refs #2886, #2914, #2918, #2921, #2925.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced optional build configuration to reduce memory footprint on resource-constrained embedded devices, enabling deployments with limited flash storage.

* **Documentation**
  * Updated optimization documentation to include new memory-saving configuration option, with guidance on behavioral constraints for channel initialization when dynamic resolution is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->