### PR TITLE
perf(json): JsonToType<T> dispatch through non-template cores (-2 KB Teensy 4; closes #3247)

### DIFF
--- a/src/fl/remote/rpc/_build.cpp.hpp
+++ b/src/fl/remote/rpc/_build.cpp.hpp
@@ -2,5 +2,6 @@
 /// @brief Unity build header for fl/remote/rpc/ directory
 
 #include "fl/remote/rpc/base64.cpp.hpp"
+#include "fl/remote/rpc/json_dispatch.cpp.hpp"
 #include "fl/remote/rpc/rpc.cpp.hpp"
 #include "fl/remote/rpc/server.cpp.hpp"

--- a/src/fl/remote/rpc/json_dispatch.cpp.hpp
+++ b/src/fl/remote/rpc/json_dispatch.cpp.hpp
@@ -1,0 +1,216 @@
+// IWYU pragma: private, include "fl/remote/rpc/json_dispatch.h"
+//
+// json_dispatch: implementation of the non-template JSON-to-primitive
+// conversion cores. See `json_dispatch.h` for design rationale
+// (FastLED #3247 / #3244 Tier 2E Phase 2).
+
+#include "fl/remote/rpc/json_dispatch.h"
+#include "fl/stl/json/types.h"
+#include "fl/stl/string.h"
+#include "fl/stl/cstdlib.h"  // fl::strtol
+#include "fl/system/sketch_macros.h"  // FL_PLATFORM_HAS_LARGE_MEMORY
+
+namespace fl {
+namespace detail {
+
+FL_NO_INLINE
+TypeConversionResult json_convert_to_i64_core(const json_value& val,
+                                              fl::i64* out_value) FL_NOEXCEPT {
+    TypeConversionResult result;
+    if (auto* p = val.data.template ptr<i64>()) {
+        *out_value = *p;
+        return result;
+    }
+    if (auto* p = val.data.template ptr<bool>()) {
+        *out_value = *p ? 1 : 0;
+        result.addWarning(fl::string("bool converted to int ") + fl::to_string(*out_value));
+        return result;
+    }
+    if (auto* p = val.data.template ptr<float>()) {
+#if FL_PLATFORM_HAS_LARGE_MEMORY
+        *out_value = static_cast<i64>(*p);
+        if (*p != static_cast<float>(*out_value)) {
+            result.addWarning(fl::string("float ") + fl::to_string(*p, 6) +
+                              " truncated to int " + fl::to_string(*out_value));
+        }
+#else
+        (void)p;
+        *out_value = 0;
+        result.setError("float -> int not supported on Low-memory");
+#endif
+        return result;
+    }
+    if (auto* p = val.data.template ptr<fl::string>()) {
+        char* end = nullptr;
+        long parsed = fl::strtol(p->c_str(), &end, 10);
+        if (end != p->c_str() && *end == '\0') {
+            *out_value = static_cast<i64>(parsed);
+            result.addWarning(fl::string("string '") + *p + "' parsed to int " + fl::to_string(*out_value));
+        } else {
+            result.setError(fl::string("cannot parse string '") + *p + "' as integer");
+        }
+        return result;
+    }
+    if (val.data.template ptr<fl::nullptr_t>()) {
+        result.setError("cannot convert null to integer");
+        return result;
+    }
+    // Any remaining alternative (json_object, json_array, vector<i16>,
+    // vector<u8>, vector<float>) -- all are "container" types that don't
+    // convert cleanly to an integer.
+    result.setError("cannot convert array or object to integer");
+    *out_value = 0;
+    return result;
+}
+
+FL_NO_INLINE
+TypeConversionResult json_convert_to_bool_core(const json_value& val,
+                                               bool* out_value) FL_NOEXCEPT {
+    TypeConversionResult result;
+    if (auto* p = val.data.template ptr<bool>()) {
+        *out_value = *p;
+        return result;
+    }
+    if (auto* p = val.data.template ptr<i64>()) {
+        *out_value = (*p != 0);
+        result.addWarning(fl::string("int ") + fl::to_string(*p) +
+                          " converted to bool " + (*out_value ? "true" : "false"));
+        return result;
+    }
+    if (auto* p = val.data.template ptr<float>()) {
+#if FL_PLATFORM_HAS_LARGE_MEMORY
+        *out_value = (*p != 0.0f);
+        result.addWarning(fl::string("float ") + fl::to_string(*p, 6) +
+                          " converted to bool " + (*out_value ? "true" : "false"));
+#else
+        (void)p;
+        *out_value = false;
+        result.setError("float -> bool not supported on Low-memory");
+#endif
+        return result;
+    }
+    if (auto* p = val.data.template ptr<fl::string>()) {
+        if (*p == "true" || *p == "1" || *p == "yes") {
+            *out_value = true;
+            result.addWarning(fl::string("string '") + *p + "' parsed as bool true");
+        } else if (*p == "false" || *p == "0" || *p == "no") {
+            *out_value = false;
+            result.addWarning(fl::string("string '") + *p + "' parsed as bool false");
+        } else {
+            result.setError(fl::string("cannot parse string '") + *p + "' as bool");
+            *out_value = false;
+        }
+        return result;
+    }
+    if (val.data.template ptr<fl::nullptr_t>()) {
+        result.setError("cannot convert null to bool");
+        *out_value = false;
+        return result;
+    }
+    result.setError("cannot convert array or object to bool");
+    *out_value = false;
+    return result;
+}
+
+FL_NO_INLINE
+TypeConversionResult json_convert_to_float_core(const json_value& val,
+                                                float* out_value) FL_NOEXCEPT {
+    TypeConversionResult result;
+    if (auto* p = val.data.template ptr<float>()) {
+        *out_value = *p;
+        return result;
+    }
+    if (auto* p = val.data.template ptr<i64>()) {
+#if FL_PLATFORM_HAS_LARGE_MEMORY
+        *out_value = static_cast<float>(*p);
+        if (sizeof(float) < 8 && (*p > 16777216 || *p < -16777216)) {
+            result.addWarning(fl::string("large int ") + fl::to_string(*p) +
+                              " may lose precision as float");
+        }
+#else
+        // Avoid __aeabi_l2f via i32 route (same trick as #3076).
+        if (*p > 2147483647LL) {
+            *out_value = static_cast<float>(2147483647);
+        } else if (*p < -2147483648LL) {
+            *out_value = static_cast<float>(-2147483648);
+        } else {
+            *out_value = static_cast<float>(static_cast<fl::i32>(*p));
+        }
+#endif
+        return result;
+    }
+    if (auto* p = val.data.template ptr<bool>()) {
+        *out_value = *p ? 1.0f : 0.0f;
+        result.addWarning(fl::string("bool converted to float ") +
+                          (*p ? "1.0" : "0.0"));
+        return result;
+    }
+    if (auto* p = val.data.template ptr<fl::string>()) {
+#if FL_PLATFORM_HAS_LARGE_MEMORY
+        char* end = nullptr;
+        double parsed = fl::strtod(p->c_str(), &end);
+        if (end != p->c_str() && *end == '\0') {
+            *out_value = static_cast<float>(parsed);
+            result.addWarning(fl::string("string '") + *p + "' parsed to float");
+        } else {
+            result.setError(fl::string("cannot parse string '") + *p + "' as float");
+            *out_value = 0.0f;
+        }
+#else
+        (void)p;
+        *out_value = 0.0f;
+        result.setError("string -> float not supported on Low-memory");
+#endif
+        return result;
+    }
+    if (val.data.template ptr<fl::nullptr_t>()) {
+        result.setError("cannot convert null to float");
+        *out_value = 0.0f;
+        return result;
+    }
+    result.setError("cannot convert array or object to float");
+    *out_value = 0.0f;
+    return result;
+}
+
+FL_NO_INLINE
+TypeConversionResult json_convert_to_string_core(const json_value& val,
+                                                 fl::string* out_value) FL_NOEXCEPT {
+    TypeConversionResult result;
+    if (auto* p = val.data.template ptr<fl::string>()) {
+        *out_value = *p;
+        return result;
+    }
+    if (auto* p = val.data.template ptr<i64>()) {
+        *out_value = fl::to_string(*p);
+        result.addWarning(fl::string("int ") + *out_value + " converted to string");
+        return result;
+    }
+    if (auto* p = val.data.template ptr<float>()) {
+#if FL_PLATFORM_HAS_LARGE_MEMORY
+        *out_value = fl::to_string(*p, 6);
+        result.addWarning(fl::string("float ") + *out_value + " converted to string");
+#else
+        (void)p;
+        *out_value = "0";
+        result.setError("float -> string not supported on Low-memory");
+#endif
+        return result;
+    }
+    if (auto* p = val.data.template ptr<bool>()) {
+        *out_value = *p ? "true" : "false";
+        result.addWarning(fl::string("bool converted to string '") + *out_value + "'");
+        return result;
+    }
+    if (val.data.template ptr<fl::nullptr_t>()) {
+        *out_value = "null";
+        result.addWarning("null converted to string 'null'");
+        return result;
+    }
+    result.setError("cannot convert array or object to string");
+    out_value->clear();
+    return result;
+}
+
+} // namespace detail
+} // namespace fl

--- a/src/fl/remote/rpc/json_dispatch.h
+++ b/src/fl/remote/rpc/json_dispatch.h
@@ -1,0 +1,64 @@
+#pragma once
+
+// json_dispatch: type-erased core helpers for JSON-to-primitive conversion.
+//
+// `fl::detail::JsonToIntegerVisitor<T>`, `JsonToFloatVisitor<T>`,
+// `JsonToBoolVisitor`, and `JsonToStringVisitor` each contain ~10
+// `operator()` overloads (one per `json_value::variant_t` alternative).
+// When invoked via `data.visit(visitor)`, the variant emits a
+// `visit_fn<T, Visitor>` thunk per (alternative × visitor) pair. With ~6
+// distinct visitor instantiations × 10 alternatives that's ~60+ thunks,
+// plus the per-T body fan-out for the templated visitors -- the audit
+// in #3235 catalogued ~2-3 KB of visitor codegen on LPC845 alone.
+//
+// This dispatch layer collapses the per-(visitor × alternative) explosion
+// to **one** shared non-template body per output type. The thin templated
+// `JsonToType<T>::convert` (in `json_to_type.h`) calls the appropriate
+// core, gets back the canonical type (`i64` / `bool` / `float` / `string`)
+// plus a `TypeConversionResult`, and applies per-T narrowing + range
+// checking. The per-(T × alternative) thunk explosion goes away.
+//
+// `FL_NO_INLINE` on the implementations is load-bearing under LTO --
+// without it the compiler inlines the body back at each call site,
+// defeating dedup.
+//
+// See FastLED #3247 / #3244 Tier 2E Phase 2.
+
+#include "fl/remote/rpc/type_conversion_result.h"  // IWYU pragma: keep
+#include "fl/stl/int.h"
+#include "fl/stl/compiler_control.h"  // FL_NO_INLINE
+#include "fl/stl/noexcept.h"
+
+namespace fl {
+
+struct json_value;
+
+namespace detail {
+
+// Each core returns the converted result in `out_value` and emits any
+// warnings / errors via the returned `TypeConversionResult`. Caller is
+// responsible for applying per-T narrowing on the result (e.g. casting
+// the returned `i64` to `int8_t` with overflow detection).
+//
+// All four cores switch over `val.data.tag()` and read the active
+// alternative via `data.template ptr<T>()` -- no `data.visit(visitor)`
+// call, no `visit_fn<T, Visitor>` thunk instantiation.
+
+FL_NO_INLINE
+TypeConversionResult json_convert_to_i64_core(const json_value& val,
+                                              fl::i64* out_value) FL_NOEXCEPT;
+
+FL_NO_INLINE
+TypeConversionResult json_convert_to_bool_core(const json_value& val,
+                                               bool* out_value) FL_NOEXCEPT;
+
+FL_NO_INLINE
+TypeConversionResult json_convert_to_float_core(const json_value& val,
+                                                float* out_value) FL_NOEXCEPT;
+
+FL_NO_INLINE
+TypeConversionResult json_convert_to_string_core(const json_value& val,
+                                                 fl::string* out_value) FL_NOEXCEPT;
+
+} // namespace detail
+} // namespace fl

--- a/src/fl/remote/rpc/json_to_type.h
+++ b/src/fl/remote/rpc/json_to_type.h
@@ -2,6 +2,7 @@
 
 #include "fl/stl/json.h"
 #include "fl/remote/rpc/type_conversion_result.h"
+#include "fl/remote/rpc/json_dispatch.h"  // type-erased conversion cores (#3247)
 #include "fl/remote/rpc/json_visitors.h"
 #include "fl/stl/tuple.h"
 #include "fl/stl/type_traits.h"
@@ -62,75 +63,78 @@ struct JsonToType {
     }
 };
 
