### PR TITLE
fix(ci): cast sorted(macros, key=len) to list[str] to satisfy ty

### DIFF
--- a/ci/lint_cpp/legacy_log_macro_checker.py
+++ b/ci/lint_cpp/legacy_log_macro_checker.py
@@ -8,6 +8,7 @@ formatter work is centralized in `fl::printf` instead of instantiating a fresh
 
 import re
 from pathlib import Path
+from typing import cast
 
 from ci.util.check_files import FileContent, FileContentChecker
 from ci.util.paths import PROJECT_ROOT
@@ -47,10 +48,9 @@ LEGACY_MACROS = (
     "FL_LOG_OBJECTFLED_ASYNC_MAIN",
 )
 
+_LEGACY_SORTED = cast(list[str], sorted(LEGACY_MACROS, key=len, reverse=True))
 _LEGACY_PATTERN = re.compile(
-    r"\b("
-    + "|".join(re.escape(name) for name in sorted(LEGACY_MACROS, key=len, reverse=True))
-    + r")\s*\("
+    r"\b(" + "|".join(re.escape(name) for name in _LEGACY_SORTED) + r")\s*\("
 )
 
 

--- a/ci/tools/migrate_fl_logs.py
+++ b/ci/tools/migrate_fl_logs.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import argparse
 import re
 from pathlib import Path
+from typing import cast
 
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -48,10 +49,9 @@ MACROS: dict[str, str] = {
     "FL_LOG_OBJECTFLED_ASYNC_MAIN": "FL_LOG_OBJECTFLED_ASYNC_MAIN_F",
 }
 
+_MACRO_NAMES_SORTED = cast(list[str], sorted(MACROS, key=len, reverse=True))
 MACRO_RE = re.compile(
-    r"\b("
-    + "|".join(re.escape(name) for name in sorted(MACROS, key=len, reverse=True))
-    + r")\s*\("
+    r"\b(" + "|".join(re.escape(name) for name in _MACRO_NAMES_SORTED) + r")\s*\("
 )
 
 


### PR DESCRIPTION
## Summary

\`ty\` (Astral's type checker) infers \`sorted(iterable, key=len)\` as \`list[Sized]\` rather than \`list[str]\` — the \`key=\` argument constrains the element type to whatever \`len()\` accepts, which is \`Sized\` (a broader type than \`str\`). That broke the downstream \`re.escape(name)\` call which requires \`AnyStr\`.

Both \`ci/lint_cpp/legacy_log_macro_checker.py:52\` and \`ci/tools/migrate_fl_logs.py:53\` were failing \`bash lint\` on master. Wrapped both calls in \`typing.cast(list[str], ...)\` so ty knows the elements are strings. Runtime behaviour is unchanged.

Detected via a stop-hook lint run during work on a separate PR — these errors live on master today and block CI's \`ty\` step.

## Test plan

- [x] \`uv run ty check ci/lint_cpp/legacy_log_macro_checker.py ci/tools/migrate_fl_logs.py\` → \`All checks passed!\`
- [x] No behavioural changes; runtime \`sorted()\` call is identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal improvements to CI/CD tooling for better code quality checks.

---

**Note:** These changes are internal infrastructure updates with no visible impact to end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->