### PR TITLE
perf(stl): mark string cleanup chain noexcept

### DIFF
--- a/src/fl/stl/basic_string.cpp.hpp
+++ b/src/fl/stl/basic_string.cpp.hpp
@@ -16,7 +16,7 @@ basic_string::basic_string(fl::span<char, static_cast<fl::size>(-1)> storage) FL
 
 // ======= DESTRUCTOR =======
 
-basic_string::~basic_string() FL_NOEXCEPT {}
+basic_string::~basic_string() FL_DTOR_NOEXCEPT {}
 
 // ======= string_view CONSTRUCTOR FROM basic_string =======
 // Defined here (in the same TU as basic_string itself) so

--- a/src/fl/stl/basic_string.h
+++ b/src/fl/stl/basic_string.h
@@ -436,7 +436,7 @@ class basic_string {
     // ======= DESTRUCTOR =======
     // Body in basic_string.cpp.hpp per the project's header-thin
     // convention (declarations in `*.h`, definitions in `*.cpp.hpp`).
-    ~basic_string() FL_NOEXCEPT;
+    ~basic_string() FL_DTOR_NOEXCEPT;
 
     // ======= PUBLIC CONSTRUCTION =======
     // Construct a basic_string backed by a caller-provided buffer.

--- a/src/fl/stl/detail/string_holder.cpp.hpp
+++ b/src/fl/stl/detail/string_holder.cpp.hpp
@@ -36,7 +36,7 @@ StringHolder::StringHolder(const char *str, size length)
     mData[mLength] = '\0';
 }
 
