### PR TITLE
fix(autoresearch): block stale Teensy preupload

### DIFF
--- a/ci/autoresearch/phases.py
+++ b/ci/autoresearch/phases.py
@@ -316,58 +316,6 @@ async def _run_native_autoresearch(args: Args, build_mode: str = "quick") -> int
     return 0 if result.success else 1
 
 
-def _try_teensy_bootloader_upload(build_dir: Path, environment: str | None) -> bool:
-    """Try to detect Teensy in HalfKay bootloader mode and upload firmware."""
-    if not environment:
-        return False
-
-    loader_paths = [
-        Path.home()
-        / ".platformio"
-        / "packages"
-        / "tool-teensy"
-        / "teensy_loader_cli.exe",
-        Path.home() / ".platformio" / "packages" / "tool-teensy" / "teensy_loader_cli",
-    ]
-    loader = None
-    for p in loader_paths:
-        if p.exists():
-            loader = p
-            break
-    if not loader:
-        return False
-
-    hex_path = build_dir / ".pio" / "build" / environment / "firmware.hex"
-    if not hex_path.exists():
-        return False
-
-    mcu_map = {
-        "teensy41": "TEENSY41",
-        "teensy40": "TEENSY40",
-        "teensylc": "TEENSYLC",
-        "teensy36": "TEENSY36",
-        "teensy35": "TEENSY35",
-        "teensy31": "TEENSY31",
-    }
-    mcu = mcu_map.get(environment.lower())
-    if not mcu:
-        return False
-
-    try:
-        result = subprocess.run(
-            [str(loader), f"--mcu={mcu}", "-v", str(hex_path)],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-        if result.returncode == 0 and "Programming" in result.stdout:
-            return True
-    except (subprocess.TimeoutExpired, OSError):
-        pass
-
-    return False
-
-
 # ============================================================
 # Phase A: Parse args and build commands
 # ============================================================
@@ -1025,7 +973,14 @@ async def _resolve_port_and_environment(ctx: RunContext) -> int | None:
             if is_teensy:
                 print(f"\n{Fore.YELLOW}{'=' * 60}")
                 print(f"  Teensy not detected on USB.")
-                print(f"  Press the PROGRAM button on the Teensy to enter bootloader.")
+                print(
+                    "  AutoResearch will not pre-upload stale .pio firmware "
+                    "during port detection."
+                )
+                print(
+                    "  Power-cycle or reconnect the Teensy so the USB serial "
+                    "port appears, then let fbuild own the deploy."
+                )
                 print(f"{'=' * 60}{Style.RESET_ALL}\n")
             print(
                 f"\u23f3 No USB serial port found yet. Waiting up to {max_wait_s}s for device..."
@@ -1043,26 +998,6 @@ async def _resolve_port_and_environment(ctx: RunContext) -> int | None:
                         f"\u2705 USB serial port detected after {elapsed:.1f}s: {result.selected_port}"
                     )
                     break
-                if is_teensy:
-                    teensy_result = _try_teensy_bootloader_upload(
-                        ctx.build_dir, ctx.final_environment
-                    )
-                    if teensy_result:
-                        print(
-                            "\u2705 Firmware uploaded via Teensy bootloader, waiting for serial port..."
-                        )
-                        serial_deadline = time.monotonic() + 15
-                        while time.monotonic() < serial_deadline:
-                            time.sleep(1.0)
-                            result = auto_detect_upload_port(
-                                expected_environment=expected_environment
-                            )
-                            if result.ok:
-                                print(
-                                    f"\u2705 Teensy serial port detected: {result.selected_port}"
-                                )
-                                break
-                        break
                 now = time.monotonic()
                 if now - last_msg_at >= 5.0:
                     remaining = deadline - now
@@ -1089,7 +1024,9 @@ async def _resolve_port_and_environment(ctx: RunContext) -> int | None:
             )
             if is_teensy:
                 print(
-                    f"{Fore.YELLOW}Teensy hint: Hold the PROGRAM button while plugging in USB to force bootloader mode.{Style.RESET_ALL}"
+                    f"{Fore.YELLOW}Teensy hint: keep the board in USB serial mode "
+                    f"for AutoResearch acceptance; fbuild must perform the first "
+                    f"firmware deploy for this run.{Style.RESET_ALL}"
                 )
             print(
                 f"{Fore.RED}Note: Bluetooth serial ports (BTHENUM) are not supported.{Style.RESET_ALL}\n"

--- a/ci/lint_cpp_rs/src/checkers/style.rs
+++ b/ci/lint_cpp_rs/src/checkers/style.rs
@@ -372,6 +372,71 @@ impl FileContentChecker for ExampleSerialChecker {
     }
 }
 
