### PR TITLE
[codex] Require AutoResearch test pin metadata

### DIFF
--- a/ci/autoresearch/phases.py
+++ b/ci/autoresearch/phases.py
@@ -2503,8 +2503,38 @@ def _actual_test_drivers(method: str, data: dict[str, Any]) -> list[str]:
     return []
 
 
+def _expected_test_pins(
+    method: str,
+    cmd: dict[str, Any],
+    default_tx_pin: int | None,
+    default_rx_pin: int | None,
+) -> tuple[int | None, int | None]:
+    params = cmd.get("params")
+    if not isinstance(params, dict):
+        return default_tx_pin, default_rx_pin
+
+    if method == "runParallelTest":
+        drivers = params.get("drivers")
+        if isinstance(drivers, list) and drivers and isinstance(drivers[0], dict):
+            tx_pin = drivers[0].get("pinTx")
+            if _is_plain_int(tx_pin):
+                return tx_pin, default_rx_pin
+        return default_tx_pin, default_rx_pin
+
+    tx_pin = params.get("pinTx")
+    rx_pin = params.get("pinRx")
+    return (
+        tx_pin if _is_plain_int(tx_pin) else default_tx_pin,
+        rx_pin if _is_plain_int(rx_pin) else default_rx_pin,
+    )
+
+
 def _validate_test_rpc_response(
-    method: str, cmd: dict[str, Any], data: dict[str, Any]
+    method: str,
+    cmd: dict[str, Any],
+    data: dict[str, Any],
+    expected_tx_pin: int | None,
+    expected_rx_pin: int | None,
 ) -> list[str]:
     """Return validation errors that prevent a test RPC from proving PASS."""
     errors: list[str] = []
@@ -2540,6 +2570,23 @@ def _validate_test_rpc_response(
         for driver in expected_drivers:
             if driver not in actual_drivers:
                 errors.append(f"missing expected driver {driver}")
+
+    expected_tx_pin, expected_rx_pin = _expected_test_pins(
+        method, cmd, expected_tx_pin, expected_rx_pin
+    )
+    for field, expected in (
+        ("requestedTxPin", expected_tx_pin),
+        ("requestedRxPin", expected_rx_pin),
+        ("actualTxPin", expected_tx_pin),
+        ("actualRxPin", expected_rx_pin),
+    ):
+        if expected is None:
+            continue
+        value = data.get(field)
+        if not _is_plain_int(value):
+            errors.append(f"missing integer {field}")
+        elif expected is not None and value != expected:
+            errors.append(f"{field}={value} does not match expected {expected}")
 
     return errors
 
@@ -2648,7 +2695,11 @@ async def _run_rpc_tests(ctx: RunContext, qctx: QuietContext) -> int:
 
                 elif test_method and (
                     validation_errors := _validate_test_rpc_response(
-                        method, cmd, test_data
+                        method,
+                        cmd,
+                        test_data,
+                        ctx.effective_tx_pin,
+                        ctx.effective_rx_pin,
                     )
                 ):
                     stop_word_found = "ERROR"

--- a/ci/tests/test_autoresearch_rpc_acceptance.py
+++ b/ci/tests/test_autoresearch_rpc_acceptance.py
@@ -45,6 +45,8 @@ def _make_ctx(commands: list[dict[str, Any]]) -> RunContext:
         upload_port="COM5",
         use_fbuild=False,
         build_driver=None,
+        effective_tx_pin=1,
+        effective_rx_pin=0,
     )
 
 
@@ -98,6 +100,10 @@ def _valid_single_pass() -> dict[str, Any]:
         "duration_ms": 42,
         "passedTests": 1,
         "totalTests": 1,
+        "requestedTxPin": 1,
+        "requestedRxPin": 0,
+        "actualTxPin": 1,
+        "actualRxPin": 0,
     }
 
 
@@ -151,6 +157,27 @@ def test_run_single_response_driver_must_match_request() -> None:
     assert rc == 1
 
 
