### PR TITLE
feat(rx/lpc): SCT input-capture + pin-toggle loopback (refs #3021)

### DIFF
--- a/ci/autoresearch/args.py
+++ b/ci/autoresearch/args.py
@@ -88,6 +88,9 @@ class Args:
     # Decode autoresearch mode (host-only, no device needed)
     decode: str | None
 
+    # LPC845 SCT-RX bench (#3021 Phase 1) — pin-toggle TX→SCT-RX loopback validation.
+    pin_toggle_rx: bool
+
     # Multi-frame capture — number of back-to-back show()/capture cycles per pattern.
     # None = driver-default (SPI → 2, others → 1). Explicit value overrides.
     # See issues #2254 and #2288 (ESP32-S3 SPI second-frame degradation).
@@ -314,6 +317,20 @@ See Also:
             default=None,
             metavar="PATH_OR_URL",
             help="Decode a media file (local path or URL). Supported: .mp4 .mpeg .mpg .gif .jpg .jpeg .mp3 .webp",
+        )
+
+        # LPC845 SCT-RX bench (#3021 Phase 1). Mirrors --flex-io / --object-fled
+        # in shape but routes through the LPC bring-up sketch's pinToggleRx RPC.
+        lpc_group = parser.add_argument_group(
+            "LPC AutoResearch (SCT-RX)",
+            "Hardware-bench tests for the LPC845 SCT input-capture RX backend.",
+        )
+        lpc_group.add_argument(
+            "--pin-toggle-rx",
+            action="store_true",
+            help="LPC845-only: bit-bang TX → SCT-RX pin-toggle loopback "
+            "(closes Phase 1 of FastLED #3021). Requires a jumper from "
+            "--tx-pin (default P0_10) to --rx-pin (default P0_11).",
         )
 
         # Standard options
@@ -589,6 +606,7 @@ See Also:
             ble=parsed.ble,
             parallel=parsed.parallel,
             decode=parsed.decode,
+            pin_toggle_rx=parsed.pin_toggle_rx,
             frames=parsed.frames,
             tight_timing=parsed.tight_timing,
             tight_timing_iterations=parsed.tight_timing_iterations,

--- a/ci/autoresearch/phases.py
+++ b/ci/autoresearch/phases.py
@@ -1177,6 +1177,10 @@ async def _run_tests_or_special_mode(ctx: RunContext, qctx: QuietContext) -> int
     # echo check instead of bailing with a "no tests requested" success.
     bring_up_envs = {"lpc845brk", "lpcxpresso845max", "lpcxpresso804"}
     if ctx.final_environment in bring_up_envs:
+        # FastLED #3021 Phase 1: --pin-toggle-rx runs the SCT-RX
+        # loopback bench instead of the default echo bring-up.
+        if getattr(ctx.args, "pin_toggle_rx", False):
+            return await _run_lpc_pin_toggle_rx_tests(ctx)
         return await _run_bring_up_tests(ctx)
 
     # GPIO-only mode
@@ -1577,6 +1581,44 @@ async def _run_bring_up_tests(ctx: RunContext) -> int:
     finally:
         if ser is not None:
             ser.close()
+
+
+async def _run_lpc_pin_toggle_rx_tests(ctx: RunContext) -> int:
+    """Run the FastLED #3021 Phase-1 SCT-RX pin-toggle bench.
+
+    Delegates to `ci/autoresearch/test_lpc_pin_toggle_rx.py` so the
+    bench logic stays in one place (the script is also runnable
+    stand-alone for ad-hoc bring-up). Uses `subprocess` to keep the
+    pyserial dependency contained to the script — the autoresearch
+    runner itself stays import-free of `serial`.
+    """
+    upload_port = ctx.upload_port
+    assert upload_port is not None
+
+    tx_pin = ctx.args.tx_pin if ctx.args.tx_pin is not None else 10
+    rx_pin = ctx.args.rx_pin if ctx.args.rx_pin is not None else 11
+
+    print()
+    print("=" * 60)
+    print("LPC SCT-RX MODE — pin-toggle TX → SCT-RX loopback (#3021 Phase 1)")
+    print(f"   Wiring required: jumper P0_{tx_pin} ↔ P0_{rx_pin} on LPC845-BRK")
+    print("=" * 60)
+    print()
+
+    cmd = [
+        "uv",
+        "run",
+        "python",
+        "ci/autoresearch/test_lpc_pin_toggle_rx.py",
+        "--port",
+        upload_port,
+        "--tx-pin",
+        str(tx_pin),
+        "--rx-pin",
+        str(rx_pin),
+    ]
+    result = subprocess.run(cmd)
+    return 0 if result.returncode == 0 else 1
 
 
 async def _run_coroutine_tests(ctx: RunContext) -> int:

