### PR TITLE
Prefer reference input gamut mutator

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -236,6 +236,13 @@ reviews:
         `src/FastLED.h` and document the god-instance form in the PR
         description / examples.
 
+        Mutable caller-owned objects SHOULD be passed as `T&`, not `T*`,
+        unless `nullptr` has an explicit documented meaning such as reset,
+        no-op compatibility, or another nullable contract. Flag new mutable
+        pointer parameters that merely express mutation; the fix is usually a
+        non-const reference overload plus a documented compatibility wrapper
+        only when preserving an existing nullable API.
+
     - path: "src/fl/log/**"
       instructions: |
         FL_WARN / FL_ERROR default-visibility invariant (#2886 Stage 1):

--- a/agents/docs/cpp-standards.md
+++ b/agents/docs/cpp-standards.md
@@ -254,8 +254,8 @@ class CFastLED {
 
 **Rules**:
 1. ❌ **NEVER ship a new `fl::set_*` / `fl::enable_*` / `fl::disable_*` / `fl::use_*` free function that mutates library-wide state without a matching `CFastLED::setX()` / `enableX()` wrapper.**
-   - ❌ Bad: `fl::set_input_gamut(&profile, fl::InputGamut::Rec709);` as the documented call site
-   - ✅ Good: `FastLED.setInputGamut(&profile, fl::InputGamut::Rec709);` (god instance), with a `fl::set_input_gamut(...)` free function backing it
+   - ❌ Bad: `fl::set_input_gamut(profile, fl::InputGamut::Rec709);` as the documented call site
+   - ✅ Good: `FastLED.setInputGamut(profile, fl::InputGamut::Rec709);` (god instance), with a `fl::set_input_gamut(...)` free function backing it
 2. ✅ **The wrapper is a `inline` one-liner that delegates** — no logic, no validation, no error handling. The free function holds all behavior.
 3. ✅ **Per-object configuration (e.g. one strip's diode profile, one controller's correction) MAY live on the per-object API.** This rule targets *library-wide / process-wide / default-profile* state.
 4. ✅ **Documentation, examples, and PR descriptions reference the god-instance form.** The free function is an implementation detail.
@@ -308,35 +308,53 @@ class CFastLED {
 2. If the parameter is `const T*` AND the storage is `const T*`, flag as HIGH severity (pointer storage = use-after-scope).
 3. If the parameter is `const T*` but the storage is `T` and the body copies on non-null + resets on null, that's the allowed nullable-reset shape — no violation.
 
+## Mutating Caller-Owned Objects: Prefer References Over Pointers
+
+**Core Principle**: Public APIs that mutate a required caller-owned object SHOULD take `T&`, not `T*`. A mutable pointer is permitted only when null has an explicit semantic contract, such as "reset to default" for a global setting or a temporary compatibility overload that preserves an older no-op-on-null API.
+
+**Rules**:
+1. ❌ **NEVER use a mutable pointer merely because the function mutates the object.**
+   - ❌ Bad: `void set_input_gamut(DiodeProfile* profile, InputGamut g);`
+   - ✅ Good: `void set_input_gamut(DiodeProfile& profile, InputGamut g);`
+2. ✅ **Keep pointer overloads only when null behavior is intentionally documented.**
+   - ✅ Compatibility: `void set_input_gamut(DiodeProfile* profile, InputGamut g);  // nullptr is a no-op for legacy callers`
+   - ✅ Nullable reset: `void set_rgbww_colorimetric_profile(const RgbcctProfile* p);  // nullptr resets to default`
+3. ✅ **For read-only required inputs, use `const T&`; for required mutations, use `T&`; for optional inputs, prefer an overload or a named optional type over a raw pointer when practical.**
+
+**Check Process**:
+1. For every new public function taking `T*`, ask whether `nullptr` is meaningful and documented.
+2. If null is not meaningful, require `T&` or `const T&`.
+3. If the pointer remains for compatibility, add the reference overload as the preferred API and document the pointer overload as legacy/nullable.
+
 ## In-Place Profile Mutation Bumps a Version (Cache Invalidation Contract)
 
-**Core Principle**: If `set_X(T* obj, ...)` writes into the fields of a caller-owned `*obj`, and any subsystem caches values *derived from* `*obj` keyed only on `(obj_ptr, ...)`, then the setter MUST bump `obj->mCacheVersion` (or call `obj->invalidate()`) and the cache key MUST include that version. Otherwise the cache returns stale data the next time the same pointer is passed in.
+**Core Principle**: If `set_X(T& obj, ...)` writes into the fields of a caller-owned `obj`, and any subsystem caches values *derived from* `obj` keyed only on `(&obj, ...)`, then the setter MUST bump `obj.mCacheVersion` (or call `obj.invalidate()`) and the cache key MUST include that version. Otherwise the cache returns stale data the next time the same object is passed in.
 
 **Rules**:
 1. ❌ **NEVER mutate a profile field in place without bumping a version counter** when a cache exists keyed on the profile pointer.
    - ❌ Bad:
      ```cpp
-     void set_input_gamut(DiodeProfile* p, InputGamut g) FL_NOEXCEPT {
-         apply_gamut(p, g);  // rewrites p->input_xy_*
-         // …no version bump; ProfileCache keyed on (p, cct) still returns stale M_src
+     void set_input_gamut(DiodeProfile& p, InputGamut g) FL_NOEXCEPT {
+         apply_gamut(p, g);  // rewrites p.input_xy_*
+         // …no version bump; ProfileCache keyed on (&p, cct) still returns stale M_src
      }
      ```
    - ✅ Good:
      ```cpp
-     void set_input_gamut(DiodeProfile* p, InputGamut g) FL_NOEXCEPT {
+     void set_input_gamut(DiodeProfile& p, InputGamut g) FL_NOEXCEPT {
          apply_gamut(p, g);
-         ++p->mCacheVersion;  // forces any derived-value cache to rebuild
+         ++p.mCacheVersion;  // forces any derived-value cache to rebuild
      }
      // and:
      struct CacheKey { const DiodeProfile* p; u32 version; int cct; };
      ```
-2. ✅ **Document the cache-invalidation contract** in the setter's doxygen: "Mutates `*p` in place; bumps `p->mCacheVersion` so derived caches rebuild on next access."
+2. ✅ **Document the cache-invalidation contract** in the setter's doxygen: "Mutates `p` in place; bumps `p.mCacheVersion` so derived caches rebuild on next access."
 3. ✅ **Prefer immutable profiles when possible.** A `DiodeProfile` that ships as `const` to all consumers and is replaced wholesale (`set_profile(const T&)`) eliminates this entire class of bug — see Singleton-Stored Configuration rule above.
 
 **Rationale**: Drove four CodeRabbit findings in the survey window (#2554, #2589, #2707, #2711) and is the root cause of the colorimetric "looks right in tests but stale in production" class. Tests typically construct one profile per test case so the cache never hits — the bug only shows up in real applications that mutate one shared profile across frames.
 
 **Check Process**:
-1. For each `fl::set_*(T* obj, ...)` where the body mutates `*obj`, search the codebase for a cache keyed on `obj` (typical names: `ProfileCache`, `kCache`, `sCachedDerived`).
+1. For each `fl::set_*(T& obj, ...)` where the body mutates `obj`, search the codebase for a cache keyed on `&obj` (typical names: `ProfileCache`, `kCache`, `sCachedDerived`).
 2. If a cache exists and the setter doesn't bump a version field, flag as HIGH severity.
 
 ## Contract Change Fanout (API Surface Changes Touch All Layers in One PR)
@@ -365,16 +383,16 @@ class CFastLED {
    - ❌ Bad: `using write_bytes_handler_t = fl::function<size_t(const u8*, size_t)>;`
    - ✅ Good: `using write_bytes_handler_t = fl::function<size_t(fl::span<const u8>)>;`
 2. ❌ **NEVER take small fixed-size arrays as raw pointers.**
-   - ❌ Bad: `void set_input_gamut(DiodeProfile* p, InputGamut g, const float white_xy[2]);`
-   - ✅ Good: `void set_input_gamut(DiodeProfile* p, InputGamut g, fl::span<const float, 2> white_xy);`
-   - ✅ Good (alternative — by-value pair): `void set_white_point(DiodeProfile* p, fl::vec2f white_xy);`
+   - ❌ Bad: `void set_input_gamut(DiodeProfile& p, InputGamut g, const float white_xy[2]);`
+   - ✅ Good: `void set_input_gamut(DiodeProfile& p, InputGamut g, fl::span<const float, 2> white_xy);`
+   - ✅ Good (alternative — by-value pair): `void set_white_point(DiodeProfile& p, fl::vec2f white_xy);`
 3. ❌ **NEVER use function parameter array spelling (`T value[N]` or `T value[]`).**
    - C++ adjusts these to `T* value`; the extent is not part of the function type and is not enforced.
    - ❌ Bad: `void cct_to_xy(int cct, float out[2]);`
    - ❌ Bad: `void encode(fl::u8 output[4]);`
    - ✅ Good for normal APIs: `void cct_to_xy(int cct, fl::span<float, 2> out);`
    - ✅ Good for ISR / `FL_IRAM` APIs: `void encode(fl::u8 (&output)[4]);`
-   - ✅ Good where a wrapper type would obscure the domain: `void set_white_point(DiodeProfile* p, fl::vec2f white_xy);`
+   - ✅ Good where a wrapper type would obscure the domain: `void set_white_point(DiodeProfile& p, fl::vec2f white_xy);`
    - Suppress only intentional C ABI or platform compatibility cases with `// ok array parameter`.
 4. ⚠️ **For ISR / `FL_IRAM` callgraphs, prefer array references over `fl::span<T, N>`.**
    - `fl::span<T, N>` is the right general API shape, but current span accessors are not explicitly `FASTLED_FORCE_INLINE` / `FL_IRAM`. Until an explicitly ISR-safe span exists, ISR-facing fixed-size output buffers should use `T (&value)[N]`.

--- a/ci/lint_cpp/public_settings_pattern_checker.py
+++ b/ci/lint_cpp/public_settings_pattern_checker.py
@@ -190,7 +190,7 @@ def _is_per_object_setter(decl_line: str) -> bool:
     is likely mutating an object the caller owns, not global state.
 
     Examples that return True (per-object — skip):
-        void set_input_gamut(DiodeProfile* obj, InputGamut g)
+        void set_input_gamut(DiodeProfile& obj, InputGamut g)
         void set_color(CRGB& out, uint8_t r, uint8_t g, uint8_t b)
 
     Examples that return False (global state — flag):

--- a/ci/lint_cpp/test_public_settings_pattern_checker.py
+++ b/ci/lint_cpp/test_public_settings_pattern_checker.py
@@ -301,7 +301,7 @@ class TestGrandfatheredAllowlist(unittest.TestCase):
     def test_set_input_gamut_not_flagged(self) -> None:
         code = (
             "namespace fl {\n"
-            "void set_input_gamut(DiodeProfile* p, InputGamut g) FL_NOEXCEPT;\n"
+            "void set_input_gamut(DiodeProfile& p, InputGamut g) FL_NOEXCEPT;\n"
             "}"
         )
         self.assertEqual(len(_violations(code)), 0)
@@ -343,8 +343,13 @@ class TestGrandfatheredAllowlist(unittest.TestCase):
 class TestPerObjectSetterCarveout(unittest.TestCase):
     """_is_per_object_setter() and the checker integration."""
 
-    def test_non_const_ptr_first_param_is_per_object(self) -> None:
-        # Non-const pointer to user type → per-object, not flagged
+    def test_non_const_ref_first_param_is_per_object(self) -> None:
+        # Non-const reference to user type -> per-object, not flagged
+        line = "void set_input_gamut(DiodeProfile& obj, InputGamut g);"
+        self.assertTrue(_is_per_object_setter(line))
+
+    def test_non_const_ptr_first_param_is_per_object_compatibility(self) -> None:
+        # Legacy compatibility overloads may still be nullable per-object mutators.
         line = "void set_input_gamut(DiodeProfile* obj, InputGamut g);"
         self.assertTrue(_is_per_object_setter(line))
 

--- a/ci/tools/array_param_baseline.txt
+++ b/ci/tools/array_param_baseline.txt
@@ -5,8 +5,6 @@
 # Format: src/path|normalized source signature
 # New entries fail the default unified C++ linter.
 
-src/fl/gfx/rgbw.cpp.hpp|void set_input_gamut(DiodeProfile* profile, InputGamut g, const float white_xy[2]) FL_NOEXCEPT {
-src/fl/gfx/rgbw.h|void set_input_gamut(DiodeProfile* profile, InputGamut g, const float white_xy[2]) FL_NOEXCEPT;
 src/fl/gfx/rgbw_colorimetric.h|inline void nnls3(const float M[3][3], const float b[3], float t_out[3], float* residual_out) FL_NOEXCEPT {
 src/fl/math/transposition.cpp.hpp|bool SPITransposer::transpose16(const fl::optional<LaneData> lanes[16], fl::span<u8> output, const char** error) {
 src/fl/math/transposition.cpp.hpp|bool SPITransposer::transpose8(const fl::optional<LaneData> lanes[8], fl::span<u8> output, const char** error) {

--- a/src/FastLED.h
+++ b/src/FastLED.h
@@ -1502,19 +1502,43 @@ public:
 
 	/// Reconfigure `profile`'s input gamut to one of the named source
 	/// chromaticity sets (Native / Rec709 / Rec2020 / DCI-P3 D65 / D60).
-	/// Mutates `profile` in place; no-op if `profile == nullptr`.
+	/// Mutates `profile` in place.
 	/// @code
-	/// FastLED.setInputGamut(&my_profile, fl::InputGamut::Rec709);
+	/// FastLED.setInputGamut(my_profile, fl::InputGamut::Rec709);
 	/// @endcode
+	inline void setInputGamut(fl::DiodeProfile& profile, fl::InputGamut g) FL_NOEXCEPT {
+		fl::set_input_gamut(profile, g);
+	}
+
+	/// Compatibility overload for existing sketches. Prefer the reference
+	/// overload above for new code; passing `nullptr` is a no-op.
 	inline void setInputGamut(fl::DiodeProfile* profile, fl::InputGamut g) FL_NOEXCEPT {
 		fl::set_input_gamut(profile, g);
 	}
 
-	/// Same as above with an explicit input white-point override. Pass
-	/// `nullptr` for `white_xy` to fall back to the gamut's standard
-	/// reference white (equivalent to the 2-argument overload).
+	/// Same as above with an explicit two-float input white-point override.
+	inline void setInputGamut(fl::DiodeProfile& profile, fl::InputGamut g,
+	                          fl::span<const float, 2> white_xy) FL_NOEXCEPT {
+		fl::set_input_gamut(profile, g, white_xy);
+	}
+
+	/// Compatibility overload for existing pointer-profile call sites.
 	inline void setInputGamut(fl::DiodeProfile* profile, fl::InputGamut g,
-	                          const float white_xy[2]) FL_NOEXCEPT {
+	                          fl::span<const float, 2> white_xy) FL_NOEXCEPT {
+		fl::set_input_gamut(profile, g, white_xy);
+	}
+
+	/// Compatibility overload for old callers that passed `nullptr` for the
+	/// white override. Prefer the 2-argument overload for new code.
+	inline void setInputGamut(fl::DiodeProfile& profile, fl::InputGamut g,
+	                          decltype(nullptr) white_xy) FL_NOEXCEPT {
+		fl::set_input_gamut(profile, g, white_xy);
+	}
+
+	/// Compatibility overload for old callers that passed `nullptr` for the
+	/// profile and/or white override.
+	inline void setInputGamut(fl::DiodeProfile* profile, fl::InputGamut g,
+	                          decltype(nullptr) white_xy) FL_NOEXCEPT {
 		fl::set_input_gamut(profile, g, white_xy);
 	}
 

--- a/src/fl/gfx/rgbw.cpp.hpp
+++ b/src/fl/gfx/rgbw.cpp.hpp
@@ -239,15 +239,15 @@ constexpr NamedGamut kDciP3D60  = {{0.6800f, 0.3200f}, {0.2650f, 0.6900f},
 // after a gamut switch on the currently active profile.
 namespace { void invalidate_colorimetric_caches_for(const DiodeProfile* profile) FL_NOEXCEPT; }
 
-void set_input_gamut(DiodeProfile* profile, InputGamut g,
-                     const float white_xy[2]) FL_NOEXCEPT {
-    if (profile == nullptr) return;
-    auto apply = [profile](const float r[2], const float gp[2],
+namespace {
+void set_input_gamut_impl(DiodeProfile& profile, InputGamut g,
+                          const float* white_xy) FL_NOEXCEPT {
+    auto apply = [&profile](const float r[2], const float gp[2],
                            const float b[2], const float w[2]) {
-        profile->input_xy_r[0] = r[0];  profile->input_xy_r[1] = r[1];
-        profile->input_xy_g[0] = gp[0]; profile->input_xy_g[1] = gp[1];
-        profile->input_xy_b[0] = b[0];  profile->input_xy_b[1] = b[1];
-        profile->input_xy_w[0] = w[0];  profile->input_xy_w[1] = w[1];
+        profile.input_xy_r[0] = r[0];  profile.input_xy_r[1] = r[1];
+        profile.input_xy_g[0] = gp[0]; profile.input_xy_g[1] = gp[1];
+        profile.input_xy_b[0] = b[0];  profile.input_xy_b[1] = b[1];
+        profile.input_xy_w[0] = w[0];  profile.input_xy_w[1] = w[1];
     };
     switch (g) {
     case InputGamut::Native: {
@@ -255,29 +255,58 @@ void set_input_gamut(DiodeProfile* profile, InputGamut g,
         // copy them over rather than picking a fixed sRGB-like fallback.
         const float d65[2] = {0.31272f, 0.32903f};
         const float* w = (white_xy != nullptr) ? white_xy : d65;
-        apply(profile->xy_r, profile->xy_g, profile->xy_b, w);
-        invalidate_colorimetric_caches_for(profile);
+        apply(profile.xy_r, profile.xy_g, profile.xy_b, w);
+        invalidate_colorimetric_caches_for(&profile);
         return;
     }
     case InputGamut::Rec709:   apply(kRec709.xy_r,   kRec709.xy_g,   kRec709.xy_b,
                                      white_xy != nullptr ? white_xy : kRec709.xy_w);
-                                invalidate_colorimetric_caches_for(profile);   return;
+                                invalidate_colorimetric_caches_for(&profile);   return;
     case InputGamut::Rec2020:  apply(kRec2020.xy_r,  kRec2020.xy_g,  kRec2020.xy_b,
                                      white_xy != nullptr ? white_xy : kRec2020.xy_w);
-                                invalidate_colorimetric_caches_for(profile);  return;
+                                invalidate_colorimetric_caches_for(&profile);  return;
     case InputGamut::DciP3D65: apply(kDciP3D65.xy_r, kDciP3D65.xy_g, kDciP3D65.xy_b,
                                      white_xy != nullptr ? white_xy : kDciP3D65.xy_w);
-                                invalidate_colorimetric_caches_for(profile); return;
+                                invalidate_colorimetric_caches_for(&profile); return;
     case InputGamut::DciP3D60: apply(kDciP3D60.xy_r, kDciP3D60.xy_g, kDciP3D60.xy_b,
                                      white_xy != nullptr ? white_xy : kDciP3D60.xy_w);
-                                invalidate_colorimetric_caches_for(profile); return;
+                                invalidate_colorimetric_caches_for(&profile); return;
     }
     // Default-fallthrough for forward-compat with future enum additions:
     // leave the profile's input_xy_* untouched — also nothing to invalidate.
 }
+} // namespace
+
+void set_input_gamut(DiodeProfile& profile, InputGamut g,
+                     fl::span<const float, 2> white_xy) FL_NOEXCEPT {
+    set_input_gamut_impl(profile, g, white_xy.data());
+}
+
+void set_input_gamut(DiodeProfile& profile, InputGamut g) FL_NOEXCEPT {
+    set_input_gamut_impl(profile, g, nullptr);
+}
+
+void set_input_gamut(DiodeProfile* profile, InputGamut g,
+                     fl::span<const float, 2> white_xy) FL_NOEXCEPT {
+    if (profile == nullptr) return;
+    set_input_gamut(*profile, g, white_xy);
+}
 
 void set_input_gamut(DiodeProfile* profile, InputGamut g) FL_NOEXCEPT {
-    set_input_gamut(profile, g, nullptr);
+    if (profile == nullptr) return;
+    set_input_gamut(*profile, g);
+}
+
+void set_input_gamut(DiodeProfile& profile, InputGamut g,
+                     decltype(nullptr) white_xy) FL_NOEXCEPT {
+    (void)white_xy;
+    set_input_gamut(profile, g);
+}
+
+void set_input_gamut(DiodeProfile* profile, InputGamut g,
+                     decltype(nullptr) white_xy) FL_NOEXCEPT {
+    (void)white_xy;
+    set_input_gamut(profile, g);
 }
 
 #if FASTLED_RGBW_COLORIMETRIC

--- a/src/fl/gfx/rgbw.h
+++ b/src/fl/gfx/rgbw.h
@@ -8,6 +8,7 @@
 #include "eorder.h"
 #include "fl/stl/compiler_control.h"
 #include "fl/stl/noexcept.h"
+#include "fl/stl/span.h"
 
 namespace fl {
 
@@ -88,17 +89,26 @@ enum class InputGamut : u8 {
 // standard published primary chromaticities + that gamut's reference white.
 // Mutates `profile` in place; subsequent solver calls observe the new gamut
 // (the cache is keyed on the profile pointer and rebuilds automatically).
-// No-op if `profile == nullptr`.
-void set_input_gamut(DiodeProfile* profile, InputGamut g) FL_NOEXCEPT;
+void set_input_gamut(DiodeProfile& profile, InputGamut g) FL_NOEXCEPT;
 
-// Same as the above, but lets you optionally override the input white point.
-// `white_xy` either points to a 2-float (x, y) chromaticity OR is `nullptr`
-// to fall back to the gamut's standard reference white (equivalent to the
-// 2-argument overload above). Use the override for niche cases (D50
+// Same as the above, but lets you override the input white point with an
+// exactly two-float (x, y) chromaticity. Omit this argument to fall back to
+// the gamut's standard reference white. Use the override for niche cases (D50
 // photography workflow, D60 ACES cinema, a custom calibration target) where
 // the standard gamut's reference white doesn't match your content.
+void set_input_gamut(DiodeProfile& profile, InputGamut g,
+                     fl::span<const float, 2> white_xy) FL_NOEXCEPT;
+
+// Compatibility overloads for existing sketches. Prefer the reference
+// overloads above for new code; passing a null profile is intentionally a
+// no-op here to preserve the old API contract.
+void set_input_gamut(DiodeProfile* profile, InputGamut g) FL_NOEXCEPT;
 void set_input_gamut(DiodeProfile* profile, InputGamut g,
-                     const float white_xy[2]) FL_NOEXCEPT;
+                     fl::span<const float, 2> white_xy) FL_NOEXCEPT;
+void set_input_gamut(DiodeProfile& profile, InputGamut g,
+                     decltype(nullptr) white_xy) FL_NOEXCEPT;
+void set_input_gamut(DiodeProfile* profile, InputGamut g,
+                     decltype(nullptr) white_xy) FL_NOEXCEPT;
 
 // Default profile: SK6812 RGBW3535 @ ~6000K (datasheet wavelengths -> xy +
 // typical luminance ratios). Always declared so user code referencing it

--- a/tests/fl/gfx/rgbw_colorimetric.cpp
+++ b/tests/fl/gfx/rgbw_colorimetric.cpp
@@ -325,7 +325,7 @@ FL_TEST_CASE("source matrix matches published sRGB->XYZ matrix (Rec709 opt-in)")
     //   Y = 0.2126729 R + 0.7151522 G + 0.0721750 B
     //   Z = 0.0193339 R + 0.1191920 G + 0.9503041 B
     DiodeProfile p = kRgbwDefaultProfile;
-    set_input_gamut(&p, InputGamut::Rec709);
+    set_input_gamut(p, InputGamut::Rec709);
     float M[3][3];
     FL_CHECK(build_source_matrix(p.input_xy_r, p.input_xy_g,
                                  p.input_xy_b, p.input_xy_w, M));
@@ -351,7 +351,7 @@ FL_TEST_CASE("set_input_gamut: Native copies LED primaries") {
     p.input_xy_g[0] = 0; p.input_xy_g[1] = 0;
     p.input_xy_b[0] = 0; p.input_xy_b[1] = 0;
     p.input_xy_w[0] = 0; p.input_xy_w[1] = 0;
-    set_input_gamut(&p, InputGamut::Native);
+    set_input_gamut(p, InputGamut::Native);
     FL_CHECK_CLOSE(p.input_xy_r[0], p.xy_r[0], 1e-6f);
     FL_CHECK_CLOSE(p.input_xy_g[0], p.xy_g[0], 1e-6f);
     FL_CHECK_CLOSE(p.input_xy_b[0], p.xy_b[0], 1e-6f);
@@ -363,21 +363,21 @@ FL_TEST_CASE("set_input_gamut: Native copies LED primaries") {
 
 FL_TEST_CASE("set_input_gamut: named gamuts populate canonical primaries") {
     DiodeProfile p = kRgbwDefaultProfile;
-    set_input_gamut(&p, InputGamut::Rec709);
+    set_input_gamut(p, InputGamut::Rec709);
     FL_CHECK_CLOSE(p.input_xy_r[0], 0.6400f, 1e-6f);
     FL_CHECK_CLOSE(p.input_xy_g[1], 0.6000f, 1e-6f);
     FL_CHECK_CLOSE(p.input_xy_w[0], 0.31272f, 1e-5f);
 
-    set_input_gamut(&p, InputGamut::Rec2020);
+    set_input_gamut(p, InputGamut::Rec2020);
     FL_CHECK_CLOSE(p.input_xy_r[0], 0.7080f, 1e-6f);
     FL_CHECK_CLOSE(p.input_xy_g[0], 0.1700f, 1e-6f);
 
-    set_input_gamut(&p, InputGamut::DciP3D65);
+    set_input_gamut(p, InputGamut::DciP3D65);
     FL_CHECK_CLOSE(p.input_xy_r[0], 0.6800f, 1e-6f);
     FL_CHECK_CLOSE(p.input_xy_g[0], 0.2650f, 1e-6f);
     FL_CHECK_CLOSE(p.input_xy_w[0], 0.31272f, 1e-5f);  // D65
 
-    set_input_gamut(&p, InputGamut::DciP3D60);
+    set_input_gamut(p, InputGamut::DciP3D60);
     // Same primaries as DciP3D65, different white (ACES D60).
     FL_CHECK_CLOSE(p.input_xy_r[0], 0.6800f, 1e-6f);
     FL_CHECK_CLOSE(p.input_xy_w[0], 0.32168f, 1e-5f);
@@ -388,17 +388,16 @@ FL_TEST_CASE("set_input_gamut: named gamuts populate canonical primaries") {
 FL_TEST_CASE("set_input_gamut: white override honored") {
     DiodeProfile p = kRgbwDefaultProfile;
     const float custom_white[2] = {0.34567f, 0.35850f};  // D50
-    set_input_gamut(&p, InputGamut::Rec709, custom_white);
+    set_input_gamut(p, InputGamut::Rec709, custom_white);
     FL_CHECK_CLOSE(p.input_xy_r[0], 0.6400f, 1e-6f);  // primaries: Rec709
     FL_CHECK_CLOSE(p.input_xy_w[0], 0.34567f, 1e-6f); // white: override
     FL_CHECK_CLOSE(p.input_xy_w[1], 0.35850f, 1e-6f);
 }
 
 
-FL_TEST_CASE("set_input_gamut: null profile is a no-op") {
-    // Defensive guard so caller code that passes a nullptr by mistake
-    // doesn't fault; consistent with set_rgbw_colorimetric_profile(nullptr)
-    // semantics.
+FL_TEST_CASE("set_input_gamut: compatibility pointer overload no-ops on null") {
+    // Legacy pointer-profile overloads keep the old null contract while new
+    // code uses the reference overload above.
     set_input_gamut(nullptr, InputGamut::Rec709);
     set_input_gamut(nullptr, InputGamut::Native);
     // No assertions — just verify the calls don't crash.
@@ -1189,7 +1188,7 @@ inline DiodeProfile native_profile() {
     // can just copy it. Explicit set_input_gamut(InputGamut::Native) makes
     // the contract obvious in the test source.
     DiodeProfile p = kRgbwDefaultProfile;
-    set_input_gamut(&p, InputGamut::Native);
+    set_input_gamut(p, InputGamut::Native);
     return p;
 }
 
@@ -1362,7 +1361,7 @@ FL_TEST_CASE("issue #2748: non-native input gamut bypasses topology guard") {
     // contract, sRGB pure blue (out of LED hull) would be passed through
     // verbatim and produce a black output once quantized.
     DiodeProfile p = kRgbwDefaultProfile;
-    set_input_gamut(&p, InputGamut::Rec709);  // input != LED native
+    set_input_gamut(p, InputGamut::Rec709);  // input != LED native
     ProfileCache cache; fastled_mirror::build_cache(&p, &cache);
 
     float rgbw[4] = {0};
@@ -1455,20 +1454,20 @@ FL_TEST_CASE("issue #2748: public dispatch — boosted mode preserves native top
 
 FL_TEST_CASE("issue #2748: is_native_input_gamut helper agrees with profile flags") {
     DiodeProfile p = kRgbwDefaultProfile;
-    set_input_gamut(&p, InputGamut::Native);
+    set_input_gamut(p, InputGamut::Native);
     FL_CHECK(is_native_input_gamut(p));
 
-    set_input_gamut(&p, InputGamut::Rec709);
+    set_input_gamut(p, InputGamut::Rec709);
     FL_CHECK(!is_native_input_gamut(p));
 
-    set_input_gamut(&p, InputGamut::Rec2020);
+    set_input_gamut(p, InputGamut::Rec2020);
     FL_CHECK(!is_native_input_gamut(p));
 
-    set_input_gamut(&p, InputGamut::DciP3D65);
+    set_input_gamut(p, InputGamut::DciP3D65);
     FL_CHECK(!is_native_input_gamut(p));
 
     // Restore Native so subsequent tests in this TU see expected defaults.
-    set_input_gamut(&p, InputGamut::Native);
+    set_input_gamut(p, InputGamut::Native);
     FL_CHECK(is_native_input_gamut(p));
 }
 
@@ -1485,4 +1484,3 @@ FL_TEST_CASE("issue #2748: count_active_channels classification") {
     // Below LSB-eps — counted as inactive.
     FL_CHECK(count_active_channels(1.0e-6f, 1.0f, 1.0f) == 2);
 }
-


### PR DESCRIPTION
## Summary
- Add reference-first `set_input_gamut` / `FastLED.setInputGamut` overloads for required profile mutation.
- Keep legacy pointer overloads only as documented nullable compatibility wrappers.
- Replace the `white_xy[2]` API shape with fixed-extent `fl::span<const float, 2>` and shrink the array-param baseline.
- Update CodeRabbit and FastLED review guidance to flag mutable pointer parameters unless null is an intentional contract.

Closes #3234

## Tests
- `uv run python ci/tools/check_array_params.py --scope all --update-baseline`
- `uv run pytest ci/tools/test_check_array_params.py ci/lint_cpp/test_public_settings_pattern_checker.py -q`
- `bash test fl_gfx_rgbw_colorimetric`
- `uv run python ci/tools/check_array_params.py --scope all`
- `git diff --check`
- `bash lint`
- `bash test --cpp`