### PR TITLE
chore(platformio/lpc845brk): document build flags + default-on SCT+DMA driver

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -154,16 +154,33 @@ extra_scripts = pre:ci/ci-flags.py
 ; which consumes zackees/ArduinoCore-LPC8xx. PlatformIO does not have a
 ; native nxplpc platform; this env is here only so the AutoResearch wrapper
 ; (`bash autoresearch lpc845brk`) can resolve a known environment name and
-; dispatch to the bring-up sketch at examples/AutoResearchLpc/.
+; dispatch to the consolidated bring-up sketch at examples/AutoResearch/
+; (low-memory mode auto-engages on LPC8xx; see FastLED #3030 / #3041).
 ;
-; -DRELEASE disables FASTLED_FORCE_DBG, which would otherwise pull every
-; FL_DBG call site through fl::println (~4 KB of flash bloat that doesn't
-; fit on this 64 KB part). FL_DBG is by-design no-op on Low-memory
-; platforms; this is the canonical way to gate it OFF for release builds.
+; Build flags:
+;   -DRELEASE                     -- disables FASTLED_FORCE_DBG so the FL_DBG
+;                                    call sites stay no-op (~4 KB saved).
+;   ; -DFASTLED_LPC_PWM_DMA=1       -- activates the hardware-accelerated SCT +
+;                                    DMA-to-GPIO clockless driver (FastLED
+;                                    #2842 / #2850) in place of the bit-bang
+;                                    default. Claims the SCT + 3 DMA channels
+;                                    for the FastLED controller lifetime.
+;   -DFASTLED_LPC_RX_SCT_WS2812=1 -- binds the `ws2812SctTest` AutoResearch
+;                                    loopback RPC (FastLED #3021 Phase 2).
+;                                    Pulls in `<FastLED.h>` alongside fl::Remote;
+;                                    fits the 64 KB budget after #3038's
+;                                    soft-FP-codec replacement.
 platform = nxplpc
 board = lpc845brk
 framework = arduino
-build_flags = -DRELEASE
+build_flags =
+    -DRELEASE
+    -DFASTLED_LPC_PWM_DMA=1
+    -DFASTLED_AUTORESEARCH_LOW_MEMORY=1
+    ; -DFASTLED_LPC_RX_SCT_WS2812=1   ; pulls <FastLED.h>, +20 KB, exceeds 64 KB
+    ;                                  ; flash budget on LPC845-BRK. Re-enable
+    ;                                  ; once additional flash-budget reduction
+    ;                                  ; lands (gamma LUT / EngineEvents / etc.).
 
 
 [platformio]


### PR DESCRIPTION
## Summary

Three env:lpc845brk updates pulled out of the developer-only `feat/lpc845-sct-dma-dev-unblock` branch:

1. Stale dispatch comment replaced — refers to the consolidated `examples/AutoResearch/` (low-memory mode auto-engages on LPC8xx per FastLED #3030 / #3041), not the retired `examples/AutoResearchLpc/`.
2. Build-flag comment block documents each flag's role.
3. Default-enables the hardware-accelerated SCT+DMA WS2812 driver (`-DFASTLED_LPC_PWM_DMA=1`) plus the low-memory autoresearch mode (`-DFASTLED_AUTORESEARCH_LOW_MEMORY=1`). Bit-bang driver still available via `build_unflags = -DFASTLED_LPC_PWM_DMA=1`.

## Note on the dropped override

The `feat/lpc845-sct-dma-dev-unblock` branch also carried `[tool.uv.sources] fbuild = { path = ..., editable = true }` pointing at `~/dev/fbuild`. That override is dropped — PyPI fbuild 2.2.28 (PR #3056) has the LPC delegation to `zackees/ArduinoCore-LPC8xx`, so no local-source workaround is needed.

## Test plan

- [x] `uv run fbuild --version` reports 2.2.28 from PyPI.
- [x] `env:lpc845brk` resolves and dispatches to `examples/AutoResearch/AutoResearch.ino`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Optimized firmware build configuration for LPC845 boards with enhanced memory efficiency and improved PWM/DMA hardware support. Updated build documentation and settings to better accommodate resource constraints while maintaining feature availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->