### PR TITLE
chore(.gitignore): globally ignore .clangd + .vscode/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,12 @@ Thumbs.db
 .piolibdeps/
 .platformio/
 .vscode/c_cpp_properties.json
+# Per-developer IDE / language-server artifacts. clangd and VS Code drop
+# these into any directory they index (e.g. examples/AutoResearch/.clangd,
+# examples/<Sketch>/.vscode/). Globally ignore so they stop polluting
+# `git status` across the example tree.
+.clangd
+.vscode/
 .aider*
 !.aider.conf.yml
 !.aiderignore


### PR DESCRIPTION
## Summary

clangd and VS Code drop per-developer artifacts (`.clangd` config, `.vscode/` workspace settings) into any directory they index — `examples/AutoResearch/.clangd`, `examples/<Sketch>/.vscode/`, etc. The existing ignore set only covered `.vscode/c_cpp_properties.json` and `ci/native/.vscode/`, so the rest leaked into every `git status` across the example tree.

This PR adds two global rules:

```
.clangd
.vscode/
```

These are per-developer; nothing in this tree should track them. The narrower `c_cpp_properties.json` rule remains in place to avoid churn but is now redundant under the broader `.vscode/` directory ignore.

## Verification

After the rule, `git status` on a fresh `master` checkout no longer surfaces the AutoResearch IDE leftovers we've been seeing for the last several PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development configuration to ignore additional IDE and language-server artifacts, improving consistency across developer environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->