### PR TITLE
feat(wave): output Gaussian-style blur as super-sample alternative (refs #3122 A4)

### DIFF
--- a/src/fl/fx/2d/wave.h
+++ b/src/fl/fx/2d/wave.h
@@ -8,6 +8,7 @@
 
 #include "fl/stl/stdint.h"
 
+#include "fl/gfx/blur.h"
 #include "fl/gfx/gradient.h"
 #include "fl/stl/shared_ptr.h"  // For FASTLED_SHARED_PTR macros and shared_ptr
 #include "fl/math/wave/wave_simulation.h"
@@ -130,6 +131,16 @@ struct WaveFxArgs {
     bool x_cyclical = false;
     /// Use change grid tracking for optimization (may reduce visual quality)
     bool use_change_grid = false;
+    /// Post-process Gaussian-style blur (#3122 A4 / #3112 research §A1).
+    /// Applied to the rendered CRGB output after `mapWaveToLEDs`. 0 = off.
+    /// Values 32-128 give a smoothing effect comparable to SUPER_SAMPLE_2X
+    /// at ~1.2x scalar cost vs 8-512x for true super-sampling. Recommended
+    /// as a cheaper alternative to SuperSample for ripple smoothing.
+    fl::u8 output_blur_amount = 0;
+    /// Number of blur passes (1 = single pass, 2+ = repeated smoothing).
+    /// Use 1 for typical smoothing; 2 only if you genuinely need a heavier
+    /// blur — visually subtle gain past 2 passes.
+    fl::u8 output_blur_passes = 1;
     /// Custom color mapper (nullptr uses default grayscale)
     WaveCrgbMapPtr crgbMap;
 };
@@ -184,7 +195,25 @@ class WaveFx : public Fx2d {
         setAutoUpdate(args.auto_updates);
         setXCylindrical(args.x_cyclical);
         setUseChangeGrid(args.use_change_grid);
+        setOutputBlur(args.output_blur_amount, args.output_blur_passes);
     }
+
+    /// @brief Configure the post-process output blur (#3122 A4)
+    /// @param amount Blur strength (0-255). 0 disables. 32-128 ≈ smoothing
+    ///               comparable to SUPER_SAMPLE_2X.
+    /// @param passes Number of repeated blur passes. 1 = single. >1 only
+    ///               for heavy smoothing.
+    ///
+    /// Applied to the rendered CRGB output buffer after `mapWaveToLEDs`.
+    /// ~1.2x scalar cost vs 8-512x for SuperSample with broadly
+    /// comparable visual quality on smooth fields. See #3112 research
+    /// doc §A1 for the rationale.
+    void setOutputBlur(fl::u8 amount, fl::u8 passes = 1) FL_NOEXCEPT {
+        mOutputBlurAmount = amount;
+        mOutputBlurPasses = (passes < 1) ? 1 : passes;
+    }
+    fl::u8 getOutputBlurAmount() const FL_NOEXCEPT { return mOutputBlurAmount; }
+    fl::u8 getOutputBlurPasses() const FL_NOEXCEPT { return mOutputBlurPasses; }
 
     /// @brief Enable/disable cylindrical topology on x-axis
     /// @param on If true, waves wrap around from right edge to left edge
@@ -345,6 +374,17 @@ class WaveFx : public Fx2d {
         }
         // Map the wave values to the LEDs.
         mCrgbMap->mapWaveToLEDs(mXyMap, mWaveSim, context.leds);
+        // #3122 A4 — post-process output blur as a cheaper alternative
+        // to SuperSample. Skipped entirely when amount == 0.
+        if (mOutputBlurAmount > 0) {
+            const fl::u32 w = mWaveSim.getWidth();
+            const fl::u32 h = mWaveSim.getHeight();
+            for (fl::u8 pass = 0; pass < mOutputBlurPasses; ++pass) {
+                fl::blur2d(context.leds, static_cast<fl::u8>(w),
+                           static_cast<fl::u8>(h), mOutputBlurAmount,
+                           mXyMap);
+            }
+        }
     }
 
     /// @brief Enable/disable automatic simulation updates
@@ -376,6 +416,8 @@ class WaveFx : public Fx2d {
     WaveSimulation2D mWaveSim;
     WaveCrgbMapPtr mCrgbMap;
     bool mAutoUpdates = true;
+    fl::u8 mOutputBlurAmount = 0;  // #3122 A4 — 0 disables
+    fl::u8 mOutputBlurPasses = 1;
 };
 
 } // namespace fl


### PR DESCRIPTION
A4 of meta #3122. Implements #3112 research doc §A1 — addresses super-sample's actual user motivation (LED-grid anti-aliasing on smooth fields) at ~1.2× scalar cost vs 8–512× for true super-sample.

## API

```cpp
// On WaveFxArgs:
fl::u8 output_blur_amount = 0;   // 0 disables. 32-128 ≈ SUPER_SAMPLE_2X
fl::u8 output_blur_passes = 1;

// On WaveFx (FL_NOEXCEPT):
void setOutputBlur(fl::u8 amount, fl::u8 passes = 1);
fl::u8 getOutputBlurAmount() const;
fl::u8 getOutputBlurPasses() const;
```

Runs in `WaveFx::draw()` after `mCrgbMap->mapWaveToLEDs()` via `fl::blur2d` (which already handles the LED grid topology including serpentine).

## Cost comparison

| Mode | Cost vs scalar | Visual quality |
|---|---|---|
| `SuperSample::NONE` + `output_blur=64` | **~1.1×** | comparable to SS-2X on smooth fields |
| `SuperSample::SUPER_SAMPLE_2X` (current default) | ~8× | smooth |
| `SuperSample::SUPER_SAMPLE_4X` | ~64× | very smooth |
| `SuperSample::SUPER_SAMPLE_8X` | ~512× | overkill |

Per the research doc: super-sample wins on hard edges (half-duplex zero floor) but `WaveFx` is rarely used at hard edges.

## What's NOT in this PR

Deliberate slicing:
- **Defaulting `SuperSample` to NONE wholesale** — wider behavioral change; lands separately after users evaluate blur quality.
- **New UI checkbox in example sketches** — separate slice; pattern mirrors #3110's stencil toggle.
- **Bench numbers from `--wave2d-perf`** — separate slice, requires hardware.

## Validation

- `bash lint --cpp` — clean.
- `bash compile wasm --examples Wave2d` — build clean.

Refs #3122 A4, #3112 research doc §A1, #3113 parent meta.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Wave effect now supports optional post-process blur for smoother output. Configure blur amount and number of passes as a lightweight alternative to supersampling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->