### PR TITLE
fix(rgbw): normalize colorimetric endpoints

### DIFF
--- a/src/fl/gfx/colorimetric_response.h
+++ b/src/fl/gfx/colorimetric_response.h
@@ -264,5 +264,118 @@ struct EmitterProfile {
     float input_xy_w[2];  // source white chromaticity (default D65)
 };
 
+// Backward-compat alias for the original PR vocabulary (issue #3231 → PR 2
+// of #3255). New code should prefer the topology-independent
+// `EmitterProfile` name; existing call sites that spell out
+// `RgbColorimetricProfile` keep compiling.
+using RgbColorimetricProfile = EmitterProfile;
+
+// Cache derived from `EmitterProfile`: precomputed XYZ primaries, inverse
+// primary matrix, and source-space matrix when an input gamut is supplied.
+// Built once per profile and reused across pixels.
+struct RgbColorimetricCache {
+    float P_R[3], P_G[3], P_B[3];
+    float P_RGB_inv[3][3];
+    float M_src[3][3];
+    bool has_source_space;
+};
+
+// Build the precomputed primaries / inverse matrices for `p`. Returns false
+// only when the device-emitter primary matrix is singular (collinear
+// chromaticities); the cache is still populated with zeros so callers can
+// safely fall back to the no-op solve.
+//
+// Source-space handling matches the RGBW path (#2705 semantics): when
+// `input_xy_w[1]` is effectively zero, the input RGB triple IS treated as
+// drive coordinates. Otherwise a source-primary matrix is built and
+// normalized so that the source white at unit drive lands on the maximum
+// per-channel column — keeping outputs in [0, 1] for in-gamut inputs.
+inline bool build_rgb_colorimetric_cache(const EmitterProfile& p,
+                                         RgbColorimetricCache* cache) FL_NO_EXCEPT {
+    xyY_to_XYZ(p.xy_r[0], p.xy_r[1], p.lum_r, cache->P_R);
+    xyY_to_XYZ(p.xy_g[0], p.xy_g[1], p.lum_g, cache->P_G);
+    xyY_to_XYZ(p.xy_b[0], p.xy_b[1], p.lum_b, cache->P_B);
+
+    const float P_RGB[3][3] = {
+        { cache->P_R[0], cache->P_G[0], cache->P_B[0] },
+        { cache->P_R[1], cache->P_G[1], cache->P_B[1] },
+        { cache->P_R[2], cache->P_G[2], cache->P_B[2] },
+    };
+    const bool ok_rgb = invert3x3(P_RGB, cache->P_RGB_inv);
+    cache->has_source_space = (p.input_xy_w[1] > 1e-6f)
+                           && build_source_matrix(p.input_xy_r, p.input_xy_g,
+                                                  p.input_xy_b, p.input_xy_w,
+                                                  cache->M_src);
+    if (cache->has_source_space && ok_rgb) {
+        float X_w[3];
+        xyY_to_XYZ(p.input_xy_w[0], p.input_xy_w[1], 1.0f, X_w);
+        float t[3];
+        matvec3(cache->P_RGB_inv, X_w, t);
+        const float mt = fl::max(fl::max(fl::fabs(t[0]), fl::fabs(t[1])),
+                                 fl::fabs(t[2]));
+        if (mt > 1e-6f) {
+            const float scale_k = 1.0f / mt;
+            for (int i = 0; i < 3; ++i) {
+                for (int j = 0; j < 3; ++j) {
+                    cache->M_src[i][j] *= scale_k;
+                }
+            }
+        }
+    }
+    if (!ok_rgb) {
+        for (int i = 0; i < 3; ++i) {
+            for (int j = 0; j < 3; ++j) {
+                cache->P_RGB_inv[i][j] = 0.0f;
+            }
+        }
+    }
+    if (!cache->has_source_space) {
+        for (int i = 0; i < 3; ++i) {
+            for (int j = 0; j < 3; ++j) {
+                cache->M_src[i][j] = 0.0f;
+            }
+        }
+    }
+    return ok_rgb;
+}
+
+// Map a source-space RGB triple to absolute XYZ. With a configured source
+// gamut, this is the M_src multiplication; without one, the device-emitter
+// primary columns are used directly (the input is treated as drive
+// coordinates).
+inline void rgb_source_to_XYZ(const RgbColorimetricCache& cache, float s_r,
+                              float s_g, float s_b,
+                              float X_t[3]) FL_NO_EXCEPT {
+    if (cache.has_source_space) {
+        const float s[3] = { s_r, s_g, s_b };
+        matvec3(cache.M_src, s, X_t);
+    } else {
+        X_t[0] = cache.P_R[0] * s_r + cache.P_G[0] * s_g + cache.P_B[0] * s_b;
+        X_t[1] = cache.P_R[1] * s_r + cache.P_G[1] * s_g + cache.P_B[1] * s_b;
+        X_t[2] = cache.P_R[2] * s_r + cache.P_G[2] * s_g + cache.P_B[2] * s_b;
+    }
+}
+
+// Solve a source-space RGB target for the device RGB drives. The result is
+// clamped to non-negative and normalized so the per-channel max ≤ 1.
+inline bool solve_rgb_colorimetric(const RgbColorimetricCache& cache,
+                                   float s_r, float s_g, float s_b,
+                                   float out_rgb[3]) FL_NO_EXCEPT {
+    float X_t[3];
+    rgb_source_to_XYZ(cache, s_r, s_g, s_b, X_t);
+    matvec3(cache.P_RGB_inv, X_t, out_rgb);
+    out_rgb[0] = fl::max(out_rgb[0], 0.0f);
+    out_rgb[1] = fl::max(out_rgb[1], 0.0f);
+    out_rgb[2] = fl::max(out_rgb[2], 0.0f);
+    const float m = fl::max(fl::max(out_rgb[0], out_rgb[1]), out_rgb[2]);
+    if (m > 1.0f) {
+        const float inv_m = 1.0f / m;
+        out_rgb[0] *= inv_m;
+        out_rgb[1] *= inv_m;
+        out_rgb[2] *= inv_m;
+    }
+    return true;
+}
+
 } // namespace colorimetric_response
 } // namespace fl

