### PR TITLE
fix(autoresearch): exercise both ObjectFLED and FlexIO on Teensy 4.x

### DIFF
--- a/ci/autoresearch/args.py
+++ b/ci/autoresearch/args.py
@@ -22,6 +22,7 @@ class Args:
     lcd_spi: bool
     lcd_rgb: bool
     object_fled: bool
+    flex_io: bool
     all: bool
     simd: bool
     coroutine: bool
@@ -232,9 +233,14 @@ See Also:
             help="Test only ObjectFLED DMA driver (Teensy 4.x only)",
         )
         driver_group.add_argument(
+            "--flex-io",
+            action="store_true",
+            help="Test only FlexIO clockless driver (Teensy 4.x only; requires --tx-pin in {6-13,32})",
+        )
+        driver_group.add_argument(
             "--all",
             action="store_true",
-            help="Test all drivers (equivalent to --parlio --rmt --spi --uart --lcd --lcd-spi --lcd-rgb --object-fled)",
+            help="Test all drivers (equivalent to --parlio --rmt --spi --uart --lcd --lcd-spi --lcd-rgb --object-fled --flex-io)",
         )
         driver_group.add_argument(
             "--simd",
@@ -547,6 +553,7 @@ See Also:
             lcd_spi=parsed.lcd_spi,
             lcd_rgb=parsed.lcd_rgb,
             object_fled=parsed.object_fled,
+            flex_io=parsed.flex_io,
             all=parsed.all,
             simd=parsed.simd,
             coroutine=parsed.coroutine,

--- a/ci/autoresearch/phases.py
+++ b/ci/autoresearch/phases.py
@@ -207,7 +207,8 @@ def _parse_args_and_build_commands(args: Args) -> RunContext | int:
             "LCD_CLOCKLESS",
             "LCD_SPI",
             "LCD_RGB",
-            "OBJECTFLED",
+            "OBJECT_FLED",
+            "FLEX_IO",
         ]
     else:
         if args.parlio:
@@ -225,7 +226,9 @@ def _parse_args_and_build_commands(args: Args) -> RunContext | int:
         if args.lcd_rgb:
             drivers.append("LCD_RGB")
         if args.object_fled:
-            drivers.append("OBJECTFLED")
+            drivers.append("OBJECT_FLED")
+        if args.flex_io:
+            drivers.append("FLEX_IO")
 
     parallel_mode = args.parallel
     if parallel_mode:
@@ -507,6 +510,11 @@ def _parse_args_and_build_commands(args: Args) -> RunContext | int:
             f"({len(drivers_list)} drivers \u00d7 {lane_range['max'] - lane_range['min'] + 1} lane count(s) \u00d7 {len(strip_sizes)} strip size(s))"
         )
     else:
+        # FlexIO on Teensy 4.x only routes through pins {6-13, 32}; the global
+        # default TX pin (1) is not FlexIO2-capable so canHandle() rejects it
+        # and the manager silently falls back to ObjectFLED. Pin the FLEX_IO
+        # tests to a known FlexIO2 pin so the engine actually runs.
+        flex_io_tx_pin = 6
         for driver in drivers_list:
             for lane_count in range(lane_range["min"], lane_range["max"] + 1):
                 for strip_size in strip_sizes:
@@ -518,6 +526,8 @@ def _parse_args_and_build_commands(args: Args) -> RunContext | int:
                         "iterations": 1,
                         "timing": timing_name,
                     }
+                    if driver == "FLEX_IO" and args.tx_pin is None:
+                        test_config["pinTx"] = flex_io_tx_pin
                     if args.legacy:
                         test_config["useLegacyApi"] = True
                     # Multi-frame capture: back-to-back show()/capture cycles per pattern.
@@ -542,7 +552,9 @@ def _parse_args_and_build_commands(args: Args) -> RunContext | int:
                             print("Error: --tight-timing-max-overhead-us must be >= 1")
                             return 1
                         test_config["tightTiming"] = True
