### PR TITLE
fix(deque): free orphaned chunks in grow_map to stop chunked-deque leak (closes #3286)

### DIFF
--- a/src/fl/stl/deque.h
+++ b/src/fl/stl/deque.h
@@ -87,7 +87,12 @@ private:
     // Grow the chunk-pointer map. After return:
     //   - mMap has at least `extra_front` empty slots before mFrontMapIdx
     //   - mMap has at least `extra_back` empty slots after the back chunk
-    // Existing chunk pointers are preserved (chunks themselves are never moved).
+    // Live chunk pointers in [mFrontMapIdx, mFrontMapIdx+used) are preserved
+    // (chunks themselves are never moved). Orphaned chunks outside that range
+    // (left behind by prior pop_front / pop_back when a chunk emptied without
+    // being released) are FREED here -- otherwise the old `mMap` is
+    // deallocated below and those chunk pointers are lost forever, leaking
+    // their backing storage. See FastLED #3286.
     // mFrontMapIdx may shift to a new position within the new map.
     void grow_map(fl::size extra_front, fl::size extra_back) FL_NO_EXCEPT {
         fl::size used = used_chunks();
@@ -102,6 +107,16 @@ private:
             // vector-style ensure_capacity. Callers must defensively check
             // capacity / size after push_*.
             return;
+        }
+        // Free any chunk pointers in the OLD map that live outside the
+        // [mFrontMapIdx, mFrontMapIdx+used) live range; those are orphans
+        // and would otherwise leak when the old map is deallocated.
+        fl::size live_end = mFrontMapIdx + used;
+        for (fl::size i = 0; i < mMapCapacity; ++i) {
+            if (i < mFrontMapIdx || i >= live_end) {
+                deallocate_chunk(mMap[i]);
+                mMap[i] = nullptr;
+            }
         }
         for (fl::size i = 0; i < used; ++i) {
             new_map[new_front + i] = mMap[mFrontMapIdx + i];

--- a/tests/fl/stl/deque.cpp
+++ b/tests/fl/stl/deque.cpp
@@ -1003,4 +1003,80 @@ FL_TEST_CASE("fl::deque_traits<T> chunk_size override (#3270)") {
     }
 }
 
+// FastLED #3286: regression test for the chunked-deque grow_map leak.
+//
+// Original bug (introduced in #3282 / commit a8b5cac9a):
+//
+//   pop_front() advances mFrontMapIdx past the now-empty front chunk
+//   without freeing it -- the chunk pointer is left orphaned in
+//   mMap[mFrontMapIdx-1]. The destructor catches this (it iterates the
+//   entire mMap), so the orphan is harmless as long as the map itself
+//   survives.
+//
+//   But when later push_back() forces grow_map(), the old map is
+//   deallocated and ONLY pointers in [mFrontMapIdx, mFrontMapIdx+used)
+//   are copied forward. Every orphaned pointer below mFrontMapIdx is
+//   silently lost -- and its backing chunk leaks.
+//
+//   macOS-arm64 ASAN's LeakSanitizer caught this; Linux x86-64 didn't,
+//   because that job ran without leak detection enabled. The
+//   TempoAnalyzer's sliding mBPMHistory / mOnsetTimes exercise exactly
+//   this push/pop/push-grow pattern.
+//
+// This test pins chunk_size=4 (via SmallChunkTag) to make the bug
+// reproducible in a few dozen ops instead of the thousands needed at
+// the default chunk_size=64.
+FL_TEST_CASE("fl::deque - grow_map releases orphaned chunks (#3286)") {
+    deque<SmallChunkTag> dq;
+
+    // Phase 1: fill chunks 0..3 (initial map capacity is 4, chunk_size=4
+    // -> 16 elements fills the map exactly).
+    for (int i = 0; i < 16; ++i) dq.push_back(SmallChunkTag(i));
+    FL_CHECK_EQ(dq.size(), 16u);
+
+    // Phase 2: pop_front 12 elements (3 full chunks). After this,
+    // mFrontMapIdx advances to 3; the chunks at mMap[0], mMap[1],
+    // mMap[2] are now orphans -- still allocated, still in the map,
+    // but no live element lives there.
+    for (int i = 0; i < 12; ++i) dq.pop_front();
+    FL_CHECK_EQ(dq.size(), 4u);
+    FL_CHECK_EQ(dq[0].v, 12);
+    FL_CHECK_EQ(dq[3].v, 15);
+
+    // Phase 3: push_back enough to force grow_map(). At this point the
+    // back is in chunk 3 (the only live chunk); pushing past the end
+    // of chunk 3 needs chunk 4, which is past mMapCapacity=4, so
+    // grow_map runs.
+    //
+    // Before the #3286 fix this is where the leak happened: orphans at
+    // mMap[0..2] were never freed and never copied forward; only the
+    // live chunk at mMap[3] survived into the new map. Three chunk
+    // allocations were lost on the floor every time this pattern fired.
+    //
+    // After the fix, grow_map proactively releases orphans before
+    // deallocating the old map -- no chunk pointers go missing.
+    for (int i = 0; i < 20; ++i) dq.push_back(SmallChunkTag(100 + i));
+    FL_CHECK_EQ(dq.size(), 24u);
+
+    // The grow-triggering pattern is the leak path. We don't try to
+    // detect the leak in-test (that's ASAN's job); we just exercise
+    // the path so that any leak reproduces under sanitizers. The data
+    // invariants below also verify that the surviving live chunks
+    // weren't accidentally double-freed by the fix.
+    FL_CHECK_EQ(dq[0].v, 12);
+    FL_CHECK_EQ(dq[3].v, 15);
+    FL_CHECK_EQ(dq[4].v, 100);
+    FL_CHECK_EQ(dq[23].v, 119);
+
+    // Phase 4: hammer the slide pattern across many grow cycles to
+    // exercise the path the audio detector hits (mOnsetTimes /
+    // mBPMHistory pop_front + push_back loop for ~hundreds of frames).
+    for (int round = 0; round < 50; ++round) {
+        dq.pop_front();
+        dq.push_back(SmallChunkTag(1000 + round));
+    }
+    FL_CHECK_EQ(dq.size(), 24u);
+    FL_CHECK_EQ(dq[23].v, 1049);
+}
+
 } // FL_TEST_FILE


