### PR TITLE
ci(lockdown): freeze max_size in every check_*_size.yml + add lint enforcement

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -84,6 +84,51 @@ reviews:
         "`fl::span` for Callback Typedefs and Small Fixed-Size Arrays" and
         FastLED issue #3233.
 
+    - path: ".github/workflows/check_*_size.yml"
+      instructions: |
+        BINARY-SIZE THRESHOLD LOCKDOWN.
+
+        The `max_size` and `max_size_apa102` values in every
+        `.github/workflows/check_*_size.yml` workflow are FROZEN. CI agents
+        have repeatedly tried to "fix" a red size-check by raising the cap
+        to make the threshold pass. THAT IS A HIGH SEVERITY VIOLATION.
+
+        A red size check means a real regression in the binary. The correct
+        responses are:
+          1. Revert the change that caused the regression.
+          2. Fix the build flag / linker / over-link / symbol-leak that
+             grew the binary.
+          3. (Only when (1) and (2) are demonstrably impossible) raise the
+             cap, AND in the SAME PR update `ci/lint/check_size_thresholds.py`
+             FROZEN_THRESHOLDS to match, AND link an open issue justifying
+             the new ceiling, AND get explicit maintainer sign-off.
+
+        Flag as HIGH SEVERITY any PR that:
+        - Raises `max_size` or `max_size_apa102` without ALSO modifying
+          `ci/lint/check_size_thresholds.py` in the same diff.
+        - Adds a comment like "bump cap to clear CI" / "temporary raise" /
+          "pending follow-up issue" without a referenced merged-issue
+          explaining the actual architectural reason.
+        - Removes the FROZEN SIZE THRESHOLD banner.
+        - Adds a new `check_*_size.yml` workflow without registering its
+          thresholds in `ci/lint/check_size_thresholds.py`.
+
+        Mirror enforcement: `bash lint` runs `ci/lint/check_size_thresholds.py`
+        which fails (exit 1, ERROR mode — no warn-only) on any value that
+        doesn't match the frozen constant in the lint script. This makes the
+        "two-file friction" deliberate — agents trying to silently bump the
+        YAML will hit the lint failure.
+
+    - path: "ci/lint/check_size_thresholds.py"
+      instructions: |
+        BINARY-SIZE THRESHOLD LOCKDOWN — companion to
+        `.github/workflows/check_*_size.yml`.
+
+        Changes to `FROZEN_THRESHOLDS` here MUST be paired with the matching
+        YAML edit in the same PR, AND require an open issue link explaining
+        why the new ceiling is correct. A PR that raises a frozen value
+        without an issue ref + maintainer sign-off is HIGH SEVERITY.
+
     - path: "platformio.ini"
       instructions: |
         ROOT `./platformio.ini` LOCKDOWN (#3274 / #3281 follow-up).

--- a/.github/workflows/check_bluepill_size.yml
+++ b/.github/workflows/check_bluepill_size.yml
@@ -23,5 +23,9 @@ jobs:
     uses: ./.github/workflows/build_template_binary_size.yml
     with:
       board: stm32f103c8
+      # FROZEN SIZE THRESHOLD — DO NOT RAISE TO MAKE CI GREEN.
+      # Mirror-locked by ci/lint/check_size_thresholds.py. Raising a value
+      # here without updating the frozen-list constant in that script will
+      # fail `bash lint`. Fix the regression instead.
       max_size: 55000
       max_size_apa102: 45000

--- a/.github/workflows/check_esp32_size.yml
+++ b/.github/workflows/check_esp32_size.yml
@@ -30,15 +30,20 @@ jobs:
     uses: ./.github/workflows/build_template_binary_size.yml
     with:
       board: esp32dev
-      # 330 KB was the aspirational PR #3268 ceiling. After the #3278
-      # root-platformio.ini sever (and #3279 Phase 4 cleanup), the band-
-      # aid `-Os` / `-fno-exceptions` flags from root no longer reach
-      # fbuild — they relied on the legacy merge that has been removed.
-      # The fbuild build path needs its own flag-port mechanism that
-      # actually propagates these to the underlying ESP32 toolchain
-      # (tracked in #3298). Until then, raise the cap to 700 KB
-      # to match the pre-#3268 ceiling (PR #2790 / #2608) so CI runs to
-      # completion and we can measure real regressions. Today's fbuild
-      # esp32dev Blink size is ~401 KB; Apa102 sits a bit higher.
-      max_size: 700000
-      max_size_apa102: 700000
+      # ==========================================================================
+      # FROZEN SIZE THRESHOLD — DO NOT RAISE TO MAKE CI GREEN.
+      #
+      # 330 KB is the canonical ceiling. CI being red on esp32dev means a real
+      # regression that must be FIXED (in code or in the build system), not
+      # hidden by raising the cap. The known cause of current redness is #3298
+      # (fbuild does not propagate ESP32 board-level build_flags/build_unflags
+      # to the toolchain) — fix #3298, do not raise this number.
+      #
+      # The value here is mirror-locked by `ci/lint/check_size_thresholds.py`:
+      # changing this number without updating the frozen-list constant in that
+      # script will fail `bash lint`. The matching CodeRabbit rule on path
+      # `.github/workflows/check_*_size.yml` flags any raise as HIGH severity
+      # and requires an explicit issue reference + maintainer sign-off.
+      # ==========================================================================
+      max_size: 330000
+      max_size_apa102: 330000

--- a/.github/workflows/check_teensy30_size.yml
+++ b/.github/workflows/check_teensy30_size.yml
@@ -32,5 +32,9 @@ jobs:
     uses: ./.github/workflows/build_template_binary_size.yml
     with:
       board: teensy30
+      # FROZEN SIZE THRESHOLD — DO NOT RAISE TO MAKE CI GREEN.
+      # Mirror-locked by ci/lint/check_size_thresholds.py. Raising a value
+      # here without updating the frozen-list constant in that script will
+      # fail `bash lint`. Fix the regression instead.
       max_size: 60000
       max_size_apa102: 50000

--- a/.github/workflows/check_teensy31_size.yml
+++ b/.github/workflows/check_teensy31_size.yml
@@ -32,5 +32,9 @@ jobs:
     uses: ./.github/workflows/build_template_binary_size.yml
     with:
       board: teensy31
+      # FROZEN SIZE THRESHOLD — DO NOT RAISE TO MAKE CI GREEN.
+      # Mirror-locked by ci/lint/check_size_thresholds.py. Raising a value
+      # here without updating the frozen-list constant in that script will
+      # fail `bash lint`. Fix the regression instead.
       max_size: 80000
       max_size_apa102: 65000

--- a/.github/workflows/check_teensy32_size.yml
+++ b/.github/workflows/check_teensy32_size.yml
@@ -32,5 +32,9 @@ jobs:
     uses: ./.github/workflows/build_template_binary_size.yml
     with:
       board: teensy32
+      # FROZEN SIZE THRESHOLD — DO NOT RAISE TO MAKE CI GREEN.
+      # Mirror-locked by ci/lint/check_size_thresholds.py. Raising a value
+      # here without updating the frozen-list constant in that script will
+      # fail `bash lint`. Fix the regression instead.
       max_size: 80000
       max_size_apa102: 65000

--- a/.github/workflows/check_teensy35_size.yml
+++ b/.github/workflows/check_teensy35_size.yml
@@ -32,5 +32,9 @@ jobs:
     uses: ./.github/workflows/build_template_binary_size.yml
     with:
       board: teensy35
+      # FROZEN SIZE THRESHOLD — DO NOT RAISE TO MAKE CI GREEN.
+      # Mirror-locked by ci/lint/check_size_thresholds.py. Raising a value
+      # here without updating the frozen-list constant in that script will
+      # fail `bash lint`. Fix the regression instead.
       max_size: 100000
       max_size_apa102: 85000

--- a/.github/workflows/check_teensy36_size.yml
+++ b/.github/workflows/check_teensy36_size.yml
@@ -32,5 +32,9 @@ jobs:
     uses: ./.github/workflows/build_template_binary_size.yml
     with:
       board: teensy36
+      # FROZEN SIZE THRESHOLD — DO NOT RAISE TO MAKE CI GREEN.
+      # Mirror-locked by ci/lint/check_size_thresholds.py. Raising a value
+      # here without updating the frozen-list constant in that script will
+      # fail `bash lint`. Fix the regression instead.
       max_size: 120000
       max_size_apa102: 100000

--- a/.github/workflows/check_teensy41_size.yml
+++ b/.github/workflows/check_teensy41_size.yml
@@ -32,9 +32,14 @@ jobs:
     uses: ./.github/workflows/build_template_binary_size.yml
     with:
       board: teensy41
+      # FROZEN SIZE THRESHOLD — DO NOT RAISE TO MAKE CI GREEN.
+      # Mirror-locked by ci/lint/check_size_thresholds.py. Raising a value
+      # here without updating the frozen-list constant in that script will
+      # fail `bash lint`. Fix the regression instead.
+      #
+      # NOTE on apa102 (165000): bumped from 88000 to clear CI in #2802;
+      # current real size ≈148476 B. The real ceiling is 88000 once #2802's
+      # fl::ifstream / fl::AsyncLog* over-link is fixed — DO NOT raise above
+      # 165000 in the meantime.
       max_size: 120000
-      # TODO(#2802): bumped 88000 → 165000 to clear CI; current real Apa102
-      # size ≈148476 B. Follow-up: investigate why Apa102 pulls in
-      # fl::ifstream / fl::posix_filebuf / fl::strerror / fl::AsyncLog* and
-      # either gate those off LED-driver paths or accept and re-budget.
       max_size_apa102: 165000

--- a/.github/workflows/check_teensylc_size.yml
+++ b/.github/workflows/check_teensylc_size.yml
@@ -32,5 +32,9 @@ jobs:
     uses: ./.github/workflows/build_template_binary_size.yml
     with:
       board: teensylc
+      # FROZEN SIZE THRESHOLD — DO NOT RAISE TO MAKE CI GREEN.
+      # Mirror-locked by ci/lint/check_size_thresholds.py. Raising a value
+      # here without updating the frozen-list constant in that script will
+      # fail `bash lint`. Fix the regression instead.
       max_size: 35000
       max_size_apa102: 30000

--- a/.github/workflows/check_uno_size.yml
+++ b/.github/workflows/check_uno_size.yml
@@ -23,6 +23,10 @@ jobs:
     uses: ./.github/workflows/build_template_binary_size.yml
     with:
       board: uno
+      # FROZEN SIZE THRESHOLD — DO NOT RAISE TO MAKE CI GREEN.
+      # Mirror-locked by ci/lint/check_size_thresholds.py. Raising a value
+      # here without updating the frozen-list constant in that script will
+      # fail `bash lint`. Fix the regression instead.
       max_size: 11000
       max_size_apa102: 9300
   build_no_forced_inline:

--- a/ci/lint.py
+++ b/ci/lint.py
@@ -12,6 +12,7 @@ import sys
 from pathlib import Path
 
 from ci.lint.args_parser import LintArgs, parse_lint_args
+from ci.lint.check_size_thresholds import run as run_size_thresholds_check
 from ci.lint.duration_tracker import DurationTracker
 from ci.lint.orchestrator import LintOrchestrator
 from ci.lint.stage_impls import (
@@ -274,6 +275,19 @@ def create_stages(args: LintArgs) -> list[LintStage]:
                 run_fn=lambda: run_root_platformio_lockdown_lint(
                     warn_only=_root_pio_warn_only_from_env()
                 ),
+                timeout=10.0,
+            )
+        )
+        # check_*_size.yml threshold lockdown: every max_size{,_apa102} value
+        # in .github/workflows/check_*_size.yml must match the frozen list
+        # in ci/lint/check_size_thresholds.py. Prevents agents from silently
+        # raising the ceiling to make CI green. ALWAYS error mode — no
+        # warn-only escape hatch.
+        stages.append(
+            LintStage(
+                name="size_thresholds_locked",
+                display_name="SIZE-CHECK YML THRESHOLDS LOCKED",
+                run_fn=run_size_thresholds_check,
                 timeout=10.0,
             )
         )

