### PR TITLE
docs(lpc/rx): mark #3035 Phase 3 shipped (decoder consolidation + sketch retirement)

### DIFF
--- a/src/platforms/arm/lpc/rx_sct_capture.h
+++ b/src/platforms/arm/lpc/rx_sct_capture.h
@@ -10,10 +10,13 @@
 ///     work that has its own capture front-end) can push a known edge
 ///     stream into the device and have it round-trip through `decode()`.
 ///   * `decode()` — fully functional. Delegates to the shared 4-phase
-///     WS2812 decoder in `src/fl/channels/rx/decode_ws2812.h`, also used
-///     by `NativeRxDevice`. The FlexPWM / FlexIO drivers use a different
-///     decoder variant (see FastLED #3035 Phase 3 for the consolidation
-///     status across the four EdgeTime-based RX backends).
+///     WS2812 decoder in `src/fl/channels/rx/decode_ws2812.h`, shared
+///     with `NativeRxDevice`. FastLED #3035 Phase 3 (decoder
+///     consolidation + LPC sketch retirement) is **shipped** via
+///     #3037 (decoder split into .h/.cpp.hpp) and #3041 (LPC sketch
+///     folded into the main AutoResearch low-memory mode). What remains
+///     in #3035 is the Phase-1 / 2a / 2b hardware bench validation,
+///     tracked alongside the #2880 hardware sign-off checklist.
 ///   * `getRawEdgeTimes()` / `finished()` / `wait()` / `name()` /
 ///     `getPin()` — fully functional against the in-RAM edge buffer.
 ///   * `begin()` — stores config, clears the buffer, returns `true`. The


### PR DESCRIPTION
## Summary

Closes the code-side of #3035. Phase 3 (decoder consolidation + LPC sketch retirement) is shipped end-to-end via #3037 + #3041 + the orchestrator update in the latter. What remains in #3035 are Phases 1, 2a, 2b — hardware bench validation that needs real LPC845-BRK silicon + scope, shared with the #2880 sign-off checklist.

## Changes

- `src/platforms/arm/lpc/rx_sct_capture.h` — header comment updated. The Phase-3 \"see #3035 for consolidation status\" note now reads as shipped (with the relevant PR links) so future readers don't go fishing for status in the meta.

## Test plan

- [x] No behavioral change — docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal technical documentation to reflect current development status and pending validation phases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->