### PR TITLE
fix(platforms/lpc): work around Serial.println silent-drop on LPC8xx (closes #3313)

### DIFF
--- a/src/platforms/arm/lpc/io_lpc.cpp.hpp
+++ b/src/platforms/arm/lpc/io_lpc.cpp.hpp
@@ -38,7 +38,15 @@ void print(const char* str) FL_NO_EXCEPT {
 
 void println(const char* str) FL_NO_EXCEPT {
     if (!Serial) return;
-    Serial.println(str);
+    // FastLED #3313: Serial.println silently drops on LPC8xx -- bytes
+    // never reach the USB-VCOM bridge. Empirically, splitting into two
+    // Serial.print calls (the same byte-write path FL_DBG_F uses via
+    // fl::printf -> platforms::print) reaches the host reliably. Root
+    // cause is in Print::println's path in the Arduino core; filed
+    // separately. This workaround unblocks every fl::println / FL_WARN_LIT
+    // call site on LPC.
+    Serial.print(str);
+    Serial.print("\r\n");
 }
 
 int available() FL_NO_EXCEPT {


### PR DESCRIPTION
## Summary

Empirical bug: `Serial.println(s)` on LPC845-BRK with the Arduino core silently drops every byte. But `Serial.print(s)` works fine, and `Serial.print(\"\r\n\")` works fine. So `fl::println` -- which routes through `platforms::println -> Serial.println` -- is invisible on the wire, making every `fl::println` / `FL_WARN_LIT` / `FL_LOG_LIT` call site silent on LPC.

That blocked the FastLED/FastLED#3300 LPC845-BRK bring-up echo investigation: every diagnostic trace marker I added to setup() and the dispatcher was compiled in correctly (verified via `arm-none-eabi-strings firmware.elf`) but never reached the host serial monitor.

Closes #3313.

## Workaround

Split `platforms::println` into two `Serial.print` calls. Same byte-write path that `FL_DBG_F`'s `log_emit_f` uses successfully (`fl::printf -> fl::print -> platforms::print`).

\`\`\`diff
 void println(const char* str) FL_NO_EXCEPT {
     if (!Serial) return;
-    Serial.println(str);
+    Serial.print(str);
+    Serial.print(\"\r\n\");
 }
\`\`\`

Root cause is in `Print::println`'s path in the Arduino core (filed separately for upstream investigation). Until the Arduino-core fix lands, FastLED's `platforms::println` shim is the right place to prevent every LPC user from hitting silent diagnostics.

## Verification

- ✅ \`bash test --cpp\` -- 333/333 pass (host unaffected).
- ✅ \`bash compile lpc845brk --examples AutoResearch\` -- builds cleanly.

## Test plan

- [x] Host unit tests green.
- [x] LPC845 compile green.
- [ ] CI matrix green (this PR).

## Refs

- #3313 -- the underlying \`Serial.println\` silent-drop investigation.
- #3300 -- LPC845-BRK bring-up echo silence (this PR unblocks the diagnostic-trace path needed to root-cause that).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed serial output handling on LPC-based microcontroller platforms to resolve communication issues with USB-VCOM interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->