### PR TITLE
[codex] Require AutoResearch capture backend metadata

### DIFF
--- a/ci/autoresearch/phases.py
+++ b/ci/autoresearch/phases.py
@@ -2574,6 +2574,11 @@ def _validate_test_rpc_response(
     expected_tx_pin, expected_rx_pin = _expected_test_pins(
         method, cmd, expected_tx_pin, expected_rx_pin
     )
+    if expected_tx_pin is not None or expected_rx_pin is not None:
+        capture_backend = data.get("captureBackend")
+        if not isinstance(capture_backend, str) or not capture_backend:
+            errors.append("missing string captureBackend")
+
     for field, expected in (
         ("requestedTxPin", expected_tx_pin),
         ("requestedRxPin", expected_rx_pin),

--- a/ci/tests/test_autoresearch_rpc_acceptance.py
+++ b/ci/tests/test_autoresearch_rpc_acceptance.py
@@ -104,6 +104,7 @@ def _valid_single_pass() -> dict[str, Any]:
         "requestedRxPin": 0,
         "actualTxPin": 1,
         "actualRxPin": 0,
+        "captureBackend": "FLEXPWM",
     }
 
 
@@ -166,6 +167,15 @@ def test_run_single_missing_actual_pin_fails() -> None:
     assert rc == 1
 
 
+def test_run_single_missing_capture_backend_fails() -> None:
+    response = _valid_single_pass()
+    del response["captureBackend"]
+
+    rc = _run_rpc([_run_single_command()], [response])
+
+    assert rc == 1
+
+
 def test_run_single_pin_override_is_accepted_when_response_matches() -> None:
     command = _run_single_command()
     command["params"]["pinTx"] = 6
@@ -204,6 +214,7 @@ def _valid_parallel_pass() -> dict[str, Any]:
         "requestedRxPin": 0,
         "actualTxPin": 1,
         "actualRxPin": 0,
+        "captureBackend": "FLEXPWM",
         "drivers": [
             {"driver": "PARLIO", "pinTx": 1, "laneSizes": [100], "laneCount": 1},
             {"driver": "RMT", "pinTx": 2, "laneSizes": [100], "laneCount": 1},

--- a/examples/AutoResearch/AutoResearchRemoteRunParallelTest.cpp
+++ b/examples/AutoResearch/AutoResearchRemoteRunParallelTest.cpp
@@ -369,6 +369,10 @@ fl::json AutoResearchRemoteControl::runParallelTestImpl(const fl::json& args) {
     response.set("requestedRxPin", static_cast<int64_t>(mState->pin_rx));
     response.set("actualTxPin", static_cast<int64_t>(primary_tx_pin));
     response.set("actualRxPin", static_cast<int64_t>(mState->pin_rx));
+    fl::string capture_backend = mState->rx_channel
+                                     ? mState->rx_channel->getEngineName()
+                                     : fl::string("none");
+    response.set("captureBackend", capture_backend.c_str());
     response.set("duration_ms", static_cast<int64_t>(duration_ms));
     response.set("show_duration_us", static_cast<int64_t>(show_duration_us));
     response.set("iterations", static_cast<int64_t>(iterations));

--- a/examples/AutoResearch/AutoResearchRemoteRunSingleTest.cpp
+++ b/examples/AutoResearch/AutoResearchRemoteRunSingleTest.cpp
@@ -638,6 +638,10 @@ fl::json AutoResearchRemoteControl::runSingleTestImpl(const fl::json& args) {
     response.set("actualTxPin", static_cast<int64_t>(pin_tx));
     response.set("actualRxPin", static_cast<int64_t>(
         rx_channel_to_use ? rx_channel_to_use->getPin() : pin_rx));
+    fl::string capture_backend = rx_channel_to_use
+                                     ? rx_channel_to_use->getEngineName()
+                                     : fl::string("none");
+    response.set("captureBackend", capture_backend.c_str());
     response.set("laneCount", static_cast<int64_t>(lane_sizes.size()));
 
     fl::json sizes_response = fl::json::array();


### PR DESCRIPTION
﻿## Summary

- Add `captureBackend` to `runSingleTest` responses using the RX channel engine name.
- Add `captureBackend` to `runParallelTest` responses.
- Make host-side AutoResearch acceptance reject test responses missing `captureBackend` when expected pins are known.
- Add focused coverage for missing capture backend rejection.

## Validation

- `git diff --check -- ci/autoresearch/phases.py examples/AutoResearch/AutoResearchRemoteRunSingleTest.cpp examples/AutoResearch/AutoResearchRemoteRunParallelTest.cpp ci/tests/test_autoresearch_rpc_acceptance.py`
- `uv run --no-sync pytest ci/tests/test_autoresearch_rpc_acceptance.py ci/tests/test_autoresearch_phases.py -q` -> 71 passed
- `uv run --no-sync ruff check ci/autoresearch/phases.py ci/tests/test_autoresearch_rpc_acceptance.py`
- `uv run --no-sync ruff format --check ci/autoresearch/phases.py ci/tests/test_autoresearch_rpc_acceptance.py`
- `bash autoresearch teensy41 --object-fled --tx-pin 22 --rx-pin 8 --timeout 120`

Hardware result: build/lint/deploy succeeded through fbuild on `teensy41 @ COM20`; GPIO pre-test passed for `TX 22 -> RX 8`; AutoResearch accepted the new capture-backend metadata and correctly failed `OBJECT_FLED` with zero captured/decoded bytes.
