### PR TITLE
refactor(wave): perf-bench owned by wave simulator; AutoResearch is external binder (refs #3113)

### DIFF
--- a/examples/AutoResearch/AutoResearchRemote.cpp
+++ b/examples/AutoResearch/AutoResearchRemote.cpp
@@ -26,7 +26,7 @@
 #include "fl/stl/json.h"
 #include "fl/task/task.h"
 #include "fl/task/executor.h"
-#include "fl/math/wave/wave_simulation_real.h"
+#include "fl/math/wave/wave_perf_bench.h"
 #include "fl/stl/atomic.h"
 #include "fl/task/promise.h"
 #include "fl/math/simd.h"
@@ -3740,55 +3740,26 @@ void AutoResearchRemoteControl::registerFunctions(fl::shared_ptr<AutoResearchSta
             response.set("error", "out_of_range");
             return response;
         }
-        fl::LaplacianStencil stencil =
+        const fl::LaplacianStencil stencil =
             (stencil_name == "NinePointIsotropic")
             ? fl::LaplacianStencil::NinePointIsotropic
             : fl::LaplacianStencil::FivePoint;
-        auto sim = fl::make_unique<fl::WaveSimulation2D_Real>(
-            static_cast<fl::u32>(W), static_cast<fl::u32>(H), 0.16f, 6.0f);
-        sim->setHalfDuplex(false);
-        sim->setStencil(stencil);
-        for (int y = 0; y < H; ++y) {
-            for (int x = 0; x < W; ++x) {
-                sim->setf(static_cast<fl::size>(x),
-                          static_cast<fl::size>(y),
-                          ((x + y) & 1) ? -0.5f : 0.5f);
-            }
-        }
-        sim->update();  // warm-up
-        double sum = 0.0;
-        double sum_sq = 0.0;
-        for (int r = 0; r < repeats; ++r) {
-            const fl::u32 t0 = fl::micros();
-            for (int i = 0; i < iterations; ++i) {
-                sim->update();
-            }
-            const fl::u32 t1 = fl::micros();
-            const double us_per_update =
-                static_cast<double>(t1 - t0) / iterations;
-            sum += us_per_update;
-            sum_sq += us_per_update * us_per_update;
-        }
-        const double mean = sum / repeats;
-        const double variance = (sum_sq / repeats) - (mean * mean);
-        double std_dev = 0.0;
-        if (variance > 0.0) {
-            // Newton-Raphson sqrt — avoids pulling in <cmath> on
-            // platforms where it's costly. 6 iterations gives ~14
-            // significant digits for the input ranges we expect.
-            double s = variance;
-            for (int k = 0; k < 6; ++k) {
-                s = 0.5 * (s + variance / s);
-            }
-            std_dev = s;
-        }
-        const double std_dev_pct = (mean > 0.0)
-            ? (100.0 * std_dev / mean) : 0.0;
-        response.set("success", true);
+        // External-binder pattern: simulator-side code (in
+        // src/fl/math/wave/wave_perf_bench.h) owns the wave PDE setup,
+        // checkerboard seed, warm-up, timing and statistics. This RPC
+        // is the thin JSON-RPC translation layer.
+        const fl::wave_perf::WavePerfRepeatResult bench =
+            fl::wave_perf::runWavePerfRepeat(
+                static_cast<fl::u32>(W),
+                static_cast<fl::u32>(H),
+                static_cast<fl::u32>(iterations),
+                static_cast<fl::u32>(repeats),
+                stencil);
+        response.set("success", bench.success);
         response.set("stencil", stencil_name.c_str());
-        response.set("mean_us_per_update", mean);
-        response.set("std_dev_us_per_update", std_dev);
-        response.set("std_dev_pct", std_dev_pct);
+        response.set("mean_us_per_update", bench.mean_us_per_update);
+        response.set("std_dev_us_per_update", bench.std_dev_us_per_update);
+        response.set("std_dev_pct", bench.std_dev_pct);
         return response;
     });
 
@@ -3848,71 +3819,29 @@ void AutoResearchRemoteControl::registerFunctions(fl::shared_ptr<AutoResearchSta
             return response;
         }
 
-        fl::LaplacianStencil stencil = fl::LaplacianStencil::NinePointIsotropic;
-        if (stencil_name == "FivePoint") {
-            stencil = fl::LaplacianStencil::FivePoint;
-        }
+        const fl::LaplacianStencil stencil =
+            (stencil_name == "FivePoint")
+            ? fl::LaplacianStencil::FivePoint
+            : fl::LaplacianStencil::NinePointIsotropic;
 
