### PR TITLE
[codex] Map Teensy AutoResearch SPI to SPI_UNIFIED

### DIFF
--- a/ci/autoresearch/args.py
+++ b/ci/autoresearch/args.py
@@ -144,7 +144,7 @@ Driver Selection (JSON-RPC):
   MANDATORY: You MUST specify at least one driver flag:
     --parlio       Test only PARLIO driver
     --rmt          Test only RMT driver
-    --spi          Test only SPI driver
+    --spi          Test only SPI driver (Teensy 4.x resolves to SPI_UNIFIED)
     --uart         Test only UART driver
     --lcd          Test only LCD_CLOCKLESS driver (ESP32-S3 only, replaces misnamed I2S)
     --lcd-spi      Test only LCD_SPI driver (ESP32-S3 only, APA102/SK9822)
@@ -223,7 +223,7 @@ See Also:
         driver_group.add_argument(
             "--spi",
             action="store_true",
-            help="Test only SPI driver",
+            help="Test only SPI driver (Teensy 4.x resolves to SPI_UNIFIED)",
         )
         driver_group.add_argument(
             "--uart",

--- a/ci/autoresearch/phases.py
+++ b/ci/autoresearch/phases.py
@@ -65,6 +65,19 @@ WATCHDOG_GRACE_SECONDS = 20.0
 FLEX_IO_TEENSY_DEFAULT_TX_PIN = 6
 
 
+def _is_teensy4_environment(final_environment: str | None) -> bool:
+    return final_environment is not None and final_environment.lower() in (
+        "teensy40",
+        "teensy41",
+    )
+
+
+def _driver_name_for_environment(driver: str, final_environment: str | None) -> str:
+    if driver == "SPI" and _is_teensy4_environment(final_environment):
+        return "SPI_UNIFIED"
+    return driver
+
+
 def _uses_teensy_flex_io_default_tx(
     args: Args, final_environment: str, drivers: list[str]
 ) -> bool:
@@ -390,10 +403,7 @@ def _parse_args_and_build_commands(args: Args) -> RunContext | int:
             )
             sys.exit(2)
 
-    is_teensy4 = final_environment is not None and final_environment.lower() in (
-        "teensy40",
-        "teensy41",
-    )
+    is_teensy4 = _is_teensy4_environment(final_environment)
     is_teensy_specific_driver = args.object_fled or args.flex_io or args.lpuart
 
     if args.use_root_platformio_ini and (is_teensy4 or is_teensy_specific_driver):
@@ -434,7 +444,7 @@ def _parse_args_and_build_commands(args: Args) -> RunContext | int:
         if args.rmt:
             drivers.append("RMT")
         if args.spi:
-            drivers.append("SPI")
+            drivers.append(_driver_name_for_environment("SPI", final_environment))
         if args.uart:
             drivers.append("UART")
         if args.lcd:

--- a/ci/lint_cpp_rs/src/lint_core/regexes.rs
+++ b/ci/lint_cpp_rs/src/lint_core/regexes.rs
@@ -465,7 +465,7 @@ fn regex_autoresearch_forbidden_runtime_output() -> &'static Regex {
     static VALUE: OnceLock<Regex> = OnceLock::new();
     VALUE.get_or_init(|| {
         Regex::new(
-            r"\b(?:FL_(?:PRINT|WARN|ERROR)(?:_[A-Z0-9]+)?|Serial\.(?:print\w*|write|flush)|fl::(?:print|println|printf|write|flush|serial_(?:print|println|printf|write|flush)))\s*\(",
+            r"\b(?:FL_(?:PRINT|WARN|ERROR)(?:_[A-Z0-9]+)*|Serial\.(?:print\w*|write|flush)|fl::(?:print|println|printf|write|flush|serial_(?:print\w*|println|printf|write|flush)))\s*\(",
         )
         .unwrap()
     })

