### PR TITLE
docs(fled): document FLED container format

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,7 @@
 | Editing meson.build files | `agents/docs/build-system.md` |
 | Running tests, Docker, WASM, QEMU | `agents/docs/testing-commands.md` |
 | Test-Driven Development (TDD) | Use `/tdd` or `/tdd-implement` skills |
+| Editing `.fled` container docs or `src/fl/fled/` | `agents/docs/fled-format.md` |
 | Hardware autoresearch / `bash autoresearch` | `agents/docs/hardware-autoresearch.md` |
 | Debugging a C++ crash | `agents/docs/debugging.md` |
 | Investigating binary size / flash bloat | `agents/docs/binary-size-analysis.md` |
@@ -20,7 +21,7 @@
 | Detailed command reference | `agents/docs/commands-reference.md` |
 | Workflow and task management | `agents/docs/workflow.md` |
 
-**By directory:** `src/`/`tests/` → `agents/docs/cpp-standards.md` | `ci/` → `agents/docs/python-standards.md`, `agents/ci.md` | `tests/` → `agents/tests.md` | `examples/` → `agents/examples.md` | `meson.build` → `agents/docs/build-system.md`
+**By directory:** `src/`/`tests/` → `agents/docs/cpp-standards.md` | `src/fl/fled/` → `agents/docs/fled-format.md` | `ci/` → `agents/docs/python-standards.md`, `agents/ci.md` | `tests/` → `agents/tests.md` | `examples/` → `agents/examples.md` | `meson.build` → `agents/docs/build-system.md`
 
 ## Key Commands
 

--- a/agents/docs/fled-format.md
+++ b/agents/docs/fled-format.md
@@ -1,0 +1,9 @@
+# .fled Container Format
+
+- `.fled` is FastLED's self-describing LED bundle container: a binary header, a JSON envelope with screenmap/video metadata, and raw frame payload.
+- Canonical spec: https://github.com/zackees/ledmapper/blob/main/docs/fled-format.md
+- Local FastLED mirror: `src/fl/fled/FLED_FORMAT.md`
+- Primary in-tree consumer is `fl::Fled` from #3311 once that subtree lands.
+- Legacy `fl::Video` remains relevant for `.rgb` and for consuming the video section inside `.fled`.
+- The container is designed to grow beyond video.
+- Roadmap sections include channels config plus MicroPython and WASM scripts so one `.fled` can carry video, screenmap, channels, and behavior.

