### PR TITLE
refactor(log): unify FL_WARN/FL_WARN_F via argument-count dispatch (#3272)

### DIFF
--- a/src/fl/log/log.h
+++ b/src/fl/log/log.h
@@ -217,41 +217,78 @@ fl::string log_format_string(const char* format, const Args&... args) FL_NOEXCEP
 // out-of-line. The noinline attribute is what makes this proposal
 // actually win bytes; bare centralisation alone isn't enough.
 void log_emit(log_kind kind, const char* file, int line, fl::sstream& body) FL_NO_INLINE FL_NOEXCEPT;
+
 } } // namespace fl::detail
+
+// =============================================================================
+// Unified-dispatch helpers for FL_WARN / FL_ERROR / FL_INFO / FL_PRINT (#3272)
+// =============================================================================
+// One `FL_WARN(...)` macro accepts BOTH stream-style and printf-style:
+//
+//   FL_WARN("plain literal")            // 1 arg  → stream form  (sstream())
+//   FL_WARN("foo " << x << " bar")      // 1 arg  → stream form  (sstream())
+//   FL_WARN("got %d items", n)          // 2 args → printf form  (log_emit_f)
+//
+// Macro-level dispatch (rather than C++ overload resolution) is required
+// because the single-arg stream form is a chained `<<` expression — it
+// only compiles when the macro injects `fl::sstream()` as the LHS.
+// Routing through a function call would force the `<<` chain to evaluate
+// standalone, which fails (`const char*` has no `operator<<(float)`).
+//
+// The dispatch supports up to 16 user arguments in the printf form. The
+// filler list `_FL_M*15, _FL_S` is positioned so the (17 - argc)-th element
+// of the merged list lands at the `NAME` slot:
+//   1 user arg  → NAME = _FL_S  (single → stream)
+//   2..16 args → NAME = _FL_M  (multi  → printf)
+#define _FL_VA_PICK17( \
+    _1, _2, _3, _4, _5, _6, _7, _8, \
+    _9, _10, _11, _12, _13, _14, _15, _16, \
+    NAME, ...) NAME
+
+#define _FL_VA_DISPATCH(_S, _M, ...) \
+    _FL_VA_PICK17(__VA_ARGS__, \
+        _M, _M, _M, _M, _M, _M, _M, _M, \
+        _M, _M, _M, _M, _M, _M, _M, _S)
 
 // =============================================================================
 // Error Macros (FL_ERROR)
 // =============================================================================
 
+// Per-kind dispatch helpers — _FL_*_S = single-arg stream form; _FL_*_M = multi-arg printf form.
+#define _FL_ERROR_S(X) ::fl::detail::log_emit( \
+    ::fl::detail::log_kind::ERROR, \
+    ::fl::fastled_file_offset(__FILE__), int(__LINE__), \
+    ::fl::sstream() << X)
+#define _FL_ERROR_M(...) ::fl::detail::log_emit_f( \
+    ::fl::detail::log_kind::ERROR, \
+    ::fl::fastled_file_offset(__FILE__), int(__LINE__), \
+    __VA_ARGS__)
+
 #ifndef FASTLED_ERROR
-// FASTLED_ERROR: Supports stream-style formatting with << operator.
-// Routes through fl::detail::log_emit so the prefix-format chain
-// is single-copy in libFastLED instead of inlined at every site.
-#define FASTLED_ERROR(MSG) fl::detail::log_emit( \
-    fl::detail::log_kind::ERROR, \
-    fl::fastled_file_offset(__FILE__), int(__LINE__), \
-    fl::sstream() << MSG)
-#define FASTLED_ERROR_IF(COND, MSG) do { if (COND) FASTLED_ERROR(MSG); } while(0)
+// FASTLED_ERROR: Supports both stream-style (<<) and printf-style formatting via
+// argument-count dispatch — see #3272.
+#define FASTLED_ERROR(...) _FL_VA_DISPATCH(_FL_ERROR_S, _FL_ERROR_M, __VA_ARGS__)(__VA_ARGS__)
+#define FASTLED_ERROR_IF(COND, ...) do { if (COND) FASTLED_ERROR(__VA_ARGS__); } while(0)
 #endif
 
 #ifndef FL_ERROR
 #if FASTLED_LOG_RUNTIME_ENABLED
-// FL_ERROR: routes through fl::detail::log_emit (see header banner above).
-#define FL_ERROR(X) fl::detail::log_emit( \
-    fl::detail::log_kind::ERROR, \
-    fl::fastled_file_offset(__FILE__), int(__LINE__), \
-    fl::sstream() << X)
-#define FL_ERROR_F(...) fl::detail::log_emit_f( \
-    fl::detail::log_kind::ERROR, \
-    fl::fastled_file_offset(__FILE__), int(__LINE__), \
-    __VA_ARGS__)
-#define FL_ERROR_IF(COND, MSG) do { if (COND) FL_ERROR(MSG); } while(0)
-#define FL_ERROR_F_IF(COND, ...) do { if (COND) FL_ERROR_F(__VA_ARGS__); } while(0)
+// FL_ERROR: unified entry point — accepts both `"foo " << x` and `"foo %d", x`
+// via macro-level argument-count dispatch. See #3272.
+#define FL_ERROR(...) _FL_VA_DISPATCH(_FL_ERROR_S, _FL_ERROR_M, __VA_ARGS__)(__VA_ARGS__)
+// _F suffix preserved as alias for backward compatibility (#3272). New code
+// should drop the _F suffix and rely on argument-count dispatch.
+#define FL_ERROR_F(...) FL_ERROR(__VA_ARGS__)
+#define FL_ERROR_IF(COND, ...) do { if (COND) FL_ERROR(__VA_ARGS__); } while(0)
+#define FL_ERROR_F_IF(COND, ...) FL_ERROR_IF(COND, __VA_ARGS__)
 #else
 // No-op macros — either memory-constrained platform or FASTLED_LOG_VERBOSITY=0.
-#define FL_ERROR(X) do { } while(0)
+// Args are dropped entirely (matching pre-#3272 behaviour of FL_*_F). See
+// commit notes — earlier draft used `sstream_noop()` type-check but that
+// forced evaluation of args declared only under FASTLED_LOG_*_ENABLED.
+#define FL_ERROR(...) do { } while(0)
 #define FL_ERROR_F(...) do { } while(0)
-#define FL_ERROR_IF(COND, MSG) do { } while(0)
+#define FL_ERROR_IF(COND, ...) do { } while(0)
 #define FL_ERROR_F_IF(COND, ...) do { } while(0)
 #endif
 #endif
@@ -260,49 +297,49 @@ void log_emit(log_kind kind, const char* file, int line, fl::sstream& body) FL_N
 // Warning Macros (FL_WARN)
 // =============================================================================
 
+// Per-kind dispatch helpers — _FL_WARN_S = single-arg stream form; _FL_WARN_M = multi-arg printf form.
+#define _FL_WARN_S(X) ::fl::detail::log_emit( \
+    ::fl::detail::log_kind::WARN, \
+    ::fl::fastled_file_offset(__FILE__), int(__LINE__), \
+    ::fl::sstream() << X)
+#define _FL_WARN_M(...) ::fl::detail::log_emit_f( \
+    ::fl::detail::log_kind::WARN, \
+    ::fl::fastled_file_offset(__FILE__), int(__LINE__), \
+    __VA_ARGS__)
+
 #ifndef FASTLED_WARN
-// FASTLED_WARN: Supports stream-style formatting with << operator.
-#define FASTLED_WARN(MSG) fl::detail::log_emit( \
-    fl::detail::log_kind::WARN, \
-    fl::fastled_file_offset(__FILE__), int(__LINE__), \
-    fl::sstream() << MSG)
-#define FASTLED_WARN_IF(COND, MSG) do { if (COND) FASTLED_WARN(MSG); } while(0)
+// FASTLED_WARN: Supports both stream-style (<<) and printf-style formatting via
+// argument-count dispatch — see #3272.
+#define FASTLED_WARN(...) _FL_VA_DISPATCH(_FL_WARN_S, _FL_WARN_M, __VA_ARGS__)(__VA_ARGS__)
+#define FASTLED_WARN_IF(COND, ...) do { if (COND) FASTLED_WARN(__VA_ARGS__); } while(0)
 #endif
 
 #ifndef FL_WARN
 #if FASTLED_LOG_RUNTIME_ENABLED
-// FL_WARN: routes through fl::detail::log_emit (see header banner above).
-#define FL_WARN(X) fl::detail::log_emit( \
-    fl::detail::log_kind::WARN, \
-    fl::fastled_file_offset(__FILE__), int(__LINE__), \
-    fl::sstream() << X)
-#define FL_WARN_F(...) fl::detail::log_emit_f( \
-    fl::detail::log_kind::WARN, \
-    fl::fastled_file_offset(__FILE__), int(__LINE__), \
-    __VA_ARGS__)
-#define FL_WARN_IF(COND, MSG) do { if (COND) FL_WARN(MSG); } while(0)
-#define FL_WARN_F_IF(COND, ...) do { if (COND) FL_WARN_F(__VA_ARGS__); } while(0)
+// FL_WARN: unified entry point — accepts both `"foo " << x` and `"foo %d", x`
+// via macro-level argument-count dispatch. Single-arg → stream form (legacy
+// compatible); two-or-more args → printf form. See #3272.
+#define FL_WARN(...) _FL_VA_DISPATCH(_FL_WARN_S, _FL_WARN_M, __VA_ARGS__)(__VA_ARGS__)
+// _F suffix preserved as alias for backward compatibility (#3272). New code
+// should drop the _F suffix and rely on argument-count dispatch.
+#define FL_WARN_F(...) FL_WARN(__VA_ARGS__)
+#define FL_WARN_IF(COND, ...) do { if (COND) FL_WARN(__VA_ARGS__); } while(0)
+#define FL_WARN_F_IF(COND, ...) FL_WARN_IF(COND, __VA_ARGS__)
 
 // FL_WARN_ONCE: Emits warning only once per unique location (static flag per call site)
 // Uses static bool flag initialized to false - first call prints, subsequent calls no-op
