### PR TITLE
perf(rx-channel): skip auto-naming in release builds (#2954)

### DIFF
--- a/src/fl/channels/rx/channel.cpp.hpp
+++ b/src/fl/channels/rx/channel.cpp.hpp
@@ -1,5 +1,6 @@
 #include "fl/channels/rx/channel.h"
 
+#include "fl/log/log.h"
 #include "fl/stl/atomic.h"
 #include "fl/stl/string.h"
 
@@ -47,7 +48,17 @@ fl::string RxChannel::makeName(i32 id, const fl::string& config_name) FL_NOEXCEP
     if (!config_name.empty()) {
         return config_name;
     }
+    // Mirrors Channel::makeName's release-build gate (#2942/#2943).
+    // mName is consumed only by FL_WARN/FL_ERROR sites that collapse to
+    // do-while-0 when FASTLED_LOG_VERBOSITY=0 (NDEBUG default per #2890),
+    // so the string + fl::to_string<i64> + heap concat run for nothing
+    // in release. See #2954.
+#if FASTLED_LOG_RUNTIME_ENABLED
     return "RxChannel_" + fl::to_string(static_cast<i64>(id));
+#else
+    (void)id;
+    return {};
+#endif
 }
 
 RxChannelPtr RxChannel::create(const RxChannelConfig& config) FL_NOEXCEPT {


### PR DESCRIPTION
## Summary
- Mirrors #2943's \`Channel::makeName\` release-gate on \`RxChannel::makeName\`.
- In release builds (NDEBUG → \`FASTLED_LOG_VERBOSITY=0\` per #2890) every FL_WARN/FL_ERROR site that reads the name collapses, so the string + \`fl::to_string<i64>\` + heap concat run for nothing.
- User-provided names (\`config.name\` non-empty) unchanged in both builds.

## Behavior matrix
| Build | config_name | mName value |
|---|:---:|---|
| Debug | non-empty | config_name |
| Debug | empty | \`\"RxChannel_<id>\"\` |
| Release | non-empty | config_name |
| Release | empty | \`\"\"\` (empty) |

## Test plan
- [x] \`bash lint --cpp\` passes
- [ ] Bloat regression gate either reports positive headroom (RxChannel reachable in Blink) or zero delta (not reachable). Both outcomes are fine — the fix is correct symmetry with #2943.

Closes #2954. Refs #2886.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized channel naming performance by reducing unnecessary string construction when logging is disabled, improving efficiency in non-logging builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->