### PR TITLE
chore: bump zccache floor 1.11.18 -> 1.11.20

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,7 +104,7 @@ dependencies = [
     # incremental builds produce stale .obj files after a git pull that
     # changes transitive headers (symptom: `undefined symbol: ...` link
     # errors hours after a header actually changed).
-    "zccache>=1.11.18",
+    "zccache>=1.11.20",
     "ninja",
     "meson>=1.11.0",
     "download",


### PR DESCRIPTION
Lift the Python dependency floor in `pyproject.toml` to pick up zccache 1.11.19 + 1.11.20:

- **#681** depgraph eviction fix (1.11.19) — no more wasted hits when artifact GC fires. Directly relevant to FastLED's 600+ TU warm builds; the dogfood reproducer's hit rate jumped from 15.7% back to ~99% after this fix.
- **#670** application-layer back-pressure groundwork (1.11.19).
- **#686** `ZCCACHE_DIAG_CWD` diagnostic (1.11.17) — opt-in CWD/argv diagnostic for Windows wrapper-mode debugging.
- **#679** cached-stderr cross-worktree docs (1.11.20) — explains the surface that #672 / #474 / #489 left visible in diagnostics.
- **#684** feature comparison matrix (1.11.20).
- **#678** lost-connection message cleanup (1.11.16).

No code changes — `pyproject.toml` floor only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency version constraint for improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->