### PR TITLE
fix(json): use integer float conversion for low-memory JSON

### DIFF
--- a/src/fl/math/screenmap.cpp.hpp
+++ b/src/fl/math/screenmap.cpp.hpp
@@ -370,7 +370,7 @@ void ScreenMap::toJson(const fl::flat_map<string, ScreenMap> &segmentMaps,
                        fl::json *doc) {
 
 #if FASTLED_NO_JSON
-    FL_WARN_F("ScreenMap::toJson called with FASTLED_NO_JSON");
+    FL_WARN("ScreenMap::toJson called with FASTLED_NO_JSON");
     return;
 #else
     if (!doc) {
@@ -412,11 +412,11 @@ void ScreenMap::toJson(const fl::flat_map<string, ScreenMap> &segmentMaps,
 
         fl::json xArray = fl::json::array();
         for (u16 i = 0; i < segment.getLength(); i++) {
-            xArray.push_back(fl::json(static_cast<double>(segment[i].x)));
+            xArray.push_back(fl::json(segment[i].x));
         }
         fl::json yArray = fl::json::array();
         for (u16 i = 0; i < segment.getLength(); i++) {
-            yArray.push_back(fl::json(static_cast<double>(segment[i].y)));
+            yArray.push_back(fl::json(segment[i].y));
         }
 
         fl::json groupObj = fl::json::object();
@@ -429,13 +429,13 @@ void ScreenMap::toJson(const fl::flat_map<string, ScreenMap> &segmentMaps,
         segmentObj.set("group", fl::json(fl::string(name)));
         segmentObj.set("x", xArray);
         segmentObj.set("y", yArray);
-        segmentObj.set("diameter", fl::json(static_cast<double>(diameter)));
+        segmentObj.set("diameter", fl::json(diameter));
         segmentsArr.push_back(segmentObj);
 
         idx++;
     }
 
-    doc->set("version", fl::json(static_cast<double>(2)));
+    doc->set("version", fl::json(i64(2)));
     doc->set("groups", groupsObj);
     doc->set("segments", segmentsArr);
 

--- a/src/fl/stl/json.h
+++ b/src/fl/stl/json.h
@@ -123,9 +123,142 @@
 
 // Implementation details - users should not rely on these directly
 #include "fl/stl/json/types.h"
+#include "fl/stl/bit_cast.h"
 #include "fl/stl/noexcept.h"
+#include "fl/stl/static_assert.h"
 
 namespace fl {
+
+namespace detail {
+
+template <typename T, typename = void>
+struct is_fl_fixed_point : fl::false_type {};
+
+template <typename T>
+struct is_fl_fixed_point<T, decltype(
+    static_cast<void>(T::INT_BITS),
+    static_cast<void>(T::FRAC_BITS),
+    static_cast<void>(fl::declval<const T&>().raw()),
+    static_cast<void>(T::from_raw(fl::declval<const T&>().raw())),
+    void()
+)> : fl::true_type {};
+
+inline u32 round_shift_right_u64(u64 value, int shift) FL_NOEXCEPT {
+    if (shift <= 0) {
+        return static_cast<u32>(value);
+    }
+    if (shift >= 64) {
+        return 0;
+    }
+    const u64 half = u64(1) << (shift - 1);
+    const u64 mask = (u64(1) << shift) - 1;
+    const u64 truncated = value >> shift;
+    const u64 remainder = value & mask;
+    const bool round_up = remainder > half || (remainder == half && (truncated & 1));
+    return static_cast<u32>(truncated + (round_up ? 1 : 0));
+}
+
+inline u32 ieee754_bits_from_scaled_u64(
+    u32 sign, u64 magnitude, int binary_exp) FL_NOEXCEPT {
+    if (magnitude == 0) {
+        return sign;
+    }
+
+    const int top_bit = json_floor_log2_u64(magnitude);
+    int exponent = top_bit + binary_exp;
+    if (exponent > 127) {
+        return sign | 0x7F800000u;
+    }
+
+    if (exponent >= -126) {
+        const int shift = top_bit - 23;
+        u32 significand = 0;
+        if (shift > 0) {
+            significand = round_shift_right_u64(magnitude, shift);
+        } else {
+            significand = static_cast<u32>(magnitude << -shift);
+        }
+        if (significand >= 0x01000000u) {
+            significand >>= 1;
+            ++exponent;
+            if (exponent > 127) {
+                return sign | 0x7F800000u;
+            }
+        }
+        return sign | (static_cast<u32>(exponent + 127) << 23) |
+               (significand & 0x007FFFFFu);
+    }
+
+    const int subnormal_shift = -(binary_exp + 149);
+    u32 mantissa = 0;
+    if (subnormal_shift > 0) {
+        mantissa = round_shift_right_u64(magnitude, subnormal_shift);
+    } else {
+        const int left_shift = -subnormal_shift;
+        if (left_shift >= 64 || magnitude > (u64(-1) >> left_shift)) {
+            return sign | 0x7F800000u;
+        }
+        const u64 shifted = magnitude << left_shift;
+        mantissa = shifted > 0x007FFFFFu ? 0x00800000u : static_cast<u32>(shifted);
+    }
+    if (mantissa >= 0x00800000u) {
+        return sign | 0x00800000u;
+    }
+    return sign | mantissa;
+}
+
+inline u32 ieee754_bits_from_fixed_raw(i64 raw, int frac_bits) FL_NOEXCEPT {
+    const u32 sign = raw < 0 ? 0x80000000u : 0u;
+    const u64 magnitude = raw < 0
+        ? static_cast<u64>(-(raw + 1)) + 1u
+        : static_cast<u64>(raw);
+    return ieee754_bits_from_scaled_u64(sign, magnitude, -frac_bits);
+}
+
+inline bool fixed_raw_from_ieee754_bits(u32 bits, int frac_bits, i64* out) FL_NOEXCEPT {
+    const bool negative = (bits & 0x80000000u) != 0;
+    const u32 exp_bits = (bits >> 23) & 0xFFu;
+    const u32 mantissa_bits = bits & 0x007FFFFFu;
+    if (exp_bits == 0xFFu) {
+        return false;
+    }
+
+    u64 significand = mantissa_bits;
+    int exponent = -126;
+    if (exp_bits != 0) {
+        significand |= 0x00800000u;
+        exponent = static_cast<int>(exp_bits) - 127;
+    }
+
+    const int shift = exponent + frac_bits - 23;
+    u64 magnitude = 0;
+    if (shift >= 0) {
+        if (shift >= 63 || significand > (u64(0x7FFFFFFFFFFFFFFF) >> shift)) {
+            return false;
+        }
+        magnitude = significand << shift;
+    } else {
+        magnitude = round_shift_right_u64(significand, -shift);
+    }
+    if ((!negative && magnitude > u64(0x7FFFFFFFFFFFFFFF)) ||
+        (negative && magnitude > (u64(0x7FFFFFFFFFFFFFFF) + 1u))) {
+        return false;
+    }
+    *out = negative
+        ? (magnitude == (u64(0x7FFFFFFFFFFFFFFF) + 1u)
+            ? static_cast<i64>(0x8000000000000000ull)
+            : -static_cast<i64>(magnitude))
+        : static_cast<i64>(magnitude);
+    return true;
+}
+
+template <typename FP>
+float fixed_point_to_float(FP value) FL_NOEXCEPT {
+    return fl::bit_cast<float>(
+        ieee754_bits_from_fixed_raw(static_cast<i64>(value.raw()), FP::FRAC_BITS));
+}
+
+}  // namespace detail
 
 class json {
 private:
@@ -139,7 +272,9 @@ public:
     json(int i) FL_NOEXCEPT : mValue(fl::make_shared<json_value>(static_cast<i64>(i))) {}
     json(i64 i) FL_NOEXCEPT : mValue(fl::make_shared<json_value>(i)) {}
     json(float f) FL_NOEXCEPT : mValue(fl::make_shared<json_value>(f)) {}  // Use float directly
-    json(double d) FL_NOEXCEPT : mValue(fl::make_shared<json_value>(static_cast<float>(d))) {}  // Convert double to float
+    json(double d) FL_NOEXCEPT : mValue(fl::make_shared<json_value>(detail::json_double_to_float(d))) {}
+    template <typename FP, typename fl::enable_if<detail::is_fl_fixed_point<FP>::value, int>::type = 0>
+    json(FP v) FL_NOEXCEPT : mValue(fl::make_shared<json_value>(detail::fixed_point_to_float(v))) {}
     json(const fl::string& s) FL_NOEXCEPT : mValue(fl::make_shared<json_value>(s)) {}
     json(const char* s) FL_NOEXCEPT : json(fl::string(s)) {}
     json(json_array a) FL_NOEXCEPT : mValue(fl::make_shared<json_value>(fl::move(a))) {}
@@ -210,7 +345,13 @@ public:
     }
     
     json& operator=(double value) FL_NOEXCEPT {
-        mValue = fl::make_shared<json_value>(static_cast<float>(value));
+        mValue = fl::make_shared<json_value>(detail::json_double_to_float(value));
+        return *this;
+    }
+
+    template <typename FP, typename fl::enable_if<detail::is_fl_fixed_point<FP>::value, int>::type = 0>
+    json& operator=(FP v) FL_NOEXCEPT {
+        mValue = fl::make_shared<json_value>(detail::fixed_point_to_float(v));
         return *this;
     }
     
@@ -279,6 +420,24 @@ public:
     fl::optional<FloatType> as_float() const FL_NOEXCEPT {
         if (!mValue) return fl::nullopt;
         return mValue->template as_float<FloatType>(); 
+    }
+
+    template <typename FP>
+    typename fl::enable_if<detail::is_fl_fixed_point<FP>::value, fl::optional<FP>>::type
+    as_fixed_point() const FL_NOEXCEPT {
+        if (!mValue) return fl::nullopt;
+        if (auto raw = mValue->data.template ptr<i64>()) {
+            return FP::from_raw(static_cast<decltype(FP().raw())>(*raw));
+        }
+        if (auto f = mValue->data.template ptr<float>()) {
+            i64 raw = 0;
+            if (!detail::fixed_raw_from_ieee754_bits(
+                    fl::bit_cast<u32>(*f), FP::FRAC_BITS, &raw)) {
+                return fl::nullopt;
+            }
+            return FP::from_raw(static_cast<decltype(FP().raw())>(raw));
+        }
+        return fl::nullopt;
     }
     
     fl::optional<fl::string> as_string() const FL_NOEXCEPT {
@@ -722,6 +881,8 @@ public:
     void set(const fl::string& key, i64 value) FL_NOEXCEPT { set(key, json(value)); }
     void set(const fl::string& key, float value) FL_NOEXCEPT { set(key, json(value)); }
     void set(const fl::string& key, double value) FL_NOEXCEPT { set(key, json(value)); }
+    template <typename FP, typename fl::enable_if<detail::is_fl_fixed_point<FP>::value, int>::type = 0>
+    void set(const fl::string& key, FP value) FL_NOEXCEPT { set(key, json(value)); }
     void set(const fl::string& key, const fl::string& value) FL_NOEXCEPT { set(key, json(value)); }
     void set(const fl::string& key, const char* value) FL_NOEXCEPT { set(key, json(value)); }
     template<typename T, typename = fl::enable_if_t<fl::is_same<T, char>::value>>

--- a/src/fl/stl/json/types.h
+++ b/src/fl/stl/json/types.h
@@ -21,10 +21,27 @@
 #include "fl/log/log.h"
 #include "fl/task/promise.h" // For fl::task::Error type
 #include "fl/stl/string_view.h"
+#include "fl/stl/bit_cast.h"
 
+#include "fl/system/sketch_macros.h"
 #include "fl/stl/noexcept.h"
 
+#ifndef FL_JSON_FLOAT_ENABLED
+#define FL_JSON_FLOAT_ENABLED FL_PLATFORM_HAS_LARGE_MEMORY
+#endif
+
 namespace fl {
+
+namespace detail {
+
+inline u32 json_round_shift_right_u64(u64 value, int shift) FL_NOEXCEPT;
+inline int json_floor_log2_u64(u64 value) FL_NOEXCEPT;
+inline u32 json_ieee754_float_bits_from_scaled_u64(
+    u32 sign, u64 magnitude, int binary_exp) FL_NOEXCEPT;
+inline u32 json_ieee754_float_bits_from_double_bits(u64 bits) FL_NOEXCEPT;
+inline float json_double_to_float(double value) FL_NOEXCEPT;
+
+} // namespace detail
 
 struct json_value;
 
@@ -788,7 +805,7 @@ struct json_value {
     }
 
     json_value& operator=(double d) FL_NOEXCEPT {
-        data = static_cast<float>(d);
+        data = detail::json_double_to_float(d);
         return *this;
     }
     
@@ -1739,3 +1756,5 @@ private:
 // Main json class that provides a more fluid and user-friendly interface
 
 } // namespace fl
+
+#include "fl/stl/json/types.impl.hpp"

--- a/src/fl/stl/json/types.impl.hpp
+++ b/src/fl/stl/json/types.impl.hpp
@@ -1,0 +1,112 @@
+#pragma once
+
+namespace fl {
+namespace detail {
+
+inline u32 json_round_shift_right_u64(u64 value, int shift) FL_NOEXCEPT {
+    if (shift <= 0) {
+        return static_cast<u32>(value);
+    }
+    if (shift >= 64) {
+        return 0;
+    }
+    const u64 half = u64(1) << (shift - 1);
+    const u64 mask = (u64(1) << shift) - 1;
+    const u64 truncated = value >> shift;
+    const u64 remainder = value & mask;
+    const bool round_up = remainder > half || (remainder == half && (truncated & 1));
+    return static_cast<u32>(truncated + (round_up ? 1 : 0));
+}
+
+inline int json_floor_log2_u64(u64 value) FL_NOEXCEPT {
+    int bit = -1;
+    while (value != 0) {
+        value >>= 1;
+        ++bit;
+    }
+    return bit;
+}
+
+inline u32 json_ieee754_float_bits_from_scaled_u64(
+    u32 sign, u64 magnitude, int binary_exp) FL_NOEXCEPT {
+    if (magnitude == 0) {
+        return sign;
+    }
+
+    const int top_bit = json_floor_log2_u64(magnitude);
+    int exponent = top_bit + binary_exp;
+    if (exponent > 127) {
+        return sign | 0x7F800000u;
+    }
+
+    if (exponent >= -126) {
+        const int shift = top_bit - 23;
+        u32 significand = shift > 0
+            ? json_round_shift_right_u64(magnitude, shift)
+            : static_cast<u32>(magnitude << -shift);
+        if (significand >= 0x01000000u) {
+            significand >>= 1;
+            ++exponent;
+            if (exponent > 127) {
+                return sign | 0x7F800000u;
+            }
+        }
+        return sign | (static_cast<u32>(exponent + 127) << 23) |
+               (significand & 0x007FFFFFu);
+    }
+
+    const int subnormal_shift = -(binary_exp + 149);
+    u32 mantissa = 0;
+    if (subnormal_shift > 0) {
+        mantissa = json_round_shift_right_u64(magnitude, subnormal_shift);
+    } else {
+        const int left_shift = -subnormal_shift;
+        if (left_shift >= 64 || magnitude > (u64(-1) >> left_shift)) {
+            return sign | 0x7F800000u;
+        }
+        const u64 shifted = magnitude << left_shift;
+        mantissa = shifted > 0x007FFFFFu ? 0x00800000u : static_cast<u32>(shifted);
+    }
+    if (mantissa >= 0x00800000u) {
+        return sign | 0x00800000u;
+    }
+    return sign | mantissa;
+}
+
+inline u32 json_ieee754_float_bits_from_double_bits(u64 bits) FL_NOEXCEPT {
+    const u32 sign = (bits >> 63) ? 0x80000000u : 0u;
+    const u32 exp_bits = static_cast<u32>((bits >> 52) & 0x7FFu);
+    const u64 mantissa_bits = bits & 0x000FFFFFFFFFFFFFull;
+    if (exp_bits == 0x7FFu) {
+        return mantissa_bits == 0 ? sign | 0x7F800000u : sign | 0x7FC00000u;
+    }
+    if (exp_bits == 0) {
+        return json_ieee754_float_bits_from_scaled_u64(sign, mantissa_bits, -1074);
+    }
+    return json_ieee754_float_bits_from_scaled_u64(
+        sign, mantissa_bits | 0x0010000000000000ull,
+        static_cast<int>(exp_bits) - 1075);
+}
+
+template <typename To, typename From>
+inline To json_bit_copy(const From& value) FL_NOEXCEPT {
+    To out = 0;
+    const char* src = reinterpret_cast<const char*>(&value);
+    char* dst = reinterpret_cast<char*>(&out);
+    const fl::size n = sizeof(To) < sizeof(From) ? sizeof(To) : sizeof(From);
+    for (fl::size i = 0; i < n; ++i) {
+        dst[i] = src[i];
+    }
+    return out;
+}
+
+inline float json_double_to_float(double value) FL_NOEXCEPT {
+    if (sizeof(double) == sizeof(u32)) {
+        return fl::bit_cast<float>(json_bit_copy<u32>(value));
+    }
+    return fl::bit_cast<float>(
+        json_ieee754_float_bits_from_double_bits(json_bit_copy<u64>(value)));
+}
+
+} // namespace detail
+} // namespace fl

--- a/src/platforms/shared/ui/json/json_console.cpp.hpp
+++ b/src/platforms/shared/ui/json/json_console.cpp.hpp
@@ -1,13 +1,13 @@
 // IWYU pragma: private
 
 #include "fl/system/sketch_macros.h"
+#include "fl/stl/json/types.h"
 
-#if SKETCH_HAS_LARGE_MEMORY
+#if SKETCH_HAS_LARGE_MEMORY && FL_JSON_FLOAT_ENABLED
 
 
 #include "platforms/shared/ui/json/json_console.h"
 #include "fl/log/log.h"
-#include "fl/stl/json.h"
 #include "fl/stl/json.h"
 #include "fl/stl/algorithm.h"
 #include "fl/stl/stdint.h"
@@ -349,4 +349,4 @@ void JsonConsole::dump(fl::sstream& out) FL_NOEXCEPT {
 
 } // namespace fl
 
-#endif // SKETCH_HAS_LARGE_MEMORY
+#endif // SKETCH_HAS_LARGE_MEMORY && FL_JSON_FLOAT_ENABLED

--- a/src/platforms/shared/ui/json/number_field.cpp.hpp
+++ b/src/platforms/shared/ui/json/number_field.cpp.hpp
@@ -7,6 +7,9 @@
 #include "platforms/shared/ui/json/ui_internal.h"
 #include "platforms/shared/ui/json/ui.h"
 #include "fl/stl/noexcept.h"
+
+#if FL_JSON_FLOAT_ENABLED
+
 namespace fl {
 
 // Definition of the internal class that was previously in number_field_internal.h
@@ -131,3 +134,5 @@ bool JsonNumberFieldImpl::operator!=(float v) const FL_NOEXCEPT { return !fl::al
 bool JsonNumberFieldImpl::operator!=(int v) const FL_NOEXCEPT { return !fl::almost_equal(value(), static_cast<float>(v)); }
 
 } // namespace fl
+
+#endif  // FL_JSON_FLOAT_ENABLED

--- a/src/platforms/shared/ui/json/slider.cpp.hpp
+++ b/src/platforms/shared/ui/json/slider.cpp.hpp
@@ -9,6 +9,8 @@
 #include "fl/stl/compiler_control.h"
 #include "fl/stl/noexcept.h"
 
+#if FL_JSON_FLOAT_ENABLED
+
 FL_DISABLE_WARNING(deprecated-declarations)
 namespace fl {
 
@@ -150,3 +152,5 @@ int JsonSliderImpl::id() const FL_NOEXCEPT {
 }
 
 } // namespace fl
+
+#endif  // FL_JSON_FLOAT_ENABLED

--- a/tests/fl/stl/json.cpp
+++ b/tests/fl/stl/json.cpp
@@ -5,6 +5,7 @@
 
 #include "fl/stl/json.h"
 #include "fl/math/screenmap.h"
+#include "fl/math/fixed_point.h"
 #include "fl/stl/map.h"
 #include "fl/stl/stdint.h"
 #include "fl/stl/string.h"
@@ -1596,6 +1597,64 @@ FL_TEST_CASE("json set() with various integer types") {
         FL_REQUIRE(underflow8.has_value()); // Still returns a value
         FL_CHECK_EQ(*underflow8, 127); // Wraps around to maximum value
     }
+}
+
+FL_TEST_CASE("json fixed_point converts through float storage") {
+    using FP = fl::fixed_point<16, 16>;
+    const FP original = FP::from_raw(0x00018000);
+
+    json value(original);
+    auto extracted = value.as_fixed_point<FP>();
+    FL_REQUIRE(extracted.has_value());
+    FL_CHECK_EQ(extracted->raw(), original.raw());
+
+    json assigned;
+    assigned = original;
+    auto assigned_value = assigned.as_fixed_point<FP>();
+    FL_REQUIRE(assigned_value.has_value());
+    FL_CHECK_EQ(assigned_value->raw(), original.raw());
+
+    json obj = json::object();
+    obj.set("gain", original);
+    auto object_value = obj["gain"].as_fixed_point<FP>();
+    FL_REQUIRE(object_value.has_value());
+    FL_CHECK_EQ(object_value->raw(), original.raw());
+}
+
+FL_TEST_CASE("json fixed_point IEEE conversion saturates oversized magnitudes") {
+    const u64 sixty_bit_magnitude = u64(1) << 59;
+    FL_CHECK_EQ(
+        fl::detail::json_ieee754_float_bits_from_scaled_u64(
+            0, sixty_bit_magnitude, 80),
+        0x7F800000u);
+    FL_CHECK_EQ(
+        fl::detail::json_ieee754_float_bits_from_scaled_u64(
+            0x80000000u, sixty_bit_magnitude, 80),
+        0xFF800000u);
+}
+
+FL_TEST_CASE("json double input uses IEEE bit conversion") {
+    const double one = fl::bit_cast<double>(0x3FF0000000000000ull);
+    json value(one);
+    auto as_float = value.as<float>();
+    FL_REQUIRE(as_float.has_value());
+    FL_CHECK_EQ(fl::bit_cast<u32>(*as_float), 0x3F800000u);
+
+    json assigned;
+    assigned = fl::bit_cast<double>(0x4004000000000000ull);
+    auto assigned_float = assigned.as<float>();
+    FL_REQUIRE(assigned_float.has_value());
+    FL_CHECK_EQ(fl::bit_cast<u32>(*assigned_float), 0x40200000u);
+
+    json overflow(fl::bit_cast<double>(0x7FEFFFFFFFFFFFFFull));
+    auto overflow_float = overflow.as<float>();
+    FL_REQUIRE(overflow_float.has_value());
+    FL_CHECK_EQ(fl::bit_cast<u32>(*overflow_float), 0x7F800000u);
+
+    json nan_value(fl::bit_cast<double>(0x7FF8000000000001ull));
+    auto nan_float = nan_value.as<float>();
+    FL_REQUIRE(nan_float.has_value());
+    FL_CHECK_EQ(fl::bit_cast<u32>(*nan_float), 0x7FC00000u);
 }
 
 FL_TEST_CASE("json generic integer setter comprehensive test") {


### PR DESCRIPTION
﻿Fixes #3029.
Updates #3208.

## Summary
- Keep `fl::json` float/double entry points available on low-memory targets while avoiding floating-point arithmetic in the conversion path.
- Convert 64-bit `double` inputs to JSON's single-precision float storage with integer IEEE-754 bit handling, including NaN/inf preservation and overflow saturation to infinity.
- Convert FastLED fixed-point values to JSON float storage with integer bit construction, including saturation when the fixed-point magnitude is too large for single precision.
- Keep direct `float` inputs as existing float storage, avoid unnecessary `float -> double` promotion in `ScreenMap::toJson`, and continue gating JSON UI implementation files that do real floating-point parsing/arithmetic behind `FL_JSON_FLOAT_ENABLED`.

## Validation
- `bash test --cpp tests/fl/stl/json.cpp`
- `bash compile uno --examples Blink --backend fbuild`
- `bash compile lpc845brk --examples AutoResearch --backend fbuild` passed: flash 62.47 KB / 64 KB, RAM 10.99 KB / 16 KB.

## Upgrade Notes
No user-facing upgrade is required for existing JSON float callers. Low-memory builds should continue to use the same `fl::json(float)`, `fl::json(double)`, and fixed-point JSON APIs; the conversion is now handled without depending on target floating-point conversion helpers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added fixed-point numeric type support for JSON values, including constructors, setters, and `as_fixed_point<FP>()` extraction.

* **Improvements**
  * Enhanced JSON float handling with IEEE-754 bit-accurate conversion.
  * Updated JSON geometry (v2) to emit `x`/`y`, `diameter`, and an integer `version`.
  * UI JSON number fields and sliders now compile only when float JSON support is enabled.

* **Bug Fixes**
  * Adjusted JSON-related warning behavior for builds without JSON support.

* **Tests**
  * Added regression coverage for fixed-point round-trips and IEEE-754 conversions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->