### PR TITLE
[codex] Classify AutoResearch hardware failures

### DIFF
--- a/ci/autoresearch/gpio.py
+++ b/ci/autoresearch/gpio.py
@@ -145,6 +145,7 @@ async def run_gpio_pretest(
                 print(f"{Fore.RED}\u274c GPIO PRE-TEST FAILED{Style.RESET_ALL}")
                 print()
                 print(f"   {Fore.RED}Error: {msg}{Style.RESET_ALL}")
+                print(f"   Failure class: electrical_issue")
                 print()
                 # Provide specific diagnosis based on pin readings
                 if rx_low == 1 and rx_high == 1:

--- a/ci/autoresearch/phases.py
+++ b/ci/autoresearch/phases.py
@@ -2608,6 +2608,56 @@ def _validate_test_rpc_response(
     return errors
 
 
+def _classify_test_failure(data: dict[str, Any]) -> tuple[str, str]:
+    """Classify a failed test response using structured RPC evidence."""
+    patterns = data.get("patterns")
+    if isinstance(patterns, list) and patterns:
+        saw_pattern = False
+        saw_capture_bytes = False
+        saw_raw_edges = False
+        saw_mismatched_bytes = False
+        saw_capture_failure = False
+
+        for pattern in patterns:
+            if not isinstance(pattern, dict):
+                continue
+            saw_pattern = True
+            captured = pattern.get("capturedBytes")
+            raw_edges = pattern.get("rawEdgesAfterWait")
+            mismatched = pattern.get("mismatchedBytes")
+            if _is_plain_int(captured) and captured > 0:
+                saw_capture_bytes = True
+            if _is_plain_int(raw_edges) and raw_edges > 0:
+                saw_raw_edges = True
+            if _is_plain_int(mismatched) and mismatched > 0:
+                saw_mismatched_bytes = True
+            if pattern.get("captureFailed") is True:
+                saw_capture_failure = True
+
+        if saw_pattern:
+            if not saw_capture_bytes and not saw_raw_edges:
+                return (
+                    "zero_capture",
+                    "RX produced no raw edges or decodable bytes",
+                )
+            if saw_mismatched_bytes or saw_capture_failure:
+                return (
+                    "decode_mismatch",
+                    "RX captured signal/data but decoded output did not match",
+                )
+
+    evidence_bytes = data.get("captureEvidenceBytes")
+    evidence_edges = data.get("captureEvidenceRawEdges")
+    has_capture_bytes = _is_plain_int(evidence_bytes) and evidence_bytes > 0
+    has_capture_edges = _is_plain_int(evidence_edges) and evidence_edges > 0
+    if data.get("passed") is False:
+        if not has_capture_bytes and not has_capture_edges:
+            return ("zero_capture", "test failed with no positive capture evidence")
+        return ("decode_mismatch", "test failed despite positive capture evidence")
+
+    return ("test_failed", "test response reported failure")
+
+
 async def _run_rpc_tests(ctx: RunContext, qctx: QuietContext) -> int:
     """Execute main RPC test loop."""
     upload_port = ctx.upload_port
@@ -2722,8 +2772,10 @@ async def _run_rpc_tests(ctx: RunContext, qctx: QuietContext) -> int:
                     stop_word_found = "ERROR"
                     test_failed = True
                     print(f"{Fore.RED}\u274c Malformed test response{Style.RESET_ALL}")
+                    print("   Failure class: malformed_response")
                     for error in validation_errors:
                         print(f"   - {error}")
+                    qctx.emit(f"FAILURE class=malformed_response method={method}")
                     break
 
                 elif test_data.get("success") and test_data.get("passed"):
@@ -2774,12 +2826,16 @@ async def _run_rpc_tests(ctx: RunContext, qctx: QuietContext) -> int:
                 ):
                     stop_word_found = "ERROR"
                     test_failed = True
+                    failure_class, failure_detail = _classify_test_failure(test_data)
                     print(f"{Fore.RED}\u274c Test failed{Style.RESET_ALL}")
+                    print(f"   Failure class: {failure_class}")
+                    print(f"   Detail: {failure_detail}")
                     _err_detail = ""
                     if "firstFailure" in test_data:
                         _err_detail = f" {test_data['firstFailure'].get('pattern', '')}"
                     qctx.emit(
-                        f"TEST {_driver} lanes={_lanes} leds={_leds} FAIL {_dur}ms{_err_detail}"
+                        f"TEST {_driver} lanes={_lanes} leds={_leds} FAIL {_dur}ms "
+                        f"class={failure_class}{_err_detail}"
                     )
 
                     if "firstFailure" in test_data:
@@ -2805,8 +2861,10 @@ async def _run_rpc_tests(ctx: RunContext, qctx: QuietContext) -> int:
                 print(
                     f"{Fore.RED}\u274c Device crashed during {method}(){Style.RESET_ALL}"
                 )
+                print("   Failure class: crash")
                 if not crash_err.decoded_lines:
                     print("   (no decoded stack trace available)")
+                qctx.emit(f"FAILURE class=crash method={method}")
                 test_failed = True
                 stop_word_found = "ERROR"
                 break
@@ -2814,6 +2872,8 @@ async def _run_rpc_tests(ctx: RunContext, qctx: QuietContext) -> int:
             except RpcTimeoutError:
                 print(f"{Fore.RED}\u274c RPC timeout{Style.RESET_ALL}")
                 print(f"   No response within {120}s")
+                print("   Failure class: timeout")
+                qctx.emit(f"FAILURE class=timeout method={method}")
                 test_failed = True
                 stop_word_found = "ERROR"
                 break

--- a/ci/tests/test_autoresearch_rpc_acceptance.py
+++ b/ci/tests/test_autoresearch_rpc_acceptance.py
@@ -9,7 +9,7 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from ci.autoresearch.context import QuietContext, RunContext
-from ci.autoresearch.phases import _run_tests_or_special_mode
+from ci.autoresearch.phases import _classify_test_failure, _run_tests_or_special_mode
 
 
 _PATCH_MOD = "ci.autoresearch.phases"
@@ -270,3 +270,45 @@ def test_run_parallel_pass_requires_capture_evidence() -> None:
     rc = _run_rpc([_run_parallel_command()], [response])
 
     assert rc == 1
+
+
+def test_failed_response_with_no_edges_is_zero_capture() -> None:
+    failure_class, detail = _classify_test_failure(
+        {
+            "passed": False,
+            "captureEvidenceBytes": 0,
+            "captureEvidenceRawEdges": 0,
+            "patterns": [
+                {
+                    "capturedBytes": 0,
+                    "rawEdgesAfterWait": 0,
+                    "mismatchedBytes": 300,
+                    "captureFailed": True,
+                }
+            ],
+        }
+    )
+
+    assert failure_class == "zero_capture"
+    assert "no raw edges" in detail
+
+
+def test_failed_response_with_edges_is_decode_mismatch() -> None:
+    failure_class, detail = _classify_test_failure(
+        {
+            "passed": False,
+            "captureEvidenceBytes": 32,
+            "captureEvidenceRawEdges": 128,
+            "patterns": [
+                {
+                    "capturedBytes": 32,
+                    "rawEdgesAfterWait": 128,
+                    "mismatchedBytes": 300,
+                    "captureFailed": False,
+                }
+            ],
+        }
+    )
+
+    assert failure_class == "decode_mismatch"
+    assert "did not match" in detail


### PR DESCRIPTION
﻿## Summary

- Classifies failed AutoResearch test responses as `zero_capture`, `decode_mismatch`, or generic test failure using structured capture evidence.
- Emits explicit failure classes for malformed responses, crashes, RPC timeouts, and GPIO electrical failures.
- Adds host-side coverage for zero-capture and decode-mismatch classification.

## Validation

- `git diff --check -- ci/autoresearch/phases.py ci/autoresearch/gpio.py ci/tests/test_autoresearch_rpc_acceptance.py`
- `uv run --no-sync pytest ci/tests/test_autoresearch_rpc_acceptance.py ci/tests/test_autoresearch_phases.py ci/tests/test_gpio_serial_proxy_retry.py -q` -> 78 passed
- `uv run --no-sync ruff check ci/autoresearch/phases.py ci/autoresearch/gpio.py ci/tests/test_autoresearch_rpc_acceptance.py`
- `uv run --no-sync ruff format --check ci/autoresearch/phases.py ci/autoresearch/gpio.py ci/tests/test_autoresearch_rpc_acceptance.py`
- `bash autoresearch teensy41 --object-fled --tx-pin 22 --rx-pin 8 --timeout 120` -> fbuild deploy succeeded on COM20; GPIO `TX 22 -> RX 8` passed; ObjectFLED failed honestly with `class=zero_capture` and 0 captured bytes.

No `bash compile`, no PlatformIO backend, and no manual serial utility were used for hardware validation.