-#define FL_WARN_ONCE(X) do { \
+#define FL_WARN_ONCE(...) do { \
     static bool _warned = false; \
     if (!_warned) { \
         _warned = true; \
-        FL_WARN(X); \
+        FL_WARN(__VA_ARGS__); \
     } \
 } while(0)
-#define FL_WARN_F_ONCE(...) do { \
-    static bool _warned = false; \
-    if (!_warned) { \
-        _warned = true; \
-        FL_WARN_F(__VA_ARGS__); \
-    } \
-} while(0)
+#define FL_WARN_F_ONCE(...) FL_WARN_ONCE(__VA_ARGS__)
 
 // FL_WARN_FMT: Alias for FL_WARN (kept for backwards compatibility)
-#define FL_WARN_FMT(X) FL_WARN(X)
-#define FL_WARN_FMT_IF(COND, MSG) FL_WARN_IF(COND, MSG)
+#define FL_WARN_FMT(...) FL_WARN(__VA_ARGS__)
+#define FL_WARN_FMT_IF(COND, ...) FL_WARN_IF(COND, __VA_ARGS__)
 
 // FL_WARN_LIT: defined below outside the FASTLED_LOG_RUNTIME_ENABLED block —
 // gated on FASTLED_LOG_LITE_ENABLED so it stays available on Low-memory
@@ -310,33 +347,30 @@ void log_emit(log_kind kind, const char* file, int line, fl::sstream& body) FL_N
 
 // FL_WARN_EVERY: Rate-limited warning that prints at most once per interval
 // Uses static timestamp to track last print time - throttles output in tight loops
-#define FL_WARN_EVERY(MILLIS, X) do { \
+#define FL_WARN_EVERY(MILLIS, ...) do { \
     static fl::u32 _last_warn_time = 0; \
     fl::u32 _now = fl::millis(); \
     if (_now - _last_warn_time >= (MILLIS)) { \
         _last_warn_time = _now; \
-        FL_WARN(X); \
+        FL_WARN(__VA_ARGS__); \
     } \
 } while(0)
-#define FL_WARN_F_EVERY(MILLIS, ...) do { \
-    static fl::u32 _last_warn_time = 0; \
-    fl::u32 _now = fl::millis(); \
-    if (_now - _last_warn_time >= (MILLIS)) { \
-        _last_warn_time = _now; \
-        FL_WARN_F(__VA_ARGS__); \
-    } \
-} while(0)
+#define FL_WARN_F_EVERY(MILLIS, ...) FL_WARN_EVERY(MILLIS, __VA_ARGS__)
 #else
 // No-op macros — either memory-constrained platform or FASTLED_LOG_VERBOSITY=0.
-#define FL_WARN(X) do { } while(0)
+// Args dropped entirely — see the corresponding FL_ERROR section above for
+// the rationale (pre-existing call sites declare some args only under
+// FASTLED_LOG_*_ENABLED, so any `if(false)` type-check would force a build
+// error).
+#define FL_WARN(...) do { } while(0)
 #define FL_WARN_F(...) do { } while(0)
-#define FL_WARN_IF(COND, MSG) if(false) { void(fl::sstream_noop() << MSG); }
+#define FL_WARN_IF(COND, ...) do { } while(0)
 #define FL_WARN_F_IF(COND, ...) do { } while(0)
-#define FL_WARN_ONCE(X) do { } while(0)
+#define FL_WARN_ONCE(...) do { } while(0)
 #define FL_WARN_F_ONCE(...) do { } while(0)
-#define FL_WARN_FMT(X) do { } while(0)
-#define FL_WARN_FMT_IF(COND, MSG) do { } while(0)
-#define FL_WARN_EVERY(MILLIS, X) do { } while(0)
+#define FL_WARN_FMT(...) do { } while(0)
+#define FL_WARN_FMT_IF(COND, ...) do { } while(0)
+#define FL_WARN_EVERY(MILLIS, ...) do { } while(0)
 #define FL_WARN_F_EVERY(MILLIS, ...) do { } while(0)
 #endif
 #endif
@@ -359,38 +393,47 @@ void log_emit(log_kind kind, const char* file, int line, fl::sstream& body) FL_N
 // Info Macros (FL_INFO)
 // =============================================================================
 
+// Per-kind dispatch helpers — _FL_INFO_S = single-arg stream form; _FL_INFO_M = multi-arg printf form.
+#define _FL_INFO_S(X) ::fl::detail::log_emit( \
+    ::fl::detail::log_kind::INFO, \
+    ::fl::fastled_file_offset(__FILE__), int(__LINE__), \
+    ::fl::sstream() << X)
+#define _FL_INFO_M(...) ::fl::detail::log_emit_f( \
+    ::fl::detail::log_kind::INFO, \
+    ::fl::fastled_file_offset(__FILE__), int(__LINE__), \
+    __VA_ARGS__)
+
 #ifndef FASTLED_INFO
-// FASTLED_INFO: Supports stream-style formatting with << operator.
-#define FASTLED_INFO(MSG) fl::detail::log_emit( \
-    fl::detail::log_kind::INFO, \
-    fl::fastled_file_offset(__FILE__), int(__LINE__), \
-    fl::sstream() << MSG)
-#define FASTLED_INFO_IF(COND, MSG) do { if (COND) FASTLED_INFO(MSG); } while(0)
+// FASTLED_INFO: Supports both stream-style (<<) and printf-style formatting via
+// argument-count dispatch — see #3272.
+#define FASTLED_INFO(...) _FL_VA_DISPATCH(_FL_INFO_S, _FL_INFO_M, __VA_ARGS__)(__VA_ARGS__)
+#define FASTLED_INFO_IF(COND, ...) do { if (COND) FASTLED_INFO(__VA_ARGS__); } while(0)
 #endif
 
 #ifndef FL_INFO
 #if FASTLED_LOG_RUNTIME_ENABLED
-// FL_INFO: routes through fl::detail::log_emit (see header banner above).
-#define FL_INFO(X) fl::detail::log_emit( \
-    fl::detail::log_kind::INFO, \
-    fl::fastled_file_offset(__FILE__), int(__LINE__), \
-    fl::sstream() << X)
-#define FL_INFO_IF(COND, MSG) do { if (COND) FL_INFO(MSG); } while(0)
+// FL_INFO: unified entry point — accepts both stream- and printf-style. See #3272.
+#define FL_INFO(...) _FL_VA_DISPATCH(_FL_INFO_S, _FL_INFO_M, __VA_ARGS__)(__VA_ARGS__)
+#define FL_INFO_F(...) FL_INFO(__VA_ARGS__)
+#define FL_INFO_IF(COND, ...) do { if (COND) FL_INFO(__VA_ARGS__); } while(0)
+#define FL_INFO_F_IF(COND, ...) FL_INFO_IF(COND, __VA_ARGS__)
 
 // FL_INFO_ONCE: Emits info only once per unique location (static flag per call site)
 // Uses static bool flag initialized to false - first call prints, subsequent calls no-op
-#define FL_INFO_ONCE(X) do { \
+#define FL_INFO_ONCE(...) do { \
     static bool _infoed = false; \
     if (!_infoed) { \
         _infoed = true; \
-        FL_INFO(X); \
+        FL_INFO(__VA_ARGS__); \
     } \
 } while(0)
 #else
 // No-op macros — either memory-constrained platform or FASTLED_LOG_VERBOSITY=0.
-#define FL_INFO(X) do { } while(0)
-#define FL_INFO_IF(COND, MSG) do { } while(0)
-#define FL_INFO_ONCE(X) do { } while(0)
+#define FL_INFO(...) do { } while(0)
+#define FL_INFO_F(...) do { } while(0)
+#define FL_INFO_IF(COND, ...) do { } while(0)
+#define FL_INFO_F_IF(COND, ...) do { } while(0)
+#define FL_INFO_ONCE(...) do { } while(0)
 #endif
 #endif
 
@@ -519,34 +562,34 @@ void log_emit(log_kind kind, const char* file, int line, fl::sstream& body) FL_N
 /// Example:
 ///   FL_PRINT("Value: " << x);
 ///   FL_PRINT(ss.str());
+// Per-form dispatch helpers — _FL_PRINT_S = stream; _FL_PRINT_M = printf.
+// Unlike FL_WARN, no "<file>(<line>): WARN:" prefix is prepended.
+#define _FL_PRINT_S(X) ::fl::println((::fl::sstream() << X).c_str())
+#define _FL_PRINT_M(...) do { ::fl::printf(__VA_ARGS__); ::fl::printf("\n"); } while(0)
+
 #ifndef FL_PRINT
 #if FASTLED_LOG_RUNTIME_ENABLED
