### PR TITLE
refactor(lpc): rename FL_LPC* macros to FL_IS_ARM_LPC_* (closes #2999)

### DIFF
--- a/src/platforms/arm/lpc/README.md
+++ b/src/platforms/arm/lpc/README.md
@@ -12,7 +12,7 @@ NXP LPC microcontroller family support. Initial port landed in #2837 ([meta #283
 The LPC family currently covers two ARM cores:
 
 - **Cortex-M0+** (LPC845, LPC804) — bare-metal target via [fbuild](https://github.com/FastLED/fbuild) ≥ v2.2.18. Bit-banged clockless driver shipped; optional hardware-assisted drivers available per chip.
-- **Cortex-M0** (LPC11xx) and **Cortex-M3** (LPC15xx) — family **detection** is wired (`FL_LPC11`, `FL_LPC15`), but full driver wiring (`led_sysdefs`, `fastpin`, clockless) is pending hardware bring-up. See [#2845](https://github.com/FastLED/FastLED/issues/2845) Stage 4.
+- **Cortex-M0** (LPC11xx) and **Cortex-M3** (LPC15xx) — family **detection** is wired (`FL_IS_ARM_LPC_11`, `FL_IS_ARM_LPC_15`), but full driver wiring (`led_sysdefs`, `fastpin`, clockless) is pending hardware bring-up. See [#2845](https://github.com/FastLED/FastLED/issues/2845) Stage 4.
 
 ### Supported Platforms
 
@@ -34,7 +34,7 @@ The LPC family currently covers two ARM cores:
 - `spi_arm_lpc.h` — LPC845 / LPC804 hardware SPI driver for **APA102 / SK9822 / WS2801** clocked strips. Targets the LPC8xx SPI peripheral (UM11029 §"SPI") in master / MSB-first / mode-0 / 8-bit configuration. SPI0 default; users route to SPI1 via the `pSPIX` template arg. Pin routing through the LPC Switch Matrix is the user's responsibility (matching the bit-bang clockless driver's "FastPin sees raw GPIO" convention). Closes #2845 Stage 4 item 3.
 - `led_sysdefs_arm_lpc.h` — System defines (sets `FL_IS_ARM_M0_PLUS`, `F_CPU`, forces `FASTLED_M0_USE_C_IMPLEMENTATION`, includes `<LPC845.h>` / `<LPC804.h>` CMSIS device headers).
 - `fastpin_arm_lpc.h` — see above.
-- `is_lpc.h` — Detection macros (`FL_LPC845`, `FL_LPC804`, `FL_LPC11`, `FL_LPC15`, `FL_IS_ARM_LPC`).
+- `is_lpc.h` — Detection macros (`FL_IS_ARM_LPC_845`, `FL_IS_ARM_LPC_804`, `FL_IS_ARM_LPC_11`, `FL_IS_ARM_LPC_15`, `FL_IS_ARM_LPC`).
 - `int.h` — Integer type definitions.
 
 ## Optional feature defines
@@ -60,7 +60,7 @@ fbuild build lpc804 --examples Blink
 
 The fbuild assets (board JSON, linker script, SystemInit, vector table) live in `crates/fbuild-config/assets/boards/json/lpc8{04,45}.json` and `crates/fbuild-build/src/nxplpc/assets/` in the fbuild repo. The board-validation script ([fbuild#421/#422](https://github.com/FastLED/fbuild/issues/421)) explicitly tallies these as fbuild-native (no PlatformIO upstream).
 
-For LPC11xx and LPC15xx, no fbuild board entry exists yet; community contributors targeting those families with their own PlatformIO platform should expect to wire `led_sysdefs`, `fastpin`, and clockless headers per family before FastLED can compile against them. The hold is documented in `fastled_arm_lpc.h` — attempting to build with only `FL_LPC11` or `FL_LPC15` set emits a clear `#error` pointing here.
+For LPC11xx and LPC15xx, no fbuild board entry exists yet; community contributors targeting those families with their own PlatformIO platform should expect to wire `led_sysdefs`, `fastpin`, and clockless headers per family before FastLED can compile against them. The hold is documented in `fastled_arm_lpc.h` — attempting to build with only `FL_IS_ARM_LPC_11` or `FL_IS_ARM_LPC_15` set emits a clear `#error` pointing here.
 
 ## Detection scaffolds
 

--- a/src/platforms/arm/lpc/clockless_arm_lpc.h
+++ b/src/platforms/arm/lpc/clockless_arm_lpc.h
@@ -19,9 +19,9 @@
 // On LPC11xx legacy parts (LPC1110/1112/1114/1115) the GPIO is at
 // 0x50000000 with 12-bit masked-access semantics — that family needs its
 // own clockless driver, tracked in #2845 Stage 4.
-#if (defined(FL_LPC845) || defined(FL_LPC804) || \
-     defined(FL_LPC11_USB) || defined(FL_LPC15)) && \
-    !(defined(FL_LPC804) && defined(FASTLED_LPC_PLU))
+#if (defined(FL_IS_ARM_LPC_845) || defined(FL_IS_ARM_LPC_804) || \
+     defined(FL_IS_ARM_LPC_11_USB) || defined(FL_IS_ARM_LPC_15)) && \
+    !(defined(FL_IS_ARM_LPC_804) && defined(FASTLED_LPC_PLU))
 
 #include "platforms/arm/common/m0clockless.h"
 #include "fl/chipsets/timing_traits.h"
@@ -93,5 +93,5 @@ public:
 
 }  // namespace fl
 
-#endif  // (FL_LPC845 || FL_LPC804) && !(FL_LPC804 && FASTLED_LPC_PLU)
+#endif  // (FL_IS_ARM_LPC_845 || FL_IS_ARM_LPC_804) && !(FL_IS_ARM_LPC_804 && FASTLED_LPC_PLU)
 #endif  // __INC_CLOCKLESS_ARM_LPC_H

--- a/src/platforms/arm/lpc/clockless_arm_lpc_plu.h
+++ b/src/platforms/arm/lpc/clockless_arm_lpc_plu.h
@@ -33,7 +33,7 @@
 //
 //  Build-time opt-in
 //  -----------------
-//      -DFASTLED_LPC_PLU=1   (only honoured when FL_LPC804 is set)
+//      -DFASTLED_LPC_PLU=1   (only honoured when FL_IS_ARM_LPC_804 is set)
 //
 //  When the macro is set, this header registers itself ahead of the bit-banged
 //  C++ driver in `fastled_arm_lpc.h`. The LPC845 path (no PLU) is unaffected.
@@ -61,7 +61,7 @@
 #include "platforms/arm/is_arm.h"
 #include "platforms/arm/lpc/is_lpc.h"
 
-#if defined(FL_LPC804) && defined(FASTLED_LPC_PLU)
+#if defined(FL_IS_ARM_LPC_804) && defined(FASTLED_LPC_PLU)
 
 #include "fl/chipsets/timing_traits.h"
 #include "fl/stl/noexcept.h"
@@ -401,5 +401,5 @@ private:
 
 }  // namespace fl
 
-#endif  // FL_LPC804 && FASTLED_LPC_PLU
+#endif  // FL_IS_ARM_LPC_804 && FASTLED_LPC_PLU
 #endif  // __INC_CLOCKLESS_ARM_LPC_PLU_H

--- a/src/platforms/arm/lpc/clockless_arm_lpc_pwm_dma.h
+++ b/src/platforms/arm/lpc/clockless_arm_lpc_pwm_dma.h
@@ -28,7 +28,7 @@
 // BUILD-TIME OPT-IN
 // -----------------
 // Activated only when *both* are defined:
-//   * FL_LPC845 (auto-detected from CMSIS device macros in is_lpc.h)
+//   * FL_IS_ARM_LPC_845 (auto-detected from CMSIS device macros in is_lpc.h)
 //   * FASTLED_LPC_PWM_DMA  (user-supplied, default off)
 //
 // When FASTLED_LPC_PWM_DMA is not set, fastled_arm_lpc.h continues to route
@@ -111,7 +111,7 @@
 // IMPLEMENTATION
 // =============================================================================
 
-#if defined(FL_IS_ARM_LPC) && defined(FL_LPC845) && defined(FASTLED_LPC_PWM_DMA)
+#if defined(FL_IS_ARM_LPC) && defined(FL_IS_ARM_LPC_845) && defined(FASTLED_LPC_PWM_DMA)
 
 #include "fl/chipsets/timing_traits.h"
 #include "fl/stl/noexcept.h"
@@ -582,5 +582,5 @@ u32 ClocklessController<P, T, R, X, F, W>::sChannelBuf
 
 }  // namespace fl
 
