### PR TITLE
feat(autoresearch): wire timingDriftTest RPC for #2994 repro

### DIFF
--- a/examples/AutoResearch/AutoResearch.ino
+++ b/examples/AutoResearch/AutoResearch.ino
@@ -213,6 +213,7 @@ void loop()  { autoResearchLowMemoryLoop(); }
 #include "AutoResearchSimd.h"
 #include "AutoResearchWave8Expand.h"  // boot-time #2526 micro-bench
 #include "AutoResearchParlioEncode.h" // full parlio encode bench (post-byte-LUT)
+#include "AutoResearchTimingDrift.h"  // #2994 compounded-timing-drift repro
 #include "AutoResearchParlioStream.h" // #2548 PARLIO streaming validation (RPC-driven)
 
 // ============================================================================

--- a/examples/AutoResearch/AutoResearchRemote.cpp
+++ b/examples/AutoResearch/AutoResearchRemote.cpp
@@ -46,6 +46,7 @@
 #include "AutoResearchAnimartrixBench.h"  // animartrixPerlinBench RPC (#2628 follow-up)
 #include "AutoResearchWave8Expand.h"  // #2526 wave8ExpandBenchmark RPC
 #include "AutoResearchParlioEncode.h" // parlioEncodeBenchmark RPC (#2526 follow-up)
+#include "AutoResearchTimingDrift.h"  // timingDriftTest RPC (#2994 repro)
 #include "AutoResearchParlioStream.h" // parlioStreamValidate RPC (#2548 follow-up)
 #include "fl/system/heap.h"
 #include "fl/chipsets/spi.h"

--- a/examples/AutoResearch/AutoResearchRemoteAsyncMethods.cpp
+++ b/examples/AutoResearch/AutoResearchRemoteAsyncMethods.cpp
@@ -37,6 +37,7 @@
 #include "AutoResearchAnimartrixBench.h"
 #include "AutoResearchWave8Expand.h"
 #include "AutoResearchParlioEncode.h"
+#include "AutoResearchTimingDrift.h"
 #include "AutoResearchParlioStream.h"
 #include "fl/chipsets/spi.h"
 #include "fl/channels/config.h"

--- a/examples/AutoResearch/AutoResearchRemoteBenchmarkMethods.cpp
+++ b/examples/AutoResearch/AutoResearchRemoteBenchmarkMethods.cpp
@@ -38,6 +38,7 @@
 #include "AutoResearchAnimartrixBench.h"
 #include "AutoResearchWave8Expand.h"
 #include "AutoResearchParlioEncode.h"
+#include "AutoResearchTimingDrift.h"
 #include "AutoResearchParlioStream.h"
 #include "fl/chipsets/spi.h"
 #include "fl/channels/config.h"

--- a/examples/AutoResearch/AutoResearchRemoteDriverMethods.cpp
+++ b/examples/AutoResearch/AutoResearchRemoteDriverMethods.cpp
@@ -39,6 +39,7 @@
 #include "AutoResearchWave8Expand.h"
 #include "AutoResearchParlioEncode.h"
 #include "AutoResearchParlioStream.h"
+#include "AutoResearchTimingDrift.h"  // timingDriftTest RPC (#2994 repro)
 #include "fl/chipsets/spi.h"
 #include "fl/channels/config.h"
 #include <Arduino.h>
