### PR TITLE
refactor(boards): derive PARLIO flag emission from per-chip capability bit (#3304)

### DIFF
--- a/ci/boards.py
+++ b/ci/boards.py
@@ -94,6 +94,13 @@ class Board:
     # down — see PR #2658). Set True when the board's workflow genuinely
     # needs the optimization-info dump for size/perf debugging.
     generate_optimization_report: bool = False
+    # Set True on chips where Espressif's `SOC_PARLIO_SUPPORTED=1` (per
+    # `components/soc/<chip>/include/soc/soc_caps.h`). The canonical chip
+    # family list lives in `src/platforms/esp/32/drivers/parlio/bus_traits.h:6`
+    # — keep these two lists in sync. When True, `to_platformio_ini()`
+    # auto-prepends `_ESP32_PARLIO_BUILD_FLAGS` to `build_flags` so the PARLIO
+    # TX ISR is pinned in IRAM and cache-safe (see #3271, #3304).
+    parlio_capable: bool = False
 
     def __post_init__(self) -> None:
         # Check if framework is set, warn and auto-set to arduino if missing (except for native/stub platforms)
@@ -610,6 +617,14 @@ class Board:
         if additional_defines:
             build_flags_elements.extend(f"-D{define}" for define in additional_defines)
 
+        # Auto-emit PARLIO IRAM flags on chips with SOC_PARLIO_SUPPORTED=1
+        # (capability declared via `parlio_capable=True` on the Board). Mirrors
+        # the auto-default pattern used above for ESP32-family `monitor_filters`
+        # — moves the flag list off a hand-maintained allowlist of board names
+        # and onto the per-chip capability bit. See #3304.
+        if self.parlio_capable:
+            build_flags_elements.extend(_ESP32_PARLIO_BUILD_FLAGS)
+
         # Use static build flags
         if self.build_flags:
             build_flags_elements.extend(self.build_flags)
@@ -869,7 +884,7 @@ ESP32_C5_DEVKITC_1 = Board(
     board_name="esp32c5",
     real_board_name="esp32-c5-devkitc-1",
     platform=ESP32_IDF_5_5_1_PIOARDUINO,
-    build_flags=list(_ESP32_PARLIO_BUILD_FLAGS),
+    parlio_capable=True,  # SOC_PARLIO_SUPPORTED=1 — flags auto-emitted by to_platformio_ini()
 )
 
 ESP32_C6_DEVKITC_1 = Board(
@@ -878,8 +893,8 @@ ESP32_C6_DEVKITC_1 = Board(
     platform=ESP32_IDF_5_5_1_PIOARDUINO,
     board_build_flash_size="4MB",  # ESP32-C6FH4 actual flash size confirmed by esptool
     board_partitions="huge_app.csv",
+    parlio_capable=True,  # SOC_PARLIO_SUPPORTED=1 — flags auto-emitted by to_platformio_ini()
     build_flags=[
-        *_ESP32_PARLIO_BUILD_FLAGS,
         "-funwind-tables",  # Better stack traces for RISC-V crash decoding
         "-DARDUINO_USB_MODE=1",  # Select HWCDC (USB-Serial/JTAG) over OTG
         "-DARDUINO_USB_CDC_ON_BOOT=1",  # Route Serial to HWCDC. Safe with setTxTimeoutMs(0); see #2668
@@ -895,8 +910,10 @@ ESP32_S3_DEVKITC_1 = Board(
     board_build_flash_size="4MB",  # Set to 4MB for QEMU compatibility (default is 8MB)
     board_partitions="huge_app.csv",  # 3MB app partition (default.csv only has 1.25MB, too small for Validation)
     build_unflags=["-DFASTLED_RMT5=0", "-DFASTLED_RMT5"],
+    # NOTE: esp32s3 has NO PARLIO peripheral (SOC_PARLIO_SUPPORTED is unset in
+    # soc_caps.h). Do NOT set parlio_capable=True here — PR #3276 historically
+    # had this wrong; #3304 fixes it.
     build_flags=[
-        *_ESP32_PARLIO_BUILD_FLAGS,
         "-DARDUINO_USB_MODE=1",  # Route Serial over native USB for AutoResearch RPC on the upload port
         "-DARDUINO_USB_CDC_ON_BOOT=1",
         "-DARDUINO_LOOP_STACK_SIZE=16384",  # AutoResearch RPC plus ESP driver setup is deep enough to exceed the Arduino 8KB default
@@ -921,7 +938,7 @@ ESP32H2 = Board(
     real_board_name="esp32-h2-devkitm-1",
     platform_needs_install=True,  # Install platform package to get the boards
     platform=ESP32_IDF_5_3_PIOARDUINO,
-    build_flags=list(_ESP32_PARLIO_BUILD_FLAGS),
+    parlio_capable=True,  # SOC_PARLIO_SUPPORTED=1 — flags auto-emitted by to_platformio_ini()
 )
 
 ESP32_P4 = Board(
@@ -929,7 +946,7 @@ ESP32_P4 = Board(
     real_board_name="esp32-p4-evboard",
     platform=ESP32_IDF_5_5_1_PIOARDUINO,
     board_partitions="huge_app.csv",
-    build_flags=list(_ESP32_PARLIO_BUILD_FLAGS),
+    parlio_capable=True,  # SOC_PARLIO_SUPPORTED=1 — flags auto-emitted by to_platformio_ini()
     # Route Serial → USB-Serial-JTAG (HWCDCSerial) instead of UART0 (pins 37/38).
     # Without these the AutoResearch firmware listens on UART0 while the host
     # tool talks to the USB-Serial-JTAG COM port — every RPC write times out.

--- a/ci/tests/test_parlio_capable_boards.py
+++ b/ci/tests/test_parlio_capable_boards.py
@@ -1,0 +1,102 @@
+"""Snapshot test: PARLIO-capable boards in ``ci/boards.py``.
+
+The set of boards that get the PARLIO IRAM build flags (i.e.
+``CONFIG_PARLIO_TX_ISR_HANDLER_IN_IRAM=1`` /
+``CONFIG_PARLIO_TX_ISR_CACHE_SAFE=1``) must equal the chip-family list that
+FastLED's own driver supports — ``src/platforms/esp/32/drivers/parlio/bus_traits.h:6``
+(C5/C6/H2/P4). Historically (#3276) this list was hand-maintained and
+``esp32s3`` ended up in it incorrectly, even though S3 has no PARLIO
+peripheral (``SOC_PARLIO_SUPPORTED`` is unset in its ``soc_caps.h``).
+
+This test pins down both halves of that contract:
+
+1.  The ``parlio_capable=True`` set on the Board dataclass equals exactly
+    ``{esp32c5, esp32c6, esp32h2, esp32p4}``.
+2.  The generated ``platformio.ini`` snippet for ``esp32s3`` does NOT contain
+    ``CONFIG_PARLIO_TX_ISR_HANDLER_IN_IRAM`` — guards against a regression of
+    the #3276 bug.
+
+See issue #3304 for the design rationale.
+"""
+
+import unittest
+
+from ci import boards as boards_module
+from ci.boards import ESP32_S3_DEVKITC_1, Board
+
+
+# Canonical PARLIO-capable chip family — must stay in sync with
+# src/platforms/esp/32/drivers/parlio/bus_traits.h:6.
+EXPECTED_PARLIO_BOARDS = {"esp32c5", "esp32c6", "esp32h2", "esp32p4"}
+
+
+def _all_boards() -> list[Board]:
+    """Return every Board instance defined at module load time.
+
+    ``ci.boards`` populates a module-level ``ALL`` list as a side effect of
+    ``Board.__post_init__`` for any Board with ``add_board_to_all=True`` (the
+    default). Importing the module is enough to populate it.
+    """
+    return list(boards_module.ALL)
+
+
+class TestParlioCapableBoards(unittest.TestCase):
+    """Pin the PARLIO-capable board set against the FastLED driver allowlist."""
+
+    def test_parlio_capable_set_matches_driver_allowlist(self) -> None:
+        parlio_boards = {b.board_name for b in _all_boards() if b.parlio_capable}
+        self.assertEqual(
+            parlio_boards,
+            EXPECTED_PARLIO_BOARDS,
+            "ci/boards.py's parlio_capable set drifted from the driver "
+            "allowlist in src/platforms/esp/32/drivers/parlio/bus_traits.h:6. "
+            f"Got {sorted(parlio_boards)}, expected {sorted(EXPECTED_PARLIO_BOARDS)}.",
+        )
+
+    def test_esp32s3_not_parlio_capable(self) -> None:
+        # esp32s3 has no PARLIO peripheral. PR #3276 historically had this
+        # wrong; do not regress.
+        self.assertFalse(
+            ESP32_S3_DEVKITC_1.parlio_capable,
+            "esp32s3 has SOC_PARLIO_SUPPORTED unset in soc_caps.h — it must "
+            "not be marked parlio_capable. See #3304.",
+        )
+
+    def test_esp32s3_platformio_ini_omits_parlio_flags(self) -> None:
+        ini = ESP32_S3_DEVKITC_1.to_platformio_ini()
+        self.assertNotIn(
+            "CONFIG_PARLIO_TX_ISR_HANDLER_IN_IRAM",
+            ini,
+            "esp32s3 platformio.ini contains a PARLIO IRAM flag — that's the "
+            "#3276 bug. The flag must only be emitted on chips with "
+            "parlio_capable=True (C5/C6/H2/P4).",
+        )
+
+    def test_each_parlio_board_emits_iram_flags(self) -> None:
+        # Positive half of the contract: every parlio_capable board's
+        # generated ini must carry the IRAM-pin flags so the ISR is not
+        # placed in flash (which would cause cache-miss stalls and break
+        # LED protocol timing).
+        for board in _all_boards():
+            if not board.parlio_capable:
+                continue
+            ini = board.to_platformio_ini()
+            with self.subTest(board=board.board_name):
+                self.assertIn(
+                    "CONFIG_PARLIO_TX_ISR_HANDLER_IN_IRAM=1",
+                    ini,
+                    f"{board.board_name} is parlio_capable but its "
+                    "platformio.ini does not contain "
+                    "CONFIG_PARLIO_TX_ISR_HANDLER_IN_IRAM=1.",
+                )
+                self.assertIn(
+                    "CONFIG_PARLIO_TX_ISR_CACHE_SAFE=1",
+                    ini,
+                    f"{board.board_name} is parlio_capable but its "
+                    "platformio.ini does not contain "
+                    "CONFIG_PARLIO_TX_ISR_CACHE_SAFE=1.",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add `parlio_capable: bool = False` to the `Board` dataclass; `Board.to_platformio_ini()` auto-prepends `_ESP32_PARLIO_BUILD_FLAGS` when set. Mirrors the existing `monitor_filters` auto-default pattern.
- Set `parlio_capable=True` on `ESP32_C5_DEVKITC_1`, `ESP32_C6_DEVKITC_1`, `ESP32H2`, `ESP32_P4` and drop the manual `*_ESP32_PARLIO_BUILD_FLAGS` spread from those four boards.
- Remove the bogus `*_ESP32_PARLIO_BUILD_FLAGS` spread from `ESP32_S3_DEVKITC_1` (S3 has `SOC_PARLIO_SUPPORTED` unset — the #3276 bug). Comment explicitly warns against regressing it.
- New snapshot test `ci/tests/test_parlio_capable_boards.py` pins the `parlio_capable` set to `{esp32c5, esp32c6, esp32h2, esp32p4}`, asserts `esp32s3.to_platformio_ini()` contains no PARLIO flag, and verifies every `parlio_capable=True` board emits both IRAM flags.

The `_ESP32_PARLIO_BUILD_FLAGS` constant remains as the single source of truth for the two flag values; only the spread call sites moved.

Closes #3304

## Out of scope

- Auto-deriving `parlio_capable` from a vendored copy of ESP-IDF's `soc_caps.h` (the issue lists this as a stretch goal; deferred to a follow-up).
- Anything from #3305 (size threshold audit).

## Test plan

- [x] `uv run pytest ci/tests/test_parlio_capable_boards.py -v` — 4 tests, 4 subtests pass
- [x] `uv run pytest ci/tests/test_board_to_platformio_ini.py -v` — existing tests still pass
- [x] `uv run python -c "from ci.boards import ESP32_S3_DEVKITC_1, ESP32_C6_DEVKITC_1; assert 'PARLIO' not in str(ESP32_S3_DEVKITC_1.to_platformio_ini()); assert 'PARLIO' in str(ESP32_C6_DEVKITC_1.to_platformio_ini()); print('OK')"` -> `OK`
- [x] `bash lint` — only pre-existing `python_pipeline FAILED` (master-state, unrelated); no NEW lint failures introduced

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected PARLIO peripheral support detection for ESP32 board variants.

* **Tests**
  * Added validation tests for PARLIO-capable board configurations.

* **Chores**
  * Streamlined build flag configuration for boards with PARLIO support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->