### PR TITLE
fix(lpc): derive AutoResearch WS2812 loopback from platform

### DIFF
--- a/ci/autoresearch/args.py
+++ b/ci/autoresearch/args.py
@@ -362,8 +362,8 @@ See Also:
             action="store_true",
             help="LPC845-only: WS2812 byte-match loopback via "
             "FastLED.show() (bit-bang TX) → SCT input-capture RX "
-            "(FastLED #3021 Phase 2). Requires the sketch to be built "
-            "with -DFASTLED_LPC_RX_SCT_WS2812=1.",
+            "(FastLED #3021 Phase 2). The LPC845 low-memory sketch binds "
+            "the RPC automatically.",
         )
 
         # Standard options

--- a/ci/autoresearch/phases.py
+++ b/ci/autoresearch/phases.py
@@ -57,6 +57,13 @@ if TYPE_CHECKING:
 # ============================================================
 
 MAX_AUTORESEARCH_LANES = 16
+LPC_BRING_UP_ENVS = {
+    "lpc845brk",
+    "lpc845",
+    "lpcxpresso845max",
+    "lpcxpresso804",
+}
+LPC_WS2812_ENVS = {"lpc845brk", "lpc845", "lpcxpresso845max"}
 
 
 def _is_native_platform(environment: str | None) -> bool:
@@ -915,6 +922,7 @@ async def _run_build_deploy(ctx: RunContext, qctx: QuietContext) -> int | None:
     args = ctx.args
     build_dir = ctx.build_dir
     final_environment = ctx.final_environment
+    final_environment_norm = (final_environment or "").lower()
     upload_port = ctx.upload_port
     build_driver = ctx.build_driver
     assert build_driver is not None
@@ -937,14 +945,13 @@ async def _run_build_deploy(ctx: RunContext, qctx: QuietContext) -> int | None:
     # Phase 2+3: Build + Deploy
     print(f"\U0001f4e6 Using {build_driver.name}")
 
-    bring_up_envs = {"lpc845brk", "lpcxpresso845max", "lpcxpresso804"}
-    if final_environment in bring_up_envs:
+    if final_environment_norm in LPC_BRING_UP_ENVS:
         # fbuild's nxplpc orchestrator does not yet ship a deployer
         # (`daemon/.../deploy.rs` only dispatches avr/teensy). Bring-up boards
         # run `fbuild build` followed by a pyocd-based flash + sw-reset here.
         if not _build_and_flash_nxplpc(
             build_dir,
-            environment=final_environment,
+            environment=final_environment_norm or final_environment,
             upload_port=upload_port,
             verbose=args.verbose,
         ):
@@ -1127,9 +1134,8 @@ async def _run_schema_and_pin_setup(ctx: RunContext) -> int | None:
     # so pin discovery would hang. Skip it for those boards — the bring-up
     # short-circuit later in `_run_full_autoresearch_pipeline` will run
     # `_run_bring_up_tests` directly against the configured upload port.
-    bring_up_envs = {"lpc845brk", "lpc845", "lpcxpresso845max", "lpcxpresso804"}
     final_environment = (ctx.final_environment or "").lower()
-    if final_environment in bring_up_envs:
+    if final_environment in LPC_BRING_UP_ENVS:
         print(
             f"\n\U0001f4cc LPC bring-up mode ({ctx.final_environment}): "
             "skipping pin discovery and GPIO pre-test"
@@ -1190,7 +1196,7 @@ async def _run_schema_and_pin_setup(ctx: RunContext) -> int | None:
         )
 
     # GPIO connectivity pre-test
-    if final_environment in bring_up_envs:
+    if final_environment in LPC_BRING_UP_ENVS:
         # LPC bring-up: no jumper wire / pin loop, the bring-up RPC test
         # itself is the only check we run.
         pass
