### PR TITLE
refactor(rx/decode_ws2812): apply CodeRabbit follow-ups from #3036 (ASCII + header/impl split)

### DIFF
--- a/src/fl/channels/rx/_build.cpp.hpp
+++ b/src/fl/channels/rx/_build.cpp.hpp
@@ -2,3 +2,4 @@
 /// @brief Unity build header for fl/channels/rx directory
 
 #include "fl/channels/rx/channel.cpp.hpp"
+#include "fl/channels/rx/decode_ws2812.cpp.hpp"

--- a/src/fl/channels/rx/decode_ws2812.cpp.hpp
+++ b/src/fl/channels/rx/decode_ws2812.cpp.hpp
@@ -1,0 +1,92 @@
+/// @file fl/channels/rx/decode_ws2812.cpp.hpp
+/// @brief Shared 4-phase WS2812 edge-pair -> byte decoder (definition).
+///
+/// See `decode_ws2812.h` for the full contract and the explicit list of
+/// behaviours preserved verbatim from the original Native + LPC SCT
+/// decoders that this consolidation replaces.
+
+// IWYU pragma: private
+
+#include "fl/channels/rx/decode_ws2812.h"
+
+namespace fl {
+namespace channels {
+namespace rx {
+
+fl::result<u32, DecodeError>
+decodeWs2812Edges(const ChipsetTiming4Phase& timing,
+                  fl::span<const EdgeTime> edges,
+                  fl::span<u8> out) FL_NOEXCEPT {
+    const size_t edge_count = edges.size();
+    if (edge_count == 0) {
+        return fl::result<u32, DecodeError>::failure(DecodeError::INVALID_ARGUMENT);
+    }
+
+    size_t bytes_written = 0;
+    size_t bit_index = 0;
+    u8 current_byte = 0;
+    u32 error_count = 0;
+
+    size_t i = 0;
+    while (i + 1 < edge_count) {
+        const EdgeTime high_edge = edges[i];
+        const EdgeTime low_edge  = edges[i + 1];
+
+        if (!high_edge.high || low_edge.high) {
+            error_count++;
+            i++;
+            continue;
+        }
+
+        const u32 high_ns = high_edge.ns;
+        const u32 low_ns  = low_edge.ns;
+
+        bool is_bit1 = (high_ns >= timing.t1h_min_ns && high_ns <= timing.t1h_max_ns &&
+                        low_ns  >= timing.t1l_min_ns && low_ns  <= timing.t1l_max_ns);
+        bool is_bit0 = (high_ns >= timing.t0h_min_ns && high_ns <= timing.t0h_max_ns &&
+                        low_ns  >= timing.t0l_min_ns && low_ns  <= timing.t0l_max_ns);
+
+        if (!is_bit0 && !is_bit1) {
+            if (low_ns >= static_cast<u32>(timing.reset_min_us) * 1000u) {
+                break;  // WS2812 reset pulse -> end of frame
+            }
+            if (timing.gap_tolerance_ns > 0 && low_ns <= timing.gap_tolerance_ns) {
+                if (high_ns >= timing.t1h_min_ns && high_ns <= timing.t1h_max_ns) {
+                    is_bit1 = true;
+                } else if (high_ns >= timing.t0h_min_ns && high_ns <= timing.t0h_max_ns) {
+                    is_bit0 = true;
+                }
+            }
+            if (!is_bit0 && !is_bit1) {
+                error_count++;
+                i += 2;
+                continue;
+            }
+        }
+
+        const u8 bit = is_bit1 ? u8{1} : u8{0};
+        current_byte = static_cast<u8>((current_byte << 1) | bit);
+        bit_index++;
+
+        if (bit_index == 8) {
+            if (bytes_written >= out.size()) {
+                return fl::result<u32, DecodeError>::failure(DecodeError::BUFFER_OVERFLOW);
+            }
+            out[bytes_written++] = current_byte;
+            current_byte = 0;
+            bit_index = 0;
+        }
+
+        i += 2;
+    }
+
+    if (bytes_written > 0 && error_count * 10 > bytes_written * 8) {
+        return fl::result<u32, DecodeError>::failure(DecodeError::HIGH_ERROR_RATE);
+    }
+
+    return fl::result<u32, DecodeError>::success(static_cast<u32>(bytes_written));
+}
+
+}  // namespace rx
+}  // namespace channels
+}  // namespace fl

--- a/src/fl/channels/rx/decode_ws2812.h
+++ b/src/fl/channels/rx/decode_ws2812.h
@@ -1,15 +1,14 @@
 /// @file fl/channels/rx/decode_ws2812.h
