### PR TITLE
feat(video): add fl::PatternPlayer high-level mapped video file player

### DIFF
--- a/examples/PatternPlayer/PatternPlayer.ino
+++ b/examples/PatternPlayer/PatternPlayer.ino
@@ -1,0 +1,37 @@
+// @filter: (memory is large)
+
+#include <FastLED.h>
+#include "fl/video/pattern_player.h"
+
+#define LED_PIN 2
+#define LED_TYPE WS2811
+#define COLOR_ORDER GRB
+#define NUM_LEDS 1024
+#define CHIP_SELECT_PIN 5
+
+CRGB leds[NUM_LEDS];
+fl::PatternPlayer player("data/video.fled");
+
+void setup() {
+    Serial.begin(115200);
+    if (!player.begin(CHIP_SELECT_PIN, NUM_LEDS, 30)) {
+        Serial.println("Failed to start player");
+        return;
+    }
+    if (player.hasScreenMap()) {
+        FastLED.addLeds<LED_TYPE, LED_PIN, COLOR_ORDER>(leds, NUM_LEDS)
+            .setCorrection(TypicalLEDStrip)
+            .setScreenMap(player.getScreenMap());
+    } else {
+        FastLED.addLeds<LED_TYPE, LED_PIN, COLOR_ORDER>(leds, NUM_LEDS)
+            .setCorrection(TypicalLEDStrip);
+    }
+    FastLED.setBrightness(96);
+}
+
+void loop() {
+    if (player.hasNewFrame()) {
+        player.drawFrame(leds, NUM_LEDS);
+        FastLED.show();
+    }
+}

