### PR TITLE
[codex] Cover ObjectFLED legacy one-strip path

### DIFF
--- a/ci/autoresearch/args.py
+++ b/ci/autoresearch/args.py
@@ -571,7 +571,7 @@ See Also:
         parser.add_argument(
             "--legacy",
             action="store_true",
-            help="Test using legacy template addLeds API (WS2812B<PIN>) instead of Channel API. Single-lane only, pin must be 0-8.",
+            help="Test using legacy template addLeds API (WS2812B<PIN>) instead of Channel API. Single-lane only; supported TX pins are 0-8 and 22.",
         )
 
         # Chipset selection

--- a/ci/autoresearch/phases.py
+++ b/ci/autoresearch/phases.py
@@ -568,13 +568,13 @@ def _parse_args_and_build_commands(args: Args) -> RunContext | int:
     if args.legacy:
         if max_lanes is not None and max_lanes > 1:
             print(
-                "\u274c Error: --legacy only supports single-lane (pin 0-8). Remove --lanes or use --lanes 1"
+                "\u274c Error: --legacy only supports single-lane. Remove --lanes or use --lanes 1"
             )
             return 1
         min_lanes = 1
         max_lanes = 1
         print(
-            "\u2139\ufe0f  Legacy API mode: using WS2812B<PIN> template path (single-lane, pin 0-8)"
+            "\u2139\ufe0f  Legacy API mode: using WS2812B<PIN> template path (single-lane, supported TX pins 0-8 and 22)"
         )
 
     if min_lanes is not None and max_lanes is not None:

--- a/ci/lint_cpp_rs/src/lint_core/regexes.rs
+++ b/ci/lint_cpp_rs/src/lint_core/regexes.rs
@@ -465,7 +465,7 @@ fn regex_autoresearch_forbidden_runtime_output() -> &'static Regex {
     static VALUE: OnceLock<Regex> = OnceLock::new();
     VALUE.get_or_init(|| {
         Regex::new(
-            r"\b(?:FL_(?:PRINT|WARN|ERROR)(?:_[A-Z0-9]+)*|Serial\.(?:print\w*|write|flush)|fl::(?:print|println|printf|write|flush|serial_(?:print\w*|println|printf|write|flush)|serial(?:Print\w*|Write|Flush)))\s*\(",
+            r"\b(?:FL_(?:PRINT|WARN|ERROR)(?:_[A-Z0-9]+)*|Serial\.(?:print\w*|write|flush)|fl::(?:Serial\.(?:print\w*|write|flush)|print|println|printf|write|flush|serial_(?:print\w*|println|printf|write|flush)|serial(?:Print\w*|Write|Flush)))\s*\(",
         )
         .unwrap()
     })

--- a/ci/lint_cpp_rs/src/lint_core/tests.rs
+++ b/ci/lint_cpp_rs/src/lint_core/tests.rs
@@ -55,9 +55,9 @@ mod tests {
         let checker = AutoResearchRuntimeOutputChecker;
         let result = checker.check_file_content(&file(
             "examples/AutoResearch/AutoResearch.ino",
-            "FL_WARN(\"boot chatter\");\nFL_WARN_F_ONCE(\"boot chatter\");\nFL_WARN_LIT(\"boot chatter\");\nFL_PRINT_EVERY(1000, \"tick\");\nFL_PRINT_F(\"tick\");\nFL_ERROR(\"boot failure\");\nSerial.println(\"not rpc\");\nSerial.printf(\"not rpc\");\nSerial.printHex(\"not rpc\");\nfl::println(\"nope\");\nfl::serial_print(\"nope\");\nfl::serial_println(\"nope\");\nfl::serial_printf(\"nope\");\nfl::serialPrintln(\"nope\");\n",
+            "FL_WARN(\"boot chatter\");\nFL_WARN_F_ONCE(\"boot chatter\");\nFL_WARN_LIT(\"boot chatter\");\nFL_PRINT_EVERY(1000, \"tick\");\nFL_PRINT_F(\"tick\");\nFL_ERROR(\"boot failure\");\nSerial.println(\"not rpc\");\nSerial.printf(\"not rpc\");\nSerial.printHex(\"not rpc\");\nfl::println(\"nope\");\nfl::Serial.println(\"nope\");\nfl::serial_print(\"nope\");\nfl::serial_println(\"nope\");\nfl::serial_printf(\"nope\");\nfl::serialPrintln(\"nope\");\n",
         ));
-        assert_eq!(result.len(), 14);
+        assert_eq!(result.len(), 15);
     }
 
     #[test]

