### PR TITLE
feat(autoresearch): wire LPUART driver into --lpuart and --all (refs #3023)

### DIFF
--- a/ci/autoresearch/args.py
+++ b/ci/autoresearch/args.py
@@ -23,6 +23,7 @@ class Args:
     lcd_rgb: bool
     object_fled: bool
     flex_io: bool
+    lpuart: bool
     all: bool
     simd: bool
     coroutine: bool
@@ -139,6 +140,7 @@ Driver Selection (JSON-RPC):
     --lcd-spi      Test only LCD_SPI driver (ESP32-S3 only, APA102/SK9822)
     --lcd-rgb      Test only LCD RGB driver (ESP32-P4 only)
     --object-fled  Test only ObjectFLED DMA driver (Teensy 4.x)
+    --lpuart       Test only LPUART driver (Teensy 4.x; eDMA-backed UART TX, pinned to pin 1 by default)
     --all          Test all drivers
 
 Strip Size Configuration:
@@ -244,9 +246,14 @@ See Also:
             help="Test only FlexIO clockless driver (Teensy 4.x only; requires --tx-pin in {6-13,32})",
         )
         driver_group.add_argument(
+            "--lpuart",
+            action="store_true",
+            help="Test only LPUART clockless driver (Teensy 4.x only; eDMA-backed UART TX; pin pinned to 1=LPUART6_TX by default, override with --tx-pin in {1,8,14,17,20,24,29,35,47,48})",
+        )
+        driver_group.add_argument(
             "--all",
             action="store_true",
-            help="Test all drivers (equivalent to --parlio --rmt --spi --uart --lcd --lcd-spi --lcd-rgb --object-fled --flex-io)",
+            help="Test all drivers (equivalent to --parlio --rmt --spi --uart --lcd --lcd-spi --lcd-rgb --object-fled --flex-io --lpuart)",
         )
         driver_group.add_argument(
             "--simd",
@@ -582,6 +589,7 @@ See Also:
             lcd_rgb=parsed.lcd_rgb,
             object_fled=parsed.object_fled,
             flex_io=parsed.flex_io,
+            lpuart=parsed.lpuart,
             all=parsed.all,
             simd=parsed.simd,
             coroutine=parsed.coroutine,

--- a/ci/autoresearch/phases.py
+++ b/ci/autoresearch/phases.py
@@ -210,6 +210,7 @@ def _parse_args_and_build_commands(args: Args) -> RunContext | int:
             "LCD_RGB",
             "OBJECT_FLED",
             "FLEX_IO",
+            "LPUART",
         ]
     else:
         if args.parlio:
@@ -230,6 +231,8 @@ def _parse_args_and_build_commands(args: Args) -> RunContext | int:
             drivers.append("OBJECT_FLED")
         if args.flex_io:
             drivers.append("FLEX_IO")
+        if args.lpuart:
+            drivers.append("LPUART")
 
     parallel_mode = args.parallel
     if parallel_mode:
@@ -516,6 +519,11 @@ def _parse_args_and_build_commands(args: Args) -> RunContext | int:
         # and the manager silently falls back to ObjectFLED. Pin the FLEX_IO
         # tests to a known FlexIO2 pin so the engine actually runs.
         flex_io_tx_pin = 6
+        # LPUART on Teensy 4.x routes through {1, 8, 14, 17, 20, 24, 29, 35,
+        # 47, 48}. Pin LPUART tests to pin 1 (LPUART6_TX, Teensy 4's default
+        # Serial2 TX) so the engine accepts the request when --tx-pin is not
+        # supplied. Mirrors the FLEX_IO override above.
+        lpuart_tx_pin = 1
         for driver in drivers_list:
             for lane_count in range(lane_range["min"], lane_range["max"] + 1):
                 for strip_size in strip_sizes:
@@ -529,6 +537,8 @@ def _parse_args_and_build_commands(args: Args) -> RunContext | int:
                     }
                     if driver == "FLEX_IO" and args.tx_pin is None:
                         test_config["pinTx"] = flex_io_tx_pin
+                    if driver == "LPUART" and args.tx_pin is None:
+                        test_config["pinTx"] = lpuart_tx_pin
                     if args.legacy:
                         test_config["useLegacyApi"] = True
                     # Multi-frame capture: back-to-back show()/capture cycles per pattern.

