### PR TITLE
refactor(math): move JSON soft-FP bit-codec into fl/math/ + fl::number scaffold

### DIFF
--- a/src/fl/math/number.h
+++ b/src/fl/math/number.h
@@ -1,0 +1,122 @@
+#pragma once
+
+// fl::number -- 64-bit packed tagged numeric value.
+//
+// A purpose-built single-slot replacement for `fl::variant<i64, float,
+// double>` that fits the JSON / RPC / serialized-numeric use case at half
+// the storage cost. Designed for FastLED #3022; reusable beyond JSON for
+// anyone trafficking small numeric values whose precision needs are
+// dominated by integer ranges with optional fractional resolution.
+//
+// Layout (64 bits total):
+//   Bits [63:61]  tag      -- 3-bit discriminator (8 representations)
+//   Bits [60:0]   payload  -- 61-bit value, interpretation per `tag`
+//
+// The shared 64-bit slot means a `number` slots into the same union storage
+// as a `double` with zero size overhead -- no separate discriminator byte
+// gets padded into a 16-byte cell.
+//
+// Tag semantics (initial set; tags 4..7 reserved for future expansion):
+//   SIGNED_INT   -- payload is a 61-bit two's-complement signed integer
+//                   (range: ~ +/- 1.15e18). Common case for JSON / RPC
+//                   integers; covers microsecond timestamps and
+//                   LED-count-like values without truncation.
+//   UNSIGNED_INT -- payload is a 61-bit unsigned integer.
+//                   (range: 0 .. ~2.3e18).
+//   FLOAT_60     -- payload is a custom 60-bit IEEE-754-like float:
+//                     bit 60     sign
+//                     bits 59:49 11-bit exponent (bias 1023, same as
+//                                IEEE-754 double, but range clipped to fit)
+//                     bits 48:0  49-bit mantissa (implicit-1, like double)
+//                   Reuses the soft_float bit-codec for widening to/from
+//                   IEEE-754 double when an FPU is present.
+//                   This is the slot the "float60 with identifier tag"
+//                   note in the design refers to.
+//   (4..7 reserved -- future tags for Q-format fixed-point, IEEE-half
+//   on host, error/NaN sentinel for parse failures, etc.)
+//
+// This header defines only the type, tag enum, and basic accessors.
+// Arithmetic, parser, serializer, and JSON-side adoption land in
+// follow-up PRs so each step ships with verifiable LPC-side bloat
+// reductions without bundling unrelated design changes.
+
+#include "fl/stl/cstddef.h"
+#include "fl/stl/noexcept.h"
+#include "fl/stl/static_assert.h"
+#include "fl/stl/stdint.h"
+
+namespace fl {
+
+class number {
+public:
+    enum class tag : fl::u8 {
+        SIGNED_INT   = 0,
+        UNSIGNED_INT = 1,
+        FLOAT_60     = 2,
+        RESERVED_3   = 3,
+        RESERVED_4   = 4,
+        RESERVED_5   = 5,
+        RESERVED_6   = 6,
+        RESERVED_7   = 7,
+    };
+
+    // 64-bit raw representation: tag in top 3 bits, payload in low 61.
+    fl::u64 raw;
+
+    static constexpr fl::u64 kPayloadMask = (fl::u64(1) << 61) - 1;
+    static constexpr int     kPayloadBits = 61;
+    static constexpr int     kTagShift    = 61;
+
+    constexpr number() FL_NO_EXCEPT : raw(0) {}
+
+    // Direct construction from (tag, payload). Caller is responsible for
+    // ensuring the payload fits in 61 bits (or has been masked).
+    constexpr number(tag t, fl::u64 payload) FL_NO_EXCEPT
+        : raw((static_cast<fl::u64>(t) << kTagShift) |
+              (payload & kPayloadMask)) {}
+
+    // Factories for the initial tag set.
+
+    // Construct a SIGNED_INT number from any 64-bit signed integer that
+    // fits in 61 signed bits. Saturates at +/-(2^60 - 1) for out-of-range
+    // inputs (returns SIGNED_INT_MAX / MIN-of-61-bits) so the call site
+    // never silently aliases into a different tag's payload.
+    static number from_signed(fl::i64 v) FL_NO_EXCEPT {
+        constexpr fl::i64 kMax = (fl::i64(1) << 60) - 1;
+        constexpr fl::i64 kMin = -(fl::i64(1) << 60);
+        if (v > kMax) v = kMax;
+        if (v < kMin) v = kMin;
+        // Sign-extend into 61 bits, then mask.
+        const fl::u64 payload = static_cast<fl::u64>(v) & kPayloadMask;
+        return number(tag::SIGNED_INT, payload);
+    }
+
+    // Construct an UNSIGNED_INT number; saturates at 2^61 - 1.
+    static number from_unsigned(fl::u64 v) FL_NO_EXCEPT {
+        if (v > kPayloadMask) v = kPayloadMask;
+        return number(tag::UNSIGNED_INT, v);
+    }
+
+    // Tag / payload accessors.
+    constexpr tag get_tag() const FL_NO_EXCEPT {
+        return static_cast<tag>(raw >> kTagShift);
+    }
+    constexpr fl::u64 payload() const FL_NO_EXCEPT {
+        return raw & kPayloadMask;
+    }
+
+    // Sign-extended payload for SIGNED_INT extraction. Caller is
+    // responsible for asserting `get_tag() == tag::SIGNED_INT`.
+    fl::i64 as_signed_payload() const FL_NO_EXCEPT {
+        // Sign-extend bit 60 across the upper 3 bits.
+        const fl::u64 p = payload();
+        const fl::u64 sign_bit = p & (fl::u64(1) << 60);
+        return static_cast<fl::i64>(sign_bit ? (p | ~kPayloadMask) : p);
+    }
+};
+
+FL_STATIC_ASSERT(sizeof(number) == sizeof(fl::u64),
+                 "fl::number must be exactly 64 bits to slot into JSON / RPC "
+                 "value cells without padding overhead.");
+
+} // namespace fl

