### PR TITLE
refactor(system): introduce FL_PLATFORM_HAS_*_MEMORY canonical names (closes #3000)

### DIFF
--- a/src/fl/system/sketch_macros.h
+++ b/src/fl/system/sketch_macros.h
@@ -1,104 +1,192 @@
 #pragma once
 
-// Four-tier memory classification:
-//   Tiny: SKETCH_HAS_TINY_MEMORY=1, SKETCH_HAS_LARGE_MEMORY=0, SKETCH_HAS_HUGE_MEMORY=0
-//         (classic ATtiny <=512B parts, ATtiny1604 1KB, select modern tinyAVR
-//          0/1-series parts with <=1KB SRAM — see FL_IS_AVR_ATTINY_TINY_MEMORY
-//          in is_avr.h for the full list; 2-series parts with 2KB+ are excluded)
-//   Low:  SKETCH_HAS_TINY_MEMORY=0, SKETCH_HAS_LARGE_MEMORY=0, SKETCH_HAS_HUGE_MEMORY=0
-//         (AVR Uno/Nano/Leonardo, ATtiny1616/1624/3216/3224 (2-3KB), ESP8266,
-//          Teensy LC/3.0/3.1/3.2, STM32F1, Renesas UNO)
-//   High: SKETCH_HAS_LARGE_MEMORY=1, SKETCH_HAS_HUGE_MEMORY=0
-//         (Apollo3, nRF52, SAMD21, generic ARM)
-//   Huge: SKETCH_HAS_LARGE_MEMORY=1, SKETCH_HAS_HUGE_MEMORY=1
-//         (ESP32, Teensy 3.5/3.6/4.x, RP2040/RP2350, SAMD51, STM32F4+/H7, native/WASM)
+// Four-tier platform-memory classification (FastLED #3000).
+//
+// Canonical names:
+//   FL_PLATFORM_HAS_TINY_MEMORY   — 1 on parts with <=1KB SRAM
+//                                   (classic ATtiny <=512B, ATtiny1604 1KB,
+//                                    select modern tinyAVR 0/1-series with
+//                                    <=1KB SRAM — see FL_IS_AVR_ATTINY_TINY_MEMORY
+//                                    in is_avr.h; 2-series parts with 2KB+ are
+//                                    excluded)
+//   FL_PLATFORM_HAS_LARGE_MEMORY  — 1 on the "high" tier (Apollo3, nRF52,
+//                                   SAMD21, generic ARM)
+//   FL_PLATFORM_HAS_HUGE_MEMORY   — 1 on the "huge" tier (ESP32, Teensy
+//                                   3.5/3.6/4.x, RP2040/RP2350, SAMD51,
+//                                   STM32F4+/H7, native/WASM)
+//
+// Tier truth table:
+//   Tiny: TINY=1, LARGE=0, HUGE=0  (<=1KB SRAM parts)
+//   Low:  TINY=0, LARGE=0, HUGE=0  (AVR Uno/Nano/Leonardo, ATtiny 2-3KB,
+//                                   ESP8266, Teensy LC/3.0/3.1/3.2, STM32F1,
+//                                   Renesas UNO, LPC8xx)
+//   High: TINY=0, LARGE=1, HUGE=0
+//   Huge: TINY=0, LARGE=1, HUGE=1
 //
 // Invariants:
 //   HUGE=1 implies LARGE=1. LARGE=0 implies HUGE=0.
 //   TINY=1 implies LARGE=0 and HUGE=0.
+//
+// Backward compatibility (#3000):
+//   The names `SKETCH_HAS_TINY_MEMORY`, `SKETCH_HAS_LARGE_MEMORY`,
+//   `SKETCH_HAS_HUGE_MEMORY` (and `_OVERRIDDEN` variants, plus the older
+//   `SKETCH_HAS_LOTS_OF_MEMORY` / `SKETCH_HAS_VERY_LARGE_MEMORY` aliases)
+//   are preserved as deprecated aliases so external user sketches keep
+//   compiling. Internal FastLED code is migrating to the
+//   `FL_PLATFORM_HAS_*` names over a series of follow-up PRs; both names
+//   work identically until that migration completes. Either name can be
+//   used as a build-flag override (e.g. `-DSKETCH_HAS_LARGE_MEMORY=1` or
+//   `-DFL_PLATFORM_HAS_LARGE_MEMORY=1`).
+//
+// Override mechanism: define the macro to 0 or 1 in build flags or
+// before including FastLED. The header detects the override and sets
+// the corresponding `_OVERRIDDEN` flag, which `platforms/*/compile_test.hpp`
+// uses to skip the platform-default sanity assertion.
 
-// Tiny-memory devices: <= 1KB SRAM. These cannot fit many of the standard
-// FastLED example sketches. Detect BEFORE computing SKETCH_HAS_LARGE_MEMORY so
-// that LARGE is always 0 on tiny parts.
-// FL_IS_AVR_ATTINY_TINY_MEMORY is defined in platforms/avr/is_avr.h (included
-// via platforms/is_platform.h upstream in FastLED.h).
-#ifdef SKETCH_HAS_TINY_MEMORY
-#define SKETCH_HAS_TINY_MEMORY_OVERRIDDEN 1
+// =============================================================================
+// Tier 1: tiny (<=1KB SRAM)
+// =============================================================================
+//
+// Detect BEFORE computing LARGE/HUGE so the invariant TINY=1 → LARGE=0,
+// HUGE=0 holds for the platform-default paths.
+//
+// `FL_IS_AVR_ATTINY_TINY_MEMORY` is defined in `platforms/avr/is_avr.h`
+// (included via `platforms/is_platform.h` upstream in FastLED.h).
+#if defined(FL_PLATFORM_HAS_TINY_MEMORY) || defined(SKETCH_HAS_TINY_MEMORY)
+  // User-supplied override. Accept either spelling.
+  #ifndef FL_PLATFORM_HAS_TINY_MEMORY
+    #define FL_PLATFORM_HAS_TINY_MEMORY SKETCH_HAS_TINY_MEMORY
+  #endif
+  #define FL_PLATFORM_HAS_TINY_MEMORY_OVERRIDDEN 1
 #else
-#if defined(FL_IS_AVR_ATTINY_TINY_MEMORY)
-#define SKETCH_HAS_TINY_MEMORY 1
-#else
-#define SKETCH_HAS_TINY_MEMORY 0
-#endif
-#endif
-
-#ifdef SKETCH_HAS_LARGE_MEMORY
-// User has manually defined SKETCH_HAS_LARGE_MEMORY via build flags.
-// Mark it as overridden so platform compile tests don't fire.
-#define SKETCH_HAS_LARGE_MEMORY_OVERRIDDEN 1
-#else
-#if defined(FL_IS_AVR) \
-  || defined(__AVR_ATtiny85__) \
-  || defined(__AVR_ATtiny88__) \
-  || defined(__AVR_ATmega32U4__) \
-  || defined(ARDUINO_attinyxy6) \
-  || defined(ARDUINO_attinyxy4) \
-  || defined(FL_IS_TEENSY_LC) \
-  || defined(FL_IS_TEENSY_30) \
-  || defined(FL_IS_TEENSY_31) \
-  || defined(FL_IS_TEENSY_32) \
-  || defined(FL_IS_STM32_F1) \
-  || defined(FL_IS_ESP8266) \
-  || defined(ARDUINO_ARCH_RENESAS_UNO) \
-  || defined(ARDUINO_BLUEPILL_F103C8) \
-  || defined(FL_IS_ARM_LPC)
-#define SKETCH_HAS_LARGE_MEMORY 0
-#else
-#define SKETCH_HAS_LARGE_MEMORY 1
-#endif
+  #if defined(FL_IS_AVR_ATTINY_TINY_MEMORY)
+    #define FL_PLATFORM_HAS_TINY_MEMORY 1
+  #else
+    #define FL_PLATFORM_HAS_TINY_MEMORY 0
+  #endif
 #endif
 
-#ifdef SKETCH_HAS_HUGE_MEMORY
-// User has manually defined SKETCH_HAS_HUGE_MEMORY via build flags.
-#define SKETCH_HAS_HUGE_MEMORY_OVERRIDDEN 1
+// =============================================================================
+// Tier 3: large / high (>= 256KB flash, "high" tier)
+// =============================================================================
+#if defined(FL_PLATFORM_HAS_LARGE_MEMORY) || defined(SKETCH_HAS_LARGE_MEMORY)
+  // User-supplied override. Accept either spelling.
+  #ifndef FL_PLATFORM_HAS_LARGE_MEMORY
+    #define FL_PLATFORM_HAS_LARGE_MEMORY SKETCH_HAS_LARGE_MEMORY
+  #endif
+  #define FL_PLATFORM_HAS_LARGE_MEMORY_OVERRIDDEN 1
 #else
-// Huge memory platforms: >= 256KB RAM, >= 512KB flash.
-// ESP32 (all), Teensy 4.x/3.5/3.6, RP2040/RP2350, SAMD51, STM32F4+/H7, native/WASM.
-#if defined(FL_IS_ESP32) \
-  || defined(FL_IS_TEENSY_35) \
-  || defined(FL_IS_TEENSY_36) \
-  || defined(FL_IS_TEENSY_4X) \
-  || defined(ARDUINO_ARCH_RP2040) \
-  || defined(PICO_RP2040) \
-  || defined(PICO_RP2350) \
-  || defined(__SAMD51__) \
-  || defined(STM32F4xx) || defined(STM32H7xx) || defined(ARDUINO_GIGA) \
-  || defined(FASTLED_STUB_IMPL) \
-  || defined(__EMSCRIPTEN__)
-#define SKETCH_HAS_HUGE_MEMORY 1
+  #if defined(FL_IS_AVR) \
+    || defined(__AVR_ATtiny85__) \
+    || defined(__AVR_ATtiny88__) \
+    || defined(__AVR_ATmega32U4__) \
+    || defined(ARDUINO_attinyxy6) \
+    || defined(ARDUINO_attinyxy4) \
+    || defined(FL_IS_TEENSY_LC) \
+    || defined(FL_IS_TEENSY_30) \
+    || defined(FL_IS_TEENSY_31) \
+    || defined(FL_IS_TEENSY_32) \
+    || defined(FL_IS_STM32_F1) \
+    || defined(FL_IS_ESP8266) \
+    || defined(ARDUINO_ARCH_RENESAS_UNO) \
+    || defined(ARDUINO_BLUEPILL_F103C8) \
+    || defined(FL_IS_ARM_LPC)
+    #define FL_PLATFORM_HAS_LARGE_MEMORY 0
+  #else
+    #define FL_PLATFORM_HAS_LARGE_MEMORY 1
+  #endif
+#endif
+
+// =============================================================================
+// Tier 4: huge (>= 256KB RAM, "huge" tier)
+// =============================================================================
+//
+// ESP32 (all), Teensy 4.x/3.5/3.6, RP2040/RP2350, SAMD51, STM32F4+/H7,
+// native/WASM.
+#if defined(FL_PLATFORM_HAS_HUGE_MEMORY) || defined(SKETCH_HAS_HUGE_MEMORY)
+  // User-supplied override. Accept either spelling.
+  #ifndef FL_PLATFORM_HAS_HUGE_MEMORY
+    #define FL_PLATFORM_HAS_HUGE_MEMORY SKETCH_HAS_HUGE_MEMORY
+  #endif
+  #define FL_PLATFORM_HAS_HUGE_MEMORY_OVERRIDDEN 1
 #else
-#define SKETCH_HAS_HUGE_MEMORY 0
-#endif
+  #if defined(FL_IS_ESP32) \
+    || defined(FL_IS_TEENSY_35) \
+    || defined(FL_IS_TEENSY_36) \
+    || defined(FL_IS_TEENSY_4X) \
+    || defined(ARDUINO_ARCH_RP2040) \
+    || defined(PICO_RP2040) \
+    || defined(PICO_RP2350) \
+    || defined(__SAMD51__) \
+    || defined(STM32F4xx) || defined(STM32H7xx) || defined(ARDUINO_GIGA) \
+    || defined(FASTLED_STUB_IMPL) \
+    || defined(__EMSCRIPTEN__)
+    #define FL_PLATFORM_HAS_HUGE_MEMORY 1
+  #else
+    #define FL_PLATFORM_HAS_HUGE_MEMORY 0
+  #endif
 #endif
 
-// Enforce invariant: HUGE=1 requires LARGE=1.
-#if SKETCH_HAS_HUGE_MEMORY && !SKETCH_HAS_LARGE_MEMORY
-#error "SKETCH_HAS_HUGE_MEMORY=1 requires SKETCH_HAS_LARGE_MEMORY=1"
+// =============================================================================
+// Invariant enforcement
+// =============================================================================
+#if FL_PLATFORM_HAS_HUGE_MEMORY && !FL_PLATFORM_HAS_LARGE_MEMORY
+  #error "FL_PLATFORM_HAS_HUGE_MEMORY=1 requires FL_PLATFORM_HAS_LARGE_MEMORY=1"
+#endif
+#if FL_PLATFORM_HAS_TINY_MEMORY && FL_PLATFORM_HAS_LARGE_MEMORY
+  #error "FL_PLATFORM_HAS_TINY_MEMORY=1 is incompatible with FL_PLATFORM_HAS_LARGE_MEMORY=1"
 #endif
 
-// Enforce invariant: TINY=1 requires LARGE=0 (and therefore HUGE=0).
-#if SKETCH_HAS_TINY_MEMORY && SKETCH_HAS_LARGE_MEMORY
-#error "SKETCH_HAS_TINY_MEMORY=1 is incompatible with SKETCH_HAS_LARGE_MEMORY=1"
+// =============================================================================
+// Backward-compat aliases (FastLED #3000)
+// =============================================================================
+//
+// The legacy `SKETCH_HAS_*_MEMORY` names mirror the canonical
+// `FL_PLATFORM_HAS_*_MEMORY` defines verbatim. Both names will continue
+// to evaluate identically; new code should prefer the `FL_PLATFORM_HAS_*`
+// names. The `_OVERRIDDEN` variants are also mirrored for parity with
+// the platform `compile_test.hpp` files that key off them.
+//
+// `#ifndef` guards protect the case where the user already supplied
+// `SKETCH_HAS_*` (which we picked up above as an override) — preventing
+// a redefinition warning.
+#ifndef SKETCH_HAS_TINY_MEMORY
+  #define SKETCH_HAS_TINY_MEMORY FL_PLATFORM_HAS_TINY_MEMORY
+#endif
+#ifndef SKETCH_HAS_LARGE_MEMORY
+  #define SKETCH_HAS_LARGE_MEMORY FL_PLATFORM_HAS_LARGE_MEMORY
+#endif
+#ifndef SKETCH_HAS_HUGE_MEMORY
+  #define SKETCH_HAS_HUGE_MEMORY FL_PLATFORM_HAS_HUGE_MEMORY
 #endif
 
-// Backward compatibility aliases for external user code.
+#ifdef FL_PLATFORM_HAS_TINY_MEMORY_OVERRIDDEN
+  #ifndef SKETCH_HAS_TINY_MEMORY_OVERRIDDEN
+    #define SKETCH_HAS_TINY_MEMORY_OVERRIDDEN 1
+  #endif
+#endif
+#ifdef FL_PLATFORM_HAS_LARGE_MEMORY_OVERRIDDEN
+  #ifndef SKETCH_HAS_LARGE_MEMORY_OVERRIDDEN
+    #define SKETCH_HAS_LARGE_MEMORY_OVERRIDDEN 1
+  #endif
+#endif
+#ifdef FL_PLATFORM_HAS_HUGE_MEMORY_OVERRIDDEN
+  #ifndef SKETCH_HAS_HUGE_MEMORY_OVERRIDDEN
+    #define SKETCH_HAS_HUGE_MEMORY_OVERRIDDEN 1
+  #endif
+#endif
+
+// Older spellings still seen in some user sketches.
 #ifndef SKETCH_HAS_LOTS_OF_MEMORY
-#define SKETCH_HAS_LOTS_OF_MEMORY SKETCH_HAS_LARGE_MEMORY
+  #define SKETCH_HAS_LOTS_OF_MEMORY FL_PLATFORM_HAS_LARGE_MEMORY
 #endif
 #ifndef SKETCH_HAS_VERY_LARGE_MEMORY
-#define SKETCH_HAS_VERY_LARGE_MEMORY SKETCH_HAS_HUGE_MEMORY
+  #define SKETCH_HAS_VERY_LARGE_MEMORY FL_PLATFORM_HAS_HUGE_MEMORY
 #endif
 
+// =============================================================================
+// Misc utilities (kept as-is)
+// =============================================================================
 #ifndef SKETCH_STRINGIFY
 #define SKETCH_STRINGIFY_HELPER(x) #x
 #define SKETCH_STRINGIFY(x) SKETCH_STRINGIFY_HELPER(x)


### PR DESCRIPTION
## Summary

The memory-tier classification macros are named `SKETCH_HAS_*_MEMORY`, but they describe *platform* memory capacity, not anything about a user sketch. The name was misleading — and worse, it implied that sketches could/should override the value when in practice it is silicon-derived (with a build-flag escape hatch).

This PR promotes `FL_PLATFORM_HAS_*_MEMORY` to the canonical spelling and re-derives the legacy `SKETCH_HAS_*_MEMORY` names as deprecated aliases. Both spellings continue to evaluate identically; external user sketches keep compiling unchanged.

## Changes (single file — `src/fl/system/sketch_macros.h`)

- `FL_PLATFORM_HAS_TINY_MEMORY` / `FL_PLATFORM_HAS_LARGE_MEMORY` / `FL_PLATFORM_HAS_HUGE_MEMORY` are now the source-of-truth defines (plus the `_OVERRIDDEN` variants).
- Override detection accepts **either** spelling on the build-flag side — `-DSKETCH_HAS_LARGE_MEMORY=1` and `-DFL_PLATFORM_HAS_LARGE_MEMORY=1` are equivalent inputs, and setting one defines the other plus the `_OVERRIDDEN` marker.
- `SKETCH_HAS_*_MEMORY` / `SKETCH_HAS_*_MEMORY_OVERRIDDEN` / `SKETCH_HAS_LOTS_OF_MEMORY` / `SKETCH_HAS_VERY_LARGE_MEMORY` are preserved as backward-compat aliases via `#ifndef` + `#define` chains pointing at the canonical `FL_PLATFORM_HAS_*` names.

The ~50 internal callers in `src/`, `examples/`, `tests/`, and `ci/` that still spell the macro `SKETCH_HAS_*_MEMORY` are intentionally **NOT** touched in this PR — they keep working via the alias path. Each subsystem will migrate to the canonical name in its own focused follow-up PR, where the diff is reviewable in isolation. The issue body's explicit requirement that the rename "MUST keep the old `SKETCH_HAS_*` names working as deprecated aliases" is satisfied by this single-file change today.

## Open question from the issue (`FL_PLATFORM_HAS_*` vs `FL_HAS_*`)

Went with the issue's recommendation (`FL_PLATFORM_HAS_*`) because the tier is a property of the target platform/MCU, and the `FL_PLATFORM_` prefix matches other platform-detection macros. If a maintainer prefers `FL_HAS_*`, the alias chain means that future rename is also non-breaking — just re-point the `SKETCH_HAS_*` aliases to the new name.

## Test plan

- [x] `bash lint` — clean.
- [x] `bash test fl_log --cpp` — passes (uses `FASTLED_LOG_RUNTIME_ENABLED` which is gated on `SKETCH_HAS_LARGE_MEMORY` via the alias).
- [x] `bash test power --cpp` — passes (`power_mgt.cpp.hpp` keys off `SKETCH_HAS_LARGE_MEMORY` via the alias).
- [x] `bash autoresearch lpc845brk --upload-port COM10 --skip-lint --timeout 5` — LPC845 firmware still builds (text **62.16 KB / 64 KB**; **same byte-for-byte as before**, confirming the aliases are zero-overhead) and the bring-up RPC test passes on real hardware.

Closes #3000.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized platform memory configuration macros to new canonical naming convention
  * Maintained full backward compatibility with legacy macro names
  * Added support for explicit build-flag override detection and reporting
  * Restructured memory tier detection logic for improved platform compatibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->