@@ -570,6 +571,66 @@ void AutoResearchRemoteControl::bindDriverMethods(fl::Remote& remote) {
         response.set("first_edges", edges_arr);
         return response;
 #endif
+    });
+
+    // Register "timingDriftTest" — issue #2994 reproducer for compounded
+    // per-sequence timing drift on master vs 3.10.3. Replays the reporter's
+    // minimal sketch (35-LED WS2812B ring, setMaxRefreshRate(800),
+    // millisDelay-gated 255-step fade, delay(1000) between sequences) and
+    // returns per-sequence wall time so the host can build a histogram.
+    // Args: [{pin, numLeds, iterations}] (all optional;
+    //        default pin=4, numLeds=35, iterations=10; iterations clamped to
+    //        autoresearch::timing_drift::kMaxIterations)
+    remote.bind("timingDriftTest", [](const fl::json& args) -> fl::json {
+        fl::json response = fl::json::object();
+
+        int pin = 4;
+        int num_leds = 35;
+        int iterations = 10;
+
+        fl::json config;
+        if (args.is_object()) {
+            config = args;
+        } else if (args.is_array() && args.size() >= 1 && args[0].is_object()) {
+            config = args[0];
+        }
+        if (!config.is_null()) {
+            if (config.contains("pin") && config["pin"].is_int()) {
+                pin = static_cast<int>(config["pin"].as_int().value());
+            }
+            if (config.contains("numLeds") && config["numLeds"].is_int()) {
+                num_leds = static_cast<int>(config["numLeds"].as_int().value());
+            }
+            if (config.contains("iterations") && config["iterations"].is_int()) {
+                iterations = static_cast<int>(config["iterations"].as_int().value());
+            }
+        }
+
+        auto r = autoresearch::timing_drift::run(pin, num_leds, iterations);
+
+        response.set("success", r.valid_pin);
+        if (!r.valid_pin) {
+            response.set("error", "InvalidPin");
+            response.set("message",
+                         "pin is outside LegacyClocklessProxy range");
+            response.set("pin", r.pin);
+            return response;
+        }
+        response.set("pin", r.pin);
+        response.set("num_leds", r.num_leds);
+        response.set("iterations", r.iterations);
+        response.set("cpu_mhz", static_cast<int64_t>(r.cpu_mhz));
+        response.set("show_count", static_cast<int64_t>(r.show_count));
+        response.set("show_min_us", static_cast<int64_t>(r.show_min_us));
+        response.set("show_max_us", static_cast<int64_t>(r.show_max_us));
+        response.set("show_total_us", static_cast<int64_t>(r.show_total_us));
+
+        fl::json iter_ms_arr = fl::json::array();
+        for (int i = 0; i < r.iterations; ++i) {
+            iter_ms_arr.push_back(static_cast<int64_t>(r.iter_ms[i]));
+        }
+        response.set("iter_ms", iter_ms_arr);
+        return response;
     });
 }
 

--- a/examples/AutoResearch/AutoResearchRemoteMathMethods.cpp
+++ b/examples/AutoResearch/AutoResearchRemoteMathMethods.cpp
@@ -37,6 +37,7 @@
 #include "AutoResearchAnimartrixBench.h"
 #include "AutoResearchWave8Expand.h"
 #include "AutoResearchParlioEncode.h"
+#include "AutoResearchTimingDrift.h"
 #include "AutoResearchParlioStream.h"
 #include "fl/chipsets/spi.h"
 #include "fl/channels/config.h"

--- a/examples/AutoResearch/AutoResearchRemoteNetworkMethods.cpp
+++ b/examples/AutoResearch/AutoResearchRemoteNetworkMethods.cpp
@@ -38,6 +38,7 @@
 #include "AutoResearchAnimartrixBench.h"
 #include "AutoResearchWave8Expand.h"
 #include "AutoResearchParlioEncode.h"
+#include "AutoResearchTimingDrift.h"
 #include "AutoResearchParlioStream.h"
 #include "fl/chipsets/spi.h"
 #include "fl/channels/config.h"

--- a/examples/AutoResearch/AutoResearchRemotePinMethods.cpp
+++ b/examples/AutoResearch/AutoResearchRemotePinMethods.cpp
@@ -36,6 +36,7 @@
 #include "AutoResearchAnimartrixBench.h"
 #include "AutoResearchWave8Expand.h"
 #include "AutoResearchParlioEncode.h"
+#include "AutoResearchTimingDrift.h"
 #include "AutoResearchParlioStream.h"
 #include "fl/chipsets/spi.h"
 #include "fl/channels/config.h"
