### PR TITLE
perf(string): consolidate basic_string::write overloads (refs #3122 B5 / #2886 Stage 5)

### DIFF
--- a/src/fl/stl/basic_string.cpp.hpp
+++ b/src/fl/stl/basic_string.cpp.hpp
@@ -210,16 +210,19 @@ const NotNullStringHolderPtr& basic_string::heapData() const {
 
 // ======= WRITE =======
 
+// Trivial delegates to the workhorse write(const char*, fl::size) below.
+// Folding away the address-of-byte indirection that write(u8) previously
+// did, and dropping the verbose static_cast<void*> intermediate from
+// write(u8*) — shrinks each call site by a few bytes (#3122 B5 /
+// #2886 Stage 5).
 fl::size basic_string::write(const fl::u8* data, fl::size n) {
-    const char* str = fl::bit_cast_ptr<const char>(static_cast<const void*>(data));
-    return write(str, n);
+    return write(fl::bit_cast_ptr<const char>(data), n);
 }
 
 fl::size basic_string::write(char c) { return write(&c, 1); }
 
 fl::size basic_string::write(fl::u8 c) {
-    const char* str = fl::bit_cast_ptr<const char>(static_cast<const void*>(&c));
-    return write(str, 1);
+    return write(static_cast<char>(c));
 }
 
 fl::size basic_string::write(const char* str, fl::size n) {


### PR DESCRIPTION
B5 of meta #3122, Stage 5 of #2886.

Three trivial delegates that previously each rebuilt a `const char*` pointer via an unnecessary `static_cast<const void*>` → `bit_cast_ptr` chain (`write(u8*)`) or took the address of a single byte then `bit_cast`'d it (`write(u8)`) are now simple one-line tail-calls:

```cpp
// Before:
fl::size basic_string::write(const fl::u8* data, fl::size n) {
    const char* str = fl::bit_cast_ptr<const char>(static_cast<const void*>(data));
    return write(str, n);
}
fl::size basic_string::write(fl::u8 c) {
    const char* str = fl::bit_cast_ptr<const char>(static_cast<const void*>(&c));
    return write(str, 1);
}

// After:
fl::size basic_string::write(const fl::u8* data, fl::size n) {
    return write(fl::bit_cast_ptr<const char>(data), n);
}
fl::size basic_string::write(fl::u8 c) {
    return write(static_cast<char>(c));
}
```

Net per-call-site savings: a few bytes — the order of magnitude the meta projected for Stage 5 (~0.5-1 KB across all call sites).

## Validation

- `bash test fl_stl_string --cpp` — passes.
- `bash lint --cpp` — clean.

Initial `reinterpret_cast` attempt was rejected by the project's `ReinterpretCastChecker`; `bit_cast_ptr` is the project-preferred form for this kind of pointer-type conversion.

Refs #3122 B5, #2886 Stage 5.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal string write method implementations by removing unnecessary casting indirection and improving code clarity through enhanced comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->