### PR TITLE
[codex] Fix ObjectFLED raw framebuffer transmit

### DIFF
--- a/src/platforms/arm/teensy/teensy4_common/clockless_objectfled.cpp.hpp
+++ b/src/platforms/arm/teensy/teensy4_common/clockless_objectfled.cpp.hpp
@@ -187,8 +187,8 @@ void ObjectFLEDGroupBase::flush() {
                     totalBytes);
     }
 
-    // TRANSMIT to hardware!
-    objectfled->show();
+    // Transmit the already packed RectangularDrawBuffer bytes.
+    objectfled->showRawFrameBuffer();
 }
 
 void ObjectFLEDGroupBase::rebuildObjectFLED() {

--- a/src/platforms/arm/teensy/teensy4_common/drivers/objectfled/objectfled_peripheral_real.cpp.hpp
+++ b/src/platforms/arm/teensy/teensy4_common/drivers/objectfled/objectfled_peripheral_real.cpp.hpp
@@ -52,7 +52,7 @@ public:
     void show() override {
         updateBusyState();
         objectFledDiagnosticsRecord("beforeShow", mPins, mPinCount);
-        mObjectFLED->show();
+        mObjectFLED->showRawFrameBuffer();
         updateBusyState();
         objectFledDiagnosticsRecord("afterShowReturn", mPins, mPinCount);
     }
@@ -115,13 +115,6 @@ public:
             static_cast<u16>(reset_us)
         );
         objectFledDiagnosticsRecord("afterBegin", pinList, numPins);
-
-        // CRITICAL: Set drawBuffer to frameBufferLocal so genFrameBuffer()
-        // (called inside show()) doesn't dereference nullptr. We write
-        // pixel data directly into frameBufferLocal, so genFrameBuffer's
-        // copy from drawBuffer→frameBufferLocal becomes a self-copy (no-op
-        // at default brightness=255).
-        ofled->drawBuffer = ofled->frameBufferLocal;
 
         int bytesPerLed = isRgbw ? 4 : 3;
         u32 totalBytes = static_cast<u32>(totalLeds * bytesPerLed);

--- a/src/third_party/object_fled/src/ObjectFLED.h
+++ b/src/third_party/object_fled/src/ObjectFLED.h
@@ -153,6 +153,7 @@ private:
 public:
 
 	void show(void);
+	void showRawFrameBuffer(void);
 	void waitForDmaToFinish();
 
 	int busy(void);
@@ -174,6 +175,7 @@ private:
 	static void isr(void);
 
 	void genFrameBuffer(uint32_t);
+	void showInternal(bool regenerateFrameBuffer);
 
 	uint32_t update_begin_micros = 0;
 	uint8_t brightness = 255;

--- a/src/third_party/object_fled/src/OjectFLED.cpp.hpp
+++ b/src/third_party/object_fled/src/OjectFLED.cpp.hpp
@@ -481,6 +481,14 @@ void ObjectFLED::genFrameBuffer(uint32_t serp) {
 // 4 word32s for each bit in (led data)/pin = 16 * 8 = 96 bitdata bytes for each LED byte: 288 bytes / LED
 // launches DMA with IRQ activation to reload bitdata from frameBuffer
 void ObjectFLED::show(void) {
+	showInternal(true);
+}
+
+void ObjectFLED::showRawFrameBuffer(void) {
+	showInternal(false);
+}
+
+void ObjectFLED::showInternal(bool regenerateFrameBuffer) {
 	auto& dma = ObjectFLEDDmaManager::getInstance();
 
 	// Acquire DMA (blocks if another instance transmitting)
@@ -509,7 +517,9 @@ void ObjectFLED::show(void) {
 		dma.dma3.TCD->BITER_ELINKNO = dma.numbytes * 8;
 	} //done restoring context
 
-	genFrameBuffer(serpNumber);
+	if (regenerateFrameBuffer) {
+		genFrameBuffer(serpNumber);
+	}
 
 	// disable timers
 	uint16_t enable = TMR4_ENBL;
@@ -577,7 +587,7 @@ void ObjectFLED::show(void) {
 
 	// Release DMA (transmission continues asynchronously)
 	dma.release(this);
-}	// show()
+}	// showInternal()
 
 
 //INPUT: dma2, dma2next, bitdata, framebuffer_inedex, numpins, numbytes, pin_offset[], pin_bitnum[]


### PR DESCRIPTION
﻿## Summary

- Add `ObjectFLED::showRawFrameBuffer()` so callers that already populate `frameBufferLocal` can transmit without regenerating from `drawBuffer`.
- Keep existing `ObjectFLED::show()` behavior for direct ObjectFLED callers that still provide a draw buffer.
- Route both FastLED ObjectFLED paths through raw transmit:
  - channel driver wrapper
  - legacy ObjectFLED proxy flush
- Remove the old channel-path `drawBuffer = frameBufferLocal` self-copy workaround.

## Validation

- `git diff --check`
- `bash test --unit --no-fingerprint` -> 254/254 passed
- `bash autoresearch teensy41 --object-fled --tx-pin 22 --rx-pin 8 --timeout 120 --skip-lint` -> fbuild deploy succeeded on COM20, GPIO pretest passed for `TX 22 -> RX 8`, selected `OBJECT_FLED`, and still failed honestly as `class=zero_capture`.

## Notes

This resolves the S6 burn-down item for legacy null `drawBuffer` construction by adding a raw framebuffer transmit mode and using it from the legacy flush path. The current channel-path hardware failure remains zero capture, so this does not claim ObjectFLED acceptance yet.
