### PR TITLE
lpc: move bare-metal support into platform code

### DIFF
--- a/src/FastLED.cpp.hpp
+++ b/src/FastLED.cpp.hpp
@@ -13,6 +13,7 @@
 #include "fl/channels/driver.h"  // for IChannelDriver
 #include "fl/channels/detail/wait_spin_budget.h"  // for tiered-wait spin-budget setters (#2818)
 #include "fl/system/delay.h"  // for delayMicroseconds
+#include "fl/system/yield.h"  // for fl::yield
 #include "fl/system/sketch_macros.h"
 #if SKETCH_HAS_LARGE_MEMORY
 #include "fl/task/executor.h"  // for task::run (WiFi yield in show() spin loop)
@@ -382,7 +383,7 @@ void CFastLED::delay(unsigned long ms) {
 		fl::delay(1);
 #endif
 		show();
-		yield();
+		fl::yield();
 	}
 	while((fl::millis()-start) < ms);
 }

--- a/src/platforms/arm/_build.cpp.hpp
+++ b/src/platforms/arm/_build.cpp.hpp
@@ -7,6 +7,7 @@
 // Subdirectory implementations (alphabetical order)
 #include "platforms/arm/d21/_build.cpp.hpp"
 #include "platforms/arm/d51/_build.cpp.hpp"
+#include "platforms/arm/lpc/_build.cpp.hpp"
 #include "platforms/arm/mgm240/_build.cpp.hpp"
 #include "platforms/arm/nrf52/_build.cpp.hpp"
 #include "platforms/arm/renesas/_build.cpp.hpp"

--- a/src/platforms/arm/lpc/_build.cpp.hpp
+++ b/src/platforms/arm/lpc/_build.cpp.hpp
@@ -1,0 +1,8 @@
+// IWYU pragma: private
+
+/// @file _build.cpp.hpp
+/// @brief Unity build header for platforms/arm/lpc/ implementations
+
+#include "platforms/arm/lpc/io_lpc.cpp.hpp"
+#include "platforms/arm/lpc/platform_time_lpc.cpp.hpp"
+#include "platforms/arm/lpc/runtime_lpc.cpp.hpp"

--- a/src/platforms/arm/lpc/clockless_arm_lpc.h
+++ b/src/platforms/arm/lpc/clockless_arm_lpc.h
@@ -5,6 +5,7 @@
 
 #include "platforms/arm/is_arm.h"
 #include "platforms/arm/lpc/is_lpc.h"
+#include "fastled_delay.h"
 
 // When the PLU opt-in is set on an LPC804 build, the dedicated PLU driver
 // (clockless_arm_lpc_plu.h) provides the ClocklessController specialisation;

--- a/src/platforms/arm/lpc/clockless_arm_lpc_pwm_dma.h
+++ b/src/platforms/arm/lpc/clockless_arm_lpc_pwm_dma.h
@@ -5,6 +5,7 @@
 
 #include "platforms/arm/is_arm.h"
 #include "platforms/arm/lpc/is_lpc.h"
+#include "fastled_delay.h"
 
 // =============================================================================
 // LPC845 PWM+DMA-to-GPIO clockless driver (Stage 2c of #2836, issue #2842)

--- a/src/platforms/arm/lpc/io_lpc.cpp.hpp
+++ b/src/platforms/arm/lpc/io_lpc.cpp.hpp
@@ -1,0 +1,70 @@
+#pragma once
+
+// IWYU pragma: private
+
+#include "platforms/arm/lpc/is_lpc.h"
+
+#ifdef FL_IS_ARM_LPC
+
+#include "fl/stl/cstddef.h"
+#include "fl/stl/noexcept.h"
+#include "fl/stl/stdint.h"
+#include "platforms/io.h"
+
+namespace fl {
+namespace platforms {
+
+void begin(u32 baudRate) FL_NOEXCEPT {
+    (void)baudRate;
+}
+
+void print(const char* str) FL_NOEXCEPT {
+    (void)str;
+}
+
+void println(const char* str) FL_NOEXCEPT {
+    (void)str;
+}
+
+int available() FL_NOEXCEPT {
+    return 0;
+}
+
+int peek() FL_NOEXCEPT {
+    return -1;
+}
+
+int read() FL_NOEXCEPT {
+    return -1;
+}
+
+int readLineNative(char delimiter, char* out, int outLen) FL_NOEXCEPT {
+    (void)delimiter;
+    (void)out;
+    (void)outLen;
+    return -1;
+}
+
+bool flush(u32 timeoutMs) FL_NOEXCEPT {
+    (void)timeoutMs;
+    return true;
+}
+
+size_t write_bytes(const u8* buffer, size_t size) FL_NOEXCEPT {
+    (void)buffer;
+    (void)size;
+    return 0;
+}
+
+bool serial_ready() FL_NOEXCEPT {
+    return false;
+}
+
+bool serial_is_buffered() FL_NOEXCEPT {
+    return false;
+}
+
+}  // namespace platforms
+}  // namespace fl
+
+#endif  // FL_IS_ARM_LPC

