### PR TITLE
fix(ci/pio): sever root platformio.ini merge from CI compile path (#3278 Phase 2)

### DIFF
--- a/.github/workflows/avr8js_docker_template.yml
+++ b/.github/workflows/avr8js_docker_template.yml
@@ -37,6 +37,11 @@ permissions:
 jobs:
   avr8js_test:
     runs-on: ubuntu-latest
+    # Tripwire for #3278: any board still relying on the legacy
+    # root-platformio.ini merge raises instead of silently inheriting
+    # flags. Port the missing flag to ci/boards.py.
+    env:
+      FASTLED_FAIL_ON_ROOT_MERGE: "1"
 
     steps:
       - name: Checkout

--- a/.github/workflows/build_template.yml
+++ b/.github/workflows/build_template.yml
@@ -81,6 +81,11 @@ jobs:
 
       - name: Build FastLED examples with "./compile --no-interactive  ${{ inputs.args }}"
         id: build_examples
+        env:
+          # Tripwire for #3278: if any board still relies on the legacy
+          # root-platformio.ini merge, the build raises instead of silently
+          # inheriting flags. Port the missing flag to ci/boards.py.
+          FASTLED_FAIL_ON_ROOT_MERGE: "1"
         run: |
           set -o pipefail
           ./compile --no-interactive --no-parallel --log-failures failures --max-failures 3  ${{ inputs.args }} | tee build.log

--- a/.github/workflows/build_template_binary_size.yml
+++ b/.github/workflows/build_template_binary_size.yml
@@ -26,6 +26,11 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    # Tripwire for #3278: any board still relying on the legacy
+    # root-platformio.ini merge raises instead of silently inheriting
+    # flags. Port the missing flag to ci/boards.py.
+    env:
+      FASTLED_FAIL_ON_ROOT_MERGE: "1"
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/build_template_custom_board.yml
+++ b/.github/workflows/build_template_custom_board.yml
@@ -16,6 +16,11 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    # Tripwire for #3278: any board still relying on the legacy
+    # root-platformio.ini merge raises instead of silently inheriting
+    # flags. Port the missing flag to ci/boards.py.
+    env:
+      FASTLED_FAIL_ON_ROOT_MERGE: "1"
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/qemu_docker_template.yml
+++ b/.github/workflows/qemu_docker_template.yml
@@ -35,6 +35,11 @@ permissions:
 jobs:
   qemu_test:
     runs-on: ubuntu-latest
+    # Tripwire for #3278: any board still relying on the legacy
+    # root-platformio.ini merge raises instead of silently inheriting
+    # flags. Port the missing flag to ci/boards.py.
+    env:
+      FASTLED_FAIL_ON_ROOT_MERGE: "1"
 
     steps:
       - name: Checkout

--- a/ci/compiler/compilation_orchestrator.py
+++ b/ci/compiler/compilation_orchestrator.py
@@ -119,7 +119,10 @@ def compile_board_examples(
     print(f"{'=' * 60}")
 
     try:
-        # Create PioCompiler instance
+        # Create PioCompiler instance.
+        # merge_root_platformio=False (#3278): CI compile paths must be
+        # hermetic w.r.t. the repo-root platformio.ini. Per-board flags
+        # live in ci/boards.py.
         compiler = PioCompiler(
             board=board,
             verbose=verbose,
@@ -127,6 +130,7 @@ def compile_board_examples(
             additional_defines=defines,
             additional_libs=extra_packages,
             use_fbuild=use_fbuild,
+            merge_root_platformio=False,
         )
 
         # Build all examples - use merged-bin method if requested

--- a/ci/compiler/pio.py
+++ b/ci/compiler/pio.py
@@ -10,6 +10,7 @@ Provides a clean interface for building FastLED projects with PlatformIO.
 
 import gc
 import hashlib
+import os
 import platform
 import shutil
 import subprocess
@@ -65,12 +66,27 @@ def _init_platformio_build(
     additional_include_dirs: Optional[list[str]] = None,
     additional_libs: Optional[list[str]] = None,
     use_fbuild: bool = False,
+    merge_root_platformio: bool = False,
 ) -> InitResult:
     """Initialize the PlatformIO build directory. Assumes lock is already held by caller.
 
     When use_fbuild=True, skips PIO-specific package management and the pio run build.
     The build directory, platformio.ini, and source files are still set up since fbuild
     uses the same project structure.
+
+    When ``merge_root_platformio=True``, ``build_flags`` from the matching
+    ``[env:<board>]`` section of the repo-root ``platformio.ini`` are
+    appended to the synthesised env (legacy behaviour for issue #2664).
+    Defaults to ``False`` as of #3278 — CI must remain hermetic w.r.t. the
+    root ini so that edits to ``platformio.ini`` (an "orthogonal" surface
+    used by `bash debug` / `bash autoresearch`) cannot silently change CI
+    binaries. The intended per-board flags live in ``ci/boards.py``.
+
+    When the ``FASTLED_FAIL_ON_ROOT_MERGE=1`` env var is set, this function
+    additionally probes the root ini even when ``merge_root_platformio`` is
+    ``False`` and raises if any flags would have been silently merged.
+    That canary catches any per-board flag we forgot to port to
+    ``ci/boards.py`` during the #3274 sever.
     """
     project_root = resolve_project_root()
     build_dir = build_dir or (project_root / ".build" / "pio" / board.board_name)
@@ -145,15 +161,45 @@ def _init_platformio_build(
         # Non-fatal: continue without optimization artifacts if path resolution fails
         pass
 
-    # Merge any per-env build_flags the user has declared in the root
-    # platformio.ini (issue #2664). Without this step, flags in
-    # [env:<board>].build_flags of the root file are silently discarded
-    # when bash compile --backend platformio synthesises a fresh project
-    # from ci/boards.py. Board flags come first, root flags are appended,
-    # so root values take precedence per PlatformIO's "last wins" semantics
-    # for repeated -D / linker flags.
-    root_build_flags = get_root_platformio_build_flags(board.board_name, project_root)
-    if root_build_flags:
+    # Root-platformio.ini merge (issue #2664 / sever tracked in #3278).
+    #
+    # Historically every build silently appended ``[env:<board>].build_flags``
+    # from the repo-root ``platformio.ini`` to the synthesised env. CI now
+    # opts OUT by default (``merge_root_platformio=False``) so the root file
+    # cannot quietly change CI binaries — per-board flags belong in
+    # ``ci/boards.py``. Interactive entry points (`bash debug`, ad-hoc
+    # ``bash compile --use-root-ini`` invocations) can still opt back in.
+    #
+    # The ``FASTLED_FAIL_ON_ROOT_MERGE=1`` env var turns this into a tripwire:
+    # we still probe the root ini and raise if any flag would have been
+    # silently merged, which catches per-board flags that should have been
+    # ported to ``ci/boards.py`` but were not.
+    fail_on_root_merge = os.environ.get("FASTLED_FAIL_ON_ROOT_MERGE", "").lower() in (
+        "1",
+        "true",
+        "yes",
+        "on",
+    )
+    if merge_root_platformio or fail_on_root_merge:
+        root_build_flags = get_root_platformio_build_flags(
+            board.board_name, project_root
+        )
+    else:
+        root_build_flags = []
+
+    if root_build_flags and not merge_root_platformio and fail_on_root_merge:
+        # Tripwire fired: CI compile produced flags from the root ini that
+        # were NOT supposed to reach the build. Raise so the build fails
+        # loudly with the missing per-board flags listed.
+        raise RuntimeError(
+            f"FASTLED_FAIL_ON_ROOT_MERGE=1: root platformio.ini "
+            f"[env:{board.board_name}] would silently inject "
+            f"{len(root_build_flags)} build_flag(s) into the CI build: "
+            f"{root_build_flags}. These must be ported to ci/boards.py "
+            f"(see #3278) before the sever can complete."
+        )
+
+    if root_build_flags and merge_root_platformio:
         print(
             f"Merging {len(root_build_flags)} build_flag(s) from root "
             f"platformio.ini [env:{board.board_name}]: {root_build_flags}"
@@ -318,7 +364,17 @@ class PioCompiler(Compiler):
         additional_include_dirs: Optional[list[str]] = None,
         additional_libs: Optional[list[str]] = None,
         use_fbuild: bool = False,
+        merge_root_platformio: bool = False,
     ) -> None:
+        """Construct a PlatformIO compiler driver.
+
+        ``merge_root_platformio`` (default ``False`` per #3278) controls
+        whether ``[env:<board>].build_flags`` from the repo-root
+        ``platformio.ini`` are appended to the synthesised env. CI compile
+        paths must keep this ``False`` so the root file cannot silently
+        change CI binaries; interactive entry points (`bash debug`,
+        ad-hoc `bash compile --use-root-ini`) can opt back in.
+        """
         # Call parent constructor
         super().__init__()
 
@@ -332,6 +388,7 @@ class PioCompiler(Compiler):
         self.additional_include_dirs = additional_include_dirs
         self.additional_libs = additional_libs
         self.use_fbuild = use_fbuild
+        self.merge_root_platformio = merge_root_platformio
 
         # Global cache directory is already resolved by caller
         self.global_cache_dir = global_cache_dir
@@ -371,6 +428,7 @@ class PioCompiler(Compiler):
             additional_include_dirs=self.additional_include_dirs,
             additional_libs=self.additional_libs,
             use_fbuild=self.use_fbuild,
+            merge_root_platformio=self.merge_root_platformio,
         )
         if result.success:
             self.initialized = True
@@ -516,6 +574,7 @@ class PioCompiler(Compiler):
                 additional_include_dirs=self.additional_include_dirs,
                 additional_libs=self.additional_libs,
                 use_fbuild=True,
+                merge_root_platformio=self.merge_root_platformio,
             )
             if not init_result.success:
                 raise RuntimeError(init_result.output)
@@ -1658,5 +1717,6 @@ def run_pio_build(
         additional_defines,
         additional_include_dirs,
         None,
+        merge_root_platformio=False,  # #3278: CI must be hermetic w.r.t. root platformio.ini
     )
     return pio.build(examples)

--- a/ci/tests/test_root_platformio_sever.py
+++ b/ci/tests/test_root_platformio_sever.py
@@ -1,0 +1,254 @@
+"""Tests for the Phase-2 sever of the root-platformio.ini merge (issue #3278).
+
+Until #3278 landed, ``_init_platformio_build`` in ``ci/compiler/pio.py``
+*always* appended ``[env:<board>].build_flags`` from the repo-root
+``platformio.ini`` to the synthesised env. That made the root file an
+implicit input to every CI binary — edits to root could silently change
+CI behaviour. #3278 inverts the default: ``merge_root_platformio=False``
+on every CI entry point, and ``FASTLED_FAIL_ON_ROOT_MERGE=1`` turns the
+probe into a tripwire that fires when any flag would have been merged
+silently.
+
+These tests exercise that behaviour directly against
+``_init_platformio_build`` so we don't have to spin up real PlatformIO.
+"""
+
+from __future__ import annotations
+
+import os
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import mock
+
+from ci.boards import Board
+from ci.compiler import build_config as build_config_module
+from ci.compiler import pio as pio_module
+from ci.compiler.path_manager import FastLEDPaths
+
+
+def _make_paths(tmp: Path) -> FastLEDPaths:
+    """Build a FastLEDPaths object rooted under ``tmp`` for testing."""
+    paths = FastLEDPaths("esp32c6")
+    # Steer every cache/output path into the tempdir so this test never
+    # touches the user's real ~/.fastled.
+    paths._global_platformio_cache_dir = tmp / "pio_cache"
+    return paths
+
+
+def _write_root_ini_with_esp32c6_flag(root: Path, flag: str) -> None:
+    """Write a minimal root platformio.ini exposing one esp32c6 flag."""
+    (root / "platformio.ini").write_text(
+        f"[env:esp32c6]\nplatform = espressif32\nbuild_flags = {flag}\n",
+    )
+
+
+def _patch_no_op_pipeline(
+    stack: "mock._patch_dict.__class__ | unittest.mock._patch",
+) -> None:  # pragma: no cover - signature placeholder, see callers
+    """Placeholder kept for future shared patching helpers."""
+    raise NotImplementedError
+
+
+class TestRootPlatformioSever(unittest.TestCase):
+    """Verify the #3278 sever semantics on _init_platformio_build."""
+
+    def _run_init(
+        self,
+        tmp: Path,
+        merge_root_platformio: bool,
+        fail_on_root_merge: bool,
+        captured_flags: list[list[str]],
+    ) -> object:
+        """Drive ``_init_platformio_build`` with the project root patched
+        to ``tmp`` and all heavyweight side effects mocked out.
+
+        ``captured_flags`` collects the final ``build_flags`` that
+        ``apply_board_specific_config`` would have written, so each test
+        can assert what reached the synthesised env.
+        """
+        # Patch resolve_project_root() so the root platformio.ini probe
+        # reads from our tempdir and the build directory lands there too.
+        env_patch = {}
+        if fail_on_root_merge:
+            env_patch["FASTLED_FAIL_ON_ROOT_MERGE"] = "1"
+        else:
+            # Ensure inherited env from the host doesn't accidentally turn
+            # the tripwire on for the merge=False/probe=off cases.
+            env_patch["FASTLED_FAIL_ON_ROOT_MERGE"] = ""
+
+        def fake_apply(
+            board: Board,
+            platformio_ini_path: Path,
+            example: str,
+            paths: FastLEDPaths,
+            additional_defines: object = None,
+            additional_include_dirs: object = None,
+            additional_libs: object = None,
+        ) -> bool:
+            # Snapshot the final flag list so the test can inspect it.
+            captured_flags.append(list(board.build_flags or []))
+            platformio_ini_path.write_text("[platformio]\n")
+            return True
+
+        board = Board(
+            board_name="esp32c6",
+            real_board_name="esp32-c6-devkitc-1",
+            platform="espressif32",
+            framework="arduino",
+        )
+        paths = _make_paths(tmp)
+        build_dir = tmp / "build"
+
+        with (
+            mock.patch.dict(os.environ, env_patch, clear=False),
+            mock.patch.object(pio_module, "resolve_project_root", return_value=tmp),
+            mock.patch.object(
+                pio_module, "apply_board_specific_config", side_effect=fake_apply
+            ),
+            mock.patch.object(pio_module, "copy_example_source", return_value=True),
+            mock.patch.object(pio_module, "copy_fastled_library", return_value=True),
+            mock.patch.object(pio_module, "copy_boards_directory", return_value=True),
+        ):
+            return pio_module._init_platformio_build(
+                board,
+                verbose=False,
+                example="Blink",
+                paths=paths,
+                build_dir=build_dir,
+                use_fbuild=True,  # skip ensure_platform_installed / pio run
+                merge_root_platformio=merge_root_platformio,
+            )
+
+    def test_default_skips_root_merge(self) -> None:
+        """``merge_root_platformio=False`` does not append root flags."""
+        with TemporaryDirectory() as tmp_str:
+            tmp = Path(tmp_str)
+            _write_root_ini_with_esp32c6_flag(tmp, "-D LEGACY_ROOT_ONLY=1")
+            captured: list[list[str]] = []
+            result = self._run_init(
+                tmp,
+                merge_root_platformio=False,
+                fail_on_root_merge=False,
+                captured_flags=captured,
+            )
+            self.assertTrue(result.success, msg=getattr(result, "output", ""))
+            self.assertEqual(len(captured), 1)
+            # The legacy root-only flag MUST NOT appear in the final build_flags.
+            self.assertFalse(
+                any("LEGACY_ROOT_ONLY" in flag for flag in captured[0]),
+                f"Root-only flag leaked into synthesised env: {captured[0]!r}",
+            )
+
+    def test_opt_in_appends_root_flags(self) -> None:
+        """``merge_root_platformio=True`` restores the legacy merge."""
+        with TemporaryDirectory() as tmp_str:
+            tmp = Path(tmp_str)
+            _write_root_ini_with_esp32c6_flag(tmp, "-D ROOT_OPT_IN=1")
+            captured: list[list[str]] = []
+            result = self._run_init(
+                tmp,
+                merge_root_platformio=True,
+                fail_on_root_merge=False,
+                captured_flags=captured,
+            )
+            self.assertTrue(result.success, msg=getattr(result, "output", ""))
+            self.assertEqual(len(captured), 1)
+            self.assertTrue(
+                any("ROOT_OPT_IN" in flag for flag in captured[0]),
+                f"Opt-in root flag did not reach synthesised env: {captured[0]!r}",
+            )
+
+    def test_tripwire_raises_when_root_would_merge(self) -> None:
+        """``FASTLED_FAIL_ON_ROOT_MERGE=1`` + non-empty root => raise."""
+        with TemporaryDirectory() as tmp_str:
+            tmp = Path(tmp_str)
+            _write_root_ini_with_esp32c6_flag(tmp, "-D MUST_BE_PORTED=1")
+            captured: list[list[str]] = []
+            with self.assertRaises(RuntimeError) as ctx:
+                self._run_init(
+                    tmp,
+                    merge_root_platformio=False,
+                    fail_on_root_merge=True,
+                    captured_flags=captured,
+                )
+            self.assertIn("MUST_BE_PORTED", str(ctx.exception))
+            self.assertIn("FASTLED_FAIL_ON_ROOT_MERGE", str(ctx.exception))
+
+    def test_tripwire_silent_when_root_has_no_matching_env(self) -> None:
+        """Tripwire is a no-op when the root ini has no [env:<board>] match."""
+        with TemporaryDirectory() as tmp_str:
+            tmp = Path(tmp_str)
+            # Write a root ini but with NO [env:esp32c6] section.
+            (tmp / "platformio.ini").write_text(
+                "[env:uno]\nplatform = atmelavr\nbuild_flags = -DUNO_ONLY\n",
+            )
+            captured: list[list[str]] = []
+            result = self._run_init(
+                tmp,
+                merge_root_platformio=False,
+                fail_on_root_merge=True,
+                captured_flags=captured,
+            )
+            # No exception, no leak.
+            self.assertTrue(result.success, msg=getattr(result, "output", ""))
+            self.assertFalse(
+                any("UNO_ONLY" in flag for flag in captured[0]),
+                f"Unrelated env flag leaked: {captured[0]!r}",
+            )
+
+    def test_tripwire_allows_opt_in_merge(self) -> None:
+        """``merge_root_platformio=True`` + tripwire set => still merges, no raise.
+
+        The tripwire only fires when a flag would have been SILENTLY merged.
+        Opt-in callers (e.g. `bash debug --use-root-ini`) are explicit and
+        should not be blocked by the canary.
+        """
+        with TemporaryDirectory() as tmp_str:
+            tmp = Path(tmp_str)
+            _write_root_ini_with_esp32c6_flag(tmp, "-D EXPLICIT_OPT_IN=1")
+            captured: list[list[str]] = []
+            result = self._run_init(
+                tmp,
+                merge_root_platformio=True,
+                fail_on_root_merge=True,
+                captured_flags=captured,
+            )
+            self.assertTrue(result.success, msg=getattr(result, "output", ""))
+            self.assertTrue(
+                any("EXPLICIT_OPT_IN" in flag for flag in captured[0]),
+                f"Opt-in flag did not reach synthesised env: {captured[0]!r}",
+            )
+
+
+class TestPioCompilerConstructor(unittest.TestCase):
+    """Verify the new constructor parameter defaults to False."""
+
+    def test_default_merge_root_platformio_is_false(self) -> None:
+        """Constructing PioCompiler without the kwarg gives the sever default."""
+        with TemporaryDirectory() as tmp_str:
+            tmp = Path(tmp_str)
+            compiler = pio_module.PioCompiler(
+                board=Board(board_name="uno"),
+                verbose=False,
+                global_cache_dir=tmp / "cache",
+                use_fbuild=True,
+            )
+            self.assertFalse(compiler.merge_root_platformio)
+
+    def test_opt_in_keyword_is_stored(self) -> None:
+        """Passing merge_root_platformio=True is preserved on the instance."""
+        with TemporaryDirectory() as tmp_str:
+            tmp = Path(tmp_str)
+            compiler = pio_module.PioCompiler(
+                board=Board(board_name="uno"),
+                verbose=False,
+                global_cache_dir=tmp / "cache",
+                use_fbuild=True,
+                merge_root_platformio=True,
+            )
+            self.assertTrue(compiler.merge_root_platformio)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Phase 2 of meta-issue #3274 — severs the silent merge of root `platformio.ini` into every CI firmware build.

- Adds `merge_root_platformio: bool = False` parameter to `PioCompiler.__init__` and `_init_platformio_build`. Default is **off** — CI compile paths (`ci-compile.py` → `compile_board_examples`, plus `run_pio_build`) no longer silently inherit flags from the repo-root `platformio.ini`. Per-board flags belong in `ci/boards.py`.
- Adds `FASTLED_FAIL_ON_ROOT_MERGE=1` env-var tripwire that **raises** if any flag would still have been silently merged. Set on every CI build workflow so a forgotten Phase-1 flag fails CI loudly rather than changing CI binaries quietly.
- Test coverage in `ci/tests/test_root_platformio_sever.py` covers default-off, opt-in, tripwire-raises, tripwire-no-op, and tripwire-allows-opt-in.

Phase 1 (PRs #3276 + #3277) already ported the only load-bearing flags the legacy merge was actually delivering:

- `CONFIG_PARLIO_TX_ISR_HANDLER_IN_IRAM=1` + `CONFIG_PARLIO_TX_ISR_CACHE_SAFE=1` to a shared `_ESP32_PARLIO_BUILD_FLAGS` in `ci/boards.py` for every PARLIO-capable target (C5/C6/H2/P4/S3).
- `monitor_filters = default, esp32_exception_decoder` auto-defaulted for every ESP32-family board.
- `check_tool` plumbed into `boards.py`.

With those landed, the sever is safe and `bash compile <board>` paths stay green.

## Out of scope (deferred to #3279 Phase 3 + 4)

- Removing the `-UDEBUG / -DNDEBUG / -Os` band-aids in `[env:esp32dev]` added by PR #3268 to neutralise the legacy merge for the binary-size canary. They become dead weight after this PR but their removal is its own follow-up.
- Deleting `get_root_platformio_build_flags` entirely.
- Deprecating `PioCompiler` as a build fallback.
- Modifying root `platformio.ini` (orthogonal surface — lockdown rule enforced by PR #3280).
- The bash autoresearch sever (#3281) and the audio-detector regression (#3286).

## Test plan

- [x] `bash lint` clean.
- [x] `uv run pytest ci/tests/test_root_platformio_sever.py ci/tests/test_root_platformio_flag_merge.py ci/tests/test_fbuild_default_selection.py ci/tests/test_fbuild_compile_many.py` — 22/22 passed.
- [x] `bash compile uno --examples Blink` — succeeded locally (Flash: 4.90KB / 31.50KB).
- [x] Generated `.build/pio/esp32c6/platformio.ini` confirmed to NOT contain legacy root-only flags (`-DDEBUG`, `-DPIN_CLOCK=7`, `-DCORE_DEBUG_LEVEL=5`, etc.) — only the per-board flags from `ci/boards.py` are present.
- [ ] CI matrix (with `FASTLED_FAIL_ON_ROOT_MERGE=1` armed) confirms no per-board flag is still silently relying on the legacy merge.

Closes #3278
Refs #3274

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI validation to explicitly detect legacy configuration patterns instead of silently inheriting flags, ensuring builds fail transparently when misconfigurations are present.

* **Tests**
  * Added tests for configuration merge behavior validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->