### PR TITLE
feat(ui): add UIAudioReactive widget for browser audio-reactive FFT (WASM compiler)

### DIFF
--- a/examples/AudioReactive/AudioReactive.ino
+++ b/examples/AudioReactive/AudioReactive.ino
@@ -1,53 +1,65 @@
-// @filter: (mem is large) and ((platform is teensy) or (platform is esp32))
-
-// Audio Reactive LEDs using FastLED.add(Config)
-// Demonstrates the auto-pumped audio pipeline: mic → processor → callbacks → LEDs
+// @filter: (mem is large)
 
 #include "FastLED.h"
-
-#if defined(FL_IS_TEENSY)
-// Keep fbuild's library scanner aware of PJRC Audio sources for Teensy.
-#include <Audio.h>
-#endif
 
 #define NUM_LEDS 60
 #define LED_PIN 2
 
-// I2S pins for INMP441 microphone (adjust for your board)
-#define I2S_WS  7
-#define I2S_SD  8
-#define I2S_CLK 4
-
 CRGB leds[NUM_LEDS];
-fl::shared_ptr<fl::audio::Processor> audio;
+fl::UIAudioReactive audio("Audio");
+
+int bandToLeds(float level, int maxLeds) {
+    int count = static_cast<int>(level * maxLeds);
+    if (count < 0) {
+        count = 0;
+    }
+    if (count > maxLeds) {
+        count = maxLeds;
+    }
+    return count;
+}
 
 void setup() {
     Serial.begin(115200);
     FastLED.addLeds<WS2812B, LED_PIN, GRB>(leds, NUM_LEDS);
-    FastLED.setBrightness(128);
-
-    auto config = fl::audio::Config::CreateInmp441(I2S_WS, I2S_SD, I2S_CLK, fl::audio::AudioChannel::Right);
-    audio = FastLED.add(config);
-    audio->setGain(2.0f);  // Boost input by 2x
-
-    // Flash white on every beat
-    audio->onBeat([] {
-        fill_solid(leds, NUM_LEDS, CRGB::White);
-    });
-
-    // Map bass level to hue
-    audio->onBass([](float level) {
-        uint8_t hue = static_cast<uint8_t>(level * 160);
-        fill_solid(leds, NUM_LEDS, CHSV(hue, 255, 255));
-    });
-
-    // Dim to black on silence
-    audio->onSilenceStart([] {
-        fill_solid(leds, NUM_LEDS, CRGB::Black);
-    });
 }
 
 void loop() {
-    fadeToBlackBy(leds, NUM_LEDS, 20);
+    float volume = audio.getVolume();
+    float bass = audio.getBass();
+    float mid = audio.getMid();
+    float treble = audio.getTreble();
+    bool beat = audio.isBeat();
+
+    fadeToBlackBy(leds, NUM_LEDS, 10);
+
+    int center = NUM_LEDS / 2;
+
+    if (beat) {
+        fill_solid(leds, NUM_LEDS, CRGB::White);
+    } else {
+        int bassLeds = bandToLeds(bass, center);
+        int midLeds = bandToLeds(mid, center);
+        int trebleLeds = bandToLeds(treble, center);
+
+        for (int i = 0; i < bassLeds; ++i) {
+            leds[center + i] += CHSV(0, 255, 150);
+            leds[center - 1 - i] += CHSV(0, 255, 150);
+        }
+        for (int i = 0; i < midLeds; ++i) {
+            leds[center + i] += CHSV(96, 255, 100);
+            leds[center - 1 - i] += CHSV(96, 255, 100);
+        }
+        for (int i = 0; i < trebleLeds; ++i) {
+            leds[center + i] += CHSV(160, 255, 50);
+            leds[center - 1 - i] += CHSV(160, 255, 50);
+        }
+    }
+
+    if (volume > 1.0f) {
+        volume = 1.0f;
+    }
+    FastLED.setBrightness(static_cast<uint8_t>(volume * 255.0f));
     FastLED.show();
+    delay(16);
 }

--- a/src/FastLED.h
+++ b/src/FastLED.h
@@ -1818,6 +1818,8 @@ using fl::UINumberField;
 using fl::UISlider;
 using fl::UIDropdown;
 using fl::UIGroup;
+using fl::UIAudioReactive;
+using fl::UIAudio;
 using fl::XYMap;
 using fl::round;  // Template version avoids conflicts with ::round
 // Only expose fl::delay as global delay() on non-hardware platforms (stub/WASM).

