### PR TITLE
refactor(rpc): rename envelope markers __async / __skip to ackOnly / noEnqueue (#3228)

### DIFF
--- a/src/fl/remote/remote.cpp.hpp
+++ b/src/fl/remote/remote.cpp.hpp
@@ -201,12 +201,16 @@ fl::json Remote::processRpc(const fl::json& request) {
     fl::json response = mRpc.handle(request);
 
 #if FL_PLATFORM_HAS_LARGE_MEMORY
-    // For async functions, response already sent via sendAsyncResponse()
-    if (response.contains("__async") && response["__async"].as_bool().value_or(false)) {
-        // Don't return response (ACK already sent by Rpc)
-        // Return null to prevent Server from queuing it
+    // For async functions, response already sent via sendAsyncResponse().
+    // Envelope marker names renamed in #3228 -- accept legacy `__async` for
+    // one release of back-compat in case external Server forks set it.
+    bool ackAlready = (response.contains("ackOnly") && response["ackOnly"].as_bool().value_or(false))
+                  || (response.contains("__async") && response["__async"].as_bool().value_or(false));
+    if (ackAlready) {
+        // Don't return response (ACK already sent by Rpc).
+        // Return a skip-envelope to prevent Server from queueing it.
         fl::json nullResponse = fl::json::object();
-        nullResponse.set("__skip", true);  // Marker to skip queueing
+        nullResponse.set("noEnqueue", true);
         return nullResponse;
     }
 

--- a/src/fl/remote/rpc/rpc.cpp.hpp
+++ b/src/fl/remote/rpc/rpc.cpp.hpp
@@ -209,9 +209,12 @@ json Rpc::handle(const json& request) {
         response.set("warnings", warnings);
     }
 
-    // For async functions, mark response to not queue it (ACK already sent)
+    // For async functions, mark response to signal "ACK already sent" so
+    // downstream queue machinery skips pushing a duplicate response.
+    // Renamed from `__async` in #3228 -- field is a public envelope-control
+    // marker, not a reserved-namespace identifier.
     if (isAsync) {
-        response.set("__async", true);  // Internal marker
+        response.set("ackOnly", true);
     }
 #endif
 

--- a/src/fl/remote/rpc/server.cpp.hpp
+++ b/src/fl/remote/rpc/server.cpp.hpp
@@ -49,9 +49,12 @@ size_t Server::pull() {
         // Process request through handler
         fl::json response = mRequestHandler(request);
 
-        // Queue response (skip scheduled acknowledgments and async skip markers)
+        // Queue response (skip scheduled acknowledgments and async skip markers).
+        // `noEnqueue` is the new envelope marker (#3228); accept legacy `__skip`
+        // for one release of back-compat.
         bool isScheduledAck = response.contains("scheduled") && response["scheduled"].as_bool().value_or(false);
-        bool isAsyncSkip = response.contains("__skip") && response["__skip"].as_bool().value_or(false);
+        bool isAsyncSkip = (response.contains("noEnqueue") && response["noEnqueue"].as_bool().value_or(false))
+                       || (response.contains("__skip") && response["__skip"].as_bool().value_or(false));
         if (!response.is_null() && !isScheduledAck && !isAsyncSkip) {
             mOutgoingQueue.push_back(fl::move(response));
         }


### PR DESCRIPTION
## Summary

Renames the FastLED JSON-RPC envelope control markers from the misleading double-underscore-prefixed names (which read as reserved-namespace identifiers per C/C++ tradition) to descriptive names that match their actual public-envelope-control role:

| Today | After |
|---|---|
| ``__async: true`` | ``ackOnly: true`` |
| ``__skip: true`` | ``noEnqueue: true`` |

Producers write the new names; consumers accept either new or legacy for one release of back-compat in case external Server forks set the legacy markers directly.

## Why

Per #3228: ``__async`` / ``__skip`` look reserved-namespace but are actually public envelope-control fields. They cause linter false positives, search collisions with C-runtime ``__async_*`` symbols, and they read as "private/don't touch" in the eventual OpenRPC schema (#3081) when they're actually the canonical way to signal "ACK already sent."

## Closes #3228

## Test plan

- [x] ``bash test rpc`` -- 1/1 test binary passes (all RPC test cases included).
- [x] ``bash lint --cpp`` -- 0 violations.
- [x] Back-compat read paths verified: ``Server::poll`` (#3228 consumer) and ``Remote::processRpc`` (other consumer) accept both old and new names.
- [x] Producer paths verified: ``Rpc::handle`` writes ``ackOnly``, ``Remote::processRpc`` writes ``noEnqueue``.

## Files

- ``src/fl/remote/rpc/rpc.cpp.hpp`` -- writes ``ackOnly`` instead of ``__async``
- ``src/fl/remote/remote.cpp.hpp`` -- writes ``noEnqueue`` instead of ``__skip``; reads either ``ackOnly`` or legacy ``__async`` from upstream
- ``src/fl/remote/rpc/server.cpp.hpp`` -- reads either ``noEnqueue`` or legacy ``__skip``

Refs #3228, #3224 (Tier 1B), #3244.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved async RPC response handling with enhanced internal markers for better control over response queuing and skipping behavior.
  * Updated communication protocol implementation to support refined async operation handling while maintaining backward compatibility with previous versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->