### PR TITLE
chore(deps): bump zccache floor >=1.12.0 -> >=1.12.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,7 +143,7 @@ dependencies = [
     # incremental builds produce stale .obj files after a git pull that
     # changes transitive headers (symptom: `undefined symbol: ...` link
     # errors hours after a header actually changed).
-    "zccache>=1.12.0",
+    "zccache>=1.12.1",
     "ninja",
     "meson>=1.11.0",
     "download",


### PR DESCRIPTION
## Summary

Picks up [zccache#724](https://github.com/zackees/zccache/issues/724) fix shipped in [zccache#725](https://github.com/zackees/zccache/pull/725) (zccache 1.12.1): `FingerprintManager::on_batch` no longer holds DashMap shard locks across canonicalize + full-file blake3 hashing.

Before this, ESP32 builds with ~400 watch roots wedged the daemon under burst load — fbuild's compile path tripped `lost connection to daemon`.

## Test plan

- [x] pyproject floor bumped
- [ ] CI green once zccache 1.12.1 hits PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development dependencies to latest compatible versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->