### PR TITLE
fix(autoresearch): demote unavailable Teensy LPUART

### DIFF
--- a/ci/autoresearch/args.py
+++ b/ci/autoresearch/args.py
@@ -150,8 +150,8 @@ Driver Selection (JSON-RPC):
     --lcd-spi      Test only LCD_SPI driver (ESP32-S3 only, APA102/SK9822)
     --lcd-rgb      Test only LCD RGB driver (ESP32-P4 only)
     --object-fled  Test only ObjectFLED DMA driver (Teensy 4.x)
-    --lpuart       Test only LPUART driver (Teensy 4.x; eDMA-backed UART TX, pinned to pin 1 by default)
-    --all          Test all drivers
+    --lpuart       Reserved for future Teensy 4.x LPUART driver; currently unavailable
+    --all          Test all currently implemented drivers
 
 Strip Size Configuration:
   Configure LED strip sizes for autoresearch testing via JSON-RPC:
@@ -258,12 +258,12 @@ See Also:
         driver_group.add_argument(
             "--lpuart",
             action="store_true",
-            help="Test only LPUART clockless driver (Teensy 4.x only; eDMA-backed UART TX; pin pinned to 1=LPUART6_TX by default, override with --tx-pin in {1,8,14,17,20,24,29,35,47,48})",
+            help="Reserved for the future Teensy 4.x LPUART clockless driver; currently unavailable and not included in --all",
         )
         driver_group.add_argument(
             "--all",
             action="store_true",
-            help="Test all drivers (equivalent to --parlio --rmt --spi --uart --lcd --lcd-spi --lcd-rgb --object-fled --flex-io --lpuart)",
+            help="Test all currently implemented drivers (Teensy 4.x: --object-fled --flex-io)",
         )
         driver_group.add_argument(
             "--simd",

--- a/ci/autoresearch/phases.py
+++ b/ci/autoresearch/phases.py
@@ -422,11 +422,17 @@ def _parse_args_and_build_commands(args: Args) -> RunContext | int:
         "teensy41",
     )
 
+    if args.lpuart:
+        print(
+            f"{Fore.RED}\u274c Error: --lpuart is reserved but not currently implemented. "
+            f"LPUART is not part of the active AutoResearch driver matrix; see #3157.{Style.RESET_ALL}"
+        )
+        return 1
+
     if args.all and is_teensy4:
         drivers = [
             "OBJECT_FLED",
             "FLEX_IO",
-            "LPUART",
         ]
     elif args.all:
         drivers = [
@@ -439,7 +445,6 @@ def _parse_args_and_build_commands(args: Args) -> RunContext | int:
             "LCD_RGB",
             "OBJECT_FLED",
             "FLEX_IO",
-            "LPUART",
         ]
     else:
         if args.parlio:
@@ -750,11 +755,6 @@ def _parse_args_and_build_commands(args: Args) -> RunContext | int:
         # and the manager silently falls back to ObjectFLED. Pin the FLEX_IO
         # tests to a known FlexIO2 pin so the engine actually runs.
         flex_io_tx_pin = 6
-        # LPUART on Teensy 4.x routes through {1, 8, 14, 17, 20, 24, 29, 35,
-        # 47, 48}. Pin LPUART tests to pin 1 (LPUART6_TX, Teensy 4's default
-        # Serial2 TX) so the engine accepts the request when --tx-pin is not
-        # supplied. Mirrors the FLEX_IO override above.
-        lpuart_tx_pin = 1
         for driver in drivers_list:
             for lane_count in range(lane_range["min"], lane_range["max"] + 1):
                 for strip_size in strip_sizes:
@@ -768,8 +768,6 @@ def _parse_args_and_build_commands(args: Args) -> RunContext | int:
                     }
                     if driver == "FLEX_IO" and args.tx_pin is None:
                         test_config["pinTx"] = flex_io_tx_pin
-                    if driver == "LPUART" and args.tx_pin is None:
-                        test_config["pinTx"] = lpuart_tx_pin
                     if args.legacy:
                         test_config["useLegacyApi"] = True
                     # Multi-frame capture: back-to-back show()/capture cycles per pattern.

--- a/ci/tests/test_autoresearch_phases.py
+++ b/ci/tests/test_autoresearch_phases.py
@@ -215,7 +215,6 @@ class TestParseArgsAndBuildCommands:
             "LCD_RGB",
             "OBJECT_FLED",
             "FLEX_IO",
-            "LPUART",
         }
 
     def test_all_drivers_teensy4_only_real_teensy_drivers(
@@ -229,11 +228,20 @@ class TestParseArgsAndBuildCommands:
         )
         result = _parse_args_and_build_commands(args)
         assert isinstance(result, RunContext)
-        assert result.drivers == ["OBJECT_FLED", "FLEX_IO", "LPUART"]
+        assert result.drivers == ["OBJECT_FLED", "FLEX_IO"]
         assert {cmd["method"] for cmd in result.json_rpc_commands} == {
             "runSingleTest"
         }
         assert not any("__skip_with_pass" in cmd for cmd in result.json_rpc_commands)
+
+    def test_lpuart_is_reserved_not_selectable(self, fake_project_dir: Path) -> None:
+        args = _make_args(
+            parlio=False,
+            lpuart=True,
+            project_dir=fake_project_dir,
+        )
+        result = _parse_args_and_build_commands(args)
+        assert result == 1
 
     def test_multiple_drivers(self, fake_project_dir: Path) -> None:
         args = _make_args(parlio=True, rmt=True, spi=True, project_dir=fake_project_dir)


### PR DESCRIPTION
﻿## Summary

Part of #3353.
Addresses #3352 by demoting LPUART from the active AutoResearch driver matrix.

LPUART currently has a reserved bus enum and interface scaffold, but no real Teensy channel engine/peripheral implementation in the active tree. Treating it as part of `--all` or accepting `--lpuart` makes AutoResearch look greener than the firmware really is.

Changes:
- Remove `LPUART` from Teensy `--all`.
- Remove `LPUART` from the generic `--all` list.
- Make explicit `--lpuart` fail fast with a clear reserved/unimplemented message pointing to #3157.
- Update parser tests so LPUART cannot drift back into the matrix silently.

## Verification

```bash
uv run --no-sync pytest ci/tests/test_autoresearch_phases.py::TestParseArgsAndBuildCommands::test_all_drivers ci/tests/test_autoresearch_phases.py::TestParseArgsAndBuildCommands::test_all_drivers_teensy4_only_real_teensy_drivers ci/tests/test_autoresearch_phases.py::TestParseArgsAndBuildCommands::test_lpuart_is_reserved_not_selectable
```

Result: 3 passed.

```bash
bash autoresearch teensy41 --lpuart --tx-pin 8 --rx-pin 9 --timeout 2m
```

Result: exits immediately with `--lpuart is reserved but not currently implemented`; no build/deploy or hardware test is attempted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Clarified command-line help for driver selection, including that one option is currently unavailable and reserved for future use.
  * Prevented the unavailable driver option from being used during runs; it now returns a clear error instead of proceeding.
  * Updated the automatic driver list so only currently implemented drivers are included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->