### PR TITLE
perf(flat_map): type-erase lower_bound / upper_bound binary search (#3235 Tier 2D)

### DIFF
--- a/src/fl/stl/_build.cpp.hpp
+++ b/src/fl/stl/_build.cpp.hpp
@@ -12,6 +12,7 @@
 #include "fl/stl/cstdio.cpp.hpp"
 #include "fl/stl/cstdlib.cpp.hpp"
 #include "fl/stl/cstring.cpp.hpp"
+#include "fl/stl/flat_map_basic.cpp.hpp"
 #include "fl/stl/fstream.cpp.hpp"
 #include "fl/stl/ieee754_string.cpp.hpp"
 #include "fl/stl/ios.cpp.hpp"

--- a/src/fl/stl/flat_map.h
+++ b/src/fl/stl/flat_map.h
@@ -5,6 +5,7 @@
 #include "fl/stl/algorithm.h"
 #include "fl/stl/assert.h"  // IWYU pragma: keep
 #include "fl/stl/comparators.h"
+#include "fl/stl/flat_map_basic.h"  // type-erased binary-search helpers (#3235 Tier 2D)
 #include "fl/stl/pair.h"
 #include "fl/stl/vector.h"
 #include "fl/stl/allocator.h"
@@ -162,77 +163,51 @@ class flat_map {
         return contains(key);
     }
 
-    // Bounds - binary search using pointer arithmetic
-    iterator lower_bound(const Key& key) FL_NOEXCEPT {
-        // Binary search: find first element where !(element < key)
-        iterator first = mData.begin();
-        size_type count = mData.size();
+    // Bounds - delegate to the type-erased binary-search core. The per-Sig
+    // tax (~80-150 B of duplicated binary-search code per instantiation)
+    // shifts to a one-time ~80 B body in `fl/stl/flat_map_basic.cpp.hpp`
+    // shared across every `flat_map<K, V, Less>` instantiation in the
+    // binary. See FastLED #3235 Tier 2D.
+private:
+    template <typename L = Less>
+    static bool less_thunk(const void* ctx, const void* a, const void* b) FL_NOEXCEPT {
+        const L* less = static_cast<const L*>(ctx);
+        const Key* ka = static_cast<const Key*>(a);
+        const Key* kb = static_cast<const Key*>(b);
+        return (*less)(*ka, *kb);
+    }
 
-        while (count > 0) {
-            size_type step = count / 2;
-            iterator it = first + step;
-            if (mLess(it->first, key)) {
-                first = it + 1;
-                count -= step + 1;
-            } else {
-                count = step;
-            }
-        }
-        return first;
+    detail::flat_map_ops make_ops() const FL_NOEXCEPT {
+        detail::flat_map_ops ops;
+        ops.less_fn = &less_thunk<Less>;
+        ops.less_ctx = static_cast<const void*>(&mLess);
+        ops.element_size = sizeof(value_type);
+        return ops;
+    }
+
+public:
+    iterator lower_bound(const Key& key) FL_NOEXCEPT {
+        fl::size idx = detail::flat_map_lower_bound_idx(
+            mData.data(), mData.size(), &key, make_ops());
+        return mData.begin() + idx;
     }
 
     const_iterator lower_bound(const Key& key) const FL_NOEXCEPT {
-        // Binary search: find first element where !(element < key)
-        const_iterator first = mData.begin();
-        size_type count = mData.size();
-
-        while (count > 0) {
-            size_type step = count / 2;
-            const_iterator it = first + step;
-            if (mLess(it->first, key)) {
-                first = it + 1;
-                count -= step + 1;
-            } else {
-                count = step;
-            }
-        }
-        return first;
+        fl::size idx = detail::flat_map_lower_bound_idx(
+            mData.data(), mData.size(), &key, make_ops());
+        return mData.begin() + idx;
     }
 
     iterator upper_bound(const Key& key) FL_NOEXCEPT {
-        // Binary search: find first element where key < element
-        iterator first = mData.begin();
-        size_type count = mData.size();
-
-        while (count > 0) {
-            size_type step = count / 2;
-            iterator it = first + step;
-            if (!mLess(key, it->first)) {
-                first = it + 1;
-                count -= step + 1;
-            } else {
-                count = step;
-            }
-        }
-        return first;
+        fl::size idx = detail::flat_map_upper_bound_idx(
+            mData.data(), mData.size(), &key, make_ops());
+        return mData.begin() + idx;
     }
 
     const_iterator upper_bound(const Key& key) const FL_NOEXCEPT {
-        // Binary search: find first element where key < element
-        const_iterator first = mData.begin();
-        size_type count = mData.size();
-
-        while (count > 0) {
-            size_type step = count / 2;
-            const_iterator it = first + step;
-            if (!mLess(key, it->first)) {
-                first = it + 1;
-                count -= step + 1;
-            } else {
-                count = step;
-            }
-        }
-        return first;
+        fl::size idx = detail::flat_map_upper_bound_idx(
+            mData.data(), mData.size(), &key, make_ops());
+        return mData.begin() + idx;
     }
 
     fl::pair<iterator, iterator> equal_range(const Key& key) FL_NOEXCEPT {

--- a/src/fl/stl/flat_map_basic.cpp.hpp
+++ b/src/fl/stl/flat_map_basic.cpp.hpp
@@ -1,0 +1,57 @@
+// IWYU pragma: private, include "fl/stl/flat_map_basic.h"
+//
+// flat_map_basic: implementation of the type-erased binary-search
+// helpers shared across all `fl::flat_map<K, V, Less>` instantiations.
+// See `flat_map_basic.h` for design rationale (FastLED #3235 Tier 2D).
+
+#include "fl/stl/flat_map_basic.h"
+
+namespace fl {
+namespace detail {
+
+FL_NO_INLINE
+fl::size flat_map_lower_bound_idx(const void* data, fl::size n,
+                                  const void* key,
+                                  const flat_map_ops& ops) FL_NOEXCEPT {
+    const char* base = static_cast<const char*>(data);
+    fl::size first_idx = 0;
+    fl::size count = n;
+    while (count > 0) {
+        fl::size step = count / 2;
+        fl::size mid_idx = first_idx + step;
+        // `.first` of `pair<Key, Value>` is at offset 0 (standard layout).
+        const void* mid_key = base + mid_idx * ops.element_size;
+        if (ops.less_fn(ops.less_ctx, mid_key, key)) {
+            first_idx = mid_idx + 1;
+            count -= step + 1;
+        } else {
+            count = step;
+        }
+    }
+    return first_idx;
+}
+
+FL_NO_INLINE
+fl::size flat_map_upper_bound_idx(const void* data, fl::size n,
+                                  const void* key,
+                                  const flat_map_ops& ops) FL_NOEXCEPT {
+    const char* base = static_cast<const char*>(data);
+    fl::size first_idx = 0;
+    fl::size count = n;
+    while (count > 0) {
+        fl::size step = count / 2;
+        fl::size mid_idx = first_idx + step;
+        const void* mid_key = base + mid_idx * ops.element_size;
+        // upper_bound: advance past elements where !(key < elem.first).
+        if (!ops.less_fn(ops.less_ctx, key, mid_key)) {
+            first_idx = mid_idx + 1;
+            count -= step + 1;
+        } else {
+            count = step;
+        }
+    }
+    return first_idx;
+}
+
+} // namespace detail
+} // namespace fl

--- a/src/fl/stl/flat_map_basic.h
+++ b/src/fl/stl/flat_map_basic.h
@@ -1,0 +1,73 @@
+#pragma once
+
+// flat_map_basic: type-erased binary-search core shared by all
+// `fl::flat_map<K, V, Less>` instantiations. The per-instantiation
+// binary-search code (`lower_bound`, `upper_bound`) is pure byte-arithmetic
+// + one comparator call per iteration; it does not depend on the K or V
+// types beyond their layout (`sizeof(pair<K,V>)`) and the comparator's
+// behavior. Sharing the loop across instantiations saves ~150 B per
+// distinct flat_map type at the cost of ~30-50 B per call site.
+//
+// Design pattern mirrors `fl::vector_basic`: the templated public
+// `flat_map<K, V, Less>` calls into the non-template helpers below
+// through a `flat_map_ops` parameter block that carries (a) a thunk
+// pointer that knows how to compare two `Key` values given their
+// addresses and (b) the element stride (`sizeof(pair<K,V>)`).
+//
+// Comparator state is passed via a `const void*` context pointer so
+// that stateful comparators (e.g. ones that capture string-intern
+// tables) are supported uniformly with stateless ones (`fl::less<T>`).
+// The thunk casts the context back to its concrete `Less*` and invokes
+// `(*less)(key_a, key_b)`. For `fl::pair<K, V>`, `.first` is at offset
+// 0 (standard layout) so the helpers can treat the storage as an array
+// of K-prefixed records and compare on the prefix directly.
+//
+// FL_NO_INLINE on the implementations is load-bearing: with LTO enabled
+// (default on every embedded target) the compiler would otherwise fold
+// the body back into each call site, defeating the whole dedup goal.
+//
+// See FastLED #3235 Tier 2D. Note: at small instantiation counts the
+// per-call thunk overhead can exceed the savings (sketches with 1-2
+// flat_map types see neutral-or-slightly-negative deltas). The win
+// scales with the number of distinct `flat_map<K,V,Less>` types in the
+// link, so the value materializes on kitchen-sink builds (WASM compiler
+// runtime, full RPC + audio + UI matrices) more than on focused
+// sketches.
+
+#include "fl/stl/int.h"
+#include "fl/stl/cstddef.h"
+#include "fl/stl/compiler_control.h"  // for FL_NO_INLINE
+#include "fl/stl/noexcept.h"
+
+namespace fl {
+namespace detail {
+
+// Function-pointer-with-context comparator: returns true iff *a < *b.
+using flat_map_less_thunk_t = bool (*)(const void* ctx,
+                                       const void* a, const void* b) FL_NOEXCEPT;
+
+struct flat_map_ops {
+    flat_map_less_thunk_t less_fn;
+    const void* less_ctx;   // address of the owning flat_map's `mLess`
+    fl::size element_size;  // sizeof(pair<K, V>)
+};
+
+// lower_bound returns the index of the first element in [0, n) whose
+// `.first` (a `Key` prefix at the start of each element) is NOT less
+// than `*key`. If no such element exists, returns `n`. Caller turns the
+// index back into an iterator via `begin() + idx`.
+FL_NO_INLINE
+fl::size flat_map_lower_bound_idx(const void* data, fl::size n,
+                                  const void* key,
+                                  const flat_map_ops& ops) FL_NOEXCEPT;
+
+// upper_bound returns the index of the first element in [0, n) whose
+// `.first` is strictly greater than `*key` (equivalently: `less(*key,
+// elem.first)` is true).
+FL_NO_INLINE
+fl::size flat_map_upper_bound_idx(const void* data, fl::size n,
+                                  const void* key,
+                                  const flat_map_ops& ops) FL_NOEXCEPT;
+
+} // namespace detail
+} // namespace fl


### PR DESCRIPTION
Closes #3235 Tier 2D.

Lands  /  as non-template shared cores under `fl/stl/flat_map_basic.h`. Comparator dispatch through a function-pointer-with-context tuple to support stateful comparators uniformly with stateless ones.

`FL_NO_INLINE` on the implementations is load-bearing — without it LTO inlines the bodies back at each call site, defeating dedup.

## Measurement honesty

On AutoResearch (1-2 flat_map instances) the per-call thunk overhead matches or slightly exceeds the per-instance savings, so the immediate flash delta is neutral-to-negative. The win materializes on builds with more instantiations — the audit predicted ~6-9 KB on kitchen-sink builds with ~30 flat_map types. Landing the infrastructure now so future additions amortize against the shared core (the `fl::vector_basic` precedent.)

| Sketch | flat_map instances | Net flash change |
|---|---:|---:|
| LPC845 / AutoResearch | 1 | +72 B |
| Teensy 4 / AutoResearch | 2 | ±0 B |

## Test plan
- [x] LPC845 / AutoResearch build → succeeded
- [x] Teensy 4 / AutoResearch build → succeeded (separately verified earlier in session)
- [ ] CI matrix

Refs #3235 (Tier 2D)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal `flat_map` implementation to reduce code duplication and improve maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->