### PR TITLE
[codex] Sync AutoResearch default pins with firmware

### DIFF
--- a/ci/autoresearch/context.py
+++ b/ci/autoresearch/context.py
@@ -18,9 +18,32 @@ if TYPE_CHECKING:
 # Constants
 # ============================================================
 
-# GPIO pin definitions (must match AutoResearch.ino)
-PIN_TX = 1  # TX pin used by FastLED drivers
-PIN_RX = 0  # RX pin used by RMT receiver (ESP32-C6 default; ESP32 uses 2)
+# Legacy fallback GPIO pin definitions. Platform-aware code should use
+# default_pins_for_environment() so host defaults stay synchronized with
+# examples/AutoResearch/AutoResearchPlatform.h.
+PIN_TX = 1
+PIN_RX = 0
+
+
+def _normalize_environment_name(environment: str | None) -> str:
+    return (environment or "").lower().replace("-", "").replace("_", "")
+
+
+def default_pins_for_environment(environment: str | None) -> tuple[int, int]:
+    """Return AutoResearch firmware default TX/RX pins for a board environment."""
+    env = _normalize_environment_name(environment)
+    if env in {"native", "stub", "host"} or "stub" in env:
+        return (1, 1)
+    if "esp32s3" in env:
+        return (1, 2)
+    if "esp32p4" in env:
+        return (5, 6)
+    if env in {"teensy40", "teensy41"}:
+        return (1, 2)
+    if any(chip in env for chip in ("esp32s2", "esp32c6", "esp32c3")):
+        return (1, 0)
+    return (PIN_TX, PIN_RX)
+
 
 # No legacy expect patterns — JSON-RPC test_complete is the authoritative
 # completion signal.

--- a/ci/autoresearch/phases.py
+++ b/ci/autoresearch/phases.py
@@ -24,10 +24,9 @@ from ci.autoresearch.context import (
     DEFAULT_EXPECT_PATTERNS,
     DEFAULT_FAIL_ON_PATTERN,
     EXIT_ON_ERROR_PATTERNS,
-    PIN_RX,
-    PIN_TX,
     QuietContext,
     RunContext,
+    default_pins_for_environment,
     display_pattern_details,
     display_tight_timing,
 )
@@ -1455,6 +1454,7 @@ async def _run_schema_and_pin_setup(ctx: RunContext) -> int | None:
     from ci.util.serial_interface import create_serial_interface
 
     final_environment = (ctx.final_environment or "").lower()
+    default_tx_pin, default_rx_pin = default_pins_for_environment(final_environment)
     use_pyserial = (not use_fbuild) or final_environment in LPC_BRING_UP_ENVS
     ctx.serial_iface = create_serial_interface(
         port=upload_port, use_pyserial=use_pyserial
@@ -1493,8 +1493,12 @@ async def _run_schema_and_pin_setup(ctx: RunContext) -> int | None:
     elif ctx.ble_mode:
         print("\n\U0001f4cc BLE mode: skipping pin discovery and GPIO pre-test")
     elif args.tx_pin is not None or args.rx_pin is not None:
-        ctx.effective_tx_pin = args.tx_pin if args.tx_pin is not None else PIN_TX
-        ctx.effective_rx_pin = args.rx_pin if args.rx_pin is not None else PIN_RX
+        ctx.effective_tx_pin = (
+            args.tx_pin if args.tx_pin is not None else default_tx_pin
+        )
+        ctx.effective_rx_pin = (
+            args.rx_pin if args.rx_pin is not None else default_rx_pin
+        )
         print(
             f"\n\U0001f4cc Using CLI-specified pins: TX={ctx.effective_tx_pin}, RX={ctx.effective_rx_pin}"
         )
@@ -1522,8 +1526,8 @@ async def _run_schema_and_pin_setup(ctx: RunContext) -> int | None:
                 f"\U0001f4cc Using discovered pins: TX={ctx.effective_tx_pin}, RX={ctx.effective_rx_pin}"
             )
         else:
