### PR TITLE
chore(deps): bump zccache floor 1.12.3 -> 1.12.5 (fixes #3048)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,7 +143,15 @@ dependencies = [
     # incremental builds produce stale .obj files after a git pull that
     # changes transitive headers (symptom: `undefined symbol: ...` link
     # errors hours after a header actually changed).
-    "zccache>=1.12.3",
+    # 1.12.5 (released 2026-06-14): native-file lifecycle fix on Windows
+    # (zackees/zccache#710, surfaced in FastLED #3048). The meson-snapshot
+    # restore path no longer leaves `meson_native.txt` in a broken state
+    # after the file-lock race -- restores rewrite the native file
+    # unconditionally on failure recovery. Eliminates the
+    # `FileNotFoundError: meson_native.txt` / `ninja: error: rebuilding
+    # 'build.ninja': subcommand failed` cascade we hit during long-session
+    # `bash test --cpp` cycles.
+    "zccache>=1.12.5",
     "ninja",
     "meson>=1.11.0",
     "download",


### PR DESCRIPTION
## Summary

zccache 1.12.5 (released 2026-06-14) ships the meson-native-file lifecycle fix from [zackees/zccache#710](https://github.com/zackees/zccache/issues/710), which closes FastLED #3048. The snapshot-restore path on Windows previously left `meson_native.txt` in a broken state after the file-lock race; 1.12.5 rewrites the native file unconditionally on failure recovery.

## Change

- `pyproject.toml` — `\"zccache>=1.12.3\"` → `\"zccache>=1.12.5\"` + a comment block documenting the 1.12.5 fix.
- `uv.lock` is gitignored; the next `uv sync` against this branch resolves `zccache` at 1.12.5 from the new floor.

## Verification

Locally:

```
$ uv lock --upgrade-package zccache
Resolved 166 packages in 224ms
$ grep -A 1 '^name = \"zccache\"' uv.lock
name = \"zccache\"
version = \"1.12.5\"
```

Closes #3048.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated dependency to resolve Windows native-file lifecycle issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->