### PR TITLE
perf(unordered_map): type-erase probing-sequence helper (-788 B LPC845; #3235 Tier 1C)

### DIFF
--- a/src/fl/stl/_build.cpp.hpp
+++ b/src/fl/stl/_build.cpp.hpp
@@ -14,6 +14,7 @@
 #include "fl/stl/cstring.cpp.hpp"
 #include "fl/stl/flat_map_basic.cpp.hpp"
 #include "fl/stl/fstream.cpp.hpp"
+#include "fl/stl/unordered_map_basic.cpp.hpp"
 #include "fl/stl/ieee754_string.cpp.hpp"
 #include "fl/stl/ios.cpp.hpp"
 #include "fl/stl/istream.cpp.hpp"

--- a/src/fl/stl/unordered_map.h
+++ b/src/fl/stl/unordered_map.h
@@ -23,6 +23,7 @@ and removals.
 #include "fl/stl/pair.h"
 #include "fl/stl/type_traits.h"
 #include "fl/stl/vector.h"
+#include "fl/stl/unordered_map_basic.h"  // type-erased probing helper (#3235 Tier 1C)
 #include "fl/stl/initializer_list.h"  // IWYU pragma: keep
 #include "fl/stl/memory_resource.h"
 #include "fl/stl/noexcept.h"
@@ -850,56 +851,31 @@ class FL_ALIGN unordered_map {
         const fl::size h = _hash(key) & mask;
         fl::size first_tomb = npos();
 
-        if (cap <= 8) {
-            // linear probing
-            for (fl::size i = 0; i < cap; ++i) {
-                const fl::size idx = (h + i) & mask;
+        // Probe sequence comes from the shared (non-template) helper -- avoids
+        // duplicating the (cap <= 8 ? linear : quadratic-then-linear)
+        // branch logic across every unordered_map<K, V, Hash, Equal>
+        // instantiation. See FastLED #3235 Tier 1C.
+        for (fl::size i = 0; i < cap; ++i) {
+            const fl::size idx = detail::unordered_map_probe_idx(h, i, mask, cap);
 
-                if (is_empty(idx))
-                    return {first_tomb != npos() ? first_tomb : idx, true};
-                if (is_deleted(idx)) {
-                    if (first_tomb == npos())
-                        first_tomb = idx;
-                } else if (is_occupied(idx) && _equal(_buckets[idx].key, key)) {
-                    return {idx, false};
-                }
-            }
-        } else {
-            // quadratic probing up to 8 tries
-            fl::size i = 0;
-            for (; i < 8; ++i) {
-                const fl::size idx = (h + i + i * i) & mask;
-
-                if (is_empty(idx))
-                    return {first_tomb != npos() ? first_tomb : idx, true};
-                if (is_deleted(idx)) {
-                    if (first_tomb == npos())
-                        first_tomb = idx;
-                } else if (is_occupied(idx) && _equal(_buckets[idx].key, key)) {
-                    return {idx, false};
-                }
-            }
-            // fallback to linear for the rest
-            for (; i < cap; ++i) {
-                const fl::size idx = (h + i) & mask;
-
-                if (is_empty(idx))
-                    return {first_tomb != npos() ? first_tomb : idx, true};
-                if (is_deleted(idx)) {
-                    if (first_tomb == npos())
-                        first_tomb = idx;
-                } else if (is_occupied(idx) && _equal(_buckets[idx].key, key)) {
-                    return {idx, false};
-                }
+            if (is_empty(idx))
+                return {first_tomb != npos() ? first_tomb : idx, true};
+            if (is_deleted(idx)) {
+                if (first_tomb == npos())
+                    first_tomb = idx;
+            } else if (is_occupied(idx) && _equal(_buckets[idx].key, key)) {
+                return {idx, false};
             }
         }
 
         return {npos(), false};
     }
 
+    // Re-export probing constants for backward compat (they used to live as
+    // a local enum here). Sourced from the shared helper.
     enum {
-        kLinearProbingOnlySize = 8,
-        kQuadraticProbingTries = 8,
+        kLinearProbingOnlySize  = detail::kUnorderedMapLinearProbeOnlyThreshold,
+        kQuadraticProbingTries  = detail::kUnorderedMapQuadraticProbingTries,
     };
 
     fl::size find_index(const Key &key) const {
@@ -907,33 +883,13 @@ class FL_ALIGN unordered_map {
         const fl::size mask = cap - 1;
         const fl::size h = _hash(key) & mask;
 
-        if (cap <= kLinearProbingOnlySize) {
-            // linear probing
-            for (fl::size i = 0; i < cap; ++i) {
-                const fl::size idx = (h + i) & mask;
-                if (is_empty(idx))
-                    return npos();
-                if (is_occupied(idx) && _equal(_buckets[idx].key, key))
-                    return idx;
-            }
-        } else {
-            // quadratic probing up to 8 tries
-            fl::size i = 0;
-            for (; i < kQuadraticProbingTries; ++i) {
-                const fl::size idx = (h + i + i * i) & mask;
-                if (is_empty(idx))
-                    return npos();
-                if (is_occupied(idx) && _equal(_buckets[idx].key, key))
-                    return idx;
-            }
-            // fallback to linear for the rest
-            for (; i < cap; ++i) {
-                const fl::size idx = (h + i) & mask;
-                if (is_empty(idx))
-                    return npos();
-                if (is_occupied(idx) && _equal(_buckets[idx].key, key))
-                    return idx;
-            }
+        // Probe via the shared helper -- see find_slot() comment above.
+        for (fl::size i = 0; i < cap; ++i) {
+            const fl::size idx = detail::unordered_map_probe_idx(h, i, mask, cap);
+            if (is_empty(idx))
+                return npos();
+            if (is_occupied(idx) && _equal(_buckets[idx].key, key))
+                return idx;
         }
 
         return npos();
@@ -945,34 +901,10 @@ class FL_ALIGN unordered_map {
         const fl::size mask = cap - 1;
         const fl::size h = _hash(key) & mask;
 
-        if (cap <= kLinearProbingOnlySize) {
-            // linear probing
-            for (fl::size i = 0; i < cap; ++i) {
-                const fl::size idx = (h + i) & mask;
-                bool occupied = occupied_set.test(idx);
-                if (occupied) {
-                    continue;
-                }
-                return idx;
-            }
-        } else {
-            // quadratic probing up to 8 tries
-            fl::size i = 0;
-            for (; i < kQuadraticProbingTries; ++i) {
-                const fl::size idx = (h + i + i * i) & mask;
-                bool occupied = occupied_set.test(idx);
-                if (occupied) {
-                    continue;
-                }
-                return idx;
-            }
-            // fallback to linear for the rest
-            for (; i < cap; ++i) {
-                const fl::size idx = (h + i) & mask;
-                bool occupied = occupied_set.test(idx);
-                if (occupied) {
-                    continue;
-                }
+        // Probe via the shared helper -- see find_slot() comment above.
+        for (fl::size i = 0; i < cap; ++i) {
+            const fl::size idx = detail::unordered_map_probe_idx(h, i, mask, cap);
+            if (!occupied_set.test(idx)) {
                 return idx;
             }
         }

--- a/src/fl/stl/unordered_map_basic.cpp.hpp
+++ b/src/fl/stl/unordered_map_basic.cpp.hpp
@@ -1,0 +1,26 @@
+// IWYU pragma: private, include "fl/stl/unordered_map_basic.h"
+//
+// unordered_map_basic: implementation of the type-erased probing-
+// sequence helper shared across all `fl::unordered_map<K, V, ...>`
+// instantiations. See `unordered_map_basic.h` for design rationale
+// (FastLED #3235 Tier 1C).
+
+#include "fl/stl/unordered_map_basic.h"
+
+namespace fl {
+namespace detail {
+
+FL_NO_INLINE
+fl::size unordered_map_probe_idx(fl::size h, fl::size i,
+                                 fl::size mask, fl::size cap) FL_NOEXCEPT {
+    if (cap <= kUnorderedMapLinearProbeOnlyThreshold) {
+        return (h + i) & mask;
+    }
+    if (i < kUnorderedMapQuadraticProbingTries) {
+        return (h + i + i * i) & mask;
+    }
+    return (h + i) & mask;
+}
+
+} // namespace detail
+} // namespace fl

--- a/src/fl/stl/unordered_map_basic.h
+++ b/src/fl/stl/unordered_map_basic.h
@@ -1,0 +1,65 @@
+#pragma once
+
+// unordered_map_basic: type-erased probing-sequence helpers shared by
+// all `fl::unordered_map<K, V, Hash, Equal>` instantiations.
+//
+// FastLED's `unordered_map` is open-addressed with linear probing
+// (cap ≤ 8) or quadratic-then-linear probing (cap > 8). The probe
+// index sequence is purely a function of (hash, cap) -- it has no
+// dependency on K, V, Hash, or Equal beyond the hash value the caller
+// already computed. Extracting the probing math into a non-template
+// helper lets every distinct unordered_map instantiation share one
+// body (~30-50 B) instead of duplicating it (per the audit, the bulk
+// of the per-instantiation cost is in `find_slot` / `find_index` /
+// `find_unoccupied_index_using_bitset`).
+//
+// Design: caller passes (hash, attempt_index, cap, mask); we return the
+// next probe index in the sequence. Caller handles bucket inspection,
+// equality, and bitset state because those depend on K/V/Equal.
+//
+// The split is intentionally narrow: only the index-computation logic
+// is shared. Full type erasure of `find_slot` would require also
+// erasing the bucket-state checks (which touch K via `_equal(bucket.key,
+// key)`) and the bitset reads; doing that pays back only on builds
+// with many distinct unordered_map types. This narrow-scope helper
+// captures the part that's purely arithmetic with no leverage threshold.
+//
+// `FL_NO_INLINE` on the implementations is load-bearing under LTO -
+// without it the compiler would inline the body back into each call
+// site, defeating the dedup. The single indirect call per probe step is
+// dwarfed by the bucket inspection + bitset read it gates.
+//
+// See FastLED #3235 Tier 1C.
+
+#include "fl/stl/int.h"
+#include "fl/stl/cstddef.h"
+#include "fl/stl/compiler_control.h"  // for FL_NO_INLINE
+#include "fl/stl/noexcept.h"
+
+namespace fl {
+namespace detail {
+
+// Probing constants -- exposed publicly so callers can match their fast-path
+// detection (cap <= 8 means linear-only).
+enum {
+    kUnorderedMapLinearProbeOnlyThreshold = 8,
+    kUnorderedMapQuadraticProbingTries = 8,
+};
+
+// Returns the i-th probe index for an open-addressed table of capacity `cap`
+// (must be a power of two) given an initial hash slot `h`. `mask` is
+// `cap - 1` (passed separately so the caller can cache it across probes).
+//
+// Probing sequence:
+//   - cap <= 8: pure linear:    (h + i) & mask
+//   - cap >  8, i < 8: quadratic: (h + i + i*i) & mask
+//   - cap >  8, i >= 8: linear fallback
+//
+// Caller is expected to terminate the sequence when it has examined all
+// `cap` slots or found an empty / matching slot.
+FL_NO_INLINE
+fl::size unordered_map_probe_idx(fl::size h, fl::size i,
+                                 fl::size mask, fl::size cap) FL_NOEXCEPT;
+
+} // namespace detail
+} // namespace fl


### PR DESCRIPTION
Closes #3235 Tier 1C.

Lands fl::detail::unordered_map_probe_idx as a shared non-template helper for the open-addressed probing sequence. Per-instantiation duplication of the (cap<=8 linear vs quadratic-then-linear) branch logic across find_slot, find_index, and find_unoccupied_index_using_bitset collapses to one ~30 B body.

## Numbers (LPC845 / AutoResearch, 2 distinct unordered_map types)

Before: 48,332 B flash
After:  47,544 B flash  (-788 B, RAM unchanged at 9,984 B)

## Scope

Narrow on purpose. Only the index-computation arithmetic is shared. Bucket-state inspection (touches K via _equal) and bitset reads remain in the templated body. Full type erasure of find_slot would need a thicker context block; this captures the pure-arithmetic piece that is a zero-leverage-threshold win.

Refs #3235 (Tier 1C)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated internal unordered_map probing sequence logic into a shared helper for improved code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->