### PR TITLE
feat(fl): bidirectional fromFled factories on Video / ScreenMap / MultiChannelConfig (#3311 PR4)

### DIFF
--- a/src/fl/channels/config.h
+++ b/src/fl/channels/config.h
@@ -363,7 +363,16 @@ struct ChannelConfigOf {
 /// config.add(channel1);
 /// config.add(channel2);
 /// ```
+class Fled;  // fwd - fl/fled/fled.h, for fromFled factory
+
 struct MultiChannelConfig {
+    // Bidirectional factory for the .fled bundle subsystem (#3311 PR4).
+    // One-line forwarder to fl::Fled::channels(); kept here so call sites
+    // can spell either fled.channels() or
+    // fl::MultiChannelConfig::fromFled(fled) interchangeably. Returns
+    // nullptr until fl::Fled::channels() body lands (currently a stub).
+    static fl::shared_ptr<MultiChannelConfig> fromFled(const Fled& fled) FL_NO_EXCEPT;
+
     MultiChannelConfig() FL_NO_EXCEPT = default;
     MultiChannelConfig(const MultiChannelConfig&) FL_NO_EXCEPT = default;
     MultiChannelConfig(MultiChannelConfig&&) FL_NO_EXCEPT = default;

--- a/src/fl/fled/fled.cpp.hpp
+++ b/src/fl/fled/fled.cpp.hpp
@@ -1,7 +1,9 @@
 #include "fl/fled/fled.h"
 
+#include "fl/channels/config.h"
 #include "fl/fled/fled_impl.hpp"
 #include "fl/fled/fled_script.h"
+#include "fl/fx/video.h"
 #include "fl/math/screenmap.h"
 #include "fl/stl/bit_cast.h"
 #include "fl/stl/cstring.h"
@@ -219,6 +221,25 @@ fl::u8 Fled::version() const FL_NO_EXCEPT {
 fl::size Fled::sectionCount() const FL_NO_EXCEPT {
     if (!mImpl) return 0;
     return static_cast<fl::size>(mImpl->envelope().keys().size());
+}
+
+// ---- bidirectional fromFled factories (PR4) ----
+// Each is a one-line forwarder to the corresponding Fled accessor; the
+// only purpose is to let call sites spell the call site-first
+// (Type::fromFled(fled)) as well as fled-first (fled.video()) - same
+// data, same return type, same null/empty contract.
+
+fl::shared_ptr<Video> Video::fromFled(const Fled &fled) FL_NO_EXCEPT {
+    return fled.video();
+}
+
+fl::shared_ptr<ScreenMap> ScreenMap::fromFled(const Fled &fled) FL_NO_EXCEPT {
+    return fled.screenMap();
+}
+
+fl::shared_ptr<MultiChannelConfig>
+MultiChannelConfig::fromFled(const Fled &fled) FL_NO_EXCEPT {
+    return fled.channels();
 }
 
 } // namespace fl

--- a/src/fl/fx/video.h
+++ b/src/fl/fx/video.h
@@ -30,8 +30,16 @@ using VideoImplPtr = fl::shared_ptr<VideoImpl>;
 // Video represents a video file that can be played back on a LED strip.
 // The video file is expected to be a sequence of frames. Pass any filebuf
 // to begin() — streaming vs seekable is auto-detected.
+class Fled;  // fwd - fl/fled/fled.h
+
 class Video : public Fx1d { // Fx1d because video can be irregular.
   public:
+    // Bidirectional factory for the .fled bundle subsystem (#3311 PR4).
+    // One-line forwarder to fl::Fled::video(); kept here so call sites can
+    // spell either fled.video() or fl::Video::fromFled(fled) interchangeably.
+    // Returns nullptr until fl::Fled::video() body lands (currently a stub).
+    static fl::shared_ptr<Video> fromFled(const Fled& fled) FL_NO_EXCEPT;
+
     static size_t DefaultFrameHistoryCount() {
 #ifdef FL_IS_AVR
         return 1;

--- a/src/fl/math/screenmap.h
+++ b/src/fl/math/screenmap.h
@@ -25,6 +25,9 @@ using vec2f = vec2<float>;
 // Forward declare XYMap for optional source storage
 class XYMap;
 
+// Forward declare Fled (fl/fled/fled.h) for the bidirectional fromFled factory.
+class Fled;
+
 // Forward declare LUT types and smart pointers
 template<typename T> class LUT;
 using LUTXYFLOAT = LUT<vec2f>;
@@ -44,6 +47,12 @@ class ScreenMap {
     static ScreenMap DefaultStrip(int numLeds, float cm_between_leds = 1.5f,
                                   float cm_led_diameter = 0.2f,
                                   float completion = .9f) FL_NO_EXCEPT;
+
+    // Bidirectional factory for the .fled bundle subsystem (#3311 PR4).
+    // One-line forwarder to fl::Fled::screenMap(); kept here so call sites
+    // can spell either fled.screenMap() or fl::ScreenMap::fromFled(fled)
+    // interchangeably.
+    static fl::shared_ptr<ScreenMap> fromFled(const Fled& fled) FL_NO_EXCEPT;
 
     // Constructors and destructor - implemented in .cpp for proper smart_ptr handling
     ScreenMap() FL_NO_EXCEPT;

--- a/tests/fl/fled/fled_from_fled.cpp
+++ b/tests/fl/fled/fled_from_fled.cpp
@@ -1,0 +1,69 @@
+// Tests for the bidirectional `fromFled` factories added in PR4 of #3311.
+// Each factory is a one-line forwarder to the matching Fled accessor; the
+// test surface here is "the spelling works and returns the same shape".
+
+#include "fl/channels/config.h"
+#include "fl/fled/fled.h"
+#include "fl/fx/video.h"
+#include "fl/math/screenmap.h"
+#include "fl/stl/int.h"
+#include "fl/stl/move.h"
+#include "fl/stl/shared_ptr.h"
+#include "fl/stl/vector.h"
+#include "test.h"
+
+FL_TEST_FILE(FL_FILEPATH) {
+
+using namespace fl;
+
+namespace {
+
+// Minimal valid v1 .fled (no map / video sections); used to exercise
+// "factory returns the same thing as the accessor for the stub paths".
+fl::vector<fl::u8> buildEmptyBundle() {
+    const char env[] = "{}";
+    const fl::u32 jsonLen = static_cast<fl::u32>(sizeof(env) - 1);
+    fl::vector<fl::u8> out;
+    out.resize(12 + jsonLen);
+    out[0] = 'F'; out[1] = 'L'; out[2] = 'E'; out[3] = 'D';
+    out[4] = 1;
+    out[5] = 0;
+    out[6] = 0; out[7] = 0;
+    out[8]  = static_cast<fl::u8>(jsonLen & 0xff);
+    out[9]  = static_cast<fl::u8>((jsonLen >> 8) & 0xff);
+    out[10] = static_cast<fl::u8>((jsonLen >> 16) & 0xff);
+    out[11] = static_cast<fl::u8>((jsonLen >> 24) & 0xff);
+    for (fl::size i = 0; i < jsonLen; ++i) {
+        out[12 + i] = static_cast<fl::u8>(env[i]);
+    }
+    return out;
+}
+
+}  // namespace
+
+FL_TEST_CASE("fromFled - null Fled returns nullptr for all three") {
+    Fled f;
+    FL_CHECK(Video::fromFled(f) == nullptr);
+    FL_CHECK(ScreenMap::fromFled(f) == nullptr);
+    FL_CHECK(MultiChannelConfig::fromFled(f) == nullptr);
+}
+
+FL_TEST_CASE("fromFled - empty bundle returns nullptr for all three") {
+    fl::vector<fl::u8> buf = buildEmptyBundle();
+    Fled f = Fled::loadFromVector(fl::move(buf));
+    FL_CHECK(static_cast<bool>(f));
+    // None of the three sections exist in an empty {} envelope.
+    FL_CHECK(Video::fromFled(f) == nullptr);
+    FL_CHECK(ScreenMap::fromFled(f) == nullptr);
+    FL_CHECK(MultiChannelConfig::fromFled(f) == nullptr);
+}
+
+FL_TEST_CASE("fromFled - returns same shape as fled.accessor() for stub paths") {
+    fl::vector<fl::u8> buf = buildEmptyBundle();
+    Fled f = Fled::loadFromVector(fl::move(buf));
+    FL_CHECK(Video::fromFled(f).get() == f.video().get());
+    FL_CHECK(ScreenMap::fromFled(f).get() == f.screenMap().get());
+    FL_CHECK(MultiChannelConfig::fromFled(f).get() == f.channels().get());
+}
+
+}  // FL_TEST_FILE


### PR DESCRIPTION
## Summary

**PR4 of #3311.** Adds the per-type `fromFled` static factories on the three section types that `fl::Fled` produces, so call sites can spell either:

```cpp
auto v = fled.video();                  // fled-side
auto v = fl::Video::fromFled(fled);     // type-side
```

interchangeably — same data, same return type, same null/empty contract.

### Tree-shake

Each factory is a one-line forwarder defined in `src/fl/fled/fled.cpp.hpp` (the canonical fled TU). The declarations live in the host headers with only a forward decl of `fl::Fled`, so callers don't pay an extra include cost. The linker resolves the static methods to `fled.cpp.hpp`'s TU, which is only pulled in when something already references the Fled subsystem — sketches that don't use fled see zero size cost.

### Stub state today

- `ScreenMap::fromFled` returns a real `ScreenMap` (because PR2's `Fled::screenMap()` is implemented).
- `Video::fromFled` and `MultiChannelConfig::fromFled` return nullptr (because the matching `Fled::video()` and `Fled::channels()` are themselves stubs in PR2; they'll start returning real objects when those accessors are filled in).

### Files changed

- `src/fl/fx/video.h` — fwd decl + `static fromFled` declaration
- `src/fl/math/screenmap.h` — fwd decl + `static fromFled` declaration
- `src/fl/channels/config.h` — fwd decl + `static fromFled` declaration on `MultiChannelConfig`
- `src/fl/fled/fled.cpp.hpp` — three one-line bodies
- `tests/fl/fled/fled_from_fled.cpp` — new, 3 cases

## Test plan

- [x] `bash test fled --debug` — green
- [x] `bash lint --cpp` — green
- [ ] CI matrix

Refs #3311

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Added alternative factory methods for Video, ScreenMap, and MultiChannelConfig that allow creating instances directly from Fled bundles.

## Tests
- Added test suite validating the new factory methods handle default, empty, and populated Fled bundle scenarios correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->