### PR TITLE
fix(ci/lpc8xx): drop Fx/FxEngine from LPC canaries (FLASH-overflow)

### DIFF
--- a/.github/workflows/build_lpc804.yml
+++ b/.github/workflows/build_lpc804.yml
@@ -24,4 +24,4 @@ jobs:
   build:
     uses: ./.github/workflows/build_template.yml
     with:
-      args: lpc804 Blink DemoReel100 Fx/FxEngine
+      args: lpc804 Blink DemoReel100

--- a/.github/workflows/build_lpc845.yml
+++ b/.github/workflows/build_lpc845.yml
@@ -24,4 +24,4 @@ jobs:
   build:
     uses: ./.github/workflows/build_template.yml
     with:
-      args: lpc845 Blink DemoReel100 Fx/FxEngine
+      args: lpc845 Blink DemoReel100

--- a/.github/workflows/build_lpc845brk.yml
+++ b/.github/workflows/build_lpc845brk.yml
@@ -24,4 +24,4 @@ jobs:
   build:
     uses: ./.github/workflows/build_template.yml
     with:
-      args: lpc845brk Blink DemoReel100 Fx/FxEngine
+      args: lpc845brk Blink DemoReel100

--- a/.github/workflows/build_lpcxpresso804.yml
+++ b/.github/workflows/build_lpcxpresso804.yml
@@ -24,4 +24,4 @@ jobs:
   build:
     uses: ./.github/workflows/build_template.yml
     with:
-      args: lpcxpresso804 Blink DemoReel100 Fx/FxEngine
+      args: lpcxpresso804 Blink DemoReel100

--- a/.github/workflows/build_lpcxpresso845max.yml
+++ b/.github/workflows/build_lpcxpresso845max.yml
@@ -24,4 +24,4 @@ jobs:
   build:
     uses: ./.github/workflows/build_template.yml
     with:
-      args: lpcxpresso845max Blink DemoReel100 Fx/FxEngine
+      args: lpcxpresso845max Blink DemoReel100


### PR DESCRIPTION
## Summary

All 5 LPC8xx variant CI workflows (lpc804, lpc845, lpc845brk, lpcxpresso804, lpcxpresso845max) have been **RED on master** since the canary lineup was expanded beyond the Blink-only baseline. Root cause: \`Fx/FxEngine\` pulls in the FxEngine + wave2d/blend infrastructure, which overflows the LPC8xx 64 KB FLASH budget by **9,188 bytes** at link time.

CI failure excerpt (lpc845brk, run [27805199049](https://github.com/FastLED/FastLED/actions/runs/27805199049)):
\`\`\`
ld: ...firmware.elf section \`.text' will not fit in region \`FLASH'
ld: region \`FLASH' overflowed by 9188 bytes
collect2: error: ld returned 1 exit status
FAILED: Fx/FxEngine
ERROR: Compilation failed for board lpc845brk
\`\`\`

#2990's acceptance criterion was:

> Wire \`examples/Blink/Blink.ino\` into FastLED's per-board CI for all five variants

\`Fx/FxEngine\` was a stretch goal that doesn't fit the platform's flash budget. \`Blink\` and \`DemoReel100\` DO fit and continue to be exercised.

## Change

5 workflow files (one per variant), 1 line each: drop \` Fx/FxEngine\` from the \`args:\` line.

## Closes

Closes #2990 — original acceptance (is_arm dispatcher + Blink canary CI for all 5 LPC8xx variants) is met once CI is green again with this trim.

## Test plan

- [x] grep verified all 5 \`args:\` lines now read \`<variant> Blink DemoReel100\`
- [ ] CI green on master after merge (5 \`build_lpc*.yml\` runs go from red → green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build workflows for multiple platforms (LPC804, LPC845, LPC845BRK, LPCXpresso804, and LPCXpresso845MAX) by streamlining build arguments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->