@@ -571,6 +572,14 @@ void AutoResearchRemoteControl::bindPinMethods(fl::Remote& remote) {
         parlioEncodeBenchmark_fn.set("returns", "{success, iters, lanes, leds_per_lane, scratchPsramOk, outputPsramOk, perpos_ss_us, perpos_sp_us, perpos_ps_us, perpos_pp_us, frame_ss_us, frame_sp_us, frame_ps_us, frame_pp_us, sink}");
         parlioEncodeBenchmark_fn.set("description", "Bench full PARLIO encode hot loop (16-lane gather + BF1 pipe4 direct encode) with SRAM and optional PSRAM placements; answers PSRAM hypothesis + ISR-streaming feasibility");
         functions.push_back(parlioEncodeBenchmark_fn);
+
+        fl::json timingDriftTest_fn = fl::json::object();
+        timingDriftTest_fn.set("name", "timingDriftTest");
+        timingDriftTest_fn.set("phase", "Phase 4: Utility");
+        timingDriftTest_fn.set("args", "[{pin, numLeds, iterations}] (all optional; default pin=4, numLeds=35, iterations=10)");
+        timingDriftTest_fn.set("returns", "{success, pin, num_leds, iterations, cpu_mhz, show_count, show_min_us, show_max_us, show_total_us, iter_ms:[...]}");
+        timingDriftTest_fn.set("description", "Issue #2994 repro for compounded per-sequence timing drift on master vs 3.10.3. Replays the reporter's WS2812B-ring + millisDelay-gated fade sketch and returns per-sequence wall time (theoretical 2495 ms; on 3.10.3 rock-steady, on master 2563-2752).");
+        functions.push_back(timingDriftTest_fn);
 
         fl::json parlioStreamValidate_fn = fl::json::object();
         parlioStreamValidate_fn.set("name", "parlioStreamValidate");

--- a/examples/AutoResearch/AutoResearchRemotePinMethods.cpp
+++ b/examples/AutoResearch/AutoResearchRemotePinMethods.cpp
@@ -607,7 +607,7 @@ void AutoResearchRemoteControl::bindPinMethods(fl::Remote& remote) {
 
         fl::json response = fl::json::object();
         response.set("success", true);
-        response.set("totalFunctions", static_cast<int64_t>(28));
+        response.set("totalFunctions", static_cast<int64_t>(functions.size()));
         response.set("functions", functions);
         return response;
     });

--- a/examples/AutoResearch/AutoResearchRemoteRunParallelTest.cpp
+++ b/examples/AutoResearch/AutoResearchRemoteRunParallelTest.cpp
@@ -33,6 +33,7 @@
 #include "AutoResearchAnimartrixBench.h"
 #include "AutoResearchWave8Expand.h"
 #include "AutoResearchParlioEncode.h"
+#include "AutoResearchTimingDrift.h"
 #include "AutoResearchParlioStream.h"
 #include "fl/chipsets/spi.h"
 #include "fl/channels/config.h"

--- a/examples/AutoResearch/AutoResearchRemoteRunSingleTest.cpp
+++ b/examples/AutoResearch/AutoResearchRemoteRunSingleTest.cpp
@@ -34,6 +34,7 @@
 #include "AutoResearchAnimartrixBench.h"
 #include "AutoResearchWave8Expand.h"
 #include "AutoResearchParlioEncode.h"
+#include "AutoResearchTimingDrift.h"
 #include "AutoResearchParlioStream.h"
 #include "fl/chipsets/spi.h"
 #include "fl/channels/config.h"

--- a/examples/AutoResearch/AutoResearchRemoteSystemMethods.cpp
+++ b/examples/AutoResearch/AutoResearchRemoteSystemMethods.cpp
@@ -37,6 +37,7 @@
 #include "AutoResearchAnimartrixBench.h"
 #include "AutoResearchWave8Expand.h"
 #include "AutoResearchParlioEncode.h"
+#include "AutoResearchTimingDrift.h"
 #include "AutoResearchParlioStream.h"
 #include "fl/chipsets/spi.h"
 #include "fl/channels/config.h"

--- a/examples/AutoResearch/AutoResearchTimingDrift.h
+++ b/examples/AutoResearch/AutoResearchTimingDrift.h
@@ -90,14 +90,20 @@ inline DriftResult run(int pin, int num_leds, int iterations) {
         leds[i] = CRGB::Black;
     }
 