-#endif  // FL_IS_ARM_LPC && FL_LPC845 && FASTLED_LPC_PWM_DMA
+#endif  // FL_IS_ARM_LPC && FL_IS_ARM_LPC_845 && FASTLED_LPC_PWM_DMA
 #endif  // __INC_CLOCKLESS_ARM_LPC_PWM_DMA_H

--- a/src/platforms/arm/lpc/fastled_arm_lpc.h
+++ b/src/platforms/arm/lpc/fastled_arm_lpc.h
@@ -4,11 +4,12 @@
 #ifndef __INC_FASTLED_ARM_LPC_H
 #define __INC_FASTLED_ARM_LPC_H
 
+#include "platforms/arm/is_arm.h"
 #include "platforms/arm/lpc/fastpin_arm_lpc.h"
 
 // LPC family driver-wiring status (#2845 Stage 4 items 1 + 2 land here):
-//   FL_LPC845 / FL_LPC804  — supported (Stage 2a #2837, optional Stage 2b/2c)
-//   FL_LPC11_USB           — supported via shared LPC8xx fastpin + M0
+//   FL_IS_ARM_LPC_845 / FL_IS_ARM_LPC_804  — supported (Stage 2a #2837, optional Stage 2b/2c)
+//   FL_IS_ARM_LPC_11_USB           — supported via shared LPC8xx fastpin + M0
 //                            clockless path. UM10462 §9 confirms the
 //                            LPC11Uxx GPIO controller layout is identical
 //                            to LPC8xx (DIR/MASK/PIN/SET/CLR/NOT at the
