### PR TITLE
[codex] Fix ObjectFLED legacy frame-end flush

### DIFF
--- a/src/platforms/arm/teensy/teensy4_common/clockless_objectfled.cpp.hpp
+++ b/src/platforms/arm/teensy/teensy4_common/clockless_objectfled.cpp.hpp
@@ -29,6 +29,14 @@ namespace fl {
 // ObjectFLEDRegistry Implementation (non-template)
 // ============================================================================
 
+ObjectFLEDRegistry::ObjectFLEDRegistry() FL_NO_EXCEPT {
+    EngineEvents::addListener(this);
+}
+
+ObjectFLEDRegistry::~ObjectFLEDRegistry() FL_NO_EXCEPT {
+    EngineEvents::removeListener(this);
+}
+
 void ObjectFLEDRegistry::registerGroup(void* groupPtr, void (*flushFunc)(void*)) {
     GroupEntry entry{groupPtr, flushFunc};
     if (!contains(entry)) {
@@ -37,10 +45,11 @@ void ObjectFLEDRegistry::registerGroup(void* groupPtr, void (*flushFunc)(void*))
 }
 
 void ObjectFLEDRegistry::flushAll() {
-    for (auto& entry : mGroups) {
+    fl::vector<GroupEntry> groups = mGroups;
+    mGroups.clear();
+    for (auto& entry : groups) {
         entry.flushFunc(entry.groupPtr);
     }
-    mGroups.clear();
 }
 
 void ObjectFLEDRegistry::flushAllExcept(void* exceptPtr) {
@@ -60,6 +69,10 @@ bool ObjectFLEDRegistry::contains(const GroupEntry& entry) {
         if (e == entry) return true;
     }
     return false;
+}
+
+void ObjectFLEDRegistry::onEndFrame() FL_NO_EXCEPT {
+    flushAll();
 }
 
 // ============================================================================

--- a/src/platforms/arm/teensy/teensy4_common/clockless_objectfled.h
+++ b/src/platforms/arm/teensy/teensy4_common/clockless_objectfled.h
@@ -32,6 +32,7 @@
 #include "fl/stl/singleton.h"
 #include "fl/stl/map.h"
 #include "fl/stl/noexcept.h"
+#include "fl/system/engine_events.h"
 
 #ifndef FASTLED_OBJECTFLED_LATCH_DELAY
 #define FASTLED_OBJECTFLED_LATCH_DELAY 300  // WS2812-5VB
@@ -47,8 +48,11 @@ template <typename TIMING> class ObjectFLEDGroup;
 // ============================================================================
 
 /// Track all active chipset groups across all chipset types
-class ObjectFLEDRegistry {
+class ObjectFLEDRegistry : public EngineEvents::Listener {
 public:
+    ObjectFLEDRegistry() FL_NO_EXCEPT;
+    ~ObjectFLEDRegistry() FL_NO_EXCEPT override;
+
     static ObjectFLEDRegistry& getInstance() FL_NO_EXCEPT {
         return fl::Singleton<ObjectFLEDRegistry>::instance();
     }
@@ -61,6 +65,8 @@ public:
 
     // Flush all groups except the specified one
     void flushAllExcept(void* exceptPtr) FL_NO_EXCEPT;
+
+    void onEndFrame() FL_NO_EXCEPT override;
 
 private:
     struct GroupEntry {
@@ -125,22 +131,30 @@ public:
 
     ObjectFLEDGroup()
         : mBase(ObjectFLEDTimingConfig{TIMING::T1, TIMING::T2, TIMING::T3, TIMING::RESET}) {
-        // Auto-register with global registry on construction
-        ObjectFLEDRegistry::getInstance().registerGroup(
-            this,
-            [](void* ptr) {
-                static_cast<ObjectFLEDGroup*>(ptr)->flush();
-            }
-        );
+        registerWithRegistry();
     }
 
-    void onQueuingStart() { mBase.onQueuingStart(); }
+    void onQueuingStart() {
+        registerWithRegistry();
+        mBase.onQueuingStart();
+    }
     void addStrip(u8 pin, PixelIterator& pixel_iterator) FL_NO_EXCEPT {
         mBase.addStrip(pin, pixel_iterator);
     }
     void flush() { mBase.flush(); }
 
 private:
+    static void flushRegisteredGroup(void* ptr) FL_NO_EXCEPT {
+        static_cast<ObjectFLEDGroup*>(ptr)->flush();
+    }
+
+    void registerWithRegistry() FL_NO_EXCEPT {
+        ObjectFLEDRegistry::getInstance().registerGroup(
+            this,
+            &ObjectFLEDGroup<TIMING>::flushRegisteredGroup
+        );
+    }
+
     ObjectFLEDGroupBase mBase;  // Delegate all work to concrete base
 };
 


### PR DESCRIPTION
﻿## Summary

- Register the legacy ObjectFLED registry as an engine-event listener.
- Flush pending legacy ObjectFLED groups at frame end so a single or final group is not left queued forever.
- Re-register per-chipset singleton groups when queuing starts so later frames continue to participate after `flushAll()` clears the registry.

## Validation

- `git diff --check`
- `bash test --unit --no-fingerprint` -> 254/254 passed
- `bash autoresearch teensy41 --object-fled --tx-pin 22 --rx-pin 8 --timeout 120 --skip-lint` -> fbuild deploy succeeded on COM20, GPIO pretest passed for `TX 22 -> RX 8`, result still fails honestly as `class=zero_capture` on the current channel path.

## Notes

This resolves the first S6 burn-down item in #3359: add a real end-frame flush path for the last/single legacy ObjectFLED group. It does not claim the remaining S6 raw-framebuffer/null-drawBuffer or multi-strip finalization tasks.