-#define FL_PRINT(X) fl::println((fl::sstream() << X).c_str())
-#define FL_PRINT_F(...) do { fl::printf(__VA_ARGS__); fl::printf("\n"); } while(0)
+// FL_PRINT: unified entry point — accepts both stream- and printf-style.
+// No "WARN:" / "file(line):" prefix (unlike FL_WARN). See #3272.
+#define FL_PRINT(...) _FL_VA_DISPATCH(_FL_PRINT_S, _FL_PRINT_M, __VA_ARGS__)(__VA_ARGS__)
+#define FL_PRINT_F(...) FL_PRINT(__VA_ARGS__)
 
 // FL_PRINT_EVERY: Rate-limited print that outputs at most once per interval
 // Uses static timestamp to track last print time - throttles output in tight loops
-#define FL_PRINT_EVERY(MILLIS, X) do { \
+#define FL_PRINT_EVERY(MILLIS, ...) do { \
     static fl::u32 _last_print_time = 0; \
     fl::u32 _now = fl::millis(); \
     if (_now - _last_print_time >= (MILLIS)) { \
         _last_print_time = _now; \
-        FL_PRINT(X); \
+        FL_PRINT(__VA_ARGS__); \
     } \
 } while(0)
-#define FL_PRINT_F_EVERY(MILLIS, ...) do { \
-    static fl::u32 _last_print_time = 0; \
-    fl::u32 _now = fl::millis(); \
-    if (_now - _last_print_time >= (MILLIS)) { \
-        _last_print_time = _now; \
-        FL_PRINT_F(__VA_ARGS__); \
-    } \
-} while(0)
+#define FL_PRINT_F_EVERY(MILLIS, ...) FL_PRINT_EVERY(MILLIS, __VA_ARGS__)
 #else
 // No-op macro for memory-constrained platforms
-#define FL_PRINT(X) do { } while(0)
+#define FL_PRINT(...) do { } while(0)
 #define FL_PRINT_F(...) do { } while(0)
-#define FL_PRINT_EVERY(MILLIS, X) do { } while(0)
+#define FL_PRINT_EVERY(MILLIS, ...) do { } while(0)
 #define FL_PRINT_F_EVERY(MILLIS, ...) do { } while(0)
 #endif
 #endif
@@ -561,71 +604,71 @@ void log_emit(log_kind kind, const char* file, int line, fl::sstream& body) FL_N
 /// @brief Serial Peripheral Interface (SPI) logging
 /// Logs SPI configuration, initialization, and transfers
 #ifdef FASTLED_LOG_SPI_ENABLED
-    #define FL_LOG_SPI(X) FL_WARN(X)
-    #define FL_LOG_SPI_F(...) FL_WARN_F(__VA_ARGS__)
+    #define FL_LOG_SPI(...) FL_WARN(__VA_ARGS__)
+    #define FL_LOG_SPI_F(...) FL_WARN(__VA_ARGS__)
 #else
-    #define FL_LOG_SPI(X) FL_DBG_NO_OP(X)
-    #define FL_LOG_SPI_F(...) do {} while(0)
+    #define FL_LOG_SPI(...) do { } while(0)
+    #define FL_LOG_SPI_F(...) FL_LOG_SPI(__VA_ARGS__)
 #endif
 
 /// @brief Remote Control Module (RMT) logging (ESP32)
 /// Logs RMT channel configuration, timing, and signal generation
 #ifdef FASTLED_LOG_RMT_ENABLED
-    #define FL_LOG_RMT(X) FL_WARN(X)
-    #define FL_LOG_RMT_F(...) FL_WARN_F(__VA_ARGS__)
+    #define FL_LOG_RMT(...) FL_WARN(__VA_ARGS__)
+    #define FL_LOG_RMT_F(...) FL_WARN(__VA_ARGS__)
 #else
-    #define FL_LOG_RMT(X) FL_DBG_NO_OP(X)
-    #define FL_LOG_RMT_F(...) do {} while(0)
+    #define FL_LOG_RMT(...) do { } while(0)
+    #define FL_LOG_RMT_F(...) FL_LOG_RMT(__VA_ARGS__)
 #endif
 
 /// @brief Parallel I/O (Parlio) logging (ESP32-P4)
 /// Logs Parlio configuration, GPIO setup, and parallel transfers
 #ifdef FASTLED_LOG_PARLIO_ENABLED
-    #define FL_LOG_PARLIO(X) FL_WARN(X)
-    #define FL_LOG_PARLIO_F(...) FL_WARN_F(__VA_ARGS__)
+    #define FL_LOG_PARLIO(...) FL_WARN(__VA_ARGS__)
+    #define FL_LOG_PARLIO_F(...) FL_WARN(__VA_ARGS__)
 #else
-    #define FL_LOG_PARLIO(X) FL_DBG_NO_OP(X)
-    #define FL_LOG_PARLIO_F(...) do {} while(0)
+    #define FL_LOG_PARLIO(...) do { } while(0)
+    #define FL_LOG_PARLIO_F(...) FL_LOG_PARLIO(__VA_ARGS__)
 #endif
 
 /// @brief Audio processing logging
 /// Logs audio sample processing, FFT computation, beat detection, and detector updates
 #ifdef FASTLED_LOG_AUDIO_ENABLED
-    #define FL_LOG_AUDIO(X) FL_WARN(X)
-    #define FL_LOG_AUDIO_F(...) FL_WARN_F(__VA_ARGS__)
+    #define FL_LOG_AUDIO(...) FL_WARN(__VA_ARGS__)
+    #define FL_LOG_AUDIO_F(...) FL_WARN(__VA_ARGS__)
 #else
-    #define FL_LOG_AUDIO(X) FL_DBG_NO_OP(X)
-    #define FL_LOG_AUDIO_F(...) do {} while(0)
+    #define FL_LOG_AUDIO(...) do { } while(0)
+    #define FL_LOG_AUDIO_F(...) FL_LOG_AUDIO(__VA_ARGS__)
 #endif
 
 /// @brief Interrupt handling logging
 /// Logs interrupt installation, handler registration, and ISR events
 #ifdef FASTLED_LOG_INTERRUPT_ENABLED
-    #define FL_LOG_INTERRUPT(X) FL_WARN(X)
-    #define FL_LOG_INTERRUPT_F(...) FL_WARN_F(__VA_ARGS__)
+    #define FL_LOG_INTERRUPT(...) FL_WARN(__VA_ARGS__)
+    #define FL_LOG_INTERRUPT_F(...) FL_WARN(__VA_ARGS__)
 #else
-    #define FL_LOG_INTERRUPT(X) FL_DBG_NO_OP(X)
-    #define FL_LOG_INTERRUPT_F(...) do {} while(0)
+    #define FL_LOG_INTERRUPT(...) do { } while(0)
+    #define FL_LOG_INTERRUPT_F(...) FL_LOG_INTERRUPT(__VA_ARGS__)
 #endif
 
 /// @brief FlexIO logging (Teensy 4.x)
 /// Logs FlexIO configuration, pin setup, DMA, and signal generation
 #ifdef FASTLED_LOG_FLEXIO_ENABLED
-    #define FL_LOG_FLEXIO(X) FL_WARN(X)
-    #define FL_LOG_FLEXIO_F(...) FL_WARN_F(__VA_ARGS__)
+    #define FL_LOG_FLEXIO(...) FL_WARN(__VA_ARGS__)
+    #define FL_LOG_FLEXIO_F(...) FL_WARN(__VA_ARGS__)
 #else
-    #define FL_LOG_FLEXIO(X) FL_DBG_NO_OP(X)
-    #define FL_LOG_FLEXIO_F(...) do {} while(0)
+    #define FL_LOG_FLEXIO(...) do { } while(0)
+    #define FL_LOG_FLEXIO_F(...) FL_LOG_FLEXIO(__VA_ARGS__)
 #endif
 
 /// @brief ObjectFLED logging (Teensy 4.x)
 /// Logs ObjectFLED configuration, pin mapping, and DMA transfers
 #ifdef FASTLED_LOG_OBJECTFLED_ENABLED
-    #define FL_LOG_OBJECTFLED(X) FL_WARN(X)
-    #define FL_LOG_OBJECTFLED_F(...) FL_WARN_F(__VA_ARGS__)
+    #define FL_LOG_OBJECTFLED(...) FL_WARN(__VA_ARGS__)
+    #define FL_LOG_OBJECTFLED_F(...) FL_WARN(__VA_ARGS__)
 #else
-    #define FL_LOG_OBJECTFLED(X) FL_DBG_NO_OP(X)
-    #define FL_LOG_OBJECTFLED_F(...) do {} while(0)
+    #define FL_LOG_OBJECTFLED(...) do { } while(0)
+    #define FL_LOG_OBJECTFLED_F(...) FL_LOG_OBJECTFLED(__VA_ARGS__)
 #endif
 
 /// @}
@@ -692,15 +735,17 @@ void log_emit(log_kind kind, const char* file, int line, fl::sstream& body) FL_N
 /// @param X Stream-style expression (e.g., "msg " << var)
 /// @warning This macro uses heap allocation (fl::string) and should NOT be used in ISR context
 /// @see FL_LOG_ASYNC_ISR for ISR-safe const char* only variant
-#define FL_LOG_ASYNC(logger, X) \
-    do { \
-        (logger).push((fl::sstream() << X).str()); \
-    } while(0)
+// Per-form dispatch helpers — _S = stream form, _M = printf form. Pushes the
+// composed message to the caller-provided AsyncLogger instance.
+#define _FL_LOG_ASYNC_S(logger, X) do { (logger).push((::fl::sstream() << X).str()); } while(0)
+#define _FL_LOG_ASYNC_M(logger, ...) do { (logger).push(::fl::detail::log_format_string(__VA_ARGS__)); } while(0)
 