--- a/src/platforms/arm/lpc/led_sysdefs_arm_lpc.h
+++ b/src/platforms/arm/lpc/led_sysdefs_arm_lpc.h
@@ -66,6 +66,10 @@
 #define FASTLED_USE_PROGMEM 0
 #endif
 
+#ifndef FASTLED_NO_PINMAP
+#define FASTLED_NO_PINMAP
+#endif
+
 #define FASTLED_SPI_BYTE_ONLY
 
 #include "fl/stl/stdint.h"
@@ -73,7 +77,9 @@
 typedef volatile fl::u32 RoReg;
 typedef volatile fl::u32 RwReg;
 typedef fl::u32          prog_uint32_t;
+#if !defined(ARDUINO)
 typedef fl::u8           boolean;
+#endif
 
 #define PROGMEM
 #define NO_PROGMEM

--- a/src/platforms/arm/lpc/platform_time_lpc.cpp.hpp
+++ b/src/platforms/arm/lpc/platform_time_lpc.cpp.hpp
@@ -1,0 +1,105 @@
+#pragma once
+
+// IWYU pragma: private
+
+#include "platforms/arm/lpc/is_lpc.h"
+
+#if defined(FL_IS_ARM_LPC) && !defined(ARDUINO)
+
+#include "platforms/arm/is_arm.h"
+#include "platforms/arm/lpc/led_sysdefs_arm_lpc.h"
+#include "platforms/time_platform.h"
+
+namespace fl {
+namespace platforms {
+namespace lpc_time {
+
+static volatile u32 g_millis = 0;
+static bool g_systick_started = false;
+
+static u32 ticks_per_ms() FL_NOEXCEPT {
+    return F_CPU / 1000UL;
+}
+
+static u32 ticks_per_us() FL_NOEXCEPT {
+    return F_CPU / 1000000UL;
+}
+
+static void init_systick() FL_NOEXCEPT {
+    if (g_systick_started) {
+        return;
+    }
+
+    const u32 ticks = ticks_per_ms();
+    if (ticks == 0 || ticks > 0x1000000UL) {
+        return;
+    }
+
+    SysTick->LOAD = ticks - 1;
+    SysTick->VAL = 0;
+    SysTick->CTRL = SysTick_CTRL_CLKSOURCE_Msk |
+                    SysTick_CTRL_TICKINT_Msk |
+                    SysTick_CTRL_ENABLE_Msk;
+    g_systick_started = true;
+}
+
+static u32 current_ms_fraction_us() FL_NOEXCEPT {
+    const u32 per_us = ticks_per_us();
+    if (!g_systick_started || per_us == 0) {
+        return 0;
+    }
+
+    const u32 period_ticks = SysTick->LOAD + 1;
+    const u32 current_ticks = SysTick->VAL;
+    const u32 elapsed_ticks = period_ticks - current_ticks;
+    const u32 fraction_us = elapsed_ticks / per_us;
+    return fraction_us < 1000UL ? fraction_us : 999UL;
+}
+
+}  // namespace lpc_time
+}  // namespace platforms
+}  // namespace fl
+
+extern "C" void SysTick_Handler(void) {
+    ++fl::platforms::lpc_time::g_millis;
+}
+
+namespace fl {
+namespace platforms {
+
+void delay(u32 ms) FL_NOEXCEPT {
+    const u32 start = millis();
+    while ((millis() - start) < ms) {
+    }
+}
+
+void delayMicroseconds(u32 us) FL_NOEXCEPT {
+    const u32 start = micros();
+    while ((micros() - start) < us) {
+    }
+}
+
+u32 millis() FL_NOEXCEPT {
+    lpc_time::init_systick();
+    return lpc_time::g_millis;
+}
+
+u32 micros() FL_NOEXCEPT {
+    lpc_time::init_systick();
+
+    u32 before;
+    u32 fraction;
+    u32 after;
+    do {
+        before = lpc_time::g_millis;
+        fraction = lpc_time::current_ms_fraction_us();
+        after = lpc_time::g_millis;
+    } while (before != after);
+
+    return before * 1000UL + fraction;
+}
+
+}  // namespace platforms
+}  // namespace fl
+
+#endif  // FL_IS_ARM_LPC && !ARDUINO

