### PR TITLE
[codex] Harden AutoResearch test RPC acceptance

### DIFF
--- a/ci/autoresearch/phases.py
+++ b/ci/autoresearch/phases.py
@@ -2452,6 +2452,98 @@ async def _run_coroutine_tests(ctx: RunContext) -> int:
             await client.close()
 
 
+_TEST_RPC_METHODS = frozenset({"runSingleTest", "runParallelTest"})
+
+
+def _is_plain_int(value: Any) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def _expected_test_drivers(method: str, cmd: dict[str, Any]) -> list[str]:
+    params = cmd.get("params")
+    if not isinstance(params, dict):
+        return []
+
+    if method == "runSingleTest":
+        driver = params.get("driver")
+        return [driver] if isinstance(driver, str) and driver else []
+
+    if method == "runParallelTest":
+        drivers = params.get("drivers")
+        if not isinstance(drivers, list):
+            return []
+        expected: list[str] = []
+        for entry in drivers:
+            if isinstance(entry, dict):
+                driver = entry.get("driver")
+                if isinstance(driver, str) and driver:
+                    expected.append(driver)
+        return expected
+
+    return []
+
+
+def _actual_test_drivers(method: str, data: dict[str, Any]) -> list[str]:
+    if method == "runSingleTest":
+        driver = data.get("driver")
+        return [driver] if isinstance(driver, str) and driver else []
+
+    if method == "runParallelTest":
+        drivers = data.get("drivers")
+        if not isinstance(drivers, list):
+            return []
+        actual: list[str] = []
+        for entry in drivers:
+            if isinstance(entry, dict):
+                driver = entry.get("driver")
+                if isinstance(driver, str) and driver:
+                    actual.append(driver)
+        return actual
+
+    return []
+
+
+def _validate_test_rpc_response(
+    method: str, cmd: dict[str, Any], data: dict[str, Any]
+) -> list[str]:
+    """Return validation errors that prevent a test RPC from proving PASS."""
+    errors: list[str] = []
+
+    if not isinstance(data.get("success"), bool):
+        errors.append("missing boolean success")
+    if not isinstance(data.get("passed"), bool):
+        errors.append("missing boolean passed")
+
+    total_tests = data.get("totalTests")
+    passed_tests = data.get("passedTests")
+    if not _is_plain_int(total_tests):
+        errors.append("missing integer totalTests")
+    elif total_tests <= 0:
+        errors.append("totalTests must be > 0")
+
+    if not _is_plain_int(passed_tests):
+        errors.append("missing integer passedTests")
+    elif _is_plain_int(total_tests):
+        if passed_tests < 0:
+            errors.append("passedTests must be >= 0")
+        if passed_tests > total_tests:
+            errors.append("passedTests must be <= totalTests")
+        if data.get("passed") is True and passed_tests != total_tests:
+            errors.append("passed=true requires passedTests == totalTests")
+
+    expected_drivers = _expected_test_drivers(method, cmd)
+    actual_drivers = _actual_test_drivers(method, data)
+    if not actual_drivers:
+        field = "driver" if method == "runSingleTest" else "drivers"
+        errors.append(f"missing selected {field}")
+    else:
+        for driver in expected_drivers:
+            if driver not in actual_drivers:
+                errors.append(f"missing expected driver {driver}")
+
+    return errors
+
+
 async def _run_rpc_tests(ctx: RunContext, qctx: QuietContext) -> int:
     """Execute main RPC test loop."""
     upload_port = ctx.upload_port
@@ -2505,6 +2597,7 @@ async def _run_rpc_tests(ctx: RunContext, qctx: QuietContext) -> int:
                 "setLaneSizes",
                 "setSolidColor",
             }
+            test_method = method in _TEST_RPC_METHODS
 
             print(f"\n[{i}/{len(json_rpc_commands)}] Calling {method}()...")
 
@@ -2531,6 +2624,10 @@ async def _run_rpc_tests(ctx: RunContext, qctx: QuietContext) -> int:
                         f"{Fore.YELLOW}\u26a0\ufe0f  Unexpected response type: {type(test_data)}{Style.RESET_ALL}"
                     )
                     print(f"   Response: {test_data}")
+                    if test_method:
+                        test_failed = True
+                        stop_word_found = "ERROR"
+                        break
                     continue
 
                 _driver = test_data.get("driver", method)
@@ -2548,6 +2645,18 @@ async def _run_rpc_tests(ctx: RunContext, qctx: QuietContext) -> int:
                         print(f"   Message: {test_data['message']}")
                     if setup_method:
                         break
