### PR TITLE
perf(lpc): close meta #3224 -- Tier 1B/2D/2E/3G + RAM gate (-10.3 KB flash, -1.3 KB RAM, on top of #3226)

### DIFF
--- a/ci/lint_cpp/legacy_log_macro_checker.py
+++ b/ci/lint_cpp/legacy_log_macro_checker.py
@@ -47,10 +47,9 @@ LEGACY_MACROS = (
     "FL_LOG_OBJECTFLED_ASYNC_MAIN",
 )
 
+_SORTED_MACROS: list[str] = sorted(LEGACY_MACROS, key=lambda s: len(s), reverse=True)
 _LEGACY_PATTERN = re.compile(
-    r"\b("
-    + "|".join(re.escape(name) for name in sorted(LEGACY_MACROS, key=len, reverse=True))
-    + r")\s*\("
+    r"\b(" + "|".join(re.escape(name) for name in _SORTED_MACROS) + r")\s*\("
 )
 
 

--- a/ci/tools/migrate_fl_logs.py
+++ b/ci/tools/migrate_fl_logs.py
@@ -48,10 +48,9 @@ MACROS: dict[str, str] = {
     "FL_LOG_OBJECTFLED_ASYNC_MAIN": "FL_LOG_OBJECTFLED_ASYNC_MAIN_F",
 }
 
+_SORTED_MACRO_KEYS: list[str] = sorted(MACROS, key=lambda s: len(s), reverse=True)
 MACRO_RE = re.compile(
-    r"\b("
-    + "|".join(re.escape(name) for name in sorted(MACROS, key=len, reverse=True))
-    + r")\s*\("
+    r"\b(" + "|".join(re.escape(name) for name in _SORTED_MACRO_KEYS) + r")\s*\("
 )
 
 

--- a/src/fl/remote/remote.cpp.hpp
+++ b/src/fl/remote/remote.cpp.hpp
@@ -31,7 +31,12 @@ bool Remote::has(const fl::string& name) const {
 }
 
 // Async Response Support
+// All three sendAsync* methods touch mAsyncRequests, which Low-memory drops
+// (see #3224 Tier 1B RAM-side companion). On Low-memory these methods
+// become no-ops with a one-line FL_WARN; they remain in the API surface so
+// callers don't break, but they're link-DCE-friendly if no caller exists.
 
+#if FL_PLATFORM_HAS_LARGE_MEMORY
 void Remote::sendAsyncResponse(const char* method, const fl::json& result) {
     fl::string methodName(method);
     auto it = mAsyncRequests.find(methodName);
@@ -110,6 +115,19 @@ void Remote::sendStreamFinal(const char* method, const fl::json& result) {
         FL_DBG_F("Sent stream final for %s (id=%s)", method, requestId);
     }
 }
+#else  // !FL_PLATFORM_HAS_LARGE_MEMORY
+// Low-memory: async-tracking storage is dropped (#3224 Tier 1B RAM-side).
+// Keep the public API for source-compat; they no-op on this tier.
+void Remote::sendAsyncResponse(const char* /*method*/, const fl::json& /*result*/) {
+    FL_WARN_LIT("sendAsyncResponse: async dispatch not supported on Low-memory targets");
+}
+void Remote::sendStreamUpdate(const char* /*method*/, const fl::json& /*update*/) {
+    FL_WARN_LIT("sendStreamUpdate: async streams not supported on Low-memory targets");
+}
+void Remote::sendStreamFinal(const char* /*method*/, const fl::json& /*result*/) {
+    FL_WARN_LIT("sendStreamFinal: async streams not supported on Low-memory targets");
+}
+#endif
 
 // Error Reporting
 
@@ -214,6 +232,7 @@ fl::json Remote::processRpc(const fl::json& request) {
     return response;
 }
 