--- a/src/fl/ui/_build.cpp.hpp
+++ b/src/fl/ui/_build.cpp.hpp
@@ -2,6 +2,7 @@
 /// @brief Unity build header for fl/ui/ directory
 
 #include "fl/ui/audio.cpp.hpp"
+#include "fl/ui/audio_reactive.cpp.hpp"
 #include "fl/ui/button.cpp.hpp"
 #include "fl/ui/checkbox.cpp.hpp"
 #include "fl/ui/description.cpp.hpp"

--- a/src/fl/ui/audio_reactive.cpp.hpp
+++ b/src/fl/ui/audio_reactive.cpp.hpp
@@ -1,0 +1,89 @@
+#include "fl/ui/audio_reactive.h"
+#include "fl/stl/noexcept.h"
+
+namespace fl {
+
+UIAudioReactive::UIAudioReactive(const fl::string& name) FL_NO_EXCEPT
+    : mImpl(name) {
+    audio::ReactiveConfig config;
+    config.sampleRate = AUDIO_DEFAULT_SAMPLE_RATE;
+    mReactive.begin(config);
+}
+
+UIAudioReactive::UIAudioReactive(const fl::string& name, const fl::url& url) FL_NO_EXCEPT
+    : mImpl(name, url) {
+    audio::ReactiveConfig config;
+    config.sampleRate = AUDIO_DEFAULT_SAMPLE_RATE;
+    mReactive.begin(config);
+}
+
+UIAudioReactive::UIAudioReactive(const fl::string& name, const fl::asset_ref& asset) FL_NO_EXCEPT
+    : mImpl(name, fl::resolve_asset(asset)) {
+    audio::ReactiveConfig config;
+    config.sampleRate = AUDIO_DEFAULT_SAMPLE_RATE;
+    mReactive.begin(config);
+}
+
+UIAudioReactive::UIAudioReactive(const fl::string& name, const fl::audio::Config& config) FL_NO_EXCEPT
+    : mImpl(name, config), mConfig(config) {
+    audio::ReactiveConfig rConfig;
+    rConfig.sampleRate = AUDIO_DEFAULT_SAMPLE_RATE;
+    if (const audio::ConfigI2S* i2s = config.ptr<audio::ConfigI2S>()) {
+        rConfig.sampleRate = i2s->mSampleRate;
+    } else if (const audio::ConfigPdm* pdm = config.ptr<audio::ConfigPdm>()) {
+        rConfig.sampleRate = pdm->mSampleRate;
+    }
+    mReactive.begin(rConfig);
+}
+
+UIAudioReactive::~UIAudioReactive() FL_NO_EXCEPT {}
+
+void UIAudioReactive::update() FL_NO_EXCEPT {
+    while (mImpl.hasNext()) {
+        audio::Sample sample = mImpl.next();
+        if (!sample.isValid()) {
+            break;
+        }
+        mReactive.processSample(sample);
+    }
+}
+
+float UIAudioReactive::getVolume() FL_NO_EXCEPT {
+    update();
+    return mReactive.getVolume();
+}
+
+float UIAudioReactive::getBass() FL_NO_EXCEPT {
+    update();
+    return mReactive.getBass();
+}
+
+float UIAudioReactive::getMid() FL_NO_EXCEPT {
+    update();
+    return mReactive.getMid();
+}
+
+float UIAudioReactive::getTreble() FL_NO_EXCEPT {
+    update();
+    return mReactive.getTreble();
+}
+
+float UIAudioReactive::getBand(fl::u8 band) FL_NO_EXCEPT {
+    update();
+    if (band >= kNumBands) {
+        return 0.0f;
+    }
+    return mReactive.getData().frequencyBins[band];
+}
+
+bool UIAudioReactive::isBeat() FL_NO_EXCEPT {
+    update();
+    return mReactive.isBeat();
+}
+
+void UIAudioReactive::setGroup(const fl::string& groupName) FL_NO_EXCEPT {
+    UIElement::setGroup(groupName);
+    mImpl.setGroup(groupName);
+}
+
+}