--- a/ci/tests/test_autoresearch_phases.py
+++ b/ci/tests/test_autoresearch_phases.py
@@ -259,6 +259,35 @@ class TestParseArgsAndBuildCommands:
         assert result.json_rpc_commands[0]["method"] == "runSingleTest"
         assert result.json_rpc_commands[0]["params"]["contaminateTxMux"] is True
 
+    def test_object_fled_legacy_one_strip_command(self, fake_project_dir: Path) -> None:
+        args = _make_args(
+            object_fled=True,
+            parlio=False,
+            legacy=True,
+            strip_sizes="1",
+            tx_pin=22,
+            rx_pin=8,
+            environment_positional="teensy41",
+            project_dir=fake_project_dir,
+            use_root_platformio_ini=False,
+        )
+        with patch(
+            "ci.autoresearch.staging.synthesise_autoresearch_project",
+            return_value=fake_project_dir,
+        ):
+            result = _parse_args_and_build_commands(args)
+        assert isinstance(result, RunContext)
+        assert result.drivers == ["OBJECT_FLED"]
+
+        run_commands = [
+            cmd for cmd in result.json_rpc_commands if cmd["method"] == "runSingleTest"
+        ]
+        assert len(run_commands) == 1
+        params = run_commands[0]["params"]
+        assert params["driver"] == "OBJECT_FLED"
+        assert params["laneSizes"] == [1]
+        assert params["useLegacyApi"] is True
+
     def test_spi_driver_name_remains_spi_on_esp32(self, fake_project_dir: Path) -> None:
         args = _make_args(parlio=False, spi=True, project_dir=fake_project_dir)
         result = _parse_args_and_build_commands(args)

--- a/examples/AutoResearch/AutoResearchRemoteRunSingleTest.cpp
+++ b/examples/AutoResearch/AutoResearchRemoteRunSingleTest.cpp
@@ -467,15 +467,20 @@ fl::json AutoResearchRemoteControl::runSingleTestImpl(const fl::json& args) {
         tight_timing_max_overhead_us = static_cast<uint32_t>(max_overhead);
     }
 