-#define FL_LOG_ASYNC_F(logger, ...) \
-    do { \
-        (logger).push(fl::detail::log_format_string(__VA_ARGS__)); \
-    } while(0)
+// Unified async-log dispatch (#3272). Single-arg payload → stream form (legacy
+// compatible); two-or-more args → printf form via log_format_string.
+#define FL_LOG_ASYNC(logger, ...) _FL_VA_DISPATCH(_FL_LOG_ASYNC_S, _FL_LOG_ASYNC_M, __VA_ARGS__)(logger, __VA_ARGS__)
+
+// _F suffix preserved as alias for backward compatibility.
+#define FL_LOG_ASYNC_F(logger, ...) FL_LOG_ASYNC(logger, __VA_ARGS__)
 
 /// @brief ISR-safe async logging macro (const char* literals only, zero heap allocation)
 /// @param logger Reference to AsyncLogger instance (e.g., get_parlio_async_logger_isr())
@@ -719,16 +764,16 @@ void log_emit(log_kind kind, const char* file, int line, fl::sstream& body) FL_N
 
 #ifdef FASTLED_LOG_SPI_ENABLED
     #define FL_LOG_SPI_ASYNC_ISR(X) FL_LOG_ASYNC_ISR(fl::get_spi_async_logger_isr(), X)
-    #define FL_LOG_SPI_ASYNC_MAIN(X) FL_LOG_ASYNC(fl::get_spi_async_logger_main(), X)
-    #define FL_LOG_SPI_ASYNC_MAIN_F(...) FL_LOG_ASYNC_F(fl::get_spi_async_logger_main(), __VA_ARGS__)
+    #define FL_LOG_SPI_ASYNC_MAIN(...) FL_LOG_ASYNC(fl::get_spi_async_logger_main(), __VA_ARGS__)
+    #define FL_LOG_SPI_ASYNC_MAIN_F(...) FL_LOG_SPI_ASYNC_MAIN(__VA_ARGS__)
     #define FL_LOG_SPI_ASYNC_FLUSH() do { \
         fl::get_spi_async_logger_isr().flush(); \
         fl::get_spi_async_logger_main().flush(); \
     } while(0)
 #else
     #define FL_LOG_SPI_ASYNC_ISR(X) FL_DBG_NO_OP(X)
-    #define FL_LOG_SPI_ASYNC_MAIN(X) FL_DBG_NO_OP(X)
-    #define FL_LOG_SPI_ASYNC_MAIN_F(...) do {} while(0)
+    #define FL_LOG_SPI_ASYNC_MAIN(...) do { } while(0)
+    #define FL_LOG_SPI_ASYNC_MAIN_F(...) FL_LOG_SPI_ASYNC_MAIN(__VA_ARGS__)
     #define FL_LOG_SPI_ASYNC_FLUSH() do {} while(0)
 #endif
 
@@ -738,16 +783,16 @@ void log_emit(log_kind kind, const char* file, int line, fl::sstream& body) FL_N
 
 #ifdef FASTLED_LOG_RMT_ENABLED
     #define FL_LOG_RMT_ASYNC_ISR(X) FL_LOG_ASYNC_ISR(fl::get_rmt_async_logger_isr(), X)
-    #define FL_LOG_RMT_ASYNC_MAIN(X) FL_LOG_ASYNC(fl::get_rmt_async_logger_main(), X)
-    #define FL_LOG_RMT_ASYNC_MAIN_F(...) FL_LOG_ASYNC_F(fl::get_rmt_async_logger_main(), __VA_ARGS__)
+    #define FL_LOG_RMT_ASYNC_MAIN(...) FL_LOG_ASYNC(fl::get_rmt_async_logger_main(), __VA_ARGS__)
+    #define FL_LOG_RMT_ASYNC_MAIN_F(...) FL_LOG_RMT_ASYNC_MAIN(__VA_ARGS__)
     #define FL_LOG_RMT_ASYNC_FLUSH() do { \
         fl::get_rmt_async_logger_isr().flush(); \
         fl::get_rmt_async_logger_main().flush(); \
     } while(0)
 #else
     #define FL_LOG_RMT_ASYNC_ISR(X) FL_DBG_NO_OP(X)
-    #define FL_LOG_RMT_ASYNC_MAIN(X) FL_DBG_NO_OP(X)
-    #define FL_LOG_RMT_ASYNC_MAIN_F(...) do {} while(0)
+    #define FL_LOG_RMT_ASYNC_MAIN(...) do { } while(0)
+    #define FL_LOG_RMT_ASYNC_MAIN_F(...) FL_LOG_RMT_ASYNC_MAIN(__VA_ARGS__)
     #define FL_LOG_RMT_ASYNC_FLUSH() do {} while(0)
 #endif
 
@@ -757,16 +802,16 @@ void log_emit(log_kind kind, const char* file, int line, fl::sstream& body) FL_N
 
 #ifdef FASTLED_LOG_PARLIO_ENABLED
     #define FL_LOG_PARLIO_ASYNC_ISR(X) FL_LOG_ASYNC_ISR(fl::get_parlio_async_logger_isr(), X)
-    #define FL_LOG_PARLIO_ASYNC_MAIN(X) FL_LOG_ASYNC(fl::get_parlio_async_logger_main(), X)
-    #define FL_LOG_PARLIO_ASYNC_MAIN_F(...) FL_LOG_ASYNC_F(fl::get_parlio_async_logger_main(), __VA_ARGS__)
+    #define FL_LOG_PARLIO_ASYNC_MAIN(...) FL_LOG_ASYNC(fl::get_parlio_async_logger_main(), __VA_ARGS__)
+    #define FL_LOG_PARLIO_ASYNC_MAIN_F(...) FL_LOG_PARLIO_ASYNC_MAIN(__VA_ARGS__)
     #define FL_LOG_PARLIO_ASYNC_FLUSH() do { \
         fl::get_parlio_async_logger_isr().flush(); \
         fl::get_parlio_async_logger_main().flush(); \
     } while(0)
 #else
     #define FL_LOG_PARLIO_ASYNC_ISR(X) FL_DBG_NO_OP(X)
-    #define FL_LOG_PARLIO_ASYNC_MAIN(X) FL_DBG_NO_OP(X)
-    #define FL_LOG_PARLIO_ASYNC_MAIN_F(...) do {} while(0)
+    #define FL_LOG_PARLIO_ASYNC_MAIN(...) do { } while(0)
+    #define FL_LOG_PARLIO_ASYNC_MAIN_F(...) FL_LOG_PARLIO_ASYNC_MAIN(__VA_ARGS__)
     #define FL_LOG_PARLIO_ASYNC_FLUSH() do {} while(0)
 #endif
 
@@ -776,16 +821,16 @@ void log_emit(log_kind kind, const char* file, int line, fl::sstream& body) FL_N
 
 #ifdef FASTLED_LOG_AUDIO_ENABLED
     #define FL_LOG_AUDIO_ASYNC_ISR(X) FL_LOG_ASYNC_ISR(fl::get_audio_async_logger_isr(), X)
-    #define FL_LOG_AUDIO_ASYNC_MAIN(X) FL_LOG_ASYNC(fl::get_audio_async_logger_main(), X)
-    #define FL_LOG_AUDIO_ASYNC_MAIN_F(...) FL_LOG_ASYNC_F(fl::get_audio_async_logger_main(), __VA_ARGS__)
+    #define FL_LOG_AUDIO_ASYNC_MAIN(...) FL_LOG_ASYNC(fl::get_audio_async_logger_main(), __VA_ARGS__)
+    #define FL_LOG_AUDIO_ASYNC_MAIN_F(...) FL_LOG_AUDIO_ASYNC_MAIN(__VA_ARGS__)
     #define FL_LOG_AUDIO_ASYNC_FLUSH() do { \
         fl::get_audio_async_logger_isr().flush(); \
         fl::get_audio_async_logger_main().flush(); \
     } while(0)
 #else
     #define FL_LOG_AUDIO_ASYNC_ISR(X) FL_DBG_NO_OP(X)
-    #define FL_LOG_AUDIO_ASYNC_MAIN(X) FL_DBG_NO_OP(X)
-    #define FL_LOG_AUDIO_ASYNC_MAIN_F(...) do {} while(0)
+    #define FL_LOG_AUDIO_ASYNC_MAIN(...) do { } while(0)
+    #define FL_LOG_AUDIO_ASYNC_MAIN_F(...) FL_LOG_AUDIO_ASYNC_MAIN(__VA_ARGS__)
     #define FL_LOG_AUDIO_ASYNC_FLUSH() do {} while(0)
 #endif
 
@@ -795,16 +840,16 @@ void log_emit(log_kind kind, const char* file, int line, fl::sstream& body) FL_N
 
 #ifdef FASTLED_LOG_INTERRUPT_ENABLED
     #define FL_LOG_INTERRUPT_ASYNC_ISR(X) FL_LOG_ASYNC_ISR(fl::get_interrupt_async_logger_isr(), X)
-    #define FL_LOG_INTERRUPT_ASYNC_MAIN(X) FL_LOG_ASYNC(fl::get_interrupt_async_logger_main(), X)
-    #define FL_LOG_INTERRUPT_ASYNC_MAIN_F(...) FL_LOG_ASYNC_F(fl::get_interrupt_async_logger_main(), __VA_ARGS__)
+    #define FL_LOG_INTERRUPT_ASYNC_MAIN(...) FL_LOG_ASYNC(fl::get_interrupt_async_logger_main(), __VA_ARGS__)
+    #define FL_LOG_INTERRUPT_ASYNC_MAIN_F(...) FL_LOG_INTERRUPT_ASYNC_MAIN(__VA_ARGS__)
     #define FL_LOG_INTERRUPT_ASYNC_FLUSH() do { \
         fl::get_interrupt_async_logger_isr().flush(); \
         fl::get_interrupt_async_logger_main().flush(); \
     } while(0)
 #else
     #define FL_LOG_INTERRUPT_ASYNC_ISR(X) FL_DBG_NO_OP(X)
