### PR TITLE
Fix LPC AutoResearch SCT RX setup

### DIFF
--- a/ci/autoresearch/args.py
+++ b/ci/autoresearch/args.py
@@ -361,7 +361,7 @@ See Also:
             action="store_true",
             help="LPC845-only: bit-bang TX → SCT-RX pin-toggle loopback "
             "(closes Phase 1 of FastLED #3021). Requires a jumper from "
-            "--tx-pin (default P0_10) to --rx-pin (default P0_11).",
+            "--tx-pin (default P0_14) to --rx-pin (default P0_15).",
         )
         lpc_group.add_argument(
             "--ws2812-loopback",

--- a/ci/autoresearch/build_driver.py
+++ b/ci/autoresearch/build_driver.py
@@ -7,6 +7,40 @@ from pathlib import Path
 from typing import IO, Protocol, runtime_checkable
 
 
+def fbuild_firmware_path_candidates(build_dir: Path, environment: str) -> list[Path]:
+    """Return known fbuild firmware.bin artifact locations for a project."""
+    return [
+        build_dir / ".fbuild" / "build" / "release" / "firmware.bin",
+        build_dir / ".fbuild" / "build" / environment / "release" / "firmware.bin",
+        build_dir
+        / ".build"
+        / "pio"
+        / environment
+        / ".fbuild"
+        / "build"
+        / "release"
+        / "firmware.bin",
+        build_dir
+        / ".build"
+        / "pio"
+        / environment
+        / ".fbuild"
+        / "build"
+        / environment
+        / "release"
+        / "firmware.bin",
+    ]
+
+
+def find_fbuild_firmware_path(build_dir: Path, environment: str) -> Path:
+    """Return the existing fbuild firmware.bin path, or the primary candidate."""
+    candidates = fbuild_firmware_path_candidates(build_dir, environment)
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate
+    return candidates[0]
+
+
 @runtime_checkable
 class BuildDriver(Protocol):
     """Abstract build system driver for compile + deploy.
@@ -80,7 +114,7 @@ class FbuildDriver:
         )
 
     def firmware_path(self, build_dir: Path, environment: str) -> Path:
-        return build_dir / ".fbuild" / "build" / environment / "firmware.bin"
+        return find_fbuild_firmware_path(build_dir, environment)
 
 
 class PlatformIODriver:

--- a/ci/autoresearch/phases.py
+++ b/ci/autoresearch/phases.py
@@ -18,7 +18,10 @@ from typing import TYPE_CHECKING, Any
 from colorama import Fore, Style
 
 from ci.autoresearch.args import Args
-from ci.autoresearch.build_driver import select_build_driver
+from ci.autoresearch.build_driver import (
+    find_fbuild_firmware_path,
+    select_build_driver,
+)
 from ci.autoresearch.context import (
     DEFAULT_EXPECT_PATTERNS,
     DEFAULT_FAIL_ON_PATTERN,
@@ -67,6 +70,8 @@ LPC_WS2812_ENVS = {"lpc845brk", "lpc845", "lpcxpresso845max"}
 LPC_IEEE754_BUILD_ENVS = {
     "lpc845brk": "lpc845brk_ieee754",
 }
+LPC_PIN_TOGGLE_DEFAULT_TX_PIN = 14
+LPC_PIN_TOGGLE_DEFAULT_RX_PIN = 15
 
 
 def _is_native_platform(environment: str | None) -> bool:
@@ -1838,14 +1843,7 @@ def _build_and_flash_nxplpc(
         )
         return False
 
-    firmware_bin = (
-        build_dir
-        / ".fbuild"
-        / "build"
-        / (environment or "lpc845brk")
-        / "release"
-        / "firmware.bin"
-    )
+    firmware_bin = find_fbuild_firmware_path(build_dir, environment or "lpc845brk")
     if not firmware_bin.is_file():
         print(f"{Fore.RED}❌ firmware.bin not found at {firmware_bin}{Style.RESET_ALL}")
         return False
@@ -2040,8 +2038,16 @@ async def _run_lpc_pin_toggle_rx_tests(ctx: RunContext) -> int:
     upload_port = ctx.upload_port
     assert upload_port is not None
 
-    tx_pin = ctx.args.tx_pin if ctx.args.tx_pin is not None else 10
-    rx_pin = ctx.args.rx_pin if ctx.args.rx_pin is not None else 11
+    tx_pin = (
+        ctx.args.tx_pin
+        if ctx.args.tx_pin is not None
+        else LPC_PIN_TOGGLE_DEFAULT_TX_PIN
+    )
+    rx_pin = (
+        ctx.args.rx_pin
+        if ctx.args.rx_pin is not None
+        else LPC_PIN_TOGGLE_DEFAULT_RX_PIN
+    )
 
     print()
     print("=" * 60)
@@ -2084,8 +2090,16 @@ async def _run_lpc_ws2812_loopback_tests(ctx: RunContext) -> int:
     upload_port = ctx.upload_port
     assert upload_port is not None
 
-    tx_pin = ctx.args.tx_pin if ctx.args.tx_pin is not None else 10
-    rx_pin = ctx.args.rx_pin if ctx.args.rx_pin is not None else 11
+    tx_pin = (
+        ctx.args.tx_pin
+        if ctx.args.tx_pin is not None
+        else LPC_PIN_TOGGLE_DEFAULT_TX_PIN
+    )
+    rx_pin = (
+        ctx.args.rx_pin
+        if ctx.args.rx_pin is not None
+        else LPC_PIN_TOGGLE_DEFAULT_RX_PIN
+    )
 
     print()
     print("=" * 60)

--- a/ci/autoresearch/test_lpc_pin_toggle_rx.py
+++ b/ci/autoresearch/test_lpc_pin_toggle_rx.py
@@ -168,16 +168,16 @@ def main() -> int:
     p.add_argument("--baud", default=DEFAULT_BAUD, type=int)
     p.add_argument(
         "--tx-pin",
-        default=10,
+        default=14,
         type=int,
-        help="LPC845 GPIO PIO0_n driven by bit-bang TX (default: P0_10)",
+        help="LPC845 GPIO PIO0_n driven by bit-bang TX (default: P0_14)",
     )
     p.add_argument(
         "--rx-pin",
-        default=11,
+        default=15,
         type=int,
         help="LPC845 GPIO PIO0_n routed to SCT input 0 for capture "
-        "(default: P0_11; any PIO0_n works via SWM)",
+        "(default: P0_15; any PIO0_n works via SWM)",
     )
     args = p.parse_args()
 

--- a/ci/autoresearch/test_lpc_ws2812_loopback.py
+++ b/ci/autoresearch/test_lpc_ws2812_loopback.py
@@ -166,16 +166,15 @@ def main() -> int:
     p.add_argument("--baud", default=DEFAULT_BAUD, type=int)
     p.add_argument(
         "--tx-pin",
-        default=10,
+        default=14,
         type=int,
-        help="LPC845 GPIO PIO0_n driven by bit-bang WS2812 TX (default: P0_10, "
-        "must match the compile-time constant in the sketch handler)",
+        help="LPC845 GPIO PIO0_n driven by bit-bang WS2812 TX (default: P0_14)",
     )
     p.add_argument(
         "--rx-pin",
-        default=11,
+        default=15,
         type=int,
-        help="LPC845 GPIO PIO0_n routed to SCT input 0 for capture (default: P0_11)",
+        help="LPC845 GPIO PIO0_n routed to SCT input 0 for capture (default: P0_15)",
     )
     p.add_argument(
         "--capture-ms",

--- a/ci/tests/test_autoresearch_phases.py
+++ b/ci/tests/test_autoresearch_phases.py
@@ -746,6 +746,48 @@ class TestRunTestsOrSpecialMode:
         assert rc == 0
         mock_ble.assert_called_once()
 
+    def test_lpc_pin_toggle_rx_defaults_to_normal_gpio_pair(self) -> None:
+        args = _make_args(parlio=False, pin_toggle_rx=True)
+        ctx = _make_ctx(args=args, final_environment="lpc845brk")
+        qctx = QuietContext(quiet=False)
+        completed = MagicMock(returncode=0)
+
+        with patch(f"{_PATCH_MOD}.subprocess.run", return_value=completed) as run:
+            rc = asyncio.run(_run_tests_or_special_mode(ctx, qctx))
+
+        assert rc == 0
+        cmd = run.call_args.args[0]
+        assert cmd[cmd.index("--tx-pin") + 1] == "14"
+        assert cmd[cmd.index("--rx-pin") + 1] == "15"
+
+    def test_lpc_pin_toggle_rx_cli_pins_override_defaults(self) -> None:
+        args = _make_args(parlio=False, pin_toggle_rx=True, tx_pin=8, rx_pin=9)
+        ctx = _make_ctx(args=args, final_environment="lpc845brk")
+        qctx = QuietContext(quiet=False)
+        completed = MagicMock(returncode=0)
+
+        with patch(f"{_PATCH_MOD}.subprocess.run", return_value=completed) as run:
+            rc = asyncio.run(_run_tests_or_special_mode(ctx, qctx))
+
+        assert rc == 0
+        cmd = run.call_args.args[0]
+        assert cmd[cmd.index("--tx-pin") + 1] == "8"
+        assert cmd[cmd.index("--rx-pin") + 1] == "9"
+
+    def test_lpc_ws2812_loopback_defaults_to_normal_gpio_pair(self) -> None:
+        args = _make_args(parlio=False, ws2812_loopback=True)
+        ctx = _make_ctx(args=args, final_environment="lpc845brk")
+        qctx = QuietContext(quiet=False)
+        completed = MagicMock(returncode=0)
+
+        with patch(f"{_PATCH_MOD}.subprocess.run", return_value=completed) as run:
+            rc = asyncio.run(_run_tests_or_special_mode(ctx, qctx))
+
+        assert rc == 0
+        cmd = run.call_args.args[0]
+        assert cmd[cmd.index("--tx-pin") + 1] == "14"
+        assert cmd[cmd.index("--rx-pin") + 1] == "15"
+
     def test_ota_mode_delegates(self) -> None:
         ctx = _make_ctx(ota_mode=True)
         qctx = QuietContext(quiet=False)

--- a/ci/tests/test_fbuild_default_selection.py
+++ b/ci/tests/test_fbuild_default_selection.py
@@ -5,7 +5,11 @@ from typing import Any
 import pytest
 
 from ci.autoresearch.args import Args
-from ci.autoresearch.build_driver import FbuildDriver, select_build_driver
+from ci.autoresearch.build_driver import (
+    FbuildDriver,
+    find_fbuild_firmware_path,
+    select_build_driver,
+)
 from ci.boards import Board
 from ci.compiler.compilation_orchestrator import compile_board_examples
 from ci.compiler.compiler import SketchResult
@@ -82,6 +86,37 @@ def test_autoresearch_fbuild_install_packages_does_not_call_platformio(
     )
 
     assert FbuildDriver().install_packages(Path("."), "esp32s3") is True
+
+
+def test_autoresearch_fbuild_firmware_path_points_to_release_dir() -> None:
+    """fbuild writes firmware.bin under the release artifact directory."""
+    assert FbuildDriver().firmware_path(Path("/project"), "lpc845brk") == (
+        Path("/project")
+        / ".fbuild"
+        / "build"
+        / "release"
+        / "firmware.bin"
+    )
+
+
+def test_find_fbuild_firmware_path_finds_staged_pio_artifact(
+    tmp_path: Path,
+) -> None:
+    """ci-compile stages fbuild artifacts below .build/pio/<env>."""
+    firmware = (
+        tmp_path
+        / ".build"
+        / "pio"
+        / "lpc845brk"
+        / ".fbuild"
+        / "build"
+        / "release"
+        / "firmware.bin"
+    )
+    firmware.parent.mkdir(parents=True)
+    firmware.write_bytes(b"firmware")
+
+    assert find_fbuild_firmware_path(tmp_path, "lpc845brk") == firmware
 
 
 def test_autoresearch_parse_args_warns_for_deprecated_fbuild_flags(

--- a/platformio.ini
+++ b/platformio.ini
@@ -165,6 +165,9 @@ extra_scripts = pre:ci/ci-flags.py
 ;                                    #2842 / #2850) in place of the bit-bang
 ;                                    default. Claims the SCT + 3 DMA channels
 ;                                    for the FastLED controller lifetime.
+;   -DFASTLED_LPC_RX_SCT=1        -- compiles the LPC SCT input-capture RX
+;                                    backend used by AutoResearch pin-toggle
+;                                    loopback validation.
 ; The WS2812 loopback RPC is now derived from the LPC845 platform predicate
 ; inside AutoResearchLowMemory.h; no user build flag is required.
 platform = https://github.com/zackees/platform-nxplpc-arduino.git#2ee527ae80de98e9105329a7260edb003289dfda
@@ -173,6 +176,7 @@ framework = arduino
 build_flags =
     -DRELEASE
     -DFASTLED_LPC_PWM_DMA=1
+    -DFASTLED_LPC_RX_SCT=1
     -DFASTLED_AUTORESEARCH_LOW_MEMORY=1
 
 [env:lpc845brk_ieee754]

--- a/src/platforms/arm/lpc/rx_sct_capture.cpp.hpp
+++ b/src/platforms/arm/lpc/rx_sct_capture.cpp.hpp
@@ -96,18 +96,32 @@ namespace {
 
 constexpr fl::u32 kSysconBase   = 0x40048000u;
 constexpr fl::u32 kSwmBase      = 0x4000C000u;
+constexpr fl::u32 kIoconBase    = 0x40044000u;
+constexpr fl::u32 kGpioBase     = 0xA0000000u;
 constexpr fl::u32 kInputMuxBase = 0x4002C000u;
 constexpr fl::u32 kSctBase      = 0x50004000u;
 constexpr fl::u32 kDmaBase      = 0x50008000u;
 
 constexpr fl::u32 kOffSYSAHBCLKCTRL0 = 0x080u;
+constexpr fl::u32 kOffSCTCLKSEL      = 0x06Cu;
+constexpr fl::u32 kOffSCTCLKDIV      = 0x070u;
 constexpr fl::u32 kOffPRESETCTRL0    = 0x088u;
 constexpr fl::u32 kClkSWM = (1u <<  7);
 constexpr fl::u32 kClkSCT = (1u <<  8);
+constexpr fl::u32 kClkIOCON = (1u << 18);
 constexpr fl::u32 kClkDMA = (1u << 29);
-constexpr fl::u32 kRstSWM = (1u <<  7);
 constexpr fl::u32 kRstSCT = (1u <<  8);
 constexpr fl::u32 kRstDMA = (1u << 29);
+
+constexpr fl::u32 kOffGpioDir = 0x2000u;
+constexpr fl::u32 kIoconModeMask = (0x3u << 3);
+constexpr fl::u32 kIoconModePullup = (0x2u << 3);
+constexpr fl::u32 kIoconInv = (1u << 6);
+constexpr fl::u32 kIoconSModeMask = (0x3u << 11);
+constexpr fl::u32 kOffSctInputMux0 = 0x020u;
+constexpr fl::u32 kSctInputMuxSctPin0 = 0x0u;
+constexpr fl::u32 kSctClkMain = 0x1u;
+constexpr fl::u32 kSctClkDiv1 = 0x1u;
 
 constexpr fl::u32 kOffPINASSIGN6 = 0x018u;
 constexpr fl::u32 kOffPINASSIGN7 = 0x01Cu;
@@ -204,9 +218,32 @@ inline fl::u32* sct_cap_addr(fl::u32 n) FL_NOEXCEPT {
 }
 inline volatile fl::u32& dma(fl::u32 offset) FL_NOEXCEPT { return reg(kDmaBase, offset); }
 
-// Assign or unassign the user's GPIO pin to SCT input 0 (SCT0_GPIO_IN_A_I)
-// via SWM PINASSIGN6 byte[31:24]. The byte value is the encoded pin number
-// (PIO0_n -> n; PIO1_n -> 0x20+n).
+inline fl::u32 ioconOffsetPio0(fl::u8 pin) FL_NOEXCEPT {
+    static const fl::u8 offsets[] = {
+        0x44u, 0x2Cu, 0x18u, 0x14u, 0x10u, 0x0Cu, 0x40u, 0x3Cu,
+        0x38u, 0x34u, 0x20u, 0x1Cu, 0x08u, 0x04u, 0x48u, 0x28u,
+        0x24u, 0x00u, 0x78u, 0x74u, 0x70u, 0x6Cu, 0x68u, 0x64u,
+        0x60u, 0x5Cu, 0x58u, 0x54u, 0x50u, 0xC8u, 0xCCu, 0x8Cu,
+    };
+    return (pin < sizeof(offsets)) ? offsets[pin] : 0xFFFFFFFFu;
+}
+
+inline void configureDigitalInput(fl::u8 pin) FL_NOEXCEPT {
+    // SCT input routing samples the pad path configured by IOCON. LPC84x
+    // IOCON registers are not ordered by pin number, and the Arduino core's
+    // direct PIO[n] indexing misses pins like P0_10/P0_11.
+    const fl::u32 offset = ioconOffsetPio0(pin);
+    if (offset != 0xFFFFFFFFu) {
+        reg(kIoconBase, offset) =
+            (reg(kIoconBase, offset) & ~(kIoconModeMask | kIoconInv | kIoconSModeMask))
+            | kIoconModePullup;
+    }
+    reg(kGpioBase, kOffGpioDir) &= ~(1u << pin);
+}
+
+// Assign or unassign the user's GPIO pin to SCT_PIN0 via SWM PINASSIGN6
+// byte[31:24]. The byte value is the encoded pin number (PIO0_n -> n;
+// PIO1_n -> 0x20+n).
 inline void swmAssignSctInput0(fl::u8 swm_byte) FL_NOEXCEPT {
     volatile fl::u32& r = reg(kSwmBase, kOffPINASSIGN6);
     fl::u32 v = r;
@@ -360,28 +397,35 @@ bool LpcSctRxChannel::begin(const RxConfig& config) FL_NOEXCEPT {
 #if defined(FASTLED_LPC_RX_SCT) && defined(FL_IS_ARM_LPC_845)
     // ---- 1. Power up SCT + SWM (and DMA when the DMA path is opted in),
     //         then pulse their resets. ----
-    reg(kSysconBase, kOffSYSAHBCLKCTRL0) |= (kClkSCT | kClkSWM
+    reg(kSysconBase, kOffSYSAHBCLKCTRL0) |= (kClkSCT | kClkSWM | kClkIOCON
 #if defined(FASTLED_LPC_RX_SCT_DMA)
         | kClkDMA
 #endif
         );
+    reg(kSysconBase, kOffSCTCLKSEL) = kSctClkMain;
+    reg(kSysconBase, kOffSCTCLKDIV) = kSctClkDiv1;
     volatile fl::u32& presetctrl = reg(kSysconBase, kOffPRESETCTRL0);
-    presetctrl &= ~(kRstSCT | kRstSWM
+    presetctrl &= ~(kRstSCT
 #if defined(FASTLED_LPC_RX_SCT_DMA)
         | kRstDMA
 #endif
         );   // assert reset (low pulse)
-    presetctrl |=  (kRstSCT | kRstSWM
+    presetctrl |=  (kRstSCT
 #if defined(FASTLED_LPC_RX_SCT_DMA)
         | kRstDMA
 #endif
         );   // release reset
 
-    // ---- 2. Route mPin -> SCT input 0 via SWM PINASSIGN6 byte[31:24]. ----
-    swmAssignSctInput0(static_cast<fl::u8>(mPin & 0xFFu));
+    // ---- 2. Prepare the pad as a digital input, then route it to SCT input 0
+    //         via SWM PINASSIGN6 byte[31:24]. ----
+    const fl::u8 rx_pin = static_cast<fl::u8>(mPin & 0xFFu);
+    configureDigitalInput(rx_pin);
+    swmAssignSctInput0(rx_pin);
+    reg(kInputMuxBase, kOffSctInputMux0) = kSctInputMuxSctPin0;
 
     // ---- 3. Configure SCT: UNIFY counter + INSYNC for input 0. ----
-    // The 2-clock synchronizer adds ~67 ns of capture jitter at F_CPU=30 MHz,
+    // The 2-clock synchronizer adds a small fixed capture jitter at the SCT
+    // clock rate, but removes asynchronous input metastability risk.
     // well below the WS2812 T0H/T1H discrimination window (~500 ns margin).
     sct(kOffCTRL)    = kCtrlHaltL | kCtrlClrCtrL;   // halted, counter zeroed
     sct(kOffCONFIG)  = kCfgUnify  | kCfgInsync0;


### PR DESCRIPTION
﻿## Summary

- enable the LPC SCT RX backend in the `lpc845brk` build so AutoResearch links the real capture implementation
- configure LPC845 SCT input pads through IOCON/SWM/INPUTMUX, set the SCT clock divider, and avoid resetting SWM so UART routing survives
- fix fbuild firmware artifact lookup for AutoResearch and move LPC loopback defaults off true-open-drain P0_10/P0_11 to P0_14/P0_15
- cover the fbuild path and LPC loopback command defaults with focused tests

## Context

Follow-up to #3218 / #3221 while validating AutoResearch LPC pin-toggle bring-up. The previous build could flash and echo, but the SCT RX backend was not compiled into the library TU and the test defaults used LPC845 true-open-drain I2C pins.

## Verification

- `uv run python -m pytest ci/tests/test_autoresearch_phases.py ci/tests/test_fbuild_default_selection.py -q`
  - 60 passed
- `python -m py_compile ci/autoresearch/build_driver.py ci/autoresearch/phases.py ci/autoresearch/test_lpc_pin_toggle_rx.py ci/autoresearch/test_lpc_ws2812_loopback.py ci/tests/test_autoresearch_phases.py ci/tests/test_fbuild_default_selection.py`
- `git diff --check`
- `uv run ci/ci-compile.py lpc845brk --examples AutoResearch --fbuild --max-failures 1`
  - succeeded; flags include `-DFASTLED_LPC_RX_SCT=1`; firmware size 63.12 KB / 64 KB
- `uv run python -m ci.autoresearch lpc845brk --pin-toggle-rx --upload-port COM10 --quiet --skip-schema --timeout 120s`
  - build, pyOCD flash, reset, and RPC echo succeeded
  - pin-toggle capture still failed with 0 edges at 1 kHz, 10 kHz, and 100 kHz because this attached board has no detected TX?RX electrical loopback; the runner now asks for P0_14 ? P0_15

## Remaining hardware gate

The AutoResearch pin-toggle validation still needs a physical jumper from P0_14 to P0_15, or equivalent wiring, on the attached LPC845-BRK. Earlier probing found no built-in connected GPIO pair, and same-pin SCT input is not a valid loopback.
