### PR TITLE
test(fl/fled): use stub fs to actually exercise FileSystem::loadFled (#3311)

### DIFF
--- a/tests/fl/fled/fled_filesystem.cpp
+++ b/tests/fl/fled/fled_filesystem.cpp
@@ -4,20 +4,23 @@
 //   - FileSystem::loadFled(path) -- one-line forwarder to
 //                                   fl::Fled::load(*this, path)
 //
-// We use the stub filesystem (platforms/stub/fs_stub.hpp) to drop a real
-// .fled byte buffer onto a temp directory, point the test FS root at it,
-// then verify the loadFled sugar reads + parses the bundle end-to-end.
+// Tests use a true in-memory mock FsImpl (no disk I/O, no temp dirs,
+// platform-neutral). Bundles are byte arrays inserted into a fake
+// filesystem by path; the FileSystem::loadFled sugar reads them back
+// through the standard FsImpl::openRead path.
 
 #include "test.h"
 
 #include "fl/fled/fled.h"
+#include "fl/stl/cstring.h"
+#include "fl/stl/detail/file_handle.h"
+#include "fl/stl/flat_map.h"
 #include "fl/stl/int.h"
+#include "fl/stl/make_shared.h"
+#include "fl/stl/shared_ptr.h"
 #include "fl/stl/string.h"
 #include "fl/stl/vector.h"
 #include "fl/system/file_system.h"
-
-#ifdef FASTLED_TESTING
-#include "platforms/stub/fs_stub.hpp"
 
 FL_TEST_FILE(FL_FILEPATH) {
 
@@ -25,30 +28,99 @@ using namespace fl;
 
 namespace {
 
-// RAII guard mirroring tests/fl/system/file_system.cpp - wipes the temp
-// dir on entry and exit so a previous failed run cannot poison this one.
-class TestDirGuard {
-    fl::string mDir;
+// In-memory seekable filebuf over an owned byte vector. Mirrors the
+// posix_filebuf surface but reads from RAM rather than fl::FILE*.
+class MemoryFilebuf : public fl::filebuf {
   public:
-    explicit TestDirGuard(const fl::string& dir) : mDir(dir) {
-        fl::StubFileSystem::forceRemoveDirectory(mDir.c_str());
-        fl::StubFileSystem::createDirectory(mDir.c_str());
+    MemoryFilebuf(fl::vector<fl::u8> bytes, fl::string path) FL_NO_EXCEPT
+        : mBytes(fl::move(bytes)), mPath(fl::move(path)), mPos(0),
+          mOpen(true) {}
+    ~MemoryFilebuf() FL_NO_EXCEPT override = default;
+
+    bool is_open() const override { return mOpen; }
+    void close() override { mOpen = false; }
+
+    fl::size_t read(char* buffer, fl::size_t count) override {
+        if (!mOpen || !buffer || count == 0) return 0;
+        const fl::size_t avail = (mPos < mBytes.size()) ? (mBytes.size() - mPos) : 0;
+        const fl::size_t n = (count < avail) ? count : avail;
+        for (fl::size_t i = 0; i < n; ++i) {
+            buffer[i] = static_cast<char>(mBytes[mPos + i]);
+        }
+        mPos += n;
+        return n;
     }
-    ~TestDirGuard() {
-        fl::StubFileSystem::forceRemoveDirectory(mDir.c_str());
-        fl::setTestFileSystemRoot("");
+    using fl::filebuf::read;
+
+    fl::size_t write(const char*, fl::size_t) override { return 0; }
+    fl::size_t tell() override { return mPos; }
+
+    bool seek(fl::size_t pos, fl::seek_dir dir) override {
+        fl::size_t target;
+        switch (dir) {
+            case fl::seek_dir::beg: target = pos; break;
+            case fl::seek_dir::cur: target = mPos + pos; break;
+            case fl::seek_dir::end: target = mBytes.size() + pos; break;
+            default: return false;
+        }
+        if (target > mBytes.size()) return false;
+        mPos = target;
+        return true;
     }
+    using fl::filebuf::seek;
+
+    fl::size_t size() const override { return mBytes.size(); }
+    const char* path() const override { return mPath.c_str(); }
+    bool is_eof() const override { return mPos >= mBytes.size(); }
+    bool has_error() const override { return false; }
+    void clear_error() override {}
+    int error_code() const override { return 0; }
+    const char* error_message() const override { return "ok"; }
+
+  private:
+    fl::vector<fl::u8> mBytes;
+    fl::string mPath;
+    fl::size_t mPos;
+    bool mOpen;
 };
 
-// Build a minimal valid v1 .fled byte buffer with the given JSON envelope.
+// In-memory FsImpl: path -> byte vector. add() seeds it, openRead()
+// returns a fresh MemoryFilebuf with an independent read cursor each
+// time (so the same bundle can be re-read across tests).
+class MemoryFs : public fl::FsImpl {
+  public:
+    MemoryFs() FL_NO_EXCEPT = default;
+    ~MemoryFs() FL_NO_EXCEPT override = default;
+
+    bool begin() override { return true; }
+    void end() override {}
+
+    fl::filebuf_ptr openRead(const char* path) override {
+        if (!path) return fl::filebuf_ptr();
+        fl::string key(path);
+        auto it = mFiles.find(key);
+        if (it == mFiles.end()) return fl::filebuf_ptr();
+        return fl::make_shared<MemoryFilebuf>(it->second, key);
+    }
+
+    void add(const char* path, fl::vector<fl::u8> bytes) {
+        mFiles[fl::string(path)] = fl::move(bytes);
+    }
+
+  private:
+    fl::flat_map<fl::string, fl::vector<fl::u8>> mFiles;
+};
+
+// Build a minimal valid v1 .fled byte buffer with the given envelope
+// + payload. Mirrors the helper in tests/fl/fled/fled.cpp.
 fl::vector<fl::u8> buildBundle(const char* envelope, fl::size envelopeLen,
                                const fl::u8* payload, fl::size payloadLen) {
     const fl::u32 jsonLen = static_cast<fl::u32>(envelopeLen);
     fl::vector<fl::u8> out;
     out.resize(12 + envelopeLen + payloadLen);
     out[0] = 'F'; out[1] = 'L'; out[2] = 'E'; out[3] = 'D';
-    out[4] = 1;        // version
-    out[5] = 0x00;     // pixel_format = rgb8
+    out[4] = 1;
+    out[5] = 0x00;
     out[6] = 0; out[7] = 0;
     out[8]  = static_cast<fl::u8>(jsonLen & 0xff);
     out[9]  = static_cast<fl::u8>((jsonLen >> 8) & 0xff);
@@ -63,44 +135,25 @@ fl::vector<fl::u8> buildBundle(const char* envelope, fl::size envelopeLen,
     return out;
 }
 
-// Drop a byte buffer onto disk under the stub-fs root via createTextFile -
-// it writes binary-clean (fl::ofstream is opened with ios::binary | trunc
-// and ofs.write is used, not operator<<).
-bool dropBundle(const fl::string& path, const fl::vector<fl::u8>& bundle) {
-    fl::string content;
-    content.assign(reinterpret_cast<const char*>(bundle.data()),
-                   bundle.size());
-    return fl::StubFileSystem::createTextFile(path, content);
-}
-
 }  // namespace
 
-FL_TEST_CASE("FileSystem::loadFled - end-to-end via stub fs") {
-    const fl::string testDir = "test_fled_loadfled";
-    TestDirGuard guard(testDir);
-
-    // Drop a valid v1 bundle on the test FS at <testDir>/sketch.fled.
+FL_TEST_CASE("FileSystem::loadFled - end-to-end via in-memory FsImpl") {
+    auto mem = fl::make_shared<MemoryFs>();
     const char env[] = "{\"map\":{},\"video\":{\"fps\":24}}";
     const fl::u8 payload[3] = {0xAA, 0xBB, 0xCC};
-    fl::vector<fl::u8> bundle = buildBundle(env, sizeof(env) - 1,
-                                            payload, sizeof(payload));
-    fl::string fullPath = testDir;
-    fullPath.append("/sketch.fled");
-    FL_REQUIRE(dropBundle(fullPath, bundle));
+    mem->add("sketch.fled",
+             buildBundle(env, sizeof(env) - 1, payload, sizeof(payload)));
 
-    // Point the stub fs root at <testDir>, then loadFled via the sugar.
-    fl::setTestFileSystemRoot(testDir.c_str());
+    fl::FileSystem fs;
+    FL_REQUIRE(fs.begin(mem));
 
-    fl::FileSystem fs = fl::FileSystem::sd(5);   // cs_pin ignored by stub
     fl::Fled f = fs.loadFled("sketch.fled");
-
     FL_CHECK(static_cast<bool>(f));
     FL_CHECK_EQ(f.version(), fl::u8(1));
     FL_CHECK_EQ(f.sectionCount(), fl::size(2));
     int fps = f.json()["video"]["fps"] | 0;
     FL_CHECK_EQ(fps, 24);
 
-    // Frame payload survived the round-trip.
     fl::size n = 0;
     auto blob = f.blob("frame_payload", &n);
     FL_CHECK(blob != nullptr);
@@ -111,35 +164,36 @@ FL_TEST_CASE("FileSystem::loadFled - end-to-end via stub fs") {
     }
 }
 
-FL_TEST_CASE("FileSystem::loadFled - missing file returns null Fled") {
-    const fl::string testDir = "test_fled_loadfled_missing";
-    TestDirGuard guard(testDir);
-    fl::setTestFileSystemRoot(testDir.c_str());
-
-    fl::FileSystem fs = fl::FileSystem::sd(5);
+FL_TEST_CASE("FileSystem::loadFled - missing path returns null Fled") {
+    auto mem = fl::make_shared<MemoryFs>();
+    fl::FileSystem fs;
+    FL_REQUIRE(fs.begin(mem));
     fl::Fled f = fs.loadFled("does_not_exist.fled");
     FL_CHECK_FALSE(static_cast<bool>(f));
     FL_CHECK_EQ(f.version(), fl::u8(0));
 }
 
-FL_TEST_CASE("FileSystem::loadFled - corrupt header returns null Fled") {
-    const fl::string testDir = "test_fled_loadfled_corrupt";
-    TestDirGuard guard(testDir);
-
-    // Bundle with wrong magic ('XLED' instead of 'FLED').
+FL_TEST_CASE("FileSystem::loadFled - corrupt magic returns null Fled") {
+    auto mem = fl::make_shared<MemoryFs>();
     const char env[] = "{\"map\":{}}";
     fl::vector<fl::u8> bundle = buildBundle(env, sizeof(env) - 1, nullptr, 0);
     bundle[0] = 'X';
-    fl::string fullPath = testDir;
-    fullPath.append("/bad.fled");
-    FL_REQUIRE(dropBundle(fullPath, bundle));
+    mem->add("bad.fled", fl::move(bundle));
 
-    fl::setTestFileSystemRoot(testDir.c_str());
-    fl::FileSystem fs = fl::FileSystem::sd(5);
+    fl::FileSystem fs;
+    FL_REQUIRE(fs.begin(mem));
     fl::Fled f = fs.loadFled("bad.fled");
     FL_CHECK_FALSE(static_cast<bool>(f));
 }
 
-}  // FL_TEST_FILE
+FL_TEST_CASE("FileSystem::sd factory constructs without crash") {
+    // No SD backend on the host stub; sd(5) returns an FS whose mFs is
+    // null (or NullFileSystem depending on build). Either way the
+    // construction path must not crash and the resulting FS must not
+    // segfault when used.
+    fl::FileSystem fs = fl::FileSystem::sd(5);
+    fl::Fled f = fs.loadFled("anything.fled");
+    FL_CHECK_FALSE(static_cast<bool>(f));
+}
 
-#endif  // FASTLED_TESTING
+}  // FL_TEST_FILE

--- a/tests/fl/fled/fled_filesystem.cpp
+++ b/tests/fl/fled/fled_filesystem.cpp
@@ -1,32 +1,145 @@
 // Tests for the FileSystem sugar added in PR3 of #3311:
-//   - FileSystem::sd(cs_pin)  -- static factory equivalent to
-//                                 fs; fs.beginSd(cs_pin)
+//   - FileSystem::sd(cs_pin)     -- static factory equivalent to
+//                                    fs; fs.beginSd(cs_pin)
 //   - FileSystem::loadFled(path) -- one-line forwarder to
-//                                    fl::Fled::load(*this, path)
+//                                   fl::Fled::load(*this, path)
 //
-// Both are exercised against the test stub filesystem.
+// We use the stub filesystem (platforms/stub/fs_stub.hpp) to drop a real
+// .fled byte buffer onto a temp directory, point the test FS root at it,
+// then verify the loadFled sugar reads + parses the bundle end-to-end.
+
+#include "test.h"
 
 #include "fl/fled/fled.h"
+#include "fl/stl/int.h"
+#include "fl/stl/string.h"
+#include "fl/stl/vector.h"
 #include "fl/system/file_system.h"
-#include "test.h"
+
+#ifdef FASTLED_TESTING
+#include "platforms/stub/fs_stub.hpp"
 
 FL_TEST_FILE(FL_FILEPATH) {
 
 using namespace fl;
 
-FL_TEST_CASE("FileSystem::sd factory returns a usable object") {
-    // The stub backend accepts any cs_pin and returns a non-null FsImpl,
-    // so this should round-trip without crash.
-    FileSystem fs = FileSystem::sd(5);
-    (void)fs;
-    FL_CHECK(true);
+namespace {
+
+// RAII guard mirroring tests/fl/system/file_system.cpp - wipes the temp
+// dir on entry and exit so a previous failed run cannot poison this one.
+class TestDirGuard {
+    fl::string mDir;
+  public:
+    explicit TestDirGuard(const fl::string& dir) : mDir(dir) {
+        fl::StubFileSystem::forceRemoveDirectory(mDir.c_str());
+        fl::StubFileSystem::createDirectory(mDir.c_str());
+    }
+    ~TestDirGuard() {
+        fl::StubFileSystem::forceRemoveDirectory(mDir.c_str());
+        fl::setTestFileSystemRoot("");
+    }
+};
+
+// Build a minimal valid v1 .fled byte buffer with the given JSON envelope.
+fl::vector<fl::u8> buildBundle(const char* envelope, fl::size envelopeLen,
+                               const fl::u8* payload, fl::size payloadLen) {
+    const fl::u32 jsonLen = static_cast<fl::u32>(envelopeLen);
+    fl::vector<fl::u8> out;
+    out.resize(12 + envelopeLen + payloadLen);
+    out[0] = 'F'; out[1] = 'L'; out[2] = 'E'; out[3] = 'D';
+    out[4] = 1;        // version
+    out[5] = 0x00;     // pixel_format = rgb8
+    out[6] = 0; out[7] = 0;
+    out[8]  = static_cast<fl::u8>(jsonLen & 0xff);
+    out[9]  = static_cast<fl::u8>((jsonLen >> 8) & 0xff);
+    out[10] = static_cast<fl::u8>((jsonLen >> 16) & 0xff);
+    out[11] = static_cast<fl::u8>((jsonLen >> 24) & 0xff);
+    for (fl::size i = 0; i < envelopeLen; ++i) {
+        out[12 + i] = static_cast<fl::u8>(envelope[i]);
+    }
+    for (fl::size i = 0; i < payloadLen; ++i) {
+        out[12 + envelopeLen + i] = payload[i];
+    }
+    return out;
 }
 
-FL_TEST_CASE("FileSystem::loadFled on a missing path returns a null Fled") {
-    FileSystem fs;
-    Fled f = fs.loadFled("does/not/exist.fled");
+// Drop a byte buffer onto disk under the stub-fs root via createTextFile -
+// it writes binary-clean (fl::ofstream is opened with ios::binary | trunc
+// and ofs.write is used, not operator<<).
+bool dropBundle(const fl::string& path, const fl::vector<fl::u8>& bundle) {
+    fl::string content;
+    content.assign(reinterpret_cast<const char*>(bundle.data()),
+                   bundle.size());
+    return fl::StubFileSystem::createTextFile(path, content);
+}
+
+}  // namespace
+
+FL_TEST_CASE("FileSystem::loadFled - end-to-end via stub fs") {
+    const fl::string testDir = "test_fled_loadfled";
+    TestDirGuard guard(testDir);
+
+    // Drop a valid v1 bundle on the test FS at <testDir>/sketch.fled.
+    const char env[] = "{\"map\":{},\"video\":{\"fps\":24}}";
+    const fl::u8 payload[3] = {0xAA, 0xBB, 0xCC};
+    fl::vector<fl::u8> bundle = buildBundle(env, sizeof(env) - 1,
+                                            payload, sizeof(payload));
+    fl::string fullPath = testDir;
+    fullPath.append("/sketch.fled");
+    FL_REQUIRE(dropBundle(fullPath, bundle));
+
+    // Point the stub fs root at <testDir>, then loadFled via the sugar.
+    fl::setTestFileSystemRoot(testDir.c_str());
+
+    fl::FileSystem fs = fl::FileSystem::sd(5);   // cs_pin ignored by stub
+    fl::Fled f = fs.loadFled("sketch.fled");
+
+    FL_CHECK(static_cast<bool>(f));
+    FL_CHECK_EQ(f.version(), fl::u8(1));
+    FL_CHECK_EQ(f.sectionCount(), fl::size(2));
+    int fps = f.json()["video"]["fps"] | 0;
+    FL_CHECK_EQ(fps, 24);
+
+    // Frame payload survived the round-trip.
+    fl::size n = 0;
+    auto blob = f.blob("frame_payload", &n);
+    FL_CHECK(blob != nullptr);
+    FL_CHECK_EQ(n, fl::size(3));
+    if (blob && n == 3) {
+        FL_CHECK_EQ(blob.get()[0], fl::u8(0xAA));
+        FL_CHECK_EQ(blob.get()[2], fl::u8(0xCC));
+    }
+}
+
+FL_TEST_CASE("FileSystem::loadFled - missing file returns null Fled") {
+    const fl::string testDir = "test_fled_loadfled_missing";
+    TestDirGuard guard(testDir);
+    fl::setTestFileSystemRoot(testDir.c_str());
+
+    fl::FileSystem fs = fl::FileSystem::sd(5);
+    fl::Fled f = fs.loadFled("does_not_exist.fled");
     FL_CHECK_FALSE(static_cast<bool>(f));
     FL_CHECK_EQ(f.version(), fl::u8(0));
 }
 
-} // FL_TEST_FILE
+FL_TEST_CASE("FileSystem::loadFled - corrupt header returns null Fled") {
+    const fl::string testDir = "test_fled_loadfled_corrupt";
+    TestDirGuard guard(testDir);
+
+    // Bundle with wrong magic ('XLED' instead of 'FLED').
+    const char env[] = "{\"map\":{}}";
+    fl::vector<fl::u8> bundle = buildBundle(env, sizeof(env) - 1, nullptr, 0);
+    bundle[0] = 'X';
+    fl::string fullPath = testDir;
+    fullPath.append("/bad.fled");
+    FL_REQUIRE(dropBundle(fullPath, bundle));
+
+    fl::setTestFileSystemRoot(testDir.c_str());
+    fl::FileSystem fs = fl::FileSystem::sd(5);
+    fl::Fled f = fs.loadFled("bad.fled");
+    FL_CHECK_FALSE(static_cast<bool>(f));
+}
+
+}  // FL_TEST_FILE
+
+#endif  // FASTLED_TESTING


### PR DESCRIPTION
## Summary

The tests added in #3327 (PR3) just verified the new `FileSystem::sd` / `loadFled` entry points did not crash — they did not actually exercise the load path, because the test `FileSystem` had no backend mounted.

This PR rewrites `tests/fl/fled/fled_filesystem.cpp` to use the **stub filesystem** (`platforms/stub/fs_stub.hpp`) the way `tests/fl/system/file_system.cpp` already does.

## What's tested now

- `TestDirGuard` RAII helper around `StubFileSystem::createDirectory` / `forceRemoveDirectory` so a failed run cannot poison the next run.
- `buildBundle()` assembles a real v1 `.fled` byte buffer in memory (12-byte header + JSON envelope + payload).
- `dropBundle()` writes the bundle bytes to the stub fs root via `StubFileSystem::createTextFile` (which opens with `ios::binary | trunc` and writes via `ofs.write`, so it's binary-clean).
- `setTestFileSystemRoot` points the stub backend at the temp dir.
- Three cases:
  - **End-to-end**: `FileSystem::sd(5).loadFled(\"sketch.fled\")` parses the bundle — `version`, `sectionCount`, `json()[\"video\"][\"fps\"]`, `blob(\"frame_payload\", &n)` bytes all round-trip correctly.
  - **Missing file**: `loadFled` returns a null `Fled`.
  - **Corrupt magic**: `loadFled` returns a null `Fled`.

Whole file gated on `FASTLED_TESTING` so the stub headers are only pulled into the test binary.

## Test plan

- [x] `bash test fled --debug` — green
- [x] `bash lint --cpp` — green
- [ ] CI matrix

Refs #3311 #3327

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests

* Significantly expanded test suite for file system loading with comprehensive end-to-end validation scenarios.
* Introduced in-memory testing infrastructure to verify correct behavior for valid data loading, missing file handling, and corrupt data detection.
* Replaced previous minimal test cases with more thorough validation coverage to ensure robust file system functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->