### PR TITLE
perf(wave): hoist row arithmetic + FL_RESTRICT_PARAM in 2D update inner loop (closes #3094)

### DIFF
--- a/src/fl/math/wave/wave_simulation_real.cpp.hpp
+++ b/src/fl/math/wave/wave_simulation_real.cpp.hpp
@@ -260,27 +260,33 @@ void WaveSimulation2D_Real::update() {
     // PSRAM-backed grids).
     const i32 q15_min = mHalfDuplex ? 0 : -32768;
 
-    // Update each inner cell.
+    // Update each inner cell. Per-row hoist: lift j*stride out of the inner
+    // loop, set up row pointers to curr/next/above/below, and mark them
+    // FL_RESTRICT_PARAM so the optimizer knows curr and next don't alias.
+    // This gives the compiler a clean dependency picture across iterations
+    // (it can vectorize / interleave loads without re-deriving the address).
     for (fl::size j = 1; j <= height; ++j) {
+        const fl::size row = j * stride;
+        const i16* FL_RESTRICT_PARAM row_curr  = curr + row;
+        const i16* FL_RESTRICT_PARAM row_above = curr + (row - stride);
+        const i16* FL_RESTRICT_PARAM row_below = curr + (row + stride);
+        i16*       FL_RESTRICT_PARAM row_next  = next + row;
         for (fl::size i = 1; i <= width; ++i) {
-            int index = j * stride + i;
+            const i32 c = row_curr[i];
             // Laplacian: sum of four neighbors minus 4 times the center.
-            i32 laplacian = (i32)curr[index + 1] + curr[index - 1] +
-                                curr[index + stride] + curr[index - stride] -
-                                ((i32)curr[index] << 2);
-            // Compute the new value:
-            // f = - next[index] + 2 * curr[index] + mCourantSq * laplacian
-            // The multiplication is in Q15, so we shift right by 15.
+            const i32 laplacian = (i32)row_curr[i + 1] + row_curr[i - 1] +
+                                  row_above[i] + row_below[i] -
+                                  (c << 2);
             // Promote to i64 before the multiply. With the 2D CFL clamp at
             // 0.5, max |mCourantSq32| = 16383 and max |laplacian| ~262,140
             // (saturated checkerboard) give a worst-case product of ~4.3e9
             // — past i32 max (2.15e9). The i64 promote also acts as a
             // safety net if the clamp is ever regressed; pre-clamp the
             // 2D product could already reach ~8.6e9.
-            i32 term = static_cast<i32>(
+            const i32 term = static_cast<i32>(
                 (static_cast<i64>(mCourantSq32) * laplacian) >> 15);
-            i32 f =
-                -(i32)next[index] + ((i32)curr[index] << 1) + term;
+            // f = -next[index] + 2 * curr[index] + mCourantSq * laplacian.
+            i32 f = -(i32)row_next[i] + (c << 1) + term;
 
             // Apply damping: dampening factor is 2^mDampening, so the
             // division simplifies to an arithmetic shift. See the 1D
@@ -289,7 +295,7 @@ void WaveSimulation2D_Real::update() {
 
             // Clamp f into [q15_min, 32767] in a single step — subsumes
             // both the Q15 saturation clamp and the half-duplex zero pass.
-            next[index] = static_cast<i16>(fl::clamp(f, q15_min, static_cast<i32>(32767)));
+            row_next[i] = static_cast<i16>(fl::clamp(f, q15_min, static_cast<i32>(32767)));
         }
     }
 


### PR DESCRIPTION
Implements #3094 (§4 from meta tracker #3098).

## Scope reduction note

The §4 issue body proposed two changes — **(a) branchless Q15 clamp** and **(b) hoisted row indexing + `__restrict__`**. (a) was already done as a side effect of #3101 (§3 half-duplex fold-in: `fl::clamp` replaced the branchy if/else). This PR is the (b) row-indexing portion only.

## Change

In `WaveSimulation2D_Real::update()`:
- Lift `row = j * stride` out of the inner loop.
- Set up four row pointers (`row_curr`, `row_above`, `row_below`, `row_next`) qualified with `FL_RESTRICT_PARAM` (codebase's portable restrict macro from `fl/stl/compiler_control.h` — `__restrict__` on gcc/clang, `__restrict` on MSVC, `restrict` on C99).
- Inner loop now indexes by `i` only.
- Small side benefit: `c = row_curr[i]` is fetched once and reused in both the Laplacian (`-(c << 2)`) and the new-value computation (`(c << 1)`).

1D update is unchanged — no `j * stride` to hoist.

## Why

`fl::size` is `size_t` and the optimizer can't always prove the curr/next pointers don't alias. With `FL_RESTRICT_PARAM` and explicit row pointers the dependency picture across iterations is clear, which lets the back-end interleave loads or vectorize.

## Validation

- `bash test fl_math_wave_wave_simulation_real --cpp` — 5/5 pass.
- `bash lint --cpp` — clean.

Closes #3094
Refs #3098 (parent meta), #3099 §2, #3101 §3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized wave simulation engine performance through enhanced memory access patterns in core update calculations. All mathematical precision, damping behavior, and output characteristics remain unchanged, ensuring backward compatibility while delivering improved performance to wave-based effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->