### PR TITLE
[codex] Harden Teensy AutoResearch guardrails

### DIFF
--- a/agents/docs/hardware-autoresearch.md
+++ b/agents/docs/hardware-autoresearch.md
@@ -70,7 +70,7 @@ Board selection happens in this order:
 3. `--lcd` / `--lcd-spi` / `--lcd-rgb` — implies `esp32s3` / `esp32p4`; synthesised immediately.
 4. Auto-detect from attached USB device — synthesis deferred until after `detect_attached_chip()`.
 
-**Legacy escape hatch (deprecated):** `--use-root-platformio-ini` re-enables the old behavior of reading root `./platformio.ini` instead of synthesising. Emits a deprecation warning when used; slated for removal one release cycle after #3281. Use only if you have local edits to root `./platformio.ini` that the synthesised file misses — in which case the correct fix is to move those edits into `ci/boards.py`.
+**Legacy escape hatch (deprecated):** `--use-root-platformio-ini` re-enables the old behavior of reading root `./platformio.ini` instead of synthesising. It is not allowed for Teensy AutoResearch acceptance or any ObjectFLED/FlexIO bring-up run. Use only for non-Teensy diagnostic comparisons when you have local edits to root `./platformio.ini` that the synthesised file misses — in which case the correct fix is to move those edits into `ci/boards.py`.
 
 ```bash
 # Default (synthesised):
@@ -78,6 +78,12 @@ bash autoresearch esp32c6 --parlio
 
 # Legacy (consumes root ./platformio.ini, deprecated):
 bash autoresearch esp32c6 --parlio --use-root-platformio-ini
+```
+
+For Teensy 4.x validation, always use the synthesised fbuild path:
+
+```bash
+bash autoresearch teensy41 --object-fled --tx-pin 8 --rx-pin 9 --timeout 120
 ```
 
 ### Strip Size Configuration