--- a/ci/tests/test_autoresearch_phases.py
+++ b/ci/tests/test_autoresearch_phases.py
@@ -51,6 +51,7 @@ def _make_args(**overrides) -> Args:
         lcd_rgb=False,
         object_fled=False,
         flex_io=False,
+        lpuart=False,
         all=False,
         simd=False,
         coroutine=False,
@@ -89,6 +90,8 @@ def _make_args(**overrides) -> Args:
         tight_timing=False,
         tight_timing_iterations=8,
         tight_timing_max_overhead_us=2000,
+        pin_toggle_rx=False,
+        ws2812_loopback=False,
     )
     defaults.update(overrides)
     return Args(**defaults)
@@ -202,6 +205,7 @@ class TestParseArgsAndBuildCommands:
             "LCD_RGB",
             "OBJECT_FLED",
             "FLEX_IO",
+            "LPUART",
         }
 
     def test_multiple_drivers(self, fake_project_dir: Path) -> None:

--- a/examples/AutoResearch/AutoResearchRemote.cpp
+++ b/examples/AutoResearch/AutoResearchRemote.cpp
@@ -942,6 +942,7 @@ fl::json AutoResearchRemoteControl::runParallelTestImpl(const fl::json& args) {
                 else if (n == "UART")          opts.mBus = fl::Bus::UART;
                 else if (n == "FLEX_IO")       opts.mBus = fl::Bus::FLEX_IO;
                 else if (n == "OBJECT_FLED")   opts.mBus = fl::Bus::OBJECT_FLED;
+                else if (n == "LPUART")        opts.mBus = fl::Bus::LPUART;
                 else if (n == "BIT_BANG")      opts.mBus = fl::Bus::BIT_BANG;
                 else if (n == "STUB")          opts.mBus = fl::Bus::STUB;
                 // else: leave Bus::AUTO; priority dispatch will pick.


### PR DESCRIPTION
## Summary

Phase 2 of workstream A in #3023: extends the AutoResearch orchestration so the upcoming Teensy 4 LPUART clockless driver can be exercised end-to-end the moment the engine TU lands. Mirrors the `--flex-io` wiring pattern shipped in #3005.

## Changes

- **`examples/AutoResearch/AutoResearchRemote.cpp:944`** — adds `else if (n == "LPUART") opts.mBus = fl::Bus::LPUART;` to the driver-name → Bus mapping. `Bus::LPUART` itself was reserved in #3026.
- **`ci/autoresearch/args.py`** — new `lpuart: bool` field on `Args`, new `--lpuart` argparse flag with a help string documenting the iMXRT1062 LPUART TX pin set (`{1, 8, 14, 17, 20, 24, 29, 35, 47, 48}`), and the `--all` help text is updated to mention `--lpuart` alongside `--flex-io`.
- **`ci/autoresearch/phases.py`** — `LPUART` added to the `--all` driver list and to the per-flag mapping. Adds an `lpuart_tx_pin = 1` override (LPUART6_TX, Teensy 4's default Serial2 TX) so AutoResearch pins the LPUART tests to a known-good pin when the user doesn't supply `--tx-pin` — analogous to the existing `flex_io_tx_pin = 6` override.
- **`ci/tests/test_autoresearch_phases.py`** — adds `lpuart=False` to `_make_args` defaults and includes `LPUART` in the `test_all_drivers` expected set. Also patches a pre-existing unrelated breakage in `_make_args` (was missing `pin_toggle_rx` and `ws2812_loopback` after recent additions to `Args` — the test file was failing with `TypeError: missing 2 required positional arguments`).

## Test plan

- [x] `uv run pytest ci/tests/test_autoresearch_phases.py -x -q` → **48 passed in 7.58s**.
- [ ] `bash autoresearch teensy40 --lpuart` becomes runnable once the `lpuart_peripheral_real.cpp.hpp` + engine TU land (workstream A Phase 1 follow-up).

## Why ship Phase 2 before Phase 1 completes

Phase 2 is purely orchestration — the runtime sketch silently falls back to `Bus::AUTO` until the LPUART engine registers itself with the channel manager. Landing the AutoResearch wiring early means the Phase 1 follow-up PR (real iMXRT register driver) doesn't need to touch the AutoResearch infrastructure at all, keeping that PR focused on the hardware-verified driver code.

Refs #3023

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Teensy 4.x LPUART clockless driver option to the autoresearch test runner with automatic pin configuration support.

* **Tests**
  * Updated unit tests to validate LPUART driver integration and test generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->