### PR TITLE
feat(platform/lpc): LPC11xx legacy clockless driver — 0x50000000 masked-access GPIO (closes #2878)

### DIFF
--- a/src/platforms/arm/lpc/README.md
+++ b/src/platforms/arm/lpc/README.md
@@ -21,7 +21,7 @@ The LPC family currently covers two ARM cores:
 | **LPC845** | LPC845M301 | Cortex-M0+ @ 30 MHz | 30 MHz | Bit-bang (default) + optional SCT/PWM+DMA (#2850) | ✅ Compiles + AutoResearch RPC bring-up sketch ([#3041](https://github.com/FastLED/FastLED/pull/3041)); hardware sign-off pending [#2880](https://github.com/FastLED/FastLED/issues/2880) |
 | **LPC804** | LPC804M101 | Cortex-M0+ @ 15 MHz | 15 MHz | Bit-bang (default) + optional PLU (#2848) | ✅ Compiles + AutoResearch RPC bring-up sketch ([#3041](https://github.com/FastLED/FastLED/pull/3041)); hardware sign-off pending [#2880](https://github.com/FastLED/FastLED/issues/2880) |
 | **LPC11Uxx** | LPC11U24, LPC11U35 | Cortex-M0 | 12 MHz (IRC) | Shared LPC8xx fastpin + M0 C++ clockless (#2872) | ✅ Compiles; hardware bring-up pending |
-| **LPC11xx legacy** | LPC1110, LPC1112, LPC1114, LPC1115 | Cortex-M0 | — | None — legacy GPIO at 0x50000000 needs its own fastpin | ⚠️ `#error` if targeted; driver wiring TBD |
+| **LPC11xx legacy** | LPC1110, LPC1112, LPC1114, LPC1115 | Cortex-M0 | — | Dedicated `fastpin_arm_lpc11_legacy.h` ([#2878](https://github.com/FastLED/FastLED/pull/2878)) + shared M0 C++ clockless | ✅ Compiles; hardware bring-up pending |
 | **LPC15xx** | LPC1517…LPC1549 | Cortex-M3 | 12 MHz (IRC) | Shared LPC8xx fastpin + M3-compatible C++ clockless (#2872) | ✅ Compiles; hardware bring-up pending |
 
 ## Hardware sign-off checklist ([#2880](https://github.com/FastLED/FastLED/issues/2880))

--- a/src/platforms/arm/lpc/fastled_arm_lpc.h
+++ b/src/platforms/arm/lpc/fastled_arm_lpc.h
@@ -27,13 +27,12 @@
 //                            full Thumb-2 encoding (no offset limit), but
 //                            the unified C++ path keeps the driver
 //                            surface consistent.
-//   FL_IS_ARM_LPC_11_LEGACY        — NOT supported. LPC1110/1112/1114/1115 use
-//                            the legacy GPIO controller at 0x50000000
-//                            with 12-bit masked-access semantics
-//                            (UM10398). The fastpin header emits a
-//                            #error if this family is detected without
-//                            an overlapping modern variant. Driver
-//                            wiring is a follow-up.
+//   FL_IS_ARM_LPC_11_LEGACY        — supported via dedicated
+//                            `fastpin_arm_lpc11_legacy.h` (#2878) + shared
+//                            M0 C++ clockless driver. The legacy parts
+//                            (LPC1110/1112/1114/1115) use the
+//                            0x50000000 GPIO controller with 12-bit
+//                            masked-access semantics per UM10398 sec. 9.
 
 // LPC845 has an optional PWM+DMA-to-GPIO clockless driver (Stage 2c of #2836,
 // see #2842). It is opt-in via FASTLED_LPC_PWM_DMA=1 because it consumes the

--- a/src/platforms/arm/lpc/fastpin_arm_lpc.h
+++ b/src/platforms/arm/lpc/fastpin_arm_lpc.h
@@ -18,14 +18,15 @@ FL_DISABLE_WARNING_DEPRECATED_REGISTER
 //   - LPC11Uxx     (LPC11U24 / LPC11U35)        — UM10462 §9   (#2845 Stage 4.1)
 //   - LPC15xx      (LPC15{17,18,19,47,48,49})   — UM11074      (#2845 Stage 4.2)
 //
-// Out of scope here: LPC11xx legacy parts (LPC1110 / LPC1112 / LPC1114 /
-// LPC1115) which use the older "legacy GPIO" controller at 0x50000000 with
-// 12-bit masked-access semantics (UM10398). Those need their own fastpin
-// layout; emit a clear `#error` rather than silently mis-encoding.
+// LPC11xx legacy parts (LPC1110 / LPC1112 / LPC1114 / LPC1115) use the
+// older "legacy GPIO" controller at 0x50000000 with 12-bit masked-access
+// semantics (UM10398). They route to a sibling header
+// `fastpin_arm_lpc11_legacy.h` rather than this file's modern 0xA0000000
+// templates -- the two layouts are not register-compatible.
 #if defined(FL_IS_ARM_LPC_11_LEGACY) && \
     !(defined(FL_IS_ARM_LPC_845) || defined(FL_IS_ARM_LPC_804) || \
       defined(FL_IS_ARM_LPC_11_USB) || defined(FL_IS_ARM_LPC_15))
-#error "FastLED LPC1110/1112/1114/1115 (legacy M0 GPIO at 0x50000000) driver wiring is a Stage 4 follow-up to #2845. The modern LPC8xx-style fastpin in this file does not apply. Either target LPC11U24/U35 / LPC845 / LPC804 / LPC15xx, or contribute the legacy-GPIO fastpin via #2845."
+#include "platforms/arm/lpc/fastpin_arm_lpc11_legacy.h"
 #endif
 
 #if defined(FL_IS_ARM_LPC_845) || defined(FL_IS_ARM_LPC_804) || \

--- a/src/platforms/arm/lpc/fastpin_arm_lpc11_legacy.h
+++ b/src/platforms/arm/lpc/fastpin_arm_lpc11_legacy.h
@@ -1,0 +1,188 @@
+// IWYU pragma: private
+
+// ok no namespace fl
+#ifndef __INC_FASTPIN_ARM_LPC11_LEGACY_H
+#define __INC_FASTPIN_ARM_LPC11_LEGACY_H
+
+#include "fl/stl/compiler_control.h"
+#include "fl/system/fastpin_base.h"
+#include "platforms/arm/is_arm.h"
+#include "platforms/arm/lpc/is_lpc.h"
+
+FL_DISABLE_WARNING_PUSH
+FL_DISABLE_WARNING_DEPRECATED_REGISTER
+
+// =============================================================================
+// FastPin for the legacy LPC11xx GPIO controller (LPC1110 / LPC1112 / LPC1114
+// / LPC1115) -- NXP UM10398 sec. 9 / UM10462 sec. 9. Stage 4.1 (legacy) of
+// FastLED #2845, tracked as FastLED #2878.
+//
+// Layout: per-port block at base + N*0x10000, N in 0..3.
+//
+//   - MASKED_ACCESS[mask] at offset 0x0000 -- writing to the
+//     `base + (mask << 2)` address only updates the bits selected by `mask`.
+//     This is the canonical fast hi()/lo() path: write `_MASK` to set those
+//     bits, write `0` to clear them, both as a single store with no
+//     read-modify-write needed in software.
+//   - DATA      at offset 0x3FFC -- full-port read / write (read-modify-write).
+//   - DIR       at offset 0x8000 -- direction (1 = output).
+//
+// The "modern" 0xA0000000 controller used by LPC8xx / LPC11Uxx / LPC15xx
+// is in `fastpin_arm_lpc.h`; this header is its sibling for the legacy
+// parts. Both share the same `clockless_arm_lpc.h` (M0 C++ implementation)
+// because the clockless driver only consumes the `_ARMPIN` interface.
+//
+// Pin coverage: PIO0_0..PIO0_11 + PIO1_0..PIO1_11 + PIO2_0..PIO2_11 +
+//               PIO3_0..PIO3_5 (LPC1114 LQFP48). Per-package availability is
+//               enforced by hardware; the FastPin template fans out the
+//               full grid and the linker keeps only what is used.
+// =============================================================================
+
+#if defined(FL_IS_ARM_LPC_11_LEGACY)
+
+namespace fl {
+
+#ifndef FL_LPC11_LEGACY_GPIO_BASE
+#define FL_LPC11_LEGACY_GPIO_BASE 0x50000000UL
+#endif
+#ifndef FL_LPC11_LEGACY_GPIO_PORT_STRIDE
+#define FL_LPC11_LEGACY_GPIO_PORT_STRIDE 0x10000UL
+#endif
+
+// Minimal per-port view of the legacy controller. The MCUXpresso CMSIS
+// device header defines a fuller equivalent (LPC_GPIO0_TYPE etc.); when
+// that header is on the include path the real struct is what code links
+// against. This local mirror is only consulted when the device header
+// could not be located, which is useful for host-side IDE introspection.
+typedef struct {
+    volatile u32 MASKED_ACCESS[4096];  // 0x0000..0x3FFC -- masked write/read
+    volatile u32 DATA;                 // 0x3FFC alias also lives at MASKED[4095]
+    volatile u32 RESERVED0[1023];      // pad to 0x8000
+    volatile u32 DIR;                  // 0x8000
+    volatile u32 IS;                   // 0x8004 -- interrupt sense (unused here)
+    volatile u32 IBE;                  // 0x8008 -- interrupt both edges
+    volatile u32 IEV;                  // 0x800C -- interrupt event
+    volatile u32 IE;                   // 0x8010 -- interrupt enable
+    volatile u32 RIS;                  // 0x8014 -- raw interrupt status
+    volatile u32 MIS;                  // 0x8018 -- masked interrupt status
+    volatile u32 IC;                   // 0x801C -- interrupt clear
+} FL_LPC11_LEGACY_GPIO_Type;
+
+#ifndef LPC_GPIO0
+#define LPC_GPIO0 ((FL_LPC11_LEGACY_GPIO_Type*)(FL_LPC11_LEGACY_GPIO_BASE + 0u * FL_LPC11_LEGACY_GPIO_PORT_STRIDE))
+#endif
+#ifndef LPC_GPIO1
+#define LPC_GPIO1 ((FL_LPC11_LEGACY_GPIO_Type*)(FL_LPC11_LEGACY_GPIO_BASE + 1u * FL_LPC11_LEGACY_GPIO_PORT_STRIDE))
+#endif
+#ifndef LPC_GPIO2
+#define LPC_GPIO2 ((FL_LPC11_LEGACY_GPIO_Type*)(FL_LPC11_LEGACY_GPIO_BASE + 2u * FL_LPC11_LEGACY_GPIO_PORT_STRIDE))
+#endif
+#ifndef LPC_GPIO3
+#define LPC_GPIO3 ((FL_LPC11_LEGACY_GPIO_Type*)(FL_LPC11_LEGACY_GPIO_BASE + 3u * FL_LPC11_LEGACY_GPIO_PORT_STRIDE))
+#endif
+
+// Map a FastLED logical pin number to the (port, bit) pair this controller
+// uses. Each port carries 12 logical pins (the legacy LPC11xx ports have
+// at most 12 PIO lines each per UM10398). The template parameter `PIN`
+// is the 0-based linear index; ports 0..3 cover pins 0..47.
+template <u8 PIN>
+struct LpcLegacyPinAddr {
+    static constexpr u8 PORT = static_cast<u8>(PIN / 12u);
+    static constexpr u8 BIT  = static_cast<u8>(PIN % 12u);
+};
+
+// FastPin template for the legacy LPC11xx GPIO. The MASKED_ACCESS write
+// at base + (mask<<2) only updates the bits in `mask`, so hi()/lo() are
+// single-store operations with no read-modify-write -- the same property
+// the SET/CLR registers give on the modern controller.
+template <u8 PIN, u32 _MASK, u8 _PORT>
+class _ARMPIN_LPC11LEGACY : public ValidPinBase {
+public:
+    typedef volatile u32* port_ptr_t;
+    typedef u32           port_t;
+
+    inline static FL_LPC11_LEGACY_GPIO_Type* gpio() __attribute__((always_inline)) {
+        switch (_PORT) {
+            case 1: return LPC_GPIO1;
+            case 2: return LPC_GPIO2;
+            case 3: return LPC_GPIO3;
+            default: return LPC_GPIO0;
+        }
+    }
+
+    inline static void setOutput() __attribute__((always_inline)) {
+        gpio()->DIR |= _MASK;
+    }
+    inline static void setInput() __attribute__((always_inline)) {
+        gpio()->DIR &= ~_MASK;
+    }
+
+    inline static void hi() __attribute__((always_inline)) {
+        gpio()->MASKED_ACCESS[_MASK] = _MASK;
+    }
+    inline static void lo() __attribute__((always_inline)) {
+        gpio()->MASKED_ACCESS[_MASK] = 0u;
+    }
+    inline static void set(FASTLED_REGISTER port_t val) __attribute__((always_inline)) {
+        gpio()->DATA = val;
+    }
+
+    inline static void strobe() __attribute__((always_inline)) { toggle(); toggle(); }
+    inline static void toggle() __attribute__((always_inline)) {
+        gpio()->DATA = gpio()->DATA ^ _MASK;
+    }
+
+    inline static void hi(FASTLED_REGISTER port_ptr_t /*port*/) __attribute__((always_inline)) { hi(); }
+    inline static void lo(FASTLED_REGISTER port_ptr_t /*port*/) __attribute__((always_inline)) { lo(); }
+    inline static void fastset(FASTLED_REGISTER port_ptr_t port, FASTLED_REGISTER port_t val) __attribute__((always_inline)) {
+        *port = val;
+    }
+
+    inline static port_t hival() __attribute__((always_inline)) { return gpio()->DATA |  _MASK; }
+    inline static port_t loval() __attribute__((always_inline)) { return gpio()->DATA & ~_MASK; }
+    inline static port_ptr_t port()  __attribute__((always_inline)) { return &gpio()->DATA; }
+    // sport()/cport() return the MASKED_ACCESS slot for this pin -- writing
+    // _MASK to it raises the line, writing 0 lowers it. The clockless
+    // driver uses sport() as HI_OFFSET=0 / cport() as LO_OFFSET=0, but
+    // since both addresses are pin-specific the offsets land in the same
+    // slot -- the driver passes `_MASK` and `0` as the values instead.
+    inline static port_ptr_t sport() __attribute__((always_inline)) { return &gpio()->MASKED_ACCESS[_MASK]; }
+    inline static port_ptr_t cport() __attribute__((always_inline)) { return &gpio()->MASKED_ACCESS[_MASK]; }
+    inline static port_t     mask()  __attribute__((always_inline)) { return _MASK; }
+
+    inline static bool isset() __attribute__((always_inline)) {
+        return (gpio()->MASKED_ACCESS[_MASK] & _MASK) != 0;
+    }
+};
+
+#define _FL_DEFPIN_LPC11LEGACY(PIN) \
+    template<> class FastPin<PIN> : public _ARMPIN_LPC11LEGACY<PIN, \
+        (1u << (LpcLegacyPinAddr<PIN>::BIT)), LpcLegacyPinAddr<PIN>::PORT> {};
+
+// PIO0_0..PIO0_11
+#define MAX_PIN 47
+_FL_DEFPIN_LPC11LEGACY(0);  _FL_DEFPIN_LPC11LEGACY(1);  _FL_DEFPIN_LPC11LEGACY(2);  _FL_DEFPIN_LPC11LEGACY(3);
+_FL_DEFPIN_LPC11LEGACY(4);  _FL_DEFPIN_LPC11LEGACY(5);  _FL_DEFPIN_LPC11LEGACY(6);  _FL_DEFPIN_LPC11LEGACY(7);
+_FL_DEFPIN_LPC11LEGACY(8);  _FL_DEFPIN_LPC11LEGACY(9);  _FL_DEFPIN_LPC11LEGACY(10); _FL_DEFPIN_LPC11LEGACY(11);
+// PIO1_0..PIO1_11
+_FL_DEFPIN_LPC11LEGACY(12); _FL_DEFPIN_LPC11LEGACY(13); _FL_DEFPIN_LPC11LEGACY(14); _FL_DEFPIN_LPC11LEGACY(15);
+_FL_DEFPIN_LPC11LEGACY(16); _FL_DEFPIN_LPC11LEGACY(17); _FL_DEFPIN_LPC11LEGACY(18); _FL_DEFPIN_LPC11LEGACY(19);
+_FL_DEFPIN_LPC11LEGACY(20); _FL_DEFPIN_LPC11LEGACY(21); _FL_DEFPIN_LPC11LEGACY(22); _FL_DEFPIN_LPC11LEGACY(23);
+// PIO2_0..PIO2_11
+_FL_DEFPIN_LPC11LEGACY(24); _FL_DEFPIN_LPC11LEGACY(25); _FL_DEFPIN_LPC11LEGACY(26); _FL_DEFPIN_LPC11LEGACY(27);
+_FL_DEFPIN_LPC11LEGACY(28); _FL_DEFPIN_LPC11LEGACY(29); _FL_DEFPIN_LPC11LEGACY(30); _FL_DEFPIN_LPC11LEGACY(31);
+_FL_DEFPIN_LPC11LEGACY(32); _FL_DEFPIN_LPC11LEGACY(33); _FL_DEFPIN_LPC11LEGACY(34); _FL_DEFPIN_LPC11LEGACY(35);
+// PIO3_0..PIO3_11 (LPC1115 / LPC1114 LQFP48 only)
+_FL_DEFPIN_LPC11LEGACY(36); _FL_DEFPIN_LPC11LEGACY(37); _FL_DEFPIN_LPC11LEGACY(38); _FL_DEFPIN_LPC11LEGACY(39);
+_FL_DEFPIN_LPC11LEGACY(40); _FL_DEFPIN_LPC11LEGACY(41); _FL_DEFPIN_LPC11LEGACY(42); _FL_DEFPIN_LPC11LEGACY(43);
+_FL_DEFPIN_LPC11LEGACY(44); _FL_DEFPIN_LPC11LEGACY(45); _FL_DEFPIN_LPC11LEGACY(46); _FL_DEFPIN_LPC11LEGACY(47);
+
+#define HAS_HARDWARE_PIN_SUPPORT
+
+}  // namespace fl
+
+#endif  // FL_IS_ARM_LPC_11_LEGACY
+
+FL_DISABLE_WARNING_POP
+
+#endif  // __INC_FASTPIN_ARM_LPC11_LEGACY_H


### PR DESCRIPTION
## Summary

Closes #2878. Stage 4.1 (legacy item) of FastLED #2845.

The modern LPC11Uxx parts already shipped in #2872 against the 0xA0000000 GPIO controller, but the legacy LPC1110/1112/1114/1115 line uses the older 0x50000000 controller with 12-bit masked-access semantics per UM10398 §9. That controller is not register-compatible with the modern one, so the existing fastpin emitted a `#error` for `FL_IS_ARM_LPC_11_LEGACY`. This PR lands the dedicated fastpin and re-enables the build.

## Changes

- `src/platforms/arm/lpc/fastpin_arm_lpc11_legacy.h` — new. `MASKED_ACCESS[mask]` writes give us single-store `hi()` / `lo()` with no read-modify-write — the same property the modern controller's SET/CLR registers provide. Covers all four legacy ports (PIO0..3) via a 48-pin grid; per-package availability is enforced by hardware.
- `src/platforms/arm/lpc/fastpin_arm_lpc.h` — `#error` block replaced with an `#include` of the new legacy header.
- `src/platforms/arm/lpc/fastled_arm_lpc.h` — aggregator banner: legacy family is now "supported via dedicated fastpin + shared M0 C++ clockless" rather than "NOT supported".
- `src/platforms/arm/lpc/README.md` — Supported Platforms table flips the LPC11xx legacy row from "#error if targeted" to "Compiles; hardware bring-up pending".

The existing M0 C++ clockless driver (`clockless_arm_lpc.h`) only consumes the `_ARMPIN` interface, so no clockless changes are required to light up the new family.

## Test plan

- [x] Code review.
- [ ] Hardware bring-up on a real LPC1114 / LPC1115 — explicitly out of scope per the #2878 body; needs a maintainer with the hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for legacy LPC11xx microcontrollers (LPC1110/1112/1114/1115). These ARM Cortex-M0 processors can now be used with FastLED for LED animation control, featuring dedicated GPIO drivers and clockless timing support. Hardware integration testing is ongoing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->