### PR TITLE
Add LPC IEEE754 AutoResearch codec mode

### DIFF
--- a/agents/docs/hardware-autoresearch.md
+++ b/agents/docs/hardware-autoresearch.md
@@ -16,6 +16,7 @@ You **must** specify at least one LED driver to test using one of these flags:
 - `--lcd-rgb` - Test LCD RGB driver (ESP32-P4 only)
 - `--all` - Test all drivers (equivalent to `--parlio --rmt --spi --uart --i2s --lcd-rgb`)
 - `--parallel` - Test multiple drivers simultaneously (requires 2+ drivers)
+- `--ieee754` - Special mode: run integer IEEE 754 decimal codec verification without LED driver loopback
 
 ### Usage Examples
 ```bash
@@ -27,6 +28,7 @@ bash autoresearch --spi
 bash autoresearch --uart
 bash autoresearch --i2s                       # ESP32-S3 only
 bash autoresearch --lcd-rgb                   # ESP32-P4 only
+bash autoresearch lpc845brk --ieee754         # LPC low-memory IEEE 754 codec check
 
 # Test multiple drivers (sequentially)
 bash autoresearch --parlio --rmt              # Auto-detect environment

--- a/ci/autoresearch/args.py
+++ b/ci/autoresearch/args.py
@@ -27,6 +27,7 @@ class Args:
     all: bool
     simd: bool
     coroutine: bool
+    ieee754: bool
     # Wave2D perf benchmark — accepts "<W>x<H>" (e.g. "32x32") or None.
     # Cf. issue #3124 for the future --perf-XX / --test-XX convention.
     wave2d_perf: str | None
@@ -267,6 +268,11 @@ See Also:
             "--coroutine",
             action="store_true",
             help="Test coroutine/task creation, stop, and await (no LED drivers needed)",
+        )
+        driver_group.add_argument(
+            "--ieee754",
+            action="store_true",
+            help="Run on-device integer IEEE 754 decimal codec verification (#3039)",
         )
         driver_group.add_argument(
             "--wave2d-perf",
@@ -608,6 +614,7 @@ See Also:
             all=parsed.all,
             simd=parsed.simd,
             coroutine=parsed.coroutine,
+            ieee754=parsed.ieee754,
             wave2d_perf=parsed.wave2d_perf,
             environment=parsed.environment,
             verbose=parsed.verbose,

--- a/ci/autoresearch/context.py
+++ b/ci/autoresearch/context.py
@@ -123,6 +123,7 @@ class RunContext:
     # Mode flags
     simd_test_mode: bool
     coroutine_test_mode: bool
+    ieee754_test_mode: bool
     # Wave2D perf benchmark — None disables, otherwise (W, H).
     # See issue #3124 for the planned --perf-XX convention rename.
     wave2d_perf_grid: tuple[int, int] | None

--- a/ci/autoresearch/phases.py
+++ b/ci/autoresearch/phases.py
@@ -64,6 +64,9 @@ LPC_BRING_UP_ENVS = {
     "lpcxpresso804",
 }
 LPC_WS2812_ENVS = {"lpc845brk", "lpc845", "lpcxpresso845max"}
+LPC_IEEE754_BUILD_ENVS = {
+    "lpc845brk": "lpc845brk_ieee754",
+}
 
 
 def _is_native_platform(environment: str | None) -> bool:
@@ -71,6 +74,16 @@ def _is_native_platform(environment: str | None) -> bool:
     if not environment:
         return False
     return environment.lower() in ("native", "stub", "host")
+
+
+def _build_environment_for_mode(ctx: RunContext) -> str | None:
+    """Return the PlatformIO/fbuild environment to compile for this run mode."""
+    environment = ctx.final_environment
+    if not environment:
+        return None
+    if ctx.ieee754_test_mode:
+        return LPC_IEEE754_BUILD_ENVS.get(environment.lower(), environment)
+    return environment
 
 
 async def _run_native_autoresearch(args: Args, build_mode: str = "quick") -> int:
@@ -206,6 +219,7 @@ def _parse_args_and_build_commands(args: Args) -> RunContext | int:
     drivers: list[str] = []
     simd_test_mode = args.simd
     coroutine_test_mode = args.coroutine
+    ieee754_test_mode = args.ieee754
 
     # Parse --wave2d-perf "<W>x<H>" — None disables the mode.
     # Cf. #3124 for the planned --perf-XX convention rename.
@@ -288,6 +302,7 @@ def _parse_args_and_build_commands(args: Args) -> RunContext | int:
             bool(drivers)
             or simd_test_mode
             or coroutine_test_mode
+            or ieee754_test_mode
             or net_server_mode
             or net_client_mode
             or net_loopback_mode
@@ -303,7 +318,7 @@ def _parse_args_and_build_commands(args: Args) -> RunContext | int:
     # Validate mutual exclusivity
     if (
         net_server_mode or net_client_mode or net_loopback_mode or ota_mode or ble_mode
-    ) and (drivers or simd_test_mode or coroutine_test_mode):
+    ) and (drivers or simd_test_mode or coroutine_test_mode or ieee754_test_mode):
         print(
             f"{Fore.RED}\u274c Error: --net/--net-server/--net-client/--ota/--ble cannot be combined with driver flags, --simd, or --coroutine{Style.RESET_ALL}"
         )
@@ -329,6 +344,7 @@ def _parse_args_and_build_commands(args: Args) -> RunContext | int:
         not drivers
         and not simd_test_mode
         and not coroutine_test_mode
+        and not ieee754_test_mode
         and not net_server_mode
         and not net_client_mode
         and not net_loopback_mode
@@ -733,6 +749,7 @@ def _parse_args_and_build_commands(args: Args) -> RunContext | int:
         build_dir=build_dir,
         simd_test_mode=simd_test_mode,
         coroutine_test_mode=coroutine_test_mode,
+        ieee754_test_mode=ieee754_test_mode,
         wave2d_perf_grid=wave2d_perf_grid,
         net_server_mode=net_server_mode,
         net_client_mode=net_client_mode,
@@ -923,12 +940,13 @@ async def _run_build_deploy(ctx: RunContext, qctx: QuietContext) -> int | None:
     build_dir = ctx.build_dir
     final_environment = ctx.final_environment
     final_environment_norm = (final_environment or "").lower()
+    build_environment = _build_environment_for_mode(ctx)
     upload_port = ctx.upload_port
     build_driver = ctx.build_driver
     assert build_driver is not None
 
     # Phase 0: Package Installation
-    if not build_driver.install_packages(build_dir, final_environment):
+    if not build_driver.install_packages(build_dir, build_environment):
         print("\n\u274c Package installation failed")
         return 1
     print()
@@ -951,7 +969,7 @@ async def _run_build_deploy(ctx: RunContext, qctx: QuietContext) -> int | None:
         # run `fbuild build` followed by a pyocd-based flash + sw-reset here.
         if not _build_and_flash_nxplpc(
             build_dir,
-            environment=final_environment_norm or final_environment,
+            environment=build_environment or final_environment_norm or final_environment,
             upload_port=upload_port,
             verbose=args.verbose,
         ):
@@ -960,7 +978,7 @@ async def _run_build_deploy(ctx: RunContext, qctx: QuietContext) -> int | None:
             return 1
     elif not build_driver.deploy(
         build_dir,
-        environment=final_environment,
+        environment=build_environment,
         upload_port=upload_port,
         verbose=args.verbose,
         clean=args.clean,
@@ -1117,8 +1135,10 @@ async def _run_schema_and_pin_setup(ctx: RunContext) -> int | None:
     # Create serial interface
     from ci.util.serial_interface import create_serial_interface
 
+    final_environment = (ctx.final_environment or "").lower()
+    use_pyserial = (not use_fbuild) or final_environment in LPC_BRING_UP_ENVS
     ctx.serial_iface = create_serial_interface(
-        port=upload_port, use_pyserial=not use_fbuild
+        port=upload_port, use_pyserial=use_pyserial
     )
 
     # Create crash trace decoder
@@ -1134,7 +1154,6 @@ async def _run_schema_and_pin_setup(ctx: RunContext) -> int | None:
     # so pin discovery would hang. Skip it for those boards — the bring-up
     # short-circuit later in `_run_full_autoresearch_pipeline` will run
     # `_run_bring_up_tests` directly against the configured upload port.
-    final_environment = (ctx.final_environment or "").lower()
     if final_environment in LPC_BRING_UP_ENVS:
         print(
             f"\n\U0001f4cc LPC bring-up mode ({ctx.final_environment}): "
@@ -1144,6 +1163,8 @@ async def _run_schema_and_pin_setup(ctx: RunContext) -> int | None:
         print("\n\U0001f4cc SIMD mode: skipping pin discovery and GPIO pre-test")
     elif ctx.coroutine_test_mode:
         print("\n\U0001f4cc Coroutine mode: skipping pin discovery and GPIO pre-test")
+    elif ctx.ieee754_test_mode:
+        print("\n\U0001f4cc IEEE754 codec mode: skipping pin discovery and GPIO pre-test")
     elif ctx.net_server_mode or ctx.net_client_mode or ctx.net_loopback_mode:
         print("\n\U0001f4cc Network mode: skipping pin discovery and GPIO pre-test")
     elif ctx.ota_mode:
@@ -1203,6 +1224,8 @@ async def _run_schema_and_pin_setup(ctx: RunContext) -> int | None:
     elif ctx.simd_test_mode:
         pass
     elif ctx.coroutine_test_mode:
+        pass
+    elif ctx.ieee754_test_mode:
         pass
     elif ctx.net_server_mode or ctx.net_client_mode or ctx.net_loopback_mode:
         pass
@@ -1272,6 +1295,8 @@ async def _run_tests_or_special_mode(ctx: RunContext, qctx: QuietContext) -> int
     # echo check instead of bailing with a "no tests requested" success.
     final_environment = (ctx.final_environment or "").lower()
     if final_environment in LPC_BRING_UP_ENVS:
+        if ctx.ieee754_test_mode:
+            return await _run_ieee754_tests(ctx)
         # FastLED #3021 Phase 1: --pin-toggle-rx runs the SCT-RX
         # loopback bench instead of the default echo bring-up.
         if getattr(ctx.args, "pin_toggle_rx", False):
@@ -1370,6 +1395,10 @@ async def _run_tests_or_special_mode(ctx: RunContext, qctx: QuietContext) -> int
     # Coroutine test mode
     if ctx.coroutine_test_mode:
         return await _run_coroutine_tests(ctx)
+
+    # IEEE 754 codec test mode
+    if ctx.ieee754_test_mode:
+        return await _run_ieee754_tests(ctx)
 
     # Wave2D perf benchmark mode (#3113 Task 1 / #3122 A1)
     if ctx.wave2d_perf_grid is not None:
@@ -1544,6 +1573,74 @@ async def _run_wave2d_perf_tests(ctx: RunContext) -> int:
     except Exception as e:
         print()
         print(f"{Fore.RED}WAVE2D PERF ERROR: {e}{Style.RESET_ALL}")
+        return 1
+    finally:
+        if client is not None:
+            await client.close()
+
+
+async def _run_ieee754_tests(ctx: RunContext) -> int:
+    """Run integer IEEE 754 decimal codec verification via RPC."""
+    upload_port = ctx.upload_port
+    assert upload_port is not None
+    serial_iface = ctx.serial_iface
+
+    print()
+    print("=" * 60)
+    print("IEEE754 CODEC TEST MODE")
+    print("=" * 60)
+    print()
+
+    client: RpcClient | None = None
+    try:
+        print("   Connecting to device...", end="", flush=True)
+        client = RpcClient(upload_port, timeout=30.0, serial_interface=serial_iface)
+        await client.connect(boot_wait=1.0, drain_boot=True)
+        print(f" {Fore.GREEN}ok{Style.RESET_ALL}")
+
+        print("   Sending ieee754CodecTest RPC...", end="", flush=True)
+        response = await client.send_and_match(
+            "ieee754CodecTest", match_key="success", retries=3
+        )
+        print(f" {Fore.GREEN}ok{Style.RESET_ALL}")
+        print()
+
+        data = response.data
+        tests_run = int(data.get("tests_run", 0))
+        tests_failed = int(data.get("tests_failed", 0))
+        first_failure = str(data.get("first_failure", ""))
+        expected_bits = int(data.get("expected_bits", 0))
+        actual_bits = int(data.get("actual_bits", 0))
+
+        print(json.dumps(data, indent=2))
+        print()
+
+        if data.get("success", False) and tests_failed == 0 and tests_run > 0:
+            print(f"{Fore.GREEN}IEEE754 CODEC TEST PASSED ({tests_run} checks){Style.RESET_ALL}")
+            return 0
+
+        print(
+            f"{Fore.RED}IEEE754 CODEC TEST FAILED"
+            f" ({tests_failed}/{tests_run} failures){Style.RESET_ALL}"
+        )
+        if first_failure:
+            print(
+                f"   first_failure={first_failure} "
+                f"expected=0x{expected_bits:08x} actual=0x{actual_bits:08x}"
+            )
+        return 1
+
+    except RpcTimeoutError:
+        print()
+        print(f"{Fore.RED}IEEE754 CODEC TEST TIMEOUT{Style.RESET_ALL}")
+        print("   No response from device within 30 seconds")
+        return 1
+    except KeyboardInterrupt as ki:
+        handle_keyboard_interrupt(ki)
+        raise
+    except Exception as e:
+        print()
+        print(f"{Fore.RED}IEEE754 CODEC TEST ERROR: {e}{Style.RESET_ALL}")
         return 1
     finally:
         if client is not None:

--- a/ci/tests/test_autoresearch_phases.py
+++ b/ci/tests/test_autoresearch_phases.py
@@ -20,6 +20,7 @@ from ci.autoresearch.args import Args
 from ci.autoresearch.build_driver import BuildDriver
 from ci.autoresearch.context import QuietContext, RunContext
 from ci.autoresearch.phases import (
+    _build_environment_for_mode,
     _parse_args_and_build_commands,
     _resolve_port_and_environment,
     _run_build_deploy,
@@ -55,6 +56,7 @@ def _make_args(**overrides) -> Args:
         all=False,
         simd=False,
         coroutine=False,
+        ieee754=False,
         wave2d_perf=None,
         environment=None,
         verbose=False,
@@ -135,6 +137,7 @@ def _make_ctx(**overrides) -> RunContext:
         build_dir=Path("/fake/project"),
         simd_test_mode=False,
         coroutine_test_mode=False,
+        ieee754_test_mode=False,
         wave2d_perf_grid=None,
         net_server_mode=False,
         net_client_mode=False,
@@ -579,6 +582,26 @@ class TestRunBuildDeploy:
             rc = asyncio.run(_run_build_deploy(ctx, qctx))
         assert rc == 1
 
+    def test_lpc_ieee754_uses_dedicated_build_environment(self) -> None:
+        mock_driver = _make_mock_driver()
+        ctx = _make_ctx(
+            args=_make_args(skip_lint=True, ieee754=True),
+            build_driver=mock_driver,
+            final_environment="lpc845brk",
+            ieee754_test_mode=True,
+        )
+        qctx = QuietContext(quiet=False)
+        with patch(f"{_PATCH_MOD}._build_and_flash_nxplpc", return_value=True) as flash:
+            rc = asyncio.run(_run_build_deploy(ctx, qctx))
+        assert rc is None
+        assert _build_environment_for_mode(ctx) == "lpc845brk_ieee754"
+        mock_driver.install_packages.assert_called_once_with(
+            Path("/fake/project"), "lpc845brk_ieee754"
+        )
+        flash.assert_called_once()
+        assert flash.call_args.kwargs["environment"] == "lpc845brk_ieee754"
+        mock_driver.deploy.assert_not_called()
+
 
 # ============================================================
 # Tests: _run_schema_and_pin_setup
@@ -633,6 +656,23 @@ class TestRunSchemaAndPinSetup:
         assert rc is None
         assert ctx.effective_tx_pin is None
         assert ctx.effective_rx_pin is None
+
+    def test_lpc_fbuild_uses_pyserial_for_rpc(self) -> None:
+        args = _make_args(skip_schema=True)
+        ctx = _make_ctx(
+            args=args,
+            final_environment="lpc845brk",
+            use_fbuild=True,
+        )
+        mock_serial = MagicMock()
+        with patch(
+            "ci.util.serial_interface.create_serial_interface",
+            return_value=mock_serial,
+        ) as create_serial:
+            rc = asyncio.run(_run_schema_and_pin_setup(ctx))
+        assert rc is None
+        assert ctx.serial_iface is mock_serial
+        create_serial.assert_called_once_with(port="COM5", use_pyserial=True)
 
     def test_auto_discover_pins_success(self) -> None:
         args = _make_args(auto_discover_pins=True, skip_schema=True)

--- a/examples/AutoResearch/AutoResearchIeee754.h
+++ b/examples/AutoResearch/AutoResearchIeee754.h
@@ -1,0 +1,141 @@
+/// @file AutoResearchIeee754.h
+/// @brief On-device verification for the integer-only IEEE 754 decimal codec.
+
+#pragma once
+
+#include "fl/stl/ieee754_string.h"
+#include "fl/stl/int.h"
+#include "fl/stl/string.h"
+#include "fl/stl/cstring.h"
+
+namespace autoresearch {
+namespace ieee754_check {
+
+struct Result {
+    bool success;
+    fl::u32 tests_run;
+    fl::u32 tests_failed;
+    const char* first_failure;
+    fl::u32 expected_bits;
+    fl::u32 actual_bits;
+};
+
+struct ParseCase {
+    const char* text;
+    fl::u32 expected_bits;
+    bool exact;
+};
+
+struct FormatCase {
+    fl::u32 bits;
+    int precision;
+    const char* expected_text;
+};
+
+inline fl::u32 absDiff(fl::u32 a, fl::u32 b) FL_NOEXCEPT {
+    return a > b ? a - b : b - a;
+}
+
+inline bool withinOneUlp(fl::u32 actual, fl::u32 expected) FL_NOEXCEPT {
+    if (actual == expected) {
+        return true;
+    }
+    if ((actual & 0x80000000u) != (expected & 0x80000000u)) {
+        return false;
+    }
+    return absDiff(actual, expected) <= 1u;
+}
+
+inline void recordCheck(Result& r, const char* name, bool passed,
+                        fl::u32 expected = 0, fl::u32 actual = 0) FL_NOEXCEPT {
+    ++r.tests_run;
+    if (passed) {
+        return;
+    }
+    ++r.tests_failed;
+    if (r.first_failure == nullptr) {
+        r.first_failure = name;
+        r.expected_bits = expected;
+        r.actual_bits = actual;
+    }
+}
+
+inline Result run() {
+    Result r{};
+    r.success = true;
+    r.first_failure = nullptr;
+
+    static const ParseCase kParseCases[] = {
+        {"0", 0x00000000u, true},
+        {"-0", 0x80000000u, true},
+        {"1", 0x3F800000u, true},
+        {"-1", 0xBF800000u, true},
+        {"0.5", 0x3F000000u, true},
+        {"2.5", 0x40200000u, true},
+        {"3.14159", 0x40490FD0u, false},
+        {"2.71828", 0x402DF84Du, false},
+        {"100", 0x42C80000u, true},
+        {"1000", 0x447A0000u, true},
+        {"1e30", 0x7149F2CAu, false},
+        {"1e-30", 0x0DA24260u, false},
+        {"1e-40", 0x00000000u, true},
+        {"1e40", 0x7F800000u, true},
+        {"-1e40", 0xFF800000u, true},
+    };
+
+    for (fl::size i = 0; i < sizeof(kParseCases) / sizeof(kParseCases[0]); ++i) {
+        const ParseCase& c = kParseCases[i];
+        fl::size consumed = 0;
+        const fl::u32 actual =
+            fl::ieee754_parse_decimal(c.text, fl::strlen(c.text), &consumed);
+        const bool value_ok = c.exact
+            ? actual == c.expected_bits
+            : withinOneUlp(actual, c.expected_bits);
+        recordCheck(r, c.text, value_ok && consumed == fl::strlen(c.text),
+                    c.expected_bits, actual);
+    }
+
+    static const FormatCase kFormatCases[] = {
+        {0x00000000u, 6, "0.000000"},
+        {0x80000000u, 6, "-0.000000"},
+        {0x3F800000u, 6, "1.000000"},
+        {0xBF800000u, 6, "-1.000000"},
+        {0x3F000000u, 6, "0.500000"},
+        {0x41200000u, 2, "10.00"},
+        {0x7F800000u, 6, "inf"},
+        {0xFF800000u, 6, "-inf"},
+        {0x7FC00000u, 6, "nan"},
+    };
+
+    for (fl::size i = 0; i < sizeof(kFormatCases) / sizeof(kFormatCases[0]); ++i) {
+        const FormatCase& c = kFormatCases[i];
+        const fl::string actual = fl::ieee754_format_decimal(c.bits, c.precision);
+        recordCheck(r, c.expected_text, actual == c.expected_text,
+                    c.bits, c.bits);
+    }
+
+    static const fl::u32 kRoundTripBits[] = {
+        0x00000000u, 0x80000000u, 0x3F800000u, 0xBF800000u,
+        0x3F000000u, 0x40200000u, 0x40490FDBu, 0x40B00000u,
+        0x42C80000u, 0x447A0000u,
+    };
+
+    for (fl::size i = 0; i < sizeof(kRoundTripBits) / sizeof(kRoundTripBits[0]); ++i) {
+        const fl::u32 expected = kRoundTripBits[i];
+        const fl::string text = fl::ieee754_format_decimal(expected, 9);
+        const fl::u32 actual =
+            fl::ieee754_parse_decimal(text.c_str(), text.size());
+        recordCheck(r, "roundtrip", withinOneUlp(actual, expected),
+                    expected, actual);
+    }
+
+    fl::size consumed = 123u;
+    (void)fl::ieee754_parse_decimal("nan", 3, &consumed);
+    recordCheck(r, "nan-reject", consumed == 0u, 0u, static_cast<fl::u32>(consumed));
+
+    r.success = r.tests_failed == 0u;
+    return r;
+}
+
+} // namespace ieee754_check
+} // namespace autoresearch

--- a/examples/AutoResearch/AutoResearchLowMemory.h
+++ b/examples/AutoResearch/AutoResearchLowMemory.h
@@ -31,18 +31,26 @@
 #define RELEASE 1
 #endif
 
+// Dedicated #3039 codec-test builds keep the low-memory surface to echo +
+// IEEE754 only. The SCT/WS2812 handlers are useful diagnostics, but they are
+// unrelated to the codec and push LPC845 past its flash budget when combined.
+#if defined(FL_AUTORESEARCH_IEEE754) && FL_AUTORESEARCH_IEEE754
+#define FASTLED_AUTORESEARCH_IEEE754_MODE 1
+#endif
+
 // Opt in to the SCT input-capture RX backend (FastLED #3021). With this
 // flag set, `LpcSctRxChannel::begin()` programs the SCT for hardware
 // edge-capture; without it the driver is a no-op stub (host tests still
 // work via `injectEdges()`).
+#if !defined(FASTLED_AUTORESEARCH_IEEE754_MODE)
 #ifndef FASTLED_LPC_RX_SCT
 #define FASTLED_LPC_RX_SCT 1
 #endif
+#endif
 
-// The LPC845-BRK low-memory build now fits FastLED + Remote + the WS2812
-// loopback RPC. Derive that surface from the platform instead of requiring a
-// user-set build flag.
-#if defined(FL_IS_ARM_LPC_845)
+// The LPC845-BRK low-memory build fits FastLED + Remote + the WS2812 loopback
+// RPC in normal mode. The dedicated IEEE754 mode deliberately omits it.
+#if defined(FL_IS_ARM_LPC_845) && !defined(FASTLED_AUTORESEARCH_IEEE754_MODE)
 #define FASTLED_AUTORESEARCH_LPC_WS2812 1
 #endif
 
@@ -58,12 +66,16 @@
 #include "fl/log/log.h"
 #include "fl/stl/cstdio.h"  // fl::serial_begin -- HWCDC-safe Serial.begin wrapper
 
+#if defined(FASTLED_AUTORESEARCH_IEEE754_MODE)
+#include "AutoResearchIeee754.h"
+#endif
+
 // The host-stub example DLL build (`tests/shared/example_dll_wrapper_template.cpp`)
 // compiles this sketch on Linux to surface ABI breaks. The RX SCT driver
 // types are platform-gated behind `FL_IS_ARM_LPC` -- they only exist on
 // the real LPC build. So the include + every RX usage below must be gated
 // the same way.
-#if defined(FL_IS_ARM_LPC)
+#if defined(FL_IS_ARM_LPC) && !defined(FASTLED_AUTORESEARCH_IEEE754_MODE)
 #include "fl/channels/rx_sct_capture.h"
 #include "fl/stl/strstream.h"
 #endif
@@ -76,7 +88,7 @@
 namespace {
 fl::Remote* g_low_memory_remote = nullptr;
 
-#if defined(FL_IS_ARM_LPC)
+#if defined(FL_IS_ARM_LPC) && !defined(FASTLED_AUTORESEARCH_IEEE754_MODE)
 // Period-stat helpers for `pinToggleRx`. Mirrors the FlexIO RX benchmark
 // logic in `examples/AutoResearch/AutoResearchRemote.cpp::flexioRxBenchmark`
 // but inline so we don't pull in the AutoResearch ObjectFLED bus.
@@ -120,7 +132,7 @@ inline LowMemPinTogglePeriodStats computeLowMemPeriodStats(
     s.max_ns   = max_ns;
     return s;
 }
-#endif  // FL_IS_ARM_LPC
+#endif  // FL_IS_ARM_LPC && !FASTLED_AUTORESEARCH_IEEE754_MODE
 
 }  // namespace
 
@@ -148,7 +160,22 @@ inline void autoResearchLowMemorySetup() {
         return v;
     });
 
-#if defined(FL_IS_ARM_LPC)
+#if defined(FASTLED_AUTORESEARCH_IEEE754_MODE)
+    remote.bind("ieee754CodecTest", [](const fl::json& args) -> fl::json {
+        (void)args;
+        const auto r = autoresearch::ieee754_check::run();
+        fl::json response = fl::json::object();
+        response.set("success", r.success);
+        response.set("tests_run", static_cast<int64_t>(r.tests_run));
+        response.set("tests_failed", static_cast<int64_t>(r.tests_failed));
+        response.set("first_failure", r.first_failure ? r.first_failure : "");
+        response.set("expected_bits", static_cast<int64_t>(r.expected_bits));
+        response.set("actual_bits", static_cast<int64_t>(r.actual_bits));
+        return response;
+    });
+#endif
+
+#if defined(FL_IS_ARM_LPC) && !defined(FASTLED_AUTORESEARCH_IEEE754_MODE)
     // pinToggleRx (FastLED #3021 Phase 1) — bit-bang square wave on tx_pin
     // and capture SCT edges on rx_pin. CSV stats out.
     remote.bind("pinToggleRx",
@@ -320,7 +347,7 @@ inline void autoResearchLowMemorySetup() {
             return s.str();
         });
 #endif  // FASTLED_AUTORESEARCH_LPC_WS2812
-#endif  // FL_IS_ARM_LPC
+#endif  // FL_IS_ARM_LPC && !FASTLED_AUTORESEARCH_IEEE754_MODE
 }
 
 inline void autoResearchLowMemoryLoop() {

--- a/examples/AutoResearch/AutoResearchRemoteMathMethods.cpp
+++ b/examples/AutoResearch/AutoResearchRemoteMathMethods.cpp
@@ -39,6 +39,7 @@
 #include "AutoResearchParlioEncode.h"
 #include "AutoResearchTimingDrift.h"
 #include "AutoResearchParlioStream.h"
+#include "AutoResearchIeee754.h"
 #include "fl/chipsets/spi.h"
 #include "fl/channels/config.h"
 #include <Arduino.h>
@@ -212,6 +213,21 @@ void AutoResearchRemoteControl::bindMathMethods(fl::Remote& remote) {
         response.set("transpose16_nibble_us", static_cast<int64_t>(r.transpose16_nibble_us));
         response.set("transpose16_byte_us", static_cast<int64_t>(r.transpose16_byte_us));
         response.set("sink", static_cast<int64_t>(r.sink));
+        return response;
+    });
+
+    // Register "ieee754CodecTest" - on-device integer IEEE 754 decimal codec
+    // verification for #3039. No strtof/libm reference is used by the test.
+    remote.bind("ieee754CodecTest", [](const fl::json& args) -> fl::json {
+        (void)args;
+        const auto r = autoresearch::ieee754_check::run();
+        fl::json response = fl::json::object();
+        response.set("success", r.success);
+        response.set("tests_run", static_cast<int64_t>(r.tests_run));
+        response.set("tests_failed", static_cast<int64_t>(r.tests_failed));
+        response.set("first_failure", r.first_failure ? r.first_failure : "");
+        response.set("expected_bits", static_cast<int64_t>(r.expected_bits));
+        response.set("actual_bits", static_cast<int64_t>(r.actual_bits));
         return response;
     });
 

--- a/examples/AutoResearch/AutoResearchRemotePinMethods.cpp
+++ b/examples/AutoResearch/AutoResearchRemotePinMethods.cpp
@@ -565,6 +565,14 @@ void AutoResearchRemoteControl::bindPinMethods(fl::Remote& remote) {
         wave8ExpandBenchmark_fn.set("description", "Bench PARLIO Wave8 expansion (#2526): nibble vs byte vs batched LUT, plus full per-byte-position cost (expansion + 16-lane transpose)");
         functions.push_back(wave8ExpandBenchmark_fn);
 
+        fl::json ieee754CodecTest_fn = fl::json::object();
+        ieee754CodecTest_fn.set("name", "ieee754CodecTest");
+        ieee754CodecTest_fn.set("phase", "Phase 4: Utility");
+        ieee754CodecTest_fn.set("args", "[]");
+        ieee754CodecTest_fn.set("returns", "{success, tests_run, tests_failed, first_failure, expected_bits, actual_bits}");
+        ieee754CodecTest_fn.set("description", "On-device verification of the integer-only IEEE 754 decimal codec (#3039): parse, format, round-trip, overflow/underflow, and NaN rejection without strtof/libm.");
+        functions.push_back(ieee754CodecTest_fn);
+
         fl::json parlioEncodeBenchmark_fn = fl::json::object();
         parlioEncodeBenchmark_fn.set("name", "parlioEncodeBenchmark");
         parlioEncodeBenchmark_fn.set("phase", "Phase 4: Utility");

--- a/platformio.ini
+++ b/platformio.ini
@@ -175,6 +175,16 @@ build_flags =
     -DFASTLED_LPC_PWM_DMA=1
     -DFASTLED_AUTORESEARCH_LOW_MEMORY=1
 
+[env:lpc845brk_ieee754]
+; Dedicated AutoResearch IEEE754 codec surface for FastLED #3039. This keeps
+; the default LPC845-BRK low-memory RPC surface size-neutral while letting
+; `bash autoresearch lpc845brk --ieee754` build a firmware that binds only the
+; echo and ieee754CodecTest RPCs.
+extends = env:lpc845brk
+build_flags =
+    ${env:lpc845brk.build_flags}
+    -DFL_AUTORESEARCH_IEEE754=1
+
 ; --------------------------------------------------------------------------
 ; LPC8xx canary envs (FastLED #2990 — fbuild Stage 6 canary).
 ;


### PR DESCRIPTION
## Summary
- add an AutoResearch `--ieee754` mode for on-device integer IEEE 754 decimal codec verification (#3039)
- add a dedicated `lpc845brk_ieee754` low-memory build surface so default LPC AutoResearch stays under flash budget
- use pyserial for LPC RPC after the pyocd flash path and expose the `ieee754CodecTest` RPC in full and low-memory AutoResearch

Fixes #3039

## Validation
- `uv run pytest ci/tests/test_autoresearch_phases.py` (50 passed)
- `bash test --cpp tests/fl/stl/ieee754_string.cpp` (passed, cached on final run)
- `bash compile lpc845brk --examples AutoResearch --backend fbuild` (default firmware 62.47KB / 64KB)
- `bash autoresearch lpc845brk --ieee754 --upload-port COM10 --skip-lint --skip-schema` (hardware passed: 35 checks, 0 failures; IEEE754 firmware 59.36KB / 64KB)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--ieee754` execution mode to autoresearch for running on-device integer IEEE 754 decimal codec verification, including parsing, formatting, and round-trip testing. Supported on lpc845brk target.

* **Chores**
  * Added new PlatformIO build environment configuration for IEEE754 testing support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->