### PR DESCRIPTION
## Summary

Fixes the macOS-arm64 unit-test regression that's been red on master since #3282 (commit a8b5cac9a). LeakSanitizer reported ~5KB leaked in 20 allocations rooted in `fl::deque<float>::ensure_back_room()` from `TempoAnalyzer::updateCurrentTempo` / `update`.

Closes #3286.

## Root cause

The chunked-deque refactor in #3282 has a chunk-orphaning bug in the pop / grow interaction:

- `pop_front()` / `pop_back()` advance `mFrontMapIdx` / `mSize` past an emptied chunk without freeing or nulling the chunk pointer. The chunk is left orphaned in `mMap[]`.
- The destructor sweeps the entire map, so orphans are harmless as long as the map itself survives.
- BUT `grow_map()` only copies pointers in `[mFrontMapIdx, mFrontMapIdx+used)` forward into the new map, then deallocates the old map. **Every orphaned chunk pointer outside that range is silently lost, leaking its backing storage.**

The audio `TempoAnalyzer` hits this directly: `mOnsetTimes` (50-entry sliding window) and `mBPMHistory` (20-entry sliding window) do push_back + pop_front each frame. After enough frames, an old chunk gets orphaned, then a later push_back forces grow_map, then the orphan leaks. Linux x86-64 CI doesn't run leak detection so the regression only tripped the macos job.

## Fix

In `grow_map()`, after a successful new-map allocation but before deallocating the old map, free any chunk pointers in the old map that fall outside the live `[mFrontMapIdx, mFrontMapIdx+used)` range. The live range still copies forward unchanged, so chunk addresses stay stable for surviving elements (preserves the #3270 pointer / iterator stability guarantee).

Two-file diff:
- `src/fl/stl/deque.h` — the orphan-cleanup loop inside `grow_map`
- `tests/fl/stl/deque.cpp` — regression test using `SmallChunkTag` (chunk_size=4) to reproduce the leak pattern in a few dozen ops

## Test plan
- [x] `bash test fl_stl_deque --debug` (clang + ASAN) → pass
- [x] `bash test fl_audio_detectors --debug` (clang + ASAN) → pass
- [x] `bash lint --cpp` → clean
- [ ] macOS-arm64 CI confirms the original failing test now passes

## References
- Breaking PR: #3282 (commit a8b5cac9a)
- Regression issue: #3286

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed memory leak in deque container where orphaned chunk pointers were not properly deallocated during internal map resizing cycles.

* **Tests**
  * Added regression test case validating deque behavior during repeated pop and push operations that trigger internal map growth.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->