@@ -1264,10 +1270,8 @@ async def _run_tests_or_special_mode(ctx: RunContext, qctx: QuietContext) -> int
     # GPIO + LED-protocol matrix that ESP32/Teensy targets use. Must come
     # BEFORE the gpio_only_mode early-return so the harness actually runs the
     # echo check instead of bailing with a "no tests requested" success.
-    bring_up_envs = {"lpc845brk", "lpc845", "lpcxpresso845max", "lpcxpresso804"}
-    lpc_ws2812_envs = {"lpc845brk", "lpc845", "lpcxpresso845max"}
     final_environment = (ctx.final_environment or "").lower()
-    if final_environment in bring_up_envs:
+    if final_environment in LPC_BRING_UP_ENVS:
         # FastLED #3021 Phase 1: --pin-toggle-rx runs the SCT-RX
         # loopback bench instead of the default echo bring-up.
         if getattr(ctx.args, "pin_toggle_rx", False):
@@ -1276,7 +1280,7 @@ async def _run_tests_or_special_mode(ctx: RunContext, qctx: QuietContext) -> int
         # byte-match loopback bench. LPC845 low-memory builds bind the
         # required RPC automatically from the platform predicate.
         if getattr(ctx.args, "ws2812_loopback", False):
-            if final_environment not in lpc_ws2812_envs:
+            if final_environment not in LPC_WS2812_ENVS:
                 print(
                     "--ws2812-loopback is only supported on LPC845 boards "
                     "(lpc845brk, lpc845, lpcxpresso845max)."
@@ -1903,8 +1907,7 @@ async def _run_lpc_ws2812_loopback_tests(ctx: RunContext) -> int:
     predicate; no manual WS2812 build flag is required.
     """
     final_environment = (ctx.final_environment or "").lower()
-    lpc_ws2812_envs = {"lpc845brk", "lpc845", "lpcxpresso845max"}
-    if final_environment not in lpc_ws2812_envs:
+    if final_environment not in LPC_WS2812_ENVS:
         print(
             "--ws2812-loopback is only supported on LPC845 boards "
             "(lpc845brk, lpc845, lpcxpresso845max)."

--- a/ci/autoresearch/phases.py
+++ b/ci/autoresearch/phases.py
@@ -1270,9 +1270,8 @@ async def _run_tests_or_special_mode(ctx: RunContext, qctx: QuietContext) -> int
         if getattr(ctx.args, "pin_toggle_rx", False):
             return await _run_lpc_pin_toggle_rx_tests(ctx)
         # FastLED #3021 Phase 2: --ws2812-loopback runs the WS2812
-        # byte-match loopback bench. Requires the sketch to be
-        # rebuilt with -DFASTLED_LPC_RX_SCT_WS2812=1 (gated due to
-        # flash budget — see issue #3002).
+        # byte-match loopback bench. LPC845 low-memory builds bind the
+        # required RPC automatically from the platform predicate.
         if getattr(ctx.args, "ws2812_loopback", False):
             return await _run_lpc_ws2812_loopback_tests(ctx)
         return await _run_bring_up_tests(ctx)
@@ -1890,14 +1889,9 @@ async def _run_lpc_pin_toggle_rx_tests(ctx: RunContext) -> int:
 async def _run_lpc_ws2812_loopback_tests(ctx: RunContext) -> int:
     """Run the FastLED #3021 Phase-2 SCT-RX WS2812 byte-match bench.
 
-    Delegates to `ci/autoresearch/test_lpc_ws2812_loopback.py`. The
-    sketch must be built with `-DFASTLED_LPC_RX_SCT_WS2812=1` for the
-    `ws2812SctTest` RPC to be bound — without that flag the RPC is
-    absent from the sketch's `fl::Remote` registry and the orchestrator
-    will report `no response` for every test case. This is by design:
-    the WS2812 driver pulls in `<FastLED.h>` which overflows the
-    LPC845 64 KB flash budget until #3002 (fl::json soft-FP cleanup)
-    lands.
+    Delegates to `ci/autoresearch/test_lpc_ws2812_loopback.py`. LPC845
+    low-memory builds bind `ws2812SctTest` automatically from the platform
+    predicate; no manual WS2812 build flag is required.
     """
     upload_port = ctx.upload_port
     assert upload_port is not None
@@ -1909,7 +1903,7 @@ async def _run_lpc_ws2812_loopback_tests(ctx: RunContext) -> int:
     print("=" * 60)
     print("LPC SCT-RX MODE — WS2812 byte-match loopback (#3021 Phase 2)")
     print(f"   Wiring required: jumper P0_{tx_pin} ↔ P0_{rx_pin} on LPC845-BRK")
-    print("   Sketch must be built with -DFASTLED_LPC_RX_SCT_WS2812=1")
+    print("   ws2812SctTest RPC is platform-enabled on LPC845 builds")
     print("=" * 60)
     print()
 

--- a/ci/autoresearch/phases.py
+++ b/ci/autoresearch/phases.py
@@ -1127,8 +1127,9 @@ async def _run_schema_and_pin_setup(ctx: RunContext) -> int | None:
     # so pin discovery would hang. Skip it for those boards — the bring-up
     # short-circuit later in `_run_full_autoresearch_pipeline` will run
     # `_run_bring_up_tests` directly against the configured upload port.
-    bring_up_envs = {"lpc845brk", "lpcxpresso845max", "lpcxpresso804"}
-    if ctx.final_environment in bring_up_envs:
+    bring_up_envs = {"lpc845brk", "lpc845", "lpcxpresso845max", "lpcxpresso804"}
+    final_environment = (ctx.final_environment or "").lower()
+    if final_environment in bring_up_envs:
         print(
             f"\n\U0001f4cc LPC bring-up mode ({ctx.final_environment}): "
             "skipping pin discovery and GPIO pre-test"
@@ -1189,7 +1190,7 @@ async def _run_schema_and_pin_setup(ctx: RunContext) -> int | None:
         )
 
     # GPIO connectivity pre-test
-    if ctx.final_environment in bring_up_envs:
+    if final_environment in bring_up_envs:
         # LPC bring-up: no jumper wire / pin loop, the bring-up RPC test
         # itself is the only check we run.
         pass
@@ -1263,8 +1264,10 @@ async def _run_tests_or_special_mode(ctx: RunContext, qctx: QuietContext) -> int
     # GPIO + LED-protocol matrix that ESP32/Teensy targets use. Must come
     # BEFORE the gpio_only_mode early-return so the harness actually runs the
     # echo check instead of bailing with a "no tests requested" success.
-    bring_up_envs = {"lpc845brk", "lpcxpresso845max", "lpcxpresso804"}
-    if ctx.final_environment in bring_up_envs:
+    bring_up_envs = {"lpc845brk", "lpc845", "lpcxpresso845max", "lpcxpresso804"}
+    lpc_ws2812_envs = {"lpc845brk", "lpc845", "lpcxpresso845max"}
+    final_environment = (ctx.final_environment or "").lower()
+    if final_environment in bring_up_envs:
         # FastLED #3021 Phase 1: --pin-toggle-rx runs the SCT-RX
         # loopback bench instead of the default echo bring-up.
         if getattr(ctx.args, "pin_toggle_rx", False):
@@ -1273,6 +1276,12 @@ async def _run_tests_or_special_mode(ctx: RunContext, qctx: QuietContext) -> int
         # byte-match loopback bench. LPC845 low-memory builds bind the
         # required RPC automatically from the platform predicate.
         if getattr(ctx.args, "ws2812_loopback", False):
+            if final_environment not in lpc_ws2812_envs:
+                print(
+                    "--ws2812-loopback is only supported on LPC845 boards "
+                    "(lpc845brk, lpc845, lpcxpresso845max)."
+                )
+                return 1
             return await _run_lpc_ws2812_loopback_tests(ctx)
         return await _run_bring_up_tests(ctx)
 
@@ -1893,6 +1902,15 @@ async def _run_lpc_ws2812_loopback_tests(ctx: RunContext) -> int:
     low-memory builds bind `ws2812SctTest` automatically from the platform
     predicate; no manual WS2812 build flag is required.
     """
+    final_environment = (ctx.final_environment or "").lower()
+    lpc_ws2812_envs = {"lpc845brk", "lpc845", "lpcxpresso845max"}
+    if final_environment not in lpc_ws2812_envs:
+        print(
+            "--ws2812-loopback is only supported on LPC845 boards "
+            "(lpc845brk, lpc845, lpcxpresso845max)."
+        )
+        return 1
+
     upload_port = ctx.upload_port
     assert upload_port is not None
 

--- a/ci/autoresearch/test_lpc_ws2812_loopback.py
+++ b/ci/autoresearch/test_lpc_ws2812_loopback.py
@@ -27,9 +27,8 @@ gap is observable.
 Usage:
     uv run python ci/autoresearch/test_lpc_ws2812_loopback.py [--port COM10]
 
-The orchestrator also requires the firmware to be built with
-`-DFASTLED_LPC_RX_SCT_WS2812=1` (default off — see flash budget note
-in `examples/AutoResearchLpc/AutoResearchLpc.ino`).
+The LPC845 low-memory firmware binds the `ws2812SctTest` RPC automatically
+from the platform predicate; no manual WS2812 build flag is required.
 
 Exits 0 on success, 1 on any failed assertion / RPC error.
 """

--- a/ci/boards.py
+++ b/ci/boards.py
@@ -1035,6 +1035,46 @@ RPI_PICO2 = Board(
     board_build_filesystem_size="0.5m",
 )
 
+# NXP LPC8xx family. PlatformIO has no native Arduino-capable nxplpc
+# platform, so use the zackees fork that layers ArduinoCore-LPC8xx on top of
+# platformio/platform-nxplpc.
+_NXPLPC_PLATFORM = "https://github.com/zackees/platform-nxplpc-arduino.git"
+
+LPC845BRK = Board(
+    board_name="lpc845brk",
+    platform=_NXPLPC_PLATFORM,
+    platform_needs_install=True,
+    framework="arduino",
+)
+
+LPC845 = Board(
+    board_name="lpc845",
+    platform=_NXPLPC_PLATFORM,
+    platform_needs_install=True,
+    framework="arduino",
+)
+
+LPC804 = Board(
+    board_name="lpc804",
+    platform=_NXPLPC_PLATFORM,
+    platform_needs_install=True,
+    framework="arduino",
+)
+
+LPCXPRESSO845MAX = Board(
+    board_name="lpcxpresso845max",
+    platform=_NXPLPC_PLATFORM,
+    platform_needs_install=True,
+    framework="arduino",
+)
+
+LPCXPRESSO804 = Board(
+    board_name="lpcxpresso804",
+    platform=_NXPLPC_PLATFORM,
+    platform_needs_install=True,
+    framework="arduino",
+)
+
 STM32F103C8_BLUEPILL = Board(
     board_name="stm32f103c8",
     real_board_name="bluepill_f103c8",

--- a/ci/boards.py
+++ b/ci/boards.py
@@ -1038,7 +1038,7 @@ RPI_PICO2 = Board(
 # NXP LPC8xx family. PlatformIO has no native Arduino-capable nxplpc
 # platform, so use the zackees fork that layers ArduinoCore-LPC8xx on top of
 # platformio/platform-nxplpc.
-_NXPLPC_PLATFORM = "https://github.com/zackees/platform-nxplpc-arduino.git"
+_NXPLPC_PLATFORM = "https://github.com/zackees/platform-nxplpc-arduino.git#2ee527ae80de98e9105329a7260edb003289dfda"
 
 LPC845BRK = Board(
     board_name="lpc845brk",

--- a/examples/AutoResearch/AutoResearchLowMemory.h
+++ b/examples/AutoResearch/AutoResearchLowMemory.h
@@ -20,6 +20,8 @@
 // See FastLED #3021 for the SCT-RX bring-up flags.
 //
 
+#include "platforms/arm/lpc/is_lpc.h"  // ok platform headers - LPC RX driver gate
+
 // Gate FL_DBG to no-op. Without `RELEASE`, fl/log/log.h auto-sets
 // FASTLED_FORCE_DBG=1, which expands every FL_DBG call site (inside
 // fl::Remote etc.) through the fl::println formatting machinery and
@@ -37,9 +39,15 @@
 #define FASTLED_LPC_RX_SCT 1
 #endif
 
-// Opt in to the SCT->DMA RX capture path. Required for WS2812 hardware
-// loopback. Auto-enabled when WS2812 mode is on.
-#if defined(FASTLED_LPC_RX_SCT_WS2812) && !defined(FASTLED_LPC_RX_SCT_DMA)
+// The LPC845-BRK low-memory build now fits FastLED + Remote + the WS2812
+// loopback RPC. Derive that surface from the platform instead of requiring a
+// user-set build flag.
+#if defined(FL_IS_ARM_LPC_845)
+#define FASTLED_AUTORESEARCH_LPC_WS2812 1
+#endif
+
+// The WS2812 loopback uses the SCT->DMA RX capture path.
+#if defined(FASTLED_AUTORESEARCH_LPC_WS2812) && !defined(FASTLED_LPC_RX_SCT_DMA)
 #define FASTLED_LPC_RX_SCT_DMA 1
 #endif
 
@@ -55,13 +63,12 @@
 // types are platform-gated behind `FL_IS_ARM_LPC` -- they only exist on
 // the real LPC build. So the include + every RX usage below must be gated
 // the same way.
-#include "platforms/arm/lpc/is_lpc.h"  // ok platform headers - LPC RX driver gate
 #if defined(FL_IS_ARM_LPC)
 #include "fl/channels/rx_sct_capture.h"
 #include "fl/stl/strstream.h"
 #endif
 
-#if defined(FASTLED_LPC_RX_SCT_WS2812)
+#if defined(FASTLED_AUTORESEARCH_LPC_WS2812)
 #include "FastLED.h"
 #include "fl/chipsets/timing_traits.h"
 #endif
@@ -206,7 +213,7 @@ inline void autoResearchLowMemorySetup() {
             return s.str();
         });
 
-#if defined(FASTLED_LPC_RX_SCT_WS2812)
+#if defined(FASTLED_AUTORESEARCH_LPC_WS2812)
     // ws2812SctTest (FastLED #3021 Phase 2) -- WS2812 byte-match loopback.
     remote.bind("ws2812SctTest",
         [](int test_case, int tx_pin, int rx_pin, int capture_ms) -> fl::string {
@@ -312,7 +319,7 @@ inline void autoResearchLowMemorySetup() {
               << static_cast<fl::u32>(edges_captured);
             return s.str();
         });
-#endif  // FASTLED_LPC_RX_SCT_WS2812
+#endif  // FASTLED_AUTORESEARCH_LPC_WS2812
 #endif  // FL_IS_ARM_LPC
 }
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -167,7 +167,7 @@ extra_scripts = pre:ci/ci-flags.py
 ;                                    for the FastLED controller lifetime.
 ; The WS2812 loopback RPC is now derived from the LPC845 platform predicate
 ; inside AutoResearchLowMemory.h; no user build flag is required.
-platform = https://github.com/zackees/platform-nxplpc-arduino.git
+platform = https://github.com/zackees/platform-nxplpc-arduino.git#2ee527ae80de98e9105329a7260edb003289dfda
 board = lpc845brk
 framework = arduino
 build_flags =
@@ -191,22 +191,22 @@ build_flags =
 ; --------------------------------------------------------------------------
 
 [env:lpc845]
-platform = https://github.com/zackees/platform-nxplpc-arduino.git
+platform = https://github.com/zackees/platform-nxplpc-arduino.git#2ee527ae80de98e9105329a7260edb003289dfda
 board = lpc845
 framework = arduino
 
 [env:lpc804]
-platform = https://github.com/zackees/platform-nxplpc-arduino.git
+platform = https://github.com/zackees/platform-nxplpc-arduino.git#2ee527ae80de98e9105329a7260edb003289dfda
 board = lpc804
 framework = arduino
 
 [env:lpcxpresso845max]
-platform = https://github.com/zackees/platform-nxplpc-arduino.git
+platform = https://github.com/zackees/platform-nxplpc-arduino.git#2ee527ae80de98e9105329a7260edb003289dfda
 board = lpcxpresso845max
 framework = arduino
 
 [env:lpcxpresso804]
-platform = https://github.com/zackees/platform-nxplpc-arduino.git
+platform = https://github.com/zackees/platform-nxplpc-arduino.git#2ee527ae80de98e9105329a7260edb003289dfda
 board = lpcxpresso804
 framework = arduino
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -165,23 +165,15 @@ extra_scripts = pre:ci/ci-flags.py
 ;                                    #2842 / #2850) in place of the bit-bang
 ;                                    default. Claims the SCT + 3 DMA channels
 ;                                    for the FastLED controller lifetime.
-;   -DFASTLED_LPC_RX_SCT_WS2812=1 -- binds the `ws2812SctTest` AutoResearch
-;                                    loopback RPC (FastLED #3021 Phase 2).
-;                                    Pulls in `<FastLED.h>` alongside fl::Remote;
-;                                    fits the 64 KB budget after #3038's
-;                                    soft-FP-codec replacement.
-platform = nxplpc
+; The WS2812 loopback RPC is now derived from the LPC845 platform predicate
+; inside AutoResearchLowMemory.h; no user build flag is required.
+platform = https://github.com/zackees/platform-nxplpc-arduino.git
 board = lpc845brk
 framework = arduino
 build_flags =
     -DRELEASE
     -DFASTLED_LPC_PWM_DMA=1
     -DFASTLED_AUTORESEARCH_LOW_MEMORY=1
-    -DFASTLED_LPC_RX_SCT_WS2812=1
-    ; -DFASTLED_LPC_RX_SCT_WS2812=1   ; pulls <FastLED.h>, +20 KB, exceeds 64 KB
-    ;                                  ; flash budget on LPC845-BRK. Re-enable
-    ;                                  ; once additional flash-budget reduction
-    ;                                  ; lands (gamma LUT / EngineEvents / etc.).
 
 ; --------------------------------------------------------------------------
 ; LPC8xx canary envs (FastLED #2990 — fbuild Stage 6 canary).
@@ -199,22 +191,22 @@ build_flags =
 ; --------------------------------------------------------------------------
 
 [env:lpc845]
-platform = nxplpc
+platform = https://github.com/zackees/platform-nxplpc-arduino.git
 board = lpc845
 framework = arduino
 
 [env:lpc804]
-platform = nxplpc
+platform = https://github.com/zackees/platform-nxplpc-arduino.git
 board = lpc804
 framework = arduino
 
 [env:lpcxpresso845max]
-platform = nxplpc
+platform = https://github.com/zackees/platform-nxplpc-arduino.git
 board = lpcxpresso845max
 framework = arduino
 
 [env:lpcxpresso804]
-platform = nxplpc
+platform = https://github.com/zackees/platform-nxplpc-arduino.git
 board = lpcxpresso804
 framework = arduino
 

--- a/src/platforms/arm/lpc/led_sysdefs_arm_lpc.h
+++ b/src/platforms/arm/lpc/led_sysdefs_arm_lpc.h
@@ -93,16 +93,18 @@ typedef fl::u8           boolean;
 #define NO_PROGMEM
 #define NEED_CXX_BITS
 
-// CMSIS device header from MCUXpresso SDK provides __disable_irq / __enable_irq
-// via core_cm0plus.h. Some integrations only pull in the SoC header (e.g.
-// LPC845.h / LPC804.h), which transitively includes the core header.
-// IWYU pragma: begin_keep
-#if defined(FL_IS_ARM_LPC_845)
-#include <LPC845.h>
-#elif defined(FL_IS_ARM_LPC_804)
-#include <LPC804.h>
+// CMSIS device headers provide these intrinsics when they are on the include
+// path. ArduinoCore-LPC8xx's PlatformIO binding exposes only the active variant
+// directory, so board aliases such as lpc845brk may not make LPC845.h directly
+// includable. Keep the IRQ primitives local so FastLED does not depend on that
+// package-specific include layout.
+#ifndef __disable_irq
+#define __disable_irq() __asm volatile("cpsid i" ::: "memory")
 #endif
-// IWYU pragma: end_keep
+
+#ifndef __enable_irq
+#define __enable_irq() __asm volatile("cpsie i" ::: "memory")
+#endif
 
 #define cli() __disable_irq()
 #define sei() __enable_irq()


### PR DESCRIPTION
## Summary

Fixes #3128.
Updates #3208.

Retires the user-facing `FASTLED_LPC_RX_SCT_WS2812` opt-in. The LPC845 AutoResearch low-memory sketch now derives the WS2812 loopback surface from `FL_IS_ARM_LPC_845`, auto-enables the SCT DMA capture path for that surface, and binds `ws2812SctTest` without a manual build flag.

This also promotes two LPC buildability fixes needed to validate the cleanup from clean `master`:

- add the five LPC8xx boards to `ci/boards.py` with the concrete `zackees/platform-nxplpc-arduino` URL;
- stop hard-including `LPC845.h` / `LPC804.h` from FastLED's LPC sysdefs because the ArduinoCore-LPC8xx PlatformIO package exposes only the active variant include directory.

## Validation

- `rg -n "FASTLED_LPC_RX_SCT_WS2812" src examples ci platformio.ini` returns no matches.
- `bash compile lpc845brk --examples AutoResearch --backend platformio` now resolves the LPC platform and compiles through to link; GCC 8.2.1 overflows by 2200 bytes, which is the known old-toolchain flash-size limit rather than a missing RPC gate.
- Local fbuild 2.2.30 produced `.build/pio/lpc845brk/.fbuild/build/release/firmware.bin` at 63,984 bytes.
- Flashed that exact binary to LPC845-BRK after chip erase with pyOCD.
- Live SWD halt after reset: `pc = 0x0000d9f6`, `sp = 0x10003e78`.
- Serial RPC on COM10:
  - `echo` returned `REMOTE: {"id":1,"result":4242,"jsonrpc":"2.0"}`
  - `ws2812SctTest` returned `REMOTE: {"id":2,"result":"0,0,1,3,0,0,3,0","jsonrpc":"2.0"}`

The WS2812 response proves the RPC is bound without the retired `FASTLED_LPC_RX_SCT_WS2812` build flag. The nonzero mismatch payload is the existing SCT capture/loopback behavior tracked by the hardware bench meta, not a method-registration failure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for NXP LPC8xx boards (LPC845BRK, LPC845, LPC804, LPCXPRESSO845MAX, LPCXPRESSO804).

* **Improvements**
  * WS2812 loopback testing is now automatically enabled on LPC845 low-memory builds (no manual compile-time flag needed).
  * `--ws2812-loopback` help text updated, and the option is now accepted only for supported LPC845-related environments with a clear failure message otherwise.

* **Documentation**
  * Updated AutoResearch LPC examples and run info to match the new automatic WS2812 RPC binding behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->