### PR TITLE
fix(objectfled): drain DMA before ready

### DIFF
--- a/src/platforms/arm/teensy/teensy4_common/drivers/objectfled/channel_engine_objectfled.cpp.hpp
+++ b/src/platforms/arm/teensy/teensy4_common/drivers/objectfled/channel_engine_objectfled.cpp.hpp
@@ -73,10 +73,11 @@ void ChannelEngineObjectFLED::enqueue(ChannelDataPtr channelData) FL_NO_EXCEPT {
 }
 
 void ChannelEngineObjectFLED::show() FL_NO_EXCEPT {
-    // Wait for any previous transmission (per DMA Wait Pattern)
-    while (poll() != DriverState::READY) {
-        // ObjectFLED show() is synchronous, so this should be instant
+    if (mEnqueuedChannels.empty()) {
+        return;
     }
+
+    waitForReady();
 
     // Move enqueued -> transmitting
     mTransmittingChannels.swap(mEnqueuedChannels);
@@ -114,116 +115,157 @@ void ChannelEngineObjectFLED::show() FL_NO_EXCEPT {
         found->channels.push_back(ch);
     }
 
-    // ================================================================
-    // Transmit each timing group that has channels this frame
-    // ================================================================
-    for (auto& group : mTimingGroups) {
-        if (group->channels.empty()) {
-            continue;  // No channels this frame for this timing group
+    mCurrentGroupIndex = 0;
+    if (!startNextTimingGroup()) {
+        finishTransmission();
+    }
+}
+
+bool ChannelEngineObjectFLED::startNextTimingGroup() FL_NO_EXCEPT {
+    while (mCurrentGroupIndex < mTimingGroups.size()) {
+        TimingGroup& group = *mTimingGroups[mCurrentGroupIndex];
+        if (group.channels.empty()) {
+            ++mCurrentGroupIndex;
+            continue;
+        }
+        if (startTimingGroup(group)) {
+            return true;
+        }
+        ++mCurrentGroupIndex;
+    }
+    return false;
+}
+
+bool ChannelEngineObjectFLED::startTimingGroup(TimingGroup& group) FL_NO_EXCEPT {
+    RectangularDrawBuffer& drawBuf = group.drawBuffer;
+    drawBuf.onQueuingStart();
+
+    // Queue all channels in this group
+    for (auto& ch : group.channels) {
+        const u8 pin = static_cast<u8>(ch->getPin());
+
+        // Validate pin
+        auto validation = mPeripheral->validatePin(pin);
+        if (!validation.valid) {
+            FL_LOG_OBJECTFLED_F("ChannelEngineObjectFLED: Pin %s invalid: %s", (int)pin, validation.error_message);
+            continue;
         }
 
-        RectangularDrawBuffer& drawBuf = group->drawBuffer;
-        drawBuf.onQueuingStart();
+        // Determine bytes per LED from data size and pin count
+        const auto& data = ch->getData();
+        const size_t dataSize = data.size();
 
-        // Queue all channels in this group
-        for (auto& ch : group->channels) {
-            const u8 pin = static_cast<u8>(ch->getPin());
+        // Determine if RGBW: data size must be divisible by 4 but not 3,
+        // or divisible by both but 4 gives an integer LED count matching 3's
+        // Simple heuristic: if dataSize % 4 == 0 and dataSize % 3 != 0 -> RGBW
+        // Otherwise RGB
+        bool isRgbw = (dataSize % 4 == 0) && (dataSize % 3 != 0);
+        int bytesPerLed = isRgbw ? 4 : 3;
+        u16 numLeds = static_cast<u16>(dataSize / bytesPerLed);
 
-            // Validate pin
-            auto validation = mPeripheral->validatePin(pin);
-            if (!validation.valid) {
-                FL_LOG_OBJECTFLED_F("ChannelEngineObjectFLED: Pin %s invalid: %s", (int)pin, validation.error_message);
-                continue;
-            }
+        drawBuf.queue(DrawItem(pin, numLeds, isRgbw));
+    }
+    drawBuf.onQueuingDone();
 
-            // Determine bytes per LED from data size and pin count
-            const auto& data = ch->getData();
-            const size_t dataSize = data.size();
-
-            // Determine if RGBW: data size must be divisible by 4 but not 3,
-            // or divisible by both but 4 gives an integer LED count matching 3's
-            // Simple heuristic: if dataSize % 4 == 0 and dataSize % 3 != 0 -> RGBW
-            // Otherwise RGB
-            bool isRgbw = (dataSize % 4 == 0) && (dataSize % 3 != 0);
-            int bytesPerLed = isRgbw ? 4 : 3;
-            u16 numLeds = static_cast<u16>(dataSize / bytesPerLed);
-
-            drawBuf.queue(DrawItem(pin, numLeds, isRgbw));
-        }
-        drawBuf.onQueuingDone();
-
-        // Copy raw RGB bytes from ChannelData into the draw buffer
-        for (auto& ch : group->channels) {
-            const u8 pin = static_cast<u8>(ch->getPin());
-            auto validation = mPeripheral->validatePin(pin);
-            if (!validation.valid) {
-                continue;
-            }
-
-            fl::span<u8> stripBytes = drawBuf.getLedsBufferBytesForPin(pin, true);
-            const auto& srcData = ch->getData();
-            const size_t copySize = (srcData.size() < stripBytes.size())
-                                      ? srcData.size()
-                                      : stripBytes.size();
-            if (copySize > 0) {
-                fl::memcpy(stripBytes.data(), srcData.data(), copySize);
-            }
+    // Copy raw RGB bytes from ChannelData into the draw buffer
+    for (auto& ch : group.channels) {
+        const u8 pin = static_cast<u8>(ch->getPin());
+        auto validation = mPeripheral->validatePin(pin);
+        if (!validation.valid) {
+            continue;
         }
 
-        // Build/rebuild ObjectFLED instance only when draw list changes
-        bool drawListChanged = drawBuf.mDrawListChangedThisFrame;
-        if (drawListChanged || !group->instance) {
-            group->instance.reset();
-
-            // Build pin list
-            fl::FixedVector<u8, 50> pinList;
-            bool hasRgbw = false;
-            for (const auto& item : drawBuf.mDrawList) {
-                pinList.push_back(item.mPin);
-                if (item.mIsRgbw) {
-                    hasRgbw = true;
-                }
-            }
-
-            if (pinList.empty()) {
-                continue;  // All pins invalid, skip this group
-            }
-
-            u32 num_strips = 0;
-            u32 bytes_per_strip = 0;
-            u32 total_bytes = 0;
-            drawBuf.getBlockInfo(&num_strips, &bytes_per_strip, &total_bytes);
-
-            int bytesPerLed = hasRgbw ? 4 : 3;
-            int totalLeds = total_bytes / bytesPerLed;
-
-            group->instance = mPeripheral->createInstance(
-                totalLeds, hasRgbw, pinList.size(), pinList.data(),
-                group->timing.t1_ns, group->timing.t2_ns,
-                group->timing.t3_ns, group->timing.reset_us
-            );
+        fl::span<u8> stripBytes = drawBuf.getLedsBufferBytesForPin(pin, true);
+        const auto& srcData = ch->getData();
+        const size_t copySize = (srcData.size() < stripBytes.size())
+                                  ? srcData.size()
+                                  : stripBytes.size();
+        if (copySize > 0) {
+            fl::memcpy(stripBytes.data(), srcData.data(), copySize);
         }
-
-        if (!group->instance) {
-            continue;  // createInstance failed
-        }
-
-        // Copy draw buffer into instance's frame buffer
-        u32 totalBytes = drawBuf.getTotalBytes();
-        u32 frameBufferSize = group->instance->getFrameBufferSize();
-        u32 copyBytes = totalBytes < frameBufferSize ? totalBytes : frameBufferSize;
-        if (copyBytes > 0) {
-            fl::memcpy(
-                group->instance->getFrameBuffer(),
-                drawBuf.mAllLedsBufferUint8.get(),
-                copyBytes
-            );
-        }
-
-        // Transmit! (synchronous - blocks until DMA completes)
-        group->instance->show();
     }
 
+    // Build/rebuild ObjectFLED instance only when draw list changes
+    bool drawListChanged = drawBuf.mDrawListChangedThisFrame;
+    if (drawListChanged || !group.instance) {
+        group.instance.reset();
+
+        // Build pin list
+        fl::FixedVector<u8, 50> pinList;
+        bool hasRgbw = false;
+        for (const auto& item : drawBuf.mDrawList) {
+            pinList.push_back(item.mPin);
+            if (item.mIsRgbw) {
+                hasRgbw = true;
+            }
+        }
+
+        if (pinList.empty()) {
+            return false;  // All pins invalid, skip this group
+        }
+
+        u32 num_strips = 0;
+        u32 bytes_per_strip = 0;
+        u32 total_bytes = 0;
+        drawBuf.getBlockInfo(&num_strips, &bytes_per_strip, &total_bytes);
+
+        int bytesPerLed = hasRgbw ? 4 : 3;
+        int totalLeds = total_bytes / bytesPerLed;
+
+        group.instance = mPeripheral->createInstance(
+            totalLeds, hasRgbw, pinList.size(), pinList.data(),
+            group.timing.t1_ns, group.timing.t2_ns,
+            group.timing.t3_ns, group.timing.reset_us
+        );
+    }
+
+    if (!group.instance) {
+        return false;  // createInstance failed
+    }
+
+    // Copy draw buffer into instance's frame buffer
+    u32 totalBytes = drawBuf.getTotalBytes();
+    u32 frameBufferSize = group.instance->getFrameBufferSize();
+    u32 copyBytes = totalBytes < frameBufferSize ? totalBytes : frameBufferSize;
+    if (copyBytes > 0) {
+        fl::memcpy(
+            group.instance->getFrameBuffer(),
+            drawBuf.mAllLedsBufferUint8.get(),
+            copyBytes
+        );
+    }
+
+    group.instance->show();
+    return true;
+}
+
+IChannelDriver::DriverState ChannelEngineObjectFLED::poll() FL_NO_EXCEPT {
+    if (mTransmittingChannels.empty()) {
+        return DriverState::READY;
+    }
+
+    while (mCurrentGroupIndex < mTimingGroups.size()) {
+        TimingGroup& group = *mTimingGroups[mCurrentGroupIndex];
+        if (group.channels.empty() || !group.instance) {
+            ++mCurrentGroupIndex;
+            continue;
+        }
+
+        if (group.instance->isBusy()) {
+            return DriverState::DRAINING;
+        }
+
+        ++mCurrentGroupIndex;
+        if (startNextTimingGroup()) {
+            return DriverState::BUSY;
+        }
+    }
+
+    finishTransmission();
+    return DriverState::READY;
+}
+
+void ChannelEngineObjectFLED::finishTransmission() FL_NO_EXCEPT {
     // Remove stale timing groups that had no channels this frame
     // (channels were destroyed, e.g., FastLED.clear(ClearFlags::CHANNELS))
     for (size_t i = mTimingGroups.size(); i > 0; --i) {
@@ -237,11 +279,7 @@ void ChannelEngineObjectFLED::show() FL_NO_EXCEPT {
         ch->setInUse(false);
     }
     mTransmittingChannels.clear();
-}
-
-IChannelDriver::DriverState ChannelEngineObjectFLED::poll() FL_NO_EXCEPT {
-    // ObjectFLED show() is synchronous - always READY after show() returns
-    return DriverState::READY;
+    mCurrentGroupIndex = 0;
 }
 
 } // namespace fl

--- a/src/platforms/arm/teensy/teensy4_common/drivers/objectfled/channel_engine_objectfled.h
+++ b/src/platforms/arm/teensy/teensy4_common/drivers/objectfled/channel_engine_objectfled.h
@@ -2,8 +2,8 @@
 /// @brief ObjectFLED DMA-based channel engine for Teensy 4.x
 ///
 /// Implements IChannelDriver wrapping ObjectFLED's 3:1 DMA bit transposition.
-/// ObjectFLED's show() is synchronous (blocks until DMA completes), so the
-/// state machine is simply: READY -> BUSY -> READY (no DRAINING).
+/// ObjectFLED's show() starts DMA and returns while output/latch timing may
+/// still be active, so poll() owns the DRAINING -> READY transition.
 ///
 /// Data format: ChannelData contains raw RGB/RGBW bytes (from ws2812 encoder),
 /// which is exactly what ObjectFLED expects in its frameBufferLocal.
@@ -38,7 +38,7 @@ class IObjectFLEDPeripheral;
 /// period 1000-2500ns (standard WS2812/SK6812 range). Rejects WS2816 and
 /// other HD chipsets that use different encoding.
 ///
-/// State machine: READY -> BUSY -> READY (synchronous DMA)
+/// State machine: READY -> BUSY -> DRAINING -> READY
 class ChannelEngineObjectFLED : public IChannelDriver {
 public:
     /// @brief Construct with platform-default peripheral
@@ -56,11 +56,11 @@ public:
     /// @brief Enqueue channel data for transmission
     void enqueue(ChannelDataPtr channelData) FL_NO_EXCEPT override;
 
-    /// @brief Trigger transmission of enqueued data (synchronous DMA)
+    /// @brief Trigger transmission of enqueued data
     void show() FL_NO_EXCEPT override;
 
     /// @brief Query engine state
-    /// @return READY (ObjectFLED show() is synchronous, always completes before returning)
+    /// @return DRAINING while ObjectFLED DMA/latch timing is active
     DriverState poll() FL_NO_EXCEPT override;
 
     /// @brief Get engine name
@@ -86,6 +86,12 @@ private:
 
     /// @brief Persistent timing groups (cached across frames)
     fl::vector<fl::unique_ptr<TimingGroup>> mTimingGroups;
+
+    size_t mCurrentGroupIndex = 0;
+
+    bool startNextTimingGroup() FL_NO_EXCEPT;
+    bool startTimingGroup(TimingGroup& group) FL_NO_EXCEPT;
+    void finishTransmission() FL_NO_EXCEPT;
 };
 
 } // namespace fl

--- a/src/platforms/arm/teensy/teensy4_common/drivers/objectfled/iobjectfled_peripheral.h
+++ b/src/platforms/arm/teensy/teensy4_common/drivers/objectfled/iobjectfled_peripheral.h
@@ -27,7 +27,8 @@ struct ObjectFLEDPinResult {
 /// @brief Abstract handle for a single ObjectFLED timing-group instance
 ///
 /// Owns a frame buffer that the channel engine writes pixel data into.
-/// show() triggers synchronous DMA transmission.
+/// show() starts DMA transmission; isBusy() remains true while DMA or latch
+/// reset timing is still active.
 class IObjectFLEDInstance {
 public:
     virtual ~IObjectFLEDInstance() = default;
@@ -38,8 +39,11 @@ public:
     /// @brief Get size of the frame buffer in bytes
     virtual u32 getFrameBufferSize() const FL_NO_EXCEPT = 0;
 
-    /// @brief Trigger synchronous DMA transmission
+    /// @brief Trigger DMA transmission
     virtual void show() FL_NO_EXCEPT = 0;
+
+    /// @brief Return true while DMA output or latch/reset timing is active
+    virtual bool isBusy() FL_NO_EXCEPT = 0;
 
 protected:
     IObjectFLEDInstance() = default;

--- a/src/platforms/arm/teensy/teensy4_common/drivers/objectfled/objectfled_peripheral_real.cpp.hpp
+++ b/src/platforms/arm/teensy/teensy4_common/drivers/objectfled/objectfled_peripheral_real.cpp.hpp
@@ -13,6 +13,7 @@
 #include "fl/stl/cstring.h"
 // IWYU pragma: begin_keep
 #include "third_party/object_fled/src/ObjectFLED.h"
+#include "third_party/object_fled/src/ObjectFLEDDmaManager.h"
 #include "third_party/object_fled/src/ObjectFLEDPinValidation.h"
 // IWYU pragma: end_keep
 
@@ -52,6 +53,14 @@ public:
         objectFledDiagnosticsRecord("beforeShow", mPins, mPinCount);
         mObjectFLED->show();
         objectFledDiagnosticsRecord("afterShowReturn", mPins, mPinCount);
+    }
+
+    bool isBusy() override {
+        if (mObjectFLED == nullptr) {
+            return false;
+        }
+        return mObjectFLED->busy() != 0 ||
+               ObjectFLEDDmaManager::getInstance().isBusy();
     }
 
 private:

--- a/src/platforms/shared/mock/arm/teensy4/drivers/objectfled/objectfled_peripheral_mock.h
+++ b/src/platforms/shared/mock/arm/teensy4/drivers/objectfled/objectfled_peripheral_mock.h
@@ -25,8 +25,9 @@ namespace fl {
 
 class ObjectFLEDInstanceMock : public IObjectFLEDInstance {
 public:
-    ObjectFLEDInstanceMock(u32 totalBytes)
- FL_NO_EXCEPT : mBuffer(totalBytes, 0), mShowCount(0) {}
+    ObjectFLEDInstanceMock(u32 totalBytes, bool busyAfterShow = false)
+ FL_NO_EXCEPT : mBuffer(totalBytes, 0), mShowCount(0),
+                 mBusyAfterShow(busyAfterShow), mBusy(false) {}
 
     ~ObjectFLEDInstanceMock() override = default;
 
@@ -40,6 +41,11 @@ public:
 
     void show() FL_NO_EXCEPT override {
         ++mShowCount;
+        mBusy = mBusyAfterShow;
+    }
+
+    bool isBusy() FL_NO_EXCEPT override {
+        return mBusy;
     }
 
     // =========================================================================
@@ -52,9 +58,19 @@ public:
     /// @brief Get raw buffer contents (written by channel engine before show())
     const fl::vector<u8>& getRawBuffer() const FL_NO_EXCEPT { return mBuffer; }
 
+    /// @brief Complete the simulated DMA/latch wait
+    void complete() FL_NO_EXCEPT { mBusy = false; }
+
+    /// @brief Configure whether show() leaves the instance busy
+    void setBusyAfterShow(bool busyAfterShow) FL_NO_EXCEPT {
+        mBusyAfterShow = busyAfterShow;
+    }
+
 private:
     fl::vector<u8> mBuffer;
     u32 mShowCount;
+    bool mBusyAfterShow;
+    bool mBusy;
 };
 
 // ============================================================================
@@ -72,7 +88,8 @@ public:
         u32 t1_ns, t2_ns, t3_ns, reset_us;
     };
 
-    ObjectFLEDPeripheralMock() FL_NO_EXCEPT : mForceCreateFailure(false) {}
+    ObjectFLEDPeripheralMock() FL_NO_EXCEPT
+        : mForceCreateFailure(false), mBusyAfterShow(false) {}
     ~ObjectFLEDPeripheralMock() override = default;
 
     // =========================================================================
@@ -111,8 +128,9 @@ public:
         int bytesPerLed = isRgbw ? 4 : 3;
         u32 totalBytes = static_cast<u32>(totalLeds * bytesPerLed);
 
-        auto instance = fl::make_unique<ObjectFLEDInstanceMock>(totalBytes);
+        auto instance = fl::make_unique<ObjectFLEDInstanceMock>(totalBytes, mBusyAfterShow);
         mLastInstance = instance.get();
+        mInstances.push_back(instance.get());
         return instance;
     }
 
@@ -131,6 +149,9 @@ public:
     /// @brief Force createInstance() to return nullptr
     void setCreateFailure(bool fail) FL_NO_EXCEPT { mForceCreateFailure = fail; }
 
+    /// @brief Force newly-created instances to remain busy after show()
+    void setBusyAfterShow(bool busy) FL_NO_EXCEPT { mBusyAfterShow = busy; }
+
     /// @brief Get total number of createInstance() calls
     size_t getCreateCount() const FL_NO_EXCEPT { return mCreateRecords.size(); }
 
@@ -146,12 +167,22 @@ public:
     /// @brief Get the last created instance (raw pointer, not owned)
     ObjectFLEDInstanceMock* getLastInstance() const FL_NO_EXCEPT { return mLastInstance; }
 
+    /// @brief Get a created instance by creation index (raw pointer, not owned)
+    ObjectFLEDInstanceMock* getInstance(size_t index) const FL_NO_EXCEPT {
+        if (index >= mInstances.size()) {
+            return nullptr;
+        }
+        return mInstances[index];
+    }
+
     /// @brief Reset all mock state
     void reset() FL_NO_EXCEPT {
         mInvalidPins.clear();
         mCreateRecords.clear();
+        mInstances.clear();
         mLastInstance = nullptr;
         mForceCreateFailure = false;
+        mBusyAfterShow = false;
     }
 
 private:
@@ -162,8 +193,10 @@ private:
 
     fl::vector<InvalidPin> mInvalidPins;
     fl::vector<CreateRecord> mCreateRecords;
+    fl::vector<ObjectFLEDInstanceMock*> mInstances;
     ObjectFLEDInstanceMock* mLastInstance = nullptr;
     bool mForceCreateFailure;
+    bool mBusyAfterShow;
 };
 
 } // namespace fl

--- a/tests/platforms/arm/teensy/teensy4_common/drivers/objectfled/channel_engine_objectfled.cpp
+++ b/tests/platforms/arm/teensy/teensy4_common/drivers/objectfled/channel_engine_objectfled.cpp
@@ -193,8 +193,67 @@ FL_TEST_CASE("ObjectFLED engine - different timing = 2 instances") {
     engine.enqueue(ch1);
     engine.enqueue(ch2);
     engine.show();
+    while (engine.poll() != DriverState::READY) {
+    }
 
     FL_CHECK(mock->getCreateCount() == 2);
+}
+
+FL_TEST_CASE("ObjectFLED engine - poll drains active DMA/latch state") {
+    auto mock = fl::make_shared<ObjectFLEDPeripheralMock>();
+    mock->setBusyAfterShow(true);
+    ChannelEngineObjectFLED engine(mock);
+
+    uint8_t red[] = {0xFF, 0x00, 0x00};
+    auto ch = createRGBChannelData(2, 1, red);
+
+    engine.enqueue(ch);
+    engine.show();
+
+    auto* inst = mock->getLastInstance();
+    FL_REQUIRE(inst != nullptr);
+    FL_CHECK(ch->isInUse() == true);
+    FL_CHECK(engine.poll() == DriverState::DRAINING);
+
+    inst->complete();
+    FL_CHECK(engine.poll() == DriverState::READY);
+    FL_CHECK(ch->isInUse() == false);
+}
+
+FL_TEST_CASE("ObjectFLED engine - timing groups sequence after busy completion") {
+    auto mock = fl::make_shared<ObjectFLEDPeripheralMock>();
+    mock->setBusyAfterShow(true);
+    ChannelEngineObjectFLED engine(mock);
+
+    ChipsetTimingConfig ws2812 = createWS2812Timing();
+    ChipsetTimingConfig sk6812 = createSK6812Timing();
+    auto ch1 = createRGBChannelData(2, 1, nullptr, &ws2812);
+    auto ch2 = createRGBChannelData(3, 1, nullptr, &sk6812);
+
+    engine.enqueue(ch1);
+    engine.enqueue(ch2);
+    engine.show();
+
+    FL_CHECK(mock->getCreateCount() == 1);
+    FL_CHECK(ch1->isInUse() == true);
+    FL_CHECK(ch2->isInUse() == true);
+    FL_CHECK(engine.poll() == DriverState::DRAINING);
+
+    auto* first = mock->getInstance(0);
+    FL_REQUIRE(first != nullptr);
+    first->complete();
+
+    FL_CHECK(engine.poll() == DriverState::BUSY);
+    FL_CHECK(mock->getCreateCount() == 2);
+    FL_CHECK(engine.poll() == DriverState::DRAINING);
+
+    auto* second = mock->getInstance(1);
+    FL_REQUIRE(second != nullptr);
+    second->complete();
+
+    FL_CHECK(engine.poll() == DriverState::READY);
+    FL_CHECK(ch1->isInUse() == false);
+    FL_CHECK(ch2->isInUse() == false);
 }
 
 FL_TEST_CASE("ObjectFLED engine - empty enqueue does nothing") {


### PR DESCRIPTION
## Summary
- expose ObjectFLED instance busy state through `IObjectFLEDInstance`
- make the real ObjectFLED instance report busy while DMA or latch/reset timing is active
- change `ChannelEngineObjectFLED` from an immediate-ready synchronous loop to a `DRAINING` state machine that starts one timing group at a time
- keep channel data marked in-use until `poll()` observes completion
- add mock/unit coverage for active busy draining and sequencing multiple timing groups only after the previous group completes

## Why
S3/S4 diagnostics showed `FastLED.wait()` returned while ObjectFLED DMA/TCD state was still active. The engine comment claimed ObjectFLED `show()` was synchronous, but ObjectFLED starts DMA and returns while output/latch timing can still be active.

## Validation
- `bash test --unit --no-fingerprint` -> 254/254 passed, including `channel_engine_objectfled`
- `git diff --check`
- attempted `bash test objectfled --unit --no-fingerprint`; wrapper selected the correct source but misrouted to missing target `tests/profile/channel_engine_objectfled`, so full unit suite was used instead
- attempted `bash lint --cpp`; blocked by the known local Rust/MSVC sysroot issue: `can't find crate for std` for `x86_64-pc-windows-msvc`

## Hardware
`bash autoresearch teensy41 --object-fled --tx-pin 22 --rx-pin 8 --timeout 120 --skip-lint`

- fbuild deploy succeeded on `teensy41 @ COM20`
- serial backend was `FbuildSerialAdapter`; no manual serial utility was used
- GPIO pre-test passed for `TX 22 -> RX 8`
- leading `setPins` echoed `txPin=22`, `rxPin=8`
- ObjectFLED still failed honestly as `class=zero_capture`
- diagnostics changed in the intended direction: after `FastLED.wait()`, `framebufferIndex=300` for `numbytes=300` and DMA request state was mostly drained (`dma.erq=8` rather than the earlier active multi-channel request state)
- the remaining zero-capture failure now points to actual signal generation/GPIO/timer/DMA correctness, not the engine reporting READY immediately

This PR is S5 progress only; it does not claim ObjectFLED acceptance.