### PR TITLE
fix(ci/fingerprint): include .c source files in test/example fingerprints (#3129 A13)

### DIFF
--- a/ci/util/test_types.py
+++ b/ci/util/test_types.py
@@ -383,7 +383,7 @@ def _hash_directory(start_directory: Path, glob: str) -> str:
 
 
 def fingerprint_code_base(
-    start_directory: Path, glob: str = "**/*.h,**/*.cpp,**/*.hpp"
+    start_directory: Path, glob: str = "**/*.h,**/*.cpp,**/*.hpp,**/*.c"
 ) -> FingerprintResult:
     """
     Create a fingerprint of the code base by hashing file contents.
@@ -452,13 +452,15 @@ def calculate_cpp_test_fingerprint(
     # Process src/ directory (C++ source files)
     src_dir = cwd / "src"
     if src_dir.exists():
-        src_result = fingerprint_code_base(src_dir, "**/*.h,**/*.cpp,**/*.hpp")
+        src_result = fingerprint_code_base(src_dir, "**/*.h,**/*.cpp,**/*.hpp,**/*.c")
         hasher.update(f"src:{src_result.hash}".encode("utf-8"))
 
     # Process tests/ directory (test files)
     tests_dir = cwd / "tests"
     if tests_dir.exists():
-        tests_result = fingerprint_code_base(tests_dir, "**/*.h,**/*.cpp,**/*.hpp")
+        tests_result = fingerprint_code_base(
+            tests_dir, "**/*.h,**/*.cpp,**/*.hpp,**/*.c"
+        )
         hasher.update(f"tests:{tests_result.hash}".encode("utf-8"))
 
     # Include meson.build files that affect build configuration
@@ -516,14 +518,14 @@ def calculate_examples_fingerprint(
     # Process src/ directory (affects example compilation)
     src_dir = cwd / "src"
     if src_dir.exists():
-        src_result = fingerprint_code_base(src_dir, "**/*.h,**/*.cpp,**/*.hpp")
+        src_result = fingerprint_code_base(src_dir, "**/*.h,**/*.cpp,**/*.hpp,**/*.c")
         hasher.update(f"src:{src_result.hash}".encode("utf-8"))
 
     # Process examples/ directory
     examples_dir = cwd / "examples"
     if examples_dir.exists():
         examples_result = fingerprint_code_base(
-            examples_dir, "**/*.ino,**/*.h,**/*.cpp,**/*.hpp"
+            examples_dir, "**/*.ino,**/*.h,**/*.cpp,**/*.hpp,**/*.c"
         )
         hasher.update(f"examples:{examples_result.hash}".encode("utf-8"))
 
@@ -644,14 +646,15 @@ def calculate_wasm_fingerprint() -> FingerprintResult:
     # Process src/ directory (affects WASM compilation)
     src_dir = cwd / "src"
     if src_dir.exists():
-        src_result = fingerprint_code_base(src_dir, "**/*.h,**/*.cpp,**/*.hpp")
+        src_result = fingerprint_code_base(src_dir, "**/*.h,**/*.cpp,**/*.hpp,**/*.c")
         hasher.update(f"src:{src_result.hash}".encode("utf-8"))
 
     # Process examples/wasm directory (the default WASM test example)
     wasm_example_dir = cwd / "examples" / "wasm"
     if wasm_example_dir.exists():
         wasm_result = fingerprint_code_base(
-            wasm_example_dir, "**/*.ino,**/*.h,**/*.cpp,**/*.hpp,**/*.js,**/*.html"
+            wasm_example_dir,
+            "**/*.ino,**/*.h,**/*.cpp,**/*.hpp,**/*.c,**/*.js,**/*.html",
         )
         hasher.update(f"wasm_example:{wasm_result.hash}".encode("utf-8"))
 


### PR DESCRIPTION
## Summary

`ci/util/unified_test_cache.py` correctly globs `**/*.c` alongside `h`/`cpp`/`hpp` for SRC_CODE_INCLUDE, CPP_TEST_INCLUDE, and EXAMPLES_INCLUDE — but the `FingerprintManager` in `ci/util/test_types.py` was missing `.c`.

### Symptom

Editing a `.c` file under `src/` did **not** change the `cpp_test`, `examples`, or `wasm` fingerprint, so the test layer could incorrectly skip a run when a `.c` file was the only change. Pure FastLED-side bug, no upstream blocker.

## What changes

Six glob strings in `ci/util/test_types.py` now include `**/*.c`:

| Caller | Glob (before) → (after) |
| --- | --- |
| `calculate_cpp_test_fingerprint()` src/ | `**/*.h,**/*.cpp,**/*.hpp` → `+,**/*.c` |
| `calculate_cpp_test_fingerprint()` tests/ | same |
| `calculate_examples_fingerprint()` src/ | same |
| `calculate_examples_fingerprint()` examples/ | `**/*.ino,**/*.h,**/*.cpp,**/*.hpp` → `+,**/*.c` |
| `calculate_wasm_examples_fingerprint()` src/ | same as cpp_test src/ |
| `calculate_wasm_examples_fingerprint()` examples/wasm | `**/*.ino,**/*.h,**/*.cpp,**/*.hpp,**/*.js,**/*.html` → adds `,**/*.c` |
| `fingerprint_code_base()` default arg | same as cpp_test src/ |

**1 file changed, 10 insertions(+), 7 deletions(-)**

The audit at #3129 A13 cited 4 specific glob strings (lines 455/461/519/527). I also patched the default arg (line 386) and the two WASM globs (lines 649/656) to fix the same bug consistently across the file.

## Validation

- ✅ `bash lint` clean
- ✅ Matches the authoritative glob list in `ci/util/unified_test_cache.py`

Part of #3129 (Section A13).

🤖 Generated with [Claude Code](https://claude.com/claude-code)