### PR TITLE
fix(autoresearch): reject unsupported RX pins

### DIFF
--- a/ci/autoresearch/context.py
+++ b/ci/autoresearch/context.py
@@ -240,6 +240,8 @@ def display_pattern_details(result: dict[str, Any]) -> None:
         total_bytes = pat.get("totalBytes", num_leds * 3)
         mismatched_bytes = pat.get("mismatchedBytes", 0)
         lsb_only = pat.get("lsbOnlyErrors", 0)
+        captured_bytes = pat.get("capturedBytes")
+        capture_failed = bool(pat.get("captureFailed", False))
 
         agg_total_bytes += total_bytes
         agg_mismatched_bytes += mismatched_bytes
@@ -249,6 +251,10 @@ def display_pattern_details(result: dict[str, Any]) -> None:
         lsb_pct = 100.0 * lsb_only / mismatched_bytes if mismatched_bytes > 0 else 0.0
 
         print(f"    Mismatched LEDs:  {mismatched_leds}/{num_leds}")
+        if captured_bytes is not None:
+            print(f"    Captured bytes:   {captured_bytes}/{total_bytes}")
+        if capture_failed:
+            print(f"    Capture status:   RX produced no decodable bytes")
         print(
             f"    Byte corruption:  {mismatched_bytes}/{total_bytes} bytes ({byte_pct:.1f}%)"
         )

--- a/ci/autoresearch/phases.py
+++ b/ci/autoresearch/phases.py
@@ -2471,6 +2471,13 @@ async def _run_rpc_tests(ctx: RunContext, qctx: QuietContext) -> int:
         for i, cmd in enumerate(json_rpc_commands, 1):
             method = cmd.get("method", "unknown")
             params = cmd.get("params", [])
+            setup_method = method in {
+                "setPins",
+                "setTxPin",
+                "setRxPin",
+                "setLaneSizes",
+                "setSolidColor",
+            }
 
             print(f"\n[{i}/{len(json_rpc_commands)}] Calling {method}()...")
 
@@ -2504,7 +2511,18 @@ async def _run_rpc_tests(ctx: RunContext, qctx: QuietContext) -> int:
                 _leds = sum(test_data.get("laneSizes", [0]))
                 _dur = test_data.get("duration_ms", "?")
 
