### PR TITLE
feat(autoresearch): 30s default timeout + yellow banner + standard time notation (closes #3309)

### DIFF
--- a/ci/autoresearch/args.py
+++ b/ci/autoresearch/args.py
@@ -128,7 +128,7 @@ Examples:
   %(prog)s --rmt --spi                 # Test RMT and SPI drivers
   %(prog)s --all                       # Test all drivers
   %(prog)s --parlio --skip-lint        # Skip linting for faster iteration
-  %(prog)s --rmt --timeout 120         # Custom timeout (default: 60s)
+  %(prog)s --rmt --timeout 2m          # Custom timeout (default: 30s; supports s/m/h/ms)
   %(prog)s --lcd --lanes 2 --strip-sizes 100,300  # Test LCD_CLOCKLESS with 2 lanes, strips of 100 and 300 LEDs
   %(prog)s --lcd-spi --strip-sizes 100,500   # Test LCD_SPI (APA102) on ESP32-S3
   %(prog)s --parlio --lanes 1-4        # Test PARLIO with 1-4 lanes
@@ -405,8 +405,23 @@ See Also:
             "--timeout",
             "-t",
             type=str,
-            default="60",
-            help="Timeout for monitor phase. Supports: plain number (seconds), '120s', '2m', '5000ms' (default: 60)",
+            default=None,
+            help=(
+                "Timeout for monitor phase. Supports: plain number (seconds), "
+                "'30s', '2m', '1h', '5000ms'. "
+                "Default: 30s with a yellow advisory banner (FastLED #3309). "
+                "Pass --no-timeout to disable."
+            ),
+        )
+        parser.add_argument(
+            "--no-timeout",
+            action="store_true",
+            help=(
+                "Disable the monitor-phase timeout entirely. Use for debugger "
+                "sessions or interactive bring-up where the device may legitimately "
+                "stay quiet for a long time. Suppresses the default-timeout banner. "
+                "FastLED #3309."
+            ),
         )
         parser.add_argument(
             "--project-dir",

--- a/ci/autoresearch/phases.py
+++ b/ci/autoresearch/phases.py
@@ -766,12 +766,34 @@ def _parse_args_and_build_commands(args: Args) -> RunContext | int:
         if args.fail_keywords:
             fail_keywords.extend(args.fail_keywords)
 
-    # Parse timeout
-    try:
-        timeout_seconds = parse_timeout(args.timeout)
-    except ValueError as e:
-        print(f"\u274c Error: {e}")
-        return 1
+    # Parse timeout (FastLED #3309: 30s default with advisory banner;
+    # --no-timeout to disable; supports 30s / 10m / 1h / 5000ms notation).
+    AUTORESEARCH_DEFAULT_TIMEOUT_S = 30
+    no_timeout = bool(getattr(args, "no_timeout", False))
+    quiet = bool(getattr(args, "quiet", False))
+    if no_timeout:
+        # Effectively unbounded: a year-of-seconds is "no timeout" for any
+        # practical bring-up session and stays well within int range.
+        timeout_seconds = 365 * 24 * 3600
+    elif args.timeout is None:
+        timeout_seconds = AUTORESEARCH_DEFAULT_TIMEOUT_S
+        if not quiet:
+            # Yellow advisory banner so the user sees the default is in effect
+            # and knows how to override. Suppressed under --quiet. Fore/Style
+            # are imported at module level above.
+            print(
+                f"{Fore.YELLOW}"
+                f"[default {AUTORESEARCH_DEFAULT_TIMEOUT_S}s timeout in effect "
+                f"-- pass --timeout <duration> (e.g. 30s / 2m / 1h) or "
+                f"--no-timeout to override]"
+                f"{Style.RESET_ALL}"
+            )
+    else:
+        try:
+            timeout_seconds = parse_timeout(args.timeout)
+        except ValueError as e:
+            print(f"\u274c Error: {e}")
+            return 1
 
     # Resolve project root (always the user's invocation cwd) and build_dir.
     #

--- a/ci/tests/test_parse_timeout.py
+++ b/ci/tests/test_parse_timeout.py
@@ -1,0 +1,63 @@
+"""Tests for ci.util.sketch_resolver.parse_timeout (FastLED #3309).
+
+Covers the time-notation parsing surface that autoresearch's --timeout
+argument feeds: plain seconds, ms / s / m / h suffixes, error cases.
+"""
+
+import pytest
+
+from ci.util.sketch_resolver import parse_timeout
+
+
+class TestParseTimeout:
+    """parse_timeout accepts standard time notation strings."""
+
+    def test_plain_number_is_seconds(self) -> None:
+        assert parse_timeout("30") == 30
+        assert parse_timeout("60") == 60
+        assert parse_timeout("1") == 1
+
+    def test_seconds_suffix(self) -> None:
+        assert parse_timeout("30s") == 30
+        assert parse_timeout("90s") == 90
+        # Case-insensitive
+        assert parse_timeout("30S") == 30
+
+    def test_minutes_suffix(self) -> None:
+        assert parse_timeout("1m") == 60
+        assert parse_timeout("2m") == 120
+        assert parse_timeout("10m") == 600
+
+    def test_milliseconds_suffix(self) -> None:
+        # 5000ms == 5 s
+        assert parse_timeout("5000ms") == 5
+        # Sub-second timeouts saturate to 1 (min positive integer)
+        assert parse_timeout("500ms") == 1
+
+    def test_hours_suffix_new_in_3309(self) -> None:
+        # FastLED #3309: added `h` suffix for hour-scale timeouts so
+        # debugger / interactive sessions don't have to type 3600.
+        assert parse_timeout("1h") == 3600
+        assert parse_timeout("2h") == 7200
+
+    def test_whitespace_tolerated(self) -> None:
+        assert parse_timeout("  30  ") == 30
+        assert parse_timeout(" 2m") == 120
+
+    def test_decimal_values(self) -> None:
+        assert parse_timeout("1.5m") == 90
+        assert parse_timeout("0.5h") == 1800
+
+    def test_invalid_format_raises(self) -> None:
+        with pytest.raises(ValueError, match="Invalid timeout format"):
+            parse_timeout("abc")
+        with pytest.raises(ValueError, match="Invalid timeout format"):
+            parse_timeout("30sx")
+        with pytest.raises(ValueError, match="Invalid timeout format"):
+            parse_timeout("30 minutes")
+
+    def test_non_positive_raises(self) -> None:
+        with pytest.raises(ValueError, match="must be positive"):
+            parse_timeout("0")
+        with pytest.raises(ValueError, match="must be positive"):
+            parse_timeout("0s")

--- a/ci/util/sketch_resolver.py
+++ b/ci/util/sketch_resolver.py
@@ -104,13 +104,14 @@ def parse_timeout(timeout_str: str) -> int:
     """Parse timeout string with optional suffix into seconds.
 
     Supported formats:
-        - Plain number: "120" → 120 seconds
-        - Milliseconds: "5000ms" → 5 seconds
-        - Seconds: "120s" → 120 seconds
-        - Minutes: "2m" → 120 seconds
+        - Plain number: "120" -> 120 seconds
+        - Milliseconds: "5000ms" -> 5 seconds
+        - Seconds: "120s" -> 120 seconds
+        - Minutes: "2m" -> 120 seconds
+        - Hours: "1h" -> 3600 seconds (FastLED #3309)
 
     Args:
-        timeout_str: Timeout string (e.g., "120", "2m", "5000ms")
+        timeout_str: Timeout string (e.g., "120", "2m", "1h", "5000ms")
 
     Returns:
         Timeout in seconds (integer)
@@ -123,11 +124,11 @@ def parse_timeout(timeout_str: str) -> int:
     timeout_str = timeout_str.strip()
 
     # Match number with optional suffix
-    match = re.match(r"^(\d+(?:\.\d+)?)\s*(ms|s|m)?$", timeout_str, re.IGNORECASE)
+    match = re.match(r"^(\d+(?:\.\d+)?)\s*(ms|s|m|h)?$", timeout_str, re.IGNORECASE)
     if not match:
         raise ValueError(
             f"Invalid timeout format: '{timeout_str}'. "
-            f"Expected formats: '120', '120s', '2m', '5000ms'"
+            f"Expected formats: '120', '120s', '2m', '1h', '5000ms'"
         )
 
     value_str, suffix = match.groups()
@@ -146,6 +147,9 @@ def parse_timeout(timeout_str: str) -> int:
     elif suffix.lower() == "m":
         # Minutes to seconds
         seconds = value * 60
+    elif suffix.lower() == "h":
+        # Hours to seconds (FastLED #3309)
+        seconds = value * 3600
     else:
         # Should never reach here due to regex
         raise ValueError(f"Unknown suffix: {suffix}")


### PR DESCRIPTION
## Summary

Three UX improvements to the autoresearch timeout surface so silent waits stop reading as hung shells (FastLED #3309):

1. **Default --timeout** changed from 60 s → **30 s**. Real-world bring-up RPC round-trips are well under 100 ms; 30 s catches genuine hangs sooner without false-tripping legit work.
2. **Yellow advisory banner** is printed when --timeout is not explicitly passed:

   ```
   [default 30s timeout in effect — pass --timeout <duration> (e.g. 30s / 2m / 1h) or --no-timeout to override]
   ```

   Suppressed under \`--quiet\`.
3. **`--no-timeout`** flag lets debugger sessions run unbounded.
4. **`parse_timeout`** gains an `h` (hours) suffix.

Closes #3309.

## Test plan

- [x] 9 new unit tests in \`ci/tests/test_parse_timeout.py\` covering plain seconds, ms/s/m/h suffixes, decimals, whitespace, error paths.
- [x] \`uv run python -m ci.autoresearch --help\` shows both flags with correct descriptions.
- [x] \`bash lint\` clean.

## Files

- \`ci/autoresearch/args.py\` — \`--timeout\` default + help, new \`--no-timeout\` flag, updated examples block.
- \`ci/autoresearch/phases.py\` — wire default + banner + no-timeout into the timeout-parse block.
- \`ci/util/sketch_resolver.py\` — \`parse_timeout\` adds the \`h\` suffix.
- \`ci/tests/test_parse_timeout.py\` — new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Extended timeout argument to support hour-based formats (e.g., `1h`), minutes, seconds, and milliseconds.
  * Added `--no-timeout` flag to disable monitor-phase timeout.

* **Improvements**
  * Applied 30-second default timeout with advisory banner when not explicitly specified.
  * Enhanced CLI help text with supported timeout format examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->