### PR TITLE
refactor(examples): pass fl::Remote* explicitly to AutoResearchRemote bind*Methods

### DIFF
--- a/examples/AutoResearch/AutoResearchRemote.cpp
+++ b/examples/AutoResearch/AutoResearchRemote.cpp
@@ -291,13 +291,13 @@ void AutoResearchRemoteControl::registerFunctions(fl::shared_ptr<AutoResearchSta
     //
     // Bindings are partitioned across sibling .cpp files (#3132 / meta #3127) so
     // each file stays under 1 K LOC.
-    bindBasicMethods();
-    bindFlexioMethods();
-    bindGpioMethods();
-    bindBenchmarkMethods();
-    bindAsyncNetMethods();
-    bindCoroutineMethods();
-    bindPerfMethods();
+    bindBasicMethods(mRemote.get());
+    bindFlexioMethods(mRemote.get());
+    bindGpioMethods(mRemote.get());
+    bindBenchmarkMethods(mRemote.get());
+    bindAsyncNetMethods(mRemote.get());
+    bindCoroutineMethods(mRemote.get());
+    bindPerfMethods(mRemote.get());
 }
 
 

--- a/examples/AutoResearch/AutoResearchRemote.h
+++ b/examples/AutoResearch/AutoResearchRemote.h
@@ -106,13 +106,14 @@ private:
     fl::json findConnectedPinsImpl(const fl::json& args);
 
     // RPC binding helpers — each implemented in its own .cpp file to keep
-    // file sizes below 1 K LOC (#3132 / meta #3127). All are called from
-    // registerFunctions() in order on mRemote.
-    void bindBasicMethods();
-    void bindFlexioMethods();
-    void bindGpioMethods();
-    void bindBenchmarkMethods();
-    void bindAsyncNetMethods();
-    void bindCoroutineMethods();
-    void bindPerfMethods();
+    // file sizes below 1 K LOC (#3132 / meta #3127). The Remote target is
+    // passed explicitly so the same partitioning can be used for the BLE
+    // Remote (mBleRemote) or any future transport.
+    void bindBasicMethods(fl::Remote* remote);
+    void bindFlexioMethods(fl::Remote* remote);
+    void bindGpioMethods(fl::Remote* remote);
+    void bindBenchmarkMethods(fl::Remote* remote);
+    void bindAsyncNetMethods(fl::Remote* remote);
+    void bindCoroutineMethods(fl::Remote* remote);
+    void bindPerfMethods(fl::Remote* remote);
 };

--- a/examples/AutoResearch/AutoResearchRemoteAsyncNetMethods.cpp
+++ b/examples/AutoResearch/AutoResearchRemoteAsyncNetMethods.cpp
@@ -47,10 +47,10 @@
 #include "fl/fx/frame.h"
 
 