-                if test_data.get("success") and test_data.get("passed"):
+                if test_data.get("success") is False or "error" in test_data:
+                    stop_word_found = "ERROR"
+                    test_failed = True
+                    print(f"{Fore.RED}\u274c RPC command failed{Style.RESET_ALL}")
+                    if "error" in test_data:
+                        print(f"   Error: {test_data['error']}")
+                    if "message" in test_data:
+                        print(f"   Message: {test_data['message']}")
+                    if setup_method:
+                        break
+
+                elif test_data.get("success") and test_data.get("passed"):
                     stop_word_found = "OK"
                     print(f"{Fore.GREEN}\u2705 Test passed{Style.RESET_ALL}")
                     qctx.emit(
@@ -2571,13 +2589,6 @@ async def _run_rpc_tests(ctx: RunContext, qctx: QuietContext) -> int:
 
                     if "patterns" in test_data:
                         display_pattern_details(test_data)
-
-                elif test_data.get("success") is False:
-                    stop_word_found = "ERROR"
-                    test_failed = True
-                    print(f"{Fore.RED}\u274c RPC command failed{Style.RESET_ALL}")
-                    if "error" in test_data:
-                        print(f"   Error: {test_data['error']}")
 
                 else:
                     stop_word_found = "OK"

--- a/ci/tests/test_autoresearch_phases.py
+++ b/ci/tests/test_autoresearch_phases.py
@@ -950,6 +950,32 @@ class TestRunTestsOrSpecialMode:
             rc = asyncio.run(_run_tests_or_special_mode(ctx, qctx))
         assert rc == 0
 
+    def test_rpc_control_error_without_success_false_stops_run(self) -> None:
+        ctx = _make_ctx()
+        ctx.json_rpc_commands.insert(
+            0, {"method": "setPins", "params": [{"txPin": 8, "rxPin": 9}]}
+        )
+        qctx = QuietContext(quiet=False)
+
+        mock_client = AsyncMock()
+        set_pins_response = MagicMock()
+        set_pins_response.data = {
+            "error": "RxChannelCreationFailed",
+            "message": "Failed to create RX channel",
+        }
+        mock_client.send = AsyncMock(return_value=set_pins_response)
+        mock_client.connect = AsyncMock()
+        mock_client.close = AsyncMock()
+
+        with (
+            patch(f"{_PATCH_MOD}.RpcClient", return_value=mock_client),
+            patch(f"{_PATCH_MOD}.kill_port_users"),
+            patch("time.sleep"),
+        ):
+            rc = asyncio.run(_run_tests_or_special_mode(ctx, qctx))
+        assert rc == 1
+        assert mock_client.send.await_count == 1
+
     def test_discovery_client_reuse(self) -> None:
         """Verify that discovery_client is reused instead of creating a new one."""
         mock_discovery = AsyncMock()

--- a/examples/AutoResearch/AutoResearch.ino
+++ b/examples/AutoResearch/AutoResearch.ino
@@ -278,7 +278,11 @@ constexpr int RX_BUFFER_SIZE = 3000 * 32 + 100;  // LEDs × 32:1 expansion + hea
 // This allows AutoResearchRemoteControl to recreate the RX channel when the pin changes
 fl::shared_ptr<fl::RxChannel> createRxDevice(int pin) {
     fl::RxChannelConfig config(pin, RX_BACKEND);
-    return FastLED.addRx(config);
+    fl::shared_ptr<fl::RxChannel> channel = FastLED.addRx(config);
+    if (!channel || channel->getPin() != pin) {
+        return fl::shared_ptr<fl::RxChannel>();
+    }
+    return channel;
 }
 
 // Global autoresearch state (shared between main loop and RPC handlers)


### PR DESCRIPTION
﻿## Summary

Fixes #3355.
Part of #3353.

This makes AutoResearch reject unsupported RX pins honestly instead of allowing `FastLED.addRx()` to hand back a dummy channel and then spending time on a driver test that cannot capture bytes.

Changes:
- Treat RX channel creation as failed when `FastLED.addRx()` returns null or a channel whose `getPin()` does not match the requested RX pin.
- Treat JSON-RPC error responses as failures even when the response omits `success: false`.
- Stop immediately when setup RPCs such as `setPins` fail.
- Surface captured-byte counts and zero-capture status in host diagnostics.

## Verification

```bash
uv run --no-sync pytest ci/tests/test_autoresearch_phases.py::TestRunTestsOrSpecialMode::test_rpc_control_success_without_passed_field ci/tests/test_autoresearch_phases.py::TestRunTestsOrSpecialMode::test_rpc_control_error_without_success_false_stops_run ci/tests/test_autoresearch_phases.py::TestRunTestsOrSpecialMode::test_rpc_test_failure ci/tests/test_autoresearch_phases.py::TestRunTestsOrSpecialMode::test_rpc_test_all_pass
```

Result: 4 passed.

```bash
bash autoresearch teensy41 --object-fled --tx-pin 8 --rx-pin 9 --strip-sizes 1 --timeout 2m
```

Result: expected failure at `setPins` with `RxChannelCreationFailed`; only 1 RPC test request sent. This confirms the unsupported Teensy RX pin is rejected before driver testing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved RX diagnostics so failed captures now show how many bytes were received and when no decodable data was produced.
  * Made setup-related control operations stop earlier when an error occurs, preventing follow-on commands from running after a failed initialization step.
  * Strengthened RX channel creation to avoid using a channel when it does not match the requested pin, reducing misconfiguration issues.

* **Tests**
  * Added coverage for control errors that do not explicitly report `success: false`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->