### PR TITLE
[codex] add legacy ObjectFLED mixed timing coverage

### DIFF
--- a/ci/autoresearch/args.py
+++ b/ci/autoresearch/args.py
@@ -73,6 +73,7 @@ class Args:
 
     # Legacy API testing
     legacy: bool
+    legacy_mixed_timings: bool
 
     # Chipset selection
     chipset: str
@@ -573,6 +574,15 @@ See Also:
             action="store_true",
             help="Test using legacy template addLeds API (WS2812B<PIN>) instead of Channel API. Supports consecutive TX pins 0-8; pin 22 is single-lane for the current ObjectFLED loopback.",
         )
+        parser.add_argument(
+            "--legacy-mixed-timings",
+            action="store_true",
+            help=(
+                "With --legacy, alternate WS2812B/SK6812 template chipsets "
+                "across lanes to exercise multiple ObjectFLED timing groups. "
+                "Requires multi-lane historical TX pins 0-8."
+            ),
+        )
 
         # Chipset selection
         parser.add_argument(
@@ -694,6 +704,7 @@ See Also:
             lane_counts=parsed.lane_counts,
             color_pattern=parsed.color_pattern,
             legacy=parsed.legacy,
+            legacy_mixed_timings=parsed.legacy_mixed_timings,
             chipset=parsed.chipset,
             net_server=parsed.net_server,
             net_client=parsed.net_client,

--- a/ci/autoresearch/phases.py
+++ b/ci/autoresearch/phases.py
@@ -568,6 +568,11 @@ def _parse_args_and_build_commands(args: Args) -> RunContext | int:
     if args.legacy:
         requested_min_lanes = min_lanes if min_lanes is not None else 1
         requested_max_lanes = max_lanes if max_lanes is not None else 1
+        if args.legacy_mixed_timings and requested_max_lanes < 2:
+            print(
+                "\u274c Error: --legacy-mixed-timings requires --legacy with at least 2 lanes"
+            )
+            return 1
         if requested_max_lanes > 1:
             if args.tx_pin is None:
                 print(
@@ -585,6 +590,13 @@ def _parse_args_and_build_commands(args: Args) -> RunContext | int:
         print(
             "\u2139\ufe0f  Legacy API mode: using WS2812B<PIN> template path (supported TX pins 0-8; pin 22 single-lane current loopback)"
         )
+        if args.legacy_mixed_timings:
+            print(
+                "\u2139\ufe0f  Legacy mixed timing mode: alternating WS2812B/SK6812 template chipsets across lanes"
+            )
+    elif args.legacy_mixed_timings:
+        print("\u274c Error: --legacy-mixed-timings requires --legacy")
+        return 1
 
     if min_lanes is not None and max_lanes is not None:
         if min_lanes < 1 or max_lanes < 1 or min_lanes > max_lanes:
@@ -765,6 +777,11 @@ def _parse_args_and_build_commands(args: Args) -> RunContext | int:
                     }
                     if args.legacy:
                         test_config["useLegacyApi"] = True
+                        if args.legacy_mixed_timings:
+                            test_config["legacyChipsets"] = [
+                                "WS2812B" if i % 2 == 0 else "SK6812"
+                                for i in range(lane_count)
+                            ]
                     # Multi-frame capture: back-to-back show()/capture cycles per pattern.
                     # Defaults: SPI -> 2 (catches #2254/#2288 second-frame degradation),
                     # others -> 1. User can override with --frames N.

--- a/ci/tests/test_autoresearch_phases.py
+++ b/ci/tests/test_autoresearch_phases.py
@@ -82,6 +82,7 @@ def _make_args(**overrides) -> Args:
         lane_counts=None,
         color_pattern=None,
         legacy=False,
+        legacy_mixed_timings=False,
         chipset="ws2812",
         net_server=False,
         net_client=False,
@@ -319,6 +320,77 @@ class TestParseArgsAndBuildCommands:
         assert params["driver"] == "OBJECT_FLED"
         assert params["laneSizes"] == [3, 3]
         assert params["useLegacyApi"] is True
+        assert "legacyChipsets" not in params
+
+    def test_object_fled_legacy_mixed_timing_multistrip_command(
+        self, fake_project_dir: Path
+    ) -> None:
+        args = _make_args(
+            object_fled=True,
+            parlio=False,
+            legacy=True,
+            legacy_mixed_timings=True,
+            lanes="2",
+            strip_sizes="3",
+            tx_pin=0,
+            rx_pin=8,
+            environment_positional="teensy41",
+            project_dir=fake_project_dir,
+            use_root_platformio_ini=False,
+        )
+        with patch(
+            "ci.autoresearch.staging.synthesise_autoresearch_project",
+            return_value=fake_project_dir,
+        ):
+            result = _parse_args_and_build_commands(args)
+        assert isinstance(result, RunContext)
+        assert result.drivers == ["OBJECT_FLED"]
+
+        run_commands = [
+            cmd for cmd in result.json_rpc_commands if cmd["method"] == "runSingleTest"
+        ]
+        assert len(run_commands) == 1
+        params = run_commands[0]["params"]
+        assert params["driver"] == "OBJECT_FLED"
+        assert params["laneSizes"] == [3, 3]
+        assert params["useLegacyApi"] is True
+        assert params["legacyChipsets"] == ["WS2812B", "SK6812"]
+
+    def test_legacy_mixed_timings_requires_legacy(self, fake_project_dir: Path) -> None:
+        args = _make_args(
+            object_fled=True,
+            parlio=False,
+            legacy=False,
+            legacy_mixed_timings=True,
+            lanes="2",
+            strip_sizes="3",
+            tx_pin=0,
+            rx_pin=8,
+            environment_positional="teensy41",
+            project_dir=fake_project_dir,
+            use_root_platformio_ini=False,
+        )
+        result = _parse_args_and_build_commands(args)
+        assert result == 1
+
+    def test_legacy_mixed_timings_requires_multiple_lanes(
+        self, fake_project_dir: Path
+    ) -> None:
+        args = _make_args(
+            object_fled=True,
+            parlio=False,
+            legacy=True,
+            legacy_mixed_timings=True,
+            lanes="1",
+            strip_sizes="3",
+            tx_pin=0,
+            rx_pin=8,
+            environment_positional="teensy41",
+            project_dir=fake_project_dir,
+            use_root_platformio_ini=False,
+        )
+        result = _parse_args_and_build_commands(args)
+        assert result == 1
 
     def test_object_fled_legacy_current_pin_rejects_multistrip(
         self, fake_project_dir: Path

--- a/examples/AutoResearch/AutoResearchRemoteRunSingleTest.cpp
+++ b/examples/AutoResearch/AutoResearchRemoteRunSingleTest.cpp
@@ -427,6 +427,52 @@ fl::json AutoResearchRemoteControl::runSingleTestImpl(const fl::json& args) {
         use_legacy_api = config["useLegacyApi"].as_bool().value();
     }
 
+    fl::vector<LegacyClocklessChipset> legacy_chipsets;
+    if (config.contains("legacyChipsets") && !use_legacy_api) {
+        response.set("success", false);
+        response.set("error", "LegacyChipsetsRequireLegacyApi");
+        response.set("message", "legacyChipsets requires useLegacyApi=true");
+        return response;
+    }
+    if (use_legacy_api) {
+        for (fl::size i = 0; i < lane_sizes.size(); i++) {
+            legacy_chipsets.push_back(LegacyClocklessChipset::WS2812B);
+        }
+        if (config.contains("legacyChipsets")) {
+            if (!config["legacyChipsets"].is_array()) {
+                response.set("success", false);
+                response.set("error", "InvalidLegacyChipsets");
+                response.set("message", "legacyChipsets must be an array");
+                return response;
+            }
+            fl::json legacy_chipsets_json = config["legacyChipsets"];
+            if (legacy_chipsets_json.size() != lane_sizes.size()) {
+                response.set("success", false);
+                response.set("error", "InvalidLegacyChipsetCount");
+                response.set("message", "legacyChipsets length must match laneSizes");
+                return response;
+            }
+            for (fl::size i = 0; i < legacy_chipsets_json.size(); i++) {
+                if (!legacy_chipsets_json[i].is_string()) {
+                    response.set("success", false);
+                    response.set("error", "InvalidLegacyChipsetType");
+                    response.set("message", "legacyChipsets entries must be strings");
+                    return response;
+                }
+                fl::string chipset_name =
+                    legacy_chipsets_json[i].as_string().value();
+                LegacyClocklessChipset chipset;
+                if (!legacyClocklessChipsetFromName(chipset_name, &chipset)) {
+                    response.set("success", false);
+                    response.set("error", "UnsupportedLegacyChipset");
+                    response.set("message", "supported legacyChipsets: WS2812B, SK6812");
+                    return response;
+                }
+                legacy_chipsets[i] = chipset;
+            }
+        }
+    }
+
     // 9. Extract contaminateTxMux (optional, default: false)
     bool contaminate_tx_mux = false;
     if (config.contains("contaminateTxMux") &&
@@ -517,15 +563,26 @@ fl::json AutoResearchRemoteControl::runSingleTestImpl(const fl::json& args) {
     }
 
     // Get timing configuration
-    // Legacy API: WS2812B<PIN> template uses TIMING_WS2812_800KHZ (T1=250, T2=625, T3=375)
+    // Legacy API: default WS2812B<PIN> template uses TIMING_WS2812_800KHZ.
+    // If mixed legacy chipsets are requested, lane 0 timing is used for RX
+    // decode because AutoResearch captures only lane 0.
     // Channel API: Uses timing_name from RPC (default: WS2812B-V5)
     // RX decode timing MUST match actual TX timing for correct capture
     fl::ChipsetTimingConfig resolved_timing;
     fl::ClocklessEncoder resolved_encoder = fl::ClocklessEncoder::CLOCKLESS_ENCODER_WS2812;
     if (use_legacy_api) {
-        resolved_timing = fl::makeTimingConfig<fl::TIMING_WS2812_800KHZ>();
-        resolved_encoder = fl::encoder_for<fl::TIMING_WS2812_800KHZ>();
-        timing_name = "WS2812-800KHZ";
+        LegacyClocklessChipset first_chipset = LegacyClocklessChipset::WS2812B;
+        if (!legacy_chipsets.empty()) {
+            first_chipset = legacy_chipsets[0];
+        }
+        if (first_chipset == LegacyClocklessChipset::SK6812) {
+            resolved_timing = fl::makeTimingConfig<fl::TIMING_SK6812>();
+            resolved_encoder = fl::encoder_for<fl::TIMING_SK6812>();
+        } else {
+            resolved_timing = fl::makeTimingConfig<fl::TIMING_WS2812_800KHZ>();
+            resolved_encoder = fl::encoder_for<fl::TIMING_WS2812_800KHZ>();
+        }
+        timing_name = legacyClocklessChipsetName(first_chipset);
     } else if (timing_name == "UCS7604-800KHZ") {
         resolved_timing = fl::makeTimingConfig<fl::TIMING_UCS7604_800KHZ>();
         resolved_encoder = fl::encoder_for<fl::TIMING_UCS7604_800KHZ>();
@@ -598,7 +655,8 @@ fl::json AutoResearchRemoteControl::runSingleTestImpl(const fl::json& args) {
         mState->rx_buffer,
         lane_sizes[0],  // base_strip_size (used for logging)
         fl::RxDeviceType::RMT,  // Default RX device type
-        timing_config.encoder
+        timing_config.encoder,
+        fl::span<const LegacyClocklessChipset>(legacy_chipsets)
     );
 
     // Run test with debug output suppressed
@@ -714,6 +772,14 @@ fl::json AutoResearchRemoteControl::runSingleTestImpl(const fl::json& args) {
     response.set("laneSizes", sizes_response);
     response.set("pattern", pattern.c_str());
     response.set("useLegacyApi", use_legacy_api);
+    if (use_legacy_api) {
+        fl::json legacy_chipsets_response = fl::json::array();
+        for (LegacyClocklessChipset chipset : legacy_chipsets) {
+            legacy_chipsets_response.push_back(
+                legacyClocklessChipsetName(chipset));
+        }
+        response.set("legacyChipsets", legacy_chipsets_response);
+    }
     response.set("frameCount", static_cast<int64_t>(frame_count));
     response.set("contaminateTxMux", contaminate_tx_mux);
     if (contaminate_tx_mux) {

--- a/examples/AutoResearch/AutoResearchTest.cpp
+++ b/examples/AutoResearch/AutoResearchTest.cpp
@@ -1213,17 +1213,26 @@ void autoResearchChipsetTimingLegacy(fl::AutoResearchConfig& config,
     ss << "========================================";
     FL_WARN(ss.str());
 
-    // Create one legacy proxy per lane (each maps runtime pin to WS2812B<PIN> template)
+    // Create one legacy proxy per lane. By default every lane uses WS2812B,
+    // but AutoResearch can supply per-lane chipsets to exercise multiple
+    // ObjectFLED timing groups in a single FastLED.show().
     fl::vector<fl::unique_ptr<LegacyClocklessProxy>> proxies;
     for (size_t i = 0; i < config.tx_configs.size(); i++) {
         int pin = config.tx_configs[i].getDataPin();
         CRGB* leds = config.tx_configs[i].mLeds.data();
         int numLeds = static_cast<int>(config.tx_configs[i].mLeds.size());
+        LegacyClocklessChipset chipset = LegacyClocklessChipset::WS2812B;
+        if (!config.legacy_chipsets.empty() &&
+            i < config.legacy_chipsets.size()) {
+            chipset = config.legacy_chipsets[i];
+        }
 
-        auto proxy = fl::make_unique<LegacyClocklessProxy>(pin, leds, numLeds);
+        auto proxy =
+            fl::make_unique<LegacyClocklessProxy>(pin, leds, numLeds, chipset);
         if (!proxy->valid()) {
             FL_ERROR("Legacy proxy invalid for lane " << i << " (pin " << pin
-                     << " not in supported set 0-8 or 22)");
+                     << ", chipset " << legacyClocklessChipsetName(chipset)
+                     << " not in supported set)");
             return;  // vector destructor cleans up already-created proxies
         }
         proxies.push_back(fl::move(proxy));

--- a/examples/AutoResearch/AutoResearchTest.h
+++ b/examples/AutoResearch/AutoResearchTest.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <FastLED.h>
+#include "LegacyClocklessProxy.h"
 #include "fl/channels/validation.h"
 
 namespace fl {
@@ -20,6 +21,7 @@ struct AutoResearchConfig {
     fl::span<uint8_t> rx_buffer;                 ///< Buffer to store received bytes
     int base_strip_size;                         ///< Base strip size (10 or 300 LEDs)
     fl::RxDeviceType rx_type;                    ///< RX device type (RMT or ISR)
+    fl::span<const LegacyClocklessChipset> legacy_chipsets;  ///< Optional per-lane legacy templates
 
     AutoResearchConfig(const fl::ChipsetTimingConfig& t,
                      const char* tn,
@@ -29,7 +31,8 @@ struct AutoResearchConfig {
                      fl::span<uint8_t> rb,
                      int bss,
                      fl::RxDeviceType rt,
-                     fl::ClocklessEncoder enc = fl::ClocklessEncoder::CLOCKLESS_ENCODER_WS2812)
+                     fl::ClocklessEncoder enc = fl::ClocklessEncoder::CLOCKLESS_ENCODER_WS2812,
+                     fl::span<const LegacyClocklessChipset> legacy = fl::span<const LegacyClocklessChipset>())
         : timing(t)
         , encoder(enc)
         , timing_name(tn)
@@ -38,7 +41,8 @@ struct AutoResearchConfig {
         , rx_channel(rc)
         , rx_buffer(rb)
         , base_strip_size(bss)
-        , rx_type(rt) {}
+        , rx_type(rt)
+        , legacy_chipsets(legacy) {}
 };
 
 /// @brief Test context for detailed error reporting

--- a/examples/AutoResearch/LegacyClocklessProxy.h
+++ b/examples/AutoResearch/LegacyClocklessProxy.h
@@ -1,50 +1,92 @@
 // LegacyClocklessProxy.h - Runtime-to-template pin dispatch for legacy addLeds API
 //
-// Maps a runtime pin number to compile-time WS2812B<PIN, RGB> template
+// Maps a runtime pin number and chipset name to compile-time clockless template
 // instantiations via a switch statement. This allows AutoResearch testing of the
-// legacy template API path: WS2812B<PIN> -> WS2812Controller800Khz ->
-// ClocklessControllerImpl -> ClocklessIdf5 -> Channel
+// legacy template API path: CHIPSET<PIN> -> ClocklessControllerImpl ->
+// ClocklessIdf5 -> Channel.
 
 #pragma once
 
 #include <FastLED.h>
 #include "fl/stl/unique_ptr.h"
 
-/// @brief Proxy that creates a legacy WS2812B controller from a runtime pin number.
+enum class LegacyClocklessChipset : uint8_t {
+    WS2812B,
+    SK6812,
+};
+
+inline const char* legacyClocklessChipsetName(LegacyClocklessChipset chipset) {
+    switch (chipset) {
+        case LegacyClocklessChipset::WS2812B:
+            return "WS2812B";
+        case LegacyClocklessChipset::SK6812:
+            return "SK6812";
+    }
+    return "UNKNOWN";
+}
+
+inline bool legacyClocklessChipsetFromName(const fl::string& name,
+                                           LegacyClocklessChipset* out) {
+    if (name == "WS2812B" || name == "WS2812") {
+        if (out) *out = LegacyClocklessChipset::WS2812B;
+        return true;
+    }
+    if (name == "SK6812") {
+        if (out) *out = LegacyClocklessChipset::SK6812;
+        return true;
+    }
+    return false;
+}
+
+/// @brief Proxy that creates a legacy clockless controller from runtime inputs.
 ///
 /// The legacy FastLED API requires compile-time template pin parameters:
 ///   FastLED.addLeds<WS2812B, PIN>(leds, numLeds)
 ///
 /// This proxy uses a switch statement to dispatch supported AutoResearch legacy
-/// pin values to the corresponding template instantiation, enabling testing of
-/// the full legacy code path. Pins 0-8 are historical coverage pins; pin 22 is
-/// the current Teensy ObjectFLED loopback TX pin.
+/// pin and chipset values to the corresponding template instantiation, enabling
+/// testing of the full legacy code path. Pins 0-8 are historical coverage pins;
+/// pin 22 is the current Teensy ObjectFLED loopback TX pin.
 ///
 /// Destructor deletes the controller, which on ESP32 (SKETCH_HAS_LARGE_MEMORY)
 /// automatically calls removeFromDrawList() via ~CLEDController().
 class LegacyClocklessProxy {
     fl::unique_ptr<CLEDController> mController;
 
-    template<int PIN>
-    fl::unique_ptr<CLEDController> create(CRGB* leds, int numLeds) {
-        auto c = fl::make_unique<WS2812B<PIN, RGB>>();
+    template<typename Controller>
+    fl::unique_ptr<CLEDController> createTyped(CRGB* leds, int numLeds) {
+        auto c = fl::make_unique<Controller>();
         FastLED.addLeds(c.get(), leds, numLeds);
         return c;
     }
 
+    template<int PIN>
+    fl::unique_ptr<CLEDController> create(CRGB* leds, int numLeds,
+                                          LegacyClocklessChipset chipset) {
+        switch (chipset) {
+            case LegacyClocklessChipset::WS2812B:
+                return createTyped<WS2812B<PIN, RGB>>(leds, numLeds);
+            case LegacyClocklessChipset::SK6812:
+                return createTyped<SK6812<PIN, RGB>>(leds, numLeds);
+        }
+        return nullptr;
+    }
+
 public:
-    LegacyClocklessProxy(int pin, CRGB* leds, int numLeds) {
+    LegacyClocklessProxy(
+        int pin, CRGB* leds, int numLeds,
+        LegacyClocklessChipset chipset = LegacyClocklessChipset::WS2812B) {
         switch (pin) {
-            case 0: mController = create<0>(leds, numLeds); break;
-            case 1: mController = create<1>(leds, numLeds); break;
-            case 2: mController = create<2>(leds, numLeds); break;
-            case 3: mController = create<3>(leds, numLeds); break;
-            case 4: mController = create<4>(leds, numLeds); break;
-            case 5: mController = create<5>(leds, numLeds); break;
-            case 6: mController = create<6>(leds, numLeds); break;
-            case 7: mController = create<7>(leds, numLeds); break;
-            case 8: mController = create<8>(leds, numLeds); break;
-            case 22: mController = create<22>(leds, numLeds); break;
+            case 0: mController = create<0>(leds, numLeds, chipset); break;
+            case 1: mController = create<1>(leds, numLeds, chipset); break;
+            case 2: mController = create<2>(leds, numLeds, chipset); break;
+            case 3: mController = create<3>(leds, numLeds, chipset); break;
+            case 4: mController = create<4>(leds, numLeds, chipset); break;
+            case 5: mController = create<5>(leds, numLeds, chipset); break;
+            case 6: mController = create<6>(leds, numLeds, chipset); break;
+            case 7: mController = create<7>(leds, numLeds, chipset); break;
+            case 8: mController = create<8>(leds, numLeds, chipset); break;
+            case 22: mController = create<22>(leds, numLeds, chipset); break;
             default: break;  // mController stays nullptr
         }
     }


### PR DESCRIPTION
## Summary

Adds legacy ObjectFLED regression coverage for multiple timing groups.

Changes:
- adds `LegacyClocklessChipset` selection for the legacy runtime-to-template proxy
- supports `WS2812B` and `SK6812` legacy template instantiations per lane
- adds optional `legacyChipsets` JSON-RPC field for `runSingleTest` when `useLegacyApi=true`
- adds `--legacy-mixed-timings` to AutoResearch, generating alternating `WS2812B` / `SK6812` lanes
- keeps the existing same-timing legacy request unchanged unless the new flag is explicit
- adds host request-builder coverage and guardrail tests

## Validation

```bash
uv run --no-sync ruff format --check ci/autoresearch/args.py ci/autoresearch/phases.py ci/tests/test_autoresearch_phases.py
uv run --no-sync ruff check ci/autoresearch/args.py ci/autoresearch/phases.py ci/tests/test_autoresearch_phases.py
uv run --no-sync pytest ci/tests/test_autoresearch_phases.py -q
# 77 passed
soldr cargo fmt --manifest-path ci/lint_cpp_rs/Cargo.toml -- --check
soldr cargo check --manifest-path ci/lint_cpp_rs/Cargo.toml --target x86_64-unknown-linux-gnu --tests
# passed with existing unrelated warnings
bash test --unit --no-fingerprint
# 254/254 passed
git diff --check
```

AutoResearch firmware sanity check:

```bash
bash autoresearch teensy41 --object-fled --legacy --legacy-mixed-timings --lanes 2 --tx-pin 0 --rx-pin 8 --strip-sizes 1 --timeout 120 --skip-lint
```

Result:
- fbuild deploy succeeded on `teensy41 @ COM20`.
- Serial backend was `FbuildSerialAdapter`; no manual serial utility was used.
- Firmware compiled with the mixed legacy chipset support.
- Run then failed at GPIO pretest as expected: current hardware is soldered `TX 22 -> RX 8`, while this historical multi-lane coverage command intentionally tested `TX 0 -> RX 8`.
- Failure class was `electrical_issue`, not a firmware compile or RPC failure.
- The zero-byte `-r` artifact reappeared after AutoResearch and was removed.

This is regression coverage progress only; ObjectFLED hardware acceptance is still open.