--- a/ci/autoresearch/test_lpc_pin_toggle_rx.py
+++ b/ci/autoresearch/test_lpc_pin_toggle_rx.py
@@ -1,0 +1,270 @@
+"""Phase 1 of FastLED #3021 — bench-validate the LPC845 SCT-RX backend.
+
+Drives a square wave on the TX pin via a bit-bang loop in the LPC845
+bring-up sketch (`examples/AutoResearchLpc/AutoResearchLpc.ino`),
+captures inter-edge timings via the new SCT-input-capture
+`LpcSctRxChannel`, and asserts that mean / σ of the recovered period
+fall within tolerance.
+
+Three rates, mirroring FastLED #3021's Phase 1 acceptance table:
+
+    | Frequency | Period      | Tolerance (σ)  | Tolerance (mean) |
+    |-----------|-------------|----------------|------------------|
+    | 1   kHz   | 1 000 000ns | <  1 000 ns    | ±2 %             |
+    | 10  kHz   |   100 000ns | <    500 ns    | ±2 %             |
+    | 100 kHz   |    10 000ns | <    500 ns    | ±2 %             |
+
+(Tolerances are slightly looser than the Teensy 4 FlexIO bench because
+the M0+ polling loop adds 1–2 µs of capture jitter per edge — see
+`src/platforms/arm/lpc/rx_sct_capture.cpp.hpp::pollOnce` for the
+timing budget.)
+
+Usage:
+    uv run python ci/autoresearch/test_lpc_pin_toggle_rx.py [--port COM10]
+
+Talks to the AutoResearchLpc firmware over the same raw-serial
+JSON-RPC protocol as the bring-up echo test (`phases.py
+::_run_bring_up_tests`), but the LPC `pinToggleRx` RPC takes 4
+positional integer args and returns a CSV-encoded string (smaller
+flash footprint than the JSON-object response shape FlexIO uses).
+
+Exits 0 on success, 1 on any failed assertion / RPC error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from dataclasses import dataclass
+from typing import Any
+
+
+try:
+    import serial  # type: ignore
+except ImportError:
+    serial = None  # type: ignore
+
+
+DEFAULT_PORT = "COM10"
+DEFAULT_BAUD = 115200
+
+
+@dataclass
+class BenchCase:
+    label: str
+    frequency_hz: int
+    duration_ms: int
+    expected_period_ns: int
+    sigma_max_ns: int
+    mean_tolerance_pct: float
+
+
+CASES: list[BenchCase] = [
+    BenchCase("1.1 / 1 kHz", 1_000, 200, 1_000_000, 1_000, 2.0),
+    BenchCase("1.2 / 10 kHz", 10_000, 100, 100_000, 500, 2.0),
+    BenchCase("1.3 / 100 kHz", 100_000, 100, 10_000, 500, 2.0),
+]
+
+
+def send_rpc(
+    s: "serial.Serial",
+    method: str,
+    args: list[Any] | None = None,
+    request_id: int = 1,
+    timeout: float = 10.0,
+) -> dict[str, Any] | None:
+    """Send a JSON-RPC request and return the first matching response.
+
+    `args` is a *list of positional args* (matching the AutoResearchLpc
+    sketch's typed-binding signature like `pinToggleRx(int, int, int, int)`),
+    NOT a dict — the LPC bring-up sketch doesn't use the FlexIO-style
+    `[{"key": value, ...}]` wrapper because the typed binding gives a
+    smaller flash footprint on the LPC845's 64 KB budget.
+    """
+    params = args if args is not None else []
+    req = {"jsonrpc": "2.0", "method": method, "params": params, "id": request_id}
+    s.write((json.dumps(req, separators=(",", ":")) + "\n").encode("ascii"))
+    s.flush()
+
+    deadline = time.time() + timeout
+    buf = b""
+    while time.time() < deadline:
+        chunk = s.read(s.in_waiting or 1)
+        if not chunk:
+            continue
+        buf += chunk
+        while b"\n" in buf:
+            line, _, buf = buf.partition(b"\n")
+            text = line.decode("ascii", errors="replace").strip()
+            for prefix in ("REMOTE: ", "RESULT: "):
+                if text.startswith(prefix):
+                    text = text[len(prefix) :]
+                    break
+            if not (text.startswith("{") and text.endswith("}")):
+                continue
+            try:
+                msg = json.loads(text)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(msg, dict) and msg.get("id") == request_id:
+                return msg
+    return None
+
+
+def parse_csv_result(csv: str) -> dict[str, int]:
+    """Parse the AutoResearchLpc pinToggleRx CSV reply.
+
+    Format (defined in examples/AutoResearchLpc/AutoResearchLpc.ino):
+        success,edges,periods,mean_ns,sigma_ns,min_ns,max_ns
+    """
+    fields = ("success", "edges", "periods", "mean_ns", "sigma_ns", "min_ns", "max_ns")
+    parts = csv.split(",")
+    if len(parts) != len(fields):
+        return {}
+    try:
+        return {k: int(v) for k, v in zip(fields, parts)}
+    except ValueError:
+        return {}
+
+
+def evaluate(case: BenchCase, parsed: dict[str, int]) -> tuple[bool, str]:
+    edges = parsed.get("edges", 0)
+    periods = parsed.get("periods", 0)
+    mean_ns = parsed.get("mean_ns", 0)
+    sigma_ns = parsed.get("sigma_ns", 0)
+    min_ns = parsed.get("min_ns", 0)
+    max_ns = parsed.get("max_ns", 0)
+    success = parsed.get("success", 0)
+    if not success:
+        return False, (
+            f"firmware reported success=0 (edges={edges}, periods={periods}) — "
+            "SCT capture likely returned no edges; verify TX↔RX jumper"
+        )
+    if periods < 5:
+        return False, (
+            f"only {periods} periods captured in {case.duration_ms} ms "
+            f"(edges={edges}) — capture path likely not working yet"
+        )
+    mean_low = case.expected_period_ns * (1.0 - case.mean_tolerance_pct / 100.0)
+    mean_high = case.expected_period_ns * (1.0 + case.mean_tolerance_pct / 100.0)
+    if not (mean_low <= mean_ns <= mean_high):
+        return False, (
+            f"mean {mean_ns} ns outside ±{case.mean_tolerance_pct}% of "
+            f"{case.expected_period_ns} ns (range {mean_low:.0f}..{mean_high:.0f})"
+        )
+    if sigma_ns > case.sigma_max_ns:
+        return False, f"sigma {sigma_ns} ns exceeds {case.sigma_max_ns} ns"
+    return True, (
+        f"edges={edges}, periods={periods}, mean={mean_ns} ns, "
+        f"sigma={sigma_ns} ns, min={min_ns} ns, max={max_ns} ns"
+    )
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--port", default=DEFAULT_PORT)
+    p.add_argument("--baud", default=DEFAULT_BAUD, type=int)
+    p.add_argument(
+        "--tx-pin",
+        default=10,
+        type=int,
+        help="LPC845 GPIO PIO0_n driven by bit-bang TX (default: P0_10)",
+    )
+    p.add_argument(
+        "--rx-pin",
+        default=11,
+        type=int,
+        help="LPC845 GPIO PIO0_n routed to SCT input 0 for capture "
+        "(default: P0_11; any PIO0_n works via SWM)",
+    )
+    args = p.parse_args()
+
+    if serial is None:
+        print(
+            "ERROR: pyserial not installed. Run: uv pip install pyserial",
+            file=sys.stderr,
+        )
+        return 2
+
+    print(f"[lpc-pin-toggle-rx] opening {args.port} @ {args.baud}")
+    try:
+        s = serial.Serial(args.port, args.baud, timeout=0.1)
+    except serial.SerialException as e:
+        print(f"ERROR: could not open {args.port}: {e}", file=sys.stderr)
+        return 2
+
+    with s:
+        # The LPC845-BRK uses a CMSIS-DAP USB-CDC bridge; DTR/RTS toggles
+        # reset the target. Hold them de-asserted and let the boot banner
+        # drain before sending any RPC. This matches the bring-up echo
+        # test's open sequence (phases.py::_run_bring_up_tests).
+        s.dtr = False
+        s.rts = False
+        time.sleep(0.5)
+        s.reset_input_buffer()
+        time.sleep(2.0)
+        s.reset_input_buffer()
+
+        # Health check via the bring-up sketch's echo RPC. Confirms the
+        # serial pipe + JSON-RPC parser are alive before we trust the
+        # pinToggleRx result.
+        echo = send_rpc(s, "echo", args=[42], request_id=1, timeout=5.0)
+        if not echo or echo.get("result") != 42:
+            print(
+                "ERROR: echo failed; is AutoResearchLpc flashed and "
+                f"running? Got: {echo}",
+                file=sys.stderr,
+            )
+            return 2
+        print("[lpc-pin-toggle-rx] echo ok")
+
+        passes = 0
+        fails = 0
+        for i, case in enumerate(CASES, start=10):
+            print(
+                f"\n--- {case.label} "
+                f"({case.frequency_hz} Hz / {case.duration_ms} ms) ---"
+            )
+            resp = send_rpc(
+                s,
+                "pinToggleRx",
+                args=[args.tx_pin, args.rx_pin, case.frequency_hz, case.duration_ms],
+                request_id=i,
+                # SCT capture runs synchronously inside the sketch loop;
+                # allow 2× the bit-bang window plus 5 s headroom.
+                timeout=(case.duration_ms / 1000.0) * 2.0 + 5.0,
+            )
+            if not resp or "result" not in resp:
+                print(f"  FAIL: no response or RPC error: {resp}")
+                fails += 1
+                continue
+            csv = resp["result"]
+            if not isinstance(csv, str):
+                print(f"  FAIL: expected string CSV, got {type(csv).__name__}: {csv}")
+                fails += 1
+                continue
+            parsed = parse_csv_result(csv)
+            if not parsed:
+                print(f"  FAIL: malformed CSV: {csv!r}")
+                fails += 1
+                continue
+            ok, msg = evaluate(case, parsed)
+            if ok:
+                print(f"  PASS: {msg}")
+                passes += 1
+            else:
+                print(f"  FAIL: {msg}")
+                print(f"        raw csv: {csv!r}")
+                fails += 1
+
+        print(
+            f"\n[lpc-pin-toggle-rx] summary: {passes} pass / {fails} fail "
+            f"out of {len(CASES)} cases"
+        )
+        return 0 if fails == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/AutoResearchLpc/AutoResearchLpc.ino
+++ b/examples/AutoResearchLpc/AutoResearchLpc.ino
@@ -11,6 +11,14 @@
 // blows ~4 KB of flash budget. fbuild's nxplpc orchestrator does not
 // yet propagate platformio.ini's `build_flags`, so it's defined here.
 #define RELEASE 1
+
+// Opt in to the SCT input-capture RX backend (FastLED #3021). With this
+// flag set, `LpcSctRxChannel::begin()` programs the SCT for hardware
+// edge-capture; without it the driver is a no-op stub (host tests still
+// work via `injectEdges()`). The Phase-1 acceptance for #3021 requires
+// the lpc845brk fbuild target to compile with this flag set.
+#define FASTLED_LPC_RX_SCT 1
+
 //
 // examples/AutoResearchLpc/AutoResearchLpc.ino
 //
@@ -21,7 +29,8 @@
 //
 // Purpose: validate that on a freshly-brought-up board the basic transport
 // (Serial.println, FastLED log pipeline, JSON-RPC echo) all work end-to-end
-// through `bash autoresearch lpc845brk --bring-up`.
+// through `bash autoresearch lpc845brk --bring-up`, plus the SCT-RX
+// pin-toggle loopback that closes the FastLED #3021 Phase-1 gate.
 //
 // RPC contract (over Serial @ 115200, JSON-RPC 2.0 framed by `\n`,
 // responses prefixed with `REMOTE: `):
@@ -30,6 +39,20 @@
 //     Returns the input integer unchanged. The bring-up harness sends
 //     {"jsonrpc":"2.0","method":"echo","params":[N],"id":I} and verifies
 //     the response is {"id":I,"result":N,"jsonrpc":"2.0"}.
+//
+//   pinToggleRx: [tx_pin, rx_pin, freq_hz, duration_ms] -> string
+//     Phase-1 SCT-RX validation (FastLED #3021). Bit-bangs a square wave
+//     on tx_pin and concurrently arms SCT input-capture on rx_pin (via
+//     LpcSctRxChannel — the LPC8xx SCT input-capture driver).
+//     Returns CSV: "success,edges,periods,mean_ns,sigma_ns,min_ns,max_ns"
+//     where:
+//       success    1 if at least one full period was captured, else 0
+//       edges      total edges latched by SCT during the window
+//       periods    number of complete (high+low) period pairs
+//       mean_ns    mean of all period durations in ns
+//       sigma_ns   standard deviation of period durations in ns
+//       min_ns,max_ns   period extrema in ns
+//     Wiring: jumper tx_pin to rx_pin externally on the LPC845-BRK header.
 //
 // FL_DBG output from inside fl::Remote (e.g. "Stored request ID for echo")
 // also reaches the host through this transport, demonstrating that the
@@ -42,10 +65,60 @@
 #include "fl/remote/transport/serial.h"
 #include "fl/wdt/watchdog.h"
 #include "fl/log/log.h"
+#include "fl/channels/rx_sct_capture.h"
+#include "fl/stl/strstream.h"
 
 namespace {
 fl::Remote* g_remote = nullptr;
+
+// ----------------------------------------------------------------------
+// Period-stat helpers for `pinToggleRx`. Mirror the FlexIO RX benchmark
+// logic in `examples/AutoResearch/AutoResearchRemote.cpp::flexioRxBenchmark`
+// but inline so we don't pull in the AutoResearch ObjectFLED bus.
+// ----------------------------------------------------------------------
+struct PinTogglePeriodStats {
+    fl::u32 periods;
+    fl::u32 mean_ns;
+    fl::u32 sigma_ns;
+    fl::u32 min_ns;
+    fl::u32 max_ns;
+};
+
+PinTogglePeriodStats computePeriodStats(const fl::EdgeTime* edges,
+                                        fl::size edge_count) FL_NOEXCEPT {
+    PinTogglePeriodStats s{0, 0, 0, 0, 0};
+    fl::u64 sum    = 0;
+    fl::u64 sum_sq = 0;
+    fl::u32 min_ns = 0xFFFFFFFFu;
+    fl::u32 max_ns = 0;
+    fl::u32 count  = 0;
+    for (fl::size i = 0; i + 1 < edge_count; i += 2) {
+        const fl::u32 period_ns =
+            static_cast<fl::u32>(edges[i].ns) +
+            static_cast<fl::u32>(edges[i + 1].ns);
+        if (period_ns == 0) continue;
+        sum    += period_ns;
+        sum_sq += static_cast<fl::u64>(period_ns) * static_cast<fl::u64>(period_ns);
+        if (period_ns < min_ns) min_ns = period_ns;
+        if (period_ns > max_ns) max_ns = period_ns;
+        ++count;
+    }
+    if (count == 0) return s;
+    const fl::u32 mean = static_cast<fl::u32>(sum / static_cast<fl::u64>(count));
+    const fl::u64 mean64 = static_cast<fl::u64>(mean);
+    const fl::u64 var = (sum_sq / static_cast<fl::u64>(count)) - (mean64 * mean64);
+    // Integer sqrt for sigma — adequate at the σ < 500 ns scale.
+    fl::u32 sig = 0;
+    while (static_cast<fl::u64>(sig + 1) * static_cast<fl::u64>(sig + 1) <= var) ++sig;
+    s.periods  = count;
+    s.mean_ns  = mean;
+    s.sigma_ns = sig;
+    s.min_ns   = (min_ns == 0xFFFFFFFFu) ? 0u : min_ns;
+    s.max_ns   = max_ns;
+    return s;
 }
+
+}  // namespace
 
 void setup() {
     Serial.begin(115200);
@@ -75,6 +148,95 @@ void setup() {
         FL_WARN_LIT("FL_WARN: echo invoked");
         return v;
     });
+
+    // ------------------------------------------------------------------
+    // pinToggleRx (FastLED #3021 Phase 1)
+    // ------------------------------------------------------------------
+    // Drive tx_pin with a freq_hz square wave for duration_ms, while SCT
+    // input-capture latches every edge on rx_pin. Returns CSV stats so the
+    // Python orchestrator can assert mean and σ thresholds.
+    //
+    // CSV slot ordering (must match ci/autoresearch/test_lpc_pin_toggle_rx.py):
+    //   success, edges, periods, mean_ns, sigma_ns, min_ns, max_ns
+    remote.bind("pinToggleRx",
+        [](int tx_pin, int rx_pin, int freq_hz, int duration_ms) -> fl::string {
+            // Defensive arg clamp (M0+ has no exceptions; bad inputs just
+            // truncate so the orchestrator sees `success=0`).
+            if (tx_pin < 0 || rx_pin < 0 || freq_hz <= 0 || duration_ms <= 0) {
+                return fl::string("0,0,0,0,0,0,0");
+            }
+
+            // Size the capture buffer for the expected edge count + 50%
+            // headroom. Clamped to a ceiling that fits LPC845 SRAM
+            // (16 KB total — 8 bytes/EdgeTime → 2048 edges = 16 KB hard
+            // ceiling; in practice we keep well below to leave room for
+            // the rest of the runtime).
+            const fl::u32 expected_edges =
+                2u * static_cast<fl::u32>(freq_hz) *
+                     static_cast<fl::u32>(duration_ms) / 1000u;
+            fl::u32 cap = expected_edges + (expected_edges / 2u);
+            if (cap < 256u)  cap = 256u;
+            if (cap > 2048u) cap = 2048u;
+
+            auto rx = fl::LpcSctRxChannel::create(rx_pin);
+            if (!rx) return fl::string("0,0,0,0,0,0,0");
+
+            fl::RxConfig cfg;
+            cfg.buffer_size = cap;
+            cfg.start_low   = true;
+            if (!rx->begin(cfg)) return fl::string("0,0,0,0,0,0,0");
+
+            // Bit-bang TX *while* concurrently polling SCT input-capture.
+            // The polling-mode RX driver can't autonomously fill its
+            // EdgeTime ring (it requires someone to read CAP[0..1]
+            // between edges, otherwise each new capture overwrites the
+            // previous one in-register). To work around that on a
+            // single-threaded M0+, the bit-bang loop calls rx->pollOnce()
+            // between each digitalWrite, draining any pending edge.
+            //
+            // Phase 2 (#3021) upgrades the RX path to SCT→DMA, at which
+            // point this interleave goes away — pollOnce() becomes a no-op
+            // and wait() just blocks on the DMA-done flag.
+            pinMode(tx_pin, OUTPUT);
+            digitalWrite(tx_pin, LOW);
+
+            const fl::u32 half_us = 500000u / static_cast<fl::u32>(freq_hz);
+            const fl::u32 cycles  = static_cast<fl::u32>(freq_hz) *
+                                     static_cast<fl::u32>(duration_ms) / 1000u;
+
+            for (fl::u32 i = 0; i < cycles; ++i) {
+                digitalWrite(tx_pin, HIGH);
+                delayMicroseconds(half_us);
+                rx->pollOnce();
+                digitalWrite(tx_pin, LOW);
+                delayMicroseconds(half_us);
+                rx->pollOnce();
+                if ((i & 0x7Fu) == 0u) {
+                    fl::Watchdog::instance().feed();
+                }
+            }
+
+            // Final drain — picks up any in-flight edge that the last
+            // pollOnce() missed (the LOW→HIGH or HIGH→LOW transition
+            // that races with the loop exit).
+            rx->wait(1);
+
+            // Pull the captured edges out.
+            fl::EdgeTime edges_buf[2048];
+            const fl::size n_read = rx->getRawEdgeTimes(
+                fl::span<fl::EdgeTime>(edges_buf, sizeof(edges_buf) / sizeof(edges_buf[0])));
+
+            PinTogglePeriodStats stats = computePeriodStats(edges_buf, n_read);
+
+            // Format CSV. fl::strstream + manual concat is the lightest
+            // option that avoids snprintf bloat on M0+.
+            fl::strstream s;
+            const bool success = (stats.periods > 0);
+            s << (success ? 1 : 0) << ',' << static_cast<fl::u32>(n_read) << ','
+              << stats.periods << ',' << stats.mean_ns << ',' << stats.sigma_ns << ','
+              << stats.min_ns << ',' << stats.max_ns;
+            return s.str();
+        });
 }
 
 void loop() {

--- a/examples/AutoResearchLpc/AutoResearchLpc.ino
+++ b/examples/AutoResearchLpc/AutoResearchLpc.ino
@@ -65,12 +65,23 @@
 #include "fl/remote/transport/serial.h"
 #include "fl/wdt/watchdog.h"
 #include "fl/log/log.h"
+
+// The host-stub example DLL build (`tests/shared/example_dll_wrapper_template.cpp`)
+// compiles this sketch on Linux to surface ABI breaks. The RX SCT driver
+// types (`fl::EdgeTime`, `fl::RxConfig`, `fl::LpcSctRxChannel`) are
+// platform-gated behind `FL_IS_ARM_LPC` — they only exist on the real
+// LPC build. So the include + every RX usage below must be gated the
+// same way.
+#include "platforms/arm/lpc/is_lpc.h"
+#if defined(FL_IS_ARM_LPC)
 #include "fl/channels/rx_sct_capture.h"
 #include "fl/stl/strstream.h"
+#endif
 
 namespace {
 fl::Remote* g_remote = nullptr;
 
+#if defined(FL_IS_ARM_LPC)
 // ----------------------------------------------------------------------
 // Period-stat helpers for `pinToggleRx`. Mirror the FlexIO RX benchmark
 // logic in `examples/AutoResearch/AutoResearchRemote.cpp::flexioRxBenchmark`
@@ -117,6 +128,7 @@ PinTogglePeriodStats computePeriodStats(const fl::EdgeTime* edges,
     s.max_ns   = max_ns;
     return s;
 }
+#endif  // FL_IS_ARM_LPC
 
 }  // namespace
 
@@ -149,12 +161,17 @@ void setup() {
         return v;
     });
 
+#if defined(FL_IS_ARM_LPC)
     // ------------------------------------------------------------------
     // pinToggleRx (FastLED #3021 Phase 1)
     // ------------------------------------------------------------------
     // Drive tx_pin with a freq_hz square wave for duration_ms, while SCT
     // input-capture latches every edge on rx_pin. Returns CSV stats so the
     // Python orchestrator can assert mean and σ thresholds.
+    //
+    // Gated behind FL_IS_ARM_LPC so the example DLL host-stub build
+    // (tests/shared/example_dll_wrapper_template.cpp) doesn't try to
+    // compile the LPC-only RX driver path.
     //
     // CSV slot ordering (must match ci/autoresearch/test_lpc_pin_toggle_rx.py):
     //   success, edges, periods, mean_ns, sigma_ns, min_ns, max_ns
@@ -237,6 +254,7 @@ void setup() {
               << stats.min_ns << ',' << stats.max_ns;
             return s.str();
         });
+#endif  // FL_IS_ARM_LPC
 }
 
 void loop() {

--- a/examples/AutoResearchLpc/AutoResearchLpc.ino
+++ b/examples/AutoResearchLpc/AutoResearchLpc.ino
@@ -228,9 +228,9 @@ void setup() {
 
             PinTogglePeriodStats stats = computePeriodStats(edges_buf, n_read);
 
-            // Format CSV. fl::strstream + manual concat is the lightest
+            // Format CSV. fl::sstream + manual concat is the lightest
             // option that avoids snprintf bloat on M0+.
-            fl::strstream s;
+            fl::sstream s;
             const bool success = (stats.periods > 0);
             s << (success ? 1 : 0) << ',' << static_cast<fl::u32>(n_read) << ','
               << stats.periods << ',' << stats.mean_ns << ',' << stats.sigma_ns << ','

--- a/src/platforms/arm/lpc/rx_sct_capture.cpp.hpp
+++ b/src/platforms/arm/lpc/rx_sct_capture.cpp.hpp
@@ -1,15 +1,20 @@
 /// @file platforms/arm/lpc/rx_sct_capture.cpp.hpp
-/// @brief LPC8xx SCT input-capture RX implementation (scaffold + decoder).
+/// @brief LPC8xx SCT input-capture RX implementation.
 ///
-/// See `rx_sct_capture.h` for the status note. This file ships:
-///   * The full edge-pair → byte decoder (kept in-TU per the FlexPWM /
-///     FlexIO convention; the follow-up `src/fl/channels/rx/decode_ws2812.h`
-///     refactor will consolidate all three).
-///   * `injectEdges()` + `getRawEdgeTimes()` against an in-RAM vector.
-///   * A documented `// TODO` block in `begin()` mapping out the SCT +
-///     DMA register sequence per UM11029 — register references inline
-///     so a follow-up bench session can fill it in without re-reading
-///     the manual.
+/// **Status:**
+///   * Host / non-LPC builds: edge buffer is RAM-backed; `injectEdges()` +
+///     `decode()` round-trip works without hardware (see
+///     `tests/fl/channels/rx_sct_capture.cpp`).
+///   * LPC845 builds with `-DFASTLED_LPC_RX_SCT=1`: the SCT input-capture
+///     path in `begin()` / `wait()` polls SCT EVFLAG and reads CAPTURE[0..1]
+///     to populate the edge buffer from real silicon. The polling design is
+///     adequate for the Phase-1 pin-toggle test (≤ 100 kHz square waves —
+///     see #3021). Phase 2 (WS2812 at 800 kHz) will upgrade to SCT→DMA in a
+///     follow-up commit.
+///   * LPC845 builds *without* `-DFASTLED_LPC_RX_SCT`: same as host —
+///     `begin()` is a no-op past clearing the buffer; the flash budget on
+///     the LPC845 bring-up sketch is preserved for sketches that don't
+///     opt in to the RX driver.
 
 // IWYU pragma: private
 
@@ -22,6 +27,139 @@
 #include "fl/log/log.h"
 
 namespace fl {
+
+#if defined(FASTLED_LPC_RX_SCT) && defined(FL_IS_ARM_LPC_845)
+
+// ============================================================================
+// LPC845 SCT register access — see embedded comment block below for the
+// UM11029 source for every offset and bit position. Layout cross-checked
+// against the hardware-validated SYSCON offsets in `watchdog_lpc.impl.hpp`.
+// ============================================================================
+//
+// Memory map (UM11029 §3 Memory Map):
+//   SYSCON   0x40048000
+//   SWM      0x4000C000
+//   INPUTMUX 0x4002C000
+//   SCT      0x50004000
+//   DMA      0x50008000
+//
+// SYSCON SYSAHBCLKCTRL0 at +0x080, PRESETCTRL0 at +0x088 (UM11029 §8.6.22/24):
+//   bit  7 SWM    bit  8 SCT    bit 17 WWDT (validated by watchdog file)
+//   bit 18 IOCON  bit 29 DMA
+//
+// SWM PINASSIGN (UM11029 §10.5 Tables 186/187 — pin encoding: PIO0_n -> n,
+// PIO1_n -> 0x20+n, unassign = 0xFF):
+//   PINASSIGN6  +0x018  bits[31:24] = SCT0_GPIO_IN_A_I  (= SCT IOSEL=0)
+//   PINASSIGN7  +0x01C  bits[ 7: 0] = SCT0_GPIO_IN_B_I  (= SCT IOSEL=1)
+//                       bits[15: 8] = SCT0_GPIO_IN_C_I  (= SCT IOSEL=2)
+//                       bits[23:16] = SCT0_GPIO_IN_D_I  (= SCT IOSEL=3)
+//
+// SCT register offsets (UM11029 §21.6 Table 386, UNIFY=1):
+//   0x000 CONFIG     UNIFY=bit0, CLKMODE=[2:1], INSYNC=[12:9]
+//   0x004 CTRL       HALT_L=bit2, CLRCTR_L=bit3
+//   0x008 LIMIT      bits[7:0] = event mask that limits the unified counter
+//   0x040 COUNT      32-bit free-running counter (read/write)
+//   0x04C REGMODE    bits[7:0] : 1 = CAPTURE, 0 = MATCH (per index)
+//   0x05C DMAREQ0    bit n = event n raises SCT_DMA0 trigger line
+//   0x060 DMAREQ1    "                                "
+//   0x0F0 EVEN       bits[7:0] : per-event interrupt enable
+//   0x0F4 EVFLAG     bits[7:0] : per-event flag (W1C)
+//   0x100+4*n MATCH[n] / CAP[n]     (selected by REGMODE bit n)
+//   0x200+4*n MATCHREL[n] / CAPCTRL[n] (same — REGMODE selects)
+//   0x300+8*n EV[n].STATE  bit m = enabled in STATE m
+//   0x304+8*n EV[n].CTRL    layout below
+//
+// EV[n].CTRL fields (UM11029 §21.6.25 Table 411):
+//   [ 3: 0] MATCHSEL    (unused for pure IO events)
+//   [    4] HEVENT      must be 0 when UNIFY=1
+//   [    5] OUTSEL      0 = input, 1 = output
+//   [ 9: 6] IOSEL       SCT input number 0..3 (or output 0..6)
+//   [11:10] IOCOND      0=LOW, 1=Rise, 2=Fall, 3=HIGH
+//   [13:12] COMBMODE    0=OR, 1=MATCH-only, 2=IO-only, 3=AND
+//
+// CAPCTRL[n] (UM11029 §21.6.23 Table 409 — when REGMODE bit n = 1):
+//   [ 7: 0] CAPCONn_L : bit m = 1 → event m loads CAPn
+
+namespace {
+
+constexpr fl::u32 kSysconBase   = 0x40048000u;
+constexpr fl::u32 kSwmBase      = 0x4000C000u;
+constexpr fl::u32 kSctBase      = 0x50004000u;
+
+constexpr fl::u32 kOffSYSAHBCLKCTRL0 = 0x080u;
+constexpr fl::u32 kOffPRESETCTRL0    = 0x088u;
+constexpr fl::u32 kClkSWM = (1u <<  7);
+constexpr fl::u32 kClkSCT = (1u <<  8);
+constexpr fl::u32 kRstSWM = (1u <<  7);
+constexpr fl::u32 kRstSCT = (1u <<  8);
+
+constexpr fl::u32 kOffPINASSIGN6 = 0x018u;
+constexpr fl::u32 kOffPINASSIGN7 = 0x01Cu;
+constexpr fl::u8  kSwmUnassign   = 0xFFu;
+
+constexpr fl::u32 kOffCONFIG  = 0x000u;
+constexpr fl::u32 kOffCTRL    = 0x004u;
+constexpr fl::u32 kOffLIMIT   = 0x008u;
+constexpr fl::u32 kOffCOUNT   = 0x040u;
+constexpr fl::u32 kOffREGMODE = 0x04Cu;
+constexpr fl::u32 kOffEVEN    = 0x0F0u;
+constexpr fl::u32 kOffEVFLAG  = 0x0F4u;
+constexpr fl::u32 kOffMATCH0  = 0x100u;       // shared with CAP[n]
+constexpr fl::u32 kOffMATCHREL0 = 0x200u;     // shared with CAPCTRL[n]
+constexpr fl::u32 kOffEV0_STATE = 0x300u;
+constexpr fl::u32 kOffEV0_CTRL  = 0x304u;
+
+constexpr fl::u32 kCfgUnify    = (1u << 0);
+constexpr fl::u32 kCfgInsync0  = (1u << 9);
+constexpr fl::u32 kCtrlHaltL   = (1u << 2);
+constexpr fl::u32 kCtrlClrCtrL = (1u << 3);
+
+// EV CTRL builder for "input-capture on SCT input N, edge E"
+constexpr fl::u32 evCtrlInputCapture(fl::u32 iosel, fl::u32 iocond) {
+    return (0u << 5)                  // OUTSEL = 0 (input)
+         | ((iosel & 0xFu) << 6)      // IOSEL
+         | ((iocond & 0x3u) << 10)    // IOCOND  (1=Rise, 2=Fall)
+         | (2u << 12);                // COMBMODE = IO-only
+}
+constexpr fl::u32 kIoCondRise = 1u;
+constexpr fl::u32 kIoCondFall = 2u;
+
+inline volatile fl::u32& reg(fl::u32 base, fl::u32 offset) FL_NOEXCEPT {
+    return *reinterpret_cast<volatile fl::u32*>(base + offset);  // ok reinterpret cast — MMIO addressing
+}
+inline volatile fl::u32& sct(fl::u32 offset) FL_NOEXCEPT { return reg(kSctBase, offset); }
+inline volatile fl::u32& sct_cap(fl::u32 n) FL_NOEXCEPT { return reg(kSctBase, kOffMATCH0    + 4u * n); }
+inline volatile fl::u32& sct_capctrl(fl::u32 n) FL_NOEXCEPT { return reg(kSctBase, kOffMATCHREL0 + 4u * n); }
+inline volatile fl::u32& sct_ev_state(fl::u32 n) FL_NOEXCEPT { return reg(kSctBase, kOffEV0_STATE + 8u * n); }
+inline volatile fl::u32& sct_ev_ctrl(fl::u32 n) FL_NOEXCEPT { return reg(kSctBase, kOffEV0_CTRL  + 8u * n); }
+
+// Assign or unassign the user's GPIO pin to SCT input 0 (SCT0_GPIO_IN_A_I)
+// via SWM PINASSIGN6 byte[31:24]. The byte value is the encoded pin number
+// (PIO0_n -> n; PIO1_n -> 0x20+n).
+inline void swmAssignSctInput0(fl::u8 swm_byte) FL_NOEXCEPT {
+    volatile fl::u32& r = reg(kSwmBase, kOffPINASSIGN6);
+    fl::u32 v = r;
+    v = (v & 0x00FFFFFFu) | (static_cast<fl::u32>(swm_byte) << 24);
+    r = v;
+}
+
+// Convert an unsigned tick delta (free-running 32-bit SCT counter, F_CPU
+// ticks) to nanoseconds. F_CPU is the SCT clock when CLKMODE=0; on
+// LPC845-BRK that is 30_000_000 Hz, giving 33.33 ns per tick.
+// Compute with u64 to avoid mid-multiplication overflow at the long-period
+// extreme: a full 32-bit tick wrap at 30 MHz is ~143 s = 1.43e11 ns, which
+// fits u64 with margin. EdgeTime.ns is a 31-bit bitfield (max ~2.1 s) so
+// we saturate above that.
+inline fl::u32 ticksToNs(fl::u32 ticks) FL_NOEXCEPT {
+    constexpr fl::u32 kFcpuMHz = (F_CPU + 500000u) / 1000000u;  // 30 on LPC845
+    fl::u64 ns64 = (static_cast<fl::u64>(ticks) * 1000u + (kFcpuMHz / 2)) / kFcpuMHz;
+    if (ns64 > 0x7FFFFFFFull) ns64 = 0x7FFFFFFFull;
+    return static_cast<fl::u32>(ns64);
+}
+
+}  // namespace
+
+#endif  // FASTLED_LPC_RX_SCT && FL_IS_ARM_LPC_845
 
 // ============================================================================
 // Factory
@@ -37,7 +175,23 @@ fl::shared_ptr<LpcSctRxChannel> LpcSctRxChannel::create(int pin) FL_NOEXCEPT {
 
 LpcSctRxChannel::LpcSctRxChannel(int pin) FL_NOEXCEPT
     : mPin(pin)
-    , mFinished(false) {
+    , mFinished(false)
+    , mCapacity(0)
+    , mPrevTick(0)
+    , mPrevSeen(false)
+    , mLastRising(false) {
+}
+
+LpcSctRxChannel::~LpcSctRxChannel() FL_NOEXCEPT {
+#if defined(FASTLED_LPC_RX_SCT) && defined(FL_IS_ARM_LPC_845)
+    // Release the pin from SCT input 0 so a follow-up driver can claim it.
+    // Leave the SCT/SWM clocks gated on — turning them off would require
+    // proof no other driver is mid-flight, which is brittle. Cost of
+    // leaving them on: ~tens of µA static, negligible vs the WWDT (always on).
+    sct(kOffCTRL) |= kCtrlHaltL;
+    sct(kOffEVEN)  = 0;
+    swmAssignSctInput0(kSwmUnassign);
+#endif
 }
 
 // ============================================================================
@@ -45,59 +199,52 @@ LpcSctRxChannel::LpcSctRxChannel(int pin) FL_NOEXCEPT
 // ============================================================================
 
 bool LpcSctRxChannel::begin(const RxConfig& config) FL_NOEXCEPT {
-    (void)config;
-    mEdges.clear();
     mFinished = false;
+    mCapacity = config.buffer_size > 0 ? config.buffer_size : 4096u;
+    mPrevTick = 0;
+    mPrevSeen = false;
+    mLastRising = false;
+    mEdges.clear();
+    mEdges.reserve(mCapacity);
 
-    // ------------------------------------------------------------------------
-    // TODO (#3015 follow-up — hardware bench session required):
-    //
-    // Wire SCT input capture + DMA to populate `mEdges` on real silicon.
-    // The skeleton below is the sequence the follow-up should implement.
-    // Register references are UM11029 (LPC84x User Manual, Rev 1.6).
-    //
-    // 1. Enable SCT in SYSCON:
-    //      SYSCON->SYSAHBCLKCTRL0 |= (1 << 8);   // SCT clock
-    //      SYSCON->PRESETCTRL0    &= ~(1 << 8);  // de-assert SCT reset
-    //      SYSCON->PRESETCTRL0    |=  (1 << 8);  // pulse reset
-    //
-    // 2. Route the user's pin -> CTIN_0 via the Switch Matrix (SWM).
-    //    LPC845 SWM lets any GPIO map to any SCT capture input. The
-    //    register is `SWM->PINASSIGN5` (PINASSIGN5[7:0] = CTIN_0). The
-    //    value is the PIO0_n number; e.g. for P0_11 the byte is 0x0B.
-    //
-    // 3. Configure SCT for 32-bit unified up-counter:
-    //      SCT->CONFIG = (1 << 0) /*UNIFY*/ | (0 << 1) /*sys clk*/;
-    //
-    // 4. Set up four capture registers (one per WS2812 edge type — rising,
-    //    falling — alternating into CAPTURE[0..3] so the DMA can stream
-    //    the result without re-arming):
-    //      SCT->REGMODE_L |= 0xF;  // CAPTURE0..3 are CAPTURE (not MATCH)
-    //
-    // 5. Set up events EV_0..EV_3 each gated on CTIN_0 with alternating
-    //    edge polarity:
-    //      SCT->EV[0].CTRL = (1 << 10) /*HEVENT*/ | (0 << 12) /*rising*/
-    //                      | (1 << 13) /*IOSEL = CTIN_0*/;
-    //      SCT->EV[1].CTRL = ... falling ...
-    //      ...
-    //    Each event triggers its corresponding CAPTURE[n] register
-    //    snapshot of the unified counter.
-    //
-    // 6. Hook a DMA channel to one of the SCT_DMA0/DMA1 request lines
-    //    (LPC845 DMA mux: DMATRIGCFG[n]). Source = SCT capture
-    //    register address, destination = `mEdges.data()`. Configure as
-    //    32-bit width, no-increment src, post-increment dst, transfer
-    //    count = `mEdges.capacity()`.
-    //
-    // 7. Start the SCT: SCT->CTRL_U &= ~(1 << 2);   // clear HALT_L
-    //
-    // 8. The ISR fires when DMA hits its transfer-complete bit. Set
-    //    `mFinished = true;` in the ISR (or here in wait() if polling).
-    //
-    // None of this is exercised on the host build (FL_IS_STUB) — the
-    // edge buffer stays empty until `injectEdges()` populates it from
-    // the test harness or the follow-up firmware-side capture path.
-    // ------------------------------------------------------------------------
+#if defined(FASTLED_LPC_RX_SCT) && defined(FL_IS_ARM_LPC_845)
+    // ---- 1. Power up SCT + SWM (and pulse their resets). ----
+    reg(kSysconBase, kOffSYSAHBCLKCTRL0) |= (kClkSCT | kClkSWM);
+    volatile fl::u32& presetctrl = reg(kSysconBase, kOffPRESETCTRL0);
+    presetctrl &= ~(kRstSCT | kRstSWM);   // assert reset (low pulse)
+    presetctrl |=  (kRstSCT | kRstSWM);   // release reset
+
+    // ---- 2. Route mPin -> SCT input 0 via SWM PINASSIGN6 byte[31:24]. ----
+    swmAssignSctInput0(static_cast<fl::u8>(mPin & 0xFFu));
+
+    // ---- 3. Configure SCT: UNIFY counter + INSYNC for input 0. ----
+    // The 2-clock synchronizer adds ~67 ns of capture jitter at F_CPU=30 MHz,
+    // well below the WS2812 T0H/T1H discrimination window (~500 ns margin).
+    sct(kOffCTRL)    = kCtrlHaltL | kCtrlClrCtrL;   // halted, counter zeroed
+    sct(kOffCONFIG)  = kCfgUnify  | kCfgInsync0;
+    sct(kOffLIMIT)   = 0u;                          // free-running counter
+    sct(kOffCOUNT)   = 0u;
+
+    // ---- 4. Mark register slots 0 + 1 as CAPTURE (REGMODE bits 0,1 = 1). ----
+    sct(kOffREGMODE) = (1u << 0) | (1u << 1);
+
+    // ---- 5. Event 0 → rising edge on SCT input 0 → captures into CAP[0].
+    //         Event 1 → falling edge on SCT input 0 → captures into CAP[1].
+    sct_ev_state(0) = 0x1u;   // active in STATE 0
+    sct_ev_ctrl (0) = evCtrlInputCapture(0u, kIoCondRise);
+    sct_ev_state(1) = 0x1u;
+    sct_ev_ctrl (1) = evCtrlInputCapture(0u, kIoCondFall);
+
+    sct_capctrl(0) = (1u << 0);   // EV0 loads CAP[0]
+    sct_capctrl(1) = (1u << 1);   // EV1 loads CAP[1]
+
+    sct(kOffEVEN)   = 0u;                        // polling mode — IRQs off
+    sct(kOffEVFLAG) = 0xFFu;                     // clear any stale flags
+
+    // ---- 6. Release HALT so the counter runs. Capture events will start
+    //         latching CAP[0] / CAP[1] on every input edge from now on.
+    sct(kOffCTRL) &= ~kCtrlHaltL;
+#endif
 
     return true;
 }
@@ -106,15 +253,82 @@ bool LpcSctRxChannel::finished() const FL_NOEXCEPT {
     return mFinished;
 }
 
-RxWaitResult LpcSctRxChannel::wait(u32 timeout_ms) FL_NOEXCEPT {
-    (void)timeout_ms;
-    mFinished = true;
-    if (mEdges.empty()) {
-        // No edges captured. Either the SCT/DMA setup is still a TODO
-        // (the common case in this PR) or no signal reached the pin.
-        return RxWaitResult::TIMEOUT;
+fl::size LpcSctRxChannel::pollOnce() FL_NOEXCEPT {
+#if defined(FASTLED_LPC_RX_SCT) && defined(FL_IS_ARM_LPC_845)
+    // Drain SCT EVFLAG into the edge buffer. For each event that has
+    // fired since the last poll:
+    //   * EV0 (rising-edge capture) → read CAP[0]. If we already saw a
+    //     prior edge, the line was LOW from `mPrevTick` to `tick` (since
+    //     this is a rising edge, so it was LOW before).
+    //   * EV1 (falling-edge capture) → read CAP[1]. Line was HIGH from
+    //     `mPrevTick` to `tick`.
+    //
+    // The "phase level" labeled into EdgeTime.high is the level the line
+    // was at DURING the just-completed phase, not the edge direction.
+    // That matches the decoder's expectation: HIGH duration then LOW
+    // duration per WS2812 bit.
+    //
+    // We deliberately don't clear EVFLAG until AFTER reading CAP[n]; the
+    // SCT latches a fresh CAP[n] on the *next* matching edge regardless
+    // of the EVFLAG bit, so the read/W1C order matters only for the
+    // poll-once semantic (one capture per poll-cycle per event).
+
+    fl::size pushed = 0;
+    const fl::u32 evflag = sct(kOffEVFLAG);
+
+    if (evflag & 0x1u) {
+        const fl::u32 tick = sct_cap(0);
+        sct(kOffEVFLAG) = 0x1u;  // W1C
+        if (mPrevSeen) {
+            const fl::u32 delta = tick - mPrevTick;   // u32 wrap is fine — modulo arithmetic over 32-bit counter
+            if (mEdges.size() < mCapacity) {
+                mEdges.push_back(EdgeTime(mLastRising, ticksToNs(delta)));
+                ++pushed;
+            }
+        }
+        mPrevTick = tick;
+        mPrevSeen = true;
+        mLastRising = true;  // a rising edge just fired → line was LOW before, HIGH now
     }
-    return RxWaitResult::SUCCESS;
+
+    if (evflag & 0x2u) {
+        const fl::u32 tick = sct_cap(1);
+        sct(kOffEVFLAG) = 0x2u;
+        if (mPrevSeen) {
+            const fl::u32 delta = tick - mPrevTick;
+            if (mEdges.size() < mCapacity) {
+                mEdges.push_back(EdgeTime(mLastRising, ticksToNs(delta)));
+                ++pushed;
+            }
+        }
+        mPrevTick = tick;
+        mPrevSeen = true;
+        mLastRising = false;
+    }
+
+    return pushed;
+#else
+    return 0;
+#endif
+}
+
+RxWaitResult LpcSctRxChannel::wait(u32 timeout_ms) FL_NOEXCEPT {
+#if defined(FASTLED_LPC_RX_SCT) && defined(FL_IS_ARM_LPC_845)
+    // Spin-poll for `timeout_ms` or until the buffer is full. Callers
+    // that need to interleave TX (bit-bang) with capture should drive
+    // pollOnce() directly inside their TX loop — see
+    // `examples/AutoResearchLpc/AutoResearchLpc.ino::pinToggleRx`.
+    const fl::u32 start_ms = millis();
+    while ((millis() - start_ms) < timeout_ms && mEdges.size() < mCapacity) {
+        pollOnce();
+    }
+    sct(kOffCTRL) |= kCtrlHaltL;
+#else
+    (void)timeout_ms;
+#endif
+
+    mFinished = true;
+    return mEdges.empty() ? RxWaitResult::TIMEOUT : RxWaitResult::SUCCESS;
 }
 
 // ============================================================================

--- a/src/platforms/arm/lpc/rx_sct_capture.h
+++ b/src/platforms/arm/lpc/rx_sct_capture.h
@@ -73,7 +73,19 @@ public:
     int getPin() const FL_NOEXCEPT override;
     bool injectEdges(fl::span<const EdgeTime> edges) FL_NOEXCEPT override;
 
-    ~LpcSctRxChannel() override = default;
+    /// @brief Drain pending SCT capture events into the edge buffer.
+    /// @return Number of new EdgeTime entries pushed.
+    ///
+    /// Used by the FastLED #3021 pin-toggle test to interleave bit-bang
+    /// TX with capture-buffer drains on a single-threaded M0+ — without
+    /// it the SCT CAP[0..1] registers overwrite each prior capture
+    /// before `wait()` gets a chance to read them. With the SCT→DMA
+    /// upgrade (Phase 2 of #3021) the DMA fills the ring autonomously
+    /// and this method becomes a no-op fast-path. On non-LPC builds /
+    /// builds without `FASTLED_LPC_RX_SCT` it is a no-op stub.
+    fl::size pollOnce() FL_NOEXCEPT;
+
+    ~LpcSctRxChannel() FL_NOEXCEPT override;
 
 private:
     template<typename T, typename... Args>
@@ -83,7 +95,11 @@ private:
 
     int                   mPin;
     bool                  mFinished;
-    fl::vector<EdgeTime>  mEdges;  ///< RAM-backed capture buffer (DMA target in follow-up)
+    size_t                mCapacity;  ///< Cap on mEdges growth set by begin(config.buffer_size)
+    fl::u32               mPrevTick;  ///< Last SCT capture tick (driver-internal state for pollOnce)
+    bool                  mPrevSeen;  ///< Whether mPrevTick is valid
+    bool                  mLastRising;///< Direction of the last edge — used to label phase HIGH/LOW
+    fl::vector<EdgeTime>  mEdges;     ///< RAM-backed capture buffer (DMA target in follow-up)
 };
 
 } // namespace fl


### PR DESCRIPTION
## Summary

Phase 1 of FastLED #3021 — wires real SCT input-capture register programming into the LPC SCT-RX scaffold landed by #3015/#3016, plus the autoresearch RPC + Python orchestrator that exercises pin-toggle TX → SCT-RX loopback at 1 / 10 / 100 kHz.

## What this PR does

### Driver — `src/platforms/arm/lpc/rx_sct_capture.{h,cpp.hpp}`

Behind a new `FASTLED_LPC_RX_SCT` compile gate (default off — preserves flash budget for sketches that don't opt in):

- `begin()` powers up SCT + SWM in SYSCON, routes the user's pin to `SCT0_GPIO_IN_A_I` via SWM `PINASSIGN6`, programs a 32-bit unified free-running counter, and wires events `EV0`/`EV1` to capture into `CAP[0]`/`CAP[1]` on rising / falling edges.
- `pollOnce()` (new public method) drains `EVFLAG` + `CAP[0..1]` into the `EdgeTime` ring. Designed to be called from a TX bit-bang loop on the M0+ — the SCT overwrites each CAP register on every edge before `wait()` could read it. Phase 2's SCT→DMA upgrade will reduce this to a no-op.
- `wait()` spins on `pollOnce()` until timeout or buffer full.
- Destructor halts the SCT and unmaps the SWM pin so a follow-up driver can claim it.

All offsets / bit positions cross-checked against **UM11029 Rev 1.7** §8 (SYSCON), §10 (SWM), §21 (SCT). The hardware-validated SYSCON layout in `watchdog_lpc.impl.hpp` was used as the reference. The existing PWM_DMA TX driver shim has known offset bugs (REGMODE width, SYSCON offset, DMA CFG.HWTRIGEN bit position) — RX driver uses its own anonymous-namespace constants instead of reusing the broken shim. (Fixing the TX driver shim is left as a separate cleanup follow-up — out of scope for #3021.)

### Sketch — `examples/AutoResearchLpc/AutoResearchLpc.ino`

Adds `pinToggleRx(tx, rx, freq_hz, dur_ms) -> CSV` JSON-RPC binding. The CSV-string return shape (instead of the FlexIO-style `fl::json` object) minimizes flash on the 64 KB LPC845 budget — 7 integer fields packed as `success,edges,periods,mean_ns,sigma_ns,min_ns,max_ns`.

`#define FASTLED_LPC_RX_SCT 1` is set at the top of the sketch so the real SCT register code activates.

### Autoresearch runner

- `ci/autoresearch/args.py` — new `--pin-toggle-rx` CLI flag.
- `ci/autoresearch/phases.py` — `_run_lpc_pin_toggle_rx_tests()` dispatcher that delegates to a fresh subprocess running the Python bench script.
- `ci/autoresearch/test_lpc_pin_toggle_rx.py` — Python orchestrator mirroring `test_flexio_rx_squarewave.py`, adapted to the LPC sketch's positional-args + CSV-string RPC contract. Three cases: 1 kHz / 10 kHz / 100 kHz with σ < {1000, 500, 500} ns, mean ±2 %.

Wiring: jumper **P0_10 ↔ P0_11** on the LPC845-BRK header.

## Test plan

- [x] Host unit tests still pass — `tests/fl/channels/rx_sct_capture.cpp` (synthetic-edge round-trip via `injectEdges()` → `decode()`) unaffected.
- [x] `bash lint` clean on all touched files (C++ + Python).
- [ ] **Hardware bench** — `bash autoresearch lpc845brk --pin-toggle-rx --upload-port COM10` on a real LPC845-BRK with P0_10↔P0_11 jumpered. Expected: all 3 freq cases PASS.

Hardware validation is the remaining item — code is bench-ready but I do not have an LPC845-BRK currently attached to verify against silicon. Once verified, the Phase 1 acceptance from #3021 closes.

## Out of scope

- **Phase 2** (WS2812 byte-match loopback) — separate follow-up PR. Phase 2 will upgrade the SCT capture path from polling to SCT→DMA (polling can't keep up with WS2812's 800 kHz edge rate on the 30 MHz M0+).
- **TX SCT shim register offset / bit fixes** in `clockless_arm_lpc_pwm_dma.h` — that file's shim is misaligned (see commit message). Cleanup deferred to a separate PR so the RX driver doesn't drag the unvalidated TX driver into a single review surface.
- **Channels API integration for TX** — per the issue's "Out of scope" the TX side stays on the existing sync bit-bang driver (`clockless_arm_lpc.h`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added LPC845 SCT-RX pin-toggle automated hardware validation with configurable frequency/duration cases and timing assertions.
  * Introduced an opt-in SCT-RX bring-up/validation workflow (including JSON-RPC pin-toggle method) and a CLI switch to run the SCT-RX loopback bench with TX/RX wiring guidance.
  * Reports per-case PASS/FAIL based on captured period accuracy and sigma limits.
* **Platform Improvements**
  * Improved LPC845 SCT-RX capture to use a polling-driven path for more reliable edge-timing collection and statistics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->