+struct AutoResearchRuntimeOutputChecker;
+
+impl FileContentChecker for AutoResearchRuntimeOutputChecker {
+    fn name(&self) -> &'static str {
+        "AutoResearchRuntimeOutputChecker"
+    }
+
+    fn should_process_file(&self, file_path: &str, _project_root: &Path) -> bool {
+        if !ends_with_any(file_path, &[".cpp", ".h", ".hpp", ".ino"]) {
+            return false;
+        }
+        let normalized = normalize_path(file_path);
+        normalized.ends_with("examples/AutoResearch/AutoResearch.ino")
+            || normalized.contains("examples/AutoResearch/AutoResearchRemote")
+    }
+
+    fn check_file_content(&self, file_content: &FileContent) -> Vec<(usize, String)> {
+        if !self.should_process_file(&file_content.path, Path::new(".")) {
+            return Vec::new();
+        }
+
+        let mut violations = Vec::new();
+        let mut in_multiline_comment = false;
+
+        for (index, line) in file_content.lines.iter().enumerate() {
+            let stripped = line.trim();
+
+            if line.contains("/*") {
+                in_multiline_comment = true;
+            }
+            if line.contains("*/") {
+                in_multiline_comment = false;
+                continue;
+            }
+            if in_multiline_comment || stripped.starts_with("//") {
+                continue;
+            }
+
+            let (code_part, comment_part) = line
+                .split_once("//")
+                .map_or((line.as_str(), ""), |(code, comment)| (code, comment));
+            let code_without_strings =
+                regex_string_literal().replace_all(code_part, "\"\"").to_string();
+            if !regex_autoresearch_forbidden_runtime_output().is_match(&code_without_strings) {
+                continue;
+            }
+            if comment_part
+                .to_ascii_lowercase()
+                .contains("ok autoresearch rpc serial")
+            {
+                continue;
+            }
+
+            violations.push((
+                index + 1,
+                format!(
+                    "AutoResearch runtime output must use JSON-RPC result fields, not direct logging/serial output.\n      Line: {stripped}\n      If this is the RPC transport boundary itself, suppress with `// ok autoresearch rpc serial - <reason>`."
+                ),
+            ));
+        }
+
+        violations
+    }
+}
+
 struct IncludeAfterNamespaceChecker;
 
 impl FileContentChecker for IncludeAfterNamespaceChecker {
@@ -547,4 +612,3 @@ impl FileContentChecker for UsingNamespaceChecker {
         violations
     }
 }
-

