### PR TITLE
chore(deps): bump fbuild 2.2.18 → 2.2.20 (#2946)

### DIFF
--- a/ci/bloat.py
+++ b/ci/bloat.py
@@ -155,12 +155,11 @@ def assert_fbuild_has_symbols() -> None:
         ) from e
     except subprocess.CalledProcessError as e:
         raise SystemExit(
-            "Bloat: `fbuild symbols` rejected. fbuild 2.2.18 (the released "
-            "wheel) does NOT carry the symbols subcommand — it was merged "
-            "to fbuild#main after the 2.2.18 tag. Rebuild fbuild from main "
-            "(or wait for the 2.2.19 wheel) and drop the binary into "
-            ".venv/Scripts/fbuild.exe. See CLAUDE.md > 'Binary Size "
-            "Analysis' for the upgrade path.\n\n"
+            "Bloat: `fbuild symbols` rejected. Your installed fbuild "
+            "doesn't carry the symbols subcommand. Reinstall project "
+            "dependencies (`uv sync`) — pyproject.toml pins a release "
+            "that ships symbols/bloat. See agents/docs/binary-size-"
+            "analysis.md for the upgrade path.\n\n"
             f"Output:\n{e.output}"
         ) from e
     if "symbols" not in out.lower() and "bloat" not in out.lower():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,17 +5,29 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    # Pin to fbuild 2.2.18 (released 2026-06-05). 2.2.18 adds the
-    # FastLED #2836 Stage 1 deliverable — LPC804 + LPC845 bare-metal
-    # targets (FastLED/fbuild#419) — plus a batch of vendor-warning
-    # scopings (renesas FSP, nRF52 Adafruit BSP), the
-    # ESP32-S2/S3 USB_VID/USB_PID redef-warning fix
-    # (FastLED/fbuild#413), nested-example build-info parent-dir
-    # creation (FastLED/fbuild#410), a larger CLI Windows stack
-    # reservation, and the SAMD/STM32/ATmega/CH559 test-fixture
-    # coverage that backs the validate_boards reconciliation
-    # tracked at FastLED/fbuild#421/#422. zccache pinned >=1.11.15.
+    # Pin to fbuild 2.2.20 (released 2026-06-07). 2.2.20 ships the
+    # `fbuild symbols`/bloat subcommand that `ci/bloat.py` relies on
+    # — without it the FastLED #2886 Stage-6 regression gate cannot
+    # run. Specifically it exposes linker --cref back-references as
+    # `referenced_by` (FastLED/fbuild#459/#460) and emits graphviz
+    # `.dot` back-reference graphs (FastLED/fbuild#463/#468). Also
+    # contains a cargo binary-locator fix
+    # (FastLED/fbuild#461), Stop-hook + pre-push hook polish
+    # (FastLED/fbuild#462/#464/#465/#467/#469), and the GH-Action
+    # release-flow rework (FastLED/fbuild#457). zccache pinned
+    # >=1.11.15. (No 2.2.19 release was tagged on GitHub; fbuild
+    # jumped from 2.2.18 → 2.2.20 directly.)
     # Prior pins preserved for context:
+    #   2.2.18 — FastLED #2836 Stage 1: LPC804/LPC845 bare-metal
+    #            (FastLED/fbuild#419) + vendor-warning scopings
+    #            (renesas FSP, nRF52 Adafruit BSP), the
+    #            ESP32-S2/S3 USB_VID/USB_PID redef-warning fix
+    #            (FastLED/fbuild#413), nested-example build-info
+    #            parent-dir creation (FastLED/fbuild#410), a
+    #            larger CLI Windows stack reservation, and the
+    #            SAMD/STM32/ATmega/CH559 test-fixture coverage
+    #            backing the validate_boards reconciliation
+    #            (FastLED/fbuild#421/#422).
     #   2.2.17 — routed ESP32-S3 native deploys through esptool
     #            (FastLED/fbuild#380), one of the user-visible
     #            failure modes tracked in FastLED #2700.
@@ -38,7 +50,7 @@ dependencies = [
     #   2.2.16 — completed ESP32-C2 framework skeleton installs
     #            and patched the missing touch_sensor_legacy_types.h
     #            no-touch compatibility header (FastLED/fbuild#378).
-    "fbuild==2.2.18",
+    "fbuild==2.2.20",
     "platformio>=6.1.19,<6.2",
     "python-dateutil",
     "ruff",


### PR DESCRIPTION
## Summary
- Bumps \`fbuild==2.2.18\` → \`fbuild==2.2.20\` in \`pyproject.toml\`.
- Restores \`bash bloat <board>\` and the Stage-6 regression gate (#2886): fbuild 2.2.20 ships the \`symbols\` subcommand that \`ci/bloat.py\` requires (added in fbuild#459/#460 + fbuild#463/#468 after the 2.2.18 tag).
- Cleans the stale \"wait for 2.2.19 wheel\" guidance from \`ci/bloat.py\`'s error message (2.2.20 superseded the never-tagged 2.2.19).

## Test plan
- [x] \`bash lint ci/bloat.py\` passes.
- [ ] Post-merge: \`bloat regression esp32s3\` workflow reaches the gate and reports a real verdict (pass or honest fail). The companion fix #2945 (setup-uv@v6) already unstuck the workflow setup.

Closes #2946. Refs #2886.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated fbuild dependency from version 2.2.18 to 2.2.20.

* **Updates**
  * Enhanced error messaging for the binary size analysis tool to direct users to relevant upgrade documentation instead of detailed rebuild instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->