### PR TITLE
diag(teensy4/flexio-rx): dump DMA + FLEXIO1 state on wait() timeout (refs #3066 phase 1)

### DIFF
--- a/src/platforms/arm/teensy/teensy4_common/rx_flexio_channel.cpp.hpp
+++ b/src/platforms/arm/teensy/teensy4_common/rx_flexio_channel.cpp.hpp
@@ -568,6 +568,28 @@ RxWaitResult FlexIoRxChannelImpl::wait(u32 timeout_ms) {
     const u32 start = millis();
     while (!mReceiveDone) {
         if ((millis() - start) >= timeout_ms) {
+            // FastLED#3066 Phase 1 sub-task 1 diagnostic: when the
+            // completion ISR never fires, dump the DMA channel state +
+            // FLEXIO1 shifter/timer status so the host can see why.
+            // Reading `mDma.complete()`, `mDma.error()`, and the live TCD
+            // CITER/BITER tells us whether the channel even started, how
+            // many transfers it processed, and whether it errored. The
+            // FLEXIO1 SHIFTSTAT/SHIFTERR/TIMSTAT reads tell us whether
+            // the shifter ever latched a captured value to trigger DMA.
+            const u32 citer = mDma.TCD->CITER & 0x7FFFu;
+            const u32 biter = mDma.TCD->BITER & 0x7FFFu;
+            const u32 transfers_done = (biter > citer) ? (biter - citer) : 0u;
+            FL_WARN("[FlexIO RX] wait() TIMEOUT after "
+                    << timeout_ms << "ms:"
+                    << " DMA complete=" << (mDma.complete() ? 1 : 0)
+                    << " error=" << (mDma.error() ? 1 : 0)
+                    << " CITER=" << citer << "/" << biter
+                    << " (transfers_done=" << transfers_done << ")");
+            FL_WARN("[FlexIO RX] post-timeout FLEXIO1:"
+                    << " SHIFTSTAT=0x" << fl::hex << FLEXIO1_SHIFTSTAT
+                    << " SHIFTERR=0x" << FLEXIO1_SHIFTERR
+                    << " TIMSTAT=0x" << FLEXIO1_TIMSTAT
+                    << " CTRL=0x" << FLEXIO1_CTRL << fl::dec);
             return RxWaitResult::TIMEOUT;
         }
     }


### PR DESCRIPTION
## Summary

First iteration of the `/loop` loop targeting issue #3066. Phase 1 sub-task 1: **confirm DMA channel is actually being triggered.**

Adds `FL_WARN` dumps inside `FlexIoRxChannelImpl::wait()` that fire when the completion ISR never arrives. The dumps surface:

- DMA channel state: `complete`, `error`, `CITER` vs `BITER` → live `transfers_done` count.
- FLEXIO1 module state: `SHIFTSTAT`, `SHIFTERR`, `TIMSTAT`, `CTRL`.

## Live findings (verified on Teensy 4.0, COM20)

`flexioObjectFledTest` `test_case=4` (100-LED OBJECT_FLED frame) → `wait()` times out → diagnostic fires:

```
DMA complete=0 error=0 CITER=6064/6064 (transfers_done=0)
SHIFTSTAT=0x0 SHIFTERR=0x0 TIMSTAT=0x0 CTRL=0x1
```

Decoded:

- DMA armed correctly (CITER == BITER == 6064 = the configured buffer size).
- DMA **never made a single transfer** (`transfers_done=0`) and didn't error.
- FLEXIO1 module is enabled (`CTRL=0x1` = FLEXEN=1).
- Shifter 0 **never latched** a value (`SHIFTSTAT=0`).
- Timer 0 **never reached its compare value** (`TIMSTAT=0`).

→ The DMA hardware trigger path (Shifter status flag → DMAMUX_SOURCE_FLEXIO1_REQUEST0) is dead because the shifter is never triggered, because the timer never compares.

## Root cause hypothesis (for Phase 1 sub-tasks 3 + 4)

`TIMOD=3` configures the timer as a 16-bit countdown counter loaded from `TIMCMP=0xFFFF` and decrementing every functional-clock tick (60 MHz post-#2772 fix). `TIMRST=6` reloads the counter on every trigger rising edge.

WS2812 bit period ≈ 1.25 µs ≈ 75 ticks at 60 MHz. Counter starts at 65535, decrements ~75 ticks before the next rising edge slams it back to 65535. **It never reaches 0**, so the timer compare event never fires, so the shifter never shifts, so DMA never triggers.

This is a fundamental misconfig of the FlexIO timer/shifter for the "capture inter-edge interval" use case. The right pattern likely:

1. Use a different `TIMOD` for capture (`TIMOD=2` "16-bit baud counter" with the shifter latching on a different event), OR
2. Use the **pin-edge → shifter status flag** path directly without the timer compare gating it, OR
3. Drive the timer via the shifter status flag and capture the timer value on each input edge with a different `TIMENA`/`TIMRST` combo.

The next loop iteration picks this up as Phase 1 sub-tasks 3–4.

## Test plan

- [x] Live: diagnostic dumps fire correctly and surface the actionable state on Teensy 4.0 timeout.
- [x] No behavior change for the success path (only adds logging on timeout).
- [ ] CI

## Loop housekeeping

After merge, the next iteration will:
- Update issue #3066's "Current state" with the new finding.
- Tick Phase 1 sub-task 1 ✓.
- Promote sub-tasks 3 + 4 to "active blocker" status.
- Add the loop-history breadcrumb.

Refs #3066

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timeout diagnostics for data capture operations, now reporting additional system state information to help troubleshoot communication issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->