-    #define FL_LOG_INTERRUPT_ASYNC_MAIN(X) FL_DBG_NO_OP(X)
-    #define FL_LOG_INTERRUPT_ASYNC_MAIN_F(...) do {} while(0)
+    #define FL_LOG_INTERRUPT_ASYNC_MAIN(...) do { } while(0)
+    #define FL_LOG_INTERRUPT_ASYNC_MAIN_F(...) FL_LOG_INTERRUPT_ASYNC_MAIN(__VA_ARGS__)
     #define FL_LOG_INTERRUPT_ASYNC_FLUSH() do {} while(0)
 #endif
 
@@ -814,16 +859,16 @@ void log_emit(log_kind kind, const char* file, int line, fl::sstream& body) FL_N
 
 #ifdef FASTLED_LOG_FLEXIO_ENABLED
     #define FL_LOG_FLEXIO_ASYNC_ISR(X) FL_LOG_ASYNC_ISR(fl::get_flexio_async_logger_isr(), X)
-    #define FL_LOG_FLEXIO_ASYNC_MAIN(X) FL_LOG_ASYNC(fl::get_flexio_async_logger_main(), X)
-    #define FL_LOG_FLEXIO_ASYNC_MAIN_F(...) FL_LOG_ASYNC_F(fl::get_flexio_async_logger_main(), __VA_ARGS__)
+    #define FL_LOG_FLEXIO_ASYNC_MAIN(...) FL_LOG_ASYNC(fl::get_flexio_async_logger_main(), __VA_ARGS__)
+    #define FL_LOG_FLEXIO_ASYNC_MAIN_F(...) FL_LOG_FLEXIO_ASYNC_MAIN(__VA_ARGS__)
     #define FL_LOG_FLEXIO_ASYNC_FLUSH() do { \
         fl::get_flexio_async_logger_isr().flush(); \
         fl::get_flexio_async_logger_main().flush(); \
     } while(0)
 #else
     #define FL_LOG_FLEXIO_ASYNC_ISR(X) FL_DBG_NO_OP(X)
-    #define FL_LOG_FLEXIO_ASYNC_MAIN(X) FL_DBG_NO_OP(X)
-    #define FL_LOG_FLEXIO_ASYNC_MAIN_F(...) do {} while(0)
+    #define FL_LOG_FLEXIO_ASYNC_MAIN(...) do { } while(0)
+    #define FL_LOG_FLEXIO_ASYNC_MAIN_F(...) FL_LOG_FLEXIO_ASYNC_MAIN(__VA_ARGS__)
     #define FL_LOG_FLEXIO_ASYNC_FLUSH() do {} while(0)
 #endif
 
@@ -833,16 +878,16 @@ void log_emit(log_kind kind, const char* file, int line, fl::sstream& body) FL_N
 
 #ifdef FASTLED_LOG_OBJECTFLED_ENABLED
     #define FL_LOG_OBJECTFLED_ASYNC_ISR(X) FL_LOG_ASYNC_ISR(fl::get_objectfled_async_logger_isr(), X)
-    #define FL_LOG_OBJECTFLED_ASYNC_MAIN(X) FL_LOG_ASYNC(fl::get_objectfled_async_logger_main(), X)
-    #define FL_LOG_OBJECTFLED_ASYNC_MAIN_F(...) FL_LOG_ASYNC_F(fl::get_objectfled_async_logger_main(), __VA_ARGS__)
+    #define FL_LOG_OBJECTFLED_ASYNC_MAIN(...) FL_LOG_ASYNC(fl::get_objectfled_async_logger_main(), __VA_ARGS__)
+    #define FL_LOG_OBJECTFLED_ASYNC_MAIN_F(...) FL_LOG_OBJECTFLED_ASYNC_MAIN(__VA_ARGS__)
     #define FL_LOG_OBJECTFLED_ASYNC_FLUSH() do { \
         fl::get_objectfled_async_logger_isr().flush(); \
         fl::get_objectfled_async_logger_main().flush(); \
     } while(0)
 #else
     #define FL_LOG_OBJECTFLED_ASYNC_ISR(X) FL_DBG_NO_OP(X)
-    #define FL_LOG_OBJECTFLED_ASYNC_MAIN(X) FL_DBG_NO_OP(X)
-    #define FL_LOG_OBJECTFLED_ASYNC_MAIN_F(...) do {} while(0)
+    #define FL_LOG_OBJECTFLED_ASYNC_MAIN(...) do { } while(0)
+    #define FL_LOG_OBJECTFLED_ASYNC_MAIN_F(...) FL_LOG_OBJECTFLED_ASYNC_MAIN(__VA_ARGS__)
     #define FL_LOG_OBJECTFLED_ASYNC_FLUSH() do {} while(0)
 #endif
 

--- a/src/fl/log/log.h
+++ b/src/fl/log/log.h
@@ -7,7 +7,7 @@
 #include "fl/stl/compiler_control.h"  // IWYU pragma: keep - FL_NO_INLINE for log_emit
 
 // =============================================================================
-// FL_LOG_*_ENABLED → FASTLED_LOG_*_ENABLED backward compatibility
+// FL_LOG_*_ENABLED -> FASTLED_LOG_*_ENABLED backward compatibility
 // =============================================================================
 // Users can now use the shorter FL_LOG_*_ENABLED defines. The old
 // FASTLED_LOG_*_ENABLED names still work for backward compatibility.
@@ -40,7 +40,7 @@
 #endif
 
 // =============================================================================
-// FASTLED_LOG_VERBOSITY — release-mode knob to no-op FL_WARN/FL_INFO/
+// FASTLED_LOG_VERBOSITY - release-mode knob to no-op FL_WARN/FL_INFO/
 //                          FL_ERROR/FL_PRINT and free ~20-40 KB of
 //                          `.flash.rodata` string-pool bloat on embedded
 //                          builds. See FastLED #2773 item 2.3.
@@ -49,34 +49,34 @@
 // Each `FL_WARN(...)` / `FL_INFO(...)` / `FL_ERROR(...)` / `FL_PRINT(...)`
 // call site bakes a `__FILE__ + __LINE__ + user-supplied message` literal
 // into `.flash.rodata`. On the ESP32-S3 NEOPIXEL Blink build that pool is
-// ~57 KB — the single biggest `.rodata` contributor (see the audit on
+// ~57 KB - the single biggest `.rodata` contributor (see the audit on
 // #2473). The strings are live only because their call sites are live.
 //
 // Levels (mirror standard log-verbosity conventions; higher = more output):
 //
-//   * `FASTLED_LOG_VERBOSITY == 0` → ALL of FL_WARN/FL_INFO/FL_ERROR/
+//   * `FASTLED_LOG_VERBOSITY == 0` -> ALL of FL_WARN/FL_INFO/FL_ERROR/
 //     FL_PRINT/FL_DBG expand to `do {} while(0)`. Strings, `fl::sstream`
 //     uses, and any transitive `fl::println` references vanish; the
 //     downstream printf chain may shrink further as a result.
-//   * `FASTLED_LOG_VERBOSITY == 1` → current behavior; FL_WARN /
+//   * `FASTLED_LOG_VERBOSITY == 1` -> current behavior; FL_WARN /
 //     FL_INFO / FL_ERROR / FL_PRINT fire on platforms where
 //     `SKETCH_HAS_LARGE_MEMORY` is set. FL_DBG follows its existing
 //     `FASTLED_HAS_DBG` gate.
-//   * `FASTLED_LOG_VERBOSITY >= 2` → reserved for future "even noisier
+//   * `FASTLED_LOG_VERBOSITY >= 2` -> reserved for future "even noisier
 //     than debug" output; currently equivalent to level 1.
 //
 // Default selection (in resolution order):
 //
-//   * `FASTLED_TESTING` is set     → 1 (host unit tests need full diagnostics)
-//   * `NDEBUG` is set (release)    → 0 (drop ~55 KB of FL_WARN/FL_LOG strings
+//   * `FASTLED_TESTING` is set     -> 1 (host unit tests need full diagnostics)
+//   * `NDEBUG` is set (release)    -> 0 (drop ~55 KB of FL_WARN/FL_LOG strings
 //                                      on ESP32-S3 NEOPIXEL Blink; see #2886)
-//   * otherwise (debug builds)     → 1 (preserve current behavior)
+//   * otherwise (debug builds)     -> 1 (preserve current behavior)
 //
 // Users who want logs back on a release build define
 // `-DFASTLED_LOG_VERBOSITY=1` in their build flags or
 // `#define FASTLED_LOG_VERBOSITY 1` before `#include <FastLED.h>`. The
 // per-channel logging defines (`FASTLED_LOG_RMT_ENABLED`, `FASTLED_LOG_SPI_ENABLED`,
-// etc.) are still gated by their own `#define`s — only the verbosity floor
+// etc.) are still gated by their own `#define`s - only the verbosity floor
 // changes here.
 #ifdef FASTLED_TESTING
   // Host unit tests always want the full diagnostic stream so assertion
@@ -97,7 +97,7 @@
 
 // Resolved compile-time gate. Logging fires only when BOTH the platform
 // has a sufficient memory budget AND the user hasn't opted out via
