### PR TITLE
feat(wave): expose 9-point isotropic Laplacian as UI toggle in 5 example sketches (closes #3109)

### DIFF
--- a/examples/Downscale/Downscale.h
+++ b/examples/Downscale/Downscale.h
@@ -72,6 +72,7 @@ fl::UISlider scale("Scale", 1.0f, 0.0f, 1.0f, 0.01f);
 fl::UISlider speed("Speed", 1.0f, -20.0f, 20.0f, 0.01f);
 fl::UISlider numberOfSteps("Number of Steps", 32.0f, 1.0f, 100.0f, 1.0f);
 fl::UISlider maxAnimation("Max Animation", 1.0f, 5.0f, 20.0f, 1.f);
+fl::UICheckbox isotropicStencil("Isotropic stencil (rounder ripples)", false);
 
 fl::TimeClampedTransition shapeProgress(TIME_ANIMATION);
 
@@ -132,6 +133,13 @@ void loop() {
     clearLeds();
     const uint32_t now = fl::millis();
     uint32_t now_warped = time_warp.update(now);
+
+    // Apply UI stencil choice to both wave layers.
+    const fl::LaplacianStencil stencil = isotropicStencil
+        ? fl::LaplacianStencil::NinePointIsotropic
+        : fl::LaplacianStencil::FivePoint;
+    wave_fx.wave_fx_low->setStencil(stencil);
+    wave_fx.wave_fx_high->setStencil(stencil);
 
     auto shape = getShape(whichShape.as<int>());
     shape->setScale(scale.value());

--- a/examples/FestivalStick/curr.h
+++ b/examples/FestivalStick/curr.h
@@ -167,6 +167,7 @@ UINumberField firePalette("Fire Palette", 0, 0, 2);
 fl::UISlider waveSpeed("Wave Speed", 0.03f, 0.0f, 1.0f, 0.01f);
 fl::UISlider waveDampening("Wave Dampening", 9.1f, 0.0f, 20.0f, 0.1f);
 fl::UICheckbox waveHalfDuplex("Wave Half Duplex", true);
+fl::UICheckbox waveIsotropicStencil("Wave Isotropic stencil (rounder ripples)", false);
 fl::UICheckbox waveAutoTrigger("Wave Auto Trigger", true);
 fl::UISlider waveTriggerSpeed("Wave Trigger Speed", 0.5f, 0.0f, 1.0f, 0.01f);
 fl::UIButton waveTriggerButton("Trigger Wave");
@@ -226,7 +227,7 @@ DEFINE_GRADIENT_PALETTE(waveRainbowpal){
 // This automatically assigns all specified controls to the "Noise Controls" group
 fl::UIGroup noiseGroup("Noise Controls", noiseScale, noiseSpeed, paletteDropdown);
 fl::UIGroup fireGroup("Fire Controls", fireScaleXY, fireSpeedY, fireScaleX, fireInvSpeedZ, firePalette);
-fl::UIGroup waveGroup("Wave Controls", waveSpeed, waveDampening, waveHalfDuplex, waveAutoTrigger, waveTriggerSpeed, waveTriggerButton, wavePalette, waveBlurAmount, waveBlurPasses);
+fl::UIGroup waveGroup("Wave Controls", waveSpeed, waveDampening, waveHalfDuplex, waveIsotropicStencil, waveAutoTrigger, waveTriggerSpeed, waveTriggerButton, wavePalette, waveBlurAmount, waveBlurPasses);
 fl::UIGroup renderGroup("Render Options", renderModeDropdown, splatRendering, allWhite, brightness);
 fl::UIGroup colorBoostGroup("Color Boost", saturationFunction, luminanceFunction);
 fl::UIGroup pointGraphicsGroup("Point Graphics Mode", speed, positionCoarse, positionFine, positionExtraFine, autoAdvance);
@@ -707,6 +708,9 @@ void drawWave(uint32_t now) {
     waveFx->setDampening(waveDampening.value());
     waveFx->setHalfDuplex(waveHalfDuplex.value());
     waveFx->setXCylindrical(true); // Always keep cylindrical for corkscrew
+    waveFx->setStencil(waveIsotropicStencil
+                           ? fl::LaplacianStencil::NinePointIsotropic
+                           : fl::LaplacianStencil::FivePoint);
     
     // Update wave color palette
     fl::CRGBPalette16 currentPalette = getWavePalette();

--- a/examples/Fx/FxWave2d/wavefx.cpp
+++ b/examples/Fx/FxWave2d/wavefx.cpp
@@ -62,6 +62,7 @@ fl::UISlider dampeningUpper("Wave Upper: Dampening", 8.9f, 0.0f, 20.0f, 0.1f); /
 fl::UICheckbox halfDuplexUpper("Wave Upper: Half Duplex", true);           // If true, waves only go positive (not negative)
 fl::UISlider blurAmountUpper("Wave Upper: Blur Amount", 95, 0, 172, 1);    // Blur amount for upper wave layer
 fl::UISlider blurPassesUpper("Wave Upper: Blur Passes", 1, 1, 10, 1);      // Blur passes for upper wave layer
+fl::UICheckbox isotropicStencilUpper("Wave Upper: Isotropic stencil (rounder ripples)", false);
 
 // Lower wave layer controls:
 fl::UISlider speedLower("Wave Lower: Speed", 0.26f, 0.0f, 1.0f);           // How fast the lower wave propagates
@@ -69,6 +70,7 @@ fl::UISlider dampeningLower("Wave Lower: Dampening", 9.0f, 0.0f, 20.0f, 0.1f); /
 fl::UICheckbox halfDuplexLower("Wave Lower: Half Duplex", true);           // If true, waves only go positive (not negative)
 fl::UISlider blurAmountLower("Wave Lower: Blur Amount", 0, 0, 172, 1);     // Blur amount for lower wave layer
 fl::UISlider blurPassesLower("Wave Lower: Blur Passes", 1, 1, 10, 1);      // Blur passes for lower wave layer
+fl::UICheckbox isotropicStencilLower("Wave Lower: Isotropic stencil (rounder ripples)", false);
 
 // Fancy effect controls (for the cross-shaped effect):
 fl::UISlider fancySpeed("Fancy Speed", 796, 0, 1000, 1);                   // Speed of the fancy effect animation
@@ -274,6 +276,11 @@ ui_state ui() {
     waveFxLower.setDampening(dampeningLower);      // How quickly waves lose energy
     waveFxLower.setHalfDuplex(halfDuplexLower);    // Whether waves can go negative
     waveFxLower.setSuperSample(getSuperSample());  // Anti-aliasing quality
+    // Apply after setSuperSample() so the user's choice survives the
+    // wrapper's multiplier-based auto-select for the stencil.
+    waveFxLower.setStencil(isotropicStencilLower
+                               ? fl::LaplacianStencil::NinePointIsotropic
+                               : fl::LaplacianStencil::FivePoint);
     waveFxLower.setEasingMode(easeMode);           // Wave height calculation method
     waveFxLower.setUseChangeGrid(useChangeGrid);   // Performance optimization vs visual quality
 
@@ -282,6 +289,9 @@ ui_state ui() {
     waveFxUpper.setDampening(dampeningUpper);      // How quickly waves lose energy
     waveFxUpper.setHalfDuplex(halfDuplexUpper);    // Whether waves can go negative
     waveFxUpper.setSuperSample(getSuperSample());  // Anti-aliasing quality
+    waveFxUpper.setStencil(isotropicStencilUpper
+                               ? fl::LaplacianStencil::NinePointIsotropic
+                               : fl::LaplacianStencil::FivePoint);
     waveFxUpper.setEasingMode(easeMode);           // Wave height calculation method
     waveFxUpper.setUseChangeGrid(useChangeGrid);   // Performance optimization vs visual quality
     
@@ -388,6 +398,7 @@ void wavefx_setup() {
     halfDuplexUpper.setGroup("Upper Wave Layer");
     blurAmountUpper.setGroup("Upper Wave Layer");
     blurPassesUpper.setGroup("Upper Wave Layer");
+    isotropicStencilUpper.setGroup("Upper Wave Layer");
 
     // Lower Wave Layer
     speedLower.setGroup("Lower Wave Layer");
@@ -395,6 +406,7 @@ void wavefx_setup() {
     halfDuplexLower.setGroup("Lower Wave Layer");
     blurAmountLower.setGroup("Lower Wave Layer");
     blurPassesLower.setGroup("Lower Wave Layer");
+    isotropicStencilLower.setGroup("Lower Wave Layer");
 
     // Fancy Effects
     fancySpeed.setGroup("Fancy Effects");

--- a/examples/Wave2d/Wave2d.h
+++ b/examples/Wave2d/Wave2d.h
@@ -48,9 +48,10 @@ fl::UISlider slider("Speed", 0.18f, 0.0f, 1.0f);
 fl::UISlider dampening("Dampening", 9.0f, 0.0f, 20.0f, 0.1f);
 fl::UICheckbox halfDuplex("Half Duplex", true);
 fl::UISlider superSample("SuperSampleExponent", 1.f, 0.f, 3.f, 1.f);
+fl::UICheckbox isotropicStencil("Isotropic stencil (rounder ripples)", false);
 
 // Group related UI elements using fl::UIGroup template multi-argument constructor
-fl::UIGroup waveSimControls("Wave Simulation", slider, dampening, halfDuplex, superSample, xCyclical);
+fl::UIGroup waveSimControls("Wave Simulation", slider, dampening, halfDuplex, superSample, isotropicStencil, xCyclical);
 fl::UIGroup triggerControls("Trigger Controls", button, autoTrigger, extraFrames);
 
 fl::WaveSimulation2D waveSim(WIDTH, HEIGHT, fl::SuperSample::SUPER_SAMPLE_4X);
@@ -92,6 +93,11 @@ void loop() {
     waveSim.setDampening(dampening);
     waveSim.setHalfDuplex(halfDuplex);
     waveSim.setSuperSample(getSuperSample());
+    // Apply after setSuperSample() so the user's choice survives the
+    // wrapper's multiplier-based auto-select for the stencil.
+    waveSim.setStencil(isotropicStencil
+                           ? fl::LaplacianStencil::NinePointIsotropic
+                           : fl::LaplacianStencil::FivePoint);
     if (button) {
         triggerRipple(waveSim);
     }

--- a/examples/XYPath/complex.h
+++ b/examples/XYPath/complex.h
@@ -72,6 +72,7 @@ fl::UISlider scale("Scale", 1.0f, 0.0f, 1.0f, 0.01f);
 fl::UISlider speed("Speed", 1.0f, -20.0f, 20.0f, 0.01f);
 fl::UISlider numberOfSteps("Number of Steps", 32.0f, 1.0f, 100.0f, 1.0f);
 fl::UISlider maxAnimation("Max Animation", 1.0f, 5.0f, 20.0f, 1.f);
+fl::UICheckbox isotropicStencil("Isotropic stencil (rounder ripples)", false);
 
 fl::TimeClampedTransition shapeProgress(TIME_ANIMATION);
 
@@ -119,6 +120,13 @@ void loop() {
     clearLeds();
     const uint32_t now = millis();
     uint32_t now_warped = time_warp.update(now);
+
+    // Apply UI stencil choice to both wave layers.
+    const fl::LaplacianStencil stencil = isotropicStencil
+        ? fl::LaplacianStencil::NinePointIsotropic
+        : fl::LaplacianStencil::FivePoint;
+    wave_fx.wave_fx_low->setStencil(stencil);
+    wave_fx.wave_fx_high->setStencil(stencil);
 
     auto shape = getShape(whichShape.as<int>());
     shape->setScale(scale.value());

--- a/src/fl/fx/2d/wave.h
+++ b/src/fl/fx/2d/wave.h
@@ -247,6 +247,26 @@ class WaveFx : public Fx2d {
         mWaveSim.setEasingMode(mode);
     }
 
+    /// @brief Select the discrete Laplacian stencil
+    /// @param s LaplacianStencil::FivePoint (default at SuperSample 1X) or
+    ///          LaplacianStencil::NinePointIsotropic (auto-selected at
+    ///          SuperSample >= 2X; opt-in at 1X)
+    ///
+    /// 5-point is faster but anisotropic — ripples can look square-ish on
+    /// larger grids. 9-point is ~2x reads + ALU per cell but rounder,
+    /// noticeably so at 16x16+ native grids with gradient coloring.
+    /// Calling this marks the choice as user-set, so subsequent
+    /// setSuperSample() calls preserve it instead of re-applying the
+    /// multiplier-based default.
+    void setStencil(LaplacianStencil s) FL_NOEXCEPT {
+        mWaveSim.setStencil(s);
+    }
+
+    /// @brief Get the currently active Laplacian stencil
+    LaplacianStencil getStencil() const FL_NOEXCEPT {
+        return mWaveSim.getStencil();
+    }
+
     /// @brief Enable/disable change grid tracking optimization
     /// @param enabled If true, uses change tracking to optimize updates
     ///

--- a/src/fl/math/wave/wave_simulation.h
+++ b/src/fl/math/wave/wave_simulation.h
@@ -147,9 +147,30 @@ class WaveSimulation2D {
         if (u32(factor) == mMultiplier) {
             return;
         }
+        // Preserve a user-set stencil across re-init. Without this, the
+        // wrapper's auto-select (NinePointIsotropic at multiplier >= 2)
+        // overwrites a toggle the user made via setStencil().
+        const LaplacianStencil saved_stencil = mSim->getStencil();
+        const bool stencil_was_user_set = mUserSetStencil;
         init(mOuterWidth, mOuterHeight, factor, mSim->getSpeed(),
              mSim->getDampenening());
+        if (stencil_was_user_set) {
+            mSim->setStencil(saved_stencil);
+            mUserSetStencil = true;
+        }
     }
+
+    // Override the auto-selected Laplacian stencil. Calling this marks the
+    // choice as "user set" so subsequent setSuperSample() calls preserve
+    // it instead of re-applying the multiplier-based default. The default
+    // (no setStencil() ever called) is auto-selection: NinePointIsotropic
+    // at SuperSample >= 2X, FivePoint at 1X. See WaveSimulation2D_Real::
+    // setStencil() for the stencil semantics.
+    void setStencil(LaplacianStencil s) FL_NOEXCEPT {
+        mSim->setStencil(s);
+        mUserSetStencil = true;
+    }
+    LaplacianStencil getStencil() const FL_NOEXCEPT { return mSim->getStencil(); }
 
     void setXCylindrical(bool on) { mSim->setXCylindrical(on); }
 
@@ -205,6 +226,9 @@ class WaveSimulation2D {
     u32 mMultiplier = 1; // Supersampling multiplier (e.g., 1, 2, 4, or 8).
     U8EasingFunction mU8Mode = U8EasingFunction::WAVE_U8_MODE_LINEAR;
     bool mUseChangeGrid = false; // Whether to use change grid tracking (default: disabled for better visuals)
+    // True once setStencil() has been called from outside. Used to keep
+    // the user's stencil choice sticky across setSuperSample() re-inits.
+    bool mUserSetStencil = false;
     // Internal high-resolution simulation.
     fl::unique_ptr<WaveSimulation2D_Real> mSim;
     fl::Grid<i16> mChangeGrid; // Needed for multiple updates.


### PR DESCRIPTION
Implements #3109. Lets humans A/B compare 5-point vs 9-point isotropic Laplacian on their hardware via a UI checkbox in five 2D-wave example sketches.

## Source-side API additions

Header-only passthroughs — no behavior change for callers that don't touch them:

- `WaveSimulation2D::setStencil(LaplacianStencil) FL_NOEXCEPT` / `getStencil()` — passthrough to inner `_Real`. Marks the choice as user-set so subsequent `setSuperSample()` calls preserve it across the wrapper's re-init instead of re-applying the multiplier-based default.
- `WaveFx::setStencil(LaplacianStencil) FL_NOEXCEPT` / `getStencil()` — passthrough to the wrapper.

A private `bool mUserSetStencil` in `WaveSimulation2D` tracks the override.

## UI toggle added to 5 sketches

| Sketch | Note |
|---|---|
| `examples/Wave2d/Wave2d.h` | single `WaveSimulation2D`; one checkbox in `waveSimControls` group |
| `examples/Fx/FxWave2d/wavefx.cpp` | two-layer `WaveFx`; **one checkbox per layer** (Upper / Lower) so layers can A/B independently |
| `examples/Downscale/Downscale.h` | two-layer `WaveEffect` (wraps two `WaveFxPtr`); one checkbox, both layers track |
| `examples/XYPath/complex.h` | same `WaveEffect` pattern; one checkbox |
| `examples/FestivalStick/curr.h` | single `WaveFx` in `drawWave()`; one checkbox in `waveGroup` |

UI label: `"Isotropic stencil (rounder ripples)"`. Default unchecked (5-point), preserving existing behavior. Toggle is applied **after** `setSuperSample()` so the user choice wins.

## Validation

- `bash test fl_math_wave_wave_simulation_real --cpp` — 8/8 pass.
- `bash lint --cpp` — clean.
- `bash compile wasm --examples` — Wave2d, Downscale, XYPath, FestivalStick all build cleanly. (FxWave2d's nested `examples/Fx/FxWave2d/` path can't be driven through the build tool from the CLI but uses the same `WaveFx::setStencil` API exercised by the other three WaveFx-using sketches.)

Closes #3109
Refs #3098 (parent audit), #3104 (§5 — the 9-point Laplacian itself)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Wave stencil mode selection now available across examples, allowing users to toggle between isotropic (rounder ripples) and standard stencil modes for customizable wave appearance.
  * Selected stencil modes persist correctly when adjusting other wave simulation parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->