### PR TITLE
chore(deps): bump zccache floor to >=1.12.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,7 +117,7 @@ dependencies = [
     # incremental builds produce stale .obj files after a git pull that
     # changes transitive headers (symptom: `undefined symbol: ...` link
     # errors hours after a header actually changed).
-    "zccache>=1.11.20",
+    "zccache>=1.12.0",
     "ninja",
     "meson>=1.11.0",
     "download",


### PR DESCRIPTION
## Summary
- Bump the `zccache` floor `>=1.11.20` -> `>=1.12.0`.

1.12.0 is the release that adopts the running-process v1 broker. Aligning every zccache consumer (FastLED, fbuild, soldr, clang-tool-chain) on this floor keeps them on one protocol-compatible daemon and removes the version-skew conflict.

## Test plan
- [ ] CI green (installs zccache 1.12.0 from PyPI)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated zccache dependency to version 1.12.0 or higher.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->