### PR TITLE
fix(autoresearch): drop misleading 'RMT RX' label on non-RMT platforms (#3059 partial)

### DIFF
--- a/examples/AutoResearch/AutoResearchTest.cpp
+++ b/examples/AutoResearch/AutoResearchTest.cpp
@@ -349,7 +349,12 @@ size_t capture(fl::shared_ptr<fl::RxChannel> rx_channel, fl::span<uint8_t> rx_bu
     if (is_rmt_driver) {
         FL_WARN("[CAPTURE] RMT TX -> RMT RX: Internal loopback enabled (io_loop_back=true)");
     } else {
-        FL_WARN("[CAPTURE] " << driver_name << " TX -> RMT RX: External GPIO wire (io_loop_back=false, use_dma=true)");
+        // The RX peripheral is platform-dependent (RMT on ESP32, FlexPWM on
+        // Teensy 4, LPC_SCT on LPC845, …). Don't claim "RMT RX" on platforms
+        // that have no RMT — that label burned an hour of Teensy-4 debug
+        // (FastLED#3059). Just say "external RX" so the label stays correct
+        // regardless of backend.
+        FL_WARN("[CAPTURE] " << driver_name << " TX -> external RX: External GPIO wire (io_loop_back=false, use_dma=true)");
     }
 
     // Driver-aware capture strategy:


### PR DESCRIPTION
## Summary

Stops the AutoResearch capture log from hardcoding "RMT RX" on platforms that have no RMT. This is the surgical part of #3059 — the decoder-tolerance / decoder-reject-reason asks need bench work and are documented in a follow-up investigation comment on the issue.

## What changed

```cpp
- FL_WARN("[CAPTURE] " << driver_name << " TX -> RMT RX: External GPIO wire ...");
+ FL_WARN("[CAPTURE] " << driver_name << " TX -> external RX: External GPIO wire ...");
```

Truthful on every backend: RMT on ESP32, FlexPWM on Teensy 4, LPC_SCT on LPC845, ISR / native elsewhere.

## Why not address tolerance + decoder reject reason in this PR

The hypothesis posted in #3059 was "the 170ns decoder tolerance was sized for RMT RX; FlexPWM + FlexIO jitter on Teensy 4 needs ~250-300ns." Investigating against the live edge dump from this session, that hypothesis didn't hold:

- The test config was *already* passing WS2812B-V5 timing (T1=225, T2=355, T3=645) to `capture()` — not legacy WS2812 — so the decoder's reference windows were aligned with the V5 spec, not RMT-era legacy.
- The captured edges show a bimodal HIGH pattern (`H=940` interleaved with `H=640`) and a bimodal LOW pattern (`L=286` interleaved with `L=586`). Neither matches V5 (225/580 H, 645/1000 L) nor legacy (250/875 H, 375/1000 L) — most edges sit *between* the expected bins, not inside either.
- That bimodal distribution looks like adjacent same-state edges being **merged** by the RX capture path (the FlexPWM RX backend on Teensy 4), not a tolerance / timing-baseline problem in the test layer.

If the FlexPWM RX is merging edges (or undersampling at high transition density), no amount of tolerance widening on the decoder side can recover the missing edges. The fix has to live in the FlexPWM RX backend, not in `AutoResearchTest.cpp`. That's a different repo of work and shouldn't get folded into this label fix.

So this PR ships only the change I can defend. The decoder asks remain open on #3059 with a detailed investigation comment.

## Test plan

- [x] Locally inspected the diff against the live failure log; no other code path uses the "RMT RX" string.
- [x] Builds for the AutoResearch sketch were green before (this run); no API surface changed.
- [ ] CI

Refs #3059


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Corrected misleading label in test capture output to accurately reflect external RX behavior instead of incorrectly labeling it as RMT RX.
  * Enhanced test comments to clarify that RX peripheral handling is platform-dependent and RMT availability varies across platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->