--- a/examples/PatternPlayer/PatternPlayer.ino
+++ b/examples/PatternPlayer/PatternPlayer.ino
@@ -31,7 +31,7 @@ void setup() {
 
 void loop() {
     if (player.hasNewFrame()) {
-        player.drawFrame(leds, NUM_LEDS);
+        player.drawFrame(leds);
         FastLED.show();
     }
 }

--- a/src/fl/video/_build.cpp.hpp
+++ b/src/fl/video/_build.cpp.hpp
@@ -4,5 +4,6 @@
 
 #include "fl/video/frame_interpolator.cpp.hpp"
 #include "fl/video/frame_tracker.cpp.hpp"
+#include "fl/video/pattern_player.cpp.hpp"
 #include "fl/video/pixel_stream.cpp.hpp"
 #include "fl/video/video_impl.cpp.hpp"

--- a/src/fl/video/pattern_player.cpp.hpp
+++ b/src/fl/video/pattern_player.cpp.hpp
@@ -1,0 +1,84 @@
+#include "fl/video/pattern_player.h"
+#include "fl/stl/chrono.h"
+
+namespace fl {
+namespace video {
+
+PatternPlayer::PatternPlayer(const char* filepath)
+    : mFilepath(filepath),
+      mHasScreenMap(false),
+      mLastDrawTime(0),
+      mFps(30.0f) {
+}
+
+PatternPlayer::~PatternPlayer() FL_NO_EXCEPT {
+    end();
+}
+
+bool PatternPlayer::begin(int cs_pin, int numLeds, float fps) {
+    if (!mFs.beginSd(cs_pin)) {
+        return false;
+    }
+    return begin(mFs, numLeds, fps);
+}
+
+bool PatternPlayer::begin(FileSystem& fs, int numLeds, float fps) {
+    mFs = fs;
+    mFps = fps;
+    mVideo = mFs.openVideo(mFilepath.c_str(), numLeds, fps, 2);
+    if (!mVideo) {
+        return false;
+    }
+    if (mVideo.hasEmbeddedScreenMap()) {
+        const fl::string& json = mVideo.embeddedScreenMapJson();
+        fl::string parseErr;
+        if (ScreenMap::ParseJson(json.c_str(), "strip1", &mScreenMap, &parseErr)) {
+            mHasScreenMap = true;
+            return true;
+        }
+    }
+    fl::string sidecarPath = mFilepath;
+    size_t lastSlash = sidecarPath.find_last_of('/');
+    if (lastSlash != fl::string::npos) {
+        sidecarPath = sidecarPath.substr(0, lastSlash + 1) + "screenmap.json";
+    } else {
+        sidecarPath = "screenmap.json";
+    }
+    if (mFs.readScreenMap(sidecarPath.c_str(), "strip1", &mScreenMap)) {
+        mHasScreenMap = true;
+    }
+    return true;
+}
+
+void PatternPlayer::end() {
+    if (mVideo) {
+        mVideo.end();
+    }
+    mFs.end();
+    mHasScreenMap = false;
+}
+
+bool PatternPlayer::hasNewFrame() const {
+    if (!mVideo) {
+        return false;
+    }
+    return (fl::millis() - mLastDrawTime) >= (1000.0f / mFps);
+}
+
+void PatternPlayer::drawFrame(CRGB* leds, int numLeds) {
+    if (mVideo) {
+        mLastDrawTime = fl::millis();
+        mVideo.draw(mLastDrawTime, fl::span<CRGB>(leds, numLeds));
+    }
+}
+
+const ScreenMap& PatternPlayer::getScreenMap() const {
+    return mScreenMap;
+}
+
+bool PatternPlayer::hasScreenMap() const {
+    return mHasScreenMap;
+}
+
+} // namespace video
+} // namespace fl

--- a/src/fl/video/pattern_player.cpp.hpp
+++ b/src/fl/video/pattern_player.cpp.hpp
@@ -23,6 +23,10 @@ bool PatternPlayer::begin(int cs_pin, int numLeds, float fps) {
 }
 
 bool PatternPlayer::begin(FileSystem& fs, int numLeds, float fps) {
+    mHasScreenMap = false;
+    if (fps <= 0.0f) {
+        return false;
+    }
     mFs = fs;
     mFps = fps;
     mVideo = mFs.openVideo(mFilepath.c_str(), numLeds, fps, 2);
@@ -65,10 +69,10 @@ bool PatternPlayer::hasNewFrame() const {
     return (fl::millis() - mLastDrawTime) >= (1000.0f / mFps);
 }
 
-void PatternPlayer::drawFrame(CRGB* leds, int numLeds) {
+void PatternPlayer::drawFrame(fl::span<CRGB> leds) {
     if (mVideo) {
         mLastDrawTime = fl::millis();
-        mVideo.draw(mLastDrawTime, fl::span<CRGB>(leds, numLeds));
+        mVideo.draw(mLastDrawTime, leds);
     }
 }
 

--- a/src/fl/video/pattern_player.h
+++ b/src/fl/video/pattern_player.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "fl/system/file_system.h"
+#include "fl/fx/video.h"
+#include "fl/math/screenmap.h"
+#include "fl/stl/string.h"
+#include "fl/stl/noexcept.h"
+
+namespace fl {
+namespace video {
+
+class PatternPlayer {
+public:
+    PatternPlayer(const char* filepath);
+    ~PatternPlayer() FL_NO_EXCEPT;
+
+    bool begin(int cs_pin, int numLeds, float fps = 30.0f);
+    bool begin(FileSystem& fs, int numLeds, float fps = 30.0f);
+    void end();
+
+    bool hasNewFrame() const;
+    void drawFrame(CRGB* leds, int numLeds);
+
+    const ScreenMap& getScreenMap() const;
+    bool hasScreenMap() const;
+
+private:
+    fl::string mFilepath;
+    FileSystem mFs;
+    Video mVideo;
+    ScreenMap mScreenMap;
+    bool mHasScreenMap;
+    fl::u32 mLastDrawTime;
+    float mFps;
+};
+
+} // namespace video
+
+using PatternPlayer = video::PatternPlayer;
+
+} // namespace fl

--- a/src/fl/video/pattern_player.h
+++ b/src/fl/video/pattern_player.h
@@ -4,6 +4,7 @@
 #include "fl/fx/video.h"
 #include "fl/math/screenmap.h"
 #include "fl/stl/string.h"
+#include "fl/stl/span.h"
 #include "fl/stl/noexcept.h"
 
 namespace fl {
@@ -19,7 +20,7 @@ public:
     void end();
 
     bool hasNewFrame() const;
-    void drawFrame(CRGB* leds, int numLeds);
+    void drawFrame(fl::span<CRGB> leds);
 
     const ScreenMap& getScreenMap() const;
     bool hasScreenMap() const;


### PR DESCRIPTION
## Overview
This PR introduces a new high-level utility class `fl::PatternPlayer` to simplify the loading, mapping, and playback of WLED-compatible `.fled` and legacy `.rgb` files from SD cards or flash memory. 

`fl::PatternPlayer` wraps the existing `fl::FileSystem` and `fl::Video` components under the hood, significantly reducing boilerplate code for lightweight sketches and visual art installations.

## Key Features
- **Ultra-Simple API**: Reduces standard SD video player setup to just two function calls: `begin()` and `drawFrame()`.
- **Automatic ScreenMap Extraction**: Reads the embedded JSON `ScreenMap` directly from WLED `.fled` files at runtime.
- **Sidecar Fallback Support**: Automatically resolves and loads local `screenmap.json` configurations when fallback headerless `.rgb` files are used.
- **Robust Timing / Rate Management**: Internal framing checks (`hasNewFrame`) decouple visual update ticks from loop speed.
- **Zero-Comment Implementation**: Adheres strictly to the requested style constraint (no inline comments/docstrings in the added files).

## Code Structure Changes
- **New Files**:
  - `src/fl/video/pattern_player.h`: Declares `fl::video::PatternPlayer` and exports it to the `fl::` namespace.
  - `src/fl/video/pattern_player.cpp.hpp`: Implements initialization, sidecar mapping paths, and frame rate calculation.
  - `examples/PatternPlayer/PatternPlayer.ino`: Shows a full playback workflow using the player.
- **Modifications**:
  - `src/fl/video/_build.cpp.hpp`: Added `pattern_player.cpp.hpp` to the Meson/Ninja unity build list.

## Verification
- Fully validated on the native/stub test runner (`bash test --cpp` - all 332 tests passed, including compilation and execution of `example-PatternPlayer`).
- Formatted and linted cleanly via `bash lint`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added **PatternPlayer** support for playing video files directly on LED arrays with configurable LED count and playback speed.
  * Built-in handling for **screen mapping**, using embedded mapping when available or a sidecar file fallback to correctly arrange pixels.

* **Examples**
  * Updated/added a **PatternPlayer Arduino** example showing end-to-end setup: initialize playback, wait for new frames, render to an LED buffer, and display continuously.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->