### PR TITLE
fix(video): add FL_NOEXCEPT to embeddedScreenMap accessors (12 NoexceptAstChecker violations)

### DIFF
--- a/src/fl/fx/video.cpp.hpp
+++ b/src/fl/fx/video.cpp.hpp
@@ -121,12 +121,12 @@ size_t Video::pixelsPerFrame() const {
     return mImpl->pixelsPerFrame();
 }
 
-bool Video::hasEmbeddedScreenMap() const {
+bool Video::hasEmbeddedScreenMap() const FL_NOEXCEPT {
     if (!mImpl) return false;
     return mImpl->hasEmbeddedScreenMap();
 }
 
-const fl::string &Video::embeddedScreenMapJson() const {
+const fl::string &Video::embeddedScreenMapJson() const FL_NOEXCEPT {
     static const fl::string kEmpty;
     if (!mImpl) return kEmpty;
     return mImpl->embeddedScreenMapJson();

--- a/src/fl/fx/video.h
+++ b/src/fl/fx/video.h
@@ -75,8 +75,8 @@ class Video : public Fx1d { // Fx1d because video can be irregular.
     // opened a FLED-formatted file (12-byte "FLED" magic header). Legacy
     // headerless `.rgb` files return false / empty string.
     // Spec: https://github.com/zackees/ledmapper/blob/main/docs/fled-format.md
-    bool hasEmbeddedScreenMap() const;
-    const fl::string &embeddedScreenMapJson() const;
+    bool hasEmbeddedScreenMap() const FL_NOEXCEPT;
+    const fl::string &embeddedScreenMapJson() const FL_NOEXCEPT;
     void pause(fl::u32 now) override;
     void resume(fl::u32 now) override;
     void setFade(fl::u32 fadeInTime, fl::u32 fadeOutTime);

--- a/src/fl/video/pixel_stream.cpp.hpp
+++ b/src/fl/video/pixel_stream.cpp.hpp
@@ -209,11 +209,11 @@ PixelStream::Type PixelStream::getType() const {
     return mType;
 }
 
-bool PixelStream::hasEmbeddedScreenMap() const {
+bool PixelStream::hasEmbeddedScreenMap() const FL_NOEXCEPT {
     return !mEmbeddedScreenMapJson.empty();
 }
 
-const fl::string &PixelStream::embeddedScreenMapJson() const {
+const fl::string &PixelStream::embeddedScreenMapJson() const FL_NOEXCEPT {
     return mEmbeddedScreenMapJson;
 }
 

--- a/src/fl/video/pixel_stream.h
+++ b/src/fl/video/pixel_stream.h
@@ -57,8 +57,8 @@ class PixelStream {
 
     // FLED v1 container accessors. True/non-empty only when begin() found
     // a valid FLED header on a seekable handle; otherwise empty / false.
-    bool hasEmbeddedScreenMap() const;
-    const fl::string &embeddedScreenMapJson() const;
+    bool hasEmbeddedScreenMap() const FL_NOEXCEPT;
+    const fl::string &embeddedScreenMapJson() const FL_NOEXCEPT;
 
   private:
     fl::i32 mbytesPerFrame;

--- a/src/fl/video/video_impl.cpp.hpp
+++ b/src/fl/video/video_impl.cpp.hpp
@@ -355,12 +355,12 @@ bool VideoImpl::rewind() {
     return true;
 }
 
-bool VideoImpl::hasEmbeddedScreenMap() const {
+bool VideoImpl::hasEmbeddedScreenMap() const FL_NOEXCEPT {
     if (!mStream) return false;
     return mStream->hasEmbeddedScreenMap();
 }
 
-const fl::string &VideoImpl::embeddedScreenMapJson() const {
+const fl::string &VideoImpl::embeddedScreenMapJson() const FL_NOEXCEPT {
     static const fl::string kEmpty;
     if (!mStream) return kEmpty;
     return mStream->embeddedScreenMapJson();

--- a/src/fl/video/video_impl.h
+++ b/src/fl/video/video_impl.h
@@ -56,8 +56,8 @@ class VideoImpl {
 
     // FLED v1 container accessors. Forwards to the underlying PixelStream;
     // empty / false for legacy headerless `.rgb` files.
-    bool hasEmbeddedScreenMap() const;
-    const fl::string &embeddedScreenMapJson() const;
+    bool hasEmbeddedScreenMap() const FL_NOEXCEPT;
+    const fl::string &embeddedScreenMapJson() const FL_NOEXCEPT;
 
   private:
     bool updateBufferIfNecessary(fl::u32 prev, fl::u32 now);


### PR DESCRIPTION
## Summary

Quietens 12 NoexceptAstChecker violations from #3074 (FLED v1 container support), surfaced by the stop-hook lint check.

## Files touched

- \`src/fl/fx/video.{h,cpp.hpp}\` — \`Video::hasEmbeddedScreenMap()\` / \`embeddedScreenMapJson()\`
- \`src/fl/video/pixel_stream.{h,cpp.hpp}\` — \`PixelStream::hasEmbeddedScreenMap()\` / \`embeddedScreenMapJson()\`
- \`src/fl/video/video_impl.{h,cpp.hpp}\` — \`VideoImpl::hasEmbeddedScreenMap()\` / \`embeddedScreenMapJson()\`

All six accessors are simple forwarders / member-field returns; \`FL_NOEXCEPT\` is the correct annotation. No behavior change.

## Test plan

- [x] \`bash lint --cpp\` passes (NoexceptAstChecker clean)
- [ ] CI: full matrix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated method signatures to explicitly declare non-throwing exception guarantees for video operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->