### PR TITLE
build(tests): drop test_pch depends:[fastled_lib] (#3129 A11)

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -35,7 +35,6 @@ test_pch = custom_target('test_pch',
   input: 'test_pch.h',
   output: 'test_pch.h.pch',      # Only PCH is an output; .d file is depfile only
   depfile: 'test_pch.h.d',
-  depends: [fastled_lib],         # Ensure library is built first (tests link against it)
   command: [
     uv, 'run', 'python',
     meson.project_source_root() / 'ci/compile_pch.py',


### PR DESCRIPTION
## Summary

Removes the misplaced `depends: [fastled_lib]` edge from the `test_pch` custom_target in `tests/meson.build`.

## Why this is safe

- The PCH input is `test_pch.h`, which `#includes FastLED.h` directly.
- The PCH compile already uses `-MD -MF @DEPFILE@` to emit a gcc-style depfile, so the build graph tracks every header that `test_pch.h` pulls in.
- `fastled_lib` is the **compiled DLL**, not a header. The PCH does not link, so a wall-clock dep on the library was never required for correctness.

## Why this matters

The spurious edge serialized ~241 test DLLs behind every relink of `fastled.dll`. Even though `restat=1` would let the build graph skip downstream rebuilds when the archive is content-equal, the wall-clock dependency was forcing the graph to wait for the link before evaluating PCH staleness.

Removing the edge lets the build parallelize PCH and library work freely.

**1 file changed, 1 deletion(-)**.

Part of #3129 (Section A11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal build system optimization to adjust dependency ordering for test compilation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->