### PR TITLE
docs(review): forbid new FASTLED_* macros, require FL_* prefix

### DIFF
--- a/.claude/commands/code_review.md
+++ b/.claude/commands/code_review.md
@@ -146,7 +146,7 @@ meson.build (root)          → Source discovery, library compilation
 - Dispatcher: `src/platforms/coroutine.impl.cpp.hpp`, `src/platforms/channel_drivers.impl.cpp.hpp`
 - No-op fallback: `src/platforms/shared/memory_noop.hpp`, `src/platforms/shared/pin_noop.hpp`, `src/platforms/shared/simd_noop.hpp`
 
-### Macro Naming — THREE TYPES, NO ACRONYM-STYLE CAPABILITY FLAGS
+### Macro Naming — THREE TYPES, NO ACRONYM-STYLE CAPABILITY FLAGS, NO NEW `FASTLED_*`
 
 **Authoritative reference:** `agents/docs/cpp-standards.md` → "Macro Definition Patterns".
 
@@ -155,21 +155,35 @@ The codebase recognizes three macro types:
 | Type | Pattern | Has value? | Use case |
 |---|---|---|---|
 | 1. Platform detection | `FL_IS_<PLATFORM>` | No (defined/undefined) | "Am I running on this platform?" |
-| 2. Configuration | `FASTLED_<NAME>` | Yes (0/1/numeric, explicit) | User-tunable build settings |
-| 3. Component capability flag | `FL_<COMPONENT>_HAS_<FEATURE>` or `FL_<COMPONENT>_<NUMERIC>` | Boolean: no value. Numeric: explicit value. | "Does this subsystem have this feature on this platform?" |
+| 2. Configuration (LEGACY) | `FASTLED_<NAME>` | Yes (0/1/numeric, explicit) | Pre-existing user-tunable build settings — **frozen vocabulary** |
+| 3. Component capability / config | `FL_<COMPONENT>_HAS_<FEATURE>` (bool) / `FL_<COMPONENT>_<NUMERIC>` (numeric) / `FL_<COMPONENT>_<NAME>` (new build settings) | Boolean: no value. Numeric: explicit value. | "Does this subsystem have this feature?" + **all new tunables** |
 
-**CRITICAL: Type 3 capability macros use SPELLED-OUT component names — no acronyms.**
+**CRITICAL RULE #1 — No new `FASTLED_*` macros.** The `FASTLED_*` prefix is frozen for backwards compatibility with already-shipped names. Every NEW macro — capability flag, tunable, build-time switch — uses the `FL_*` prefix. Renaming existing `FASTLED_*` macros is out of scope; this rule only blocks NEW additions.
+
+- ❌ Wrong (new code): `#define FASTLED_LPC_PWM_DMA 1`, `#define FASTLED_LPC_RX_SCT_WS2812 1`, `-DFASTLED_NEW_FEATURE=1`
+- ✅ Correct (new code): `#define FL_LPC_PWM_DMA 1`, `#define FL_LPC_RX_SCT_WS2812 1`, `-DFL_NEW_FEATURE=1`
+
+This applies to **all locations where macros are introduced**:
+- `#define` directives in `src/**`, `tests/**`, `examples/**`, `platforms/**`
+- `-D<NAME>=...` flags in `platformio.ini` `build_flags = ...` blocks
+- `-D<NAME>=...` flags in `meson.build`, `CMakeLists.txt`, GitHub Actions YAML
+- `defined(...)` / `#ifdef` checks introducing brand-new identifiers (not just guarding existing ones)
+
+**CRITICAL RULE #2 — Type 3 capability macros use SPELLED-OUT component names — no acronyms.**
 
 The macro identifier and the public API name share a single vocabulary. If the API is `FastLED.watchdog()`, the macros are `FL_WATCHDOG_*`. If the API is `FastLED.audio()`, the macros are `FL_AUDIO_*`. Forcing readers to learn an acronym in addition to the spelled-out API name is exactly the jargon failure these conventions exist to prevent.
 
 - ✅ Correct: `FL_WATCHDOG_HAS_WINDOW_MODE`, `FL_WATCHDOG_PERSIST_BYTES`, `FL_AUDIO_HAS_I2S`, `FL_CODEC_HAS_H264`