--- a/src/fl/math/soft_float.h
+++ b/src/fl/math/soft_float.h
@@ -1,0 +1,201 @@
+#pragma once
+
+// fl::soft_float -- integer-only IEEE-754 float<->double conversion.
+//
+// On no-FPU targets (Cortex-M0+, ATmega, ...) a plain `static_cast<double>(f)`
+// or `static_cast<float>(d)` anchors libgcc's soft-FP helpers
+// (`__aeabi_f2d`, `__aeabi_d2f`) which transitively pull `__aeabi_dadd /
+// dmul / ddiv / dcmpun / scalbn` and similar. That's ~6 KB of flash on
+// LPC845 / similar 64 KB-flash parts -- ~10% of the budget.
+//
+// This module provides bit-level conversions that perform the IEEE-754
+// widening / narrowing using only integer arithmetic (shift / mask / add).
+// They are correct on every host with IEEE-754 `float` / `double` (which is
+// every supported FastLED target), produce bit-exact results, and emit
+// zero soft-FP symbols even when called from a no-FPU build.
+//
+// Symmetric narrowing-vs-widening contract:
+//   - Sign bit copied directly.
+//   - +/-zero, +/-inf preserved bit-exactly.
+//   - NaN canonicalized to a quiet-NaN with the standard payload
+//     (matches what the JSON path already did with its narrowing helper).
+//   - Subnormal float -> normal double (widening); double subnormal /
+//     small normal -> float subnormal (narrowing).
+//
+// Predecessor: this code lived in `fl/stl/json/types_impl.h` (`json_*`
+// names) for the LPC845 JSON-RPC bring-up (FastLED #3038 / #3076 / #3226).
+// Moved to `fl/math/` as part of FastLED #3022 so non-JSON callers
+// (audio, animation timing, anyone else who needs FP without the libgcc
+// soft-FP tax) can use it directly.
+
+#include "fl/stl/bit_cast.h"
+#include "fl/stl/cstddef.h"
+#include "fl/stl/stdint.h"
+#include "fl/stl/noexcept.h"
+
+namespace fl {
+
+namespace detail {
+
+// Byte-wise reinterpret. Differs from `fl::bit_cast<To, From>` in that it
+// does NOT static-assert on size equality -- it copies
+// `min(sizeof(To), sizeof(From))` bytes and zero-pads the rest. Used here
+// so the `sizeof(double) == sizeof(u32)` (pathological-host) branch can
+// compile alongside the standard 8-byte-double branch without tripping
+// `bit_cast`'s assertion.
+template <typename To, typename From>
+inline To soft_bit_copy(const From& value) FL_NO_EXCEPT {
+    To out = 0;
+    const char* src = fl::bit_cast_ptr<const char>(&value);
+    char* dst = fl::bit_cast_ptr<char>(&out);
+    const fl::size n = sizeof(To) < sizeof(From) ? sizeof(To) : sizeof(From);
+    for (fl::size i = 0; i < n; ++i) {
+        dst[i] = src[i];
+    }
+    return out;
+}
+
+inline u32 soft_round_shift_right_u64(u64 value, int shift) FL_NO_EXCEPT {
+    if (shift <= 0) {
+        return static_cast<u32>(value);
+    }
+    if (shift >= 64) {
+        return 0;
+    }
+    const u64 half = u64(1) << (shift - 1);
+    const u64 mask = (u64(1) << shift) - 1;
+    const u64 truncated = value >> shift;
+    const u64 remainder = value & mask;
+    const bool round_up = remainder > half || (remainder == half && (truncated & 1));
+    return static_cast<u32>(truncated + (round_up ? 1 : 0));
+}
+
+inline int soft_floor_log2_u64(u64 value) FL_NO_EXCEPT {
+    int bit = -1;
+    while (value != 0) {
+        value >>= 1;
+        ++bit;
+    }
+    return bit;
+}
+
+inline u32 soft_float_bits_from_scaled_u64(
+    u32 sign, u64 magnitude, int binary_exp) FL_NO_EXCEPT {
+    if (magnitude == 0) {
+        return sign;
+    }
+
+    const int top_bit = soft_floor_log2_u64(magnitude);
+    int exponent = top_bit + binary_exp;
+    if (exponent > 127) {
+        return sign | 0x7F800000u;
+    }
+
+    if (exponent >= -126) {
+        const int shift = top_bit - 23;
+        u32 significand = shift > 0
+            ? soft_round_shift_right_u64(magnitude, shift)
+            : static_cast<u32>(magnitude << -shift);
+        if (significand >= 0x01000000u) {
+            significand >>= 1;
+            ++exponent;
+            if (exponent > 127) {
+                return sign | 0x7F800000u;
+            }
+        }
+        return sign | (static_cast<u32>(exponent + 127) << 23) |
+               (significand & 0x007FFFFFu);
+    }
+
+    const int subnormal_shift = -(binary_exp + 149);
+    u32 mantissa = 0;
+    if (subnormal_shift > 0) {
+        mantissa = soft_round_shift_right_u64(magnitude, subnormal_shift);
+    } else {
+        const int left_shift = -subnormal_shift;
+        if (left_shift >= 64 || magnitude > (u64(-1) >> left_shift)) {
+            return sign | 0x7F800000u;
+        }
+        const u64 shifted = magnitude << left_shift;
+        mantissa = shifted > 0x007FFFFFu ? 0x00800000u : static_cast<u32>(shifted);
+    }
+    if (mantissa >= 0x00800000u) {
+        return sign | 0x00800000u;
+    }
+    return sign | mantissa;
+}
+
+} // namespace detail
+
+// Narrow a 64-bit double's bit pattern to the bit pattern of the closest
+// 32-bit float, using only integer arithmetic. Round-to-nearest-even.
+inline u32 soft_float_bits_from_double_bits(u64 bits) FL_NO_EXCEPT {
+    const u32 sign = (bits >> 63) ? 0x80000000u : 0u;
+    const u32 exp_bits = static_cast<u32>((bits >> 52) & 0x7FFu);
+    const u64 mantissa_bits = bits & 0x000FFFFFFFFFFFFFull;
+    if (exp_bits == 0x7FFu) {
+        return mantissa_bits == 0 ? sign | 0x7F800000u : sign | 0x7FC00000u;
+    }
+    if (exp_bits == 0) {
+        return detail::soft_float_bits_from_scaled_u64(sign, mantissa_bits, -1074);
+    }
+    return detail::soft_float_bits_from_scaled_u64(
+        sign, mantissa_bits | 0x0010000000000000ull,
+        static_cast<int>(exp_bits) - 1075);
+}
+
+// Widen a 32-bit float's bit pattern to the bit pattern of the same value
+// as a 64-bit double, using only integer arithmetic. Lossless: every finite
+// float has an exact double representation, and the round-trip
+// `double_bits_from_float_bits(float_bits_from_double_bits(d))` is the
+// identity for any `d` that was a widened float.
+inline u64 soft_double_bits_from_float_bits(u32 bits) FL_NO_EXCEPT {
+    const u64 sign = (bits >> 31) ? 0x8000000000000000ull : 0ull;
+    const u32 exp_bits = (bits >> 23) & 0xFFu;
+    const u32 mantissa_bits = bits & 0x007FFFFFu;
+    if (exp_bits == 0xFFu) {
+        return mantissa_bits == 0 ? sign | 0x7FF0000000000000ull
+                                  : sign | 0x7FF8000000000000ull;
+    }
+    if (exp_bits == 0) {
+        if (mantissa_bits == 0) {
+            return sign;
+        }
+        // Subnormal float -- always a normal double. Walk the implicit bit
+        // up to position 23, adjust exponent accordingly.
+        u32 m = mantissa_bits;
+        int shift = 0;
+        while ((m & 0x00800000u) == 0) {
+            m <<= 1;
+            ++shift;
+        }
+        const int double_exp = 1 - 127 - shift + 1023;
+        const u64 mantissa_d = static_cast<u64>(m & 0x007FFFFFu) << 29;
+        return sign | (static_cast<u64>(double_exp) << 52) | mantissa_d;
+    }
+    const int double_exp = static_cast<int>(exp_bits) - 127 + 1023;
+    const u64 mantissa_d = static_cast<u64>(mantissa_bits) << 29;
+    return sign | (static_cast<u64>(double_exp) << 52) | mantissa_d;
+}
+
+// Convenience: narrow a `double` value to a `float` via the integer codec.
+inline float soft_double_to_float(double value) FL_NO_EXCEPT {
+    if (sizeof(double) == sizeof(u32)) {
+        return detail::soft_bit_copy<float>(value);
+    }
+    const u32 narrowed_bits =
+        soft_float_bits_from_double_bits(detail::soft_bit_copy<u64>(value));
+    return detail::soft_bit_copy<float>(narrowed_bits);
+}
+
+// Convenience: widen a `float` value to a `double` via the integer codec.
+inline double soft_float_to_double(float value) FL_NO_EXCEPT {
+    if (sizeof(double) == sizeof(u32)) {
+        return detail::soft_bit_copy<double>(value);
+    }
+    const u64 widened_bits =
+        soft_double_bits_from_float_bits(detail::soft_bit_copy<u32>(value));
+    return detail::soft_bit_copy<double>(widened_bits);
+}
+
+} // namespace fl