--- a/ci/lint_cpp_rs/src/lint_core/tests.rs
+++ b/ci/lint_cpp_rs/src/lint_core/tests.rs
@@ -55,9 +55,19 @@ mod tests {
         let checker = AutoResearchRuntimeOutputChecker;
         let result = checker.check_file_content(&file(
             "examples/AutoResearch/AutoResearch.ino",
-            "FL_WARN(\"boot chatter\");\nFL_ERROR(\"boot failure\");\nSerial.println(\"not rpc\");\nfl::println(\"nope\");\n",
+            "FL_WARN(\"boot chatter\");\nFL_WARN_F_ONCE(\"boot chatter\");\nFL_PRINT_EVERY(1000, \"tick\");\nFL_ERROR(\"boot failure\");\nSerial.println(\"not rpc\");\nSerial.printf(\"not rpc\");\nfl::println(\"nope\");\nfl::serial_println(\"nope\");\nfl::serial_printf(\"nope\");\n",
         ));
-        assert_eq!(result.len(), 4);
+        assert_eq!(result.len(), 9);
+    }
+
+    #[test]
+    fn autoresearch_runtime_output_allows_serial_setup_helpers() {
+        let checker = AutoResearchRuntimeOutputChecker;
+        let result = checker.check_file_content(&file(
+            "examples/AutoResearch/AutoResearch.ino",
+            "fl::serial_begin(115200);\nwhile (!fl::serial_ready()) {}\n",
+        ));
+        assert!(result.is_empty());
     }
 
     #[test]

--- a/ci/tests/test_autoresearch_phases.py
+++ b/ci/tests/test_autoresearch_phases.py
@@ -238,6 +238,32 @@ class TestParseArgsAndBuildCommands:
         assert not any("__skip_with_pass" in cmd for cmd in result.json_rpc_commands)
         assert all("pinTx" not in cmd["params"] for cmd in result.json_rpc_commands)
 
+    def test_spi_driver_name_remains_spi_on_esp32(self, fake_project_dir: Path) -> None:
+        args = _make_args(parlio=False, spi=True, project_dir=fake_project_dir)
+        result = _parse_args_and_build_commands(args)
+        assert isinstance(result, RunContext)
+        assert result.drivers == ["SPI"]
+        assert result.json_rpc_commands[0]["params"]["driver"] == "SPI"
+
+    def test_spi_driver_name_maps_to_spi_unified_on_teensy4(
+        self, fake_project_dir: Path
+    ) -> None:
+        args = _make_args(
+            parlio=False,
+            spi=True,
+            environment_positional="teensy41",
+            project_dir=fake_project_dir,
+            use_root_platformio_ini=False,
+        )
+        with patch(
+            "ci.autoresearch.staging.synthesise_autoresearch_project",
+            return_value=fake_project_dir,
+        ):
+            result = _parse_args_and_build_commands(args)
+        assert isinstance(result, RunContext)
+        assert result.drivers == ["SPI_UNIFIED"]
+        assert result.json_rpc_commands[0]["params"]["driver"] == "SPI_UNIFIED"
+
     def test_flex_io_does_not_hide_tx_pin_override(
         self, fake_project_dir: Path
     ) -> None:

--- a/examples/AutoResearch/AutoResearch.ino
+++ b/examples/AutoResearch/AutoResearch.ino
@@ -404,7 +404,7 @@ void setup() {
         errorData.set("error", "RxChannelCreationFailed");
         errorData.set("message", "Failed to create RX channel during setup");
         errorData.set("pinRx", static_cast<int64_t>(PIN_RX));
-        errorData.set("rxBackend", fl::toString(RX_BACKEND).c_str());
+        errorData.set("rxBackend", fl::toString(RX_BACKEND));
         printStreamRaw("setupError", errorData);
         return;
     }
@@ -475,7 +475,7 @@ void setup() {
     readyData.set("pinTx", static_cast<int64_t>(PIN_TX));
     readyData.set("pinRx", static_cast<int64_t>(PIN_RX));
     readyData.set("chip", autoresearch::chipName());
-    readyData.set("rxBackend", fl::toString(RX_BACKEND).c_str());
+    readyData.set("rxBackend", fl::toString(RX_BACKEND));
     readyData.set("loopbackMode", loop_back_mode);
     readyData.set("rxBufferSize", static_cast<int64_t>(RX_BUFFER_SIZE));
     printStreamRaw("ready", readyData);

--- a/examples/AutoResearch/AutoResearchRemoteAsyncMethods.cpp
+++ b/examples/AutoResearch/AutoResearchRemoteAsyncMethods.cpp
@@ -480,10 +480,8 @@ void AutoResearchRemoteControl::bindAsyncMethods(fl::Remote& remote) {
                 }
                 if (success) {
                     passed++;
-                    FL_PRINT("[COROUTINE] PASS: " << test_names[i]);
                 } else {
                     failed++;
-                    FL_PRINT("[COROUTINE] FAIL: " << test_names[i]);
                 }
                 results.set(test_names[i], test_result);
             } else {
@@ -492,7 +490,6 @@ void AutoResearchRemoteControl::bindAsyncMethods(fl::Remote& remote) {
                 err.set("success", false);
                 err.set("error", "Method not found");
                 results.set(test_names[i], err);
-                FL_PRINT("[COROUTINE] FAIL: " << test_names[i] << " (not found)");
             }
         }
 