+    // Probe whether the requested pin is dispatchable BEFORE mutating any
+    // global state — invalid pins must not clear other RPC tests' channels.
+    {
+        LegacyClocklessProxy probe(pin, leds, num_leds);
+        if (!probe.valid()) {
+            return r;  // valid_pin stays false; no side effects
+        }
+    }
+
     // Clean slate: drop any channels left over from earlier RPC tests so
     // show() drives only the legacy controller under test.
     FastLED.clear(ClearFlags::CHANNELS);
 
     LegacyClocklessProxy proxy(pin, leds, num_leds);
-    if (!proxy.valid()) {
-        return r;  // valid_pin stays false
-    }
     r.valid_pin = true;
 
 #if defined(ARDUINO_ARCH_ESP32)
@@ -142,6 +148,19 @@ inline DriftResult run(int pin, int num_leds, int iterations) {
     const int i_ring_end = num_leds - 1;
     const int i_ring_divisor = 7;
 
+    // Each sequence runs ~2.5 s and we may queue up to kMaxIterations of
+    // them, so feed the AutoResearch watchdog (5 s timeout) on a coarse
+    // cadence to keep the device alive through long runs.
+    uint32_t last_wdt_feed_ms = millis();
+    constexpr uint32_t kWdtFeedIntervalMs = 1000;
+    auto maybeFeedWatchdog = [&]() {
+        const uint32_t now = millis();
+        if (now - last_wdt_feed_ms >= kWdtFeedIntervalMs) {
+            FastLED.watchdog().feed();
+            last_wdt_feed_ms = now;
+        }
+    };
+
     // Transliteration of the sketch's loop(); `continue` stands in for the
     // sketch's early `return` (Arduino re-enters loop()).
     while (completed < iterations) {
@@ -171,7 +190,10 @@ inline DriftResult run(int pin, int num_leds, int iterations) {
                 }
 
                 updateLEDs();
+                FastLED.watchdog().feed();  // before the 1 s sleep
                 delay(1000);
+                FastLED.watchdog().feed();  // after the 1 s sleep
+                last_wdt_feed_ms = millis();
                 i_post_fade = 255;
                 ms_delay_post.start(225);
                 continue;
@@ -180,6 +202,7 @@ inline DriftResult run(int pin, int num_leds, int iterations) {
             }
         }
         updateLEDs();
+        maybeFeedWatchdog();
     }
 
     r.iterations = completed;

