### PR TITLE
refactor(colorimetric): extract shared response layer (#3255 PR 1)

### DIFF
--- a/src/fl/gfx/_build.cpp.hpp
+++ b/src/fl/gfx/_build.cpp.hpp
@@ -5,6 +5,7 @@
 
 // begin current directory includes
 #include "fl/gfx/blur.cpp.hpp"
+#include "fl/gfx/colorimetric_response.cpp.hpp"
 #include "fl/gfx/colorutils.cpp.hpp"
 #include "fl/gfx/corkscrew.cpp.hpp"
 #include "fl/gfx/crgb_extra.cpp.hpp"

--- a/src/fl/gfx/colorimetric_response.cpp.hpp
+++ b/src/fl/gfx/colorimetric_response.cpp.hpp
@@ -1,0 +1,24 @@
+/// @file colorimetric_response.cpp.hpp
+/// Reserved for the heavy implementations of the shared colorimetric
+/// response layer (issue #3255).
+///
+/// PR 1 of #3255 only extracts the inline header helpers into
+/// `colorimetric_response.h`; no out-of-line definitions live here yet.
+/// PR 3 will land `solve_rgb_colorimetric(...)` and the per-pixel
+/// `apply_rgb_colorimetric_impl(...)` adapter behind the same gate that
+/// `rgbw_colorimetric.cpp.hpp` uses today, so the unity build picks the
+/// file up consistently.
+
+#include "fl/gfx/colorimetric_response.h"
+
+#if FASTLED_RGBW_COLORIMETRIC
+
+namespace fl {
+namespace colorimetric_response {
+
+// (Empty — implementations land in PR 3 of #3255.)
+
+} // namespace colorimetric_response
+} // namespace fl
+
+#endif  // FASTLED_RGBW_COLORIMETRIC

--- a/src/fl/gfx/colorimetric_response.h
+++ b/src/fl/gfx/colorimetric_response.h
@@ -1,0 +1,268 @@
+/// @file colorimetric_response.h
+/// Shared colorimetric primitives reusable by the RGBW and (future) RGB
+/// colorimetric paths (issue #3255).
+///
+/// This module is the topology-independent layer extracted from
+/// `rgbw_colorimetric.h`: small-matrix linear algebra, chromaticity
+/// conversions, the source-primary matrix construction, and the LUT
+/// quantization constants. None of these helpers know about W diodes,
+/// RGBW sub-gamuts, or the boosted / RGBCCT solver topology.
+///
+/// All helpers are header-inline — they appear in hot inner loops and the
+/// optimizer needs to fold them. Tests at
+/// `tests/fl/gfx/colorimetric_response.cpp` exercise them in isolation of
+/// the RGBW topology, complementing the RGBW-flavored coverage in
+/// `tests/fl/gfx/rgbw_colorimetric.cpp`.
+///
+/// Backward compatibility: the existing `fl::colorimetric_detail::`
+/// namespace re-exports every name from here via using-declarations, so
+/// callers reaching into `colorimetric_detail::xyY_to_XYZ(...)` etc. keep
+/// compiling unchanged. New code should reach `colorimetric_response::`
+/// directly.
+
+#pragma once
+
+#include "fl/math/math.h"
+#include "fl/stl/stdint.h"
+
+namespace fl {
+namespace colorimetric_response {
+
+// ===== Pure-math inline helpers ==============================================
+// Tight, leaf-level operations kept inline because:
+//   1. They're trivial bodies (≤ 25 lines).
+//   2. They appear in hot inner loops; inlining lets the optimizer fold them.
+//   3. Tests can validate them directly without a full library rebuild.
+
+// Krystek's approximation for blackbody chromaticity (good 1000K - 15000K).
+// Krystek's outputs are (u, v) in the CIE 1960 UCS; convert to xy via the
+// standard 1960->xy formulas. Reference: Krystek, "An algorithm to calculate
+// correlated color temperature", Color Research & Application, 1985.
+inline void cct_to_xy(int cct, float out[2]) FL_NOEXCEPT {
+    const float T = static_cast<float>(
+        (cct < 1500) ? 1500 : ((cct > 15000) ? 15000 : cct));
+    const float T2 = T * T;
+    const float u_num = 0.860117757f + 1.54118254e-4f * T + 1.28641212e-7f * T2;
+    const float u_den = 1.0f + 8.42420235e-4f * T + 7.08145163e-7f * T2;
+    const float v_num = 0.317398726f + 4.22806245e-5f * T + 4.20481691e-8f * T2;
+    const float v_den = 1.0f - 2.89741816e-5f * T + 1.61456053e-7f * T2;
+    const float u = u_num / u_den;
+    const float v = v_num / v_den;
+    const float den = 2.0f * u - 8.0f * v + 4.0f;
+    out[0] = 3.0f * u / den;
+    out[1] = 2.0f * v / den;
+}
+
+inline void xyY_to_XYZ(float x, float y, float Y, float out[3]) FL_NOEXCEPT {
+    if (y < 1e-12f) {
+        out[0] = out[1] = out[2] = 0.0f;
+        return;
+    }
+    const float inv_y = 1.0f / y;
+    out[0] = x * Y * inv_y;
+    out[1] = Y;
+    out[2] = (1.0f - x - y) * Y * inv_y;
+}
+
+inline bool invert3x3(const float in[3][3], float out[3][3]) FL_NOEXCEPT {
+    const float a = in[0][0], b = in[0][1], c = in[0][2];
+    const float d = in[1][0], e = in[1][1], f = in[1][2];
+    const float g = in[2][0], h = in[2][1], i = in[2][2];
+    const float det = a * (e * i - f * h) - b * (d * i - f * g) + c * (d * h - e * g);
+    if (fl::fabs(det) < 1e-20f) {
+        return false;
+    }
+    const float inv_det = 1.0f / det;
+    out[0][0] = (e * i - f * h) * inv_det;
+    out[0][1] = (c * h - b * i) * inv_det;
+    out[0][2] = (b * f - c * e) * inv_det;
+    out[1][0] = (f * g - d * i) * inv_det;
+    out[1][1] = (a * i - c * g) * inv_det;
+    out[1][2] = (c * d - a * f) * inv_det;
+    out[2][0] = (d * h - e * g) * inv_det;
+    out[2][1] = (b * g - a * h) * inv_det;
+    out[2][2] = (a * e - b * d) * inv_det;
+    return true;
+}
+
+inline void matvec3(const float M[3][3], const float v[3], float out[3]) FL_NOEXCEPT {
+    out[0] = M[0][0] * v[0] + M[0][1] * v[1] + M[0][2] * v[2];
+    out[1] = M[1][0] * v[0] + M[1][1] * v[1] + M[1][2] * v[2];
+    out[2] = M[2][0] * v[0] + M[2][1] * v[1] + M[2][2] * v[2];
+}
+
+inline bool barycentric_xy(const float t[2], const float A[2], const float B[2],
+                           const float C[2], float bary[3]) FL_NOEXCEPT {
+    const float v0x = B[0] - A[0], v0y = B[1] - A[1];
+    const float v1x = C[0] - A[0], v1y = C[1] - A[1];
+    const float v2x = t[0] - A[0], v2y = t[1] - A[1];
+    const float d00 = v0x * v0x + v0y * v0y;
+    const float d01 = v0x * v1x + v0y * v1y;
+    const float d11 = v1x * v1x + v1y * v1y;
+    const float d20 = v2x * v0x + v2y * v0y;
+    const float d21 = v2x * v1x + v2y * v1y;
+    const float den = d00 * d11 - d01 * d01;
+    if (fl::fabs(den) < 1e-20f) {
+        return false;
+    }
+    const float inv_den = 1.0f / den;
+    const float u = (d11 * d20 - d01 * d21) * inv_den;
+    const float v = (d00 * d21 - d01 * d20) * inv_den;
+    bary[0] = 1.0f - u - v;
+    bary[1] = u;
+    bary[2] = v;
+    return true;
+}
+
+inline u8 quantize_u8(float v) FL_NOEXCEPT {
+    const float scaled = v * 255.0f + 0.5f;
+    if (scaled <= 0.0f) return 0;
+    if (scaled >= 255.0f) return 255;
+    return static_cast<u8>(scaled);
+}
+
+// Standard CIE primary-matrix construction (#2705). Given source primary
+// chromaticities xy_r/g/b and a source white chromaticity xy_w, build the
+// 3x3 matrix M such that M·[1,1,1]^T = xyY_to_XYZ(xy_w, 1.0). Columns are
+// per-channel scaled XYZ vectors of the primaries at Y=1, with scaling
+// chosen so the (1,1,1) input lands at source white in XYZ. This is the
+// classic linear-sRGB -> XYZ derivation generalized to arbitrary primaries.
+// Returns false if the primary matrix is singular (collinear chromaticities).
+inline bool build_source_matrix(const float xy_r[2], const float xy_g[2],
+                                const float xy_b[2], const float xy_w[2],
+                                float M_out[3][3]) FL_NOEXCEPT {
+    float xyz_R[3], xyz_G[3], xyz_B[3], xyz_W[3];
+    xyY_to_XYZ(xy_r[0], xy_r[1], 1.0f, xyz_R);
+    xyY_to_XYZ(xy_g[0], xy_g[1], 1.0f, xyz_G);
+    xyY_to_XYZ(xy_b[0], xy_b[1], 1.0f, xyz_B);
+    xyY_to_XYZ(xy_w[0], xy_w[1], 1.0f, xyz_W);
+
+    float P[3][3];
+    P[0][0] = xyz_R[0]; P[0][1] = xyz_G[0]; P[0][2] = xyz_B[0];
+    P[1][0] = xyz_R[1]; P[1][1] = xyz_G[1]; P[1][2] = xyz_B[1];
+    P[2][0] = xyz_R[2]; P[2][1] = xyz_G[2]; P[2][2] = xyz_B[2];
+
+    float P_inv[3][3];
+    if (!invert3x3(P, P_inv)) {
+        return false;
+    }
+    float k[3];
+    matvec3(P_inv, xyz_W, k);
+
+    M_out[0][0] = k[0] * xyz_R[0]; M_out[0][1] = k[1] * xyz_G[0]; M_out[0][2] = k[2] * xyz_B[0];
+    M_out[1][0] = k[0] * xyz_R[1]; M_out[1][1] = k[1] * xyz_G[1]; M_out[1][2] = k[2] * xyz_B[1];
+    M_out[2][0] = k[0] * xyz_R[2]; M_out[2][1] = k[1] * xyz_G[2]; M_out[2][2] = k[2] * xyz_B[2];
+    return true;
+}
+
+// Non-negative least squares for the 3×3 sub-system M·t = b with t ≥ 0
+// (#2708, gist §3). Projected-gradient form matching the reference
+// `_nnls_solve` fallback used when scipy is unavailable: 500 iterations at
+// step 0.01. Cheap (~50 µs scalar on a typical MCU at -O2; only invoked for
+// out-of-hull source targets, never on the in-hull fast path) and free of
+// dynamic allocation, which makes it safe to inline behind the colorimetric
+// solvers' rare-branch.
+inline void nnls3(const float M[3][3], const float b[3],   // ok array parameter
+                  float t_out[3], float* residual_out) FL_NOEXCEPT {
+    float t[3] = {0.0f, 0.0f, 0.0f};
+    constexpr float kStep = 0.01f;
+    constexpr int kIters = 500;
+    for (int it = 0; it < kIters; ++it) {
+        float r[3];
+        r[0] = M[0][0]*t[0] + M[0][1]*t[1] + M[0][2]*t[2] - b[0];
+        r[1] = M[1][0]*t[0] + M[1][1]*t[1] + M[1][2]*t[2] - b[1];
+        r[2] = M[2][0]*t[0] + M[2][1]*t[1] + M[2][2]*t[2] - b[2];
+        // grad = Mᵀ · r
+        float g[3];
+        g[0] = M[0][0]*r[0] + M[1][0]*r[1] + M[2][0]*r[2];
+        g[1] = M[0][1]*r[0] + M[1][1]*r[1] + M[2][1]*r[2];
+        g[2] = M[0][2]*r[0] + M[1][2]*r[1] + M[2][2]*r[2];
+        for (int j = 0; j < 3; ++j) {
+            float v = t[j] - kStep * g[j];
+            t[j] = v > 0.0f ? v : 0.0f;
+        }
+    }
+    if (residual_out != nullptr) {
+        float r[3];
+        r[0] = M[0][0]*t[0] + M[0][1]*t[1] + M[0][2]*t[2] - b[0];
+        r[1] = M[1][0]*t[0] + M[1][1]*t[1] + M[1][2]*t[2] - b[1];
+        r[2] = M[2][0]*t[0] + M[2][1]*t[1] + M[2][2]*t[2] - b[2];
+        *residual_out = fl::sqrt(r[0]*r[0] + r[1]*r[1] + r[2]*r[2]);
+    }
+    t_out[0] = t[0]; t_out[1] = t[1]; t_out[2] = t[2];
+}
+
+// ===== LUT quantization and interpolation constants =========================
+// Used by both the RGBW LUT (today) and any future RGB / RGBCCT LUT paths
+// extracted out of the topology-specific solver modules.
+
+// LUT cell quantization scale (value in [-8, +8) maps to i16 via *kLutQ).
+constexpr i16 kLutQ = 4096;
+
+// Storage stride per grid point. Bilinear LUTs store 4 (rgbw) values; Hermite
+// LUTs additionally store ∂/∂t_x and ∂/∂t_y per channel (in cell-parameter
+// units), enabling bicubic Hermite interpolation that reaches comparable
+// accuracy at ~half the grid edge length — ~25 % of the memory at ~ the
+// same error vs. bilinear. The grid step is uniform so derivatives are
+// naturally expressed in cell-parameter units (t ∈ [0, 1] per cell).
+constexpr int kLutStrideBilinear = 4;
+constexpr int kLutStrideHermite = 12;
+
+enum class LutInterp : u8 {
+    Bilinear = 0,
+    Hermite = 1,
+};
+
+// Cubic Hermite basis on [0, 1]. Output layout: { h00, h01, h10, h11 } where
+//   h00(t) = 2t³ - 3t² + 1   value at t=0
+//   h01(t) = -2t³ + 3t²      value at t=1
+//   h10(t) = t³ - 2t² + t    derivative at t=0
+//   h11(t) = t³ - t²         derivative at t=1
+// Lifted into a header inline so `lookup_lut` and the test suite consume
+// exactly the same evaluator (CodeRabbit #2707: tests that redefine basis
+// locally cannot catch regressions in the production code).
+inline void hermite_basis(float t, float out[4]) FL_NOEXCEPT {
+    const float t2 = t * t;
+    const float t3 = t2 * t;
+    out[0] = 2.0f * t3 - 3.0f * t2 + 1.0f;
+    out[1] = -2.0f * t3 + 3.0f * t2;
+    out[2] = t3 - 2.0f * t2 + t;
+    out[3] = t3 - t2;
+}
+
+inline i16 quantize_lut_cell(float v) FL_NOEXCEPT {
+    const float scaled = v * static_cast<float>(kLutQ) + 0.5f;
+    if (scaled <= -32768.0f) return -32768;
+    if (scaled >= 32767.0f) return 32767;
+    return static_cast<i16>(scaled);
+}
+
+// ===== RGB-only emitter profile =============================================
+// Reserved for the PR 3 RGB colorimetric path (issue #3255). The struct is
+// declared here so callers and tests can reference it from PR 1 onwards;
+// the matching `solve_rgb_colorimetric(...)` lands in PR 3.
+//
+// Mirrors the RGB subset of the existing RGBW `DiodeProfile` (which carries
+// xy_w / lum_w / nominal_cct on top of these fields). An RGB strip has no
+// W diode, so those fields are intentionally absent — see #3255 → Decision 3
+// for the type-separation rationale.
+struct EmitterProfile {
+    float xy_r[2];      // R diode chromaticity (CIE 1931 xy)
+    float xy_g[2];      // G diode chromaticity
+    float xy_b[2];      // B diode chromaticity
+    float lum_r;        // R diode peak luminance (relative to source white = 1.0)
+    float lum_g;
+    float lum_b;
+
+    // Source / input color space (#2705 semantics). When `input_xy_w[1]` is
+    // 0 (the default for value-initialized profiles), solvers fall back to
+    // the legacy interpretation in which the input RGB triple IS the
+    // device-emitter drive coordinates — preserved for backward compat.
+    float input_xy_r[2];  // source R primary chromaticity (default: native LED R)
+    float input_xy_g[2];  // source G primary chromaticity (default: native LED G)
+    float input_xy_b[2];  // source B primary chromaticity (default: native LED B)
+    float input_xy_w[2];  // source white chromaticity (default D65)
+};
+
+} // namespace colorimetric_response
+} // namespace fl

--- a/src/fl/gfx/rgbw_colorimetric.h
+++ b/src/fl/gfx/rgbw_colorimetric.h
@@ -2,10 +2,18 @@
 /// Chromaticity-aware RGBW solvers — strict sub-gamut + wx_lp_legacy white
 /// extraction + boosted overdrive + LUT + RGBCCT (issue #2545).
 ///
-/// This header carries the public/internal declarations and the small inline
-/// math helpers used by the implementation.  The heavier solver, LUT, and
-/// RGBCCT code lives in rgbw_colorimetric.cpp.hpp behind the
-/// FASTLED_RGBW_COLORIMETRIC compile gate.
+/// This header carries the public/internal declarations for the RGBW-specific
+/// solver topology. The shared math primitives (CCT-to-xy, xy/XYZ conversion,
+/// 3x3 invert, NNLS, Hermite basis, LUT quantization constants) now live in
+/// `fl/gfx/colorimetric_response.h` and are re-exported into the
+/// `fl::colorimetric_detail::` namespace below so existing callers
+/// (`rgbw.cpp.hpp`, `rgbww.cpp.hpp`, tests using
+/// `using namespace fl::colorimetric_detail`) keep compiling unchanged.
+/// See #3255 for the extraction plan.
+///
+/// The heavier solver, LUT, and RGBCCT code lives in
+/// rgbw_colorimetric.cpp.hpp behind the FASTLED_RGBW_COLORIMETRIC compile
+/// gate.
 ///
 /// Solver model in one paragraph:
 ///   * Input RGB is treated as linear-light source-gamut coordinates.
@@ -28,6 +36,7 @@
 
 #pragma once
 
+#include "fl/gfx/colorimetric_response.h"
 #include "fl/gfx/rgbw.h"
 #include "fl/math/math.h"
 #include "fl/stl/stdint.h"
@@ -36,132 +45,37 @@
 namespace fl {
 namespace colorimetric_detail {
 
-// ===== Pure-math inline helpers ==============================================
-// Tight, leaf-level operations kept inline because:
-//   1. They're trivial bodies (≤ 25 lines).
-//   2. They appear in hot inner loops; inlining lets the optimizer fold them.
-//   3. Tests can validate them directly without a full library rebuild.
+// ===== Shared primitives — re-exported from colorimetric_response ===========
+//
+// The pure-math leaf helpers, the LUT quantization constants, and the
+// `LutInterp` enum now live in `colorimetric_response::` (#3255). They are
+// re-exported here so callers that reach into `colorimetric_detail::name`
+// (and tests using `using namespace fl::colorimetric_detail`) keep
+// compiling without churn. New code should prefer the
+// `colorimetric_response::` namespace directly.
 
-// Krystek's approximation for blackbody chromaticity (good 1000K - 15000K).
-// Krystek's outputs are (u, v) in the CIE 1960 UCS; convert to xy via the
-// standard 1960->xy formulas. Reference: Krystek, "An algorithm to calculate
-// correlated color temperature", Color Research & Application, 1985.
-inline void cct_to_xy(int cct, float out[2]) FL_NOEXCEPT {
-    const float T = static_cast<float>(
-        (cct < 1500) ? 1500 : ((cct > 15000) ? 15000 : cct));
-    const float T2 = T * T;
-    const float u_num = 0.860117757f + 1.54118254e-4f * T + 1.28641212e-7f * T2;
-    const float u_den = 1.0f + 8.42420235e-4f * T + 7.08145163e-7f * T2;
-    const float v_num = 0.317398726f + 4.22806245e-5f * T + 4.20481691e-8f * T2;
-    const float v_den = 1.0f - 2.89741816e-5f * T + 1.61456053e-7f * T2;
-    const float u = u_num / u_den;
-    const float v = v_num / v_den;
-    const float den = 2.0f * u - 8.0f * v + 4.0f;
-    out[0] = 3.0f * u / den;
-    out[1] = 2.0f * v / den;
-}
+using colorimetric_response::cct_to_xy;            // ok bare using
+using colorimetric_response::xyY_to_XYZ;           // ok bare using
+using colorimetric_response::invert3x3;            // ok bare using
+using colorimetric_response::matvec3;              // ok bare using
+using colorimetric_response::barycentric_xy;       // ok bare using
+using colorimetric_response::build_source_matrix;  // ok bare using
+using colorimetric_response::quantize_u8;          // ok bare using
+using colorimetric_response::quantize_lut_cell;    // ok bare using
+using colorimetric_response::nnls3;                // ok bare using
+using colorimetric_response::hermite_basis;        // ok bare using
+using colorimetric_response::LutInterp;            // ok bare using
 
-inline void xyY_to_XYZ(float x, float y, float Y, float out[3]) FL_NOEXCEPT {
-    if (y < 1e-12f) {
-        out[0] = out[1] = out[2] = 0.0f;
-        return;
-    }
-    const float inv_y = 1.0f / y;
-    out[0] = x * Y * inv_y;
-    out[1] = Y;
-    out[2] = (1.0f - x - y) * Y * inv_y;
-}
+// `constexpr` variables cannot be re-exported via using-declarations in a
+// way that preserves constant-expression status across all consumers, so
+// shadow them here as initialized constexpr aliases pointing at the
+// shared definitions. The values come from one place — the shared header —
+// and any future change there flows through automatically.
+constexpr i16 kLutQ = colorimetric_response::kLutQ;
+constexpr int kLutStrideBilinear = colorimetric_response::kLutStrideBilinear;
+constexpr int kLutStrideHermite = colorimetric_response::kLutStrideHermite;
 
-inline bool invert3x3(const float in[3][3], float out[3][3]) FL_NOEXCEPT {
-    const float a = in[0][0], b = in[0][1], c = in[0][2];
-    const float d = in[1][0], e = in[1][1], f = in[1][2];
-    const float g = in[2][0], h = in[2][1], i = in[2][2];
-    const float det = a * (e * i - f * h) - b * (d * i - f * g) + c * (d * h - e * g);
-    if (fl::fabs(det) < 1e-20f) {
-        return false;
-    }
-    const float inv_det = 1.0f / det;
-    out[0][0] = (e * i - f * h) * inv_det;
-    out[0][1] = (c * h - b * i) * inv_det;
-    out[0][2] = (b * f - c * e) * inv_det;
-    out[1][0] = (f * g - d * i) * inv_det;
-    out[1][1] = (a * i - c * g) * inv_det;
-    out[1][2] = (c * d - a * f) * inv_det;
-    out[2][0] = (d * h - e * g) * inv_det;
-    out[2][1] = (b * g - a * h) * inv_det;
-    out[2][2] = (a * e - b * d) * inv_det;
-    return true;
-}
-
-inline void matvec3(const float M[3][3], const float v[3], float out[3]) FL_NOEXCEPT {
-    out[0] = M[0][0] * v[0] + M[0][1] * v[1] + M[0][2] * v[2];
-    out[1] = M[1][0] * v[0] + M[1][1] * v[1] + M[1][2] * v[2];
-    out[2] = M[2][0] * v[0] + M[2][1] * v[1] + M[2][2] * v[2];
-}
-
-inline bool barycentric_xy(const float t[2], const float A[2], const float B[2],
-                           const float C[2], float bary[3]) FL_NOEXCEPT {
-    const float v0x = B[0] - A[0], v0y = B[1] - A[1];
-    const float v1x = C[0] - A[0], v1y = C[1] - A[1];
-    const float v2x = t[0] - A[0], v2y = t[1] - A[1];
-    const float d00 = v0x * v0x + v0y * v0y;
-    const float d01 = v0x * v1x + v0y * v1y;
-    const float d11 = v1x * v1x + v1y * v1y;
-    const float d20 = v2x * v0x + v2y * v0y;
-    const float d21 = v2x * v1x + v2y * v1y;
-    const float den = d00 * d11 - d01 * d01;
-    if (fl::fabs(den) < 1e-20f) {
-        return false;
-    }
-    const float inv_den = 1.0f / den;
-    const float u = (d11 * d20 - d01 * d21) * inv_den;
-    const float v = (d00 * d21 - d01 * d20) * inv_den;
-    bary[0] = 1.0f - u - v;
-    bary[1] = u;
-    bary[2] = v;
-    return true;
-}
-
-inline u8 quantize_u8(float v) FL_NOEXCEPT {
-    const float scaled = v * 255.0f + 0.5f;
-    if (scaled <= 0.0f) return 0;
-    if (scaled >= 255.0f) return 255;
-    return static_cast<u8>(scaled);
-}
-
-// Standard CIE primary-matrix construction (#2705). Given source primary
-// chromaticities xy_r/g/b and a source white chromaticity xy_w, build the
-// 3x3 matrix M such that M·[1,1,1]^T = xyY_to_XYZ(xy_w, 1.0). Columns are
-// per-channel scaled XYZ vectors of the primaries at Y=1, with scaling
-// chosen so the (1,1,1) input lands at source white in XYZ. This is the
-// classic linear-sRGB -> XYZ derivation generalized to arbitrary primaries.
-// Returns false if the primary matrix is singular (collinear chromaticities).
-inline bool build_source_matrix(const float xy_r[2], const float xy_g[2],
-                                const float xy_b[2], const float xy_w[2],
-                                float M_out[3][3]) FL_NOEXCEPT {
-    float xyz_R[3], xyz_G[3], xyz_B[3], xyz_W[3];
-    xyY_to_XYZ(xy_r[0], xy_r[1], 1.0f, xyz_R);
-    xyY_to_XYZ(xy_g[0], xy_g[1], 1.0f, xyz_G);
-    xyY_to_XYZ(xy_b[0], xy_b[1], 1.0f, xyz_B);
-    xyY_to_XYZ(xy_w[0], xy_w[1], 1.0f, xyz_W);
-
-    float P[3][3];
-    P[0][0] = xyz_R[0]; P[0][1] = xyz_G[0]; P[0][2] = xyz_B[0];
-    P[1][0] = xyz_R[1]; P[1][1] = xyz_G[1]; P[1][2] = xyz_B[1];
-    P[2][0] = xyz_R[2]; P[2][1] = xyz_G[2]; P[2][2] = xyz_B[2];
-
-    float P_inv[3][3];
-    if (!invert3x3(P, P_inv)) {
-        return false;
-    }
-    float k[3];
-    matvec3(P_inv, xyz_W, k);
-
-    M_out[0][0] = k[0] * xyz_R[0]; M_out[0][1] = k[1] * xyz_G[0]; M_out[0][2] = k[2] * xyz_B[0];
-    M_out[1][0] = k[0] * xyz_R[1]; M_out[1][1] = k[1] * xyz_G[1]; M_out[1][2] = k[2] * xyz_B[1];
-    M_out[2][0] = k[0] * xyz_R[2]; M_out[2][1] = k[1] * xyz_G[2]; M_out[2][2] = k[2] * xyz_B[2];
-    return true;
-}
+// ===== RGBW-specific topology helpers =======================================
 
 // Native-gamut detection (#2748). Returns true when the source primaries
 // of `p` (input_xy_r/g/b) match the LED's measured primaries (xy_r/g/b)
@@ -216,43 +130,6 @@ inline int count_active_channels(float s_r, float s_g, float s_b) FL_NOEXCEPT {
     return n;
 }
 
-// Non-negative least squares for the 3×3 sub-system M·t = b with t ≥ 0
-// (#2708, gist §3). Projected-gradient form matching the reference
-// `_nnls_solve` fallback used when scipy is unavailable: 500 iterations at
-// step 0.01. Cheap (~50 µs scalar on a typical MCU at -O2; only invoked for
-// out-of-hull source targets, never on the in-hull fast path) and free of
-// dynamic allocation, which makes it safe to inline behind the colorimetric
-// solvers' rare-branch.
-inline void nnls3(const float M[3][3], const float b[3],
-                  float t_out[3], float* residual_out) FL_NOEXCEPT {
-    float t[3] = {0.0f, 0.0f, 0.0f};
-    constexpr float kStep = 0.01f;
-    constexpr int kIters = 500;
-    for (int it = 0; it < kIters; ++it) {
-        float r[3];
-        r[0] = M[0][0]*t[0] + M[0][1]*t[1] + M[0][2]*t[2] - b[0];
-        r[1] = M[1][0]*t[0] + M[1][1]*t[1] + M[1][2]*t[2] - b[1];
-        r[2] = M[2][0]*t[0] + M[2][1]*t[1] + M[2][2]*t[2] - b[2];
-        // grad = Mᵀ · r
-        float g[3];
-        g[0] = M[0][0]*r[0] + M[1][0]*r[1] + M[2][0]*r[2];
-        g[1] = M[0][1]*r[0] + M[1][1]*r[1] + M[2][1]*r[2];
-        g[2] = M[0][2]*r[0] + M[1][2]*r[1] + M[2][2]*r[2];
-        for (int j = 0; j < 3; ++j) {
-            float v = t[j] - kStep * g[j];
-            t[j] = v > 0.0f ? v : 0.0f;
-        }
-    }
-    if (residual_out != nullptr) {
-        float r[3];
-        r[0] = M[0][0]*t[0] + M[0][1]*t[1] + M[0][2]*t[2] - b[0];
-        r[1] = M[1][0]*t[0] + M[1][1]*t[1] + M[1][2]*t[2] - b[1];
-        r[2] = M[2][0]*t[0] + M[2][1]*t[1] + M[2][2]*t[2] - b[2];
-        *residual_out = fl::sqrt(r[0]*r[0] + r[1]*r[1] + r[2]*r[2]);
-    }
-    t_out[0] = t[0]; t_out[1] = t[1]; t_out[2] = t[2];
-}
-
 // ===== Types =================================================================
 
 // Precomputed per-profile data: emitter XYZ columns + the four matrix inverses
@@ -291,40 +168,6 @@ struct ProfileCache {
     bool has_source_space;
 };
 
-// LUT cell quantization scale (value in [-8, +8) maps to i16 via *kLutQ).
-constexpr i16 kLutQ = 4096;
-
-// Storage stride per grid point. Bilinear LUTs store 4 (rgbw) values; Hermite
-// LUTs additionally store ∂/∂t_x and ∂/∂t_y per channel (in cell-parameter
-// units), enabling bicubic Hermite interpolation that reaches comparable
-// accuracy at ~half the grid edge length — ~25 % of the memory at ~ the
-// same error vs. bilinear. The grid step is uniform so derivatives are
-// naturally expressed in cell-parameter units (t ∈ [0, 1] per cell).
-constexpr int kLutStrideBilinear = 4;
-constexpr int kLutStrideHermite = 12;
-
-enum class LutInterp : u8 {
-    Bilinear = 0,
-    Hermite = 1,
-};
-
-// Cubic Hermite basis on [0, 1]. Output layout: { h00, h01, h10, h11 } where
-//   h00(t) = 2t³ - 3t² + 1   value at t=0
-//   h01(t) = -2t³ + 3t²      value at t=1
-//   h10(t) = t³ - 2t² + t    derivative at t=0
-//   h11(t) = t³ - t²         derivative at t=1
-// Lifted into a header inline so `lookup_lut` and the test suite consume
-// exactly the same evaluator (CodeRabbit #2707: tests that redefine basis
-// locally cannot catch regressions in the production code).
-inline void hermite_basis(float t, float out[4]) FL_NOEXCEPT {
-    const float t2 = t * t;
-    const float t3 = t2 * t;
-    out[0] = 2.0f * t3 - 3.0f * t2 + 1.0f;
-    out[1] = -2.0f * t3 + 3.0f * t2;
-    out[2] = t3 - 2.0f * t2 + t;
-    out[3] = t3 - t2;
-}
-
 // Owns its cell storage via fl::unique_ptr. Obtain via `build_lut(...)`,
 // which atomically allocates + populates. Lookup code can rely on
 // .cells.get() being non-null for the table's lifetime.
@@ -341,13 +184,6 @@ struct RgbcctProfile {
     DiodeProfile warm_path;  // R, G, B, W=warm — typical xy_w ≈ 3000K
     DiodeProfile cool_path;  // R, G, B, W=cool — typical xy_w ≈ 6500K
 };
-
-inline i16 quantize_lut_cell(float v) FL_NOEXCEPT {
-    const float scaled = v * static_cast<float>(kLutQ) + 0.5f;
-    if (scaled <= -32768.0f) return -32768;
-    if (scaled >= 32767.0f) return 32767;
-    return static_cast<i16>(scaled);
-}
 
 // Convenience: derive eta from a target CCT relative to the warm/cool
 // reference CCTs. Linear interpolation in CCT space, clamped to [0, 1].

--- a/tests/fl/gfx/colorimetric_response.cpp
+++ b/tests/fl/gfx/colorimetric_response.cpp
@@ -58,7 +58,7 @@ FL_TEST_CASE("invert3x3: M * M^-1 == I on a non-trivial matrix") {
     float Minv[3][3];
     FL_CHECK(invert3x3(M, Minv));
 
-    // P = M * Minv — should be identity within float tolerance.
+    // P = M * Minv -- should be identity within float tolerance.
     float P[3][3] = {{0}};
     for (int r = 0; r < 3; ++r) {
         for (int c = 0; c < 3; ++c) {
@@ -77,7 +77,7 @@ FL_TEST_CASE("invert3x3: M * M^-1 == I on a non-trivial matrix") {
 
 
 FL_TEST_CASE("invert3x3: singular matrix returns false") {
-    // Two identical rows — determinant is zero.
+    // Two identical rows -- determinant is zero.
     const float singular[3][3] = {
         {1.0f, 2.0f, 3.0f},
         {1.0f, 2.0f, 3.0f},
@@ -163,7 +163,7 @@ FL_TEST_CASE("quantize_u8: rounding + saturation") {
 }
 
 
-FL_TEST_CASE("build_source_matrix: Rec.709 + D65 reproduces published sRGB → XYZ") {
+FL_TEST_CASE("build_source_matrix: Rec.709 + D65 reproduces published sRGB -> XYZ") {
     // Rec.709 / sRGB primary chromaticities + D65 white.
     const float xy_r[2] = {0.640f, 0.330f};
     const float xy_g[2] = {0.300f, 0.600f};
@@ -172,7 +172,7 @@ FL_TEST_CASE("build_source_matrix: Rec.709 + D65 reproduces published sRGB → X
     float M[3][3];
     FL_CHECK(build_source_matrix(xy_r, xy_g, xy_b, xy_w, M));
 
-    // M · [1, 1, 1] must land at D65 in XYZ-at-Y=1.
+    // M * [1, 1, 1] must land at D65 in XYZ-at-Y=1.
     const float one[3] = {1.0f, 1.0f, 1.0f};
     float white_xyz[3];
     matvec3(M, one, white_xyz);
@@ -183,7 +183,7 @@ FL_TEST_CASE("build_source_matrix: Rec.709 + D65 reproduces published sRGB → X
     FL_CHECK_CLOSE(white_xyz[1], d65_xyz[1], 1e-4f);
     FL_CHECK_CLOSE(white_xyz[2], d65_xyz[2], 1e-4f);
 
-    // Compare against the published linear sRGB → XYZ D65 matrix (Bruce
+    // Compare against the published linear sRGB -> XYZ D65 matrix (Bruce
     // Lindbloom). Loose tolerance because Lindbloom's published constants
     // use rounded primaries; the construction is exact from the inputs.
     FL_CHECK_CLOSE(M[0][0], 0.4124f, 5e-3f);
@@ -193,7 +193,7 @@ FL_TEST_CASE("build_source_matrix: Rec.709 + D65 reproduces published sRGB → X
 
 
 FL_TEST_CASE("build_source_matrix: singular primaries return false") {
-    // Three identical primary chromaticities — all columns of the primary
+    // Three identical primary chromaticities -- all columns of the primary
     // matrix collapse to one vector, det is exactly zero in float
     // arithmetic, so invert3x3() bails and build_source_matrix() reports
     // failure. Near-collinear but distinct primaries can still pass float
@@ -206,9 +206,9 @@ FL_TEST_CASE("build_source_matrix: singular primaries return false") {
 
 
 FL_TEST_CASE("nnls3: identity system trivial recovery") {
-    // M = I, b = (1, 2, 3) → t ≈ (1, 2, 3), residual ≈ 0.
-    // Tolerance reflects the documented solver shape — 500 iterations at
-    // step 0.01 has geometric convergence 0.99^500 ≈ 0.66 %, so the gap
+    // M = I, b = (1, 2, 3) -> t ~= (1, 2, 3), residual ~= 0.
+    // Tolerance reflects the documented solver shape -- 500 iterations at
+    // step 0.01 has geometric convergence 0.99^500 ~= 0.66 %, so the gap
     // for target 3 is ~0.02. Use a comfortable 3 % bound.
     const float M[3][3] = {{1, 0, 0}, {0, 1, 0}, {0, 0, 1}};
     const float b[3] = {1.0f, 2.0f, 3.0f};
@@ -263,7 +263,7 @@ FL_TEST_CASE("hermite_basis: node values at t = 0, 0.5, 1") {
 
 
 FL_TEST_CASE("hermite_basis: partition-of-unity at every node") {
-    // h00(t) + h01(t) must equal 1 for ALL t — they're the value basis.
+    // h00(t) + h01(t) must equal 1 for ALL t -- they're the value basis.
     for (int i = 0; i <= 10; ++i) {
         const float t = static_cast<float>(i) / 10.0f;
         float b[4];
@@ -274,8 +274,8 @@ FL_TEST_CASE("hermite_basis: partition-of-unity at every node") {
 
 
 FL_TEST_CASE("quantize_lut_cell: round-trip via kLutQ") {
-    // value v → i16(v * kLutQ + 0.5), then dequantize via i16 * (1/kLutQ).
-    // Round-trip error ≤ 0.5 / kLutQ ≈ 1.2e-4.
+    // value v -> i16(v * kLutQ + 0.5), then dequantize via i16 * (1/kLutQ).
+    // Round-trip error <= 0.5 / kLutQ ~= 1.2e-4.
     const float v_in = 0.7531f;
     const i16 q = quantize_lut_cell(v_in);
     const float v_out = static_cast<float>(q) / static_cast<float>(kLutQ);

--- a/tests/fl/gfx/colorimetric_response.cpp
+++ b/tests/fl/gfx/colorimetric_response.cpp
@@ -1,0 +1,309 @@
+// ok cpp include
+// Tests for the shared colorimetric_response math primitives (issue #3255).
+//
+// These exercise the helpers in isolation of the RGBW solver topology, so a
+// future RGB-only colorimetric path (PR 3 of #3255) and the existing RGBW
+// path share the same coverage of the underlying primitives. The
+// rgbw_colorimetric.cpp test suite covers them indirectly via the RGBW
+// solvers; here we hit them directly through the canonical
+// `fl::colorimetric_response::` namespace.
+
+#include "test.h"
+
+#include "fl/gfx/colorimetric_response.h"
+#include "fl/math/math.h"
+
+using namespace fl;
+using namespace fl::colorimetric_response;
+
+
+FL_TEST_CASE("xyY_to_XYZ: round trip vs. direct math") {
+    // Build XYZ from (x=0.5, y=0.3, Y=1.0), then verify the relationships
+    //   X = x * Y / y
+    //   Z = (1 - x - y) * Y / y
+    float xyz[3];
+    xyY_to_XYZ(0.5f, 0.3f, 1.0f, xyz);
+    FL_CHECK_CLOSE(xyz[0], 0.5f / 0.3f, 1e-5f);
+    FL_CHECK_CLOSE(xyz[1], 1.0f, 1e-5f);
+    FL_CHECK_CLOSE(xyz[2], (1.0f - 0.5f - 0.3f) / 0.3f, 1e-5f);
+}
+
+
+FL_TEST_CASE("xyY_to_XYZ: degenerate y returns zero") {
+    float xyz[3] = {99.0f, 99.0f, 99.0f};
+    xyY_to_XYZ(0.5f, 0.0f, 1.0f, xyz);
+    FL_CHECK_CLOSE(xyz[0], 0.0f, 1e-9f);
+    FL_CHECK_CLOSE(xyz[1], 0.0f, 1e-9f);
+    FL_CHECK_CLOSE(xyz[2], 0.0f, 1e-9f);
+}
+
+
+FL_TEST_CASE("invert3x3: identity") {
+    const float I[3][3] = {{1, 0, 0}, {0, 1, 0}, {0, 0, 1}};
+    float Iinv[3][3];
+    FL_CHECK(invert3x3(I, Iinv));
+    for (int r = 0; r < 3; ++r) {
+        for (int c = 0; c < 3; ++c) {
+            FL_CHECK_CLOSE(Iinv[r][c], I[r][c], 1e-6f);
+        }
+    }
+}
+
+
+FL_TEST_CASE("invert3x3: M * M^-1 == I on a non-trivial matrix") {
+    const float M[3][3] = {
+        {1.0f, 2.0f, 3.0f},
+        {0.0f, 1.0f, 4.0f},
+        {5.0f, 6.0f, 0.0f}};
+    float Minv[3][3];
+    FL_CHECK(invert3x3(M, Minv));
+
+    // P = M * Minv — should be identity within float tolerance.
+    float P[3][3] = {{0}};
+    for (int r = 0; r < 3; ++r) {
+        for (int c = 0; c < 3; ++c) {
+            for (int k = 0; k < 3; ++k) {
+                P[r][c] += M[r][k] * Minv[k][c];
+            }
+        }
+    }
+    for (int r = 0; r < 3; ++r) {
+        for (int c = 0; c < 3; ++c) {
+            const float expected = (r == c) ? 1.0f : 0.0f;
+            FL_CHECK_CLOSE(P[r][c], expected, 1e-4f);
+        }
+    }
+}
+
+
+FL_TEST_CASE("invert3x3: singular matrix returns false") {
+    // Two identical rows — determinant is zero.
+    const float singular[3][3] = {
+        {1.0f, 2.0f, 3.0f},
+        {1.0f, 2.0f, 3.0f},
+        {4.0f, 5.0f, 6.0f}};
+    float out[3][3];
+    FL_CHECK(!invert3x3(singular, out));
+}
+
+
+FL_TEST_CASE("matvec3: hand-computed product") {
+    const float M[3][3] = {{1, 2, 3}, {4, 5, 6}, {7, 8, 9}};
+    const float v[3] = {1.0f, 0.0f, -1.0f};
+    float out[3];
+    matvec3(M, v, out);
+    // [1*1 + 2*0 + 3*(-1), 4*1 + 5*0 + 6*(-1), 7*1 + 8*0 + 9*(-1)]
+    //  = [-2, -2, -2]
+    FL_CHECK_CLOSE(out[0], -2.0f, 1e-6f);
+    FL_CHECK_CLOSE(out[1], -2.0f, 1e-6f);
+    FL_CHECK_CLOSE(out[2], -2.0f, 1e-6f);
+}
+
+
+FL_TEST_CASE("barycentric_xy: inside/outside classification") {
+    const float A[2] = {0.0f, 0.0f};
+    const float B[2] = {1.0f, 0.0f};
+    const float C[2] = {0.0f, 1.0f};
+
+    const float centroid[2] = {1.0f / 3.0f, 1.0f / 3.0f};
+    float bary[3];
+    FL_CHECK(barycentric_xy(centroid, A, B, C, bary));
+    FL_CHECK(bary[0] >= 0.0f);
+    FL_CHECK(bary[1] >= 0.0f);
+    FL_CHECK(bary[2] >= 0.0f);
+    FL_CHECK_CLOSE(bary[0] + bary[1] + bary[2], 1.0f, 1e-5f);
+
+    const float outside[2] = {2.0f, 2.0f};
+    FL_CHECK(barycentric_xy(outside, A, B, C, bary));
+    FL_CHECK(bary[0] < 0.0f);
+}
+
+
+FL_TEST_CASE("cct_to_xy: known Planckian-locus points") {
+    // Krystek's algorithm returns Planckian (blackbody) chromaticities.
+    // Reference values from the Planckian locus tables (loose tolerance
+    // for single-precision drift).
+    float xy[2];
+
+    cct_to_xy(6500, xy);
+    FL_CHECK_CLOSE(xy[0], 0.3135f, 0.005f);
+    FL_CHECK_CLOSE(xy[1], 0.3237f, 0.005f);
+
+    cct_to_xy(2700, xy);
+    FL_CHECK_CLOSE(xy[0], 0.4600f, 0.005f);
+    FL_CHECK_CLOSE(xy[1], 0.4107f, 0.005f);
+
+    cct_to_xy(4000, xy);
+    FL_CHECK_CLOSE(xy[0], 0.3805f, 0.005f);
+    FL_CHECK_CLOSE(xy[1], 0.3768f, 0.005f);
+}
+
+
+FL_TEST_CASE("cct_to_xy: clamps out-of-range CCTs") {
+    float xy_low[2], xy_clamp_low[2];
+    cct_to_xy(1500, xy_low);
+    cct_to_xy(500, xy_clamp_low);
+    FL_CHECK_CLOSE(xy_low[0], xy_clamp_low[0], 1e-5f);
+    FL_CHECK_CLOSE(xy_low[1], xy_clamp_low[1], 1e-5f);
+
+    float xy_high[2], xy_clamp_high[2];
+    cct_to_xy(15000, xy_high);
+    cct_to_xy(25000, xy_clamp_high);
+    FL_CHECK_CLOSE(xy_high[0], xy_clamp_high[0], 1e-5f);
+    FL_CHECK_CLOSE(xy_high[1], xy_clamp_high[1], 1e-5f);
+}
+
+
+FL_TEST_CASE("quantize_u8: rounding + saturation") {
+    FL_CHECK(quantize_u8(-1.0f) == 0);
+    FL_CHECK(quantize_u8(0.0f) == 0);
+    FL_CHECK(quantize_u8(1.0f) == 255);
+    FL_CHECK(quantize_u8(2.0f) == 255);
+    FL_CHECK(quantize_u8(0.5f) == 128);
+}
+
+
+FL_TEST_CASE("build_source_matrix: Rec.709 + D65 reproduces published sRGB → XYZ") {
+    // Rec.709 / sRGB primary chromaticities + D65 white.
+    const float xy_r[2] = {0.640f, 0.330f};
+    const float xy_g[2] = {0.300f, 0.600f};
+    const float xy_b[2] = {0.150f, 0.060f};
+    const float xy_w[2] = {0.3127f, 0.3290f};
+    float M[3][3];
+    FL_CHECK(build_source_matrix(xy_r, xy_g, xy_b, xy_w, M));
+
+    // M · [1, 1, 1] must land at D65 in XYZ-at-Y=1.
+    const float one[3] = {1.0f, 1.0f, 1.0f};
+    float white_xyz[3];
+    matvec3(M, one, white_xyz);
+
+    float d65_xyz[3];
+    xyY_to_XYZ(xy_w[0], xy_w[1], 1.0f, d65_xyz);
+    FL_CHECK_CLOSE(white_xyz[0], d65_xyz[0], 1e-4f);
+    FL_CHECK_CLOSE(white_xyz[1], d65_xyz[1], 1e-4f);
+    FL_CHECK_CLOSE(white_xyz[2], d65_xyz[2], 1e-4f);
+
+    // Compare against the published linear sRGB → XYZ D65 matrix (Bruce
+    // Lindbloom). Loose tolerance because Lindbloom's published constants
+    // use rounded primaries; the construction is exact from the inputs.
+    FL_CHECK_CLOSE(M[0][0], 0.4124f, 5e-3f);
+    FL_CHECK_CLOSE(M[1][0], 0.2126f, 5e-3f);
+    FL_CHECK_CLOSE(M[2][0], 0.0193f, 5e-3f);
+}
+
+
+FL_TEST_CASE("build_source_matrix: singular primaries return false") {
+    // Three identical primary chromaticities — all columns of the primary
+    // matrix collapse to one vector, det is exactly zero in float
+    // arithmetic, so invert3x3() bails and build_source_matrix() reports
+    // failure. Near-collinear but distinct primaries can still pass float
+    // precision; only the exact-collapse case is a hard guarantee.
+    const float xy_same[2] = {0.30f, 0.30f};
+    const float xy_w[2] = {0.30f, 0.30f};
+    float M[3][3];
+    FL_CHECK(!build_source_matrix(xy_same, xy_same, xy_same, xy_w, M));
+}
+
+
+FL_TEST_CASE("nnls3: identity system trivial recovery") {
+    // M = I, b = (1, 2, 3) → t ≈ (1, 2, 3), residual ≈ 0.
+    // Tolerance reflects the documented solver shape — 500 iterations at
+    // step 0.01 has geometric convergence 0.99^500 ≈ 0.66 %, so the gap
+    // for target 3 is ~0.02. Use a comfortable 3 % bound.
+    const float M[3][3] = {{1, 0, 0}, {0, 1, 0}, {0, 0, 1}};
+    const float b[3] = {1.0f, 2.0f, 3.0f};
+    float t[3];
+    float residual = -1.0f;
+    nnls3(M, b, t, &residual);
+    FL_CHECK_CLOSE(t[0], 1.0f, 0.03f);
+    FL_CHECK_CLOSE(t[1], 2.0f, 0.06f);
+    FL_CHECK_CLOSE(t[2], 3.0f, 0.10f);
+    FL_CHECK(residual < 0.10f);
+}
+
+
+FL_TEST_CASE("nnls3: non-negativity is enforced") {
+    // M = I, b = (-1, 0, 0). The unconstrained least-squares solution is
+    // (-1, 0, 0) but the non-negativity constraint should clamp t[0] to 0.
+    const float M[3][3] = {{1, 0, 0}, {0, 1, 0}, {0, 0, 1}};
+    const float b[3] = {-1.0f, 0.0f, 0.0f};
+    float t[3];
+    nnls3(M, b, t, nullptr);
+    FL_CHECK(t[0] >= 0.0f);
+    FL_CHECK(t[1] >= 0.0f);
+    FL_CHECK(t[2] >= 0.0f);
+    FL_CHECK_CLOSE(t[0], 0.0f, 1e-3f);
+}
+
+
+FL_TEST_CASE("hermite_basis: node values at t = 0, 0.5, 1") {
+    // h00(0)=1, h01(0)=0, h10(0)=0, h11(0)=0
+    // h00(1)=0, h01(1)=1, h10(1)=0, h11(1)=0
+    // h00(0.5)=0.5, h01(0.5)=0.5, h10(0.5)=0.125, h11(0.5)=-0.125
+    float b[4];
+
+    hermite_basis(0.0f, b);
+    FL_CHECK_CLOSE(b[0], 1.0f, 1e-6f);
+    FL_CHECK_CLOSE(b[1], 0.0f, 1e-6f);
+    FL_CHECK_CLOSE(b[2], 0.0f, 1e-6f);
+    FL_CHECK_CLOSE(b[3], 0.0f, 1e-6f);
+
+    hermite_basis(1.0f, b);
+    FL_CHECK_CLOSE(b[0], 0.0f, 1e-6f);
+    FL_CHECK_CLOSE(b[1], 1.0f, 1e-6f);
+    FL_CHECK_CLOSE(b[2], 0.0f, 1e-6f);
+    FL_CHECK_CLOSE(b[3], 0.0f, 1e-6f);
+
+    hermite_basis(0.5f, b);
+    FL_CHECK_CLOSE(b[0], 0.5f, 1e-6f);
+    FL_CHECK_CLOSE(b[1], 0.5f, 1e-6f);
+    FL_CHECK_CLOSE(b[2], 0.125f, 1e-6f);
+    FL_CHECK_CLOSE(b[3], -0.125f, 1e-6f);
+}
+
+
+FL_TEST_CASE("hermite_basis: partition-of-unity at every node") {
+    // h00(t) + h01(t) must equal 1 for ALL t — they're the value basis.
+    for (int i = 0; i <= 10; ++i) {
+        const float t = static_cast<float>(i) / 10.0f;
+        float b[4];
+        hermite_basis(t, b);
+        FL_CHECK_CLOSE(b[0] + b[1], 1.0f, 1e-6f);
+    }
+}
+
+
+FL_TEST_CASE("quantize_lut_cell: round-trip via kLutQ") {
+    // value v → i16(v * kLutQ + 0.5), then dequantize via i16 * (1/kLutQ).
+    // Round-trip error ≤ 0.5 / kLutQ ≈ 1.2e-4.
+    const float v_in = 0.7531f;
+    const i16 q = quantize_lut_cell(v_in);
+    const float v_out = static_cast<float>(q) / static_cast<float>(kLutQ);
+    FL_CHECK_CLOSE(v_out, v_in, 0.5f / static_cast<float>(kLutQ));
+}
+
+
+FL_TEST_CASE("quantize_lut_cell: saturates at i16 bounds") {
+    // Very large positive value clamps to i16 max (32767).
+    FL_CHECK(quantize_lut_cell(100.0f) == 32767);
+    // Very large negative value clamps to i16 min (-32768).
+    FL_CHECK(quantize_lut_cell(-100.0f) == -32768);
+}
+
+
+FL_TEST_CASE("LUT stride constants match documented per-cell storage") {
+    FL_CHECK(kLutStrideBilinear == 4);   // 4 channel values per cell
+    FL_CHECK(kLutStrideHermite == 12);   // 4 values + 8 slopes per cell
+    FL_CHECK(LutInterp::Bilinear != LutInterp::Hermite);
+}
+
+
+FL_TEST_CASE("EmitterProfile is trivially constructible and zero-initialized") {
+    // PR 1 only declares the struct; the solver lands in PR 3. Verify the
+    // struct is value-init-compatible (no constructors, no virtual, POD-like)
+    // so it can ship in `kRgbDefaultProfile` as a constexpr / extern const.
+    EmitterProfile p{};
+    FL_CHECK_CLOSE(p.xy_r[0], 0.0f, 1e-9f);
+    FL_CHECK_CLOSE(p.lum_g, 0.0f, 1e-9f);
+    FL_CHECK_CLOSE(p.input_xy_w[1], 0.0f, 1e-9f);
+}


### PR DESCRIPTION
## Summary

PR 1 of #3255. Pure refactor — moves the topology-independent colorimetric math helpers out of `fl::colorimetric_detail::` (RGBW-specific) into a new `fl::colorimetric_response::` namespace so the upcoming RGB-only colorimetric path (PR 3) can reuse them.

Zero behavior change — every RGBW path still calls the same code via using-declarations that re-export the moved names back into `colorimetric_detail::`. PR 2 will drop those re-exports as part of the variant + shared_ptr config refactor.

## What moved

Into `src/fl/gfx/colorimetric_response.h` under `namespace fl::colorimetric_response`:

- `cct_to_xy`, `xyY_to_XYZ`, `invert3x3`, `matvec3`, `barycentric_xy`, `build_source_matrix`
- `quantize_u8`, `quantize_lut_cell`, `nnls3`, `hermite_basis`
- `kLutQ`, `kLutStrideBilinear`, `kLutStrideHermite`, the `LutInterp` enum
- New `EmitterProfile` struct (RGB-only profile shape; declared here so PR 3 can land the solver without a structural reshuffle).

## What stayed

`src/fl/gfx/rgbw_colorimetric.h` keeps every RGBW-specific declaration: `ProfileCache`, `LutTable`, `RgbcctProfile`, `is_native_input_gamut`, `count_active_channels`, the `build_profile_cache` / `solve_strict_subgamut*` / `solve_wx_lp_legacy` / `solve_wx_overdrive` / `build_lut` / `lookup_lut` / `solve_rgbcct` declarations, the `kDefaultOverdriveRatio` constant.

The header now `#include`s `colorimetric_response.h` and starts with a using-declaration block (each marked `// ok bare using` — controlled re-export inside a namespace block) that re-imports the moved names into `colorimetric_detail::`. That keeps every external caller working unchanged: `src/fl/gfx/rgbw.cpp.hpp` (6 references), `src/fl/gfx/rgbww.cpp.hpp` (11 references), `src/fl/gfx/rgbww.h`, and `tests/fl/gfx/rgbw_colorimetric.cpp` (uses `using namespace fl::colorimetric_detail;`).

## New test coverage

`tests/fl/gfx/colorimetric_response.cpp` exercises the moved primitives in isolation of any RGBW topology — 20 test cases covering xyY/XYZ round-trip, 3x3 invert identity + singular detection, matvec3 hand-computed product, barycentric inside/outside, CCT-to-xy at 2700/4000/6500K, quantize edges, NNLS identity + non-negativity, Hermite basis at nodes + partition-of-unity, LUT stride constants, and `EmitterProfile` zero-init.

The existing `tests/fl/gfx/rgbw_colorimetric.cpp` was deliberately not touched and continues to pass byte-identically — it pulls in the moved helpers via the using-declarations.

## Build manifest

`src/fl/gfx/_build.cpp.hpp` picks up `colorimetric_response.cpp.hpp` in the same unity-build slot as the other gfx modules. The new `.cpp.hpp` is empty (gated by `FASTLED_RGBW_COLORIMETRIC` so it matches the existing gate exactly) and reserved for PR 3's `solve_rgb_colorimetric` definition.

## Test plan

- [x] `bash test fl_gfx_colorimetric_response` — new module, 20/20 pass
- [x] `bash test fl_gfx_rgbw_colorimetric` — existing, byte-identical, pass
- [x] `bash test fl_gfx_rgbww` — existing, byte-identical, pass
- [x] `bash test --cpp` — 331/331 pass
- [x] `bash lint --cpp` — clean

## Out of scope

PR 2 of #3255: `fl::variant<RGBW_MODE, ColorimetricMode>` + `DiodeProfilePtr` (`fl::shared_ptr<const DiodeProfile>`), removal of `FASTLED_RGBW_COLORIMETRIC` macro + `kRGBWColorimetric`/`kRGBWColorimetricBoosted` enum entries + global setters + the using-declaration re-exports added here.

PR 3 of #3255: actual RGB solver implementation, per-strip `loadAndScaleRGB` hook, `CLEDController::setRgbColorimetricProfile`, `FL_PLATFORM_HAS_TINY_MEMORY` gating on per-instance state.

Refs #3255.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a colorimetric response math layer with chromaticity/XYZ conversions, 3×3 matrix helpers, barycentric classification, CCT→xy, quantization, LUT interpolation utilities, and an `EmitterProfile` structure.

* **Refactor**
  * Centralized shared chromaticity/LUT primitives into the new colorimetric response header and re-exported them for backward compatibility from the existing colorimetric detail area.

* **Tests**
  * Added unit tests validating conversions, matrix operations, LUT quantization/strides, solver behavior, Hermite basis properties, and `EmitterProfile` initialization.

* **Chores**
  * Updated the unity build compilation to include the new colorimetric response component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->