### PR TITLE
feat(lpc): LPC845 Arduino serial I/O + pin dispatch (supersedes #2996)

### DIFF
--- a/src/FastLED.cpp.hpp
+++ b/src/FastLED.cpp.hpp
@@ -689,7 +689,7 @@ fl::RxChannelPtr CFastLED::addRx(const fl::RxChannelConfig& config) {
 #ifdef NEED_CXX_BITS
 namespace __cxxabiv1
 {
-	#if !defined(FL_IS_ESP8266) && !defined(FL_IS_ESP32)
+	#if !defined(FL_IS_ESP8266) && !defined(FL_IS_ESP32) && !defined(ARDUINO)
 	extern "C" void __cxa_pure_virtual (void) {}
 	#endif
 

--- a/src/platforms/arm/lpc/io_lpc.cpp.hpp
+++ b/src/platforms/arm/lpc/io_lpc.cpp.hpp
@@ -17,6 +17,8 @@
 // readStringUntil(), so readLineNative() is implemented by hand below.
 // IWYU pragma: begin_keep
 #include "fl/system/arduino.h"
+#include "fl/system/yield.h"
+#include "fl/stl/chrono.h"
 // IWYU pragma: end_keep
 #endif
 
@@ -57,14 +59,14 @@ int readLineNative(char delimiter, char* out, int outLen) FL_NOEXCEPT {
         return 0;
     }
     const unsigned long timeoutMs = 1000UL;
-    unsigned long start = millis();
+    unsigned long start = fl::millis();
     int len = 0;
     while (true) {
         if (!Serial.available()) {
-            if (millis() - start >= timeoutMs) {
+            if (fl::millis() - start >= timeoutMs) {
                 break;
             }
-            yield();
+            fl::yield();
             continue;
         }
         const int value = Serial.read();
@@ -78,7 +80,7 @@ int readLineNative(char delimiter, char* out, int outLen) FL_NOEXCEPT {
         if (len < outLen - 1) {
             out[len++] = c;
         }
-        start = millis();
+        start = fl::millis();
     }
     out[len] = '\0';
     return len;

--- a/src/platforms/arm/lpc/io_lpc.cpp.hpp
+++ b/src/platforms/arm/lpc/io_lpc.cpp.hpp
@@ -12,8 +12,99 @@
 #include "platforms/arm/is_arm.h"
 #include "platforms/io.h"
 
+#if defined(ARDUINO)
+// LPC Arduino core exposes the standard Serial API. LPC's HardwareSerial lacks
+// readStringUntil(), so readLineNative() is implemented by hand below.
+// IWYU pragma: begin_keep
+#include "fl/system/arduino.h"
+// IWYU pragma: end_keep
+#endif
+
 namespace fl {
 namespace platforms {
+
+#if defined(ARDUINO)
+
+void begin(u32 baudRate) FL_NOEXCEPT {
+    Serial.begin(baudRate);
+}
+
+void print(const char* str) FL_NOEXCEPT {
+    if (!Serial) return;
+    Serial.print(str);
+}
+
+void println(const char* str) FL_NOEXCEPT {
+    if (!Serial) return;
+    Serial.println(str);
+}
+
+int available() FL_NOEXCEPT {
+    return Serial.available();
+}
+
+int peek() FL_NOEXCEPT {
+    return Serial.peek();
+}
+
+int read() FL_NOEXCEPT {
+    return Serial.read();
+}
+
+// LPC's HardwareSerial lacks readStringUntil(), so read the line manually.
+int readLineNative(char delimiter, char* out, int outLen) FL_NOEXCEPT {
+    if (outLen <= 0) {
+        return 0;
+    }
+    const unsigned long timeoutMs = 1000UL;
+    unsigned long start = millis();
+    int len = 0;
+    while (true) {
+        if (!Serial.available()) {
+            if (millis() - start >= timeoutMs) {
+                break;
+            }
+            yield();
+            continue;
+        }
+        const int value = Serial.read();
+        if (value < 0) {
+            break;
+        }
+        const char c = static_cast<char>(value);
+        if (c == delimiter) {
+            break;
+        }
+        if (len < outLen - 1) {
+            out[len++] = c;
+        }
+        start = millis();
+    }
+    out[len] = '\0';
+    return len;
+}
+
+bool flush(u32 timeoutMs) FL_NOEXCEPT {
+    (void)timeoutMs;
+    if (!Serial) return true;
+    Serial.flush();
+    return true;
+}
+
+size_t write_bytes(const u8* buffer, size_t size) FL_NOEXCEPT {
+    if (!Serial) return 0;
+    return Serial.write(buffer, size);
+}
+
+bool serial_ready() FL_NOEXCEPT {
+    return Serial ? true : false;
+}
+
+bool serial_is_buffered() FL_NOEXCEPT {
+    return true;  // LPC Arduino uses buffered UART
+}
+
+#else  // bare-metal: no Serial available yet
 
 void begin(u32 baudRate) FL_NOEXCEPT {
     (void)baudRate;
@@ -64,6 +155,8 @@ bool serial_ready() FL_NOEXCEPT {
 bool serial_is_buffered() FL_NOEXCEPT {
     return false;
 }
+
+#endif  // ARDUINO
 
 }  // namespace platforms
 }  // namespace fl

--- a/src/platforms/esp/32/channel_poll_signal_esp32.h
+++ b/src/platforms/esp/32/channel_poll_signal_esp32.h
@@ -1,5 +1,7 @@
 #pragma once
 
+// IWYU pragma: private
+
 /// @file platforms/esp/32/channel_poll_signal_esp32.h
 /// @brief ESP32 channel-manager poll wake signal.
 

--- a/src/platforms/pin.h
+++ b/src/platforms/pin.h
@@ -41,9 +41,6 @@
     #include "platforms/arm/silabs/pin_silabs.hpp"
 #elif defined(FL_IS_APOLLO3)
     #include "platforms/apollo3/pin_apollo3.hpp"
-#elif defined(FL_LPC845) || defined(FL_LPC804) || defined(FL_LPC11_USB) || defined(FL_LPC15) || defined(FL_LPC11_LEGACY)
-    // LPC platform uses fastpin (no pin management needed for now)
-    #include "platforms/shared/pin_noop.hpp"
 #elif defined(FL_IS_STUB)
     // Stub platform for testing — tracks pin state via fl::stub::setPinState
     #include "platforms/stub/pin_stub.hpp"

--- a/src/platforms/pin.h
+++ b/src/platforms/pin.h
@@ -41,6 +41,9 @@
     #include "platforms/arm/silabs/pin_silabs.hpp"
 #elif defined(FL_IS_APOLLO3)
     #include "platforms/apollo3/pin_apollo3.hpp"
+#elif defined(FL_LPC845) || defined(FL_LPC804) || defined(FL_LPC11_USB) || defined(FL_LPC15) || defined(FL_LPC11_LEGACY)
+    // LPC platform uses fastpin (no pin management needed for now)
+    #include "platforms/shared/pin_noop.hpp"
 #elif defined(FL_IS_STUB)
     // Stub platform for testing — tracks pin state via fl::stub::setPinState
     #include "platforms/stub/pin_stub.hpp"

--- a/src/platforms/shared/channel_poll_signal.h
+++ b/src/platforms/shared/channel_poll_signal.h
@@ -1,6 +1,8 @@
 // ok no namespace fl
 #pragma once
 
+// IWYU pragma: private
+
 /// @file platforms/shared/channel_poll_signal.h
 /// @brief Fallback channel-manager poll wake signal.
 


### PR DESCRIPTION
Supersedes #2996.

Rebases the **core `src/` changes** from @phatpaul's WIP PR #2996 onto current `master`, which has since absorbed most of the LPC port (bare-metal support in #2989/#2992/#2995). Original commit authorship preserved.

## What changed vs #2996
Most of #2996's `src/` edits were already merged into `master` in a more complete form (clockless driver, `led_sysdefs`, unity build). What remains genuinely additive:

- **`io_lpc.cpp.hpp`** — adds the Arduino `Serial`-backed I/O implementation under `#if defined(ARDUINO)`, while **preserving master's bare-metal stub path** for non-Arduino builds (so #2989's bare-metal support is not regressed).
- **`pin.h`** — routes LPC parts (LPC845/804/11U/15/11-legacy) to `platforms/shared/pin_noop.hpp`.
- **`FastLED.cpp.hpp`** — skips the `__cxa_pure_virtual` definition under `ARDUINO` (the Arduino core already provides it).

## Dropped from #2996
- The `examples/BlinkLPC845Arduino/` and `examples/BlinkLPC845CMSIS/` sketches (kept out of the example/CI matrix per project policy).
- A duplicate `#include "fastspi_types.h"` in `spi_arm_lpc.h` and a commented-out unused-variable block in the shared `m0clockless_c.h` — both noise that's unnecessary against current master.

## Also included
- `fix(lint)`: added the missing `// IWYU pragma: private` to two pre-existing channel_poll_signal headers that were failing `bash lint --cpp` on master.

## Notes
Per #2996, Serial on real hardware was still WIP at the time. This PR keeps the implementation compile-gated to Arduino LPC builds and does not touch the native test path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Paul Abbott <phatpaul@gmail.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced Arduino platform support for LPC I/O operations, enabling Serial communication for read, write, and buffered operations with line reading and timeout handling.

* **Refactor**
  * Refined platform code organization and expanded ABI guard conditions for improved cross-platform compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->