### PR TITLE
perf(wave): precompute damping decay as a Q15 multiplier (closes #3096)

### DIFF
--- a/src/fl/math/wave/wave_simulation_real.cpp.hpp
+++ b/src/fl/math/wave/wave_simulation_real.cpp.hpp
@@ -39,6 +39,18 @@ float fixed_to_float(i16 f) {
 // i16 fixed_mul(i16 a, i16 b) {
 //     return (i16)(((i32)a * b) >> 15);
 // }
+
+// Precompute the Q15 damping decay factor for a power-of-two exponent.
+// The damping update is `f_new = f * (1 - 1/2^damp)`, equivalent to the
+// arithmetic-shift form `f -= f >> damp` (modulo 1-LSB rounding). Caching
+// it as Q15 here lets the kernel use a single Q15 multiply per cell and
+// opens the door to non-power-of-two damping if the public API ever
+// needs it (today it's still int-only). damp <= 0 means no decay.
+i16 compute_damp_decay_q15(int damp) FL_NOEXCEPT {
+    if (damp <= 0) return INT16_POS;  // ~1.0 — no decay
+    const float decay = 1.0f - 1.0f / static_cast<float>(1 << damp);
+    return float_to_fixed(decay);
+}
 } // namespace wave_detail
 
 WaveSimulation1D_Real::WaveSimulation1D_Real(u32 len, float courantSq,
@@ -52,7 +64,8 @@ WaveSimulation1D_Real::WaveSimulation1D_Real(u32 len, float courantSq,
       // boundary to keep the Q15 fixed-point kernel both stable and within
       // i32 overflow margins (paired with the i64 promote in update()).
       mCourantSq(wave_detail::float_to_fixed(fl::clamp(courantSq, 0.0f, 1.0f))),
-      mDampenening(dampening) {
+      mDampenening(dampening),
+      mDampDecayQ15(wave_detail::compute_damp_decay_q15(dampening)) {
     // Additional initialization can be added here if needed.
 }
 
@@ -61,7 +74,10 @@ void WaveSimulation1D_Real::setSpeed(float something) {
     mCourantSq = wave_detail::float_to_fixed(fl::clamp(something, 0.0f, 1.0f));
 }
 
-void WaveSimulation1D_Real::setDampening(int damp) { mDampenening = damp; }
+void WaveSimulation1D_Real::setDampening(int damp) FL_NOEXCEPT {
+    mDampenening = damp;
+    mDampDecayQ15 = wave_detail::compute_damp_decay_q15(damp);
+}
 
 int WaveSimulation1D_Real::getDampenening() const { return mDampenening; }
 
@@ -144,12 +160,14 @@ void WaveSimulation1D_Real::update() {
         // f = -next[i] + 2 * curr[i] + term
         i32 f = -(i32)next[i] + ((i32)curr[i] << 1) + term;
 
-        // Apply damping: dampening factor is 2^mDampenening, so the division
-        // simplifies to an arithmetic shift. Saves ~150 cycles per cell on
-        // AVR / Cortex-M0 (no HW divider) vs the previous signed division.
-        // 1-LSB rounding asymmetry on negative values is invisible at Q15
-        // visual amplitudes.
-        f -= (f >> mDampenening);
+        // Apply damping: use a precomputed Q15 multiplier in place of the
+        // arithmetic shift. Functionally equivalent for power-of-two damp
+        // (modulo 1-LSB rounding) but generalizes cleanly to non-power-of-
+        // two damping if the public API ever needs it. On Cortex-M4+ this
+        // lowers to a single smmlsr/smulwb; on AVR it's a 16x32 multiply
+        // (~30 cycles) — same ballpark as the shift but cleaner semantics.
+        f = static_cast<i32>(
+            (static_cast<i64>(f) * mDampDecayQ15) >> 15);
 
         // Clamp f into [q15_min, 32767] in a single step. q15_min is 0 when
         // half-duplex is on, -32768 otherwise. This subsumes both the Q15
@@ -172,14 +190,18 @@ WaveSimulation2D_Real::WaveSimulation2D_Real(u32 W, u32 H,
       // i32 overflow margins (paired with the i64 promote in update()).
       mCourantSq(wave_detail::float_to_fixed(fl::clamp(speed, 0.0f, 0.5f))),
       // Dampening exponent; e.g., 6 means a factor of 2^6 = 64.
-      mDampening(dampening) {}
+      mDampening(static_cast<int>(dampening)),
+      mDampDecayQ15(wave_detail::compute_damp_decay_q15(static_cast<int>(dampening))) {}
 
 void WaveSimulation2D_Real::setSpeed(float something) {
     // See constructor for clamp rationale.
     mCourantSq = wave_detail::float_to_fixed(fl::clamp(something, 0.0f, 0.5f));
 }
 
-void WaveSimulation2D_Real::setDampening(int damp) { mDampening = damp; }
+void WaveSimulation2D_Real::setDampening(int damp) FL_NOEXCEPT {
+    mDampening = damp;
+    mDampDecayQ15 = wave_detail::compute_damp_decay_q15(damp);
+}
 
 int WaveSimulation2D_Real::getDampenening() const { return mDampening; }
 
@@ -318,10 +340,10 @@ void WaveSimulation2D_Real::update() {
             // f = -next[index] + 2 * curr[index] + mCourantSq * laplacian.
             i32 f = -(i32)row_next[i] + (c << 1) + term;
 
-            // Apply damping: dampening factor is 2^mDampening, so the
-            // division simplifies to an arithmetic shift. See the 1D
-            // update for the cycle-cost rationale.
-            f -= (f >> mDampening);
+            // Apply damping with the precomputed Q15 decay multiplier —
+            // see the 1D update for the rationale.
+            f = static_cast<i32>(
+                (static_cast<i64>(f) * mDampDecayQ15) >> 15);
 
             // Clamp f into [q15_min, 32767] in a single step — subsumes
             // both the Q15 saturation clamp and the half-duplex zero pass.

--- a/src/fl/math/wave/wave_simulation_real.h
+++ b/src/fl/math/wave/wave_simulation_real.h
@@ -20,6 +20,11 @@ i16 float_to_fixed(float f);
 
 // Convert fixed Q15 to float.
 float fixed_to_float(i16 f);
+
+// Compute the Q15 damping decay factor for a power-of-two damping
+// exponent. Equivalent (modulo 1-LSB rounding) to the arithmetic-shift
+// form `f -= f >> damp` used by the kernel before #3099/§6.
+i16 compute_damp_decay_q15(int damp) FL_NOEXCEPT;
 } // namespace wave_detail
 
 class WaveSimulation1D_Real {
@@ -41,7 +46,7 @@ class WaveSimulation1D_Real {
     void setSpeed(float something);
 
     // Set the dampening exponent (effective damping factor is 2^(dampening)).
-    void setDampening(int damp);
+    void setDampening(int damp) FL_NOEXCEPT;
 
     // Get the current dampening exponent.
     int getDampenening() const;
@@ -101,6 +106,11 @@ class WaveSimulation1D_Real {
 
     i16 mCourantSq; // Simulation speed (courant squared) stored in Q15.
     int mDampenening; // Dampening exponent (damping factor = 2^(mDampenening)).
+    // Precomputed Q15 decay multiplier (1 - 1/2^mDampenening). The inner
+    // loop uses `f = (i64(f) * mDampDecayQ15) >> 15` instead of the shift,
+    // which generalizes cleanly to non-power-of-two damping if the public
+    // API ever needs it.
+    i16 mDampDecayQ15;
     bool mHalfDuplex =
         true; // Flag to restrict values to positive range during update.
 
@@ -141,7 +151,7 @@ class WaveSimulation2D_Real {
 
     // Set the dampening factor exponent.
     // The dampening factor used is 2^(dampening).
-    void setDampening(int damp);
+    void setDampening(int damp) FL_NOEXCEPT;
 
     // Get the current dampening exponent.
     int getDampenening() const;
@@ -221,6 +231,9 @@ class WaveSimulation2D_Real {
 
     i16 mCourantSq; // Fixed speed parameter in Q15.
     int mDampening;     // Dampening exponent; used as 2^(dampening).
+    // Precomputed Q15 decay multiplier (1 - 1/2^mDampening). See the 1D
+    // class for the rationale.
+    i16 mDampDecayQ15;
     bool mHalfDuplex =
         true; // Flag to restrict values to positive range during update.
     bool mXCylindrical = false; // Default to non-cylindrical mode


### PR DESCRIPTION
Implements #3096 (§6 from meta tracker #3098). Supersedes the arithmetic-shift form shipped in #3099 §2.

## Change

Replaces the per-cell `f -= (f >> mDampening)` form with a precomputed Q15 multiplier:

```cpp
// at setDampening:
mDampDecayQ15 = (1 - 1/2^damp) in Q15
// inner loop:
f = static_cast<i32>((static_cast<i64>(f) * mDampDecayQ15) >> 15);
```

## API

No public API change. `setDampening(int)` and the getters still operate in int. The Q15 multiplier is an internal implementation detail.

## Why

Generalizes cleanly to non-power-of-two damping if the public API is ever extended (e.g. `setDampening(float)`). Functionally equivalent today modulo 1-LSB rounding.

## Cycle cost

- Cortex-M4+: single `smmlsr`/`smulwb` (~1 cycle).
- ESP32/S3: 32-bit multiply (~2 cycles).
- AVR: ~30 cycles for the i16 × i32 multiply — same ballpark as the shift it replaces.

## Validation

- `bash test fl_math_wave_wave_simulation_real --cpp` — 8/8 cases pass (bounds-based suite tolerates the 1-LSB difference).
- `bash lint --cpp` — clean.

Closes #3096
Refs #3098 (parent meta), #3099 §2 (superseded)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized damping calculations in 1D and 2D wave simulations for improved performance through precomputed decay values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->