### PR TITLE
[codex] Cover legacy ObjectFLED RGBW small counts

### DIFF
--- a/ci/autoresearch/args.py
+++ b/ci/autoresearch/args.py
@@ -74,6 +74,7 @@ class Args:
     # Legacy API testing
     legacy: bool
     legacy_mixed_timings: bool
+    legacy_rgbw_small_counts: bool
 
     # Chipset selection
     chipset: str
@@ -583,6 +584,14 @@ See Also:
                 "Requires multi-lane historical TX pins 0-8."
             ),
         )
+        parser.add_argument(
+            "--legacy-rgbw-small-counts",
+            action="store_true",
+            help=(
+                "With --legacy, run RGBW 1, 2, 3, and 4 LED cases to cover "
+                "small-count ObjectFLED RGBW overflow regressions."
+            ),
+        )
 
         # Chipset selection
         parser.add_argument(
@@ -705,6 +714,7 @@ See Also:
             color_pattern=parsed.color_pattern,
             legacy=parsed.legacy,
             legacy_mixed_timings=parsed.legacy_mixed_timings,
+            legacy_rgbw_small_counts=parsed.legacy_rgbw_small_counts,
             chipset=parsed.chipset,
             net_server=parsed.net_server,
             net_client=parsed.net_client,

--- a/ci/autoresearch/phases.py
+++ b/ci/autoresearch/phases.py
@@ -573,6 +573,17 @@ def _parse_args_and_build_commands(args: Args) -> RunContext | int:
                 "\u274c Error: --legacy-mixed-timings requires --legacy with at least 2 lanes"
             )
             return 1
+        if args.legacy_rgbw_small_counts:
+            if requested_min_lanes != 1 or requested_max_lanes != 1:
+                print(
+                    "\u274c Error: --legacy-rgbw-small-counts requires exactly 1 lane"
+                )
+                return 1
+            if args.strip_sizes is not None:
+                print(
+                    "\u274c Error: --legacy-rgbw-small-counts supplies strip sizes 1,2,3,4; do not combine with --strip-sizes"
+                )
+                return 1
         if requested_max_lanes > 1:
             if args.tx_pin is None:
                 print(
@@ -594,8 +605,17 @@ def _parse_args_and_build_commands(args: Args) -> RunContext | int:
             print(
                 "\u2139\ufe0f  Legacy mixed timing mode: alternating WS2812B/SK6812 template chipsets across lanes"
             )
-    elif args.legacy_mixed_timings:
-        print("\u274c Error: --legacy-mixed-timings requires --legacy")
+        if args.legacy_rgbw_small_counts:
+            print(
+                "\u2139\ufe0f  Legacy RGBW small-count mode: running RGBW strip sizes 1, 2, 3, and 4"
+            )
+    elif args.legacy_mixed_timings or args.legacy_rgbw_small_counts:
+        flag = (
+            "--legacy-mixed-timings"
+            if args.legacy_mixed_timings
+            else "--legacy-rgbw-small-counts"
+        )
+        print(f"\u274c Error: {flag} requires --legacy")
         return 1
 
     if min_lanes is not None and max_lanes is not None:
@@ -709,6 +729,9 @@ def _parse_args_and_build_commands(args: Args) -> RunContext | int:
                 )
                 return 1
 
+    if args.legacy_rgbw_small_counts:
+        config["stripSizes"] = [1, 2, 3, 4]
+
     rpc_commands_list: list[dict[str, Any]] = []
 
     if per_lane_counts is not None:
@@ -777,6 +800,8 @@ def _parse_args_and_build_commands(args: Args) -> RunContext | int:
                     }
                     if args.legacy:
                         test_config["useLegacyApi"] = True
