### PR TITLE
chore(deps): bump fbuild 2.2.27 -> 2.2.28 (LPC delegation to upstream Arduino core)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,17 @@ dependencies = [
     #   2.2.16 — completed ESP32-C2 framework skeleton installs
     #            and patched the missing touch_sensor_legacy_types.h
     #            no-touch compatibility header (FastLED/fbuild#378).
-    "fbuild==2.2.27",
+    # 2.2.28 (released 2026-06-15) -- LPC port delegates SystemInit +
+    # linker scripts to zackees/ArduinoCore-LPC8xx upstream; fbuild no
+    # longer ships shadow copies of those NXP-managed assets. Also rolls
+    # up the lite-SCons extra_scripts harness work (FastLED/fbuild#553
+    # steps 3-4, #581/#583/#585), the managed zccache bump to 1.12.4
+    # (FastLED/fbuild#582 -- separate from FastLED's own zccache pin
+    # which is a Python dep), the ESP auto-recovery-from-ROM-download
+    # primitive (FastLED/fbuild#532, #577/#580), and an
+    # http-connect-timeout fix on the managed-zccache client
+    # (FastLED/fbuild#573).
+    "fbuild==2.2.28",
     "platformio>=6.1.19,<6.2",
     "python-dateutil",
     "ruff",


### PR DESCRIPTION
## Summary

fbuild 2.2.28 (PyPI, released 2026-06-15) is now the floor. The LPC port delegates `SystemInit` + linker scripts to `zackees/ArduinoCore-LPC8xx` upstream rather than carrying shadow copies — matches the architectural direction discussed during the LPC845 SCT+DMA WS2812 bring-up earlier today.

## Rollups in 2.2.28

- Lite-SCons `extra_scripts` harness (fbuild#553 steps 3-4 — fbuild#581/#583/#585).
- Managed zccache bump 1.12.3 → 1.12.4 (fbuild#582). Note: this is the binary fbuild ships embedded, separate from FastLED's own Python `zccache>=1.12.5` floor.
- ESP auto-recovery from ROM download mode (fbuild#532, fbuild#577/#580).
- HTTP connect-timeout fix on the managed-zccache client (fbuild#573).

## Effect on the open WIP branch

`feat/lpc845-sct-dma-dev-unblock` carried a `[tool.uv.sources] fbuild = { path = \"../fbuild\", editable = true }` override pointing at `~/dev/fbuild`. That workaround is no longer needed — the WIP branch can drop the override on its next rebase. The four source-tree fixes from that bring-up (F_CPU, sketch_macros include order, SCT INPUT/OUTPUT shim, timing-API migration) already landed in #3055.

## Test plan

- [x] `uv sync` resolves to fbuild 2.2.28.
- [x] `uv run fbuild --version` reports `fbuild 2.2.28`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated fbuild dependency to version 2.2.28 with the latest release notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->