### PR TITLE
fix(ci/cppcheck): recognize fbuild's collapsed-env release-dir layout (closes #3264)

### DIFF
--- a/ci/util/fbuild_compiledb.py
+++ b/ci/util/fbuild_compiledb.py
@@ -26,11 +26,17 @@ def _candidate_fbuild_release_dirs(
 
     FastLED compiles fbuild with ``build_dir=<repo>/.build/pio/<board>/`` (see
     ``ci/compiler/pio.py::_artifacts_dir``), so fbuild's output lives at
-    ``.build/pio/<board>/.fbuild/build/<env>/release/``. The standalone CLI
-    (``fbuild <repo> build --target compiledb``) instead emits
-    ``<repo>/.fbuild/build/<env>/release/`` — we treat both as valid so that a
-    direct ``--target compiledb`` invocation (no prior FastLED compile) also
-    works. An older ``.build/.fbuild/…`` layout is kept as a tail fallback.
+    ``.build/pio/<board>/.fbuild/build/<env>/release/`` — except when the
+    FastLED orchestrator invokes fbuild without an explicit ``-e <env>``
+    (the common case for boards where the fbuild env name matches the
+    build_dir's board name), in which case fbuild collapses the ``<env>``
+    segment and emits to ``.build/pio/<board>/.fbuild/build/release/``
+    directly. The latter is what every current LPC8xx CI workflow produces.
+    The standalone CLI (``fbuild <repo> build --target compiledb``) instead
+    emits ``<repo>/.fbuild/build/<env>/release/`` — we treat all variants as
+    valid so that a direct ``--target compiledb`` invocation (no prior
+    FastLED compile) also works. An older ``.build/.fbuild/…`` layout is
+    kept as a tail fallback.
 
     ``project_root`` is passed explicitly rather than derived from
     ``build_root.name == ".build"`` — callers always know their repo root
@@ -42,6 +48,11 @@ def _candidate_fbuild_release_dirs(
     """
     return [
         build_root / "pio" / board_name / ".fbuild" / "build" / board_name / "release",
+        # FastLED-CI-orchestrated builds where fbuild collapses the <env>
+        # segment. See #3264 — without this, every LPC8xx CI build falls
+        # through to `pio check`, which then fails for boards the PIO
+        # platform doesn't register (e.g. `lpc804`).
+        build_root / "pio" / board_name / ".fbuild" / "build" / "release",
         project_root / ".fbuild" / "build" / board_name / "release",
         build_root / ".fbuild" / "build" / board_name / "release",
     ]


### PR DESCRIPTION
## Summary

\`ci/util/fbuild_compiledb.py::_candidate_fbuild_release_dirs\` knew about three layouts for where fbuild writes its release artifacts, but missed the one the FastLED CI orchestrator actually produces: when fbuild's env name matches the build-dir's board name, fbuild collapses the \`<env>\` segment and emits to \`.build/pio/<board>/.fbuild/build/release/\` (no env in the path).

## The bug

\`was_compiled_with_fbuild\` returned \`False\` for every LPC8xx board, so \`ci/ci-cppcheck.py\` fell through to \`pio check\` for all of them. The platformio-side platform \`zackees/platform-nxplpc-arduino\` happens to register lpc845/lpc845brk/lpcxpresso804/lpcxpresso845max but **not** \`lpc804\`, so on that one board \`pio check\` raised:

\`\`\`
Checking lpc804 > cppcheck (board: lpc804; platform: ...; framework: arduino)
UnknownBoard: Unknown board ID 'lpc804'
##[error]Process completed with exit code 123.
\`\`\`

The bug is invisible on the boards PIO knows about — they pass \`pio check\` even though they were never supposed to be on that path; they should have routed through the fbuild fast-path that uses the emitted \`compile_commands.json\`.

## Evidence

From the lpc804 failure ([run 27811322117](https://github.com/FastLED/FastLED/actions/runs/27811322117)):

\`\`\`
Artifact: .../.build/pio/lpc804/.fbuild/build/release/firmware.elf (30.68KB)
\`\`\`

— path uses \`.fbuild/build/release/\`, not \`.fbuild/build/lpc804/release/\` like the candidate list expected.

## Fix

Add the collapsed-env path \`build_root / \"pio\" / board_name / \".fbuild\" / \"build\" / \"release\"\` as the second candidate (right after the env-named path), so:

1. Standalone \`fbuild --target compiledb\` invocations still match the env-named path (highest priority).
2. FastLED-CI builds (the common case today) match the new no-env path.
3. The legacy \`.build/.fbuild/...\` fallback stays at the tail.

Docstring updated to explain the collapsing behavior.

## Side effect

After this lands, lpcxpresso804/lpcxpresso845max/lpc845brk also flip from \`pio check\` → \`clang-tool-chain-tidy\` (the intended fbuild path). That's a behavior change but is the original design intent per the existing code path's docstring. If clang-tidy surfaces real findings on those boards, they need addressing separately; the fix here is correct independent of that.

## Closes

Closes #3264

## Test plan

- [x] \`ruff check\` and \`ty check\` clean on \`ci/util/fbuild_compiledb.py\`
- [ ] Validate post-merge: \`build_lpc804.yml\` flips green on master
- [ ] Validate post-merge: the 3 currently-green LPC variants stay green (they shouldn't regress — clang-tidy via fbuild path is gentler than \`pio check\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of compiler output files by adding support for additional build directory layouts, particularly for builds orchestrated without explicit environment configuration.

* **Documentation**
  * Updated documentation to clarify supported `fbuild` output directory structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->