### PR TITLE
feat(boards.py): port monitor_filters + check_tool from root platformio.ini (#3274 Phase 1)

### DIFF
--- a/ci/boards.py
+++ b/ci/boards.py
@@ -79,6 +79,14 @@ class Board:
     extra_scripts: list[str] | None = (
         None  # Custom build scripts to run (e.g., ['pre:script.py'] for pre-build hooks)
     )
+    # Serial monitor filters (e.g., ["default", "esp32_exception_decoder"]).
+    # ESP32-family boards auto-default to ["default", "esp32_exception_decoder"]
+    # in to_platformio_ini() when this is left None — see #3274 Phase 1. Set to
+    # [] to suppress the auto-default; set to a custom list to override.
+    monitor_filters: list[str] | None = None
+    # PlatformIO static-analysis tool name (e.g., "clangtidy"). Opt-in per-board;
+    # not auto-defaulted. Only consumed by `pio check`, not the compile path.
+    check_tool: str | None = None
     # Opt-in for GCC -fopt-info-all -> optimization_report.txt. Default OFF
     # because the file accumulates across every example in the matrix and can
     # exceed 100 MB on no-LTO boards with a large sketch set (nrf52840 with
@@ -651,6 +659,29 @@ class Board:
                 lines.append("lib_ignore =")
                 for lib in self.lib_ignore:
                     lines.append(f"    {lib}")
+
+        # Serial monitor filters. ESP32-family boards auto-default to
+        # ["default", "esp32_exception_decoder"] so that crash backtraces
+        # decode to file:line under `bash debug` / `pio device monitor`
+        # without depending on the root platformio.ini merge (see #3274
+        # Phase 1). An explicit `monitor_filters=[]` on a Board suppresses
+        # the auto-default; any non-None value overrides it.
+        is_esp32_family = self.board_name.startswith("esp32") or (
+            self.real_board_name is not None
+            and self.real_board_name.startswith("esp32")
+        )
+        effective_monitor_filters = self.monitor_filters
+        if effective_monitor_filters is None and is_esp32_family:
+            effective_monitor_filters = ["default", "esp32_exception_decoder"]
+        if effective_monitor_filters:
+            lines.append("monitor_filters =")
+            for mf in effective_monitor_filters:
+                lines.append(f"    {mf}")
+
+        # PlatformIO static-analysis tool (consumed by `pio check`, not the
+        # compile path). Opt-in per-board; not auto-defaulted.
+        if self.check_tool:
+            lines.append(f"check_tool = {self.check_tool}")
 
         # Add FastLED-specific configurations if project_root is provided
         if project_root:


### PR DESCRIPTION
## Summary

Phase 1 remainder of #3274. Adds two new optional fields to the `Board` dataclass and auto-applies the ESP32 crash-decoder filter for the ESP32 family so the synthesised `.build/pio/<env>/platformio.ini` carries them without depending on the root `platformio.ini` merge.

- `monitor_filters: list[str] | None` — serial monitor decoders/filters
- `check_tool: str | None` — `pio check` static-analysis tool name

ESP32-family boards (`board_name` or `real_board_name` starting with `esp32`) auto-default `monitor_filters` to `["default", "esp32_exception_decoder"]` inside `Board.to_platformio_ini()`. This matches the existing QEMU flash-mode auto-detection pattern in the same method. A board can suppress the auto-default with `monitor_filters=[]`, or override it with a custom list.

`check_tool` is **opt-in per-board** with no auto-default — it only affects `pio check`, not the compile path, and isn't a CI gap. Sets that want it can declare `check_tool="clangtidy"` explicitly.

## Why

PR #3276 (the PARLIO IRAM piece of Phase 1) and this PR together close the two gaps in `ci/boards.py` that the root-`platformio.ini` merge in `ci/compiler/pio.py:155` is silently masking. With both landed, severing that merge (Phase 2 of #3274) becomes safe — every flag/filter the merge was carrying for CI has an authoritative declaration in `boards.py`.

## Root `platformio.ini` deliberately untouched

The orthogonality rule: `ci/boards.py` and root `platformio.ini` serve disjoint audiences (CI vs. interactive local-dev). Root `[env:generic-esp]` retains its own `monitor_filters` and `check_tool` declarations for `bash autoresearch` / `bash debug` / raw `pio run`. Adding the flag to `boards.py` does NOT mean removing it from root — both surfaces independently need it.

## Verification

```python
$ uv run python -c "
from ci.boards import ESP32DEV, ESP32_C6_DEVKITC_1, ESP32_S3_DEVKITC_1, ESP32H2, ESP32_P4
from ci.boards import APOLLO3_RED_BOARD
assert 'monitor_filters' not in APOLLO3_RED_BOARD.to_platformio_ini()
for b in (ESP32DEV, ESP32_C6_DEVKITC_1, ESP32_S3_DEVKITC_1, ESP32H2, ESP32_P4):
    ini = b.to_platformio_ini()
    assert 'monitor_filters =' in ini and 'esp32_exception_decoder' in ini
print('OK')
"
```
- All ESP32-family boards now emit `monitor_filters` with `esp32_exception_decoder` in the synthesised ini.
- Non-ESP32 boards (Apollo3, Teensy, AVR, etc.) correctly omit it.
- `bash lint` clean.

## Files changed

- `ci/boards.py` — `Board` dataclass: 2 new optional fields; `to_platformio_ini`: ~18-line emission block with the ESP32 auto-detect. +31 / -0.

## Out of scope (deliberately deferred)

- Severing the root-merge in `ci/compiler/pio.py:155` — Phase 2 of #3274.
- `merge_root_platformio: bool = False` parameter on `PioCompiler` — Phase 2.
- Deprecating `PioCompiler` as a build fallback — Phase 3.
- Touching root `platformio.ini` — orthogonality rule.
- Setting `check_tool="clangtidy"` on the ESP32 boards — opt-in per-board; defer unless a use case for `pio check` from the synthesised ini emerges.

## Possible textual conflict with #3276

Both PRs add fields/constants near each other in `ci/boards.py`. Conflicts (if any) will be small and resolvable by whichever lands second.

## Test plan

- [x] `bash lint` — clean
- [x] Smoke test confirms all 5 sampled ESP32 boards auto-emit `monitor_filters` and a non-ESP32 board does not
- [ ] CI compile of an ESP32 board (e.g. esp32c6) — confirm `monitor_filters` line appears in `.build/pio/esp32c6/platformio.ini`

Refs #3274

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Boards now support configurable serial monitor filtering and static-analysis tool settings, enabling more granular control over development tools and workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->