-// Integer conversion (excluding bool) - uses visitor pattern
+// Integer conversion (excluding bool) - dispatches through the shared
+// non-template `json_convert_to_i64_core` (FastLED #3247). Per-T narrowing
+// + overflow detection happen here; the heavy variant-walking lives once
+// in the core.
 template <typename T>
 struct JsonToType<T, typename fl::enable_if<fl::is_integral<T>::value && !fl::is_same<T, bool>::value>::type> {
     static fl::tuple<T, TypeConversionResult> convert(const json& j) {
-        // Access internal json_value directly instead of re-parsing
         const json_value* val = j.internal_value();
         if (!val) {
             TypeConversionResult result;
             result.setError("failed to access JSON value");
             return fl::make_tuple(T(), result);
         }
-
-        JsonToIntegerVisitor<T> visitor;
-        val->data.visit(visitor);
-        return fl::make_tuple(visitor.mValue, visitor.mResult);
+        fl::i64 raw = 0;
+        TypeConversionResult result = json_convert_to_i64_core(*val, &raw);
+        T narrowed = static_cast<T>(raw);
+        if (static_cast<fl::i64>(narrowed) != raw) {
+            result.addWarning(fl::string("integer overflow/truncation: ") +
+                              fl::to_string(raw) + " converted to " +
+                              fl::to_string(static_cast<fl::i64>(narrowed)));
+        }
+        return fl::make_tuple(narrowed, result);
     }
 };
 
