### PR TITLE
fix(teensy4/flexio-rx): drive timer via PINSEL+TIMENA=4 path; DMA now fires on pin edges (refs #3066)

### DIFF
--- a/examples/AutoResearch/AutoResearchRemote.cpp
+++ b/examples/AutoResearch/AutoResearchRemote.cpp
@@ -1872,6 +1872,22 @@ void AutoResearchRemoteControl::registerFunctions(fl::shared_ptr<AutoResearchSta
             level = !level;
         }
 
+        // FastLED#3066 iter 6 diagnostic: dump FLEXIO1 live state
+        // immediately AFTER the toggles, before `wait()` runs. If the
+        // shifter/timer chain works end-to-end, SHIFTSTAT and TIMSTAT
+        // should now be non-zero, and FLEXIO1.PIN bit `flexio_pin`
+        // should track the last toggled state.
+        {
+            constexpr uintptr_t kFLEXIO1_BASE_DIAG = 0x401AC000u;
+            volatile uint32_t *pin   = (volatile uint32_t *)(kFLEXIO1_BASE_DIAG + 0x00C);
+            volatile uint32_t *shftstat = (volatile uint32_t *)(kFLEXIO1_BASE_DIAG + 0x010);
+            volatile uint32_t *timstat = (volatile uint32_t *)(kFLEXIO1_BASE_DIAG + 0x018);
+            FL_WARN("[ping diag] post-toggle FLEXIO1: PIN=0x"
+                    << fl::hex << *pin
+                    << " SHIFTSTAT=0x" << *shftstat
+                    << " TIMSTAT=0x" << *timstat << fl::dec);
+        }
+
         // 3. Wait briefly for FlexIO RX to flush any pending DMA. The DMA
         //    is configured for completion-on-buffer-full; a partial fill
         //    won't trigger the ISR, so `wait()` will TIMEOUT — which is

--- a/src/platforms/arm/teensy/teensy4_common/rx_flexio_channel.cpp.hpp
+++ b/src/platforms/arm/teensy/teensy4_common/rx_flexio_channel.cpp.hpp
@@ -428,30 +428,42 @@ static bool flexio1_configure(u8 flexio_pin) {
                          (0u << 7) |                 // PINPOL active high
                          ((u32)flexio_pin << 8) |    // PINSEL
                          (0u << 16) |                // PINCFG = input
-                         (1u << 23) |                // TIMPOL negative
+                         (0u << 23) |                // TIMPOL = positive
                          (0u << 24);                 // TIMSEL = timer 0
 
     FLEXIO1_SHIFTCFG[0] = 0;                          // no start/stop bits
 
     // -- Timer 0 (16-bit counter; restart on every input edge) --
-    const u32 trgsel = (u32)(2u * flexio_pin + 1u);
+    // FastLED#3066 iter 6: drive the timer from its own PINSEL field
+    // (not from TRGSEL). The TRGSEL=2*flexio_pin formula matches the RM
+    // ("Pin 2N input") but the trigger source on this iMXRT1062 build
+    // doesn't actually engage TIMENA — iter 6 verified that 8 hand-
+    // driven pin toggles produced zero TIMSTAT pulses even with
+    // TRGSEL=12 (= Pin 6 edge). The TIMER PINSEL path (TIMCTL bits
+    // [13:8]) bypasses TRGSEL entirely; TIMENA=4 then reads "Pin rising
+    // edge of PINSEL" directly.
     FLEXIO1_TIMCTL[0] = (3u << 0) |                   // TIMOD = 16-bit counter
                         (0u << 7) |                   // PINPOL active high
-                        (0u << 8) |                   // PINSEL unused
+                        ((u32)flexio_pin << 8) |      // PINSEL = input pin
                         (0u << 16) |                  // PINCFG = output disabled
                         (0u << 22) |                  // TRGSRC = external (pin)
                         (0u << 23) |                  // TRGPOL active high
-                        (trgsel << 24);               // TRGSEL = pin edge
+                        (0u << 24);                   // TRGSEL unused
 
-    FLEXIO1_TIMCFG[0] = (6u << 8) |                   // TIMENA = trigger rising
+    FLEXIO1_TIMCFG[0] = (4u << 8) |                   // TIMENA = pin rising
                         (2u << 12) |                  // TIMDIS = on compare
-                        (6u << 16) |                  // TIMRST = trigger rising
+                        (2u << 16) |                  // TIMRST = pin rising
                         (0u << 20) |                  // TIMDEC clk-rising
                         (0u << 24);                   // TIMOUT logic 0 on enable
 
-    // Run the counter for its full 16-bit range — we read the latched value
-    // on each edge to recover the inter-edge tick count.
-    FLEXIO1_TIMCMP[0] = 0xFFFFu;
+    // FastLED#3066 iter 6: TIMCMP=1 makes the timer reach compare
+    // immediately after each TIMENA=4 pin-rising-edge enable. The
+    // shifter then latches the pin state on each compare event
+    // (TIMPOL=0). This gives us a pin-edge sampler — not true
+    // inter-edge timing — but proves the chain CAN fire and DMA CAN
+    // transfer. Future iterations will refine TIMCMP / SHIFTBUF
+    // semantics for actual edge interval recovery.
+    FLEXIO1_TIMCMP[0] = 1u;
 
     // Clear status / error flags
     FLEXIO1_SHIFTSTAT = 0xFFu;


### PR DESCRIPTION
## Summary

Loop iter 6 of #3066. With IOMUX routing now proven open (PR #3069 gave us `FLEXIO1.PIN` bit 6 tracking pin 4's pull-up at `0x40`), the remaining bug was the timer's trigger source. The original `TIMENA=6` + `TIMRST=6` + `TRGSEL=2*flexio_pin+1` pattern never engaged on this iMXRT1062 build — verified across iters 2/3/5 by `TIMSTAT=0` across 8 hand-driven pin transitions.

This change drives the timer from its own PINSEL field instead of TRGSEL:

| Field | Was | Is |
|---|---|---|
| TIMCTL.PINSEL | 0 | `flexio_pin` (the input pin) |
| TIMCTL.TRGSEL | `2*flexio_pin+1` (= Shifter 3 status, wrong) | unused |
| TIMCFG.TIMENA | 6 (Trigger rising + Pin high) | **4 (Pin rising)** |
| TIMCFG.TIMRST | 6 (Trigger rising) | **2 (Pin rising)** |
| TIMCMP | `0xFFFF` (1.09 ms wrap, never reached between toggles) | **1 (immediate compare)** |
| SHIFTCTL.TIMPOL | 1 (negative — never fires) | **0 (positive)** |

## Live verification on Teensy 4.0 (COM20)

`flexioRxLoopbackPing` with 8 toggles 50 µs apart on pin 3 (jumpered to pin 4):

```
pre-fix:  TIMSTAT=0, transfers_done=0
post-fix: TIMSTAT=1, transfers_done=4   ← matches 4 rising edges in 8 toggles
```

DMA fires once per pin rising edge. The chain from pin → timer → shifter → DMA is finally alive end-to-end.

## What this does NOT fix yet

`mCaptureBuffer` is still all-zero — the shifter is latching a 1-bit value at the timer-compare moment but it reads as 0. That's the next iter's puzzle around SHIFTBUF semantics. Not enough to decode WS2812 frames yet, but the chain is alive and DMA actually moves data per pin transition. Major step forward.

## Test plan

- [x] Live: `flexioRxLoopbackPing` reports `transfers_done` matching the requested edge count (rising edges only).
- [ ] CI

Refs #3066

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved FlexIO edge capture triggering on Teensy 4.x by switching to pin-edge detection method for more reliable signal sampling.

* **Chores**
  * Added diagnostic logging for FlexIO register states during loopback testing to aid in debugging and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->