### PR TITLE
fix(ci/lint): make python_pipeline green on master (KBI002 + dead monkeypatch from #3290)

### DIFF
--- a/ci/autoresearch/phases.py
+++ b/ci/autoresearch/phases.py
@@ -810,10 +810,11 @@ def _parse_args_and_build_commands(args: Args) -> RunContext | int:
                 project_root=project_root,
                 verbose=args.verbose,
             )
-        except KeyboardInterrupt:
-            # Let user-initiated interrupts propagate; never swallow them
-            # under the broad Exception handler below (CodeRabbit feedback,
-            # PR #3290).
+        except KeyboardInterrupt as ki:
+            # Let user-initiated interrupts propagate via the project's
+            # canonical handler; never swallow them under the broad
+            # Exception handler below (CodeRabbit feedback, PR #3290).
+            handle_keyboard_interrupt(ki)
             raise
         except Exception as e:
             print(
@@ -1064,10 +1065,11 @@ async def _resolve_port_and_environment(ctx: RunContext) -> int | None:
             staged_sketch = ctx.build_dir / "src" / "sketch"
             if staged_sketch.exists():
                 os.environ["PLATFORMIO_SRC_DIR"] = str(staged_sketch)
-        except KeyboardInterrupt:
-            # Let user-initiated interrupts propagate; never swallow them
-            # under the broad Exception handler below (CodeRabbit feedback,
-            # PR #3290).
+        except KeyboardInterrupt as ki:
+            # Let user-initiated interrupts propagate via the project's
+            # canonical handler; never swallow them under the broad
+            # Exception handler below (CodeRabbit feedback, PR #3290).
+            handle_keyboard_interrupt(ki)
             raise
         except Exception as e:
             print(

--- a/ci/autoresearch/staging.py
+++ b/ci/autoresearch/staging.py
@@ -24,43 +24,10 @@ auto-detect).
 
 from __future__ import annotations
 
-from contextlib import contextmanager
 from pathlib import Path
-from typing import Iterator
 
 from ci.boards import create_board
 from ci.compiler.path_manager import FastLEDPaths, resolve_project_root
-
-
-@contextmanager
-def _suppress_root_platformio_merge(project_root: Path) -> Iterator[None]:
-    """Make ``get_root_platformio_build_flags`` see no root ``platformio.ini``.
-
-    ``ci/compiler/pio.py::_init_platformio_build`` unconditionally merges
-    ``build_flags`` from root ``./platformio.ini`` via
-    :func:`get_root_platformio_build_flags`. That behaviour is exactly what
-    issue #3281 wants to eliminate from the autoresearch path. Until #3278
-    introduces an opt-out parameter, the simplest non-invasive bridge is to
-    point ``get_root_platformio_build_flags`` at a project root with no root
-    ``platformio.ini`` for the duration of the synthesis call — which is the
-    documented "missing root ini" code path the function already handles
-    correctly (returns ``[]``).
-
-    We do this by monkey-patching the function symbol in ``ci.compiler.pio``
-    (the import site used by ``_init_platformio_build``) to a stub that
-    returns an empty list. Restoration is unconditional, even on exception.
-    """
-    # Local import — keeps the autoresearch import graph slim until staging
-    # is actually requested.
-    from ci.compiler import pio as _pio
-
-    _ = project_root  # currently unused; reserved for future direct-arg suppression
-    original = _pio.get_root_platformio_build_flags
-    _pio.get_root_platformio_build_flags = lambda _board, _root: []  # type: ignore[assignment]
-    try:
-        yield
-    finally:
-        _pio.get_root_platformio_build_flags = original  # type: ignore[assignment]
 
 
 def synthesise_autoresearch_project(
@@ -94,15 +61,19 @@ def synthesise_autoresearch_project(
     paths = FastLEDPaths(board.board_name, project_root=root)
     build_dir = paths.build_dir
 
-    with _suppress_root_platformio_merge(root):
-        init_result = _init_platformio_build(
-            board,
-            verbose,
-            "AutoResearch",
-            paths,
-            build_dir=build_dir,
-            use_fbuild=True,
-        )
+    # PR #3291 (#3278 Phase 2) severed the root platformio.ini merge in
+    # `_init_platformio_build`; PR #3295 (#3279 Phase 4) deleted the
+    # `get_root_platformio_build_flags` function entirely. The previous
+    # monkeypatch bridge that lived here is obsolete — autoresearch's
+    # fbuild path no longer reads root platformio.ini regardless.
+    init_result = _init_platformio_build(
+        board,
+        verbose,
+        "AutoResearch",
+        paths,
+        build_dir=build_dir,
+        use_fbuild=True,
+    )
     if not init_result.success:
         raise RuntimeError(
             f"Failed to synthesise autoresearch project for board "


### PR DESCRIPTION
Two pre-existing lint failures on master blocking the session-stop hook every turn. Both small, both cleanup.

## Changes

1. **`ci/autoresearch/phases.py:813,1067`** — bare `except KeyboardInterrupt: raise` violated **KBI002**. Replaced with `except KeyboardInterrupt as ki: handle_keyboard_interrupt(ki); raise` (the canonical project pattern; `handle_keyboard_interrupt` already imported).

2. **`ci/autoresearch/staging.py`** — `_suppress_root_platformio_merge` monkeypatched `ci.compiler.pio.get_root_platformio_build_flags`. That function was a bridge from PR #3290 while PR #3278 was in flight. **PR #3278 (sever) and #3279 (Phase 4 cleanup, via PR #3295) have both merged**; `get_root_platformio_build_flags` was deleted entirely. The monkeypatch's target no longer exists — `ty` was correctly flagging the `unresolved-attribute` reference. Deleted the obsolete context manager + its `with` block.

## Test plan

- `bash lint` python_pipeline now green (ruff + ty both pass).
- The deletion in (2) is functionally a no-op: PR #3278 already made the merge opt-in (default off) and PR #3295 deleted the merge function entirely, so the patch was dead code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved keyboard interrupt handling during project synthesis process.
  * Simplified internal project staging initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->