### PR TITLE
ci(bloat): bump bloat-regression setup-uv from v3 to v6 (#2944)

### DIFF
--- a/.github/workflows/bloat_regression_esp32s3.yml
+++ b/.github/workflows/bloat_regression_esp32s3.yml
@@ -66,7 +66,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up uv (Python toolchain)
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v6
         with:
           enable-cache: true
 


### PR DESCRIPTION
## Summary
- Bumps \`astral-sh/setup-uv\` from \`@v3\` to \`@v6\` in \`.github/workflows/bloat_regression_esp32s3.yml\`.
- Restores the Stage-6 bloat regression gate (#2886) which has been silently failing in ~10s at the \"Set up uv\" step on every PR and master push for many runs.
- All other setup-uv usages in the repo already pin \`@v6\`.

## Root cause
\`setup-uv@v3\`'s cache-key glob (\`**/uv.lock\`) errors when the glob returns zero matches even though \`uv.lock\` is present in the repo at HEAD. Fixed in v4+. Verified by comparing against the 7 other workflows in the repo that use setup-uv successfully (they all pin v6).

## Test plan
- [ ] The bloat regression check on this PR reaches the \"Run ESP32-S3 bloat regression gate\" step instead of failing in setup.
- [ ] Post-merge master push run does not fail in setup.

Closes #2944. Refs #2886.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the CI/CD workflow to use the latest version of the Python toolchain setup tool, improving the development infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->