### PR TITLE
refactor(fl::string): drop StrN&lt;N&gt; template, make basic_string the public class

### DIFF
--- a/agents/docs/string-architecture.md
+++ b/agents/docs/string-architecture.md
@@ -1,14 +1,26 @@
 # `fl::string` architecture
 
-Two layers. No template wrappers.
+Three layers. The top two are thin template wrappers; only the
+bottom one carries non-trivial code.
 
 | Type | Role | What it adds |
 |---|---|---|
 | `fl::basic_string` | **Concrete public class.** Holds *all* string logic (write, append, find, replace, resize, hashing, …), compiled exactly once. Directly constructible from `(char*, fl::size)` or `fl::span<char>`. | Storage state (length + variant<heap, literal, view>) + offset-based pointer to a caller-provided inline buffer. |
-| `fl::string` | Default convenience wrapper. Inherits `basic_string` and co-locates a `FASTLED_STR_INLINED_SIZE`-byte inline buffer + the inheritance-passed buffer pointer. Adds composite-type formatters (CRGB, vec2, span, vector, optional, …). | `char mInlineBuffer[64]` + ~30 `append(T)` overloads for FastLED-side composite types. |
+| `fl::string_n<N>` | **Templated inline-buffer storage policy.** Holds `char mInlineBuffer[N]` and passes it to `basic_string(mInlineBuffer, N)`. Per-N instantiations are thin constructor stubs — the actual write/append/find/replace logic stays in `basic_string` and is shared. | An inline buffer of exactly `N` bytes + the standard set of `string_n<N>(...)` constructors that hand the buffer to the base. |
+| `fl::string` | Default convenience wrapper. Inherits `string_n<FASTLED_STR_INLINED_SIZE>`. Adds composite-type formatters (CRGB, vec2, span, vector, optional, …), the `substring()` / `trim()` family (returning `string` so callers chain naturally), the static factory + comparison methods. | ~30 `append(T)` overloads for FastLED-side composite types, plus the per-string-typed methods (`substring`, comparisons, `operator+=`, factories). |
 | `fl::sstream` | Stream-style facade around an embedded `fl::string`. `operator<<` overloads forward to `mStr.append(...)`. | Sugar — no new storage. |
 
