### PR TITLE
feat: add ISR-backed channel poll wakeups

### DIFF
--- a/ci/autoresearch/args.py
+++ b/ci/autoresearch/args.py
@@ -92,6 +92,11 @@ class Args:
     # See issues #2254 and #2288 (ESP32-S3 SPI second-frame degradation).
     frames: int | None
 
+    # Tight timing metric (#2991)
+    tight_timing: bool
+    tight_timing_iterations: int
+    tight_timing_max_overhead_us: int
+
     @staticmethod
     def parse_args(argv: list[str] | None = None) -> "Args":
         """Parse command-line arguments and return Args dataclass instance."""
@@ -497,6 +502,30 @@ See Also:
             "See issues #2254, #2288.",
         )
 
+        timing_group = parser.add_argument_group(
+            "Tight Timing Metric",
+            "Measure show()+wait() latency against expected LED wire time.",
+        )
+        timing_group.add_argument(
+            "--tight-timing",
+            action="store_true",
+            help="Add the tight timing metric to each runSingleTest response and fail if it exceeds the overhead budget.",
+        )
+        timing_group.add_argument(
+            "--tight-timing-iterations",
+            type=int,
+            default=8,
+            metavar="N",
+            help="Number of steady-state show()+wait() samples for --tight-timing (default: 8).",
+        )
+        timing_group.add_argument(
+            "--tight-timing-max-overhead-us",
+            type=int,
+            default=2000,
+            metavar="US",
+            help="Maximum allowed max(show()+wait()-wire_time) overhead for --tight-timing (default: 2000us).",
+        )
+
         parsed = parser.parse_args(argv)
 
         if parsed.use_fbuild or parsed.no_fbuild:
@@ -554,4 +583,7 @@ See Also:
             parallel=parsed.parallel,
             decode=parsed.decode,
             frames=parsed.frames,
+            tight_timing=parsed.tight_timing,
+            tight_timing_iterations=parsed.tight_timing_iterations,
+            tight_timing_max_overhead_us=parsed.tight_timing_max_overhead_us,
         )

--- a/ci/autoresearch/context.py
+++ b/ci/autoresearch/context.py
@@ -258,6 +258,28 @@ def display_pattern_details(result: dict[str, Any]) -> None:
     print("-" * 62)
 
 
+def display_tight_timing(result: dict[str, Any]) -> None:
+    """Display tight timing metrics from runSingleTest responses."""
+    metric = result.get("tightTiming")
+    if not isinstance(metric, dict):
+        return
+
+    if not metric.get("supported", False):
+        reason = metric.get("message", "unsupported")
+        print(f"   Tight timing: unsupported ({reason})")
+        return
+
+    status = "PASS" if metric.get("passed", False) else "FAIL"
+    max_overhead = metric.get("max_overhead_us", "?")
+    max_allowed = metric.get("max_allowed_overhead_us", "?")
+    expected = metric.get("expected_wire_us", "?")
+    avg_total = metric.get("avg_total_us", "?")
+    print(
+        f"   Tight timing: {status} max overhead {max_overhead}us "
+        f"(limit {max_allowed}us, wire {expected}us, avg total {avg_total}us)"
+    )
+
+
 def print_run_summary(ctx: RunContext) -> None:
     """Print the compact configuration header."""
     print("\u2500" * 60)

--- a/ci/autoresearch/phases.py
+++ b/ci/autoresearch/phases.py
@@ -26,6 +26,7 @@ from ci.autoresearch.context import (
     QuietContext,
     RunContext,
     display_pattern_details,
+    display_tight_timing,
 )
 from ci.autoresearch.gpio import run_gpio_pretest, run_pin_discovery
 from ci.debug_attached import run_cpp_lint
@@ -530,6 +531,21 @@ def _parse_args_and_build_commands(args: Args) -> RunContext | int:
                         frame_count = 1
                     if frame_count > 1:
                         test_config["frameCount"] = frame_count
+                    if args.tight_timing:
+                        if (
+                            args.tight_timing_iterations < 1
+                            or args.tight_timing_iterations > 64
+                        ):
+                            print("Error: --tight-timing-iterations must be in [1, 64]")
+                            return 1
+                        if args.tight_timing_max_overhead_us < 1:
+                            print("Error: --tight-timing-max-overhead-us must be >= 1")
+                            return 1
+                        test_config["tightTiming"] = True
+                        test_config["tightTimingIterations"] = args.tight_timing_iterations
+                        test_config["tightTimingMaxOverheadUs"] = (
+                            args.tight_timing_max_overhead_us
+                        )
                     rpc_command = {"method": "runSingleTest", "params": test_config}
                     rpc_commands_list.append(rpc_command)
 
@@ -1441,6 +1457,8 @@ async def _run_rpc_tests(ctx: RunContext, qctx: QuietContext) -> int:
                             )
                         print(f"   Duration: {duration_str}")
 
+                    display_tight_timing(test_data)
+
                     if "drivers" in test_data and isinstance(
                         test_data["drivers"], list
                     ):
@@ -1474,6 +1492,8 @@ async def _run_rpc_tests(ctx: RunContext, qctx: QuietContext) -> int:
                         print(f"   Lane: {failure.get('lane', 'unknown')}")
                         print(f"   Expected: {failure.get('expected', 'unknown')}")
                         print(f"   Actual: {failure.get('actual', 'unknown')}")
+
+                    display_tight_timing(test_data)
 
                     if "patterns" in test_data:
                         display_pattern_details(test_data)

--- a/ci/boards.py
+++ b/ci/boards.py
@@ -808,6 +808,7 @@ ESP32_C6_DEVKITC_1 = Board(
         "-funwind-tables",  # Better stack traces for RISC-V crash decoding
         "-DARDUINO_USB_MODE=1",  # Select HWCDC (USB-Serial/JTAG) over OTG
         "-DARDUINO_USB_CDC_ON_BOOT=1",  # Route Serial to HWCDC. Safe with setTxTimeoutMs(0); see #2668
+        "-DARDUINO_LOOP_STACK_SIZE=16384",  # AutoResearch PARLIO init plus JSON-RPC exceeds the Arduino 8KB default on C6
     ],
 )
 
