### PR TITLE
fix(ci/size): esp32dev overrides generic-esp debug flags (restore 330KB ceiling)

### DIFF
--- a/.github/workflows/check_esp32_size.yml
+++ b/.github/workflows/check_esp32_size.yml
@@ -29,22 +29,5 @@ jobs:
     uses: ./.github/workflows/build_template_binary_size.yml
     with:
       board: esp32dev
-      # Current fbuild-measured size sits at ~631 KB. The 330 KB ceiling
-      # set in e646657d01 was an intentional regression-signal that
-      # presumed a ~300 KB worth of pending memory work would land
-      # alongside it; it never did, and the workflow has been red on
-      # master continuously since 2026-06-17.
-      #
-      # The proximate measurement bug (PIO re-link reintroducing
-      # .eh_frame machinery) is fixed in ci/compiled_size.py on this PR,
-      # but the actual fbuild link itself produces ~631 KB. Bump the
-      # ceiling to 640 KB so the workflow:
-      #   - goes green at today's actual footprint, and
-      #   - still catches any +1.5% regression from this baseline.
-      #
-      # When the memory work referenced in e646657d01 resumes, tighten
-      # this back down as savings land.
-      max_size: 640000
-      # Apa102 carries the SPI chipset code on top of Blink's baseline and
-      # measures ~687520 B today; give it ~2% headroom.
-      max_size_apa102: 700000
+      max_size: 330000
+      max_size_apa102: 330000

--- a/.github/workflows/check_esp32_size.yml
+++ b/.github/workflows/check_esp32_size.yml
@@ -24,6 +24,7 @@ on:
       - 'ci/compiler/build_config.py'
       - '.github/workflows/check_esp32_size.yml'
       - '.github/workflows/build_template_binary_size.yml'
+      - 'platformio.ini'
 jobs:
   build:
     uses: ./.github/workflows/build_template_binary_size.yml

--- a/platformio.ini
+++ b/platformio.ini
@@ -123,8 +123,33 @@ board = esp32dev
 ; causing "Failed to set QIE bit" error and boot assertion failure in startup_funcs.c:95
 ; DIO (Dual I/O) mode works reliably in both hardware and QEMU emulation
 board_build.flash_mode = dio
+; esp32dev is FastLED's binary-size reference target — `check_esp32_size`
+; tracks the 330 KB ceiling here. We MUST override generic-esp's debug
+; build_type (=> -Og, no exception/unwind stripping) and verbose logging
+; flags or the test compiles a debug binary and reads ~2x the real release
+; footprint.
+build_type = release
 build_flags =
   ${env:generic-esp.build_flags}
+  ; -- override generic-esp debug flags for size-check builds --
+  -UDEBUG
+  -DNDEBUG
+  -UFASTLED_DEBUG
+  -UCORE_DEBUG_LEVEL
+  -DCORE_DEBUG_LEVEL=0
+  -ULOG_LOCAL_LEVEL
+  -DLOG_LOCAL_LEVEL=ESP_LOG_NONE
+  ; -- size-strip flags (mirror Teensy 4 cxx_flags) --
+  -Os
+  -fno-exceptions
+  -fno-rtti
+  -fno-unwind-tables
+  -fno-asynchronous-unwind-tables
+  -ffunction-sections
+  -fdata-sections
+build_unflags =
+  -Og
+  -g
 
 
 [env:teensy40]


### PR DESCRIPTION
## Investigation result

User flagged that PR #3262's 640KB/700KB ceiling bumps masked the real issue: **the esp32dev build is ~2× too big because `[env:esp32dev]` silently inherits debug-mode flags**, not because fbuild fails to strip EH frames.

### Evidence

**Teensy 4 fbuild cxx_flags** (read from a local `build_info.json`):
```
-Os -fno-exceptions -fno-rtti -fno-asynchronous-unwind-tables -fno-unwind-tables
-ffunction-sections -fdata-sections
```
That config produces ~50 KB Blink binaries.

**esp32dev inherits from `[env:generic-esp]`**:
```ini
build_type = debug
build_flags =
    -DDEBUG
    -DFASTLED_DEBUG=1
    -g
    -Og
    -DCORE_DEBUG_LEVEL=5
    -DLOG_LOCAL_LEVEL=ESP_LOG_VERBOSE
```
None of the release / size-strip flags are passed. nm on the resulting ELF shows `__gxx_personality_v0` (689 B), `std::logic_error::~logic_error`, vtables for `__gnu_cxx::__concurrence_lock_error`, the full `_vfprintf_r` (12 KB) family — exactly what `-fno-exceptions` + dead-log-string stripping would have prevented.

The generic-esp debug config was added 2026-04-06 for an ESP32 crash-trace investigation. It's appropriate for development of the s3/c6/c3/p4 environments, but esp32dev is the size-check reference — it must be release.

## Fix

### `platformio.ini` `[env:esp32dev]`
- `build_type = release` (overrides parent's `debug`)
- `build_unflags = -Og -g` (strip the inherited debug opts)
- Appended: `-UDEBUG -DNDEBUG -UFASTLED_DEBUG -DCORE_DEBUG_LEVEL=0 -DLOG_LOCAL_LEVEL=ESP_LOG_NONE -Os -fno-exceptions -fno-rtti -fno-unwind-tables -fno-asynchronous-unwind-tables -ffunction-sections -fdata-sections`

### `.github/workflows/check_esp32_size.yml`
- Reverted ceilings to the historical **330 KB** Blink and Apa102 limits (the user's intent).
- Added `platformio.ini` to the PR trigger paths so this change runs the workflow on the PR itself.

Other esp32 envs (`s3` / `c6` / `c3` / `p4` / `c2`) keep `generic-esp.debug` for development.

## Test plan

- [ ] CI: `esp32dev_binary_size` workflow on this PR. Expected: size drops from 631100 toward ~300 KB and both Blink + Apa102 fit under 330 KB.
- [ ] If the size still exceeds 330 KB after the release flags, treat that as the real surface for further investigation (which symbols dominate after EH + log-string stripping) and surface it on the PR rather than hide it behind another budget bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ESP32 firmware build configuration with optimized compiler settings.
  * Adjusted build size thresholds for ESP32 targets to reflect current requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->