### PR TITLE
ci(probe): drop Windows zccache stop step (#3129 A7)

### DIFF
--- a/.github/workflows/template_unit_test.yml
+++ b/.github/workflows/template_unit_test.yml
@@ -56,19 +56,6 @@ jobs:
         run: |
           uv run python ci/lint_cpp/no_using_namespace_fl_in_headers.py
 
-      - name: Reset zccache daemon (Windows flake mitigation, FastLED#2805)
-        if: runner.os == 'Windows'
-        run: |
-          # The zccache daemon's named-pipe IPC drops mid-link under heavy
-          # parallel link load on Windows hosted runners — the daemon's own
-          # diagnostic emits 'lost connection to daemon ... try `zccache stop`'.
-          # Start each Windows job with a known-clean daemon state so the
-          # first wave of test-DLL links doesn't race a stale/partially-
-          # initialized daemon. `|| true` because there may be no daemon to
-          # stop on a fresh runner — that's the desired end state anyway.
-          zccache stop || true
-        shell: bash
-
       - name: Run All Unit Tests
         id: run_tests
         run: |


### PR DESCRIPTION
## Summary

**Probe** PR: removes the \`zccache stop || true\` step at the top of every Windows unit-test job. The step worked around the named-pipe IPC daemon flake from FastLED#2805 (upstream tracked as zccache#669/#674/#724/#726, mostly fixed in zccache 1.11.15–1.12.3). Our pinned floor is **1.12.7**.

## How to read CI on this branch

This is a probe-and-revert candidate. If CI stays green across the Windows unit-test matrix for ~1 week, the workaround stays gone; if the daemon flake re-surfaces on any Windows job (look for \`zccache[err][R]: lost connection to daemon\`), revert.

## Risk

- **Low**: the upstream fixes are in our floor.
- **Mitigation**: any failed Windows run becomes the revert signal.

**1 file changed, 13 deletions(-)**.

Part of #3129 (Section A7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added C++ header namespace validation to the unit test workflow.
  * Removed a Windows-specific build cache workaround from the CI pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->