-            ctx.effective_tx_pin = PIN_TX
-            ctx.effective_rx_pin = PIN_RX
+            ctx.effective_tx_pin = default_tx_pin
+            ctx.effective_rx_pin = default_rx_pin
             print(
                 f"\U0001f4cc Using default pins: TX={ctx.effective_tx_pin}, RX={ctx.effective_rx_pin}"
             )
@@ -1531,8 +1535,8 @@ async def _run_schema_and_pin_setup(ctx: RunContext) -> int | None:
                 await ctx.discovery_client.close()
                 ctx.discovery_client = None
     else:
-        ctx.effective_tx_pin = PIN_TX
-        ctx.effective_rx_pin = PIN_RX
+        ctx.effective_tx_pin = default_tx_pin
+        ctx.effective_rx_pin = default_rx_pin
         print(
             f"\n\U0001f4cc Using default pins: TX={ctx.effective_tx_pin}, RX={ctx.effective_rx_pin}"
         )
@@ -1558,8 +1562,8 @@ async def _run_schema_and_pin_setup(ctx: RunContext) -> int | None:
         print("\n\u2705 Skipping GPIO pre-test (pins verified during discovery)")
     elif not await run_gpio_pretest(
         upload_port,
-        ctx.effective_tx_pin or PIN_TX,
-        ctx.effective_rx_pin or PIN_RX,
+        ctx.effective_tx_pin if ctx.effective_tx_pin is not None else default_tx_pin,
+        ctx.effective_rx_pin if ctx.effective_rx_pin is not None else default_rx_pin,
         serial_interface=serial_iface,
     ):
         print()
@@ -1573,8 +1577,12 @@ async def _run_schema_and_pin_setup(ctx: RunContext) -> int | None:
         print("     JSON-RPC commands. Check serial output above for boot errors")
         print("     or crashes. Try power-cycling the device.")
         print()
-        tx = ctx.effective_tx_pin if ctx.effective_tx_pin is not None else PIN_TX
-        rx = ctx.effective_rx_pin if ctx.effective_rx_pin is not None else PIN_RX
+        tx = (
+            ctx.effective_tx_pin if ctx.effective_tx_pin is not None else default_tx_pin
+        )
+        rx = (
+            ctx.effective_rx_pin if ctx.effective_rx_pin is not None else default_rx_pin
+        )
         print("  2. WRONG PIN PAIR: The jumper wire may be connected to different")
         print(f"     pins than expected (tested TX={tx}, RX={rx}).")
         print("     Try: bash autoresearch --auto-discover-pins")

--- a/ci/tests/test_autoresearch_phases.py
+++ b/ci/tests/test_autoresearch_phases.py
@@ -234,9 +234,7 @@ class TestParseArgsAndBuildCommands:
             result = _parse_args_and_build_commands(args)
         assert isinstance(result, RunContext)
         assert result.drivers == ["OBJECT_FLED", "FLEX_IO"]
-        assert {cmd["method"] for cmd in result.json_rpc_commands} == {
-            "runSingleTest"
-        }
+        assert {cmd["method"] for cmd in result.json_rpc_commands} == {"runSingleTest"}
         assert not any("__skip_with_pass" in cmd for cmd in result.json_rpc_commands)
 
     def test_lpuart_is_reserved_not_selectable(self, fake_project_dir: Path) -> None:
@@ -798,8 +796,51 @@ class TestRunSchemaAndPinSetup:
         ):
             rc = asyncio.run(_run_schema_and_pin_setup(ctx))
         assert rc is None
