### PR TITLE
chore(release): 3.10.3 -> 3.10.4 — bump zccache floor to 1.12.7

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=FastLED
-version=3.10.3
+version=3.10.4
 author=Daniel Garcia
 maintainer=Daniel Garcia <dgarcia@fastled.io>
 sentence=Multi-platform library for controlling dozens of different types of LEDs along with optimized math, effect, and noise functions.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ci"
-version = "0.1.0"
+version = "0.1.1"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -161,7 +161,7 @@ dependencies = [
     # `FileNotFoundError: meson_native.txt` / `ninja: error: rebuilding
     # 'build.ninja': subcommand failed` cascade we hit during long-session
     # `bash test --cpp` cycles.
-    "zccache>=1.12.5",
+    "zccache>=1.12.7",
     "ninja",
     "meson>=1.11.0",
     "download",

--- a/src/FastLED.h
+++ b/src/FastLED.h
@@ -34,7 +34,7 @@
 /// * 1 digit for the major version
 /// * 3 digits for the minor version
 /// * 3 digits for the patch version
-#define FASTLED_VERSION 3010003
+#define FASTLED_VERSION 3010004
 #ifndef FASTLED_INTERNAL
 #  ifdef  FASTLED_SHOW_VERSION
 #    ifdef FASTLED_HAS_PRAGMA_MESSAGE


### PR DESCRIPTION
Picks up [zackees/zccache#763](https://github.com/zackees/zccache/pull/763) (version-namespaced cache root, closes the version-shadow chain at zackees/zccache#762).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated library and project versions to latest patch releases.
  * Updated dependency constraint to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->