### PR TITLE
fix(bloat): force ELF delete before each measure-opt-ins compile

### DIFF
--- a/tests/measure_esp32s3_opt_ins.py
+++ b/tests/measure_esp32s3_opt_ins.py
@@ -313,11 +313,43 @@ def archive_report(cfg: OptInConfig) -> Path:
     return dst
 
 
+_ELF_PATH = (
+    PROJECT_ROOT
+    / ".build"
+    / "pio"
+    / "esp32s3"
+    / ".pio"
+    / "build"
+    / "esp32s3"
+    / "firmware.elf"
+)
+
+
+def _force_relink() -> None:
+    """Delete the prior ELF so PIO's link step actually runs.
+
+    PIO's build cache returns cached .o files on consecutive runs with
+    overlapping object hashes — that's the right speed/correctness
+    trade-off. But the link step decides whether to relink based on
+    object-file timestamps, NOT on platformio.ini / sdkconfig changes.
+    Switching configs that affect only sdkconfig (e.g. stage3 ↔
+    baseline) can therefore leave the previous config's ELF on disk
+    even after `bash compile` returns successfully — and the downstream
+    `bash bloat` step measures that stale ELF.
+
+    Deleting the ELF before each compile forces the link to run; the
+    cached objects make the rebuild fast anyway. See #2940.
+    """
+    if _ELF_PATH.is_file():
+        _ELF_PATH.unlink()
+
+
 def measure_one(cfg: OptInConfig, example: str) -> int | None:
     """Build + bloat one config; return total_flash or None on failure."""
     print(f"\n=== measure-opt-ins: config {cfg.name} ({cfg.label}) ===", flush=True)
     restore_platformio_ini(keep_backup=True)
     patch_platformio_ini(cfg)
+    _force_relink()
     if not run_compile(example, cfg.name):
         print(f"measure-opt-ins: compile failed for {cfg.name}", file=sys.stderr)
         return None


### PR DESCRIPTION
Closes #2940. Forces PIO relink between configs by deleting the prior ELF; the cached objects still make rebuild fast. Smoke test before fix: baseline reported stage3's 280,738 B (stale). After fix: 339,962 B (correct). Refs #2886.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated measurement workflow to automatically clear previously compiled binaries between configuration changes, ensuring firmware measurements reflect the current build state and preventing inaccuracies from stale artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->