-        auto sim = fl::make_unique<fl::WaveSimulation2D_Real>(
-            static_cast<fl::u32>(W), static_cast<fl::u32>(H), 0.16f, 6.0f);
-        sim->setHalfDuplex(false);
-        sim->setStencil(stencil);
+        // External-binder pattern: simulator-side code (in
+        // src/fl/math/wave/wave_perf_bench.h) owns the wave PDE setup,
+        // checkerboard seed, warm-up, and timing. This RPC is the thin
+        // JSON-RPC translation layer.
+        const fl::wave_perf::WavePerfResult bench = loads_only
+            ? fl::wave_perf::runWavePerfLoadsOnly(
+                  static_cast<fl::u32>(W), static_cast<fl::u32>(H),
+                  static_cast<fl::u32>(iterations), stencil)
+            : fl::wave_perf::runWavePerf(
+                  static_cast<fl::u32>(W), static_cast<fl::u32>(H),
+                  static_cast<fl::u32>(iterations), stencil);
 
-        // Deterministic checkerboard seed at +/-0.5 (avoids the +/-1.0
-        // float_to_fixed asymmetry issue noted in #3083's audit).
-        for (int y = 0; y < H; ++y) {
-            for (int x = 0; x < W; ++x) {
-                sim->setf(static_cast<fl::size>(x),
-                          static_cast<fl::size>(y),
-                          ((x + y) & 1) ? -0.5f : 0.5f);
-            }
-        }
-
-        // Warm-up step — gets past any first-call init quirks and primes
-        // caches before the measurement window.
-        sim->update();
-
-        const fl::u32 t0 = fl::micros();
-        if (loads_only) {
-            // Memory-bound baseline: read every inner cell `iterations`
-            // times, sum into a volatile sink so the compiler can't
-            // hoist or elide the loop. Touches the same memory pattern
-            // as update() without any of the kernel arithmetic.
-            volatile fl::i32 sink = 0;
-            for (int i = 0; i < iterations; ++i) {
-                fl::i32 acc = 0;
-                for (int y = 0; y < H; ++y) {
-                    for (int x = 0; x < W; ++x) {
-                        acc += sim->geti16(
-                            static_cast<fl::size>(x),
-                            static_cast<fl::size>(y));
-                    }
-                }
-                sink += acc;
-            }
-            (void)sink;
-        } else {
-            for (int i = 0; i < iterations; ++i) {
-                sim->update();
-            }
-        }
-        const fl::u32 t1 = fl::micros();
-        const fl::u32 total_us = t1 - t0;
-
-        const double cells_per_update = static_cast<double>(W) * H;
-        const double us_per_update =
-            static_cast<double>(total_us) / static_cast<double>(iterations);
-        const double us_per_cell_per_update =
-            us_per_update / cells_per_update;
-        const double fps_at_one_update_per_frame =
-            us_per_update > 0.0 ? (1.0e6 / us_per_update) : 0.0;
-
-        response.set("success", true);
-        response.set("total_us", static_cast<int64_t>(total_us));
-        response.set("us_per_update", us_per_update);
-        response.set("us_per_cell_per_update", us_per_cell_per_update);
+        response.set("success", bench.success);
+        response.set("total_us", static_cast<int64_t>(bench.total_us));
+        response.set("us_per_update", bench.us_per_update);
+        response.set("us_per_cell_per_update", bench.us_per_cell_per_update);
         response.set("fps_at_one_update_per_frame",
-                     fps_at_one_update_per_frame);
+                     bench.fps_at_one_update_per_frame);
         return response;
     });
 }

