### PR TITLE
feat(lpuart): scaffold Teensy 4 LPUART peripheral interface + host mock (refs #3023)

### DIFF
--- a/src/platforms/arm/teensy/teensy4_common/drivers/lpuart/ilpuart_peripheral.h
+++ b/src/platforms/arm/teensy/teensy4_common/drivers/lpuart/ilpuart_peripheral.h
@@ -1,0 +1,149 @@
+/// @file ilpuart_peripheral.h
+/// @brief Abstract interface for Teensy 4.x iMXRT1062 LPUART peripheral
+///        (issue #3023 workstream A).
+///
+/// `Bus::LPUART` is the third orthogonal Teensy 4.x clockless peripheral
+/// (alongside `Bus::FLEX_IO` and `Bus::OBJECT_FLED`). The driver uses the
+/// LPUART hardware in inverted-TX mode with eDMA backing so a single byte
+/// frame on the wire decomposes into 8 freely-programmable pulses sandwiched
+/// between a HIGH leading idle and a LOW trailing transition — the exact
+/// topology of every WS281x-family / SK6812 / TM181x chipset (verified by
+/// the `wave8` framing invariant test in `tests/fl/channels/wave8.cpp`).
+///
+/// This header is the platform-agnostic seam between:
+///
+///   - `LPUARTPeripheralReal` (concrete iMXRT1062 register driver — landed in
+///     a follow-up PR; needs hardware verification), and
+///   - `LPUARTPeripheralMock` (host-side stub used by unit tests that exercise
+///     `ChannelEngineLPUART` without requiring real hardware).
+///
+/// The interface is intentionally narrow — single TX pin per instance, a
+/// single contiguous DMA buffer, and a synchronous `show()` for Phase 1.
+/// Async streaming (#3023 workstream D) will fold in `isBusy()` / `poll()`
+/// follow-ups via interface extension or a sibling interface, *not* by
+/// reshaping the existing surface.
+///
+/// **No engine code in this PR.** This header only defines the abstract
+/// seam plus the mock — registration with `ChannelManager`, the wave8
+/// encoder, the real iMXRT register driver, and `canHandle()` accept/reject
+/// logic land in subsequent PRs against the meta issue.
+
+#pragma once
+
+// IWYU pragma: private
+
+#include "fl/stl/stdint.h"
+#include "fl/stl/shared_ptr.h"
+#include "fl/stl/unique_ptr.h"
+#include "fl/stl/noexcept.h"
+
+namespace fl {
+
+/// @brief Result of pin validation against the iMXRT1062 LPUART TX pin set.
+///
+/// `valid == false` and `error_message != nullptr` always travel together —
+/// the engine surfaces `error_message` via `ChannelManager::reportError` so
+/// users see a specific reason (e.g. "pin not LPUART-TX capable") rather
+/// than a generic refusal.
+struct LPUARTPinResult {
+    bool valid;
+    const char* error_message;
+};
+
+/// @brief Compile-time list of Teensy 4.0 / 4.1 LPUART TX-capable pins.
+///
+/// Sourced from the iMXRT1062 reference manual's IOMUXC pad-mux table:
+///   pin 1  → LPUART6_TX (default after `Serial2.begin()`)
+///   pin 8  → LPUART3_TX
+///   pin 14 → LPUART2_TX
+///   pin 17 → LPUART4_TX
+///   pin 20 → LPUART8_TX
+///   pin 24 → LPUART5_TX
+///   pin 29 → LPUART7_TX
+///   pin 35 → LPUART1_TX  (Teensy 4.1 only — physically present on T4.1)
+///   pin 47 → LPUART3_TX_ALT (Teensy 4.1 only — exposed on the bottom SD pad row)
+///   pin 48 → LPUART8_TX_ALT (Teensy 4.1 only)
+///
+/// Mirrors workstream A Phase 1 of issue #3023. Validating against this
+/// array is the basis of `LPUARTPeripheralReal::validatePin`; the mock
+/// accepts the same set by default but lets tests override via
+/// `setInvalidPin()` to exercise error paths.
+constexpr u8 kLPUARTTxPins[] = {1, 8, 14, 17, 20, 24, 29, 35, 47, 48};
+
+/// @brief Number of LPUART-TX capable pins exposed on Teensy 4.x.
+constexpr u32 kLPUARTTxPinCount = sizeof(kLPUARTTxPins) / sizeof(kLPUARTTxPins[0]);
+
+/// @brief Abstract handle for a single LPUART TX instance bound to one TX pin.
+///
+/// Owns a single contiguous TX buffer that `ChannelEngineLPUART` writes
+/// pre-encoded (wave8 → UART byte) data into. `show()` triggers a
+/// synchronous eDMA transmission on the real implementation and a
+/// capture-only no-op on the mock.
+///
+/// Lifetime is owned by the channel engine (via `unique_ptr`). Tearing
+/// down the instance releases the LPUART hardware lock back to the
+/// peripheral so a different pin can bind on the next `addLeds()` cycle.
+class ILPUARTInstance {
+public:
+    virtual ~ILPUARTInstance() = default;
+
+    /// @brief Get a writable pointer to the TX buffer (wave8-encoded UART bytes).
+    virtual u8* getTxBuffer() FL_NOEXCEPT = 0;
+
+    /// @brief Get the TX buffer size in bytes.
+    virtual u32 getTxBufferSize() const FL_NOEXCEPT = 0;
+
+    /// @brief Trigger a synchronous eDMA transmission. Blocks until done.
+    virtual void show() FL_NOEXCEPT = 0;
+
+protected:
+    ILPUARTInstance() = default;
+    ILPUARTInstance(const ILPUARTInstance&) = delete;
+    ILPUARTInstance& operator=(const ILPUARTInstance&) = delete;
+};
+
+/// @brief Abstract factory/validator for the LPUART peripheral.
+///
+/// Concrete implementations:
+///   - `LPUARTPeripheralReal`: real iMXRT1062 register + eDMA driver. Lands
+///     in a follow-up PR that adds the engine and its hardware backend.
+///   - `LPUARTPeripheralMock`: host-side stub used by unit tests. Captures
+///     `createInstance()` records and the per-pin invalid-pin list.
+///
+/// `create()` is the single ODR-use seam — the engine takes the
+/// `shared_ptr` it returns and never re-resolves. Tests construct a mock
+/// directly via `make_shared<LPUARTPeripheralMock>()` and inject it
+/// without going through `create()`.
+class ILPUARTPeripheral {
+public:
+    virtual ~ILPUARTPeripheral() = default;
+
+    /// @brief Validate whether a pin can carry LPUART TX on the target board.
+    /// @param pin Teensy digital pin number.
+    /// @return Validation result with error message if invalid.
+    virtual LPUARTPinResult validatePin(u8 pin) const FL_NOEXCEPT = 0;
+
+    /// @brief Create an LPUART TX instance bound to a single pin.
+    /// @param tx_pin Digital pin number (must be in `kLPUARTTxPins`).
+    /// @param total_leds Number of LEDs on this strip.
+    /// @param is_rgbw `true` if the chipset is RGBW (4 bytes/LED).
+    /// @param t1_ns   T0H phase duration (nanoseconds).
+    /// @param t2_ns   T1H-T0H phase duration (nanoseconds).
+    /// @param t3_ns   T0L tail-LOW duration (nanoseconds).
+    /// @param reset_us Reset/latch pulse duration (microseconds).
+    /// @return Instance handle, or `nullptr` on failure.
+    virtual fl::unique_ptr<ILPUARTInstance> createInstance(
+        u8 tx_pin, u32 total_leds, bool is_rgbw,
+        u32 t1_ns, u32 t2_ns, u32 t3_ns, u32 reset_us) FL_NOEXCEPT = 0;
+
+    /// @brief Get the platform-specific peripheral instance. Implemented in
+    ///        the real driver TU (Teensy 4.x) and the host stub TU (tests).
+    static fl::shared_ptr<ILPUARTPeripheral> create() FL_NOEXCEPT;
+
+protected:
+    ILPUARTPeripheral() = default;
+    ILPUARTPeripheral(const ILPUARTPeripheral&) = delete;
+    ILPUARTPeripheral& operator=(const ILPUARTPeripheral&) = delete;
+};
+
+} // namespace fl

--- a/src/platforms/shared/mock/arm/teensy4/drivers/_build.cpp.hpp
+++ b/src/platforms/shared/mock/arm/teensy4/drivers/_build.cpp.hpp
@@ -5,3 +5,4 @@
 
 #include "platforms/shared/mock/arm/teensy4/drivers/flexio/_build.cpp.hpp"
 #include "platforms/shared/mock/arm/teensy4/drivers/objectfled/_build.cpp.hpp"
+#include "platforms/shared/mock/arm/teensy4/drivers/lpuart/_build.cpp.hpp"

--- a/src/platforms/shared/mock/arm/teensy4/drivers/lpuart/_build.cpp.hpp
+++ b/src/platforms/shared/mock/arm/teensy4/drivers/lpuart/_build.cpp.hpp
@@ -1,0 +1,11 @@
+// IWYU pragma: private
+
+/// @file _build.cpp.hpp
+/// @brief Unity build header for mock/arm/teensy4/drivers/lpuart/ directory.
+///
+/// Provides the mock LPUART peripheral factory (`ILPUARTPeripheral::create()`)
+/// for non-Teensy hosts. The real iMXRT register driver lives next to the
+/// engine TU and is compiled via the Teensy platform's `_build.cpp.hpp`
+/// hierarchy in a follow-up PR.
+
+#include "platforms/shared/mock/arm/teensy4/drivers/lpuart/lpuart_peripheral_mock.cpp.hpp"

--- a/src/platforms/shared/mock/arm/teensy4/drivers/lpuart/lpuart_peripheral_mock.cpp.hpp
+++ b/src/platforms/shared/mock/arm/teensy4/drivers/lpuart/lpuart_peripheral_mock.cpp.hpp
@@ -1,0 +1,29 @@
+// IWYU pragma: private
+
+/// @file lpuart_peripheral_mock.cpp.hpp
+/// @brief Provides ILPUARTPeripheral::create() factory for non-Teensy platforms.
+///
+/// On Teensy 4.x the real iMXRT register driver provides this factory (lands
+/// in a follow-up PR that adds `lpuart_peripheral_real.cpp.hpp` next to the
+/// engine). On every other host (unit-test build, WASM, native) the factory
+/// returns a fresh `LPUARTPeripheralMock` so engine-level tests run without
+/// touching real hardware.
+
+#include "platforms/arm/teensy/is_teensy.h"
+
+// Only compile on non-Teensy platforms (Teensy will use the real driver TU).
+#if !defined(FL_IS_TEENSY_4X)
+
+#include "platforms/arm/teensy/teensy4_common/drivers/lpuart/ilpuart_peripheral.h"
+#include "platforms/shared/mock/arm/teensy4/drivers/lpuart/lpuart_peripheral_mock.h"
+#include "fl/stl/noexcept.h"
+
+namespace fl {
+
+fl::shared_ptr<ILPUARTPeripheral> ILPUARTPeripheral::create() FL_NOEXCEPT {
+    return fl::make_shared<LPUARTPeripheralMock>();
+}
+
+} // namespace fl
+
+#endif // !FL_IS_TEENSY_4X

--- a/src/platforms/shared/mock/arm/teensy4/drivers/lpuart/lpuart_peripheral_mock.h
+++ b/src/platforms/shared/mock/arm/teensy4/drivers/lpuart/lpuart_peripheral_mock.h
@@ -125,6 +125,12 @@ public:
 
         const u32 bytes_per_led = is_rgbw ? 4u : 3u;
         // 4 UART bytes per LED byte (2-bit-per-frame wave8 packing).
+        // Reject configurations whose buffer size cannot be represented in u32 —
+        // otherwise the multiplication wraps and we allocate an undersized TX
+        // buffer while still returning a seemingly-valid instance (CodeRabbit).
+        if (total_leds > (0xFFFFFFFFu / bytes_per_led) / 4u) {
+            return nullptr;
+        }
         const u32 buffer_bytes = total_leds * bytes_per_led * 4u;
         auto instance = fl::make_unique<LPUARTInstanceMock>(buffer_bytes);
         mLastInstance = instance.get();

--- a/src/platforms/shared/mock/arm/teensy4/drivers/lpuart/lpuart_peripheral_mock.h
+++ b/src/platforms/shared/mock/arm/teensy4/drivers/lpuart/lpuart_peripheral_mock.h
@@ -1,0 +1,185 @@
+/// @file lpuart_peripheral_mock.h
+/// @brief Host-side mock for the iMXRT1062 LPUART peripheral
+///        (issue #3023 workstream A).
+///
+/// Mirrors `ObjectFLEDPeripheralMock` — fields the abstract `ILPUARTPeripheral`
+/// interface, captures per-instance configuration for test inspection, and
+/// supports configurable failure injection. The engine TU (lands in a
+/// follow-up PR) is host-testable by wiring this mock into
+/// `ChannelEngineLPUART` instead of the real iMXRT register driver.
+///
+/// **Streaming-ISR plumbing intentionally omitted.** Issue #3023 workstream C
+/// extracts the parlio mock's deferred-callback + `settleEngineState()`
+/// pattern into a shared template fixture. Once that lands, this mock will
+/// adopt the fixture from day one to keep `waitAllDone()` and
+/// `deinitialize()` semantics aligned with the post-#2992 async engine
+/// pattern. Until then this mock is sync-only and tests cover the sync
+/// `show()` path that Phase 1 ships.
+
+#pragma once
+
+// IWYU pragma: private
+
+#include "platforms/arm/teensy/teensy4_common/drivers/lpuart/ilpuart_peripheral.h"
+#include "fl/stl/vector.h"
+#include "fl/stl/stdint.h"
+#include "fl/stl/noexcept.h"
+
+namespace fl {
+
+// ============================================================================
+// LPUARTInstanceMock — allocates a vector<u8> TX buffer, counts show() calls
+// ============================================================================
+
+class LPUARTInstanceMock : public ILPUARTInstance {
+public:
+    explicit LPUARTInstanceMock(u32 buffer_bytes) FL_NOEXCEPT
+        : mBuffer(buffer_bytes, 0), mShowCount(0) {}
+
+    ~LPUARTInstanceMock() override = default;
+
+    u8* getTxBuffer() FL_NOEXCEPT override {
+        return mBuffer.data();
+    }
+
+    u32 getTxBufferSize() const FL_NOEXCEPT override {
+        return static_cast<u32>(mBuffer.size());
+    }
+
+    void show() FL_NOEXCEPT override {
+        ++mShowCount;
+    }
+
+    // ------------------------------------------------------------------
+    // Mock-Specific API
+    // ------------------------------------------------------------------
+
+    /// @brief Number of `show()` calls.
+    u32 getShowCount() const FL_NOEXCEPT { return mShowCount; }
+
+    /// @brief Raw TX buffer contents (written by the engine before `show()`).
+    const fl::vector<u8>& getRawBuffer() const FL_NOEXCEPT { return mBuffer; }
+
+private:
+    fl::vector<u8> mBuffer;
+    u32 mShowCount;
+};
+
+// ============================================================================
+// LPUARTPeripheralMock — accepts every kLPUARTTxPins[] entry by default,
+//                       tracks createInstance() records, supports failure
+//                       injection per-pin or globally on create.
+// ============================================================================
+
+class LPUARTPeripheralMock : public ILPUARTPeripheral {
+public:
+    /// @brief Record of a `createInstance()` call.
+    struct CreateRecord {
+        u8 tx_pin;
+        u32 total_leds;
+        bool is_rgbw;
+        u32 t1_ns;
+        u32 t2_ns;
+        u32 t3_ns;
+        u32 reset_us;
+    };
+
+    LPUARTPeripheralMock() FL_NOEXCEPT : mForceCreateFailure(false), mLastInstance(nullptr) {}
+    ~LPUARTPeripheralMock() override = default;
+
+    // ------------------------------------------------------------------
+    // ILPUARTPeripheral interface
+    // ------------------------------------------------------------------
+
+    LPUARTPinResult validatePin(u8 pin) const FL_NOEXCEPT override {
+        for (const auto& invalid : mInvalidPins) {
+            if (invalid.pin == pin) {
+                return {false, invalid.message};
+            }
+        }
+        // Default acceptance: pin must appear in the kLPUARTTxPins[] table.
+        for (u32 i = 0; i < kLPUARTTxPinCount; ++i) {
+            if (kLPUARTTxPins[i] == pin) {
+                return {true, nullptr};
+            }
+        }
+        return {false, "pin not LPUART-TX capable on iMXRT1062"};
+    }
+
+    fl::unique_ptr<ILPUARTInstance> createInstance(
+            u8 tx_pin, u32 total_leds, bool is_rgbw,
+            u32 t1_ns, u32 t2_ns, u32 t3_ns, u32 reset_us) FL_NOEXCEPT override {
+        CreateRecord record;
+        record.tx_pin = tx_pin;
+        record.total_leds = total_leds;
+        record.is_rgbw = is_rgbw;
+        record.t1_ns = t1_ns;
+        record.t2_ns = t2_ns;
+        record.t3_ns = t3_ns;
+        record.reset_us = reset_us;
+        mCreateRecords.push_back(record);
+
+        if (mForceCreateFailure) {
+            return nullptr;
+        }
+
+        const u32 bytes_per_led = is_rgbw ? 4u : 3u;
+        // 4 UART bytes per LED byte (2-bit-per-frame wave8 packing).
+        const u32 buffer_bytes = total_leds * bytes_per_led * 4u;
+        auto instance = fl::make_unique<LPUARTInstanceMock>(buffer_bytes);
+        mLastInstance = instance.get();
+        return instance;
+    }
+
+    // ------------------------------------------------------------------
+    // Mock-Specific API
+    // ------------------------------------------------------------------
+
+    /// @brief Mark a pin as invalid (overrides default `kLPUARTTxPins[]`
+    ///        acceptance — useful for negative-path tests).
+    void setInvalidPin(u8 pin, const char* message = "Pin invalid (mock)") FL_NOEXCEPT {
+        mInvalidPins.push_back({pin, message});
+    }
+
+    /// @brief Clear all invalid-pin overrides.
+    void clearInvalidPins() FL_NOEXCEPT { mInvalidPins.clear(); }
+
+    /// @brief Force `createInstance()` to return `nullptr`.
+    void setCreateFailure(bool fail) FL_NOEXCEPT { mForceCreateFailure = fail; }
+
+    /// @brief Total number of `createInstance()` calls.
+    size_t getCreateCount() const FL_NOEXCEPT { return mCreateRecords.size(); }
+
+    /// @brief All `createInstance()` call records, in chronological order.
+    const fl::vector<CreateRecord>& getCreateRecords() const FL_NOEXCEPT { return mCreateRecords; }
+
+    /// @brief Most recent `createInstance()` record, or `nullptr` if none.
+    const CreateRecord* getLastCreateRecord() const FL_NOEXCEPT {
+        if (mCreateRecords.empty()) return nullptr;
+        return &mCreateRecords[mCreateRecords.size() - 1];
+    }
+
+    /// @brief Most recent created instance (raw pointer, not owned).
+    LPUARTInstanceMock* getLastInstance() const FL_NOEXCEPT { return mLastInstance; }
+
+    /// @brief Reset all mock state.
+    void reset() FL_NOEXCEPT {
+        mInvalidPins.clear();
+        mCreateRecords.clear();
+        mLastInstance = nullptr;
+        mForceCreateFailure = false;
+    }
+
+private:
+    struct InvalidPin {
+        u8 pin;
+        const char* message;
+    };
+
+    fl::vector<InvalidPin> mInvalidPins;
+    fl::vector<CreateRecord> mCreateRecords;
+    LPUARTInstanceMock* mLastInstance;
+    bool mForceCreateFailure;
+};
+
+} // namespace fl

--- a/tests/platforms/arm/teensy/teensy4_common/drivers/lpuart/ilpuart_peripheral.cpp
+++ b/tests/platforms/arm/teensy/teensy4_common/drivers/lpuart/ilpuart_peripheral.cpp
@@ -1,0 +1,128 @@
+/// @file ilpuart_peripheral.cpp
+/// @brief Host tests for the LPUART peripheral abstraction (issue #3023.A).
+///
+/// Exercises the abstract `ILPUARTPeripheral` interface against the host
+/// stub mock (`LPUARTPeripheralMock`). The engine TU and the real iMXRT
+/// register driver land in follow-up PRs; these tests are scoped to the
+/// peripheral seam.
+
+#ifdef FASTLED_STUB_IMPL
+
+#include "platforms/arm/teensy/teensy4_common/drivers/lpuart/ilpuart_peripheral.h"
+#include "platforms/shared/mock/arm/teensy4/drivers/lpuart/lpuart_peripheral_mock.h"
+#include "fl/stl/shared_ptr.h"
+#include "test.h"
+
+FL_TEST_FILE(FL_FILEPATH) {
+
+using namespace fl;
+
+FL_TEST_CASE("LPUARTPeripheralMock accepts every kLPUARTTxPins[] entry by default") {
+    LPUARTPeripheralMock mock;
+    for (u32 i = 0; i < kLPUARTTxPinCount; ++i) {
+        const u8 pin = kLPUARTTxPins[i];
+        const LPUARTPinResult result = mock.validatePin(pin);
+        FL_INFO("pin=" << static_cast<int>(pin));
+        FL_REQUIRE(result.valid);
+        FL_REQUIRE(result.error_message == nullptr);
+    }
+}
+
+FL_TEST_CASE("LPUARTPeripheralMock rejects pins outside the kLPUARTTxPins[] set") {
+    LPUARTPeripheralMock mock;
+    // Pin 0 and 13 are intentionally not in the table (pin 13 is LED_BUILTIN /
+    // SPI_SCK on Teensy 4 — would collide). The exact error text is part of
+    // the contract: the engine surfaces it via ChannelManager::reportError.
+    const u8 not_in_table[] = {0, 2, 3, 4, 5, 6, 7, 9, 10, 11, 12, 13};
+    for (auto pin : not_in_table) {
+        const LPUARTPinResult result = mock.validatePin(pin);
+        FL_INFO("pin=" << static_cast<int>(pin));
+        FL_REQUIRE_FALSE(result.valid);
+        FL_REQUIRE(result.error_message != nullptr);
+    }
+}
+
+FL_TEST_CASE("LPUARTPeripheralMock setInvalidPin overrides default acceptance") {
+    LPUARTPeripheralMock mock;
+    // Pin 1 is LPUART6_TX — accepted by default.
+    FL_REQUIRE(mock.validatePin(1).valid);
+    mock.setInvalidPin(1, "test override");
+    const LPUARTPinResult result = mock.validatePin(1);
+    FL_REQUIRE_FALSE(result.valid);
+    FL_REQUIRE(result.error_message != nullptr);
+    // The override should be the message we set.
+    FL_REQUIRE(fl::string::from_literal(result.error_message)
+               == fl::string::from_literal("test override"));
+    mock.clearInvalidPins();
+    FL_REQUIRE(mock.validatePin(1).valid);
+}
+
+FL_TEST_CASE("LPUARTPeripheralMock createInstance captures the full call record") {
+    LPUARTPeripheralMock mock;
+    auto instance = mock.createInstance(
+        /* tx_pin   */ 1,
+        /* total    */ 64,
+        /* is_rgbw  */ false,
+        /* t1_ns    */ 250,
+        /* t2_ns    */ 625,
+        /* t3_ns    */ 375,
+        /* reset_us */ 280);
+    FL_REQUIRE(instance != nullptr);
+    FL_REQUIRE_EQ(mock.getCreateCount(), 1u);
+
+    const auto* record = mock.getLastCreateRecord();
+    FL_REQUIRE(record != nullptr);
+    FL_REQUIRE_EQ(record->tx_pin, 1u);
+    FL_REQUIRE_EQ(record->total_leds, 64u);
+    FL_REQUIRE_FALSE(record->is_rgbw);
+    FL_REQUIRE_EQ(record->t1_ns, 250u);
+    FL_REQUIRE_EQ(record->t2_ns, 625u);
+    FL_REQUIRE_EQ(record->t3_ns, 375u);
+    FL_REQUIRE_EQ(record->reset_us, 280u);
+
+    // Buffer sized for 64 LEDs × 3 bytes × 4 UART-bytes-per-LED-byte.
+    FL_REQUIRE_EQ(instance->getTxBufferSize(), 64u * 3u * 4u);
+    FL_REQUIRE(instance->getTxBuffer() != nullptr);
+
+    // show() should be sync (returns immediately) and bump the counter.
+    FL_REQUIRE_EQ(static_cast<LPUARTInstanceMock*>(instance.get())->getShowCount(), 0u);
+    instance->show();
+    FL_REQUIRE_EQ(static_cast<LPUARTInstanceMock*>(instance.get())->getShowCount(), 1u);
+}
+
+FL_TEST_CASE("LPUARTPeripheralMock createInstance honors RGBW buffer sizing") {
+    LPUARTPeripheralMock mock;
+    auto instance = mock.createInstance(
+        /* tx_pin   */ 8,
+        /* total    */ 32,
+        /* is_rgbw  */ true,
+        /* t1_ns    */ 300, /* t2_ns */ 600, /* t3_ns */ 300, /* reset_us */ 80);
+    FL_REQUIRE(instance != nullptr);
+    // 32 LEDs × 4 bytes (RGBW) × 4 UART-bytes-per-LED-byte.
+    FL_REQUIRE_EQ(instance->getTxBufferSize(), 32u * 4u * 4u);
+}
+
+FL_TEST_CASE("LPUARTPeripheralMock setCreateFailure forces nullptr from createInstance") {
+    LPUARTPeripheralMock mock;
+    mock.setCreateFailure(true);
+    auto instance = mock.createInstance(1, 64, false, 250, 625, 375, 280);
+    FL_REQUIRE(instance == nullptr);
+    // The record is still captured even on failure — useful when tests want
+    // to verify the engine attempted the create() with the expected args.
+    FL_REQUIRE_EQ(mock.getCreateCount(), 1u);
+    mock.setCreateFailure(false);
+    auto instance2 = mock.createInstance(1, 64, false, 250, 625, 375, 280);
+    FL_REQUIRE(instance2 != nullptr);
+}
+
+FL_TEST_CASE("ILPUARTPeripheral::create returns a mock on the host build") {
+    auto periph = ILPUARTPeripheral::create();
+    FL_REQUIRE(periph != nullptr);
+    // Should accept a known-good TX pin.
+    FL_REQUIRE(periph->validatePin(1).valid);
+    FL_REQUIRE_FALSE(periph->validatePin(0).valid);
+}
+
+}  // FL_TEST_FILE
+
+#endif  // FASTLED_STUB_IMPL


### PR DESCRIPTION
## Summary

Lays down the platform-agnostic seam for the upcoming `Bus::LPUART`
driver (issue #3023 workstream A). No engine, no real iMXRT register
driver, no `canHandle()` logic — those land in follow-up PRs that need
hardware verification. This PR is the foundation for host-testable
driver development.

## New files

- **`src/platforms/arm/teensy/teensy4_common/drivers/lpuart/ilpuart_peripheral.h`** — abstract `ILPUARTPeripheral` + `ILPUARTInstance` interface mirroring the `iobjectfled_peripheral.h` shape. Carries the compile-time `kLPUARTTxPins[]` table (the iMXRT1062 LPUART TX-capable pin set: `{1, 8, 14, 17, 20, 24, 29, 35, 47, 48}`) so both the real driver and the mock validate against a single source of truth.
- **`src/platforms/shared/mock/arm/teensy4/drivers/lpuart/lpuart_peripheral_mock.{h,cpp.hpp}`** — host-side stub. Accepts every `kLPUARTTxPins[]` entry by default, supports per-pin invalid overrides, captures `createInstance()` records (pin, LED count, RGBW flag, timing), and counts `show()` calls. Streaming-ISR plumbing is intentionally omitted until workstream C extracts the parlio mock deferred-callback pattern into a shared template fixture.
- **`src/platforms/shared/mock/arm/teensy4/drivers/lpuart/_build.cpp.hpp`** — unity-build entry for the new mock TU.
- **`tests/platforms/arm/teensy/teensy4_common/drivers/lpuart/ilpuart_peripheral.cpp`** — host tests pinning the contract: every `kLPUARTTxPins[]` entry accepted by default; non-table pins rejected with a non-null error message; `setInvalidPin()` overrides default acceptance; `createInstance()` captures the full call record and sizes the TX buffer to `total_leds × bytes_per_led × 4` (4 UART bytes per LED byte under wave8 2-bit-per-frame packing); `setCreateFailure()` forces `nullptr` from `createInstance()`.

## Modified

- **`src/platforms/shared/mock/arm/teensy4/drivers/_build.cpp.hpp`** — append the new lpuart mock build header alongside flexio + objectfled.

## Test plan

- [x] Mirrors the established `iobjectfled_peripheral.h` + `objectfled_peripheral_mock.h` pattern that already lands clean on host CI; the structural equivalence is the verification.
- [ ] CI will run the new `ilpuart_peripheral` host test (the local build state is wedged on the worktree path — CI runs from a clean tree).

## Why ship this without a working engine

The interface is the public seam every follow-up PR depends on. Landing it early lets the real `lpuart_peripheral_real.cpp.hpp` (iMXRT registers + eDMA) and `channel_engine_lpuart.cpp.hpp` (wave8 encoder + `canHandle()`) PRs land independently against a fixed contract instead of co-evolving in one giant PR. The mock makes the contract testable on day one.

Refs #3023

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a Teensy 4.x LPUART peripheral abstraction for WS281x-family output, including pin validation and synchronous “show” transmission support.
  * Added a host-side mock LPUART peripheral to enable non-Teensy development and testing.
* **Tests**
  * Added unit tests covering pin validation, instance creation behavior, RGBW vs non-RGBW buffer sizing, and failure modes.
* **Chores**
  * Updated the unity build integration for the mock and related driver components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->