--- a/examples/AutoResearch/AutoResearchRemoteDriverMethods.cpp
+++ b/examples/AutoResearch/AutoResearchRemoteDriverMethods.cpp
@@ -526,13 +526,14 @@ void AutoResearchRemoteControl::bindDriverMethods(fl::Remote& remote) {
             volatile uint32_t *shftbuf  = (volatile uint32_t *)(kFLEXIO1_BASE_DIAG + 0x200);
             volatile uint32_t *shftbufbis = (volatile uint32_t *)(kFLEXIO1_BASE_DIAG + 0x280);
             volatile uint32_t *shftbufbys = (volatile uint32_t *)(kFLEXIO1_BASE_DIAG + 0x300);
-            FL_WARN("[ping diag] post-toggle FLEXIO1: PIN=0x"
-                    << fl::hex << *pin
-                    << " SHIFTSTAT=0x" << *shftstat
-                    << " TIMSTAT=0x" << *timstat << fl::dec);
-            FL_WARN("[ping diag] SHIFTBUF[0]=0x" << fl::hex << *shftbuf
-                    << " SHIFTBUFBIS[0]=0x" << *shftbufbis
-                    << " SHIFTBUFBYS[0]=0x" << *shftbufbys << fl::dec);
+            fl::json flexio_diag = fl::json::object();
+            flexio_diag.set("pin", static_cast<int64_t>(*pin));
+            flexio_diag.set("shiftstat", static_cast<int64_t>(*shftstat));
+            flexio_diag.set("timstat", static_cast<int64_t>(*timstat));
+            flexio_diag.set("shiftbuf0", static_cast<int64_t>(*shftbuf));
+            flexio_diag.set("shiftbufbis0", static_cast<int64_t>(*shftbufbis));
+            flexio_diag.set("shiftbufbys0", static_cast<int64_t>(*shftbufbys));
+            response.set("flexio1", flexio_diag);
         }
 
         // 3. Wait briefly for FlexIO RX to flush any pending DMA. The DMA