+def test_run_single_missing_actual_pin_fails() -> None:
+    response = _valid_single_pass()
+    del response["actualRxPin"]
+
+    rc = _run_rpc([_run_single_command()], [response])
+
+    assert rc == 1
+
+
+def test_run_single_pin_override_is_accepted_when_response_matches() -> None:
+    command = _run_single_command()
+    command["params"]["pinTx"] = 6
+    response = _valid_single_pass()
+    response["requestedTxPin"] = 6
+    response["actualTxPin"] = 6
+
+    rc = _run_rpc([command], [response])
+
+    assert rc == 0
+
+
 def _run_parallel_command() -> dict[str, Any]:
     return {
         "method": "runParallelTest",
@@ -173,6 +200,10 @@ def _valid_parallel_pass() -> dict[str, Any]:
         "duration_ms": 50,
         "totalTests": 1,
         "passedTests": 1,
+        "requestedTxPin": 1,
+        "requestedRxPin": 0,
+        "actualTxPin": 1,
+        "actualRxPin": 0,
         "drivers": [
             {"driver": "PARLIO", "pinTx": 1, "laneSizes": [100], "laneCount": 1},
             {"driver": "RMT", "pinTx": 2, "laneSizes": [100], "laneCount": 1},

--- a/examples/AutoResearch/AutoResearchRemoteRunParallelTest.cpp
+++ b/examples/AutoResearch/AutoResearchRemoteRunParallelTest.cpp
@@ -349,6 +349,9 @@ fl::json AutoResearchRemoteControl::runParallelTestImpl(const fl::json& args) {
     uint32_t duration_ms = millis() - start_ms;
     int total_tests = 1;
     int passed_tests = show_success ? 1 : 0;
+    const int primary_tx_pin = driver_entries.empty()
+                                   ? mState->pin_tx
+                                   : driver_entries[0].pin_tx;
     if (rx_validation_attempted) {
         total_tests++;
         if (rx_validation_passed) {
@@ -362,6 +365,10 @@ fl::json AutoResearchRemoteControl::runParallelTestImpl(const fl::json& args) {
     response.set("totalTests", static_cast<int64_t>(total_tests));
     response.set("passedTests", static_cast<int64_t>(passed_tests));
     response.set("failedTests", static_cast<int64_t>(total_tests - passed_tests));
+    response.set("requestedTxPin", static_cast<int64_t>(primary_tx_pin));
+    response.set("requestedRxPin", static_cast<int64_t>(mState->pin_rx));
+    response.set("actualTxPin", static_cast<int64_t>(primary_tx_pin));
+    response.set("actualRxPin", static_cast<int64_t>(mState->pin_rx));
     response.set("duration_ms", static_cast<int64_t>(duration_ms));
     response.set("show_duration_us", static_cast<int64_t>(show_duration_us));
     response.set("iterations", static_cast<int64_t>(iterations));

--- a/examples/AutoResearch/AutoResearchRemoteRunSingleTest.cpp
+++ b/examples/AutoResearch/AutoResearchRemoteRunSingleTest.cpp
@@ -633,6 +633,11 @@ fl::json AutoResearchRemoteControl::runSingleTestImpl(const fl::json& args) {
     response.set("duration_ms", static_cast<int64_t>(duration_ms));
     response.set("show_duration_ms", static_cast<int64_t>(show_duration_ms));
     response.set("driver", driver_name.c_str());
+    response.set("requestedTxPin", static_cast<int64_t>(pin_tx));
+    response.set("requestedRxPin", static_cast<int64_t>(pin_rx));
+    response.set("actualTxPin", static_cast<int64_t>(pin_tx));
+    response.set("actualRxPin", static_cast<int64_t>(
+        rx_channel_to_use ? rx_channel_to_use->getPin() : pin_rx));
     response.set("laneCount", static_cast<int64_t>(lane_sizes.size()));
 
     fl::json sizes_response = fl::json::array();


### PR DESCRIPTION
﻿## Summary

- Add requested/actual TX/RX pin metadata to `runSingleTest` responses.
- Add requested/actual TX/RX pin metadata to `runParallelTest` responses.
- Make host-side AutoResearch acceptance reject test RPC responses that omit or mismatch pin metadata when the wrapper knows the expected pins.
- Preserve command-level `pinTx` / `pinRx` overrides when computing expected pins.
- Add focused tests for missing actual pin metadata and pin override acceptance.

## Validation

- `git diff --check -- ci/autoresearch/phases.py examples/AutoResearch/AutoResearchRemoteRunSingleTest.cpp examples/AutoResearch/AutoResearchRemoteRunParallelTest.cpp ci/tests/test_autoresearch_rpc_acceptance.py`
- `uv run --no-sync pytest ci/tests/test_autoresearch_rpc_acceptance.py ci/tests/test_autoresearch_phases.py -q` -> 70 passed
- `uv run --no-sync ruff check ci/autoresearch/phases.py ci/tests/test_autoresearch_rpc_acceptance.py`
- `uv run --no-sync ruff format --check ci/autoresearch/phases.py ci/tests/test_autoresearch_rpc_acceptance.py`
- `bash autoresearch teensy41 --object-fled --tx-pin 22 --rx-pin 8 --timeout 120`

Hardware result: build/lint/deploy succeeded through fbuild on `teensy41 @ COM20`; GPIO pre-test passed for `TX 22 -> RX 8`; AutoResearch accepted the new pin metadata shape and correctly failed `OBJECT_FLED` with zero captured/decoded bytes.
