### PR TITLE
[codex] bump fbuild to 2.3.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,17 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    # Pin to fbuild 2.2.27 (released 2026-06-12). 2.2.27 bumps the
+    # Pin to fbuild 2.3.3 (released 2026-06-23).
+    #
+    # Pin history:
+    #   2.3.3 -- latest PyPI release as of 2026-06-24; carries the
+    #            post-2.3.1 fbuild fixes needed by the current
+    #            AutoResearch/ObjectFLED validation pass.
+    #   2.3.1 -- latest PyPI release as of 2026-06-22; carries the
+    #            post-2.3.0 Teensy deploy/serial fixes needed while
+    #            validating AutoResearch/ObjectFLED on physical T4.x
+    #            hardware.
+    #   2.2.27 (released 2026-06-12). 2.2.27 bumps the
     # bundled `running-process` daemon broker to 4.2.0
     # (FastLED/fbuild#537) on top of the 2.2.26 ArmCompiler/zccache
     # unification (FastLED/fbuild#526) and LPC845-BRK board stubs
@@ -112,7 +122,7 @@ dependencies = [
     # primitive (FastLED/fbuild#532, #577/#580), and an
     # http-connect-timeout fix on the managed-zccache client
     # (FastLED/fbuild#573).
-    "fbuild==2.3.0",
+    "fbuild==2.3.3",
     "platformio>=6.1.19,<6.2",
     "python-dateutil",
     "ruff",


### PR DESCRIPTION
﻿## Summary

- Bump the pinned `fbuild` dependency from `2.3.0` to `2.3.3` in `pyproject.toml`.
- Update the nearby pin-history comment to record the current PyPI release.

## Validation

- `uv run --frozen python -c "import tomllib; tomllib.load(open('pyproject.toml','rb')); print('pyproject.toml OK')"`

## Notes

Only `pyproject.toml` is included in this PR. Other local AutoResearch/ObjectFLED worktree changes were left unstaged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a project dependency to the latest pinned patch release.
  * Refreshed release-history comments to reflect the newest version details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->