### PR TITLE
diag(objectfled): attach register snapshots

### DIFF
--- a/ci/autoresearch/context.py
+++ b/ci/autoresearch/context.py
@@ -347,6 +347,29 @@ def display_tight_timing(result: dict[str, Any]) -> None:
     )
 
 
+def display_objectfled_diagnostics(result: dict[str, Any]) -> None:
+    """Display ObjectFLED register snapshots attached to runSingleTest."""
+    diagnostics = result.get("objectFledDiagnostics")
+    if not isinstance(diagnostics, dict):
+        return
+    if diagnostics.get("enabled") is not True:
+        return
+
+    event_count = diagnostics.get("eventCount", "?")
+    overflow_count = diagnostics.get("overflowCount", "?")
+    fmt = diagnostics.get("format", "unknown")
+    snapshot = diagnostics.get("snapshot")
+
+    print()
+    print("  ObjectFLED diagnostics")
+    print(f"    format: {fmt}")
+    print(f"    events: {event_count}, overflow: {overflow_count}")
+    if isinstance(snapshot, str) and snapshot:
+        print("    snapshot:")
+        for line in snapshot.splitlines():
+            print(f"      {line}")
+
+
 def print_run_summary(ctx: RunContext) -> None:
     """Print the compact configuration header."""
     print("\u2500" * 60)

--- a/ci/autoresearch/phases.py
+++ b/ci/autoresearch/phases.py
@@ -27,6 +27,7 @@ from ci.autoresearch.context import (
     QuietContext,
     RunContext,
     default_pins_for_environment,
+    display_objectfled_diagnostics,
     display_pattern_details,
     display_tight_timing,
 )
@@ -2867,6 +2868,7 @@ async def _run_rpc_tests(ctx: RunContext, qctx: QuietContext) -> int:
                         print(f"   Duration: {duration_str}")
 
                     display_tight_timing(test_data)
