### PR TITLE
Reuse fbuild serial proxy in autoresearch recovery

### DIFF
--- a/ci/autoresearch/driver_sweep.py
+++ b/ci/autoresearch/driver_sweep.py
@@ -211,9 +211,8 @@ async def run_sweep(
         )
     print()
 
-    # Connect to device using pyserial (avoids fbuild daemon port locking issues)
     print(f"Connecting to {port}...")
-    iface = create_serial_interface(port, use_pyserial=True)
+    iface = create_serial_interface(port)
     client = RpcClient(
         port,
         timeout=timeout,

--- a/ci/autoresearch/gpio.py
+++ b/ci/autoresearch/gpio.py
@@ -67,9 +67,6 @@ async def run_gpio_pretest(
                 # Try DTR reset and retry — device may be booted but idle
                 print(f"\u26a0\ufe0f  Ping failed ({e}), attempting DTR reset...")
                 try:
-                    await client.close()
-                    client = None  # Prevent double-close in outer finally
-
                     # Use SerialInterface.reset_device(wait_for_output=True)
                     # to block until the device starts producing serial output
                     reset_ok = False
@@ -86,13 +83,18 @@ async def run_gpio_pretest(
                     # Use longer boot_wait if reset reported failure
                     boot_wait = 1.0 if reset_ok else 3.0
 
-                    client = RpcClient(
-                        port,
-                        timeout=timeout,
-                        serial_interface=serial_interface,
-                        verbose=True,
-                    )
-                    await client.connect(boot_wait=boot_wait, drain_boot=True)
+                    if serial_interface is None:
+                        await client.close()
+                        client = None  # Prevent double-close in outer finally
+                        client = RpcClient(
+                            port,
+                            timeout=timeout,
+                            serial_interface=serial_interface,
+                            verbose=True,
+                        )
+                        await client.connect(boot_wait=boot_wait, drain_boot=True)
+                    else:
+                        await client.drain_boot_output(verbose=True)
                     ping_response = await client.send("ping", retries=3)
                     print(
                         f"\u2705 Ping successful after DTR reset: {ping_response.data}"
@@ -265,10 +267,6 @@ async def run_pin_discovery(
             # Try DTR reset and retry — device may be booted but idle
             print(f"\u26a0\ufe0f  Ping failed ({e}), attempting DTR reset...")
             try:
-                if client:
-                    await client.close()
-                client = None
-
                 # Use SerialInterface.reset_device(wait_for_output=True)
                 reset_ok = False
                 if serial_interface is not None:
@@ -283,13 +281,19 @@ async def run_pin_discovery(
 
                 boot_wait = 1.0 if reset_ok else 3.0
 
-                client = RpcClient(
-                    port,
-                    timeout=timeout,
-                    serial_interface=serial_interface,
-                    verbose=True,
-                )
-                await client.connect(boot_wait=boot_wait, drain_boot=True)
+                if serial_interface is None:
+                    if client:
+                        await client.close()
+                    client = None
+                    client = RpcClient(
+                        port,
+                        timeout=timeout,
+                        serial_interface=serial_interface,
+                        verbose=True,
+                    )
+                    await client.connect(boot_wait=boot_wait, drain_boot=True)
+                else:
+                    await client.drain_boot_output(verbose=True)
                 ping_response = await client.send("ping", timeout=30.0, retries=3)
                 print(f"\u2705 Ping successful after DTR reset: {ping_response.data}")
             except KeyboardInterrupt as ki:

--- a/ci/tests/test_gpio_serial_proxy_retry.py
+++ b/ci/tests/test_gpio_serial_proxy_retry.py
@@ -1,0 +1,132 @@
+"""GPIO retry paths keep proxy-backed serial sessions open."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+from typing import Any
+from unittest.mock import patch
+
+from ci.autoresearch.gpio import run_gpio_pretest, run_pin_discovery
+from ci.rpc_client import RpcResponse
+
+
+class _FakeSerialInterface:
+    def __init__(self) -> None:
+        self.reset_count = 0
+
+    async def connect(self) -> None:  # pragma: no cover - driven through fake client
+        pass
+
+    async def close(self) -> None:  # pragma: no cover - fake client tracks closes
+        pass
+
+    async def write(self, data: str) -> None:  # pragma: no cover
+        pass
+
+    async def read_lines(
+        self, timeout: float
+    ) -> AsyncIterator[str]:  # pragma: no cover
+        if False:
+            yield ""
+
+    async def reset_device(self, board: str | None) -> bool:
+        self.reset_count += 1
+        return True
+
+
+class _FakeRpcClient:
+    instances: list["_FakeRpcClient"] = []
+
+    def __init__(
+        self,
+        port: str,
+        timeout: float,
+        serial_interface: _FakeSerialInterface | None = None,
+        verbose: bool = False,
+        **_: Any,
+    ) -> None:
+        self.port = port
+        self.timeout = timeout
+        self.serial_interface = serial_interface
+        self.verbose = verbose
+        self.connect_count = 0
+        self.close_count = 0
+        self.drain_count = 0
+        self.ping_attempts = 0
+        _FakeRpcClient.instances.append(self)
+
+    async def connect(self, **_: Any) -> None:
+        self.connect_count += 1
+
+    async def close(self) -> None:
+        self.close_count += 1
+
+    async def drain_boot_output(self, **_: Any) -> int:
+        self.drain_count += 1
+        return 0
+
+    async def send(
+        self,
+        function: str,
+        *_: Any,
+        **__: Any,
+    ) -> RpcResponse:
+        if function == "ping":
+            self.ping_attempts += 1
+            if self.ping_attempts == 1:
+                raise RuntimeError("first ping fails")
+            return RpcResponse(success=True, data={"message": "pong"}, raw_line="")
+        raise AssertionError(f"unexpected RPC call: {function}")
+
+    async def send_and_match(self, function: str, **_: Any) -> RpcResponse:
+        if function == "testGpioConnection":
+            return RpcResponse(
+                success=True,
+                data={"connected": True},
+                raw_line="",
+            )
+        if function == "findConnectedPins":
+            return RpcResponse(
+                success=True,
+                data={"found": True, "txPin": 1, "rxPin": 2, "autoApplied": True},
+                raw_line="",
+            )
+        raise AssertionError(f"unexpected RPC call: {function}")
+
+
+def _reset_fake_clients() -> None:
+    _FakeRpcClient.instances = []
+
+
+def test_gpio_pretest_reuses_serial_proxy_after_reset() -> None:
+    serial_interface = _FakeSerialInterface()
+    _reset_fake_clients()
+
+    with patch("ci.autoresearch.gpio.RpcClient", _FakeRpcClient):
+        ok = asyncio.run(run_gpio_pretest("COM5", serial_interface=serial_interface))
+
+    assert ok is True
+    assert len(_FakeRpcClient.instances) == 1
+    client = _FakeRpcClient.instances[0]
+    assert serial_interface.reset_count == 1
+    assert client.drain_count == 1
+    assert client.close_count == 1  # final cleanup only
+
+
+def test_pin_discovery_reuses_serial_proxy_after_reset() -> None:
+    serial_interface = _FakeSerialInterface()
+    _reset_fake_clients()
+
+    with patch("ci.autoresearch.gpio.RpcClient", _FakeRpcClient):
+        result = asyncio.run(
+            run_pin_discovery("COM5", serial_interface=serial_interface)
+        )
+
+    assert result.success is True
+    assert len(_FakeRpcClient.instances) == 1
+    client = _FakeRpcClient.instances[0]
+    assert result.client is client
+    assert serial_interface.reset_count == 1
+    assert client.drain_count == 1
+    assert client.close_count == 0


### PR DESCRIPTION
Refs FastLED/fbuild#592.\n\n## Summary\n- stop driver_sweep from forcing direct pyserial because of old fbuild daemon locking behavior\n- reuse the existing proxy-backed RpcClient after GPIO reset recovery instead of closing and recreating it\n- add host-only tests proving GPIO retry paths keep the supplied serial proxy open\n\n## Tests\n- uv run ruff format ci/autoresearch/driver_sweep.py ci/autoresearch/gpio.py ci/tests/test_gpio_serial_proxy_retry.py\n- uv run ruff check ci/autoresearch/driver_sweep.py ci/autoresearch/gpio.py ci/tests/test_gpio_serial_proxy_retry.py\n- uv run pytest ci/tests/test_gpio_serial_proxy_retry.py\n- uv run pytest ci/tests/test_autoresearch_phases.py ci/tests/test_serial_interface_reset.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved serial interface recovery behavior during device resets and connection failures.

* **Tests**
  * Added test coverage for GPIO workflows to ensure serial proxy sessions remain stable across device reset and retry scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->