### PR TITLE
fix(autoresearch): gate 6 companion .cpp files on FASTLED_AUTORESEARCH_LOW_MEMORY (refs #3076)

### DIFF
--- a/examples/AutoResearch/AutoResearchBle.cpp
+++ b/examples/AutoResearch/AutoResearchBle.cpp
@@ -4,6 +4,16 @@
 // BLE transport creation/destruction is handled by
 // AutoResearchRemoteControl::startBleRemote()/stopBleRemote() in AutoResearchRemote.cpp.
 
+// Gate the entire file out under low-memory mode -- the LowMemory bring-up
+// surface (AutoResearchLowMemory.h) doesn't use BLE state and the full
+// fl::net BLE stack does not fit on parts like LPC845-BRK (64 KB flash).
+// Matches the conditional structure in AutoResearch.ino itself.
+#include "fl/system/sketch_macros.h"
+#if !defined(FASTLED_AUTORESEARCH_LOW_MEMORY) && !FL_PLATFORM_HAS_LARGE_MEMORY
+#define FASTLED_AUTORESEARCH_LOW_MEMORY 1
+#endif
+#if !(defined(FASTLED_AUTORESEARCH_LOW_MEMORY) && FASTLED_AUTORESEARCH_LOW_MEMORY)
+
 #include "AutoResearchBle.h"
 
 // Global BLE state
@@ -12,3 +22,5 @@ static AutoResearchBleState s_ble_state;
 AutoResearchBleState& getBleState() {
     return s_ble_state;
 }
+
+#endif  // !FASTLED_AUTORESEARCH_LOW_MEMORY

--- a/examples/AutoResearch/AutoResearchHelpers.cpp
+++ b/examples/AutoResearch/AutoResearchHelpers.cpp
@@ -1,5 +1,16 @@
 // AutoResearchHelpers.cpp - Helper function implementations
 
+// Gate out under low-memory mode -- the LowMemory bring-up surface
+// (AutoResearchLowMemory.h) carries its own minimal helper inlined into
+// the .ino, and the full helpers here pull in fl/channels/manager.h and
+// the validation suite which exceed the LPC845 / Tiny-memory budgets.
+// Matches the conditional structure in AutoResearch.ino itself.
+#include "fl/system/sketch_macros.h"
+#if !defined(FASTLED_AUTORESEARCH_LOW_MEMORY) && !FL_PLATFORM_HAS_LARGE_MEMORY
+#define FASTLED_AUTORESEARCH_LOW_MEMORY 1
+#endif
+#if !(defined(FASTLED_AUTORESEARCH_LOW_MEMORY) && FASTLED_AUTORESEARCH_LOW_MEMORY)
+
 #include "AutoResearchHelpers.h"
 #include "fl/channels/manager.h"
 #include "fl/stl/sstream.h"
@@ -102,3 +113,5 @@ void printSummaryTable(const fl::vector<fl::DriverTestResult>& driver_results) {
 }
 
 // Build test matrix configuration from preprocessor defines and available drivers
+
+#endif  // !FASTLED_AUTORESEARCH_LOW_MEMORY

--- a/examples/AutoResearch/AutoResearchNet.cpp
+++ b/examples/AutoResearch/AutoResearchNet.cpp
@@ -5,6 +5,17 @@
 // Uses ESP-IDF native APIs for WiFi Soft AP and HTTP client.
 // Guarded with FL_IS_ESP32 - no-op stubs on other platforms.
 
+// Gate out under low-memory mode -- the LowMemory bring-up surface
+// (AutoResearchLowMemory.h) doesn't expose any network endpoints and the
+// fl::net HTTP / asio machinery is several KB that won't fit on the
+// LPC845-BRK / similar Low + Tiny memory targets. Matches the conditional
+// structure in AutoResearch.ino itself.
+#include "fl/system/sketch_macros.h"
+#if !defined(FASTLED_AUTORESEARCH_LOW_MEMORY) && !FL_PLATFORM_HAS_LARGE_MEMORY
+#define FASTLED_AUTORESEARCH_LOW_MEMORY 1
+#endif
+#if !(defined(FASTLED_AUTORESEARCH_LOW_MEMORY) && FASTLED_AUTORESEARCH_LOW_MEMORY)
+
 #include "AutoResearchNet.h"
 #include "fl/stl/json.h"
 #include "fl/log/log.h"
@@ -480,3 +491,5 @@ fl::json stopNet() {
 }
 
 #endif  // FL_IS_ESP32
+
+#endif  // !FASTLED_AUTORESEARCH_LOW_MEMORY

--- a/examples/AutoResearch/AutoResearchOta.cpp
+++ b/examples/AutoResearch/AutoResearchOta.cpp
@@ -5,6 +5,15 @@
 // Uses ESP-IDF native APIs for WiFi Soft AP.
 // Guarded with FL_IS_ESP32 - no-op stubs on other platforms.
 
+// Gate out under low-memory mode -- no OTA path on parts that don't have
+// WiFi / a network stack. Matches the conditional structure in
+// AutoResearch.ino itself.
+#include "fl/system/sketch_macros.h"
+#if !defined(FASTLED_AUTORESEARCH_LOW_MEMORY) && !FL_PLATFORM_HAS_LARGE_MEMORY
+#define FASTLED_AUTORESEARCH_LOW_MEMORY 1
+#endif
+#if !(defined(FASTLED_AUTORESEARCH_LOW_MEMORY) && FASTLED_AUTORESEARCH_LOW_MEMORY)
+
 #include "AutoResearchOta.h"
 #include "fl/stl/json.h"
 #include "fl/log/log.h"
@@ -195,3 +204,5 @@ fl::json stopOta() {
 }
 
 #endif  // FL_IS_ESP32
+
+#endif  // !FASTLED_AUTORESEARCH_LOW_MEMORY

--- a/examples/AutoResearch/AutoResearchRemote.cpp
+++ b/examples/AutoResearch/AutoResearchRemote.cpp
@@ -7,6 +7,18 @@
 // - Test execution wrapped in fl::ScopedLogDisable to suppress debug noise
 // - This provides clean, parseable JSON output without FL_DBG/FL_PRINT spam
 
+// Gate out under low-memory mode -- the LowMemory bring-up surface
+// (AutoResearchLowMemory.h) binds its own minimal pinToggleRx / echo /
+// ws2812SctTest handlers directly; the full remote-control wiring here
+// references the AutoResearchTest / AutoResearchBle helpers and pulls in
+// the entire RPC dispatch surface which doesn't fit Low-memory budgets.
+// Matches the conditional structure in AutoResearch.ino itself.
+#include "fl/system/sketch_macros.h"
+#if !defined(FASTLED_AUTORESEARCH_LOW_MEMORY) && !FL_PLATFORM_HAS_LARGE_MEMORY
+#define FASTLED_AUTORESEARCH_LOW_MEMORY 1
+#endif
+#if !(defined(FASTLED_AUTORESEARCH_LOW_MEMORY) && FASTLED_AUTORESEARCH_LOW_MEMORY)
+
 // Legacy debug macros (no-ops, kept for debugTest RPC function)
 #define DEBUG_PRINT(x) do {} while(0)
 #define DEBUG_PRINTLN(x) do {} while(0)
@@ -3944,3 +3956,5 @@ fl::json AutoResearchRemoteControl::stopBleRemote() {
     response.set("success", true);
     return response;
 }
+
+#endif  // !FASTLED_AUTORESEARCH_LOW_MEMORY

--- a/examples/AutoResearch/AutoResearchTest.cpp
+++ b/examples/AutoResearch/AutoResearchTest.cpp
@@ -1,6 +1,17 @@
 // AutoResearchTest.cpp - Generic LED autoresearch testing infrastructure
 // Driver-agnostic test function implementations
 
+// Gate out under low-memory mode -- this file pulls in <FastLED.h> and
+// the full chipset / encoder matrix (UCS7604, wave3, pixel iterators).
+// LowMemory targets don't use those (their RPC surface is in
+// AutoResearchLowMemory.h, which only uses fl::Remote + the LPC SCT
+// driver). Matches the conditional structure in AutoResearch.ino itself.
+#include "fl/system/sketch_macros.h"
+#if !defined(FASTLED_AUTORESEARCH_LOW_MEMORY) && !FL_PLATFORM_HAS_LARGE_MEMORY
+#define FASTLED_AUTORESEARCH_LOW_MEMORY 1
+#endif
+#if !(defined(FASTLED_AUTORESEARCH_LOW_MEMORY) && FASTLED_AUTORESEARCH_LOW_MEMORY)
+
 #include "AutoResearchTest.h"
 #include "LegacyClocklessProxy.h"
 #include <FastLED.h>
@@ -1263,3 +1274,5 @@ const char* getBitPatternName(int pattern_id) {
         default: return "Unknown Pattern";
     }
 }