--- a/examples/AutoResearch/AutoResearchTimingDrift.h
+++ b/examples/AutoResearch/AutoResearchTimingDrift.h
@@ -1,0 +1,197 @@
+/// @file AutoResearchTimingDrift.h
+/// @brief Issue #2994 repro: compounded per-sequence timing drift vs 3.10.3.
+///
+/// Replays the reporter's minimal sketch as faithfully as possible:
+///   - 35-LED WS2812B ring on the legacy template addLeds path
+///     (WS2812B<PIN> -> ClocklessControllerImpl -> ClocklessIdf5 -> Channel)
+///     via LegacyClocklessProxy.
+///   - FastLED.setMaxRefreshRate(800).
+///   - millisDelay-gated 255-step fade: first step after 225ms, then 5ms
+///     cadence; FastLED.show() throttled to a 5ms cadence; delay(1000)
+///     between sequences.
+///   - Records millis() elapsed per completed sequence — the value the
+///     reporter printed over serial. Theoretical period:
+///       225 + 254*5 + 1000 = 2495ms.
+///     On 3.10.3 the reporter sees a rock-steady 2495; on master 2563-2752.
+///
+/// Deliberate deviations from the sketch (documented for reviewers):
+///   - No setCpuFrequencyMhz(160): changing CPU clock mid-session risks the
+///     RPC serial link; the current CPU MHz is reported instead.
+///   - No .setCorrection(TypicalLEDStrip): color correction only scales
+///     pixel values and does not affect pacing.
+///   - The first recorded sequence is partial (no leading 225ms arm or
+///     1000ms delay); the host skips index 0 when building the histogram.
+///
+/// Invoked via the `timingDriftTest` JSON-RPC handler registered in
+/// AutoResearchRemote.cpp. NOTE: blocks ~2.5s per iteration.
+
+#pragma once
+
+#include "FastLED.h"
+#include "fl/stl/int.h"
+#include "LegacyClocklessProxy.h"
+
+#include <Arduino.h>  // millis(), micros(), delay()
+
+namespace autoresearch {
+namespace timing_drift {
+
+constexpr int kMaxIterations = 64;
+constexpr int kMaxLeds = 256;
+
+/// Faithful emulation of the millisDelay library used by the issue sketch:
+/// start(t) arms a deadline; justFinished() fires true exactly once when
+/// elapsed >= t; stop() disarms.
+struct MillisDelay {
+    uint32_t mStart = 0;
+    uint32_t mDelay = 0;
+    bool mRunning = false;
+
+    void start(uint32_t delay_ms) {
+        mDelay = delay_ms;
+        mStart = millis();
+        mRunning = true;
+    }
+    void stop() { mRunning = false; }
+    bool justFinished() {
+        if (mRunning && (millis() - mStart) >= mDelay) {
+            mRunning = false;
+            return true;
+        }
+        return false;
+    }
+};
+
+struct DriftResult {
+    bool valid_pin;                    // false if pin outside LegacyClocklessProxy range (0-8)
+    int pin;
+    int num_leds;
+    int iterations;                    // completed sequence count
+    uint32_t cpu_mhz;                  // CPU frequency during the run (0 if unknown)
+    uint32_t iter_ms[kMaxIterations];  // per-sequence wall time; index 0 is partial
+    uint32_t show_count;               // FastLED.show() calls inside the fade loop
+    uint32_t show_min_us;
+    uint32_t show_max_us;
+    uint64_t show_total_us;
+};
+
+inline DriftResult run(int pin, int num_leds, int iterations) {
+    DriftResult r{};
+    r.pin = pin;
+
+    if (iterations < 1) iterations = 1;
+    if (iterations > kMaxIterations) iterations = kMaxIterations;
+    if (num_leds < 2) num_leds = 2;
+    if (num_leds > kMaxLeds) num_leds = kMaxLeds;
+    r.num_leds = num_leds;
+
+    static CRGB leds[kMaxLeds];
+    for (int i = 0; i < num_leds; ++i) {
+        leds[i] = CRGB::Black;
+    }
+
+    // Clean slate: drop any channels left over from earlier RPC tests so
+    // show() drives only the legacy controller under test.
+    FastLED.clear(ClearFlags::CHANNELS);
+
+    LegacyClocklessProxy proxy(pin, leds, num_leds);
+    if (!proxy.valid()) {
+        return r;  // valid_pin stays false
+    }
+    r.valid_pin = true;
+
+#if defined(ARDUINO_ARCH_ESP32)
+    r.cpu_mhz = getCpuFrequencyMhz();
+#endif
+
+    // sketch setup() — addLeds happened in the proxy above.
+    FastLED.setMaxRefreshRate(800);
+    FastLED.show();
+
+    constexpr uint32_t kFastLedUpdateMs = 5;
+    MillisDelay ms_fast_led;
+    MillisDelay ms_delay_post;
+
+    ms_delay_post.start(0);
+    ms_fast_led.start(kFastLedUpdateMs);
+
+    int i_post_fade = 255;
+    uint32_t i_iteration_time = millis();
+    int completed = 0;
+
+    r.show_min_us = 0xFFFFFFFFu;
+
+    auto timedShow = [&]() {
+        const uint32_t t0 = micros();
+        FastLED.show();
+        const uint32_t dt = micros() - t0;
+        r.show_count++;
+        r.show_total_us += dt;
+        if (dt < r.show_min_us) r.show_min_us = dt;
+        if (dt > r.show_max_us) r.show_max_us = dt;
+    };
+
+    auto updateLEDs = [&]() {
+        if (ms_fast_led.justFinished()) {
+            timedShow();
+            ms_fast_led.start(kFastLedUpdateMs);
+        }
+    };
+
+    const int i_ring_start = 0;
+    const int i_ring_end = num_leds - 1;
+    const int i_ring_divisor = 7;
+
+    // Transliteration of the sketch's loop(); `continue` stands in for the
+    // sketch's early `return` (Arduino re-enters loop()).
+    while (completed < iterations) {
+        if (i_post_fade > 0 && ms_delay_post.justFinished()) {
+            const int i_ring_counter =
+                ((255 - i_post_fade) / i_ring_divisor) + i_ring_start;
+
+            if (i_ring_counter <= i_ring_end) {
+                leds[i_ring_counter] = CRGB::Red;
+            }
+            if (i_ring_counter - 1 >= i_ring_start &&
+                i_ring_counter - 1 <= i_ring_end) {
+                leds[i_ring_counter - 1] = CRGB::Black;
+            }
+
+            i_post_fade--;
+
+            if (i_post_fade == 0) {
+                const uint32_t now = millis();
+                r.iter_ms[completed] = now - i_iteration_time;
+                completed++;
+                i_iteration_time = now;
+                ms_delay_post.stop();
+
+                for (int i = i_ring_start; i <= i_ring_end; i++) {
+                    leds[i] = CRGB::Black;
+                }
+
+                updateLEDs();
+                delay(1000);
+                i_post_fade = 255;
+                ms_delay_post.start(225);
+                continue;
+            } else {
+                ms_delay_post.start(5);
+            }
+        }
+        updateLEDs();
+    }
+
+    r.iterations = completed;
+    if (r.show_count == 0) {
+        r.show_min_us = 0;
+    }
+
+    // Teardown: restore unthrottled refresh (boot default). The proxy
+    // destructor removes the legacy controller from the draw list.
+    FastLED.setMaxRefreshRate(0);
+    return r;
+}
+
+}  // namespace timing_drift
+}  // namespace autoresearch


