### PR TITLE
[codex] Cover ObjectFLED legacy same-timing strips

### DIFF
--- a/ci/autoresearch/args.py
+++ b/ci/autoresearch/args.py
@@ -571,7 +571,7 @@ See Also:
         parser.add_argument(
             "--legacy",
             action="store_true",
-            help="Test using legacy template addLeds API (WS2812B<PIN>) instead of Channel API. Single-lane only; supported TX pins are 0-8 and 22.",
+            help="Test using legacy template addLeds API (WS2812B<PIN>) instead of Channel API. Supports consecutive TX pins 0-8; pin 22 is single-lane for the current ObjectFLED loopback.",
         )
 
         # Chipset selection

--- a/ci/autoresearch/phases.py
+++ b/ci/autoresearch/phases.py
@@ -566,15 +566,24 @@ def _parse_args_and_build_commands(args: Args) -> RunContext | int:
                 return 1
 
     if args.legacy:
-        if max_lanes is not None and max_lanes > 1:
-            print(
-                "\u274c Error: --legacy only supports single-lane. Remove --lanes or use --lanes 1"
-            )
-            return 1
-        min_lanes = 1
-        max_lanes = 1
+        requested_min_lanes = min_lanes if min_lanes is not None else 1
+        requested_max_lanes = max_lanes if max_lanes is not None else 1
+        if requested_max_lanes > 1:
+            if args.tx_pin is None:
+                print(
+                    "\u274c Error: --legacy multi-lane requires explicit --tx-pin in the historical 0-8 template range"
+                )
+                return 1
+            max_pin = args.tx_pin + requested_max_lanes - 1
+            if args.tx_pin < 0 or max_pin > 8:
+                print(
+                    "\u274c Error: --legacy multi-lane supports consecutive TX pins 0-8 only; pin 22 is single-lane for the current ObjectFLED loopback"
+                )
+                return 1
+        min_lanes = requested_min_lanes
+        max_lanes = requested_max_lanes
         print(
-            "\u2139\ufe0f  Legacy API mode: using WS2812B<PIN> template path (single-lane, supported TX pins 0-8 and 22)"
+            "\u2139\ufe0f  Legacy API mode: using WS2812B<PIN> template path (supported TX pins 0-8; pin 22 single-lane current loopback)"
         )
 
     if min_lanes is not None and max_lanes is not None:

--- a/ci/tests/test_autoresearch_phases.py
+++ b/ci/tests/test_autoresearch_phases.py
@@ -288,6 +288,56 @@ class TestParseArgsAndBuildCommands:
         assert params["laneSizes"] == [1]
         assert params["useLegacyApi"] is True
 
+    def test_object_fled_legacy_same_timing_multistrip_command(
+        self, fake_project_dir: Path
+    ) -> None:
+        args = _make_args(
+            object_fled=True,
+            parlio=False,
+            legacy=True,
+            lanes="2",
+            strip_sizes="3",
+            tx_pin=0,
+            rx_pin=8,
+            environment_positional="teensy41",
+            project_dir=fake_project_dir,
+            use_root_platformio_ini=False,
+        )
+        with patch(
+            "ci.autoresearch.staging.synthesise_autoresearch_project",
+            return_value=fake_project_dir,
+        ):
+            result = _parse_args_and_build_commands(args)
+        assert isinstance(result, RunContext)
+        assert result.drivers == ["OBJECT_FLED"]
+
+        run_commands = [
+            cmd for cmd in result.json_rpc_commands if cmd["method"] == "runSingleTest"
+        ]
+        assert len(run_commands) == 1
+        params = run_commands[0]["params"]
+        assert params["driver"] == "OBJECT_FLED"
+        assert params["laneSizes"] == [3, 3]
+        assert params["useLegacyApi"] is True
+
+    def test_object_fled_legacy_current_pin_rejects_multistrip(
+        self, fake_project_dir: Path
+    ) -> None:
+        args = _make_args(
+            object_fled=True,
+            parlio=False,
+            legacy=True,
+            lanes="2",
+            strip_sizes="3",
+            tx_pin=22,
+            rx_pin=8,
+            environment_positional="teensy41",
+            project_dir=fake_project_dir,
+            use_root_platformio_ini=False,
+        )
+        result = _parse_args_and_build_commands(args)
+        assert result == 1
+
     def test_spi_driver_name_remains_spi_on_esp32(self, fake_project_dir: Path) -> None:
         args = _make_args(parlio=False, spi=True, project_dir=fake_project_dir)
         result = _parse_args_and_build_commands(args)


### PR DESCRIPTION
## Summary

- Allow AutoResearch legacy multi-lane runs when the requested consecutive TX pins stay inside the historical `0-8` template dispatch range.
- Keep the current soldered loopback pin 22 explicitly single-lane-only.
- Add host regression coverage for a same-timing two-strip legacy ObjectFLED request: `laneSizes=[3, 3]`, `useLegacyApi=true`.
- Add guard coverage rejecting `--legacy --lanes 2 --tx-pin 22`, because `TX 22 -> RX 8` is the current one-wire loopback and cannot represent multiple TX pins.

## Validation

- `uv run --no-sync ruff format ci/autoresearch/args.py ci/autoresearch/phases.py ci/tests/test_autoresearch_phases.py`
- `uv run --no-sync ruff check ci/autoresearch/args.py ci/autoresearch/phases.py ci/tests/test_autoresearch_phases.py`
- `uv run --no-sync pytest ci/tests/test_autoresearch_phases.py -q` -> 74 passed
- `git diff --check`

## Hardware

No multi-pin hardware acceptance run was performed for this PR. The current board is soldered as `TX 22 -> RX 8`, and pin 22 is intentionally allowed only for the single-lane current-loopback case. The same-timing multi-strip regression added here targets the historical legacy pin set `0-8`, where consecutive template pins can represent multiple strips.