### PR TITLE
feat(screenmap): add v2 schema parser alongside v1, auto-detect by shape

### DIFF
--- a/src/fl/math/screenmap.cpp.hpp
+++ b/src/fl/math/screenmap.cpp.hpp
@@ -95,6 +95,94 @@ ScreenMap ScreenMap::DefaultStrip(int numLeds, float cm_between_leds,
     return Circle(numLeds, cm_between_leds, cm_led_diameter, completion);
 }
 
+// Helper: parse a v2 screenmap document into the flat segmentMaps.
+// v2 shape (see ledmapper #92):
+//   {
+//     "version": 2,                                  // optional, explicit
+//     "groups":   { "<name>": { "color": "...", ... } },  // optional, ignored by firmware
+//     "segments": [
+//       { "id": "<unique>", "pin": <int|str>, "group": "<name>",
+//         "x": [...], "y": [...], "z": [...],         // z optional
+//         "parent": "<id>", "offset": <int|null> }    // parent+offset on forks only
+//     ]
+//   }
+//
+// Flatten policy: each segment becomes one ScreenMap entry keyed by `id`.
+// `pin`, `group`, `parent`, `offset` are not represented in the firmware-side
+// flat_map; they're UI/wiring metadata the editor and video tools care about.
+// `z` is dropped (firmware-side ScreenMap is 2D today).
+static bool parseV2SegmentArray(const fl::json& segmentsArr,
+                                fl::flat_map<string, ScreenMap> *segmentMaps,
+                                string *err) FL_NOEXCEPT {
+    if (!segmentsArr.has_value() || !segmentsArr.is_array()) {
+        *err = "v2 'segments' is not an array";
+        return false;
+    }
+
+    auto arrPtr = segmentsArr.as_array();
+    if (!arrPtr) {
+        *err = "v2 'segments' array could not be read";
+        return false;
+    }
+
+    for (const auto& elem : *arrPtr) {
+        if (!elem) {
+            *err = "v2 segment is null";
+            return false;
+        }
+        fl::json segVal(elem);
+        if (!segVal.has_value() || !segVal.is_object()) {
+            *err = "v2 segment is not an object";
+            return false;
+        }
+
+        // Required: id
+        if (!segVal.contains("id") || !segVal["id"].has_value()) {
+            *err = "v2 segment missing 'id'";
+            return false;
+        }
+        auto idOpt = segVal["id"].as_string();
+        if (!idOpt) {
+            *err = "v2 segment 'id' is not a string";
+            return false;
+        }
+        string id = *idOpt;
+
+        // Required: x
+        if (!segVal.contains("x") || !segVal["x"].has_value() || !segVal["x"].is_array()) {
+            *err = "v2 segment '" + id + "' missing or invalid 'x' array";
+            return false;
+        }
+        fl::vector<float> x_array = jsonArrayToFloatVector(segVal["x"]);
+
+        // Required: y
+        if (!segVal.contains("y") || !segVal["y"].has_value() || !segVal["y"].is_array()) {
+            *err = "v2 segment '" + id + "' missing or invalid 'y' array";
+            return false;
+        }
+        fl::vector<float> y_array = jsonArrayToFloatVector(segVal["y"]);
+
+        // Optional: diameter (not in canonical v2 but accepted as a backward-compat
+        // hint when present; otherwise the per-group `diameter` could be wired here
+        // in a future iteration).
+        float diameter = -1.0f;
+        if (segVal.contains("diameter") && segVal["diameter"].has_value()) {
+            auto diameterOpt = segVal["diameter"].as_float();
+            if (diameterOpt) {
+                diameter = static_cast<float>(*diameterOpt);
+            }
+        }
+
+        auto n = fl::min(x_array.size(), y_array.size());
+        ScreenMap segment_map(n, diameter);
+        for (size_t i = 0; i < n; i++) {
+            segment_map.set(i, vec2f{x_array[i], y_array[i]});
+        }
+        (*segmentMaps)[id] = fl::move(segment_map);
+    }
+    return true;
+}
+
 bool ScreenMap::ParseJson(const char *jsonStrScreenMap,
                           fl::flat_map<string, ScreenMap> *segmentMaps, string *err) {
 
@@ -109,7 +197,7 @@ bool ScreenMap::ParseJson(const char *jsonStrScreenMap,
     return false;
 #else
     //FL_WARN_SCREENMAP("ParseJson called with JSON: " << jsonStrScreenMap);
-    
+
     string _err;
     if (!err) {
         err = &_err;
@@ -121,13 +209,36 @@ bool ScreenMap::ParseJson(const char *jsonStrScreenMap,
         FL_WARN("Failed to parse JSON");
         return false;
     }
-    
+
     if (!jsonDoc.is_object()) {
         *err = "JSON root is not an object";
         FL_WARN("JSON root is not an object");
         return false;
     }
-    
+
+    // ── v2 dispatch ──────────────────────────────────────────────────────
+    // v2 if: explicit "version": 2  OR  has top-level "segments" array.
+    // v1 if: explicit "version": 1  OR  has top-level "map" object.
+    bool explicitV2 = false;
+    bool explicitV1 = false;
+    if (jsonDoc.contains("version") && jsonDoc["version"].has_value()) {
+        auto versionOpt = jsonDoc["version"].as_int();
+        if (versionOpt) {
+            int v = static_cast<int>(*versionOpt);
+            if (v == 2) explicitV2 = true;
+            else if (v == 1) explicitV1 = true;
+        }
+    }
+    bool hasSegments = jsonDoc.contains("segments") && jsonDoc["segments"].has_value()
+                       && jsonDoc["segments"].is_array();
+    bool hasMap = jsonDoc.contains("map") && jsonDoc["map"].has_value()
+                  && jsonDoc["map"].is_object();
+
+    if (explicitV2 || (!explicitV1 && hasSegments && !hasMap)) {
+        return parseV2SegmentArray(jsonDoc["segments"], segmentMaps, err);
+    }
+
+    // Fall through to v1 path.
     // Check if "map" key exists and is an object
     if (!jsonDoc.contains("map")) {
         *err = "Missing 'map' key in JSON";

--- a/tests/fl/math/screenmap.cpp
+++ b/tests/fl/math/screenmap.cpp
@@ -160,6 +160,127 @@ FL_TEST_CASE("ScreenMap getBounds functionality") {
     FL_CHECK(emptyBounds.y == 0.0f);
 }
 
+FL_TEST_CASE("ScreenMap v2 JSON parsing — basic segments") {
+    // v2: top-level `segments` array, each entry has its own x/y arrays.
+    const char* json = R"({
+        "version": 2,
+        "groups": { "trunk": { "color": "#ffffff" } },
+        "segments": [
+            { "id": "a", "pin": 1, "group": "trunk",
+              "x": [0.0, 1.0, 2.0], "y": [0.0, 0.0, 0.0] },
+            { "id": "b", "pin": 2, "group": "trunk",
+              "x": [10.0, 11.0], "y": [5.0, 5.0] }
+        ]
+    })";
+
+    fl::flat_map<string, ScreenMap> segmentMaps;
+    string err;
+    bool ok = ScreenMap::ParseJson(json, &segmentMaps, &err);
+    FL_CHECK(ok);
+    FL_CHECK(segmentMaps.size() == 2);
+
+    ScreenMap& a = segmentMaps["a"];
+    FL_CHECK(a.getLength() == 3);
+    FL_CHECK(a[0].x == 0.0f); FL_CHECK(a[0].y == 0.0f);
+    FL_CHECK(a[1].x == 1.0f); FL_CHECK(a[1].y == 0.0f);
+    FL_CHECK(a[2].x == 2.0f); FL_CHECK(a[2].y == 0.0f);
+
+    ScreenMap& b = segmentMaps["b"];
+    FL_CHECK(b.getLength() == 2);
+    FL_CHECK(b[0].x == 10.0f); FL_CHECK(b[0].y == 5.0f);
+    FL_CHECK(b[1].x == 11.0f); FL_CHECK(b[1].y == 5.0f);
+}
+
+FL_TEST_CASE("ScreenMap v2 JSON parsing — auto-detect without explicit version") {
+    // Same shape as the test above but no "version" key — parser should still
+    // route to v2 because the root has a `segments` array.
+    const char* json = R"({
+        "segments": [
+            { "id": "x", "pin": 1, "group": "g",
+              "x": [0.5, 1.5], "y": [2.5, 3.5] }
+        ]
+    })";
+
+    fl::flat_map<string, ScreenMap> segmentMaps;
+    string err;
+    bool ok = ScreenMap::ParseJson(json, &segmentMaps, &err);
+    FL_CHECK(ok);
+    FL_CHECK(segmentMaps.size() == 1);
+    ScreenMap& x = segmentMaps["x"];
+    FL_CHECK(x.getLength() == 2);
+    FL_CHECK(x[0].x == 0.5f); FL_CHECK(x[0].y == 2.5f);
+    FL_CHECK(x[1].x == 1.5f); FL_CHECK(x[1].y == 3.5f);
+}
+
+FL_TEST_CASE("ScreenMap v2 JSON parsing — forks produce separate entries") {
+    // A fork is just another segment with the same shape; in firmware-flat form
+    // each fork twin gets its own keyed entry under its `id`.
+    const char* json = R"({
+        "version": 2,
+        "groups": { "trunk": { "color": "#fff" }, "branch": { "color": "#f00" } },
+        "segments": [
+            { "id": "a", "pin": 1, "group": "trunk",
+              "x": [0.0, 1.0, 2.0, 3.0, 4.0],
+              "y": [0.0, 0.0, 0.0, 0.0, 0.0] },
+            { "id": "b", "pin": 2, "group": "branch", "parent": "a", "offset": 2,
+              "x": [2.0, 2.0, 2.0],
+              "y": [0.0, 1.0, 2.0] }
+        ]
+    })";
+
+    fl::flat_map<string, ScreenMap> segmentMaps;
+    string err;
+    bool ok = ScreenMap::ParseJson(json, &segmentMaps, &err);
+    FL_CHECK(ok);
+    FL_CHECK(segmentMaps.size() == 2);
+
+    ScreenMap& a = segmentMaps["a"];
+    FL_CHECK(a.getLength() == 5);
+    FL_CHECK(a[0].x == 0.0f); FL_CHECK(a[2].x == 2.0f); FL_CHECK(a[4].x == 4.0f);
+
+    ScreenMap& b = segmentMaps["b"];
+    FL_CHECK(b.getLength() == 3);
+    FL_CHECK(b[0].x == 2.0f); FL_CHECK(b[0].y == 0.0f);
+    FL_CHECK(b[2].x == 2.0f); FL_CHECK(b[2].y == 2.0f);
+}
+
+FL_TEST_CASE("ScreenMap v2 JSON parsing — v1 file with explicit version=1 still works") {
+    // Explicit "version": 1 should NOT trip v2 dispatch. Existing "map" path runs.
+    const char* json = R"({
+        "version": 1,
+        "map": {
+            "strip1": { "x": [1.0, 2.0], "y": [3.0, 4.0], "diameter": 0.25 }
+        }
+    })";
+
+    fl::flat_map<string, ScreenMap> segmentMaps;
+    string err;
+    bool ok = ScreenMap::ParseJson(json, &segmentMaps, &err);
+    FL_CHECK(ok);
+    FL_CHECK(segmentMaps.size() == 1);
+    ScreenMap& s = segmentMaps["strip1"];
+    FL_CHECK(s.getLength() == 2);
+    FL_CHECK(s.getDiameter() == 0.25f);
+    FL_CHECK(s[0].x == 1.0f); FL_CHECK(s[1].y == 4.0f);
+}
+
+FL_TEST_CASE("ScreenMap v2 JSON parsing — malformed segments errors cleanly") {
+    // Missing 'x' should produce an informative error string and return false.
+    const char* json = R"({
+        "version": 2,
+        "segments": [
+            { "id": "broken", "pin": 1, "group": "g", "y": [0.0, 1.0] }
+        ]
+    })";
+
+    fl::flat_map<string, ScreenMap> segmentMaps;
+    string err;
+    bool ok = ScreenMap::ParseJson(json, &segmentMaps, &err);
+    FL_CHECK(!ok);
+    FL_CHECK(segmentMaps.size() == 0);
+    FL_CHECK(err.size() > 0);
+}
+
 // Grouped tests
 #include "tests/fl/math/xymap.hpp"
 