### PR DESCRIPTION
## Summary

`examples/AutoResearch/AutoResearchTimingDrift.h` has been sitting untracked on `master` — its docstring claimed it's "Invoked via the `timingDriftTest` JSON-RPC handler registered in AutoResearchRemote.cpp", but the handler was never written and the file wasn't `#include`d anywhere. This PR wires it up so the harness can actually be invoked.

Related to open issue [#2994](https://github.com/FastLED/FastLED/issues/2994) (compounded per-sequence timing drift on master vs 3.10.3).

## Changes

- Add `AutoResearchTimingDrift.h` to the tracked tree.
- Add the `#include` in `AutoResearch.ino`, `AutoResearchRemote.cpp`, and all 9 `*Methods.cpp` translation units (matches the existing pattern used by `AutoResearchSimd` / `Wave8Expand` / `ParlioEncode` / `ParlioStream` / `AnimartrixBench`).
- Register `timingDriftTest` in `bindDriverMethods()`:
  - Args: `[{pin, numLeds, iterations}]` (all optional; defaults `4 / 35 / 10`; `iterations` clamped to `kMaxIterations = 64`).
  - Returns: `{success, pin, num_leds, iterations, cpu_mhz, show_count, show_min_us, show_max_us, show_total_us, iter_ms: [...]}`.
- Add the discovery catalog entry in `PinMethods` so the function shows up in the listed RPC catalog.

No host-side Python caller — the harness is invocable through the generic JSON-RPC test path when #2994 is next investigated.

## Test plan

- [x] `bash compile wasm --examples AutoResearch` — build successful (55s).
- [x] `bash lint --cpp` — no new violations (one pre-existing warn-only PlatformIO-internal-usage hit, tracked in #2701).
- [ ] Live hardware invocation on ESP32-S3 to reproduce the #2994 drift histogram.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a timing-drift test utility that runs repeated legacy clockless fade sequences and reports CPU frequency (when available), per-`show()` timing statistics (count/min/max/total), and per-sequence elapsed milliseconds.
  * Added a remote testing RPC (`timingDriftTest`) that accepts optional pin, LED count, and iteration parameters and returns validity plus the collected timing metrics in JSON.

* **Documentation**
  * Updated the `help` RPC to include the new `timingDriftTest` endpoint and to report the function count dynamically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->