### PR TITLE
fix(esp32): disable unsupported C2 RMT backend

### DIFF
--- a/src/platforms/esp/32/feature_flags/enabled.h
+++ b/src/platforms/esp/32/feature_flags/enabled.h
@@ -93,7 +93,12 @@ FL_EXTERN_C_END
 
 // RMT driver availability - use SoC capability macro
 #if !defined(FASTLED_ESP32_HAS_RMT)
+#if defined(FL_IS_ESP_32C2)
+// ESP32-C2's IDF package does not expose the direct RMT register header used by FastLED's RMT backends.
+#define FASTLED_ESP32_HAS_RMT 0
+#else
 #define FASTLED_ESP32_HAS_RMT SOC_RMT_SUPPORTED
+#endif
 #endif
 
 // Helper macro: Platforms that ONLY support RMT5 (no RMT4 fallback)
@@ -108,7 +113,11 @@ FL_EXTERN_C_END
 // Note that FASTLED_RMT5 is a legacy name,
 // so we keep it because "RMT" is specific to ESP32
 // Auto-detect RMT5 based on ESP-IDF version if not explicitly defined
-#if !defined(FASTLED_RMT5)
+#if defined(FL_IS_ESP_32C2)
+// The esp32c2 PlatformIO env currently passes -DFASTLED_RMT5=1; force the unsupported backend off.
+#undef FASTLED_RMT5
+#define FASTLED_RMT5 0
+#elif !defined(FASTLED_RMT5)
 #if FASTLED_ESP32_RMT5_ONLY_PLATFORM
 #define FASTLED_RMT5 1  // RMT5-only chips must use new driver
 #elif ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0) && FASTLED_ESP32_HAS_RMT


### PR DESCRIPTION
## Summary
- disable FastLED's RMT/RMT5 backend for ESP32-C2 because the C2 IDF package does not expose the direct \\soc/rmt_struct.h\\ register header used by the backend
- force \\FASTLED_RMT5\\ off for C2 even when the esp32c2 PlatformIO env passes \\-DFASTLED_RMT5=1\\, allowing the existing clockless-SPI path to compile

Fixes failing job: https://github.com/FastLED/FastLED/actions/runs/27759522985/job/82129954144

## Tests
- \\.venv\\Scripts\\python.exe ci\\ci-compile.py --no-interactive --no-parallel --max-failures 1 esp32c2 AnalogOutput\\ (passes; build metadata generation later reported a non-fatal 900s timeout)
- \\git diff --check\\`n- \\.venv\\Scripts\\python.exe -m pytest ci\\tests -q\\ (timed out after 120s)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved RMT capability detection and configuration for ESP32-C2 hardware variant to ensure proper functionality and prevent initialization errors on this device model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->