### PR TITLE
perf(rpc/lpc): gate schema generator + enable RX_SCT_WS2812 default on lpc845brk (closes #3079)

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -177,6 +177,7 @@ build_flags =
     -DRELEASE
     -DFASTLED_LPC_PWM_DMA=1
     -DFASTLED_AUTORESEARCH_LOW_MEMORY=1
+    -DFASTLED_LPC_RX_SCT_WS2812=1
     ; -DFASTLED_LPC_RX_SCT_WS2812=1   ; pulls <FastLED.h>, +20 KB, exceeds 64 KB
     ;                                  ; flash budget on LPC845-BRK. Re-enable
     ;                                  ; once additional flash-budget reduction

--- a/src/fl/remote/rpc/rpc.cpp.hpp
+++ b/src/fl/remote/rpc/rpc.cpp.hpp
@@ -40,8 +40,11 @@ void Rpc::bindAsync(const char* name,
     entry.mIsResponseAware = true;
     entry.mResponseAwareFn = fl::move(fn);
 
-    // Create schema generator for void(json) signature (params not decomposed)
+#if FL_PLATFORM_HAS_LARGE_MEMORY
+    // Create schema generator for void(json) signature (params not decomposed).
+    // Gated on Low-memory per FastLED #3081 / #3079 (rpc.discover unreachable).
     entry.mSchemaGenerator = fl::make_shared<detail::TypedSchemaGenerator<void(const json&)>>();
+#endif
     entry.mDescription = "";
     entry.mTags = {};
 

--- a/src/fl/remote/rpc/rpc.h
+++ b/src/fl/remote/rpc/rpc.h
@@ -360,14 +360,24 @@ public:
         entry.mTypeTag = detail::TypeTag<Sig>::id();
         entry.mInvoker = fl::make_shared<detail::TypedInvoker<Sig>>(fn);
         entry.mTypedCallable = fl::make_shared<detail::TypedCallableHolder<Sig>>(fn);
+#if FL_PLATFORM_HAS_LARGE_MEMORY
+        // Schema generator construction gated on Low-memory targets per
+        // FastLED #3081 / #3079. The schema generator is only consumed by
+        // `rpc.discover` (also gated). Skipping it on Low-memory drops
+        // `TypedSchemaGenerator<Sig>::params()` (~800 B per signature).
         entry.mSchemaGenerator = fl::make_shared<detail::TypedSchemaGenerator<Sig>>();
+#endif
         entry.mDescription = description;
         entry.mTags = tags;
         entry.mMode = mode;
 
+#if FL_PLATFORM_HAS_LARGE_MEMORY
         if (!paramNames.empty()) {
             entry.mSchemaGenerator->setParamNames(paramNames);
         }
+#else
+        (void)paramNames;
+#endif
 
         mRegistry[key] = fl::move(entry);
         return true;


### PR DESCRIPTION
## Summary

Final piece of meta #3079 (LPC845 64 KB flash bloat hunt). Closes the meta with:

1. Gate \`mSchemaGenerator\` construction on Low-memory targets (drops per-signature 800+ B \`TypedSchemaGenerator<Sig>::params()\` instantiations that PR #3088 didn't reach because they're constructed at registration time, not at \`rpc.discover\` time).
2. Default-enable \`-DFASTLED_LPC_RX_SCT_WS2812=1\` in \`[env:lpc845brk]\` — the WS2812 SCT-RX loopback RPC binding now ships on by default. The original blocker: \"Re-enable \`-DFASTLED_LPC_RX_SCT_WS2812=1\` once additional flash-budget reduction lands\".

## Final flash budget on LPC845-BRK

\`\`\`
PLATFORMIO_SRC_DIR=examples/AutoResearch fbuild build -e lpc845brk

  Flash: 62.61KB / 64.00KB (97.8%)
  RAM:   10.50KB / 16.00KB (65.6%)
  build succeeded
\`\`\`

**1,420 B headroom under the 64 KB ceiling** with \`FASTLED_LPC_RX_SCT_WS2812=1\` ON.

## Meta #3079 progress arc

| PR | Closes | Saved | Cumulative |
|---|---|---:|---:|
| Baseline | — | — | 77,004 B (+11,112) |
| #3084 | #3077 (fl::function variant) | -3,904 | -3,904 |
| #3085 | #3076 (soft-FP cascade) | -4,016 | -7,920 |
| #3086 | unblocker (AVR \`F()\` macro) | 0 | -7,920 |
| #3087 | #3082 (ieee754 codec gate) | -2,528 | various interaction |
| #3088 | #3081 (rpc.discover gate) | various | -11,256 net |
| **this PR** | **#3079 (final + default-on)** | **-1,632** | **-12,888 net** |

## Acceptance verification

Meta #3079 acceptance criteria:
- [x] \`examples/AutoResearch/AutoResearch.ino\` with \`FASTLED_AUTORESEARCH_LOW_MEMORY=1\` + \`FASTLED_LPC_PWM_DMA=1\` + \`FASTLED_LPC_RX_SCT_WS2812=1\` links cleanly under 64 KB
- [x] \`platformio.ini [env:lpc845brk]\` enables \`-DFASTLED_LPC_RX_SCT_WS2812=1\` by default
- [x] All four sub-issues (#3076, #3077, #3081, #3082) closed via merged PRs (#3085, #3084, #3088, #3087)
- [ ] \`bash autoresearch lpc845brk --ws2812-loopback\` — requires hardware verification on next AutoResearch session

## Related

- Meta #3079 — LPC845 64 KB flash bloat hunt
- FastLED/fbuild#594 — tooling gap (the manual nm + LD-script-patching workaround used throughout this meta)
- #3084, #3085, #3086, #3087, #3088 — sibling sub-issue PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Optimization**
  * Reduced memory consumption on resource-constrained devices by conditionally compiling remote procedure call features based on available platform memory.

* **Improvements**
  * Enabled FastLED WS2812 LED driver hardware acceleration support for the LPC845 breakout board.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->