### PR TITLE
fix(autoresearch/lpc): move pinToggleRx + ws2812SctTest edge buffers off the stack (closes #3125)

### DIFF
--- a/examples/AutoResearch/AutoResearchLowMemory.h
+++ b/examples/AutoResearch/AutoResearchLowMemory.h
@@ -152,9 +152,18 @@ inline void autoResearchLowMemorySetup() {
             const fl::u32 expected_edges =
                 2u * static_cast<fl::u32>(freq_hz) *
                      static_cast<fl::u32>(duration_ms) / 1000u;
+            // Cap the captured edge count at kLowMemEdgeBufSize so the
+            // static buffer below stays small enough to fit alongside .bss
+            // on a 16 KB SRAM part. See FastLED #3125 -- the previous
+            // 2048-entry buffer was 8 KB stack on top of an already-8.5 KB
+            // .bss, which overflowed SRAM the moment this handler ran.
+            // 512 entries = 256 period pairs is plenty for the bench's
+            // 1 / 10 / 100 kHz sigma measurement (sample count converges
+            // well before 256 pairs at any of those rates).
+            constexpr fl::u32 kLowMemEdgeBufSize = 512u;
             fl::u32 cap = expected_edges + (expected_edges / 2u);
             if (cap < 256u)  cap = 256u;
-            if (cap > 2048u) cap = 2048u;
+            if (cap > kLowMemEdgeBufSize) cap = kLowMemEdgeBufSize;
 
             auto rx = fl::LpcSctRxChannel::create(rx_pin);
             if (!rx) return fl::string("0,0,0,0,0,0,0");
@@ -184,7 +193,11 @@ inline void autoResearchLowMemorySetup() {
             }
             rx->wait(1);
 
-            fl::EdgeTime edges_buf[2048];
+            // Static storage so the 2 KB buffer (512 * 4 B) lives in .bss
+            // instead of bloating the lambda's stack frame on a 16 KB
+            // SRAM part. The handler is invoked serially over JSON-RPC,
+            // so sharing across calls is safe. See FastLED #3125.
+            static fl::EdgeTime edges_buf[kLowMemEdgeBufSize];
             const fl::size n_read = rx->getRawEdgeTimes(
                 fl::span<fl::EdgeTime>(edges_buf, sizeof(edges_buf) / sizeof(edges_buf[0])));
 
@@ -283,9 +296,16 @@ inline void autoResearchLowMemorySetup() {
             const fl::u32 missing = (fl::u32)expected_bytes - decoded_bytes;
             mismatched += missing;
 
-            fl::EdgeTime probe[1024];
+            // Static storage so the diagnostic probe (4 KB at 1024 entries,
+            // now 2 KB at 512) lives in .bss rather than the lambda's
+            // stack frame. See FastLED #3125 -- same pattern as the
+            // pinToggleRx handler above. Diagnostic-only; truncating at
+            // 512 doesn't affect decode correctness (the decoder uses
+            // its own count via cfg.buffer_size).
+            constexpr fl::size kLowMemWs2812ProbeSize = 512u;
+            static fl::EdgeTime probe[kLowMemWs2812ProbeSize];
             const fl::size edges_captured = rx->getRawEdgeTimes(
-                fl::span<fl::EdgeTime>(probe, 1024));
+                fl::span<fl::EdgeTime>(probe, kLowMemWs2812ProbeSize));
 
             const bool success = (mismatched == 0 && decoded_bytes == (fl::u32)expected_bytes);
 


### PR DESCRIPTION
## Summary

Closes #3125. Moves the multi-KB edge buffers from stack to right-sized `static` storage so the LPC845-BRK LowMemory build doesn't stack-overflow the moment the RPC handler is invoked.

## What was wrong

Both LowMemory RPC handlers in `examples/AutoResearch/AutoResearchLowMemory.h` declared multi-KB stack buffers inside the lambda body:

```cpp
// line 187 (pinToggleRx)
fl::EdgeTime edges_buf[2048];  // 8 KB on the stack

// line 286 (ws2812SctTest)
fl::EdgeTime probe[1024];      // 4 KB on the stack
```

On LPC845-BRK (16 KB SRAM) `.bss` already sits at ~8.5 KB after the LowMemory build's `fl::Remote` + watchdog + `fl::json` instances. The first allocation alone pushed total SRAM demand over the 16 KB ceiling — the device crashed the moment a `pinToggleRx` request landed.

Verified today on hardware:

```
$ bash autoresearch lpc845brk --pin-toggle-rx --upload-port COM10
[lpc-pin-toggle-rx] opening COM10 @ 115200
[lpc-pin-toggle-rx] echo ok                   # device boots; echo RPC works

--- 1.1 / 1 kHz (1000 Hz / 200 ms) ---
  FAIL: no response or RPC error: None
--- 1.2 / 10 kHz ---
  FAIL: no response or RPC error: None
--- 1.3 / 100 kHz ---
  FAIL: no response or RPC error: None
```

Echo round-trips cleanly (handler doesn't allocate). `pinToggleRx` silently never replies (handler allocates 8 KB → stack overflow → trap before any reply).

## The fix

Two changes to `examples/AutoResearch/AutoResearchLowMemory.h`:

1. **`pinToggleRx`** — buffer right-sized from 2048 to 512 entries and moved to `static` storage. Cap clamp updated to match. The bench cases at 1 / 10 / 100 kHz all converge sigma well before 256 period pairs, so 512 entries is comfortable.
2. **`ws2812SctTest`** — probe right-sized from 1024 to 512 entries, also `static`. Diagnostic-only buffer; decoder accuracy is controlled by `cfg.buffer_size`, not by this output probe.

Net RAM budget change:

| Site | Before | After |
|---|---|---|
| `pinToggleRx::edges_buf` | 8 KB stack at every call | 2 KB permanent `.bss` |
| `ws2812SctTest::probe` | 4 KB stack at every call | 2 KB permanent `.bss` |
| **Total** | up to 12 KB stack pressure | 4 KB `.bss` |

Handlers are invoked serially over JSON-RPC, so sharing the `static` storage across calls is safe.

## Verification

- [x] `bash lint` — clean.
- [x] Build still fits 64 KB flash (no regression on the #3076 budget).
- [ ] On-hardware re-test of `bash autoresearch lpc845brk --pin-toggle-rx --upload-port COM<N>` after merge — final acceptance gate per the issue body. Expected: non-`None` RPC replies, with the 1 kHz case showing `success=1`. (Bench session needed; covered by FastLED#3102 Section 1.)

## Refs

- Closes #3125
- Refs #3102 Section 1 — bench-validation meta, this PR unblocks the Phase 1 pin-toggle gate.
- Orthogonal to #3128 (the `FASTLED_LPC_RX_SCT_WS2812` macro retirement) — that's a build-flag cleanup, this is the runtime SRAM fix.
- Orthogonal to #3123 (the LowMemory `.cpp` companion-file gating PR) — different files, different concerns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Optimized memory usage in low-memory configurations, reducing buffer allocations and improving efficiency on memory-constrained systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->