--- a/ci/lint/check_size_thresholds.py
+++ b/ci/lint/check_size_thresholds.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python3
+"""Enforce frozen binary-size thresholds in `.github/workflows/check_*_size.yml`.
+
+CI agents have repeatedly tried to "fix" red size-check workflows by raising the
+`max_size` / `max_size_apa102` thresholds instead of fixing the underlying
+regression. The thresholds in this file are the canonical ceilings. Any change
+to a number in a `check_*_size.yml` workflow must be matched by an explicit
+update to ``FROZEN_THRESHOLDS`` below — by design, the friction of touching
+two places in one PR forces a maintainer to actually consider whether the
+raise is justified.
+
+If `bash lint` reports a violation here, the correct response is one of:
+    1. Revert the YAML edit — the size regression that prompted it is real and
+       must be fixed in code or in the build system.
+    2. Open a PR that updates both the YAML and ``FROZEN_THRESHOLDS`` here,
+       with an issue link explaining why the new ceiling is correct.
+
+Failure modes deliberately blocked:
+    - Agent silently bumps esp32 from 330000 → 700000 to clear CI.
+    - Agent adds a new check_*_size.yml workflow without registering its frozen
+      thresholds here (the linter fails on any unknown file).
+    - Agent removes a `max_size:` line from an existing workflow.
+
+This check is ERROR mode by default — there is no warn-only fallback. The
+whole point is that the threshold values cannot drift silently.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+from typing import NamedTuple
+
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+WORKFLOWS_DIR = PROJECT_ROOT / ".github" / "workflows"
+
+# ============================================================================
+# FROZEN SIZE THRESHOLDS — single source of truth.
+#
+# To change a threshold:
+#   1. Open an issue justifying the new ceiling (real architectural change,
+#      not "CI is red and I want it green").
+#   2. Edit the matching `.github/workflows/check_<board>_size.yml` value.
+#   3. Edit the matching entry below to match.
+#   4. Reference the issue # in the PR body. CodeRabbit will flag the diff
+#      and the lockdown rule in `.coderabbit.yaml` will require maintainer
+#      sign-off.
+#
+# Each value is a frozenset of integers. Multiple values are allowed for
+# workflows that legitimately run the same target with different configs
+# (see `check_uno_size.yml`'s `build_no_forced_inline` job which uses -1
+# as a "no check" sentinel).
+# ============================================================================
+FROZEN_THRESHOLDS: dict[str, dict[str, frozenset[int]]] = {
+    "check_bluepill_size.yml": {
+        "max_size": frozenset({55000}),
+        "max_size_apa102": frozenset({45000}),
+    },
+    "check_esp32_size.yml": {
+        "max_size": frozenset({330000}),
+        "max_size_apa102": frozenset({330000}),
+    },
+    "check_teensy30_size.yml": {
+        "max_size": frozenset({60000}),
+        "max_size_apa102": frozenset({50000}),
+    },
+    "check_teensy31_size.yml": {
+        "max_size": frozenset({80000}),
+        "max_size_apa102": frozenset({65000}),
+    },
+    "check_teensy32_size.yml": {
+        "max_size": frozenset({80000}),
+        "max_size_apa102": frozenset({65000}),
+    },
+    "check_teensy35_size.yml": {
+        "max_size": frozenset({100000}),
+        "max_size_apa102": frozenset({85000}),
+    },
+    "check_teensy36_size.yml": {
+        "max_size": frozenset({120000}),
+        "max_size_apa102": frozenset({100000}),
+    },
+    "check_teensy41_size.yml": {
+        "max_size": frozenset({120000}),
+        # 165000 was bumped from 88000 per #2802; the real ceiling is 88000
+        # once #2802's fl::ifstream / fl::AsyncLog* over-link is fixed.
+        "max_size_apa102": frozenset({165000}),
+    },
+    "check_teensylc_size.yml": {
+        "max_size": frozenset({35000}),
+        "max_size_apa102": frozenset({30000}),
+    },
+    "check_uno_size.yml": {
+        # `build` job: hard check. `build_no_forced_inline` job: -1 (no check).
+        "max_size": frozenset({11000, -1}),
+        "max_size_apa102": frozenset({9300, -1}),
+    },
+}
+
+
+_VALUE_RE = re.compile(r"^\s*(max_size|max_size_apa102)\s*:\s*(-?\d+)\s*$")
+
+
+class Violation(NamedTuple):
+    file: str
+    line_no: int
+    key: str
+    found: int
+    expected: frozenset[int]
+    kind: str  # "unknown_file" | "unknown_key" | "wrong_value" | "missing_key"
+
+
+def _scan_file(path: Path) -> list[tuple[int, str, int]]:
+    """Return [(line_no, key, value), ...] for every max_size{,_apa102} line."""
+    hits: list[tuple[int, str, int]] = []
+    text = path.read_text(encoding="utf-8", errors="replace")
+    for line_no, line in enumerate(text.splitlines(), start=1):
+        # Skip commented-out lines so the lockdown banner doesn't trip the regex.
+        stripped = line.lstrip()
+        if stripped.startswith("#"):
+            continue
+        m = _VALUE_RE.match(line)
+        if m:
+            hits.append((line_no, m.group(1), int(m.group(2))))
+    return hits
+
+
+def check() -> list[Violation]:
+    """Walk every `.github/workflows/check_*_size.yml` and validate."""
+    violations: list[Violation] = []
+
+    actual_files = sorted(p.name for p in WORKFLOWS_DIR.glob("check_*_size.yml"))
+    known_files = set(FROZEN_THRESHOLDS.keys())
+
+    # Unknown file: a new check_*_size.yml workflow without a frozen entry.
+    for name in actual_files:
+        if name not in known_files:
+            violations.append(
+                Violation(
+                    file=name,
+                    line_no=0,
+                    key="<file>",
+                    found=0,
+                    expected=frozenset(),
+                    kind="unknown_file",
+                )
+            )
+
+    # Missing file: an entry in FROZEN_THRESHOLDS whose YAML was deleted.
+    for name in known_files - set(actual_files):
+        violations.append(
+            Violation(
+                file=name,
+                line_no=0,
+                key="<file>",
+                found=0,
+                expected=frozenset(),
+                kind="missing_file",
+            )
+        )
+
+    for name in actual_files:
+        if name not in known_files:
+            continue
+        path = WORKFLOWS_DIR / name
+        hits = _scan_file(path)
+        expected_spec = FROZEN_THRESHOLDS[name]
+
+        # Track which keys actually appeared so we can flag missing ones.
+        seen_keys: set[str] = set()
+
+        for line_no, key, value in hits:
+            seen_keys.add(key)
+            allowed = expected_spec.get(key)
+            if allowed is None:
+                violations.append(
+                    Violation(
+                        file=name,
+                        line_no=line_no,
+                        key=key,
+                        found=value,
+                        expected=frozenset(),
+                        kind="unknown_key",
+                    )
+                )
+                continue
+            if value not in allowed:
+                violations.append(
+                    Violation(
+                        file=name,
+                        line_no=line_no,
+                        key=key,
+                        found=value,
+                        expected=allowed,
+                        kind="wrong_value",
+                    )
+                )
+
+        for required_key in expected_spec.keys():
+            if required_key not in seen_keys:
+                violations.append(
+                    Violation(
+                        file=name,
+                        line_no=0,
+                        key=required_key,
+                        found=0,
+                        expected=expected_spec[required_key],
+                        kind="missing_key",
+                    )
+                )
+
+    return violations
+
+
+def _print_violations(violations: list[Violation]) -> None:
+    print()
+    print("=" * 80)
+    print(
+        f"[size-thresholds-locked] ERROR — {len(violations)} frozen-threshold "
+        f"violation(s) in `.github/workflows/check_*_size.yml`:"
+    )
+    print("=" * 80)
+    print(
+        "These thresholds are frozen by ci/lint/check_size_thresholds.py.\n"
+        "Raising a number here to make CI green is forbidden — fix the\n"
+        "underlying regression instead, OR (if the bump is genuinely\n"
+        "justified) update both the YAML and FROZEN_THRESHOLDS in the lint\n"
+        "script in one PR, with an issue link.\n"
+    )
+    for v in violations:
+        if v.kind == "unknown_file":
+            print(
+                f"  {v.file}: new workflow has no entry in FROZEN_THRESHOLDS. "
+                f"Add a frozenset for it in ci/lint/check_size_thresholds.py."
+            )
+        elif v.kind == "missing_file":
+            print(
+                f"  {v.file}: workflow was deleted but still listed in "
+                f"FROZEN_THRESHOLDS. Remove the entry."
+            )
+        elif v.kind == "unknown_key":
+            print(
+                f"  {v.file}:{v.line_no}: unknown key `{v.key}: {v.found}` — "
+                f"not in FROZEN_THRESHOLDS for this file."
+            )
+        elif v.kind == "wrong_value":
+            allowed = ", ".join(str(x) for x in sorted(v.expected))
+            print(
+                f"  {v.file}:{v.line_no}: `{v.key}: {v.found}` does not match "
+                f"frozen value(s) {{{allowed}}}."
+            )
+        elif v.kind == "missing_key":
+            allowed = ", ".join(str(x) for x in sorted(v.expected))
+            print(
+                f"  {v.file}: missing required `{v.key}` line (frozen value "
+                f"{{{allowed}}})."
+            )
+    print()
+    print("=" * 80)
+
+
+def run() -> bool:
+    """Return True on clean, False on any violation."""
+    if not WORKFLOWS_DIR.exists():
+        return True
+    violations = check()
+    if not violations:
+        print(
+            "✅ Size-thresholds lockdown: "
+            f"all {len(FROZEN_THRESHOLDS)} check_*_size.yml workflow(s) match "
+            "frozen values."
+        )
+        return True
+    _print_violations(violations)
+    return False
+
+
+def main(argv: list[str] | None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Validate `.github/workflows/check_*_size.yml` thresholds against "
+            "the frozen list in ci/lint/check_size_thresholds.py."
+        ),
+    )
+    parser.parse_args(argv)
+    ok = run()
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(None))


### PR DESCRIPTION
## Summary

Three-pronged lockdown to stop CI agents from "fixing" red size-check workflows by raising the threshold ceiling instead of fixing the underlying regression. Same pattern as the root `./platformio.ini` lockdown (PR #3280) but applied to `.github/workflows/check_*_size.yml`.

## What lands

### 1. Lockdown banner in all 10 size-check workflows

`.github/workflows/check_*_size.yml` (bluepill, esp32, teensy30/31/32/35/36/41/lc, uno) all gain a comment block above the `max_size` lines telling the reader the value is **mirror-locked** by `ci/lint/check_size_thresholds.py`.

### 2. New lint check (`ci/lint/check_size_thresholds.py`)

- Frozen `FROZEN_THRESHOLDS` dict — single source of truth for all canonical ceilings.
- Validates every `max_size{,_apa102}` value in every `check_*_size.yml` against the dict.
- Wired into `bash lint` as stage `size_thresholds_locked`.
- **ERROR mode by design** — no warn-only escape hatch. Changing a YAML value without updating the dict in the same PR fails lint.
- Catches: silent threshold bumps, removal of `max_size` lines, new `check_*_size.yml` workflows added without registration in the frozen dict.

### 3. CodeRabbit rule

New `.coderabbit.yaml` entries on `.github/workflows/check_*_size.yml` and on the lint script itself. Flags any threshold raise as HIGH severity and requires explicit issue reference + maintainer sign-off.

## Threshold revert

This PR **reverts the recent esp32 700KB cap back to 330KB**. The 700KB bump was the band-aid from PR #3295 to make CI green while **#3298** (fbuild not propagating ESP32 board-level `build_flags`/`build_unflags` to the toolchain) is unfixed. CI on `check_esp32_size.yml` will be RED until #3298 is fixed — **that is the correct state**: the red signal is what forces the underlying fbuild bug to be addressed.

teensy41 apa102 (165000) is preserved at its bumped value with an explanatory comment — the real ceiling is 88000 once #2802 `fl::ifstream` over-link is fixed.

## Frozen values

| Board | max_size | max_size_apa102 |
|---|---|---|
| bluepill | 55000 | 45000 |
| **esp32** | **330000** | **330000** |
| teensy30 | 60000 | 50000 |
| teensy31 | 80000 | 65000 |
| teensy32 | 80000 | 65000 |
| teensy35 | 100000 | 85000 |
| teensy36 | 120000 | 100000 |
| teensy41 | 120000 | 165000 (waiting on #2802) |
| teensylc | 35000 | 30000 |
| uno | 11000 / -1 | 9300 / -1 |

## Verification

```
$ uv run python ci/lint/check_size_thresholds.py
✅ Size-thresholds lockdown: all 10 check_*_size.yml workflow(s) match frozen values.

$ bash lint
  ✅ size_thresholds_locked completed  (0s)
🎉 All linting completed!
```

Failure-mode test: temporarily bumping `check_esp32_size.yml` from 330000 → 700000 (without updating the lint dict) fails:
```
[size-thresholds-locked] ERROR — 2 frozen-threshold violation(s):
  check_esp32_size.yml:43: `max_size: 700000` does not match frozen value(s) {330000}.
  check_esp32_size.yml:44: `max_size_apa102: 700000` does not match frozen value(s) {330000}.
```

## Out of scope (deferred to follow-up issues filed alongside this PR)

- Fixing #3298 (fbuild not honoring board-level `build_flags`) — that's what would actually allow esp32 CI to pass at 330KB.
- Fixing #2802 (teensy41 apa102 over-link from `fl::ifstream` / `fl::AsyncLog*`).

## Note on python_pipeline lint

`bash lint` shows `python_pipeline FAILED` — that's pre-existing on master (9 ty diagnostics about `os.system` soft-deprecation, unrelated to this PR). Verified by running `ty check ci/` on master directly.

## Test plan

- [x] `bash lint` — `size_thresholds_locked` stage clean
- [x] Manual failure-mode test (bumped value flagged correctly with exit 1)
- [x] Manual passing-case test (all 10 frozen values pass)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented stricter enforcement of binary size limits across supported boards through a centralized verification system.
  * Updated size threshold documentation in CI workflows to clarify immutable limits and synchronization requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->