--- a/src/platforms/arm/lpc/runtime_lpc.cpp.hpp
+++ b/src/platforms/arm/lpc/runtime_lpc.cpp.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+// IWYU pragma: private
+
+#include "platforms/arm/lpc/is_lpc.h"
+
+#ifdef FL_IS_ARM_LPC
+
+#include "fl/stl/cstddef.h"
+#include "fl/stl/compiler_control.h"
+#include "fl/stl/noexcept.h"
+
+extern "C" {
+FL_LINK_WEAK void* __dso_handle;
+FL_LINK_WEAK char end;
+FL_LINK_WEAK char _end;
+}
+
+FL_LINK_WEAK void operator delete(void* ptr) FL_NOEXCEPT {
+    (void)ptr;
+}
+
+FL_LINK_WEAK void operator delete[](void* ptr) FL_NOEXCEPT {
+    (void)ptr;
+}
+
+FL_LINK_WEAK void operator delete(void* ptr, size_t size) FL_NOEXCEPT {
+    (void)ptr;
+    (void)size;
+}
+
+FL_LINK_WEAK void operator delete[](void* ptr, size_t size) FL_NOEXCEPT {
+    (void)ptr;
+    (void)size;
+}
+
+#endif  // FL_IS_ARM_LPC

--- a/src/platforms/arm/lpc/spi_arm_lpc.h
+++ b/src/platforms/arm/lpc/spi_arm_lpc.h
@@ -5,6 +5,7 @@
 
 #include "fl/stl/compiler_control.h"
 #include "fl/stl/noexcept.h"
+#include "fastspi_types.h"
 #include "platforms/arm/is_arm.h"
 #include "platforms/arm/lpc/is_lpc.h"
 

--- a/src/platforms/pin.h
+++ b/src/platforms/pin.h
@@ -35,6 +35,8 @@
     #include "platforms/arm/nrf52/pin_nrf52.hpp"
 #elif defined(FL_IS_RENESAS)
     #include "platforms/arm/renesas/pin_renesas.hpp"
+#elif defined(FL_IS_ARM_LPC)
+    #include "platforms/shared/pin_noop.hpp"
 #elif defined(FL_IS_SILABS)
     #include "platforms/arm/silabs/pin_silabs.hpp"
 #elif defined(FL_IS_APOLLO3)


### PR DESCRIPTION
## Summary
- move the LPC-specific FastLED runtime/time/IO glue into `src/platforms/arm/lpc` instead of keeping board-support files under an example
- wire LPC into the ARM platform build aggregation and use the shared no-op pin map path
- qualify FastLED's internal yield call as `fl::yield()` so Arduino global `yield()` stubs do not collide
- keep Arduino-owned typedefs and timing out of the bare-metal LPC fallback path

This intentionally does not bring over the misplaced `examples/BlinkLPC845` include tree or generated build-info JSON from external PR #2988. Those fbuild-owned pieces are in the companion PR: FastLED/fbuild#512.

## Validation
- `git diff --check master..HEAD`
- with scratch-only `examples/Blink/platformio.ini`: `..\fbuild\target\debug\fbuild.exe ci --board lpc845 examples\Blink\Blink.ino --lib . --quick -v`
- with scratch-only `examples/Blink/platformio.ini`: `..\fbuild\target\debug\fbuild.exe ci --board lpc804 examples\Blink\Blink.ino --lib . --quick -v`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for ARM LPC microcontroller platform with timing, I/O operations, and runtime management

* **Bug Fixes**
  * Fixed delay implementation to use correct function namespace resolution

* **Refactor**
  * Enhanced platform architecture to integrate new ARM LPC platform support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->