### PR TITLE
fix(ci/serial): make FbuildSerialAdapter.close() reusable (FastLED/fbuild#592)

### DIFF
--- a/ci/util/serial_interface.py
+++ b/ci/util/serial_interface.py
@@ -174,7 +174,12 @@ class FbuildSerialAdapter:
 
     async def close(self) -> None:
         await self._run_in_thread(self._monitor.__exit__, None, None, None)
-        self._executor.shutdown(wait=False)
+        # NOTE: do NOT shut down self._executor here. The autoresearch
+        # recovery path (ci/autoresearch/gpio.py) calls close() then reuses
+        # the same adapter on a new RpcClient. Shutting the executor down
+        # makes the next _run_in_thread fail with "cannot schedule new
+        # futures after shutdown" and breaks DTR-reset retries. See
+        # FastLED/fbuild#592.
 
     async def write(self, data: str) -> None:
         await self._run_in_thread(self._monitor.write, data)


### PR DESCRIPTION
## Summary

Stops `FbuildSerialAdapter.close()` from permanently killing its per-adapter `ThreadPoolExecutor`. The autoresearch recovery branch (`ci/autoresearch/gpio.py:70`) closes the adapter and reuses it for a fresh `RpcClient` — the executor shutdown made the next `_run_in_thread` fail with `cannot schedule new futures after shutdown`.

This was the second link in the Teensy 4.0 failure chain:

```
post-flash USB re-enumeration
  -> WebSocket error: connection forcibly closed (os error 10054)
  -> FastLED retries: client.close() then new RpcClient(serial_interface=...)
  -> cannot schedule new futures after shutdown        # <-- this PR fixes this
```

## Verification (live, Teensy 4.0)

After this change + the matching fbuild fix (FastLED/fbuild#593), the OBJECT_FLED (FlexIO TX) autoresearch run no longer crashes on the recovery path. The raw-edge analyzer captures and decodes real WS2812 timing:

```
[RAW EDGE TIMING] Pattern Analysis:
  Short HIGH (~225ns, Bit 0): FOUND ✓
  Long HIGH  (~580ns, Bit 1): FOUND ✓
  Short LOW  (~645ns, Bit 1): FOUND ✓
  Long LOW   (~1000ns, Bit 0): FOUND ✓
[RAW EDGE TIMING] ✓ Encoder appears to be working correctly (varied timing patterns)
```

So the FlexIO driver itself is fine; this PR removes the layered-on crash that was masking the actual test progress.

## Why removing it is safe

- The `ThreadPoolExecutor` is created inside `__init__` and lives for the adapter's lifetime; nothing else stashes a reference to it.
- When the adapter is dropped (e.g. when its owning `RpcClient` is garbage-collected), the executor's destructor cleans up.
- The bug was specifically that calling `close()` was leaving the *adapter object* alive but its executor dead. Removing the shutdown call restores the invariant that close is logically idempotent and reusable.

## Test plan

- [x] Live: `bash autoresearch teensy40 --object-fled --upload-port COM20` no longer crashes on the post-flash USB re-enum recovery path
- [x] Live: FlexIO TX edge timing analyzer reports all four pulse widths in the WS2812 spec
- [ ] CI

Refs: FastLED/fbuild#592, FastLED/fbuild#593

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of serial communication recovery by ensuring necessary system resources remain available during recovery operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->