--- a/src/fl/gfx/rgbw.cpp.hpp
+++ b/src/fl/gfx/rgbw.cpp.hpp
@@ -508,7 +508,8 @@ void rgb_2_rgbw_colorimetric(const Rgbw& cfg, u8 r,
             return;
         }
         const float xy_t[2] = { X_t[0] / sum, X_t[1] / sum };
-        colorimetric_detail::lookup_lut(*lut_state.table, xy_t, X_t[1], rgbw);
+        const float source_value = fl::max(fl::max(s_r, s_g), s_b);
+        colorimetric_detail::lookup_lut(*lut_state.table, xy_t, source_value, rgbw);
         *out_r = colorimetric_detail::quantize_u8(rgbw[0]);
         *out_g = colorimetric_detail::quantize_u8(rgbw[1]);
         *out_b = colorimetric_detail::quantize_u8(rgbw[2]);

--- a/src/fl/gfx/rgbw_colorimetric.cpp.hpp
+++ b/src/fl/gfx/rgbw_colorimetric.cpp.hpp
@@ -466,7 +466,7 @@ static bool solve_strict_subgamut_from_XYZ(const ProfileCache& cache,
         t[1] = fl::max(t[1], 0.0f);
         t[2] = fl::max(t[2], 0.0f);
         const float m = max3f(t[0], t[1], t[2]);
-        if (m > 1.0f) {
+        if (m > 1e-9f) {
             const float inv_m = 1.0f / m;
             t[0] *= inv_m; t[1] *= inv_m; t[2] *= inv_m;
         }
@@ -531,14 +531,14 @@ bool solve_strict_subgamut(const ProfileCache& cache, float s_r,
 }
 
 bool solve_strict_subgamut_xy(const ProfileCache& cache,
-                              const float xy_t[2], float Y_t,
+                              const float xy_t[2], float source_value,
                               float out_rgbw[4]) FL_NO_EXCEPT {
     out_rgbw[0] = out_rgbw[1] = out_rgbw[2] = out_rgbw[3] = 0.0f;
-    if (Y_t < 1e-9f) {
+    if (source_value < 1e-9f) {
         return true;
     }
     float X_t[3];
-    xyY_to_XYZ(xy_t[0], xy_t[1], Y_t, X_t);
+    xyY_to_XYZ(xy_t[0], xy_t[1], 1.0f, X_t);
 
     // Out-of-hull projection (#2708). xy_t arrives directly (this variant is
     // called by the LUT builder), so we must project here before routing.
@@ -576,6 +576,13 @@ bool solve_strict_subgamut_xy(const ProfileCache& cache,
         t[0] = fl::max(t[0], 0.0f);
         t[1] = fl::max(t[1], 0.0f);
         t[2] = fl::max(t[2], 0.0f);
+        const float m = max3f(t[0], t[1], t[2]);
+        if (m > 1e-9f) {
+            const float endpoint_scale = source_value / m;
+            t[0] *= endpoint_scale;
+            t[1] *= endpoint_scale;
+            t[2] *= endpoint_scale;
+        }
         out_rgbw[sg.idx_a] = t[0];
         out_rgbw[sg.idx_b] = t[1];
         out_rgbw[sg.idx_c] = t[2];
@@ -944,7 +951,7 @@ LutTable build_lut(const ProfileCache& cache, int grid_n,
     return lut;
 }
 
-void lookup_lut(const LutTable& lut, const float xy_t[2], float Y_t,
+void lookup_lut(const LutTable& lut, const float xy_t[2], float source_value,
                 float out_rgbw[4]) FL_NO_EXCEPT {
     // Defend against degenerate LUTs (empty table, unbuilt cells, zero span).
     // build_lut() returns an empty LutTable on bad input â€” without these
@@ -1002,7 +1009,7 @@ void lookup_lut(const LutTable& lut, const float xy_t[2], float Y_t,
             const float dy01 = c01[8 + k] * inv_Q;
             const float dy11 = c11[8 + k] * inv_Q;
 
-            const float per_Y =
+            const float endpoint =
                   v00 * h00x * h00y + v10 * h01x * h00y
                 + v01 * h00x * h01y + v11 * h01x * h01y
                 + dx00 * h10x * h00y + dx10 * h11x * h00y
@@ -1010,7 +1017,7 @@ void lookup_lut(const LutTable& lut, const float xy_t[2], float Y_t,
                 + dy00 * h00x * h10y + dy10 * h01x * h10y
                 + dy01 * h00x * h11y + dy11 * h01x * h11y;
 
-            float t = per_Y * Y_t;
+            float t = endpoint * source_value;
             if (t < 0.0f) t = 0.0f;
             out_rgbw[k] = t;
         }
@@ -1020,9 +1027,9 @@ void lookup_lut(const LutTable& lut, const float xy_t[2], float Y_t,
         const float w01 = (1 - fx) * fy;
         const float w11 = fx * fy;
         for (int k = 0; k < 4; ++k) {
-            const float per_Y = (w00 * c00[k] + w10 * c10[k]
-                               + w01 * c01[k] + w11 * c11[k]) * inv_Q;
-            float t = per_Y * Y_t;
+            const float endpoint = (w00 * c00[k] + w10 * c10[k]
+                                  + w01 * c01[k] + w11 * c11[k]) * inv_Q;
+            float t = endpoint * source_value;
             if (t < 0.0f) t = 0.0f;
             out_rgbw[k] = t;
         }

--- a/src/fl/gfx/rgbw_colorimetric.h
+++ b/src/fl/gfx/rgbw_colorimetric.h
@@ -75,6 +75,14 @@ constexpr i16 kLutQ = colorimetric_response::kLutQ;
 constexpr int kLutStrideBilinear = colorimetric_response::kLutStrideBilinear;
 constexpr int kLutStrideHermite = colorimetric_response::kLutStrideHermite;
 
+// ===== RGB colorimetric layer — re-exported for backward-compat callers =====
+using colorimetric_response::EmitterProfile;                // ok bare using
+using colorimetric_response::RgbColorimetricProfile;        // ok bare using
+using colorimetric_response::RgbColorimetricCache;          // ok bare using
+using colorimetric_response::build_rgb_colorimetric_cache;  // ok bare using
+using colorimetric_response::rgb_source_to_XYZ;             // ok bare using
+using colorimetric_response::solve_rgb_colorimetric;        // ok bare using
+
 // ===== RGBW-specific topology helpers =======================================
 
 // Native-gamut detection (#2748). Returns true when the source primaries
@@ -235,7 +243,7 @@ bool solve_strict_subgamut(const ProfileCache& cache, float s_r,
 // because there is no source RGB active-channel mask attached to an arbitrary
 // xy sample.
 bool solve_strict_subgamut_xy(const ProfileCache& cache,
-                              const float xy_t[2], float Y_t,
+                              const float xy_t[2], float source_value,
                               float out_rgbw[4]) FL_NO_EXCEPT;
 
 // Reference wx_lp_legacy solver.
@@ -283,7 +291,7 @@ inline LutTable build_lut(const ProfileCache& cache, int grid_n) FL_NO_EXCEPT {
 }
 
 // Bilinear lookup + Y multiply + normalize.
-void lookup_lut(const LutTable& lut, const float xy_t[2], float Y_t,
+void lookup_lut(const LutTable& lut, const float xy_t[2], float source_value,
                 float out_rgbw[4]) FL_NO_EXCEPT;
 
 // RGBCCT layered solver: solve target against each W diode separately, then

--- a/tests/fl/gfx/rgbw_colorimetric.cpp
+++ b/tests/fl/gfx/rgbw_colorimetric.cpp
@@ -369,6 +369,53 @@ FL_TEST_CASE("source matrix matches published sRGB->XYZ matrix (Rec709 opt-in)")
 }
 
 
+FL_TEST_CASE("rgb colorimetric cache: fallback source space preserves direct RGB drives") {
+    RgbColorimetricProfile p = {};
+    p.xy_r[0] = kRgbwDefaultProfile.xy_r[0]; p.xy_r[1] = kRgbwDefaultProfile.xy_r[1];
+    p.xy_g[0] = kRgbwDefaultProfile.xy_g[0]; p.xy_g[1] = kRgbwDefaultProfile.xy_g[1];
+    p.xy_b[0] = kRgbwDefaultProfile.xy_b[0]; p.xy_b[1] = kRgbwDefaultProfile.xy_b[1];
+    p.lum_r = kRgbwDefaultProfile.lum_r;
+    p.lum_g = kRgbwDefaultProfile.lum_g;
+    p.lum_b = kRgbwDefaultProfile.lum_b;
+
+    RgbColorimetricCache cache;
+    FL_CHECK(build_rgb_colorimetric_cache(p, &cache));
+    FL_CHECK(!cache.has_source_space);
+
+    float rgb[3] = {0};
+    FL_CHECK(solve_rgb_colorimetric(cache, 0.25f, 0.50f, 0.75f, rgb));
+    FL_CHECK_CLOSE(rgb[0], 0.25f, 1e-5f);
+    FL_CHECK_CLOSE(rgb[1], 0.50f, 1e-5f);
+    FL_CHECK_CLOSE(rgb[2], 0.75f, 1e-5f);
+}
+
+
+FL_TEST_CASE("rgb colorimetric cache: source space solve is finite and normalized") {
+    RgbColorimetricProfile p = {};
+    p.xy_r[0] = kRgbwDefaultProfile.xy_r[0]; p.xy_r[1] = kRgbwDefaultProfile.xy_r[1];
+    p.xy_g[0] = kRgbwDefaultProfile.xy_g[0]; p.xy_g[1] = kRgbwDefaultProfile.xy_g[1];
+    p.xy_b[0] = kRgbwDefaultProfile.xy_b[0]; p.xy_b[1] = kRgbwDefaultProfile.xy_b[1];
+    p.lum_r = kRgbwDefaultProfile.lum_r;
+    p.lum_g = kRgbwDefaultProfile.lum_g;
+    p.lum_b = kRgbwDefaultProfile.lum_b;
+    p.input_xy_r[0] = 0.6400f; p.input_xy_r[1] = 0.3300f;
+    p.input_xy_g[0] = 0.3000f; p.input_xy_g[1] = 0.6000f;
+    p.input_xy_b[0] = 0.1500f; p.input_xy_b[1] = 0.0600f;
+    p.input_xy_w[0] = 0.31272f; p.input_xy_w[1] = 0.32903f;
+
+    RgbColorimetricCache cache;
+    FL_CHECK(build_rgb_colorimetric_cache(p, &cache));
+    FL_CHECK(cache.has_source_space);
+
+    float rgb[3] = {0};
+    FL_CHECK(solve_rgb_colorimetric(cache, 1.0f, 0.85f, 0.25f, rgb));
+    FL_CHECK(rgb[0] >= 0.0f && rgb[0] <= 1.0f);
+    FL_CHECK(rgb[1] >= 0.0f && rgb[1] <= 1.0f);
+    FL_CHECK(rgb[2] >= 0.0f && rgb[2] <= 1.0f);
+    FL_CHECK(fl::max(fl::max(rgb[0], rgb[1]), rgb[2]) <= 1.0f);
+}
+
+
 FL_TEST_CASE("set_input_gamut: Native copies LED primaries") {
     DiodeProfile p = kRgbwDefaultProfile;
     // First trash input_xy_* so we can prove Native restored them.
@@ -639,6 +686,169 @@ inline void build_cache(const DiodeProfile* p, ProfileCache* cache) {
     cache->has_source_space = (p->input_xy_w[1] > 1e-6f) &&
         build_source_matrix(p->input_xy_r, p->input_xy_g, p->input_xy_b,
                             p->input_xy_w, cache->M_src);
+    if (cache->has_source_space) {
+        float X_w[3];
+        xyY_to_XYZ(p->input_xy_w[0], p->input_xy_w[1], 1.0f, X_w);
+        const float (*invs[3])[3] = {
+            cache->P_RGW_inv, cache->P_RBW_inv, cache->P_BGW_inv,
+        };
+        float best_max_t = 0.0f;
+        bool found_scale = false;
+        constexpr float kScaleEps = 1e-6f;
+        for (int k = 0; k < 3; ++k) {
+            float t[3];
+            matvec3(invs[k], X_w, t);
+            if (t[0] < -kScaleEps || t[1] < -kScaleEps || t[2] < -kScaleEps) {
+                continue;
+            }
+            const float mt = fl::max(fl::max(t[0], t[1]), t[2]);
+            if (mt > kScaleEps && (!found_scale || mt < best_max_t)) {
+                best_max_t = mt;
+                found_scale = true;
+            }
+        }
+        if (!found_scale) {
+            float t[3];
+            matvec3(cache->P_RGB_inv, X_w, t);
+            const float mt = fl::max(fl::max(fl::fabs(t[0]), fl::fabs(t[1])),
+                                     fl::fabs(t[2]));
+            if (mt > kScaleEps) {
+                best_max_t = mt;
+                found_scale = true;
+            }
+        }
+        const float scale_k = found_scale ? (1.0f / best_max_t) : 1.0f;
+        for (int i = 0; i < 3; ++i) {
+            for (int j = 0; j < 3; ++j) {
+                cache->M_src[i][j] *= scale_k;
+            }
+        }
+    }
+}
+
+inline void zero4(float out[4]) {
+    out[0] = out[1] = out[2] = out[3] = 0.0f;
+}
+
+inline float max3(float a, float b, float c) {
+    return fl::max(fl::max(a, b), c);
+}
+
+inline void normalize4_if_needed(float out[4]) {
+    const float m = fl::max(fl::max(out[0], out[1]), fl::max(out[2], out[3]));
+    if (m > 1.0f) {
+        const float inv_m = 1.0f / m;
+        out[0] *= inv_m; out[1] *= inv_m; out[2] *= inv_m; out[3] *= inv_m;
+    }
+}
+
+inline const float* column_for_idx(const ProfileCache& cache, int idx) {
+    switch (idx) {
+    case 0: return cache.P_R;
+    case 1: return cache.P_G;
+    case 2: return cache.P_B;
+    default: return cache.P_W;
+    }
+}
+
+inline void source_rgb_to_XYZ(const ProfileCache& cache, float s_r,
+                              float s_g, float s_b, float X_t[3]) {
+    if (cache.has_source_space) {
+        const float s[3] = { s_r, s_g, s_b };
+        matvec3(cache.M_src, s, X_t);
+    } else {
+        X_t[0] = cache.P_R[0]*s_r + cache.P_G[0]*s_g + cache.P_B[0]*s_b;
+        X_t[1] = cache.P_R[1]*s_r + cache.P_G[1]*s_g + cache.P_B[1]*s_b;
+        X_t[2] = cache.P_R[2]*s_r + cache.P_G[2]*s_g + cache.P_B[2]*s_b;
+    }
+}
+
+inline bool native_single_identity(float s_r, float s_g, float s_b, float out[4]) {
+    out[0] = fl::clamp(s_r, 0.0f, 1.0f);
+    out[1] = fl::clamp(s_g, 0.0f, 1.0f);
+    out[2] = fl::clamp(s_b, 0.0f, 1.0f);
+    out[3] = 0.0f;
+    return true;
+}
+
+inline bool solve_fixed_topology_least_squares(const ProfileCache& cache,
+                                               const float X[3],
+                                               const int* idx,
+                                               int n,
+                                               float out[4]) {
+    zero4(out);
+    constexpr float kEps = 1e-9f;
+    if (n == 1) {
+        const float* A = column_for_idx(cache, idx[0]);
+        const float aa = A[0]*A[0] + A[1]*A[1] + A[2]*A[2];
+        const float ax = A[0]*X[0] + A[1]*X[1] + A[2]*X[2];
+        out[idx[0]] = (aa > kEps) ? fl::max(ax / aa, 0.0f) : 0.0f;
+        return true;
+    }
+    if (n == 2) {
+        const float* A = column_for_idx(cache, idx[0]);
+        const float* B = column_for_idx(cache, idx[1]);
+        const float aa = A[0]*A[0] + A[1]*A[1] + A[2]*A[2];
+        const float ab = A[0]*B[0] + A[1]*B[1] + A[2]*B[2];
+        const float bb = B[0]*B[0] + B[1]*B[1] + B[2]*B[2];
+        const float ax = A[0]*X[0] + A[1]*X[1] + A[2]*X[2];
+        const float bx = B[0]*X[0] + B[1]*X[1] + B[2]*X[2];
+        const float det = aa * bb - ab * ab;
+        if (fl::fabs(det) < kEps) {
+            return false;
+        }
+        float t0 = ( ax * bb - bx * ab) / det;
+        float t1 = (-ax * ab + bx * aa) / det;
+        if (t0 < 0.0f && t1 >= 0.0f) {
+            t0 = 0.0f;
+            t1 = (bb > kEps) ? fl::max(bx / bb, 0.0f) : 0.0f;
+        } else if (t1 < 0.0f && t0 >= 0.0f) {
+            t1 = 0.0f;
+            t0 = (aa > kEps) ? fl::max(ax / aa, 0.0f) : 0.0f;
+        } else if (t0 < 0.0f && t1 < 0.0f) {
+            t0 = 0.0f;
+            t1 = 0.0f;
+        }
+        out[idx[0]] = fl::max(t0, 0.0f);
+        out[idx[1]] = fl::max(t1, 0.0f);
+        return true;
+    }
+    return false;
+}
+
+inline bool solve_native_dual_edge_fixed_topology(const ProfileCache& cache,
+                                                  float s_r, float s_g,
+                                                  float s_b, float out[4]) {
+    zero4(out);
+    constexpr float kEps = 1.0f / 65535.0f;
+    const float value = max3(s_r, s_g, s_b);
+    if (value <= kEps) {
+        return true;
+    }
+    const float c_r = s_r / value;
+    const float c_g = s_g / value;
+    const float c_b = s_b / value;
+    float X_full[3];
+    source_rgb_to_XYZ(cache, c_r, c_g, c_b, X_full);
+    int active[2];
+    int n = 0;
+    if (s_r > kEps) active[n++] = 0;
+    if (s_g > kEps) active[n++] = 1;
+    if (s_b > kEps) active[n++] = 2;
+    if (n != 2) {
+        return false;
+    }
+    float full[4];
+    if (!solve_fixed_topology_least_squares(cache, X_full, active, n, full)) {
+        return false;
+    }
+    normalize4_if_needed(full);
+    out[0] = full[0] * value;
+    out[1] = full[1] * value;
+    out[2] = full[2] * value;
+    out[3] = 0.0f;
+    normalize4_if_needed(out);
+    return true;
 }
 
 // Mirror of project_to_hull (#2708) — verbatim copy of the static helper in
@@ -693,29 +903,29 @@ inline bool project_to_hull_mirror(const ProfileCache& cache,
 // Verbatim copy of solve_strict_subgamut (post-#2708 — includes hull projection,
 // post-#2748 — includes native topology authority guard).
 inline bool strict_subgamut(const ProfileCache& cache, float s_r, float s_g, float s_b, float out[4]) {
-    out[0] = out[1] = out[2] = out[3] = 0.0f;
+    zero4(out);
+    const float value = max3(s_r, s_g, s_b);
+    if (value <= 1e-9f) {
+        return true;
+    }
 
     // #2748 native topology authority guard. Mirrors the production check.
     if (is_native_input_gamut(*cache.profile)) {
         const int n_active = count_active_channels(s_r, s_g, s_b);
-        if (n_active <= 2) {
-            out[0] = fl::clamp(s_r, 0.0f, 1.0f);
-            out[1] = fl::clamp(s_g, 0.0f, 1.0f);
-            out[2] = fl::clamp(s_b, 0.0f, 1.0f);
-            out[3] = 0.0f;
-            return true;
+        if (n_active == 1) {
+            return native_single_identity(s_r, s_g, s_b, out);
+        }
+        if (n_active == 2) {
+            return solve_native_dual_edge_fixed_topology(cache, s_r, s_g,
+                                                         s_b, out);
         }
     }
 
+    const float c_r = s_r / value;
+    const float c_g = s_g / value;
+    const float c_b = s_b / value;
     float X_t[3];
-    if (cache.has_source_space) {
-        const float s[3] = { s_r, s_g, s_b };
-        matvec3(cache.M_src, s, X_t);
-    } else {
-        X_t[0] = cache.P_R[0]*s_r + cache.P_G[0]*s_g + cache.P_B[0]*s_b;
-        X_t[1] = cache.P_R[1]*s_r + cache.P_G[1]*s_g + cache.P_B[1]*s_b;
-        X_t[2] = cache.P_R[2]*s_r + cache.P_G[2]*s_g + cache.P_B[2]*s_b;
-    }
+    source_rgb_to_XYZ(cache, c_r, c_g, c_b, X_t);
     const float sum = X_t[0]+X_t[1]+X_t[2];
     if (sum < 1e-9f) return true;
     float xy_t[2] = { X_t[0]/sum, X_t[1]/sum };
@@ -737,8 +947,9 @@ inline bool strict_subgamut(const ProfileCache& cache, float s_r, float s_g, flo
         if (t[0] < -kEps || t[1] < -kEps || t[2] < -kEps) continue;
         if (t[0] < 0) t[0] = 0; if (t[1] < 0) t[1] = 0; if (t[2] < 0) t[2] = 0;
         float m = t[0]; if (t[1] > m) m = t[1]; if (t[2] > m) m = t[2];
-        if (m > 1.0f) { float inv = 1.0f/m; t[0]*=inv; t[1]*=inv; t[2]*=inv; }
-        out[sg.ia] = t[0]; out[sg.ib] = t[1]; out[sg.ic] = t[2];
+        if (m > 1e-9f) { float inv = 1.0f/m; t[0]*=inv; t[1]*=inv; t[2]*=inv; }
+        out[sg.ia] = t[0] * value; out[sg.ib] = t[1] * value; out[sg.ic] = t[2] * value;
+        fastled_mirror::normalize4_if_needed(out);
         return true;
     }
     return false;
@@ -846,14 +1057,19 @@ inline bool strict_with_projection(const DiodeProfile& p, ProfileCache& cache,
                                    float out[4]) {
     fastled_mirror::build_cache(&p, &cache);  // shared cache builder
     out[0] = out[1] = out[2] = out[3] = 0.0f;
+    const float value = fl::max(fl::max(s_r, s_g), s_b);
+    if (value <= 1e-9f) return true;
+    const float c_r = s_r / value;
+    const float c_g = s_g / value;
+    const float c_b = s_b / value;
     float X_t[3];
     if (cache.has_source_space) {
-        const float s[3] = { s_r, s_g, s_b };
+        const float s[3] = { c_r, c_g, c_b };
         matvec3(cache.M_src, s, X_t);
     } else {
-        X_t[0] = cache.P_R[0]*s_r + cache.P_G[0]*s_g + cache.P_B[0]*s_b;
-        X_t[1] = cache.P_R[1]*s_r + cache.P_G[1]*s_g + cache.P_B[1]*s_b;
-        X_t[2] = cache.P_R[2]*s_r + cache.P_G[2]*s_g + cache.P_B[2]*s_b;
+        X_t[0] = cache.P_R[0]*c_r + cache.P_G[0]*c_g + cache.P_B[0]*c_b;
+        X_t[1] = cache.P_R[1]*c_r + cache.P_G[1]*c_g + cache.P_B[1]*c_b;
+        X_t[2] = cache.P_R[2]*c_r + cache.P_G[2]*c_g + cache.P_B[2]*c_b;
     }
     if (X_t[0]+X_t[1]+X_t[2] < 1e-9f) return true;
     float xy_t[2];
@@ -876,8 +1092,9 @@ inline bool strict_with_projection(const DiodeProfile& p, ProfileCache& cache,
         if (t[0] < -kEps || t[1] < -kEps || t[2] < -kEps) continue;
         if (t[0] < 0) t[0] = 0; if (t[1] < 0) t[1] = 0; if (t[2] < 0) t[2] = 0;
         float m = t[0]; if (t[1] > m) m = t[1]; if (t[2] > m) m = t[2];
-        if (m > 1.0f) { float inv = 1.0f/m; t[0]*=inv; t[1]*=inv; t[2]*=inv; }
-        out[sg.ia] = t[0]; out[sg.ib] = t[1]; out[sg.ic] = t[2];
+        if (m > 1e-9f) { float inv = 1.0f/m; t[0]*=inv; t[1]*=inv; t[2]*=inv; }
+        out[sg.ia] = t[0] * value; out[sg.ib] = t[1] * value; out[sg.ic] = t[2] * value;
+        fastled_mirror::normalize4_if_needed(out);
         return true;
     }
     return false;
@@ -1274,9 +1491,10 @@ FL_TEST_CASE("issue #2748: native dual-channel (cyan) keeps outer-edge topology"
     FL_CHECK(fastled_mirror::strict_subgamut(cache, 0.0f, 1.0f, 1.0f, rgbw));
     // BG edge — W and R must remain zero.
     FL_CHECK_CLOSE(rgbw[0], 0.0f, 1e-6f);
-    FL_CHECK_CLOSE(rgbw[1], 1.0f, 1e-6f);
-    FL_CHECK_CLOSE(rgbw[2], 1.0f, 1e-6f);
     FL_CHECK_CLOSE(rgbw[3], 0.0f, 1e-6f);
+    FL_CHECK(rgbw[1] > 0.0f);
+    FL_CHECK(rgbw[2] > 0.0f);
+    FL_CHECK_CLOSE(fl::max(rgbw[1], rgbw[2]), 1.0f, 1e-6f);
 }
 
 
@@ -1287,10 +1505,11 @@ FL_TEST_CASE("issue #2748: native dual-channel (yellow) keeps outer-edge topolog
 
     float rgbw[4] = {0};
     FL_CHECK(fastled_mirror::strict_subgamut(cache, 1.0f, 1.0f, 0.0f, rgbw));
-    FL_CHECK_CLOSE(rgbw[0], 1.0f, 1e-6f);
-    FL_CHECK_CLOSE(rgbw[1], 1.0f, 1e-6f);
     FL_CHECK_CLOSE(rgbw[2], 0.0f, 1e-6f);
     FL_CHECK_CLOSE(rgbw[3], 0.0f, 1e-6f);
+    FL_CHECK(rgbw[0] > 0.0f);
+    FL_CHECK(rgbw[1] > 0.0f);
+    FL_CHECK_CLOSE(fl::max(rgbw[0], rgbw[1]), 1.0f, 1e-6f);
 }
 
 
@@ -1301,10 +1520,11 @@ FL_TEST_CASE("issue #2748: native dual-channel (magenta) keeps outer-edge topolo
 
     float rgbw[4] = {0};
     FL_CHECK(fastled_mirror::strict_subgamut(cache, 1.0f, 0.0f, 1.0f, rgbw));
-    FL_CHECK_CLOSE(rgbw[0], 1.0f, 1e-6f);
     FL_CHECK_CLOSE(rgbw[1], 0.0f, 1e-6f);
-    FL_CHECK_CLOSE(rgbw[2], 1.0f, 1e-6f);
     FL_CHECK_CLOSE(rgbw[3], 0.0f, 1e-6f);
+    FL_CHECK(rgbw[0] > 0.0f);
+    FL_CHECK(rgbw[2] > 0.0f);
+    FL_CHECK_CLOSE(fl::max(rgbw[0], rgbw[2]), 1.0f, 1e-6f);
 }
 
 
@@ -1319,18 +1539,21 @@ FL_TEST_CASE("issue #2748: native dual-channel ramp preserves value granularity"
 
     const float values[] = {0.15f, 0.35f, 0.55f, 0.75f, 1.0f};
     float prev_g = -1.0f;
+    float prev_b = -1.0f;
     for (float v : values) {
         float rgbw[4] = {0};
         FL_CHECK(fastled_mirror::strict_subgamut(cache, 0.0f, v, v, rgbw));
         // Edge-locked: only G and B drive, no W, no R.
         FL_CHECK_CLOSE(rgbw[0], 0.0f, 1e-6f);
         FL_CHECK_CLOSE(rgbw[3], 0.0f, 1e-6f);
-        // Linear scaling: G / B drive equals input drive directly.
-        FL_CHECK_CLOSE(rgbw[1], v, 1e-6f);
-        FL_CHECK_CLOSE(rgbw[2], v, 1e-6f);
+        FL_CHECK(rgbw[1] > 0.0f);
+        FL_CHECK(rgbw[2] > 0.0f);
+        FL_CHECK_CLOSE(fl::max(rgbw[1], rgbw[2]), v, 1e-6f);
         // Monotonic strictly increasing — proves the collapse is gone.
         FL_CHECK(rgbw[1] > prev_g);
+        FL_CHECK(rgbw[2] > prev_b);
         prev_g = rgbw[1];
+        prev_b = rgbw[2];
     }
 }
 
@@ -1376,6 +1599,28 @@ FL_TEST_CASE("issue #2748: native three-channel input still uses sub-gamut routi
     // if the LED's W is uninvolved at this chromaticity). Both are valid; the
     // key invariant is that the solver actually ran, not just passed through.
     FL_CHECK(rgbw[3] >= 0.0f);
+}
+
+
+FL_TEST_CASE("issue #3231: strict endpoint scaling uses full available channel budget") {
+    using namespace native_topo;
+    const DiodeProfile p = native_profile();
+    ProfileCache cache; fastled_mirror::build_cache(&p, &cache);
+
+    // Reproducer from h315_s015_v100 in the issue report:
+    // input 65535/55705/63077 previously solved to W=55705 because the
+    // sub-gamut endpoint was left under-normalized before value scaling.
+    const float s_r = 65535.0f / 65535.0f;
+    const float s_g = 55705.0f / 65535.0f;
+    const float s_b = 63077.0f / 65535.0f;
+    float rgbw[4] = {0};
+    FL_CHECK(fastled_mirror::strict_subgamut(cache, s_r, s_g, s_b, rgbw));
+
+    FL_CHECK_CLOSE(rgbw[1], 0.0f, 1e-5f);
+    FL_CHECK_CLOSE(rgbw[3], 1.0f, 1e-5f);
+    FL_CHECK(rgbw[0] > 0.0f);
+    FL_CHECK(rgbw[2] > 0.0f);
+    FL_CHECK_CLOSE(fl::max(fl::max(rgbw[0], rgbw[2]), rgbw[3]), 1.0f, 1e-5f);
 }
 
 


### PR DESCRIPTION
## Summary
- Normalize strict RGBW sub-gamut endpoints before applying source value so split-channel energy no longer caps the final output.
- Make LUT lookup use source RGB value against normalized endpoint cells.
- Extract shared colorimetric primitives into `colorimetric_response.h` and add an RGB-only cache/solve shape for the follow-up plumbing.
- Refresh RGBW colorimetric tests for endpoint scaling, native dual-edge topology, and RGB-only helper coverage.

## Tests
- `python test.py --unit rgbw_colorimetric --no-interactive`
- `python test.py --unit rgbw_colorimetric --no-interactive --debug`
- `python test.py --unit rgbw --no-interactive`
- `git diff --check`

Closes #3231

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added an RGB-family colorimetric response layer with reusable caching to speed up source-to-output conversions.
  * Introduced an RGB-specific colorimetric profile/compatibility alias for smoother integration.

* **Bug Fixes**
  * Improved RGBW colorimetric scaling by consistently using the maximum source channel value.
  * Refined strict sub-gamut solving and LUT interpolation for more consistent normalization and endpoint behavior.

* **Tests**
  * Added tests for source-space vs no-source-space behavior and stricter RGBW endpoint/normalization regressions.
  * Expanded solver and monotonicity assertions for tighter output validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->