-/// @brief Shared 4-phase WS2812 edge-pair → byte decoder.
+/// @brief Shared 4-phase WS2812 edge-pair -> byte decoder (declaration).
 ///
 /// Lifted out of the duplicated bodies in
 /// `platforms/shared/rx_device_native.cpp.hpp::NativeRxDevice::decode` and
-/// `platforms/arm/lpc/rx_sct_capture.cpp.hpp::LpcSctRxChannel::decode` —
-/// both were verbatim copies of the same algorithm. Header-only so the
-/// per-driver decode() wrappers can keep their device-specific FL_WARN
-/// messages (which reference the pin number, which this function doesn't
-/// know about).
+/// `platforms/arm/lpc/rx_sct_capture.cpp.hpp::LpcSctRxChannel::decode` --
+/// both were verbatim copies of the same algorithm. The per-driver decode()
+/// wrappers keep their device-specific FL_WARN messages (which reference
+/// the pin number; this function does not know about it).
 ///
-/// **Scope.** This decoder handles the variant used by Native and LPC SCT —
+/// **Scope.** This decoder handles the variant used by Native and LPC SCT --
 /// reset-pulse breakout when LOW exceeds `reset_min_us`, gap-tolerance
 /// fallback when `gap_tolerance_ns > 0`, 10 %-error gate against the
 /// number of bits actually decoded. The FlexPWM (`decodeEdges` in
@@ -17,8 +16,19 @@
 /// `rx_flexio_channel.cpp.hpp`) drivers use a slightly different variant
 /// (partial-byte left-shift, no reset detection, no gap tolerance,
 /// different error counting). Folding those into this function is a
-/// separate change tracked under FastLED #3035 Phase 3 — see the issue
+/// separate change tracked under FastLED #3035 Phase 3 -- see the issue
 /// for the rationale and the behaviour deltas.
+///
+/// **Preserved-from-original quirks** (intentionally NOT fixed in the
+/// consolidation, see #3035 follow-ups):
+///   1. Reset-pulse detection fires BEFORE gap-tolerance evaluation, so
+///      a LOW pulse in the documented "reset_min_us .. gap_tolerance_ns"
+///      window currently terminates the frame instead of being tolerated.
+///      Matches the prior behaviour of both Native and LPC decoders.
+///   2. Error-rate denominator is `bytes_written * 8` rather than total
+///      decoded bits; the partial trailing `bit_index` residue is not
+///      counted. Can over-reject frames that end mid-byte. Same
+///      preserved behaviour.
 
 #pragma once
 
