### PR TITLE
fix(lint): #3308 PR-A small lint-infra fixes (PchFileChecker case, AST tool detection, cache Rust sources, examples lint-on-save, FL_LINT_AB retirement)

### DIFF
--- a/ci/cpp_lint_cache.py
+++ b/ci/cpp_lint_cache.py
@@ -32,6 +32,9 @@ _DEFAULT_CPP_LINT_GLOBS = [
     "tests/**/*.cpp",
     "tests/**/*.hpp",
     "ci/lint_cpp/*.py",
+    "ci/lint_cpp_rs/Cargo.toml",
+    "ci/lint_cpp_rs/Cargo.lock",
+    "ci/lint_cpp_rs/src/**/*.rs",
 ]
 
 
@@ -49,9 +52,17 @@ def _get_cpp_lint_patterns() -> tuple[list[str], list[str]]:
         manifest = DependencyManifest()
         include = manifest.get_globs("cpp_lint")
         exclude = manifest.get_excludes("cpp_lint")
-        # Also monitor linter scripts
-        if "ci/lint_cpp/*.py" not in include:
-            include.append("ci/lint_cpp/*.py")
+        # Also monitor linter scripts (Python + Rust) — local edits to either
+        # checker implementation must invalidate the lint-success cache.
+        extra_includes = [
+            "ci/lint_cpp/*.py",
+            "ci/lint_cpp_rs/Cargo.toml",
+            "ci/lint_cpp_rs/Cargo.lock",
+            "ci/lint_cpp_rs/src/**/*.rs",
+        ]
+        for pattern in extra_includes:
+            if pattern not in include:
+                include.append(pattern)
         return include, exclude
     except (FileNotFoundError, KeyError):
         return list(_DEFAULT_CPP_LINT_GLOBS), []

--- a/ci/hooks/lint-on-save.py
+++ b/ci/hooks/lint-on-save.py
@@ -111,10 +111,12 @@ def main() -> int:
         if rel_norm == sub_path or rel_norm.startswith(sub_path + "/"):
             return 0
 
-    # Skip C++ files in examples directory (IWYU checks not applicable)
-    if Path(file_path).suffix.lower() in CPP_EXTENSIONS:
-        if rel_path.startswith("examples" + os.sep) or rel_path.startswith("examples/"):
-            return 0
+    # Note: previously C++ files under examples/ were short-circuited here
+    # because IWYU checks aren't applicable. After PR #3293 the Rust lint
+    # path needs to run on save for examples-scope checkers
+    # (UsingNamespaceFlInExamplesChecker, ExampleSerialChecker, the
+    # examples-scope BannedHeadersChecker). The fingerprint cache keeps
+    # the per-save cost low, so the short-circuit was removed.
 
     # Delegate to lint.py in single-file mode
     # Always use --strict for Python files (pyright on single file is fast)

