### PR TITLE
fix(autoresearch): stabilize ObjectFLED bring-up path

### DIFF
--- a/examples/AutoResearch/AutoResearch.ino
+++ b/examples/AutoResearch/AutoResearch.ino
@@ -319,69 +319,16 @@ using RemoteControlSingleton = fl::Singleton<AutoResearchRemoteControl>;
 uint32_t frame_counter = 0;
 
 
-#if defined(FL_IS_TEENSY_4X) && defined(__IMXRT1062__)
-// =============================================================================
-// CRITICAL: WDOG3 (RTWDOG) startup-early-hook recovery (FastLED#2731)
-// =============================================================================
-// The iMXRT1062 RTWDOG (WDOG3) is enabled by default at chip reset with
-// TOVAL = 0x400 LPO ticks ≈ 32 ms. The Teensy 4 core does NOT disable it in
-// startup.c — most sketches happen to be fast enough or stay in WAIT mode
-// where WDOG3 stops counting, so it never bites in practice.
-//
-// But if a previous run armed WDOG3 with a short timeout, or if any
-// peripheral init takes longer than 32 ms, the chip enters a reset loop
-// where the new sketch can't even complete USB enumeration. Symptom: red
-// LED double-blink + "Unknown USB Device (Device Descriptor Request Failed)".
-//
-// `startup_early_hook` is a weak symbol in Teensyduino's startup.c that runs
-// very early in ResetHandler2(), before main() and before ITCM is even
-// initialized. Overriding it here disables WDOG3 BEFORE any other code can
-// observe a reset. Must be in FLASHMEM (ITCM not ready yet).
-extern "C" FLASHMEM void startup_early_hook(void) {
-    // Enable the WDOG3 clock gate (CCM_CCGR5 bits 4-5) so the WDOG3
-    // peripheral registers are addressable. Per imxrt.h comment:
-    // "WDOG3 requires CCM_CCGR5_WDOG3".
-    CCM_CCGR5 |= CCM_CCGR5_WDOG3(3);
-    // Ensure the CCM store is visible to the peripheral bus before
-    // touching WDOG3.
-    __asm__ volatile ("dsb" ::: "memory");
-    __asm__ volatile ("isb" ::: "memory");
-
-    // Unlock RTWDOG with the 32-bit key (works because CS.CMD32EN=1 at reset).
-    WDOG3_CNT = 0xD928C520u;
-
-    // Wait for the unlock window to open. Bounded spin — if for any reason
-    // the unlock never lands, we'd rather continue and let the WDOG bite
-    // than hang here forever.
-    {
-        volatile uint32_t spin = 0;
-        while (!(WDOG3_CS & WDOG_CS_ULK)) {
-            if (++spin > 200000u) break;
-        }
-    }
-
-    // Disable: clear EN, keep CMD32EN+UPDATE+CLK(LPO) so future arms work.
-    // Set TOVAL to max so even if the disable doesn't take, we have ~524 sec
-    // before any reset can occur.
-    WDOG3_TOVAL = 0xFFFFu;
-    WDOG3_WIN = 0;
-    WDOG3_CS = WDOG_CS_CMD32EN | WDOG_CS_UPDATE | WDOG_CS_CLK(1);  // EN=0
-
-    // Wait for reconfigure complete (bounded).
-    {
-        volatile uint32_t spin = 0;
-        while (!(WDOG3_CS & WDOG_CS_RCS)) {
-            if (++spin > 200000u) break;
-        }
-    }
-}
-#endif
+// Teensy 4 WDOG3 startup recovery lives in AutoResearchStartupHook.cpp.
+// Keeping the extern "C" hook out of this .ino avoids Arduino prototype
+// generation with C++ linkage during fbuild deploy.
 
 void setup() {
     // Initialize serial buffers with platform-specific configuration
     // Must be called BEFORE Serial.begin()
     init_serial_buffers();
     fl::serial_begin(115200);
+    fl::setLogLevel(static_cast<fl::u8>(fl::LogLevel::FL_LOG_LEVEL_NONE));
 #if defined(ARDUINO_USB_CDC_ON_BOOT) && ARDUINO_USB_CDC_ON_BOOT
     // Make HWCDC writes drop instead of block when no host is reading.
     // Without this, Serial.print() on ESP32-C3/C6/H2 can stall up to ~2s

--- a/examples/AutoResearch/AutoResearchRemote.cpp
+++ b/examples/AutoResearch/AutoResearchRemote.cpp
@@ -38,6 +38,7 @@
 #include "fl/stl/json.h"
 #include "fl/task/task.h"
 #include "fl/task/executor.h"
+#include <Arduino.h>
 #include "fl/math/wave/wave_perf_bench.h"
 #include "fl/stl/atomic.h"
 #include "fl/task/promise.h"
@@ -68,9 +69,19 @@
 void printJsonRaw(const fl::json& json, const char* prefix) {
     // Serialize and print response
     fl::string formatted = fl::formatJsonResponse(json, prefix);
-    fl::println(formatted.c_str());
-    fl::flush();
+    Serial.println(formatted.c_str());  // ok serial - RPC response bypasses FastLED log gate
+    Serial.flush();                     // ok serial - ensure host sees RPC boundary promptly
 }
+
+namespace {
+
+void printRemoteResponseRaw(const fl::json& response) {
+    fl::string formatted = fl::formatJsonResponse(response, "REMOTE: ");
+    Serial.println(formatted.c_str());  // ok serial - RPC response bypasses FastLED log gate
+    Serial.flush();                     // ok serial - host waits for RPC response boundary
+}
+
+}  // namespace
 
 void printStreamRaw(const char* messageType, const fl::json& data) {
     // Build pure JSONL message: RESULT: {"type":"...", ...data}
@@ -87,7 +98,7 @@ void printStreamRaw(const char* messageType, const fl::json& data) {
 
     // Use fl:: serial transport for consistent formatting
     fl::string formatted = fl::formatJsonResponse(output, "RESULT: ");
-    fl::println(formatted.c_str());
+    Serial.println(formatted.c_str());  // ok serial - stream response bypasses FastLED log gate
 }
 
 // ============================================================================
@@ -273,7 +284,7 @@ fl::json AutoResearchRemoteControl::findConnectedPinsImpl(const fl::json& args) 
 AutoResearchRemoteControl::AutoResearchRemoteControl()
     : mRemote(fl::make_unique<fl::Remote>(
         fl::createSerialRequestSource(),
-        fl::createSerialResponseSink("REMOTE: ")
+        printRemoteResponseRaw
     )) {
     // mState will be set by registerFunctions()
 }

--- a/examples/AutoResearch/AutoResearchRemotePinMethods.cpp
+++ b/examples/AutoResearch/AutoResearchRemotePinMethods.cpp
@@ -46,6 +46,7 @@
 
 #include "fl/codec/h264.h"
 #include "fl/codec/mp4_parser.h"
+#include "fl/stl/cstdio.h"
 #include "fl/stl/detail/memory_file_handle.h"
 #include "fl/fx/frame.h"
 
@@ -72,6 +73,9 @@ void AutoResearchRemoteControl::bindPinMethods(fl::Remote& remote) {
 
         bool enabled = args[0].as_bool().value();
         mState->debug_enabled = enabled;
+        fl::setLogLevel(static_cast<fl::u8>(
+            enabled ? fl::LogLevel::FL_LOG_LEVEL_DEBUG
+                    : fl::LogLevel::FL_LOG_LEVEL_NONE));
 
         response.set("success", true);
         response.set("debug_enabled", enabled);

--- a/examples/AutoResearch/AutoResearchRemoteRunSingleTest.cpp
+++ b/examples/AutoResearch/AutoResearchRemoteRunSingleTest.cpp
@@ -24,6 +24,7 @@
 #include "fl/stl/unique_ptr.h"
 #include "fl/stl/optional.h"
 #include "fl/stl/json.h"
+#include "fl/stl/cstdio.h"
 #include "fl/task/task.h"
 #include "fl/task/executor.h"
 #include "fl/math/wave/wave_perf_bench.h"
@@ -567,9 +568,11 @@ fl::json AutoResearchRemoteControl::runSingleTestImpl(const fl::json& args) {
     bool tight_timing_passed = true;
 
     {
-        // Note: ScopedLogDisable removed to enable diagnostic output during test execution.
-        // This allows capture/decode debug messages (e.g., RX timing, edge dumps) to appear
-        // on serial, which is critical for diagnosing PARLIO failures at different LED counts.
+        // Keep timing-sensitive hardware validation quiet. On Teensy 4,
+        // Serial-backed FL_WARN output can block long enough to starve
+        // ObjectFLED's DMA refill path, which is exactly what #3343 is
+        // trying to prove or eliminate. JSON-RPC responses bypass this guard.
+        fl::ScopedLogDisable quiet_logs;
 
         if (use_legacy_api) {
             // Legacy API path: WS2812B<PIN> template instantiation
@@ -655,6 +658,8 @@ fl::json AutoResearchRemoteControl::runSingleTestImpl(const fl::json& args) {
             pat.set("runNumber", static_cast<int64_t>(rr.run_number));
             pat.set("totalLeds", static_cast<int64_t>(rr.total_leds));
             pat.set("mismatchedLeds", static_cast<int64_t>(rr.mismatches));
+            pat.set("capturedBytes", static_cast<int64_t>(rr.capturedBytes));
+            pat.set("captureFailed", rr.captureFailed);
             pat.set("mismatchedBytes", static_cast<int64_t>(rr.mismatchedBytes));
             pat.set("lsbOnlyErrors", static_cast<int64_t>(rr.lsbOnlyErrors));
 

--- a/examples/AutoResearch/AutoResearchStartupHook.cpp
+++ b/examples/AutoResearch/AutoResearchStartupHook.cpp
@@ -1,0 +1,45 @@
+#include "fl/system/sketch_macros.h"
+
+#if defined(FL_IS_TEENSY_4X) && defined(__IMXRT1062__)
+
+#include <Arduino.h>
+
+// Disable the iMXRT1062 RTWDOG before the Arduino runtime starts.
+//
+// WDOG3 can already be armed when this sketch boots, and a short prior timeout
+// can reset the chip before USB enumeration or setup() runs. Teensyduino exposes
+// startup_early_hook as a weak symbol specifically for this kind of early reset
+// recovery. Keep the override in this .cpp file: Arduino prototype generation
+// can give .ino prototypes C++ linkage, which conflicts with the C-linkage weak
+// symbol and breaks fbuild deploy.
+extern "C" FLASHMEM void startup_early_hook(void) {
+    CCM_CCGR5 |= CCM_CCGR5_WDOG3(3);
+    __asm__ volatile ("dsb" ::: "memory");
+    __asm__ volatile ("isb" ::: "memory");
+
+    WDOG3_CNT = 0xD928C520u;
+
+    {
+        volatile uint32_t spin = 0;
+        while (!(WDOG3_CS & WDOG_CS_ULK)) {
+            if (++spin > 200000u) {
+                break;
+            }
+        }
+    }
+
+    WDOG3_TOVAL = 0xFFFFu;
+    WDOG3_WIN = 0;
+    WDOG3_CS = WDOG_CS_CMD32EN | WDOG_CS_UPDATE | WDOG_CS_CLK(1);
+
+    {
+        volatile uint32_t spin = 0;
+        while (!(WDOG3_CS & WDOG_CS_RCS)) {
+            if (++spin > 200000u) {
+                break;
+            }
+        }
+    }
+}
+
+#endif

--- a/examples/AutoResearch/AutoResearchTest.cpp
+++ b/examples/AutoResearch/AutoResearchTest.cpp
@@ -813,9 +813,13 @@ void runMultiTest(const char* test_name,
 
             // Capture RX data
             size_t bytes_captured = capture(config.rx_channel, config.rx_buffer, config.timing, config.driver_name);
+            result.capturedBytes = static_cast<int>(bytes_captured);
 
             if (bytes_captured == 0) {
                 FL_WARN("[Run " << run << "] Capture failed");
+                result.mismatches = static_cast<int>(num_leds);
+                result.mismatchedBytes = static_cast<int>(result.totalBytes);
+                result.captureFailed = true;
                 result.passed = false;
                 break;
             }

--- a/examples/AutoResearch/AutoResearchTest.h
+++ b/examples/AutoResearch/AutoResearchTest.h
@@ -78,14 +78,16 @@ struct RunResult {
     int total_leds;                 ///< Total LEDs tested
     int mismatches;                 ///< Number of LED mismatches
     int totalBytes;                 ///< Total bytes compared (num_leds * 3)
+    int capturedBytes;              ///< Bytes decoded from the RX channel
     int mismatchedBytes;            ///< Number of individual bytes that differ
     int lsbOnlyErrors;              ///< Bytes where (expected ^ actual) == 0x01
     fl::vector<LEDError> errors;    ///< First few errors (up to 10)
+    bool captureFailed;             ///< True when RX produced no decodable bytes
     bool passed;                    ///< True if no errors
 
     RunResult() : run_number(0), total_leds(0), mismatches(0),
-                  totalBytes(0), mismatchedBytes(0), lsbOnlyErrors(0),
-                  passed(false) {}
+                  totalBytes(0), capturedBytes(0), mismatchedBytes(0),
+                  lsbOnlyErrors(0), captureFailed(false), passed(false) {}
 };
 
 /// @brief Multi-run test configuration

--- a/src/third_party/object_fled/src/ObjectFLED.h
+++ b/src/third_party/object_fled/src/ObjectFLED.h
@@ -58,7 +58,9 @@
 // smaller than the half the Cortex-M7 data cache.
 //bitdata[B_P_D * 64]		buffer holds data (10KB) for 80 LED bytes: 4DW * 8b = 32DW/LEDB = 96DW/LED
 //framebuffer_index = B_P_D * 2 = pointer to next block for transfer (80 LEDB / bitdata buffer)
-#define BYTES_PER_DMA	20		//= number of pairs of LEDB (40=80B) bitmasks in bitdata.
+#ifndef BYTES_PER_DMA
+#define BYTES_PER_DMA	60		//= number of pairs of LEDB (120=240B) bitmasks in bitdata.
+#endif
 
 #define CORDER_RGB	0	//* WS2811, YF923
 #define CORDER_RBG	1

--- a/src/third_party/object_fled/src/ObjectFLEDDmaManager.h
+++ b/src/third_party/object_fled/src/ObjectFLEDDmaManager.h
@@ -11,7 +11,7 @@ namespace fl {
 
 // Forward declarations
 #ifndef BYTES_PER_DMA
-#define BYTES_PER_DMA 20
+#define BYTES_PER_DMA 60
 #endif
 
 /// Singleton manager for shared ObjectFLED DMA resources

--- a/src/third_party/object_fled/src/OjectFLED.cpp.hpp
+++ b/src/third_party/object_fled/src/OjectFLED.cpp.hpp
@@ -710,7 +710,8 @@ void drawSquare(void* leds, uint16_t planeY, uint16_t planeX, int yCorner, int x
 ObjectFLED::~ObjectFLED() {
 	// Wait for prior xmission to end, don't need to wait for latch time before deleting buffer
 	while (micros() - update_begin_micros < numbytesLocal * 8 * TH_TL / 1000 + 5);
-	delete frameBufferLocal;
+	waitForDmaToFinish();
+	delete[] frameBufferLocal;
 }
 
 void ObjectFLED::waitForDmaToFinish() {


### PR DESCRIPTION
﻿## Summary

Part of #3353.

Stabilizes the ObjectFLED AutoResearch path before the next valid-RX hardware pass.

Changes:
- Increase ObjectFLED DMA chunk size to 60 and make both ObjectFLED headers agree regardless of include order.
- Wait for ObjectFLED DMA completion before destruction and use `delete[]` for the frame buffer allocated with `new[]`.
- Keep AutoResearch hardware validation quiet with `ScopedLogDisable` while sending JSON-RPC responses through raw `Serial`, so response framing survives log suppression.
- Move the Teensy 4 `startup_early_hook` into a `.cpp` file to avoid Arduino prototype/linkage issues during fbuild deploy.
- Add captured-byte and zero-capture fields to RPC results so ObjectFLED failures distinguish "bad bytes" from "no RX capture" without FL_WARN spam.

## Verification

```bash
bash autoresearch teensy41 --object-fled --tx-pin 8 --rx-pin 9 --strip-sizes 1 --timeout 2m
```

Result:
- C++ lint passed.
- fbuild deploy succeeded.
- GPIO pretest passed for current physical `8 -> 9` jumper.
- Run stopped honestly at `setPins` with `RxChannelCreationFailed` because RX pin 9 is not supported by the current capture backend.

Final ObjectFLED pass still requires rewiring to a supported RX capture pin, expected `GPIO 8 -> GPIO 22` per #3353/#3355.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved AutoResearch run reporting with additional capture details, including captured bytes and capture-failure status.
  * Added early startup recovery support for Teensy 4 boards.

* **Bug Fixes**
  * Improved stability around hardware capture and DMA handling.
  * Fixed memory cleanup for frame buffers and made shutdown wait for DMA transfers to complete safely.
  * Expanded failure diagnostics when a capture does not complete as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->