-    // Legacy API: all pins must be in range 0-8 (compile-time template range)
-    // Multi-lane uses consecutive pins starting at pin_tx
+    // Legacy API: pins 0-8 are the historical compile-time template range.
+    // Pin 22 is included for the current Teensy ObjectFLED loopback wiring.
+    // Multi-lane uses consecutive pins starting at pin_tx.
     if (use_legacy_api) {
         int max_pin = pin_tx + (int)lane_sizes.size() - 1;
-        if (pin_tx < 0 || max_pin > 8) {
+        const bool historical_pin_range = pin_tx >= 0 && max_pin <= 8;
+        const bool current_loopback_pin =
+                lane_sizes.size() == 1 && pin_tx == 22;
+        if (!historical_pin_range && !current_loopback_pin) {
             response.set("success", false);
             response.set("error", "LegacyApiPinRange");
             fl::sstream msg;
-            msg << "Legacy template API requires all pins in range 0-8, got pins "
+            msg << "Legacy template API supports pins 0-8, plus single-lane "
+                << "pin 22 for current ObjectFLED loopback, got pins "
                 << pin_tx << "-" << max_pin;
             response.set("message", msg.str().c_str());
             return response;

--- a/examples/AutoResearch/AutoResearchTest.cpp
+++ b/examples/AutoResearch/AutoResearchTest.cpp
@@ -1222,7 +1222,8 @@ void autoResearchChipsetTimingLegacy(fl::AutoResearchConfig& config,
 
         auto proxy = fl::make_unique<LegacyClocklessProxy>(pin, leds, numLeds);
         if (!proxy->valid()) {
-            FL_ERROR("Legacy proxy invalid for lane " << i << " (pin " << pin << " out of range 0-8)");
+            FL_ERROR("Legacy proxy invalid for lane " << i << " (pin " << pin
+                     << " not in supported set 0-8 or 22)");
             return;  // vector destructor cleans up already-created proxies
         }
         proxies.push_back(fl::move(proxy));

--- a/examples/AutoResearch/LegacyClocklessProxy.h
+++ b/examples/AutoResearch/LegacyClocklessProxy.h
@@ -1,7 +1,7 @@
 // LegacyClocklessProxy.h - Runtime-to-template pin dispatch for legacy addLeds API
 //
-// Maps a runtime pin number (0-8) to compile-time WS2812B<PIN, RGB> template
-// instantiations via a switch statement. This allows autoresearch testing of the
+// Maps a runtime pin number to compile-time WS2812B<PIN, RGB> template
+// instantiations via a switch statement. This allows AutoResearch testing of the
 // legacy template API path: WS2812B<PIN> -> WS2812Controller800Khz ->
 // ClocklessControllerImpl -> ClocklessIdf5 -> Channel
 
@@ -15,9 +15,10 @@
 /// The legacy FastLED API requires compile-time template pin parameters:
 ///   FastLED.addLeds<WS2812B, PIN>(leds, numLeds)
 ///
-/// This proxy uses a switch statement to dispatch runtime pin values (0-8) to
-/// the corresponding template instantiation, enabling autoresearch testing of the
-/// full legacy code path.
+/// This proxy uses a switch statement to dispatch supported AutoResearch legacy
+/// pin values to the corresponding template instantiation, enabling testing of
+/// the full legacy code path. Pins 0-8 are historical coverage pins; pin 22 is
+/// the current Teensy ObjectFLED loopback TX pin.
 ///
 /// Destructor deletes the controller, which on ESP32 (SKETCH_HAS_LARGE_MEMORY)
 /// automatically calls removeFromDrawList() via ~CLEDController().
@@ -43,6 +44,7 @@ public:
             case 6: mController = create<6>(leds, numLeds); break;
             case 7: mController = create<7>(leds, numLeds); break;
             case 8: mController = create<8>(leds, numLeds); break;
+            case 22: mController = create<22>(leds, numLeds); break;
             default: break;  // mController stays nullptr
         }
     }


### PR DESCRIPTION
## Summary

- Add AutoResearch legacy ObjectFLED dispatch for the current soldered Teensy loopback TX pin 22 in the single-strip case.
- Add host command coverage proving `--object-fled --legacy --tx-pin 22 --rx-pin 8 --strip-sizes 1` builds a one-strip `runSingleTest` request with `useLegacyApi=true`.
- Tighten the AutoResearch runtime-output lint to also ban `fl::Serial.print*`/`write`/`flush` direct output.

## Validation

- `uv run --no-sync ruff format --check ci/autoresearch/args.py ci/autoresearch/phases.py ci/tests/test_autoresearch_phases.py`
- `uv run --no-sync ruff check ci/autoresearch/args.py ci/autoresearch/phases.py ci/tests/test_autoresearch_phases.py`
- `uv run --no-sync pytest ci/tests/test_autoresearch_phases.py -q` -> 72 passed
- `soldr cargo fmt --manifest-path ci/lint_cpp_rs/Cargo.toml -- --check`
- `soldr cargo check --manifest-path ci/lint_cpp_rs/Cargo.toml --target x86_64-unknown-linux-gnu --tests`
- `git diff --check`
- `bash test --unit --no-fingerprint` -> 254/254 passed

## Hardware

- `bash autoresearch teensy41 --object-fled --legacy --tx-pin 22 --rx-pin 8 --strip-sizes 1 --timeout 120 --skip-lint`
- fbuild deploy succeeded on `teensy41 @ COM20`.
- Serial backend was `FbuildSerialAdapter`; no manual serial utility was used.
- GPIO pre-test passed for `TX 22 -> RX 8`.
- Leading `setPins` echoed `txPin=22`, `rxPin=8`.
- `runSingleTest` used `driver=OBJECT_FLED`, `laneSizes=[1]`, `useLegacyApi=true`.
- The run failed honestly as the current known `class=zero_capture`, with diagnostics showing DMA drained for `numbytes=3`, `numpins=1`, `framebufferIndex=3`.