-// `FASTLED_LOG_VERBOSITY=0`. The two gates are independent — embedded
+// `FASTLED_LOG_VERBOSITY=0`. The two gates are independent - embedded
 // targets without `SKETCH_HAS_LARGE_MEMORY` are no-op regardless of the
 // verbosity knob (matching the pre-#2773 behavior on AVR/ATtiny).
 #if SKETCH_HAS_LARGE_MEMORY && (FASTLED_LOG_VERBOSITY >= 1)
@@ -106,10 +106,10 @@
   #define FASTLED_LOG_RUNTIME_ENABLED 0
 #endif
 
-// Lite gate for FL_WARN_LIT / FL_LOG_LIT — string-literal-only macros that
+// Lite gate for FL_WARN_LIT / FL_LOG_LIT - string-literal-only macros that
 // route through fl::println without the sstream / operator<< / log_emit
 // chain. These are intentionally usable on Low-memory targets (LPC845,
-// AVR, ATtiny) where the full FL_WARN pipeline is too expensive — the
+// AVR, ATtiny) where the full FL_WARN pipeline is too expensive - the
 // caller pays for one `fl::println(const char*)` symbol and the literal
 // bytes, nothing more. See FastLED #3002 (LPC845 bring-up).
 #if FASTLED_LOG_VERBOSITY >= 1
@@ -154,7 +154,7 @@ const char *fastled_file_offset(const char *file) FL_NOEXCEPT;
 // then emits via `fl::println(body.c_str())`.
 //
 // Lifetime-safe variant of Path C's "Option 1" attempt. The body
-// sstream temporary lives in the **caller's** frame — its
+// sstream temporary lives in the **caller's** frame - its
 // lifetime extends to the end of the FL_WARN/FL_ERROR/FL_INFO
 // full expression, exactly as the OLD inline macro's temporary
 // did. So `body.c_str()` passed to `println` has the same
@@ -167,7 +167,7 @@ const char *fastled_file_offset(const char *file) FL_NOEXCEPT;
 //   `<< file << "(" << line << "): KIND: " << X`
 // chain at every FL_WARN site (1,372 sites × ~30-50 B of inlined
 // prefix-format code). With this helper, the prefix-format chain
-// is compiled ONCE into libFastLED — each call site only emits
+// is compiled ONCE into libFastLED - each call site only emits
 // the `fl::sstream() << X` ctor + the user's payload chain + a
 // single `log_emit` call.
 namespace fl { namespace detail {
@@ -213,7 +213,7 @@ fl::string log_format_string(const char* format, const Args&... args) FL_NOEXCEP
 //
 // `FL_NO_INLINE` enforces the centralisation. Without it, at -O2
 // with LTO the compiler often inlines `log_emit` at every FL_WARN
-// site — defeating the whole point of moving the prefix chain
+// site - defeating the whole point of moving the prefix chain
 // out-of-line. The noinline attribute is what makes this proposal
 // actually win bytes; bare centralisation alone isn't enough.
 void log_emit(log_kind kind, const char* file, int line, fl::sstream& body) FL_NO_INLINE FL_NOEXCEPT;
@@ -225,12 +225,12 @@ void log_emit(log_kind kind, const char* file, int line, fl::sstream& body) FL_N
 // =============================================================================
 // One `FL_WARN(...)` macro accepts BOTH stream-style and printf-style:
 //
-//   FL_WARN("plain literal")            // 1 arg  → stream form  (sstream())
-//   FL_WARN("foo " << x << " bar")      // 1 arg  → stream form  (sstream())
-//   FL_WARN("got %d items", n)          // 2 args → printf form  (log_emit_f)
+//   FL_WARN("plain literal")            // 1 arg  -> stream form  (sstream())
+//   FL_WARN("foo " << x << " bar")      // 1 arg  -> stream form  (sstream())
+//   FL_WARN("got %d items", n)          // 2 args -> printf form  (log_emit_f)
 //
 // Macro-level dispatch (rather than C++ overload resolution) is required
-// because the single-arg stream form is a chained `<<` expression — it
+// because the single-arg stream form is a chained `<<` expression - it
 // only compiles when the macro injects `fl::sstream()` as the LHS.
 // Routing through a function call would force the `<<` chain to evaluate
 // standalone, which fails (`const char*` has no `operator<<(float)`).
@@ -238,8 +238,8 @@ void log_emit(log_kind kind, const char* file, int line, fl::sstream& body) FL_N
 // The dispatch supports up to 16 user arguments in the printf form. The
 // filler list `_FL_M*15, _FL_S` is positioned so the (17 - argc)-th element
 // of the merged list lands at the `NAME` slot:
-//   1 user arg  → NAME = _FL_S  (single → stream)
-//   2..16 args → NAME = _FL_M  (multi  → printf)
+//   1 user arg  -> NAME = _FL_S  (single -> stream)
+//   2..16 args -> NAME = _FL_M  (multi  -> printf)
 #define _FL_VA_PICK17( \
     _1, _2, _3, _4, _5, _6, _7, _8, \
     _9, _10, _11, _12, _13, _14, _15, _16, \
@@ -254,7 +254,7 @@ void log_emit(log_kind kind, const char* file, int line, fl::sstream& body) FL_N
 // Error Macros (FL_ERROR)
 // =============================================================================
 
-// Per-kind dispatch helpers — _FL_*_S = single-arg stream form; _FL_*_M = multi-arg printf form.
+// Per-kind dispatch helpers - _FL_*_S = single-arg stream form; _FL_*_M = multi-arg printf form.
 #define _FL_ERROR_S(X) ::fl::detail::log_emit( \
     ::fl::detail::log_kind::ERROR, \
     ::fl::fastled_file_offset(__FILE__), int(__LINE__), \
@@ -266,14 +266,14 @@ void log_emit(log_kind kind, const char* file, int line, fl::sstream& body) FL_N
 
 #ifndef FASTLED_ERROR
 // FASTLED_ERROR: Supports both stream-style (<<) and printf-style formatting via
-// argument-count dispatch — see #3272.
+// argument-count dispatch - see #3272.
 #define FASTLED_ERROR(...) _FL_VA_DISPATCH(_FL_ERROR_S, _FL_ERROR_M, __VA_ARGS__)(__VA_ARGS__)
 #define FASTLED_ERROR_IF(COND, ...) do { if (COND) FASTLED_ERROR(__VA_ARGS__); } while(0)
 #endif
 
 #ifndef FL_ERROR
 #if FASTLED_LOG_RUNTIME_ENABLED
-// FL_ERROR: unified entry point — accepts both `"foo " << x` and `"foo %d", x`
+// FL_ERROR: unified entry point - accepts both `"foo " << x` and `"foo %d", x`
 // via macro-level argument-count dispatch. See #3272.
 #define FL_ERROR(...) _FL_VA_DISPATCH(_FL_ERROR_S, _FL_ERROR_M, __VA_ARGS__)(__VA_ARGS__)
 // _F suffix preserved as alias for backward compatibility (#3272). New code
@@ -282,9 +282,9 @@ void log_emit(log_kind kind, const char* file, int line, fl::sstream& body) FL_N
 #define FL_ERROR_IF(COND, ...) do { if (COND) FL_ERROR(__VA_ARGS__); } while(0)
 #define FL_ERROR_F_IF(COND, ...) FL_ERROR_IF(COND, __VA_ARGS__)
 #else
-// No-op macros — either memory-constrained platform or FASTLED_LOG_VERBOSITY=0.
+// No-op macros - either memory-constrained platform or FASTLED_LOG_VERBOSITY=0.
 // Args are dropped entirely (matching pre-#3272 behaviour of FL_*_F). See
-// commit notes — earlier draft used `sstream_noop()` type-check but that
+// commit notes - earlier draft used `sstream_noop()` type-check but that
 // forced evaluation of args declared only under FASTLED_LOG_*_ENABLED.
 #define FL_ERROR(...) do { } while(0)
 #define FL_ERROR_F(...) do { } while(0)
@@ -297,7 +297,7 @@ void log_emit(log_kind kind, const char* file, int line, fl::sstream& body) FL_N
 // Warning Macros (FL_WARN)
 // =============================================================================
 
-// Per-kind dispatch helpers — _FL_WARN_S = single-arg stream form; _FL_WARN_M = multi-arg printf form.
+// Per-kind dispatch helpers - _FL_WARN_S = single-arg stream form; _FL_WARN_M = multi-arg printf form.
 #define _FL_WARN_S(X) ::fl::detail::log_emit( \
     ::fl::detail::log_kind::WARN, \
     ::fl::fastled_file_offset(__FILE__), int(__LINE__), \
@@ -309,16 +309,16 @@ void log_emit(log_kind kind, const char* file, int line, fl::sstream& body) FL_N
 
 #ifndef FASTLED_WARN
 // FASTLED_WARN: Supports both stream-style (<<) and printf-style formatting via
-// argument-count dispatch — see #3272.
+// argument-count dispatch - see #3272.
 #define FASTLED_WARN(...) _FL_VA_DISPATCH(_FL_WARN_S, _FL_WARN_M, __VA_ARGS__)(__VA_ARGS__)
 #define FASTLED_WARN_IF(COND, ...) do { if (COND) FASTLED_WARN(__VA_ARGS__); } while(0)
 #endif
 
 #ifndef FL_WARN
 #if FASTLED_LOG_RUNTIME_ENABLED
-// FL_WARN: unified entry point — accepts both `"foo " << x` and `"foo %d", x`
-// via macro-level argument-count dispatch. Single-arg → stream form (legacy
-// compatible); two-or-more args → printf form. See #3272.
+// FL_WARN: unified entry point - accepts both `"foo " << x` and `"foo %d", x`
+// via macro-level argument-count dispatch. Single-arg -> stream form (legacy
+// compatible); two-or-more args -> printf form. See #3272.
 #define FL_WARN(...) _FL_VA_DISPATCH(_FL_WARN_S, _FL_WARN_M, __VA_ARGS__)(__VA_ARGS__)
 // _F suffix preserved as alias for backward compatibility (#3272). New code
 // should drop the _F suffix and rely on argument-count dispatch.
@@ -341,7 +341,7 @@ void log_emit(log_kind kind, const char* file, int line, fl::sstream& body) FL_N
 #define FL_WARN_FMT(...) FL_WARN(__VA_ARGS__)
 #define FL_WARN_FMT_IF(COND, ...) FL_WARN_IF(COND, __VA_ARGS__)
 
-// FL_WARN_LIT: defined below outside the FASTLED_LOG_RUNTIME_ENABLED block —
+// FL_WARN_LIT: defined below outside the FASTLED_LOG_RUNTIME_ENABLED block -
 // gated on FASTLED_LOG_LITE_ENABLED so it stays available on Low-memory
 // targets. See "Lite-variant literal macros" section below.
 
@@ -357,8 +357,8 @@ void log_emit(log_kind kind, const char* file, int line, fl::sstream& body) FL_N
 } while(0)
 #define FL_WARN_F_EVERY(MILLIS, ...) FL_WARN_EVERY(MILLIS, __VA_ARGS__)
 #else
-// No-op macros — either memory-constrained platform or FASTLED_LOG_VERBOSITY=0.
-// Args dropped entirely — see the corresponding FL_ERROR section above for
+// No-op macros - either memory-constrained platform or FASTLED_LOG_VERBOSITY=0.
+// Args dropped entirely - see the corresponding FL_ERROR section above for
 // the rationale (pre-existing call sites declare some args only under
 // FASTLED_LOG_*_ENABLED, so any `if(false)` type-check would force a build
 // error).
@@ -393,7 +393,7 @@ void log_emit(log_kind kind, const char* file, int line, fl::sstream& body) FL_N
 // Info Macros (FL_INFO)
 // =============================================================================
 
-// Per-kind dispatch helpers — _FL_INFO_S = single-arg stream form; _FL_INFO_M = multi-arg printf form.
+// Per-kind dispatch helpers - _FL_INFO_S = single-arg stream form; _FL_INFO_M = multi-arg printf form.
 #define _FL_INFO_S(X) ::fl::detail::log_emit( \
     ::fl::detail::log_kind::INFO, \
     ::fl::fastled_file_offset(__FILE__), int(__LINE__), \
@@ -405,18 +405,19 @@ void log_emit(log_kind kind, const char* file, int line, fl::sstream& body) FL_N
 
 #ifndef FASTLED_INFO
 // FASTLED_INFO: Supports both stream-style (<<) and printf-style formatting via
-// argument-count dispatch — see #3272.
+// argument-count dispatch - see #3272.
 #define FASTLED_INFO(...) _FL_VA_DISPATCH(_FL_INFO_S, _FL_INFO_M, __VA_ARGS__)(__VA_ARGS__)
 #define FASTLED_INFO_IF(COND, ...) do { if (COND) FASTLED_INFO(__VA_ARGS__); } while(0)
 #endif
 
 #ifndef FL_INFO
 #if FASTLED_LOG_RUNTIME_ENABLED
-// FL_INFO: unified entry point — accepts both stream- and printf-style. See #3272.
+// FL_INFO: unified entry point - accepts both stream- and printf-style. See #3272.
+// Note: master never had an FL_INFO_F variant, so no `_F` alias is introduced
+// here. The unified FL_INFO already accepts printf-style; new code should call
+// FL_INFO("fmt %d", x) directly.
 #define FL_INFO(...) _FL_VA_DISPATCH(_FL_INFO_S, _FL_INFO_M, __VA_ARGS__)(__VA_ARGS__)
-#define FL_INFO_F(...) FL_INFO(__VA_ARGS__)
 #define FL_INFO_IF(COND, ...) do { if (COND) FL_INFO(__VA_ARGS__); } while(0)
-#define FL_INFO_F_IF(COND, ...) FL_INFO_IF(COND, __VA_ARGS__)
 
 // FL_INFO_ONCE: Emits info only once per unique location (static flag per call site)
 // Uses static bool flag initialized to false - first call prints, subsequent calls no-op
@@ -428,11 +429,9 @@ void log_emit(log_kind kind, const char* file, int line, fl::sstream& body) FL_N
     } \
 } while(0)
 #else
