### PR TITLE
[codex] tighten AutoResearch runtime output lint

### DIFF
--- a/ci/lint_cpp_rs/src/lint_core/regexes.rs
+++ b/ci/lint_cpp_rs/src/lint_core/regexes.rs
@@ -465,7 +465,7 @@ fn regex_autoresearch_forbidden_runtime_output() -> &'static Regex {
     static VALUE: OnceLock<Regex> = OnceLock::new();
     VALUE.get_or_init(|| {
         Regex::new(
-            r"\b(?:FL_(?:PRINT|WARN|ERROR)(?:_[A-Z0-9]+)*|Serial\.(?:print\w*|write|flush)|fl::(?:Serial\.(?:print\w*|write|flush)|print|println|printf|write|flush|serial_(?:print\w*|println|printf|write|flush)|serial(?:Print\w*|Write|Flush)))\s*\(",
+            r"\b(?:FL_(?:PRINT|WARN|ERROR)[A-Z0-9_]*|Serial\.(?:print\w*|write|flush)|fl::(?:Serial\.(?:print\w*|write|flush)|print|println|printf|write(?:_bytes)?|flush|serial_(?:print\w*|write\w*|flush\w*)|serial(?:Print\w*|Write\w*|Flush\w*)))\s*\(",
         )
         .unwrap()
     })

--- a/ci/lint_cpp_rs/src/lint_core/tests.rs
+++ b/ci/lint_cpp_rs/src/lint_core/tests.rs
@@ -55,9 +55,9 @@ mod tests {
         let checker = AutoResearchRuntimeOutputChecker;
         let result = checker.check_file_content(&file(
             "examples/AutoResearch/AutoResearch.ino",
-            "FL_WARN(\"boot chatter\");\nFL_WARN_F_ONCE(\"boot chatter\");\nFL_WARN_LIT(\"boot chatter\");\nFL_PRINT_EVERY(1000, \"tick\");\nFL_PRINT_F(\"tick\");\nFL_ERROR(\"boot failure\");\nSerial.println(\"not rpc\");\nSerial.printf(\"not rpc\");\nSerial.printHex(\"not rpc\");\nfl::println(\"nope\");\nfl::Serial.println(\"nope\");\nfl::serial_print(\"nope\");\nfl::serial_println(\"nope\");\nfl::serial_printf(\"nope\");\nfl::serialPrintln(\"nope\");\n",
+            "FL_WARN(\"boot chatter\");\nFL_WARN_F_ONCE(\"boot chatter\");\nFL_WARN_LIT(\"boot chatter\");\nFL_PRINT_EVERY(1000, \"tick\");\nFL_PRINT_F(\"tick\");\nFL_PRINTLN(\"tick\");\nFL_ERROR(\"boot failure\");\nSerial.println(\"not rpc\");\nSerial.printf(\"not rpc\");\nSerial.printHex(\"not rpc\");\nfl::println(\"nope\");\nfl::write_bytes(bytes, len);\nfl::Serial.println(\"nope\");\nfl::Serial.printHex(\"nope\");\nfl::serial_print(\"nope\");\nfl::serial_println(\"nope\");\nfl::serial_printf(\"nope\");\nfl::serial_write(bytes, len);\nfl::serialPrintln(\"nope\");\nfl::serialWrite(bytes, len);\n",
         ));
-        assert_eq!(result.len(), 15);
+        assert_eq!(result.len(), 20);
     }
 
     #[test]

--- a/examples/AutoResearch/AutoResearch.ino
+++ b/examples/AutoResearch/AutoResearch.ino
@@ -105,8 +105,9 @@ void loop()  { autoResearchLowMemoryLoop(); }
 // 🚫 DO NOT "CHEAT" THE TEST:
 //    - DO NOT change "ERROR" to "FAIL", "WARNING", "FAILURE", or any other
 //      keyword to avoid test detection
-//    - DO NOT add FL_ERROR, FL_PRINT, FL_WARN, Serial.print*, or fl::print*
-//      runtime output in this sketch
+//    - DO NOT add FL_ERROR, FL_PRINT, FL_WARN, Serial.print*, fl::Serial.print*,
+//      fl::print*, fl::write_bytes, or fl::serial_print* runtime output in this
+//      sketch or lint-marked runtime sections. Use JSON-RPC / RESULT JSONL.
 //    - The "ERROR" keyword is INTENTIONAL and part of the autoresearch contract
 //
 // ✅ VALID MODIFICATIONS (only if explicitly requested):


### PR DESCRIPTION
## Summary

Tightens the scoped AutoResearch runtime-output lint so it catches the output paths that can interfere with hardware test runs.

Changes:
- ban attached `FL_PRINT*` / `FL_WARN*` / `FL_ERROR*` macro suffixes as well as underscore variants
- ban `fl::write_bytes`, `fl::Serial.print*`, and output-shaped `fl::serial*` helper calls in guarded AutoResearch runtime paths
- expand the lint fixture to cover the banned spelling families
- update the AutoResearch agent directive to require JSON-RPC / RESULT JSONL for runtime output

## Validation

```bash
soldr cargo fmt --manifest-path ci/lint_cpp_rs/Cargo.toml -- --check
soldr cargo check --manifest-path ci/lint_cpp_rs/Cargo.toml --target x86_64-unknown-linux-gnu --tests
git diff --check
```

`cargo check` passed with existing unrelated warnings in `test_structure.rs` and `unity_build.rs`.

Focused `cargo test` could not link in this local environment: Linux target lacks `cc`, and default Windows target lacks `x86_64-pc-windows-msvc` std.