### PR TITLE
fix(autoresearch/lpc): assert DTR=True + VID:PID port detection (#3300)

### DIFF
--- a/ci/autoresearch/phases.py
+++ b/ci/autoresearch/phases.py
@@ -2076,8 +2076,17 @@ async def _run_bring_up_tests(ctx: RunContext) -> int:
     try:
         print("   Opening serial port...", end="", flush=True)
         ser = _serial.Serial(upload_port, 115200, timeout=2)
-        ser.dtr = False  # type: ignore[assignment]
-        ser.rts = False  # type: ignore[assignment]
+        # Assert DTR/RTS = True (universal "host ready" idle state).
+        # ESP32 native USB CDC tolerates this (it's the post-reset idle state);
+        # LPC845-BRK *requires* DTR=True because the LPC11U35 USB-VCOM bridge
+        # uses DTR as a flow gate. Previously hardcoded to False here, which
+        # silently dropped every byte the LPC845 transmitted and produced the
+        # bring-up "zero bytes" false alarm under FastLED #3300 / #3325.
+        # See ci/util/pyserial_monitor.py for the same fix on the monitor path,
+        # and ci/util/serial_probe.py for the agent-facing helper that mirrors
+        # this default.
+        ser.dtr = True  # type: ignore[assignment]
+        ser.rts = True  # type: ignore[assignment]
         await asyncio.sleep(0.5)
         ser.reset_input_buffer()
         await asyncio.sleep(2.0)  # let boot banner drain

--- a/ci/hooks/check_forbidden_commands.py
+++ b/ci/hooks/check_forbidden_commands.py
@@ -94,6 +94,28 @@ FORBIDDEN_PATTERNS = [
         r" ninja ",
         "ninja is forbidden - use 'bash test' instead (FastLED build system handles ninja invocation)",
     ),
+    # PowerShell SerialPort is forbidden — see FastLED #3336. Multiple sessions
+    # have wasted hours on what looked like "silent firmware" but was actually
+    # PowerShell's `[System.IO.Ports.SerialPort]` defaulting DTR/RTS to false.
+    # On boards with USB-VCOM bridges (LPC11U35 on LPC845-BRK, FTDI in some
+    # modes), DTR=false silently gates the device's bytes off so the host
+    # sees nothing. The project has the right tool already; use it.
+    (
+        r"(?i)powershell.*System\.IO\.Ports\.SerialPort",
+        "PowerShell [System.IO.Ports.SerialPort] is forbidden for device monitoring "
+        "(FastLED #3336). It defaults DTR/RTS to false, silently dropping bytes from "
+        "boards with USB-VCOM bridges (LPC11U35, FTDI). Use: "
+        "(1) 'bash autoresearch <board>' — full build+flash+monitor cycle with correct "
+        "DTR/RTS, or (2) 'uv run --no-project --with pyserial python ci/util/serial_probe.py "
+        "<port>' for ad-hoc probing — pyserial via the project helper sets DTR/RTS "
+        "correctly.",
+    ),
+    (
+        r"(?i)powershell.*SerialPort.*Open",
+        "PowerShell SerialPort.Open() is forbidden for device monitoring "
+        "(FastLED #3336). Use 'bash autoresearch <board>' or "
+        "'uv run --no-project --with pyserial python ci/util/serial_probe.py <port>'.",
+    ),
 ]
 
 FORBIDDEN_ENV_VARS = [

--- a/ci/hooks/check_forbidden_commands.py
+++ b/ci/hooks/check_forbidden_commands.py
@@ -107,7 +107,7 @@ FORBIDDEN_PATTERNS = [
     # anywhere in the command would falsely flag commit messages, docs, and
     # error strings that mention the pattern (including this one!).
     (
-        r"(?i)powershell(?:\.exe)?\s+[^|;]*(?:-Command|-NoProfile|-c)[^|;]*System\.IO\.Ports\.SerialPort",
+        r"(?i)powershell(?:\.exe)?\s+[^|;]*(?:-Command\b|-NoProfile\b|-c\b)[^|;]*System\.IO\.Ports\.SerialPort",
         "PowerShell [System.IO.Ports.SerialPort] is forbidden for device monitoring "
         "(FastLED #3336). It defaults DTR/RTS to false, silently dropping bytes from "
         "boards with USB-VCOM bridges (LPC11U35, FTDI). Use: "

--- a/ci/hooks/check_forbidden_commands.py
+++ b/ci/hooks/check_forbidden_commands.py
@@ -100,8 +100,14 @@ FORBIDDEN_PATTERNS = [
     # On boards with USB-VCOM bridges (LPC11U35 on LPC845-BRK, FTDI in some
     # modes), DTR=false silently gates the device's bytes off so the host
     # sees nothing. The project has the right tool already; use it.
+    #
+    # Match an actual invocation — powershell(.exe)? immediately followed by
+    # the typical PS flags (`-Command` / `-NoProfile` / `-c`) plus the
+    # SerialPort literal somewhere downstream. Matching plain `powershell`
+    # anywhere in the command would falsely flag commit messages, docs, and
+    # error strings that mention the pattern (including this one!).
     (
-        r"(?i)powershell.*System\.IO\.Ports\.SerialPort",
+        r"(?i)powershell(?:\.exe)?\s+[^|;]*(?:-Command|-NoProfile|-c)[^|;]*System\.IO\.Ports\.SerialPort",
         "PowerShell [System.IO.Ports.SerialPort] is forbidden for device monitoring "
         "(FastLED #3336). It defaults DTR/RTS to false, silently dropping bytes from "
         "boards with USB-VCOM bridges (LPC11U35, FTDI). Use: "
@@ -109,12 +115,6 @@ FORBIDDEN_PATTERNS = [
         "DTR/RTS, or (2) 'uv run --no-project --with pyserial python ci/util/serial_probe.py "
         "<port>' for ad-hoc probing — pyserial via the project helper sets DTR/RTS "
         "correctly.",
-    ),
-    (
-        r"(?i)powershell.*SerialPort.*Open",
-        "PowerShell SerialPort.Open() is forbidden for device monitoring "
-        "(FastLED #3336). Use 'bash autoresearch <board>' or "
-        "'uv run --no-project --with pyserial python ci/util/serial_probe.py <port>'.",
     ),
 ]
 

--- a/ci/util/port_utils.py
+++ b/ci/util/port_utils.py
@@ -43,6 +43,24 @@ CHIP_TO_ENVIRONMENT: dict[str, str] = {
 # ESP32 variants that lack WiFi hardware
 NO_WIFI_ENVIRONMENTS: set[str] = {"esp32h2", "esp32p4"}
 
+# PlatformIO environments → expected USB VID:PID for the data-bearing VCOM
+# port. This bypasses the description-string heuristic for boards whose USB
+# descriptors are too generic to disambiguate (e.g. "USB Serial Device" on
+# Windows for both the LPC845-BRK VCOM and any other Microsoft CDC device).
+# Add new entries here when porting to a new board. See FastLED #3300 for
+# the LPC845-BRK case that motivated this map. ci/util/serial_probe.py has
+# a richer fingerprint table; this map only carries the entries autoresearch
+# needs for default-port selection.
+ENVIRONMENT_TO_VCOM_VID_PID: dict[str, tuple[int, int]] = {
+    # LPC8xx family: LPC11U35-on-board USB-VCOM bridge for USART0.
+    # Same VID:PID across all four LPC8xx canary boards.
+    "lpc845brk": (0x16C0, 0x0483),
+    "lpc845": (0x16C0, 0x0483),
+    "lpc804": (0x16C0, 0x0483),
+    "lpcxpresso845max": (0x16C0, 0x0483),
+    "lpcxpresso804": (0x16C0, 0x0483),
+}
+
 
 def environment_has_wifi(environment: str) -> bool:
     """Check if a PlatformIO environment has WiFi hardware."""
@@ -130,6 +148,44 @@ def auto_detect_upload_port(expected_environment: str | None) -> ComportResult:
         )
 
     expected_env = expected_environment.lower() if expected_environment else None
+
+    # VID:PID-based detection takes precedence over chip-probe and description
+    # heuristics. For boards whose VCOM bridges have well-known IDs (LPC845-BRK
+    # via LPC11U35, see FastLED #3300), this is the only reliable signal on
+    # Windows where multiple boards report a generic "USB Serial Device" name.
+    expected_vid_pid = (
+        ENVIRONMENT_TO_VCOM_VID_PID.get(expected_env) if expected_env else None
+    )
+    if expected_vid_pid is not None:
+        for port in usb_ports:
+            if (port.vid, port.pid) == expected_vid_pid:
+                return ComportResult(
+                    ok=True,
+                    selected_port=port.device,
+                    error_message=None,
+                    all_ports=all_ports,
+                )
+        # Fingerprint expected but no port matched. Don't fall through to the
+        # ESP probe — the wrong port will fail later with PermissionError or
+        # silent timeout. Report explicitly so the user can plug the board in.
+        vid, pid = expected_vid_pid
+        return ComportResult(
+            ok=False,
+            selected_port=None,
+            error_message=(
+                f"No USB serial port matched expected VCOM fingerprint for "
+                f"'{expected_environment}' (VID:PID {vid:04X}:{pid:04X}). "
+                f"Detected USB ports: "
+                + ", ".join(
+                    f"{p.device}={p.vid:04X}:{p.pid:04X}"
+                    if p.vid and p.pid
+                    else f"{p.device}=----:----"
+                    for p in usb_ports
+                )
+            ),
+            all_ports=all_ports,
+        )
+
     esp_environments = {env.lower() for env in CHIP_TO_ENVIRONMENT.values()}
     if expected_env in esp_environments:
         probe_notes: list[str] = []

--- a/ci/util/pyserial_monitor.py
+++ b/ci/util/pyserial_monitor.py
@@ -89,6 +89,16 @@ class SerialMonitor:
                 timeout=0.1,  # Short timeout for non-blocking reads
                 write_timeout=1.0,
             )
+            # Assert DTR/RTS to the universal "host ready" idle state.
+            # Critical for LPC845-BRK (#3300): the LPC11U35 USB-VCOM bridge
+            # gates serial data through DTR. _pyserial_dtr_reset ends with
+            # dtr=False (esptool ClassicReset convention — correct for ESP32
+            # native USB CDC) but that leaves the LPC11U35 in "host not
+            # ready" mode and the device's transmissions are silently
+            # dropped. Forcing DTR=True+RTS=True is safe for ESP32 (it's
+            # the post-reset idle state) and necessary for LPC.
+            self._ser.dtr = True
+            self._ser.rts = True
             # Flush any stale data from previous sessions (crash output, etc.)
             # This prevents false positives from old crash messages in the buffer
             self._ser.reset_input_buffer()

--- a/ci/util/serial_probe.py
+++ b/ci/util/serial_probe.py
@@ -52,7 +52,17 @@ BOARD_FINGERPRINTS: dict[tuple[int, int], str] = {
     # NXP LPC845-BRK ships with an LPC11U35 carrying both the CMSIS-DAP
     # debug interface AND a USB-VCOM bridge for the LPC845's USART0.
     (0x1FC9, 0x0132): "NXP CMSIS-DAP debug (LPC845-BRK / LPC11U35)",
-    (0x16C0, 0x0483): "LPC11U35 VCOM bridge (LPC845-BRK USART0)",
+    # 16C0:0483 is shared between the LPC11U35 VCOM bridge (when used on
+    # LPC845-BRK) and PJRC Teensy USB-Serial. Disambiguation requires
+    # additional signal — e.g. presence of a sibling CMSIS-DAP port for
+    # LPC, or `manufacturer.startswith("Teensyduino")` for PJRC. The
+    # fingerprint table only carries the joint hint; callers that need
+    # to act on the difference must inspect `manufacturer` / `serial_number`
+    # or the companion-port heuristic in `find_lpc845brk_vcom`.
+    (
+        0x16C0,
+        0x0483,
+    ): "LPC11U35 VCOM bridge (LPC845-BRK USART0) OR PJRC Teensy USB-Serial",
     # Espressif native USB CDC across ESP32-S3/C3/C6/H2/P4 variants.
     (0x303A, 0x1001): "Espressif native USB CDC (ESP32-S3/C3/C6/H2/P4)",
     # CP2102 from Silicon Labs — common on ESP32-WROOM dev kits.
@@ -65,7 +75,6 @@ BOARD_FINGERPRINTS: dict[tuple[int, int], str] = {
     (0x0403, 0x6010): "FTDI FT2232 dual UART",
     (0x0403, 0x6014): "FTDI FT232H USB-UART",
     # Teensy 3.x/4.x.
-    (0x16C0, 0x0483): "PJRC / Teensy USB-Serial (also LPC11U35 VCOM)",
     (0x16C0, 0x0486): "PJRC / Teensy USB-Serial (alt)",
 }
 
@@ -121,17 +130,30 @@ def find_by_vid_pid(vid: int, pid: int) -> list[PortInfo]:
 
 
 def find_lpc845brk_vcom() -> PortInfo | None:
-    """Return the LPC845-BRK USART0 VCOM port (LPC11U35 bridge), or None."""
+    """Return the LPC845-BRK USART0 VCOM port (LPC11U35 bridge), or None.
+
+    Returns None on ambiguity — `16C0:0483` is shared between the LPC11U35
+    VCOM bridge and PJRC Teensy USB-Serial, so when multiple matches are
+    detected we cannot pick one safely without additional signal. The
+    caller should require an explicit `--port` instead. (Per the
+    no-silent-fallback rule; see PR #3339 review.)
+    """
     matches = find_by_vid_pid(0x16C0, 0x0483)
     if not matches:
         return None
-    # If multiple boards present (e.g. Teensy + LPC sharing the VID:PID),
-    # prefer one whose CMSIS-DAP debug companion is also detected.
-    if len(matches) > 1:
-        cmsis_dap_ports = find_by_vid_pid(0x1FC9, 0x0132)
-        if cmsis_dap_ports:
-            return matches[0]
-    return matches[0]
+    if len(matches) == 1:
+        return matches[0]
+    # Ambiguous: filter to ports whose `manufacturer` looks like the LPC's
+    # mbed/DAPLink stack (rather than PJRC's "Teensyduino"). If exactly one
+    # remains, that's our LPC. Otherwise fail fast.
+    lpc_like = [
+        p
+        for p in matches
+        if p.manufacturer and not p.manufacturer.lower().startswith("teensy")
+    ]
+    if len(lpc_like) == 1:
+        return lpc_like[0]
+    return None
 
 
 def read_port(

--- a/ci/util/serial_probe.py
+++ b/ci/util/serial_probe.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python3
+"""Ad-hoc serial-port probe with correct DTR/RTS handshake.
+
+This is the agent-facing replacement for the forbidden PowerShell
+`[System.IO.Ports.SerialPort]::Open()` pattern (FastLED #3336). It also
+backs `port_utils.py`'s richer LPC845-BRK detection.
+
+Two modes:
+
+  - `list`   — enumerate every detected serial port with rich metadata
+               (VID:PID, description, manufacturer, board hint).
+  - `read`   — open a port with DTR=True/RTS=True (the universal host-ready
+               idle state), read for N seconds, dump everything to stdout.
+
+Why DTR=True/RTS=True is the right default:
+
+  ESP32 native USB CDC: idle state — no reset, normal operation.
+  CP2102 / CH340 / FTDI: harmless — chip gates data through.
+  LPC11U35 USB-VCOM bridge (LPC845-BRK): REQUIRED — bridge uses DTR as a
+    "host ready" signal. DTR=False makes the bridge silently drop every
+    byte the device transmits. This is what burned #3300 / #3325 for two
+    full sessions before being noticed.
+
+Run from project root via `bash test` won't work (this is not a unit test);
+invoke directly:
+
+    uv run --no-project --with pyserial python ci/util/serial_probe.py list
+    uv run --no-project --with pyserial python ci/util/serial_probe.py read COM20
+    uv run --no-project --with pyserial python ci/util/serial_probe.py read COM20 --seconds 8
+    uv run --no-project --with pyserial python ci/util/serial_probe.py read COM20 --send '{"jsonrpc":"2.0","id":1,"method":"echo","params":[4242]}'
+
+See also:
+- `ci/util/port_utils.py`        — autoresearch's port-detection logic.
+- `ci/util/pyserial_monitor.py`  — the long-lived monitor used by autoresearch.
+- FastLED #3336                  — why the PowerShell pattern is forbidden.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+from dataclasses import dataclass
+
+import serial  # type: ignore[import-not-found]
+import serial.tools.list_ports  # type: ignore[import-not-found]
+
+
+# Known board USB VID:PID fingerprints. Add new entries here when porting to
+# a new board so port_utils.py can pick the right COM port without guessing.
+BOARD_FINGERPRINTS: dict[tuple[int, int], str] = {
+    # NXP LPC845-BRK ships with an LPC11U35 carrying both the CMSIS-DAP
+    # debug interface AND a USB-VCOM bridge for the LPC845's USART0.
+    (0x1FC9, 0x0132): "NXP CMSIS-DAP debug (LPC845-BRK / LPC11U35)",
+    (0x16C0, 0x0483): "LPC11U35 VCOM bridge (LPC845-BRK USART0)",
+    # Espressif native USB CDC across ESP32-S3/C3/C6/H2/P4 variants.
+    (0x303A, 0x1001): "Espressif native USB CDC (ESP32-S3/C3/C6/H2/P4)",
+    # CP2102 from Silicon Labs — common on ESP32-WROOM dev kits.
+    (0x10C4, 0xEA60): "Silicon Labs CP2102 USB-UART (ESP32 dev kit)",
+    # CH340/CH341 from WCH — common on cheaper ESP32/Arduino clones.
+    (0x1A86, 0x7523): "WCH CH340 USB-Serial",
+    (0x1A86, 0x55D4): "WCH CH343 USB-Serial",
+    # FTDI FT232R — older Arduinos, some shields.
+    (0x0403, 0x6001): "FTDI FT232R USB-UART",
+    (0x0403, 0x6010): "FTDI FT2232 dual UART",
+    (0x0403, 0x6014): "FTDI FT232H USB-UART",
+    # Teensy 3.x/4.x.
+    (0x16C0, 0x0483): "PJRC / Teensy USB-Serial (also LPC11U35 VCOM)",
+    (0x16C0, 0x0486): "PJRC / Teensy USB-Serial (alt)",
+}
+
+
+@dataclass(frozen=True)
+class PortInfo:
+    device: str
+    vid: int | None
+    pid: int | None
+    description: str
+    manufacturer: str | None
+    serial_number: str | None
+    hwid: str
+
+    @property
+    def vid_pid(self) -> tuple[int, int] | None:
+        return (self.vid, self.pid) if (self.vid and self.pid) else None
+
+    @property
+    def board_hint(self) -> str | None:
+        vp = self.vid_pid
+        if vp is None:
+            return None
+        return BOARD_FINGERPRINTS.get(vp)
+
+    def format(self) -> str:
+        vp = f"{self.vid:04X}:{self.pid:04X}" if self.vid and self.pid else "----:----"
+        hint = f"  [{self.board_hint}]" if self.board_hint else ""
+        ser = f"  ser={self.serial_number}" if self.serial_number else ""
+        return f"{self.device:8s}  {vp}{ser}  {self.description}{hint}"
+
+
+def list_ports() -> list[PortInfo]:
+    out: list[PortInfo] = []
+    for p in serial.tools.list_ports.comports():
+        out.append(
+            PortInfo(
+                device=p.device,
+                vid=p.vid,
+                pid=p.pid,
+                description=p.description or "",
+                manufacturer=p.manufacturer,
+                serial_number=p.serial_number,
+                hwid=p.hwid or "",
+            )
+        )
+    return out
+
+
+def find_by_vid_pid(vid: int, pid: int) -> list[PortInfo]:
+    """Return all detected ports matching the given VID:PID."""
+    return [p for p in list_ports() if p.vid_pid == (vid, pid)]
+
+
+def find_lpc845brk_vcom() -> PortInfo | None:
+    """Return the LPC845-BRK USART0 VCOM port (LPC11U35 bridge), or None."""
+    matches = find_by_vid_pid(0x16C0, 0x0483)
+    if not matches:
+        return None
+    # If multiple boards present (e.g. Teensy + LPC sharing the VID:PID),
+    # prefer one whose CMSIS-DAP debug companion is also detected.
+    if len(matches) > 1:
+        cmsis_dap_ports = find_by_vid_pid(0x1FC9, 0x0132)
+        if cmsis_dap_ports:
+            return matches[0]
+    return matches[0]
+
+
+def read_port(
+    device: str,
+    seconds: float,
+    baud: int = 115200,
+    send: str | None = None,
+    quiet: bool = False,
+) -> int:
+    """Open a port with DTR/RTS=True, optionally send, then dump bytes for `seconds`.
+
+    Returns the total byte count read. Exits non-zero on open failure.
+    """
+    try:
+        s = serial.Serial(device, baud, timeout=0.2, write_timeout=1.0)
+    except serial.SerialException as e:
+        print(f"ERROR: cannot open {device}: {e}", file=sys.stderr)
+        return -1
+
+    try:
+        # The whole point of this helper — universal host-ready idle state.
+        s.dtr = True
+        s.rts = True
+        # Small settle to let the bridge flush whatever it had buffered while
+        # DTR was de-asserted.
+        time.sleep(0.2)
+
+        if send is not None:
+            payload = send if send.endswith("\n") else send + "\n"
+            s.write(payload.encode("utf-8"))
+            s.flush()
+            if not quiet:
+                print(f"[serial_probe] SENT: {send!r}", file=sys.stderr)
+
+        deadline = time.monotonic() + seconds
+        total = 0
+        buf = bytearray()
+        while time.monotonic() < deadline:
+            n = s.in_waiting
+            if n:
+                chunk = s.read(n)
+                total += len(chunk)
+                buf.extend(chunk)
+                # Flush as text per-newline for streaming feel.
+                while b"\n" in buf:
+                    line, _, rest = buf.partition(b"\n")
+                    sys.stdout.write(line.decode("utf-8", errors="replace") + "\n")
+                    buf = bytearray(rest)
+                sys.stdout.flush()
+            else:
+                time.sleep(0.02)
+        if buf:
+            sys.stdout.write(buf.decode("utf-8", errors="replace"))
+            sys.stdout.flush()
+        if not quiet:
+            print(
+                f"\n[serial_probe] {total} bytes in {seconds:.1f}s from {device}",
+                file=sys.stderr,
+            )
+        return total
+    finally:
+        s.close()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Ad-hoc serial-port probe (replaces forbidden PowerShell SerialPort patterns; see FastLED #3336)."
+    )
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_list = sub.add_parser(
+        "list", help="Enumerate all serial ports with rich metadata."
+    )
+    p_list.add_argument(
+        "--vid-pid",
+        metavar="VID:PID",
+        help="Filter to ports matching the given VID:PID (hex, e.g. 16C0:0483 for LPC845-BRK VCOM).",
+    )
+
+    p_read = sub.add_parser(
+        "read", help="Open a port with DTR=True/RTS=True and dump bytes."
+    )
+    p_read.add_argument("port", help="Serial port (e.g. COM20, /dev/ttyUSB0).")
+    p_read.add_argument(
+        "--seconds", type=float, default=6.0, help="How long to read (default: 6.0 s)."
+    )
+    p_read.add_argument(
+        "--baud", type=int, default=115200, help="Baud rate (default: 115200)."
+    )
+    p_read.add_argument(
+        "--send",
+        default=None,
+        help="Optional payload to write immediately after open (auto-appends newline).",
+    )
+    p_read.add_argument(
+        "--quiet", action="store_true", help="Suppress informational stderr output."
+    )
+
+    p_find = sub.add_parser(
+        "find-lpc",
+        help="Print the LPC845-BRK USART0 VCOM port device path (16C0:0483) or exit non-zero.",
+    )
+    p_find.add_argument(
+        "--quiet", action="store_true", help="Print device only, no banner."
+    )
+
+    args = parser.parse_args(argv)
+
+    if args.cmd == "list":
+        ports = list_ports()
+        filt = args.vid_pid
+        if filt:
+            try:
+                vid_s, pid_s = filt.split(":")
+                vid, pid = int(vid_s, 16), int(pid_s, 16)
+                ports = [p for p in ports if p.vid_pid == (vid, pid)]
+            except (ValueError, AttributeError):
+                print(
+                    f"ERROR: bad --vid-pid: {filt!r} (expected HEX:HEX)",
+                    file=sys.stderr,
+                )
+                return 2
+        if not ports:
+            print("(no matching ports)", file=sys.stderr)
+            return 1
+        for p in ports:
+            print(p.format())
+        return 0
+
+    if args.cmd == "read":
+        rc = read_port(
+            args.port,
+            seconds=args.seconds,
+            baud=args.baud,
+            send=args.send,
+            quiet=args.quiet,
+        )
+        return 0 if rc >= 0 else 1
+
+    if args.cmd == "find-lpc":
+        p = find_lpc845brk_vcom()
+        if p is None:
+            if not args.quiet:
+                print(
+                    "ERROR: no LPC845-BRK VCOM port detected (VID:PID 16C0:0483)",
+                    file=sys.stderr,
+                )
+            return 1
+        if args.quiet:
+            print(p.device)
+        else:
+            print(p.format())
+        return 0
+
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

\`bash autoresearch lpc845brk\` works again. Three independent host-side bugs in the autoresearch serial stack — none of them in firmware — were combining to make the LPC845-BRK look silent. Each fix is isolated and small; together they restore end-to-end autoresearch on LPC and unblock #3300's diagnostic.

| Bug | File | Fix |
|---|---|---|
| **A1** \`SerialMonitor.__enter__\` left DTR/RTS at Windows default (false) → LPC11U35 VCOM bridge silently drops every byte the LPC845 transmits. | \`ci/util/pyserial_monitor.py\` | Set \`dtr=True; rts=True\` after open. Safe for ESP32 (post-reset idle state); required for LPC11U35 / FTDI CDC. |
| **A2** \`_run_bring_up_tests\` explicitly hardcoded \`ser.dtr=False; ser.rts=False\` — ESP32 convention baked in. | \`ci/autoresearch/phases.py\` | Same fix as A1, with rationale comment pointing at this PR. |
| **B** Port auto-detection's fallback path picks \`usb_ports[0]\` when no description matches CP2102/CH340/FTDI/uart. LPC enumerates as generic \"USB Serial Device\" on Windows so it loses the heuristic and grabs whichever ESP board happens to enumerate first (locked, PermissionError). | \`ci/util/port_utils.py\` | New \`ENVIRONMENT_TO_VCOM_VID_PID\` map; LPC8xx envs key to (0x16C0, 0x0483). VID:PID match takes precedence over description heuristics. Clear error if board not plugged in. ESP path unchanged. |

Plus two pieces from FastLED #3336:

- **\`ci/util/serial_probe.py\`** — agent-facing helper. Replaces the forbidden PowerShell SerialPort pattern. Three subcommands: \`list\` (enumerate ports with VID:PID + board hints), \`read <port> [--send X]\` (open with DTR/RTS=True and dump), \`find-lpc\` (print the LPC VCOM device path).
- **\`ci/hooks/check_forbidden_commands.py\`** — new ban for actual PowerShell SerialPort invocations. Regex requires a real invocation token (\`powershell\` + \`-Command\`/\`-NoProfile\`) so commit messages and docs don't false-positive. The commit body of this PR triggered the ban legitimately when I first tried to commit — confirms the regex works. Closes #3336.

## Verification

**Before:** \`bash autoresearch lpc845brk --timeout 30\` failed with \`could not open port COM25: PermissionError(13, 'Access is denied.')\` because port_utils picked the wrong COM, and even on the right port the monitor / bring-up test never received bytes.

**After:** Same command flashes the device, opens **COM20** (correct LPC VCOM), and the bring-up test now reports the actual device state:

\`\`\`
TX: {\"jsonrpc\":\"2.0\",\"method\":\"echo\",\"params\":[4242],\"id\":1}
RX: b'src/fl/remote/remote.cpp.hpp(151): INFO: Stored request ID for echo (id=1)
    src/fl/remote/rpc/rpc.cpp.hpp(102): WARN: RPC: Method not found: echo
    REMOTE: {\"id\":1,\"error\":{\"code\":-32601,\"message\":\"Method not found: echo\"},\"jsonrpc\":\"2.0\"}\r\n
    RESULT: {\"type\":\"status\",\"ready\":true,\"uptimeMs\":154644031}\r\n'

remote_ok=True   -- REMOTE: response received
log_ok=True      -- FL_DBG \"Stored request ID\" reached host
echo_ok=False    -- real #3300 bug now properly surfaced
warn_ok=False    -- handler never fires (because echo unbound)
\`\`\`

The \`echo_ok=False\` / \`warn_ok=False\` results are the *real* FastLED-side regression in #3300, finally visible instead of masked by \"zero bytes\" silence. The diagnosis path now hands the user a clean signal: transport works, dispatch works, the binding is missing. That's actionable. Previous behavior had two whole sessions chasing a fictitious Arduino-core LPC8xx regression (see #3325 update [comment 4757727203](https://github.com/FastLED/FastLED/issues/3325#issuecomment-4757727203)).

## ESP32 sanity

Each env resolves to its own correct port and DTR/RTS=True on monitor open is the ESP32 post-reset idle state — not a reset trigger:

\`\`\`
esp32c6      -> ok=True port=COM9
esp32s3      -> ok=True port=COM22
lpc845brk    -> ok=True port=COM20
\`\`\`

## Test plan

- [x] \`bash autoresearch lpc845brk --timeout 30\` — end-to-end build + flash + reset + bring-up test against real LPC845-BRK hardware.
- [x] Port resolution unit-check across esp32c6 / esp32s3 / lpc845brk.
- [x] Hook regex: blocks real \`powershell.exe -NoProfile -Command [System.IO.Ports.SerialPort]::Open\`, does NOT block \`echo PowerShell System.IO.Ports.SerialPort\` (benign mention).
- [ ] CI cross-platform.

## Refs

- FastLED#3300 — root: LPC bring-up echo silence (now correctly diagnosed as a binding regression, not transport).
- FastLED#3325 — bisection plan re-scoped after this PR surfaced the real symptom.
- FastLED#3336 — agents/hooks forbid PowerShell SerialPort (closed by the hook + helper in this PR).
- FastLED#3337 — host canary test for the (still-open) FastLED-side echo binding regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed serial initialization to assert DTR/RTS on LPC845/LPC11U35 to prevent lost bytes and false “zero bytes” readings.
  * Improved auto-detection of expected USB VCOM ports using VID/PID mapping, with clearer failure reporting when no match is found.
* **New Features**
  * Added a serial-port diagnostic tool to enumerate ports, perform DTR/RTS readiness reads, and detect the LPC845-BRK VCOM port.
* **Chores**
  * Strengthened CI command checks to block unsafe PowerShell SerialPort invocation patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->