### PR TITLE
revert(lpc): drop -std=gnu++17 overrides; PIO defaults now compile

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -190,15 +190,7 @@ extra_scripts = pre:ci/ci-flags.py
 platform = https://github.com/zackees/platform-nxplpc-arduino.git#2ee527ae80de98e9105329a7260edb003289dfda
 board = lpc845brk
 framework = arduino
-; justification: drop default gnu++11/c++11 (fatal on m0clockless_c.h digit separators).
-; added-in: PR-3332 (#3329)
-build_unflags =
-    -std=gnu++11
-    -std=c++11
-; justification: force gnu++17 to match fbuild backend; required for m0clockless_c.h.
-; added-in: PR-3332 (#3329)
 build_flags =
-    -std=gnu++17
     -DRELEASE
     -DFASTLED_LPC_PWM_DMA=1
     -DFASTLED_AUTORESEARCH_LOW_MEMORY=1
@@ -228,64 +220,25 @@ build_flags =
 ; that repo (see #2990 body).
 ; --------------------------------------------------------------------------
 
-; justification: LPC canary envs share the same gnu++17 default as lpc845brk
-;   (same C++14 digit-separator blocker on the bisection path — see #3329).
-; added-in: PR-3332 (#3329)
 [env:lpc845]
 platform = https://github.com/zackees/platform-nxplpc-arduino.git#2ee527ae80de98e9105329a7260edb003289dfda
 board = lpc845
 framework = arduino
-; justification: drop default gnu++11/c++11 (fatal on C++14 digit separators).
-; added-in: PR-3332 (#3329)
-build_unflags =
-    -std=gnu++11
-    -std=c++11
-; justification: match fbuild backend default; needed for m0clockless_c.h.
-; added-in: PR-3332 (#3329)
-build_flags =
-    -std=gnu++17
 
 [env:lpc804]
 platform = https://github.com/zackees/platform-nxplpc-arduino.git#2ee527ae80de98e9105329a7260edb003289dfda
 board = lpc804
 framework = arduino
-; justification: drop default gnu++11/c++11 (fatal on C++14 digit separators).
-; added-in: PR-3332 (#3329)
-build_unflags =
-    -std=gnu++11
-    -std=c++11
-; justification: match fbuild backend default; needed for m0clockless_c.h.
-; added-in: PR-3332 (#3329)
-build_flags =
-    -std=gnu++17
 
 [env:lpcxpresso845max]
 platform = https://github.com/zackees/platform-nxplpc-arduino.git#2ee527ae80de98e9105329a7260edb003289dfda
 board = lpcxpresso845max
 framework = arduino
-; justification: drop default gnu++11/c++11 (fatal on C++14 digit separators).
-; added-in: PR-3332 (#3329)
-build_unflags =
-    -std=gnu++11
-    -std=c++11
-; justification: match fbuild backend default; needed for m0clockless_c.h.
-; added-in: PR-3332 (#3329)
-build_flags =
-    -std=gnu++17
 
 [env:lpcxpresso804]
 platform = https://github.com/zackees/platform-nxplpc-arduino.git#2ee527ae80de98e9105329a7260edb003289dfda
 board = lpcxpresso804
 framework = arduino
-; justification: drop default gnu++11/c++11 (fatal on C++14 digit separators).
-; added-in: PR-3332 (#3329)
-build_unflags =
-    -std=gnu++11
-    -std=c++11
-; justification: match fbuild backend default; needed for m0clockless_c.h.
-; added-in: PR-3332 (#3329)
-build_flags =
-    -std=gnu++17
 
 
 [platformio]


### PR DESCRIPTION
## Summary

PR #3332 added `build_unflags = -std=gnu++11 -std=c++11` + `build_flags = -std=gnu++17` to 5 LPC PIO envs as a workaround for the C++14 digit separators in `m0clockless_c.h`. **That same PR also dropped those digit separators** and added `BareDigitSeparatorChecker` to prevent regression, which means PIO's default `-std=gnu++11` now compiles the LPC framework cleanly.

This PR removes the now-redundant `gnu++17` overrides from:

- `env:lpc845brk` (functional `-DRELEASE` / `-DFASTLED_LPC_PWM_DMA=1` / `-DFASTLED_AUTORESEARCH_LOW_MEMORY=1` flags preserved)
- `env:lpc845`
- `env:lpc804`
- `env:lpcxpresso845max`
- `env:lpcxpresso804`

`env:lpc845brk_ieee754` extends `env:lpc845brk` and tracks automatically.

Per maintainer:
> we should be able to keep the defaults again now that the fastled c++17 / 14 fix landed, it should compile with C++11

This also moots the "Part B" open question on #3329 about whether the gnu++17 default should live in `zackees/platform-nxplpc-arduino`'s `platform.json` — the FastLED-side fix means neither side needs the override for our builds, leaving the platform-side decision purely to that maintainer's preference.

## Verification

| Backend | Default `-std=` | Result | Flash | RAM |
|---|---|---|---|---|
| **PIO** | `gnu++11` (default) | ✅ SUCCESS in 49s | 59996 / 65536 (91.5%) | 5924 / 16384 (36.2%) |
| **fbuild** | `gnu++17` (config) | ✅ SUCCESS in 41s | 55140 / 65536 (84.1%) | 9248 / 16384 (56.4%) |

Commands run:

```bash
bash compile lpc845brk --examples AutoResearch --platformio    # PIO @ gnu++11
bash compile lpc845brk --examples AutoResearch                 # fbuild @ gnu++17
```

## Test plan

- [x] PIO LPC compile under default C++11
- [x] fbuild LPC compile (no regression)
- [ ] CI: cross-platform compile matrix
- [ ] CI: `bash test --cpp`

Refs #3329, #3332.

🤖 Generated with [Claude Code](https://claude.com/claude-code)