### PR TITLE
perf(channel): gate bus-miss diagnostic probe in release builds (#2952)

### DIFF
--- a/src/fl/channels/channel.cpp.hpp
+++ b/src/fl/channels/channel.cpp.hpp
@@ -411,6 +411,7 @@ fl::shared_ptr<IChannelDriver> Channel::resolveDynamicDriver() {
     // instantiated" from "driver exists but canHandle() rejected this
     // chipset" — resolution paths differ. The mBusWarned guard suppresses
     // duplicate logs on subsequent shows of the same channel.
+#if FASTLED_LOG_RUNTIME_ENABLED
     if (mBus != Bus::AUTO && !mBusWarned &&
         (!driver || driver->getName() != busKey)) {
         auto busDriver = ChannelManager::instance().findDriverByName(busKey);
@@ -436,6 +437,11 @@ fl::shared_ptr<IChannelDriver> Channel::resolveDynamicDriver() {
     if (!driver) {
         FL_ERROR("Channel '" << mName << "': No compatible driver found - cannot transmit");
     }
+#endif  // FASTLED_LOG_RUNTIME_ENABLED — release skips the per-frame
+        // driver->getName() != busKey compare + the silent
+        // findDriverByName probe (used only to differentiate the
+        // FL_ERROR message). The functional return value below is
+        // preserved in both builds. See #2952.
     return driver;
 #endif  // !FASTLED_DISABLE_DYNAMIC_DRIVER
 }


### PR DESCRIPTION
## Summary
- Gates the per-frame bus-miss diagnostic block in \`resolveDynamicDriver\` on \`FASTLED_LOG_RUNTIME_ENABLED\`.
- In release the empty FL_ERROR bodies + \`driver->getName() != busKey\` virtual-call + \`findDriverByName\` silent probe + \`mBusWarned\` machinery dead-strip.
- Functional return value preserved in both builds; only the diagnostic side-effect is gated.

## Behavior matrix
| Build | Bus | canHandle | Behaviour |
|---|---|:---:|---|
| Debug | typed | no | One-shot FL_ERROR with remediation hint |
| Debug | AUTO | n/a | Silent |
| Release | typed | no | Caller's \`if (!driver) return;\` skips frame; no diagnostic |
| Release | AUTO | n/a | Silent (same as debug) |

## Test plan
- [x] \`bash lint --cpp\` passes.
- [ ] Post-merge bloat regression run reports positive saving (projected ~150-300 B based on #2951's 24 B and #2943's 1,845 B bracket).

Closes #2952. Refs #2886.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized release builds by gating diagnostic logic behind conditional compilation flags, reducing unnecessary checks while maintaining functional behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->