### PR TITLE
ci: wire backend flag-drift detector into teensy40 (refs #3122 B4 / #2410 / #2413)

### DIFF
--- a/.github/workflows/backend_flag_drift_teensy40.yml
+++ b/.github/workflows/backend_flag_drift_teensy40.yml
@@ -1,0 +1,105 @@
+# fbuild <-> PlatformIO compiler-flag drift detection for teensy40.
+#
+# B4 of meta #3122 / closes the canonical-board-coverage gap on #2410.
+#
+# Background (#2413): fbuild silently drifted from PlatformIO and broke
+# Teensy 4.x for 50+ consecutive master CI runs (the `.progmem`
+# section-type conflict in `colorpalettes.h:23`). The drift was only
+# caught after manual archaeology of CI history because no automated job
+# was comparing flag sets between backends.
+#
+# This workflow runs ci/check_backend_flag_drift.py (shipped in #2801)
+# on **teensy40** specifically, since that's the canonical broken case
+# the meta cites. Failure here surfaces drift in the workflow summary
+# without failing master CI -- the script writes a structured report we
+# attach as an artifact for later analysis. If we want to gate merges on
+# drift later, flip `continue-on-error: false` below.
+
+name: backend-flag-drift-teensy40
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'ci/check_backend_flag_drift.py'
+      - 'ci/ci-compile.py'
+      - 'ci/**/build_info*'
+      - 'src/platforms/arm/mxrt1062/**'
+      - 'platformio.ini'
+      - '.github/workflows/backend_flag_drift_teensy40.yml'
+  pull_request:
+    paths:
+      - 'ci/check_backend_flag_drift.py'
+      - 'ci/ci-compile.py'
+      - 'src/platforms/arm/mxrt1062/**'
+      - 'platformio.ini'
+      - '.github/workflows/backend_flag_drift_teensy40.yml'
+  workflow_dispatch:
+
+jobs:
+  drift-check:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    # Drift on a single board should not block merges by itself.
+    # The artifact + summary make it visible without being a gate.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      - name: Install Python deps
+        run: uv sync
+
+      - name: Run flag-drift check
+        id: drift
+        run: |
+          set -o pipefail
+          mkdir -p .build/drift
+          uv run python ci/check_backend_flag_drift.py \
+              --board teensy40 \
+              --example Blink \
+              --timeout 1200 \
+              2>&1 | tee .build/drift/teensy40_drift.txt
+          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
+
+      - name: Surface in workflow summary
+        if: always()
+        run: |
+          {
+            echo "## fbuild <-> PlatformIO drift — teensy40"
+            echo ""
+            echo "Script: \`ci/check_backend_flag_drift.py\` (#2801)"
+            echo "Board:  teensy40"
+            echo "Example: Blink"
+            echo ""
+            echo "<details><summary>Full report</summary>"
+            echo ""
+            echo '```'
+            cat .build/drift/teensy40_drift.txt || echo "(no report produced)"
+            echo '```'
+            echo ""
+            echo "</details>"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload drift report artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: backend-flag-drift-teensy40
+          path: .build/drift/
+          if-no-files-found: warn
+          retention-days: 30


### PR DESCRIPTION
B4 of meta #3122. Wires the existing `ci/check_backend_flag_drift.py` (shipped in #2801, refs #2410) into a dedicated GitHub Actions workflow for **teensy40** — the canonical broken case cited in #2413 ("fbuild silently drifted from PlatformIO and broke Teensy 4.x for 50+ consecutive master CI runs ... the `.progmem` section-type conflict in `colorpalettes.h:23`").

## What the workflow does

- Triggers on pushes to master + PRs touching the script, compile orchestrator, T4 platform code, or the workflow itself.
- Drives both backends to build `Blink` for teensy40, runs the drift script.
- Writes a report to `.build/drift/teensy40_drift.txt`, surfaces it in the workflow summary, uploads as an artifact (30-day retention).

## Drift gating

`continue-on-error: true` — drift surfaces visibly but does **not** block merges yet. The right next step is gating merges on drift *after* a clean-slate run confirms the existing flag set is the intended one. Today's PR makes drift **legible**, not mandatory.

## Why single-board scope

Doing all 5+ envs at once would obscure which board the drift came from in the summary view. Starting with **teensy40** closes the original reported bug; future PRs can add per-board workflows or refactor to a matrix once the contract is proven.

## Validation

- `bash lint` — clean.
- Workflow won't actually execute until merged + master is hit; first execution will populate the artifact + summary that prove the contract end-to-end.

Refs #3122 B4, #2410, #2413, #2801.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated compiler-flag drift verification for Teensy 40 board during continuous integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->