-        assert ctx.effective_tx_pin == 1  # PIN_TX default
-        assert ctx.effective_rx_pin == 0  # PIN_RX default
+        assert ctx.effective_tx_pin == 1
+        assert ctx.effective_rx_pin == 2
+
+    def test_teensy_default_pins_match_firmware(self) -> None:
+        args = _make_args(skip_schema=True)
+        ctx = _make_ctx(args=args, final_environment="teensy41")
+        with patch(
+            f"{_PATCH_MOD}.run_gpio_pretest",
+            new_callable=AsyncMock,
+            return_value=True,
+        ):
+            rc = asyncio.run(_run_schema_and_pin_setup(ctx))
+        assert rc is None
+        assert ctx.effective_tx_pin == 1
+        assert ctx.effective_rx_pin == 2
+
+    def test_esp32p4_default_pins_match_firmware(self) -> None:
+        args = _make_args(skip_schema=True)
+        ctx = _make_ctx(args=args, final_environment="esp32p4")
+        with patch(
+            f"{_PATCH_MOD}.run_gpio_pretest",
+            new_callable=AsyncMock,
+            return_value=True,
+        ):
+            rc = asyncio.run(_run_schema_and_pin_setup(ctx))
+        assert rc is None
+        assert ctx.effective_tx_pin == 5
+        assert ctx.effective_rx_pin == 6
+
+    def test_teensy_cli_half_override_uses_firmware_default_complement(self) -> None:
+        args = _make_args(tx_pin=22, skip_schema=True)
+        ctx = _make_ctx(args=args, final_environment="teensy41")
+        with patch(
+            f"{_PATCH_MOD}.run_gpio_pretest",
+            new_callable=AsyncMock,
+            return_value=True,
+        ):
+            rc = asyncio.run(_run_schema_and_pin_setup(ctx))
+        assert rc is None
+        assert ctx.effective_tx_pin == 22
+        assert ctx.effective_rx_pin == 2
+        assert ctx.json_rpc_commands[0] == {
+            "method": "setPins",
+            "params": [{"txPin": 22, "rxPin": 2}],
+        }
 
     def test_gpio_pretest_failure(self) -> None:
         args = _make_args(skip_schema=True)
@@ -852,6 +893,31 @@ class TestRunSchemaAndPinSetup:
         assert ctx.effective_rx_pin == 6
         assert ctx.discovery_client is not None
         assert ctx.pins_discovered is True
+
+    def test_auto_discover_pins_failure_uses_platform_defaults(self) -> None:
+        args = _make_args(auto_discover_pins=True, skip_schema=True)
+        ctx = _make_ctx(args=args, final_environment="esp32p4")
+        mock_client = AsyncMock()
+        mock_discovery = MagicMock(
+            success=False, tx_pin=None, rx_pin=None, client=mock_client
+        )
+        with (
+            patch(
+                f"{_PATCH_MOD}.run_pin_discovery",
+                new_callable=AsyncMock,
+                return_value=mock_discovery,
+            ),
+            patch(
+                f"{_PATCH_MOD}.run_gpio_pretest",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+        ):
+            rc = asyncio.run(_run_schema_and_pin_setup(ctx))
+        assert rc is None
+        assert ctx.effective_tx_pin == 5
+        assert ctx.effective_rx_pin == 6
+        mock_client.close.assert_awaited_once()
 
 
 # ============================================================


### PR DESCRIPTION
## Summary

- add a platform-aware AutoResearch host default pin helper matching `examples/AutoResearch/AutoResearchPlatform.h`
- use those defaults in schema/pin setup for CLI half-overrides, discovery fallback, default fallback, GPIO pretest, and diagnostics
- add coverage for ESP32-S3, ESP32-P4, Teensy 4.x, half-specified Teensy CLI pins, and failed auto-discovery fallback

## Why

Issue #3359 S2 calls out host-vs-firmware pin default divergence. The firmware defaults Teensy 4.x and ESP32-S3 to RX 2 and ESP32-P4 to TX/RX 5/6, while the host fallback still used global 1/0. That let omitted pins silently mean different pairs on host vs firmware.

## Validation

- `git diff --check -- ci/autoresearch/context.py ci/autoresearch/phases.py ci/tests/test_autoresearch_phases.py`
- `uv run --no-sync pytest ci/tests/test_autoresearch_phases.py -q` -> 64 passed
- `uv run --no-sync ruff check ci/autoresearch/context.py ci/autoresearch/phases.py ci/tests/test_autoresearch_phases.py`
- `uv run --no-sync ruff format --check ci/autoresearch/context.py ci/autoresearch/phases.py ci/tests/test_autoresearch_phases.py`

Targets #3359 S2: remove/synchronize host-vs-firmware pin default divergence.