### PR TITLE
Fixed wrong offsets in FL_LPC_GPIO_Type for LPC GPIO register map.

### DIFF
--- a/src/platforms/arm/lpc/fastpin_arm_lpc.h
+++ b/src/platforms/arm/lpc/fastpin_arm_lpc.h
@@ -48,8 +48,9 @@ namespace fl {
 
 typedef struct {
     volatile u8  B[2][32];         // 0x0000 byte-pin access
+    volatile u8 RESERVED00[4032];  // pad to 0x1000 word-pin access
     volatile u32 W[2][32];         // 0x1000 word-pin access (0x80 bytes per port)
-    volatile u32 RESERVED0[1024 - 256];
+    volatile u8 RESERVED0[3840];   // pad to 0x2000 DIR/MASK/PIN/MPIN/SET/CLR/NOT access
     volatile u32 DIR[2];           // 0x2000
     volatile u32 RESERVED1[30];
     volatile u32 MASK[2];          // 0x2080


### PR DESCRIPTION
Also, I had to add a line that inits the clock gating to the GPIO port in my main.cpp before calling `fl::FastPin<LED_PIN>::setOutput();`  Seems that is missing from the FastPin class and I didn't know where best to put it.

```c
/*
 * main.cpp  
 * Based on example project from MCUXpresso SDK on LPC845
 */

#include "fsl_device_registers.h"
#include "fsl_debug_console.h"
#include "board.h"
#include "app.h"

// #include "FastLED/fl/log/log.h"                          // fl::println
#include "FastLED/bitswap.cpp.hpp"                        // fl::platforms::begin
#include "FastLED/platforms/arm/lpc/platform_time_lpc.cpp.hpp"  // fl::platforms::delay, millis SysTick-based time implementation for LPC
#include "FastLED/platforms/arm/lpc/fastpin_arm_lpc.h"   // fl::FastPin<>

/*******************************************************************************
 * Definitions
 ******************************************************************************/

namespace {
// PIO0_15 on the LPC845-BRK / LPCXpresso845-MAX breakout header.
// Wire an external LED + series resistor here.
// (FastPin only covers PORT0 today, so the on-board RGB LED on
//  PORT1 isn't reachable yet — see fastpin_arm_lpc.h.)
constexpr unsigned LED_PIN  = 16;
constexpr unsigned BLINK_MS = 250;   // 2 Hz toggle
}  // namespace

/*******************************************************************************
 * Prototypes
 ******************************************************************************/

/*******************************************************************************
 * Variables
 ******************************************************************************/

/*******************************************************************************
 * Code
 ******************************************************************************/
/*!
 * @brief Main function
 */

extern "C" int main(void)
{
    /* Init board hardware. */
    BOARD_InitHardware();

    PRINTF("MCUX SDK version: %s\r\n", MCUXSDK_VERSION_FULL_STR);

    PRINTF("hello world.\r\n");

    GPIO_PortInit(GPIO, 0); // needed for FastPin<16> to work, since it uses the PORT0 DIR/SET/CLR registers directly without going through the GPIO driver
    fl::FastPin<LED_PIN>::setOutput();

    fl::u32 last_log_ms = fl::platforms::millis();

    for (;;) {
        fl::FastPin<LED_PIN>::hi();
        fl::platforms::delay(BLINK_MS);
        fl::FastPin<LED_PIN>::lo();
        fl::platforms::delay(BLINK_MS);
        PRINTF(".");

        const fl::u32 now = fl::platforms::millis();
        if ((now - last_log_ms) >= 2000) {
            PRINTF("heartbeat.\r\n");
            last_log_ms = now;
        }
    }
    return 0;
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected memory layout alignment for ARM LPC GPIO register handling to ensure proper operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->