### PR TITLE
diag(objectfled): report busy state snapshots

### DIFF
--- a/ci/lint_cpp_rs/src/checkers/style.rs
+++ b/ci/lint_cpp_rs/src/checkers/style.rs
@@ -384,8 +384,7 @@ impl FileContentChecker for AutoResearchRuntimeOutputChecker {
             return false;
         }
         let normalized = normalize_path(file_path);
-        normalized.ends_with("examples/AutoResearch/AutoResearch.ino")
-            || normalized.contains("examples/AutoResearch/AutoResearchRemote")
+        normalized.contains("examples/AutoResearch/")
     }
 
     fn check_file_content(&self, file_content: &FileContent) -> Vec<(usize, String)> {
@@ -393,11 +392,29 @@ impl FileContentChecker for AutoResearchRuntimeOutputChecker {
             return Vec::new();
         }
 
+        let normalized_path = normalize_path(&file_content.path);
+        let always_enforced =
+            normalized_path.ends_with("examples/AutoResearch/AutoResearch.ino")
+                || normalized_path.contains("examples/AutoResearch/AutoResearchRemote");
         let mut violations = Vec::new();
         let mut in_multiline_comment = false;
+        let mut lint_active = always_enforced;
 
         for (index, line) in file_content.lines.iter().enumerate() {
             let stripped = line.trim();
+            let lower_line = line.to_ascii_lowercase();
+
+            if lower_line.contains("autoresearch-runtime-output-lint: begin") {
+                lint_active = true;
+                continue;
+            }
+            if lower_line.contains("autoresearch-runtime-output-lint: end") {
+                lint_active = always_enforced;
+                continue;
+            }
+            if !lint_active {
+                continue;
+            }
 
             if line.contains("/*") {
                 in_multiline_comment = true;
@@ -428,7 +445,7 @@ impl FileContentChecker for AutoResearchRuntimeOutputChecker {
             violations.push((
                 index + 1,
                 format!(
-                    "AutoResearch runtime output must use JSON-RPC result fields, not direct logging/serial output.\n      Line: {stripped}\n      If this is the RPC transport boundary itself, suppress with `// ok autoresearch rpc serial - <reason>`."
+                    "AutoResearch runtime output must use JSON-RPC result fields, not direct logging/serial output.\n      Line: {stripped}\n      Boot/RPC files are always checked; other AutoResearch files can protect critical test sections with `// autoresearch-runtime-output-lint: begin` and `// autoresearch-runtime-output-lint: end`.\n      If this is the RPC transport boundary itself, suppress with `// ok autoresearch rpc serial - <reason>`."
                 ),
             ));
         }

--- a/ci/lint_cpp_rs/src/lint_core/tests.rs
+++ b/ci/lint_cpp_rs/src/lint_core/tests.rs
@@ -87,7 +87,7 @@ mod tests {
             "examples/AutoResearch/AutoResearchRemotePinMethods.cpp",
             Path::new(".")
         ));
-        assert!(!checker.should_process_file(
+        assert!(checker.should_process_file(
             "examples/AutoResearch/AutoResearchTest.cpp",
             Path::new(".")
         ));
@@ -97,6 +97,33 @@ mod tests {
                 "FL_WARN(\"diagnostic-only path\");\n",
             ))
             .is_empty());
+    }
+
+    #[test]
+    fn autoresearch_runtime_output_marker_scope_flags_test_time_sections() {
+        let checker = AutoResearchRuntimeOutputChecker;
+        let result = checker.check_file_content(&file(
+            "examples/AutoResearch/AutoResearchTest.cpp",
+            "FL_WARN(\"legacy diagnostic outside guarded section\");\n\
+// autoresearch-runtime-output-lint: begin\n\
+FL_WARN(\"test-time chatter\");\n\
+Serial.println(\"test-time chatter\");\n\
+fl::serial_println(\"test-time chatter\");\n\
+// autoresearch-runtime-output-lint: end\n\
+FL_WARN(\"legacy diagnostic outside guarded section\");\n",
+        ));
+        assert_eq!(result.len(), 3);
+    }
+
+    #[test]
+    fn autoresearch_runtime_output_marker_scope_restores_always_checked_files() {
+        let checker = AutoResearchRuntimeOutputChecker;
+        let result = checker.check_file_content(&file(
+            "examples/AutoResearch/AutoResearchRemoteRunSingleTest.cpp",
+            "// autoresearch-runtime-output-lint: end\n\
+FL_WARN(\"still checked because remote files are always guarded\");\n",
+        ));
+        assert_eq!(result.len(), 1);
     }
 
     #[test]

--- a/src/platforms/arm/teensy/teensy4_common/drivers/objectfled/objectfled_diagnostics.cpp.hpp
+++ b/src/platforms/arm/teensy/teensy4_common/drivers/objectfled/objectfled_diagnostics.cpp.hpp
@@ -97,6 +97,12 @@ struct DmaSnapshot {
     DmaChannelSnapshot dma2next;
 };
 
+struct BusyStateSnapshot {
+    bool dmaActive = false;
+    bool latchActive = false;
+    bool ready = true;
+};
+
 struct SnapshotEvent {
     const char* stage = "";
     u32 millisValue = 0;
@@ -111,6 +117,7 @@ struct SnapshotEvent {
     u32 xbarCtrl0 = 0;
     u32 xbarCtrl1 = 0;
     DmaSnapshot dma;
+    BusyStateSnapshot busy;
 };
 
 SnapshotEvent s_events[kMaxEvents];
@@ -118,6 +125,7 @@ u8 s_eventCount = 0;
 u32 s_overflowCount = 0;
 u8 s_lastPins[kMaxPins];
 u8 s_lastPinCount = 0;
+BusyStateSnapshot s_busyState;
 
 u32 ptrToU32(const volatile void* ptr) FL_NO_EXCEPT {
     return static_cast<u32>(fl::ptr_to_int(const_cast<void*>(ptr)));
@@ -344,6 +352,9 @@ void appendEvent(fl::sstream& out, const SnapshotEvent& event) FL_NO_EXCEPT {
     out << "stage=" << event.stage
         << " ms=" << event.millisValue
         << " us=" << event.microsValue
+        << " busy.dmaActive=" << (event.busy.dmaActive ? 1 : 0)
+        << " busy.latchActive=" << (event.busy.latchActive ? 1 : 0)
+        << " busy.ready=" << (event.busy.ready ? 1 : 0)
         << " gpr26=" << event.gpr[0]
         << " gpr27=" << event.gpr[1]
         << " gpr28=" << event.gpr[2]
@@ -407,6 +418,14 @@ void objectFledDiagnosticsReset() FL_NO_EXCEPT {
     s_eventCount = 0;
     s_overflowCount = 0;
     s_lastPinCount = 0;
+    s_busyState = BusyStateSnapshot();
+}
+
+void objectFledDiagnosticsSetBusyState(bool dma_active,
+                                       bool latch_active) FL_NO_EXCEPT {
+    s_busyState.dmaActive = dma_active;
+    s_busyState.latchActive = latch_active;
+    s_busyState.ready = !dma_active && !latch_active;
 }
 
 void objectFledDiagnosticsRecord(const char* stage, const u8* pins,
@@ -434,6 +453,7 @@ void objectFledDiagnosticsRecord(const char* stage, const u8* pins,
     event.stage = stage != nullptr ? stage : "";
     event.millisValue = millis();
     event.microsValue = micros();
+    event.busy = s_busyState;
     event.pinCount = static_cast<u8>(pin_count < kMaxPins ? pin_count : kMaxPins);
     for (u8 i = 0; i < event.pinCount; ++i) {
         event.pins[i] = capturePin(pins[i]);
@@ -458,7 +478,7 @@ fl::json objectFledDiagnosticsToJson() FL_NO_EXCEPT {
     out.set("enabled", true);
     setU32(out, "eventCount", s_eventCount);
     setU32(out, "overflowCount", s_overflowCount);
-    out.set("format", "objectfled-register-snapshot-v1");
+    out.set("format", "objectfled-register-snapshot-v2");
     out.set("note",
             "snapshot is newline-delimited key=value register state");
     fl::sstream snapshot;

--- a/src/platforms/arm/teensy/teensy4_common/drivers/objectfled/objectfled_diagnostics.h
+++ b/src/platforms/arm/teensy/teensy4_common/drivers/objectfled/objectfled_diagnostics.h
@@ -13,6 +13,8 @@ namespace fl {
 #if defined(FL_IS_TEENSY_4X) && defined(FASTLED_OBJECTFLED_DIAGNOSTICS) && FASTLED_OBJECTFLED_DIAGNOSTICS
 
 void objectFledDiagnosticsReset() FL_NO_EXCEPT;
+void objectFledDiagnosticsSetBusyState(bool dma_active,
+                                       bool latch_active) FL_NO_EXCEPT;
 void objectFledDiagnosticsRecord(const char* stage, const u8* pins = nullptr,
                                  u32 pin_count = 0) FL_NO_EXCEPT;
 fl::json objectFledDiagnosticsToJson() FL_NO_EXCEPT;
@@ -20,6 +22,8 @@ fl::json objectFledDiagnosticsToJson() FL_NO_EXCEPT;
 #else
 
 inline void objectFledDiagnosticsReset() FL_NO_EXCEPT {}
+
+inline void objectFledDiagnosticsSetBusyState(bool, bool) FL_NO_EXCEPT {}
 
 inline void objectFledDiagnosticsRecord(const char*, const u8* = nullptr,
                                         u32 = 0) FL_NO_EXCEPT {}

--- a/src/platforms/arm/teensy/teensy4_common/drivers/objectfled/objectfled_peripheral_real.cpp.hpp
+++ b/src/platforms/arm/teensy/teensy4_common/drivers/objectfled/objectfled_peripheral_real.cpp.hpp
@@ -50,20 +50,29 @@ public:
     }
 
     void show() override {
+        updateBusyState();
         objectFledDiagnosticsRecord("beforeShow", mPins, mPinCount);
         mObjectFLED->show();
+        updateBusyState();
         objectFledDiagnosticsRecord("afterShowReturn", mPins, mPinCount);
     }
 
     bool isBusy() override {
-        if (mObjectFLED == nullptr) {
-            return false;
-        }
-        return mObjectFLED->busy() != 0 ||
-               ObjectFLEDDmaManager::getInstance().isBusy();
+        return updateBusyState();
     }
 
 private:
+    bool updateBusyState() {
+        if (mObjectFLED == nullptr) {
+            objectFledDiagnosticsSetBusyState(false, false);
+            return false;
+        }
+        const bool latchBusy = mObjectFLED->busy() != 0;
+        const bool dmaBusy = ObjectFLEDDmaManager::getInstance().isBusy();
+        objectFledDiagnosticsSetBusyState(dmaBusy, latchBusy);
+        return latchBusy || dmaBusy;
+    }
+
     static constexpr u32 kMaxCapturedPins = 16;
     ObjectFLED* mObjectFLED;
     u32 mTotalBytes;


### PR DESCRIPTION
## Summary

- add ObjectFLED diagnostic busy-state fields for DMA-active, latch-active, and ready snapshots
- update the ObjectFLED real peripheral wrapper so each diagnostic lifecycle event records current busy state
- extend the AutoResearch runtime-output lint so boot/RPC files remain always guarded while other AutoResearch files can opt into guarded sections with marker comments

## Validation

- `git diff --check`
- `soldr cargo fmt --manifest-path ci/lint_cpp_rs/Cargo.toml -- --check`
- `soldr cargo check --manifest-path ci/lint_cpp_rs/Cargo.toml --target x86_64-unknown-linux-gnu --tests` (existing unrelated warnings only)
- `bash test --unit --no-fingerprint` -> 254/254 passed
- `bash autoresearch teensy41 --object-fled --tx-pin 22 --rx-pin 8 --timeout 120 --skip-lint`

## Hardware Result

The AutoResearch run used fbuild deploy on `teensy41 @ COM20`, `FbuildSerialAdapter`, and the current soldered loopback `TX 22 -> RX 8`. GPIO pretest passed and `setPins` echoed `txPin=22`, `rxPin=8`.

ObjectFLED still fails honestly as `class=zero_capture`, but diagnostics now distinguish the S5 states:

- `beforeShow`: `busy.dmaActive=0`, `busy.latchActive=0`, `busy.ready=1`
- `afterShowReturn`: `busy.dmaActive=1`, `busy.latchActive=1`, `busy.ready=0`
- `afterFastLedWait`: `busy.dmaActive=0`, `busy.latchActive=0`, `busy.ready=1`

The remaining issue is actual signal generation/capture, not the S5 diagnostic visibility item.