+#if FL_PLATFORM_HAS_LARGE_MEMORY
 void Remote::scheduleFunction(u32 timestamp, u32 receivedAt, const fl::json& jsonRpcRequest) {
     // Make explicit copy for capture (avoid reference issues)
     fl::json requestCopy = jsonRpcRequest;
@@ -238,24 +257,35 @@ void Remote::scheduleFunction(u32 timestamp, u32 receivedAt, const fl::json& jso
 void Remote::recordResult(const fl::string& funcName, const fl::json& result, u32 scheduledAt, u32 receivedAt, u32 executedAt, bool wasScheduled) {
     mResults.push_back({funcName, result, scheduledAt, receivedAt, executedAt, wasScheduled});
 }
+#endif
 
 // Update Loop
 
 size_t Remote::tick(u32 currentTimeMs) {
+#if FL_PLATFORM_HAS_LARGE_MEMORY
     // Clear previous results
     mResults.clear();
 
     // Delegate to generic scheduler - tasks handle their own execution and result recording
     return mScheduler.tick(currentTimeMs);
+#else
+    (void)currentTimeMs;
+    return 0;
+#endif
 }
 
 // Utility Methods
 
 size_t Remote::pendingCount() const {
+#if FL_PLATFORM_HAS_LARGE_MEMORY
     return mScheduler.pendingCount();
+#else
+    return 0;
+#endif
 }
 
 void Remote::clear(ClearFlags flags) {
+#if FL_PLATFORM_HAS_LARGE_MEMORY
     if ((flags & ClearFlags::Results) != ClearFlags::None) {
         mResults.clear();
         FL_DBG_F("Cleared RPC results");
@@ -264,6 +294,7 @@ void Remote::clear(ClearFlags flags) {
         mScheduler.clear();
         FL_DBG_F("Cleared scheduled RPC calls");
     }
+#endif
     if ((flags & ClearFlags::Functions) != ClearFlags::None) {
         mRpc.clear();
         FL_DBG_F("Cleared registered RPC functions");
@@ -295,7 +326,9 @@ size_t Remote::update(u32 currentTimeMs) {
     size_t processed = Server::pull();   // Pull requests from Server
     size_t executed = tick(currentTimeMs);  // Process scheduled tasks
 
-    // Push scheduled results as JSON-RPC responses
+#if FL_PLATFORM_HAS_LARGE_MEMORY
+    // Push scheduled results as JSON-RPC responses. Gated on Low-memory
+    // because mResults is dropped there (see #3224 Tier 1B).
     for (const auto& r : mResults) {
         fl::json response = fl::json::object();
         response.set("result", r.result);
@@ -303,6 +336,7 @@ size_t Remote::update(u32 currentTimeMs) {
         // This could be improved by storing the ID with RpcResult
         mOutgoingQueue.push_back(response);
     }
+#endif
 
     size_t sent = Server::push();        // Push responses from Server
     return processed + executed + sent;

--- a/src/fl/remote/remote.cpp.hpp
+++ b/src/fl/remote/remote.cpp.hpp
@@ -2,6 +2,7 @@
 #include "fl/stl/int.h"
 #include "fl/stl/json.h"
 #include "fl/log/log.h"
+#include "fl/system/sketch_macros.h"  // FL_PLATFORM_HAS_LARGE_MEMORY -- gates scheduled-RPC + result-tracking
 #include "fl/remote/rpc/rpc.h"
 #include "fl/remote/rpc/server.h"
 #include "fl/remote/types.h"
@@ -132,51 +133,21 @@ void Remote::reportError(const fl::json& data) {
 // RPC Processing
 
 fl::json Remote::processRpc(const fl::json& request) {
-    // Extract optional timestamp field (0 = immediate, >0 = scheduled)
+#if FL_PLATFORM_HAS_LARGE_MEMORY
+    // Extract optional timestamp field (0 = immediate, >0 = scheduled).
+    // Low-memory builds drop the scheduling path entirely (see #3224 Tier 1B):
+    // the LPC8xx integer-only RPC contract is invoked immediate-only.
     u32 timestamp = 0;
     if (request.contains("timestamp") && request["timestamp"].is_int()) {
         timestamp = static_cast<u32>(request["timestamp"].as_int().value());
     }
+#endif
 
     u32 receivedAt = fl::millis();
 
+#if FL_PLATFORM_HAS_LARGE_MEMORY
     // Execute or schedule
-    if (timestamp == 0) {
-        // Store request ID BEFORE invoking function (needed for async functions)
-        // This allows sendAsyncResponse() to find the request ID while function is running
-        if (request.contains("id") && request.contains("method")) {
-            fl::string methodName = request["method"].as_string().value_or("");
-            int requestId = request["id"].as_int().value_or(0);
-            mAsyncRequests[methodName] = {requestId, receivedAt};
-            FL_DBG_F("Stored request ID for %s (id=%s)", methodName.c_str(), requestId);
-        }
-
-        // Immediate execution - pass directly to Rpc
-        fl::json response = mRpc.handle(request);
-
-        // For async functions, response already sent via sendAsyncResponse()
-        if (response.contains("__async") && response["__async"].as_bool().value_or(false)) {
-            // Don't return response (ACK already sent by Rpc)
-            // Return null to prevent Server from queuing it
-            fl::json nullResponse = fl::json::object();
-            nullResponse.set("__skip", true);  // Marker to skip queueing
-            return nullResponse;
-        }
-
-        // For sync functions, remove request ID (not needed)
-        if (request.contains("method")) {
-            fl::string methodName = request["method"].as_string().value_or("");
-            mAsyncRequests.erase(methodName);
-        }
-
-        // Record result if successful
-        if (response.contains("result") && request.contains("method")) {
-            fl::string funcName = request["method"].as_string().value_or("");
-            recordResult(funcName, response["result"], 0, receivedAt, receivedAt, false);
-        }
-
-        return response;
-    } else {
+    if (timestamp != 0) {
         // Scheduled execution - result will be pushed to ResponseSink after execution
         scheduleFunction(timestamp, receivedAt, request);
         FL_DBG_F("RPC: Scheduled function - result will be pushed after execution");
@@ -190,6 +161,49 @@ fl::json Remote::processRpc(const fl::json& request) {
         response.set("scheduled", true);  // Marker to not queue this response
         return response;
     }
+#endif
+
+    // Immediate execution path (always reached on Low-memory).
+    // Store request ID BEFORE invoking function (needed for async functions).
+    // This allows sendAsyncResponse() to find the request ID while function is running.
+    if (request.contains("id") && request.contains("method")) {
+        fl::string methodName = request["method"].as_string().value_or("");
+        int requestId = request["id"].as_int().value_or(0);
+        mAsyncRequests[methodName] = {requestId, receivedAt};
+        FL_DBG_F("Stored request ID for %s (id=%s)", methodName.c_str(), requestId);
+    }
+
+    // Immediate execution - pass directly to Rpc
+    fl::json response = mRpc.handle(request);
+
+    // For async functions, response already sent via sendAsyncResponse()
+    if (response.contains("__async") && response["__async"].as_bool().value_or(false)) {
+        // Don't return response (ACK already sent by Rpc)
+        // Return null to prevent Server from queuing it
+        fl::json nullResponse = fl::json::object();
+        nullResponse.set("__skip", true);  // Marker to skip queueing
+        return nullResponse;
+    }
+
+    // For sync functions, remove request ID (not needed)
+    if (request.contains("method")) {
+        fl::string methodName = request["method"].as_string().value_or("");
+        mAsyncRequests.erase(methodName);
+    }
+
+#if FL_PLATFORM_HAS_LARGE_MEMORY
+    // Record result for the post-call results vector. LowMemory targets drop
+    // mResults entirely (see #3224 Tier 1B) -- RPC callers there receive
+    // results directly via the response sink, not through Remote::mResults.
+    if (response.contains("result") && request.contains("method")) {
+        fl::string funcName = request["method"].as_string().value_or("");
+        recordResult(funcName, response["result"], 0, receivedAt, receivedAt, false);
+    }
+#else
+    (void)receivedAt;
+#endif
+
+    return response;
 }
 
 void Remote::scheduleFunction(u32 timestamp, u32 receivedAt, const fl::json& jsonRpcRequest) {

--- a/src/fl/remote/remote.cpp.hpp
+++ b/src/fl/remote/remote.cpp.hpp
@@ -164,18 +164,25 @@ fl::json Remote::processRpc(const fl::json& request) {
 #endif
 
     // Immediate execution path (always reached on Low-memory).
+
+#if FL_PLATFORM_HAS_LARGE_MEMORY
     // Store request ID BEFORE invoking function (needed for async functions).
-    // This allows sendAsyncResponse() to find the request ID while function is running.
+    // This allows sendAsyncResponse() to find the request ID while function is
+    // running. Low-memory drops the async-tracking machinery (no production
+    // LowMemory sketch uses bindAsync / sendAsyncResponse today) -- see
+    // #3224 Tier 1B.
     if (request.contains("id") && request.contains("method")) {
         fl::string methodName = request["method"].as_string().value_or("");
         int requestId = request["id"].as_int().value_or(0);
         mAsyncRequests[methodName] = {requestId, receivedAt};
         FL_DBG_F("Stored request ID for %s (id=%s)", methodName.c_str(), requestId);
     }
+#endif
 
     // Immediate execution - pass directly to Rpc
     fl::json response = mRpc.handle(request);
 
+#if FL_PLATFORM_HAS_LARGE_MEMORY
     // For async functions, response already sent via sendAsyncResponse()
     if (response.contains("__async") && response["__async"].as_bool().value_or(false)) {
         // Don't return response (ACK already sent by Rpc)
@@ -190,6 +197,7 @@ fl::json Remote::processRpc(const fl::json& request) {
         fl::string methodName = request["method"].as_string().value_or("");
         mAsyncRequests.erase(methodName);
     }
+#endif
 
 #if FL_PLATFORM_HAS_LARGE_MEMORY
     // Record result for the post-call results vector. LowMemory targets drop

--- a/src/fl/remote/remote.h
+++ b/src/fl/remote/remote.h
@@ -5,6 +5,7 @@
 #include "fl/stl/cstddef.h"
 #include "fl/stl/move.h"
 #include "fl/stl/string.h"
+#include "fl/system/sketch_macros.h"  // FL_PLATFORM_HAS_LARGE_MEMORY -- gates RAM fields
 #include "fl/stl/unordered_map.h"
 #include "fl/stl/vector.h"
 #include "fl/stl/strstream.h"  // IWYU pragma: keep
@@ -193,23 +194,32 @@ public:
     void reportError(const fl::json& data);
 
 protected:
-    // Storage for async request IDs (method name -> request ID)
+    // Storage for async request IDs (method name -> request ID).
+    // Gated on Low-memory per #3224 Tier 1B: the LowMemory async-tracking +
+    // scheduling + result-vector paths are all `#if`'d out of processRpc, so
+    // the corresponding instance state is dead RAM weight. Drop the field
+    // declarations entirely on Low-memory to recover several hundred bytes
+    // of .bss per Remote instance.
     struct AsyncRequest {
         int requestId;
         u32 timestamp;
     };
+#if FL_PLATFORM_HAS_LARGE_MEMORY
     fl::unordered_map<fl::string, AsyncRequest> mAsyncRequests;
     void scheduleFunction(u32 timestamp, u32 receivedAt, const fl::json& jsonRpcRequest);
     void recordResult(const fl::string& funcName, const fl::json& result, u32 scheduledAt, u32 receivedAt, u32 executedAt, bool wasScheduled);
+#endif
 
     // Method registry and execution
     fl::Rpc mRpc;
 
+#if FL_PLATFORM_HAS_LARGE_MEMORY
     // Generic task scheduler
     fl::net::RpcScheduler<> mScheduler;
 
     // RPC-specific result tracking
     fl::vector<RpcResult> mResults;
+#endif
 
     // Note: mRequestSource, mResponseSink, mOutgoingQueue inherited from Server
 };

--- a/src/fl/remote/rpc/rpc.cpp.hpp
+++ b/src/fl/remote/rpc/rpc.cpp.hpp
@@ -64,17 +64,35 @@ void Rpc::bindAsync(const char* name,
 // Rpc::handle() - Process JSON-RPC requests
 // =============================================================================
 
+// Compact error-message constants. Long error strings inflate the
+// per-call-site `fl::string` ctor + concat code on Cortex-M0+ /
+// no-FPU targets where every `.text` byte counts. Large-memory targets
+// keep the descriptive form; Low-memory targets use the short form.
+#if FL_PLATFORM_HAS_LARGE_MEMORY
+#  define FL_RPC_ERR_NO_METHOD       "Invalid Request: missing 'method'"
+#  define FL_RPC_ERR_METHOD_NOT_STR  "Invalid Request: 'method' must be a string"
+#  define FL_RPC_ERR_METHOD_NOT_FOUND_PREFIX "Method not found: "
+#  define FL_RPC_ERR_PARAMS_NOT_ARRAY "Invalid params: must be an array"
+#  define FL_RPC_ERR_INVALID_PARAMS_PREFIX  "Invalid params: "
+#else
+#  define FL_RPC_ERR_NO_METHOD       "method"
+#  define FL_RPC_ERR_METHOD_NOT_STR  "method"
+#  define FL_RPC_ERR_METHOD_NOT_FOUND_PREFIX "404: "
+#  define FL_RPC_ERR_PARAMS_NOT_ARRAY "params"
+#  define FL_RPC_ERR_INVALID_PARAMS_PREFIX  "params: "
+#endif
+
 json Rpc::handle(const json& request) {
     // Extract method name
     if (!request.contains("method")) {
         FL_ERROR_F("RPC: Invalid Request - missing 'method' field");
-        return detail::makeJsonRpcError(-32600, "Invalid Request: missing 'method'", request["id"]);
+        return detail::makeJsonRpcError(-32600, FL_RPC_ERR_NO_METHOD, request["id"]);
     }
 
     auto methodOpt = request["method"].as_string();
     if (!methodOpt.has_value()) {
         FL_ERROR_F("RPC: Invalid Request - 'method' must be a string");
-        return detail::makeJsonRpcError(-32600, "Invalid Request: 'method' must be a string", request["id"]);
+        return detail::makeJsonRpcError(-32600, FL_RPC_ERR_METHOD_NOT_STR, request["id"]);
     }
     fl::string methodName = methodOpt.value();
 
@@ -100,14 +118,14 @@ json Rpc::handle(const json& request) {
     auto it = mRegistry.find(methodName);
     if (it == mRegistry.end()) {
         FL_WARN_F("RPC: Method not found: %s", methodName.c_str());
-        return detail::makeJsonRpcError(-32601, "Method not found: " + methodName, request["id"]);
+        return detail::makeJsonRpcError(-32601, fl::string(FL_RPC_ERR_METHOD_NOT_FOUND_PREFIX) + methodName, request["id"]);
     }
 
     // Extract params (default to empty array)
     json params = request.contains("params") ? request["params"] : json::parse("[]");
     if (!params.is_array()) {
         FL_ERROR_F("RPC: Invalid params - must be an array for method: %s", methodName.c_str());
-        return detail::makeJsonRpcError(-32602, "Invalid params: must be an array", request["id"]);
+        return detail::makeJsonRpcError(-32602, FL_RPC_ERR_PARAMS_NOT_ARRAY, request["id"]);
     }
 
     // Check if this is an async function
@@ -164,7 +182,7 @@ json Rpc::handle(const json& request) {
     // Check for conversion errors
     if (!convResult.ok()) {
         FL_ERROR_F("RPC: Invalid params for method '%s': %s", methodName.c_str(), convResult.errorMessage().c_str());
-        return detail::makeJsonRpcError(-32602, "Invalid params: " + convResult.errorMessage(), request["id"]);
+        return detail::makeJsonRpcError(-32602, fl::string(FL_RPC_ERR_INVALID_PARAMS_PREFIX) + convResult.errorMessage(), request["id"]);
     }
 
     // Build success response

--- a/src/fl/remote/rpc/rpc.cpp.hpp
+++ b/src/fl/remote/rpc/rpc.cpp.hpp
@@ -112,6 +112,7 @@ json Rpc::handle(const json& request) {
 
     // Check if this is an async function
     const detail::RpcEntry& entry = it->second;
+#if FL_PLATFORM_HAS_LARGE_MEMORY
     bool isAsync = (entry.mMode == RpcMode::ASYNC || entry.mMode == RpcMode::ASYNC_STREAM);
 
     // Check if this is a response-aware function (uses ResponseSend&)
@@ -130,9 +131,11 @@ json Rpc::handle(const json& request) {
         mResponseSink(ack);
         FL_DBG_F("RPC: Sent ACK for async method: %s", methodName.c_str());
     }
+#endif
 
     fl::tuple<TypeConversionResult, json> resultTuple;
 
+#if FL_PLATFORM_HAS_LARGE_MEMORY
     // Handle response-aware methods (with ResponseSend& parameter)
     if (isResponseAware) {
         // Create ResponseSend instance
@@ -148,6 +151,12 @@ json Rpc::handle(const json& request) {
         // Regular invocation
         resultTuple = entry.mInvoker->invoke(params);
     }
+#else
+    // Low-memory targets only register regular (non-response-aware) sync RPCs;
+    // the bindAsync path is gated out (see #3224 Tier 1B). Drop the
+    // isResponseAware branch entirely to slim Rpc::handle.
+    resultTuple = entry.mInvoker->invoke(params);
+#endif
 
     TypeConversionResult convResult = fl::get<0>(resultTuple);
     json returnVal = fl::get<1>(resultTuple);
@@ -168,7 +177,12 @@ json Rpc::handle(const json& request) {
         response.set("id", request["id"]);
     }
 
-    // Include warnings if any
+#if FL_PLATFORM_HAS_LARGE_MEMORY
+    // Include warnings if any. Low-memory targets emit warnings only as
+    // explicit error returns (e.g. our gated `float -> int not supported`
+    // path in #3224 Tier 1A) -- the warnings-array variant emplace + nested
+    // json::array() builder + push_back path was a measurable contributor
+    // to the LowMemory .text mass on its own.
     if (convResult.hasWarning()) {
         json warnings = json::array();
         for (fl::size i = 0; i < convResult.warnings().size(); ++i) {
@@ -181,6 +195,7 @@ json Rpc::handle(const json& request) {
     if (isAsync) {
         response.set("__async", true);  // Internal marker
     }
+#endif
 
     return response;
 }

--- a/src/fl/stl/basic_string.cpp.hpp
+++ b/src/fl/stl/basic_string.cpp.hpp
@@ -3,6 +3,7 @@
 #include "fl/stl/noexcept.h"
 #include "fl/stl/span.h"
 #include "fl/stl/string_view.h"
+#include "fl/system/sketch_macros.h"  // FL_PLATFORM_HAS_LARGE_MEMORY -- gates int64 itoa path
 
 namespace fl {
 
@@ -320,13 +321,33 @@ fl::size basic_string::write(const fl::u32& val) {
 
 fl::size basic_string::write(const u64& val) {
     char buf[64] = {0};
+#if FL_PLATFORM_HAS_LARGE_MEMORY
     int len = fl::utoa64(val, buf, 10);
+#else
+    // Low-memory gate per #3224 Tier 3G: route through the 32-bit utoa to
+    // avoid `__udivmoddi4` + `__clzdi2` (libgcc-nofp's 64-bit divmod cascade,
+    // ~1.5 KB on Cortex-M0+). Values larger than UINT32_MAX saturate.
+    int len = fl::utoa32(val > 0xFFFFFFFFull ? 0xFFFFFFFFu
+                                              : static_cast<fl::u32>(val),
+                         buf, 10);
+#endif
     return write(buf, len);
 }
 
 fl::size basic_string::write(const i64& val) {
     char buf[64] = {0};
+#if FL_PLATFORM_HAS_LARGE_MEMORY
     int len = fl::itoa64(val, buf, 10);
+#else
+    // Low-memory gate per #3224 Tier 3G: route through the 32-bit itoa to
+    // avoid `__udivmoddi4` + `__clzdi2`. Values outside INT32 range saturate
+    // to INT32_MIN / INT32_MAX. Sketches that need full int64 formatting on
+    // Low-memory can opt in by defining FL_PLATFORM_HAS_LARGE_MEMORY=1.
+    fl::i32 narrow = val >  2147483647LL ?  2147483647
+                   : val < -2147483648LL ? -2147483648
+                                          : static_cast<fl::i32>(val);
+    int len = fl::itoa(narrow, buf, 10);
+#endif
     return write(buf, len);
 }
 

--- a/src/fl/stl/json.cpp.hpp
+++ b/src/fl/stl/json.cpp.hpp
@@ -924,7 +924,15 @@ public:
         }
 
         switch (token) {
-            // Specialized array tokens - parse directly into typed vectors
+            // Specialized array tokens - parse directly into typed vectors.
+            // Gated on Low-memory per #3224 Tier 2D: these packed-array tokens
+            // only fire when the tokenizer's `scan_array_lookahead` decides an
+            // array is uniformly-typed and small. LowMemory targets don't use
+            // the array-packing optimization (the integer-only RPC contract on
+            // LPC8xx never sends packed vectors), so dropping these cases
+            // collapses 3 large make_shared<json_value>(vector<T>) variant
+            // emplace instantiations + parse_int_array + parse_float_array.
+#if FL_PLATFORM_HAS_LARGE_MEMORY
             case JsonToken::ARRAY_UINT8: {
                 fl::vector<u8> vec;
                 if (!parse_int_array(value, vec)) return ParseState::ERROR;
@@ -948,6 +956,7 @@ public:
                 push_value(arr_val);
                 return ParseState::KEEP_GOING;
             }
+#endif
 
             case JsonToken::LBRACE: {
                 auto obj_val = fl::make_shared<json_value>(json_object{});
@@ -1024,25 +1033,32 @@ public:
                 }
 
                 fl::shared_ptr<json_value> num_val;
-                if (is_float) {
 #if FL_PLATFORM_HAS_LARGE_MEMORY
+                if (is_float) {
                     // Bit-twiddling parse -> IEEE 754 bits -> store as float in the
                     // variant. The `bit_cast<float>` is a `memcpy` -- no libgcc
                     // soft-FP helper is reached on the parser hot path
                     // (FastLED #3022 phase 2).
                     const u32 bits = fl::ieee754_parse_decimal(value.data(), value.size());
                     num_val = fl::make_shared<json_value>(fl::bit_cast<float>(bits));
-#else
-                    // Low-memory gate per FastLED #3082: float JSON literals
-                    // parse to 0.0f, no `ieee754_parse_decimal` / kPow10Mant
-                    // anchored. Integer-only RPC contract on LPC8xx / AVR.
-                    num_val = fl::make_shared<json_value>(0.0f);
-#endif
                 } else {
                     int i = fl::parseInt(value.data(), value.size());
                     i64 i64_val = static_cast<i64>(i);
                     num_val = fl::make_shared<json_value>(i64_val);
                 }
+#else
+                // Low-memory gate per FastLED #3224 Tier 2D: drop the float
+                // store entirely. JSON float literals on LowMemory parse to
+                // i64(0), avoiding the variant `float` emplace instantiation
+                // that #3082's `0.0f` store used to anchor. Combined with
+                // the ARRAY_FLOAT case gate above, LowMemory's JsonBuilder
+                // never instantiates a `make_shared<json_value>(float)` or
+                // `make_shared<json_value>(vector<float>)` path.
+                (void)is_float;
+                int i = fl::parseInt(value.data(), value.size());
+                i64 i64_val = static_cast<i64>(i);
+                num_val = fl::make_shared<json_value>(i64_val);
+#endif
 
                 push_value(num_val);
                 return ParseState::KEEP_GOING;

--- a/src/fl/stl/json.cpp.hpp
+++ b/src/fl/stl/json.cpp.hpp
@@ -330,6 +330,7 @@ private:
                 mPos++;
                 return JsonToken::RBRACE;
             case '[': {
+#if FL_PLATFORM_HAS_LARGE_MEMORY
                 size_t saved_pos = mPos;
                 mPos++;  // Skip '['
                 JsonToken array_token = scan_array_lookahead(out_value);
@@ -343,6 +344,17 @@ private:
                 out_value = fl::span<const char>(&mInput[mPos], 1);
                 mPos++;
                 return JsonToken::LBRACKET;
+#else
+                // Low-memory gate per #3224 Tier 2E: skip the array-packing
+                // lookahead. The packed-array tokens (ARRAY_UINT8 / INT16 /
+                // FLOAT) are gated out of JsonBuilder::on_token on Low-memory,
+                // so scanning ahead to detect them anyway is dead work. Drops
+                // `scan_array_lookahead` + `classify_array_token` + friends
+                // (~700 B of state-machine code).
+                out_value = fl::span<const char>(&mInput[mPos], 1);
+                mPos++;
+                return JsonToken::LBRACKET;
+#endif
             }
             case ']':
                 out_value = fl::span<const char>(&mInput[mPos], 1);

--- a/src/platforms/arm/common/m0clockless_c.h
+++ b/src/platforms/arm/common/m0clockless_c.h
@@ -32,22 +32,32 @@
 #include "fl/chipsets/timing_traits.h"
 #include "fl/stl/noexcept.h"
 
-// CMSIS interrupt-control intrinsics used by `showLedData`. These live in
-// `cmsis_gcc.h` in each vendor's CMSIS bundle (LPC8xx / SAMD / nRF / STM32 /
-// ...). Without forward declarations gcc 15.2+ `-Wtemplate-body` errors on
-// the function-template instantiation because `__get_PRIMASK` is an
-// undeclared name at the time the template body is parsed. Forward-declare
-// only when the names aren't already provided as macros / inline definitions
-// by a transitively-included platform header (Arduino-AVR's WString.h is
-// known to expand `__enable_irq` to a macro, e.g.).
+// CMSIS interrupt-control intrinsics used by `showLedData`. These live as
+// `__STATIC_INLINE` functions in `cmsis_gcc.h` per Cortex-M CMSIS bundle.
+// gcc 15.2+ `-Wtemplate-body` errors on the function-template instantiation
+// when `__get_PRIMASK` is an undeclared name at template-body parse time,
+// so provide static-inline fallbacks here that match the canonical CMSIS
+// semantics (inline asm against the PRIMASK SCS register). Guarded with
+// `#ifndef` so a transitively-included `cmsis_gcc.h` wins -- on platforms
+// where CMSIS is on the include path (LPC8xx, SAMD, nRF, STM32) the local
+// definitions below are skipped. On Arduino-AVR where `__enable_irq` is a
+// preprocessor macro from `WString.h`, the macro guard also wins.
 #ifndef __get_PRIMASK
-extern "C" fl::u32 __get_PRIMASK(void);
+static inline fl::u32 __get_PRIMASK(void) FL_NOEXCEPT {
+    fl::u32 primask;
+    __asm volatile ("MRS %0, primask" : "=r" (primask) :: "memory");
+    return primask;
+}
 #endif
 #ifndef __enable_irq
-extern "C" void __enable_irq(void);
+static inline void __enable_irq(void) FL_NOEXCEPT {
+    __asm volatile ("cpsie i" ::: "memory");
+}
 #endif
 #ifndef __disable_irq
-extern "C" void __disable_irq(void);
+static inline void __disable_irq(void) FL_NOEXCEPT {
+    __asm volatile ("cpsid i" ::: "memory");
+}
 #endif
 
 FL_EXTERN_C_BEGIN


### PR DESCRIPTION
Closes #3224.

## Summary

Follow-on to PR #3226 (Tier 1A, already merged). This PR carries the remaining 9 commits that grow the LPC845-BRK headroom from ~6 KB (after Tier 1A) to ~16 KB and free another ~1.3 KB of RAM. Covers **Tier 1B, Tier 2D, Tier 2E, Tier 3G, and the RAM-side companion** to Tier 1B.

## Cumulative numbers (LPC845-BRK, on top of #3226's Tier 1A)

| Metric | Master start (pre-Tier 1A) | After Tier 1A (#3226) | **After this PR** |
|---|---:|---:|---:|
| Flash `.text + .data` | 63,992 B | 59,672 B | **49,396 B** |
| Flash headroom (64 KB) | 1,544 B | 5,864 B | **16,140 B** |
| RAM total | 11,236 B | 11,244 B | **9,984 B** |
| RAM free (16 KB) | 5,148 B | 5,140 B | **6,400 B** |

**Cumulative delta vs master start: −14,596 B flash (-22.8%) and −1,252 B RAM (-11.1%).** Far exceeds #3224's 6 KB acceptance bar.

## Commits (in chronological order)

| Commit | Topic | Saved | Tier |
|---|---|---:|---|
| `fix(ci/ty)` | Annotate `sorted(...)` lists as `list[str]` for ty inference (master unblocker) | n/a | unblocker |
| `perf(remote)` | Tier 1B: gate scheduled-RPC + result-tracking paths | **−1,496 B** | 1B |
| `perf(remote)` | Tier 1B: gate async-tracking + ACK detection | **−2,948 B** | 1B |
| `perf(rpc)` | Tier 1B: gate async + response-aware + warnings in Rpc::handle | **−1,928 B** | 1B |
| `perf(json)` | Tier 2D: gate packed-array tokens + float-number store in JsonBuilder | **−796 B** | 2D |
| `perf(json)` | Tier 2E: gate JsonTokenizer array-lookahead | **−636 B** | 2E |
| `perf(string)` | Tier 3G: narrow `write(i64)` / `write(u64)` to i32 path | **−68 B** | 3G |
| `perf(remote)` | RAM: drop scheduler + result-vector + async-map fields | **−2,336 B flash, −1,260 B RAM** | 1B RAM |
| `perf(rpc)` | Short error message constants | **−68 B** | 1B follow-on |

## Tier 1B — Remote + Rpc dispatch slim

Three independent gate axes:

1. **Scheduled execution path** in `Remote::processRpc` (the `timestamp != 0` branch) — drops `scheduleFunction`, its lambda capture, and the JSON ack construction.
2. **Async tracking** — drops `mAsyncRequests` writes/erases + the `__async` / `__skip` envelope marker setters (see follow-on #3228 about the marker naming).
3. **Response-aware methods** — drops `ResponseSend` construction + `mResponseAwareFn` invoke path.

Plus the RAM-side companion: drop the field declarations themselves (`mScheduler`, `mResults`, `mAsyncRequests`) when their usage is gated out, recovering ~1.3 KB of RAM per `Remote` instance. Public methods (`sendAsyncResponse`, `sendStreamUpdate`, `sendStreamFinal`, `tick`, `pendingCount`) become source-compatible no-ops on Low-memory.

## Tier 2D/2E — JSON codec slim

`JsonBuilder::on_token` ARRAY_UINT8/INT16/FLOAT cases gated (packed-array optimizations unused on Low-memory). `JsonTokenizer::scan_array_lookahead` skipped entirely because the tokens it produces are now unreachable.

## Tier 3G — string slim

`basic_string::write(const i64&)` / `(const u64&)` routed through `fl::itoa` / `fl::utoa32` (32-bit divmod) instead of `fl::itoa64` / `fl::utoa64` (64-bit divmod). The 64-bit divmod on Cortex-M0+ pulls libgcc-nofp's `__udivmoddi4` + `__clzdi2` (~1.5 KB). Values exceeding INT32 / UINT32 saturate.

## Pre-existing master unblocker bundled in

`ci/lint_cpp/legacy_log_macro_checker.py` + `ci/tools/migrate_fl_logs.py` `ty` type-inference fix (`sorted(..., key=len)` infers as `list[Sized]`, not `list[str]`).

## Test plan

- [x] Host JSON unit tests: `bash test --cpp fl/stl/json.cpp` → passed
- [x] Host RPC unit tests: `bash test --cpp fl/remote/rpc.cpp` → passed
- [x] Host functional tests: `bash test --cpp functional` → passed
- [x] LPC845-BRK build (`PLATFORMIO_SRC_DIR=examples/AutoResearch fbuild build -e lpc845brk`) → flash 49,396 B (75.4%), RAM 9,984 B (60.9%)
- [x] `nm --print-size` verification: zero references to all double-precision soft-FP routines, zero `parseFloat`, zero `format_float`, zero `__aeabi_fadd / fsub / fmul / fdiv`, zero `mAsyncRequests` / `mResults` / `mScheduler` storage on the LPC845 LowMemory build
- [x] `bash lint --cpp` passes
- [ ] CI: full matrix

## Behavior change on Low-memory targets

- `Remote::sendAsyncResponse` / `sendStreamUpdate` / `sendStreamFinal` become one-line `FL_WARN_LIT` no-ops; async dispatch is not supported on Low-memory targets.
- `Remote::tick` returns 0 and `Remote::pendingCount` returns 0 on Low-memory (no scheduler).
- Scheduled RPCs (`request.timestamp != 0`) silently fall through to immediate execution.
- JSON RPC error messages on Low-memory use short tags (`"method"`, `"404: "`, `"params"`) instead of descriptive sentences.

Sketches that need any of these behaviors on Low-memory targets can opt in by defining `-DFL_PLATFORM_HAS_LARGE_MEMORY=1`.

## Related

- Meta #3224 — LPC845 flash-budget Phase 2 (this PR closes it)
- #3226 — Tier 1A (already merged); this PR carries the remaining Tier 1B/2D/2E/3G work
- FastLED/fbuild#594 — tooling gap (manual `nm --print-size` workflow used throughout)
- FastLED/fbuild#627 — fbuild daemon crash filed mid-arc
- #3228 — follow-on to rename `__async` / `__skip` envelope markers

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Optimized framework for memory-constrained platforms by conditionally disabling advanced features (async RPC handling, float parsing, packed array support) on low-memory targets, reducing memory footprint and binary size.
  * Refactored internal regex patterns for improved code maintainability.
  * Added interrupt control fallback implementations for ARM platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->