### PR TITLE
fix(test-runner): refuse stale/missing DLLs in streaming path (closes #3011)

### DIFF
--- a/ci/meson/streaming_runner.py
+++ b/ci/meson/streaming_runner.py
@@ -40,6 +40,61 @@ from ci.util.output_formatter import TimestampFormatter
 from ci.util.timestamp_print import ts_print as _ts_print
 
 
+def validate_test_artifact(
+    test_path: Path, build_start_time: float
+) -> Optional[TestResult]:
+    """Validate a test/example binary before running it.
+
+    Returns ``None`` if the artifact is fresh and ready to run. Returns
+    a populated ``TestResult`` (``success=False``) if the artifact is
+    missing or stale, so the caller can surface the failure directly
+    instead of silently running broken/old code.
+
+    Why this matters (FastLED #3011): the streaming compiler submits
+    tests to the runner as soon as Ninja prints ``[N/M] Linking <X>``
+    — but that line is Ninja's PRE-link announcement, NOT a success
+    signal. If the link then FAILS (zccache daemon crash under the
+    parallel-link storm, ld.lld permission error, etc.) ``test_path``
+    is either missing entirely (clean build) or stale from a previous
+    build sitting in the same build dir. Running it produces a
+    false pass or false fail; refusing to run it surfaces the link
+    failure where it belongs.
+    """
+    if not test_path.exists():
+        return TestResult(
+            success=False,
+            output=(
+                f"[MESON] ❌ Test artifact missing: {test_path}\n"
+                f"  Link likely failed during the parallel-link storm "
+                f"(zccache daemon crash, ld.lld error, etc.) — see "
+                f"FastLED #3011. Refusing to run a missing DLL.\n"
+                f"  Resolve the underlying link failure and re-run."
+            ),
+        )
+    try:
+        dll_mtime = test_path.stat().st_mtime
+    except OSError:
+        # stat() failure is non-fatal — let the subprocess loader
+        # surface whatever it actually sees on disk.
+        return None
+    if dll_mtime < build_start_time:
+        return TestResult(
+            success=False,
+            output=(
+                f"[MESON] ❌ Stale test artifact: {test_path}\n"
+                f"  DLL mtime ({dll_mtime:.2f}) predates this build's "
+                f"start ({build_start_time:.2f}). The current link "
+                f"likely failed and left a previous build's DLL behind "
+                f"— running it would produce misleading results (see "
+                f"FastLED #3011).\n"
+                f"  Resolve the underlying link failure (`zccache stop` "
+                f"+ retry usually clears the daemon-crash variant) and "
+                f"re-run."
+            ),
+        )
+    return None
+
+
 @dataclass
 class StreamingContext:
     """Parameters needed by the streaming execution path."""
@@ -215,6 +270,15 @@ def run_streaming_path(ctx: StreamingContext) -> MesonTestResult:
         output when tests run in parallel.
         """
         try:
+            # FastLED #3011 — refuse to run missing or stale artifacts.
+            # The streaming compiler submits tests as soon as Ninja prints
+            # "Linking <X>" (a PRE-link announcement, not success). If
+            # the link then fails, what's at test_path is either nothing
+            # or yesterday's DLL — running it produces false pass / fail.
+            failure = validate_test_artifact(test_path, ctx.start_time)
+            if failure is not None:
+                return failure
+
             if test_path.suffix.lower() in (".dll", ".so", ".dylib"):
                 runner_suffix = ".exe" if os.name == "nt" else ""
                 if test_path.parent.name == "tests":

--- a/ci/tests/test_streaming_runner_artifact_validation.py
+++ b/ci/tests/test_streaming_runner_artifact_validation.py
@@ -1,0 +1,95 @@
+"""Tests for streaming-runner artifact validation (FastLED #3011).
+
+`validate_test_artifact` is the gate that catches the false-pass /
+false-fail mode where Ninja's "Linking <X>" announcement submits a
+test to the runner, the link then fails (e.g. zccache daemon crash
+under the parallel-link storm), and the runner loads either a
+missing DLL (clean build) or a stale one from a previous build.
+"""
+
+import time
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from ci.meson.streaming import TestResult  # noqa: E402
+from ci.meson.streaming_runner import validate_test_artifact  # noqa: E402
+
+
+class TestValidateTestArtifact(unittest.TestCase):
+    """`validate_test_artifact` returns None on success, TestResult on failure."""
+
+    def test_fresh_dll_returns_none(self) -> None:
+        """A DLL whose mtime is newer than build start is accepted."""
+        with TemporaryDirectory() as tmp:
+            dll = Path(tmp) / "fl_audio.dll"
+            dll.write_bytes(b"fake")
+            build_start = dll.stat().st_mtime - 10.0  # 10 s before write
+            result = validate_test_artifact(dll, build_start)
+            self.assertIsNone(result)
+
+    def test_missing_dll_returns_failure(self) -> None:
+        """A nonexistent path produces a TestResult(success=False)."""
+        with TemporaryDirectory() as tmp:
+            dll = Path(tmp) / "fl_audio.dll"  # never created
+            build_start = time.time()
+            result = validate_test_artifact(dll, build_start)
+            self.assertIsNotNone(result)
+            assert isinstance(result, TestResult)
+            self.assertFalse(result.success)
+            self.assertIn("Test artifact missing", result.output)
+            self.assertIn(str(dll), result.output)
+            self.assertIn("#3011", result.output)
+
+    def test_stale_dll_returns_failure(self) -> None:
+        """A DLL with mtime older than build_start_time fails validation."""
+        with TemporaryDirectory() as tmp:
+            dll = Path(tmp) / "fl_audio.dll"
+            dll.write_bytes(b"old")
+            dll_mtime = dll.stat().st_mtime
+            build_start = dll_mtime + 100.0  # 100 s AFTER the file was written
+            result = validate_test_artifact(dll, build_start)
+            self.assertIsNotNone(result)
+            assert isinstance(result, TestResult)
+            self.assertFalse(result.success)
+            self.assertIn("Stale test artifact", result.output)
+            self.assertIn(str(dll), result.output)
+            self.assertIn("#3011", result.output)
+
+    def test_exactly_at_build_start_is_accepted(self) -> None:
+        """A DLL with mtime == build_start (no slop) passes the check.
+
+        The validator uses ``<`` not ``<=``, so artifacts written at
+        the exact tick the build started are treated as fresh. This
+        matches reality on filesystems with coarse mtime resolution
+        (Windows FAT32 is 2 s; ext3 was 1 s).
+        """
+        with TemporaryDirectory() as tmp:
+            dll = Path(tmp) / "fl_audio.dll"
+            dll.write_bytes(b"fresh")
+            build_start = dll.stat().st_mtime  # exactly equal
+            result = validate_test_artifact(dll, build_start)
+            self.assertIsNone(result)
+
+    def test_failure_messages_are_actionable(self) -> None:
+        """The failure messages include both the path and a remediation hint."""
+        with TemporaryDirectory() as tmp:
+            dll = Path(tmp) / "fl_audio_reactive.dll"
+            build_start = time.time()
+
+            # Missing case
+            missing = validate_test_artifact(dll, build_start)
+            assert isinstance(missing, TestResult)
+            self.assertIn("re-run", missing.output.lower())
+
+            # Stale case
+            dll.write_bytes(b"old")
+            stale = validate_test_artifact(
+                dll, dll.stat().st_mtime + 5.0
+            )
+            assert isinstance(stale, TestResult)
+            self.assertIn("zccache stop", stale.output)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

The streaming test runner submits a test to the executor as soon as Ninja prints `[N/M] Linking <X>` — but that's Ninja's PRE-link *announcement*, not a success signal. When the link then fails (canonical example: zccache daemon crashes under the `all-with-examples` parallel-link storm of 245 test DLLs + 96 example DLLs racing against one daemon), the runner ends up loading either:

- **Nothing** — on a clean build, the link failure leaves no DLL.
- **Yesterday's DLL** — on an incremental build, the link failure leaves a previous build's artifact at the target path.

Either way the test executes garbage:

- **False-fail direction** — stale DLL hits an assertion the in-progress diff was meant to fix; wastes investigation time chasing the previous bug.
- **False-pass direction** — stale DLL doesn't yet contain the new assertion the diff *would* have failed; green-lights a broken change.

Both surface as `[MESON] ❌ Some tests failed (0/0 tests in 92.31s)` followed by 9-test-worth of stale assertion output, with no indication that the link itself failed.

## The fix

`ci/meson/streaming_runner.py`:

1. New helper `validate_test_artifact(test_path, build_start_time) -> Optional[TestResult]`.
2. `test_callback` calls it before launching the runner. Two checks:
   - The DLL exists at `test_path`.
   - The DLL's mtime is ≥ the build's start time (`ctx.start_time`, already plumbed for the duration measurement). Stale artifacts have mtime < start.
3. If either gate fails, returns a `TestResult(success=False)` with an actionable message naming the path, the FastLED #3011 root cause, and the remediation (`zccache stop` + retry for the daemon-crash variant).

The mtime check is robust against Ninja output not arriving in a parseable form, against zccache crashing late in the link, and against any other "link reported success but the artifact is bad" failure mode. The pre-link announcement / post-link result race is structurally unobservable from Ninja's stdout alone, but the on-disk state is authoritative.

This addresses **suggested fix #1** in the issue ("Make the test runner fail hard when its DLL is missing or stale"). Suggested fixes #2 (link-parallelism cap) and #3 (auto-restart zccache on `lost connection to daemon`) remain as independent follow-ups — both attack the same mode from different angles, but this gate alone is sufficient to keep the runner honest while those are designed.

## Test plan

New `ci/tests/test_streaming_runner_artifact_validation.py` — 5 unit tests:

- Fresh DLL (mtime > build_start) → `None` (proceed to run).
- Missing DLL → `TestResult(success=False)` with message mentioning `Test artifact missing`, the path, and `#3011`.
- Stale DLL (mtime < build_start) → `TestResult(success=False)` with message mentioning `Stale test artifact`, the path, and `#3011`.
- DLL with mtime exactly == build_start → accepted (uses `<` not `<=` to match coarse-mtime filesystems — Windows FAT32 is 2 s; ext3 was 1 s).
- Failure messages include actionable remediation (`re-run`, `zccache stop`).

```
$ python -m pytest ci/tests/test_streaming_runner_artifact_validation.py -v
collected 5 items
test_streaming_runner_artifact_validation.py::TestValidateTestArtifact::test_exactly_at_build_start_is_accepted PASSED [ 20%]
test_streaming_runner_artifact_validation.py::TestValidateTestArtifact::test_failure_messages_are_actionable     PASSED [ 40%]
test_streaming_runner_artifact_validation.py::TestValidateTestArtifact::test_fresh_dll_returns_none              PASSED [ 60%]
test_streaming_runner_artifact_validation.py::TestValidateTestArtifact::test_missing_dll_returns_failure         PASSED [ 80%]
test_streaming_runner_artifact_validation.py::TestValidateTestArtifact::test_stale_dll_returns_failure           PASSED [100%]
5 passed in 0.38s
```

`ruff check` clean on both modified files.

Closes #3011.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CI test validation to detect missing or stale test binaries before execution, preventing false pass/fail results from outdated builds and properly surfacing link-time failures.

* **Tests**
  * Added comprehensive test coverage for artifact validation logic, including scenarios for fresh binaries, missing artifacts, stale binaries, and actionable error messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->