### PR TITLE
Rev 3.10.5

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -48,7 +48,7 @@ PROJECT_NAME           = FastLED
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER = 3.10.3
+PROJECT_NUMBER = 3.10.5
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewers a

--- a/library.json
+++ b/library.json
@@ -38,7 +38,7 @@
         "type": "git",
         "url": "https://github.com/FastLED/FastLED.git"
     },
-    "version": "3.10.3",
+    "version": "3.10.5",
     "license": "MIT",
     "homepage": "http://fastled.io",
     "frameworks": "arduino",

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=FastLED
-version=3.10.4
+version=3.10.5
 author=Daniel Garcia
 maintainer=Daniel Garcia <dgarcia@fastled.io>
 sentence=Multi-platform library for controlling dozens of different types of LEDs along with optimized math, effect, and noise functions.

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,7 +1,7 @@
 
 
 
-FastLED 3.10.4 (Next Release)
+FastLED 3.10.4
 ==============
   * **NEW: TrueType Font Rendering Support**: Full TrueType font (.ttf/.ttc) rendering API with embedded default font
     * **High-quality text rendering**: Render scalable TrueType fonts to LED matrices with antialiasing support

--- a/src/FastLED.h
+++ b/src/FastLED.h
@@ -34,13 +34,13 @@
 /// * 1 digit for the major version
 /// * 3 digits for the minor version
 /// * 3 digits for the patch version
-#define FASTLED_VERSION 3010004
+#define FASTLED_VERSION 3010005
 #ifndef FASTLED_INTERNAL
 #  ifdef  FASTLED_SHOW_VERSION
 #    ifdef FASTLED_HAS_PRAGMA_MESSAGE
-#      pragma message "FastLED version 3.010.003"
+#      pragma message "FastLED version 3.010.005"
 #    else
-#      warning FastLED version 3.010.003  (Not really a warning, just telling you here.)
+#      warning FastLED version 3.010.005  (Not really a warning, just telling you here.)
 #    endif
 #  endif
 #endif


### PR DESCRIPTION
Version bump to **3.10.5**.

## Summary

- Bump version to `3.10.5` across `library.properties`, `library.json`, `docs/Doxyfile`, `src/FastLED.h`
- Finalize the `release_notes.md` heading: drop "(Next Release)" so the section is labeled simply `FastLED 3.10.4`
  - The shipped content matches the 3.10.4 release — 3.10.5 ships that same content following the master-reset in #3345

## Files changed

- `library.properties`: `3.10.4` → `3.10.5`
- `library.json`: `3.10.3` → `3.10.5` (was inconsistent with the other files)
- `docs/Doxyfile`: `3.10.3` → `3.10.5` (was inconsistent)
- `src/FastLED.h`: `FASTLED_VERSION 3010004` → `3010005`, pragma/warning strings updated
- `release_notes.md`: heading `FastLED 3.10.4 (Next Release)` → `FastLED 3.10.4`

## Post-merge

Tag `3.10.5` should be created from master and pushed after merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated library version to 3.10.5 across configuration files.

* **Documentation**
  * Finalized release notes for the current release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->