### PR TITLE
fix(lpc): F_CPU=24MHz + platform-detection ordering + SCT macro shim

### DIFF
--- a/examples/AutoResearch/AutoResearchLowMemory.h
+++ b/examples/AutoResearch/AutoResearchLowMemory.h
@@ -267,9 +267,9 @@ inline void autoResearchLowMemorySetup() {
             for (int i = 0; i < expected_bytes; ++i) decoded_buf[i] = 0;
 
             fl::ChipsetTiming4Phase timing =
-                fl::make4PhaseTiming(fl::TimingTraits<WS2812Chipset>::T1,
-                                     fl::TimingTraits<WS2812Chipset>::T2,
-                                     fl::TimingTraits<WS2812Chipset>::T3);
+                fl::make4PhaseTiming(
+                    fl::to_runtime_timing<fl::WS2812ChipsetTiming>(),
+                    /*reset_us=*/0u);
 
             auto dec = rx->decode(timing, fl::span<u8>(decoded_buf, expected_bytes));
             const fl::u32 decoded_bytes = dec.ok() ? dec.value() : 0u;

--- a/src/fl/system/sketch_macros.h
+++ b/src/fl/system/sketch_macros.h
@@ -1,5 +1,15 @@
 #pragma once
 
+// Pull in platform detection BEFORE the tier classification fires. Without
+// this, FL_IS_ARM_LPC / FL_IS_TEENSY_LC / FL_IS_STM32_F1 etc. -- the gates
+// in the Low-tier branch below -- are undefined when sketch_macros.h is
+// transitively included via fl/system/engine_events.h before any other
+// platform-aware include. Result: LPC builds get FL_PLATFORM_HAS_LARGE_MEMORY=1
+// (wrong) and pull in FASTLED_HAS_ENGINE_EVENTS code that lacks symbol
+// definitions -- link fails. Pulling is_platform.h here makes the detection
+// canonical regardless of include order.
+#include "platforms/is_platform.h"
+
 // Four-tier platform-memory classification (FastLED #3000).
 //
 // Canonical names:

--- a/src/platforms/arm/lpc/clockless_arm_lpc_pwm_dma.h
+++ b/src/platforms/arm/lpc/clockless_arm_lpc_pwm_dma.h
@@ -60,13 +60,18 @@
 // SCT TIMING (UM11029 16.6.6 MATCH registers, 16.6.13 STATE/EVENT machine)
 // ------------------------------------------------------------------------
 // The SCT runs as a single 16-bit unified up-counter driven by the system
-// clock (F_CPU = 30 MHz on LPC845). At F_CPU = 30 MHz the SCT tick is
-// 33.33 ns; the WS2812 timing positions fall on these counts:
+// clock. At the canonical LPC845 default F_CPU = 24 MHz (Arduino core
+// + fbuild lpc845brk.json contract) the SCT tick is 41.67 ns; the
+// WS2812 timing positions fall on these counts:
 //
 //   T0_RISE  = 0            (rising edge of every bit)
-//   T0_FALL  = 11  (~367 ns) (T0H window end -> drop for '0' bits)
-//   T1_FALL  = 24  (~800 ns) (T1H window end -> drop for '1' bits)
-//   T_END    = 37  (~1233 ns) (counter reload, next bit starts)
+//   T0_FALL  =  9  (~375 ns) (T0H window end -> drop for '0' bits)
+//   T1_FALL  = 19  (~792 ns) (T1H window end -> drop for '1' bits)
+//   T_END    = 30  (~1250 ns) (counter reload, next bit starts)
+//
+// (Counts at F_CPU=30 MHz, an opt-in PLL configuration: T0_FALL=11 / 367 ns,
+//  T1_FALL=24 / 800 ns, T_END=37 / 1233 ns. The derivation macro at line 313
+//  picks up whichever F_CPU is set at compile time.)
 //
 // Three match registers fire the three DMA streams. MATCH3 is configured to
 // reload the counter on T_END.
@@ -206,6 +211,17 @@ namespace fl {
 // a real LPC845 toolchain include <LPC845.h> via led_sysdefs_arm_lpc.h and
 // the genuine struct wins.
 #if !defined(LPC_SCT) && !defined(LPC_SCT_TYPE_)
+// Arduino.h on the LPC8xx core defines INPUT / OUTPUT as preprocessor
+// macros for digitalRead/Write. The SCT register block uses identifiers
+// with the same names (INPUT at offset 0x048, OUTPUT at 0x054 per
+// UM11029 sec. 16.6); macro expansion would corrupt the struct fields.
+// Push the Arduino macros aside for the struct definition only;
+// downstream user code that calls pinMode(pin, OUTPUT) still works
+// because the macros get redefined at the bottom of this block.
+#pragma push_macro("INPUT")
+#pragma push_macro("OUTPUT")
+#undef INPUT
+#undef OUTPUT
 struct FL_LPC_SCT_Shim {
     volatile u32 CONFIG;        // 0x000  config
     volatile u32 CTRL;          // 0x004  control
@@ -248,6 +264,8 @@ struct FL_LPC_SCT_Shim {
         volatile u32 CTRL;      // 0x304, 0x30C, ...
     } EV[8];
 };
+#pragma pop_macro("OUTPUT")
+#pragma pop_macro("INPUT")
 #define LPC_SCT ((FL_LPC_SCT_Shim*)LPC_SCT_BASE)
 #endif  // !LPC_SCT
 

--- a/src/platforms/arm/lpc/led_sysdefs_arm_lpc.h
+++ b/src/platforms/arm/lpc/led_sysdefs_arm_lpc.h
@@ -38,7 +38,15 @@
 
 #ifndef F_CPU
 #if defined(FL_IS_ARM_LPC_845)
-#define F_CPU 30000000UL
+// LPC845 native FRO is 24 MHz (post-/2 divider direct path per UM11029
+// sec. 4.1). 30 MHz is only reachable via the PLL, which neither the
+// Arduino core (zackees/ArduinoCore-LPC8xx) nor fbuild programs by
+// default. Both sources of truth (Arduino boards.txt + fbuild
+// lpc845brk.json) declare f_cpu=24000000L. The previous 30 MHz default
+// in this header introduced a ~25%% cycle-count drift on the bit-bang
+// and SCT+DMA clockless drivers. Users who actually program the PLL
+// can override via -DF_CPU=30000000UL.
+#define F_CPU 24000000UL
 #elif defined(FL_IS_ARM_LPC_804)
 #define F_CPU 15000000UL
 #elif defined(FL_IS_ARM_LPC_11_USB)


### PR DESCRIPTION
## Summary

Four source-tree fixes uncovered while bringing up the LPC845 SCT+DMA WS2812 driver against the consolidated AutoResearch sketch. Each is a real bug independent of the bring-up effort.

| File | Fix |
|---|---|
| `src/platforms/arm/lpc/led_sysdefs_arm_lpc.h` | LPC845 `F_CPU` corrected from 30 MHz to 24 MHz. The chip's FRO native direct-path rate is 24 MHz per UM11029 §4.1; both Arduino core `boards.txt` and fbuild `lpc845brk.json` declare `f_cpu=24000000L`. Previous 30 MHz default → ~25 % cycle-count drift on bit-bang + SCT+DMA. PLL users override via `-DF_CPU=30000000UL`. |
| `src/fl/system/sketch_macros.h` | Pulls in `platforms/is_platform.h` before tier classification fires. Without this, `FL_IS_ARM_LPC` was undefined when `sketch_macros.h` came in via `fl/system/engine_events.h` before any other platform-aware include — LPC builds got `FL_PLATFORM_HAS_LARGE_MEMORY=1` (wrong), `FASTLED_HAS_ENGINE_EVENTS=1`, and `CLEDController::showLeds()` emitted unresolved refs to `fl::EngineEvents::getInstance()` etc. |
| `src/platforms/arm/lpc/clockless_arm_lpc_pwm_dma.h` | (a) `#pragma push_macro` around `FL_LPC_SCT_Shim` so Arduino.h's `INPUT 0x0` / `OUTPUT 0x1` macros don't corrupt SCT register field names `INPUT` (0x048) / `OUTPUT` (0x054). Macros pop at struct close so user `pinMode(pin, OUTPUT)` still works. (b) SCT timing comment block updated to reflect 24 MHz match counts (tick = 41.67 ns, T0_FALL=9, T1_FALL=19, T_END=30). |
| `examples/AutoResearch/AutoResearchLowMemory.h` | `ws2812SctTest` migrated to the current `fl::make4PhaseTiming(const ChipsetTiming&, u32 reset_us)` signature using `fl::to_runtime_timing<fl::WS2812ChipsetTiming>()`. The retired LPC sketch used a 3-u32 prototype that no longer exists. |

## Test plan

- [x] AutoResearch.ino in low-memory mode compiles end-to-end for `lpc845brk` via local fbuild against `zackees/ArduinoCore-LPC8xx`.
- [x] SCT+DMA driver header compiles cleanly under `-DFASTLED_LPC_PWM_DMA=1`.
- [x] EngineEvents link errors that fired on the prior platform-detection-ordering bug are gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed build issues caused by incorrect platform detection macro ordering during header inclusion
  * Added protection to prevent Arduino core macros from corrupting internal register definitions on LPC platforms

* **Documentation**
  * Updated LPC845 timing documentation to reflect canonical default clock frequency and derived register values

* **Chores**
  * Adjusted default system clock configuration for LPC845 from 30 MHz to 24 MHz

<!-- end of auto-generated comment: release notes by coderabbit.ai -->