@@ -19,14 +20,14 @@
 //                            (FASTLED_M0_USE_C_IMPLEMENTATION), so the
 //                            single-instruction encoding limit of plain
 //                            M0 doesn't bite us.
-//   FL_LPC15               — supported via shared LPC8xx fastpin + the
+//   FL_IS_ARM_LPC_15               — supported via shared LPC8xx fastpin + the
 //                            same C++ clockless path. UM11074 confirms
 //                            the same modern GPIO controller at
 //                            0xA0000000. M3 has DWT cycle counters and
 //                            full Thumb-2 encoding (no offset limit), but
 //                            the unified C++ path keeps the driver
 //                            surface consistent.
-//   FL_LPC11_LEGACY        — NOT supported. LPC1110/1112/1114/1115 use
+//   FL_IS_ARM_LPC_11_LEGACY        — NOT supported. LPC1110/1112/1114/1115 use
 //                            the legacy GPIO controller at 0x50000000
 //                            with 12-bit masked-access semantics
 //                            (UM10398). The fastpin header emits a
@@ -40,13 +41,13 @@
 // peripherals. When the macro is set on an LPC845 build, the PWM+DMA driver
 // supplies fl::ClocklessController; otherwise the Stage 2a bit-bang driver in
 // clockless_arm_lpc.h remains the default.
