### PR TITLE
refactor(ci): remove no-op clear_zccache_stats() and its caller (#3129 A8)

### DIFF
--- a/ci/util/test_runner.py
+++ b/ci/util/test_runner.py
@@ -1518,10 +1518,10 @@ def runner(
         if active_flags:
             ts_print(f"Active flags: {', '.join(active_flags)}")
 
-    # Clear zccache stats at start to show only metrics from this build
-    from ci.util.zccache_config import clear_zccache_stats
-
-    clear_zccache_stats()
+    # Per-build zccache metrics are provided via the session mechanism in
+    # ci/meson/runner_helpers.py::_start_zccache_session (sets ZCCACHE_SESSION_ID),
+    # then surfaced by show_zccache_stats() at teardown. zccache 1.12.7 has no
+    # global "zero-stats" command, so there is nothing to clear at start.
 
     # Determine test categories first to check if we should use meson
     test_categories = determine_test_categories(args)

--- a/ci/util/zccache_config.py
+++ b/ci/util/zccache_config.py
@@ -63,15 +63,6 @@ def get_zccache_wrapper_path() -> str | None:
     return None
 
 
-def clear_zccache_stats() -> None:
-    """Clear zccache statistics (no-op).
-
-    zccache 1.0.3 does not support --zero-stats.
-    Stats are per-daemon-uptime and reset automatically on daemon restart.
-    """
-    pass
-
-
 def show_zccache_stats() -> None:
     """Display zccache statistics if zccache is available."""
     zccache_path = get_zccache_wrapper_path()


### PR DESCRIPTION
## Summary

The `clear_zccache_stats()` function in `ci/util/zccache_config.py` was a no-op with a docstring citing zccache 1.0.3:

\`\`\`python
def clear_zccache_stats() -> None:
    """Clear zccache statistics (no-op).

    zccache 1.0.3 does not support --zero-stats.
    Stats are per-daemon-uptime and reset automatically on daemon restart.
    """
    pass
\`\`\`

The current floor is **1.12.7**, which still has no global "zero-stats" command — verified against \`zccache --help\` (only \`--clear\` (artifact cache), \`status\`, \`session-start\`, \`session-end\`, \`session-stats\`).

## Why this is the right fix

Per-build metrics ARE accurate today via the session mechanism:

- `ci/meson/runner_helpers.py::_start_zccache_session` calls `zccache session-start --stats --log <path>` and sets `ZCCACHE_SESSION_ID` in `os.environ`
- All compiler invocations through zccache then attribute their work to that session
- `show_zccache_stats()` at teardown queries `session-stats $ZCCACHE_SESSION_ID` and ends the session

So the no-op function and its no-op call site are both dead weight. The right replacement is a comment pointing at the actual mechanism.

## What changes

| File | Change |
| --- | --- |
| `ci/util/zccache_config.py` | Delete `clear_zccache_stats()` (no-op) |
| `ci/util/test_runner.py` | Delete the import + call; replace with a comment pointing at the session mechanism |

**2 files changed, 4 insertions(+), 13 deletions(-)** — net 9-line code reduction.

Part of #3129 (Section A8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unused cache clearing code and updated internal testing infrastructure comments to reflect current cache metrics handling via session mechanism.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->