### PR TITLE
ci(probe): drop ZCCACHE_PROBE_BYPASS=1 setdefault (#3129 A9)

### DIFF
--- a/ci/meson/runner_helpers.py
+++ b/ci/meson/runner_helpers.py
@@ -374,13 +374,9 @@ def _start_zccache_session(build_dir: Path) -> None:
     if "ZCCACHE_LINK_DEPLOY_CMD" not in os.environ:
         os.environ["ZCCACHE_LINK_DEPLOY_CMD"] = "clang-tool-chain-libdeploy"
     os.environ.setdefault("ZCCACHE_STRICT_PATHS", "absolute")
-    # Opt in to zccache's CLI-side probe-bypass fast-path for meson
-    # configure-phase try-compiles (zackees/zccache#625, #633, #636 — bench
-    # in #636 shows 7-10s saved per configure run). Not a disable: per-call
-    # routing, only sub-4 KiB single-source no-PCH no-@rsp invocations
-    # bypass; production TUs continue to use the cache. setdefault keeps any
-    # user override intact; older zccache without this env var ignores it.
-    os.environ.setdefault("ZCCACHE_PROBE_BYPASS", "1")
+    # ZCCACHE_PROBE_BYPASS=1 setdefault removed as a probe per #3129 A9
+    # (the CLI-side probe-bypass fast-path was internalised in zccache
+    # 1.12.x). If configure-phase try-compile times regress, revert.
 
     zccache_bin = _find_zccache_binary()
     if not zccache_bin:


### PR DESCRIPTION
## Summary

**Probe** PR: removes the `os.environ.setdefault("ZCCACHE_PROBE_BYPASS", "1")` line in `ci/meson/runner_helpers.py::_start_zccache_session`. The setdefault was added in the zccache#625/#633/#636 era to opt in to a CLI-side probe-bypass fast-path for configure-phase try-compiles (claimed 7–10s saved per configure run).

## Hypothesis

zccache 1.12.7 routes per-call internally — the env var should now be redundant.

## How to read CI on this branch

- **Watch:** total `bash test --cpp` wall-clock vs. master for a few days. If the configure phase regresses by >5s consistently, revert.
- **Green for a week** → keep the change.

**1 file changed, 3 insertions(+), 7 deletions(-)**.

Part of #3129 (Section A9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build system cache configuration in CI runner helpers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->