+                    display_objectfled_diagnostics(test_data)
 
                     if "drivers" in test_data and isinstance(
                         test_data["drivers"], list
@@ -2911,6 +2913,7 @@ async def _run_rpc_tests(ctx: RunContext, qctx: QuietContext) -> int:
                         print(f"   Actual: {failure.get('actual', 'unknown')}")
 
                     display_tight_timing(test_data)
+                    display_objectfled_diagnostics(test_data)
 
                     if "patterns" in test_data:
                         display_pattern_details(test_data)

--- a/ci/autoresearch/staging.py
+++ b/ci/autoresearch/staging.py
@@ -72,6 +72,7 @@ def synthesise_autoresearch_project(
         "AutoResearch",
         paths,
         build_dir=build_dir,
+        additional_defines=["FASTLED_OBJECTFLED_DIAGNOSTICS=1"],
         use_fbuild=True,
     )
     if not init_result.success:

--- a/ci/lint_cpp_rs/src/lint_core/regexes.rs
+++ b/ci/lint_cpp_rs/src/lint_core/regexes.rs
@@ -465,7 +465,7 @@ fn regex_autoresearch_forbidden_runtime_output() -> &'static Regex {
     static VALUE: OnceLock<Regex> = OnceLock::new();
     VALUE.get_or_init(|| {
         Regex::new(
-            r"\b(?:FL_(?:PRINT|WARN|ERROR)(?:_[A-Z0-9]+)*|Serial\.(?:print\w*|write|flush)|fl::(?:print|println|printf|write|flush|serial_(?:print\w*|println|printf|write|flush)))\s*\(",
+            r"\b(?:FL_(?:PRINT|WARN|ERROR)(?:_[A-Z0-9]+)*|Serial\.(?:print\w*|write|flush)|fl::(?:print|println|printf|write|flush|serial_(?:print\w*|println|printf|write|flush)|serial(?:Print\w*|Write|Flush)))\s*\(",
         )
         .unwrap()
     })

--- a/ci/lint_cpp_rs/src/lint_core/tests.rs
+++ b/ci/lint_cpp_rs/src/lint_core/tests.rs
@@ -55,9 +55,9 @@ mod tests {
         let checker = AutoResearchRuntimeOutputChecker;
         let result = checker.check_file_content(&file(
             "examples/AutoResearch/AutoResearch.ino",
-            "FL_WARN(\"boot chatter\");\nFL_WARN_F_ONCE(\"boot chatter\");\nFL_PRINT_EVERY(1000, \"tick\");\nFL_ERROR(\"boot failure\");\nSerial.println(\"not rpc\");\nSerial.printf(\"not rpc\");\nfl::println(\"nope\");\nfl::serial_println(\"nope\");\nfl::serial_printf(\"nope\");\n",
+            "FL_WARN(\"boot chatter\");\nFL_WARN_F_ONCE(\"boot chatter\");\nFL_WARN_LIT(\"boot chatter\");\nFL_PRINT_EVERY(1000, \"tick\");\nFL_PRINT_F(\"tick\");\nFL_ERROR(\"boot failure\");\nSerial.println(\"not rpc\");\nSerial.printf(\"not rpc\");\nSerial.printHex(\"not rpc\");\nfl::println(\"nope\");\nfl::serial_print(\"nope\");\nfl::serial_println(\"nope\");\nfl::serial_printf(\"nope\");\nfl::serialPrintln(\"nope\");\n",
         ));
-        assert_eq!(result.len(), 9);
+        assert_eq!(result.len(), 14);
     }
 
     #[test]

--- a/ci/tests/test_autoresearch_staging.py
+++ b/ci/tests/test_autoresearch_staging.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from ci.autoresearch.staging import synthesise_autoresearch_project
+
+
+def test_autoresearch_staging_enables_objectfled_diagnostics(
+    tmp_path: Path,
+) -> None:
+    with patch("ci.compiler.pio._init_platformio_build") as mock_init:
+        mock_init.return_value = SimpleNamespace(success=True, output="")
+
+        build_dir = synthesise_autoresearch_project(
+            "teensy41",
+            project_root=tmp_path,
+            verbose=False,
+        )
+
+    assert build_dir == tmp_path / ".build" / "pio" / "teensy41"
+    _, kwargs = mock_init.call_args
+    assert kwargs["additional_defines"] == ["FASTLED_OBJECTFLED_DIAGNOSTICS=1"]

--- a/examples/AutoResearch/AutoResearchRemoteRunSingleTest.cpp
+++ b/examples/AutoResearch/AutoResearchRemoteRunSingleTest.cpp
@@ -37,6 +37,7 @@
 #include "AutoResearchParlioEncode.h"
 #include "AutoResearchTimingDrift.h"
 #include "AutoResearchParlioStream.h"
+#include "platforms/arm/teensy/teensy4_common/drivers/objectfled/objectfled_diagnostics.h"
 #include "fl/chipsets/spi.h"
 #include "fl/channels/config.h"
 #include <Arduino.h>
@@ -500,6 +501,7 @@ fl::json AutoResearchRemoteControl::runSingleTestImpl(const fl::json& args) {
 
     // SPI chipset drivers use APA102 protocol with data+clock pins.
     // Clockless drivers use WS2812B timing on a single data pin
+    bool is_object_fled_driver = (driver_name == "OBJECT_FLED");
     bool is_spi_chipset_driver = (driver_name == "LCD_SPI" ||
                                   driver_name == "I2S_SPI" ||
                                   driver_name == "SPI_UNIFIED");
@@ -575,6 +577,10 @@ fl::json AutoResearchRemoteControl::runSingleTestImpl(const fl::json& args) {
         // ObjectFLED's DMA refill path, which is exactly what #3343 is
         // trying to prove or eliminate. JSON-RPC responses bypass this guard.
         fl::ScopedLogDisable quiet_logs;
+
+        if (is_object_fled_driver) {
+            fl::objectFledDiagnosticsReset();
+        }
 
         if (use_legacy_api) {
             // Legacy API path: WS2812B<PIN> template instantiation
@@ -672,6 +678,10 @@ fl::json AutoResearchRemoteControl::runSingleTestImpl(const fl::json& args) {
     response.set("frameCount", static_cast<int64_t>(frame_count));
     if (measure_tight_timing) {
         response.set("tightTiming", tight_timing_response);
+    }
+    if (is_object_fled_driver) {
+        response.set("objectFledDiagnostics",
+                     fl::objectFledDiagnosticsToJson());
     }
 
     // Free run_results before building response to reclaim heap

--- a/examples/AutoResearch/AutoResearchTest.cpp
+++ b/examples/AutoResearch/AutoResearchTest.cpp
@@ -14,6 +14,7 @@
 
 #include "AutoResearchTest.h"
 #include "LegacyClocklessProxy.h"
+#include "platforms/arm/teensy/teensy4_common/drivers/objectfled/objectfled_diagnostics.h"
 #include <FastLED.h>
 #include "fl/stl/sstream.h"
 #include "fl/chipsets/encoders/ucs7604.h"
@@ -355,6 +356,7 @@ size_t capture(fl::shared_ptr<fl::RxChannel> rx_channel,
     // Buffer size: 1 LED byte = 8 bits = 8 RMT symbols
     // UART with TX inversion produces standard WS2812 waveform, same symbol count
     bool is_uart_driver = (fl::strcmp(driver_name, "UART") == 0);
+    bool is_object_fled_driver = (fl::strcmp(driver_name, "OBJECT_FLED") == 0);
     rx_config.edge_capacity = rx_buffer.size() * 8;
 
     // Internal loopback configuration: Enable ONLY for RMT TX -> RMT RX scenarios
@@ -422,8 +424,14 @@ size_t capture(fl::shared_ptr<fl::RxChannel> rx_channel,
         FastLED.show();
         FL_WARN("[CAPTURE] FastLED.show() returned, calling wait...");
         if (!FastLED.wait(TX_WAIT_TIMEOUT_MS)) {
+            if (is_object_fled_driver) {
+                fl::objectFledDiagnosticsRecord("afterFastLedWaitTimeout");
+            }
             FL_WARN("[CAPTURE] FastLED.wait() timed out");
             return 0;
+        }
+        if (is_object_fled_driver) {
+            fl::objectFledDiagnosticsRecord("afterFastLedWait");
         }
         FL_WARN("[CAPTURE] FastLED.wait() done");
     }
@@ -1175,6 +1183,9 @@ void autoResearchChipsetTiming(fl::AutoResearchConfig& config,
     // CRITICAL: Clear FastLED's global channel registry to prevent accumulation
     // If we only destroy local shared_ptrs, FastLED still holds references
     FastLED.clear(ClearFlags::CHANNELS);
+    if (fl::strcmp(config.driver_name, "OBJECT_FLED") == 0) {
+        fl::objectFledDiagnosticsRecord("afterFastLedClear");
+    }
     // Channel destruction is synchronous - no delay needed
 }
 

--- a/src/platforms/arm/teensy/teensy4_common/drivers/objectfled/_build.cpp.hpp
+++ b/src/platforms/arm/teensy/teensy4_common/drivers/objectfled/_build.cpp.hpp
@@ -4,6 +4,7 @@
 /// @brief Unity build header for drivers/objectfled/ directory
 
 #include "platforms/arm/teensy/teensy4_common/drivers/objectfled/channel_engine_objectfled.cpp.hpp"
+#include "platforms/arm/teensy/teensy4_common/drivers/objectfled/objectfled_diagnostics.cpp.hpp"
 #include "platforms/arm/teensy/teensy4_common/drivers/objectfled/objectfled_peripheral_real.cpp.hpp"
 
 // BusTraits<Bus::OBJECT_FLED> specialization.

--- a/src/platforms/arm/teensy/teensy4_common/drivers/objectfled/objectfled_diagnostics.cpp.hpp
+++ b/src/platforms/arm/teensy/teensy4_common/drivers/objectfled/objectfled_diagnostics.cpp.hpp
@@ -1,0 +1,475 @@
+// IWYU pragma: private
+
+#include "platforms/arm/teensy/is_teensy.h"
+
+#if defined(FL_IS_TEENSY_4X) && defined(FASTLED_OBJECTFLED_DIAGNOSTICS) && FASTLED_OBJECTFLED_DIAGNOSTICS
+
+#include "platforms/arm/teensy/teensy4_common/drivers/objectfled/objectfled_diagnostics.h"
+
+#include "fl/stl/bit_cast.h"
+#include "fl/stl/cstring.h"
+#include "fl/stl/sstream.h"
+#include "third_party/object_fled/src/ObjectFLEDDmaManager.h"
+
+#include <Arduino.h>
+#include "DMAChannel.h"
+
+namespace fl {
+namespace {
+
+constexpr u8 kMaxEvents = 16;
+constexpr u8 kMaxPins = 16;
+
+struct PinRegisterSnapshot {
+    u8 pin = 0;
+    u8 bit = 0;
+    u8 fastGpio = 0;
+    u8 standardGpio = 0;
+    u32 mask = 0;
+    u32 gpr = 0;
+    u32 gprMask = 0;
+    bool mappedToStandard = false;
+    u32 muxRegister = 0;
+    u32 mux = 0;
+    u32 padRegister = 0;
+    u32 pad = 0;
+    u32 outputRegister = 0;
+    u32 outputValue = 0;
+    u32 modeRegister = 0;
+    u32 modeValue = 0;
+    u32 inputRegister = 0;
+    u32 inputValue = 0;
+};
+
+struct TimerChannelSnapshot {
+    u32 ctrl = 0;
+    u32 sctrl = 0;
+    u32 csctrl = 0;
+    u32 cntr = 0;
+    u32 load = 0;
+    u32 comp1 = 0;
+    u32 comp2 = 0;
+    u32 cmpld1 = 0;
+    u32 cmpld2 = 0;
+};
+
+struct TcdSnapshot {
+    u32 tcdAddress = 0;
+    u32 saddr = 0;
+    i32 soff = 0;
+    u32 attr = 0;
+    u32 nbytes = 0;
+    i32 slast = 0;
+    u32 daddr = 0;
+    i32 doff = 0;
+    u32 citer = 0;
+    i32 dlastsga = 0;
+    u32 csr = 0;
+    u32 biter = 0;
+};
+
+struct DmaChannelSnapshot {
+    const char* name = "";
+    bool hasHardwareChannel = false;
+    u8 channel = 0;
+    u32 dmamuxChcfg = 0;
+    TcdSnapshot tcd;
+};
+
+struct DmaSnapshot {
+    u32 es = 0;
+    u32 erq = 0;
+    u32 err = 0;
+    u32 irq = 0;
+    u32 hrs = 0;
+    u32 allocatedMask = 0;
+    u32 currentOwner = 0;
+    u32 frameBuffer = 0;
+    u32 bitdata = 0;
+    u32 bitmask = 0;
+    u32 framebufferIndex = 0;
+    u32 numbytes = 0;
+    u32 numpins = 0;
+    u32 bitmaskWords[4] = {0, 0, 0, 0};
+    DmaChannelSnapshot dma1;
+    DmaChannelSnapshot dma2;
+    DmaChannelSnapshot dma3;
+    DmaChannelSnapshot dma2next;
+};
+
+struct SnapshotEvent {
+    const char* stage = "";
+    u32 millisValue = 0;
+    u32 microsValue = 0;
+    u8 pinCount = 0;
+    PinRegisterSnapshot pins[kMaxPins];
+    u32 gpr[4] = {0, 0, 0, 0};
+    TimerChannelSnapshot tmr[3];
+    u32 tmrEnbl = 0;
+    u32 xbarSel15 = 0;
+    u32 xbarSel47 = 0;
+    u32 xbarCtrl0 = 0;
+    u32 xbarCtrl1 = 0;
+    DmaSnapshot dma;
+};
+
+SnapshotEvent s_events[kMaxEvents];
+u8 s_eventCount = 0;
+u32 s_overflowCount = 0;
+u8 s_lastPins[kMaxPins];
+u8 s_lastPinCount = 0;
+
+u32 ptrToU32(const volatile void* ptr) FL_NO_EXCEPT {
+    return static_cast<u32>(fl::ptr_to_int(const_cast<void*>(ptr)));
+}
+
+void setU32(fl::json& out, const char* key, u32 value) FL_NO_EXCEPT {
+    out.set(key, static_cast<i64>(value));
+}
+
+volatile uint32_t* standardGpioAddr(volatile uint32_t* fastgpio) FL_NO_EXCEPT {
+    return reinterpret_cast<volatile uint32_t*>( // ok reinterpret cast - Teensy GPIO alias address map
+        ptrToU32(fastgpio) - 0x01E48000u);
+}
+
+PinRegisterSnapshot capturePin(u8 pin) FL_NO_EXCEPT {
+    PinRegisterSnapshot out;
+    out.pin = pin;
+    if (pin >= NUM_DIGITAL_PINS) {
+        return out;
+    }
+
+    out.bit = digitalPinToBit(pin);
+    out.mask = 1u << out.bit;
+
+    volatile uint32_t* outputReg = portOutputRegister(pin);
+    volatile uint32_t* modeReg = portModeRegister(pin);
+    volatile uint32_t* inputReg = portInputRegister(pin);
+    volatile uint32_t* muxReg = portConfigRegister(pin);
+    volatile uint32_t* padReg = portControlRegister(pin);
+
+    out.outputRegister = ptrToU32(outputReg);
+    out.outputValue = *outputReg;
+    out.modeRegister = ptrToU32(modeReg);
+    out.modeValue = *modeReg;
+    out.inputRegister = ptrToU32(inputReg);
+    out.inputValue = *inputReg;
+    out.muxRegister = ptrToU32(muxReg);
+    out.mux = *muxReg;
+    out.padRegister = ptrToU32(padReg);
+    out.pad = *padReg;
+
+    const u32 gpio6Base = ptrToU32(&GPIO6_DR);
+    const u32 outputAddress = ptrToU32(outputReg);
+    const u8 offset = static_cast<u8>((outputAddress - gpio6Base) >> 14);
+    if (offset <= 3) {
+        out.fastGpio = static_cast<u8>(6 + offset);
+        out.standardGpio = static_cast<u8>(1 + offset);
+        volatile uint32_t* gprReg = &IOMUXC_GPR_GPR26 + offset;
+        out.gpr = *gprReg;
+        out.gprMask = out.mask;
+        out.mappedToStandard = ((*gprReg & out.mask) == 0);
+
+        volatile uint32_t* standardModeReg = standardGpioAddr(modeReg);
+        out.modeRegister = ptrToU32(standardModeReg);
+        out.modeValue = *standardModeReg;
+    }
+    return out;
+}
+
+TimerChannelSnapshot captureTimerChannel(u8 index) FL_NO_EXCEPT {
+    TimerChannelSnapshot out;
+    if (index == 0) {
+        out.ctrl = TMR4_CTRL0;
+        out.sctrl = TMR4_SCTRL0;
+        out.csctrl = TMR4_CSCTRL0;
+        out.cntr = TMR4_CNTR0;
+        out.load = TMR4_LOAD0;
+        out.comp1 = TMR4_COMP10;
+        out.comp2 = TMR4_COMP20;
+        out.cmpld1 = TMR4_CMPLD10;
+        out.cmpld2 = TMR4_CMPLD20;
+    } else if (index == 1) {
+        out.ctrl = TMR4_CTRL1;
+        out.sctrl = TMR4_SCTRL1;
+        out.csctrl = TMR4_CSCTRL1;
+        out.cntr = TMR4_CNTR1;
+        out.load = TMR4_LOAD1;
+        out.comp1 = TMR4_COMP11;
+        out.comp2 = TMR4_COMP21;
+        out.cmpld1 = TMR4_CMPLD11;
+        out.cmpld2 = TMR4_CMPLD21;
+    } else {
+        out.ctrl = TMR4_CTRL2;
+        out.sctrl = TMR4_SCTRL2;
+        out.csctrl = TMR4_CSCTRL2;
+        out.cntr = TMR4_CNTR2;
+        out.load = TMR4_LOAD2;
+        out.comp1 = TMR4_COMP12;
+        out.comp2 = TMR4_COMP22;
+        out.cmpld1 = TMR4_CMPLD12;
+        out.cmpld2 = TMR4_CMPLD22;
+    }
+    return out;
+}
+
+TcdSnapshot captureTcd(const DMABaseClass::TCD_t* tcd) FL_NO_EXCEPT {
+    TcdSnapshot out;
+    if (tcd == nullptr) {
+        return out;
+    }
+    out.tcdAddress = ptrToU32(tcd);
+    out.saddr = ptrToU32(tcd->SADDR);
+    out.soff = tcd->SOFF;
+    out.attr = tcd->ATTR;
+    out.nbytes = tcd->NBYTES;
+    out.slast = tcd->SLAST;
+    out.daddr = ptrToU32(tcd->DADDR);
+    out.doff = tcd->DOFF;
+    out.citer = tcd->CITER;
+    out.dlastsga = tcd->DLASTSGA;
+    out.csr = tcd->CSR;
+    out.biter = tcd->BITER;
+    return out;
+}
+
+u32 captureDmamuxChcfg(u8 channel) FL_NO_EXCEPT {
+    volatile uint32_t* dmamux = &DMAMUX_CHCFG0 + channel;
+    return *dmamux;
+}
+
+DmaChannelSnapshot captureDmaChannel(const char* name, const DMAChannel& channel) FL_NO_EXCEPT {
+    DmaChannelSnapshot out;
+    out.name = name;
+    out.hasHardwareChannel = true;
+    out.channel = channel.channel;
+    out.dmamuxChcfg = captureDmamuxChcfg(channel.channel);
+    out.tcd = captureTcd(channel.TCD);
+    return out;
+}
+
+DmaChannelSnapshot captureDmaSetting(const char* name, const DMASetting& setting) FL_NO_EXCEPT {
+    DmaChannelSnapshot out;
+    out.name = name;
+    out.hasHardwareChannel = false;
+    out.tcd = captureTcd(setting.TCD);
+    return out;
+}
+
+DmaSnapshot captureDma() FL_NO_EXCEPT {
+    auto& dma = ObjectFLEDDmaManager::getInstance();
+    DmaSnapshot out;
+    out.es = DMA_ES;
+    out.erq = DMA_ERQ;
+    out.err = DMA_ERR;
+    out.irq = DMA_INT;
+    out.hrs = DMA_HRS;
+    out.allocatedMask = dma_channel_allocated_mask;
+    out.currentOwner = ptrToU32(dma.getCurrentOwner());
+    out.frameBuffer = ptrToU32(dma.frameBuffer);
+    out.bitdata = ptrToU32(dma.bitdata);
+    out.bitmask = ptrToU32(dma.bitmask);
+    out.framebufferIndex = dma.framebuffer_index;
+    out.numbytes = dma.numbytes;
+    out.numpins = dma.numpins;
+    for (u8 i = 0; i < 4; ++i) {
+        out.bitmaskWords[i] = dma.bitmask[i];
+    }
+    out.dma1 = captureDmaChannel("dma1", dma.dma1);
+    out.dma2 = captureDmaChannel("dma2", dma.dma2);
+    out.dma3 = captureDmaChannel("dma3", dma.dma3);
+    out.dma2next = captureDmaSetting("dma2next", dma.dma2next);
+    return out;
+}
+
+void appendTcd(fl::sstream& out, const char* name,
+               const TcdSnapshot& tcd) FL_NO_EXCEPT {
+    out << ' ' << name << ".tcd=" << tcd.tcdAddress
+        << " saddr=" << tcd.saddr
+        << " soff=" << tcd.soff
+        << " attr=" << tcd.attr
+        << " nbytes=" << tcd.nbytes
+        << " slast=" << tcd.slast
+        << " daddr=" << tcd.daddr
+        << " doff=" << tcd.doff
+        << " citer=" << tcd.citer
+        << " dlastsga=" << tcd.dlastsga
+        << " csr=" << tcd.csr
+        << " biter=" << tcd.biter;
+}
+
+void appendDmaChannel(fl::sstream& out,
+                      const DmaChannelSnapshot& ch) FL_NO_EXCEPT {
+    out << ' ' << ch.name << ".hasChannel=" << (ch.hasHardwareChannel ? 1 : 0)
+        << ' ' << ch.name << ".channel=" << static_cast<int>(ch.channel)
+        << ' ' << ch.name << ".dmamux=" << ch.dmamuxChcfg;
+    appendTcd(out, ch.name, ch.tcd);
+}
+
+void appendTimer(fl::sstream& out, const char* name,
+                 const TimerChannelSnapshot& timer) FL_NO_EXCEPT {
+    out << ' ' << name << ".ctrl=" << timer.ctrl
+        << ' ' << name << ".sctrl=" << timer.sctrl
+        << ' ' << name << ".csctrl=" << timer.csctrl
+        << ' ' << name << ".cntr=" << timer.cntr
+        << ' ' << name << ".load=" << timer.load
+        << ' ' << name << ".comp1=" << timer.comp1
+        << ' ' << name << ".comp2=" << timer.comp2
+        << ' ' << name << ".cmpld1=" << timer.cmpld1
+        << ' ' << name << ".cmpld2=" << timer.cmpld2;
+}
+
+void appendPin(fl::sstream& out, const PinRegisterSnapshot& pin) FL_NO_EXCEPT {
+    out << " pin=" << static_cast<int>(pin.pin)
+        << " bit=" << static_cast<int>(pin.bit)
+        << " mask=" << pin.mask
+        << " fastGpio=" << static_cast<int>(pin.fastGpio)
+        << " standardGpio=" << static_cast<int>(pin.standardGpio)
+        << " mappedToStandard=" << (pin.mappedToStandard ? 1 : 0)
+        << " gpr=" << pin.gpr
+        << " gprMask=" << pin.gprMask
+        << " muxReg=" << pin.muxRegister
+        << " mux=" << pin.mux
+        << " padReg=" << pin.padRegister
+        << " pad=" << pin.pad
+        << " outReg=" << pin.outputRegister
+        << " out=" << pin.outputValue
+        << " modeReg=" << pin.modeRegister
+        << " mode=" << pin.modeValue
+        << " inReg=" << pin.inputRegister
+        << " in=" << pin.inputValue;
+}
+
+void appendEvent(fl::sstream& out, const SnapshotEvent& event) FL_NO_EXCEPT {
+    out << "stage=" << event.stage
+        << " ms=" << event.millisValue
+        << " us=" << event.microsValue
+        << " gpr26=" << event.gpr[0]
+        << " gpr27=" << event.gpr[1]
+        << " gpr28=" << event.gpr[2]
+        << " gpr29=" << event.gpr[3]
+        << " tmr4.enbl=" << event.tmrEnbl
+        << " xbar.sel15=" << event.xbarSel15
+        << " xbar.sel47=" << event.xbarSel47
+        << " xbar.ctrl0=" << event.xbarCtrl0
+        << " xbar.ctrl1=" << event.xbarCtrl1;
+    appendTimer(out, "tmr4.ch0", event.tmr[0]);
+    appendTimer(out, "tmr4.ch1", event.tmr[1]);
+    appendTimer(out, "tmr4.ch2", event.tmr[2]);
+    out << " dma.es=" << event.dma.es
+        << " dma.erq=" << event.dma.erq
+        << " dma.err=" << event.dma.err
+        << " dma.int=" << event.dma.irq
+        << " dma.hrs=" << event.dma.hrs
+        << " dma.allocatedMask=" << event.dma.allocatedMask
+        << " dma.currentOwner=" << event.dma.currentOwner
+        << " dma.frameBuffer=" << event.dma.frameBuffer
+        << " dma.bitdata=" << event.dma.bitdata
+        << " dma.bitmask=" << event.dma.bitmask
+        << " dma.framebufferIndex=" << event.dma.framebufferIndex
+        << " dma.numbytes=" << event.dma.numbytes
+        << " dma.numpins=" << event.dma.numpins
+        << " dma.bitmaskWords=[" << event.dma.bitmaskWords[0] << ','
+        << event.dma.bitmaskWords[1] << ',' << event.dma.bitmaskWords[2]
+        << ',' << event.dma.bitmaskWords[3] << ']';
+    appendDmaChannel(out, event.dma.dma1);
+    appendDmaChannel(out, event.dma.dma2);
+    appendDmaChannel(out, event.dma.dma3);
+    appendDmaChannel(out, event.dma.dma2next);
+    for (u8 i = 0; i < event.pinCount; ++i) {
+        out << " pin[" << static_cast<int>(i) << "].";
+        appendPin(out, event.pins[i]);
+    }
+    out << '\n';
+}
+
+bool stageEquals(const char* left, const char* right) FL_NO_EXCEPT {
+    if (left == nullptr || right == nullptr) {
+        return false;
+    }
+    return fl::strcmp(left, right) == 0;
+}
+
+bool stageAlreadyCaptured(const char* stage) FL_NO_EXCEPT {
+    for (u8 i = 0; i < s_eventCount; ++i) {
+        if (stageEquals(s_events[i].stage, stage)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+} // namespace
+
+void objectFledDiagnosticsReset() FL_NO_EXCEPT {
+    fl::memset(s_events, 0, sizeof(s_events));
+    fl::memset(s_lastPins, 0, sizeof(s_lastPins));
+    s_eventCount = 0;
+    s_overflowCount = 0;
+    s_lastPinCount = 0;
+}
+
+void objectFledDiagnosticsRecord(const char* stage, const u8* pins,
+                                 u32 pin_count) FL_NO_EXCEPT {
+    if (stageAlreadyCaptured(stage)) {
+        return;
+    }
+
+    if (pins != nullptr && pin_count > 0) {
+        s_lastPinCount = static_cast<u8>(pin_count < kMaxPins ? pin_count : kMaxPins);
+        for (u8 i = 0; i < s_lastPinCount; ++i) {
+            s_lastPins[i] = pins[i];
+        }
+    } else {
+        pins = s_lastPins;
+        pin_count = s_lastPinCount;
+    }
+
+    if (s_eventCount >= kMaxEvents) {
+        ++s_overflowCount;
+        return;
+    }
+
+    SnapshotEvent& event = s_events[s_eventCount++];
+    event.stage = stage != nullptr ? stage : "";
+    event.millisValue = millis();
+    event.microsValue = micros();
+    event.pinCount = static_cast<u8>(pin_count < kMaxPins ? pin_count : kMaxPins);
+    for (u8 i = 0; i < event.pinCount; ++i) {
+        event.pins[i] = capturePin(pins[i]);
+    }
+    event.gpr[0] = IOMUXC_GPR_GPR26;
+    event.gpr[1] = IOMUXC_GPR_GPR27;
+    event.gpr[2] = IOMUXC_GPR_GPR28;
+    event.gpr[3] = IOMUXC_GPR_GPR29;
+    event.tmrEnbl = TMR4_ENBL;
+    event.tmr[0] = captureTimerChannel(0);
+    event.tmr[1] = captureTimerChannel(1);
+    event.tmr[2] = captureTimerChannel(2);
+    event.xbarSel15 = XBARA1_SEL15;
+    event.xbarSel47 = XBARA1_SEL47;
+    event.xbarCtrl0 = XBARA1_CTRL0;
+    event.xbarCtrl1 = XBARA1_CTRL1;
+    event.dma = captureDma();
+}
+
+fl::json objectFledDiagnosticsToJson() FL_NO_EXCEPT {
+    fl::json out = fl::json::object();
+    out.set("enabled", true);
+    setU32(out, "eventCount", s_eventCount);
+    setU32(out, "overflowCount", s_overflowCount);
+    out.set("format", "objectfled-register-snapshot-v1");
+    out.set("note",
+            "snapshot is newline-delimited key=value register state");
+    fl::sstream snapshot;
+    for (u8 i = 0; i < s_eventCount; ++i) {
+        appendEvent(snapshot, s_events[i]);
+    }
+    fl::string text = snapshot.str();
+    out.set("snapshot", text.c_str());
+    return out;
+}
+
+} // namespace fl
+
+#endif // FASTLED_OBJECTFLED_DIAGNOSTICS

--- a/src/platforms/arm/teensy/teensy4_common/drivers/objectfled/objectfled_diagnostics.h
+++ b/src/platforms/arm/teensy/teensy4_common/drivers/objectfled/objectfled_diagnostics.h
@@ -1,0 +1,35 @@
+#pragma once
+
+// IWYU pragma: private
+
+#include "platforms/arm/teensy/is_teensy.h"
+
+#include "fl/stl/json.h"
+#include "fl/stl/noexcept.h"
+#include "fl/stl/stdint.h"
+
+namespace fl {
+
+#if defined(FL_IS_TEENSY_4X) && defined(FASTLED_OBJECTFLED_DIAGNOSTICS) && FASTLED_OBJECTFLED_DIAGNOSTICS
+
+void objectFledDiagnosticsReset() FL_NO_EXCEPT;
+void objectFledDiagnosticsRecord(const char* stage, const u8* pins = nullptr,
+                                 u32 pin_count = 0) FL_NO_EXCEPT;
+fl::json objectFledDiagnosticsToJson() FL_NO_EXCEPT;
+
+#else
+
+inline void objectFledDiagnosticsReset() FL_NO_EXCEPT {}
+
+inline void objectFledDiagnosticsRecord(const char*, const u8* = nullptr,
+                                        u32 = 0) FL_NO_EXCEPT {}
+
+inline fl::json objectFledDiagnosticsToJson() FL_NO_EXCEPT {
+    fl::json result = fl::json::object();
+    result.set("enabled", false);
+    return result;
+}
+
+#endif
+
+} // namespace fl

--- a/src/platforms/arm/teensy/teensy4_common/drivers/objectfled/objectfled_peripheral_real.cpp.hpp
+++ b/src/platforms/arm/teensy/teensy4_common/drivers/objectfled/objectfled_peripheral_real.cpp.hpp
@@ -8,6 +8,7 @@
 #if defined(FL_IS_TEENSY_4X)
 
 #include "platforms/arm/teensy/teensy4_common/drivers/objectfled/iobjectfled_peripheral.h"
+#include "platforms/arm/teensy/teensy4_common/drivers/objectfled/objectfled_diagnostics.h"
 
 #include "fl/stl/cstring.h"
 // IWYU pragma: begin_keep
@@ -23,11 +24,20 @@ namespace fl {
 
 class ObjectFLEDInstanceReal : public IObjectFLEDInstance {
 public:
-    ObjectFLEDInstanceReal(ObjectFLED* ofled, u32 totalBytes)
-        : mObjectFLED(ofled), mTotalBytes(totalBytes) {}
+    ObjectFLEDInstanceReal(ObjectFLED* ofled, u32 totalBytes, const u8* pins,
+                           u32 pinCount)
+        : mObjectFLED(ofled), mTotalBytes(totalBytes),
+          mPinCount(pinCount < kMaxCapturedPins ? pinCount : kMaxCapturedPins) {
+        if (pins != nullptr && mPinCount > 0) {
+            fl::memcpy(mPins, pins, mPinCount);
+        }
+    }
 
     ~ObjectFLEDInstanceReal() override {
+        objectFledDiagnosticsRecord("beforeDestroy", mPins, mPinCount);
         delete mObjectFLED;  // ok bare allocation
+        mObjectFLED = nullptr;
+        objectFledDiagnosticsRecord("afterDestroy", mPins, mPinCount);
     }
 
     u8* getFrameBuffer() override {
@@ -39,12 +49,17 @@ public:
     }
 
     void show() override {
+        objectFledDiagnosticsRecord("beforeShow", mPins, mPinCount);
         mObjectFLED->show();
+        objectFledDiagnosticsRecord("afterShowReturn", mPins, mPinCount);
     }
 
 private:
+    static constexpr u32 kMaxCapturedPins = 16;
     ObjectFLED* mObjectFLED;
     u32 mTotalBytes;
+    u8 mPins[kMaxCapturedPins] = {};
+    u32 mPinCount = 0;
 };
 
 // ============================================================================
@@ -74,12 +89,14 @@ public:
             0  // No serpentine
         );
 
+        objectFledDiagnosticsRecord("beforeBegin", pinList, numPins);
         ofled->begin(
             static_cast<u16>(t1_ns),
             static_cast<u16>(t2_ns),
             static_cast<u16>(t3_ns),
             static_cast<u16>(reset_us)
         );
+        objectFledDiagnosticsRecord("afterBegin", pinList, numPins);
 
         // CRITICAL: Set drawBuffer to frameBufferLocal so genFrameBuffer()
         // (called inside show()) doesn't dereference nullptr. We write
@@ -94,7 +111,8 @@ public:
         // Clear frame buffer for padding
         fl::memset(ofled->frameBufferLocal, 0, totalBytes);
 
-        return fl::make_unique<ObjectFLEDInstanceReal>(ofled, totalBytes);
+        return fl::make_unique<ObjectFLEDInstanceReal>(
+            ofled, totalBytes, pinList, numPins);
     }
 };
 


### PR DESCRIPTION
## Summary

- Add Teensy 4.x ObjectFLED register snapshot diagnostics gated by `FASTLED_OBJECTFLED_DIAGNOSTICS`.
- Capture ObjectFLED state at before/after begin, before/after show, after `FastLED.wait()`, after channel clear, and destruction hooks where reached.
- Attach the snapshot bundle to AutoResearch `runSingleTest` JSON-RPC responses for `OBJECT_FLED` and display it on the host.
- Enable the diagnostic define for staged AutoResearch fbuild projects.
- Tighten the scoped AutoResearch runtime-output lint for future `fl::serialPrint*`-style helpers.

## Validation

- `uv run --no-sync ruff check ci/autoresearch/context.py ci/autoresearch/phases.py ci/autoresearch/staging.py ci/tests/test_autoresearch_staging.py`
- `uv run --no-sync ruff format --check ci/autoresearch/context.py ci/autoresearch/phases.py ci/autoresearch/staging.py ci/tests/test_autoresearch_staging.py`
- `uv run --no-sync pytest ci/tests/test_autoresearch_staging.py ci/tests/test_autoresearch_phases.py -q` -> 71 passed
- `soldr cargo fmt --manifest-path ci/lint_cpp_rs/Cargo.toml -- --check`
- `soldr cargo check --manifest-path ci/lint_cpp_rs/Cargo.toml --target x86_64-unknown-linux-gnu --tests` -> passed with existing warnings
- `git diff --check`

## Hardware

Canonical command first stopped before deploy at the known local Rust lint MSVC-target failure:

```bash
bash autoresearch teensy41 --object-fled --tx-pin 22 --rx-pin 8 --timeout 120
```

Follow-up through AutoResearch/fbuild, skipping only the broken local lint gate:

```bash
bash autoresearch teensy41 --object-fled --tx-pin 22 --rx-pin 8 --timeout 120 --skip-lint
```

Result:

- fbuild deploy succeeded on `teensy41 @ COM20`.
- Serial backend was `FbuildSerialAdapter`; no manual serial utility was used.
- GPIO pre-test passed for `TX 22 -> RX 8`.
- `setPins` echoed `txPin=22`, `rxPin=8`.
- `OBJECT_FLED` failed honestly as `class=zero_capture`.
- Response included `objectFledDiagnostics` with `eventCount=6`, `overflow=0`, format `objectfled-register-snapshot-v1`.
- Captured stages included `beforeBegin`, `afterBegin`, `beforeShow`, `afterShowReturn`, `afterFastLedWait`, and `afterFastLedClear`.
- Snapshot includes `IOMUXC_GPR_GPR26..29`, pin mux/pad/GPIO routing, TMR4 ch0-2 state, XBAR state, DMAMUX config, DMA status/request bits, and TCD state for `dma1`, `dma2`, `dma3`, and `dma2next`.

Closes no issue; advances FastLED/FastLED#3359 S3.