### PR TITLE
fix(ci/boards): set PARLIO TX ISR IRAM flags on all PARLIO-capable boards (#3271)

### DIFF
--- a/ci/boards.py
+++ b/ci/boards.py
@@ -808,19 +808,6 @@ STM32H747XI_GIGA = Board(
 #     platform=ESP32_IDF_5_1_PIOARDUINO,
 # )
 
-# Required on every PARLIO-capable ESP32 target (C5/C6/H2/P4/S3). Without these,
-# the PARLIO TX ISR is placed in flash and may take cache-miss stalls during
-# execution — long enough to violate LED protocol timing. The driver emits a
-# #warning at compile time when CONFIG_PARLIO_TX_ISR_HANDLER_IN_IRAM is missing
-# (src/platforms/esp/32/drivers/parlio/parlio_peripheral_esp.cpp.hpp:46-48).
-# Historically these lived only in root platformio.ini under [env:esp32c6] and
-# reached CI only via the implicit root-merge — leaving every other PARLIO
-# board (S3, H2, P4, C5) compiling without them. See #3271.
-_ESP32_PARLIO_BUILD_FLAGS = [
-    "-DCONFIG_PARLIO_TX_ISR_HANDLER_IN_IRAM=1",
-    "-DCONFIG_PARLIO_TX_ISR_CACHE_SAFE=1",
-]
-
 # ESP32-C2: Use Arduino framework only (not "arduino, espidf")
 # The dual framework mode causes PlatformIO to use ESP-IDF's component-based build system,
 # which does not automatically discover and compile .cpp files in example subdirectories
@@ -853,7 +840,6 @@ ESP32_C5_DEVKITC_1 = Board(
     real_board_name="esp32-c5-devkitc-1",
     platform=ESP32_IDF_5_5_1_PIOARDUINO,
     build_flags=[*ESP32_PARLIO_BUILD_FLAGS],
-    build_flags=list(_ESP32_PARLIO_BUILD_FLAGS),
 )
 
 ESP32_C6_DEVKITC_1 = Board(
@@ -863,7 +849,6 @@ ESP32_C6_DEVKITC_1 = Board(
     board_build_flash_size="4MB",  # ESP32-C6FH4 actual flash size confirmed by esptool
     board_partitions="huge_app.csv",
     build_flags=[
-        *_ESP32_PARLIO_BUILD_FLAGS,
         "-funwind-tables",  # Better stack traces for RISC-V crash decoding
         "-DARDUINO_USB_MODE=1",  # Select HWCDC (USB-Serial/JTAG) over OTG
         "-DARDUINO_USB_CDC_ON_BOOT=1",  # Route Serial to HWCDC. Safe with setTxTimeoutMs(0); see #2668
@@ -881,7 +866,6 @@ ESP32_S3_DEVKITC_1 = Board(
     board_partitions="huge_app.csv",  # 3MB app partition (default.csv only has 1.25MB, too small for Validation)
     build_unflags=["-DFASTLED_RMT5=0", "-DFASTLED_RMT5"],
     build_flags=[
-        *_ESP32_PARLIO_BUILD_FLAGS,
         "-DARDUINO_USB_MODE=1",  # Route Serial over native USB for AutoResearch RPC on the upload port
         "-DARDUINO_USB_CDC_ON_BOOT=1",
         "-DARDUINO_LOOP_STACK_SIZE=16384",  # AutoResearch RPC plus ESP driver setup is deep enough to exceed the Arduino 8KB default
@@ -908,7 +892,6 @@ ESP32H2 = Board(
     platform_needs_install=True,  # Install platform package to get the boards
     platform=ESP32_IDF_5_3_PIOARDUINO,
     build_flags=[*ESP32_PARLIO_BUILD_FLAGS],
-    build_flags=list(_ESP32_PARLIO_BUILD_FLAGS),
 )
 
 ESP32_P4 = Board(
@@ -916,7 +899,6 @@ ESP32_P4 = Board(
     real_board_name="esp32-p4-evboard",
     platform=ESP32_IDF_5_5_1_PIOARDUINO,
     board_partitions="huge_app.csv",
-    build_flags=list(_ESP32_PARLIO_BUILD_FLAGS),
     # Route Serial → USB-Serial-JTAG (HWCDCSerial) instead of UART0 (pins 37/38).
     # Without these the AutoResearch firmware listens on UART0 while the host
     # tool talks to the USB-Serial-JTAG COM port — every RPC write times out.

--- a/ci/boards.py
+++ b/ci/boards.py
@@ -32,6 +32,18 @@ APOLLO3_2_2_0 = "https://github.com/nigelb/platform-apollo3blue"
 # Old fork that we were using
 # ESP32_IDF_5_1_PIOARDUINO = "https://github.com/zackees/platform-espressif32#Arduino/IDF5"
 
+# PARLIO TX ISR placement flags. Required on every PARLIO-capable ESP32 target
+# (SOC_PARLIO_SUPPORTED): without them the TX ISR sits in flash, takes cache-miss
+# stalls mid-execution, and violates LED protocol timing. The driver #warning's
+# when CONFIG_PARLIO_TX_ISR_HANDLER_IN_IRAM is missing
+# (src/platforms/esp/32/drivers/parlio/parlio_peripheral_esp.cpp.hpp). Apply this
+# to the build_flags of every PARLIO board so the next one added cannot silently
+# miss them. See #3271.
+ESP32_PARLIO_BUILD_FLAGS = [
+    "-DCONFIG_PARLIO_TX_ISR_HANDLER_IN_IRAM=1",
+    "-DCONFIG_PARLIO_TX_ISR_CACHE_SAFE=1",
+]
+
 # ALL will be auto populated in the Board constructor whenever a
 # board is defined.
 ALL: list["Board"] = []
@@ -796,6 +808,7 @@ ESP32_C5_DEVKITC_1 = Board(
     board_name="esp32c5",
     real_board_name="esp32-c5-devkitc-1",
     platform=ESP32_IDF_5_5_1_PIOARDUINO,
+    build_flags=[*ESP32_PARLIO_BUILD_FLAGS],
 )
 
 ESP32_C6_DEVKITC_1 = Board(
@@ -809,6 +822,7 @@ ESP32_C6_DEVKITC_1 = Board(
         "-DARDUINO_USB_MODE=1",  # Select HWCDC (USB-Serial/JTAG) over OTG
         "-DARDUINO_USB_CDC_ON_BOOT=1",  # Route Serial to HWCDC. Safe with setTxTimeoutMs(0); see #2668
         "-DARDUINO_LOOP_STACK_SIZE=16384",  # AutoResearch PARLIO init plus JSON-RPC exceeds the Arduino 8KB default on C6
+        *ESP32_PARLIO_BUILD_FLAGS,
     ],
 )
 
@@ -824,6 +838,7 @@ ESP32_S3_DEVKITC_1 = Board(
         "-DARDUINO_USB_MODE=1",  # Route Serial over native USB for AutoResearch RPC on the upload port
         "-DARDUINO_USB_CDC_ON_BOOT=1",
         "-DARDUINO_LOOP_STACK_SIZE=16384",  # AutoResearch RPC plus ESP driver setup is deep enough to exceed the Arduino 8KB default
+        *ESP32_PARLIO_BUILD_FLAGS,
     ],
 )
 
@@ -845,6 +860,7 @@ ESP32H2 = Board(
     real_board_name="esp32-h2-devkitm-1",
     platform_needs_install=True,  # Install platform package to get the boards
     platform=ESP32_IDF_5_3_PIOARDUINO,
+    build_flags=[*ESP32_PARLIO_BUILD_FLAGS],
 )
 
 ESP32_P4 = Board(
@@ -860,6 +876,7 @@ ESP32_P4 = Board(
         "ARDUINO_USB_MODE=1",
         "ARDUINO_USB_CDC_ON_BOOT=1",
     ],
+    build_flags=[*ESP32_PARLIO_BUILD_FLAGS],
 )
 
 ADA_FEATHER_NRF52840_SENSE = Board(

--- a/ci/boards.py
+++ b/ci/boards.py
@@ -39,7 +39,7 @@ APOLLO3_2_2_0 = "https://github.com/nigelb/platform-apollo3blue"
 # (src/platforms/esp/32/drivers/parlio/parlio_peripheral_esp.cpp.hpp). Apply this
 # to the build_flags of every PARLIO board so the next one added cannot silently
 # miss them. See #3271.
-ESP32_PARLIO_BUILD_FLAGS = [
+ESP32_PARLIO_BUILD_FLAGS: list[str] = [
     "-DCONFIG_PARLIO_TX_ISR_HANDLER_IN_IRAM=1",
     "-DCONFIG_PARLIO_TX_ISR_CACHE_SAFE=1",
 ]


### PR DESCRIPTION
## Summary

Fixes #3271.

`CONFIG_PARLIO_TX_ISR_HANDLER_IN_IRAM=1` and `CONFIG_PARLIO_TX_ISR_CACHE_SAFE=1` are required for correct PARLIO TX ISR behavior. Without them the ISR sits in flash, takes cache-miss stalls during execution, and violates LED protocol timing — the driver only signals this with a compile-time `#warning` (`src/platforms/esp/32/drivers/parlio/parlio_peripheral_esp.cpp.hpp:46-48`).

Today these flags live **only** in the root `platformio.ini` `[env:esp32c6]` block. CI gets them by accident via the root-merge in `PioCompiler._init_platformio_build` — and only for `esp32c6`. Every other PARLIO-capable board (`esp32s3`, `esp32h2`, `esp32p4`, `esp32c5`) compiles without them today.

## Change

- Extract a shared `ESP32_PARLIO_BUILD_FLAGS` constant in `ci/boards.py`.
- Apply it to the `build_flags` of every PARLIO-capable board: `esp32c5`, `esp32c6`, `esp32s3`, `esp32h2`, `esp32p4`.

This makes `ci/boards.py` a self-sufficient source of truth ahead of the planned root-`platformio.ini` sever, and ensures the next PARLIO board added cannot silently miss the flags (just spread the shared constant).

## Scope note

The root `platformio.ini` `[env:esp32c6]` flags are intentionally **left in place**. That env is still used for standalone manual `pio run` (which does not go through `boards.py`), and the root-merge removal it depends on is tracked as separate follow-up work in #3271. Removing them now would regress standalone dev builds before the sever lands. The duplicate `-D` on the c6 CI build is harmless.

## Verification

Rendered each board's `to_platformio_ini()` and confirmed both flags are present:

```
esp32c5      IRAM=True CACHE_SAFE=True
esp32c6      IRAM=True CACHE_SAFE=True
esp32s3      IRAM=True CACHE_SAFE=True
esp32h2      IRAM=True CACHE_SAFE=True
esp32p4      IRAM=True CACHE_SAFE=True
```

`python3 -m py_compile ci/boards.py` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Standardized PARLIO-related compiler flags across all PARLIO-capable ESP32 board variants (C5, C6, S3, H2, and P4) to ensure consistent build behavior.
  * Exposed a shared, reusable set of build flags for PARLIO so each board applies the same ISR placement and cache-safety settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->