### PR TITLE
fix(rpc_client): restart wait after async ACK so Phase 3 RPCs aren't timed out by the pre-ACK budget (#3060)

### DIFF
--- a/ci/rpc_client.py
+++ b/ci/rpc_client.py
@@ -120,6 +120,14 @@ class RpcClient:
 
     RESPONSE_PREFIX = "REMOTE: "
 
+    # Post-ACK timeout floor for async (Phase 3) RPCs. After the device sends
+    # `{"acknowledged": true}` the client restarts its wait with at least this
+    # many seconds for the final response (or the caller-supplied timeout,
+    # whichever is larger). Picked generously so a 100-LED runSingleTest on a
+    # slow MCU has headroom; the typical run on Teensy 4 finishes in 80-90s.
+    # See FastLED#3060.
+    ASYNC_POST_ACK_TIMEOUT: float = 600.0
+
     def __init__(
         self,
         port: str,
@@ -639,11 +647,28 @@ class RpcClient:
                         and "acknowledged" in response_data
                         and response_data["acknowledged"] is True
                     ):
+                        # Async RPCs (Phase 3: runSingleTest, runParallelTest,
+                        # all testCoroutine*, the net/ble test runners) can run
+                        # for tens of seconds — the runSingleTest path through
+                        # 100 LEDs × 4 patterns takes ~80s on Teensy 4. Folding
+                        # both the ACK-wait and the result-wait into the single
+                        # caller-supplied `timeout` caused
+                        # `RpcTimeoutError('No response with ID N within 60s')`
+                        # for tests that genuinely needed 70-90s of post-ACK
+                        # time. Restart the wait with a budget large enough to
+                        # cover any reasonable test: the caller's own timeout
+                        # if they bumped it above the async floor, else
+                        # `ASYNC_POST_ACK_TIMEOUT` (10 min). See FastLED#3060.
+                        post_ack_timeout = max(timeout, self.ASYNC_POST_ACK_TIMEOUT)
                         if self.verbose:
                             print(
-                                f"[RPC] ACK received for request {expected_id}, waiting for final response..."
+                                f"[RPC] ACK received for request {expected_id}, "
+                                f"restarting wait for final response "
+                                f"(post-ACK timeout={post_ack_timeout}s)..."
                             )
-                        continue  # Skip ACK, wait for final response
+                        return await self._wait_for_response(
+                            post_ack_timeout, expected_id
+                        )
 
                     # Determine success: void functions return null, treat as success
                     success: bool  # Explicit type declaration


### PR DESCRIPTION
## Summary

`RpcClient.send()` already skipped `{"acknowledged": true}` ACKs from async (Phase 3) RPCs, but it kept reading inside the original caller-supplied timeout window. The runSingleTest path through 100 LEDs × 4 patterns on Teensy 4 takes 70-90 s of device-side work; the default 60 s budget fired before `sendAsyncResponse` landed, and surfaced as `RpcTimeoutError('No response with ID N within 60s')` even though the device was faithfully running the test.

After this PR, when the ACK arrives the client *returns into a fresh* `_wait_for_response` call with `max(caller_timeout, ASYNC_POST_ACK_TIMEOUT=600s)`. Synchronous calls are unchanged (they never see an ACK); async calls get a budget large enough for any reasonable HIL test.

## Why this didn't need a streaming-envelope rewrite

The investigation in #3060 hypothesised a missing `{"streamMode": true}` handler. Walking the firmware (`src/fl/remote/rpc/rpc.cpp.hpp:115-117`) and the existing client (`ci/rpc_client.py:636-646`), the actual envelope is `{"acknowledged": true}` and the client already skips it correctly. The bug was that the second wait (for the real result) still ran on the original ACK-budget clock, so any test taking longer than `timeout` post-ACK appeared identical to a hung device.

That made the fix narrower: keep the existing protocol handling, but restart the wait once the ACK proves the device is alive and running the test.

## Live validation

Tested on the Teensy 4 attached to this workstation (COM20, `OBJECT_FLED` driver):

```
$ uv run python -c "..."
[RPC] ACK received for request 1, restarting wait for final response (post-ACK timeout=600.0s)...
FINAL: 4
```

Pre-fix, the identical call with `timeout=10` raised `RpcTimeoutError`. Post-fix, the call returns the full test result (totalTests=4) without the caller having to manually bump the timeout.

## Test plan

- [x] Live: `runSingleTest` via `RpcClient(timeout=10)` against attached Teensy 4 returns the expected result (was timing out pre-fix).
- [x] Smoke: `RpcClient.ASYNC_POST_ACK_TIMEOUT` is reachable as a class constant; module imports cleanly.
- [x] Synchronous RPCs (`ping`, `status`, `drivers`) — unchanged code path, no behaviour change.
- [ ] CI

Closes #3060


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced asynchronous RPC call handling by improving acknowledgment processing. The system now properly extends response-waiting timeouts when receiving asynchronous acknowledgments, using a minimum 600-second buffer. This ensures final responses are reliably captured instead of timing out prematurely, particularly during long-running operations or extended network delays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->