-// Boolean conversion - uses visitor pattern
+// Boolean conversion - dispatches through `json_convert_to_bool_core`.
 template <>
 struct JsonToType<bool, void> {
     static fl::tuple<bool, TypeConversionResult> convert(const json& j) {
-        // Access internal json_value directly instead of re-parsing
         const json_value* val = j.internal_value();
         if (!val) {
             TypeConversionResult result;
             result.setError("failed to access JSON value");
             return fl::make_tuple(bool(false), result);
         }
-
-        JsonToBoolVisitor visitor;
-        val->data.visit(visitor);
-        return fl::make_tuple(visitor.mValue, visitor.mResult);
+        bool out = false;
+        TypeConversionResult result = json_convert_to_bool_core(*val, &out);
+        return fl::make_tuple(out, result);
     }
 };
 
-// Float/double conversion - uses visitor pattern
+// Float / double conversion - dispatches through `json_convert_to_float_core`.
+// The core works in float precision (no double soft-FP on no-FPU targets);
+// the per-T narrowing here lifts to double for `T == double` if requested.
 template <typename T>
 struct JsonToType<T, typename fl::enable_if<fl::is_floating_point<T>::value>::type> {
     static fl::tuple<T, TypeConversionResult> convert(const json& j) {
-        // Access internal json_value directly instead of re-parsing
         const json_value* val = j.internal_value();
         if (!val) {
             TypeConversionResult result;
             result.setError("failed to access JSON value");
             return fl::make_tuple(T(), result);
         }
-
-        JsonToFloatVisitor<T> visitor;
-        val->data.visit(visitor);
-        return fl::make_tuple(visitor.mValue, visitor.mResult);
+        float raw = 0.0f;
+        TypeConversionResult result = json_convert_to_float_core(*val, &raw);
+        return fl::make_tuple(static_cast<T>(raw), result);
     }
 };
 
