### PR TITLE
[codex] Wire AutoResearch capture diagnostics

### DIFF
--- a/examples/AutoResearch/AutoResearchRemoteRunSingleTest.cpp
+++ b/examples/AutoResearch/AutoResearchRemoteRunSingleTest.cpp
@@ -659,6 +659,8 @@ fl::json AutoResearchRemoteControl::runSingleTestImpl(const fl::json& args) {
             pat.set("totalLeds", static_cast<int64_t>(rr.total_leds));
             pat.set("mismatchedLeds", static_cast<int64_t>(rr.mismatches));
             pat.set("capturedBytes", static_cast<int64_t>(rr.capturedBytes));
+            pat.set("captureWaitResult", static_cast<int64_t>(rr.captureWaitResult));
+            pat.set("rawEdgesAfterWait", static_cast<int64_t>(rr.rawEdgesAfterWait));
             pat.set("captureFailed", rr.captureFailed);
             pat.set("mismatchedBytes", static_cast<int64_t>(rr.mismatchedBytes));
             pat.set("lsbOnlyErrors", static_cast<int64_t>(rr.lsbOnlyErrors));

--- a/examples/AutoResearch/AutoResearchTest.cpp
+++ b/examples/AutoResearch/AutoResearchTest.cpp
@@ -330,7 +330,16 @@ static size_t decodeSpiEdges(fl::shared_ptr<fl::RxChannel> rx_channel,
 // - timing: Chipset timing configuration for RX decoder
 // - driver_name: Name of the TX driver being tested (e.g., "RMT", "PARLIO") - enables io_loop_back only for RMT
 // Returns number of bytes captured, or 0 on error
-size_t capture(fl::shared_ptr<fl::RxChannel> rx_channel, fl::span<uint8_t> rx_buffer, const fl::ChipsetTimingConfig& timing, const char* driver_name) {
+size_t capture(fl::shared_ptr<fl::RxChannel> rx_channel,
+               fl::span<uint8_t> rx_buffer,
+               const fl::ChipsetTimingConfig& timing,
+               const char* driver_name,
+               fl::RunResult* diagnostics) {
+    if (diagnostics) {
+        diagnostics->captureWaitResult = -1;
+        diagnostics->rawEdgesAfterWait = 0;
+    }
+
     if (!rx_channel) {
         FL_ERROR("RX channel is null");
         return 0;
@@ -428,6 +437,12 @@ size_t capture(fl::shared_ptr<fl::RxChannel> rx_channel, fl::span<uint8_t> rx_bu
     const uint32_t rx_wait_ms = is_uart_driver ? 500 : 150;
     FL_WARN("[CAPTURE] Waiting for RX completion (" << rx_wait_ms << "ms timeout)...");
     auto wait_result = rx_channel->wait(rx_wait_ms);
+    if (diagnostics) {
+        diagnostics->captureWaitResult = static_cast<int>(wait_result);
+        fl::FixedVector<fl::EdgeTime, 256> edges;
+        edges.resize(256);
+        diagnostics->rawEdgesAfterWait = static_cast<int>(rx_channel->getRawEdgeTimes(edges, 0));
+    }
     FL_WARN("[CAPTURE] RX wait returned: " << static_cast<int>(wait_result));
 
     if (wait_result != fl::RxWaitResult::SUCCESS) {
@@ -812,7 +827,7 @@ void runMultiTest(const char* test_name,
             result.totalBytes = num_leds * 3;
 
             // Capture RX data
-            size_t bytes_captured = capture(config.rx_channel, config.rx_buffer, config.timing, config.driver_name);
+            size_t bytes_captured = capture(config.rx_channel, config.rx_buffer, config.timing, config.driver_name, &result);
             result.capturedBytes = static_cast<int>(bytes_captured);
 
             if (bytes_captured == 0) {

--- a/examples/AutoResearch/AutoResearchTest.h
+++ b/examples/AutoResearch/AutoResearchTest.h
@@ -79,6 +79,8 @@ struct RunResult {
     int mismatches;                 ///< Number of LED mismatches
     int totalBytes;                 ///< Total bytes compared (num_leds * 3)
     int capturedBytes;              ///< Bytes decoded from the RX channel
+    int captureWaitResult;          ///< RxWaitResult value, or -1 before wait
+    int rawEdgesAfterWait;          ///< Raw edges visible after RX wait/decode
     int mismatchedBytes;            ///< Number of individual bytes that differ
     int lsbOnlyErrors;              ///< Bytes where (expected ^ actual) == 0x01
     fl::vector<LEDError> errors;    ///< First few errors (up to 10)
@@ -86,8 +88,9 @@ struct RunResult {
     bool passed;                    ///< True if no errors
 
     RunResult() : run_number(0), total_leds(0), mismatches(0),
-                  totalBytes(0), capturedBytes(0), mismatchedBytes(0),
-                  lsbOnlyErrors(0), captureFailed(false), passed(false) {}
+                  totalBytes(0), capturedBytes(0), captureWaitResult(-1),
+                  rawEdgesAfterWait(0), mismatchedBytes(0), lsbOnlyErrors(0),
+                  captureFailed(false), passed(false) {}
 };
 
 /// @brief Multi-run test configuration
@@ -114,7 +117,11 @@ struct MultiRunConfig {
 // - timing: Chipset timing configuration for RX decoder
 // - driver_name: Name of the TX driver being tested (e.g., "RMT", "PARLIO") - enables io_loop_back only for RMT
 // Returns number of bytes captured, or 0 on error
-size_t capture(fl::shared_ptr<fl::RxChannel> rx_channel, fl::span<uint8_t> rx_buffer, const fl::ChipsetTimingConfig& timing, const char* driver_name);
+size_t capture(fl::shared_ptr<fl::RxChannel> rx_channel,
+               fl::span<uint8_t> rx_buffer,
+               const fl::ChipsetTimingConfig& timing,
+               const char* driver_name,
+               fl::RunResult* diagnostics = nullptr);
 
 // Generic driver-agnostic autoresearch test runner (single run)
 // Tests all channels using the specified configuration


### PR DESCRIPTION
﻿## Summary

- Complete the AutoResearch `capture()` diagnostics signature so the Teensy build no longer sees an overload mismatch.
- Record RX wait result and raw edge count into `RunResult`.
- Include those fields in failed-pattern JSON-RPC details so hardware evidence does not require extra direct serial logging.

## Validation

- `git diff --check -- examples/AutoResearch/AutoResearchTest.h examples/AutoResearch/AutoResearchTest.cpp examples/AutoResearch/AutoResearchRemoteRunSingleTest.cpp`
- `bash autoresearch teensy41 --object-fled --tx-pin 22 --rx-pin 8 --timeout 120`

AutoResearch result: build/lint/deploy succeeded through fbuild on `teensy41 @ COM20`; GPIO pre-test passed for `TX 22 -> RX 8`; ObjectFLED failed with zero captured/decoded bytes, which is the next driver bug to investigate.
