### PR TITLE
chore(deps): bump zccache floor >=1.12.1 -> >=1.12.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,7 +143,7 @@ dependencies = [
     # incremental builds produce stale .obj files after a git pull that
     # changes transitive headers (symptom: `undefined symbol: ...` link
     # errors hours after a header actually changed).
-    "zccache>=1.12.1",
+    "zccache>=1.12.3",
     "ninja",
     "meson>=1.11.0",
     "download",


### PR DESCRIPTION
## Summary

Bumps zccache floor to >=1.12.3. The high-value FastLED-visible fix is **zackees/zccache#710**: the meson configure snapshot was capturing `*.pch` / `*.obj` from already-built dirs and restoring them into freshly-cleaned dirs, defeating `#pragma once` dedup and producing `redefinition of 'IChannelDriver'` errors. 1.12.3 fixes the capture (strict allowlist), the no-op-reconfigure capture path, and makes `zccache clear` purge the poisoned entries.

Also picked up:
- **#726** — wedge guard no longer kills healthy daemon under burst link load.
- **#728** — enriched persist WARN diagnostics.

## Test plan

- [ ] CI green once zccache 1.12.3 hits PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `zccache` dependency from version `>=1.12.1` to `>=1.12.3`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->