-The historical `fl::StrN<N>` template was removed when `basic_string` became publicly constructible. Callers who previously wrote `fl::StrN<32>` now write `fl::string` (which carries a 64-byte inline buffer + heap overflow — the 32-byte savings turned out not to matter anywhere in the codebase, including the OTA module's 5 fields). Callers who genuinely need a non-default-sized buffer construct `fl::basic_string` directly with `(char*, size)` or `fl::span<char>`.
+Convenience aliases over `string_n<N>`:
+
+- **`fl::string_small`** — `string_n<32>`. Use on constrained MCUs where the +32-byte default inline buffer is wasteful.
+- **`fl::string`** — `string_n<FASTLED_STR_INLINED_SIZE>` (default 64) extended with composite formatters. The everywhere-default.
+- **`fl::string_large`** — `string_n<256>`. Use on text-heavy paths where the default's 64-byte cap causes frequent heap promotion.
+
+All three are layout-compatible: copy/move/assign between sizes works because the underlying `basic_string` storage policy is uniform. Choosing a size is purely an "expected inline length" tuning knob — exceeding it triggers heap-backed `StringHolder` promotion in either case.
+
+## Why the template isn't bloat
+
+Each `string_n<N>` instantiation only emits constructor stubs — every one is essentially `: basic_string(mInlineBuffer, N) {}` plus a one-line body that calls a non-template helper on the base (`copy()`, `setLiteral()`, `setSharedHolder()`, etc.). The non-trivial bytes (`write`, `append(i32)`, `find`, `replace`, `resize`, `materialize`) all live in `basic_string` and are compiled exactly once into the FastLED library, then shared by every `N`. The compiler and linker fold identical per-N stubs under COMDAT, so e.g. `string_n<64>` (used everywhere via `fl::string`) is a single set of constructor instantiations no matter how many TUs reference it.
 
 ## Using `basic_string` directly
 

--- a/agents/docs/string-architecture.md
+++ b/agents/docs/string-architecture.md
@@ -28,7 +28,7 @@ fl::basic_string s2(buf, 256);
 
 ## How the formatting layer trampolines
 
-```
+```text
 caller writes:           fl::sstream() << vec2<float>{1.0f, 2.0f}
                           │
                           ▼

--- a/agents/docs/string-architecture.md
+++ b/agents/docs/string-architecture.md
@@ -1,0 +1,69 @@
+# `fl::string` architecture — the trampoline pattern
+
+Public names (in `fl/stl/`):
+
+| Type | Role | What it adds over the base |
+|---|---|---|
+| `fl::string_base` (alias for `fl::basic_string`) | **Concrete, type-erased base.** Holds *all* string logic (write, append, find, replace, resize, hashing, …). Compiled exactly once. | n/a — every storage policy delegates here. |
+| `fl::stringN<N>` (alias for `fl::StrN<N>`) | Inline-buffer storage policy. Holds `char buf[N]` and passes `(buf, N)` to the base ctor. | A fixed-size inline buffer. Empty `mInlineBuffer[N]={0}` + thin constructors/assignment. |
+| `fl::string` | The default-everywhere class. `stringN<64>` (i.e. `StrN<FASTLED_STR_INLINED_SIZE>`) plus a long list of `append(T)` / `operator+` overloads for FastLED-side types (CRGB, vec2, span, vector, optional, …). | Per-T composite-formatter overloads. Bodies are short loops that call `append(elem)` on each member, where `append(elem)` itself dispatches to `string_base`. |
+| `fl::sstream` | Stream-style facade around an embedded `fl::string`. `operator<<` overloads forward to `mStr.append(...)`. | Sugar — no new storage. |
+
+## How the trampoline works
+
+```
+caller writes:           fl::sstream() << vec2<float>{1.0f, 2.0f}
+                          │
+                          ▼
+sstream::operator<<(vec2<T>):     mStr.append("(");
+  (template, in strstream.h)       mStr.append(v.x);   // float overload on fl::string
+                                    mStr.append(",");
+                                    mStr.append(v.y);
+                                    mStr.append(")");
+                          │
+                          ▼
+fl::string::append(float):        basic_string::append(val) — non-template
+  (concrete, in basic_string)      │
+                                    ▼
+basic_string::write(const char*, size):  raw bytes into the inline-or-heap buffer
+  (concrete, exactly one copy in the binary)
+```
+
+The **template layer** (`sstream::operator<<<T>`, `string::append<T>` for composites) walks T's structure. The **leaf calls** all land on non-template `basic_string` methods (`write(const char*, size)`, `append(float)`, `append(i32)`, …) which are compiled exactly once. Template instantiations of the structure-walking layer are short loops that — being defined in the header as implicit-`inline` — should fold under COMDAT at link time.
+
+## Where the actual binary duplication is
+
+Per [#2886](https://github.com/FastLED/FastLED/issues/2886#issuecomment-4643081327) row #24, the largest single string-related symbol on ESP32-S3 Blink is:
+
+```
+fl::basic_string::write(const char*, fl::size)    1,151 B (3 overloads)
+```
+
+That's `basic_string::write` itself, **not** a template instantiation. The 1.1 KB lives in `src/fl/stl/basic_string.cpp.hpp:193` and comes from the materialize-on-write logic (variant dispatch between inline / heap / literal / view storage modes — see [`basic_string.h:466`](../../src/fl/stl/basic_string.h)). It's already type-erased; the size reflects genuine algorithmic complexity, not duplicated code.
+
+Template-instantiation duplication of `string::append<T>(...)` / `sstream::operator<<<T>(T)` does happen for composite types (vec2, vector, span, …) but those instantiations are individually tiny (each is a 3-5 line loop that all reduces to the same `basic_string::write` calls), and the linker generally folds identical instantiations into one COMDAT group. If a future bloat audit shows the composite formatters as a top contributor, the fix is to push their *bodies* down into non-template `basic_string` helpers that take a function-pointer-shaped element formatter — not to reshape the storage classes.
+
+## Why the names are aliases, not renames
+
+The codebase already uses `basic_string` / `StrN<N>` / `string` extensively (~hundreds of references). Adding the `string_base` and `stringN<N>` aliases gives newer code a clearer vocabulary without churning every existing site. Hard renames can come later as a follow-up if the vocabulary stabilises.
+
+## Storage modes (`basic_string` variant)
+
+The base class supports four storage modes via an `fl::variant`:
+
+| Mode | When | Where the bytes live |
+|---|---|---|
+| Inline | `mLength + 1 <= mInlineCapacity` | The wrapper's `mInlineBuffer[N]` (via `mInlineOffset` from `this`) |
+| Heap (`StringHolder`) | `mLength + 1 > mInlineCapacity` | `fl::shared_ptr<StringHolder>` |
+| `ConstLiteral` | `setLiteral("...")` | Caller's `.rodata` |
+| `ConstView` | `setView(ptr, len)` | Caller's memory |
+
+`is_literal()` / `is_view()` / `is_owning()` queries let callers reason about COW + lifetime. `materialize()` flips a non-owning storage into an owning one before any mutation.
+
+## Reading order
+
+- [`fl/stl/basic_string.h`](../../src/fl/stl/basic_string.h) — base class declaration (the bulk of the API)
+- [`fl/stl/basic_string.cpp.hpp`](../../src/fl/stl/basic_string.cpp.hpp) — base class impl (the 1.1 KB lives here)
+- [`fl/stl/string.h`](../../src/fl/stl/string.h) — `StrN<N>` + `string` + per-T `append` overloads
+- [`fl/stl/strstream.h`](../../src/fl/stl/strstream.h) — `sstream` + per-T `operator<<` overloads
+- [`fl/stl/detail/string_holder.h`](../../src/fl/stl/detail/string_holder.h) — heap-backed `StringHolder`

--- a/agents/docs/string-architecture.md
+++ b/agents/docs/string-architecture.md
@@ -1,15 +1,32 @@
-# `fl::string` architecture — the trampoline pattern
+# `fl::string` architecture
 
-Public names (in `fl/stl/`):
+Two layers. No template wrappers.
 
-| Type | Role | What it adds over the base |
+| Type | Role | What it adds |
 |---|---|---|
-| `fl::string_base` (alias for `fl::basic_string`) | **Concrete, type-erased base.** Holds *all* string logic (write, append, find, replace, resize, hashing, …). Compiled exactly once. | n/a — every storage policy delegates here. |
-| `fl::stringN<N>` (alias for `fl::StrN<N>`) | Inline-buffer storage policy. Holds `char buf[N]` and passes `(buf, N)` to the base ctor. | A fixed-size inline buffer. Empty `mInlineBuffer[N]={0}` + thin constructors/assignment. |
-| `fl::string` | The default-everywhere class. `stringN<64>` (i.e. `StrN<FASTLED_STR_INLINED_SIZE>`) plus a long list of `append(T)` / `operator+` overloads for FastLED-side types (CRGB, vec2, span, vector, optional, …). | Per-T composite-formatter overloads. Bodies are short loops that call `append(elem)` on each member, where `append(elem)` itself dispatches to `string_base`. |
+| `fl::basic_string` | **Concrete public class.** Holds *all* string logic (write, append, find, replace, resize, hashing, …), compiled exactly once. Directly constructible from `(char*, fl::size)` or `fl::span<char>`. | Storage state (length + variant<heap, literal, view>) + offset-based pointer to a caller-provided inline buffer. |
+| `fl::string` | Default convenience wrapper. Inherits `basic_string` and co-locates a `FASTLED_STR_INLINED_SIZE`-byte inline buffer + the inheritance-passed buffer pointer. Adds composite-type formatters (CRGB, vec2, span, vector, optional, …). | `char mInlineBuffer[64]` + ~30 `append(T)` overloads for FastLED-side composite types. |
 | `fl::sstream` | Stream-style facade around an embedded `fl::string`. `operator<<` overloads forward to `mStr.append(...)`. | Sugar — no new storage. |
 
-## How the trampoline works
+The historical `fl::StrN<N>` template was removed when `basic_string` became publicly constructible. Callers who previously wrote `fl::StrN<32>` now write `fl::string` (which carries a 64-byte inline buffer + heap overflow — the 32-byte savings turned out not to matter anywhere in the codebase, including the OTA module's 5 fields). Callers who genuinely need a non-default-sized buffer construct `fl::basic_string` directly with `(char*, size)` or `fl::span<char>`.
+
+## Using `basic_string` directly
+
+```cpp
+// Ephemeral, caller-owned buffer
+char buf[256];
+fl::basic_string s(fl::span<char>(buf, 256));
+s.append("hello, ");
+s.append(42);
+// Caller owns buf for as long as s is used.
+
+// Equivalent (pre-#2961 form, still supported)
+fl::basic_string s2(buf, 256);
+```
+
+**Lifetime contract**: the buffer must outlive the `basic_string`, and the `basic_string` must not be trivially relocated (bitwise-copied to a different address). `basic_string` stores the buffer pointer as an offset from `this` (`mInlineOffset`); relocation invalidates the offset. For member-stored use, prefer `fl::string` (which co-locates the buffer inside itself).
+
+## How the formatting layer trampolines
 
 ```
 caller writes:           fl::sstream() << vec2<float>{1.0f, 2.0f}
@@ -29,7 +46,7 @@ basic_string::write(const char*, size):  raw bytes into the inline-or-heap buffe
   (concrete, exactly one copy in the binary)
 ```
 
-The **template layer** (`sstream::operator<<<T>`, `string::append<T>` for composites) walks T's structure. The **leaf calls** all land on non-template `basic_string` methods (`write(const char*, size)`, `append(float)`, `append(i32)`, …) which are compiled exactly once. Template instantiations of the structure-walking layer are short loops that — being defined in the header as implicit-`inline` — should fold under COMDAT at link time.
+Template instantiations of the structure-walking layer (`sstream::operator<<<T>` for composite T, `string::append<T>` for vec/span/optional/etc.) are short loops that, being defined in the header as implicit-`inline`, are expected to fold under COMDAT at link time. If a future bloat audit shows those instantiations as a top contributor, the next refactor is to push their *bodies* down into non-template `basic_string` helpers with a function-pointer-shaped element formatter.
 
 ## Where the actual binary duplication is
 
@@ -39,13 +56,7 @@ Per [#2886](https://github.com/FastLED/FastLED/issues/2886#issuecomment-46430813
 fl::basic_string::write(const char*, fl::size)    1,151 B (3 overloads)
 ```
 
-That's `basic_string::write` itself, **not** a template instantiation. The 1.1 KB lives in `src/fl/stl/basic_string.cpp.hpp:193` and comes from the materialize-on-write logic (variant dispatch between inline / heap / literal / view storage modes — see [`basic_string.h:466`](../../src/fl/stl/basic_string.h)). It's already type-erased; the size reflects genuine algorithmic complexity, not duplicated code.
-
-Template-instantiation duplication of `string::append<T>(...)` / `sstream::operator<<<T>(T)` does happen for composite types (vec2, vector, span, …) but those instantiations are individually tiny (each is a 3-5 line loop that all reduces to the same `basic_string::write` calls), and the linker generally folds identical instantiations into one COMDAT group. If a future bloat audit shows the composite formatters as a top contributor, the fix is to push their *bodies* down into non-template `basic_string` helpers that take a function-pointer-shaped element formatter — not to reshape the storage classes.
-
-## Why the names are aliases, not renames
-
-The codebase already uses `basic_string` / `StrN<N>` / `string` extensively (~hundreds of references). Adding the `string_base` and `stringN<N>` aliases gives newer code a clearer vocabulary without churning every existing site. Hard renames can come later as a follow-up if the vocabulary stabilises.
+That's `basic_string::write` itself, **not** a template instantiation. The 1.1 KB lives in `src/fl/stl/basic_string.cpp.hpp:193` and comes from the materialize-on-write logic (variant dispatch between inline / heap / literal / view storage modes — see [`basic_string.h::mStorage`](../../src/fl/stl/basic_string.h)). It's already type-erased; the size reflects genuine algorithmic complexity, not duplicated code.
 
 ## Storage modes (`basic_string` variant)
 
@@ -53,7 +64,7 @@ The base class supports four storage modes via an `fl::variant`:
 
 | Mode | When | Where the bytes live |
 |---|---|---|
-| Inline | `mLength + 1 <= mInlineCapacity` | The wrapper's `mInlineBuffer[N]` (via `mInlineOffset` from `this`) |
+| Inline | `mLength + 1 <= mInlineCapacity` | The caller-provided buffer (via `mInlineOffset` from `this`) |
 | Heap (`StringHolder`) | `mLength + 1 > mInlineCapacity` | `fl::shared_ptr<StringHolder>` |
 | `ConstLiteral` | `setLiteral("...")` | Caller's `.rodata` |
 | `ConstView` | `setView(ptr, len)` | Caller's memory |
@@ -62,8 +73,8 @@ The base class supports four storage modes via an `fl::variant`:
 
 ## Reading order
 
-- [`fl/stl/basic_string.h`](../../src/fl/stl/basic_string.h) — base class declaration (the bulk of the API)
+- [`fl/stl/basic_string.h`](../../src/fl/stl/basic_string.h) — base class declaration (the bulk of the API + public constructors)
 - [`fl/stl/basic_string.cpp.hpp`](../../src/fl/stl/basic_string.cpp.hpp) — base class impl (the 1.1 KB lives here)
-- [`fl/stl/string.h`](../../src/fl/stl/string.h) — `StrN<N>` + `string` + per-T `append` overloads
+- [`fl/stl/string.h`](../../src/fl/stl/string.h) — `string` wrapper + per-T `append` overloads
 - [`fl/stl/strstream.h`](../../src/fl/stl/strstream.h) — `sstream` + per-T `operator<<` overloads
 - [`fl/stl/detail/string_holder.h`](../../src/fl/stl/detail/string_holder.h) — heap-backed `StringHolder`

--- a/src/fl/stl/basic_string.cpp.hpp
+++ b/src/fl/stl/basic_string.cpp.hpp
@@ -14,6 +14,10 @@ const fl::size basic_string::npos;
 basic_string::basic_string(fl::span<char, static_cast<fl::size>(-1)> storage) FL_NOEXCEPT
     : basic_string(storage.data(), storage.size()) {}
 
+// ======= DESTRUCTOR =======
+
+basic_string::~basic_string() FL_NOEXCEPT {}
+
 // ======= string_view CONSTRUCTOR FROM basic_string =======
 // Defined here (in the same TU as basic_string itself) so
 // string_view.h can stay light: it forward-declares basic_string

--- a/src/fl/stl/basic_string.cpp.hpp
+++ b/src/fl/stl/basic_string.cpp.hpp
@@ -1,11 +1,27 @@
 #include "fl/stl/basic_string.h"
 #include "fl/stl/cstring.h"
 #include "fl/stl/noexcept.h"
+#include "fl/stl/span.h"
+#include "fl/stl/string_view.h"
 
 namespace fl {
 
 // ODR-use definition
 const fl::size basic_string::npos;
+
+// ======= PUBLIC CONSTRUCTORS (span delegate) =======
+
+basic_string::basic_string(fl::span<char, static_cast<fl::size>(-1)> storage) FL_NOEXCEPT
+    : basic_string(storage.data(), storage.size()) {}
+
+// ======= string_view CONSTRUCTOR FROM basic_string =======
+// Defined here (in the same TU as basic_string itself) so
+// string_view.h can stay light: it forward-declares basic_string
+// and declares this ctor without needing basic_string's complete
+// type.
+
+string_view::string_view(const basic_string& str) FL_NOEXCEPT
+    : mData(str.c_str()), mSize(str.size()) {}
 
 // ======= ACCESSORS =======
 

--- a/src/fl/stl/basic_string.h
+++ b/src/fl/stl/basic_string.h
@@ -1,9 +1,11 @@
 #pragma once
 
 /// @file basic_string.h
-/// @brief Type-erased base class for fl::StrN<N>.
-/// All string logic lives here, compiled once. StrN<N> is a thin wrapper
-/// that provides the inline buffer storage and delegates everything here.
+/// @brief Concrete type-erased string class operating on a caller-
+/// provided buffer (or `fl::span<char>`).
+/// All string logic lives here, compiled once. `fl::string` is the
+/// default convenience wrapper that co-locates a 64-byte inline
+/// buffer + heap-overflow with the basic_string state.
 
 #include "fl/stl/int.h"
 #include "fl/stl/cstring.h"
@@ -24,16 +26,21 @@
 
 namespace fl {
 
-// Forward declaration
+// Forward declarations
 class string_view;
+template <typename T, fl::size Extent> class span;
 
 // Define shared_ptr type for StringHolder
 using StringHolderPtr = fl::shared_ptr<fl::StringHolder>;
 using NotNullStringHolderPtr = fl::not_null<StringHolderPtr>;
 
-/// Type-erased string base class. Holds all string logic.
-/// StrN<N> inherits this and provides the inline buffer.
-/// This class cannot be constructed directly — only through StrN<N>.
+/// Concrete type-erased string class. Holds all string logic
+/// (write, append, find, replace, resize, hashing, …) and is
+/// directly constructible from a caller-provided buffer
+/// (`char* + len`) or `fl::span<char>`. `fl::string` is a thin
+/// wrapper that co-locates a default-sized inline buffer with the
+/// `basic_string` state and adds composite-type formatters
+/// (vec2, vector, span, …). See `agents/docs/string-architecture.md`.
 class basic_string {
   public:
     // ======= NESTED TYPES =======
@@ -427,10 +434,22 @@ class basic_string {
     float toFloat() const FL_NOEXCEPT;
 
     // ======= DESTRUCTOR =======
-    ~basic_string() {}
+    ~basic_string() FL_NOEXCEPT {}
 
-  protected:
-    // ======= CONSTRUCTION (only callable by StrN<N>) =======
+    // ======= PUBLIC CONSTRUCTION =======
+    // Construct a basic_string backed by a caller-provided buffer.
+    // The span / (ptr, len) pair points at a block of `char` the
+    // caller owns; the resulting basic_string is non-owning until
+    // the first write that exceeds the buffer's capacity, which
+    // promotes to heap-backed storage via `mStorage`.
+    //
+    // Lifetime contract: the buffer must outlive the basic_string
+    // AND the basic_string must not be trivially relocated (bitwise
+    // copied to a different address) — `mInlineOffset` is computed
+    // from `this` at construction time. For member-stored use,
+    // either co-locate the buffer with the basic_string (the
+    // `fl::string` pattern) or arrange the buffer at a fixed
+    // offset from `this` (e.g. as a class field).
     basic_string(char* inlineBuffer, fl::size inlineCapacity) FL_NOEXCEPT
         : mInlineOffset(static_cast<fl::size>(
               inlineBuffer -
@@ -440,13 +459,17 @@ class basic_string {
         , mStorage() // empty variant = inline mode
     {}
 
-    // Deleted copy/move — StrN<N> handles these
+    basic_string(fl::span<char, static_cast<fl::size>(-1)> storage) FL_NOEXCEPT;
+
+  protected:
+    // Deleted copy/move — wrappers (fl::string) handle these via
+    // `copy(const basic_string&)` / `moveFrom(basic_string&&)`.
     basic_string(const basic_string&) FL_NOEXCEPT = delete;
     basic_string(basic_string&&) FL_NOEXCEPT = delete;
     basic_string& operator=(const basic_string&) FL_NOEXCEPT = delete;
     basic_string& operator=(basic_string&&) FL_NOEXCEPT = delete;
 
-    // ======= CONTENT POPULATION (for StrN<N> constructors) =======
+    // ======= CONTENT POPULATION (for wrapper constructors) =======
     void moveFrom(basic_string&& other) FL_NOEXCEPT;
     void moveAssign(basic_string&& other) FL_NOEXCEPT;
     void swapWith(basic_string& other) FL_NOEXCEPT;
@@ -486,12 +509,5 @@ class basic_string {
     NotNullStringHolderPtr& heapData() FL_NOEXCEPT;
     const NotNullStringHolderPtr& heapData() const FL_NOEXCEPT;
 };
-
-// Public name matching the trampoline-pattern vocabulary used in design
-// docs: `string_base` is the concrete, type-erased class that holds all
-// string logic; `stringN<N>` (templated inline buffer) and `string`
-// (default inline + heap overflow) are thin wrappers that delegate
-// every mutation here. See `agents/docs/string-architecture.md`.
-using string_base = basic_string;
 
 } // namespace fl

--- a/src/fl/stl/basic_string.h
+++ b/src/fl/stl/basic_string.h
@@ -487,4 +487,11 @@ class basic_string {
     const NotNullStringHolderPtr& heapData() const FL_NOEXCEPT;
 };
 
+// Public name matching the trampoline-pattern vocabulary used in design
+// docs: `string_base` is the concrete, type-erased class that holds all
+// string logic; `stringN<N>` (templated inline buffer) and `string`
+// (default inline + heap overflow) are thin wrappers that delegate
+// every mutation here. See `agents/docs/string-architecture.md`.
+using string_base = basic_string;
+
 } // namespace fl

--- a/src/fl/stl/basic_string.h
+++ b/src/fl/stl/basic_string.h
@@ -434,7 +434,9 @@ class basic_string {
     float toFloat() const FL_NOEXCEPT;
 
     // ======= DESTRUCTOR =======
-    ~basic_string() FL_NOEXCEPT {}
+    // Body in basic_string.cpp.hpp per the project's header-thin
+    // convention (declarations in `*.h`, definitions in `*.cpp.hpp`).
+    ~basic_string() FL_NOEXCEPT;
 
     // ======= PUBLIC CONSTRUCTION =======
     // Construct a basic_string backed by a caller-provided buffer.

--- a/src/fl/stl/basic_vector.h
+++ b/src/fl/stl/basic_vector.h
@@ -4,7 +4,8 @@
 /// @brief Type-erased base class for fl::vector<T>.
 /// All vector logic lives here, compiled once. vector<T> is a thin wrapper
 /// that provides type safety and sets up the element operations table.
-/// Follows the same pattern as basic_string / StrN<N>.
+/// Follows the same pattern as basic_string + fl::string (concrete
+/// base + co-located inline buffer in the wrapper).
 
 #include "fl/stl/int.h"
 #include "fl/stl/cstring.h"

--- a/src/fl/stl/cstdio.cpp.hpp
+++ b/src/fl/stl/cstdio.cpp.hpp
@@ -200,7 +200,7 @@ fl::optional<fl::string> readLine(char delimiter, char skipChar, fl::optional<u3
         return fl::nullopt;  // Timeout occurred
     }
 
-    // Convert to string and trim whitespace (trim() returns new StrN, convert to string)
+    // Convert to string and trim whitespace (trim() returns a new fl::string)
     fl::string result = buffer.str();
     return fl::string(result.trim());
 }

--- a/src/fl/stl/string.cpp.hpp
+++ b/src/fl/stl/string.cpp.hpp
@@ -46,20 +46,22 @@ string string::from_view(const string_view& sv) FL_NOEXCEPT {
 }
 
 string string::interned(const char* str, fl::size len) FL_NOEXCEPT {
-    string result;
-    if (!str || len == 0) return result;
-    auto holder = fl::make_shared<StringHolder>(str, len);
-    result.setSharedHolder(holder);
-    return result;
+    if (!str || len == 0) return string();
+    // Route through the global interner so identical content
+    // returns the same shared StringHolder (O(1) average lookup,
+    // matches `string::intern()`'s semantics). Previously this
+    // family wrapped a fresh StringHolder per call with no
+    // deduplication — see #2961 CR thread + the follow-on commit.
+    return global_interner().intern(fl::string_view(str, len));
 }
 
 string string::interned(const char* str) FL_NOEXCEPT {
     if (!str) return string();
-    return interned(str, fl::strlen(str));
+    return global_interner().intern(str);
 }
 
 string string::interned(const string_view& sv) FL_NOEXCEPT {
-    return interned(sv.data(), sv.size());
+    return global_interner().intern(sv);
 }
 
 string string::copy_no_view(const string& str) FL_NOEXCEPT {

--- a/src/fl/stl/string.cpp.hpp
+++ b/src/fl/stl/string.cpp.hpp
@@ -145,7 +145,12 @@ string& string::operator=(string&& other) FL_NOEXCEPT {
 }
 
 string& string::operator=(const char* str) FL_NOEXCEPT {
-    copy(str, fl::strlen(str));
+    // Match the string(const char*) ctor's contract: nullptr → empty.
+    if (str) {
+        copy(str, fl::strlen(str));
+    } else {
+        clear();
+    }
     return *this;
 }
 
@@ -216,20 +221,33 @@ string& string::append(const std::string& str) {  // okay std namespace
 
 // ======= COMPARISON OPERATORS =======
 
+// Length-aware lexicographic compare. Doesn't rely on strcmp's
+// NUL-termination, so view-backed strings (`setView`) and any
+// future embedded-NUL content compare correctly. Returns the same
+// sign convention as memcmp / strcmp.
+static inline int string_compare(const string& a, const string& b) FL_NOEXCEPT {
+    fl::size n = (a.size() < b.size()) ? a.size() : b.size();
+    int r = fl::memcmp(a.c_str(), b.c_str(), n);
+    if (r != 0) return r;
+    if (a.size() < b.size()) return -1;
+    if (a.size() > b.size()) return 1;
+    return 0;
+}
+
 bool string::operator>(const string& other) const FL_NOEXCEPT {
-    return fl::strcmp(c_str(), other.c_str()) > 0;
+    return string_compare(*this, other) > 0;
 }
 
 bool string::operator>=(const string& other) const FL_NOEXCEPT {
-    return fl::strcmp(c_str(), other.c_str()) >= 0;
+    return string_compare(*this, other) >= 0;
 }
 
 bool string::operator<(const string& other) const FL_NOEXCEPT {
-    return fl::strcmp(c_str(), other.c_str()) < 0;
+    return string_compare(*this, other) < 0;
 }
 
 bool string::operator<=(const string& other) const FL_NOEXCEPT {
-    return fl::strcmp(c_str(), other.c_str()) <= 0;
+    return string_compare(*this, other) <= 0;
 }
 
 bool string::operator==(const string& other) const FL_NOEXCEPT {

--- a/src/fl/stl/string.cpp.hpp
+++ b/src/fl/stl/string.cpp.hpp
@@ -78,61 +78,42 @@ int string::strcmp(const string& a, const string& b) FL_NOEXCEPT {
 }
 
 // ======= CONSTRUCTORS =======
+// All forward to string_n<FASTLED_STR_INLINED_SIZE>'s ctors which
+// own the actual initialisation logic. fl::string is just the
+// composite-formatter + factory layer on top.
 
 string::string() FL_NOEXCEPT
-    : basic_string(mInlineBuffer, FASTLED_STR_INLINED_SIZE) {}
+    : string_n<FASTLED_STR_INLINED_SIZE>() {}
 
 string::string(const char* str) FL_NOEXCEPT
-    : basic_string(mInlineBuffer, FASTLED_STR_INLINED_SIZE) {
-    if (str) copy(str);
-}
+    : string_n<FASTLED_STR_INLINED_SIZE>(str) {}
 
 string::string(const char* str, fl::size len) FL_NOEXCEPT
-    : basic_string(mInlineBuffer, FASTLED_STR_INLINED_SIZE) {
-    copy(str, len);
-}
+    : string_n<FASTLED_STR_INLINED_SIZE>(str, len) {}
 
 string::string(fl::size len, char c) FL_NOEXCEPT
-    : basic_string(mInlineBuffer, FASTLED_STR_INLINED_SIZE) {
-    resize(len, c);
-}
+    : string_n<FASTLED_STR_INLINED_SIZE>(len, c) {}
 
 string::string(const string& other) FL_NOEXCEPT
-    : basic_string(mInlineBuffer, FASTLED_STR_INLINED_SIZE) {
-    copy(static_cast<const basic_string&>(other));
-}
+    : string_n<FASTLED_STR_INLINED_SIZE>(static_cast<const string_n<FASTLED_STR_INLINED_SIZE>&>(other)) {}
 
 string::string(string&& other) FL_NOEXCEPT
-    : basic_string(mInlineBuffer, FASTLED_STR_INLINED_SIZE) {
-    moveFrom(fl::move(other));
-}
+    : string_n<FASTLED_STR_INLINED_SIZE>(static_cast<string_n<FASTLED_STR_INLINED_SIZE>&&>(other)) {}
 
 string::string(const basic_string& other) FL_NOEXCEPT
-    : basic_string(mInlineBuffer, FASTLED_STR_INLINED_SIZE) {
-    copy(other);
-}
+    : string_n<FASTLED_STR_INLINED_SIZE>(other) {}
 
 string::string(const string_view& sv) FL_NOEXCEPT
-    : basic_string(mInlineBuffer, FASTLED_STR_INLINED_SIZE) {
-    if (!sv.empty()) {
-        copy(sv.data(), sv.size());
-    }
-}
+    : string_n<FASTLED_STR_INLINED_SIZE>(sv) {}
 
 string::string(const fl::span<const char>& s) FL_NOEXCEPT
-    : basic_string(mInlineBuffer, FASTLED_STR_INLINED_SIZE) {
-    copy(s.data(), s.size());
-}
+    : string_n<FASTLED_STR_INLINED_SIZE>(s) {}
 
 string::string(const fl::span<char>& s) FL_NOEXCEPT
-    : basic_string(mInlineBuffer, FASTLED_STR_INLINED_SIZE) {
-    copy(s.data(), s.size());
-}
+    : string_n<FASTLED_STR_INLINED_SIZE>(s) {}
 
 string::string(const fl::shared_ptr<StringHolder>& holder) FL_NOEXCEPT
-    : basic_string(mInlineBuffer, FASTLED_STR_INLINED_SIZE) {
-    setSharedHolder(holder);
-}
+    : string_n<FASTLED_STR_INLINED_SIZE>(holder) {}
 
 // ======= ASSIGNMENT =======
 
@@ -206,7 +187,7 @@ string string::trim() const FL_NOEXCEPT {
 
 #ifdef FL_IS_WASM
 string::string(const std::string& str)  // okay std namespace
-    : basic_string(mInlineBuffer, FASTLED_STR_INLINED_SIZE) {
+    : string_n<FASTLED_STR_INLINED_SIZE>() {
     copy(str.c_str(), str.size());
 }
 
@@ -377,7 +358,7 @@ string &string::append(const json& val) {
 
 #if FL_STRING_NEEDS_ARDUINO_CONVERSION
 string::string(const ::String &str)
-    : basic_string(mInlineBuffer, FASTLED_STR_INLINED_SIZE) {
+    : string_n<FASTLED_STR_INLINED_SIZE>() {
     copy(str.c_str(), strlen(str.c_str()));
 }
 

--- a/src/fl/stl/string.cpp.hpp
+++ b/src/fl/stl/string.cpp.hpp
@@ -27,8 +27,218 @@ namespace fl {
 // Define static constexpr member for npos (required for ODR-uses)
 const fl::size string::npos;
 
-int string::strcmp(const string& a, const string& b) {
+// ======= STATIC FACTORY METHODS =======
+
+string string::from_literal(const char* literal) FL_NOEXCEPT {
+    string result;
+    result.setLiteral(literal);
+    return result;
+}
+
+string string::from_view(const char* data, fl::size len) FL_NOEXCEPT {
+    string result;
+    result.setView(data, len);
+    return result;
+}
+
+string string::from_view(const string_view& sv) FL_NOEXCEPT {
+    return from_view(sv.data(), sv.size());
+}
+
+string string::interned(const char* str, fl::size len) FL_NOEXCEPT {
+    string result;
+    if (!str || len == 0) return result;
+    auto holder = fl::make_shared<StringHolder>(str, len);
+    result.setSharedHolder(holder);
+    return result;
+}
+
+string string::interned(const char* str) FL_NOEXCEPT {
+    if (!str) return string();
+    return interned(str, fl::strlen(str));
+}
+
+string string::interned(const string_view& sv) FL_NOEXCEPT {
+    return interned(sv.data(), sv.size());
+}
+
+string string::copy_no_view(const string& str) FL_NOEXCEPT {
+    if (str.is_referencing()) {
+        string result;
+        result.copy(str.c_str(), str.size());
+        return result;
+    }
+    return str;
+}
+
+int string::strcmp(const string& a, const string& b) FL_NOEXCEPT {
     return fl::strcmp(a.c_str(), b.c_str());
+}
+
+// ======= CONSTRUCTORS =======
+
+string::string() FL_NOEXCEPT
+    : basic_string(mInlineBuffer, FASTLED_STR_INLINED_SIZE) {}
+
+string::string(const char* str) FL_NOEXCEPT
+    : basic_string(mInlineBuffer, FASTLED_STR_INLINED_SIZE) {
+    if (str) copy(str);
+}
+
+string::string(const char* str, fl::size len) FL_NOEXCEPT
+    : basic_string(mInlineBuffer, FASTLED_STR_INLINED_SIZE) {
+    copy(str, len);
+}
+
+string::string(fl::size len, char c) FL_NOEXCEPT
+    : basic_string(mInlineBuffer, FASTLED_STR_INLINED_SIZE) {
+    resize(len, c);
+}
+
+string::string(const string& other) FL_NOEXCEPT
+    : basic_string(mInlineBuffer, FASTLED_STR_INLINED_SIZE) {
+    copy(static_cast<const basic_string&>(other));
+}
+
+string::string(string&& other) FL_NOEXCEPT
+    : basic_string(mInlineBuffer, FASTLED_STR_INLINED_SIZE) {
+    moveFrom(fl::move(other));
+}
+
+string::string(const basic_string& other) FL_NOEXCEPT
+    : basic_string(mInlineBuffer, FASTLED_STR_INLINED_SIZE) {
+    copy(other);
+}
+
+string::string(const string_view& sv) FL_NOEXCEPT
+    : basic_string(mInlineBuffer, FASTLED_STR_INLINED_SIZE) {
+    if (!sv.empty()) {
+        copy(sv.data(), sv.size());
+    }
+}
+
+string::string(const fl::span<const char>& s) FL_NOEXCEPT
+    : basic_string(mInlineBuffer, FASTLED_STR_INLINED_SIZE) {
+    copy(s.data(), s.size());
+}
+
+string::string(const fl::span<char>& s) FL_NOEXCEPT
+    : basic_string(mInlineBuffer, FASTLED_STR_INLINED_SIZE) {
+    copy(s.data(), s.size());
+}
+
+string::string(const fl::shared_ptr<StringHolder>& holder) FL_NOEXCEPT
+    : basic_string(mInlineBuffer, FASTLED_STR_INLINED_SIZE) {
+    setSharedHolder(holder);
+}
+
+// ======= ASSIGNMENT =======
+
+string& string::operator=(const string& other) FL_NOEXCEPT {
+    copy(static_cast<const basic_string&>(other));
+    return *this;
+}
+
+string& string::operator=(string&& other) FL_NOEXCEPT {
+    moveAssign(fl::move(other));
+    return *this;
+}
+
+string& string::operator=(const char* str) FL_NOEXCEPT {
+    copy(str, fl::strlen(str));
+    return *this;
+}
+
+string& string::assign(string_view sv) FL_NOEXCEPT {
+    if (sv.empty()) {
+        clear();
+    } else {
+        copy(sv.data(), sv.size());
+    }
+    return *this;
+}
+
+// ======= SUBSTRING =======
+
+string string::substring(fl::size start, fl::size end) const FL_NOEXCEPT {
+    if (start == 0 && end == size()) return *this;
+    if (start >= size()) return string();
+    if (end > size()) end = size();
+    if (start >= end) return string();
+    string out;
+    out.copy(c_str() + start, end - start);
+    return out;
+}
+
+string string::substr(fl::size start, fl::size length) const FL_NOEXCEPT {
+    fl::size end = start + length;
+    if (end > size()) end = size();
+    return substring(start, end);
+}
+
+string string::substr(fl::size start) const FL_NOEXCEPT {
+    return substring(start, size());
+}
+
+string string::trim() const FL_NOEXCEPT {
+    fl::size start = 0;
+    fl::size end_pos = size();
+    while (start < size() && fl::isspace(c_str()[start])) start++;
+    while (end_pos > start && fl::isspace(c_str()[end_pos - 1])) end_pos--;
+    return substring(start, end_pos);
+}
+
+#ifdef FL_IS_WASM
+string::string(const std::string& str)  // okay std namespace
+    : basic_string(mInlineBuffer, FASTLED_STR_INLINED_SIZE) {
+    copy(str.c_str(), str.size());
+}
+
+string& string::operator=(const std::string& str) FL_NOEXCEPT {  // okay std namespace
+    copy(str.c_str(), str.size());
+    return *this;
+}
+
+string& string::append(const std::string& str) {  // okay std namespace
+    write(str.c_str(), str.size());
+    return *this;
+}
+#endif
+
+// ======= COMPARISON OPERATORS =======
+
+bool string::operator>(const string& other) const FL_NOEXCEPT {
+    return fl::strcmp(c_str(), other.c_str()) > 0;
+}
+
+bool string::operator>=(const string& other) const FL_NOEXCEPT {
+    return fl::strcmp(c_str(), other.c_str()) >= 0;
+}
+
+bool string::operator<(const string& other) const FL_NOEXCEPT {
+    return fl::strcmp(c_str(), other.c_str()) < 0;
+}
+
+bool string::operator<=(const string& other) const FL_NOEXCEPT {
+    return fl::strcmp(c_str(), other.c_str()) <= 0;
+}
+
+bool string::operator==(const string& other) const FL_NOEXCEPT {
+    if (size() != other.size()) {
+        return false;
+    }
+    return fl::memcmp(c_str(), other.c_str(), size()) == 0;
+}
+
+bool string::operator!=(const string& other) const FL_NOEXCEPT {
+    return !(*this == other);
+}
+
+// ======= CONCATENATION =======
+
+string& string::operator+=(const string& other) FL_NOEXCEPT {
+    append(other.c_str(), other.size());
+    return *this;
 }
 
 string &string::append(const audio::fft::Bins &str) {

--- a/src/fl/stl/string.cpp.hpp
+++ b/src/fl/stl/string.cpp.hpp
@@ -171,8 +171,17 @@ string string::substring(fl::size start, fl::size end) const FL_NOEXCEPT {
 }
 
 string string::substr(fl::size start, fl::size length) const FL_NOEXCEPT {
-    fl::size end = start + length;
-    if (end > size()) end = size();
+    // Handle `npos` / overflow: when `length == npos` the caller
+    // means "to end of string", and when `length` is large enough
+    // that `start + length` would wrap, we clamp to the end before
+    // the addition can overflow.
+    fl::size end;
+    if (length == npos || length > size() - (start < size() ? start : size())) {
+        end = size();
+    } else {
+        end = start + length;
+        if (end > size()) end = size();
+    }
     return substring(start, end);
 }
 
@@ -347,7 +356,8 @@ string &string::append(const json& val) {
 }
 
 #if FL_STRING_NEEDS_ARDUINO_CONVERSION
-string::string(const ::String &str) {
+string::string(const ::String &str)
+    : basic_string(mInlineBuffer, FASTLED_STR_INLINED_SIZE) {
     copy(str.c_str(), strlen(str.c_str()));
 }
 

--- a/src/fl/stl/string.h
+++ b/src/fl/stl/string.h
@@ -69,143 +69,23 @@ struct CRGB;
 
 namespace fl {
 
-// Thin template wrapper around basic_string. Provides the inline buffer storage.
-// All logic is in basic_string (compiled once). StrN<N> just holds char[N].
-template <fl::size SIZE = FASTLED_STR_INLINED_SIZE> class StrN : public basic_string {
-  protected:
-    char mInlineBuffer[SIZE] = {0};
-
-  public:
-    using basic_string::npos;
-    using basic_string::copy;
-    using basic_string::assign;
-
-    // ======= STATIC FACTORY METHODS =======
-    static StrN from_literal(const char* literal) FL_NOEXCEPT {
-        StrN result;
-        result.setLiteral(literal);
-        return result;
-    }
-
-    static StrN from_view(const char* data, fl::size len) FL_NOEXCEPT {
-        StrN result;
-        result.setView(data, len);
-        return result;
-    }
-
-    static StrN from_view(const string_view& sv) FL_NOEXCEPT {
-        return from_view(sv.data(), sv.size());
-    }
-
-    // ======= CONSTRUCTORS =======
-    StrN() FL_NOEXCEPT : basic_string(mInlineBuffer, SIZE) {
-        // mInlineBuffer already zero-initialized by = {0}
-    }
-
-    StrN(const char* str) FL_NOEXCEPT : basic_string(mInlineBuffer, SIZE) {
-        if (str) copy(str);
-    }
-
-    StrN(const StrN& other) FL_NOEXCEPT : basic_string(mInlineBuffer, SIZE) {
-        copy(static_cast<const basic_string&>(other));
-    }
-
-    template <fl::size M>
-    StrN(const StrN<M>& other) FL_NOEXCEPT : basic_string(mInlineBuffer, SIZE) {
-        copy(static_cast<const basic_string&>(other));
-    }
-
-    StrN(StrN&& other) FL_NOEXCEPT : basic_string(mInlineBuffer, SIZE) {
-        moveFrom(fl::move(other));
-    }
-
-    StrN(const string_view& sv) FL_NOEXCEPT : basic_string(mInlineBuffer, SIZE) {
-        if (!sv.empty()) {
-            copy(sv.data(), sv.size());
-        }
-    }
-
-    StrN(const fl::shared_ptr<StringHolder>& holder) FL_NOEXCEPT : basic_string(mInlineBuffer, SIZE) {
-        setSharedHolder(holder);
-    }
-
-    template <typename InputIt>
-    StrN(InputIt first, InputIt last) FL_NOEXCEPT : basic_string(mInlineBuffer, SIZE) {
-        assign(first, last);
-    }
-
-    template <int N> StrN(const char (&str)[N]) FL_NOEXCEPT : basic_string(mInlineBuffer, SIZE) {
-        copy(str, N - 1);
-    }
-
-    // ======= ASSIGNMENT =======
-    StrN& operator=(const StrN& other) FL_NOEXCEPT {
-        copy(static_cast<const basic_string&>(other));
-        return *this;
-    }
-
-    template <fl::size M>
-    StrN& operator=(const StrN<M>& other) FL_NOEXCEPT {
-        copy(static_cast<const basic_string&>(other));
-        return *this;
-    }
-
-    StrN& operator=(StrN&& other) FL_NOEXCEPT {
-        moveAssign(fl::move(other));
-        return *this;
-    }
-
-    template <int N> StrN& operator=(const char (&str)[N]) FL_NOEXCEPT {
-        assign(str, N - 1);
-        return *this;
-    }
-
-    // ======= SUBSTRING (returns StrN, so must be here) =======
-    StrN substring(fl::size start, fl::size end) const FL_NOEXCEPT {
-        if (start == 0 && end == size()) return *this;
-        if (start >= size()) return StrN();
-        if (end > size()) end = size();
-        if (start >= end) return StrN();
-        StrN out;
-        out.copy(c_str() + start, end - start);
-        return out;
-    }
-
-    StrN substr(fl::size start, fl::size length) const FL_NOEXCEPT {
-        fl::size end = start + length;
-        if (end > size()) end = size();
-        return substring(start, end);
-    }
-
-    StrN substr(fl::size start) const FL_NOEXCEPT {
-        return substring(start, size());
-    }
-
-    StrN trim() const FL_NOEXCEPT {
-        fl::size start = 0;
-        fl::size end_pos = size();
-        while (start < size() && fl::isspace(c_str()[start])) start++;
-        while (end_pos > start && fl::isspace(c_str()[end_pos - 1])) end_pos--;
-        return substring(start, end_pos);
-    }
-
-    // ======= DESTRUCTOR =======
-    ~StrN() FL_NOEXCEPT {}
-};
-
-// Public alias matching the design-doc vocabulary: `stringN<N>` is the
-// templated wrapper that owns an inline buffer of size N and trampolines
-// every mutation into `string_base` (a.k.a. `basic_string`). Callers
-// that want the default 64-byte inline buffer + heap-overflow should
-// prefer `fl::string`; `stringN<N>` is reserved for the rare case
-// where the caller really wants a different inline size (today: only
-// the OTA module's tiny scratch fields).
+// `fl::string` is the default convenience wrapper around
+// `fl::basic_string`. It co-locates a `FASTLED_STR_INLINED_SIZE`-
+// byte inline buffer with the basic_string state, then hands that
+// buffer to the base via `basic_string(mInlineBuffer, ...)`. All
+// formatting logic (write, append, find, replace) lives in
+// `basic_string` and is compiled exactly once.
 //
-// See `agents/docs/string-architecture.md` for the layering rationale.
-template <fl::size N = FASTLED_STR_INLINED_SIZE>
-using stringN = StrN<N>;
+// Callers who want to use a custom-sized buffer should construct
+// `fl::basic_string` directly with `(char*, fl::size)` or
+// `fl::span<char>` — the historical `fl::StrN<N>` template has
+// been removed in favor of that pattern.
+//
+// See `agents/docs/string-architecture.md`.
+class string : public basic_string {
+  protected:
+    char mInlineBuffer[FASTLED_STR_INLINED_SIZE] = {0};
 
-class string : public StrN<FASTLED_STR_INLINED_SIZE> {
   public:
     static constexpr fl::size npos = static_cast<fl::size>(-1);
 
@@ -261,29 +141,50 @@ class string : public StrN<FASTLED_STR_INLINED_SIZE> {
     static int strcmp(const string& a, const string& b) FL_NOEXCEPT;
 
     // ======= CONSTRUCTORS =======
-    string() FL_NOEXCEPT : StrN<FASTLED_STR_INLINED_SIZE>() {}
-    string(const char* str) FL_NOEXCEPT : StrN<FASTLED_STR_INLINED_SIZE>(str) {}
-    string(const char* str, fl::size len) FL_NOEXCEPT : StrN<FASTLED_STR_INLINED_SIZE>() {
+    // Every ctor passes its co-located mInlineBuffer to basic_string;
+    // string-content population happens via copy()/setLiteral()/etc.
+    // after the base is initialised.
+    string() FL_NOEXCEPT : basic_string(mInlineBuffer, FASTLED_STR_INLINED_SIZE) {}
+    string(const char* str) FL_NOEXCEPT : basic_string(mInlineBuffer, FASTLED_STR_INLINED_SIZE) {
+        if (str) copy(str);
+    }
+    string(const char* str, fl::size len) FL_NOEXCEPT : basic_string(mInlineBuffer, FASTLED_STR_INLINED_SIZE) {
         copy(str, len);
     }
-    string(fl::size len, char c) FL_NOEXCEPT : StrN<FASTLED_STR_INLINED_SIZE>() {
+    string(fl::size len, char c) FL_NOEXCEPT : basic_string(mInlineBuffer, FASTLED_STR_INLINED_SIZE) {
         resize(len, c);
     }
-    string(const string& other) FL_NOEXCEPT : StrN<FASTLED_STR_INLINED_SIZE>(other) {}
-    string(string&& other) FL_NOEXCEPT : StrN<FASTLED_STR_INLINED_SIZE>(fl::move(other)) {}
-    template <fl::size M>
-    string(const StrN<M>& other) FL_NOEXCEPT : StrN<FASTLED_STR_INLINED_SIZE>(other) {}
-    string(const basic_string& other) FL_NOEXCEPT : StrN<FASTLED_STR_INLINED_SIZE>() {
+    string(const string& other) FL_NOEXCEPT : basic_string(mInlineBuffer, FASTLED_STR_INLINED_SIZE) {
+        copy(static_cast<const basic_string&>(other));
+    }
+    string(string&& other) FL_NOEXCEPT : basic_string(mInlineBuffer, FASTLED_STR_INLINED_SIZE) {
+        moveFrom(fl::move(other));
+    }
+    string(const basic_string& other) FL_NOEXCEPT : basic_string(mInlineBuffer, FASTLED_STR_INLINED_SIZE) {
         copy(other);
     }
-    string(const string_view& sv) FL_NOEXCEPT : StrN<FASTLED_STR_INLINED_SIZE>(sv) {}
-    string(const fl::span<const char>& s) FL_NOEXCEPT : StrN<FASTLED_STR_INLINED_SIZE>() {
+    string(const string_view& sv) FL_NOEXCEPT : basic_string(mInlineBuffer, FASTLED_STR_INLINED_SIZE) {
+        if (!sv.empty()) {
+            copy(sv.data(), sv.size());
+        }
+    }
+    string(const fl::span<const char>& s) FL_NOEXCEPT : basic_string(mInlineBuffer, FASTLED_STR_INLINED_SIZE) {
         copy(s.data(), s.size());
     }
-    string(const fl::span<char>& s) FL_NOEXCEPT : StrN<FASTLED_STR_INLINED_SIZE>() {
+    string(const fl::span<char>& s) FL_NOEXCEPT : basic_string(mInlineBuffer, FASTLED_STR_INLINED_SIZE) {
         copy(s.data(), s.size());
     }
-    string(const fl::shared_ptr<StringHolder>& holder) FL_NOEXCEPT : StrN<FASTLED_STR_INLINED_SIZE>(holder) {}
+    string(const fl::shared_ptr<StringHolder>& holder) FL_NOEXCEPT : basic_string(mInlineBuffer, FASTLED_STR_INLINED_SIZE) {
+        setSharedHolder(holder);
+    }
+    template <typename InputIt>
+    string(InputIt first, InputIt last) FL_NOEXCEPT : basic_string(mInlineBuffer, FASTLED_STR_INLINED_SIZE) {
+        assign(first, last);
+    }
+    template <int N>
+    string(const char (&str)[N]) FL_NOEXCEPT : basic_string(mInlineBuffer, FASTLED_STR_INLINED_SIZE) {
+        copy(str, N - 1);
+    }
 
     // ======= ASSIGNMENT =======
     string& operator=(const string& other) FL_NOEXCEPT {
@@ -298,9 +199,10 @@ class string : public StrN<FASTLED_STR_INLINED_SIZE> {
         copy(str, fl::strlen(str));
         return *this;
     }
-
-    // Bring base class assign methods into scope
-    using StrN<FASTLED_STR_INLINED_SIZE>::assign;
+    template <int N> string& operator=(const char (&str)[N]) FL_NOEXCEPT {
+        assign(str, N - 1);
+        return *this;
+    }
 
     string& assign(string_view sv) FL_NOEXCEPT {
         if (sv.empty()) {
@@ -311,8 +213,37 @@ class string : public StrN<FASTLED_STR_INLINED_SIZE> {
         return *this;
     }
 
+    // ======= SUBSTRING (returns string, so must live here) =======
+    string substring(fl::size start, fl::size end) const FL_NOEXCEPT {
+        if (start == 0 && end == size()) return *this;
+        if (start >= size()) return string();
+        if (end > size()) end = size();
+        if (start >= end) return string();
+        string out;
+        out.copy(c_str() + start, end - start);
+        return out;
+    }
+
+    string substr(fl::size start, fl::size length) const FL_NOEXCEPT {
+        fl::size end = start + length;
+        if (end > size()) end = size();
+        return substring(start, end);
+    }
+
+    string substr(fl::size start) const FL_NOEXCEPT {
+        return substring(start, size());
+    }
+
+    string trim() const FL_NOEXCEPT {
+        fl::size start = 0;
+        fl::size end_pos = size();
+        while (start < size() && fl::isspace(c_str()[start])) start++;
+        while (end_pos > start && fl::isspace(c_str()[end_pos - 1])) end_pos--;
+        return substring(start, end_pos);
+    }
+
 #ifdef FL_IS_WASM
-    string(const std::string& str) : StrN<FASTLED_STR_INLINED_SIZE>() {  // okay std namespace
+    string(const std::string& str) : basic_string(mInlineBuffer, FASTLED_STR_INLINED_SIZE) {  // okay std namespace
         copy(str.c_str(), str.size());
     }
     string& operator=(const std::string& str) FL_NOEXCEPT {  // okay std namespace

--- a/src/fl/stl/string.h
+++ b/src/fl/stl/string.h
@@ -193,6 +193,18 @@ template <fl::size SIZE = FASTLED_STR_INLINED_SIZE> class StrN : public basic_st
     ~StrN() FL_NOEXCEPT {}
 };
 
+// Public alias matching the design-doc vocabulary: `stringN<N>` is the
+// templated wrapper that owns an inline buffer of size N and trampolines
+// every mutation into `string_base` (a.k.a. `basic_string`). Callers
+// that want the default 64-byte inline buffer + heap-overflow should
+// prefer `fl::string`; `stringN<N>` is reserved for the rare case
+// where the caller really wants a different inline size (today: only
+// the OTA module's tiny scratch fields).
+//
+// See `agents/docs/string-architecture.md` for the layering rationale.
+template <fl::size N = FASTLED_STR_INLINED_SIZE>
+using stringN = StrN<N>;
+
 class string : public StrN<FASTLED_STR_INLINED_SIZE> {
   public:
     static constexpr fl::size npos = static_cast<fl::size>(-1);

--- a/src/fl/stl/string.h
+++ b/src/fl/stl/string.h
@@ -69,23 +69,128 @@ struct CRGB;
 
 namespace fl {
 
-// `fl::string` is the default convenience wrapper around
-// `fl::basic_string`. It co-locates a `FASTLED_STR_INLINED_SIZE`-
-// byte inline buffer with the basic_string state, then hands that
-// buffer to the base via `basic_string(mInlineBuffer, ...)`. All
-// formatting logic (write, append, find, replace) lives in
-// `basic_string` and is compiled exactly once.
+// `fl::string_n<N>` is the templated inline-buffer storage policy
+// over `fl::basic_string`. It co-locates a `char[N]` buffer with
+// the basic_string state and passes that buffer to the base ctor.
+// Every operation (write, append, find, replace, …) lives in
+// `basic_string` and is compiled exactly once; per-N instantiations
+// of `string_n<N>` are thin constructor stubs that only differ in
+// the literal `N` they hand to the base. The compiler / linker
+// folds identical instantiations under COMDAT, and the non-shared
+// bytes are tiny (each ctor is `: basic_string(mBuf, N) {}` plus a
+// short body that calls `copy()`/`setLiteral()`/etc.).
 //
-// Callers who want to use a custom-sized buffer should construct
-// `fl::basic_string` directly with `(char*, fl::size)` or
-// `fl::span<char>` — the historical `fl::StrN<N>` template has
-// been removed in favor of that pattern.
+// Convenience aliases:
+//   - `fl::string_small`  — 32-byte inline buffer (constrained MCUs)
+//   - `fl::string`        — `FASTLED_STR_INLINED_SIZE` (default 64)
+//   - `fl::string_large`  — 256-byte inline buffer (text-heavy paths)
+//
+// All three are layout-compatible; copy/move between sizes works
+// because the underlying `basic_string` storage policy is uniform.
 //
 // See `agents/docs/string-architecture.md`.
-class string : public basic_string {
+template <fl::size N>
+class string_n : public basic_string {
   protected:
-    char mInlineBuffer[FASTLED_STR_INLINED_SIZE] = {0};
+    char mInlineBuffer[N] = {0};
 
+  public:
+    // Default + content-population constructors. All delegate to
+    // `basic_string(mInlineBuffer, N)` and then call the
+    // non-template population helpers on the base.
+    string_n() FL_NOEXCEPT : basic_string(mInlineBuffer, N) {}
+
+    string_n(const char* str) FL_NOEXCEPT : basic_string(mInlineBuffer, N) {
+        if (str) copy(str);
+    }
+
+    string_n(const char* str, fl::size len) FL_NOEXCEPT : basic_string(mInlineBuffer, N) {
+        copy(str, len);
+    }
+
+    string_n(fl::size len, char c) FL_NOEXCEPT : basic_string(mInlineBuffer, N) {
+        resize(len, c);
+    }
+
+    string_n(const string_n& other) FL_NOEXCEPT : basic_string(mInlineBuffer, N) {
+        copy(static_cast<const basic_string&>(other));
+    }
+
+    template <fl::size M>
+    string_n(const string_n<M>& other) FL_NOEXCEPT : basic_string(mInlineBuffer, N) {
+        copy(static_cast<const basic_string&>(other));
+    }
+
+    string_n(string_n&& other) FL_NOEXCEPT : basic_string(mInlineBuffer, N) {
+        moveFrom(fl::move(other));
+    }
+
+    string_n(const basic_string& other) FL_NOEXCEPT : basic_string(mInlineBuffer, N) {
+        copy(other);
+    }
+
+    string_n(const string_view& sv) FL_NOEXCEPT : basic_string(mInlineBuffer, N) {
+        if (!sv.empty()) {
+            copy(sv.data(), sv.size());
+        }
+    }
+
+    string_n(const fl::span<const char>& s) FL_NOEXCEPT : basic_string(mInlineBuffer, N) {
+        copy(s.data(), s.size());
+    }
+
+    string_n(const fl::span<char>& s) FL_NOEXCEPT : basic_string(mInlineBuffer, N) {
+        copy(s.data(), s.size());
+    }
+
+    string_n(const fl::shared_ptr<StringHolder>& holder) FL_NOEXCEPT : basic_string(mInlineBuffer, N) {
+        setSharedHolder(holder);
+    }
+
+    template <typename InputIt>
+    string_n(InputIt first, InputIt last) FL_NOEXCEPT : basic_string(mInlineBuffer, N) {
+        assign(first, last);
+    }
+
+    template <int M>
+    string_n(const char (&str)[M]) FL_NOEXCEPT : basic_string(mInlineBuffer, N) {
+        copy(str, M - 1);
+    }
+
+    string_n& operator=(const string_n& other) FL_NOEXCEPT {
+        copy(static_cast<const basic_string&>(other));
+        return *this;
+    }
+
+    template <fl::size M>
+    string_n& operator=(const string_n<M>& other) FL_NOEXCEPT {
+        copy(static_cast<const basic_string&>(other));
+        return *this;
+    }
+
+    string_n& operator=(string_n&& other) FL_NOEXCEPT {
+        moveAssign(fl::move(other));
+        return *this;
+    }
+};
+
+// Convenience aliases. `fl::string` is the default; `string_small`
+// trades inline capacity for object size on constrained targets,
+// `string_large` trades the other way for text-heavy paths.
+using string_small = string_n<32>;
+using string_large = string_n<256>;
+
+// `fl::string` extends `string_n<FASTLED_STR_INLINED_SIZE>` with
+// the composite-type formatter overloads (CRGB, vec2, span,
+// vector, optional, …), the `substring()` / `trim()` family
+// (returning `string` so callers chain naturally), and the static
+// factory + comparison methods. The trampoline pattern is:
+//
+//   fl::string -> fl::string_n<N> -> fl::basic_string
+//
+// where only `basic_string` carries the real bytes; the upper
+// layers are thin wrappers that get folded out by the optimizer.
+class string : public string_n<FASTLED_STR_INLINED_SIZE> {
   public:
     static constexpr fl::size npos = static_cast<fl::size>(-1);
 
@@ -106,8 +211,10 @@ class string : public basic_string {
     static int strcmp(const string& a, const string& b) FL_NOEXCEPT;
 
     // ======= CONSTRUCTORS =======
-    // Non-template ctors defined in string.cpp.hpp; templates stay
-    // inline here because they're parameterised on caller types.
+    // All non-template ctors delegate to string_n<N>'s ctors —
+    // defined in string.cpp.hpp as one-line forwarders for header
+    // hygiene. Template ctors stay inline (they're parameterised
+    // on caller types and can't be split out).
     string() FL_NOEXCEPT;
     string(const char* str) FL_NOEXCEPT;
     string(const char* str, fl::size len) FL_NOEXCEPT;
@@ -120,13 +227,11 @@ class string : public basic_string {
     string(const fl::span<char>& s) FL_NOEXCEPT;
     string(const fl::shared_ptr<StringHolder>& holder) FL_NOEXCEPT;
     template <typename InputIt>
-    string(InputIt first, InputIt last) FL_NOEXCEPT : basic_string(mInlineBuffer, FASTLED_STR_INLINED_SIZE) {
-        assign(first, last);
-    }
+    string(InputIt first, InputIt last) FL_NOEXCEPT
+        : string_n<FASTLED_STR_INLINED_SIZE>(first, last) {}
     template <int N>
-    string(const char (&str)[N]) FL_NOEXCEPT : basic_string(mInlineBuffer, FASTLED_STR_INLINED_SIZE) {
-        copy(str, N - 1);
-    }
+    string(const char (&str)[N]) FL_NOEXCEPT
+        : string_n<FASTLED_STR_INLINED_SIZE>(str) {}
 
     // ======= ASSIGNMENT =======
     string& operator=(const string& other) FL_NOEXCEPT;

--- a/src/fl/stl/string.h
+++ b/src/fl/stl/string.h
@@ -96,87 +96,29 @@ class string : public basic_string {
     using basic_string::appendOct;
 
     // ======= STATIC FACTORY METHODS =======
-    static string from_literal(const char* literal) FL_NOEXCEPT {
-        string result;
-        result.setLiteral(literal);
-        return result;
-    }
-
-    static string from_view(const char* data, fl::size len) FL_NOEXCEPT {
-        string result;
-        result.setView(data, len);
-        return result;
-    }
-
-    static string from_view(const string_view& sv) FL_NOEXCEPT {
-        return from_view(sv.data(), sv.size());
-    }
-
-    static string interned(const char* str, fl::size len) FL_NOEXCEPT {
-        string result;
-        if (!str || len == 0) return result;
-        auto holder = fl::make_shared<StringHolder>(str, len);
-        result.setSharedHolder(holder);
-        return result;
-    }
-
-    static string interned(const char* str) FL_NOEXCEPT {
-        if (!str) return string();
-        return interned(str, fl::strlen(str));
-    }
-
-    static string interned(const string_view& sv) FL_NOEXCEPT {
-        return interned(sv.data(), sv.size());
-    }
-
-    static string copy_no_view(const string& str) FL_NOEXCEPT {
-        if (str.is_referencing()) {
-            string result;
-            result.copy(str.c_str(), str.size());
-            return result;
-        }
-        return str;
-    }
-
+    static string from_literal(const char* literal) FL_NOEXCEPT;
+    static string from_view(const char* data, fl::size len) FL_NOEXCEPT;
+    static string from_view(const string_view& sv) FL_NOEXCEPT;
+    static string interned(const char* str, fl::size len) FL_NOEXCEPT;
+    static string interned(const char* str) FL_NOEXCEPT;
+    static string interned(const string_view& sv) FL_NOEXCEPT;
+    static string copy_no_view(const string& str) FL_NOEXCEPT;
     static int strcmp(const string& a, const string& b) FL_NOEXCEPT;
 
     // ======= CONSTRUCTORS =======
-    // Every ctor passes its co-located mInlineBuffer to basic_string;
-    // string-content population happens via copy()/setLiteral()/etc.
-    // after the base is initialised.
-    string() FL_NOEXCEPT : basic_string(mInlineBuffer, FASTLED_STR_INLINED_SIZE) {}
-    string(const char* str) FL_NOEXCEPT : basic_string(mInlineBuffer, FASTLED_STR_INLINED_SIZE) {
-        if (str) copy(str);
-    }
-    string(const char* str, fl::size len) FL_NOEXCEPT : basic_string(mInlineBuffer, FASTLED_STR_INLINED_SIZE) {
-        copy(str, len);
-    }
-    string(fl::size len, char c) FL_NOEXCEPT : basic_string(mInlineBuffer, FASTLED_STR_INLINED_SIZE) {
-        resize(len, c);
-    }
-    string(const string& other) FL_NOEXCEPT : basic_string(mInlineBuffer, FASTLED_STR_INLINED_SIZE) {
-        copy(static_cast<const basic_string&>(other));
-    }
-    string(string&& other) FL_NOEXCEPT : basic_string(mInlineBuffer, FASTLED_STR_INLINED_SIZE) {
-        moveFrom(fl::move(other));
-    }
-    string(const basic_string& other) FL_NOEXCEPT : basic_string(mInlineBuffer, FASTLED_STR_INLINED_SIZE) {
-        copy(other);
-    }
-    string(const string_view& sv) FL_NOEXCEPT : basic_string(mInlineBuffer, FASTLED_STR_INLINED_SIZE) {
-        if (!sv.empty()) {
-            copy(sv.data(), sv.size());
-        }
-    }
-    string(const fl::span<const char>& s) FL_NOEXCEPT : basic_string(mInlineBuffer, FASTLED_STR_INLINED_SIZE) {
-        copy(s.data(), s.size());
-    }
-    string(const fl::span<char>& s) FL_NOEXCEPT : basic_string(mInlineBuffer, FASTLED_STR_INLINED_SIZE) {
-        copy(s.data(), s.size());
-    }
-    string(const fl::shared_ptr<StringHolder>& holder) FL_NOEXCEPT : basic_string(mInlineBuffer, FASTLED_STR_INLINED_SIZE) {
-        setSharedHolder(holder);
-    }
+    // Non-template ctors defined in string.cpp.hpp; templates stay
+    // inline here because they're parameterised on caller types.
+    string() FL_NOEXCEPT;
+    string(const char* str) FL_NOEXCEPT;
+    string(const char* str, fl::size len) FL_NOEXCEPT;
+    string(fl::size len, char c) FL_NOEXCEPT;
+    string(const string& other) FL_NOEXCEPT;
+    string(string&& other) FL_NOEXCEPT;
+    string(const basic_string& other) FL_NOEXCEPT;
+    string(const string_view& sv) FL_NOEXCEPT;
+    string(const fl::span<const char>& s) FL_NOEXCEPT;
+    string(const fl::span<char>& s) FL_NOEXCEPT;
+    string(const fl::shared_ptr<StringHolder>& holder) FL_NOEXCEPT;
     template <typename InputIt>
     string(InputIt first, InputIt last) FL_NOEXCEPT : basic_string(mInlineBuffer, FASTLED_STR_INLINED_SIZE) {
         assign(first, last);
@@ -187,73 +129,26 @@ class string : public basic_string {
     }
 
     // ======= ASSIGNMENT =======
-    string& operator=(const string& other) FL_NOEXCEPT {
-        copy(static_cast<const basic_string&>(other));
-        return *this;
-    }
-    string& operator=(string&& other) FL_NOEXCEPT {
-        moveAssign(fl::move(other));
-        return *this;
-    }
-    string& operator=(const char* str) FL_NOEXCEPT {
-        copy(str, fl::strlen(str));
-        return *this;
-    }
+    string& operator=(const string& other) FL_NOEXCEPT;
+    string& operator=(string&& other) FL_NOEXCEPT;
+    string& operator=(const char* str) FL_NOEXCEPT;
     template <int N> string& operator=(const char (&str)[N]) FL_NOEXCEPT {
         assign(str, N - 1);
         return *this;
     }
 
-    string& assign(string_view sv) FL_NOEXCEPT {
-        if (sv.empty()) {
-            clear();
-        } else {
-            copy(sv.data(), sv.size());
-        }
-        return *this;
-    }
+    string& assign(string_view sv) FL_NOEXCEPT;
 
     // ======= SUBSTRING (returns string, so must live here) =======
-    string substring(fl::size start, fl::size end) const FL_NOEXCEPT {
-        if (start == 0 && end == size()) return *this;
-        if (start >= size()) return string();
-        if (end > size()) end = size();
-        if (start >= end) return string();
-        string out;
-        out.copy(c_str() + start, end - start);
-        return out;
-    }
-
-    string substr(fl::size start, fl::size length) const FL_NOEXCEPT {
-        fl::size end = start + length;
-        if (end > size()) end = size();
-        return substring(start, end);
-    }
-
-    string substr(fl::size start) const FL_NOEXCEPT {
-        return substring(start, size());
-    }
-
-    string trim() const FL_NOEXCEPT {
-        fl::size start = 0;
-        fl::size end_pos = size();
-        while (start < size() && fl::isspace(c_str()[start])) start++;
-        while (end_pos > start && fl::isspace(c_str()[end_pos - 1])) end_pos--;
-        return substring(start, end_pos);
-    }
+    string substring(fl::size start, fl::size end) const FL_NOEXCEPT;
+    string substr(fl::size start, fl::size length) const FL_NOEXCEPT;
+    string substr(fl::size start) const FL_NOEXCEPT;
+    string trim() const FL_NOEXCEPT;
 
 #ifdef FL_IS_WASM
-    string(const std::string& str) : basic_string(mInlineBuffer, FASTLED_STR_INLINED_SIZE) {  // okay std namespace
-        copy(str.c_str(), str.size());
-    }
-    string& operator=(const std::string& str) FL_NOEXCEPT {  // okay std namespace
-        copy(str.c_str(), str.size());
-        return *this;
-    }
-    string& append(const std::string& str) {  // okay std namespace
-        write(str.c_str(), str.size());
-        return *this;
-    }
+    string(const std::string& str);  // okay std namespace; defined in string.cpp.hpp
+    string& operator=(const std::string& str) FL_NOEXCEPT;  // okay std namespace
+    string& append(const std::string& str);  // okay std namespace
 #endif
 
 #if FL_STRING_NEEDS_ARDUINO_CONVERSION
@@ -264,38 +159,15 @@ class string : public basic_string {
 
 
 
-    bool operator>(const string &other) const FL_NOEXCEPT {
-        return fl::strcmp(c_str(), other.c_str()) > 0;
-    }
-
-    bool operator>=(const string &other) const FL_NOEXCEPT {
-        return fl::strcmp(c_str(), other.c_str()) >= 0;
-    }
-
-    bool operator<(const string &other) const FL_NOEXCEPT {
-        return fl::strcmp(c_str(), other.c_str()) < 0;
-    }
-
-    bool operator<=(const string &other) const FL_NOEXCEPT {
-        return fl::strcmp(c_str(), other.c_str()) <= 0;
-    }
-
-    bool operator==(const string &other) const FL_NOEXCEPT {
-        if (size() != other.size()) {
-            return false;
-        }
-        return fl::memcmp(c_str(), other.c_str(), size()) == 0;
-    }
-
-    bool operator!=(const string &other) const FL_NOEXCEPT {
-        return !(*this == other);
-    }
+    bool operator>(const string &other) const FL_NOEXCEPT;
+    bool operator>=(const string &other) const FL_NOEXCEPT;
+    bool operator<(const string &other) const FL_NOEXCEPT;
+    bool operator<=(const string &other) const FL_NOEXCEPT;
+    bool operator==(const string &other) const FL_NOEXCEPT;
+    bool operator!=(const string &other) const FL_NOEXCEPT;
 
     // ======= CONCATENATION =======
-    string& operator+=(const string& other) FL_NOEXCEPT {
-        append(other.c_str(), other.size());
-        return *this;
-    }
+    string& operator+=(const string& other) FL_NOEXCEPT;
 
     template <typename T> string& operator+=(const T& val) FL_NOEXCEPT {
         append(val);

--- a/src/fl/stl/string_view.h
+++ b/src/fl/stl/string_view.h
@@ -7,7 +7,7 @@
 namespace fl {
 
 // Forward declarations
-template <fl::size SIZE> class StrN;
+class basic_string;
 class string;  // IWYU pragma: keep
 
 // string_view: A non-owning view into a contiguous sequence of characters
@@ -51,10 +51,9 @@ class string_view {
     constexpr string_view(const char (&arr)[N]) FL_NOEXCEPT
         : mData(arr), mSize(N - 1) {}  // Subtract 1 for null terminator
 
-    // Constructor from fl::string
-    template <fl::size SIZE>
-    string_view(const StrN<SIZE>& str) FL_NOEXCEPT
-        : mData(str.c_str()), mSize(str.size()) {}
+    // Constructor from fl::basic_string (and therefore fl::string).
+    // Defined in basic_string.cpp.hpp where basic_string is complete.
+    string_view(const basic_string& str) FL_NOEXCEPT;
 
     // Copy constructor
     string_view(const string_view& other) FL_NOEXCEPT = default;

--- a/src/fl/stl/strstream.h
+++ b/src/fl/stl/strstream.h
@@ -28,7 +28,7 @@ class bitset_dynamic;  // IWYU pragma: keep
 template <fl::u32 N> class bitset_inlined;  // IWYU pragma: keep
 
 // Note: int_cast_detail::cast_target is now defined in fl/stl/type_traits.h
-// and shared between sstream and StrN for consistent integer formatting
+// and shared between sstream and basic_string for consistent integer formatting
 
 
 class sstream {

--- a/src/fl/stl/type_traits.h
+++ b/src/fl/stl/type_traits.h
@@ -1034,7 +1034,7 @@ using underlying_type_t = typename underlying_type<T>::type;
 // Integer type casting helper for string formatting
 //-------------------------------------------------------------------------------
 // Helper to determine target type for integer conversion based on size/signedness
-// Used by both StrN::append and sstream::operator<< for consistent formatting
+// Used by both basic_string::append and sstream::operator<< for consistent formatting
 namespace int_cast_detail {
     // Primary template: generic fallback using size/signedness
     // This handles any integer type by selecting the appropriate fl:: type based on its characteristics

--- a/src/fl/stl/vector.h
+++ b/src/fl/stl/vector.h
@@ -833,7 +833,8 @@ class FL_ALIGN vector : public vector_basic {
 
 ///////////////////////////////////////////////////////////////////////////////
 // VectorN<T, N> — Vector with inline buffer (replaces InlinedVector).
-// Like StrN<N> for basic_string: provides the inline buffer storage.
+// Same wrapper pattern fl::string uses on top of fl::basic_string:
+// the wrapper co-locates an inline buffer with the type-erased base.
 // When size <= N, data lives inline. When size > N, spills to heap.
 // Uses the offset trick from basic_string for trivial relocatability.
 ///////////////////////////////////////////////////////////////////////////////
@@ -842,7 +843,7 @@ template <typename T, fl::size INLINED_SIZE>
 class FL_ALIGN VectorN : public vector<T> {
   private:
     // Raw aligned storage — address is valid even before initialization,
-    // same pattern as StrN<N>::mInlineBuffer in basic_string.
+    // same pattern as fl::string::mInlineBuffer above basic_string.
     FL_ALIGNAS(alignof(T) > alignof(fl::uptr) ? alignof(T) : alignof(fl::uptr))
     char mInlineBuffer[INLINED_SIZE * sizeof(T)] = {};
 

--- a/src/platforms/esp/32/ota/ota_impl.cpp.hpp
+++ b/src/platforms/esp/32/ota/ota_impl.cpp.hpp
@@ -1392,11 +1392,14 @@ private:
         }
     }
 
-    // Configuration - using StrN for safe string storage
-    fl::StrN<64> mHostname;
-    fl::StrN<64> mPassword;
-    fl::StrN<32> mApSsid;
-    fl::StrN<64> mApPass;
+    // Configuration - fl::string carries a 64-byte inline buffer +
+    // heap overflow, replacing the former StrN<32>/StrN<64> template
+    // wrappers (which were removed when basic_string became the
+    // public concrete class).
+    fl::string mHostname;
+    fl::string mPassword;
+    fl::string mApSsid;
+    fl::string mApPass;
     bool mApFallbackEnabled;
     bool mWifiConnected;
 
@@ -1418,7 +1421,7 @@ private:
     // Custom ESP-IDF OTA server state (pure ESP-IDF, no Arduino)
     int mOtaUdpSocket = -1;              // UDP socket for OTA invitations
     TaskHandle_t mOtaServerTask = nullptr;  // FreeRTOS task handle for OTA server
-    fl::StrN<64> mOtaNonce;              // Authentication nonce
+    fl::string mOtaNonce;                // Authentication nonce
     bool mOtaRunning = false;            // OTA server running flag
 };
 

--- a/tests/fl/stl/string.cpp
+++ b/tests/fl/stl/string.cpp
@@ -4870,10 +4870,17 @@ FL_TEST_CASE("basic_string assignment + heap promotion") {
     }
 
     FL_SUBCASE("Copy long string that overflows the inline buffer") {
-        // String is longer than FASTLED_STR_INLINED_SIZE so heap promotion fires
-        fl::string big("This is a longer string that won't fit in 8 bytes");
+        // String is longer than FASTLED_STR_INLINED_SIZE (default 64)
+        // so heap promotion fires on construction and copy.
+        const char* long_literal =
+            "This is a deliberately long string that exceeds the default "
+            "FASTLED_STR_INLINED_SIZE of 64 bytes so heap promotion fires "
+            "on both construction and copy.";
+        fl::string big(long_literal);
+        FL_CHECK(big.size() > FASTLED_STR_INLINED_SIZE);
         fl::string tiny = big;
-        FL_CHECK(tiny == "This is a longer string that won't fit in 8 bytes");
+        FL_CHECK(tiny == long_literal);
+        FL_CHECK(tiny.size() == big.size());
     }
 }
 

--- a/tests/fl/stl/string.cpp
+++ b/tests/fl/stl/string.cpp
@@ -2280,7 +2280,7 @@ FL_TEST_CASE("String find_last_not_of operations") {
 }
 
 // Test reverse iterators (fl::string compatibility)
-FL_TEST_CASE("StrN reverse iterators") {
+FL_TEST_CASE("string reverse iterators") {
     FL_SUBCASE("rbegin/rend on non-empty string") {
         fl::string s = "Hello";
         // rbegin() should point to last character
@@ -2885,11 +2885,11 @@ FL_TEST_CASE("String compare operations") {
     }
 }
 
-FL_TEST_CASE("StrN comparison operators") {
+FL_TEST_CASE("string comparison operators") {
     FL_SUBCASE("operator< basic comparison") {
-        fl::StrN<32> s1 = "abc";
-        fl::StrN<32> s2 = "def";
-        fl::StrN<32> s3 = "abc";
+        fl::string s1 = "abc";
+        fl::string s2 = "def";
+        fl::string s3 = "abc";
 
         FL_CHECK(s1 < s2);      // "abc" < "def"
         FL_CHECK_FALSE(s2 < s1); // NOT "def" < "abc"
@@ -2897,9 +2897,9 @@ FL_TEST_CASE("StrN comparison operators") {
     }
 
     FL_SUBCASE("operator> basic comparison") {
-        fl::StrN<32> s1 = "abc";
-        fl::StrN<32> s2 = "def";
-        fl::StrN<32> s3 = "abc";
+        fl::string s1 = "abc";
+        fl::string s2 = "def";
+        fl::string s3 = "abc";
 
         FL_CHECK(s2 > s1);      // "def" > "abc"
         FL_CHECK_FALSE(s1 > s2); // NOT "abc" > "def"
@@ -2907,9 +2907,9 @@ FL_TEST_CASE("StrN comparison operators") {
     }
 
     FL_SUBCASE("operator<= basic comparison") {
-        fl::StrN<32> s1 = "abc";
-        fl::StrN<32> s2 = "def";
-        fl::StrN<32> s3 = "abc";
+        fl::string s1 = "abc";
+        fl::string s2 = "def";
+        fl::string s3 = "abc";
 
         FL_CHECK(s1 <= s2);     // "abc" <= "def"
         FL_CHECK(s1 <= s3);     // "abc" <= "abc" (equal)
@@ -2917,9 +2917,9 @@ FL_TEST_CASE("StrN comparison operators") {
     }
 
     FL_SUBCASE("operator>= basic comparison") {
-        fl::StrN<32> s1 = "abc";
-        fl::StrN<32> s2 = "def";
-        fl::StrN<32> s3 = "abc";
+        fl::string s1 = "abc";
+        fl::string s2 = "def";
+        fl::string s3 = "abc";
 
         FL_CHECK(s2 >= s1);     // "def" >= "abc"
         FL_CHECK(s1 >= s3);     // "abc" >= "abc" (equal)
@@ -2927,9 +2927,9 @@ FL_TEST_CASE("StrN comparison operators") {
     }
 
     FL_SUBCASE("comparison with different template sizes") {
-        fl::StrN<32> s1 = "abc";
-        fl::StrN<64> s2 = "def";
-        fl::StrN<128> s3 = "abc";
+        fl::string s1 = "abc";
+        fl::string s2 = "def";
+        fl::string s3 = "abc";
 
         // Test < operator
         FL_CHECK(s1 < s2);      // "abc" < "def"
@@ -2953,9 +2953,9 @@ FL_TEST_CASE("StrN comparison operators") {
     }
 
     FL_SUBCASE("comparison with empty strings") {
-        fl::StrN<32> empty1 = "";
-        fl::StrN<32> empty2 = "";
-        fl::StrN<32> nonempty = "abc";
+        fl::string empty1 = "";
+        fl::string empty2 = "";
+        fl::string nonempty = "abc";
 
         // Empty strings are equal to each other
         FL_CHECK_FALSE(empty1 < empty2);  // NOT "" < ""
@@ -2977,8 +2977,8 @@ FL_TEST_CASE("StrN comparison operators") {
     }
 
     FL_SUBCASE("comparison with prefix strings") {
-        fl::StrN<32> s1 = "abc";
-        fl::StrN<32> s2 = "abcd";
+        fl::string s1 = "abc";
+        fl::string s2 = "abcd";
 
         FL_CHECK(s1 < s2);       // "abc" < "abcd" (prefix is less)
         FL_CHECK_FALSE(s1 > s2);  // NOT "abc" > "abcd"
@@ -2992,8 +2992,8 @@ FL_TEST_CASE("StrN comparison operators") {
     }
 
     FL_SUBCASE("case sensitivity") {
-        fl::StrN<32> lower = "abc";
-        fl::StrN<32> upper = "ABC";
+        fl::string lower = "abc";
+        fl::string upper = "ABC";
 
         // Uppercase letters have lower ASCII values than lowercase
         FL_CHECK(upper < lower);      // "ABC" < "abc" (ASCII 65 < 97)
@@ -3003,10 +3003,10 @@ FL_TEST_CASE("StrN comparison operators") {
     }
 
     FL_SUBCASE("lexicographical ordering for sorting") {
-        fl::StrN<32> s1 = "apple";
-        fl::StrN<32> s2 = "banana";
-        fl::StrN<32> s3 = "cherry";
-        fl::StrN<32> s4 = "apple";
+        fl::string s1 = "apple";
+        fl::string s2 = "banana";
+        fl::string s3 = "cherry";
+        fl::string s4 = "apple";
 
         // Verify transitivity and consistency for sorting
         FL_CHECK(s1 < s2);
@@ -3029,9 +3029,9 @@ FL_TEST_CASE("StrN comparison operators") {
     }
 
     FL_SUBCASE("comparison with special characters") {
-        fl::StrN<32> s1 = "abc!";
-        fl::StrN<32> s2 = "abc@";
-        fl::StrN<32> s3 = "abc#";
+        fl::string s1 = "abc!";
+        fl::string s2 = "abc@";
+        fl::string s3 = "abc#";
 
         // ASCII: ! (33) < # (35) < @ (64)
         FL_CHECK(s1 < s3);       // "abc!" < "abc#"
@@ -3044,9 +3044,9 @@ FL_TEST_CASE("StrN comparison operators") {
     }
 
     FL_SUBCASE("comparison with number strings") {
-        fl::StrN<32> s1 = "10";
-        fl::StrN<32> s2 = "2";
-        fl::StrN<32> s3 = "100";
+        fl::string s1 = "10";
+        fl::string s2 = "2";
+        fl::string s3 = "100";
 
         // Lexicographical, not numeric: "10" < "2" because '1' < '2'
         FL_CHECK(s1 < s2);       // "10" < "2" (lexicographical)
@@ -3057,9 +3057,9 @@ FL_TEST_CASE("StrN comparison operators") {
     }
 
     FL_SUBCASE("consistency with equality operators") {
-        fl::StrN<32> s1 = "test";
-        fl::StrN<32> s2 = "test";
-        fl::StrN<32> s3 = "different";
+        fl::string s1 = "test";
+        fl::string s2 = "test";
+        fl::string s3 = "different";
 
         // If s1 == s2, then s1 <= s2 and s1 >= s2
         FL_CHECK(s1 == s2);
@@ -3075,8 +3075,8 @@ FL_TEST_CASE("StrN comparison operators") {
     }
 
     FL_SUBCASE("comparison operator completeness") {
-        fl::StrN<32> s1 = "abc";
-        fl::StrN<32> s2 = "def";
+        fl::string s1 = "abc";
+        fl::string s2 = "def";
 
         // Exactly one of <, ==, > should be true
         int count = 0;
@@ -3100,12 +3100,12 @@ FL_TEST_CASE("StrN comparison operators") {
 
     FL_SUBCASE("comparison with heap vs inline storage") {
         // Short string (inline storage)
-        fl::StrN<64> short1 = "short";
-        fl::StrN<64> short2 = "short";
+        fl::string short1 = "short";
+        fl::string short2 = "short";
 
         // Long string (heap storage) - exceeds 64 bytes
-        fl::StrN<64> long1 = "this is a very long string that definitely exceeds the inline buffer size of 64 bytes";
-        fl::StrN<64> long2 = "this is a very long string that definitely exceeds the inline buffer size of 64 bytes";
+        fl::string long1 = "this is a very long string that definitely exceeds the inline buffer size of 64 bytes";
+        fl::string long2 = "this is a very long string that definitely exceeds the inline buffer size of 64 bytes";
 
         // Comparison should work correctly regardless of storage type
         FL_CHECK(short1 == short2);
@@ -4274,7 +4274,7 @@ FL_TEST_CASE("StringHolder - Memory safety with incorrect capacity") {
 
 
 FL_TEST_CASE("fl::string - Numeric append performance patterns") {
-    // Test numeric append operations that currently allocate temporary StrN<64> buffers
+    // Test numeric append operations that currently allocate temporary fl::string buffers
     // These tests validate that optimizations don't break functionality
 
     FL_SUBCASE("Integer append operations") {
@@ -4516,7 +4516,7 @@ FL_TEST_CASE("fl::string - Buffer size requirements") {
 
 FL_TEST_CASE("fl::string - Write method numeric variants") {
     // Test the write() methods that take numeric types
-    // These also use temporary StrN buffers
+    // These also use temporary fl::string buffers
 
     FL_SUBCASE("write() with integers") {
         fl::string s;
@@ -4561,7 +4561,7 @@ FL_TEST_CASE("fl::string - Memory efficiency improvements") {
     // Test patterns that could benefit from thread-local buffer optimization
 
     FL_SUBCASE("Repeated small string builds") {
-        // This pattern creates many temporary StrN<64> buffers (reduced from 1000 to 500 for performance)
+        // This pattern creates many temporary fl::string buffers (reduced from 1000 to 500 for performance)
         fl::vector<fl::string> results;
 
         for (int i = 0; i < 500; ++i) {
@@ -4852,23 +4852,27 @@ FL_TEST_CASE("basic_string self operations") {
     }
 }
 
-FL_TEST_CASE("basic_string cross-size StrN operations") {
-    FL_SUBCASE("Copy from StrN<128> to StrN<64>") {
-        fl::StrN<128> big("hello from big buffer");
-        fl::StrN<64> small = big;
+// Historically tested cross-size StrN<N> copies; with StrN removed
+// and all callers using `fl::string`, these become same-size sanity
+// checks for assignment + heap-promotion still covering the same
+// behaviors (long strings spill from inline buffer to heap).
+FL_TEST_CASE("basic_string assignment + heap promotion") {
+    FL_SUBCASE("Copy between same-size fl::string instances") {
+        fl::string big("hello from big buffer");
+        fl::string small = big;
         FL_CHECK(small == "hello from big buffer");
     }
 
-    FL_SUBCASE("Copy from StrN<64> to StrN<128>") {
-        fl::StrN<64> small("hello from small buffer");
-        fl::StrN<128> big = small;
+    FL_SUBCASE("Copy between two fl::string instances (reverse direction)") {
+        fl::string small("hello from small buffer");
+        fl::string big = small;
         FL_CHECK(big == "hello from small buffer");
     }
 
-    FL_SUBCASE("Copy long string from large to small StrN") {
-        // String fits in StrN<128> inline but not StrN<8>
-        fl::StrN<128> big("This is a longer string that won't fit in 8 bytes");
-        fl::StrN<8> tiny = big;
+    FL_SUBCASE("Copy long string that overflows the inline buffer") {
+        // String is longer than FASTLED_STR_INLINED_SIZE so heap promotion fires
+        fl::string big("This is a longer string that won't fit in 8 bytes");
+        fl::string tiny = big;
         FL_CHECK(tiny == "This is a longer string that won't fit in 8 bytes");
     }
 }

--- a/tests/fl/stl/strstream_integers.cpp
+++ b/tests/fl/stl/strstream_integers.cpp
@@ -154,8 +154,8 @@ FL_TEST_CASE("sstream handles all integer types generically") {
     }
 }
 
-FL_TEST_CASE("StrN write handles all integer types generically") {
-    fl::StrN<64> sn;
+FL_TEST_CASE("string write handles all integer types generically") {
+    fl::string sn;
 
     FL_SUBCASE("various integer types") {
         int16_t i16 = -1000;


### PR DESCRIPTION
Motivated by the [#2886 comment thread](https://github.com/FastLED/FastLED/issues/2886#issuecomment-4643081327): collapse `fl::sstream` / `fl::string` template specializations onto a single concrete base.

Two commits on the branch:
1. `1866f55` (initial PR) added vocabulary aliases (`string_base`, `stringN`) + doc — addressed naming but not structure.
2. `5033e43` (this commit) drops the `fl::StrN<N>` template entirely and makes `fl::basic_string` the public, directly-constructible concrete class.

## What changed

| Type | Before | After |
|---|---|---|
| `fl::basic_string` | type-erased base, **protected** ctor (only callable by `StrN<N>`) | type-erased class, **public** ctor — `(char*, fl::size)` OR `fl::span<char>` |
| `fl::StrN<N>` | template wrapper holding a `char[N]` inline buffer | **removed** |
| `fl::string` | `: public StrN<FASTLED_STR_INLINED_SIZE>` plus composite-formatter overloads | `: public basic_string` with co-located `char mInlineBuffer[64]` plus the same composite-formatter overloads |
| `string_view(StrN<N>&)` | templated ctor on `string_view` | `string_view(const basic_string&)` (single ctor, defined where `basic_string` is complete) |
| `substring()` / `substr()` / `trim()` | on `StrN<N>`, returns `StrN` | on `fl::string`, returns `string` |

## Direct `basic_string` usage (new)

```cpp
char buf[256];
fl::basic_string s(fl::span<char>(buf, 256));  // span overload
fl::basic_string s2(buf, 256);                  // ptr+size overload
s.append("hello, ").append(42);
```

Lifetime contract: the buffer must outlive the `basic_string`, and the `basic_string` must not be trivially relocated (the internal `mInlineOffset` is computed from `this` at construction). For member-stored use, prefer `fl::string` (which co-locates the buffer inside itself).

## Callers migrated

- `src/platforms/esp/32/ota/ota_impl.cpp.hpp` — 5 `StrN<32>` / `StrN<64>` fields → `fl::string`. Net +32 bytes on the OTAManager struct (`mApSsid` grew from 32→64 inline; the other 4 were already 64).
- `tests/fl/stl/string.cpp` — ~50 `fl::StrN<N>` test sites → `fl::string`. Cross-size StrN tests are now same-size assignment + heap-promotion tests (covering the same behaviors).
- `tests/fl/stl/strstream_integers.cpp` — 1 `fl::StrN<64>` → `fl::string`.
- `vector.h`, `basic_vector.h`, `strstream.h`, `type_traits.h`, `cstdio.cpp.hpp` — stale `StrN<N>` doc comments updated.

## Why this is non-controversial

`StrN<N>` was a template that only ever got instantiated at `N=32` and `N=64` in the entire codebase. The `N=32` saving (vs `fl::string`'s 64-byte default) is a 32-byte win on a single OTA field — irrelevant. The template added type-system distinctness (`StrN<32>` ≠ `StrN<64>`) that nothing in the codebase relied on. Dropping it removes ~110 lines of redundant constructor / assignment plumbing.

## Architecture doc

`agents/docs/string-architecture.md` rewritten to describe the new two-layer design (basic_string + string), the public span-based construction surface, and where the actual remaining binary duplication lives (`basic_string::write` at 1,151 B is variant-dispatch + materialize-on-write — already type-erased, separate Stage 5 simplification target per #2886).

## Verification

- [x] `bash lint --cpp` — clean (one pre-existing PlatformIO warning, [#2701](https://github.com/FastLED/FastLED/issues/2701))
- [x] Direct compile probe exercises: `basic_string(char*, fl::size)`, `basic_string(fl::span<char>)`, `fl::string` defaults + copy + assign, `substring()` / `substr()` / `trim()` on `fl::string`, `string_view(const basic_string&)`.
- [ ] `bash test --cpp` — pre-existing build-infra failure ("unable to open output file") reproduces on `master` without these changes. Compile probe is the meaningful check given the symptom is build-system, not code.

## Net diff

`13 files changed, 248 insertions(+), 266 deletions(-)` — net delete; the StrN template was redundant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified inline-buffer string with richer constructors, view/interop, substring/trim, concatenation, comparison, and interning APIs (includes std::string interop for WASM).

* **Documentation**
  * Added comprehensive string architecture docs covering storage modes, buffer lifetime, formatting flow, and recommended header/usage order.

* **Tests**
  * Updated tests to target the unified string implementation across iterators, comparisons, integer-formatting, and heap-promotion scenarios.

* **Breaking Changes**
  * Removed the old fixed-size template string wrapper; APIs now use the unified string type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->