### PR TITLE
perf(rmt5): gate handleAllocateTxFailure diagnostic block (#2956)

### DIFF
--- a/src/platforms/esp/32/drivers/rmt/rmt_5/rmt_memory_manager.cpp.hpp
+++ b/src/platforms/esp/32/drivers/rmt/rmt_5/rmt_memory_manager.cpp.hpp
@@ -447,7 +447,12 @@ RmtMemoryManager::handleAllocateTxFailure(u8 channel_id, size_t mem_blocks,
         FL_LOG_RMT("  [FAIL] Fallback failed: insufficient memory even for single-buffer");
     }
 
-    // Fallback failed or not attempted - provide detailed diagnostic message
+    // Fallback failed or not attempted - provide detailed diagnostic message.
+    // Gate the entire block on FASTLED_LOG_RUNTIME_ENABLED — in release
+    // builds (NDEBUG → FASTLED_LOG_VERBOSITY=0 per Stage 1) the 9 FL_WARN
+    // bodies collapse to do-while-0, but the locals they feed (including
+    // the getAvailableWords() call + 3 mLedger reads) still run. See #2956.
+#if FASTLED_LOG_RUNTIME_ENABLED
     size_t total = mLedger.is_global_pool ? mLedger.total_words : mLedger.total_tx_words;
     size_t allocated = mLedger.is_global_pool ? mLedger.allocated_words : mLedger.allocated_tx_words;
     size_t reserved = mLedger.reserved_tx_words;
@@ -473,6 +478,7 @@ RmtMemoryManager::handleAllocateTxFailure(u8 channel_id, size_t mem_blocks,
                 << " words per channel)");
         FL_WARN("              Consider disabling network or using DMA channels");
     }
+#endif
 
     return result<size_t, RmtMemoryError>::failure(RmtMemoryError::INSUFFICIENT_TX_MEMORY);
 }


### PR DESCRIPTION
## Summary
- Gates the 9-line FL_WARN diagnostic + suggestion block in \`handleAllocateTxFailure\` on \`FASTLED_LOG_RUNTIME_ENABLED\`.
- In release the 4 local-variable initializations (including a \`getAvailableWords()\` call + 3 \`mLedger\` reads) + 3 conditional suggestion branches dead-strip alongside the empty FL_WARN bodies.
- Function's return value preserved unconditionally; only the diagnostic side-effect is gated.

## Test plan
- [x] \`bash lint --cpp\` passes.
- [ ] Bloat regression gate passes with positive saving (projected ~50-300 B).

Closes #2956. Refs #2886.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized diagnostic logging behavior for production builds to reduce overhead while maintaining functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->