-- ❌ Wrong: `FL_WDT_HAS_WINDOW_MODE` (acronym hides the component), `FASTLED_WATCHDOG_*` (use `FL_` for newer per-component capability flags, reserve `FASTLED_` for Type 2 build settings), `WATCHDOG_HAS_WINDOW_MODE` (missing prefix)
+- ❌ Wrong: `FL_WDT_HAS_WINDOW_MODE` (acronym hides the component), `WATCHDOG_HAS_WINDOW_MODE` (missing prefix)
 
 **Check Process for PRs:**
-1. Grep for any new `#define FL_*` in the diff.
-2. If it contains a known acronym for a longer component name (`WDT`, `IRQ`, `MUX`, `DMA` as a *component name* vs as a feature descriptor), flag it. (Note: `FL_WATCHDOG_HAS_DMA_RESET` is fine — `DMA` is a feature within the watchdog component, not the component itself.)
-3. If a no-op header is added and lacks the `_noop` suffix, flag it.
-4. If a new `*.cpp.hpp` lives in a per-family subdirectory rather than `src/platforms/` root, flag it as a misuse of the dispatcher suffix.
+1. Grep the diff for newly added lines matching `^\+.*#define\s+FASTLED_` — every hit is a HIGH-severity violation. Rewrite the identifier with the `FL_` prefix.
+2. Grep the diff for newly added lines matching `^\+.*-DFASTLED_` in `platformio.ini`, `meson.build`, `CMakeLists.txt`, or workflow YAML — same rule, HIGH severity.
+3. Grep the diff for newly added `#define FL_*` — verify it does NOT contain a known acronym for a longer component name (`WDT`, `IRQ`, `MUX`, `DMA` as a *component name* vs as a feature descriptor). Note: `FL_WATCHDOG_HAS_DMA_RESET` is fine — `DMA` is a feature within the watchdog component, not the component itself.
+4. If a no-op header is added and lacks the `_noop` suffix, flag it.
+5. If a new `*.cpp.hpp` lives in a per-family subdirectory rather than `src/platforms/` root, flag it as a misuse of the dispatcher suffix.
+
+**Grandfathering:** Existing `FASTLED_*` references that the PR merely touches (reformat, move, comment) are NOT violations. Only NEW identifiers are flagged. If unsure whether a `FASTLED_*` token is new, search the base branch — if it already exists, it's grandfathered.
 
 ### **/*.h and **/*.cpp changes - PLATFORM HEADER ISOLATION
 
