### PR TITLE
feat(fl/fled): typed section accessors + FledScript passive type (#3311 PR2)

### DIFF
--- a/src/fl/fled/fled.cpp.hpp
+++ b/src/fl/fled/fled.cpp.hpp
@@ -1,8 +1,11 @@
 #include "fl/fled/fled.h"
 
 #include "fl/fled/fled_impl.hpp"
+#include "fl/fled/fled_script.h"
+#include "fl/math/screenmap.h"
 #include "fl/stl/bit_cast.h"
 #include "fl/stl/cstring.h"
+#include "fl/stl/flat_map.h"
 #include "fl/stl/json.h"
 #include "fl/stl/move.h"
 #include "fl/stl/noexcept.h"
@@ -159,6 +162,54 @@ fl::shared_ptr<const fl::u8> Fled::blob(const char *sectionName,
     // NOTE: for loadFromStatic, the bytes themselves still live in the
     // caller's static span - see Fled::loadFromStatic contract.
     return fl::shared_ptr<const fl::u8>(mImpl, raw);
+}
+
+// ---- typed section accessors ----
+
+fl::shared_ptr<Video> Fled::video() const FL_NO_EXCEPT {
+    // TODO(#3311 PR4): construct Video from bundle bytes via Video::fromBytes
+    return fl::shared_ptr<Video>();
+}
+
+fl::shared_ptr<ScreenMap> Fled::screenMap() const FL_NO_EXCEPT {
+    if (!mImpl) {
+        return fl::shared_ptr<ScreenMap>();
+    }
+    const fl::json &env = mImpl->envelope();
+    // Only attempt a parse if "map" is present AND is an object. A missing
+    // key, null value, or non-object value all read as "no screen map".
+    if (!env.contains(fl::string("map")) || !env["map"].is_object()) {
+        return fl::shared_ptr<ScreenMap>();
+    }
+    // ScreenMap::ParseJson expects a JSON document containing a top-level
+    // "map" key (v1 shape) - the bundle envelope already has that shape,
+    // so we can hand the envelope's serialization straight to the parser.
+    fl::string jsonStr = env.to_string();
+    fl::flat_map<fl::string, ScreenMap> segments;
+    if (!ScreenMap::ParseJson(jsonStr.c_str(), &segments)) {
+        return fl::shared_ptr<ScreenMap>();
+    }
+    if (segments.empty()) {
+        return fl::shared_ptr<ScreenMap>();
+    }
+    // PR2 returns the first segment. Multi-strip bundles will get a
+    // dedicated multi-segment accessor in a later PR; this path keeps the
+    // single-strip case working today without committing to that API.
+    ScreenMap &first = segments.begin()->second;
+    if (first.getLength() == 0) {
+        return fl::shared_ptr<ScreenMap>();
+    }
+    return fl::make_shared<ScreenMap>(first);
+}
+
+fl::shared_ptr<MultiChannelConfig> Fled::channels() const FL_NO_EXCEPT {
+    // TODO(#3311 PR5): construct MultiChannelConfig from envelope["channels"] once the JSON deserializer lands
+    return fl::shared_ptr<MultiChannelConfig>();
+}
+
+fl::shared_ptr<FledScript> Fled::script() const FL_NO_EXCEPT {
+    // TODO(#3311 v2): v1 bundles do not carry script sections
+    return fl::shared_ptr<FledScript>();
 }
 
 fl::u8 Fled::version() const FL_NO_EXCEPT {

--- a/src/fl/fled/fled.h
+++ b/src/fl/fled/fled.h
@@ -5,8 +5,10 @@
 // and evaluate to false. See FLED_FORMAT.md for the on-disk format.
 //
 // PR1 surface: factories, raw json()/blob() accessors, version/sectionCount,
-// and the null-state contract. Typed accessors (video/screenMap/channels)
-// arrive in PR2.
+// and the null-state contract. PR2 adds the four typed section accessors
+// (screenMap/video/channels/script). Of these, only screenMap() has a real
+// body in PR2; the other three are stubs whose implementations land in
+// later PRs once the corresponding deserializers exist.
 
 #include "fl/stl/int.h"
 #include "fl/stl/noexcept.h"
@@ -19,6 +21,16 @@ namespace fl {
 class FileSystem;
 class json;
 class FledImpl;
+
+// Forward decls for the typed section accessors below. Defined in:
+//   Video              - fl/fx/video.h
+//   ScreenMap          - fl/math/screenmap.h
+//   MultiChannelConfig - fl/channels/config.h (declared as struct there)
+//   FledScript         - fl/fled/fled_script.h
+class Video;
+class ScreenMap;
+struct MultiChannelConfig;
+struct FledScript;
 
 class Fled {
   public:
@@ -54,6 +66,16 @@ class Fled {
     // those still depend on the caller's span outliving every use.
     fl::shared_ptr<const fl::u8> blob(const char *sectionName,
                                       fl::size *outLen) const FL_NO_EXCEPT;
+
+    // Typed section accessors. Each returns nullptr if the bundle has no
+    // section of that type. Construction touches NO global state (no
+    // controller registration, no EngineEvents broadcast, no scheduler).
+    // PR4 fills in video() and adds Video::fromFled. PR5 fills in channels()
+    // once the MultiChannelConfig JSON deserializer lands.
+    fl::shared_ptr<Video>              video()     const FL_NO_EXCEPT;
+    fl::shared_ptr<ScreenMap>          screenMap() const FL_NO_EXCEPT;
+    fl::shared_ptr<MultiChannelConfig> channels()  const FL_NO_EXCEPT;
+    fl::shared_ptr<FledScript>         script()    const FL_NO_EXCEPT;
 
     // Header version byte. Returns 0 for null Fled, 1 for valid v1.
     fl::u8 version() const FL_NO_EXCEPT;

--- a/src/fl/fled/fled_script.h
+++ b/src/fl/fled/fled_script.h
@@ -1,0 +1,20 @@
+#pragma once
+
+// fl::FledScript - passive carrier for an embedded script section of a
+// .fled v2 bundle. PR2 introduces the type; v1 bundles never carry a
+// script section so fl::Fled::script() currently always returns nullptr.
+
+#include "fl/stl/int.h"
+#include "fl/stl/shared_ptr.h"
+
+namespace fl {
+
+enum class ScriptKind : fl::u8 { Wasm, MicroPy };
+
+struct FledScript {
+    ScriptKind                   kind;
+    fl::shared_ptr<const fl::u8> bytes;
+    fl::size                     length;
+};
+
+} // namespace fl

--- a/tests/fl/fled/fled.cpp
+++ b/tests/fl/fled/fled.cpp
@@ -1,12 +1,18 @@
-// Unit tests for fl::Fled PR1 surface: factories, raw json()/blob(),
-// version/sectionCount, null-state contract. No on-disk fixtures -
-// each test hand-builds its byte buffer.
+// Unit tests for fl::Fled. PR1 surface: factories, raw json()/blob(),
+// version/sectionCount, null-state contract. PR2 surface: the four
+// typed section accessors (screenMap/video/channels/script).
+// No on-disk fixtures - each test hand-builds its byte buffer.
 
+#include "fl/channels/config.h"
 #include "fl/fled/fled.h"
+#include "fl/fled/fled_script.h"
+#include "fl/fx/video.h"
+#include "fl/math/screenmap.h"
 #include "fl/stl/cstring.h"
 #include "fl/stl/int.h"
 #include "fl/stl/json.h"
 #include "fl/stl/move.h"
+#include "fl/stl/shared_ptr.h"
 #include "fl/stl/span.h"
 #include "fl/stl/string.h"
 #include "fl/stl/vector.h"
@@ -22,6 +28,26 @@ namespace {
 const char kEnvelope[] = "{\"map\":{},\"video\":{\"fps\":30}}";
 // Five-byte frame payload - value doesn't matter, just length.
 const fl::u8 kPayload[5] = {0x01, 0x02, 0x03, 0x04, 0x05};
+
+// Build a v1 .fled buffer wrapping an arbitrary JSON envelope (no payload).
+fl::vector<fl::u8> buildBundleFromEnvelope(const char *envelope,
+                                            fl::size envelopeLen) {
+    const fl::u32 jsonLen = static_cast<fl::u32>(envelopeLen);
+    fl::vector<fl::u8> out;
+    out.resize(12 + envelopeLen);
+    out[0] = 'F'; out[1] = 'L'; out[2] = 'E'; out[3] = 'D';
+    out[4] = 1;        // version
+    out[5] = 0x00;     // pixel_format = rgb8
+    out[6] = 0; out[7] = 0;  // reserved
+    out[8]  = static_cast<fl::u8>(jsonLen & 0xff);
+    out[9]  = static_cast<fl::u8>((jsonLen >> 8) & 0xff);
+    out[10] = static_cast<fl::u8>((jsonLen >> 16) & 0xff);
+    out[11] = static_cast<fl::u8>((jsonLen >> 24) & 0xff);
+    for (fl::size i = 0; i < envelopeLen; ++i) {
+        out[12 + i] = static_cast<fl::u8>(envelope[i]);
+    }
+    return out;
+}
 
 // Build a valid v1 .fled byte buffer in a fl::vector<u8>.
 fl::vector<fl::u8> buildValidBundle() {
@@ -180,6 +206,69 @@ FL_TEST_CASE("fl::Fled - malformed JSON rejected") {
     buf[12 + jsonLen + 2] = 0xCC;
     Fled f = Fled::loadFromVector(fl::move(buf));
     FL_CHECK_FALSE(static_cast<bool>(f));
+}
+
+
+// ---- PR2: typed section accessors ----
+
+FL_TEST_CASE("fl::Fled - screenMap() returns null on default-constructed Fled") {
+    Fled f;
+    fl::shared_ptr<ScreenMap> sm = f.screenMap();
+    FL_CHECK(sm == nullptr);
+}
+
+FL_TEST_CASE("fl::Fled - screenMap() returns null when envelope has no 'map' key") {
+    // Envelope with only a 'video' key - no 'map'.
+    const char env[] = "{\"video\":{\"fps\":30}}";
+    fl::vector<fl::u8> buf = buildBundleFromEnvelope(env, sizeof(env) - 1);
+    Fled f = Fled::loadFromVector(fl::move(buf));
+    FL_CHECK(static_cast<bool>(f));
+    fl::shared_ptr<ScreenMap> sm = f.screenMap();
+    FL_CHECK(sm == nullptr);
+}
+
+FL_TEST_CASE("fl::Fled - screenMap() returns null when 'map' is an empty object") {
+    // The shipped buildValidBundle uses {\"map\":{}} which has no segments,
+    // so the parser should yield no entries and screenMap() must report null.
+    fl::vector<fl::u8> buf = buildValidBundle();
+    Fled f = Fled::loadFromVector(fl::move(buf));
+    FL_CHECK(static_cast<bool>(f));
+    fl::shared_ptr<ScreenMap> sm = f.screenMap();
+    FL_CHECK(sm == nullptr);
+}
+
+FL_TEST_CASE("fl::Fled - screenMap() parses a real v1 map") {
+    // v1 ScreenMap shape: top-level \"map\" key holding one or more named
+    // strips with x[], y[], optional diameter. See tests/fl/math/screenmap.cpp.
+    const char env[] =
+        "{\"map\":{\"strip1\":{\"x\":[10.5,30.5,50.5],"
+        "\"y\":[20.5,40.5,60.5],\"diameter\":2.5}}}";
+    fl::vector<fl::u8> buf = buildBundleFromEnvelope(env, sizeof(env) - 1);
+    Fled f = Fled::loadFromVector(fl::move(buf));
+    FL_CHECK(static_cast<bool>(f));
+    fl::shared_ptr<ScreenMap> sm = f.screenMap();
+    FL_CHECK(sm != nullptr);
+    FL_CHECK_EQ(sm->getLength(), fl::u32(3));
+    FL_CHECK(sm->getDiameter() == 2.5f);
+    FL_CHECK((*sm)[0].x == 10.5f);
+    FL_CHECK((*sm)[2].y == 60.5f);
+}
+
+FL_TEST_CASE("fl::Fled - video()/channels()/script() are stubs returning nullptr") {
+    fl::vector<fl::u8> buf = buildValidBundle();
+    Fled f = Fled::loadFromVector(fl::move(buf));
+    FL_CHECK(static_cast<bool>(f));
+    // All three are PR2 stubs; full implementations land in PR4/PR5/v2 bundle.
+    FL_CHECK(f.video() == nullptr);
+    FL_CHECK(f.channels() == nullptr);
+    FL_CHECK(f.script() == nullptr);
+}
+
+FL_TEST_CASE("fl::Fled - video()/channels()/script() return null on null Fled") {
+    Fled f;
+    FL_CHECK(f.video() == nullptr);
+    FL_CHECK(f.channels() == nullptr);
+    FL_CHECK(f.script() == nullptr);
 }
 
 } // FL_TEST_FILE


### PR DESCRIPTION
## Summary

**PR2 of #3311.** Adds the four typed section accessors to `fl::Fled` plus the new `fl::FledScript` passive type. Only `screenMap()` has a real body in PR2; `video/channels/script` are stubs whose implementations land in later PRs once their supporting deserializers exist.

> **Stacked on #3323 (PR1).** Until that merges, this PR's diff will show the PR1 commits too. After #3323 lands, this auto-cleans up.

Per #3311's directive: each accessor touches **zero global state** (no controller registration, no `EngineEvents` broadcast, no scheduler).

### What this PR adds

**New type — `fl::FledScript`** (`src/fl/fled/fled_script.h`):
```cpp
enum class ScriptKind : fl::u8 { Wasm, MicroPy };
struct FledScript {
    ScriptKind                   kind;
    fl::shared_ptr<const fl::u8> bytes;
    fl::size                     length;
};
```

**New accessors on `fl::Fled`:**
| Accessor | PR2 status | Filled in by |
|---|---|---|
| `video()` | stub returning nullptr | PR4 (needs `Video::fromBytes` factory) |
| `screenMap()` | **implemented** via `ScreenMap::ParseJson` on envelope's `"map"` key | — |
| `channels()` | stub returning nullptr | PR5 (needs `MultiChannelConfig` JSON deserializer) |
| `script()` | stub returning nullptr | v2 bundle format (no script section in v1) |

`screenMap()` returns the **first segment** for multi-strip bundles; a dedicated multi-segment accessor is a later refactor. All non-object / absent `"map"` cases return nullptr.

### Tests (6 new cases)

- `screenMap()` returns null on default-constructed Fled
- `screenMap()` returns null when envelope has no `"map"` key
- `screenMap()` returns null when `"map"` is an empty object
- `screenMap()` parses a real strip1 ScreenMap to length=3 with correct coordinates
- `video()/channels()/script()` are stubs returning nullptr for a valid bundle
- `video()/channels()/script()` return null on null Fled

## Test plan

- [x] `bash test fled --debug` — green (1/1 DLL passed; 15 cases inside)
- [x] `bash lint --cpp` — green
- [ ] CI matrix on this PR (will rerun after PR1 merges and this rebases)

Refs #3311

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added bundle file parsing and loading from multiple sources (filesystem, byte spans, vectors).
  * Implemented JSON envelope and payload section access with validation for format integrity.
  * Introduced typed accessors for embedded resources including video, screen maps, channel configurations, and scripts.
  * Added version and section count queries for bundle inspection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->