### PR TITLE
perf(fl::json): gate ieee754 float codec behind FL_PLATFORM_HAS_LARGE_MEMORY (-2.5 KB on LowMemory, closes #3082)

### DIFF
--- a/src/fl/stl/json.cpp.hpp
+++ b/src/fl/stl/json.cpp.hpp
@@ -1,6 +1,7 @@
 
 #include "fl/stl/json.h"
 #include "fl/stl/json/types.h"
+#include "fl/system/sketch_macros.h"  // FL_PLATFORM_HAS_LARGE_MEMORY -- gates ieee754_format_decimal
 #include "fl/stl/string.h"
 #include "fl/stl/vector.h"
 #include "fl/stl/deque.h"
@@ -213,6 +214,7 @@ private:
 
                 if (is_float) {
                     has_float = true;
+#if FL_PLATFORM_HAS_LARGE_MEMORY
                     // Bit-twiddling parse -- never reaches libgcc soft-FP. The
                     // resulting u32 carries the same IEEE 754 single-precision
                     // bit pattern strtof would produce (+/-1 ULP). The magnitude
@@ -221,6 +223,13 @@ private:
                     if (float_bits_magnitude_exceeds_2_24(f_bits)) {
                         has_float_beyond_precision = true;
                     }
+#else
+                    // Low-memory gate per FastLED #3082: assume float values
+                    // exceed 2^24 (forces slow path / generic array fallback).
+                    // Drops `ieee754_parse_decimal` (598 B) + `kPow10Mant` LUT
+                    // (824 B) + `kPow10BExp` (206 B) from the link.
+                    has_float_beyond_precision = true;
+#endif
                 } else {
                     has_int = true;
                     // Parse actual value to get accurate range
@@ -845,12 +854,19 @@ private:
 
             T val;
             if (is_float) {
+#if FL_PLATFORM_HAS_LARGE_MEMORY
                 // Bit-twiddling parse -> IEEE 754 bit pattern -> bit-cast to float.
                 // The `static_cast<T>` from `float` is the caller's responsibility
                 // (e.g. T=float costs nothing; T=int pulls one __aeabi_f2iz at the
                 // call site, which we accept per the "user opts in" mandate).
                 const u32 bits = fl::ieee754_parse_decimal(num_start, p - num_start);
                 val = static_cast<T>(fl::bit_cast<float>(bits));
+#else
+                // Low-memory gate per FastLED #3082: float JSON literals in
+                // packed-array parse path saturate to zero. The integer-only
+                // RPC contract on LPC8xx / AVR never emits floats here.
+                val = static_cast<T>(0);
+#endif
             } else {
                 val = static_cast<T>(fl::parseInt(num_start, p - num_start));
             }
@@ -1001,12 +1017,19 @@ public:
 
                 fl::shared_ptr<json_value> num_val;
                 if (is_float) {
+#if FL_PLATFORM_HAS_LARGE_MEMORY
                     // Bit-twiddling parse -> IEEE 754 bits -> store as float in the
                     // variant. The `bit_cast<float>` is a `memcpy` -- no libgcc
                     // soft-FP helper is reached on the parser hot path
                     // (FastLED #3022 phase 2).
                     const u32 bits = fl::ieee754_parse_decimal(value.data(), value.size());
                     num_val = fl::make_shared<json_value>(fl::bit_cast<float>(bits));
+#else
+                    // Low-memory gate per FastLED #3082: float JSON literals
+                    // parse to 0.0f, no `ieee754_parse_decimal` / kPow10Mant
+                    // anchored. Integer-only RPC contract on LPC8xx / AVR.
+                    num_val = fl::make_shared<json_value>(0.0f);
+#endif
                 } else {
                     int i = fl::parseInt(value.data(), value.size());
                     i64 i64_val = static_cast<i64>(i);
@@ -1146,9 +1169,20 @@ struct SerializerVisitor {
     }
 
     void accept(const float& f) {
+#if FL_PLATFORM_HAS_LARGE_MEMORY
         // Integer-only bits -> decimal (FastLED #3022 phase 2). Default 3-digit
         // precision matches the previous `num_str.append(f, 3)` contract.
         append_str(fl::ieee754_format_decimal(fl::bit_cast<u32>(f), 3));
+#else
+        // Low-memory targets gate the float decimal codec to drop
+        // `ieee754_format_decimal` (594 B) + `kPow10Mant` LUT (824 B) from the
+        // link. The integer-only RPC contract on LPC8xx / AVR-class targets
+        // never serializes float values; this writes a stub for the rare cases
+        // where a `json(float)` round-trip happens to be exercised in test
+        // code that also runs on Low-memory. See FastLED #3082.
+        (void)f;
+        append_str(fl::string("0"));
+#endif
     }
 
     void accept(const fl::string& s) { append_escaped(s); }
@@ -1217,9 +1251,15 @@ struct SerializerVisitor {
         for (const auto& item : floats) {
             if (!first) out.push_back(',');
             first = false;
+#if FL_PLATFORM_HAS_LARGE_MEMORY
             // Integer-only bits -> decimal per element (FastLED #3022 phase 2).
             // 6-digit precision preserves the previous output contract.
             append_str(fl::ieee754_format_decimal(fl::bit_cast<u32>(item), 6));
+#else
+            // Low-memory gate per FastLED #3082; see scalar `accept(float)`.
+            (void)item;
+            append_str(fl::string("0"));
+#endif
         }
         out.push_back(']');
     }


### PR DESCRIPTION
## Summary

Saves ~2.5 KB of `.text` + rodata on LPC845-BRK by gating the IEEE 754 float decimal codec behind `FL_PLATFORM_HAS_LARGE_MEMORY`. Closes #3082.

The integer-only RPC contract on LPC8xx / AVR-class Low-memory targets never emits or consumes JSON float values, but the parser was still reachable from JsonTokenizer + JsonBuilder NUMBER token handlers, anchoring 4 large symbols.

## Numbers (LPC845-BRK, `arm-none-eabi-nm --print-size`)

| Symbol | Before | After |
|---|---:|---:|
| `fl::ieee754_format_decimal` | 594 B | **removed** |
| `fl::ieee754_parse_decimal` | 598 B | **removed** |
| `fl::(anon).kPow10Mant` LUT | 824 B | **removed** |
| `fl::(anon).kPow10BExp` LUT | 206 B | **removed** |
| Total `.text` (`-DFASTLED_LPC_RX_SCT_WS2812=1`) | 77,004 B | 74,476 B |
| Overage against 64 KB FLASH | +11,112 B | **+8,584 B** |

## What changed

5 call sites in `src/fl/stl/json.cpp.hpp` gated behind `#if FL_PLATFORM_HAS_LARGE_MEMORY`:

1. `JsonTokenizer::scan_array_lookahead` float branch — assume `has_float_beyond_precision` (forces slow path fallback)
2. `parse_array_directly<T>` float branch — value saturates to 0
3. `JsonBuilder::on_token` NUMBER float branch — stores 0.0f
4. `SerializerVisitor::accept(const float&)` — emits "0"
5. `SerializerVisitor::accept(const vector<float>&)` per-element — emits "0"

## Test plan

- [x] Host JSON unit tests: `bash test --cpp fl/stl/json.cpp` → passed (host build is LargeMemory; full codec active)
- [x] LPC845-BRK build: `PLATFORMIO_SRC_DIR=examples/AutoResearch fbuild build -e lpc845brk` with `-DFASTLED_LPC_RX_SCT_WS2812=1` → built; flash dropped 2.5 KB
- [x] `nm --print-size` verification: zero references to `ieee754_format_decimal` / `ieee754_parse_decimal` / `kPow10Mant` / `kPow10BExp` on LPC845 build
- [ ] CI: full matrix (note: master Uno build is red pre-existing; PR #3086 fixes that)

## Behavior change on Low-memory targets

JSON float literals in the input stream (`{"x": 3.14}`) parse as `0.0f` and serialize back as `"0"`. The integer-only RPC contract on LPC8xx / AVR / similar parts never emits or consumes floats, so this is unobservable in practice. Sketches that need float JSON values on Low-memory targets should set `-DFL_PLATFORM_HAS_LARGE_MEMORY=1` to opt in to the full codec.

## Cumulative meta #3079 progress

| PR | Saved | Overage after |
|---|---:|---:|
| baseline | — | +11,112 B |
| #3084 (#3077: fl::function variant) | −3,904 B | +7,208 B |
| #3085 (#3076: soft-FP cascade) | −4,016 B | +3,192 B |
| **#3083 (this PR, #3082: ieee754 gate)** | **−2,528 B** | **+664 B** |
| _remaining_ | (need −0.7 KB) | _almost there_ |

Combined effect not yet measured. Once all three land, a final small PR (or accumulated savings from interaction effects) should close the overage.

## Related

- Meta #3079 — LPC845 64 KB flash bloat hunt
- #3084, #3085 — sibling sub-issue PRs
- #3086 — pre-existing master Uno build unblocker
- FastLED/fbuild#594 — tooling gap (verified using the LD-script-patching workaround)
- #3022 / #3038 — original integer-only IEEE 754 codec work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved JSON floating-point handling for constrained platforms by reducing memory usage during number parsing and formatting.
  * Floating-point values (including float arrays/vectors) now use a simplified, compatibility-focused serialization strategy when resources are limited, instead of the full precision conversion path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->