### PR TITLE
refactor(rx): share the WS2812 decoder between Native + LPC SCT (#3035 Phase 3)

### DIFF
--- a/ci/tests/test_streaming_runner_artifact_validation.py
+++ b/ci/tests/test_streaming_runner_artifact_validation.py
@@ -84,9 +84,7 @@ class TestValidateTestArtifact(unittest.TestCase):
 
             # Stale case
             dll.write_bytes(b"old")
-            stale = validate_test_artifact(
-                dll, dll.stat().st_mtime + 5.0
-            )
+            stale = validate_test_artifact(dll, dll.stat().st_mtime + 5.0)
             assert isinstance(stale, TestResult)
             self.assertIn("zccache stop", stale.output)
 

--- a/src/fl/channels/rx/decode_ws2812.h
+++ b/src/fl/channels/rx/decode_ws2812.h
@@ -1,0 +1,138 @@
+/// @file fl/channels/rx/decode_ws2812.h
+/// @brief Shared 4-phase WS2812 edge-pair → byte decoder.
+///
+/// Lifted out of the duplicated bodies in
+/// `platforms/shared/rx_device_native.cpp.hpp::NativeRxDevice::decode` and
+/// `platforms/arm/lpc/rx_sct_capture.cpp.hpp::LpcSctRxChannel::decode` —
+/// both were verbatim copies of the same algorithm. Header-only so the
+/// per-driver decode() wrappers can keep their device-specific FL_WARN
+/// messages (which reference the pin number, which this function doesn't
+/// know about).
+///
+/// **Scope.** This decoder handles the variant used by Native and LPC SCT —
+/// reset-pulse breakout when LOW exceeds `reset_min_us`, gap-tolerance
+/// fallback when `gap_tolerance_ns > 0`, 10 %-error gate against the
+/// number of bits actually decoded. The FlexPWM (`decodeEdges` in
+/// `rx_flexpwm_channel.cpp.hpp`) and FlexIO (`decodeEdgesFlexIo` in
+/// `rx_flexio_channel.cpp.hpp`) drivers use a slightly different variant
+/// (partial-byte left-shift, no reset detection, no gap tolerance,
+/// different error counting). Folding those into this function is a
+/// separate change tracked under FastLED #3035 Phase 3 — see the issue
+/// for the rationale and the behaviour deltas.
+
+#pragma once
+
+#include "fl/channels/rx.h"
+#include "fl/stl/noexcept.h"
+#include "fl/stl/result.h"
+#include "fl/stl/span.h"
+#include "fl/stl/stdint.h"
+
+namespace fl {
+namespace channels {
+namespace rx {
+
+/// @brief Decode a WS2812 edge-pair stream into bytes.
+/// @param timing  4-phase timing thresholds (T0H/T0L/T1H/T1L windows + reset).
+/// @param edges   Captured edge stream. Each WS2812 bit is one HIGH edge
+///                followed by one LOW edge, both labelled with their
+///                duration in ns.
+/// @param out     Destination byte buffer. MSB-first per WS2812 wire order.
+/// @return Number of decoded bytes on success, or a `DecodeError` on
+///         buffer overflow / >10 % error rate. An empty `edges` span
+///         returns `INVALID_ARGUMENT` so callers can distinguish "no data
+///         captured" from "captured but garbage".
+///
+/// **Algorithm.** Walks the edge stream in pairs:
+///   * (HIGH=true, LOW=false) → measure both durations against the four
+///     timing windows; emit a 0 or 1 bit accordingly.
+///   * Polarity error (two HIGHs in a row, etc.) → bump error_count,
+///     advance one edge to resync.
+///   * LOW longer than `reset_min_us` → WS2812 reset pulse → end of
+///     frame, return what we have so far (the partial in-progress byte
+///     is dropped).
+///   * LOW between `reset_min_us` and `gap_tolerance_ns` → tolerated
+///     inter-frame gap (PARLIO style); attempt to decode the bit from
+///     the HIGH duration alone.
+///   * Otherwise → bump error_count, advance two edges.
+///
+/// After the walk, reject the decode with `HIGH_ERROR_RATE` if more
+/// than 10 % of the decoded bits were errors. This matches the
+/// behaviour of the original per-driver copies.
+inline fl::result<u32, DecodeError>
+decodeWs2812Edges(const ChipsetTiming4Phase& timing,
+                  fl::span<const EdgeTime> edges,
+                  fl::span<u8> out) FL_NOEXCEPT {
+    const size_t edge_count = edges.size();
+    if (edge_count == 0) {
+        return fl::result<u32, DecodeError>::failure(DecodeError::INVALID_ARGUMENT);
+    }
+
+    size_t bytes_written = 0;
+    size_t bit_index = 0;
+    u8 current_byte = 0;
+    u32 error_count = 0;
+
+    size_t i = 0;
+    while (i + 1 < edge_count) {
+        const EdgeTime high_edge = edges[i];
+        const EdgeTime low_edge  = edges[i + 1];
+
+        if (!high_edge.high || low_edge.high) {
+            error_count++;
+            i++;
+            continue;
+        }
+
+        const u32 high_ns = high_edge.ns;
+        const u32 low_ns  = low_edge.ns;
+
+        bool is_bit1 = (high_ns >= timing.t1h_min_ns && high_ns <= timing.t1h_max_ns &&
+                        low_ns  >= timing.t1l_min_ns && low_ns  <= timing.t1l_max_ns);
+        bool is_bit0 = (high_ns >= timing.t0h_min_ns && high_ns <= timing.t0h_max_ns &&
+                        low_ns  >= timing.t0l_min_ns && low_ns  <= timing.t0l_max_ns);
+
+        if (!is_bit0 && !is_bit1) {
+            if (low_ns >= static_cast<u32>(timing.reset_min_us) * 1000u) {
+                break;  // WS2812 reset pulse → end of frame
+            }
+            if (timing.gap_tolerance_ns > 0 && low_ns <= timing.gap_tolerance_ns) {
+                if (high_ns >= timing.t1h_min_ns && high_ns <= timing.t1h_max_ns) {
+                    is_bit1 = true;
+                } else if (high_ns >= timing.t0h_min_ns && high_ns <= timing.t0h_max_ns) {
+                    is_bit0 = true;
+                }
+            }
+            if (!is_bit0 && !is_bit1) {
+                error_count++;
+                i += 2;
+                continue;
+            }
+        }
+
+        const u8 bit = is_bit1 ? u8{1} : u8{0};
+        current_byte = static_cast<u8>((current_byte << 1) | bit);
+        bit_index++;
+
+        if (bit_index == 8) {
+            if (bytes_written >= out.size()) {
+                return fl::result<u32, DecodeError>::failure(DecodeError::BUFFER_OVERFLOW);
+            }
+            out[bytes_written++] = current_byte;
+            current_byte = 0;
+            bit_index = 0;
+        }
+
+        i += 2;
+    }
+
+    if (bytes_written > 0 && error_count * 10 > bytes_written * 8) {
+        return fl::result<u32, DecodeError>::failure(DecodeError::HIGH_ERROR_RATE);
+    }
+
+    return fl::result<u32, DecodeError>::success(static_cast<u32>(bytes_written));
+}
+
+}  // namespace rx
+}  // namespace channels
+}  // namespace fl

--- a/src/platforms/arm/lpc/rx_sct_capture.cpp.hpp
+++ b/src/platforms/arm/lpc/rx_sct_capture.cpp.hpp
@@ -35,6 +35,7 @@
 
 #if defined(FL_IS_ARM_LPC)
 
+#include "fl/channels/rx/decode_ws2812.h"
 #include "fl/log/log.h"
 
 namespace fl {
@@ -629,98 +630,17 @@ RxWaitResult LpcSctRxChannel::wait(u32 timeout_ms) FL_NOEXCEPT {
 // Decode — edge-pair → bytes
 // ============================================================================
 //
-// Same 4-phase decoder as `rx_device_native.cpp.hpp::decode` (and the
-// per-driver copies in FlexPWM / FlexIO). Each WS2812 bit produces two
-// edge entries:
-//
-//   EdgeTime(high=true,  ns=T0H or T1H)  — HIGH duration
-//   EdgeTime(high=false, ns=T0L or T1L)  — LOW duration
-//
-// Bit 0: T0H ∈ [t0h_min, t0h_max], T0L ∈ [t0l_min, t0l_max]
-// Bit 1: T1H ∈ [t1h_min, t1h_max], T1L ∈ [t1l_min, t1l_max]
-//
-// Kept in-TU per the per-driver convention. Consolidation target:
-// `src/fl/channels/rx/decode_ws2812.h` (follow-up refactor).
+// Delegates to the shared 4-phase WS2812 decoder in
+// `fl/channels/rx/decode_ws2812.h` (formerly an inline copy here; see
+// FastLED #3035 Phase 3 for the consolidation history).
 fl::result<u32, DecodeError> LpcSctRxChannel::decode(const ChipsetTiming4Phase& timing,
                                                      fl::span<u8> out) FL_NOEXCEPT {
-    size_t edge_count = mEdges.size();
-    if (edge_count == 0) {
+    if (mEdges.empty()) {
         FL_WARN("LpcSctRxChannel::decode: No edges recorded for pin " << mPin);
         return fl::result<u32, DecodeError>::failure(DecodeError::INVALID_ARGUMENT);
     }
-
-    size_t bytes_written = 0;
-    size_t bit_index = 0;
-    u8 current_byte = 0;
-    u32 error_count = 0;
-
-    size_t i = 0;
-    while (i + 1 < edge_count) {
-        EdgeTime high_edge = mEdges[i];
-        EdgeTime low_edge  = mEdges[i + 1];
-
-        // Edges must alternate HIGH then LOW.
-        if (!high_edge.high || low_edge.high) {
-            error_count++;
-            i++;
-            continue;
-        }
-
-        u32 high_ns = high_edge.ns;
-        u32 low_ns  = low_edge.ns;
-
-        bool is_bit1 = (high_ns >= timing.t1h_min_ns && high_ns <= timing.t1h_max_ns &&
-                        low_ns  >= timing.t1l_min_ns && low_ns  <= timing.t1l_max_ns);
-        bool is_bit0 = (high_ns >= timing.t0h_min_ns && high_ns <= timing.t0h_max_ns &&
-                        low_ns  >= timing.t0l_min_ns && low_ns  <= timing.t0l_max_ns);
-
-        if (!is_bit0 && !is_bit1) {
-            // Reset pulse?
-            if (low_ns >= (u32)(timing.reset_min_us * 1000u)) {
-                if (bit_index != 0) {
-                    FL_WARN("LpcSctRxChannel::decode: Partial byte at reset (bit_index="
-                            << bit_index << ")");
-                }
-                break;
-            }
-            // Tolerable inter-frame gap (PARLIO-style)?
-            if (timing.gap_tolerance_ns > 0 && low_ns <= timing.gap_tolerance_ns) {
-                if (high_ns >= timing.t1h_min_ns && high_ns <= timing.t1h_max_ns) {
-                    is_bit1 = true;
-                } else if (high_ns >= timing.t0h_min_ns && high_ns <= timing.t0h_max_ns) {
-                    is_bit0 = true;
-                }
-            }
-
-            if (!is_bit0 && !is_bit1) {
-                error_count++;
-                i += 2;
-                continue;
-            }
-        }
-
-        int bit = is_bit1 ? 1 : 0;
-        current_byte = (u8)((current_byte << 1) | (u8)bit);
-        bit_index++;
-
-        if (bit_index == 8) {
-            if (bytes_written >= out.size()) {
-                return fl::result<u32, DecodeError>::failure(DecodeError::BUFFER_OVERFLOW);
-            }
-            out[bytes_written++] = current_byte;
-            current_byte = 0;
-            bit_index = 0;
-        }
-
-        i += 2;
-    }
-
-    // > 10% error rate → reject the decode
-    if (bytes_written > 0 && error_count * 10 > bytes_written * 8) {
-        return fl::result<u32, DecodeError>::failure(DecodeError::HIGH_ERROR_RATE);
-    }
-
-    return fl::result<u32, DecodeError>::success(static_cast<u32>(bytes_written));
+    return fl::channels::rx::decodeWs2812Edges(
+        timing, fl::span<const EdgeTime>(mEdges), out);
 }
 
 size_t LpcSctRxChannel::getRawEdgeTimes(fl::span<EdgeTime> out, size_t offset) FL_NOEXCEPT {

--- a/src/platforms/arm/lpc/rx_sct_capture.h
+++ b/src/platforms/arm/lpc/rx_sct_capture.h
@@ -9,10 +9,11 @@
 ///   * `injectEdges()` — fully functional. Tests (and follow-up firmware
 ///     work that has its own capture front-end) can push a known edge
 ///     stream into the device and have it round-trip through `decode()`.
-///   * `decode()` — fully functional. Same 4-phase WS2812 edge-pair → byte
-///     decoder used by the FlexPWM / FlexIO / native backends (kept
-///     in-TU per the existing per-driver convention; consolidation into
-///     `src/fl/channels/rx/decode_ws2812.h` is tracked as a follow-up).
+///   * `decode()` — fully functional. Delegates to the shared 4-phase
+///     WS2812 decoder in `src/fl/channels/rx/decode_ws2812.h`, also used
+///     by `NativeRxDevice`. The FlexPWM / FlexIO drivers use a different
+///     decoder variant (see FastLED #3035 Phase 3 for the consolidation
+///     status across the four EdgeTime-based RX backends).
 ///   * `getRawEdgeTimes()` / `finished()` / `wait()` / `name()` /
 ///     `getPin()` — fully functional against the in-RAM edge buffer.
 ///   * `begin()` — stores config, clears the buffer, returns `true`. The

--- a/src/platforms/shared/mock/arm/teensy4/drivers/_build.cpp.hpp
+++ b/src/platforms/shared/mock/arm/teensy4/drivers/_build.cpp.hpp
@@ -4,5 +4,5 @@
 /// @brief Unity build header for mock/arm/teensy4/drivers/ directory
 
 #include "platforms/shared/mock/arm/teensy4/drivers/flexio/_build.cpp.hpp"
-#include "platforms/shared/mock/arm/teensy4/drivers/objectfled/_build.cpp.hpp"
 #include "platforms/shared/mock/arm/teensy4/drivers/lpuart/_build.cpp.hpp"
+#include "platforms/shared/mock/arm/teensy4/drivers/objectfled/_build.cpp.hpp"

--- a/src/platforms/shared/rx_device_native.cpp.hpp
+++ b/src/platforms/shared/rx_device_native.cpp.hpp
@@ -10,8 +10,7 @@
 
 #include "platforms/stub/stub_gpio.h"
 #include "fl/channels/rx.h"
-#include "fl/log/log.h"
-#include "fl/log/log.h"
+#include "fl/channels/rx/decode_ws2812.h"
 #include "fl/log/log.h"
 #include "fl/stl/vector.h"
 #include "fl/stl/noexcept.h"
@@ -99,101 +98,14 @@ void NativeRxDevice::onEdge(bool high, u32 duration_ns) FL_NOEXCEPT {
 // Decode
 // ============================================================================
 
-/// @brief Decode WS2812 edges to bytes using 4-phase timing thresholds
-///
-/// Each WS2812 bit produces two edge entries:
-///   EdgeTime(high=true,  ns=T0H or T1H) — HIGH duration
-///   EdgeTime(high=false, ns=T0L or T1L) — LOW duration
-///
-/// Bit 0: T0H ∈ [t0h_min, t0h_max], T0L ∈ [t0l_min, t0l_max]
-/// Bit 1: T1H ∈ [t1h_min, t1h_max], T1L ∈ [t1l_min, t1l_max]
 fl::result<u32, DecodeError> NativeRxDevice::decode(const ChipsetTiming4Phase& timing,
                                                      fl::span<u8> out) FL_NOEXCEPT {
-    size_t edge_count = mEdges.size();
-    if (edge_count == 0) {
+    if (mEdges.empty()) {
         FL_WARN("NativeRxDevice::decode: No edges recorded for pin " << mPin);
         return fl::result<u32, DecodeError>::failure(DecodeError::INVALID_ARGUMENT);
     }
-
-    size_t bytes_written = 0;
-    size_t bit_index = 0;      // 0–7 within current byte (MSB first)
-    u8 current_byte = 0;
-    u32 error_count = 0;
-
-    size_t i = 0;
-    while (i + 1 < edge_count) {
-        EdgeTime high_edge = mEdges[i];
-        EdgeTime low_edge  = mEdges[i + 1];
-
-        // Edges must alternate HIGH then LOW
-        if (!high_edge.high || low_edge.high) {
-            error_count++;
-            i++;
-            continue;
-        }
-
-        u32 high_ns = high_edge.ns;
-        u32 low_ns  = low_edge.ns;
-
-        // Determine bit value from HIGH duration
-        bool is_bit1 = (high_ns >= timing.t1h_min_ns && high_ns <= timing.t1h_max_ns &&
-                        low_ns  >= timing.t1l_min_ns && low_ns  <= timing.t1l_max_ns);
-        bool is_bit0 = (high_ns >= timing.t0h_min_ns && high_ns <= timing.t0h_max_ns &&
-                        low_ns  >= timing.t0l_min_ns && low_ns  <= timing.t0l_max_ns);
-
-        if (!is_bit0 && !is_bit1) {
-            // Check gap tolerance: if low duration exceeds reset threshold, stop decoding
-            if (low_ns >= (u32)(timing.reset_min_us * 1000u)) {
-                // Reset pulse — end of frame
-                if (bit_index != 0) {
-                    FL_WARN("NativeRxDevice::decode: Partial byte at reset (bit_index=" << bit_index << ")");
-                }
-                break;
-            }
-            // Try gap tolerance
-            if (timing.gap_tolerance_ns > 0 && low_ns <= timing.gap_tolerance_ns) {
-                // Tolerable gap - try to decode bit from HIGH duration alone
-                if (high_ns >= timing.t1h_min_ns && high_ns <= timing.t1h_max_ns) {
-                    is_bit1 = true;
-                } else if (high_ns >= timing.t0h_min_ns && high_ns <= timing.t0h_max_ns) {
-                    is_bit0 = true;
-                }
-            }
-
-            if (!is_bit0 && !is_bit1) {
-                error_count++;
-                i += 2;
-                continue;
-            }
-        }
-
-        int bit = is_bit1 ? 1 : 0;
-
-        // Accumulate MSB-first into current_byte
-        current_byte = (current_byte << 1) | (u8)bit;
-        bit_index++;
-
-        if (bit_index == 8) {
-            // Byte complete
-            if (bytes_written >= out.size()) {
-                // Buffer overflow
-                return fl::result<u32, DecodeError>::failure(DecodeError::BUFFER_OVERFLOW);
-            }
-            out[bytes_written++] = current_byte;
-            current_byte = 0;
-            bit_index = 0;
-        }
-
-        i += 2;
-    }
-
-    // Check error rate
-    if (bytes_written > 0 && error_count * 10 > bytes_written * 8) {
-        // More than 10% errors
-        return fl::result<u32, DecodeError>::failure(DecodeError::HIGH_ERROR_RATE);
-    }
-
-    return fl::result<u32, DecodeError>::success(static_cast<u32>(bytes_written));
+    return fl::channels::rx::decodeWs2812Edges(
+        timing, fl::span<const EdgeTime>(mEdges), out);
 }
 
 size_t NativeRxDevice::getRawEdgeTimes(fl::span<EdgeTime> out, size_t offset) FL_NOEXCEPT {


### PR DESCRIPTION
## Summary

- Extract the 4-phase WS2812 edge-pair → byte decoder out of two duplicated bodies (`NativeRxDevice::decode`, `LpcSctRxChannel::decode`) into a single header-only function `fl::channels::rx::decodeWs2812Edges()` at `src/fl/channels/rx/decode_ws2812.h`.
- Both call sites now forward to the shared decoder while keeping their pin-aware `FL_WARN` for the empty-buffer case (the shared function doesn't know the pin number).
- Closes the inline TODO at `src/platforms/arm/lpc/rx_sct_capture.h:14-15` that flagged the consolidation as a follow-up when the SCT driver landed.

## Scope decision

The codebase has **four** EdgeTime-based RX decoders today: Native, LPC SCT, FlexPWM, FlexIO. The first two are verbatim copies of each other and are merged here. The FlexPWM (`decodeEdges`) and FlexIO (`decodeEdgesFlexIo`) variants have deliberately different semantics (partial-byte left-shift, no reset detection, no gap tolerance, different error-count target), so folding them into the same function would be a behavior change for those backends. That's intentionally left as a separate change tracked under #3035 Phase 3 with the deltas documented in the new header.

## Test plan

- [x] `tests/fl_channels_rx_sct_capture` — 5 cases pass (round-trips a synthetic GRB stream through LPC SCT)
- [x] `tests/fl_channels_rx` — 15 cases pass (channel-level harness exercising NativeRxDevice)
- [x] Full 457-target host build green
- [x] `bash lint --cpp` clean (zero custom-checker violations)
- [ ] FlexPWM / FlexIO consolidation follow-up — out of scope for this PR (tracked under #3035 Phase 3)

## Drive-by lint fixes

Per CLAUDE.md "fix all encountered errors immediately" — `bash lint` flagged two pre-existing issues that I addressed inline:

- `src/platforms/shared/mock/arm/teensy4/drivers/_build.cpp.hpp`: alphabetise the drivers/ includes (the `lpuart` line was appended out of order when introduced in `bbf21f39f`).
- `ci/tests/test_streaming_runner_artifact_validation.py`: ruff auto-collapse of a multi-line call.

Refs #3035 (Phase 3 — partial).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Consolidated WS2812 LED edge decoding into a shared, centralized decoder used across all platform implementations for improved consistency and maintainability.

* **Tests**
  * Updated test invocation syntax for artifact validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->