### PR TITLE
perf(wave): fold half-duplex zero-clamp into main update loop (closes #3093)

### DIFF
--- a/src/fl/math/wave/wave_simulation_real.cpp.hpp
+++ b/src/fl/math/wave/wave_simulation_real.cpp.hpp
@@ -117,6 +117,12 @@ void WaveSimulation1D_Real::update() {
     curr[length + 1] = curr[length];
 
     i32 mCourantSq32 = static_cast<i32>(mCourantSq);
+    // Hoist the lower-saturation bound: in half-duplex mode the new value
+    // must be >= 0 (negative parts of the wave are clipped); in full-duplex
+    // mode the full Q15 negative range is allowed. Folding this into the
+    // per-cell clamp via fl::clamp lets us drop the dedicated second pass
+    // that used to walk the whole grid after the update loop.
+    const i32 q15_min = mHalfDuplex ? 0 : -32768;
     // Iterate over each inner cell.
     for (fl::size i = 1; i < length + 1; i++) {
         // Compute the 1D Laplacian:
@@ -145,22 +151,10 @@ void WaveSimulation1D_Real::update() {
         // visual amplitudes.
         f -= (f >> mDampenening);
 
-        // Clamp the result to the Q15 range [-32768, 32767].
-        if (f > 32767)
-            f = 32767;
-        else if (f < -32768)
-            f = -32768;
-
-        next[i] = (i16)f;
-    }
-
-    if (mHalfDuplex) {
-        // Set the negative values to zero.
-        for (fl::size i = 1; i < length + 1; i++) {
-            if (next[i] < 0) {
-                next[i] = 0;
-            }
-        }
+        // Clamp f into [q15_min, 32767] in a single step. q15_min is 0 when
+        // half-duplex is on, -32768 otherwise. This subsumes both the Q15
+        // saturation clamp and the post-pass that used to zero negatives.
+        next[i] = static_cast<i16>(fl::clamp(f, q15_min, static_cast<i32>(32767)));
     }
 
     // Toggle the active grid.
@@ -260,6 +254,11 @@ void WaveSimulation2D_Real::update() {
     }
 
     i32 mCourantSq32 = static_cast<i32>(mCourantSq);
+    // Hoist the lower-saturation bound — see WaveSimulation1D_Real::update()
+    // for the rationale. Fold half-duplex into the per-cell clamp instead
+    // of running a second pass over the grid (especially expensive on
+    // PSRAM-backed grids).
+    const i32 q15_min = mHalfDuplex ? 0 : -32768;
 
     // Update each inner cell.
     for (fl::size j = 1; j <= height; ++j) {
@@ -288,25 +287,9 @@ void WaveSimulation2D_Real::update() {
             // update for the cycle-cost rationale.
             f -= (f >> mDampening);
 
-            // Clamp f to the Q15 range.
-            if (f > 32767)
-                f = 32767;
-            else if (f < -32768)
-                f = -32768;
-
-            next[index] = (i16)f;
-        }
-    }
-
-    if (mHalfDuplex) {
-        // Set negative values to zero.
-        for (fl::size j = 1; j <= height; ++j) {
-            for (fl::size i = 1; i <= width; ++i) {
-                int index = j * stride + i;
-                if (next[index] < 0) {
-                    next[index] = 0;
-                }
-            }
+            // Clamp f into [q15_min, 32767] in a single step — subsumes
+            // both the Q15 saturation clamp and the half-duplex zero pass.
+            next[index] = static_cast<i16>(fl::clamp(f, q15_min, static_cast<i32>(32767)));
         }
     }
 


### PR DESCRIPTION
Implements #3093 (§3 from meta tracker #3098).

## Change

`WaveSimulation{1D,2D}_Real::update()` previously ran a separate `if (mHalfDuplex)` second pass over the entire grid after the main update loop, walking every cell to clamp negative values to zero.

This PR hoists the half-duplex lower bound into a single `const i32 q15_min = mHalfDuplex ? 0 : -32768;` before the update loop and folds it into a single `fl::clamp(f, q15_min, 32767)` per cell. The dedicated post-update pass is removed.

## Side effect

The existing branchy `if (f > 32767) ... else if (f < -32768) ...` Q15 saturation clamp is replaced with `fl::clamp`, which most compilers lower branchlessly on Cortex-M4+. This overlaps with §4 (#3094)'s broader "branchless clamp" goal, but #3094 also hoists `j * stride` and adds `__restrict__` — this PR is just the half-duplex fold-in.

## Why

On PSRAM-backed 2D grids (`vector_psram<i16>`) the second pass doubled memory traffic for no benefit. The single-pass version is equivalent and cheaper.

## Validation

- `bash test fl_math_wave_wave_simulation_real --cpp` — 5/5 cases pass, including the saturation tests that exercise the half-duplex floor.
- `bash lint --cpp` — clean.

Closes #3093
Refs #3098 (parent meta), #3099 (sibling §2 merged)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance Improvements**
  * Optimized wave simulation update process to reduce computational overhead by consolidating clamp operations into a single pass per update step, resulting in faster simulation performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->