### PR TITLE
docs(platforms): mandate vendor CMSIS PAL for register maps

### DIFF
--- a/.claude/agents/platform-port-agent.md
+++ b/.claude/agents/platform-port-agent.md
@@ -77,12 +77,24 @@ Register in `src/platforms/int.h` dispatcher with appropriate `#elif` guard.
 
 The clockless driver is the minimum for LED output. It bit-bangs the GPIO pin.
 
+**BEFORE touching any peripheral register, read `agents/docs/register-maps.md`.**
+The rule: use the vendor CMSIS PAL header (`LPC845.h`, `stm32f4xx.h`,
+`nrf52840.h`, `hardware/structs/sio.h`, etc.) — do NOT hand-roll a parallel
+`struct FooShim { volatile u32 _resv0[16]; ... }` from the chip's user manual.
+Hand-rolled shims have already shipped wrong offsets to LPC845 twice
+(issue #2990, fix PR #3349). Vendor headers are generated from the silicon
+designer's SVD/IP-XACT and encode silicon-revision-specific layout quirks
+that human-readable user manuals miss.
+
 **Key implementation requirements**:
 1. **Nanosecond-precision timing** — use cycle counting or hardware timers
 2. **Interrupt disable during output** — LED protocols are timing-sensitive
-3. **GPIO direct register access** — `digitalWrite()` is too slow
+3. **GPIO direct register access** — `digitalWrite()` is too slow, but go
+   through the vendor's typedef'd peripheral pointers (`GPIOx->BSRR`,
+   `sio_hw->gpio_set`, `NRF_GPIO->OUTSET`) — never type out the struct
+   yourself.
 
-**GPIO access patterns by architecture**:
+**GPIO access patterns by architecture** (all use vendor CMSIS pointers):
 - ARM Cortex-M: `GPIOx->BSRR = pin_mask` (set), `GPIOx->BRR = pin_mask` (clear)
 - AVR: `PORTB |= pin_mask` / `PORTB &= ~pin_mask`
 - ESP32: `GPIO.out_w1ts = pin_mask` / `GPIO.out_w1tc = pin_mask`
@@ -141,6 +153,7 @@ If the platform has hardware SPI:
 
 - **Research before implementing** — get architecture details right
 - **Follow existing patterns** — look at similar platforms already ported
+- **Use vendor CMSIS register definitions, never hand-roll register-map shims** — read `agents/docs/register-maps.md` before authoring any `struct *Shim` or typing out register offsets from a user manual
 - **Use the correct naming convention** — `FL_IS_<PLATFORM>` for detection macros
 - **Never modify `fl/stl/int.h` or `fl/stdint.h`** — only platform-specific int files
 - **Stay in project root** — never `cd` to subdirectories

--- a/.claude/skills/platform-port/SKILL.md
+++ b/.claude/skills/platform-port/SKILL.md
@@ -26,6 +26,11 @@ $ARGUMENTS
 - SPI hardware driver if platform supports it
 - RMT/I2S/PARLIO drivers for ESP32 variants
 - GPIO register access patterns for the target MCU
+- **Register-map authoring** — use the vendor CMSIS PAL header
+  (`LPC845.h`, `stm32f4xx.h`, `nrf52840.h`, `hardware/structs/*.h`,
+  etc.); do not hand-roll register shims. See
+  `agents/docs/register-maps.md` for the rule, the vendor-source
+  table, and the tier-1/2/3 integration pattern.
 
 ### Build System Integration
 - PlatformIO board definition

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,7 @@
 | Task | Read |
 |------|------|
 | Writing/editing C++ code | `agents/docs/cpp-standards.md` |
+| Defining a register map / accessing MCU peripherals | `agents/docs/register-maps.md` (use vendor CMSIS PAL — do not hand-roll shims) |
 | Creating an API wrapper type | `agents/docs/cpp-standards.md` → "API Object Pattern" |
 | Adding a global setting / configuration knob | `agents/docs/cpp-standards.md` → "Public Settings Pattern" (new setters go on `CFastLED`, not as bare `fl::set_*` free functions) |
 | Writing/editing Python code | `agents/docs/python-standards.md` |

--- a/agents/docs/register-maps.md
+++ b/agents/docs/register-maps.md
@@ -1,0 +1,178 @@
+# Register Maps & Vendor CMSIS Headers
+
+**Rule for ALL agents (human and AI):** when a MCU has an official vendor
+peripheral-access-layer (CMSIS PAL) header — `LPC845.h`, `stm32f4xx.h`,
+`MK20DX256.h`, `nrf52840.h`, `samd21.h`, `hardware/structs/*.h`, etc. — that
+header is the **source of truth** for peripheral register layouts. Do not
+hand-roll a parallel `struct FooShim { volatile u32 _resv0[16]; ... }` from
+the chip's user manual when the vendor already publishes the typedef.
+
+This document exists because two register-offset bugs slipped into
+`src/platforms/arm/lpc/clockless_arm_lpc_pwm_dma.h` (issue #2990, fix PR
+#3349). Both were hand-rolled shim entries whose offsets disagreed with NXP's
+`LPC845.h`. The contributor who hit them put it bluntly: *"This seems like a
+waste of time debugging AI hallucinated register maps, when it would be so
+much easier and safer to use the vendor provided CMSIS Peripheral Access
+Layer."*
+
+## Why hand-rolled shims fail
+
+A vendor CMSIS header is generated from the silicon designer's IP-XACT /
+SVD description of the part. It encodes:
+
+- Exact byte offsets including silicon-revision-specific reserved gaps.
+- The correct width and packing of bit-fields.
+- Errata-driven layout quirks that don't appear in the human-readable user
+  manual.
+
+Re-typing those struct members by hand from the user manual is *literally
+the kind of work that LLMs and humans both get wrong*. Off-by-one on a
+`_resv0[16]` vs `_resv0[32]` is invisible at compile time, silently
+writes to a different register at runtime, and the bug doesn't show up
+until someone scopes the GPIO pin and notices the LED isn't blinking.
+
+The same point applies to every vendor: NXP, ST, Nordic, Atmel/Microchip,
+Raspberry Pi, Silicon Labs, Renesas, GigaDevice. If they publish a CMSIS PAL
+header, **use it**.
+
+## Where to find the vendor header
+
+These are the canonical upstream sources for the platforms FastLED currently
+supports. All are BSD-3-Clause / Apache-2.0 / equivalent permissive — safe to
+vendor in `src/platforms/<arch>/<vendor>/cmsis/` if upstream availability
+through the toolchain proves unreliable.
+
+| Vendor | Family | Upstream | License |
+|---|---|---|---|
+| NXP | LPC8xx (LPC845, LPC804) | https://github.com/nxp-mcuxpresso/mcux-devices-lpc/tree/main/LPC800 | BSD-3-Clause |
+| NXP | LPC11xx, LPC15xx | https://github.com/nxp-mcuxpresso/mcux-devices-lpc | BSD-3-Clause |
+| NXP | i.MX RT (Teensy 4.x base) | https://github.com/nxp-mcuxpresso/mcux-devices-imxrt | BSD-3-Clause |
+| STMicro | STM32F/G/H/L/U | https://github.com/STMicroelectronics/cmsis-device-* (one repo per family) | Apache-2.0 |
+| Nordic | nRF51 / nRF52 / nRF53 | https://github.com/NordicSemiconductor/nrfx (headers in `mdk/`) | BSD-3-Clause |
+| Microchip (Atmel) | SAMD / SAM | https://github.com/avrxml/asf (CMSIS in `sam0/utils/cmsis/`) | BSD-3-Clause |
+| Raspberry Pi | RP2040 / RP2350 | https://github.com/raspberrypi/pico-sdk (`src/rp2_common/hardware_*/include/hardware/structs/`) | BSD-3-Clause |
+| Silicon Labs | EFM32 / EFR32 / MGM240 | https://github.com/SiliconLabs/gecko_sdk (`platform/Device/SiliconLabs/`) | Zlib |
+| PJRC (Teensy) | MK20DX, MK66, MIMXRT1062 | https://github.com/PaulStoffregen/cores | MIT |
+
+If a part is missing from this table, the rule of thumb is "search GitHub for
+`<chip part number>.h`" — the official repo is almost always the first hit.
+If the only available header is in a board-vendor SDK (e.g. an Arduino core)
+that's also fine; the goal is *use the upstream, do not retype it*.
+
+## How to integrate a vendor header
+
+The order below is best to worst. Pick the highest tier that works for the
+build environment you actually need to support.
+
+### Tier 1 — Toolchain provides it (preferred)
+
+The board's Arduino core or PlatformIO platform places the CMSIS header on
+the include path automatically. Just `#include <LPC845.h>` (or the
+appropriate header) from `led_sysdefs_<arch>_<vendor>.h` and use the
+vendor's typedef'd peripheral pointers (`LPC_SCT->CONFIG`, `GPIOA->BSRR`,
+`NRF_SPIM0->TXD.PTR`).
+
+**Exemplars in this tree:**
+
+- `src/platforms/arm/rp/rpcommon/clockless_rp_pio.h` — uses `hardware/pio.h`,
+  `hardware/dma.h`, `hardware/structs/sio.h` from the Pico SDK directly.
+- `src/platforms/arm/nrf52/spi_hw_2_nrf52.h` — uses `<nrf_spim.h>` and
+  `<nrfx_timer.h>` directly.
+- `src/platforms/arm/sam/fastspi_arm_sam.h` — uses Atmel CMSIS
+  `(Spi*)SPI0`, `SPI_SR`, `SPI_TDR`.
+
+### Tier 2 — Vendor the header into the tree
+
+If the toolchain's include path is unreliable (e.g. the Arduino core only
+exposes the active variant directory, like the NXP `ArduinoCore-LPC8xx`
+PlatformIO binding does), copy the vendor header into
+`src/platforms/<arch>/<vendor>/cmsis/<chip>.h`. License headers stay intact;
+add a one-line `README.md` next to it citing the upstream URL and the
+commit SHA the copy is from. Update the platform's `led_sysdefs_*.h` to
+include the local copy.
+
+### Tier 3 — Local shim, **last resort only**
+
+A local `struct ShimName { volatile u32 ...; }` may be defined only when:
+
+1. **Both** tiers 1 and 2 above were investigated and documented as
+   infeasible for the targeted build configurations. Cite the reason in a
+   comment on the shim.
+2. The shim is gated behind the vendor header's own include guard so the
+   real CMSIS definition wins automatically when present. The LPC8xx shims
+   demonstrate this — the include guard is the typedef name from the
+   vendor header (e.g. `LPC_SCT_TYPE_`):
+
+   ```cpp
+   #if !defined(LPC_SCT) && !defined(LPC_SCT_TYPE_)
+   struct FL_LPC_SCT_Shim { /* ... */ };
+   #define LPC_SCT ((FL_LPC_SCT_Shim*)LPC_SCT_BASE)
+   #endif
+   ```
+
+3. **Every** struct member cites both the user-manual section *and* the
+   corresponding member name in the vendor header. Example:
+
+   ```cpp
+   volatile u32 SYSAHBCLKCTRL0;  // UM11029 §4.6.13 ; CMSIS LPC_SYSCON_Type.SYSAHBCLKCTRL0 @ 0x080
+   ```
+
+4. The shim is reviewed against the actual vendor header before merge.
+   "I read the user manual" is not sufficient. The reviewer checklist
+   below is the gate.
+
+## When in doubt, don't write the shim
+
+If you cannot complete the four bullets above for a given peripheral,
+**stop and ask** before merging. Filing an issue against the FastLED
+repo with the chip part number, the missing peripheral, and the upstream
+header URL is always preferable to landing speculative offsets.
+
+## Reviewer checklist (block merge if any answer is no)
+
+When reviewing a PR that adds or modifies peripheral register access:
+
+- [ ] If a vendor CMSIS header exists for this chip, is the PR using it
+      (tier 1 or 2)? If not, does the PR document *why* the vendor header
+      cannot be used in the target build configuration?
+- [ ] If a local shim is used (tier 3), is it gated behind the vendor's
+      include guard (`#if !defined(VENDOR_TYPEDEF_NAME)`) so the real
+      definition takes precedence when available?
+- [ ] Does **every** shim member cite both the user-manual section and
+      the corresponding vendor-header member name? Pulled up the vendor
+      header in a second window and spot-checked at least three offsets?
+- [ ] Is the shim file listed in the platform's `README.md` under
+      "files (quick pass)" with a note that it is a tier-3 fallback?
+- [ ] If the change touches an existing shim, does the diff include the
+      vendor-header offset for any added/changed member?
+
+## Worked anti-example: LPC845
+
+`src/platforms/arm/lpc/clockless_arm_lpc_pwm_dma.h` lines 225–322 define
+three shim structs (`FL_LPC_SCT_Shim`, `FL_LPC_DMA_Shim`,
+`FL_LPC_SYSCON_Shim`). They follow rule (2) above — the include guard is
+the vendor typedef name, so a real `<LPC845.h>` wins — but they were
+written from the user manual without cross-checking the vendor header,
+and the offsets were wrong twice:
+
+- **First miss** — `FL_LPC_SYSCON_Shim` had `_resv0[16]` (placing
+  `SYSAHBCLKCTRL0` at offset `0x040`). The real LPC845 layout puts it at
+  `0x080`. Caught and fixed in #3349.
+- **Second miss** — `DMA_CHANNEL.CFG` was written with only the
+  `HWTRIGEN` bit; the channel actually needs `PERIPHREQEN | HWTRIGEN`
+  plus explicit `TRIGPOL=0`, `TRIGTYPE=0`. Also fixed in #3349.
+
+The right fix going forward is tier 2: vendor a copy of NXP's `LPC845.h`
+(BSD-3-Clause) into `src/platforms/arm/lpc/cmsis/LPC845.h`, include it
+unconditionally from `led_sysdefs_arm_lpc.h`, and delete the shims. This
+work is tracked as an open follow-up; until it lands, the tier-3 shim
+remains the source of truth for non-Arduino build paths and any further
+edits must follow the rules in this document.
+
+## Cross-references
+
+- `agents/docs/cpp-standards.md` — general C++ rules.
+- `.claude/agents/platform-port-agent.md` — porting walkthrough that links
+  here before any peripheral struct is authored.
+- `.claude/skills/platform-port/SKILL.md` — same.
+- `src/platforms/arm/lpc/README.md` — worked anti-example reference.

--- a/src/platforms/arm/lpc/README.md
+++ b/src/platforms/arm/lpc/README.md
@@ -42,6 +42,21 @@ What the harness asserts:
 
 Once all four run green against an LPC845-BRK with the loopback jumper, [#2880](https://github.com/FastLED/FastLED/issues/2880) closes and the table above flips its LPC845 / LPC804 rows to "✅ hardware verified". No human-eyeball scope trace required.
 
+## Register-map authoring note (issue #2990)
+
+`clockless_arm_lpc_pwm_dma.h` defines tier-3 fallback shim structs
+(`FL_LPC_SCT_Shim`, `FL_LPC_DMA_Shim`, `FL_LPC_SYSCON_Shim`) for build
+configurations where NXP's `<LPC845.h>` is not on the include path.
+Those shims have shipped wrong offsets twice (#3349 fixed `SYSCON`
+`_resv0[16]→[32]` and `DMA_CHANNEL.CFG` bit composition). Any further
+edits to those structs — or to any new LPC register access — MUST follow
+`agents/docs/register-maps.md`: cite both the UM section and the
+vendor CMSIS member name on every line, gate the shim behind the
+vendor typedef's include guard, and spot-check three offsets against
+the real header before merging. The long-term plan is tier-2 vendoring
+of `LPC845.h` (BSD-3-Clause) into `src/platforms/arm/lpc/cmsis/` and
+deletion of the shims.
+
 ## Files (quick pass)
 
 - `fastled_arm_lpc.h` — Aggregator; selects between bit-bang / PLU / PWM+DMA per chip and opt-in macro.


### PR DESCRIPTION
## Summary

Two LPC845 register-offset bugs (issue #2990, fix PR #3349) traced back to hand-rolled `FL_LPC_*_Shim` structs in `src/platforms/arm/lpc/clockless_arm_lpc_pwm_dma.h` whose offsets disagreed with NXP's `LPC845.h`. Both were invisible at compile time and only surfaced when contributors scoped the GPIO pin. The contributor put it bluntly: *"This seems like a waste of time debugging AI hallucinated register maps, when it would be so much easier and safer to use the vendor provided CMSIS Peripheral Access Layer."*

This PR lands the documentation gap that allowed those bugs to ship:

- **`agents/docs/register-maps.md`** (new) — the rule, why hand-rolled shims fail, a vendor-source table (NXP / ST / Nordic / Atmel / RPi / SiLabs / PJRC CMSIS repos with licenses), a tier-1/2/3 integration pattern, a reviewer checklist, and the LPC845 worked anti-example.
- **`CLAUDE.md`** — new row in "Read the Right File for Your Task" pointing at the new doc, so it shows up in the routing table every agent reads at session start.
- **`.claude/agents/platform-port-agent.md`** + **`.claude/skills/platform-port/SKILL.md`** — cross-reference the doc *before* any peripheral struct is authored, with the LPC845 incident cited inline.
- **`src/platforms/arm/lpc/README.md`** — pin the lesson at the scene of the crime; flag the existing shims as tier-3 fallbacks and tee up the longer-term tier-2 fix (vendoring `LPC845.h` into `src/platforms/arm/lpc/cmsis/`).

No code changes in this PR — a follow-up will land the tier-2 LPC845 vendoring and delete the shims.

## Test plan

- [x] `agents/docs/register-maps.md` renders cleanly (Markdown only).
- [x] CLAUDE.md table parses (visual check — column count preserved).
- [x] No build files touched, so no `bash compile` / `bash test` impact.
- [ ] Reviewer spot-check: does the vendor-source table cover the platforms FastLED currently supports?
- [ ] Reviewer spot-check: tier-1/2/3 examples (RP2040, nRF52, SAM3X8E) match how those drivers actually use vendor headers today.

Closes the documentation gap behind issue #2990's "AI hallucinated register maps" comment.

Related: #2990, #3349

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clear guidance for working with MCU peripheral register layouts.
  * Encourages using vendor CMSIS headers as the source of truth and avoids hand-written register shims.
  * Added step-by-step rules, review checks, and examples for safer register-map handling.
  * Updated platform porting docs with stronger register-access instructions and notes for LPC targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->