--- a/src/fl/stl/json/types.h
+++ b/src/fl/stl/json/types.h
@@ -41,7 +41,9 @@ inline int json_floor_log2_u64(u64 value) FL_NO_EXCEPT;
 inline u32 json_ieee754_float_bits_from_scaled_u64(
     u32 sign, u64 magnitude, int binary_exp) FL_NO_EXCEPT;
 inline u32 json_ieee754_float_bits_from_double_bits(u64 bits) FL_NO_EXCEPT;
+inline u64 json_ieee754_double_bits_from_float_bits(u32 bits) FL_NO_EXCEPT;
 inline float json_double_to_float(double value) FL_NO_EXCEPT;
+inline double json_float_to_double(float value) FL_NO_EXCEPT;
 
 } // namespace detail
 
@@ -433,18 +435,24 @@ struct float_conversion_visitor {
         result = value;
     }
     
-    // Special handling to avoid conflict when FloatType is double
+    // Special handling to avoid conflict when FloatType is double.
+    // Narrowing path: double -> float (FloatType resolves to float here).
+    // Use the integer IEEE-754 bit-codec from #3038 so this never anchors
+    // `__aeabi_d2f` on no-FPU targets. See FastLED #3022 / #3002.
     template<typename T = FloatType>
     typename fl::enable_if<!fl::is_same<T, double>::value, void>::type
     operator()(const double& value) FL_NO_EXCEPT {
-        result = static_cast<FloatType>(value);
+        result = static_cast<FloatType>(detail::json_double_to_float(value));
     }
