### PR TITLE
docs: #3308 retire stale references to deleted Python C++ checkers

### DIFF
--- a/.claude/agents/architecture-reviewer-agent.md
+++ b/.claude/agents/architecture-reviewer-agent.md
@@ -104,7 +104,7 @@ Search for these patterns:
   - Grep `src/FastLED.h` for a `CFastLED` method that delegates to it.
   - If no wrapper exists, flag as **HIGH severity architectural violation** with this language:
     > "New global setter `fl::<name>` lacks a `CFastLED::<wrapperName>()` wrapper. The documented user-facing API for library-wide configuration is `FastLED.setX(...)`, not `fl::set_x(...)`. Add an `inline` one-liner on `CFastLED` that delegates to this free function (see exemplar `CFastLED::setPowerModel` in `src/FastLED.h:1455` → `fl::set_power_model`). Rationale: `agents/docs/cpp-standards.md` → 'Public Settings Pattern'."
-- Strict for new code. A small transitional allowlist (`GRANDFATHERED_NAMES` in `ci/lint_cpp/public_settings_pattern_checker.py`) exempts a handful of legacy bare setters (`fl::set_input_gamut` #2710, `fl::enable_rgbw_colorimetric_lut`, `fl::set_rgbww_colorimetric_profile`) until their wrappers land. Entries are removed as each name is wrapped; new additions do NOT get grandfathered.
+- Strict for new code. A small transitional allowlist (`PUBLIC_SETTINGS_GRANDFATHERED` in `ci/lint_cpp_rs/src/checkers/public_settings.rs::PublicSettingsPatternChecker`) exempts a handful of legacy bare setters (`fl::set_input_gamut` #2710, `fl::enable_rgbw_colorimetric_lut`, `fl::set_rgbww_colorimetric_profile`) until their wrappers land. Entries are removed as each name is wrapped; new additions do NOT get grandfathered.
 - Rule does not apply to: helpers, constructors, factories, per-object configuration, anonymous-namespace / `fl::detail::` internals, functions that only mutate caller-owned objects (e.g. `fl::fill_solid(span, color)`).
 
 ### 4. Check Dependency Direction

--- a/.claude/agents/cpp-linter-builder-agent.md
+++ b/.claude/agents/cpp-linter-builder-agent.md
@@ -186,6 +186,6 @@ Then one edit in `ci/lint_cpp/rust_bridge.py`:
 Only use the Python tier (`ci/lint_cpp/`) for cases the Rust binary cannot model:
 
 - **AST ratchets** (libclang / clang-query): copy the pattern in `ci/tools/check_noexcept.py` or `ci/tools/check_array_params.py`. Wire it into `run_noexcept_ast_check` / `run_array_param_ast_check` in `run_all_checkers.py`.
-- **Cross-file structural checks**: see `ci/lint_cpp/test_unity_build.py`, `ci/lint_cpp/test_aggregation_checker.py`, `ci/lint_cpp/pch_file_checker.py` for the shape.
+- **Cross-file structural checks**: see `ci/lint_cpp_rs/src/checkers/unity_build.rs` and `ci/lint_cpp_rs/src/checkers/structural_passes.rs` for the shape. (These were ported from Python in #3293.)
 
 If you find yourself porting a per-line content rule to Python, stop — write it in Rust instead.

--- a/.claude/commands/code_review.md
+++ b/.claude/commands/code_review.md
@@ -336,7 +336,7 @@ inline void setPowerModel(const PowerModelRGB& model) {
 2. ✅ **The wrapper is a thin `inline` delegator** — no logic, validation, or error handling embedded.
 3. ✅ **Examples, README, and PR descriptions** should call `FastLED.setX(...)`, never `fl::set_x(...)`.
 
-**Strict for new code; transitional allowlist for legacy names only.** Every *new* public global setter under `fl::` must ship with a `CFastLED` wrapper in the same PR. A small transitional allowlist (`GRANDFATHERED_NAMES` in `ci/lint_cpp/public_settings_pattern_checker.py`) exempts pre-existing bare setters (e.g. `fl::set_input_gamut` #2710) until their wrappers land. Entries are removed as each name is wrapped; new additions block the PR.
+**Strict for new code; transitional allowlist for legacy names only.** Every *new* public global setter under `fl::` must ship with a `CFastLED` wrapper in the same PR. A small transitional allowlist (`PUBLIC_SETTINGS_GRANDFATHERED` in `ci/lint_cpp_rs/src/checkers/public_settings.rs`) exempts pre-existing bare setters (e.g. `fl::set_input_gamut` #2710) until their wrappers land. Entries are removed as each name is wrapped; new additions block the PR.
 
 **Does NOT apply to**:
 - Helpers, constructors, factories (not "setters of global state")

--- a/agents/docs/cpp-standards.md
+++ b/agents/docs/cpp-standards.md
@@ -259,12 +259,12 @@ class CFastLED {
 2. ✅ **The wrapper is a `inline` one-liner that delegates** — no logic, no validation, no error handling. The free function holds all behavior.
 3. ✅ **Per-object configuration (e.g. one strip's diode profile, one controller's correction) MAY live on the per-object API.** This rule targets *library-wide / process-wide / default-profile* state.
 4. ✅ **Documentation, examples, and PR descriptions reference the god-instance form.** The free function is an implementation detail.
-5. ⚠️ **Strict for new code; transitional allowlist for legacy names only.** Every *new* public global setter under `fl::` must ship with a `CFastLED` wrapper. A small transitional allowlist (`GRANDFATHERED_NAMES` in `ci/lint_cpp/public_settings_pattern_checker.py`) exempts pre-existing bare setters (e.g. `fl::set_input_gamut` #2710, `fl::enable_rgbw_colorimetric_lut`, `fl::set_rgbww_colorimetric_profile`) until their wrappers land. Entries are removed as each name is wrapped — the goal is an empty allowlist. New additions do NOT get grandfathered.
+5. ⚠️ **Strict for new code; transitional allowlist for legacy names only.** Every *new* public global setter under `fl::` must ship with a `CFastLED` wrapper. A small transitional allowlist (`PUBLIC_SETTINGS_GRANDFATHERED` in `ci/lint_cpp_rs/src/checkers/public_settings.rs`) exempts pre-existing bare setters (e.g. `fl::set_input_gamut` #2710, `fl::enable_rgbw_colorimetric_lut`, `fl::set_rgbww_colorimetric_profile`) until their wrappers land. Entries are removed as each name is wrapped — the goal is an empty allowlist. New additions do NOT get grandfathered.
 
 **Check Process**:
 1. For every new public function in `src/fl/**/*.h` whose name matches `^set_|^enable_|^disable_|^use_` and that mutates a static / global / namespace-scope variable, grep `src/FastLED.h` for a `CFastLED` method that delegates to it.
 2. If none exists: violation — add the wrapper in the same PR.
-3. Enforced by `ci/lint_cpp/public_settings_pattern_checker.py`. The checker carries a shrinking `GRANDFATHERED_NAMES` allowlist for legacy bare setters; remove a name from the list once its `CFastLED` wrapper is merged.
+3. Enforced by `PublicSettingsPatternChecker` in `ci/lint_cpp_rs/src/checkers/public_settings.rs`. The checker carries a shrinking `PUBLIC_SETTINGS_GRANDFATHERED` allowlist for legacy bare setters; remove a name from the list once its `CFastLED` wrapper is merged.
 
 **Where the rule does NOT apply**:
 - Helpers, constructors, factory functions — these are not setters of global state.

--- a/agents/docs/linter-architecture.md
+++ b/agents/docs/linter-architecture.md
@@ -152,7 +152,7 @@ FL_LINT_AB=1 bash lint --cpp                      # A/B parity check vs Python o
 
 ## When to still use Python
 
-As of PR #3293, **all single-file content checkers and cross-file structural checks run in the Rust crate** (`ci/lint_cpp_rs/`). The Python tier is reserved exclusively for the three remaining Tier-4 AST ratchets that need libclang / clang-query, which the Rust binary cannot model today:
+As of PR #3293, **all single-file content checkers and cross-file structural checks run in the Rust crate** (`ci/lint_cpp_rs/`). The Python tier is reserved exclusively for the two remaining Tier-4 AST ratchets (across three Python files) that need libclang / clang-query, which the Rust binary cannot model today:
 
 - **AST ratchets only**: `run_noexcept_ast_check` and `run_array_param_ast_check` in `ci/lint_cpp/run_all_checkers.py`, backed by `ci/lint_cpp/noexcept_checker.py`, `ci/tools/check_noexcept.py`, and `ci/tools/check_array_params.py`. These compare AST query output against a checked-in baseline so the violation count can only drop, not grow.
 

--- a/agents/docs/linter-architecture.md
+++ b/agents/docs/linter-architecture.md
@@ -152,22 +152,13 @@ FL_LINT_AB=1 bash lint --cpp                      # A/B parity check vs Python o
 
 ## When to still use Python
 
-The Python tier is reserved for cases the Rust binary can't model today:
+As of PR #3293, **all single-file content checkers and cross-file structural checks run in the Rust crate** (`ci/lint_cpp_rs/`). The Python tier is reserved exclusively for the three remaining Tier-4 AST ratchets that need libclang / clang-query, which the Rust binary cannot model today:
 
-- **AST ratchets** (require libclang / clang-query): `run_noexcept_ast_check` and `run_array_param_ast_check` in `ci/lint_cpp/run_all_checkers.py` (backed by `ci/tools/check_noexcept.py` and `ci/tools/check_array_params.py`). These compare AST query output against a checked-in baseline so the violation count can only drop, not grow.
-- **Cross-file structural checks** that have to reason about the whole tree at once:
-  - `ci/lint_cpp/test_unity_build.py::check` — validates `.cpp.hpp` / `_build.cpp.hpp` unity structure.
-  - `ci/lint_cpp/test_aggregation_checker.py::check` — validates test aggregation rules.
-  - `ci/lint_cpp/pch_file_checker.py::check` — validates precompiled-header file shape.
-- **The six remaining Python-only single-file checkers** that have not been ported yet (all wired in `create_checkers()` in `run_all_checkers.py`):
-  - `BareLibmChecker` (`bare_libm_checker.py`)
-  - `BareNoInlineChecker` (`bare_noinline_checker.py`)
-  - `BareSnprintfChecker` (`bare_snprintf_checker.py`)
-  - `LegacyLogMacroChecker` (`legacy_log_macro_checker.py`)
-  - `PublicSettingsPatternChecker` (`public_settings_pattern_checker.py`)
-  - `FlNoUnderscoreChecker` (`fl_no_underscore_checker.py`)
+- **AST ratchets only**: `run_noexcept_ast_check` and `run_array_param_ast_check` in `ci/lint_cpp/run_all_checkers.py`, backed by `ci/lint_cpp/noexcept_checker.py`, `ci/tools/check_noexcept.py`, and `ci/tools/check_array_params.py`. These compare AST query output against a checked-in baseline so the violation count can only drop, not grow.
 
-If your rule is single-file and content-based, it does **not** belong in this list — write it in Rust.
+Everything else — unity-build structure, test aggregation, PCH file shape, `BareLibmChecker`, `BareNoInlineChecker`, `BareSnprintfChecker`, `LegacyLogMacroChecker`, `PublicSettingsPatternChecker`, `FlNoUnderscoreChecker`, etc. — now lives under `ci/lint_cpp_rs/src/checkers/`.
+
+If your rule is single-file and content-based, write it in Rust. Cross-file structural rules also belong in Rust (see `ci/lint_cpp_rs/src/checkers/unity_build.rs` and `structural_passes.rs`).
 
 ## DO NOT
 

--- a/ci/dependencies.json
+++ b/ci/dependencies.json
@@ -58,20 +58,11 @@
       ],
       "tools": [
         "clang-format",
-        "ci/lint_cpp_rs/ (Rust fastled-lint binary — primary checker fleet)",
-        "ci/lint_cpp/run_all_checkers.py (Python orchestrator: invokes Rust, then runs remaining Python-only checkers + AST ratchets)",
+        "ci/lint_cpp_rs/ (Rust fastled-lint crate — primary checker fleet; all single-file and cross-file structural checks)",
+        "ci/lint_cpp/run_all_checkers.py (Python orchestrator: invokes Rust, then runs AST ratchets)",
         "ci/lint_cpp/rust_binary_cache.py (build-on-change cache for fastled-lint)",
-        "ci/lint_cpp/rust_bridge.py (Rust ↔ Python result bridge)",
-        "ci/lint_cpp/bare_libm_checker.py (Python-only)",
-        "ci/lint_cpp/bare_noinline_checker.py (Python-only)",
-        "ci/lint_cpp/bare_snprintf_checker.py (Python-only)",
-        "ci/lint_cpp/fl_no_underscore_checker.py (Python-only)",
-        "ci/lint_cpp/legacy_log_macro_checker.py (Python-only)",
-        "ci/lint_cpp/public_settings_pattern_checker.py (Python-only)",
-        "ci/lint_cpp/noexcept_checker.py (AST ratchet)",
-        "ci/lint_cpp/pch_file_checker.py (cross-file structural)",
-        "ci/lint_cpp/test_unity_build.py (cross-file structural)",
-        "ci/lint_cpp/test_aggregation_checker.py (cross-file structural)"
+        "ci/lint_cpp/rust_bridge.py (Rust to Python result bridge)",
+        "ci/lint_cpp/noexcept_checker.py (AST ratchet — clang-query)"
       ],
       "script": "ci/cpp_lint_cache.py",
       "lint_command": "bash lint --cpp (default-on Rust path; --no-rust falls back to Python-only)"

--- a/ci/fix_has_include.py
+++ b/ci/fix_has_include.py
@@ -9,6 +9,16 @@ This script:
 4. Optionally fixes them by adding the include
 """
 
+"""Manual one-shot fixer for the FL_HAS_INCLUDE include rule (issue #3308).
+
+This tool is retained as a manual utility — no orchestrator or hook
+invokes it automatically. The corresponding CI lint rule was retired
+along with the broader Python-checker migration (#3293) and has not
+been ported to the Rust crate yet. Re-port the rule under
+`ci/lint_cpp_rs/src/checkers/preprocessor.rs` if CI enforcement is
+needed again.
+"""
+
 import _thread
 import re
 import sys

--- a/ci/fix_has_include_README.md
+++ b/ci/fix_has_include_README.md
@@ -34,7 +34,7 @@ uv run python ci/fix_has_include.py --help
 - Adds IWYU pragma to prevent removal
 - Handles indentation matching
 
-A standalone CI linter for this rule has not (yet) been ported to the Rust crate (`ci/lint_cpp_rs/`). The original Python `has_include_checker.py` was retired with the wider Rust migration (FastLED #3288); add a Rust checker under `ci/lint_cpp_rs/src/checkers/preprocessor.rs` if the rule needs CI enforcement again — see `agents/docs/linter-architecture.md` for the workflow.
+The standalone `ci/fix_has_include.py` tool remains as a one-shot manual fixer; the CI lint rule it once paired with was retired in #3293 and has not been ported to the Rust crate — see issue #3308 acceptance criterion for `fix_has_include.py`. Add a Rust checker under `ci/lint_cpp_rs/src/checkers/preprocessor.rs` if the rule needs CI enforcement again — see `agents/docs/linter-architecture.md` for the workflow.
 
 ## How It Works
 

--- a/src/fl/stl/compiler_control.h
+++ b/src/fl/stl/compiler_control.h
@@ -333,8 +333,9 @@
 
 // Unconditional "do not inline this function" attribute, portable across
 // GCC/Clang/MSVC. Prefer this over a bare `__attribute__((noinline))` in
-// `src/` — a lint check in `ci/lint_cpp/bare_noinline_checker.py` enforces
-// the use of the macro so the GCC-only syntax doesn't sneak in.
+// `src/` — a lint check in `ci/lint_cpp_rs/src/checkers/bare_legacy.rs`
+// (`BareNoInlineChecker`) enforces the use of the macro so the GCC-only
+// syntax doesn't sneak in.
 //
 // Typical use: cold helpers extracted out of a hot path so the compiler
 // can't fold them back via inline expansion. Pair with the lint guard.


### PR DESCRIPTION
## Summary

After PR #3293 migrated the C++ checker fleet from Python to the Rust crate at `ci/lint_cpp_rs/`, several docs and configs still pointed at deleted `.py` files. This PR retires every stale reference and redirects it to the live Rust target.

## Files changed (9)

- `agents/docs/linter-architecture.md` — rewrote "When to still use Python" section; only the 3 Tier-4 AST ratchets remain in Python.
- `agents/docs/cpp-standards.md` — Public Settings allowlist now points at `ci/lint_cpp_rs/src/checkers/public_settings.rs::PUBLIC_SETTINGS_GRANDFATHERED`.
- `.claude/agents/cpp-linter-builder-agent.md` — replaced deleted `test_unity_build.py` / `test_aggregation_checker.py` / `pch_file_checker.py` with `ci/lint_cpp_rs/src/checkers/unity_build.rs` and `structural_passes.rs`.
- `.claude/agents/architecture-reviewer-agent.md` — updated PublicSettings pointer to Rust.
- `.claude/commands/code_review.md` — same update.
- `ci/dependencies.json` — pruned `tools` array to surviving entries (`run_all_checkers.py`, `rust_bridge.py`, `rust_binary_cache.py`, `noexcept_checker.py`) plus the Rust crate.
- `src/fl/stl/compiler_control.h` — `FL_NO_INLINE` comment redirected to `BareNoInlineChecker` in `ci/lint_cpp_rs/src/checkers/bare_legacy.rs`.
- `ci/fix_has_include_README.md` — rewrote the retired-rule paragraph per #3308 acceptance criterion.
- `ci/fix_has_include.py` — added docstring marking it manual-only (orphan tool disposition).

## Test plan

- [x] `bash lint --cpp` passes
- [x] `python -m json.tool ci/dependencies.json` parses
- [x] Sweep grep for deleted `ci/lint_cpp/*_checker.py` references returns 0 hits outside `ci/lint_cpp_rs/` migration comments
- [x] Verified every Rust pointer target exists (e.g. `struct PublicSettingsPatternChecker`, `PUBLIC_SETTINGS_GRANDFATHERED`, `BareNoInlineChecker`)

Refs #3308.

Generated with Claude Code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated “Public Settings Pattern” guidance in multiple guides to match the current transitional allowlist name and updated “Check Process” wording.
  * Refreshed guidance on when to still use Python, clarifying Rust-first behavior for most checks and limiting Python to specific AST ratchets.
  * Updated docs for the retained manual `fix_has_include` utility and its (non-)enforcement status.

* **Chores**
  * Updated CI tooling/config descriptions to reflect Rust-based checker orchestration and consolidated checker entry points.
  * Adjusted an internal header comment to point to the current Rust lint check location.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->