### PR TITLE
perf(variant): collapse trivial-destructor / trivial-copy thunks (#3249 / #3244 Tier 3G)

### DIFF
--- a/src/fl/stl/variant.h
+++ b/src/fl/stl/variant.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "fl/stl/cstddef.h"       // for size_t
+#include "fl/stl/cstring.h"        // for fl::memcpy (trivial copy/move thunks)
 #include "fl/stl/int.h"               // for u8
 #include "fl/stl/type_traits.h" // for fl::enable_if, fl::is_same, etc.
 #include "fl/stl/bit_cast.h"    // for safe type-punning
@@ -11,6 +12,101 @@
 #include "fl/stl/noexcept.h"
 
 namespace fl {
+
+namespace detail {
+
+// =============================================================================
+// variant lifecycle thunks (FastLED #3249 / #3244 Tier 3G)
+// =============================================================================
+//
+// Each (T x op) pair in `fl::variant<Ts...>` previously emitted its own
+// per-instantiation thunk -- on the json_value 10-alternative variant the
+// audit catalogued ~245 thunks totalling ~6.7 KB on LPC845.
+//
+// The collapse:
+//   1. Thunks now live at namespace scope (`fl::detail`) so two distinct
+//      `variant<Ts...>` instantiations that share a type `T` also share
+//      `typed_destroy_thunk<T>`, `typed_copy_thunk<T>`, `typed_move_thunk<T>`.
+//      Previously each variant's outer template params re-mangled the symbol.
+//   2. Trivially-copyable T's route through a shared `noop_destroy` and
+//      per-size `trivial_copy_n<sizeof(T)>` / `trivial_move_n<sizeof(T)>`
+//      thunks. All `bool`, `i64`, `float`, `nullptr_t`, etc. alternatives
+//      collapse to one no-op + a handful of memcpy bodies keyed on size,
+//      regardless of how many variant types ride on them.
+//
+// `is_trivially_copyable<T>` is used as the gate for both the destroy AND
+// copy/move collapses: per the C++ standard, trivially-copyable implies
+// trivially-destructible, so this is strictly correct (and a touch more
+// conservative than the issue body's `is_trivially_destructible<T>` --
+// we don't have that trait in `fl/stl/type_traits.h` and the
+// conservative variant captures every json_value primitive alternative).
+//
+// `visit_fn<T, Visitor>` stays per-instantiation -- it encodes T-specific
+// dispatch into the visitor's `operator()(T const&)` and the collapse
+// would change behavior. See `variant<Ts...>::visit_fn` below.
+
+using variant_destroy_fn = void (*)(void* /*storage*/);
+using variant_copy_fn    = void (*)(void* /*dst*/, const void* /*src*/);
+using variant_move_fn    = void (*)(void* /*dst*/, void* /*src*/);
+
+// -- per-T thunks (used when T is not trivially-copyable) ---------------------
+
+template <typename T>
+void typed_destroy_thunk(void* storage) FL_NOEXCEPT {
+    fl::bit_cast_ptr<T>(storage)->~T();
+}
+
+template <typename T>
+void typed_copy_thunk(void* dst, const void* src) FL_NOEXCEPT {
+    const T* source = fl::bit_cast_ptr<const T>(src);
+    new (dst) T(*source);
+}
+
+template <typename T>
+void typed_move_thunk(void* dst, void* src) FL_NOEXCEPT {
+    T* source = fl::bit_cast_ptr<T>(src);
+    new (dst) T(fl::move(*source));
+}
+
+// -- shared thunks for trivially-copyable types -------------------------------
+
+inline void variant_noop_destroy(void* /*storage*/) FL_NOEXCEPT {}
+
+template <fl::size N>
+void variant_trivial_copy_n(void* dst, const void* src) FL_NOEXCEPT {
+    fl::memcpy(dst, src, N);
+}
+
+template <fl::size N>
+void variant_trivial_move_n(void* dst, void* src) FL_NOEXCEPT {
+    fl::memcpy(dst, src, N);
+}
+
+// -- per-T compile-time pickers (one symbol per Sig, populates the variant's
+// static dispatch table at startup) ------------------------------------------
+
+template <typename T>
+constexpr variant_destroy_fn pick_variant_destroy_fn() FL_NOEXCEPT {
+    return is_trivially_copyable<T>::value
+        ? &variant_noop_destroy
+        : &typed_destroy_thunk<T>;
+}
+
+template <typename T>
+constexpr variant_copy_fn pick_variant_copy_fn() FL_NOEXCEPT {
+    return is_trivially_copyable<T>::value
+        ? &variant_trivial_copy_n<sizeof(T)>
+        : &typed_copy_thunk<T>;
+}
+
+template <typename T>
+constexpr variant_move_fn pick_variant_move_fn() FL_NOEXCEPT {
+    return is_trivially_copyable<T>::value
+        ? &variant_trivial_move_n<sizeof(T)>
+        : &typed_move_thunk<T>;
+}
+
+} // namespace detail
 
 // A variant that can hold any of N different types
 template <typename... Types>
@@ -218,61 +314,46 @@ class FL_ALIGN_AS_T(max_align<Types...>::value) variant {
         v.accept(*typed_ptr);
     }
 
-    // –– destroy via table
+    // –– destroy via table -- dispatches through fl::detail::pick_variant_destroy_fn,
+    //    which collapses trivially-copyable T's to the shared `variant_noop_destroy`
+    //    (one symbol across every variant<...> in the link). See #3249 header.
     void destroy_current() FL_NOEXCEPT {
-        using Fn = void (*)(void *);
         FL_DISABLE_WARNING_PUSH
         FL_DISABLE_WARNING(array-bounds)
-        static constexpr Fn table[] = {&variant::template destroy_fn<Types>...};
+        static constexpr detail::variant_destroy_fn table[] = {
+            detail::pick_variant_destroy_fn<Types>()...
+        };
         if (_tag != Empty) {
             table[_tag - 1](&_storage);
         }
         FL_DISABLE_WARNING_POP
     }
 
-    template <typename T> static void destroy_fn(void *storage) FL_NOEXCEPT {
-        // Use bit_cast_ptr for safe type-punning on properly aligned storage
-        // The storage is guaranteed to be properly aligned by alignas(max_align<Types...>::value)
-        T* typed_ptr = fl::bit_cast_ptr<T>(storage);
-        typed_ptr->~T();
-    }
-
-    // –– copy‐construct via table
+    // –– copy‐construct via table -- collapses trivially-copyable T's to the
+    //    shared per-size `variant_trivial_copy_n<sizeof(T)>` thunk. See #3249.
     void copy_construct_from(const variant &other) FL_NOEXCEPT {
-        using Fn = void (*)(void *, const variant &);
         FL_DISABLE_WARNING_PUSH
         FL_DISABLE_WARNING(array-bounds)
-        static constexpr Fn table[] = {&variant::template copy_fn<Types>...};
-        table[other._tag - 1](&_storage, other);
+        static constexpr detail::variant_copy_fn table[] = {
+            detail::pick_variant_copy_fn<Types>()...
+        };
+        table[other._tag - 1](&_storage, &other._storage[0]);
         FL_DISABLE_WARNING_POP
         _tag = other._tag;
     }
 
-    template <typename T>
-    static void copy_fn(void *storage, const variant &other) FL_NOEXCEPT {
-        // Use bit_cast_ptr for safe type-punning on properly aligned storage
-        // The storage is guaranteed to be properly aligned by alignas(max_align<Types...>::value)
-        const T* source_ptr = fl::bit_cast_ptr<const T>(&other._storage[0]);
-        new (storage) T(*source_ptr);
-    }
-
-    // –– move‐construct via table
+    // –– move‐construct via table -- collapses trivially-copyable T's to the
+    //    shared per-size `variant_trivial_move_n<sizeof(T)>` thunk. See #3249.
     void move_construct_from(variant &other) FL_NOEXCEPT {
-        using Fn = void (*)(void *, variant &);
         FL_DISABLE_WARNING_PUSH
         FL_DISABLE_WARNING(array-bounds)
-        static constexpr Fn table[] = {&variant::template move_fn<Types>...};
-        table[other._tag - 1](&_storage, other);
+        static constexpr detail::variant_move_fn table[] = {
+            detail::pick_variant_move_fn<Types>()...
+        };
+        table[other._tag - 1](&_storage, &other._storage[0]);
         FL_DISABLE_WARNING_POP
         _tag = other._tag;
         other.reset();
-    }
-
-    template <typename T> static void move_fn(void *storage, variant &other) FL_NOEXCEPT {
-        // Use bit_cast_ptr for safe type-punning on properly aligned storage
-        // The storage is guaranteed to be properly aligned by alignas(max_align<Types...>::value)
-        T* source_ptr = fl::bit_cast_ptr<T>(&other._storage[0]);
-        new (storage) T(fl::move(*source_ptr));
     }
 
     // –– everything below here (type_traits, construct<T>, type_to_tag,


### PR DESCRIPTION
## Summary

Two-axis collapse of the per-(variant × T × op) thunk explosion in ``fl::variant<Ts...>``:

1. **Namespace extraction.** Thunks move out of ``variant<Ts...>`` into ``fl::detail::`` namespace scope. Previously each variant instantiation had its own mangled ``variant<Types...>::destroy_fn<T>`` / ``copy_fn<T>`` / ``move_fn<T>`` symbols; now ``typed_destroy_thunk<T>`` / ``typed_copy_thunk<T>`` / ``typed_move_thunk<T>`` are shared across every variant instantiation containing ``T``.

2. **Trivial collapse.** Trivially-copyable T's collapse further to a single shared ``variant_noop_destroy`` + per-size ``variant_trivial_copy_n<sizeof(T)>`` / ``variant_trivial_move_n<sizeof(T)>`` thunks. All ``bool``, ``i64``, ``float``, ``nullptr_t``, etc. alternatives across every variant in the link now share one noop-destroy and a handful of size-keyed memcpy bodies.

``visit_fn<T, Visitor>`` stays per-(T × Visitor) -- it dispatches into the visitor's typed ``operator()(T const&)`` and the collapse would change behavior. Out of scope per acceptance.

## Trait choice

The issue body called for ``is_trivially_destructible<T>`` as the gate. That trait is not in ``fl/stl/type_traits.h``; ``is_trivially_copyable<T>`` is used instead. Per the C++ standard, trivially-copyable implies trivially-destructible, so the destroy collapse is correctness-preserving (slightly more conservative than the issue's wording but captures every primitive alternative the audit named in json_value's ``bool`` / ``i64`` / ``float`` / ``nullptr_t``).

## Flash impact (LPC845-BRK / AutoResearch)

| Metric | Master | Branch | Delta |
|---|---:|---:|---:|
| Flash (.bin) | 46,840 B | 46,404 B | **-436 B** |
| ELF .text | 135,160 B | 130,692 B | **-4,468 B** |
| Flash % of 64 KB | 71.5% | 70.8% | -0.7% |
| Per-variant thunk symbols (``variant<...>::destroy_fn/copy_fn/move_fn``) | 55 | **0** | structural collapse |

## Honest caveat re acceptance bullet ``≥ 800 B net flash drop``

The 436 B drop is **below the acceptance target**. Same documented pattern as #3258 (#3246) and #3261 (#3251) before it: AutoResearch's LowMemory mode exercises only ~3 distinct ``variant<...>`` instantiations against json_value's 10-alternative variant, so the audit-predicted 2-3 KB (which assumed json-heavy Large-memory builds) only partially materializes here.

The structural collapse is verified -- 55 per-variant thunk symbols in master → 0 in branch; everything is routed through the shared namespace-scope thunks (verified via ``llvm-nm`` symbol diff in the commit body).

## Test plan

- [x] ``bash test --cpp`` -- 330/330 unit tests pass.
- [x] ``bash test variant`` -- variant-specific tests pass; semantics preserved.
- [x] ``bash lint --cpp`` -- 0 violations.
- [x] LPC845-BRK / AutoResearch host-cross build green (flash 70.8% < 71.5% baseline).
- [x] ``llvm-nm`` symbol audit shows the 55 old ``variant<...>::destroy_fn/copy_fn/move_fn`` symbols are gone and the ``typed_destroy_thunk<T>`` / ``typed_copy_thunk<T>`` / ``typed_move_thunk<T>`` shared symbols + per-size ``variant_trivial_copy_n<N>`` thunks are present.

## Files

- ``src/fl/stl/variant.h`` -- 114 added, 33 removed (1 file modified)

Refs #3249, #3244 (Tier 3G), #3235.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured variant's internal lifetime management with improved dispatch mechanisms for copy, move, and destroy operations. Optimized handling of trivially-copyable types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->