### PR TITLE
perf(channel): gate emitDisabledDriverError diagnostic chain (#2950)

### DIFF
--- a/src/fl/channels/channel.cpp.hpp
+++ b/src/fl/channels/channel.cpp.hpp
@@ -634,19 +634,27 @@ void Channel::showPixels(PixelController<RGB, 1, 0xFFFFFFFF> &pixels) {
     fl::string driverName = driver->getName();
     auto status = ChannelManager::instance().driverStatus(driverName);
     if (status == ChannelManager::DriverStatus::STATUS_DISABLED) {
+#if FASTLED_LOG_RUNTIME_ENABLED
         if (!mDisabledDriverWarned) {
             emitDisabledDriverError(
                 mName, driverName,
                 ChannelManager::instance().exclusiveDriverName());
             mDisabledDriverWarned = true;
         }
+#endif
         // Skip the enqueue — the data wouldn't be sent anyway, and dropping
         // it here matches the existing behaviour (rather than leaving stale
         // bytes in the driver's pending queue across an enable/disable flip).
+        // The drop happens in both debug and release; only the diagnostic
+        // and the one-shot latch are gated. In release, the empty
+        // emitDisabledDriverError + the exclusiveDriverName() call + the
+        // 3-arg fl::string chain dead-strip (see #2950).
         return;
     } else if (status == ChannelManager::DriverStatus::STATUS_ENABLED) {
+#if FASTLED_LOG_RUNTIME_ENABLED
         // Reset the one-shot guard so a future disable re-emits the diagnostic.
         mDisabledDriverWarned = false;
+#endif
     }
     // NOT_REGISTERED: driver is not managed by ChannelManager (e.g. a custom
     // test driver, or one that was removed). Fall through to enqueue and let


### PR DESCRIPTION
## Summary
- Gates the \"silent-drop\" diagnostic in \`Channel::showPixels\` on \`FASTLED_LOG_RUNTIME_ENABLED\`.
- In release builds (NDEBUG → \`FASTLED_LOG_VERBOSITY=0\` per #2890), the empty \`emitDisabledDriverError\` body + the \`ChannelManager::instance().exclusiveDriverName()\` call + the 3-arg \`fl::string\` pass-by-const-ref chain + the \`mDisabledDriverWarned\` latch maintenance dead-strip.
- The unconditional \`return\` on STATUS_DISABLED is preserved — release builds still drop the frame, just silently. Users opt into that by disabling logs.

## Behavior matrix
| Build | status | Behaviour |
|---|---|---|
| Debug | DISABLED | One-shot FL_ERROR emitted; frame dropped. |
| Debug | ENABLED | Latch reset; frame enqueued. |
| Release | DISABLED | Frame dropped silently. |
| Release | ENABLED | Frame enqueued. |

## Test plan
- [x] \`bash lint --cpp\` passes.
- [ ] Post-merge bloat regression run reports a positive saving (projected 300-800 B, may cascade higher per the #2918/#2925/#2943 pattern).

Closes #2950. Refs #2886.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized conditional compilation of driver status diagnostics, making diagnostic behavior contingent on logging configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->