### PR TITLE
fix(esp32/parlio): CONFIG_PARLIO_TX_ISR_HANDLER_IN_IRAM=1 default in boards.py

### DIFF
--- a/ci/boards.py
+++ b/ci/boards.py
@@ -765,6 +765,19 @@ STM32H747XI_GIGA = Board(
 #     platform=ESP32_IDF_5_1_PIOARDUINO,
 # )
 
+# Required on every PARLIO-capable ESP32 target (C5/C6/H2/P4/S3). Without these,
+# the PARLIO TX ISR is placed in flash and may take cache-miss stalls during
+# execution — long enough to violate LED protocol timing. The driver emits a
+# #warning at compile time when CONFIG_PARLIO_TX_ISR_HANDLER_IN_IRAM is missing
+# (src/platforms/esp/32/drivers/parlio/parlio_peripheral_esp.cpp.hpp:46-48).
+# Historically these lived only in root platformio.ini under [env:esp32c6] and
+# reached CI only via the implicit root-merge — leaving every other PARLIO
+# board (S3, H2, P4, C5) compiling without them. See #3271.
+_ESP32_PARLIO_BUILD_FLAGS = [
+    "-DCONFIG_PARLIO_TX_ISR_HANDLER_IN_IRAM=1",
+    "-DCONFIG_PARLIO_TX_ISR_CACHE_SAFE=1",
+]
+
 # ESP32-C2: Use Arduino framework only (not "arduino, espidf")
 # The dual framework mode causes PlatformIO to use ESP-IDF's component-based build system,
 # which does not automatically discover and compile .cpp files in example subdirectories
@@ -796,6 +809,7 @@ ESP32_C5_DEVKITC_1 = Board(
     board_name="esp32c5",
     real_board_name="esp32-c5-devkitc-1",
     platform=ESP32_IDF_5_5_1_PIOARDUINO,
+    build_flags=list(_ESP32_PARLIO_BUILD_FLAGS),
 )
 
 ESP32_C6_DEVKITC_1 = Board(
@@ -805,6 +819,7 @@ ESP32_C6_DEVKITC_1 = Board(
     board_build_flash_size="4MB",  # ESP32-C6FH4 actual flash size confirmed by esptool
     board_partitions="huge_app.csv",
     build_flags=[
+        *_ESP32_PARLIO_BUILD_FLAGS,
         "-funwind-tables",  # Better stack traces for RISC-V crash decoding
         "-DARDUINO_USB_MODE=1",  # Select HWCDC (USB-Serial/JTAG) over OTG
         "-DARDUINO_USB_CDC_ON_BOOT=1",  # Route Serial to HWCDC. Safe with setTxTimeoutMs(0); see #2668
@@ -821,6 +836,7 @@ ESP32_S3_DEVKITC_1 = Board(
     board_partitions="huge_app.csv",  # 3MB app partition (default.csv only has 1.25MB, too small for Validation)
     build_unflags=["-DFASTLED_RMT5=0", "-DFASTLED_RMT5"],
     build_flags=[
+        *_ESP32_PARLIO_BUILD_FLAGS,
         "-DARDUINO_USB_MODE=1",  # Route Serial over native USB for AutoResearch RPC on the upload port
         "-DARDUINO_USB_CDC_ON_BOOT=1",
         "-DARDUINO_LOOP_STACK_SIZE=16384",  # AutoResearch RPC plus ESP driver setup is deep enough to exceed the Arduino 8KB default
@@ -845,6 +861,7 @@ ESP32H2 = Board(
     real_board_name="esp32-h2-devkitm-1",
     platform_needs_install=True,  # Install platform package to get the boards
     platform=ESP32_IDF_5_3_PIOARDUINO,
+    build_flags=list(_ESP32_PARLIO_BUILD_FLAGS),
 )
 
 ESP32_P4 = Board(
@@ -852,6 +869,7 @@ ESP32_P4 = Board(
     real_board_name="esp32-p4-evboard",
     platform=ESP32_IDF_5_5_1_PIOARDUINO,
     board_partitions="huge_app.csv",
+    build_flags=list(_ESP32_PARLIO_BUILD_FLAGS),
     # Route Serial → USB-Serial-JTAG (HWCDCSerial) instead of UART0 (pins 37/38).
     # Without these the AutoResearch firmware listens on UART0 while the host
     # tool talks to the USB-Serial-JTAG COM port — every RPC write times out.


### PR DESCRIPTION
## Summary

Adds `-DCONFIG_PARLIO_TX_ISR_HANDLER_IN_IRAM=1` and `-DCONFIG_PARLIO_TX_ISR_CACHE_SAFE=1` to every PARLIO-capable ESP32 board definition in `ci/boards.py` (C5, C6, H2, P4, S3) via a new shared `_ESP32_PARLIO_BUILD_FLAGS` constant. The next PARLIO-capable target added cannot silently miss them — the constant is spread into each board's `build_flags`.

## Why

Without these macros the PARLIO TX ISR sits in flash and can take cache-miss stalls during execution, long enough to violate LED protocol timing. The driver already `#warning`s when the IRAM flag is absent (`src/platforms/esp/32/drivers/parlio/parlio_peripheral_esp.cpp.hpp:46-48`), but the warning was easy to miss because the flag reached CI only for `esp32c6` via the implicit root-`platformio.ini` merge (`ci/compiler/pio.py:155`). Every other PARLIO-capable board (S3/H2/P4/C5) was compiling without it.

## Why root `platformio.ini` is intentionally left alone

The duplicate `-D` lines under `[env:esp32c6]` in root `platformio.ini` are NOT removed. Root `platformio.ini` is an orthogonal surface used by interactive `bash debug` / `bash autoresearch` / raw `pio run`, and must stay self-sufficient. Severing the root-merge from the CI compile path is tracked separately in #3274; this PR is the Phase 1 prep that makes that sever safe.

## Files changed

- `ci/boards.py` — added `_ESP32_PARLIO_BUILD_FLAGS` constant; wired into `ESP32_C5_DEVKITC_1`, `ESP32_C6_DEVKITC_1`, `ESP32_S3_DEVKITC_1`, `ESP32H2`, `ESP32_P4` (+18 / -0).

## Test plan

- [x] `bash lint` — clean
- [x] `uv run python -c "from ci.boards import ..."` smoke test — confirms all 5 PARLIO boards now carry both flags
- [ ] CI compile of esp32c6 / esp32s3 via the normal `bash compile` path — should NOT emit the `parlio_peripheral_esp.cpp.hpp:46` `#warning` for any PARLIO board

Closes #3271
Refs #3274

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Centralized PARLIO ESP32 build-time flags into a shared configuration, reducing duplication across board definitions and improving maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->