### PR TITLE
fix(objectfled): reclaim GPIO mux after PWM contamination

### DIFF
--- a/ci/autoresearch/args.py
+++ b/ci/autoresearch/args.py
@@ -50,6 +50,7 @@ class Args:
     tx_pin: int | None
     rx_pin: int | None
     auto_discover_pins: bool
+    contaminate_tx_mux: bool
 
     # Build system selection
     use_fbuild: bool
@@ -487,6 +488,14 @@ See Also:
             action="store_true",
             help="Disable auto-discovery of connected pins",
         )
+        pin_group.add_argument(
+            "--contaminate-tx-mux",
+            action="store_true",
+            help=(
+                "Before runSingleTest, remux the selected TX pin through "
+                "analogWrite() so ObjectFLED must reclaim GPIO mux mode."
+            ),
+        )
 
         # Build system selection
         parser.add_argument(
@@ -674,6 +683,7 @@ See Also:
             rx_pin=parsed.rx_pin,
             auto_discover_pins=parsed.auto_discover_pins
             and not parsed.no_auto_discover_pins,
+            contaminate_tx_mux=parsed.contaminate_tx_mux,
             use_fbuild=parsed.use_fbuild,
             no_fbuild=parsed.no_fbuild,
             clean=parsed.clean,

--- a/ci/autoresearch/phases.py
+++ b/ci/autoresearch/phases.py
@@ -767,6 +767,8 @@ def _parse_args_and_build_commands(args: Args) -> RunContext | int:
                         frame_count = 1
                     if frame_count > 1:
                         test_config["frameCount"] = frame_count
+                    if args.contaminate_tx_mux:
+                        test_config["contaminateTxMux"] = True
                     if args.tight_timing:
                         if (
                             args.tight_timing_iterations < 1

--- a/ci/tests/test_autoresearch_phases.py
+++ b/ci/tests/test_autoresearch_phases.py
@@ -71,6 +71,7 @@ def _make_args(**overrides) -> Args:
         tx_pin=None,
         rx_pin=None,
         auto_discover_pins=False,
+        contaminate_tx_mux=False,
         use_fbuild=False,
         no_fbuild=True,
         clean=False,
@@ -237,6 +238,26 @@ class TestParseArgsAndBuildCommands:
         assert {cmd["method"] for cmd in result.json_rpc_commands} == {"runSingleTest"}
         assert not any("__skip_with_pass" in cmd for cmd in result.json_rpc_commands)
         assert all("pinTx" not in cmd["params"] for cmd in result.json_rpc_commands)
+
+    def test_contaminate_tx_mux_sets_run_single_test_field(
+        self, fake_project_dir: Path
+    ) -> None:
+        args = _make_args(
+            object_fled=True,
+            parlio=False,
+            contaminate_tx_mux=True,
+            environment_positional="teensy41",
+            project_dir=fake_project_dir,
+            use_root_platformio_ini=False,
+        )
+        with patch(
+            "ci.autoresearch.staging.synthesise_autoresearch_project",
+            return_value=fake_project_dir,
+        ):
+            result = _parse_args_and_build_commands(args)
+        assert isinstance(result, RunContext)
+        assert result.json_rpc_commands[0]["method"] == "runSingleTest"
+        assert result.json_rpc_commands[0]["params"]["contaminateTxMux"] is True
 
     def test_spi_driver_name_remains_spi_on_esp32(self, fake_project_dir: Path) -> None:
         args = _make_args(parlio=False, spi=True, project_dir=fake_project_dir)

--- a/examples/AutoResearch/AutoResearchRemoteRunSingleTest.cpp
+++ b/examples/AutoResearch/AutoResearchRemoteRunSingleTest.cpp
@@ -87,6 +87,18 @@ class ScopedFastLedBrightness {
     uint8_t mSavedBrightness;
 };
 
+bool contaminateTxMuxWithPwm(int pin) {
+#if defined(FL_IS_TEENSY_4X)
+    analogWriteFrequency(pin, 1000.0f);
+    analogWrite(pin, 128);
+    delay(2);
+    return true;
+#else
+    (void)pin;
+    return false;
+#endif
+}
+
 fl::json measureTightTiming(const fl::string& driver_name,
                             const fl::ChipsetTimingConfig& timing,
                             const fl::vector<fl::ChannelConfig>& tx_configs,
@@ -277,6 +289,7 @@ fl::json AutoResearchRemoteControl::runSingleTestImpl(const fl::json& args) {
         return response;
     }
     fl::string driver_name = config["driver"].as_string().value();
+    const bool is_object_fled_driver = (driver_name == "OBJECT_FLED");
 
     // Validate driver exists
     bool driver_found = false;
@@ -414,7 +427,14 @@ fl::json AutoResearchRemoteControl::runSingleTestImpl(const fl::json& args) {
         use_legacy_api = config["useLegacyApi"].as_bool().value();
     }
 
-    // 9. Extract tightTiming (optional, default: false)
+    // 9. Extract contaminateTxMux (optional, default: false)
+    bool contaminate_tx_mux = false;
+    if (config.contains("contaminateTxMux") &&
+        config["contaminateTxMux"].is_bool()) {
+        contaminate_tx_mux = config["contaminateTxMux"].as_bool().value();
+    }
+
+    // 10. Extract tightTiming (optional, default: false)
     bool measure_tight_timing = false;
     if (config.contains("tightTiming") && config["tightTiming"].is_bool()) {
         measure_tight_timing = config["tightTiming"].as_bool().value();
@@ -466,6 +486,21 @@ fl::json AutoResearchRemoteControl::runSingleTestImpl(const fl::json& args) {
 
     uint32_t start_ms = millis();
 
+    if (contaminate_tx_mux) {
+        if (!is_object_fled_driver) {
+            response.set("success", false);
+            response.set("error", "MuxContaminationDriverUnsupported");
+            response.set("message", "contaminateTxMux is only supported for OBJECT_FLED");
+            return response;
+        }
+        if (!contaminateTxMuxWithPwm(pin_tx)) {
+            response.set("success", false);
+            response.set("error", "MuxContaminationUnsupported");
+            response.set("message", "contaminateTxMux requires Teensy 4.x analogWriteFrequency support");
+            return response;
+        }
+    }
+
     // Set driver as exclusive (by-name path: driver_name comes from RPC)
     if (!autoResearchSetExclusiveDriverByName(driver_name.c_str())) {
         response.set("success", false);
@@ -501,7 +536,6 @@ fl::json AutoResearchRemoteControl::runSingleTestImpl(const fl::json& args) {
 
     // SPI chipset drivers use APA102 protocol with data+clock pins.
     // Clockless drivers use WS2812B timing on a single data pin
-    bool is_object_fled_driver = (driver_name == "OBJECT_FLED");
     bool is_spi_chipset_driver = (driver_name == "LCD_SPI" ||
                                   driver_name == "I2S_SPI" ||
                                   driver_name == "SPI_UNIFIED");
@@ -676,6 +710,10 @@ fl::json AutoResearchRemoteControl::runSingleTestImpl(const fl::json& args) {
     response.set("pattern", pattern.c_str());
     response.set("useLegacyApi", use_legacy_api);
     response.set("frameCount", static_cast<int64_t>(frame_count));
+    response.set("contaminateTxMux", contaminate_tx_mux);
+    if (contaminate_tx_mux) {
+        response.set("contaminateTxMuxPin", static_cast<int64_t>(pin_tx));
+    }
     if (measure_tight_timing) {
         response.set("tightTiming", tight_timing_response);
     }

--- a/src/third_party/object_fled/src/OjectFLED.cpp.hpp
+++ b/src/third_party/object_fled/src/OjectFLED.cpp.hpp
@@ -105,6 +105,12 @@ static volatile uint32_t *standard_gpio_addr(volatile uint32_t *fastgpio) {
 	return (volatile uint32_t *)((uint32_t)fastgpio - 0x01E48000);
 }
 
+static void force_pin_to_gpio_mux(uint8_t pin) {
+	// Teensy 4.x GPIO pads use MUX_MODE=5. Keep SION set so diagnostics can
+	// observe the pad input path while DMA drives the standard GPIO alias.
+	*portConfigRegister(pin) = 5 | 0x10;
+}
+
 
 void ObjectFLED::begin(uint16_t latchDelay) {
 	LATCH_DELAY = latchDelay;
@@ -179,6 +185,7 @@ void ObjectFLED::begin(void) {
 		pin_offsetLocal[i] = offset;	//local copy for context switch
 		uint32_t mask = 1 << bit;	//mask32 = bit set @position in GPIO DR
 		tempBitmask[offset] |= mask;	//bitmask32[0..3] = collective pin bit masks for each GPIO DR
+		force_pin_to_gpio_mux(pin);	// reclaim pin after PWM/Serial/FlexIO mux use
 		//bit7:6 SPEED; bit 5:3 DSE; bit0 SRE  (default SPEED = 0b10; def. DSE = 0b110)
 		*portControlRegister(pin) &= ~0xF9;		//clear SPEED, DSE, SRE
 		*portControlRegister(pin) |= ((OUTPUT_PAD_SPEED & 0x3) << 6) | \


### PR DESCRIPTION
## Summary
- force ObjectFLED-selected Teensy pins back to GPIO mux mode during `ObjectFLED::begin()` after prior peripheral use
- add AutoResearch `--contaminate-tx-mux` to remux the selected TX pin through `analogWrite()` before `runSingleTest`
- return contamination metadata through JSON-RPC result fields for diagnostics

## Validation
- `uv run --no-sync pytest ci/tests/test_autoresearch_phases.py -q` -> 71 passed
- `uv run --no-sync ruff check ci/autoresearch/args.py ci/autoresearch/phases.py ci/tests/test_autoresearch_phases.py`
- `uv run --no-sync ruff format --check ci/autoresearch/args.py ci/autoresearch/phases.py ci/tests/test_autoresearch_phases.py`
- `soldr cargo fmt --manifest-path ci/lint_cpp_rs/Cargo.toml -- --check`
- `soldr cargo check --manifest-path ci/lint_cpp_rs/Cargo.toml --target x86_64-unknown-linux-gnu --tests` -> passed with existing warnings
- `git diff --check`

## Hardware
`bash autoresearch teensy41 --object-fled --tx-pin 22 --rx-pin 8 --contaminate-tx-mux --timeout 120 --skip-lint`

- fbuild deploy succeeded on `teensy41 @ COM20`
- serial backend was `FbuildSerialAdapter`; no manual serial utility was used
- GPIO pre-test passed for `TX 22 -> RX 8`
- `setPins` echoed `txPin=22`, `rxPin=8`
- `runSingleTest` included `contaminateTxMux: true`
- ObjectFLED still failed honestly as `class=zero_capture`
- diagnostics prove the mux-reclaim path: pin 22 `beforeBegin mux=1 mappedToStandard=0 pad=56`, then `afterBegin mux=21 mappedToStandard=1 pad=24 mode=16777216`
- DMA request/TCD state remained active after wait/clear, so S5 busy/drain/latch semantics remain the next likely fix

This PR completes the provable S4 mux-reclaim/repro parts, but it does not claim ObjectFLED acceptance.