--- a/ci/lint_cpp/run_all_checkers.py
+++ b/ci/lint_cpp/run_all_checkers.py
@@ -15,8 +15,6 @@ from typing import Any, cast
 
 from ci.lint_cpp.rust_bridge import (
     merge_checker_results,
-    remove_rust_supported_checkers,
-    run_rust_ab_check,
     run_rust_linter,
 )
 from ci.util.check_files import (
@@ -356,11 +354,8 @@ def _ast_tool_unavailable(message: str) -> bool:
     clang-tool-chain wheel installed.
     """
     lower = message.lower()
-    return (
-        "clang-query not found" in lower
-        or "failed to spawn" in lower
-        or "no such file or directory" in lower
-    )
+    tool_named = "clang-query" in lower or "clang-tool-chain-query" in lower
+    return tool_named and ("not found" in lower or "failed to spawn" in lower)
 
 
 def run_noexcept_ast_check(file_path: str | None = None) -> CheckerResults:
@@ -710,8 +705,7 @@ def main() -> int:
         ),
     )
     args = parser.parse_args()
-    rust_ab = os.environ.get("FL_LINT_AB") == "1"
-    use_rust_fast_path = args.rust and not rust_ab
+    use_rust_fast_path = args.rust
 
     if args.file:
         # Single file mode
@@ -735,7 +729,6 @@ def main() -> int:
         rust_results: dict[str, CheckerResults] = {}
         if use_rust_fast_path:
             rust_results = run_rust_linter([str(file_path)])
-            remove_rust_supported_checkers(checkers_by_scope)
 
         # Run all applicable checkers on the single file
         results = run_checkers_on_single_file(str(file_path), checkers_by_scope)
@@ -758,8 +751,6 @@ def main() -> int:
             results["ArrayParamAstChecker"] = array_param_results
 
         # Format and print results
-        if rust_ab and not run_rust_ab_check(results, [str(file_path)]):
-            return 1
         exit_code = format_and_print_results(results)
 
         return exit_code
@@ -778,7 +769,6 @@ def main() -> int:
         rust_results: dict[str, CheckerResults] = {}
         if use_rust_fast_path:
             rust_results = run_rust_linter(None)
-            remove_rust_supported_checkers(checkers_by_scope)
 
         # Run all checkers in a single pass per scope
         results = run_checkers(files_by_dir, checkers_by_scope)
@@ -800,8 +790,6 @@ def main() -> int:
             results["ArrayParamAstChecker"] = array_param_results
 
         # Format and print results
-        if rust_ab and not run_rust_ab_check(results, None):
-            return 1
         exit_code = format_and_print_results(results)
 
         return exit_code

--- a/ci/lint_cpp/rust_bridge.py
+++ b/ci/lint_cpp/rust_bridge.py
@@ -4,102 +4,13 @@ from __future__ import annotations
 
 import json
 import sys
-from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from running_process import RunningProcess
 
 from ci.lint_cpp.rust_binary_cache import ensure_rust_lint_binary
-from ci.util.check_files import CheckerResults, FileContentChecker
+from ci.util.check_files import CheckerResults
 from ci.util.paths import PROJECT_ROOT
-
-
-RUST_SUPPORTED_CHECKERS = frozenset(
-    {
-        "ArduinoMacroUsageChecker",
-        "AsmJsLocationChecker",
-        "AttributeChecker",
-        "BareAllocationChecker",
-        "BareLibmChecker",
-        "BareNoInlineChecker",
-        "BareSnprintfChecker",
-        "BareUsingChecker",
-        "BannedDefineChecker",
-        "BannedHeadersChecker",
-        "BannedMacrosChecker",
-        "BannedNamespaceChecker",
-        "BuiltinMemcpyChecker",
-        "FlNoUnderscoreChecker",
-        "LegacyLogMacroChecker",
-        "CppHppHeaderPairChecker",
-        "CppHppIncludesChecker",
-        "CppIncludeChecker",
-        "CtypeGlobalChecker",
-        "EmAsmClangFormatChecker",
-        "EnumClassChecker",
-        "EspRomPrintfChecker",
-        "ExampleSerialChecker",
-        "FastLEDHeaderUsageChecker",
-        "FlIsDefinedChecker",
-        "HeadersExistChecker",
-        "IncludeAfterNamespaceChecker",
-        "IncludePathsChecker",
-        "ImplHppIncludesChecker",
-        "IsHeaderIncludeChecker",
-        "IwyuPragmaBlockChecker",
-        "IwyuPragmaPrivateChecker",
-        "LoggingInIramChecker",
-        "MemberStyleChecker",
-        "NamespaceFlDeclarationChecker",
-        "NamespaceIncludesChecker",
-        "NamespacePlatformsChecker",
-        "NativePlatformDefinesChecker",
-        "NoexceptSpecialMembersChecker",
-        "NumericLimitMacroChecker",
-        "PlatformIncludesChecker",
-        "PlatformsFlNamespaceChecker",
-        "PragmaOnceChecker",
-        "PchFileChecker",
-        "PlatformPragmaChecker",
-        "PlatformTrampolineChecker",
-        "PublicSettingsPatternChecker",
-        "UnityBuildChecker",
-        "RawNoexceptChecker",
-        "RawPragmaChecker",
-        "ReinterpretCastChecker",
-        "RelativeIncludeChecker",
-        "SerialPrintfChecker",
-        "SimdIntrinsicsChecker",
-        "SleepForChecker",
-        "SingletonInHeadersChecker",
-        "SpanFromPointerChecker",
-        "StaticInHeaderChecker",
-        "StdNamespaceChecker",
-        "StdintTypeChecker",
-        "SubdirNamespaceChecker",
-        "TestAggregationChecker",
-        "TestIncludePathsChecker",
-        "TestPathStructureChecker",
-        "ThreadLocalKeywordChecker",
-        "UnitTestChecker",
-        "UsingNamespaceChecker",
-        "UsingNamespaceFlChecker",
-        "UsingNamespaceFlInExamplesChecker",
-        "WeakAttributeChecker",
-    }
-)
-
-
-def remove_rust_supported_checkers(
-    checkers_by_scope: dict[str, list[FileContentChecker]],
-) -> None:
-    """Remove checker instances handled by the Rust fast path."""
-    for scope, checkers in checkers_by_scope.items():
-        filtered: list[FileContentChecker] = []
-        for checker in checkers:
-            if checker.__class__.__name__ not in RUST_SUPPORTED_CHECKERS:
-                filtered.append(checker)
-        checkers_by_scope[scope] = filtered
 
 
 def run_rust_linter(files: list[str] | None) -> dict[str, CheckerResults]:
@@ -160,34 +71,9 @@ def parse_rust_json_output(stdout: str | None) -> list[dict[str, Any]]:
         except json.JSONDecodeError:
             continue
         if isinstance(value, list):
-            return value
+            return cast(list[dict[str, Any]], value)
 
     raise RuntimeError("Rust C++ linter did not produce valid JSON on stdout")
-
-
-def run_rust_ab_check(
-    python_results: dict[str, CheckerResults],
-    files: list[str] | None,
-) -> bool:
-    """Compare Rust-supported checker output against the Python oracle."""
-    rust_results = run_rust_linter(files)
-    python_canonical = _canonical_results(
-        {
-            name: results
-            for name, results in python_results.items()
-            if name in RUST_SUPPORTED_CHECKERS
-        }
-    )
-    rust_canonical = _canonical_results(rust_results)
-
-    if python_canonical == rust_canonical:
-        print("Rust/Python C++ linter A/B parity passed for supported checkers.")
-        return True
-
-    print("Rust/Python C++ linter A/B parity failed.", file=sys.stderr)
-    _print_diff_sample("Python-only", python_canonical - rust_canonical)
-    _print_diff_sample("Rust-only", rust_canonical - python_canonical)
-    return False
 
 
 def merge_checker_results(
@@ -217,30 +103,3 @@ def _violations_to_results(
         message = str(item["message"])
         results.setdefault(checker, CheckerResults()).add_violation(path, line, message)
     return results
-
-
-def _canonical_results(
-    results: dict[str, CheckerResults],
-) -> set[tuple[str, str, int, str]]:
-    canonical: set[tuple[str, str, int, str]] = set()
-    for checker_name, checker_results in results.items():
-        for file_path, file_violations in checker_results.violations.items():
-            normalized_path = str(Path(file_path)).replace("\\", "/")
-            for violation in file_violations.violations:
-                canonical.add(
-                    (
-                        checker_name,
-                        normalized_path,
-                        violation.line_number,
-                        violation.content,
-                    )
-                )
-    return canonical
-
-
-def _print_diff_sample(label: str, values: set[tuple[str, str, int, str]]) -> None:
-    if not values:
-        return
-    print(f"{label} differences ({len(values)} total, first 20):", file=sys.stderr)
-    for checker, path, line, message in sorted(values)[:20]:
-        print(f"  {checker} {path}:{line}: {message}", file=sys.stderr)

--- a/ci/lint_cpp_rs/src/checkers/structural_passes.rs
+++ b/ci/lint_cpp_rs/src/checkers/structural_passes.rs
@@ -132,10 +132,10 @@ fn pch_file_pass(project_root: &Path, violations: &mut Vec<LintViolation>) {
                 continue;
             }
             let path = entry.path();
-            let Some(ext) = path.extension().and_then(|value| value.to_str()) else {
-                continue;
-            };
-            if ext.eq_ignore_ascii_case("pch") {
+            // Mirror Python's case-sensitive `scan_dir.rglob("*.pch")` so
+            // capital-suffix files (e.g. `Foo.PCH`) are not over-flagged on
+            // Linux/macOS where Python skipped them.
+            if path.extension().and_then(|value| value.to_str()) == Some("pch") {
                 let rel = path.strip_prefix(project_root).unwrap_or(path);
                 let rel_display = normalize_path(&path_to_string(rel));
                 // Python emits one violation per .pch with path="pch_files"


### PR DESCRIPTION
## Summary

PR-A of the parallel-agent split for #3308. Five small lint-infrastructure fixes that share the same change-zone (cpp lint cache, on-save hook, Rust checker, A/B compare). No test or doc changes (PR-B/PR-C cover those).

### Fixes included

- **PchFileChecker case-sensitivity (HIGH)** — `ci/lint_cpp_rs/src/checkers/structural_passes.rs` now matches `*.pch` exact-case (mirrors Python's `rglob("*.pch")`, which is case-sensitive on Linux/macOS). Eliminates the cross-port over-flag of `.PCH`/`.Pch` files.
- **`_ast_tool_unavailable` over-broad (HIGH)** — `ci/lint_cpp/run_all_checkers.py` no longer swallows arbitrary `"no such file or directory"` errors from clang. Requires the tool name (`clang-query` / `clang-tool-chain-query`) to co-occur with `"not found"` / `"failed to spawn"`.
- **`cpp_lint_cache.py` Rust sources (MEDIUM)** — added `Cargo.toml`, `Cargo.lock`, `src/**/*.rs` to the fingerprint glob list (both default + manifest path). Local edits to Rust checkers now invalidate the lint-success cache.
- **`lint-on-save.py` examples short-circuit (MEDIUM)** — removed; the Rust path needs to run on save for examples-scope checkers (`UsingNamespaceFlInExamplesChecker`, `ExampleSerialChecker`, examples-scope `BannedHeadersChecker`). Fingerprint cache keeps cost low.
- **`FL_LINT_AB=1` retirement (MEDIUM)** — post-#3293 the Python `create_checkers()` returns all-empty lists, so the A/B compare was trivially empty. Deleted `run_rust_ab_check`, `_canonical_results`, `_print_diff_sample`, `RUST_SUPPORTED_CHECKERS`, and `remove_rust_supported_checkers` from `ci/lint_cpp/rust_bridge.py`; removed the `FL_LINT_AB` env-var plumbing from `ci/lint_cpp/run_all_checkers.py`.

Drive-by: tightened a pre-existing `reportUnknownVariableType` pyright finding on `parse_rust_json_output()` with an explicit `cast`.

### Acceptance criteria closed (4 of 9)

- [x] PchFileChecker case-sensitivity matches Python (Linux/macOS)
- [x] `_ast_tool_unavailable` no longer swallows real clang errors
- [x] `cpp_lint_cache.py` invalidates on Rust source edits
- [x] `lint-on-save.py` runs Rust path on `examples/` C++ files
- [x] `FL_LINT_AB` infrastructure retired

Remaining items (test/doc fixups) are handled by PR-B and PR-C.

## Test plan

- [x] `uv run python ci/lint_cpp/rust_binary_cache.py` — Rust binary rebuilt cleanly after `structural_passes.rs` change
- [x] `uv run python ci/lint_cpp/run_all_checkers.py` — passes (default Rust path)
- [x] `bash lint --cpp` — passes
- [x] `uv run pyright ci/lint_cpp/run_all_checkers.py ci/lint_cpp/rust_bridge.py ci/cpp_lint_cache.py ci/hooks/lint-on-save.py` — 0 errors

Refs #3308

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Made `.pch` artifact detection case-sensitive in C++ linting.
  * Improved behavior when C++ AST tooling is missing or fails, reducing misleading lint outcomes.

* **Chores**
  * Improved C++ lint cache invalidation to include Rust lint sources/outputs.
  * Enabled C++ linting for `examples/` files on save.
  * Simplified the Rust linter integration used during C++ lint runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->