### PR TITLE
ci(probe): drop runtime-DLL PATH injection (#3129 A6)

### DIFF
--- a/ci/meson/native/meson.build
+++ b/ci/meson/native/meson.build
@@ -503,34 +503,19 @@ fastled_lib = shared_library('fastled',
 fastled_lib_dir = meson.current_build_dir()
 
 # ============================================================================
-# CLANG-TOOL-CHAIN RUNTIME DLL PATHS (Windows only)
+# CLANG-TOOL-CHAIN RUNTIME DLL PATHS — removed as probe (#3129 A6)
 # ============================================================================
-# When zccache caches link results, ctc-clang++'s post-link DLL deployment
-# is skipped (the cached binary is written directly without invoking the
-# compiler wrapper). This means ASan/MinGW runtime DLLs may not be deployed
-# alongside the output binary. We query clang-tool-chain for its runtime
-# directories and add them to the test PATH so DLLs are always discoverable.
+# This block used to populate `runtime_dll_paths` by invoking
+# `ci/meson/get_runtime_dll_paths.py` and prepending its output to the test
+# environment's PATH in three call sites (tests/meson.build x2, examples/
+# meson.build x1). The upstream-blessed replacement is the
+# `ZCCACHE_LINK_DEPLOY_CMD=clang-tool-chain-libdeploy` env var (set at
+# ci/meson/runner_helpers.py:374-375 — zccache#33). Per #3129 A6 the local
+# PATH injection is belt-and-suspenders that may now be redundant; this
+# branch is the probe. The script itself
+# (ci/meson/get_runtime_dll_paths.py) is left in place in case revert is
+# needed.
 runtime_dll_paths = []
-if is_windows
-  # Use uv_prog to run the script via the project venv, ensuring clang_tool_chain
-  # is importable. A bare find_program('python3') may resolve to a system Python
-  # that lacks clang_tool_chain, silently returning no paths and causing
-  # 0xc0000135 (STATUS_DLL_NOT_FOUND) at runtime in debug mode.
-  _rtdll_script = meson.project_source_root() / 'ci' / 'meson' / 'get_runtime_dll_paths.py'
-  _rtdll_result = run_command(uv_prog, 'run', 'python', _rtdll_script, check: false)
-  if _rtdll_result.returncode() == 0
-    foreach _line : _rtdll_result.stdout().strip().split('\n')
-      if _line != ''
-        runtime_dll_paths += [_line]
-      endif
-    endforeach
-  else
-    warning('get_runtime_dll_paths.py failed (rc=' + _rtdll_result.returncode().to_string() + '): ' + _rtdll_result.stderr().strip())
-  endif
-  if runtime_dll_paths.length() > 0
-    message('clang-tool-chain runtime DLL paths: ' + ', '.join(runtime_dll_paths))
-  endif
-endif
 
 # ============================================================================
 # FASTLED PRECOMPILED HEADER (shared by tests and examples)

--- a/examples/meson.build
+++ b/examples/meson.build
@@ -310,11 +310,9 @@ foreach example_name : example_paths.keys()
     # Environment ensures fastled.dll and runtime DLLs (ASan, MinGW) are discoverable
     example_test_env = environment()
     example_test_env.prepend('PATH', fastled_lib_dir)
-    # Add clang-tool-chain runtime dirs so ASan/MinGW DLLs are found even when
-    # zccache caches the link and skips ctc-clang++'s post-link deployment.
-    foreach _rtdll_dir : runtime_dll_paths
-      example_test_env.prepend('PATH', _rtdll_dir)
-    endforeach
+    # Runtime-DLL PATH injection removed as probe (#3129 A6) —
+    # ZCCACHE_LINK_DEPLOY_CMD=clang-tool-chain-libdeploy is the
+    # upstream-blessed replacement (zccache#33).
     test('example-' + example_name, example_runner_exe,
         args: [example_dll.full_path()],
         suite: 'examples',

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -153,11 +153,11 @@ all_test_runners = []
 # Environment for test execution - ensure fastled.dll and runtime DLLs are discoverable
 test_env = environment()
 test_env.prepend('PATH', fastled_lib_dir)
-# Add clang-tool-chain runtime dirs so ASan/MinGW DLLs are found even when
-# zccache caches the link and skips ctc-clang++'s post-link deployment.
-foreach _rtdll_dir : runtime_dll_paths
-  test_env.prepend('PATH', _rtdll_dir)
-endforeach
+# Clang-tool-chain runtime DLL PATH injection removed as probe (#3129 A6).
+# ZCCACHE_LINK_DEPLOY_CMD=clang-tool-chain-libdeploy (zccache#33) is the
+# upstream-blessed replacement. If ASan/MinGW DLLs go missing in CI,
+# revert this hunk + ci/meson/native/meson.build to re-enable the
+# belt-and-suspenders injection.
 
 # Find python once for test wrapper (avoid 245 find_program calls inside loop)
 python_exe = find_program('python')
@@ -301,9 +301,7 @@ foreach test_name : test_names
   # timeout to match the meson timeout (runner defaults to 20s otherwise).
   this_test_env = environment()
   this_test_env.prepend('PATH', fastled_lib_dir)
-  foreach _rtdll_dir : runtime_dll_paths
-    this_test_env.prepend('PATH', _rtdll_dir)
-  endforeach
+  # Runtime-DLL PATH injection removed — see test_env above and #3129 A6.
   this_test_env.set('FASTLED_TEST_TIMEOUT', test_timeout.to_string())
 
   if use_wrapper


### PR DESCRIPTION
## Summary

**Probe** PR: removes three call sites that prepended clang-tool-chain runtime directories (ASan, MinGW) to the test PATH so DLLs would be discoverable even when zccache caches the link and skips `ctc-clang++`'s post-link deployment.

The upstream-blessed replacement is already in place: `ZCCACHE_LINK_DEPLOY_CMD=clang-tool-chain-libdeploy`, set at `ci/meson/runner_helpers.py:374-375` (zccache#33). The commit message that added the env var explicitly described the PATH workaround as **belt-and-suspenders**.

## What changes

| File | Change |
| --- | --- |
| `ci/meson/native/meson.build` | Drop the `run_command(uv_prog, ...)` that populates `runtime_dll_paths`; leave `runtime_dll_paths = []` so dead references don't error |
| `tests/meson.build` | Drop two `foreach _rtdll_dir : runtime_dll_paths` loops (test_env, this_test_env) |
| `examples/meson.build` | Drop one `foreach _rtdll_dir : runtime_dll_paths` loop (example_test_env) |

`ci/meson/get_runtime_dll_paths.py` is intentionally left in place so revert is a single-line restoration of the `run_command(...)`.

## How to read CI on this branch

- **Watch:** Windows unit-test and example-test runs for `0xc0000135` (STATUS_DLL_NOT_FOUND) or "DLL not found" failures.
- **Green for a week** → workaround stays gone.
- **Any DLL-load failure** → revert.

**3 files changed, 20 insertions(+), 39 deletions(-)**.

Part of #3129 (Section A6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified build configuration by removing legacy Windows runtime dependency path injection across CI, testing, and example environments. The build system now relies on upstream link-deployment mechanisms for resolving runtime dependencies, reducing configuration complexity and improving maintainability while maintaining full functionality of tests and examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->