--- a/ci/lint_cpp_rs/src/lint_core/processor_registry_cli.rs
+++ b/ci/lint_cpp_rs/src/lint_core/processor_registry_cli.rs
@@ -253,6 +253,7 @@ pub fn supported_checker_names() -> &'static [&'static str] {
         "banned_macros",
         "banned_namespace",
         "builtin_memcpy",
+        "autoresearch_runtime_output",
         "fl_no_underscore",
         "legacy_log_macro",
         "cpp_hpp_includes",
@@ -329,6 +330,7 @@ pub fn supported_python_checker_names() -> &'static [&'static str] {
         "BannedMacrosChecker",
         "BannedNamespaceChecker",
         "BuiltinMemcpyChecker",
+        "AutoResearchRuntimeOutputChecker",
         "FlNoUnderscoreChecker",
         "LegacyLogMacroChecker",
         "CppHppIncludesChecker",
@@ -462,6 +464,10 @@ pub fn create_checkers(
         ("banned_macros", Box::new(BannedMacrosChecker)),
         ("banned_namespace", Box::new(BannedNamespaceChecker)),
         ("builtin_memcpy", Box::new(BuiltinMemcpyChecker)),
+        (
+            "autoresearch_runtime_output",
+            Box::new(AutoResearchRuntimeOutputChecker),
+        ),
         ("fl_no_underscore", Box::new(FlNoUnderscoreChecker)),
         ("legacy_log_macro", Box::new(LegacyLogMacroChecker)),
         ("cpp_hpp_includes", Box::new(CppHppIncludesChecker)),
@@ -984,4 +990,3 @@ fn strip_string_literals(code: &str) -> String {
 
     result
 }
-

--- a/ci/lint_cpp_rs/src/lint_core/regexes.rs
+++ b/ci/lint_cpp_rs/src/lint_core/regexes.rs
@@ -461,6 +461,16 @@ fn regex_serial_method() -> &'static Regex {
     VALUE.get_or_init(|| Regex::new(r"\bSerial\.(\w+)\s*\(").unwrap())
 }
 
+fn regex_autoresearch_forbidden_runtime_output() -> &'static Regex {
+    static VALUE: OnceLock<Regex> = OnceLock::new();
+    VALUE.get_or_init(|| {
+        Regex::new(
+            r"\b(?:FL_(?:PRINT|WARN|ERROR)(?:_[A-Z0-9]+)?|Serial\.(?:print\w*|write|flush)|fl::(?:print|println|printf|write|flush|serial_(?:print|println|printf|write|flush)))\s*\(",
+        )
+        .unwrap()
+    })
+}
+
 fn regex_iram_function() -> &'static Regex {
     static VALUE: OnceLock<Regex> = OnceLock::new();
     VALUE.get_or_init(|| {
@@ -659,4 +669,3 @@ fn regex_legacy_log_macro() -> &'static Regex {
         Regex::new(&format!(r"\b({})\s*\(", MACROS.join("|"))).unwrap()
     })
 }
-

--- a/ci/lint_cpp_rs/src/lint_core/tests.rs
+++ b/ci/lint_cpp_rs/src/lint_core/tests.rs
@@ -51,6 +51,55 @@ mod tests {
     }
 
     #[test]
