### PR TITLE
[codex] Always apply AutoResearch effective pins

### DIFF
--- a/ci/autoresearch/phases.py
+++ b/ci/autoresearch/phases.py
@@ -1502,11 +1502,6 @@ async def _run_schema_and_pin_setup(ctx: RunContext) -> int | None:
         print(
             f"\n\U0001f4cc Using CLI-specified pins: TX={ctx.effective_tx_pin}, RX={ctx.effective_rx_pin}"
         )
-        set_pins_cmd = {
-            "method": "setPins",
-            "params": [{"txPin": ctx.effective_tx_pin, "rxPin": ctx.effective_rx_pin}],
-        }
-        ctx.json_rpc_commands.insert(0, set_pins_cmd)
     elif args.auto_discover_pins:
         print("\n\U0001f50d Auto-discovery enabled - searching for connected pins...")
         pin_discovery = await run_pin_discovery(
@@ -1540,6 +1535,8 @@ async def _run_schema_and_pin_setup(ctx: RunContext) -> int | None:
         print(
             f"\n\U0001f4cc Using default pins: TX={ctx.effective_tx_pin}, RX={ctx.effective_rx_pin}"
         )
+
+    _ensure_leading_set_pins_command(ctx)
 
     # GPIO connectivity pre-test
     if final_environment in LPC_BRING_UP_ENVS:
@@ -2509,6 +2506,21 @@ def _actual_test_drivers(method: str, data: dict[str, Any]) -> list[str]:
         return actual
 
     return []
+
+
+def _set_pins_rpc_command(tx_pin: int, rx_pin: int) -> dict[str, Any]:
+    return {"method": "setPins", "params": [{"txPin": tx_pin, "rxPin": rx_pin}]}
+
+
+def _ensure_leading_set_pins_command(ctx: RunContext) -> None:
+    if ctx.effective_tx_pin is None or ctx.effective_rx_pin is None:
+        return
+
+    set_pins_cmd = _set_pins_rpc_command(ctx.effective_tx_pin, ctx.effective_rx_pin)
+    if ctx.json_rpc_commands and ctx.json_rpc_commands[0].get("method") == "setPins":
+        ctx.json_rpc_commands[0] = set_pins_cmd
+        return
+    ctx.json_rpc_commands.insert(0, set_pins_cmd)
 
 
 def _expected_test_pins(

--- a/ci/tests/test_autoresearch_phases.py
+++ b/ci/tests/test_autoresearch_phases.py
@@ -784,7 +784,10 @@ class TestRunSchemaAndPinSetup:
         assert rc is None
         assert ctx.effective_tx_pin == 3
         assert ctx.effective_rx_pin == 4
-        assert ctx.json_rpc_commands[0]["method"] == "setPins"
+        assert ctx.json_rpc_commands[0] == {
+            "method": "setPins",
+            "params": [{"txPin": 3, "rxPin": 4}],
+        }
 
     def test_default_pins(self) -> None:
         args = _make_args(skip_schema=True)
@@ -798,6 +801,10 @@ class TestRunSchemaAndPinSetup:
         assert rc is None
         assert ctx.effective_tx_pin == 1
         assert ctx.effective_rx_pin == 2
+        assert ctx.json_rpc_commands[0] == {
+            "method": "setPins",
+            "params": [{"txPin": 1, "rxPin": 2}],
+        }
 
     def test_teensy_default_pins_match_firmware(self) -> None:
         args = _make_args(skip_schema=True)
@@ -811,6 +818,10 @@ class TestRunSchemaAndPinSetup:
         assert rc is None
         assert ctx.effective_tx_pin == 1
         assert ctx.effective_rx_pin == 2
+        assert ctx.json_rpc_commands[0] == {
+            "method": "setPins",
+            "params": [{"txPin": 1, "rxPin": 2}],
+        }
 
     def test_esp32p4_default_pins_match_firmware(self) -> None:
         args = _make_args(skip_schema=True)
@@ -824,6 +835,10 @@ class TestRunSchemaAndPinSetup:
         assert rc is None
         assert ctx.effective_tx_pin == 5
         assert ctx.effective_rx_pin == 6
+        assert ctx.json_rpc_commands[0] == {
+            "method": "setPins",
+            "params": [{"txPin": 5, "rxPin": 6}],
+        }
 
     def test_teensy_cli_half_override_uses_firmware_default_complement(self) -> None:
         args = _make_args(tx_pin=22, skip_schema=True)
@@ -893,6 +908,10 @@ class TestRunSchemaAndPinSetup:
         assert ctx.effective_rx_pin == 6
         assert ctx.discovery_client is not None
         assert ctx.pins_discovered is True
+        assert ctx.json_rpc_commands[0] == {
+            "method": "setPins",
+            "params": [{"txPin": 5, "rxPin": 6}],
+        }
 
     def test_auto_discover_pins_failure_uses_platform_defaults(self) -> None:
         args = _make_args(auto_discover_pins=True, skip_schema=True)
@@ -917,6 +936,10 @@ class TestRunSchemaAndPinSetup:
         assert rc is None
         assert ctx.effective_tx_pin == 5
         assert ctx.effective_rx_pin == 6
+        assert ctx.json_rpc_commands[0] == {
+            "method": "setPins",
+            "params": [{"txPin": 5, "rxPin": 6}],
+        }
         mock_client.close.assert_awaited_once()
 
 


### PR DESCRIPTION
## Summary

- centralize AutoResearch `setPins` command generation for the final effective TX/RX pair
- prepend or replace the leading `setPins` RPC after CLI pins, discovered pins, discovery fallback pins, or default pins are resolved
- expand phase tests so default, explicit, discovered, and fallback pin flows all assert the queued `setPins` command

## Why

Issue #3359 S2 requires wrapper logs, firmware state, and returned result pins to stay visible and synchronized. Before this change, AutoResearch only queued `setPins` for explicitly supplied CLI pins. Omitted/default pins and auto-discovery paths could proceed without applying the final effective pair through firmware RPC state.

## Validation

- `git diff --check -- ci/autoresearch/phases.py ci/tests/test_autoresearch_phases.py`
- `uv run --no-sync pytest ci/tests/test_autoresearch_phases.py -q` -> 64 passed
- `uv run --no-sync ruff check ci/autoresearch/phases.py ci/tests/test_autoresearch_phases.py`
- `uv run --no-sync ruff format --check ci/autoresearch/phases.py ci/tests/test_autoresearch_phases.py`

Targets #3359 S2: always send `setPins` for the final effective TX/RX pair, including fallback/default cases.