### PR TITLE
[codex] Fix ObjectFLED legacy multi-strip finalization

### DIFF
--- a/src/platforms/arm/teensy/teensy4_common/clockless_objectfled.cpp.hpp
+++ b/src/platforms/arm/teensy/teensy4_common/clockless_objectfled.cpp.hpp
@@ -90,7 +90,10 @@ ObjectFLEDGroupBase::~ObjectFLEDGroupBase() {
 }
 
 void ObjectFLEDGroupBase::onQueuingStart() {
-    mRectDrawBuffer.onQueuingStart();
+    const bool started = mRectDrawBuffer.onQueuingStart();
+    if (started) {
+        mPendingStrips.clear();
+    }
     mDrawn = false;
 }
 
@@ -128,11 +131,11 @@ void ObjectFLEDGroupBase::addStrip(u8 pin, PixelIterator& pixel_iterator) {
     const bool isRgbw = pixel_iterator.get_rgbw().active();
     mRectDrawBuffer.queue(DrawItem(pin, numLeds, isRgbw));
 
-    // Finalize buffer layout so we can write pixels
-    mRectDrawBuffer.onQueuingDone();
+    PendingStrip pending;
+    pending.pin = pin;
+    pending.bytes.resize(numLeds * (isRgbw ? 4 : 3));
 
-    // Write pixels into RectangularDrawBuffer
-    fl::span<u8> strip_bytes = mRectDrawBuffer.getLedsBufferBytesForPin(pin, true);
+    fl::span<u8> strip_bytes(pending.bytes.data(), pending.bytes.size());
     const Rgbw rgbw = pixel_iterator.get_rgbw();
 
     if (rgbw.active()) {
@@ -164,6 +167,8 @@ void ObjectFLEDGroupBase::addStrip(u8 pin, PixelIterator& pixel_iterator) {
             pixel_iterator.stepDithering();
         }
     }
+
+    mPendingStrips.push_back(pending);
 }
 
 void ObjectFLEDGroupBase::flush() {
@@ -172,6 +177,19 @@ void ObjectFLEDGroupBase::flush() {
     }
 
     mDrawn = true;
+
+    mRectDrawBuffer.onQueuingDone();
+    for (const auto& pending : mPendingStrips) {
+        fl::span<u8> strip_bytes =
+                mRectDrawBuffer.getLedsBufferBytesForPin(pending.pin, true);
+        const size_t copy_size = pending.bytes.size() < strip_bytes.size()
+                ? pending.bytes.size()
+                : strip_bytes.size();
+        if (copy_size > 0) {
+            fl::memcpy(strip_bytes.data(), pending.bytes.data(), copy_size);
+        }
+    }
+    mPendingStrips.clear();
 
     bool drawListChanged = mRectDrawBuffer.mDrawListChangedThisFrame;
     if (drawListChanged || !mObjectFLED) {

--- a/src/platforms/arm/teensy/teensy4_common/clockless_objectfled.h
+++ b/src/platforms/arm/teensy/teensy4_common/clockless_objectfled.h
@@ -116,6 +116,11 @@ private:
 
     ObjectFLEDTimingConfig mTiming;
     RectangularDrawBuffer mRectDrawBuffer;
+    struct PendingStrip {
+        u8 pin = 0;
+        fl::vector<u8> bytes;
+    };
+    fl::vector<PendingStrip> mPendingStrips;
     void* mObjectFLED;  // Opaque pointer to ObjectFLED
     bool mDrawn;
 };


### PR DESCRIPTION
﻿## Summary

- Defer legacy ObjectFLED `RectangularDrawBuffer::onQueuingDone()` until group flush instead of finalizing inside each `showPixels()` call.
- Copy each legacy strip's scaled bytes into owned pending storage while the stack `PixelController` is still valid.
- At flush time, finalize the rectangular layout once and copy pending strip bytes into their assigned pin segments.

## Validation

- `git diff --check`
- `bash test --unit --no-fingerprint` -> 254/254 passed
- `bash autoresearch teensy41 --object-fled --tx-pin 22 --rx-pin 8 --timeout 120 --skip-lint` -> fbuild deploy succeeded on COM20, GPIO pretest passed for `TX 22 -> RX 8`, selected `OBJECT_FLED`, and still failed honestly as `class=zero_capture` on the active channel path.

## Notes

This resolves the S6 burn-down item for same-timing multi-strip queue finalization in the legacy ObjectFLED proxy. The current soldered hardware pair is `TX 22 -> RX 8`; legacy AutoResearch pin dispatch remains limited to pins 0-8, so this PR is validated by code review, host unit suite, and Teensy firmware build/deploy through AutoResearch rather than a direct legacy loopback pass.