-void AutoResearchRemoteControl::bindAsyncNetMethods() {
+void AutoResearchRemoteControl::bindAsyncNetMethods(fl::Remote* remote) {
     // Register "testAsync" function - verify that show() returns before TX completes (async DMA)
     // This proves the SPI driver releases back to the main thread while draining.
-    mRemote->bind("testAsync", [this](const fl::json& args) -> fl::json {
+    remote->bind("testAsync", [this](const fl::json& args) -> fl::json {
         fl::json response = fl::json::object();
 
         // Parse optional parameters from args object
@@ -186,20 +186,20 @@ void AutoResearchRemoteControl::bindAsyncNetMethods() {
     // ========================================================================
 
     // Register "startNetServer" - Start WiFi AP + HTTP server for net-server validation
-    mRemote->bind("startNetServer", [this](const fl::json& args) -> fl::json {
+    remote->bind("startNetServer", [this](const fl::json& args) -> fl::json {
         mState->net_server_active = true;
         return startNetServer();
     });
 
     // Register "startNetClient" - Start WiFi AP only for net-client validation
-    mRemote->bind("startNetClient", [this](const fl::json& args) -> fl::json {
+    remote->bind("startNetClient", [this](const fl::json& args) -> fl::json {
         mState->net_client_active = true;
         return startNetClient();
     });
 
     // Register "runNetClientTest" - ESP32 fetches from host HTTP server
     // Args: {host_ip: string, port: int}
-    mRemote->bind("runNetClientTest", [](const fl::json& args) -> fl::json {
+    remote->bind("runNetClientTest", [](const fl::json& args) -> fl::json {
         fl::json response = fl::json::object();
 
         // Parse arguments - args is the config object
@@ -226,12 +226,12 @@ void AutoResearchRemoteControl::bindAsyncNetMethods() {
 
     // Register "runNetLoopback" - Self-contained loopback test (no WiFi needed)
     // Starts HTTP server on localhost, client GETs 127.0.0.1 endpoints
-    mRemote->bind("runNetLoopback", [](const fl::json& args) -> fl::json {
+    remote->bind("runNetLoopback", [](const fl::json& args) -> fl::json {
         return runNetLoopback();
     });
 
     // Register "stopNet" - Stop WiFi AP and HTTP server/client
-    mRemote->bind("stopNet", [this](const fl::json& args) -> fl::json {
+    remote->bind("stopNet", [this](const fl::json& args) -> fl::json {
         mState->net_server_active = false;
         mState->net_client_active = false;
         return stopNet();
@@ -242,12 +242,12 @@ void AutoResearchRemoteControl::bindAsyncNetMethods() {
     // ========================================================================
 
     // Register "startOta" - Start WiFi AP + OTA HTTP server for OTA validation
-    mRemote->bind("startOta", [](const fl::json& args) -> fl::json {
+    remote->bind("startOta", [](const fl::json& args) -> fl::json {
         return startOta();
     });
 
     // Register "stopOta" - Stop OTA server and WiFi AP
-    mRemote->bind("stopOta", [](const fl::json& args) -> fl::json {
+    remote->bind("stopOta", [](const fl::json& args) -> fl::json {
         return stopOta();
     });
 
@@ -256,18 +256,18 @@ void AutoResearchRemoteControl::bindAsyncNetMethods() {
     // ========================================================================
 
     // Register "startBle" - Start BLE GATT server + create BLE Remote
-    mRemote->bind("startBle", [this](const fl::json& args) -> fl::json {
+    remote->bind("startBle", [this](const fl::json& args) -> fl::json {
         return this->startBleRemote();
     });
 
     // Register "stopBle" - Stop BLE GATT server + destroy BLE Remote
-    mRemote->bind("stopBle", [this](const fl::json& args) -> fl::json {
+    remote->bind("stopBle", [this](const fl::json& args) -> fl::json {
         return this->stopBleRemote();
     });
 
     // Register "decodeFile" - Decode a media file and return first 16 pixels
     // Args: [base64_data_string, extension_string]  (base64 auto-decoded to fl::vector<fl::u8>)
-    mRemote->bind("decodeFile", [](fl::vector<fl::u8> data, fl::string ext) -> fl::json {
+    remote->bind("decodeFile", [](fl::vector<fl::u8> data, fl::string ext) -> fl::json {
         fl::json response = fl::json::object();
 
         if (ext != ".mp4") {
@@ -352,7 +352,7 @@ void AutoResearchRemoteControl::bindAsyncNetMethods() {
     });
 
     // Register "bleStatus" - Query BLE connection/subscription state
-    mRemote->bind("bleStatus", [this](const fl::json& args) -> fl::json {
+    remote->bind("bleStatus", [this](const fl::json& args) -> fl::json {
         fl::json response = fl::json::object();
         response.set("ble_active", mState->ble_server_active);
         fl::net::ble::StatusInfo info = fl::net::ble::queryStatus(mBleState);

--- a/examples/AutoResearch/AutoResearchRemoteBasicMethods.cpp
+++ b/examples/AutoResearch/AutoResearchRemoteBasicMethods.cpp
@@ -47,10 +47,10 @@
 #include "fl/fx/frame.h"
 
 
-void AutoResearchRemoteControl::bindBasicMethods() {
+void AutoResearchRemoteControl::bindBasicMethods(fl::Remote* remote) {
 
     // Register "status" function - device readiness check
-    mRemote->bind("status", [this](const fl::json& args) -> fl::json {
+    remote->bind("status", [this](const fl::json& args) -> fl::json {
         fl::json status = fl::json::object();
         status.set("ready", true);
         status.set("pinTx", static_cast<int64_t>(mState->pin_tx));
@@ -63,7 +63,7 @@ void AutoResearchRemoteControl::bindBasicMethods() {
     // the full OpenRPC schema. Our custom getSchema was causing stack overflow on ESP32-C6.
 
     // Register "debugTest" function - test RPC argument passing
-    mRemote->bind("debugTest", [](const fl::json& args) -> fl::json {
+    remote->bind("debugTest", [](const fl::json& args) -> fl::json {
         fl::json response = fl::json::object();
         response.set("success", true);
         response.set("received", args);
@@ -76,7 +76,7 @@ void AutoResearchRemoteControl::bindBasicMethods() {
     // device, and let the bootloader become reachable again.
     // Returns success BEFORE hanging so the caller sees the ACK; the hang
     // begins in the next iteration of the loop.
-    mRemote->bind("deliberateHang", [this](const fl::json& args) -> fl::json {
+    remote->bind("deliberateHang", [this](const fl::json& args) -> fl::json {
         (void)args;
         FL_WARN("[deliberateHang] watchdog test: spinning forever in 200 ms");
         mState->deliberate_hang_requested = true;
@@ -87,7 +87,7 @@ void AutoResearchRemoteControl::bindBasicMethods() {
     });
 
     // Register "drivers" function - list available drivers
-    mRemote->bind("drivers", [this](const fl::json& args) -> fl::json {
+    remote->bind("drivers", [this](const fl::json& args) -> fl::json {
         fl::json drivers = fl::json::array();
         for (fl::size i = 0; i < mState->drivers_available.size(); i++) {
             fl::json driver = fl::json::object();
@@ -105,7 +105,7 @@ void AutoResearchRemoteControl::bindBasicMethods() {
     // NOTE: runSingleTestImpl() may return early (error cases) without calling
     // sendAsyncResponse(). This wrapper ensures a response is ALWAYS sent so
     // the Python client never times out waiting 120s for a missing response.
-    mRemote->bind("runSingleTest", [this](const fl::json& args) -> fl::json {
+    remote->bind("runSingleTest", [this](const fl::json& args) -> fl::json {
         fl::json result = this->runSingleTestImpl(args);
         // If runSingleTestImpl returned a non-null response, it exited early without
         // calling sendAsyncResponse(). Send it now so the client gets a response.
@@ -120,7 +120,7 @@ void AutoResearchRemoteControl::bindBasicMethods() {
     //         pattern?: "MSB_LSB_A", iterations?: 1, timing?: "WS2812B-V5"}
     // Returns: {success, passed, duration_ms, show_duration_us, drivers: [...],
     //           rx_validation_attempted, rx_validation_passed}
-    mRemote->bind("runParallelTest", [this](const fl::json& args) -> fl::json {
+    remote->bind("runParallelTest", [this](const fl::json& args) -> fl::json {
         fl::json result = this->runParallelTestImpl(args);
         if (!result.is_null()) {
             mRemote->sendAsyncResponse("runParallelTest", result);
@@ -133,7 +133,7 @@ void AutoResearchRemoteControl::bindBasicMethods() {
     // ========================================================================
 
     // Register "ping" function - health check with timestamp
-    mRemote->bind("ping", [this](const fl::json& args) -> fl::json {
+    remote->bind("ping", [this](const fl::json& args) -> fl::json {
         uint32_t now = millis();
 
         fl::json response = fl::json::object();
@@ -145,7 +145,7 @@ void AutoResearchRemoteControl::bindBasicMethods() {
     });
 
     // TEST: Simple RPC without Serial to verify task context works
-    mRemote->bind("testNoSerial", [this](const fl::json& args) -> fl::json {
+    remote->bind("testNoSerial", [this](const fl::json& args) -> fl::json {
         fl::json response = fl::json::object();
         response.set("success", true);
         response.set("message", "RPC works from task context");

--- a/examples/AutoResearch/AutoResearchRemoteBenchmarkMethods.cpp
+++ b/examples/AutoResearch/AutoResearchRemoteBenchmarkMethods.cpp
@@ -47,9 +47,9 @@
 #include "fl/fx/frame.h"
 
 
-void AutoResearchRemoteControl::bindBenchmarkMethods() {
+void AutoResearchRemoteControl::bindBenchmarkMethods(fl::Remote* remote) {
     // Register "testSimd" function - run comprehensive SIMD test suite
-    mRemote->bind("testSimd", [](const fl::json& args) -> fl::json {
+    remote->bind("testSimd", [](const fl::json& args) -> fl::json {
         fl::json response = fl::json::object();
 
         // Run the full test suite and collect per-test results
@@ -84,7 +84,7 @@ void AutoResearchRemoteControl::bindBenchmarkMethods() {
     });
 
     // Register "testSimdBenchmark" - multiply speed benchmark
-    mRemote->bind("testSimdBenchmark", [](const fl::json& args) -> fl::json {
+    remote->bind("testSimdBenchmark", [](const fl::json& args) -> fl::json {
         fl::json response = fl::json::object();
 
         int iters = 10000;
@@ -144,7 +144,7 @@ void AutoResearchRemoteControl::bindBenchmarkMethods() {
     // (fl::perlin_i16_optimized::pnoise2d). Same workload that drives every
     // Animartrix frame — one Perlin lookup per output pixel, 16x16 grid
     // per iteration. Args: {iterations} (optional, default 100).
-    mRemote->bind("animartrixPerlinBench", [](const fl::json& args) -> fl::json {
+    remote->bind("animartrixPerlinBench", [](const fl::json& args) -> fl::json {
         fl::json response = fl::json::object();
 
         int iters = 100;
@@ -184,7 +184,7 @@ void AutoResearchRemoteControl::bindBenchmarkMethods() {
     // Compares nibble-LUT vs byte-LUT vs batched byte-LUT, and times the full
     // per-byte-position cost (expansion + 16-lane transpose) for both LUTs.
     // Args: {iterations} (optional, default 30000, max 200000)
-    mRemote->bind("wave8ExpandBenchmark", [](const fl::json& args) -> fl::json {
+    remote->bind("wave8ExpandBenchmark", [](const fl::json& args) -> fl::json {
         fl::json response = fl::json::object();
 
         int iters = 30000;
@@ -216,7 +216,7 @@ void AutoResearchRemoteControl::bindBenchmarkMethods() {
     // path which dispatches to wave8Transpose_16x4_bf1_pipe4 (BF1, #2559).
     // Drives N back-to-back FastLED.show() cycles and verifies each completes
     // within timeout. Returns per-iter timing so the host can diagnose stalls.
-    mRemote->bind("parlioStreamValidate", [this](const fl::json& args) -> fl::json {
+    remote->bind("parlioStreamValidate", [this](const fl::json& args) -> fl::json {
         fl::json response = fl::json::object();
         auto invalidArgs = [](const char* message) -> fl::json {
             fl::json error = fl::json::object();
@@ -364,7 +364,7 @@ void AutoResearchRemoteControl::bindBenchmarkMethods() {
     // {scratch, output} in SRAM/PSRAM (4 combinations). Answers the PSRAM
     // hypothesis + ISR-streaming feasibility on the byte-LUT path (#2526
     // follow-up).
-    mRemote->bind("parlioEncodeBenchmark", [](const fl::json& args) -> fl::json {
+    remote->bind("parlioEncodeBenchmark", [](const fl::json& args) -> fl::json {
         fl::json response = fl::json::object();
 
         int iters = 12000;

--- a/examples/AutoResearch/AutoResearchRemoteCoroutineMethods.cpp
+++ b/examples/AutoResearch/AutoResearchRemoteCoroutineMethods.cpp
@@ -47,13 +47,13 @@
 #include "fl/fx/frame.h"
 
 
-void AutoResearchRemoteControl::bindCoroutineMethods() {
+void AutoResearchRemoteControl::bindCoroutineMethods(fl::Remote* remote) {
     // ========================================================================
     // Coroutine Tests - fl::task::coroutine() and fl::task::await()
     // ========================================================================
 
     // Test: Basic coroutine creation and completion
-    mRemote->bind("testCoroutineBasic", [](const fl::json& args) -> fl::json {
+    remote->bind("testCoroutineBasic", [](const fl::json& args) -> fl::json {
         (void)args;
         fl::json r = fl::json::object();
 
@@ -84,7 +84,7 @@ void AutoResearchRemoteControl::bindCoroutineMethods() {
     });
 
     // Test: Task stop() while running
-    mRemote->bind("testCoroutineStop", [](const fl::json& args) -> fl::json {
+    remote->bind("testCoroutineStop", [](const fl::json& args) -> fl::json {
         (void)args;
         fl::json r = fl::json::object();
 
@@ -119,7 +119,7 @@ void AutoResearchRemoteControl::bindCoroutineMethods() {
     });
 
     // Test: Multiple concurrent coroutines
-    mRemote->bind("testCoroutineConcurrent", [](const fl::json& args) -> fl::json {
+    remote->bind("testCoroutineConcurrent", [](const fl::json& args) -> fl::json {
         (void)args;
         fl::json r = fl::json::object();
 
@@ -166,7 +166,7 @@ void AutoResearchRemoteControl::bindCoroutineMethods() {
     // Test: Consumer coroutine awaits promise, producer coroutine fulfills it.
     // Verifies fl::task::await() truly blocks until the producer resolves the promise.
     // Main thread does NOT touch the promise — only the producer coroutine does.
-    mRemote->bind("testCoroutineAwait", [](const fl::json& args) -> fl::json {
+    remote->bind("testCoroutineAwait", [](const fl::json& args) -> fl::json {
         (void)args;
         fl::json r = fl::json::object();
 
@@ -232,7 +232,7 @@ void AutoResearchRemoteControl::bindCoroutineMethods() {
 
     // Test: Consumer coroutine awaits promise, producer coroutine rejects it.
     // Verifies that fl::task::await() properly propagates errors from producer.
-    mRemote->bind("testCoroutineAwaitError", [](const fl::json& args) -> fl::json {
+    remote->bind("testCoroutineAwaitError", [](const fl::json& args) -> fl::json {
         (void)args;
         fl::json r = fl::json::object();
 
@@ -282,7 +282,7 @@ void AutoResearchRemoteControl::bindCoroutineMethods() {
     // Test: Promise then/catch_ callbacks fire correctly when fulfilled by a coroutine.
     // The promise is created with .then() and .catch_() callbacks attached BEFORE
     // the producer coroutine fulfills it, verifying callback dispatch works.
-    mRemote->bind("testCoroutinePromiseCallbacks", [](const fl::json& args) -> fl::json {
+    remote->bind("testCoroutinePromiseCallbacks", [](const fl::json& args) -> fl::json {
         (void)args;
         fl::json r = fl::json::object();
 
@@ -331,7 +331,7 @@ void AutoResearchRemoteControl::bindCoroutineMethods() {
     });
 
     // Test: Promise catch_ callback fires on rejection by a coroutine.
-    mRemote->bind("testCoroutinePromiseCatchCallback", [](const fl::json& args) -> fl::json {
+    remote->bind("testCoroutinePromiseCatchCallback", [](const fl::json& args) -> fl::json {
         (void)args;
         fl::json r = fl::json::object();
 
@@ -376,7 +376,7 @@ void AutoResearchRemoteControl::bindCoroutineMethods() {
 
     // Test: Pipeline of 3 coroutines passing data through promises.
     // coroutine A produces value -> promise1 -> coroutine B transforms -> promise2 -> coroutine C consumes
-    mRemote->bind("testCoroutineChainedAwait", [](const fl::json& args) -> fl::json {
+    remote->bind("testCoroutineChainedAwait", [](const fl::json& args) -> fl::json {
         (void)args;
         fl::json r = fl::json::object();
 
@@ -444,7 +444,7 @@ void AutoResearchRemoteControl::bindCoroutineMethods() {
     });
 
     // Run all coroutine tests sequentially
-    mRemote->bind("testCoroutineAll", [this](const fl::json& args) -> fl::json {
+    remote->bind("testCoroutineAll", [this](const fl::json& args) -> fl::json {
         (void)args;
         fl::json r = fl::json::object();
 

--- a/examples/AutoResearch/AutoResearchRemoteFlexioMethods.cpp
+++ b/examples/AutoResearch/AutoResearchRemoteFlexioMethods.cpp
@@ -47,7 +47,7 @@
 #include "fl/fx/frame.h"
 
 
-void AutoResearchRemoteControl::bindFlexioMethods() {
+void AutoResearchRemoteControl::bindFlexioMethods(fl::Remote* remote) {
     // Register "flexioRxBenchmark" — square-wave validation for the new
     // FlexIO RX backend (Phase 2 of FastLED#2764).
     //
@@ -67,7 +67,7 @@ void AutoResearchRemoteControl::bindFlexioMethods() {
     // Teensy-4-only because FLEXIO1 is iMXRT1062-specific. Other platforms
     // get a clean "not supported" response so the RPC harness can still
     // round-trip.
-    mRemote->bind("flexioRxBenchmark", [this](const fl::json& args) -> fl::json {
+    remote->bind("flexioRxBenchmark", [this](const fl::json& args) -> fl::json {
         fl::json response = fl::json::object();
 #if !defined(FL_IS_TEENSY_4X)
         (void)args;
@@ -230,7 +230,7 @@ void AutoResearchRemoteControl::bindFlexioMethods() {
     //
     // Teensy-4-only — FLEXIO1 is iMXRT1062-specific. ObjectFLED also relies
     // on Teensy 4-core APIs, so non-Teensy builds return `PlatformNotSupported`.
-    mRemote->bind("flexioObjectFledTest", [this](const fl::json& args) -> fl::json {
+    remote->bind("flexioObjectFledTest", [this](const fl::json& args) -> fl::json {
         fl::json response = fl::json::object();
 #if !defined(FL_IS_TEENSY_4X)
         (void)args;
@@ -446,7 +446,7 @@ void AutoResearchRemoteControl::bindFlexioMethods() {
     //     capture_buffer_first8_hex: [...], notes }
     //
     // Teensy-4-only.
-    mRemote->bind("flexioRxLoopbackPing", [this](const fl::json& args) -> fl::json {
+    remote->bind("flexioRxLoopbackPing", [this](const fl::json& args) -> fl::json {
         fl::json response = fl::json::object();
 #if !defined(FL_IS_TEENSY_4X)
         (void)args;

--- a/examples/AutoResearch/AutoResearchRemoteGpioMethods.cpp
+++ b/examples/AutoResearch/AutoResearchRemoteGpioMethods.cpp
@@ -47,9 +47,9 @@
 #include "fl/fx/frame.h"
 
 
-void AutoResearchRemoteControl::bindGpioMethods() {
+void AutoResearchRemoteControl::bindGpioMethods(fl::Remote* remote) {
     // Register "setDebug" function - enable/disable runtime debug logging
-    mRemote->bind("setDebug", [this](const fl::json& args) -> fl::json {
+    remote->bind("setDebug", [this](const fl::json& args) -> fl::json {
         fl::json response = fl::json::object();
 
         // Validate args: expects [enabled: bool]
@@ -79,7 +79,7 @@ void AutoResearchRemoteControl::bindGpioMethods() {
 
     // Register "testGpioConnection" function - test if TX and RX pins are electrically connected
     // This is a pre-test to diagnose hardware connection issues before running validation
-    mRemote->bind("testGpioConnection", [](const fl::json& args) -> fl::json {
+    remote->bind("testGpioConnection", [](const fl::json& args) -> fl::json {
         fl::json response = fl::json::object();
 
         // Validate args: expects [txPin, rxPin]
@@ -145,7 +145,7 @@ void AutoResearchRemoteControl::bindGpioMethods() {
     // ========================================================================
 
     // Register "getPins" function - query current and default pin configuration
-    mRemote->bind("getPins", [this](const fl::json& args) -> fl::json {
+    remote->bind("getPins", [this](const fl::json& args) -> fl::json {
         fl::json response = fl::json::object();
         response.set("success", true);
         response.set("txPin", static_cast<int64_t>(mState->pin_tx));
@@ -172,7 +172,7 @@ void AutoResearchRemoteControl::bindGpioMethods() {
     });
 
     // Register "setTxPin" function - set TX pin (regenerates test cases)
-    mRemote->bind("setTxPin", [this](const fl::json& args) -> fl::json {
+    remote->bind("setTxPin", [this](const fl::json& args) -> fl::json {
         fl::json response = fl::json::object();
 
         if (!args.is_array() || args.size() != 1 || !args[0].is_int()) {
@@ -202,7 +202,7 @@ void AutoResearchRemoteControl::bindGpioMethods() {
     });
 
     // Register "setRxPin" function - set RX pin (recreates RX channel)
-    mRemote->bind("setRxPin", [this](const fl::json& args) -> fl::json {
+    remote->bind("setRxPin", [this](const fl::json& args) -> fl::json {
         fl::json response = fl::json::object();
 
         if (!args.is_array() || args.size() != 1 || !args[0].is_int()) {
@@ -257,7 +257,7 @@ void AutoResearchRemoteControl::bindGpioMethods() {
     });
 
     // Register "setPins" function - set both TX and RX pins atomically
-    mRemote->bind("setPins", [this](const fl::json& args) -> fl::json {
+    remote->bind("setPins", [this](const fl::json& args) -> fl::json {
         fl::json response = fl::json::object();
 
         // Accept either {txPin, rxPin} object or [txPin, rxPin] array
@@ -349,12 +349,12 @@ void AutoResearchRemoteControl::bindGpioMethods() {
 
     // Register "findConnectedPins" function - probe adjacent pin pairs to find a jumper wire connection
     // This allows automatic discovery of TX/RX pin pair without requiring user to specify them
-    mRemote->bind("findConnectedPins", [this](const fl::json& args) -> fl::json {
+    remote->bind("findConnectedPins", [this](const fl::json& args) -> fl::json {
         return findConnectedPinsImpl(args);
     });
 
     // Register "help" function - list all RPC functions with descriptions
-    mRemote->bind("help", [this](const fl::json& args) -> fl::json {
+    remote->bind("help", [this](const fl::json& args) -> fl::json {
         fl::json functions = fl::json::array();
 
         // Phase 1: Basic Control

--- a/examples/AutoResearch/AutoResearchRemotePerfMethods.cpp
+++ b/examples/AutoResearch/AutoResearchRemotePerfMethods.cpp
@@ -47,7 +47,7 @@
 #include "fl/fx/frame.h"
 
 
-void AutoResearchRemoteControl::bindPerfMethods() {
+void AutoResearchRemoteControl::bindPerfMethods(fl::Remote* remote) {
     // ====== AutoResearch perf-instrumentation sanity probes ======
     // Task 2 of meta #3113. Three probes verify autoresearch timing
     // produces trustworthy data BEFORE we use it to gate optimizations.
@@ -57,7 +57,7 @@ void AutoResearchRemoteControl::bindPerfMethods() {
     // Probe 2a: memcpy throughput. Caller invokes with { bytes,
     // iterations }; returns MB/s on SRAM. Host compares vs per-platform
     // vendor floor (e.g. ESP32-S3 ~175 MB/s) before trusting wave2dPerf.
-    mRemote->bind("perfProbeMemcpy", [](const fl::json& args) -> fl::json {
+    remote->bind("perfProbeMemcpy", [](const fl::json& args) -> fl::json {
         int bytes = 4096;
         int iterations = 1000;
         if (args.is_array() && args.size() >= 1 && args[0].is_object()) {
@@ -102,7 +102,7 @@ void AutoResearchRemoteControl::bindPerfMethods() {
     // compiler optimizing the loop away. Host computes
     // (total_us * cpu_mhz / iterations) and checks [1.0, 2.5]
     // cycles-per-nop. Out-of-band → timer broken or IRQ jitter.
-    mRemote->bind("perfProbeNop", [](const fl::json& args) -> fl::json {
+    remote->bind("perfProbeNop", [](const fl::json& args) -> fl::json {
         int iterations = 100000;
         if (args.is_array() && args.size() >= 1 && args[0].is_object()) {
             const fl::json &cfg = args[0];
@@ -141,7 +141,7 @@ void AutoResearchRemoteControl::bindPerfMethods() {
     // N times at a fixed config, reports mean + std-dev. Host checks
     // std_dev/mean < 5%; higher → IRQ noise or RPC framing jitter is
     // contaminating wave2dPerf, mark UNTRUSTED.
-    mRemote->bind("perfProbeRepeat", [](const fl::json& args) -> fl::json {
+    remote->bind("perfProbeRepeat", [](const fl::json& args) -> fl::json {
         int W = 16;
         int H = 16;
         int iterations = 50;
@@ -214,7 +214,7 @@ void AutoResearchRemoteControl::bindPerfMethods() {
     // sum every cell into a sink) so the gap between the two reveals
     // compute vs memory cost — critical for the ESP32-S3 PSRAM-vs-SRAM
     // analysis in sibling issue #3114.
-    mRemote->bind("wave2dPerf", [](const fl::json& args) -> fl::json {
+    remote->bind("wave2dPerf", [](const fl::json& args) -> fl::json {
         // Defaults sized so the test runs in a sensible budget on small
         // platforms (32x32 / 100 iters ~= 100-500 ms on M4-class).
         int W = 32;


### PR DESCRIPTION
Follow-up to #3187. Makes the bind target explicit in the signature instead of implicit via `mRemote`.

**Before:** `void bindBasicMethods();` (lambdas captured `[this]` and called `mRemote->bind(...)`)

**After:** `void bindBasicMethods(fl::Remote* remote);` (lambdas still capture `[this]` for state/method access; binding goes through the parameter)

**Mechanical sweep:** 50 `mRemote->bind` sites rewritten to `remote->bind` across 7 binder files. Header signatures updated. `registerFunctions()` shell updated to pass `mRemote.get()` to each call.

**Why:**
- The bind target is now obvious from the signature alone
- Same partitioning could serve `mBleRemote` (or any future transport) without code duplication
- Easier to reason about — no implicit `this->mRemote` coupling

**Verified:** `bash compile wasm --examples AutoResearch` — success (48.42 s total).

Generated with Claude Code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated remote control method binding to accept explicit remote instances instead of relying on implicit internal references, improving flexibility in handling remote communication configurations across multiple binding method groups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->