### PR TITLE
feat(flexpwm-rx): enable Phase 4 raw-capture dumps by default (#3066)

### DIFF
--- a/src/platforms/arm/teensy/teensy4_common/rx_flexpwm_channel.cpp.hpp
+++ b/src/platforms/arm/teensy/teensy4_common/rx_flexpwm_channel.cpp.hpp
@@ -24,6 +24,22 @@
 
 #if defined(FL_IS_TEENSY_4X)
 
+// FastLED #3066 Phase 4 sub-task 2: enable the per-frame raw-capture dumps
+// in this file by default. These FL_DEBUG-gated FL_WARN_F sites surface the
+// bimodal-edge symptom (940/640 ns HIGH, 286/586 ns LOW from an OBJECT_FLED
+// frame) over the serial RPC link so bench operators can characterise the
+// FIFO-watermark / merging hypothesis without rebuilding.
+//
+// Users who need silent FlexPWM RX can `#define FL_RX_FLEXPWM_QUIET 1`
+// upstream of this include — that path #undef's FL_DEBUG so the production
+// fast path is unchanged.
+#ifndef FL_RX_FLEXPWM_QUIET
+#ifndef FL_DEBUG
+#define FL_DEBUG 1
+#define FL_DEBUG_DEFINED_BY_RX_FLEXPWM 1
+#endif
+#endif
+
 #define FASTLED_INTERNAL
 #include "fl/system/fastled.h"
 #include "platforms/arm/teensy/teensy4_common/rx_flexpwm_channel.h"
@@ -497,7 +513,7 @@ void FlexPwmRxChannelImpl::configureDma() {
 #ifdef FL_DEBUG
     // Debug: dump DMA channel and DMAMUX state
     volatile u32 *dmamux_reg = &DMAMUX_CHCFG0 + mDma.channel;
-    uintptr_t dma_daddr = mDma.TCD->DADDR; // ok reading register
+    uintptr_t dma_daddr = reinterpret_cast<uintptr_t>(const_cast<void*>(mDma.TCD->DADDR)); // ok reinterpret cast - reading register
     uintptr_t buf_addr = reinterpret_cast<uintptr_t>(mCaptureBuffer.data()); // ok reinterpret cast
     FL_WARN_F("[FlexPWM DMA] ch=%s src=%d DMAMUX=0x%x CITER=%d ERQ=%d DADDR_match=%s",
               mDma.channel, static_cast<int>(mPinInfo->dma_source),
@@ -744,5 +760,10 @@ fl::shared_ptr<FlexPwmRxChannel> FlexPwmRxChannel::create(int pin) {
 }
 
 } // namespace fl
+
+#ifdef FL_DEBUG_DEFINED_BY_RX_FLEXPWM
+#undef FL_DEBUG_DEFINED_BY_RX_FLEXPWM
+#undef FL_DEBUG
+#endif
 
 #endif // FL_IS_TEENSY_4X


### PR DESCRIPTION
## Summary

Concrete step on Phase 4 of the [#3066 ledger](https://github.com/FastLED/FastLED/issues/3066): the FlexPWM RX driver's `FL_DEBUG`-gated dumps have been written but never visible to bench operators because `FL_DEBUG` was never set on production builds. This change file-locally enables them by default — exactly what Phase 4 sub-task 2 asks for.

## Why this matters

The [iter-9 cross-check](https://github.com/FastLED/FastLED/issues/3066#issuecomment-4740201201) recommended pivoting from FlexIO RX (architecturally blocked per NXP docs) to FlexPWM RX (has dedicated input-capture silicon). FlexPWM RX captures non-zero data today; the open question is whether the bimodal pulse widths (940/640 ns HIGH, 286/586 ns LOW) come from a FIFO-watermark / merging bug or DMA dropping requests. Without visibility into `mCaptureBuffer[0..7]` and `CITER`/`BITER` deltas on a per-frame basis, nobody can answer that question on the bench.

## Changes

- `src/platforms/arm/teensy/teensy4_common/rx_flexpwm_channel.cpp.hpp`:
  - Top: `#define FL_DEBUG 1` (guarded by `#ifndef FL_DEBUG` so upstream `-DFL_DEBUG=1` users aren't affected).
  - Bottom: `#undef FL_DEBUG` (only if this file set it) so the macro doesn't leak into other TUs.
  - New `FL_RX_FLEXPWM_QUIET` escape hatch for users who want a silent FlexPWM RX.
  - Latent compile fix at line 516: `mDma.TCD->DADDR` is `volatile void*` and needed an explicit `reinterpret_cast<uintptr_t>(const_cast<void*>(...))` — the error was hidden by `FL_DEBUG` being off.

## Test plan

- [x] `bash compile teensy40 --examples AutoResearch` succeeds (1m25s).
- [x] `bash lint --cpp` clean (only pre-existing warn-only #2701).
- [ ] Live bench: flash → run `bash autoresearch teensy40 --object-fled` and observe `[FlexPWM RAW]` / `[FlexPWM DMA]` / `[FlexPWM DECODE]` lines on the serial RPC stream. (next bench iteration)

## Related

- [#3066](https://github.com/FastLED/FastLED/issues/3066) Phase 4 sub-task 2 ("Enable `#define FL_DEBUG` in `rx_flexpwm_channel.cpp.hpp` and dump the raw u16 capture buffer values").
- [#3066 comment 4740201201](https://github.com/FastLED/FastLED/issues/3066#issuecomment-4740201201) — iter-9 NXP cross-check recommending the FlexPWM-RX pivot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced internal debugging capabilities for ARM Teensy 4 hardware PWM capture functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->