### PR TITLE
[codex] Guard ObjectFLED runtime output paths

### DIFF
--- a/ci/lint_cpp_rs/src/checkers/style.rs
+++ b/ci/lint_cpp_rs/src/checkers/style.rs
@@ -380,11 +380,7 @@ impl FileContentChecker for AutoResearchRuntimeOutputChecker {
     }
 
     fn should_process_file(&self, file_path: &str, _project_root: &Path) -> bool {
-        if !ends_with_any(file_path, &[".cpp", ".h", ".hpp", ".ino"]) {
-            return false;
-        }
-        let normalized = normalize_path(file_path);
-        normalized.contains("examples/AutoResearch/")
+        ends_with_any(file_path, &[".cpp", ".h", ".hpp", ".ino", ".cpp.hpp"])
     }
 
     fn check_file_content(&self, file_content: &FileContent) -> Vec<(usize, String)> {
@@ -393,6 +389,14 @@ impl FileContentChecker for AutoResearchRuntimeOutputChecker {
         }
 
         let normalized_path = normalize_path(&file_content.path);
+        let is_autoresearch_file = normalized_path.contains("examples/AutoResearch/");
+        let has_marker = file_content
+            .content
+            .to_ascii_lowercase()
+            .contains("autoresearch-runtime-output-lint:");
+        if !is_autoresearch_file && !has_marker {
+            return Vec::new();
+        }
         let always_enforced =
             normalized_path.ends_with("examples/AutoResearch/AutoResearch.ino")
                 || normalized_path.contains("examples/AutoResearch/AutoResearchRemote");

--- a/ci/lint_cpp_rs/src/lint_core/tests.rs
+++ b/ci/lint_cpp_rs/src/lint_core/tests.rs
@@ -71,6 +71,34 @@ mod tests {
     }
 
     #[test]
+    fn autoresearch_runtime_output_marker_scope_can_protect_driver_cpp_hpp() {
+        let checker = AutoResearchRuntimeOutputChecker;
+        let path = "src/platforms/arm/teensy/teensy4_common/example.cpp.hpp";
+        assert!(checker.should_process_file(path, Path::new(".")));
+        let result = checker.check_file_content(&file(
+            path,
+            "// autoresearch-runtime-output-lint: begin\n\
+FL_WARN(\"driver chatter\");\n\
+FL_PRINT(\"driver chatter\");\n\
+Serial.printX(\"driver chatter\");\n\
+fl::serialPrintln(\"driver chatter\");\n\
+fl::serial_write(bytes, len);\n\
+// autoresearch-runtime-output-lint: end\n",
+        ));
+        assert_eq!(result.len(), 5);
+    }
+
+    #[test]
+    fn autoresearch_runtime_output_ignores_unmarked_non_autoresearch_files() {
+        let checker = AutoResearchRuntimeOutputChecker;
+        let result = checker.check_file_content(&file(
+            "src/platforms/arm/teensy/teensy4_common/example.cpp.hpp",
+            "FL_WARN(\"allowed outside an explicit protected span\");\n",
+        ));
+        assert!(result.is_empty());
+    }
+
+    #[test]
     fn autoresearch_runtime_output_allows_rpc_serial_boundary_only() {
         let checker = AutoResearchRuntimeOutputChecker;
         let result = checker.check_file_content(&file(

--- a/examples/AutoResearch/AutoResearch.ino
+++ b/examples/AutoResearch/AutoResearch.ino
@@ -106,8 +106,9 @@ void loop()  { autoResearchLowMemoryLoop(); }
 //    - DO NOT change "ERROR" to "FAIL", "WARNING", "FAILURE", or any other
 //      keyword to avoid test detection
 //    - DO NOT add FL_ERROR, FL_PRINT, FL_WARN, Serial.print*, fl::Serial.print*,
-//      fl::print*, fl::write_bytes, or fl::serial_print* runtime output in this
-//      sketch or lint-marked runtime sections. Use JSON-RPC / RESULT JSONL.
+//      fl::print*, fl::write_bytes, or fl::serial print/write/flush runtime
+//      output in this sketch or any `autoresearch-runtime-output-lint` section.
+//      fl::serial_begin/ready setup helpers are allowed. Use JSON-RPC / RESULT JSONL.
 //    - The "ERROR" keyword is INTENTIONAL and part of the autoresearch contract
 //
 // ✅ VALID MODIFICATIONS (only if explicitly requested):

--- a/src/platforms/arm/teensy/teensy4_common/clockless_objectfled.cpp.hpp
+++ b/src/platforms/arm/teensy/teensy4_common/clockless_objectfled.cpp.hpp
@@ -171,6 +171,7 @@ void ObjectFLEDGroupBase::addStrip(u8 pin, PixelIterator& pixel_iterator) {
     mPendingStrips.push_back(pending);
 }
 
+// autoresearch-runtime-output-lint: begin
 void ObjectFLEDGroupBase::flush() {
     if (mDrawn || mRectDrawBuffer.mDrawList.size() == 0) {
         return;  // Already drawn or no data
@@ -249,10 +250,6 @@ void ObjectFLEDGroupBase::rebuildObjectFLED() {
     int totalLeds = static_cast<int>(
             objectFledTotalLedsForRectangularBlock(num_strips, bytes_per_strip, hasRgbw));
 
-    #ifdef FASTLED_DEBUG_OBJECTFLED
-    FL_WARN_F("ObjectFLEDGroupBase: totalLeds=%s bytesPerStrip=%s frameBytes=%s", totalLeds, bytes_per_strip, frame_bytes);
-    #endif
-
     // Pass nullptr so ObjectFLED allocates frameBufferLocal internally
     auto* objectfled = new fl::ObjectFLED(  // ok bare allocation
         totalLeds,
@@ -271,6 +268,7 @@ void ObjectFLEDGroupBase::rebuildObjectFLED() {
     // Clear frameBufferLocal to zeros (for padding)
     fl::memset(objectfled->frameBufferLocal, 0, frame_bytes);
 }
+// autoresearch-runtime-output-lint: end
 
 } // namespace fl
 

--- a/src/platforms/arm/teensy/teensy4_common/drivers/objectfled/channel_engine_objectfled.cpp.hpp
+++ b/src/platforms/arm/teensy/teensy4_common/drivers/objectfled/channel_engine_objectfled.cpp.hpp
@@ -137,6 +137,7 @@ bool ChannelEngineObjectFLED::startNextTimingGroup() FL_NO_EXCEPT {
     return false;
 }
 
+// autoresearch-runtime-output-lint: begin
 bool ChannelEngineObjectFLED::startTimingGroup(TimingGroup& group) FL_NO_EXCEPT {
     RectangularDrawBuffer& drawBuf = group.drawBuffer;
     drawBuf.onQueuingStart();
@@ -240,6 +241,7 @@ bool ChannelEngineObjectFLED::startTimingGroup(TimingGroup& group) FL_NO_EXCEPT 
     group.instance->show();
     return true;
 }
+// autoresearch-runtime-output-lint: end
 
 IChannelDriver::DriverState ChannelEngineObjectFLED::poll() FL_NO_EXCEPT {
     if (mTransmittingChannels.empty()) {


### PR DESCRIPTION
## Summary

- Extend the scoped AutoResearch runtime-output checker so explicit `autoresearch-runtime-output-lint` spans can protect non-AutoResearch C++ files, including `.cpp.hpp` driver implementation files.
- Add focused Rust tests proving the guarded span rejects `FL_PRINT*`, `FL_WARN*`, `Serial.printX`, and `fl::serial*` output helpers.
- Mark ObjectFLED transmit paths as protected spans and remove a debug-only direct `FL_WARN_F` from the protected rebuild path.
- Clarify the AutoResearch sketch directive so setup-only `fl::serial_begin/ready` helpers remain allowed while runtime output goes through JSON-RPC / RESULT JSONL.

## Validation

- `soldr cargo test --manifest-path ci/lint_cpp_rs/Cargo.toml autoresearch_runtime_output -- --nocapture`
- `soldr cargo fmt --manifest-path ci/lint_cpp_rs/Cargo.toml -- --check`
- `soldr cargo run --manifest-path ci/lint_cpp_rs/Cargo.toml -- --checker autoresearch_runtime_output examples\AutoResearch src\platforms\arm\teensy\teensy4_common\clockless_objectfled.cpp.hpp src\platforms\arm\teensy\teensy4_common\drivers\objectfled\channel_engine_objectfled.cpp.hpp`
- `git diff --check`
- `bash lint --cpp`