-#if defined(FL_LPC845) && defined(FASTLED_LPC_PWM_DMA)
+#if defined(FL_IS_ARM_LPC_845) && defined(FASTLED_LPC_PWM_DMA)
 #include "platforms/arm/lpc/clockless_arm_lpc_pwm_dma.h"
 #else
 #include "platforms/arm/lpc/clockless_arm_lpc.h"
 // LPC804-specific PLU clockless driver (Stage 2b of #2836, see #2841).
 // Build-time opt-in via FASTLED_LPC_PLU. The header self-gates with
-// `#if defined(FL_LPC804) && defined(FASTLED_LPC_PLU)` and the bit-banged
+// `#if defined(FL_IS_ARM_LPC_804) && defined(FASTLED_LPC_PLU)` and the bit-banged
 // driver above compiles itself out under the same gate, so the LPC845 path
 // is completely unaffected.
 #include "platforms/arm/lpc/clockless_arm_lpc_plu.h"

--- a/src/platforms/arm/lpc/fastpin_arm_lpc.h
+++ b/src/platforms/arm/lpc/fastpin_arm_lpc.h
@@ -22,14 +22,14 @@ FL_DISABLE_WARNING_DEPRECATED_REGISTER
 // LPC1115) which use the older "legacy GPIO" controller at 0x50000000 with
 // 12-bit masked-access semantics (UM10398). Those need their own fastpin
 // layout; emit a clear `#error` rather than silently mis-encoding.
-#if defined(FL_LPC11_LEGACY) && \
-    !(defined(FL_LPC845) || defined(FL_LPC804) || \
-      defined(FL_LPC11_USB) || defined(FL_LPC15))
+#if defined(FL_IS_ARM_LPC_11_LEGACY) && \
+    !(defined(FL_IS_ARM_LPC_845) || defined(FL_IS_ARM_LPC_804) || \
+      defined(FL_IS_ARM_LPC_11_USB) || defined(FL_IS_ARM_LPC_15))
 #error "FastLED LPC1110/1112/1114/1115 (legacy M0 GPIO at 0x50000000) driver wiring is a Stage 4 follow-up to #2845. The modern LPC8xx-style fastpin in this file does not apply. Either target LPC11U24/U35 / LPC845 / LPC804 / LPC15xx, or contribute the legacy-GPIO fastpin via #2845."
 #endif
 
-#if defined(FL_LPC845) || defined(FL_LPC804) || \
-    defined(FL_LPC11_USB) || defined(FL_LPC15)
+#if defined(FL_IS_ARM_LPC_845) || defined(FL_IS_ARM_LPC_804) || \
+    defined(FL_IS_ARM_LPC_11_USB) || defined(FL_IS_ARM_LPC_15)
 
 namespace fl {
 
@@ -146,7 +146,7 @@ _FL_DEFPIN(28); _FL_DEFPIN(29); _FL_DEFPIN(30); _FL_DEFPIN(31);
 
 }  // namespace fl
 
-#endif  // FL_LPC845 || FL_LPC804 || FL_LPC11_USB || FL_LPC15
+#endif  // FL_IS_ARM_LPC_845 || FL_IS_ARM_LPC_804 || FL_IS_ARM_LPC_11_USB || FL_IS_ARM_LPC_15
 
 FL_DISABLE_WARNING_POP
 

--- a/src/platforms/arm/lpc/is_lpc.h
+++ b/src/platforms/arm/lpc/is_lpc.h
@@ -16,19 +16,26 @@
 /// CPU_LPC845M301JBD48, CPU_LPC1115FBD48) as well as bare project-level defines
 /// that fbuild / PlatformIO configurations are expected to provide
 /// (__LPC845__, __LPC804__, __LPC11xx__).
