### PR TITLE
Migrate logging macros to printf style

### DIFF
--- a/ci/lint_cpp/legacy_log_macro_checker.py
+++ b/ci/lint_cpp/legacy_log_macro_checker.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Checker that bans legacy stream-style FastLED logging macros in src/.
+
+FastLED logging call sites should use the printf-style `_F` variants so the
+formatter work is centralized in `fl::printf` instead of instantiating a fresh
+`fl::sstream` operator chain at every call site.
+"""
+
+import re
+from pathlib import Path
+
+from ci.util.check_files import FileContent, FileContentChecker
+from ci.util.paths import PROJECT_ROOT
+
+
+SRC_ROOT = PROJECT_ROOT / "src"
+LOG_HEADER = (SRC_ROOT / "fl" / "log" / "log.h").resolve()
+
+LEGACY_MACROS = (
+    "FL_WARN",
+    "FL_WARN_IF",
+    "FL_WARN_ONCE",
+    "FL_WARN_EVERY",
+    "FL_WARN_FMT",
+    "FL_WARN_FMT_IF",
+    "FL_PRINT",
+    "FL_PRINT_EVERY",
+    "FL_DBG",
+    "FL_DBG_IF",
+    "FL_DBG_EVERY",
+    "FL_ERROR",
+    "FL_ERROR_IF",
+    "FL_LOG_SPI",
+    "FL_LOG_RMT",
+    "FL_LOG_PARLIO",
+    "FL_LOG_AUDIO",
+    "FL_LOG_INTERRUPT",
+    "FL_LOG_FLEXIO",
+    "FL_LOG_OBJECTFLED",
+    "FL_LOG_ASYNC",
+    "FL_LOG_SPI_ASYNC_MAIN",
+    "FL_LOG_RMT_ASYNC_MAIN",
+    "FL_LOG_PARLIO_ASYNC_MAIN",
+    "FL_LOG_AUDIO_ASYNC_MAIN",
+    "FL_LOG_INTERRUPT_ASYNC_MAIN",
+    "FL_LOG_FLEXIO_ASYNC_MAIN",
+    "FL_LOG_OBJECTFLED_ASYNC_MAIN",
+)
+
+_LEGACY_PATTERN = re.compile(
+    r"\b("
+    + "|".join(re.escape(name) for name in sorted(LEGACY_MACROS, key=len, reverse=True))
+    + r")\s*\("
+)
+
+
+class LegacyLogMacroChecker(FileContentChecker):
+    """Bans legacy stream-style logging macro calls inside src/."""
+
+    def __init__(self):
+        self.violations: dict[str, list[tuple[int, str]]] = {}
+
+    def should_process_file(self, file_path: str) -> bool:
+        path = file_path.replace("\\", "/")
+        if not file_path.startswith(str(SRC_ROOT)):
+            return False
+        if not file_path.endswith((".cpp", ".h", ".hpp")):
+            return False
+        if "/third_party/" in path:
+            return False
+        if Path(file_path).resolve() == LOG_HEADER:
+            return False
+        return True
+
+    def check_file_content(self, file_content: FileContent) -> list[str]:
+        violations: list[tuple[int, str]] = []
+        in_block_comment = False
+
+        for line_number, line in enumerate(file_content.lines, 1):
+            stripped = line.strip()
+            if in_block_comment:
+                if "*/" in line:
+                    in_block_comment = False
+                continue
+            if "/*" in line and "*/" not in line:
+                in_block_comment = True
+                continue
+            if stripped.startswith("//") or stripped.startswith("#define"):
+                continue
+
+            code = line.split("//")[0]
+            match = _LEGACY_PATTERN.search(code)
+            if not match:
+                continue
+            macro = match.group(1)
+            replacement = _replacement_for(macro)
+            violations.append(
+                (
+                    line_number,
+                    f"{line.rstrip()}  [use {replacement} instead of {macro}]",
+                )
+            )
+
+        if violations:
+            self.violations[file_content.path] = violations
+
+        return []
+
+
+def _replacement_for(macro: str) -> str:
+    if macro.endswith("_ASYNC_MAIN"):
+        return f"{macro}_F"
+    if macro == "FL_LOG_ASYNC":
+        return "FL_LOG_ASYNC_F"
+    if macro.endswith("_FMT_IF"):
+        return macro.replace("_FMT_IF", "_F_IF")
+    if macro.endswith("_FMT"):
+        return macro.replace("_FMT", "_F")
+    if macro.endswith("_IF"):
+        return macro.replace("_IF", "_F_IF")
+    if macro.endswith("_ONCE"):
+        return macro.replace("_ONCE", "_F_ONCE")
+    if macro.endswith("_EVERY"):
+        return macro.replace("_EVERY", "_F_EVERY")
+    return f"{macro}_F"
+
+
+def main() -> None:
+    from ci.util.check_files import run_checker_standalone
+
+    checker = LegacyLogMacroChecker()
+    run_checker_standalone(
+        checker,
+        [str(SRC_ROOT)],
+        "Found legacy stream-style FastLED logging macros in src/ "
+        "(use FL_*_F printf-style macros)",
+        extensions=[".cpp", ".h", ".hpp"],
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/ci/lint_cpp/run_all_checkers.py
+++ b/ci/lint_cpp/run_all_checkers.py
@@ -52,6 +52,7 @@ from ci.lint_cpp.include_after_namespace_checker import IncludeAfterNamespaceChe
 from ci.lint_cpp.include_paths_checker import IncludePathsChecker
 from ci.lint_cpp.is_header_include_checker import IsHeaderIncludeChecker
 from ci.lint_cpp.iwyu_pragma_block_checker import IwyuPragmaBlockChecker
+from ci.lint_cpp.legacy_log_macro_checker import LegacyLogMacroChecker
 from ci.lint_cpp.logging_in_iram_checker import LoggingInIramChecker
 from ci.lint_cpp.member_style_checker import MemberStyleChecker
 from ci.lint_cpp.namespace_platforms_checker import NamespacePlatformsChecker
@@ -187,6 +188,7 @@ def create_checkers(
         NumericLimitMacroChecker(),
         StaticInHeaderChecker(),
         LoggingInIramChecker(),
+        LegacyLogMacroChecker(),
         PlatformIncludesChecker(),
         PlatformTrampolineChecker(),  # Enforce trampoline architecture in src/fl/** and root src/
         WeakAttributeChecker(),

--- a/ci/lint_cpp/test_path_structure_checker.py
+++ b/ci/lint_cpp/test_path_structure_checker.py
@@ -86,6 +86,30 @@ EXCLUDED_TEST_FILES = {
 }
 
 
+def _matching_source_exists(test_name_no_ext: Path) -> bool:
+    """Return True when a test stem maps to an existing source artifact."""
+    return (
+        (SRC_ROOT / test_name_no_ext.with_suffix(".h")).exists()
+        or (SRC_ROOT / test_name_no_ext.with_suffix(".hpp")).exists()
+        or (SRC_ROOT / (str(test_name_no_ext) + ".cpp.hpp")).exists()
+    )
+
+
+def _split_test_source_exists(test_name_no_ext: Path) -> bool:
+    """Allow shard-style tests whose suffix maps back to an umbrella header.
+
+    Tests such as tests/fl/stl/string_append_concat.cpp still test
+    src/fl/stl/string.h.  Walk trailing underscore suffixes until either an
+    existing source file is found or no suffix remains.
+    """
+    candidate = test_name_no_ext
+    while "_" in candidate.name:
+        candidate = candidate.with_name(candidate.name.rsplit("_", 1)[0])
+        if _matching_source_exists(candidate):
+            return True
+    return False
+
+
 class TestPathStructureChecker(FileContentChecker):
     """Checker class for test file path structure validation."""
 
@@ -152,11 +176,12 @@ class TestPathStructureChecker(FileContentChecker):
         expected_source_cpp_hpp = SRC_ROOT / (str(test_name_no_ext) + ".cpp.hpp")
 
         # If matching source file exists at the expected location, no issue
-        if (
-            expected_source_h.exists()
-            or expected_source_hpp.exists()
-            or expected_source_cpp_hpp.exists()
-        ):
+        if _matching_source_exists(test_name_no_ext):
+            return []
+
+        # Split/sharded tests may add descriptive suffixes to a real umbrella
+        # source name, e.g. string_append_concat.cpp -> string.h.
+        if _split_test_source_exists(test_name_no_ext):
             return []
 
         # Check if file has "// ok standalone" comment in first few lines

--- a/ci/lint_cpp_rs/src/checkers/test_structure.rs
+++ b/ci/lint_cpp_rs/src/checkers/test_structure.rs
@@ -101,6 +101,30 @@ impl FileContentChecker for TestIncludePathsChecker {
 
 struct TestPathStructureChecker;
 
+fn test_path_matching_source_exists(root_prefix: &str, test_name_no_ext: &str) -> bool {
+    let expected_h = format!("src/{test_name_no_ext}.h");
+    let expected_hpp = format!("src/{test_name_no_ext}.hpp");
+    let expected_cpp_hpp = format!("src/{test_name_no_ext}.cpp.hpp");
+    join_project_path(root_prefix, &expected_h).exists()
+        || join_project_path(root_prefix, &expected_hpp).exists()
+        || join_project_path(root_prefix, &expected_cpp_hpp).exists()
+}
+
+fn test_path_split_source_exists(root_prefix: &str, test_name_no_ext: &str) -> bool {
+    let mut candidate = test_name_no_ext.to_string();
+    while let Some((prefix, suffix)) = candidate.rsplit_once('_') {
+        let slash_in_suffix = suffix.contains('/');
+        if slash_in_suffix || prefix.is_empty() {
+            break;
+        }
+        candidate = prefix.to_string();
+        if test_path_matching_source_exists(root_prefix, &candidate) {
+            return true;
+        }
+    }
+    false
+}
+
 impl FileContentChecker for TestPathStructureChecker {
     fn name(&self) -> &'static str {
         "TestPathStructureChecker"
@@ -141,10 +165,10 @@ impl FileContentChecker for TestPathStructureChecker {
         let expected_h = format!("src/{test_name_no_ext}.h");
         let expected_hpp = format!("src/{test_name_no_ext}.hpp");
         let expected_cpp_hpp = format!("src/{test_name_no_ext}.cpp.hpp");
-        if join_project_path(&root_prefix, &expected_h).exists()
-            || join_project_path(&root_prefix, &expected_hpp).exists()
-            || join_project_path(&root_prefix, &expected_cpp_hpp).exists()
-        {
+        if test_path_matching_source_exists(&root_prefix, &test_name_no_ext) {
+            return Vec::new();
+        }
+        if test_path_split_source_exists(&root_prefix, &test_name_no_ext) {
             return Vec::new();
         }
         if file_content
@@ -589,4 +613,3 @@ impl FileContentChecker for NoexceptSpecialMembersChecker {
         violations
     }
 }
-

--- a/ci/tools/migrate_fl_logs.py
+++ b/ci/tools/migrate_fl_logs.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+"""Mechanical migration helper for legacy FastLED logging macros.
+
+This handles straightforward stream chains by converting them to printf-style
+`FL_*_F` calls with `%s` placeholders. It intentionally skips harder cases
+such as stream manipulators so the linter can report them for manual cleanup.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SRC = ROOT / "src"
+CPP_EXTS = {".cpp", ".h", ".hpp"}
+
+MACROS: dict[str, str] = {
+    "FL_WARN": "FL_WARN_F",
+    "FL_WARN_IF": "FL_WARN_F_IF",
+    "FL_WARN_ONCE": "FL_WARN_F_ONCE",
+    "FL_WARN_EVERY": "FL_WARN_F_EVERY",
+    "FL_WARN_FMT": "FL_WARN_F",
+    "FL_WARN_FMT_IF": "FL_WARN_F_IF",
+    "FL_PRINT": "FL_PRINT_F",
+    "FL_PRINT_EVERY": "FL_PRINT_F_EVERY",
+    "FL_DBG": "FL_DBG_F",
+    "FL_DBG_IF": "FL_DBG_F_IF",
+    "FL_DBG_EVERY": "FL_DBG_F_EVERY",
+    "FL_ERROR": "FL_ERROR_F",
+    "FL_ERROR_IF": "FL_ERROR_F_IF",
+    "FL_LOG_SPI": "FL_LOG_SPI_F",
+    "FL_LOG_RMT": "FL_LOG_RMT_F",
+    "FL_LOG_PARLIO": "FL_LOG_PARLIO_F",
+    "FL_LOG_AUDIO": "FL_LOG_AUDIO_F",
+    "FL_LOG_INTERRUPT": "FL_LOG_INTERRUPT_F",
+    "FL_LOG_FLEXIO": "FL_LOG_FLEXIO_F",
+    "FL_LOG_OBJECTFLED": "FL_LOG_OBJECTFLED_F",
+    "FL_LOG_ASYNC": "FL_LOG_ASYNC_F",
+    "FL_LOG_SPI_ASYNC_MAIN": "FL_LOG_SPI_ASYNC_MAIN_F",
+    "FL_LOG_RMT_ASYNC_MAIN": "FL_LOG_RMT_ASYNC_MAIN_F",
+    "FL_LOG_PARLIO_ASYNC_MAIN": "FL_LOG_PARLIO_ASYNC_MAIN_F",
+    "FL_LOG_AUDIO_ASYNC_MAIN": "FL_LOG_AUDIO_ASYNC_MAIN_F",
+    "FL_LOG_INTERRUPT_ASYNC_MAIN": "FL_LOG_INTERRUPT_ASYNC_MAIN_F",
+    "FL_LOG_FLEXIO_ASYNC_MAIN": "FL_LOG_FLEXIO_ASYNC_MAIN_F",
+    "FL_LOG_OBJECTFLED_ASYNC_MAIN": "FL_LOG_OBJECTFLED_ASYNC_MAIN_F",
+}
+
+MACRO_RE = re.compile(
+    r"\b("
+    + "|".join(re.escape(name) for name in sorted(MACROS, key=len, reverse=True))
+    + r")\s*\("
+)
+
+
+def iter_files(paths: list[Path]) -> list[Path]:
+    files: list[Path] = []
+    for path in paths:
+        if path.is_file() and path.suffix in CPP_EXTS:
+            files.append(path)
+            continue
+        if path.is_dir():
+            files.extend(p for p in path.rglob("*") if p.suffix in CPP_EXTS)
+    return sorted(set(files))
+
+
+def find_matching_paren(text: str, open_index: int) -> int:
+    depth = 0
+    quote: str | None = None
+    escape = False
+    in_line_comment = False
+    in_block_comment = False
+    i = open_index
+    while i < len(text):
+        ch = text[i]
+        nxt = text[i + 1] if i + 1 < len(text) else ""
+        if in_line_comment:
+            if ch == "\n":
+                in_line_comment = False
+            i += 1
+            continue
+        if in_block_comment:
+            if ch == "*" and nxt == "/":
+                in_block_comment = False
+                i += 2
+                continue
+            i += 1
+            continue
+        if quote:
+            if escape:
+                escape = False
+            elif ch == "\\":
+                escape = True
+            elif ch == quote:
+                quote = None
+            i += 1
+            continue
+        if ch == "/" and nxt == "/":
+            in_line_comment = True
+            i += 2
+            continue
+        if ch == "/" and nxt == "*":
+            in_block_comment = True
+            i += 2
+            continue
+        if ch in {"'", '"'}:
+            quote = ch
+            i += 1
+            continue
+        if ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+            if depth == 0:
+                return i
+        i += 1
+    return -1
+
+
+def split_top_level(text: str, delimiter: str) -> list[str]:
+    parts: list[str] = []
+    start = 0
+    depth = 0
+    quote: str | None = None
+    escape = False
+    i = 0
+    while i < len(text):
+        ch = text[i]
+        if quote:
+            if escape:
+                escape = False
+            elif ch == "\\":
+                escape = True
+            elif ch == quote:
+                quote = None
+            i += 1
+            continue
+        if ch in {"'", '"'}:
+            quote = ch
+            i += 1
+            continue
+        if depth == 0 and text.startswith(delimiter, i):
+            parts.append(text[start:i].strip())
+            i += len(delimiter)
+            start = i
+            continue
+        if ch in "([{":
+            depth += 1
+        elif ch in ")]}":
+            depth = max(0, depth - 1)
+        i += 1
+    parts.append(text[start:].strip())
+    return parts
+
+
+def string_literal_payload(expr: str) -> str | None:
+    expr = expr.strip()
+    if len(expr) < 2 or expr[0] != '"' or expr[-1] != '"':
+        return None
+    if len(expr) >= 3 and expr[-2] == "\\":
+        return None
+    return expr[1:-1]
+
+
+def convert_stream_expr(expr: str) -> str | None:
+    expr = expr.strip()
+    if "fl::hex" in expr or "fl::dec" in expr:
+        return None
+    parts = split_top_level(expr, "<<")
+    if not parts:
+        return None
+
+    fmt_parts: list[str] = []
+    args: list[str] = []
+    for part in parts:
+        payload = string_literal_payload(part)
+        if payload is not None:
+            fmt_parts.append(payload)
+        else:
+            fmt_parts.append("%s")
+            args.append(part)
+
+    fmt = '"' + "".join(fmt_parts).replace('"', '\\"') + '"'
+    if args:
+        return fmt + ", " + ", ".join(args)
+    return fmt
+
+
+def convert_args(macro: str, args_text: str) -> str | None:
+    if macro in {"FL_WARN_IF", "FL_WARN_FMT_IF", "FL_DBG_IF", "FL_ERROR_IF"}:
+        args = split_top_level(args_text, ",")
+        if len(args) != 2:
+            return None
+        converted = convert_stream_expr(args[1])
+        return f"{args[0]}, {converted}" if converted else None
+    if macro in {"FL_WARN_EVERY", "FL_PRINT_EVERY", "FL_DBG_EVERY"}:
+        args = split_top_level(args_text, ",")
+        if len(args) != 2:
+            return None
+        converted = convert_stream_expr(args[1])
+        return f"{args[0]}, {converted}" if converted else None
+    if macro == "FL_LOG_ASYNC":
+        args = split_top_level(args_text, ",")
+        if len(args) != 2:
+            return None
+        converted = convert_stream_expr(args[1])
+        return f"{args[0]}, {converted}" if converted else None
+    converted = convert_stream_expr(args_text)
+    return converted
+
+
+def convert_file(path: Path) -> int:
+    text = path.read_text(encoding="utf-8")
+    output: list[str] = []
+    cursor = 0
+    changes = 0
+    for match in MACRO_RE.finditer(text):
+        macro = match.group(1)
+        if macro.endswith("_F"):
+            continue
+        line_start = text.rfind("\n", 0, match.start()) + 1
+        line_prefix = text[line_start : match.start()]
+        if line_prefix.lstrip().startswith("//") or line_prefix.lstrip().startswith(
+            "#define"
+        ):
+            continue
+        open_paren = text.find("(", match.start())
+        close_paren = find_matching_paren(text, open_paren)
+        if close_paren < 0:
+            continue
+        args_text = text[open_paren + 1 : close_paren]
+        converted_args = convert_args(macro, args_text)
+        if converted_args is None:
+            continue
+        output.append(text[cursor : match.start()])
+        output.append(f"{MACROS[macro]}({converted_args})")
+        cursor = close_paren + 1
+        changes += 1
+    if changes:
+        output.append(text[cursor:])
+        path.write_text("".join(output), encoding="utf-8", newline="")
+    return changes
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("paths", nargs="*", default=[str(SRC)])
+    args = parser.parse_args()
+    total = 0
+    for path in iter_files([Path(p) for p in args.paths]):
+        if path.resolve() == (SRC / "fl" / "log" / "log.h").resolve():
+            continue
+        total += convert_file(path)
+    print(f"Converted {total} legacy log call(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/AutoResearch/AutoResearchRemoteBenchmarkMethods.cpp
+++ b/examples/AutoResearch/AutoResearchRemoteBenchmarkMethods.cpp
@@ -23,6 +23,7 @@
 #include "Common.h"
 #include "AutoResearchTest.h"
 #include "AutoResearchHelpers.h"
+#include "fl/stl/compiler_control.h"
 #include "fl/stl/sstream.h"
 #include "fl/stl/unique_ptr.h"
 #include "fl/stl/optional.h"
@@ -87,7 +88,7 @@ void AutoResearchRemoteControl::bindBenchmarkMethods(fl::Remote& remote) {
         }
         const fl::u32 t0 = fl::micros();
         for (int i = 0; i < iterations; ++i) {
-            memcpy(dst_buf, src_buf, bytes);
+            FL_BUILTIN_MEMCPY(dst_buf, src_buf, bytes);
         }
         const fl::u32 t1 = fl::micros();
         const fl::u32 total_us = t1 - t0;

--- a/src/FastLED.cpp.hpp
+++ b/src/FastLED.cpp.hpp
@@ -1,8 +1,8 @@
-#define FASTLED_INTERNAL
+﻿#define FASTLED_INTERNAL
 // IWYU pragma: begin_keep
 #include <stdint.h>
 // IWYU pragma: end_keep  // for u8, u32, u16
-#include "FastLED.h"
+#include "FastLED.h"  // ok include: this file implements CFastLED, declared in FastLED.h
 #include "fl/system/engine_events.h"
 #include "fl/stl/compiler_control.h"
 #include "fl/channels/all_drivers.h"
@@ -618,7 +618,7 @@ fl::ChannelPtr CFastLED::add(const fl::ChannelConfig& config) {
     // selection mode. To make sure `cfg.options.mBus` (or priority dispatch
     // when `mBus == Bus::AUTO`) can actually find the requested driver at
     // runtime, we eagerly enroll every driver available on this platform.
-    // That trades binary size for ergonomics — the user wanted runtime
+    // That trades binary size for ergonomics â€” the user wanted runtime
     // selection, so they get runtime selection.
     //
     // For minimum binary size, callers should use the compile-time path:
@@ -629,7 +629,7 @@ fl::ChannelPtr CFastLED::add(const fl::ChannelConfig& config) {
     // The warning fires at most once per process (FL_WARN_ONCE) and can be
     // disabled with `-DFASTLED_SUPPRESS_RUNTIME_DRIVER_WARNING`.
     #ifndef FASTLED_SUPPRESS_RUNTIME_DRIVER_WARNING
-    FL_WARN_ONCE("FastLED.add(cfg): runtime-selection mode — enrolling every "
+    FL_WARN_F_ONCE("FastLED.add(cfg): runtime-selection mode â€” enrolling every "
                  "available driver via fl::enableAllDrivers(). For minimum "
                  "binary size, prefer FastLED.addLeds<CHIPSET, PIN, ORDER, "
                  "fl::Bus::X>(leds, n) which links only the named driver. "

--- a/src/FastLED.h
+++ b/src/FastLED.h
@@ -1782,8 +1782,8 @@ extern CFastLED FastLED;
 #include "fl/math/math.h"  // fl::clamp, fl::map_range, fl::min, fl::max, etc.
 
 #include "fl/log/log.h"
-#include "fl/log/log.h"  // FL_WARN("time now: " << millis()), FL_WARN_IF(condition, "time now: " << millis());"
-#include "fl/log/log.h"  // FL_PRINT("message" << value), FL_LOG_*() category-specific logging
+#include "fl/log/log.h"  // FL_WARN_F("time now: %s", millis()), FL_WARN_F_IF(condition, "time now: %s", millis());"
+#include "fl/log/log.h"  // FL_PRINT_F("message%s", value), FL_LOG_*() category-specific logging
 #include "fl/system/serial.h"  // Arduino-compatible Serial API: fl::Serial.print(), fl::Serial.read(), etc.
 #include "fl/stl/assert.h"  // FASTLED_ASSERT(condition, "message");
 #include "fl/stl/sstream.h"  // fl::sstream for string stream operations

--- a/src/crgb.cpp.hpp
+++ b/src/crgb.cpp.hpp
@@ -77,9 +77,7 @@ void CRGB::downscale(const CRGB *src, const fl::XYMap &srcXY, CRGB *dst,
 
 void CRGB::upscale(const CRGB *src, const fl::XYMap &srcXY, CRGB *dst,
                    const fl::XYMap &dstXY) {
-    FL_WARN_IF(
-        srcXY.getType() != fl::XYMap::kLineByLine,
-        "Upscaling only works with a src matrix that is rectangular");
+    FL_WARN_F_IF(srcXY.getType() != fl::XYMap::kLineByLine, "Upscaling only works with a src matrix that is rectangular");
     fl::u16 w = srcXY.getWidth();
     fl::u16 h = srcXY.getHeight();
     fl::upscale(src, dst, w, h, dstXY);

--- a/src/fl/audio/audio_manager.cpp.hpp
+++ b/src/fl/audio/audio_manager.cpp.hpp
@@ -20,7 +20,7 @@ shared_ptr<Processor> AudioManager::add(const Config &config) {
     fl::string errorMsg;
     auto input = IInput::create(config, &errorMsg);
     if (!input) {
-        FL_WARN("Failed to create audio input: " << errorMsg);
+        FL_WARN_F("Failed to create audio input: %s", errorMsg);
         return nullptr;
     }
     input->start();
@@ -29,7 +29,7 @@ shared_ptr<Processor> AudioManager::add(const Config &config) {
         proc->setMicProfile(config.getMicProfile());
     }
     if (processor()) {
-        FL_WARN("Replacing existing audio processor");
+        FL_WARN_F("Replacing existing audio processor");
     }
     processor() = proc;
     return proc;
@@ -37,7 +37,7 @@ shared_ptr<Processor> AudioManager::add(const Config &config) {
     (void)config;
     auto proc = fl::make_shared<Processor>();
     if (processor()) {
-        FL_WARN("Replacing existing audio processor");
+        FL_WARN_F("Replacing existing audio processor");
     }
     processor() = proc;
     return proc;
@@ -46,13 +46,13 @@ shared_ptr<Processor> AudioManager::add(const Config &config) {
 
 shared_ptr<Processor> AudioManager::add(shared_ptr<IInput> input) {
     if (!input) {
-        FL_WARN("Cannot add null audio input");
+        FL_WARN_F("Cannot add null audio input");
         return nullptr;
     }
     input->start();
     auto proc = Processor::createWithAutoInput(fl::move(input));
     if (processor()) {
-        FL_WARN("Replacing existing audio processor");
+        FL_WARN_F("Replacing existing audio processor");
     }
     processor() = proc;
     return proc;
@@ -69,7 +69,7 @@ shared_ptr<Processor> AudioManager::add(UIAudio &uiAudio) {
     if (cfg.has_value()) {
         return add(*cfg);
     }
-    FL_WARN("UIAudio has no audio input and no hardware config");
+    FL_WARN_F("UIAudio has no audio input and no hardware config");
     return nullptr;
 }
 

--- a/src/fl/audio/detector/buildup.cpp.hpp
+++ b/src/fl/audio/detector/buildup.cpp.hpp
@@ -39,7 +39,7 @@ BuildupDetector::~BuildupDetector() FL_NOEXCEPT = default;
 
 void BuildupDetector::update(shared_ptr<Context> context) {
     if (!context) {
-        FL_WARN("BuildupDetector::update: null context");
+        FL_WARN_F("BuildupDetector::update: null context");
         return;
     }
 
@@ -73,7 +73,7 @@ void BuildupDetector::update(shared_ptr<Context> context) {
             mCurrentBuildup.duration = 0;
             mCurrentBuildup.active = true;
 
-            FL_DBG("BuildupDetector: Buildup started (intensity=" << intensity << ")");
+            FL_DBG_F("BuildupDetector: Buildup started (intensity=%s)", intensity);
 
             mFireBuildupStart = true;
         }
@@ -89,7 +89,7 @@ void BuildupDetector::update(shared_ptr<Context> context) {
         // Check if we've reached peak (just before drop)
         if (!mPeakFired && shouldPeak()) {
             mPeakFired = true;
-            FL_DBG("BuildupDetector: Peak reached");
+            FL_DBG_F("BuildupDetector: Peak reached");
 
             mFireBuildupPeak = true;
         }
@@ -102,7 +102,7 @@ void BuildupDetector::update(shared_ptr<Context> context) {
 
         // Check if buildup should end
         if (shouldEndBuildup()) {
-            FL_DBG("BuildupDetector: Buildup ended (duration=" << mCurrentBuildup.duration << "ms)");
+            FL_DBG_F("BuildupDetector: Buildup ended (duration=%sms)", mCurrentBuildup.duration);
 
             mBuildupActive = false;
             mCurrentBuildup.active = false;

--- a/src/fl/audio/detector/chord.cpp.hpp
+++ b/src/fl/audio/detector/chord.cpp.hpp
@@ -83,9 +83,7 @@ void ChordDetector::update(shared_ptr<Context> context) {
 
             mFireChordChange = true;
 
-            FL_DBG("Chord detected: " << mCurrentChord.getRootName()
-                   << mCurrentChord.getTypeName()
-                   << " (conf: " << mCurrentChord.confidence << ")");
+            FL_DBG_F("Chord detected: %s%s (conf: %s)", mCurrentChord.getRootName(), mCurrentChord.getTypeName(), mCurrentChord.confidence);
         } else {
             // Same chord, update confidence
             mCurrentChord.confidence = detected.confidence;

--- a/src/fl/audio/detector/drop.cpp.hpp
+++ b/src/fl/audio/detector/drop.cpp.hpp
@@ -66,9 +66,7 @@ void DropDetector::update(shared_ptr<Context> context) {
         mLastDrop = dropEvent;
         mDropDetectedThisFrame = true;
 
-        FL_DBG("DropDetector: Drop detected! Impact=" << impact
-               << ", Bass=" << bassEnergy
-               << ", Energy flux=" << energyFlux);
+        FL_DBG_F("DropDetector: Drop detected! Impact=%s, Bass=%s, Energy flux=%s", impact, bassEnergy, energyFlux);
     }
 
     // Update baselines (exponential moving average)

--- a/src/fl/audio/detector/key.cpp.hpp
+++ b/src/fl/audio/detector/key.cpp.hpp
@@ -167,9 +167,7 @@ void KeyDetector::update(shared_ptr<Context> context) {
             mKeyStartTime = timestamp;
             mKeyActive = true;
 
-            FL_DBG("Key change: " << mCurrentKey.getRootName() << " "
-                   << mCurrentKey.getQuality() << " (confidence: "
-                   << mCurrentKey.confidence << ")");
+            FL_DBG_F("Key change: %s %s (confidence: %s)", mCurrentKey.getRootName(), mCurrentKey.getQuality(), mCurrentKey.confidence);
 
             mFireKeyChange = true;
         }
@@ -177,7 +175,7 @@ void KeyDetector::update(shared_ptr<Context> context) {
 
     // Check for key end (confidence drop)
     if (mKeyActive && detectedKey.confidence < mConfidenceThreshold * 0.5f) {
-        FL_DBG("Key ended: " << mCurrentKey.getRootName() << " " << mCurrentKey.getQuality());
+        FL_DBG_F("Key ended: %s %s", mCurrentKey.getRootName(), mCurrentKey.getQuality());
 
         mFireKeyEnd = true;
         mKeyActive = false;

--- a/src/fl/audio/fft/fft_backend.h
+++ b/src/fl/audio/fft/fft_backend.h
@@ -139,7 +139,7 @@ inline bool espDspGlobalInit() FL_NOEXCEPT {
     esp_err_t err =
         dsps_fft2r_init_fc32(nullptr, CONFIG_DSP_MAX_FFT_SIZE);
     if (err != ESP_OK) {
-        FL_WARN("dsps_fft2r_init_fc32 failed: " << static_cast<int>(err));
+        FL_WARN_F("dsps_fft2r_init_fc32 failed: %s", static_cast<int>(err));
         return false;
     }
     initialized = true;

--- a/src/fl/audio/fft/fft_impl.cpp.hpp
+++ b/src/fl/audio/fft/fft_impl.cpp.hpp
@@ -69,7 +69,7 @@ class Context {
 
         mFftrCfg = kiss_fftr_alloc(samples, 0, nullptr, nullptr);
         if (!mFftrCfg) {
-            FL_WARN("Failed to allocate Impl context");
+            FL_WARN_F("Failed to allocate Impl context");
             return;
         }
 
@@ -87,7 +87,7 @@ class Context {
             initOctaveWise(samples, bands, fmin, fmax, sample_rate);
             break;
         case Mode::AUTO:
-            FL_WARN("Mode::AUTO should have been resolved");
+            FL_WARN_F("Mode::AUTO should have been resolved");
             break;
         }
     }
@@ -129,7 +129,7 @@ class Context {
             runHybrid(buffer, out);
             break;
         case Mode::AUTO:
-            FL_WARN("Mode::AUTO should have been resolved");
+            FL_WARN_F("Mode::AUTO should have been resolved");
             break;
         }
     }
@@ -1142,7 +1142,7 @@ fl::string Impl::info() const {
     if (mContext) {
         return mContext->info();
     } else {
-        FL_WARN("Impl context is not initialized");
+        FL_WARN_F("Impl context is not initialized");
         return fl::string();
     }
 }
@@ -1165,7 +1165,7 @@ Impl::Result Impl::run(span<const i16> sample, Bins *out) {
         return Impl::Result(false, "Impl context is not initialized");
     }
     if (sample.size() != mContext->sampleSize()) {
-        FL_WARN("Impl sample size mismatch");
+        FL_WARN_F("Impl sample size mismatch");
         return Impl::Result(false, "Impl sample size mismatch");
     }
     mContext->run(sample, out);

--- a/src/fl/audio/frequency_bin_mapper.cpp.hpp
+++ b/src/fl/audio/frequency_bin_mapper.cpp.hpp
@@ -123,8 +123,7 @@ void FrequencyBinMapper::mapBins(span<const float> fftBins, span<float> outputBi
 
     // Validate output buffer size
     if (outputBins.size() < numBins) {
-        FL_WARN("FrequencyBinMapper: output buffer too small (" << outputBins.size()
-                << " < " << numBins << ")");
+        FL_WARN_F("FrequencyBinMapper: output buffer too small (%s < %s)", outputBins.size(), numBins);
         return;
     }
 

--- a/src/fl/audio/spectral_equalizer.cpp.hpp
+++ b/src/fl/audio/spectral_equalizer.cpp.hpp
@@ -55,9 +55,7 @@ void SpectralEqualizer::calculateGains() {
                     mGains[i] = mConfig.customGains[i];
                 }
             } else {
-                FL_WARN("SpectralEqualizer: custom gains size mismatch ("
-                        << mConfig.customGains.size() << " != " << mConfig.numBands
-                        << "), using flat gains");
+                FL_WARN_F("SpectralEqualizer: custom gains size mismatch (%s != %s), using flat gains", mConfig.customGains.size(), mConfig.numBands);
                 calculateFlatGains();
             }
             break;
@@ -88,8 +86,7 @@ void SpectralEqualizer::calculateAWeightingGains() {
         curveSize = 32;
     } else {
         // Unsupported band count - use flat gains
-        FL_WARN("SpectralEqualizer: A-weighting not defined for " << mConfig.numBands
-                << " bands, using flat gains");
+        FL_WARN_F("SpectralEqualizer: A-weighting not defined for %s bands, using flat gains", mConfig.numBands);
         calculateFlatGains();
         return;
     }
@@ -102,8 +99,7 @@ void SpectralEqualizer::calculateAWeightingGains() {
 
 void SpectralEqualizer::setCustomGains(span<const float> gains) {
     if (gains.size() != mConfig.numBands) {
-        FL_WARN("SpectralEqualizer: custom gains size mismatch ("
-                << gains.size() << " != " << mConfig.numBands << ")");
+        FL_WARN_F("SpectralEqualizer: custom gains size mismatch (%s != %s)", gains.size(), mConfig.numBands);
         return;
     }
 
@@ -121,14 +117,12 @@ void SpectralEqualizer::setCustomGains(span<const float> gains) {
 
 void SpectralEqualizer::apply(span<const float> inputBins, span<float> outputBins) const {
     if (inputBins.size() != mConfig.numBands) {
-        FL_WARN("SpectralEqualizer: input size mismatch ("
-                << inputBins.size() << " != " << mConfig.numBands << ")");
+        FL_WARN_F("SpectralEqualizer: input size mismatch (%s != %s)", inputBins.size(), mConfig.numBands);
         return;
     }
 
     if (outputBins.size() < mConfig.numBands) {
-        FL_WARN("SpectralEqualizer: output buffer too small ("
-                << outputBins.size() << " < " << mConfig.numBands << ")");
+        FL_WARN_F("SpectralEqualizer: output buffer too small (%s < %s)", outputBins.size(), mConfig.numBands);
         return;
     }
 

--- a/src/fl/channels/adapters/spi_channel_adapter.cpp.hpp
+++ b/src/fl/channels/adapters/spi_channel_adapter.cpp.hpp
@@ -22,17 +22,17 @@ fl::shared_ptr<SpiChannelEngineAdapter> SpiChannelEngineAdapter::create(
 ) {
     // Validation
     if (hwControllers.empty()) {
-        FL_WARN("SpiChannelEngineAdapter::create: No controllers provided");
+        FL_WARN_F("SpiChannelEngineAdapter::create: No controllers provided");
         return nullptr;
     }
 
     if (hwControllers.size() != priorities.size() || hwControllers.size() != names.size()) {
-        FL_WARN("SpiChannelEngineAdapter::create: Size mismatch in arguments");
+        FL_WARN_F("SpiChannelEngineAdapter::create: Size mismatch in arguments");
         return nullptr;
     }
 
     if (!adapterName || adapterName[0] == '\0') {
-        FL_WARN("SpiChannelEngineAdapter::create: Empty adapter name");
+        FL_WARN_F("SpiChannelEngineAdapter::create: Empty adapter name");
         return nullptr;
     }
 
@@ -42,19 +42,17 @@ fl::shared_ptr<SpiChannelEngineAdapter> SpiChannelEngineAdapter::create(
     // Register all controllers
     for (size_t i = 0; i < hwControllers.size(); i++) {
         if (!hwControllers[i]) {
-            FL_WARN("SpiChannelEngineAdapter: Null controller at index " << i);
+            FL_WARN_F("SpiChannelEngineAdapter: Null controller at index %s", i);
             continue;
         }
 
         adapter->mControllers.emplace_back(hwControllers[i], priorities[i], names[i]);
 
-        FL_DBG("SpiChannelEngineAdapter: Registered controller '" << names[i]
-               << "' (priority " << priorities[i]
-               << ", lanes: " << static_cast<int>(hwControllers[i]->getLaneCount()) << ")");
+        FL_DBG_F("SpiChannelEngineAdapter: Registered controller '%s' (priority %s, lanes: %s)", names[i], priorities[i], static_cast<int>(hwControllers[i]->getLaneCount()));
     }
 
     if (adapter->mControllers.empty()) {
-        FL_WARN("SpiChannelEngineAdapter: No valid controllers registered");
+        FL_WARN_F("SpiChannelEngineAdapter: No valid controllers registered");
         return nullptr;
     }
 
@@ -68,7 +66,7 @@ SpiChannelEngineAdapter::SpiChannelEngineAdapter(const char* name)
 }
 
 SpiChannelEngineAdapter::~SpiChannelEngineAdapter() FL_NOEXCEPT {
-    FL_DBG("SpiChannelEngineAdapter: Destructor for '" << mName << "'");
+    FL_DBG_F("SpiChannelEngineAdapter: Destructor for '%s'", mName);
 
     // Clear any enqueued channels that were never transmitted
     // This prevents infinite loop in poll() which returns DRAINING if enqueued channels exist
@@ -158,8 +156,7 @@ bool SpiChannelEngineAdapter::initializeControllerIfNeeded(
                 return true;  // Already configured for this pin
             }
         }
-        FL_WARN("SpiChannelEngineAdapter: Controller " << ctrl.name
-                << " already initialized with different clock pin");
+        FL_WARN_F("SpiChannelEngineAdapter: Controller %s already initialized with different clock pin", ctrl.name);
         return false;
     }
 
@@ -175,20 +172,19 @@ bool SpiChannelEngineAdapter::initializeControllerIfNeeded(
         config.max_transfer_sz = 65536;
 
         if (!ctrl.controller->begin(&config)) {
-            FL_WARN("SpiChannelEngineAdapter: Failed to initialize " << ctrl.name);
+            FL_WARN_F("SpiChannelEngineAdapter: Failed to initialize %s", ctrl.name);
             return false;
         }
     } else {
         // TODO: Multi-lane initialization (SpiHw2/4/8/16)
-        FL_WARN("SpiChannelEngineAdapter: Multi-lane init not yet implemented");
+        FL_WARN_F("SpiChannelEngineAdapter: Multi-lane init not yet implemented");
         return false;
     }
 
     ctrl.isInitialized = true;
     ctrl.assignedClockPins.push_back(clockPin);
 
-    FL_DBG("SpiChannelEngineAdapter: Initialized " << ctrl.name
-           << " with clock pin " << clockPin);
+    FL_DBG_F("SpiChannelEngineAdapter: Initialized %s with clock pin %s", ctrl.name, clockPin);
 
     return true;
 }
@@ -212,18 +208,18 @@ bool SpiChannelEngineAdapter::canHandle(const ChannelDataPtr& data) const {
 
 void SpiChannelEngineAdapter::enqueue(ChannelDataPtr channelData) {
     if (!channelData) {
-        FL_WARN("SpiChannelEngineAdapter: Null channel data passed to enqueue()");
+        FL_WARN_F("SpiChannelEngineAdapter: Null channel data passed to enqueue()");
         return;
     }
 
     // Validate that we can handle this data
     if (!canHandle(channelData)) {
-        FL_WARN("SpiChannelEngineAdapter: Cannot handle non-SPI channel data (chipset mismatch)");
+        FL_WARN_F("SpiChannelEngineAdapter: Cannot handle non-SPI channel data (chipset mismatch)");
         return;
     }
 
     mEnqueuedChannels.push_back(channelData);
-    FL_DBG("SpiChannelEngineAdapter: Enqueued channel (total: " << mEnqueuedChannels.size() << ")");
+    FL_DBG_F("SpiChannelEngineAdapter: Enqueued channel (total: %s)", mEnqueuedChannels.size());
 }
 
 void SpiChannelEngineAdapter::show() {
@@ -231,7 +227,7 @@ void SpiChannelEngineAdapter::show() {
         return;
     }
 
-    FL_DBG("SpiChannelEngineAdapter: show() called with " << mEnqueuedChannels.size() << " channels");
+    FL_DBG_F("SpiChannelEngineAdapter: show() called with %s channels", mEnqueuedChannels.size());
 
     // Move enqueued channels to transmitting list
     mTransmittingChannels = fl::move(mEnqueuedChannels);
@@ -241,22 +237,21 @@ void SpiChannelEngineAdapter::show() {
     // Channels with the same clock pin can share SPI bus configuration
     auto groups = groupByClockPin(mTransmittingChannels);
 
-    FL_DBG("SpiChannelEngineAdapter: Grouped into " << groups.size() << " clock pin groups");
+    FL_DBG_F("SpiChannelEngineAdapter: Grouped into %s clock pin groups", groups.size());
 
     // Transmit each group sequentially
     for (size_t i = 0; i < groups.size(); i++) {
         const ClockPinGroup& group = groups[i];
 
-        FL_DBG("SpiChannelEngineAdapter: Transmitting group with clock pin "
-               << group.clockPin << " (" << group.channels.size() << " channels)");
+        FL_DBG_F("SpiChannelEngineAdapter: Transmitting group with clock pin %s (%s channels)", group.clockPin, group.channels.size());
 
         if (!transmitBatch(group.channels)) {
-            FL_WARN("SpiChannelEngineAdapter: Failed to transmit batch for clock pin " << group.clockPin);
+            FL_WARN_F("SpiChannelEngineAdapter: Failed to transmit batch for clock pin %s", group.clockPin);
             // Continue with other groups rather than aborting entirely
         }
     }
 
-    FL_DBG("SpiChannelEngineAdapter: show() complete");
+    FL_DBG_F("SpiChannelEngineAdapter: show() complete");
 }
 
 IChannelDriver::DriverState SpiChannelEngineAdapter::poll() {
@@ -275,8 +270,7 @@ IChannelDriver::DriverState SpiChannelEngineAdapter::poll() {
 
     // All controllers idle - release transmitting channels
     if (!mTransmittingChannels.empty()) {
-        FL_DBG("SpiChannelEngineAdapter: Releasing " << mTransmittingChannels.size()
-               << " completed channels");
+        FL_DBG_F("SpiChannelEngineAdapter: Releasing %s completed channels", mTransmittingChannels.size());
 
         for (const auto& channel : mTransmittingChannels) {
             if (channel) {
@@ -307,7 +301,7 @@ fl::vector<SpiChannelEngineAdapter::ClockPinGroup> SpiChannelEngineAdapter::grou
         // Extract clock pin from chipset configuration
         const auto& chipset = channel->getChipset();
         if (!chipset.is<SpiChipsetConfig>()) {
-            FL_WARN("SpiChannelEngineAdapter: Non-SPI chipset in groupByClockPin");
+            FL_WARN_F("SpiChannelEngineAdapter: Non-SPI chipset in groupByClockPin");
             continue;
         }
 
@@ -345,7 +339,7 @@ bool SpiChannelEngineAdapter::transmitBatch(fl::span<const ChannelDataPtr> chann
     // Extract clock pin and data pin from first channel (all same in batch)
     const auto& chipset = channels[0]->getChipset();
     if (!chipset.is<SpiChipsetConfig>()) {
-        FL_WARN("SpiChannelEngineAdapter: Non-SPI chipset in transmitBatch");
+        FL_WARN_F("SpiChannelEngineAdapter: Non-SPI chipset in transmitBatch");
         return false;
     }
 
@@ -356,7 +350,7 @@ bool SpiChannelEngineAdapter::transmitBatch(fl::span<const ChannelDataPtr> chann
     // Select controller for this clock pin
     int controllerIndex = selectControllerForClockPin(clockPin);
     if (controllerIndex < 0) {
-        FL_WARN("SpiChannelEngineAdapter: No available controller for clock pin " << clockPin);
+        FL_WARN_F("SpiChannelEngineAdapter: No available controller for clock pin %s", clockPin);
         return false;
     }
 
@@ -379,19 +373,17 @@ bool SpiChannelEngineAdapter::transmitBatch(fl::span<const ChannelDataPtr> chann
         // Get encoded data
         const auto& data = channel->getData();
         if (data.empty()) {
-            FL_WARN("SpiChannelEngineAdapter: Empty channel data");
+            FL_WARN_F("SpiChannelEngineAdapter: Empty channel data");
             channel->setInUse(false);
             continue;
         }
 
-        FL_DBG("SpiChannelEngineAdapter: Transmitting channel via " << ctrl.name
-               << " (pin " << channel->getPin() << ", " << data.size() << " bytes)");
+        FL_DBG_F("SpiChannelEngineAdapter: Transmitting channel via %s (pin %s, %s bytes)", ctrl.name, channel->getPin(), data.size());
 
         // Acquire DMA buffer
         DMABuffer dmaBuffer = ctrl.controller->acquireDMABuffer(data.size());
         if (!dmaBuffer.ok()) {
-            FL_WARN("SpiChannelEngineAdapter: Failed to acquire DMA buffer (error "
-                   << static_cast<int>(dmaBuffer.error()) << ")");
+            FL_WARN_F("SpiChannelEngineAdapter: Failed to acquire DMA buffer (error %s)", static_cast<int>(dmaBuffer.error()));
             channel->setInUse(false);
             return false;
         }
@@ -399,8 +391,7 @@ bool SpiChannelEngineAdapter::transmitBatch(fl::span<const ChannelDataPtr> chann
         // Copy data to DMA buffer
         fl::span<u8> buffer = dmaBuffer.data();
         if (buffer.size() < data.size()) {
-            FL_WARN("SpiChannelEngineAdapter: DMA buffer too small ("
-                   << buffer.size() << " < " << data.size() << ")");
+            FL_WARN_F("SpiChannelEngineAdapter: DMA buffer too small (%s < %s)", buffer.size(), data.size());
             channel->setInUse(false);
             return false;
         }
@@ -409,22 +400,22 @@ bool SpiChannelEngineAdapter::transmitBatch(fl::span<const ChannelDataPtr> chann
 
         // Transmit (async mode for non-blocking operation)
         if (!ctrl.controller->transmit(TransmitMode::ASYNC)) {
-            FL_WARN("SpiChannelEngineAdapter: Transmission failed");
+            FL_WARN_F("SpiChannelEngineAdapter: Transmission failed");
             channel->setInUse(false);
             return false;
         }
 
-        FL_DBG("SpiChannelEngineAdapter: Transmission queued successfully");
+        FL_DBG_F("SpiChannelEngineAdapter: Transmission queued successfully");
     }
 
     // Wait for transmission to complete (synchronous for now)
     // TODO: Make fully async by returning BUSY state and polling in poll()
     if (!ctrl.controller->waitComplete(1000)) {  // 1 second timeout
-        FL_WARN("SpiChannelEngineAdapter: Transmission timeout");
+        FL_WARN_F("SpiChannelEngineAdapter: Transmission timeout");
         return false;
     }
 
-    FL_DBG("SpiChannelEngineAdapter: Batch transmission complete");
+    FL_DBG_F("SpiChannelEngineAdapter: Batch transmission complete");
     return true;
 }
 

--- a/src/fl/channels/channel.cpp.hpp
+++ b/src/fl/channels/channel.cpp.hpp
@@ -1,4 +1,4 @@
-/// @file channel.cpp
+﻿/// @file channel.cpp
 /// @brief LED channel implementation
 
 #include "platforms/is_platform.h"
@@ -39,7 +39,7 @@ inline void applyWhiteCfg(CLEDController& ctrl,
     } else if (auto* p = options.mWhiteCfg.ptr<Rgbw>()) {
         ctrl.setRgbw(*p);
     } else {
-        // Empty alternative (or default-constructed) → plain RGB.
+        // Empty alternative (or default-constructed) â†’ plain RGB.
         ctrl.clearWhiteChannel();
     }
 }
@@ -80,9 +80,7 @@ class ReorderingPixelIteratorAny {
 
             // Validate that XYMap dimensions match channel LED count
             if (expectedLeds != numLeds) {
-                FL_ERROR("Channel '" << channelName << "': XYMap dimensions (" << width << "x" << height
-                        << "=" << expectedLeds << ") don't match LED count (" << numLeds
-                        << "). Addressing transformation may produce unexpected results.");
+                FL_ERROR_F("Channel '%s': XYMap dimensions (%sx%s=%s) don't match LED count (%s). Addressing transformation may produce unexpected results.", channelName, width, height, expectedLeds, numLeds);
             }
 
             // Cast mData to CRGB array
@@ -125,23 +123,16 @@ class ReorderingPixelIteratorAny {
 /// instantiations in showPixels' prologue/epilogue for code that runs
 /// at most once per channel lifetime. Splitting matches the same
 /// pattern the maintainer adopted for `resolveDynamicDriver()` in PR
-/// #2830 — keep the diagnostic chain in a `FL_NO_INLINE` helper so it
+/// #2830 â€” keep the diagnostic chain in a `FL_NO_INLINE` helper so it
 /// can't fold back into the hot path. (#2773 follow-up to #2832.)
 FL_NO_INLINE
 static void emitDisabledDriverError(const fl::string& channelName,
                                     const fl::string& driverName,
                                     const fl::string& exclusive) FL_NOEXCEPT {
     if (!exclusive.empty()) {
-        FL_ERROR("Channel '" << channelName << "': bound driver '" << driverName
-            << "' is currently DISABLED by exclusive-driver selection '"
-            << exclusive << "'. Frame will be silently dropped. "
-            << "Resolve with: FastLED.enableDrivers<fl::Bus::"
-            << driverName << ">() or FastLED.enableAllDrivers().");
+        FL_ERROR_F("Channel '%s': bound driver '%s' is currently DISABLED by exclusive-driver selection '%s'. Frame will be silently dropped. Resolve with: FastLED.enableDrivers<fl::Bus::%s>() or FastLED.enableAllDrivers().", channelName, driverName, exclusive, driverName);
     } else {
-        FL_ERROR("Channel '" << channelName << "': bound driver '" << driverName
-            << "' is currently DISABLED. Frame will be silently dropped. "
-            << "Resolve with: FastLED.enableDrivers<fl::Bus::"
-            << driverName << ">() or FastLED.enableAllDrivers().");
+        FL_ERROR_F("Channel '%s': bound driver '%s' is currently DISABLED. Frame will be silently dropped. Resolve with: FastLED.enableDrivers<fl::Bus::%s>() or FastLED.enableAllDrivers().", channelName, driverName, driverName);
     }
 }
 
@@ -157,8 +148,8 @@ fl::string Channel::makeName(i32 id, const fl::optional<fl::string>& configName)
     if (configName.has_value()) {
         return configName.value();
     }
-    // Auto-naming `"Channel_<id>"` only matters for diagnostics — in release
-    // builds (NDEBUG → FASTLED_LOG_VERBOSITY=0 per Stage 1) every FL_WARN /
+    // Auto-naming `"Channel_<id>"` only matters for diagnostics â€” in release
+    // builds (NDEBUG â†’ FASTLED_LOG_VERBOSITY=0 per Stage 1) every FL_WARN /
     // FL_ERROR site that reads mName collapses to `do { } while(0)`, so the
     // string and the supporting `fl::to_string` + `operator+` chain go
     // unused. Empty in release saves the `fl::to_string<i64>` instantiation
@@ -211,7 +202,7 @@ Channel::Channel(const ChipsetVariant& chipset, EOrder rgbOrder, RegistrationMod
     , mBus(Bus::AUTO)
     , mId(nextId())
     , mName(makeName(mId)) {
-    // NOTE: Do NOT call fl::pinMode() here — see comment in the
+    // NOTE: Do NOT call fl::pinMode() here â€” see comment in the
     // Channel(ChipsetVariant, span, EOrder, ChannelOptions) constructor.
     mChannelData = ChannelData::create(mChipset);
 }
@@ -259,7 +250,7 @@ Channel::Channel(int pin, const ChipsetTimingConfig& timing, fl::span<CRGB> leds
     , mBus(options.mBus)  // Bus selection (#2459)
     , mId(nextId())
     , mName(makeName(mId)) {
-    // NOTE: Do NOT call fl::pinMode() here — see comment in the
+    // NOTE: Do NOT call fl::pinMode() here â€” see comment in the
     // Channel(ChipsetVariant, span, EOrder, ChannelOptions) constructor.
 
     // Set the LED data array
@@ -333,7 +324,7 @@ void writeUCS7604(fl::vector_psram<u8>* data, PixelIterator& pixelIterator,
             mode = UCS7604Mode::UCS7604_MODE_16BIT_1600KHZ;
             break;
         default:
-            // Should never happen — caller already checked
+            // Should never happen â€” caller already checked
             mode = UCS7604Mode::UCS7604_MODE_16BIT_800KHZ;
             break;
     }
@@ -358,12 +349,12 @@ void writeUCS7604(fl::vector_psram<u8>* data, PixelIterator& pixelIterator,
 
     // (#2558) UCS7604 is a 4-channel chipset (always RGBW). If the user
     // configured this channel for 5-channel RGBWW (warm-W + cool-W), the
-    // chipset can't carry the second W byte. Warn loudly — silently dropping
+    // chipset can't carry the second W byte. Warn loudly â€” silently dropping
     // the white channels would be very hard to diagnose. The pixel iterator
     // continues to emit RGB-only bytes (is_rgbw=false) so the strip still
     // lights up, just without the W diode.
     if (pixelIterator.get_rgbww().active() && !is_rgbw) {
-        FL_WARN_ONCE("UCS7604 cannot carry 5-channel RGBWW — this chipset "
+        FL_WARN_F_ONCE("UCS7604 cannot carry 5-channel RGBWW â€” this chipset "
                      "always emits 4-channel RGBW. The warm/cool white "
                      "channels in your Rgbww config will be dropped. "
                      "Set ChannelOptions.mWhiteCfg = Rgbw{...} instead to "
@@ -380,11 +371,11 @@ void writeUCS7604(fl::vector_psram<u8>* data, PixelIterator& pixelIterator,
 /// @brief Cold fallback for the non-pre-bound driver path. Handles dynamic
 ///        `ChannelManager::selectDriverForChannel` lookup AND the
 ///        bus-key-miss diagnostic chain. Hoisted out of `showPixels` so the
-///        hot legacy `addLeds<>` path stays compact — see #2773 item 2.1.
+///        hot legacy `addLeds<>` path stays compact â€” see #2773 item 2.1.
 ///
 /// Marked `noinline` (via `FL_NOINLINE`) so the compiler doesn't fold the
 /// cold body back into `showPixels`. The whole helper is reachable only
-/// when `mDriverPreBound == false`, which on stock Blink is never true —
+/// when `mDriverPreBound == false`, which on stock Blink is never true â€”
 /// LTO can use that across the call site to keep the cold body off the
 /// hot icache line.
 FL_NO_INLINE
@@ -409,35 +400,26 @@ fl::shared_ptr<IChannelDriver> Channel::resolveDynamicDriver() {
     // #2455 / #2459: one-shot diagnostic when a typed-Bus miss happens.
     // Probe via `findDriverByName` (silent) to distinguish "driver wasn't
     // instantiated" from "driver exists but canHandle() rejected this
-    // chipset" — resolution paths differ. The mBusWarned guard suppresses
+    // chipset" â€” resolution paths differ. The mBusWarned guard suppresses
     // duplicate logs on subsequent shows of the same channel.
 #if FASTLED_LOG_RUNTIME_ENABLED
     if (mBus != Bus::AUTO && !mBusWarned &&
         (!driver || driver->getName() != busKey)) {
         auto busDriver = ChannelManager::instance().findDriverByName(busKey);
         if (!busDriver) {
-            // Typed Bus miss — emit the actionable hint with the three
+            // Typed Bus miss â€” emit the actionable hint with the three
             // currently-shipping remediations (option 3 added in #2460).
-            FL_ERROR("Channel '" << mName << "': Driver '" << busKey
-                << "' wasn't instantiated. Resolve with: "
-                << "(1) fl::enableDrivers<fl::Bus::" << busKey << ">() "
-                << "(links only this driver), "
-                << "(2) FastLED.enableAllDrivers() (links every driver), or "
-                << "(3) FastLED.addLeds<..., fl::Bus::" << busKey << ">(...) "
-                << "(legacy API; pins Bus + triggers linker keep-alive). "
-                << "Defaulting to AUTO/priority dispatch.");
+            FL_ERROR_F("Channel '%s': Driver '%s' wasn't instantiated. Resolve with: (1) fl::enableDrivers<fl::Bus::%s>() (links only this driver), (2) FastLED.enableAllDrivers() (links every driver), or (3) FastLED.addLeds<..., fl::Bus::%s>(...) (legacy API; pins Bus + triggers linker keep-alive). Defaulting to AUTO/priority dispatch.", mName, busKey, busKey, busKey);
         } else {
-            // Registered, but canHandle() said no — bus/chipset mismatch.
-            FL_ERROR("Channel '" << mName << "': Driver '" << busKey
-                << "' is registered but cannot handle this channel's chipset "
-                << "(bus/chipset mismatch). Defaulting to AUTO/priority dispatch.");
+            // Registered, but canHandle() said no â€” bus/chipset mismatch.
+            FL_ERROR_F("Channel '%s': Driver '%s' is registered but cannot handle this channel's chipset (bus/chipset mismatch). Defaulting to AUTO/priority dispatch.", mName, busKey);
         }
         mBusWarned = true;
     }
     if (!driver) {
-        FL_ERROR("Channel '" << mName << "': No compatible driver found - cannot transmit");
+        FL_ERROR_F("Channel '%s': No compatible driver found - cannot transmit", mName);
     }
-#endif  // FASTLED_LOG_RUNTIME_ENABLED — release skips the per-frame
+#endif  // FASTLED_LOG_RUNTIME_ENABLED â€” release skips the per-frame
         // driver->getName() != busKey compare + the silent
         // findDriverByName probe (used only to differentiate the
         // FL_ERROR message). The functional return value below is
@@ -451,19 +433,19 @@ void Channel::showPixels(PixelController<RGB, 1, 0xFFFFFFFF> &pixels) {
 
     // Safety check: don't modify buffer if driver is currently transmitting it
     if (mChannelData->isInUse()) {
-        FL_WARN("Channel '" << mName << "': showPixels() called while mChannelData is in use by driver, attempting to wait");
+        FL_WARN_F("Channel '%s': showPixels() called while mChannelData is in use by driver, attempting to wait", mName);
         auto driver = mDriver.lock();
         if (!driver) {
-            FL_ERROR("Channel '" << mName << "': No driver bound yet the mChannelData is in use - cannot transmit");
+            FL_ERROR_F("Channel '%s': No driver bound yet the mChannelData is in use - cannot transmit", mName);
             return;
         }
         // wait until the driver is in a READY state.
         bool ok = driver->waitForReady();
         if (!ok) {
-            FL_ERROR("Channel '" << mName << "': Timeout occurred while waiting for driver to become READY");
+            FL_ERROR_F("Channel '%s': Timeout occurred while waiting for driver to become READY", mName);
             return;
         }
-        FL_WARN("Channel '" << mName << "': Engine became READY after waiting");
+        FL_WARN_F("Channel '%s': Engine became READY after waiting", mName);
     }
 
     // Phase 5b of #2428: if the driver was pre-bound via setDriver() (legacy
@@ -475,7 +457,7 @@ void Channel::showPixels(PixelController<RGB, 1, 0xFFFFFFFF> &pixels) {
     // **Fast path (#2773 item 2.1):** the legacy `addLeds<NEOPIXEL>` flow is
     // by far the hot per-frame path on stock Blink. It needs no busKey
     // construction, no dynamic driver lookup, no busKey-miss diagnostics,
-    // and no fallback `FL_ERROR` reporting — the driver was already pre-bound
+    // and no fallback `FL_ERROR` reporting â€” the driver was already pre-bound
     // in the controller's constructor. Pulling all of that boilerplate out
     // of `showPixels` lets the compiler keep the hot path compact and lets
     // the slow path's `fl::string` ops / `ChannelManager::selectDriverForChannel`
@@ -485,7 +467,7 @@ void Channel::showPixels(PixelController<RGB, 1, 0xFFFFFFFF> &pixels) {
         driver = mDriver.lock();
         if (!driver) {
             // Pre-bound driver got destroyed (singleton shutdown, etc.). Silent
-            // bail — this is unrecoverable from showPixels.
+            // bail â€” this is unrecoverable from showPixels.
             return;
         }
     } else {
@@ -497,11 +479,11 @@ void Channel::showPixels(PixelController<RGB, 1, 0xFFFFFFFF> &pixels) {
 #else
         // Dynamic-driver lookup gated out via FASTLED_DISABLE_DYNAMIC_DRIVER
         // (#2926). The else branch is dead at runtime for every legacy
-        // `addLeds<>` flavor — those pre-bind their driver in the ctor. The
+        // `addLeds<>` flavor â€” those pre-bind their driver in the ctor. The
         // gate lets `--gc-sections` drop the resolveDynamicDriver body plus
         // the ChannelManager::findDriverByName / selectDriverForChannel
         // chain (~400-900 B). Channels created via `Channel::create(cfg)`
-        // without a pre-bound driver silently emit nothing under this flag —
+        // without a pre-bound driver silently emit nothing under this flag â€”
         // user accepts the constraint.
         return;
 #endif
@@ -551,7 +533,7 @@ void Channel::showPixels(PixelController<RGB, 1, 0xFFFFFFFF> &pixels) {
         //
         // Gated by FASTLED_DISABLE_SPI_CHIPSETS (#2913). For NEOPIXEL-only
         // sketches on ESP32-S3 the SPI branch is dead at runtime, but the
-        // compiler cannot prove that — each pixelIterator.writeXXX(...)
+        // compiler cannot prove that â€” each pixelIterator.writeXXX(...)
         // reference below is statically reachable, keeping ~720 B of
         // encoder bodies (writeAPA102, writeSK9822, writeLPD8806,
         // writeSM16716) plus the 11-case switch table linked. Setting
@@ -559,7 +541,7 @@ void Channel::showPixels(PixelController<RGB, 1, 0xFFFFFFFF> &pixels) {
         // whole branch and recovers ~1.0-1.2 KB on a NEOPIXEL Blink.
         //
         // When the gate is enabled, calling showPixels() on an
-        // SpiChipsetConfig channel silently emits nothing — the user
+        // SpiChipsetConfig channel silently emits nothing â€” the user
         // accepts that constraint by setting the flag.
         const SpiChipsetConfig* spi = mChipset.ptr<SpiChipsetConfig>();
         const SpiEncoder& config = spi->timing;
@@ -627,7 +609,7 @@ void Channel::showPixels(PixelController<RGB, 1, 0xFFFFFFFF> &pixels) {
 
 
 
-    // #2517: detect the silent-drop scenario before enqueuing — if the
+    // #2517: detect the silent-drop scenario before enqueuing â€” if the
     // resolved driver is registered with ChannelManager but currently
     // disabled (typically by `FastLED.setExclusiveDriver<OtherBus>()`),
     // `ChannelManager::onEndFrame()` will skip its `show()` call and the
@@ -648,7 +630,7 @@ void Channel::showPixels(PixelController<RGB, 1, 0xFFFFFFFF> &pixels) {
             mDisabledDriverWarned = true;
         }
 #endif
-        // Skip the enqueue — the data wouldn't be sent anyway, and dropping
+        // Skip the enqueue â€” the data wouldn't be sent anyway, and dropping
         // it here matches the existing behaviour (rather than leaving stale
         // bytes in the driver's pending queue across an enable/disable flip).
         // The drop happens in both debug and release; only the diagnostic
@@ -664,7 +646,7 @@ void Channel::showPixels(PixelController<RGB, 1, 0xFFFFFFFF> &pixels) {
     }
     // NOT_REGISTERED: driver is not managed by ChannelManager (e.g. a custom
     // test driver, or one that was removed). Fall through to enqueue and let
-    // the driver decide what to do — this is the historic behaviour.
+    // the driver decide what to do â€” this is the historic behaviour.
 
     // Enqueue for transmission (will be sent when driver->show() is called)
     driver->enqueue(mChannelData);
@@ -691,7 +673,7 @@ public:
         // No-op: stub driver does nothing
         static bool warned = false;
         if (!warned) {
-            FL_DBG("StubChannelEngine: No-op enqueue (use for testing or unsupported platforms)");
+            FL_DBG_F("StubChannelEngine: No-op enqueue (use for testing or unsupported platforms)");
             warned = true;
         }
     }
@@ -723,7 +705,7 @@ IChannelDriver* getStubChannelEngine() {
 // Re-exposed protected base class methods
 void Channel::addToDrawList() {
     if (isInList()) {
-        FL_WARN("Channel '" << mName << "': Skipping addToDrawList() - already in draw list");
+        FL_WARN_F("Channel '%s': Skipping addToDrawList() - already in draw list", mName);
         return;
     }
     CPixelLEDController<RGB>::addToList();
@@ -734,7 +716,7 @@ void Channel::addToDrawList() {
 
 void Channel::removeFromDrawList() {
     if (!isInList()) {
-        FL_WARN("Channel '" << mName << "': Skipping removeFromDrawList() - not in draw list");
+        FL_WARN_F("Channel '%s': Skipping removeFromDrawList() - not in draw list", mName);
         return;
     }
     CPixelLEDController<RGB>::removeFromDrawList();

--- a/src/fl/channels/detail/validation/platform.cpp.hpp
+++ b/src/fl/channels/detail/validation/platform.cpp.hpp
@@ -21,20 +21,17 @@ void printEngineValidation() {
     auto infos = channelManager().getDriverInfos();
 
     if (infos.empty()) {
-        FL_ERROR("[VALIDATION] No drivers registered with ChannelManager!");
+        FL_ERROR_F("[VALIDATION] No drivers registered with ChannelManager!");
         return;
     }
 
-    FL_WARN("\n[VALIDATION] Registered drivers: " << infos.size());
+    FL_WARN_F("\n[VALIDATION] Registered drivers: %s", infos.size());
     for (fl::size i = 0; i < infos.size(); i++) {
         const auto& info = infos[i];
         FL_UNUSED(info);  // silences -Wunused-variable when FL_WARN is a no-op
-        FL_WARN("  - " << info.name.c_str()
-                        << " (priority=" << info.priority
-                        << ", enabled=" << (info.enabled ? "true" : "false")
-                        << ")");
+        FL_WARN_F("  - %s (priority=%s, enabled=%s)", info.name.c_str(), info.priority, (info.enabled ? "true" : "false"));
     }
-    FL_WARN("[VALIDATION] Driver registration OK");
+    FL_WARN_F("[VALIDATION] Driver registration OK");
 }
 
 }  // namespace validation

--- a/src/fl/channels/detail/validation/result_formatter.cpp.hpp
+++ b/src/fl/channels/detail/validation/result_formatter.cpp.hpp
@@ -73,7 +73,7 @@ string formatSummaryTable(const fl::vector<fl::DriverTestResult>& driver_results
 }
 
 void printSummaryTable(const fl::vector<fl::DriverTestResult>& driver_results) {
-    FL_WARN(formatSummaryTable(driver_results).c_str());
+    FL_WARN_F("%s", formatSummaryTable(driver_results).c_str());
 }
 
 }  // namespace validation

--- a/src/fl/channels/detail/validation/rx_test.cpp.hpp
+++ b/src/fl/channels/detail/validation/rx_test.cpp.hpp
@@ -19,7 +19,7 @@ bool testRxChannel(
     u32 hz,
     size_t buffer_size) {
 
-    FL_WARN("[RX TEST] Testing RX channel with manual GPIO toggle on PIN " << pin_tx);
+    FL_WARN_F("[RX TEST] Testing RX channel with manual GPIO toggle on PIN %s", pin_tx);
 
     // Configure PIN_TX as output using fl::pin functions (temporarily take ownership from FastLED)
     fl::pinMode(pin_tx, fl::PinMode::Output);
@@ -39,7 +39,7 @@ bool testRxChannel(
     rx_config.start_low = true;
 
     if (!rx_channel->begin(rx_config)) {
-        FL_ERROR("[RX TEST]: Failed to begin RX channel");
+        FL_ERROR_F("[RX TEST]: Failed to begin RX channel");
         fl::pinMode(pin_tx, fl::PinMode::Input);  // Release pin
         return false;
     }
@@ -64,9 +64,9 @@ bool testRxChannel(
 
     // Check if we successfully captured data
     if (wait_result != fl::RxWaitResult::SUCCESS) {
-        FL_ERROR("[RX TEST]: RX channel wait failed (result: " << static_cast<int>(wait_result) << ")");
-        FL_ERROR("[RX TEST]: RX may not be working - check PIN_RX (" << pin_rx << ") and RMT peripheral");
-        FL_ERROR("[RX TEST]: If using non-RMT TX, ensure physical jumper from PIN " << pin_tx << " to PIN " << pin_rx);
+        FL_ERROR_F("[RX TEST]: RX channel wait failed (result: %s)", static_cast<int>(wait_result));
+        FL_ERROR_F("[RX TEST]: RX may not be working - check PIN_RX (%s) and RMT peripheral", pin_rx);
+        FL_ERROR_F("[RX TEST]: If using non-RMT TX, ensure physical jumper from PIN %s to PIN %s", pin_tx, pin_rx);
         return false;
     }
 
@@ -75,13 +75,13 @@ bool testRxChannel(
     check_edges.resize(4);
     size_t edge_count = rx_channel->getRawEdgeTimes(check_edges, 0);
     if (edge_count == 0) {
-        FL_ERROR("[RX TEST]: wait() succeeded but 0 edges captured - DMA trigger may be misconfigured");
-        FL_ERROR("[RX TEST]: Check DMAMUX source number for PIN_RX (" << pin_rx << ")");
+        FL_ERROR_F("[RX TEST]: wait() succeeded but 0 edges captured - DMA trigger may be misconfigured");
+        FL_ERROR_F("[RX TEST]: Check DMAMUX source number for PIN_RX (%s)", pin_rx);
         return false;
     }
 
-    FL_WARN("[RX TEST] ✓ RX channel captured " << edge_count << " edges from " << num_toggles << " toggles");
-    FL_WARN("[RX TEST] ✓ RX channel is functioning correctly");
+    FL_WARN_F("[RX TEST] ✓ RX channel captured %s edges from %s toggles", edge_count, num_toggles);
+    FL_WARN_F("[RX TEST] ✓ RX channel is functioning correctly");
 
     return true;
 }

--- a/src/fl/channels/driver.cpp.hpp
+++ b/src/fl/channels/driver.cpp.hpp
@@ -30,7 +30,7 @@ bool IChannelDriver::waitForCondition(Condition condition, u32 timeoutMs) {
                     return true;
                 }
                 if (timeoutMs > 0 && (millis() - startTime) >= timeoutMs) {
-                    FL_ERROR("Timeout occurred while waiting for condition");
+                    FL_ERROR_F("Timeout occurred while waiting for condition");
                     return false;
                 }
             }
@@ -40,7 +40,7 @@ bool IChannelDriver::waitForCondition(Condition condition, u32 timeoutMs) {
     while (!condition()) {
         // Check timeout if specified
         if (timeoutMs > 0 && (millis() - startTime >= timeoutMs)) {
-            FL_ERROR("Timeout occurred while waiting for condition");
+            FL_ERROR_F("Timeout occurred while waiting for condition");
             return false;  // Timeout occurred
         }
 

--- a/src/fl/channels/manager.cpp.hpp
+++ b/src/fl/channels/manager.cpp.hpp
@@ -35,14 +35,14 @@ ChannelManager& ChannelManager::instance() {
 ChannelManager::ChannelManager() FL_NOEXCEPT
     : mPollNeededCallback(&ChannelManager::notifyPollNeededThunk, this),
       mPollNeededSignal() {
-    FL_DBG("ChannelManager: Initializing");
+    FL_DBG_F("ChannelManager: Initializing");
 
     // Register as frame event listener for per-frame reset
     EngineEvents::addListener(this);
 }
 
 ChannelManager::~ChannelManager() FL_NOEXCEPT {
-    FL_DBG("ChannelManager: Destructor called");
+    FL_DBG_F("ChannelManager: Destructor called");
 
     // Remove self from EngineEvents listener list
     EngineEvents::removeListener(this);
@@ -86,7 +86,7 @@ u32 ChannelManager::pollNeededWaitSliceMs(u32 startTime, u32 timeoutMs) const FL
 
 void ChannelManager::addDriver(int priority, fl::shared_ptr<IChannelDriver> driver) {
     if (!driver) {
-        FL_WARN("ChannelManager::addDriver() - Null driver provided");
+        FL_WARN_F("ChannelManager::addDriver() - Null driver provided");
         return;
     }
 
@@ -95,7 +95,7 @@ void ChannelManager::addDriver(int priority, fl::shared_ptr<IChannelDriver> driv
 
     // Reject drivers with empty names
     if (engineName.empty()) {
-        FL_WARN("ChannelManager::addDriver() - Engine has empty name (driver->getName() returned empty string)");
+        FL_WARN_F("ChannelManager::addDriver() - Engine has empty name (driver->getName() returned empty string)");
         return;
     }
 
@@ -109,26 +109,24 @@ void ChannelManager::addDriver(int priority, fl::shared_ptr<IChannelDriver> driv
             // replace flow entirely so we don't waitForReady() or emit a
             // spurious "Replacing" warning.
             if (entry.driver == driver && entry.priority == priority) {
-                FL_DBG("ChannelManager::addDriver() - '" << engineName.c_str()
-                       << "' already registered at priority " << priority
-                       << " (idempotent no-op)");
+                FL_DBG_F("ChannelManager::addDriver() - '%s' already registered at priority %s (idempotent no-op)", engineName.c_str(), priority);
                 return;
             }
             replacing = true;
-            FL_WARN("ChannelManager::addDriver() - Replacing existing driver '" << engineName.c_str() << "'");
+            FL_WARN_F("ChannelManager::addDriver() - Replacing existing driver '%s'", engineName.c_str());
             break;
         }
     }
 
     // If replacing, wait for all drivers to become READY
     if (replacing) {
-        FL_DBG("ChannelManager: Waiting for all drivers to become READY before replacement");
+        FL_DBG_F("ChannelManager: Waiting for all drivers to become READY before replacement");
         waitForReady();
 
         // Remove the old driver with matching name (shared_ptr may trigger deletion)
         for (size_t i = 0; i < mDrivers.size(); ++i) {
             if (mDrivers[i].name == engineName) {
-                FL_DBG("ChannelManager: Removing old driver '" << engineName.c_str() << "' (shared_ptr may delete)");
+                FL_DBG_F("ChannelManager: Removing old driver '%s' (shared_ptr may delete)", engineName.c_str());
                 if (mDrivers[i].driver) {
                     mDrivers[i].driver->setPollNeededCallback(IChannelDriver::PollNeededCallback());
                 }
@@ -168,7 +166,7 @@ void ChannelManager::addDriver(int priority, fl::shared_ptr<IChannelDriver> driv
         capStr = "NONE";
     }
 
-    FL_DBG("ChannelManager: Added driver '" << engineName.c_str() << "' (priority " << priority << ", caps: " << capStr.c_str() << ")");
+    FL_DBG_F("ChannelManager: Added driver '%s' (priority %s, caps: %s)", engineName.c_str(), priority, capStr.c_str());
 #endif
 
     // Sort drivers by priority descending (higher values first) after each insertion
@@ -180,14 +178,14 @@ void ChannelManager::addDriver(int priority, fl::shared_ptr<IChannelDriver> driv
 
 bool ChannelManager::removeDriver(fl::shared_ptr<IChannelDriver> driver) {
     if (!driver) {
-        FL_WARN("ChannelManager::removeDriver() - Null driver provided");
+        FL_WARN_F("ChannelManager::removeDriver() - Null driver provided");
         return false;
     }
 
     // Find and remove the driver from the list
     for (size_t i = 0; i < mDrivers.size(); ++i) {
         if (mDrivers[i].driver == driver) {
-            FL_DBG("ChannelManager: Removing driver '" << mDrivers[i].name << "'");
+            FL_DBG_F("ChannelManager: Removing driver '%s'", mDrivers[i].name);
 
             mDrivers[i].driver->setPollNeededCallback(IChannelDriver::PollNeededCallback());
 
@@ -198,18 +196,18 @@ bool ChannelManager::removeDriver(fl::shared_ptr<IChannelDriver> driver) {
     }
 
     // Engine not found
-    FL_WARN("ChannelManager::removeDriver() - Engine " << driver.get() << " not found in registry");
+    FL_WARN_F("ChannelManager::removeDriver() - Engine %s not found in registry", driver.get());
     return false;
 }
 
 void ChannelManager::clearAllDrivers() {
-    FL_DBG("ChannelManager: Waiting for all drivers to become READY before clearing");
+    FL_DBG_F("ChannelManager: Waiting for all drivers to become READY before clearing");
 
     // Wait for all drivers to become READY before clearing
     // This prevents clearing drivers that are still transmitting
     waitForReady();
 
-    FL_DBG("ChannelManager: Clearing " << mDrivers.size() << " drivers");
+    FL_DBG_F("ChannelManager: Clearing %s drivers", mDrivers.size());
 
     for (auto& entry : mDrivers) {
         if (entry.driver) {
@@ -223,7 +221,7 @@ void ChannelManager::clearAllDrivers() {
 
 void ChannelManager::setDriverEnabled(const char* name, bool enabled) {
     if (!name) {
-        FL_ERROR("ChannelManager::setDriverEnabled() - Null driver name provided");
+        FL_ERROR_F("ChannelManager::setDriverEnabled() - Null driver name provided");
         return;
     }
 
@@ -232,12 +230,12 @@ void ChannelManager::setDriverEnabled(const char* name, bool enabled) {
         if (entry.name == name) {
             entry.enabled = enabled;
             found = true;
-            FL_DBG("ChannelManager: Driver '" << name << "' " << (enabled ? "enabled" : "disabled"));
+            FL_DBG_F("ChannelManager: Driver '%s' %s", name, (enabled ? "enabled" : "disabled"));
         }
     }
 
     if (!found) {
-        FL_ERROR("ChannelManager::setDriverEnabled() - Driver '" << name << "' not found in registry");
+        FL_ERROR_F("ChannelManager::setDriverEnabled() - Driver '%s' not found in registry", name);
     }
 }
 
@@ -248,7 +246,7 @@ bool ChannelManager::setExclusiveDriver(Bus bus) {
 bool ChannelManager::setExclusiveDriverByName(const char* name) {
     // Handle null or empty name: disable everything.
     if (!name || !name[0]) {
-        FL_ERROR("ChannelManager::setExclusiveDriverByName() - Null or empty driver name provided");
+        FL_ERROR_F("ChannelManager::setExclusiveDriverByName() - Null or empty driver name provided");
         mExclusiveDriver.clear();
         for (auto& entry : mDrivers) {
             entry.enabled = false;
@@ -268,14 +266,14 @@ bool ChannelManager::setExclusiveDriverByName(const char* name) {
     }
 
     if (!found) {
-        FL_ERROR("ChannelManager::setExclusiveDriverByName() - Driver '" << name << "' not found in registry");
+        FL_ERROR_F("ChannelManager::setExclusiveDriverByName() - Driver '%s' not found in registry", name);
     }
     return found;
 }
 
 bool ChannelManager::setDriverPriority(const fl::string& name, int priority) {
     if (name.empty()) {
-        FL_ERROR("ChannelManager::setDriverPriority() - Empty driver name provided");
+        FL_ERROR_F("ChannelManager::setDriverPriority() - Empty driver name provided");
         return false;
     }
 
@@ -285,13 +283,13 @@ bool ChannelManager::setDriverPriority(const fl::string& name, int priority) {
         if (entry.name == name) {
             entry.priority = priority;
             found = true;
-            FL_DBG("ChannelManager: Driver '" << name << "' priority changed to " << priority);
+            FL_DBG_F("ChannelManager: Driver '%s' priority changed to %s", name, priority);
             break;
         }
     }
 
     if (!found) {
-        FL_ERROR("ChannelManager::setDriverPriority() - Driver '" << name << "' not found in registry");
+        FL_ERROR_F("ChannelManager::setDriverPriority() - Driver '%s' not found in registry", name);
         return false;
     }
 
@@ -299,13 +297,13 @@ bool ChannelManager::setDriverPriority(const fl::string& name, int priority) {
     // 1-4 drivers expected here too — sort_small avoids the quicksort body.
     fl::sort_small(mDrivers.begin(), mDrivers.end());
 
-    FL_DBG("ChannelManager: Engine list re-sorted after priority change");
+    FL_DBG_F("ChannelManager: Engine list re-sorted after priority change");
     return true;
 }
 
 bool ChannelManager::isDriverEnabled(const char* name) const {
     if (!name) {
-        FL_ERROR("ChannelManager::isDriverEnabled() - Null driver name provided");
+        FL_ERROR_F("ChannelManager::isDriverEnabled() - Null driver name provided");
         return false;
     }
 
@@ -315,7 +313,7 @@ bool ChannelManager::isDriverEnabled(const char* name) const {
         }
     }
 
-    FL_ERROR("ChannelManager::isDriverEnabled() - Driver '" << name << "' not found in registry");
+    FL_ERROR_F("ChannelManager::isDriverEnabled() - Driver '%s' not found in registry", name);
     return false;
 }
 
@@ -367,19 +365,19 @@ fl::shared_ptr<IChannelDriver> ChannelManager::findDriverByName(const fl::string
 
 fl::shared_ptr<IChannelDriver> ChannelManager::getDriverByName(const fl::string& name) const {
     if (name.empty()) {
-        FL_ERROR("ChannelManager::getDriverByName() - Empty driver name provided");
+        FL_ERROR_F("ChannelManager::getDriverByName() - Empty driver name provided");
         return fl::shared_ptr<IChannelDriver>();
     }
     auto driver = findDriverByName(name);
     if (!driver) {
-        FL_ERROR("ChannelManager::getDriverByName() - Driver '" << name.c_str() << "' not found or not enabled");
+        FL_ERROR_F("ChannelManager::getDriverByName() - Driver '%s' not found or not enabled", name.c_str());
     }
     return driver;
 }
 
 fl::shared_ptr<IChannelDriver> ChannelManager::selectDriverForChannel(const ChannelDataPtr& data, const fl::string& affinity) {
     if (!data) {
-        FL_ERROR("ChannelManager::selectDriverForChannel() - Null channel data");
+        FL_ERROR_F("ChannelManager::selectDriverForChannel() - Null channel data");
         return fl::shared_ptr<IChannelDriver>();
     }
 
@@ -398,9 +396,7 @@ fl::shared_ptr<IChannelDriver> ChannelManager::selectDriverForChannel(const Chan
             break;  // diagnostic emitted at the channel layer
         }
         if (!driver->canHandle(data)) {
-            FL_WARN_ONCE("ChannelManager: Affinity driver '" << affinity
-                         << "' cannot handle channel data (chipset/bus mismatch). "
-                         << "Falling back to AUTO/priority dispatch.");
+            FL_WARN_F_ONCE("ChannelManager: Affinity driver '%s' cannot handle channel data (chipset/bus mismatch). Falling back to AUTO/priority dispatch.", affinity);
             break;
         }
         return driver;
@@ -415,7 +411,7 @@ fl::shared_ptr<IChannelDriver> ChannelManager::selectDriverForChannel(const Chan
         }
     }
 
-    FL_ERROR("ChannelManager: No compatible driver found for channel data");
+    FL_ERROR_F("ChannelManager: No compatible driver found for channel data");
     return fl::shared_ptr<IChannelDriver>();
 }
 
@@ -443,7 +439,7 @@ bool ChannelManager::waitForCondition(Condition condition, u32 timeoutMs) {
                     return true;
                 }
                 if (timeoutMs > 0 && (millis() - startTime) >= timeoutMs) {
-                    FL_ERROR("ChannelManager: Timeout occurred while waiting for condition");
+                    FL_ERROR_F("ChannelManager: Timeout occurred while waiting for condition");
                     return false;
                 }
             }
@@ -453,7 +449,7 @@ bool ChannelManager::waitForCondition(Condition condition, u32 timeoutMs) {
     while (!condition()) {
         // Check timeout if specified
         if (timeoutMs > 0 && (millis() - startTime >= timeoutMs)) {
-            FL_ERROR("ChannelManager: Timeout occurred while waiting for condition");
+            FL_ERROR_F("ChannelManager: Timeout occurred while waiting for condition");
             return false;  // Timeout occurred
         }
 
@@ -529,7 +525,7 @@ bool ChannelManager::waitForReady(u32 timeoutMs) {
         return poll().state == IChannelDriver::DriverState::READY;
     }, timeoutMs);
     if (!ok) {
-        FL_ERROR("ChannelManager: Timeout occurred while waiting for READY state");
+        FL_ERROR_F("ChannelManager: Timeout occurred while waiting for READY state");
     }
     return ok;
 }
@@ -544,7 +540,7 @@ bool ChannelManager::waitForReadyOrDraining(u32 timeoutMs) {
         return draining_or_done;
     }, timeoutMs);
     if (!ok) {
-        FL_ERROR("ChannelManager: Timeout occurred while waiting for READY or DRAINING state");
+        FL_ERROR_F("ChannelManager: Timeout occurred while waiting for READY or DRAINING state");
     }
     return ok;
 }
@@ -569,7 +565,7 @@ void ChannelManager::onEndFrame() {
 void ChannelManager::reset() {
     // Allow all channel drivers to clean up
     waitForReady();
-    FL_DBG("ChannelManager: reset() - all drivers ready");
+    FL_DBG_F("ChannelManager: reset() - all drivers ready");
 }
 
 ChannelManager& channelManager() {

--- a/src/fl/channels/spi/device.cpp.hpp
+++ b/src/fl/channels/spi/device.cpp.hpp
@@ -20,26 +20,25 @@ namespace spi {
 
 Device::Device(const Config& config)
     : pImpl(fl::make_unique<Impl>(config)) {
-    FL_LOG_SPI("SPI Device: Created with clock=" << config.clock_pin
-           << " data_pins.size()=" << config.data_pins.size());
+    FL_LOG_SPI_F("SPI Device: Created with clock=%s data_pins.size()=%s", config.clock_pin, config.data_pins.size());
 }
 
 Device::~Device() FL_NOEXCEPT {
-    FL_LOG_SPI("SPI Device: Destructor called");
+    FL_LOG_SPI_F("SPI Device: Destructor called");
     if (pImpl && pImpl->initialized) {
-        FL_LOG_SPI("SPI Device: Calling end() from destructor");
+        FL_LOG_SPI_F("SPI Device: Calling end() from destructor");
         end();
     }
 
-    FL_LOG_SPI("SPI Device: Checking owned hardware backend");
+    FL_LOG_SPI_F("SPI Device: Checking owned hardware backend");
     // Clean up owned hardware backend (for SINGLE_SPI mode)
     // Note: hw_backend is now a shared_ptr, so cleanup is automatic
     if (pImpl && pImpl->owns_backend && pImpl->hw_backend) {
-        FL_LOG_SPI("SPI Device: Cleaning up owned hardware backend");
+        FL_LOG_SPI_F("SPI Device: Cleaning up owned hardware backend");
         pImpl->hw_backend->end();
         pImpl->hw_backend = nullptr;
     }
-    FL_LOG_SPI("SPI Device: Destructor complete");
+    FL_LOG_SPI_F("SPI Device: Destructor complete");
 }
 
 fl::optional<fl::task::Error> Device::begin() {
@@ -54,15 +53,14 @@ fl::optional<fl::task::Error> Device::begin() {
 
     // Validate SPI mode (0-3 for CPOL/CPHA combinations)
     if (pImpl->config.spi_mode > 3) {
-        FL_WARN("SPI Device: Invalid SPI mode " << pImpl->config.spi_mode << " (must be 0-3)");
+        FL_WARN_F("SPI Device: Invalid SPI mode %s (must be 0-3)", pImpl->config.spi_mode);
         return fl::task::Error("Invalid SPI mode");
     }
 
     // Note: SPI mode configuration is not yet supported by the hardware layer
     // All devices currently operate in mode 0 (CPOL=0, CPHA=0)
     if (pImpl->config.spi_mode != 0) {
-        FL_WARN("SPI Device: SPI mode " << pImpl->config.spi_mode
-                << " requested but hardware layer only supports mode 0 - ignoring");
+        FL_WARN_F("SPI Device: SPI mode %s requested but hardware layer only supports mode 0 - ignoring", pImpl->config.spi_mode);
     }
 
     // Register with SPIBusManager
@@ -76,13 +74,13 @@ fl::optional<fl::task::Error> Device::begin() {
     );
 
     if (!pImpl->bus_handle.is_valid) {
-        FL_WARN("SPI Device: Failed to register with bus manager");
+        FL_WARN_F("SPI Device: Failed to register with bus manager");
         return fl::task::Error("Failed to register with bus manager");
     }
 
     // Initialize the bus
     if (!mgr.initialize()) {
-        FL_WARN("SPI Device: Bus initialization failed");
+        FL_WARN_F("SPI Device: Bus initialization failed");
         return fl::task::Error("Bus initialization failed");
     }
 
@@ -92,7 +90,7 @@ fl::optional<fl::task::Error> Device::begin() {
         // Create and initialize a SpiHw1 controller
         const fl::vector<fl::shared_ptr<SpiHw1>>& controllers = SpiHw1::getAll();
         if (controllers.empty()) {
-            FL_WARN("SPI Device: No SpiHw1 controllers available on this platform");
+            FL_WARN_F("SPI Device: No SpiHw1 controllers available on this platform");
             return fl::task::Error("No SpiHw1 controllers available");
         }
 
@@ -106,13 +104,13 @@ fl::optional<fl::task::Error> Device::begin() {
         hw_config.bus_num = 0;  // Default to bus 0
 
         if (!hw->begin(hw_config)) {
-            FL_WARN("SPI Device: Failed to initialize SpiHw1 controller");
+            FL_WARN_F("SPI Device: Failed to initialize SpiHw1 controller");
             return fl::task::Error("Failed to initialize SpiHw1");
         }
 
         pImpl->hw_backend = hw;
         pImpl->owns_backend = false;  // We don't own it (it's from the static pool)
-        FL_LOG_SPI("SPI Device: Created SpiHw1 controller for SINGLE_SPI mode");
+        FL_LOG_SPI_F("SPI Device: Created SpiHw1 controller for SINGLE_SPI mode");
     } else {
         // Multi-lane or hardware controller already exists
         pImpl->hw_backend = bus_info ? bus_info->hw_controller : nullptr;
@@ -120,7 +118,7 @@ fl::optional<fl::task::Error> Device::begin() {
     }
 
     pImpl->initialized = true;
-    FL_LOG_SPI("SPI Device: Initialized successfully");
+    FL_LOG_SPI_F("SPI Device: Initialized successfully");
     return fl::nullopt;
 }
 
@@ -146,7 +144,7 @@ void Device::end() {
     }
 
     pImpl->initialized = false;
-    FL_LOG_SPI("SPI Device: Shutdown complete");
+    FL_LOG_SPI_F("SPI Device: Shutdown complete");
 }
 
 bool Device::isReady() const {
@@ -198,14 +196,14 @@ Result<Transaction> Device::writeAsync(const u8* data, size_t size) {
     // Acquire DMA buffer
     DMABuffer buffer = acquireBuffer(size);
     if (!buffer.ok()) {
-        FL_WARN("SPI Device: Failed to acquire DMA buffer for async write");
+        FL_WARN_F("SPI Device: Failed to acquire DMA buffer for async write");
         return Result<Transaction>::failure(buffer.error(), "Failed to acquire DMA buffer");
     }
 
     // Copy data to DMA buffer
     fl::span<u8> buf_span = buffer.data();
     if (buf_span.size() < size) {
-        FL_WARN("SPI Device: Buffer size mismatch");
+        FL_WARN_F("SPI Device: Buffer size mismatch");
         return Result<Transaction>::failure(SPIError::BUFFER_TOO_LARGE, "Buffer size mismatch");
     }
 
@@ -216,7 +214,7 @@ Result<Transaction> Device::writeAsync(const u8* data, size_t size) {
     // Start async transmission
     fl::optional<fl::task::Error> tx_result = transmit(buffer, true);  // true = async
     if (tx_result) {  // If error is present
-        FL_WARN("SPI Device: Failed to start async transmission");
+        FL_WARN_F("SPI Device: Failed to start async transmission");
         return Result<Transaction>::failure(SPIError::NOT_SUPPORTED, tx_result->message.c_str());
     }
 
@@ -232,7 +230,7 @@ Result<Transaction> Device::writeAsync(const u8* data, size_t size) {
     txn.pImpl = fl::make_unique<Transaction::Impl>(this);
     txn.pImpl->completed = false;  // Will complete when hardware finishes
 
-    FL_LOG_SPI("SPI Device: Async write started (" << size << " bytes)");
+    FL_LOG_SPI_F("SPI Device: Async write started (%s bytes)", size);
     return Result<Transaction>::success(fl::move(txn));
 }
 
@@ -263,7 +261,7 @@ DMABuffer Device::acquireBuffer(size_t size) {
 
     // Get hardware controller
     if (!pImpl->hw_backend) {
-        FL_WARN("SPI Device: No hardware controller available");
+        FL_WARN_F("SPI Device: No hardware controller available");
         return DMABuffer(SPIError::NOT_INITIALIZED);
     }
 
@@ -275,9 +273,9 @@ DMABuffer Device::acquireBuffer(size_t size) {
     DMABuffer buffer = hw->acquireDMABuffer(size);
 
     if (!buffer.ok()) {
-        FL_WARN("SPI Device: Failed to acquire DMA buffer from hardware");
+        FL_WARN_F("SPI Device: Failed to acquire DMA buffer from hardware");
     } else {
-        FL_LOG_SPI("SPI Device: Acquired DMA buffer (" << size << " bytes)");
+        FL_LOG_SPI_F("SPI Device: Acquired DMA buffer (%s bytes)", size);
     }
 
     return buffer;
@@ -294,7 +292,7 @@ fl::optional<fl::task::Error> Device::transmit(DMABuffer& buffer, bool async) {
 
     // Get hardware controller
     if (!pImpl->hw_backend) {
-        FL_WARN("SPI Device: No hardware controller available");
+        FL_WARN_F("SPI Device: No hardware controller available");
         return fl::task::Error("No hardware controller");
     }
 
@@ -306,19 +304,19 @@ fl::optional<fl::task::Error> Device::transmit(DMABuffer& buffer, bool async) {
     bool success = hw->transmit(mode);
 
     if (!success) {
-        FL_WARN("SPI Device: Transmission failed");
+        FL_WARN_F("SPI Device: Transmission failed");
         return fl::task::Error("Transmission failed");
     }
 
     // If blocking mode, wait for completion
     if (!async) {
         if (!hw->waitComplete()) {
-            FL_WARN("SPI Device: Wait for completion failed");
+            FL_WARN_F("SPI Device: Wait for completion failed");
             return fl::task::Error("Wait for completion failed");
         }
     }
 
-    FL_LOG_SPI("SPI Device: Transmission started (" << (async ? "async" : "blocking") << ")");
+    FL_LOG_SPI_F("SPI Device: Transmission started (%s)", (async ? "async" : "blocking"));
     return fl::nullopt;
 }
 
@@ -329,7 +327,7 @@ bool Device::waitComplete(u32 timeout_ms) {
 
     // Get hardware controller
     if (!pImpl->hw_backend) {
-        FL_WARN("SPI Device: No hardware controller available");
+        FL_WARN_F("SPI Device: No hardware controller available");
         return false;
     }
 
@@ -368,10 +366,9 @@ fl::optional<fl::task::Error> Device::setClockSpeed(u32 speed_hz) {
     // To apply immediately, call end() followed by begin().
 
     if (pImpl->initialized) {
-        FL_LOG_SPI("SPI Device: Clock speed updated to " << speed_hz
-               << " Hz (will take effect on next begin())");
+        FL_LOG_SPI_F("SPI Device: Clock speed updated to %s Hz (will take effect on next begin())", speed_hz);
     } else {
-        FL_LOG_SPI("SPI Device: Clock speed set to " << speed_hz << " Hz");
+        FL_LOG_SPI_F("SPI Device: Clock speed set to %s Hz", speed_hz);
     }
 
     return fl::nullopt;
@@ -435,8 +432,10 @@ bool Transaction::wait(u32 timeout_ms) {
         return false;
     }
 
-    // Wait for the hardware to complete
+#ifdef FASTLED_LOG_SPI_ENABLED
     u32 start_time = fl::millis();
+#endif
+    // Wait for the hardware to complete
     bool success = pImpl->device->waitComplete(timeout_ms);
 
     if (success) {
@@ -447,14 +446,15 @@ bool Transaction::wait(u32 timeout_ms) {
         pImpl->completed = true;
         pImpl->result = fl::nullopt;
 
-        u32 elapsed = fl::millis() - start_time;
-        FL_LOG_SPI("Transaction: Completed successfully (waited " << elapsed << "ms)");
+#ifdef FASTLED_LOG_SPI_ENABLED
+        FL_LOG_SPI_F("Transaction: Completed successfully (waited %sms)", fl::millis() - start_time);
+#endif
         return true;
     } else {
         // Timeout occurred
         pImpl->completed = true;
         pImpl->result = fl::task::Error("Transaction timeout");
-        FL_WARN("Transaction: Timeout after " << timeout_ms << "ms");
+        FL_WARN_F("Transaction: Timeout after %sms", timeout_ms);
         return false;
     }
 }
@@ -485,7 +485,7 @@ bool Transaction::cancel() {
         pImpl->device->pImpl->async_state.active = false;
     }
 
-    FL_LOG_SPI("Transaction: Cancelled");
+    FL_LOG_SPI_F("Transaction: Cancelled");
     return true;
 }
 

--- a/src/fl/channels/spi/impl.h
+++ b/src/fl/channels/spi/impl.h
@@ -49,7 +49,7 @@ struct Device::Impl {
 
     /// @brief Destructor
     ~Impl() FL_NOEXCEPT {
-        FL_LOG_SPI("Device::Impl: Destructor called");
+        FL_LOG_SPI_F("Device::Impl: Destructor called");
         // Members will be destroyed in reverse order of declaration:
         // 1. owns_backend (bool) - trivial
         // 2. hw_backend (void*) - trivial (pointer not owned here)
@@ -57,7 +57,7 @@ struct Device::Impl {
         // 4. initialized (bool) - trivial
         // 5. bus_handle (struct) - trivial
         // 6. config (Config) - contains fl::vector which might cause issues
-        FL_LOG_SPI("Device::Impl: Destructor complete");
+        FL_LOG_SPI_F("Device::Impl: Destructor complete");
     }
 };
 

--- a/src/fl/channels/spi/lane.cpp.hpp
+++ b/src/fl/channels/spi/lane.cpp.hpp
@@ -12,7 +12,7 @@ Lane::Lane(size_t lane_id, MultiLaneDevice* parent)
 
 void Lane::write(const u8* data, size_t size) {
     if (!data || size == 0) {
-        FL_WARN("Lane " << mLaneId << ": Invalid data or size");
+        FL_WARN_F("Lane %s: Invalid data or size", mLaneId);
         return;
     }
 
@@ -24,7 +24,7 @@ void Lane::write(const u8* data, size_t size) {
         mBuffer[i] = data[i];
     }
 
-    FL_DBG("Lane " << mLaneId << ": Buffered " << size << " bytes");
+    FL_DBG_F("Lane %s: Buffered %s bytes", mLaneId, size);
 }
 
 fl::span<u8> Lane::getBuffer(size_t size) {

--- a/src/fl/channels/spi/multi_lane_device.cpp.hpp
+++ b/src/fl/channels/spi/multi_lane_device.cpp.hpp
@@ -62,11 +62,10 @@ MultiLaneDevice::MultiLaneDevice(const Config& config)
     // Validate configuration
     size_t num_lanes = config.data_pins.size();
     if (num_lanes < 1 || num_lanes > 8) {
-        FL_WARN("MultiLaneDevice: Invalid number of data pins (" << num_lanes
-                << "), must be 1-8");
+        FL_WARN_F("MultiLaneDevice: Invalid number of data pins (%s), must be 1-8", num_lanes);
     }
 
-    FL_DBG("MultiLaneDevice: Created with " << num_lanes << " lane(s)");
+    FL_DBG_F("MultiLaneDevice: Created with %s lane(s)", num_lanes);
 }
 
 MultiLaneDevice::~MultiLaneDevice() FL_NOEXCEPT {
@@ -97,7 +96,7 @@ fl::optional<fl::task::Error> MultiLaneDevice::begin() {
         // Try Single-SPI (SpiHw1)
         const auto& controllers = SpiHw1::getAll();
         if (controllers.empty()) {
-            FL_WARN("MultiLaneDevice: No Single-SPI hardware available");
+            FL_WARN_F("MultiLaneDevice: No Single-SPI hardware available");
             return fl::task::Error("Single-SPI hardware not available");
         }
 
@@ -111,7 +110,7 @@ fl::optional<fl::task::Error> MultiLaneDevice::begin() {
         }
 
         if (!hw) {
-            FL_WARN("MultiLaneDevice: All Single-SPI controllers in use");
+            FL_WARN_F("MultiLaneDevice: All Single-SPI controllers in use");
             return fl::task::Error("All Single-SPI controllers already in use");
         }
 
@@ -123,19 +122,19 @@ fl::optional<fl::task::Error> MultiLaneDevice::begin() {
         hw_config.data_pin = pImpl->config.data_pins[0];
 
         if (!hw->begin(hw_config)) {
-            FL_WARN("MultiLaneDevice: Failed to initialize Single-SPI hardware");
+            FL_WARN_F("MultiLaneDevice: Failed to initialize Single-SPI hardware");
             return fl::task::Error("Failed to initialize Single-SPI hardware");
         }
 
         pImpl->backend = hw;
         pImpl->backend_type = 1;
-        FL_DBG("MultiLaneDevice: Initialized Single-SPI (" << hw->getName() << ")");
+        FL_DBG_F("MultiLaneDevice: Initialized Single-SPI (%s)", hw->getName());
 
     } else if (num_lanes == 2) {
         // Try Dual-SPI (SpiHw2)
         const auto& controllers = SpiHw2::getAll();
         if (controllers.empty()) {
-            FL_WARN("MultiLaneDevice: No Dual-SPI hardware available");
+            FL_WARN_F("MultiLaneDevice: No Dual-SPI hardware available");
             return fl::task::Error("Dual-SPI hardware not available");
         }
 
@@ -149,7 +148,7 @@ fl::optional<fl::task::Error> MultiLaneDevice::begin() {
         }
 
         if (!hw) {
-            FL_WARN("MultiLaneDevice: All Dual-SPI controllers in use");
+            FL_WARN_F("MultiLaneDevice: All Dual-SPI controllers in use");
             return fl::task::Error("All Dual-SPI controllers already in use");
         }
 
@@ -162,19 +161,19 @@ fl::optional<fl::task::Error> MultiLaneDevice::begin() {
         hw_config.data1_pin = pImpl->config.data_pins[1];
 
         if (!hw->begin(hw_config)) {
-            FL_WARN("MultiLaneDevice: Failed to initialize Dual-SPI hardware");
+            FL_WARN_F("MultiLaneDevice: Failed to initialize Dual-SPI hardware");
             return fl::task::Error("Failed to initialize Dual-SPI hardware");
         }
 
         pImpl->backend = hw;
         pImpl->backend_type = 2;
-        FL_DBG("MultiLaneDevice: Initialized Dual-SPI (" << hw->getName() << ")");
+        FL_DBG_F("MultiLaneDevice: Initialized Dual-SPI (%s)", hw->getName());
 
     } else if (num_lanes >= 3 && num_lanes <= 4) {
         // Try Quad-SPI (SpiHw4)
         const auto& controllers = SpiHw4::getAll();
         if (controllers.empty()) {
-            FL_WARN("MultiLaneDevice: No Quad-SPI hardware available");
+            FL_WARN_F("MultiLaneDevice: No Quad-SPI hardware available");
             return fl::task::Error("Quad-SPI hardware not available");
         }
 
@@ -188,7 +187,7 @@ fl::optional<fl::task::Error> MultiLaneDevice::begin() {
         }
 
         if (!hw) {
-            FL_WARN("MultiLaneDevice: All Quad-SPI controllers in use");
+            FL_WARN_F("MultiLaneDevice: All Quad-SPI controllers in use");
             return fl::task::Error("All Quad-SPI controllers already in use");
         }
 
@@ -203,19 +202,19 @@ fl::optional<fl::task::Error> MultiLaneDevice::begin() {
         hw_config.data3_pin = (num_lanes > 3) ? pImpl->config.data_pins[3] : -1;
 
         if (!hw->begin(hw_config)) {
-            FL_WARN("MultiLaneDevice: Failed to initialize Quad-SPI hardware");
+            FL_WARN_F("MultiLaneDevice: Failed to initialize Quad-SPI hardware");
             return fl::task::Error("Failed to initialize Quad-SPI hardware");
         }
 
         pImpl->backend = hw;
         pImpl->backend_type = 4;
-        FL_DBG("MultiLaneDevice: Initialized Quad-SPI (" << hw->getName() << ")");
+        FL_DBG_F("MultiLaneDevice: Initialized Quad-SPI (%s)", hw->getName());
 
     } else if (num_lanes >= 5 && num_lanes <= 8) {
         // Try Octal-SPI (SpiHw8)
         const auto& controllers = SpiHw8::getAll();
         if (controllers.empty()) {
-            FL_WARN("MultiLaneDevice: No Octal-SPI hardware available");
+            FL_WARN_F("MultiLaneDevice: No Octal-SPI hardware available");
             return fl::task::Error("Octal-SPI hardware not available");
         }
 
@@ -229,7 +228,7 @@ fl::optional<fl::task::Error> MultiLaneDevice::begin() {
         }
 
         if (!hw) {
-            FL_WARN("MultiLaneDevice: All Octal-SPI controllers in use");
+            FL_WARN_F("MultiLaneDevice: All Octal-SPI controllers in use");
             return fl::task::Error("All Octal-SPI controllers already in use");
         }
 
@@ -248,13 +247,13 @@ fl::optional<fl::task::Error> MultiLaneDevice::begin() {
         hw_config.data7_pin = (num_lanes > 7) ? pImpl->config.data_pins[7] : -1;
 
         if (!hw->begin(hw_config)) {
-            FL_WARN("MultiLaneDevice: Failed to initialize Octal-SPI hardware");
+            FL_WARN_F("MultiLaneDevice: Failed to initialize Octal-SPI hardware");
             return fl::task::Error("Failed to initialize Octal-SPI hardware");
         }
 
         pImpl->backend = hw;
         pImpl->backend_type = 8;
-        FL_DBG("MultiLaneDevice: Initialized Octal-SPI (" << hw->getName() << ")");
+        FL_DBG_F("MultiLaneDevice: Initialized Octal-SPI (%s)", hw->getName());
     }
 
     pImpl->initialized = true;
@@ -277,7 +276,7 @@ void MultiLaneDevice::end() {
         lane.clear();
     }
 
-    FL_DBG("MultiLaneDevice: Shutdown complete");
+    FL_DBG_F("MultiLaneDevice: Shutdown complete");
 }
 
 bool MultiLaneDevice::isReady() const {
@@ -286,7 +285,7 @@ bool MultiLaneDevice::isReady() const {
 
 Lane& MultiLaneDevice::lane(size_t lane_id) {
     if (!pImpl || lane_id >= pImpl->lanes.size()) {
-        FL_WARN("MultiLaneDevice: Invalid lane ID " << lane_id);
+        FL_WARN_F("MultiLaneDevice: Invalid lane ID %s", lane_id);
         // Return first lane as fallback (avoid crash)
         static Lane dummy_lane(0, nullptr); // okay static in header
         return dummy_lane;
@@ -318,8 +317,7 @@ Result<void> MultiLaneDevice::flush() {
                 found_first = true;
             } else if (lane_size != expected_size) {
                 // Size mismatch detected
-                FL_WARN("MultiLaneDevice: Lane size mismatch - expected " << expected_size
-                        << " bytes (lane 0), but lane " << i << " has " << lane_size << " bytes");
+                FL_WARN_F("MultiLaneDevice: Lane size mismatch - expected %s bytes (lane 0), but lane %s has %s bytes", expected_size, i, lane_size);
                 return Result<void>::failure(SPIError::INVALID_PARAMETER,
                     "Lane size mismatch: all lanes must have identical sizes");
             }
@@ -327,7 +325,7 @@ Result<void> MultiLaneDevice::flush() {
     }
 
     if (expected_size == 0) {
-        FL_WARN("MultiLaneDevice: No data to flush (all lanes empty)");
+        FL_WARN_F("MultiLaneDevice: No data to flush (all lanes empty)");
         return Result<void>::failure(SPIError::ALLOCATION_FAILED,
             "No data to transmit");
     }
@@ -339,7 +337,7 @@ Result<void> MultiLaneDevice::flush() {
     DMABuffer dma_buffer = pImpl->backend->acquireDMABuffer(max_size);
 
     if (!dma_buffer.ok()) {
-        FL_WARN("MultiLaneDevice: Failed to acquire DMA buffer");
+        FL_WARN_F("MultiLaneDevice: Failed to acquire DMA buffer");
         return Result<void>::failure(dma_buffer.error(),
             "Failed to acquire DMA buffer");
     }
@@ -356,8 +354,7 @@ Result<void> MultiLaneDevice::flush() {
 
             // Verify sizes match (DMA buffer should be exactly the size we requested)
             if (lane_data.size() != dma_data.size()) {
-                FL_WARN("MultiLaneDevice: DMA buffer size mismatch - expected " << lane_data.size()
-                        << " bytes, got " << dma_data.size() << " bytes");
+                FL_WARN_F("MultiLaneDevice: DMA buffer size mismatch - expected %s bytes, got %s bytes", lane_data.size(), dma_data.size());
                 error = "DMA buffer size mismatch";
                 transpose_ok = false;
             } else {
@@ -417,7 +414,7 @@ Result<void> MultiLaneDevice::flush() {
     }
 
     if (!transpose_ok) {
-        FL_WARN("MultiLaneDevice: Transposition failed - " << (error ? error : "unknown error"));
+        FL_WARN_F("MultiLaneDevice: Transposition failed - %s", (error ? error : "unknown error"));
         return Result<void>::failure(SPIError::ALLOCATION_FAILED,
             error ? error : "Transposition failed");
     }
@@ -426,7 +423,7 @@ Result<void> MultiLaneDevice::flush() {
     bool transmit_ok = pImpl->backend->transmit(TransmitMode::ASYNC);
 
     if (!transmit_ok) {
-        FL_WARN("MultiLaneDevice: Hardware transmit failed");
+        FL_WARN_F("MultiLaneDevice: Hardware transmit failed");
         return Result<void>::failure(SPIError::BUSY,
             "Hardware transmit failed");
     }
@@ -436,8 +433,7 @@ Result<void> MultiLaneDevice::flush() {
         lane.clear();
     }
 
-    FL_DBG("MultiLaneDevice: Flushed " << pImpl->lanes.size() << " lanes ("
-           << max_size << " bytes per lane)");
+    FL_DBG_F("MultiLaneDevice: Flushed %s lanes (%s bytes per lane)", pImpl->lanes.size(), max_size);
 
     // Success - transmission started asynchronously
     // User must call waitComplete() manually to block until transmission completes
@@ -464,13 +460,12 @@ bool MultiLaneDevice::isBusy() const {
 
 WriteResult MultiLaneDevice::writeImpl(fl::span<const fl::span<const u8>> lane_data) {
     if (!isReady()) {
-        FL_WARN("MultiLaneDevice: Not ready for write");
+        FL_WARN_F("MultiLaneDevice: Not ready for write");
         return WriteResult("Device not ready");
     }
 
     if (lane_data.size() > pImpl->lanes.size()) {
-        FL_WARN("MultiLaneDevice: Too many lanes provided (" << lane_data.size()
-                << " > " << pImpl->lanes.size() << ")");
+        FL_WARN_F("MultiLaneDevice: Too many lanes provided (%s > %s)", lane_data.size(), pImpl->lanes.size());
         return WriteResult("Too many lanes provided");
     }
 
@@ -479,8 +474,7 @@ WriteResult MultiLaneDevice::writeImpl(fl::span<const fl::span<const u8>> lane_d
         size_t first_size = lane_data[0].size();
         for (size_t i = 1; i < lane_data.size(); i++) {
             if (lane_data[i].size() != first_size) {
-                FL_WARN("MultiLaneDevice: Lane size mismatch - lane 0 has " << first_size
-                        << " bytes, lane " << i << " has " << lane_data[i].size() << " bytes");
+                FL_WARN_F("MultiLaneDevice: Lane size mismatch - lane 0 has %s bytes, lane %s has %s bytes", first_size, i, lane_data[i].size());
                 return WriteResult("Lane size mismatch: all lanes must have identical sizes");
             }
         }
@@ -497,11 +491,11 @@ WriteResult MultiLaneDevice::writeImpl(fl::span<const fl::span<const u8>> lane_d
     // Start hardware transmission (async)
     auto flush_result = flush();
     if (!flush_result.ok()) {
-        FL_WARN("MultiLaneDevice: Flush failed");
+        FL_WARN_F("MultiLaneDevice: Flush failed");
         return WriteResult("Flush failed");
     }
 
-    FL_DBG("MultiLaneDevice: Wrote " << lane_data.size() << " lanes atomically (async)");
+    FL_DBG_F("MultiLaneDevice: Wrote %s lanes atomically (async)", lane_data.size());
 
     // Return success - use device->wait() to block until complete
     return WriteResult();

--- a/src/fl/channels/spi/parallel_device.cpp.hpp
+++ b/src/fl/channels/spi/parallel_device.cpp.hpp
@@ -139,11 +139,10 @@ ParallelDevice::ParallelDevice(const Config& config)
     // Validate configuration
     size_t num_pins = config.gpio_pins.size();
     if (num_pins == 0 || num_pins > 32) {
-        FL_WARN("ParallelDevice: Invalid number of GPIO pins (" << num_pins
-                << "), must be 1-32");
+        FL_WARN_F("ParallelDevice: Invalid number of GPIO pins (%s), must be 1-32", num_pins);
     }
 
-    FL_DBG("ParallelDevice: Created with " << num_pins << " GPIO pins");
+    FL_DBG_F("ParallelDevice: Created with %s GPIO pins", num_pins);
 }
 
 ParallelDevice::~ParallelDevice() FL_NOEXCEPT {
@@ -195,7 +194,7 @@ fl::optional<fl::task::Error> ParallelDevice::begin() {
 
     if (use_isr) {
         // ISR-based backend
-        FL_DBG("ParallelDevice: Initializing ISR mode (width=" << (int)backend_width << ")");
+        FL_DBG_F("ParallelDevice: Initializing ISR mode (width=%s)", (int)backend_width);
 
         // Note: These need to be heap-allocated for type-erasure
         // For now, return error indicating ISR mode not yet implemented
@@ -203,7 +202,7 @@ fl::optional<fl::task::Error> ParallelDevice::begin() {
 
     } else {
         // Bit-bang (blocking) backend
-        FL_DBG("ParallelDevice: Initializing bit-bang mode (width=" << (int)backend_width << ")");
+        FL_DBG_F("ParallelDevice: Initializing bit-bang mode (width=%s)", (int)backend_width);
 
         // Note: These need to be heap-allocated for type-erasure
         // For now, return error indicating bit-bang mode not yet implemented
@@ -225,7 +224,7 @@ void ParallelDevice::end() {
     // Release backend
     pImpl->releaseBackend();
 
-    FL_DBG("ParallelDevice: Shutdown complete");
+    FL_DBG_F("ParallelDevice: Shutdown complete");
 }
 
 bool ParallelDevice::isReady() const {
@@ -273,13 +272,13 @@ bool ParallelDevice::isBusy() const {
 
 void ParallelDevice::configureLUT(const u32* set_masks, const u32* clear_masks) {
     if (!set_masks || !clear_masks) {
-        FL_WARN("ParallelDevice: Invalid LUT pointers");
+        FL_WARN_F("ParallelDevice: Invalid LUT pointers");
         return;
     }
 
     // LUT configuration depends on backend type
     // For now, this is a no-op
-    FL_DBG("ParallelDevice: LUT configuration not yet implemented");
+    FL_DBG_F("ParallelDevice: LUT configuration not yet implemented");
 }
 
 const ParallelDevice::Config& ParallelDevice::getConfig() const {

--- a/src/fl/channels/spi/spi.cpp.hpp
+++ b/src/fl/channels/spi/spi.cpp.hpp
@@ -27,7 +27,7 @@ Spi::Spi(const SpiConfig& config)
     // Validate number of lanes
     size_t num_lanes = config.data_pins.size();
     if (num_lanes < 1 || num_lanes > 8) {
-        FL_WARN("fl::Spi: Invalid number of data pins (" << num_lanes << "), must be 1-8");
+        FL_WARN_F("fl::Spi: Invalid number of data pins (%s), must be 1-8", num_lanes);
         error_code = SPIError::NOT_INITIALIZED;
         return;
     }
@@ -44,13 +44,13 @@ Spi::Spi(const SpiConfig& config)
 
     // Create device
     device = fl::make_unique<spi::MultiLaneDevice>(ml_config);
-    FL_DBG("fl::Spi: Created MultiLaneDevice with " << num_lanes << " lane(s)");
+    FL_DBG_F("fl::Spi: Created MultiLaneDevice with %s lane(s)", num_lanes);
 
     // Initialize device
     auto begin_result = device->begin();
     if (begin_result) {
         // begin() returned an error (optional has a value)
-        FL_WARN("fl::Spi: begin() failed");
+        FL_WARN_F("fl::Spi: begin() failed");
         error_code = SPIError::NOT_INITIALIZED;
         device.reset();
         return;

--- a/src/fl/codec/file_system_codecs.cpp.hpp
+++ b/src/fl/codec/file_system_codecs.cpp.hpp
@@ -105,7 +105,7 @@ FramePtr FileSystem::loadJpeg(const char *path, const JpegConfig &config,
     fl::ifstream file = openRead(path);
     if (!file.is_open()) {
         if (error_message) { *error_message = "Failed to open file: "; error_message->append(path); }
-        FL_WARN("Failed to open JPEG file: " << path); return FramePtr();
+        FL_WARN_F("Failed to open JPEG file: %s", path); return FramePtr();
     }
     fl::size fileSize = file.size();
     if (fileSize == 0) {
@@ -129,7 +129,7 @@ FramePtr FileSystem::loadJpeg(const char *path, const JpegConfig &config,
             error_message->append(" bytes, got ");
             error_message->append(static_cast<u32>(bytesRead));
         }
-        FL_WARN("Failed to read complete JPEG file: " << path); return FramePtr();
+        FL_WARN_F("Failed to read complete JPEG file: %s", path); return FramePtr();
     }
     fl::span<const u8> jpegData(buffer.data(), buffer.size());
     FramePtr frame = Jpeg::decode(config, jpegData, error_message);
@@ -143,13 +143,13 @@ fl::Mp3DecoderPtr FileSystem::openMp3(const char *path, fl::string *error_messag
     fl::ifstream file = openRead(path);
     if (!file.is_open()) {
         if (error_message) { *error_message = "Failed to open file: "; error_message->append(path); }
-        FL_WARN("Failed to open MP3 file: " << path); return fl::Mp3DecoderPtr();
+        FL_WARN_F("Failed to open MP3 file: %s", path); return fl::Mp3DecoderPtr();
     }
     fl::Mp3DecoderPtr decoder = fl::Mp3::createDecoder(error_message);
     if (!decoder->begin(file.rdbuf())) {
         fl::string decoder_error; decoder->hasError(&decoder_error);
         if (error_message) { *error_message = "Failed to initialize MP3 decoder: "; error_message->append(decoder_error); }
-        FL_WARN("Failed to initialize MP3 decoder for: " << path); return fl::Mp3DecoderPtr();
+        FL_WARN_F("Failed to initialize MP3 decoder for: %s", path); return fl::Mp3DecoderPtr();
     }
     return decoder;
 }

--- a/src/fl/control/wled.cpp.hpp
+++ b/src/fl/control/wled.cpp.hpp
@@ -13,19 +13,19 @@ WLED::WLED()
     ) {}
 
 fl::optional<fl::json> WLED::stubRequestSource() {
-    FL_ERROR("WLED::stubRequestSource: Not implemented - provide a real RequestSource callback");
+    FL_ERROR_F("WLED::stubRequestSource: Not implemented - provide a real RequestSource callback");
     return fl::nullopt;
 }
 
 void WLED::stubResponseSink(const fl::json& response) {
-    FL_ERROR("WLED::stubResponseSink: Not implemented - provide a real ResponseSink callback");
+    FL_ERROR_F("WLED::stubResponseSink: Not implemented - provide a real ResponseSink callback");
 }
 
 // WLED State Management
 
 void WLED::setState(const fl::json& wledState) {
     if (!wledState.has_value()) {
-        FL_WARN("WLED: setState called with invalid JSON");
+        FL_WARN_F("WLED: setState called with invalid JSON");
         return;
     }
 
@@ -34,7 +34,7 @@ void WLED::setState(const fl::json& wledState) {
         bool newOn = wledState["on"] | mWledOn;
         if (newOn != mWledOn) {
             mWledOn = newOn;
-            FL_DBG("WLED: on=" << (mWledOn ? "true" : "false"));
+            FL_DBG_F("WLED: on=%s", (mWledOn ? "true" : "false"));
         }
     }
 
@@ -44,19 +44,19 @@ void WLED::setState(const fl::json& wledState) {
             i64 briInt = wledState["bri"] | static_cast<i64>(mWledBri);
             // Clamp to valid range 0-255
             if (briInt < 0) {
-                FL_WARN("WLED: brightness " << briInt << " out of range, clamping to 0");
+                FL_WARN_F("WLED: brightness %s out of range, clamping to 0", briInt);
                 briInt = 0;
             } else if (briInt > 255) {
-                FL_WARN("WLED: brightness " << briInt << " out of range, clamping to 255");
+                FL_WARN_F("WLED: brightness %s out of range, clamping to 255", briInt);
                 briInt = 255;
             }
             u8 newBri = static_cast<u8>(briInt);
             if (newBri != mWledBri) {
                 mWledBri = newBri;
-                FL_DBG("WLED: bri=" << static_cast<int>(mWledBri));
+                FL_DBG_F("WLED: bri=%s", static_cast<int>(mWledBri));
             }
         } else {
-            FL_WARN("WLED: 'bri' field has invalid type (expected int)");
+            FL_WARN_F("WLED: 'bri' field has invalid type (expected int)");
         }
     }
 
@@ -66,19 +66,19 @@ void WLED::setState(const fl::json& wledState) {
             i64 transInt = wledState["transition"] | static_cast<i64>(mTransition);
             // Clamp to valid range 0-65535
             if (transInt < 0) {
-                FL_WARN("WLED: transition " << transInt << " out of range, clamping to 0");
+                FL_WARN_F("WLED: transition %s out of range, clamping to 0", transInt);
                 transInt = 0;
             } else if (transInt > 65535) {
-                FL_WARN("WLED: transition " << transInt << " out of range, clamping to 65535");
+                FL_WARN_F("WLED: transition %s out of range, clamping to 65535", transInt);
                 transInt = 65535;
             }
             u16 newTransition = static_cast<u16>(transInt);
             if (newTransition != mTransition) {
                 mTransition = newTransition;
-                FL_DBG("WLED: transition=" << mTransition);
+                FL_DBG_F("WLED: transition=%s", mTransition);
             }
         } else {
-            FL_WARN("WLED: 'transition' field has invalid type (expected int)");
+            FL_WARN_F("WLED: 'transition' field has invalid type (expected int)");
         }
     }
 
@@ -88,19 +88,19 @@ void WLED::setState(const fl::json& wledState) {
             i64 psInt = wledState["ps"] | static_cast<i64>(mPreset);
             // Clamp to valid range -1 to 250
             if (psInt < -1) {
-                FL_WARN("WLED: preset " << psInt << " out of range, clamping to -1");
+                FL_WARN_F("WLED: preset %s out of range, clamping to -1", psInt);
                 psInt = -1;
             } else if (psInt > 250) {
-                FL_WARN("WLED: preset " << psInt << " out of range, clamping to 250");
+                FL_WARN_F("WLED: preset %s out of range, clamping to 250", psInt);
                 psInt = 250;
             }
             i16 newPreset = static_cast<i16>(psInt);
             if (newPreset != mPreset) {
                 mPreset = newPreset;
-                FL_DBG("WLED: ps=" << mPreset);
+                FL_DBG_F("WLED: ps=%s", mPreset);
             }
         } else {
-            FL_WARN("WLED: 'ps' field has invalid type (expected int)");
+            FL_WARN_F("WLED: 'ps' field has invalid type (expected int)");
         }
     }
 
@@ -110,19 +110,19 @@ void WLED::setState(const fl::json& wledState) {
             i64 plInt = wledState["pl"] | static_cast<i64>(mPlaylist);
             // Clamp to valid range -1 to 250
             if (plInt < -1) {
-                FL_WARN("WLED: playlist " << plInt << " out of range, clamping to -1");
+                FL_WARN_F("WLED: playlist %s out of range, clamping to -1", plInt);
                 plInt = -1;
             } else if (plInt > 250) {
-                FL_WARN("WLED: playlist " << plInt << " out of range, clamping to 250");
+                FL_WARN_F("WLED: playlist %s out of range, clamping to 250", plInt);
                 plInt = 250;
             }
             i16 newPlaylist = static_cast<i16>(plInt);
             if (newPlaylist != mPlaylist) {
                 mPlaylist = newPlaylist;
-                FL_DBG("WLED: pl=" << mPlaylist);
+                FL_DBG_F("WLED: pl=%s", mPlaylist);
             }
         } else {
-            FL_WARN("WLED: 'pl' field has invalid type (expected int)");
+            FL_WARN_F("WLED: 'pl' field has invalid type (expected int)");
         }
     }
 
@@ -132,19 +132,19 @@ void WLED::setState(const fl::json& wledState) {
             i64 lorInt = wledState["lor"] | static_cast<i64>(mLiveOverride);
             // Clamp to valid range 0-2
             if (lorInt < 0) {
-                FL_WARN("WLED: live override " << lorInt << " out of range, clamping to 0");
+                FL_WARN_F("WLED: live override %s out of range, clamping to 0", lorInt);
                 lorInt = 0;
             } else if (lorInt > 2) {
-                FL_WARN("WLED: live override " << lorInt << " out of range, clamping to 2");
+                FL_WARN_F("WLED: live override %s out of range, clamping to 2", lorInt);
                 lorInt = 2;
             }
             u8 newLiveOverride = static_cast<u8>(lorInt);
             if (newLiveOverride != mLiveOverride) {
                 mLiveOverride = newLiveOverride;
-                FL_DBG("WLED: lor=" << static_cast<int>(mLiveOverride));
+                FL_DBG_F("WLED: lor=%s", static_cast<int>(mLiveOverride));
             }
         } else {
-            FL_WARN("WLED: 'lor' field has invalid type (expected int)");
+            FL_WARN_F("WLED: 'lor' field has invalid type (expected int)");
         }
     }
 
@@ -154,19 +154,19 @@ void WLED::setState(const fl::json& wledState) {
             i64 mainsegInt = wledState["mainseg"] | static_cast<i64>(mMainSegment);
             // Clamp to valid range 0-255
             if (mainsegInt < 0) {
-                FL_WARN("WLED: main segment " << mainsegInt << " out of range, clamping to 0");
+                FL_WARN_F("WLED: main segment %s out of range, clamping to 0", mainsegInt);
                 mainsegInt = 0;
             } else if (mainsegInt > 255) {
-                FL_WARN("WLED: main segment " << mainsegInt << " out of range, clamping to 255");
+                FL_WARN_F("WLED: main segment %s out of range, clamping to 255", mainsegInt);
                 mainsegInt = 255;
             }
             u8 newMainSegment = static_cast<u8>(mainsegInt);
             if (newMainSegment != mMainSegment) {
                 mMainSegment = newMainSegment;
-                FL_DBG("WLED: mainseg=" << static_cast<int>(mMainSegment));
+                FL_DBG_F("WLED: mainseg=%s", static_cast<int>(mMainSegment));
             }
         } else {
-            FL_WARN("WLED: 'mainseg' field has invalid type (expected int)");
+            FL_WARN_F("WLED: 'mainseg' field has invalid type (expected int)");
         }
     }
 
@@ -180,7 +180,7 @@ void WLED::setState(const fl::json& wledState) {
                 bool newNlOn = nl["on"] | mNightlightOn;
                 if (newNlOn != mNightlightOn) {
                     mNightlightOn = newNlOn;
-                    FL_DBG("WLED: nl.on=" << (mNightlightOn ? "true" : "false"));
+                    FL_DBG_F("WLED: nl.on=%s", (mNightlightOn ? "true" : "false"));
                 }
             }
 
@@ -190,19 +190,19 @@ void WLED::setState(const fl::json& wledState) {
                     i64 durInt = nl["dur"] | static_cast<i64>(mNightlightDuration);
                     // Clamp to valid range 1-255
                     if (durInt < 1) {
-                        FL_WARN("WLED: nl.dur " << durInt << " out of range, clamping to 1");
+                        FL_WARN_F("WLED: nl.dur %s out of range, clamping to 1", durInt);
                         durInt = 1;
                     } else if (durInt > 255) {
-                        FL_WARN("WLED: nl.dur " << durInt << " out of range, clamping to 255");
+                        FL_WARN_F("WLED: nl.dur %s out of range, clamping to 255", durInt);
                         durInt = 255;
                     }
                     u8 newDur = static_cast<u8>(durInt);
                     if (newDur != mNightlightDuration) {
                         mNightlightDuration = newDur;
-                        FL_DBG("WLED: nl.dur=" << static_cast<int>(mNightlightDuration));
+                        FL_DBG_F("WLED: nl.dur=%s", static_cast<int>(mNightlightDuration));
                     }
                 } else {
-                    FL_WARN("WLED: 'nl.dur' field has invalid type (expected int)");
+                    FL_WARN_F("WLED: 'nl.dur' field has invalid type (expected int)");
                 }
             }
 
@@ -212,19 +212,19 @@ void WLED::setState(const fl::json& wledState) {
                     i64 modeInt = nl["mode"] | static_cast<i64>(mNightlightMode);
                     // Clamp to valid range 0-3
                     if (modeInt < 0) {
-                        FL_WARN("WLED: nl.mode " << modeInt << " out of range, clamping to 0");
+                        FL_WARN_F("WLED: nl.mode %s out of range, clamping to 0", modeInt);
                         modeInt = 0;
                     } else if (modeInt > 3) {
-                        FL_WARN("WLED: nl.mode " << modeInt << " out of range, clamping to 3");
+                        FL_WARN_F("WLED: nl.mode %s out of range, clamping to 3", modeInt);
                         modeInt = 3;
                     }
                     u8 newMode = static_cast<u8>(modeInt);
                     if (newMode != mNightlightMode) {
                         mNightlightMode = newMode;
-                        FL_DBG("WLED: nl.mode=" << static_cast<int>(mNightlightMode));
+                        FL_DBG_F("WLED: nl.mode=%s", static_cast<int>(mNightlightMode));
                     }
                 } else {
-                    FL_WARN("WLED: 'nl.mode' field has invalid type (expected int)");
+                    FL_WARN_F("WLED: 'nl.mode' field has invalid type (expected int)");
                 }
             }
 
@@ -234,23 +234,23 @@ void WLED::setState(const fl::json& wledState) {
                     i64 tbriInt = nl["tbri"] | static_cast<i64>(mNightlightTargetBrightness);
                     // Clamp to valid range 0-255
                     if (tbriInt < 0) {
-                        FL_WARN("WLED: nl.tbri " << tbriInt << " out of range, clamping to 0");
+                        FL_WARN_F("WLED: nl.tbri %s out of range, clamping to 0", tbriInt);
                         tbriInt = 0;
                     } else if (tbriInt > 255) {
-                        FL_WARN("WLED: nl.tbri " << tbriInt << " out of range, clamping to 255");
+                        FL_WARN_F("WLED: nl.tbri %s out of range, clamping to 255", tbriInt);
                         tbriInt = 255;
                     }
                     u8 newTbri = static_cast<u8>(tbriInt);
                     if (newTbri != mNightlightTargetBrightness) {
                         mNightlightTargetBrightness = newTbri;
-                        FL_DBG("WLED: nl.tbri=" << static_cast<int>(mNightlightTargetBrightness));
+                        FL_DBG_F("WLED: nl.tbri=%s", static_cast<int>(mNightlightTargetBrightness));
                     }
                 } else {
-                    FL_WARN("WLED: 'nl.tbri' field has invalid type (expected int)");
+                    FL_WARN_F("WLED: 'nl.tbri' field has invalid type (expected int)");
                 }
             }
         } else {
-            FL_WARN("WLED: 'nl' field has invalid type (expected object)");
+            FL_WARN_F("WLED: 'nl' field has invalid type (expected object)");
         }
     }
 
@@ -264,7 +264,7 @@ void WLED::setState(const fl::json& wledState) {
                 bool newSend = udpn["send"] | mUdpSend;
                 if (newSend != mUdpSend) {
                     mUdpSend = newSend;
-                    FL_DBG("WLED: udpn.send=" << (mUdpSend ? "true" : "false"));
+                    FL_DBG_F("WLED: udpn.send=%s", (mUdpSend ? "true" : "false"));
                 }
             }
 
@@ -273,11 +273,11 @@ void WLED::setState(const fl::json& wledState) {
                 bool newRecv = udpn["recv"] | mUdpReceive;
                 if (newRecv != mUdpReceive) {
                     mUdpReceive = newRecv;
-                    FL_DBG("WLED: udpn.recv=" << (mUdpReceive ? "true" : "false"));
+                    FL_DBG_F("WLED: udpn.recv=%s", (mUdpReceive ? "true" : "false"));
                 }
             }
         } else {
-            FL_WARN("WLED: 'udpn' field has invalid type (expected object)");
+            FL_WARN_F("WLED: 'udpn' field has invalid type (expected object)");
         }
     }
 
@@ -298,7 +298,7 @@ void WLED::setState(const fl::json& wledState) {
                         mPlaylistPresets.push_back(static_cast<i16>(psInt));
                     }
                 }
-                FL_DBG("WLED: playlist.ps count=" << mPlaylistPresets.size());
+                FL_DBG_F("WLED: playlist.ps count=%s", mPlaylistPresets.size());
             }
 
             // Extract "dur" field (array of durations in seconds)
@@ -333,7 +333,7 @@ void WLED::setState(const fl::json& wledState) {
                 if (repeatInt < 0) repeatInt = 0;
                 if (repeatInt > 65535) repeatInt = 65535;
                 mPlaylistRepeat = static_cast<u16>(repeatInt);
-                FL_DBG("WLED: playlist.repeat=" << mPlaylistRepeat);
+                FL_DBG_F("WLED: playlist.repeat=%s", mPlaylistRepeat);
             }
 
             // Extract "end" field
@@ -342,16 +342,16 @@ void WLED::setState(const fl::json& wledState) {
                 if (endInt < -1) endInt = -1;
                 if (endInt > 250) endInt = 250;
                 mPlaylistEnd = static_cast<i16>(endInt);
-                FL_DBG("WLED: playlist.end=" << mPlaylistEnd);
+                FL_DBG_F("WLED: playlist.end=%s", mPlaylistEnd);
             }
 
             // Extract "r" field (randomize)
             if (pl.contains("r") && pl["r"].is_bool()) {
                 mPlaylistRandomize = pl["r"] | false;
-                FL_DBG("WLED: playlist.r=" << (mPlaylistRandomize ? "true" : "false"));
+                FL_DBG_F("WLED: playlist.r=%s", (mPlaylistRandomize ? "true" : "false"));
             }
         } else {
-            FL_WARN("WLED: 'playlist' field has invalid type (expected object)");
+            FL_WARN_F("WLED: 'playlist' field has invalid type (expected object)");
         }
     }
 
@@ -361,7 +361,7 @@ void WLED::setState(const fl::json& wledState) {
             for (size_t i = 0; i < wledState["seg"].size(); i++) {
                 const fl::json& segJson = wledState["seg"][i];
                 if (!segJson.is_object()) {
-                    FL_WARN("WLED: segment at index " << i << " is not an object");
+                    FL_WARN_F("WLED: segment at index %s is not an object", i);
                     continue;
                 }
 
@@ -397,7 +397,7 @@ void WLED::setState(const fl::json& wledState) {
                 wled::parseSegmentFields(segJson, *seg);
             }
         } else {
-            FL_WARN("WLED: 'seg' field has invalid type (expected array)");
+            FL_WARN_F("WLED: 'seg' field has invalid type (expected array)");
         }
     }
 }

--- a/src/fl/control/wled/client.cpp.hpp
+++ b/src/fl/control/wled/client.cpp.hpp
@@ -10,13 +10,13 @@ namespace fl {
 WLEDClient::WLEDClient(fl::shared_ptr<IFastLED> controller)
     : mController(controller), mBrightness(255), mOn(false) {
     if (!mController) {
-        FL_WARN("WLEDClient: constructed with null controller");
+        FL_WARN_F("WLEDClient: constructed with null controller");
     }
 }
 
 void WLEDClient::setBrightness(u8 brightness) {
     mBrightness = brightness;
-    FL_DBG("WLEDClient: setBrightness(" << static_cast<int>(mBrightness) << ")");
+    FL_DBG_F("WLEDClient: setBrightness(%s)", static_cast<int>(mBrightness));
 
     // Apply brightness to controller if we're on
     if (mOn && mController) {
@@ -26,7 +26,7 @@ void WLEDClient::setBrightness(u8 brightness) {
 
 void WLEDClient::setOn(bool on) {
     mOn = on;
-    FL_DBG("WLEDClient: setOn(" << (mOn ? "true" : "false") << ")");
+    FL_DBG_F("WLEDClient: setOn(%s)", (mOn ? "true" : "false"));
 
     if (!mController) {
         return;
@@ -42,7 +42,7 @@ void WLEDClient::setOn(bool on) {
 }
 
 void WLEDClient::clear(bool writeToStrip) {
-    FL_DBG("WLEDClient: clear(writeToStrip=" << (writeToStrip ? "true" : "false") << ")");
+    FL_DBG_F("WLEDClient: clear(writeToStrip=%s)", (writeToStrip ? "true" : "false"));
 
     if (!mController) {
         return;
@@ -52,7 +52,7 @@ void WLEDClient::clear(bool writeToStrip) {
 }
 
 void WLEDClient::update() {
-    FL_DBG("WLEDClient: update()");
+    FL_DBG_F("WLEDClient: update()");
 
     if (!mController) {
         return;
@@ -78,7 +78,7 @@ size_t WLEDClient::getNumLEDs() const {
 }
 
 void WLEDClient::setSegment(size_t start, size_t end) {
-    FL_DBG("WLEDClient: setSegment(" << start << ", " << end << ")");
+    FL_DBG_F("WLEDClient: setSegment(%s, %s)", start, end);
 
     if (!mController) {
         return;
@@ -88,7 +88,7 @@ void WLEDClient::setSegment(size_t start, size_t end) {
 }
 
 void WLEDClient::clearSegment() {
-    FL_DBG("WLEDClient: clearSegment()");
+    FL_DBG_F("WLEDClient: clearSegment()");
 
     if (!mController) {
         return;
@@ -98,9 +98,7 @@ void WLEDClient::clearSegment() {
 }
 
 void WLEDClient::setCorrection(CRGB correction) {
-    FL_DBG("WLEDClient: setCorrection(r=" << static_cast<int>(correction.r)
-           << ", g=" << static_cast<int>(correction.g)
-           << ", b=" << static_cast<int>(correction.b) << ")");
+    FL_DBG_F("WLEDClient: setCorrection(r=%s, g=%s, b=%s)", static_cast<int>(correction.r), static_cast<int>(correction.g), static_cast<int>(correction.b));
 
     if (!mController) {
         return;
@@ -110,9 +108,7 @@ void WLEDClient::setCorrection(CRGB correction) {
 }
 
 void WLEDClient::setTemperature(CRGB temperature) {
-    FL_DBG("WLEDClient: setTemperature(r=" << static_cast<int>(temperature.r)
-           << ", g=" << static_cast<int>(temperature.g)
-           << ", b=" << static_cast<int>(temperature.b) << ")");
+    FL_DBG_F("WLEDClient: setTemperature(r=%s, g=%s, b=%s)", static_cast<int>(temperature.r), static_cast<int>(temperature.g), static_cast<int>(temperature.b));
 
     if (!mController) {
         return;
@@ -122,7 +118,7 @@ void WLEDClient::setTemperature(CRGB temperature) {
 }
 
 void WLEDClient::setMaxRefreshRate(u16 fps) {
-    FL_DBG("WLEDClient: setMaxRefreshRate(" << fps << ")");
+    FL_DBG_F("WLEDClient: setMaxRefreshRate(%s)", fps);
 
     if (!mController) {
         return;

--- a/src/fl/control/wled/json_helpers.cpp.hpp
+++ b/src/fl/control/wled/json_helpers.cpp.hpp
@@ -254,7 +254,7 @@ void parseSegmentFields(const fl::json& segJson, WLEDSegment& seg) {
                     color.push_back(b);
                     seg.mColors.push_back(color);
                 } else {
-                    FL_WARN("WLED: invalid hex color string: " << hexStr);
+                    FL_WARN_F("WLED: invalid hex color string: %s", hexStr);
                 }
             }
         }
@@ -297,13 +297,13 @@ void parseSegmentFields(const fl::json& segJson, WLEDSegment& seg) {
                     char* endptr;
                     long startVal = fl::strtol(startStr.c_str(), &endptr, 10);
                     if (endptr == startStr.c_str() || startVal < 0) {
-                        FL_WARN("WLED: invalid range start index: " << startStr);
+                        FL_WARN_F("WLED: invalid range start index: %s", startStr);
                         continue;
                     }
 
                     long endVal = fl::strtol(endStr.c_str(), &endptr, 10);
                     if (endptr == endStr.c_str() || endVal < 0) {
-                        FL_WARN("WLED: invalid range end index: " << endStr);
+                        FL_WARN_F("WLED: invalid range end index: %s", endStr);
                         continue;
                     }
 
@@ -314,7 +314,7 @@ void parseSegmentFields(const fl::json& segJson, WLEDSegment& seg) {
                     char* endptr;
                     long idxVal = fl::strtol(indexStr.c_str(), &endptr, 10);
                     if (endptr == indexStr.c_str() || idxVal < 0) {
-                        FL_WARN("WLED: invalid LED index: " << indexStr);
+                        FL_WARN_F("WLED: invalid LED index: %s", indexStr);
                         continue;
                     }
                     startIdx = endIdx = static_cast<size_t>(idxVal);
@@ -328,7 +328,7 @@ void parseSegmentFields(const fl::json& segJson, WLEDSegment& seg) {
             // Parse hex color
             u8 r, g, b;
             if (!parseHexColor(hexStr, r, g, b)) {
-                FL_WARN("WLED: invalid hex color in individual LED: " << hexStr);
+                FL_WARN_F("WLED: invalid hex color in individual LED: %s", hexStr);
                 continue;
             }
 

--- a/src/fl/fx/2d/animartrix.hpp
+++ b/src/fl/fx/2d/animartrix.hpp
@@ -281,7 +281,7 @@ class Animartrix : public Fx2d {
         }
         fx = fx % static_cast<int>(AnimartrixAnim::NUM_ANIMATIONS);
         mCurrentAnimation = static_cast<AnimartrixAnim>(fx);
-        FL_DBG("Setting animation to " << getAnimartrixName(static_cast<int>(mCurrentAnimation)));
+        FL_DBG_F("Setting animation to %s", getAnimartrixName(static_cast<int>(mCurrentAnimation)));
     }
 
     int fxGet() const { return static_cast<int>(mCurrentAnimation); }

--- a/src/fl/fx/2d/blend.cpp.hpp
+++ b/src/fl/fx/2d/blend.cpp.hpp
@@ -38,7 +38,7 @@ string Blend2d::fxName() const {
 void Blend2d::add(Fx2dPtr layer, const Params &p) {
     if (!layer->getXYMap().isRectangularGrid()) {
         if (!getXYMap().isRectangularGrid()) {
-            FL_WARN("Blend2d has a xymap, but so does the Sub layer " << layer->fxName() << ", the sub layer will have it's map replaced with a rectangular map, to avoid double transformation.");
+            FL_WARN_F("Blend2d has a xymap, but so does the Sub layer %s, the sub layer will have it's map replaced with a rectangular map, to avoid double transformation.", layer->fxName());
             layer->setXYMap(XYMap::constructRectangularGrid(layer->getWidth(), layer->getHeight()));
         }
     }
@@ -114,7 +114,7 @@ bool Blend2d::setParams(Fx2dPtr fx, const Params &p) {
         }
     }
 
-    FL_WARN("Fx2d not found in Blend2d::setBlurParams");
+    FL_WARN_F("Fx2d not found in Blend2d::setBlurParams");
     return false;
 }
 

--- a/src/fl/fx/frame.cpp.hpp
+++ b/src/fl/fx/frame.cpp.hpp
@@ -73,13 +73,11 @@ void Frame::drawXY(fl::span<CRGB> leds, const XYMap &xyMap, DrawMode draw_mode) 
             fl::u32 in_idx = xyMap(w, h);
             fl::u32 out_idx = count++;
             if (in_idx >= mPixelsCount) {
-                FL_WARN(
-                    "Frame::drawXY: in index out of range: " << in_idx);
+                FL_WARN_F("Frame::drawXY: in index out of range: %s", in_idx);
                 continue;
             }
             if (out_idx >= mPixelsCount) {
-                FL_WARN(
-                    "Frame::drawXY: out index out of range: " << out_idx);
+                FL_WARN_F("Frame::drawXY: out index out of range: %s", out_idx);
                 continue;
             }
             switch (draw_mode) {
@@ -127,7 +125,7 @@ void Frame::interpolate(const Frame &frame1, const Frame &frame2,
 void Frame::interpolate(const Frame &frame1, const Frame &frame2,
                         u8 amountOfFrame2) {
     if (frame1.size() != frame2.size() || frame1.size() != mPixelsCount) {
-        FL_DBG("Frames must have the same size");
+        FL_DBG_F("Frames must have the same size");
         return; // Frames must have the same size
     }
     interpolate(frame1, frame2, amountOfFrame2, rgb());

--- a/src/fl/fx/time.cpp.hpp
+++ b/src/fl/fx/time.cpp.hpp
@@ -20,7 +20,7 @@ float TimeWarp::scale() const { return mTimeScale; }
 
 void TimeWarp::pause(fl::u32 now) {
     if (mPauseTime) {
-        FL_WARN("TimeWarp::pause: already paused");
+        FL_WARN_F("TimeWarp::pause: already paused");
         return;
     }
     mPauseTime = now;
@@ -52,7 +52,7 @@ void TimeWarp::reset(fl::u32 realTimeNow) {
 void TimeWarp::applyExact(fl::u32 timeNow) {
     // Handle time going backwards - reset if this happens
     if (timeNow < mLastRealTime) {
-        FL_WARN("TimeWarp::applyExact: time went backwards, resetting");
+        FL_WARN_F("TimeWarp::applyExact: time went backwards, resetting");
         reset(timeNow);
         return;
     }

--- a/src/fl/fx/video.cpp.hpp
+++ b/src/fl/fx/video.cpp.hpp
@@ -1,4 +1,4 @@
-#include "fl/fx/video.h"
+﻿#include "fl/fx/video.h"
 
 #include "crgb.h"
 #include "fl/stl/detail/memory_file_handle.h"
@@ -37,17 +37,17 @@ Video &Video::operator=(const Video &) FL_NOEXCEPT = default;
 
 bool Video::begin(filebuf_ptr handle) {
     if (!mImpl) {
-        FL_WARN("Video::begin: mImpl is null, manually constructed videos "
+        FL_WARN_F("Video::begin: mImpl is null, manually constructed videos "
                      "must include full parameters.");
         return false;
     }
     if (!handle) {
         mError = "filebuf is null";
-        FL_DBG(mError.c_str());
+        FL_DBG_F("%s", mError.c_str());
         return false;
     }
     if (mError.size()) {
-        FL_DBG(mError.c_str());
+        FL_DBG_F("%s", mError.c_str());
         return false;
     }
     mError.clear();
@@ -57,7 +57,7 @@ bool Video::begin(filebuf_ptr handle) {
 
 bool Video::draw(fl::u32 now, fl::span<CRGB> leds) {
     if (!mImpl) {
-        FL_WARN_IF(!mError.empty(), mError.c_str());
+        FL_WARN_F_IF(!mError.empty(), "%s", mError.c_str());
         return false;
     }
     bool ok = mImpl->draw(now, leds);
@@ -70,7 +70,7 @@ bool Video::draw(fl::u32 now, fl::span<CRGB> leds) {
 
 void Video::draw(DrawContext context) {
     if (!mImpl) {
-        FL_WARN_IF(!mError.empty(), mError.c_str());
+        FL_WARN_F_IF(!mError.empty(), "%s", mError.c_str());
         return;
     }
     mImpl->draw(context.now, context.leds);
@@ -148,7 +148,7 @@ bool Video::rewind() {
 
 VideoFxWrapper::VideoFxWrapper(fl::shared_ptr<Fx> fx) : Fx1d(fx->getNumLeds()), mFx(fx) {
     if (!mFx->hasFixedFrameRate(&mFps)) {
-        FL_WARN("VideoFxWrapper: Fx does not have a fixed frame rate, "
+        FL_WARN_F("VideoFxWrapper: Fx does not have a fixed frame rate, "
                      "assuming 30fps.");
         mFps = 30.0f;
     }
@@ -174,7 +174,7 @@ void VideoFxWrapper::draw(DrawContext context) {
     }
     bool ok = mVideo->draw(context.now, context.leds);
     if (!ok) {
-        FL_WARN("VideoFxWrapper: draw failed.");
+        FL_WARN_F("VideoFxWrapper: draw failed.");
     }
 }
 

--- a/src/fl/gfx/blur.cpp.hpp
+++ b/src/fl/gfx/blur.cpp.hpp
@@ -35,7 +35,7 @@ fl::u16 XY(fl::u8 x, fl::u8 y) FL_LINK_WEAK;
 FL_LINK_WEAK fl::u16 XY(fl::u8 x, fl::u8 y) {
     FASTLED_UNUSED(x);
     FASTLED_UNUSED(y);
-    FL_ERROR("XY function not provided - using default [0][0]. Use blur2d with XYMap instead");
+    FL_ERROR_F("XY function not provided - using default [0][0]. Use blur2d with XYMap instead");
     return 0;
 }
 

--- a/src/fl/gfx/colorutils.h
+++ b/src/fl/gfx/colorutils.h
@@ -784,7 +784,7 @@ class CRGBPalette16 : public detail::TCRGBPalette<16> {
                 break;
             }
             if (count >= FASTLED_MAX_GRADIENT_PALETTE_ENTRIES) {
-                FL_WARN("DEFINE_GRADIENT_PALETTE missing index=255 terminator! "
+                FL_WARN_F("DEFINE_GRADIENT_PALETTE missing index=255 terminator! "
                         "This will cause buffer overruns and crashes. "
                         "Auto-correcting but please fix your gradient definition.");
                 break;
@@ -862,7 +862,7 @@ class CRGBPalette16 : public detail::TCRGBPalette<16> {
                 break;
             }
             if (count >= FASTLED_MAX_GRADIENT_PALETTE_ENTRIES) {
-                FL_WARN("Dynamic gradient palette missing index=255 terminator! "
+                FL_WARN_F("Dynamic gradient palette missing index=255 terminator! "
                         "This will cause buffer overruns and crashes. "
                         "Auto-correcting but please fix your gradient definition.");
                 break;
@@ -1062,7 +1062,7 @@ class CRGBPalette32 : public detail::TCRGBPalette<32> {
                 break;
             }
             if (count >= FASTLED_MAX_GRADIENT_PALETTE_ENTRIES) {
-                FL_WARN("DEFINE_GRADIENT_PALETTE missing index=255 terminator! "
+                FL_WARN_F("DEFINE_GRADIENT_PALETTE missing index=255 terminator! "
                         "This will cause buffer overruns and crashes. "
                         "Auto-correcting but please fix your gradient definition.");
                 break;
@@ -1140,7 +1140,7 @@ class CRGBPalette32 : public detail::TCRGBPalette<32> {
                 break;
             }
             if (count >= FASTLED_MAX_GRADIENT_PALETTE_ENTRIES) {
-                FL_WARN("Dynamic gradient palette missing index=255 terminator! "
+                FL_WARN_F("Dynamic gradient palette missing index=255 terminator! "
                         "This will cause buffer overruns and crashes. "
                         "Auto-correcting but please fix your gradient definition.");
                 break;
@@ -1280,7 +1280,7 @@ class CRGBPalette256 : public detail::TCRGBPalette<256> {
         while (indexstart < 255) {
             // Safety: check BEFORE reading to prevent buffer overrun
             if (entries_processed >= FASTLED_MAX_GRADIENT_PALETTE_ENTRIES) {
-                FL_WARN("DEFINE_GRADIENT_PALETTE missing index=255 terminator! "
+                FL_WARN_F("DEFINE_GRADIENT_PALETTE missing index=255 terminator! "
                         "This will cause buffer overruns and crashes. "
                         "Auto-correcting but please fix your gradient definition.");
                 // Extend current color to 255
@@ -1317,7 +1317,7 @@ class CRGBPalette256 : public detail::TCRGBPalette<256> {
         while (indexstart < 255) {
             // Safety: check BEFORE reading to prevent buffer overrun
             if (entries_processed >= FASTLED_MAX_GRADIENT_PALETTE_ENTRIES) {
-                FL_WARN("Dynamic gradient palette missing index=255 terminator! "
+                FL_WARN_F("Dynamic gradient palette missing index=255 terminator! "
                         "This will cause buffer overruns and crashes. "
                         "Auto-correcting but please fix your gradient definition.");
                 // Extend current color to 255

--- a/src/fl/gfx/corkscrew.cpp.hpp
+++ b/src/fl/gfx/corkscrew.cpp.hpp
@@ -133,8 +133,7 @@ Tile2x2_u8 Corkscrew::at_splat_extrapolate(float i) const {
     if (i >= mNumLeds) {
         // Handle out-of-bounds access, possibly by returning a default
         // Tile2x2_u8
-        FASTLED_ASSERT(false, "Out of bounds access in Corkscrew at_splat: "
-                                  << i << " size: " << mNumLeds);
+        FASTLED_ASSERT(false, "Out of bounds access in Corkscrew at_splat");
         return Tile2x2_u8();
     }
     

--- a/src/fl/gfx/raster_sparse.cpp.hpp
+++ b/src/fl/gfx/raster_sparse.cpp.hpp
@@ -30,7 +30,7 @@ void XYRasterU8Sparse::rasterize(const span<const Tile2x2_u8> &tiles) {
     // Tile2x2_u8::Rasterize(tiles, this, mAbsoluteBoundsSet ? &mAbsoluteBounds
     // : nullptr);
     if (tiles.size() == 0) {
-        FL_WARN("Rasterize: no tiles");
+        FL_WARN_F("Rasterize: no tiles");
         return;
     }
     const rect<u16> *optional_bounds =

--- a/src/fl/gfx/rgbw.cpp.hpp
+++ b/src/fl/gfx/rgbw.cpp.hpp
@@ -518,7 +518,7 @@ void rgb_2_rgbw_colorimetric(u16 w_color_temperature, u8 r,
                              u8 g_scale, u8 b_scale, u8 *out_r,
                              u8 *out_g, u8 *out_b, u8 *out_w) FL_NOEXCEPT {
 #ifndef FASTLED_SUPPRESS_COLORIMETRIC_FALLBACK_WARNING
-    FL_WARN_ONCE("RGBW: kRGBWColorimetric requested but FASTLED_RGBW_COLORIMETRIC is not defined — falling back to kRGBWExactColors. Define FASTLED_RGBW_COLORIMETRIC=1 to enable the colorimetric path.");
+    FL_WARN_F_ONCE("RGBW: kRGBWColorimetric requested but FASTLED_RGBW_COLORIMETRIC is not defined — falling back to kRGBWExactColors. Define FASTLED_RGBW_COLORIMETRIC=1 to enable the colorimetric path.");
 #endif
     rgb_2_rgbw_exact(w_color_temperature, r, g, b, r_scale, g_scale, b_scale,
                      out_r, out_g, out_b, out_w);
@@ -529,7 +529,7 @@ void rgb_2_rgbw_colorimetric_boosted(u16 w_color_temperature, u8 r,
                                      u8 g_scale, u8 b_scale, u8 *out_r,
                                      u8 *out_g, u8 *out_b, u8 *out_w) FL_NOEXCEPT {
 #ifndef FASTLED_SUPPRESS_COLORIMETRIC_FALLBACK_WARNING
-    FL_WARN_ONCE("RGBW: kRGBWColorimetricBoosted requested but FASTLED_RGBW_COLORIMETRIC is not defined — falling back to kRGBWExactColors. Define FASTLED_RGBW_COLORIMETRIC=1 to enable the colorimetric path.");
+    FL_WARN_F_ONCE("RGBW: kRGBWColorimetricBoosted requested but FASTLED_RGBW_COLORIMETRIC is not defined — falling back to kRGBWExactColors. Define FASTLED_RGBW_COLORIMETRIC=1 to enable the colorimetric path.");
 #endif
     rgb_2_rgbw_exact(w_color_temperature, r, g, b, r_scale, g_scale, b_scale,
                      out_r, out_g, out_b, out_w);

--- a/src/fl/gfx/rgbw_colorimetric.cpp.hpp
+++ b/src/fl/gfx/rgbw_colorimetric.cpp.hpp
@@ -1,4 +1,4 @@
-/// @file rgbw_colorimetric.cpp.hpp
+﻿/// @file rgbw_colorimetric.cpp.hpp
 /// Heavy implementations for the colorimetric RGBW solvers (issue #2545).
 /// Gated by FASTLED_RGBW_COLORIMETRIC so the float math + simplex solver
 /// + LUT machinery only land in the binary when the user opts in.
@@ -86,7 +86,7 @@ void build_profile_cache(const DiodeProfile* p, int cct_override,
     pack(cache->P_B, cache->P_G, cache->P_W, P_BGW);
 
     // Inverting a singular matrix leaves the destination with whatever
-    // invert3x3 wrote — solvers reading it would silently produce garbage.
+    // invert3x3 wrote â€” solvers reading it would silently produce garbage.
     // Warn once if any inversion fails so the user knows their profile has
     // degenerate primaries (colinear chromaticities, near-zero luminance, etc).
     const bool ok_rgb = invert3x3(P_RGB, cache->P_RGB_inv);
@@ -94,7 +94,7 @@ void build_profile_cache(const DiodeProfile* p, int cct_override,
     const bool ok_rbw = invert3x3(P_RBW, cache->P_RBW_inv);
     const bool ok_bgw = invert3x3(P_BGW, cache->P_BGW_inv);
     if (!(ok_rgb && ok_rgw && ok_rbw && ok_bgw)) {
-        FL_WARN_ONCE("RGBW colorimetric: profile has degenerate primaries — "
+        FL_WARN_F_ONCE("RGBW colorimetric: profile has degenerate primaries â€” "
                      "one or more sub-gamut matrix inversions failed. Output "
                      "colors will be incorrect. Check DiodeProfile xy/lum values.");
         // Zero-init any failed inverse so downstream matvec3() output is
@@ -124,7 +124,7 @@ void build_profile_cache(const DiodeProfile* p, int cct_override,
         // measured-device absolute XYZ units, so scale M_src by the same
         // white-fit factor used by the reference math model:
         //   K = 1 / max(solve_subgamut(source_white_Y1))
-        // This makes M_src·[1,1,1] land at the brightest achievable device
+        // This makes M_srcÂ·[1,1,1] land at the brightest achievable device
         // white instead of an underpowered Y=1 target. Without this scale,
         // native/D65 dual-edge and LP solves cannot match the Python model.
         float X_w[3];
@@ -171,7 +171,7 @@ void build_profile_cache(const DiodeProfile* p, int cct_override,
 }
 
 // Project an out-of-hull target XYZ onto the achievable LED gamut (#2708,
-// math-model gist §3). Returns true if a projection was applied, in which
+// math-model gist Â§3). Returns true if a projection was applied, in which
 // case `X_t` and `xy_t` are updated to the projected point at unit Y. When
 // the target is already inside the full RGB triangle, returns false and
 // leaves `X_t` / `xy_t` untouched.
@@ -189,7 +189,7 @@ static bool project_to_hull(const ProfileCache& cache,
 
     const DiodeProfile& p = *cache.profile;
     float bary[3];
-    // Test the full RGB triangle (not the sub-gamut triangles) — a target
+    // Test the full RGB triangle (not the sub-gamut triangles) â€” a target
     // can be outside a single sub-gamut yet still inside the full hull.
     if (barycentric_xy(xy_t, p.xy_r, p.xy_g, p.xy_b, bary)
         && bary[0] >= -1e-9f && bary[1] >= -1e-9f && bary[2] >= -1e-9f) {
@@ -229,7 +229,7 @@ static bool project_to_hull(const ProfileCache& cache,
         }
     }
     if (best_xyz[1] <= 1e-12f) {
-        // All sub-gamut projections collapsed to zero — pathological
+        // All sub-gamut projections collapsed to zero â€” pathological
         // profile or extreme target. Leave the original X_t alone; the
         // strict solver will return false and the dispatch falls back.
         return false;
@@ -947,7 +947,7 @@ LutTable build_lut(const ProfileCache& cache, int grid_n,
 void lookup_lut(const LutTable& lut, const float xy_t[2], float Y_t,
                 float out_rgbw[4]) FL_NOEXCEPT {
     // Defend against degenerate LUTs (empty table, unbuilt cells, zero span).
-    // build_lut() returns an empty LutTable on bad input — without these
+    // build_lut() returns an empty LutTable on bad input â€” without these
     // guards the divide-by-zero and OOB reads would corrupt random memory.
     out_rgbw[0] = out_rgbw[1] = out_rgbw[2] = out_rgbw[3] = 0.0f;
     if (lut.N < 2 || lut.cells.get() == nullptr) {

--- a/src/fl/gfx/rgbww.cpp.hpp
+++ b/src/fl/gfx/rgbww.cpp.hpp
@@ -1,10 +1,10 @@
-/// @file rgbww.cpp.hpp
+﻿/// @file rgbww.cpp.hpp
 /// Dispatch + implementations for the 5-channel RGB->RGBWW path
 /// (issue #2558, Phase 3 of #2545).
 ///
 /// The colorimetric modes call `solve_rgbcct()` from
 /// fl/gfx/rgbw_colorimetric.h whenever FASTLED_RGBW_COLORIMETRIC is defined
-/// (that's the one flag that gates the underlying color math library — see
+/// (that's the one flag that gates the underlying color math library â€” see
 /// PR #2552). Without it, the dispatch emits FL_WARN_ONCE and outputs five
 /// zero bytes. Suppress the warn-once with
 /// `-DFASTLED_SUPPRESS_RGBWW_FALLBACK_WARNING=1`.
@@ -23,7 +23,7 @@
 // rgbw_colorimetric.h carries the RgbcctProfile type definition that
 // kRgbwwDefaultProfile needs, plus the inline math primitives Phase D uses.
 // The non-inline solve_rgbcct symbol itself only exists when
-// FASTLED_RGBW_COLORIMETRIC is defined at library build time — see the gated
+// FASTLED_RGBW_COLORIMETRIC is defined at library build time â€” see the gated
 // dispatch bodies further down.
 #include "fl/gfx/rgbw_colorimetric.h"
 #include "fl/log/log.h"
@@ -45,8 +45,8 @@ inline void zero_out(u8 *r, u8 *g, u8 *b, u8 *ww, u8 *wc) FL_NOEXCEPT {
 // kRgbwDefaultProfile (the colorimetric 4-channel default); W vertex is
 // hardcoded to the Planckian xy at 2700K (warm) and 6500K (cool) so static
 // initialization stays trivial (no CCT conversion at init time).
-//   2700K Planckian xy ≈ (0.4600, 0.4107)  (matches cct_to_xy(2700) ± 0.002)
-//   6500K Planckian xy ≈ (0.3135, 0.3237)  (matches cct_to_xy(6500) ± 0.002)
+//   2700K Planckian xy â‰ˆ (0.4600, 0.4107)  (matches cct_to_xy(2700) Â± 0.002)
+//   6500K Planckian xy â‰ˆ (0.3135, 0.3237)  (matches cct_to_xy(6500) Â± 0.002)
 // Default profile: native LED gamut + D65 source white on both warm and cool
 // paths (#2710). Users wanting Rec709 / Rec2020 / DCI-P3 input semantics
 // should call `fl::set_input_gamut()` on their per-strip profile copy.
@@ -111,7 +111,7 @@ const colorimetric_detail::RgbcctProfile* get_rgbww_colorimetric_profile() FL_NO
 }
 
 // User-installable RGB->RGBWW function pointer, held behind a lazy
-// Singleton<T> (same pattern as the rgb_2_rgbw user function — see #2424 for
+// Singleton<T> (same pattern as the rgb_2_rgbw user function â€” see #2424 for
 // the binary-bloat rationale). Default is nullptr; the user function path
 // emits zero output when nothing is installed.
 namespace {
@@ -158,7 +158,7 @@ void rgb_2_rgbww_user_function(const Rgbww& cfg,
                                u8 *out_ww, u8 *out_wc) FL_NOEXCEPT {
     rgb_2_rgbww_function fn = fl::Singleton<Rgb2RgbwwUserState>::instance().fn;
     if (fn == nullptr) {
-        // No user function installed — produce safe zero output.
+        // No user function installed â€” produce safe zero output.
         zero_out(out_r, out_g, out_b, out_ww, out_wc);
         return;
     }
@@ -171,15 +171,15 @@ void rgb_2_rgbww_user_function(const Rgbww& cfg,
 
 namespace {
 // Compute the warm/cool blend factor from the input chromaticity. Simple
-// x-based heuristic: warmer inputs (higher x, closer to warm white) → lower
-// eta (more warm-W); cooler inputs → higher eta. Mathematically not optimal
-// — a chromaticity-aware solver could place eta to minimize dE — but cheap,
+// x-based heuristic: warmer inputs (higher x, closer to warm white) â†’ lower
+// eta (more warm-W); cooler inputs â†’ higher eta. Mathematically not optimal
+// â€” a chromaticity-aware solver could place eta to minimize dE â€” but cheap,
 // monotonic, and good enough for the common ambilight / neutral-pastel case.
 // Per-process cache for the input chromaticity matrix used by
 // compute_eta_from_input. `build_source_matrix` runs a 3x3 invert, which is
 // far too expensive to repeat per pixel (CodeRabbit #2707). The keyed input
-// fields are profile-level data — the matrix is invariant until the active
-// profile's input_xy_* changes — so we cache it and invalidate only when one
+// fields are profile-level data â€” the matrix is invariant until the active
+// profile's input_xy_* changes â€” so we cache it and invalidate only when one
 // of those eight floats differs from the cached snapshot.
 struct EtaSourceMatrixCache {
     float xy_r[2] = {0.0f, 0.0f};
@@ -202,7 +202,7 @@ inline float compute_eta_from_input(const colorimetric_detail::RgbcctProfile& pr
     // emitter-space projection used previously would bias eta toward the LED
     // gamut, so a neutral source white wouldn't blend symmetrically across
     // warm/cool when the source primaries (e.g. sRGB) differ from the LED
-    // primaries — exactly the regression flagged on this PR.
+    // primaries â€” exactly the regression flagged on this PR.
     EtaSourceMatrixCache& cache =
         fl::Singleton<EtaSourceMatrixCache>::instance();
     const fl::DiodeProfile& wp = profile.warm_path;
@@ -232,7 +232,7 @@ inline float compute_eta_from_input(const colorimetric_detail::RgbcctProfile& pr
         X = xyz[0]; Y = xyz[1]; Z = xyz[2];
     } else {
         // Legacy emitter-space fallback for profiles without populated source.
-        // Three xyY_to_XYZ calls per pixel — degraded but still cheap, and
+        // Three xyY_to_XYZ calls per pixel â€” degraded but still cheap, and
         // only reached when the user explicitly opts out of source space.
         float P_R[3], P_G[3], P_B[3];
         colorimetric_detail::xyY_to_XYZ(wp.xy_r[0], wp.xy_r[1], wp.lum_r, P_R);
@@ -256,7 +256,7 @@ inline float compute_eta_from_input(const colorimetric_detail::RgbcctProfile& pr
 // Resolve the per-call RgbcctProfile, honoring cfg.warm_cct / cool_cct.
 //
 // (#2558) CodeRabbit caught that the previous implementation ignored the
-// per-strip CCT fields whenever cfg.profile == nullptr — every Rgbww config
+// per-strip CCT fields whenever cfg.profile == nullptr â€” every Rgbww config
 // produced the same warm=2700/cool=6500 default. Now we shift the W vertex
 // of a per-call profile to whatever CCTs the user requested. When the
 // requested CCTs match the default profile's nominal_cct values exactly, we
@@ -361,7 +361,7 @@ void rgb_2_rgbww_colorimetric_boosted(const Rgbww& cfg,
 
 // Stub path when the colorimetric math library is not compiled in. Emits
 // FL_WARN_ONCE (suppressible) and five zero bytes. Does not pull in the
-// solver, profile cache, or float math machinery — same gc-section behavior
+// solver, profile cache, or float math machinery â€” same gc-section behavior
 // as the rest of the colorimetric Phase 1 dispatch in PR #2552.
 void rgb_2_rgbww_colorimetric(const Rgbww& cfg,
                               u8 r, u8 g, u8 b,
@@ -371,7 +371,7 @@ void rgb_2_rgbww_colorimetric(const Rgbww& cfg,
     (void)cfg; (void)r; (void)g; (void)b;
     (void)r_scale; (void)g_scale; (void)b_scale;
 #ifndef FASTLED_SUPPRESS_RGBWW_FALLBACK_WARNING
-    FL_WARN_ONCE("RGBWW: kRGBWWColorimetric requires FASTLED_RGBW_COLORIMETRIC=1 "
+    FL_WARN_F_ONCE("RGBWW: kRGBWWColorimetric requires FASTLED_RGBW_COLORIMETRIC=1 "
                  "(the math library that provides solve_rgbcct). Outputting zeros.");
 #endif
     zero_out(out_r, out_g, out_b, out_ww, out_wc);
@@ -385,7 +385,7 @@ void rgb_2_rgbww_colorimetric_boosted(const Rgbww& cfg,
     (void)cfg; (void)r; (void)g; (void)b;
     (void)r_scale; (void)g_scale; (void)b_scale;
 #ifndef FASTLED_SUPPRESS_RGBWW_FALLBACK_WARNING
-    FL_WARN_ONCE("RGBWW: kRGBWWColorimetricBoosted requires FASTLED_RGBW_COLORIMETRIC=1. "
+    FL_WARN_F_ONCE("RGBWW: kRGBWWColorimetricBoosted requires FASTLED_RGBW_COLORIMETRIC=1. "
                  "Outputting zeros.");
 #endif
     zero_out(out_r, out_g, out_b, out_ww, out_wc);

--- a/src/fl/gfx/xypath.cpp.hpp
+++ b/src/fl/gfx/xypath.cpp.hpp
@@ -256,8 +256,7 @@ XYPathPtr XYPath::NewCustomPath(const fl::function<vec2f(float)> &f,
     if (path->hasDrawBounds(&bounds)) {
         if (!bounds.mMin.is_zero()) {
             // Set the bounds to the path's bounds
-            FL_WARN(
-                "Bounds with an origin other than 0,0 is not supported yet");
+            FL_WARN_F("Bounds with an origin other than 0,0 is not supported yet");
         }
         auto w = bounds.width();
         auto h = bounds.height();

--- a/src/fl/gfx/xypath_renderer.cpp.hpp
+++ b/src/fl/gfx/xypath_renderer.cpp.hpp
@@ -24,7 +24,7 @@ vec2f XYPathRenderer::compute_float(float alpha, const TransformFloat &tx) {
 Tile2x2_u8 XYPathRenderer::at_subpixel(float alpha) {
     // 1) continuous point, in “pixel‐centers” coordinates [0.5 … W–0.5]
     if (!mDrawBoundsSet) {
-        FL_WARN("XYPathRenderer::at_subpixel: draw bounds not set");
+        FL_WARN_F("XYPathRenderer::at_subpixel: draw bounds not set");
         return Tile2x2_u8();
     }
     vec2f xy = at(alpha);

--- a/src/fl/log/async_logger.cpp.hpp
+++ b/src/fl/log/async_logger.cpp.hpp
@@ -17,8 +17,7 @@ namespace detail {
     /// Called from checkLoggerEnabled template function
     /// IMPORTANT: This must NOT be inline - needs external linkage for cross-TU calls
     void printLoggerDisabledError(const char* category_name, const char* define_name) {
-        FL_ERROR(category_name << " ASYNC LOGGING NOT ENABLED. "
-            << "Add '#define " << define_name << "' before including FastLED.h");
+        FL_ERROR_F("%s ASYNC LOGGING NOT ENABLED. Add '#define %s' before including FastLED.h", category_name, define_name);
     }
 } // namespace detail
 

--- a/src/fl/log/log.h
+++ b/src/fl/log/log.h
@@ -2,6 +2,7 @@
 
 #include "fl/system/sketch_macros.h"
 #include "fl/stl/strstream.h"  // IWYU pragma: keep - Required by FL_WARN/FL_ERROR/FL_DBG macros
+#include "fl/stl/stdio.h"      // IWYU pragma: keep - Required by FL_*_F macros
 #include "fl/stl/chrono.h"       // IWYU pragma: keep - Required by FL_WARN_EVERY/FL_DBG_EVERY/FL_PRINT_EVERY macros
 #include "fl/stl/compiler_control.h"  // IWYU pragma: keep - FL_NO_INLINE for log_emit
 
@@ -175,6 +176,33 @@ enum class log_kind : fl::u8 {
     ERROR = 1,
     INFO  = 2,
 };
+
+inline const char* log_kind_name(log_kind kind) FL_NOEXCEPT {
+    switch (kind) {
+        case log_kind::WARN:
+            return "WARN";
+        case log_kind::ERROR:
+            return "ERROR";
+        case log_kind::INFO:
+            return "INFO";
+    }
+    return "LOG";
+}
+
+template <typename... Args>
+void log_emit_f(log_kind kind, const char* file, int line, const char* format,
+                const Args&... args) FL_NOEXCEPT {
+    fl::printf("%s(%d): %s: ", file, line, log_kind_name(kind));
+    fl::printf(format, args...);
+    fl::printf("\n");
+}
+
+template <typename... Args>
+fl::string log_format_string(const char* format, const Args&... args) FL_NOEXCEPT {
+    char buffer[256];
+    fl::snprintf(buffer, sizeof(buffer), format, args...);
+    return fl::string(buffer);
+}
 // Takes `body` by non-const lvalue reference (not `&&`) because the
 // macro's `fl::sstream() << X` expression has type `sstream&` (the
 // returned lvalue ref from chained operator<<). The underlying
@@ -213,11 +241,18 @@ void log_emit(log_kind kind, const char* file, int line, fl::sstream& body) FL_N
     fl::detail::log_kind::ERROR, \
     fl::fastled_file_offset(__FILE__), int(__LINE__), \
     fl::sstream() << X)
+#define FL_ERROR_F(...) fl::detail::log_emit_f( \
+    fl::detail::log_kind::ERROR, \
+    fl::fastled_file_offset(__FILE__), int(__LINE__), \
+    __VA_ARGS__)
 #define FL_ERROR_IF(COND, MSG) do { if (COND) FL_ERROR(MSG); } while(0)
+#define FL_ERROR_F_IF(COND, ...) do { if (COND) FL_ERROR_F(__VA_ARGS__); } while(0)
 #else
 // No-op macros — either memory-constrained platform or FASTLED_LOG_VERBOSITY=0.
 #define FL_ERROR(X) do { } while(0)
+#define FL_ERROR_F(...) do { } while(0)
 #define FL_ERROR_IF(COND, MSG) do { } while(0)
+#define FL_ERROR_F_IF(COND, ...) do { } while(0)
 #endif
 #endif
 
@@ -241,7 +276,12 @@ void log_emit(log_kind kind, const char* file, int line, fl::sstream& body) FL_N
     fl::detail::log_kind::WARN, \
     fl::fastled_file_offset(__FILE__), int(__LINE__), \
     fl::sstream() << X)
+#define FL_WARN_F(...) fl::detail::log_emit_f( \
+    fl::detail::log_kind::WARN, \
+    fl::fastled_file_offset(__FILE__), int(__LINE__), \
+    __VA_ARGS__)
 #define FL_WARN_IF(COND, MSG) do { if (COND) FL_WARN(MSG); } while(0)
+#define FL_WARN_F_IF(COND, ...) do { if (COND) FL_WARN_F(__VA_ARGS__); } while(0)
 
 // FL_WARN_ONCE: Emits warning only once per unique location (static flag per call site)
 // Uses static bool flag initialized to false - first call prints, subsequent calls no-op
@@ -250,6 +290,13 @@ void log_emit(log_kind kind, const char* file, int line, fl::sstream& body) FL_N
     if (!_warned) { \
         _warned = true; \
         FL_WARN(X); \
+    } \
+} while(0)
+#define FL_WARN_F_ONCE(...) do { \
+    static bool _warned = false; \
+    if (!_warned) { \
+        _warned = true; \
+        FL_WARN_F(__VA_ARGS__); \
     } \
 } while(0)
 
@@ -271,14 +318,26 @@ void log_emit(log_kind kind, const char* file, int line, fl::sstream& body) FL_N
         FL_WARN(X); \
     } \
 } while(0)
+#define FL_WARN_F_EVERY(MILLIS, ...) do { \
+    static fl::u32 _last_warn_time = 0; \
+    fl::u32 _now = fl::millis(); \
+    if (_now - _last_warn_time >= (MILLIS)) { \
+        _last_warn_time = _now; \
+        FL_WARN_F(__VA_ARGS__); \
+    } \
+} while(0)
 #else
 // No-op macros — either memory-constrained platform or FASTLED_LOG_VERBOSITY=0.
 #define FL_WARN(X) do { } while(0)
+#define FL_WARN_F(...) do { } while(0)
 #define FL_WARN_IF(COND, MSG) if(false) { void(fl::sstream_noop() << MSG); }
+#define FL_WARN_F_IF(COND, ...) do { } while(0)
 #define FL_WARN_ONCE(X) do { } while(0)
+#define FL_WARN_F_ONCE(...) do { } while(0)
 #define FL_WARN_FMT(X) do { } while(0)
 #define FL_WARN_FMT_IF(COND, MSG) do { } while(0)
 #define FL_WARN_EVERY(MILLIS, X) do { } while(0)
+#define FL_WARN_F_EVERY(MILLIS, ...) do { } while(0)
 #endif
 #endif
 
@@ -373,20 +432,33 @@ void log_emit(log_kind kind, const char* file, int line, fl::sstream& body) FL_N
         (fl::sstream() << (fl::fastled_file_offset(__FILE__))                \
                          << "(" << int(__LINE__) << "): " << X)                     \
             .c_str())
+#define _FASTLED_DBG_F(...) fl::detail::log_emit_f( \
+    fl::detail::log_kind::INFO, \
+    fl::fastled_file_offset(__FILE__), int(__LINE__), \
+    __VA_ARGS__)
 #endif
 
 #define FASTLED_DBG(X) _FASTLED_DGB(X)
+#ifndef _FASTLED_DBG_F
+#define _FASTLED_DBG_F(...) do { } while(0)
+#endif
+#define FASTLED_DBG_F(...) _FASTLED_DBG_F(__VA_ARGS__)
 
 #ifndef FASTLED_DBG_IF
 #define FASTLED_DBG_IF(COND, MSG)                                              \
     if (COND)                                                                  \
     FASTLED_DBG(MSG)
 #endif // FASTLED_DBG_IF
+#ifndef FASTLED_DBG_F_IF
+#define FASTLED_DBG_F_IF(COND, ...) do { if (COND) FASTLED_DBG_F(__VA_ARGS__); } while(0)
+#endif
 
 // Short-form aliases for convenience (following pattern from warn.h)
 #ifndef FL_DBG
 #define FL_DBG FASTLED_DBG
+#define FL_DBG_F FASTLED_DBG_F
 #define FL_DBG_IF FASTLED_DBG_IF
+#define FL_DBG_F_IF FASTLED_DBG_F_IF
 
 // FL_DBG_EVERY: Rate-limited debug output that prints at most once per interval
 // Uses static timestamp to track last print time - throttles output in tight loops
@@ -399,8 +471,17 @@ void log_emit(log_kind kind, const char* file, int line, fl::sstream& body) FL_N
         FL_DBG(X); \
     } \
 } while(0)
+#define FL_DBG_F_EVERY(MILLIS, ...) do { \
+    static fl::u32 _last_dbg_time = 0; \
+    fl::u32 _now = fl::millis(); \
+    if (_now - _last_dbg_time >= (MILLIS)) { \
+        _last_dbg_time = _now; \
+        FL_DBG_F(__VA_ARGS__); \
+    } \
+} while(0)
 #else
 #define FL_DBG_EVERY(MILLIS, X) FL_DBG_NO_OP(X)
+#define FL_DBG_F_EVERY(MILLIS, ...) do { } while(0)
 #endif
 #endif
 
@@ -441,6 +522,7 @@ void log_emit(log_kind kind, const char* file, int line, fl::sstream& body) FL_N
 #ifndef FL_PRINT
 #if FASTLED_LOG_RUNTIME_ENABLED
 #define FL_PRINT(X) fl::println((fl::sstream() << X).c_str())
+#define FL_PRINT_F(...) do { fl::printf(__VA_ARGS__); fl::printf("\n"); } while(0)
 
 // FL_PRINT_EVERY: Rate-limited print that outputs at most once per interval
 // Uses static timestamp to track last print time - throttles output in tight loops
@@ -452,10 +534,20 @@ void log_emit(log_kind kind, const char* file, int line, fl::sstream& body) FL_N
         FL_PRINT(X); \
     } \
 } while(0)
+#define FL_PRINT_F_EVERY(MILLIS, ...) do { \
+    static fl::u32 _last_print_time = 0; \
+    fl::u32 _now = fl::millis(); \
+    if (_now - _last_print_time >= (MILLIS)) { \
+        _last_print_time = _now; \
+        FL_PRINT_F(__VA_ARGS__); \
+    } \
+} while(0)
 #else
 // No-op macro for memory-constrained platforms
 #define FL_PRINT(X) do { } while(0)
+#define FL_PRINT_F(...) do { } while(0)
 #define FL_PRINT_EVERY(MILLIS, X) do { } while(0)
+#define FL_PRINT_F_EVERY(MILLIS, ...) do { } while(0)
 #endif
 #endif
 
@@ -470,56 +562,70 @@ void log_emit(log_kind kind, const char* file, int line, fl::sstream& body) FL_N
 /// Logs SPI configuration, initialization, and transfers
 #ifdef FASTLED_LOG_SPI_ENABLED
     #define FL_LOG_SPI(X) FL_WARN(X)
+    #define FL_LOG_SPI_F(...) FL_WARN_F(__VA_ARGS__)
 #else
     #define FL_LOG_SPI(X) FL_DBG_NO_OP(X)
+    #define FL_LOG_SPI_F(...) do {} while(0)
 #endif
 
 /// @brief Remote Control Module (RMT) logging (ESP32)
 /// Logs RMT channel configuration, timing, and signal generation
 #ifdef FASTLED_LOG_RMT_ENABLED
     #define FL_LOG_RMT(X) FL_WARN(X)
+    #define FL_LOG_RMT_F(...) FL_WARN_F(__VA_ARGS__)
 #else
     #define FL_LOG_RMT(X) FL_DBG_NO_OP(X)
+    #define FL_LOG_RMT_F(...) do {} while(0)
 #endif
 
 /// @brief Parallel I/O (Parlio) logging (ESP32-P4)
 /// Logs Parlio configuration, GPIO setup, and parallel transfers
 #ifdef FASTLED_LOG_PARLIO_ENABLED
     #define FL_LOG_PARLIO(X) FL_WARN(X)
+    #define FL_LOG_PARLIO_F(...) FL_WARN_F(__VA_ARGS__)
 #else
     #define FL_LOG_PARLIO(X) FL_DBG_NO_OP(X)
+    #define FL_LOG_PARLIO_F(...) do {} while(0)
 #endif
 
 /// @brief Audio processing logging
 /// Logs audio sample processing, FFT computation, beat detection, and detector updates
 #ifdef FASTLED_LOG_AUDIO_ENABLED
     #define FL_LOG_AUDIO(X) FL_WARN(X)
+    #define FL_LOG_AUDIO_F(...) FL_WARN_F(__VA_ARGS__)
 #else
     #define FL_LOG_AUDIO(X) FL_DBG_NO_OP(X)
+    #define FL_LOG_AUDIO_F(...) do {} while(0)
 #endif
 
 /// @brief Interrupt handling logging
 /// Logs interrupt installation, handler registration, and ISR events
 #ifdef FASTLED_LOG_INTERRUPT_ENABLED
     #define FL_LOG_INTERRUPT(X) FL_WARN(X)
+    #define FL_LOG_INTERRUPT_F(...) FL_WARN_F(__VA_ARGS__)
 #else
     #define FL_LOG_INTERRUPT(X) FL_DBG_NO_OP(X)
+    #define FL_LOG_INTERRUPT_F(...) do {} while(0)
 #endif
 
 /// @brief FlexIO logging (Teensy 4.x)
 /// Logs FlexIO configuration, pin setup, DMA, and signal generation
 #ifdef FASTLED_LOG_FLEXIO_ENABLED
     #define FL_LOG_FLEXIO(X) FL_WARN(X)
+    #define FL_LOG_FLEXIO_F(...) FL_WARN_F(__VA_ARGS__)
 #else
     #define FL_LOG_FLEXIO(X) FL_DBG_NO_OP(X)
+    #define FL_LOG_FLEXIO_F(...) do {} while(0)
 #endif
 
 /// @brief ObjectFLED logging (Teensy 4.x)
 /// Logs ObjectFLED configuration, pin mapping, and DMA transfers
 #ifdef FASTLED_LOG_OBJECTFLED_ENABLED
     #define FL_LOG_OBJECTFLED(X) FL_WARN(X)
+    #define FL_LOG_OBJECTFLED_F(...) FL_WARN_F(__VA_ARGS__)
 #else
     #define FL_LOG_OBJECTFLED(X) FL_DBG_NO_OP(X)
+    #define FL_LOG_OBJECTFLED_F(...) do {} while(0)
 #endif
 
 /// @}
@@ -591,6 +697,11 @@ void log_emit(log_kind kind, const char* file, int line, fl::sstream& body) FL_N
         (logger).push((fl::sstream() << X).str()); \
     } while(0)
 
+#define FL_LOG_ASYNC_F(logger, ...) \
+    do { \
+        (logger).push(fl::detail::log_format_string(__VA_ARGS__)); \
+    } while(0)
+
 /// @brief ISR-safe async logging macro (const char* literals only, zero heap allocation)
 /// @param logger Reference to AsyncLogger instance (e.g., get_parlio_async_logger_isr())
 /// @param msg Compile-time const char* literal (e.g., "event occurred")
@@ -609,6 +720,7 @@ void log_emit(log_kind kind, const char* file, int line, fl::sstream& body) FL_N
 #ifdef FASTLED_LOG_SPI_ENABLED
     #define FL_LOG_SPI_ASYNC_ISR(X) FL_LOG_ASYNC_ISR(fl::get_spi_async_logger_isr(), X)
     #define FL_LOG_SPI_ASYNC_MAIN(X) FL_LOG_ASYNC(fl::get_spi_async_logger_main(), X)
+    #define FL_LOG_SPI_ASYNC_MAIN_F(...) FL_LOG_ASYNC_F(fl::get_spi_async_logger_main(), __VA_ARGS__)
     #define FL_LOG_SPI_ASYNC_FLUSH() do { \
         fl::get_spi_async_logger_isr().flush(); \
         fl::get_spi_async_logger_main().flush(); \
@@ -616,6 +728,7 @@ void log_emit(log_kind kind, const char* file, int line, fl::sstream& body) FL_N
 #else
     #define FL_LOG_SPI_ASYNC_ISR(X) FL_DBG_NO_OP(X)
     #define FL_LOG_SPI_ASYNC_MAIN(X) FL_DBG_NO_OP(X)
+    #define FL_LOG_SPI_ASYNC_MAIN_F(...) do {} while(0)
     #define FL_LOG_SPI_ASYNC_FLUSH() do {} while(0)
 #endif
 
@@ -626,6 +739,7 @@ void log_emit(log_kind kind, const char* file, int line, fl::sstream& body) FL_N
 #ifdef FASTLED_LOG_RMT_ENABLED
     #define FL_LOG_RMT_ASYNC_ISR(X) FL_LOG_ASYNC_ISR(fl::get_rmt_async_logger_isr(), X)
     #define FL_LOG_RMT_ASYNC_MAIN(X) FL_LOG_ASYNC(fl::get_rmt_async_logger_main(), X)
+    #define FL_LOG_RMT_ASYNC_MAIN_F(...) FL_LOG_ASYNC_F(fl::get_rmt_async_logger_main(), __VA_ARGS__)
     #define FL_LOG_RMT_ASYNC_FLUSH() do { \
         fl::get_rmt_async_logger_isr().flush(); \
         fl::get_rmt_async_logger_main().flush(); \
@@ -633,6 +747,7 @@ void log_emit(log_kind kind, const char* file, int line, fl::sstream& body) FL_N
 #else
     #define FL_LOG_RMT_ASYNC_ISR(X) FL_DBG_NO_OP(X)
     #define FL_LOG_RMT_ASYNC_MAIN(X) FL_DBG_NO_OP(X)
+    #define FL_LOG_RMT_ASYNC_MAIN_F(...) do {} while(0)
     #define FL_LOG_RMT_ASYNC_FLUSH() do {} while(0)
 #endif
 
@@ -643,6 +758,7 @@ void log_emit(log_kind kind, const char* file, int line, fl::sstream& body) FL_N
 #ifdef FASTLED_LOG_PARLIO_ENABLED
     #define FL_LOG_PARLIO_ASYNC_ISR(X) FL_LOG_ASYNC_ISR(fl::get_parlio_async_logger_isr(), X)
     #define FL_LOG_PARLIO_ASYNC_MAIN(X) FL_LOG_ASYNC(fl::get_parlio_async_logger_main(), X)
+    #define FL_LOG_PARLIO_ASYNC_MAIN_F(...) FL_LOG_ASYNC_F(fl::get_parlio_async_logger_main(), __VA_ARGS__)
     #define FL_LOG_PARLIO_ASYNC_FLUSH() do { \
         fl::get_parlio_async_logger_isr().flush(); \
         fl::get_parlio_async_logger_main().flush(); \
@@ -650,6 +766,7 @@ void log_emit(log_kind kind, const char* file, int line, fl::sstream& body) FL_N
 #else
     #define FL_LOG_PARLIO_ASYNC_ISR(X) FL_DBG_NO_OP(X)
     #define FL_LOG_PARLIO_ASYNC_MAIN(X) FL_DBG_NO_OP(X)
+    #define FL_LOG_PARLIO_ASYNC_MAIN_F(...) do {} while(0)
     #define FL_LOG_PARLIO_ASYNC_FLUSH() do {} while(0)
 #endif
 
@@ -660,6 +777,7 @@ void log_emit(log_kind kind, const char* file, int line, fl::sstream& body) FL_N
 #ifdef FASTLED_LOG_AUDIO_ENABLED
     #define FL_LOG_AUDIO_ASYNC_ISR(X) FL_LOG_ASYNC_ISR(fl::get_audio_async_logger_isr(), X)
     #define FL_LOG_AUDIO_ASYNC_MAIN(X) FL_LOG_ASYNC(fl::get_audio_async_logger_main(), X)
+    #define FL_LOG_AUDIO_ASYNC_MAIN_F(...) FL_LOG_ASYNC_F(fl::get_audio_async_logger_main(), __VA_ARGS__)
     #define FL_LOG_AUDIO_ASYNC_FLUSH() do { \
         fl::get_audio_async_logger_isr().flush(); \
         fl::get_audio_async_logger_main().flush(); \
@@ -667,6 +785,7 @@ void log_emit(log_kind kind, const char* file, int line, fl::sstream& body) FL_N
 #else
     #define FL_LOG_AUDIO_ASYNC_ISR(X) FL_DBG_NO_OP(X)
     #define FL_LOG_AUDIO_ASYNC_MAIN(X) FL_DBG_NO_OP(X)
+    #define FL_LOG_AUDIO_ASYNC_MAIN_F(...) do {} while(0)
     #define FL_LOG_AUDIO_ASYNC_FLUSH() do {} while(0)
 #endif
 
@@ -677,6 +796,7 @@ void log_emit(log_kind kind, const char* file, int line, fl::sstream& body) FL_N
 #ifdef FASTLED_LOG_INTERRUPT_ENABLED
     #define FL_LOG_INTERRUPT_ASYNC_ISR(X) FL_LOG_ASYNC_ISR(fl::get_interrupt_async_logger_isr(), X)
     #define FL_LOG_INTERRUPT_ASYNC_MAIN(X) FL_LOG_ASYNC(fl::get_interrupt_async_logger_main(), X)
+    #define FL_LOG_INTERRUPT_ASYNC_MAIN_F(...) FL_LOG_ASYNC_F(fl::get_interrupt_async_logger_main(), __VA_ARGS__)
     #define FL_LOG_INTERRUPT_ASYNC_FLUSH() do { \
         fl::get_interrupt_async_logger_isr().flush(); \
         fl::get_interrupt_async_logger_main().flush(); \
@@ -684,6 +804,7 @@ void log_emit(log_kind kind, const char* file, int line, fl::sstream& body) FL_N
 #else
     #define FL_LOG_INTERRUPT_ASYNC_ISR(X) FL_DBG_NO_OP(X)
     #define FL_LOG_INTERRUPT_ASYNC_MAIN(X) FL_DBG_NO_OP(X)
+    #define FL_LOG_INTERRUPT_ASYNC_MAIN_F(...) do {} while(0)
     #define FL_LOG_INTERRUPT_ASYNC_FLUSH() do {} while(0)
 #endif
 
@@ -694,6 +815,7 @@ void log_emit(log_kind kind, const char* file, int line, fl::sstream& body) FL_N
 #ifdef FASTLED_LOG_FLEXIO_ENABLED
     #define FL_LOG_FLEXIO_ASYNC_ISR(X) FL_LOG_ASYNC_ISR(fl::get_flexio_async_logger_isr(), X)
     #define FL_LOG_FLEXIO_ASYNC_MAIN(X) FL_LOG_ASYNC(fl::get_flexio_async_logger_main(), X)
+    #define FL_LOG_FLEXIO_ASYNC_MAIN_F(...) FL_LOG_ASYNC_F(fl::get_flexio_async_logger_main(), __VA_ARGS__)
     #define FL_LOG_FLEXIO_ASYNC_FLUSH() do { \
         fl::get_flexio_async_logger_isr().flush(); \
         fl::get_flexio_async_logger_main().flush(); \
@@ -701,6 +823,7 @@ void log_emit(log_kind kind, const char* file, int line, fl::sstream& body) FL_N
 #else
     #define FL_LOG_FLEXIO_ASYNC_ISR(X) FL_DBG_NO_OP(X)
     #define FL_LOG_FLEXIO_ASYNC_MAIN(X) FL_DBG_NO_OP(X)
+    #define FL_LOG_FLEXIO_ASYNC_MAIN_F(...) do {} while(0)
     #define FL_LOG_FLEXIO_ASYNC_FLUSH() do {} while(0)
 #endif
 
@@ -711,6 +834,7 @@ void log_emit(log_kind kind, const char* file, int line, fl::sstream& body) FL_N
 #ifdef FASTLED_LOG_OBJECTFLED_ENABLED
     #define FL_LOG_OBJECTFLED_ASYNC_ISR(X) FL_LOG_ASYNC_ISR(fl::get_objectfled_async_logger_isr(), X)
     #define FL_LOG_OBJECTFLED_ASYNC_MAIN(X) FL_LOG_ASYNC(fl::get_objectfled_async_logger_main(), X)
+    #define FL_LOG_OBJECTFLED_ASYNC_MAIN_F(...) FL_LOG_ASYNC_F(fl::get_objectfled_async_logger_main(), __VA_ARGS__)
     #define FL_LOG_OBJECTFLED_ASYNC_FLUSH() do { \
         fl::get_objectfled_async_logger_isr().flush(); \
         fl::get_objectfled_async_logger_main().flush(); \
@@ -718,6 +842,7 @@ void log_emit(log_kind kind, const char* file, int line, fl::sstream& body) FL_N
 #else
     #define FL_LOG_OBJECTFLED_ASYNC_ISR(X) FL_DBG_NO_OP(X)
     #define FL_LOG_OBJECTFLED_ASYNC_MAIN(X) FL_DBG_NO_OP(X)
+    #define FL_LOG_OBJECTFLED_ASYNC_MAIN_F(...) do {} while(0)
     #define FL_LOG_OBJECTFLED_ASYNC_FLUSH() do {} while(0)
 #endif
 

--- a/src/fl/math/filter/hampel_filter_impl.h
+++ b/src/fl/math/filter/hampel_filter_impl.h
@@ -21,7 +21,7 @@ class HampelFilterImpl {
         : mRing(capacity), mSorted(capacity),
           mSortedCount(0), mThreshold(threshold), mLastValue(T(0)) {
         if (capacity % 2 == 0) {
-            FL_ERROR("HampelFilter: capacity should be odd, adding 1");
+            FL_ERROR_F("HampelFilter: capacity should be odd, adding 1");
             mRing = circular_buffer<T, N>(capacity + 1);
             mSorted = circular_buffer<T, N>(capacity + 1);
         }
@@ -99,7 +99,7 @@ class HampelFilterImpl {
 
     void resize(fl::size new_capacity) {
         if (new_capacity % 2 == 0) {
-            FL_ERROR("HampelFilter: capacity should be odd, adding 1");
+            FL_ERROR_F("HampelFilter: capacity should be odd, adding 1");
             new_capacity += 1;
         }
         mRing = circular_buffer<T, N>(new_capacity);

--- a/src/fl/math/filter/median_filter_impl.h
+++ b/src/fl/math/filter/median_filter_impl.h
@@ -20,7 +20,7 @@ class MedianFilterImpl {
         : mRing(capacity), mSorted(capacity),
           mSortedCount(0), mLastMedian(T(0)) {
         if (capacity % 2 == 0) {
-            FL_ERROR("MedianFilter: capacity should be odd, adding 1");
+            FL_ERROR_F("MedianFilter: capacity should be odd, adding 1");
             mRing = circular_buffer<T, N>(capacity + 1);
             mSorted = circular_buffer<T, N>(capacity + 1);
         }
@@ -86,7 +86,7 @@ class MedianFilterImpl {
 
     void resize(fl::size new_capacity) {
         if (new_capacity % 2 == 0) {
-            FL_ERROR("MedianFilter: capacity should be odd, adding 1");
+            FL_ERROR_F("MedianFilter: capacity should be odd, adding 1");
             new_capacity += 1;
         }
         mRing = circular_buffer<T, N>(new_capacity);

--- a/src/fl/math/filter/savitzky_golay_filter_impl.h
+++ b/src/fl/math/filter/savitzky_golay_filter_impl.h
@@ -19,7 +19,7 @@ class SavitzkyGolayFilterImpl {
     explicit SavitzkyGolayFilterImpl(fl::size capacity)
         : mBuf(capacity), mLastValue(T(0)) {
         if (capacity % 2 == 0) {
-            FL_ERROR("SavitzkyGolayFilter: capacity should be odd, adding 1");
+            FL_ERROR_F("SavitzkyGolayFilter: capacity should be odd, adding 1");
             mBuf = circular_buffer<T, N>(capacity + 1);
         }
     }
@@ -45,7 +45,7 @@ class SavitzkyGolayFilterImpl {
 
     void resize(fl::size new_capacity) {
         if (new_capacity % 2 == 0) {
-            FL_ERROR("SavitzkyGolayFilter: capacity should be odd, adding 1");
+            FL_ERROR_F("SavitzkyGolayFilter: capacity should be odd, adding 1");
             new_capacity += 1;
         }
         mBuf = circular_buffer<T, N>(new_capacity);

--- a/src/fl/math/filter/triangular_filter_impl.h
+++ b/src/fl/math/filter/triangular_filter_impl.h
@@ -19,7 +19,7 @@ class TriangularFilterImpl {
     explicit TriangularFilterImpl(fl::size capacity)
         : mBuf(capacity), mLastValue(T(0)) {
         if (capacity % 2 == 0) {
-            FL_ERROR("TriangularFilter: capacity should be odd, adding 1");
+            FL_ERROR_F("TriangularFilter: capacity should be odd, adding 1");
             mBuf = circular_buffer<T, N>(capacity + 1);
         }
     }
@@ -45,7 +45,7 @@ class TriangularFilterImpl {
 
     void resize(fl::size new_capacity) {
         if (new_capacity % 2 == 0) {
-            FL_ERROR("TriangularFilter: capacity should be odd, adding 1");
+            FL_ERROR_F("TriangularFilter: capacity should be odd, adding 1");
             new_capacity += 1;
         }
         mBuf = circular_buffer<T, N>(new_capacity);

--- a/src/fl/math/screenmap.cpp.hpp
+++ b/src/fl/math/screenmap.cpp.hpp
@@ -53,7 +53,7 @@ fl::vector<float> jsonArrayToFloatVector(const fl::json& jsonArray) {
         if (!parseResult.has_error()) {
             result.push_back(parseResult.get_value());
         } else {
-            FL_WARN("jsonArrayToFloatVector: parse_result<float> has error: " << parseResult.get_error().message);
+            FL_WARN_F("jsonArrayToFloatVector: parse_result<float> has error: %s", parseResult.get_error().message);
         }
     }
     
@@ -190,7 +190,7 @@ bool ScreenMap::ParseJson(const char *jsonStrScreenMap,
     FL_UNUSED(jsonStrScreenMap);
     FL_UNUSED(segmentMaps);
     FL_UNUSED(err);
-    FL_WARN("ScreenMap::ParseJson called with FASTLED_NO_JSON");
+    FL_WARN_F("ScreenMap::ParseJson called with FASTLED_NO_JSON");
     if (err) {
         *err = "JSON is not supported in this build";
     }
@@ -206,13 +206,13 @@ bool ScreenMap::ParseJson(const char *jsonStrScreenMap,
     auto jsonDoc = fl::json::parse(jsonStrScreenMap);
     if (!jsonDoc.has_value()) {
         *err = "Failed to parse JSON";
-        FL_WARN("Failed to parse JSON");
+        FL_WARN_F("Failed to parse JSON");
         return false;
     }
 
     if (!jsonDoc.is_object()) {
         *err = "JSON root is not an object";
-        FL_WARN("JSON root is not an object");
+        FL_WARN_F("JSON root is not an object");
         return false;
     }
 
@@ -242,7 +242,7 @@ bool ScreenMap::ParseJson(const char *jsonStrScreenMap,
     // Check if "map" key exists and is an object
     if (!jsonDoc.contains("map")) {
         *err = "Missing 'map' key in JSON";
-        FL_WARN("Missing 'map' key in JSON");
+        FL_WARN_F("Missing 'map' key in JSON");
         return false;
     }
     
@@ -250,14 +250,14 @@ bool ScreenMap::ParseJson(const char *jsonStrScreenMap,
     auto mapObj = jsonDoc["map"];
     if (!mapObj.has_value() || !mapObj.is_object()) {
         *err = "Invalid 'map' object in JSON";
-        FL_WARN("Invalid 'map' object in JSON");
+        FL_WARN_F("Invalid 'map' object in JSON");
         return false;
     }
     
     auto jsonMapPtr = mapObj.as_object();
     if (!jsonMapPtr || jsonMapPtr->empty()) {
         *err = "Failed to parse map from JSON or map is empty";
-        FL_WARN("Failed to parse map from JSON or map is empty");
+        FL_WARN_F("Failed to parse map from JSON or map is empty");
         return false;
     }
 
@@ -370,11 +370,11 @@ void ScreenMap::toJson(const fl::flat_map<string, ScreenMap> &segmentMaps,
                        fl::json *doc) {
 
 #if FASTLED_NO_JSON
-    FL_WARN("ScreenMap::toJson called with FASTLED_NO_JSON");
+    FL_WARN_F("ScreenMap::toJson called with FASTLED_NO_JSON");
     return;
 #else
     if (!doc) {
-        FL_WARN("ScreenMap::toJson called with nullptr doc");
+        FL_WARN_F("ScreenMap::toJson called with nullptr doc");
         return;
     }
 
@@ -402,7 +402,7 @@ void ScreenMap::toJson(const fl::flat_map<string, ScreenMap> &segmentMaps,
     size_t idx = 0;
     for (const auto& kv : segmentMaps) {
         if (kv.second.getLength() == 0) {
-            FL_WARN("ScreenMap::toJson called with empty segment: " << fl::string(kv.first));
+            FL_WARN_F("ScreenMap::toJson called with empty segment: %s", fl::string(kv.first));
             continue;
         }
 
@@ -440,7 +440,7 @@ void ScreenMap::toJson(const fl::flat_map<string, ScreenMap> &segmentMaps,
     doc->set("segments", segmentsArr);
 
     fl::string debugStr = doc->to_string();
-    FL_WARN("ScreenMap::toJson generated JSON: " << debugStr);
+    FL_WARN_F("ScreenMap::toJson generated JSON: %s", debugStr);
 #endif
 }
 

--- a/src/fl/math/wave/wave_simulation_real.cpp.hpp
+++ b/src/fl/math/wave/wave_simulation_real.cpp.hpp
@@ -87,7 +87,7 @@ float WaveSimulation1D_Real::getSpeed() const {
 
 i16 WaveSimulation1D_Real::geti16(fl::size x) const {
     if (x >= length) {
-        FL_WARN("Out of range.");
+        FL_WARN_F("Out of range.");
         return 0;
     }
     const i16 *curr = (whichGrid == 0) ? grid1.data() : grid2.data();
@@ -96,7 +96,7 @@ i16 WaveSimulation1D_Real::geti16(fl::size x) const {
 
 i16 WaveSimulation1D_Real::geti16Previous(fl::size x) const {
     if (x >= length) {
-        FL_WARN("Out of range.");
+        FL_WARN_F("Out of range.");
         return 0;
     }
     const i16 *prev = (whichGrid == 0) ? grid2.data() : grid1.data();
@@ -105,7 +105,7 @@ i16 WaveSimulation1D_Real::geti16Previous(fl::size x) const {
 
 float WaveSimulation1D_Real::getf(fl::size x) const {
     if (x >= length) {
-        FL_WARN("Out of range.");
+        FL_WARN_F("Out of range.");
         return 0.0f;
     }
     // Retrieve value from the active grid (offset by 1 for boundary).
@@ -117,7 +117,7 @@ bool WaveSimulation1D_Real::has(fl::size x) const { return (x < length); }
 
 void WaveSimulation1D_Real::set(fl::size x, float value) {
     if (x >= length) {
-        FL_WARN("warning X value too high");
+        FL_WARN_F("warning X value too high");
         return;
     }
     i16 *curr = (whichGrid == 0) ? grid1.data() : grid2.data();
@@ -229,7 +229,7 @@ float WaveSimulation2D_Real::getSpeed() const {
 
 float WaveSimulation2D_Real::getf(fl::size x, fl::size y) const {
     if (x >= width || y >= height) {
-        FL_WARN("Out of range: " << x << ", " << y);
+        FL_WARN_F("Out of range: %s, %s", x, y);
         return 0.0f;
     }
     const i16 *curr = (whichGrid == 0 ? grid1.data() : grid2.data());
@@ -238,7 +238,7 @@ float WaveSimulation2D_Real::getf(fl::size x, fl::size y) const {
 
 i16 WaveSimulation2D_Real::geti16(fl::size x, fl::size y) const {
     if (x >= width || y >= height) {
-        FL_WARN("Out of range: " << x << ", " << y);
+        FL_WARN_F("Out of range: %s, %s", x, y);
         return 0;
     }
     const i16 *curr = (whichGrid == 0 ? grid1.data() : grid2.data());
@@ -247,7 +247,7 @@ i16 WaveSimulation2D_Real::geti16(fl::size x, fl::size y) const {
 
 i16 WaveSimulation2D_Real::geti16Previous(fl::size x, fl::size y) const {
     if (x >= width || y >= height) {
-        FL_WARN("Out of range: " << x << ", " << y);
+        FL_WARN_F("Out of range: %s, %s", x, y);
         return 0;
     }
     const i16 *prev = (whichGrid == 0 ? grid2.data() : grid1.data());
@@ -265,7 +265,7 @@ void WaveSimulation2D_Real::setf(fl::size x, fl::size y, float value) {
 
 void WaveSimulation2D_Real::seti16(fl::size x, fl::size y, i16 value) {
     if (x >= width || y >= height) {
-        FL_WARN("Out of range: " << x << ", " << y);
+        FL_WARN_F("Out of range: %s, %s", x, y);
         return;
     }
     i16 *curr = (whichGrid == 0 ? grid1.data() : grid2.data());

--- a/src/fl/net/ble.cpp.hpp
+++ b/src/fl/net/ble.cpp.hpp
@@ -19,22 +19,22 @@ namespace net {
 namespace ble {
 
 TransportState* createTransport(const char*) FL_NOEXCEPT {
-    FL_ERROR("BLE not implemented on this platform");
+    FL_ERROR_F("BLE not implemented on this platform");
     return nullptr;
 }
 
 void destroyTransport(TransportState*) FL_NOEXCEPT {
-    FL_ERROR("BLE not implemented on this platform");
+    FL_ERROR_F("BLE not implemented on this platform");
 }
 
 StatusInfo queryStatus(const TransportState*) FL_NOEXCEPT {
-    FL_ERROR("BLE not implemented on this platform");
+    FL_ERROR_F("BLE not implemented on this platform");
     return StatusInfo{};
 }
 
 fl::pair<fl::function<fl::optional<fl::json>()>, fl::function<void(const fl::json&)>>
 getTransportCallbacks(TransportState*) FL_NOEXCEPT {
-    FL_ERROR("BLE not implemented on this platform");
+    FL_ERROR_F("BLE not implemented on this platform");
     return {
         fl::function<fl::optional<fl::json>()>([]() -> fl::optional<fl::json> { return fl::optional<fl::json>(); }),
         fl::function<void(const fl::json&)>([](const fl::json&) {})

--- a/src/fl/net/http/fetch.cpp.hpp
+++ b/src/fl/net/http/fetch.cpp.hpp
@@ -119,7 +119,7 @@ response perform_http_request(const fl::string& url, const FetchOptions& request
     }
 
     // Resolve hostname
-    FL_WARN("[FETCH] Resolving hostname: " << parsed.host);
+    FL_WARN_F("[FETCH] Resolving hostname: %s", parsed.host);
     struct hostent* server = gethostbyname(parsed.host.c_str());
     if (server == nullptr) {
         close(sock);
@@ -167,7 +167,7 @@ response perform_http_request(const fl::string& url, const FetchOptions& request
         FD_SET(sock, &write_fds);
 
         // Wait for connection with async pumping
-        FL_WARN("[FETCH] Waiting for connection to " << parsed.host << ":" << parsed.port);
+        FL_WARN_F("[FETCH] Waiting for connection to %s:%s", parsed.host, parsed.port);
         while (true) {
             timeout.tv_sec = 0;
             timeout.tv_usec = 10000;  // 10ms
@@ -227,7 +227,7 @@ response perform_http_request(const fl::string& url, const FetchOptions& request
     }
 
     // Read response (non-blocking with async pumping)
-    FL_WARN("[FETCH] Waiting for HTTP response...");
+    FL_WARN_F("[FETCH] Waiting for HTTP response...");
     fl::string response_data;
     char buffer[4096];
     int retries = 0;
@@ -409,7 +409,7 @@ void fetch(const fl::string& url, const FetchCallback& callback) {
 
 fl::task::Promise<Response> execute_fetch_request(const fl::string& url, const FetchOptions& request) {
     (void)request;
-    FL_WARN("HTTP fetch is not supported on this platform. URL: " << url);
+    FL_WARN_F("HTTP fetch is not supported on this platform. URL: %s", url);
     Response error_response(501, "Not Implemented");
     error_response.set_body("HTTP fetch is not available on this platform.");
     return fl::task::Promise<Response>::resolve(error_response);
@@ -651,7 +651,7 @@ fl::json Response::json() const {
         if (is_json() || mBody.find("{") != fl::string::npos || mBody.find("[") != fl::string::npos) {
             mCachedJson = parse_json_body();
         } else {
-            FL_WARN("Response is not JSON: " << mBody);
+            FL_WARN_F("Response is not JSON: %s", mBody);
             mCachedJson = fl::json(nullptr);  // Not JSON content
         }
         mJsonParsed = true;

--- a/src/fl/net/http/fetch_request.cpp.hpp
+++ b/src/fl/net/http/fetch_request.cpp.hpp
@@ -120,7 +120,7 @@ void FetchRequest::handle_dns_lookup() {
     // Pump async system before DNS to keep server responsive
     fl::task::run(1000);
 
-    FL_WARN("[FETCH] Resolving hostname: " << mHostname);
+    FL_WARN_F("[FETCH] Resolving hostname: %s", mHostname);
 
     // DNS lookup (blocking 10-100ms, but acceptable)
     // Note: localhost is typically instant due to OS caching
@@ -160,7 +160,7 @@ void FetchRequest::handle_dns_lookup() {
     fl::memcpy(&addr_ptr, mDnsResult->h_addr_list, sizeof(addr_ptr));
     fl::memcpy(&server_addr.sin_addr, addr_ptr, mDnsResult->h_length);
 
-    FL_WARN("[FETCH] Waiting for connection to " << mHostname << ":" << mPort);
+    FL_WARN_F("[FETCH] Waiting for connection to %s:%s", mHostname, mPort);
 
     connect(mSocketFd, (sockaddr*)&server_addr, sizeof(server_addr));
     // connect() returns immediately with EINPROGRESS/WSAEWOULDBLOCK (expected)
@@ -219,7 +219,7 @@ void FetchRequest::handle_sending() {
     if (sent > 0) {
         mBytesSent += sent;
         if (mBytesSent >= mRequestBuffer.size()) {
-            FL_WARN("[FETCH] Waiting for HTTP response...");
+            FL_WARN_F("[FETCH] Waiting for HTTP response...");
             mState = RECEIVING;
             mStateStartTime = fl::millis();
         }

--- a/src/fl/remote/remote.cpp.hpp
+++ b/src/fl/remote/remote.cpp.hpp
@@ -20,7 +20,7 @@ namespace fl {
 bool Remote::unbind(const fl::string& name) {
     bool removed = mRpc.unbind(name.c_str());
     if (removed) {
-        FL_DBG("Unregistered RPC function: " << name);
+        FL_DBG_F("Unregistered RPC function: %s", name);
     }
     return removed;
 }
@@ -35,7 +35,7 @@ void Remote::sendAsyncResponse(const char* method, const fl::json& result) {
     fl::string methodName(method);
     auto it = mAsyncRequests.find(methodName);
     if (it == mAsyncRequests.end()) {
-        FL_WARN("No pending async request for method: " << method);
+        FL_WARN_F("No pending async request for method: %s", method);
         return;
     }
 
@@ -51,7 +51,7 @@ void Remote::sendAsyncResponse(const char* method, const fl::json& result) {
     // Send via response sink
     if (mResponseSink) {
         mResponseSink(response);
-        FL_DBG("Sent async response for " << method << " (id=" << requestId << ")");
+        FL_DBG_F("Sent async response for %s (id=%s)", method, requestId);
     }
 }
 
@@ -59,7 +59,7 @@ void Remote::sendStreamUpdate(const char* method, const fl::json& update) {
     fl::string methodName(method);
     auto it = mAsyncRequests.find(methodName);
     if (it == mAsyncRequests.end()) {
-        FL_WARN("No pending async request for method: " << method);
+        FL_WARN_F("No pending async request for method: %s", method);
         return;
     }
 
@@ -78,7 +78,7 @@ void Remote::sendStreamUpdate(const char* method, const fl::json& update) {
     // Send via response sink
     if (mResponseSink) {
         mResponseSink(response);
-        FL_DBG("Sent stream update for " << method << " (id=" << requestId << ")");
+        FL_DBG_F("Sent stream update for %s (id=%s)", method, requestId);
     }
 }
 
@@ -86,7 +86,7 @@ void Remote::sendStreamFinal(const char* method, const fl::json& result) {
     fl::string methodName(method);
     auto it = mAsyncRequests.find(methodName);
     if (it == mAsyncRequests.end()) {
-        FL_WARN("No pending async request for method: " << method);
+        FL_WARN_F("No pending async request for method: %s", method);
         return;
     }
 
@@ -106,7 +106,7 @@ void Remote::sendStreamFinal(const char* method, const fl::json& result) {
     // Send via response sink
     if (mResponseSink) {
         mResponseSink(response);
-        FL_DBG("Sent stream final for " << method << " (id=" << requestId << ")");
+        FL_DBG_F("Sent stream final for %s (id=%s)", method, requestId);
     }
 }
 
@@ -148,7 +148,7 @@ fl::json Remote::processRpc(const fl::json& request) {
             fl::string methodName = request["method"].as_string().value_or("");
             int requestId = request["id"].as_int().value_or(0);
             mAsyncRequests[methodName] = {requestId, receivedAt};
-            FL_DBG("Stored request ID for " << methodName.c_str() << " (id=" << requestId << ")");
+            FL_DBG_F("Stored request ID for %s (id=%s)", methodName.c_str(), requestId);
         }
 
         // Immediate execution - pass directly to Rpc
@@ -179,7 +179,7 @@ fl::json Remote::processRpc(const fl::json& request) {
     } else {
         // Scheduled execution - result will be pushed to ResponseSink after execution
         scheduleFunction(timestamp, receivedAt, request);
-        FL_DBG("RPC: Scheduled function - result will be pushed after execution");
+        FL_DBG_F("RPC: Scheduled function - result will be pushed after execution");
 
         // Return acknowledgment with null result and "scheduled" marker
         fl::json response = fl::json::object();
@@ -210,7 +210,7 @@ void Remote::scheduleFunction(u32 timestamp, u32 receivedAt, const fl::json& jso
         }
     });
 
-    FL_DBG("Scheduled RPC: " << funcName << " at " << timestamp);
+    FL_DBG_F("Scheduled RPC: %s at %s", funcName, timestamp);
 }
 
 void Remote::recordResult(const fl::string& funcName, const fl::json& result, u32 scheduledAt, u32 receivedAt, u32 executedAt, bool wasScheduled) {
@@ -236,15 +236,15 @@ size_t Remote::pendingCount() const {
 void Remote::clear(ClearFlags flags) {
     if ((flags & ClearFlags::Results) != ClearFlags::None) {
         mResults.clear();
-        FL_DBG("Cleared RPC results");
+        FL_DBG_F("Cleared RPC results");
     }
     if ((flags & ClearFlags::Scheduled) != ClearFlags::None) {
         mScheduler.clear();
-        FL_DBG("Cleared scheduled RPC calls");
+        FL_DBG_F("Cleared scheduled RPC calls");
     }
     if ((flags & ClearFlags::Functions) != ClearFlags::None) {
         mRpc.clear();
-        FL_DBG("Cleared registered RPC functions");
+        FL_DBG_F("Cleared registered RPC functions");
     }
 }
 

--- a/src/fl/remote/rpc/rpc.cpp.hpp
+++ b/src/fl/remote/rpc/rpc.cpp.hpp
@@ -67,13 +67,13 @@ void Rpc::bindAsync(const char* name,
 json Rpc::handle(const json& request) {
     // Extract method name
     if (!request.contains("method")) {
-        FL_ERROR("RPC: Invalid Request - missing 'method' field");
+        FL_ERROR_F("RPC: Invalid Request - missing 'method' field");
         return detail::makeJsonRpcError(-32600, "Invalid Request: missing 'method'", request["id"]);
     }
 
     auto methodOpt = request["method"].as_string();
     if (!methodOpt.has_value()) {
-        FL_ERROR("RPC: Invalid Request - 'method' must be a string");
+        FL_ERROR_F("RPC: Invalid Request - 'method' must be a string");
         return detail::makeJsonRpcError(-32600, "Invalid Request: 'method' must be a string", request["id"]);
     }
     fl::string methodName = methodOpt.value();
@@ -99,14 +99,14 @@ json Rpc::handle(const json& request) {
     // Look up the method
     auto it = mRegistry.find(methodName);
     if (it == mRegistry.end()) {
-        FL_WARN("RPC: Method not found: " << methodName.c_str());
+        FL_WARN_F("RPC: Method not found: %s", methodName.c_str());
         return detail::makeJsonRpcError(-32601, "Method not found: " + methodName, request["id"]);
     }
 
     // Extract params (default to empty array)
     json params = request.contains("params") ? request["params"] : json::parse("[]");
     if (!params.is_array()) {
-        FL_ERROR("RPC: Invalid params - must be an array for method: " << methodName.c_str());
+        FL_ERROR_F("RPC: Invalid params - must be an array for method: %s", methodName.c_str());
         return detail::makeJsonRpcError(-32602, "Invalid params: must be an array", request["id"]);
     }
 
@@ -128,7 +128,7 @@ json Rpc::handle(const json& request) {
         ack.set("result", ackResult);
 
         mResponseSink(ack);
-        FL_DBG("RPC: Sent ACK for async method: " << methodName.c_str());
+        FL_DBG_F("RPC: Sent ACK for async method: %s", methodName.c_str());
     }
 
     fl::tuple<TypeConversionResult, json> resultTuple;
@@ -154,7 +154,7 @@ json Rpc::handle(const json& request) {
 
     // Check for conversion errors
     if (!convResult.ok()) {
-        FL_ERROR("RPC: Invalid params for method '" << methodName.c_str() << "': " << convResult.errorMessage().c_str());
+        FL_ERROR_F("RPC: Invalid params for method '%s': %s", methodName.c_str(), convResult.errorMessage().c_str());
         return detail::makeJsonRpcError(-32602, "Invalid params: " + convResult.errorMessage(), request["id"]);
     }
 

--- a/src/fl/stl/_build.cpp.hpp
+++ b/src/fl/stl/_build.cpp.hpp
@@ -23,6 +23,7 @@
 #include "fl/stl/ostream.cpp.hpp"
 #include "fl/stl/shared_ptr.cpp.hpp"
 #include "fl/stl/singleton.cpp.hpp"
+#include "fl/stl/stdio.cpp.hpp"
 #include "fl/stl/string.cpp.hpp"
 #include "fl/stl/string_interner.cpp.hpp"
 #include "fl/stl/string_view.cpp.hpp"

--- a/src/fl/stl/asio/http/server.cpp.hpp
+++ b/src/fl/stl/asio/http/server.cpp.hpp
@@ -850,7 +850,7 @@ bool Server::start(int port) {
     esp_err_t err = httpd_start(&s_esp_httpd, &config);
     if (err != ESP_OK) {
         mLastError = "httpd_start failed";
-        FL_WARN("[HTTP] httpd_start failed: " << esp_err_to_name(err));
+        FL_WARN_F("[HTTP] httpd_start failed: %s", esp_err_to_name(err));
         return false;
     }
 
@@ -866,7 +866,7 @@ bool Server::start(int port) {
 
         esp_err_t reg_err = httpd_register_uri_handler(s_esp_httpd, &uri_handler);
         if (reg_err != ESP_OK) {
-            FL_WARN("[HTTP] Failed to register route " << mRoutes[i].path.c_str());
+            FL_WARN_F("[HTTP] Failed to register route %s", mRoutes[i].path.c_str());
         }
         s_esp_route_contexts.push_back(fl::move(ctx));
     }
@@ -875,7 +875,7 @@ bool Server::start(int port) {
     mRunning = true;
     mLastError.clear();
 
-    FL_WARN("[HTTP] Server started on port " << port);
+    FL_WARN_F("[HTTP] Server started on port %s", port);
     return true;
 }
 
@@ -894,7 +894,7 @@ void Server::stop() {
     mRoutes.clear();
 
     mRunning = false;
-    FL_WARN("[HTTP] Server stopped");
+    FL_WARN_F("[HTTP] Server stopped");
 }
 
 void Server::route(const string& method, const string& path, RouteHandler handler) {

--- a/src/fl/stl/json.cpp.hpp
+++ b/src/fl/stl/json.cpp.hpp
@@ -522,7 +522,7 @@ public:
 
         // Recursion depth check
         if (mDepth > MAX_JSON_DEPTH) {
-            FL_ERROR("JSON parser: FATAL - recursion depth exceeded " << MAX_JSON_DEPTH);
+            FL_ERROR_F("JSON parser: FATAL - recursion depth exceeded %s", MAX_JSON_DEPTH);
             return ParseState::ERROR;
         }
 
@@ -919,7 +919,7 @@ public:
     ParseState on_token(JsonToken token, const fl::span<const char>& value) override {
         // Recursion depth check
         if (mDepth > MAX_JSON_DEPTH) {
-            FL_ERROR("JSON parser: FATAL - recursion depth exceeded " << MAX_JSON_DEPTH);
+            FL_ERROR_F("JSON parser: FATAL - recursion depth exceeded %s", MAX_JSON_DEPTH);
             return ParseState::ERROR;
         }
 

--- a/src/fl/stl/json.h
+++ b/src/fl/stl/json.h
@@ -44,19 +44,19 @@
  *
  * // Accessing an integer with a default value
  * int brightness = jsonDoc["config"]["brightness"] | 255; // Result: 128
- * FL_WARN("Brightness: " << brightness);
+ * FL_WARN_F("Brightness: %s", brightness);
  *
  * // Accessing a boolean with a default value
  * bool enabled = jsonDoc["config"]["enabled"] | false;    // Result: true
- * FL_WARN("Enabled: " << enabled);
+ * FL_WARN_F("Enabled: %s", enabled);
  *
  * // Accessing a string with a default value
  * fl::string deviceName = jsonDoc["config"]["name"] | fl::string("unknown"); // Result: "my_device"
- * FL_WARN("Device Name: " << deviceName);
+ * FL_WARN_F("Device Name: %s", deviceName);
  *
  * // Accessing a non-existent key with a default value
  * int nonExistent = jsonDoc["config"]["non_existent_key"] | 0; // Result: 0
- * FL_WARN("Non-existent: " << nonExistent);
+ * FL_WARN_F("Non-existent: %s", nonExistent);
  * @endcode
  *
  * Generating JSON Data - Build with Ease:
@@ -92,7 +92,7 @@
  *
  * // Convert the entire JSON object to a string
  * fl::string jsonString = newJson.to_string();
- * FL_WARN("Generated JSON:\n" << jsonString);
+ * FL_WARN_F("Generated JSON:\n%s", jsonString);
  * // Expected output (formatting may vary):
  * // {"version":1.0,"isActive":true,"message":"Hello, FastLED!","settings":{"mode":"dynamic","speed":50},"colors":["red","green","blue"]}
  * @endcode

--- a/src/fl/stl/json/types.h
+++ b/src/fl/stl/json/types.h
@@ -148,8 +148,7 @@ struct int_conversion_visitor {
         const i64 min_val = static_cast<i64>((fl::numeric_limits<Target>::min)());
         const i64 max_val = static_cast<i64>((fl::numeric_limits<Target>::max)());
         if (value < min_val || value > max_val) {
-            FL_WARN("JSON integer overflow: value " << value << " does not fit in target type (range: "
-                    << min_val << " to " << max_val << "), truncating");
+            FL_WARN_F("JSON integer overflow: value %s does not fit in target type (range: %s to %s), truncating", value, min_val, max_val);
             return true;
         }
         return false;
@@ -160,8 +159,7 @@ struct int_conversion_visitor {
     is_i64_out_of_range(const i64& value) FL_NOEXCEPT {
         const u64 max_val = static_cast<u64>((fl::numeric_limits<Target>::max)());
         if (value < 0 || static_cast<u64>(value) > max_val) {
-            FL_WARN("JSON integer overflow: value " << value << " does not fit in target type (range: 0 to "
-                    << max_val << "), truncating");
+            FL_WARN_F("JSON integer overflow: value %s does not fit in target type (range: 0 to %s), truncating", value, max_val);
             return true;
         }
         return false;

--- a/src/fl/stl/stdio.cpp.hpp
+++ b/src/fl/stl/stdio.cpp.hpp
@@ -1,0 +1,13 @@
+#include "fl/stl/stdio.h"
+
+namespace fl { namespace printf_detail {
+
+void format_arg(sstream& stream, const FormatSpec& spec, const fl::string& arg) FL_NOEXCEPT {
+    format_arg(stream, spec, arg.c_str());
+}
+
+void format_arg(sstream& stream, const FormatSpec& spec, const fl::string_view& arg) FL_NOEXCEPT {
+    format_arg(stream, spec, fl::string(arg).c_str());
+}
+
+} } // namespace fl::printf_detail

--- a/src/fl/stl/stdio.h
+++ b/src/fl/stl/stdio.h
@@ -553,6 +553,9 @@ inline void format_arg(sstream& stream, const FormatSpec& spec, const char* arg)
     stream << result;
 }
 
+void format_arg(sstream& stream, const FormatSpec& spec, const fl::string& arg) FL_NOEXCEPT;
+void format_arg(sstream& stream, const FormatSpec& spec, const fl::string_view& arg) FL_NOEXCEPT;
+
 // Specialized format_arg for char arrays (string literals like "hello")
 template<fl::size N>
 void format_arg(sstream& stream, const FormatSpec& spec, const char (&arg)[N]) FL_NOEXCEPT {

--- a/src/fl/stl/unordered_map.h
+++ b/src/fl/stl/unordered_map.h
@@ -343,8 +343,7 @@ class FL_ALIGN unordered_map {
             mark_occupied(idx);
             ++_size;
         } else {
-            FASTLED_ASSERT(idx != npos(), "unordered_map::insert: invalid index at "
-                                            << idx << " which is " << npos());
+            FASTLED_ASSERT(idx != npos(), "unordered_map::insert: invalid index");
             _buckets[idx].value = value;
         }
         return {iterator(this, idx), is_new};
@@ -374,8 +373,7 @@ class FL_ALIGN unordered_map {
             mark_occupied(idx);
             ++_size;
         } else {
-            FASTLED_ASSERT(idx != npos(), "unordered_map::insert: invalid index at "
-                                            << idx << " which is " << npos());
+            FASTLED_ASSERT(idx != npos(), "unordered_map::insert: invalid index");
             _buckets[idx].value = fl::move(value);
         }
         return {iterator(this, idx), is_new};
@@ -1043,8 +1041,7 @@ class FL_ALIGN unordered_map {
             if (idx == npos()) {
                 // no more space
                 FASTLED_ASSERT(
-                    false, "unordered_map::rehash_inline_no_resize: invalid index at "
-                               << idx << " which is " << npos());
+                    false, "unordered_map::rehash_inline_no_resize: invalid index");
                 return;
             }
             // if idx < pos then we are moving the entry to a new location
@@ -1068,8 +1065,7 @@ class FL_ALIGN unordered_map {
                     // no more space
                     FASTLED_ASSERT(
                         false,
-                        "unordered_map::rehash_inline_no_resize: invalid index at "
-                            << new_idx << " which is " << npos());
+                        "unordered_map::rehash_inline_no_resize: invalid index");
                     return;
                 }
                 occupied.set(new_idx);
@@ -1086,9 +1082,9 @@ class FL_ALIGN unordered_map {
             }
             FASTLED_ASSERT(
                 occupied.test(i),
-                "unordered_map::rehash_inline_no_resize: invalid occupied at " << i);
+                "unordered_map::rehash_inline_no_resize: invalid occupied");
             FASTLED_ASSERT(
-                tmp.empty(), "unordered_map::rehash_inline_no_resize: invalid tmp at " << i);
+                tmp.empty(), "unordered_map::rehash_inline_no_resize: invalid tmp");
         }
         // Reset tombstones count since we've cleared all deleted entries
         _tombstones = 0;

--- a/src/fl/system/file_system.cpp.hpp
+++ b/src/fl/system/file_system.cpp.hpp
@@ -1,4 +1,4 @@
-#include "fl/system/file_system.h"
+﻿#include "fl/system/file_system.h"
 #include "fl/stl/has_include.h"
 #include "fl/log/log.h"
 #include "fl/stl/vector.h"
@@ -12,7 +12,7 @@
 // This split lets the linker tree-shake the entire SD chain (libSD.a,
 // libFS.a, Arduino's VFSImpl, the printf engine VFSFileImpl drags in
 // via snprintf) AUTOMATICALLY when the user never calls
-// `FileSystem::beginSd()` — no FASTLED_USE_SDCARD opt-in required, and
+// `FileSystem::beginSd()` â€” no FASTLED_USE_SDCARD opt-in required, and
 // the macro that the earlier macro-gate PR (#2778 v1) shipped is
 // removed by this PR. See FastLED #2773 item 1.2 and the SD TU header
 // for the mechanism.
@@ -68,7 +68,7 @@ class NullFileHandle : public filebuf {
 class NullFileSystem : public FsImpl {
   public:
     NullFileSystem() FL_NOEXCEPT {
-        FL_WARN("NullFileSystem instantiated as a placeholder, please "
+        FL_WARN_F("NullFileSystem instantiated as a placeholder, please "
                      "implement a file system for your platform.");
     }
     ~NullFileSystem() FL_NOEXCEPT override {}
@@ -124,7 +124,7 @@ bool FileSystem::readScreenMaps(const char *path,
                                 fl::flat_map<string, ScreenMap> *out, string *error) {
     string text;
     if (!readText(path, &text)) {
-        FL_WARN("Failed to read file: " << path);
+        FL_WARN_F("Failed to read file: %s", path);
         if (error) {
             *error = "Failed to read file: ";
             error->append(path);
@@ -134,7 +134,7 @@ bool FileSystem::readScreenMaps(const char *path,
     string err;
     bool ok = ScreenMap::ParseJson(text.c_str(), out, &err);
     if (!ok) {
-        FL_WARN("Failed to parse screen map: " << err.c_str());
+        FL_WARN_F("Failed to parse screen map: %s", err.c_str());
         *error = err;
         return false;
     }
@@ -145,7 +145,7 @@ bool FileSystem::readScreenMap(const char *path, const char *name,
                                ScreenMap *out, string *error) {
     string text;
     if (!readText(path, &text)) {
-        FL_WARN("Failed to read file: " << path);
+        FL_WARN_F("Failed to read file: %s", path);
         if (error) {
             *error = "Failed to read file: ";
             error->append(path);
@@ -155,7 +155,7 @@ bool FileSystem::readScreenMap(const char *path, const char *name,
     string err;
     bool ok = ScreenMap::ParseJson(text.c_str(), name, out, &err);
     if (!ok) {
-        FL_WARN("Failed to parse screen map: " << err.c_str());
+        FL_WARN_F("Failed to parse screen map: %s", err.c_str());
         *error = err;
         return false;
     }
@@ -180,7 +180,7 @@ Video FileSystem::openVideo(const char *path, fl::size pixelsPerFrame, float fps
 bool FileSystem::readText(const char *path, fl::string *out) {
     fl::ifstream file = openRead(path);
     if (!file.is_open()) {
-        FL_WARN("Failed to open file: " << path);
+        FL_WARN_F("Failed to open file: %s", path);
         return false;
     }
     fl::size size = file.size();
@@ -193,7 +193,7 @@ bool FileSystem::readText(const char *path, fl::string *out) {
         wrote = true;
     }
     file.close();
-    FL_DBG_IF(!wrote, "Failed to write any data to the output string.");
+    FL_DBG_F_IF(!wrote, "Failed to write any data to the output string.");
     return wrote;
 }
 

--- a/src/fl/system/pin.cpp.hpp
+++ b/src/fl/system/pin.cpp.hpp
@@ -184,7 +184,7 @@ int ensureIsrActive() {
 
     int result = fl::isr::attach_timer_handler(cfg, &st.isr_handle);
     if (result != 0) {
-        FL_WARN("PWM: ISR attach failed: " << fl::isr::get_error_string(result));
+        FL_WARN_F("PWM: ISR attach failed: %s", fl::isr::get_error_string(result));
         return result;
     }
     st.isr_active = true;
@@ -283,7 +283,7 @@ int setPwmFrequency(int pin, u32 frequency_hz) {
 
     // Validate frequency
     if (frequency_hz == 0) {
-        FL_WARN("setPwmFrequency: Frequency must be > 0");
+        FL_WARN_F("setPwmFrequency: Frequency must be > 0");
         return -1;
     }
 
@@ -294,14 +294,14 @@ int setPwmFrequency(int pin, u32 frequency_hz) {
         // Native path
         int result = platforms::setPwmFrequencyNative(pin, frequency_hz);
         if (result != 0) {
-            FL_WARN("setPwmFrequency: Native backend failed: " << result);
+            FL_WARN_F("setPwmFrequency: Native backend failed: %s", result);
             return result;
         }
 
         // Allocate tracking slot
         ch = pwm_state::allocate();
         if (!ch) {
-            FL_WARN("setPwmFrequency: All " << static_cast<int>(pwm_state::MAX_PWM_CHANNELS) << " channels in use");
+            FL_WARN_F("setPwmFrequency: All %s channels in use", static_cast<int>(pwm_state::MAX_PWM_CHANNELS));
             return -2;
         }
 
@@ -314,14 +314,14 @@ int setPwmFrequency(int pin, u32 frequency_hz) {
 
     // ISR software fallback path
     if (frequency_hz > pwm_state::MAX_ISR_PWM_FREQUENCY) {
-        FL_WARN("setPwmFrequency: ISR fallback max " << pwm_state::MAX_ISR_PWM_FREQUENCY << " Hz, requested " << frequency_hz);
+        FL_WARN_F("setPwmFrequency: ISR fallback max %s Hz, requested %s", pwm_state::MAX_ISR_PWM_FREQUENCY, frequency_hz);
         return -1;
     }
 
     // Allocate channel
     ch = pwm_state::allocate();
     if (!ch) {
-        FL_WARN("setPwmFrequency: All " << static_cast<int>(pwm_state::MAX_PWM_CHANNELS) << " channels in use");
+        FL_WARN_F("setPwmFrequency: All %s channels in use", static_cast<int>(pwm_state::MAX_PWM_CHANNELS));
         return -2;
     }
 

--- a/src/fl/system/pins.cpp.hpp
+++ b/src/fl/system/pins.cpp.hpp
@@ -193,10 +193,7 @@ void DigitalMultiWrite8::init(const Pins8& pins) {
                 continue;
             }
             if (port_ids[i] != best_port) {
-                FL_WARN("digitalMultiWrite8: pin "
-                        << mPins[i] << " (port " << port_ids[i]
-                        << ") disabled — not on majority port "
-                        << best_port);
+                FL_WARN_F("digitalMultiWrite8: pin %s (port %s) disabled — not on majority port %s", mPins[i], port_ids[i], best_port);
                 mPins[i] = -1;
             }
         }
@@ -311,10 +308,7 @@ void DigitalMultiWrite16::init(const Pins16& pins) {
                 continue;
             }
             if (port_ids[i] != best_port) {
-                FL_WARN("digitalMultiWrite16: pin "
-                        << mPins[i] << " (port " << port_ids[i]
-                        << ") disabled — not on majority port "
-                        << best_port);
+                FL_WARN_F("digitalMultiWrite16: pin %s (port %s) disabled — not on majority port %s", mPins[i], port_ids[i], best_port);
                 mPins[i] = -1;
             }
         }

--- a/src/fl/task/executor.cpp.hpp
+++ b/src/fl/task/executor.cpp.hpp
@@ -76,7 +76,7 @@ void run(fl::u32 microseconds, ExecFlags flags) {
     // Re-entrancy guard: detect if run is called from within run
     bool& running = SingletonThreadLocal<bool>::instance();
     if (running) {
-        FL_WARN_ONCE("task::run re-entrancy detected, skipping nested call");
+        FL_WARN_F_ONCE("task::run re-entrancy detected, skipping nested call");
         return;
     }
     running = true;

--- a/src/fl/task/scheduler.cpp.hpp
+++ b/src/fl/task/scheduler.cpp.hpp
@@ -111,17 +111,17 @@ void Scheduler::update_tasks_of_type(TaskType task_type) {
 
 void Scheduler::warn_no_then(int task_id, const fl::string& trace_label) {
     if (!trace_label.empty()) {
-        FL_WARN(fl::string("[fl::task] Warning: no then() callback set for Task#") << task_id << " launched at " << trace_label);
+        FL_WARN_F("%s%s launched at %s", fl::string("[fl::task] Warning: no then() callback set for Task#"), task_id, trace_label);
     } else {
-        FL_WARN(fl::string("[fl::task] Warning: no then() callback set for Task#") << task_id);
+        FL_WARN_F("%s%s", fl::string("[fl::task] Warning: no then() callback set for Task#"), task_id);
     }
 }
 
 void Scheduler::warn_no_catch(int task_id, const fl::string& trace_label, const Error& error) {
         if (!trace_label.empty()) {
-        FL_WARN(fl::string("[fl::task] Warning: no catch_() callback set for Task#") << task_id << " launched at " << trace_label << ". Error: " << error.message);
+        FL_WARN_F("%s%s launched at %s. Error: %s", fl::string("[fl::task] Warning: no catch_() callback set for Task#"), task_id, trace_label, error.message);
     } else {
-        FL_WARN(fl::string("[fl/task] Warning: no catch_() callback set for Task#") << task_id << ". Error: " << error.message);
+        FL_WARN_F("%s%s. Error: %s", fl::string("[fl/task] Warning: no catch_() callback set for Task#"), task_id, error.message);
     }
 }
 

--- a/src/fl/task/task.h
+++ b/src/fl/task/task.h
@@ -85,7 +85,7 @@ auto t = fl::task::coroutine({
             // Process the data
             process_data(data);
         } else {
-            FL_WARN("Fetch failed: " << result.error().message);
+            FL_WARN_F("Fetch failed: %s", result.error().message);
         }
 
         // Task completes and automatically cleans up

--- a/src/fl/ui/audio.h
+++ b/src/fl/ui/audio.h
@@ -34,12 +34,12 @@ class UIAudioImpl {
     ~UIAudioImpl() FL_NOEXCEPT {}
 
     audio::Sample next() {
-        FL_WARN("Audio sample not implemented");
+        FL_WARN_F("Audio sample not implemented");
         return audio::Sample();
     }
 
     bool hasNext() {
-        FL_WARN("Audio sample not implemented");
+        FL_WARN_F("Audio sample not implemented");
         return false;
     }
 

--- a/src/fl/video/pixel_stream.cpp.hpp
+++ b/src/fl/video/pixel_stream.cpp.hpp
@@ -143,7 +143,7 @@ bool PixelStream::hasFrame(fl::u32 frameNumber) {
 bool PixelStream::readFrameAt(fl::u32 frameNumber, Frame *frame) {
     if (mType == kStreaming) {
         // Streaming handle doesn't support seeking
-        FL_DBG("Streaming handle doesn't support seeking");
+        FL_DBG_F("Streaming handle doesn't support seeking");
         return false;
     }
     fl::size_t frameBytes = static_cast<fl::size_t>(frameNumber)

--- a/src/fl/video/video_impl.cpp.hpp
+++ b/src/fl/video/video_impl.cpp.hpp
@@ -94,13 +94,13 @@ bool VideoImpl::draw(fl::u32 now, fl::span<CRGB> leds) {
     }
     now = mTime->update(now);
     if (!mStream) {
-        FL_WARN("no stream");
+        FL_WARN_F("no stream");
         return false;
     }
     bool ok = updateBufferIfNecessary(mPrevNow, now);
     mPrevNow = now;
     if (!ok) {
-        FL_WARN("updateBufferIfNecessary failed");
+        FL_WARN_F("updateBufferIfNecessary failed");
         return false;
     }
     mFrameInterpolator->draw(now, leds);
@@ -151,7 +151,7 @@ bool VideoImpl::draw(fl::u32 now, fl::span<CRGB> leds) {
 bool VideoImpl::updateBufferFromStream(fl::u32 now) {
     FASTLED_ASSERT(mTime, "mTime is null");
     if (!mStream) {
-        FL_WARN("no stream");
+        FL_WARN_F("no stream");
         return false;
     }
     if (mStream->atEnd()) {
@@ -167,7 +167,7 @@ bool VideoImpl::updateBufferFromStream(fl::u32 now) {
     }
 
     if (mFrameInterpolator->capacity() == 0) {
-        FL_WARN("capacity == 0");
+        FL_WARN_F("capacity == 0");
         return false;
     }
 
@@ -190,12 +190,12 @@ bool VideoImpl::updateBufferFromStream(fl::u32 now) {
             bool ok =
                 mFrameInterpolator->get_oldest_frame_number(&frame_to_erase);
             if (!ok) {
-                FL_WARN("get_oldest_frame_number failed");
+                FL_WARN_F("get_oldest_frame_number failed");
                 return false;
             }
             recycled_frame = mFrameInterpolator->erase(frame_to_erase);
             if (!recycled_frame) {
-                FL_WARN("erase failed for frame: " << frame_to_erase);
+                FL_WARN_F("erase failed for frame: %s", frame_to_erase);
                 return false;
             }
         }
@@ -208,14 +208,14 @@ bool VideoImpl::updateBufferFromStream(fl::u32 now) {
         if (!mStream->readFrame(recycled_frame.get())) {
             if (mStream->atEnd()) {
                 if (!mStream->rewind()) {
-                    FL_WARN("rewind failed");
+                    FL_WARN_F("rewind failed");
                     return false;
                 }
                 mTime->reset(now);
                 frame_to_fetch = 0;
                 if (!mStream->readFrameAt(frame_to_fetch,
                                           recycled_frame.get())) {
-                    FL_WARN("readFrameAt failed");
+                    FL_WARN_F("readFrameAt failed");
                     return false;
                 }
             } else {
@@ -225,13 +225,13 @@ bool VideoImpl::updateBufferFromStream(fl::u32 now) {
                 if (mStream->getType() == PixelStream::kStreaming) {
                     return true;  // Gracefully handle empty streaming buffer
                 }
-                FL_WARN("We failed for some other reason");
+                FL_WARN_F("We failed for some other reason");
                 return false;
             }
         }
         bool ok = mFrameInterpolator->insert(frame_to_fetch, recycled_frame);
         if (!ok) {
-            FL_WARN("insert failed");
+            FL_WARN_F("insert failed");
             return false;
         }
     }
@@ -252,7 +252,7 @@ bool VideoImpl::updateBufferFromFile(fl::u32 now, bool forward) {
         return true;
     }
     if (mFrameInterpolator->capacity() == 0) {
-        FL_WARN("capacity == 0");
+        FL_WARN_F("capacity == 0");
         return false;
     }
 
@@ -274,20 +274,20 @@ bool VideoImpl::updateBufferFromFile(fl::u32 now, bool forward) {
                 ok = mFrameInterpolator->get_oldest_frame_number(
                     &frame_to_erase);
                 if (!ok) {
-                    FL_WARN("get_oldest_frame_number failed");
+                    FL_WARN_F("get_oldest_frame_number failed");
                     return false;
                 }
             } else {
                 ok = mFrameInterpolator->get_newest_frame_number(
                     &frame_to_erase);
                 if (!ok) {
-                    FL_WARN("get_newest_frame_number failed");
+                    FL_WARN_F("get_newest_frame_number failed");
                     return false;
                 }
             }
             recycled_frame = mFrameInterpolator->erase(frame_to_erase);
             if (!recycled_frame) {
-                FL_WARN("erase failed for frame: " << frame_to_erase);
+                FL_WARN_F("erase failed for frame: %s", frame_to_erase);
                 return false;
             }
         }
@@ -305,19 +305,19 @@ bool VideoImpl::updateBufferFromFile(fl::u32 now, bool forward) {
                 }
                 if (mStream->atEnd()) {
                     if (!mStream->rewind()) { // Is this still
-                        FL_WARN("rewind failed");
+                        FL_WARN_F("rewind failed");
                         return false;
                     }
                     mTime->reset(now);
                     frame_to_fetch = 0;
                     if (!mStream->readFrameAt(frame_to_fetch,
                                               recycled_frame.get())) {
-                        FL_WARN("readFrameAt failed");
+                        FL_WARN_F("readFrameAt failed");
                         return false;
                     }
                     break; // we have the frame, so we can break out of the loop
                 }
-                FL_WARN("We failed for some other reason");
+                FL_WARN_F("We failed for some other reason");
                 return false;
             }
             break;
@@ -325,7 +325,7 @@ bool VideoImpl::updateBufferFromFile(fl::u32 now, bool forward) {
 
         bool ok = mFrameInterpolator->insert(frame_to_fetch, recycled_frame);
         if (!ok) {
-            FL_WARN("insert failed");
+            FL_WARN_F("insert failed");
             return false;
         }
     }
@@ -342,7 +342,7 @@ bool VideoImpl::updateBufferIfNecessary(fl::u32 prev, fl::u32 now) {
     case PixelStream::kStreaming:
         return updateBufferFromStream(now);
     default:
-        FL_WARN("Unknown type: " << fl::u32(type));
+        FL_WARN_F("Unknown type: %s", fl::u32(type));
         return false;
     }
 }

--- a/src/fl/wdt/_build.cpp.hpp
+++ b/src/fl/wdt/_build.cpp.hpp
@@ -17,7 +17,7 @@ namespace platforms {
 // here (in the unity TU) rather than in watchdog.cpp.hpp so that public
 // headers don't pull in fl/log/log.h.
 void scopedWatchdogPrintLine(fl::string_view sv) FL_NOEXCEPT {
-    FL_WARN(sv);
+    FL_WARN_F("%s", sv);
 }
 
 // Wraps fl::delay() — portable across stub/WASM/embedded.

--- a/src/pixel_controller.h
+++ b/src/pixel_controller.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 /// @file pixel_controller.h
 /// Low level pixel data writing class
@@ -232,18 +232,18 @@ struct PixelController {
 //
 // THE PROBLEM:
 //   Integer scaling causes color shifts at low brightness. For example:
-//     CRGB(100, 60, 20) at 20% brightness → RGB(19, 11, 3)
+//     CRGB(100, 60, 20) at 20% brightness â†’ RGB(19, 11, 3)
 //   Each channel loses different fractional precision, distorting the color.
 //
 // THE SOLUTION:
 //   Add frame-varying noise BEFORE scaling, causing different rounding outcomes:
 //     Frame 1: scale8(100+0, 51) = 19
-//     Frame 2: scale8(100+3, 51) = 20  ← noise pushed over threshold
+//     Frame 2: scale8(100+3, 51) = 20  â† noise pushed over threshold
 //   Your eye averages these to perceive the correct fractional brightness.
 //
 // THE ALGORITHM:
 //   1. Frame counter R cycles 0-7, creating an 8-frame pattern
-//   2. Bit-reverse R to Q (0→0, 1→128, 2→64...) to distribute pattern temporally
+//   2. Bit-reverse R to Q (0â†’0, 1â†’128, 2â†’64...) to distribute pattern temporally
 //   3. Center pattern: Q += 16
 //   4. Scale per channel: e[i] = 256/brightness, d[i] = scale8(Q, e[i])
 //      Lower brightness needs BIGGER dither to compensate for larger % error
@@ -251,7 +251,7 @@ struct PixelController {
 //   6. Apply: pixel = scale8(qadd8(pixel, d[i]), brightness)
 //
 // VIRTUAL BITS:
-//   8-frame cycle at 400Hz = 50Hz complete cycle → +3 "virtual" bits
+//   8-frame cycle at 400Hz = 50Hz complete cycle â†’ +3 "virtual" bits
 //   Result: 8-bit hardware provides 11-bit perceived precision (0-2047 levels)
 //
 // DISABLE FOR:
@@ -317,10 +317,10 @@ struct PixelController {
         R &= (0x01 << ditherBits) - 1;
 
         // STEP 3: Bit-reverse R to create maximally-spaced pattern Q
-        // Why? Prevents visible ramping patterns. Turns 0,1,2,3,4,5,6,7 → 0,128,64,192,32,160,96,224
+        // Why? Prevents visible ramping patterns. Turns 0,1,2,3,4,5,6,7 â†’ 0,128,64,192,32,160,96,224
         fl::u8 Q = 0;
 
-        // Bit reversal magic: mirrors bit positions (bit 0 ↔ bit 7, bit 1 ↔ bit 6, etc.)
+        // Bit reversal magic: mirrors bit positions (bit 0 â†” bit 7, bit 1 â†” bit 6, etc.)
         {
             if(R & 0x01) { Q |= 0x80; }
             if(R & 0x02) { Q |= 0x40; }
@@ -346,7 +346,7 @@ struct PixelController {
                 fl::u8 s = mColorAdjustment.premixed.raw[i];  // Brightness scale factor
 
                 // Calculate max dither range: e = 256/brightness
-                // At 100% (255): e≈1 (tiny range), At 20% (51): e≈5 (large range)
+                // At 100% (255): eâ‰ˆ1 (tiny range), At 20% (51): eâ‰ˆ5 (large range)
                 e[i] = s ? (256/s) + 1 : 0;
 
                 // Scale Q by the dither range to get current offset
@@ -457,18 +457,18 @@ struct PixelController {
     /// @{
 
 
-    /// Complete pipeline: load → dither → scale (THE MAGIC HAPPENS HERE!)
+    /// Complete pipeline: load â†’ dither â†’ scale (THE MAGIC HAPPENS HERE!)
     /// Order is critical: pixel + dither FIRST, then scale by brightness
     template<int SLOT>  FASTLED_FORCE_INLINE static fl::u8 loadAndScale(PixelController & pc) {
         return scale<SLOT>(pc, pc.dither<SLOT>(pc, pc.loadByte<SLOT>(pc)));
     }
 
-    /// Complete pipeline: load → dither → scale (parallel output version)
+    /// Complete pipeline: load â†’ dither â†’ scale (parallel output version)
     template<int SLOT>  FASTLED_FORCE_INLINE static fl::u8 loadAndScale(PixelController & pc, int lane) {
         return scale<SLOT>(pc, pc.dither<SLOT>(pc, pc.loadByte<SLOT>(pc, lane)));
     }
 
-    /// Complete pipeline: load → dither → scale (explicit dither/scale values)
+    /// Complete pipeline: load â†’ dither â†’ scale (explicit dither/scale values)
     template<int SLOT>  FASTLED_FORCE_INLINE static fl::u8 loadAndScale(PixelController & pc, int lane, fl::u8 d, fl::u8 scale) {
         return fl::scale8(pc.dither<SLOT>(pc, pc.loadByte<SLOT>(pc, lane), d), scale);
     }
@@ -640,9 +640,9 @@ struct PixelController {
         // AVR: float colorimetric math is too expensive on the 8-bit core;
         // the strip will get RGB-only output with both white channels black.
         // Surface this with a FL_WARN_ONCE so the silent dropout is visible
-        // when debugging — a user configuring RGBWW on an AVR target almost
+        // when debugging â€” a user configuring RGBWW on an AVR target almost
         // certainly didn't expect their warm/cool W channels to be inert.
-        FL_WARN_ONCE("RGBWW colorimetric is not supported on AVR — the warm "
+        FL_WARN_F_ONCE("RGBWW colorimetric is not supported on AVR â€” the warm "
                      "and cool white channels will be black. Use an ESP32 / "
                      "Teensy / RP2040 target for full RGBWW support.");
         fl::u8 r_pre = loadAndScale0();

--- a/src/platforms/adafruit/clockless_fake.hpp
+++ b/src/platforms/adafruit/clockless_fake.hpp
@@ -23,12 +23,12 @@ public:
     
     void init(int dataPin) FL_NOEXCEPT override {
         FL_UNUSED(dataPin);
-        FL_WARN("Please install adafruit neopixel package to use this api bridge.");
+        FL_WARN_F("Please install adafruit neopixel package to use this api bridge.");
     }
     
     void showPixels(PixelIterator& pixelIterator) FL_NOEXCEPT override {
         FL_UNUSED(pixelIterator);
-        FL_WARN("Please install adafruit neopixel package to use this api bridge.");
+        FL_WARN_F("Please install adafruit neopixel package to use this api bridge.");
     }
 };
 

--- a/src/platforms/apollo3/pin_apollo3_native.hpp
+++ b/src/platforms/apollo3/pin_apollo3_native.hpp
@@ -71,7 +71,7 @@ static PWMState g_pwm_state[AM_HAL_GPIO_MAX_PADS] = {};
 
 inline void pinMode(int pin, PinMode mode) FL_NOEXCEPT {
     if (pin < 0 || pin >= AM_HAL_GPIO_MAX_PADS) {
-        FL_WARN("Apollo3: Invalid pin " << pin);
+        FL_WARN_F("Apollo3: Invalid pin %s", pin);
         return;
     }
 
@@ -105,13 +105,13 @@ inline void pinMode(int pin, PinMode mode) FL_NOEXCEPT {
             pin_config.eGPInput = AM_HAL_GPIO_PIN_INPUT_ENABLE;
             pin_config.eGPOutcfg = AM_HAL_GPIO_PIN_OUTCFG_DISABLE;
             pin_config.ePullup = AM_HAL_GPIO_PIN_PULLUP_NONE;  // Apollo3 doesn't have internal pulldown
-            FL_WARN("Apollo3: InputPulldown mode not supported (no internal pulldown), using Input mode");
+            FL_WARN_F("Apollo3: InputPulldown mode not supported (no internal pulldown), using Input mode");
             break;
     }
 
     u32 result = am_hal_gpio_pinconfig(pin, pin_config);
     if (result != AM_HAL_STATUS_SUCCESS) {
-        FL_WARN("Apollo3: Failed to configure pin " << pin);
+        FL_WARN_F("Apollo3: Failed to configure pin %s", pin);
     }
 }
 
@@ -168,7 +168,7 @@ inline u16 analogRead(int pin) FL_NOEXCEPT {
         case 34: adc_channel = AM_HAL_ADC_SLOT_CHSEL_SE7; break;
         case 35: adc_channel = AM_HAL_ADC_SLOT_CHSEL_SE8; break;
         default:
-            FL_WARN("Apollo3: Pin " << pin << " does not support ADC");
+            FL_WARN_F("Apollo3: Pin %s does not support ADC", pin);
             return 0;
     }
 
@@ -176,14 +176,14 @@ inline u16 analogRead(int pin) FL_NOEXCEPT {
     if (!g_adc_state.initialized) {
         u32 status = am_hal_adc_initialize(0, &g_adc_state.handle);
         if (status != AM_HAL_STATUS_SUCCESS) {
-            FL_WARN("Apollo3: ADC initialization failed");
+            FL_WARN_F("Apollo3: ADC initialization failed");
             return 0;
         }
 
         // Power on ADC
         status = am_hal_adc_power_control(g_adc_state.handle, AM_HAL_SYSCTRL_WAKE, false);
         if (status != AM_HAL_STATUS_SUCCESS) {
-            FL_WARN("Apollo3: ADC power control failed");
+            FL_WARN_F("Apollo3: ADC power control failed");
             am_hal_adc_deinitialize(g_adc_state.handle);
             g_adc_state.handle = nullptr;
             return 0;
@@ -201,7 +201,7 @@ inline u16 analogRead(int pin) FL_NOEXCEPT {
 
         status = am_hal_adc_configure(g_adc_state.handle, &adc_config);
         if (status != AM_HAL_STATUS_SUCCESS) {
-            FL_WARN("Apollo3: ADC configuration failed");
+            FL_WARN_F("Apollo3: ADC configuration failed");
             am_hal_adc_power_control(g_adc_state.handle, AM_HAL_SYSCTRL_DEEPSLEEP, false);
             am_hal_adc_deinitialize(g_adc_state.handle);
             g_adc_state.handle = nullptr;
@@ -211,7 +211,7 @@ inline u16 analogRead(int pin) FL_NOEXCEPT {
         // Enable ADC
         status = am_hal_adc_enable(g_adc_state.handle);
         if (status != AM_HAL_STATUS_SUCCESS) {
-            FL_WARN("Apollo3: ADC enable failed");
+            FL_WARN_F("Apollo3: ADC enable failed");
             am_hal_adc_power_control(g_adc_state.handle, AM_HAL_SYSCTRL_DEEPSLEEP, false);
             am_hal_adc_deinitialize(g_adc_state.handle);
             g_adc_state.handle = nullptr;
@@ -231,14 +231,14 @@ inline u16 analogRead(int pin) FL_NOEXCEPT {
 
     u32 status = am_hal_adc_configure_slot(g_adc_state.handle, 0, &slot_config);
     if (status != AM_HAL_STATUS_SUCCESS) {
-        FL_WARN("Apollo3: ADC slot configuration failed");
+        FL_WARN_F("Apollo3: ADC slot configuration failed");
         return 0;
     }
 
     // Trigger ADC conversion
     status = am_hal_adc_sw_trigger(g_adc_state.handle);
     if (status != AM_HAL_STATUS_SUCCESS) {
-        FL_WARN("Apollo3: ADC trigger failed");
+        FL_WARN_F("Apollo3: ADC trigger failed");
         return 0;
     }
 
@@ -264,7 +264,7 @@ inline u16 analogRead(int pin) FL_NOEXCEPT {
         for (volatile int i = 0; i < 10; i++);
     }
 
-    FL_WARN("Apollo3: ADC conversion timeout");
+    FL_WARN_F("Apollo3: ADC conversion timeout");
     return 0;
 }
 
@@ -276,7 +276,7 @@ inline void analogWrite(int pin, u16 val) FL_NOEXCEPT {
 
     // Validate pin range
     if (pin < 0 || pin >= AM_HAL_GPIO_MAX_PADS) {
-        FL_WARN("Apollo3: Invalid pin " << pin);
+        FL_WARN_F("Apollo3: Invalid pin %s", pin);
         return;
     }
 
@@ -327,7 +327,7 @@ inline void analogWrite(int pin, u16 val) FL_NOEXCEPT {
 
         u32 status = am_hal_gpio_pinconfig(pin, pin_config);
         if (status != AM_HAL_STATUS_SUCCESS) {
-            FL_WARN("Apollo3: Failed to configure pin " << pin << " for PWM");
+            FL_WARN_F("Apollo3: Failed to configure pin %s for PWM", pin);
             return;
         }
 
@@ -417,18 +417,18 @@ inline void setAdcRange(AdcRange range) FL_NOEXCEPT {
 
         u32 status = am_hal_adc_configure(g_adc_state.handle, &adc_config);
         if (status != AM_HAL_STATUS_SUCCESS) {
-            FL_WARN("Apollo3: ADC reconfiguration failed");
+            FL_WARN_F("Apollo3: ADC reconfiguration failed");
             return;
         }
 
         // Re-enable ADC
         status = am_hal_adc_enable(g_adc_state.handle);
         if (status != AM_HAL_STATUS_SUCCESS) {
-            FL_WARN("Apollo3: ADC re-enable failed");
+            FL_WARN_F("Apollo3: ADC re-enable failed");
             return;
         }
 
-        FL_DBG("Apollo3: ADC reference changed");
+        FL_DBG_F("Apollo3: ADC reference changed");
     }
 
     // Store reference for future use (will be applied on next ADC init if not yet initialized)

--- a/src/platforms/arduino/audio_input.hpp
+++ b/src/platforms/arduino/audio_input.hpp
@@ -70,7 +70,7 @@ public:
 
     void start() FL_NOEXCEPT override {
         if (mInitialized) {
-            FL_WARN("Arduino I2S is already initialized");
+            FL_WARN_F("Arduino I2S is already initialized");
             return;
         }
 
@@ -89,13 +89,13 @@ public:
         if (!success) {
             mHasError = true;
             mErrorMessage = "Failed to initialize Arduino I2S";
-            FL_WARN(mErrorMessage.c_str());
+            FL_WARN_F("%s", mErrorMessage.c_str());
             return;
         }
 
         mInitialized = true;
         mTotalSamplesRead = 0;
-        FL_WARN("Arduino I2S audio input started successfully");
+        FL_WARN_F("Arduino I2S audio input started successfully");
     }
 
     void stop() FL_NOEXCEPT override {
@@ -106,7 +106,7 @@ public:
         I2S.end();
         mInitialized = false;
         mTotalSamplesRead = 0;
-        FL_WARN("Arduino I2S audio input stopped");
+        FL_WARN_F("Arduino I2S audio input stopped");
     }
 
     bool error(fl::string *msg = nullptr) FL_NOEXCEPT override {
@@ -118,7 +118,7 @@ public:
 
     audio::Sample read() FL_NOEXCEPT override {
         if (!mInitialized) {
-            FL_WARN("Arduino I2S is not initialized");
+            FL_WARN_F("Arduino I2S is not initialized");
             return audio::Sample();  // Invalid sample
         }
 
@@ -200,12 +200,12 @@ private:
 // Platform-specific audio input creation function for Arduino
 fl::shared_ptr<audio::IInput> arduino_create_audio_input(const audio::Config& config, fl::string* error_message = nullptr) FL_NOEXCEPT {
     if (config.is<audio::ConfigI2S>()) {
-        FL_WARN("Creating Arduino I2S audio source");
+        FL_WARN_F("Creating Arduino I2S audio source");
         audio::ConfigI2S i2s_config = config.get<audio::ConfigI2S>();
         return fl::make_shared<Arduino_I2S_Audio>(i2s_config);
     } else if (config.is<audio::ConfigPdm>()) {
         const char* ERROR_MESSAGE = "PDM audio not supported in Arduino I2S implementation";
-        FL_WARN(ERROR_MESSAGE);
+        FL_WARN_F("%s", ERROR_MESSAGE);
         if (error_message) {
             *error_message = ERROR_MESSAGE;
         }
@@ -213,7 +213,7 @@ fl::shared_ptr<audio::IInput> arduino_create_audio_input(const audio::Config& co
     }
 
     const char* ERROR_MESSAGE = "Unsupported audio configuration for Arduino";
-    FL_WARN(ERROR_MESSAGE);
+    FL_WARN_F("%s", ERROR_MESSAGE);
     if (error_message) {
         *error_message = ERROR_MESSAGE;
     }
@@ -230,7 +230,7 @@ fl::shared_ptr<audio::IInput> arduino_create_audio_input(const audio::Config& co
 #else
     const char* ERROR_MESSAGE = "Arduino I2S library not available - please install I2S library";
 #endif
-    FL_WARN(ERROR_MESSAGE);
+    FL_WARN_F("%s", ERROR_MESSAGE);
     if (error_message) {
         *error_message = ERROR_MESSAGE;
     }

--- a/src/platforms/arm/d21/init_channel_driver_samd21.cpp.hpp
+++ b/src/platforms/arm/d21/init_channel_driver_samd21.cpp.hpp
@@ -30,7 +30,7 @@ namespace detail {
 
 /// @brief Add HW SPI drivers if supported by platform (UNIFIED VERSION)
 static void addSpiHardwareIfPossible(ChannelManager& manager) {
-    FL_DBG("SAMD21: Registering unified HW SPI channel driver");
+    FL_DBG_F("SAMD21: Registering unified HW SPI channel driver");
 
     fl::vector<fl::shared_ptr<SpiHwBase>> controllers;
     fl::vector<int> priorities;
@@ -40,7 +40,7 @@ static void addSpiHardwareIfPossible(ChannelManager& manager) {
     // Collect SpiHw2 controllers (priority: 6)
     // ========================================================================
     const auto& hw2Controllers = SpiHw2::getAll();
-    FL_DBG("SAMD21: Found " << hw2Controllers.size() << " SpiHw2 controllers");
+    FL_DBG_F("SAMD21: Found %s SpiHw2 controllers", hw2Controllers.size());
 
     for (const auto& ctrl : hw2Controllers) {
         if (ctrl) {
@@ -72,14 +72,12 @@ static void addSpiHardwareIfPossible(ChannelManager& manager) {
 
             manager.addDriver(maxPriority, adapter);
 
-            FL_DBG("SAMD21: Registered unified SPI driver with "
-                   << controllers.size() << " controllers (priority "
-                   << maxPriority << ")");
+            FL_DBG_F("SAMD21: Registered unified SPI driver with %s controllers (priority %s)", controllers.size(), maxPriority);
         } else {
-            FL_WARN("SAMD21: Failed to create unified SPI adapter");
+            FL_WARN_F("SAMD21: Failed to create unified SPI adapter");
         }
     } else {
-        FL_DBG("SAMD21: No SPI hardware controllers available");
+        FL_DBG_F("SAMD21: No SPI hardware controllers available");
     }
 }
 
@@ -92,14 +90,14 @@ namespace platforms {
 /// Called lazily on first access to ChannelManager::instance().
 /// Registers platform-specific drivers (SPI hardware) with the bus manager.
 void initChannelDrivers() {
-    FL_DBG("SAMD21: Lazy initialization of channel drivers");
+    FL_DBG_F("SAMD21: Lazy initialization of channel drivers");
 
     auto& manager = channelManager();
 
     // Register true SPI hardware (priority 6)
     detail::addSpiHardwareIfPossible(manager);
 
-    FL_DBG("SAMD21: Channel drivers initialized");
+    FL_DBG_F("SAMD21: Channel drivers initialized");
 }
 
 } // namespace platforms

--- a/src/platforms/arm/d21/init_samd21.cpp.hpp
+++ b/src/platforms/arm/d21/init_samd21.cpp.hpp
@@ -30,13 +30,13 @@ void init() {
         return;  // Already initialized
     }
 
-    FL_DBG("SAMD21: Platform initialization starting");
+    FL_DBG_F("SAMD21: Platform initialization starting");
 
     // Trigger weak linkage initialization for dual-lane SPI controller
     (void)fl::SpiHw2::getAll();
 
     initialized = true;
-    FL_DBG("SAMD21: Platform initialization complete");
+    FL_DBG_F("SAMD21: Platform initialization complete");
 }
 
 } // namespace platforms

--- a/src/platforms/arm/d21/mutex_samd.cpp.hpp
+++ b/src/platforms/arm/d21/mutex_samd.cpp.hpp
@@ -36,7 +36,7 @@ void MutexSAMD::lock() {
     // Check if already locked
     if (mLocked) {
         __enable_irq();
-        FL_WARN("MutexSAMD::lock() called when already locked (would deadlock on threaded system)");
+        FL_WARN_F("MutexSAMD::lock() called when already locked (would deadlock on threaded system)");
         return;
     }
 
@@ -53,7 +53,7 @@ void MutexSAMD::unlock() {
     // Check if already unlocked
     if (!mLocked) {
         __enable_irq();
-        FL_WARN("MutexSAMD::unlock() called when not locked");
+        FL_WARN_F("MutexSAMD::unlock() called when not locked");
         return;
     }
 
@@ -105,7 +105,7 @@ void RecursiveMutexSAMD::unlock() {
     // Check if already unlocked
     if (mLockCount == 0) {
         __enable_irq();
-        FL_WARN("RecursiveMutexSAMD::unlock() called when not locked");
+        FL_WARN_F("RecursiveMutexSAMD::unlock() called when not locked");
         return;
     }
 

--- a/src/platforms/arm/d21/semaphore_samd.cpp.hpp
+++ b/src/platforms/arm/d21/semaphore_samd.cpp.hpp
@@ -64,7 +64,7 @@ void CountingSemaphoreSAMD<LeastMaxValue>::acquire() {
     // Check if counter is zero
     if (mCounter == 0) {
         __enable_irq();
-        FL_WARN("CountingSemaphoreSAMD::acquire() called when counter is 0 (would deadlock on threaded system)");
+        FL_WARN_F("CountingSemaphoreSAMD::acquire() called when counter is 0 (would deadlock on threaded system)");
         return;
     }
 

--- a/src/platforms/arm/d21/spi_hw_2_samd21.cpp.hpp
+++ b/src/platforms/arm/d21/spi_hw_2_samd21.cpp.hpp
@@ -158,13 +158,13 @@ bool SPIDualSAMD21::begin(const SpiHw2::Config& config) {
 
     // Validate bus_num against mBusId if driver has pre-assigned ID
     if (mBusId != -1 && config.bus_num != static_cast<u8>(mBusId)) {
-        FL_WARN("SPIDualSAMD21: Bus ID mismatch");
+        FL_WARN_F("SPIDualSAMD21: Bus ID mismatch");
         return false;
     }
 
     // Validate pin assignments
     if (config.clock_pin < 0 || config.data0_pin < 0 || config.data1_pin < 0) {
-        FL_WARN("SPIDualSAMD21: Invalid pin configuration");
+        FL_WARN_F("SPIDualSAMD21: Invalid pin configuration");
         return false;
     }
 
@@ -177,7 +177,7 @@ bool SPIDualSAMD21::begin(const SpiHw2::Config& config) {
     // Map bus_num to SERCOM instance
     int sercom_num = (mBusId != -1) ? mBusId : config.bus_num;
     if (sercom_num < 0 || sercom_num > 5) {
-        FL_WARN("SPIDualSAMD21: Invalid SERCOM number");
+        FL_WARN_F("SPIDualSAMD21: Invalid SERCOM number");
         return false;
     }
 
@@ -191,12 +191,12 @@ bool SPIDualSAMD21::begin(const SpiHw2::Config& config) {
         case 4: mSercom = SERCOM4; break;
         case 5: mSercom = SERCOM5; break;
         default:
-            FL_WARN("SPIDualSAMD21: Invalid SERCOM");
+            FL_WARN_F("SPIDualSAMD21: Invalid SERCOM");
             return false;
     }
 
     if (mSercom == nullptr) {
-        FL_WARN("SPIDualSAMD21: SERCOM not available");
+        FL_WARN_F("SPIDualSAMD21: SERCOM not available");
         return false;
     }
 
@@ -308,9 +308,7 @@ bool SPIDualSAMD21::begin(const SpiHw2::Config& config) {
     mSercom->SPI.CTRLA.bit.ENABLE = 1;
     while (mSercom->SPI.SYNCBUSY.bit.ENABLE);
 
-    FL_WARN("SPIDualSAMD21: Initialized on SERCOM" << sercom_num
-            << " at " << (f_cpu / (2 * (baud_div + 1)) / 1000000.0) << " MHz"
-            << " (polling mode, single-lane - true dual-lane TBD)");
+    FL_WARN_F("SPIDualSAMD21: Initialized on SERCOM%s at %s MHz (polling mode, single-lane - true dual-lane TBD)", sercom_num, (f_cpu / (2 * (baud_div + 1)) / 1000000.0));
 
     // Note: This is a single-lane implementation like SAMD51
     // True dual-lane requires:
@@ -419,7 +417,7 @@ bool SPIDualSAMD21::waitComplete(u32 timeout_ms) {
     // Check TXC (Transmit Complete) flag in INTFLAG register
     while (mSercom && !mSercom->SPI.INTFLAG.bit.TXC) {
         if ((fl::millis() - start_time) >= timeout_ms) {
-            FL_WARN("SPIDualSAMD21: waitComplete timeout");
+            FL_WARN_F("SPIDualSAMD21: waitComplete timeout");
             return false;  // Timeout
         }
     }

--- a/src/platforms/arm/d21/spi_hw_manager_samd21.cpp.hpp
+++ b/src/platforms/arm/d21/spi_hw_manager_samd21.cpp.hpp
@@ -32,7 +32,7 @@ constexpr int PRIORITY_SPI_HW_2 = 6;   // Dual-SPI (only mode available on SAMD2
 static void addSpiHw2IfPossible() {
     // Note: SPIDualSAMD21 class is defined in spi_hw_2_samd21.cpp.hpp
     // which is included by _build.hpp before this file
-    FL_DBG("SAMD21: Registering SpiHw2 instances");
+    FL_DBG_F("SAMD21: Registering SpiHw2 instances");
 
     // SAMD21 typically has 2-3 SERCOM peripherals available for SPI
     static auto controller0 = fl::make_shared<SPIDualSAMD21>(0, "SPI0");
@@ -41,7 +41,7 @@ static void addSpiHw2IfPossible() {
     SpiHw2::registerInstance(controller0);
     SpiHw2::registerInstance(controller1);
 
-    FL_DBG("SAMD21: SpiHw2 instances registered");
+    FL_DBG_F("SAMD21: SpiHw2 instances registered");
 }
 
 }  // namespace detail
@@ -56,11 +56,11 @@ namespace platforms {
 /// Platform availability:
 /// - SAMD21: SpiHw2 only (dual-lane via SERCOM)
 void initSpiHardware() {
-    FL_DBG("SAMD21: Initializing SPI hardware");
+    FL_DBG_F("SAMD21: Initializing SPI hardware");
 
     detail::addSpiHw2IfPossible();  // Priority 6
 
-    FL_DBG("SAMD21: SPI hardware initialized");
+    FL_DBG_F("SAMD21: SPI hardware initialized");
 }
 
 }  // namespace platforms

--- a/src/platforms/arm/d51/init_channel_driver_samd51.cpp.hpp
+++ b/src/platforms/arm/d51/init_channel_driver_samd51.cpp.hpp
@@ -30,7 +30,7 @@ namespace detail {
 
 /// @brief Add HW SPI drivers if supported by platform (UNIFIED VERSION)
 static void addSpiHardwareIfPossible(ChannelManager& manager) {
-    FL_DBG("SAMD51: Registering unified HW SPI channel driver");
+    FL_DBG_F("SAMD51: Registering unified HW SPI channel driver");
 
     fl::vector<fl::shared_ptr<SpiHwBase>> controllers;
     fl::vector<int> priorities;
@@ -40,7 +40,7 @@ static void addSpiHardwareIfPossible(ChannelManager& manager) {
     // Collect SpiHw4 controllers (higher priority: 7)
     // ========================================================================
     const auto& hw4Controllers = SpiHw4::getAll();
-    FL_DBG("SAMD51: Found " << hw4Controllers.size() << " SpiHw4 controllers");
+    FL_DBG_F("SAMD51: Found %s SpiHw4 controllers", hw4Controllers.size());
 
     for (const auto& ctrl : hw4Controllers) {
         if (ctrl) {
@@ -54,7 +54,7 @@ static void addSpiHardwareIfPossible(ChannelManager& manager) {
     // Collect SpiHw2 controllers (lower priority: 6)
     // ========================================================================
     const auto& hw2Controllers = SpiHw2::getAll();
-    FL_DBG("SAMD51: Found " << hw2Controllers.size() << " SpiHw2 controllers");
+    FL_DBG_F("SAMD51: Found %s SpiHw2 controllers", hw2Controllers.size());
 
     for (const auto& ctrl : hw2Controllers) {
         if (ctrl) {
@@ -86,14 +86,12 @@ static void addSpiHardwareIfPossible(ChannelManager& manager) {
 
             manager.addDriver(maxPriority, adapter);
 
-            FL_DBG("SAMD51: Registered unified SPI driver with "
-                   << controllers.size() << " controllers (priority "
-                   << maxPriority << ")");
+            FL_DBG_F("SAMD51: Registered unified SPI driver with %s controllers (priority %s)", controllers.size(), maxPriority);
         } else {
-            FL_WARN("SAMD51: Failed to create unified SPI adapter");
+            FL_WARN_F("SAMD51: Failed to create unified SPI adapter");
         }
     } else {
-        FL_DBG("SAMD51: No SPI hardware controllers available");
+        FL_DBG_F("SAMD51: No SPI hardware controllers available");
     }
 }
 
@@ -106,14 +104,14 @@ namespace platforms {
 /// Called lazily on first access to ChannelManager::instance().
 /// Registers platform-specific drivers (SPI hardware) with the bus manager.
 void initChannelDrivers() {
-    FL_DBG("SAMD51: Lazy initialization of channel drivers");
+    FL_DBG_F("SAMD51: Lazy initialization of channel drivers");
 
     auto& manager = channelManager();
 
     // Register true SPI hardware (priority 6-7)
     detail::addSpiHardwareIfPossible(manager);
 
-    FL_DBG("SAMD51: Channel drivers initialized");
+    FL_DBG_F("SAMD51: Channel drivers initialized");
 }
 
 } // namespace platforms

--- a/src/platforms/arm/d51/init_samd51.cpp.hpp
+++ b/src/platforms/arm/d51/init_samd51.cpp.hpp
@@ -31,14 +31,14 @@ void init() {
         return;  // Already initialized
     }
 
-    FL_DBG("SAMD51: Platform initialization starting");
+    FL_DBG_F("SAMD51: Platform initialization starting");
 
     // Trigger weak linkage initialization for dual-lane and quad-lane SPI controllers
     (void)fl::SpiHw2::getAll();
     (void)fl::SpiHw4::getAll();
 
     initialized = true;
-    FL_DBG("SAMD51: Platform initialization complete");
+    FL_DBG_F("SAMD51: Platform initialization complete");
 }
 
 } // namespace platforms

--- a/src/platforms/arm/d51/spi_hw_2_samd51.cpp.hpp
+++ b/src/platforms/arm/d51/spi_hw_2_samd51.cpp.hpp
@@ -185,13 +185,13 @@ bool SPIDualSAMD51::begin(const SpiHw2::Config& config) {
 
     // Validate bus_num against mBusId if driver has pre-assigned ID
     if (mBusId != -1 && config.bus_num != static_cast<u8>(mBusId)) {
-        FL_WARN("SPIDualSAMD51: Bus ID mismatch");
+        FL_WARN_F("SPIDualSAMD51: Bus ID mismatch");
         return false;
     }
 
     // Validate pin assignments
     if (config.clock_pin < 0 || config.data0_pin < 0 || config.data1_pin < 0) {
-        FL_WARN("SPIDualSAMD51: Invalid pin configuration");
+        FL_WARN_F("SPIDualSAMD51: Invalid pin configuration");
         return false;
     }
 
@@ -204,7 +204,7 @@ bool SPIDualSAMD51::begin(const SpiHw2::Config& config) {
     // Map bus_num to SERCOM instance
     int sercom_num = (mBusId != -1) ? mBusId : config.bus_num;
     if (sercom_num < 0 || sercom_num > 7) {
-        FL_WARN("SPIDualSAMD51: Invalid SERCOM number");
+        FL_WARN_F("SPIDualSAMD51: Invalid SERCOM number");
         return false;
     }
 
@@ -228,12 +228,12 @@ bool SPIDualSAMD51::begin(const SpiHw2::Config& config) {
         case 7: mSercom = SERCOM7; break;
 #endif
         default:
-            FL_WARN("SPIDualSAMD51: Invalid SERCOM");
+            FL_WARN_F("SPIDualSAMD51: Invalid SERCOM");
             return false;
     }
 
     if (mSercom == nullptr) {
-        FL_WARN("SPIDualSAMD51: SERCOM not available");
+        FL_WARN_F("SPIDualSAMD51: SERCOM not available");
         return false;
     }
 
@@ -359,9 +359,7 @@ bool SPIDualSAMD51::begin(const SpiHw2::Config& config) {
     // For now, we'll use polling mode and document the DMA requirements
     mDmaChannel = -1;  // Mark as not using DMA
 
-    FL_WARN("SPIDualSAMD51: Initialized on SERCOM" << sercom_num
-            << " at " << (f_cpu / (2 * (baud_div + 1)) / 1000000.0) << " MHz"
-            << " (polling mode - DMA can be added later)");
+    FL_WARN_F("SPIDualSAMD51: Initialized on SERCOM%s at %s MHz (polling mode - DMA can be added later)", sercom_num, (f_cpu / (2 * (baud_div + 1)) / 1000000.0));
 
     mInitialized = true;
     return true;
@@ -469,7 +467,7 @@ bool SPIDualSAMD51::waitComplete(u32 timeout_ms) {
     // Check TXC (Transmit Complete) flag in INTFLAG register
     while (mSercom && !mSercom->SPI.INTFLAG.bit.TXC) {
         if ((fl::millis() - start_time) >= timeout_ms) {
-            FL_WARN("SPIDualSAMD51: waitComplete timeout");
+            FL_WARN_F("SPIDualSAMD51: waitComplete timeout");
             return false;  // Timeout
         }
     }

--- a/src/platforms/arm/d51/spi_hw_4_samd51.cpp.hpp
+++ b/src/platforms/arm/d51/spi_hw_4_samd51.cpp.hpp
@@ -207,13 +207,13 @@ bool SPIQuadSAMD51::begin(const SpiHw4::Config& config) {
     // Validate bus_num against mBusId if driver has pre-assigned ID
     // SAMD51 only has one QSPI peripheral (bus 0)
     if (mBusId != -1 && config.bus_num != static_cast<u8>(mBusId)) {
-        FL_WARN("SPIQuadSAMD51: Bus ID mismatch");
+        FL_WARN_F("SPIQuadSAMD51: Bus ID mismatch");
         return false;
     }
 
     // Validate pin assignments - at least clock and D0 must be set
     if (config.clock_pin < 0 || config.data0_pin < 0) {
-        FL_WARN("SPIQuadSAMD51: Invalid pin configuration (clock and D0 required)");
+        FL_WARN_F("SPIQuadSAMD51: Invalid pin configuration (clock and D0 required)");
         return false;
     }
 
@@ -446,7 +446,7 @@ bool SPIQuadSAMD51::transmit(TransmitMode mode) {
         while (!QSPI->INTFLAG.bit.DRE) {
             // Check for error condition
             if (QSPI->INTFLAG.bit.ERROR) {
-                FL_WARN("QSPI ERROR flag set during transmission");
+                FL_WARN_F("QSPI ERROR flag set during transmission");
                 // Clear ERROR flag
                 QSPI->INTFLAG.reg = QSPI_INTFLAG_ERROR;
                 mTransactionActive = false;
@@ -492,12 +492,12 @@ bool SPIQuadSAMD51::waitComplete(u32 timeout_ms) {
     // Check INSTREND (Instruction End) flag in INTFLAG register
     while (!QSPI->INTFLAG.bit.INSTREND) {
         if ((fl::millis() - start_time) >= timeout_ms) {
-            FL_WARN("SPIQuadSAMD51: waitComplete timeout");
+            FL_WARN_F("SPIQuadSAMD51: waitComplete timeout");
             return false;  // Timeout
         }
         // Check for error condition
         if (QSPI->INTFLAG.bit.ERROR) {
-            FL_WARN("SPIQuadSAMD51: QSPI error during waitComplete");
+            FL_WARN_F("SPIQuadSAMD51: QSPI error during waitComplete");
             QSPI->INTFLAG.reg = QSPI_INTFLAG_ERROR;  // Clear error
             return false;
         }

--- a/src/platforms/arm/d51/spi_hw_manager_samd51.cpp.hpp
+++ b/src/platforms/arm/d51/spi_hw_manager_samd51.cpp.hpp
@@ -35,7 +35,7 @@ constexpr int PRIORITY_SPI_HW_2 = 6;   // Lower (2-lane dual-SPI)
 static void addSpiHw2IfPossible() {
     // Note: SPIDualSAMD51 class is defined in spi_hw_2_samd51.cpp.hpp
     // which is included by _build.hpp before this file
-    FL_DBG("SAMD51: Registering SpiHw2 instances");
+    FL_DBG_F("SAMD51: Registering SpiHw2 instances");
 
     // SAMD51 has multiple SERCOM peripherals available for SPI
     static auto controller0 = fl::make_shared<SPIDualSAMD51>(0, "SPI0");
@@ -44,14 +44,14 @@ static void addSpiHw2IfPossible() {
     SpiHw2::registerInstance(controller0);
     SpiHw2::registerInstance(controller1);
 
-    FL_DBG("SAMD51: SpiHw2 instances registered");
+    FL_DBG_F("SAMD51: SpiHw2 instances registered");
 }
 
 /// @brief Register SAMD51 SpiHw4 instances
 static void addSpiHw4IfPossible() {
     // Note: SPIQuadSAMD51 class is defined in spi_hw_4_samd51.cpp.hpp
     // which is included by _build.hpp before this file
-    FL_DBG("SAMD51: Registering SpiHw4 instances");
+    FL_DBG_F("SAMD51: Registering SpiHw4 instances");
 
     // SAMD51 has multiple SERCOM peripherals available for SPI
     static auto controller0 = fl::make_shared<SPIQuadSAMD51>(0, "SPI0");
@@ -60,7 +60,7 @@ static void addSpiHw4IfPossible() {
     SpiHw4::registerInstance(controller0);
     SpiHw4::registerInstance(controller1);
 
-    FL_DBG("SAMD51: SpiHw4 instances registered");
+    FL_DBG_F("SAMD51: SpiHw4 instances registered");
 }
 
 }  // namespace detail
@@ -79,13 +79,13 @@ namespace platforms {
 /// Platform availability:
 /// - SAMD51: Both SpiHw2 and SpiHw4 (via SERCOM)
 void initSpiHardware() {
-    FL_DBG("SAMD51: Initializing SPI hardware");
+    FL_DBG_F("SAMD51: Initializing SPI hardware");
 
     // Register in priority order (highest to lowest)
     detail::addSpiHw4IfPossible();  // Priority 7
     detail::addSpiHw2IfPossible();  // Priority 6
 
-    FL_DBG("SAMD51: SPI hardware initialized");
+    FL_DBG_F("SAMD51: SPI hardware initialized");
 }
 
 }  // namespace platforms

--- a/src/platforms/arm/lpc/rx_sct_capture.cpp.hpp
+++ b/src/platforms/arm/lpc/rx_sct_capture.cpp.hpp
@@ -636,7 +636,7 @@ RxWaitResult LpcSctRxChannel::wait(u32 timeout_ms) FL_NOEXCEPT {
 fl::result<u32, DecodeError> LpcSctRxChannel::decode(const ChipsetTiming4Phase& timing,
                                                      fl::span<u8> out) FL_NOEXCEPT {
     if (mEdges.empty()) {
-        FL_WARN("LpcSctRxChannel::decode: No edges recorded for pin " << mPin);
+        FL_WARN_F("LpcSctRxChannel::decode: No edges recorded for pin %s", mPin);
         return fl::result<u32, DecodeError>::failure(DecodeError::INVALID_ARGUMENT);
     }
     return fl::channels::rx::decodeWs2812Edges(

--- a/src/platforms/arm/mxrt1062/spi_device_proxy.h
+++ b/src/platforms/arm/mxrt1062/spi_device_proxy.h
@@ -98,8 +98,7 @@ public:
         mHandle = mBusManager->registerDevice(CLOCK_PIN, DATA_PIN, SPI_CLOCK_RATE, this);
 
         if (!mHandle.is_valid) {
-            FL_LOG_SPI("SPIDeviceProxy: Failed to register with bus manager (pin "
-                    << static_cast<int>(CLOCK_PIN) << ":" << static_cast<int>(DATA_PIN) << ")");
+            FL_LOG_SPI_F("SPIDeviceProxy: Failed to register with bus manager (pin %s:%s)", static_cast<int>(CLOCK_PIN), static_cast<int>(DATA_PIN));
             return;
         }
 

--- a/src/platforms/arm/nrf52/init_channel_driver_nrf52.cpp.hpp
+++ b/src/platforms/arm/nrf52/init_channel_driver_nrf52.cpp.hpp
@@ -30,7 +30,7 @@ namespace detail {
 
 /// @brief Add HW SPI drivers if supported by platform (UNIFIED VERSION)
 static void addSpiHardwareIfPossible(ChannelManager& manager) {
-    FL_DBG("NRF52: Registering unified HW SPI channel driver");
+    FL_DBG_F("NRF52: Registering unified HW SPI channel driver");
 
     fl::vector<fl::shared_ptr<SpiHwBase>> controllers;
     fl::vector<int> priorities;
@@ -40,7 +40,7 @@ static void addSpiHardwareIfPossible(ChannelManager& manager) {
     // Collect SpiHw4 controllers (higher priority: 7)
     // ========================================================================
     const auto& hw4Controllers = SpiHw4::getAll();
-    FL_DBG("NRF52: Found " << hw4Controllers.size() << " SpiHw4 controllers");
+    FL_DBG_F("NRF52: Found %s SpiHw4 controllers", hw4Controllers.size());
 
     for (const auto& ctrl : hw4Controllers) {
         if (ctrl) {
@@ -54,7 +54,7 @@ static void addSpiHardwareIfPossible(ChannelManager& manager) {
     // Collect SpiHw2 controllers (lower priority: 6)
     // ========================================================================
     const auto& hw2Controllers = SpiHw2::getAll();
-    FL_DBG("NRF52: Found " << hw2Controllers.size() << " SpiHw2 controllers");
+    FL_DBG_F("NRF52: Found %s SpiHw2 controllers", hw2Controllers.size());
 
     for (const auto& ctrl : hw2Controllers) {
         if (ctrl) {
@@ -86,14 +86,12 @@ static void addSpiHardwareIfPossible(ChannelManager& manager) {
 
             manager.addDriver(maxPriority, adapter);
 
-            FL_DBG("NRF52: Registered unified SPI driver with "
-                   << controllers.size() << " controllers (priority "
-                   << maxPriority << ")");
+            FL_DBG_F("NRF52: Registered unified SPI driver with %s controllers (priority %s)", controllers.size(), maxPriority);
         } else {
-            FL_WARN("NRF52: Failed to create unified SPI adapter");
+            FL_WARN_F("NRF52: Failed to create unified SPI adapter");
         }
     } else {
-        FL_DBG("NRF52: No SPI hardware controllers available");
+        FL_DBG_F("NRF52: No SPI hardware controllers available");
     }
 }
 
@@ -106,14 +104,14 @@ namespace platforms {
 /// Called lazily on first access to ChannelManager::instance().
 /// Registers platform-specific drivers (SPI hardware) with the bus manager.
 void initChannelDrivers() {
-    FL_DBG("NRF52: Lazy initialization of channel drivers");
+    FL_DBG_F("NRF52: Lazy initialization of channel drivers");
 
     auto& manager = channelManager();
 
     // Register true SPI hardware (priority 6-7)
     detail::addSpiHardwareIfPossible(manager);
 
-    FL_DBG("NRF52: Channel drivers initialized");
+    FL_DBG_F("NRF52: Channel drivers initialized");
 }
 
 } // namespace platforms

--- a/src/platforms/arm/nrf52/init_nrf52.cpp.hpp
+++ b/src/platforms/arm/nrf52/init_nrf52.cpp.hpp
@@ -31,14 +31,14 @@ void init() {
         return;  // Already initialized
     }
 
-    FL_DBG("nRF52: Platform initialization starting");
+    FL_DBG_F("nRF52: Platform initialization starting");
 
     // Trigger weak linkage initialization for dual-lane and quad-lane SPI controllers
     (void)fl::SpiHw2::getAll();
     (void)fl::SpiHw4::getAll();
 
     initialized = true;
-    FL_DBG("nRF52: Platform initialization complete");
+    FL_DBG_F("nRF52: Platform initialization complete");
 }
 
 } // namespace platforms

--- a/src/platforms/arm/nrf52/isr_nrf52.hpp
+++ b/src/platforms/arm/nrf52/isr_nrf52.hpp
@@ -343,12 +343,12 @@ extern "C" {
 
 int attach_timer_handler(const isr_config_t& config, isr_handle_t* out_handle) FL_NOEXCEPT {
     if (!config.handler) {
-        FL_WARN("attachTimerHandler: handler is null");
+        FL_WARN_F("attachTimerHandler: handler is null");
         return -1;  // Invalid parameter
     }
 
     if (config.frequency_hz == 0) {
-        FL_WARN("attachTimerHandler: frequency_hz is 0");
+        FL_WARN_F("attachTimerHandler: frequency_hz is 0");
         return -2;  // Invalid frequency
     }
 
@@ -356,14 +356,14 @@ int attach_timer_handler(const isr_config_t& config, isr_handle_t* out_handle) F
     int timer_idx = -1;
     u8 channel = 0;
     if (!allocate_timer_channel(timer_idx, channel)) {
-        FL_WARN("attachTimerHandler: no free timer channels");
+        FL_WARN_F("attachTimerHandler: no free timer channels");
         return -3;  // Out of resources
     }
 
     NRF_TIMER_Type* timer = get_timer_instance(timer_idx);
     if (!timer) {
         free_timer_channel(timer_idx, channel);
-        FL_WARN("attachTimerHandler: invalid timer instance");
+        FL_WARN_F("attachTimerHandler: invalid timer instance");
         return -4;  // Internal error
     }
 
@@ -372,7 +372,7 @@ int attach_timer_handler(const isr_config_t& config, isr_handle_t* out_handle) F
     auto* handle_data = handle_owner.get();
     if (!handle_data) {
         free_timer_channel(timer_idx, channel);
-        FL_WARN("attachTimerHandler: failed to allocate handle data");
+        FL_WARN_F("attachTimerHandler: failed to allocate handle data");
         return -5;  // Out of memory
     }
 
@@ -466,8 +466,7 @@ int attach_timer_handler(const isr_config_t& config, isr_handle_t* out_handle) F
         nrf_timer_task_trigger(timer, NRF_TIMER_TASK_START);
     }
 
-    FL_DBG("Timer started at " << config.frequency_hz << " Hz on TIMER" << timer_idx
-           << " channel " << static_cast<int>(channel));
+    FL_DBG_F("Timer started at %s Hz on TIMER%s channel %s", config.frequency_hz, timer_idx, static_cast<int>(channel));
 
     // Release ownership - pointer is now managed by the C API (timer_handles + out_handle)
     handle_owner.release();
@@ -485,14 +484,14 @@ int attach_timer_handler(const isr_config_t& config, isr_handle_t* out_handle) F
 
 int attach_external_handler(u8 pin, const isr_config_t& config, isr_handle_t* out_handle) FL_NOEXCEPT {
     if (!config.handler) {
-        FL_WARN("attachExternalHandler: handler is null");
+        FL_WARN_F("attachExternalHandler: handler is null");
         return -1;  // Invalid parameter
     }
 
     // Allocate a GPIOTE channel
     i8 gpiote_ch = allocate_gpiote_channel();
     if (gpiote_ch < 0) {
-        FL_WARN("attachExternalHandler: no free GPIOTE channels");
+        FL_WARN_F("attachExternalHandler: no free GPIOTE channels");
         return -3;  // Out of resources
     }
 
@@ -501,7 +500,7 @@ int attach_external_handler(u8 pin, const isr_config_t& config, isr_handle_t* ou
     auto* handle_data = handle_owner.get();
     if (!handle_data) {
         free_gpiote_channel(gpiote_ch);
-        FL_WARN("attachExternalHandler: failed to allocate handle data");
+        FL_WARN_F("attachExternalHandler: failed to allocate handle data");
         return -5;  // Out of memory
     }
 
@@ -540,8 +539,7 @@ int attach_external_handler(u8 pin, const isr_config_t& config, isr_handle_t* ou
     NVIC_SetPriority(GPIOTE_IRQn, nvic_priority) FL_NOEXCEPT;
     NVIC_EnableIRQ(GPIOTE_IRQn) FL_NOEXCEPT;
 
-    FL_DBG("GPIO interrupt attached on pin " << static_cast<int>(pin)
-           << " GPIOTE channel " << static_cast<int>(gpiote_ch));
+    FL_DBG_F("GPIO interrupt attached on pin %s GPIOTE channel %s", static_cast<int>(pin), static_cast<int>(gpiote_ch));
 
     // Release ownership - pointer is now managed by the C API (gpiote_handles + out_handle)
     handle_owner.release();
@@ -559,13 +557,13 @@ int attach_external_handler(u8 pin, const isr_config_t& config, isr_handle_t* ou
 
 int detach_handler(isr_handle_t& handle) FL_NOEXCEPT {
     if (!handle.is_valid() || handle.platform_id != NRF52_PLATFORM_ID) {
-        FL_WARN("detachHandler: invalid handle");
+        FL_WARN_F("detachHandler: invalid handle");
         return -1;  // Invalid handle
     }
 
     nrf52_isr_handle_data* handle_data = static_cast<nrf52_isr_handle_data*>(handle.platform_handle);
     if (!handle_data) {
-        FL_WARN("detachHandler: null handle data");
+        FL_WARN_F("detachHandler: null handle data");
         return -1;  // Invalid handle
     }
 
@@ -592,19 +590,19 @@ int detach_handler(isr_handle_t& handle) FL_NOEXCEPT {
     handle.platform_handle = nullptr;
     handle.platform_id = 0;
 
-    FL_DBG("Handler detached");
+    FL_DBG_F("Handler detached");
     return 0;  // Success
 }
 
 int enable_handler(const isr_handle_t& handle) FL_NOEXCEPT {
     if (!handle.is_valid() || handle.platform_id != NRF52_PLATFORM_ID) {
-        FL_WARN("enableHandler: invalid handle");
+        FL_WARN_F("enableHandler: invalid handle");
         return -1;  // Invalid handle
     }
 
     nrf52_isr_handle_data* handle_data = static_cast<nrf52_isr_handle_data*>(handle.platform_handle);
     if (!handle_data) {
-        FL_WARN("enableHandler: null handle data");
+        FL_WARN_F("enableHandler: null handle data");
         return -1;  // Invalid handle
     }
 
@@ -623,13 +621,13 @@ int enable_handler(const isr_handle_t& handle) FL_NOEXCEPT {
 
 int disable_handler(const isr_handle_t& handle) FL_NOEXCEPT {
     if (!handle.is_valid() || handle.platform_id != NRF52_PLATFORM_ID) {
-        FL_WARN("disableHandler: invalid handle");
+        FL_WARN_F("disableHandler: invalid handle");
         return -1;  // Invalid handle
     }
 
     nrf52_isr_handle_data* handle_data = static_cast<nrf52_isr_handle_data*>(handle.platform_handle);
     if (!handle_data) {
-        FL_WARN("disableHandler: null handle data");
+        FL_WARN_F("disableHandler: null handle data");
         return -1;  // Invalid handle
     }
 

--- a/src/platforms/arm/nrf52/spi_device_proxy.h
+++ b/src/platforms/arm/nrf52/spi_device_proxy.h
@@ -102,8 +102,7 @@ public:
         mHandle = mBusManager->registerDevice(CLOCK_PIN, DATA_PIN, SPI_CLOCK_DIVIDER, this);
 
         if (!mHandle.is_valid) {
-            FL_WARN("SPIDeviceProxy: Failed to register with bus manager (pin "
-                    << static_cast<int>(CLOCK_PIN) << ":" << static_cast<int>(DATA_PIN) << ")");
+            FL_WARN_F("SPIDeviceProxy: Failed to register with bus manager (pin %s:%s)", static_cast<int>(CLOCK_PIN), static_cast<int>(DATA_PIN));
             return;
         }
 
@@ -313,7 +312,7 @@ public:
         } else {
             // Multi-lane SPI doesn't support bit-level operations
             // This is typically only used for specific LED protocols
-            FL_WARN("SPIDeviceProxy: writeBit() not supported for multi-lane SPI");
+            FL_WARN_F("SPIDeviceProxy: writeBit() not supported for multi-lane SPI");
         }
     }
 
@@ -335,7 +334,7 @@ public:
         // For the proxy, we can't easily support this in multi-lane mode
         // since we need the instance's buffer
         // This should only be called from within writeBytes<D>() which handles buffering
-        FL_WARN("SPIDeviceProxy: writeBytesValueRaw() should not be called directly");
+        FL_WARN_F("SPIDeviceProxy: writeBytesValueRaw() should not be called directly");
     }
 
     /// Finalize transmission - flush buffered multi-lane SPI writes

--- a/src/platforms/arm/nrf52/spi_hw_2_nrf52.cpp.hpp
+++ b/src/platforms/arm/nrf52/spi_hw_2_nrf52.cpp.hpp
@@ -57,13 +57,13 @@ bool SPIDualNRF52::begin(const SpiHw2::Config& config) {
 
     // Validate bus_num against mBusId if driver has pre-assigned ID
     if (mBusId != -1 && config.bus_num != static_cast<u8>(mBusId)) {
-        FL_WARN("SPIDualNRF52: Bus ID mismatch");
+        FL_WARN_F("SPIDualNRF52: Bus ID mismatch");
         return false;
     }
 
     // Validate pin assignments
     if (config.clock_pin < 0 || config.data0_pin < 0 || config.data1_pin < 0) {
-        FL_WARN("SPIDualNRF52: Invalid pin configuration");
+        FL_WARN_F("SPIDualNRF52: Invalid pin configuration");
         return false;
     }
 
@@ -206,13 +206,13 @@ bool SPIDualNRF52::allocateDMABuffers(size_t required_size) {
     // Allocate new buffers in RAM (required for EasyDMA)
     mLane0Buffer = (u8*)fl::malloc(required_size);
     if (mLane0Buffer == nullptr) {
-        FL_WARN("SPIDualNRF52: Failed to allocate lane 0 DMA buffer");
+        FL_WARN_F("SPIDualNRF52: Failed to allocate lane 0 DMA buffer");
         return false;
     }
 
     mLane1Buffer = (u8*)fl::malloc(required_size);
     if (mLane1Buffer == nullptr) {
-        FL_WARN("SPIDualNRF52: Failed to allocate lane 1 DMA buffer");
+        FL_WARN_F("SPIDualNRF52: Failed to allocate lane 1 DMA buffer");
         fl::free(mLane0Buffer);
         mLane0Buffer = nullptr;
         return false;
@@ -291,7 +291,7 @@ bool SPIDualNRF52::waitComplete(u32 timeout_ms) {
     // Use (max)() to prevent macro expansion by Arduino.h's max macro
     bool timed_out = (timeout_ms != (fl::numeric_limits<u32>::max)()) && (iterations >= timeout_iterations);
     if (timed_out) {
-        FL_WARN("SPIDualNRF52: Transaction timeout");
+        FL_WARN_F("SPIDualNRF52: Transaction timeout");
         // Clear state even on timeout
         mTransactionActive = false;
         return false;

--- a/src/platforms/arm/nrf52/spi_hw_4_nrf52.cpp.hpp
+++ b/src/platforms/arm/nrf52/spi_hw_4_nrf52.cpp.hpp
@@ -65,14 +65,14 @@ bool SPIQuadNRF52::begin(const SpiHw4::Config& config) {
 
     // Validate bus_num against mBusId if driver has pre-assigned ID
     if (mBusId != -1 && config.bus_num != static_cast<u8>(mBusId)) {
-        FL_WARN("SPIQuadNRF52: Bus ID mismatch");
+        FL_WARN_F("SPIQuadNRF52: Bus ID mismatch");
         return false;
     }
 
     // Validate pin assignments
     if (config.clock_pin < 0 || config.data0_pin < 0 || config.data1_pin < 0 ||
         config.data2_pin < 0 || config.data3_pin < 0) {
-        FL_WARN("SPIQuadNRF52: Invalid pin configuration");
+        FL_WARN_F("SPIQuadNRF52: Invalid pin configuration");
         return false;
     }
 
@@ -233,13 +233,13 @@ bool SPIQuadNRF52::allocateDMABuffers(size_t required_size) {
     // Allocate new buffers in RAM (required for EasyDMA)
     mLane0Buffer = (u8*)fl::malloc(required_size);
     if (mLane0Buffer == nullptr) {
-        FL_WARN("SPIQuadNRF52: Failed to allocate lane 0 DMA buffer");
+        FL_WARN_F("SPIQuadNRF52: Failed to allocate lane 0 DMA buffer");
         return false;
     }
 
     mLane1Buffer = (u8*)fl::malloc(required_size);
     if (mLane1Buffer == nullptr) {
-        FL_WARN("SPIQuadNRF52: Failed to allocate lane 1 DMA buffer");
+        FL_WARN_F("SPIQuadNRF52: Failed to allocate lane 1 DMA buffer");
         fl::free(mLane0Buffer);
         mLane0Buffer = nullptr;
         return false;
@@ -247,7 +247,7 @@ bool SPIQuadNRF52::allocateDMABuffers(size_t required_size) {
 
     mLane2Buffer = (u8*)fl::malloc(required_size);
     if (mLane2Buffer == nullptr) {
-        FL_WARN("SPIQuadNRF52: Failed to allocate lane 2 DMA buffer");
+        FL_WARN_F("SPIQuadNRF52: Failed to allocate lane 2 DMA buffer");
         fl::free(mLane0Buffer);
         fl::free(mLane1Buffer);
         mLane0Buffer = nullptr;
@@ -257,7 +257,7 @@ bool SPIQuadNRF52::allocateDMABuffers(size_t required_size) {
 
     mLane3Buffer = (u8*)fl::malloc(required_size);
     if (mLane3Buffer == nullptr) {
-        FL_WARN("SPIQuadNRF52: Failed to allocate lane 3 DMA buffer");
+        FL_WARN_F("SPIQuadNRF52: Failed to allocate lane 3 DMA buffer");
         fl::free(mLane0Buffer);
         fl::free(mLane1Buffer);
         fl::free(mLane2Buffer);
@@ -350,7 +350,7 @@ bool SPIQuadNRF52::waitComplete(u32 timeout_ms) {
     // Check if we timed out
     bool timed_out = (timeout_ms != fl::numeric_limits<u32>::max()) && (iterations >= timeout_iterations);
     if (timed_out) {
-        FL_WARN("SPIQuadNRF52: Transaction timeout");
+        FL_WARN_F("SPIQuadNRF52: Transaction timeout");
         // Clear state even on timeout
         mTransactionActive = false;
         return false;

--- a/src/platforms/arm/nrf52/spi_hw_manager_nrf52.cpp.hpp
+++ b/src/platforms/arm/nrf52/spi_hw_manager_nrf52.cpp.hpp
@@ -37,7 +37,7 @@ constexpr int PRIORITY_SPI_HW_2 = 6;   // Lower (2-lane dual-SPI)
 
 /// @brief Register nRF52 SpiHw2 instances
 static void addSpiHw2IfPossible() {
-    FL_DBG("nRF52: Registering SpiHw2 instances");
+    FL_DBG_F("nRF52: Registering SpiHw2 instances");
 
     // nRF52 has multiple Timer/PPI combinations available
     static auto controller0 = fl::make_shared<SPIDualNRF52>(0, "SPI0");
@@ -46,13 +46,13 @@ static void addSpiHw2IfPossible() {
     SpiHw2::registerInstance(controller0);
     SpiHw2::registerInstance(controller1);
 
-    FL_DBG("nRF52: SpiHw2 instances registered");
+    FL_DBG_F("nRF52: SpiHw2 instances registered");
 }
 
 #if defined(FL_IS_NRF52840) || defined(FL_IS_NRF52833)
 /// @brief Register nRF52 SpiHw4 instances (NRF52840/52833 only)
 static void addSpiHw4IfPossible() {
-    FL_DBG("nRF52: Registering SpiHw4 instances");
+    FL_DBG_F("nRF52: Registering SpiHw4 instances");
 
     // nRF52 has multiple Timer/PPI combinations available
     static auto controller0 = fl::make_shared<SPIQuadNRF52>(0, "SPI0");
@@ -61,7 +61,7 @@ static void addSpiHw4IfPossible() {
     SpiHw4::registerInstance(controller0);
     SpiHw4::registerInstance(controller1);
 
-    FL_DBG("nRF52: SpiHw4 instances registered");
+    FL_DBG_F("nRF52: SpiHw4 instances registered");
 }
 #endif
 
@@ -82,7 +82,7 @@ namespace platforms {
 /// - nRF52832: SpiHw2 only (via Timer/PPI peripherals)
 /// - nRF52840/52833: Both SpiHw2 and SpiHw4 (via Timer/PPI peripherals)
 void initSpiHardware() {
-    FL_DBG("nRF52: Initializing SPI hardware");
+    FL_DBG_F("nRF52: Initializing SPI hardware");
 
     // Register in priority order (highest to lowest)
 #if defined(FL_IS_NRF52840) || defined(FL_IS_NRF52833)
@@ -90,7 +90,7 @@ void initSpiHardware() {
 #endif
     detail::addSpiHw2IfPossible();  // Priority 6 (all variants)
 
-    FL_DBG("nRF52: SPI hardware initialized");
+    FL_DBG_F("nRF52: SPI hardware initialized");
 }
 
 }  // namespace platforms

--- a/src/platforms/arm/rp/init_rp.cpp.hpp
+++ b/src/platforms/arm/rp/init_rp.cpp.hpp
@@ -29,14 +29,14 @@ void init() {
         return;  // Already initialized
     }
 
-    FL_DBG("RP2040/RP2350: Platform initialization starting");
+    FL_DBG_F("RP2040/RP2350: Platform initialization starting");
 
     // PIO parallel group singleton is initialized lazily on first use when
     // FastLED.addLeds() is called. No explicit initialization needed here.
     // ISR alarm lock and ADC are also initialized on-demand.
 
     initialized = true;
-    FL_DBG("RP2040/RP2350: Platform initialization complete");
+    FL_DBG_F("RP2040/RP2350: Platform initialization complete");
 }
 
 } // namespace platforms

--- a/src/platforms/arm/rp/isr_rp2040.hpp
+++ b/src/platforms/arm/rp/isr_rp2040.hpp
@@ -225,25 +225,25 @@ static void gpio_callback_wrapper(uint gpio, u32 events) FL_NOEXCEPT {
 
 int attach_timer_handler(const isr_config_t& config, isr_handle_t* out_handle) FL_NOEXCEPT {
     if (!config.handler) {
-        FL_WARN("attachTimerHandler: handler is null");
+        FL_WARN_F("attachTimerHandler: handler is null");
         return -1;  // Invalid parameter
     }
 
     if (config.frequency_hz == 0) {
-        FL_WARN("attachTimerHandler: frequency_hz is 0");
+        FL_WARN_F("attachTimerHandler: frequency_hz is 0");
         return -2;  // Invalid frequency
     }
 
     // Check frequency bounds (practical limits for RP2040)
     if (config.frequency_hz > 1000000) {
-        FL_WARN("attachTimerHandler: frequency " << config.frequency_hz << " Hz exceeds 1 MHz limit");
+        FL_WARN_F("attachTimerHandler: frequency %s Hz exceeds 1 MHz limit", config.frequency_hz);
         return -2;  // Invalid frequency
     }
 
     // Allocate a hardware alarm
     i8 alarm_num = allocate_alarm();
     if (alarm_num < 0) {
-        FL_WARN("attachTimerHandler: no free hardware alarms (max 4)");
+        FL_WARN_F("attachTimerHandler: no free hardware alarms (max 4)");
         return -3;  // Out of resources
     }
 
@@ -252,7 +252,7 @@ int attach_timer_handler(const isr_config_t& config, isr_handle_t* out_handle) F
     auto* handle_data = handle_owner.get();
     if (!handle_data) {
         free_alarm(alarm_num);
-        FL_WARN("attachTimerHandler: failed to allocate handle data");
+        FL_WARN_F("attachTimerHandler: failed to allocate handle data");
         return -5;  // Out of memory
     }
 
@@ -277,7 +277,7 @@ int attach_timer_handler(const isr_config_t& config, isr_handle_t* out_handle) F
         // Alarm creation failed
         free_alarm(alarm_num);
         alarm_handles[alarm_num] = nullptr;
-        FL_WARN("attachTimerHandler: add_alarm_in_us failed");
+        FL_WARN_F("attachTimerHandler: add_alarm_in_us failed");
         return -4;  // Internal error
     }
 
@@ -287,8 +287,7 @@ int attach_timer_handler(const isr_config_t& config, isr_handle_t* out_handle) F
         irq_set_priority(TIMER_IRQ_0 + alarm_num, nvic_priority);
     }
 
-    FL_DBG("Timer started at " << config.frequency_hz << " Hz on alarm "
-           << static_cast<int>(alarm_num));
+    FL_DBG_F("Timer started at %s Hz on alarm %s", config.frequency_hz, static_cast<int>(alarm_num));
 
     // Release ownership - pointer is now managed by the C API (alarm_handles + out_handle)
     handle_owner.release();
@@ -306,20 +305,18 @@ int attach_timer_handler(const isr_config_t& config, isr_handle_t* out_handle) F
 
 int attach_external_handler(u8 pin, const isr_config_t& config, isr_handle_t* out_handle) FL_NOEXCEPT {
     if (!config.handler) {
-        FL_WARN("attachExternalHandler: handler is null");
+        FL_WARN_F("attachExternalHandler: handler is null");
         return -1;  // Invalid parameter
     }
 
     if (pin >= 30) {
-        FL_WARN("attachExternalHandler: invalid pin " << static_cast<int>(pin)
-                << " (RP2040 has 30 GPIO pins)");
+        FL_WARN_F("attachExternalHandler: invalid pin %s (RP2040 has 30 GPIO pins)", static_cast<int>(pin));
         return -1;  // Invalid parameter
     }
 
     // Check if pin already has a handler
     if (gpio_handles[pin] != nullptr) {
-        FL_WARN("attachExternalHandler: pin " << static_cast<int>(pin)
-                << " already has an attached handler");
+        FL_WARN_F("attachExternalHandler: pin %s already has an attached handler", static_cast<int>(pin));
         return -3;  // Resource already in use
     }
 
@@ -327,7 +324,7 @@ int attach_external_handler(u8 pin, const isr_config_t& config, isr_handle_t* ou
     auto handle_owner = fl::make_unique<rp2040_isr_handle_data>();
     auto* handle_data = handle_owner.get();
     if (!handle_data) {
-        FL_WARN("attachExternalHandler: failed to allocate handle data");
+        FL_WARN_F("attachExternalHandler: failed to allocate handle data");
         return -5;  // Out of memory
     }
 
@@ -374,8 +371,7 @@ int attach_external_handler(u8 pin, const isr_config_t& config, isr_handle_t* ou
         irq_set_priority(IO_IRQ_BANK0, nvic_priority);
     }
 
-    FL_DBG("GPIO interrupt attached on pin " << static_cast<int>(pin)
-           << " with events 0x" << fl::to_hex(events));
+    FL_DBG_F("GPIO interrupt attached on pin %s with events 0x%s", static_cast<int>(pin), fl::to_hex(events));
 
     // Release ownership - pointer is now managed by the C API (gpio_handles + out_handle)
     handle_owner.release();
@@ -393,13 +389,13 @@ int attach_external_handler(u8 pin, const isr_config_t& config, isr_handle_t* ou
 
 int detach_handler(isr_handle_t& handle) FL_NOEXCEPT {
     if (!handle.is_valid() || handle.platform_id != RP2040_PLATFORM_ID) {
-        FL_WARN("detachHandler: invalid handle");
+        FL_WARN_F("detachHandler: invalid handle");
         return -1;  // Invalid handle
     }
 
     rp2040_isr_handle_data* handle_data = static_cast<rp2040_isr_handle_data*>(handle.platform_handle);
     if (!handle_data) {
-        FL_WARN("detachHandler: null handle data");
+        FL_WARN_F("detachHandler: null handle data");
         return -1;  // Invalid handle
     }
 
@@ -423,19 +419,19 @@ int detach_handler(isr_handle_t& handle) FL_NOEXCEPT {
     handle.platform_handle = nullptr;
     handle.platform_id = 0;
 
-    FL_DBG("Handler detached");
+    FL_DBG_F("Handler detached");
     return 0;  // Success
 }
 
 int enable_handler(const isr_handle_t& handle) FL_NOEXCEPT {
     if (!handle.is_valid() || handle.platform_id != RP2040_PLATFORM_ID) {
-        FL_WARN("enableHandler: invalid handle");
+        FL_WARN_F("enableHandler: invalid handle");
         return -1;  // Invalid handle
     }
 
     rp2040_isr_handle_data* handle_data = static_cast<rp2040_isr_handle_data*>(handle.platform_handle);
     if (!handle_data) {
-        FL_WARN("enableHandler: null handle data");
+        FL_WARN_F("enableHandler: null handle data");
         return -1;  // Invalid handle
     }
 
@@ -449,7 +445,7 @@ int enable_handler(const isr_handle_t& handle) FL_NOEXCEPT {
         handle_data->alarm_id = add_alarm_in_us(interval_us, alarm_callback_wrapper,
                                                  handle_data, true);
         if (handle_data->alarm_id == 0 || handle_data->alarm_id == -1) {
-            FL_WARN("enableHandler: failed to restart alarm");
+            FL_WARN_F("enableHandler: failed to restart alarm");
             return -2;  // Failed to restart
         }
     } else {
@@ -463,13 +459,13 @@ int enable_handler(const isr_handle_t& handle) FL_NOEXCEPT {
 
 int disable_handler(const isr_handle_t& handle) FL_NOEXCEPT {
     if (!handle.is_valid() || handle.platform_id != RP2040_PLATFORM_ID) {
-        FL_WARN("disableHandler: invalid handle");
+        FL_WARN_F("disableHandler: invalid handle");
         return -1;  // Invalid handle
     }
 
     rp2040_isr_handle_data* handle_data = static_cast<rp2040_isr_handle_data*>(handle.platform_handle);
     if (!handle_data) {
-        FL_WARN("disableHandler: null handle data");
+        FL_WARN_F("disableHandler: null handle data");
         return -1;  // Invalid handle
     }
 

--- a/src/platforms/arm/rp/isr_rp2350.hpp
+++ b/src/platforms/arm/rp/isr_rp2350.hpp
@@ -231,25 +231,25 @@ static void gpio_callback_wrapper(uint gpio, u32 events) FL_NOEXCEPT {
 
 int attach_timer_handler(const isr_config_t& config, isr_handle_t* out_handle) FL_NOEXCEPT {
     if (!config.handler) {
-        FL_WARN("attachTimerHandler: handler is null");
+        FL_WARN_F("attachTimerHandler: handler is null");
         return -1;  // Invalid parameter
     }
 
     if (config.frequency_hz == 0) {
-        FL_WARN("attachTimerHandler: frequency_hz is 0");
+        FL_WARN_F("attachTimerHandler: frequency_hz is 0");
         return -2;  // Invalid frequency
     }
 
     // Check frequency bounds (practical limits for RP2350)
     if (config.frequency_hz > 1000000) {
-        FL_WARN("attachTimerHandler: frequency " << config.frequency_hz << " Hz exceeds 1 MHz limit");
+        FL_WARN_F("attachTimerHandler: frequency %s Hz exceeds 1 MHz limit", config.frequency_hz);
         return -2;  // Invalid frequency
     }
 
     // Allocate a hardware alarm
     i8 alarm_num = allocate_alarm();
     if (alarm_num < 0) {
-        FL_WARN("attachTimerHandler: no free hardware alarms (max 4)");
+        FL_WARN_F("attachTimerHandler: no free hardware alarms (max 4)");
         return -3;  // Out of resources
     }
 
@@ -258,7 +258,7 @@ int attach_timer_handler(const isr_config_t& config, isr_handle_t* out_handle) F
     auto* handle_data = handle_owner.get();
     if (!handle_data) {
         free_alarm(alarm_num);
-        FL_WARN("attachTimerHandler: failed to allocate handle data");
+        FL_WARN_F("attachTimerHandler: failed to allocate handle data");
         return -5;  // Out of memory
     }
 
@@ -283,7 +283,7 @@ int attach_timer_handler(const isr_config_t& config, isr_handle_t* out_handle) F
         // Alarm creation failed
         free_alarm(alarm_num);
         alarm_handles[alarm_num] = nullptr;
-        FL_WARN("attachTimerHandler: add_alarm_in_us failed");
+        FL_WARN_F("attachTimerHandler: add_alarm_in_us failed");
         return -4;  // Internal error
     }
 
@@ -295,8 +295,7 @@ int attach_timer_handler(const isr_config_t& config, isr_handle_t* out_handle) F
         irq_set_priority(TIMER_ALARM_IRQ_NUM(timer_hw, alarm_num), nvic_priority);
     }
 
-    FL_DBG("Timer started at " << config.frequency_hz << " Hz on alarm "
-           << static_cast<int>(alarm_num));
+    FL_DBG_F("Timer started at %s Hz on alarm %s", config.frequency_hz, static_cast<int>(alarm_num));
 
     // Release ownership - pointer is now managed by the C API (alarm_handles + out_handle)
     handle_owner.release();
@@ -314,20 +313,18 @@ int attach_timer_handler(const isr_config_t& config, isr_handle_t* out_handle) F
 
 int attach_external_handler(u8 pin, const isr_config_t& config, isr_handle_t* out_handle) FL_NOEXCEPT {
     if (!config.handler) {
-        FL_WARN("attachExternalHandler: handler is null");
+        FL_WARN_F("attachExternalHandler: handler is null");
         return -1;  // Invalid parameter
     }
 
     if (pin >= 30) {
-        FL_WARN("attachExternalHandler: invalid pin " << static_cast<int>(pin)
-                << " (RP2350 has 30 GPIO pins)");
+        FL_WARN_F("attachExternalHandler: invalid pin %s (RP2350 has 30 GPIO pins)", static_cast<int>(pin));
         return -1;  // Invalid parameter
     }
 
     // Check if pin already has a handler
     if (gpio_handles[pin] != nullptr) {
-        FL_WARN("attachExternalHandler: pin " << static_cast<int>(pin)
-                << " already has an attached handler");
+        FL_WARN_F("attachExternalHandler: pin %s already has an attached handler", static_cast<int>(pin));
         return -3;  // Resource already in use
     }
 
@@ -335,7 +332,7 @@ int attach_external_handler(u8 pin, const isr_config_t& config, isr_handle_t* ou
     auto handle_owner = fl::make_unique<rp2350_isr_handle_data>();
     auto* handle_data = handle_owner.get();
     if (!handle_data) {
-        FL_WARN("attachExternalHandler: failed to allocate handle data");
+        FL_WARN_F("attachExternalHandler: failed to allocate handle data");
         return -5;  // Out of memory
     }
 
@@ -382,8 +379,7 @@ int attach_external_handler(u8 pin, const isr_config_t& config, isr_handle_t* ou
         irq_set_priority(IO_IRQ_BANK0, nvic_priority);
     }
 
-    FL_DBG("GPIO interrupt attached on pin " << static_cast<int>(pin)
-           << " with events 0x" << fl::to_hex(events));
+    FL_DBG_F("GPIO interrupt attached on pin %s with events 0x%s", static_cast<int>(pin), fl::to_hex(events));
 
     // Release ownership - pointer is now managed by the C API (gpio_handles + out_handle)
     handle_owner.release();
@@ -401,13 +397,13 @@ int attach_external_handler(u8 pin, const isr_config_t& config, isr_handle_t* ou
 
 int detach_handler(isr_handle_t& handle) FL_NOEXCEPT {
     if (!handle.is_valid() || handle.platform_id != RP2350_PLATFORM_ID) {
-        FL_WARN("detachHandler: invalid handle");
+        FL_WARN_F("detachHandler: invalid handle");
         return -1;  // Invalid handle
     }
 
     rp2350_isr_handle_data* handle_data = static_cast<rp2350_isr_handle_data*>(handle.platform_handle);
     if (!handle_data) {
-        FL_WARN("detachHandler: null handle data");
+        FL_WARN_F("detachHandler: null handle data");
         return -1;  // Invalid handle
     }
 
@@ -431,19 +427,19 @@ int detach_handler(isr_handle_t& handle) FL_NOEXCEPT {
     handle.platform_handle = nullptr;
     handle.platform_id = 0;
 
-    FL_DBG("Handler detached");
+    FL_DBG_F("Handler detached");
     return 0;  // Success
 }
 
 int enable_handler(const isr_handle_t& handle) FL_NOEXCEPT {
     if (!handle.is_valid() || handle.platform_id != RP2350_PLATFORM_ID) {
-        FL_WARN("enableHandler: invalid handle");
+        FL_WARN_F("enableHandler: invalid handle");
         return -1;  // Invalid handle
     }
 
     rp2350_isr_handle_data* handle_data = static_cast<rp2350_isr_handle_data*>(handle.platform_handle);
     if (!handle_data) {
-        FL_WARN("enableHandler: null handle data");
+        FL_WARN_F("enableHandler: null handle data");
         return -1;  // Invalid handle
     }
 
@@ -457,7 +453,7 @@ int enable_handler(const isr_handle_t& handle) FL_NOEXCEPT {
         handle_data->alarm_id = add_alarm_in_us(interval_us, alarm_callback_wrapper,
                                                  handle_data, true);
         if (handle_data->alarm_id == 0 || handle_data->alarm_id == -1) {
-            FL_WARN("enableHandler: failed to restart alarm");
+            FL_WARN_F("enableHandler: failed to restart alarm");
             return -2;  // Failed to restart
         }
     } else {
@@ -471,13 +467,13 @@ int enable_handler(const isr_handle_t& handle) FL_NOEXCEPT {
 
 int disable_handler(const isr_handle_t& handle) FL_NOEXCEPT {
     if (!handle.is_valid() || handle.platform_id != RP2350_PLATFORM_ID) {
-        FL_WARN("disableHandler: invalid handle");
+        FL_WARN_F("disableHandler: invalid handle");
         return -1;  // Invalid handle
     }
 
     rp2350_isr_handle_data* handle_data = static_cast<rp2350_isr_handle_data*>(handle.platform_handle);
     if (!handle_data) {
-        FL_WARN("disableHandler: null handle data");
+        FL_WARN_F("disableHandler: null handle data");
         return -1;  // Invalid handle
     }
 

--- a/src/platforms/arm/rp/mutex_rp.cpp.hpp
+++ b/src/platforms/arm/rp/mutex_rp.cpp.hpp
@@ -33,7 +33,7 @@ MutexRP::MutexRP() : mSpinlock(nullptr), mOwnerCore(0xFFFFFFFF), mLocked(false) 
     int spinlock_num = spin_lock_claim_unused(true);  // true = required (panic if none available)
 
     if (spinlock_num < 0) {
-        FL_WARN("MutexRP: Failed to claim hardware spinlock");
+        FL_WARN_F("MutexRP: Failed to claim hardware spinlock");
         return;
     }
 
@@ -116,7 +116,7 @@ RecursiveMutexRP::RecursiveMutexRP() : mSpinlock(nullptr), mOwnerCore(0xFFFFFFFF
     int spinlock_num = spin_lock_claim_unused(true);  // true = required (panic if none available)
 
     if (spinlock_num < 0) {
-        FL_WARN("RecursiveMutexRP: Failed to claim hardware spinlock");
+        FL_WARN_F("RecursiveMutexRP: Failed to claim hardware spinlock");
         return;
     }
 

--- a/src/platforms/arm/rp/rpcommon/clockless_rp_pio_auto.cpp.hpp
+++ b/src/platforms/arm/rp/rpcommon/clockless_rp_pio_auto.cpp.hpp
@@ -77,7 +77,7 @@ struct PinGroup {
             pio = pio1;
             sm = pio_claim_unused_sm(pio, false);
             if (sm == -1) {
-                FL_WARN("Failed to claim PIO state machine for pin group starting at GPIO " << (int)base_pin);
+                FL_WARN_F("Failed to claim PIO state machine for pin group starting at GPIO %s", (int)base_pin);
                 return false;
             }
         }
@@ -86,7 +86,7 @@ struct PinGroup {
         if (dma_chan == -1) {
             pio_sm_unclaim(pio, sm);
             sm = -1;
-            FL_WARN("Failed to claim DMA channel for pin group starting at GPIO " << (int)base_pin);
+            FL_WARN_F("Failed to claim DMA channel for pin group starting at GPIO %s", (int)base_pin);
             return false;
         }
 
@@ -96,8 +96,7 @@ struct PinGroup {
             gpio_set_dir(base_pin + i, GPIO_OUT);
         }
 
-        FL_DBG("Allocated resources for " << (int)num_pins << "-pin parallel group at GPIO "
-               << (int)base_pin << " (PIO" << (pio == pio0 ? 0 : 1) << ", SM" << sm << ", DMA" << dma_chan << ")");
+        FL_DBG_F("Allocated resources for %s-pin parallel group at GPIO %s (PIO%s, SM%s, DMA%s)", (int)num_pins, (int)base_pin, (pio == pio0 ? 0 : 1), sm, dma_chan);
 
         return true;
     }
@@ -173,7 +172,7 @@ class RP2040ParallelGroup {
             sorted_pins[j + 1] = key;
         }
 
-        FL_DBG("Detecting pin groups from " << sorted_pins.size() << " pins");
+        FL_DBG_F("Detecting pin groups from %s pins", sorted_pins.size());
 
         // Detect consecutive runs
         fl::u32 i = 0;
@@ -209,9 +208,9 @@ class RP2040ParallelGroup {
             }
 
             if (group_size > 1) {
-                FL_DBG("Created " << (int)group_size << "-pin parallel group at GPIO " << (int)start_pin);
+                FL_DBG_F("Created %s-pin parallel group at GPIO %s", (int)group_size, (int)start_pin);
             } else {
-                FL_DBG("Created single-pin (sequential) group at GPIO " << (int)start_pin);
+                FL_DBG_F("Created single-pin (sequential) group at GPIO %s", (int)start_pin);
             }
 
             mPinGroups.push_back(fl::move(group));
@@ -220,7 +219,7 @@ class RP2040ParallelGroup {
             i += group_size;
         }
 
-        FL_DBG("Total pin groups: " << mPinGroups.size());
+        FL_DBG_F("Total pin groups: %s", mPinGroups.size());
     }
 
     /// @brief Show all pixels - called once per frame
@@ -242,7 +241,7 @@ class RP2040ParallelGroup {
 
         if (drawlist_changed) {
             // Pin configuration changed - rebuild groups
-            FL_DBG("Pin configuration changed, rebuilding groups");
+            FL_DBG_F("Pin configuration changed, rebuilding groups");
             detectPinGroups();
 
             // Allocate resources for each group
@@ -282,7 +281,7 @@ class RP2040ParallelGroup {
 
         // TODO: Implement sequential PIO output for single pins
         // For now, just log that we would output this data
-        FL_DBG("Sequential output for GPIO " << (int)pin << " (" << led_data.size() << " bytes)");
+        FL_DBG_F("Sequential output for GPIO %s (%s bytes)", (int)pin, led_data.size());
 
         // In a full implementation, this would use the regular non-parallel
         // clockless driver from clockless_rp_pio.h
@@ -291,8 +290,7 @@ class RP2040ParallelGroup {
     /// @brief Output a parallel group with bit transposition
     void outputParallelGroup(PinGroup* group) {
         if (group->sm == -1 || group->dma_chan == -1) {
-            FL_WARN("Parallel group at GPIO " << (int)group->base_pin
-                    << " has no allocated resources, skipping");
+            FL_WARN_F("Parallel group at GPIO %s has no allocated resources, skipping", (int)group->base_pin);
             return;
         }
 
@@ -350,17 +348,15 @@ class RP2040ParallelGroup {
                 fl::transpose_2strips(strip_ptrs, group->transpose_buffer.get(), max_leds, bytes_per_led);
                 break;
             default:
-                FL_WARN("Invalid parallel group size: " << (int)group->num_pins);
+                FL_WARN_F("Invalid parallel group size: %s", (int)group->num_pins);
                 return;
         }
 
-        FL_DBG("Transposed " << group->num_pins << "-pin group at GPIO " << (int)group->base_pin
-               << " (" << max_leds << " LEDs, " << needed_buffer_size << " bytes)");
+        FL_DBG_F("Transposed %s-pin group at GPIO %s (%s LEDs, %s bytes)", group->num_pins, (int)group->base_pin, max_leds, needed_buffer_size);
 
         // TODO: Configure PIO program and start DMA transfer
         // For now, just log that we would output this data
-        FL_DBG("Parallel output for " << group->num_pins << " pins starting at GPIO "
-               << (int)group->base_pin << " (" << needed_buffer_size << " bytes)");
+        FL_DBG_F("Parallel output for %s pins starting at GPIO %s (%s bytes)", group->num_pins, (int)group->base_pin, needed_buffer_size);
 
         // In a full implementation, this would:
         // 1. Configure PIO program with WS2812 timing

--- a/src/platforms/arm/rp/rpcommon/init_channel_driver_rp.cpp.hpp
+++ b/src/platforms/arm/rp/rpcommon/init_channel_driver_rp.cpp.hpp
@@ -37,7 +37,7 @@ namespace detail {
 
 /// @brief Add HW SPI drivers if supported by platform (UNIFIED VERSION)
 static void addSpiHardwareIfPossible(ChannelManager& manager) {
-    FL_DBG("RP2040/RP2350: Registering unified HW SPI channel driver");
+    FL_DBG_F("RP2040/RP2350: Registering unified HW SPI channel driver");
 
     fl::vector<fl::shared_ptr<SpiHwBase>> controllers;
     fl::vector<int> priorities;
@@ -47,7 +47,7 @@ static void addSpiHardwareIfPossible(ChannelManager& manager) {
     // Collect SpiHw8 controllers (highest priority: 8)
     // ========================================================================
     const auto& hw8Controllers = SpiHw8::getAll();
-    FL_DBG("RP2040/RP2350: Found " << hw8Controllers.size() << " SpiHw8 controllers");
+    FL_DBG_F("RP2040/RP2350: Found %s SpiHw8 controllers", hw8Controllers.size());
 
     for (const auto& ctrl : hw8Controllers) {
         if (ctrl) {
@@ -61,7 +61,7 @@ static void addSpiHardwareIfPossible(ChannelManager& manager) {
     // Collect SpiHw4 controllers (medium priority: 7)
     // ========================================================================
     const auto& hw4Controllers = SpiHw4::getAll();
-    FL_DBG("RP2040/RP2350: Found " << hw4Controllers.size() << " SpiHw4 controllers");
+    FL_DBG_F("RP2040/RP2350: Found %s SpiHw4 controllers", hw4Controllers.size());
 
     for (const auto& ctrl : hw4Controllers) {
         if (ctrl) {
@@ -75,7 +75,7 @@ static void addSpiHardwareIfPossible(ChannelManager& manager) {
     // Collect SpiHw2 controllers (lower priority: 6)
     // ========================================================================
     const auto& hw2Controllers = SpiHw2::getAll();
-    FL_DBG("RP2040/RP2350: Found " << hw2Controllers.size() << " SpiHw2 controllers");
+    FL_DBG_F("RP2040/RP2350: Found %s SpiHw2 controllers", hw2Controllers.size());
 
     for (const auto& ctrl : hw2Controllers) {
         if (ctrl) {
@@ -107,14 +107,12 @@ static void addSpiHardwareIfPossible(ChannelManager& manager) {
 
             manager.addDriver(maxPriority, adapter);
 
-            FL_DBG("RP2040/RP2350: Registered unified SPI driver with "
-                   << controllers.size() << " controllers (priority "
-                   << maxPriority << ")");
+            FL_DBG_F("RP2040/RP2350: Registered unified SPI driver with %s controllers (priority %s)", controllers.size(), maxPriority);
         } else {
-            FL_WARN("RP2040/RP2350: Failed to create unified SPI adapter");
+            FL_WARN_F("RP2040/RP2350: Failed to create unified SPI adapter");
         }
     } else {
-        FL_DBG("RP2040/RP2350: No SPI hardware controllers available");
+        FL_DBG_F("RP2040/RP2350: No SPI hardware controllers available");
     }
 }
 
@@ -127,14 +125,14 @@ namespace platforms {
 /// Called lazily on first access to ChannelManager::instance().
 /// Registers platform-specific drivers (SPI hardware) with the bus manager.
 void initChannelDrivers() {
-    FL_DBG("RP2040/RP2350: Lazy initialization of channel drivers");
+    FL_DBG_F("RP2040/RP2350: Lazy initialization of channel drivers");
 
     auto& manager = channelManager();
 
     // Register true SPI hardware (priority 6-8)
     detail::addSpiHardwareIfPossible(manager);
 
-    FL_DBG("RP2040/RP2350: Channel drivers initialized");
+    FL_DBG_F("RP2040/RP2350: Channel drivers initialized");
 }
 
 } // namespace platforms

--- a/src/platforms/arm/rp/rpcommon/spi_hw_2_rp.cpp.hpp
+++ b/src/platforms/arm/rp/rpcommon/spi_hw_2_rp.cpp.hpp
@@ -244,13 +244,13 @@ bool SPIDualRP2040::begin(const SpiHw2::Config& config) {
 
     // Validate bus_num against mBusId if driver has pre-assigned ID
     if (mBusId != -1 && config.bus_num != static_cast<u8>(mBusId)) {
-        FL_WARN("SPIDualRP2040: Bus ID mismatch");
+        FL_WARN_F("SPIDualRP2040: Bus ID mismatch");
         return false;
     }
 
     // Validate pin assignments
     if (config.clock_pin < 0 || config.data0_pin < 0 || config.data1_pin < 0) {
-        FL_WARN("SPIDualRP2040: Invalid pin configuration");
+        FL_WARN_F("SPIDualRP2040: Invalid pin configuration");
         return false;
     }
 
@@ -288,14 +288,14 @@ bool SPIDualRP2040::begin(const SpiHw2::Config& config) {
     }
 
     if (mPIO == nullptr || mStateMachine == -1 || mPIOOffset == -1) {
-        FL_WARN("SPIDualRP2040: No available PIO resources");
+        FL_WARN_F("SPIDualRP2040: No available PIO resources");
         return false;
     }
 
     // Claim DMA channel
     mDMAChannel = dma_claim_unused_channel(false);
     if (mDMAChannel == -1) {
-        FL_WARN("SPIDualRP2040: No available DMA channel");
+        FL_WARN_F("SPIDualRP2040: No available DMA channel");
         pio_sm_unclaim(mPIO, mStateMachine);
         return false;
     }
@@ -303,7 +303,7 @@ bool SPIDualRP2040::begin(const SpiHw2::Config& config) {
     // Configure GPIO pins for PIO
     // Data pins must be consecutive
     if (mData1Pin != mData0Pin + 1) {
-        FL_WARN("SPIDualRP2040: Data pins must be consecutive (D0, D0+1)");
+        FL_WARN_F("SPIDualRP2040: Data pins must be consecutive (D0, D0+1)");
         dma_channel_unclaim(mDMAChannel);
         pio_sm_unclaim(mPIO, mStateMachine);
         return false;

--- a/src/platforms/arm/rp/rpcommon/spi_hw_4_rp.cpp.hpp
+++ b/src/platforms/arm/rp/rpcommon/spi_hw_4_rp.cpp.hpp
@@ -256,13 +256,13 @@ bool SPIQuadRP2040::begin(const SpiHw4::Config& config) {
 
     // Validate bus_num against mBusId if driver has pre-assigned ID
     if (mBusId != -1 && config.bus_num != static_cast<u8>(mBusId)) {
-        FL_WARN("SPIQuadRP2040: Bus ID mismatch");
+        FL_WARN_F("SPIQuadRP2040: Bus ID mismatch");
         return false;
     }
 
     // Validate pin assignments - at least clock and D0 must be set
     if (config.clock_pin < 0 || config.data0_pin < 0) {
-        FL_WARN("SPIQuadRP2040: Invalid pin configuration (clock and D0 required)");
+        FL_WARN_F("SPIQuadRP2040: Invalid pin configuration (clock and D0 required)");
         return false;
     }
 
@@ -302,14 +302,14 @@ bool SPIQuadRP2040::begin(const SpiHw4::Config& config) {
     }
 
     if (mPIO == nullptr || mStateMachine == -1 || mPIOOffset == -1) {
-        FL_WARN("SPIQuadRP2040: No available PIO resources");
+        FL_WARN_F("SPIQuadRP2040: No available PIO resources");
         return false;
     }
 
     // Claim DMA channel
     mDMAChannel = dma_claim_unused_channel(false);
     if (mDMAChannel == -1) {
-        FL_WARN("SPIQuadRP2040: No available DMA channel");
+        FL_WARN_F("SPIQuadRP2040: No available DMA channel");
         pio_sm_unclaim(mPIO, mStateMachine);
         return false;
     }
@@ -319,7 +319,7 @@ bool SPIQuadRP2040::begin(const SpiHw4::Config& config) {
     if (mData1Pin >= 0 && mData2Pin >= 0 && mData3Pin >= 0) {
         // Full quad mode - all 4 pins must be consecutive
         if (mData1Pin != mData0Pin + 1 || mData2Pin != mData0Pin + 2 || mData3Pin != mData0Pin + 3) {
-            FL_WARN("SPIQuadRP2040: Data pins must be consecutive (D0, D0+1, D0+2, D0+3)");
+            FL_WARN_F("SPIQuadRP2040: Data pins must be consecutive (D0, D0+1, D0+2, D0+3)");
             dma_channel_unclaim(mDMAChannel);
             pio_sm_unclaim(mPIO, mStateMachine);
             return false;

--- a/src/platforms/arm/rp/rpcommon/spi_hw_8_rp.cpp.hpp
+++ b/src/platforms/arm/rp/rpcommon/spi_hw_8_rp.cpp.hpp
@@ -255,7 +255,7 @@ bool SpiHw8RP2040::begin(const SpiHw8::Config& config) {
 
     // Validate bus_num against mBusId if driver has pre-assigned ID
     if (mBusId != -1 && config.bus_num != static_cast<u8>(mBusId)) {
-        FL_WARN("SpiHw8RP2040: Bus ID mismatch");
+        FL_WARN_F("SpiHw8RP2040: Bus ID mismatch");
         return false;
     }
 
@@ -263,7 +263,7 @@ bool SpiHw8RP2040::begin(const SpiHw8::Config& config) {
     if (config.clock_pin < 0 || config.data0_pin < 0 || config.data1_pin < 0 ||
         config.data2_pin < 0 || config.data3_pin < 0 || config.data4_pin < 0 ||
         config.data5_pin < 0 || config.data6_pin < 0 || config.data7_pin < 0) {
-        FL_WARN("SpiHw8RP2040: Invalid pin configuration (all 8 data pins + clock required)");
+        FL_WARN_F("SpiHw8RP2040: Invalid pin configuration (all 8 data pins + clock required)");
         return false;
     }
 
@@ -281,7 +281,7 @@ bool SpiHw8RP2040::begin(const SpiHw8::Config& config) {
     // Validate that all 8 data pins are consecutive
     for (int i = 1; i < 8; ++i) {
         if (mDataPins[i] != mDataPins[0] + i) {
-            FL_WARN("SpiHw8RP2040: Data pins must be consecutive (D0, D0+1, ..., D0+7)");
+            FL_WARN_F("SpiHw8RP2040: Data pins must be consecutive (D0, D0+1, ..., D0+7)");
             return false;
         }
     }
@@ -315,14 +315,14 @@ bool SpiHw8RP2040::begin(const SpiHw8::Config& config) {
     }
 
     if (mPIO == nullptr || mStateMachine == -1 || mPIOOffset == -1) {
-        FL_WARN("SpiHw8RP2040: No available PIO resources");
+        FL_WARN_F("SpiHw8RP2040: No available PIO resources");
         return false;
     }
 
     // Claim DMA channel
     mDMAChannel = dma_claim_unused_channel(false);
     if (mDMAChannel == -1) {
-        FL_WARN("SpiHw8RP2040: No available DMA channel");
+        FL_WARN_F("SpiHw8RP2040: No available DMA channel");
         pio_sm_unclaim(mPIO, mStateMachine);
         return false;
     }

--- a/src/platforms/arm/rp/rpcommon/spi_hw_manager_rp.cpp.hpp
+++ b/src/platforms/arm/rp/rpcommon/spi_hw_manager_rp.cpp.hpp
@@ -43,7 +43,7 @@ constexpr int PRIORITY_SPI_HW_2 = 6;   // Lowest (2-lane dual-SPI)
 
 /// @brief Register RP2040/RP2350 SpiHw2 instances
 static void addSpiHw2IfPossible() {
-    FL_DBG("RP2040/RP2350: Registering SpiHw2 instances");
+    FL_DBG_F("RP2040/RP2350: Registering SpiHw2 instances");
 
     // Create 2 logical SPI buses (each uses separate PIO state machine)
     static auto controller0 = fl::make_shared<SPIDualRP2040>(0, "SPI0");
@@ -52,12 +52,12 @@ static void addSpiHw2IfPossible() {
     SpiHw2::registerInstance(controller0);
     SpiHw2::registerInstance(controller1);
 
-    FL_DBG("RP2040/RP2350: SpiHw2 instances registered");
+    FL_DBG_F("RP2040/RP2350: SpiHw2 instances registered");
 }
 
 /// @brief Register RP2040/RP2350 SpiHw4 instances
 static void addSpiHw4IfPossible() {
-    FL_DBG("RP2040/RP2350: Registering SpiHw4 instances");
+    FL_DBG_F("RP2040/RP2350: Registering SpiHw4 instances");
 
     // Create 2 logical SPI buses (each uses separate PIO state machine)
     static auto controller0 = fl::make_shared<SPIQuadRP2040>(0, "SPI0");
@@ -66,12 +66,12 @@ static void addSpiHw4IfPossible() {
     SpiHw4::registerInstance(controller0);
     SpiHw4::registerInstance(controller1);
 
-    FL_DBG("RP2040/RP2350: SpiHw4 instances registered");
+    FL_DBG_F("RP2040/RP2350: SpiHw4 instances registered");
 }
 
 /// @brief Register RP2040/RP2350 SpiHw8 instances
 static void addSpiHw8IfPossible() {
-    FL_DBG("RP2040/RP2350: Registering SpiHw8 instances");
+    FL_DBG_F("RP2040/RP2350: Registering SpiHw8 instances");
 
     // Create 2 logical SPI buses (each uses separate PIO state machine)
     static auto controller0 = fl::make_shared<SpiHw8RP2040>(0, "SPI0");
@@ -80,7 +80,7 @@ static void addSpiHw8IfPossible() {
     SpiHw8::registerInstance(controller0);
     SpiHw8::registerInstance(controller1);
 
-    FL_DBG("RP2040/RP2350: SpiHw8 instances registered");
+    FL_DBG_F("RP2040/RP2350: SpiHw8 instances registered");
 }
 
 }  // namespace detail
@@ -101,14 +101,14 @@ namespace platforms {
 /// - RP2040: All three (2 PIO blocks × 4 state machines = 8 total)
 /// - RP2350: All three (3 PIO blocks × 4 state machines = 12 total)
 void initSpiHardware() {
-    FL_DBG("RP2040/RP2350: Initializing SPI hardware");
+    FL_DBG_F("RP2040/RP2350: Initializing SPI hardware");
 
     // Register in priority order (highest to lowest)
     detail::addSpiHw8IfPossible();  // Priority 8
     detail::addSpiHw4IfPossible();  // Priority 7
     detail::addSpiHw2IfPossible();  // Priority 6
 
-    FL_DBG("RP2040/RP2350: SPI hardware initialized");
+    FL_DBG_F("RP2040/RP2350: SPI hardware initialized");
 }
 
 }  // namespace platforms

--- a/src/platforms/arm/rp/semaphore_rp.cpp.hpp
+++ b/src/platforms/arm/rp/semaphore_rp.cpp.hpp
@@ -43,7 +43,7 @@ CountingSemaphoreRP<LeastMaxValue>::CountingSemaphoreRP(ptrdiff_t desired)
     int spinlock_num = spin_lock_claim_unused(true);  // true = required (panic if none available)
 
     if (spinlock_num < 0) {
-        FL_WARN("CountingSemaphoreRP: Failed to claim hardware spinlock");
+        FL_WARN_F("CountingSemaphoreRP: Failed to claim hardware spinlock");
         return;
     }
 

--- a/src/platforms/arm/sam/spi_device_proxy.h
+++ b/src/platforms/arm/sam/spi_device_proxy.h
@@ -93,8 +93,7 @@ public:
         mHandle = mBusManager->registerDevice(CLOCK_PIN, DATA_PIN, spi_speed_hz, this);
 
         if (!mHandle.is_valid) {
-            FL_WARN("SPIDeviceProxy: Failed to register with bus manager (pin "
-                    << static_cast<int>(CLOCK_PIN) << ":" << static_cast<int>(DATA_PIN) << ")");
+            FL_WARN_F("SPIDeviceProxy: Failed to register with bus manager (pin %s:%s)", static_cast<int>(CLOCK_PIN), static_cast<int>(DATA_PIN));
             return;
         }
 

--- a/src/platforms/arm/samd/isr_samd.hpp
+++ b/src/platforms/arm/samd/isr_samd.hpp
@@ -368,26 +368,26 @@ extern "C" {
 
 int attach_timer_handler(const isr_config_t& config, isr_handle_t* out_handle) FL_NOEXCEPT {
     if (!config.handler) {
-        FL_WARN("attachTimerHandler: handler is null");
+        FL_WARN_F("attachTimerHandler: handler is null");
         return -1;  // Invalid parameter
     }
 
     if (config.frequency_hz == 0) {
-        FL_WARN("attachTimerHandler: frequency_hz is 0");
+        FL_WARN_F("attachTimerHandler: frequency_hz is 0");
         return -2;  // Invalid frequency
     }
 
     // Allocate a free timer
     u8 timer_idx = 0;
     if (!allocate_timer(timer_idx)) {
-        FL_WARN("attachTimerHandler: no free timers");
+        FL_WARN_F("attachTimerHandler: no free timers");
         return -3;  // Out of resources
     }
 
     Tc* timer = get_timer_instance(timer_idx);
     if (!timer) {
         free_timer(timer_idx);
-        FL_WARN("attachTimerHandler: invalid timer instance");
+        FL_WARN_F("attachTimerHandler: invalid timer instance");
         return -4;  // Internal error
     }
 
@@ -396,7 +396,7 @@ int attach_timer_handler(const isr_config_t& config, isr_handle_t* out_handle) F
     auto* handle_data = handle_owner.get();
     if (!handle_data) {
         free_timer(timer_idx);
-        FL_WARN("attachTimerHandler: failed to allocate handle data");
+        FL_WARN_F("attachTimerHandler: failed to allocate handle data");
         return -5;  // Out of memory
     }
 
@@ -506,7 +506,7 @@ int attach_timer_handler(const isr_config_t& config, isr_handle_t* out_handle) F
     timer->COUNT16.CTRLA.reg |= TC_CTRLA_ENABLE;
     tc_wait_sync(timer);
 
-    FL_DBG("Timer started at " << config.frequency_hz << " Hz on TC" << static_cast<int>(timer_idx));
+    FL_DBG_F("Timer started at %s Hz on TC%s", config.frequency_hz, static_cast<int>(timer_idx));
 
     // Release ownership - pointer is now managed by the C API (timer_handles + out_handle)
     handle_owner.release();
@@ -524,14 +524,14 @@ int attach_timer_handler(const isr_config_t& config, isr_handle_t* out_handle) F
 
 int attach_external_handler(u8 pin, const isr_config_t& config, isr_handle_t* out_handle) FL_NOEXCEPT {
     if (!config.handler) {
-        FL_WARN("attachExternalHandler: handler is null");
+        FL_WARN_F("attachExternalHandler: handler is null");
         return -1;  // Invalid parameter
     }
 
     // Allocate an EIC channel
     u8 eic_ch = 0;
     if (!allocate_eic_channel(eic_ch)) {
-        FL_WARN("attachExternalHandler: no free EIC channels");
+        FL_WARN_F("attachExternalHandler: no free EIC channels");
         return -3;  // Out of resources
     }
 
@@ -540,7 +540,7 @@ int attach_external_handler(u8 pin, const isr_config_t& config, isr_handle_t* ou
     auto* handle_data = handle_owner.get();
     if (!handle_data) {
         free_eic_channel(eic_ch);
-        FL_WARN("attachExternalHandler: failed to allocate handle data");
+        FL_WARN_F("attachExternalHandler: failed to allocate handle data");
         return -5;  // Out of memory
     }
 
@@ -639,8 +639,7 @@ int attach_external_handler(u8 pin, const isr_config_t& config, isr_handle_t* ou
     NVIC_SetPriority(EIC_IRQn, nvic_priority) FL_NOEXCEPT;
     NVIC_EnableIRQ(EIC_IRQn) FL_NOEXCEPT;
 
-    FL_DBG("EIC interrupt attached on pin " << static_cast<int>(pin)
-           << " EIC channel " << static_cast<int>(eic_ch));
+    FL_DBG_F("EIC interrupt attached on pin %s EIC channel %s", static_cast<int>(pin), static_cast<int>(eic_ch));
 
     // Release ownership - pointer is now managed by the C API (eic_handles + out_handle)
     handle_owner.release();
@@ -658,13 +657,13 @@ int attach_external_handler(u8 pin, const isr_config_t& config, isr_handle_t* ou
 
 int detach_handler(isr_handle_t& handle) FL_NOEXCEPT {
     if (!handle.is_valid() || handle.platform_id != SAMD_PLATFORM_ID) {
-        FL_WARN("detachHandler: invalid handle");
+        FL_WARN_F("detachHandler: invalid handle");
         return -1;  // Invalid handle
     }
 
     samd_isr_handle_data* handle_data = static_cast<samd_isr_handle_data*>(handle.platform_handle);
     if (!handle_data) {
-        FL_WARN("detachHandler: null handle data");
+        FL_WARN_F("detachHandler: null handle data");
         return -1;  // Invalid handle
     }
 
@@ -691,19 +690,19 @@ int detach_handler(isr_handle_t& handle) FL_NOEXCEPT {
     handle.platform_handle = nullptr;
     handle.platform_id = 0;
 
-    FL_DBG("Handler detached");
+    FL_DBG_F("Handler detached");
     return 0;  // Success
 }
 
 int enable_handler(const isr_handle_t& handle) FL_NOEXCEPT {
     if (!handle.is_valid() || handle.platform_id != SAMD_PLATFORM_ID) {
-        FL_WARN("enableHandler: invalid handle");
+        FL_WARN_F("enableHandler: invalid handle");
         return -1;  // Invalid handle
     }
 
     samd_isr_handle_data* handle_data = static_cast<samd_isr_handle_data*>(handle.platform_handle);
     if (!handle_data) {
-        FL_WARN("enableHandler: null handle data");
+        FL_WARN_F("enableHandler: null handle data");
         return -1;  // Invalid handle
     }
 
@@ -724,13 +723,13 @@ int enable_handler(const isr_handle_t& handle) FL_NOEXCEPT {
 
 int disable_handler(const isr_handle_t& handle) FL_NOEXCEPT {
     if (!handle.is_valid() || handle.platform_id != SAMD_PLATFORM_ID) {
-        FL_WARN("disableHandler: invalid handle");
+        FL_WARN_F("disableHandler: invalid handle");
         return -1;  // Invalid handle
     }
 
     samd_isr_handle_data* handle_data = static_cast<samd_isr_handle_data*>(handle.platform_handle);
     if (!handle_data) {
-        FL_WARN("disableHandler: null handle data");
+        FL_WARN_F("disableHandler: null handle data");
         return -1;  // Invalid handle
     }
 

--- a/src/platforms/arm/stm32/drivers/spi_hw_2_stm32.cpp.hpp
+++ b/src/platforms/arm/stm32/drivers/spi_hw_2_stm32.cpp.hpp
@@ -229,13 +229,13 @@ bool SPIDualSTM32::begin(const SpiHw2::Config& config) {
 
     // Validate bus_num against mBusId if driver has pre-assigned ID
     if (mBusId != -1 && config.bus_num != static_cast<u8>(mBusId)) {
-        FL_WARN("SPIDualSTM32: Bus ID mismatch");
+        FL_WARN_F("SPIDualSTM32: Bus ID mismatch");
         return false;
     }
 
     // Validate pin assignments
     if (config.clock_pin < 0 || config.data0_pin < 0 || config.data1_pin < 0) {
-        FL_WARN("SPIDualSTM32: Invalid pin configuration");
+        FL_WARN_F("SPIDualSTM32: Invalid pin configuration");
         return false;
     }
 
@@ -247,15 +247,15 @@ bool SPIDualSTM32::begin(const SpiHw2::Config& config) {
 
     // Validate pins using GPIO helper functions
     if (!isValidPin(mClockPin)) {
-        FL_WARN("SPIDualSTM32: Invalid clock pin " << static_cast<int>(mClockPin));
+        FL_WARN_F("SPIDualSTM32: Invalid clock pin %s", static_cast<int>(mClockPin));
         return false;
     }
     if (!isValidPin(mData0Pin)) {
-        FL_WARN("SPIDualSTM32: Invalid data0 pin " << static_cast<int>(mData0Pin));
+        FL_WARN_F("SPIDualSTM32: Invalid data0 pin %s", static_cast<int>(mData0Pin));
         return false;
     }
     if (!isValidPin(mData1Pin)) {
-        FL_WARN("SPIDualSTM32: Invalid data1 pin " << static_cast<int>(mData1Pin));
+        FL_WARN_F("SPIDualSTM32: Invalid data1 pin %s", static_cast<int>(mData1Pin));
         return false;
     }
 
@@ -263,18 +263,18 @@ bool SPIDualSTM32::begin(const SpiHw2::Config& config) {
 #ifdef HAL_GPIO_MODULE_ENABLED
     // Configure data pins as outputs
     if (!configurePinAsOutput(mData0Pin, GPIO_SPEED_FREQ_HIGH)) {
-        FL_WARN("SPIDualSTM32: Failed to configure data0 pin");
+        FL_WARN_F("SPIDualSTM32: Failed to configure data0 pin");
         return false;
     }
     if (!configurePinAsOutput(mData1Pin, GPIO_SPEED_FREQ_HIGH)) {
-        FL_WARN("SPIDualSTM32: Failed to configure data1 pin");
+        FL_WARN_F("SPIDualSTM32: Failed to configure data1 pin");
         return false;
     }
 
-    FL_DBG("SPIDualSTM32: GPIO pins configured successfully");
-    FL_DBG("  Clock pin: " << static_cast<int>(mClockPin));
-    FL_DBG("  Data0 pin: " << static_cast<int>(mData0Pin));
-    FL_DBG("  Data1 pin: " << static_cast<int>(mData1Pin));
+    FL_DBG_F("SPIDualSTM32: GPIO pins configured successfully");
+    FL_DBG_F("  Clock pin: %s", static_cast<int>(mClockPin));
+    FL_DBG_F("  Data0 pin: %s", static_cast<int>(mData0Pin));
+    FL_DBG_F("  Data1 pin: %s", static_cast<int>(mData1Pin));
 #endif
 
     // Configure Timer for clock generation
@@ -282,31 +282,31 @@ bool SPIDualSTM32::begin(const SpiHw2::Config& config) {
     // Select timer based on bus_id
     mTimer = selectTimer(mBusId);
     if (mTimer == nullptr) {
-        FL_WARN("SPIDualSTM32: Failed to select timer for bus " << mBusId);
+        FL_WARN_F("SPIDualSTM32: Failed to select timer for bus %s", mBusId);
         return false;
     }
 
     // Initialize timer for PWM clock generation
     if (!initTimerPWM(&mTimerHandle, mTimer, mClockSpeedHz)) {
-        FL_WARN("SPIDualSTM32: Failed to initialize timer PWM");
+        FL_WARN_F("SPIDualSTM32: Failed to initialize timer PWM");
         mTimer = nullptr;
         return false;
     }
 
     // Configure clock pin as timer alternate function
     if (!configurePinAsTimerAF(mClockPin, mTimer, FASTLED_GPIO_SPEED_MAX)) {
-        FL_WARN("SPIDualSTM32: Failed to configure clock pin as timer AF");
+        FL_WARN_F("SPIDualSTM32: Failed to configure clock pin as timer AF");
         mTimer = nullptr;
         return false;
     }
 
-    FL_DBG("SPIDualSTM32: Timer configured successfully");
-    FL_DBG("  Timer: TIM" << ((mTimer == TIM2) ? "2" : (mTimer == TIM3) ? "3" : (mTimer == TIM4) ? "4"
+    FL_DBG_F("SPIDualSTM32: Timer configured successfully");
+    FL_DBG_F("  Timer: TIM%s", ((mTimer == TIM2) ? "2" : (mTimer == TIM3) ? "3" : (mTimer == TIM4) ? "4"
 #ifdef FASTLED_STM32_HAS_TIM5
          : (mTimer == TIM5) ? "5"
 #endif
          : "?"));
-    FL_DBG("  Clock speed: " << mClockSpeedHz << " Hz");
+    FL_DBG_F("  Clock speed: %s Hz", mClockSpeedHz);
 #endif
 
     // Configure DMA streams for data lanes
@@ -316,7 +316,7 @@ bool SPIDualSTM32::begin(const SpiHw2::Config& config) {
     mDMAStream1 = getDMAStream(mTimer, mBusId, 1);
 
     if (mDMAStream0 == nullptr || mDMAStream1 == nullptr) {
-        FL_WARN("SPIDualSTM32: Failed to select DMA streams for bus " << mBusId);
+        FL_WARN_F("SPIDualSTM32: Failed to select DMA streams for bus %s", mBusId);
         mTimer = nullptr;
         mDMAStream0 = nullptr;
         mDMAStream1 = nullptr;
@@ -326,7 +326,7 @@ bool SPIDualSTM32::begin(const SpiHw2::Config& config) {
     // Get DMA channel number for timer update event
     u32 dma_channel = getDMAChannel(mTimer);
     if (dma_channel == 0xFF) {
-        FL_WARN("SPIDualSTM32: Failed to get DMA channel for timer");
+        FL_WARN_F("SPIDualSTM32: Failed to get DMA channel for timer");
         mTimer = nullptr;
         mDMAStream0 = nullptr;
         mDMAStream1 = nullptr;
@@ -337,16 +337,16 @@ bool SPIDualSTM32::begin(const SpiHw2::Config& config) {
     enableDMAClock(getDMAController(mDMAStream0));
     enableDMAClock(getDMAController(mDMAStream1));
 
-    FL_DBG("SPIDualSTM32: DMA streams selected successfully");
-    FL_DBG("  Stream 0: " << (void*)mDMAStream0);
-    FL_DBG("  Stream 1: " << (void*)mDMAStream1);
-    FL_DBG("  DMA channel: " << dma_channel);
+    FL_DBG_F("SPIDualSTM32: DMA streams selected successfully");
+    FL_DBG_F("  Stream 0: %s", (void*)mDMAStream0);
+    FL_DBG_F("  Stream 1: %s", (void*)mDMAStream1);
+    FL_DBG_F("  DMA channel: %s", dma_channel);
 
     // Note: DMA stream configuration (addresses, sizes) happens in transmit()
     // because we need to know the buffer addresses and sizes at that time.
     // Here we just allocate the streams and verify they're available.
 #else
-    FL_WARN("SPIDualSTM32: DMA not supported on this platform");
+    FL_WARN_F("SPIDualSTM32: DMA not supported on this platform");
     mTimer = nullptr;
     return false;
 #endif
@@ -355,7 +355,7 @@ bool SPIDualSTM32::begin(const SpiHw2::Config& config) {
     mInitialized = true;
     mTransactionActive = false;
 
-    FL_DBG("SPIDualSTM32: Hardware initialization complete");
+    FL_DBG_F("SPIDualSTM32: Hardware initialization complete");
     return true;
 }
 
@@ -430,13 +430,13 @@ bool SPIDualSTM32::allocateDMABuffer(size_t required_size) {
     // Using malloc with alignment - consider using aligned_alloc() or memalign() if available
     mDMABuffer0 = fl::malloc(required_size);
     if (mDMABuffer0 == nullptr) {
-        FL_WARN("SPIDualSTM32: Failed to allocate DMA buffer 0");
+        FL_WARN_F("SPIDualSTM32: Failed to allocate DMA buffer 0");
         return false;
     }
 
     mDMABuffer1 = fl::malloc(required_size);
     if (mDMABuffer1 == nullptr) {
-        FL_WARN("SPIDualSTM32: Failed to allocate DMA buffer 1");
+        FL_WARN_F("SPIDualSTM32: Failed to allocate DMA buffer 1");
         fl::free(mDMABuffer0);
         mDMABuffer0 = nullptr;
         return false;
@@ -526,14 +526,14 @@ bool SPIDualSTM32::transmit(TransmitMode mode) {
     GPIO_TypeDef* port1 = getGPIOPort(mData1Pin);
 
     if (port0 == nullptr || port1 == nullptr) {
-        FL_WARN("SPIDualSTM32: Failed to get GPIO ports for data pins");
+        FL_WARN_F("SPIDualSTM32: Failed to get GPIO ports for data pins");
         return false;
     }
 
     // Get DMA channel number for timer update event
     u32 dma_channel = getDMAChannel(mTimer);
     if (dma_channel == 0xFF) {
-        FL_WARN("SPIDualSTM32: Failed to get DMA channel for timer");
+        FL_WARN_F("SPIDualSTM32: Failed to get DMA channel for timer");
         return false;
     }
 
@@ -544,14 +544,14 @@ bool SPIDualSTM32::transmit(TransmitMode mode) {
     // Configure and start DMA stream 0 (lane 0)
     volatile void* odr0 = (volatile void*)&port0->ODR;
     if (!initDMA(mDMAStream0, mDMABuffer0, odr0, buffer_size_per_lane, dma_channel)) {
-        FL_WARN("SPIDualSTM32: Failed to initialize DMA stream 0");
+        FL_WARN_F("SPIDualSTM32: Failed to initialize DMA stream 0");
         return false;
     }
 
     // Configure and start DMA stream 1 (lane 1)
     volatile void* odr1 = (volatile void*)&port1->ODR;
     if (!initDMA(mDMAStream1, mDMABuffer1, odr1, buffer_size_per_lane, dma_channel)) {
-        FL_WARN("SPIDualSTM32: Failed to initialize DMA stream 1");
+        FL_WARN_F("SPIDualSTM32: Failed to initialize DMA stream 1");
         stopDMA(mDMAStream0);  // Stop stream 0 since we're aborting
         return false;
     }
@@ -563,21 +563,21 @@ bool SPIDualSTM32::transmit(TransmitMode mode) {
 
     // Start timer PWM to trigger DMA transfers
     if (!startTimer(&mTimerHandle)) {
-        FL_WARN("SPIDualSTM32: Failed to start timer");
+        FL_WARN_F("SPIDualSTM32: Failed to start timer");
         stopDMA(mDMAStream0);
         stopDMA(mDMAStream1);
         __HAL_TIM_DISABLE_DMA(&htim, TIM_DMA_UPDATE);
         return false;
     }
 
-    FL_DBG("SPIDualSTM32: DMA transmission started");
-    FL_DBG("  Buffer size per lane: " << buffer_size_per_lane << " bytes");
-    FL_DBG("  Total bytes: " << mCurrentTotalSize);
+    FL_DBG_F("SPIDualSTM32: DMA transmission started");
+    FL_DBG_F("  Buffer size per lane: %s bytes", buffer_size_per_lane);
+    FL_DBG_F("  Total bytes: %s", mCurrentTotalSize);
 
     mTransactionActive = true;
     return true;
 #else
-    FL_WARN("SPIDualSTM32: DMA not supported on this platform");
+    FL_WARN_F("SPIDualSTM32: DMA not supported on this platform");
     return false;
 #endif
 }
@@ -600,7 +600,7 @@ bool SPIDualSTM32::waitComplete(u32 timeout_ms) {
 
         // Check if both streams completed
         if (stream0_complete && stream1_complete) {
-            FL_DBG("SPIDualSTM32: DMA transfer complete");
+            FL_DBG_F("SPIDualSTM32: DMA transfer complete");
             break;
         }
 
@@ -608,7 +608,7 @@ bool SPIDualSTM32::waitComplete(u32 timeout_ms) {
         if (timeout_enabled) {
             u32 elapsed_ms = fl::millis() - start_ms;
             if (elapsed_ms >= timeout_ms) {
-                FL_WARN("SPIDualSTM32: DMA transfer timeout after " << elapsed_ms << " ms");
+                FL_WARN_F("SPIDualSTM32: DMA transfer timeout after %s ms", elapsed_ms);
 
                 // Emergency stop: disable DMA and timer
                 stopDMA(mDMAStream0);
@@ -644,7 +644,7 @@ bool SPIDualSTM32::waitComplete(u32 timeout_ms) {
     clearDMAFlags(mDMAStream0);
     clearDMAFlags(mDMAStream1);
 
-    FL_DBG("SPIDualSTM32: Timer and DMA stopped successfully");
+    FL_DBG_F("SPIDualSTM32: Timer and DMA stopped successfully");
 
     mTransactionActive = false;
 

--- a/src/platforms/arm/stm32/drivers/spi_hw_4_stm32.cpp.hpp
+++ b/src/platforms/arm/stm32/drivers/spi_hw_4_stm32.cpp.hpp
@@ -220,14 +220,14 @@ bool SPIQuadSTM32::begin(const SpiHw4::Config& config) {
 
     // Validate bus_num against mBusId if driver has pre-assigned ID
     if (mBusId != -1 && config.bus_num != static_cast<u8>(mBusId)) {
-        FL_WARN("SPIQuadSTM32: Bus ID mismatch");
+        FL_WARN_F("SPIQuadSTM32: Bus ID mismatch");
         return false;
     }
 
     // Validate pin assignments - require clock and all 4 data pins for full quad mode
     if (config.clock_pin < 0 || config.data0_pin < 0 || config.data1_pin < 0 ||
         config.data2_pin < 0 || config.data3_pin < 0) {
-        FL_WARN("SPIQuadSTM32: Invalid pin configuration (clock and D0-D3 required)");
+        FL_WARN_F("SPIQuadSTM32: Invalid pin configuration (clock and D0-D3 required)");
         return false;
     }
 
@@ -241,23 +241,23 @@ bool SPIQuadSTM32::begin(const SpiHw4::Config& config) {
 
     // Validate all pins using GPIO helper functions
     if (!isValidPin(mClockPin)) {
-        FL_WARN("SPIQuadSTM32: Invalid clock pin " << static_cast<int>(mClockPin));
+        FL_WARN_F("SPIQuadSTM32: Invalid clock pin %s", static_cast<int>(mClockPin));
         return false;
     }
     if (!isValidPin(mData0Pin)) {
-        FL_WARN("SPIQuadSTM32: Invalid data0 pin " << static_cast<int>(mData0Pin));
+        FL_WARN_F("SPIQuadSTM32: Invalid data0 pin %s", static_cast<int>(mData0Pin));
         return false;
     }
     if (!isValidPin(mData1Pin)) {
-        FL_WARN("SPIQuadSTM32: Invalid data1 pin " << static_cast<int>(mData1Pin));
+        FL_WARN_F("SPIQuadSTM32: Invalid data1 pin %s", static_cast<int>(mData1Pin));
         return false;
     }
     if (!isValidPin(mData2Pin)) {
-        FL_WARN("SPIQuadSTM32: Invalid data2 pin " << static_cast<int>(mData2Pin));
+        FL_WARN_F("SPIQuadSTM32: Invalid data2 pin %s", static_cast<int>(mData2Pin));
         return false;
     }
     if (!isValidPin(mData3Pin)) {
-        FL_WARN("SPIQuadSTM32: Invalid data3 pin " << static_cast<int>(mData3Pin));
+        FL_WARN_F("SPIQuadSTM32: Invalid data3 pin %s", static_cast<int>(mData3Pin));
         return false;
     }
 
@@ -265,28 +265,25 @@ bool SPIQuadSTM32::begin(const SpiHw4::Config& config) {
 #ifdef HAL_GPIO_MODULE_ENABLED
     // Configure all 4 data pins as outputs
     if (!configurePinAsOutput(mData0Pin, GPIO_SPEED_FREQ_HIGH)) {
-        FL_WARN("SPIQuadSTM32: Failed to configure data0 pin");
+        FL_WARN_F("SPIQuadSTM32: Failed to configure data0 pin");
         return false;
     }
     if (!configurePinAsOutput(mData1Pin, GPIO_SPEED_FREQ_HIGH)) {
-        FL_WARN("SPIQuadSTM32: Failed to configure data1 pin");
+        FL_WARN_F("SPIQuadSTM32: Failed to configure data1 pin");
         return false;
     }
     if (!configurePinAsOutput(mData2Pin, GPIO_SPEED_FREQ_HIGH)) {
-        FL_WARN("SPIQuadSTM32: Failed to configure data2 pin");
+        FL_WARN_F("SPIQuadSTM32: Failed to configure data2 pin");
         return false;
     }
     if (!configurePinAsOutput(mData3Pin, GPIO_SPEED_FREQ_HIGH)) {
-        FL_WARN("SPIQuadSTM32: Failed to configure data3 pin");
+        FL_WARN_F("SPIQuadSTM32: Failed to configure data3 pin");
         return false;
     }
 
-    FL_DBG("SPIQuadSTM32: GPIO pins configured successfully");
-    FL_DBG("  Clock pin: " << static_cast<int>(mClockPin));
-    FL_DBG("  Data pins: " << static_cast<int>(mData0Pin) << ", "
-                           << static_cast<int>(mData1Pin) << ", "
-                           << static_cast<int>(mData2Pin) << ", "
-                           << static_cast<int>(mData3Pin));
+    FL_DBG_F("SPIQuadSTM32: GPIO pins configured successfully");
+    FL_DBG_F("  Clock pin: %s", static_cast<int>(mClockPin));
+    FL_DBG_F("  Data pins: %s, %s, %s, %s", static_cast<int>(mData0Pin), static_cast<int>(mData1Pin), static_cast<int>(mData2Pin), static_cast<int>(mData3Pin));
 #endif
 
     // TODO: Implement remaining hardware initialization
@@ -302,8 +299,8 @@ bool SPIQuadSTM32::begin(const SpiHw4::Config& config) {
     // 3. Start Timer
 
     // For now, return error until Timer/DMA implementation is added
-    FL_WARN("SPIQuadSTM32: Timer/DMA initialization not yet implemented");
-    FL_WARN("SPIQuadSTM32: GPIO configuration complete - hardware integration not complete");
+    FL_WARN_F("SPIQuadSTM32: Timer/DMA initialization not yet implemented");
+    FL_WARN_F("SPIQuadSTM32: GPIO configuration complete - hardware integration not complete");
 
     // Uncomment when Timer/DMA implementation is ready:
     // mInitialized = true;
@@ -391,13 +388,13 @@ bool SPIQuadSTM32::allocateDMABuffer(size_t required_size) {
     // Allocate new buffers (word-aligned for DMA requirements)
     mDMABuffer0 = fl::malloc(required_size);
     if (mDMABuffer0 == nullptr) {
-        FL_WARN("SPIQuadSTM32: Failed to allocate DMA buffer 0");
+        FL_WARN_F("SPIQuadSTM32: Failed to allocate DMA buffer 0");
         return false;
     }
 
     mDMABuffer1 = fl::malloc(required_size);
     if (mDMABuffer1 == nullptr) {
-        FL_WARN("SPIQuadSTM32: Failed to allocate DMA buffer 1");
+        FL_WARN_F("SPIQuadSTM32: Failed to allocate DMA buffer 1");
         fl::free(mDMABuffer0);
         mDMABuffer0 = nullptr;
         return false;
@@ -405,7 +402,7 @@ bool SPIQuadSTM32::allocateDMABuffer(size_t required_size) {
 
     mDMABuffer2 = fl::malloc(required_size);
     if (mDMABuffer2 == nullptr) {
-        FL_WARN("SPIQuadSTM32: Failed to allocate DMA buffer 2");
+        FL_WARN_F("SPIQuadSTM32: Failed to allocate DMA buffer 2");
         fl::free(mDMABuffer0);
         fl::free(mDMABuffer1);
         mDMABuffer0 = nullptr;
@@ -415,7 +412,7 @@ bool SPIQuadSTM32::allocateDMABuffer(size_t required_size) {
 
     mDMABuffer3 = fl::malloc(required_size);
     if (mDMABuffer3 == nullptr) {
-        FL_WARN("SPIQuadSTM32: Failed to allocate DMA buffer 3");
+        FL_WARN_F("SPIQuadSTM32: Failed to allocate DMA buffer 3");
         fl::free(mDMABuffer0);
         fl::free(mDMABuffer1);
         fl::free(mDMABuffer2);
@@ -531,7 +528,7 @@ bool SPIQuadSTM32::transmit(TransmitMode mode) {
     // 5. Start Timer to trigger all 4 DMA channels at clock rate
     // 6. Set mTransactionActive = true
 
-    FL_WARN("SPIQuadSTM32: DMA transfer not yet implemented");
+    FL_WARN_F("SPIQuadSTM32: DMA transfer not yet implemented");
 
     // Uncomment when implementation is ready:
     // mTransactionActive = true;

--- a/src/platforms/arm/stm32/drivers/spi_hw_8_stm32.cpp.hpp
+++ b/src/platforms/arm/stm32/drivers/spi_hw_8_stm32.cpp.hpp
@@ -226,7 +226,7 @@ bool SPIOctalSTM32::begin(const SpiHw8::Config& config) {
 
     // Validate bus_num against mBusId if driver has pre-assigned ID
     if (mBusId != -1 && config.bus_num != static_cast<u8>(mBusId)) {
-        FL_WARN("SPIOctalSTM32: Bus ID mismatch");
+        FL_WARN_F("SPIOctalSTM32: Bus ID mismatch");
         return false;
     }
 
@@ -234,7 +234,7 @@ bool SPIOctalSTM32::begin(const SpiHw8::Config& config) {
     if (config.clock_pin < 0 || config.data0_pin < 0 || config.data1_pin < 0 ||
         config.data2_pin < 0 || config.data3_pin < 0 || config.data4_pin < 0 ||
         config.data5_pin < 0 || config.data6_pin < 0 || config.data7_pin < 0) {
-        FL_WARN("SPIOctalSTM32: Invalid pin configuration (all 8 data pins + clock required)");
+        FL_WARN_F("SPIOctalSTM32: Invalid pin configuration (all 8 data pins + clock required)");
         return false;
     }
 
@@ -252,12 +252,12 @@ bool SPIOctalSTM32::begin(const SpiHw8::Config& config) {
 
     // Validate all pins using GPIO helper functions
     if (!isValidPin(mClockPin)) {
-        FL_WARN("SPIOctalSTM32: Invalid clock pin " << static_cast<int>(mClockPin));
+        FL_WARN_F("SPIOctalSTM32: Invalid clock pin %s", static_cast<int>(mClockPin));
         return false;
     }
     for (int i = 0; i < 8; ++i) {
         if (!isValidPin(mDataPins[i])) {
-            FL_WARN("SPIOctalSTM32: Invalid data pin " << i << ": " << static_cast<int>(mDataPins[i]));
+            FL_WARN_F("SPIOctalSTM32: Invalid data pin %s: %s", i, static_cast<int>(mDataPins[i]));
             return false;
         }
     }
@@ -267,17 +267,14 @@ bool SPIOctalSTM32::begin(const SpiHw8::Config& config) {
     // Configure all 8 data pins as outputs
     for (int i = 0; i < 8; ++i) {
         if (!configurePinAsOutput(mDataPins[i], GPIO_SPEED_FREQ_HIGH)) {
-            FL_WARN("SPIOctalSTM32: Failed to configure data pin " << i);
+            FL_WARN_F("SPIOctalSTM32: Failed to configure data pin %s", i);
             return false;
         }
     }
 
-    FL_DBG("SPIOctalSTM32: GPIO pins configured successfully");
-    FL_DBG("  Clock pin: " << static_cast<int>(mClockPin));
-    FL_DBG("  Data pins: " << static_cast<int>(mDataPins[0]) << ", " << static_cast<int>(mDataPins[1]) << ", "
-                           << static_cast<int>(mDataPins[2]) << ", " << static_cast<int>(mDataPins[3]) << ", "
-                           << static_cast<int>(mDataPins[4]) << ", " << static_cast<int>(mDataPins[5]) << ", "
-                           << static_cast<int>(mDataPins[6]) << ", " << static_cast<int>(mDataPins[7]));
+    FL_DBG_F("SPIOctalSTM32: GPIO pins configured successfully");
+    FL_DBG_F("  Clock pin: %s", static_cast<int>(mClockPin));
+    FL_DBG_F("  Data pins: %s, %s, %s, %s, %s, %s, %s, %s", static_cast<int>(mDataPins[0]), static_cast<int>(mDataPins[1]), static_cast<int>(mDataPins[2]), static_cast<int>(mDataPins[3]), static_cast<int>(mDataPins[4]), static_cast<int>(mDataPins[5]), static_cast<int>(mDataPins[6]), static_cast<int>(mDataPins[7]));
 #endif
 
     // TODO: Implement remaining hardware initialization
@@ -292,8 +289,8 @@ bool SPIOctalSTM32::begin(const SpiHw8::Config& config) {
     //    - Link all DMA channels to Timer Update event
     // 3. Start Timer
 
-    FL_WARN("SPIOctalSTM32: Timer/DMA initialization not yet implemented");
-    FL_WARN("SPIOctalSTM32: GPIO configuration complete - hardware integration not complete");
+    FL_WARN_F("SPIOctalSTM32: Timer/DMA initialization not yet implemented");
+    FL_WARN_F("SPIOctalSTM32: GPIO configuration complete - hardware integration not complete");
 
     // Uncomment when Timer/DMA implementation is ready:
     // mInitialized = true;
@@ -372,7 +369,7 @@ bool SPIOctalSTM32::allocateDMABuffer(size_t required_size) {
     for (int i = 0; i < 8; ++i) {
         mDMABuffers[i] = (u8*)fl::malloc(required_size);
         if (mDMABuffers[i] == nullptr) {
-            FL_WARN("SPIOctalSTM32: Failed to allocate DMA buffer for lane " << i);
+            FL_WARN_F("SPIOctalSTM32: Failed to allocate DMA buffer for lane %s", i);
             // Free any buffers that were successfully allocated
             for (int j = 0; j < i; ++j) {
                 fl::free(mDMABuffers[j]);

--- a/src/platforms/arm/stm32/drivers/spi_hw_manager_stm32.cpp.hpp
+++ b/src/platforms/arm/stm32/drivers/spi_hw_manager_stm32.cpp.hpp
@@ -45,7 +45,7 @@ constexpr int PRIORITY_SPI_HW_2 = 6;   // Lowest (2-lane dual-SPI)
 /// @brief Register STM32 SpiHw2 instances if available
 static void addSpiHw2IfPossible() {
 #ifdef FL_STM32_HAS_SPI_HW_2
-    FL_DBG("STM32: Registering SpiHw2 instances");
+    FL_DBG_F("STM32: Registering SpiHw2 instances");
 
     // Create logical SPI buses based on available Timer/DMA resources
     static auto controller0 = fl::make_shared<SPIDualSTM32>(0, "DSPI0");
@@ -54,17 +54,17 @@ static void addSpiHw2IfPossible() {
     SpiHw2::registerInstance(controller0);
     SpiHw2::registerInstance(controller1);
 
-    FL_DBG("STM32: SpiHw2 instances registered");
+    FL_DBG_F("STM32: SpiHw2 instances registered");
 #else
     // No-op if FL_STM32_HAS_SPI_HW_2 not defined
-    FL_DBG("STM32: SpiHw2 not available (stream-based DMA required)");
+    FL_DBG_F("STM32: SpiHw2 not available (stream-based DMA required)");
 #endif
 }
 
 /// @brief Register STM32 SpiHw4 instances if available
 static void addSpiHw4IfPossible() {
 #ifdef FL_STM32_HAS_SPI_HW_4
-    FL_DBG("STM32: Registering SpiHw4 instances");
+    FL_DBG_F("STM32: Registering SpiHw4 instances");
 
     // Create logical SPI buses based on available Timer/DMA resources
     static auto controller0 = fl::make_shared<SPIQuadSTM32>(0, "QSPI0");
@@ -73,17 +73,17 @@ static void addSpiHw4IfPossible() {
     SpiHw4::registerInstance(controller0);
     SpiHw4::registerInstance(controller1);
 
-    FL_DBG("STM32: SpiHw4 instances registered");
+    FL_DBG_F("STM32: SpiHw4 instances registered");
 #else
     // No-op if FL_STM32_HAS_SPI_HW_4 not defined
-    FL_DBG("STM32: SpiHw4 not available (stream-based DMA required)");
+    FL_DBG_F("STM32: SpiHw4 not available (stream-based DMA required)");
 #endif
 }
 
 /// @brief Register STM32 SpiHw8 instances if available
 static void addSpiHw8IfPossible() {
 #ifdef FL_STM32_HAS_SPI_HW_8
-    FL_DBG("STM32: Registering SpiHw8 instances");
+    FL_DBG_F("STM32: Registering SpiHw8 instances");
 
     // Create 2 logical octal-SPI buses
     static auto controller0 = fl::make_shared<SPIOctalSTM32>(0, "OSPI0");
@@ -92,10 +92,10 @@ static void addSpiHw8IfPossible() {
     SpiHw8::registerInstance(controller0);
     SpiHw8::registerInstance(controller1);
 
-    FL_DBG("STM32: SpiHw8 instances registered");
+    FL_DBG_F("STM32: SpiHw8 instances registered");
 #else
     // No-op if FL_STM32_HAS_SPI_HW_8 not defined
-    FL_DBG("STM32: SpiHw8 not available (stream-based DMA required)");
+    FL_DBG_F("STM32: SpiHw8 not available (stream-based DMA required)");
 #endif
 }
 
@@ -125,14 +125,14 @@ namespace platforms {
 /// - STM32F1/G4/U5: None (channel-based DMA not yet implemented)
 #if defined(FL_STM32_HAS_SPI_HW_2) || defined(FL_STM32_HAS_SPI_HW_4) || defined(FL_STM32_HAS_SPI_HW_8)
 void initSpiHardware() {
-    FL_DBG("STM32: Initializing SPI hardware");
+    FL_DBG_F("STM32: Initializing SPI hardware");
 
     // Register in priority order (highest to lowest)
     detail::addSpiHw8IfPossible();  // Priority 8
     detail::addSpiHw4IfPossible();  // Priority 7
     detail::addSpiHw2IfPossible();  // Priority 6
 
-    FL_DBG("STM32: SPI hardware initialized");
+    FL_DBG_F("STM32: SPI hardware initialized");
 }
 #else
 // Stub implementation for STM32 platforms without hardware SPI support

--- a/src/platforms/arm/stm32/init_channel_driver_stm32.cpp.hpp
+++ b/src/platforms/arm/stm32/init_channel_driver_stm32.cpp.hpp
@@ -40,7 +40,7 @@ namespace detail {
 
 /// @brief Add HW SPI drivers if supported by platform (UNIFIED VERSION)
 static void addSpiHardwareIfPossible(ChannelManager& manager) {
-    FL_DBG("STM32: Registering unified HW SPI channel driver");
+    FL_DBG_F("STM32: Registering unified HW SPI channel driver");
 
     fl::vector<fl::shared_ptr<SpiHwBase>> controllers;
     fl::vector<int> priorities;
@@ -50,7 +50,7 @@ static void addSpiHardwareIfPossible(ChannelManager& manager) {
     // Collect SpiHw8 controllers (highest priority: 8)
     // ========================================================================
     const auto& hw8Controllers = SpiHw8::getAll();
-    FL_DBG("STM32: Found " << hw8Controllers.size() << " SpiHw8 controllers");
+    FL_DBG_F("STM32: Found %s SpiHw8 controllers", hw8Controllers.size());
 
     for (const auto& ctrl : hw8Controllers) {
         if (ctrl) {
@@ -64,7 +64,7 @@ static void addSpiHardwareIfPossible(ChannelManager& manager) {
     // Collect SpiHw4 controllers (medium priority: 7)
     // ========================================================================
     const auto& hw4Controllers = SpiHw4::getAll();
-    FL_DBG("STM32: Found " << hw4Controllers.size() << " SpiHw4 controllers");
+    FL_DBG_F("STM32: Found %s SpiHw4 controllers", hw4Controllers.size());
 
     for (const auto& ctrl : hw4Controllers) {
         if (ctrl) {
@@ -78,7 +78,7 @@ static void addSpiHardwareIfPossible(ChannelManager& manager) {
     // Collect SpiHw2 controllers (lower priority: 6)
     // ========================================================================
     const auto& hw2Controllers = SpiHw2::getAll();
-    FL_DBG("STM32: Found " << hw2Controllers.size() << " SpiHw2 controllers");
+    FL_DBG_F("STM32: Found %s SpiHw2 controllers", hw2Controllers.size());
 
     for (const auto& ctrl : hw2Controllers) {
         if (ctrl) {
@@ -110,14 +110,12 @@ static void addSpiHardwareIfPossible(ChannelManager& manager) {
 
             manager.addDriver(maxPriority, adapter);
 
-            FL_DBG("STM32: Registered unified SPI driver with "
-                   << controllers.size() << " controllers (priority "
-                   << maxPriority << ")");
+            FL_DBG_F("STM32: Registered unified SPI driver with %s controllers (priority %s)", controllers.size(), maxPriority);
         } else {
-            FL_WARN("STM32: Failed to create unified SPI adapter");
+            FL_WARN_F("STM32: Failed to create unified SPI adapter");
         }
     } else {
-        FL_DBG("STM32: No SPI hardware controllers available");
+        FL_DBG_F("STM32: No SPI hardware controllers available");
     }
 }
 
@@ -130,7 +128,7 @@ namespace platforms {
 /// Called lazily on first access to ChannelManager::instance().
 /// Registers platform-specific drivers (SPI hardware) with the bus manager.
 void initChannelDrivers() {
-    FL_DBG("STM32: Lazy initialization of channel drivers");
+    FL_DBG_F("STM32: Lazy initialization of channel drivers");
 
     auto& manager = channelManager();
 
@@ -138,7 +136,7 @@ void initChannelDrivers() {
     // STM32 currently has no clockless drivers, so only SPI hardware is registered
     detail::addSpiHardwareIfPossible(manager);
 
-    FL_DBG("STM32: Channel drivers initialized");
+    FL_DBG_F("STM32: Channel drivers initialized");
 }
 
 } // namespace platforms

--- a/src/platforms/arm/stm32/init_stm32.cpp.hpp
+++ b/src/platforms/arm/stm32/init_stm32.cpp.hpp
@@ -33,7 +33,7 @@ void init() {
         return;  // Already initialized
     }
 
-    FL_DBG("STM32: Platform initialization starting");
+    FL_DBG_F("STM32: Platform initialization starting");
 
     // Trigger weak linkage initialization for SPI hardware controllers
     // This ensures the static vectors are populated early for consistent behavior
@@ -43,7 +43,7 @@ void init() {
     (void)fl::SpiHw8::getAll();
 
     initialized = true;
-    FL_DBG("STM32: Platform initialization complete");
+    FL_DBG_F("STM32: Platform initialization complete");
 }
 
 } // namespace platforms

--- a/src/platforms/arm/stm32/isr_stm32.hpp
+++ b/src/platforms/arm/stm32/isr_stm32.hpp
@@ -26,7 +26,7 @@ constexpr u8 STM32_PLATFORM_ID = 6;
 int attach_timer_handler(const isr_config_t& config, isr_handle_t* out_handle) FL_NOEXCEPT {
     (void)config;
     (void)out_handle;
-    FL_WARN("STM32 ISR: not yet implemented");
+    FL_WARN_F("STM32 ISR: not yet implemented");
     return -100;  // Not implemented
 }
 
@@ -34,25 +34,25 @@ int attach_external_handler(u8 pin, const isr_config_t& config, isr_handle_t* ou
     (void)pin;
     (void)config;
     (void)out_handle;
-    FL_WARN("STM32 ISR: not yet implemented");
+    FL_WARN_F("STM32 ISR: not yet implemented");
     return -100;  // Not implemented
 }
 
 int detach_handler(isr_handle_t& handle) FL_NOEXCEPT {
     (void)handle;
-    FL_WARN("STM32 ISR: not yet implemented");
+    FL_WARN_F("STM32 ISR: not yet implemented");
     return -100;  // Not implemented
 }
 
 int enable_handler(const isr_handle_t& handle) FL_NOEXCEPT {
     (void)handle;
-    FL_WARN("STM32 ISR: not yet implemented");
+    FL_WARN_F("STM32 ISR: not yet implemented");
     return -100;  // Not implemented
 }
 
 int disable_handler(const isr_handle_t& handle) FL_NOEXCEPT {
     (void)handle;
-    FL_WARN("STM32 ISR: not yet implemented");
+    FL_WARN_F("STM32 ISR: not yet implemented");
     return -100;  // Not implemented
 }
 

--- a/src/platforms/arm/stm32/mutex_stm32.cpp.hpp
+++ b/src/platforms/arm/stm32/mutex_stm32.cpp.hpp
@@ -35,7 +35,7 @@ MutexSTM32::MutexSTM32() : mHandle(nullptr) {
     SemaphoreHandle_t handle = xSemaphoreCreateMutex();
 
     if (handle == nullptr) {
-        FL_WARN("MutexSTM32: Failed to create mutex");
+        FL_WARN_F("MutexSTM32: Failed to create mutex");
     }
 
     mHandle = static_cast<void*>(handle);
@@ -92,7 +92,7 @@ RecursiveMutexSTM32::RecursiveMutexSTM32() : mHandle(nullptr) {
     SemaphoreHandle_t handle = xSemaphoreCreateRecursiveMutex();
 
     if (handle == nullptr) {
-        FL_WARN("RecursiveMutexSTM32: Failed to create recursive mutex");
+        FL_WARN_F("RecursiveMutexSTM32: Failed to create recursive mutex");
     }
 
     mHandle = static_cast<void*>(handle);

--- a/src/platforms/arm/stm32/pin_stm32_native.hpp
+++ b/src/platforms/arm/stm32/pin_stm32_native.hpp
@@ -61,7 +61,7 @@ inline void pinMode(int pin, PinMode mode) FL_NOEXCEPT {
     u32 pin_mask = fl::stm32::getGPIOPin(pin);
 
     if (port == nullptr || pin_mask == 0) {
-        FL_WARN("STM32: Invalid pin " << pin);
+        FL_WARN_F("STM32: Invalid pin %s", pin);
         return;
     }
 
@@ -125,7 +125,7 @@ inline void pinMode(int pin, PinMode mode) FL_NOEXCEPT {
             GPIO_InitStruct.Pull = GPIO_PULLDOWN;
             break;
         default:
-            FL_WARN("STM32: Unknown pin mode " << static_cast<int>(mode) << " for pin " << pin);
+            FL_WARN_F("STM32: Unknown pin mode %s for pin %s", static_cast<int>(mode), pin);
             return;
     }
 
@@ -133,7 +133,7 @@ inline void pinMode(int pin, PinMode mode) FL_NOEXCEPT {
 #else
     (void)pin;
     (void)mode;
-    FL_WARN("STM32: HAL_GPIO_MODULE not enabled");
+    FL_WARN_F("STM32: HAL_GPIO_MODULE not enabled");
 #endif
 }
 
@@ -188,7 +188,7 @@ inline u16 analogRead(int pin) FL_NOEXCEPT {
     // without the pinmap tables provided by STM32duino core.
     // For non-Arduino STM32 builds, ADC must be configured manually using HAL APIs.
     (void)pin;
-    FL_WARN("STM32: analogRead not available without STM32duino core");
+    FL_WARN_F("STM32: analogRead not available without STM32duino core");
     return 0;
 #if 0  // Disabled: requires STM32duino pinmap functions
 #if defined(HAL_ADC_MODULE_ENABLED) && defined(FL_STM32_HAS_PINMAP)
@@ -199,14 +199,14 @@ inline u16 analogRead(int pin) FL_NOEXCEPT {
     // These are only available when STM32duino core is present
     PinName pin_name = digitalPinToPinName(pin);
     if (pin_name == NC) {
-        FL_WARN("STM32: Invalid pin " << pin);
+        FL_WARN_F("STM32: Invalid pin %s", pin);
         return 0;
     }
 
     // Find ADC instance and channel for this pin using STM32duino pinmap
     u32 function = pinmap_find_function(pin_name, PinMap_ADC);
     if (function == (u32)NC) {
-        FL_WARN("STM32: Pin " << pin << " does not support ADC");
+        FL_WARN_F("STM32: Pin %s does not support ADC", pin);
         return 0;
     }
 
@@ -215,7 +215,7 @@ inline u16 analogRead(int pin) FL_NOEXCEPT {
     u32 adc_channel = STM_PIN_CHANNEL(function);
 
     if (adc_instance == nullptr) {
-        FL_WARN("STM32: Failed to get ADC instance for pin " << pin);
+        FL_WARN_F("STM32: Failed to get ADC instance for pin %s", pin);
         return 0;
     }
 
@@ -253,7 +253,7 @@ inline u16 analogRead(int pin) FL_NOEXCEPT {
 
     // Initialize ADC peripheral
     if (HAL_ADC_Init(&AdcHandle) != HAL_OK) {
-        FL_WARN("STM32: ADC initialization failed");
+        FL_WARN_F("STM32: ADC initialization failed");
         return 0;
     }
 
@@ -274,21 +274,21 @@ inline u16 analogRead(int pin) FL_NOEXCEPT {
 #endif
 
     if (HAL_ADC_ConfigChannel(&AdcHandle, &AdcChannelConf) != HAL_OK) {
-        FL_WARN("STM32: ADC channel configuration failed");
+        FL_WARN_F("STM32: ADC channel configuration failed");
         HAL_ADC_DeInit(&AdcHandle) FL_NOEXCEPT;
         return 0;
     }
 
     // Start ADC conversion
     if (HAL_ADC_Start(&AdcHandle) != HAL_OK) {
-        FL_WARN("STM32: ADC start failed");
+        FL_WARN_F("STM32: ADC start failed");
         HAL_ADC_DeInit(&AdcHandle) FL_NOEXCEPT;
         return 0;
     }
 
     // Poll for conversion complete (10ms timeout)
     if (HAL_ADC_PollForConversion(&AdcHandle, 10) != HAL_OK) {
-        FL_WARN("STM32: ADC conversion timeout");
+        FL_WARN_F("STM32: ADC conversion timeout");
         HAL_ADC_Stop(&AdcHandle) FL_NOEXCEPT;
         HAL_ADC_DeInit(&AdcHandle) FL_NOEXCEPT;
         return 0;
@@ -321,7 +321,7 @@ inline void analogWrite(int pin, u16 val) FL_NOEXCEPT {
     // For non-Arduino STM32 builds, PWM must be configured manually using HAL TIM APIs.
     (void)pin;
     (void)val;
-    FL_WARN("STM32: analogWrite not available without STM32duino core");
+    FL_WARN_F("STM32: analogWrite not available without STM32duino core");
 #if 0  // Disabled: requires STM32duino pinmap functions
 #if defined(HAL_TIM_MODULE_ENABLED) && defined(FL_STM32_HAS_PINMAP)
     // Implementation based on STM32duino analog.cpp pwm_start()
@@ -331,7 +331,7 @@ inline void analogWrite(int pin, u16 val) FL_NOEXCEPT {
     // These are only available when STM32duino core is present
     PinName pin_name = digitalPinToPinName(pin);
     if (pin_name == NC) {
-        FL_WARN("STM32: Invalid pin " << pin);
+        FL_WARN_F("STM32: Invalid pin %s", pin);
         return;
     }
 
@@ -352,7 +352,7 @@ inline void analogWrite(int pin, u16 val) FL_NOEXCEPT {
     u32 timer_channel = STM_PIN_CHANNEL(function);
 
     if (timer_instance == nullptr) {
-        FL_WARN("STM32: Failed to get Timer instance for pin " << pin);
+        FL_WARN_F("STM32: Failed to get Timer instance for pin %s", pin);
         return;
     }
 
@@ -364,7 +364,7 @@ inline void analogWrite(int pin, u16 val) FL_NOEXCEPT {
         case 3: hal_channel = TIM_CHANNEL_3; break;
         case 4: hal_channel = TIM_CHANNEL_4; break;
         default:
-            FL_WARN("STM32: Invalid timer channel " << timer_channel);
+            FL_WARN_F("STM32: Invalid timer channel %s", timer_channel);
             return;
     }
 
@@ -374,7 +374,7 @@ inline void analogWrite(int pin, u16 val) FL_NOEXCEPT {
     u32 pin_mask = STM_GPIO_PIN(pin_name);
 
     if (port == nullptr) {
-        FL_WARN("STM32: Failed to get GPIO port for pin " << pin);
+        FL_WARN_F("STM32: Failed to get GPIO port for pin %s", pin);
         return;
     }
 
@@ -401,7 +401,7 @@ inline void analogWrite(int pin, u16 val) FL_NOEXCEPT {
     // Get timer clock frequency for PWM calculation
     u32 timer_clock = fl::stm32::getTimerClockFreq(timer_instance);
     if (timer_clock == 0) {
-        FL_WARN("STM32: Failed to get timer clock frequency");
+        FL_WARN_F("STM32: Failed to get timer clock frequency");
         return;
     }
 
@@ -443,7 +443,7 @@ inline void analogWrite(int pin, u16 val) FL_NOEXCEPT {
 #endif
 
     if (timer_idx < 0) {
-        FL_WARN("STM32: Unsupported timer instance for PWM");
+        FL_WARN_F("STM32: Unsupported timer instance for PWM");
         return;
     }
 
@@ -457,7 +457,7 @@ inline void analogWrite(int pin, u16 val) FL_NOEXCEPT {
 
     // Initialize timer base
     if (HAL_TIM_Base_Init(htim) != HAL_OK) {
-        FL_WARN("STM32: Timer base initialization failed");
+        FL_WARN_F("STM32: Timer base initialization failed");
         return;
     }
 
@@ -472,13 +472,13 @@ inline void analogWrite(int pin, u16 val) FL_NOEXCEPT {
     sConfigOC.Pulse = (static_cast<u32>(val) * period) / 255;
 
     if (HAL_TIM_PWM_ConfigChannel(htim, &sConfigOC, hal_channel) != HAL_OK) {
-        FL_WARN("STM32: Timer PWM configuration failed");
+        FL_WARN_F("STM32: Timer PWM configuration failed");
         return;
     }
 
     // Start PWM output
     if (HAL_TIM_PWM_Start(htim, hal_channel) != HAL_OK) {
-        FL_WARN("STM32: Timer PWM start failed");
+        FL_WARN_F("STM32: Timer PWM start failed");
         return;
     }
 
@@ -518,7 +518,7 @@ inline void setAdcRange(AdcRange range) FL_NOEXCEPT {
     // dynamic switching. Users should configure VREF hardware appropriately.
 
     (void)range;
-    FL_DBG("STM32: setAdcRange not dynamically configurable - using hardware VREF");
+    FL_DBG_F("STM32: setAdcRange not dynamically configurable - using hardware VREF");
 }
 
 // ============================================================================

--- a/src/platforms/arm/stm32/semaphore_stm32.cpp.hpp
+++ b/src/platforms/arm/stm32/semaphore_stm32.cpp.hpp
@@ -46,7 +46,7 @@ CountingSemaphoreSTM32<LeastMaxValue>::CountingSemaphoreSTM32(ptrdiff_t desired)
     );
 
     if (handle == nullptr) {
-        FL_WARN("CountingSemaphoreSTM32: Failed to create counting semaphore");
+        FL_WARN_F("CountingSemaphoreSTM32: Failed to create counting semaphore");
     }
 
     mHandle = static_cast<void*>(handle);

--- a/src/platforms/arm/stm32/spi_device_proxy.h
+++ b/src/platforms/arm/stm32/spi_device_proxy.h
@@ -88,8 +88,7 @@ public:
         mHandle = mBusManager->registerDevice(CLOCK_PIN, DATA_PIN, SPI_SPEED, this);
 
         if (!mHandle.is_valid) {
-            FL_WARN("SPIDeviceProxy: Failed to register with bus manager (pin "
-                    << static_cast<int>(CLOCK_PIN) << ":" << static_cast<int>(DATA_PIN) << ")");
+            FL_WARN_F("SPIDeviceProxy: Failed to register with bus manager (pin %s:%s)", static_cast<int>(CLOCK_PIN), static_cast<int>(DATA_PIN));
             return;
         }
 

--- a/src/platforms/arm/stm32/stm32_gpio_timer_helpers.cpp.hpp
+++ b/src/platforms/arm/stm32/stm32_gpio_timer_helpers.cpp.hpp
@@ -267,7 +267,7 @@ bool configurePinAsTimerAF(u8 pin, TIM_TypeDef* timer, u32 speed) {
 
     if (af_mode == (u32)NC) {
         // Pin doesn't support Timer AF
-        FL_WARN("STM32: Pin " << pin << " does not support Timer AF");
+        FL_WARN_F("STM32: Pin %s does not support Timer AF", pin);
         return false;
     }
 
@@ -478,7 +478,7 @@ bool initTimerPWM(TIM_HandleTypeDef* htim, TIM_TypeDef* timer, u32 frequency_hz)
     // Get timer clock frequency
     u32 timer_clock = getTimerClockFreq(timer);
     if (timer_clock == 0) {
-        FL_WARN("STM32: Failed to get timer clock frequency");
+        FL_WARN_F("STM32: Failed to get timer clock frequency");
         return false;
     }
 
@@ -496,7 +496,7 @@ bool initTimerPWM(TIM_HandleTypeDef* htim, TIM_TypeDef* timer, u32 frequency_hz)
     u32 max_period = is_32bit ? 0xFFFFFFFF : 0xFFFF;
 
     if (period > max_period) {
-        FL_WARN("STM32: Timer period " << period << " exceeds max " << max_period);
+        FL_WARN_F("STM32: Timer period %s exceeds max %s", period, max_period);
         return false;
     }
 
@@ -510,7 +510,7 @@ bool initTimerPWM(TIM_HandleTypeDef* htim, TIM_TypeDef* timer, u32 frequency_hz)
     htim->Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_ENABLE;
 
     if (HAL_TIM_Base_Init(htim) != HAL_OK) {
-        FL_WARN("STM32: Timer base init failed");
+        FL_WARN_F("STM32: Timer base init failed");
         return false;
     }
 
@@ -522,7 +522,7 @@ bool initTimerPWM(TIM_HandleTypeDef* htim, TIM_TypeDef* timer, u32 frequency_hz)
     sConfigOC.OCFastMode = TIM_OCFAST_DISABLE;
 
     if (HAL_TIM_PWM_ConfigChannel(htim, &sConfigOC, TIM_CHANNEL_1) != HAL_OK) {
-        FL_WARN("STM32: Timer PWM config failed");
+        FL_WARN_F("STM32: Timer PWM config failed");
         return false;
     }
 
@@ -543,7 +543,7 @@ bool startTimer(TIM_HandleTypeDef* htim) {
 
     // Start PWM on channel 1
     if (HAL_TIM_PWM_Start(htim, TIM_CHANNEL_1) != HAL_OK) {
-        FL_WARN("STM32: Failed to start timer PWM");
+        FL_WARN_F("STM32: Failed to start timer PWM");
         return false;
     }
 
@@ -821,17 +821,17 @@ bool initDMA(DMA_Stream_TypeDef* stream, const void* src, volatile void* dst, u3
     hdma.Init.FIFOMode = DMA_FIFOMODE_DISABLE;
 
     if (HAL_DMA_Init(&hdma) != HAL_OK) {
-        FL_WARN("STM32: DMA init failed");
+        FL_WARN_F("STM32: DMA init failed");
         return false;
     }
 
     // Configure transfer addresses and size
     if (HAL_DMA_Start(&hdma, (u32)src, (u32)dst, size) != HAL_OK) {
-        FL_WARN("STM32: DMA start failed");
+        FL_WARN_F("STM32: DMA start failed");
         return false;
     }
 
-    FL_DBG("STM32: DMA stream configured successfully");
+    FL_DBG_F("STM32: DMA stream configured successfully");
     return true;
 #else
     (void)stream;
@@ -976,7 +976,7 @@ void stopDMA(DMA_Stream_TypeDef* stream) {
     // Clear flags
     clearDMAFlags(stream);
 
-    FL_DBG("STM32: DMA stream stopped");
+    FL_DBG_F("STM32: DMA stream stopped");
 #else
     (void)stream;
 #endif

--- a/src/platforms/arm/teensy/audio_input_teensy.cpp.hpp
+++ b/src/platforms/arm/teensy/audio_input_teensy.cpp.hpp
@@ -92,7 +92,7 @@ Teensy_I2S_Audio::Teensy_I2S_Audio(const audio::ConfigI2S& config)
     if (mConfig.mSampleRate != 44100) {
         mHasError = true;
         mErrorMessage = "Teensy Audio Library only supports 44100Hz sample rate";
-        FL_WARN(mErrorMessage.c_str());
+        FL_WARN_F("%s", mErrorMessage.c_str());
         return;
     }
 
@@ -100,7 +100,7 @@ Teensy_I2S_Audio::Teensy_I2S_Audio(const audio::ConfigI2S& config)
     if (mConfig.mBitResolution != 16) {
         mHasError = true;
         mErrorMessage = "Teensy Audio Library only supports 16-bit resolution";
-        FL_WARN(mErrorMessage.c_str());
+        FL_WARN_F("%s", mErrorMessage.c_str());
         return;
     }
 
@@ -109,7 +109,7 @@ Teensy_I2S_Audio::Teensy_I2S_Audio(const audio::ConfigI2S& config)
     if (static_cast<audio::TeensyI2S::I2SPort>(mConfig.mI2sNum) == audio::TeensyI2S::I2SPort::I2S2) {
         mHasError = true;
         mErrorMessage = "I2S2 is not available on Teensy 3.x (only I2S1 supported)";
-        FL_WARN(mErrorMessage.c_str());
+        FL_WARN_F("%s", mErrorMessage.c_str());
         return;
     }
 #endif
@@ -135,7 +135,7 @@ Teensy_I2S_Audio::Teensy_I2S_Audio(const audio::ConfigI2S& config)
     else {
         mHasError = true;
         mErrorMessage = "Invalid I2S port selection";
-        FL_WARN(mErrorMessage.c_str());
+        FL_WARN_F("%s", mErrorMessage.c_str());
         return;
     }
 }
@@ -146,12 +146,12 @@ Teensy_I2S_Audio::~Teensy_I2S_Audio() {
 
 void Teensy_I2S_Audio::start() {
     if (mHasError) {
-        FL_WARN("Cannot start Teensy I2S audio - initialization error occurred");
+        FL_WARN_F("Cannot start Teensy I2S audio - initialization error occurred");
         return;
     }
 
     if (mInitialized) {
-        FL_WARN("Teensy I2S audio is already initialized");
+        FL_WARN_F("Teensy I2S audio is already initialized");
         return;
     }
 
@@ -165,20 +165,20 @@ void Teensy_I2S_Audio::start() {
         mRecorder->reset();
     }
 
-    FL_WARN("Teensy I2S audio input started (512-sample mono buffering)");
+    FL_WARN_F("Teensy I2S audio input started (512-sample mono buffering)");
 
 #if defined(FL_IS_TEENSY_3X)
-    FL_WARN("  Teensy 3.x I2S1 pins: BCLK=9, MCLK=11, RX=13, LRCLK=23");
+    FL_WARN_F("  Teensy 3.x I2S1 pins: BCLK=9, MCLK=11, RX=13, LRCLK=23");
 #elif defined(FL_IS_TEENSY_4X)
     if (static_cast<audio::TeensyI2S::I2SPort>(mConfig.mI2sNum) == audio::TeensyI2S::I2SPort::I2S1) {
-        FL_WARN("  Teensy 4.x I2S1 pins: BCLK=21, MCLK=23, RX=8, LRCLK=20");
+        FL_WARN_F("  Teensy 4.x I2S1 pins: BCLK=21, MCLK=23, RX=8, LRCLK=20");
     } else {
-        FL_WARN("  Teensy 4.x I2S2 pins: BCLK=4, MCLK=33, RX=5, LRCLK=3");
+        FL_WARN_F("  Teensy 4.x I2S2 pins: BCLK=4, MCLK=33, RX=5, LRCLK=3");
     }
 #endif
 
     // Log channel selection
-    FL_WARN("  Channel: " << ((mConfig.mAudioChannel == audio::AudioChannel::Left) ? "Left" :
+    FL_WARN_F("  Channel: %s", ((mConfig.mAudioChannel == audio::AudioChannel::Left) ? "Left" :
                               (mConfig.mAudioChannel == audio::AudioChannel::Right) ? "Right" : "Both (downmixed)"));
 }
 
@@ -197,7 +197,7 @@ void Teensy_I2S_Audio::stop() {
         mRecorder->reset();
     }
 
-    FL_WARN("Teensy I2S audio input stopped");
+    FL_WARN_F("Teensy I2S audio input stopped");
 }
 
 bool Teensy_I2S_Audio::error(fl::string* msg) {
@@ -299,7 +299,7 @@ fl::shared_ptr<audio::IInput> teensy_create_audio_input(
     fl::string* error_message
 ) {
     if (config.is<audio::ConfigI2S>()) {
-        FL_WARN("Creating Teensy I2S audio source");
+        FL_WARN_F("Creating Teensy I2S audio source");
         audio::ConfigI2S i2s_config = config.get<audio::ConfigI2S>();
         auto audio = fl::make_shared<Teensy_I2S_Audio>(i2s_config);
 
@@ -315,7 +315,7 @@ fl::shared_ptr<audio::IInput> teensy_create_audio_input(
         return audio;
     } else if (config.is<audio::ConfigPdm>()) {
         const char* ERROR_MESSAGE = "PDM audio not supported in Teensy Audio Library implementation";
-        FL_WARN(ERROR_MESSAGE);
+        FL_WARN_F("%s", ERROR_MESSAGE);
         if (error_message) {
             *error_message = ERROR_MESSAGE;
         }
@@ -323,7 +323,7 @@ fl::shared_ptr<audio::IInput> teensy_create_audio_input(
     }
 
     const char* ERROR_MESSAGE = "Unsupported audio configuration for Teensy";
-    FL_WARN(ERROR_MESSAGE);
+    FL_WARN_F("%s", ERROR_MESSAGE);
     if (error_message) {
         *error_message = ERROR_MESSAGE;
     }
@@ -339,7 +339,7 @@ fl::shared_ptr<audio::IInput> teensy_create_audio_input(
 ) FL_NOEXCEPT {
     FL_UNUSED(config);
     const char* ERROR_MESSAGE = "Teensy Audio Library not found. Install from Arduino Library Manager.";
-    FL_WARN(ERROR_MESSAGE);
+    FL_WARN_F("%s", ERROR_MESSAGE);
     if (error_message) {
         *error_message = ERROR_MESSAGE;
     }

--- a/src/platforms/arm/teensy/coroutine_teensy.impl.hpp
+++ b/src/platforms/arm/teensy/coroutine_teensy.impl.hpp
@@ -198,7 +198,7 @@ void* CoroutinePlatformTeensy::createContext(void (*entry_fn)(),
 
     fl::u8* stack = static_cast<fl::u8*>(malloc(stack_size));  // ok bare allocation
     if (!stack) {
-        FL_WARN("CoroutinePlatformTeensy: Failed to allocate stack");
+        FL_WARN_F("CoroutinePlatformTeensy: Failed to allocate stack");
         return nullptr;
     }
 
@@ -288,7 +288,7 @@ TaskCoroutinePtr TaskCoroutineTeensy::create(
         u8 /*priority*/) FL_NOEXCEPT {
     auto* ctx = CoroutineContext::create(fl::move(function), stack_size);
     if (!ctx) {
-        FL_WARN("TaskCoroutineTeensy: Failed to create context for '" << name << "'");
+        FL_WARN_F("TaskCoroutineTeensy: Failed to create context for '%s'", name);
         return nullptr;
     }
 

--- a/src/platforms/arm/teensy/init_teensy4.cpp.hpp
+++ b/src/platforms/arm/teensy/init_teensy4.cpp.hpp
@@ -31,7 +31,7 @@ void init() {
         return;  // Already initialized
     }
 
-    FL_DBG("Teensy 4.x: Platform initialization starting");
+    FL_DBG_F("Teensy 4.x: Platform initialization starting");
 
     // Initialize ObjectFLED registry singleton
     // This ensures the registry exists before any strips are created,
@@ -39,7 +39,7 @@ void init() {
     (void)ObjectFLEDRegistry::getInstance();
 
     initialized = true;
-    FL_DBG("Teensy 4.x: Platform initialization complete");
+    FL_DBG_F("Teensy 4.x: Platform initialization complete");
 }
 
 } // namespace platforms

--- a/src/platforms/arm/teensy/isr_teensy.hpp
+++ b/src/platforms/arm/teensy/isr_teensy.hpp
@@ -93,7 +93,7 @@ int teensy_attach_timer_handler(const isr_config_t& config, isr_handle_t* handle
 
     // Check frequency bounds (Teensy IntervalTimer supports ~1 Hz to ~150 kHz typical)
     if (config.frequency_hz > 150000) {
-        FL_WARN("Teensy timer frequency " << config.frequency_hz << " Hz may be too high (max ~150 kHz)");
+        FL_WARN_F("Teensy timer frequency %s Hz may be too high (max ~150 kHz)", config.frequency_hz);
     }
 
     // Allocate platform handle data

--- a/src/platforms/arm/teensy/teensy4_common/clockless_objectfled.cpp.hpp
+++ b/src/platforms/arm/teensy/teensy4_common/clockless_objectfled.cpp.hpp
@@ -85,27 +85,27 @@ void ObjectFLEDGroupBase::addStrip(u8 pin, PixelIterator& pixel_iterator) {
     // Validate pin before adding
     auto validation = objectfled::validate_teensy4_pin(pin);
     if (!validation.valid) {
-        FL_WARN("================================================================================");
-        FL_WARN("FASTLED ERROR: Strip on pin " << (int)pin << " is INVALID and has been disabled");
-        FL_WARN(validation.error_message);
-        FL_WARN("================================================================================");
+        FL_WARN_F("================================================================================");
+        FL_WARN_F("FASTLED ERROR: Strip on pin %s is INVALID and has been disabled", (int)pin);
+        FL_WARN_F("%s", validation.error_message);
+        FL_WARN_F("================================================================================");
         return;
     }
 
     // Check for warnings (pin is valid but may have issues)
     if (validation.error_message != nullptr) {
-        FL_WARN("================================================================================");
-        FL_WARN("FASTLED WARNING: Strip on pin " << (int)pin << " may have issues");
-        FL_WARN(validation.error_message);
-        FL_WARN("================================================================================");
+        FL_WARN_F("================================================================================");
+        FL_WARN_F("FASTLED WARNING: Strip on pin %s may have issues", (int)pin);
+        FL_WARN_F("%s", validation.error_message);
+        FL_WARN_F("================================================================================");
     }
 
     // Check for duplicate pin in current draw list
     for (const auto& item : mRectDrawBuffer.mDrawList) {
         if (item.mPin == pin) {
-            FL_WARN("================================================================================");
-            FL_WARN("FASTLED ERROR: Pin " << (int)pin << " is already in use - strip disabled");
-            FL_WARN("================================================================================");
+            FL_WARN_F("================================================================================");
+            FL_WARN_F("FASTLED ERROR: Pin %s is already in use - strip disabled", (int)pin);
+            FL_WARN_F("================================================================================");
             return;
         }
     }
@@ -202,7 +202,7 @@ void ObjectFLEDGroupBase::rebuildObjectFLED() {
     int totalLeds = total_bytes / bytesPerLed;
 
     #ifdef FASTLED_DEBUG_OBJECTFLED
-    FL_WARN("ObjectFLEDGroupBase: totalLeds=" << totalLeds << " bytesPerStrip=" << bytes_per_strip);
+    FL_WARN_F("ObjectFLEDGroupBase: totalLeds=%s bytesPerStrip=%s", totalLeds, bytes_per_strip);
     #endif
 
     // Pass nullptr so ObjectFLED allocates frameBufferLocal internally

--- a/src/platforms/arm/teensy/teensy4_common/drivers/flexio/channel_engine_flexio.cpp.hpp
+++ b/src/platforms/arm/teensy/teensy4_common/drivers/flexio/channel_engine_flexio.cpp.hpp
@@ -29,20 +29,20 @@ static constexpr u32 kFlexIOMaxPeriodNs = 2500;
 ChannelEngineFlexIO::ChannelEngineFlexIO()
  FL_NOEXCEPT : mPeripheral(IFlexIOPeripheral::create()),
       mHwInitialized(false), mCurrentPin(0xFF) {
-    FL_LOG_FLEXIO("ChannelEngineFlexIO: created");
+    FL_LOG_FLEXIO_F("ChannelEngineFlexIO: created");
 }
 
 ChannelEngineFlexIO::ChannelEngineFlexIO(fl::shared_ptr<IFlexIOPeripheral> peripheral)
  FL_NOEXCEPT : mPeripheral(fl::move(peripheral)),
       mHwInitialized(false), mCurrentPin(0xFF) {
-    FL_LOG_FLEXIO("ChannelEngineFlexIO: created (injected peripheral)");
+    FL_LOG_FLEXIO_F("ChannelEngineFlexIO: created (injected peripheral)");
 }
 
 ChannelEngineFlexIO::~ChannelEngineFlexIO() {
     if (mPeripheral) {
         mPeripheral->deinit();
     }
-    FL_LOG_FLEXIO("ChannelEngineFlexIO: destroyed");
+    FL_LOG_FLEXIO_F("ChannelEngineFlexIO: destroyed");
 }
 
 bool ChannelEngineFlexIO::canHandle(const ChannelDataPtr& data) const FL_NOEXCEPT {
@@ -100,7 +100,7 @@ void ChannelEngineFlexIO::show() FL_NOEXCEPT {
             mPeripheral->deinit();
 
             if (!mPeripheral->canHandlePin(pin)) {
-                FL_LOG_FLEXIO("ChannelEngineFlexIO: Pin " << (int)pin << " not FlexIO2-capable");
+                FL_LOG_FLEXIO_F("ChannelEngineFlexIO: Pin %s not FlexIO2-capable", (int)pin);
                 continue;
             }
 
@@ -110,7 +110,7 @@ void ChannelEngineFlexIO::show() FL_NOEXCEPT {
             u32 period = timing.total_period_ns();
 
             if (!mPeripheral->init(pin, t0h, t1h, period, timing.reset_us)) {
-                FL_LOG_FLEXIO("ChannelEngineFlexIO: Failed to init FlexIO for pin " << (int)pin);
+                FL_LOG_FLEXIO_F("ChannelEngineFlexIO: Failed to init FlexIO for pin %s", (int)pin);
                 continue;
             }
 

--- a/src/platforms/arm/teensy/teensy4_common/drivers/flexio/flexio_driver.cpp.hpp
+++ b/src/platforms/arm/teensy/teensy4_common/drivers/flexio/flexio_driver.cpp.hpp
@@ -248,7 +248,7 @@ static bool flexio_dma_init() {
     }
     sDmaChannel = new DMAChannel();  // ok bare allocation
     if (!sDmaChannel) {
-        FL_LOG_FLEXIO("FlexIO: Failed to allocate DMA channel");
+        FL_LOG_FLEXIO_F("FlexIO: Failed to allocate DMA channel");
         return false;
     }
     sDmaChannel->triggerAtHardwareEvent(DMAMUX_SOURCE_FLEXIO2_REQUEST0);
@@ -266,8 +266,7 @@ bool flexio_init(const FlexIOPinInfo& pin_info, u32 t0h_ns, u32 t1h_ns,
         flexio_deinit();
     }
 
-    FL_LOG_FLEXIO("FlexIO: init pin " << (int)pin_info.teensy_pin
-           << " (FlexIO2:" << (int)pin_info.flexio_pin << ")");
+    FL_LOG_FLEXIO_F("FlexIO: init pin %s (FlexIO2:%s)", (int)pin_info.teensy_pin, (int)pin_info.flexio_pin);
 
     flexio_clock_init();
     flexio_pin_init(pin_info);

--- a/src/platforms/arm/teensy/teensy4_common/drivers/objectfled/channel_engine_objectfled.cpp.hpp
+++ b/src/platforms/arm/teensy/teensy4_common/drivers/objectfled/channel_engine_objectfled.cpp.hpp
@@ -44,17 +44,17 @@ struct TimingGroup {
 
 ChannelEngineObjectFLED::ChannelEngineObjectFLED()
  FL_NOEXCEPT : mPeripheral(IObjectFLEDPeripheral::create()) {
-    FL_LOG_OBJECTFLED("ChannelEngineObjectFLED: created");
+    FL_LOG_OBJECTFLED_F("ChannelEngineObjectFLED: created");
 }
 
 ChannelEngineObjectFLED::ChannelEngineObjectFLED(
         fl::shared_ptr<IObjectFLEDPeripheral> peripheral)
  FL_NOEXCEPT : mPeripheral(fl::move(peripheral)) {
-    FL_LOG_OBJECTFLED("ChannelEngineObjectFLED: created with injected peripheral");
+    FL_LOG_OBJECTFLED_F("ChannelEngineObjectFLED: created with injected peripheral");
 }
 
 ChannelEngineObjectFLED::~ChannelEngineObjectFLED() {
-    FL_LOG_OBJECTFLED("ChannelEngineObjectFLED: destroyed");
+    FL_LOG_OBJECTFLED_F("ChannelEngineObjectFLED: destroyed");
 }
 
 bool ChannelEngineObjectFLED::canHandle(const ChannelDataPtr& data) const FL_NOEXCEPT {
@@ -132,8 +132,7 @@ void ChannelEngineObjectFLED::show() FL_NOEXCEPT {
             // Validate pin
             auto validation = mPeripheral->validatePin(pin);
             if (!validation.valid) {
-                FL_LOG_OBJECTFLED("ChannelEngineObjectFLED: Pin " << (int)pin
-                        << " invalid: " << validation.error_message);
+                FL_LOG_OBJECTFLED_F("ChannelEngineObjectFLED: Pin %s invalid: %s", (int)pin, validation.error_message);
                 continue;
             }
 

--- a/src/platforms/arm/teensy/teensy4_common/init_channel_driver_mxrt1062.cpp.hpp
+++ b/src/platforms/arm/teensy/teensy4_common/init_channel_driver_mxrt1062.cpp.hpp
@@ -38,7 +38,7 @@ namespace detail {
 
 /// @brief Add HW SPI drivers if supported by platform (UNIFIED VERSION)
 static void addSpiHardwareIfPossible(ChannelManager& manager) {
-    FL_DBG("Teensy 4.x: Registering unified HW SPI channel driver");
+    FL_DBG_F("Teensy 4.x: Registering unified HW SPI channel driver");
 
     fl::vector<fl::shared_ptr<SpiHwBase>> controllers;
     fl::vector<int> priorities;
@@ -48,7 +48,7 @@ static void addSpiHardwareIfPossible(ChannelManager& manager) {
     // Collect SpiHw4 controllers (higher priority: 7)
     // ========================================================================
     const auto& hw4Controllers = SpiHw4::getAll();
-    FL_DBG("Teensy 4.x: Found " << hw4Controllers.size() << " SpiHw4 controllers");
+    FL_DBG_F("Teensy 4.x: Found %s SpiHw4 controllers", hw4Controllers.size());
 
     for (const auto& ctrl : hw4Controllers) {
         if (ctrl) {
@@ -62,7 +62,7 @@ static void addSpiHardwareIfPossible(ChannelManager& manager) {
     // Collect SpiHw2 controllers (lower priority: 6)
     // ========================================================================
     const auto& hw2Controllers = SpiHw2::getAll();
-    FL_DBG("Teensy 4.x: Found " << hw2Controllers.size() << " SpiHw2 controllers");
+    FL_DBG_F("Teensy 4.x: Found %s SpiHw2 controllers", hw2Controllers.size());
 
     for (const auto& ctrl : hw2Controllers) {
         if (ctrl) {
@@ -94,35 +94,33 @@ static void addSpiHardwareIfPossible(ChannelManager& manager) {
 
             manager.addDriver(maxPriority, adapter);
 
-            FL_DBG("Teensy 4.x: Registered unified SPI driver with "
-                   << controllers.size() << " controllers (priority "
-                   << maxPriority << ")");
+            FL_DBG_F("Teensy 4.x: Registered unified SPI driver with %s controllers (priority %s)", controllers.size(), maxPriority);
         } else {
-            FL_WARN("Teensy 4.x: Failed to create unified SPI adapter");
+            FL_WARN_F("Teensy 4.x: Failed to create unified SPI adapter");
         }
     } else {
-        FL_DBG("Teensy 4.x: No SPI hardware controllers available");
+        FL_DBG_F("Teensy 4.x: No SPI hardware controllers available");
     }
 }
 
 /// @brief Add FlexIO2 engine for clockless LED strips on FlexIO-capable pins
 static void addFlexIOIfPossible(ChannelManager& manager) {
-    FL_DBG("Teensy 4.x: Registering FlexIO channel driver");
+    FL_DBG_F("Teensy 4.x: Registering FlexIO channel driver");
 
     auto engine = fl::make_shared<ChannelEngineFlexIO>();
     manager.addDriver(8, engine);
 
-    FL_DBG("Teensy 4.x: Registered FlexIO driver (priority 8)");
+    FL_DBG_F("Teensy 4.x: Registered FlexIO driver (priority 8)");
 }
 
 /// @brief Add ObjectFLED DMA engine for clockless LED strips
 static void addObjectFLEDIfPossible(ChannelManager& manager) {
-    FL_DBG("Teensy 4.x: Registering ObjectFLED channel driver");
+    FL_DBG_F("Teensy 4.x: Registering ObjectFLED channel driver");
 
     auto engine = fl::make_shared<ChannelEngineObjectFLED>();
     manager.addDriver(5, engine);
 
-    FL_DBG("Teensy 4.x: Registered ObjectFLED driver (priority 5)");
+    FL_DBG_F("Teensy 4.x: Registered ObjectFLED driver (priority 5)");
 }
 
 } // namespace detail
@@ -134,7 +132,7 @@ namespace platforms {
 /// Called lazily on first access to ChannelManager::instance().
 /// Registers platform-specific drivers (SPI hardware, ObjectFLED DMA) with the bus manager.
 void initChannelDrivers() {
-    FL_DBG("Teensy 4.x: Lazy initialization of channel drivers");
+    FL_DBG_F("Teensy 4.x: Lazy initialization of channel drivers");
 
     auto& manager = channelManager();
 
@@ -147,7 +145,7 @@ void initChannelDrivers() {
     // Register true SPI hardware (priority 6-7)
     detail::addSpiHardwareIfPossible(manager);
 
-    FL_DBG("Teensy 4.x: Channel drivers initialized");
+    FL_DBG_F("Teensy 4.x: Channel drivers initialized");
 }
 
 } // namespace platforms

--- a/src/platforms/arm/teensy/teensy4_common/rx_flexio_channel.cpp.hpp
+++ b/src/platforms/arm/teensy/teensy4_common/rx_flexio_channel.cpp.hpp
@@ -1,12 +1,12 @@
-/// @file rx_flexio_channel.cpp.hpp
+﻿/// @file rx_flexio_channel.cpp.hpp
 /// @brief Teensy 4.x FlexIO shifter-based RX implementation
 ///
-/// **Phase 1B** of FastLED#2764 — replaces the Phase 1A skeleton with real
+/// **Phase 1B** of FastLED#2764 â€” replaces the Phase 1A skeleton with real
 /// FLEXIO1 register programming, IOMUXC pin muxing, and an eDMA-driven
 /// capture pipeline that mirrors the FlexIO TX driver's structure but in
 /// the reverse direction.
 ///
-/// Design (input-edge timing measurement, per NXP AN12686 §4 + iMXRT1062
+/// Design (input-edge timing measurement, per NXP AN12686 Â§4 + iMXRT1062
 /// reference manual chapter 50):
 ///
 /// 1.  **Timer 0** runs in 16-bit-counter mode (TIMOD=3), clocked by the
@@ -40,7 +40,7 @@
 /// **Status / scope:** this PR brings up the configuration code, the DMA
 /// channel, and the wait/decode flow. Bench validation against a
 /// `analogWriteFrequency`-generated reference signal (Phase 2) is the next
-/// step in the #2764 series — until then we keep `PLATFORM_DEFAULT` on
+/// step in the #2764 series â€” until then we keep `PLATFORM_DEFAULT` on
 /// `FLEXPWM` so the existing RX flows are untouched. The public API is
 /// identical to Phase 1A.
 
@@ -96,9 +96,9 @@ namespace {
 // `IMXRT_FLEXIO1.offsetNNN`):
 //
 //   FLEXIO1 base = 0x401AC000
-//   VERID      @ +0x000   (Version ID, read-only — NOT CTRL!)
+//   VERID      @ +0x000   (Version ID, read-only â€” NOT CTRL!)
 //   PARAM      @ +0x004   (Parameter, read-only)
-//   CTRL       @ +0x008   (Control register — module enable + SW reset bit)
+//   CTRL       @ +0x008   (Control register â€” module enable + SW reset bit)
 //   SHIFTSTAT  @ +0x010   (status flags)
 //   SHIFTERR   @ +0x014   (error flags)
 //   TIMSTAT    @ +0x018   (timer status)
@@ -112,11 +112,11 @@ namespace {
 //
 // **#2772 root cause:** the original Phase 1B code put CTRL at +0x000.
 // Writes to FLEXIO1 +0x000 (VERID) on iMXRT1062 with the FLEXIO1 clock
-// gated on are silently ignored — but the subsequent **read** of +0x000
+// gated on are silently ignored â€” but the subsequent **read** of +0x000
 // the spin loop performed to check the SW-reset bit produced an
-// imprecise data-bus error (IMPRECISERR, CFSR=0x400) → LOCKUP HardFault
-// → SYSRESETREQ. Cross-checked against `xtensa-esp32s3-elf-nm`-style
-// disassembly of `firmware.elf` (`addr2line 0x2D166` → `FlexIoRxChannelImpl::begin`).
+// imprecise data-bus error (IMPRECISERR, CFSR=0x400) â†’ LOCKUP HardFault
+// â†’ SYSRESETREQ. Cross-checked against `xtensa-esp32s3-elf-nm`-style
+// disassembly of `firmware.elf` (`addr2line 0x2D166` â†’ `FlexIoRxChannelImpl::begin`).
 
 static constexpr u32 kFLEXIO1_BASE = 0x401AC000u;
 
@@ -134,7 +134,7 @@ static volatile u32 *FLEXIO1_TIMCFG    = (volatile u32 *)(kFLEXIO1_BASE + 0x480)
 static volatile u32 *FLEXIO1_TIMCMP    = (volatile u32 *)(kFLEXIO1_BASE + 0x500);
 
 // ---------------------------------------------------------------------------
-// Teensy 4.0 → FLEXIO1 pin mapping table
+// Teensy 4.0 â†’ FLEXIO1 pin mapping table
 // ---------------------------------------------------------------------------
 //
 // Each entry maps a Teensy digital pin to its FLEXIO1 pin index. The IOMUXC
@@ -157,7 +157,7 @@ struct FlexIo1PinInfo {
 
 static constexpr u32 kFlexIo1IomuxcBase = 0x401F8000u;
 
-// Initial pin map — Teensy 4.0/4.1 pins whose ALT4 mux routes to FLEXIO1.
+// Initial pin map â€” Teensy 4.0/4.1 pins whose ALT4 mux routes to FLEXIO1.
 // Verified against the Teensy 4.0 pinout card + iMXRT1062 RM Table 11-1.
 // Phase 1C can extend this to additional pins (e.g. 2, 3, 5, the rest of the
 // GPIO_EMC_* bank) as bench validation proves them out.
@@ -181,12 +181,12 @@ static const FlexIo1PinInfo *lookupFlexIo1Pin(int teensy_pin) {
 }
 
 // ---------------------------------------------------------------------------
-// WS2812 bit decoder — mirrors the FlexPWM RX driver's decode path.
+// WS2812 bit decoder â€” mirrors the FlexPWM RX driver's decode path.
 // ---------------------------------------------------------------------------
 //
-// Phase 3 of FastLED#2764 wires the same edge-pair → bit-cell decoder that
+// Phase 3 of FastLED#2764 wires the same edge-pair â†’ bit-cell decoder that
 // the existing FlexPWM RX driver uses, so the new FlexIO RX backend can be
-// used as a drop-in source for AutoResearch's TX→RX byte-verification flow.
+// used as a drop-in source for AutoResearch's TXâ†’RX byte-verification flow.
 //
 // Kept as static helpers in this TU rather than extracting to a shared
 // header so the FlexPWM and FlexIO RX paths remain independently reviewable.
@@ -219,7 +219,7 @@ decodeEdgesFlexIo(const ChipsetTiming4Phase &timing,
     u32 total_bits = 0;
     size_t i = 0;
     while (i + 1 < edges.size()) {
-        // Each bit cell = (HIGH, LOW) pair. Polarity error → skip + resync.
+        // Each bit cell = (HIGH, LOW) pair. Polarity error â†’ skip + resync.
         if (!edges[i].high) {
             ++i;
             continue;
@@ -264,36 +264,36 @@ decodeEdgesFlexIo(const ChipsetTiming4Phase &timing,
 // **Source-clock choice**: we deliberately pick OSC (24 MHz, always-on) via
 // CCM_CDCDR_FLEXIO1_CLK_SEL(1) rather than PLL3_PFD3. Teensy 4's `startup.c`
 // programs the four PLL3 PFDs but leaves their CLKGATE bits **set** (line
-// 139–141: `CCM_ANALOG_PFD_480_SET = 0x80808080`). PFD3 is gated off post-
+// 139â€“141: `CCM_ANALOG_PFD_480_SET = 0x80808080`). PFD3 is gated off post-
 // boot. If FLEXIO1 selects a gated PFD as its source, the first write to
-// any FLEXIO1 register hits an imprecise data-bus error → HardFault →
+// any FLEXIO1 register hits an imprecise data-bus error â†’ HardFault â†’
 // LOCKUP reset. Confirmed against the dev-bench Teensy 4.0 in #2772.
 //
 // Cost of using OSC: ~41.7 ns/tick resolution instead of ~8.3 ns. Plenty
 // for WS2812 inter-edge timing (worst-case T0H ~350 ns) and for the bench
-// matrix (1 / 10 / 100 kHz square waves whose half-period is ≥5 µs).
+// matrix (1 / 10 / 100 kHz square waves whose half-period is â‰¥5 Âµs).
 
 static constexpr u32 kFlexIo1ClkMHz = 60u;
 
 static void flexio1_clock_init() {
     // Root cause of FastLED#2772 / #3059 FLEXIO1 hang (live-debugged
     // 2026-06-15): the CCM_CDCDR POR default `0x33f71f92` has
-    // FLEXIO1_CLK_SEL=2 (PLL5 — the video PLL), which Teensyduino does
+    // FLEXIO1_CLK_SEL=2 (PLL5 â€” the video PLL), which Teensyduino does
     // not enable. With no functional clock, the FLEXIO1 CTRL.SWRST bit
-    // can never self-clear (RM §50.5.1.1: "automatically cleared after
+    // can never self-clear (RM Â§50.5.1.1: "automatically cleared after
     // reset is complete, AS LONG AS THE FLEXIO IS BEING CLOCKED") and
-    // every previous code variant — including the original #2772 fix —
+    // every previous code variant â€” including the original #2772 fix â€”
     // hit the 1M-poll spin bound.
     //
     // Fix: gate the clock off, switch CLK_SEL to pll3_sw_clk (=3, the
-    // 480 MHz USB PLL — Teensyduino guarantees it is running because the
+    // 480 MHz USB PLL â€” Teensyduino guarantees it is running because the
     // core's USB CDC stack depends on it), pick a /1/8 divider so the
     // resulting 60 MHz ipg_clk_flexio is well under FLEXIO's ~120 MHz
     // ceiling, then gate the clock back on. Standard "change divider
     // while gated" sequence to avoid mid-divider glitches.
 
-    FL_WARN("[FlexIO RX] pre-init: CCGR5=0x" << fl::hex << CCM_CCGR5
-            << " CDCDR=0x" << CCM_CDCDR << fl::dec);
+    FL_WARN_F("[FlexIO RX] pre-init: CCGR5=0x%x CDCDR=0x%x",
+              CCM_CCGR5, CCM_CDCDR);
 
     // 1. Gate FLEXIO1 clock OFF so we can safely reprogram CDCDR.
     CCM_CCGR5 &= ~CCM_CCGR5_FLEXIO1(0x3);
@@ -316,32 +316,32 @@ static void flexio1_clock_init() {
     __asm__ volatile("dsb 0xF" ::: "memory");
     __asm__ volatile("isb 0xF" ::: "memory");
 
-    FL_WARN("[FlexIO RX] post-init: CCGR5=0x" << fl::hex << CCM_CCGR5
-            << " CDCDR=0x" << CCM_CDCDR << fl::dec);
+    FL_WARN_F("[FlexIO RX] post-init: CCGR5=0x%x CDCDR=0x%x",
+              CCM_CCGR5, CCM_CDCDR);
 
     // Diagnostic: read VERID @ +0x000 (should be non-zero if bus clock is on)
     volatile u32 *flexio1_verid = (volatile u32 *)(kFLEXIO1_BASE + 0x000);
-    FL_WARN("[FlexIO RX] FLEXIO1 VERID=0x" << fl::hex << *flexio1_verid
-            << " PARAM=0x" << *(volatile u32 *)(kFLEXIO1_BASE + 0x004)
-            << " CTRL=0x" << FLEXIO1_CTRL << fl::dec);
+    FL_WARN_F("[FlexIO RX] FLEXIO1 VERID=0x%x PARAM=0x%x CTRL=0x%x",
+              *flexio1_verid, *(volatile u32 *)(kFLEXIO1_BASE + 0x004),
+              FLEXIO1_CTRL);
 
     // Memory barrier so the CCM writes have actually committed before any
     // downstream code touches FLEXIO1_CTRL. Without this, the very next
     // read/write of FLEXIO1_CTRL on a fresh-from-reset chip can hit the
-    // module while its clock is still gated off — observed on the dev-bench
+    // module while its clock is still gated off â€” observed on the dev-bench
     // Teensy 4.0 as an infinite spin on the software-reset wait (#2772).
     __asm__ volatile("dsb 0xF" ::: "memory");        // step 6 (DSB)
     __asm__ volatile("isb 0xF" ::: "memory");        // step 6 (ISB)
 }
 
-// IOMUXC pad: ALT4 + hysteresis + 100 kΩ pull-up keeper (matches FlexIO TX
+// IOMUXC pad: ALT4 + hysteresis + 100 kÎ© pull-up keeper (matches FlexIO TX
 // pad config rationale: clean edge detection, no floating-input glitches
 // before the signal is driven).
 //
 // FastLED#3066 phase 1.7 root cause: also set the **SION** (Software Input
 // On) bit. Without SION, the IOMUX doesn't force the input path through
 // to the peripheral when the pad's MUX_MODE selects an alternate function
-// — so even though pin 4 is muxed to ALT4 (FLEXIO1_FLEXIO06), the FLEXIO1
+// â€” so even though pin 4 is muxed to ALT4 (FLEXIO1_FLEXIO06), the FLEXIO1
 // module never sees pad activity. The working FlexPWM RX driver sets
 // SION the same way (`rx_flexpwm_channel.cpp.hpp:405`); FlexIO RX needed
 // the same fix. Verified by `flexioRxLoopbackPing`: with SION cleared,
@@ -358,19 +358,17 @@ static void flexio1_pin_init(const FlexIo1PinInfo &pin_info) {
     // and FLEXIO1 PIN status so we can see whether the mux writes
     // committed and whether FLEXIO1 sees pad activity on the selected
     // input pin.
-    FL_WARN("[FlexIO RX] post-pin-init: pin=" << (int)pin_info.teensy_pin
-            << " flexio_pin=" << (int)pin_info.flexio_pin
-            << " mux_reg=0x" << fl::hex << *(pin_info.mux_reg)
-            << " pad_reg=0x" << *(pin_info.pad_reg) << fl::dec);
+    FL_WARN_F("[FlexIO RX] post-pin-init: pin=%d flexio_pin=%d mux_reg=0x%x pad_reg=0x%x",
+              (int)pin_info.teensy_pin, (int)pin_info.flexio_pin,
+              *(pin_info.mux_reg), *(pin_info.pad_reg));
 
     // FLEXIO1 PIN @ +0x00C reflects the live state of each input pin.
     // If our pad routing works, bit `flexio_pin` should track the pad.
-    // (offset 0x040 — used in the earlier iter 5 diagnostic — was the
+    // (offset 0x040 â€” used in the earlier iter 5 diagnostic â€” was the
     // wrong register and read 0 unconditionally.)
     volatile u32 *flexio1_pin_reg = (volatile u32 *)(kFLEXIO1_BASE + 0x00C);
-    FL_WARN("[FlexIO RX] FLEXIO1 PIN=0x" << fl::hex << *flexio1_pin_reg
-            << " (expect bit " << fl::dec << (int)pin_info.flexio_pin
-            << " to track pad)");
+    FL_WARN_F("[FlexIO RX] FLEXIO1 PIN=0x%x (expect bit %d to track pad)",
+              *flexio1_pin_reg, (int)pin_info.flexio_pin);
 }
 
 // ---------------------------------------------------------------------------
@@ -400,7 +398,7 @@ static void flexio1_pin_init(const FlexIo1PinInfo &pin_info) {
 
 /// @brief Configure FLEXIO1 for edge-timing capture on the given pin.
 /// @return true on success; false on hardware error. (The SWRST spin
-///         that historically returned false has been removed — see the
+///         that historically returned false has been removed â€” see the
 ///         comment block inside.)
 static bool flexio1_configure(u8 flexio_pin) {
     // FastLED#2772 / #3059 device-side root cause (live-debugged
@@ -437,7 +435,7 @@ static bool flexio1_configure(u8 flexio_pin) {
     // FastLED#3066 iter 6: drive the timer from its own PINSEL field
     // (not from TRGSEL). The TRGSEL=2*flexio_pin formula matches the RM
     // ("Pin 2N input") but the trigger source on this iMXRT1062 build
-    // doesn't actually engage TIMENA — iter 6 verified that 8 hand-
+    // doesn't actually engage TIMENA â€” iter 6 verified that 8 hand-
     // driven pin toggles produced zero TIMSTAT pulses even with
     // TRGSEL=12 (= Pin 6 edge). The TIMER PINSEL path (TIMCTL bits
     // [13:8]) bypasses TRGSEL entirely; TIMENA=4 then reads "Pin rising
@@ -459,8 +457,8 @@ static bool flexio1_configure(u8 flexio_pin) {
     // FastLED#3066 iter 6: TIMCMP=1 makes the timer reach compare
     // immediately after each TIMENA=4 pin-rising-edge enable. The
     // shifter then latches the pin state on each compare event
-    // (TIMPOL=0). This gives us a pin-edge sampler — not true
-    // inter-edge timing — but proves the chain CAN fire and DMA CAN
+    // (TIMPOL=0). This gives us a pin-edge sampler â€” not true
+    // inter-edge timing â€” but proves the chain CAN fire and DMA CAN
     // transfer. Future iterations will refine TIMCMP / SHIFTBUF
     // semantics for actual edge interval recovery.
     FLEXIO1_TIMCMP[0] = 10u;
@@ -541,16 +539,14 @@ void FlexIoRxChannelImpl::dmaIsr() {
 bool FlexIoRxChannelImpl::begin(const RxConfig &config) {
     mPinInfo = lookupFlexIo1Pin(mPin);
     if (!mPinInfo) {
-        FL_WARN("[FlexIO RX] Pin "
-                << mPin
-                << " has no FLEXIO1 mux mapping on Teensy 4.x (only a small "
+        FL_WARN_F("[FlexIO RX] Pin %s has no FLEXIO1 mux mapping on Teensy 4.x (only a small "
                    "subset is enabled; see rx_flexio_channel.cpp.hpp). See "
-                   "FastLED#2764.");
+                   "FastLED#2764.", mPin);
         return false;
     }
 
     if (sActiveInstance && sActiveInstance != this) {
-        FL_WARN("[FlexIO RX] Another FlexIoRxChannel is already active; only "
+        FL_WARN_F("[FlexIO RX] Another FlexIoRxChannel is already active; only "
                 "one RX channel may use FLEXIO1 at a time.");
         return false;
     }
@@ -565,7 +561,7 @@ bool FlexIoRxChannelImpl::begin(const RxConfig &config) {
     // one u32 per captured inter-edge delta. Cap at a safe upper bound so
     // we never balloon RAM during exploratory runs. The 16 384-entry cap
     // (64 KiB) covers a 100 ms window at 100 kHz square wave with 50 %
-    // headroom — see `flexioRxBenchmark` in `AutoResearchRemote.cpp`.
+    // headroom â€” see `flexioRxBenchmark` in `AutoResearchRemote.cpp`.
     const size_t requested = config.buffer_size > 0 ? config.buffer_size
                                                     : mBufferSize;
     mBufferSize = requested > 16384 ? 16384 : requested;
@@ -574,14 +570,14 @@ bool FlexIoRxChannelImpl::begin(const RxConfig &config) {
     flexio1_clock_init();
     flexio1_pin_init(*mPinInfo);
     if (!flexio1_configure(mPinInfo->flexio_pin)) {
-        // Reset spin hit its bound. Don't enable DMA — there's nothing on
+        // Reset spin hit its bound. Don't enable DMA â€” there's nothing on
         // the other end to feed it, and leaving the channel armed would
         // corrupt mCaptureBuffer if the FlexIO module came alive later.
         // The caller already got an FL_WARN with the diagnostic.
         return false;
     }
 
-    // DMA: copy SHIFTBUF[0] → mCaptureBuffer on each shifter-status flag.
+    // DMA: copy SHIFTBUF[0] â†’ mCaptureBuffer on each shifter-status flag.
     mDma.source((volatile u32 &)FLEXIO1_SHIFTBUF[0]);
     mDma.destinationBuffer(mCaptureBuffer.data(), mCaptureBuffer.size() * sizeof(u32));
     mDma.transferSize(4);
@@ -619,32 +615,21 @@ RxWaitResult FlexIoRxChannelImpl::wait(u32 timeout_ms) {
             const u32 citer = mDma.TCD->CITER & 0x7FFFu;
             const u32 biter = mDma.TCD->BITER & 0x7FFFu;
             const u32 transfers_done = (biter > citer) ? (biter - citer) : 0u;
-            FL_WARN("[FlexIO RX] wait() TIMEOUT after "
-                    << timeout_ms << "ms:"
-                    << " DMA complete=" << (mDma.complete() ? 1 : 0)
-                    << " error=" << (mDma.error() ? 1 : 0)
-                    << " CITER=" << citer << "/" << biter
-                    << " (transfers_done=" << transfers_done << ")");
-            FL_WARN("[FlexIO RX] post-timeout FLEXIO1:"
-                    << " SHIFTSTAT=0x" << fl::hex << FLEXIO1_SHIFTSTAT
-                    << " SHIFTERR=0x" << FLEXIO1_SHIFTERR
-                    << " TIMSTAT=0x" << FLEXIO1_TIMSTAT
-                    << " CTRL=0x" << FLEXIO1_CTRL << fl::dec);
+            FL_WARN_F("[FlexIO RX] wait() TIMEOUT after %sms: DMA complete=%s error=%s CITER=%s/%s (transfers_done=%s)", timeout_ms, (mDma.complete() ? 1 : 0), (mDma.error() ? 1 : 0), citer, biter, transfers_done);
+            FL_WARN_F("[FlexIO RX] post-timeout FLEXIO1: SHIFTSTAT=0x%x SHIFTERR=0x%x TIMSTAT=0x%x CTRL=0x%x",
+                      FLEXIO1_SHIFTSTAT, FLEXIO1_SHIFTERR, FLEXIO1_TIMSTAT,
+                      FLEXIO1_CTRL);
             // FastLED#3066 Phase 1 diagnostic: also dump the first few
             // words of mCaptureBuffer so subsequent iterations can see
             // whether the DMA actually copied any non-zero data into RAM
-            // — distinguishing "shifter never fired" from "shifter fired
+            // â€” distinguishing "shifter never fired" from "shifter fired
             // but latched all-zero pin samples".
             if (mCaptureBuffer.size() >= 8u) {
-                FL_WARN("[FlexIO RX] mCaptureBuffer[0..7]: 0x"
-                        << fl::hex << mCaptureBuffer[0] << " 0x"
-                        << mCaptureBuffer[1] << " 0x"
-                        << mCaptureBuffer[2] << " 0x"
-                        << mCaptureBuffer[3] << " 0x"
-                        << mCaptureBuffer[4] << " 0x"
-                        << mCaptureBuffer[5] << " 0x"
-                        << mCaptureBuffer[6] << " 0x"
-                        << mCaptureBuffer[7] << fl::dec);
+                FL_WARN_F("[FlexIO RX] mCaptureBuffer[0..7]: 0x%x 0x%x 0x%x 0x%x 0x%x 0x%x 0x%x 0x%x",
+                          mCaptureBuffer[0], mCaptureBuffer[1],
+                          mCaptureBuffer[2], mCaptureBuffer[3],
+                          mCaptureBuffer[4], mCaptureBuffer[5],
+                          mCaptureBuffer[6], mCaptureBuffer[7]);
             }
             return RxWaitResult::TIMEOUT;
         }
@@ -653,23 +638,17 @@ RxWaitResult FlexIoRxChannelImpl::wait(u32 timeout_ms) {
     // iterations can compare buffer-fill behaviour between the timeout
     // path and the completion path. Iter 4 surfaced a surprise: DMA can
     // signal "complete" with `transfers_done=0/N` when the channel
-    // already reloaded CITER=BITER and the buffer is all-zero — meaning
+    // already reloaded CITER=BITER and the buffer is all-zero â€” meaning
     // either the shifter never fired or the ISR was misfired.
     if (mCaptureBuffer.size() >= 8u) {
         const u32 citer = mDma.TCD->CITER & 0x7FFFu;
         const u32 biter = mDma.TCD->BITER & 0x7FFFu;
         const u32 transfers_done = (biter > citer) ? (biter - citer) : 0u;
-        FL_WARN("[FlexIO RX] wait() SUCCESS: transfers_done="
-                << transfers_done << "/" << biter);
-        FL_WARN("[FlexIO RX] mCaptureBuffer[0..7]: 0x"
-                << fl::hex << mCaptureBuffer[0] << " 0x"
-                << mCaptureBuffer[1] << " 0x"
-                << mCaptureBuffer[2] << " 0x"
-                << mCaptureBuffer[3] << " 0x"
-                << mCaptureBuffer[4] << " 0x"
-                << mCaptureBuffer[5] << " 0x"
-                << mCaptureBuffer[6] << " 0x"
-                << mCaptureBuffer[7] << fl::dec);
+        FL_WARN_F("[FlexIO RX] wait() SUCCESS: transfers_done=%s/%s", transfers_done, biter);
+        FL_WARN_F("[FlexIO RX] mCaptureBuffer[0..7]: 0x%x 0x%x 0x%x 0x%x 0x%x 0x%x 0x%x 0x%x",
+                  mCaptureBuffer[0], mCaptureBuffer[1], mCaptureBuffer[2],
+                  mCaptureBuffer[3], mCaptureBuffer[4], mCaptureBuffer[5],
+                  mCaptureBuffer[6], mCaptureBuffer[7]);
     }
     return RxWaitResult::SUCCESS;
 }
@@ -679,11 +658,11 @@ void FlexIoRxChannelImpl::buildEdgeTimesFromCaptures() {
     mEdges.clear();
 
     // Each capture is a 16-bit tick count of the time the pin spent in its
-    // previous LEVEL — i.e. the duration of the segment THAT JUST ENDED at
+    // previous LEVEL â€” i.e. the duration of the segment THAT JUST ENDED at
     // the moment this edge fired. We convert to nanoseconds via
     //   delta_ns = (ticks * 1000) / kFlexIo1ClkMHz
     // and store one `EdgeTime{level, ns}` per segment. Level alternates
-    // starting from the pin's idle state (`mStartLow == true` → first
+    // starting from the pin's idle state (`mStartLow == true` â†’ first
     // recorded segment was LOW).
     bool high = !mStartLow;
     for (size_t i = 0; i < mCaptureBuffer.size(); ++i) {
@@ -742,11 +721,9 @@ bool FlexIoRxChannelImpl::injectEdges(fl::span<const EdgeTime> edges) {
 fl::shared_ptr<FlexIoRxChannel> FlexIoRxChannel::create(int pin) {
     const FlexIo1PinInfo *info = lookupFlexIo1Pin(pin);
     if (!info) {
-        FL_WARN("[FlexIO RX] Pin "
-                << pin
-                << " has no FLEXIO1 mux mapping (Phase 1B initial map is "
+        FL_WARN_F("[FlexIO RX] Pin %s has no FLEXIO1 mux mapping (Phase 1B initial map is "
                    "minimal; expand kFlexIo1Pins[] as bench tests qualify "
-                   "additional pins). See FastLED#2764.");
+                   "additional pins). See FastLED#2764.", pin);
         return fl::shared_ptr<FlexIoRxChannel>();
     }
     return fl::make_shared<FlexIoRxChannelImpl>(pin);

--- a/src/platforms/arm/teensy/teensy4_common/rx_flexpwm_channel.cpp.hpp
+++ b/src/platforms/arm/teensy/teensy4_common/rx_flexpwm_channel.cpp.hpp
@@ -270,16 +270,9 @@ decodeEdges(const ChipsetTiming4Phase &timing,
     }
 
 #ifdef FL_DEBUG
-    FL_WARN("[FlexPWM DECODE] bytes=" << byte_index
-            << " total_bits=" << total_bits
-            << " errors=" << error_count
-            << " resyncs=" << resync_count
-            << " edges=" << edges.size());
+    FL_WARN_F("[FlexPWM DECODE] bytes=%s total_bits=%s errors=%s resyncs=%s edges=%s", byte_index, total_bits, error_count, resync_count, edges.size());
     if (edges.size() >= 4) {
-        FL_WARN("[FlexPWM DECODE] e[0]=" << (edges[0].high?"H":"L") << edges[0].ns
-                << " e[1]=" << (edges[1].high?"H":"L") << edges[1].ns
-                << " e[2]=" << (edges[2].high?"H":"L") << edges[2].ns
-                << " e[3]=" << (edges[3].high?"H":"L") << edges[3].ns);
+        FL_WARN_F("[FlexPWM DECODE] e[0]=%s%s e[1]=%s%s e[2]=%s%s e[3]=%s%s", (edges[0].high?"H":"L"), edges[0].ns, (edges[1].high?"H":"L"), edges[1].ns, (edges[2].high?"H":"L"), edges[2].ns, (edges[3].high?"H":"L"), edges[3].ns);
     }
 #endif
 
@@ -353,8 +346,7 @@ FlexPwmRxChannelImpl *FlexPwmRxChannelImpl::sActiveInstance = nullptr;
 bool FlexPwmRxChannelImpl::begin(const RxConfig &config) {
     mPinInfo = lookupPin(mPin);
     if (!mPinInfo) {
-        FL_WARN("Pin " << mPin
-                        << " does not support FlexPWM capture on Teensy 4.x");
+        FL_WARN_F("Pin %s does not support FlexPWM capture on Teensy 4.x", mPin);
         return false;
     }
 
@@ -455,23 +447,19 @@ void FlexPwmRxChannelImpl::configureFlexPwm() {
     pwm->MCTRL |= FLEXPWM_MCTRL_RUN(1 << sm);
 
 #ifdef FL_DEBUG
-    FL_WARN("[FlexPWM CFG] pin=" << static_cast<int>(mPinInfo->pin)
-            << " pwm" << (pwm == &IMXRT_FLEXPWM1 ? 1 : pwm == &IMXRT_FLEXPWM2 ? 2 : pwm == &IMXRT_FLEXPWM3 ? 3 : 4)
-            << " sm=" << static_cast<int>(sm)
-            << " chB=" << mPinInfo->channel_b);
-    FL_WARN("[FlexPWM CFG] MCTRL=0x" << fl::hex << pwm->MCTRL
-            << " CTRL2=0x" << pwm->SM[sm].CTRL2
-            << " CTRL=0x" << pwm->SM[sm].CTRL << fl::dec);
+    FL_WARN_F("[FlexPWM CFG] pin=%s pwm%s sm=%s chB=%s", static_cast<int>(mPinInfo->pin), (pwm == &IMXRT_FLEXPWM1 ? 1 : pwm == &IMXRT_FLEXPWM2 ? 2 : pwm == &IMXRT_FLEXPWM3 ? 3 : 4), static_cast<int>(sm), mPinInfo->channel_b);
+    FL_WARN_F("[FlexPWM CFG] MCTRL=0x%x CTRL2=0x%x CTRL=0x%x",
+              pwm->MCTRL, pwm->SM[sm].CTRL2, pwm->SM[sm].CTRL);
     if (!mPinInfo->channel_b) {
-        FL_WARN("[FlexPWM CFG] CAPTCTRLA=0x" << fl::hex << pwm->SM[sm].CAPTCTRLA
-                << " DMAEN=0x" << pwm->SM[sm].DMAEN
-                << " STS=0x" << pwm->SM[sm].STS << fl::dec);
+        FL_WARN_F("[FlexPWM CFG] CAPTCTRLA=0x%x DMAEN=0x%x STS=0x%x",
+                  pwm->SM[sm].CAPTCTRLA, pwm->SM[sm].DMAEN,
+                  pwm->SM[sm].STS);
     } else {
-        FL_WARN("[FlexPWM CFG] CAPTCTRLB=0x" << fl::hex << pwm->SM[sm].CAPTCTRLB
-                << " DMAEN=0x" << pwm->SM[sm].DMAEN
-                << " STS=0x" << pwm->SM[sm].STS << fl::dec);
+        FL_WARN_F("[FlexPWM CFG] CAPTCTRLB=0x%x DMAEN=0x%x STS=0x%x",
+                  pwm->SM[sm].CAPTCTRLB, pwm->SM[sm].DMAEN,
+                  pwm->SM[sm].STS);
     }
-    FL_WARN("[FlexPWM CFG] MUX=0x" << fl::hex << *(mPinInfo->mux_register) << fl::dec);
+    FL_WARN_F("[FlexPWM CFG] MUX=0x%x", *(mPinInfo->mux_register));
 #endif
 }
 
@@ -511,12 +499,11 @@ void FlexPwmRxChannelImpl::configureDma() {
     volatile u32 *dmamux_reg = &DMAMUX_CHCFG0 + mDma.channel;
     uintptr_t dma_daddr = mDma.TCD->DADDR; // ok reading register
     uintptr_t buf_addr = reinterpret_cast<uintptr_t>(mCaptureBuffer.data()); // ok reinterpret cast
-    FL_WARN("[FlexPWM DMA] ch=" << mDma.channel
-            << " src=" << static_cast<int>(mPinInfo->dma_source)
-            << " DMAMUX=0x" << fl::hex << *dmamux_reg << fl::dec
-            << " CITER=" << static_cast<int>(mDma.TCD->CITER)
-            << " ERQ=" << (DMA_ERQ & (1 << mDma.channel) ? 1 : 0)
-            << " DADDR_match=" << (dma_daddr == buf_addr ? "YES" : "NO"));
+    FL_WARN_F("[FlexPWM DMA] ch=%s src=%d DMAMUX=0x%x CITER=%d ERQ=%d DADDR_match=%s",
+              mDma.channel, static_cast<int>(mPinInfo->dma_source),
+              *dmamux_reg, static_cast<int>(mDma.TCD->CITER),
+              (DMA_ERQ & (1 << mDma.channel) ? 1 : 0),
+              (dma_daddr == buf_addr ? "YES" : "NO"));
 #endif
 }
 
@@ -627,12 +614,7 @@ void FlexPwmRxChannelImpl::buildEdgeTimesFromCaptures() {
     }
 
 #ifdef FL_DEBUG
-    FL_WARN("[FlexPWM RX] DMA captures_written=" << captures_written
-            << " BITER=" << biter << " CITER=" << citer
-            << " done=" << (dma_done ? 1 : 0)
-            << " mReceiveDone=" << (mReceiveDone ? 1 : 0)
-            << " ch=" << mDma.channel
-            << " pin=" << static_cast<int>(mPinInfo->pin));
+    FL_WARN_F("[FlexPWM RX] DMA captures_written=%s BITER=%s CITER=%s done=%s mReceiveDone=%s ch=%s pin=%s", captures_written, biter, citer, (dma_done ? 1 : 0), (mReceiveDone ? 1 : 0), mDma.channel, static_cast<int>(mPinInfo->pin));
 #endif
 
     // CRITICAL: Invalidate D-cache for the capture buffer region.
@@ -646,11 +628,9 @@ void FlexPwmRxChannelImpl::buildEdgeTimesFromCaptures() {
 
 #ifdef FL_DEBUG
     if (captures_written >= 8) {
-        FL_WARN("[FlexPWM RAW] first: " << mCaptureBuffer[0] << " " << mCaptureBuffer[1]
-                << " " << mCaptureBuffer[2] << " " << mCaptureBuffer[3]);
+        FL_WARN_F("[FlexPWM RAW] first: %s %s %s %s", mCaptureBuffer[0], mCaptureBuffer[1], mCaptureBuffer[2], mCaptureBuffer[3]);
         size_t mid = captures_written / 2;
-        FL_WARN("[FlexPWM RAW] mid[" << mid << "]: " << mCaptureBuffer[mid] << " " << mCaptureBuffer[mid+1]
-                << " " << mCaptureBuffer[mid+2] << " " << mCaptureBuffer[mid+3]);
+        FL_WARN_F("[FlexPWM RAW] mid[%s]: %s %s %s %s", mid, mCaptureBuffer[mid], mCaptureBuffer[mid+1], mCaptureBuffer[mid+2], mCaptureBuffer[mid+3]);
     }
 #endif
 
@@ -686,18 +666,11 @@ void FlexPwmRxChannelImpl::buildEdgeTimesFromCaptures() {
     }
 
 #ifdef FL_DEBUG
-    FL_WARN("[FlexPWM EDGE] total=" << mEdges.size());
+    FL_WARN_F("[FlexPWM EDGE] total=%s", mEdges.size());
     if (mEdges.size() >= 8) {
-        FL_WARN("[FlexPWM E] 0:" << (mEdges[0].high?"H":"L") << mEdges[0].ns
-                << " 1:" << (mEdges[1].high?"H":"L") << mEdges[1].ns
-                << " 2:" << (mEdges[2].high?"H":"L") << mEdges[2].ns
-                << " 3:" << (mEdges[3].high?"H":"L") << mEdges[3].ns);
+        FL_WARN_F("[FlexPWM E] 0:%s%s 1:%s%s 2:%s%s 3:%s%s", (mEdges[0].high?"H":"L"), mEdges[0].ns, (mEdges[1].high?"H":"L"), mEdges[1].ns, (mEdges[2].high?"H":"L"), mEdges[2].ns, (mEdges[3].high?"H":"L"), mEdges[3].ns);
         size_t mid = mEdges.size() / 2;
-        FL_WARN("[FlexPWM E@" << mid << "] "
-                << (mEdges[mid].high?"H":"L") << mEdges[mid].ns
-                << " " << (mEdges[mid+1].high?"H":"L") << mEdges[mid+1].ns
-                << " " << (mEdges[mid+2].high?"H":"L") << mEdges[mid+2].ns
-                << " " << (mEdges[mid+3].high?"H":"L") << mEdges[mid+3].ns);
+        FL_WARN_F("[FlexPWM E@%s] %s%s %s%s %s%s %s%s", mid, (mEdges[mid].high?"H":"L"), mEdges[mid].ns, (mEdges[mid+1].high?"H":"L"), mEdges[mid+1].ns, (mEdges[mid+2].high?"H":"L"), mEdges[mid+2].ns, (mEdges[mid+3].high?"H":"L"), mEdges[mid+3].ns);
     }
 #endif
 
@@ -764,8 +737,7 @@ bool FlexPwmRxChannelImpl::injectEdges(fl::span<const EdgeTime> edges) {
 fl::shared_ptr<FlexPwmRxChannel> FlexPwmRxChannel::create(int pin) {
     const FlexPwmPinInfo *info = lookupPin(pin);
     if (!info) {
-        FL_WARN("Pin " << pin
-                        << " does not support FlexPWM capture on Teensy 4.x");
+        FL_WARN_F("Pin %s does not support FlexPWM capture on Teensy 4.x", pin);
         return fl::shared_ptr<FlexPwmRxChannel>();
     }
     return fl::make_shared<FlexPwmRxChannelImpl>(pin);

--- a/src/platforms/arm/teensy/teensy4_common/spi_hw_2_mxrt1062.cpp.hpp
+++ b/src/platforms/arm/teensy/teensy4_common/spi_hw_2_mxrt1062.cpp.hpp
@@ -123,7 +123,7 @@ bool SpiHw2MXRT1062::begin(const SpiHw2::Config& config) {
 
     // Validate bus_num against mBusId if driver has pre-assigned ID
     if (mBusId != -1 && config.bus_num != static_cast<u8>(mBusId)) {
-        FL_WARN("SpiHw2MXRT1062: Bus mismatch - expected " << mBusId << ", got " << static_cast<int>(config.bus_num));
+        FL_WARN_F("SpiHw2MXRT1062: Bus mismatch - expected %s, got %s", mBusId, static_cast<int>(config.bus_num));
         return false;
     }
 
@@ -143,13 +143,13 @@ bool SpiHw2MXRT1062::begin(const SpiHw2::Config& config) {
             mBusId = 2;
             break;
         default:
-            FL_WARN("SpiHw2MXRT1062: Invalid bus number " << static_cast<int>(bus_num));
+            FL_WARN_F("SpiHw2MXRT1062: Invalid bus number %s", static_cast<int>(bus_num));
             return false;
     }
 
     // Validate that both data pins are specified
     if (config.data0_pin < 0 || config.data1_pin < 0) {
-        FL_WARN("SpiHw2MXRT1062: Dual-SPI requires both data0 and data1 pins");
+        FL_WARN_F("SpiHw2MXRT1062: Dual-SPI requires both data0 and data1 pins");
         return false;
     }
 
@@ -183,13 +183,9 @@ bool SpiHw2MXRT1062::begin(const SpiHw2::Config& config) {
     }
 
     if (!pins_valid) {
-        FL_WARN("SpiHw2MXRT1062: Invalid pin combination for bus " << mBusId);
-        FL_WARN("  Expected: SCK=" << (int)valid_pins[mBusId].sck
-                   << " D0=" << (int)valid_pins[mBusId].mosi
-                   << " D1=" << (int)valid_pins[mBusId].miso);
-        FL_WARN("  Got: SCK=" << (int)mClockPin
-                   << " D0=" << (int)mData0Pin
-                   << " D1=" << (int)mData1Pin);
+        FL_WARN_F("SpiHw2MXRT1062: Invalid pin combination for bus %s", mBusId);
+        FL_WARN_F("  Expected: SCK=%s D0=%s D1=%s", (int)valid_pins[mBusId].sck, (int)valid_pins[mBusId].mosi, (int)valid_pins[mBusId].miso);
+        FL_WARN_F("  Got: SCK=%s D0=%s D1=%s", (int)mClockPin, (int)mData0Pin, (int)mData1Pin);
         return false;
     }
 
@@ -229,15 +225,10 @@ bool SpiHw2MXRT1062::begin(const SpiHw2::Config& config) {
 
         port->CFGR1 = cfgr1;
 
-        FL_LOG_SPI("SpiHw2MXRT1062: Configured CFGR1=" << cfgr1
-                   << " (OUTCFG enabled for dual-mode)");
+        FL_LOG_SPI_F("SpiHw2MXRT1062: Configured CFGR1=%s (OUTCFG enabled for dual-mode)", cfgr1);
     }
 
-    FL_LOG_SPI("SpiHw2MXRT1062: Initialized on bus " << mBusId
-            << " clock=" << mClockSpeed << "Hz"
-            << " pins: CLK=" << (int)mClockPin
-            << " D0=" << (int)mData0Pin
-            << " D1=" << (int)mData1Pin);
+    FL_LOG_SPI_F("SpiHw2MXRT1062: Initialized on bus %s clock=%sHz pins: CLK=%s D0=%s D1=%s", mBusId, mClockSpeed, (int)mClockPin, (int)mData0Pin, (int)mData1Pin);
 
     mInitialized = true;
     mTransactionActive = false;
@@ -296,7 +287,7 @@ bool SpiHw2MXRT1062::transmit(TransmitMode mode) {
         return true;  // Nothing to transmit
     }
 
-    FL_LOG_SPI("SpiHw2MXRT1062: Transmitting " << mCurrentTotalSize << " bytes via LPSPI bus " << mBusId);
+    FL_LOG_SPI_F("SpiHw2MXRT1062: Transmitting %s bytes via LPSPI bus %s", mCurrentTotalSize, mBusId);
 
     // Begin SPI transaction with configured clock speed
     mSPI->beginTransaction(SPISettings(mClockSpeed, MSBFIRST, SPI_MODE0));

--- a/src/platforms/arm/teensy/teensy4_common/spi_hw_4_mxrt1062.cpp.hpp
+++ b/src/platforms/arm/teensy/teensy4_common/spi_hw_4_mxrt1062.cpp.hpp
@@ -139,7 +139,7 @@ bool SpiHw4MXRT1062::begin(const SpiHw4::Config& config) {
 
     // Validate bus_num against mBusId if driver has pre-assigned ID
     if (mBusId != -1 && config.bus_num != static_cast<u8>(mBusId)) {
-        FL_LOG_SPI("SpiHw4MXRT1062: Bus mismatch - expected " << mBusId << ", got " << static_cast<int>(config.bus_num));
+        FL_LOG_SPI_F("SpiHw4MXRT1062: Bus mismatch - expected %s, got %s", mBusId, static_cast<int>(config.bus_num));
         return false;
     }
 
@@ -159,7 +159,7 @@ bool SpiHw4MXRT1062::begin(const SpiHw4::Config& config) {
             mBusId = 2;
             break;
         default:
-            FL_LOG_SPI("SpiHw4MXRT1062: Invalid bus number " << static_cast<int>(bus_num));
+            FL_LOG_SPI_F("SpiHw4MXRT1062: Invalid bus number %s", static_cast<int>(bus_num));
             return false;
     }
 
@@ -179,9 +179,9 @@ bool SpiHw4MXRT1062::begin(const SpiHw4::Config& config) {
 
     // Warn if quad mode requested but pins aren't available on standard boards
     if (mActiveLanes == 4) {
-        FL_LOG_SPI("SpiHw4MXRT1062: Quad-SPI mode enabled with 4 lanes");
-        FL_LOG_SPI("  Note: data2/data3 pins (PCS2/PCS3) are not exposed on standard Teensy 4.0/4.1 boards");
-        FL_LOG_SPI("  This requires custom hardware or breakout adapters");
+        FL_LOG_SPI_F("SpiHw4MXRT1062: Quad-SPI mode enabled with 4 lanes");
+        FL_LOG_SPI_F("  Note: data2/data3 pins (PCS2/PCS3) are not exposed on standard Teensy 4.0/4.1 boards");
+        FL_LOG_SPI_F("  This requires custom hardware or breakout adapters");
     }
 
     // Configure custom pins BEFORE calling begin()
@@ -204,14 +204,7 @@ bool SpiHw4MXRT1062::begin(const SpiHw4::Config& config) {
     // Initialize the SPI peripheral
     mSPI->begin();
 
-    FL_LOG_SPI("SpiHw4MXRT1062: Initialized on bus " << mBusId
-            << " clock=" << mClockSpeed << "Hz"
-            << " lanes=" << static_cast<int>(mActiveLanes)
-            << " pins: CLK=" << (int)mClockPin
-            << " D0=" << (int)mData0Pin
-            << " D1=" << (int)mData1Pin
-            << " D2=" << (int)mData2Pin
-            << " D3=" << (int)mData3Pin);
+    FL_LOG_SPI_F("SpiHw4MXRT1062: Initialized on bus %s clock=%sHz lanes=%s pins: CLK=%s D0=%s D1=%s D2=%s D3=%s", mBusId, mClockSpeed, static_cast<int>(mActiveLanes), (int)mClockPin, (int)mData0Pin, (int)mData1Pin, (int)mData2Pin, (int)mData3Pin);
 
     mInitialized = true;
     mTransactionActive = false;
@@ -270,8 +263,7 @@ bool SpiHw4MXRT1062::transmit(TransmitMode mode) {
         return true;  // Nothing to transmit
     }
 
-    FL_LOG_SPI("SpiHw4MXRT1062: Transmitting " << mCurrentTotalSize << " bytes via LPSPI bus " << mBusId
-            << " with " << static_cast<int>(mActiveLanes) << " lanes");
+    FL_LOG_SPI_F("SpiHw4MXRT1062: Transmitting %s bytes via LPSPI bus %s with %s lanes", mCurrentTotalSize, mBusId, static_cast<int>(mActiveLanes));
 
     // Begin SPI transaction with configured clock speed
     mSPI->beginTransaction(SPISettings(mClockSpeed, MSBFIRST, SPI_MODE0));

--- a/src/platforms/arm/teensy/teensy4_common/spi_hw_manager_mxrt1062.cpp.hpp
+++ b/src/platforms/arm/teensy/teensy4_common/spi_hw_manager_mxrt1062.cpp.hpp
@@ -41,7 +41,7 @@ constexpr int PRIORITY_SPI_HW_2 = 6;   // Lower (2-lane dual-SPI)
 static void addSpiHw2IfPossible() {
     // Note: SpiHw2MXRT1062 class is defined in spi_hw_2_mxrt1062.cpp.hpp
     // which is included by _build.hpp before this file
-    FL_DBG("Teensy 4.x: Registering SpiHw2 instances");
+    FL_DBG_F("Teensy 4.x: Registering SpiHw2 instances");
 
     // Teensy 4.x has 3 LPSPI peripherals available
     // SPI (bus 0), SPI1 (bus 1), SPI2 (bus 2)
@@ -53,14 +53,14 @@ static void addSpiHw2IfPossible() {
     SpiHw2::registerInstance(controller1);
     SpiHw2::registerInstance(controller2);
 
-    FL_DBG("Teensy 4.x: SpiHw2 instances registered");
+    FL_DBG_F("Teensy 4.x: SpiHw2 instances registered");
 }
 
 /// @brief Register Teensy 4.x SpiHw4 instances
 static void addSpiHw4IfPossible() {
     // Note: SpiHw4MXRT1062 class is defined in spi_hw_4_mxrt1062.cpp.hpp
     // which is included by _build.hpp before this file
-    FL_DBG("Teensy 4.x: Registering SpiHw4 instances");
+    FL_DBG_F("Teensy 4.x: Registering SpiHw4 instances");
 
     // Teensy 4.x has 3 LPSPI peripherals available
     // SPI (bus 0), SPI1 (bus 1), SPI2 (bus 2)
@@ -72,7 +72,7 @@ static void addSpiHw4IfPossible() {
     SpiHw4::registerInstance(controller1);
     SpiHw4::registerInstance(controller2);
 
-    FL_DBG("Teensy 4.x: SpiHw4 instances registered");
+    FL_DBG_F("Teensy 4.x: SpiHw4 instances registered");
 }
 
 }  // namespace detail
@@ -91,13 +91,13 @@ namespace platforms {
 /// Platform availability:
 /// - Teensy 4.0/4.1: Both SpiHw2 and SpiHw4 (3 LPSPI controllers)
 void initSpiHardware() {
-    FL_DBG("Teensy 4.x: Initializing SPI hardware");
+    FL_DBG_F("Teensy 4.x: Initializing SPI hardware");
 
     // Register in priority order (highest to lowest)
     detail::addSpiHw4IfPossible();  // Priority 7
     detail::addSpiHw2IfPossible();  // Priority 6
 
-    FL_DBG("Teensy 4.x: SPI hardware initialized");
+    FL_DBG_F("Teensy 4.x: SPI hardware initialized");
 }
 
 }  // namespace platforms

--- a/src/platforms/avr/atmega/isr_avr_atmega.hpp
+++ b/src/platforms/avr/atmega/isr_avr_atmega.hpp
@@ -159,18 +159,18 @@ ISR(TIMER1_COMPA_vect) {
 
 int attach_timer_handler(const isr_config_t& config, isr_handle_t* out_handle) FL_NOEXCEPT {
     if (!config.handler) {
-        FL_WARN("AVR ISR: handler is null");
+        FL_WARN_F("AVR ISR: handler is null");
         return -1;  // Invalid parameter
     }
 
     if (config.frequency_hz == 0) {
-        FL_WARN("AVR ISR: frequency_hz is 0");
+        FL_WARN_F("AVR ISR: frequency_hz is 0");
         return -2;  // Invalid frequency
     }
 
     // Check if timer is already in use
     if (g_avr_timer_data != nullptr) {
-        FL_WARN("AVR ISR: Timer1 already in use (only one timer supported)");
+        FL_WARN_F("AVR ISR: Timer1 already in use (only one timer supported)");
         return -16;  // Timer already in use
     }
 
@@ -178,7 +178,7 @@ int attach_timer_handler(const isr_config_t& config, isr_handle_t* out_handle) F
     auto handle_owner = fl::make_unique<avr_isr_handle_data>();
     auto* handle_data = handle_owner.get();
     if (!handle_data) {
-        FL_WARN("AVR ISR: failed to allocate handle data");
+        FL_WARN_F("AVR ISR: failed to allocate handle data");
         return -3;  // Out of memory
     }
 
@@ -186,7 +186,7 @@ int attach_timer_handler(const isr_config_t& config, isr_handle_t* out_handle) F
     u8 prescaler_idx;
     u16 ocr_value;
     if (!calculate_timer_config(config.frequency_hz, prescaler_idx, ocr_value)) {
-        FL_WARN("AVR ISR: frequency " << config.frequency_hz << " Hz out of range");
+        FL_WARN_F("AVR ISR: frequency %s Hz out of range", config.frequency_hz);
         return -2;  // Invalid frequency (out of range)
     }
 
@@ -197,12 +197,10 @@ int attach_timer_handler(const isr_config_t& config, isr_handle_t* out_handle) F
     i32 freq_error = static_cast<i32>(actual_freq) - static_cast<i32>(config.frequency_hz);
     i32 error_pct = (freq_error * 100) / static_cast<i32>(config.frequency_hz);
     if (error_pct > 5 || error_pct < -5) {
-        FL_WARN("AVR ISR: frequency error " << error_pct << "% (requested "
-                << config.frequency_hz << " Hz, actual " << actual_freq << " Hz)");
+        FL_WARN_F("AVR ISR: frequency error %s% (requested %s Hz, actual %s Hz)", error_pct, config.frequency_hz, actual_freq);
     }
 
-    FL_DBG("AVR ISR: Timer1 config: prescaler=" << PRESCALERS[prescaler_idx].value
-           << ", OCR1A=" << ocr_value << ", actual_freq=" << actual_freq << " Hz");
+    FL_DBG_F("AVR ISR: Timer1 config: prescaler=%s, OCR1A=%s, actual_freq=%s Hz", PRESCALERS[prescaler_idx].value, ocr_value, actual_freq);
 
     // Store configuration
     handle_data->mIsTimer = true;
@@ -239,7 +237,7 @@ int attach_timer_handler(const isr_config_t& config, isr_handle_t* out_handle) F
 
     handle_data->mIsEnabled = true;
 
-    FL_DBG("AVR ISR: Timer1 started at " << actual_freq << " Hz");
+    FL_DBG_F("AVR ISR: Timer1 started at %s Hz", actual_freq);
 
     // Populate output handle
     if (out_handle) {
@@ -259,19 +257,19 @@ int attach_external_handler(u8 pin, const isr_config_t& config, isr_handle_t* ou
     (void)pin;
     (void)config;
     (void)out_handle;
-    FL_WARN("AVR ISR: external interrupts not yet implemented");
+    FL_WARN_F("AVR ISR: external interrupts not yet implemented");
     return -100;  // Not implemented
 }
 
 int detach_handler(isr_handle_t& handle) FL_NOEXCEPT {
     if (!handle.is_valid() || handle.platform_id != AVR_PLATFORM_ID) {
-        FL_WARN("AVR ISR: invalid handle");
+        FL_WARN_F("AVR ISR: invalid handle");
         return -1;  // Invalid handle
     }
 
     avr_isr_handle_data* handle_data = static_cast<avr_isr_handle_data*>(handle.platform_handle);
     if (!handle_data) {
-        FL_WARN("AVR ISR: null handle data");
+        FL_WARN_F("AVR ISR: null handle data");
         return -1;  // Invalid handle
     }
 
@@ -296,19 +294,19 @@ int detach_handler(isr_handle_t& handle) FL_NOEXCEPT {
     handle.platform_handle = nullptr;
     handle.platform_id = 0;
 
-    FL_DBG("AVR ISR: handler detached");
+    FL_DBG_F("AVR ISR: handler detached");
     return 0;  // Success
 }
 
 int enable_handler(const isr_handle_t& handle) FL_NOEXCEPT {
     if (!handle.is_valid() || handle.platform_id != AVR_PLATFORM_ID) {
-        FL_WARN("AVR ISR: invalid handle");
+        FL_WARN_F("AVR ISR: invalid handle");
         return -1;  // Invalid handle
     }
 
     avr_isr_handle_data* handle_data = static_cast<avr_isr_handle_data*>(handle.platform_handle);
     if (!handle_data) {
-        FL_WARN("AVR ISR: null handle data");
+        FL_WARN_F("AVR ISR: null handle data");
         return -1;  // Invalid handle
     }
 
@@ -337,13 +335,13 @@ int enable_handler(const isr_handle_t& handle) FL_NOEXCEPT {
 
 int disable_handler(const isr_handle_t& handle) FL_NOEXCEPT {
     if (!handle.is_valid() || handle.platform_id != AVR_PLATFORM_ID) {
-        FL_WARN("AVR ISR: invalid handle");
+        FL_WARN_F("AVR ISR: invalid handle");
         return -1;  // Invalid handle
     }
 
     avr_isr_handle_data* handle_data = static_cast<avr_isr_handle_data*>(handle.platform_handle);
     if (!handle_data) {
-        FL_WARN("AVR ISR: null handle data");
+        FL_WARN_F("AVR ISR: null handle data");
         return -1;  // Invalid handle
     }
 

--- a/src/platforms/esp/32/audio/audio_impl.hpp
+++ b/src/platforms/esp/32/audio/audio_impl.hpp
@@ -25,7 +25,7 @@ esp32_create_audio_input(const audio::Config &config,
                          fl::string *error_message) FL_NOEXCEPT {
     if (config.is<audio::ConfigI2S>()) {
 #if FASTLED_ESP32_I2S_SUPPORTED
-        FL_WARN("Creating I2S standard mode audio source");
+        FL_WARN_F("Creating I2S standard mode audio source");
         audio::ConfigI2S std_config = config.get<audio::ConfigI2S>();
         fl::shared_ptr<audio::IInput> out =
             fl::make_shared<fl::I2S_Audio>(std_config);
@@ -33,7 +33,7 @@ esp32_create_audio_input(const audio::Config &config,
 #else
         const char *ERROR_MESSAGE =
             "I2S audio not supported on this ESP32 variant (no I2S hardware)";
-        FL_WARN(ERROR_MESSAGE);
+        FL_WARN_F("%s", ERROR_MESSAGE);
         if (error_message) {
             *error_message = ERROR_MESSAGE;
         }
@@ -41,7 +41,7 @@ esp32_create_audio_input(const audio::Config &config,
 #endif
     } else if (config.is<audio::ConfigPdm>()) {
 #if FASTLED_ESP32_PDM_SUPPORTED
-        FL_WARN("Creating PDM mode audio source");
+        FL_WARN_F("Creating PDM mode audio source");
         audio::ConfigPdm pdm_config = config.get<audio::ConfigPdm>();
         fl::shared_ptr<audio::IInput> out =
             fl::make_shared<fl::PDM_Audio>(pdm_config);
@@ -49,7 +49,7 @@ esp32_create_audio_input(const audio::Config &config,
 #else
         const char *ERROR_MESSAGE = "PDM audio not supported on this ESP32 "
                                     "variant (no PDM RX hardware)";
-        FL_WARN(ERROR_MESSAGE);
+        FL_WARN_F("%s", ERROR_MESSAGE);
         if (error_message) {
             *error_message = ERROR_MESSAGE;
         }
@@ -57,7 +57,7 @@ esp32_create_audio_input(const audio::Config &config,
 #endif
     }
     const char *ERROR_MESSAGE = "Unsupported audio configuration";
-    FL_WARN(ERROR_MESSAGE);
+    FL_WARN_F("%s", ERROR_MESSAGE);
     if (error_message) {
         *error_message = ERROR_MESSAGE;
     }

--- a/src/platforms/esp/32/audio/devices/i2s.hpp
+++ b/src/platforms/esp/32/audio/devices/i2s.hpp
@@ -45,7 +45,7 @@ class I2S_Audio : public audio::IInput {
 
     void start() FL_NOEXCEPT override {
         if (mI2sContextOpt) {
-            FL_WARN("I2S channel is already initialized");
+            FL_WARN_F("I2S channel is already initialized");
             return;
         }
         esp_i2s::I2SContext ctx = esp_i2s::i2s_audio_init(mStdConfig);
@@ -71,7 +71,7 @@ class I2S_Audio : public audio::IInput {
 
     audio::Sample read() FL_NOEXCEPT override {
         if (!mI2sContextOpt) {
-            FL_WARN("I2S channel is not initialized");
+            FL_WARN_F("I2S channel is not initialized");
             return audio::Sample();  // Invalid sample
         }
 

--- a/src/platforms/esp/32/audio/devices/idf4_pdm_context.hpp
+++ b/src/platforms/esp/32/audio/devices/idf4_pdm_context.hpp
@@ -55,12 +55,12 @@ PDMContext pdm_audio_init(const audio::ConfigPdm &config) FL_NOEXCEPT {
 
     esp_err_t ret = i2s_driver_install(i2s_port, &i2s_config, 0, nullptr);
     if (ret != ESP_OK) {
-        FL_WARN("Failed to install PDM I2S driver: " << ret);
+        FL_WARN_F("Failed to install PDM I2S driver: %s", ret);
         return ctx;
     }
     ret = i2s_set_pin(i2s_port, &pin_config);
     if (ret != ESP_OK) {
-        FL_WARN("Failed to set PDM I2S pins: " << ret);
+        FL_WARN_F("Failed to set PDM I2S pins: %s", ret);
         i2s_driver_uninstall(i2s_port);
         return ctx;
     }

--- a/src/platforms/esp/32/audio/devices/idf5_pdm_context.hpp
+++ b/src/platforms/esp/32/audio/devices/idf5_pdm_context.hpp
@@ -48,7 +48,7 @@ PDMContext pdm_audio_init(const audio::ConfigPdm &config) FL_NOEXCEPT {
     // Create RX channel
     esp_err_t ret = i2s_new_channel(&chan_cfg, nullptr, &ctx.rx_handle);
     if (ret != ESP_OK) {
-        FL_WARN("Failed to create PDM I2S channel: " << ret);
+        FL_WARN_F("Failed to create PDM I2S channel: %s", ret);
         return ctx;
     }
 
@@ -71,7 +71,7 @@ PDMContext pdm_audio_init(const audio::ConfigPdm &config) FL_NOEXCEPT {
     // Initialize channel with PDM RX mode configuration
     ret = i2s_channel_init_pdm_rx_mode(ctx.rx_handle, &pdm_rx_cfg);
     if (ret != ESP_OK) {
-        FL_WARN("Failed to initialize PDM RX mode: " << ret);
+        FL_WARN_F("Failed to initialize PDM RX mode: %s", ret);
         i2s_del_channel(ctx.rx_handle);
         ctx.rx_handle = nullptr;
         return ctx;
@@ -80,7 +80,7 @@ PDMContext pdm_audio_init(const audio::ConfigPdm &config) FL_NOEXCEPT {
     // Enable the channel
     ret = i2s_channel_enable(ctx.rx_handle);
     if (ret != ESP_OK) {
-        FL_WARN("Failed to enable PDM channel: " << ret);
+        FL_WARN_F("Failed to enable PDM channel: %s", ret);
         i2s_del_channel(ctx.rx_handle);
         ctx.rx_handle = nullptr;
         return ctx;

--- a/src/platforms/esp/32/audio/devices/pdm.hpp
+++ b/src/platforms/esp/32/audio/devices/pdm.hpp
@@ -52,7 +52,7 @@ class PDM_Audio : public audio::IInput {
 
     void start() FL_NOEXCEPT override {
         if (mPdmContextOpt) {
-            FL_WARN("PDM channel is already initialized");
+            FL_WARN_F("PDM channel is already initialized");
             return;
         }
         esp_pdm::PDMContext ctx = esp_pdm::pdm_audio_init(mPdmConfig);
@@ -83,7 +83,7 @@ class PDM_Audio : public audio::IInput {
 
     audio::Sample read() FL_NOEXCEPT override {
         if (!mPdmContextOpt) {
-            FL_WARN("PDM channel is not initialized");
+            FL_WARN_F("PDM channel is not initialized");
             return audio::Sample();
         }
 

--- a/src/platforms/esp/32/condition_variable_esp32.cpp.hpp
+++ b/src/platforms/esp/32/condition_variable_esp32.cpp.hpp
@@ -56,7 +56,7 @@ ConditionVariableESP32::ConditionVariableESP32()
     // Create internal mutex for protecting the wait queue
     SemaphoreHandle_t mutex = xSemaphoreCreateMutex();
     if (mutex == nullptr) {
-        FL_WARN("ConditionVariableESP32: Failed to create internal mutex");
+        FL_WARN_F("ConditionVariableESP32: Failed to create internal mutex");
     }
     mMutex = static_cast<void*>(mutex);
 
@@ -64,7 +64,7 @@ ConditionVariableESP32::ConditionVariableESP32()
     // Queue can hold up to 10 waiting tasks (configurable if needed)
     QueueHandle_t queue = xQueueCreate(10, sizeof(WaitingTask));
     if (queue == nullptr) {
-        FL_WARN("ConditionVariableESP32: Failed to create wait queue");
+        FL_WARN_F("ConditionVariableESP32: Failed to create wait queue");
     }
     mWaitQueue = static_cast<void*>(queue);
 }
@@ -155,7 +155,7 @@ void ConditionVariableESP32::wait(unique_lock<Mutex>& lock) {
     // Add to wait queue
     BaseType_t result = xQueueSend(queue, &waiter, 0);
     if (result != pdTRUE) {
-        FL_WARN("ConditionVariableESP32: Wait queue full");
+        FL_WARN_F("ConditionVariableESP32: Wait queue full");
         xSemaphoreGive(internal_mutex);
         return;
     }
@@ -209,7 +209,7 @@ cv_status ConditionVariableESP32::wait_for(
     // Add to wait queue
     BaseType_t result = xQueueSend(queue, &waiter, 0);
     if (result != pdTRUE) {
-        FL_WARN("ConditionVariableESP32: Wait queue full");
+        FL_WARN_F("ConditionVariableESP32: Wait queue full");
         xSemaphoreGive(internal_mutex);
         return cv_status::timeout;
     }

--- a/src/platforms/esp/32/core/fastspi_esp32_idf.h
+++ b/src/platforms/esp/32/core/fastspi_esp32_idf.h
@@ -109,7 +109,7 @@ public:
         // Initialize bus with auto DMA
         esp_err_t ret = spi_bus_initialize(mHost, &bus_config, SPI_DMA_CH_AUTO);
         if (ret != ESP_OK) {
-            FL_WARN("SPI bus init failed: " << ret);
+            FL_WARN_F("SPI bus init failed: %s", ret);
             return;
         }
 
@@ -124,7 +124,7 @@ public:
         // Add device to bus
         ret = spi_bus_add_device(mHost, &dev_config, &mSPIHandle);
         if (ret != ESP_OK) {
-            FL_WARN("SPI add device failed: " << ret);
+            FL_WARN_F("SPI add device failed: %s", ret);
             spi_bus_free(mHost);
             return;
         }

--- a/src/platforms/esp/32/coroutine_esp32.impl.hpp
+++ b/src/platforms/esp/32/coroutine_esp32.impl.hpp
@@ -219,8 +219,7 @@ TaskCoroutinePtr TaskCoroutineESP32::create(
         heap_caps_malloc(sizeof(StaticTask_t),
                          MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT)));
     if (!impl->mStackBuf || !impl->mTaskTcb) {
-        FL_WARN("TaskCoroutineESP32: Failed to allocate stack/TCB for '"
-                << impl->mName << "'");
+        FL_WARN_F("TaskCoroutineESP32: Failed to allocate stack/TCB for '%s'", impl->mName);
         task.reset();
         return nullptr;
     }
@@ -252,8 +251,7 @@ TaskCoroutinePtr TaskCoroutineESP32::create(
 #endif
 
     if (!impl->mTask) {
-        FL_WARN("TaskCoroutineESP32: Failed to create FreeRTOS task for '"
-                << impl->mName << "'");
+        FL_WARN_F("TaskCoroutineESP32: Failed to create FreeRTOS task for '%s'", impl->mName);
         task.reset();
         return nullptr;
     }

--- a/src/platforms/esp/32/detail/io_esp_jtag_or_uart.hpp
+++ b/src/platforms/esp/32/detail/io_esp_jtag_or_uart.hpp
@@ -1,4 +1,4 @@
-// ESP32 I/O implementation - Unified UART + USB-Serial JTAG backend
+﻿// ESP32 I/O implementation - Unified UART + USB-Serial JTAG backend
 // Auto-detects USB-Serial JTAG on ESP32-S3/C3/C6/H2, falls back to UART otherwise
 // No Arduino dependencies - works standalone with ESP-IDF
 
@@ -8,7 +8,7 @@
 
 #include "platforms/esp/is_esp.h"
 
-#include "fl/log/log.h"  // FL_PRINT (used by reportInitDiagnosticsIfNeeded)
+#include "fl/log/log.h"  // FL_PRINT_F("%s", used by reportInitDiagnosticsIfNeeded)
 #include "fl/stl/compiler_control.h"
 #include "fl/stl/singleton.h"
 #include "platforms/esp/32/drivers/uart_esp32.h"
@@ -29,7 +29,7 @@
 // Previously EspIO held BOTH UartEsp32 AND UsbSerialJtagEsp32 as direct
 // members and runtime-probed which one was buffered. The linker had to
 // keep both drivers (and the ESP-IDF JTAG driver they pull in) alive
-// because both were reachable from every print/read/write/flush path —
+// because both were reachable from every print/read/write/flush path â€”
 // ~2-3 KB of dead weight when only one backend is actually used. See
 // FastLED #2773 item 1.4.
 //
@@ -38,15 +38,15 @@
 // Arduino-ESP32's existing `ARDUINO_USB_CDC_ON_BOOT` convention:
 //
 //   * ARDUINO_USB_CDC_ON_BOOT=1 (Arduino routes Serial through USB
-//     Serial-JTAG)     → EspIO uses UsbSerialJtagEsp32.
+//     Serial-JTAG)     â†’ EspIO uses UsbSerialJtagEsp32.
 //   * otherwise (Arduino-default UART0 console, or non-Arduino ESP-IDF
-//     build)            → EspIO uses UartEsp32.
+//     build)            â†’ EspIO uses UartEsp32.
 //
 // Explicit overrides for the rare case where a user wants a different
 // backend than what their Arduino board config implies:
 //
-//   * `#define FASTLED_ESP_FORCE_UART_SERIAL`        → forces UART.
-//   * `#define FASTLED_ESP_FORCE_USB_SERIAL_JTAG`    → forces JTAG.
+//   * `#define FASTLED_ESP_FORCE_UART_SERIAL`        â†’ forces UART.
+//   * `#define FASTLED_ESP_FORCE_USB_SERIAL_JTAG`    â†’ forces JTAG.
 //
 // Both macros are honored only when JTAG hardware is available; on
 // chips without JTAG (`FL_ESP_HAS_USB_SERIAL_JTAG == 0`) the choice is
@@ -227,11 +227,9 @@ private:
             case UsbSerialJtagEsp32::InitOutcome::kVerificationFailed:  outcome = "VerificationFailed"; break;
             case UsbSerialJtagEsp32::InitOutcome::kNotAvailable:        outcome = "NotAvailable"; break;
         }
-        FL_PRINT("EspIO: backend=" << backend
-                 << " usb_jtag_outcome=" << outcome
-                 << " err=" << static_cast<int>(mDriver.initError()));
+        FL_PRINT_F("EspIO: backend=%s usb_jtag_outcome=%s err=%s", backend, outcome, static_cast<int>(mDriver.initError()));
 #else
-        FL_PRINT("EspIO: backend=UART0 (compile-time choice; "
+        FL_PRINT_F("EspIO: backend=UART0 (compile-time choice; "
                  "#define FASTLED_ESP_FORCE_USB_SERIAL_JTAG to switch)");
 #endif
     }

--- a/src/platforms/esp/32/drivers/ble/ble_esp32.cpp.hpp
+++ b/src/platforms/esp/32/drivers/ble/ble_esp32.cpp.hpp
@@ -171,15 +171,15 @@ static int fl_ble_gatt_access_cb(u16 conn_handle, u16 attr_handle, // ok no noex
         u16 out_len = 0;
         int rc = ble_hs_mbuf_to_flat(ctxt->om, &val[0], om_len, &out_len);
         if (rc != 0) {
-            FL_WARN("[BLE RX] mbuf_to_flat failed rc=" << rc);
+            FL_WARN_F("[BLE RX] mbuf_to_flat failed rc=%s", rc);
             return BLE_ATT_ERR_UNLIKELY;
         }
         val.resize(out_len);
 
-        FL_WARN("[BLE RX] onWrite len=" << val.size() << ": " << val.c_str());
+        FL_WARN_F("[BLE RX] onWrite len=%s: %s", val.size(), val.c_str());
         int nextHead = (state->head + 1) % kBleRingBufferSize;
         if (nextHead == state->tail) {
-            FL_WARN("[BLE] Ring buffer full, dropping message");
+            FL_WARN_F("[BLE] Ring buffer full, dropping message");
             return 0;
         }
         state->ringBuffer[state->head] = val;
@@ -216,10 +216,9 @@ static int fl_ble_gap_event_cb(struct ble_gap_event *event, void *arg) { // ok n
         if (event->connect.status == 0) {
             state->connHandle = event->connect.conn_handle;
             state->connected = true;
-            FL_WARN("[BLE] Client connected, conn_handle=" << event->connect.conn_handle);
+            FL_WARN_F("[BLE] Client connected, conn_handle=%s", event->connect.conn_handle);
         } else {
-            FL_WARN("[BLE] Connection failed, status=" << event->connect.status
-                    << " — restarting advertising");
+            FL_WARN_F("[BLE] Connection failed, status=%s — restarting advertising", event->connect.status);
             fl_ble_start_advertise(state);
         }
         break;
@@ -227,27 +226,24 @@ static int fl_ble_gap_event_cb(struct ble_gap_event *event, void *arg) { // ok n
     case BLE_GAP_EVENT_DISCONNECT:
         state->connected = false;
         state->connHandle = BLE_HS_CONN_HANDLE_NONE;
-        FL_WARN("[BLE] Client disconnected, reason=" << event->disconnect.reason
-                << " — restarting advertising");
+        FL_WARN_F("[BLE] Client disconnected, reason=%s — restarting advertising", event->disconnect.reason);
         fl_ble_start_advertise(state);
         break;
 
     case BLE_GAP_EVENT_ADV_COMPLETE:
         // Advertising timed out without connection — restart
-        FL_WARN("[BLE] Advertising complete — restarting");
+        FL_WARN_F("[BLE] Advertising complete — restarting");
         fl_ble_start_advertise(state);
         break;
 
     case BLE_GAP_EVENT_SUBSCRIBE:
-        FL_WARN("[BLE TX] subscribe event: cur_notify="
-                << (int)event->subscribe.cur_notify
-                << " cur_indicate=" << (int)event->subscribe.cur_indicate);
+        FL_WARN_F("[BLE TX] subscribe event: cur_notify=%s cur_indicate=%s", (int)event->subscribe.cur_notify, (int)event->subscribe.cur_indicate);
         break;
 
     case BLE_GAP_EVENT_NOTIFY_TX:
         if (event->notify_tx.status != 0
             && event->notify_tx.status != BLE_HS_EDONE) {
-            FL_WARN("[BLE TX] notify failed, status=" << event->notify_tx.status);
+            FL_WARN_F("[BLE TX] notify failed, status=%s", event->notify_tx.status);
         }
         break;
 
@@ -274,7 +270,7 @@ static void fl_ble_start_advertise(TransportState *state) FL_NOEXCEPT {
 
     int rc = ble_gap_adv_set_fields(&fields);
     if (rc != 0) {
-        FL_WARN("[BLE] adv_set_fields failed rc=" << rc);
+        FL_WARN_F("[BLE] adv_set_fields failed rc=%s", rc);
         return;
     }
 
@@ -285,7 +281,7 @@ static void fl_ble_start_advertise(TransportState *state) FL_NOEXCEPT {
     rsp_fields.uuids128_is_complete = 1;
     rc = ble_gap_adv_rsp_set_fields(&rsp_fields);
     if (rc != 0) {
-        FL_WARN("[BLE] adv_rsp_set_fields failed rc=" << rc);
+        FL_WARN_F("[BLE] adv_rsp_set_fields failed rc=%s", rc);
     }
 
     struct ble_gap_adv_params adv_params = {};
@@ -295,14 +291,14 @@ static void fl_ble_start_advertise(TransportState *state) FL_NOEXCEPT {
     u8 addr_type;
     rc = ble_hs_id_infer_auto(0, &addr_type);
     if (rc != 0) {
-        FL_WARN("[BLE] id_infer_auto failed rc=" << rc);
+        FL_WARN_F("[BLE] id_infer_auto failed rc=%s", rc);
         return;
     }
 
     rc = ble_gap_adv_start(addr_type, nullptr, BLE_HS_FOREVER, &adv_params,
                            fl_ble_gap_event_cb, state);
     if (rc != 0 && rc != BLE_HS_EALREADY) {
-        FL_WARN("[BLE] adv_start failed rc=" << rc);
+        FL_WARN_F("[BLE] adv_start failed rc=%s", rc);
     }
 }
 
@@ -314,7 +310,7 @@ static void fl_ble_on_sync(void) { // ok no noexcept
     // Use best available address
     int rc = ble_hs_util_ensure_addr(0);
     if (rc != 0) {
-        FL_WARN("[BLE] ensure_addr failed rc=" << rc);
+        FL_WARN_F("[BLE] ensure_addr failed rc=%s", rc);
         return;
     }
 
@@ -347,7 +343,7 @@ TransportState* createTransport(const char* deviceName) FL_NOEXCEPT {
     // Initialize NimBLE stack (IDF 5+ API)
     int rc = nimble_port_init();
     if (rc != 0) {
-        FL_WARN("[BLE] nimble_port_init failed rc=" << rc);
+        FL_WARN_F("[BLE] nimble_port_init failed rc=%s", rc);
         s_bleState = nullptr;
         return nullptr;
     }
@@ -363,14 +359,14 @@ TransportState* createTransport(const char* deviceName) FL_NOEXCEPT {
     fl_ble_patch_gatt_table(state);
     rc = ble_gatts_count_cfg(fl_gatt_svr_svcs_mut);
     if (rc != 0) {
-        FL_WARN("[BLE] gatts_count_cfg failed rc=" << rc);
+        FL_WARN_F("[BLE] gatts_count_cfg failed rc=%s", rc);
         nimble_port_deinit();
         s_bleState = nullptr;
         return nullptr;
     }
     rc = ble_gatts_add_svcs(fl_gatt_svr_svcs_mut);
     if (rc != 0) {
-        FL_WARN("[BLE] gatts_add_svcs failed rc=" << rc);
+        FL_WARN_F("[BLE] gatts_add_svcs failed rc=%s", rc);
         nimble_port_deinit();
         s_bleState = nullptr;
         return nullptr;
@@ -379,13 +375,13 @@ TransportState* createTransport(const char* deviceName) FL_NOEXCEPT {
     // Set device name
     rc = ble_svc_gap_device_name_set(deviceName);
     if (rc != 0) {
-        FL_WARN("[BLE] device_name_set failed rc=" << rc);
+        FL_WARN_F("[BLE] device_name_set failed rc=%s", rc);
     }
 
     // Start NimBLE host task on FreeRTOS
     nimble_port_freertos_init(fl_ble_host_task);
 
-    FL_WARN("[BLE] GATT server started: name=" << deviceName);
+    FL_WARN_F("[BLE] GATT server started: name=%s", deviceName);
     uptr.release(); // caller owns the state now
     return state;
 }
@@ -400,17 +396,17 @@ void destroyTransport(TransportState* state) FL_NOEXCEPT {
     // Signal NimBLE host task to stop
     int rc = nimble_port_stop();
     if (rc != 0) {
-        FL_WARN("[BLE] nimble_port_stop failed rc=" << rc);
+        FL_WARN_F("[BLE] nimble_port_stop failed rc=%s", rc);
     }
 
     // Deinitialize NimBLE stack
     rc = nimble_port_deinit();
     if (rc != 0) {
-        FL_WARN("[BLE] nimble_port_deinit failed rc=" << rc);
+        FL_WARN_F("[BLE] nimble_port_deinit failed rc=%s", rc);
     }
 
     s_bleState = nullptr;
-    FL_WARN("[BLE] GATT server stopped");
+    FL_WARN_F("[BLE] GATT server stopped");
 }
 
 StatusInfo queryStatus(const TransportState* state) FL_NOEXCEPT {
@@ -436,7 +432,7 @@ getTransportCallbacks(TransportState* state) FL_NOEXCEPT {
         fl::string& raw = state->ringBuffer[state->tail];
         state->tail = (state->tail + 1) % kBleRingBufferSize;
 
-        FL_WARN("[BLE SRC] raw: " << raw.c_str());
+        FL_WARN_F("[BLE SRC] raw: %s", raw.c_str());
 
         // Use string_view for zero-copy prefix stripping and trimming
         fl::string_view view = raw;
@@ -455,16 +451,16 @@ getTransportCallbacks(TransportState* state) FL_NOEXCEPT {
         }
 
         if (view.empty() || view[0] != '{') {
-            FL_WARN("[BLE SRC] rejected (not JSON): " << raw.c_str());
+            FL_WARN_F("[BLE SRC] rejected (not JSON): %s", raw.c_str());
             return fl::nullopt;
         }
 
         fl::string input(view); // ok no noexcept
         auto parsed = fl::json::parse(input);
         if (parsed.has_value()) {
-            FL_WARN("[BLE SRC] parsed OK");
+            FL_WARN_F("[BLE SRC] parsed OK");
         } else {
-            FL_WARN("[BLE SRC] parse FAILED");
+            FL_WARN_F("[BLE SRC] parse FAILED");
         }
         return parsed;
     };
@@ -474,13 +470,13 @@ getTransportCallbacks(TransportState* state) FL_NOEXCEPT {
     // The host should READ the TX characteristic as a fallback.
     auto responseSink = [state](const fl::json& response) {
         fl::string formatted = formatJsonResponse(response, "REMOTE: ");
-        FL_WARN("[BLE TX] sending (" << formatted.size() << " bytes): " << formatted.c_str());
+        FL_WARN_F("[BLE TX] sending (%s bytes): %s", formatted.size(), formatted.c_str());
 
         // Store for READ fallback
         state->lastTxValue = formatted;
 
         if (!state->connected || state->connHandle == BLE_HS_CONN_HANDLE_NONE) {
-            FL_WARN("[BLE TX] not connected, skipping notify");
+            FL_WARN_F("[BLE TX] not connected, skipping notify");
             return;
         }
 
@@ -488,13 +484,13 @@ getTransportCallbacks(TransportState* state) FL_NOEXCEPT {
         struct os_mbuf *om = ble_hs_mbuf_from_flat(
             formatted.c_str(), static_cast<u16>(formatted.size()));
         if (!om) {
-            FL_WARN("[BLE TX] mbuf alloc failed");
+            FL_WARN_F("[BLE TX] mbuf alloc failed");
             return;
         }
 
         int rc = ble_gatts_notify_custom(state->connHandle, state->txAttrHandle, om);
         if (rc != 0) {
-            FL_WARN("[BLE TX] notify_custom failed rc=" << rc);
+            FL_WARN_F("[BLE TX] notify_custom failed rc=%s", rc);
         }
     };
 

--- a/src/platforms/esp/32/drivers/channel_manager_esp32.cpp.hpp
+++ b/src/platforms/esp/32/drivers/channel_manager_esp32.cpp.hpp
@@ -132,7 +132,7 @@ constexpr int PRIORITY_LCD_CLOCKLESS = 2; ///< LCD_CAM clockless driver (ESP32-S
 
 /// @brief Add HW SPI drivers if supported by platform (UNIFIED VERSION)
 static void addSpiHardwareIfPossible(ChannelManager& manager) FL_NOEXCEPT {
-    FL_DBG("ESP32: Registering unified HW SPI channel driver");
+    FL_DBG_F("ESP32: Registering unified HW SPI channel driver");
 
     fl::vector<fl::shared_ptr<SpiHwBase>> controllers;
     fl::vector<int> priorities;
@@ -143,7 +143,7 @@ static void addSpiHardwareIfPossible(ChannelManager& manager) FL_NOEXCEPT {
     // Note: SpiHw16 (I2S parallel) replaced by I2S_SPI/LCD_SPI channel drivers
     // ========================================================================
     const auto& hw1Controllers = SpiHw1::getAll();
-    FL_DBG("ESP32: Found " << hw1Controllers.size() << " SpiHw1 controllers");
+    FL_DBG_F("ESP32: Found %s SpiHw1 controllers", hw1Controllers.size());
 
     for (const auto& ctrl : hw1Controllers) {
         if (ctrl) {
@@ -175,14 +175,12 @@ static void addSpiHardwareIfPossible(ChannelManager& manager) FL_NOEXCEPT {
 
             manager.addDriver(maxPriority, adapter);
 
-            FL_DBG("ESP32: Registered unified SPI driver with "
-                   << controllers.size() << " controllers (priority "
-                   << maxPriority << ")");
+            FL_DBG_F("ESP32: Registered unified SPI driver with %s controllers (priority %s)", controllers.size(), maxPriority);
         } else {
-            FL_WARN("ESP32: Failed to create unified SPI adapter");
+            FL_WARN_F("ESP32: Failed to create unified SPI adapter");
         }
     } else {
-        FL_DBG("ESP32: No SPI hardware controllers available");
+        FL_DBG_F("ESP32: No SPI hardware controllers available");
     }
 }
 
@@ -197,7 +195,7 @@ static void addSpiHardwareIfPossible(ChannelManager& manager) FL_NOEXCEPT {
 static void addParlioIfPossible(ChannelManager& manager) FL_NOEXCEPT {
 #if FASTLED_ESP32_HAS_PARLIO
     manager.addDriver(PRIORITY_PARLIO, BusTraits<Bus::PARLIO>::instancePtr());
-    FL_DBG("ESP32: Added PARLIO driver (priority " << PRIORITY_PARLIO << ")");
+    FL_DBG_F("ESP32: Added PARLIO driver (priority %s)", PRIORITY_PARLIO);
 #else
     (void)manager;  // Suppress unused parameter warning
 #endif
@@ -209,9 +207,9 @@ static void addLcdRgbIfPossible(ChannelManager& manager) FL_NOEXCEPT {
     auto driver = BusTraits<Bus::LCD_RGB>::instancePtr();
     if (driver) {
         manager.addDriver(PRIORITY_LCD_RGB, driver);
-        FL_DBG("ESP32: Added LCD_RGB driver (priority " << PRIORITY_LCD_RGB << ")");
+        FL_DBG_F("ESP32: Added LCD_RGB driver (priority %s)", PRIORITY_LCD_RGB);
     } else {
-        FL_DBG("ESP32-P4: LCD_RGB driver creation failed");
+        FL_DBG_F("ESP32-P4: LCD_RGB driver creation failed");
     }
 #else
     (void)manager;  // Suppress unused parameter warning
@@ -222,7 +220,7 @@ static void addLcdRgbIfPossible(ChannelManager& manager) FL_NOEXCEPT {
 static void addSpiIfPossible(ChannelManager& manager) FL_NOEXCEPT {
 #if FASTLED_ESP32_HAS_CLOCKLESS_SPI
     manager.addDriver(PRIORITY_SPI, BusTraits<Bus::SPI>::instancePtr());
-    FL_DBG("ESP32: Added SPI driver (priority " << PRIORITY_SPI << ")");
+    FL_DBG_F("ESP32: Added SPI driver (priority %s)", PRIORITY_SPI);
 #else
     (void)manager;  // Suppress unused parameter warning
 #endif
@@ -236,7 +234,7 @@ static void addUartIfPossible(ChannelManager& manager) FL_NOEXCEPT {
     // BusTraits<Bus::UART>::instancePtr() also constructs the UartPeripheralEsp
     // dependency inside its UartBusHolder.
     manager.addDriver(PRIORITY_UART, BusTraits<Bus::UART>::instancePtr());
-    FL_DBG("ESP32: Added UART driver (priority " << PRIORITY_UART << ")");
+    FL_DBG_F("ESP32: Added UART driver (priority %s)", PRIORITY_UART);
 #else
     (void)manager;  // Suppress unused parameter warning
 #endif
@@ -256,7 +254,7 @@ static void addRmtIfPossible(ChannelManager& manager) FL_NOEXCEPT {
     #endif
 
     manager.addDriver(PRIORITY_RMT, driver);
-    FL_DBG("ESP32: Added " << version << " driver (priority " << PRIORITY_RMT << ")");
+    FL_DBG_F("ESP32: Added %s driver (priority %s)", version, PRIORITY_RMT);
 #else
     (void)manager;  // Suppress unused parameter warning
 #endif
@@ -268,9 +266,9 @@ static void addI2sSpiIfPossible(ChannelManager& manager) FL_NOEXCEPT {
     auto driver = BusTraits<Bus::I2S_SPI>::instancePtr();
     if (driver) {
         manager.addDriver(PRIORITY_I2S_SPI, driver);
-        FL_DBG("ESP32: Added I2S_SPI driver (priority " << PRIORITY_I2S_SPI << ")");
+        FL_DBG_F("ESP32: Added I2S_SPI driver (priority %s)", PRIORITY_I2S_SPI);
     } else {
-        FL_DBG("ESP32: I2S_SPI driver creation deferred (no ESP peripheral yet)");
+        FL_DBG_F("ESP32: I2S_SPI driver creation deferred (no ESP peripheral yet)");
     }
 #else
     (void)manager;
@@ -283,9 +281,9 @@ static void addLcdSpiIfPossible(ChannelManager& manager) FL_NOEXCEPT {
     auto driver = BusTraits<Bus::LCD_SPI>::instancePtr();
     if (driver) {
         manager.addDriver(PRIORITY_LCD_SPI, driver);
-        FL_DBG("ESP32-S3: Added LCD_SPI driver (priority " << PRIORITY_LCD_SPI << ")");
+        FL_DBG_F("ESP32-S3: Added LCD_SPI driver (priority %s)", PRIORITY_LCD_SPI);
     } else {
-        FL_DBG("ESP32-S3: LCD_SPI driver creation deferred (no ESP peripheral yet)");
+        FL_DBG_F("ESP32-S3: LCD_SPI driver creation deferred (no ESP peripheral yet)");
     }
 #else
     (void)manager;
@@ -298,9 +296,9 @@ static void addLcdClocklessIfPossible(ChannelManager& manager) FL_NOEXCEPT {
     auto driver = BusTraits<Bus::LCD_CLOCKLESS>::instancePtr();
     if (driver) {
         manager.addDriver(PRIORITY_LCD_CLOCKLESS, driver);
-        FL_DBG("ESP32-S3: Added LCD_CLOCKLESS driver (priority " << PRIORITY_LCD_CLOCKLESS << ")");
+        FL_DBG_F("ESP32-S3: Added LCD_CLOCKLESS driver (priority %s)", PRIORITY_LCD_CLOCKLESS);
     } else {
-        FL_DBG("ESP32-S3: LCD_CLOCKLESS driver creation deferred");
+        FL_DBG_F("ESP32-S3: LCD_CLOCKLESS driver creation deferred");
     }
 #else
     (void)manager;
@@ -315,9 +313,9 @@ static void addI2sIfPossible(ChannelManager& manager) FL_NOEXCEPT {
     auto driver = BusTraits<Bus::I2S>::instancePtr();
     if (driver) {
         manager.addDriver(PRIORITY_I2S, driver);
-        FL_DBG("ESP32-S3: Added I2S LCD_CAM driver (priority " << PRIORITY_I2S << ")");
+        FL_DBG_F("ESP32-S3: Added I2S LCD_CAM driver (priority %s)", PRIORITY_I2S);
     } else {
-        FL_DBG("ESP32-S3: I2S LCD_CAM driver creation failed");
+        FL_DBG_F("ESP32-S3: I2S LCD_CAM driver creation failed");
     }
 #else
     (void)manager;  // Suppress unused parameter warning

--- a/src/platforms/esp/32/drivers/cled.cpp.hpp
+++ b/src/platforms/esp/32/drivers/cled.cpp.hpp
@@ -48,7 +48,7 @@ bool CLED::begin(const CLEDConfig& config) FL_NOEXCEPT {
     // Validate parameters
     if (config.resolution_bits > 20) {
         // ESP32 LEDC maximum is 20 bits
-        FL_WARN("CLED: resolution_bits > 20 not supported (requested: " << config.resolution_bits << ")");
+        FL_WARN_F("CLED: resolution_bits > 20 not supported (requested: %s)", config.resolution_bits);
         return false;
     }
 
@@ -61,28 +61,25 @@ bool CLED::begin(const CLEDConfig& config) FL_NOEXCEPT {
     // New API (Arduino Core 3.x): ledcAttach auto-assigns channel
     u8 assigned_channel = ledcAttach(config.pin, config.frequency, config.resolution_bits);
     if (assigned_channel == 0) {
-        FL_WARN("CLED: LEDC attach failed for pin " << config.pin);
+        FL_WARN_F("CLED: LEDC attach failed for pin %s", config.pin);
         return false;
     }
 
     // Update internal state with auto-assigned channel
     mConfig.channel = assigned_channel;
 
-    FL_DBG("CLED: Initialized pin " << config.pin << " with auto-assigned channel "
-           << static_cast<int>(assigned_channel) << " at " << config.frequency
-           << " Hz, " << config.resolution_bits << " bits");
+    FL_DBG_F("CLED: Initialized pin %s with auto-assigned channel %s at %s Hz, %s bits", config.pin, static_cast<int>(assigned_channel), config.frequency, config.resolution_bits);
 #else
     // Old API (Arduino Core 2.x): ledcSetup + ledcAttachPin with explicit channel
     ledcAttachPin(config.pin, config.channel);
     u32 freq = ledcSetup(config.channel, config.frequency, config.resolution_bits);
 
     if (freq == 0) {
-        FL_WARN("CLED: LEDC setup failed for channel " << config.channel);
+        FL_WARN_F("CLED: LEDC setup failed for channel %s", config.channel);
         return false;
     }
 
-    FL_DBG("CLED: Initialized channel " << config.channel << " at " << freq
-           << " Hz, " << config.resolution_bits << " bits");
+    FL_DBG_F("CLED: Initialized channel %s at %s Hz, %s bits", config.channel, freq, config.resolution_bits);
 #endif
 
     mInitialized = true;

--- a/src/platforms/esp/32/drivers/gpio_isr_rx/gpio_isr_rx.h
+++ b/src/platforms/esp/32/drivers/gpio_isr_rx/gpio_isr_rx.h
@@ -69,7 +69,7 @@ struct EdgeTimestamp {
  * config.skip_signals = 0;
  *
  * if (!rx->begin(config)) {
- *     FL_WARN("GPIO ISR RX init failed");
+ *     FL_WARN_F("GPIO ISR RX init failed");
  *     return;
  * }
  *
@@ -77,7 +77,7 @@ struct EdgeTimestamp {
  * if (rx->wait(100) == RxWaitResult::SUCCESS) {
  *     // Get captured edges
  *     fl::span<const EdgeTimestamp> edges = rx->getEdges();
- *     FL_DBG("Captured " << edges.size() << " edges");
+ *     FL_DBG_F("Captured %s edges", edges.size());
  * }
  * @endcode
  */

--- a/src/platforms/esp/32/drivers/gpio_isr_rx/gpio_isr_rx_mcpwm.cpp.hpp
+++ b/src/platforms/esp/32/drivers/gpio_isr_rx/gpio_isr_rx_mcpwm.cpp.hpp
@@ -84,7 +84,7 @@ namespace {
  * @return true on success, false on failure
  */
 bool install_direct_gpio_isr(int gpio_num, void* isr_context, intr_handle_t* interrupt_handle) FL_NOEXCEPT {
-    FL_DBG("Installing direct GPIO ISR for pin " << gpio_num);
+    FL_DBG_F("Installing direct GPIO ISR for pin %s", gpio_num);
 
     // Step 1: Determine GPIO interrupt source
     // ESP32-P4 has per-CPU GPIO interrupt sources (ETS_GPIO_INTR0_SOURCE..3)
@@ -94,7 +94,7 @@ bool install_direct_gpio_isr(int gpio_num, void* isr_context, intr_handle_t* int
 #else
     int intr_source = ETS_GPIO_INTR_SOURCE;
 #endif
-    FL_DBG("GPIO interrupt source: " << intr_source);
+    FL_DBG_F("GPIO interrupt source: %s", intr_source);
 
     // Step 2: Allocate interrupt with high priority (Level 3-5)
     // ESP_INTR_FLAG_LEVEL3 = Higher priority than default (Level 1)
@@ -110,11 +110,11 @@ bool install_direct_gpio_isr(int gpio_num, void* isr_context, intr_handle_t* int
     );
 
     if (err != ESP_OK) {
-        FL_WARN("esp_intr_alloc failed: " << esp_err_to_name(err));
+        FL_WARN_F("esp_intr_alloc failed: %s", esp_err_to_name(err));
         return false;
     }
 
-    FL_DBG("Allocated interrupt handle: " << *interrupt_handle);
+    FL_DBG_F("Allocated interrupt handle: %s", *interrupt_handle);
 
     // Step 3: Configure GPIO pin
     gpio_config_t io_conf = {};
@@ -126,7 +126,7 @@ bool install_direct_gpio_isr(int gpio_num, void* isr_context, intr_handle_t* int
 
     err = gpio_config(&io_conf);
     if (err != ESP_OK) {
-        FL_WARN("gpio_config failed: " << esp_err_to_name(err));
+        FL_WARN_F("gpio_config failed: %s", esp_err_to_name(err));
         esp_intr_free(*interrupt_handle);
         *interrupt_handle = nullptr;
         return false;
@@ -135,13 +135,13 @@ bool install_direct_gpio_isr(int gpio_num, void* isr_context, intr_handle_t* int
     // Step 4: Enable GPIO interrupt
     err = gpio_intr_enable(static_cast<gpio_num_t>(gpio_num));
     if (err != ESP_OK) {
-        FL_WARN("gpio_intr_enable failed: " << esp_err_to_name(err));
+        FL_WARN_F("gpio_intr_enable failed: %s", esp_err_to_name(err));
         esp_intr_free(*interrupt_handle);
         *interrupt_handle = nullptr;
         return false;
     }
 
-    FL_DBG("Direct GPIO ISR installed successfully (expected latency: ~300-400ns)");
+    FL_DBG_F("Direct GPIO ISR installed successfully (expected latency: ~300-400ns)");
     return true;
 }
 
@@ -230,16 +230,16 @@ fl::result<u32, DecodeError> decodeEdgeTimestamps(const ChipsetTiming4Phase &tim
     const size_t bytes_capacity = bytes_out.size();
 
     if (edge_count == 0) {
-        FL_WARN("decodeEdgeTimestamps: edges span is empty");
+        FL_WARN_F("decodeEdgeTimestamps: edges span is empty");
         return fl::result<u32, DecodeError>::failure(DecodeError::INVALID_ARGUMENT);
     }
 
     if (bytes_capacity == 0) {
-        FL_WARN("decodeEdgeTimestamps: bytes_out span is empty");
+        FL_WARN_F("decodeEdgeTimestamps: bytes_out span is empty");
         return fl::result<u32, DecodeError>::failure(DecodeError::INVALID_ARGUMENT);
     }
 
-    FL_DBG("decodeEdgeTimestamps: decoding " << edge_count << " edges into buffer of " << bytes_capacity << " bytes");
+    FL_DBG_F("decodeEdgeTimestamps: decoding %s edges into buffer of %s bytes", edge_count, bytes_capacity);
 
     // Decoding state
     size_t error_count = 0;
@@ -264,16 +264,16 @@ fl::result<u32, DecodeError> decodeEdgeTimestamps(const ChipsetTiming4Phase &tim
         // Check for reset pulse (long low period indicates frame end)
         u32 pulse0_duration = edge1.time_ns - edge0.time_ns;
         if (edge0.level == 0 && pulse0_duration >= reset_min_ns) {
-            FL_DBG("decodeEdgeTimestamps: reset pulse detected at edge " << i);
+            FL_DBG_F("decodeEdgeTimestamps: reset pulse detected at edge %s", i);
 
             // Flush partial byte if needed
             if (bit_index != 0) {
-                FL_WARN("decodeEdgeTimestamps: partial byte at reset (bit_index=" << bit_index << ")");
+                FL_WARN_F("decodeEdgeTimestamps: partial byte at reset (bit_index=%s)", bit_index);
                 current_byte <<= (8 - bit_index);
                 if (bytes_decoded < bytes_capacity) {
                     out_ptr[bytes_decoded++] = current_byte;
                 } else {
-                    FL_WARN("decodeEdgeTimestamps: buffer overflow");
+                    FL_WARN_F("decodeEdgeTimestamps: buffer overflow");
                     return fl::result<u32, DecodeError>::failure(DecodeError::BUFFER_OVERFLOW);
                 }
             }
@@ -282,7 +282,7 @@ fl::result<u32, DecodeError> decodeEdgeTimestamps(const ChipsetTiming4Phase &tim
 
         // WS2812B protocol: expect HIGH -> LOW pattern
         if (edge0.level != 1 || edge1.level != 0) {
-            FL_DBG("decodeEdgeTimestamps: unexpected edge pattern at " << i);
+            FL_DBG_F("decodeEdgeTimestamps: unexpected edge pattern at %s", i);
             error_count++;
             i++;
             continue;
@@ -308,7 +308,7 @@ fl::result<u32, DecodeError> decodeEdgeTimestamps(const ChipsetTiming4Phase &tim
 
         if (bit < 0) {
             error_count++;
-            FL_DBG("decodeEdgeTimestamps: invalid pulse at edge " << i);
+            FL_DBG_F("decodeEdgeTimestamps: invalid pulse at edge %s", i);
             i += 2;
             continue;
         }
@@ -320,7 +320,7 @@ fl::result<u32, DecodeError> decodeEdgeTimestamps(const ChipsetTiming4Phase &tim
         // Byte complete?
         if (bit_index == 8) {
             if (bytes_decoded >= bytes_capacity) {
-                FL_WARN("decodeEdgeTimestamps: buffer overflow at byte " << bytes_decoded);
+                FL_WARN_F("decodeEdgeTimestamps: buffer overflow at byte %s", bytes_decoded);
                 return fl::result<u32, DecodeError>::failure(DecodeError::BUFFER_OVERFLOW);
             }
             out_ptr[bytes_decoded++] = current_byte;
@@ -333,7 +333,7 @@ fl::result<u32, DecodeError> decodeEdgeTimestamps(const ChipsetTiming4Phase &tim
 
     // Flush partial byte if we reached end
     if (bit_index != 0) {
-        FL_WARN("decodeEdgeTimestamps: partial byte at end (bit_index=" << bit_index << ")");
+        FL_WARN_F("decodeEdgeTimestamps: partial byte at end (bit_index=%s)", bit_index);
         current_byte <<= (8 - bit_index);
         if (bytes_decoded < bytes_capacity) {
             out_ptr[bytes_decoded++] = current_byte;
@@ -342,12 +342,12 @@ fl::result<u32, DecodeError> decodeEdgeTimestamps(const ChipsetTiming4Phase &tim
         }
     }
 
-    FL_DBG("decodeEdgeTimestamps: decoded " << bytes_decoded << " bytes, " << error_count << " errors");
+    FL_DBG_F("decodeEdgeTimestamps: decoded %s bytes, %s errors", bytes_decoded, error_count);
 
     // Calculate error rate (avoid division by zero)
     size_t total_pulses = edge_count / 2;
     if (total_pulses > 0 && error_count >= (total_pulses / 10)) {
-        FL_WARN("decodeEdgeTimestamps: high error rate: " << error_count << "/" << total_pulses);
+        FL_WARN_F("decodeEdgeTimestamps: high error rate: %s/%s", error_count, total_pulses);
         return fl::result<u32, DecodeError>::failure(DecodeError::HIGH_ERROR_RATE);
     }
 
@@ -377,7 +377,7 @@ public:
         , mIsrContext{}
         , mInitialized(false)
     {
-        FL_DBG("GpioIsrRxMcpwm constructed with pin=" << pin);
+        FL_DBG_F("GpioIsrRxMcpwm constructed with pin=%s", pin);
     }
 
     ~GpioIsrRxMcpwm() override {
@@ -387,21 +387,19 @@ public:
     bool begin(const RxConfig& config) FL_NOEXCEPT override {
         // Validate pin
         if (!isValidGpioPin(static_cast<int>(mPin))) {
-            FL_ERROR("GPIO ISR RX MCPWM: Invalid pin " << static_cast<int>(mPin)
-                     << " - pin is reserved for UART, flash, or other system use");
+            FL_ERROR_F("GPIO ISR RX MCPWM: Invalid pin %s - pin is reserved for UART, flash, or other system use", static_cast<int>(mPin));
             return false;
         }
 
         // Validate buffer size
         if (config.buffer_size == 0) {
-            FL_WARN("GPIO ISR RX MCPWM begin: Invalid buffer_size (must be > 0)");
+            FL_WARN_F("GPIO ISR RX MCPWM begin: Invalid buffer_size (must be > 0)");
             return false;
         }
 
         // Buffer size must be power of 2 for fast modulo optimization
         if ((config.buffer_size & (config.buffer_size - 1)) != 0) {
-            FL_ERROR("GPIO ISR RX MCPWM begin: buffer_size must be power of 2 (got "
-                     << config.buffer_size << ")");
+            FL_ERROR_F("GPIO ISR RX MCPWM begin: buffer_size must be power of 2 (got %s)", config.buffer_size);
             return false;
         }
 
@@ -410,8 +408,7 @@ public:
             mBufferSize = config.buffer_size;
             mOutputBufferSize = config.buffer_size;  // Same size for simplicity
 
-            FL_DBG("GPIO ISR RX MCPWM first-time init: pin=" << static_cast<int>(mPin)
-                   << ", buffer_size=" << mBufferSize);
+            FL_DBG_F("GPIO ISR RX MCPWM first-time init: pin=%s, buffer_size=%s", static_cast<int>(mPin), mBufferSize);
 
             // Allocate circular buffer
             mEdgeBuffer.clear();
@@ -452,7 +449,7 @@ public:
             io_conf.intr_type = GPIO_INTR_ANYEDGE;
             esp_err_t err = gpio_config(&io_conf);
             if (err != ESP_OK) {
-                FL_WARN("Failed to configure GPIO: " << static_cast<int>(err));
+                FL_WARN_F("Failed to configure GPIO: %s", static_cast<int>(err));
                 return false;
             }
 
@@ -470,7 +467,7 @@ public:
 
             // Initialize MCPWM timer
             if (mcpwm_timer_init(&mIsrContext, static_cast<int>(mPin)) != 0) {
-                FL_WARN("Failed to initialize MCPWM timer");
+                FL_WARN_F("Failed to initialize MCPWM timer");
                 return false;
             }
 
@@ -483,7 +480,7 @@ public:
 
             err = gptimer_new_timer(&timer_config, reinterpret_cast<gptimer_handle_t*>(&mIsrContext.gptimer_handle)); // ok reinterpret cast
             if (err != ESP_OK) {
-                FL_WARN("Failed to create GPTimer: " << static_cast<int>(err));
+                FL_WARN_F("Failed to create GPTimer: %s", static_cast<int>(err));
                 mcpwm_timer_cleanup();
                 return false;
             }
@@ -497,7 +494,7 @@ public:
                 &cbs,
                 &mIsrContext);
             if (err != ESP_OK) {
-                FL_WARN("Failed to register GPTimer callback: " << static_cast<int>(err));
+                FL_WARN_F("Failed to register GPTimer callback: %s", static_cast<int>(err));
                 gptimer_del_timer(reinterpret_cast<gptimer_handle_t>(mIsrContext.gptimer_handle)); // ok reinterpret cast
                 mIsrContext.gptimer_handle = nullptr;
                 mcpwm_timer_cleanup();
@@ -516,7 +513,7 @@ public:
                 reinterpret_cast<gptimer_handle_t>(mIsrContext.gptimer_handle), // ok reinterpret cast
                 &alarm_config);
             if (err != ESP_OK) {
-                FL_WARN("Failed to set GPTimer alarm: " << static_cast<int>(err));
+                FL_WARN_F("Failed to set GPTimer alarm: %s", static_cast<int>(err));
                 gptimer_del_timer(reinterpret_cast<gptimer_handle_t>(mIsrContext.gptimer_handle)); // ok reinterpret cast
                 mIsrContext.gptimer_handle = nullptr;
                 mcpwm_timer_cleanup();
@@ -526,7 +523,7 @@ public:
             // Enable GPTimer
             err = gptimer_enable(reinterpret_cast<gptimer_handle_t>(mIsrContext.gptimer_handle)); // ok reinterpret cast
             if (err != ESP_OK) {
-                FL_WARN("Failed to enable GPTimer: " << static_cast<int>(err));
+                FL_WARN_F("Failed to enable GPTimer: %s", static_cast<int>(err));
                 gptimer_del_timer(reinterpret_cast<gptimer_handle_t>(mIsrContext.gptimer_handle)); // ok reinterpret cast
                 mIsrContext.gptimer_handle = nullptr;
                 mcpwm_timer_cleanup();
@@ -539,7 +536,7 @@ public:
             // This provides low-latency interrupt handling (~300-400ns) while remaining
             // fully compatible with ESP-IDF's interrupt system
             if (!install_direct_gpio_isr(static_cast<int>(mPin), &mIsrContext, &mInterruptHandle)) {
-                FL_WARN("Failed to install direct GPIO ISR for pin " << static_cast<int>(mPin));
+                FL_WARN_F("Failed to install direct GPIO ISR for pin %s", static_cast<int>(mPin));
                 gptimer_disable(reinterpret_cast<gptimer_handle_t>(mIsrContext.gptimer_handle)); // ok reinterpret cast
                 gptimer_del_timer(reinterpret_cast<gptimer_handle_t>(mIsrContext.gptimer_handle)); // ok reinterpret cast
                 mIsrContext.gptimer_handle = nullptr;
@@ -547,7 +544,7 @@ public:
                 return false;
             }
 
-            FL_DBG("Using RISC-V high-priority ISR (Level 3) - expect ~300-400ns latency");
+            FL_DBG_F("Using RISC-V high-priority ISR (Level 3) - expect ~300-400ns latency");
             #else
             // Xtensa: Use ESP-IDF interrupt allocation (existing implementation)
             // Direct allocation with esp_intr_alloc() is required for assembly ISR handlers
@@ -558,10 +555,8 @@ public:
             // "Must be NULL when an interrupt of level >3 is requested"
             int flags = ESP_INTR_FLAG_IRAM | ESP_INTR_FLAG_LEVEL5;
 
-            FL_DBG("Allocating GPIO interrupt: source=" << ETS_GPIO_INTR_SOURCE
-                   << " flags=0x" << fl::hex << flags << fl::dec
-                   << " handler=nullptr (Level 5 requires nullptr per ESP-IDF docs)"
-                   << " arg=nullptr (cannot pass context with nullptr handler)");
+            FL_DBG_F("Allocating GPIO interrupt: source=%s flags=0x%x handler=nullptr (Level 5 requires nullptr per ESP-IDF docs) arg=nullptr (cannot pass context with nullptr handler)",
+                     ETS_GPIO_INTR_SOURCE, flags);
 
             err = esp_intr_alloc(
                 ETS_GPIO_INTR_SOURCE,                           // GPIO interrupt source
@@ -571,12 +566,11 @@ public:
                 reinterpret_cast<intr_handle_t*>(&mIsrContext.intr_handle)  // ok reinterpret cast  // Store handle
             );
 
-            FL_DBG("esp_intr_alloc result: " << esp_err_to_name(err) << " (0x" << fl::hex << err << fl::dec << ")");
+            FL_DBG_F("esp_intr_alloc result: %s (0x%x)", esp_err_to_name(err), err);
 
             if (err != ESP_OK) {
-                FL_WARN("Failed to register GPIO interrupt: " << esp_err_to_name(err)
-                        << " - interrupt source=" << ETS_GPIO_INTR_SOURCE
-                        << " flags=0x" << fl::hex << flags << fl::dec);
+                FL_WARN_F("Failed to register GPIO interrupt: %s - interrupt source=%s flags=0x%x",
+                          esp_err_to_name(err), ETS_GPIO_INTR_SOURCE, flags);
                 gptimer_disable(reinterpret_cast<gptimer_handle_t>(mIsrContext.gptimer_handle)); // ok reinterpret cast
                 gptimer_del_timer(reinterpret_cast<gptimer_handle_t>(mIsrContext.gptimer_handle)); // ok reinterpret cast
                 mIsrContext.gptimer_handle = nullptr;
@@ -587,7 +581,7 @@ public:
             // Enable GPIO interrupt
             err = gpio_intr_enable(mPin);
             if (err != ESP_OK) {
-                FL_WARN("Failed to enable GPIO interrupt: " << esp_err_to_name(err));
+                FL_WARN_F("Failed to enable GPIO interrupt: %s", esp_err_to_name(err));
                 esp_intr_free(reinterpret_cast<intr_handle_t>(mIsrContext.intr_handle)); // ok reinterpret cast
                 mIsrContext.intr_handle = nullptr;
                 gptimer_disable(reinterpret_cast<gptimer_handle_t>(mIsrContext.gptimer_handle)); // ok reinterpret cast
@@ -597,11 +591,11 @@ public:
                 return false;
             }
 
-            FL_DBG("GPIO interrupt allocated successfully at Level 5 (Xtensa)");
+            FL_DBG_F("GPIO interrupt allocated successfully at Level 5 (Xtensa)");
             #endif
 
             mInitialized = true;
-            FL_DBG("GPIO ISR RX MCPWM initialized successfully");
+            FL_DBG_F("GPIO ISR RX MCPWM initialized successfully");
         }
 
         // Store configuration parameters
@@ -616,11 +610,7 @@ public:
             mIsrContext.min_pulse_ticks = 1;  // Minimum 1 tick
         }
 
-        FL_DBG("GPIO ISR RX MCPWM begin: signal_range_min=" << config.signal_range_min_ns
-               << "ns (" << mIsrContext.min_pulse_ticks << " ticks)"
-               << ", signal_range_max=" << config.signal_range_max_ns << "ns ("
-               << mIsrContext.timeout_ticks << " ticks)"
-               << ", skip_signals=" << config.skip_signals);
+        FL_DBG_F("GPIO ISR RX MCPWM begin: signal_range_min=%sns (%s ticks), signal_range_max=%sns (%s ticks), skip_signals=%s", config.signal_range_min_ns, mIsrContext.min_pulse_ticks, config.signal_range_max_ns, mIsrContext.timeout_ticks, config.skip_signals);
 
         // Clear receive state
         mIsrContext.write_index = 0;
@@ -631,14 +621,14 @@ public:
 
         // Start MCPWM timer
         if (mcpwm_timer_start() != 0) {
-            FL_WARN("Failed to start MCPWM timer");
+            FL_WARN_F("Failed to start MCPWM timer");
             return false;
         }
 
         // Start GPTimer
         esp_err_t err = gptimer_start(reinterpret_cast<gptimer_handle_t>(mIsrContext.gptimer_handle)); // ok reinterpret cast
         if (err != ESP_OK) {
-            FL_WARN("Failed to start GPTimer: " << static_cast<int>(err));
+            FL_WARN_F("Failed to start GPTimer: %s", static_cast<int>(err));
             mcpwm_timer_stop();
             return false;
         }
@@ -646,7 +636,7 @@ public:
         // Arm fast ISR (atomic store with release semantics)
         __atomic_store_n(&mIsrContext.armed, true, __ATOMIC_RELEASE);
 
-        FL_DBG("GPIO ISR RX MCPWM armed and ready");
+        FL_DBG_F("GPIO ISR RX MCPWM armed and ready");
         return true;
     }
 
@@ -657,11 +647,11 @@ public:
 
     RxWaitResult wait(u32 timeout_ms) FL_NOEXCEPT override {
         if (!mInitialized) {
-            FL_WARN("wait(): GPIO ISR RX MCPWM not initialized");
+            FL_WARN_F("wait(): GPIO ISR RX MCPWM not initialized");
             return RxWaitResult::TIMEOUT;
         }
 
-        FL_DBG("wait(): timeout_ms=" << timeout_ms);
+        FL_DBG_F("wait(): timeout_ms=%s", timeout_ms);
 
         // Convert timeout to microseconds
         i64 timeout_us = static_cast<i64>(timeout_ms) * 1000;
@@ -673,8 +663,7 @@ public:
 
             // Check wait timeout
             if (elapsed_us >= timeout_us) {
-                FL_WARN("wait(): timeout after " << elapsed_us << "us, captured "
-                        << mIsrContext.output_count << " edges");
+                FL_WARN_F("wait(): timeout after %sus, captured %s edges", elapsed_us, mIsrContext.output_count);
                 return RxWaitResult::TIMEOUT;
             }
 
@@ -682,7 +671,7 @@ public:
         }
 
         // Receive completed
-        FL_DBG("wait(): receive done, count=" << mIsrContext.output_count);
+        FL_DBG_F("wait(): receive done, count=%s", mIsrContext.output_count);
         return RxWaitResult::SUCCESS;
     }
 
@@ -924,7 +913,7 @@ private:
         mcpwm_timer_cleanup();
 
         mInitialized = false;
-        FL_DBG("GPIO ISR RX MCPWM cleaned up");
+        FL_DBG_F("GPIO ISR RX MCPWM cleaned up");
     }
 
     gpio_num_t mPin;

--- a/src/platforms/esp/32/drivers/i2s/channel_driver_i2s.cpp.hpp
+++ b/src/platforms/esp/32/drivers/i2s/channel_driver_i2s.cpp.hpp
@@ -324,9 +324,8 @@ bool ChannelEngineI2S::beginTransmission(fl::span<const ChannelDataPtr> channelD
         u32 clock_hz = calculateI2sClockHz(ct);
         mConfig.pclk_hz = clock_hz;
 
-        FL_DBG("ChannelEngineI2S: Built Wave8 LUT for timing T1=" << timing.t1_ns
-               << "ns, T2=" << timing.t2_ns << "ns, T3=" << timing.t3_ns << "ns");
-        FL_DBG("ChannelEngineI2S: I2S clock set to " << clock_hz << " Hz");
+        FL_DBG_F("ChannelEngineI2S: Built Wave8 LUT for timing T1=%sns, T2=%sns, T3=%sns", timing.t1_ns, timing.t2_ns, timing.t3_ns);
+        FL_DBG_F("ChannelEngineI2S: I2S clock set to %s Hz", clock_hz);
     }
 
     // Initialize or reconfigure if needed
@@ -389,8 +388,7 @@ bool ChannelEngineI2S::beginTransmission(fl::span<const ChannelDataPtr> channelD
         pconfig.max_transfer_bytes = data_size;
         mBufferSize = data_size;
 
-        FL_DBG("ChannelEngineI2S: Wave8 buffer size = " << data_size << " bytes ("
-               << total_words << " words) for " << mNumLeds << " LEDs");
+        FL_DBG_F("ChannelEngineI2S: Wave8 buffer size = %s bytes (%s words) for %s LEDs", data_size, total_words, mNumLeds);
 #else
         // Legacy transpose encoding
         size_t offset_start = 0;
@@ -406,12 +404,12 @@ bool ChannelEngineI2S::beginTransmission(fl::span<const ChannelDataPtr> channelD
         }
 
         if (!mPeripheral->initialize(pconfig)) {
-            FL_WARN("ChannelEngineI2S: Failed to initialize peripheral");
+            FL_WARN_F("ChannelEngineI2S: Failed to initialize peripheral");
             return false;
         }
         if (!mPeripheral->registerTransmitCallback(
                 reinterpret_cast<void*>(&isrTransmitDone), this)) { // ok reinterpret cast
-            FL_WARN("ChannelEngineI2S: registerTransmitCallback failed");
+            FL_WARN_F("ChannelEngineI2S: registerTransmitCallback failed");
             mPeripheral->deinitialize();
             return false;
         }
@@ -420,7 +418,7 @@ bool ChannelEngineI2S::beginTransmission(fl::span<const ChannelDataPtr> channelD
         for (int i = 0; i < 2; i++) {
             mBuffers[i] = mPeripheral->allocateBuffer(mBufferSize);
             if (mBuffers[i] == nullptr) {
-                FL_WARN("ChannelEngineI2S: Failed to allocate buffer");
+                FL_WARN_F("ChannelEngineI2S: Failed to allocate buffer");
                 return false;
             }
             // Initialize with zeros (LOW for reset)
@@ -469,7 +467,7 @@ bool ChannelEngineI2S::beginTransmission(fl::span<const ChannelDataPtr> channelD
         for (const auto& channel : channelData) {
             channel->setInUse(false);
         }
-        FL_WARN("ChannelEngineI2S: Failed to start transmission");
+        FL_WARN_F("ChannelEngineI2S: Failed to start transmission");
         return false;
     }
 

--- a/src/platforms/esp/32/drivers/i2s/i2s_esp32dev.cpp.hpp
+++ b/src/platforms/esp/32/drivers/i2s/i2s_esp32dev.cpp.hpp
@@ -1,4 +1,4 @@
-// IWYU pragma: private
+﻿// IWYU pragma: private
 
 
 
@@ -581,7 +581,7 @@ void i2s_transpose_and_encode(int channel, u32 has_data_mask,
 namespace fl {
 bool i2s_is_initialized() FL_NOEXCEPT { return false; }
 void i2s_init(int) FL_NOEXCEPT {
-    FL_WARN_ONCE("I2S parallel driver is disabled. "
+    FL_WARN_F_ONCE("I2S parallel driver is disabled. "
                  "Falling back to RMT/SPI driver.");
 }
 }  // namespace fl

--- a/src/platforms/esp/32/drivers/i2s/i2s_lcd_cam_peripheral_esp.cpp.hpp
+++ b/src/platforms/esp/32/drivers/i2s/i2s_lcd_cam_peripheral_esp.cpp.hpp
@@ -105,12 +105,12 @@ bool I2sLcdCamPeripheralEsp::initialize(const I2sLcdCamConfig& config) FL_NOEXCE
             mConfig.use_psram == config.use_psram) {
             // GPIOs might differ for different channels, but peripheral can be shared
             // as long as all GPIOs are configured in the bus
-            FL_WARN_ONCE("I2sLcdCamPeripheralEsp: Already initialized, reusing peripheral");
+            FL_WARN_F_ONCE("I2sLcdCamPeripheralEsp: Already initialized, reusing peripheral");
             return true;
         }
 
         // Config doesn't match - need to reinitialize
-        FL_WARN_ONCE("I2sLcdCamPeripheralEsp: Config changed, reinitializing peripheral");
+        FL_WARN_F_ONCE("I2sLcdCamPeripheralEsp: Config changed, reinitializing peripheral");
         deinitialize();
     }
 
@@ -118,12 +118,12 @@ bool I2sLcdCamPeripheralEsp::initialize(const I2sLcdCamConfig& config) FL_NOEXCE
 
     // Validate configuration
     if (config.num_lanes < 1 || config.num_lanes > 16) {
-        FL_WARN("I2sLcdCamPeripheralEsp: Invalid num_lanes: " << config.num_lanes);
+        FL_WARN_F("I2sLcdCamPeripheralEsp: Invalid num_lanes: %s", config.num_lanes);
         return false;
     }
 
     if (config.pclk_hz == 0) {
-        FL_WARN("I2sLcdCamPeripheralEsp: Invalid pclk_hz: 0");
+        FL_WARN_F("I2sLcdCamPeripheralEsp: Invalid pclk_hz: 0");
         return false;
     }
 
@@ -158,7 +158,7 @@ bool I2sLcdCamPeripheralEsp::initialize(const I2sLcdCamConfig& config) FL_NOEXCE
     // Create I80 bus
     esp_err_t err = esp_lcd_new_i80_bus(&bus_config, &mI80Bus);
     if (err != ESP_OK) {
-        FL_WARN("I2sLcdCamPeripheralEsp: Failed to create I80 bus: " << err);
+        FL_WARN_F("I2sLcdCamPeripheralEsp: Failed to create I80 bus: %s", err);
         return false;
     }
 
@@ -181,7 +181,7 @@ bool I2sLcdCamPeripheralEsp::initialize(const I2sLcdCamConfig& config) FL_NOEXCE
     // Create panel IO
     err = esp_lcd_new_panel_io_i80(mI80Bus, &io_config, &mPanelIo);
     if (err != ESP_OK) {
-        FL_WARN("I2sLcdCamPeripheralEsp: Failed to create panel IO: " << err);
+        FL_WARN_F("I2sLcdCamPeripheralEsp: Failed to create panel IO: %s", err);
         esp_lcd_del_i80_bus(mI80Bus);
         mI80Bus = nullptr;
         return false;

--- a/src/platforms/esp/32/drivers/i2s/i2s_lcd_cam_peripheral_mock.cpp.hpp
+++ b/src/platforms/esp/32/drivers/i2s/i2s_lcd_cam_peripheral_mock.cpp.hpp
@@ -161,7 +161,7 @@ I2sLcdCamPeripheralMockImpl::~I2sLcdCamPeripheralMockImpl() {
 bool I2sLcdCamPeripheralMockImpl::initialize(const I2sLcdCamConfig& config) FL_NOEXCEPT {
     // Validate config
     if (config.num_lanes == 0 || config.num_lanes > 16) {
-        FL_WARN("I2sLcdCamPeripheralMock: Invalid num_lanes: " << config.num_lanes);
+        FL_WARN_F("I2sLcdCamPeripheralMock: Invalid num_lanes: %s", config.num_lanes);
         return false;
     }
 
@@ -198,7 +198,7 @@ u16* I2sLcdCamPeripheralMockImpl::allocateBuffer(size_t size_bytes) FL_NOEXCEPT 
 #endif
 
     if (buffer == nullptr) {
-        FL_WARN("I2sLcdCamPeripheralMock: Failed to allocate buffer (" << aligned_size << " bytes)");
+        FL_WARN_F("I2sLcdCamPeripheralMock: Failed to allocate buffer (%s bytes)", aligned_size);
     }
 
     return static_cast<u16*>(buffer);
@@ -220,7 +220,7 @@ void I2sLcdCamPeripheralMockImpl::freeBuffer(u16* buffer) FL_NOEXCEPT {
 
 bool I2sLcdCamPeripheralMockImpl::transmit(const u16* buffer, size_t size_bytes) FL_NOEXCEPT {
     if (!mInitialized) {
-        FL_WARN("I2sLcdCamPeripheralMock: Cannot transmit - not initialized");
+        FL_WARN_F("I2sLcdCamPeripheralMock: Cannot transmit - not initialized");
         return false;
     }
 

--- a/src/platforms/esp/32/drivers/i2s/wave8_encoder_i2s.cpp.hpp
+++ b/src/platforms/esp/32/drivers/i2s/wave8_encoder_i2s.cpp.hpp
@@ -21,8 +21,7 @@ size_t wave8EncodeI2sSingleLane(
     // Calculate required output size
     const size_t required_words = wave8CalculateI2sOutputSize(input.size());
     if (output.size() < required_words) {
-        FL_WARN("wave8EncodeI2sSingleLane: Output buffer too small (need "
-                << required_words << " words, have " << output.size() << ")");
+        FL_WARN_F("wave8EncodeI2sSingleLane: Output buffer too small (need %s words, have %s)", required_words, output.size());
         return 0;
     }
 
@@ -72,7 +71,7 @@ size_t wave8EncodeI2sMultiLane(
     const size_t lane_size = lanes[0].size();
     for (int i = 1; i < num_lanes; i++) {
         if (lanes[i].size() != lane_size) {
-            FL_WARN("wave8EncodeI2sMultiLane: Lane size mismatch");
+            FL_WARN_F("wave8EncodeI2sMultiLane: Lane size mismatch");
             return 0;
         }
     }
@@ -80,7 +79,7 @@ size_t wave8EncodeI2sMultiLane(
     // Calculate required output size
     const size_t required_words = wave8CalculateI2sOutputSize(lane_size);
     if (output.size() < required_words) {
-        FL_WARN("wave8EncodeI2sMultiLane: Output buffer too small");
+        FL_WARN_F("wave8EncodeI2sMultiLane: Output buffer too small");
         return 0;
     }
 

--- a/src/platforms/esp/32/drivers/i2s_spi/channel_driver_i2s_spi.cpp.hpp
+++ b/src/platforms/esp/32/drivers/i2s_spi/channel_driver_i2s_spi.cpp.hpp
@@ -89,7 +89,7 @@ void ChannelDriverI2sSpi::show() FL_NOEXCEPT {
         fl::task::run(250, fl::task::ExecFlags::SYSTEM);
     }
     if (mBusy) {
-        FL_WARN("ChannelDriverI2sSpi: DMA hung — forcing release");
+        FL_WARN_F("ChannelDriverI2sSpi: DMA hung — forcing release");
         mBusy = false;
         for (auto &channel : mTransmittingChannels) {
             channel->setInUse(false);
@@ -187,14 +187,14 @@ bool ChannelDriverI2sSpi::beginTransmission(
         }
 
         if (!mPeripheral->initialize(config)) {
-            FL_WARN("ChannelDriverI2sSpi: Failed to initialize peripheral");
+            FL_WARN_F("ChannelDriverI2sSpi: Failed to initialize peripheral");
             return false;
         }
 
         // Allocate buffer
         mBuffer = mPeripheral->allocateBuffer(interleavedSize);
         if (mBuffer == nullptr) {
-            FL_WARN("ChannelDriverI2sSpi: Failed to allocate buffer");
+            FL_WARN_F("ChannelDriverI2sSpi: Failed to allocate buffer");
             return false;
         }
         mBufferSize = interleavedSize;
@@ -224,7 +224,7 @@ bool ChannelDriverI2sSpi::beginTransmission(
         for (const auto &channel : channels) {
             channel->setInUse(false);
         }
-        FL_WARN("ChannelDriverI2sSpi: Transmit failed");
+        FL_WARN_F("ChannelDriverI2sSpi: Transmit failed");
         return false;
     }
 

--- a/src/platforms/esp/32/drivers/i2s_spi/i2s_spi_peripheral_esp.cpp.hpp
+++ b/src/platforms/esp/32/drivers/i2s_spi/i2s_spi_peripheral_esp.cpp.hpp
@@ -162,13 +162,12 @@ bool I2sSpiPeripheralEsp::initialize(const I2sSpiConfig &config) FL_NOEXCEPT {
     }
 
     if (config.num_lanes < 1 || config.num_lanes > 16) {
-        FL_WARN("I2sSpiPeripheralEsp: Invalid num_lanes: "
-                << config.num_lanes);
+        FL_WARN_F("I2sSpiPeripheralEsp: Invalid num_lanes: %s", config.num_lanes);
         return false;
     }
 
     if (config.clock_gpio < 0) {
-        FL_WARN("I2sSpiPeripheralEsp: Invalid clock_gpio");
+        FL_WARN_F("I2sSpiPeripheralEsp: Invalid clock_gpio");
         return false;
     }
 
@@ -282,7 +281,7 @@ bool I2sSpiPeripheralEsp::initialize(const I2sSpiConfig &config) FL_NOEXCEPT {
     mDmaBuffer = static_cast<u16 *>(
         heap_caps_malloc(dmaBytes, MALLOC_CAP_DMA | MALLOC_CAP_8BIT));
     if (mDmaBuffer == nullptr) {
-        FL_WARN("I2sSpiPeripheralEsp: Failed to allocate DMA buffer");
+        FL_WARN_F("I2sSpiPeripheralEsp: Failed to allocate DMA buffer");
         return false;
     }
     fl::memset(mDmaBuffer, 0, dmaBytes);
@@ -298,7 +297,7 @@ bool I2sSpiPeripheralEsp::initialize(const I2sSpiConfig &config) FL_NOEXCEPT {
     mDmaDescs = static_cast<lldesc_t *>(heap_caps_malloc(
         mDmaDescCount * sizeof(lldesc_t), MALLOC_CAP_DMA));
     if (mDmaDescs == nullptr) {
-        FL_WARN("I2sSpiPeripheralEsp: Failed to allocate DMA descriptors");
+        FL_WARN_F("I2sSpiPeripheralEsp: Failed to allocate DMA descriptors");
         heap_caps_free(mDmaBuffer);
         mDmaBuffer = nullptr;
         mDmaBufferWords = 0;
@@ -335,8 +334,7 @@ bool I2sSpiPeripheralEsp::initialize(const I2sSpiConfig &config) FL_NOEXCEPT {
         ETS_I2S0_INTR_SOURCE, ESP_INTR_FLAG_IRAM, &isrHandler, this,
         &mIntrHandle);
     if (intr_err != ESP_OK) {
-        FL_WARN("I2sSpiPeripheralEsp: Failed to allocate interrupt: "
-                << intr_err);
+        FL_WARN_F("I2sSpiPeripheralEsp: Failed to allocate interrupt: %s", intr_err);
         heap_caps_free(mDmaDescs);
         mDmaDescs = nullptr;
         mDmaDescCount = 0;
@@ -352,8 +350,7 @@ bool I2sSpiPeripheralEsp::initialize(const I2sSpiConfig &config) FL_NOEXCEPT {
     }
 
     mInitialized = true;
-    FL_DBG("I2sSpiPeripheralEsp: Native I2S init with "
-           << config.num_lanes << " lanes, " << clockMHz << " MHz clock");
+    FL_DBG_F("I2sSpiPeripheralEsp: Native I2S init with %s lanes, %s MHz clock", config.num_lanes, clockMHz);
     return true;
 }
 

--- a/src/platforms/esp/32/drivers/i2s_spi/i2s_spi_peripheral_mock.cpp.hpp
+++ b/src/platforms/esp/32/drivers/i2s_spi/i2s_spi_peripheral_mock.cpp.hpp
@@ -115,7 +115,7 @@ I2sSpiPeripheralMockImpl::~I2sSpiPeripheralMockImpl() {}
 bool I2sSpiPeripheralMockImpl::initialize(
     const I2sSpiConfig &config) FL_NOEXCEPT {
     if (config.num_lanes == 0 || config.num_lanes > 16) {
-        FL_WARN("I2sSpiPeripheralMock: Invalid num_lanes: " << config.num_lanes);
+        FL_WARN_F("I2sSpiPeripheralMock: Invalid num_lanes: %s", config.num_lanes);
         return false;
     }
     mConfig = config;
@@ -148,8 +148,7 @@ u8 *I2sSpiPeripheralMockImpl::allocateBuffer(size_t size_bytes) FL_NOEXCEPT {
     buffer = aligned_alloc(64, aligned_size);
 #endif
     if (buffer == nullptr) {
-        FL_WARN("I2sSpiPeripheralMock: Failed to allocate buffer ("
-                << aligned_size << " bytes)");
+        FL_WARN_F("I2sSpiPeripheralMock: Failed to allocate buffer (%s bytes)", aligned_size);
     }
     return static_cast<u8 *>(buffer);
 }
@@ -171,7 +170,7 @@ void I2sSpiPeripheralMockImpl::freeBuffer(u8 *buffer) FL_NOEXCEPT {
 bool I2sSpiPeripheralMockImpl::transmit(const u8 *buffer,
                                         size_t size_bytes) FL_NOEXCEPT {
     if (!mInitialized) {
-        FL_WARN("I2sSpiPeripheralMock: Cannot transmit - not initialized");
+        FL_WARN_F("I2sSpiPeripheralMock: Cannot transmit - not initialized");
         return false;
     }
     if (mShouldFailTransmit) {

--- a/src/platforms/esp/32/drivers/lcd_cam/channel_driver_lcd_rgb.cpp.hpp
+++ b/src/platforms/esp/32/drivers/lcd_cam/channel_driver_lcd_rgb.cpp.hpp
@@ -248,7 +248,7 @@ bool ChannelEngineLcdRgb::beginTransmission(fl::span<const ChannelDataPtr> chann
         }
 
         if (!mPeripheral->initialize(pconfig)) {
-            FL_WARN("ChannelEngineLcdRgb: Failed to initialize peripheral");
+            FL_WARN_F("ChannelEngineLcdRgb: Failed to initialize peripheral");
             return false;
         }
 
@@ -267,7 +267,7 @@ bool ChannelEngineLcdRgb::beginTransmission(fl::span<const ChannelDataPtr> chann
         for (int i = 0; i < 2; i++) {
             mBuffers[i] = mPeripheral->allocateFrameBuffer(mBufferSize);
             if (mBuffers[i] == nullptr) {
-                FL_WARN("ChannelEngineLcdRgb: Failed to allocate buffer");
+                FL_WARN_F("ChannelEngineLcdRgb: Failed to allocate buffer");
                 return false;
             }
             // Initialize with zeros
@@ -299,7 +299,7 @@ bool ChannelEngineLcdRgb::beginTransmission(fl::span<const ChannelDataPtr> chann
         for (const auto& channel : channelData) {
             channel->setInUse(false);
         }
-        FL_WARN("ChannelEngineLcdRgb: Failed to start transmission");
+        FL_WARN_F("ChannelEngineLcdRgb: Failed to start transmission");
         return false;
     }
 

--- a/src/platforms/esp/32/drivers/lcd_cam/lcd_rgb_peripheral_esp.cpp.hpp
+++ b/src/platforms/esp/32/drivers/lcd_cam/lcd_rgb_peripheral_esp.cpp.hpp
@@ -68,7 +68,7 @@ LcdRgbPeripheralEsp::~LcdRgbPeripheralEsp() {
 
 bool LcdRgbPeripheralEsp::initialize(const LcdRgbPeripheralConfig& config) FL_NOEXCEPT {
     if (mInitialized) {
-        FL_WARN("LcdRgbPeripheralEsp: Already initialized");
+        FL_WARN_F("LcdRgbPeripheralEsp: Already initialized");
         return false;
     }
 
@@ -76,12 +76,12 @@ bool LcdRgbPeripheralEsp::initialize(const LcdRgbPeripheralConfig& config) FL_NO
 
     // Validate configuration
     if (config.num_lanes < 1 || config.num_lanes > 16) {
-        FL_WARN("LcdRgbPeripheralEsp: Invalid num_lanes: " << config.num_lanes);
+        FL_WARN_F("LcdRgbPeripheralEsp: Invalid num_lanes: %s", config.num_lanes);
         return false;
     }
 
     if (config.pclk_hz == 0) {
-        FL_WARN("LcdRgbPeripheralEsp: Invalid pclk_hz: 0");
+        FL_WARN_F("LcdRgbPeripheralEsp: Invalid pclk_hz: 0");
         return false;
     }
 
@@ -137,14 +137,14 @@ bool LcdRgbPeripheralEsp::initialize(const LcdRgbPeripheralConfig& config) FL_NO
     // Create RGB panel
     esp_err_t err = esp_lcd_new_rgb_panel(&panel_config, &mPanelHandle);
     if (err != ESP_OK) {
-        FL_WARN("LcdRgbPeripheralEsp: Failed to create RGB panel: " << err);
+        FL_WARN_F("LcdRgbPeripheralEsp: Failed to create RGB panel: %s", err);
         return false;
     }
 
     // Initialize panel
     err = esp_lcd_panel_init(mPanelHandle);
     if (err != ESP_OK) {
-        FL_WARN("LcdRgbPeripheralEsp: Failed to initialize panel: " << err);
+        FL_WARN_F("LcdRgbPeripheralEsp: Failed to initialize panel: %s", err);
         esp_lcd_panel_del(mPanelHandle);
         mPanelHandle = nullptr;
         return false;

--- a/src/platforms/esp/32/drivers/lcd_cam/lcd_rgb_peripheral_mock.cpp.hpp
+++ b/src/platforms/esp/32/drivers/lcd_cam/lcd_rgb_peripheral_mock.cpp.hpp
@@ -148,7 +148,7 @@ LcdRgbPeripheralMockImpl::~LcdRgbPeripheralMockImpl() {
 bool LcdRgbPeripheralMockImpl::initialize(const LcdRgbPeripheralConfig& config) FL_NOEXCEPT {
     // Validate config
     if (config.num_lanes == 0 || config.num_lanes > 16) {
-        FL_WARN("LcdRgbPeripheralMock: Invalid num_lanes: " << config.num_lanes);
+        FL_WARN_F("LcdRgbPeripheralMock: Invalid num_lanes: %s", config.num_lanes);
         return false;
     }
 
@@ -186,7 +186,7 @@ u16* LcdRgbPeripheralMockImpl::allocateFrameBuffer(size_t size_bytes) FL_NOEXCEP
 #endif
 
     if (buffer == nullptr) {
-        FL_WARN("LcdRgbPeripheralMock: Failed to allocate buffer (" << aligned_size << " bytes)");
+        FL_WARN_F("LcdRgbPeripheralMock: Failed to allocate buffer (%s bytes)", aligned_size);
     }
 
     return static_cast<u16*>(buffer);
@@ -208,7 +208,7 @@ void LcdRgbPeripheralMockImpl::freeFrameBuffer(u16* buffer) FL_NOEXCEPT {
 
 bool LcdRgbPeripheralMockImpl::drawFrame(const u16* buffer, size_t size_bytes) FL_NOEXCEPT {
     if (!mInitialized) {
-        FL_WARN("LcdRgbPeripheralMock: Cannot draw - not initialized");
+        FL_WARN_F("LcdRgbPeripheralMock: Cannot draw - not initialized");
         return false;
     }
 

--- a/src/platforms/esp/32/drivers/lcd_spi/channel_driver_lcd_clockless.cpp.hpp
+++ b/src/platforms/esp/32/drivers/lcd_spi/channel_driver_lcd_clockless.cpp.hpp
@@ -1,4 +1,4 @@
-// IWYU pragma: private
+﻿// IWYU pragma: private
 
 /// @file channel_driver_lcd_clockless.cpp.hpp
 /// @brief LCD_CAM I80 clockless channel driver implementation
@@ -80,7 +80,7 @@ ChannelDriverLcdClockless::~ChannelDriverLcdClockless() {
         bool done = mPeripheral->waitTransmitDone(2000);
         mBusy = false;
         if (!done) {
-            FL_WARN("ChannelDriverLcdClockless: DMA wait timed out — "
+            FL_WARN_F("ChannelDriverLcdClockless: DMA wait timed out â€” "
                     "freeing ring buffers anyway");
         }
     }
@@ -113,7 +113,7 @@ bool ChannelDriverLcdClockless::allocateRingBuffers(
     for (size_t i = 0; i < kRingBufferCount; i++) {
         mRingBuffers[i] = mPeripheral->allocateBuffer(slotCapacityBytes);
         if (mRingBuffers[i] == nullptr) {
-            FL_WARN("ChannelDriverLcdClockless: ring buffer alloc failed");
+            FL_WARN_F("ChannelDriverLcdClockless: ring buffer alloc failed");
             freeRingBuffers();
             return false;
         }
@@ -308,7 +308,7 @@ void ChannelDriverLcdClockless::show() FL_NOEXCEPT {
 
     (void)waitForReady(2000);
     if (mBusy) {
-        FL_WARN("ChannelDriverLcdClockless: DMA hung — forcing release");
+        FL_WARN_F("ChannelDriverLcdClockless: DMA hung â€” forcing release");
         mBusy = false;
         for (auto &channel : mTransmittingChannels) {
             channel->setInUse(false);
@@ -363,7 +363,7 @@ IChannelDriver::DriverState ChannelDriverLcdClockless::poll() FL_NOEXCEPT {
 }
 
 //=============================================================================
-// Encoding — wave3 or wave8 transpose into u16 DMA words
+// Encoding â€” wave3 or wave8 transpose into u16 DMA words
 //=============================================================================
 
 void ChannelDriverLcdClockless::setPollNeededCallback(PollNeededCallback callback) FL_NOEXCEPT {
@@ -420,7 +420,7 @@ size_t FL_IRAM ChannelDriverLcdClockless::encodeChunk(
 // ISR Callback
 //=============================================================================
 
-// FL_IRAM matches the declaration in channel_driver_lcd_clockless.h — this
+// FL_IRAM matches the declaration in channel_driver_lcd_clockless.h â€” this
 // callback runs in ISR context and MUST live in IRAM so it can execute while
 // flash cache is suspended. Without it, a concurrent flash operation (NVS
 // commit, esp_flash_erase_region, etc.) keeps the ISR stalled past the 300 ms
@@ -462,13 +462,12 @@ bool ChannelDriverLcdClockless::beginTransmission(
     }
 
     if (channels.size() > 16) {
-        FL_WARN("ChannelDriverLcdClockless: too many channels ("
-                << channels.size() << "), max 16 supported");
+        FL_WARN_F("ChannelDriverLcdClockless: too many channels (%s), max 16 supported", channels.size());
         return false;
     }
 
     if (!ensureWorkerTask()) {
-        FL_WARN("ChannelDriverLcdClockless: worker task creation failed");
+        FL_WARN_F("ChannelDriverLcdClockless: worker task creation failed");
         return false;
     }
 
@@ -576,7 +575,7 @@ bool ChannelDriverLcdClockless::beginTransmission(
         // PCLK and DC pins are required by the LCD I80 bus API but the
         // signals are not connected to LEDs for clockless output (data
         // streams out on data_gpios). Use GPIO 0 for both (same convention
-        // as the legacy I2S LCD_CAM driver this replaces — proven safe on
+        // as the legacy I2S LCD_CAM driver this replaces â€” proven safe on
         // ESP32-S3 because the strapping pin tolerates being multiplexed
         // to unused peripheral functions).
         if (config.clock_gpio < 0) {
@@ -587,7 +586,7 @@ bool ChannelDriverLcdClockless::beginTransmission(
         }
 
         if (!mPeripheral->initialize(config)) {
-            FL_WARN("ChannelDriverLcdClockless: Failed to init peripheral");
+            FL_WARN_F("ChannelDriverLcdClockless: Failed to init peripheral");
             return false;
         }
 
@@ -602,7 +601,7 @@ bool ChannelDriverLcdClockless::beginTransmission(
     // Register ISR callback
     if (!mPeripheral->registerTransmitCallback(
             reinterpret_cast<void *>(&isrChunkDone), this)) { // ok reinterpret cast
-        FL_WARN("ChannelDriverLcdClockless: registerTransmitCallback failed");
+        FL_WARN_F("ChannelDriverLcdClockless: registerTransmitCallback failed");
         return false;
     }
 
@@ -623,7 +622,7 @@ bool ChannelDriverLcdClockless::beginTransmission(
         for (const auto &channel : channels) {
             channel->setInUse(false);
         }
-        FL_WARN("ChannelDriverLcdClockless: Initial transmit failed");
+        FL_WARN_F("ChannelDriverLcdClockless: Initial transmit failed");
         return false;
     }
     mIsrCtx.mSubmittedChunks = 1;

--- a/src/platforms/esp/32/drivers/lcd_spi/channel_driver_lcd_spi.cpp.hpp
+++ b/src/platforms/esp/32/drivers/lcd_spi/channel_driver_lcd_spi.cpp.hpp
@@ -1,4 +1,4 @@
-// IWYU pragma: private
+﻿// IWYU pragma: private
 
 /// @file channel_driver_lcd_spi.cpp
 /// @brief LCD_CAM SPI channel driver implementation
@@ -59,7 +59,7 @@ ChannelDriverLcdSpi::ChannelDriverLcdSpi(
 }
 
 ChannelDriverLcdSpi::~ChannelDriverLcdSpi() {
-    // Block until DMA completes — ring buffers are DMA sources,
+    // Block until DMA completes â€” ring buffers are DMA sources,
     // so freeing them while DMA is active would be a use-after-free.
     if (mBusy && mPeripheral) {
         bool done = mPeripheral->waitTransmitDone(2000);
@@ -69,7 +69,7 @@ ChannelDriverLcdSpi::~ChannelDriverLcdSpi() {
             // hardware or a mock with no auto-completion. Free anyway:
             // LeakSanitizer flags the alternative, and a 2 s stall already
             // indicates the DMA is lost.
-            FL_WARN("ChannelDriverLcdSpi: DMA wait timed out — "
+            FL_WARN_F("ChannelDriverLcdSpi: DMA wait timed out â€” "
                     "freeing ring buffers anyway");
         }
     }
@@ -101,8 +101,7 @@ bool ChannelDriverLcdSpi::allocateRingBuffers(
     for (size_t i = 0; i < kRingBufferCount; i++) {
         mRingBuffers[i] = mPeripheral->allocateBuffer(slotCapacityBytes);
         if (mRingBuffers[i] == nullptr) {
-            FL_WARN("ChannelDriverLcdSpi: ring buffer alloc failed slot "
-                    << i);
+            FL_WARN_F("ChannelDriverLcdSpi: ring buffer alloc failed slot %s", i);
             freeRingBuffers();
             return false;
         }
@@ -143,7 +142,7 @@ void ChannelDriverLcdSpi::show() FL_NOEXCEPT {
         fl::task::run(250, fl::task::ExecFlags::SYSTEM);
     }
     if (mBusy) {
-        FL_WARN("ChannelDriverLcdSpi: DMA hung — forcing release");
+        FL_WARN_F("ChannelDriverLcdSpi: DMA hung â€” forcing release");
         mBusy = false;
         for (auto &channel : mTransmittingChannels) {
             channel->setInUse(false);
@@ -184,7 +183,7 @@ IChannelDriver::DriverState ChannelDriverLcdSpi::poll() FL_NOEXCEPT {
 }
 
 //=============================================================================
-// Transposition (byte → 16-bit word, per-chunk)
+// Transposition (byte â†’ 16-bit word, per-chunk)
 //=============================================================================
 
 void ChannelDriverLcdSpi::transposeToWords(
@@ -219,7 +218,7 @@ void ChannelDriverLcdSpi::transposeToWords(
 }
 
 //=============================================================================
-// ISR Callback — processes chunk completion
+// ISR Callback â€” processes chunk completion
 //=============================================================================
 
 bool ChannelDriverLcdSpi::isrChunkDone(void *panel_io, const void *edata,
@@ -241,7 +240,7 @@ bool ChannelDriverLcdSpi::isrChunkDone(void *panel_io, const void *edata,
     size_t writeIdx = ctx.mRingWriteIdx;
     u16 *buf = self->mRingBuffers[writeIdx];
 
-    // Calculate bytes for this chunk (may pad beyond source data — that's OK,
+    // Calculate bytes for this chunk (may pad beyond source data â€” that's OK,
     // transposeToWords outputs zeros for out-of-range bytes)
     size_t bytesRemaining = ctx.mTotalBytes - ctx.mNextByteOffset;
     size_t chunkBytes = ctx.mChunkInputBytes;
@@ -253,7 +252,7 @@ bool ChannelDriverLcdSpi::isrChunkDone(void *panel_io, const void *edata,
     self->transposeToWords(self->mTransmittingChannels, buf,
                            ctx.mNextByteOffset, chunkBytes);
 
-    // Explicit read-modify-write — `mNextByteOffset` is volatile (ISR/main
+    // Explicit read-modify-write â€” `mNextByteOffset` is volatile (ISR/main
     // memory model, see channel_driver_lcd_spi.h:117-130). C++20 deprecates
     // compound assignment on volatile (-Wvolatile); C++23 makes it a hard
     // error. #2723
@@ -263,17 +262,17 @@ bool ChannelDriverLcdSpi::isrChunkDone(void *panel_io, const void *edata,
     // Submit this chunk for DMA
     size_t dmaBytes = chunkBytes * 8 * sizeof(u16);
     if (!self->mPeripheral->transmit(buf, dmaBytes)) {
-        // Transmit failed — abort stream
+        // Transmit failed â€” abort stream
         ctx.mStreamComplete = true;
         self->mBusy = false;
-        FL_WARN("ChannelDriverLcdSpi: ISR transmit failed");
+        FL_WARN_F("ChannelDriverLcdSpi: ISR transmit failed");
     }
 
     return false;
 }
 
 //=============================================================================
-// Begin Transmission — sets up chunked streaming
+// Begin Transmission â€” sets up chunked streaming
 //=============================================================================
 
 bool ChannelDriverLcdSpi::beginTransmission(
@@ -305,7 +304,7 @@ bool ChannelDriverLcdSpi::beginTransmission(
         chunkInputBytes = maxSize;
     }
 
-    // Each source byte → 8 u16 words → 16 DMA bytes
+    // Each source byte â†’ 8 u16 words â†’ 16 DMA bytes
     size_t slotCapacityBytes = chunkInputBytes * 8 * sizeof(u16);
 
     // Only reinitialize the peripheral when hardware config changes
@@ -346,7 +345,7 @@ bool ChannelDriverLcdSpi::beginTransmission(
         }
 
         if (!mPeripheral->initialize(config)) {
-            FL_WARN("ChannelDriverLcdSpi: Failed to initialize peripheral");
+            FL_WARN_F("ChannelDriverLcdSpi: Failed to initialize peripheral");
             return false;
         }
 
@@ -362,7 +361,7 @@ bool ChannelDriverLcdSpi::beginTransmission(
     // Register the ISR callback for chunked streaming
     if (!mPeripheral->registerTransmitCallback(
             reinterpret_cast<void *>(&isrChunkDone), this)) { // ok reinterpret cast
-        FL_WARN("ChannelDriverLcdSpi: registerTransmitCallback failed");
+        FL_WARN_F("ChannelDriverLcdSpi: registerTransmitCallback failed");
         return false;
     }
 
@@ -388,7 +387,7 @@ bool ChannelDriverLcdSpi::beginTransmission(
     mIsrCtx.mNextByteOffset = firstChunkBytes;
     mIsrCtx.mRingWriteIdx = 1; // next write goes to slot 1
 
-    // Submit first chunk — ISR callback handles the rest
+    // Submit first chunk â€” ISR callback handles the rest
     mBusy = true;
     size_t firstDmaBytes = firstChunkBytes * 8 * sizeof(u16);
     if (!mPeripheral->transmit(mRingBuffers[0], firstDmaBytes)) {
@@ -396,7 +395,7 @@ bool ChannelDriverLcdSpi::beginTransmission(
         for (const auto &channel : channels) {
             channel->setInUse(false);
         }
-        FL_WARN("ChannelDriverLcdSpi: Initial transmit failed");
+        FL_WARN_F("ChannelDriverLcdSpi: Initial transmit failed");
         return false;
     }
 

--- a/src/platforms/esp/32/drivers/lcd_spi/lcd_spi_peripheral_esp.cpp.hpp
+++ b/src/platforms/esp/32/drivers/lcd_spi/lcd_spi_peripheral_esp.cpp.hpp
@@ -1,4 +1,4 @@
-// IWYU pragma: private
+﻿// IWYU pragma: private
 
 /// @file lcd_spi_peripheral_esp.cpp
 /// @brief ESP32-S3 LCD_CAM SPI peripheral implementation
@@ -58,7 +58,7 @@ namespace detail {
 bool IRAM_ATTR lcd_spi_flush_ready(
     esp_lcd_panel_io_handle_t panel_io,
     esp_lcd_panel_io_event_data_t *edata,
-    void *user_ctx) { // ok no noexcept — matches friend decl
+    void *user_ctx) { // ok no noexcept â€” matches friend decl
     LcdSpiPeripheralEsp *self =
         static_cast<LcdSpiPeripheralEsp *>(user_ctx);
     if (self->mPendingTransmits > 0) {
@@ -75,7 +75,7 @@ bool IRAM_ATTR lcd_spi_flush_ready(
 
     bool result = false;
     if (self->mCallback) {
-        // WARNING: callback MUST be in IRAM — called from ISR context.
+        // WARNING: callback MUST be in IRAM â€” called from ISR context.
         using CallbackType = bool (*)(void *, const void *, void *);
         auto fn =
             reinterpret_cast<CallbackType>(self->mCallback); // ok reinterpret cast
@@ -147,18 +147,17 @@ bool LcdSpiPeripheralEsp::initialize(const LcdSpiConfig &config) FL_NOEXCEPT {
     }
 
     if (config.num_lanes < 1 || config.num_lanes > 16) {
-        FL_WARN("LcdSpiPeripheralEsp: Invalid num_lanes: "
-                << config.num_lanes);
+        FL_WARN_F("LcdSpiPeripheralEsp: Invalid num_lanes: %s", config.num_lanes);
         return false;
     }
 
     if (config.clock_gpio < 0) {
-        FL_WARN("LcdSpiPeripheralEsp: Invalid clock_gpio");
+        FL_WARN_F("LcdSpiPeripheralEsp: Invalid clock_gpio");
         return false;
     }
 
     if (config.clock_hz == 0) {
-        FL_WARN("LcdSpiPeripheralEsp: Invalid clock_hz: 0");
+        FL_WARN_F("LcdSpiPeripheralEsp: Invalid clock_hz: 0");
         return false;
     }
 
@@ -170,13 +169,13 @@ bool LcdSpiPeripheralEsp::initialize(const LcdSpiConfig &config) FL_NOEXCEPT {
     // DC pin is not functionally needed for LED data streaming but
     // the I80 bus API requires a valid GPIO.  GPIO 0 is used as a
     // dummy (matching i2s_lcd_cam_peripheral_esp.cpp.hpp convention).
-    // NOTE: GPIO 0 is a strapping pin — if your board uses GPIO 0 for
+    // NOTE: GPIO 0 is a strapping pin â€” if your board uses GPIO 0 for
     // boot-mode selection, set dc_gpio in LcdSpiConfig to an unused pin.
     if (config.dc_gpio >= 0) {
         bus_config.dc_gpio_num = static_cast<gpio_num_t>(config.dc_gpio);
     } else {
         bus_config.dc_gpio_num = static_cast<gpio_num_t>(0);
-        FL_WARN("LcdSpiPeripheralEsp: dc_gpio not set, defaulting to "
+        FL_WARN_F("LcdSpiPeripheralEsp: dc_gpio not set, defaulting to "
                 "GPIO 0 (strapping pin). Set LcdSpiConfig::dc_gpio to "
                 "an unused pin to avoid boot issues.");
     }
@@ -206,7 +205,7 @@ bool LcdSpiPeripheralEsp::initialize(const LcdSpiConfig &config) FL_NOEXCEPT {
 
     esp_err_t err = esp_lcd_new_i80_bus(&bus_config, &mI80Bus);
     if (err != ESP_OK) {
-        FL_WARN("LcdSpiPeripheralEsp: Failed to create I80 bus: " << err);
+        FL_WARN_F("LcdSpiPeripheralEsp: Failed to create I80 bus: %s", err);
         return false;
     }
 
@@ -225,9 +224,7 @@ bool LcdSpiPeripheralEsp::initialize(const LcdSpiConfig &config) FL_NOEXCEPT {
     mLastTransmitSize = 0;
     mInitialized = true;
     mOwner = config.owner;
-    FL_DBG("LcdSpiPeripheralEsp: Initialized with " << config.num_lanes
-           << " lanes, " << config.clock_hz << " Hz clock, owner="
-           << static_cast<int>(config.owner));
+    FL_DBG_F("LcdSpiPeripheralEsp: Initialized with %s lanes, %s Hz clock, owner=%s", config.num_lanes, config.clock_hz, static_cast<int>(config.owner));
     return true;
 }
 
@@ -339,7 +336,7 @@ bool FL_IRAM LcdSpiPeripheralEsp::transmitInternal(
     // next chunk from the on_color_trans_done callback, transmit() runs in
     // interrupt context. lcd_spi_flush_ready() already did xSemaphoreGiveFromISR
     // *before* invoking our user callback, so the take is guaranteed to be
-    // non-blocking — but we MUST use the FromISR variant because the regular
+    // non-blocking â€” but we MUST use the FromISR variant because the regular
     // xSemaphoreTake() asserts (configASSERT) when called from ISR.
     if (wait_for_slot && mCompleteSem) {
         if (xPortInIsrContext()) {
@@ -347,7 +344,7 @@ bool FL_IRAM LcdSpiPeripheralEsp::transmitInternal(
             if (xSemaphoreTakeFromISR(mCompleteSem, &hpw) != pdTRUE) {
                 // Semaphore should always be available here because
                 // lcd_spi_flush_ready already gave it before invoking our
-                // callback. If not, abort the re-arm — the next CPU-side
+                // callback. If not, abort the re-arm â€” the next CPU-side
                 // transmit() will pick up where we left off.
                 mBusy = false;
                 return false;
@@ -357,7 +354,7 @@ bool FL_IRAM LcdSpiPeripheralEsp::transmitInternal(
             }
         } else {
             if (xSemaphoreTake(mCompleteSem, pdMS_TO_TICKS(2000)) != pdTRUE) {
-                // Latch — LoggingInIramChecker forbids FL_WARN anywhere in an
+                // Latch â€” LoggingInIramChecker forbids FL_WARN anywhere in an
                 // FL_IRAM function, even on a branch that's provably task-only.
                 // Reported from waitTransmitDone() in task context.
                 mLastWaitForSlotTimeout = true;
@@ -389,8 +386,8 @@ bool FL_IRAM LcdSpiPeripheralEsp::transmitInternal(
         // trans_queue_depth=2: ChannelDriverLcdClockless::isrChunkDone calls
         // back into tx_color() from on_color_trans_done. With depth=1 the
         // currently-running transaction has not been retired from the I80
-        // queue yet, so the re-arm blocks waiting for a queue slot — from
-        // ISR context — and trips the interrupt watchdog. Depth=2 leaves
+        // queue yet, so the re-arm blocks waiting for a queue slot â€” from
+        // ISR context â€” and trips the interrupt watchdog. Depth=2 leaves
         // a free slot for the ISR-driven re-arm.
         io_config.trans_queue_depth = 2;
         io_config.dc_levels = {
@@ -407,7 +404,7 @@ bool FL_IRAM LcdSpiPeripheralEsp::transmitInternal(
         esp_err_t err =
             esp_lcd_new_panel_io_i80(mI80Bus, &io_config, &mPanelIo);
         if (err != ESP_OK) {
-            // Latch — transmit() can be entered from ISR context. Reported
+            // Latch â€” transmit() can be entered from ISR context. Reported
             // from waitTransmitDone() in task context.
             mLastPanelIoRecreateError = err;
             return false;
@@ -440,7 +437,7 @@ bool FL_IRAM LcdSpiPeripheralEsp::transmitInternal(
             mPendingTransmits = mPendingTransmits - 1;
         }
         mBusy = mPendingTransmits > 0;
-        // Latch — transmit() can be entered from ISR context. Reported
+        // Latch â€” transmit() can be entered from ISR context. Reported
         // from waitTransmitDone() in task context.
         mLastTxColorError = err;
         return false;
@@ -473,19 +470,19 @@ bool LcdSpiPeripheralEsp::waitTransmitDone(u32 timeout_ms) FL_NOEXCEPT {
     }
     mBusy = false;
 
-    // Drain errors latched by the FL_IRAM transmit path. Safe here — this
+    // Drain errors latched by the FL_IRAM transmit path. Safe here â€” this
     // function is task-only (xSemaphoreTake above would fail configASSERT
     // from ISR context).
     if (mLastWaitForSlotTimeout) {
-        FL_WARN("LcdSpiPeripheralEsp: timed out waiting for previous transmit to complete");
+        FL_WARN_F("LcdSpiPeripheralEsp: timed out waiting for previous transmit to complete");
         mLastWaitForSlotTimeout = false;
     }
     if (mLastPanelIoRecreateError != ESP_OK) {
-        FL_WARN("LcdSpiPeripheralEsp: panel IO recreate failed: " << static_cast<int>(mLastPanelIoRecreateError));
+        FL_WARN_F("LcdSpiPeripheralEsp: panel IO recreate failed: %s", static_cast<int>(mLastPanelIoRecreateError));
         mLastPanelIoRecreateError = ESP_OK;
     }
     if (mLastTxColorError != ESP_OK) {
-        FL_WARN("LcdSpiPeripheralEsp: tx_color failed: " << static_cast<int>(mLastTxColorError));
+        FL_WARN_F("LcdSpiPeripheralEsp: tx_color failed: %s", static_cast<int>(mLastTxColorError));
         mLastTxColorError = ESP_OK;
     }
     return true;

--- a/src/platforms/esp/32/drivers/lcd_spi/lcd_spi_peripheral_mock.cpp.hpp
+++ b/src/platforms/esp/32/drivers/lcd_spi/lcd_spi_peripheral_mock.cpp.hpp
@@ -96,8 +96,7 @@ LcdSpiPeripheralMockImpl::~LcdSpiPeripheralMockImpl() {}
 bool LcdSpiPeripheralMockImpl::initialize(
     const LcdSpiConfig &config) FL_NOEXCEPT {
     if (config.num_lanes == 0 || config.num_lanes > 16) {
-        FL_WARN("LcdSpiPeripheralMock: Invalid num_lanes: "
-                << config.num_lanes);
+        FL_WARN_F("LcdSpiPeripheralMock: Invalid num_lanes: %s", config.num_lanes);
         return false;
     }
     // Issue #2270: mirror the real peripheral's owner-aware teardown so
@@ -135,8 +134,7 @@ u16 *LcdSpiPeripheralMockImpl::allocateBuffer(size_t size_bytes) FL_NOEXCEPT {
     buffer = aligned_alloc(64, aligned_size);
 #endif
     if (buffer == nullptr) {
-        FL_WARN("LcdSpiPeripheralMock: Failed to allocate buffer ("
-                << aligned_size << " bytes)");
+        FL_WARN_F("LcdSpiPeripheralMock: Failed to allocate buffer (%s bytes)", aligned_size);
     }
     return static_cast<u16 *>(buffer);
 }
@@ -154,7 +152,7 @@ void LcdSpiPeripheralMockImpl::freeBuffer(u16 *buffer) FL_NOEXCEPT {
 bool LcdSpiPeripheralMockImpl::transmit(const u16 *buffer,
                                         size_t size_bytes) FL_NOEXCEPT {
     if (!mInitialized) {
-        FL_WARN("LcdSpiPeripheralMock: Cannot transmit - not initialized");
+        FL_WARN_F("LcdSpiPeripheralMock: Cannot transmit - not initialized");
         return false;
     }
     if (mShouldFailTransmit) {

--- a/src/platforms/esp/32/drivers/parlio/channel_driver_parlio.cpp.hpp
+++ b/src/platforms/esp/32/drivers/parlio/channel_driver_parlio.cpp.hpp
@@ -66,8 +66,7 @@ ChannelDriverPARLIOImpl::ChannelDriverPARLIOImpl(size_t data_width) FL_NOEXCEPT
     // Validate data width
     if (data_width != 1 && data_width != 2 && data_width != 4 &&
         data_width != 8 && data_width != 16) {
-        FL_WARN("PARLIO: Invalid data_width="
-                << data_width << " (must be 1, 2, 4, 8, or 16)");
+        FL_WARN_F("PARLIO: Invalid data_width=%s (must be 1, 2, 4, 8, or 16)", data_width);
         // Constructor will still complete, but initialization will fail
         return;
     }
@@ -80,7 +79,7 @@ ChannelDriverPARLIOImpl::~ChannelDriverPARLIOImpl() {
     u32 start = mDriver.peripheral()->millis();
     while (state.state != DriverState::READY && state.state != DriverState::ERROR) {
         if (mDriver.peripheral()->millis() - start >= 2000) {
-            FL_ERROR("PARLIO: Destructor timeout waiting for READY");
+            FL_ERROR_F("PARLIO: Destructor timeout waiting for READY");
             break;
         }
         mDriver.peripheral()->delayMicroseconds(100);
@@ -214,7 +213,7 @@ void ChannelDriverPARLIOImpl::show() FL_NOEXCEPT {
                 }
             }
             if (!has_unique_pins) {
-                FL_LOG_PARLIO("PARLIO: Channels in group " << group.mTiming.name << " have non-unique pins");
+                FL_LOG_PARLIO_F("PARLIO: Channels in group %s have non-unique pins", group.mTiming.name);
             }
         }
 
@@ -308,17 +307,14 @@ void ChannelDriverPARLIOImpl::beginTransmission(
     // Validate channel count is within bounds
     size_t channel_count = channelData.size();
     if (channel_count > 16) {
-        FL_WARN("PARLIO: Too many channels (got " << channel_count
-                                                  << ", max 16)");
+        FL_WARN_F("PARLIO: Too many channels (got %s, max 16)", channel_count);
         return;
     }
 
     // Validate channel count matches data_width constraints
     size_t required_width = selectDataWidth(channel_count);
     if (required_width != mDataWidth) {
-        FL_WARN("PARLIO: Channel count "
-                << channel_count << " requires data_width=" << required_width
-                << " but this instance is data_width=" << mDataWidth);
+        FL_WARN_F("PARLIO: Channel count %s requires data_width=%s but this instance is data_width=%s", channel_count, required_width, mDataWidth);
         return;
     }
 
@@ -327,9 +323,7 @@ void ChannelDriverPARLIOImpl::beginTransmission(
     for (size_t i = 0; i < channel_count; i++) {
         int pin = channelData[i]->getPin();
         if (!isValidParlioOutputPin(pin)) {
-            FL_WARN("PARLIO: Invalid output GPIO "
-                    << pin
-                    << " for this ESP32 target; refusing to configure PARLIO");
+            FL_WARN_F("PARLIO: Invalid output GPIO %s for this ESP32 target; refusing to configure PARLIO", pin);
             return;
         }
         pins.push_back(pin);
@@ -349,7 +343,7 @@ void ChannelDriverPARLIOImpl::beginTransmission(
 
     for (size_t i = 0; i < channelData.size(); i++) {
         if (!channelData[i]) {
-            FL_WARN("PARLIO: Null channel data at index " << i);
+            FL_WARN_F("PARLIO: Null channel data at index %s", i);
             return;
         }
 
@@ -374,10 +368,7 @@ void ChannelDriverPARLIOImpl::beginTransmission(
 
     // Initialize HAL if needed
     if (!mDriver.initialize(mDataWidth, pins, timing, maxLeds)) {
-        FL_WARN("PARLIO: HAL initialization failed (data_width=" << mDataWidth
-                << ", channels=" << channel_count << ", maxLeds=" << maxLeds
-                << "). Try reducing FL_ESP_PARLIO_MAX_LEDS_PER_CHANNEL or "
-                << "FASTLED_PARLIO_MAX_RING_BUFFER_TOTAL_BYTES");
+        FL_WARN_F("PARLIO: HAL initialization failed (data_width=%s, channels=%s, maxLeds=%s). Try reducing FL_ESP_PARLIO_MAX_LEDS_PER_CHANNEL or FASTLED_PARLIO_MAX_RING_BUFFER_TOTAL_BYTES", mDataWidth, channel_count, maxLeds);
         return;
     }
 
@@ -395,7 +386,7 @@ void ChannelDriverPARLIOImpl::beginTransmission(
             totalBufferSize,        // ITERATION 9 FIX: Pass total buffer size, not per-lane size
             channelData.size(),
             maxChannelSize)) {
-        FL_WARN("PARLIO: Transmission failed");
+        FL_WARN_F("PARLIO: Transmission failed");
     }
 }
 
@@ -416,7 +407,7 @@ void ChannelDriverPARLIOImpl::prepareScratchBuffer(
 
         // Safety check: Skip empty channels (shouldn't happen in normal operation)
         if (srcData.size() == 0 || dataSize == 0) {
-            FL_WARN("PARLIO: Channel " << i << " has empty data (size=" << srcData.size() << "), skipping transmission");
+            FL_WARN_F("PARLIO: Channel %s has empty data (size=%s), skipping transmission", i, srcData.size());
             return;  // Abort transmission - channel not ready
         }
 
@@ -580,14 +571,13 @@ void ChannelDriverPARLIO::beginClocklessTransmission(
 
     size_t channel_count = channelData.size();
     if (channel_count > 16) {
-        FL_WARN("PARLIO: Too many clockless channels (got " << channel_count
-                                                            << ", max 16)");
+        FL_WARN_F("PARLIO: Too many clockless channels (got %s, max 16)", channel_count);
         return;
     }
 
     size_t required_width = selectDataWidth(channel_count);
     if (required_width == 0) {
-        FL_WARN("PARLIO: Invalid clockless channel count " << channel_count);
+        FL_WARN_F("PARLIO: Invalid clockless channel count %s", channel_count);
         return;
     }
 
@@ -619,7 +609,7 @@ void ChannelDriverPARLIO::beginSingleSpiChannel(const ChannelDataPtr& channelDat
     const ChipsetVariant& chipset = channelData->getChipset();
     const SpiChipsetConfig* spiConfig = chipset.ptr<SpiChipsetConfig>();
     if (!spiConfig) {
-        FL_WARN("PARLIO_SPI: Channel is not SPI type");
+        FL_WARN_F("PARLIO_SPI: Channel is not SPI type");
         return;
     }
 
@@ -637,7 +627,7 @@ void ChannelDriverPARLIO::beginSingleSpiChannel(const ChannelDataPtr& channelDat
     // Initialize engine in SPI mode
     auto& driver = detail::ParlioEngine::getInstance();
     if (!driver.initializeSpi(pins, spiConfig->timing.clock_hz, dataSize)) {
-        FL_WARN("PARLIO_SPI: HAL initialization failed");
+        FL_WARN_F("PARLIO_SPI: HAL initialization failed");
         return;
     }
     mSpiInitialized = true;
@@ -648,7 +638,7 @@ void ChannelDriverPARLIO::beginSingleSpiChannel(const ChannelDataPtr& channelDat
 
     // Transmit (single lane, laneStride = dataSize)
     if (!driver.beginTransmission(mSpiScratchBuffer.data(), dataSize, 1, dataSize)) {
-        FL_WARN("PARLIO_SPI: Transmission failed");
+        FL_WARN_F("PARLIO_SPI: Transmission failed");
     }
 }
 

--- a/src/platforms/esp/32/drivers/parlio/parlio_buffer_calc.h
+++ b/src/platforms/esp/32/drivers/parlio/parlio_buffer_calc.h
@@ -234,12 +234,12 @@ struct ParlioBufferCalculator {
         size_t dmaBufferCapacity = dmaBufferSize(inputBytesPerBuffer, reset_us);
 
         if (dmaBufferCapacity > perBufferCap) {
+#ifdef FASTLED_LOG_PARLIO_ENABLED
             size_t uncappedCapacity = dmaBufferCapacity;
+#endif
             dmaBufferCapacity = perBufferCap;
 
-            FL_LOG_PARLIO("PARLIO: Ring buffer capped at " << dmaBufferCapacity
-                   << " bytes/buffer (uncapped: " << uncappedCapacity
-                   << ", total cap: " << totalCapBytes << " bytes)");
+            FL_LOG_PARLIO_F("PARLIO: Ring buffer capped at %s bytes/buffer (uncapped: %s, total cap: %s bytes)", dmaBufferCapacity, uncappedCapacity, totalCapBytes);
         }
 
         dmaBufferCapacity += safetyMargin;

--- a/src/platforms/esp/32/drivers/parlio/parlio_engine.cpp.hpp
+++ b/src/platforms/esp/32/drivers/parlio/parlio_engine.cpp.hpp
@@ -59,10 +59,10 @@ fl::detail::IParlioPeripheral* getParlioPeripheral() FL_NOEXCEPT {
     // Get peripheral singleton instance
     #ifdef FASTLED_STUB_IMPL
         return &fl::detail::ParlioPeripheralMock::instance();
-        FL_LOG_PARLIO("PARLIO_INIT: Using mock peripheral");
+        FL_LOG_PARLIO_F("PARLIO_INIT: Using mock peripheral");
     #else
         return &fl::detail::ParlioPeripheralESP::instance();
-        FL_LOG_PARLIO("PARLIO_INIT: Using ESP peripheral (real hardware)");
+        FL_LOG_PARLIO_F("PARLIO_INIT: Using ESP peripheral (real hardware)");
     #endif
 }
 
@@ -350,7 +350,7 @@ ParlioEngine::ParlioEngine() FL_NOEXCEPT
       mErrorOccurred(false),
       mTxUnitEnabled(false),
       mMaxLedsPerChannel(0) {
-    FL_LOG_PARLIO("PARLIO_INIT: Constructor entered");
+    FL_LOG_PARLIO_F("PARLIO_INIT: Constructor entered");
 }
 
 ParlioEngine::~ParlioEngine() {
@@ -358,7 +358,7 @@ ParlioEngine::~ParlioEngine() {
     u32 start = mPeripheral ? mPeripheral->millis() : 0;
     while (isTransmitting()) {
         if (mPeripheral && (mPeripheral->millis() - start >= 2000)) {
-            FL_LOG_PARLIO("PARLIO: Engine destructor timeout waiting for transmission");
+            FL_LOG_PARLIO_F("PARLIO: Engine destructor timeout waiting for transmission");
             break;
         }
         if (mPeripheral) mPeripheral->delayMicroseconds(100);
@@ -368,13 +368,13 @@ ParlioEngine::~ParlioEngine() {
     if (mPeripheral != nullptr) {
         // Wait for any pending transmissions (with timeout)
         if (!mPeripheral->waitAllDone(1000)) {
-            FL_LOG_PARLIO("PARLIO: Wait for transmission timeout during cleanup");
+            FL_LOG_PARLIO_F("PARLIO: Wait for transmission timeout during cleanup");
         }
 
         // Disable peripheral (only if currently enabled)
         if (mTxUnitEnabled) {
             if (!mPeripheral->disable()) {
-                FL_LOG_PARLIO("PARLIO: Failed to disable peripheral");
+                FL_LOG_PARLIO_F("PARLIO: Failed to disable peripheral");
             }
             mTxUnitEnabled = false;
         }
@@ -481,19 +481,11 @@ void ParlioEngine::debugTaskFunction(void* arg) FL_NOEXCEPT {
             ctx->mHardwareIdle.load(fl::memory_order_acquire);
 
         // Print ISR debug state (using FL_LOG_PARLIO which is safe from task context)
-        FL_LOG_PARLIO("ISR_STATE:"
-               << " txDone=" << ctx->mDebugTxDoneCount
-               << " worker=" << ctx->mDebugWorkerIsrCount
-               << " ring_count=" << ctx->mRingCount
-               << " bytes_tx=" << ctx->mBytesTransmitted << "/" << ctx->mTotalBytes
-               << " transmitting=" << (transmitting ? "YES" : "NO")
-               << " complete=" << (stream_complete ? "YES" : "NO")
-               << " hw_idle=" << (hardware_idle ? "YES" : "NO"));
+        FL_LOG_PARLIO_F("ISR_STATE: txDone=%s worker=%s ring_count=%s bytes_tx=%s/%s transmitting=%s complete=%s hw_idle=%s", ctx->mDebugTxDoneCount, ctx->mDebugWorkerIsrCount, ctx->mRingCount, ctx->mBytesTransmitted, ctx->mTotalBytes, (transmitting ? "YES" : "NO"), (stream_complete ? "YES" : "NO"), (hardware_idle ? "YES" : "NO"));
 
         // Check for ring buffer underrun (CRITICAL ERROR per LOOP.md)
         if (hardware_idle && ctx->mRingCount == 0 && transmitting) {
-            FL_ERROR("PARLIO: BUFFER UNDERRUN DETECTED - Hardware idle with empty ring during transmission"
-                    << " | bytes_tx=" << ctx->mBytesTransmitted << "/" << ctx->mTotalBytes);
+            FL_ERROR_F("PARLIO: BUFFER UNDERRUN DETECTED - Hardware idle with empty ring during transmission | bytes_tx=%s/%s", ctx->mBytesTransmitted, ctx->mTotalBytes);
             // DO NOT restart PARLIO - per LOOP.md this is a critical error
             // Exit task and let main thread detect the error
             break;
@@ -1174,9 +1166,7 @@ bool ParlioEngine::allocateRingBuffers() FL_NOEXCEPT {
     if (!parlioDmaPsramAvailable() &&
         !parlioCanAllocateInternalDmaRing(mRingBufferCapacity,
                                           ParlioRingBuffer3::RING_BUFFER_COUNT)) {
-        FL_LOG_PARLIO("PARLIO: Insufficient DMA heap for "
-                      << ParlioRingBuffer3::RING_BUFFER_COUNT
-                      << " ring buffers of " << mRingBufferCapacity << " bytes");
+        FL_LOG_PARLIO_F("PARLIO: Insufficient DMA heap for %s ring buffers of %s bytes", ParlioRingBuffer3::RING_BUFFER_COUNT, mRingBufferCapacity);
         return false;
     }
 
@@ -1185,8 +1175,7 @@ bool ParlioEngine::allocateRingBuffers() FL_NOEXCEPT {
         buffers[i] = mPeripheral->allocateDmaBuffer(mRingBufferCapacity);
 
         if (!buffers[i]) {
-            FL_LOG_PARLIO("PARLIO: Failed to allocate ring buffer "
-                    << i << "/3 (requested " << mRingBufferCapacity << " bytes)");
+            FL_LOG_PARLIO_F("PARLIO: Failed to allocate ring buffer %s/3 (requested %s bytes)", i, mRingBufferCapacity);
 
             // Clean up any buffers we already allocated
             for (size_t j = 0; j < i; j++) {
@@ -1210,7 +1199,7 @@ bool ParlioEngine::allocateRingBuffers() FL_NOEXCEPT {
     );
 
     if (!mRingBuffer) {
-        FL_LOG_PARLIO("PARLIO: Failed to allocate ring buffer structure");
+        FL_LOG_PARLIO_F("PARLIO: Failed to allocate ring buffer structure");
         // Clean up DMA buffers
         for (size_t i = 0; i < 3; i++) {
             mPeripheral->freeDmaBuffer(buffers[i]);
@@ -1346,7 +1335,7 @@ bool ParlioEngine::initialize(size_t dataWidth,
                               const fl::vector<int>& pins,
                               const ChipsetTimingConfig& timing,
                               size_t maxLedsPerChannel) FL_NOEXCEPT {
-    FL_LOG_PARLIO("PARLIO_INIT: initialize() called - dataWidth=" << dataWidth << " pins=" << pins.size());
+    FL_LOG_PARLIO_F("PARLIO_INIT: initialize() called - dataWidth=%s pins=%s", dataWidth, pins.size());
 
     // Get peripheral first (needed for both initial and re-initialization)
     if (mPeripheral == nullptr) {
@@ -1367,9 +1356,7 @@ bool ParlioEngine::initialize(size_t dataWidth,
     if (mInitialized && mPeripheral && mPeripheral->isInitialized() && config_matches) {
         // Config matches but check if ring buffers need reallocation for larger LED count
         if (maxLedsPerChannel > mMaxLedsPerChannel) {
-            FL_LOG_PARLIO("PARLIO_INIT: Config matches but maxLeds increased from "
-                         << mMaxLedsPerChannel << " to " << maxLedsPerChannel
-                         << " - reallocating ring buffers");
+            FL_LOG_PARLIO_F("PARLIO_INIT: Config matches but maxLeds increased from %s to %s - reallocating ring buffers", mMaxLedsPerChannel, maxLedsPerChannel);
 
             // Recalculate ring buffer capacity for larger LED count
             ParlioBufferCalculator calc(mDataWidth, mUseWave3, mClockFreqHz); // ok no noexcept
@@ -1393,12 +1380,12 @@ bool ParlioEngine::initialize(size_t dataWidth,
                         mRingBufferCapacity = ((raw_capacity + 63) / 64) * 64;
                     }
                     if (!psram_cap_available || !allocateRingBuffers()) {
-                        FL_LOG_PARLIO("PARLIO_INIT: FAILED to reallocate ring buffers");
+                        FL_LOG_PARLIO_F("PARLIO_INIT: FAILED to reallocate ring buffers");
                         mInitialized = false;
                         return false;
                     }
                 }
-                FL_LOG_PARLIO("PARLIO_INIT: Ring buffers reallocated (capacity=" << mRingBufferCapacity << ")");
+                FL_LOG_PARLIO_F("PARLIO_INIT: Ring buffers reallocated (capacity=%s)", mRingBufferCapacity);
             }
             mMaxLedsPerChannel = maxLedsPerChannel;
         }
@@ -1407,7 +1394,7 @@ bool ParlioEngine::initialize(size_t dataWidth,
         // The ESP32 PARLIO TX unit's internal DMA state machine can get stuck after
         // channels are destroyed and recreated. A full deinit/reinit of the TX unit
         // resets this state while keeping ring buffers allocated (avoiding fragmentation).
-        FL_LOG_PARLIO("PARLIO_INIT: Reinitializing TX unit for clean DMA state");
+        FL_LOG_PARLIO_F("PARLIO_INIT: Reinitializing TX unit for clean DMA state");
         mPeripheral->deinitialize();
         mTxUnitEnabled = false;
 
@@ -1424,25 +1411,25 @@ bool ParlioEngine::initialize(size_t dataWidth,
             parlioDmaPsramAvailable()
         );
         if (!mPeripheral->initialize(config)) {
-            FL_LOG_PARLIO("PARLIO_INIT: FAILED to reinitialize TX unit");
+            FL_LOG_PARLIO_F("PARLIO_INIT: FAILED to reinitialize TX unit");
             mInitialized = false;
             return false;
         }
         if (!mPeripheral->registerTxDoneCallback(
                 reinterpret_cast<void*>(txDoneCallback), this)) { // ok reinterpret cast - callback function pointer to void*
-            FL_LOG_PARLIO("PARLIO_INIT: FAILED to re-register ISR callback");
+            FL_LOG_PARLIO_F("PARLIO_INIT: FAILED to re-register ISR callback");
             mPeripheral->deinitialize();
             mInitialized = false;
             return false;
         }
 
-        FL_LOG_PARLIO("PARLIO_INIT: TX unit reinitialized, config still matching");
+        FL_LOG_PARLIO_F("PARLIO_INIT: TX unit reinitialized, config still matching");
         return true;
     }
 
     // If configuration changed, we need to re-initialize
     if (mInitialized && !config_matches) {
-        FL_LOG_PARLIO("PARLIO_INIT: Configuration changed, re-initializing");
+        FL_LOG_PARLIO_F("PARLIO_INIT: Configuration changed, re-initializing");
         mInitialized = false;
         mTxUnitEnabled = false;
         // Free old ring buffers BEFORE allocating new ones to avoid peak
@@ -1454,7 +1441,7 @@ bool ParlioEngine::initialize(size_t dataWidth,
     // If we reach here, either first initialization or peripheral was reset
     // Reset engine state to allow re-initialization
     if (mInitialized && mPeripheral && !mPeripheral->isInitialized()) {
-        FL_LOG_PARLIO("PARLIO_INIT: Peripheral was reset, re-initializing");
+        FL_LOG_PARLIO_F("PARLIO_INIT: Peripheral was reset, re-initializing");
         mInitialized = false;
         mTxUnitEnabled = false;  // Reset enable state to match peripheral
     }
@@ -1470,7 +1457,7 @@ bool ParlioEngine::initialize(size_t dataWidth,
     }
     mDummyLanes = mDataWidth - mActualChannels;
 
-    FL_LOG_PARLIO("PARLIO_INIT: mDataWidth=" << mDataWidth << " mActualChannels=" << mActualChannels << " mDummyLanes=" << mDummyLanes);
+    FL_LOG_PARLIO_F("PARLIO_INIT: mDataWidth=%s mActualChannels=%s mDummyLanes=%s", mDataWidth, mActualChannels, mDummyLanes);
 
     // Store timing parameters
     mTimingT1Ns = timing.t1_ns;
@@ -1481,7 +1468,7 @@ bool ParlioEngine::initialize(size_t dataWidth,
     // Validate data width
     if (dataWidth != 1 && dataWidth != 2 && dataWidth != 4 &&
         dataWidth != 8 && dataWidth != 16) {
-        FL_LOG_PARLIO("PARLIO: Invalid data_width=" << dataWidth);
+        FL_LOG_PARLIO_F("PARLIO: Invalid data_width=%s", dataWidth);
         return false;
     }
 
@@ -1492,8 +1479,7 @@ bool ParlioEngine::initialize(size_t dataWidth,
 
     // Validate pin count matches data width
     if (pins.size() != dataWidth) {
-        FL_LOG_PARLIO("PARLIO: Pin configuration error - expected "
-                << dataWidth << " pins, got " << pins.size());
+        FL_LOG_PARLIO_F("PARLIO: Pin configuration error - expected %s pins, got %s", dataWidth, pins.size());
         return false;
     }
 
@@ -1510,10 +1496,10 @@ bool ParlioEngine::initialize(size_t dataWidth,
     if (mUseWave3) {
         mClockFreqHz = wave3ClockFrequencyHz(chipsetTiming);
         mWave3Lut = buildWave3ExpansionLUT(chipsetTiming);
-        FL_LOG_PARLIO("PARLIO_INIT: Wave3 mode selected (clock=" << mClockFreqHz << " Hz)");
+        FL_LOG_PARLIO_F("PARLIO_INIT: Wave3 mode selected (clock=%s Hz)", mClockFreqHz);
     } else {
         mClockFreqHz = FL_ESP_PARLIO_CLOCK_FREQ_HZ;
-        FL_LOG_PARLIO("PARLIO_INIT: Wave8 mode selected (clock=" << mClockFreqHz << " Hz)");
+        FL_LOG_PARLIO_F("PARLIO_INIT: Wave8 mode selected (clock=%s Hz)", mClockFreqHz);
     }
     // Always build wave8 LUT (needed as fallback and for SPI mode)
     mWave8Lut = buildWave8ExpansionLUT(chipsetTiming);
@@ -1540,35 +1526,35 @@ bool ParlioEngine::initialize(size_t dataWidth,
         #endif
         psram_cap_available  // prefer_psram only when DMA-capable PSRAM exists
     );
-    FL_LOG_PARLIO("PARLIO_INIT: Config - clock=" << mClockFreqHz << " queue_depth=" << FL_ESP_PARLIO_HARDWARE_QUEUE_DEPTH);
+    FL_LOG_PARLIO_F("PARLIO_INIT: Config - clock=%s queue_depth=%s", mClockFreqHz, FL_ESP_PARLIO_HARDWARE_QUEUE_DEPTH);
 
     // DIAGNOSTIC: Log bit packing mode
     #if PARLIO_FORCE_LSB_MODE
-        FL_LOG_PARLIO("PARLIO_INIT: ⚠️ LSB MODE ENABLED (DIAGNOSTIC) - expect waveform failures!");
+        FL_LOG_PARLIO_F("PARLIO_INIT: ⚠️ LSB MODE ENABLED (DIAGNOSTIC) - expect waveform failures!");
     #else
-        FL_LOG_PARLIO("PARLIO_INIT: MSB mode enabled (correct for Wave8)");
+        FL_LOG_PARLIO_F("PARLIO_INIT: MSB mode enabled (correct for Wave8)");
     #endif
 
     // Initialize peripheral
-    FL_LOG_PARLIO("PARLIO_INIT: Calling mPeripheral->initialize()");
+    FL_LOG_PARLIO_F("PARLIO_INIT: Calling mPeripheral->initialize()");
     if (!mPeripheral->initialize(config)) {
-        FL_LOG_PARLIO("PARLIO_INIT: FAILED to initialize peripheral");
+        FL_LOG_PARLIO_F("PARLIO_INIT: FAILED to initialize peripheral");
         mPeripheral = nullptr;
         return false;
     }
-    FL_LOG_PARLIO("PARLIO_INIT: Peripheral initialized successfully");
+    FL_LOG_PARLIO_F("PARLIO_INIT: Peripheral initialized successfully");
 
     // Register ISR callback
-    FL_LOG_PARLIO("PARLIO_INIT: Registering ISR callback");
+    FL_LOG_PARLIO_F("PARLIO_INIT: Registering ISR callback");
     if (!mPeripheral->registerTxDoneCallback(
             reinterpret_cast<void*>(txDoneCallback), this)) { // ok reinterpret cast - callback function pointer to void*
-        FL_LOG_PARLIO("PARLIO_INIT: FAILED to register ISR callback");
-        FL_LOG_PARLIO("PARLIO: Failed to register callbacks");
+        FL_LOG_PARLIO_F("PARLIO_INIT: FAILED to register ISR callback");
+        FL_LOG_PARLIO_F("PARLIO: Failed to register callbacks");
         mPeripheral->deinitialize(); // Clean up TX unit so re-init can succeed
         mPeripheral = nullptr;
         return false;
     }
-    FL_LOG_PARLIO("PARLIO_INIT: ISR callback registered successfully");
+    FL_LOG_PARLIO_F("PARLIO_INIT: ISR callback registered successfully");
 
     // Calculate ring buffer capacity. Use the PSRAM cap only when a DMA-capable
     // PSRAM heap exists; C6 has no PSRAM and should go straight to the SRAM cap.
@@ -1586,14 +1572,14 @@ bool ParlioEngine::initialize(size_t dataWidth,
     mRingBufferCapacity = ((raw_capacity + 63) / 64) * 64;
 
     if (mRingBufferCapacity != raw_capacity) {
-        FL_LOG_PARLIO("PARLIO: Rounded buffer capacity from " << raw_capacity << " to " << mRingBufferCapacity << " bytes (64-byte alignment)");
+        FL_LOG_PARLIO_F("PARLIO: Rounded buffer capacity from %s to %s bytes (64-byte alignment)", raw_capacity, mRingBufferCapacity);
     }
 
     // Allocate ring buffers - try PSRAM-sized first only when PSRAM exists.
-    FL_LOG_PARLIO("PARLIO_INIT: Allocating ring buffers (capacity=" << mRingBufferCapacity << ")");
+    FL_LOG_PARLIO_F("PARLIO_INIT: Allocating ring buffers (capacity=%s)", mRingBufferCapacity);
     if (!allocateRingBuffers()) {
         if (psram_cap_available) {
-            FL_LOG_PARLIO("PARLIO_INIT: PSRAM-sized allocation failed, retrying with SRAM cap");
+            FL_LOG_PARLIO_F("PARLIO_INIT: PSRAM-sized allocation failed, retrying with SRAM cap");
             raw_capacity = calc.calculateRingBufferCapacity(
                 maxLedsPerChannel, mResetUs, ParlioRingBuffer3::RING_BUFFER_COUNT,
                 FASTLED_PARLIO_MAX_RING_BUFFER_TOTAL_BYTES);
@@ -1601,13 +1587,13 @@ bool ParlioEngine::initialize(size_t dataWidth,
         }
 
         if (!psram_cap_available || !allocateRingBuffers()) {
-            FL_LOG_PARLIO("PARLIO_INIT: FAILED to allocate ring buffers");
+            FL_LOG_PARLIO_F("PARLIO_INIT: FAILED to allocate ring buffers");
             mPeripheral->deinitialize(); // Clean up TX unit so re-init can succeed
             mPeripheral = nullptr;
             return false;
         }
     }
-    FL_LOG_PARLIO("PARLIO_INIT: Ring buffers allocated successfully (capacity=" << mRingBufferCapacity << ")");
+    FL_LOG_PARLIO_F("PARLIO_INIT: Ring buffers allocated successfully (capacity=%s)", mRingBufferCapacity);
 
     // Initialize ISR context state
     if (mIsrContext) {
@@ -1620,7 +1606,7 @@ bool ParlioEngine::initialize(size_t dataWidth,
 
     mMaxLedsPerChannel = maxLedsPerChannel;
     mInitialized = true;
-    FL_LOG_PARLIO("PARLIO_INIT: Initialization COMPLETE - mInitialized=true, maxLeds=" << maxLedsPerChannel);
+    FL_LOG_PARLIO_F("PARLIO_INIT: Initialization COMPLETE - mInitialized=true, maxLeds=%s", maxLedsPerChannel);
     return true;
 }
 
@@ -1629,7 +1615,7 @@ bool ParlioEngine::initializeSpi(const fl::vector<int>& pins,
                                   size_t maxBytesPerChannel) FL_NOEXCEPT {
     // SPI-over-PARLIO requires exactly 2 pins (clock + data)
     if (pins.size() != 2) {
-        FL_WARN("PARLIO_SPI: Expected 2 pins (clock, data), got " << pins.size());
+        FL_WARN_F("PARLIO_SPI: Expected 2 pins (clock, data), got %s", pins.size());
         return false;
     }
 
@@ -1698,7 +1684,7 @@ bool ParlioEngine::initializeSpi(const fl::vector<int>& pins,
     );
 
     if (!mPeripheral->initialize(config)) {
-        FL_WARN("PARLIO_SPI: Peripheral initialization failed");
+        FL_WARN_F("PARLIO_SPI: Peripheral initialization failed");
         mPeripheral = nullptr;
         return false;
     }
@@ -1706,7 +1692,7 @@ bool ParlioEngine::initializeSpi(const fl::vector<int>& pins,
     // Register ISR callback
     if (!mPeripheral->registerTxDoneCallback(
             reinterpret_cast<void*>(txDoneCallback), this)) { // ok reinterpret cast
-        FL_WARN("PARLIO_SPI: Failed to register ISR callback");
+        FL_WARN_F("PARLIO_SPI: Failed to register ISR callback");
         mPeripheral->deinitialize();
         mPeripheral = nullptr;
         return false;
@@ -1731,7 +1717,7 @@ bool ParlioEngine::initializeSpi(const fl::vector<int>& pins,
         }
 
         if (!psram_cap_available || !allocateRingBuffers()) {
-            FL_WARN("PARLIO_SPI: Failed to allocate ring buffers");
+            FL_WARN_F("PARLIO_SPI: Failed to allocate ring buffers");
             mPeripheral->deinitialize();
             mPeripheral = nullptr;
             return false;
@@ -1748,7 +1734,7 @@ bool ParlioEngine::initializeSpi(const fl::vector<int>& pins,
     mErrorOccurred = false;
 
     mInitialized = true;
-    FL_LOG_PARLIO("PARLIO_SPI: Initialization COMPLETE - clockHz=" << parlioClockHz);
+    FL_LOG_PARLIO_F("PARLIO_SPI: Initialization COMPLETE - clockHz=%s", parlioClockHz);
     return true;
 }
 
@@ -1830,10 +1816,10 @@ bool ParlioEngine::beginTransmission(const u8* scratchBuffer,
                                      size_t totalBytes,
                                      size_t numLanes,
                                      size_t laneStride) FL_NOEXCEPT {
-    FL_LOG_PARLIO("PARLIO_TX: beginTransmission() called - totalBytes=" << totalBytes << " numLanes=" << numLanes);
+    FL_LOG_PARLIO_F("PARLIO_TX: beginTransmission() called - totalBytes=%s numLanes=%s", totalBytes, numLanes);
 
     if (!mInitialized || !mPeripheral || !mIsrContext) {
-        FL_LOG_PARLIO("PARLIO_TX: FAILED - not initialized (mInit=" << mInitialized << " mPeripheral=" << (mPeripheral?1:0) << " mIsr=" << (mIsrContext?1:0) << ")");
+        FL_LOG_PARLIO_F("PARLIO_TX: FAILED - not initialized (mInit=%s mPeripheral=%s mIsr=%s)", mInitialized, (mPeripheral?1:0), (mIsrContext?1:0));
         return false;
     }
 
@@ -1847,13 +1833,13 @@ bool ParlioEngine::beginTransmission(const u8* scratchBuffer,
 
     // Check if already transmitting
     if (mIsrContext->mTransmitting.load(fl::memory_order_acquire)) {
-        FL_LOG_PARLIO("PARLIO_TX: FAILED - transmission already in progress");
-        FL_LOG_PARLIO("PARLIO: Transmission already in progress");
+        FL_LOG_PARLIO_F("PARLIO_TX: FAILED - transmission already in progress");
+        FL_LOG_PARLIO_F("PARLIO: Transmission already in progress");
         return false;
     }
 
     if (totalBytes == 0) {
-        FL_LOG_PARLIO("PARLIO_TX: Zero bytes - returning success");
+        FL_LOG_PARLIO_F("PARLIO_TX: Zero bytes - returning success");
         return true; // Nothing to transmit
     }
 
@@ -1874,7 +1860,7 @@ bool ParlioEngine::beginTransmission(const u8* scratchBuffer,
     // If laneStride is correct (= computed), this is a no-op
     // If laneStride is incorrect (= totalBytes), this fixes it
     if (laneStride > computed_lane_stride) {
-        FL_LOG_PARLIO("PARLIO: Correcting laneStride from " << laneStride << " to " << computed_lane_stride);
+        FL_LOG_PARLIO_F("PARLIO: Correcting laneStride from %s to %s", laneStride, computed_lane_stride);
         mLaneStride = computed_lane_stride;
     } else {
         mLaneStride = laneStride;
@@ -1919,25 +1905,21 @@ bool ParlioEngine::beginTransmission(const u8* scratchBuffer,
     mIsrContext->mDebugLastWorkerIsrTime = 0;
 
     // Pre-populate ring buffers (fill all buffers if possible)
-    FL_LOG_PARLIO("PARLIO_TX: Pre-populating ring buffers - mScratchBuffer=" << (void*)mScratchBuffer << " stride=" << mLaneStride);
+    FL_LOG_PARLIO_F("PARLIO_TX: Pre-populating ring buffers - mScratchBuffer=%s stride=%s", (void*)mScratchBuffer, mLaneStride);
     while (hasRingSpace() && populateNextDMABuffer()) {
         // Buffer populated into ring
     }
 
     // Get actual number of buffers populated
     size_t buffers_populated = mIsrContext->mRingCount;
-    FL_LOG_PARLIO("PARLIO_TX: Ring buffers populated - count=" << buffers_populated);
+    FL_LOG_PARLIO_F("PARLIO_TX: Ring buffers populated - count=%s", buffers_populated);
 
     // Debug: Log input_sizes array
-    FL_LOG_PARLIO("PARLIO: DEBUG input_sizes[0]=" << mRingBuffer->input_sizes[0]
-         << " [1]=" << mRingBuffer->input_sizes[1]
-         << " [2]=" << mRingBuffer->input_sizes[2]
-         << " buffers=" << buffers_populated
-         << " total=" << totalBytes);
+    FL_LOG_PARLIO_F("PARLIO: DEBUG input_sizes[0]=%s [1]=%s [2]=%s buffers=%s total=%s", mRingBuffer->input_sizes[0], mRingBuffer->input_sizes[1], mRingBuffer->input_sizes[2], buffers_populated, totalBytes);
 
     // Verify at least one buffer was populated
     if (buffers_populated == 0) {
-        FL_LOG_PARLIO("PARLIO: No buffers populated - cannot start transmission");
+        FL_LOG_PARLIO_F("PARLIO: No buffers populated - cannot start transmission");
         mErrorOccurred = true;
         return false;
     }
@@ -1948,26 +1930,25 @@ bool ParlioEngine::beginTransmission(const u8* scratchBuffer,
     // (DMA doesn't start, TX produces no output, RX captures 0 bytes).
     // Measured cost: ~25-30 µs (negligible).
     if (mTxUnitEnabled) {
-        FL_LOG_PARLIO("PARLIO_TX: Disabling peripheral for re-enable cycle");
+        FL_LOG_PARLIO_F("PARLIO_TX: Disabling peripheral for re-enable cycle");
         mPeripheral->disable();
         mTxUnitEnabled = false;
     }
 
-    FL_LOG_PARLIO("PARLIO_TX: Enabling peripheral");
+    FL_LOG_PARLIO_F("PARLIO_TX: Enabling peripheral");
     if (!mPeripheral->enable()) {
-        FL_LOG_PARLIO("PARLIO: Failed to enable peripheral");
+        FL_LOG_PARLIO_F("PARLIO: Failed to enable peripheral");
         mErrorOccurred = true;
         return false;
     }
     mTxUnitEnabled = true;
-    FL_LOG_PARLIO("PARLIO_TX: Peripheral enabled successfully");
+    FL_LOG_PARLIO_F("PARLIO_TX: Peripheral enabled successfully");
 
     // Queue first buffer to start transmission
-    FL_LOG_PARLIO("PARLIO: Starting ISR-based streaming | first_buffer_size="
-           << mRingBuffer->sizes[0] << " | buffers_ready=" << buffers_populated);
+    FL_LOG_PARLIO_F("PARLIO: Starting ISR-based streaming | first_buffer_size=%s | buffers_ready=%s", mRingBuffer->sizes[0], buffers_populated);
 
     size_t first_buffer_size = mRingBuffer->sizes[0];
-    FL_LOG_PARLIO("PARLIO_TX: Starting transmission - first_buffer=" << first_buffer_size << " bytes, buffers_ready=" << buffers_populated);
+    FL_LOG_PARLIO_F("PARLIO_TX: Starting transmission - first_buffer=%s bytes, buffers_ready=%s", first_buffer_size, buffers_populated);
 
     // CRITICAL FIX: Mark transmission started BEFORE submitting buffer
     // This closes the race window where txDoneCallback could fire before flag is set (Issue #2)
@@ -1981,14 +1962,14 @@ bool ParlioEngine::beginTransmission(const u8* scratchBuffer,
     FL_MEMORY_BARRIER;
 
     if (!mPeripheral->transmit(mRingBuffer->ptrs[0], first_buffer_size * 8, 0x0000)) {
-        FL_LOG_PARLIO("PARLIO: Failed to queue first buffer");
+        FL_LOG_PARLIO_F("PARLIO: Failed to queue first buffer");
         mIsrContext->mTransmitting.store(false, fl::memory_order_release);
         mIsrContext->mRingReadIdx = 0;  // Rollback index on error
         mIsrContext->mRingCount = buffers_populated;  // Rollback count on error
         mErrorOccurred = true;
         return false;
     }
-    FL_LOG_PARLIO("PARLIO_TX: First buffer submitted successfully - transmission started");
+    FL_LOG_PARLIO_F("PARLIO_TX: First buffer submitted successfully - transmission started");
 
     // #2548: Eager-queue additional pre-encoded buffers to the IDF TX queue,
     // so the hardware chains them via DMA descriptors instead of waiting for
@@ -2041,29 +2022,20 @@ bool ParlioEngine::beginTransmission(const u8* scratchBuffer,
     // - Simpler code path with lower latency
     //=========================================================================
 
-    FL_LOG_PARLIO("PARLIO: Worker function configured (one-shot mode, called from txDoneCallback)"
-           << " | buffers_ready=" << buffers_populated);
+    FL_LOG_PARLIO_F("PARLIO: Worker function configured (one-shot mode, called from txDoneCallback) | buffers_ready=%s", buffers_populated);
 
     // For test/mock environments, block and wait for completion
     // Real hardware uses async mode where caller polls via poll() method
     #ifdef FASTLED_STUB_IMPL
     // Block until transmission completes by polling
-    FL_LOG_PARLIO("PARLIO STUB: Entering polling loop - totalBytes=" << totalBytes
-                   << " streamComplete=" << mIsrContext->mStreamComplete.load(fl::memory_order_acquire));
+    FL_LOG_PARLIO_F("PARLIO STUB: Entering polling loop - totalBytes=%s streamComplete=%s", totalBytes, mIsrContext->mStreamComplete.load(fl::memory_order_acquire));
     size_t poll_iterations = 0;
     while (!mIsrContext->mStreamComplete.load(fl::memory_order_acquire) && !mErrorOccurred) {
         ParlioEngineState state = poll();
         poll_iterations++;
 
         if (poll_iterations % 100 == 0) {
-            FL_LOG_PARLIO("PARLIO STUB: Poll iteration " << poll_iterations
-                   << " - bytesTransmitted=" << mIsrContext->mBytesTransmitted
-                   << "/" << mIsrContext->mTotalBytes
-                   << " streamComplete=" << mIsrContext->mStreamComplete.load(fl::memory_order_acquire)
-                   << " transmitting=" << mIsrContext->mTransmitting.load(fl::memory_order_acquire)
-                   << " ringCount=" << mIsrContext->mRingCount
-                   << " txDone=" << mIsrContext->mDebugTxDoneCount
-                   << " worker=" << mIsrContext->mDebugWorkerIsrCount);
+            FL_LOG_PARLIO_F("PARLIO STUB: Poll iteration %s - bytesTransmitted=%s/%s streamComplete=%s transmitting=%s ringCount=%s txDone=%s worker=%s", poll_iterations, mIsrContext->mBytesTransmitted, mIsrContext->mTotalBytes, mIsrContext->mStreamComplete.load(fl::memory_order_acquire), mIsrContext->mTransmitting.load(fl::memory_order_acquire), mIsrContext->mRingCount, mIsrContext->mDebugTxDoneCount, mIsrContext->mDebugWorkerIsrCount);
         }
 
         if (state == ParlioEngineState::READY || state == ParlioEngineState::ERROR) {
@@ -2072,10 +2044,10 @@ bool ParlioEngine::beginTransmission(const u8* scratchBuffer,
         // Small delay to avoid busy-wait
         mPeripheral->delay(1);
     }
-    FL_LOG_PARLIO("PARLIO STUB: Exited polling loop after " << poll_iterations << " iterations");
+    FL_LOG_PARLIO_F("PARLIO STUB: Exited polling loop after %s iterations", poll_iterations);
 
     if (mErrorOccurred) {
-        FL_LOG_PARLIO("PARLIO: Error occurred during transmission");
+        FL_LOG_PARLIO_F("PARLIO: Error occurred during transmission");
         return false;
     }
     #endif
@@ -2093,17 +2065,13 @@ bool ParlioEngine::beginTransmission(const u8* scratchBuffer,
         config.priority = 1;       // Low priority (tskIDLE_PRIORITY + 1)
         mDebugTask = fl::task::coroutine(config);
 
-        FL_LOG_PARLIO("PARLIO: Debug task created (500ms logging interval)");
+        FL_LOG_PARLIO_F("PARLIO: Debug task created (500ms logging interval)");
     }
 #endif
 
     // Debug: Print initial counter state
     // Note: read_idx and ring_count already advanced before buffer submission (Iteration 2 fix)
-    FL_LOG_PARLIO("DEBUG: Transmission started (async)"
-           << " | read_idx=" << mIsrContext->mRingReadIdx
-           << " | ring_count=" << mIsrContext->mRingCount
-           << " | txDone_count=" << mIsrContext->mDebugTxDoneCount
-           << " | worker_count=" << mIsrContext->mDebugWorkerIsrCount);
+    FL_LOG_PARLIO_F("DEBUG: Transmission started (async) | read_idx=%s | ring_count=%s | txDone_count=%s | worker_count=%s", mIsrContext->mRingReadIdx, mIsrContext->mRingCount, mIsrContext->mDebugTxDoneCount, mIsrContext->mDebugWorkerIsrCount);
 
     // PHASE 1: ASYNC MODE - Return immediately without blocking
     // ISRs will handle buffer population and hardware submission in background
@@ -2120,7 +2088,7 @@ ParlioEngineState ParlioEngine::poll() FL_NOEXCEPT {
 
     // Check for errors
     if (mErrorOccurred) {
-        FL_LOG_PARLIO("PARLIO: Error occurred during transmission");
+        FL_LOG_PARLIO_F("PARLIO: Error occurred during transmission");
         mIsrContext->mTransmitting.store(false, fl::memory_order_release);
         mErrorOccurred = false;
         return ParlioEngineState::ERROR;
@@ -2137,7 +2105,7 @@ ParlioEngineState ParlioEngine::poll() FL_NOEXCEPT {
             // All transmissions complete - disable peripheral (only if currently enabled)
             if (mTxUnitEnabled) {
                 if (!mPeripheral->disable()) {
-                    FL_LOG_PARLIO("PARLIO: Failed to disable peripheral");
+                    FL_LOG_PARLIO_F("PARLIO: Failed to disable peripheral");
                 } else {
                     mTxUnitEnabled = false;
                 }

--- a/src/platforms/esp/32/drivers/parlio/parlio_peripheral_esp.cpp.hpp
+++ b/src/platforms/esp/32/drivers/parlio/parlio_peripheral_esp.cpp.hpp
@@ -118,14 +118,14 @@ ParlioPeripheralESPImpl::~ParlioPeripheralESPImpl() {
         // Wait for any pending transmissions (with timeout)
         esp_err_t err = parlio_tx_unit_wait_all_done(mTxUnit, pdMS_TO_TICKS(1000));
         if (err != ESP_OK) {
-            FL_LOG_PARLIO("ParlioPeripheralESP: Wait timeout during cleanup: " << err);
+            FL_LOG_PARLIO_F("ParlioPeripheralESP: Wait timeout during cleanup: %s", err);
         }
 
         // Disable TX unit if enabled
         if (mEnabled) {
             err = parlio_tx_unit_disable(mTxUnit);
             if (err != ESP_OK) {
-                FL_LOG_PARLIO("ParlioPeripheralESP: Failed to disable TX unit: " << err);
+                FL_LOG_PARLIO_F("ParlioPeripheralESP: Failed to disable TX unit: %s", err);
             }
             mEnabled = false;
         }
@@ -133,7 +133,7 @@ ParlioPeripheralESPImpl::~ParlioPeripheralESPImpl() {
         // Delete TX unit
         err = parlio_del_tx_unit(mTxUnit);
         if (err != ESP_OK) {
-            FL_LOG_PARLIO("ParlioPeripheralESP: Failed to delete TX unit: " << err);
+            FL_LOG_PARLIO_F("ParlioPeripheralESP: Failed to delete TX unit: %s", err);
         }
 
         mTxUnit = nullptr;
@@ -145,7 +145,7 @@ ParlioPeripheralESPImpl::~ParlioPeripheralESPImpl() {
 //=============================================================================
 
 bool ParlioPeripheralESPImpl::initialize(const ParlioPeripheralConfig& config) FL_NOEXCEPT {
-    FL_LOG_PARLIO("PARLIO_PERIPH: initialize() called - data_width=" << config.data_width << " clock=" << config.clock_freq_hz);
+    FL_LOG_PARLIO_F("PARLIO_PERIPH: initialize() called - data_width=%s clock=%s", config.data_width, config.clock_freq_hz);
 
     // ⚠️ ESP32-C6 KNOWN HARDWARE LIMITATION:
     // The ESP32-C6 PARLIO peripheral has an undocumented hardware timing issue causing
@@ -163,7 +163,7 @@ bool ParlioPeripheralESPImpl::initialize(const ParlioPeripheralConfig& config) F
     // partially succeeded (TX unit created) but a later step (e.g., ring buffer
     // allocation) failed and the caller is retrying.
     if (mTxUnit != nullptr) {
-        FL_LOG_PARLIO("ParlioPeripheralESP: Already initialized, deinitializing for re-init");
+        FL_LOG_PARLIO_F("ParlioPeripheralESP: Already initialized, deinitializing for re-init");
         deinitialize();
     }
 
@@ -182,11 +182,11 @@ bool ParlioPeripheralESPImpl::initialize(const ParlioPeripheralConfig& config) F
     esp_config.dma_burst_size = 64;  // Match ESP32-P4 cache line size (64 bytes)
 
     // Assign GPIO pins
-    FL_LOG_PARLIO("PARLIO_PERIPH: GPIO pins:");
+    FL_LOG_PARLIO_F("PARLIO_PERIPH: GPIO pins:");
     for (size_t i = 0; i < 16; i++) {
         esp_config.data_gpio_nums[i] = static_cast<gpio_num_t>(config.gpio_pins[i]);
         if (config.gpio_pins[i] >= 0) {
-            FL_LOG_PARLIO("  [" << i << "] = GPIO " << config.gpio_pins[i]);
+            FL_LOG_PARLIO_F("  [%s] = GPIO %s", i, config.gpio_pins[i]);
         }
     }
 
@@ -195,27 +195,20 @@ bool ParlioPeripheralESPImpl::initialize(const ParlioPeripheralConfig& config) F
     esp_config.valid_gpio_num = static_cast<gpio_num_t>(-1);
 
     // Log heap availability before allocation attempts (visible with FL_LOG_PARLIO_ENABLED)
-    FL_LOG_PARLIO("PARLIO_PERIPH: DMA heap - free: "
-           << heap_caps_get_free_size(MALLOC_CAP_DMA)
-           << ", largest block: " << heap_caps_get_largest_free_block(MALLOC_CAP_DMA));
-    FL_LOG_PARLIO("PARLIO_PERIPH: PSRAM heap - free: "
-           << heap_caps_get_free_size(MALLOC_CAP_SPIRAM)
-           << ", largest block: " << heap_caps_get_largest_free_block(MALLOC_CAP_SPIRAM));
+    FL_LOG_PARLIO_F("PARLIO_PERIPH: DMA heap - free: %s, largest block: %s", heap_caps_get_free_size(MALLOC_CAP_DMA), heap_caps_get_largest_free_block(MALLOC_CAP_DMA));
+    FL_LOG_PARLIO_F("PARLIO_PERIPH: PSRAM heap - free: %s, largest block: %s", heap_caps_get_free_size(MALLOC_CAP_SPIRAM), heap_caps_get_largest_free_block(MALLOC_CAP_SPIRAM));
 
     // Create TX unit (delegate to ESP-IDF)
-    FL_LOG_PARLIO("PARLIO_PERIPH: Calling parlio_new_tx_unit()");
+    FL_LOG_PARLIO_F("PARLIO_PERIPH: Calling parlio_new_tx_unit()");
     esp_err_t err = parlio_new_tx_unit(&esp_config, &mTxUnit);
     if (err != ESP_OK) {
-        FL_WARN("ParlioPeripheralESP: parlio_new_tx_unit() failed: "
-                << esp_err_to_name(err) << " (" << err << ")"
-                << " data_width=" << config.data_width);
+        FL_WARN_F("ParlioPeripheralESP: parlio_new_tx_unit() failed: %s (%s) data_width=%s", esp_err_to_name(err), err, config.data_width);
         mTxUnit = nullptr;
         return false;
     }
-    FL_LOG_PARLIO("PARLIO_PERIPH: parlio_new_tx_unit() SUCCESS - handle=" << (void*)mTxUnit);
+    FL_LOG_PARLIO_F("PARLIO_PERIPH: parlio_new_tx_unit() SUCCESS - handle=%s", (void*)mTxUnit);
 
-    FL_LOG_PARLIO("PARLIO: Initialized (data_width=" << config.data_width
-                  << ", clock=" << config.clock_freq_hz << " Hz)");
+    FL_LOG_PARLIO_F("PARLIO: Initialized (data_width=%s, clock=%s Hz)", config.data_width, config.clock_freq_hz);
 
     return true;
 }
@@ -229,8 +222,7 @@ bool ParlioPeripheralESPImpl::deinitialize() FL_NOEXCEPT {
     if (mEnabled) {
         esp_err_t err = parlio_tx_unit_disable(mTxUnit);
         if (err != ESP_OK) {
-            FL_WARN("ParlioPeripheralESP: Failed to disable TX unit during deinitialize: "
-                    << esp_err_to_name(err) << " (" << err << ")");
+            FL_WARN_F("ParlioPeripheralESP: Failed to disable TX unit during deinitialize: %s (%s)", esp_err_to_name(err), err);
         }
         mEnabled = false;
     }
@@ -238,8 +230,7 @@ bool ParlioPeripheralESPImpl::deinitialize() FL_NOEXCEPT {
     // Delete TX unit to free hardware resources
     esp_err_t err = parlio_del_tx_unit(mTxUnit);
     if (err != ESP_OK) {
-        FL_WARN("ParlioPeripheralESP: Failed to delete TX unit during deinitialize: "
-                << esp_err_to_name(err) << " (" << err << ")");
+        FL_WARN_F("ParlioPeripheralESP: Failed to delete TX unit during deinitialize: %s (%s)", esp_err_to_name(err), err);
         return false;
     }
 
@@ -248,37 +239,36 @@ bool ParlioPeripheralESPImpl::deinitialize() FL_NOEXCEPT {
 }
 
 bool ParlioPeripheralESPImpl::enable() FL_NOEXCEPT {
-    FL_LOG_PARLIO("PARLIO_PERIPH: enable() called");
+    FL_LOG_PARLIO_F("PARLIO_PERIPH: enable() called");
     if (mTxUnit == nullptr) {
-        FL_LOG_PARLIO("PARLIO_PERIPH: FAILED enable - not initialized");
-        FL_WARN("ParlioPeripheralESP: Cannot enable - not initialized");
+        FL_LOG_PARLIO_F("PARLIO_PERIPH: FAILED enable - not initialized");
+        FL_WARN_F("ParlioPeripheralESP: Cannot enable - not initialized");
         return false;
     }
 
     // Delegate to ESP-IDF
-    FL_LOG_PARLIO("PARLIO_PERIPH: Calling parlio_tx_unit_enable()");
+    FL_LOG_PARLIO_F("PARLIO_PERIPH: Calling parlio_tx_unit_enable()");
     esp_err_t err = parlio_tx_unit_enable(mTxUnit);
     if (err != ESP_OK) {
-        FL_WARN("ParlioPeripheralESP: Failed to enable TX unit: "
-                << esp_err_to_name(err) << " (" << err << ")");
+        FL_WARN_F("ParlioPeripheralESP: Failed to enable TX unit: %s (%s)", esp_err_to_name(err), err);
         return false;
     }
 
     mEnabled = true;
-    FL_LOG_PARLIO("PARLIO_PERIPH: enable() SUCCESS");
+    FL_LOG_PARLIO_F("PARLIO_PERIPH: enable() SUCCESS");
     return true;
 }
 
 bool ParlioPeripheralESPImpl::disable() FL_NOEXCEPT {
     if (mTxUnit == nullptr) {
-        FL_WARN("ParlioPeripheralESP: Cannot disable - not initialized");
+        FL_WARN_F("ParlioPeripheralESP: Cannot disable - not initialized");
         return false;
     }
 
     // Delegate to ESP-IDF
     esp_err_t err = parlio_tx_unit_disable(mTxUnit);
     if (err != ESP_OK) {
-        FL_LOG_PARLIO("ParlioPeripheralESP: Failed to disable TX unit: " << err);
+        FL_LOG_PARLIO_F("ParlioPeripheralESP: Failed to disable TX unit: %s", err);
         return false;
     }
 
@@ -333,7 +323,7 @@ bool FL_IRAM ParlioPeripheralESPImpl::transmit(const u8* buffer, size_t bit_coun
 
 bool ParlioPeripheralESPImpl::waitAllDone(u32 timeout_ms) FL_NOEXCEPT {
     if (mTxUnit == nullptr) {
-        FL_WARN("ParlioPeripheralESP: Cannot wait - not initialized");
+        FL_WARN_F("ParlioPeripheralESP: Cannot wait - not initialized");
         return false;
     }
 
@@ -357,10 +347,10 @@ bool ParlioPeripheralESPImpl::waitAllDone(u32 timeout_ms) FL_NOEXCEPT {
 //=============================================================================
 
 bool ParlioPeripheralESPImpl::registerTxDoneCallback(void* callback, void* user_ctx) FL_NOEXCEPT {
-    FL_LOG_PARLIO("PARLIO_PERIPH: registerTxDoneCallback() called");
+    FL_LOG_PARLIO_F("PARLIO_PERIPH: registerTxDoneCallback() called");
     if (mTxUnit == nullptr) {
-        FL_LOG_PARLIO("PARLIO_PERIPH: FAILED register callback - not initialized");
-        FL_WARN("ParlioPeripheralESP: Cannot register callback - not initialized");
+        FL_LOG_PARLIO_F("PARLIO_PERIPH: FAILED register callback - not initialized");
+        FL_WARN_F("ParlioPeripheralESP: Cannot register callback - not initialized");
         return false;
     }
 
@@ -369,15 +359,14 @@ bool ParlioPeripheralESPImpl::registerTxDoneCallback(void* callback, void* user_
     callbacks.on_trans_done = reinterpret_cast<parlio_tx_done_callback_t>(callback); // ok reinterpret cast
 
     // Delegate to ESP-IDF
-    FL_LOG_PARLIO("PARLIO_PERIPH: Calling parlio_tx_unit_register_event_callbacks()");
+    FL_LOG_PARLIO_F("PARLIO_PERIPH: Calling parlio_tx_unit_register_event_callbacks()");
     esp_err_t err = parlio_tx_unit_register_event_callbacks(mTxUnit, &callbacks, user_ctx);
     if (err != ESP_OK) {
-        FL_WARN("ParlioPeripheralESP: Failed to register callbacks: "
-                << esp_err_to_name(err) << " (" << err << ")");
+        FL_WARN_F("ParlioPeripheralESP: Failed to register callbacks: %s (%s)", esp_err_to_name(err), err);
         return false;
     }
 
-    FL_LOG_PARLIO("PARLIO_PERIPH: registerTxDoneCallback() SUCCESS");
+    FL_LOG_PARLIO_F("PARLIO_PERIPH: registerTxDoneCallback() SUCCESS");
     return true;
 }
 
@@ -412,13 +401,11 @@ u8* ParlioPeripheralESPImpl::allocateDmaBuffer(size_t size) FL_NOEXCEPT {
     }
 
     if (buffer == nullptr) {
-        FL_WARN("ParlioPeripheralESP: Failed to allocate DMA buffer (" << aligned_size << " bytes)");
+        FL_WARN_F("ParlioPeripheralESP: Failed to allocate DMA buffer (%s bytes)", aligned_size);
         // Detailed heap stats visible with FL_LOG_PARLIO_ENABLED
-        FL_LOG_PARLIO("  DMA heap: " << heap_caps_get_free_size(MALLOC_CAP_DMA)
-                << " free, " << heap_caps_get_largest_free_block(MALLOC_CAP_DMA) << " largest block");
+        FL_LOG_PARLIO_F("  DMA heap: %s free, %s largest block", heap_caps_get_free_size(MALLOC_CAP_DMA), heap_caps_get_largest_free_block(MALLOC_CAP_DMA));
         if (mPreferPsram) {
-            FL_LOG_PARLIO("  PSRAM heap: " << heap_caps_get_free_size(MALLOC_CAP_SPIRAM)
-                    << " free, " << heap_caps_get_largest_free_block(MALLOC_CAP_SPIRAM) << " largest block");
+            FL_LOG_PARLIO_F("  PSRAM heap: %s free, %s largest block", heap_caps_get_free_size(MALLOC_CAP_SPIRAM), heap_caps_get_largest_free_block(MALLOC_CAP_SPIRAM));
         }
     }
 

--- a/src/platforms/esp/32/drivers/parlio/parlio_peripheral_mock.cpp.hpp
+++ b/src/platforms/esp/32/drivers/parlio/parlio_peripheral_mock.cpp.hpp
@@ -199,7 +199,7 @@ ParlioPeripheralMockImpl::~ParlioPeripheralMockImpl() {
 
 bool ParlioPeripheralMockImpl::initialize(const ParlioPeripheralConfig& config) FL_NOEXCEPT {
     if (config.data_width == 0 || config.data_width > 16) {
-        FL_WARN("ParlioPeripheralMock: Invalid data width: " << config.data_width);
+        FL_WARN_F("ParlioPeripheralMock: Invalid data width: %s", config.data_width);
         return false;
     }
     mConfig = config;
@@ -221,7 +221,7 @@ bool ParlioPeripheralMockImpl::deinitialize() FL_NOEXCEPT {
 
 bool ParlioPeripheralMockImpl::enable() FL_NOEXCEPT {
     if (!mInitialized) {
-        FL_WARN("ParlioPeripheralMock: Cannot enable - not initialized");
+        FL_WARN_F("ParlioPeripheralMock: Cannot enable - not initialized");
         return false;
     }
     mEnabled = true;
@@ -230,7 +230,7 @@ bool ParlioPeripheralMockImpl::enable() FL_NOEXCEPT {
 
 bool ParlioPeripheralMockImpl::disable() FL_NOEXCEPT {
     if (!mInitialized) {
-        FL_WARN("ParlioPeripheralMock: Cannot disable - not initialized");
+        FL_WARN_F("ParlioPeripheralMock: Cannot disable - not initialized");
         return false;
     }
     mEnabled = false;
@@ -243,12 +243,12 @@ bool ParlioPeripheralMockImpl::disable() FL_NOEXCEPT {
 
 bool ParlioPeripheralMockImpl::transmit(const u8* buffer, size_t bit_count, u16 idle_value) FL_NOEXCEPT {
     if (!mInitialized) {
-        FL_WARN("ParlioPeripheralMock: Cannot transmit - not initialized");
+        FL_WARN_F("ParlioPeripheralMock: Cannot transmit - not initialized");
         return false;
     }
 
     if (!mEnabled) {
-        FL_WARN("ParlioPeripheralMock: Cannot transmit - not enabled");
+        FL_WARN_F("ParlioPeripheralMock: Cannot transmit - not enabled");
         return false;
     }
 
@@ -293,7 +293,7 @@ bool ParlioPeripheralMockImpl::transmit(const u8* buffer, size_t bit_count, u16 
 bool ParlioPeripheralMockImpl::waitAllDone(u32 timeout_ms) FL_NOEXCEPT {
     (void)timeout_ms;
     if (!mInitialized) {
-        FL_WARN("ParlioPeripheralMock: Cannot wait - not initialized");
+        FL_WARN_F("ParlioPeripheralMock: Cannot wait - not initialized");
         return false;
     }
     // GAP CLOSURE (#2992 follow-up):
@@ -333,7 +333,7 @@ void ParlioPeripheralMockImpl::settleEngineState() FL_NOEXCEPT {
 
 bool ParlioPeripheralMockImpl::registerTxDoneCallback(void* callback, void* user_ctx) FL_NOEXCEPT {
     if (!mInitialized) {
-        FL_WARN("ParlioPeripheralMock: Cannot register callback - not initialized");
+        FL_WARN_F("ParlioPeripheralMock: Cannot register callback - not initialized");
         return false;
     }
     mCallback = callback;
@@ -389,7 +389,7 @@ u8* ParlioPeripheralMockImpl::allocateDmaBuffer(size_t size) FL_NOEXCEPT {
 #endif
 
     if (buffer == nullptr) {
-        FL_WARN("ParlioPeripheralMock: Failed to allocate buffer (" << aligned_size << " bytes)");
+        FL_WARN_F("ParlioPeripheralMock: Failed to allocate buffer (%s bytes)", aligned_size);
     }
     return static_cast<u8*>(buffer);
 }
@@ -484,7 +484,7 @@ fl::span<const u8> ParlioPeripheralMockImpl::getTransmissionDataForPin(int gpio_
     }
     auto it = mPerPinData.find(gpio_pin);
     if (it == mPerPinData.end()) {
-        FL_WARN("ParlioPeripheralMock: GPIO pin " << gpio_pin << " not found in transmission data");
+        FL_WARN_F("ParlioPeripheralMock: GPIO pin %s not found in transmission data", gpio_pin);
         return fl::span<const u8>();
     }
     return fl::span<const u8>(it->second);

--- a/src/platforms/esp/32/drivers/rmt/rmt_4/channel_driver_rmt4.cpp.hpp
+++ b/src/platforms/esp/32/drivers/rmt/rmt_4/channel_driver_rmt4.cpp.hpp
@@ -41,7 +41,7 @@ ChannelEngineRMT4Impl::ChannelEngineRMT4Impl() FL_NOEXCEPT
     , mRmtSpinlock(portMUX_INITIALIZER_UNLOCKED)
     , mInitialized(false)
 {
-    FL_WARN("ChannelEngineRMT4: Initializing RMT4 driver for IDF 4.x");
+    FL_WARN_F("ChannelEngineRMT4: Initializing RMT4 driver for IDF 4.x");
 
     // Reserve space for channels (inlined vector, no heap allocation)
     mChannels.reserve(FASTLED_RMT_MAX_CHANNELS);
@@ -59,12 +59,12 @@ ChannelEngineRMT4Impl::ChannelEngineRMT4Impl() FL_NOEXCEPT
     );
 
     if (err != ESP_OK) {
-        FL_WARN("ChannelEngineRMT4: Failed to allocate RMT interrupt, error=" << err);
+        FL_WARN_F("ChannelEngineRMT4: Failed to allocate RMT interrupt, error=%s", err);
         return;
     }
 
     mInitialized = true;
-    FL_WARN("ChannelEngineRMT4: Initialized successfully");
+    FL_WARN_F("ChannelEngineRMT4: Initialized successfully");
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -72,7 +72,7 @@ ChannelEngineRMT4Impl::ChannelEngineRMT4Impl() FL_NOEXCEPT
 // ═══════════════════════════════════════════════════════════════════════════
 
 ChannelEngineRMT4Impl::~ChannelEngineRMT4Impl() {
-    FL_WARN("ChannelEngineRMT4: Shutting down");
+    FL_WARN_F("ChannelEngineRMT4: Shutting down");
 
     // Free the interrupt handler
     if (mRMT_intr_handle != nullptr) {
@@ -98,7 +98,7 @@ ChannelEngineRMT4Impl::~ChannelEngineRMT4Impl() {
     mPendingChannels.clear();
     mInitialized = false;
 
-    FL_WARN("ChannelEngineRMT4: Shutdown complete");
+    FL_WARN_F("ChannelEngineRMT4: Shutdown complete");
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -195,8 +195,7 @@ ChannelEngineRMT4Impl::ChannelState* ChannelEngineRMT4Impl::acquireChannel(
             state.lastFill = 0;
             state.transmissionStartTime = 0;
 
-            FL_WARN("acquireChannel: Reusing channel " << state.channel
-                   << " for pin " << static_cast<int>(pin));
+            FL_WARN_F("acquireChannel: Reusing channel %s for pin %s", state.channel, static_cast<int>(pin));
             return &state;
         }
     }
@@ -208,21 +207,19 @@ ChannelEngineRMT4Impl::ChannelState* ChannelEngineRMT4Impl::acquireChannel(
 
             // Reconfigure hardware for new pin/timing
             if (!configureChannel(&state, pin, timing)) {
-                FL_WARN("acquireChannel: Failed to reconfigure channel " << state.channel);
+                FL_WARN_F("acquireChannel: Failed to reconfigure channel %s", state.channel);
                 state.inUse = false;
                 return nullptr;
             }
 
-            FL_WARN("acquireChannel: Reconfigured channel " << state.channel
-                   << " for pin " << static_cast<int>(pin));
+            FL_WARN_F("acquireChannel: Reconfigured channel %s for pin %s", state.channel, static_cast<int>(pin));
             return &state;
         }
     }
 
     // Strategy 3: Create new channel if hardware available
     if (mChannels.size() >= FASTLED_RMT_MAX_CHANNELS) {
-        FL_WARN("acquireChannel: All " << FASTLED_RMT_MAX_CHANNELS
-               << " RMT channels in use, time-multiplexing required");
+        FL_WARN_F("acquireChannel: All %s RMT channels in use, time-multiplexing required", FASTLED_RMT_MAX_CHANNELS);
         return nullptr;
     }
 
@@ -244,7 +241,7 @@ ChannelEngineRMT4Impl::ChannelState* ChannelEngineRMT4Impl::acquireChannel(
 
     // Configure the hardware
     if (!configureChannel(&newState, pin, timing)) {
-        FL_WARN("acquireChannel: Failed to configure new channel " << newState.channel);
+        FL_WARN_F("acquireChannel: Failed to configure new channel %s", newState.channel);
         return nullptr;
     }
 
@@ -252,9 +249,7 @@ ChannelEngineRMT4Impl::ChannelState* ChannelEngineRMT4Impl::acquireChannel(
     mChannels.push_back(newState);
     ChannelState* stablePtr = &mChannels.back();
 
-    FL_WARN("acquireChannel: Created new channel " << stablePtr->channel
-           << " for pin " << static_cast<int>(pin)
-           << " (total: " << mChannels.size() << "/" << FASTLED_RMT_MAX_CHANNELS << ")");
+    FL_WARN_F("acquireChannel: Created new channel %s for pin %s (total: %s/%s)", stablePtr->channel, static_cast<int>(pin), mChannels.size(), FASTLED_RMT_MAX_CHANNELS);
 
     return stablePtr;
 }
@@ -264,12 +259,12 @@ void ChannelEngineRMT4Impl::releaseChannel(ChannelState* state) FL_NOEXCEPT {
     // NOTE: We do NOT destroy the RMT channel - keep it configured for fast reuse
 
     if (!state) {
-        FL_WARN("releaseChannel: null state pointer");
+        FL_WARN_F("releaseChannel: null state pointer");
         return;
     }
 
     if (!state->inUse) {
-        FL_WARN("releaseChannel: Channel " << state->channel << " already released");
+        FL_WARN_F("releaseChannel: Channel %s already released", state->channel);
         return;
     }
 
@@ -309,8 +304,7 @@ void ChannelEngineRMT4Impl::releaseChannel(ChannelState* state) FL_NOEXCEPT {
     // - state->memStart, state->memPtr (hardware memory pointers)
     // - RMT driver remains installed (fast reacquisition)
 
-    FL_WARN("releaseChannel: Released channel " << state->channel
-           << " on pin " << static_cast<int>(state->pin));
+    FL_WARN_F("releaseChannel: Released channel %s on pin %s", state->channel, static_cast<int>(state->pin));
 }
 
 bool ChannelEngineRMT4Impl::configureChannel(
@@ -322,7 +316,7 @@ bool ChannelEngineRMT4Impl::configureChannel(
     // Configures RMT hardware for the given pin and timing
 
     if (!state) {
-        FL_WARN("configureChannel: null state pointer");
+        FL_WARN_F("configureChannel: null state pointer");
         return false;
     }
 
@@ -361,21 +355,21 @@ bool ChannelEngineRMT4Impl::configureChannel(
     // Apply the configuration
     err = rmt_config(&rmt_tx);
     if (err != ESP_OK) {
-        FL_WARN("configureChannel: rmt_config failed, error=" << err);
+        FL_WARN_F("configureChannel: rmt_config failed, error=%s", err);
         return false;
     }
 
     // Install RMT driver (no internal buffer - we use custom ISR)
     err = rmt_driver_install(state->channel, 0, 0);
     if (err != ESP_OK) {
-        FL_WARN("configureChannel: rmt_driver_install failed, error=" << err);
+        FL_WARN_F("configureChannel: rmt_driver_install failed, error=%s", err);
         return false;
     }
 
     // Set up threshold interrupt for double-buffer refill
     err = rmt_set_tx_thr_intr_en(state->channel, true, PULSES_PER_FILL_RMT4);
     if (err != ESP_OK) {
-        FL_WARN("configureChannel: rmt_set_tx_thr_intr_en failed, error=" << err);
+        FL_WARN_F("configureChannel: rmt_set_tx_thr_intr_en failed, error=%s", err);
         rmt_driver_uninstall(state->channel);
         return false;
     }
@@ -391,13 +385,12 @@ bool ChannelEngineRMT4Impl::configureChannel(
     err = rmt_set_pin(state->channel, RMT_MODE_TX, pin);
 #endif
     if (err != ESP_OK) {
-        FL_WARN("configureChannel: rmt_set_gpio/rmt_set_pin failed, error=" << err);
+        FL_WARN_F("configureChannel: rmt_set_gpio/rmt_set_pin failed, error=%s", err);
         rmt_driver_uninstall(state->channel);
         return false;
     }
 
-    FL_WARN("configureChannel: Configured channel " << state->channel
-           << " on pin " << static_cast<int>(pin));
+    FL_WARN_F("configureChannel: Configured channel %s on pin %s", state->channel, static_cast<int>(pin));
 
     return true;
 }
@@ -420,9 +413,7 @@ void ChannelEngineRMT4Impl::processPendingChannels() FL_NOEXCEPT {
 
         if (state == nullptr) {
             // All channels busy - time-multiplexing will resume later in poll()
-            FL_WARN("processPendingChannels: All " << FASTLED_RMT_MAX_CHANNELS
-                   << " channels busy, deferring " << (mPendingChannels.size() - i)
-                   << " pending strips");
+            FL_WARN_F("processPendingChannels: All %s channels busy, deferring %s pending strips", FASTLED_RMT_MAX_CHANNELS, (mPendingChannels.size() - i));
             break;
         }
 
@@ -448,7 +439,7 @@ void ChannelEngineRMT4Impl::startTransmission(ChannelState* state, const Channel
     // 5. Kick off transmission via tx_start()
 
     if (!state) {
-        FL_WARN("startTransmission: null state pointer");
+        FL_WARN_F("startTransmission: null state pointer");
         return;
     }
 
@@ -464,11 +455,7 @@ void ChannelEngineRMT4Impl::startTransmission(ChannelState* state, const Channel
     state->pixelDataSize = dataBuffer.size();
 
     // DEBUG: Log pixel data details
-    FL_DBG("RMT4: startTransmission() called with " << state->pixelDataSize
-           << " bytes, first 3 bytes: "
-           << (state->pixelDataSize > 0 ? static_cast<int>(state->pixelData[0]) : -1) << " "
-           << (state->pixelDataSize > 1 ? static_cast<int>(state->pixelData[1]) : -1) << " "
-           << (state->pixelDataSize > 2 ? static_cast<int>(state->pixelData[2]) : -1));
+    FL_DBG_F("RMT4: startTransmission() called with %s bytes, first 3 bytes: %s %s %s", state->pixelDataSize, (state->pixelDataSize > 0 ? static_cast<int>(state->pixelData[0]) : -1), (state->pixelDataSize > 1 ? static_cast<int>(state->pixelData[1]) : -1), (state->pixelDataSize > 2 ? static_cast<int>(state->pixelData[2]) : -1));
 
     // Reset transmission state
     state->pixelDataPos = 0;
@@ -486,7 +473,7 @@ void ChannelEngineRMT4Impl::startTransmission(ChannelState* state, const Channel
     // Enable TX interrupts for this channel
     esp_err_t err = rmt_set_tx_intr_en(state->channel, true);
     if (err != ESP_OK) {
-        FL_WARN("startTransmission: rmt_set_tx_intr_en failed, error=" << err);
+        FL_WARN_F("startTransmission: rmt_set_tx_intr_en failed, error=%s", err);
         // Mark complete to trigger cleanup in poll()
         state->transmissionComplete = true;
         data->setInUse(false);
@@ -498,9 +485,7 @@ void ChannelEngineRMT4Impl::startTransmission(ChannelState* state, const Channel
     tx_start(state);
     portEXIT_CRITICAL(&mRmtSpinlock);
 
-    FL_DBG("RMT4: Transmission started on channel " << state->channel
-           << ", pin " << static_cast<int>(state->pin)
-           << ", " << state->pixelDataSize << " bytes");
+    FL_DBG_F("RMT4: Transmission started on channel %s, pin %s, %s bytes", state->channel, static_cast<int>(state->pin), state->pixelDataSize);
 }
 
 // Note: findChannelByNumber() and tx_start() are now inlined in the header
@@ -515,7 +500,7 @@ void ChannelEngineRMT4Impl::enqueue(ChannelDataPtr channelData) FL_NOEXCEPT {
     if (channelData) {
         mEnqueuedChannels.push_back(channelData);
     } else {
-        FL_WARN("enqueue: Received null ChannelData");
+        FL_WARN_F("enqueue: Received null ChannelData");
     }
 }
 
@@ -523,7 +508,7 @@ void ChannelEngineRMT4Impl::show() FL_NOEXCEPT {
     // Trigger transmission of all enqueued data
     // Called by ChannelManager when user calls FastLED.show()
 
-    FL_WARN("show: Transmitting " << mEnqueuedChannels.size() << " enqueued channels");
+    FL_WARN_F("show: Transmitting %s enqueued channels", mEnqueuedChannels.size());
 
     if (!mEnqueuedChannels.empty()) {
         // Pass batched data to internal transmission handler
@@ -556,7 +541,7 @@ IChannelDriver::DriverState ChannelEngineRMT4Impl::poll() FL_NOEXCEPT {
 
         if (state.transmissionComplete) {
             // Transmission complete - release channel and mark data available
-            FL_WARN("poll: Channel " << state.channel << " completed");
+            FL_WARN_F("poll: Channel %s completed", state.channel);
 
             // Clear in-use flag on source data
             if (state.sourceData) {
@@ -571,8 +556,7 @@ IChannelDriver::DriverState ChannelEngineRMT4Impl::poll() FL_NOEXCEPT {
             u32 elapsed = fl::millis() - state.transmissionStartTime;
             if (elapsed > FASTLED_RMT4_TRANSMISSION_TIMEOUT_MS) {
                 // Timeout detected - force channel reset
-                FL_WARN("poll: Channel " << state.channel << " timed out after "
-                       << elapsed << "ms (limit: " << FASTLED_RMT4_TRANSMISSION_TIMEOUT_MS << "ms)");
+                FL_WARN_F("poll: Channel %s timed out after %sms (limit: %sms)", state.channel, elapsed, FASTLED_RMT4_TRANSMISSION_TIMEOUT_MS);
 
                 // Disable interrupts for this channel
                 rmt_set_tx_intr_en(state.channel, false);
@@ -626,7 +610,7 @@ void ChannelEngineRMT4Impl::beginTransmission(fl::span<const ChannelDataPtr> cha
     // 4. Start as many transmissions as hardware allows
     // 5. Release flash lock after transmission starts
 
-    FL_WARN("beginTransmission: Queueing " << channelData.size() << " channels");
+    FL_WARN_F("beginTransmission: Queueing %s channels", channelData.size());
 
 #if FASTLED_ESP32_FLASH_LOCK == 1
     // Block flash operations during LED transmission to prevent timing glitches
@@ -635,11 +619,11 @@ void ChannelEngineRMT4Impl::beginTransmission(fl::span<const ChannelDataPtr> cha
     // IDF 4.x+ uses esp_flash_app_disable_protect()
     // Note: This API may not be available on all IDF versions
     // For now, we'll skip the flash lock and document the limitation
-    FL_DBG("RMT4: Flash lock not yet implemented for IDF 4.x+");
+    FL_DBG_F("RMT4: Flash lock not yet implemented for IDF 4.x+");
     #else
     // IDF 3.x uses spi_flash_op_lock()
     spi_flash_op_lock();
-    FL_DBG("RMT4: Flash operations locked");
+    FL_DBG_F("RMT4: Flash operations locked");
     #endif
 #endif
 
@@ -651,7 +635,7 @@ void ChannelEngineRMT4Impl::beginTransmission(fl::span<const ChannelDataPtr> cha
         if (data) {
             mPendingChannels.push_back(data);
         } else {
-            FL_WARN("beginTransmission: Null ChannelData in span");
+            FL_WARN_F("beginTransmission: Null ChannelData in span");
         }
     }
 
@@ -662,7 +646,7 @@ void ChannelEngineRMT4Impl::beginTransmission(fl::span<const ChannelDataPtr> cha
     #if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(4, 0, 0)
     // Release flash lock after transmission starts
     spi_flash_op_unlock();
-    FL_DBG("RMT4: Flash operations unlocked");
+    FL_DBG_F("RMT4: Flash operations unlocked");
     #endif
 #endif
 }

--- a/src/platforms/esp/32/drivers/rmt/rmt_4/idf4_clockless_rmt_esp32.h
+++ b/src/platforms/esp/32/drivers/rmt/rmt_4/idf4_clockless_rmt_esp32.h
@@ -80,7 +80,7 @@ protected:
     virtual void showPixels(PixelController<RGB_ORDER> &pixels) FL_NOEXCEPT override
     {
         if (!mDriver) {
-            FL_WARN_EVERY(100, "No Engine");
+            FL_WARN_F_EVERY(100, "No Engine");
             return;
         }
         // Wait for previous transmission to complete and release buffer
@@ -88,10 +88,10 @@ protected:
         u32 startTime = fl::millis();
         u32 lastWarnTime = startTime;
         if (mChannelData->isInUse()) {
-            FL_WARN_EVERY(100, "ClocklessIdf4: driver should have finished transmitting by now - waiting");
+            FL_WARN_F_EVERY(100, "ClocklessIdf4: driver should have finished transmitting by now - waiting");
             bool finished = mDriver->waitForReady();
             if (!finished) {
-                FL_ERROR("ClocklessIdf4: Engine still busy after " << fl::millis() - startTime << "ms");
+                FL_ERROR_F("ClocklessIdf4: Engine still busy after %sms", fl::millis() - startTime);
                 return;
             }
 

--- a/src/platforms/esp/32/drivers/rmt/rmt_5/buffer_pool.cpp.hpp
+++ b/src/platforms/esp/32/drivers/rmt/rmt_5/buffer_pool.cpp.hpp
@@ -62,13 +62,12 @@ int RMTBufferPool::allocateOrResizeSlot(fl::size size) FL_NOEXCEPT {
             // Resize this buffer
             u8* newData = static_cast<u8*>(fl::InternalRealloc(slot.data, size));
             if (!newData) {
-                FL_WARN("RMTBufferPool: Failed to realloc internal buffer from "
-                        << slot.capacity << " to " << size << " bytes");
+                FL_WARN_F("RMTBufferPool: Failed to realloc internal buffer from %s to %s bytes", slot.capacity, size);
                 return -1;
             }
             slot.data = newData;
             slot.capacity = size;
-            FL_LOG_RMT("RMTBufferPool: Resized buffer " << i << " to " << size << " bytes");
+            FL_LOG_RMT_F("RMTBufferPool: Resized buffer %s to %s bytes", i, size);
             return static_cast<int>(i);
         }
     }
@@ -77,15 +76,14 @@ int RMTBufferPool::allocateOrResizeSlot(fl::size size) FL_NOEXCEPT {
     BufferSlot newSlot;
     newSlot.data = static_cast<u8*>(fl::InternalAlloc(size));
     if (!newSlot.data) {
-        FL_WARN("RMTBufferPool: Failed to allocate new internal buffer of " << size << " bytes");
+        FL_WARN_F("RMTBufferPool: Failed to allocate new internal buffer of %s bytes", size);
         return -1;
     }
     newSlot.capacity = size;
     newSlot.inUse = false;
 
     mInternalBuffers.push_back(newSlot);
-    FL_LOG_RMT("RMTBufferPool: Allocated new buffer " << (mInternalBuffers.size() - 1)
-           << " with " << size << " bytes");
+    FL_LOG_RMT_F("RMTBufferPool: Allocated new buffer %s with %s bytes", (mInternalBuffers.size() - 1), size);
     return static_cast<int>(mInternalBuffers.size() - 1);
 }
 
@@ -117,7 +115,7 @@ fl::span<u8> RMTBufferPool::acquireDMA(fl::size size) FL_NOEXCEPT {
     }
 
     if (mDMABuffer.inUse) {
-        FL_WARN("RMTBufferPool: DMA buffer already in use (hardware limit: 1 DMA channel)");
+        FL_WARN_F("RMTBufferPool: DMA buffer already in use (hardware limit: 1 DMA channel)");
         return fl::span<u8>();
     }
 
@@ -132,11 +130,11 @@ fl::span<u8> RMTBufferPool::acquireDMA(fl::size size) FL_NOEXCEPT {
 
         mDMABuffer.data = static_cast<u8*>(fl::DMAAlloc(size));
         if (!mDMABuffer.data) {
-            FL_WARN("RMTBufferPool: Failed to allocate DMA buffer of " << size << " bytes");
+            FL_WARN_F("RMTBufferPool: Failed to allocate DMA buffer of %s bytes", size);
             return fl::span<u8>();
         }
         mDMABuffer.capacity = size;
-        FL_LOG_RMT("RMTBufferPool: Allocated DMA buffer with " << size << " bytes");
+        FL_LOG_RMT_F("RMTBufferPool: Allocated DMA buffer with %s bytes", size);
     }
 
     mDMABuffer.inUse = true;
@@ -153,19 +151,19 @@ void RMTBufferPool::releaseInternal(fl::span<u8> buffer) FL_NOEXCEPT {
     for (auto& slot : mInternalBuffers) {
         if (slot.data == bufferPtr) {
             if (!slot.inUse) {
-                FL_WARN("RMTBufferPool: Releasing buffer that was not marked as in-use");
+                FL_WARN_F("RMTBufferPool: Releasing buffer that was not marked as in-use");
             }
             slot.inUse = false;
             return;
         }
     }
 
-    FL_WARN("RMTBufferPool: Attempted to release unknown buffer " << static_cast<void*>(bufferPtr));
+    FL_WARN_F("RMTBufferPool: Attempted to release unknown buffer %s", static_cast<void*>(bufferPtr));
 }
 
 void RMTBufferPool::releaseDMA() FL_NOEXCEPT {
     if (!mDMABuffer.inUse) {
-        FL_WARN("RMTBufferPool: Releasing DMA buffer that was not in use");
+        FL_WARN_F("RMTBufferPool: Releasing DMA buffer that was not in use");
     }
     mDMABuffer.inUse = false;
 }

--- a/src/platforms/esp/32/drivers/rmt/rmt_5/channel_driver_rmt.cpp.hpp
+++ b/src/platforms/esp/32/drivers/rmt/rmt_5/channel_driver_rmt.cpp.hpp
@@ -1,4 +1,4 @@
-// IWYU pragma: private
+﻿// IWYU pragma: private
 
 /// @file channel_driver_rmt.cpp
 /// @brief RMT5 ChannelEngine implementation
@@ -137,12 +137,12 @@ class ChannelEngineRMTImpl : public ChannelEngineRMT {
         // Configure platform-specific logging (RMT and cache log levels)
         mPeripheral.configureLogging();
 
-        FL_LOG_RMT("RMT Channel Engine initialized");
+        FL_LOG_RMT_F("RMT Channel Engine initialized");
     }
 
     ~ChannelEngineRMTImpl() override {
         // The destructor body (drain-wait + per-channel cleanup loop +
-        // FL_WARN timeout diagnostic + FL_LOG_RMT trailer) is a cold path —
+        // FL_WARN timeout diagnostic + FL_LOG_RMT trailer) is a cold path â€”
         // only reached at process end. Move it into an FL_NO_INLINE helper
         // so its operator<< instantiations + cleanup loop body don't
         // contribute to icache footprint. #2856 item 3.1.
@@ -196,7 +196,7 @@ class ChannelEngineRMTImpl : public ChannelEngineRMT {
         }
         mChannels.clear();
 
-        FL_LOG_RMT("RMT Channel Engine destroyed");
+        FL_LOG_RMT_F("RMT Channel Engine destroyed");
     }
 
     // IChannelDriver interface implementation
@@ -241,7 +241,9 @@ class ChannelEngineRMTImpl : public ChannelEngineRMT {
         // Check hardware status
         bool anyActive = false;
         int activeCount = 0;
+#ifdef FASTLED_LOG_RMT_ENABLED
         int completedCount = 0;
+#endif
 
         // Check each channel for completion
         for (auto &ch : mChannels) {
@@ -253,20 +255,21 @@ class ChannelEngineRMTImpl : public ChannelEngineRMT {
             anyActive = true;
 
             if (ch.transmissionComplete.load(fl::memory_order_acquire)) {
+#ifdef FASTLED_LOG_RMT_ENABLED
                 completedCount++;
-                FL_LOG_RMT("Channel on pin " << ch.pin
-                                             << " completed transmission");
+#endif
+                FL_LOG_RMT_F("Channel on pin %s completed transmission", ch.pin);
 
                 // Disable channel to release HW resources
                 if (ch.channel) {
                     bool disable_success = mPeripheral.disableChannel(ch.channel);
                     if (!disable_success) {
-                        FL_LOG_RMT("Failed to disable channel");
+                        FL_LOG_RMT_F("Failed to disable channel");
                     }
                 }
 
                 // Release channel back to pool
-                FL_LOG_RMT("Releasing channel " << ch.pin);
+                FL_LOG_RMT_F("Releasing channel %s", ch.pin);
                 releaseChannel(&ch);
 
                 // Decrement activeCount since we just released this channel
@@ -275,22 +278,17 @@ class ChannelEngineRMTImpl : public ChannelEngineRMT {
                 // Try to start pending channels
                 processPendingChannels();
             } else {
-                FL_LOG_RMT(
-                    "Channel on pin "
-                    << ch.pin
-                    << " still transmitting (inUse=true, complete=false)");
+                FL_LOG_RMT_F("Channel on pin %s still transmitting (inUse=true, complete=false)", ch.pin);
             }
         }
 
         // Check if any pending channels remain
         if (!mPendingChannels.empty()) {
             anyActive = true;
-            FL_LOG_RMT("Pending channels: " << mPendingChannels.size());
+            FL_LOG_RMT_F("Pending channels: %s", mPendingChannels.size());
         } else if (activeCount > 0) {
             anyActive = true;
-            FL_LOG_RMT("No pending channels, but "
-                       << activeCount << " active channels (" << completedCount
-                       << " completed)");
+            FL_LOG_RMT_F("No pending channels, but %s active channels (%s completed)", activeCount, completedCount);
         } else {
             // No active channels and no pending channels
             anyActive = false;
@@ -396,10 +394,10 @@ class ChannelEngineRMTImpl : public ChannelEngineRMT {
     /// @param channelData Span of channel data to transmit
     void beginTransmission(fl::span<const ChannelDataPtr> channelData) FL_NOEXCEPT {
         if (channelData.size() == 0) {
-            FL_LOG_RMT("beginTransmission: No channels to transmit");
+            FL_LOG_RMT_F("beginTransmission: No channels to transmit");
             return;
         }
-        FL_LOG_RMT("ChannelEngineRMT::beginTransmission() is running");
+        FL_LOG_RMT_F("ChannelEngineRMT::beginTransmission() is running");
 
         // Network-aware channel reconfiguration (once per frame)
         #if FASTLED_RMT_NETWORK_REDUCE_CHANNELS
@@ -408,14 +406,14 @@ class ChannelEngineRMTImpl : public ChannelEngineRMT {
 
         // Reset allocation failure flag at start of each frame to allow retry
         if (mAllocationFailed) {
-            FL_LOG_RMT("Resetting allocation failure flag (retry at start of frame)");
+            FL_LOG_RMT_F("Resetting allocation failure flag (retry at start of frame)");
             mAllocationFailed = false;
         }
 
         // Sort: smallest strips first (helps async parallelism).
         // Container is bounded at 16 by construction (fl::vector_inlined<T, 16>),
         // so use sort_small to avoid instantiating quicksort_impl in the
-        // ClocklessIdf5 transitive closure — see #2907.
+        // ClocklessIdf5 transitive closure â€” see #2907.
         fl::vector_inlined<ChannelDataPtr, 16> sorted;
         for (const auto& data : channelData) {
             sorted.push_back(data);
@@ -463,10 +461,10 @@ class ChannelEngineRMTImpl : public ChannelEngineRMT {
         size_t original_symbols, size_t reduced_symbols,
         size_t external_words) FL_NOEXCEPT {
         // Gate the entire body on FASTLED_LOG_RUNTIME_ENABLED. In release
-        // builds (NDEBUG → FASTLED_LOG_VERBOSITY=0 per Stage 1) the
+        // builds (NDEBUG â†’ FASTLED_LOG_VERBOSITY=0 per Stage 1) the
         // FL_WARN(msg.str()) call at the bottom is a no-op, but the
         // `fl::sstream msg;` construction and 15 `operator<<` chain calls
-        // above happen unconditionally — they have observable side effects
+        // above happen unconditionally â€” they have observable side effects
         // on msg's internal buffer that the optimizer can't prove away.
         // Gating collapses the FL_NO_INLINE helper to an effectively-empty
         // function in release (~5 B vs ~410 B). See #2917 / #2886.
@@ -489,7 +487,7 @@ class ChannelEngineRMTImpl : public ChannelEngineRMT {
             << "FastLED will continue with reduced buffer size.\n"
             << "Performance may be degraded during WiFi/network activity.\n"
             << "========================================";
-        FL_WARN(msg.str());
+        FL_WARN_F("%s", msg.str());
 #else
         (void)original_symbols;
         (void)reduced_symbols;
@@ -501,7 +499,7 @@ class ChannelEngineRMTImpl : public ChannelEngineRMT {
     /// Extracted from createChannel so the hot path (initial allocation
     /// succeeds, which is the common case at boot) stays small. The retry
     /// loop pulls FL_LOG_RMT/FL_WARN `fl::sstream` operator<< instantiations
-    /// and a per-iteration Rmt5ChannelConfig constructor — all of which the
+    /// and a per-iteration Rmt5ChannelConfig constructor â€” all of which the
     /// linker would otherwise have to keep live inside the hot function body.
     /// Returns true on successful recovery (caller continues to encoder
     /// creation), false otherwise (caller returns false). Mutates
@@ -511,9 +509,8 @@ class ChannelEngineRMTImpl : public ChannelEngineRMT {
         fl::size &mem_block_symbols) FL_NOEXCEPT {
         auto &memMgr = RmtMemoryManager::instance();
 
-        FL_WARN("RMT channel allocation failed (initial request: "
-                << mem_block_symbols << " symbols)");
-        FL_WARN("Attempting progressive memory reduction recovery...");
+        FL_WARN_F("RMT channel allocation failed (initial request: %s symbols)", mem_block_symbols);
+        FL_WARN_F("Attempting progressive memory reduction recovery...");
 
         mConsecutiveAllocationFailures++;
         size_t original_symbols = mem_block_symbols;
@@ -537,8 +534,7 @@ class ChannelEngineRMTImpl : public ChannelEngineRMT {
             Rmt5ChannelConfig retry_config(pin, FASTLED_RMT5_CLOCK_HZ,
                                             reduced_symbols, 1, false, intr_priority);
 
-            FL_LOG_RMT("Retry #" << retry_count << ": Attempting " << reduced_symbols
-                       << " symbols (reduced by " << (original_symbols - reduced_symbols) << ")");
+            FL_LOG_RMT_F("Retry #%s: Attempting %s symbols (reduced by %s)", retry_count, reduced_symbols, (original_symbols - reduced_symbols));
 
             success = mPeripheral.createTxChannel(retry_config, (void**)&state->channel);
             if (success) {
@@ -553,9 +549,7 @@ class ChannelEngineRMTImpl : public ChannelEngineRMT {
                 }
 
                 memMgr.recordRecoveryAllocation(state->memoryChannelId, reduced_symbols, true);
-                FL_LOG_RMT("Recovery: Re-added allocation to ledger: "
-                           << reduced_symbols << " words for channel "
-                           << static_cast<int>(state->memoryChannelId));
+                FL_LOG_RMT_F("Recovery: Re-added allocation to ledger: %s words for channel %s", reduced_symbols, static_cast<int>(state->memoryChannelId));
 
                 mem_block_symbols = reduced_symbols;
                 recovery_succeeded = true;
@@ -578,7 +572,7 @@ class ChannelEngineRMTImpl : public ChannelEngineRMT {
     FL_NO_INLINE void emitAllocationFailureError(
         size_t retry_count, size_t original_symbols, size_t min_symbols,
         int pin) FL_NOEXCEPT {
-        // Same gating rationale as emitRecoveryWarning above — see #2917.
+        // Same gating rationale as emitRecoveryWarning above â€” see #2917.
 #if FASTLED_LOG_RUNTIME_ENABLED
         fl::sstream msg;
         msg << "\n========================================\n"
@@ -596,7 +590,7 @@ class ChannelEngineRMTImpl : public ChannelEngineRMT {
             << "\n"
             << "LEDs on pin " << pin << " will NOT work!\n"
             << "========================================";
-        FL_ERROR(msg.str());
+        FL_ERROR_F("%s", msg.str());
 #else
         (void)retry_count;
         (void)original_symbols;
@@ -614,7 +608,7 @@ class ChannelEngineRMTImpl : public ChannelEngineRMT {
         // RMT5 MEMORY MANAGEMENT - Now using centralized RmtMemoryManager
         // ============================================================================
         // Memory allocation policy:
-        // - TX channels: Always double-buffer (2×
+        // - TX channels: Always double-buffer (2Ã—
         // SOC_RMT_MEM_WORDS_PER_CHANNEL)
         // - DMA channels: Bypass on-chip memory (allocated from DRAM instead)
         // - RX channels: User-specified size (managed separately in
@@ -647,7 +641,7 @@ class ChannelEngineRMTImpl : public ChannelEngineRMT {
         // Get current Network state for memory allocation.
         // Under FASTLED_RMT_STATIC_ALLOCATION the user has asserted no
         // network during LED transmission, so this resolves to a compile-
-        // time constant — the linker then drops the entire NetworkDetector
+        // time constant â€” the linker then drops the entire NetworkDetector
         // singleton + WiFi-state-reading chain from the binary. See #2856
         // item 3.3.
 #if FASTLED_RMT_STATIC_ALLOCATION
@@ -681,21 +675,15 @@ class ChannelEngineRMTImpl : public ChannelEngineRMT {
         // This prevents the observed issue where TX transmissions never complete
         // when both TX (DMA) and RX are using the RMT peripheral simultaneously.
         if (tryDMA && memMgr.hasActiveRxChannels()) {
-            FL_WARN("TX Channel: RX channel detected - disabling DMA to avoid TX/RX conflict");
+            FL_WARN_F("TX Channel: RX channel detected - disabling DMA to avoid TX/RX conflict");
             tryDMA = false;
         }
         if (tryDMA) {
             // DMA slot available - first channel across TX/RX
-            FL_LOG_RMT("TX Channel #" << (mChannels.size() + 1)
-                                      << ": DMA slot available for pin "
-                                      << static_cast<int>(pin)
-                                      << " (data size: " << dataSize
-                                      << " bytes)");
+            FL_LOG_RMT_F("TX Channel #%s: DMA slot available for pin %s (data size: %s bytes)", (mChannels.size() + 1), static_cast<int>(pin), dataSize);
         } else {
             // DMA not available (platform doesn't support it, or slot is taken)
-            FL_LOG_RMT("TX Channel #" << (mChannels.size() + 1)
-                       << ": DMA not available, using non-DMA for pin "
-                       << static_cast<int>(pin));
+            FL_LOG_RMT_F("TX Channel #%s: DMA not available, using non-DMA for pin %s", (mChannels.size() + 1), static_cast<int>(pin));
         }
 
         // STEP 1: Try DMA channel creation (first channel only on ESP32-S3)
@@ -705,8 +693,7 @@ class ChannelEngineRMTImpl : public ChannelEngineRMT {
             size_t dma_alloc_words = 0;
             if (!memMgr.tryAllocateTx(state->memoryChannelId, true,
                                        networkActive, dma_alloc_words)) {
-                FL_WARN("Memory manager TX allocation failed for DMA channel "
-                        << static_cast<int>(state->memoryChannelId));
+                FL_WARN_F("Memory manager TX allocation failed for DMA channel %s", static_cast<int>(state->memoryChannelId));
                 return false;
             }
 
@@ -723,9 +710,7 @@ class ChannelEngineRMTImpl : public ChannelEngineRMT {
             // - https://github.com/espressif/esp-idf/issues/12564
             // - https://github.com/espressif/idf-extra-components/issues/466
             fl::size dma_mem_block_symbols = 1024;  // ESP-IDF recommended DMA buffer size
-            FL_LOG_RMT("DMA allocation: "
-                       << dma_mem_block_symbols << " symbols (DMA chunk size) for " << dataSize
-                       << " bytes (" << (dataSize / 3) << " LEDs)");
+            FL_LOG_RMT_F("DMA allocation: %s symbols (DMA chunk size) for %s bytes (%s LEDs)", dma_mem_block_symbols, dataSize, (dataSize / 3));
 
             // RMT5 interrupt priority is always set to level 3 (highest
             // supported) RMT5 hardware limitation: Cannot boost priority above
@@ -748,7 +733,7 @@ class ChannelEngineRMTImpl : public ChannelEngineRMT {
                 // DMA SUCCESS - claim DMA slot in memory manager
                 if (!memMgr.allocateDMA(state->memoryChannelId,
                                         true)) { // true = TX channel
-                    FL_WARN("DMA hardware creation succeeded but memory "
+                    FL_WARN_F("DMA hardware creation succeeded but memory "
                             "manager allocation failed");
                     mPeripheral.deleteChannel(state->channel);
                     state->channel = nullptr;
@@ -765,7 +750,7 @@ class ChannelEngineRMTImpl : public ChannelEngineRMT {
                 // Create encoder for this DMA channel
                 state->encoder = mPeripheral.createEncoder(timing, FASTLED_RMT5_CLOCK_HZ);
                 if (!state->encoder) {
-                    FL_WARN("Failed to create encoder for DMA channel");
+                    FL_WARN_F("Failed to create encoder for DMA channel");
                     mPeripheral.deleteChannel(state->channel);
                     state->channel = nullptr;
                     mDMAChannelsInUse--;
@@ -775,16 +760,13 @@ class ChannelEngineRMTImpl : public ChannelEngineRMT {
                     return false;
                 }
 
-                FL_LOG_RMT("✓ TX Channel #"
-                           << (mChannels.size() + 1) << ": DMA enabled on GPIO "
-                           << static_cast<int>(pin) << " ("
-                           << dma_mem_block_symbols << " symbols)");
+                FL_LOG_RMT_F("âœ“ TX Channel #%s: DMA enabled on GPIO %s (%s symbols)", (mChannels.size() + 1), static_cast<int>(pin), dma_mem_block_symbols);
                 return true;
             } else {
                 // DMA FAILED - free memory and fall through to non-DMA
                 // Free memory allocation
                 memMgr.free(state->memoryChannelId, true);
-                FL_WARN("DMA channel creation failed - unexpected failure on DMA-capable platform, falling back to non-DMA");
+                FL_WARN_F("DMA channel creation failed - unexpected failure on DMA-capable platform, falling back to non-DMA");
             }
         }
 
@@ -797,40 +779,33 @@ class ChannelEngineRMTImpl : public ChannelEngineRMT {
             // Memory allocation failed - this can happen when:
             // 1. External RMT users (USB CDC, etc.) consume memory
             // 2. Too many non-DMA channels requested
-            // 3. Network mode requires 3× buffering but insufficient memory
+            // 3. Network mode requires 3Ã— buffering but insufficient memory
             //
             // Note: DMA channels consume 0 on-chip words, but ESP32-S3 only has
             // 1 DMA channel. Subsequent channels must use non-DMA (on-chip memory).
-            FL_WARN("Memory manager TX allocation failed for channel "
-                    << static_cast<int>(state->memoryChannelId)
-                    << " - insufficient on-chip memory");
-            FL_WARN("  Available: " << memMgr.availableTxWords() << " words");
-            FL_WARN("  Requested: " << (RmtMemoryManager::calculateMemoryBlocks(networkActive) * SOC_RMT_MEM_WORDS_PER_CHANNEL) << " words");
-            FL_WARN("  DMA channels in use: " << memMgr.getDMAChannelsInUse() << "/1");
+            FL_WARN_F("Memory manager TX allocation failed for channel %s - insufficient on-chip memory", static_cast<int>(state->memoryChannelId));
+            FL_WARN_F("  Available: %s words", memMgr.availableTxWords());
+            FL_WARN_F("  Requested: %s words", (RmtMemoryManager::calculateMemoryBlocks(networkActive) * SOC_RMT_MEM_WORDS_PER_CHANNEL));
+            FL_WARN_F("  DMA channels in use: %s/1", memMgr.getDMAChannelsInUse());
             return false;
         }
 
         // Apply previously discovered memory reduction offset (from self-healing)
         // This prevents re-running the progressive retry on every allocation
         if (mMemoryReductionOffset > 0 && mem_block_symbols > mMemoryReductionOffset) {
-            FL_LOG_RMT("Applying memory reduction offset: " << mMemoryReductionOffset
-                       << " symbols (learned from previous recovery)");
+            FL_LOG_RMT_F("Applying memory reduction offset: %s symbols (learned from previous recovery)", mMemoryReductionOffset);
             mem_block_symbols -= mMemoryReductionOffset;
         }
 
         // Log channel number and allocation type
+#ifdef FASTLED_LOG_RMT_ENABLED
         size_t channel_num = mChannels.size() + 1;
         if (memMgr.getDMAChannelsInUse() > 0) {
-            FL_LOG_RMT("✓ TX Channel #"
-                       << channel_num
-                       << ": Non-DMA (double-buffer: " << mem_block_symbols
-                       << " words) - DMA slot taken by another channel");
+            FL_LOG_RMT_F("OK TX Channel #%s: Non-DMA (double-buffer: %s words) - DMA slot taken by another channel", channel_num, mem_block_symbols);
         } else {
-            FL_LOG_RMT("✓ TX Channel #"
-                       << channel_num
-                       << ": Non-DMA (double-buffer: " << mem_block_symbols
-                       << " words) - No DMA support on platform");
+            FL_LOG_RMT_F("OK TX Channel #%s: Non-DMA (double-buffer: %s words) - No DMA support on platform", channel_num, mem_block_symbols);
         }
+#endif
 
         // RMT5 interrupt priority is always set to level 3 (highest supported)
         // RMT5 hardware limitation: Cannot boost priority above level 3
@@ -872,8 +847,7 @@ class ChannelEngineRMTImpl : public ChannelEngineRMT {
 
         if (!success) {
             // Non-recoverable error (already at minimum or other failure)
-            FL_LOG_RMT("Failed to create non-DMA RMT channel on pin "
-                       << static_cast<int>(pin));
+            FL_LOG_RMT_F("Failed to create non-DMA RMT channel on pin %s", static_cast<int>(pin));
             state->channel = nullptr;
             memMgr.free(state->memoryChannelId, true);
             return false;
@@ -890,7 +864,7 @@ class ChannelEngineRMTImpl : public ChannelEngineRMT {
         // Create encoder for this channel
         state->encoder = mPeripheral.createEncoder(timing, FASTLED_RMT5_CLOCK_HZ);
         if (!state->encoder) {
-            FL_WARN("Failed to create encoder for channel");
+            FL_WARN_F("Failed to create encoder for channel");
             mPeripheral.deleteChannel(state->channel);
             state->channel = nullptr;
             // Free memory allocation
@@ -898,8 +872,7 @@ class ChannelEngineRMTImpl : public ChannelEngineRMT {
             return false;
         }
 
-        FL_WARN("[RMT TX] Channel created on GPIO " << static_cast<int>(pin)
-                << " (" << mem_block_symbols << " symbols, non-DMA)");
+        FL_WARN_F("[RMT TX] Channel created on GPIO %s (%s symbols, non-DMA)", static_cast<int>(pin), mem_block_symbols);
         return true;
     }
 
@@ -921,9 +894,7 @@ class ChannelEngineRMTImpl : public ChannelEngineRMT {
 
         // If pin changed, destroy and recreate channel
         if (state->channel && state->pin != pin) {
-            FL_LOG_RMT("Pin changed from " << static_cast<int>(state->pin)
-                                           << " to " << static_cast<int>(pin)
-                                           << ", recreating channel");
+            FL_LOG_RMT_F("Pin changed from %s to %s, recreating channel", static_cast<int>(state->pin), static_cast<int>(pin));
 
             // Wait for any pending transmission to complete
             mPeripheral.waitAllDone(state->channel, 100);
@@ -953,13 +924,9 @@ class ChannelEngineRMTImpl : public ChannelEngineRMT {
 
         // If timing changed but channel exists, recreate encoder
         if (timingChanged) {
-            FL_LOG_RMT("Timing changed for pin " << static_cast<int>(pin)
-                                                 << ", recreating encoder");
-            FL_LOG_RMT("  Old: T1=" << state->timing.T1
-                                    << " T2=" << state->timing.T2
-                                    << " T3=" << state->timing.T3);
-            FL_LOG_RMT("  New: T1=" << timing.T1 << " T2=" << timing.T2
-                                    << " T3=" << timing.T3);
+            FL_LOG_RMT_F("Timing changed for pin %s, recreating encoder", static_cast<int>(pin));
+            FL_LOG_RMT_F("  Old: T1=%s T2=%s T3=%s", state->timing.T1, state->timing.T2, state->timing.T3);
+            FL_LOG_RMT_F("  New: T1=%s T2=%s T3=%s", timing.T1, timing.T2, timing.T3);
 
             // Wait for any pending transmission to complete
             mPeripheral.waitAllDone(state->channel, 100);
@@ -973,7 +940,7 @@ class ChannelEngineRMTImpl : public ChannelEngineRMT {
             // Create new encoder with updated timing
             state->encoder = mPeripheral.createEncoder(timing, FASTLED_RMT5_CLOCK_HZ);
             if (!state->encoder) {
-                FL_WARN("Failed to recreate encoder with new timing");
+                FL_WARN_F("Failed to recreate encoder with new timing");
                 // Channel is still valid but encoder is broken - mark channel
                 // as unusable
                 mPeripheral.deleteChannel(state->channel);
@@ -991,21 +958,20 @@ class ChannelEngineRMTImpl : public ChannelEngineRMT {
                 return;
             }
 
-            FL_LOG_RMT("Encoder recreated successfully with new timing");
+            FL_LOG_RMT_F("Encoder recreated successfully with new timing");
         }
 
         // Create channel if needed
         if (!state->channel) {
             if (!createChannel(state, pin, timing, dataSize)) {
-                FL_LOG_RMT("Failed to recreate channel for pin "
-                           << static_cast<int>(pin));
+                FL_LOG_RMT_F("Failed to recreate channel for pin %s", static_cast<int>(pin));
                 return;
             }
 
             // Register callback after creation (state pointer is already stable
             // here)
             if (!registerChannelCallback(state)) {
-                FL_WARN("Failed to register callback after reconfiguration");
+                FL_WARN_F("Failed to register callback after reconfiguration");
                 if (state->encoder) {
                     mPeripheral.deleteEncoder(state->encoder);
                     state->encoder = nullptr;
@@ -1057,7 +1023,7 @@ class ChannelEngineRMTImpl : public ChannelEngineRMT {
 
             // Verify channel has encoder (should always be true if createChannel succeeded)
             if (!channel->encoder) {
-                FL_WARN("Channel missing encoder for pin " << pending.pin);
+                FL_WARN_F("Channel missing encoder for pin %s", pending.pin);
                 releaseChannel(channel);
                 ++i;
                 continue;
@@ -1074,8 +1040,7 @@ class ChannelEngineRMTImpl : public ChannelEngineRMT {
                 mBufferPool.acquireInternal(dataSize);
 
             if (pooledBuffer.empty()) {
-                FL_WARN("Failed to acquire pooled buffer for pin " << pending.pin
-                        << " (" << dataSize << " bytes, DMA=" << channel->useDMA << ")");
+                FL_WARN_F("Failed to acquire pooled buffer for pin %s (%s bytes, DMA=%s)", pending.pin, dataSize, channel->useDMA);
                 releaseChannel(channel);
                 ++i;
                 continue;
@@ -1090,7 +1055,7 @@ class ChannelEngineRMTImpl : public ChannelEngineRMT {
 
             bool enable_success = mPeripheral.enableChannel(channel->channel);
             if (!enable_success) {
-                FL_LOG_RMT("Failed to enable channel");
+                FL_LOG_RMT_F("Failed to enable channel");
                 // Release buffer back to pool before releasing channel
                 if (channel->useDMA) {
                     mBufferPool.releaseDMA();
@@ -1105,7 +1070,7 @@ class ChannelEngineRMTImpl : public ChannelEngineRMT {
 
             // Explicitly reset encoder before each transmission to ensure clean state
             if (!mPeripheral.resetEncoder(channel->encoder)) {
-                FL_LOG_RMT("Failed to reset encoder");
+                FL_LOG_RMT_F("Failed to reset encoder");
                 mPeripheral.disableChannel(channel->channel);
                 // Release buffer back to pool before releasing channel
                 if (channel->useDMA) {
@@ -1134,7 +1099,7 @@ class ChannelEngineRMTImpl : public ChannelEngineRMT {
                                                     pooledBuffer.data(),
                                                     pooledBuffer.size());
             if (!tx_success) {
-                FL_WARN("[RMT TX] transmit() FAILED on pin " << static_cast<int>(channel->pin));
+                FL_WARN_F("[RMT TX] transmit() FAILED on pin %s", static_cast<int>(channel->pin));
                 mPeripheral.disableChannel(channel->channel);
                 // Release buffer back to pool before releasing channel
                 if (channel->useDMA) {
@@ -1148,8 +1113,7 @@ class ChannelEngineRMTImpl : public ChannelEngineRMT {
                 continue;
             }
 
-            FL_LOG_RMT("Started transmission for pin " << pending.pin
-                       << " (" << pending.data->getSize() << " bytes)");
+            FL_LOG_RMT_F("Started transmission for pin %s (%s bytes)", pending.pin, pending.data->getSize());
 
             // Remove from pending queue (swap with last and pop)
             if (i < mPendingChannels.size() - 1) {
@@ -1176,13 +1140,13 @@ class ChannelEngineRMTImpl : public ChannelEngineRMT {
     /// @return Target number of channels for current state
     size_t calculateTargetChannelCount(bool networkActive) FL_NOEXCEPT {
         if (!networkActive) {
-            // No network: Use maximum channels for platform (2× memory blocks)
+            // No network: Use maximum channels for platform (2Ã— memory blocks)
             #if defined(FL_IS_ESP_32DEV)
-                return 4;  // 512 words ÷ 128 = 4 channels
+                return 4;  // 512 words Ã· 128 = 4 channels
             #elif defined(FL_IS_ESP_32S2)
-                return 2;  // 256 words ÷ 128 = 2 channels
+                return 2;  // 256 words Ã· 128 = 2 channels
             #elif defined(FL_IS_ESP_32S3)
-                return 3;  // 1 DMA + 2 on-chip (192 ÷ 96 = 2)
+                return 3;  // 1 DMA + 2 on-chip (192 Ã· 96 = 2)
             #elif defined(FL_IS_ESP_32C3) || defined(FL_IS_ESP_32C6) || \
                   defined(CONFIG_IDF_TARGET_ESP32H2) || defined(CONFIG_IDF_TARGET_ESP32C5)
                 return 1;  // C3/C6/H2/C5: Only 96 words
@@ -1190,16 +1154,16 @@ class ChannelEngineRMTImpl : public ChannelEngineRMT {
                 return 1;  // Unknown platform: conservative default
             #endif
         } else {
-            // Network active: Reduce channels to allow 3× buffering (except C3/C6/H2/C5)
+            // Network active: Reduce channels to allow 3Ã— buffering (except C3/C6/H2/C5)
             #if defined(FL_IS_ESP_32DEV)
-                return 2;  // 512 words ÷ 192 = 2 channels (3× buffering)
+                return 2;  // 512 words Ã· 192 = 2 channels (3Ã— buffering)
             #elif defined(FL_IS_ESP_32S2)
-                return 1;  // 256 words ÷ 192 = 1 channel (3× buffering)
+                return 1;  // 256 words Ã· 192 = 1 channel (3Ã— buffering)
             #elif defined(FL_IS_ESP_32S3)
-                return 2;  // 1 DMA + 1 on-chip (192 words ÷ 144 = 1 on-chip with 3×)
+                return 2;  // 1 DMA + 1 on-chip (192 words Ã· 144 = 1 on-chip with 3Ã—)
             #elif defined(FL_IS_ESP_32C3) || defined(FL_IS_ESP_32C6) || \
                   defined(CONFIG_IDF_TARGET_ESP32H2) || defined(CONFIG_IDF_TARGET_ESP32C5)
-                return 1;  // C3/C6/H2/C5: Cannot use 3× (insufficient memory), keep 1 channel
+                return 1;  // C3/C6/H2/C5: Cannot use 3Ã— (insufficient memory), keep 1 channel
             #else
                 return 1;  // Unknown platform: conservative default
             #endif
@@ -1217,8 +1181,7 @@ class ChannelEngineRMTImpl : public ChannelEngineRMT {
 
         bool networkActive = networkTracker.isActive();
         bool wasNetworkActive = !networkActive;  // Previous state is opposite of current
-        FL_DBG("Network state changed: " << (networkActive ? "ACTIVE" : "INACTIVE")
-               << " (was: " << (wasNetworkActive ? "ACTIVE" : "INACTIVE") << ")");
+        FL_DBG_F("Network state changed: %s (was: %s)", (networkActive ? "ACTIVE" : "INACTIVE"), (wasNetworkActive ? "ACTIVE" : "INACTIVE"));
 
         // Check if memory allocation size would actually change
         // On platforms like ESP32-C3/C6/H2 with limited memory, network state doesn't affect memory blocks
@@ -1227,27 +1190,25 @@ class ChannelEngineRMTImpl : public ChannelEngineRMT {
         size_t newMemBlocks = RmtMemoryManager::calculateMemoryBlocks(networkActive);
 
         if (oldMemBlocks == newMemBlocks) {
-            FL_DBG("Network state changed but memory allocation size unchanged ("
-                   << newMemBlocks << "× blocks) - skipping reconfiguration");
+            FL_DBG_F("Network state changed but memory allocation size unchanged (%sÃ— blocks) - skipping reconfiguration", newMemBlocks);
             return;  // Memory allocation size doesn't change - no need to reconfigure
         }
 
-        FL_DBG("Memory allocation changing from " << oldMemBlocks << "× to "
-               << newMemBlocks << "× blocks due to network state change");
+        FL_DBG_F("Memory allocation changing from %sÃ— to %sÃ— blocks due to network state change", oldMemBlocks, newMemBlocks);
 
         // Calculate target channel count for new Network state
         size_t targetChannels = calculateTargetChannelCount(networkActive);
-        FL_DBG("Target channel count: " << targetChannels << " (current: " << mChannels.size() << ")");
+        FL_DBG_F("Target channel count: %s (current: %s)", targetChannels, mChannels.size());
 
         // PHASE 1: Destroy excess channels if Network activated and we exceed target
         if (networkActive && mChannels.size() > targetChannels) {
             size_t channelsToDestroy = mChannels.size() - targetChannels;
-            FL_DBG("Network activated - destroying " << channelsToDestroy << " excess channels");
+            FL_DBG_F("Network activated - destroying %s excess channels", channelsToDestroy);
             destroyLeastUsedChannels(channelsToDestroy);
         }
 
         // PHASE 2: Reconfigure remaining idle channels with new memory allocation
-        // This ensures existing channels use Network-appropriate memory (2× vs 3× blocks)
+        // This ensures existing channels use Network-appropriate memory (2Ã— vs 3Ã— blocks)
         size_t reconfigured = 0;
 
         for (size_t i = 0; i < mChannels.size(); ++i) {
@@ -1259,7 +1220,7 @@ class ChannelEngineRMTImpl : public ChannelEngineRMT {
             }
 
             // Destroy the channel and its encoder
-            FL_DBG("Reconfiguring idle channel " << i << " (pin: " << static_cast<int>(state.pin) << ")");
+            FL_DBG_F("Reconfiguring idle channel %s (pin: %s)", i, static_cast<int>(state.pin));
 
             // Delete encoder first
             if (state.encoder) {
@@ -1289,7 +1250,7 @@ class ChannelEngineRMTImpl : public ChannelEngineRMT {
             if (createChannel(&state, state.pin, state.timing, 0)) {
                 // Re-register callback for the recreated channel
                 if (!registerChannelCallback(&state)) {
-                    FL_WARN("Failed to re-register callback for reconfigured channel " << i);
+                    FL_WARN_F("Failed to re-register callback for reconfigured channel %s", i);
                     // Channel creation succeeded but callback failed - destroy it
                     if (state.channel) {
                         mPeripheral.deleteChannel(state.channel);
@@ -1308,14 +1269,14 @@ class ChannelEngineRMTImpl : public ChannelEngineRMT {
                     memMgr.free(state.memoryChannelId, true);
                 } else {
                     reconfigured++;
-                    FL_DBG("Successfully reconfigured channel " << i);
+                    FL_DBG_F("Successfully reconfigured channel %s", i);
                 }
             } else {
-                FL_WARN("Failed to recreate channel " << i << " during Network reconfiguration");
+                FL_WARN_F("Failed to recreate channel %s during Network reconfiguration", i);
             }
         }
 
-        FL_DBG("Network reconfiguration complete - " << reconfigured << " channels reconfigured");
+        FL_DBG_F("Network reconfiguration complete - %s channels reconfigured", reconfigured);
     }
 
     /// @brief ISR callback for transmission completion
@@ -1382,15 +1343,12 @@ ChannelEngineRMTImpl::ChannelState *ChannelEngineRMTImpl::acquireChannel(
     int pin, const ChipsetTiming &timing, fl::size dataSize) FL_NOEXCEPT {
     // Strategy 1: Find channel with matching pin (zero-cost reuse)
     // This applies to both DMA and non-DMA channels
-    FL_LOG_RMT("acquireChannel: Finding channel with matching pin "
-               << static_cast<int>(pin));
+    FL_LOG_RMT_F("acquireChannel: Finding channel with matching pin %s", static_cast<int>(pin));
     for (auto &ch : mChannels) {
         if (!ch.inUse && ch.channel && ch.pin == pin) {
             ch.inUse = true;
             configureChannel(&ch, pin, timing, dataSize);
-            FL_LOG_RMT("Reusing " << (ch.useDMA ? "DMA" : "non-DMA")
-                                  << " channel for pin "
-                                  << static_cast<int>(pin));
+            FL_LOG_RMT_F("Reusing %s channel for pin %s", (ch.useDMA ? "DMA" : "non-DMA"), static_cast<int>(pin));
             return &ch;
         }
     }
@@ -1400,8 +1358,7 @@ ChannelEngineRMTImpl::ChannelState *ChannelEngineRMTImpl::acquireChannel(
         if (!ch.inUse && ch.channel && !ch.useDMA) {
             ch.inUse = true;
             configureChannel(&ch, pin, timing, dataSize);
-            FL_LOG_RMT("Reconfiguring idle non-DMA channel for pin "
-                       << static_cast<int>(pin));
+            FL_LOG_RMT_F("Reconfiguring idle non-DMA channel for pin %s", static_cast<int>(pin));
             return &ch;
         }
     }
@@ -1410,7 +1367,7 @@ ChannelEngineRMTImpl::ChannelState *ChannelEngineRMTImpl::acquireChannel(
     // BUT: Skip if allocation previously failed (reset at start of next frame
     // in beginTransmission)
     if (mAllocationFailed) {
-        FL_LOG_RMT("Skipping channel creation (allocation failed, will retry "
+        FL_LOG_RMT_F("Skipping channel creation (allocation failed, will retry "
                    "next frame)");
         return nullptr;
     }
@@ -1424,7 +1381,7 @@ ChannelEngineRMTImpl::ChannelState *ChannelEngineRMTImpl::acquireChannel(
         // pointer
         ChannelState *stablePtr = &mChannels.back();
         if (!registerChannelCallback(stablePtr)) {
-            FL_WARN("Failed to register callback for new channel");
+            FL_WARN_F("Failed to register callback for new channel");
             // Free memory allocation that createChannel() made
             auto &memMgr = RmtMemoryManager::instance();
             if (stablePtr->useDMA) {
@@ -1438,14 +1395,12 @@ ChannelEngineRMTImpl::ChannelState *ChannelEngineRMTImpl::acquireChannel(
             return nullptr;
         }
 
-        FL_LOG_RMT("Created new channel for pin "
-                   << static_cast<int>(pin) << " (total: " << mChannels.size()
-                   << ")");
+        FL_LOG_RMT_F("Created new channel for pin %s (total: %s)", static_cast<int>(pin), mChannels.size());
         return stablePtr;
     }
 
     // No HW channels available - mark allocation failed
-    FL_LOG_RMT("Channel allocation failed - max channels reached");
+    FL_LOG_RMT_F("Channel allocation failed - max channels reached");
     mAllocationFailed = true;
     return nullptr;
 }
@@ -1498,12 +1453,11 @@ bool ChannelEngineRMTImpl::registerChannelCallback(ChannelState *state) FL_NOEXC
         &transmitDoneCallback,
         state);
     if (!success) {
-        FL_WARN("Failed to register callbacks");
+        FL_WARN_F("Failed to register callbacks");
         return false;
     }
 
-    FL_LOG_RMT("Registered callback for channel on GPIO "
-               << static_cast<int>(state->pin));
+    FL_LOG_RMT_F("Registered callback for channel on GPIO %s", static_cast<int>(state->pin));
     return true;
 }
 
@@ -1521,8 +1475,7 @@ void ChannelEngineRMTImpl::destroyChannel(ChannelState *state) FL_NOEXCEPT {
     // Wait for transmission to complete (should already be done if !inUse)
     bool wait_success = mPeripheral.waitAllDone(state->channel, 100);
     if (!wait_success) {
-        FL_WARN("destroyChannel: Wait all done timeout for pin "
-                << static_cast<int>(state->pin));
+        FL_WARN_F("destroyChannel: Wait all done timeout for pin %s", static_cast<int>(state->pin));
     }
 
     // Delete encoder
@@ -1534,7 +1487,7 @@ void ChannelEngineRMTImpl::destroyChannel(ChannelState *state) FL_NOEXCEPT {
     // Delete channel
     bool del_success = mPeripheral.deleteChannel(state->channel);
     if (!del_success) {
-        FL_WARN("destroyChannel: Failed to delete channel");
+        FL_WARN_F("destroyChannel: Failed to delete channel");
     }
     state->channel = nullptr;
 
@@ -1548,9 +1501,7 @@ void ChannelEngineRMTImpl::destroyChannel(ChannelState *state) FL_NOEXCEPT {
 
     state->useDMA = false;
 
-    FL_LOG_RMT("Destroyed channel on pin "
-               << static_cast<int>(state->pin) << " (memoryChannelId: "
-               << static_cast<int>(state->memoryChannelId) << ")");
+    FL_LOG_RMT_F("Destroyed channel on pin %s (memoryChannelId: %s)", static_cast<int>(state->pin), static_cast<int>(state->memoryChannelId));
 }
 
 void ChannelEngineRMTImpl::destroyLeastUsedChannels(size_t count) FL_NOEXCEPT {
@@ -1558,7 +1509,7 @@ void ChannelEngineRMTImpl::destroyLeastUsedChannels(size_t count) FL_NOEXCEPT {
         return;
     }
 
-    FL_LOG_RMT("Destroying " << count << " least-used channels");
+    FL_LOG_RMT_F("Destroying %s least-used channels", count);
 
     // Destroy channels from end of vector (FIFO - oldest channels at end)
     // NOTE: Future enhancement could track lastUsedTimestamp for true LRU
@@ -1575,15 +1526,13 @@ void ChannelEngineRMTImpl::destroyLeastUsedChannels(size_t count) FL_NOEXCEPT {
         } else {
             // Cannot destroy in-use channel - skip for now
             // This could happen if WiFi activates during transmission
-            FL_WARN("destroyLeastUsedChannels: Cannot destroy in-use channel "
-                    "on pin "
-                    << static_cast<int>(state.pin) << ", skipping");
+            FL_WARN_F("destroyLeastUsedChannels: Cannot destroy in-use channel "
+                    "on pin %s, skipping", static_cast<int>(state.pin));
             break;
         }
     }
 
-    FL_LOG_RMT("Destroyed " << destroyed << " channels (requested: " << count
-                            << ")");
+    FL_LOG_RMT_F("Destroyed %s channels (requested: %s)", destroyed, count);
 }
 
 //=============================================================================
@@ -1612,9 +1561,9 @@ void ChannelEngineRMTImpl::destroyLeastUsedChannels(size_t count) FL_NOEXCEPT {
 /// Without this hardware wait, the following race condition can occur:
 ///   - Frame N transmission starts (RMT hardware reading buffer A)
 ///   - ISR fires (callback sets transmissionComplete = true)
-///   - Main thread calls releaseChannel() → clears mInUse flag
+///   - Main thread calls releaseChannel() â†’ clears mInUse flag
 ///   - User calls FastLED.show() for Frame N+1
-///   - ClocklessRMT::showPixels() sees mInUse == false → proceeds to encode
+///   - ClocklessRMT::showPixels() sees mInUse == false â†’ proceeds to encode
 ///   - NEW pixel data overwrites buffer A while RMT is still shifting it out
 ///   - LEDs display corrupted mix of Frame N and Frame N+1 data
 ///

--- a/src/platforms/esp/32/drivers/rmt/rmt_5/rmt5_controller_lowlevel.cpp.hpp
+++ b/src/platforms/esp/32/drivers/rmt/rmt_5/rmt5_controller_lowlevel.cpp.hpp
@@ -65,7 +65,7 @@ RmtController5LowLevel::~RmtController5LowLevel() {
 void RmtController5LowLevel::loadPixelData(PixelIterator& pixels) FL_NOEXCEPT {
     // Safety check: don't modify buffer if driver is transmitting it
     if (mChannelData->isInUse()) {
-        FL_WARN("RMT5 Controller: Skipping update - buffer in use by driver");
+        FL_WARN_F("RMT5 Controller: Skipping update - buffer in use by driver");
         return;
     }
 
@@ -88,7 +88,7 @@ void RmtController5LowLevel::showPixels() FL_NOEXCEPT {
     if (mDriver) {
         mDriver->enqueue(mChannelData);
     } else {
-        FL_WARN("RMT5 Controller: RMT driver not available for showPixels()");
+        FL_WARN_F("RMT5 Controller: RMT driver not available for showPixels()");
     }
 }
 

--- a/src/platforms/esp/32/drivers/rmt/rmt_5/rmt5_peripheral_esp.cpp.hpp
+++ b/src/platforms/esp/32/drivers/rmt/rmt_5/rmt5_peripheral_esp.cpp.hpp
@@ -1,4 +1,4 @@
-// IWYU pragma: private
+﻿// IWYU pragma: private
 
 /// @file rmt5_peripheral_esp.cpp
 /// @brief Real ESP32 RMT5 peripheral implementation
@@ -142,7 +142,7 @@ static volatile int s_lastTxChannelGpio = -1;
 bool Rmt5PeripheralESPImpl::createTxChannel(const Rmt5ChannelConfig& config,
                                              void** out_handle) FL_NOEXCEPT {
     if (out_handle == nullptr) {
-        FL_WARN("Rmt5PeripheralESP: out_handle is nullptr");
+        FL_WARN_F("Rmt5PeripheralESP: out_handle is nullptr");
         return false;
     }
 
@@ -171,17 +171,16 @@ bool Rmt5PeripheralESPImpl::createTxChannel(const Rmt5ChannelConfig& config,
     // gpio_reset_pin() was interfering with GPIO matrix routing when both TX and RX are active
 
     // Delegate to ESP-IDF
-    FL_LOG_RMT("RMT5_PERIPH: Creating TX channel on GPIO " << config.gpio_num);
+    FL_LOG_RMT_F("RMT5_PERIPH: Creating TX channel on GPIO %s", config.gpio_num);
 
     rmt_channel_handle_t channel;
     esp_err_t err = rmt_new_tx_channel(&esp_config, &channel);
     if (err != ESP_OK) {
-        FL_WARN("[RMT5_PERIPH] Failed to create TX channel: " << esp_err_to_name(err)
-                << " (err=" << static_cast<int>(err) << ")");
+        FL_WARN_F("[RMT5_PERIPH] Failed to create TX channel: %s (err=%s)", esp_err_to_name(err), static_cast<int>(err));
         return false;
     }
 
-    FL_LOG_RMT("RMT5_PERIPH: TX channel created successfully on GPIO " << config.gpio_num);
+    FL_LOG_RMT_F("RMT5_PERIPH: TX channel created successfully on GPIO %s", config.gpio_num);
 
     // NOTE: Previous workaround for ESP32-S3 TX+RX GPIO conflict has been removed.
     // The workaround was routing RMT_SIG_OUT0_IDX to the GPIO, but this was wrong:
@@ -204,7 +203,7 @@ bool Rmt5PeripheralESPImpl::createTxChannel(const Rmt5ChannelConfig& config,
 
 bool Rmt5PeripheralESPImpl::deleteChannel(void* channel_handle) FL_NOEXCEPT {
     if (channel_handle == nullptr) {
-        FL_WARN("Rmt5PeripheralESP: channel_handle is nullptr");
+        FL_WARN_F("Rmt5PeripheralESP: channel_handle is nullptr");
         return false;
     }
 
@@ -212,17 +211,17 @@ bool Rmt5PeripheralESPImpl::deleteChannel(void* channel_handle) FL_NOEXCEPT {
     rmt_channel_handle_t channel = static_cast<rmt_channel_handle_t>(channel_handle);
     esp_err_t err = rmt_del_channel(channel);
     if (err != ESP_OK) {
-        FL_LOG_RMT("RMT5_PERIPH: Failed to delete channel: " << esp_err_to_name(err));
+        FL_LOG_RMT_F("RMT5_PERIPH: Failed to delete channel: %s", esp_err_to_name(err));
         return false;
     }
 
-    FL_LOG_RMT("RMT5_PERIPH: Channel deleted successfully");
+    FL_LOG_RMT_F("RMT5_PERIPH: Channel deleted successfully");
     return true;
 }
 
 bool Rmt5PeripheralESPImpl::enableChannel(void* channel_handle) FL_NOEXCEPT {
     if (channel_handle == nullptr) {
-        FL_WARN("Rmt5PeripheralESP: channel_handle is nullptr");
+        FL_WARN_F("Rmt5PeripheralESP: channel_handle is nullptr");
         return false;
     }
 
@@ -231,18 +230,18 @@ bool Rmt5PeripheralESPImpl::enableChannel(void* channel_handle) FL_NOEXCEPT {
 
     esp_err_t err = rmt_enable(channel);
     if (err != ESP_OK) {
-        FL_LOG_RMT("RMT5_PERIPH: Failed to enable channel: " << esp_err_to_name(err));
+        FL_LOG_RMT_F("RMT5_PERIPH: Failed to enable channel: %s", esp_err_to_name(err));
         return false;
     }
 
-    FL_LOG_RMT("RMT5_PERIPH: TX channel enabled successfully");
+    FL_LOG_RMT_F("RMT5_PERIPH: TX channel enabled successfully");
 
     return true;
 }
 
 bool Rmt5PeripheralESPImpl::disableChannel(void* channel_handle) FL_NOEXCEPT {
     if (channel_handle == nullptr) {
-        FL_WARN("Rmt5PeripheralESP: channel_handle is nullptr");
+        FL_WARN_F("Rmt5PeripheralESP: channel_handle is nullptr");
         return false;
     }
 
@@ -250,11 +249,11 @@ bool Rmt5PeripheralESPImpl::disableChannel(void* channel_handle) FL_NOEXCEPT {
     rmt_channel_handle_t channel = static_cast<rmt_channel_handle_t>(channel_handle);
     esp_err_t err = rmt_disable(channel);
     if (err != ESP_OK) {
-        FL_LOG_RMT("RMT5_PERIPH: Failed to disable channel: " << esp_err_to_name(err));
+        FL_LOG_RMT_F("RMT5_PERIPH: Failed to disable channel: %s", esp_err_to_name(err));
         return false;
     }
 
-    FL_LOG_RMT("RMT5_PERIPH: Channel disabled successfully");
+    FL_LOG_RMT_F("RMT5_PERIPH: Channel disabled successfully");
     return true;
 }
 
@@ -262,7 +261,7 @@ bool Rmt5PeripheralESPImpl::disableChannel(void* channel_handle) FL_NOEXCEPT {
 // Transmission Methods
 //=============================================================================
 
-/// Static counter to track TX done callback invocations (for debugging RMT TX → RX issues)
+/// Static counter to track TX done callback invocations (for debugging RMT TX â†’ RX issues)
 static volatile u32 s_txDoneCallbackCount = 0;
 
 /// Static counter to track encoder encode callback invocations (ISR context)
@@ -274,7 +273,7 @@ static volatile size_t s_totalSymbolsEncoded = 0;
 bool Rmt5PeripheralESPImpl::transmit(void* channel_handle, void* encoder_handle,
                                       const u8* buffer, size_t buffer_size) FL_NOEXCEPT {
     if (channel_handle == nullptr || encoder_handle == nullptr || buffer == nullptr) {
-        FL_WARN("Rmt5PeripheralESP: Invalid parameter (nullptr)");
+        FL_WARN_F("Rmt5PeripheralESP: Invalid parameter (nullptr)");
         return false;
     }
 
@@ -289,7 +288,7 @@ bool Rmt5PeripheralESPImpl::transmit(void* channel_handle, void* encoder_handle,
 
     esp_err_t err = rmt_transmit(channel, encoder, buffer, buffer_size, &tx_config);
     if (err != ESP_OK) {
-        FL_WARN("RMT5_PERIPH: rmt_transmit() FAILED: " << esp_err_to_name(err));
+        FL_WARN_F("RMT5_PERIPH: rmt_transmit() FAILED: %s", esp_err_to_name(err));
         return false;
     }
 
@@ -298,7 +297,7 @@ bool Rmt5PeripheralESPImpl::transmit(void* channel_handle, void* encoder_handle,
 
 bool Rmt5PeripheralESPImpl::waitAllDone(void* channel_handle, u32 timeout_ms) FL_NOEXCEPT {
     if (channel_handle == nullptr) {
-        FL_WARN("Rmt5PeripheralESP: channel_handle is nullptr");
+        FL_WARN_F("Rmt5PeripheralESP: channel_handle is nullptr");
         return false;
     }
 
@@ -314,9 +313,9 @@ bool Rmt5PeripheralESPImpl::waitAllDone(void* channel_handle, u32 timeout_ms) FL
 
     if (err != ESP_OK) {
         if (err == ESP_ERR_TIMEOUT) {
-            FL_WARN("RMT5_PERIPH: TX wait TIMEOUT after " << timeout_ms << " ms");
+            FL_WARN_F("RMT5_PERIPH: TX wait TIMEOUT after %s ms", timeout_ms);
         } else {
-            FL_WARN("RMT5_PERIPH: TX wait FAILED: " << esp_err_to_name(err));
+            FL_WARN_F("RMT5_PERIPH: TX wait FAILED: %s", esp_err_to_name(err));
         }
         return false;
     }
@@ -370,7 +369,7 @@ bool Rmt5PeripheralESPImpl::registerTxCallback(void* channel_handle,
                                                 Rmt5TxDoneCallback callback,
                                                 void* user_ctx) FL_NOEXCEPT {
     if (channel_handle == nullptr || callback == nullptr) {
-        FL_WARN("Rmt5PeripheralESP: Invalid parameter (nullptr)");
+        FL_WARN_F("Rmt5PeripheralESP: Invalid parameter (nullptr)");
         return false;
     }
 
@@ -391,12 +390,12 @@ bool Rmt5PeripheralESPImpl::registerTxCallback(void* channel_handle,
     rmt_channel_handle_t channel = static_cast<rmt_channel_handle_t>(channel_handle);
     esp_err_t err = rmt_tx_register_event_callbacks(channel, &cbs, ctx);
     if (err != ESP_OK) {
-        FL_LOG_RMT("RMT5_PERIPH: Failed to register callback: " << esp_err_to_name(err));
+        FL_LOG_RMT_F("RMT5_PERIPH: Failed to register callback: %s", esp_err_to_name(err));
         delete ctx;  // ok bare allocation
         return false;
     }
 
-    FL_LOG_RMT("RMT5_PERIPH: TX callback registered successfully");
+    FL_LOG_RMT_F("RMT5_PERIPH: TX callback registered successfully");
     return true;
 }
 
@@ -413,7 +412,7 @@ void Rmt5PeripheralESPImpl::configureLogging() FL_NOEXCEPT {
     // Cache sync errors are printed by ESP-IDF before FastLED can handle them
     esp_log_level_set("cache", ESP_LOG_NONE);
 
-    FL_LOG_RMT("RMT5_PERIPH: Logging configured (RMT: WARN, cache: NONE)");
+    FL_LOG_RMT_F("RMT5_PERIPH: Logging configured (RMT: WARN, cache: NONE)");
 }
 
 bool Rmt5PeripheralESPImpl::syncCache(void* buffer, size_t size) FL_NOEXCEPT {
@@ -461,12 +460,11 @@ bool Rmt5PeripheralESPImpl::syncCache(void* buffer, size_t size) FL_NOEXCEPT {
             // sufficient for correct operation. The esp_cache_msync() is an
             // optimization that may not be strictly required on all platforms.
             mCacheSyncDisabled = true;
-            FL_DBG("RMT5_PERIPH: Cache sync disabled due to ESP_ERR_INVALID_ARG. "
+            FL_DBG_F("RMT5_PERIPH: Cache sync disabled due to ESP_ERR_INVALID_ARG. "
                    "Memory barriers will ensure ordering.");
         } else {
             // Other errors are logged but non-fatal
-            FL_LOG_RMT("RMT5_PERIPH: Cache sync returned error: " << esp_err_to_name(err)
-                       << " (non-fatal, memory barriers ensure ordering)");
+            FL_LOG_RMT_F("RMT5_PERIPH: Cache sync returned error: %s (non-fatal, memory barriers ensure ordering)", esp_err_to_name(err));
         }
     }
 
@@ -479,7 +477,7 @@ bool Rmt5PeripheralESPImpl::syncCache(void* buffer, size_t size) FL_NOEXCEPT {
 
 u8* Rmt5PeripheralESPImpl::allocateDmaBuffer(size_t size) FL_NOEXCEPT {
     if (size == 0) {
-        FL_WARN("Rmt5PeripheralESP: Cannot allocate zero-size buffer");
+        FL_WARN_F("Rmt5PeripheralESP: Cannot allocate zero-size buffer");
         return nullptr;
     }
 
@@ -492,12 +490,11 @@ u8* Rmt5PeripheralESPImpl::allocateDmaBuffer(size_t size) FL_NOEXCEPT {
         heap_caps_aligned_alloc(alignment, aligned_size, MALLOC_CAP_DMA));
 
     if (buffer == nullptr) {
-        FL_WARN("Rmt5PeripheralESP: Failed to allocate DMA buffer ("
-                << aligned_size << " bytes)");
+        FL_WARN_F("Rmt5PeripheralESP: Failed to allocate DMA buffer (%s bytes)", aligned_size);
         return nullptr;
     }
 
-    FL_LOG_RMT("RMT5_PERIPH: Allocated DMA buffer (" << aligned_size << " bytes)");
+    FL_LOG_RMT_F("RMT5_PERIPH: Allocated DMA buffer (%s bytes)", aligned_size);
     return buffer;
 }
 
@@ -507,7 +504,7 @@ void Rmt5PeripheralESPImpl::freeDmaBuffer(u8* buffer) FL_NOEXCEPT {
     }
 
     heap_caps_free(buffer);
-    FL_LOG_RMT("RMT5_PERIPH: Freed DMA buffer");
+    FL_LOG_RMT_F("RMT5_PERIPH: Freed DMA buffer");
 }
 
 //=============================================================================
@@ -556,11 +553,11 @@ struct Rmt5EncoderImpl {
     static Rmt5EncoderImpl* create(const ChipsetTiming& timing, u32 resolution_hz) FL_NOEXCEPT {
         Rmt5EncoderImpl* impl = new Rmt5EncoderImpl(timing, resolution_hz);  // ok bare allocation
         if (impl == nullptr) {
-            FL_WARN("Rmt5EncoderImpl::create: Failed to allocate encoder");
+            FL_WARN_F("Rmt5EncoderImpl::create: Failed to allocate encoder");
             return nullptr;
         }
         if (impl->getHandle() == nullptr) {
-            FL_WARN("Rmt5EncoderImpl::create: Encoder initialization failed");
+            FL_WARN_F("Rmt5EncoderImpl::create: Encoder initialization failed");
             delete impl;  // ok bare allocation
             return nullptr;
         }
@@ -594,7 +591,7 @@ private:
 
         esp_err_t ret = initialize(timing, resolution_hz);
         if (ret != ESP_OK) {
-            FL_WARN("Rmt5EncoderImpl: Initialization failed: " << esp_err_to_name(ret));
+            FL_WARN_F("Rmt5EncoderImpl: Initialization failed: %s", esp_err_to_name(ret));
         }
     }
 
@@ -602,7 +599,7 @@ private:
     // Note: No static global accesses allowed in FL_IRAM functions on Xtensa.
     // Static globals require 32-bit address loads via l32r, which needs literal
     // pool entries. Per-function IRAM sections cause the linker to place literals
-    // after code, but l32r can only reference backward — causing link failure.
+    // after code, but l32r can only reference backward â€” causing link failure.
     size_t FL_IRAM encode(rmt_channel_handle_t channel,
                           const void* primary_data, size_t data_size,
                           rmt_encode_state_t* ret_state) FL_NOEXCEPT {
@@ -682,11 +679,10 @@ private:
         mBit1LowTicks = static_cast<u32>((timing.T3 + half_ns_per_tick) / ns_per_tick);
         mResetTicks = static_cast<u32>((timing.RESET * 1000ULL + half_ns_per_tick) / ns_per_tick);
 
-        FL_WARN("[RMT5_ENCODER] Timing config: resolution=" << resolution_hz
-                << "Hz, ns_per_tick=" << ns_per_tick);
-        FL_WARN("[RMT5_ENCODER] Bit0: high=" << mBit0HighTicks << " ticks, low=" << mBit0LowTicks << " ticks");
-        FL_WARN("[RMT5_ENCODER] Bit1: high=" << mBit1HighTicks << " ticks, low=" << mBit1LowTicks << " ticks");
-        FL_WARN("[RMT5_ENCODER] Reset: " << mResetTicks << " ticks");
+        FL_WARN_F("[RMT5_ENCODER] Timing config: resolution=%sHz, ns_per_tick=%s", resolution_hz, ns_per_tick);
+        FL_WARN_F("[RMT5_ENCODER] Bit0: high=%s ticks, low=%s ticks", mBit0HighTicks, mBit0LowTicks);
+        FL_WARN_F("[RMT5_ENCODER] Bit1: high=%s ticks, low=%s ticks", mBit1HighTicks, mBit1LowTicks);
+        FL_WARN_F("[RMT5_ENCODER] Reset: %s ticks", mResetTicks);
 
         rmt_bytes_encoder_config_t bytes_config = {};
         bytes_config.bit0.level0 = 1;
@@ -701,14 +697,14 @@ private:
 
         esp_err_t ret = rmt_new_bytes_encoder(&bytes_config, &mBytesEncoder);
         if (ret != ESP_OK) {
-            FL_WARN("[RMT5_ENCODER] Failed to create bytes encoder: " << esp_err_to_name(ret));
+            FL_WARN_F("[RMT5_ENCODER] Failed to create bytes encoder: %s", esp_err_to_name(ret));
             return ret;
         }
 
         rmt_copy_encoder_config_t copy_config = {};
         ret = rmt_new_copy_encoder(&copy_config, &mCopyEncoder);
         if (ret != ESP_OK) {
-            FL_WARN("[RMT5_ENCODER] Failed to create copy encoder: " << esp_err_to_name(ret));
+            FL_WARN_F("[RMT5_ENCODER] Failed to create copy encoder: %s", esp_err_to_name(ret));
             rmt_del_encoder(mBytesEncoder);
             mBytesEncoder = nullptr;
             return ret;
@@ -719,7 +715,7 @@ private:
         mResetCode.duration1 = 0;
         mResetCode.level1 = 0;
 
-        FL_WARN("[RMT5_ENCODER] Encoder created successfully");
+        FL_WARN_F("[RMT5_ENCODER] Encoder created successfully");
         return ESP_OK;
     }
 
@@ -756,11 +752,11 @@ void* Rmt5PeripheralESPImpl::createEncoder(const ChipsetTiming& timing,
                                             u32 resolution_hz) FL_NOEXCEPT {
     Rmt5EncoderImpl* encoder = Rmt5EncoderImpl::create(timing, resolution_hz);
     if (encoder == nullptr) {
-        FL_WARN("Rmt5PeripheralESP: Failed to create encoder");
+        FL_WARN_F("Rmt5PeripheralESP: Failed to create encoder");
         return nullptr;
     }
 
-    FL_LOG_RMT("RMT5_PERIPH: Encoder created successfully");
+    FL_LOG_RMT_F("RMT5_PERIPH: Encoder created successfully");
     return static_cast<void*>(encoder->getHandle());
 }
 
@@ -778,12 +774,12 @@ void Rmt5PeripheralESPImpl::deleteEncoder(void* encoder_handle) FL_NOEXCEPT {
         encoder->del(encoder);
     }
 
-    FL_LOG_RMT("RMT5_PERIPH: Encoder deleted successfully");
+    FL_LOG_RMT_F("RMT5_PERIPH: Encoder deleted successfully");
 }
 
 bool Rmt5PeripheralESPImpl::resetEncoder(void* encoder_handle) FL_NOEXCEPT {
     if (encoder_handle == nullptr) {
-        FL_WARN("Rmt5PeripheralESP: Invalid encoder handle (nullptr)");
+        FL_WARN_F("Rmt5PeripheralESP: Invalid encoder handle (nullptr)");
         return false;
     }
 
@@ -792,17 +788,17 @@ bool Rmt5PeripheralESPImpl::resetEncoder(void* encoder_handle) FL_NOEXCEPT {
 
     // Call the encoder's reset callback
     if (encoder->reset == nullptr) {
-        FL_WARN("Rmt5PeripheralESP: Encoder has no reset callback");
+        FL_WARN_F("Rmt5PeripheralESP: Encoder has no reset callback");
         return false;
     }
 
     esp_err_t err = encoder->reset(encoder);
     if (err != ESP_OK) {
-        FL_LOG_RMT("RMT5_PERIPH: Failed to reset encoder: " << esp_err_to_name(err));
+        FL_LOG_RMT_F("RMT5_PERIPH: Failed to reset encoder: %s", esp_err_to_name(err));
         return false;
     }
 
-    FL_LOG_RMT("RMT5_PERIPH: Encoder reset successfully");
+    FL_LOG_RMT_F("RMT5_PERIPH: Encoder reset successfully");
     return true;
 }
 

--- a/src/platforms/esp/32/drivers/rmt/rmt_5/rmt_memory_manager.cpp.hpp
+++ b/src/platforms/esp/32/drivers/rmt/rmt_5/rmt_memory_manager.cpp.hpp
@@ -34,32 +34,32 @@ void RmtMemoryManager::initPlatformLimits(size_t& total_tx, size_t& total_rx) FL
     // ESP32: 8 flexible channels × 64 words = 512 words SHARED global pool
     total_tx = 8 * SOC_RMT_MEM_WORDS_PER_CHANNEL;  // 512 words (global pool)
     total_rx = 0;  // Not used for global pool
-    FL_DBG("RMT Memory (ESP32): " << total_tx << " words GLOBAL POOL (shared TX/RX)");
+    FL_DBG_F("RMT Memory (ESP32): %s words GLOBAL POOL (shared TX/RX)", total_tx);
 
 #elif defined(FL_IS_ESP_32S2)
     // ESP32-S2: 4 flexible channels × 64 words = 256 words SHARED global pool
     total_tx = 4 * SOC_RMT_MEM_WORDS_PER_CHANNEL;  // 256 words (global pool)
     total_rx = 0;  // Not used for global pool
-    FL_DBG("RMT Memory (ESP32-S2): " << total_tx << " words GLOBAL POOL (shared TX/RX)");
+    FL_DBG_F("RMT Memory (ESP32-S2): %s words GLOBAL POOL (shared TX/RX)", total_tx);
 
 #elif defined(FL_IS_ESP_32S3)
     // ESP32-S3: 4 dedicated TX + 4 dedicated RX channels × 48 words
     total_tx = 4 * SOC_RMT_MEM_WORDS_PER_CHANNEL;  // 192 words (dedicated TX pool)
     total_rx = 4 * SOC_RMT_MEM_WORDS_PER_CHANNEL;  // 192 words (dedicated RX pool)
-    FL_DBG("RMT Memory (ESP32-S3): TX=" << total_tx << " words, RX=" << total_rx << " words (DEDICATED pools)");
+    FL_DBG_F("RMT Memory (ESP32-S3): TX=%s words, RX=%s words (DEDICATED pools)", total_tx, total_rx);
 
 #elif defined(FL_IS_ESP_32C3) || defined(FL_IS_ESP_32C6) || \
       defined(CONFIG_IDF_TARGET_ESP32H2) || defined(CONFIG_IDF_TARGET_ESP32C5)
     // ESP32-C3/C6/H2/C5: 2 dedicated TX + 2 dedicated RX channels × 48 words
     total_tx = 2 * SOC_RMT_MEM_WORDS_PER_CHANNEL;  // 96 words (dedicated TX pool)
     total_rx = 2 * SOC_RMT_MEM_WORDS_PER_CHANNEL;  // 96 words (dedicated RX pool)
-    FL_DBG("RMT Memory (ESP32-C3/C6/H2): TX=" << total_tx << " words, RX=" << total_rx << " words (DEDICATED pools)");
+    FL_DBG_F("RMT Memory (ESP32-C3/C6/H2): TX=%s words, RX=%s words (DEDICATED pools)", total_tx, total_rx);
 
 #else
     // Unknown platform - assume dedicated pools (conservative)
     total_tx = 2 * SOC_RMT_MEM_WORDS_PER_CHANNEL;  // Assume 2 TX channels
     total_rx = 2 * SOC_RMT_MEM_WORDS_PER_CHANNEL;  // Assume 2 RX channels
-    FL_WARN("RMT Memory (Unknown platform): TX=" << total_tx << " words, RX=" << total_rx << " words (assumed DEDICATED)");
+    FL_WARN_F("RMT Memory (Unknown platform): TX=%s words, RX=%s words (assumed DEDICATED)", total_tx, total_rx);
 #endif
 }
 
@@ -122,7 +122,7 @@ RmtMemoryManager::RmtMemoryManager(size_t total_tx, size_t total_rx, bool is_glo
         mLedger.allocated_words = 0;
         mLedger.total_tx_words = 0;
         mLedger.total_rx_words = 0;
-        FL_DBG("RMT Memory Manager (TEST): " << total_tx << " words GLOBAL POOL");
+        FL_DBG_F("RMT Memory Manager (TEST): %s words GLOBAL POOL", total_tx);
     } else {
         // Dedicated pool mode (ESP32-S3, C3, C6, H2)
         mLedger.total_tx_words = total_tx;
@@ -130,7 +130,7 @@ RmtMemoryManager::RmtMemoryManager(size_t total_tx, size_t total_rx, bool is_glo
         mLedger.allocated_tx_words = 0;
         mLedger.allocated_rx_words = 0;
         mLedger.total_words = 0;
-        FL_DBG("RMT Memory Manager (TEST): TX=" << total_tx << " words, RX=" << total_rx << " words (DEDICATED pools)");
+        FL_DBG_F("RMT Memory Manager (TEST): TX=%s words, RX=%s words (DEDICATED pools)", total_tx, total_rx);
     }
 }
 
@@ -265,13 +265,12 @@ size_t RmtMemoryManager::calculateMemoryBlocks(bool networkActive) FL_NOEXCEPT {
          channels_at_requested_rate < kMemoryPressureThreshold);
 
     if (memory_pressure) {
-        FL_LOG_RMT("Adaptive RMT allocation: Memory pressure detected");
-        FL_LOG_RMT("  Total TX: " << total_memory << " words, Allocated TX: " << allocated_memory
-                << " words (" << allocated_tx_channels << " TX channels)");
-        FL_LOG_RMT("  Available: " << available_memory << " words");
-        FL_LOG_RMT("  Requested: " << requested_blocks << " blocks (" << requested_words << " words)");
-        FL_LOG_RMT("  → At this rate, only " << channels_at_requested_rate << " TX channel(s) would fit");
-        FL_LOG_RMT("  → Reducing to 1 block (" << words_per_block << " words) for better channel density");
+        FL_LOG_RMT_F("Adaptive RMT allocation: Memory pressure detected");
+        FL_LOG_RMT_F("  Total TX: %s words, Allocated TX: %s words (%s TX channels)", total_memory, allocated_memory, allocated_tx_channels);
+        FL_LOG_RMT_F("  Available: %s words", available_memory);
+        FL_LOG_RMT_F("  Requested: %s blocks (%s words)", requested_blocks, requested_words);
+        FL_LOG_RMT_F("  → At this rate, only %s TX channel(s) would fit", channels_at_requested_rate);
+        FL_LOG_RMT_F("  → Reducing to 1 block (%s words) for better channel density", words_per_block);
         requested_blocks = 1;
     }
 
@@ -280,32 +279,25 @@ size_t RmtMemoryManager::calculateMemoryBlocks(bool networkActive) FL_NOEXCEPT {
     // Insufficient TX memory for triple-buffering (C3/C6/H2/C5: 2 TX channels)
     // Force cap to 2 blocks regardless of strategy
     if (requested_blocks > 2) {
-        FL_WARN("Platform limited to 2× buffering (SOC_RMT_TX_CANDIDATES_PER_GROUP="
-                << SOC_RMT_TX_CANDIDATES_PER_GROUP << "), capping from "
-                << requested_blocks << " to 2 blocks");
+        FL_WARN_F("Platform limited to 2× buffering (SOC_RMT_TX_CANDIDATES_PER_GROUP=%s), capping from %s to 2 blocks", SOC_RMT_TX_CANDIDATES_PER_GROUP, requested_blocks);
         requested_blocks = 2;
     }
 #else
     // Sufficient TX memory for network-aware allocation
     // Validate requested blocks do not exceed platform maximum
     if (requested_blocks > max_blocks) {
-        FL_WARN("Requested " << requested_blocks << " blocks exceeds platform max "
-                << max_blocks << " (SOC_RMT_TX_CANDIDATES_PER_GROUP), capping to "
-                << max_blocks);
+        FL_WARN_F("Requested %s blocks exceeds platform max %s (SOC_RMT_TX_CANDIDATES_PER_GROUP), capping to %s", requested_blocks, max_blocks, max_blocks);
         requested_blocks = max_blocks;
     }
 #endif
 
     // Ensure minimum 1 block
     if (requested_blocks == 0) {
-        FL_WARN("Zero blocks requested, clamping to minimum 1 block");
+        FL_WARN_F("Zero blocks requested, clamping to minimum 1 block");
         requested_blocks = 1;
     }
 
-    FL_DBG("calculateMemoryBlocks(networkActive=" << networkActive
-           << "): using " << requested_blocks << " blocks (idle=" << idleBlocks
-           << ", network=" << networkBlocks << ", max=" << max_blocks
-           << ", allocated_tx_channels=" << allocated_tx_channels << ")");
+    FL_DBG_F("calculateMemoryBlocks(networkActive=%s): using %s blocks (idle=%s, network=%s, max=%s, allocated_tx_channels=%s)", networkActive, requested_blocks, idleBlocks, networkBlocks, max_blocks, allocated_tx_channels);
 
     return requested_blocks;
 #endif // FASTLED_RMT_STATIC_ALLOCATION
@@ -318,23 +310,21 @@ void RmtMemoryManager::setMemoryBlockStrategy(size_t idleBlocks, size_t networkB
 
     // Zero-block validation: clamp to minimum 1 block
     if (idleBlocks == 0) {
-        FL_WARN("RMT setMemoryBlockStrategy: idleBlocks=0 invalid, clamping to 1");
+        FL_WARN_F("RMT setMemoryBlockStrategy: idleBlocks=0 invalid, clamping to 1");
         idleBlocks = 1;
     }
     if (networkBlocks == 0) {
-        FL_WARN("RMT setMemoryBlockStrategy: networkBlocks=0 invalid, clamping to 1");
+        FL_WARN_F("RMT setMemoryBlockStrategy: networkBlocks=0 invalid, clamping to 1");
         networkBlocks = 1;
     }
 
     // Platform limit validation: cap to max_blocks
     if (idleBlocks > max_blocks) {
-        FL_WARN("RMT setMemoryBlockStrategy: idleBlocks=" << idleBlocks
-                << " exceeds platform limit=" << max_blocks << ", capping");
+        FL_WARN_F("RMT setMemoryBlockStrategy: idleBlocks=%s exceeds platform limit=%s, capping", idleBlocks, max_blocks);
         idleBlocks = max_blocks;
     }
     if (networkBlocks > max_blocks) {
-        FL_WARN("RMT setMemoryBlockStrategy: networkBlocks=" << networkBlocks
-                << " exceeds platform limit=" << max_blocks << ", capping");
+        FL_WARN_F("RMT setMemoryBlockStrategy: networkBlocks=%s exceeds platform limit=%s, capping", networkBlocks, max_blocks);
         networkBlocks = max_blocks;
     }
 
@@ -342,7 +332,7 @@ void RmtMemoryManager::setMemoryBlockStrategy(size_t idleBlocks, size_t networkB
     mIdleBlocks = idleBlocks;
     mNetworkBlocks = networkBlocks;
 
-    FL_DBG("RMT Memory Strategy updated: idle=" << idleBlocks << "×, network=" << networkBlocks << "×");
+    FL_DBG_F("RMT Memory Strategy updated: idle=%s×, network=%s×", idleBlocks, networkBlocks);
 }
 
 void RmtMemoryManager::getMemoryBlockStrategy(size_t& idleBlocks, size_t& networkBlocks) const FL_NOEXCEPT {
@@ -354,7 +344,7 @@ void RmtMemoryManager::getMemoryBlockStrategy(size_t& idleBlocks, size_t& networ
 result<size_t, RmtMemoryError> RmtMemoryManager::allocateTx(u8 channel_id, bool use_dma, bool networkActive) FL_NOEXCEPT {
     // Check if channel already allocated
     if (findAllocation(channel_id, true) != nullptr) {
-        FL_WARN("RMT TX channel " << static_cast<int>(channel_id) << " already allocated");
+        FL_WARN_F("RMT TX channel %s already allocated", static_cast<int>(channel_id));
         return result<size_t, RmtMemoryError>::failure(RmtMemoryError::CHANNEL_ALREADY_ALLOCATED);
     }
 
@@ -372,22 +362,18 @@ result<size_t, RmtMemoryError> RmtMemoryManager::allocateTx(u8 channel_id, bool 
         // ESP32-S3: DMA channel consumes 1 memory block (48 words)
         size_t dma_words = SOC_RMT_MEM_WORDS_PER_CHANNEL;
         if (!tryAllocateWords(dma_words, true)) {
-            FL_WARN("RMT TX DMA allocation failed for channel "
-                    << static_cast<int>(channel_id)
-                    << " - insufficient on-chip memory");
-            FL_WARN("  Requested: " << dma_words << " words (1 block for DMA descriptor)");
-            FL_WARN("  Available: " << getAvailableWords(true) << " words");
+            FL_WARN_F("RMT TX DMA allocation failed for channel %s - insufficient on-chip memory", static_cast<int>(channel_id));
+            FL_WARN_F("  Requested: %s words (1 block for DMA descriptor)", dma_words);
+            FL_WARN_F("  Available: %s words", getAvailableWords(true));
             return result<size_t, RmtMemoryError>::failure(RmtMemoryError::INSUFFICIENT_TX_MEMORY);
         }
         mLedger.allocations.push_back(ChannelAllocation(channel_id, dma_words, true, true));
-        FL_LOG_RMT("RMT TX channel " << static_cast<int>(channel_id)
-                   << " allocated (DMA, " << dma_words << " words for descriptor)");
+        FL_LOG_RMT_F("RMT TX channel %s allocated (DMA, %s words for descriptor)", static_cast<int>(channel_id), dma_words);
         return result<size_t, RmtMemoryError>::success(dma_words);
 #else
         // Other platforms (if DMA supported): Assume DMA bypasses on-chip memory
         mLedger.allocations.push_back(ChannelAllocation(channel_id, 0, true, true));
-        FL_LOG_RMT("RMT TX channel " << static_cast<int>(channel_id)
-                   << " allocated (DMA, bypasses on-chip memory)");
+        FL_LOG_RMT_F("RMT TX channel %s allocated (DMA, bypasses on-chip memory)", static_cast<int>(channel_id));
         return result<size_t, RmtMemoryError>::success(0);
 #endif
     }
@@ -407,9 +393,7 @@ result<size_t, RmtMemoryError> RmtMemoryManager::allocateTx(u8 channel_id, bool 
 
     mLedger.allocations.push_back(ChannelAllocation(channel_id, words_needed, true, false));
 
-    FL_LOG_RMT("RMT TX channel " << static_cast<int>(channel_id)
-               << " allocated: " << words_needed << " words (" << mem_blocks << "× buffer"
-               << (networkActive ? ", Network mode" : "") << ")");
+    FL_LOG_RMT_F("RMT TX channel %s allocated: %s words (%s× buffer%s)", static_cast<int>(channel_id), words_needed, mem_blocks, (networkActive ? ", Network mode" : ""));
 
     return result<size_t, RmtMemoryError>::success(words_needed);
 }
@@ -433,18 +417,17 @@ RmtMemoryManager::handleAllocateTxFailure(u8 channel_id, size_t mem_blocks,
         size_t fallback_blocks = 1;
         size_t fallback_words = fallback_blocks * SOC_RMT_MEM_WORDS_PER_CHANNEL;
 
-        FL_LOG_RMT("RMT TX allocation failed with " << mem_blocks << "× buffering (" << words_needed << " words)");
-        FL_LOG_RMT("  Attempting fallback to " << fallback_blocks << "× buffering (" << fallback_words << " words)...");
+        FL_LOG_RMT_F("RMT TX allocation failed with %s× buffering (%s words)", mem_blocks, words_needed);
+        FL_LOG_RMT_F("  Attempting fallback to %s× buffering (%s words)...", fallback_blocks, fallback_words);
 
         if (tryAllocateWords(fallback_words, true)) {
-            FL_LOG_RMT("  [OK] Fallback successful: allocated " << fallback_words << " words (single-buffer mode)");
+            FL_LOG_RMT_F("  [OK] Fallback successful: allocated %s words (single-buffer mode)", fallback_words);
             mLedger.allocations.push_back(ChannelAllocation(channel_id, fallback_words, true, false));
-            FL_LOG_RMT("RMT TX channel " << static_cast<int>(channel_id)
-                       << " allocated (non-DMA, " << fallback_words << " words, single-buffer)");
+            FL_LOG_RMT_F("RMT TX channel %s allocated (non-DMA, %s words, single-buffer)", static_cast<int>(channel_id), fallback_words);
             return result<size_t, RmtMemoryError>::success(fallback_words);
         }
 
-        FL_LOG_RMT("  [FAIL] Fallback failed: insufficient memory even for single-buffer");
+        FL_LOG_RMT_F("  [FAIL] Fallback failed: insufficient memory even for single-buffer");
     }
 
     // Fallback failed or not attempted - provide detailed diagnostic message.
@@ -458,25 +441,22 @@ RmtMemoryManager::handleAllocateTxFailure(u8 channel_id, size_t mem_blocks,
     size_t reserved = mLedger.reserved_tx_words;
     size_t available = getAvailableWords(true);
 
-    FL_WARN("RMT TX allocation failed for channel " << static_cast<int>(channel_id));
-    FL_WARN("  Requested: " << words_needed << " words (" << mem_blocks << "× buffer"
-            << (networkActive ? ", Network mode" : "") << ")");
-    FL_WARN("  Available: " << available << " words");
-    FL_WARN("  Memory breakdown: Total=" << total << ", Allocated=" << allocated
-            << ", Reserved=" << reserved << " (external RMT usage)");
+    FL_WARN_F("RMT TX allocation failed for channel %s", static_cast<int>(channel_id));
+    FL_WARN_F("  Requested: %s words (%s× buffer%s)", words_needed, mem_blocks, (networkActive ? ", Network mode" : ""));
+    FL_WARN_F("  Available: %s words", available);
+    FL_WARN_F("  Memory breakdown: Total=%s, Allocated=%s, Reserved=%s (external RMT usage)", total, allocated, reserved);
 
     if (reserved > 0) {
-        FL_WARN("  Suggestion: " << reserved << " words reserved by external RMT usage (e.g., USB CDC)");
-        FL_WARN("              Consider using DMA channels (use_dma=true) to bypass on-chip memory");
+        FL_WARN_F("  Suggestion: %s words reserved by external RMT usage (e.g., USB CDC)", reserved);
+        FL_WARN_F("              Consider using DMA channels (use_dma=true) to bypass on-chip memory");
     }
     if (allocated > 0) {
-        FL_WARN("  Suggestion: " << allocated << " words already allocated to other channels");
-        FL_WARN("              Consider reducing LED count or using fewer channels");
+        FL_WARN_F("  Suggestion: %s words already allocated to other channels", allocated);
+        FL_WARN_F("              Consider reducing LED count or using fewer channels");
     }
     if (mem_blocks > 2 && networkActive) {
-        FL_WARN("  Suggestion: Network mode uses 3× buffering (" << (mem_blocks * SOC_RMT_MEM_WORDS_PER_CHANNEL)
-                << " words per channel)");
-        FL_WARN("              Consider disabling network or using DMA channels");
+        FL_WARN_F("  Suggestion: Network mode uses 3× buffering (%s words per channel)", (mem_blocks * SOC_RMT_MEM_WORDS_PER_CHANNEL));
+        FL_WARN_F("              Consider disabling network or using DMA channels");
     }
 #endif
 
@@ -486,15 +466,14 @@ RmtMemoryManager::handleAllocateTxFailure(u8 channel_id, size_t mem_blocks,
 result<size_t, RmtMemoryError> RmtMemoryManager::allocateRx(u8 channel_id, size_t symbols, bool use_dma) FL_NOEXCEPT {
     // Check if channel already allocated
     if (findAllocation(channel_id, false) != nullptr) {
-        FL_WARN("RMT RX channel " << static_cast<int>(channel_id) << " already allocated");
+        FL_WARN_F("RMT RX channel %s already allocated", static_cast<int>(channel_id));
         return result<size_t, RmtMemoryError>::failure(RmtMemoryError::CHANNEL_ALREADY_ALLOCATED);
     }
 
     // DMA channels bypass on-chip memory (use DRAM instead)
     if (use_dma) {
         mLedger.allocations.push_back(ChannelAllocation(channel_id, 0, false, true));
-        FL_LOG_RMT("RMT RX channel " << static_cast<int>(channel_id)
-                   << " allocated (DMA, bypasses on-chip memory, uses DRAM buffer)");
+        FL_LOG_RMT_F("RMT RX channel %s allocated (DMA, bypasses on-chip memory, uses DRAM buffer)", static_cast<int>(channel_id));
         return result<size_t, RmtMemoryError>::success(0);
     }
 
@@ -509,20 +488,19 @@ result<size_t, RmtMemoryError> RmtMemoryManager::allocateRx(u8 channel_id, size_
         size_t reserved = mLedger.reserved_rx_words;
         size_t available = getAvailableWords(false);
 
-        FL_WARN("RMT RX allocation failed for channel " << static_cast<int>(channel_id));
-        FL_WARN("  Requested: " << words_needed << " words (" << symbols << " symbols)");
-        FL_WARN("  Available: " << available << " words");
-        FL_WARN("  Memory breakdown: Total=" << total << ", Allocated=" << allocated
-                << ", Reserved=" << reserved << " (external RMT usage)");
+        FL_WARN_F("RMT RX allocation failed for channel %s", static_cast<int>(channel_id));
+        FL_WARN_F("  Requested: %s words (%s symbols)", words_needed, symbols);
+        FL_WARN_F("  Available: %s words", available);
+        FL_WARN_F("  Memory breakdown: Total=%s, Allocated=%s, Reserved=%s (external RMT usage)", total, allocated, reserved);
 
         // Provide actionable suggestions
         if (reserved > 0) {
-            FL_WARN("  Suggestion: " << reserved << " words reserved by external RMT usage");
-            FL_WARN("              Consider using DMA channels (use_dma=true) to bypass on-chip memory");
+            FL_WARN_F("  Suggestion: %s words reserved by external RMT usage", reserved);
+            FL_WARN_F("              Consider using DMA channels (use_dma=true) to bypass on-chip memory");
         }
         if (allocated > 0) {
-            FL_WARN("  Suggestion: " << allocated << " words already allocated to other channels");
-            FL_WARN("              Consider reducing symbol count or using fewer channels");
+            FL_WARN_F("  Suggestion: %s words already allocated to other channels", allocated);
+            FL_WARN_F("              Consider reducing symbol count or using fewer channels");
         }
 
         return result<size_t, RmtMemoryError>::failure(RmtMemoryError::INSUFFICIENT_RX_MEMORY);
@@ -530,8 +508,7 @@ result<size_t, RmtMemoryError> RmtMemoryManager::allocateRx(u8 channel_id, size_
 
     mLedger.allocations.push_back(ChannelAllocation(channel_id, words_needed, false, false));
 
-    FL_LOG_RMT("RMT RX channel " << static_cast<int>(channel_id)
-               << " allocated: " << words_needed << " words (" << symbols << " symbols)");
+    FL_LOG_RMT_F("RMT RX channel %s allocated: %s words (%s symbols)", static_cast<int>(channel_id), words_needed, symbols);
 
     return result<size_t, RmtMemoryError>::success(words_needed);
 }
@@ -569,17 +546,14 @@ void RmtMemoryManager::free(u8 channel_id, bool is_tx) FL_NOEXCEPT {
 #else
     ChannelAllocation* alloc = findAllocation(channel_id, is_tx);
     if (!alloc) {
-        FL_WARN("RMT " << (is_tx ? "TX" : "RX") << " channel "
-                << static_cast<int>(channel_id) << " not found in allocations");
+        FL_WARN_F("RMT %s channel %s not found in allocations", (is_tx ? "TX" : "RX"), static_cast<int>(channel_id));
         return;
     }
 
     // Free words from appropriate pool (DMA channels have 0 words, so this is safe)
     freeWords(alloc->words, is_tx);
 
-    FL_LOG_RMT("RMT " << (is_tx ? "TX" : "RX") << " channel "
-               << static_cast<int>(channel_id) << " freed: " << alloc->words << " words"
-               << (alloc->is_dma ? " (DMA)" : ""));
+    FL_LOG_RMT_F("RMT %s channel %s freed: %s words%s", (is_tx ? "TX" : "RX"), static_cast<int>(channel_id), alloc->words, (alloc->is_dma ? " (DMA)" : ""));
 
     // Remove from allocations vector
     for (auto it = mLedger.allocations.begin(); it != mLedger.allocations.end(); ++it) {
@@ -595,8 +569,7 @@ void RmtMemoryManager::recordRecoveryAllocation(u8 channel_id, size_t words, boo
     // Check if already exists (shouldn't, but be safe)
     ChannelAllocation* existing = findAllocation(channel_id, is_tx);
     if (existing) {
-        FL_WARN("RMT " << (is_tx ? "TX" : "RX") << " channel "
-                << static_cast<int>(channel_id) << " already has allocation during recovery");
+        FL_WARN_F("RMT %s channel %s already has allocation during recovery", (is_tx ? "TX" : "RX"), static_cast<int>(channel_id));
         return;
     }
 
@@ -615,9 +588,7 @@ void RmtMemoryManager::recordRecoveryAllocation(u8 channel_id, size_t words, boo
         }
     }
 
-    FL_LOG_RMT("RMT " << (is_tx ? "TX" : "RX") << " channel "
-               << static_cast<int>(channel_id) << " recovery allocation recorded: "
-               << words << " words");
+    FL_LOG_RMT_F("RMT %s channel %s recovery allocation recorded: %s words", (is_tx ? "TX" : "RX"), static_cast<int>(channel_id), words);
 }
 
 size_t RmtMemoryManager::availableTxWords() const FL_NOEXCEPT {
@@ -647,7 +618,7 @@ size_t RmtMemoryManager::getAllocatedWords(u8 channel_id, bool is_tx) const FL_N
 }
 
 void RmtMemoryManager::reset() FL_NOEXCEPT {
-    FL_LOG_RMT("RMT Memory Manager reset - clearing all allocations");
+    FL_LOG_RMT_F("RMT Memory Manager reset - clearing all allocations");
 
     // Reset appropriate fields based on pool architecture
     if (mLedger.is_global_pool) {
@@ -756,9 +727,7 @@ bool RmtMemoryManager::isDMAAvailable() const FL_NOEXCEPT {
 bool RmtMemoryManager::allocateDMA(u8 channel_id, bool is_tx) FL_NOEXCEPT {
 #if FASTLED_RMT5_DMA_SUPPORTED
     if (mDMAAllocation.allocated) {
-        FL_WARN("DMA allocation failed: DMA already allocated to "
-                << (mDMAAllocation.is_tx ? "TX" : "RX") << " channel "
-                << static_cast<int>(mDMAAllocation.channel_id));
+        FL_WARN_F("DMA allocation failed: DMA already allocated to %s channel %s", (mDMAAllocation.is_tx ? "TX" : "RX"), static_cast<int>(mDMAAllocation.channel_id));
         return false;
     }
 
@@ -766,9 +735,7 @@ bool RmtMemoryManager::allocateDMA(u8 channel_id, bool is_tx) FL_NOEXCEPT {
     mDMAAllocation.is_tx = is_tx;
     mDMAAllocation.allocated = true;
 
-    FL_LOG_RMT("DMA allocated to " << (is_tx ? "TX" : "RX") << " channel "
-               << static_cast<int>(channel_id)
-               << " | DMA slots: 1/" << FASTLED_RMT5_MAX_DMA_CHANNELS);
+    FL_LOG_RMT_F("DMA allocated to %s channel %s | DMA slots: 1/%s", (is_tx ? "TX" : "RX"), static_cast<int>(channel_id), FASTLED_RMT5_MAX_DMA_CHANNELS);
     return true;
 #else
     (void)channel_id;
@@ -787,22 +754,16 @@ void RmtMemoryManager::freeDMA(u8 channel_id, bool is_tx) FL_NOEXCEPT {
     (void)is_tx;
 #elif FASTLED_RMT5_DMA_SUPPORTED
     if (!mDMAAllocation.allocated) {
-        FL_WARN("DMA free called but no DMA allocated");
+        FL_WARN_F("DMA free called but no DMA allocated");
         return;
     }
 
     if (mDMAAllocation.channel_id != channel_id || mDMAAllocation.is_tx != is_tx) {
-        FL_WARN("DMA free mismatch: expected "
-                << (mDMAAllocation.is_tx ? "TX" : "RX") << " channel "
-                << static_cast<int>(mDMAAllocation.channel_id)
-                << ", got " << (is_tx ? "TX" : "RX") << " channel "
-                << static_cast<int>(channel_id));
+        FL_WARN_F("DMA free mismatch: expected %s channel %s, got %s channel %s", (mDMAAllocation.is_tx ? "TX" : "RX"), static_cast<int>(mDMAAllocation.channel_id), (is_tx ? "TX" : "RX"), static_cast<int>(channel_id));
         return;
     }
 
-    FL_LOG_RMT("DMA freed from " << (is_tx ? "TX" : "RX") << " channel "
-               << static_cast<int>(channel_id)
-               << " | DMA slots: 0/" << FASTLED_RMT5_MAX_DMA_CHANNELS);
+    FL_LOG_RMT_F("DMA freed from %s channel %s | DMA slots: 0/%s", (is_tx ? "TX" : "RX"), static_cast<int>(channel_id), FASTLED_RMT5_MAX_DMA_CHANNELS);
 
     mDMAAllocation.allocated = false;
     mDMAAllocation.channel_id = 0;
@@ -855,19 +816,12 @@ void RmtMemoryManager::reserveExternalMemory(size_t tx_words, size_t rx_words) F
 
     if (mLedger.is_global_pool) {
         size_t total_reserved = tx_words + rx_words;
-        FL_DBG("RMT External Reservation (GLOBAL pool): " << total_reserved
-               << " words (TX:" << tx_words << " + RX:" << rx_words << ")");
-        FL_DBG("  Available after reservation: "
-               << (mLedger.total_words > total_reserved ? mLedger.total_words - total_reserved : 0)
-               << "/" << mLedger.total_words << " words");
+        FL_DBG_F("RMT External Reservation (GLOBAL pool): %s words (TX:%s + RX:%s)", total_reserved, tx_words, rx_words);
+        FL_DBG_F("  Available after reservation: %s/%s words", (mLedger.total_words > total_reserved ? mLedger.total_words - total_reserved : 0), mLedger.total_words);
     } else {
-        FL_DBG("RMT External Reservation (DEDICATED pools):");
-        FL_DBG("  TX: " << tx_words << " words reserved, "
-               << (mLedger.total_tx_words > tx_words ? mLedger.total_tx_words - tx_words : 0)
-               << "/" << mLedger.total_tx_words << " available");
-        FL_DBG("  RX: " << rx_words << " words reserved, "
-               << (mLedger.total_rx_words > rx_words ? mLedger.total_rx_words - rx_words : 0)
-               << "/" << mLedger.total_rx_words << " available");
+        FL_DBG_F("RMT External Reservation (DEDICATED pools):");
+        FL_DBG_F("  TX: %s words reserved, %s/%s available", tx_words, (mLedger.total_tx_words > tx_words ? mLedger.total_tx_words - tx_words : 0), mLedger.total_tx_words);
+        FL_DBG_F("  RX: %s words reserved, %s/%s available", rx_words, (mLedger.total_rx_words > rx_words ? mLedger.total_rx_words - rx_words : 0), mLedger.total_rx_words);
     }
 }
 

--- a/src/platforms/esp/32/drivers/rmt_rx/rmt_rx_channel.cpp.hpp
+++ b/src/platforms/esp/32/drivers/rmt_rx/rmt_rx_channel.cpp.hpp
@@ -1,4 +1,4 @@
-// IWYU pragma: private
+﻿// IWYU pragma: private
 
 #include "platforms/esp/32/drivers/rmt_rx/rmt_rx_channel.h"
 
@@ -82,7 +82,7 @@ namespace {
  */
 inline u32 ticksToNs(u32 ticks, u32 ns_per_tick) {
     // Convert RMT ticks to nanoseconds
-    // Example: 16 ticks × 25 ns/tick = 400ns
+    // Example: 16 ticks Ã— 25 ns/tick = 400ns
     return ticks * ns_per_tick;
 }
 
@@ -112,13 +112,11 @@ inline bool isResetPulse(RmtSymbol symbol, const ChipsetTiming4Phase &timing,
     // Reset pulse should have level=0 (low) for the long duration
     // Check duration0 with level0=0, or duration1 with level1=0
     if (rmt_sym.level0 == 0 && duration0_ns >= reset_min_ns) {
-        FL_WARN("isResetPulse DETECTED: duration0=" << duration0_ns << "ns (level0=0), reset_min="
-               << reset_min_ns << "ns (" << timing.reset_min_us << "us)");
+        FL_WARN_F("isResetPulse DETECTED: duration0=%sns (level0=0), reset_min=%sns (%sus)", duration0_ns, reset_min_ns, timing.reset_min_us);
         return true;
     }
     if (rmt_sym.level1 == 0 && duration1_ns >= reset_min_ns) {
-        FL_WARN("isResetPulse DETECTED: duration1=" << duration1_ns << "ns (level1=0), reset_min="
-               << reset_min_ns << "ns (" << timing.reset_min_us << "us)");
+        FL_WARN_F("isResetPulse DETECTED: duration1=%sns (level1=0), reset_min=%sns (%sus)", duration1_ns, reset_min_ns, timing.reset_min_us);
         return true;
     }
 
@@ -163,16 +161,14 @@ inline bool isGapPulse(RmtSymbol symbol, const ChipsetTiming4Phase &timing,
     // Check duration1 (most common case - gap at end of bit sequence)
     if (rmt_sym.level1 == 0 && duration1_ns > timing.t0l_max_ns &&
         duration1_ns <= timing.gap_tolerance_ns) {
-        FL_WARN("isGapPulse DETECTED: duration1=" << duration1_ns << "ns (level1=0), t0l_max="
-               << timing.t0l_max_ns << "ns, gap_tolerance=" << timing.gap_tolerance_ns << "ns");
+        FL_WARN_F("isGapPulse DETECTED: duration1=%sns (level1=0), t0l_max=%sns, gap_tolerance=%sns", duration1_ns, timing.t0l_max_ns, timing.gap_tolerance_ns);
         return true;
     }
 
     // Check duration0 (less common - gap at start)
     if (rmt_sym.level0 == 0 && duration0_ns > timing.t0l_max_ns &&
         duration0_ns <= timing.gap_tolerance_ns) {
-        FL_WARN("isGapPulse DETECTED: duration0=" << duration0_ns << "ns (level0=0), t0l_max="
-               << timing.t0l_max_ns << "ns, gap_tolerance=" << timing.gap_tolerance_ns << "ns");
+        FL_WARN_F("isGapPulse DETECTED: duration0=%sns (level0=0), t0l_max=%sns, gap_tolerance=%sns", duration0_ns, timing.t0l_max_ns, timing.gap_tolerance_ns);
         return true;
     }
 
@@ -202,8 +198,7 @@ inline int decodeBit(RmtSymbol symbol, const ChipsetTiming4Phase &timing,
     // Check if levels match expected pattern (high=1, low=0)
     if (rmt_sym.level0 != 1 || rmt_sym.level1 != 0) {
         // Unexpected level pattern - possibly inverted signal or noise
-        FL_WARN("decodeBit REJECTED: Invalid level pattern (level0=" << static_cast<int>(rmt_sym.level0)
-               << ", level1=" << static_cast<int>(rmt_sym.level1) << ") - expected level0=1, level1=0");
+        FL_WARN_F("decodeBit REJECTED: Invalid level pattern (level0=%s, level1=%s) - expected level0=1, level1=0", static_cast<int>(rmt_sym.level0), static_cast<int>(rmt_sym.level1));
         return -1;
     }
 
@@ -228,13 +223,9 @@ inline int decodeBit(RmtSymbol symbol, const ChipsetTiming4Phase &timing,
     }
 
     // Timing doesn't match either pattern - log detailed rejection reason
-    FL_WARN("decodeBit REJECTED: Timing mismatch (high=" << high_ns << "ns, low=" << low_ns << "ns)");
-    FL_WARN("  Bit0 thresholds: t0h=[" << timing.t0h_min_ns << "-" << timing.t0h_max_ns
-           << "]ns (match=" << t0h_match << "), t0l=[" << timing.t0l_min_ns << "-" << timing.t0l_max_ns
-           << "]ns (match=" << t0l_match << ")");
-    FL_WARN("  Bit1 thresholds: t1h=[" << timing.t1h_min_ns << "-" << timing.t1h_max_ns
-           << "]ns (match=" << t1h_match << "), t1l=[" << timing.t1l_min_ns << "-" << timing.t1l_max_ns
-           << "]ns (match=" << t1l_match << ")");
+    FL_WARN_F("decodeBit REJECTED: Timing mismatch (high=%sns, low=%sns)", high_ns, low_ns);
+    FL_WARN_F("  Bit0 thresholds: t0h=[%s-%s]ns (match=%s), t0l=[%s-%s]ns (match=%s)", timing.t0h_min_ns, timing.t0h_max_ns, t0h_match, timing.t0l_min_ns, timing.t0l_max_ns, t0l_match);
+    FL_WARN_F("  Bit1 thresholds: t1h=[%s-%s]ns (match=%s), t1l=[%s-%s]ns (match=%s)", timing.t1h_min_ns, timing.t1h_max_ns, t1h_match, timing.t1l_min_ns, timing.t1l_max_ns, t1l_match);
 
     return -1; // Invalid
 }
@@ -254,19 +245,19 @@ decodeRmtSymbols(const ChipsetTiming4Phase &timing, u32 resolution_hz,
                  fl::span<const RmtSymbol> symbols, fl::span<u8> bytes_out,
                  bool start_low = true) {
     if (symbols.empty()) {
-        FL_WARN("decodeRmtSymbols: symbols span is empty");
+        FL_WARN_F("decodeRmtSymbols: symbols span is empty");
         return fl::result<u32, DecodeError>::failure(
             DecodeError::INVALID_ARGUMENT);
     }
 
     if (bytes_out.empty()) {
-        FL_WARN("decodeRmtSymbols: bytes_out span is empty");
+        FL_WARN_F("decodeRmtSymbols: bytes_out span is empty");
         return fl::result<u32, DecodeError>::failure(
             DecodeError::INVALID_ARGUMENT);
     }
 
     // Calculate nanoseconds per tick for efficient conversion
-    // Example: 40MHz = 40,000,000 Hz → 1,000,000,000 / 40,000,000 = 25ns per
+    // Example: 40MHz = 40,000,000 Hz â†’ 1,000,000,000 / 40,000,000 = 25ns per
     // tick
     u32 ns_per_tick = 1000000000UL / resolution_hz;
 
@@ -319,8 +310,8 @@ decodeRmtSymbols(const ChipsetTiming4Phase &timing, u32 resolution_hz,
     //
     // EVIDENCE: Hex dump shows pattern "ff 00 00 00" repeating (R=255, G=0,
     // B=0, SPURIOUS=0x00)
-    // - Expected: 24 symbols/LED × 255 LEDs = 6120 symbols total
-    // - Actual: 32 symbols/LED × 255 LEDs = 8160 symbols total (33% overhead)
+    // - Expected: 24 symbols/LED Ã— 255 LEDs = 6120 symbols total
+    // - Actual: 32 symbols/LED Ã— 255 LEDs = 8160 symbols total (33% overhead)
     //
     // ROOT CAUSE: Unknown - could be TX encoder adding padding, RX capture
     // artifact, or timing peculiarity of the test setup. The extra 8 symbols
@@ -346,8 +337,7 @@ decodeRmtSymbols(const ChipsetTiming4Phase &timing, u32 resolution_hz,
 
             // Flush partial byte if needed
             if (bit_index != 0) {
-                FL_WARN("decodeRmtSymbols: partial byte at reset (bit_index="
-                        << bit_index << "), flushing");
+                FL_WARN_F("decodeRmtSymbols: partial byte at reset (bit_index=%s), flushing", bit_index);
                 // Shift remaining bits to MSB position
                 current_byte <<= (8 - bit_index);
 
@@ -448,8 +438,7 @@ decodeRmtSymbols(const ChipsetTiming4Phase &timing, u32 resolution_hz,
 #endif
             } else {
                 // Buffer full, stop decoding
-                FL_WARN("decodeRmtSymbols: output buffer overflow at byte "
-                        << bytes_decoded);
+                FL_WARN_F("decodeRmtSymbols: output buffer overflow at byte %s", bytes_decoded);
                 buffer_overflow = true;
                 break;
             }
@@ -483,15 +472,13 @@ decodeRmtSymbols(const ChipsetTiming4Phase &timing, u32 resolution_hz,
 
     // Determine error type and return Result
     if (buffer_overflow) {
-        FL_WARN("decodeRmtSymbols: buffer overflow - output buffer too small");
+        FL_WARN_F("decodeRmtSymbols: buffer overflow - output buffer too small");
         return fl::result<u32, DecodeError>::failure(
             DecodeError::BUFFER_OVERFLOW);
     }
 
     if (error_count >= (symbols.size() / 10)) {
-        FL_WARN("decodeRmtSymbols: high error rate: "
-                << error_count << "/" << symbols.size() << " symbols ("
-                << (100 * error_count / symbols.size()) << "%)");
+        FL_WARN_F("decodeRmtSymbols: high error rate: %s/%s symbols (%s%)", error_count, symbols.size(), (100 * error_count / symbols.size()));
         return fl::result<u32, DecodeError>::failure(
             DecodeError::HIGH_ERROR_RATE);
     }
@@ -572,15 +559,14 @@ class RmtRxChannelImpl : public RmtRxChannel {
         auto &memMgr = RmtMemoryManager::instance();
         mMemoryChannelId = static_cast<u8>(128 + (mPin & 0x7F));
         constexpr u32 kMinRxSymbols = 64;  // Minimum RX buffer size
-        // Status-code variant (#2856 item 3.5) — call site only needs success/fail.
+        // Status-code variant (#2856 item 3.5) â€” call site only needs success/fail.
         size_t alloc_words = 0;
         if (memMgr.tryAllocateRx(mMemoryChannelId, kMinRxSymbols, false, alloc_words)) {
             mMemoryRegistered = true;
             FL_LOG_RX("RMT RX pre-registered with memory manager in constructor (channel_id="
                       << static_cast<int>(mMemoryChannelId) << ")");
         } else {
-            FL_WARN("RMT RX failed to pre-register with memory manager (channel_id="
-                    << static_cast<int>(mMemoryChannelId) << ")");
+            FL_WARN_F("RMT RX failed to pre-register with memory manager (channel_id=%s)", static_cast<int>(mMemoryChannelId));
         }
     }
 
@@ -621,15 +607,12 @@ class RmtRxChannelImpl : public RmtRxChannel {
 
     bool begin(const RxConfig &config) FL_NOEXCEPT override {
         // If the DMA setting changed on an already-created channel, we have to
-        // tear it down — ESP-IDF bakes `flags.with_dma` into the channel at
+        // tear it down â€” ESP-IDF bakes `flags.with_dma` into the channel at
         // rmt_new_rx_channel() time, so toggling on a later begin() is a no-op
         // unless we rebuild. Also release the shared DMA slot and any DRAM
         // capture buffer so first-time init below allocates cleanly.
         if (mChannel && config.use_dma != mUseDma) {
-            FL_WARN("[RMT RX] use_dma changed ("
-                    << (mUseDma ? "true" : "false") << " -> "
-                    << (config.use_dma ? "true" : "false")
-                    << ") - rebuilding channel");
+            FL_WARN_F("[RMT RX] use_dma changed (%s -> %s) - rebuilding channel", (mUseDma ? "true" : "false"), (config.use_dma ? "true" : "false"));
             rmt_disable(mChannel);
             rmt_del_channel(mChannel);
             mChannel = nullptr;
@@ -655,8 +638,7 @@ class RmtRxChannelImpl : public RmtRxChannel {
             // First-time initialization - extract hardware parameters from
             // config
             if (config.buffer_size == 0) {
-                FL_WARN(
-                    "RX begin: Invalid buffer_size in config (buffer_size=0)");
+                FL_WARN_F("RX begin: Invalid buffer_size in config (buffer_size=0)");
                 return false;
             }
 
@@ -694,7 +676,7 @@ class RmtRxChannelImpl : public RmtRxChannel {
             // Clear receive state (resets mSkipCounter to skip_signals_)
             clear();
 
-            // Enable channel (transition "init" → "enabled")
+            // Enable channel (transition "init" â†’ "enabled")
             if (!enable()) {
                 return false;
             }
@@ -734,9 +716,9 @@ class RmtRxChannelImpl : public RmtRxChannel {
         //     num_dma_nodes = max(2, mem_block_symbols * 4 / 4095 + 1)
         //   and the per-rmt_receive() user-buffer cap is num_dma_nodes * 4092
         //   bytes (=1023 symbols/node). So to pass a 14000-symbol user buffer
-        //   (= 56 KB) we need ≥14 DMA nodes, which means mem_block_symbols ≥
+        //   (= 56 KB) we need â‰¥14 DMA nodes, which means mem_block_symbols â‰¥
         //   14336. Set 14336 to cover ~595 WS2812B LEDs in a single rmt_receive.
-        //   Memory cost: 14336 × 4 = 56 KB internal-RAM DMA buffer — ESP32-S3
+        //   Memory cost: 14336 Ã— 4 = 56 KB internal-RAM DMA buffer â€” ESP32-S3
         //   has ~320 KB so ~18%. See issue #2254.
         rx_config.mem_block_symbols = mUseDma ? 14336 : 64;
         // Interrupt priority level 3 (maximum supported by ESP-IDF RMT driver
@@ -753,13 +735,11 @@ class RmtRxChannelImpl : public RmtRxChannel {
         // rmt_new_rx_channel() time; toggling later requires rebuilding.
         rx_config.flags.with_dma = mUseDma ? 1 : 0;
         if (mUseDma) {
-            FL_WARN("[RMT RX] DMA streaming mode requested on GPIO "
-                    << static_cast<int>(mPin)
-                    << " (mem_block_symbols=" << rx_config.mem_block_symbols << ")");
+            FL_WARN_F("[RMT RX] DMA streaming mode requested on GPIO %s (mem_block_symbols=%s)", static_cast<int>(mPin), rx_config.mem_block_symbols);
         }
         // Internal loopback configuration:
         // When io_loop_back=true, RX receives from TX output internally (same GPIO).
-        // This is REQUIRED for RMT TX → RMT RX validation on ESP32-S3 because
+        // This is REQUIRED for RMT TX â†’ RMT RX validation on ESP32-S3 because
         // ESP32-S3 has a hardware limitation where TX GPIO output stops when RX
         // is actively receiving on a different GPIO. With loopback enabled,
         // TX output is routed both to the GPIO AND internally to RX.
@@ -767,7 +747,7 @@ class RmtRxChannelImpl : public RmtRxChannel {
         rx_config.flags.io_loop_back = mIoLoopBack ? 1 : 0;
 #endif
         if (mIoLoopBack) {
-            FL_WARN("[RMT RX] Internal loopback enabled (io_loop_back=1) on GPIO " << static_cast<int>(mPin));
+            FL_WARN_F("[RMT RX] Internal loopback enabled (io_loop_back=1) on GPIO %s", static_cast<int>(mPin));
         }
 
         // Note: RX channel is already registered with RmtMemoryManager in constructor
@@ -775,7 +755,7 @@ class RmtRxChannelImpl : public RmtRxChannel {
         // The registration happens early so that TX channels disable DMA when RX is active
         // (ESP32-S3 has shared DMA channel between TX and RX).
         if (!mMemoryRegistered) {
-            FL_WARN("RMT RX was not pre-registered in constructor - registering now");
+            FL_WARN_F("RMT RX was not pre-registered in constructor - registering now");
             auto &memMgr = RmtMemoryManager::instance();
             mMemoryChannelId = static_cast<u8>(128 + (mPin & 0x7F));
             // Pass use_dma=true when DMA mode is on so the memory manager
@@ -786,8 +766,7 @@ class RmtRxChannelImpl : public RmtRxChannel {
             size_t rx_alloc_words = 0;
             if (!memMgr.tryAllocateRx(mMemoryChannelId, rx_config.mem_block_symbols,
                                        mUseDma, rx_alloc_words)) {
-                FL_WARN("RMT RX memory allocation failed for channel "
-                        << static_cast<int>(mMemoryChannelId));
+                FL_WARN_F("RMT RX memory allocation failed for channel %s", static_cast<int>(mMemoryChannelId));
                 return false;
             }
             mMemoryRegistered = true;
@@ -800,7 +779,7 @@ class RmtRxChannelImpl : public RmtRxChannel {
         if (mUseDma) {
             auto &memMgr = RmtMemoryManager::instance();
             if (!memMgr.allocateDMA(mMemoryChannelId, false)) {
-                FL_WARN("[RMT RX] Shared DMA slot unavailable — falling back to non-DMA mode");
+                FL_WARN_F("[RMT RX] Shared DMA slot unavailable â€” falling back to non-DMA mode");
                 mUseDma = false;
                 rx_config.flags.with_dma = 0;
                 rx_config.mem_block_symbols = 64;
@@ -812,8 +791,7 @@ class RmtRxChannelImpl : public RmtRxChannel {
         // Create RX channel
         esp_err_t err = rmt_new_rx_channel(&rx_config, &mChannel);
         if (err != ESP_OK) {
-            FL_WARN("Failed to create RX channel: " << static_cast<int>(err)
-                    << " (" << esp_err_to_name(err) << ")");
+            FL_WARN_F("Failed to create RX channel: %s (%s)", static_cast<int>(err), esp_err_to_name(err));
             // Unregister from memory manager on failure
             if (mMemoryRegistered) {
                 auto &memMgr = RmtMemoryManager::instance();
@@ -831,8 +809,7 @@ class RmtRxChannelImpl : public RmtRxChannel {
 
         err = rmt_rx_register_event_callbacks(mChannel, &callbacks, this);
         if (err != ESP_OK) {
-            FL_WARN(
-                "Failed to register RX callbacks: " << static_cast<int>(err));
+            FL_WARN_F("Failed to register RX callbacks: %s", static_cast<int>(err));
             rmt_del_channel(mChannel);
             mChannel = nullptr;
             return false;
@@ -844,7 +821,7 @@ class RmtRxChannelImpl : public RmtRxChannel {
         // state The channel is created in "init" state by rmt_new_rx_channel()
         // We must call rmt_enable() before calling rmt_receive()
         if (!enable()) {
-            FL_WARN("Failed to enable RX channel");
+            FL_WARN_F("Failed to enable RX channel");
             rmt_del_channel(mChannel);
             mChannel = nullptr;
             return false;
@@ -855,7 +832,7 @@ class RmtRxChannelImpl : public RmtRxChannel {
         // the ISR so no pre-capture drain is required (see rxDoneCallback).
         if (!mUseDma) {
             if (!handleSkipPhase()) {
-                FL_WARN("Failed to handle skip phase in begin()");
+                FL_WARN_F("Failed to handle skip phase in begin()");
                 rmt_disable(mChannel);
                 rmt_del_channel(mChannel);
                 mChannel = nullptr;
@@ -865,11 +842,11 @@ class RmtRxChannelImpl : public RmtRxChannel {
 
         // Allocate buffer and arm receiver for actual capture
         if (!allocateAndArm()) {
-            FL_WARN("Failed to arm receiver in begin()");
+            FL_WARN_F("Failed to arm receiver in begin()");
             rmt_disable(mChannel);
             rmt_del_channel(mChannel);
             mChannel = nullptr;
-            // Release the DMA slot we acquired earlier — otherwise the slot
+            // Release the DMA slot we acquired earlier â€” otherwise the slot
             // leaks and subsequent begin() retries report "Shared DMA slot
             // unavailable" until the RxDevice is destroyed.
             if (mDmaAllocated) {
@@ -893,7 +870,7 @@ class RmtRxChannelImpl : public RmtRxChannel {
 
     RxWaitResult wait(u32 timeout_ms) FL_NOEXCEPT override {
         if (!mChannel) {
-            FL_WARN("wait(): channel not initialized");
+            FL_WARN_F("wait(): channel not initialized");
             return RxWaitResult::TIMEOUT; // Treat as timeout
         }
 
@@ -906,7 +883,7 @@ class RmtRxChannelImpl : public RmtRxChannel {
         if (mAccumulationBuffer.empty()) {
             // Allocate buffer and arm receiver
             if (!allocateAndArm()) {
-                FL_WARN("wait(): failed to allocate and arm");
+                FL_WARN_F("wait(): failed to allocate and arm");
                 return RxWaitResult::TIMEOUT; // Treat as timeout
             }
         } else {
@@ -929,10 +906,8 @@ class RmtRxChannelImpl : public RmtRxChannel {
 
             // Check timeout
             if (elapsed_us >= timeout_us) {
-                FL_ERROR("RMT RX timeout after "
-                        << elapsed_us << "us, received " << mSymbolsReceived
-                        << " symbols (expected " << mBufferSize << ")");
-                FL_ERROR("RMT RX: No data received from TX pin - check that PARLIO/SPI/RMT TX is transmitting");
+                FL_ERROR_F("RMT RX timeout after %sus, received %s symbols (expected %s)", elapsed_us, mSymbolsReceived, mBufferSize);
+                FL_ERROR_F("RMT RX: No data received from TX pin - check that PARLIO/SPI/RMT TX is transmitting");
                 return RxWaitResult::TIMEOUT;
             }
 
@@ -947,10 +922,7 @@ class RmtRxChannelImpl : public RmtRxChannel {
         // streams. mCallbackCount == 1 on a long-stream capture indicates
         // ESP-IDF ended the receive after one fill (likely due to idle
         // timeout from signal_range_max_ns). See issue #2254.
-        FL_WARN("[RMT RX] wait(): symbols=" << mSymbolsReceived
-                                          << " callbacks=" << mCallbackCount
-                                          << " use_dma="
-                                          << (mUseDma ? "true" : "false"));
+        FL_WARN_F("[RMT RX] wait(): symbols=%s callbacks=%s use_dma=%s", mSymbolsReceived, mCallbackCount, (mUseDma ? "true" : "false"));
         return RxWaitResult::SUCCESS;
     }
 
@@ -1044,14 +1016,13 @@ class RmtRxChannelImpl : public RmtRxChannel {
 
     bool injectEdges(fl::span<const EdgeTime> edges) FL_NOEXCEPT override {
         if (edges.empty()) {
-            FL_WARN("injectEdges(): empty edges span");
+            FL_WARN_F("injectEdges(): empty edges span");
             return false;
         }
 
         // Check if edges count is even (must have pairs for RMT symbols)
         if (edges.size() % 2 != 0) {
-            FL_WARN("injectEdges(): edge count must be even (got "
-                    << edges.size() << ")");
+            FL_WARN_F("injectEdges(): edge count must be even (got %s)", edges.size());
             return false;
         }
 
@@ -1066,14 +1037,12 @@ class RmtRxChannelImpl : public RmtRxChannel {
                 mAccumulationBuffer.push_back(0);
             }
         } else if (mAccumulationBuffer.size() < symbol_count) {
-            FL_WARN("injectEdges(): accumulation buffer too small (need "
-                    << symbol_count << ", have " << mAccumulationBuffer.size()
-                    << ")");
+            FL_WARN_F("injectEdges(): accumulation buffer too small (need %s, have %s)", symbol_count, mAccumulationBuffer.size());
             return false;
         }
 
-        // Calculate nanoseconds per tick for conversion (ns → ticks)
-        // Example: 40MHz = 40,000,000 Hz → 1,000,000,000 / 40,000,000 = 25ns
+        // Calculate nanoseconds per tick for conversion (ns â†’ ticks)
+        // Example: 40MHz = 40,000,000 Hz â†’ 1,000,000,000 / 40,000,000 = 25ns
         // per tick
         u32 ns_per_tick = 1000000000UL / mResolutionHz;
 
@@ -1168,7 +1137,7 @@ class RmtRxChannelImpl : public RmtRxChannel {
             // Start receive with discard buffer (rmt_receive will enable the RX
             // hardware internally)
             if (!startReceive(discard_buffer.data(), chunk_size)) {
-                FL_WARN("handleSkipPhase(): failed to start receive");
+                FL_WARN_F("handleSkipPhase(): failed to start receive");
                 return false;
             }
 
@@ -1181,7 +1150,7 @@ class RmtRxChannelImpl : public RmtRxChannel {
             while (!mReceiveDone) {
                 i64 elapsed_us = esp_timer_get_time() - start_time_us;
                 if (elapsed_us >= timeout_us) {
-                    FL_WARN("handleSkipPhase(): timeout waiting for symbols");
+                    FL_WARN_F("handleSkipPhase(): timeout waiting for symbols");
                     return false;
                 }
                 taskYIELD();
@@ -1198,9 +1167,8 @@ class RmtRxChannelImpl : public RmtRxChannel {
             if (mSkipCounter > 0) { // Only disable if more iterations needed
                 esp_err_t err = rmt_disable(mChannel);
                 if (err != ESP_OK && err != ESP_ERR_INVALID_STATE) {
-                    FL_WARN("handleSkipPhase(): failed to disable channel for "
-                            "next iteration: "
-                            << static_cast<int>(err));
+                    FL_WARN_F("handleSkipPhase(): failed to disable channel for "
+                            "next iteration: %s", static_cast<int>(err));
                     return false;
                 }
                 FL_LOG_RX("Skip phase: channel disabled for next iteration");
@@ -1226,9 +1194,8 @@ class RmtRxChannelImpl : public RmtRxChannel {
                 FL_LOG_RX("Skip phase: channel already in init state "
                        "(skip_signals=0 case)");
             } else {
-                FL_WARN("handleSkipPhase(): failed to disable channel after "
-                        "skip phase: "
-                        << static_cast<int>(err));
+                FL_WARN_F("handleSkipPhase(): failed to disable channel after "
+                        "skip phase: %s", static_cast<int>(err));
                 return false;
             }
         }
@@ -1254,17 +1221,17 @@ class RmtRxChannelImpl : public RmtRxChannel {
     bool allocateAndArm() FL_NOEXCEPT {
         // Per-receive buffer that ESP-IDF writes into. In non-DMA mode this is
         // sized for a single mem-block fill; in DMA mode ESP-IDF requires the
-        // user buffer to be ≤ mem_block_symbols (the DRAM ping-pong size),
+        // user buffer to be â‰¤ mem_block_symbols (the DRAM ping-pong size),
         // and the ISR streams from it into the accumulation buffer on every
         // partial-rx callback. The DMA variant MUST live in MALLOC_CAP_DMA |
-        // MALLOC_CAP_INTERNAL memory — a plain fl::vector can land in PSRAM on
+        // MALLOC_CAP_INTERNAL memory â€” a plain fl::vector can land in PSRAM on
         // ESP32-S3, which ESP-IDF rejects with "user buffer not in the internal
         // RAM". See issue #2254.
         constexpr size_t NONDMA_BUFFER_SIZE = 4096;
-        // DMA user buffer sized to fit within num_dma_nodes × 4092 bytes. With
+        // DMA user buffer sized to fit within num_dma_nodes Ã— 4092 bytes. With
         // mem_block_symbols=14336 we get 14 DMA nodes = 57288 bytes = 14322
         // symbols capacity. Pass 14000 symbols (= 56000 bytes) with margin.
-        // Covers 583 WS2812B LEDs in a single rmt_receive() — no need for
+        // Covers 583 WS2812B LEDs in a single rmt_receive() â€” no need for
         // ISR re-submission on typical long strips. Partial-rx ISR still fires
         // every ~1023-symbol DMA node fill, streaming into the accumulation
         // buffer via rxDoneCallback.
@@ -1282,8 +1249,7 @@ class RmtRxChannelImpl : public RmtRxChannel {
                 mDmaCapableBuffer = static_cast<RmtSymbol *>(
                     heap_caps_malloc(bytes, MALLOC_CAP_DMA | MALLOC_CAP_INTERNAL));
                 if (!mDmaCapableBuffer) {
-                    FL_WARN("allocateAndArm(): heap_caps_malloc("
-                            << bytes << ", DMA|INTERNAL) failed");
+                    FL_WARN_F("allocateAndArm(): heap_caps_malloc(%s, DMA|INTERNAL) failed", bytes);
                     return false;
                 }
                 mDmaCapableBufferSize = hw_buffer_size;
@@ -1318,9 +1284,7 @@ class RmtRxChannelImpl : public RmtRxChannel {
         }
         size_t effective_size = mAccumulationBuffer.capacity();
         if (effective_size < mBufferSize) {
-            FL_WARN("allocateAndArm(): accumulation buffer reduced from "
-                    << mBufferSize << " to " << effective_size
-                    << " symbols (memory constrained)");
+            FL_WARN_F("allocateAndArm(): accumulation buffer reduced from %s to %s symbols (memory constrained)", mBufferSize, effective_size);
         }
         for (size_t i = mAccumulationBuffer.size(); i < effective_size; i++) {
             mAccumulationBuffer.push_back(0);
@@ -1337,7 +1301,7 @@ class RmtRxChannelImpl : public RmtRxChannel {
         RmtSymbol *hw_buffer = mUseDma ? mDmaCapableBuffer
                                         : mInternalBuffer.data();
         if (!startReceive(hw_buffer, hw_buffer_size)) {
-            FL_WARN("allocateAndArm(): failed to start receive");
+            FL_WARN_F("allocateAndArm(): failed to start receive");
             return false;
         }
 
@@ -1357,20 +1321,20 @@ class RmtRxChannelImpl : public RmtRxChannel {
      * state but must be disabled before calling rmt_receive() again.
      *
      * State transitions:
-     *   - rmt_new_rx_channel() → "init" state
-     *   - rmt_enable() → "enabled" state
-     *   - rmt_receive() → requires "enabled" state
-     *   - After receive completes → remains "enabled" but must disable before
+     *   - rmt_new_rx_channel() â†’ "init" state
+     *   - rmt_enable() â†’ "enabled" state
+     *   - rmt_receive() â†’ requires "enabled" state
+     *   - After receive completes â†’ remains "enabled" but must disable before
      * next receive
-     *   - rmt_disable() → "init" state (ready for next enable/receive cycle)
+     *   - rmt_disable() â†’ "init" state (ready for next enable/receive cycle)
      */
     bool enable() FL_NOEXCEPT {
         if (!mChannel) {
-            FL_WARN("enable(): RX channel not initialized");
+            FL_WARN_F("enable(): RX channel not initialized");
             return false;
         }
 
-        // Enable channel (transition "init" → "enabled")
+        // Enable channel (transition "init" â†’ "enabled")
         esp_err_t err = rmt_enable(mChannel);
 
         // ESP_OK: Successfully enabled
@@ -1378,9 +1342,7 @@ class RmtRxChannelImpl : public RmtRxChannel {
             FL_LOG_RX("RX channel enabled");
             return true;
         } else {
-            FL_WARN("Failed to enable RX channel: "
-                    << esp_err_to_name(err)
-                    << " (code: " << static_cast<int>(err) << ")");
+            FL_WARN_F("Failed to enable RX channel: %s (code: %s)", esp_err_to_name(err), static_cast<int>(err));
             return false;
         }
     }
@@ -1421,17 +1383,17 @@ class RmtRxChannelImpl : public RmtRxChannel {
      * @return true if receive started, false on error
      *
      * IMPORTANT: This method is called with the DMA buffer, not the
-     * accumulation buffer. The ISR callback will copy from DMA buffer →
+     * accumulation buffer. The ISR callback will copy from DMA buffer â†’
      * accumulation buffer on each partial RX callback.
      */
     bool startReceive(RmtSymbol *buffer, size_t buffer_size) FL_NOEXCEPT {
         if (!mChannel) {
-            FL_WARN("RX channel not initialized (call begin() first)");
+            FL_WARN_F("RX channel not initialized (call begin() first)");
             return false;
         }
 
         if (!buffer || buffer_size == 0) {
-            FL_WARN("Invalid buffer parameters");
+            FL_WARN_F("Invalid buffer parameters");
             return false;
         }
 
@@ -1445,7 +1407,7 @@ class RmtRxChannelImpl : public RmtRxChannel {
         // Clamp signal_range_max_ns to hardware limit: each RMT symbol duration
         // field is 15 bits (max 32767 ticks). At the configured resolution,
         // max_ns = 32767 * (1e9 / resolution_hz).
-        // ESP32-C6 at 40MHz: 32767 * 25 = 818675 ns (~819µs)
+        // ESP32-C6 at 40MHz: 32767 * 25 = 818675 ns (~819Âµs)
         u32 max_signal_range_ns = mSignalRangeMaxNs;
         if (mResolutionHz > 0) {
             u64 tick_ns = 1000000000ULL / mResolutionHz;
@@ -1475,7 +1437,7 @@ class RmtRxChannelImpl : public RmtRxChannel {
             rmt_receive(mChannel, rmt_buffer,
                         buffer_size * sizeof(rmt_symbol_word_t), &rx_params);
         if (err != ESP_OK) {
-            FL_WARN("Failed to start RX receive: " << static_cast<int>(err));
+            FL_WARN_F("Failed to start RX receive: %s", static_cast<int>(err));
             return false;
         }
 
@@ -1524,10 +1486,10 @@ class RmtRxChannelImpl : public RmtRxChannel {
         // receiver fires the ISR on every ping-pong fill, and we want to
         // filter skip chunks inline without terminating the receive op.
         //
-        //   - Chunk entirely inside skip window → drop whole chunk, continue.
-        //   - Chunk straddles the skip boundary → advance past the skipped
+        //   - Chunk entirely inside skip window â†’ drop whole chunk, continue.
+        //   - Chunk straddles the skip boundary â†’ advance past the skipped
         //     prefix and copy the remainder into the accumulation buffer.
-        //   - Chunk entirely past the skip window → normal accumulation.
+        //   - Chunk entirely past the skip window â†’ normal accumulation.
         //
         // In non-DMA mode the handleSkipPhase() wrapper still owns the drain
         // loop (it calls rmt_receive() in a loop, each fill sets is_last).
@@ -1631,13 +1593,13 @@ class RmtRxChannelImpl : public RmtRxChannel {
         mSkipCounter; ///< Runtime counter for skipping (decremented in ISR)
     bool mStartLow;   ///< Pin idle state: true=LOW (WS2812B), false=HIGH
                       ///< (inverted)
-    bool mIoLoopBack; ///< Enable internal RMT loopback (TX→RX on same GPIO)
+    bool mIoLoopBack; ///< Enable internal RMT loopback (TXâ†’RX on same GPIO)
     bool mUseDma;     ///< DMA streaming mode (ESP-IDF 5.3+ en_partial_rx)
     bool mDmaAllocated; ///< True if we hold the shared DMA slot
     RmtSymbol *mDmaCapableBuffer; ///< DRAM-resident ping-pong buffer for DMA
     size_t mDmaCapableBufferSize; ///< Capacity in symbols
     fl::vector<RmtSymbol>
-        mInternalBuffer; ///< DMA buffer for hardware RX (small, ≤4096 symbols)
+        mInternalBuffer; ///< DMA buffer for hardware RX (small, â‰¤4096 symbols)
     fl::vector<RmtSymbol>
         mAccumulationBuffer; ///< Accumulation buffer for full data stream
                              ///< (user-requested size)
@@ -1667,7 +1629,7 @@ namespace fl {
 
 fl::shared_ptr<RmtRxChannel> RmtRxChannel::create(int pin) FL_NOEXCEPT {
     (void)pin; // Suppress unused parameter warning
-    FL_WARN("RmtRxChannel::create() requires RMT5 driver (ESP-IDF 5.0+). "
+    FL_WARN_F("RmtRxChannel::create() requires RMT5 driver (ESP-IDF 5.0+). "
             "Returning nullptr.");
     return nullptr;
 }

--- a/src/platforms/esp/32/drivers/rmt_rx/rmt_rx_channel.h
+++ b/src/platforms/esp/32/drivers/rmt_rx/rmt_rx_channel.h
@@ -40,7 +40,7 @@ namespace fl {
  *
  * // Initialize with custom signal range (optional - defaults to 100ns/100μs)
  * if (!rx->begin(100, 100000)) {  // min=100ns, max=100μs
- *     FL_WARN("RX channel init failed");
+ *     FL_WARN_F("RX channel init failed");
  *     return;
  * }
  *
@@ -55,7 +55,7 @@ namespace fl {
  *     fl::vector<uint8_t> bytes;
  *     auto result = rx->decode(rx_timing, fl::back_inserter(bytes));
  *     if (result.ok()) {
- *         FL_DBG("Decoded " << result.value() << " bytes");
+ *         FL_DBG_F("Decoded %s bytes", result.value());
  *     }
  * }
  * @endcode
@@ -199,7 +199,7 @@ public:
      *     uint8_t buffer[256];
      *     auto result = rx->decode(rx_timing, buffer);
      *     if (result.ok()) {
-     *         FL_DBG("Decoded " << result.value() << " bytes");
+     *         FL_DBG_F("Decoded %s bytes", result.value());
      *     }
      * }
      * @endcode
@@ -228,7 +228,7 @@ public:
      * EdgeTime edges[100];
      * size_t count = rx->getRawEdgeTimes(edges);
      * for (size_t i = 0; i < count; i++) {
-     *     FL_DBG((edges[i].high ? "HIGH " : "LOW ") << edges[i].ns << "ns");
+     *     FL_DBG_F("%s%sns", (edges[i].high ? "HIGH " : "LOW "), edges[i].ns);
      * }
      * @endcode
      */

--- a/src/platforms/esp/32/drivers/spi/channel_driver_spi.cpp.hpp
+++ b/src/platforms/esp/32/drivers/spi/channel_driver_spi.cpp.hpp
@@ -1,16 +1,16 @@
-// IWYU pragma: private
+﻿// IWYU pragma: private
 
 /// @file channel_driver_spi.cpp
 /// @brief Clockless-over-SPI ChannelEngine implementation for ESP32
 ///
-/// ⚠️ ARCHITECTURE NOTE: This is NOT a general SPI LED driver!
+/// âš ï¸ ARCHITECTURE NOTE: This is NOT a general SPI LED driver!
 /// This driver implements CLOCKLESS protocols (WS2812, SK6812, etc.) using SPI hardware
 /// as a bit-banging driver. The SPI clock is used internally for timing but is NEVER
 /// physically connected to the LED strip - only the MOSI/data pin is used.
 /// See channel_driver_spi.h for detailed explanation.
 ///
 /// ENCODING: Uses wave8 encoding (8-bit expansion):
-/// - Each LED bit → 8 SPI bits (1 byte per LED bit, 8 bytes per LED byte)
+/// - Each LED bit â†’ 8 SPI bits (1 byte per LED bit, 8 bytes per LED byte)
 /// - Wave8 LUT maps nibbles to 4-byte waveform patterns
 /// - SPI clock derived from chipset timing: ~6.4 MHz for WS2812
 ///
@@ -128,7 +128,7 @@ inline int getSpiMosiSignalIndex(spi_host_device_t host) FL_NOEXCEPT {
     }
 #endif
     // Fallback: return -1 if no valid signal found
-    FL_WARN("getSpiMosiSignalIndex: Unsupported SPI host " << host);
+    FL_WARN_F("getSpiMosiSignalIndex: Unsupported SPI host %s", host);
     return -1;
 }
 
@@ -151,7 +151,7 @@ inline u32 gcd(u32 a, u32 b) FL_NOEXCEPT {
 // ============================================================================
 // Each LED bit expands to 8 SPI bits (1 byte per LED bit, 8 bytes per LED byte)
 // SPI clock frequency is derived from chipset timing: 8 / (T1+T2+T3) in Hz
-// For WS2812 (T1=250, T2=625, T3=375 → 1250ns period): clock = 6.4 MHz
+// For WS2812 (T1=250, T2=625, T3=375 â†’ 1250ns period): clock = 6.4 MHz
 
 /// @brief Number of SPI bytes per LED color byte (8:1 wave8 expansion)
 constexpr size_t WAVE8_BYTES_PER_COLOR_BYTE = 8;
@@ -171,7 +171,7 @@ constexpr u32 calculateWave8SpiClockHz(u32 total_period_ns) {
 ///
 /// ESP32-C6's async DMA path (spi_device_queue_trans) does not produce GPIO output on the
 /// MOSI pin, even though transactions complete successfully. Root cause: GDMA-to-SPI
-/// peripheral timing sensitivity on the C6's RISC-V single-core architecture — the ISR-driven
+/// peripheral timing sensitivity on the C6's RISC-V single-core architecture â€” the ISR-driven
 /// transaction start introduces variable timing that violates the GDMA outlink-to-SPI-USR
 /// register write timing requirement (see esp-rs/esp-hal#489 where 2 CPU cycles determined
 /// success vs failure). Split polling mode (spi_device_polling_start + spi_device_polling_end)
@@ -211,11 +211,11 @@ inline esp_err_t spiCheckDone(spi_device_handle_t dev, spi_transaction_t** out_t
 
 ChannelEngineSpi::ChannelEngineSpi() FL_NOEXCEPT
     : mAllocationFailed(false), mLastRetryFrame(0) {
-    FL_DBG("ChannelEngineSpi: Constructor called");
+    FL_DBG_F("ChannelEngineSpi: Constructor called");
 }
 
 ChannelEngineSpi::~ChannelEngineSpi() {
-    FL_DBG("ChannelEngineSpi: Destructor called");
+    FL_DBG_F("ChannelEngineSpi: Destructor called");
 
     // Wait for any in-flight pipeline to complete before cleanup
     while (mPipeline.mPhase != DmaPipelineState::IDLE) {
@@ -273,7 +273,7 @@ bool ChannelEngineSpi::canHandle(const ChannelDataPtr& data) const FL_NOEXCEPT {
         return false;
     }
 
-    // ⚠️ ARCHITECTURE CLARIFICATION: This is a CLOCKLESS-over-SPI driver!
+    // âš ï¸ ARCHITECTURE CLARIFICATION: This is a CLOCKLESS-over-SPI driver!
     //
     // This driver uses SPI hardware to implement CLOCKLESS LED protocols (WS2812, SK6812, etc.),
     // NOT true SPI protocols (APA102, SK9822, etc.). The SPI clock pin is used internally for
@@ -285,52 +285,46 @@ bool ChannelEngineSpi::canHandle(const ChannelDataPtr& data) const FL_NOEXCEPT {
     //   - The SPI clock controls MOSI timing (e.g., ~6.67MHz for WS2812 = ~150ns per bit)
     //   - LEDs decode pulse widths on the data line, ignoring the clock signal
     //
-    // ✅ CORRECTED LOGIC:
+    // âœ… CORRECTED LOGIC:
     // Accept CLOCKLESS chipsets (WS2812, SK6812), reject TRUE SPI chipsets (APA102, SK9822)
     // True SPI chipsets should route to SpiChannelEngineAdapter (priority 5-9), not this driver
     //
     // Correct routing:
-    //   APA102 → SpiChannelEngineAdapter (true SPI hardware)
-    //   WS2812 → ChannelEngineSpi (this driver, clockless-over-SPI)
-    return !data->isSpi();  // ✅ FIXED: Accept clockless, reject true SPI
+    //   APA102 â†’ SpiChannelEngineAdapter (true SPI hardware)
+    //   WS2812 â†’ ChannelEngineSpi (this driver, clockless-over-SPI)
+    return !data->isSpi();  // âœ… FIXED: Accept clockless, reject true SPI
 }
 
 void ChannelEngineSpi::configureMultiLanePins(
     const MultiLanePinConfig &pinConfig) FL_NOEXCEPT {
     if (pinConfig.data0_pin < 0) {
-        FL_WARN("ChannelEngineSpi: Invalid multi-lane config - data0_pin must "
+        FL_WARN_F("ChannelEngineSpi: Invalid multi-lane config - data0_pin must "
                 "be >= 0");
         return;
     }
 
     u8 laneCount = pinConfig.getLaneCount();
-    FL_DBG("ChannelEngineSpi: Configuring "
-           << static_cast<int>(laneCount) << "-lane SPI for pin "
-           << pinConfig.data0_pin << " (data0=" << pinConfig.data0_pin
-           << ", data1=" << pinConfig.data1_pin << ", data2="
-           << pinConfig.data2_pin << ", data3=" << pinConfig.data3_pin << ")");
+    FL_DBG_F("ChannelEngineSpi: Configuring %s-lane SPI for pin %s (data0=%s, data1=%s, data2=%s, data3=%s)", static_cast<int>(laneCount), pinConfig.data0_pin, pinConfig.data0_pin, pinConfig.data1_pin, pinConfig.data2_pin, pinConfig.data3_pin);
 
 // Validate platform capabilities
 #if defined(FL_IS_ESP_32C6) || defined(FL_IS_ESP_32C3) ||                      \
     defined(FL_IS_ESP_32H2)
     // ESP32-C6/C3/H2: Dual-lane max (no quad support)
     if (laneCount > 2) {
-        FL_WARN("ChannelEngineSpi: ESP32-C6/C3/H2 only supports dual-lane SPI "
-                "(max 2 lanes), "
-                << "requested " << static_cast<int>(laneCount) << " lanes");
+        FL_WARN_F("ChannelEngineSpi: ESP32-C6/C3/H2 only supports dual-lane SPI "
+                "(max 2 lanes), requested %s lanes", static_cast<int>(laneCount));
         return;
     }
 #endif
 
     // Store the configuration
     mMultiLaneConfigs[pinConfig.data0_pin] = pinConfig;
-    FL_DBG("ChannelEngineSpi: Multi-lane configuration stored for pin "
-           << pinConfig.data0_pin);
+    FL_DBG_F("ChannelEngineSpi: Multi-lane configuration stored for pin %s", pinConfig.data0_pin);
 }
 
 void ChannelEngineSpi::enqueue(ChannelDataPtr channelData) FL_NOEXCEPT {
     if (!channelData) {
-        FL_WARN("ChannelEngineSpi: Null channel data passed to enqueue()");
+        FL_WARN_F("ChannelEngineSpi: Null channel data passed to enqueue()");
         return;
     }
 
@@ -399,7 +393,7 @@ IChannelDriver::DriverState ChannelEngineSpi::poll() FL_NOEXCEPT {
         return advancePipeline();
     }
 
-    // Pipeline idle — check for any channels needing cleanup
+    // Pipeline idle â€” check for any channels needing cleanup
     bool anyDraining = false;
     for (auto &channel : mChannels) {
         if (!channel.inUse) continue;
@@ -455,9 +449,7 @@ void ChannelEngineSpi::beginBatchedTransmission(
     // If pending channels exist, it indicates incomplete transmission from previous frame
     // or hardware saturation, which would interfere with batching logic.
     if (!mPendingChannels.empty()) {
-        FL_WARN_EVERY(100, "ChannelEngineSpi: Pending queue not empty at batch start ("
-                << mPendingChannels.size() << " channels pending). "
-                << "This may indicate hardware saturation or incomplete previous frame.");
+        FL_WARN_F_EVERY(100, "ChannelEngineSpi: Pending queue not empty at batch start (%s channels pending). This may indicate hardware saturation or incomplete previous frame.", mPendingChannels.size());
     }
 
     // ============================================================================
@@ -479,8 +471,7 @@ void ChannelEngineSpi::beginBatchedTransmission(
         timingGroups[timing].push_back(channel);
     }
 
-    FL_DBG_EVERY(100, "ChannelEngineSpi: Grouped " << channels.size()
-           << " channels into " << timingGroups.size() << " timing groups");
+    FL_DBG_F_EVERY(100, "ChannelEngineSpi: Grouped %s channels into %s timing groups", channels.size(), timingGroups.size());
 
     // ============================================================================
     // PHASE 2: Process each timing group with batching
@@ -504,8 +495,7 @@ void ChannelEngineSpi::beginBatchedTransmission(
         size_t N = groupChannels.size();
         size_t numBatches = (N + K - 1) / K;  // ceil(N/K)
 
-        FL_DBG_EVERY(100, "ChannelEngineSpi: Timing group with " << N << " channels, "
-               << static_cast<int>(K) << " lanes → " << numBatches << " batches");
+        FL_DBG_F_EVERY(100, "ChannelEngineSpi: Timing group with %s channels, %s lanes â†’ %s batches", N, static_cast<int>(K), numBatches);
 
         // ========================================================================
         // PHASE 3: Transmit each batch sequentially (blocking)
@@ -519,7 +509,7 @@ void ChannelEngineSpi::beginBatchedTransmission(
         //   - Move to next batch
         //
         // State transitions per batch:
-        //   READY → beginTransmission() → BUSY → DRAINING → READY
+        //   READY â†’ beginTransmission() â†’ BUSY â†’ DRAINING â†’ READY
         for (size_t batchIdx = 0; batchIdx < numBatches; batchIdx++) {
             size_t batchStart = batchIdx * K;
             size_t batchEnd = min(batchStart + K, N);
@@ -545,7 +535,7 @@ void ChannelEngineSpi::beginBatchedTransmission(
             DriverState state(DriverState::BUSY);
             while ((state = pollChannels()) != DriverState::READY) {
                 if (state == DriverState::ERROR) {
-                    FL_WARN_EVERY(10, "ChannelEngineSpi: Error during batch transmission");
+                    FL_WARN_F_EVERY(10, "ChannelEngineSpi: Error during batch transmission");
                     break;
                 }
                 // OS yield only while waiting for DMA
@@ -557,8 +547,7 @@ void ChannelEngineSpi::beginBatchedTransmission(
             // Without this delay, LEDs interpret the next batch as frame continuation,
             // causing alternating black/color frames (protocol violation).
             if (batchIdx + 1 < numBatches) {
-                FL_DBG_EVERY(100, "ChannelEngineSpi: Inserting reset delay ("
-                       << timing.reset_us << " μs) between batches");
+                FL_DBG_F_EVERY(100, "ChannelEngineSpi: Inserting reset delay (%s Î¼s) between batches", timing.reset_us);
                 fl::delayMicroseconds(timing.reset_us);
             }
         }
@@ -576,8 +565,8 @@ u8 ChannelEngineSpi::determineLaneCapacity(
     //   - See acquireSpiHost() at line 756: "if (tracking->refCount == 0)"
     //
     // Platform Capacity:
-    //   - ESP32/S2/S3/P4: 2 SPI hosts → K=2 (parallel transmission)
-    //   - ESP32-C3: 1 SPI host → K=1 (sequential transmission)
+    //   - ESP32/S2/S3/P4: 2 SPI hosts â†’ K=2 (parallel transmission)
+    //   - ESP32-C3: 1 SPI host â†’ K=1 (sequential transmission)
     //   - (SPI1_HOST exists but is flash-reserved, unreliable for LEDs)
     //
     // By returning the actual SPI host count, we enable:
@@ -598,8 +587,7 @@ u8 ChannelEngineSpi::determineLaneCapacity(
 // using multiple SPI peripheral hosts.
     constexpr u8 PARALLEL_SPI_HOSTS = 1;  // Single SPI host policy
 
-    FL_DBG_EVERY(100, "ChannelEngineSpi: Determined lane capacity: "
-           << static_cast<int>(PARALLEL_SPI_HOSTS) << " SPI hosts");
+    FL_DBG_F_EVERY(100, "ChannelEngineSpi: Determined lane capacity: %s SPI hosts", static_cast<int>(PARALLEL_SPI_HOSTS));
     return PARALLEL_SPI_HOSTS;
 }
 
@@ -612,14 +600,12 @@ void ChannelEngineSpi::beginTransmission(
         const ChipsetTimingConfig& timing = data->getTiming();
 
         // DEBUG: Trace timing values received from channel data
-        FL_DBG_EVERY(100, "ChannelEngineSpi: Received timing from ChannelData: t1_ns="
-               << timing.t1_ns << ", t2_ns=" << timing.t2_ns
-               << ", t3_ns=" << timing.t3_ns << ", reset_us=" << timing.reset_us);
+        FL_DBG_F_EVERY(100, "ChannelEngineSpi: Received timing from ChannelData: t1_ns=%s, t2_ns=%s, t3_ns=%s, reset_us=%s", timing.t1_ns, timing.t2_ns, timing.t3_ns, timing.reset_us);
 
         // Get LED data from channel
         const auto &ledData = data->getData();
         if (ledData.empty()) {
-            FL_WARN("ChannelEngineSpi: Empty LED data for pin " << pin);
+            FL_WARN_F("ChannelEngineSpi: Empty LED data for pin %s", pin);
             continue;
         }
 
@@ -627,8 +613,7 @@ void ChannelEngineSpi::beginTransmission(
         SpiChannelState *channel = acquireChannel(pin, timing, ledData.size());
         if (!channel) {
             // No hardware available - queue for later
-            FL_DBG("ChannelEngineSpi: No HW available for pin " << pin
-                                                                << ", queuing");
+            FL_DBG_F("ChannelEngineSpi: No HW available for pin %s, queuing", pin);
             mPendingChannels.push_back({data, pin, timing});
             continue;
         }
@@ -648,23 +633,17 @@ void ChannelEngineSpi::beginTransmission(
             // Copy to internal SRAM buffer
             fl::memcpy(channel->ledSourceBuffer, ledData.data(), ledData.size());
             channel->ledSource = channel->ledSourceBuffer;
-            FL_DBG_EVERY(100, "ChannelEngineSpi: Copied " << ledData.size() << " bytes to internal SRAM buffer");
+            FL_DBG_F_EVERY(100, "ChannelEngineSpi: Copied %s bytes to internal SRAM buffer", ledData.size());
         } else {
             // Fallback to direct access (may fail if data is in PSRAM)
             channel->ledSource = ledData.data();
-            FL_WARN_ONCE("ChannelEngineSpi: Using direct PSRAM access (ISR-unsafe!) - buffer too small or not allocated");
+            FL_WARN_F_ONCE("ChannelEngineSpi: Using direct PSRAM access (ISR-unsafe!) - buffer too small or not allocated");
         }
         channel->ledBytesRemaining = ledData.size();
 
         // DEBUG: Print first 6 bytes of input data to verify encoding input
         if (ledData.size() >= 6) {
-            FL_DBG_EVERY(100, "ChannelEngineSpi: Input LED data (first 6 bytes): ["
-                   << static_cast<int>(ledData[0]) << ","
-                   << static_cast<int>(ledData[1]) << ","
-                   << static_cast<int>(ledData[2]) << ","
-                   << static_cast<int>(ledData[3]) << ","
-                   << static_cast<int>(ledData[4]) << ","
-                   << static_cast<int>(ledData[5]) << "]");
+            FL_DBG_F_EVERY(100, "ChannelEngineSpi: Input LED data (first 6 bytes): [%s,%s,%s,%s,%s,%s]", static_cast<int>(ledData[0]), static_cast<int>(ledData[1]), static_cast<int>(ledData[2]), static_cast<int>(ledData[3]), static_cast<int>(ledData[4]), static_cast<int>(ledData[5]));
         }
 
         // Store reference to source data for cleanup
@@ -704,12 +683,11 @@ ChannelEngineSpi::acquireChannel(gpio_num_t pin, const ChipsetTimingConfig &timi
                     channel.ledSourceBufferSize =
                         channel.ledSourceBuffer ? dataSize : 0;
                     if (!channel.ledSourceBuffer) {
-                        FL_WARN("ChannelEngineSpi: Failed to reallocate "
-                                "LED source buffer ("
-                                << dataSize << " bytes)");
+                        FL_WARN_F("ChannelEngineSpi: Failed to reallocate "
+                                "LED source buffer (%s bytes)", dataSize);
                     }
                 }
-                FL_DBG_EVERY(100, "ChannelEngineSpi: Reusing SPI for pin " << pin);
+                FL_DBG_F_EVERY(100, "ChannelEngineSpi: Reusing SPI for pin %s", pin);
                 return &channel;
             }
 
@@ -720,8 +698,7 @@ ChannelEngineSpi::acquireChannel(gpio_num_t pin, const ChipsetTimingConfig &timi
                     // On ESP32-C6 (and potentially other variants), esp_rom_gpio_connect_out_signal()
                     // is NOT sufficient to reroute SPI MOSI. Must free and reinit the bus with
                     // the correct mosi_io_num via spi_bus_initialize().
-                    FL_DBG("ChannelEngineSpi: Freeing SPI from idle pin "
-                           << static_cast<int>(other.pin) << " for reuse by pin " << pin);
+                    FL_DBG_F("ChannelEngineSpi: Freeing SPI from idle pin %s for reuse by pin %s", static_cast<int>(other.pin), pin);
                     if (other.spi_device) {
                         spi_bus_remove_device(other.spi_device);
                         other.spi_device = nullptr;
@@ -733,9 +710,9 @@ ChannelEngineSpi::acquireChannel(gpio_num_t pin, const ChipsetTimingConfig &timi
             }
 
             // Reinitialize SPI hardware with the correct pin
-            FL_DBG("ChannelEngineSpi: Reinitializing SPI hardware for pin " << pin);
+            FL_DBG_F("ChannelEngineSpi: Reinitializing SPI hardware for pin %s", pin);
             if (!reinitSpiHardware(&channel, pin, dataSize)) {
-                FL_WARN("ChannelEngineSpi: Failed to reinit SPI for pin " << pin);
+                FL_WARN_F("ChannelEngineSpi: Failed to reinit SPI for pin %s", pin);
                 channel.inUse = false;
                 return nullptr;
             }
@@ -763,9 +740,7 @@ ChannelEngineSpi::acquireChannel(gpio_num_t pin, const ChipsetTimingConfig &timi
         newChannel.data1_pin = config.data1_pin;
         newChannel.data2_pin = config.data2_pin;
         newChannel.data3_pin = config.data3_pin;
-        FL_DBG("ChannelEngineSpi: Applying "
-               << static_cast<int>(newChannel.numLanes)
-               << "-lane configuration for pin " << pin);
+        FL_DBG_F("ChannelEngineSpi: Applying %s-lane configuration for pin %s", static_cast<int>(newChannel.numLanes), pin);
     } else {
         // Default to single-lane mode
         newChannel.numLanes = 1;
@@ -782,8 +757,7 @@ ChannelEngineSpi::acquireChannel(gpio_num_t pin, const ChipsetTimingConfig &timi
     // Free SPI from any idle channel on a different pin to make host available
     for (auto &other : mChannels) {
         if (!other.inUse && other.spi_host != SPI_HOST_MAX && other.pin != pin) {
-            FL_DBG("ChannelEngineSpi: Freeing SPI from idle pin "
-                   << static_cast<int>(other.pin) << " for new pin " << pin);
+            FL_DBG_F("ChannelEngineSpi: Freeing SPI from idle pin %s for new pin %s", static_cast<int>(other.pin), pin);
             if (other.spi_device) {
                 spi_bus_remove_device(other.spi_device);
                 other.spi_device = nullptr;
@@ -796,14 +770,13 @@ ChannelEngineSpi::acquireChannel(gpio_num_t pin, const ChipsetTimingConfig &timi
 
     // Now initialize the channel (this will attach ISR with correct pointer)
     if (!createChannel(channelPtr, pin, timing, dataSize)) {
-        FL_WARN_ONCE("ChannelEngineSpi: Failed to create channel for pin " << pin);
+        FL_WARN_F_ONCE("ChannelEngineSpi: Failed to create channel for pin %s", pin);
         // Remove the partially created channel
         mChannels.pop_back();
         return nullptr;
     }
 
-    FL_DBG("ChannelEngineSpi: Created new channel for pin "
-           << pin << " (total: " << mChannels.size() << ")");
+    FL_DBG_F("ChannelEngineSpi: Created new channel for pin %s (total: %s)", pin, mChannels.size());
     return channelPtr;
 }
 
@@ -830,8 +803,7 @@ void ChannelEngineSpi::releaseChannel(SpiChannelState *channel) FL_NOEXCEPT {
         // Teardown only happens in destructor or when the channel is actually destroyed.
         // This avoids the expensive ~1.2s SPI bus re-initialization cycle per frame
         // and ensures the GPIO stays in SPI MOSI mode (driven LOW by zero bytes at end of frame).
-        FL_DBG_EVERY(100, "ChannelEngineSpi: Released channel for pin " << static_cast<int>(channel->pin)
-               << " (SPI hardware kept allocated for reuse)");
+        FL_DBG_F_EVERY(100, "ChannelEngineSpi: Released channel for pin %s (SPI hardware kept allocated for reuse)", static_cast<int>(channel->pin));
     }
 }
 
@@ -842,14 +814,14 @@ bool ChannelEngineSpi::reinitSpiHardware(SpiChannelState *state, gpio_num_t pin,
 
     state->spi_host = acquireSpiHost();
     if (state->spi_host == SPI_HOST_MAX) {
-        FL_WARN_EVERY(10, "ChannelEngineSpi: No available SPI host for reinit");
+        FL_WARN_F_EVERY(10, "ChannelEngineSpi: No available SPI host for reinit");
         return false;
     }
 
     // Staging buffer sized to fit an entire ~680-LED WS2812B wave8 payload in
     // one SPI transaction (1 LED = 24 wave8 bytes). With 4096-byte staging,
     // any strip longer than ~170 LEDs was transmitted as multiple chunks with
-    // a poll()-timing-dependent gap between them — long enough to latch the
+    // a poll()-timing-dependent gap between them â€” long enough to latch the
     // first 170 LEDs and leave the rest dark (the "black frame between
     // displays" bug in #2254). 16384 bytes lets ESP-IDF's SPI DMA descriptor
     // chain produce continuous output for a single transaction.
@@ -875,7 +847,7 @@ bool ChannelEngineSpi::reinitSpiHardware(SpiChannelState *state, gpio_num_t pin,
 
     esp_err_t ret = spi_bus_initialize(state->spi_host, &bus_config, SPI_DMA_CH_AUTO);
     if (ret != ESP_OK) {
-        FL_WARN("ChannelEngineSpi: reinit spi_bus_initialize failed: " << ret);
+        FL_WARN_F("ChannelEngineSpi: reinit spi_bus_initialize failed: %s", ret);
         releaseSpiHost(state->spi_host);
         state->spi_host = SPI_HOST_MAX;
         return false;
@@ -895,7 +867,7 @@ bool ChannelEngineSpi::reinitSpiHardware(SpiChannelState *state, gpio_num_t pin,
 
     ret = spi_bus_add_device(state->spi_host, &dev_config, &state->spi_device);
     if (ret != ESP_OK) {
-        FL_WARN("ChannelEngineSpi: reinit spi_bus_add_device failed: " << ret);
+        FL_WARN_F("ChannelEngineSpi: reinit spi_bus_add_device failed: %s", ret);
         spi_bus_free(state->spi_host);
         releaseSpiHost(state->spi_host);
         state->spi_host = SPI_HOST_MAX;
@@ -904,8 +876,7 @@ bool ChannelEngineSpi::reinitSpiHardware(SpiChannelState *state, gpio_num_t pin,
 
     // NOTE: Do NOT call gpio_set_drive_capability() here (see createChannel())
 
-    FL_DBG_EVERY(100, "ChannelEngineSpi: Reinit SPI hardware for pin " << pin
-           << " host=" << static_cast<int>(state->spi_host));
+    FL_DBG_F_EVERY(100, "ChannelEngineSpi: Reinit SPI hardware for pin %s host=%s", pin, static_cast<int>(state->spi_host));
     return true;
 }
 
@@ -924,19 +895,17 @@ bool ChannelEngineSpi::createChannel(SpiChannelState *state, gpio_num_t pin,
     }
 
     creation_count++;
-    FL_DBG_EVERY(10, "ChannelEngineSpi: Creating channel for pin " << pin
-           << " (attempt " << creation_count << " in last 5s)");
+    FL_DBG_F_EVERY(10, "ChannelEngineSpi: Creating channel for pin %s (attempt %s in last 5s)", pin, creation_count);
 
     if (creation_count > 100) {
-        FL_ERROR("ChannelEngineSpi: ABORT - Too many channel creation attempts ("
-                 << creation_count << " in 5s). Possible infinite loop or resource leak.");
+        FL_ERROR_F("ChannelEngineSpi: ABORT - Too many channel creation attempts (%s in 5s). Possible infinite loop or resource leak.", creation_count);
         return false;
     }
 
     // Acquire SPI host
     state->spi_host = acquireSpiHost();
     if (state->spi_host == SPI_HOST_MAX) {
-        FL_WARN_EVERY(10, "ChannelEngineSpi: No available SPI host (attempt " << creation_count << ")");
+        FL_WARN_F_EVERY(10, "ChannelEngineSpi: No available SPI host (attempt %s)", creation_count);
         return false;
     }
 
@@ -944,9 +913,9 @@ bool ChannelEngineSpi::createChannel(SpiChannelState *state, gpio_num_t pin,
     // single ESP-IDF spi_device_queue_trans() produce continuous wave8 output
     // for up to ~680 WS2812B LEDs. With the earlier 4 KB size, any strip >
     // ~170 LEDs was split across multiple poll()-driven transactions with
-    // inter-chunk gaps long enough for WS2812B to latch — the "black frame
+    // inter-chunk gaps long enough for WS2812B to latch â€” the "black frame
     // between displays" bug reported in #2254. 16 KB matches the per-channel
-    // internal-SRAM cost (2× double-buffered = 32 KB) — tight but acceptable
+    // internal-SRAM cost (2Ã— double-buffered = 32 KB) â€” tight but acceptable
     // on ESP32-S3 (~320 KB internal SRAM).
     const size_t staging_size = 16384;
 
@@ -981,9 +950,7 @@ bool ChannelEngineSpi::createChannel(SpiChannelState *state, gpio_num_t pin,
     bus_config.quadhd_io_num = -1;  // Not used for LED strips
     bus_config.max_transfer_sz = staging_size;  // Chunked transmission: max = staging buffer size
 
-    FL_DBG("ChannelEngineSpi: SPI bus config (Espressif led_strip pattern) - MOSI=" << static_cast<int>(pin)
-           << ", SCLK=-1 (internal), MISO=-1 (unused)"
-           << ", host=" << static_cast<int>(state->spi_host));
+    FL_DBG_F("ChannelEngineSpi: SPI bus config (Espressif led_strip pattern) - MOSI=%s, SCLK=-1 (internal), MISO=-1 (unused), host=%s", static_cast<int>(pin), static_cast<int>(state->spi_host));
 
     // Match Espressif led_strip pattern EXACTLY: NO bus flags set
     // Reference: https://github.com/espressif/idf-extra-components/blob/master/led_strip/src/led_strip_spi_dev.c
@@ -1002,7 +969,7 @@ bool ChannelEngineSpi::createChannel(SpiChannelState *state, gpio_num_t pin,
     esp_err_t ret =
         spi_bus_initialize(state->spi_host, &bus_config, SPI_DMA_CH_AUTO);
     if (ret != ESP_OK) {
-        FL_WARN("ChannelEngineSpi: spi_bus_initialize failed: " << ret);
+        FL_WARN_F("ChannelEngineSpi: spi_bus_initialize failed: %s", ret);
         releaseSpiHost(state->spi_host);
         state->spi_host = SPI_HOST_MAX;
         return false;
@@ -1014,7 +981,7 @@ bool ChannelEngineSpi::createChannel(SpiChannelState *state, gpio_num_t pin,
     // For WS2812 (1250ns period): 8e9 / 1250 = 6.4 MHz
     const u32 total_period_ns = timing.total_period_ns();
     const u32 spi_clock_hz = calculateWave8SpiClockHz(total_period_ns > 0 ? total_period_ns : 1250);
-    FL_DBG("ChannelEngineSpi: Wave8 SPI clock: " << spi_clock_hz << "Hz (8-bit expansion, period=" << total_period_ns << "ns)");
+    FL_DBG_F("ChannelEngineSpi: Wave8 SPI clock: %sHz (8-bit expansion, period=%sns)", spi_clock_hz, total_period_ns);
 
     spi_device_interface_config_t dev_config = {};
     dev_config.clock_source = SPI_CLK_SRC_DEFAULT;  // Match Espressif led_strip (ESP-IDF 5.x)
@@ -1029,10 +996,7 @@ bool ChannelEngineSpi::createChannel(SpiChannelState *state, gpio_num_t pin,
     // Reference: https://github.com/espressif/idf-extra-components/blob/master/led_strip/src/led_strip_spi_dev.c
     dev_config.post_cb = nullptr;
 
-    FL_DBG("ChannelEngineSpi: SPI clock_hz=" << spi_clock_hz
-           << " (wave8 encoding)"
-           << ", bits_per_led_bit=8 (wave8)"
-           << ", buffer_size=" << spiBufferSize << " bytes");
+    FL_DBG_F("ChannelEngineSpi: SPI clock_hz=%s (wave8 encoding), bits_per_led_bit=8 (wave8), buffer_size=%s bytes", spi_clock_hz, spiBufferSize);
 
     // Device flags configuration:
     // Match Espressif led_strip pattern: minimal flags
@@ -1042,34 +1006,31 @@ bool ChannelEngineSpi::createChannel(SpiChannelState *state, gpio_num_t pin,
     if (state->numLanes >= 2) {
         // Multi-lane mode REQUIRES HALFDUPLEX flag per ESP-IDF documentation
         dev_config.flags = SPI_DEVICE_HALFDUPLEX;
-        FL_DBG("ChannelEngineSpi: Multi-lane mode (" << static_cast<int>(state->numLanes)
-               << " lanes) - using SPI_DEVICE_HALFDUPLEX");
+        FL_DBG_F("ChannelEngineSpi: Multi-lane mode (%s lanes) - using SPI_DEVICE_HALFDUPLEX", static_cast<int>(state->numLanes));
     } else {
         // Single-lane: match Espressif led_strip (no flags)
         dev_config.flags = 0;
-        FL_DBG("ChannelEngineSpi: Single-lane mode - no device flags (matches Espressif led_strip)");
+        FL_DBG_F("ChannelEngineSpi: Single-lane mode - no device flags (matches Espressif led_strip)");
     }
 
     // Add device to bus
     ret = spi_bus_add_device(state->spi_host, &dev_config, &state->spi_device);
     if (ret != ESP_OK) {
-        FL_WARN("ChannelEngineSpi: spi_bus_add_device failed: " << ret);
+        FL_WARN_F("ChannelEngineSpi: spi_bus_add_device failed: %s", ret);
         spi_bus_free(state->spi_host);
         releaseSpiHost(state->spi_host);
         state->spi_host = SPI_HOST_MAX;
         return false;
     }
 
-    // Verify actual clock frequency (tolerance: ±500 kHz for wave8)
+    // Verify actual clock frequency (tolerance: Â±500 kHz for wave8)
     int actual_freq_khz = 0;
     spi_device_get_actual_freq(state->spi_device, &actual_freq_khz);
     const int requested_freq_khz = static_cast<int>(spi_clock_hz / 1000);
-    FL_DBG("ChannelEngineSpi: Actual SPI clock frequency: " << actual_freq_khz << " kHz (requested " << requested_freq_khz << " kHz)");
+    FL_DBG_F("ChannelEngineSpi: Actual SPI clock frequency: %s kHz (requested %s kHz)", actual_freq_khz, requested_freq_khz);
     if (actual_freq_khz < requested_freq_khz - 500 ||
         actual_freq_khz > requested_freq_khz + 500) {
-        FL_WARN_ONCE("ChannelEngineSpi: Clock frequency mismatch - requested "
-                << requested_freq_khz << " kHz, actual " << actual_freq_khz
-                << " kHz (tolerance: ±500kHz)");
+        FL_WARN_F_ONCE("ChannelEngineSpi: Clock frequency mismatch - requested %s kHz, actual %s kHz (tolerance: Â±500kHz)", requested_freq_khz, actual_freq_khz);
     }
 
     // NOTE: Do NOT call gpio_set_drive_capability() here.
@@ -1094,7 +1055,7 @@ bool ChannelEngineSpi::createChannel(SpiChannelState *state, gpio_num_t pin,
         staging_size, MALLOC_CAP_INTERNAL | MALLOC_CAP_DMA);
 
     if (!state->stagingA || !state->stagingB) {
-        FL_WARN("ChannelEngineSpi: Failed to allocate staging buffers");
+        FL_WARN_F("ChannelEngineSpi: Failed to allocate staging buffers");
         if (state->stagingA) { heap_caps_free(state->stagingA); state->stagingA = nullptr; }
         if (state->stagingB) { heap_caps_free(state->stagingB); state->stagingB = nullptr; }
         spi_bus_remove_device(state->spi_device);
@@ -1107,7 +1068,7 @@ bool ChannelEngineSpi::createChannel(SpiChannelState *state, gpio_num_t pin,
     fl::memset(state->stagingA, 0, staging_size);
     fl::memset(state->stagingB, 0, staging_size);
 
-    FL_DBG("ChannelEngineSpi: Allocated double staging buffers via heap_caps_malloc (INTERNAL|DMA)");
+    FL_DBG_F("ChannelEngineSpi: Allocated double staging buffers via heap_caps_malloc (INTERNAL|DMA)");
 
     state->stagingCapacity = staging_size;
     state->currentStaging = state->stagingA;
@@ -1121,8 +1082,7 @@ bool ChannelEngineSpi::createChannel(SpiChannelState *state, gpio_num_t pin,
     state->ledSourceBufferSize = state->ledSourceBuffer ? dataSize : 0;
 
     if (!state->ledSourceBuffer) {
-        FL_WARN("ChannelEngineSpi: Failed to allocate LED source buffer ("
-                << dataSize << " bytes) - falling back to direct access");
+        FL_WARN_F("ChannelEngineSpi: Failed to allocate LED source buffer (%s bytes) - falling back to direct access", dataSize);
         // Continue without buffer - will try direct access (may fail on PSRAM)
     }
 
@@ -1151,15 +1111,13 @@ bool ChannelEngineSpi::createChannel(SpiChannelState *state, gpio_num_t pin,
         ct.name = timing.name;
         state->wave8Lut = buildWave8ExpansionLUT(ct);
         state->wave8LutInitialized = true;
-        FL_DBG("ChannelEngineSpi: Built wave8 LUT (T1=" << ct.T1 << ", T2=" << ct.T2 << ", T3=" << ct.T3 << ")");
+        FL_DBG_F("ChannelEngineSpi: Built wave8 LUT (T1=%s, T2=%s, T3=%s)", ct.T1, ct.T2, ct.T3);
     }
 
     // NOTE: Timer ISR removed. Transmission uses double-buffered streaming via
     // transmitStreaming() with spi_device_queue_trans()/spi_device_get_trans_result().
 
-    FL_DBG_EVERY(10, "ChannelEngineSpi: Created pin=" << pin
-           << " lanes=" << static_cast<int>(state->numLanes)
-           << " host=" << state->spi_host);
+    FL_DBG_F_EVERY(10, "ChannelEngineSpi: Created pin=%s lanes=%s host=%s", pin, static_cast<int>(state->numLanes), state->spi_host);
 
     return true;
 }
@@ -1224,8 +1182,7 @@ spi_host_device_t ChannelEngineSpi::acquireSpiHost() FL_NOEXCEPT {
         if (tracking->refCount == 0) {
             tracking->refCount++;
             tracking->initialized = true;
-            FL_DBG("ChannelEngineSpi: Acquired SPI host "
-                   << host << " (refCount=" << tracking->refCount << ")");
+            FL_DBG_F("ChannelEngineSpi: Acquired SPI host %s (refCount=%s)", host, tracking->refCount);
             return host;
         }
     }
@@ -1233,7 +1190,7 @@ spi_host_device_t ChannelEngineSpi::acquireSpiHost() FL_NOEXCEPT {
     // Single SPI host policy: Only one SPI host is used
     // If we get here, the preferred host is already in use - this is expected behavior
     // for multiple channels. The caller will queue the channel for later.
-    FL_DBG_EVERY(10, "ChannelEngineSpi: SPI host in use, channel will be queued for sequential transmission");
+    FL_DBG_F_EVERY(10, "ChannelEngineSpi: SPI host in use, channel will be queued for sequential transmission");
     return SPI_HOST_MAX;
 }
 
@@ -1242,14 +1199,13 @@ void ChannelEngineSpi::releaseSpiHost(spi_host_device_t host) FL_NOEXCEPT {
         if (entry.host == host) {
             if (entry.refCount > 0) {
                 entry.refCount--;
-                FL_DBG("ChannelEngineSpi: Released SPI host "
-                       << host << " (refCount=" << entry.refCount << ")");
+                FL_DBG_F("ChannelEngineSpi: Released SPI host %s (refCount=%s)", host, entry.refCount);
 
                 if (entry.refCount == 0) {
                     // Free the SPI bus
                     spi_bus_free(host);
                     entry.initialized = false;
-                    FL_DBG("ChannelEngineSpi: Freed SPI bus " << host);
+                    FL_DBG_F("ChannelEngineSpi: Freed SPI bus %s", host);
                 }
             }
             return;
@@ -1273,9 +1229,7 @@ void ChannelEngineSpi::processPendingChannels() FL_NOEXCEPT {
 
             // Give up after 50 failed attempts to prevent infinite retry storms
             if (pending.retry_count > 50) {
-                FL_WARN_ONCE("ChannelEngineSpi: Giving up on pending channel for pin "
-                         << pin << " after " << pending.retry_count << " failed attempts. "
-                         << "Possible resource leak or hardware unavailability.");
+                FL_WARN_F_ONCE("ChannelEngineSpi: Giving up on pending channel for pin %s after %s failed attempts. Possible resource leak or hardware unavailability.", pin, pending.retry_count);
                 // Drop this pending channel (don't add to stillPending)
                 continue;
             }
@@ -1301,7 +1255,7 @@ void ChannelEngineSpi::processPendingChannels() FL_NOEXCEPT {
             channel->ledSource = channel->ledSourceBuffer;
         } else {
             channel->ledSource = ledData.data();
-            FL_WARN_ONCE("ChannelEngineSpi: Using direct PSRAM access (ISR-unsafe!) in processPendingChannels");
+            FL_WARN_F_ONCE("ChannelEngineSpi: Using direct PSRAM access (ISR-unsafe!) in processPendingChannels");
         }
         channel->ledBytesRemaining = ledData.size();
 
@@ -1330,12 +1284,12 @@ size_t ChannelEngineSpi::encodeChunk(SpiChannelState* channel, u8* output, size_
     }
 
     if (!channel->wave8LutInitialized) {
-        FL_WARN("ChannelEngineSpi: Wave8 LUT not initialized, cannot encode");
+        FL_WARN_F("ChannelEngineSpi: Wave8 LUT not initialized, cannot encode");
         return 0;
     }
 
     if (channel->numLanes > 1) {
-        FL_WARN_ONCE("ChannelEngineSpi: Multi-lane wave8 encoding not yet implemented, using single-lane");
+        FL_WARN_F_ONCE("ChannelEngineSpi: Multi-lane wave8 encoding not yet implemented, using single-lane");
     }
 
     // Single-lane wave8 encoding via LUT
@@ -1485,7 +1439,7 @@ void ChannelEngineSpi::startFirstDma() FL_NOEXCEPT {
         // For long strips (>~680 LEDs) the encoded SPI data spans more than one
         // staging buffer. The naive approach (queue chunk A, wait, queue B,
         // wait, ...) leaves the SPI line idle for the poll() latency between
-        // chunks. Under RTOS contention that gap can exceed WS2812B's ~50µs
+        // chunks. Under RTOS contention that gap can exceed WS2812B's ~50Âµs
         // reset threshold and trigger a visible refresh.
         //
         // Fix: when async DMA is available, pre-encode and pre-queue the
@@ -1533,12 +1487,12 @@ void ChannelEngineSpi::startFirstDma() FL_NOEXCEPT {
                     // stream after A.
                     ch->ledSource = savedSource;
                     ch->ledBytesRemaining = savedRemaining;
-                    FL_WARN("ChannelEngineSpi: startFirstDma pre-queue B failed: " << retB);
+                    FL_WARN_F("ChannelEngineSpi: startFirstDma pre-queue B failed: %s", retB);
                 }
             }
         }
     } else {
-        FL_WARN("ChannelEngineSpi: startFirstDma spiStart failed: " << ret);
+        FL_WARN_F("ChannelEngineSpi: startFirstDma spiStart failed: %s", ret);
         ch->transmissionComplete = true;
         mPipeline.mPhase = DmaPipelineState::IDLE;
     }
@@ -1557,7 +1511,7 @@ IChannelDriver::DriverState ChannelEngineSpi::advancePipeline() FL_NOEXCEPT {
             return DriverState::READY;
         }
 
-        // "Any chunk in flight" — refreshed each iteration. Tracks the real
+        // "Any chunk in flight" â€” refreshed each iteration. Tracks the real
         // state of both transA and transB so that pre-queued back-to-back
         // chunks are accounted for (issue #2304).
         bool anyInFlight = ch->transAInFlight || ch->transBInFlight;
@@ -1588,7 +1542,7 @@ IChannelDriver::DriverState ChannelEngineSpi::advancePipeline() FL_NOEXCEPT {
 
         // Encode and queue next chunk if data remains. After the back-to-back
         // pre-queue in startFirstDma(), this fires on each subsequent
-        // completion and refills the buffer that just freed up — keeping
+        // completion and refills the buffer that just freed up â€” keeping
         // two transactions in the SPI ISR's queue so it can chain them
         // gap-free.
         if (ch->ledBytesRemaining > 0) {
@@ -1616,7 +1570,7 @@ IChannelDriver::DriverState ChannelEngineSpi::advancePipeline() FL_NOEXCEPT {
             return DriverState::DRAINING;
         }
 
-        // No more data to encode — drain any chunks still in flight before
+        // No more data to encode â€” drain any chunks still in flight before
         // marking the channel complete.
         if (anyInFlight) {
             mPipeline.mPhase = DmaPipelineState::COMPLETING;

--- a/src/platforms/esp/32/drivers/spi/idf5_clockless_spi_esp32.h
+++ b/src/platforms/esp/32/drivers/spi/idf5_clockless_spi_esp32.h
@@ -56,7 +56,7 @@ protected:
     virtual void showPixels(PixelController<RGB_ORDER> &pixels) FL_NOEXCEPT override
     {
         if (!mDriver) {
-            FL_WARN_EVERY(100, "No Engine");
+            FL_WARN_F_EVERY(100, "No Engine");
             return;
         }
         // Wait for previous transmission to complete and release buffer
@@ -64,10 +64,10 @@ protected:
         u32 startTime = fl::millis();
         u32 lastWarnTime = startTime;
         if (mChannelData->isInUse()) {
-            FL_WARN_EVERY(100, "ClocklessSPI: driver should have finished transmitting by now - waiting");
+            FL_WARN_F_EVERY(100, "ClocklessSPI: driver should have finished transmitting by now - waiting");
             bool finished = mDriver->waitForReady();
             if (!finished) {
-                FL_ERROR("ClocklessSPI: Engine still busy after " << fl::millis() - startTime << "ms");
+                FL_ERROR_F("ClocklessSPI: Engine still busy after %sms", fl::millis() - startTime);
                 return;
             }
         }

--- a/src/platforms/esp/32/drivers/spi/spi_device_proxy.h
+++ b/src/platforms/esp/32/drivers/spi/spi_device_proxy.h
@@ -88,8 +88,7 @@ public:
         mHandle = mBusManager->registerDevice(CLOCK_PIN, DATA_PIN, SPI_SPEED, this);
 
         if (!mHandle.is_valid) {
-            FL_LOG_SPI("Failed to register with bus manager (pin "
-                    << CLOCK_PIN << ":" << DATA_PIN << ")");
+            FL_LOG_SPI_F("Failed to register with bus manager (pin %s:%s)", CLOCK_PIN, DATA_PIN);
             return;
         }
 

--- a/src/platforms/esp/32/drivers/spi/spi_peripheral_esp.cpp.hpp
+++ b/src/platforms/esp/32/drivers/spi/spi_peripheral_esp.cpp.hpp
@@ -124,7 +124,7 @@ SpiPeripheralESPImpl::~SpiPeripheralESPImpl() {
 bool SpiPeripheralESPImpl::initializeBus(const SpiBusConfig& config) FL_NOEXCEPT {
     // Validate not already initialized
     if (mBusInitialized) {
-        FL_WARN("SpiPeripheralESP: Bus already initialized");
+        FL_WARN_F("SpiPeripheralESP: Bus already initialized");
         return false;
     }
 
@@ -145,25 +145,24 @@ bool SpiPeripheralESPImpl::initializeBus(const SpiBusConfig& config) FL_NOEXCEPT
     // Initialize bus with auto DMA channel selection (delegate to ESP-IDF)
     esp_err_t err = ::spi_bus_initialize(mHost, &bus_config, SPI_DMA_CH_AUTO);
     if (err != ESP_OK) {
-        FL_WARN("SpiPeripheralESP: Failed to initialize bus: " << err);
+        FL_WARN_F("SpiPeripheralESP: Failed to initialize bus: %s", err);
         return false;
     }
 
     mBusInitialized = true;
-    FL_DBG("SpiPeripheralESP: Bus initialized (MOSI=" << config.mosi_pin
-           << ", SCLK=" << config.sclk_pin << ")");
+    FL_DBG_F("SpiPeripheralESP: Bus initialized (MOSI=%s, SCLK=%s)", config.mosi_pin, config.sclk_pin);
 
     return true;
 }
 
 bool SpiPeripheralESPImpl::addDevice(const SpiDeviceConfig& config) FL_NOEXCEPT {
     if (!mBusInitialized) {
-        FL_WARN("SpiPeripheralESP: Cannot add device - bus not initialized");
+        FL_WARN_F("SpiPeripheralESP: Cannot add device - bus not initialized");
         return false;
     }
 
     if (mDeviceAdded) {
-        FL_WARN("SpiPeripheralESP: Device already added");
+        FL_WARN_F("SpiPeripheralESP: Device already added");
         return false;
     }
 
@@ -183,20 +182,19 @@ bool SpiPeripheralESPImpl::addDevice(const SpiDeviceConfig& config) FL_NOEXCEPT 
     // Add device to bus (delegate to ESP-IDF)
     esp_err_t err = ::spi_bus_add_device(mHost, &dev_config, &mDeviceHandle);
     if (err != ESP_OK) {
-        FL_WARN("SpiPeripheralESP: Failed to add device: " << err);
+        FL_WARN_F("SpiPeripheralESP: Failed to add device: %s", err);
         return false;
     }
 
     mDeviceAdded = true;
-    FL_DBG("SpiPeripheralESP: Device added (clock=" << config.clock_speed_hz
-           << " Hz, queue=" << config.queue_size << ")");
+    FL_DBG_F("SpiPeripheralESP: Device added (clock=%s Hz, queue=%s)", config.clock_speed_hz, config.queue_size);
 
     return true;
 }
 
 bool SpiPeripheralESPImpl::removeDevice() FL_NOEXCEPT {
     if (!mDeviceAdded) {
-        FL_WARN("SpiPeripheralESP: No device to remove");
+        FL_WARN_F("SpiPeripheralESP: No device to remove");
         return false;
     }
 
@@ -211,7 +209,7 @@ bool SpiPeripheralESPImpl::removeDevice() FL_NOEXCEPT {
         // Remove device (delegate to ESP-IDF)
         esp_err_t err = ::spi_bus_remove_device(mDeviceHandle);
         if (err != ESP_OK) {
-            FL_WARN("SpiPeripheralESP: Failed to remove device: " << err);
+            FL_WARN_F("SpiPeripheralESP: Failed to remove device: %s", err);
             return false;
         }
 
@@ -219,31 +217,31 @@ bool SpiPeripheralESPImpl::removeDevice() FL_NOEXCEPT {
     }
 
     mDeviceAdded = false;
-    FL_DBG("SpiPeripheralESP: Device removed");
+    FL_DBG_F("SpiPeripheralESP: Device removed");
 
     return true;
 }
 
 bool SpiPeripheralESPImpl::freeBus() FL_NOEXCEPT {
     if (!mBusInitialized) {
-        FL_WARN("SpiPeripheralESP: Bus not initialized");
+        FL_WARN_F("SpiPeripheralESP: Bus not initialized");
         return false;
     }
 
     if (mDeviceAdded) {
-        FL_WARN("SpiPeripheralESP: Cannot free bus - device still attached");
+        FL_WARN_F("SpiPeripheralESP: Cannot free bus - device still attached");
         return false;
     }
 
     // Free bus resources (delegate to ESP-IDF)
     esp_err_t err = ::spi_bus_free(mHost);
     if (err != ESP_OK) {
-        FL_WARN("SpiPeripheralESP: Failed to free bus: " << err);
+        FL_WARN_F("SpiPeripheralESP: Failed to free bus: %s", err);
         return false;
     }
 
     mBusInitialized = false;
-    FL_DBG("SpiPeripheralESP: Bus freed");
+    FL_DBG_F("SpiPeripheralESP: Bus freed");
 
     return true;
 }
@@ -258,7 +256,7 @@ bool SpiPeripheralESPImpl::isInitialized() const FL_NOEXCEPT {
 
 bool SpiPeripheralESPImpl::queueTransaction(const SpiTransaction& trans) FL_NOEXCEPT {
     if (!mDeviceAdded) {
-        FL_WARN("SpiPeripheralESP: Cannot queue transaction - device not added");
+        FL_WARN_F("SpiPeripheralESP: Cannot queue transaction - device not added");
         return false;
     }
 
@@ -273,7 +271,7 @@ bool SpiPeripheralESPImpl::queueTransaction(const SpiTransaction& trans) FL_NOEX
     // portMAX_DELAY = block until queue has space
     esp_err_t err = ::spi_device_queue_trans(mDeviceHandle, &esp_trans, portMAX_DELAY);
     if (err != ESP_OK) {
-        FL_WARN("SpiPeripheralESP: Failed to queue transaction: " << err);
+        FL_WARN_F("SpiPeripheralESP: Failed to queue transaction: %s", err);
         return false;
     }
 
@@ -282,7 +280,7 @@ bool SpiPeripheralESPImpl::queueTransaction(const SpiTransaction& trans) FL_NOEX
 
 bool SpiPeripheralESPImpl::pollTransaction(u32 timeout_ms) FL_NOEXCEPT {
     if (!mDeviceAdded) {
-        FL_WARN("SpiPeripheralESP: Cannot poll transaction - device not added");
+        FL_WARN_F("SpiPeripheralESP: Cannot poll transaction - device not added");
         return false;
     }
 
@@ -297,7 +295,7 @@ bool SpiPeripheralESPImpl::pollTransaction(u32 timeout_ms) FL_NOEXCEPT {
     }
 
     if (err != ESP_OK) {
-        FL_WARN("SpiPeripheralESP: Failed to get transaction result: " << err);
+        FL_WARN_F("SpiPeripheralESP: Failed to get transaction result: %s", err);
         return false;
     }
 
@@ -312,7 +310,7 @@ bool SpiPeripheralESPImpl::registerCallback(void* callback, void* user_ctx) FL_N
     // Note: The callback will be registered when addDevice() is called
     // (ESP-IDF requires callback to be set in device config)
 
-    FL_DBG("SpiPeripheralESP: Callback registered");
+    FL_DBG_F("SpiPeripheralESP: Callback registered");
     return true;
 }
 
@@ -330,7 +328,7 @@ u8* SpiPeripheralESPImpl::allocateDma(size_t size) FL_NOEXCEPT {
     );
 
     if (buffer == nullptr) {
-        FL_WARN("SpiPeripheralESP: Failed to allocate DMA buffer (" << size << " bytes)");
+        FL_WARN_F("SpiPeripheralESP: Failed to allocate DMA buffer (%s bytes)", size);
     }
 
     return buffer;

--- a/src/platforms/esp/32/drivers/spi/wave8_encoder_spi.h
+++ b/src/platforms/esp/32/drivers/spi/wave8_encoder_spi.h
@@ -53,8 +53,7 @@ inline size_t wave8EncodeSingleLane(
 
     const size_t required_size = input.size() * 8;
     if (output.size() < required_size) {
-        FL_WARN("wave8EncodeSingleLane: Output buffer too small (need "
-                << required_size << " bytes, have " << output.size() << " bytes)");
+        FL_WARN_F("wave8EncodeSingleLane: Output buffer too small (need %s bytes, have %s bytes)", required_size, output.size());
         return 0;
     }
 
@@ -86,15 +85,13 @@ inline size_t wave8EncodeDualLane(
     const Wave8BitExpansionLut& lut) FL_NOEXCEPT {
 
     if (lane0.size() != lane1.size()) {
-        FL_WARN("wave8EncodeDualLane: Lane sizes mismatch (lane0="
-                << lane0.size() << " bytes, lane1=" << lane1.size() << " bytes)");
+        FL_WARN_F("wave8EncodeDualLane: Lane sizes mismatch (lane0=%s bytes, lane1=%s bytes)", lane0.size(), lane1.size());
         return 0;
     }
 
     const size_t required_size = lane0.size() * 16;
     if (output.size() < required_size) {
-        FL_WARN("wave8EncodeDualLane: Output buffer too small (need "
-                << required_size << " bytes, have " << output.size() << " bytes)");
+        FL_WARN_F("wave8EncodeDualLane: Output buffer too small (need %s bytes, have %s bytes)", required_size, output.size());
         return 0;
     }
 
@@ -132,16 +129,14 @@ inline size_t wave8EncodeQuadLane(
     const size_t lane_size = lanes[0].size();
     for (int i = 1; i < 4; i++) {
         if (lanes[i].size() != lane_size) {
-            FL_WARN("wave8EncodeQuadLane: Lane size mismatch (lane0="
-                    << lane_size << " bytes, lane" << i << "=" << lanes[i].size() << " bytes)");
+            FL_WARN_F("wave8EncodeQuadLane: Lane size mismatch (lane0=%s bytes, lane%s=%s bytes)", lane_size, i, lanes[i].size());
             return 0;
         }
     }
 
     const size_t required_size = lane_size * 32;
     if (output.size() < required_size) {
-        FL_WARN("wave8EncodeQuadLane: Output buffer too small (need "
-                << required_size << " bytes, have " << output.size() << " bytes)");
+        FL_WARN_F("wave8EncodeQuadLane: Output buffer too small (need %s bytes, have %s bytes)", required_size, output.size());
         return 0;
     }
 

--- a/src/platforms/esp/32/drivers/spi_hw_manager_esp32.cpp.hpp
+++ b/src/platforms/esp/32/drivers/spi_hw_manager_esp32.cpp.hpp
@@ -39,13 +39,13 @@ constexpr int PRIORITY_HW_1 = 5;    ///< Standard single-lane SPI
 /// @brief Add SpiHw1 (single-lane SPI) if supported
 static void addSpiHw1IfPossible() FL_NOEXCEPT {
 #ifdef FL_IS_ESP32
-    FL_DBG("ESP32: Registering SpiHw1 controllers");
+    FL_DBG_F("ESP32: Registering SpiHw1 controllers");
 
     // Register SPI2_HOST controller
     fl::shared_ptr<SpiHw1> ctrl2 = getController2();
     if (ctrl2) {
         SpiHw1::registerInstance(ctrl2);
-        FL_DBG("ESP32: Registered SpiHw1 controller (SPI2)");
+        FL_DBG_F("ESP32: Registered SpiHw1 controller (SPI2)");
     }
 
     // Register SPI3_HOST controller if available (ESP32, ESP32-S2, ESP32-S3)
@@ -53,11 +53,11 @@ static void addSpiHw1IfPossible() FL_NOEXCEPT {
     fl::shared_ptr<SpiHw1> ctrl3 = getController3();
     if (ctrl3) {
         SpiHw1::registerInstance(ctrl3);
-        FL_DBG("ESP32: Registered SpiHw1 controller (SPI3)");
+        FL_DBG_F("ESP32: Registered SpiHw1 controller (SPI3)");
     }
 #endif
 
-    FL_DBG("ESP32: SpiHw1 registration complete");
+    FL_DBG_F("ESP32: SpiHw1 registration complete");
 #endif
 }
 
@@ -80,13 +80,13 @@ void initSpiHardware() FL_NOEXCEPT {
     }
     sInitialized = true;
 
-    FL_DBG("ESP32: Initializing SPI hardware");
+    FL_DBG_F("ESP32: Initializing SPI hardware");
 
     // Register SPI hardware
     // Note: SpiHw16 (I2S parallel) replaced by I2S_SPI/LCD_SPI channel drivers
     detail::addSpiHw1IfPossible();   // Priority 5 (single-lane SPI)
 
-    FL_DBG("ESP32: SPI hardware initialized");
+    FL_DBG_F("ESP32: SPI hardware initialized");
 }
 
 }  // namespace platforms

--- a/src/platforms/esp/32/drivers/uart/channel_driver_uart.cpp.hpp
+++ b/src/platforms/esp/32/drivers/uart/channel_driver_uart.cpp.hpp
@@ -31,7 +31,7 @@ ChannelEngineUART::ChannelEngineUART(fl::shared_ptr<IUartPeripheral> peripheral)
       mCurrentBaudRate(0),
       mCurrentGroupIndex(0) {
     if (!mPeripheral) {
-        FL_WARN("UART: Null peripheral pointer in constructor");
+        FL_WARN_F("UART: Null peripheral pointer in constructor");
     }
 }
 
@@ -232,16 +232,16 @@ const Wave10Lut& ChannelEngineUART::getOrBuildLut(const ChipsetTimingConfig& tim
 void ChannelEngineUART::beginTransmission(
     fl::span<const ChannelDataPtr> channelData) FL_NOEXCEPT {
 
-    FL_DBG("UART: beginTransmission() called with " << channelData.size() << " channel(s)");
+    FL_DBG_F("UART: beginTransmission() called with %s channel(s)", channelData.size());
 
     if (channelData.size() == 0) {
-        FL_DBG("UART: No channels to transmit (size==0)");
+        FL_DBG_F("UART: No channels to transmit (size==0)");
         return;
     }
 
     // UART is single-lane only - show() guarantees single channel per transmission
     if (channelData.size() != 1) {
-        FL_WARN("UART: Expected exactly 1 channel, got " << channelData.size() << " (internal error)");
+        FL_WARN_F("UART: Expected exactly 1 channel, got %s (internal error)", channelData.size());
         return;
     }
 
@@ -250,7 +250,7 @@ void ChannelEngineUART::beginTransmission(
     const ChipsetTimingConfig& timing = channel->getTiming();
     size_t dataSize = channel->getSize();
 
-    FL_DBG("UART: Channel pin=" << pin << ", dataSize=" << dataSize);
+    FL_DBG_F("UART: Channel pin=%s, dataSize=%s", pin, dataSize);
 
     if (dataSize == 0) {
         return;
@@ -263,12 +263,12 @@ void ChannelEngineUART::beginTransmission(
     if (!mInitialized || mCurrentBaudRate != required_baud) {
         if (mInitialized) {
             // Reinitialize with new baud rate
-            FL_DBG("UART: Reinitializing peripheral (baud change: " << mCurrentBaudRate << " -> " << required_baud << ")");
+            FL_DBG_F("UART: Reinitializing peripheral (baud change: %s -> %s)", mCurrentBaudRate, required_baud);
             mPeripheral->deinitialize();
             mInitialized = false;
         }
 
-        FL_DBG("UART: Initializing peripheral with baud=" << required_baud << ", pin=" << pin);
+        FL_DBG_F("UART: Initializing peripheral with baud=%s, pin=%s", required_baud, pin);
 
         UartPeripheralConfig config(
             required_baud,     // mBaudRate (derived from timing)
@@ -281,11 +281,11 @@ void ChannelEngineUART::beginTransmission(
         );
 
         if (!mPeripheral->initialize(config)) {
-            FL_WARN("UART: Peripheral initialization failed");
+            FL_WARN_F("UART: Peripheral initialization failed");
             return;
         }
 
-        FL_DBG("UART: Peripheral initialized successfully");
+        FL_DBG_F("UART: Peripheral initialized successfully");
         mInitialized = true;
         mCurrentBaudRate = required_baud;
     }
@@ -307,22 +307,21 @@ void ChannelEngineUART::beginTransmission(
         mEncodedBuffer.size(),
         lut);
 
-    FL_DBG("UART: Encoded " << encoded_bytes << " bytes from " << dataSize << " LED bytes");
+    FL_DBG_F("UART: Encoded %s bytes from %s LED bytes", encoded_bytes, dataSize);
 
     if (encoded_bytes == 0) {
-        FL_WARN("UART: Encoding failed (required="
-                << required_encoded_size << " bytes)");
+        FL_WARN_F("UART: Encoding failed (required=%s bytes)", required_encoded_size);
         return;
     }
 
     // Submit encoded data to UART peripheral
-    FL_DBG("UART: Writing " << encoded_bytes << " bytes to peripheral");
+    FL_DBG_F("UART: Writing %s bytes to peripheral", encoded_bytes);
     if (!mPeripheral->writeBytes(mEncodedBuffer.data(), encoded_bytes)) {
-        FL_WARN("UART: Write failed (size=" << encoded_bytes << " bytes)");
+        FL_WARN_F("UART: Write failed (size=%s bytes)", encoded_bytes);
         return;
     }
 
-    FL_DBG("UART: Write successful, transmission started (non-blocking DMA)");
+    FL_DBG_F("UART: Write successful, transmission started (non-blocking DMA)");
 }
 
 void ChannelEngineUART::prepareScratchBuffer(

--- a/src/platforms/esp/32/drivers/uart/uart_peripheral_esp.cpp.hpp
+++ b/src/platforms/esp/32/drivers/uart/uart_peripheral_esp.cpp.hpp
@@ -74,12 +74,11 @@ UartPeripheralEsp::~UartPeripheralEsp() {
 //=============================================================================
 
 bool UartPeripheralEsp::initialize(const UartPeripheralConfig& config) FL_NOEXCEPT {
-    FL_DBG("UART_PERIPH: initialize() called - uart_num=" << config.mUartNum
-           << " baud=" << config.mBaudRate);
+    FL_DBG_F("UART_PERIPH: initialize() called - uart_num=%s baud=%s", config.mUartNum, config.mBaudRate);
 
     // Validate not already initialized
     if (mInitialized) {
-        FL_WARN("UartPeripheralEsp: Already initialized");
+        FL_WARN_F("UartPeripheralEsp: Already initialized");
         return false;
     }
 
@@ -101,8 +100,7 @@ bool UartPeripheralEsp::initialize(const UartPeripheralConfig& config) FL_NOEXCE
     } else if (config.mStopBits == 2) {
         uart_config.stop_bits = UART_STOP_BITS_2;
     } else {
-        FL_WARN("UartPeripheralEsp: Invalid stop bits (" << config.mStopBits
-                << "), defaulting to 1");
+        FL_WARN_F("UartPeripheralEsp: Invalid stop bits (%s), defaulting to 1", config.mStopBits);
         uart_config.stop_bits = UART_STOP_BITS_1;
     }
 
@@ -113,10 +111,10 @@ bool UartPeripheralEsp::initialize(const UartPeripheralConfig& config) FL_NOEXCE
 #endif
 
     // Configure UART parameters (maps directly to ESP-IDF structure)
-    FL_DBG("UART_PERIPH: Calling uart_param_config()");
+    FL_DBG_F("UART_PERIPH: Calling uart_param_config()");
     esp_err_t err = uart_param_config(uart_num, &uart_config);
     if (err != ESP_OK) {
-        FL_WARN("UartPeripheralEsp: Failed to configure UART params: " << err);
+        FL_WARN_F("UartPeripheralEsp: Failed to configure UART params: %s", err);
         return false;
     }
 
@@ -126,7 +124,7 @@ bool UartPeripheralEsp::initialize(const UartPeripheralConfig& config) FL_NOEXCE
     // - queue_size: 0 (no event queue needed for LED control)
     // - uart_queue: NULL (no event queue)
     // - intr_alloc_flags: 0 (default interrupt priority)
-    FL_DBG("UART_PERIPH: Calling uart_driver_install()");
+    FL_DBG_F("UART_PERIPH: Calling uart_driver_install()");
     err = uart_driver_install(
         uart_num,
         config.mRxBufferSize,
@@ -136,13 +134,13 @@ bool UartPeripheralEsp::initialize(const UartPeripheralConfig& config) FL_NOEXCE
         0       // intr_alloc_flags
     );
     if (err != ESP_OK) {
-        FL_WARN("UartPeripheralEsp: Failed to install UART driver: " << err);
+        FL_WARN_F("UartPeripheralEsp: Failed to install UART driver: %s", err);
         return false;
     }
 
     // Configure GPIO pins
     // For LED control: TX-only (RX can be set to UART_PIN_NO_CHANGE or -1)
-    FL_DBG("UART_PERIPH: Calling uart_set_pin()");
+    FL_DBG_F("UART_PERIPH: Calling uart_set_pin()");
     int rx_pin = (config.mRxPin < 0) ? UART_PIN_NO_CHANGE : config.mRxPin;
     err = uart_set_pin(
         uart_num,
@@ -152,7 +150,7 @@ bool UartPeripheralEsp::initialize(const UartPeripheralConfig& config) FL_NOEXCE
         UART_PIN_NO_CHANGE              // CTS (not used)
     );
     if (err != ESP_OK) {
-        FL_WARN("UartPeripheralEsp: Failed to set UART pins: " << err);
+        FL_WARN_F("UartPeripheralEsp: Failed to set UART pins: %s", err);
         // Cleanup driver on error
         uart_driver_delete(uart_num);
         return false;
@@ -162,19 +160,16 @@ bool UartPeripheralEsp::initialize(const UartPeripheralConfig& config) FL_NOEXCE
     // Normal UART idle = HIGH, but WS2812 requires idle = LOW.
     // With TX inversion: idle=LOW, start bit=HIGH (leading edge),
     // stop bit=LOW (trailing edge). This creates correct WS2812 polarity.
-    FL_DBG("UART_PERIPH: Calling uart_set_line_inverse() for TX inversion");
+    FL_DBG_F("UART_PERIPH: Calling uart_set_line_inverse() for TX inversion");
     err = uart_set_line_inverse(uart_num, UART_SIGNAL_TXD_INV);
     if (err != ESP_OK) {
-        FL_WARN("UartPeripheralEsp: Failed to set TX inversion: " << err);
+        FL_WARN_F("UartPeripheralEsp: Failed to set TX inversion: %s", err);
         uart_driver_delete(uart_num);
         return false;
     }
 
     mInitialized = true;
-    FL_DBG("UART: Initialized (uart_num=" << config.mUartNum
-           << ", baud=" << config.mBaudRate
-           << ", tx_pin=" << config.mTxPin
-           << ", tx_inverted=true)");
+    FL_DBG_F("UART: Initialized (uart_num=%s, baud=%s, tx_pin=%s, tx_inverted=true)", config.mUartNum, config.mBaudRate, config.mTxPin);
 
     return true;
 }
@@ -187,22 +182,22 @@ void UartPeripheralEsp::deinitialize() FL_NOEXCEPT {
     uart_port_t uart_num = static_cast<uart_port_t>(mConfig.mUartNum);
 
     // Wait for any pending transmissions (with timeout)
-    FL_DBG("UART_PERIPH: Waiting for pending transmissions...");
+    FL_DBG_F("UART_PERIPH: Waiting for pending transmissions...");
     esp_err_t err = uart_wait_tx_done(uart_num, pdMS_TO_TICKS(1000));
     if (err != ESP_OK) {
-        FL_WARN("UartPeripheralEsp: Wait timeout during cleanup: " << err);
+        FL_WARN_F("UartPeripheralEsp: Wait timeout during cleanup: %s", err);
     }
 
     // Delete UART driver
-    FL_DBG("UART_PERIPH: Calling uart_driver_delete()");
+    FL_DBG_F("UART_PERIPH: Calling uart_driver_delete()");
     err = uart_driver_delete(uart_num);
     if (err != ESP_OK) {
-        FL_WARN("UartPeripheralEsp: Failed to delete UART driver: " << err);
+        FL_WARN_F("UartPeripheralEsp: Failed to delete UART driver: %s", err);
     }
 
     mInitialized = false;
     mResetExpireTime = 0;  // Clear reset period timer
-    FL_DBG("UART: Deinitialized (uart_num=" << mConfig.mUartNum << ")");
+    FL_DBG_F("UART: Deinitialized (uart_num=%s)", mConfig.mUartNum);
 }
 
 bool UartPeripheralEsp::isInitialized() const FL_NOEXCEPT {
@@ -215,12 +210,12 @@ bool UartPeripheralEsp::isInitialized() const FL_NOEXCEPT {
 
 bool UartPeripheralEsp::writeBytes(const u8* data, size_t length) FL_NOEXCEPT {
     if (!mInitialized) {
-        FL_WARN("UartPeripheralEsp: Cannot write - not initialized");
+        FL_WARN_F("UartPeripheralEsp: Cannot write - not initialized");
         return false;
     }
 
     if (data == nullptr) {
-        FL_WARN("UartPeripheralEsp: Cannot write - null buffer");
+        FL_WARN_F("UartPeripheralEsp: Cannot write - null buffer");
         return false;
     }
 
@@ -245,13 +240,13 @@ bool UartPeripheralEsp::writeBytes(const u8* data, size_t length) FL_NOEXCEPT {
 
     if (written < 0) {
         // Error occurred
-        FL_WARN("UartPeripheralEsp: Failed to write bytes: " << written);
+        FL_WARN_F("UartPeripheralEsp: Failed to write bytes: %s", written);
         return false;
     }
 
     if (static_cast<size_t>(written) != length) {
         // Partial write (shouldn't happen with blocking mode)
-        FL_WARN("UartPeripheralEsp: Partial write (" << written << " of " << length << " bytes)");
+        FL_WARN_F("UartPeripheralEsp: Partial write (%s of %s bytes)", written, length);
         return false;
     }
 
@@ -260,7 +255,7 @@ bool UartPeripheralEsp::writeBytes(const u8* data, size_t length) FL_NOEXCEPT {
 
 bool UartPeripheralEsp::waitTxDone(u32 timeout_ms) FL_NOEXCEPT {
     if (!mInitialized) {
-        FL_WARN("UartPeripheralEsp: Cannot wait - not initialized");
+        FL_WARN_F("UartPeripheralEsp: Cannot wait - not initialized");
         return false;
     }
 

--- a/src/platforms/esp/32/drivers/usb_serial_jtag_esp32_idf.hpp
+++ b/src/platforms/esp/32/drivers/usb_serial_jtag_esp32_idf.hpp
@@ -222,7 +222,7 @@ void UsbSerialJtagEsp32::write(const char* str) FL_NOEXCEPT {
                 src += (size_t)written;
                 remaining -= (size_t)written;
             } else if (written < 0) {
-                FL_WARN("USB-Serial JTAG write failed: err=" << written);
+                FL_WARN_F("USB-Serial JTAG write failed: err=%s", written);
                 break;
             }
             // written == 0: buffer full, will retry after timeout
@@ -293,7 +293,7 @@ void UsbSerialJtagEsp32::writeln(const char* str) FL_NOEXCEPT {
                 src += (size_t)written;
                 remaining -= (size_t)written;
             } else if (written < 0) {
-                FL_WARN("USB-Serial JTAG writeln failed: err=" << written);
+                FL_WARN_F("USB-Serial JTAG writeln failed: err=%s", written);
                 break;
             }
             // written == 0: buffer full after timeout, retry

--- a/src/platforms/esp/32/init_esp32.cpp.hpp
+++ b/src/platforms/esp/32/init_esp32.cpp.hpp
@@ -29,7 +29,7 @@ void init() {
         return;  // Already initialized
     }
 
-    FL_DBG("ESP32: Platform initialization starting");
+    FL_DBG_F("ESP32: Platform initialization starting");
 
     // Initialize channel bus manager (PARLIO, SPI, RMT, UART drivers)
     // Note: This is actually called lazily on first access to ChannelManager::instance()
@@ -42,7 +42,7 @@ void init() {
     (void)fl::getSPIBusManager();
 
     initialized = true;
-    FL_DBG("ESP32: Platform initialization complete");
+    FL_DBG_F("ESP32: Platform initialization complete");
 }
 
 } // namespace platforms

--- a/src/platforms/esp/32/interrupts/riscv.cpp.hpp
+++ b/src/platforms/esp/32/interrupts/riscv.cpp.hpp
@@ -44,14 +44,12 @@ esp_err_t fastled_riscv_install_interrupt(
     intr_handle_t *handle
 ) {
     if (priority < 1 || priority > FASTLED_RISCV_MAX_PRIORITY) {
-        FL_LOG_INTERRUPT("Invalid priority level: " << priority <<
-               " (must be 1-" << FASTLED_RISCV_MAX_PRIORITY << ")");
+        FL_LOG_INTERRUPT_F("Invalid priority level: %s (must be 1-%s)", priority, FASTLED_RISCV_MAX_PRIORITY);
         return ESP_ERR_INVALID_ARG;
     }
 
     if (handler == nullptr || handle == nullptr) {
-        FL_LOG_INTERRUPT("Invalid arguments: handler=" << (void*)handler <<
-               " handle=" << (void*)handle);
+        FL_LOG_INTERRUPT_F("Invalid arguments: handler=%s handle=%s", (void*)handler, (void*)handle);
         return ESP_ERR_INVALID_ARG;
     }
 
@@ -72,21 +70,20 @@ esp_err_t fastled_riscv_install_interrupt(
         case 6: flags |= ESP_INTR_FLAG_LEVEL6; break;
         case 7: flags |= ESP_INTR_FLAG_NMI; break; // Level 7 may be NMI
         default:
-            FL_LOG_INTERRUPT("Unsupported priority level: " << priority);
+            FL_LOG_INTERRUPT_F("Unsupported priority level: %s", priority);
             return ESP_ERR_NOT_SUPPORTED;
     }
 
-    FL_LOG_INTERRUPT("Installing interrupt source=" << source <<
-           " priority=" << priority << " flags=0x" << flags);
+    FL_LOG_INTERRUPT_F("Installing interrupt source=%s priority=%s flags=0x%s", source, priority, flags);
 
     esp_err_t err = esp_intr_alloc(source, flags, handler, arg, handle);
 
     if (err != ESP_OK) {
-        FL_LOG_RMT("Failed to allocate interrupt: " << esp_err_to_name(err));
+        FL_LOG_RMT_F("Failed to allocate interrupt: %s", esp_err_to_name(err));
         return err;
     }
 
-    FL_LOG_INTERRUPT("Interrupt installed successfully");
+    FL_LOG_INTERRUPT_F("Interrupt installed successfully");
     return ESP_OK;
 }
 
@@ -96,8 +93,7 @@ esp_err_t fastled_riscv_install_official_interrupt(
     void *arg,
     intr_handle_t *handle
 ) {
-    FL_LOG_INTERRUPT("Installing official FastLED interrupt (priority " <<
-           FASTLED_RISCV_PRIORITY_RECOMMENDED << ")");
+    FL_LOG_INTERRUPT_F("Installing official FastLED interrupt (priority %s)", FASTLED_RISCV_PRIORITY_RECOMMENDED);
     return fastled_riscv_install_interrupt(
         source,
         FASTLED_RISCV_PRIORITY_RECOMMENDED,
@@ -115,7 +111,7 @@ esp_err_t fastled_riscv_install_experimental_interrupt(
     intr_handle_t *handle
 ) {
     if (priority < 4 || priority > 7) {
-        FL_LOG_RMT("Experimental priority must be 4-7, got " << priority);
+        FL_LOG_RMT_F("Experimental priority must be 4-7, got %s", priority);
         return ESP_ERR_INVALID_ARG;
     }
 
@@ -131,9 +127,9 @@ esp_err_t fastled_riscv_install_experimental_interrupt(
     //
     // TODO: Implement RISC-V assembly interrupt stubs (*.S files) if Level 4+
     // is proven necessary. For now, use priority 3 with official driver.
-    FL_LOG_RMT("CANNOT INSTALL: Priority 4-7 requires ASSEMBLY handlers (not C)");
-    FL_LOG_RMT("ESP-IDF docs: handlers must be nullptr for levels >3");
-    FL_LOG_RMT("Use fastled_riscv_install_official_interrupt() for priority 1-3");
+    FL_LOG_RMT_F("CANNOT INSTALL: Priority 4-7 requires ASSEMBLY handlers (not C)");
+    FL_LOG_RMT_F("ESP-IDF docs: handlers must be nullptr for levels >3");
+    FL_LOG_RMT_F("Use fastled_riscv_install_official_interrupt() for priority 1-3");
 
     return ESP_ERR_NOT_SUPPORTED;
 }
@@ -173,20 +169,17 @@ esp_err_t fastled_riscv_rmt_init_official(
     int priority_level
 ) {
     if (priority_level < 1 || priority_level > FASTLED_RISCV_PRIORITY_OFFICIAL_MAX) {
-        FL_LOG_RMT("Official RMT priority must be 1-" <<
-                FASTLED_RISCV_PRIORITY_OFFICIAL_MAX << ", got " << priority_level);
+        FL_LOG_RMT_F("Official RMT priority must be 1-%s, got %s", FASTLED_RISCV_PRIORITY_OFFICIAL_MAX, priority_level);
         return ESP_ERR_INVALID_ARG;
     }
 
-    FL_LOG_INTERRUPT("Initializing RMT channel " << channel <<
-           " on GPIO " << gpio_num <<
-           " with priority " << priority_level);
+    FL_LOG_INTERRUPT_F("Initializing RMT channel %s on GPIO %s with priority %s", channel, gpio_num, priority_level);
 
     // TODO: Implement RMT initialization using official driver API
     // This would use rmt_tx_channel_config_t with intr_priority field
     // For now, return not implemented
 
-    FL_LOG_RMT("fastled_riscv_rmt_init_official: NOT YET IMPLEMENTED");
+    FL_LOG_RMT_F("fastled_riscv_rmt_init_official: NOT YET IMPLEMENTED");
     return ESP_ERR_NOT_SUPPORTED;
 }
 
@@ -198,7 +191,7 @@ esp_err_t fastled_riscv_rmt_init_experimental(
     int priority_level
 ) {
     if (priority_level < 4 || priority_level > 7) {
-        FL_LOG_RMT("Experimental RMT priority must be 4-7, got " << priority_level);
+        FL_LOG_RMT_F("Experimental RMT priority must be 4-7, got %s", priority_level);
         return ESP_ERR_INVALID_ARG;
     }
 
@@ -215,8 +208,8 @@ esp_err_t fastled_riscv_rmt_init_experimental(
     //
     // Recommendation: Use fastled_riscv_rmt_init_official() with priority 1-3.
     // Test if Level 3 double-buffering is sufficient before pursuing Level 4+.
-    FL_LOG_RMT("CANNOT IMPLEMENT: Priority 4-7 requires ASSEMBLY handlers");
-    FL_LOG_RMT("Use fastled_riscv_rmt_init_official() with priority 1-3 instead");
+    FL_LOG_RMT_F("CANNOT IMPLEMENT: Priority 4-7 requires ASSEMBLY handlers");
+    FL_LOG_RMT_F("Use fastled_riscv_rmt_init_official() with priority 1-3 instead");
     return ESP_ERR_NOT_SUPPORTED;
 }
 

--- a/src/platforms/esp/32/mutex_esp32.cpp.hpp
+++ b/src/platforms/esp/32/mutex_esp32.cpp.hpp
@@ -32,7 +32,7 @@ MutexESP32::MutexESP32() : mHandle(nullptr) {
     SemaphoreHandle_t handle = xSemaphoreCreateMutex();
 
     if (handle == nullptr) {
-        FL_WARN("MutexESP32: Failed to create mutex");
+        FL_WARN_F("MutexESP32: Failed to create mutex");
     }
 
     mHandle = static_cast<void*>(handle);
@@ -89,7 +89,7 @@ RecursiveMutexESP32::RecursiveMutexESP32() : mHandle(nullptr) {
     SemaphoreHandle_t handle = xSemaphoreCreateRecursiveMutex();
 
     if (handle == nullptr) {
-        FL_WARN("RecursiveMutexESP32: Failed to create recursive mutex");
+        FL_WARN_F("RecursiveMutexESP32: Failed to create recursive mutex");
     }
 
     mHandle = static_cast<void*>(handle);

--- a/src/platforms/esp/32/ota/ota_impl.cpp.hpp
+++ b/src/platforms/esp/32/ota/ota_impl.cpp.hpp
@@ -427,25 +427,24 @@ bool checkBasicAuth(httpd_req_t *req, const char* password) {
 bool validateESP32Firmware(const u8* data, size_t len) {
     // Need at least 24 bytes for ESP32 image header
     if (len < 24) {
-        FL_WARN("Firmware validation: header too small (" << len << " bytes)");
+        FL_WARN_F("Firmware validation: header too small (%s bytes)", len);
         return false;
     }
 
     // Check ESP32 magic byte (0xE9)
     if (data[0] != 0xE9) {
-        FL_WARN("Firmware validation: invalid magic byte 0x"
-                << (int)data[0] << " (expected 0xE9)");
+        FL_WARN_F("Firmware validation: invalid magic byte 0x%s (expected 0xE9)", (int)data[0]);
         return false;
     }
 
     // Check segment count is reasonable (1-16)
     u8 segments = data[1];
     if (segments == 0 || segments > 16) {
-        FL_WARN("Firmware validation: invalid segment count " << (int)segments);
+        FL_WARN_F("Firmware validation: invalid segment count %s", (int)segments);
         return false;
     }
 
-    FL_DBG("Firmware validation passed: magic=0xE9, segments=" << (int)segments);
+    FL_DBG_F("Firmware validation passed: magic=0xE9, segments=%s", (int)segments);
     return true;
 }
 
@@ -668,7 +667,7 @@ public:
 
         // Connect to Wi-Fi using ESP-IDF WiFi API (async mode)
         if (!initEspIdfWifi(ssid, wifi_pass)) {
-            FL_WARN("ESP-IDF WiFi initialization failed");
+            FL_WARN_F("ESP-IDF WiFi initialization failed");
             // Continue anyway - some services might still work
         }
 
@@ -677,7 +676,7 @@ public:
 
         // Initialize mDNS
         if (!initMDNS(mHostname.c_str())) {
-            FL_WARN("mDNS init failed - device won't be discoverable at " << mHostname.c_str() << ".local");
+            FL_WARN_F("mDNS init failed - device won't be discoverable at %s.local", mHostname.c_str());
             mFailedServices |= (u8)fl::net::ota::Service::MDNS_FAILED;
         }
 
@@ -687,7 +686,7 @@ public:
         // Start HTTP server for Web OTA
         mHttpServer = startHttpServer(&mHttpContext);
         if (!mHttpServer) {
-            FL_WARN("HTTP server failed - Web OTA unavailable (TCP OTA still works)");
+            FL_WARN_F("HTTP server failed - Web OTA unavailable (TCP OTA still works)");
             mFailedServices |= (u8)fl::net::ota::Service::HTTP_FAILED;
         }
 
@@ -711,7 +710,7 @@ public:
 
         // Initialize mDNS
         if (!initMDNS(mHostname.c_str())) {
-            FL_WARN("mDNS init failed - device won't be discoverable at " << mHostname.c_str() << ".local");
+            FL_WARN_F("mDNS init failed - device won't be discoverable at %s.local", mHostname.c_str());
             mFailedServices |= (u8)fl::net::ota::Service::MDNS_FAILED;
         }
 
@@ -721,7 +720,7 @@ public:
         // Start HTTP server for Web OTA
         mHttpServer = startHttpServer(&mHttpContext);
         if (!mHttpServer) {
-            FL_WARN("HTTP server failed - Web OTA unavailable (TCP OTA still works)");
+            FL_WARN_F("HTTP server failed - Web OTA unavailable (TCP OTA still works)");
             mFailedServices |= (u8)fl::net::ota::Service::HTTP_FAILED;
         }
 
@@ -731,13 +730,13 @@ public:
     bool enableApFallback(const char* ap_ssid, const char* ap_pass) override {
         // Validate SSID
         if (!ap_ssid || strlen(ap_ssid) == 0) {
-            FL_WARN("AP SSID cannot be empty");
+            FL_WARN_F("AP SSID cannot be empty");
             return false;
         }
 
         // Validate password (WPA2 requires minimum 8 characters)
         if (ap_pass && strlen(ap_pass) > 0 && strlen(ap_pass) < 8) {
-            FL_WARN("AP password must be at least 8 characters or nullptr for open network");
+            FL_WARN_F("AP password must be at least 8 characters or nullptr for open network");
             return false;
         }
 
@@ -789,9 +788,9 @@ private:
 
         if (event_base == WIFI_EVENT) {
             if (event_id == WIFI_EVENT_STA_CONNECTED) {
-                FL_DBG("WiFi: Station connected to AP");
+                FL_DBG_F("WiFi: Station connected to AP");
             } else if (event_id == WIFI_EVENT_STA_DISCONNECTED) {
-                FL_DBG("WiFi: Station disconnected from AP");
+                FL_DBG_F("WiFi: Station disconnected from AP");
                 self->mWifiConnected = false;
             }
         } else if (event_base == IP_EVENT) {
@@ -801,7 +800,7 @@ private:
                 // differ across IDF versions; route through void* to avoid
                 // reinterpret_cast (project lint forbids it).
                 const void* ip_ptr = &event->ip_info.ip;
-                FL_DBG("WiFi: Got IP address: " << ip4addr_ntoa(static_cast<const ip4_addr_t*>(ip_ptr)));
+                FL_DBG_F("WiFi: Got IP address: %s", ip4addr_ntoa(static_cast<const ip4_addr_t*>(ip_ptr)));
                 self->mWifiConnected = true;
             }
         }
@@ -816,14 +815,14 @@ private:
         // Note: This is safe to call multiple times
         esp_err_t err = esp_netif_init();
         if (err != ESP_OK && err != ESP_ERR_INVALID_STATE) {
-            FL_WARN("esp_netif_init failed: " << esp_err_to_name(err));
+            FL_WARN_F("esp_netif_init failed: %s", esp_err_to_name(err));
             return false;
         }
 
         // Create default event loop (if not already created)
         err = esp_event_loop_create_default();
         if (err != ESP_OK && err != ESP_ERR_INVALID_STATE) {
-            FL_WARN("esp_event_loop_create_default failed: " << esp_err_to_name(err));
+            FL_WARN_F("esp_event_loop_create_default failed: %s", esp_err_to_name(err));
             return false;
         }
 
@@ -833,7 +832,7 @@ private:
         if (!sta_netif) {
             sta_netif = esp_netif_create_default_wifi_sta();
             if (!sta_netif) {
-                FL_WARN("esp_netif_create_default_wifi_sta failed");
+                FL_WARN_F("esp_netif_create_default_wifi_sta failed");
                 return false;
             }
         }
@@ -845,7 +844,7 @@ private:
                                                     this,
                                                     nullptr);
         if (err != ESP_OK) {
-            FL_WARN("Failed to register WIFI_EVENT handler: " << esp_err_to_name(err));
+            FL_WARN_F("Failed to register WIFI_EVENT handler: %s", esp_err_to_name(err));
             return false;
         }
 
@@ -855,7 +854,7 @@ private:
                                                     this,
                                                     nullptr);
         if (err != ESP_OK) {
-            FL_WARN("Failed to register IP_EVENT handler: " << esp_err_to_name(err));
+            FL_WARN_F("Failed to register IP_EVENT handler: %s", esp_err_to_name(err));
             return false;
         }
 
@@ -863,14 +862,14 @@ private:
         wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
         err = esp_wifi_init(&cfg);
         if (err != ESP_OK && err != ESP_ERR_INVALID_STATE) {
-            FL_WARN("esp_wifi_init failed: " << esp_err_to_name(err));
+            FL_WARN_F("esp_wifi_init failed: %s", esp_err_to_name(err));
             return false;
         }
 
         // Set WiFi mode to STA (Station)
         err = esp_wifi_set_mode(WIFI_MODE_STA);
         if (err != ESP_OK) {
-            FL_WARN("esp_wifi_set_mode failed: " << esp_err_to_name(err));
+            FL_WARN_F("esp_wifi_set_mode failed: %s", esp_err_to_name(err));
             return false;
         }
 
@@ -882,32 +881,32 @@ private:
 
         err = esp_wifi_set_config(WIFI_IF_STA, &wifi_config);
         if (err != ESP_OK) {
-            FL_WARN("esp_wifi_set_config failed: " << esp_err_to_name(err));
+            FL_WARN_F("esp_wifi_set_config failed: %s", esp_err_to_name(err));
             return false;
         }
 
         // Set hostname (must be done before starting WiFi)
         err = esp_netif_set_hostname(sta_netif, mHostname.c_str());
         if (err != ESP_OK) {
-            FL_WARN("esp_netif_set_hostname failed: " << esp_err_to_name(err));
+            FL_WARN_F("esp_netif_set_hostname failed: %s", esp_err_to_name(err));
             // Non-fatal, continue
         }
 
         // Start WiFi
         err = esp_wifi_start();
         if (err != ESP_OK) {
-            FL_WARN("esp_wifi_start failed: " << esp_err_to_name(err));
+            FL_WARN_F("esp_wifi_start failed: %s", esp_err_to_name(err));
             return false;
         }
 
         // Connect to AP (async)
         err = esp_wifi_connect();
         if (err != ESP_OK) {
-            FL_WARN("esp_wifi_connect failed: " << esp_err_to_name(err));
+            FL_WARN_F("esp_wifi_connect failed: %s", esp_err_to_name(err));
             return false;
         }
 
-        FL_DBG("ESP-IDF WiFi initialization successful");
+        FL_DBG_F("ESP-IDF WiFi initialization successful");
         return true;
     }
 
@@ -996,7 +995,7 @@ private:
                              int expected_size, const char* expected_md5, int cmd) {
         // Only handle FLASH command (0) for now
         if (cmd != 0) {
-            FL_WARN("OTA: Unsupported command " << cmd << " (only FLASH supported)");
+            FL_WARN_F("OTA: Unsupported command %s (only FLASH supported)", cmd);
             if (mErrorCb) {
                 mErrorCb("Unsupported OTA command");
             }
@@ -1011,7 +1010,7 @@ private:
         // Create TCP socket to connect to client
         int tcp_socket = lwip_socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
         if (tcp_socket < 0) {
-            FL_WARN("OTA: Failed to create TCP socket");
+            FL_WARN_F("OTA: Failed to create TCP socket");
             if (mErrorCb) {
                 mErrorCb("TCP socket creation failed");
             }
@@ -1032,9 +1031,9 @@ private:
         fl::memcpy(&tcp_addr, client_addr, sizeof(struct sockaddr_in));
         tcp_addr.sin_port = lwip_htons(port);
 
-        FL_DBG("OTA: Connecting to client TCP server on port " << port);
+        FL_DBG_F("OTA: Connecting to client TCP server on port %s", port);
         if (lwip_connect(tcp_socket, (struct sockaddr*)&tcp_addr, sizeof(tcp_addr)) < 0) {
-            FL_WARN("OTA: Failed to connect to client TCP server");
+            FL_WARN_F("OTA: Failed to connect to client TCP server");
             if (mErrorCb) {
                 mErrorCb("TCP connection failed");
             }
@@ -1045,12 +1044,12 @@ private:
             return;
         }
 
-        FL_DBG("OTA: TCP connected, receiving firmware (" << expected_size << " bytes)");
+        FL_DBG_F("OTA: TCP connected, receiving firmware (%s bytes)", expected_size);
 
         // Get OTA partition
         const esp_partition_t* update_partition = esp_ota_get_next_update_partition(nullptr);
         if (!update_partition) {
-            FL_WARN("OTA: No OTA partition found");
+            FL_WARN_F("OTA: No OTA partition found");
             if (mErrorCb) {
                 mErrorCb("No OTA partition");
             }
@@ -1065,7 +1064,7 @@ private:
         esp_ota_handle_t ota_handle;
         esp_err_t err = esp_ota_begin(update_partition, expected_size, &ota_handle);
         if (err != ESP_OK) {
-            FL_WARN("OTA: esp_ota_begin failed: " << esp_err_to_name(err));
+            FL_WARN_F("OTA: esp_ota_begin failed: %s", esp_err_to_name(err));
             if (mErrorCb) {
                 mErrorCb("OTA begin failed");
             }
@@ -1094,7 +1093,7 @@ private:
 
             int received = lwip_recv(tcp_socket, buffer, to_recv, 0);
             if (received <= 0) {
-                FL_WARN("OTA: TCP receive error or timeout");
+                FL_WARN_F("OTA: TCP receive error or timeout");
                 if (mErrorCb) {
                     mErrorCb("Upload interrupted");
                 }
@@ -1108,7 +1107,7 @@ private:
             // Write to flash
             err = esp_ota_write(ota_handle, buffer, received);
             if (err != ESP_OK) {
-                FL_WARN("OTA: esp_ota_write failed: " << esp_err_to_name(err));
+                FL_WARN_F("OTA: esp_ota_write failed: %s", esp_err_to_name(err));
                 if (mErrorCb) {
                     mErrorCb("Flash write failed");
                 }
@@ -1147,11 +1146,11 @@ private:
         }
         computed_md5[32] = '\0';
 
-        FL_DBG("OTA: Expected MD5: " << expected_md5);
-        FL_DBG("OTA: Computed MD5: " << computed_md5);
+        FL_DBG_F("OTA: Expected MD5: %s", expected_md5);
+        FL_DBG_F("OTA: Computed MD5: %s", computed_md5);
 
         if (strcmp(computed_md5, expected_md5) != 0) {
-            FL_WARN("OTA: MD5 mismatch!");
+            FL_WARN_F("OTA: MD5 mismatch!");
             if (mErrorCb) {
                 mErrorCb("MD5 verification failed");
             }
@@ -1162,12 +1161,12 @@ private:
             return;
         }
 
-        FL_DBG("OTA: MD5 verification passed");
+        FL_DBG_F("OTA: MD5 verification passed");
 
         // Finalize OTA
         err = esp_ota_end(ota_handle);
         if (err != ESP_OK) {
-            FL_WARN("OTA: esp_ota_end failed: " << esp_err_to_name(err));
+            FL_WARN_F("OTA: esp_ota_end failed: %s", esp_err_to_name(err));
             if (mErrorCb) {
                 mErrorCb("OTA finalization failed");
             }
@@ -1180,7 +1179,7 @@ private:
         // Set boot partition
         err = esp_ota_set_boot_partition(update_partition);
         if (err != ESP_OK) {
-            FL_WARN("OTA: Failed to set boot partition: " << esp_err_to_name(err));
+            FL_WARN_F("OTA: Failed to set boot partition: %s", esp_err_to_name(err));
             if (mErrorCb) {
                 mErrorCb("Failed to set boot partition");
             }
@@ -1190,7 +1189,7 @@ private:
             return;
         }
 
-        FL_DBG("OTA: Firmware update successful!");
+        FL_DBG_F("OTA: Firmware update successful!");
 
         // Call end state callback
         if (mStateCb) {
@@ -1215,7 +1214,7 @@ private:
         // Create UDP socket
         self->mOtaUdpSocket = lwip_socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
         if (self->mOtaUdpSocket < 0) {
-            FL_WARN("OTA: Failed to create UDP socket");
+            FL_WARN_F("OTA: Failed to create UDP socket");
             self->mOtaRunning = false;
             vTaskDelete(nullptr);
             return;
@@ -1229,7 +1228,7 @@ private:
         addr.sin_addr.s_addr = lwip_htonl(INADDR_ANY);
 
         if (lwip_bind(self->mOtaUdpSocket, (struct sockaddr*)&addr, sizeof(addr)) < 0) {
-            FL_WARN("OTA: Failed to bind UDP socket to port 3232");
+            FL_WARN_F("OTA: Failed to bind UDP socket to port 3232");
             lwip_close(self->mOtaUdpSocket);
             self->mOtaUdpSocket = -1;
             self->mOtaRunning = false;
@@ -1237,7 +1236,7 @@ private:
             return;
         }
 
-        FL_DBG("OTA: UDP server listening on port 3232");
+        FL_DBG_F("OTA: UDP server listening on port 3232");
 
         // Set receive timeout for responsive shutdown
         struct timeval timeout;
@@ -1258,13 +1257,13 @@ private:
             }
 
             buffer[len] = '\0';
-            FL_DBG("OTA: Received UDP packet: " << buffer);
+            FL_DBG_F("OTA: Received UDP packet: %s", buffer);
 
             // Parse command: "<cmd> <port> <size> <md5>\n"
             int cmd, port, size;
             char md5[33];
             if (sscanf(buffer, "%d %d %d %32s", &cmd, &port, &size, md5) != 4) {
-                FL_WARN("OTA: Invalid invitation format");
+                FL_WARN_F("OTA: Invalid invitation format");
                 continue;
             }
 
@@ -1279,24 +1278,24 @@ private:
                 fl::snprintf(auth_response, sizeof(auth_response), "AUTH %s", nonce);
                 lwip_sendto(self->mOtaUdpSocket, auth_response, strlen(auth_response), 0,
                       (struct sockaddr*)&client_addr, client_len);
-                FL_DBG("OTA: Sent AUTH challenge");
+                FL_DBG_F("OTA: Sent AUTH challenge");
 
                 // Wait for authentication response (with timeout)
                 len = lwip_recvfrom(self->mOtaUdpSocket, buffer, sizeof(buffer) - 1, 0,
                               (struct sockaddr*)&client_addr, &client_len);
                 if (len <= 0) {
-                    FL_WARN("OTA: Authentication timeout");
+                    FL_WARN_F("OTA: Authentication timeout");
                     continue;
                 }
 
                 buffer[len] = '\0';
-                FL_DBG("OTA: Received auth response: " << buffer);
+                FL_DBG_F("OTA: Received auth response: %s", buffer);
 
                 // Parse auth response: "200 <cnonce> <response>\n"
                 int auth_cmd;
                 char cnonce[65], auth_hash[65];
                 if (sscanf(buffer, "%d %64s %64s", &auth_cmd, cnonce, auth_hash) != 3 || auth_cmd != 200) {
-                    FL_WARN("OTA: Invalid auth response format");
+                    FL_WARN_F("OTA: Invalid auth response format");
                     lwip_sendto(self->mOtaUdpSocket, "FAIL", 4, 0,
                           (struct sockaddr*)&client_addr, client_len);
                     continue;
@@ -1304,7 +1303,7 @@ private:
 
                 // Verify authentication
                 if (!verifyAuth(self->mPassword.c_str(), nonce, cnonce, auth_hash)) {
-                    FL_WARN("OTA: Authentication failed");
+                    FL_WARN_F("OTA: Authentication failed");
                     if (self->mErrorCb) {
                         self->mErrorCb("Auth Failed");
                     }
@@ -1313,7 +1312,7 @@ private:
                     continue;
                 }
 
-                FL_DBG("OTA: Authentication successful");
+                FL_DBG_F("OTA: Authentication successful");
             }
 
             // Send OK response
@@ -1321,20 +1320,20 @@ private:
                   (struct sockaddr*)&client_addr, client_len);
 
             // Handle TCP connection for firmware upload
-            FL_DBG("OTA: Ready for TCP connection on client port " << port);
+            FL_DBG_F("OTA: Ready for TCP connection on client port %s", port);
             self->handleFirmwareUpload(&client_addr, port, size, md5, cmd);
         }
 
         lwip_close(self->mOtaUdpSocket);
         self->mOtaUdpSocket = -1;
-        FL_DBG("OTA: UDP server stopped");
+        FL_DBG_F("OTA: UDP server stopped");
         vTaskDelete(nullptr);
     }
 
     void setupArduinoOTA() {
         // Start custom OTA server (replaces ArduinoOTA)
         if (mOtaRunning) {
-            FL_WARN("OTA: Server already running");
+            FL_WARN_F("OTA: Server already running");
             return;
         }
 
@@ -1351,11 +1350,11 @@ private:
         );
 
         if (result != pdPASS) {
-            FL_WARN("OTA: Failed to create server task");
+            FL_WARN_F("OTA: Failed to create server task");
             mOtaRunning = false;
             mFailedServices |= static_cast<u8>(fl::net::ota::Service::ARDUINO_OTA_FAILED);
         } else {
-            FL_DBG("OTA: Custom server started (port 3232)");
+            FL_DBG_F("OTA: Custom server started (port 3232)");
         }
     }
 
@@ -1388,7 +1387,7 @@ private:
                 mOtaUdpSocket = -1;
             }
 
-            FL_DBG("OTA: Custom server stopped");
+            FL_DBG_F("OTA: Custom server stopped");
         }
     }
 

--- a/src/platforms/esp/32/semaphore_esp32.cpp.hpp
+++ b/src/platforms/esp/32/semaphore_esp32.cpp.hpp
@@ -47,7 +47,7 @@ CountingSemaphoreESP32<LeastMaxValue>::CountingSemaphoreESP32(ptrdiff_t desired)
     );
 
     if (handle == nullptr) {
-        FL_WARN("CountingSemaphoreESP32: Failed to create counting semaphore");
+        FL_WARN_F("CountingSemaphoreESP32: Failed to create counting semaphore");
     }
 
     mHandle = static_cast<void*>(handle);

--- a/src/platforms/esp/32/watchdog_esp32_idf4.hpp
+++ b/src/platforms/esp/32/watchdog_esp32_idf4.hpp
@@ -96,14 +96,14 @@ void invoke_user_callback() FL_NOEXCEPT {
 void handle_system_reset(const char* handler_name) FL_NOEXCEPT {
     invoke_user_callback();
 
-    FL_DBG("\n[" << handler_name << "] System reset detected - performing safe USB disconnect");
+    FL_DBG_F("\n[%s] System reset detected - performing safe USB disconnect", handler_name);
 
     disconnect_usb_hardware();
 
 #if HAS_USB_SERIAL_JTAG
-    FL_DBG("[" << handler_name << "] ✓ USB disconnected - proceeding with reset");
+    FL_DBG_F("[%s] ✓ USB disconnected - proceeding with reset", handler_name);
 #else
-    FL_DBG("[" << handler_name << "] No USB Serial JTAG hardware - using default reset behavior");
+    FL_DBG_F("[%s] No USB Serial JTAG hardware - using default reset behavior", handler_name);
 #endif
 }
 
@@ -138,7 +138,7 @@ bool init_task_watchdog(u32 timeout_ms) FL_NOEXCEPT {
         err = ESP_OK;  // Already armed; keep the existing IDF4 timeout.
     }
     if (err != ESP_OK) {
-        FL_DBG("[WATCHDOG] Failed to initialize (error: " << err << ")");
+        FL_DBG_F("[WATCHDOG] Failed to initialize (error: %s)", err);
         return false;
     }
 
@@ -147,11 +147,11 @@ bool init_task_watchdog(u32 timeout_ms) FL_NOEXCEPT {
 
 // Logs watchdog configuration status
 void log_watchdog_status(u32 timeout_ms, watchdog_callback_t callback) FL_NOEXCEPT {
-    FL_DBG("[WATCHDOG] ✓ " << timeout_ms << "ms watchdog active with reset on timeout");
+    FL_DBG_F("[WATCHDOG] ✓ %sms watchdog active with reset on timeout", timeout_ms);
     if (callback != nullptr) {
-        FL_DBG("[WATCHDOG] ℹ️  User callback registered");
+        FL_DBG_F("[WATCHDOG] ℹ️  User callback registered");
     }
-    FL_DBG("[WATCHDOG] Monitors the loop task plus idle-task CPU starvation");
+    FL_DBG_F("[WATCHDOG] Monitors the loop task plus idle-task CPU starvation");
 }
 
 } // anonymous namespace
@@ -159,7 +159,7 @@ void log_watchdog_status(u32 timeout_ms, watchdog_callback_t callback) FL_NOEXCE
 void watchdog_setup(u32 timeout_ms,
                     watchdog_callback_t callback,
                     void* user_data) FL_NOEXCEPT {
-    FL_DBG("\n[WATCHDOG] Configuring ESP32 custom " << timeout_ms << "ms watchdog (IDF v4.x)");
+    FL_DBG_F("\n[WATCHDOG] Configuring ESP32 custom %sms watchdog (IDF v4.x)", timeout_ms);
 
     // Store callback for reset handlers
     detail::s_user_callback = callback;

--- a/src/platforms/esp/32/watchdog_esp32_idf5.hpp
+++ b/src/platforms/esp/32/watchdog_esp32_idf5.hpp
@@ -87,14 +87,14 @@ void invoke_user_callback() FL_NOEXCEPT {
 void handle_system_reset(const char* handler_name) FL_NOEXCEPT {
     invoke_user_callback();
 
-    FL_DBG("\n[" << handler_name << "] System reset detected - performing safe USB disconnect");
+    FL_DBG_F("\n[%s] System reset detected - performing safe USB disconnect", handler_name);
 
     disconnect_usb_hardware();
 
 #if HAS_USB_SERIAL_JTAG
-    FL_DBG("[" << handler_name << "] ✓ USB disconnected - proceeding with reset");
+    FL_DBG_F("[%s] ✓ USB disconnected - proceeding with reset", handler_name);
 #else
-    FL_DBG("[" << handler_name << "] No USB Serial JTAG hardware - using default reset behavior");
+    FL_DBG_F("[%s] No USB Serial JTAG hardware - using default reset behavior", handler_name);
 #endif
 }
 
@@ -144,7 +144,7 @@ bool init_task_watchdog(u32 timeout_ms) FL_NOEXCEPT {
         err = esp_task_wdt_reconfigure(&config);
     }
     if (err != ESP_OK) {
-        FL_DBG("[WATCHDOG] Failed to initialize (error: " << err << ")");
+        FL_DBG_F("[WATCHDOG] Failed to initialize (error: %s)", err);
         return false;
     }
 
@@ -153,11 +153,11 @@ bool init_task_watchdog(u32 timeout_ms) FL_NOEXCEPT {
 
 // Logs watchdog configuration status
 void log_watchdog_status(u32 timeout_ms, watchdog_callback_t callback) FL_NOEXCEPT {
-    FL_DBG("[WATCHDOG] ✓ " << timeout_ms << "ms watchdog active with reset on timeout");
+    FL_DBG_F("[WATCHDOG] ✓ %sms watchdog active with reset on timeout", timeout_ms);
     if (callback != nullptr) {
-        FL_DBG("[WATCHDOG] ℹ️  User callback registered");
+        FL_DBG_F("[WATCHDOG] ℹ️  User callback registered");
     }
-    FL_DBG("[WATCHDOG] Monitors the loop task plus idle-task CPU starvation");
+    FL_DBG_F("[WATCHDOG] Monitors the loop task plus idle-task CPU starvation");
 }
 
 
@@ -166,7 +166,7 @@ void log_watchdog_status(u32 timeout_ms, watchdog_callback_t callback) FL_NOEXCE
 void watchdog_setup(u32 timeout_ms,
                     watchdog_callback_t callback,
                     void* user_data) FL_NOEXCEPT {
-    FL_DBG("\n[WATCHDOG] Configuring ESP32 custom " << timeout_ms << "ms watchdog (IDF v5.x)");
+    FL_DBG_F("\n[WATCHDOG] Configuring ESP32 custom %sms watchdog (IDF v5.x)", timeout_ms);
 
     // Store callback for reset handlers
     detail::s_user_callback = callback;

--- a/src/platforms/neopixelbus/clockless.h
+++ b/src/platforms/neopixelbus/clockless.h
@@ -140,7 +140,7 @@ public:
                 // Note: numPixels will be set when FastLED calls setLeds()
                 mPixelBus = createPixelBus();
                 if (!mPixelBus) {
-                    FL_WARN("Failed to create NeoPixelBus instance");
+                    FL_WARN_F("Failed to create NeoPixelBus instance");
                     return;
                 }
                 
@@ -150,7 +150,7 @@ public:
                 // Allow derived classes to perform additional initialization
                 onInitialized();
             } catch (...) {
-                FL_WARN("NeoPixelBus initialization failed");
+                FL_WARN_F("NeoPixelBus initialization failed");
                 mInitialized = false;
             }
         }
@@ -170,7 +170,7 @@ public:
             mPixelBus.reset();
             mPixelBus = createPixelBus(pixels.size());
             if (!mPixelBus) {
-                FL_WARN("Failed to recreate NeoPixelBus with new size");
+                FL_WARN_F("Failed to recreate NeoPixelBus with new size");
                 return;
             }
             mPixelBus->Begin();
@@ -323,7 +323,7 @@ public:
             try {
                 mPixelBus = fl::make_unique<BusType>(0, DATA_PIN);
                 if (!mPixelBus) {
-                    FL_WARN("Failed to create RGBW NeoPixelBus instance");
+                    FL_WARN_F("Failed to create RGBW NeoPixelBus instance");
                     return;
                 }
                 
@@ -332,7 +332,7 @@ public:
                 
                 onInitialized();
             } catch (...) {
-                FL_WARN("RGBW NeoPixelBus initialization failed");
+                FL_WARN_F("RGBW NeoPixelBus initialization failed");
                 mInitialized = false;
             }
         }
@@ -349,7 +349,7 @@ public:
             mPixelBus.reset();
             mPixelBus = fl::make_unique<BusType>(pixels.size(), DATA_PIN);
             if (!mPixelBus) {
-                FL_WARN("Failed to recreate RGBW NeoPixelBus with new size");
+                FL_WARN_F("Failed to recreate RGBW NeoPixelBus with new size");
                 return;
             }
             mPixelBus->Begin();

--- a/src/platforms/ota.cpp.hpp
+++ b/src/platforms/ota.cpp.hpp
@@ -31,48 +31,48 @@ public:
     ~NullOTA() override = default;
 
     bool beginWiFi(const char*, const char*, const char*, const char*) FL_NOEXCEPT override {
-        FL_WARN("OTA not supported on this platform");
+        FL_WARN_F("OTA not supported on this platform");
         return false;  // Not supported
     }
 
     bool begin(const char*, const char*) FL_NOEXCEPT override {
-        FL_WARN("OTA not supported on this platform");
+        FL_WARN_F("OTA not supported on this platform");
         return false;  // Not supported
     }
 
     bool enableApFallback(const char*, const char*) FL_NOEXCEPT override {
-        FL_WARN("OTA not supported on this platform");
+        FL_WARN_F("OTA not supported on this platform");
         return false;  // Not supported
     }
 
     void onProgress(fl::function<void(size_t, size_t)>) FL_NOEXCEPT override {
-        FL_WARN("OTA not supported on this platform");
+        FL_WARN_F("OTA not supported on this platform");
         // No-op
     }
 
     void onError(fl::function<void(const char*)>) FL_NOEXCEPT override {
-        FL_WARN("OTA not supported on this platform");
+        FL_WARN_F("OTA not supported on this platform");
         // No-op
     }
 
     void onState(fl::function<void(u8)>) FL_NOEXCEPT override {
-        FL_WARN("OTA not supported on this platform");
+        FL_WARN_F("OTA not supported on this platform");
         // No-op
     }
 
     void onBeforeReboot(void (*callback)()) FL_NOEXCEPT override {
-        FL_WARN("OTA not supported on this platform");
+        FL_WARN_F("OTA not supported on this platform");
         // No-op
         (void)callback;  // Suppress unused parameter warning
     }
 
     void poll() FL_NOEXCEPT override {
-        FL_WARN("OTA not supported on this platform");
+        FL_WARN_F("OTA not supported on this platform");
         // No-op
     }
 
     bool isConnected() const FL_NOEXCEPT override {
-        FL_WARN("OTA not supported on this platform");
+        FL_WARN_F("OTA not supported on this platform");
         return false;  // Not supported
     }
 

--- a/src/platforms/shared/bitbang/bitbang_channel_driver.cpp.hpp
+++ b/src/platforms/shared/bitbang/bitbang_channel_driver.cpp.hpp
@@ -1,4 +1,4 @@
-// IWYU pragma: private
+﻿// IWYU pragma: private
 
 /// @file bitbang_channel_driver.cpp.hpp
 /// @brief Implementation of BitBangChannelDriver
@@ -67,7 +67,7 @@ void BitBangChannelDriver::rebuildPinConfig(
 
         int pin = ch->getPin();
         if (pin < 0 || pin > 255) {
-            FL_WARN("BitBangChannelDriver: pin " << pin << " out of range, skipping");
+            FL_WARN_F("BitBangChannelDriver: pin %s out of range, skipping", pin);
             continue;
         }
 
@@ -76,8 +76,8 @@ void BitBangChannelDriver::rebuildPinConfig(
         }
 
         if (mNumActiveSlots >= 8) {
-            FL_WARN("BitBangChannelDriver: more than 8 unique data pins, "
-                     "pin " << pin << " will be skipped");
+            FL_WARN_F("BitBangChannelDriver: more than 8 unique data pins, "
+                     "pin %s will be skipped", pin);
             continue;
         }
 
@@ -333,7 +333,7 @@ void BitBangChannelDriver::show() FL_NOEXCEPT {
         transmitSpi(spi);
     }
 
-    // Done — clear in-use flags
+    // Done â€” clear in-use flags
     for (fl::size i = 0; i < mTransmittingChannels.size(); ++i) {
         if (mTransmittingChannels[i]) {
             mTransmittingChannels[i]->setInUse(false);

--- a/src/platforms/shared/clockless_blocking.h
+++ b/src/platforms/shared/clockless_blocking.h
@@ -88,9 +88,9 @@ public:
         // This may indicate missing platform-specific optimizations
         static bool warned = false;  // okay static in header
         if (!warned) {
-            FL_WARN("Using GENERIC fallback clockless controller - platform-specific driver not available!");
-            FL_WARN("  This may result in reduced performance or timing issues.");
-            FL_WARN("  Expected platforms (ESP32/Teensy/etc) should use hardware drivers.");
+            FL_WARN_F("Using GENERIC fallback clockless controller - platform-specific driver not available!");
+            FL_WARN_F("  This may result in reduced performance or timing issues.");
+            FL_WARN_F("  Expected platforms (ESP32/Teensy/etc) should use hardware drivers.");
             warned = true;
         }
 

--- a/src/platforms/shared/coroutine_context.cpp.hpp
+++ b/src/platforms/shared/coroutine_context.cpp.hpp
@@ -161,7 +161,7 @@ void CoroutineContext::suspend() FL_NOEXCEPT {
 
     // Check stack health before switching — catch overflow early
     if (!platform.checkStackHealth(self->mPlatformCtx)) {
-        FL_WARN("FATAL: Stack overflow detected in coroutine");
+        FL_WARN_F("FATAL: Stack overflow detected in coroutine");
         while (true) {}  // Halt — memory is already corrupted
     }
 
@@ -188,7 +188,7 @@ void CoroutineRunner::enqueue(CoroutineContext* ctx) FL_NOEXCEPT {
     }
 
     if (mCount >= kMaxCoroutines) {
-        FL_WARN("CoroutineRunner: Queue full, cannot enqueue");
+        FL_WARN_F("CoroutineRunner: Queue full, cannot enqueue");
         return;
     }
 

--- a/src/platforms/shared/mock/arm/teensy4/drivers/lpuart/lpuart_peripheral_mock.h
+++ b/src/platforms/shared/mock/arm/teensy4/drivers/lpuart/lpuart_peripheral_mock.h
@@ -84,7 +84,7 @@ public:
         u32 reset_us;
     };
 
-    LPUARTPeripheralMock() FL_NOEXCEPT : mForceCreateFailure(false), mLastInstance(nullptr) {}
+    LPUARTPeripheralMock() FL_NOEXCEPT : mLastInstance(nullptr), mForceCreateFailure(false) {}
     ~LPUARTPeripheralMock() override = default;
 
     // ------------------------------------------------------------------

--- a/src/platforms/shared/mock/esp/32/drivers/rmt5_peripheral_mock.cpp.hpp
+++ b/src/platforms/shared/mock/esp/32/drivers/rmt5_peripheral_mock.cpp.hpp
@@ -226,13 +226,13 @@ const MockEncoder* Rmt5PeripheralMockImpl::findEncoder(void* handle) const FL_NO
 bool Rmt5PeripheralMockImpl::createTxChannel(const Rmt5ChannelConfig& config,
                                                void** out_handle) FL_NOEXCEPT {
     if (out_handle == nullptr) {
-        FL_WARN("Rmt5PeripheralMock: out_handle is nullptr");
+        FL_WARN_F("Rmt5PeripheralMock: out_handle is nullptr");
         return false;
     }
 
     // Validate config
     if (config.gpio_num < 0) {
-        FL_WARN("Rmt5PeripheralMock: Invalid GPIO pin: " << config.gpio_num);
+        FL_WARN_F("Rmt5PeripheralMock: Invalid GPIO pin: %s", config.gpio_num);
         return false;
     }
 
@@ -250,9 +250,7 @@ bool Rmt5PeripheralMockImpl::createTxChannel(const Rmt5ChannelConfig& config,
     // Return opaque handle
     *out_handle = fl::bit_cast<void*>(static_cast<intptr_t>(channel_id));
 
-    FL_DBG("RMT5_MOCK: Created TX channel " << channel_id
-           << " on GPIO " << config.gpio_num
-           << " (DMA: " << config.with_dma << ") handle=" << *out_handle);
+    FL_DBG_F("RMT5_MOCK: Created TX channel %s on GPIO %s (DMA: %s) handle=%s", channel_id, config.gpio_num, config.with_dma, *out_handle);
 
     return true;
 }
@@ -260,7 +258,7 @@ bool Rmt5PeripheralMockImpl::createTxChannel(const Rmt5ChannelConfig& config,
 bool Rmt5PeripheralMockImpl::deleteChannel(void* channel_handle) FL_NOEXCEPT {
     MockChannel* channel = findChannel(channel_handle);
     if (channel == nullptr) {
-        FL_WARN("Rmt5PeripheralMock: Invalid channel handle");
+        FL_WARN_F("Rmt5PeripheralMock: Invalid channel handle");
         return false;
     }
 
@@ -268,31 +266,31 @@ bool Rmt5PeripheralMockImpl::deleteChannel(void* channel_handle) FL_NOEXCEPT {
     delete channel;  // Free the allocated memory  // ok bare allocation
     mChannels.erase(id);
 
-    FL_DBG("RMT5_MOCK: Deleted channel " << id);
+    FL_DBG_F("RMT5_MOCK: Deleted channel %s", id);
     return true;
 }
 
 bool Rmt5PeripheralMockImpl::enableChannel(void* channel_handle) FL_NOEXCEPT {
     MockChannel* channel = findChannel(channel_handle);
     if (channel == nullptr) {
-        FL_WARN("Rmt5PeripheralMock: Invalid channel handle");
+        FL_WARN_F("Rmt5PeripheralMock: Invalid channel handle");
         return false;
     }
 
     channel->enabled = true;
-    FL_DBG("RMT5_MOCK: Enabled channel " << channel->id);
+    FL_DBG_F("RMT5_MOCK: Enabled channel %s", channel->id);
     return true;
 }
 
 bool Rmt5PeripheralMockImpl::disableChannel(void* channel_handle) FL_NOEXCEPT {
     MockChannel* channel = findChannel(channel_handle);
     if (channel == nullptr) {
-        FL_WARN("Rmt5PeripheralMock: Invalid channel handle");
+        FL_WARN_F("Rmt5PeripheralMock: Invalid channel handle");
         return false;
     }
 
     channel->enabled = false;
-    FL_DBG("RMT5_MOCK: Disabled channel " << channel->id);
+    FL_DBG_F("RMT5_MOCK: Disabled channel %s", channel->id);
     return true;
 }
 
@@ -304,29 +302,29 @@ bool Rmt5PeripheralMockImpl::transmit(void* channel_handle, void* encoder_handle
                                        const u8* buffer, size_t buffer_size) FL_NOEXCEPT {
     // Error injection
     if (mShouldFailTransmit) {
-        FL_WARN("Rmt5PeripheralMock: Transmit failure injected");
+        FL_WARN_F("Rmt5PeripheralMock: Transmit failure injected");
         return false;
     }
 
     MockChannel* channel = findChannel(channel_handle);
     if (channel == nullptr) {
-        FL_WARN("Rmt5PeripheralMock: Invalid channel handle");
+        FL_WARN_F("Rmt5PeripheralMock: Invalid channel handle");
         return false;
     }
 
     MockEncoder* encoder = findEncoder(encoder_handle);
     if (encoder == nullptr) {
-        FL_WARN("Rmt5PeripheralMock: Invalid encoder handle");
+        FL_WARN_F("Rmt5PeripheralMock: Invalid encoder handle");
         return false;
     }
 
     if (buffer == nullptr || buffer_size == 0) {
-        FL_WARN("Rmt5PeripheralMock: Invalid buffer");
+        FL_WARN_F("Rmt5PeripheralMock: Invalid buffer");
         return false;
     }
 
     if (!channel->enabled) {
-        FL_WARN("Rmt5PeripheralMock: Channel not enabled");
+        FL_WARN_F("Rmt5PeripheralMock: Channel not enabled");
         return false;
     }
 
@@ -349,8 +347,7 @@ bool Rmt5PeripheralMockImpl::transmit(void* channel_handle, void* encoder_handle
     mHistory.push_back(record);
     mTransmissionCount++;
 
-    FL_DBG("RMT5_MOCK: Transmitted " << buffer_size << " bytes on channel "
-           << channel->id << " (pin " << channel->config.gpio_num << ")");
+    FL_DBG_F("RMT5_MOCK: Transmitted %s bytes on channel %s (pin %s)", buffer_size, channel->id, channel->config.gpio_num);
 
     return true;
 }
@@ -360,13 +357,13 @@ bool Rmt5PeripheralMockImpl::waitAllDone(void* channel_handle, u32 timeout_ms) F
 
     MockChannel* channel = findChannel(channel_handle);
     if (channel == nullptr) {
-        FL_WARN("Rmt5PeripheralMock: Invalid channel handle");
+        FL_WARN_F("Rmt5PeripheralMock: Invalid channel handle");
         return false;
     }
 
     // Mock implementation: Always return true immediately
     // (transmission is instant in mock)
-    FL_DBG("RMT5_MOCK: Wait all done for channel " << channel->id);
+    FL_DBG_F("RMT5_MOCK: Wait all done for channel %s", channel->id);
     return true;
 }
 
@@ -379,14 +376,14 @@ bool Rmt5PeripheralMockImpl::registerTxCallback(void* channel_handle,
                                                  void* user_ctx) FL_NOEXCEPT {
     MockChannel* channel = findChannel(channel_handle);
     if (channel == nullptr) {
-        FL_WARN("Rmt5PeripheralMock: Invalid channel handle");
+        FL_WARN_F("Rmt5PeripheralMock: Invalid channel handle");
         return false;
     }
 
     channel->callback = callback;
     channel->user_ctx = user_ctx;
 
-    FL_DBG("RMT5_MOCK: Registered TX callback for channel " << channel->id);
+    FL_DBG_F("RMT5_MOCK: Registered TX callback for channel %s", channel->id);
     return true;
 }
 
@@ -396,14 +393,14 @@ bool Rmt5PeripheralMockImpl::registerTxCallback(void* channel_handle,
 
 void Rmt5PeripheralMockImpl::configureLogging() FL_NOEXCEPT {
     // Mock implementation: No-op (host platforms don't have ESP-IDF logging)
-    FL_DBG("RMT5_MOCK: Logging configuration (no-op on mock platform)");
+    FL_DBG_F("RMT5_MOCK: Logging configuration (no-op on mock platform)");
 }
 
 bool Rmt5PeripheralMockImpl::syncCache(void* buffer, size_t size) FL_NOEXCEPT {
     // Mock implementation: No-op (host platforms don't have DMA or cache sync)
     (void)buffer;
     (void)size;
-    FL_DBG("RMT5_MOCK: Cache sync (no-op on mock platform)");
+    FL_DBG_F("RMT5_MOCK: Cache sync (no-op on mock platform)");
     return true;  // Always succeeds
 }
 
@@ -425,8 +422,7 @@ void* Rmt5PeripheralMockImpl::createEncoder(const ChipsetTiming& timing,
     // Return opaque handle
     void* handle = fl::bit_cast<void*>(static_cast<intptr_t>(encoder_id));
 
-    FL_DBG("RMT5_MOCK: Created encoder " << encoder_id
-           << " (resolution: " << resolution_hz << " Hz)");
+    FL_DBG_F("RMT5_MOCK: Created encoder %s (resolution: %s Hz)", encoder_id, resolution_hz);
 
     return handle;
 }
@@ -441,18 +437,18 @@ void Rmt5PeripheralMockImpl::deleteEncoder(void* encoder_handle) FL_NOEXCEPT {
     delete encoder;  // Free the allocated memory  // ok bare allocation
     mEncoders.erase(id);
 
-    FL_DBG("RMT5_MOCK: Deleted encoder " << id);
+    FL_DBG_F("RMT5_MOCK: Deleted encoder %s", id);
 }
 
 bool Rmt5PeripheralMockImpl::resetEncoder(void* encoder_handle) FL_NOEXCEPT {
     MockEncoder* encoder = findEncoder(encoder_handle);
     if (encoder == nullptr) {
-        FL_WARN("Rmt5PeripheralMock: Invalid encoder handle");
+        FL_WARN_F("Rmt5PeripheralMock: Invalid encoder handle");
         return false;
     }
 
     // Mock implementation: Encoder reset is a no-op (mock encoder has no state machine)
-    FL_DBG("RMT5_MOCK: Reset encoder " << encoder->id);
+    FL_DBG_F("RMT5_MOCK: Reset encoder %s", encoder->id);
     return true;  // Always succeeds
 }
 
@@ -462,7 +458,7 @@ bool Rmt5PeripheralMockImpl::resetEncoder(void* encoder_handle) FL_NOEXCEPT {
 
 u8* Rmt5PeripheralMockImpl::allocateDmaBuffer(size_t size) FL_NOEXCEPT {
     if (size == 0) {
-        FL_WARN("Rmt5PeripheralMock: Cannot allocate zero-size buffer");
+        FL_WARN_F("Rmt5PeripheralMock: Cannot allocate zero-size buffer");
         return nullptr;
     }
 
@@ -474,12 +470,11 @@ u8* Rmt5PeripheralMockImpl::allocateDmaBuffer(size_t size) FL_NOEXCEPT {
     u8* buffer = static_cast<u8*>(fl::aligned_alloc(alignment, aligned_size));
 
     if (buffer == nullptr) {
-        FL_WARN("Rmt5PeripheralMock: Failed to allocate DMA buffer ("
-                << aligned_size << " bytes)");
+        FL_WARN_F("Rmt5PeripheralMock: Failed to allocate DMA buffer (%s bytes)", aligned_size);
         return nullptr;
     }
 
-    FL_DBG("RMT5_MOCK: Allocated DMA buffer (" << aligned_size << " bytes)");
+    FL_DBG_F("RMT5_MOCK: Allocated DMA buffer (%s bytes)", aligned_size);
     return buffer;
 }
 
@@ -490,7 +485,7 @@ void Rmt5PeripheralMockImpl::freeDmaBuffer(u8* buffer) FL_NOEXCEPT {
 
     fl::aligned_free(buffer);
 
-    FL_DBG("RMT5_MOCK: Freed DMA buffer");
+    FL_DBG_F("RMT5_MOCK: Freed DMA buffer");
 }
 
 //=============================================================================
@@ -500,23 +495,23 @@ void Rmt5PeripheralMockImpl::freeDmaBuffer(u8* buffer) FL_NOEXCEPT {
 void Rmt5PeripheralMockImpl::simulateTransmitDone(void* channel_handle) FL_NOEXCEPT {
     MockChannel* channel = findChannel(channel_handle);
     if (channel == nullptr) {
-        FL_WARN("Rmt5PeripheralMock: Invalid channel handle");
+        FL_WARN_F("Rmt5PeripheralMock: Invalid channel handle");
         return;
     }
 
     if (channel->callback == nullptr) {
-        FL_DBG("RMT5_MOCK: No callback registered for channel " << channel->id);
+        FL_DBG_F("RMT5_MOCK: No callback registered for channel %s", channel->id);
         return;
     }
 
-    FL_DBG("RMT5_MOCK: Triggering TX callback for channel " << channel->id);
+    FL_DBG_F("RMT5_MOCK: Triggering TX callback for channel %s", channel->id);
     // Pass nullptr for event_data (matches ESP-IDF behavior for simple transmissions)
     channel->callback(channel_handle, nullptr, channel->user_ctx);
 }
 
 void Rmt5PeripheralMockImpl::setTransmitFailure(bool should_fail) FL_NOEXCEPT {
     mShouldFailTransmit = should_fail;
-    FL_DBG("RMT5_MOCK: Transmit failure " << (should_fail ? "enabled" : "disabled"));
+    FL_DBG_F("RMT5_MOCK: Transmit failure %s", (should_fail ? "enabled" : "disabled"));
 }
 
 const fl::vector<Rmt5PeripheralMock::TransmissionRecord>&
@@ -526,7 +521,7 @@ Rmt5PeripheralMockImpl::getTransmissionHistory() const FL_NOEXCEPT {
 
 void Rmt5PeripheralMockImpl::clearTransmissionHistory() FL_NOEXCEPT {
     mHistory.clear();
-    FL_DBG("RMT5_MOCK: Cleared transmission history");
+    FL_DBG_F("RMT5_MOCK: Cleared transmission history");
 }
 
 fl::span<const u8> Rmt5PeripheralMockImpl::getLastTransmissionData() const FL_NOEXCEPT {
@@ -576,7 +571,7 @@ void Rmt5PeripheralMockImpl::reset() FL_NOEXCEPT {
     mShouldFailTransmit = false;
     mTransmissionCount = 0;
 
-    FL_DBG("RMT5_MOCK: Reset to initial state");
+    FL_DBG_F("RMT5_MOCK: Reset to initial state");
 }
 
 } // namespace detail

--- a/src/platforms/shared/mock/esp/32/drivers/spi_peripheral_mock.cpp.hpp
+++ b/src/platforms/shared/mock/esp/32/drivers/spi_peripheral_mock.cpp.hpp
@@ -157,13 +157,13 @@ SpiPeripheralMockImpl::SpiPeripheralMockImpl()
 
 bool SpiPeripheralMockImpl::initializeBus(const SpiBusConfig& config) FL_NOEXCEPT {
     if (mInitialized) {
-        FL_WARN("SpiPeripheralMock: Already initialized");
+        FL_WARN_F("SpiPeripheralMock: Already initialized");
         return false;
     }
 
     // Validate config
     if (config.sclk_pin < 0) {
-        FL_WARN("SpiPeripheralMock: Invalid SCLK pin: " << config.sclk_pin);
+        FL_WARN_F("SpiPeripheralMock: Invalid SCLK pin: %s", config.sclk_pin);
         return false;
     }
 
@@ -176,23 +176,23 @@ bool SpiPeripheralMockImpl::initializeBus(const SpiBusConfig& config) FL_NOEXCEP
 
 bool SpiPeripheralMockImpl::addDevice(const SpiDeviceConfig& config) FL_NOEXCEPT {
     if (!mInitialized) {
-        FL_WARN("SpiPeripheralMock: Cannot add device - bus not initialized");
+        FL_WARN_F("SpiPeripheralMock: Cannot add device - bus not initialized");
         return false;
     }
 
     if (mDeviceAdded) {
-        FL_WARN("SpiPeripheralMock: Device already added");
+        FL_WARN_F("SpiPeripheralMock: Device already added");
         return false;
     }
 
     // Validate config
     if (config.clock_speed_hz <= 0) {
-        FL_WARN("SpiPeripheralMock: Invalid clock speed: " << config.clock_speed_hz);
+        FL_WARN_F("SpiPeripheralMock: Invalid clock speed: %s", config.clock_speed_hz);
         return false;
     }
 
     if (config.queue_size <= 0) {
-        FL_WARN("SpiPeripheralMock: Invalid queue size: " << config.queue_size);
+        FL_WARN_F("SpiPeripheralMock: Invalid queue size: %s", config.queue_size);
         return false;
     }
 
@@ -206,7 +206,7 @@ bool SpiPeripheralMockImpl::addDevice(const SpiDeviceConfig& config) FL_NOEXCEPT
 
 bool SpiPeripheralMockImpl::removeDevice() FL_NOEXCEPT {
     if (!mDeviceAdded) {
-        FL_WARN("SpiPeripheralMock: No device to remove");
+        FL_WARN_F("SpiPeripheralMock: No device to remove");
         return false;
     }
 
@@ -217,12 +217,12 @@ bool SpiPeripheralMockImpl::removeDevice() FL_NOEXCEPT {
 
 bool SpiPeripheralMockImpl::freeBus() FL_NOEXCEPT {
     if (!mInitialized) {
-        FL_WARN("SpiPeripheralMock: Bus not initialized");
+        FL_WARN_F("SpiPeripheralMock: Bus not initialized");
         return false;
     }
 
     if (mDeviceAdded) {
-        FL_WARN("SpiPeripheralMock: Must remove device before freeing bus");
+        FL_WARN_F("SpiPeripheralMock: Must remove device before freeing bus");
         return false;
     }
 
@@ -240,12 +240,12 @@ bool SpiPeripheralMockImpl::isInitialized() const FL_NOEXCEPT {
 
 bool SpiPeripheralMockImpl::queueTransaction(const SpiTransaction& trans) FL_NOEXCEPT {
     if (!mInitialized) {
-        FL_WARN("SpiPeripheralMock: Cannot queue transaction - not initialized");
+        FL_WARN_F("SpiPeripheralMock: Cannot queue transaction - not initialized");
         return false;
     }
 
     if (!mDeviceAdded) {
-        FL_WARN("SpiPeripheralMock: Cannot queue transaction - no device added");
+        FL_WARN_F("SpiPeripheralMock: Cannot queue transaction - no device added");
         return false;
     }
 
@@ -256,7 +256,7 @@ bool SpiPeripheralMockImpl::queueTransaction(const SpiTransaction& trans) FL_NOE
 
     // Check queue capacity
     if (mQueuedTransactions.size() >= mMaxQueueSize) {
-        FL_WARN("SpiPeripheralMock: Transaction queue full (" << mMaxQueueSize << ")");
+        FL_WARN_F("SpiPeripheralMock: Transaction queue full (%s)", mMaxQueueSize);
         return false;
     }
 
@@ -293,12 +293,12 @@ bool SpiPeripheralMockImpl::pollTransaction(u32 timeout_ms) FL_NOEXCEPT {
     (void)timeout_ms;  // Unused in synchronous mock
 
     if (!mInitialized) {
-        FL_WARN("SpiPeripheralMock: Cannot poll - not initialized");
+        FL_WARN_F("SpiPeripheralMock: Cannot poll - not initialized");
         return false;
     }
 
     if (!mDeviceAdded) {
-        FL_WARN("SpiPeripheralMock: Cannot poll - no device added");
+        FL_WARN_F("SpiPeripheralMock: Cannot poll - no device added");
         return false;
     }
 
@@ -323,7 +323,7 @@ bool SpiPeripheralMockImpl::pollTransaction(u32 timeout_ms) FL_NOEXCEPT {
 
 bool SpiPeripheralMockImpl::registerCallback(void* callback, void* user_ctx) FL_NOEXCEPT {
     if (!mInitialized) {
-        FL_WARN("SpiPeripheralMock: Cannot register callback - not initialized");
+        FL_WARN_F("SpiPeripheralMock: Cannot register callback - not initialized");
         return false;
     }
 
@@ -360,7 +360,7 @@ u8* SpiPeripheralMockImpl::allocateDma(size_t size) FL_NOEXCEPT {
 #endif
 
     if (buffer == nullptr) {
-        FL_WARN("SpiPeripheralMock: Failed to allocate buffer (" << aligned_size << " bytes)");
+        FL_WARN_F("SpiPeripheralMock: Failed to allocate buffer (%s bytes)", aligned_size);
     }
 
     return static_cast<u8*>(buffer);

--- a/src/platforms/shared/rx_device_dummy.h
+++ b/src/platforms/shared/rx_device_dummy.h
@@ -75,7 +75,7 @@ public:
 private:
     void warnOnce() const FL_NOEXCEPT {
         if (!mWarned) {
-            FL_ERROR("RxDevice not available: " << mReason << ", falling back to DummyRxDevice");
+            FL_ERROR_F("RxDevice not available: %s, falling back to DummyRxDevice", mReason);
             mWarned = true;
         }
     }

--- a/src/platforms/shared/rx_device_native.cpp.hpp
+++ b/src/platforms/shared/rx_device_native.cpp.hpp
@@ -76,8 +76,7 @@ RxWaitResult NativeRxDevice::wait(u32 timeout_ms) FL_NOEXCEPT {
     }
     mFinished = true;
     if (mEdges.empty()) {
-        FL_WARN("NativeRxDevice: No edges captured for pin " << mPin
-                << " - stub channel engine may not have called simulateWS2812Output()");
+        FL_WARN_F("NativeRxDevice: No edges captured for pin %s - stub channel engine may not have called simulateWS2812Output()", mPin);
         return RxWaitResult::TIMEOUT;
     }
     return RxWaitResult::SUCCESS;
@@ -101,7 +100,7 @@ void NativeRxDevice::onEdge(bool high, u32 duration_ns) FL_NOEXCEPT {
 fl::result<u32, DecodeError> NativeRxDevice::decode(const ChipsetTiming4Phase& timing,
                                                      fl::span<u8> out) FL_NOEXCEPT {
     if (mEdges.empty()) {
-        FL_WARN("NativeRxDevice::decode: No edges recorded for pin " << mPin);
+        FL_WARN_F("NativeRxDevice::decode: No edges recorded for pin %s", mPin);
         return fl::result<u32, DecodeError>::failure(DecodeError::INVALID_ARGUMENT);
     }
     return fl::channels::rx::decodeWs2812Edges(

--- a/src/platforms/shared/spi_manager.cpp.hpp
+++ b/src/platforms/shared/spi_manager.cpp.hpp
@@ -48,20 +48,20 @@ SPIBusManager::~SPIBusManager() {
 
 SPIBusHandle SPIBusManager::registerDevice(u8 clock_pin, u8 data_pin, u32 requested_speed_hz, void* controller) FL_NOEXCEPT {
     if (!controller) {
-        FL_WARN("SPIBusManager: nullptr controller pointer");
+        FL_WARN_F("SPIBusManager: nullptr controller pointer");
         return SPIBusHandle();
     }
 
     // Find or create bus for this clock pin
     SPIBusInfo* bus = getOrCreateBus(clock_pin);
     if (!bus) {
-        FL_WARN_FMT("SPIBusManager: Too many different clock pins (max " << MAX_BUSES << ")");
+        FL_WARN_F("SPIBusManager: Too many different clock pins (max %s)", static_cast<int>(MAX_BUSES));
         return SPIBusHandle();
     }
 
     // Check if we can add another device to this bus
     if (bus->num_devices >= 16) {
-        FL_WARN_FMT("SPIBusManager: Too many devices on clock pin " << clock_pin << " (max 16)");
+        FL_WARN_F("SPIBusManager: Too many devices on clock pin %s (max 16)", clock_pin);
         return SPIBusHandle();
     }
 
@@ -258,7 +258,7 @@ void SPIBusManager::finalizeTransmission(SPIBusHandle handle) FL_NOEXCEPT {
         // Acquire DMA buffer (zero-copy API) - use polymorphic interface
         DMABuffer result = bus.hw_controller->acquireDMABuffer(max_size);
         if (!result.ok()) {
-            FL_WARN_FMT("SPI Bus Manager: Failed to acquire DMA buffer for Dual-SPI: " << static_cast<int>(result.error()));
+            FL_WARN_F("SPI Bus Manager: Failed to acquire DMA buffer for Dual-SPI: %s", static_cast<int>(result.error()));
             // Clear buffers and bail
             for (auto& lane_buffer : bus.lane_buffers) {
                 lane_buffer.clear();
@@ -285,7 +285,7 @@ void SPIBusManager::finalizeTransmission(SPIBusHandle handle) FL_NOEXCEPT {
         // Transpose lanes directly into DMA buffer (zero-copy!)
         const char* error = nullptr;
         if (!SPITransposer::transpose2(lane0, lane1, dma_buf, &error)) {
-            FL_WARN_FMT("SPI Bus Manager: Dual transpose failed - " << (error ? error : "unknown error"));
+            FL_WARN_F("SPI Bus Manager: Dual transpose failed - %s", (error ? error : "unknown error"));
             // Clear buffers and bail
             for (auto& lane_buffer : bus.lane_buffers) {
                 lane_buffer.clear();
@@ -298,7 +298,7 @@ void SPIBusManager::finalizeTransmission(SPIBusHandle handle) FL_NOEXCEPT {
         if (transmit_ok) {
             bus.hw_controller->waitComplete();
         } else {
-            FL_WARN("SPI Bus Manager: Dual-SPI transmit failed");
+            FL_WARN_F("SPI Bus Manager: Dual-SPI transmit failed");
         }
 
         // Clear lane buffers for next frame
@@ -340,7 +340,7 @@ void SPIBusManager::finalizeTransmission(SPIBusHandle handle) FL_NOEXCEPT {
         SpiHw16* hexadeca = static_cast<SpiHw16*>(bus.hw_controller.get());
         result = hexadeca->acquireDMABuffer(max_size);
         if (!result.ok()) {
-            FL_WARN_FMT("SPI Bus Manager: Failed to acquire DMA buffer for Hexadeca-SPI: " << static_cast<int>(result.error()));
+            FL_WARN_F("SPI Bus Manager: Failed to acquire DMA buffer for Hexadeca-SPI: %s", static_cast<int>(result.error()));
             // Clear buffers and bail
             for (auto& lane_buffer : bus.lane_buffers) {
                 lane_buffer.clear();
@@ -352,7 +352,7 @@ void SPIBusManager::finalizeTransmission(SPIBusHandle handle) FL_NOEXCEPT {
         SpiHw8* octal = static_cast<SpiHw8*>(bus.hw_controller.get());
         result = octal->acquireDMABuffer(max_size);
         if (!result.ok()) {
-            FL_WARN_FMT("SPI Bus Manager: Failed to acquire DMA buffer for Octal-SPI: " << static_cast<int>(result.error()));
+            FL_WARN_F("SPI Bus Manager: Failed to acquire DMA buffer for Octal-SPI: %s", static_cast<int>(result.error()));
             // Clear buffers and bail
             for (auto& lane_buffer : bus.lane_buffers) {
                 lane_buffer.clear();
@@ -364,7 +364,7 @@ void SPIBusManager::finalizeTransmission(SPIBusHandle handle) FL_NOEXCEPT {
         SpiHw4* quad = static_cast<SpiHw4*>(bus.hw_controller.get());
         result = quad->acquireDMABuffer(max_size);
         if (!result.ok()) {
-            FL_WARN_FMT("SPI Bus Manager: Failed to acquire DMA buffer for Quad-SPI: " << static_cast<int>(result.error()));
+            FL_WARN_F("SPI Bus Manager: Failed to acquire DMA buffer for Quad-SPI: %s", static_cast<int>(result.error()));
             // Clear buffers and bail
             for (auto& lane_buffer : bus.lane_buffers) {
                 lane_buffer.clear();
@@ -389,7 +389,7 @@ void SPIBusManager::finalizeTransmission(SPIBusHandle handle) FL_NOEXCEPT {
 
         // Transpose lanes directly into DMA buffer (zero-copy!)
         if (!SPITransposer::transpose16(lanes, dma_buf, &error)) {
-            FL_WARN_FMT("SPI Bus Manager: Hexadeca transpose failed - " << (error ? error : "unknown error"));
+            FL_WARN_F("SPI Bus Manager: Hexadeca transpose failed - %s", (error ? error : "unknown error"));
             // Clear buffers and bail
             for (auto& lane_buffer : bus.lane_buffers) {
                 lane_buffer.clear();
@@ -423,7 +423,7 @@ void SPIBusManager::finalizeTransmission(SPIBusHandle handle) FL_NOEXCEPT {
 
         // Transpose lanes directly into DMA buffer (zero-copy!)
         if (!SPITransposer::transpose8(lanes, dma_buf, &error)) {
-            FL_WARN_FMT("SPI Bus Manager: Octal transpose failed - " << (error ? error : "unknown error"));
+            FL_WARN_F("SPI Bus Manager: Octal transpose failed - %s", (error ? error : "unknown error"));
             // Clear buffers and bail
             for (auto& lane_buffer : bus.lane_buffers) {
                 lane_buffer.clear();
@@ -457,7 +457,7 @@ void SPIBusManager::finalizeTransmission(SPIBusHandle handle) FL_NOEXCEPT {
 
         // Transpose lanes directly into DMA buffer (zero-copy!)
         if (!SPITransposer::transpose4(lanes[0], lanes[1], lanes[2], lanes[3], dma_buf, &error)) {
-            FL_WARN_FMT("SPI Bus Manager: Quad transpose failed - " << (error ? error : "unknown error"));
+            FL_WARN_F("SPI Bus Manager: Quad transpose failed - %s", (error ? error : "unknown error"));
             // Clear buffers and bail
             for (auto& lane_buffer : bus.lane_buffers) {
                 lane_buffer.clear();
@@ -492,7 +492,7 @@ void SPIBusManager::finalizeTransmission(SPIBusHandle handle) FL_NOEXCEPT {
     }
 
     if (!transmit_ok) {
-        FL_WARN_FMT("SPI Bus Manager: " << (is_hexadeca_mode ? "Hexadeca" : (is_octal_mode ? "Octal" : "Quad")) << "-SPI transmit failed");
+        FL_WARN_F("SPI Bus Manager: %s-SPI transmit failed", (is_hexadeca_mode ? "Hexadeca" : (is_octal_mode ? "Octal" : "Quad")));
     }
 
     // Clear lane buffers for next frame
@@ -515,7 +515,7 @@ bool SPIBusManager::isDeviceEnabled(SPIBusHandle handle) const FL_NOEXCEPT {
 }
 
 void SPIBusManager::reset() FL_NOEXCEPT {
-    FL_DBG("SPIBusManager: reset() called");
+    FL_DBG_F("SPIBusManager: reset() called");
     // Save current mNumBuses before clearing
     u8 num_buses_to_clear = mNumBuses;
     // Set mNumBuses to 0 first to prevent re-entry issues
@@ -524,20 +524,20 @@ void SPIBusManager::reset() FL_NOEXCEPT {
 
     // Only iterate through buses that were actually used
     for (u8 i = 0; i < num_buses_to_clear; i++) {
-        FL_DBG("SPIBusManager: reset() checking bus " << static_cast<int>(i));
+        FL_DBG_F("SPIBusManager: reset() checking bus %s", static_cast<int>(i));
         // Clean up hardware controllers if allocated
         if (mBuses[i].is_initialized) {
-            FL_DBG("SPIBusManager: reset() releasing bus " << static_cast<int>(i));
+            FL_DBG_F("SPIBusManager: reset() releasing bus %s", static_cast<int>(i));
             releaseBusHardware(mBuses[i]);
-            FL_DBG("SPIBusManager: reset() released bus " << static_cast<int>(i));
+            FL_DBG_F("SPIBusManager: reset() released bus %s", static_cast<int>(i));
         }
-        FL_DBG("SPIBusManager: reset() resetting bus info for bus " << static_cast<int>(i));
+        FL_DBG_F("SPIBusManager: reset() resetting bus info for bus %s", static_cast<int>(i));
         // Explicitly clear vectors to avoid crashes during destruction
-        FL_DBG("SPIBusManager: reset() clearing lane_buffers");
+        FL_DBG_F("SPIBusManager: reset() clearing lane_buffers");
         mBuses[i].lane_buffers.clear();
-        FL_DBG("SPIBusManager: reset() clearing interleaved_buffer");
+        FL_DBG_F("SPIBusManager: reset() clearing interleaved_buffer");
         mBuses[i].interleaved_buffer.clear();
-        FL_DBG("SPIBusManager: reset() resetting scalar fields");
+        FL_DBG_F("SPIBusManager: reset() resetting scalar fields");
         // Reset scalar fields
         mBuses[i].clock_pin = 0xFF;
         mBuses[i].bus_type = SPIBusType::SOFT_SPI;
@@ -550,9 +550,9 @@ void SPIBusManager::reset() FL_NOEXCEPT {
         for (u8 j = 0; j < 16; j++) {
             mBuses[i].devices[j] = SPIDeviceInfo();
         }
-        FL_DBG("SPIBusManager: reset() done with bus " << static_cast<int>(i));
+        FL_DBG_F("SPIBusManager: reset() done with bus %s", static_cast<int>(i));
     }
-    FL_DBG("SPIBusManager: reset() complete");
+    FL_DBG_F("SPIBusManager: reset() complete");
 }
 
 u8 SPIBusManager::getNumBuses() const FL_NOEXCEPT {
@@ -600,7 +600,7 @@ bool SPIBusManager::initializeBus(SPIBusInfo& bus) FL_NOEXCEPT {
     // User explicitly requested software SPI - skip hardware attempts
     bus.bus_type = SPIBusType::SOFT_SPI;
     bus.is_initialized = true;
-    FL_DBG("SPI: Forcing software SPI (FASTLED_FORCE_SOFTWARE_SPI defined)");
+    FL_DBG_F("SPI: Forcing software SPI (FASTLED_FORCE_SOFTWARE_SPI defined)");
     return true;
 #endif
 
@@ -622,18 +622,18 @@ bool SPIBusManager::initializeBus(SPIBusInfo& bus) FL_NOEXCEPT {
                 default: break;
             }
             (void)type_name;  // Suppress unused variable warning when FL_WARN is a no-op
-            FL_WARN_FMT("SPI Manager: Promoted clock pin " << bus.clock_pin << " to " << type_name << " (" << bus.num_devices << " devices)");
+            FL_WARN_F("SPI Manager: Promoted clock pin %s to %s (%s devices)", bus.clock_pin, type_name, bus.num_devices);
             return true;
         } else {
             // Promotion failed - disable conflicting devices
-            FL_WARN_FMT("SPI Manager: Cannot promote clock pin " << bus.clock_pin << " (platform limitation)");
+            FL_WARN_F("SPI Manager: Cannot promote clock pin %s (platform limitation)", bus.clock_pin);
             disableConflictingDevices(bus);
             return false;
         }
     }
 
     // Too many devices (>16)
-    FL_WARN_FMT("SPI Manager: Too many devices on clock pin " << bus.clock_pin << " (" << bus.num_devices << " devices, max 16)");
+    FL_WARN_F("SPI Manager: Too many devices on clock pin %s (%s devices, max 16)", bus.clock_pin, bus.num_devices);
     disableConflictingDevices(bus);
     return false;
 }
@@ -680,8 +680,7 @@ bool SPIBusManager::promoteToMultiSPI(SPIBusInfo& bus) FL_NOEXCEPT {
             return false;
         }
 
-        FL_DBG("SPI: Initialized Dual-SPI controller '" << dual_ctrl->getName()
-               << "' (bus " << config.bus_num << ") at " << config.clock_speed_hz << " Hz");
+        FL_DBG_F("SPI: Initialized Dual-SPI controller '%s' (bus %s) at %s Hz", dual_ctrl->getName(), config.bus_num, config.clock_speed_hz);
 
         // Store controller pointer and SPI bus number
         bus.hw_controller = dual_ctrl;
@@ -735,8 +734,7 @@ bool SPIBusManager::promoteToMultiSPI(SPIBusInfo& bus) FL_NOEXCEPT {
             return false;
         }
 
-        FL_DBG("SPI: Initialized Quad-SPI controller '" << quad_ctrl->getName()
-               << "' (bus " << config.bus_num << ") at " << config.clock_speed_hz << " Hz");
+        FL_DBG_F("SPI: Initialized Quad-SPI controller '%s' (bus %s) at %s Hz", quad_ctrl->getName(), config.bus_num, config.clock_speed_hz);
 
         // Store controller pointer and SPI bus number
         bus.hw_controller = quad_ctrl;
@@ -795,8 +793,7 @@ bool SPIBusManager::promoteToMultiSPI(SPIBusInfo& bus) FL_NOEXCEPT {
             return false;
         }
 
-        FL_DBG("SPI: Initialized Octal-SPI controller '" << octal_ctrl->getName()
-               << "' (bus " << config.bus_num << ") at " << config.clock_speed_hz << " Hz");
+        FL_DBG_F("SPI: Initialized Octal-SPI controller '%s' (bus %s) at %s Hz", octal_ctrl->getName(), config.bus_num, config.clock_speed_hz);
 
         // Store controller pointer and SPI bus number
         bus.hw_controller = octal_ctrl;
@@ -863,8 +860,7 @@ bool SPIBusManager::promoteToMultiSPI(SPIBusInfo& bus) FL_NOEXCEPT {
             return false;
         }
 
-        FL_DBG("SPI: Initialized Hexadeca-SPI controller '" << hexadeca_ctrl->getName()
-               << "' (bus " << config.bus_num << ") at " << config.clock_speed_hz << " Hz");
+        FL_DBG_F("SPI: Initialized Hexadeca-SPI controller '%s' (bus %s) at %s Hz", hexadeca_ctrl->getName(), config.bus_num, config.clock_speed_hz);
 
         // Store controller pointer and SPI bus number
         bus.hw_controller = hexadeca_ctrl;
@@ -884,7 +880,7 @@ bool SPIBusManager::promoteToMultiSPI(SPIBusInfo& bus) FL_NOEXCEPT {
 bool SPIBusManager::createSingleSPI(SPIBusInfo& bus) FL_NOEXCEPT {
     // Single SPI is the standard path - just mark as initialized
     // The existing SPI controller code will handle it
-    FL_DBG("SPI: Using standard single-lane SPI (bus manager passthrough mode)");
+    FL_DBG_F("SPI: Using standard single-lane SPI (bus manager passthrough mode)");
     bus.is_initialized = true;
     return true;
 }
@@ -893,7 +889,7 @@ void SPIBusManager::disableConflictingDevices(SPIBusInfo& bus) FL_NOEXCEPT {
     // Keep first device enabled, disable all others
     for (u8 i = 1; i < bus.num_devices; i++) {
         bus.devices[i].is_enabled = false;
-        FL_WARN_FMT("SPI Manager: Disabled device " << i << " on clock pin " << bus.clock_pin << " (conflict)");
+        FL_WARN_F("SPI Manager: Disabled device %s on clock pin %s (conflict)", i, bus.clock_pin);
     }
 
     // Initialize first device as single SPI
@@ -925,16 +921,16 @@ u32 SPIBusManager::selectBusSpeed(const SPIBusInfo& bus) FL_NOEXCEPT {
     // Clamp to platform-specific maximum
     u32 platform_max = getPlatformMaxSpeed();
     if (min_speed > platform_max) {
-        FL_WARN_FMT("SPI: Requested speed " << min_speed << " Hz exceeds platform max "
-                << platform_max << " Hz, clamping to " << platform_max);
+        FL_WARN_F("SPI: Requested speed %s Hz exceeds platform max %s Hz, clamping to %s", min_speed, platform_max, platform_max);
         min_speed = platform_max;
     }
 
     // Log selected speed in MHz with one decimal place
+#ifdef FASTLED_LOG_SPI_ENABLED
     u32 mhz_whole = min_speed / 1000000;
     u32 mhz_tenth = (min_speed / 100000) % 10;
-    FL_LOG_SPI("SPI: Selected bus speed " << mhz_whole << "." << mhz_tenth
-               << " MHz for clock pin " << static_cast<int>(bus.clock_pin));
+    FL_LOG_SPI_F("SPI: Selected bus speed %s.%s MHz for clock pin %s", mhz_whole, mhz_tenth, static_cast<int>(bus.clock_pin));
+#endif
 
     return min_speed;
 }
@@ -974,20 +970,20 @@ u32 SPIBusManager::getPlatformMaxSpeed() FL_NOEXCEPT {
 }
 
 void SPIBusManager::releaseBusHardware(SPIBusInfo& bus) FL_NOEXCEPT {
-    FL_DBG("SPIBusManager: releaseBusHardware() called, is_initialized=" << (bus.is_initialized ? "true" : "false"));
+    FL_DBG_F("SPIBusManager: releaseBusHardware() called, is_initialized=%s", (bus.is_initialized ? "true" : "false"));
     if (!bus.is_initialized) {
-        FL_DBG("SPIBusManager: releaseBusHardware() bus not initialized, returning");
+        FL_DBG_F("SPIBusManager: releaseBusHardware() bus not initialized, returning");
         return;  // Nothing to release
     }
 
-    FL_DBG("SPIBusManager: releaseBusHardware() bus_type=" << static_cast<int>(bus.bus_type));
+    FL_DBG_F("SPIBusManager: releaseBusHardware() bus_type=%s", static_cast<int>(bus.bus_type));
     // Release Single-SPI controller (runtime detection)
     if (bus.bus_type == SPIBusType::SINGLE_SPI && bus.hw_controller) {
-        FL_DBG("SPIBusManager: releaseBusHardware() releasing SINGLE_SPI controller");
+        FL_DBG_F("SPIBusManager: releaseBusHardware() releasing SINGLE_SPI controller");
         SpiHw1* single = static_cast<SpiHw1*>(bus.hw_controller.get());
-        FL_DBG("SPIBusManager: releaseBusHardware() calling single->end()");
+        FL_DBG_F("SPIBusManager: releaseBusHardware() calling single->end()");
         single->end();  // Shutdown SPI peripheral
-        FL_DBG("SPIBusManager: releaseBusHardware() nulling hw_controller");
+        FL_DBG_F("SPIBusManager: releaseBusHardware() nulling hw_controller");
         bus.hw_controller = nullptr;
     }
 

--- a/src/platforms/shared/ui/json/json_console.cpp.hpp
+++ b/src/platforms/shared/ui/json/json_console.cpp.hpp
@@ -53,7 +53,7 @@ void JsonConsole::init() FL_NOEXCEPT {
     });
     
     if (!mUpdateEngineState) {
-        FL_WARN("JsonConsole::init: Failed to set up JsonUI handlers");
+        FL_WARN_F("JsonConsole::init: Failed to set up JsonUI handlers");
         return;
     }
     
@@ -69,10 +69,10 @@ void JsonConsole::update() FL_NOEXCEPT {
 }
 
 bool JsonConsole::executeCommand(const fl::string& command) FL_NOEXCEPT {
-    FL_WARN("JsonConsole::executeCommand called with: '" << command.c_str() << "'");
+    FL_WARN_F("JsonConsole::executeCommand called with: '%s'", command.c_str());
     
     if (command.empty()) {
-        FL_WARN("JsonConsole::executeCommand: Command is empty");
+        FL_WARN_F("JsonConsole::executeCommand: Command is empty");
         return false;
     }
     
@@ -86,16 +86,16 @@ bool JsonConsole::executeCommand(const fl::string& command) FL_NOEXCEPT {
         trimmed = trimmed.substr(0, trimmed.size()-1);
     }
     
-    FL_WARN("JsonConsole::executeCommand: Trimmed command: '" << trimmed.c_str() << "'");
+    FL_WARN_F("JsonConsole::executeCommand: Trimmed command: '%s'", trimmed.c_str());
     
     if (trimmed.empty()) {
-        FL_WARN("JsonConsole::executeCommand: Trimmed command is empty");
+        FL_WARN_F("JsonConsole::executeCommand: Trimmed command is empty");
         return false;
     }
     
     // Handle help command
     if (trimmed == "help") {
-        FL_WARN("JsonConsole::executeCommand: Executing help command");
+        FL_WARN_F("JsonConsole::executeCommand: Executing help command");
         writeOutput("Available commands:");
         writeOutput("  <component_name>: <value>  - Set component value by name");
         writeOutput("  <component_id>: <value>    - Set component value by ID");
@@ -106,9 +106,9 @@ bool JsonConsole::executeCommand(const fl::string& command) FL_NOEXCEPT {
         return true;
     }
     
-    FL_WARN("JsonConsole::executeCommand: Calling parseCommand");
+    FL_WARN_F("JsonConsole::executeCommand: Calling parseCommand");
     parseCommand(trimmed);
-    FL_WARN("JsonConsole::executeCommand: parseCommand completed");
+    FL_WARN_F("JsonConsole::executeCommand: parseCommand completed");
     return true;
 }
 
@@ -153,11 +153,11 @@ void JsonConsole::readInputFromSerial() FL_NOEXCEPT {
 }
 
 void JsonConsole::parseCommand(const fl::string& command) FL_NOEXCEPT {
-    FL_WARN("JsonConsole::parseCommand: Parsing command '" << command.c_str() << "'");
+    FL_WARN_F("JsonConsole::parseCommand: Parsing command '%s'", command.c_str());
     
     // Look for pattern: "name: value"
     i16 colonPos = command.find(':');
-    FL_WARN("JsonConsole::parseCommand: Colon position: " << colonPos);
+    FL_WARN_F("JsonConsole::parseCommand: Colon position: %s", colonPos);
     
     if (colonPos == -1) {
         writeOutput("Error: Command format should be 'name: value'");
@@ -168,8 +168,8 @@ void JsonConsole::parseCommand(const fl::string& command) FL_NOEXCEPT {
     fl::string name = command.substring(0, static_cast<fl::size>(colonPos - 1));
     fl::string valueStr = command.substring(static_cast<fl::size>(colonPos + 1), command.size());
     
-    FL_WARN("JsonConsole::parseCommand: Raw name: '" << name.c_str() << "'");
-    FL_WARN("JsonConsole::parseCommand: Raw valueStr: '" << valueStr.c_str() << "'");
+    FL_WARN_F("JsonConsole::parseCommand: Raw name: '%s'", name.c_str());
+    FL_WARN_F("JsonConsole::parseCommand: Raw valueStr: '%s'", valueStr.c_str());
     
     // Trim whitespace from name and value
     while (!name.empty() && name[name.size()-1] == ' ') {
@@ -179,8 +179,8 @@ void JsonConsole::parseCommand(const fl::string& command) FL_NOEXCEPT {
         valueStr = valueStr.substring(1, valueStr.size());
     }
     
-    FL_WARN("JsonConsole::parseCommand: Trimmed name: '" << name.c_str() << "'");
-    FL_WARN("JsonConsole::parseCommand: Trimmed valueStr: '" << valueStr.c_str() << "'");
+    FL_WARN_F("JsonConsole::parseCommand: Trimmed name: '%s'", name.c_str());
+    FL_WARN_F("JsonConsole::parseCommand: Trimmed valueStr: '%s'", valueStr.c_str());
     
     if (name.empty() || valueStr.empty()) {
         writeOutput("Error: Both name and value are required");
@@ -214,10 +214,10 @@ void JsonConsole::parseCommand(const fl::string& command) FL_NOEXCEPT {
 }
 
 bool JsonConsole::setSliderValue(const fl::string& name, float value) FL_NOEXCEPT {
-    FL_WARN("JsonConsole::setSliderValue: Looking for component '" << name.c_str() << "' with value " << value);
-    FL_WARN("JsonConsole: Component mapping size: " << mComponentNameToId.size());
+    FL_WARN_F("JsonConsole::setSliderValue: Looking for component '%s' with value %s", name.c_str(), value);
+    FL_WARN_F("JsonConsole: Component mapping size: %s", mComponentNameToId.size());
     for (const auto& pair : mComponentNameToId) {
-        FL_WARN("JsonConsole: Available component: '" << pair.first.c_str() << "' -> ID " << pair.second);
+        FL_WARN_F("JsonConsole: Available component: '%s' -> ID %s", pair.first.c_str(), pair.second);
     }
     
     int componentId = -1;
@@ -230,7 +230,7 @@ bool JsonConsole::setSliderValue(const fl::string& name, float value) FL_NOEXCEP
     if (endptr != cstr && *endptr == '\0' && parsed >= 0 && parsed <= 2147483647L) {
         // Successfully parsed as a valid integer ID
         componentId = static_cast<int>(parsed);
-        FL_WARN("JsonConsole: Using numeric ID: " << componentId);
+        FL_WARN_F("JsonConsole: Using numeric ID: %s", componentId);
     } else {
         // Not a valid integer, try to find component ID by name
         auto it = mComponentNameToId.find(name);
@@ -245,12 +245,12 @@ bool JsonConsole::setSliderValue(const fl::string& name, float value) FL_NOEXCEP
         }
         
         if (!componentIdPtr) {
-            FL_WARN("JsonConsole: Component '" << name.c_str() << "' not found in mapping");
+            FL_WARN_F("JsonConsole: Component '%s' not found in mapping", name.c_str());
             return false; // Component not found
         }
         
         componentId = *componentIdPtr;
-        FL_WARN("JsonConsole: Found component ID: " << componentId);
+        FL_WARN_F("JsonConsole: Found component ID: %s", componentId);
     }
     
     // Create JSON to update the component using new json
@@ -265,15 +265,15 @@ bool JsonConsole::setSliderValue(const fl::string& name, float value) FL_NOEXCEP
     // Convert to string and send to driver
     fl::string jsonStr = doc.to_string();
     
-    FL_WARN("JsonConsole: Sending JSON to driver: " << jsonStr.c_str());
+    FL_WARN_F("JsonConsole: Sending JSON to driver: %s", jsonStr.c_str());
     mUpdateEngineState(jsonStr.c_str());
     
     // Force immediate processing of pending updates (for testing environments)
     // In normal operation, this happens during the driver loop
-    FL_WARN("JsonConsole: Calling processJsonUiPendingUpdates()");
+    FL_WARN_F("JsonConsole: Calling processJsonUiPendingUpdates()");
     processJsonUiPendingUpdates();
     
-    FL_WARN("JsonConsole: setSliderValue completed successfully");
+    FL_WARN_F("JsonConsole: setSliderValue completed successfully");
     return true;
 }
 

--- a/src/platforms/shared/ui/json/ui.cpp.hpp
+++ b/src/platforms/shared/ui/json/ui.cpp.hpp
@@ -71,7 +71,7 @@ JsonUiUpdateInput setJsonUiHandlers(const JsonUiUpdateOutput& updateJsHandler) F
                 manager->updateUiComponents(jsonStr);
                 // FL_WARN("*** updateEngineState lambda: updateUiComponents completed");
             } else {
-                FL_WARN("*** updateEngineState lambda: NO MANAGER EXISTS!");
+                FL_WARN_F("*** updateEngineState lambda: NO MANAGER EXISTS!");
             }
         });
         // FL_WARN("setJsonUiHandlers: updateEngineState lambda created, returning it (is " << (result ? "VALID" : "nullptr") << ")");

--- a/src/platforms/shared/ui/json/ui_manager.cpp.hpp
+++ b/src/platforms/shared/ui/json/ui_manager.cpp.hpp
@@ -116,7 +116,7 @@ fl::vector<JsonUiInternalPtr> JsonUiManager::getComponents() FL_NOEXCEPT {
         if (auto ptr = component.lock()) {
             out.push_back(ptr);
         } else {
-            FL_WARN("*** WARNING: Component weak_ptr is expired, skipping");
+            FL_WARN_F("*** WARNING: Component weak_ptr is expired, skipping");
         }
     }
     // Sort components by ID to ensure consistent serialization order
@@ -185,15 +185,13 @@ void JsonUiManager::executeUiUpdates(const fl::json &doc) FL_NOEXCEPT {
                 const fl::json v = doc[key.c_str()];
                 component->updateInternal(v);
             } else {
-                FL_ERROR("could not find component with ID or name: " << id_or_name);
+                FL_ERROR_F("could not find component with ID or name: %s", id_or_name);
             }
         }
     } else {
         // Debug: Show what we actually received instead of just asserting
         fl::string debugJson = doc.to_string();
-        FL_WARN("*** UI UPDATE ERROR: Expected JSON object but got " << 
-               (doc.is_array() ? "array" : "non-object") << 
-               ": " << debugJson.substr(0, 200).c_str() << "...");
+        FL_WARN_F("*** UI UPDATE ERROR: Expected JSON object but got %s: %s...", (doc.is_array() ? "array" : "non-object"), debugJson.substr(0, 200).c_str());
         
         // Use a warning instead of assertion to prevent crashes
         // FL_ASSERT(false, "JSON document is not an object, cannot execute UI updates");

--- a/src/platforms/stub/clockless_channel_stub.h
+++ b/src/platforms/stub/clockless_channel_stub.h
@@ -72,7 +72,7 @@ protected:
         // with `cfg.options.mBus` -- the manager-driven Channel path stays.
         fl::shared_ptr<IChannelDriver> driver = mDriver.lock();
         if (!driver) {
-            FL_ERROR("ClocklessController(stub): No compatible driver found - cannot transmit");
+            FL_ERROR_F("ClocklessController(stub): No compatible driver found - cannot transmit");
             return;
         }
 
@@ -86,7 +86,7 @@ protected:
             // Warn every second if still waiting (possible deadlock or hardware issue)
             u32 elapsed = fl::millis() - startTime;
             if (elapsed > 1000 && (fl::millis() - lastWarnTime) >= 1000) {
-                FL_WARN("ClocklessController(stub): Buffer still busy after " << elapsed << "ms total - possible deadlock or slow hardware");
+                FL_WARN_F("ClocklessController(stub): Buffer still busy after %sms total - possible deadlock or slow hardware", elapsed);
                 lastWarnTime = fl::millis();
             }
         }

--- a/src/platforms/stub/fs_stub.hpp
+++ b/src/platforms/stub/fs_stub.hpp
@@ -281,13 +281,13 @@ public:
 #else
         if (access(full_path.c_str(), F_OK) != 0) {
 #endif
-            FL_WARN("Test file not found: " << full_path.c_str());
+            FL_WARN_F("Test file not found: %s", full_path.c_str());
             return filebuf_ptr();
         }
 
         auto handle = fl::make_shared<StubFileHandle>(full_path);
         if (!handle->valid()) {
-            FL_WARN("Failed to open test file: " << full_path.c_str());
+            FL_WARN_F("Failed to open test file: %s", full_path.c_str());
             return filebuf_ptr();
         }
 

--- a/src/platforms/stub/spi_16_stub.cpp.hpp
+++ b/src/platforms/stub/spi_16_stub.cpp.hpp
@@ -225,10 +225,10 @@ namespace platforms {
 /// Called lazily on first access to SpiHw16::getAll().
 /// Registers mock SpiHw16 controller instances for testing.
 void initSpiHw16Instances() FL_NOEXCEPT {
-    FL_WARN("Registering SpiHw16 stub instances...");
+    FL_WARN_F("Registering SpiHw16 stub instances...");
     SpiHw16::registerInstance(getController2_Spi16());
     SpiHw16::registerInstance(getController3_Spi16());
-    FL_WARN("SpiHw16 stub instances registered!");
+    FL_WARN_F("SpiHw16 stub instances registered!");
 }
 
 }  // namespace platforms

--- a/src/platforms/stub/spi_1_stub.cpp.hpp
+++ b/src/platforms/stub/spi_1_stub.cpp.hpp
@@ -38,23 +38,23 @@ bool SpiHw1Stub::begin(const SpiHw1::Config& config) FL_NOEXCEPT {
 }
 
 void SpiHw1Stub::end() FL_NOEXCEPT {
-    FL_LOG_SPI("SpiHw1Stub::end() called, mInitialized=" << (mInitialized ? "true" : "false"));
+    FL_LOG_SPI_F("SpiHw1Stub::end() called, mInitialized=%s", (mInitialized ? "true" : "false"));
     if (!mInitialized) {
-        FL_LOG_SPI("SpiHw1Stub::end() already ended, returning");
+        FL_LOG_SPI_F("SpiHw1Stub::end() already ended, returning");
         return;  // Already ended - idempotent
     }
 
-    FL_LOG_SPI("SpiHw1Stub::end() setting mInitialized=false");
+    FL_LOG_SPI_F("SpiHw1Stub::end() setting mInitialized=false");
     mInitialized = false;
-    FL_LOG_SPI("SpiHw1Stub::end() clearing mLastBuffer");
+    FL_LOG_SPI_F("SpiHw1Stub::end() clearing mLastBuffer");
     mLastBuffer.clear();
 
-    FL_LOG_SPI("SpiHw1Stub::end() resetting mCurrentBuffer");
+    FL_LOG_SPI_F("SpiHw1Stub::end() resetting mCurrentBuffer");
     // Release current buffer
     mCurrentBuffer.reset();
-    FL_LOG_SPI("SpiHw1Stub::end() setting mBufferAcquired=false");
+    FL_LOG_SPI_F("SpiHw1Stub::end() setting mBufferAcquired=false");
     mBufferAcquired = false;
-    FL_LOG_SPI("SpiHw1Stub::end() complete");
+    FL_LOG_SPI_F("SpiHw1Stub::end() complete");
 }
 
 DMABuffer SpiHw1Stub::acquireDMABuffer(size_t bytes_per_lane) FL_NOEXCEPT {
@@ -175,10 +175,10 @@ namespace platforms {
 /// Called lazily on first access to SpiHw1::getAll().
 /// Registers mock SpiHw1 controller instances for testing.
 void initSpiHw1Instances() FL_NOEXCEPT {
-    FL_WARN("Registering SpiHw1 stub instances...");
+    FL_WARN_F("Registering SpiHw1 stub instances...");
     SpiHw1::registerInstance(getController0_Spi1());
     SpiHw1::registerInstance(getController1_Spi1());
-    FL_WARN("SpiHw1 stub instances registered!");
+    FL_WARN_F("SpiHw1 stub instances registered!");
 }
 
 }  // namespace platforms

--- a/src/platforms/stub/spi_2_stub.cpp.hpp
+++ b/src/platforms/stub/spi_2_stub.cpp.hpp
@@ -232,10 +232,10 @@ namespace platforms {
 /// Called lazily on first access to SpiHw2::getAll().
 /// Registers mock SpiHw2 controller instances for testing.
 void initSpiHw2Instances() FL_NOEXCEPT {
-    FL_WARN("Registering SpiHw2 stub instances...");
+    FL_WARN_F("Registering SpiHw2 stub instances...");
     SpiHw2::registerInstance(getController0_Spi2());
     SpiHw2::registerInstance(getController1_Spi2());
-    FL_WARN("SpiHw2 stub instances registered!");
+    FL_WARN_F("SpiHw2 stub instances registered!");
 }
 
 }  // namespace platforms

--- a/src/platforms/stub/spi_4_stub.cpp.hpp
+++ b/src/platforms/stub/spi_4_stub.cpp.hpp
@@ -216,10 +216,10 @@ namespace platforms {
 /// Called lazily on first access to SpiHw4::getAll().
 /// Registers mock SpiHw4 controller instances for testing.
 void initSpiHw4Instances() FL_NOEXCEPT {
-    FL_WARN("Registering SpiHw4 stub instances...");
+    FL_WARN_F("Registering SpiHw4 stub instances...");
     SpiHw4::registerInstance(getController2_Spi4());
     SpiHw4::registerInstance(getController3_Spi4());
-    FL_WARN("SpiHw4 stub instances registered!");
+    FL_WARN_F("SpiHw4 stub instances registered!");
 }
 
 }  // namespace platforms

--- a/src/platforms/stub/spi_8_stub.cpp.hpp
+++ b/src/platforms/stub/spi_8_stub.cpp.hpp
@@ -216,10 +216,10 @@ namespace platforms {
 /// Called lazily on first access to SpiHw8::getAll().
 /// Registers mock SpiHw8 controller instances for testing.
 void initSpiHw8Instances() FL_NOEXCEPT {
-    FL_WARN("Registering SpiHw8 stub instances...");
+    FL_WARN_F("Registering SpiHw8 stub instances...");
     SpiHw8::registerInstance(getController2_Spi8());
     SpiHw8::registerInstance(getController3_Spi8());
-    FL_WARN("SpiHw8 stub instances registered!");
+    FL_WARN_F("SpiHw8 stub instances registered!");
 }
 
 }  // namespace platforms

--- a/src/platforms/stub/spi_channel_stub.h
+++ b/src/platforms/stub/spi_channel_stub.h
@@ -54,7 +54,7 @@ protected:
     virtual void showPixels(PixelController<RGB_ORDER>& pixels) override
     {
         if (!mDriver) {
-            FL_WARN_EVERY(100, "No Engine");
+            FL_WARN_F_EVERY(100, "No Engine");
             return;
         }
         // Wait for previous transmission to complete and release buffer
@@ -63,10 +63,10 @@ protected:
         u32 lastWarnTime = startTime;
         if (mChannelData->isInUse()) {
 
-                FL_WARN_EVERY(100, "ClocklessSPI(stub): driver should have finished transmitting by now - waiting");
+                FL_WARN_F_EVERY(100, "ClocklessSPI(stub): driver should have finished transmitting by now - waiting");
                 bool finished = mDriver->waitForReady();
                 if (!finished) {
-                    FL_ERROR("ClocklessSPI(stub): Engine still busy after " << fl::millis() - startTime << "ms");
+                    FL_ERROR_F("ClocklessSPI(stub): Engine still busy after %sms", fl::millis() - startTime);
                     return;
                 }
 

--- a/src/platforms/wasm/audio_input_wasm.cpp.hpp
+++ b/src/platforms/wasm/audio_input_wasm.cpp.hpp
@@ -36,7 +36,7 @@ WasmAudioInput::WasmAudioInput()
     // Set global instance for C callback
     g_wasmAudioInput = this;
 
-    FL_DBG("WasmAudioInput created - ring buffer: " << RING_BUFFER_SLOTS << " slots x " << BLOCK_SIZE << " samples");
+    FL_DBG_F("WasmAudioInput created - ring buffer: %s slots x %s samples", RING_BUFFER_SLOTS, BLOCK_SIZE);
 }
 
 WasmAudioInput::~WasmAudioInput() {
@@ -48,14 +48,14 @@ WasmAudioInput::~WasmAudioInput() {
 
 void WasmAudioInput::start() {
     if (mRunning) {
-        FL_DBG("WasmAudioInput already running - skipping start");
+        FL_DBG_F("WasmAudioInput already running - skipping start");
         return;  // Already running, don't re-initialize
     }
 
     mRunning = true;
     mHasError = false;
     mErrorMessage.clear();
-    FL_DBG("WasmAudioInput started");
+    FL_DBG_F("WasmAudioInput started");
 }
 
 void WasmAudioInput::stop() {
@@ -66,7 +66,7 @@ void WasmAudioInput::stop() {
     for (int i = 0; i < RING_BUFFER_SLOTS; i++) {
         mRingBuffer[i].valid = false;
     }
-    FL_DBG("WasmAudioInput stopped");
+    FL_DBG_F("WasmAudioInput stopped");
 }
 
 bool WasmAudioInput::error(fl::string* msg) {
@@ -117,7 +117,7 @@ void WasmAudioInput::pushSamples(const fl::i16* samples, int count, fl::u32 time
     }
 
     if (count <= 0 || count > BLOCK_SIZE) {
-        FL_WARN("WasmAudioInput::pushSamples - invalid block size: " << count << " (max " << BLOCK_SIZE << ")");
+        FL_WARN_F("WasmAudioInput::pushSamples - invalid block size: %s (max %s)", count, BLOCK_SIZE);
         return;
     }
 
@@ -144,7 +144,7 @@ void WasmAudioInput::flushAccumBuffer() {
     if (isFull()) {
         mDroppedBlocks++;
         if (mDroppedBlocks % 100 == 1) {
-            FL_WARN("WasmAudioInput ring buffer overflow - dropped " << mDroppedBlocks << " blocks total");
+            FL_WARN_F("WasmAudioInput ring buffer overflow - dropped %s blocks total", mDroppedBlocks);
         }
         mRingBuffer[mTail].valid = false;
         mTail = nextIndex(mTail);
@@ -191,7 +191,7 @@ fl::shared_ptr<audio::IInput> wasm_create_audio_input(const audio::Config& confi
         error_message->clear();
     }
 
-    FL_DBG("Created WASM audio input");
+    FL_DBG_F("Created WASM audio input");
     return input;
 }
 
@@ -225,7 +225,7 @@ void pushAudioSamples(const fl::i16* samples, int count, fl::u32 timestamp) {
     }
 
     if (!samples) {
-        FL_WARN("pushAudioSamples called with null samples pointer");
+        FL_WARN_F("pushAudioSamples called with null samples pointer");
         return;
     }
 

--- a/src/platforms/wasm/clockless_channel_wasm.h
+++ b/src/platforms/wasm/clockless_channel_wasm.h
@@ -60,17 +60,17 @@ protected:
     virtual void showPixels(PixelController<RGB_ORDER>& pixels) override
     {
         if (!mDriver) {
-            FL_WARN_EVERY(100, "No Engine");
+            FL_WARN_F_EVERY(100, "No Engine");
             return;
         }
         // Wait for previous transmission to complete and release buffer
         // This prevents race conditions when show() is called faster than hardware can transmit
         u32 startTime = fl::millis();
         if (mChannelData->isInUse()) {
-            FL_WARN_EVERY(100, "ClocklessController(wasm): driver should have finished transmitting by now - waiting");
+            FL_WARN_F_EVERY(100, "ClocklessController(wasm): driver should have finished transmitting by now - waiting");
             bool finished = mDriver->waitForReady();
             if (!finished) {
-                FL_ERROR("ClocklessController(wasm): Engine still busy after " << fl::millis() - startTime << "ms");
+                FL_ERROR_F("ClocklessController(wasm): Engine still busy after %sms", fl::millis() - startTime);
                 return;
             }
         }

--- a/src/platforms/wasm/coroutine_runtime_wasm.impl.hpp
+++ b/src/platforms/wasm/coroutine_runtime_wasm.impl.hpp
@@ -132,8 +132,7 @@ public:
                                     u8 priority = 5) FL_NOEXCEPT {
         auto* ctx = CoroutineContext::create(fl::move(function), stack_size);
         if (!ctx) {
-            FL_WARN("TaskCoroutineWasm: Failed to create context for '"
-                    << name << "'");
+            FL_WARN_F("TaskCoroutineWasm: Failed to create context for '%s'", name);
             return nullptr;
         }
 

--- a/src/platforms/wasm/fs_wasm.cpp.hpp
+++ b/src/platforms/wasm/fs_wasm.cpp.hpp
@@ -1,12 +1,12 @@
-// IWYU pragma: private
+﻿// IWYU pragma: private
 
 
 #include "platforms/wasm/is_wasm.h"
 #ifdef FL_IS_WASM
 
-// ⚠️⚠️⚠️ CRITICAL WARNING: C++ ↔ JavaScript FILE SYSTEM BRIDGE - HANDLE WITH EXTREME CARE! ⚠️⚠️⚠️
+// âš ï¸âš ï¸âš ï¸ CRITICAL WARNING: C++ â†” JavaScript FILE SYSTEM BRIDGE - HANDLE WITH EXTREME CARE! âš ï¸âš ï¸âš ï¸
 //
-// 🚨 THIS FILE CONTAINS C++ TO JAVASCRIPT FILE SYSTEM BINDINGS 🚨
+// ðŸš¨ THIS FILE CONTAINS C++ TO JAVASCRIPT FILE SYSTEM BINDINGS ðŸš¨
 //
 // DO NOT MODIFY FUNCTION SIGNATURES WITHOUT UPDATING CORRESPONDING JAVASCRIPT CODE!
 //
@@ -32,7 +32,7 @@
 // 3. Verify JSON parsing for file declarations works correctly
 // 4. Check that file operations remain accessible from JavaScript
 //
-// ⚠️⚠️⚠️ REMEMBER: File system errors prevent resource loading! ⚠️⚠️⚠️
+// âš ï¸âš ï¸âš ï¸ REMEMBER: File system errors prevent resource loading! âš ï¸âš ï¸âš ï¸
 
 // IWYU pragma: begin_keep
 #include <emscripten.h>
@@ -146,7 +146,7 @@ class WasmFileHandle : public fl::filebuf {
             return false;
         }
         if (!mData->ready(mPos)) {
-            FL_WARN("File is not ready yet. This is a major error because "
+            FL_WARN_F("File is not ready yet. This is a major error because "
                          "FastLED-wasm does not support async yet, the file "
                          "will fail to read.");
             return false;
@@ -171,7 +171,7 @@ class WasmFileHandle : public fl::filebuf {
             bytesToRead = mData->capacity() - mPos;
         }
         if (!mData->ready(mPos)) {
-            FL_WARN("File is not ready yet. This is a major error because "
+            FL_WARN_F("File is not ready yet. This is a major error because "
                          "FastLED-wasm does not support async yet, the file "
                          "will fail to read.");
             return 0;
@@ -238,7 +238,7 @@ class FsImplWasm : public fl::FsImpl {
                 // FL_DBG("Opened file: " << _path);
             } else {
                 out = fl::filebuf_ptr();
-                FL_DBG("File not found: " << _path);
+                FL_DBG_F("File not found: %s", _path);
             }
         }
         return out;
@@ -288,7 +288,7 @@ EMSCRIPTEN_KEEPALIVE bool jsInjectFile(const char *path, const fl::u8 *data,
 
     auto inserted = fl::_createIfNotExists(fl::string(path), len);
     if (!inserted) {
-        FL_WARN("File can only be injected once.");
+        FL_WARN_F("File can only be injected once.");
         return false;
     }
     inserted->append(data, len);
@@ -299,7 +299,7 @@ EMSCRIPTEN_KEEPALIVE bool jsAppendFile(const char *path, const fl::u8 *data,
                                        size_t len) {
     auto entry = fl::_findIfExists(fl::string(path));
     if (!entry) {
-        FL_WARN("File must be declared before it can be appended.");
+        FL_WARN_F("File must be declared before it can be appended.");
         return false;
     }
     entry->append(data, len);
@@ -310,7 +310,7 @@ EMSCRIPTEN_KEEPALIVE bool jsDeclareFile(const char *path, size_t len) {
     // declare a file and it's length. But don't fill it in yet
     auto inserted = fl::_createIfNotExists(fl::string(path), len);
     if (!inserted) {
-        FL_WARN("File can only be declared once.");
+        FL_WARN_F("File can only be declared once.");
         return false;
     }
     return true;

--- a/src/platforms/wasm/init_wasm.cpp.hpp
+++ b/src/platforms/wasm/init_wasm.cpp.hpp
@@ -34,7 +34,7 @@ void init() {
         return;  // Already initialized
     }
 
-    FL_DBG("WASM: Platform initialization starting");
+    FL_DBG_F("WASM: Platform initialization starting");
 
     // Initialize driver listener system
     // This connects FastLED driver events to the JavaScript runtime
@@ -45,7 +45,7 @@ void init() {
     platforms::initChannelDrivers();
 
     initialized = true;
-    FL_DBG("WASM: Platform initialization complete");
+    FL_DBG_F("WASM: Platform initialization complete");
 }
 
 } // namespace platforms

--- a/src/platforms/wasm/js_assert.h
+++ b/src/platforms/wasm/js_assert.h
@@ -11,7 +11,7 @@
 #define FASTLED_ASSERT(x, MSG)                                                 \
     do {                                                                       \
         if (!(x)) {                                                            \
-            FL_WARN(MSG);                                                 \
+            FL_WARN_F("%s", MSG);                                                 \
             emscripten_debugger();                                             \
         }                                                                      \
     } while (0)

--- a/src/platforms/wasm/js_bindings.cpp.hpp
+++ b/src/platforms/wasm/js_bindings.cpp.hpp
@@ -307,7 +307,7 @@ void _jsSetCanvasSize(int cledcontoller_id, const fl::ScreenMap &screenmap) {
     // JavaScript worker will cache this and avoid per-frame polling
     // NOTE: EM_JS has linking issues with partial linking - use polling approach instead
     // Worker will call getScreenMapData() during initialization to fetch this data
-    FL_DBG("Screenmap update available (worker will poll via getScreenMapData): " << jsonBuffer.c_str());
+    FL_DBG_F("Screenmap update available (worker will poll via getScreenMapData): %s", jsonBuffer.c_str());
 }
 
 EMSCRIPTEN_KEEPALIVE void jsFillInMissingScreenMaps(ActiveStripData &active_strips) {

--- a/src/platforms/wasm/js_fetch.cpp.hpp
+++ b/src/platforms/wasm/js_fetch.cpp.hpp
@@ -95,7 +95,7 @@ static WasmFetchCallbackManager& getCallbackManager() {
 
 // C++ callback function that JavaScript can call when fetch completes
 extern "C" EMSCRIPTEN_KEEPALIVE void js_fetch_success_callback(u32 request_id, const char* content) {
-    FL_WARN("Fetch success callback received for request " << request_id << ", content length: " << strlen(content));
+    FL_WARN_F("Fetch success callback received for request %s, content length: %s", request_id, strlen(content));
     
     auto callback_opt = getCallbackManager().takeCallback(request_id);
     if (callback_opt) {
@@ -106,7 +106,7 @@ extern "C" EMSCRIPTEN_KEEPALIVE void js_fetch_success_callback(u32 request_id, c
 
         (*callback_opt)(response);
     } else {
-        FL_WARN("Warning: No pending callback found for fetch success request " << request_id);
+        FL_WARN_F("Warning: No pending callback found for fetch success request %s", request_id);
     }
     // Wake any pthread parked inside fl::platforms::await().
     fl::platforms::ICoroutineRuntime::instance().wakeWaiters();
@@ -114,7 +114,7 @@ extern "C" EMSCRIPTEN_KEEPALIVE void js_fetch_success_callback(u32 request_id, c
 
 // C++ error callback function that JavaScript can call when fetch fails
 extern "C" EMSCRIPTEN_KEEPALIVE void js_fetch_error_callback(u32 request_id, const char* error_message) {
-    FL_WARN("Fetch error callback received for request " << request_id << ": " << error_message);
+    FL_WARN_F("Fetch error callback received for request %s: %s", request_id, error_message);
     
     auto callback_opt = getCallbackManager().takeCallback(request_id);
     if (callback_opt) {
@@ -126,14 +126,14 @@ extern "C" EMSCRIPTEN_KEEPALIVE void js_fetch_error_callback(u32 request_id, con
 
         (*callback_opt)(response);
     } else {
-        FL_WARN("Warning: No pending callback found for fetch error request " << request_id);
+        FL_WARN_F("Warning: No pending callback found for fetch error request %s", request_id);
     }
     // See note in js_fetch_success_callback above.
     fl::platforms::ICoroutineRuntime::instance().wakeWaiters();
 }
 
 void WasmFetchRequest::response(const FetchResponseCallback& callback) {
-    FL_WARN("Starting JavaScript-based fetch request to: " << mUrl);
+    FL_WARN_F("Starting JavaScript-based fetch request to: %s", mUrl);
     
     // Generate unique request ID for this request
     u32 request_id = getCallbackManager().generateRequestId();
@@ -141,7 +141,7 @@ void WasmFetchRequest::response(const FetchResponseCallback& callback) {
     // Store the callback for when JavaScript calls back (using move semantics)
     getCallbackManager().storeCallback(request_id, FetchResponseCallback(callback));
     
-    FL_WARN("Stored callback for request ID: " << request_id);
+    FL_WARN_F("Stored callback for request ID: %s", request_id);
     
     // Start the JavaScript fetch (non-blocking) with request ID
     js_fetch_async(request_id, mUrl.c_str());

--- a/src/platforms/wasm/spi_channel_wasm.h
+++ b/src/platforms/wasm/spi_channel_wasm.h
@@ -53,17 +53,17 @@ protected:
     virtual void showPixels(PixelController<RGB_ORDER>& pixels) override
     {
         if (!mDriver) {
-            FL_WARN_EVERY(100, "No Engine");
+            FL_WARN_F_EVERY(100, "No Engine");
             return;
         }
         // Wait for previous transmission to complete and release buffer
         // This prevents race conditions when show() is called faster than hardware can transmit
         u32 startTime = fl::millis();
         if (mChannelData->isInUse()) {
-            FL_WARN_EVERY(100, "ClocklessSPI(wasm): driver should have finished transmitting by now - waiting");
+            FL_WARN_F_EVERY(100, "ClocklessSPI(wasm): driver should have finished transmitting by now - waiting");
             bool finished = mDriver->waitForReady();
             if (!finished) {
-                FL_ERROR("ClocklessSPI(wasm): Engine still busy after " << fl::millis() - startTime << "ms");
+                FL_ERROR_F("ClocklessSPI(wasm): Engine still busy after %sms", fl::millis() - startTime);
                 return;
             }
         }

--- a/src/platforms/wasm/timer.cpp.hpp
+++ b/src/platforms/wasm/timer.cpp.hpp
@@ -71,7 +71,7 @@ double get_time_since_epoch() {
     
     // Ensure we return a reasonable positive elapsed time
     if (elapsed < 0 || elapsed == 0xffffffff) {
-        FL_WARN("WARNING: Negative elapsed time detected, resetting start time");
+        FL_WARN_F("WARNING: Negative elapsed time detected, resetting start time");
         gStartTime = now;
         elapsed = 0;
     }

--- a/src/platforms/wasm/ui.cpp.hpp
+++ b/src/platforms/wasm/ui.cpp.hpp
@@ -65,8 +65,8 @@ static bool& getUiSystemInitialized() {
 
 // Add a periodic check function that can be called from JavaScript
 extern "C" void checkUpdateEngineState() {
-    FL_WARN("*** ASYNC PERIODIC CHECK: g_updateEngineState=" << (getUpdateEngineState() ? "VALID" : "nullptr"));
-    FL_WARN("*** ASYNC PERIODIC CHECK: g_uiSystemInitialized=" << (getUiSystemInitialized() ? "true" : "false"));
+    FL_WARN_F("*** ASYNC PERIODIC CHECK: g_updateEngineState=%s", (getUpdateEngineState() ? "VALID" : "nullptr"));
+    FL_WARN_F("*** ASYNC PERIODIC CHECK: g_uiSystemInitialized=%s", (getUiSystemInitialized() ? "true" : "false"));
 }
 
 /**
@@ -81,7 +81,7 @@ void jsUpdateUiComponents(const char* jsonStr) {
     
     // Only initialize if not already initialized - don't force reinitialization
     if (!getUiSystemInitialized()) {
-        FL_WARN("*** ASYNC WASM: UI system not initialized, initializing for first time");
+        FL_WARN_F("*** ASYNC WASM: UI system not initialized, initializing for first time");
         ensureWasmUiSystemInitialized();
     }
     
@@ -95,25 +95,25 @@ void jsUpdateUiComponents(const char* jsonStr) {
             getUpdateEngineState()(jsonStr);
             //FL_WARN("*** ASYNC WASM BACKEND CALL COMPLETED SUCCESSFULLY");
         } else {
-            FL_WARN("*** ASYNC WASM BACKEND CALL FAILED: updateEngineState is null");
+            FL_WARN_F("*** ASYNC WASM BACKEND CALL FAILED: updateEngineState is null");
             return; // Early return on error
         }
         
     } else {
-        FL_WARN("*** ASYNC WASM ERROR: No driver state updater available, attempting emergency reinitialization...");
+        FL_WARN_F("*** ASYNC WASM ERROR: No driver state updater available, attempting emergency reinitialization...");
         
         // Try to reinitialize as a recovery mechanism
         getUiSystemInitialized() = false;  // Force reinitialization
         ensureWasmUiSystemInitialized();
         
-        FL_WARN("*** ASYNC AFTER EMERGENCY REINIT: g_updateEngineState=" << (getUpdateEngineState() ? "VALID" : "nullptr"));
+        FL_WARN_F("*** ASYNC AFTER EMERGENCY REINIT: g_updateEngineState=%s", (getUpdateEngineState() ? "VALID" : "nullptr"));
         
         if (getUpdateEngineState()) {
-            FL_WARN("*** ASYNC EMERGENCY REINIT SUCCESSFUL - retrying JSON processing");
+            FL_WARN_F("*** ASYNC EMERGENCY REINIT SUCCESSFUL - retrying JSON processing");
             getUpdateEngineState()(jsonStr);
-            FL_WARN("*** ASYNC EMERGENCY RETRY COMPLETED SUCCESSFULLY");
+            FL_WARN_F("*** ASYNC EMERGENCY RETRY COMPLETED SUCCESSFULLY");
         } else {
-            FL_WARN("*** ASYNC EMERGENCY REINIT FAILED - g_updateEngineState still nullptr");
+            FL_WARN_F("*** ASYNC EMERGENCY REINIT FAILED - g_updateEngineState still nullptr");
             return; // Early return on failure
         }
     }
@@ -129,18 +129,18 @@ void ensureWasmUiSystemInitialized() {
     
     // Return early if already initialized - CRITICAL FIX
     if (getUiSystemInitialized()) {
-        FL_WARN("*** ensureWasmUiSystemInitialized ASYNC: Already initialized, returning early");
+        FL_WARN_F("*** ensureWasmUiSystemInitialized ASYNC: Already initialized, returning early");
         return;
     }
     
     if (!getUiSystemInitialized() || !getUpdateEngineState()) {
-        FL_WARN("*** ASYNC WASM INITIALIZING UI SYSTEM ***");
+        FL_WARN_F("*** ASYNC WASM INITIALIZING UI SYSTEM ***");
         
         // Create UI update handler that posts message to main thread
         // In PROXY_TO_PTHREAD mode, C++ runs in worker thread, UI manager runs on main thread
         JsonUiUpdateOutput updateJsHandler = [](const char* jsonStr) {
             if (!jsonStr) {
-                FL_WARN("*** UI UPDATE HANDLER ERROR: Received null jsonStr");
+                FL_WARN_F("*** UI UPDATE HANDLER ERROR: Received null jsonStr");
                 return; // Early return on error
             }
 
@@ -152,14 +152,14 @@ void ensureWasmUiSystemInitialized() {
         // Initialize with error checking via early return
         auto tempResult = setJsonUiHandlers(updateJsHandler);
         if (!tempResult) {
-            FL_WARN("*** ASYNC WASM UI SYSTEM INITIALIZATION FAILED: setJsonUiHandlers returned null");
+            FL_WARN_F("*** ASYNC WASM UI SYSTEM INITIALIZATION FAILED: setJsonUiHandlers returned null");
             return; // Early return on failure
         }
         
         getUpdateEngineState() = tempResult;
         getUiSystemInitialized() = true;
         
-        FL_WARN("*** ASYNC WASM UI SYSTEM INITIALIZATION COMPLETED ***");
+        FL_WARN_F("*** ASYNC WASM UI SYSTEM INITIALIZATION COMPLETED ***");
     }
 }
 
@@ -169,7 +169,7 @@ void ensureWasmUiSystemInitialized() {
  */
 __attribute__((constructor))
 void on_startup_initialize_wasm_ui() {
-    FL_WARN("*** ASYNC WASM UI STARTUP INITIALIZER CALLED ***");
+    FL_WARN_F("*** ASYNC WASM UI STARTUP INITIALIZER CALLED ***");
     ensureWasmUiSystemInitialized();
 }
 
@@ -184,7 +184,7 @@ extern "C" {
     EMSCRIPTEN_KEEPALIVE void jsUpdateUiComponents(const char* jsonStr) {
         // Input validation with early return
         if (!jsonStr) {
-            FL_WARN("*** ASYNC C BINDING: Received nullptr jsonStr");
+            FL_WARN_F("*** ASYNC C BINDING: Received nullptr jsonStr");
             return;
         }
         

--- a/src/platforms/wasm/ui_audio_wasm.cpp.hpp
+++ b/src/platforms/wasm/ui_audio_wasm.cpp.hpp
@@ -28,14 +28,14 @@ static void initWasmAudio(const char* name, WasmAudioInput*& wasmInput,
             wasmInputOwner->start();
             wasmInput = wasm_get_audio_input();  // Get the created instance
             ownsInput = true;
-            FL_WARN("WasmAudioImpl: Created and started WasmAudioInput for '" << name << "'");
+            FL_WARN_F("WasmAudioImpl: Created and started WasmAudioInput for '%s'", name);
         } else {
-            FL_WARN("WasmAudioImpl: Failed to create WasmAudioInput: " << error.c_str());
+            FL_WARN_F("WasmAudioImpl: Failed to create WasmAudioInput: %s", error.c_str());
         }
     } else {
         // Ensure the existing input is started
         wasmInput->start();
-        FL_WARN("WasmAudioImpl: Using existing WasmAudioInput for '" << name << "'");
+        FL_WARN_F("WasmAudioImpl: Using existing WasmAudioInput for '%s'", name);
     }
 }
 

--- a/src/third_party/cq_kernel/kiss_fftr.cpp.hpp
+++ b/src/third_party/cq_kernel/kiss_fftr.cpp.hpp
@@ -40,7 +40,7 @@ kiss_fftr_cfg kiss_fftr_alloc(int nfft,int inverse_fft,void * mem,size_t * lenme
 
     if (nfft & 1) {
         //fprintf(stderr,"Real FFT optimization must be even.\n");
-        FL_WARN("Real FFT optimization must be even.");
+        FL_WARN_F("Real FFT optimization must be even.");
         return NULL;
     }
     nfft >>= 1;
@@ -87,7 +87,7 @@ void kiss_fftr(kiss_fftr_cfg st,const kiss_fft_scalar *timedata,kiss_fft_cpx *fr
 
     if ( st->substate->inverse) {
         //fprintf(stderr,"kiss fft usage error: improper alloc\n");
-        FL_WARN("kiss fft usage error: improper alloc");
+        FL_WARN_F("kiss fft usage error: improper alloc");
         fl::exit(1);
     }
 
@@ -143,7 +143,7 @@ void kiss_fftri(kiss_fftr_cfg st,const kiss_fft_cpx *freqdata,kiss_fft_scalar *t
 
     if (st->substate->inverse == 0) {
         //fprintf (stderr, "kiss fft usage error: improper alloc\n");
-        FL_WARN("kiss fft usage error: improper alloc");
+        FL_WARN_F("kiss fft usage error: improper alloc");
         fl::exit(1);
     }
 

--- a/src/third_party/object_fled/src/OjectFLED.cpp.hpp
+++ b/src/third_party/object_fled/src/OjectFLED.cpp.hpp
@@ -148,29 +148,29 @@ void ObjectFLED::begin(void) {
 		// Validate pin using validation helper
 		auto validation = objectfled::validate_teensy4_pin(pin);
 		if (!validation.valid) {
-			FL_WARN("================================================================================");
-			FL_WARN("FASTLED ERROR: Pin " << (int)pin << " is INVALID and has been disabled");
-			FL_WARN(validation.error_message);
-			FL_WARN("================================================================================");
+			FL_WARN_F("================================================================================");
+			FL_WARN_F("FASTLED ERROR: Pin %s is INVALID and has been disabled", (int)pin);
+			FL_WARN_F("%s", validation.error_message);
+			FL_WARN_F("================================================================================");
 			continue;
 		}
 
 		// Check for warnings (pin is valid but may have issues)
 		if (validation.error_message != nullptr) {
-			FL_WARN("================================================================================");
-			FL_WARN("FASTLED WARNING: Pin " << (int)pin << " may have issues");
-			FL_WARN(validation.error_message);
-			FL_WARN("================================================================================");
+			FL_WARN_F("================================================================================");
+			FL_WARN_F("FASTLED WARNING: Pin %s may have issues", (int)pin);
+			FL_WARN_F("%s", validation.error_message);
+			FL_WARN_F("================================================================================");
 		}
 
 		uint8_t bit = digitalPinToBit(pin);		// pin's bit index in word port DR
 		// which GPIO R controls this pin: 0-3 map to GPIO6-9 then map to DMA compat GPIO1-4
 		uint8_t offset = ((uint32_t)portOutputRegister(pin) - (uint32_t)&GPIO6_DR) >> 14;
 		if (offset > 3) {
-			FL_WARN("================================================================================");
-			FL_WARN("FASTLED ERROR: Pin " << (int)pin << " does not map to GPIO6-9 (offset=" << (int)offset << ")");
-			FL_WARN("This pin may be a ground/power/read-only pin - strip disabled");
-			FL_WARN("================================================================================");
+			FL_WARN_F("================================================================================");
+			FL_WARN_F("FASTLED ERROR: Pin %s does not map to GPIO6-9 (offset=%s)", (int)pin, (int)offset);
+			FL_WARN_F("This pin may be a ground/power/read-only pin - strip disabled");
+			FL_WARN_F("================================================================================");
 			continue;
 		}
 
@@ -190,19 +190,19 @@ void ObjectFLED::begin(void) {
 
 	// Check if any valid pins were configured
 	if (validPinCount == 0) {
-		FL_WARN("================================================================================");
-		FL_WARN("FASTLED CRITICAL ERROR: No valid pins configured!");
-		FL_WARN("All " << (int)numpinsLocal << " pins failed validation.");
-		FL_WARN("ObjectFLED driver is disabled - no LEDs will be updated.");
-		FL_WARN("================================================================================");
+		FL_WARN_F("================================================================================");
+		FL_WARN_F("FASTLED CRITICAL ERROR: No valid pins configured!");
+		FL_WARN_F("All %s pins failed validation.", (int)numpinsLocal);
+		FL_WARN_F("ObjectFLED driver is disabled - no LEDs will be updated.");
+		FL_WARN_F("================================================================================");
 		return;
 	}
 
 	if (validPinCount < numpinsLocal) {
-		FL_WARN("================================================================================");
-		FL_WARN("FASTLED WARNING: Only " << (int)validPinCount << " of " << (int)numpinsLocal << " pins are valid");
-		FL_WARN("Strips on invalid pins will not function.");
-		FL_WARN("================================================================================");
+		FL_WARN_F("================================================================================");
+		FL_WARN_F("FASTLED WARNING: Only %s of %s pins are valid", (int)validPinCount, (int)numpinsLocal);
+		FL_WARN_F("Strips on invalid pins will not function.");
+		FL_WARN_F("================================================================================");
 	}
 
 	//stash context for multi-show

--- a/tests/fl/math/fixed_point.cpp
+++ b/tests/fl/math/fixed_point.cpp
@@ -1,3 +1,4 @@
+// allow-include-after-namespace: helper headers intentionally instantiate inside this test's anonymous namespace.
 // ============================================================================
 // Fixed-Point Type Tests - Architecture
 // ============================================================================
@@ -117,8 +118,8 @@ namespace { // Anonymous namespace for fixed_point tests
 template <typename T>
 using raw_t = decltype(T().raw());
 
-#include "fixed_point_bounds.h"
-#include "fixed_point_test_helpers.h"
+#include "tests/fl/math/fixed_point_bounds.h"
+#include "tests/fl/math/fixed_point_test_helpers.h"
 
 // --- Helper functions ---
 


### PR DESCRIPTION
## Summary
- migrate legacy stream-style FastLED logging calls to printf-style `FL_*_F` macros
- add `FL_*_F` support plus an out-of-line `format_arg` implementation for `fl::string` and `fl::string_view`
- add a migration helper and lint checker to prevent legacy stream-style logging from returning
- keep split test files lint-clean by allowing shard suffixes to map back to umbrella headers

## Verification
- `bash lint`
- `bash lint --cpp`
- `bash test --cpp`
- `uv run python ci/lint_cpp/legacy_log_macro_checker.py`
- `git diff --check`