@@ -357,13 +363,7 @@ fl::RxChannelConfig cfg(rx_pin, fl::RxBackend::FLEXIO);
 auto rx = fl::RxChannel::create(cfg);
 ```
 
-```python
-# Python — call the dedicated RPCs from any harness with pyserial open
-send_rpc(s, "flexioRxBenchmark",
-         {"frequency_hz": 100000, "duration_ms": 100, "tx_pin": 3, "rx_pin": 4})
-send_rpc(s, "flexioObjectFledTest",
-         {"test_case": 4, "tx_pin": 3, "rx_pin": 4, "capture_ms": 50})
-```
+Raw pyserial RPC scripts are diagnostics only. They are not acceptance criteria for Teensy ObjectFLED/FlexIO bring-up, and they must not be open while `bash autoresearch` owns the port.
 
 ### Pin support
 
@@ -389,8 +389,8 @@ Adding a pin: append a row mapping its Teensy digital number to its FLEXIO1 inpu
 
 ### Verification
 
-- **`flexioRxBenchmark`** — RPC that drives a square wave via `analogWriteFrequency` and reports per-period mean / σ / min / max nanoseconds. Phase 2 acceptance: σ < 1 µs at 1 kHz, < 500 ns at 10 kHz, < 100 ns at 100 kHz; mean within ±1 % of expected period. See `ci/autoresearch/test_flexio_rx_squarewave.py`.
-- **`flexioObjectFledTest`** — RPC that drives a WS2812 pattern via `Bus::OBJECT_FLED` and decodes the captured edge stream against `TIMING_WS2812B_V5`. Five fixed patterns: red single LED, RGB chain, all zeros, all ones, 100-LED alternating R/G/B. Acceptance: byte-for-byte match against the transmitted CRGB array. See `ci/autoresearch/test_flexio_rx_objectfled.py`.
+- **`flexioRxBenchmark`** — diagnostic RPC that drives a square wave via `analogWriteFrequency` and reports per-period mean / sigma / min / max nanoseconds. The raw script is useful for investigation only; acceptance must be routed through canonical `bash autoresearch`.
+- **`flexioObjectFledTest`** — diagnostic RPC that drives a WS2812 pattern via `Bus::OBJECT_FLED` and decodes the captured edge stream against `TIMING_WS2812B_V5`. The raw `ci/autoresearch/test_flexio_rx_objectfled.py` script is not an acceptance path; use it only when deliberately debugging outside a canonical run, and close it before `bash autoresearch`.
 
 `RxBackend::PLATFORM_DEFAULT` switching from FlexPWM to FlexIO on Teensy 4 is intentionally **deferred** to a follow-up PR — keeps the bench-validation surface small and the existing FlexPWM-based AutoResearch flows untouched until both backends are equally exercised.
 

--- a/ci/autoresearch/phases.py
+++ b/ci/autoresearch/phases.py
@@ -363,6 +363,21 @@ def _try_teensy_bootloader_upload(build_dir: Path, environment: str | None) -> b
 # ============================================================
 
 
+def _is_teensy_environment(environment: str | None) -> bool:
+    return environment is not None and environment.lower() in ("teensy40", "teensy41")
+
+
+def _reject_teensy_root_platformio_ini(environment: str | None) -> bool:
+    if not _is_teensy_environment(environment):
+        return False
+    print(
+        f"{Fore.RED}❌ Error: --use-root-platformio-ini is not allowed for "
+        f"Teensy AutoResearch acceptance. Use the synthesized fbuild project "
+        f"from ci/boards.py instead.{Style.RESET_ALL}"
+    )
+    return True
+
+
 def _parse_args_and_build_commands(args: Args) -> RunContext | int:
     """Parse CLI args, validate modes, build JSON-RPC command list.
 
@@ -421,6 +436,15 @@ def _parse_args_and_build_commands(args: Args) -> RunContext | int:
         "teensy40",
         "teensy41",
     )
+    is_teensy_specific_driver = args.object_fled or args.flex_io or args.lpuart
+
+    if args.use_root_platformio_ini and (is_teensy4 or is_teensy_specific_driver):
+        print(
+            f"{Fore.RED}❌ Error: --use-root-platformio-ini is not allowed for "
+            f"Teensy AutoResearch acceptance. Use the synthesized fbuild project "
+            f"from ci/boards.py instead.{Style.RESET_ALL}"
+        )
+        return 1
 
     if args.lpuart:
         print(
@@ -1123,6 +1147,11 @@ async def _resolve_port_and_environment(ctx: RunContext) -> int | None:
                 )
                 return 1
         print()
+
+    if args.use_root_platformio_ini and _reject_teensy_root_platformio_ini(
+        ctx.final_environment
+    ):
+        return 1
 
     # Deferred synthesis (#3281). When --use-root-platformio-ini is NOT set
     # and the board wasn't known at parse time, the build_dir is still pointing

--- a/ci/tests/test_autoresearch_phases.py
+++ b/ci/tests/test_autoresearch_phases.py
@@ -225,8 +225,13 @@ class TestParseArgsAndBuildCommands:
             parlio=False,
             environment_positional="teensy40",
             project_dir=fake_project_dir,
+            use_root_platformio_ini=False,
         )
-        result = _parse_args_and_build_commands(args)
+        with patch(
+            "ci.autoresearch.staging.synthesise_autoresearch_project",
+            return_value=fake_project_dir,
+        ):
+            result = _parse_args_and_build_commands(args)
         assert isinstance(result, RunContext)
         assert result.drivers == ["OBJECT_FLED", "FLEX_IO"]
         assert {cmd["method"] for cmd in result.json_rpc_commands} == {
@@ -475,6 +480,31 @@ class TestParseArgsAndBuildCommands:
         assert isinstance(result, int)
         assert result == 1
 
+    def test_teensy_root_platformio_ini_rejected_up_front(
+        self, fake_project_dir: Path
+    ) -> None:
+        args = _make_args(
+            environment_positional="teensy41",
+            object_fled=True,
+            parlio=False,
+            project_dir=fake_project_dir,
+            use_root_platformio_ini=True,
+        )
+        result = _parse_args_and_build_commands(args)
+        assert result == 1
+
+    def test_teensy_specific_driver_rejects_root_platformio_without_env(
+        self, fake_project_dir: Path
+    ) -> None:
+        args = _make_args(
+            object_fled=True,
+            parlio=False,
+            project_dir=fake_project_dir,
+            use_root_platformio_ini=True,
+        )
+        result = _parse_args_and_build_commands(args)
+        assert result == 1
+
     def test_timeout_parsing(self, fake_project_dir: Path) -> None:
         args = _make_args(timeout="2m", project_dir=fake_project_dir)
         result = _parse_args_and_build_commands(args)
@@ -540,6 +570,32 @@ class TestResolvePortAndEnvironment:
         assert rc is None
         assert ctx.upload_port == "COM9"
         auto_detect.assert_called_once_with(expected_environment="esp32c6")
+
+    def test_teensy_auto_detect_rejects_root_platformio_ini(self) -> None:
+        ctx = _make_ctx(upload_port=None, final_environment=None)
+        ctx.args = _make_args(
+            upload_port=None,
+            parlio=False,
+            all=True,
+            use_root_platformio_ini=True,
+        )
+        mock_port_result = MagicMock(ok=True, selected_port="COM8")
+        mock_chip_result = MagicMock(
+            ok=True, chip_type="Teensy 4.1", environment="teensy41"
+        )
+        with (
+            patch(
+                f"{_PATCH_MOD}.auto_detect_upload_port",
+                return_value=mock_port_result,
+            ),
+            patch(
+                f"{_PATCH_MOD}.detect_attached_chip",
+                return_value=mock_chip_result,
+            ),
+        ):
+            rc = asyncio.run(_resolve_port_and_environment(ctx))
+        assert rc == 1
+        assert ctx.final_environment == "teensy41"
 
     def test_cli_upload_port(self) -> None:
         ctx = _make_ctx(upload_port=None)


### PR DESCRIPTION
## Summary

- Reject `--use-root-platformio-ini` for Teensy/ObjectFLED/FlexIO AutoResearch acceptance paths.
- Keep raw pyserial FlexIO/ObjectFLED scripts documented as diagnostics only, not acceptance.
- Add tests for the root-PlatformIO guardrail, including explicit Teensy and auto-detected Teensy cases.

## Validation

- `uv run --no-sync pytest ci/tests/test_autoresearch_phases.py -q`

Targets #3359 S0/S1 guardrails.