### PR TITLE
perf(channel): skip auto-naming in release builds (#2942)

### DIFF
--- a/src/fl/channels/channel.cpp.hpp
+++ b/src/fl/channels/channel.cpp.hpp
@@ -157,7 +157,18 @@ fl::string Channel::makeName(i32 id, const fl::optional<fl::string>& configName)
     if (configName.has_value()) {
         return configName.value();
     }
+    // Auto-naming `"Channel_<id>"` only matters for diagnostics — in release
+    // builds (NDEBUG → FASTLED_LOG_VERBOSITY=0 per Stage 1) every FL_WARN /
+    // FL_ERROR site that reads mName collapses to `do { } while(0)`, so the
+    // string and the supporting `fl::to_string` + `operator+` chain go
+    // unused. Empty in release saves the `fl::to_string<i64>` instantiation
+    // plus the heap allocation per Channel ctor. See #2942 / #2886.
+#if FASTLED_LOG_RUNTIME_ENABLED
     return "Channel_" + fl::to_string(static_cast<i64>(id));
+#else
+    (void)id;
+    return {};
+#endif
 }
 
 ChannelPtr Channel::create(const ChannelConfig &config) {


### PR DESCRIPTION
## Summary
- Gates `Channel::makeName`'s `"Channel_<id>"` auto-naming branch on `FASTLED_LOG_RUNTIME_ENABLED`.
- In release builds (NDEBUG → `FASTLED_LOG_VERBOSITY=0` per #2890), every FL_WARN/FL_ERROR site that reads `mName` collapses to `do { } while(0)`, so the synthesized name + `fl::to_string<i64>` instantiation + heap concat run for nothing.
- Explicit user-supplied names (`ChannelConfig::mName.has_value()`) are unaffected in both debug and release.

## Behavior matrix
| Build | configName set? | mName value |
|---|:---:|---|
| Debug | yes | configName.value() |
| Debug | no | `"Channel_<id>"` |
| Release | yes | configName.value() |
| Release | no | `""` (empty) |

## Test plan
- [x] `bash lint --cpp` passes
- [ ] Post-merge `tests/measure_esp32s3_opt_ins.py --config baseline` records new total; if positive, ratchet `tests/data/esp32s3_bloat_baseline.txt`

Closes #2942. Refs #2886.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modified diagnostic name generation to conditionally process string operations based on runtime logging configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->