--- a/src/fl/math/wave/wave_perf_bench.h
+++ b/src/fl/math/wave/wave_perf_bench.h
@@ -1,0 +1,192 @@
+/*
+Wave-PDE-specific performance bench helpers. The wave simulator owns
+this code; AutoResearch (or any other RPC layer) is an *external
+binder* that calls into these helpers and translates results into its
+preferred wire format. The simulator side does not know about RPC
+topology, JSON, or any specific transport.
+
+Used by meta #3113 — see `agents/docs/research/wave_pde_alternatives.md`
+for the broader motivation. The RPC binder for these helpers lives in
+`examples/AutoResearch/AutoResearchRemote.cpp`.
+*/
+
+#pragma once
+
+#include "fl/math/wave/wave_simulation_real.h"
+#include "fl/stl/chrono.h"
+#include "fl/stl/int.h"
+#include "fl/stl/noexcept.h"
+#include "fl/stl/stdint.h"
+#include "fl/stl/unique_ptr.h"
+
+namespace fl {
+
+namespace wave_perf {
+
+// Result of a single-shot wave-PDE perf measurement.
+struct WavePerfResult {
+    bool success = false;
+    u32 total_us = 0;
+    double us_per_update = 0.0;
+    double us_per_cell_per_update = 0.0;
+    double fps_at_one_update_per_frame = 0.0;
+};
+
+// Result of a multi-repeat stability check.
+struct WavePerfRepeatResult {
+    bool success = false;
+    u32 repeats = 0;
+    double mean_us_per_update = 0.0;
+    double std_dev_us_per_update = 0.0;
+    double std_dev_pct = 0.0;
+};
+
+// Bench config range gates. Tight enough to refuse pathological RPC
+// payloads (e.g. accidentally requesting a 256-MB grid) without
+// constraining real experiments.
+inline bool isValidGrid(u32 W, u32 H) FL_NOEXCEPT {
+    return W >= 4 && H >= 4 && W <= 1024 && H <= 1024;
+}
+inline bool isValidIterations(u32 iterations) FL_NOEXCEPT {
+    return iterations >= 1 && iterations <= 100000;
+}
+inline bool isValidRepeats(u32 repeats) FL_NOEXCEPT {
+    return repeats >= 2 && repeats <= 64;
+}
+
+// Build a wave simulator seeded with a deterministic +/-0.5 checkerboard.
+// Bench helpers below use this so every run starts from the same state.
+// The +/-0.5 amplitude is deliberate — avoids the +/-1.0 float_to_fixed
+// asymmetry noted in #3083's audit.
+inline fl::unique_ptr<WaveSimulation2D_Real> makeBenchSim(
+    u32 W, u32 H, LaplacianStencil stencil) FL_NOEXCEPT {
+    auto sim = fl::make_unique<WaveSimulation2D_Real>(W, H, 0.16f, 6.0f);
+    sim->setHalfDuplex(false);
+    sim->setStencil(stencil);
+    for (u32 y = 0; y < H; ++y) {
+        for (u32 x = 0; x < W; ++x) {
+            sim->setf(static_cast<fl::size>(x),
+                      static_cast<fl::size>(y),
+                      ((x + y) & 1u) ? -0.5f : 0.5f);
+        }
+    }
+    sim->update();  // warm-up: prime caches, get past init quirks
+    return sim;
+}
+
+// Single-shot: time `iterations` calls to update() and report
+// per-cell-per-update cost. The corresponding `loads_only=true` mode
+// (memory-bound baseline) lives in `runWavePerfLoadsOnly` so the
+// signatures stay simple — the gap between the two reveals memory
+// vs compute cost (critical for the ESP32-S3 PSRAM analysis from
+// #3114).
+inline WavePerfResult runWavePerf(u32 W, u32 H, u32 iterations,
+                                  LaplacianStencil stencil) FL_NOEXCEPT {
+    WavePerfResult r;
+    if (!isValidGrid(W, H) || !isValidIterations(iterations)) {
+        return r;
+    }
+    auto sim = makeBenchSim(W, H, stencil);
+    const u32 t0 = fl::micros();
+    for (u32 i = 0; i < iterations; ++i) {
+        sim->update();
+    }
+    const u32 t1 = fl::micros();
+    r.success = true;
+    r.total_us = t1 - t0;
+    const double cells_per_update = static_cast<double>(W) * H;
+    r.us_per_update = static_cast<double>(r.total_us)
+                       / static_cast<double>(iterations);
+    r.us_per_cell_per_update = r.us_per_update / cells_per_update;
+    r.fps_at_one_update_per_frame = (r.us_per_update > 0.0)
+        ? (1.0e6 / r.us_per_update) : 0.0;
+    return r;
+}
+
+// Memory-bound baseline: read every inner cell `iterations` times into
+// a volatile sink. Touches the same memory pattern as update() with
+// none of the kernel arithmetic. The gap between this and runWavePerf
+// is the memory-vs-compute breakdown.
+inline WavePerfResult runWavePerfLoadsOnly(u32 W, u32 H, u32 iterations,
+                                           LaplacianStencil stencil) FL_NOEXCEPT {
+    WavePerfResult r;
+    if (!isValidGrid(W, H) || !isValidIterations(iterations)) {
+        return r;
+    }
+    auto sim = makeBenchSim(W, H, stencil);
+    volatile fl::i32 sink = 0;
+    const u32 t0 = fl::micros();
+    for (u32 i = 0; i < iterations; ++i) {
+        fl::i32 acc = 0;
+        for (u32 y = 0; y < H; ++y) {
+            for (u32 x = 0; x < W; ++x) {
+                acc += sim->geti16(static_cast<fl::size>(x),
+                                   static_cast<fl::size>(y));
+            }
+        }
+        sink += acc;
+    }
+    const u32 t1 = fl::micros();
+    (void)sink;
+    r.success = true;
+    r.total_us = t1 - t0;
+    const double cells_per_update = static_cast<double>(W) * H;
+    r.us_per_update = static_cast<double>(r.total_us)
+                       / static_cast<double>(iterations);
+    r.us_per_cell_per_update = r.us_per_update / cells_per_update;
+    r.fps_at_one_update_per_frame = (r.us_per_update > 0.0)
+        ? (1.0e6 / r.us_per_update) : 0.0;
+    return r;
+}
+
+// Repeat-stability: run `repeats` measurements of `runWavePerf` and
+// report mean + std_dev_pct of us_per_update. Caller checks
+// std_dev_pct < 5%; higher → IRQ noise or RPC framing jitter is
+// contaminating the data, mark UNTRUSTED.
+inline WavePerfRepeatResult runWavePerfRepeat(
+    u32 W, u32 H, u32 iterations, u32 repeats,
+    LaplacianStencil stencil) FL_NOEXCEPT {
+    WavePerfRepeatResult r;
+    if (!isValidGrid(W, H) || !isValidIterations(iterations)
+        || !isValidRepeats(repeats)) {
+        return r;
+    }
+    // Single sim reused across repeats — the warm-up cost is paid once
+    // and each repeat measures steady-state cost.
+    auto sim = makeBenchSim(W, H, stencil);
+    double sum = 0.0;
+    double sum_sq = 0.0;
+    for (u32 j = 0; j < repeats; ++j) {
+        const u32 t0 = fl::micros();
+        for (u32 i = 0; i < iterations; ++i) {
+            sim->update();
+        }
+        const u32 t1 = fl::micros();
+        const double us_per_update =
+            static_cast<double>(t1 - t0) / static_cast<double>(iterations);
+        sum += us_per_update;
+        sum_sq += us_per_update * us_per_update;
+    }
+    const double mean = sum / static_cast<double>(repeats);
+    const double variance = (sum_sq / static_cast<double>(repeats))
+                          - (mean * mean);
+    double std_dev = 0.0;
+    if (variance > 0.0) {
+        // Newton-Raphson sqrt — avoids pulling in <cmath> on platforms
+        // where it's costly. 6 iterations gives ~14 significant digits.
+        double s = variance;
+        for (int k = 0; k < 6; ++k) {
+            s = 0.5 * (s + variance / s);
+        }
+        std_dev = s;
+    }
+    r.success = true;
+    r.repeats = repeats;
+    r.mean_us_per_update = mean;
+    r.std_dev_us_per_update = std_dev;
+    r.std_dev_pct = (mean > 0.0) ? (100.0 * std_dev / mean) : 0.0;
+    return r;
+}
+
+}  // namespace wave_perf
+}  // namespace fl


