### PR TITLE
fix(wave): switch WaveSimulation2D_Real grids from vector_psram to SRAM (closes #3114)

### DIFF
--- a/src/fl/math/wave/wave_simulation_real.h
+++ b/src/fl/math/wave/wave_simulation_real.h
@@ -224,8 +224,24 @@ class WaveSimulation2D_Real {
     u32 stride; // Row length (width + 2 for the borders).
 
     // Two separate grids stored in fixed Q15 format.
-    fl::vector_psram<i16> grid1;
-    fl::vector_psram<i16> grid2;
+    //
+    // SRAM, not PSRAM. The previous `fl::vector_psram<i16>` default
+    // landed both grids in PSRAM on every ESP32 with PSRAM available —
+    // including ESP32-S3, which has no L2 cache and pays the full
+    // ~80 ns PSRAM latency per cell access. The 5-point stencil reads
+    // 5 cells per inner cell, so a 64×64 update was reading ~80 KB per
+    // step at ~50 MB/s practical PSRAM throughput → ~1.6 ms per step
+    // on memory alone, cratering frame rate at the grid sizes users
+    // actually want. SRAM is predictable everywhere: ESP32-S3 has
+    // 320 KB SRAM (64×64 i16 = 8 KB, 128×128 = 32 KB, both fit
+    // easily); ESP32-P4 ~750 KB SRAM (256×256 fits); Teensy 4 OCRAM
+    // is faster still.
+    //
+    // Users with grids genuinely too large for SRAM can construct a
+    // parallel large-grid variant that re-enables PSRAM as an explicit,
+    // documented opt-in (see #3114 follow-up).
+    fl::vector<i16> grid1;
+    fl::vector<i16> grid2;
 
     fl::size whichGrid; // Indicates the active grid (0 or 1).
 


### PR DESCRIPTION
Closes #3114. Switches the silent `vector_psram<i16>` grid default in `WaveSimulation2D_Real` to plain `fl::vector<i16>` (SRAM).

## Why

The previous default landed both wave grids in PSRAM on every ESP32 with PSRAM available. On ESP32-S3 (no L2 cache) this paid the full ~80 ns PSRAM access latency per cell — the 5-point stencil reads 5 cells per inner cell, so a 64×64 update was reading ~80 KB per step at ~50 MB/s practical PSRAM throughput → **~1.6 ms per step on memory alone**, cratering frame rate at the grid sizes users actually want.

Worse, identical-looking user code produced wildly different frame rates on ESP32-S3 vs Teensy 4 vs ESP32-P4 depending on whether each had PSRAM. The auto-decision is the actual bug; making storage choice predictable is the fix.

## Where the grids now live

| Platform | Internal SRAM | Max grid (i16, 2 buffers + halo) |
|---|---|---|
| AVR | 2 KB | tiny — was always SRAM here |
| Cortex-M0 / RP2040 | 264 KB | 128×128 comfortably |
| Teensy 4 (OCRAM) | 512+ KB | 256×256 |
| ESP32-S3 | 320 KB | 128×128 easily, 256×256 tight |
| ESP32-P4 | ~750 KB | 256×256 + headroom |

Users who genuinely need grids bigger than SRAM allows can construct a parallel `WaveSimulation2D_Real_Large` (deferred follow-up) that re-enables PSRAM as an explicit, documented opt-in.

## Validation

- `bash test fl_math_wave_wave_simulation_real --cpp` — 8/8 pass.
- `bash lint --cpp` — clean.

## Out of scope

- The `WaveSimulation2D_Real_Large` opt-in variant — deferred. Today's fix removes the silent default; the explicit opt-in is a separate follow-up.
- Templated `Allocator` parameter — rejected per #3114 body for the alternatives-considered reasons (template instantiation cost, harder to debug perf).

Closes #3114
Refs #3113 (parent meta — Wave2D perf pipeline)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Internal optimization to wave simulation memory management for improved efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->