### PR TITLE
chore(lockdown): require justification on every change to root platformio.ini

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -111,7 +111,7 @@ reviews:
            ```
            +  -D NEW_THING=1
            +  ; justification: bash autoresearch needs NEW_THING for the FOO RPC
-           +  ; added-in: PR-3280
+           +  ; added-in: PR-3281
            ```
 
         3. **Non-autoresearch dependencies are forbidden.** If this PR adds any
@@ -127,7 +127,7 @@ reviews:
 
         AUTORESEARCH MIGRATION NOTE: `bash autoresearch` is on a roadmap to stop
         consuming this file entirely and synthesise its own `platformio.ini` from
-        `ci/boards.py` (see #3280). Until that lands, additions here are accepted
+        `ci/boards.py` (see #3281). Until that lands, additions here are accepted
         with justification. After it lands, this file should be append-only for
         `bash debug` use cases only.
 

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -84,6 +84,53 @@ reviews:
         "`fl::span` for Callback Typedefs and Small Fixed-Size Arrays" and
         FastLED issue #3233.
 
+    - path: "platformio.ini"
+      instructions: |
+        ROOT `./platformio.ini` LOCKDOWN (#3274 follow-up).
+
+        Root `./platformio.ini` is a frozen surface, owned only by `bash autoresearch`
+        and `bash debug` (and raw `pio run`). CI compile, size-check, bloat, and
+        regression tests consume `ci/boards.py` — NOT this file. Any change here is
+        HIGH severity unless every added/modified non-comment line is justified.
+
+        REQUIRED for every change to this file:
+
+        1. **Justification comment.** Each new or modified non-comment line must be
+           accompanied by an adjacent `; justification: <reason>` comment explaining
+           WHY the change is needed in the file that only `bash autoresearch` /
+           `bash debug` consume. Vague justifications like "needed for build" or
+           "matches boards.py" are insufficient — say which interactive flow breaks
+           without it.
+
+        2. **Commit / PR reference.** Each justification comment should include
+           `; added-in: <40-char-sha>` OR `; added-in: PR-<NNN>` so future readers
+           can locate the rationale without `git blame` archeology. A PR ref is
+           acceptable at PR-open time; the SHA can be backfilled post-merge.
+
+           Example acceptable diff:
+           ```
+           +  -D NEW_THING=1
+           +  ; justification: bash autoresearch needs NEW_THING for the FOO RPC
+           +  ; added-in: PR-3280
+           ```
+
+        3. **Non-autoresearch dependencies are forbidden.** If this PR adds any
+           NEW code path under `ci/` (other than `ci/autoresearch/` or
+           `ci/debug_attached.py`) that reads, parses, or imports this file —
+           flag as HIGH severity. CI compile must remain `ci/boards.py`-only.
+           See parent #3274.
+
+        4. **Bulk reformatting / no-op churn is forbidden.** Comment reflow,
+           whitespace cleanup, or moving lines around without a behavioral change
+           is a HIGH severity nit — that kind of edit invalidates the
+           justification-comment audit trail without buying anything.
+
+        AUTORESEARCH MIGRATION NOTE: `bash autoresearch` is on a roadmap to stop
+        consuming this file entirely and synthesise its own `platformio.ini` from
+        `ci/boards.py` (see #3280). Until that lands, additions here are accepted
+        with justification. After it lands, this file should be append-only for
+        `bash debug` use cases only.
+
     - path: "**/platformio.ini"
       instructions: |
         PlatformIO `build_flags` macro prefix rule (matches the `FL_*` vs `FASTLED_*`

--- a/agents/docs/build-system.md
+++ b/agents/docs/build-system.md
@@ -12,6 +12,17 @@
 
 All board compiles use `fbuild`. Do not add board allowlists or PlatformIO fallback paths when a board does not compile; file board build compatibility problems at https://github.com/FastLED/fbuild/issues and fix them in fbuild.
 
+### Root `./platformio.ini` is a frozen surface (#3274)
+
+Root `./platformio.ini` is owned by `bash autoresearch` and `bash debug` (and raw `pio run`). CI compile, size-check, bloat, and regression tests consume `ci/boards.py` — NOT root `platformio.ini`. The two surfaces are orthogonal and must NOT be conflated.
+
+Rules:
+
+- **No new CI code path may depend on `./platformio.ini`.** Reading, parsing, or importing it from anywhere under `ci/` (other than `ci/autoresearch/` and `ci/debug_attached.py`) is forbidden. See parent #3274.
+- **Every change to `./platformio.ini` requires justification.** Each added non-comment line must carry an adjacent `; justification: <reason>` comment plus `; added-in: PR-<NNN>` (or 40-char SHA). The `bash lint` stage `root_platformio_ini_lockdown` and the matching CodeRabbit rule (`.coderabbit.yaml` path: `platformio.ini`) enforce this.
+- **When porting a flag from root → `ci/boards.py`, do NOT remove it from root.** Both surfaces independently need it (CI vs. local-dev). Removing from one because it's "now in the other" silently breaks the audience the file actually serves.
+- **Roadmap:** `bash autoresearch` is on a path to stop consuming this file entirely and synthesise its own `platformio.ini` from `ci/boards.py` prior to launch (see #3280). Once that lands, root `./platformio.ini` becomes append-only for `bash debug` use cases with a clear path to retirement. Any new functionality should plan for this — prefer extending `ci/boards.py` first and only touch root if `bash debug` truly needs it.
+
 ### Use These Commands
 
 ```bash

--- a/agents/docs/build-system.md
+++ b/agents/docs/build-system.md
@@ -21,7 +21,7 @@ Rules:
 - **No new CI code path may depend on `./platformio.ini`.** Reading, parsing, or importing it from anywhere under `ci/` (other than `ci/autoresearch/` and `ci/debug_attached.py`) is forbidden. See parent #3274.
 - **Every change to `./platformio.ini` requires justification.** Each added non-comment line must carry an adjacent `; justification: <reason>` comment plus `; added-in: PR-<NNN>` (or 40-char SHA). The `bash lint` stage `root_platformio_ini_lockdown` and the matching CodeRabbit rule (`.coderabbit.yaml` path: `platformio.ini`) enforce this.
 - **When porting a flag from root → `ci/boards.py`, do NOT remove it from root.** Both surfaces independently need it (CI vs. local-dev). Removing from one because it's "now in the other" silently breaks the audience the file actually serves.
-- **Roadmap:** `bash autoresearch` is on a path to stop consuming this file entirely and synthesise its own `platformio.ini` from `ci/boards.py` prior to launch (see #3280). Once that lands, root `./platformio.ini` becomes append-only for `bash debug` use cases with a clear path to retirement. Any new functionality should plan for this — prefer extending `ci/boards.py` first and only touch root if `bash debug` truly needs it.
+- **Roadmap:** `bash autoresearch` is on a path to stop consuming this file entirely and synthesise its own `platformio.ini` from `ci/boards.py` prior to launch (see #3281). Once that lands, root `./platformio.ini` becomes append-only for `bash debug` use cases with a clear path to retirement. Any new functionality should plan for this — prefer extending `ci/boards.py` first and only touch root if `bash debug` truly needs it.
 
 ### Use These Commands
 

--- a/ci/lint.py
+++ b/ci/lint.py
@@ -28,7 +28,10 @@ from ci.lint.stage_impls import (
 )
 from ci.lint.stages import LintStage
 from ci.lint_meson.run_all_checkers import run_meson_lint
-from ci.lint_platformio.run_all_checkers import run_platformio_lint
+from ci.lint_platformio.run_all_checkers import (
+    run_platformio_lint,
+    run_root_platformio_lockdown_lint,
+)
 from ci.util.global_interrupt_handler import install_signal_handler, wait_for_cleanup
 
 
@@ -255,6 +258,18 @@ def create_stages(args: LintArgs) -> list[LintStage]:
                 display_name="PLATFORMIO-INTERNAL-USAGE LINT",
                 run_fn=lambda: run_platformio_lint(),
                 timeout=30.0,
+            )
+        )
+        # Root ./platformio.ini lockdown: every diff line needs an adjacent
+        # `; justification:` + `; added-in:` comment. See #3274 and the
+        # matching CodeRabbit rule. No-op on master and when the file is
+        # unchanged against origin/master.
+        stages.append(
+            LintStage(
+                name="root_platformio_ini_lockdown",
+                display_name="ROOT-PLATFORMIO.INI LOCKDOWN",
+                run_fn=lambda: run_root_platformio_lockdown_lint(),
+                timeout=10.0,
             )
         )
 

--- a/ci/lint.py
+++ b/ci/lint.py
@@ -28,6 +28,9 @@ from ci.lint.stage_impls import (
 )
 from ci.lint.stages import LintStage
 from ci.lint_meson.run_all_checkers import run_meson_lint
+from ci.lint_platformio.check_root_platformio_lockdown import (
+    _warn_only_from_env as _root_pio_warn_only_from_env,
+)
 from ci.lint_platformio.run_all_checkers import (
     run_platformio_lint,
     run_root_platformio_lockdown_lint,
@@ -268,7 +271,9 @@ def create_stages(args: LintArgs) -> list[LintStage]:
             LintStage(
                 name="root_platformio_ini_lockdown",
                 display_name="ROOT-PLATFORMIO.INI LOCKDOWN",
-                run_fn=lambda: run_root_platformio_lockdown_lint(),
+                run_fn=lambda: run_root_platformio_lockdown_lint(
+                    warn_only=_root_pio_warn_only_from_env()
+                ),
                 timeout=10.0,
             )
         )

--- a/ci/lint_platformio/check_root_platformio_lockdown.py
+++ b/ci/lint_platformio/check_root_platformio_lockdown.py
@@ -41,9 +41,7 @@ ROOT_PIO_INI = PROJECT_ROOT / "platformio.ini"
 # as comment leaders; only ";" is canonical for this file.
 _SECTION_HEADER_RE = re.compile(r"^\s*\[[^\]]+\]\s*$")
 _JUSTIFICATION_RE = re.compile(r";\s*justification\s*:", re.IGNORECASE)
-_ADDED_IN_RE = re.compile(
-    r";\s*added-in\s*:\s*(?:PR-\d+|[0-9a-f]{7,40})", re.IGNORECASE
-)
+_ADDED_IN_RE = re.compile(r";\s*added-in\s*:\s*(?:PR-\d+|[0-9a-f]{40})", re.IGNORECASE)
 
 
 class Violation(NamedTuple):
@@ -138,24 +136,36 @@ def _has_adjacent_justification(
     target_line_no: int, all_lines: Iterable[str]
 ) -> tuple[bool, bool]:
     """Look at the full new file for a `; justification:` and `; added-in:`
-    comment within 5 lines before or after `target_line_no` (1-indexed).
+    comment within 3 lines before or after `target_line_no` (1-indexed).
 
     Returns (has_justification, has_added_in).
+
+    Window is ±3 — tight enough that an unrelated nearby comment cannot
+    satisfy the rule by accident, loose enough that a 2-line
+    `; justification: / ; added-in:` block immediately above (or below)
+    a small added env block still covers every line of the block.
     """
     lines = list(all_lines)
-    lo = max(0, target_line_no - 1 - 5)
-    hi = min(len(lines), target_line_no - 1 + 6)
+    lo = max(0, target_line_no - 1 - 3)
+    hi = min(len(lines), target_line_no - 1 + 4)
     window = lines[lo:hi]
-    has_just = any(_JUSTIFICATION_RE.search(l) for l in window)
-    has_added = any(_ADDED_IN_RE.search(l) for l in window)
+    has_just = any(_JUSTIFICATION_RE.search(line) for line in window)
+    has_added = any(_ADDED_IN_RE.search(line) for line in window)
     return has_just, has_added
 
 
-def check(warn_only: bool | None = None) -> bool:
-    """Run the lockdown check. Return True if clean (or warn-only mode)."""
-    if warn_only is None:
-        warn_only = os.environ.get("FASTLED_LINT_ROOT_PLATFORMIO_ERROR", "") != "1"
+def _warn_only_from_env() -> bool:
+    """Resolve warn-only mode from FASTLED_LINT_ROOT_PLATFORMIO_ERROR.
 
+    Returns True (warn-only) unless the env var is explicitly set to "1".
+    Callers that have an explicit preference (e.g. `--error` CLI flag)
+    should bypass this helper and pass their own bool to `check`.
+    """
+    return os.environ.get("FASTLED_LINT_ROOT_PLATFORMIO_ERROR", "") != "1"
+
+
+def check(warn_only: bool) -> bool:
+    """Run the lockdown check. Return True if clean (or warn-only mode)."""
     if not ROOT_PIO_INI.exists():
         return True
 
@@ -243,7 +253,7 @@ def check(warn_only: bool | None = None) -> bool:
     return False
 
 
-def main() -> int:
+def main(argv: list[str] | None) -> int:
     parser = argparse.ArgumentParser(
         description=(
             "Enforce justification comments on every change to root "
@@ -255,10 +265,12 @@ def main() -> int:
         action="store_true",
         help="Fail (exit 1) on any unjustified change. Default is warn-only.",
     )
-    args = parser.parse_args()
-    ok = check(warn_only=not args.error)
+    args = parser.parse_args(argv)
+    # CLI --error always wins; otherwise honour the env-var fallback.
+    warn_only = False if args.error else _warn_only_from_env()
+    ok = check(warn_only=warn_only)
     return 0 if ok else 1
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    sys.exit(main(None))

--- a/ci/lint_platformio/check_root_platformio_lockdown.py
+++ b/ci/lint_platformio/check_root_platformio_lockdown.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""Enforce justification + PR/SHA comments on every change to root `./platformio.ini`.
+
+Root `./platformio.ini` is a frozen surface owned only by `bash autoresearch`
+and `bash debug`. CI compile, size-check, bloat, and regression tests
+consume `ci/boards.py` instead. To prevent silent drift, every change here
+must carry an adjacent `; justification:` comment and an `; added-in:`
+back-reference (PR number or SHA). See #3274 and the matching CodeRabbit
+rule in `.coderabbit.yaml` (path: `platformio.ini`).
+
+This check is diff-based: it compares the current `platformio.ini` against
+the merge base with `origin/master` and flags any added non-comment line
+that lacks an adjacent justification comment in the same diff hunk. It is
+no-op when:
+
+  - the file is unchanged,
+  - the current branch is `master`/`main`,
+  - we cannot determine a base (detached HEAD, no `origin/master`, etc.).
+
+Default mode is WARN (exit 0). Pass `--error` or set
+``FASTLED_LINT_ROOT_PLATFORMIO_ERROR=1`` to gate.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Iterable, NamedTuple
+
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+ROOT_PIO_INI = PROJECT_ROOT / "platformio.ini"
+
+# An added non-comment, non-blank, non-section-header line that requires
+# justification. Section headers like "[env:foo]" are scaffolding, not
+# semantic config, so they're exempt. PlatformIO uses both ";" and "#"
+# as comment leaders; only ";" is canonical for this file.
+_SECTION_HEADER_RE = re.compile(r"^\s*\[[^\]]+\]\s*$")
+_JUSTIFICATION_RE = re.compile(r";\s*justification\s*:", re.IGNORECASE)
+_ADDED_IN_RE = re.compile(
+    r";\s*added-in\s*:\s*(?:PR-\d+|[0-9a-f]{7,40})", re.IGNORECASE
+)
+
+
+class Violation(NamedTuple):
+    line_no: int  # 1-indexed line number in the NEW file
+    line_text: str
+    reason: str
+
+
+def _run(cmd: list[str]) -> tuple[int, str]:
+    """Run a git command, return (returncode, stdout). Stderr is discarded."""
+    try:
+        result = subprocess.run(
+            cmd,
+            cwd=str(PROJECT_ROOT),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        return result.returncode, result.stdout
+    except (OSError, FileNotFoundError):
+        return 1, ""
+
+
+def _current_branch() -> str | None:
+    code, out = _run(["git", "rev-parse", "--abbrev-ref", "HEAD"])
+    if code != 0:
+        return None
+    branch = out.strip()
+    if branch == "HEAD":
+        return None
+    return branch or None
+
+
+def _resolve_base() -> str | None:
+    """Pick a sensible base to diff against. Prefer origin/master."""
+    for ref in ("origin/master", "origin/main", "master", "main"):
+        code, _ = _run(["git", "rev-parse", "--verify", "--quiet", ref])
+        if code == 0:
+            return ref
+    return None
+
+
+def _diff_added_lines(base: str) -> list[tuple[int, str]]:
+    """Return [(new_line_no, raw_line), ...] for additions in platformio.ini.
+
+    Uses unified diff with zero context lines to make hunk header parsing
+    simple. Each hunk header is `@@ -a,b +c,d @@`; we walk additions and
+    advance `c` line-by-line.
+    """
+    code, diff = _run(["git", "diff", "--unified=3", base, "--", "platformio.ini"])
+    if code != 0 or not diff:
+        return []
+
+    added: list[tuple[int, str]] = []
+    new_line_no = 0
+    in_hunk = False
+    hunk_re = re.compile(r"^@@\s+-\d+(?:,\d+)?\s+\+(\d+)(?:,\d+)?\s+@@")
+    for raw in diff.splitlines():
+        if raw.startswith("+++") or raw.startswith("---"):
+            continue
+        m = hunk_re.match(raw)
+        if m:
+            in_hunk = True
+            new_line_no = int(m.group(1))
+            continue
+        if not in_hunk:
+            continue
+        if raw.startswith("+"):
+            added.append((new_line_no, raw[1:]))
+            new_line_no += 1
+        elif raw.startswith("-"):
+            continue
+        else:
+            # context line — advance the new-file pointer
+            new_line_no += 1
+    return added
+
+
+def _is_semantic_addition(line: str) -> bool:
+    """Return True if this line is the kind that requires justification."""
+    stripped = line.strip()
+    if not stripped:
+        return False
+    if stripped.startswith(";") or stripped.startswith("#"):
+        return False
+    if _SECTION_HEADER_RE.match(stripped):
+        return False
+    return True
+
+
+def _has_adjacent_justification(
+    target_line_no: int, all_lines: Iterable[str]
+) -> tuple[bool, bool]:
+    """Look at the full new file for a `; justification:` and `; added-in:`
+    comment within 5 lines before or after `target_line_no` (1-indexed).
+
+    Returns (has_justification, has_added_in).
+    """
+    lines = list(all_lines)
+    lo = max(0, target_line_no - 1 - 5)
+    hi = min(len(lines), target_line_no - 1 + 6)
+    window = lines[lo:hi]
+    has_just = any(_JUSTIFICATION_RE.search(l) for l in window)
+    has_added = any(_ADDED_IN_RE.search(l) for l in window)
+    return has_just, has_added
+
+
+def check(warn_only: bool | None = None) -> bool:
+    """Run the lockdown check. Return True if clean (or warn-only mode)."""
+    if warn_only is None:
+        warn_only = os.environ.get("FASTLED_LINT_ROOT_PLATFORMIO_ERROR", "") != "1"
+
+    if not ROOT_PIO_INI.exists():
+        return True
+
+    branch = _current_branch()
+    if branch in (None, "master", "main"):
+        # No-op on master/main or detached HEAD — nothing to gate.
+        return True
+
+    base = _resolve_base()
+    if base is None:
+        return True
+
+    added = _diff_added_lines(base)
+    if not added:
+        return True
+
+    # Load full new file for adjacency lookups.
+    new_lines = ROOT_PIO_INI.read_text(encoding="utf-8", errors="replace").splitlines()
+
+    violations: list[Violation] = []
+    for line_no, raw in added:
+        if not _is_semantic_addition(raw):
+            continue
+        has_just, has_added_in = _has_adjacent_justification(line_no, new_lines)
+        if not has_just:
+            violations.append(
+                Violation(
+                    line_no=line_no,
+                    line_text=raw.rstrip(),
+                    reason="missing adjacent `; justification: <reason>` comment",
+                )
+            )
+        elif not has_added_in:
+            violations.append(
+                Violation(
+                    line_no=line_no,
+                    line_text=raw.rstrip(),
+                    reason=(
+                        "missing adjacent `; added-in: <PR-NNN | 40-char SHA>` "
+                        "back-reference"
+                    ),
+                )
+            )
+
+    if not violations:
+        print(
+            "✅ Root platformio.ini lockdown: "
+            f"{len(added)} added line(s) — all justified."
+        )
+        return True
+
+    mode_label = "WARN" if warn_only else "ERROR"
+    print()
+    print("=" * 80)
+    print(
+        f"[root-platformio.ini-lockdown] {mode_label} mode — "
+        f"{len(violations)} unjustified change(s) in platformio.ini:"
+    )
+    print("=" * 80)
+    print(
+        "Root ./platformio.ini is a frozen surface (#3274). Every added non-comment\n"
+        "line must carry an adjacent `; justification: <reason>` AND\n"
+        "`; added-in: PR-<NNN>` (or 40-char SHA) comment. See `.coderabbit.yaml`.\n"
+    )
+    for v in violations:
+        print(f"  platformio.ini:{v.line_no}: {v.reason}")
+        print(f"    | {v.line_text}")
+    print()
+    print(
+        "Add a comment block like:\n"
+        "  -D NEW_THING=1\n"
+        "  ; justification: <which interactive flow needs this and why>\n"
+        "  ; added-in: PR-<NNN>"
+    )
+    print("=" * 80)
+
+    if warn_only:
+        print(
+            f"⚠️  root-platformio.ini-lockdown: {len(violations)} violation(s) "
+            "(warn-only — not failing CI). Set FASTLED_LINT_ROOT_PLATFORMIO_ERROR=1 "
+            "to gate, or pass --error."
+        )
+        return True
+
+    return False
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Enforce justification comments on every change to root "
+            "./platformio.ini (see #3274 and .coderabbit.yaml)."
+        ),
+    )
+    parser.add_argument(
+        "--error",
+        action="store_true",
+        help="Fail (exit 1) on any unjustified change. Default is warn-only.",
+    )
+    args = parser.parse_args()
+    ok = check(warn_only=not args.error)
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ci/lint_platformio/run_all_checkers.py
+++ b/ci/lint_platformio/run_all_checkers.py
@@ -26,7 +26,16 @@ from pathlib import Path
 from ci.lint_platformio.check_no_internal_platformio import (
     NoInternalPlatformIOChecker,
 )
+from ci.lint_platformio.check_root_platformio_lockdown import (
+    check as run_root_platformio_lockdown_lint,
+)
 from ci.util.check_files import FileContentChecker, MultiCheckerFileProcessor
+
+
+__all__ = [
+    "run_platformio_lint",
+    "run_root_platformio_lockdown_lint",
+]
 
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent


### PR DESCRIPTION
## Summary

Three-pronged lockdown on root `./platformio.ini` so the orthogonality between it (interactive `bash autoresearch` / `bash debug`) and `ci/boards.py` (CI compile, size-check, bloat) is enforceable rather than just documented. Follow-up to #3274 / PR #3268 — addresses the class of regression where flags drift between the two surfaces silently.

## What lands

### 1. CodeRabbit rule (`.coderabbit.yaml`, path: `platformio.ini`)
- Every added non-comment line must carry an adjacent `; justification: <reason>` and `; added-in: PR-<NNN>` (or 40-char SHA) comment.
- Non-autoresearch CI code paths reading `./platformio.ini` are HIGH severity.
- Bulk reformatting / no-op churn is a HIGH severity nit (invalidates the audit trail).
- Notes the autoresearch retirement roadmap (#3281, filed alongside this PR).

### 2. `bash lint` stage (`root_platformio_ini_lockdown`)
- New checker `ci/lint_platformio/check_root_platformio_lockdown.py` diffs `./platformio.ini` against `origin/master`; flags any added non-comment line lacking adjacent `; justification:` / `; added-in:` comments.
- Wired into `ci/lint.py` as a new lint stage.
- **No-op** on master/main, detached HEAD, or when the file is unchanged.
- **Warn-only by default**; pass `--error` or set `FASTLED_LINT_ROOT_PLATFORMIO_ERROR=1` to gate.

### 3. Build-system doc (`agents/docs/build-system.md`)
- New section "Root ./platformio.ini is a frozen surface" with:
  - The orthogonality rule (root ⟂ boards.py).
  - The no-CI-dependency rule.
  - The keep-both rule for flag ports (don't remove from root when adding to boards.py).
  - The autoresearch retirement roadmap pointer.

## Verification

`bash lint` → `root_platformio_ini_lockdown` stage runs in ~0s on a clean tree (the file isn't in the diff).

Manual failure-mode test (revert after): appended a raw `[env:test]` block with `platform = atmelavr` and no justification — the checker exits 1 with a clear `platformio.ini:259: missing adjacent justification` violation.

Manual passing-case test: same edit but with adjacent `; justification:` and `; added-in: PR-3281` comments — checker reports `✅ all justified.` and exits 0.

No-op test: on master, the checker short-circuits via the branch check and returns immediately.

## Out of scope

- Severing the actual root-merge in `ci/compiler/pio.py:155` — tracked in #3278 (Phase 2 of #3274).
- Programmatic "no new CI code path reads platformio.ini" guard. The CodeRabbit rule covers PR review; a static-analysis check is deferred to whoever picks up #3278.
- Migrating `bash autoresearch` off `./platformio.ini` — filed separately as #3281.

## Test plan

- [x] `bash lint` clean — `root_platformio_ini_lockdown` stage completed
- [x] Manual failure-mode test (unjustified `[env:test]` block) flagged correctly
- [x] Manual passing-case test (with `; justification:` + `; added-in:`) passed
- [x] No-op on `master` branch (skipped via branch check)

Refs #3274
Filed alongside: #3281 (autoresearch migration off platformio.ini)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance explaining that the root configuration file is a “frozen surface,” and that CI checks should rely on the board definitions under CI instead.
  * Documented required change-control rules, including adjacent justification and `added-in` annotations for new non-comment changes.

* **Chores**
  * Introduced a new CI lint stage to enforce the root configuration file change-control requirements.
  * In strict mode, CI now fails when required justification/`added-in` annotations are missing for newly added semantic lines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->