### PR TITLE
refactor(ci): drop full artifact wipe on zccache version delta (#3129 A3)

### DIFF
--- a/ci/meson/build_config.py
+++ b/ci/meson/build_config.py
@@ -295,7 +295,11 @@ def setup_meson_build(
                 force_reconfigure = True
                 force_reconfigure_reason = zccache_version_reason
                 skip_meson_setup = False
-                cleanup_build_artifacts(build_dir, "zccache version changed")
+                # NOTE (#3129 A3): no longer wipes build artifacts on zccache
+                # version delta. zccache is a cache layer, not a codegen layer
+                # — a version bump that doesn't change the cache key just
+                # forces a miss-and-recompile, which is what the reconfigure
+                # is for. Compiler-version deltas (line 275) still wipe.
 
         # If compiler/zccache version forced reconfigure but we hadn't built a cmd yet
         if force_reconfigure and cmd is None:


### PR DESCRIPTION
## Summary

`ci/meson/build_config.py` calls `cleanup_build_artifacts(...)` on every detected zccache version change. That is overkill: zccache is a **cache layer**, not a codegen layer. A version bump that does not change the cache key just forces a miss-and-recompile — which is exactly what the adjacent `force_reconfigure = True` + meson reconfigure already does.

## What this change keeps

- `force_reconfigure = True`
- `skip_meson_setup = False`
- the reconfigure-reason logging
- the **compiler-version** wipe at line 275 (clang codegen CAN change between versions — that wipe is defensible)

## What this change drops

- the `cleanup_build_artifacts(build_dir, "zccache version changed")` call

## Effect

A routine zccache patch-level bump (e.g. via `uv sync` pulling a new `>=1.12.7` release) no longer nukes every `.obj/.a/.exe/.pch/.lib/.dll/.so/.dylib` and forces a full rebuild. Meson reconfigure + ninja's normal staleness graph does the right thing — and any compile units whose cache keys actually changed will miss in zccache and recompile naturally.

**1 file changed, 5 insertions(+), 1 deletion(-)** (net +4 lines of explanatory comment).

## Validation

- ✅ `bash lint` clean
- Behavioural verification belongs in the next zccache patch-level bump that hits master — at which point the build should reconfigure cleanly without a full artifact wipe.

Part of #3129 (Section A3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized Meson build configuration to preserve build artifacts when zccache version changes instead of deleting them. The cache layer now automatically manages version transitions, reducing unnecessary rebuilds and improving build efficiency while maintaining correctness across different versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->