-StringHolder::~StringHolder() FL_NOEXCEPT {
+StringHolder::~StringHolder() FL_DTOR_NOEXCEPT {
     fl::free(mData); // Release the memory
 }
 

--- a/src/fl/stl/detail/string_holder.h
+++ b/src/fl/stl/detail/string_holder.h
@@ -15,7 +15,7 @@ class StringHolder {
     StringHolder(const char *str, size length) FL_NOEXCEPT;
     StringHolder(const StringHolder &other) FL_NOEXCEPT = delete;
     StringHolder &operator=(const StringHolder &other) FL_NOEXCEPT = delete;
-    ~StringHolder() FL_NOEXCEPT;
+    ~StringHolder() FL_DTOR_NOEXCEPT;
 
     void grow(size newLength) FL_NOEXCEPT;
     bool hasCapacity(size newLength) const FL_NOEXCEPT { return newLength + 1 <= mCapacity; }

--- a/src/fl/stl/noexcept.h
+++ b/src/fl/stl/noexcept.h
@@ -13,6 +13,9 @@
 // FL_HAS_NOEXCEPT is never defined.  Code that checks whether noexcept is
 // in effect (e.g. static_assert(noexcept(...))) must be gated on this macro.
 //
-// When noexcept support is eventually re-enabled for a platform, add:
-//   #define FL_NOEXCEPT noexcept
-//   #define FL_HAS_NOEXCEPT 1
+// FL_DTOR_NOEXCEPT is narrower: it marks destructor-only cleanup paths that
+// are known not to throw, without changing every historical FL_NOEXCEPT use.
+#ifndef FL_DTOR_NOEXCEPT
+#define FL_DTOR_NOEXCEPT noexcept
+#define FL_HAS_DTOR_NOEXCEPT 1
+#endif

--- a/src/fl/stl/shared_ptr.cpp.hpp
+++ b/src/fl/stl/shared_ptr.cpp.hpp
@@ -22,7 +22,7 @@ namespace fl {
 namespace detail {
 
 // Out-of-line destructor definition to anchor the vtable to this translation unit.
-ControlBlockBase::~ControlBlockBase() FL_NOEXCEPT = default;
+ControlBlockBase::~ControlBlockBase() FL_DTOR_NOEXCEPT = default;
 
 // Reference count increment - must be out-of-line to prevent cross-binary vtable issues.
 void ControlBlockBase::add_shared_ref() {

--- a/src/fl/stl/shared_ptr.h
+++ b/src/fl/stl/shared_ptr.h
@@ -36,9 +36,9 @@ struct ControlBlockBase {
         : shared_count(track ? 1 : NO_TRACKING_VALUE), weak_count(1) {}
     // Destructor defined out-of-line in shared_ptr.cpp.hpp to anchor vtable
     // to a single translation unit, preventing ODR violations when using shared libraries.
-    virtual ~ControlBlockBase() FL_NOEXCEPT;
-    virtual void destroy_object() FL_NOEXCEPT = 0;
-    virtual void destroy_control_block() FL_NOEXCEPT = 0;
+    virtual ~ControlBlockBase() FL_DTOR_NOEXCEPT;
+    virtual void destroy_object() FL_DTOR_NOEXCEPT = 0;
+    virtual void destroy_control_block() FL_DTOR_NOEXCEPT = 0;
     
     // Reference counting functions - defined out-of-line in shared_ptr.cpp.hpp
     // to prevent UBSAN vptr mismatch errors when objects cross shared library boundaries.
@@ -54,7 +54,7 @@ struct ControlBlockBase {
 // Default deleter implementation
 template<typename T>
 struct default_delete {
-    void operator()(T* ptr) const FL_NOEXCEPT {
+    void operator()(T* ptr) const FL_DTOR_NOEXCEPT {
         delete ptr;
     }
 };
@@ -62,7 +62,7 @@ struct default_delete {
 // Deleter that does nothing (for stack/static objects)
 template<typename T>
 struct no_op_deleter {
-    void operator()(T*) const FL_NOEXCEPT {
+    void operator()(T*) const FL_DTOR_NOEXCEPT {
         // Intentionally do nothing - object lifetime managed externally
     }
 };
@@ -70,7 +70,7 @@ struct no_op_deleter {
 // Array deleter implementation for delete[]
 template<typename T>
 struct array_delete {
-    void operator()(T* ptr) const FL_NOEXCEPT {
+    void operator()(T* ptr) const FL_DTOR_NOEXCEPT {
         delete[] ptr;
     }
 };
@@ -84,14 +84,14 @@ struct ControlBlock : public ControlBlockBase {
     ControlBlock(T* p, Deleter d = Deleter(), bool track = true) FL_NOEXCEPT
         : ControlBlockBase(track), ptr(p), deleter(d) {}
 
-    void destroy_object() FL_NOEXCEPT override {
+    void destroy_object() FL_DTOR_NOEXCEPT override {
         if (ptr && !is_no_tracking()) {  // Only delete if tracking
             deleter(ptr);
             ptr = nullptr;
         }
     }
 
-    void destroy_control_block() FL_NOEXCEPT override {
+    void destroy_control_block() FL_DTOR_NOEXCEPT override {
         delete this;
     }
 };
@@ -127,22 +127,22 @@ struct FL_ALIGNAS(control_block_alignment<T>::value) InlinedControlBlock : publi
     }
 
     // Get pointer to the inline object storage
-    T* get_object() FL_NOEXCEPT {
+    T* get_object() FL_DTOR_NOEXCEPT {
         return fl::bit_cast<T*>(&storage[0]);
     }
 
-    const T* get_object() const FL_NOEXCEPT {
+    const T* get_object() const FL_DTOR_NOEXCEPT {
         return fl::bit_cast<const T*>(&storage[0]);
     }
 
-    void destroy_object() FL_NOEXCEPT override {
+    void destroy_object() FL_DTOR_NOEXCEPT override {
         if (object_constructed) {
             get_object()->~T();  // Manual destructor call
             object_constructed = false;
         }
     }
 
-    void destroy_control_block() FL_NOEXCEPT override {
+    void destroy_control_block() FL_DTOR_NOEXCEPT override {
         delete this;
     }
 };
@@ -234,7 +234,7 @@ public:
     }
     
     // Destructor
-    ~shared_ptr() FL_NOEXCEPT {
+    ~shared_ptr() FL_DTOR_NOEXCEPT {
         //FL_WARN("shared_ptr destructor called, mPtr=" << mPtr 
         //          << ", mControlBlock=" << mControlBlock);
         reset();
@@ -283,7 +283,7 @@ public:
     }
     
     // Modifiers
-    void reset() FL_NOEXCEPT {
+    void reset() FL_DTOR_NOEXCEPT {
         //FL_WARN("shared_ptr::reset() called: mPtr=" << mPtr 
         //          << ", mControlBlock=" << mControlBlock);
         if (mControlBlock) {
@@ -301,7 +301,7 @@ public:
         mControlBlock = nullptr;
     }
 
-    void reset(shared_ptr&& other) FL_NOEXCEPT {
+    void reset(shared_ptr&& other) FL_DTOR_NOEXCEPT {
         this->swap(other);
         other.reset();
     }

--- a/src/fl/stl/variant.h
+++ b/src/fl/stl/variant.h
@@ -49,7 +49,7 @@ class FL_ALIGN_AS_T(max_align<Types...>::value) variant {
         }
     }
 
-    ~variant() FL_NOEXCEPT { reset(); }
+    ~variant() FL_DTOR_NOEXCEPT { reset(); }
 
     variant &operator=(const variant &other) FL_NOEXCEPT {
         if (this != &other) {
@@ -102,7 +102,7 @@ class FL_ALIGN_AS_T(max_align<Types...>::value) variant {
         return *ptr<T>();
     }
 
-    void reset() FL_NOEXCEPT {
+    void reset() FL_DTOR_NOEXCEPT {
         if (!empty()) {
             destroy_current();
             _tag = Empty;
@@ -219,7 +219,7 @@ class FL_ALIGN_AS_T(max_align<Types...>::value) variant {
     }
 
     // –– destroy via table
-    void destroy_current() FL_NOEXCEPT {
+    void destroy_current() FL_DTOR_NOEXCEPT {
         using Fn = void (*)(void *);
         FL_DISABLE_WARNING_PUSH
         FL_DISABLE_WARNING(array-bounds)
@@ -230,7 +230,7 @@ class FL_ALIGN_AS_T(max_align<Types...>::value) variant {
         FL_DISABLE_WARNING_POP
     }
 
-    template <typename T> static void destroy_fn(void *storage) FL_NOEXCEPT {
+    template <typename T> static void destroy_fn(void *storage) FL_DTOR_NOEXCEPT {
         // Use bit_cast_ptr for safe type-punning on properly aligned storage
         // The storage is guaranteed to be properly aligned by alignas(max_align<Types...>::value)
         T* typed_ptr = fl::bit_cast_ptr<T>(storage);


### PR DESCRIPTION
## Summary
- add a narrow `FL_DTOR_NOEXCEPT` macro while keeping broad `FL_NOEXCEPT` unchanged
- apply it to the `basic_string` / implicit `sstream` cleanup chain: `basic_string`, `StringHolder`, `variant`, `shared_ptr`, and shared control-block destroy helpers
- avoid changing `FL_WARN` behavior or broad virtual/function `FL_NOEXCEPT` call sites

Closes #2975

## Verification
- `bash bloat esp32s3 --build --top 25`
  - baseline: flash `338,392 B`, RAM `37,884 B`
  - final: flash `337,436 B`, RAM `37,884 B`
  - delta: flash `-956 B`, RAM unchanged
- `uv run test.py --cpp --quick --no-interactive` (`310/310` passed)
- `bash compile uno --examples Blink --platformio`
- `bash compile wasm --examples Blink`

## Notes
A global `FL_NOEXCEPT -> noexcept` flip exposes unrelated historical uses where the macro appears in invalid token positions or in base virtuals without matching overrides. This PR uses the conservative destructor-chain option from the issue instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal improvements to exception handling specifications in string, memory management, and variant utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->