--- a/src/fl/ui/audio_reactive.h
+++ b/src/fl/ui/audio_reactive.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include "fl/asset/asset.h"
+#include "fl/audio/audio.h"
+#include "fl/audio/audio_input.h"
+#include "fl/audio/audio_reactive.h"
+#include "fl/stl/optional.h"
+#include "fl/stl/shared_ptr.h"
+#include "fl/stl/string.h"
+#include "fl/stl/url.h"
+#include "fl/ui/element.h"
+#include "fl/ui/audio.h"
+#include "fl/stl/noexcept.h"
+
+namespace fl {
+
+class UIAudioReactive : public UIElement {
+  public:
+    FL_NO_COPY(UIAudioReactive)
+    UIAudioReactive(const fl::string& name) FL_NO_EXCEPT;
+    UIAudioReactive(const fl::string& name, const fl::url& url) FL_NO_EXCEPT;
+    UIAudioReactive(const fl::string& name, const fl::asset_ref& asset) FL_NO_EXCEPT;
+    UIAudioReactive(const fl::string& name, const fl::audio::Config& config) FL_NO_EXCEPT;
+    ~UIAudioReactive() FL_NO_EXCEPT;
+
+    float getVolume() FL_NO_EXCEPT;
+    float getBass() FL_NO_EXCEPT;
+    float getMid() FL_NO_EXCEPT;
+    float getTreble() FL_NO_EXCEPT;
+    float getBand(fl::u8 band) FL_NO_EXCEPT;
+    bool isBeat() FL_NO_EXCEPT;
+
+    static constexpr fl::u8 kNumBands = 16;
+
+    void setGroup(const fl::string& groupName) FL_NO_EXCEPT override;
+
+  protected:
+    UIAudioImpl mImpl;
+    fl::audio::Reactive mReactive;
+    fl::optional<audio::Config> mConfig;
+
+  private:
+    void update() FL_NO_EXCEPT;
+};
+
+}

--- a/src/fl/ui/ui.h
+++ b/src/fl/ui/ui.h
@@ -7,6 +7,7 @@
 /// them so consumers can include the entire UI surface with one include.
 
 #include "fl/ui/audio.h"
+#include "fl/ui/audio_reactive.h"
 #include "fl/ui/button.h"
 #include "fl/ui/checkbox.h"
 #include "fl/ui/description.h"

--- a/tests/fl/ui/ui.cpp
+++ b/tests/fl/ui/ui.cpp
@@ -19,6 +19,7 @@
 #include "fl/stl/json.h"
 #include "fl/stl/compiler_control.h"
 #include "fl/stl/string.h" // ok include
+#include "fl/math/math.h"
 #include "test.h"
 #include "test.h"
 #include "fl/log/log.h"
@@ -1087,6 +1088,62 @@ FL_TEST_CASE("UI Bug - Memory Corruption") {
         // Process pending updates again to verify everything still works
         fl::processJsonUiPendingUpdates();
     } // Components go out of scope here and should be properly destroyed
+}
+
+FL_TEST_CASE("UIAudioReactive basic functionality") {
+    fl::string capturedJsonOutput;
+    auto updateEngineState = fl::setJsonUiHandlers(
+        [&](const char* jsonStr) {
+            if (jsonStr) {
+                capturedJsonOutput = jsonStr;
+            }
+        }
+    );
+    FL_CHECK(updateEngineState);
+
+    fl::UIAudioReactive audio("SoundReactive");
+    
+    FL_CHECK(audio.getVolume() == 0.0f);
+    FL_CHECK(audio.getBass() == 0.0f);
+    FL_CHECK(audio.getMid() == 0.0f);
+    FL_CHECK(audio.getTreble() == 0.0f);
+    FL_CHECK_FALSE(audio.isBeat());
+
+    fl::string pcmList = "[";
+    for (int i = 0; i < 512; ++i) {
+        float phase = 2.0f * 3.14159265f * 1000.0f * i / 44100.0f;
+        int16_t val = static_cast<int16_t>(16000.0f * fl::sinf(phase));
+        if (i > 0) {
+            pcmList += ",";
+        }
+        pcmList += val;
+    }
+    pcmList += "]";
+
+    fl::string updateJson = "{\"SoundReactive\": {\"audioData\": [{\"timestamp\": 100, \"samples\": " + pcmList + "}]}}";
+
+    updateEngineState(updateJson.c_str());
+    fl::processJsonUiPendingUpdates();
+
+    float volume = audio.getVolume();
+    float bass = audio.getBass();
+    float mid = audio.getMid();
+    float treble = audio.getTreble();
+
+    FL_CHECK_GT(volume, 0.0f);
+    FL_CHECK_GT(bass, 0.0f);
+    FL_CHECK_GT(mid, 0.0f);
+    FL_CHECK_GT(treble, 0.0f);
+
+    FL_CHECK(audio.getBand(fl::UIAudioReactive::kNumBands) == 0.0f);
+
+    float bandEnergy = 0.0f;
+    for (fl::u8 i = 0; i < fl::UIAudioReactive::kNumBands; ++i) {
+        float band = audio.getBand(i);
+        FL_CHECK_GE(band, 0.0f);
+        bandEnergy += band;
+    }
+    FL_CHECK_GT(bandEnergy, 0.0f);
 }
 
 } // FL_TEST_FILE


