### PR TITLE
fix(autoresearch): address three lint violations in AutoResearchLowMemory.h (#3041 follow-up)

### DIFF
--- a/examples/AutoResearch/AutoResearchLowMemory.h
+++ b/examples/AutoResearch/AutoResearchLowMemory.h
@@ -48,13 +48,14 @@
 #include "fl/remote/transport/serial.h"
 #include "fl/wdt/watchdog.h"
 #include "fl/log/log.h"
+#include "fl/stl/cstdio.h"  // fl::serial_begin -- HWCDC-safe Serial.begin wrapper
 
 // The host-stub example DLL build (`tests/shared/example_dll_wrapper_template.cpp`)
 // compiles this sketch on Linux to surface ABI breaks. The RX SCT driver
 // types are platform-gated behind `FL_IS_ARM_LPC` -- they only exist on
 // the real LPC build. So the include + every RX usage below must be gated
 // the same way.
-#include "platforms/arm/lpc/is_lpc.h"
+#include "platforms/arm/lpc/is_lpc.h"  // ok platform headers - LPC RX driver gate
 #if defined(FL_IS_ARM_LPC)
 #include "fl/channels/rx_sct_capture.h"
 #include "fl/stl/strstream.h"
@@ -117,7 +118,7 @@ inline LowMemPinTogglePeriodStats computeLowMemPeriodStats(
 }  // namespace
 
 inline void autoResearchLowMemorySetup() {
-    Serial.begin(115200);
+    fl::serial_begin(115200);
 
     // Arm the watchdog so a hung sketch unbricks itself on crash.
     fl::Watchdog::instance().begin(3000);
@@ -126,7 +127,12 @@ inline void autoResearchLowMemorySetup() {
     // the FL_WARN log pipeline reaches the host.
     FL_WARN_LIT("FL_WARN: low-memory bring-up OK");
 
-    static fl::Remote remote(
+    // The C++ inline-ODR rule guarantees a single shared instance across
+    // every translation unit that calls this inline function, which is
+    // exactly what we want (one Remote bound to the singleton Serial
+    // transport). The included-once-per-sketch model of `.ino` builds
+    // also reduces to a single TU in practice.
+    static fl::Remote remote(  // okay static in header
         fl::createSerialRequestSource(),
         fl::createSerialResponseSink("REMOTE: "));
     g_low_memory_remote = &remote;


### PR DESCRIPTION
## Summary

Follow-up to #3041. Three lint violations in `examples/AutoResearch/AutoResearchLowMemory.h`:

- `ExampleSerialChecker` — swapped `Serial.begin(115200)` for the HWCDC-safe `fl::serial_begin(115200)` (FastLED #2669).
- `PlatformIncludesChecker` — suppressed with `// ok platform headers` since the `is_lpc.h` deep include gates the RX SCT driver path on real LPC builds vs. the example DLL host-stub.
- `StaticInHeaderChecker` — function-local `static fl::Remote remote(...)` in an inline function is intended (single shared instance via inline-ODR); suppressed with the checker's canonical `// okay static in header` marker.

`bash lint --cpp` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cross-platform header gating to enable compilation on host stub builds while preserving platform-specific functionality for real target deployments.

* **Refactor**
  * Updated serial communication initialization to use standardized API method.

* **Documentation**
  * Enhanced code comments to clarify static instance initialization behavior and memory management patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->