@@ -748,6 +762,7 @@ FL_TEST_CASE("my test") {
   - Missing performance attributes: N
   - DMA/poll wait loops missing yield: N
   - Public Settings Pattern violations (bare fl::set_* without CFastLED wrapper): N
+  - New `FASTLED_*` macros (should be `FL_*`): N
   - Other: N
 - Violations fixed: N
 - User confirmations needed: N

--- a/.claude/commands/code_review.md
+++ b/.claude/commands/code_review.md
@@ -179,9 +179,10 @@ The macro identifier and the public API name share a single vocabulary. If the A
 **Check Process for PRs:**
 1. Grep the diff for newly added lines matching `^\+.*#define\s+FASTLED_` — every hit is a HIGH-severity violation. Rewrite the identifier with the `FL_` prefix.
 2. Grep the diff for newly added lines matching `^\+.*-DFASTLED_` in `platformio.ini`, `meson.build`, `CMakeLists.txt`, or workflow YAML — same rule, HIGH severity.
-3. Grep the diff for newly added `#define FL_*` — verify it does NOT contain a known acronym for a longer component name (`WDT`, `IRQ`, `MUX`, `DMA` as a *component name* vs as a feature descriptor). Note: `FL_WATCHDOG_HAS_DMA_RESET` is fine — `DMA` is a feature within the watchdog component, not the component itself.
-4. If a no-op header is added and lacks the `_noop` suffix, flag it.
-5. If a new `*.cpp.hpp` lives in a per-family subdirectory rather than `src/platforms/` root, flag it as a misuse of the dispatcher suffix.
+3. Grep the diff for newly added lines matching `^\+.*defined\(\s*FASTLED_` or `^\+.*#\s*ifdef\s+FASTLED_` or `^\+.*#\s*ifndef\s+FASTLED_` — flag any preprocessor conditional that **introduces** a brand-new `FASTLED_*` identifier (i.e. the identifier is not present anywhere on the base branch). Conditionals merely guarding pre-existing `FASTLED_*` names are grandfathered. HIGH severity.
+4. Grep the diff for newly added `#define FL_*` — verify it does NOT contain a known acronym for a longer component name (`WDT`, `IRQ`, `MUX`, `DMA` as a *component name* vs as a feature descriptor). Note: `FL_WATCHDOG_HAS_DMA_RESET` is fine — `DMA` is a feature within the watchdog component, not the component itself.
+5. If a no-op header is added and lacks the `_noop` suffix, flag it.
+6. If a new `*.cpp.hpp` lives in a per-family subdirectory rather than `src/platforms/` root, flag it as a misuse of the dispatcher suffix.
 
 **Grandfathering:** Existing `FASTLED_*` references that the PR merely touches (reformat, move, comment) are NOT violations. Only NEW identifiers are flagged. If unsure whether a `FASTLED_*` token is new, search the base branch — if it already exists, it's grandfathered.
 

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -79,6 +79,79 @@ reviews:
         Existing `-DFASTLED_*` flags that the PR merely moves or reformats (without
         introducing a brand-new identifier) are grandfathered. Flag only new identifiers.
         Reference: `agents/docs/cpp-standards.md` → "Type 3: Component Capability Flags".
+
+    - path: "**/meson.build"
+      instructions: |
+        Meson build macro prefix rule (matches the `FL_*` vs `FASTLED_*` rule applied
+        to C/C++ sources and PlatformIO):
+
+        Any NEWLY ADDED `-D<NAME>...` entry — typically inside
+        `add_project_arguments`, `cpp_args`, `c_args`, `args:`, or
+        `compile_args` — whose identifier starts with `FASTLED_` is a
+        HIGH-severity violation. Use the `FL_*` prefix instead. The `FASTLED_*`
+        vocabulary is frozen — it exists only for backwards compatibility with
+        already-shipped macros.
+
+        Example violations:
+          add_project_arguments('-DFASTLED_LPC_PWM_DMA=1', language: 'cpp')  ; ❌
+          cpp_args = ['-DFASTLED_NEW_FEATURE=1']                              ; ❌
+        Rewrites:
+          add_project_arguments('-DFL_LPC_PWM_DMA=1', language: 'cpp')       ; ✅
+          cpp_args = ['-DFL_NEW_FEATURE=1']                                   ; ✅
+
+        Existing `-DFASTLED_*` entries that the PR merely moves or reformats (without
+        introducing a brand-new identifier) are grandfathered. Flag only new identifiers.
+        Reference: `agents/docs/cpp-standards.md` → "Type 3: Component Capability Flags".
+
+    - path: "**/CMakeLists.txt"
+      instructions: |
+        CMake macro prefix rule (matches the `FL_*` vs `FASTLED_*` rule applied to
+        C/C++ sources and PlatformIO):
+
+        Any NEWLY ADDED compile definition or flag — `add_compile_definitions(...)`,
+        `target_compile_definitions(...)`, `add_definitions(-D...)`, or a raw
+        `-D<NAME>=...` token inside `set(... CMAKE_CXX_FLAGS ...)` / `string(APPEND
+        CMAKE_CXX_FLAGS ...)` — whose identifier starts with `FASTLED_` is a
+        HIGH-severity violation. Use the `FL_*` prefix instead. The `FASTLED_*`
+        vocabulary is frozen.
+
+        Example violations:
+          add_compile_definitions(FASTLED_LPC_PWM_DMA=1)                            ; ❌
+          target_compile_definitions(fastled PRIVATE FASTLED_LPC_RX_SCT_WS2812=1)   ; ❌
+          add_definitions(-DFASTLED_NEW_FEATURE=1)                                  ; ❌
+        Rewrites:
+          add_compile_definitions(FL_LPC_PWM_DMA=1)                                 ; ✅
+          target_compile_definitions(fastled PRIVATE FL_LPC_RX_SCT_WS2812=1)        ; ✅
+          add_definitions(-DFL_NEW_FEATURE=1)                                       ; ✅
+
+        Existing `FASTLED_*` entries that the PR merely moves or reformats (without
+        introducing a brand-new identifier) are grandfathered. Flag only new identifiers.
+        Reference: `agents/docs/cpp-standards.md` → "Type 3: Component Capability Flags".
+
+    - path: ".github/workflows/**/*.{yml,yaml}"
+      instructions: |
+        GitHub Actions macro prefix rule (matches the `FL_*` vs `FASTLED_*` rule
+        applied to C/C++ sources and other build systems):
+
+        Any NEWLY ADDED `-D<NAME>=...` token in a workflow step — typically inside
+        `env: { CXXFLAGS: ... }`, `env: { CFLAGS: ... }`, a `run:` script that
+        forwards build flags, or an `args:` list passed to a build wrapper — whose
+        identifier starts with `FASTLED_` is a HIGH-severity violation. Use the
+        `FL_*` prefix instead.
+
+        Example violations:
+          env:
+            CXXFLAGS: "-DFASTLED_LPC_PWM_DMA=1"            ; ❌
+          run: bash compile lpc --extra-flags=-DFASTLED_NEW_FEATURE=1   ; ❌
+        Rewrites:
+          env:
+            CXXFLAGS: "-DFL_LPC_PWM_DMA=1"                 ; ✅
+          run: bash compile lpc --extra-flags=-DFL_NEW_FEATURE=1        ; ✅
+
+        Existing `-DFASTLED_*` tokens that the PR merely moves or reformats (without
+        introducing a brand-new identifier) are grandfathered. Flag only new identifiers.
+        Reference: `agents/docs/cpp-standards.md` → "Type 3: Component Capability Flags".
+
     - path: "src/**/*.h"
       instructions: |
         Header file. Verify it does NOT contain function definitions, function-local

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -37,14 +37,47 @@ reviews:
       instructions: |
         Macro naming — three types are recognized:
         1. `FL_IS_<PLATFORM>` — platform detection, defined-or-undefined, no value.
-        2. `FASTLED_<NAME>` — legacy configuration macros with explicit 0/1/numeric values.
+        2. `FASTLED_<NAME>` — **LEGACY-ONLY** configuration macros with explicit
+           0/1/numeric values. **Frozen vocabulary** — do not invent new `FASTLED_*`
+           names. All new configuration macros use the `FL_*` prefix.
         3. `FL_<COMPONENT>_HAS_<FEATURE>` — per-subsystem capability flag, defined-or-
            undefined, no value. `FL_<COMPONENT>_<NUMERIC>` — numeric property, explicit
-           value.
+           value. `FL_<COMPONENT>_<NAME>` — new configuration / tuning macros with
+           explicit value (replaces the legacy `FASTLED_*` form).
         Critical rule: `<COMPONENT>` is the SPELLED-OUT name, NOT an acronym. The macro
         and the public API share a single vocabulary. If the API is `FastLED.watchdog()`,
         the macros are `FL_WATCHDOG_*`, NOT `FL_WDT_*`. If a PR introduces acronym-style
         capability macros, flag them and request the spelled-out form.
+
+        **NEW MACRO PREFIX RULE (HIGH severity):** Any newly introduced `#define`,
+        `-D<NAME>=...` build flag, or `defined(...)` check whose identifier starts with
+        `FASTLED_` is a violation. Use `FL_<COMPONENT>_<NAME>` instead. Renaming an
+        existing `FASTLED_*` macro is out of scope here — only NEW additions are flagged.
+        Existing `FASTLED_*` references in the diff (touched but not introduced) are
+        grandfathered. Examples:
+          - ❌ `#define FASTLED_LPC_PWM_DMA 1`        →  ✅ `#define FL_LPC_PWM_DMA 1`
+          - ❌ `#define FASTLED_LPC_RX_SCT_WS2812 1`  →  ✅ `#define FL_LPC_RX_SCT_WS2812 1`
+          - ❌ `-DFASTLED_NEW_FEATURE=1` in build_flags →  ✅ `-DFL_NEW_FEATURE=1`
+        Reference: `agents/docs/cpp-standards.md` → "Type 3: Component Capability Flags".
+
+    - path: "**/platformio.ini"
+      instructions: |
+        PlatformIO `build_flags` macro prefix rule (matches the `FL_*` vs `FASTLED_*`
+        rule applied to C/C++ sources):
+
+        Any NEWLY ADDED `-D<NAME>...` build flag whose identifier starts with `FASTLED_`
+        is a HIGH-severity violation. Use the `FL_*` prefix instead. The `FASTLED_*`
+        vocabulary is frozen — it exists only for backwards compatibility with
+        already-shipped macros.
+
+        Example violation (from PR diff):
+          build_flags =
+            -DRELEASE
+            -DFASTLED_LPC_PWM_DMA=1         ; ❌ flag — should be -DFL_LPC_PWM_DMA=1
+            -DFASTLED_LPC_RX_SCT_WS2812=1   ; ❌ flag — should be -DFL_LPC_RX_SCT_WS2812=1
+
+        Existing `-DFASTLED_*` flags that the PR merely moves or reformats (without
+        introducing a brand-new identifier) are grandfathered. Flag only new identifiers.
         Reference: `agents/docs/cpp-standards.md` → "Type 3: Component Capability Flags".
     - path: "src/**/*.h"
       instructions: |


### PR DESCRIPTION
## Summary
- Mark `FASTLED_*` as **legacy / frozen vocabulary** in both `.coderabbit.yaml` and the `/code_review` skill (`.claude/commands/code_review.md`).
- Add a HIGH-severity rule that any **newly introduced** macro identifier with the `FASTLED_` prefix is a violation; new macros must use `FL_<COMPONENT>_<NAME>`.
- Extend the rule to `platformio.ini` `build_flags` (`-D<NAME>=...`), `meson.build`, `CMakeLists.txt`, and GitHub Actions YAML — not just C/C++ `#define` lines.
- Existing `FASTLED_*` references in a diff are explicitly grandfathered; only brand-new identifiers trip the rule.

Triggered by an LPC example whose build_flags read:
```
build_flags =
    -DRELEASE
    -DFASTLED_LPC_PWM_DMA=1
    -DFASTLED_LPC_RX_SCT_WS2812=1
```
Under the new rule, those would be flagged and rewritten to `-DFL_LPC_PWM_DMA=1` / `-DFL_LPC_RX_SCT_WS2812=1`.

## Test plan
- [ ] CodeRabbit picks up the new `**/platformio.ini` path block on the next PR with `-DFASTLED_*` build_flags
- [ ] `/code_review` slash command surfaces the "New `FASTLED_*` macros (should be `FL_*`)" counter in its summary template
- [ ] Sanity-check: a PR that only touches an existing `FASTLED_*` line (move/reformat) is NOT flagged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated code review guidelines to enforce consistent macro naming, marking `FASTLED_*` as legacy-only and requiring new capability/config macros to use the `FL_*` format. Also tightened rules for how capability macro components should be spelled out.

* **Chores**
  * Strengthened automated review checks to detect newly introduced `FASTLED_*` macro definitions and build flags across common build and CI configurations, ensuring they use the required `FL_*` naming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->