+///
+/// **Macro naming convention** (FastLED #2999): every platform / subtype
+/// detection macro starts with `FL_IS_` and is nested under its family
+/// roll-up — e.g. `FL_IS_ARM_LPC_845` lives under `FL_IS_ARM_LPC`. Bare
+/// `FL_LPC*` names are not used. The `__LPC*` / `LPC*` / `CPU_LPC*`
+/// inputs above come from the toolchain / vendor headers and are NOT
+/// renamed (we read them, we don't define them).
 
 // LPC845 (ARM Cortex-M0+, 30 MHz, 64KB Flash, 16KB SRAM)
 #if defined(__LPC845__) || defined(LPC845) || defined(LPC845M301) || \
     defined(CPU_LPC845M301JBD48) || defined(CPU_LPC845M301JBD64) || \
     defined(CPU_LPC845M301JHI33) || defined(CPU_LPC845M301JHI48)
-#define FL_LPC845
+#define FL_IS_ARM_LPC_845
 #endif
 
 // LPC804 (ARM Cortex-M0+, 15 MHz, 32KB Flash, 4KB SRAM, integrated PLU)
 #if defined(__LPC804__) || defined(LPC804) || defined(LPC804M101) || \
     defined(CPU_LPC804M101JDH20) || defined(CPU_LPC804M101JDH24) || \
     defined(CPU_LPC804M101JHI33)
-#define FL_LPC804
+#define FL_IS_ARM_LPC_804
 #endif
 
 // LPC11xx family (ARM Cortex-M0, up to 50 MHz, classic mbed-era hobbyist
@@ -43,30 +50,31 @@
 // offsets on parts that lack the M0+ instruction extensions. The led
 // sysdefs follow-up will set FL_IS_ARM_M0 (not M0+) for this family.
 // Sub-family split:
-//   FL_LPC11_USB    — LPC11U24 / LPC11U35 ("USB-capable" M0 parts). Modern
-//     GPIO controller at 0xA0000000 with the same DIR/MASK/PIN/SET/CLR/NOT
-//     layout as LPC8xx per UM10462 §9. Can reuse the LPC8xx fastpin + M0
-//     ASM clockless path (NOT M0+).
-//   FL_LPC11_LEGACY — LPC1110 / LPC1112 / LPC1114 / LPC1115. Legacy GPIO
-//     controller at 0x50000000 with 12-bit "masked access" semantics per
-//     UM10398 §12. Different fastpin layout from LPC8xx; driver wiring
-//     deferred — emit a clear `#error` so users on these chips know.
+//   FL_IS_ARM_LPC_11_USB    — LPC11U24 / LPC11U35 ("USB-capable" M0
+//     parts). Modern GPIO controller at 0xA0000000 with the same DIR/
+//     MASK/PIN/SET/CLR/NOT layout as LPC8xx per UM10462 §9. Can reuse
+//     the LPC8xx fastpin + M0 ASM clockless path (NOT M0+).
+//   FL_IS_ARM_LPC_11_LEGACY — LPC1110 / LPC1112 / LPC1114 / LPC1115.
+//     Legacy GPIO controller at 0x50000000 with 12-bit "masked access"
+//     semantics per UM10398 §12. Different fastpin layout from LPC8xx;
+//     driver wiring deferred — emit a clear `#error` so users on these
+//     chips know.
 #if defined(__LPC11Uxx__) || defined(LPC11Uxx) || \
     defined(CPU_LPC11U24FBD48) || defined(CPU_LPC11U24FHI33) || \
     defined(CPU_LPC11U35FBD48) || defined(CPU_LPC11U35FHI33) || \
     defined(CPU_LPC11U35FHN33)
-#define FL_LPC11_USB
+#define FL_IS_ARM_LPC_11_USB
 #endif
 
 #if defined(__LPC11xx__) || defined(LPC11xx) || \
     defined(CPU_LPC1114FBD48) || defined(CPU_LPC1114FHN33) || \
     defined(CPU_LPC1115FBD48)
