### PR TITLE
[codex] Require AutoResearch capture evidence for PASS

### DIFF
--- a/ci/autoresearch/phases.py
+++ b/ci/autoresearch/phases.py
@@ -2578,6 +2578,18 @@ def _validate_test_rpc_response(
         capture_backend = data.get("captureBackend")
         if not isinstance(capture_backend, str) or not capture_backend:
             errors.append("missing string captureBackend")
+        if data.get("passed") is True:
+            capture_evidence_bytes = data.get("captureEvidenceBytes")
+            capture_evidence_raw_edges = data.get("captureEvidenceRawEdges")
+            has_capture_bytes = (
+                _is_plain_int(capture_evidence_bytes) and capture_evidence_bytes > 0
+            )
+            has_capture_edges = (
+                _is_plain_int(capture_evidence_raw_edges)
+                and capture_evidence_raw_edges > 0
+            )
+            if not has_capture_bytes and not has_capture_edges:
+                errors.append("passed test response requires nonzero capture evidence")
 
     for field, expected in (
         ("requestedTxPin", expected_tx_pin),

--- a/ci/debug_attached.py
+++ b/ci/debug_attached.py
@@ -131,7 +131,7 @@ def run_cpp_lint() -> bool:
         # The legacy direct `cpp_lint.py` relative-includes call has been
         # retired — RelativeIncludeChecker now ships in the Rust crate.
         result = subprocess.run(
-            ["uv", "run", "python", "ci/lint.py", "--cpp"],
+            ["uv", "run", "--no-sync", "python", "ci/lint.py", "--cpp"],
             cwd=project_root,
             env=get_utf8_env(),
         )

--- a/ci/tests/test_autoresearch_rpc_acceptance.py
+++ b/ci/tests/test_autoresearch_rpc_acceptance.py
@@ -105,6 +105,9 @@ def _valid_single_pass() -> dict[str, Any]:
         "actualTxPin": 1,
         "actualRxPin": 0,
         "captureBackend": "FLEXPWM",
+        "captureEvidenceExpected": True,
+        "captureEvidenceBytes": 300,
+        "captureEvidenceRawEdges": 2400,
     }
 
 
@@ -176,6 +179,26 @@ def test_run_single_missing_capture_backend_fails() -> None:
     assert rc == 1
 
 
+def test_run_single_pass_requires_capture_evidence() -> None:
+    response = _valid_single_pass()
+    response["captureEvidenceBytes"] = 0
+    response["captureEvidenceRawEdges"] = 0
+
+    rc = _run_rpc([_run_single_command()], [response])
+
+    assert rc == 1
+
+
+def test_run_single_pass_requires_capture_evidence_fields() -> None:
+    response = _valid_single_pass()
+    del response["captureEvidenceBytes"]
+    del response["captureEvidenceRawEdges"]
+
+    rc = _run_rpc([_run_single_command()], [response])
+
+    assert rc == 1
+
+
 def test_run_single_pin_override_is_accepted_when_response_matches() -> None:
     command = _run_single_command()
     command["params"]["pinTx"] = 6
@@ -215,6 +238,9 @@ def _valid_parallel_pass() -> dict[str, Any]:
         "actualTxPin": 1,
         "actualRxPin": 0,
         "captureBackend": "FLEXPWM",
+        "captureEvidenceExpected": True,
+        "captureEvidenceBytes": 300,
+        "captureEvidenceRawEdges": 2400,
         "drivers": [
             {"driver": "PARLIO", "pinTx": 1, "laneSizes": [100], "laneCount": 1},
             {"driver": "RMT", "pinTx": 2, "laneSizes": [100], "laneCount": 1},
@@ -230,6 +256,16 @@ def test_run_parallel_valid_pass_is_accepted() -> None:
 def test_run_parallel_missing_test_counts_fails() -> None:
     response = _valid_parallel_pass()
     del response["totalTests"]
+
+    rc = _run_rpc([_run_parallel_command()], [response])
+
+    assert rc == 1
+
+
+def test_run_parallel_pass_requires_capture_evidence() -> None:
+    response = _valid_parallel_pass()
+    response["captureEvidenceBytes"] = 0
+    response["captureEvidenceRawEdges"] = 0
 
     rc = _run_rpc([_run_parallel_command()], [response])
 

--- a/ci/tests/test_debug_attached_lint.py
+++ b/ci/tests/test_debug_attached_lint.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+from ci.debug_attached import run_cpp_lint
+
+
+def test_run_cpp_lint_uses_no_sync(monkeypatch: Any) -> None:
+    calls: list[dict[str, Any]] = []
+
+    def fake_run(cmd: list[str], **kwargs: Any) -> SimpleNamespace:
+        calls.append({"cmd": cmd, **kwargs})
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr("ci.debug_attached.subprocess.run", fake_run)
+
+    assert run_cpp_lint()
+
+    assert calls
+    assert calls[0]["cmd"] == [
+        "uv",
+        "run",
+        "--no-sync",
+        "python",
+        "ci/lint.py",
+        "--cpp",
+    ]

--- a/examples/AutoResearch/AutoResearchRemoteRunParallelTest.cpp
+++ b/examples/AutoResearch/AutoResearchRemoteRunParallelTest.cpp
@@ -299,6 +299,7 @@ fl::json AutoResearchRemoteControl::runParallelTestImpl(const fl::json& args) {
     // Only the first driver (PARLIO) is typically connected to the RX pin
     bool rx_validation_passed = true;
     bool rx_validation_attempted = false;
+    fl::vector<fl::RunResult> run_results;
 
     if (mState->rx_channel && driver_entries.size() > 0) {
         const auto& primary_driver = driver_entries[0];
@@ -337,7 +338,7 @@ fl::json AutoResearchRemoteControl::runParallelTestImpl(const fl::json& args) {
             uint32_t val_show_duration_ms = 0;
 
             autoResearchChipsetTiming(autoresearch_config, total_tests, passed_tests,
-                                  val_show_duration_ms, nullptr);
+                                      val_show_duration_ms, &run_results);
 
             rx_validation_passed = (total_tests > 0) && (passed_tests == total_tests);
         }
@@ -352,6 +353,17 @@ fl::json AutoResearchRemoteControl::runParallelTestImpl(const fl::json& args) {
     const int primary_tx_pin = driver_entries.empty()
                                    ? mState->pin_tx
                                    : driver_entries[0].pin_tx;
+    int capture_evidence_bytes = 0;
+    int capture_evidence_raw_edges = 0;
+    for (fl::size ri = 0; ri < run_results.size(); ri++) {
+        const auto& rr = run_results[ri];
+        if (rr.capturedBytes > 0) {
+            capture_evidence_bytes += rr.capturedBytes;
+        }
+        if (rr.rawEdgesAfterWait > capture_evidence_raw_edges) {
+            capture_evidence_raw_edges = rr.rawEdgesAfterWait;
+        }
+    }
     if (rx_validation_attempted) {
         total_tests++;
         if (rx_validation_passed) {
@@ -373,6 +385,11 @@ fl::json AutoResearchRemoteControl::runParallelTestImpl(const fl::json& args) {
                                      ? mState->rx_channel->getEngineName()
                                      : fl::string("none");
     response.set("captureBackend", capture_backend.c_str());
+    response.set("captureEvidenceExpected", rx_validation_attempted);
+    response.set("captureEvidenceBytes",
+                 static_cast<int64_t>(capture_evidence_bytes));
+    response.set("captureEvidenceRawEdges",
+                 static_cast<int64_t>(capture_evidence_raw_edges));
     response.set("duration_ms", static_cast<int64_t>(duration_ms));
     response.set("show_duration_us", static_cast<int64_t>(show_duration_us));
     response.set("iterations", static_cast<int64_t>(iterations));

--- a/examples/AutoResearch/AutoResearchRemoteRunSingleTest.cpp
+++ b/examples/AutoResearch/AutoResearchRemoteRunSingleTest.cpp
@@ -624,12 +624,28 @@ fl::json AutoResearchRemoteControl::runSingleTestImpl(const fl::json& args) {
     }
 
     uint32_t duration_ms = millis() - start_ms;
+    int capture_evidence_bytes = 0;
+    int capture_evidence_raw_edges = 0;
+    for (fl::size ri = 0; ri < run_results.size(); ri++) {
+        const auto& rr = run_results[ri];
+        if (rr.capturedBytes > 0) {
+            capture_evidence_bytes += rr.capturedBytes;
+        }
+        if (rr.rawEdgesAfterWait > capture_evidence_raw_edges) {
+            capture_evidence_raw_edges = rr.rawEdgesAfterWait;
+        }
+    }
 
     // ========== RESPONSE ==========
     response.set("success", true);
     response.set("passed", passed);
     response.set("totalTests", static_cast<int64_t>(total_tests));
     response.set("passedTests", static_cast<int64_t>(passed_tests));
+    response.set("captureEvidenceExpected", true);
+    response.set("captureEvidenceBytes",
+                 static_cast<int64_t>(capture_evidence_bytes));
+    response.set("captureEvidenceRawEdges",
+                 static_cast<int64_t>(capture_evidence_raw_edges));
     response.set("duration_ms", static_cast<int64_t>(duration_ms));
     response.set("show_duration_ms", static_cast<int64_t>(show_duration_ms));
     response.set("driver", driver_name.c_str());


### PR DESCRIPTION
﻿## Summary

- require AutoResearch PASS responses to include nonzero capture evidence when loopback pins are known
- report aggregate capture bytes/raw-edge evidence from runSingleTest and runParallelTest
- align AutoResearch's C++ lint subprocess with `bash lint` by using `uv run --no-sync`, avoiding implicit uv sync side effects during hardware runs

## Validation

- `git diff --check -- ci/debug_attached.py ci/tests/test_debug_attached_lint.py ci/autoresearch/phases.py ci/tests/test_autoresearch_rpc_acceptance.py examples/AutoResearch/AutoResearchRemoteRunSingleTest.cpp examples/AutoResearch/AutoResearchRemoteRunParallelTest.cpp`
- `uv run --no-sync pytest ci/tests/test_debug_attached_lint.py ci/tests/test_autoresearch_rpc_acceptance.py ci/tests/test_autoresearch_phases.py -q`
- `uv run --no-sync ruff check ci/debug_attached.py ci/tests/test_debug_attached_lint.py ci/autoresearch/phases.py ci/tests/test_autoresearch_rpc_acceptance.py`
- `uv run --no-sync ruff format --check ci/debug_attached.py ci/tests/test_debug_attached_lint.py ci/autoresearch/phases.py ci/tests/test_autoresearch_rpc_acceptance.py`
- `bash autoresearch teensy41 --object-fled --tx-pin 22 --rx-pin 8 --timeout 120`

AutoResearch result: fbuild deploy succeeded on `COM20`; GPIO `TX 22 -> RX 8` passed; ObjectFLED still fails honestly with zero captured bytes, which is expected before the driver fix. The patched run did not recreate the zero-byte `-r` artifact.
