### PR TITLE
docs(flexio-rx): document iMXRT FlexIO architectural mismatch (#3066 iter 9)

### DIFF
--- a/src/platforms/arm/teensy/teensy4_common/rx_flexio_channel.cpp.hpp
+++ b/src/platforms/arm/teensy/teensy4_common/rx_flexio_channel.cpp.hpp
@@ -2,7 +2,7 @@
 /// @brief Teensy 4.x FlexIO shifter-based RX implementation
 ///
 /// ============================================================================
-/// ⚠️  STATUS: ARCHITECTURALLY BLOCKED — DO NOT TWIST KNOBS HERE (#3066 iter 9)
+/// WARNING: ARCHITECTURALLY BLOCKED — DO NOT TWIST KNOBS HERE (#3066 iter 9)
 /// ============================================================================
 ///
 /// This driver tries to capture WS281x-style pulse-width data from an LED

--- a/src/platforms/arm/teensy/teensy4_common/rx_flexio_channel.cpp.hpp
+++ b/src/platforms/arm/teensy/teensy4_common/rx_flexio_channel.cpp.hpp
@@ -1,6 +1,46 @@
 ﻿/// @file rx_flexio_channel.cpp.hpp
 /// @brief Teensy 4.x FlexIO shifter-based RX implementation
 ///
+/// ============================================================================
+/// ⚠️  STATUS: ARCHITECTURALLY BLOCKED — DO NOT TWIST KNOBS HERE (#3066 iter 9)
+/// ============================================================================
+///
+/// This driver tries to capture WS281x-style pulse-width data from an LED
+/// strip's data line by latching a FlexIO timer's count into the shifter on
+/// every pin edge. **That use case is not supported by the iMXRT1062 FlexIO
+/// silicon.** SMOD=1 (Receive mode) and SMOD=3/4 (Match Store / Match
+/// Continuous) all shift the *pin value* into the shifter; the timer
+/// dictates *when* to shift, not *what* to shift. There is no SMOD that
+/// snapshots a peer timer's count into SHIFTBUF.
+///
+/// Further, per NXP's own FlexIO documentation, "shift registers cannot
+/// shift and store on the same clock, so input data may be lost" — which
+/// means the single-timer SMOD=1 + TIMOD=3 design pattern below collides
+/// the shift and the SHIFTBUF-store on the same compare event, producing
+/// the all-zero captures that PRs #3067 / #3068 / #3069 / #3070 / #3071
+/// chased without success.
+///
+/// **Recommended path forward:** use FlexPWM RX (`rx_flexpwm_channel.cpp.hpp`)
+/// which has dedicated `SMx_CAPTCTRL` input-capture silicon. The current
+/// blocker on the FlexPWM path is the bimodal-edge bug tracked as Phase 4
+/// of the #3066 ledger (FIFO watermark / merging) — a smaller surface area
+/// than continuing to fight FlexIO's architectural limit.
+///
+/// **Iter-9 (2026-06-18) cross-check** against NXP AN12174 / AN5275, the
+/// FTF-ACC-F1179 *Introduction to FlexIO* deck, and the NXP Community
+/// thread *"FlexIO not working in Match Continuous Mode"* documented the
+/// architectural mismatch in detail. See `#3066` issue comment
+/// `4740201201` for the full register-by-register analysis.
+///
+/// Until someone with NXP application-engineering contacts can clarify
+/// whether there's a canonical iMXRT FlexIO pattern for true input
+/// capture (latching a timer's count on a pin edge), this file should
+/// remain frozen as research code.
+///
+/// ============================================================================
+/// Original design intent (preserved for historical context):
+/// ============================================================================
+///
 /// **Phase 1B** of FastLED#2764 â€” replaces the Phase 1A skeleton with real
 /// FLEXIO1 register programming, IOMUXC pin muxing, and an eDMA-driven
 /// capture pipeline that mirrors the FlexIO TX driver's structure but in


### PR DESCRIPTION
## Summary

Adds a top-of-file warning block to `src/platforms/arm/teensy/teensy4_common/rx_flexio_channel.cpp.hpp` that captures the root-cause finding from [#3066 iter 9](https://github.com/FastLED/FastLED/issues/3066#issuecomment-4740201201):

- iMXRT1062 FlexIO shifters can't snapshot a peer timer's count into `SHIFTBUF` — `SMOD=1/3/4` all shift the *pin value*, not a timer count.
- Per NXP's own docs (Match Continuous community thread), *"shift registers cannot shift and store on the same clock, so input data may be lost"* — which is exactly what `SMOD=1 + TIMOD=3` does on a single compare event.
- This explains the all-zero captures that PRs #3067 / #3068 / #3069 / #3070 / #3071 chased without success and the loop's pause at the 5-PR cap.

## Why a doc-only PR

The loop ledger explicitly paused this driver at the 5-PR cap pending bench-scope debug or a structural pivot. Iter 9 (research-only, no code) cross-checked against NXP AN12174 / AN5275, the FTF-ACC-F1179 *Introduction to FlexIO* deck, and the NXP Community threads, and concluded the path forward is FlexPWM RX (Phase 4 of #3066) instead — FlexPWM has dedicated `SMx_CAPTCTRL` input-capture silicon that FlexIO lacks.

Without this header, the next iteration (human or agent) will likely re-tread the same single-timer SMOD=1 path the prior five PRs already exhausted.

## Changes

- `src/platforms/arm/teensy/teensy4_common/rx_flexio_channel.cpp.hpp` — 40 lines of new doc-block; preserves the original design-intent comment for historical context. No code change.

## Test plan

- [x] `bash compile teensy40 --examples AutoResearch` succeeds (1m55s).
- [ ] Bench validation N/A — pure comment change.

## Related

- #3066 — Teensy 4 driver bringup ledger (active comment thread).
- #3066 / [iter-9 cross-check](https://github.com/FastLED/FastLED/issues/3066#issuecomment-4740201201) — the source material for the warning block.
- Phase 4 of #3066 — recommended pivot to FlexPWM-RX bimodal-edge fix as the next active blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded Teensy 4 platform documentation to clearly describe an architectural limitation affecting FlexIO RX shifter-based captures, including the root cause, observed symptoms, and recommended migration to the FlexPWM RX backend. The update also preserves historical design context and adds a recent cross-check note to support ongoing maintenance and future development.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->