-#define FL_LPC11_LEGACY
+#define FL_IS_ARM_LPC_11_LEGACY
 #endif
 
 // Roll-up
-#if defined(FL_LPC11_USB) || defined(FL_LPC11_LEGACY)
-#define FL_LPC11
+#if defined(FL_IS_ARM_LPC_11_USB) || defined(FL_IS_ARM_LPC_11_LEGACY)
+#define FL_IS_ARM_LPC_11
 #endif
 
 // LPC15xx family (ARM Cortex-M3, up to 72 MHz, SCT/PLU on some variants:
@@ -95,11 +103,11 @@
     defined(CPU_LPC1548JBD100) || \
     defined(CPU_LPC1549JBD48) || defined(CPU_LPC1549JBD64) || \
     defined(CPU_LPC1549JBD100)
-#define FL_LPC15
+#define FL_IS_ARM_LPC_15
 #endif
 
 // General LPC family roll-up (any LPC variant supported by this port)
-#if defined(FL_LPC845) || defined(FL_LPC804) || defined(FL_LPC11) || \
-    defined(FL_LPC15)
+#if defined(FL_IS_ARM_LPC_845) || defined(FL_IS_ARM_LPC_804) || \
+    defined(FL_IS_ARM_LPC_11) || defined(FL_IS_ARM_LPC_15)
 #define FL_IS_ARM_LPC
 #endif

--- a/src/platforms/arm/lpc/led_sysdefs_arm_lpc.h
+++ b/src/platforms/arm/lpc/led_sysdefs_arm_lpc.h
@@ -15,11 +15,11 @@
 //   LPC8xx        — Cortex-M0+
 //   LPC11Uxx      — Cortex-M0   (NOT M0+)
 //   LPC15xx       — Cortex-M3   (different ISA, has DWT cycle counter)
-#if defined(FL_LPC845) || defined(FL_LPC804)
+#if defined(FL_IS_ARM_LPC_845) || defined(FL_IS_ARM_LPC_804)
 #define FL_IS_ARM_M0_PLUS
-#elif defined(FL_LPC11_USB)
+#elif defined(FL_IS_ARM_LPC_11_USB)
 #define FL_IS_ARM_M0
-#elif defined(FL_LPC15)
+#elif defined(FL_IS_ARM_LPC_15)
 #define FL_IS_ARM_M3
 #endif
 
@@ -37,16 +37,16 @@
 #endif
 
 #ifndef F_CPU
-#if defined(FL_LPC845)
+#if defined(FL_IS_ARM_LPC_845)
 #define F_CPU 30000000UL
-#elif defined(FL_LPC804)
+#elif defined(FL_IS_ARM_LPC_804)
 #define F_CPU 15000000UL
-#elif defined(FL_LPC11_USB)
+#elif defined(FL_IS_ARM_LPC_11_USB)
 // LPC11U24 / LPC11U35 — IRC at boot is 12 MHz. PLL boost to 48 MHz is
 // possible; default kept conservative since SystemInit is the user's
 // responsibility on bare-metal builds.
 #define F_CPU 12000000UL
-#elif defined(FL_LPC15)
+#elif defined(FL_IS_ARM_LPC_15)
 // LPC15xx — IRC at boot is 12 MHz. PLL boost to 72 MHz on most variants.
 // Default kept conservative; user code can override F_CPU once a PLL is
 // brought up.
@@ -89,9 +89,9 @@ typedef fl::u8           boolean;
 // via core_cm0plus.h. Some integrations only pull in the SoC header (e.g.
 // LPC845.h / LPC804.h), which transitively includes the core header.
 // IWYU pragma: begin_keep
-#if defined(FL_LPC845)
+#if defined(FL_IS_ARM_LPC_845)
 #include <LPC845.h>
-#elif defined(FL_LPC804)
+#elif defined(FL_IS_ARM_LPC_804)
 #include <LPC804.h>
 #endif
 // IWYU pragma: end_keep

