### PR TITLE
feat(fl/system): FileSystem::sd factory + loadFled sugar (#3311 PR3)

### DIFF
--- a/src/fl/system/file_system.cpp.hpp
+++ b/src/fl/system/file_system.cpp.hpp
@@ -168,6 +168,12 @@ bool FileSystem::readScreenMap(const char *path, const char *name,
 }
 
 fl::ifstream FileSystem::openRead(const char *path) {
+    if (!mFs) {
+        // Defensive: default-constructed FileSystem or one whose begin*()
+        // call failed has a null backend. Returning a closed ifstream
+        // lets downstream code branch on is_open() rather than crash.
+        return fl::ifstream();
+    }
     return fl::ifstream(mFs->openRead(path));
 }
 Video FileSystem::openVideo(const char *path, fl::size pixelsPerFrame, float fps,

--- a/src/fl/system/file_system.cpp.hpp
+++ b/src/fl/system/file_system.cpp.hpp
@@ -102,7 +102,7 @@ bool FileSystem::begin(FsImplPtr platform_filesystem) {
     return true;
 }
 
-Fled FileSystem::loadFled(const char *path) {
+Fled FileSystem::loadFled(const char *path) FL_NO_EXCEPT {
     return Fled::load(*this, path);
 }
 

--- a/src/fl/system/file_system.cpp.hpp
+++ b/src/fl/system/file_system.cpp.hpp
@@ -1,4 +1,5 @@
 ﻿#include "fl/system/file_system.h"
+#include "fl/fled/fled.h"
 #include "fl/stl/has_include.h"
 #include "fl/log/log.h"
 #include "fl/stl/vector.h"
@@ -99,6 +100,10 @@ bool FileSystem::begin(FsImplPtr platform_filesystem) {
     }
     mFs->begin();
     return true;
+}
+
+Fled FileSystem::loadFled(const char *path) {
+    return Fled::load(*this, path);
 }
 
 FileSystem::FileSystem() : mFs() {}

--- a/src/fl/system/file_system.h
+++ b/src/fl/system/file_system.h
@@ -57,7 +57,7 @@ class FileSystem {
     // default-constructed FileSystem if the SD card could not be opened
     // (the typical begin() failure case). Sugar for code that wants to
     // chain straight into loadFled / openVideo / openRead.
-    static FileSystem sd(int cs_pin);
+    static FileSystem sd(int cs_pin) FL_NO_EXCEPT;
 
     bool beginSd(int cs_pin); // Signal to begin using the filesystem resource.
     bool begin(FsImplPtr platform_filesystem); // Signal to begin using the
@@ -89,7 +89,7 @@ class FileSystem {
     // One-line sugar for fl::Fled::load(*this, path). Returns a null
     // Fled if the file could not be opened or is malformed - the Fled
     // class itself owns all the failure-mode bookkeeping.
-    fl::Fled loadFled(const char *path);
+    fl::Fled loadFled(const char *path) FL_NO_EXCEPT;
 
   private:
     FsImplPtr mFs; // System dependent filesystem.

--- a/src/fl/system/file_system.h
+++ b/src/fl/system/file_system.h
@@ -40,6 +40,7 @@ const char* getTestFileSystemRoot();
 namespace fl {
 
 class ScreenMap;
+class Fled;
 FASTLED_SHARED_PTR(FileSystem);
 class Video;
 template <typename Key, typename Value, fl::size N> class unsorted_map_fixed;
@@ -51,6 +52,13 @@ class json;
 class FileSystem {
   public:
     FileSystem() FL_NO_EXCEPT;
+
+    // Convenience factory: construct + beginSd in one call. Returns a
+    // default-constructed FileSystem if the SD card could not be opened
+    // (the typical begin() failure case). Sugar for code that wants to
+    // chain straight into loadFled / openVideo / openRead.
+    static FileSystem sd(int cs_pin);
+
     bool beginSd(int cs_pin); // Signal to begin using the filesystem resource.
     bool begin(FsImplPtr platform_filesystem); // Signal to begin using the
                                                // filesystem resource.
@@ -77,6 +85,11 @@ class FileSystem {
     // Open MP3 audio file and return streaming decoder
     fl::Mp3DecoderPtr openMp3(const char *path,
                               fl::string *error_message = nullptr);
+
+    // One-line sugar for fl::Fled::load(*this, path). Returns a null
+    // Fled if the file could not be opened or is malformed - the Fled
+    // class itself owns all the failure-mode bookkeeping.
+    fl::Fled loadFled(const char *path);
 
   private:
     FsImplPtr mFs; // System dependent filesystem.

--- a/src/fl/system/sd/file_system_sd.cpp.hpp
+++ b/src/fl/system/sd/file_system_sd.cpp.hpp
@@ -74,4 +74,10 @@ bool FileSystem::beginSd(int cs_pin) {
     return true;
 }
 
+FileSystem FileSystem::sd(int cs_pin) {
+    FileSystem fs;
+    fs.beginSd(cs_pin);
+    return fs;
+}
+
 } // namespace fl

--- a/src/fl/system/sd/file_system_sd.cpp.hpp
+++ b/src/fl/system/sd/file_system_sd.cpp.hpp
@@ -74,7 +74,7 @@ bool FileSystem::beginSd(int cs_pin) {
     return true;
 }
 
-FileSystem FileSystem::sd(int cs_pin) {
+FileSystem FileSystem::sd(int cs_pin) FL_NO_EXCEPT {
     FileSystem fs;
     fs.beginSd(cs_pin);
     return fs;

--- a/tests/fl/fled/fled_filesystem.cpp
+++ b/tests/fl/fled/fled_filesystem.cpp
@@ -1,0 +1,32 @@
+// Tests for the FileSystem sugar added in PR3 of #3311:
+//   - FileSystem::sd(cs_pin)  -- static factory equivalent to
+//                                 fs; fs.beginSd(cs_pin)
+//   - FileSystem::loadFled(path) -- one-line forwarder to
+//                                    fl::Fled::load(*this, path)
+//
+// Both are exercised against the test stub filesystem.
+
+#include "fl/fled/fled.h"
+#include "fl/system/file_system.h"
+#include "test.h"
+
+FL_TEST_FILE(FL_FILEPATH) {
+
+using namespace fl;
+
+FL_TEST_CASE("FileSystem::sd factory returns a usable object") {
+    // The stub backend accepts any cs_pin and returns a non-null FsImpl,
+    // so this should round-trip without crash.
+    FileSystem fs = FileSystem::sd(5);
+    (void)fs;
+    FL_CHECK(true);
+}
+
+FL_TEST_CASE("FileSystem::loadFled on a missing path returns a null Fled") {
+    FileSystem fs;
+    Fled f = fs.loadFled("does/not/exist.fled");
+    FL_CHECK_FALSE(static_cast<bool>(f));
+    FL_CHECK_EQ(f.version(), fl::u8(0));
+}
+
+} // FL_TEST_FILE


### PR DESCRIPTION
## Summary

**PR3 of #3311.** Modest-scope additions to `fl::FileSystem`:

- **`static FileSystem FileSystem::sd(int cs_pin)`** — one-line factory equivalent to `fs; fs.beginSd(cs_pin)`. Definition lives in `file_system_sd.cpp.hpp` so the existing SD-library tree-shake property of `beginSd` is preserved.
- **`FileSystem::loadFled(const char* path)`** — one-line forwarder to `fl::Fled::load(*this, path)`. The Fled subsystem stays independently tree-shakeable.

Together these let bundle-load code read as:
```cpp
auto fs = fl::FileSystem::sd(CHIP_SELECT_PIN);
auto fled = fs.loadFled(\"sketch.fled\");
```

### Out of scope

The original #3311 plan called for additional `FileSystem::littleFs()` / `wasm()` / `host()` static factories. Each requires a working backend (LittleFS lib on ESP32/RP2040, the WASM VFS, desktop stdio FS) which is a much larger lift than this PR's \"sugar\" framing. Filed for follow-up; `sd(int)` + `loadFled` cover the immediate ergonomic need for the Fled subsystem.

## Test plan

- [x] `bash test fled --debug` — green (3/3 DLLs in fled subdir, including the new fled_filesystem)
- [x] `bash lint --cpp` — green
- [ ] CI matrix

Refs #3311

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a convenience factory to initialize and start the SD card filesystem in one call.
  * Added a helper to load Fled content from a file path, returning a null result on open/malformed failures.
* **Bug Fixes**
  * Improved resilience when the filesystem backend is unavailable by safely handling null backend access during read operations.
* **Tests**
  * Added coverage for the SD initialization and Fled-loading helpers, including behavior when the file is missing (including version checks).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->