### PR TITLE
ci(lpc8xx): extend canary to Blink + DemoReel100 + FxEngine (closes fbuild#550)

### DIFF
--- a/.github/workflows/build_lpc804.yml
+++ b/.github/workflows/build_lpc804.yml
@@ -24,4 +24,4 @@ jobs:
   build:
     uses: ./.github/workflows/build_template.yml
     with:
-      args: lpc804 Blink
+      args: lpc804 Blink DemoReel100 FxEngine

--- a/.github/workflows/build_lpc804.yml
+++ b/.github/workflows/build_lpc804.yml
@@ -24,4 +24,4 @@ jobs:
   build:
     uses: ./.github/workflows/build_template.yml
     with:
-      args: lpc804 Blink DemoReel100 FxEngine
+      args: lpc804 Blink DemoReel100 Fx/FxEngine

--- a/.github/workflows/build_lpc845.yml
+++ b/.github/workflows/build_lpc845.yml
@@ -24,4 +24,4 @@ jobs:
   build:
     uses: ./.github/workflows/build_template.yml
     with:
-      args: lpc845 Blink
+      args: lpc845 Blink DemoReel100 FxEngine

--- a/.github/workflows/build_lpc845.yml
+++ b/.github/workflows/build_lpc845.yml
@@ -24,4 +24,4 @@ jobs:
   build:
     uses: ./.github/workflows/build_template.yml
     with:
-      args: lpc845 Blink DemoReel100 FxEngine
+      args: lpc845 Blink DemoReel100 Fx/FxEngine

--- a/.github/workflows/build_lpc845brk.yml
+++ b/.github/workflows/build_lpc845brk.yml
@@ -24,4 +24,4 @@ jobs:
   build:
     uses: ./.github/workflows/build_template.yml
     with:
-      args: lpc845brk Blink DemoReel100 FxEngine
+      args: lpc845brk Blink DemoReel100 Fx/FxEngine

--- a/.github/workflows/build_lpc845brk.yml
+++ b/.github/workflows/build_lpc845brk.yml
@@ -24,4 +24,4 @@ jobs:
   build:
     uses: ./.github/workflows/build_template.yml
     with:
-      args: lpc845brk Blink
+      args: lpc845brk Blink DemoReel100 FxEngine

--- a/.github/workflows/build_lpcxpresso804.yml
+++ b/.github/workflows/build_lpcxpresso804.yml
@@ -24,4 +24,4 @@ jobs:
   build:
     uses: ./.github/workflows/build_template.yml
     with:
-      args: lpcxpresso804 Blink DemoReel100 FxEngine
+      args: lpcxpresso804 Blink DemoReel100 Fx/FxEngine

--- a/.github/workflows/build_lpcxpresso804.yml
+++ b/.github/workflows/build_lpcxpresso804.yml
@@ -24,4 +24,4 @@ jobs:
   build:
     uses: ./.github/workflows/build_template.yml
     with:
-      args: lpcxpresso804 Blink
+      args: lpcxpresso804 Blink DemoReel100 FxEngine

--- a/.github/workflows/build_lpcxpresso845max.yml
+++ b/.github/workflows/build_lpcxpresso845max.yml
@@ -24,4 +24,4 @@ jobs:
   build:
     uses: ./.github/workflows/build_template.yml
     with:
-      args: lpcxpresso845max Blink DemoReel100 FxEngine
+      args: lpcxpresso845max Blink DemoReel100 Fx/FxEngine

--- a/.github/workflows/build_lpcxpresso845max.yml
+++ b/.github/workflows/build_lpcxpresso845max.yml
@@ -24,4 +24,4 @@ jobs:
   build:
     uses: ./.github/workflows/build_template.yml
     with:
-      args: lpcxpresso845max Blink
+      args: lpcxpresso845max Blink DemoReel100 FxEngine


### PR DESCRIPTION
## Summary

- Extend the 5 LPC8xx canary workflows (added in #3080) from `<variant> Blink` to `<variant> Blink DemoReel100 FxEngine`.
- One-line change per file × 5 files.

## Why

fbuild#550's acceptance criterion is *"`fbuild build` of Blink / DemoReel100 / FxEngine links clean for lpc845 + lpc804."* PR #3080 wired the canary against `Blink` only as a first-light. With LPC8xx brought up end-to-end on real silicon, this extends the canary surface to the full three-example set the issue asks for.

## Why FastLED-side rather than fbuild-side fixtures

`fbuild`'s existing `tests/platform/<board>/<board>.ino` fixtures are Arduino-HAL-only (pinMode/digitalWrite/delay; no `<FastLED.h>` include). Bringing FastLED in as a fbuild test-time dependency would have required new fixture infrastructure (libs/FastLED vendoring, per-example sub-fixtures). FastLED's own per-board CI already runs `./compile <variant> <example>` through the fbuild `nxplpc` orchestrator — that's the validation surface fbuild#550 actually cares about.

This matches the option-A recommendation in the [investigation report posted on fbuild#550](https://github.com/FastLED/fbuild/issues/550#issuecomment-4710612756).

## Closes

- Closes FastLED/fbuild#550
- Refs FastLED/fbuild#586 (LPC845-BRK end-to-end burn-down meta)

## Risk + signal

If `DemoReel100` or `FxEngine` overflows the 64 KB LPC8xx flash budget, the canary will surface a clean linker-overflow with a specific size delta. That's a falsifiable signal for the next bloat-hunt round to act on (see FastLED#3079 for the broader flash bloat tracking).

## Test plan

- [x] No code changes — only the `args:` string in each workflow's `build_template.yml` call.
- [x] `bash lint` passes (no Python / C++ / JS touched).
- [ ] CI: the 5 new LPC workflows only fire on push-to-master per the existing convention, so PR CI will not exercise them — they'll be visible on master's run immediately after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Chores

* Updated continuous integration build workflows for LPC804, LPC845, LPC845BRK, LPCXpresso804, and LPCXpresso845max to extend the delegated build arguments, adding additional DemoReel100 and Fx/FxEngine targets alongside Blink to improve build coverage and compatibility checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->