### PR DESCRIPTION
## Summary

Adds **`fl::UIAudioReactive`**, a UI widget for the WASM compiler that captures audio from the developer's microphone (or a drag-and-drop / URL audio source) in the browser and pipes real-time frequency-band data back into the C++ simulation. This makes audio-reactive animations designable and tunable entirely offline — no mic module, ADC/DMA wiring, or physical noise required.

### Example

```cpp
#include <FastLED.h>

fl::UIAudioReactive audio("Music Stream");

void loop() {
    float bass   = audio.getBand(0);   // low band  (0..15)
    float treble = audio.getBand(7);   // higher band
    fadeToBlackBy(leds, NUM_LEDS, 20);
    leds[0] = CHSV(160, 255, static_cast<uint8_t>(bass * 255));
    FastLED.show();
}
```

## How it works

`UIAudioReactive` wraps the existing audio-input implementation (`JsonAudioImpl` on the host, `WasmAudioImpl` in the browser — both already expose `next()`/`hasNext()`/`setGroup()`) and pumps incoming PCM samples through `fl::audio::Reactive`, which performs the FFT/band analysis in C++. The browser sends raw PCM via the existing JSON UI `audioData` channel, so the widget reuses the battle-tested C++ FFT pipeline rather than duplicating it in JS.

## API

| Method | Returns |
|--------|---------|
| `getVolume()` | overall level |
| `getBass()` / `getMid()` / `getTreble()` | band averages |
| `getBand(uint8_t band)` | level for one of the 16 frequency bins (`kNumBands`), `0.0f` if out of range |
| `isBeat()` | beat detection |

Constructors mirror `UIAudio`: `(name)`, `(name, url)`, `(name, asset_ref)`, `(name, audio::Config)`.

## Changes

- `src/fl/ui/audio_reactive.{h,cpp.hpp}` — new widget
- `src/FastLED.h`, `src/fl/ui/ui.h`, `src/fl/ui/_build.cpp.hpp` — export/wire-in
- `examples/AudioReactive/AudioReactive.ino` — rewritten to use the widget
- `tests/fl/ui/ui.cpp` — host test feeds PCM through the JSON UI path and asserts volume/bands respond, including the `getBand` boundary

## Review notes

A pre-merge review surfaced two items:

1. **Example LED indexing under loud audio** — `getBass/getMid/getTreble` are not clamped to `[0,1]` (sqrt-scaling + gain can exceed 1.0), so a naive `band * center` index can run past the LED array. The library values are intentionally left unclamped (other consumers want raw magnitudes); defending the bounds is the sketch's responsibility. Flagged for follow-up in the example.
2. **Example `@filter` broadened to `(mem is large)`** — compiles on more boards. Low risk: `UIAudioReactive` falls back to the stub impl on non-WASM platforms, and `AnimartrixRing` already ships `fl/audio/audio_reactive` under the same filter. CI verifies fit.

## Testing

- Host unit test `UIAudioReactive basic functionality` passes (clean rebuild against latest master).
- `bash lint` clean.
- The emscripten/WASM target was **not** built locally (the bundled toolchain on the dev machine can't resolve `<cctype>` for the native launcher — environmental, pre-existing); CI compiles the real WASM target. The host path exercises the identical C++ logic via `JsonAudioImpl`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added audio-reactive UI component providing polling-based APIs to query real-time audio metrics including volume, frequency bands (bass/mid/treble), and beat detection, simplifying development of responsive visual audio effects.

* **Tests**
  * Added test coverage validating audio-reactive UI functionality and metric accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->