-// No-op macros — either memory-constrained platform or FASTLED_LOG_VERBOSITY=0.
+// No-op macros - either memory-constrained platform or FASTLED_LOG_VERBOSITY=0.
 #define FL_INFO(...) do { } while(0)
-#define FL_INFO_F(...) do { } while(0)
 #define FL_INFO_IF(COND, ...) do { } while(0)
-#define FL_INFO_F_IF(COND, ...) do { } while(0)
 #define FL_INFO_ONCE(...) do { } while(0)
 #endif
 #endif
@@ -562,14 +561,14 @@ void log_emit(log_kind kind, const char* file, int line, fl::sstream& body) FL_N
 /// Example:
 ///   FL_PRINT("Value: " << x);
 ///   FL_PRINT(ss.str());
-// Per-form dispatch helpers — _FL_PRINT_S = stream; _FL_PRINT_M = printf.
+// Per-form dispatch helpers - _FL_PRINT_S = stream; _FL_PRINT_M = printf.
 // Unlike FL_WARN, no "<file>(<line>): WARN:" prefix is prepended.
 #define _FL_PRINT_S(X) ::fl::println((::fl::sstream() << X).c_str())
 #define _FL_PRINT_M(...) do { ::fl::printf(__VA_ARGS__); ::fl::printf("\n"); } while(0)
 
 #ifndef FL_PRINT
 #if FASTLED_LOG_RUNTIME_ENABLED
-// FL_PRINT: unified entry point — accepts both stream- and printf-style.
+// FL_PRINT: unified entry point - accepts both stream- and printf-style.
 // No "WARN:" / "file(line):" prefix (unlike FL_WARN). See #3272.
 #define FL_PRINT(...) _FL_VA_DISPATCH(_FL_PRINT_S, _FL_PRINT_M, __VA_ARGS__)(__VA_ARGS__)
 #define FL_PRINT_F(...) FL_PRINT(__VA_ARGS__)
@@ -735,13 +734,13 @@ void log_emit(log_kind kind, const char* file, int line, fl::sstream& body) FL_N
 /// @param X Stream-style expression (e.g., "msg " << var)
 /// @warning This macro uses heap allocation (fl::string) and should NOT be used in ISR context
 /// @see FL_LOG_ASYNC_ISR for ISR-safe const char* only variant
-// Per-form dispatch helpers — _S = stream form, _M = printf form. Pushes the
+// Per-form dispatch helpers - _S = stream form, _M = printf form. Pushes the
 // composed message to the caller-provided AsyncLogger instance.
 #define _FL_LOG_ASYNC_S(logger, X) do { (logger).push((::fl::sstream() << X).str()); } while(0)
 #define _FL_LOG_ASYNC_M(logger, ...) do { (logger).push(::fl::detail::log_format_string(__VA_ARGS__)); } while(0)
 
-// Unified async-log dispatch (#3272). Single-arg payload → stream form (legacy
-// compatible); two-or-more args → printf form via log_format_string.
+// Unified async-log dispatch (#3272). Single-arg payload -> stream form (legacy
+// compatible); two-or-more args -> printf form via log_format_string.
 #define FL_LOG_ASYNC(logger, ...) _FL_VA_DISPATCH(_FL_LOG_ASYNC_S, _FL_LOG_ASYNC_M, __VA_ARGS__)(logger, __VA_ARGS__)
 
 // _F suffix preserved as alias for backward compatibility.