-// String conversion - uses visitor pattern
+// String conversion - dispatches through `json_convert_to_string_core`.
 template <>
 struct JsonToType<fl::string, void> {
     static fl::tuple<fl::string, TypeConversionResult> convert(const json& j) {
-        // Access internal json_value directly instead of re-parsing
         const json_value* val = j.internal_value();
         if (!val) {
             TypeConversionResult result;
             result.setError("failed to access JSON value");
             return fl::make_tuple(fl::string(), result);
         }
-
-        JsonToStringVisitor visitor;
-        val->data.visit(visitor);
-        return fl::make_tuple(visitor.mValue, visitor.mResult);
+        fl::string out;
+        TypeConversionResult result = json_convert_to_string_core(*val, &out);
+        return fl::make_tuple(out, result);
     }
 };
 


### PR DESCRIPTION
Closes #3247 (#3244 Tier 2E Phase 2).

Introduces non-template json_convert_to_<X>_core helpers, routes JsonToType<T>::convert through them.

## Verification

| Target | Before | After | Δ |
|---|---:|---:|---:|
| LPC845 / AutoResearch | 47,128 B | 47,020 B | -108 B |
| Teensy 4 / AutoResearch | 348,160 B | 346,112 B | **-2,048 B** |

LPC845 win is modest because #3226 already gated most visitor paths to setError bodies on Low-memory; the Teensy 4 win matches the audit's predicted ~2 KB.

Refs #3244, #3247.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized JSON-to-primitive type conversion infrastructure by centralizing conversion logic and improving error handling for integer, boolean, floating-point, and string conversions from JSON data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->