@@ -42,96 +52,10 @@ namespace rx {
 ///         buffer overflow / >10 % error rate. An empty `edges` span
 ///         returns `INVALID_ARGUMENT` so callers can distinguish "no data
 ///         captured" from "captured but garbage".
-///
-/// **Algorithm.** Walks the edge stream in pairs:
-///   * (HIGH=true, LOW=false) → measure both durations against the four
-///     timing windows; emit a 0 or 1 bit accordingly.
-///   * Polarity error (two HIGHs in a row, etc.) → bump error_count,
-///     advance one edge to resync.
-///   * LOW longer than `reset_min_us` → WS2812 reset pulse → end of
-///     frame, return what we have so far (the partial in-progress byte
-///     is dropped).
-///   * LOW between `reset_min_us` and `gap_tolerance_ns` → tolerated
-///     inter-frame gap (PARLIO style); attempt to decode the bit from
-///     the HIGH duration alone.
-///   * Otherwise → bump error_count, advance two edges.
-///
-/// After the walk, reject the decode with `HIGH_ERROR_RATE` if more
-/// than 10 % of the decoded bits were errors. This matches the
-/// behaviour of the original per-driver copies.
-inline fl::result<u32, DecodeError>
+fl::result<u32, DecodeError>
 decodeWs2812Edges(const ChipsetTiming4Phase& timing,
                   fl::span<const EdgeTime> edges,
-                  fl::span<u8> out) FL_NOEXCEPT {
-    const size_t edge_count = edges.size();
-    if (edge_count == 0) {
-        return fl::result<u32, DecodeError>::failure(DecodeError::INVALID_ARGUMENT);
-    }
-
-    size_t bytes_written = 0;
-    size_t bit_index = 0;
-    u8 current_byte = 0;
-    u32 error_count = 0;
-
-    size_t i = 0;
-    while (i + 1 < edge_count) {
-        const EdgeTime high_edge = edges[i];
-        const EdgeTime low_edge  = edges[i + 1];
-
-        if (!high_edge.high || low_edge.high) {
-            error_count++;
-            i++;
-            continue;
-        }
-
-        const u32 high_ns = high_edge.ns;
-        const u32 low_ns  = low_edge.ns;
-
-        bool is_bit1 = (high_ns >= timing.t1h_min_ns && high_ns <= timing.t1h_max_ns &&
-                        low_ns  >= timing.t1l_min_ns && low_ns  <= timing.t1l_max_ns);
-        bool is_bit0 = (high_ns >= timing.t0h_min_ns && high_ns <= timing.t0h_max_ns &&
-                        low_ns  >= timing.t0l_min_ns && low_ns  <= timing.t0l_max_ns);
-
-        if (!is_bit0 && !is_bit1) {
-            if (low_ns >= static_cast<u32>(timing.reset_min_us) * 1000u) {
-                break;  // WS2812 reset pulse → end of frame
-            }
-            if (timing.gap_tolerance_ns > 0 && low_ns <= timing.gap_tolerance_ns) {
-                if (high_ns >= timing.t1h_min_ns && high_ns <= timing.t1h_max_ns) {
-                    is_bit1 = true;
-                } else if (high_ns >= timing.t0h_min_ns && high_ns <= timing.t0h_max_ns) {
-                    is_bit0 = true;
-                }
-            }
-            if (!is_bit0 && !is_bit1) {
-                error_count++;
-                i += 2;
-                continue;
-            }
-        }
-
-        const u8 bit = is_bit1 ? u8{1} : u8{0};
-        current_byte = static_cast<u8>((current_byte << 1) | bit);
-        bit_index++;
-
-        if (bit_index == 8) {
-            if (bytes_written >= out.size()) {
-                return fl::result<u32, DecodeError>::failure(DecodeError::BUFFER_OVERFLOW);
-            }
-            out[bytes_written++] = current_byte;
-            current_byte = 0;
-            bit_index = 0;
-        }
-
-        i += 2;
-    }
-
-    if (bytes_written > 0 && error_count * 10 > bytes_written * 8) {
-        return fl::result<u32, DecodeError>::failure(DecodeError::HIGH_ERROR_RATE);
-    }
-
-    return fl::result<u32, DecodeError>::success(static_cast<u32>(bytes_written));
-}
+                  fl::span<u8> out) FL_NOEXCEPT;
 
 }  // namespace rx
 }  // namespace channels


### PR DESCRIPTION
## Summary

Follow-up to [#3036](https://github.com/FastLED/FastLED/pull/3036) (squash-merged as `b99cc8e3c`). #3036 was merged before I had a chance to push the CodeRabbit responses, so the two coding-standard violations CR flagged are sitting in master now. This PR addresses them.

### CR findings addressed

1. **ASCII-only source-encoding rule for `src/fl/channels/rx/decode_ws2812.h`.** The header used Unicode glyphs (`->`, `--`, `<=`, etc.) in comments. Replaced with ASCII equivalents.
2. **No function definitions in plain `.h` files** under `src/fl/channels/rx/`. Moved `decodeWs2812Edges()` from the header to a new `src/fl/channels/rx/decode_ws2812.cpp.hpp` companion (matches the existing `channel.h` / `channel.cpp.hpp` pair in the same directory) and wired it into `src/fl/channels/rx/_build.cpp.hpp` so it compiles exactly once into `libfastled`.

### CR findings explicitly deferred (see PR #3036 inline replies)

CodeRabbit also flagged two latent semantic bugs in the consolidated decoder — reset-pulse detection firing before gap-tolerance evaluation, and the error-rate denominator missing partial-bit residue. **Both behaviours are preserved verbatim from the original Native + LPC decoders that #3036 consolidated.** Faithful consolidation has to match prior behaviour byte-for-byte; correcting these would silently change shipped behaviour for two backends under a refactor-named PR. They are now explicitly documented in the new header's "Preserved-from-original quirks" block and queued for a follow-up under [#3035](https://github.com/FastLED/FastLED/issues/3035) Phase 3.

## Test plan

- [x] `tests/fl_channels_rx_sct_capture` — 5/5 pass on the rebuilt host stub
- [x] `tests/fl_channels_rx` — 15/15 pass
- [x] Build green after the header/impl split (LPC + Native both resolve `decodeWs2812Edges()` via the FastLED unity-build link)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized WS2812 decoder implementation for improved code structure and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->