### PR DESCRIPTION
Per user feedback on PRs #3116 + #3118: wave-PDE benchmarking belongs to the wave simulator side, not to the AutoResearch RPC layer. `AutoResearchRemote.cpp` was embedding wave PDE setup (checkerboard seed, halfDuplex off, stencil selection, warm-up, timing, statistics) inline in two RPC lambdas — the RPC layer should not know wave-PDE-specific details that don't belong in transport plumbing.

## Separation of concerns

**New, simulator-side:** `src/fl/math/wave/wave_perf_bench.h`
```cpp
namespace fl::wave_perf {
  struct WavePerfResult { /* total_us, us_per_update, ... */ };
  struct WavePerfRepeatResult { /* mean, std_dev, std_dev_pct, ... */ };
  WavePerfResult runWavePerf(W, H, iterations, stencil);
  WavePerfResult runWavePerfLoadsOnly(W, H, iterations, stencil);
  WavePerfRepeatResult runWavePerfRepeat(W, H, iterations, repeats, stencil);
}
```

**Existing, binder-side:** `examples/AutoResearch/AutoResearchRemote.cpp` — `wave2dPerf` and `perfProbeRepeat` RPC handlers become thin JSON-RPC translators: parse args, dispatch to `fl::wave_perf::*`, format response.

## Why header-only

Bench helpers are co-located with the simulator they measure, compile-time-cheap, and reusable by any future RPC layer (BLE, HTTP, etc.) or driven directly from a unit test without standing up the AutoResearch sketch.

## What's deliberately unchanged

- `perfProbeMemcpy` and `perfProbeNop` stay in `AutoResearchRemote.cpp` — they're not wave-PDE-specific; they're general SRAM/cycle-counter calibration helpers. If the codebase ever grows a generic `src/fl/perf/sanity_probes.h` they can move there.
- All JSON wire formats are byte-identical to #3116 / #3118. Existing host-side callers don't notice.

## Validation

- `bash test fl_math_wave_wave_simulation_real --cpp` — 8/8 pass.
- `bash lint --cpp` — clean.
- `bash compile wasm --examples AutoResearch` — build clean.

Refs #3113 Task 1 + Task 2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized wave simulation performance benchmarking infrastructure into a dedicated module for improved maintainability and reusability.
  * Updated the AutoResearch example to utilize the new benchmarking implementation, streamlining performance measurement for RPC calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->