### PR TITLE
feat(channels): reserve Bus::LPUART enum slot (refs #3023)

### DIFF
--- a/src/fl/channels/bus.h
+++ b/src/fl/channels/bus.h
@@ -70,6 +70,7 @@ enum class Bus : fl::u8 {
     UART,            ///< ESP32 UART driver via wave8 framing.
     FLEX_IO,         ///< Teensy 4.x FlexIO2 driver.
     OBJECT_FLED,     ///< Teensy 4.x ObjectFLED driver.
+    LPUART,          ///< Teensy 4.x iMXRT1062 LPUART (inverted-TX + eDMA) clockless driver.
     BIT_BANG,        ///< Portable bit-bang fallback driver.
     STUB,            ///< Native/host/test stub driver.
 };
@@ -177,6 +178,7 @@ inline const char* busName(Bus b) FL_NOEXCEPT {
         case Bus::UART:          return "UART";
         case Bus::FLEX_IO:       return "FLEX_IO";
         case Bus::OBJECT_FLED:   return "OBJECT_FLED";
+        case Bus::LPUART:        return "LPUART";
         case Bus::BIT_BANG:      return "BIT_BANG";
         case Bus::STUB:          return "STUB";
     }
@@ -186,7 +188,7 @@ inline const char* busName(Bus b) FL_NOEXCEPT {
 // Drift-prevention: if a new `Bus` enumerator is added, the switch above must
 // gain a case. Update this assertion to the new last enumerator after you
 // wire the case in — its failure is the prompt to revisit `busName()`.
-FL_STATIC_ASSERT(static_cast<fl::u8>(Bus::STUB) == 13,
+FL_STATIC_ASSERT(static_cast<fl::u8>(Bus::STUB) == 14,
                  "Bus changed: add the new value to busName() in this file");  // ok plain enum
 
 }  // namespace fl


### PR DESCRIPTION
## Summary

Reserves the `LPUART` enumerator on `fl::Bus` for the future Teensy 4.x
iMXRT1062 LPUART (inverted-TX + eDMA) clockless driver. Wires the
matching `busName()` case and bumps the drift-prevention static_assert
so `Bus::STUB` is now tracked at position 14.

This is the foundational sub-step of workstream A in #3023. No driver
code is added yet — the slot reservation lets the follow-up driver PRs
(peripheral interface, wave8 encoder, channel engine, registration)
land without conflicting on `bus.h`.

## Changes

- `src/fl/channels/bus.h`:
  - Add `Bus::LPUART` between `OBJECT_FLED` and `BIT_BANG`.
  - Add `case Bus::LPUART: return "LPUART";` to `busName()`.
  - Bump `FL_STATIC_ASSERT(static_cast<fl::u8>(Bus::STUB) == ...)` from
    `13` → `14`.

## Test plan

- [x] Compile-time invariants enforced via the existing
      `FL_STATIC_ASSERT` in `bus.h` (catches the drift).
- [x] `fl_channels_bus_traits` host test passes (exit 0).
- [x] `bash lint --cpp` passes.
- [x] No exhaustive switches on `Bus::` outside `busName()` need
      updating (only `bus.h` itself depends on the exhaustive set).

Refs #3023

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for Teensy 4.x LPUART clockless driver, enabling an additional bus option for compatible devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->