--- a/examples/AutoResearch/AutoResearchRemoteRunSingleTest.cpp
+++ b/examples/AutoResearch/AutoResearchRemoteRunSingleTest.cpp
@@ -498,9 +498,11 @@ fl::json AutoResearchRemoteControl::runSingleTestImpl(const fl::json& args) {
     fl::vector<fl::unique_ptr<fl::vector<CRGB>>> led_arrays;
     fl::vector<fl::ChannelConfig> tx_configs;
 
-    // SPI chipset drivers (LCD_SPI, I2S_SPI) use APA102 protocol with data+clock pins
+    // SPI chipset drivers use APA102 protocol with data+clock pins.
     // Clockless drivers use WS2812B timing on a single data pin
-    bool is_spi_chipset_driver = (driver_name == "LCD_SPI" || driver_name == "I2S_SPI");
+    bool is_spi_chipset_driver = (driver_name == "LCD_SPI" ||
+                                  driver_name == "I2S_SPI" ||
+                                  driver_name == "SPI_UNIFIED");
 
     for (fl::size i = 0; i < lane_sizes.size(); i++) {
         auto leds = fl::make_unique<fl::vector<CRGB>>(lane_sizes[i]);

--- a/examples/AutoResearch/AutoResearchRemoteSystemMethods.cpp
+++ b/examples/AutoResearch/AutoResearchRemoteSystemMethods.cpp
@@ -82,11 +82,12 @@ void AutoResearchRemoteControl::bindSystemMethods(fl::Remote& remote) {
     // begins in the next iteration of the loop.
     remote.bind("deliberateHang", [this](const fl::json& args) -> fl::json {
         (void)args;
-        FL_WARN("[deliberateHang] watchdog test: spinning forever in 200 ms");
         mState->deliberate_hang_requested = true;
         fl::json response = fl::json::object();
         response.set("success", true);
         response.set("message", "device will hang after RPC returns; watchdog should reset within configured timeout");
+        response.set("hangDelayMs", static_cast<int64_t>(200));
+        response.set("watchdogExpected", true);
         return response;
     });
 

--- a/examples/AutoResearch/AutoResearchTest.cpp
+++ b/examples/AutoResearch/AutoResearchTest.cpp
@@ -501,12 +501,13 @@ dumpRawEdgeTiming(rx_channel, timing, fl::EdgeRange(0, 32));
         return decode_result.value();
     }
 
-    // SPI chipset drivers (LCD_SPI, I2S_SPI): decode raw SPI bit stream
-    // These drivers use LCD_CAM I80 bus or I2S to output APA102 data.
+    // SPI chipset drivers: decode raw SPI bit stream.
+    // These drivers use platform hardware SPI/I80/I2S to output APA102 data.
     // RMT RX captures edges on the data pin; clock pin is ignored.
     bool is_lcd_spi_driver = (fl::strcmp(driver_name, "LCD_SPI") == 0);
     bool is_i2s_spi_driver = (fl::strcmp(driver_name, "I2S_SPI") == 0);
-    if (is_lcd_spi_driver || is_i2s_spi_driver) {
+    bool is_spi_unified_driver = (fl::strcmp(driver_name, "SPI_UNIFIED") == 0);
+    if (is_lcd_spi_driver || is_i2s_spi_driver || is_spi_unified_driver) {
         // SPI clock used for validation: 2.4MHz (matches ValidationRemote.cpp)
         const uint32_t spi_clock_hz = 2400000;
         FL_WARN("[CAPTURE] SPI chipset decode: clock=" << spi_clock_hz << " Hz");


### PR DESCRIPTION
## Summary

- Maps explicit Teensy 4.x AutoResearch `--spi` runs to the registered `SPI_UNIFIED` driver name.
- Treats `SPI_UNIFIED` as a real SPI chipset path in AutoResearch firmware test setup/decode code.
- Converts remaining scoped AutoResearch RPC/runtime diagnostics to JSON result fields and fixes the Teensy `rxBackend` compile blocker.
- Hardens the scoped runtime-output lint regex so multi-suffix FastLED log macros and `fl::serial_print*` helpers are caught.

## Validation

- `uv run --no-sync pytest ci/tests/test_autoresearch_phases.py -q` -> 70 passed
- `uv run --no-sync ruff check ci/autoresearch/phases.py ci/autoresearch/args.py ci/tests/test_autoresearch_phases.py`
- `uv run --no-sync ruff format --check ci/autoresearch/phases.py ci/autoresearch/args.py ci/tests/test_autoresearch_phases.py`
- `soldr cargo fmt --manifest-path ci/lint_cpp_rs/Cargo.toml --check`
- `soldr cargo check --manifest-path ci/lint_cpp_rs/Cargo.toml --target x86_64-unknown-linux-gnu --tests` -> passed with existing unrelated warnings
- `git diff --check -- <changed files>`
- Scoped source scan shows no forbidden direct runtime output in `AutoResearch.ino` / `AutoResearchRemote*` except explicit JSON-RPC serial boundary suppressions.

## Hardware

- `bash autoresearch teensy41 --spi --tx-pin 22 --rx-pin 8 --timeout 120` selected `Drivers SPI_UNIFIED` but stopped at the known local Rust linter MSVC sysroot issue before upload.
- `bash autoresearch teensy41 --spi --tx-pin 22 --rx-pin 8 --timeout 120 --skip-lint` used fbuild deploy on `teensy41 @ COM20`, `FbuildSerialAdapter`, GPIO pre-test `TX 22 -> RX 8`, `setPins` echo `txPin=22 rxPin=8`, and `runSingleTest` driver `SPI_UNIFIED`.
- Hardware result was an honest `zero_capture` failure, not an acceptance PASS: `TEST SPI_UNIFIED lanes=1 leds=100 FAIL 11ms class=zero_capture`.