### PR TITLE
feat(wave): explicit PsramStorage opt-in for WaveSimulation2D_Real (refs #3122 A3)

### DIFF
--- a/src/fl/math/wave/wave_simulation_real.cpp.hpp
+++ b/src/fl/math/wave/wave_simulation_real.cpp.hpp
@@ -193,6 +193,24 @@ WaveSimulation2D_Real::WaveSimulation2D_Real(u32 W, u32 H,
       mDampening(static_cast<int>(dampening)),
       mDampDecayQ15(wave_detail::compute_damp_decay_q15(static_cast<int>(dampening))) {}
 
+// PSRAM-backed overload. Identical to the SRAM constructor above but
+// constructs grid1 / grid2 with the PSRAM memory resource so the
+// (potentially large) cell buffers don't compete with SRAM. The grids
+// then `resize()` to the requested cell count from PSRAM.
+WaveSimulation2D_Real::WaveSimulation2D_Real(PsramStorage,
+                                             u32 W, u32 H,
+                                             float speed,
+                                             float dampening) FL_NOEXCEPT
+    : width(W), height(H), stride(W + 2),
+      grid1(psram_memory_resource()),
+      grid2(psram_memory_resource()), whichGrid(0),
+      mCourantSq(wave_detail::float_to_fixed(fl::clamp(speed, 0.0f, 0.5f))),
+      mDampening(static_cast<int>(dampening)),
+      mDampDecayQ15(wave_detail::compute_damp_decay_q15(static_cast<int>(dampening))) {
+    grid1.resize((W + 2) * (H + 2));
+    grid2.resize((W + 2) * (H + 2));
+}
+
 void WaveSimulation2D_Real::setSpeed(float something) {
     // See constructor for clamp rationale.
     mCourantSq = wave_detail::float_to_fixed(fl::clamp(something, 0.0f, 0.5f));

--- a/src/fl/math/wave/wave_simulation_real.h
+++ b/src/fl/math/wave/wave_simulation_real.h
@@ -143,6 +143,22 @@ class WaveSimulation2D_Real {
     //  - dampening: exponent so that the damping factor is 2^dampening.
     WaveSimulation2D_Real(u32 W, u32 H, float speed = 0.16f,
                           float dampening = 6.0f) FL_NOEXCEPT;
+
+    // Tag for explicit PSRAM-backed grid storage. Use the tagged
+    // constructor overload when you genuinely need a grid larger than
+    // SRAM can hold AND accept the per-cell perf cost (~5-10x slower
+    // on ESP32-S3 without L2 cache; ~no cost on ESP32-P4 with L2 +
+    // cached PSRAM). See #3114 / #3117 for the SRAM-default rationale.
+    //
+    // Example:
+    //   WaveSimulation2D_Real sim{
+    //       WaveSimulation2D_Real::PsramStorage{}, 256, 256};
+    struct PsramStorage {};
+
+    WaveSimulation2D_Real(PsramStorage, u32 W, u32 H,
+                          float speed = 0.16f,
+                          float dampening = 6.0f) FL_NOEXCEPT;
+
     ~WaveSimulation2D_Real() FL_NOEXCEPT = default;
 
     // Set the simulation speed (Courant squared). Clamped to [0.0, 0.5] — see

--- a/tests/fl/math/wave/wave_simulation_real.cpp
+++ b/tests/fl/math/wave/wave_simulation_real.cpp
@@ -207,4 +207,26 @@ FL_TEST_CASE("WaveSimulation2D_Real 9-point produces different output than 5-poi
     FL_CHECK(nine.geti16(cx + 1, cy + 1) != 0);
 }
 
+FL_TEST_CASE("WaveSimulation2D_Real PSRAM opt-in constructor builds and runs") {
+    // A3 of meta #3122 — psram_storage tag explicitly opts a grid into
+    // PSRAM (on platforms where it's available). On host where there's
+    // no real PSRAM, psram_memory_resource() falls back to the default
+    // allocator — so the test still exercises the constructor path.
+    WaveSimulation2D_Real sim(
+        WaveSimulation2D_Real::PsramStorage{}, 16, 16, 0.16f, 6.0f);
+    sim.setHalfDuplex(false);
+    sim.setf(8, 8, 1.0f);
+    sim.update();
+    bool any_nonzero = false;
+    for (u32 y = 0; y < 16; ++y) {
+        for (u32 x = 0; x < 16; ++x) {
+            const i16 v = sim.geti16(x, y);
+            FL_CHECK_GE(static_cast<int>(v), -32768);
+            FL_CHECK_LE(static_cast<int>(v), 32767);
+            if (v != 0) any_nonzero = true;
+        }
+    }
+    FL_CHECK(any_nonzero);
+}
+
 }  // FL_TEST_FILE


### PR DESCRIPTION
A3 of meta #3122. Closes the deferred PSRAM opt-in follow-up from #3114 without introducing a parallel class.

## API

Tag-dispatch constructor overload:
```cpp
// Default — SRAM (post-#3117).
WaveSimulation2D_Real sim{64, 64};

// Explicit PSRAM opt-in (#3122 A3).
WaveSimulation2D_Real sim_large{
    WaveSimulation2D_Real::PsramStorage{}, 256, 256};
```

## Why this approach

Considered and rejected: a parallel `WaveSimulation2D_Real_Large` class. The body would have duplicated everything; the existing class is already SRAM by default. One class, two constructors, predictable storage.

## When to use `PsramStorage{}`

Users who genuinely need a grid larger than SRAM can hold AND accept the per-cell perf cost:
- **ESP32-S3** (no L2): ~5-10× slower per cell vs SRAM.
- **ESP32-P4** (L2 + cached PSRAM): ~no measurable cost.
- **Teensy 4** (OCRAM is already fast): no benefit.

## Validation

- `bash test fl_math_wave_wave_simulation_real --cpp --clean` — 9/9 pass.
- `bash lint --cpp` — clean.

The new test case (`WaveSimulation2D_Real PSRAM opt-in constructor builds and runs`) exercises the constructor path on host where `psram_memory_resource()` falls back to the default allocator.

Refs #3122 A3, #3114 (closed), #3117 (SRAM default), #3113 parent meta.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Wave simulation now supports an opt-in memory storage configuration option, enabling developers to select alternative allocation strategies for simulation grids based on application requirements.

* **Tests**
  * Added test coverage for the new storage option, validating proper initialization and correct simulation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->