### PR TITLE
fix(autoresearch): verify setup pin state

### DIFF
--- a/ci/autoresearch/phases.py
+++ b/ci/autoresearch/phases.py
@@ -2534,6 +2534,66 @@ def _set_pins_rpc_command(tx_pin: int, rx_pin: int) -> dict[str, Any]:
     return {"method": "setPins", "params": [{"txPin": tx_pin, "rxPin": rx_pin}]}
 
 
+def _expected_setup_pins(
+    method: str, cmd: dict[str, Any]
+) -> tuple[int | None, int | None]:
+    params = cmd.get("params")
+    if method == "setPins":
+        if (
+            isinstance(params, list)
+            and len(params) == 1
+            and isinstance(params[0], dict)
+        ):
+            tx_pin = params[0].get("txPin")
+            rx_pin = params[0].get("rxPin")
+            return (
+                tx_pin if _is_plain_int(tx_pin) else None,
+                rx_pin if _is_plain_int(rx_pin) else None,
+            )
+        if isinstance(params, list) and len(params) == 2:
+            tx_pin, rx_pin = params
+            return (
+                tx_pin if _is_plain_int(tx_pin) else None,
+                rx_pin if _is_plain_int(rx_pin) else None,
+            )
+        return None, None
+
+    if not isinstance(params, list) or len(params) != 1:
+        return None, None
+
+    pin = params[0]
+    if not _is_plain_int(pin):
+        return None, None
+
+    if method == "setTxPin":
+        return pin, None
+    if method == "setRxPin":
+        return None, pin
+    return None, None
+
+
+def _validate_setup_rpc_response(
+    method: str, cmd: dict[str, Any], data: dict[str, Any]
+) -> list[str]:
+    """Return validation errors for setup RPCs that must not drift silently."""
+    errors: list[str] = []
+    expected_tx_pin, expected_rx_pin = _expected_setup_pins(method, cmd)
+
+    for field, expected in (
+        ("txPin", expected_tx_pin),
+        ("rxPin", expected_rx_pin),
+    ):
+        if expected is None:
+            continue
+        value = data.get(field)
+        if not _is_plain_int(value):
+            errors.append(f"missing integer {field}")
+        elif value != expected:
+            errors.append(f"{field}={value} does not match expected {expected}")
+
+    return errors
+
+
 def _ensure_leading_set_pins_command(ctx: RunContext) -> None:
     if ctx.effective_tx_pin is None or ctx.effective_rx_pin is None:
         return
@@ -2801,6 +2861,22 @@ async def _run_rpc_tests(ctx: RunContext, qctx: QuietContext) -> int:
                         print(f"   Message: {test_data['message']}")
                     if setup_method:
                         break