### PR DESCRIPTION
Closes #3050.

Adds support for the screenmap v2 format ([zackees/ledmapper#92](https://github.com/zackees/ledmapper/issues/92)) inside the existing `ScreenMap::ParseJson(const char*, flat_map<string, ScreenMap>*)`.

## Dispatch (top to bottom)

1. Explicit \`\"version\": 2\` → v2 parser
2. Explicit \`\"version\": 1\` → v1 parser
3. Has top-level \`segments\` array (and no \`map\`) → v2 parser (auto-detect)
4. Falls through to the existing \`map\` path

## Flatten policy (Proposal A from #3050)

Each v2 segment becomes one \`ScreenMap\` entry keyed by the segment's \`id\`. Fork twins each get their own entry (e.g. \`a\`, \`b\` where \`b\` has \`parent: \"a\"\`). UI/wiring metadata (\`pin\`, \`group\`, \`parent\`, \`offset\`, \`z\`, \`groups[]\`) is intentionally ignored — firmware just needs per-LED positions. A future \`ScreenMapV2\` type (Proposal B from #3050) can preserve the richer structure for editor / video tool consumers; this PR is the minimal flatten path.

## Backward compat

- All existing v1 fixtures and the existing \`\"ScreenMap JSON parsing\"\` test case stay green.
- Public API unchanged. No new signatures, no breaking renames.

## Tests added

- \`v2 basic segments parsing\` — two segments, full extraction
- \`v2 auto-detect without explicit version\` — root has \`segments\` but no \`version\`
- \`v2 forks produce separate entries\` — parent + child both materialize with own coords
- \`v1 file with explicit \"version\": 1 still works\` — explicit v1 doesn't trip v2 dispatch
- \`v2 malformed segments errors cleanly\` — missing \`x\` returns false + non-empty err

## Verified

\`uv run test.py --cpp screenmap --no-pch\` → all tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for an enhanced data format version with improved structure validation and error handling

* **Tests**
  * Comprehensive test coverage for new format support, validation errors, and backward compatibility with legacy formats

<!-- end of auto-generated comment: release notes by coderabbit.ai -->