+    fn autoresearch_runtime_output_flags_direct_logging_and_serial_prints() {
+        let checker = AutoResearchRuntimeOutputChecker;
+        let result = checker.check_file_content(&file(
+            "examples/AutoResearch/AutoResearch.ino",
+            "FL_WARN(\"boot chatter\");\nFL_ERROR(\"boot failure\");\nSerial.println(\"not rpc\");\nfl::println(\"nope\");\n",
+        ));
+        assert_eq!(result.len(), 4);
+    }
+
+    #[test]
+    fn autoresearch_runtime_output_allows_rpc_serial_boundary_only() {
+        let checker = AutoResearchRuntimeOutputChecker;
+        let result = checker.check_file_content(&file(
+            "examples/AutoResearch/AutoResearchRemote.cpp",
+            "Serial.println(formatted.c_str());  // ok autoresearch rpc serial - RPC response boundary\n",
+        ));
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn autoresearch_runtime_output_scope_is_limited() {
+        let checker = AutoResearchRuntimeOutputChecker;
+        assert!(checker.should_process_file(
+            "examples/AutoResearch/AutoResearchRemotePinMethods.cpp",
+            Path::new(".")
+        ));
+        assert!(!checker.should_process_file(
+            "examples/AutoResearch/AutoResearchTest.cpp",
+            Path::new(".")
+        ));
+        assert!(checker
+            .check_file_content(&file(
+                "examples/AutoResearch/AutoResearchTest.cpp",
+                "FL_WARN(\"diagnostic-only path\");\n",
+            ))
+            .is_empty());
+    }
+
+    #[test]
+    fn autoresearch_runtime_output_ignores_strings_and_comments() {
+        let checker = AutoResearchRuntimeOutputChecker;
+        let result = checker.check_file_content(&file(
+            "examples/AutoResearch/AutoResearch.ino",
+            "// FL_WARN(\"comment\")\nconst char* s = \"Serial.println\";\n",
+        ));
+        assert!(result.is_empty());
+    }
+
+    #[test]
     fn bare_allocation_rejects_malloc_but_not_fl_malloc() {
         let checker = BareAllocationChecker;
         assert_eq!(

--- a/ci/tests/test_autoresearch_phases.py
+++ b/ci/tests/test_autoresearch_phases.py
@@ -656,6 +656,56 @@ class TestResolvePortAndEnvironment:
             rc = asyncio.run(_resolve_port_and_environment(ctx))
         assert rc == 1
 
+    def test_teensy_port_detection_never_uploads_stale_pio_hex(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        stale_hex = tmp_path / ".pio" / "build" / "teensy41" / "firmware.hex"
+        stale_hex.parent.mkdir(parents=True)
+        stale_hex.write_text("", encoding="utf-8")
+
+        ctx = _make_ctx(
+            upload_port=None,
+            final_environment="teensy41",
+            build_dir=tmp_path,
+        )
+        ctx.args = _make_args(
+            upload_port=None,
+            environment="teensy41",
+            object_fled=True,
+            parlio=False,
+            use_root_platformio_ini=False,
+            project_dir=tmp_path,
+        )
+        mock_result = MagicMock(
+            ok=False,
+            selected_port=None,
+            error_message="No USB",
+            all_ports=[],
+        )
+        call_count = [0]
+        original_monotonic = __import__("time").monotonic
+
+        def fake_monotonic() -> float:
+            call_count[0] += 1
+            if call_count[0] <= 2:
+                return original_monotonic()
+            return original_monotonic() + 999
+
+        with (
+            patch(f"{_PATCH_MOD}.auto_detect_upload_port", return_value=mock_result),
+            patch(f"{_PATCH_MOD}.time") as mock_time,
+            patch(f"{_PATCH_MOD}.subprocess.run") as mock_subprocess_run,
+        ):
+            mock_time.monotonic = fake_monotonic
+            mock_time.sleep = MagicMock()
+            rc = asyncio.run(_resolve_port_and_environment(ctx))
+
+        output = capsys.readouterr().out
+        assert rc == 1
+        mock_subprocess_run.assert_not_called()
+        assert "AutoResearch will not pre-upload stale .pio firmware" in output
+        assert "Firmware uploaded via Teensy bootloader" not in output
+
 
 class TestAutoDetectUploadPort:
     """Test USB port detection edge cases used by autoresearch."""

--- a/examples/AutoResearch/AutoResearch.ino
+++ b/examples/AutoResearch/AutoResearch.ino
@@ -99,14 +99,14 @@ void loop()  { autoResearchLowMemoryLoop(); }
 // ============================================================================
 // AGENT INSTRUCTIONS
 // ============================================================================
-// This sketch is an autoresearch test that uses the "ERROR" keyword in FL_ERROR
-// statements to signal test failures. The `bash debug` command monitors for
-// the "ERROR" keyword and fails the test when detected (exit code 1).
+// AutoResearch runtime output must stay machine-readable. Use JSON-RPC
+// responses and RESULT JSONL events for test state, failures, and diagnostics.
 //
 // 🚫 DO NOT "CHEAT" THE TEST:
 //    - DO NOT change "ERROR" to "FAIL", "WARNING", "FAILURE", or any other
 //      keyword to avoid test detection
-//    - DO NOT modify FL_ERROR statements unless explicitly requested by the user
+//    - DO NOT add FL_ERROR, FL_PRINT, FL_WARN, Serial.print*, or fl::print*
+//      runtime output in this sketch
 //    - The "ERROR" keyword is INTENTIONAL and part of the autoresearch contract
 //
 // ✅ VALID MODIFICATIONS (only if explicitly requested):
@@ -138,7 +138,7 @@ void loop()  { autoResearchLowMemoryLoop(); }
 //       print(result)
 //   "
 //
-// Text output (FL_PRINT, FL_WARN) is for human diagnostics ONLY.
+// Direct text output is not allowed in runtime paths while tests are running.
 // Machine coordination uses ONLY JSON-RPC commands and JSONL events.
 // ============================================================================
 
@@ -341,8 +341,6 @@ void setup() {
     uint32_t serial_wait_start = millis();
     while (!fl::serial_ready() && (millis() - serial_wait_start) < AUTORESEARCH_SERIAL_WAIT_MS);  // Wait for serial monitor (early exits when connected)
 
-    FL_WARN("[SETUP] AutoResearch sketch starting - serial output active");
-
     // Note: the unified watchdog is armed lazily by FL_WATCHDOG_AUTO() at the
     // top of loop() — no explicit setup() call needed. The macro prints the
     // prior-boot reset info via ResetInfo::describe() and pauses 3 s on crash
@@ -383,7 +381,6 @@ void setup() {
     ss << "  Loopback Mode: " << loop_back_mode << "\n";
     ss << "  Color Order: RGB\n";
     ss << "  RX Buffer Size: " << RX_BUFFER_SIZE << " bytes";
-    FL_PRINT(ss.str());
 
     // SIMD validation suite, Wave8 expansion micro-bench, and full PARLIO
     // encode bench are RPC-driven — invoke via the `testSimd`,
@@ -399,23 +396,22 @@ void setup() {
     ss << "\n[RX SETUP] Creating RX channel for LED autoresearch\n";
     ss << "[RX CREATE] Creating RX channel on PIN " << PIN_RX
        << " (" << (40000000 / 1000000) << "MHz, " << RX_BUFFER_SIZE << " symbols)";
-    FL_PRINT(ss.str());
 
     g_autoresearch_state->rx_channel = createRxDevice(PIN_RX);
 
     if (!g_autoresearch_state->rx_channel) {
-        ss.clear();
-        ss << "[RX SETUP]: Failed to create RX channel\n";
-        ss << "[RX SETUP]: Check that RMT peripheral is available and not in use";
-        FL_ERROR(ss.str());
-        FL_ERROR("Sanity check failed - RX channel creation failed");
+        fl::json errorData = fl::json::object();
+        errorData.set("error", "RxChannelCreationFailed");
+        errorData.set("message", "Failed to create RX channel during setup");
+        errorData.set("pinRx", static_cast<int64_t>(PIN_RX));
+        errorData.set("rxBackend", fl::toString(RX_BACKEND).c_str());
+        printStreamRaw("setupError", errorData);
         return;
     }
 
     ss.clear();
     ss << "[RX CREATE] ✓ RX channel created successfully (will be initialized with config in begin())\n";
     ss << "[RX SETUP] ✓ RX channel ready for LED autoresearch";
-    FL_PRINT(ss.str());
 
     // PARLIO streaming validation (#2548) is now RPC-driven via the
     // `parlioStreamValidate` handler registered in AutoResearchRemote.cpp.
@@ -429,19 +425,15 @@ void setup() {
 
     ss.clear();
     ss << "\n[REMOTE RPC] Registering JSON RPC functions for dynamic control";
-    FL_PRINT(ss.str());
 
     // Initialize RemoteControl singleton and register all RPC functions
     RemoteControlSingleton::instance().registerFunctions(g_autoresearch_state);
 
-    FL_PRINT("[REMOTE RPC] ✓ RPC system initialized (testGpioConnection available)");
 
     // ========================================================================
     // Async Task Setup - JSON-RPC Processing
     // ========================================================================
-    FL_PRINT("[ASYNC] Setting up JSON-RPC async task (10ms interval)");
     autoresearch::setupRpcAsyncTask(RemoteControlSingleton::instance(), 10);
-    FL_PRINT("[ASYNC] ✓ JSON-RPC task registered with scheduler");
 
     // Stub: register self-running autoresearch client (no-op on ESP32)
     autoresearch::maybeRegisterStubAutorun(RemoteControlSingleton::instance(),
@@ -452,11 +444,9 @@ void setup() {
     // ========================================================================
     ss.clear();
     ss << "\n[GPIO BASELINE TEST] Testing GPIO " << PIN_TX << " → GPIO " << PIN_RX << " connectivity";
-    FL_PRINT(ss.str());
 
     // GPIO baseline test moved to loop() - wait for RPC start signal before testing
     // This allows JSON-RPC commands (testGpioConnection, findConnectedPins) to run first
-    FL_WARN("[GPIO BASELINE TEST] Deferred to loop() - waiting for RPC start signal");
 
     // Post-#2428 the channel driver registry no longer auto-populates. This
     // example needs every available driver enrolled with ChannelManager so the
@@ -473,7 +463,6 @@ void setup() {
            << " (priority: " << g_autoresearch_state->drivers_available[i].priority
            << ", enabled: " << (g_autoresearch_state->drivers_available[i].enabled ? "yes" : "no") << ")\n";
     }
-    FL_PRINT(ss.str());
 
     // Validate that expected drivers are available for this platform
     autoResearchExpectedEngines();
@@ -485,10 +474,12 @@ void setup() {
     readyData.set("drivers", static_cast<int64_t>(g_autoresearch_state->drivers_available.size()));
     readyData.set("pinTx", static_cast<int64_t>(PIN_TX));
     readyData.set("pinRx", static_cast<int64_t>(PIN_RX));
+    readyData.set("chip", autoresearch::chipName());
+    readyData.set("rxBackend", fl::toString(RX_BACKEND).c_str());
+    readyData.set("loopbackMode", loop_back_mode);
+    readyData.set("rxBufferSize", static_cast<int64_t>(RX_BUFFER_SIZE));
     printStreamRaw("ready", readyData);
 
-    // Human-readable diagnostics (not machine-parsed)
-    FL_PRINT("\n[SETUP COMPLETE] AutoResearch ready - awaiting JSON-RPC commands");
     delay(2000);
 }
 
@@ -529,7 +520,6 @@ void loop() {
     // and is reflashable.
     // ========================================================================
     if (g_autoresearch_state->deliberate_hang_requested) {
-        FL_WARN("[deliberateHang] entering forced-hang loop NOW");
         delay(200);  // give Serial TX FIFO time to flush
         // noInterrupts() is an Arduino-only macro; guard it so the host stub
         // build (which compiles this .ino for the unit-test framework) doesn't
@@ -555,23 +545,17 @@ void loop() {
         if (millis() > 500) {
             g_autoresearch_state->gpio_baseline_test_done = true;
 
-            FL_PRINT("\n[GPIO BASELINE TEST] Testing GPIO " << PIN_TX << " → GPIO " << PIN_RX << " connectivity");
-
             // Test RX channel with manual GPIO toggle to confirm hardware path works
             // This isolates GPIO/hardware issues from PARLIO driver issues
             // Buffer size = 100 symbols, hz = 40MHz (same as LED autoresearch)
-            if (!testRxChannel(g_autoresearch_state->rx_channel, PIN_TX, PIN_RX, 40000000, 100)) {
-                FL_WARN("[GPIO BASELINE TEST] FAILED - RX did not capture manual GPIO toggles");
-                FL_WARN("[GPIO BASELINE TEST] Possible causes:");
-                FL_WARN("  1. GPIO " << PIN_TX << " and GPIO " << PIN_RX << " are not physically connected");
-                FL_WARN("  2. RX channel initialization failed");
-                FL_WARN("  3. GPIO conflict with other peripherals (USB Serial JTAG on C6 uses certain GPIOs)");
-                FL_WARN("[GPIO BASELINE TEST] Continuing - JSON-RPC pin discovery/testing available");
-            } else {
-                FL_WARN("\n[GPIO BASELINE TEST] ✓ PASSED - GPIO path confirmed working");
-                FL_WARN("[GPIO BASELINE TEST] ✓ RX successfully captured manual GPIO toggles");
-                FL_WARN("[GPIO BASELINE TEST] ✓ Hardware connectivity verified (GPIO " << PIN_TX << " → GPIO " << PIN_RX << ")");
-            }
+            const bool gpio_ok = testRxChannel(g_autoresearch_state->rx_channel, PIN_TX, PIN_RX, 40000000, 100);
+            fl::json gpioData = fl::json::object();
+            gpioData.set("success", gpio_ok);
+            gpioData.set("pinTx", static_cast<int64_t>(PIN_TX));
+            gpioData.set("pinRx", static_cast<int64_t>(PIN_RX));
+            gpioData.set("hz", static_cast<int64_t>(40000000));
+            gpioData.set("symbols", static_cast<int64_t>(100));
+            printStreamRaw("gpioBaseline", gpioData);
         }
     }
 

--- a/examples/AutoResearch/AutoResearchRemote.cpp
+++ b/examples/AutoResearch/AutoResearchRemote.cpp
@@ -69,16 +69,16 @@
 void printJsonRaw(const fl::json& json, const char* prefix) {
     // Serialize and print response
     fl::string formatted = fl::formatJsonResponse(json, prefix);
-    Serial.println(formatted.c_str());  // ok serial - RPC response bypasses FastLED log gate
-    Serial.flush();                     // ok serial - ensure host sees RPC boundary promptly
+    Serial.println(formatted.c_str());  // ok autoresearch rpc serial - RPC response boundary
+    Serial.flush();                     // ok autoresearch rpc serial - host waits for RPC boundary
 }
 
 namespace {
 
 void printRemoteResponseRaw(const fl::json& response) {
     fl::string formatted = fl::formatJsonResponse(response, "REMOTE: ");
-    Serial.println(formatted.c_str());  // ok serial - RPC response bypasses FastLED log gate
-    Serial.flush();                     // ok serial - host waits for RPC response boundary
+    Serial.println(formatted.c_str());  // ok autoresearch rpc serial - RPC response boundary
+    Serial.flush();                     // ok autoresearch rpc serial - host waits for RPC boundary
 }
 
 }  // namespace
@@ -98,7 +98,7 @@ void printStreamRaw(const char* messageType, const fl::json& data) {
 
     // Use fl:: serial transport for consistent formatting
     fl::string formatted = fl::formatJsonResponse(output, "RESULT: ");
-    Serial.println(formatted.c_str());  // ok serial - stream response bypasses FastLED log gate
+    Serial.println(formatted.c_str());  // ok autoresearch rpc serial - stream response boundary
 }
 
 // ============================================================================
@@ -254,11 +254,11 @@ fl::json AutoResearchRemoteControl::findConnectedPinsImpl(const fl::json& args) 
                 mState->rx_channel.reset();
                 mState->rx_channel = mState->rx_factory(found_rx);
                 if (!mState->rx_channel) {
-                    FL_ERROR("[PIN PROBE] Failed to recreate RX channel on GPIO " << found_rx);
                     // Restore old values
                     mState->pin_tx = old_tx;
                     mState->pin_rx = old_rx;
                     response.set("error", "RxChannelCreationFailed");
+                    response.set("message", "Failed to recreate RX channel on discovered pin");
                     response.set("autoApplied", false);
                     return response;
                 }
@@ -330,7 +330,6 @@ void AutoResearchRemoteControl::tick(uint32_t current_millis) {
         mBleState = nullptr;
         mState->ble_server_active = false;
         getBleState().ble_server_active = false;
-        FL_WARN("[BLE] Deferred teardown complete");
     }
 }
 
@@ -398,7 +397,6 @@ fl::json AutoResearchRemoteControl::startBleRemote() {
     response.set("service_uuid", FL_BLE_SERVICE_UUID);
     response.set("rx_uuid", FL_BLE_CHAR_RX_UUID);
     response.set("tx_uuid", FL_BLE_CHAR_TX_UUID);
-    FL_WARN("[BLE] Remote created and advertising");
     return response;
 }
 

--- a/examples/AutoResearch/AutoResearchRemotePinMethods.cpp
+++ b/examples/AutoResearch/AutoResearchRemotePinMethods.cpp
@@ -200,8 +200,6 @@ void AutoResearchRemoteControl::bindPinMethods(fl::Remote& remote) {
         int old_pin = mState->pin_tx;
         mState->pin_tx = new_pin;
 
-        FL_PRINT("[RPC] setTxPin(" << new_pin << ") - TX pin changed from " << old_pin << " to " << new_pin);
-
         response.set("success", true);
         response.set("txPin", static_cast<int64_t>(new_pin));
         response.set("previousTxPin", static_cast<int64_t>(old_pin));
@@ -235,8 +233,6 @@ void AutoResearchRemoteControl::bindPinMethods(fl::Remote& remote) {
             mState->pin_rx = new_pin;
 
             // Recreate RX channel with new pin
-            FL_PRINT("[RPC] setRxPin(" << new_pin << ") - Recreating RX channel...");
-
             // Destroy old RX channel
             mState->rx_channel.reset();
 
@@ -244,12 +240,11 @@ void AutoResearchRemoteControl::bindPinMethods(fl::Remote& remote) {
             mState->rx_channel = mState->rx_factory(new_pin);
 
             if (mState->rx_channel) {
-                FL_PRINT("[RPC] setRxPin - RX channel recreated on GPIO " << new_pin);
                 rx_recreated = true;
             } else {
-                FL_ERROR("[RPC] setRxPin - Failed to create RX channel on GPIO " << new_pin);
                 response.set("error", "RxChannelCreationFailed");
                 response.set("message", "Failed to create RX channel on new pin");
+                response.set("pinRx", static_cast<int64_t>(new_pin));
                 // Restore old pin value
                 mState->pin_rx = old_pin;
                 return response;
@@ -327,12 +322,12 @@ void AutoResearchRemoteControl::bindPinMethods(fl::Remote& remote) {
             if (mState->rx_channel) {
                 rx_recreated = true;
             } else {
-                FL_ERROR("[RPC] setPins - Failed to create RX channel on GPIO " << new_rx_pin);
                 // Rollback both pins
                 mState->pin_tx = old_tx_pin;
                 mState->pin_rx = old_rx_pin;
                 response.set("error", "RxChannelCreationFailed");
                 response.set("message", "Failed to create RX channel - pins restored to previous values");
+                response.set("pinRx", static_cast<int64_t>(new_rx_pin));
                 return response;
             }
         } else {


### PR DESCRIPTION
## Summary
- remove the Teensy HalfKay/stale `.pio/build/<env>/firmware.hex` pre-upload from AutoResearch port detection so fbuild owns deploy
- add `AutoResearchRuntimeOutputChecker` to ban direct `FL_PRINT*`, `FL_WARN*`, `FL_ERROR*`, `Serial.print*`/`write`/`flush`, and `fl::print*`/serial-output helpers in AutoResearch runtime/RPC files
- keep raw `Serial` only at explicit JSON-RPC/JSONL transport boundaries with `// ok autoresearch rpc serial - ...`
- replace scoped setup/GPIO/pin-mutation diagnostics with structured JSON result fields/events

## Validation
- `uv run --no-sync pytest ci/tests/test_autoresearch_phases.py -q` -> 68 passed
- `uv run --no-sync ruff check ci/autoresearch/phases.py ci/tests/test_autoresearch_phases.py` -> passed
- `soldr cargo fmt --manifest-path ci/lint_cpp_rs/Cargo.toml --check` -> passed
- `soldr cargo check --manifest-path ci/lint_cpp_rs/Cargo.toml --target x86_64-unknown-linux-gnu --tests` -> passed, existing warnings only
- `git diff --check -- <changed files>` -> passed
- Native `soldr cargo test --manifest-path ci/lint_cpp_rs/Cargo.toml` is blocked locally by a `soldr`/MSVC sysroot issue: rustc reports missing `std` for installed target `x86_64-pc-windows-msvc`; GNU-target typecheck passed.