+
+                elif setup_method and (
+                    validation_errors := _validate_setup_rpc_response(
+                        method,
+                        cmd,
+                        test_data,
+                    )
+                ):
+                    stop_word_found = "ERROR"
+                    test_failed = True
+                    print(f"{Fore.RED}\u274c Setup response mismatch{Style.RESET_ALL}")
+                    print("   Failure class: pin_state_mismatch")
+                    for error in validation_errors:
+                        print(f"   - {error}")
+                    qctx.emit(f"FAILURE class=pin_state_mismatch method={method}")
+                    break
 
                 elif test_method and (
                     validation_errors := _validate_test_rpc_response(

--- a/ci/tests/test_autoresearch_rpc_acceptance.py
+++ b/ci/tests/test_autoresearch_rpc_acceptance.py
@@ -15,7 +15,11 @@ from ci.autoresearch.phases import _classify_test_failure, _run_tests_or_special
 _PATCH_MOD = "ci.autoresearch.phases"
 
 
-def _make_ctx(commands: list[dict[str, Any]]) -> RunContext:
+def _make_ctx(
+    commands: list[dict[str, Any]],
+    effective_tx_pin: int = 1,
+    effective_rx_pin: int = 0,
+) -> RunContext:
     return RunContext(
         args=SimpleNamespace(
             pin_toggle_rx=False,
@@ -45,8 +49,8 @@ def _make_ctx(commands: list[dict[str, Any]]) -> RunContext:
         upload_port="COM5",
         use_fbuild=False,
         build_driver=None,
-        effective_tx_pin=1,
-        effective_rx_pin=0,
+        effective_tx_pin=effective_tx_pin,
+        effective_rx_pin=effective_rx_pin,
     )
 
 
@@ -56,8 +60,17 @@ def _response(data: Any) -> MagicMock:
     return response
 
 
-def _run_rpc(commands: list[dict[str, Any]], responses: list[Any]) -> int:
-    ctx = _make_ctx(commands)
+def _run_rpc(
+    commands: list[dict[str, Any]],
+    responses: list[Any],
+    effective_tx_pin: int = 1,
+    effective_rx_pin: int = 0,
+) -> int:
+    ctx = _make_ctx(
+        commands,
+        effective_tx_pin=effective_tx_pin,
+        effective_rx_pin=effective_rx_pin,
+    )
     qctx = QuietContext(quiet=False)
 
     mock_client = AsyncMock()
@@ -150,6 +163,40 @@ def test_non_dict_test_response_fails_after_setup_ok() -> None:
     )
 
     assert rc == 1
+
+
+def test_set_pins_response_must_match_request() -> None:
+    response = _valid_single_pass()
+    response["requestedTxPin"] = 22
+    response["requestedRxPin"] = 8
+    response["actualTxPin"] = 22
+    response["actualRxPin"] = 8
+
+    rc = _run_rpc(
+        [_set_pins_command(), _run_single_command()],
+        [{"success": True, "txPin": 22, "rxPin": 9}, response],
+        effective_tx_pin=22,
+        effective_rx_pin=8,
+    )
+
+    assert rc == 1
+
+
+def test_set_pins_and_test_response_agree_with_effective_pins() -> None:
+    response = _valid_single_pass()
+    response["requestedTxPin"] = 22
+    response["requestedRxPin"] = 8
+    response["actualTxPin"] = 22
+    response["actualRxPin"] = 8
+
+    rc = _run_rpc(
+        [_set_pins_command(), _run_single_command()],
+        [{"success": True, "txPin": 22, "rxPin": 8}, response],
+        effective_tx_pin=22,
+        effective_rx_pin=8,
+    )
+
+    assert rc == 0
 
 
 def test_run_single_response_driver_must_match_request() -> None:

--- a/examples/AutoResearch/AutoResearchRemotePinMethods.cpp
+++ b/examples/AutoResearch/AutoResearchRemotePinMethods.cpp
@@ -318,8 +318,6 @@ void AutoResearchRemoteControl::bindPinMethods(fl::Remote& remote) {
         if (rx_pin_changed) {
             mState->pin_rx = new_rx_pin;
 
-            FL_PRINT("[RPC] setPins - Recreating RX channel on GPIO " << new_rx_pin << "...");
-
             // Destroy old RX channel
             mState->rx_channel.reset();
 
@@ -327,7 +325,6 @@ void AutoResearchRemoteControl::bindPinMethods(fl::Remote& remote) {
             mState->rx_channel = mState->rx_factory(new_rx_pin);
 
             if (mState->rx_channel) {
-                FL_PRINT("[RPC] setPins - RX channel recreated successfully");
                 rx_recreated = true;
             } else {
                 FL_ERROR("[RPC] setPins - Failed to create RX channel on GPIO " << new_rx_pin);
@@ -341,9 +338,6 @@ void AutoResearchRemoteControl::bindPinMethods(fl::Remote& remote) {
         } else {
             mState->pin_rx = new_rx_pin;
         }
-
-        FL_PRINT("[RPC] setPins - TX: " << old_tx_pin << " → " << new_tx_pin
-                << ", RX: " << old_rx_pin << " → " << new_rx_pin);
 
         response.set("success", true);
         response.set("txPin", static_cast<int64_t>(new_tx_pin));


### PR DESCRIPTION
﻿## Summary

- require setup RPC responses such as `setPins` to echo the TX/RX pins requested by the AutoResearch wrapper
- fail the run with `pin_state_mismatch` when firmware setup state diverges from wrapper-requested pins
- keep test RPC requested/actual pin validation in place and remove normal-path `setPins` `FL_PRINT` chatter so pin state lives in JSON-RPC fields

## Validation

- `uv run --no-sync pytest ci/tests/test_autoresearch_rpc_acceptance.py ci/tests/test_autoresearch_phases.py -q`
- `uv run --no-sync ruff check ci/autoresearch/phases.py ci/tests/test_autoresearch_rpc_acceptance.py ci/tests/test_autoresearch_phases.py`
- `uv run --no-sync ruff format --check ci/autoresearch/phases.py ci/tests/test_autoresearch_rpc_acceptance.py ci/tests/test_autoresearch_phases.py`
- `git diff --check -- ci/autoresearch/phases.py ci/tests/test_autoresearch_rpc_acceptance.py examples/AutoResearch/AutoResearchRemotePinMethods.cpp`
- `bash lint --cpp`