+                        if args.legacy_rgbw_small_counts:
+                            test_config["legacyRgbw"] = True
                         if args.legacy_mixed_timings:
                             test_config["legacyChipsets"] = [
                                 "WS2812B" if i % 2 == 0 else "SK6812"

--- a/ci/tests/test_autoresearch_phases.py
+++ b/ci/tests/test_autoresearch_phases.py
@@ -83,6 +83,7 @@ def _make_args(**overrides) -> Args:
         color_pattern=None,
         legacy=False,
         legacy_mixed_timings=False,
+        legacy_rgbw_small_counts=False,
         chipset="ws2812",
         net_server=False,
         net_client=False,
@@ -356,6 +357,45 @@ class TestParseArgsAndBuildCommands:
         assert params["useLegacyApi"] is True
         assert params["legacyChipsets"] == ["WS2812B", "SK6812"]
 
+    def test_object_fled_legacy_rgbw_small_counts_commands(
+        self, fake_project_dir: Path
+    ) -> None:
+        args = _make_args(
+            object_fled=True,
+            parlio=False,
+            legacy=True,
+            legacy_rgbw_small_counts=True,
+            tx_pin=22,
+            rx_pin=8,
+            environment_positional="teensy41",
+            project_dir=fake_project_dir,
+            use_root_platformio_ini=False,
+        )
+        with patch(
+            "ci.autoresearch.staging.synthesise_autoresearch_project",
+            return_value=fake_project_dir,
+        ):
+            result = _parse_args_and_build_commands(args)
+        assert isinstance(result, RunContext)
+        assert result.drivers == ["OBJECT_FLED"]
+
+        run_commands = [
+            cmd for cmd in result.json_rpc_commands if cmd["method"] == "runSingleTest"
+        ]
+        assert len(run_commands) == 4
+        assert [cmd["params"]["laneSizes"] for cmd in run_commands] == [
+            [1],
+            [2],
+            [3],
+            [4],
+        ]
+        for cmd in run_commands:
+            params = cmd["params"]
+            assert params["driver"] == "OBJECT_FLED"
+            assert params["useLegacyApi"] is True
+            assert params["legacyRgbw"] is True
+            assert "legacyChipsets" not in params
+
     def test_legacy_mixed_timings_requires_legacy(self, fake_project_dir: Path) -> None:
         args = _make_args(
             object_fled=True,
@@ -384,6 +424,59 @@ class TestParseArgsAndBuildCommands:
             lanes="1",
             strip_sizes="3",
             tx_pin=0,
+            rx_pin=8,
+            environment_positional="teensy41",
+            project_dir=fake_project_dir,
+            use_root_platformio_ini=False,
+        )
+        result = _parse_args_and_build_commands(args)
+        assert result == 1
+
+    def test_legacy_rgbw_small_counts_requires_legacy(
+        self, fake_project_dir: Path
+    ) -> None:
+        args = _make_args(
+            object_fled=True,
+            parlio=False,
+            legacy=False,
+            legacy_rgbw_small_counts=True,
+            tx_pin=22,
+            rx_pin=8,
+            environment_positional="teensy41",
+            project_dir=fake_project_dir,
+            use_root_platformio_ini=False,
+        )
+        result = _parse_args_and_build_commands(args)
+        assert result == 1
+
+    def test_legacy_rgbw_small_counts_requires_single_lane(
+        self, fake_project_dir: Path
+    ) -> None:
+        args = _make_args(
+            object_fled=True,
+            parlio=False,
+            legacy=True,
+            legacy_rgbw_small_counts=True,
+            lanes="2",
+            tx_pin=0,
+            rx_pin=8,
+            environment_positional="teensy41",
+            project_dir=fake_project_dir,
+            use_root_platformio_ini=False,
+        )
+        result = _parse_args_and_build_commands(args)
+        assert result == 1
+
+    def test_legacy_rgbw_small_counts_rejects_strip_size_override(
+        self, fake_project_dir: Path
+    ) -> None:
+        args = _make_args(
+            object_fled=True,
+            parlio=False,
+            legacy=True,
+            legacy_rgbw_small_counts=True,
+            strip_sizes="3",
+            tx_pin=22,
             rx_pin=8,
             environment_positional="teensy41",
             project_dir=fake_project_dir,

--- a/examples/AutoResearch/AutoResearchRemote.cpp
+++ b/examples/AutoResearch/AutoResearchRemote.cpp
@@ -69,16 +69,16 @@
 void printJsonRaw(const fl::json& json, const char* prefix) {
     // Serialize and print response
     fl::string formatted = fl::formatJsonResponse(json, prefix);
-    Serial.println(formatted.c_str());  // ok autoresearch rpc serial - RPC response boundary
-    Serial.flush();                     // ok autoresearch rpc serial - host waits for RPC boundary
+    Serial.println(formatted.c_str());  // ok serial - ok autoresearch rpc serial - RPC response boundary
+    Serial.flush();                     // ok serial - ok autoresearch rpc serial - host waits for RPC boundary
 }
 
 namespace {
 
 void printRemoteResponseRaw(const fl::json& response) {
     fl::string formatted = fl::formatJsonResponse(response, "REMOTE: ");
-    Serial.println(formatted.c_str());  // ok autoresearch rpc serial - RPC response boundary
-    Serial.flush();                     // ok autoresearch rpc serial - host waits for RPC boundary
+    Serial.println(formatted.c_str());  // ok serial - ok autoresearch rpc serial - RPC response boundary
+    Serial.flush();                     // ok serial - ok autoresearch rpc serial - host waits for RPC boundary
 }
 
 }  // namespace
@@ -98,7 +98,7 @@ void printStreamRaw(const char* messageType, const fl::json& data) {
 
     // Use fl:: serial transport for consistent formatting
     fl::string formatted = fl::formatJsonResponse(output, "RESULT: ");
-    Serial.println(formatted.c_str());  // ok autoresearch rpc serial - stream response boundary
+    Serial.println(formatted.c_str());  // ok serial - ok autoresearch rpc serial - stream response boundary
 }
 
 // ============================================================================

--- a/examples/AutoResearch/AutoResearchRemoteRunSingleTest.cpp
+++ b/examples/AutoResearch/AutoResearchRemoteRunSingleTest.cpp
@@ -427,6 +427,23 @@ fl::json AutoResearchRemoteControl::runSingleTestImpl(const fl::json& args) {
         use_legacy_api = config["useLegacyApi"].as_bool().value();
     }
 
+    bool legacy_rgbw = false;
+    if (config.contains("legacyRgbw")) {
+        if (!use_legacy_api) {
+            response.set("success", false);
+            response.set("error", "LegacyRgbwRequiresLegacyApi");
+            response.set("message", "legacyRgbw requires useLegacyApi=true");
+            return response;
+        }
+        if (!config["legacyRgbw"].is_bool()) {
+            response.set("success", false);
+            response.set("error", "InvalidLegacyRgbw");
+            response.set("message", "legacyRgbw must be a boolean");
+            return response;
+        }
+        legacy_rgbw = config["legacyRgbw"].as_bool().value();
+    }
+
     fl::vector<LegacyClocklessChipset> legacy_chipsets;
     if (config.contains("legacyChipsets") && !use_legacy_api) {
         response.set("success", false);
@@ -656,7 +673,8 @@ fl::json AutoResearchRemoteControl::runSingleTestImpl(const fl::json& args) {
         lane_sizes[0],  // base_strip_size (used for logging)
         fl::RxDeviceType::RMT,  // Default RX device type
         timing_config.encoder,
-        fl::span<const LegacyClocklessChipset>(legacy_chipsets)
+        fl::span<const LegacyClocklessChipset>(legacy_chipsets),
+        legacy_rgbw
     );
 
     // Run test with debug output suppressed
@@ -773,6 +791,7 @@ fl::json AutoResearchRemoteControl::runSingleTestImpl(const fl::json& args) {
     response.set("pattern", pattern.c_str());
     response.set("useLegacyApi", use_legacy_api);
     if (use_legacy_api) {
+        response.set("legacyRgbw", legacy_rgbw);
         fl::json legacy_chipsets_response = fl::json::array();
         for (LegacyClocklessChipset chipset : legacy_chipsets) {
             legacy_chipsets_response.push_back(

--- a/examples/AutoResearch/AutoResearchTest.cpp
+++ b/examples/AutoResearch/AutoResearchTest.cpp
@@ -1227,8 +1227,8 @@ void autoResearchChipsetTimingLegacy(fl::AutoResearchConfig& config,
             chipset = config.legacy_chipsets[i];
         }
 
-        auto proxy =
-            fl::make_unique<LegacyClocklessProxy>(pin, leds, numLeds, chipset);
+        auto proxy = fl::make_unique<LegacyClocklessProxy>(
+            pin, leds, numLeds, chipset, config.legacy_rgbw);
         if (!proxy->valid()) {
             FL_ERROR("Legacy proxy invalid for lane " << i << " (pin " << pin
                      << ", chipset " << legacyClocklessChipsetName(chipset)

--- a/examples/AutoResearch/AutoResearchTest.h
+++ b/examples/AutoResearch/AutoResearchTest.h
@@ -22,6 +22,7 @@ struct AutoResearchConfig {
     int base_strip_size;                         ///< Base strip size (10 or 300 LEDs)
     fl::RxDeviceType rx_type;                    ///< RX device type (RMT or ISR)
     fl::span<const LegacyClocklessChipset> legacy_chipsets;  ///< Optional per-lane legacy templates
+    bool legacy_rgbw;                            ///< Enable RGBW on legacy controllers
 
     AutoResearchConfig(const fl::ChipsetTimingConfig& t,
                      const char* tn,
@@ -32,7 +33,8 @@ struct AutoResearchConfig {
                      int bss,
                      fl::RxDeviceType rt,
                      fl::ClocklessEncoder enc = fl::ClocklessEncoder::CLOCKLESS_ENCODER_WS2812,
-                     fl::span<const LegacyClocklessChipset> legacy = fl::span<const LegacyClocklessChipset>())
+                     fl::span<const LegacyClocklessChipset> legacy = fl::span<const LegacyClocklessChipset>(),
+                     bool legacy_rgbw_enabled = false)
         : timing(t)
         , encoder(enc)
         , timing_name(tn)
@@ -42,7 +44,8 @@ struct AutoResearchConfig {
         , rx_buffer(rb)
         , base_strip_size(bss)
         , rx_type(rt)
-        , legacy_chipsets(legacy) {}
+        , legacy_chipsets(legacy)
+        , legacy_rgbw(legacy_rgbw_enabled) {}
 };
 
 /// @brief Test context for detailed error reporting

--- a/examples/AutoResearch/LegacyClocklessProxy.h
+++ b/examples/AutoResearch/LegacyClocklessProxy.h
@@ -54,20 +54,25 @@ class LegacyClocklessProxy {
     fl::unique_ptr<CLEDController> mController;
 
     template<typename Controller>
-    fl::unique_ptr<CLEDController> createTyped(CRGB* leds, int numLeds) {
+    fl::unique_ptr<CLEDController> createTyped(CRGB* leds, int numLeds,
+                                               bool rgbw) {
         auto c = fl::make_unique<Controller>();
         FastLED.addLeds(c.get(), leds, numLeds);
+        if (rgbw) {
+            c->setRgbw(RgbwDefault());
+        }
         return c;
     }
 
     template<int PIN>
     fl::unique_ptr<CLEDController> create(CRGB* leds, int numLeds,
-                                          LegacyClocklessChipset chipset) {
+                                          LegacyClocklessChipset chipset,
+                                          bool rgbw) {
         switch (chipset) {
             case LegacyClocklessChipset::WS2812B:
-                return createTyped<WS2812B<PIN, RGB>>(leds, numLeds);
+                return createTyped<WS2812B<PIN, RGB>>(leds, numLeds, rgbw);
             case LegacyClocklessChipset::SK6812:
-                return createTyped<SK6812<PIN, RGB>>(leds, numLeds);
+                return createTyped<SK6812<PIN, RGB>>(leds, numLeds, rgbw);
         }
         return nullptr;
     }
@@ -75,18 +80,19 @@ class LegacyClocklessProxy {
 public:
     LegacyClocklessProxy(
         int pin, CRGB* leds, int numLeds,
-        LegacyClocklessChipset chipset = LegacyClocklessChipset::WS2812B) {
+        LegacyClocklessChipset chipset = LegacyClocklessChipset::WS2812B,
+        bool rgbw = false) {
         switch (pin) {
-            case 0: mController = create<0>(leds, numLeds, chipset); break;
-            case 1: mController = create<1>(leds, numLeds, chipset); break;
-            case 2: mController = create<2>(leds, numLeds, chipset); break;
-            case 3: mController = create<3>(leds, numLeds, chipset); break;
-            case 4: mController = create<4>(leds, numLeds, chipset); break;
-            case 5: mController = create<5>(leds, numLeds, chipset); break;
-            case 6: mController = create<6>(leds, numLeds, chipset); break;
-            case 7: mController = create<7>(leds, numLeds, chipset); break;
-            case 8: mController = create<8>(leds, numLeds, chipset); break;
-            case 22: mController = create<22>(leds, numLeds, chipset); break;
+            case 0: mController = create<0>(leds, numLeds, chipset, rgbw); break;
+            case 1: mController = create<1>(leds, numLeds, chipset, rgbw); break;
+            case 2: mController = create<2>(leds, numLeds, chipset, rgbw); break;
+            case 3: mController = create<3>(leds, numLeds, chipset, rgbw); break;
+            case 4: mController = create<4>(leds, numLeds, chipset, rgbw); break;
+            case 5: mController = create<5>(leds, numLeds, chipset, rgbw); break;
+            case 6: mController = create<6>(leds, numLeds, chipset, rgbw); break;
+            case 7: mController = create<7>(leds, numLeds, chipset, rgbw); break;
+            case 8: mController = create<8>(leds, numLeds, chipset, rgbw); break;
+            case 22: mController = create<22>(leds, numLeds, chipset, rgbw); break;
             default: break;  // mController stays nullptr
         }
     }

--- a/src/platforms/arm/teensy/teensy4_common/clockless_objectfled.cpp.hpp
+++ b/src/platforms/arm/teensy/teensy4_common/clockless_objectfled.cpp.hpp
@@ -198,11 +198,27 @@ void ObjectFLEDGroupBase::flush() {
 
     // Copy pixel data from RectangularDrawBuffer into ObjectFLED's frameBufferLocal
     auto* objectfled = static_cast<fl::ObjectFLED*>(mObjectFLED);
+    bool hasRgbw = false;
+    for (const auto& item : mRectDrawBuffer.mDrawList) {
+        if (item.mIsRgbw) {
+            hasRgbw = true;
+            break;
+        }
+    }
+    u32 numStrips = 0;
+    u32 bytesPerStrip = 0;
     u32 totalBytes = mRectDrawBuffer.getTotalBytes();
-    if (totalBytes > 0) {
+    mRectDrawBuffer.getBlockInfo(&numStrips, &bytesPerStrip, &totalBytes);
+    const u32 frameBytes =
+            objectFledFrameBytesForRectangularBlock(numStrips, bytesPerStrip, hasRgbw);
+    if (frameBytes > 0) {
+        fl::memset(objectfled->frameBufferLocal, 0, frameBytes);
+    }
+    const u32 copyBytes = totalBytes < frameBytes ? totalBytes : frameBytes;
+    if (copyBytes > 0) {
         fl::memcpy(objectfled->frameBufferLocal,
                     mRectDrawBuffer.mAllLedsBufferUint8.get(),
-                    totalBytes);
+                    copyBytes);
     }
 
     // Transmit the already packed RectangularDrawBuffer bytes.
@@ -228,12 +244,13 @@ void ObjectFLEDGroupBase::rebuildObjectFLED() {
     u32 total_bytes = 0;
     mRectDrawBuffer.getBlockInfo(&num_strips, &bytes_per_strip, &total_bytes);
 
-    // Total LEDs = total_bytes / bytes_per_led
-    int bytesPerLed = hasRgbw ? 4 : 3;
-    int totalLeds = total_bytes / bytesPerLed;
+    const u32 frame_bytes =
+            objectFledFrameBytesForRectangularBlock(num_strips, bytes_per_strip, hasRgbw);
+    int totalLeds = static_cast<int>(
+            objectFledTotalLedsForRectangularBlock(num_strips, bytes_per_strip, hasRgbw));
 
     #ifdef FASTLED_DEBUG_OBJECTFLED
-    FL_WARN_F("ObjectFLEDGroupBase: totalLeds=%s bytesPerStrip=%s", totalLeds, bytes_per_strip);
+    FL_WARN_F("ObjectFLEDGroupBase: totalLeds=%s bytesPerStrip=%s frameBytes=%s", totalLeds, bytes_per_strip, frame_bytes);
     #endif
 
     // Pass nullptr so ObjectFLED allocates frameBufferLocal internally
@@ -252,7 +269,7 @@ void ObjectFLEDGroupBase::rebuildObjectFLED() {
     mObjectFLED = objectfled;
 
     // Clear frameBufferLocal to zeros (for padding)
-    fl::memset(objectfled->frameBufferLocal, 0, total_bytes);
+    fl::memset(objectfled->frameBufferLocal, 0, frame_bytes);
 }
 
 } // namespace fl

--- a/src/platforms/arm/teensy/teensy4_common/clockless_objectfled.h
+++ b/src/platforms/arm/teensy/teensy4_common/clockless_objectfled.h
@@ -73,7 +73,7 @@ private:
         void* groupPtr;
         void (*flushFunc)(void*);
 
-        bool operator==(const GroupEntry& other) const {
+        bool operator==(const GroupEntry& other) const FL_NO_EXCEPT {
             return groupPtr == other.groupPtr;
         }
     };
@@ -94,6 +94,32 @@ struct ObjectFLEDTimingConfig {
     u32 T3;     // Total bit period (ns)
     u32 RESET;  // Reset/latch time (ns)
 };
+
+inline u32 objectFledBytesPerLed(bool isRgbw) FL_NO_EXCEPT {
+    return isRgbw ? 4u : 3u;
+}
+
+inline u32 objectFledLedsPerStripForRectangularBytes(
+        u32 bytesPerStrip, bool isRgbw) FL_NO_EXCEPT {
+    const u32 bytesPerLed = objectFledBytesPerLed(isRgbw);
+    if (bytesPerStrip == 0) {
+        return 0;
+    }
+    return (bytesPerStrip + bytesPerLed - 1u) / bytesPerLed;
+}
+
+inline u32 objectFledTotalLedsForRectangularBlock(
+        u32 numStrips, u32 bytesPerStrip, bool isRgbw) FL_NO_EXCEPT {
+    return numStrips *
+           objectFledLedsPerStripForRectangularBytes(bytesPerStrip, isRgbw);
+}
+
+inline u32 objectFledFrameBytesForRectangularBlock(
+        u32 numStrips, u32 bytesPerStrip, bool isRgbw) FL_NO_EXCEPT {
+    return objectFledTotalLedsForRectangularBlock(
+               numStrips, bytesPerStrip, isRgbw) *
+           objectFledBytesPerLed(isRgbw);
+}
 
 /// Concrete (non-template) group that manages ObjectFLED for a specific timing
 /// This does all the real work - templates just delegate to this
@@ -134,19 +160,19 @@ public:
         return fl::Singleton<ObjectFLEDGroup<TIMING>>::instance();
     }
 
-    ObjectFLEDGroup()
+    ObjectFLEDGroup() FL_NO_EXCEPT
         : mBase(ObjectFLEDTimingConfig{TIMING::T1, TIMING::T2, TIMING::T3, TIMING::RESET}) {
         registerWithRegistry();
     }
 
-    void onQueuingStart() {
+    void onQueuingStart() FL_NO_EXCEPT {
         registerWithRegistry();
         mBase.onQueuingStart();
     }
     void addStrip(u8 pin, PixelIterator& pixel_iterator) FL_NO_EXCEPT {
         mBase.addStrip(pin, pixel_iterator);
     }
-    void flush() { mBase.flush(); }
+    void flush() FL_NO_EXCEPT { mBase.flush(); }
 
 private:
     static void flushRegisteredGroup(void* ptr) FL_NO_EXCEPT {
@@ -177,7 +203,7 @@ class ClocklessController_ObjectFLED_Proxy
   public:
     ClocklessController_ObjectFLED_Proxy() FL_NO_EXCEPT;
 
-    void init() override {}
+    void init() FL_NO_EXCEPT override {}
 
     virtual u16 getMaxRefreshRate() const FL_NO_EXCEPT override {
         // Calculate based on timing: if total period > 2000ns, it's 400kHz, else 800kHz
@@ -186,7 +212,7 @@ class ClocklessController_ObjectFLED_Proxy
     }
 
   protected:
-    virtual void *beginShowLeds(int nleds) override;
+    virtual void *beginShowLeds(int nleds) FL_NO_EXCEPT override;
     virtual void showPixels(PixelController<RGB_ORDER> &pixels) FL_NO_EXCEPT override;
     virtual void endShowLeds(void *data) FL_NO_EXCEPT override;
 };
@@ -196,13 +222,13 @@ class ClocklessController_ObjectFLED_Proxy
 // ============================================================================
 
 template <typename TIMING, int DATA_PIN, EOrder RGB_ORDER>
-ClocklessController_ObjectFLED_Proxy<TIMING, DATA_PIN, RGB_ORDER>::ClocklessController_ObjectFLED_Proxy()
+ClocklessController_ObjectFLED_Proxy<TIMING, DATA_PIN, RGB_ORDER>::ClocklessController_ObjectFLED_Proxy() FL_NO_EXCEPT
     : Base() {
     // Latch delay is automatically determined from TIMING::RESET
 }
 
 template <typename TIMING, int DATA_PIN, EOrder RGB_ORDER>
-void *ClocklessController_ObjectFLED_Proxy<TIMING, DATA_PIN, RGB_ORDER>::beginShowLeds(int nleds) {
+void *ClocklessController_ObjectFLED_Proxy<TIMING, DATA_PIN, RGB_ORDER>::beginShowLeds(int nleds) FL_NO_EXCEPT {
     void *data = Base::beginShowLeds(nleds);
 
     // Auto-grab the singleton for THIS chipset type
@@ -219,7 +245,7 @@ void *ClocklessController_ObjectFLED_Proxy<TIMING, DATA_PIN, RGB_ORDER>::beginSh
 
 template <typename TIMING, int DATA_PIN, EOrder RGB_ORDER>
 void ClocklessController_ObjectFLED_Proxy<TIMING, DATA_PIN, RGB_ORDER>::showPixels(
-    PixelController<RGB_ORDER> &pixels) {
+    PixelController<RGB_ORDER> &pixels) FL_NO_EXCEPT {
     // Auto-grab the singleton for THIS chipset type
     ObjectFLEDGroup<TIMING>& group = ObjectFLEDGroup<TIMING>::getInstance();
 
@@ -229,7 +255,7 @@ void ClocklessController_ObjectFLED_Proxy<TIMING, DATA_PIN, RGB_ORDER>::showPixe
 }
 
 template <typename TIMING, int DATA_PIN, EOrder RGB_ORDER>
-void ClocklessController_ObjectFLED_Proxy<TIMING, DATA_PIN, RGB_ORDER>::endShowLeds(void *data) {
+void ClocklessController_ObjectFLED_Proxy<TIMING, DATA_PIN, RGB_ORDER>::endShowLeds(void *data) FL_NO_EXCEPT {
     Base::endShowLeds(data);
 
     // DON'T flush here - let chipset change detection or frame end handle it

--- a/src/platforms/arm/teensy/teensy4_common/drivers/objectfled/channel_engine_objectfled.cpp.hpp
+++ b/src/platforms/arm/teensy/teensy4_common/drivers/objectfled/channel_engine_objectfled.cpp.hpp
@@ -5,6 +5,7 @@
 
 #include "platforms/arm/teensy/teensy4_common/drivers/objectfled/channel_engine_objectfled.h"
 #include "platforms/arm/teensy/teensy4_common/drivers/objectfled/iobjectfled_peripheral.h"
+#include "platforms/arm/teensy/teensy4_common/clockless_objectfled.h"
 
 #include "fl/log/log.h"
 #include "fl/log/log.h"
@@ -209,8 +210,9 @@ bool ChannelEngineObjectFLED::startTimingGroup(TimingGroup& group) FL_NO_EXCEPT 
         u32 total_bytes = 0;
         drawBuf.getBlockInfo(&num_strips, &bytes_per_strip, &total_bytes);
 
-        int bytesPerLed = hasRgbw ? 4 : 3;
-        int totalLeds = total_bytes / bytesPerLed;
+        int totalLeds = static_cast<int>(
+            objectFledTotalLedsForRectangularBlock(
+                num_strips, bytes_per_strip, hasRgbw));
 
         group.instance = mPeripheral->createInstance(
             totalLeds, hasRgbw, pinList.size(), pinList.data(),

--- a/src/platforms/arm/teensy/teensy4_common/drivers/objectfled/objectfled_diagnostics.cpp.hpp
+++ b/src/platforms/arm/teensy/teensy4_common/drivers/objectfled/objectfled_diagnostics.cpp.hpp
@@ -9,10 +9,12 @@
 #include "fl/stl/bit_cast.h"
 #include "fl/stl/cstring.h"
 #include "fl/stl/sstream.h"
+// IWYU pragma: begin_keep
 #include "third_party/object_fled/src/ObjectFLEDDmaManager.h"
 
 #include <Arduino.h>
-#include "DMAChannel.h"
+#include "DMAChannel.h"  // ok include path - Teensy core header
+// IWYU pragma: end_keep
 
 namespace fl {
 namespace {
@@ -135,8 +137,8 @@ void setU32(fl::json& out, const char* key, u32 value) FL_NO_EXCEPT {
     out.set(key, static_cast<i64>(value));
 }
 
-volatile uint32_t* standardGpioAddr(volatile uint32_t* fastgpio) FL_NO_EXCEPT {
-    return reinterpret_cast<volatile uint32_t*>( // ok reinterpret cast - Teensy GPIO alias address map
+volatile u32* standardGpioAddr(volatile u32* fastgpio) FL_NO_EXCEPT {
+    return reinterpret_cast<volatile u32*>( // ok reinterpret cast - Teensy GPIO alias address map
         ptrToU32(fastgpio) - 0x01E48000u);
 }
 
@@ -150,11 +152,11 @@ PinRegisterSnapshot capturePin(u8 pin) FL_NO_EXCEPT {
     out.bit = digitalPinToBit(pin);
     out.mask = 1u << out.bit;
 
-    volatile uint32_t* outputReg = portOutputRegister(pin);
-    volatile uint32_t* modeReg = portModeRegister(pin);
-    volatile uint32_t* inputReg = portInputRegister(pin);
-    volatile uint32_t* muxReg = portConfigRegister(pin);
-    volatile uint32_t* padReg = portControlRegister(pin);
+    volatile u32* outputReg = portOutputRegister(pin);
+    volatile u32* modeReg = portModeRegister(pin);
+    volatile u32* inputReg = portInputRegister(pin);
+    volatile u32* muxReg = portConfigRegister(pin);
+    volatile u32* padReg = portControlRegister(pin);
 
     out.outputRegister = ptrToU32(outputReg);
     out.outputValue = *outputReg;
@@ -173,12 +175,12 @@ PinRegisterSnapshot capturePin(u8 pin) FL_NO_EXCEPT {
     if (offset <= 3) {
         out.fastGpio = static_cast<u8>(6 + offset);
         out.standardGpio = static_cast<u8>(1 + offset);
-        volatile uint32_t* gprReg = &IOMUXC_GPR_GPR26 + offset;
+        volatile u32* gprReg = &IOMUXC_GPR_GPR26 + offset;
         out.gpr = *gprReg;
         out.gprMask = out.mask;
         out.mappedToStandard = ((*gprReg & out.mask) == 0);
 
-        volatile uint32_t* standardModeReg = standardGpioAddr(modeReg);
+        volatile u32* standardModeReg = standardGpioAddr(modeReg);
         out.modeRegister = ptrToU32(standardModeReg);
         out.modeValue = *standardModeReg;
     }
@@ -242,7 +244,7 @@ TcdSnapshot captureTcd(const DMABaseClass::TCD_t* tcd) FL_NO_EXCEPT {
 }
 
 u32 captureDmamuxChcfg(u8 channel) FL_NO_EXCEPT {
-    volatile uint32_t* dmamux = &DMAMUX_CHCFG0 + channel;
+    volatile u32* dmamux = &DMAMUX_CHCFG0 + channel;
     return *dmamux;
 }
 

--- a/tests/platforms/arm/teensy/teensy4_common/drivers/objectfled/channel_engine_objectfled.cpp
+++ b/tests/platforms/arm/teensy/teensy4_common/drivers/objectfled/channel_engine_objectfled.cpp
@@ -5,9 +5,11 @@
 
 #include "platforms/shared/mock/arm/teensy4/drivers/objectfled/objectfled_peripheral_mock.h"
 #include "platforms/arm/teensy/teensy4_common/drivers/objectfled/channel_engine_objectfled.h"
+#include "platforms/arm/teensy/teensy4_common/clockless_objectfled.h"
 #include "fl/chipsets/chipset_timing_config.h"
 #include "fl/channels/data.h"
 #include "fl/channels/driver.h"
+#include "fl/gfx/rectangular_draw_buffer.h"
 #include "test.h"
 
 FL_TEST_FILE(FL_FILEPATH) {
@@ -306,6 +308,69 @@ FL_TEST_CASE("ObjectFLED engine - detects RGBW data") {
     auto* record = mock->getLastCreateRecord();
     FL_REQUIRE(record != nullptr);
     FL_CHECK(record->isRgbw == true);
+}
+
+FL_TEST_CASE("ObjectFLED rectangular sizing rounds RGBW small counts") {
+    struct Case {
+        u16 leds;
+        u32 rectangularBytes;
+        u32 frameBytes;
+        u32 totalLeds;
+    };
+    const Case cases[] = {
+        {1, 9, 12, 3},
+        {2, 9, 12, 3},
+        {3, 15, 16, 4},
+        {4, 18, 20, 5},
+    };
+
+    for (const auto& c : cases) {
+        RectangularDrawBuffer drawBuf;
+        drawBuf.queue(DrawItem(22, c.leds, true));
+        drawBuf.onQueuingDone();
+
+        u32 numStrips = 0;
+        u32 bytesPerStrip = 0;
+        u32 totalBytes = 0;
+        drawBuf.getBlockInfo(&numStrips, &bytesPerStrip, &totalBytes);
+
+        FL_CHECK(numStrips == 1);
+        FL_CHECK(bytesPerStrip == c.rectangularBytes);
+        FL_CHECK(totalBytes == c.rectangularBytes);
+        FL_CHECK(objectFledFrameBytesForRectangularBlock(
+                     numStrips, bytesPerStrip, true) == c.frameBytes);
+        FL_CHECK(objectFledTotalLedsForRectangularBlock(
+                     numStrips, bytesPerStrip, true) == c.totalLeds);
+        FL_CHECK(c.frameBytes >= totalBytes);
+    }
+}
+
+FL_TEST_CASE("ObjectFLED engine - RGBW small counts allocate padding") {
+    struct Case {
+        size_t leds;
+        u32 expectedFrameBytes;
+    };
+    const Case cases[] = {
+        {1, 12},
+        {2, 12},
+        {4, 20},
+    };
+
+    for (const auto& c : cases) {
+        auto mock = fl::make_shared<ObjectFLEDPeripheralMock>();
+        ChannelEngineObjectFLED engine(mock);
+        auto ch = createRGBWChannelData(22, c.leds);
+
+        engine.enqueue(ch);
+        engine.show();
+
+        auto* inst = mock->getLastInstance();
+        auto* record = mock->getLastCreateRecord();
+        FL_REQUIRE(inst != nullptr);
+        FL_REQUIRE(record != nullptr);
+        FL_CHECK(record->isRgbw == true);
+        FL_CHECK(inst->getFrameBufferSize() == c.expectedFrameBytes);
+    }
 }
 
 //=============================================================================


### PR DESCRIPTION
﻿## Summary

Adds the S6 legacy ObjectFLED RGBW small-count regression path for 1, 2, 3, and 4 LED cases.

## What Changed

- Adds `--legacy-rgbw-small-counts` to AutoResearch and generates four `runSingleTest` commands with `legacyRgbw=true`.
- Validates `legacyRgbw` in the firmware JSON-RPC handler and echoes it in responses.
- Enables RGBW on the legacy `FastLED.addLeds` proxy when requested.
- Rounds ObjectFLED rectangular RGBW frame-buffer sizing up to the allocated ObjectFLED byte count so small RGBW cases do not overflow/truncate.
- Adds ObjectFLED mock/unit coverage for RGBW small-count sizing.
- Cleans touched-file lint issues around RPC-boundary serial suppressions, noexcept annotations, and ObjectFLED diagnostics includes/types.

## Validation

- `uv run --no-sync ruff format --check ci/autoresearch/args.py ci/autoresearch/phases.py ci/tests/test_autoresearch_phases.py`
- `uv run --no-sync ruff check ci/autoresearch/args.py ci/autoresearch/phases.py ci/tests/test_autoresearch_phases.py`
- `uv run --no-sync pytest ci/tests/test_autoresearch_phases.py -q` (`81 passed`)
- `git diff --check`
- `ci\lint_cpp_rs\target\x86_64-pc-windows-msvc\debug\fastled-lint.exe --checker autoresearch_runtime_output examples\AutoResearch`
- `bash lint --cpp`
- `soldr cargo fmt --manifest-path ci/lint_cpp_rs/Cargo.toml -- --check`
- `soldr cargo check --manifest-path ci/lint_cpp_rs/Cargo.toml --target x86_64-unknown-linux-gnu --tests`
- `bash test --unit --no-fingerprint` (`254/254 passed`)
- `bash autoresearch teensy41 --object-fled --legacy --legacy-rgbw-small-counts --tx-pin 22 --rx-pin 8 --timeout 120 --skip-lint`

## Hardware Result

AutoResearch deployed with fbuild on `teensy41 @ COM20`, used `FbuildSerialAdapter`, passed GPIO pre-test for `TX 22 -> RX 8`, and executed legacy RGBW sizes 1, 2, 3, and 4 without a serial cutoff/crash. The driver still fails honestly as `zero_capture`, so this is S6 coverage/crash-progress only, not ObjectFLED acceptance.