@@ -819,6 +820,11 @@ ESP32_S3_DEVKITC_1 = Board(
     board_build_flash_size="4MB",  # Set to 4MB for QEMU compatibility (default is 8MB)
     board_partitions="huge_app.csv",  # 3MB app partition (default.csv only has 1.25MB, too small for Validation)
     build_unflags=["-DFASTLED_RMT5=0", "-DFASTLED_RMT5"],
+    build_flags=[
+        "-DARDUINO_USB_MODE=1",  # Route Serial over native USB for AutoResearch RPC on the upload port
+        "-DARDUINO_USB_CDC_ON_BOOT=1",
+        "-DARDUINO_LOOP_STACK_SIZE=16384",  # AutoResearch RPC plus ESP driver setup is deep enough to exceed the Arduino 8KB default
+    ],
 )
 
 ESP32_S2_DEVKITM_1 = Board(

--- a/examples/AutoResearch/AutoResearch.ino
+++ b/examples/AutoResearch/AutoResearch.ino
@@ -227,6 +227,11 @@ static constexpr uint32_t AUTORESEARCH_SERIAL_WAIT_MS = SERIAL_TIMEOUT_MS;
 
 const fl::RxBackend RX_BACKEND = fl::RxBackend::PLATFORM_DEFAULT;
 
+// AutoResearch must recover from a wedged driver/RPC command without host
+// intervention. Keep this shorter than the Python RPC timeout so a device-side
+// hang becomes a watchdog reboot instead of a permanently owned/dead port.
+static constexpr uint32_t AUTORESEARCH_WATCHDOG_TIMEOUT_MS = 5000;
+
 // ============================================================================
 // Platform-Specific Pin Defaults
 // ============================================================================
@@ -538,7 +543,7 @@ void loop() {
     // Unified watchdog guard. First iteration: arms the WDT, prints any
     // prior-boot reset/crash info, pauses 3 s on a crash. Every iteration:
     // feeds on construction (now) and again on destruction (end of scope).
-    FL_WATCHDOG_AUTO();
+    FL_WATCHDOG_AUTO(AUTORESEARCH_WATCHDOG_TIMEOUT_MS);
 
     // Aggressively pump async tasks (including JSON-RPC task)
     // This ensures RPC commands are processed frequently even without delay() calls

--- a/examples/AutoResearch/AutoResearchRemote.cpp
+++ b/examples/AutoResearch/AutoResearchRemote.cpp
@@ -129,6 +129,21 @@ uint32_t maxLaneLeds(const fl::vector<fl::ChannelConfig>& tx_configs) {
     return max_leds;
 }
 
+class ScopedFastLedBrightness {
+  public:
+    explicit ScopedFastLedBrightness(uint8_t brightness) FL_NOEXCEPT
+        : mSavedBrightness(FastLED.getBrightness()) {
+        FastLED.setBrightness(brightness);
+    }
+
+    ~ScopedFastLedBrightness() FL_NOEXCEPT {
+        FastLED.setBrightness(mSavedBrightness);
+    }
+
+  private:
+    uint8_t mSavedBrightness;
+};
+
 fl::json measureTightTiming(const fl::string& driver_name,
                             const fl::ChipsetTimingConfig& timing,
                             const fl::vector<fl::ChannelConfig>& tx_configs,
@@ -174,7 +189,7 @@ fl::json measureTightTiming(const fl::string& driver_name,
         channels.push_back(channel);
     }
 
-    FastLED.setBrightness(255);
+    ScopedFastLedBrightness scoped_brightness(255);
     for (fl::size lane = 0; lane < sample_configs.size(); lane++) {
         fill_solid(sample_configs[lane].mLeds.data(),
                    sample_configs[lane].mLeds.size(),
@@ -281,8 +296,12 @@ fl::json measureTightTiming(const fl::string& driver_name,
 
     out_passed = !timed_out && max_overhead_us <= max_allowed_overhead_us;
     metric.set("passed", out_passed);
-    metric.set("message", out_passed ? "tight timing within budget"
-                                     : "tight timing exceeded budget");
+    if (timed_out) {
+        metric.set("message", "timing wait timeout");
+    } else {
+        metric.set("message", out_passed ? "tight timing within budget"
+                                         : "tight timing exceeded budget");
+    }
     return metric;
 }
 

--- a/examples/AutoResearch/AutoResearchRemote.cpp
+++ b/examples/AutoResearch/AutoResearchRemote.cpp
@@ -106,6 +106,188 @@ fl::json makeResponse(bool success, ReturnCode returnCode, const char* message,
 
 // No forward declarations needed - using one-test-per-RPC architecture
 
+namespace {
+
+uint32_t expectedClocklessWireUs(const fl::ChipsetTimingConfig& timing,
+                                 uint32_t max_leds) {
+    const uint64_t bit_period_ns = timing.total_period_ns();
+    const uint64_t payload_ns =
+        static_cast<uint64_t>(max_leds) * 24ULL * bit_period_ns;
+    return static_cast<uint32_t>((payload_ns + 999ULL) / 1000ULL) +
+           timing.reset_us;
+}
+
+uint32_t maxLaneLeds(const fl::vector<fl::ChannelConfig>& tx_configs) {
+    uint32_t max_leds = 0;
+    for (fl::size i = 0; i < tx_configs.size(); i++) {
+        const uint32_t count =
+            static_cast<uint32_t>(tx_configs[i].mLeds.size());
+        if (count > max_leds) {
+            max_leds = count;
+        }
+    }
+    return max_leds;
+}
+
+fl::json measureTightTiming(const fl::string& driver_name,
+                            const fl::ChipsetTimingConfig& timing,
+                            const fl::vector<fl::ChannelConfig>& tx_configs,
+                            int iterations,
+                            uint32_t max_allowed_overhead_us,
+                            bool& out_passed) {
+    fl::json metric = fl::json::object();
+    out_passed = false;
+
+    metric.set("requested", true);
+    metric.set("supported", false);
+    metric.set("driver", driver_name.c_str());
+
+    if (iterations < 1) {
+        metric.set("message", "iterations must be >= 1");
+        return metric;
+    }
+    if (tx_configs.empty()) {
+        metric.set("message", "no channel configs");
+        return metric;
+    }
+    for (fl::size i = 0; i < tx_configs.size(); i++) {
+        if (tx_configs[i].isSpi()) {
+            metric.set("message", "clocked SPI timing metric is not supported");
+            return metric;
+        }
+    }
+
+    fl::vector<fl::ChannelConfig> sample_configs = tx_configs;
+    fl::vector<fl::shared_ptr<fl::Channel>> channels;
+    for (fl::size i = 0; i < sample_configs.size(); i++) {
+        fl::ChannelConfig channel_config(
+            sample_configs[i].getDataPin(),
+            timing,
+            sample_configs[i].mLeds,
+            sample_configs[i].rgb_order);
+        fl::shared_ptr<fl::Channel> channel = FastLED.add(channel_config);
+        if (!channel) {
+            FastLED.clear(ClearFlags::CHANNELS);
+            metric.set("message", "failed to create channel");
+            return metric;
+        }
+        channels.push_back(channel);
+    }
+
+    FastLED.setBrightness(255);
+    for (fl::size lane = 0; lane < sample_configs.size(); lane++) {
+        fill_solid(sample_configs[lane].mLeds.data(),
+                   sample_configs[lane].mLeds.size(),
+                   CRGB::Black);
+    }
+    FastLED.show();
+    if (!FastLED.wait(1000)) {
+        FastLED.clear(ClearFlags::CHANNELS);
+        metric.set("message", "warmup wait timeout");
+        return metric;
+    }
+    delay(2);
+
+    const uint32_t expected_wire_us =
+        expectedClocklessWireUs(timing, maxLaneLeds(sample_configs));
+    uint32_t min_show_us = 0xFFFFFFFFu;
+    uint32_t max_show_us = 0;
+    uint32_t min_wait_us = 0xFFFFFFFFu;
+    uint32_t max_wait_us = 0;
+    uint32_t min_total_us = 0xFFFFFFFFu;
+    uint32_t max_total_us = 0;
+    uint32_t min_overhead_us = 0xFFFFFFFFu;
+    uint32_t max_overhead_us = 0;
+    uint64_t sum_show_us = 0;
+    uint64_t sum_wait_us = 0;
+    uint64_t sum_total_us = 0;
+    uint64_t sum_overhead_us = 0;
+    int samples = 0;
+    bool timed_out = false;
+
+    for (int sample = 0; sample < iterations; sample++) {
+        for (fl::size lane = 0; lane < sample_configs.size(); lane++) {
+            const uint8_t r = static_cast<uint8_t>(31 + sample * 17 + lane * 11);
+            const uint8_t g = static_cast<uint8_t>(67 + sample * 23 + lane * 7);
+            const uint8_t b = static_cast<uint8_t>(103 + sample * 29 + lane * 5);
+            fill_solid(sample_configs[lane].mLeds.data(),
+                       sample_configs[lane].mLeds.size(),
+                       CRGB(r, g, b));
+        }
+
+        const uint32_t t0 = micros();
+        FastLED.show();
+        const uint32_t t1 = micros();
+        const bool ok = FastLED.wait(1000);
+        const uint32_t t2 = micros();
+        if (!ok) {
+            timed_out = true;
+            break;
+        }
+
+        const uint32_t show_us = t1 - t0;
+        const uint32_t wait_us = t2 - t1;
+        const uint32_t total_us = t2 - t0;
+        const uint32_t overhead_us =
+            total_us > expected_wire_us ? total_us - expected_wire_us : 0;
+
+        if (show_us < min_show_us) min_show_us = show_us;
+        if (show_us > max_show_us) max_show_us = show_us;
+        if (wait_us < min_wait_us) min_wait_us = wait_us;
+        if (wait_us > max_wait_us) max_wait_us = wait_us;
+        if (total_us < min_total_us) min_total_us = total_us;
+        if (total_us > max_total_us) max_total_us = total_us;
+        if (overhead_us < min_overhead_us) min_overhead_us = overhead_us;
+        if (overhead_us > max_overhead_us) max_overhead_us = overhead_us;
+
+        sum_show_us += show_us;
+        sum_wait_us += wait_us;
+        sum_total_us += total_us;
+        sum_overhead_us += overhead_us;
+        samples++;
+    }
+
+    FastLED.clear(ClearFlags::CHANNELS);
+
+    metric.set("supported", true);
+    metric.set("samples", static_cast<int64_t>(samples));
+    metric.set("iterations", static_cast<int64_t>(iterations));
+    metric.set("expected_wire_us", static_cast<int64_t>(expected_wire_us));
+    metric.set("max_allowed_overhead_us",
+               static_cast<int64_t>(max_allowed_overhead_us));
+
+    if (samples == 0) {
+        metric.set("passed", false);
+        metric.set("message", timed_out ? "timing wait timeout" : "no samples");
+        return metric;
+    }
+
+    metric.set("min_show_us", static_cast<int64_t>(min_show_us));
+    metric.set("max_show_us", static_cast<int64_t>(max_show_us));
+    metric.set("avg_show_us",
+               static_cast<int64_t>(sum_show_us / static_cast<uint64_t>(samples)));
+    metric.set("min_wait_us", static_cast<int64_t>(min_wait_us));
+    metric.set("max_wait_us", static_cast<int64_t>(max_wait_us));
+    metric.set("avg_wait_us",
+               static_cast<int64_t>(sum_wait_us / static_cast<uint64_t>(samples)));
+    metric.set("min_total_us", static_cast<int64_t>(min_total_us));
+    metric.set("max_total_us", static_cast<int64_t>(max_total_us));
+    metric.set("avg_total_us",
+               static_cast<int64_t>(sum_total_us / static_cast<uint64_t>(samples)));
+    metric.set("min_overhead_us", static_cast<int64_t>(min_overhead_us));
+    metric.set("max_overhead_us", static_cast<int64_t>(max_overhead_us));
+    metric.set("avg_overhead_us",
+               static_cast<int64_t>(sum_overhead_us / static_cast<uint64_t>(samples)));
+
+    out_passed = !timed_out && max_overhead_us <= max_allowed_overhead_us;
+    metric.set("passed", out_passed);
+    metric.set("message", out_passed ? "tight timing within budget"
+                                     : "tight timing exceeded budget");
+    return metric;
+}
+
+} // namespace
+
 // ============================================================================
 // AutoResearchRemoteControl Private Helper Functions
 // ============================================================================
@@ -270,6 +452,39 @@ fl::json AutoResearchRemoteControl::runSingleTestImpl(const fl::json& args) {
         use_legacy_api = config["useLegacyApi"].as_bool().value();
     }
 
+    // 9. Extract tightTiming (optional, default: false)
+    bool measure_tight_timing = false;
+    if (config.contains("tightTiming") && config["tightTiming"].is_bool()) {
+        measure_tight_timing = config["tightTiming"].as_bool().value();
+    }
+
+    int tight_timing_iterations = 8;
+    if (config.contains("tightTimingIterations") &&
+        config["tightTimingIterations"].is_int()) {
+        tight_timing_iterations =
+            static_cast<int>(config["tightTimingIterations"].as_int().value());
+        if (tight_timing_iterations < 1 || tight_timing_iterations > 64) {
+            response.set("success", false);
+            response.set("error", "InvalidTightTimingIterations");
+            response.set("message", "tightTimingIterations must be in [1, 64]");
+            return response;
+        }
+    }
+
+    uint32_t tight_timing_max_overhead_us = 2000;
+    if (config.contains("tightTimingMaxOverheadUs") &&
+        config["tightTimingMaxOverheadUs"].is_int()) {
+        const int max_overhead =
+            static_cast<int>(config["tightTimingMaxOverheadUs"].as_int().value());
+        if (max_overhead < 1) {
+            response.set("success", false);
+            response.set("error", "InvalidTightTimingMaxOverheadUs");
+            response.set("message", "tightTimingMaxOverheadUs must be >= 1");
+            return response;
+        }
+        tight_timing_max_overhead_us = static_cast<uint32_t>(max_overhead);
+    }
+
     // Legacy API: all pins must be in range 0-8 (compile-time template range)
     // Multi-lane uses consecutive pins starting at pin_tx
     if (use_legacy_api) {
@@ -388,6 +603,8 @@ fl::json AutoResearchRemoteControl::runSingleTestImpl(const fl::json& args) {
     bool passed = false;
     uint32_t show_duration_ms = 0;
     fl::vector<fl::RunResult> run_results;
+    fl::json tight_timing_response = fl::json::object();
+    bool tight_timing_passed = true;
 
     {
         // Note: ScopedLogDisable removed to enable diagnostic output during test execution.
@@ -415,6 +632,34 @@ fl::json AutoResearchRemoteControl::runSingleTestImpl(const fl::json& args) {
         passed = (total_tests > 0) && (passed_tests == total_tests);
     }
 
+    if (measure_tight_timing) {
+        if (use_legacy_api) {
+            tight_timing_passed = false;
+            tight_timing_response.set("requested", true);
+            tight_timing_response.set("supported", false);
+            tight_timing_response.set("passed", false);
+            tight_timing_response.set("driver", driver_name.c_str());
+            tight_timing_response.set("message", "legacy API timing metric is not supported");
+        } else {
+            tight_timing_response = measureTightTiming(
+                driver_name,
+                timing_config.timing,
+                tx_configs,
+                tight_timing_iterations,
+                tight_timing_max_overhead_us,
+                tight_timing_passed);
+        }
+        bool tight_timing_supported = false;
+        if (tight_timing_response.contains("supported") &&
+            tight_timing_response["supported"].is_bool()) {
+            tight_timing_supported =
+                tight_timing_response["supported"].as_bool().value();
+        }
+        if (tight_timing_supported) {
+            passed = passed && tight_timing_passed;
+        }
+    }
+
     uint32_t duration_ms = millis() - start_ms;
 
     // ========== RESPONSE ==========
@@ -435,6 +680,9 @@ fl::json AutoResearchRemoteControl::runSingleTestImpl(const fl::json& args) {
     response.set("pattern", pattern.c_str());
     response.set("useLegacyApi", use_legacy_api);
     response.set("frameCount", static_cast<int64_t>(frame_count));
+    if (measure_tight_timing) {
+        response.set("tightTiming", tight_timing_response);
+    }
 
     // Free run_results before building response to reclaim heap
     // Only serialize pattern details when tests FAIL (saves heap on passing tests)

--- a/platformio.ini
+++ b/platformio.ini
@@ -62,6 +62,9 @@ board_build.flash_size = 4MB
 board_build.partitions = huge_app.csv
 build_flags =
     ${env:generic-esp.build_flags}
+    -D ARDUINO_USB_MODE=1
+    -D ARDUINO_USB_CDC_ON_BOOT=1
+    -D ARDUINO_LOOP_STACK_SIZE=16384
 
 [env:esp32c6]
 extends = env:generic-esp
@@ -72,6 +75,7 @@ build_flags =
   -D ARDUINO_USB_CDC_ON_BOOT=1
   -D CONFIG_PARLIO_TX_ISR_HANDLER_IN_IRAM=1
   -D CONFIG_PARLIO_TX_ISR_CACHE_SAFE=1
+  -D ARDUINO_LOOP_STACK_SIZE=16384
   -D PIN_DATA=21
   -D PARLIO_FORCE_LSB_MODE=0
   ; Optional: fix early prints

--- a/src/fl/channels/driver.h
+++ b/src/fl/channels/driver.h
@@ -78,40 +78,73 @@ public:
     /// @brief ISR-safe storage for a poll-needed callback handle.
     ///
     /// Task context installs or clears the handle. ISR context calls invoke().
-    /// The function pointer is published last and cleared first, so an ISR that
-    /// sees a non-null function also sees the corresponding context.
+    /// The callback/context pair is published as one immutable snapshot pointer
+    /// so an ISR cannot observe a function from one registration and a context
+    /// from another.
     class PollNeededCallbackSlot {
+      private:
+        struct Snapshot {
+            explicit Snapshot(PollNeededCallback cb) FL_NOEXCEPT
+                : callback(cb), next(nullptr) {}
+
+            PollNeededCallback callback;
+            Snapshot* next;
+        };
+
       public:
         PollNeededCallbackSlot() FL_NOEXCEPT
-            : mCallback(nullptr), mContext(nullptr) {}
+            : mSnapshot(nullptr), mRetired(nullptr) {}
+
+        ~PollNeededCallbackSlot() FL_NOEXCEPT {
+            Snapshot* active =
+                mSnapshot.exchange(nullptr, fl::memory_order_acq_rel);
+            destroySnapshots(active);
+            destroySnapshots(mRetired);
+            mRetired = nullptr;
+        }
 
         void set(PollNeededCallback callback) FL_NOEXCEPT {
             if (callback.callback == nullptr) {
                 clear();
                 return;
             }
-            mContext.store(callback.context, fl::memory_order_release);
-            mCallback.store(callback.callback, fl::memory_order_release);
+            Snapshot* snapshot = new Snapshot(callback); // ok bare allocation
+            retire(mSnapshot.exchange(snapshot, fl::memory_order_acq_rel));
         }
 
         void clear() FL_NOEXCEPT {
-            mCallback.store(nullptr, fl::memory_order_release);
-            mContext.store(nullptr, fl::memory_order_release);
+            retire(mSnapshot.exchange(nullptr, fl::memory_order_acq_rel));
         }
 
         void invoke() const FL_NOEXCEPT {
-            PollNeededCallback::Callback callback =
-                mCallback.load(fl::memory_order_acquire);
-            if (callback == nullptr) {
+            Snapshot* snapshot = mSnapshot.load(fl::memory_order_acquire);
+            if (snapshot == nullptr) {
                 return;
             }
-            void* context = mContext.load(fl::memory_order_acquire);
-            callback(context);
+            snapshot->callback.invoke();
         }
 
       private:
-        fl::atomic<PollNeededCallback::Callback> mCallback;
-        fl::atomic<void*> mContext;
+        void retire(Snapshot* snapshot) FL_NOEXCEPT {
+            if (snapshot == nullptr) {
+                return;
+            }
+            // An ISR may already have loaded this pointer, so reclaim only when
+            // the slot is destroyed and driver teardown has quiesced callbacks.
+            snapshot->next = mRetired;
+            mRetired = snapshot;
+        }
+
+        static void destroySnapshots(Snapshot* snapshot) FL_NOEXCEPT {
+            while (snapshot != nullptr) {
+                Snapshot* next = snapshot->next;
+                delete snapshot; // ok bare allocation
+                snapshot = next;
+            }
+        }
+
+        fl::atomic<Snapshot*> mSnapshot;
+        Snapshot* mRetired;
     };
 
     /// @brief Driver capabilities

--- a/src/fl/channels/driver.h
+++ b/src/fl/channels/driver.h
@@ -21,6 +21,7 @@
 #include "fl/stl/shared_ptr.h"
 #include "fl/stl/string.h"  // IWYU pragma: keep
 #include "fl/stl/noexcept.h"
+#include "fl/stl/atomic.h"
 
 namespace fl {
 
@@ -47,6 +48,72 @@ FASTLED_SHARED_PTR(ChannelData);
 /// - poll(): Return current hardware state and perform cleanup when complete
 class IChannelDriver {
 public:
+    /// @brief ISR-safe callback handle invoked when the manager should poll again.
+    ///
+    /// ChannelManager installs this callback on every driver and owns the
+    /// corresponding wait primitive. A driver may call it from an ISR when a
+    /// chunk, batch, or transfer changed state. It does not imply READY; it only
+    /// means the manager should wake and poll. Drivers that do not have such a
+    /// signal leave this unused; the manager's timed wait slice is the fallback.
+    struct PollNeededCallback {
+        using Callback = void (*)(void*) FL_NOEXCEPT;
+
+        Callback callback = nullptr;
+        void* context = nullptr;
+
+        constexpr PollNeededCallback() FL_NOEXCEPT = default;
+        constexpr PollNeededCallback(Callback cb, void* ctx) FL_NOEXCEPT
+            : callback(cb), context(ctx) {}
+
+        bool isValid() const FL_NOEXCEPT { return callback != nullptr; }
+        explicit operator bool() const FL_NOEXCEPT { return isValid(); }
+
+        void invoke() const FL_NOEXCEPT {
+            if (callback != nullptr) {
+                callback(context);
+            }
+        }
+    };
+
+    /// @brief ISR-safe storage for a poll-needed callback handle.
+    ///
+    /// Task context installs or clears the handle. ISR context calls invoke().
+    /// The function pointer is published last and cleared first, so an ISR that
+    /// sees a non-null function also sees the corresponding context.
+    class PollNeededCallbackSlot {
+      public:
+        PollNeededCallbackSlot() FL_NOEXCEPT
+            : mCallback(nullptr), mContext(nullptr) {}
+
+        void set(PollNeededCallback callback) FL_NOEXCEPT {
+            if (callback.callback == nullptr) {
+                clear();
+                return;
+            }
+            mContext.store(callback.context, fl::memory_order_release);
+            mCallback.store(callback.callback, fl::memory_order_release);
+        }
+
+        void clear() FL_NOEXCEPT {
+            mCallback.store(nullptr, fl::memory_order_release);
+            mContext.store(nullptr, fl::memory_order_release);
+        }
+
+        void invoke() const FL_NOEXCEPT {
+            PollNeededCallback::Callback callback =
+                mCallback.load(fl::memory_order_acquire);
+            if (callback == nullptr) {
+                return;
+            }
+            void* context = mContext.load(fl::memory_order_acquire);
+            callback(context);
+        }
+
+      private:
+        fl::atomic<PollNeededCallback::Callback> mCallback;
+        fl::atomic<void*> mContext;
+    };
+
     /// @brief Driver capabilities
     struct Capabilities {
         bool supportsClockless;  ///< Supports clockless protocols (WS2812, SK6812, etc.)
@@ -131,20 +198,22 @@ public:
     bool waitForReady(u32 timeoutMs = 1000) FL_NOEXCEPT;
     bool waitForReadyOrDraining(u32 timeoutMs = 1000) FL_NOEXCEPT;
 
+    /// @brief Install the manager-owned poll-needed callback for ISR wakeups.
+    ///
+    /// Implementations that can signal from an ISR should store this callback
+    /// and invoke it after updating their own state. Implementations without
+    /// such a signal can ignore it; the manager will still make progress via
+    /// bounded timeout slices.
+    virtual void setPollNeededCallback(PollNeededCallback callback) FL_NOEXCEPT {
+        (void)callback;
+    }
+
     /// @brief Block until this driver finishes any in-flight transmit.
     ///
-    /// Phase 2 of #2815: drivers that have an ISR-driven completion
-    /// primitive (semaphore, IDF wait-all-done call, event-group) should
-    /// override this to block directly on it. The default delegates to
-    /// `waitForReady(timeoutMs)` so unmigrated drivers (and all bare-metal
-    /// / non-FreeRTOS targets) continue to work via the tiered-spin path
-    /// from Phase 1 (#2818).
-    ///
-    /// `ChannelManager::waitForReady()` short-circuits to
-    /// `driver->waitDone(timeoutMs)` when exactly one driver is BUSY,
-    /// bypassing the spin tier entirely on the single-driver fast path.
-    /// The wait then wakes precisely when the DMA-done ISR fires
-    /// (~microseconds) instead of paying the 250 us spin budget.
+    /// Compatibility hook for older direct-driver call sites. ChannelManager
+    /// does not use per-driver wait primitives for its aggregate wait; it owns
+    /// a single poll-needed wait signal and polls all active drivers after each
+    /// signal or timeout slice.
     ///
     /// @param timeoutMs Optional timeout in milliseconds (0 = no timeout)
     /// @return true if driver became READY, false if timeout occurred

--- a/src/fl/channels/manager.cpp.hpp
+++ b/src/fl/channels/manager.cpp.hpp
@@ -32,7 +32,9 @@ ChannelManager& ChannelManager::instance() {
     return out;
 }
 
-ChannelManager::ChannelManager() {
+ChannelManager::ChannelManager() FL_NOEXCEPT
+    : mPollNeededCallback(&ChannelManager::notifyPollNeededThunk, this),
+      mPollNeededSignal() {
     FL_DBG("ChannelManager: Initializing");
 
     // Register as frame event listener for per-frame reset
@@ -45,7 +47,41 @@ ChannelManager::~ChannelManager() FL_NOEXCEPT {
     // Remove self from EngineEvents listener list
     EngineEvents::removeListener(this);
 
+    for (auto& entry : mDrivers) {
+        if (entry.driver) {
+            entry.driver->setPollNeededCallback(IChannelDriver::PollNeededCallback());
+        }
+    }
+
     // Shared drivers automatically cleaned up by shared_ptr destructors
+}
+
+void ChannelManager::notifyPollNeeded() FL_NOEXCEPT {
+    mPollNeededSignal.notify();
+}
+
+void ChannelManager::notifyPollNeededThunk(void* context) FL_NOEXCEPT {
+    if (context == nullptr) {
+        return;
+    }
+    static_cast<ChannelManager*>(context)->notifyPollNeeded();
+}
+
+bool ChannelManager::waitForPollNeededSignal(u32 timeoutMs) FL_NOEXCEPT {
+    return mPollNeededSignal.wait(timeoutMs);
+}
+
+u32 ChannelManager::pollNeededWaitSliceMs(u32 startTime, u32 timeoutMs) const FL_NOEXCEPT {
+    constexpr u32 kPollNeededFallbackSliceMs = 1;
+    if (timeoutMs == 0) {
+        return kPollNeededFallbackSliceMs;
+    }
+    const u32 elapsed = millis() - startTime;
+    if (elapsed >= timeoutMs) {
+        return 0;
+    }
+    const u32 remaining = timeoutMs - elapsed;
+    return remaining < kPollNeededFallbackSliceMs ? remaining : kPollNeededFallbackSliceMs;
 }
 
 void ChannelManager::addDriver(int priority, fl::shared_ptr<IChannelDriver> driver) {
@@ -93,6 +129,9 @@ void ChannelManager::addDriver(int priority, fl::shared_ptr<IChannelDriver> driv
         for (size_t i = 0; i < mDrivers.size(); ++i) {
             if (mDrivers[i].name == engineName) {
                 FL_DBG("ChannelManager: Removing old driver '" << engineName.c_str() << "' (shared_ptr may delete)");
+                if (mDrivers[i].driver) {
+                    mDrivers[i].driver->setPollNeededCallback(IChannelDriver::PollNeededCallback());
+                }
                 mDrivers.erase(mDrivers.begin() + i);
                 break;
             }
@@ -106,6 +145,7 @@ void ChannelManager::addDriver(int priority, fl::shared_ptr<IChannelDriver> driv
     }
 
     mDrivers.push_back({priority, driver, engineName, enabled});
+    driver->setPollNeededCallback(mPollNeededCallback);
 
     // Build capability string for debug output. Gate the entire block behind
     // FASTLED_HAS_DBG because the `capStr` exists ONLY to feed the FL_DBG
@@ -149,6 +189,8 @@ bool ChannelManager::removeDriver(fl::shared_ptr<IChannelDriver> driver) {
         if (mDrivers[i].driver == driver) {
             FL_DBG("ChannelManager: Removing driver '" << mDrivers[i].name << "'");
 
+            mDrivers[i].driver->setPollNeededCallback(IChannelDriver::PollNeededCallback());
+
             // Remove using vector::erase (preserves sort order)
             mDrivers.erase(mDrivers.begin() + i);
             return true;  // Engine found and removed
@@ -168,6 +210,12 @@ void ChannelManager::clearAllDrivers() {
     waitForReady();
 
     FL_DBG("ChannelManager: Clearing " << mDrivers.size() << " drivers");
+
+    for (auto& entry : mDrivers) {
+        if (entry.driver) {
+            entry.driver->setPollNeededCallback(IChannelDriver::PollNeededCallback());
+        }
+    }
 
     // Clear all drivers (shared_ptr handles cleanup automatically)
     mDrivers.clear();
@@ -409,6 +457,14 @@ bool ChannelManager::waitForCondition(Condition condition, u32 timeoutMs) {
             return false;  // Timeout occurred
         }
 
+        const u32 sliceMs = pollNeededWaitSliceMs(startTime, timeoutMs);
+        if (sliceMs == 0) {
+            return false;
+        }
+        if (waitForPollNeededSignal(sliceMs)) {
+            continue;
+        }
+
         // Adaptive yield (refs #2815, generalizes the #2493 ESP32-P4 carve-out):
         //
         // The 1-tick (>=1 ms at CONFIG_FREERTOS_HZ=1000) floor only exists to
@@ -469,48 +525,6 @@ IChannelDriver::DriverState ChannelManager::poll() {
 }
 
 bool ChannelManager::waitForReady(u32 timeoutMs) {
-    // Phase 2 of #2815 (#2819): single-driver fast path. If exactly one
-    // driver is BUSY, delegate to its waitDone() so drivers with an
-    // ISR-driven completion primitive can block directly on it (no spin
-    // tier, no cooperator yield loop). Drivers that haven't overridden
-    // waitDone() get the default delegate, which is identical to the
-    // existing waitForReady tiered loop -- so unmigrated drivers behave
-    // exactly as before.
-    //
-    // For N > 1 (multi-driver aggregate wait) we fall through to the
-    // tiered waitForCondition loop. Phase 3 (#2815 design) adds a
-    // shared-sem / task-notification fan-in for that path.
-    IChannelDriver* onlyBusy = nullptr;
-    int busyCount = 0;
-    bool sawError = false;
-    for (const auto& entry : mDrivers) {
-        if (!entry.enabled) continue;
-        const auto state = entry.driver->poll();
-        if (state.state == IChannelDriver::DriverState::ERROR) {
-            // Mirror the pre-existing waitForCondition behavior: ERROR
-            // is treated as "not READY", we fall through to the loop and
-            // either spin out the timeout or recover. A future fail-fast
-            // change can land separately.
-            sawError = true;
-            break;
-        }
-        if (state.state == IChannelDriver::DriverState::READY) continue;
-        ++busyCount;
-        onlyBusy = entry.driver.get();
-        if (busyCount > 1) {
-            onlyBusy = nullptr;
-            break;
-        }
-    }
-    if (!sawError && busyCount == 0) return true;
-    if (!sawError && busyCount == 1 && onlyBusy != nullptr) {
-        const bool ok = onlyBusy->waitDone(timeoutMs);
-        if (!ok) {
-            FL_ERROR("ChannelManager: Timeout in single-driver waitDone fast path");
-        }
-        return ok;
-    }
-
     bool ok = waitForCondition([this]() {
         return poll().state == IChannelDriver::DriverState::READY;
     }, timeoutMs);

--- a/src/fl/channels/manager.h
+++ b/src/fl/channels/manager.h
@@ -30,6 +30,7 @@
 #include "fl/stl/vector.h"
 #include "fl/stl/shared_ptr.h"
 #include "fl/stl/noexcept.h"
+#include "platforms/channel_poll_signal.h"
 
 namespace fl {
 
@@ -254,6 +255,11 @@ private:
     template<typename Condition>
     bool waitForCondition(Condition condition, u32 timeoutMs = 1000) FL_NOEXCEPT;
 
+    void notifyPollNeeded() FL_NOEXCEPT;
+    bool waitForPollNeededSignal(u32 timeoutMs) FL_NOEXCEPT;
+    u32 pollNeededWaitSliceMs(u32 startTime, u32 timeoutMs) const FL_NOEXCEPT;
+    static void notifyPollNeededThunk(void* context) FL_NOEXCEPT;
+
 private:
     /// @brief Engine registry entry (priority + shared pointer + runtime control)
     struct EngineEntry {
@@ -288,6 +294,12 @@ private:
     /// @note When non-empty, new drivers are auto-disabled if name doesn't match.
     ///       Set by `setExclusiveDriverByName()` / cleared on empty name.
     fl::string mExclusiveDriver;
+
+    /// @brief Shared callback installed on drivers that can signal poll-needed events.
+    IChannelDriver::PollNeededCallback mPollNeededCallback;
+
+    /// @brief Platform wait primitive owned by the manager.
+    platforms::ChannelPollSignal mPollNeededSignal;
 
     // Non-copyable, non-movable
     ChannelManager(const ChannelManager&) FL_NOEXCEPT = delete;

--- a/src/fl/stl/atomic.h
+++ b/src/fl/stl/atomic.h
@@ -36,7 +36,7 @@ using atomic_i32 = atomic<fl::i32>;
 
 // Forward declare memory_order enum (defined in platforms/shared/atomic.h for real atomics)
 #if !FASTLED_USE_REAL_ATOMICS
-enum class memory_order {
+enum memory_order { // ok plain enum
     memory_order_relaxed,
     memory_order_acquire,
     memory_order_release,
@@ -58,21 +58,21 @@ template <typename T> class AtomicFake {
 
     // Basic atomic operations - fake implementation (not actually atomic)
     // Memory order parameters are accepted but ignored (no-op in single-threaded mode)
-    T load(memory_order = memory_order::memory_order_seq_cst) const FL_NOEXCEPT {
+    T load(memory_order = memory_order_seq_cst) const FL_NOEXCEPT {
         return mValue;
     }
 
-    void store(T value, memory_order = memory_order::memory_order_seq_cst) FL_NOEXCEPT {
+    void store(T value, memory_order = memory_order_seq_cst) FL_NOEXCEPT {
         mValue = value;
     }
     
-    T exchange(T value) FL_NOEXCEPT {
+    T exchange(T value, memory_order = memory_order_seq_cst) FL_NOEXCEPT {
         T old = mValue;
         mValue = value;
         return old;
     }
     
-    bool compare_exchange_weak(T& expected, T desired, memory_order = memory_order::memory_order_seq_cst) FL_NOEXCEPT {
+    bool compare_exchange_weak(T& expected, T desired, memory_order = memory_order_seq_cst) FL_NOEXCEPT {
         if (mValue == expected) {
             mValue = desired;
             return true;
@@ -82,7 +82,7 @@ template <typename T> class AtomicFake {
         }
     }
 
-    bool compare_exchange_strong(T& expected, T desired, memory_order = memory_order::memory_order_seq_cst) FL_NOEXCEPT {
+    bool compare_exchange_strong(T& expected, T desired, memory_order = memory_order_seq_cst) FL_NOEXCEPT {
         return compare_exchange_weak(expected, desired);
     }
     

--- a/src/platforms/channel_poll_signal.h
+++ b/src/platforms/channel_poll_signal.h
@@ -1,0 +1,13 @@
+// ok no namespace fl
+#pragma once
+
+/// @file platforms/channel_poll_signal.h
+/// @brief Platform dispatch for channel-manager poll wake signals.
+
+#include "platforms/is_platform.h"
+
+#if defined(FL_IS_ESP32)
+#include "platforms/esp/32/channel_poll_signal_esp32.h"
+#else
+#include "platforms/shared/channel_poll_signal.h"
+#endif

--- a/src/platforms/esp/32/channel_poll_signal_esp32.h
+++ b/src/platforms/esp/32/channel_poll_signal_esp32.h
@@ -1,0 +1,44 @@
+#pragma once
+
+/// @file platforms/esp/32/channel_poll_signal_esp32.h
+/// @brief ESP32 channel-manager poll wake signal.
+
+#include "fl/stl/atomic.h"
+#include "fl/stl/int.h"
+#include "fl/stl/noexcept.h"
+#include "fl/stl/semaphore.h"
+
+namespace fl {
+namespace platforms {
+
+class ChannelPollSignal {
+  public:
+    ChannelPollSignal() FL_NOEXCEPT : mSignal(0), mPending(false) {}
+
+    void notify() FL_NOEXCEPT {
+        const bool alreadyPending = mPending.exchange(true, fl::memory_order_acq_rel);
+        if (!alreadyPending) {
+            mSignal.release();
+        }
+    }
+
+    bool wait(fl::u32 timeoutMs) FL_NOEXCEPT {
+        const bool signaled = (timeoutMs == 0) ? waitForever() : mSignal.try_acquire_for_ms(timeoutMs);
+        if (signaled) {
+            mPending.store(false, fl::memory_order_release);
+        }
+        return signaled;
+    }
+
+  private:
+    bool waitForever() FL_NOEXCEPT {
+        mSignal.acquire();
+        return true;
+    }
+
+    fl::binary_semaphore mSignal;
+    fl::atomic_bool mPending;
+};
+
+} // namespace platforms
+} // namespace fl

--- a/src/platforms/esp/32/drivers/i2s/channel_driver_i2s.cpp.hpp
+++ b/src/platforms/esp/32/drivers/i2s/channel_driver_i2s.cpp.hpp
@@ -67,6 +67,7 @@ ChannelEngineI2S::ChannelEngineI2S(fl::shared_ptr<detail::II2sLcdCamPeripheral> 
       mChipsetGroups(),
       mCurrentGroupIndex(0),
       mBusy(false),
+      mPollNeededCallback(),
       mFrameCounter(0),
       mWave8Lut(),
       mWave8LutValid(false),
@@ -79,7 +80,7 @@ ChannelEngineI2S::ChannelEngineI2S(fl::shared_ptr<detail::II2sLcdCamPeripheral> 
 
 ChannelEngineI2S::~ChannelEngineI2S() {
     // Wait for pending transmission
-    while (mBusy) {
+    while (mBusy.load(fl::memory_order_acquire)) {
         poll();
     }
 
@@ -162,7 +163,7 @@ IChannelDriver::DriverState ChannelEngineI2S::poll() FL_NOEXCEPT {
 
     // Check if current transmission is complete
     if (mPeripheral && !mPeripheral->isBusy()) {
-        mBusy = false;
+        mBusy.store(false, fl::memory_order_release);
 
         // Move to next chipset group if available
         mCurrentGroupIndex++;
@@ -188,7 +189,24 @@ IChannelDriver::DriverState ChannelEngineI2S::poll() FL_NOEXCEPT {
         return DriverState::READY;
     }
 
-    return mBusy ? DriverState::DRAINING : DriverState::READY;
+    return mBusy.load(fl::memory_order_acquire) ? DriverState::DRAINING : DriverState::READY;
+}
+
+void ChannelEngineI2S::setPollNeededCallback(PollNeededCallback callback) FL_NOEXCEPT {
+    mPollNeededCallback.set(callback);
+}
+
+bool FL_IRAM ChannelEngineI2S::isrTransmitDone(void* panel_io,
+                                               const void* edata,
+                                               void* user_ctx) FL_NOEXCEPT {
+    (void)panel_io;
+    (void)edata;
+    auto* self = static_cast<ChannelEngineI2S*>(user_ctx);
+    if (self != nullptr) {
+        self->mBusy.store(false, fl::memory_order_release);
+        self->mPollNeededCallback.invoke();
+    }
+    return false;
 }
 
 //=============================================================================
@@ -318,7 +336,7 @@ bool ChannelEngineI2S::beginTransmission(fl::span<const ChannelDataPtr> channelD
             // Wait for in-flight DMA to complete before touching buffers
             task::run(250, task::ExecFlags::SYSTEM);
         }
-        mBusy = false;
+        mBusy.store(false, fl::memory_order_release);
 
         // Free old buffers
         for (int i = 0; i < 2; i++) {
@@ -385,6 +403,12 @@ bool ChannelEngineI2S::beginTransmission(fl::span<const ChannelDataPtr> channelD
             FL_WARN("ChannelEngineI2S: Failed to initialize peripheral");
             return false;
         }
+        if (!mPeripheral->registerTransmitCallback(
+                reinterpret_cast<void*>(&isrTransmitDone), this)) { // ok reinterpret cast
+            FL_WARN("ChannelEngineI2S: registerTransmitCallback failed");
+            mPeripheral->deinitialize();
+            return false;
+        }
 
         // Allocate double buffers
         for (int i = 0; i < 2; i++) {
@@ -428,13 +452,13 @@ bool ChannelEngineI2S::beginTransmission(fl::span<const ChannelDataPtr> channelD
         // Wait for previous DMA to finish
         task::run(250, task::ExecFlags::SYSTEM);
     }
-    mBusy = false;
+    mBusy.store(false, fl::memory_order_release);
 
     // Start DMA transfer on the newly-encoded back buffer
-    mBusy = true;
+    mBusy.store(true, fl::memory_order_release);
     int backBuffer = 1 - mFrontBuffer;
     if (!mPeripheral->transmit(mBuffers[backBuffer], mBufferSize)) {
-        mBusy = false;
+        mBusy.store(false, fl::memory_order_release);
         // Clean up on failure - mark channels as not in use
         for (const auto& channel : channelData) {
             channel->setInUse(false);

--- a/src/platforms/esp/32/drivers/i2s/channel_driver_i2s.cpp.hpp
+++ b/src/platforms/esp/32/drivers/i2s/channel_driver_i2s.cpp.hpp
@@ -84,8 +84,14 @@ ChannelEngineI2S::~ChannelEngineI2S() {
         poll();
     }
 
-    // Free buffers
     if (mPeripheral) {
+        if (mPeripheral->isInitialized()) {
+            (void)mPeripheral->registerTransmitCallback(nullptr, nullptr);
+            mPeripheral->deinitialize();
+            mInitialized = false;
+        }
+
+        // Free buffers after the peripheral is stopped so no ISR can reference them.
         for (int i = 0; i < 2; i++) {
             if (mBuffers[i] != nullptr) {
                 mPeripheral->freeBuffer(mBuffers[i]);

--- a/src/platforms/esp/32/drivers/i2s/channel_driver_i2s.h
+++ b/src/platforms/esp/32/drivers/i2s/channel_driver_i2s.h
@@ -64,6 +64,7 @@
 #include "fl/channels/wave8.h"
 #include "fl/chipsets/led_timing.h"
 #include "fl/stl/span.h"
+#include "fl/stl/atomic.h"
 #include "fl/stl/vector.h"
 #include "fl/stl/unique_ptr.h"
 #include "platforms/esp/32/drivers/i2s/ii2s_lcd_cam_peripheral.h"
@@ -143,6 +144,8 @@ public:
     /// - Clean up completed transmissions
     DriverState poll() FL_NOEXCEPT override;
 
+    void setPollNeededCallback(PollNeededCallback callback) FL_NOEXCEPT override;
+
     /// @brief Get the driver name for affinity binding
     /// @return "I2S"
     fl::string getName() const FL_NOEXCEPT override { return fl::string::from_literal("I2S"); }
@@ -184,6 +187,10 @@ private:
     /// @param A Input byte array (16 bytes, one per lane)
     /// @param B Output word array (8 uint16_t words for bit-parallel output)
     static void transpose16x1(const u8* A, u16* B) FL_NOEXCEPT;
+
+    static bool FL_IRAM isrTransmitDone(void* panel_io,
+                                        const void* edata,
+                                        void* user_ctx) FL_NOEXCEPT;
 
 private:
     /// @brief Group of channels sharing the same chipset timing
@@ -231,7 +238,8 @@ private:
     size_t mCurrentGroupIndex;               ///< Index of currently transmitting group
 
     /// @brief Transfer state
-    volatile bool mBusy;
+    fl::atomic_bool mBusy;
+    PollNeededCallbackSlot mPollNeededCallback;
     u32 mFrameCounter;
 
     /// @brief Wave8 expansion LUT for current timing configuration

--- a/src/platforms/esp/32/drivers/i2s/i2s_lcd_cam_peripheral_esp.cpp.hpp
+++ b/src/platforms/esp/32/drivers/i2s/i2s_lcd_cam_peripheral_esp.cpp.hpp
@@ -19,9 +19,6 @@
 // IWYU pragma: begin_keep
 #include "freertos/FreeRTOS.h"
 // IWYU pragma: end_keep
-// IWYU pragma: begin_keep
-#include "freertos/semphr.h"
-// IWYU pragma: end_keep
 #include "esp_lcd_panel_io.h"
 #include "esp_heap_caps.h"
 #include "esp_timer.h"

--- a/src/platforms/esp/32/drivers/lcd_spi/channel_driver_lcd_clockless.cpp.hpp
+++ b/src/platforms/esp/32/drivers/lcd_spi/channel_driver_lcd_clockless.cpp.hpp
@@ -65,7 +65,7 @@ ChannelDriverLcdClockless::ChannelDriverLcdClockless(
       mRingBuffers{nullptr, nullptr, nullptr}, mRingCapacity(0),
       mNumLanes(0), mBusy(false), mIsrCtx(), mChunkInputBytesOverride(0),
       mWorkerTaskHandle(nullptr), mWorkerStop(false), mWorkerRunning(false),
-      mUseWave3(true), mWave3Lut(), mWave8Lut(), mClockHz(0),
+      mPollNeededCallback(), mUseWave3(true), mWave3Lut(), mWave8Lut(), mClockHz(0),
       mOutputBytesPerInputByte(0) {
     mIsrCtx.reset();
 }
@@ -306,12 +306,7 @@ void ChannelDriverLcdClockless::show() FL_NOEXCEPT {
         return;
     }
 
-    constexpr int kMaxIterations = 20000;
-    int iterations = 0;
-    while (mBusy && iterations++ < kMaxIterations) {
-        poll();
-        fl::task::run(250, fl::task::ExecFlags::SYSTEM);
-    }
+    (void)waitForReady(2000);
     if (mBusy) {
         FL_WARN("ChannelDriverLcdClockless: DMA hung — forcing release");
         mBusy = false;
@@ -370,6 +365,10 @@ IChannelDriver::DriverState ChannelDriverLcdClockless::poll() FL_NOEXCEPT {
 //=============================================================================
 // Encoding — wave3 or wave8 transpose into u16 DMA words
 //=============================================================================
+
+void ChannelDriverLcdClockless::setPollNeededCallback(PollNeededCallback callback) FL_NOEXCEPT {
+    mPollNeededCallback.set(callback);
+}
 
 // FL_IRAM matches the declaration in channel_driver_lcd_clockless.h. Keep the
 // encoder IRAM-safe because worker wake-up is triggered by the LCD ISR and this
@@ -441,6 +440,7 @@ bool FL_IRAM ChannelDriverLcdClockless::isrChunkDone(void *panel_io,
     if (ctx.mCompletedChunks >= ctx.mTotalChunks) {
         ctx.mStreamComplete = true;
         self->mBusy = false;
+        self->mPollNeededCallback.invoke();
         return false;
     }
 

--- a/src/platforms/esp/32/drivers/lcd_spi/channel_driver_lcd_clockless.h
+++ b/src/platforms/esp/32/drivers/lcd_spi/channel_driver_lcd_clockless.h
@@ -56,6 +56,7 @@ class ChannelDriverLcdClockless : public IChannelDriver {
     void enqueue(ChannelDataPtr channelData) FL_NOEXCEPT override;
     void show() FL_NOEXCEPT override;
     DriverState poll() FL_NOEXCEPT override;
+    void setPollNeededCallback(PollNeededCallback callback) FL_NOEXCEPT override;
 
     fl::string getName() const FL_NOEXCEPT override {
         return fl::string::from_literal("LCD_CLOCKLESS");
@@ -167,6 +168,7 @@ class ChannelDriverLcdClockless : public IChannelDriver {
     void *mWorkerTaskHandle;
     volatile bool mWorkerStop;
     volatile bool mWorkerRunning;
+    PollNeededCallbackSlot mPollNeededCallback;
 
     // Encoding state (set during beginTransmission, stable during ISR)
     bool mUseWave3;

--- a/src/platforms/esp/32/drivers/parlio/channel_driver_parlio.cpp.hpp
+++ b/src/platforms/esp/32/drivers/parlio/channel_driver_parlio.cpp.hpp
@@ -289,6 +289,10 @@ IChannelDriver::DriverState ChannelDriverPARLIOImpl::poll() FL_NOEXCEPT {
     }
 }
 
+void ChannelDriverPARLIOImpl::setPollNeededCallback(PollNeededCallback callback) FL_NOEXCEPT {
+    mDriver.setPollNeededCallback(callback);
+}
+
 //=============================================================================
 // Private Methods - Transmission
 //=============================================================================
@@ -433,6 +437,7 @@ void ChannelDriverPARLIOImpl::prepareScratchBuffer(
 ChannelDriverPARLIO::ChannelDriverPARLIO() FL_NOEXCEPT
     : mCurrentDataWidth(0),
       mPhase(TransmitPhase::IDLE),
+      mPollNeededCallback(),
       mCurrentSpiChannelIndex(0),
       mSpiInitialized(false) {}
 
@@ -559,6 +564,14 @@ IChannelDriver::DriverState ChannelDriverPARLIO::poll() FL_NOEXCEPT {
     }
 }
 
+void ChannelDriverPARLIO::setPollNeededCallback(PollNeededCallback callback) FL_NOEXCEPT {
+    mPollNeededCallback = callback;
+    detail::ParlioEngine::getInstance().setPollNeededCallback(mPollNeededCallback);
+    if (mClocklessDriver) {
+        mClocklessDriver->setPollNeededCallback(mPollNeededCallback);
+    }
+}
+
 void ChannelDriverPARLIO::beginClocklessTransmission(
     fl::span<const ChannelDataPtr> channelData) FL_NOEXCEPT {
     if (channelData.size() == 0) {
@@ -581,6 +594,7 @@ void ChannelDriverPARLIO::beginClocklessTransmission(
     // Create or reconfigure clockless driver
     if (!mClocklessDriver || mCurrentDataWidth != required_width) {
         mClocklessDriver = fl::make_unique<ChannelDriverPARLIOImpl>(required_width);
+        mClocklessDriver->setPollNeededCallback(mPollNeededCallback);
         mCurrentDataWidth = required_width;
     }
 

--- a/src/platforms/esp/32/drivers/parlio/channel_driver_parlio.h
+++ b/src/platforms/esp/32/drivers/parlio/channel_driver_parlio.h
@@ -458,6 +458,8 @@ class ChannelDriverPARLIOImpl : public IChannelDriver {
     /// @return Current driver state (READY, BUSY, DRAINING, or ERROR)
     DriverState poll() FL_NOEXCEPT override;
 
+    void setPollNeededCallback(PollNeededCallback callback) FL_NOEXCEPT override;
+
     /// @brief Get the driver name for affinity binding
     /// @return "PARLIO"
     fl::string getName() const FL_NOEXCEPT override { return fl::string::from_literal("PARLIO"); }
@@ -589,6 +591,8 @@ class ChannelDriverPARLIO : public IChannelDriver {
     /// @return Current driver state (READY, BUSY, DRAINING, or ERROR)
     DriverState poll() FL_NOEXCEPT override;
 
+    void setPollNeededCallback(PollNeededCallback callback) FL_NOEXCEPT override;
+
     /// @brief Get the driver name for affinity binding
     /// @return "PARLIO"
     fl::string getName() const FL_NOEXCEPT override { return fl::string::from_literal("PARLIO"); }
@@ -620,6 +624,9 @@ class ChannelDriverPARLIO : public IChannelDriver {
 
     /// @brief Current transmission phase
     TransmitPhase mPhase;
+
+    /// @brief Manager-owned callback signaled by the PARLIO engine ISR.
+    PollNeededCallback mPollNeededCallback;
 
     /// @brief All channels currently transmitting (for isInUse cleanup)
     fl::vector<ChannelDataPtr> mTransmittingChannels;

--- a/src/platforms/esp/32/drivers/parlio/parlio_engine.cpp.hpp
+++ b/src/platforms/esp/32/drivers/parlio/parlio_engine.cpp.hpp
@@ -342,6 +342,7 @@ ParlioEngine::ParlioEngine() FL_NOEXCEPT
       mSpiClockHz(0),
       mIsrContext(),
       mMainTaskHandle(nullptr),
+      mPollNeededCallback(),
       mRingBuffer(),
       mRingBufferCapacity(0),
       mScratchBuffer(nullptr),
@@ -419,6 +420,10 @@ ParlioEngine::~ParlioEngine() {
 
 ParlioEngine& ParlioEngine::getInstance() FL_NOEXCEPT {
     return fl::Singleton<ParlioEngine>::instance();
+}
+
+void ParlioEngine::setPollNeededCallback(IChannelDriver::PollNeededCallback callback) FL_NOEXCEPT {
+    mPollNeededCallback.set(callback);
 }
 
 void ParlioEngine::cleanup() FL_NOEXCEPT {
@@ -606,6 +611,7 @@ ParlioEngine::txDoneCallback(void* tx_unit,
             if (ctx->mBytesTransmitted > ctx->mTotalBytes) {
                 ctx->mRingError = true;  // Flag overflow for debugging
             }
+            self->mPollNeededCallback.invoke();
 
             // ASYNC MODE: No task notifications
             // - Worker task was removed (uses timer ISR instead)
@@ -2122,12 +2128,12 @@ ParlioEngineState ParlioEngine::poll() FL_NOEXCEPT {
         // Execute memory barrier to synchronize all ISR writes
         FL_MEMORY_BARRIER;
 
-        // Clear completion flags
-        mIsrContext->mTransmitting = false;
-        mIsrContext->mStreamComplete = false;
-
         // Wait for final chunk to complete (non-blocking poll)
         if (mPeripheral->waitAllDone(0)) {
+            // Clear completion flags only once the peripheral is truly idle.
+            mIsrContext->mTransmitting = false;
+            mIsrContext->mStreamComplete = false;
+
             // All transmissions complete - disable peripheral (only if currently enabled)
             if (mTxUnitEnabled) {
                 if (!mPeripheral->disable()) {

--- a/src/platforms/esp/32/drivers/parlio/parlio_engine.cpp.hpp
+++ b/src/platforms/esp/32/drivers/parlio/parlio_engine.cpp.hpp
@@ -391,9 +391,8 @@ ParlioEngine::~ParlioEngine() {
     if (mDebugTask.is_valid()) {
         // Signal task to exit by setting flags to false (task checks: while (mTransmitting || mStreamComplete))
         if (mIsrContext) {
-            mIsrContext->mTransmitting = false;
-            mIsrContext->mStreamComplete = false;  // Ensure loop exits (both conditions false)
-            FL_MEMORY_BARRIER;
+            mIsrContext->mTransmitting.store(false, fl::memory_order_release);
+            mIsrContext->mStreamComplete.store(false, fl::memory_order_release);
         }
         // Give task time to self-delete (task calls fl::task::exit_current() at end)
         // Task sleeps for 500ms, so we need to wait at least 500ms for it to wake up and check flags
@@ -433,9 +432,8 @@ void ParlioEngine::cleanup() FL_NOEXCEPT {
     if (mDebugTask.is_valid()) {
         // Signal task to exit by setting flags to false
         if (mIsrContext) {
-            mIsrContext->mTransmitting = false;
-            mIsrContext->mStreamComplete = false;
-            FL_MEMORY_BARRIER;
+            mIsrContext->mTransmitting.store(false, fl::memory_order_release);
+            mIsrContext->mStreamComplete.store(false, fl::memory_order_release);
         }
         // Give task time to self-delete (task sleeps for 500ms)
         if (mPeripheral) {
@@ -468,14 +466,19 @@ void ParlioEngine::debugTaskFunction(void* arg) FL_NOEXCEPT {
     ParlioIsrContext *ctx = self->mIsrContext.get();
 
     // Loop while transmission is active
-    while (ctx->mTransmitting || ctx->mStreamComplete) {
+    while (ctx->mTransmitting.load(fl::memory_order_acquire) ||
+           ctx->mStreamComplete.load(fl::memory_order_acquire)) {
         // Wait 500ms between prints
         if (self->mPeripheral) {
             self->mPeripheral->delay(500);
         }
 
-        // Memory barrier to ensure we see latest ISR state
-        FL_MEMORY_BARRIER;
+        const bool transmitting =
+            ctx->mTransmitting.load(fl::memory_order_acquire);
+        const bool stream_complete =
+            ctx->mStreamComplete.load(fl::memory_order_acquire);
+        const bool hardware_idle =
+            ctx->mHardwareIdle.load(fl::memory_order_acquire);
 
         // Print ISR debug state (using FL_LOG_PARLIO which is safe from task context)
         FL_LOG_PARLIO("ISR_STATE:"
@@ -483,12 +486,12 @@ void ParlioEngine::debugTaskFunction(void* arg) FL_NOEXCEPT {
                << " worker=" << ctx->mDebugWorkerIsrCount
                << " ring_count=" << ctx->mRingCount
                << " bytes_tx=" << ctx->mBytesTransmitted << "/" << ctx->mTotalBytes
-               << " transmitting=" << (ctx->mTransmitting ? "YES" : "NO")
-               << " complete=" << (ctx->mStreamComplete ? "YES" : "NO")
-               << " hw_idle=" << (ctx->mHardwareIdle ? "YES" : "NO"));
+               << " transmitting=" << (transmitting ? "YES" : "NO")
+               << " complete=" << (stream_complete ? "YES" : "NO")
+               << " hw_idle=" << (hardware_idle ? "YES" : "NO"));
 
         // Check for ring buffer underrun (CRITICAL ERROR per LOOP.md)
-        if (ctx->mHardwareIdle && ctx->mRingCount == 0 && ctx->mTransmitting) {
+        if (hardware_idle && ctx->mRingCount == 0 && transmitting) {
             FL_ERROR("PARLIO: BUFFER UNDERRUN DETECTED - Hardware idle with empty ring during transmission"
                     << " | bytes_tx=" << ctx->mBytesTransmitted << "/" << ctx->mTotalBytes);
             // DO NOT restart PARLIO - per LOOP.md this is a critical error
@@ -497,7 +500,7 @@ void ParlioEngine::debugTaskFunction(void* arg) FL_NOEXCEPT {
         }
 
         // Exit if transmission complete
-        if (ctx->mStreamComplete && !ctx->mTransmitting) {
+        if (stream_complete && !transmitting) {
             break;
         }
     }
@@ -600,17 +603,16 @@ ParlioEngine::txDoneCallback(void* tx_unit,
         // Overflow can happen due to LED boundary rounding, but we still need to complete
         if (ctx->mBytesTransmitted >= ctx->mTotalBytes) {
             // All data transmitted - mark transmission complete
-            ctx->mStreamComplete = true;
-            ctx->mTransmitting = false;
-            ctx->mTransmissionActive = false;
-            ctx->mHardwareIdle = false;
+            ctx->mTransmissionActive.store(false, fl::memory_order_release);
+            ctx->mHardwareIdle.store(false, fl::memory_order_release);
             ctx->mEndTimeUs = ctx->mDebugLastTxDoneTime;
 
             // SAFETY CHECK: Detect byte overflow (tolerate small overflows from LED rounding)
             // Flag overflow for debugging, but don't prevent completion
             if (ctx->mBytesTransmitted > ctx->mTotalBytes) {
-                ctx->mRingError = true;  // Flag overflow for debugging
+                ctx->mRingError.store(true, fl::memory_order_release);
             }
+            ctx->mStreamComplete.store(true, fl::memory_order_release);
             self->mPollNeededCallback.invoke();
 
             // ASYNC MODE: No task notifications
@@ -622,7 +624,7 @@ ParlioEngine::txDoneCallback(void* tx_unit,
         }
 
         // Ring empty but more data pending - call worker function directly
-        ctx->mHardwareIdle = true; // Signal that hardware needs restart
+        ctx->mHardwareIdle.store(true, fl::memory_order_release);
         ctx->mUnderrunCount = ctx->mUnderrunCount + 1;
 
         // ONE-SHOT PATTERN: Call worker function directly to populate next buffer
@@ -639,7 +641,7 @@ ParlioEngine::txDoneCallback(void* tx_unit,
 
     // Invalid buffer - set error flag
     if (!buffer_ptr || buffer_size == 0) {
-        ctx->mRingError = true;
+        ctx->mRingError.store(true, fl::memory_order_release);
         return false;
     }
 
@@ -657,7 +659,7 @@ ParlioEngine::txDoneCallback(void* tx_unit,
         // This is the SAME race documented in workerIsrCallback (line 830), viewed from txDone's perspective.
         // See detailed safety analysis there. Summary: bounded, self-correcting, no buffer corruption.
         ctx->mRingCount = ctx->mRingCount - 1;
-        ctx->mHardwareIdle = false; // Hardware is active again
+        ctx->mHardwareIdle.store(false, fl::memory_order_release);
 
         // ONE-SHOT PATTERN: Call worker function directly if more buffers needed
         // This eliminates the 50µs periodic timer overhead
@@ -674,7 +676,7 @@ ParlioEngine::txDoneCallback(void* tx_unit,
         return false; // No tasks woken
     } else {
         // Submission failed - set error flag for CPU to detect
-        ctx->mRingError = true;
+        ctx->mRingError.store(true, fl::memory_order_release);
     }
 
     return false; // No high-priority task woken
@@ -1309,7 +1311,7 @@ ParlioEngine::populateNextDMABuffer() FL_NOEXCEPT {
     mIsrContext->mRingCount = mIsrContext->mRingCount + 1;
 
     // CRITICAL: Check if hardware went idle while we were populating
-    if (mIsrContext->mHardwareIdle) {
+    if (mIsrContext->mHardwareIdle.load(fl::memory_order_acquire)) {
         // Get the buffer that was just populated (read_idx points to next buffer to transmit)
         size_t buffer_idx = mIsrContext->mRingReadIdx;
         u8 *buffer_ptr = mRingBuffer->ptrs[buffer_idx];  // Use cached pointer for optimization
@@ -1323,8 +1325,8 @@ ParlioEngine::populateNextDMABuffer() FL_NOEXCEPT {
                 // Successfully restarted - advance read index and decrement count
                 mIsrContext->mRingReadIdx = (mIsrContext->mRingReadIdx + 1) % ParlioRingBuffer3::RING_BUFFER_COUNT;
                 mIsrContext->mRingCount = mIsrContext->mRingCount - 1;
-                mIsrContext->mHardwareIdle = false;
-                mIsrContext->mTransmitting = true;
+                mIsrContext->mHardwareIdle.store(false, fl::memory_order_release);
+                mIsrContext->mTransmitting.store(true, fl::memory_order_release);
             } else {
                 //FL_WARN("PARLIO CPU: Failed to restart hardware: " << err);
                 mErrorOccurred = true;
@@ -1609,8 +1611,8 @@ bool ParlioEngine::initialize(size_t dataWidth,
 
     // Initialize ISR context state
     if (mIsrContext) {
-        mIsrContext->mTransmitting = false;
-        mIsrContext->mStreamComplete = false;
+        mIsrContext->mTransmitting.store(false, fl::memory_order_release);
+        mIsrContext->mStreamComplete.store(false, fl::memory_order_release);
         mIsrContext->mCurrentByte = 0;
         mIsrContext->mTotalBytes = 0;
     }
@@ -1738,8 +1740,8 @@ bool ParlioEngine::initializeSpi(const fl::vector<int>& pins,
 
     // Initialize ISR context state
     if (mIsrContext) {
-        mIsrContext->mTransmitting = false;
-        mIsrContext->mStreamComplete = false;
+        mIsrContext->mTransmitting.store(false, fl::memory_order_release);
+        mIsrContext->mStreamComplete.store(false, fl::memory_order_release);
         mIsrContext->mCurrentByte = 0;
         mIsrContext->mTotalBytes = 0;
     }
@@ -1844,7 +1846,7 @@ bool ParlioEngine::beginTransmission(const u8* scratchBuffer,
     }
 
     // Check if already transmitting
-    if (mIsrContext->mTransmitting) {
+    if (mIsrContext->mTransmitting.load(fl::memory_order_acquire)) {
         FL_LOG_PARLIO("PARLIO_TX: FAILED - transmission already in progress");
         FL_LOG_PARLIO("PARLIO: Transmission already in progress");
         return false;
@@ -1890,16 +1892,16 @@ bool ParlioEngine::beginTransmission(const u8* scratchBuffer,
     mIsrContext->mTotalBytes = mLaneStride;
     mIsrContext->mNumLanes = numLanes;
     mIsrContext->mCurrentByte = 0;
-    mIsrContext->mStreamComplete = false;
+    mIsrContext->mStreamComplete.store(false, fl::memory_order_release);
     mErrorOccurred = false;
-    mIsrContext->mTransmitting = false; // Will be set to true after first buffer submitted
+    mIsrContext->mTransmitting.store(false, fl::memory_order_release);
 
     // Initialize ring buffer indices and count
     mIsrContext->mRingReadIdx = 0;
     mIsrContext->mRingWriteIdx = 0;
     mIsrContext->mRingCount = 0;
-    mIsrContext->mRingError = false;
-    mIsrContext->mHardwareIdle = false;
+    mIsrContext->mRingError.store(false, fl::memory_order_release);
+    mIsrContext->mHardwareIdle.store(false, fl::memory_order_release);
     mIsrContext->mUnderrunCount = 0;
     mIsrContext->mNextByteOffset = 0;
 
@@ -1907,7 +1909,7 @@ bool ParlioEngine::beginTransmission(const u8* scratchBuffer,
     mIsrContext->mIsrCount = 0;
     mIsrContext->mBytesTransmitted = 0;
     mIsrContext->mChunksCompleted = 0;
-    mIsrContext->mTransmissionActive = true;
+    mIsrContext->mTransmissionActive.store(true, fl::memory_order_release);
     mIsrContext->mEndTimeUs = 0;
 
     // Initialize debug counters
@@ -1969,7 +1971,7 @@ bool ParlioEngine::beginTransmission(const u8* scratchBuffer,
 
     // CRITICAL FIX: Mark transmission started BEFORE submitting buffer
     // This closes the race window where txDoneCallback could fire before flag is set (Issue #2)
-    mIsrContext->mTransmitting = true;
+    mIsrContext->mTransmitting.store(true, fl::memory_order_release);
 
     // CRITICAL FIX (Iteration 2): Advance read index BEFORE submitting first buffer
     // This prevents race condition where txDone fires before index is advanced
@@ -1980,7 +1982,7 @@ bool ParlioEngine::beginTransmission(const u8* scratchBuffer,
 
     if (!mPeripheral->transmit(mRingBuffer->ptrs[0], first_buffer_size * 8, 0x0000)) {
         FL_LOG_PARLIO("PARLIO: Failed to queue first buffer");
-        mIsrContext->mTransmitting = false;  // Rollback flag on error
+        mIsrContext->mTransmitting.store(false, fl::memory_order_release);
         mIsrContext->mRingReadIdx = 0;  // Rollback index on error
         mIsrContext->mRingCount = buffers_populated;  // Rollback count on error
         mErrorOccurred = true;
@@ -2046,9 +2048,10 @@ bool ParlioEngine::beginTransmission(const u8* scratchBuffer,
     // Real hardware uses async mode where caller polls via poll() method
     #ifdef FASTLED_STUB_IMPL
     // Block until transmission completes by polling
-    FL_LOG_PARLIO("PARLIO STUB: Entering polling loop - totalBytes=" << totalBytes << " streamComplete=" << mIsrContext->mStreamComplete);
+    FL_LOG_PARLIO("PARLIO STUB: Entering polling loop - totalBytes=" << totalBytes
+                   << " streamComplete=" << mIsrContext->mStreamComplete.load(fl::memory_order_acquire));
     size_t poll_iterations = 0;
-    while (!mIsrContext->mStreamComplete && !mErrorOccurred) {
+    while (!mIsrContext->mStreamComplete.load(fl::memory_order_acquire) && !mErrorOccurred) {
         ParlioEngineState state = poll();
         poll_iterations++;
 
@@ -2056,8 +2059,8 @@ bool ParlioEngine::beginTransmission(const u8* scratchBuffer,
             FL_LOG_PARLIO("PARLIO STUB: Poll iteration " << poll_iterations
                    << " - bytesTransmitted=" << mIsrContext->mBytesTransmitted
                    << "/" << mIsrContext->mTotalBytes
-                   << " streamComplete=" << mIsrContext->mStreamComplete
-                   << " transmitting=" << mIsrContext->mTransmitting
+                   << " streamComplete=" << mIsrContext->mStreamComplete.load(fl::memory_order_acquire)
+                   << " transmitting=" << mIsrContext->mTransmitting.load(fl::memory_order_acquire)
                    << " ringCount=" << mIsrContext->mRingCount
                    << " txDone=" << mIsrContext->mDebugTxDoneCount
                    << " worker=" << mIsrContext->mDebugWorkerIsrCount);
@@ -2118,21 +2121,18 @@ ParlioEngineState ParlioEngine::poll() FL_NOEXCEPT {
     // Check for errors
     if (mErrorOccurred) {
         FL_LOG_PARLIO("PARLIO: Error occurred during transmission");
-        mIsrContext->mTransmitting = false;
+        mIsrContext->mTransmitting.store(false, fl::memory_order_release);
         mErrorOccurred = false;
         return ParlioEngineState::ERROR;
     }
 
     // Check if streaming is complete
-    if (mIsrContext->mStreamComplete) {
-        // Execute memory barrier to synchronize all ISR writes
-        FL_MEMORY_BARRIER;
-
+    if (mIsrContext->mStreamComplete.load(fl::memory_order_acquire)) {
         // Wait for final chunk to complete (non-blocking poll)
         if (mPeripheral->waitAllDone(0)) {
             // Clear completion flags only once the peripheral is truly idle.
-            mIsrContext->mTransmitting = false;
-            mIsrContext->mStreamComplete = false;
+            mIsrContext->mTransmitting.store(false, fl::memory_order_release);
+            mIsrContext->mStreamComplete.store(false, fl::memory_order_release);
 
             // All transmissions complete - disable peripheral (only if currently enabled)
             if (mTxUnitEnabled) {
@@ -2154,7 +2154,7 @@ ParlioEngineState ParlioEngine::poll() FL_NOEXCEPT {
     }
 
     // If not transmitting, we're ready
-    if (!mIsrContext->mTransmitting) {
+    if (!mIsrContext->mTransmitting.load(fl::memory_order_acquire)) {
         return ParlioEngineState::READY;
     }
 
@@ -2171,7 +2171,7 @@ bool ParlioEngine::isTransmitting() const FL_NOEXCEPT {
     if (!mIsrContext) {
         return false;
     }
-    return mIsrContext->mTransmitting;
+    return mIsrContext->mTransmitting.load(fl::memory_order_acquire);
 }
 
 ParlioDebugMetrics ParlioEngine::getDebugMetrics() const FL_NOEXCEPT {
@@ -2181,8 +2181,8 @@ ParlioDebugMetrics ParlioEngine::getDebugMetrics() const FL_NOEXCEPT {
         return metrics;
     }
 
-    // Execute memory barrier to ensure all ISR writes are visible
-    FL_MEMORY_BARRIER;
+    (void)mIsrContext->mStreamComplete.load(fl::memory_order_acquire);
+    (void)mIsrContext->mTransmitting.load(fl::memory_order_acquire);
 
     metrics.mStartTimeUs = 0; // Not tracked yet
     metrics.mEndTimeUs = mIsrContext->mEndTimeUs;
@@ -2196,9 +2196,10 @@ ParlioDebugMetrics ParlioEngine::getDebugMetrics() const FL_NOEXCEPT {
     metrics.mUnderrunCount = mIsrContext->mUnderrunCount;
     metrics.mRingCount = mIsrContext->mRingCount;
     metrics.mErrorCode = mErrorOccurred ? 1 : 0;
-    metrics.mRingError = mIsrContext->mRingError;
-    metrics.mHardwareIdle = mIsrContext->mHardwareIdle;
-    metrics.mTransmissionActive = mIsrContext->mTransmissionActive;
+    metrics.mRingError = mIsrContext->mRingError.load(fl::memory_order_acquire);
+    metrics.mHardwareIdle = mIsrContext->mHardwareIdle.load(fl::memory_order_acquire);
+    metrics.mTransmissionActive =
+        mIsrContext->mTransmissionActive.load(fl::memory_order_acquire);
 
     return metrics;
 }

--- a/src/platforms/esp/32/drivers/parlio/parlio_engine.h
+++ b/src/platforms/esp/32/drivers/parlio/parlio_engine.h
@@ -69,6 +69,7 @@
 #include "fl/channels/wave8.h"
 #include "fl/chipsets/led_timing.h"
 #include "fl/chipsets/chipset_timing_config.h"
+#include "fl/channels/driver.h"
 #include "fl/stl/span.h"
 #include "fl/stl/vector.h"
 #include "fl/stl/unique_ptr.h"
@@ -213,6 +214,9 @@ public:
     /// @brief Access the underlying peripheral (for time/delay delegation)
     IParlioPeripheral* peripheral() FL_NOEXCEPT { return mPeripheral; }
 
+    /// @brief Install the manager-owned poll-needed callback.
+    void setPollNeededCallback(IChannelDriver::PollNeededCallback callback) FL_NOEXCEPT;
+
 private:
     // Singleton pattern - allow Singleton<T> to construct instance
     friend class fl::Singleton<ParlioEngine>;
@@ -315,6 +319,9 @@ private:
 
     // Main task handle for transmission completion signaling (TaskHandle_t)
     void* mMainTaskHandle;
+
+    // Manager-owned callback signaled when ISR state changed and poll() should run.
+    IChannelDriver::PollNeededCallbackSlot mPollNeededCallback;
 
 #ifdef FL_DEBUG
     // Debug task for periodic ISR state logging (unified task API)

--- a/src/platforms/esp/32/drivers/parlio/parlio_isr_context.h
+++ b/src/platforms/esp/32/drivers/parlio/parlio_isr_context.h
@@ -40,8 +40,8 @@
 
 #include "fl/stl/compiler_control.h"
 
+#include "fl/stl/atomic.h"
 #include "fl/stl/isr/memcpy.h"
-#include "platforms/memory_barrier.h"
 #include "fl/stl/align.h"
 #include "fl/stl/noexcept.h"
 
@@ -55,30 +55,29 @@ namespace detail {
 /// @brief Cache-aligned ISR context for PARLIO transmission state
 ///
 /// Memory Synchronization Model:
-/// - ISR writes to volatile fields (mStreamComplete, mTransmitting, etc.)
-/// - Main thread reads volatile fields directly (compiler ensures fresh read)
-/// - After detecting mStreamComplete==true, main executes memory barrier
-/// - Memory barrier ensures all ISR writes visible before reading non-volatile fields
+/// - ISR writes completion flags with release ordering.
+/// - Main thread reads completion flags with acquire ordering.
+/// - Non-atomic counters are read after completion has been observed.
 struct FL_ALIGNAS(64) ParlioIsrContext {
-    // === Volatile Fields (ISR writes, main reads) ===
-    volatile bool mStreamComplete;
-    volatile bool mTransmitting;
+    // === ISR-shared fields (ISR writes, main reads) ===
+    fl::atomic_bool mStreamComplete;
+    fl::atomic_bool mTransmitting;
     volatile size_t mCurrentByte;
     volatile size_t mRingReadIdx;    // 0-2 (for 3-buffer ring)
     volatile size_t mRingWriteIdx;   // 0-2 (for 3-buffer ring)
     volatile size_t mRingCount;      // 0-3 (distinguishes full vs empty)
-    volatile bool mRingError;
-    volatile bool mHardwareIdle;
+    fl::atomic_bool mRingError;
+    fl::atomic_bool mHardwareIdle;
     volatile u32 mUnderrunCount;     // Ring emptied while source bytes remained
     volatile size_t mNextByteOffset; // Next byte offset in source data (Worker function updates)
 
-    // === Non-Volatile Fields (read after barrier only) ===
+    // === Fields read after completion has been observed ===
     size_t mTotalBytes;
     size_t mNumLanes;
     u32 mIsrCount;
     u32 mBytesTransmitted;
     u32 mChunksCompleted;
-    bool mTransmissionActive;
+    fl::atomic_bool mTransmissionActive;
     u64 mEndTimeUs;
 
     // === Debug Counters (volatile for ISR access) ===

--- a/src/platforms/esp/32/drivers/rmt/rmt_5/channel_driver_rmt.cpp.hpp
+++ b/src/platforms/esp/32/drivers/rmt/rmt_5/channel_driver_rmt.cpp.hpp
@@ -130,6 +130,7 @@ class ChannelEngineRMTImpl : public ChannelEngineRMT {
     // Testing constructor: Inject peripheral
     explicit ChannelEngineRMTImpl(IRMT5Peripheral& peripheral) FL_NOEXCEPT
         : mPeripheral(peripheral),
+          mPollNeededCallback(),
           mDMAChannelsInUse(0), mAllocationFailed(false),
           mMemoryReductionOffset(0),
           mConsecutiveAllocationFailures(0), mRecoveryWarningShown(false) {
@@ -251,7 +252,7 @@ class ChannelEngineRMTImpl : public ChannelEngineRMT {
             activeCount++;
             anyActive = true;
 
-            if (ch.transmissionComplete) {
+            if (ch.transmissionComplete.load(fl::memory_order_acquire)) {
                 completedCount++;
                 FL_LOG_RMT("Channel on pin " << ch.pin
                                              << " completed transmission");
@@ -308,14 +309,71 @@ class ChannelEngineRMTImpl : public ChannelEngineRMT {
         return state;
     }
 
+    void setPollNeededCallback(PollNeededCallback callback) FL_NOEXCEPT override {
+        mPollNeededCallback.set(callback);
+    }
+
   private:
     /// @brief RMT channel state (replaces RmtWorkerSimple)
     struct ChannelState {
+        ChannelState() FL_NOEXCEPT
+            : owner(nullptr),
+              channel(nullptr),
+              encoder(nullptr),
+              pin(0),
+              timing{},
+              transmissionComplete(false),
+              inUse(false),
+              useDMA(false),
+              reset_us(0),
+              pooledBuffer(),
+              memoryChannelId(0) {}
+
+        ChannelState(const ChannelState& other) FL_NOEXCEPT
+            : owner(other.owner),
+              channel(other.channel),
+              encoder(other.encoder),
+              pin(other.pin),
+              timing(other.timing),
+              transmissionComplete(other.transmissionComplete.load(fl::memory_order_acquire)),
+              inUse(other.inUse),
+              useDMA(other.useDMA),
+              reset_us(other.reset_us),
+              pooledBuffer(other.pooledBuffer),
+              memoryChannelId(other.memoryChannelId) {}
+
+        ChannelState& operator=(const ChannelState& other) FL_NOEXCEPT {
+            if (this != &other) {
+                owner = other.owner;
+                channel = other.channel;
+                encoder = other.encoder;
+                pin = other.pin;
+                timing = other.timing;
+                transmissionComplete.store(
+                    other.transmissionComplete.load(fl::memory_order_acquire),
+                    fl::memory_order_release);
+                inUse = other.inUse;
+                useDMA = other.useDMA;
+                reset_us = other.reset_us;
+                pooledBuffer = other.pooledBuffer;
+                memoryChannelId = other.memoryChannelId;
+            }
+            return *this;
+        }
+
+        ChannelState(ChannelState&& other) FL_NOEXCEPT
+            : ChannelState(static_cast<const ChannelState&>(other)) {}
+
+        ChannelState& operator=(ChannelState&& other) FL_NOEXCEPT {
+            return operator=(static_cast<const ChannelState&>(other));
+        }
+
+        ChannelEngineRMTImpl* owner;
         void* channel;  // Opaque channel handle (matches IRMT5Peripheral interface)
         void* encoder;  // Encoder handle from peripheral interface (prevents race conditions)
         int pin;        // GPIO pin number (platform-agnostic)
         ChipsetTiming timing;
-        volatile bool transmissionComplete;
+        fl::atomic_bool transmissionComplete;
         bool inUse;
         bool useDMA; // Whether this channel uses DMA
         u32 reset_us;
@@ -702,7 +760,7 @@ class ChannelEngineRMTImpl : public ChannelEngineRMT {
                 state->pin = pin;
                 state->timing = timing;
                 state->useDMA = true;
-                state->transmissionComplete = false;
+                state->transmissionComplete.store(false, fl::memory_order_release);
 
                 // Create encoder for this DMA channel
                 state->encoder = mPeripheral.createEncoder(timing, FASTLED_RMT5_CLOCK_HZ);
@@ -827,7 +885,7 @@ class ChannelEngineRMTImpl : public ChannelEngineRMT {
         state->pin = pin;
         state->timing = timing;
         state->useDMA = false; // Non-DMA channel
-        state->transmissionComplete = false;
+        state->transmissionComplete.store(false, fl::memory_order_release);
 
         // Create encoder for this channel
         state->encoder = mPeripheral.createEncoder(timing, FASTLED_RMT5_CLOCK_HZ);
@@ -974,7 +1032,7 @@ class ChannelEngineRMTImpl : public ChannelEngineRMT {
 
         // Update timing
         state->timing = timing;
-        state->transmissionComplete = false;
+        state->transmissionComplete.store(false, fl::memory_order_release);
     }
 
     /// @brief Process pending channels that couldn't be started earlier
@@ -1007,7 +1065,7 @@ class ChannelEngineRMTImpl : public ChannelEngineRMT {
 
             // Start transmission
             channel->reset_us = pending.reset_us;
-            channel->transmissionComplete = false;
+            channel->transmissionComplete.store(false, fl::memory_order_release);
 
             // Acquire buffer from pool (PSRAM -> DRAM/DMA transfer)
             // Note: dataSize already retrieved earlier for channel acquisition
@@ -1268,6 +1326,9 @@ class ChannelEngineRMTImpl : public ChannelEngineRMT {
     /// @brief Peripheral interface (real or mock)
     IRMT5Peripheral& mPeripheral;
 
+    /// @brief Manager-owned callback signaled from TX-done ISR.
+    PollNeededCallbackSlot mPollNeededCallback;
+
     /// @brief All RMT channels (active and idle)
     fl::vector_inlined<ChannelState, 16> mChannels;
 
@@ -1412,7 +1473,7 @@ void ChannelEngineRMTImpl::releaseChannel(ChannelState *channel) FL_NOEXCEPT {
     }
 
     channel->inUse = false;
-    channel->transmissionComplete = false;
+    channel->transmissionComplete.store(false, fl::memory_order_release);
 
     // NOTE: Removed GPIO reconfiguration to InputPulldown
     // This was breaking RMT's GPIO matrix routing on ESP32-S3.
@@ -1427,6 +1488,7 @@ bool ChannelEngineRMTImpl::registerChannelCallback(ChannelState *state) FL_NOEXC
     FL_ASSERT(state != nullptr, "registerChannelCallback called with nullptr");
     FL_ASSERT(state->channel != nullptr,
               "registerChannelCallback called with null channel");
+    state->owner = this;
 
     // Register transmission completion callback
     // CRITICAL: state pointer must be stable (not on stack, not subject to
@@ -1577,9 +1639,12 @@ bool IRAM_ATTR ChannelEngineRMTImpl::transmitDoneCallback(
 
     // Mark transmission as complete (polled by main thread)
     // NOTE: This flag triggers releaseChannel(), which performs hardware wait
-    state->transmissionComplete = true;
+    state->transmissionComplete.store(true, fl::memory_order_release);
+    if (state->owner != nullptr) {
+        state->owner->mPollNeededCallback.invoke();
+    }
 
-    // Non-blocking design - no semaphore signal needed
+    // Non-blocking design - the manager-owned callback performs any wakeup.
     return false; // No task switch needed
 }
 

--- a/src/platforms/esp/32/drivers/rmt/rmt_5/channel_driver_rmt.h
+++ b/src/platforms/esp/32/drivers/rmt/rmt_5/channel_driver_rmt.h
@@ -84,6 +84,8 @@ public:
      */
     virtual DriverState poll() FL_NOEXCEPT override = 0;
 
+    virtual void setPollNeededCallback(PollNeededCallback callback) FL_NOEXCEPT override = 0;
+
     /**
      * @brief Get the driver name for affinity binding
      * @return "RMT"

--- a/src/platforms/esp/32/semaphore_esp32.cpp.hpp
+++ b/src/platforms/esp/32/semaphore_esp32.cpp.hpp
@@ -18,6 +18,9 @@ FL_EXTERN_C_BEGIN
 // IWYU pragma: begin_keep
 #include "freertos/semphr.h"
 // IWYU pragma: end_keep
+// IWYU pragma: begin_keep
+#include "freertos/task.h"
+// IWYU pragma: end_keep
 FL_EXTERN_C_END
 
 // IWYU pragma: begin_keep
@@ -68,7 +71,16 @@ void CountingSemaphoreESP32<LeastMaxValue>::release(ptrdiff_t update) {
 
     // Release the semaphore 'update' times
     for (ptrdiff_t i = 0; i < update; ++i) {
-        BaseType_t result = xSemaphoreGive(handle);
+        BaseType_t result = pdFALSE;
+        if (xPortInIsrContext()) {
+            BaseType_t higherPriorityTaskWoken = pdFALSE;
+            result = xSemaphoreGiveFromISR(handle, &higherPriorityTaskWoken);
+            if (higherPriorityTaskWoken == pdTRUE) {
+                portYIELD_FROM_ISR();
+            }
+        } else {
+            result = xSemaphoreGive(handle);
+        }
 
         // If we fail to give, it means we would exceed the max value
         if (result != pdTRUE) {
@@ -105,6 +117,23 @@ bool CountingSemaphoreESP32<LeastMaxValue>::try_acquire() {
 }
 
 template<ptrdiff_t LeastMaxValue>
+bool CountingSemaphoreESP32<LeastMaxValue>::try_acquire_for_ms(fl::u32 timeout_ms) FL_NOEXCEPT {
+    if (mHandle == nullptr) {
+        return false;
+    }
+
+    TickType_t ticks = pdMS_TO_TICKS(timeout_ms);
+    if (timeout_ms > 0 && ticks == 0) {
+        ticks = 1;
+    }
+
+    SemaphoreHandle_t handle = static_cast<SemaphoreHandle_t>(mHandle);
+    BaseType_t result = xSemaphoreTake(handle, ticks);
+
+    return (result == pdTRUE);
+}
+
+template<ptrdiff_t LeastMaxValue>
 template<class Rep, class Period>
 bool CountingSemaphoreESP32<LeastMaxValue>::try_acquire_for(
     const std::chrono::duration<Rep, Period>& rel_time) {  // okay std namespace
@@ -115,7 +144,13 @@ bool CountingSemaphoreESP32<LeastMaxValue>::try_acquire_for(
 
     // Convert duration to FreeRTOS ticks
     auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(rel_time);  // okay std namespace
+    if (ms.count() <= 0) {
+        return try_acquire();
+    }
     TickType_t ticks = pdMS_TO_TICKS(ms.count());
+    if (ticks == 0) {
+        ticks = 1;
+    }
 
     SemaphoreHandle_t handle = static_cast<SemaphoreHandle_t>(mHandle);
     BaseType_t result = xSemaphoreTake(handle, ticks);

--- a/src/platforms/esp/32/semaphore_esp32.h
+++ b/src/platforms/esp/32/semaphore_esp32.h
@@ -12,6 +12,7 @@
 
 #include "fl/stl/assert.h"
 #include "fl/stl/cstddef.h"
+#include "fl/stl/int.h"
 
 // CRITICAL: Include <chrono> BEFORE opening namespace to avoid polluting std::
 // IWYU pragma: begin_keep
@@ -57,6 +58,8 @@ public:
     CountingSemaphoreESP32& operator=(CountingSemaphoreESP32&&) = delete;
 
     /// @brief Increment the semaphore count by update
+    /// @note On ESP32 this is ISR-aware and uses xSemaphoreGiveFromISR()
+    ///       plus portYIELD_FROM_ISR() when called from interrupt context.
     /// @param update Number to add to the count (default 1)
     void release(ptrdiff_t update = 1) FL_NOEXCEPT;
 
@@ -74,6 +77,9 @@ public:
     /// @return true if acquired within timeout, false otherwise
     template<class Rep, class Period>
     bool try_acquire_for(const std::chrono::duration<Rep, Period>& rel_time) FL_NOEXCEPT;  // okay std namespace
+
+    /// @brief Try to acquire with a millisecond timeout.
+    bool try_acquire_for_ms(fl::u32 timeout_ms) FL_NOEXCEPT;
 
     /// @brief Try to acquire until an absolute time point
     /// @tparam Clock Clock type

--- a/src/platforms/esp/32/watchdog_esp32.cpp.hpp
+++ b/src/platforms/esp/32/watchdog_esp32.cpp.hpp
@@ -9,9 +9,9 @@
 // This implementation fixes this by overriding the panic handler to perform a safe
 // USB disconnect sequence before reset.
 //
-// Provides a configurable proof-of-life watchdog that automatically monitors
-// the Arduino loop() task. No manual feeding required - the ESP32 framework
-// handles watchdog feeding automatically as long as loop() keeps executing.
+// Provides a configurable proof-of-life watchdog. The unified Watchdog wrapper
+// subscribes and feeds the Arduino loop task explicitly; the ESP32 backend also
+// keeps idle-task monitoring active so CPU starvation is still caught.
 //
 // This file dispatches to IDF version-specific implementations:
 // - watchdog_esp32_idf4.hpp: ESP-IDF v4.x (weak symbol override)

--- a/src/platforms/esp/32/watchdog_esp32.h
+++ b/src/platforms/esp/32/watchdog_esp32.h
@@ -4,18 +4,20 @@
 //
 // This header provides a simple watchdog timer interface for detecting
 // when the main loop hangs or stops executing. Uses the ESP32 task watchdog
-// framework which automatically monitors the main loop task.
+// framework. The unified Watchdog wrapper subscribes the calling Arduino loop
+// task and feeds it explicitly, while the ESP backend also keeps idle-task
+// monitoring active for CPU-starvation detection.
 //
 // USAGE:
 // - Call fl::watchdog_setup() once in setup()
-// - Watchdog automatically monitors loop() execution (no manual feeding needed)
+// - Watchdog monitors loop() execution through FastLED.watchdog().feed()
 // - If loop() hangs for timeout duration, watchdog triggers safe reset
 // - Safe reset includes USB disconnect to prevent phantom devices
 // - Optionally provide a callback function to execute before reset
 //
 // PLATFORM SUPPORT:
 // - ESP32 family: Full watchdog implementation with configurable timeout
-// - Automatically feeds watchdog via idle task monitoring (no manual calls needed)
+// - The unified fl::Watchdog wrapper feeds the subscribed loop task explicitly.
 
 #pragma once
 
@@ -37,7 +39,7 @@ typedef void (*watchdog_callback_t)(void* user_data);
 /// @param callback Optional callback function to execute when watchdog fires (default: nullptr)
 /// @param user_data Optional user data pointer passed to callback (default: nullptr)
 /// @note ESP32: Installs watchdog that monitors loop() task execution
-/// @note Watchdog automatically fed by ESP32 framework - no manual feeding needed
+/// @note Use FastLED.watchdog().feed() or FL_WATCHDOG_AUTO() to reset the subscribed loop task
 /// @note On timeout: Calls user callback (if provided), prints message, disconnects USB, then resets
 /// @note Callback executes in ISR context - keep it simple and avoid logging functions
 void watchdog_setup(u32 timeout_ms = 5000,

--- a/src/platforms/esp/32/watchdog_esp32.impl.hpp
+++ b/src/platforms/esp/32/watchdog_esp32.impl.hpp
@@ -22,10 +22,13 @@
 #include "fl/wdt/watchdog.h"
 #include "platforms/esp/32/watchdog_esp32.h"
 
-extern "C" {
-#include "esp_system.h"   // esp_reset_reason()
 #include "esp_idf_version.h"
-}
+#include "esp_system.h"   // esp_reset_reason()
+#include "esp_task_wdt.h"
+// IWYU pragma: begin_keep
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+// IWYU pragma: end_keep
 
 #define FL_WATCHDOG_HAS_HARDWARE
 #define FL_WATCHDOG_PERSIST_BYTES 16
@@ -50,6 +53,8 @@ struct Esp32WatchdogState {
     fl::u8     persist[FL_WATCHDOG_PERSIST_BYTES] = {0};
     bool       armed = false;
     fl::u32    armed_timeout_ms = 0;
+    void*      monitored_task = nullptr;  // TaskHandle_t; stored as void* to keep this state POD-like.
+    bool       monitored_task_added = false;
     ResetCause cached_cause = ResetCause::UNKNOWN;
     bool       cause_cached = false;
 
@@ -85,6 +90,82 @@ inline ResetCause translateEsp32ResetReason(esp_reset_reason_t r) {
     }
 }
 
+inline TaskHandle_t esp32MonitoredTask() {
+    return static_cast<TaskHandle_t>(esp32WatchdogState().monitored_task);
+}
+
+inline bool esp32SubscribeCurrentTask() {
+    if (xTaskGetSchedulerState() != taskSCHEDULER_RUNNING) {
+        return false;
+    }
+
+    TaskHandle_t current_task = xTaskGetCurrentTaskHandle();
+    if (current_task == nullptr) {
+        return false;
+    }
+
+    auto& s = esp32WatchdogState();
+    if (s.monitored_task == current_task && s.monitored_task != nullptr) {
+        (void)esp_task_wdt_reset();
+        return true;
+    }
+
+    if (s.monitored_task != nullptr && s.monitored_task_added) {
+        (void)esp_task_wdt_delete(esp32MonitoredTask());
+    }
+    s.monitored_task = nullptr;
+    s.monitored_task_added = false;
+
+    esp_err_t status = esp_task_wdt_status(current_task);
+    if (status == ESP_OK) {
+        s.monitored_task = current_task;
+        s.monitored_task_added = false;
+        (void)esp_task_wdt_reset();
+        return true;
+    }
+
+    if (status == ESP_ERR_INVALID_STATE) {
+        return false;
+    }
+
+    esp_err_t err = esp_task_wdt_add(current_task);
+    if (err != ESP_OK) {
+        return false;
+    }
+
+    s.monitored_task = current_task;
+    s.monitored_task_added = true;
+    (void)esp_task_wdt_reset();
+    return true;
+}
+
+inline void esp32ResetMonitoredTask() {
+    auto& s = esp32WatchdogState();
+    if (!s.armed || s.monitored_task == nullptr) {
+        return;
+    }
+    if (xTaskGetSchedulerState() != taskSCHEDULER_RUNNING) {
+        return;
+    }
+    if (xTaskGetCurrentTaskHandle() != esp32MonitoredTask()) {
+        return;
+    }
+    (void)esp_task_wdt_reset();
+}
+
+inline bool esp32UnsubscribeMonitoredTask() {
+    auto& s = esp32WatchdogState();
+    if (s.monitored_task != nullptr && s.monitored_task_added) {
+        esp_err_t err = esp_task_wdt_delete(esp32MonitoredTask());
+        if (err != ESP_OK && err != ESP_ERR_INVALID_STATE) {
+            return false;
+        }
+    }
+    s.monitored_task = nullptr;
+    s.monitored_task_added = false;
+    return true;
+}
+
 } // namespace platforms
 
 // `Watchdog::instance()` is defined here (and in every sibling `.impl.hpp` /
@@ -102,12 +183,12 @@ void Watchdog::begin(fl::u32 timeout_ms) FL_NOEXCEPT {
     auto& s = platforms::esp32WatchdogState();
     s.armed_timeout_ms = timeout_ms;
     fl::watchdog_setup(timeout_ms);
+    (void)platforms::esp32SubscribeCurrentTask();
     s.armed = true;
 }
 
 void Watchdog::feed() FL_NOEXCEPT {
-    // ESP32 framework auto-feeds via idle-task monitoring (see watchdog_esp32_idf{4,5}.hpp).
-    // No-op here; loop() liveness alone keeps the TWDT happy.
+    platforms::esp32ResetMonitoredTask();
 }
 
 void Watchdog::disable() FL_NOEXCEPT {
@@ -121,6 +202,7 @@ void Watchdog::disable() FL_NOEXCEPT {
     // can reason about its prior state.
     auto& s = platforms::esp32WatchdogState();
     if (fl::watchdog_disable()) {
+        (void)platforms::esp32UnsubscribeMonitoredTask();
         s.armed = false;
         s.armed_timeout_ms = 0;
     }
@@ -186,6 +268,7 @@ bool Watchdog::onTimeout(WatchdogTimeoutCallback cb, void* user_data) FL_NOEXCEP
     auto& s = platforms::esp32WatchdogState();
     fl::u32 timeout_ms = s.armed_timeout_ms != 0 ? s.armed_timeout_ms : 5000u;
     fl::watchdog_setup(timeout_ms, cb, user_data);
+    (void)platforms::esp32SubscribeCurrentTask();
     s.armed = true;
     s.armed_timeout_ms = timeout_ms;
     return true;

--- a/src/platforms/esp/32/watchdog_esp32_idf4.hpp
+++ b/src/platforms/esp/32/watchdog_esp32_idf4.hpp
@@ -134,6 +134,9 @@ bool init_task_watchdog(u32 timeout_ms) FL_NOEXCEPT {
     u32 timeout_s = (timeout_ms + 999) / 1000;  // Round up to nearest second
 
     esp_err_t err = esp_task_wdt_init(timeout_s, true);  // true = trigger panic on timeout
+    if (err == ESP_ERR_INVALID_STATE) {
+        err = ESP_OK;  // Already armed; keep the existing IDF4 timeout.
+    }
     if (err != ESP_OK) {
         FL_DBG("[WATCHDOG] Failed to initialize (error: " << err << ")");
         return false;
@@ -148,7 +151,7 @@ void log_watchdog_status(u32 timeout_ms, watchdog_callback_t callback) FL_NOEXCE
     if (callback != nullptr) {
         FL_DBG("[WATCHDOG] ℹ️  User callback registered");
     }
-    FL_DBG("[WATCHDOG] ℹ️  Automatically monitors loop() execution - no manual feeding needed");
+    FL_DBG("[WATCHDOG] Monitors the loop task plus idle-task CPU starvation");
 }
 
 } // anonymous namespace

--- a/src/platforms/esp/32/watchdog_esp32_idf5.hpp
+++ b/src/platforms/esp/32/watchdog_esp32_idf5.hpp
@@ -135,11 +135,14 @@ bool deinit_existing_watchdog() FL_NOEXCEPT {
 bool init_task_watchdog(u32 timeout_ms) FL_NOEXCEPT {
     esp_task_wdt_config_t config = {
         .timeout_ms = timeout_ms,
-        .idle_core_mask = (1 << 0),  // Monitor idle task on core 0 (main loop)
+        .idle_core_mask = (1 << 0),  // Also monitor CPU starvation via the idle task.
         .trigger_panic = true         // Trigger panic and reset on timeout
     };
 
     esp_err_t err = esp_task_wdt_init(&config);
+    if (err == ESP_ERR_INVALID_STATE) {
+        err = esp_task_wdt_reconfigure(&config);
+    }
     if (err != ESP_OK) {
         FL_DBG("[WATCHDOG] Failed to initialize (error: " << err << ")");
         return false;
@@ -154,7 +157,7 @@ void log_watchdog_status(u32 timeout_ms, watchdog_callback_t callback) FL_NOEXCE
     if (callback != nullptr) {
         FL_DBG("[WATCHDOG] ℹ️  User callback registered");
     }
-    FL_DBG("[WATCHDOG] ℹ️  Automatically monitors loop() execution - no manual feeding needed");
+    FL_DBG("[WATCHDOG] Monitors the loop task plus idle-task CPU starvation");
 }
 
 

--- a/src/platforms/shared/atomic.h
+++ b/src/platforms/shared/atomic.h
@@ -50,6 +50,11 @@ public:
         __atomic_store_n(&mValue, value, order);
     }
 
+    // Exchange operation - atomically replaces the value and returns the old value
+    T exchange(T value, int order = memory_order_acq_rel) FL_NOEXCEPT {
+        return __atomic_exchange_n(&mValue, value, order);
+    }
+
     // Pre-increment: ++atomic
     // Returns the NEW value after increment
     T operator++() {

--- a/src/platforms/shared/channel_poll_signal.h
+++ b/src/platforms/shared/channel_poll_signal.h
@@ -1,0 +1,30 @@
+// ok no namespace fl
+#pragma once
+
+/// @file platforms/shared/channel_poll_signal.h
+/// @brief Fallback channel-manager poll wake signal.
+
+#include "fl/stl/atomic.h"
+#include "fl/stl/int.h"
+#include "fl/stl/noexcept.h"
+
+namespace fl {
+namespace platforms {
+
+class ChannelPollSignal {
+  public:
+    ChannelPollSignal() FL_NOEXCEPT : mPending(false) {}
+
+    void notify() FL_NOEXCEPT { mPending.store(true); }
+
+    bool wait(fl::u32 timeoutMs) FL_NOEXCEPT {
+        (void)timeoutMs;
+        return mPending.exchange(false);
+    }
+
+  private:
+    fl::atomic_bool mPending;
+};
+
+} // namespace platforms
+} // namespace fl


### PR DESCRIPTION
## Summary

Fixes #2991.

This adds `IChannelDriver::PollNeededCallback` and `setPollNeededCallback()` so a driver ISR can wake the channel manager when driver state changed and `poll()` should run again. The callback is intentionally not a done callback: a driver may signal that a chunk, batch, or transfer changed state while more inter-batch work remains on the main thread.

`PollNeededCallback` is now an ISR-safe function/context handle, with `PollNeededCallbackSlot` providing atomic task-to-ISR publication for drivers that invoke the callback from interrupt context. This avoids storing or mutating `fl::function` on the ISR boundary.

`ChannelManager` owns the single poll-needed wait primitive. The manager talks only to `platforms::ChannelPollSignal`, so the channel-manager code has no ESP-specific semaphore guards or drain loops. On ESP32, the platform implementation uses `fl::binary_semaphore`; drivers only receive the callback. If no driver invokes the callback, the manager still wakes on bounded 1 ms timeout slices and polls, so no separate capability gate or per-driver semaphore is needed.

The ESP32 `fl::binary_semaphore` release path is now ISR-aware: it detects ISR context, uses `xSemaphoreGiveFromISR()`, and calls `portYIELD_FROM_ISR()` when a higher-priority task should run. That lets ESP wake the main loop task at the next scheduling opportunity while keeping the channel manager code normalized around a platform wait abstraction.

The PR also adds an AutoResearch `--tight-timing` metric for `FastLED.show(); FastLED.wait()` overhead, enables ESP32-S3 USB CDC for AutoResearch RPC, temporarily raises ESP32-S3/C6 Arduino loop stack size for the deeper AutoResearch driver setup path, and makes the ESP watchdog subscribe/feed the loop task so hung autotest firmware resets instead of wedging the board.

## Verification

- `git diff --check`
- touched-file C++ lint for channel manager/driver changes, platform poll signal dispatch, ESP RMT/I2S/LCD/PARLIO callback changes, ESP semaphore, ESP watchdog, shared atomic, and AutoResearch C++ changes
- `uv run python -m compileall ci/autoresearch/phases.py`
- `uv run pytest ci/tests/test_no_include_after_namespace.py -q`
- `uv run python -m ci.lint_cpp.run_all_checkers src/platforms/esp/32/watchdog_esp32.impl.hpp`
- `uv run python -m compileall ci/boards.py ci/autoresearch/args.py ci/autoresearch/phases.py ci/autoresearch/context.py`
- `uv run python -m ci.autoresearch --help`
- `bash test watchdog`
- `bash compile esp32s3 --examples AutoResearch --platformio`
- `bash compile esp32c6 --examples AutoResearch --platformio`
- Hardware: ESP32-C6 PARLIO tight timing passed, max overhead 1266 us with 2000 us limit
- Hardware: ESP32-C6 RMT tight timing passed, max overhead 296 us with 2000 us limit
- Hardware: ESP32-S3 RMT tight timing passed, max overhead 516 us with 2000 us limit
- Hardware: ESP32-S3 I2S tight timing passed, max overhead 1503 us with 2000 us limit
- Hardware: ESP32-C6 deliberate AutoResearch hang reset via watchdog and resumed RPC after reboot

## Notes

The wait-state bus should already be resolved before this path; `Bus::AUTO` must not be represented in any future bus-mask wait state. If a bus mask is added later, use a resolved bus value only.

The `-DARDUINO_LOOP_STACK_SIZE=16384` override is temporary. Follow-up issue #2993 tracks investigating the ESP AutoResearch stack growth and reverting back to stock Arduino loop stack settings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * AutoResearch now includes a "Tight Timing Metric" option to measure LED timing overhead and performance characteristics across iterations.

* **Bug Fixes**
  * Enhanced ESP32 watchdog robustness with explicit loop task monitoring and recovery mechanisms.

* **Chores**
  * Updated ESP32 board build configurations for improved USB and memory management.
  * Improved internal driver coordination for better responsiveness and ISR safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->