### PR TITLE
fix: lpc lint compliance + purge stale PCH after zccache meson snapshot restore

### DIFF
--- a/ci/meson/meson_setup_execute.py
+++ b/ci/meson/meson_setup_execute.py
@@ -545,6 +545,39 @@ def build_meson_setup_cmd(
     return cmd
 
 
+_ZCCACHE_MESON_HIT_MARKER = "[zccache-meson] hit"
+_PCH_ARTIFACT_SUFFIXES = (".pch", ".pch.input_hash", ".d.cache")
+
+
+def _purge_restored_pch_artifacts(build_dir: Path) -> None:
+    """Delete PCH binaries and their compile_pch.py sidecars from build_dir.
+
+    zccache meson snapshots capture the whole build dir (zackees/zccache#710),
+    so a restore can resurrect a stale clang PCH whose embedded file identities
+    silently defeat ``#pragma once`` dedup — along with the ``.input_hash`` /
+    ``.d.cache`` sidecars that make ``compile_pch.py`` skip rebuilding it
+    forever. Purging after a snapshot hit forces a fresh PCH compile.
+    """
+    removed = 0
+    for root, _dirs, files in os.walk(build_dir):
+        for name in files:
+            if name.endswith(_PCH_ARTIFACT_SUFFIXES):
+                path = Path(root) / name
+                try:
+                    path.unlink()
+                    removed += 1
+                except OSError as e:
+                    _ts_print(
+                        f"[MESON] Warning: could not delete {path}: {e}",
+                        file=sys.stderr,
+                    )
+    if removed:
+        _ts_print(
+            f"[MESON] Purged {removed} PCH artifact(s) restored by zccache "
+            f"meson snapshot (zackees/zccache#710)"
+        )
+
+
 def run_meson_setup_command(
     *,
     cmd: list[str],
@@ -614,6 +647,9 @@ def run_meson_setup_command(
             return False
 
         _ts_print("[MESON] Setup successful")
+
+        if _ZCCACHE_MESON_HIT_MARKER in stdout:
+            _purge_restored_pch_artifacts(build_dir)
 
         _write_configuration_markers(
             build_mode_marker=markers.build_mode,

--- a/src/platforms/arm/lpc/io_lpc.cpp.hpp
+++ b/src/platforms/arm/lpc/io_lpc.cpp.hpp
@@ -9,6 +9,7 @@
 #include "fl/stl/cstddef.h"
 #include "fl/stl/noexcept.h"
 #include "fl/stl/stdint.h"
+#include "platforms/arm/is_arm.h"
 #include "platforms/io.h"
 
 namespace fl {

--- a/src/platforms/arm/lpc/runtime_lpc.cpp.hpp
+++ b/src/platforms/arm/lpc/runtime_lpc.cpp.hpp
@@ -2,6 +2,8 @@
 
 // IWYU pragma: private
 
+// ok no namespace fl
+
 #include "platforms/arm/lpc/is_lpc.h"
 
 #ifdef FL_IS_ARM_LPC
@@ -9,6 +11,7 @@
 #include "fl/stl/cstddef.h"
 #include "fl/stl/compiler_control.h"
 #include "fl/stl/noexcept.h"
+#include "platforms/arm/is_arm.h"
 
 extern "C" {
 FL_LINK_WEAK void* __dso_handle;


### PR DESCRIPTION
## Summary

- **lpc lint fixes**: `io_lpc.cpp.hpp` / `runtime_lpc.cpp.hpp` used `FL_IS_ARM_LPC` in preprocessor conditionals without including `platforms/arm/is_arm.h` (IsHeaderIncludeChecker); `runtime_lpc.cpp.hpp` also gets the `// ok no namespace fl` opt-out since global `operator delete` overrides and `extern "C"` runtime symbols cannot live in a namespace (PlatformsFlNamespaceChecker).
- **zccache PCH guard**: `zccache meson configure` snapshots capture the entire build dir — including compiled clang PCHs and the `compile_pch.py` skip-cache sidecars (zackees/zccache#710). Restoring such a snapshot into a clean build dir resurrects a stale PCH whose embedded file identities silently defeat `#pragma once` dedup, producing `redefinition of 'IChannelDriver'`-style errors in every PCH-consuming test TU, and the restored `.input_hash`/`.d.cache` sidecars prevent the PCH from ever rebuilding. `run_meson_setup_command()` now purges `*.pch` / `*.pch.input_hash` / `*.d.cache` from the build dir whenever the setup output reports a `[zccache-meson] hit`, forcing a fresh PCH compile against the live tree. Belt-and-suspenders until zccache#710 lands.

## Test plan

- [x] `bash lint` clean (previously failed on the two lpc files)
- [x] `bash test --cpp` — 310/310 tests pass
- [x] Purge helper smoke-tested: deletes exactly `*.pch`/`*.pch.input_hash`/`*.d.cache`, leaves `.obj`, `build.ninja`, and `test_pch.h` sources untouched
- [ ] Next `[zccache-meson] hit` on a fresh build dir should log `[MESON] Purged N PCH artifact(s)...` and rebuild the PCH

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build system cleanup logic to handle stale build artifacts.
  * Updated platform-specific include dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->