-                        test_config["tightTimingIterations"] = args.tight_timing_iterations
+                        test_config["tightTimingIterations"] = (
+                            args.tight_timing_iterations
+                        )
                         test_config["tightTimingMaxOverheadUs"] = (
                             args.tight_timing_max_overhead_us
                         )

--- a/ci/tests/test_autoresearch_phases.py
+++ b/ci/tests/test_autoresearch_phases.py
@@ -50,6 +50,7 @@ def _make_args(**overrides) -> Args:
         lcd_spi=False,
         lcd_rgb=False,
         object_fled=False,
+        flex_io=False,
         all=False,
         simd=False,
         coroutine=False,
@@ -85,6 +86,9 @@ def _make_args(**overrides) -> Args:
         parallel=False,
         decode=None,
         frames=None,
+        tight_timing=False,
+        tight_timing_iterations=8,
+        tight_timing_max_overhead_us=2000,
     )
     defaults.update(overrides)
     return Args(**defaults)
@@ -196,7 +200,8 @@ class TestParseArgsAndBuildCommands:
             "LCD_CLOCKLESS",
             "LCD_SPI",
             "LCD_RGB",
-            "OBJECTFLED",
+            "OBJECT_FLED",
+            "FLEX_IO",
         }
 
     def test_multiple_drivers(self, fake_project_dir: Path) -> None:


### PR DESCRIPTION
## Summary

The Python orchestrator (`ci/autoresearch/phases.py`) emitted driver name `"OBJECTFLED"` (no underscore), which never matched the firmware-side registry name `"OBJECT_FLED"` — every `bash autoresearch teensy4x --object-fled` (and `--all`) silently bounced off `UnknownDriver` in `runSingleTestImpl` (`examples/AutoResearch/AutoResearchRemote.cpp:340`). There was also no `--flex-io` flag, and `--all` excluded `FLEX_IO` entirely, so the FlexIO TX engine was never reached from AutoResearch either.

## Changes

- `ci/autoresearch/args.py` — add `--flex-io` flag mirroring `--object-fled`; add the `flex_io: bool` field to the `Args` dataclass.
- `ci/autoresearch/phases.py` — rename `"OBJECTFLED"` → `"OBJECT_FLED"` in the `--all` set and `--object-fled` mapping; append `FLEX_IO` for `--flex-io` and to `--all`. The FLEX_IO command sets `pinTx: 6` (a FlexIO2-capable pin per `src/platforms/arm/teensy/teensy4_common/drivers/flexio/channel_engine_flexio.h:37`) so the manager actually routes to the FlexIO engine instead of silently falling through to ObjectFLED on the default TX pin (1) — pin 1 is not FlexIO2-capable, which is why every previous `Bus::AUTO` run on Teensy 4.x quietly preferred ObjectFLED.
- `ci/tests/test_autoresearch_phases.py` — update the `--all` driver-set expectation, add the `flex_io` field to the `_make_args` helper, and supply the three `tight_timing*` fields that #2991 added to `Args` without backfilling the test fixture (the fixture was already broken on `master`).

## Test plan

- [x] `uv run pytest ci/tests/test_autoresearch_phases.py` — 48 passed
- [x] Programmatic check: `--all` now emits `OBJECT_FLED` + `FLEX_IO` RPC commands; the FLEX_IO command carries `pinTx: 6` and OBJECT_FLED uses the global TX pin
- [ ] Hardware: `bash autoresearch teensy40 --all` should now reach both clockless engines (FLEX_IO on pin 6, OBJECT_FLED on pin 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new Flex IO driver option in autoresearch, including command-line selection and “all drivers” runs.
  * When no transmit pin is provided, Flex IO tests now use a consistent fallback pin for routing.

* **Bug Fixes**
  * Corrected a driver name spelling issue in driver selection.
  * Updated the “all” option to include the new Flex IO driver.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->