### PR TITLE
fix(avr/math): #undef Arduino F() macro before fl::math polynomial templates (unbreak master Uno build)

### DIFF
--- a/src/fl/math/math.cpp.hpp
+++ b/src/fl/math/math.cpp.hpp
@@ -26,6 +26,17 @@
 // IWYU pragma: end_keep  // okay banned header (STL wrapper implementation requires standard math.h)
 #endif
 
+// Arduino's WString.h (transitively included via the Arduino core on AVR and
+// other Arduino-framework targets) defines `F()` as a PROGMEM-string macro.
+// That macro collides with the `template <typename F>` parameter used by
+// the polynomial / Newton-iteration helpers in this file: every `F(value)`
+// constructor cast (e.g. `F(0.5)`) is rewritten to `WString::F(0.5)` and
+// fails to compile. Undefining the macro here is local to this translation
+// unit; the macro is only used in user sketches, never in fl::math itself.
+#ifdef F
+#undef F
+#endif
+
 namespace fl {
 
 // Standalone floor implementation for float


### PR DESCRIPTION
## Summary

Master's Uno (AVR) build has been red since `c0da8bd35d` (\"perf(fl/math): gate libm behind SKETCH_HAS_LARGE_MEMORY; polynomial impls on Low-memory\"). 5 consecutive master CI failures, none related to feature work. This PR unbreaks it.

## Root cause

Arduino's \`WString.h\` (transitively included via the Arduino core on AVR and other Arduino-framework targets) defines:

\`\`\`cpp
#define F(string_literal) (reinterpret_cast<const __FlashStringHelper *>(PSTR(string_literal)))
\`\`\`

That collides with the \`template <typename F>\` parameter used by 9 polynomial / Newton-iteration helpers in \`src/fl/math/math.cpp.hpp\` (sqrt_newton_, sin_poly_quarterturn_, cos_poly_quarterturn_, sin_reduce_, cos_reduce_, log_natural_, atan_poly_unit_, atan_full_, atan2_full_, ldexp_loop_). The preprocessor rewrites every \`F(value)\` constructor cast in those templates into \`WString::F(value)\`, which fails with:

\`\`\`
WString.h:38:74: error: initializer fails to determine size of '__c'
note: in expansion of macro 'F'
\`\`\`

## Fix

\`#undef F\` at the top of \`math.cpp.hpp\` after the includes that pull in WString.h. Local to this translation unit; \`fl::math\` itself never uses the macro; only end-user sketches do (where the macro stays defined).

No behavior change on any platform. Just unbreaks the AVR translation unit.

## Discovery context

Surfaced while CI-checking PRs #3084 and #3085 (against meta #3079 — LPC845 64 KB flash bloat hunt). Those PRs were green on every other platform but blocked by this pre-existing master breakage on AVR.

## Test plan

- [x] Code review of \`grep -n F\(\` in math.cpp.hpp — confirms all uses are template constructor casts (\`F(value)\`), none are intended PROGMEM strings.
- [ ] CI: full matrix, especially Uno (AVR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a macro naming conflict that was preventing successful compilation in certain build scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->