-    
-    // Special handling to avoid conflict when FloatType is float
+
+    // Special handling to avoid conflict when FloatType is float.
+    // Widening path: float -> double (FloatType resolves to double here).
+    // Use the integer IEEE-754 bit-codec companion so this never anchors
+    // `__aeabi_f2d` on no-FPU targets. See FastLED #3022 / #3002.
     template<typename T = FloatType>
     typename fl::enable_if<!fl::is_same<T, float>::value, void>::type
     operator()(const float& value) FL_NO_EXCEPT {
-        result = static_cast<FloatType>(value);
+        result = static_cast<FloatType>(detail::json_float_to_double(value));
     }
     
     void operator()(const i64& value) FL_NO_EXCEPT {
@@ -553,9 +561,15 @@ struct float_conversion_visitor<double> {
     void operator()(const double& value) FL_NO_EXCEPT {
         result = value;
     }
-    
+
     void operator()(const float& value) FL_NO_EXCEPT {
-        result = static_cast<double>(value);
+        // Widening float -> double via the integer IEEE-754 bit-codec
+        // companion to `json_double_to_float`. Even though `as_double()`
+        // is DCE'd from LowMemory builds today (per line 564 below),
+        // routing through the bit-codec means a future caller that keeps
+        // `as_double()` alive on a no-FPU target won't drag in
+        // `__aeabi_f2d`. See FastLED #3022 / #3002.
+        result = detail::json_float_to_double(value);
     }
     
     void operator()(const i64& value) FL_NO_EXCEPT {

--- a/src/fl/stl/json/types_impl.h
+++ b/src/fl/stl/json/types_impl.h
@@ -1,111 +1,48 @@
 #pragma once
 
+// FastLED #3022: the IEEE-754 bit-codec primitives that used to live here
+// have moved to `fl/math/soft_float.h` so non-JSON callers can use them
+// too. This file is now a thin shim that exposes the old `json_*` names
+// (still referenced by the existing forward declarations in `types.h`)
+// while delegating to the new home.
+
+#include "fl/math/soft_float.h"
+
 namespace fl {
 namespace detail {
 
 inline u32 json_round_shift_right_u64(u64 value, int shift) FL_NO_EXCEPT {
-    if (shift <= 0) {
-        return static_cast<u32>(value);
-    }
-    if (shift >= 64) {
-        return 0;
-    }
-    const u64 half = u64(1) << (shift - 1);
-    const u64 mask = (u64(1) << shift) - 1;
-    const u64 truncated = value >> shift;
-    const u64 remainder = value & mask;
-    const bool round_up = remainder > half || (remainder == half && (truncated & 1));
-    return static_cast<u32>(truncated + (round_up ? 1 : 0));
+    return fl::detail::soft_round_shift_right_u64(value, shift);
 }
 
 inline int json_floor_log2_u64(u64 value) FL_NO_EXCEPT {
-    int bit = -1;
-    while (value != 0) {
-        value >>= 1;
-        ++bit;
-    }
-    return bit;
+    return fl::detail::soft_floor_log2_u64(value);
 }
 
 inline u32 json_ieee754_float_bits_from_scaled_u64(
     u32 sign, u64 magnitude, int binary_exp) FL_NO_EXCEPT {
-    if (magnitude == 0) {
-        return sign;
-    }
-
-    const int top_bit = json_floor_log2_u64(magnitude);
-    int exponent = top_bit + binary_exp;
-    if (exponent > 127) {
-        return sign | 0x7F800000u;
-    }
-
-    if (exponent >= -126) {
-        const int shift = top_bit - 23;
-        u32 significand = shift > 0
-            ? json_round_shift_right_u64(magnitude, shift)
-            : static_cast<u32>(magnitude << -shift);
-        if (significand >= 0x01000000u) {
-            significand >>= 1;
-            ++exponent;
-            if (exponent > 127) {
-                return sign | 0x7F800000u;
-            }
-        }
-        return sign | (static_cast<u32>(exponent + 127) << 23) |
-               (significand & 0x007FFFFFu);
-    }
-
-    const int subnormal_shift = -(binary_exp + 149);
-    u32 mantissa = 0;
-    if (subnormal_shift > 0) {
-        mantissa = json_round_shift_right_u64(magnitude, subnormal_shift);
-    } else {
-        const int left_shift = -subnormal_shift;
-        if (left_shift >= 64 || magnitude > (u64(-1) >> left_shift)) {
-            return sign | 0x7F800000u;
-        }
-        const u64 shifted = magnitude << left_shift;
-        mantissa = shifted > 0x007FFFFFu ? 0x00800000u : static_cast<u32>(shifted);
-    }
-    if (mantissa >= 0x00800000u) {
-        return sign | 0x00800000u;
-    }
-    return sign | mantissa;
+    return fl::detail::soft_float_bits_from_scaled_u64(sign, magnitude, binary_exp);
 }
 
 inline u32 json_ieee754_float_bits_from_double_bits(u64 bits) FL_NO_EXCEPT {
-    const u32 sign = (bits >> 63) ? 0x80000000u : 0u;
-    const u32 exp_bits = static_cast<u32>((bits >> 52) & 0x7FFu);
-    const u64 mantissa_bits = bits & 0x000FFFFFFFFFFFFFull;
-    if (exp_bits == 0x7FFu) {
-        return mantissa_bits == 0 ? sign | 0x7F800000u : sign | 0x7FC00000u;
-    }
-    if (exp_bits == 0) {
-        return json_ieee754_float_bits_from_scaled_u64(sign, mantissa_bits, -1074);
-    }
-    return json_ieee754_float_bits_from_scaled_u64(
-        sign, mantissa_bits | 0x0010000000000000ull,
-        static_cast<int>(exp_bits) - 1075);
+    return fl::soft_float_bits_from_double_bits(bits);
+}
+
+inline u64 json_ieee754_double_bits_from_float_bits(u32 bits) FL_NO_EXCEPT {
+    return fl::soft_double_bits_from_float_bits(bits);
 }
 
 template <typename To, typename From>
 inline To json_bit_copy(const From& value) FL_NO_EXCEPT {
-    To out = 0;
-    const char* src = fl::bit_cast_ptr<const char>(&value);
-    char* dst = fl::bit_cast_ptr<char>(&out);
-    const fl::size n = sizeof(To) < sizeof(From) ? sizeof(To) : sizeof(From);
-    for (fl::size i = 0; i < n; ++i) {
-        dst[i] = src[i];
-    }
-    return out;
+    return fl::detail::soft_bit_copy<To, From>(value);
 }
 
 inline float json_double_to_float(double value) FL_NO_EXCEPT {
-    if (sizeof(double) == sizeof(u32)) {
-        return fl::bit_cast<float>(json_bit_copy<u32>(value));
-    }
-    return fl::bit_cast<float>(
-        json_ieee754_float_bits_from_double_bits(json_bit_copy<u64>(value)));
+    return fl::soft_double_to_float(value);
+}
+
+inline double json_float_to_double(float value) FL_NO_EXCEPT {
+    return fl::soft_float_to_double(value);
 }
 
 } // namespace detail

--- a/tests/fl/math/number.cpp
+++ b/tests/fl/math/number.cpp
@@ -1,0 +1,71 @@
+// Unit tests for fl::number -- 64-bit packed tagged numeric value.
+// See FastLED #3022.
+
+#include "test.h"
+
+#include "fl/math/number.h"
+#include "fl/stl/cstddef.h"
+#include "fl/stl/stdint.h"
+
+FL_TEST_FILE(FL_FILEPATH) {
+
+using namespace fl;
+
+FL_TEST_CASE("fl::number default construct is zero/SIGNED_INT") {
+    number n;
+    FL_CHECK_EQ(n.raw, 0u);
+    FL_CHECK(n.get_tag() == number::tag::SIGNED_INT);
+    FL_CHECK_EQ(n.payload(), 0u);
+}
+
+FL_TEST_CASE("fl::number from_signed round-trip") {
+    const i64 sample_values[] = {
+        0, 1, -1, 42, -42,
+        2147483647LL, -2147483648LL,
+        (i64(1) << 50), -(i64(1) << 50),
+        (i64(1) << 60) - 1,  // max positive in 61 bits
+        -(i64(1) << 60),     // min negative in 61 bits
+    };
+    for (i64 v : sample_values) {
+        number n = number::from_signed(v);
+        FL_CHECK(n.get_tag() == number::tag::SIGNED_INT);
+        FL_CHECK_EQ(n.as_signed_payload(), v);
+    }
+}
+
+FL_TEST_CASE("fl::number from_signed saturates out-of-range") {
+    // Above max (61 bits signed): saturates to (2^60 - 1).
+    number n_above = number::from_signed((i64(1) << 60) + 5);
+    FL_CHECK(n_above.get_tag() == number::tag::SIGNED_INT);
+    FL_CHECK_EQ(n_above.as_signed_payload(), (i64(1) << 60) - 1);
+
+    // Below min: saturates to -(2^60).
+    number n_below = number::from_signed(-(i64(1) << 60) - 5);
+    FL_CHECK(n_below.get_tag() == number::tag::SIGNED_INT);
+    FL_CHECK_EQ(n_below.as_signed_payload(), -(i64(1) << 60));
+}
+
+FL_TEST_CASE("fl::number from_unsigned round-trip + saturation") {
+    const u64 sample_values[] = {
+        0u, 1u, 42u,
+        (u64(1) << 32),
+        (u64(1) << 60),
+        (u64(1) << 61) - 1,  // max in 61 bits unsigned
+    };
+    for (u64 v : sample_values) {
+        number n = number::from_unsigned(v);
+        FL_CHECK(n.get_tag() == number::tag::UNSIGNED_INT);
+        FL_CHECK_EQ(n.payload(), v);
+    }
+
+    // Above max: saturates.
+    number n_sat = number::from_unsigned(u64(-1));
+    FL_CHECK(n_sat.get_tag() == number::tag::UNSIGNED_INT);
+    FL_CHECK_EQ(n_sat.payload(), (u64(1) << 61) - 1);
+}
+
+FL_TEST_CASE("fl::number storage footprint is exactly 64 bits") {
+    FL_CHECK_EQ(sizeof(number), sizeof(u64));
+}
+
+} // FL_TEST_FILE

--- a/tests/fl/math/soft_float.cpp
+++ b/tests/fl/math/soft_float.cpp
@@ -1,0 +1,125 @@
+// Unit tests for fl::soft_float -- integer-only IEEE-754 float<->double
+// bit-codec. See FastLED #3022 / #3002.
+
+#include "test.h"
+
+#include "fl/math/soft_float.h"
+#include "fl/stl/bit_cast.h"
+#include "fl/stl/cstddef.h"
+
+FL_TEST_FILE(FL_FILEPATH) {
+
+using namespace fl;
+
+static double widen_via_bitcodec(float v) {
+    return fl::soft_float_to_double(v);
+}
+
+static double widen_via_native(float v) {
+    return static_cast<double>(v);
+}
+
+static float narrow_via_bitcodec(double v) {
+    return fl::soft_double_to_float(v);
+}
+
+static float narrow_via_native(double v) {
+    return static_cast<float>(v);
+}
+
+// ---- widening: float -> double ----
+
+FL_TEST_CASE("soft_float_to_double -- zero round-trip") {
+    FL_CHECK_EQ(widen_via_bitcodec(0.0f), widen_via_native(0.0f));
+    FL_CHECK_EQ(widen_via_bitcodec(-0.0f), widen_via_native(-0.0f));
+    FL_CHECK_EQ(fl::bit_cast<u64>(widen_via_bitcodec(0.0f)),  0x0000000000000000ull);
+    FL_CHECK_EQ(fl::bit_cast<u64>(widen_via_bitcodec(-0.0f)), 0x8000000000000000ull);
+}
+
+FL_TEST_CASE("soft_float_to_double -- well-known normals") {
+    FL_CHECK_EQ(widen_via_bitcodec(1.0f), 1.0);
+    FL_CHECK_EQ(widen_via_bitcodec(-1.0f), -1.0);
+    FL_CHECK_EQ(widen_via_bitcodec(2.0f), 2.0);
+    FL_CHECK_EQ(widen_via_bitcodec(0.5f), 0.5);
+    FL_CHECK_EQ(widen_via_bitcodec(0.125f), 0.125);
+    FL_CHECK_EQ(widen_via_bitcodec(3.14f), widen_via_native(3.14f));
+}
+
+FL_TEST_CASE("soft_float_to_double -- subnormal floats become normal doubles") {
+    const u32 smallest_subnormal_bits = 0x00000001u;
+    const float subnormal = fl::bit_cast<float>(smallest_subnormal_bits);
+
+    const double via_codec = widen_via_bitcodec(subnormal);
+    const double via_native = widen_via_native(subnormal);
+    FL_CHECK_EQ(fl::bit_cast<u64>(via_codec), fl::bit_cast<u64>(via_native));
+
+    const float largest_subnormal = fl::bit_cast<float>(0x007FFFFFu);
+    FL_CHECK_EQ(fl::bit_cast<u64>(widen_via_bitcodec(largest_subnormal)),
+                fl::bit_cast<u64>(widen_via_native(largest_subnormal)));
+}
+
+FL_TEST_CASE("soft_float_to_double -- infinities and NaN") {
+    const float pos_inf = fl::bit_cast<float>(0x7F800000u);
+    const float neg_inf = fl::bit_cast<float>(0xFF800000u);
+    const float qnan    = fl::bit_cast<float>(0x7FC00000u);
+
+    FL_CHECK_EQ(fl::bit_cast<u64>(widen_via_bitcodec(pos_inf)),
+                0x7FF0000000000000ull);
+    FL_CHECK_EQ(fl::bit_cast<u64>(widen_via_bitcodec(neg_inf)),
+                0xFFF0000000000000ull);
+    // NaN canonicalization matches the narrowing path.
+    FL_CHECK_EQ(fl::bit_cast<u64>(widen_via_bitcodec(qnan)),
+                0x7FF8000000000000ull);
+}
+
+FL_TEST_CASE("soft_float_to_double -- max / min finite") {
+    const float max_finite = fl::bit_cast<float>(0x7F7FFFFFu);  // FLT_MAX
+    const float min_normal = fl::bit_cast<float>(0x00800000u);  // FLT_MIN
+    FL_CHECK_EQ(fl::bit_cast<u64>(widen_via_bitcodec(max_finite)),
+                fl::bit_cast<u64>(widen_via_native(max_finite)));
+    FL_CHECK_EQ(fl::bit_cast<u64>(widen_via_bitcodec(min_normal)),
+                fl::bit_cast<u64>(widen_via_native(min_normal)));
+}
+
+// ---- narrowing: double -> float ----
+
+FL_TEST_CASE("soft_double_to_float -- zero round-trip") {
+    FL_CHECK_EQ(narrow_via_bitcodec(0.0), narrow_via_native(0.0));
+    FL_CHECK_EQ(narrow_via_bitcodec(-0.0), narrow_via_native(-0.0));
+}
+
+FL_TEST_CASE("soft_double_to_float -- well-known normals") {
+    FL_CHECK_EQ(narrow_via_bitcodec(1.0), 1.0f);
+    FL_CHECK_EQ(narrow_via_bitcodec(0.5), 0.5f);
+    FL_CHECK_EQ(narrow_via_bitcodec(0.125), 0.125f);
+    // 3.14 widened then narrowed loses precision identically.
+    FL_CHECK_EQ(narrow_via_bitcodec(3.14), narrow_via_native(3.14));
+}
+
+// ---- round-trip ----
+
+FL_TEST_CASE("soft_float widen/narrow round-trip is identity") {
+    const u32 sample_bits[] = {
+        0x00000000u,  // +0
+        0x80000000u,  // -0
+        0x3F800000u,  // 1.0
+        0xBF800000u,  // -1.0
+        0x40490FDBu,  // pi (single)
+        0x4048F5C3u,  // 3.14
+        0x3DCCCCCDu,  // 0.1
+        0x00000001u,  // smallest subnormal
+        0x007FFFFFu,  // largest subnormal
+        0x00800000u,  // FLT_MIN
+        0x7F7FFFFFu,  // FLT_MAX
+        0x7F800000u,  // +inf
+        0xFF800000u,  // -inf
+    };
+    for (u32 bits : sample_bits) {
+        const float f = fl::bit_cast<float>(bits);
+        const double widened = fl::soft_float_to_double(f);
+        const float narrowed = fl::soft_double_to_float(widened);
+        FL_CHECK_EQ(fl::bit_cast<u32>(narrowed), bits);
+    }
+}
+
+} // FL_TEST_FILE


### PR DESCRIPTION
## Summary

Phase-1 step toward closing #3022 / #3002. Moves the integer IEEE-754 bit-codec out of `fl/stl/json/types_impl.h` into `fl/math/soft_float.h` so non-JSON callers can use it directly. Adds the widening companion (`soft_float_to_double`) -- previously the JSON layer only had the narrowing path -- and rewires `float_conversion_visitor` so the residual `static_cast<double>(float)` / `static_cast<float>(double)` on `as_float()` / `as_double()` extraction can no longer anchor `__aeabi_f2d` / `__aeabi_d2f` on no-FPU targets. Also lands the `fl::number` 64-bit packed tagged-value scaffold (#3022's design) so phase 2 can build on it.

Refs #3022, #3002, #3208.

## Background

The pre-#3038 JSON layer already used integer bit-codec for the narrowing path (`json_double_to_float`). The widening path -- when `as_double()` extracts a value stored as `float` -- still went through a plain C++ cast, which on no-FPU targets pulls `__aeabi_f2d` and transitively the soft-double cascade. Even with `as_double()` dead-code-eliminated on LowMemory builds today, the cast remained a footgun: a future caller keeping the path alive would re-drag soft-FP. This PR closes that gap structurally.

## Files

### `src/fl/math/soft_float.h` (new)

Public API:

```cpp
fl::soft_float_to_double(float) -> double           // NEW widening
fl::soft_double_to_float(double) -> float           // moved from JSON, existing
fl::soft_double_bits_from_float_bits(u32) -> u64    // NEW widening bits
fl::soft_float_bits_from_double_bits(u64) -> u32    // moved from JSON, existing
```

All four use only shift / mask / add. Handle subnormals, NaN canonicalization, +/-inf bit-exactly. Symmetric round-trip:

```
soft_double_to_float(soft_float_to_double(f)) == f   // bit-exact for finite + inf
```

### `src/fl/math/number.h` (new)

64-bit packed tagged numeric value -- the #3022 design's storage shape. Lays down:

- `fl::number` class with `raw : fl::u64` slot
- `fl::number::tag` 3-bit enum (`SIGNED_INT`, `UNSIGNED_INT`, `FLOAT_60`, `RESERVED_3..7`)
- Factory: `number::from_signed(i64)`, `number::from_unsigned(u64)` (saturate on overflow)
- Accessors: `get_tag()`, `payload()`, `as_signed_payload()`

The `FLOAT_60` tag is reserved (no parser/serializer yet -- those follow in phase 2 alongside JSON adoption). Footprint is exactly 64 bits so the type can slot into a JSON value variant cell without padding overhead.

### `src/fl/stl/json/types_impl.h` (refactor)

Now a thin shim that maps the old `json_*` names to the new `fl::soft_*` API. Zero behavior change for existing JSON callers.

### `src/fl/stl/json/types.h` (refactor)

`float_conversion_visitor`'s float<->double cast paths (the `static_cast` sites flagged in the issue) route through `detail::json_double_to_float` / `detail::json_float_to_double`, which delegate to the new `fl::soft_*` helpers.

## Verification

- ✅ `bash test --cpp` -- **327 / 327 pass** (incl. 7 new `soft_float` tests, 5 new `fl::number` tests).
- ✅ `bash lint --cpp` -- clean (FL_STATIC_ASSERT per banned-macro checker; only pre-existing warn-only PlatformIO-internal-usage findings remain).
- ⚠ `bash compile lpc845brk` -- could not verify locally due to a zccache-daemon flake (`fbuild#627` / soldr#710 -- Windows named-pipe race against a stale daemon). Failure is in upstream `ArduinoCore-LPC8xx` source files (`wiring.cpp`, `WInterrupts.c`), not in anything this PR touches. CI on Linux runners will catch any real LPC regression. No source change in this PR touches LPC-specific paths.

## Behavior matrix

| Path | Pre-PR | Post-PR |
|---|---|---|
| Store `double` into json -> `as_float()` extract | integer bit-codec (`json_double_to_float`) | same (renamed `fl::soft_double_to_float`) |
| Store `float` into json -> `as_double()` extract | **`static_cast<double>` -> `__aeabi_f2d`** | integer bit-codec (`fl::soft_float_to_double`) |
| Store `float` into json -> `as_float<float>()` extract | direct copy | same |
| Store `double` into json -> `as_float<float>()` extract | **`static_cast<float>` -> `__aeabi_d2f`** | integer bit-codec (`fl::soft_double_to_float`) |
| Non-JSON code wanting soft-FP widen/narrow | `#include "fl/stl/json/types_impl.h"` (awkward) | `#include "fl/math/soft_float.h"` (proper home) |

## Test plan

- [x] `bash test --cpp` 327/327
- [x] `bash lint --cpp` clean
- [x] Round-trip identity test (`soft_double_to_float(soft_float_to_double(f)) == f`) covers 13 sample bit-patterns spanning normal, subnormal, FLT_MIN/MAX, +/-zero, +/-inf
- [x] `fl::number` saturation + sign-extension test covers payload-boundary values
- [ ] CI green on full platform matrix (waiting on this PR's CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `fl::number` — a compact 64-bit numeric type for efficient storage of signed integers, unsigned integers, and floats.
  * Added IEEE-754 compliant float-to-double and double-to-float conversion utilities without external dependencies.
  * Enhanced JSON numeric conversion handling with improved IEEE-754 compliance.

* **Tests**
  * Added comprehensive tests for the new numeric type and conversion utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->