+
+                elif test_method and (
+                    validation_errors := _validate_test_rpc_response(
+                        method, cmd, test_data
+                    )
+                ):
+                    stop_word_found = "ERROR"
+                    test_failed = True
+                    print(f"{Fore.RED}\u274c Malformed test response{Style.RESET_ALL}")
+                    for error in validation_errors:
+                        print(f"   - {error}")
+                    break
 
                 elif test_data.get("success") and test_data.get("passed"):
                     stop_word_found = "OK"
@@ -2618,10 +2727,11 @@ async def _run_rpc_tests(ctx: RunContext, qctx: QuietContext) -> int:
                         display_pattern_details(test_data)
 
                 else:
-                    stop_word_found = "OK"
                     print(f"{Fore.GREEN}\u2713 Command completed{Style.RESET_ALL}")
                     if test_data:
                         print(f"   Response: {test_data}")
+                    if not setup_method:
+                        stop_word_found = "OK"
 
             except RpcCrashError as crash_err:
                 print(

--- a/ci/tests/test_autoresearch_rpc_acceptance.py
+++ b/ci/tests/test_autoresearch_rpc_acceptance.py
@@ -1,0 +1,194 @@
+"""Host-side AutoResearch RPC acceptance validation tests."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from ci.autoresearch.context import QuietContext, RunContext
+from ci.autoresearch.phases import _run_tests_or_special_mode
+
+
+_PATCH_MOD = "ci.autoresearch.phases"
+
+
+def _make_ctx(commands: list[dict[str, Any]]) -> RunContext:
+    return RunContext(
+        args=SimpleNamespace(
+            pin_toggle_rx=False,
+            ws2812_loopback=False,
+            tx_pin=None,
+            rx_pin=None,
+        ),
+        drivers=["PARLIO"],
+        json_rpc_commands=commands,
+        expect_keywords=[],
+        fail_keywords=["ERROR"],
+        timeout_seconds=60.0,
+        build_dir=Path("/fake/project"),
+        simd_test_mode=False,
+        coroutine_test_mode=False,
+        ieee754_test_mode=False,
+        wave2d_perf_grid=None,
+        net_server_mode=False,
+        net_client_mode=False,
+        net_loopback_mode=False,
+        ota_mode=False,
+        ble_mode=False,
+        decode_mode=False,
+        gpio_only_mode=False,
+        parallel_mode=False,
+        final_environment="esp32s3",
+        upload_port="COM5",
+        use_fbuild=False,
+        build_driver=None,
+    )
+
+
+def _response(data: Any) -> MagicMock:
+    response = MagicMock()
+    response.data = data
+    return response
+
+
+def _run_rpc(commands: list[dict[str, Any]], responses: list[Any]) -> int:
+    ctx = _make_ctx(commands)
+    qctx = QuietContext(quiet=False)
+
+    mock_client = AsyncMock()
+    mock_client.send = AsyncMock(side_effect=[_response(data) for data in responses])
+    mock_client.connect = AsyncMock()
+    mock_client.close = AsyncMock()
+
+    with (
+        patch(f"{_PATCH_MOD}.RpcClient", return_value=mock_client),
+        patch(f"{_PATCH_MOD}.kill_port_users"),
+        patch("time.sleep"),
+    ):
+        return asyncio.run(_run_tests_or_special_mode(ctx, qctx))
+
+
+def _run_single_command() -> dict[str, Any]:
+    return {
+        "method": "runSingleTest",
+        "params": {
+            "driver": "PARLIO",
+            "laneSizes": [100],
+            "pattern": "MSB_LSB_A",
+            "iterations": 1,
+            "timing": "WS2812B-V5",
+        },
+    }
+
+
+def _set_pins_command() -> dict[str, Any]:
+    return {"method": "setPins", "params": [{"txPin": 22, "rxPin": 8}]}
+
+
+def _valid_single_pass() -> dict[str, Any]:
+    return {
+        "success": True,
+        "passed": True,
+        "driver": "PARLIO",
+        "laneCount": 1,
+        "laneSizes": [100],
+        "duration_ms": 42,
+        "passedTests": 1,
+        "totalTests": 1,
+    }
+
+
+def test_run_single_valid_pass_is_accepted() -> None:
+    rc = _run_rpc([_run_single_command()], [_valid_single_pass()])
+    assert rc == 0
+
+
+def test_run_single_missing_passed_field_fails() -> None:
+    response = _valid_single_pass()
+    del response["passed"]
+
+    rc = _run_rpc([_run_single_command()], [response])
+
+    assert rc == 1
+
+
+def test_run_single_pass_requires_matching_test_counts() -> None:
+    response = _valid_single_pass()
+    response["passedTests"] = 0
+
+    rc = _run_rpc([_run_single_command()], [response])
+
+    assert rc == 1
+
+
+def test_setup_only_response_does_not_satisfy_final_pass() -> None:
+    rc = _run_rpc(
+        [_set_pins_command()],
+        [{"success": True, "txPin": 22, "rxPin": 8}],
+    )
+
+    assert rc == 1
+
+
+def test_non_dict_test_response_fails_after_setup_ok() -> None:
+    rc = _run_rpc(
+        [_set_pins_command(), _run_single_command()],
+        [{"success": True, "txPin": 22, "rxPin": 8}, "OK"],
+    )
+
+    assert rc == 1
+
+
+def test_run_single_response_driver_must_match_request() -> None:
+    response = _valid_single_pass()
+    response["driver"] = "RMT"
+
+    rc = _run_rpc([_run_single_command()], [response])
+
+    assert rc == 1
+
+
+def _run_parallel_command() -> dict[str, Any]:
+    return {
+        "method": "runParallelTest",
+        "params": {
+            "drivers": [
+                {"driver": "PARLIO", "laneSizes": [100]},
+                {"driver": "RMT", "laneSizes": [100]},
+            ],
+            "pattern": "MSB_LSB_A",
+            "iterations": 1,
+            "timing": "WS2812B-V5",
+        },
+    }
+
+
+def _valid_parallel_pass() -> dict[str, Any]:
+    return {
+        "success": True,
+        "passed": True,
+        "duration_ms": 50,
+        "totalTests": 1,
+        "passedTests": 1,
+        "drivers": [
+            {"driver": "PARLIO", "pinTx": 1, "laneSizes": [100], "laneCount": 1},
+            {"driver": "RMT", "pinTx": 2, "laneSizes": [100], "laneCount": 1},
+        ],
+    }
+
+
+def test_run_parallel_valid_pass_is_accepted() -> None:
+    rc = _run_rpc([_run_parallel_command()], [_valid_parallel_pass()])
+    assert rc == 0
+
+
+def test_run_parallel_missing_test_counts_fails() -> None:
+    response = _valid_parallel_pass()
+    del response["totalTests"]
+
+    rc = _run_rpc([_run_parallel_command()], [response])
+
+    assert rc == 1

--- a/examples/AutoResearch/AutoResearchRemoteRunParallelTest.cpp
+++ b/examples/AutoResearch/AutoResearchRemoteRunParallelTest.cpp
@@ -347,10 +347,21 @@ fl::json AutoResearchRemoteControl::runParallelTestImpl(const fl::json& args) {
     FastLED.clear(ClearFlags::CHANNELS);
 
     uint32_t duration_ms = millis() - start_ms;
+    int total_tests = 1;
+    int passed_tests = show_success ? 1 : 0;
+    if (rx_validation_attempted) {
+        total_tests++;
+        if (rx_validation_passed) {
+            passed_tests++;
+        }
+    }
 
     // ========== RESPONSE ==========
     response.set("success", true);
     response.set("passed", show_success && rx_validation_passed);
+    response.set("totalTests", static_cast<int64_t>(total_tests));
+    response.set("passedTests", static_cast<int64_t>(passed_tests));
+    response.set("failedTests", static_cast<int64_t>(total_tests - passed_tests));
     response.set("duration_ms", static_cast<int64_t>(duration_ms));
     response.set("show_duration_us", static_cast<int64_t>(show_duration_us));
     response.set("iterations", static_cast<int64_t>(iterations));


### PR DESCRIPTION
﻿## Summary

- Add host-side validation for `runSingleTest` and `runParallelTest` RPC responses before AutoResearch can accept a PASS.
- Reject non-dict and malformed test responses instead of allowing setup RPCs to leave the run in an OK state.
- Require sane `totalTests` / `passedTests` counts and returned driver metadata to match the requested test driver(s).
- Add explicit `totalTests`, `passedTests`, and `failedTests` fields to `runParallelTest` firmware responses.
- Add focused unit tests for setup-only false PASS, missing fields, mismatched counts, driver mismatch, non-dict test response, and parallel response validation.

## Validation

- `git diff --check -- ci/autoresearch/phases.py examples/AutoResearch/AutoResearchRemoteRunParallelTest.cpp ci/tests/test_autoresearch_rpc_acceptance.py`
- `uv run --no-sync pytest ci/tests/test_autoresearch_rpc_acceptance.py ci/tests/test_autoresearch_phases.py -q` -> 68 passed
- `uv run --no-sync ruff check ci/autoresearch/phases.py ci/tests/test_autoresearch_rpc_acceptance.py`
- `uv run --no-sync ruff format --check ci/autoresearch/phases.py ci/tests/test_autoresearch_rpc_acceptance.py`
- `bash autoresearch teensy41 --object-fled --tx-pin 22 --rx-pin 8 --timeout 120`

Hardware result: build/lint/deploy succeeded through fbuild on `teensy41 @ COM20`; GPIO pre-test passed for `TX 22 -> RX 8`; AutoResearch correctly failed `OBJECT_FLED` with zero captured/decoded bytes rather than false-passing.