+
+#endif  // !FASTLED_AUTORESEARCH_LOW_MEMORY


### PR DESCRIPTION
## Summary

Gates the six companion `.cpp` files in `examples/AutoResearch/` on `FASTLED_AUTORESEARCH_LOW_MEMORY` so they become empty translation units under LowMemory builds — mirroring the gate `AutoResearch.ino` already applies to its own setup/loop body.

## Why

Two problems at once:

### 1. Master build regression on LowMemory (verified now)

`AutoResearchRemote.cpp:3650` calls bare `memcpy`. With current master plus a LowMemory target (e.g. `bash autoresearch lpc845brk --pin-toggle-rx`), the compile fails with:

```
examples/AutoResearch/AutoResearchRemote.cpp:3650:13: error: 'memcpy' was not declared in this scope
 3650 |             memcpy(dst_buf, src_buf, bytes);
      |             ^~~~~~
```

The LowMemory bring-up surface (`AutoResearchLowMemory.h`) doesn't use anything in `Remote.cpp`, so gating it out fixes the regression cleanly. Same applies to the other five companion files — none are used in LowMemory mode.

### 2. Bloat hygiene (refs FastLED#3076 / FastLED#3079)

Even though LTO dead-code-eliminates most of the unused symbols, the gates make the build's intent explicit. The LowMemory bring-up doesn't need BLE / Net / OTA / schema-generator / FastLED brightness chain — and the LTO output now reflects that without anyone needing to read 3000+ lines of `Remote.cpp` to confirm.

