### PR TITLE
chore(lint): ban decayed array parameters

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -60,6 +60,30 @@ reviews:
           - ❌ `-DFASTLED_NEW_FEATURE=1` in build_flags →  ✅ `-DFL_NEW_FEATURE=1`
         Reference: `agents/docs/cpp-standards.md` → "Type 3: Component Capability Flags".
 
+        Decayed fixed-size array parameter rule (HIGH severity):
+        Do not allow function parameters spelled as `T value[N]` or `T value[]`.
+        In C++, those parameters decay to pointers, so the declared extent is not
+        enforced. Flag these in declarations, definitions, callback signatures, and
+        small output-buffer APIs.
+
+        Replacements:
+          - For ISR / `FL_IRAM` APIs, require an array reference:
+            `T (&value)[N]`.
+          - For non-ISR APIs, use either `fl::span<T, N>` or `T (&value)[N]`.
+          - For domain values like xy pairs, a concrete value type such as
+            `fl::vec2f` is also acceptable.
+
+        Examples:
+          - Bad: `void cct_to_xy(int cct, float out[2]);`
+          - Bad: `void encode(fl::u8 output[4]);`
+          - Good: `void cct_to_xy(int cct, fl::span<float, 2> out);`
+          - Good for ISR: `FL_IRAM void encode(fl::u8 (&output)[4]);`
+
+        Suppress only intentional C ABI or platform compatibility cases with
+        `// ok array parameter`. Reference: `agents/docs/cpp-standards.md` ->
+        "`fl::span` for Callback Typedefs and Small Fixed-Size Arrays" and
+        FastLED issue #3233.
+
     - path: "**/platformio.ini"
       instructions: |
         PlatformIO `build_flags` macro prefix rule (matches the `FL_*` vs `FASTLED_*`

--- a/agents/docs/cpp-standards.md
+++ b/agents/docs/cpp-standards.md
@@ -368,11 +368,21 @@ class CFastLED {
    - ❌ Bad: `void set_input_gamut(DiodeProfile* p, InputGamut g, const float white_xy[2]);`
    - ✅ Good: `void set_input_gamut(DiodeProfile* p, InputGamut g, fl::span<const float, 2> white_xy);`
    - ✅ Good (alternative — by-value pair): `void set_white_point(DiodeProfile* p, fl::vec2f white_xy);`
-3. ✅ **For RGBW / RGBWW multi-channel output**, prefer a `fl::span<u8, 4>` (or `5`) over five separate `u8*` parameters.
+3. ❌ **NEVER use function parameter array spelling (`T value[N]` or `T value[]`).**
+   - C++ adjusts these to `T* value`; the extent is not part of the function type and is not enforced.
+   - ❌ Bad: `void cct_to_xy(int cct, float out[2]);`
+   - ❌ Bad: `void encode(fl::u8 output[4]);`
+   - ✅ Good for normal APIs: `void cct_to_xy(int cct, fl::span<float, 2> out);`
+   - ✅ Good for ISR / `FL_IRAM` APIs: `void encode(fl::u8 (&output)[4]);`
+   - ✅ Good where a wrapper type would obscure the domain: `void set_white_point(DiodeProfile* p, fl::vec2f white_xy);`
+   - Suppress only intentional C ABI or platform compatibility cases with `// ok array parameter`.
+4. ⚠️ **For ISR / `FL_IRAM` callgraphs, prefer array references over `fl::span<T, N>`.**
+   - `fl::span<T, N>` is the right general API shape, but current span accessors are not explicitly `FASTLED_FORCE_INLINE` / `FL_IRAM`. Until an explicitly ISR-safe span exists, ISR-facing fixed-size output buffers should use `T (&value)[N]`.
+5. ✅ **For RGBW / RGBWW multi-channel output**, prefer a `fl::span<u8, 4>` (or `5`) over five separate `u8*` parameters, except inside ISR / `FL_IRAM` callgraphs where `u8 (&out)[4]` / `[5]` is preferred.
 
 **Scoped exception — deferred legacy migrations**: A `(ptr, size)` callback typedef MAY be temporarily retained in a legacy layer when migrating it would force a synchronized rewrite of every caller and the migration is being deferred to a follow-up PR. The exception requires (a) a comment at the typedef site referencing the migration plan / tracking issue, (b) naming the legacy location (current example: `src/fl/stl/cstdio.h` retains raw pointer+length handler signatures intentionally), and (c) the exception is timeboxed — it must be revisited at the next layer-wide migration window. Permanent divergence is not permitted; the goal is "all-or-nothing per-layer sweep when the engineering budget allows."
 
-**Rationale**: The base span rule prevents most of the pattern but CodeRabbit caught these two shapes in #2560, #2683, #2711. Just adding the two shapes to the canonical examples will close most remaining gaps. The scoped exception accommodates the real-world case where touching every caller in one PR isn't tractable; without it the rule pushes engineers toward unprincipled mixed APIs.
+**Rationale**: The base span rule prevents most of the pattern but CodeRabbit caught these two shapes in #2560, #2683, #2711. Issue #3233 adds clang-query lint coverage for source-spelled array parameters because `T value[N]` is especially misleading: it looks fixed-size but compiles as a pointer. The scoped exception accommodates the real-world case where touching every caller in one PR isn't tractable; without it the rule pushes engineers toward unprincipled mixed APIs.
 
 ## ISR-Shared State: `fl::atomic` or Critical Section, Never Bare `volatile`
 

--- a/ci/lint.py
+++ b/ci/lint.py
@@ -155,7 +155,8 @@ def print_ai_hints() -> None:
     print("  - Python linting includes: ruff (lint + format) + KBI checker + ty")
     print("  - Use --strict to also run pyright (strict type checking)")
     print(
-        "  - C++ linting includes: clang-format, custom checkers, and the default FL_NOEXCEPT AST ratchet"
+        "  - C++ linting includes: clang-format, custom checkers, and default AST ratchets"
+        " for FL_NOEXCEPT and decayed array parameters"
     )
     print("  - IWYU runs with --full, --iwyu, or --strict flags")
     print("  - clang-tidy runs with --tidy flag")

--- a/ci/lint/args_parser.py
+++ b/ci/lint/args_parser.py
@@ -49,6 +49,7 @@ Python linting includes:
 
 C++ linting includes:
   - clang-format and custom checkers
+  - AST ratchets for FL_NOEXCEPT and decayed array parameters
   - IWYU (Include-What-You-Use) runs with --full, --iwyu, or --strict
   - clang-tidy static analysis runs with --tidy
 

--- a/ci/lint/stage_impls.py
+++ b/ci/lint/stage_impls.py
@@ -133,7 +133,7 @@ def run_clang_tidy(no_fingerprint: bool, run_tidy: bool) -> bool:
 
 def run_noexcept_check(run_tidy: bool) -> bool:
     """
-    Report where FL_NOEXCEPT enforcement lives.
+    Report where AST-backed C++ enforcement lives.
 
     Args:
         run_tidy: Preserved for CLI compatibility
@@ -142,9 +142,12 @@ def run_noexcept_check(run_tidy: bool) -> bool:
         Always True; the default unified C++ linter owns this check.
     """
     print("")
-    print("FL_NOEXCEPT AST CHECK")
-    print("---------------------")
-    print("Handled by the default unified C++ linter: ci/tools/check_noexcept.py")
+    print("C++ AST CHECKS")
+    print("--------------")
+    print(
+        "Handled by the default unified C++ linter: "
+        "ci/tools/check_noexcept.py and ci/tools/check_array_params.py"
+    )
     return True
 
 

--- a/ci/lint_cpp/run_all_checkers.py
+++ b/ci/lint_cpp/run_all_checkers.py
@@ -608,6 +608,50 @@ def run_noexcept_ast_check(file_path: str | None = None) -> CheckerResults:
     return results
 
 
+def run_array_param_ast_check(file_path: str | None = None) -> CheckerResults:
+    """Run the clang-query decayed array parameter ratchet."""
+    from ci.tools.check_array_params import (
+        DEFAULT_BASELINE,
+        ArrayParamCheckError,
+        _diagnostic_for_hit,
+        diff_against_baseline,
+        find_decayed_array_params,
+        load_baseline,
+    )
+
+    results = CheckerResults()
+
+    scope = "all"
+    rel_file: str | None = None
+    if file_path is not None:
+        rel_file = os.path.relpath(str(Path(file_path).resolve()), PROJECT_ROOT)
+        rel_file = rel_file.replace("\\", "/")
+        if rel_file.startswith("src/fl/"):
+            scope = "fl"
+        elif rel_file.startswith("src/platforms/"):
+            scope = "platforms"
+        elif rel_file.startswith("src/third_party/"):
+            scope = "third_party"
+        else:
+            return results
+
+    try:
+        hits = find_decayed_array_params(scope)
+    except ArrayParamCheckError as exc:
+        results.add_violation("ci/tools/check_array_params.py", 0, str(exc))
+        return results
+
+    if rel_file is not None:
+        hits = [hit for hit in hits if hit.path == rel_file]
+
+    new_hits, _stale = diff_against_baseline(hits, load_baseline(DEFAULT_BASELINE))
+    for hit in new_hits:
+        abs_path = str(PROJECT_ROOT / hit.path)
+        results.add_violation(abs_path, hit.line, _diagnostic_for_hit(hit))
+
+    return results
+
+
 @dataclass(frozen=True)
 class LegacyViolationLineContent:
     line_number: int
@@ -911,6 +955,10 @@ def main() -> int:
         if noexcept_results.has_violations():
             results["NoexceptAstChecker"] = noexcept_results
 
+        array_param_results = run_array_param_ast_check(str(file_path))
+        if array_param_results.has_violations():
+            results["ArrayParamAstChecker"] = array_param_results
+
         # Format and print results
         if rust_ab and not run_rust_ab_check(results, [str(file_path)]):
             return 1
@@ -968,6 +1016,10 @@ def main() -> int:
         noexcept_results = run_noexcept_ast_check()
         if noexcept_results.has_violations():
             results["NoexceptAstChecker"] = noexcept_results
+
+        array_param_results = run_array_param_ast_check()
+        if array_param_results.has_violations():
+            results["ArrayParamAstChecker"] = array_param_results
 
         # Format and print results
         if rust_ab and not run_rust_ab_check(results, None):

--- a/ci/tools/array_param_baseline.txt
+++ b/ci/tools/array_param_baseline.txt
@@ -1,0 +1,43 @@
+# Known decayed C array parameters for ci/tools/check_array_params.py.
+# Generated with:
+#   uv run python ci/tools/check_array_params.py --scope all --update-baseline
+#
+# Format: src/path|normalized source signature
+# New entries fail the default unified C++ linter.
+
+src/fl/gfx/rgbw.cpp.hpp|void set_input_gamut(DiodeProfile* profile, InputGamut g, const float white_xy[2]) FL_NOEXCEPT {
+src/fl/gfx/rgbw.h|void set_input_gamut(DiodeProfile* profile, InputGamut g, const float white_xy[2]) FL_NOEXCEPT;
+src/fl/gfx/rgbw_colorimetric.h|inline void nnls3(const float M[3][3], const float b[3], float t_out[3], float* residual_out) FL_NOEXCEPT {
+src/fl/math/transposition.cpp.hpp|bool SPITransposer::transpose16(const fl::optional<LaneData> lanes[16], fl::span<u8> output, const char** error) {
+src/fl/math/transposition.cpp.hpp|bool SPITransposer::transpose8(const fl::optional<LaneData> lanes[8], fl::span<u8> output, const char** error) {
+src/fl/math/transposition.h|FASTLED_FORCE_INLINE void transpose_2strips( const u8* const input[2], u8* output, u16 num_leds, u8 bytes_per_led ) FL_NOEXCEPT {
+src/fl/math/transposition.h|FASTLED_FORCE_INLINE void transpose_4strips( const u8* const input[4], u8* output, u16 num_leds, u8 bytes_per_led ) FL_NOEXCEPT {
+src/fl/math/transposition.h|FASTLED_FORCE_INLINE void transpose_8strips( const u8* const input[8], u8* output, u16 num_leds, u8 bytes_per_led ) FL_NOEXCEPT {
+src/fl/math/transposition.h|inline void transpose_16lane_inline( const u8* const lanes[16], u8* output, size_t num_bytes ) FL_NOEXCEPT {
+src/fl/math/transposition.h|inline void transpose_16lane_inline( const u8* const lanes[16], u8* output, size_t num_bytes ) FL_NOEXCEPT;
+src/fl/math/transposition.h|inline void transpose_4lane_inline( const u8* const lanes[4], u8* output, size_t num_bytes ) FL_NOEXCEPT {
+src/fl/math/transposition.h|inline void transpose_4lane_inline( const u8* const lanes[4], u8* output, size_t num_bytes ) FL_NOEXCEPT;
+src/fl/math/transposition.h|inline void transpose_8lane_inline( const u8* const lanes[8], u8* output, size_t num_bytes ) FL_NOEXCEPT {
+src/fl/math/transposition.h|inline void transpose_8lane_inline( const u8* const lanes[8], u8* output, size_t num_bytes ) FL_NOEXCEPT;
+src/fl/math/transposition.h|inline void transpose_generic_inline( const TSource* const lanes[], size_t num_lanes, u8* output, size_t num_items ) FL_NOEXCEPT {
+src/fl/math/transposition.h|inline void transpose_generic_inline( const TSource* const lanes[], size_t num_lanes, u8* output, size_t num_items ) FL_NOEXCEPT;
+src/fl/math/transposition.h|static bool transpose16(const fl::optional<LaneData> lanes[16], fl::span<u8> output, const char** error = nullptr) FL_NOEXCEPT;
+src/fl/math/transposition.h|static bool transpose8(const fl::optional<LaneData> lanes[8], fl::span<u8> output, const char** error = nullptr) FL_NOEXCEPT;
+src/third_party/TJpg_Decoder/src/TJpg_Decoder.cpp.hpp|JRESULT TJpg_Decoder::getJpgSize(uint16_t *w, uint16_t *h, const uint8_t jpeg_data[], size_t data_size) FL_NOEXCEPT {
+src/third_party/TJpg_Decoder/src/TJpg_Decoder.h|JRESULT getJpgSize(uint16_t *w, uint16_t *h, const uint8_t array[], size_t array_size) FL_NOEXCEPT;
+src/third_party/libhelix_mp3/mp3dec.hpp|static int MP3FindFreeSync(const unsigned char *buf, const unsigned char firstFH[4], int nBytes) FL_NOEXCEPT {
+src/third_party/libhelix_mp3/real/coder.h|void IntensityProcMPEG1(int32_t x[MAX_NCHAN][MAX_NSAMP], int32_t nSamps, FrameHeader *fh, ScaleFactorInfoSub *sfis, CriticalBandInfo *cbi, int32_t midSideFlag, int32_t mixFlag, int32_t mOut[2]) FL_NOEXCEPT;
+src/third_party/libhelix_mp3/real/coder.h|void IntensityProcMPEG2(int32_t x[MAX_NCHAN][MAX_NSAMP], int32_t nSamps, FrameHeader *fh, ScaleFactorInfoSub *sfis, CriticalBandInfo *cbi, ScaleFactorJS *sfjs, int32_t midSideFlag, int32_t mixFlag, int32_t mOut[2]) FL_NOEXCEPT;
+src/third_party/libhelix_mp3/real/imdct.hpp|static int32_t HybridTransform(int32_t *xCurr, int32_t *xPrev, int32_t y[BLOCK_SIZE][NBANDS], SideInfoSub *sis, BlockCount *bc) FL_NOEXCEPT {
+src/third_party/libhelix_mp3/real/stproc.hpp|void IntensityProcMPEG1(int32_t x[MAX_NCHAN][MAX_NSAMP], int32_t nSamps, FrameHeader *fh, ScaleFactorInfoSub *sfis, CriticalBandInfo *cbi, int32_t midSideFlag, int32_t mixFlag, int32_t mOut[2]) FL_NOEXCEPT {
+src/third_party/libhelix_mp3/real/stproc.hpp|void IntensityProcMPEG2(int32_t x[MAX_NCHAN][MAX_NSAMP], int32_t nSamps, FrameHeader *fh, ScaleFactorInfoSub *sfis, CriticalBandInfo *cbi, ScaleFactorJS *sfjs, int32_t midSideFlag, int32_t mixFlag, int32_t mOut[2]) FL_NOEXCEPT {
+src/third_party/libnsgif/include/nsgif.hpp|bool nsgif_local_palette( const nsgif_t *gif, fl::u32 frame, fl::u32 table[NSGIF_MAX_COLOURS], fl::size *entries) FL_NOEXCEPT;
+src/third_party/libnsgif/include/nsgif.hpp|void nsgif_global_palette( const nsgif_t *gif, fl::u32 table[NSGIF_MAX_COLOURS], fl::size *entries) FL_NOEXCEPT;
+src/third_party/libnsgif/src/gif.cpp.hpp|bool nsgif_local_palette( const nsgif_t *gif, fl::u32 frame, fl::u32 table[NSGIF_MAX_COLOURS], fl::size *entries) FL_NOEXCEPT {
+src/third_party/libnsgif/src/gif.cpp.hpp|static inline nsgif_error nsgif__colour_table_extract( fl::u32 colour_table[NSGIF_MAX_COLOURS], const struct nsgif_colour_layout *layout, fl::size colour_table_entries, const fl::u8 *data, fl::size data_len, fl::size *used, bool decode) FL_NOEXCEPT {
+src/third_party/libnsgif/src/gif.cpp.hpp|static void nsgif__colour_table_decode( fl::u32 colour_table[NSGIF_MAX_COLOURS], const struct nsgif_colour_layout *layout, fl::size colour_table_entries, const fl::u8 *data) FL_NOEXCEPT {
+src/third_party/libnsgif/src/gif.cpp.hpp|void nsgif_global_palette( const nsgif_t *gif, fl::u32 table[NSGIF_MAX_COLOURS], fl::size *entries) FL_NOEXCEPT {
+src/third_party/pl_mpeg/src/pl_mpeg.hpp|void plm_audio_idct36(int s[32][3], int ss, float *d, int dp) FL_NOEXCEPT {
+src/third_party/pl_mpeg/src/pl_mpeg.hpp|void plm_audio_idct36(int s[32][3], int ss, float *d, int dp) FL_NOEXCEPT;
+src/third_party/stb/hexwave/stb_hexwave.cpp.hpp|static void hexwave_generate_linesegs(hexvert vert[9], HexWave *hex, float dt) FL_NOEXCEPT {
+src/third_party/stb/stb_vorbis.cpp.hpp|static void decode_residue(vorb *f, float *residue_buffers[], int32_t ch, int32_t n, int32_t rn, uint8 *do_not_decode) FL_NOEXCEPT {

--- a/ci/tools/check_array_params.py
+++ b/ci/tools/check_array_params.py
@@ -1,0 +1,479 @@
+#!/usr/bin/env python3
+"""AST-backed enforcement against decayed C array parameters.
+
+C++ adjusts function parameters spelled as arrays, such as ``float out[2]``,
+to pointer parameters. The extent is therefore documentation only. This check
+uses clang-query to find FastLED-owned function declarations with pointer
+parameters, then inspects the source-spelled signature to catch parameters
+written with the misleading array syntax.
+
+Usage:
+    uv run python ci/tools/check_array_params.py
+    uv run python ci/tools/check_array_params.py --scope platforms
+    uv run python ci/tools/check_array_params.py --update-baseline
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import shutil
+import subprocess
+import sys
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+DEFAULT_BASELINE = PROJECT_ROOT / "ci" / "tools" / "array_param_baseline.txt"
+
+_TU_PLATFORMS = "ci/tools/_noexcept_check_platforms_tu.cpp"
+_TU_FL = "ci/tools/_noexcept_check_fl_tu.cpp"
+_TU_THIRD_PARTY = "ci/tools/_noexcept_check_third_party_tu.cpp"
+
+_SCOPES: dict[str, list[tuple[str, str]]] = {
+    "platforms": [(_TU_PLATFORMS, ".*src.platforms.*")],
+    "fl": [(_TU_FL, ".*src.fl.*")],
+    "third_party": [(_TU_THIRD_PARTY, ".*src.third_party.*")],
+    "all": [
+        (_TU_PLATFORMS, ".*src.platforms.*"),
+        (_TU_FL, ".*src.fl.*"),
+        (_TU_THIRD_PARTY, ".*src.third_party.*"),
+    ],
+}
+
+_COMPILER_ARGS = [
+    "-std=c++17",
+    "-Isrc",
+    "-Isrc/platforms/stub",
+    "-DSTUB_PLATFORM",
+    "-DARDUINO=10808",
+    "-DFASTLED_USE_STUB_ARDUINO",
+    "-DFASTLED_STUB_IMPL",
+    "-DFASTLED_TESTING",
+    "-DFASTLED_NO_AUTO_NAMESPACE",
+    "-fno-exceptions",
+]
+
+_MATCH_OUTPUT_RE = re.compile(r"(src[\\/]\S+):(\d+):\d+: note: .root. binds here")
+_SUPPRESS_RE = re.compile(r"//\s*(?:ok\s+array\s+parameter|nolint)\b", re.IGNORECASE)
+_MACRO_INVOCATION_RE = re.compile(r"^\s*[A-Z][A-Z0-9_]*\s*\(")
+_ARRAY_PARAM_RE = re.compile(
+    r"\b(?P<name>[A-Za-z_]\w*)\s*(?P<extent>(?:\[[^\]]*\]\s*)+)"
+)
+_IRAM_RE = re.compile(r"\bFL_IRAM\b")
+
+
+class ArrayParamCheckError(RuntimeError):
+    """Raised when the clang-query based check cannot run."""
+
+
+@dataclass(frozen=True)
+class ArrayParamFinding:
+    """One source-spelled decayed array parameter."""
+
+    name: str
+    spelling: str
+    is_iram: bool
+
+
+@dataclass(frozen=True)
+class ArrayParamHit:
+    """One source signature with at least one decayed array parameter."""
+
+    path: str
+    line: int
+    line_text: str
+    signature: str
+    findings: tuple[ArrayParamFinding, ...]
+
+    @property
+    def baseline_key(self) -> str:
+        return f"{self.path}|{normalize_signature(self.signature)}"
+
+
+def build_query(file_regex: str) -> str:
+    """Build the clang-query matcher for candidate owned functions."""
+    matcher = (
+        "match functionDecl("
+        "unless(isImplicit()), "
+        "unless(cxxMethodDecl(ofClass(cxxRecordDecl(isLambda())))), "
+        "unless(hasParent(linkageSpecDecl())), "
+        "hasAnyParameter(parmVarDecl(hasType(pointerType()))), "
+        f'isExpansionInFileMatching("{file_regex}")).bind("root")'
+    )
+    return f"set output diag\n{matcher}\n"
+
+
+def normalize_signature(signature: str) -> str:
+    """Collapse a source signature into a stable one-line baseline key."""
+    without_comments = " ".join(
+        line.split("//", 1)[0].strip() for line in signature.splitlines()
+    )
+    return re.sub(r"\s+", " ", without_comments).strip()
+
+
+def load_baseline(path: Path = DEFAULT_BASELINE) -> Counter[str]:
+    """Load the checked-in baseline as a counted set of signature keys."""
+    baseline: Counter[str] = Counter()
+    if not path.exists():
+        return baseline
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        baseline[line] += 1
+    return baseline
+
+
+def write_baseline(hits: list[ArrayParamHit], path: Path = DEFAULT_BASELINE) -> None:
+    """Write a deterministic baseline for the current AST findings."""
+    keys = sorted(hit.baseline_key for hit in hits)
+    content = [
+        "# Known decayed C array parameters for ci/tools/check_array_params.py.",
+        "# Generated with:",
+        "#   uv run python ci/tools/check_array_params.py --scope all --update-baseline",
+        "#",
+        "# Format: src/path|normalized source signature",
+        "# New entries fail the default unified C++ linter.",
+        "",
+    ]
+    content.extend(keys)
+    path.write_text("\n".join(content) + "\n", encoding="utf-8")
+
+
+def diff_against_baseline(
+    hits: list[ArrayParamHit], baseline: Counter[str]
+) -> tuple[list[ArrayParamHit], list[str]]:
+    """Return non-baselined hits and stale baseline keys."""
+    remaining = baseline.copy()
+    new_hits: list[ArrayParamHit] = []
+    current: Counter[str] = Counter()
+
+    for hit in hits:
+        key = hit.baseline_key
+        current[key] += 1
+        if remaining[key] > 0:
+            remaining[key] -= 1
+        else:
+            new_hits.append(hit)
+
+    stale: list[str] = []
+    for key, count in (baseline - current).items():
+        stale.extend([key] * count)
+    return new_hits, stale
+
+
+def _find_clang_query() -> list[str]:
+    """Find clang-query, preferring direct binaries but falling back to uv."""
+    system_path = Path("C:/Program Files/LLVM/bin/clang-query.exe")
+    if system_path.exists():
+        return [str(system_path)]
+
+    cache_path = (
+        PROJECT_ROOT / ".cache" / "clang-tools" / "clang" / "bin" / "clang-query.exe"
+    )
+    if cache_path.exists():
+        return [str(cache_path)]
+
+    found = shutil.which("clang-query")
+    if found:
+        return [found]
+
+    wrapper = shutil.which("clang-tool-chain-query")
+    if wrapper:
+        return [wrapper]
+
+    uv = shutil.which("uv")
+    if uv:
+        return [uv, "run", "clang-tool-chain-query"]
+
+    return []
+
+
+def _read_source_signature(filepath: str, line_num: int) -> tuple[str, str]:
+    """Return display line and full source signature for an AST match."""
+    full_path = PROJECT_ROOT / filepath
+    if not full_path.exists():
+        return "", ""
+
+    lines = full_path.read_text(encoding="utf-8", errors="replace").splitlines()
+    if line_num < 1 or line_num > len(lines):
+        return "", ""
+
+    display_line = lines[line_num - 1].strip()
+    signature_lines: list[str] = []
+    paren_depth = 0
+    found_open = False
+
+    for idx in range(line_num - 1, min(line_num + 59, len(lines))):
+        raw = lines[idx].rstrip()
+        signature_lines.append(raw)
+        code = raw.split("//", 1)[0]
+        for ch in code:
+            if ch == "(":
+                paren_depth += 1
+                found_open = True
+            elif ch == ")":
+                paren_depth -= 1
+            elif ch in (";", "{") and found_open and paren_depth == 0:
+                return display_line, "\n".join(signature_lines)
+
+    return display_line, "\n".join(signature_lines)
+
+
+def _signature_is_exempt(signature: str) -> bool:
+    """Return True for documented non-actionable constructs."""
+    if not signature:
+        return True
+    if _SUPPRESS_RE.search(signature):
+        return True
+
+    code = "\n".join(line.split("//", 1)[0] for line in signature.splitlines())
+    if _MACRO_INVOCATION_RE.match(code):
+        return True
+    if 'extern "C"' in code:
+        return True
+    return False
+
+
+def _strip_comments(signature: str) -> str:
+    """Remove comments while preserving enough shape for signature parsing."""
+    without_block = re.sub(r"/\*.*?\*/", "", signature, flags=re.DOTALL)
+    return "\n".join(line.split("//", 1)[0] for line in without_block.splitlines())
+
+
+def _extract_parameter_text(signature: str) -> str:
+    """Return the first top-level function parameter list, without parens."""
+    code = _strip_comments(signature)
+    start = code.find("(")
+    if start < 0:
+        return ""
+
+    depth = 0
+    for index in range(start, len(code)):
+        ch = code[index]
+        if ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+            if depth == 0:
+                return code[start + 1 : index]
+    return ""
+
+
+def _split_parameters(parameter_text: str) -> list[str]:
+    """Split a parameter list on top-level commas."""
+    params: list[str] = []
+    start = 0
+    paren = angle = bracket = brace = 0
+    for index, ch in enumerate(parameter_text):
+        if ch == "(":
+            paren += 1
+        elif ch == ")":
+            paren -= 1
+        elif ch == "<":
+            angle += 1
+        elif ch == ">" and angle:
+            angle -= 1
+        elif ch == "[":
+            bracket += 1
+        elif ch == "]":
+            bracket -= 1
+        elif ch == "{":
+            brace += 1
+        elif ch == "}":
+            brace -= 1
+        elif ch == "," and not any((paren, angle, bracket, brace)):
+            params.append(parameter_text[start:index].strip())
+            start = index + 1
+    tail = parameter_text[start:].strip()
+    if tail:
+        params.append(tail)
+    return params
+
+
+def _find_array_params_in_signature(signature: str) -> tuple[ArrayParamFinding, ...]:
+    """Find source-spelled array parameters that decay to pointers."""
+    if _signature_is_exempt(signature):
+        return ()
+
+    is_iram = bool(_IRAM_RE.search(_strip_comments(signature)))
+    findings: list[ArrayParamFinding] = []
+    for param in _split_parameters(_extract_parameter_text(signature)):
+        for match in _ARRAY_PARAM_RE.finditer(param):
+            name = match.group("name")
+            extent = re.sub(r"\s+", "", match.group("extent"))
+            spelling = f"{name}{extent}"
+            findings.append(
+                ArrayParamFinding(name=name, spelling=spelling, is_iram=is_iram)
+            )
+            break
+    return tuple(findings)
+
+
+def _run_clang_query(
+    clang_query: list[str], tu: str, file_regex: str
+) -> list[ArrayParamHit]:
+    """Run clang-query and return source-filtered array parameter hits."""
+    result = subprocess.run(
+        [*clang_query, tu, "--", *_COMPILER_ARGS],
+        input=build_query(file_regex),
+        capture_output=True,
+        text=True,
+        cwd=str(PROJECT_ROOT),
+        timeout=300,
+    )
+    output = result.stdout + result.stderr
+    if result.returncode != 0:
+        raise ArrayParamCheckError(output.strip() or "clang-query failed")
+    if (
+        "Error parsing argument" in output
+        or "Error parsing matcher" in output
+        or "Matcher not found" in output
+    ):
+        raise ArrayParamCheckError(output.strip())
+
+    hits: list[ArrayParamHit] = []
+    seen: set[tuple[str, int]] = set()
+    for match in _MATCH_OUTPUT_RE.finditer(output):
+        filepath = match.group(1).replace("\\", "/")
+        line_num = int(match.group(2))
+        key = (filepath, line_num)
+        if key in seen:
+            continue
+        seen.add(key)
+
+        line_text, signature = _read_source_signature(filepath, line_num)
+        findings = _find_array_params_in_signature(signature)
+        if not findings:
+            continue
+        hits.append(
+            ArrayParamHit(
+                path=filepath,
+                line=line_num,
+                line_text=line_text,
+                signature=signature,
+                findings=findings,
+            )
+        )
+    return hits
+
+
+def find_decayed_array_params(scope: str = "all") -> list[ArrayParamHit]:
+    """Find current non-exempt decayed array parameter signatures."""
+    clang_query = _find_clang_query()
+    if not clang_query:
+        raise ArrayParamCheckError(
+            "clang-query not found. Install LLVM or the clang-tool-chain package."
+        )
+
+    all_hits: list[ArrayParamHit] = []
+    for tu, file_regex in _SCOPES[scope]:
+        if not (PROJECT_ROOT / tu).exists():
+            raise ArrayParamCheckError(f"translation unit not found: {tu}")
+        all_hits.extend(_run_clang_query(clang_query, tu, file_regex))
+    return all_hits
+
+
+def _diagnostic_for_hit(hit: ArrayParamHit) -> str:
+    """Return the lint diagnostic for a hit."""
+    spellings = ", ".join(finding.spelling for finding in hit.findings)
+    if any(finding.is_iram for finding in hit.findings):
+        replacement = "Use 'T (&value)[N]' for ISR-safe fixed-size parameters."
+    else:
+        replacement = "Use 'fl::span<T, N>' or 'T (&value)[N]'."
+    return (
+        f"Decayed C array parameter(s): {spellings}. Function parameter arrays "
+        f"decay to pointers, so the size is not enforced. {replacement} "
+        "Suppress only intentional C ABI/platform cases with '// ok array parameter'."
+    )
+
+
+def _print_hits(hits: list[ArrayParamHit]) -> None:
+    by_file: dict[str, list[ArrayParamHit]] = {}
+    for hit in hits:
+        by_file.setdefault(hit.path, []).append(hit)
+
+    for filepath in sorted(by_file):
+        print(f"{filepath}:")
+        for hit in sorted(by_file[filepath], key=lambda item: item.line):
+            print(f"  Line {hit.line}: {hit.line_text}")
+            print(f"    {_diagnostic_for_hit(hit)}")
+        print()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Check for decayed C array parameters in src/fl, src/platforms, "
+            "and src/third_party using clang-query AST analysis."
+        )
+    )
+    parser.add_argument(
+        "--scope",
+        choices=sorted(_SCOPES.keys()),
+        default="all",
+        help="Which owned src scope to check (default: all)",
+    )
+    parser.add_argument(
+        "--baseline",
+        type=Path,
+        default=DEFAULT_BASELINE,
+        help="Baseline file for existing decayed array parameters",
+    )
+    parser.add_argument(
+        "--no-baseline",
+        action="store_true",
+        help="Report every current finding instead of only new findings",
+    )
+    parser.add_argument(
+        "--update-baseline",
+        action="store_true",
+        help="Rewrite the baseline with the current findings",
+    )
+    args = parser.parse_args()
+
+    try:
+        hits = find_decayed_array_params(args.scope)
+    except ArrayParamCheckError as exc:
+        print(f"ERROR: {exc}")
+        return 1
+
+    if args.update_baseline:
+        write_baseline(hits, args.baseline)
+        print(f"Wrote {len(hits)} array parameter baseline entries to {args.baseline}")
+        return 0
+
+    if args.no_baseline:
+        report_hits = hits
+        stale: list[str] = []
+    else:
+        report_hits, stale = diff_against_baseline(hits, load_baseline(args.baseline))
+
+    if stale:
+        print(
+            f"NOTE: {len(stale)} stale array parameter baseline entrie(s) can be pruned."
+        )
+        print("      Re-run with --update-baseline after intentional cleanup.")
+        print()
+
+    if not report_hits:
+        print("All non-baselined owned src functions avoid decayed array parameters.")
+        print(f"Known baseline entries: {len(hits) - len(report_hits)}")
+        return 0
+
+    print(f"Found {len(report_hits)} non-baselined decayed array parameter use(s):")
+    print()
+    _print_hits(report_hits)
+    print(
+        "Use array references for ISR/FL_IRAM APIs, fl::span<T, N> or array "
+        "references elsewhere, or add a documented suppression for deliberate "
+        "C ABI/platform compatibility."
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ci/tools/test_check_array_params.py
+++ b/ci/tools/test_check_array_params.py
@@ -1,0 +1,167 @@
+from collections import Counter
+
+from ci.tools import check_array_params
+
+
+def test_query_uses_ast_to_find_owned_pointer_parameter_functions() -> None:
+    query = check_array_params.build_query(".*src.fl.*")
+
+    assert "functionDecl(" in query
+    assert "hasAnyParameter(parmVarDecl(hasType(pointerType())))" in query
+    assert "unless(isImplicit())" in query
+    assert "isLambda()" in query
+    assert "linkageSpecDecl()" in query
+    assert 'isExpansionInFileMatching(".*src.fl.*")' in query
+
+
+def test_signature_exemptions() -> None:
+    assert check_array_params._signature_is_exempt(
+        "void c_api(float out[2]); // ok array parameter"
+    )
+    assert check_array_params._signature_is_exempt(
+        "void c_api(float out[2]); // NOLINT"
+    )
+    assert check_array_params._signature_is_exempt(
+        "FASTLED_INTERNAL_CALLBACK(float out[2])"
+    )
+    assert check_array_params._signature_is_exempt(
+        'extern "C" void c_api(float out[2]);'
+    )
+
+
+def test_rejects_fixed_and_unsized_array_parameters() -> None:
+    findings = check_array_params._find_array_params_in_signature(
+        "void f(float out[2], const unsigned char bytes[]);"
+    )
+
+    assert [finding.spelling for finding in findings] == ["out[2]", "bytes[]"]
+
+
+def test_rejects_multidimensional_array_parameter() -> None:
+    findings = check_array_params._find_array_params_in_signature(
+        "void f(float matrix[2][3]);"
+    )
+
+    assert [finding.spelling for finding in findings] == ["matrix[2][3]"]
+
+
+def test_allows_array_reference_parameter() -> None:
+    findings = check_array_params._find_array_params_in_signature(
+        "void f(float (&out)[2], const float (&input)[3]);"
+    )
+
+    assert findings == ()
+
+
+def test_allows_span_parameter() -> None:
+    findings = check_array_params._find_array_params_in_signature(
+        "void f(fl::span<float, 2> out, fl::span<const fl::u8> bytes);"
+    )
+
+    assert findings == ()
+
+
+def test_ignores_local_array_and_member_array_in_function_body() -> None:
+    signature = """
+    struct Holder { float member[2]; };
+    void f(float* out) {
+        float tmp[2] = {};
+        out[0] = tmp[0];
+    }
+    """
+
+    assert check_array_params._find_array_params_in_signature(signature) == ()
+
+
+def test_handles_multiline_signature_and_top_level_commas() -> None:
+    signature = """
+    void f(
+        fl::span<const fl::pair<int, int>> pairs,
+        float out[2],
+        void (*callback)(int, int)
+    ) FL_NOEXCEPT;
+    """
+
+    findings = check_array_params._find_array_params_in_signature(signature)
+
+    assert [finding.spelling for finding in findings] == ["out[2]"]
+
+
+def test_marks_iram_signatures_for_array_reference_recommendation() -> None:
+    findings = check_array_params._find_array_params_in_signature(
+        "FL_IRAM void f(fl::u8 out[4]) FL_NOEXCEPT;"
+    )
+    hit = check_array_params.ArrayParamHit(
+        path="src/platforms/example.h",
+        line=10,
+        line_text="FL_IRAM void f(fl::u8 out[4]) FL_NOEXCEPT;",
+        signature="FL_IRAM void f(fl::u8 out[4]) FL_NOEXCEPT;",
+        findings=findings,
+    )
+
+    assert findings[0].is_iram
+    assert "Use 'T (&value)[N]' for ISR-safe" in check_array_params._diagnostic_for_hit(
+        hit
+    )
+
+
+def test_non_iram_diagnostic_allows_span_or_array_reference() -> None:
+    findings = check_array_params._find_array_params_in_signature(
+        "void f(fl::u8 out[4]) FL_NOEXCEPT;"
+    )
+    hit = check_array_params.ArrayParamHit(
+        path="src/fl/example.h",
+        line=10,
+        line_text="void f(fl::u8 out[4]) FL_NOEXCEPT;",
+        signature="void f(fl::u8 out[4]) FL_NOEXCEPT;",
+        findings=findings,
+    )
+
+    diagnostic = check_array_params._diagnostic_for_hit(hit)
+
+    assert "fl::span<T, N>" in diagnostic
+    assert "T (&value)[N]" in diagnostic
+
+
+def test_baseline_diff_counts_duplicate_signatures() -> None:
+    hits = [
+        check_array_params.ArrayParamHit(
+            path="src/fl/example.h",
+            line=10,
+            line_text="void foo(float out[2]);",
+            signature="void foo(float out[2]);",
+            findings=(
+                check_array_params.ArrayParamFinding(
+                    name="out", spelling="out[2]", is_iram=False
+                ),
+            ),
+        ),
+        check_array_params.ArrayParamHit(
+            path="src/fl/example.h",
+            line=11,
+            line_text="void foo(float out[2]);",
+            signature="void foo(float out[2]);",
+            findings=(
+                check_array_params.ArrayParamFinding(
+                    name="out", spelling="out[2]", is_iram=False
+                ),
+            ),
+        ),
+        check_array_params.ArrayParamHit(
+            path="src/fl/example.h",
+            line=12,
+            line_text="void bar(float out[]);",
+            signature="void bar(float out[]);",
+            findings=(
+                check_array_params.ArrayParamFinding(
+                    name="out", spelling="out[]", is_iram=False
+                ),
+            ),
+        ),
+    ]
+    baseline = Counter({hits[0].baseline_key: 1, "src/fl/example.h|void old();": 1})
+
+    new_hits, stale = check_array_params.diff_against_baseline(hits, baseline)
+
+    assert [hit.line for hit in new_hits] == [11, 12]
+    assert stale == ["src/fl/example.h|void old();"]


### PR DESCRIPTION
﻿## Summary

- Add `ci/tools/check_array_params.py`, a clang-query-backed ratchet for function parameters spelled as C arrays (`T value[N]` / `T value[]`).
- Wire the checker into the unified C++ linter in full-repo and single-file modes with a checked-in baseline for existing debt.
- Update CodeRabbit and FastLED agent review guidance so reviews apply the same ISR vs non-ISR replacement policy.

Closes #3233

Follow-up filed while implementing: #3234 audits whether `set_input_gamut(DiodeProfile* profile, ...)` should keep mutable pointer semantics or move to references.

## Verification

- `uv run pytest ci/tools/test_check_noexcept.py ci/tools/test_check_array_params.py -q`
- `uv run python ci/tools/check_array_params.py --scope all`
- `git diff --check`
- Temporary probe: changed an existing baseline signature from `white_xy[2]` to `white_xy[3]`; `uv run python ci/lint_cpp/run_all_checkers.py src/fl/gfx/rgbw.h` failed with `ArrayParamAstChecker`, then the probe was reverted.
- `uv run python ci/lint_cpp/run_all_checkers.py src/fl/gfx/rgbw.h`
- `bash lint`
- `bash test --cpp` (330/330 passed)