--- a/src/fl/fled/FLED_FORMAT.md
+++ b/src/fl/fled/FLED_FORMAT.md
@@ -1,0 +1,143 @@
+# FLED v1 Container Format
+
+`.fled` is the FastLED native container for self-contained LED pattern data.
+Version 1 stores a small binary header, a UTF-8 JSON envelope that carries the
+physical LED map and optional metadata, then a raw frame payload. The goal is to
+keep the bytes needed for playback together: video data, the screenmap that
+places that data on physical LEDs, and future bundle sections such as channels
+configuration and scripts.
+
+> Authority: the canonical `.fled` format specification lives in ledmapper at
+> <https://github.com/zackees/ledmapper/blob/main/docs/fled-format.md>.
+> ledmapper is the producer of `.fled` files, so if this local mirror and the
+> ledmapper spec ever disagree, ledmapper wins. Keep this file as a convenience
+> mirror for FastLED readers, agents, and on-device consumers.
+
+Diagnostic tooling lives with the producer:
+<https://github.com/zackees/ledmapper/blob/main/scripts/inspect-fled.mjs>.
+Use that inspector to dump headers, JSON envelope contents, and payload sizing
+when validating generated files.
+
+## File Layout
+
+All integers are unsigned. Multi-byte integers are little-endian. The binary
+header is exactly 12 bytes.
+
+| Offset | Size | Field | Type | Notes |
+| ---: | ---: | --- | --- | --- |
+| 0 | 4 | `magic` | ASCII | Must be `FLED`. |
+| 4 | 1 | `version` | `u8` | Must be `1` for this version. |
+| 5 | 1 | `pixel_format` | `u8` | Pixel format enum for the raw frame payload. |
+| 6 | 2 | `reserved` | `u8[2]` | Must be zero. |
+| 8 | 4 | `json_length` | `u32le` | Number of bytes in the UTF-8 JSON envelope. |
+| 12 | `json_length` | `json_bytes` | UTF-8 | JSON envelope, with no NUL terminator and no BOM. |
+| `12 + json_length` | remaining bytes | `frame_payload` | bytes | Concatenated frame data using `pixel_format`. |
+
+The payload begins at `12 + json_length`. For video content, the frame count is
+derived from the remaining file size:
+
+```text
+frame_count = payload_bytes / (led_count * bytes_per_led)
+```
+
+`led_count` comes from the embedded screenmap. `bytes_per_led` comes from the
+pixel format table below. Writers should make `payload_bytes` an exact multiple
+of `led_count * bytes_per_led`; readers should treat a remainder as malformed or
+truncated input.
+
+## Pixel Format Enum
+
+Values `0x00` through `0x04` are defined for FLED v1. Values `0x05` through
+`0xff` are reserved for future formats.
+
+| Value | Name | Bytes per LED | Payload byte order | Notes |
+| ---: | --- | ---: | --- | --- |
+| `0x00` | `rgb8` | 3 | `R, G, B` | Current FastLED reader support and the preferred v1 video payload. |
+| `0x01` | `gray8` | 1 | `Y` | 8-bit luminance. Consumers expand to RGB as needed. |
+| `0x02` | `rgba8` | 4 | `R, G, B, A` | 8-bit RGB plus alpha. Alpha handling is consumer-defined. |
+| `0x03` | `rgbw8` | 4 | `R, G, B, W` | 8-bit RGB plus white channel. |
+| `0x04` | `rgb565le` | 2 | little-endian RGB565 | 5 bits red, 6 bits green, 5 bits blue. |
+| `0x05`-`0xff` | reserved | variable | TBD | Reserved by ledmapper for future pixel encodings. |
+
+## JSON Envelope
+
+The JSON envelope is UTF-8 text and is counted exactly by `json_length`.
+It is intentionally extensible: readers should consume the sections they
+understand and preserve or ignore unknown sections according to their role.
+
+Required screenmap content:
+
+- The envelope carries the LED geometry needed to interpret the payload.
+- Current files carry the standard `ScreenMap` schema in `map`.
+- The LED order in the screenmap is the order used by the frame payload.
+- `led_count` is the total number of LEDs described by the screenmap segments.
+
+Video metadata:
+
+- `video.fps` may be present to declare the playback frame rate.
+- If `video.fps` is absent, consumers may use an application default, sketch
+  parameter, or external playback setting.
+- The raw frame payload immediately follows the JSON envelope; it is not base64
+  or otherwise embedded in JSON.
+
+Example envelope shape:
+
+```json
+{
+  "map": {
+    "strip0": {
+      "x": [0, 1, 2],
+      "y": [0, 0, 0],
+      "diameter": 0.25
+    }
+  },
+  "video": {
+    "fps": 30
+  }
+}
+```
+
+## Frame Payload
+
+The frame payload is a flat byte stream:
+
+```text
+frame 0 LED 0, frame 0 LED 1, ... frame 0 LED N-1,
+frame 1 LED 0, frame 1 LED 1, ... frame 1 LED N-1,
+...
+```
+
+Each LED record uses the `pixel_format` declared in the header. For `rgb8`, the
+payload is identical to the legacy headerless `.rgb` layout after the FLED
+header and JSON envelope are skipped.
+
+Consumers that only support a subset of pixel formats should reject unsupported
+`pixel_format` values before reading frame bytes. FastLED's legacy video reader
+currently accepts `rgb8` FLED v1 files and falls back to headerless `.rgb` when
+the `FLED` magic is absent.
+
+## Growth Notes
+
+FLED v1 reserves most of the pixel-format enum and keeps the metadata envelope
+open so one file can grow from "video plus screenmap" into a complete pattern
+bundle.
+
+Expected pixel-format growth includes compressed or alternate encodings such as
+BC1/BC3-compressed frames, indexed palettes, higher-bit-depth color, or other
+producer-defined formats. New values must be assigned in the canonical
+ledmapper spec first.
+
+Expected JSON envelope growth includes:
+
+- `channels`: `fl::MultiChannelConfig` JSON so the file can describe output
+  channel wiring and playback routing alongside the screenmap.
+- `script.micropython`: embedded MicroPython bytecode or source metadata for
+  behavior that travels with the pattern.
+- `script.wasm`: embedded WASM module metadata or payload references for
+  portable behavior that travels with the pattern.
+
+The roadmap direction is a single `.fled` file that can carry video, screenmap,
+channels, and behavior as a self-contained FastLED deployment unit. The
+channels section is the next v1 addition tracked under the `fl::Fled` umbrella;
+MicroPython and WASM script-carrying sections remain roadmap items until they
+land in ledmapper and FastLED together.