--- a/tests/fl/log/log.hpp
+++ b/tests/fl/log/log.hpp
@@ -418,11 +418,11 @@ FL_TEST_CASE("warning macros do not interfere with control flow") {
 
 // ============================================================================
 // Test Suite: Unified FL_WARN/FL_ERROR/FL_INFO/FL_PRINT (#3272)
-// Verifies that overload-on-arity dispatch correctly routes single-arg calls
+// Verifies that argument-count dispatch correctly routes single-arg calls
 // to stream form and multi-arg calls to printf form.
 // ============================================================================
 
-FL_TEST_CASE("FL_WARN unified — printf-style without _F suffix") {
+FL_TEST_CASE("FL_WARN unified - printf-style without _F suffix") {
     FL_SUBCASE("FL_WARN with printf format and one arg") {
         int n = 42;
         FL_WARN("Count: %d", n);
@@ -436,7 +436,7 @@ FL_TEST_CASE("FL_WARN unified — printf-style without _F suffix") {
     }
 
     FL_SUBCASE("FL_WARN with literal containing percent and no args (stream)") {
-        // Single-arg path — '%' is NOT interpreted as a format specifier.
+        // Single-arg path - '%' is NOT interpreted as a format specifier.
         FL_WARN("100% loaded");
         FL_CHECK(true);
     }
@@ -448,7 +448,7 @@ FL_TEST_CASE("FL_WARN unified — printf-style without _F suffix") {
     }
 }
 
-FL_TEST_CASE("FL_ERROR unified — printf-style without _F suffix") {
+FL_TEST_CASE("FL_ERROR unified - printf-style without _F suffix") {
     FL_SUBCASE("FL_ERROR with printf format") {
         int code = -1;
         FL_ERROR("Error code: %d", code);
@@ -467,7 +467,7 @@ FL_TEST_CASE("FL_ERROR unified — printf-style without _F suffix") {
     }
 }
 
-FL_TEST_CASE("FL_INFO unified — printf-style") {
+FL_TEST_CASE("FL_INFO unified - printf-style") {
     FL_SUBCASE("FL_INFO with printf format") {
         FL_INFO("info: %d", 123);
         FL_CHECK(true);
@@ -479,7 +479,19 @@ FL_TEST_CASE("FL_INFO unified — printf-style") {
     }
 }
 
-FL_TEST_CASE("FL_PRINT unified — printf-style") {
+FL_TEST_CASE("FL_INFO_IF unified - printf-style") {
+    FL_SUBCASE("FL_INFO_IF with printf format and true condition") {
+        FL_INFO_IF(true, "info conditional fmt %d", 9);
+        FL_CHECK(true);
+    }
+
+    FL_SUBCASE("FL_INFO_IF with stream chain") {
+        FL_INFO_IF(true, "info stream " << 22);
+        FL_CHECK(true);
+    }
+}
+
+FL_TEST_CASE("FL_PRINT unified - printf-style") {
     FL_SUBCASE("FL_PRINT with printf format") {
         FL_PRINT("printed: %d", 99);
         FL_CHECK(true);
@@ -496,7 +508,7 @@ FL_TEST_CASE("FL_PRINT unified — printf-style") {
     }
 }
 
-FL_TEST_CASE("FL_WARN_IF unified — printf-style") {
+FL_TEST_CASE("FL_WARN_IF unified - printf-style") {
     FL_SUBCASE("FL_WARN_IF with printf format and true condition") {
         FL_WARN_IF(true, "conditional fmt %d", 7);
         FL_CHECK(true);

--- a/tests/fl/log/log.hpp
+++ b/tests/fl/log/log.hpp
@@ -416,6 +416,98 @@ FL_TEST_CASE("warning macros do not interfere with control flow") {
     }
 }
 
+// ============================================================================
+// Test Suite: Unified FL_WARN/FL_ERROR/FL_INFO/FL_PRINT (#3272)
+// Verifies that overload-on-arity dispatch correctly routes single-arg calls
+// to stream form and multi-arg calls to printf form.
+// ============================================================================
+
+FL_TEST_CASE("FL_WARN unified — printf-style without _F suffix") {
+    FL_SUBCASE("FL_WARN with printf format and one arg") {
+        int n = 42;
+        FL_WARN("Count: %d", n);
+        FL_CHECK(true);
+    }
+
+    FL_SUBCASE("FL_WARN with printf format and multiple args") {
+        int x = 7, y = 11;
+        FL_WARN("x=%d y=%d", x, y);
+        FL_CHECK(true);
+    }
+
+    FL_SUBCASE("FL_WARN with literal containing percent and no args (stream)") {
+        // Single-arg path — '%' is NOT interpreted as a format specifier.
+        FL_WARN("100% loaded");
+        FL_CHECK(true);
+    }
+
+    FL_SUBCASE("FL_WARN_F alias still compiles") {
+        int n = 5;
+        FL_WARN_F("Legacy: %d", n);
+        FL_CHECK(true);
+    }
+}
+
+FL_TEST_CASE("FL_ERROR unified — printf-style without _F suffix") {
+    FL_SUBCASE("FL_ERROR with printf format") {
+        int code = -1;
+        FL_ERROR("Error code: %d", code);
+        FL_CHECK(true);
+    }
+
+    FL_SUBCASE("FL_ERROR_F alias still compiles") {
+        FL_ERROR_F("Legacy err: %s", "oops");
+        FL_CHECK(true);
+    }
+
+    FL_SUBCASE("FL_ERROR with stream chain still works") {
+        int v = 9;
+        FL_ERROR("value=" << v);
+        FL_CHECK(true);
+    }
+}
+
+FL_TEST_CASE("FL_INFO unified — printf-style") {
+    FL_SUBCASE("FL_INFO with printf format") {
+        FL_INFO("info: %d", 123);
+        FL_CHECK(true);
+    }
+
+    FL_SUBCASE("FL_INFO with stream chain") {
+        FL_INFO("info " << 456);
+        FL_CHECK(true);
+    }
+}
+
+FL_TEST_CASE("FL_PRINT unified — printf-style") {
+    FL_SUBCASE("FL_PRINT with printf format") {
+        FL_PRINT("printed: %d", 99);
+        FL_CHECK(true);
+    }
+
+    FL_SUBCASE("FL_PRINT with stream chain") {
+        FL_PRINT("stream " << 42);
+        FL_CHECK(true);
+    }
+
+    FL_SUBCASE("FL_PRINT_F alias still compiles") {
+        FL_PRINT_F("Legacy: %s", "abc");
+        FL_CHECK(true);
+    }
+}
+
+FL_TEST_CASE("FL_WARN_IF unified — printf-style") {
+    FL_SUBCASE("FL_WARN_IF with printf format and true condition") {
+        FL_WARN_IF(true, "conditional fmt %d", 7);
+        FL_CHECK(true);
+    }
+
+    FL_SUBCASE("FL_WARN_IF with printf format and false condition") {
+        FL_WARN_IF(false, "conditional fmt %d", 7);
+        FL_CHECK(true);
+    }
+}
+
 FL_TEST_CASE("warning macro edge cases") {
     FL_SUBCASE("empty message (should still compile)") {
         FL_WARN("");


### PR DESCRIPTION
## Summary

Closes #3272.

One `FL_WARN(...)` macro now accepts BOTH stream-style and printf-style call sites — no more `_F` suffix needed in new code. Macro-level argument-count dispatch routes single-arg calls to the existing sstream/`log_emit` path and two-or-more-arg calls to the existing `log_emit_f` path.

\`\`\`cpp
FL_WARN(\"plain literal\");          // 1 arg  → stream form (sstream/log_emit)
FL_WARN(\"foo \" << x << \" bar\");    // 1 arg  → stream form
FL_WARN(\"got %d items\", n);        // 2 args → printf form (log_emit_f)
\`\`\`

The same treatment applies to `FL_ERROR`, `FL_INFO`, `FL_PRINT`, `FL_LOG_ASYNC`, the per-channel `FL_LOG_*` family, and the per-channel `FL_LOG_*_ASYNC_MAIN` family.

## Backward compatibility

All `_F` macros are preserved as one-line aliases. Every existing call site of `FL_WARN(X)`, `FL_WARN_F(fmt, args)`, `FL_ERROR_F`, `FL_PRINT_F`, `FL_LOG_SPI_F`, `FL_LOG_RMT_F`, etc. compiles unchanged. New code should drop the `_F` suffix.

## Non-goals

This change does NOT migrate any call sites and does NOT shrink the binary. The ~5–10 KB ESP32-S3 saving stays scoped to **#3158**, which can now build on this unified entry point.

## Notes

- **Disabled-platform behavior change (LOW)**: when `FASTLED_LOG_VERBOSITY=0` or `!SKETCH_HAS_LARGE_MEMORY`, all macros now expand to true `do { } while(0)`. This drops the compile-time `sstream_noop` type-check that the old `FL_WARN_IF` carried. That check was only on `_IF` (inconsistent with `FL_WARN`/`FL_WARN_F`/`FL_WARN_F_IF` and all per-channel `_F` variants, which were already true no-ops). An early draft of this patch tried to preserve and unify the type-check, but it forced evaluation of args declared only under `FASTLED_LOG_*_ENABLED` (e.g. `parlio_buffer_calc.h:238`'s `uncappedCapacity`) and broke the build.
- **New macros added (symmetric with existing API)**: `FL_INFO_F`, `FL_INFO_F_IF` are net-new aliases (master had no printf form for `FL_INFO`).

## Implementation

A small `_FL_VA_PICK17` macro + filler list picks `_S` (single-arg stream helper) when the user passes 1 arg and `_M` (multi-arg printf helper) for 2..16 args. The picker is shared across all FL_WARN/FL_ERROR/FL_INFO/FL_PRINT/FL_LOG_ASYNC families via per-kind `_FL_<KIND>_S` / `_FL_<KIND>_M` helpers.

Macro-level dispatch (rather than C++ function-overload resolution) is required because the single-arg stream form is a chained `<<` expression — it only compiles when the macro injects `fl::sstream()` as the LHS. Routing through a function call would force the `<<` chain to evaluate standalone, which fails (`const char*` has no `operator<<(float)`).

## Test plan

- [x] `bash test --cpp` — 331/331 passed
- [x] `bash lint` — clean
- [x] New tests in `tests/fl/log/log.hpp` verify both stream and printf forms of FL_WARN/FL_ERROR/FL_INFO/FL_PRINT/FL_WARN_IF, plus `FL_WARN_F` / `FL_ERROR_F` / `FL_PRINT_F` aliases.
- [x] Pre-existing test failures (DemoReel100, ArrayOfLedArrays, ClientValidation, Downscale, fl_stl_isr in parallel runs) reproduce on master — not introduced by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Logging macros now accept both stream-style and printf-style payloads with the same call syntax, without needing separate suffix variants.
  * Updated async and hardware-category logging to follow the same unified argument handling and forwarding behavior.

* **Tests**
  * Added coverage to verify correct payload-style dispatch for warnings, errors, info, and print logging, including conditional cases and alias suffix behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->