### PR TITLE
perf(channels): gate fl::ChannelEvents behind FASTLED_DISABLE_CHANNEL_EVENTS

### DIFF
--- a/docs/SLIM_ESP32S3.md
+++ b/docs/SLIM_ESP32S3.md
@@ -46,6 +46,7 @@ To measure your own build: `bash bloat esp32s3 --build` then `jq '.total_flash' 
 | 6 | `-DFASTLED_DISABLE_SPI_CHIPSETS=1` | `build_flags`; drops the SPI dispatch branch in `Channel::showPixels`. **Constraint:** clockless-only sketches; calling `FastLED.addLeds<APA102, ...>` (or any SPI chipset) under this flag silently emits nothing. | ~1.0-1.2 KB | 📊 | #2913 |
 | 7 | `-DFASTLED_DISABLE_UCS7604=1` | `build_flags`; drops the UCS7604 cases in `Channel::showPixels`'s clockless switch. **Constraint:** WS2812-only sketches; calling `FastLED.addLeds<UCS7604, ...>` under this flag silently emits nothing. | ~400-600 B | 📊 | #2920 |
 | 8 | `-DFASTLED_DISABLE_DYNAMIC_DRIVER=1` | `build_flags`; gates out `Channel::resolveDynamicDriver()` and its `ChannelManager::findDriverByName` / `selectDriverForChannel` lookup chain. **Constraint:** legacy `addLeds<>` flow only (every `addLeds<>` flavor pre-binds in its ctor). Channels created via manager-based `Channel::create(cfg)` without pre-binding silently emit nothing. | ~400-900 B | 📊 | #2926 |
+| 9 | `-DFASTLED_DISABLE_CHANNEL_EVENTS=1` | `build_flags`; replaces the 7 `fl::function_list` event slots in `fl::ChannelEvents` with no-op fallbacks. **Constraint:** user-registered listeners via `events.onChannelXxx.add(...)` are silently dropped — the registration compiles (returns -1) but the callback never fires. | ~1-2 KB | 📊 | #2931 |
 
 **Legend:** ✅ measured against a recorded baseline · 📊 projected from the top-25 symbol attribution in #2886.
 

--- a/src/fl/channels/channel_events.cpp.hpp
+++ b/src/fl/channels/channel_events.cpp.hpp
@@ -3,8 +3,16 @@
 
 namespace fl {
 
+// Out-of-line `instance()` only exists in the full event-firing build.
+// Under FASTLED_DISABLE_CHANNEL_EVENTS the header-defined inline
+// `instance()` body fires (returns a static no-op object), and the
+// `fl::Singleton<ChannelEvents>` template is not instantiated — letting
+// `--gc-sections` drop both that template's machinery and the singleton
+// itself. See #2931 / #2886.
+#if !defined(FASTLED_DISABLE_CHANNEL_EVENTS) || !FASTLED_DISABLE_CHANNEL_EVENTS
 ChannelEvents& ChannelEvents::instance() {
     return fl::Singleton<ChannelEvents>::instance();
 }
+#endif
 
 }  // namespace fl

--- a/src/fl/channels/channel_events.h
+++ b/src/fl/channels/channel_events.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "fl/stl/function.h"
+#include "fl/stl/noexcept.h"
 #include "fl/stl/string.h"  // IWYU pragma: keep
 
 namespace fl {
@@ -39,6 +40,42 @@ struct ChannelConfig;
 /// Callbacks receive `const IChannel&` so the same listener works regardless
 /// of which `Channel<Bus, Chipset>` instantiation produced the event. See
 /// `fl/channels/ichannel.h` and issue #2428.
+#if defined(FASTLED_DISABLE_CHANNEL_EVENTS) && FASTLED_DISABLE_CHANNEL_EVENTS
+
+namespace detail {
+/// No-op event slot used when FASTLED_DISABLE_CHANNEL_EVENTS=1. All
+/// `operator()(...)` / `add(...)` / `remove(...)` calls compile and
+/// optimize to nothing. The class has no `fl::function_list` template
+/// instantiation, so `--gc-sections` can drop the supporting machinery
+/// it would have pulled in. See #2931 / #2886.
+struct NoOpChannelEvent {
+    template <typename... Args>
+    void operator()(Args&&...) const FL_NOEXCEPT {}
+
+    template <typename F>
+    int add(F&& /*f*/, int /*priority*/ = 0) const FL_NOEXCEPT { return -1; }
+
+    void remove(int /*id*/) const FL_NOEXCEPT {}
+};
+}  // namespace detail
+
+struct ChannelEvents {
+    static ChannelEvents& instance() FL_NOEXCEPT {
+        static ChannelEvents s;
+        return s;
+    }
+
+    detail::NoOpChannelEvent onChannelCreated;
+    detail::NoOpChannelEvent onChannelBeginDestroy;
+    detail::NoOpChannelEvent onChannelAdded;
+    detail::NoOpChannelEvent onChannelRemoved;
+    detail::NoOpChannelEvent onChannelConfigured;
+    detail::NoOpChannelEvent onChannelDataEncoded;
+    detail::NoOpChannelEvent onChannelEnqueued;
+};
+
+#else
+
 struct ChannelEvents {
     static ChannelEvents& instance();
 
@@ -74,5 +111,7 @@ struct ChannelEvents {
     /// Second parameter is the driver name (empty string for unnamed drivers)
     fl::function_list<void(const IChannel&, const fl::string& driverName)> onChannelEnqueued;
 };
+
+#endif  // FASTLED_DISABLE_CHANNEL_EVENTS
 
 }  // namespace fl


### PR DESCRIPTION
Closes #2931. Opt-in build flag replaces 7 fl::function_list event slots with NoOpChannelEvent. Projected ~1-2 KB on stock NEOPIXEL Blink. Refs #2886.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional `-DFASTLED_DISABLE_CHANNEL_EVENTS=1` build flag to reduce flash memory usage (~1-2 KB) on memory-constrained devices. When enabled, channel event listeners compile but callbacks are silently skipped.

* **Documentation**
  * Updated ESP32S3 optimization guide with new memory-saving build option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->