--- a/src/fl/fled/README.md
+++ b/src/fl/fled/README.md
@@ -1,0 +1,5 @@
+# fl::Fled
+
+> **On-disk format spec:** [FLED_FORMAT.md](./FLED_FORMAT.md) - the binary header, JSON envelope, and raw frame payload layout. Canonical spec lives in [zackees/ledmapper](https://github.com/zackees/ledmapper/blob/main/docs/fled-format.md); this is the local mirror.
+
+`fl::Fled` covers FastLED's documented video container format. The format spec is the source of truth for the bytes stored on disk and for compatibility expectations between writers and readers.

--- a/src/fl/video/_build.cpp.hpp
+++ b/src/fl/video/_build.cpp.hpp
@@ -1,5 +1,6 @@
 /// @file _build.hpp
 /// @brief Unity build header for fl/video/ directory
+/// FLED on-disk format reference: ../fled/FLED_FORMAT.md
 /// Includes all implementation files in alphabetical order
 
 #include "fl/video/frame_interpolator.cpp.hpp"

--- a/tests/test_fled_format_docs.py
+++ b/tests/test_fled_format_docs.py
@@ -1,0 +1,47 @@
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).parent.parent
+
+
+def _read(path: str) -> str:
+    return (PROJECT_ROOT / path).read_text(encoding="utf-8")
+
+
+def test_fled_format_mirror_documents_v1_layout_and_authority() -> None:
+    text = _read("src/fl/fled/FLED_FORMAT.md")
+
+    assert "Authority:" in text
+    assert "https://github.com/zackees/ledmapper/blob/main/docs/fled-format.md" in text
+    assert "https://github.com/zackees/ledmapper/blob/main/scripts/inspect-fled.mjs" in text
+    assert "| 0 | 4 | `magic`" in text
+    assert "| 8 | 4 | `json_length`" in text
+    assert "| `0x00` | `rgb8` | 3 |" in text
+    assert "| `0x04` | `rgb565le` | 2 |" in text
+    assert "channels" in text
+    assert "script.micropython" in text
+    assert "script.wasm" in text
+
+
+def test_fled_readme_opens_with_format_spec_link() -> None:
+    lines = _read("src/fl/fled/README.md").splitlines()
+
+    assert lines[0] == "# fl::Fled"
+    assert lines[1] == ""
+    assert lines[2].startswith("> **On-disk format spec:** [FLED_FORMAT.md]")
+    assert "./FLED_FORMAT.md" in lines[2]
+    assert "zackees/ledmapper" in lines[2]
+
+
+def test_video_and_agent_docs_route_to_local_fled_spec() -> None:
+    video_entry = _read("src/fl/video/_build.cpp.hpp")
+    agent_summary = _read("agents/docs/fled-format.md")
+    claude = _read("CLAUDE.md")
+
+    assert "../fled/FLED_FORMAT.md" in video_entry
+    assert "src/fl/fled/FLED_FORMAT.md" in agent_summary
+    assert "fl::Fled" in agent_summary
+    assert "fl::Video" in agent_summary
+    assert "MicroPython" in agent_summary
+    assert "WASM" in agent_summary
+    assert "agents/docs/fled-format.md" in claude


### PR DESCRIPTION
## Summary
- Add src/fl/fled/FLED_FORMAT.md as the local .fled v1 container format mirror with canonical ledmapper authority links.
- Add the required top-of-file src/fl/fled/README.md format-spec link and a legacy src/fl/video/ pointer to the local mirror.
- Add agent-facing .fled docs and a focused pytest contract test for the documentation links/content.

Closes #3310

## Tests
- uv run pytest tests/test_fled_format_docs.py
- bash lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive specifications for the `.fled` container format, including binary structure, JSON metadata layout, frame payload specifications, and roadmap for future extensions.

* **Tests**
  * Added validation tests to ensure documentation consistency and cross-reference accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->