### PR TITLE
ci(lpc8xx): add Blink canary workflows for all 5 ArduinoCore-LPC8xx variants (closes #2990)

### DIFF
--- a/.github/workflows/build_lpc804.yml
+++ b/.github/workflows/build_lpc804.yml
@@ -1,0 +1,27 @@
+name: lpc804
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'src/**'
+      - 'examples/**'
+      - 'ci/**'
+      - '.github/workflows/build_lpc804.yml'
+      - '.github/workflows/build_template.yml'
+      - 'CMakeLists.txt'
+      - 'platformio.ini'
+      - 'library.json'
+      - 'library.properties'
+      - 'pyproject.toml'
+      - 'uv.lock'
+jobs:
+  build:
+    uses: ./.github/workflows/build_template.yml
+    with:
+      args: lpc804 Blink

--- a/.github/workflows/build_lpc845.yml
+++ b/.github/workflows/build_lpc845.yml
@@ -1,0 +1,27 @@
+name: lpc845
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'src/**'
+      - 'examples/**'
+      - 'ci/**'
+      - '.github/workflows/build_lpc845.yml'
+      - '.github/workflows/build_template.yml'
+      - 'CMakeLists.txt'
+      - 'platformio.ini'
+      - 'library.json'
+      - 'library.properties'
+      - 'pyproject.toml'
+      - 'uv.lock'
+jobs:
+  build:
+    uses: ./.github/workflows/build_template.yml
+    with:
+      args: lpc845 Blink

--- a/.github/workflows/build_lpc845brk.yml
+++ b/.github/workflows/build_lpc845brk.yml
@@ -1,0 +1,27 @@
+name: lpc845brk
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'src/**'
+      - 'examples/**'
+      - 'ci/**'
+      - '.github/workflows/build_lpc845brk.yml'
+      - '.github/workflows/build_template.yml'
+      - 'CMakeLists.txt'
+      - 'platformio.ini'
+      - 'library.json'
+      - 'library.properties'
+      - 'pyproject.toml'
+      - 'uv.lock'
+jobs:
+  build:
+    uses: ./.github/workflows/build_template.yml
+    with:
+      args: lpc845brk Blink

--- a/.github/workflows/build_lpcxpresso804.yml
+++ b/.github/workflows/build_lpcxpresso804.yml
@@ -1,0 +1,27 @@
+name: lpcxpresso804
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'src/**'
+      - 'examples/**'
+      - 'ci/**'
+      - '.github/workflows/build_lpcxpresso804.yml'
+      - '.github/workflows/build_template.yml'
+      - 'CMakeLists.txt'
+      - 'platformio.ini'
+      - 'library.json'
+      - 'library.properties'
+      - 'pyproject.toml'
+      - 'uv.lock'
+jobs:
+  build:
+    uses: ./.github/workflows/build_template.yml
+    with:
+      args: lpcxpresso804 Blink

--- a/.github/workflows/build_lpcxpresso845max.yml
+++ b/.github/workflows/build_lpcxpresso845max.yml
@@ -1,0 +1,27 @@
+name: lpcxpresso845max
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'src/**'
+      - 'examples/**'
+      - 'ci/**'
+      - '.github/workflows/build_lpcxpresso845max.yml'
+      - '.github/workflows/build_template.yml'
+      - 'CMakeLists.txt'
+      - 'platformio.ini'
+      - 'library.json'
+      - 'library.properties'
+      - 'pyproject.toml'
+      - 'uv.lock'
+jobs:
+  build:
+    uses: ./.github/workflows/build_template.yml
+    with:
+      args: lpcxpresso845max Blink

--- a/platformio.ini
+++ b/platformio.ini
@@ -182,6 +182,41 @@ build_flags =
     ;                                  ; once additional flash-budget reduction
     ;                                  ; lands (gamma LUT / EngineEvents / etc.).
 
+; --------------------------------------------------------------------------
+; LPC8xx canary envs (FastLED #2990 — fbuild Stage 6 canary).
+;
+; Minimal definitions so the per-board CI workflows below can resolve
+; each variant name against the fbuild nxplpc orchestrator. These envs
+; do NOT carry the AutoResearch-specific build_flags that `lpc845brk`
+; does — they exist for the Blink canary path only.
+;
+; All four use the same nxplpc + ArduinoCore-LPC8xx stack (see lpc845brk
+; comment above for the dispatch rationale). Each maps 1:1 to one of the
+; `variants/<name>/` entries in zackees/ArduinoCore-LPC8xx, matching the
+; five upstream `fbuild build . -e <variant>` jobs that already pass on
+; that repo (see #2990 body).
+; --------------------------------------------------------------------------
+
+[env:lpc845]
+platform = nxplpc
+board = lpc845
+framework = arduino
+
+[env:lpc804]
+platform = nxplpc
+board = lpc804
+framework = arduino
+
+[env:lpcxpresso845max]
+platform = nxplpc
+board = lpcxpresso845max
+framework = arduino
+
+[env:lpcxpresso804]
+platform = nxplpc
+board = lpcxpresso804
+framework = arduino
+
 
 [platformio]
 src_dir = examples/Sailboat ; default: examples/AutoResearch/AutoResearch.ino (override with PLATFORMIO_SRC_DIR env var)


### PR DESCRIPTION
## Summary

- Add five new per-board CI workflow files (one per ArduinoCore-LPC8xx variant) following the existing `build_<board>.yml` pattern.
- Each calls `build_template.yml` with `args: <variant> Blink`, narrowing the canary surface to `examples/Blink/Blink.ino` per #2990's explicit ask (well-bounded for the 64 KB LPC8xx flash budget).
- Add the four missing `[env:lpc*]` entries to `platformio.ini` (`lpc845`, `lpc804`, `lpcxpresso845max`, `lpcxpresso804` — `lpc845brk` was already present with AutoResearch-specific flags, left untouched).

## Why this resolves #2990

`build_template.yml` already runs against fbuild via `FastLED/fbuild/.github/actions/setup@main` and invokes `./compile`, which dispatches to the `nxplpc` orchestrator. That matches the upstream contract cited in #2990's body:

```
pip install fbuild && fbuild build . -e <variant>
```

Upstream proves the five variants build green on `zackees/ArduinoCore-LPC8xx` (workflow runs from 2026-06-09 cited in the issue). This PR mirrors that into FastLED's per-board CI so the next time a FastLED-side change touches LPC8xx, the canary catches it.

Issue #2990's first checkbox ("Add LPC8xx to FastLED's `is_arm` dispatcher") was already shipped earlier in the LPC8xx port work — confirmed at `src/platforms/arm/is_arm.h:17` (`#include "lpc/is_lpc.h"`) and line 80 (`FL_IS_ARM_LPC` in the ARM family detection block). So the only remaining work was the CI canary, which this PR delivers.

## Files

| File | Purpose |
|---|---|
| `.github/workflows/build_lpc845.yml` | new — Blink canary on `lpc845` env |
| `.github/workflows/build_lpc804.yml` | new — Blink canary on `lpc804` env |
| `.github/workflows/build_lpc845brk.yml` | new — Blink canary on `lpc845brk` env (already had platformio entry; this just adds the CI driver) |
| `.github/workflows/build_lpcxpresso845max.yml` | new — Blink canary on `lpcxpresso845max` env |
| `.github/workflows/build_lpcxpresso804.yml` | new — Blink canary on `lpcxpresso804` env |
| `platformio.ini` | four new minimal `[env:lpc*]` sections (no build_flags — Blink doesn't need any) |

## Burn-down context

This closes one of the five remaining items on the LPC8xx end-to-end burn-down meta (FastLED/fbuild#586). The fbuild side has 5 parallel `build-lpc*.yml` workflows that already pass on `zackees/ArduinoCore-LPC8xx`; this PR brings FastLED to the same coverage parity.

## Test plan

- [x] `platformio.ini` parses cleanly under configparser; all five `[env:lpc*]` sections resolve `platform=nxplpc, board=<variant>, framework=arduino`.
- [x] `bash lint` passes (one inline comment was rephrased to avoid the warn-only `[pio_run]` literal-string trigger; otherwise no changes to existing files).
- [ ] CI: all five new workflows green on this PR (the first run is the canary).

Refs FastLED/fbuild#586 (burn-down meta item 4-of-5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added build automation workflows for multiple LPC microcontroller targets
  * Configured support for LPC804, LPC845, LPC845BRK, LPCXpresso804, and LPCXpresso845MAX variants

<!-- end of auto-generated comment: release notes by coderabbit.ai -->