### PR TITLE
fix(autoresearch): handle control RPC success

### DIFF
--- a/ci/autoresearch/phases.py
+++ b/ci/autoresearch/phases.py
@@ -2545,7 +2545,11 @@ async def _run_rpc_tests(ctx: RunContext, qctx: QuietContext) -> int:
                     if "patterns" in test_data:
                         display_pattern_details(test_data)
 
-                elif test_data.get("success") and not test_data.get("passed"):
+                elif (
+                    test_data.get("success")
+                    and "passed" in test_data
+                    and not test_data.get("passed")
+                ):
                     stop_word_found = "ERROR"
                     test_failed = True
                     print(f"{Fore.RED}\u274c Test failed{Style.RESET_ALL}")

--- a/ci/tests/test_autoresearch_phases.py
+++ b/ci/tests/test_autoresearch_phases.py
@@ -912,6 +912,44 @@ class TestRunTestsOrSpecialMode:
             rc = asyncio.run(_run_tests_or_special_mode(ctx, qctx))
         assert rc == 1
 
+    def test_rpc_control_success_without_passed_field(self) -> None:
+        ctx = _make_ctx()
+        ctx.json_rpc_commands.insert(
+            0, {"method": "setPins", "params": [{"txPin": 8, "rxPin": 9}]}
+        )
+        qctx = QuietContext(quiet=False)
+
+        mock_client = AsyncMock()
+        set_pins_response = MagicMock()
+        set_pins_response.data = {
+            "success": True,
+            "txPin": 8,
+            "rxPin": 9,
+            "rxChannelRecreated": True,
+        }
+        driver_response = MagicMock()
+        driver_response.data = {
+            "success": True,
+            "passed": True,
+            "driver": "PARLIO",
+            "laneCount": 1,
+            "laneSizes": [100],
+            "duration_ms": 42,
+            "passedTests": 1,
+            "totalTests": 1,
+        }
+        mock_client.send = AsyncMock(side_effect=[set_pins_response, driver_response])
+        mock_client.connect = AsyncMock()
+        mock_client.close = AsyncMock()
+
+        with (
+            patch(f"{_PATCH_MOD}.RpcClient", return_value=mock_client),
+            patch(f"{_PATCH_MOD}.kill_port_users"),
+            patch("time.sleep"),
+        ):
+            rc = asyncio.run(_run_tests_or_special_mode(ctx, qctx))
+        assert rc == 0
+
     def test_discovery_client_reuse(self) -> None:
         """Verify that discovery_client is reused instead of creating a new one."""
         mock_discovery = AsyncMock()


### PR DESCRIPTION
## Summary

- Treat successful control RPC responses without a `passed` field as command success instead of failed driver tests.
- Add a regression test for `setPins` followed by a passing driver RPC.

## Context

During #3353 Teensy bring-up, GPIO-only passed on `GPIO 8 -> GPIO 9`, but the ObjectFLED run printed `TEST setPins ... FAIL` before the real driver result. The device response was actually successful:

```text
Response: {'rxPin': 9, 'txPin': 8, 'success': True, ...}
```

The wrapper was classifying any `success: true` response without `passed: true` as a failed test. Control RPCs such as `setPins` are not driver tests and do not return `passed`.

## Test

```bash
uv run --no-sync pytest ci/tests/test_autoresearch_phases.py::TestRunTestsOrSpecialMode::test_rpc_control_success_without_passed_field ci/tests/test_autoresearch_phases.py::TestRunTestsOrSpecialMode::test_rpc_test_failure ci/tests/test_autoresearch_phases.py::TestRunTestsOrSpecialMode::test_rpc_test_all_pass
```

Result: 3 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of successful test responses when an optional result field is missing, preventing valid runs from being marked as failures.
  * Fixed control-test reporting so successful runs now complete as expected even when that field is not returned.
* **Tests**
  * Added coverage for the success case without the optional result field to guard against regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->