--- a/src/platforms/arm/lpc/spi_arm_lpc.h
+++ b/src/platforms/arm/lpc/spi_arm_lpc.h
@@ -15,7 +15,7 @@
 // different register layouts (UM10398 / UM10462 SSP for LPC11; LPC15 SPI is
 // closer to LPC8xx but uses different base addresses) — driver wiring for
 // those families is tracked in #2845 Stage 4.
-#if defined(FL_LPC845) || defined(FL_LPC804)
+#if defined(FL_IS_ARM_LPC_845) || defined(FL_IS_ARM_LPC_804)
 
 FL_DISABLE_WARNING_PUSH
 FL_DISABLE_WARNING_DEPRECATED_REGISTER
@@ -273,6 +273,6 @@ public:
 
 FL_DISABLE_WARNING_POP
 
-#endif  // FL_LPC845 || FL_LPC804
+#endif  // FL_IS_ARM_LPC_845 || FL_IS_ARM_LPC_804
 
 #endif  // __INC_SPI_ARM_LPC_H


### PR DESCRIPTION
## Summary

Brings the LPC subtype macros in line with the project-wide `FL_IS_<FAMILY>_<SUBTYPE>` naming convention used everywhere else (`FL_IS_TEENSY_LC`, `FL_IS_STM32_F1`, `FL_IS_ESP8266`, `FL_IS_SAMD21`, ...). Only the family roll-up `FL_IS_ARM_LPC` was previously compliant.

## Rename

| Old (wrong)        | New (correct)              |
|--------------------|----------------------------|
| `FL_LPC845`        | `FL_IS_ARM_LPC_845`        |
| `FL_LPC804`        | `FL_IS_ARM_LPC_804`        |
| `FL_LPC11`         | `FL_IS_ARM_LPC_11`         |
| `FL_LPC11_USB`     | `FL_IS_ARM_LPC_11_USB`     |
| `FL_LPC11_LEGACY`  | `FL_IS_ARM_LPC_11_LEGACY`  |
| `FL_LPC15`         | `FL_IS_ARM_LPC_15`         |

## Scope

Touched **9 files**, all under `src/platforms/arm/lpc/`. No backward-compat aliases needed — the `FL_LPC*` names were entirely internal to that directory (zero references in `src/` outside it, zero in `examples/`, `tests/`, or `ci/`). Verified zero-occurrence post-rename with a project-wide `grep -rn`.

Upstream toolchain / vendor inputs (`__LPC845__`, `LPC845M301`, `CPU_LPC845M301JBD48`, ...) are explicitly NOT renamed — we read them, we don't define them.

`fastled_arm_lpc.h` gained a `#include "platforms/arm/is_arm.h"` to satisfy the `IsHeaderIncludeChecker` lint (which requires any file using an `FL_IS_*` macro to pull in the trampoline include).

## Test plan

- [x] `bash lint` — clean (was 1 IsHeaderIncludeChecker violation pre-fix, now 0).
- [x] `bash autoresearch lpc845brk --upload-port COM10 --skip-lint --timeout 5` — LPC845 firmware builds (text **62.16 KB / 64 KB**), flashes via pyOCD, and the existing bring-up RPC test passes on real hardware:
  - ✅ Serial.println — REMOTE: response received
  - ✅ JSON-RPC echo  — sentinel 4242 round-trip verified
  - ✅ FL_WARN_LIT    — FastLED warn pipeline reached host
- [x] `bash test --cpp` — 219/219 host test cases pass (a separate intermittent zccache-daemon link race surfaced "0/0 tests built" on one run — that's the false-pass / false-fail mode tracked by #3011 and is independent of this change; the second invocation after `zccache stop` returned clean test pass counts).

Closes #2999.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized LPC platform detection macro naming across all LPC headers for device detection and feature gating in LPC845, LPC804, LPC11xx, and LPC15xx families.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->