## Pattern

Each `.cpp` picks up the same auto-detect via `fl/system/sketch_macros.h`:

```cpp
#include "fl/system/sketch_macros.h"
#if !defined(FASTLED_AUTORESEARCH_LOW_MEMORY) && !FL_PLATFORM_HAS_LARGE_MEMORY
#define FASTLED_AUTORESEARCH_LOW_MEMORY 1
#endif
#if !(defined(FASTLED_AUTORESEARCH_LOW_MEMORY) && FASTLED_AUTORESEARCH_LOW_MEMORY)

// ... original file contents ...

#endif  // !FASTLED_AUTORESEARCH_LOW_MEMORY
```

Matches the conditional structure of `AutoResearch.ino` itself (line 18). AVR / ATtiny / similar Tiny-memory targets benefit automatically via `FL_PLATFORM_HAS_LARGE_MEMORY == 0` without needing an explicit build flag.

## Files

| File | Before | After |
|---|---|---|
| `AutoResearchBle.cpp` | full BLE state accessor | empty under LowMemory |
| `AutoResearchHelpers.cpp` | pulls in `fl/channels/manager.h`, validation suite | empty under LowMemory |
| `AutoResearchNet.cpp` | pulls in `fl/stl/json.h` + ESP32 net stack | empty under LowMemory |
| `AutoResearchOta.cpp` | pulls in `fl/net/ota.h` | empty under LowMemory |
| `AutoResearchRemote.cpp` | the full RPC dispatch surface (3000+ lines, has the `memcpy` regression) | empty under LowMemory |
| `AutoResearchTest.cpp` | pulls in `<FastLED.h>` + entire chipset matrix | empty under LowMemory |

## Verification

On LPC845-BRK against current master:

- **Before this PR:** `bash autoresearch lpc845brk --pin-toggle-rx --upload-port COM10` fails at compile with the bare-`memcpy` error.
- **After this PR:** build succeeds, fits 64 KB flash budget, firmware flashes, echo RPC round-trips end-to-end. (The `pinToggleRx` RPC silent-fail observed is a separate runtime concern about the 8 KB `EdgeTime[2048]` stack frame on a 16 KB SRAM part — tracked separately, not in scope here.)

## Refs

- FastLED#3076 — LowMemory bloat hunt. Does NOT close #3076 — that closes via the bloat-reduction PRs that already shipped (#3084 / #3085 / #3087 / #3088 / #3089); this is the compile-side hygiene the bloat-fix sweep didn't pick up.
- FastLED#3041 — `AutoResearchLpc.ino` retirement; this PR is the natural follow-up because `AutoResearch.ino`'s LowMemory branch took over the LPC bring-up duty.
- FastLED#3102 Section 1 — bench-validation meta; this PR unblocks the build phase of that section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added low-memory platform support to AutoResearch examples, enabling the library to function on memory-constrained devices by automatically disabling non-essential features during compilation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->