### PR TITLE
fix(LuminescentGrand): serpentine column wiring and corrected orientation

### DIFF
--- a/examples/LuminescentGrand/arduino/LedRopeTCL.cpp
+++ b/examples/LuminescentGrand/arduino/LedRopeTCL.cpp
@@ -30,16 +30,27 @@ fl::ScreenMap init_screenmap() {
   LedColumns cols = LedLayoutArray();
   const int length = cols.length;
   int sum = 0;
+  int y_max = 0;
   for (int i = 0; i < length; ++i) {
     sum += cols.array[i];
+    int stagger = i % 2 ? 4 : 0;
+    int col_top = (cols.array[i] - 1) * 8 + stagger;
+    if (col_top > y_max) {
+      y_max = col_top;
+    }
   }
   fl::ScreenMap screen_map(sum, 0.8f);
   int curr_idx = 0;
   for (int i = 0; i < length; ++i) {
     int n = cols.array[i];
     int stagger = i % 2 ? 4 : 0;
-    for (int j = 0; j < n; ++j) {
-      fl::vec2f xy(i*4, j*8 + stagger);
+    for (int k = 0; k < n; ++k) {
+      // Wiring is serpentine by column: even columns wind one way, odd
+      // columns the other, so a single rope can snake up and down.
+      int j = i % 2 ? (n - 1 - k) : k;
+      // Mirror y (horizontal flip + 180 deg rotation) so the rendered
+      // keyboard matches the physical Luminescent Grand orientation.
+      fl::vec2f xy(i*4, y_max - (j*8 + stagger));
       screen_map.set(curr_idx++, xy);
     }
   }


### PR DESCRIPTION
## Summary
- `init_screenmap()` now wires the LED rope **serpentine by column** (odd columns reversed) so a single strand can snake up and down the keyboard instead of assuming every column is wired bottom-up.
- The layout y is now **mirrored** (horizontal flip + 180° rotation) so the rendered keyboard matches the physical Luminescent Grand orientation.
- Scale (4/8 column/row spacing, stagger 4) and dot diameter (0.8) are unchanged; only wiring order and orientation are corrected.

This mirrors the corrected `piano_grand` screenmap used in the ledmapper tooling; the generated geometry was verified to match that screenmap exactly across all 1760 LEDs.

## Test plan
- [ ] Build the LuminescentGrand example and confirm the keyboard renders right-side up with the strand snaking column-to-column.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed LED display orientation mapping to correctly align with the physical Luminescent Grand device layout. Adjusted coordinate calculations to properly mirror vertical positioning and resolve serpentine wiring sequencing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->