### PR TITLE
[codex] Add explicit ObjectFLED channel pixel formats

### DIFF
--- a/src/fl/channels/channel.cpp.hpp
+++ b/src/fl/channels/channel.cpp.hpp
@@ -501,6 +501,13 @@ void Channel::showPixels(PixelController<RGB, 1, 0xFFFFFFFF> &pixels) {
     // Encode pixels based on chipset type
     auto& data = mChannelData->getData();
     data.clear();
+    if (mSettings.isRgbww()) {
+        mChannelData->setPixelFormat(ChannelPixelFormat::RGBWW);
+    } else if (mSettings.isRgbw()) {
+        mChannelData->setPixelFormat(ChannelPixelFormat::RGBW);
+    } else {
+        mChannelData->setPixelFormat(ChannelPixelFormat::RGB);
+    }
 
     if (mChipset.is<ClocklessChipset>()) {
         // Clockless chipsets: dispatch based on encoder type

--- a/src/fl/channels/data.cpp.hpp
+++ b/src/fl/channels/data.cpp.hpp
@@ -11,17 +11,21 @@ namespace fl {
 
 ChannelDataPtr ChannelData::create(
     const ChipsetVariant& chipset,
-    fl::vector_psram<u8>&& encodedData
+    fl::vector_psram<u8>&& encodedData,
+    ChannelPixelFormat pixelFormat
 ) FL_NO_EXCEPT {
-    return fl::make_shared<ChannelData>(chipset, fl::move(encodedData));
+    return fl::make_shared<ChannelData>(
+            chipset, fl::move(encodedData), pixelFormat);
 }
 
 ChannelDataPtr ChannelData::create(
     int pin,
     const ChipsetTimingConfig& timing,
-    fl::vector_psram<u8>&& encodedData
+    fl::vector_psram<u8>&& encodedData,
+    ChannelPixelFormat pixelFormat
 ) FL_NO_EXCEPT {
-    return fl::make_shared<ChannelData>(pin, timing, fl::move(encodedData));
+    return fl::make_shared<ChannelData>(
+            pin, timing, fl::move(encodedData), pixelFormat);
 }
 
 int ChannelData::getPin() const FL_NO_EXCEPT {
@@ -44,18 +48,22 @@ const ChipsetTimingConfig& ChannelData::getTiming() const FL_NO_EXCEPT {
 
 ChannelData::ChannelData(
     const ChipsetVariant& chipset,
-    fl::vector_psram<u8>&& encodedData
+    fl::vector_psram<u8>&& encodedData,
+    ChannelPixelFormat pixelFormat
 ) FL_NO_EXCEPT
     : mChipset(chipset)
+    , mPixelFormat(pixelFormat)
     , mEncodedData(fl::move(encodedData))
 {}
 
 ChannelData::ChannelData(
     int pin,
     const ChipsetTimingConfig& timing,
-    fl::vector_psram<u8>&& encodedData
+    fl::vector_psram<u8>&& encodedData,
+    ChannelPixelFormat pixelFormat
 ) FL_NO_EXCEPT
     : mChipset(ClocklessChipset(pin, timing))
+    , mPixelFormat(pixelFormat)
     , mEncodedData(fl::move(encodedData))
 {}
 

--- a/src/fl/channels/data.h
+++ b/src/fl/channels/data.h
@@ -17,6 +17,22 @@ namespace fl {
 class ChannelData;
 FASTLED_SHARED_PTR(ChannelData);
 
+/// @brief Pixel byte layout carried by encoded channel data.
+///
+/// ChannelData stores bytes that are already encoded for a driver. Consumers
+/// that need a bytes-per-pixel stride must use this metadata rather than
+/// guessing from total byte count.
+enum class ChannelPixelFormat : u8 {
+    Unknown = 0,
+    RGB = 3,
+    RGBW = 4,
+    RGBWW = 5,
+};
+
+inline u8 channelPixelFormatBytesPerPixel(ChannelPixelFormat format) FL_NO_EXCEPT {
+    return static_cast<u8>(format);
+}
+
 /// @brief Padding generator function type
 ///
 /// Called by writeWithPadding() to write source data with padding to destination buffer.
@@ -43,7 +59,8 @@ public:
     /// @param encodedData Encoded byte stream ready for transmission (defaults to empty)
     static ChannelDataPtr create(
         const ChipsetVariant& chipset,
-        fl::vector_psram<u8>&& encodedData = fl::vector_psram<u8>()
+        fl::vector_psram<u8>&& encodedData = fl::vector_psram<u8>(),
+        ChannelPixelFormat pixelFormat = ChannelPixelFormat::RGB
     ) FL_NO_EXCEPT;
 
     /// @brief Create channel transmission data (backwards compatibility)
@@ -54,7 +71,8 @@ public:
     static ChannelDataPtr create(
         int pin,
         const ChipsetTimingConfig& timing,
-        fl::vector_psram<u8>&& encodedData = fl::vector_psram<u8>()
+        fl::vector_psram<u8>&& encodedData = fl::vector_psram<u8>(),
+        ChannelPixelFormat pixelFormat = ChannelPixelFormat::RGB
     ) FL_NO_EXCEPT;
 
     /// @brief Get the GPIO pin number
@@ -78,6 +96,19 @@ public:
 
     /// @brief Get the encoded transmission data (mutable)
     fl::vector_psram<u8>& getData() FL_NO_EXCEPT { return mEncodedData; }
+
+    /// @brief Get explicit pixel byte layout for encoded data
+    ChannelPixelFormat getPixelFormat() const FL_NO_EXCEPT { return mPixelFormat; }
+
+    /// @brief Set explicit pixel byte layout for encoded data
+    void setPixelFormat(ChannelPixelFormat pixelFormat) FL_NO_EXCEPT {
+        mPixelFormat = pixelFormat;
+    }
+
+    /// @brief Get encoded bytes per pixel/element, or 0 if unknown
+    u8 getBytesPerPixel() const FL_NO_EXCEPT {
+        return channelPixelFormatBytesPerPixel(mPixelFormat);
+    }
 
     /// @brief Get the data size in bytes
     size_t getSize() const FL_NO_EXCEPT { return mEncodedData.size(); }
@@ -128,7 +159,8 @@ private:
     /// @brief Private constructor - variant-based (modern API)
     ChannelData(
         const ChipsetVariant& chipset,
-        fl::vector_psram<u8>&& encodedData
+        fl::vector_psram<u8>&& encodedData,
+        ChannelPixelFormat pixelFormat
     ) FL_NO_EXCEPT;
 
     /// @brief Private constructor - legacy API (backwards compatibility)
@@ -136,7 +168,8 @@ private:
     ChannelData(
         int pin,
         const ChipsetTimingConfig& timing,
-        fl::vector_psram<u8>&& encodedData
+        fl::vector_psram<u8>&& encodedData,
+        ChannelPixelFormat pixelFormat
     ) FL_NO_EXCEPT;
 
     // Non-copyable (move-only via shared_ptr)
@@ -144,6 +177,7 @@ private:
     ChannelData& operator=(const ChannelData&) FL_NO_EXCEPT = delete;
 
     ChipsetVariant mChipset;                ///< Chipset configuration (clockless or SPI)
+    ChannelPixelFormat mPixelFormat;        ///< Explicit byte layout for encoded data
     PaddingGenerator mPaddingGenerator;     ///< Optional padding generator for block-size alignment
     fl::vector_psram<u8> mEncodedData; ///< Encoded transmission bytes (PSRAM)
     volatile bool mInUse = false;           ///< Engine is transmitting this data (prevents creator updates)

--- a/src/platforms/arm/teensy/teensy4_common/drivers/objectfled/channel_engine_objectfled.cpp.hpp
+++ b/src/platforms/arm/teensy/teensy4_common/drivers/objectfled/channel_engine_objectfled.cpp.hpp
@@ -10,7 +10,6 @@
 #include "fl/log/log.h"
 #include "fl/log/log.h"
 #include "fl/stl/cstring.h"
-#include "fl/gfx/rectangular_draw_buffer.h"
 #include "fl/stl/noexcept.h"
 
 namespace fl {
@@ -27,9 +26,12 @@ static constexpr u32 kMaxPeriodNs = 2500;
 
 struct TimingGroup {
     ChipsetTimingConfig timing;
+    ChannelPixelFormat pixelFormat = ChannelPixelFormat::RGB;
     fl::vector<ChannelDataPtr> channels;
-    RectangularDrawBuffer drawBuffer;
     fl::unique_ptr<IObjectFLEDInstance> instance;
+    fl::FixedVector<u8, 50> pinList;
+    u32 bytesPerStrip = 0;
+    bool isRgbw = false;
 
     TimingGroup() = default;
     ~TimingGroup() = default;
@@ -38,6 +40,24 @@ struct TimingGroup {
     TimingGroup(const TimingGroup&) = delete;
     TimingGroup& operator=(const TimingGroup&) = delete;
 };
+
+static bool objectFledSupportsPixelFormat(ChannelPixelFormat format) FL_NO_EXCEPT {
+    return format == ChannelPixelFormat::RGB ||
+           format == ChannelPixelFormat::RGBW;
+}
+
+static bool pinsEqual(const fl::FixedVector<u8, 50>& a,
+                      const fl::FixedVector<u8, 50>& b) FL_NO_EXCEPT {
+    if (a.size() != b.size()) {
+        return false;
+    }
+    for (fl::size i = 0; i < a.size(); i++) {
+        if (a[i] != b[i]) {
+            return false;
+        }
+    }
+    return true;
+}
 
 // ============================================================================
 // ChannelEngineObjectFLED Implementation
@@ -60,6 +80,9 @@ ChannelEngineObjectFLED::~ChannelEngineObjectFLED() {
 
 bool ChannelEngineObjectFLED::canHandle(const ChannelDataPtr& data) const FL_NO_EXCEPT {
     if (!data || !data->isClockless()) {
+        return false;
+    }
+    if (!objectFledSupportsPixelFormat(data->getPixelFormat())) {
         return false;
     }
     const u32 period = data->getTiming().total_period_ns();
@@ -100,9 +123,10 @@ void ChannelEngineObjectFLED::show() FL_NO_EXCEPT {
     // Assign channels to existing groups or create new ones
     for (auto& ch : mTransmittingChannels) {
         const ChipsetTimingConfig& timing = ch->getTiming();
+        const ChannelPixelFormat pixelFormat = ch->getPixelFormat();
         TimingGroup* found = nullptr;
         for (auto& g : mTimingGroups) {
-            if (g->timing == timing) {
+            if (g->timing == timing && g->pixelFormat == pixelFormat) {
                 found = g.get();
                 break;
             }
@@ -110,6 +134,7 @@ void ChannelEngineObjectFLED::show() FL_NO_EXCEPT {
         if (!found) {
             auto newGroup = fl::make_unique<TimingGroup>();
             newGroup->timing = timing;
+            newGroup->pixelFormat = pixelFormat;
             found = newGroup.get();
             mTimingGroups.push_back(fl::move(newGroup));
         }
@@ -139,10 +164,17 @@ bool ChannelEngineObjectFLED::startNextTimingGroup() FL_NO_EXCEPT {
 
 // autoresearch-runtime-output-lint: begin
 bool ChannelEngineObjectFLED::startTimingGroup(TimingGroup& group) FL_NO_EXCEPT {
-    RectangularDrawBuffer& drawBuf = group.drawBuffer;
-    drawBuf.onQueuingStart();
+    if (!objectFledSupportsPixelFormat(group.pixelFormat)) {
+        return false;
+    }
 
-    // Queue all channels in this group
+    const bool isRgbw = group.pixelFormat == ChannelPixelFormat::RGBW;
+    const u32 bytesPerLed = objectFledBytesPerLed(isRgbw);
+    fl::FixedVector<u8, 50> pinList;
+    fl::vector<ChannelDataPtr> validChannels;
+    u32 maxDataBytes = 0;
+
+    // Collect valid channels and compute the raw rectangular byte stride.
     for (auto& ch : group.channels) {
         const u8 pin = static_cast<u8>(ch->getPin());
 
@@ -153,89 +185,71 @@ bool ChannelEngineObjectFLED::startTimingGroup(TimingGroup& group) FL_NO_EXCEPT 
             continue;
         }
 
-        // Determine bytes per LED from data size and pin count
         const auto& data = ch->getData();
         const size_t dataSize = data.size();
-
-        // Determine if RGBW: data size must be divisible by 4 but not 3,
-        // or divisible by both but 4 gives an integer LED count matching 3's
-        // Simple heuristic: if dataSize % 4 == 0 and dataSize % 3 != 0 -> RGBW
-        // Otherwise RGB
-        bool isRgbw = (dataSize % 4 == 0) && (dataSize % 3 != 0);
-        int bytesPerLed = isRgbw ? 4 : 3;
-        u16 numLeds = static_cast<u16>(dataSize / bytesPerLed);
-
-        drawBuf.queue(DrawItem(pin, numLeds, isRgbw));
-    }
-    drawBuf.onQueuingDone();
-
-    // Copy raw RGB bytes from ChannelData into the draw buffer
-    for (auto& ch : group.channels) {
-        const u8 pin = static_cast<u8>(ch->getPin());
-        auto validation = mPeripheral->validatePin(pin);
-        if (!validation.valid) {
-            continue;
+        if (dataSize > maxDataBytes) {
+            maxDataBytes = static_cast<u32>(dataSize);
         }
-
-        fl::span<u8> stripBytes = drawBuf.getLedsBufferBytesForPin(pin, true);
-        const auto& srcData = ch->getData();
-        const size_t copySize = (srcData.size() < stripBytes.size())
-                                  ? srcData.size()
-                                  : stripBytes.size();
-        if (copySize > 0) {
-            fl::memcpy(stripBytes.data(), srcData.data(), copySize);
+        if (pinList.size() < pinList.capacity()) {
+            pinList.push_back(pin);
+            validChannels.push_back(ch);
         }
     }
 
-    // Build/rebuild ObjectFLED instance only when draw list changes
-    bool drawListChanged = drawBuf.mDrawListChangedThisFrame;
-    if (drawListChanged || !group.instance) {
+    if (pinList.empty()) {
+        return false;
+    }
+
+    const u32 ledsPerStrip =
+            objectFledLedsPerStripForRectangularBytes(maxDataBytes, isRgbw);
+    const u32 bytesPerStrip = ledsPerStrip * bytesPerLed;
+    const bool layoutChanged =
+            !group.instance ||
+            group.bytesPerStrip != bytesPerStrip ||
+            group.isRgbw != isRgbw ||
+            !pinsEqual(group.pinList, pinList);
+
+    if (layoutChanged) {
         group.instance.reset();
 
-        // Build pin list
-        fl::FixedVector<u8, 50> pinList;
-        bool hasRgbw = false;
-        for (const auto& item : drawBuf.mDrawList) {
-            pinList.push_back(item.mPin);
-            if (item.mIsRgbw) {
-                hasRgbw = true;
-            }
-        }
-
-        if (pinList.empty()) {
-            return false;  // All pins invalid, skip this group
-        }
-
-        u32 num_strips = 0;
-        u32 bytes_per_strip = 0;
-        u32 total_bytes = 0;
-        drawBuf.getBlockInfo(&num_strips, &bytes_per_strip, &total_bytes);
-
         int totalLeds = static_cast<int>(
-            objectFledTotalLedsForRectangularBlock(
-                num_strips, bytes_per_strip, hasRgbw));
+            ledsPerStrip * static_cast<u32>(pinList.size()));
 
         group.instance = mPeripheral->createInstance(
-            totalLeds, hasRgbw, pinList.size(), pinList.data(),
+            totalLeds, isRgbw, pinList.size(), pinList.data(),
             group.timing.t1_ns, group.timing.t2_ns,
             group.timing.t3_ns, group.timing.reset_us
         );
+        if (group.instance) {
+            group.pinList = pinList;
+            group.bytesPerStrip = bytesPerStrip;
+            group.isRgbw = isRgbw;
+        }
     }
 
     if (!group.instance) {
         return false;  // createInstance failed
     }
 
-    // Copy draw buffer into instance's frame buffer
-    u32 totalBytes = drawBuf.getTotalBytes();
     u32 frameBufferSize = group.instance->getFrameBufferSize();
-    u32 copyBytes = totalBytes < frameBufferSize ? totalBytes : frameBufferSize;
-    if (copyBytes > 0) {
-        fl::memcpy(
-            group.instance->getFrameBuffer(),
-            drawBuf.mAllLedsBufferUint8.get(),
-            copyBytes
-        );
+    u8* frameBuffer = group.instance->getFrameBuffer();
+    if (frameBuffer && frameBufferSize > 0) {
+        fl::memset(frameBuffer, 0, frameBufferSize);
+        for (fl::size i = 0; i < validChannels.size(); i++) {
+            const auto& srcData = validChannels[i]->getData();
+            const u32 dstOffset = static_cast<u32>(i) * bytesPerStrip;
+            if (dstOffset >= frameBufferSize) {
+                continue;
+            }
+            const u32 dstRemaining = frameBufferSize - dstOffset;
+            const u32 copyBytes =
+                    static_cast<u32>(srcData.size()) < dstRemaining
+                            ? static_cast<u32>(srcData.size())
+                            : dstRemaining;
+            if (copyBytes > 0) {
+                fl::memcpy(frameBuffer + dstOffset, srcData.data(), copyBytes);
+            }
+        }
     }
 
     group.instance->show();

--- a/src/platforms/arm/teensy/teensy4_common/drivers/objectfled/channel_engine_objectfled.h
+++ b/src/platforms/arm/teensy/teensy4_common/drivers/objectfled/channel_engine_objectfled.h
@@ -5,8 +5,10 @@
 /// ObjectFLED's show() starts DMA and returns while output/latch timing may
 /// still be active, so poll() owns the DRAINING -> READY transition.
 ///
-/// Data format: ChannelData contains raw RGB/RGBW bytes (from ws2812 encoder),
-/// which is exactly what ObjectFLED expects in its frameBufferLocal.
+/// Data format: ChannelData contains raw RGB/RGBW bytes (from the WS2812
+/// encoder) plus explicit ChannelPixelFormat metadata. The engine uses that
+/// metadata for ObjectFLED's raw frameBufferLocal layout; it does not infer
+/// RGBW from byte counts.
 
 #pragma once
 

--- a/tests/fl/channels/data.cpp
+++ b/tests/fl/channels/data.cpp
@@ -75,6 +75,20 @@ void ucs7604PaddingGenerator(fl::span<const uint8_t> src, fl::span<uint8_t> dst)
 
 } // anonymous namespace
 
+FL_TEST_CASE("ChannelData carries explicit pixel format metadata") {
+    auto timing = ChipsetTimingConfig(800, 450, 450, 50, "WS2812");
+    fl::vector_psram<uint8_t> encoded(12);
+    auto channelData = ChannelData::create(
+        5, timing, fl::move(encoded), ChannelPixelFormat::RGBW);
+
+    FL_CHECK(channelData->getPixelFormat() == ChannelPixelFormat::RGBW);
+    FL_CHECK(channelData->getBytesPerPixel() == 4);
+
+    channelData->setPixelFormat(ChannelPixelFormat::RGB);
+    FL_CHECK(channelData->getPixelFormat() == ChannelPixelFormat::RGB);
+    FL_CHECK(channelData->getBytesPerPixel() == 3);
+}
+
 FL_TEST_CASE("writeWithPadding - no padding generator, exact size") {
     auto timing = ChipsetTimingConfig(800, 450, 450, 50, "WS2812");
     auto channelData = ChannelData::create(5, timing);

--- a/tests/platforms/arm/teensy/teensy4_common/drivers/objectfled/channel_engine_objectfled.cpp
+++ b/tests/platforms/arm/teensy/teensy4_common/drivers/objectfled/channel_engine_objectfled.cpp
@@ -57,7 +57,8 @@ ChannelDataPtr createRGBWChannelData(int pin, size_t num_leds,
             encoded[i] = rgbw_data[i];
         }
     }
-    return ChannelData::create(pin, t, fl::move(encoded));
+    return ChannelData::create(
+        pin, t, fl::move(encoded), ChannelPixelFormat::RGBW);
 }
 
 } // anonymous namespace
@@ -310,6 +311,30 @@ FL_TEST_CASE("ObjectFLED engine - detects RGBW data") {
     FL_CHECK(record->isRgbw == true);
 }
 
+FL_TEST_CASE("ObjectFLED engine - explicit RGB metadata wins over 12-byte size") {
+    auto mock = fl::make_shared<ObjectFLEDPeripheralMock>();
+    ChannelEngineObjectFLED engine(mock);
+
+    uint8_t rgb[] = {
+        0x10, 0x11, 0x12,
+        0x20, 0x21, 0x22,
+        0x30, 0x31, 0x32,
+        0x40, 0x41, 0x42,
+    };
+    auto ch = createRGBChannelData(2, 4, rgb);
+
+    engine.enqueue(ch);
+    engine.show();
+
+    auto* record = mock->getLastCreateRecord();
+    auto* inst = mock->getLastInstance();
+    FL_REQUIRE(record != nullptr);
+    FL_REQUIRE(inst != nullptr);
+    FL_CHECK(record->isRgbw == false);
+    FL_CHECK(record->totalLeds == 4);
+    FL_CHECK(inst->getFrameBufferSize() == 12);
+}
+
 FL_TEST_CASE("ObjectFLED rectangular sizing rounds RGBW small counts") {
     struct Case {
         u16 leds;
@@ -345,15 +370,18 @@ FL_TEST_CASE("ObjectFLED rectangular sizing rounds RGBW small counts") {
     }
 }
 
-FL_TEST_CASE("ObjectFLED engine - RGBW small counts allocate padding") {
+FL_TEST_CASE("ObjectFLED engine - RGBW raw channel counts use exact byte layout") {
     struct Case {
         size_t leds;
         u32 expectedFrameBytes;
     };
     const Case cases[] = {
-        {1, 12},
-        {2, 12},
-        {4, 20},
+        {1, 4},
+        {2, 8},
+        {3, 12},
+        {4, 16},
+        {6, 24},
+        {9, 36},
     };
 
     for (const auto& c : cases) {
@@ -369,8 +397,38 @@ FL_TEST_CASE("ObjectFLED engine - RGBW small counts allocate padding") {
         FL_REQUIRE(inst != nullptr);
         FL_REQUIRE(record != nullptr);
         FL_CHECK(record->isRgbw == true);
+        FL_CHECK(record->totalLeds == static_cast<int>(c.leds));
         FL_CHECK(inst->getFrameBufferSize() == c.expectedFrameBytes);
     }
+}
+
+FL_TEST_CASE("ObjectFLED engine - RGBW raw channel preserves nonzero white") {
+    auto mock = fl::make_shared<ObjectFLEDPeripheralMock>();
+    ChannelEngineObjectFLED engine(mock);
+
+    uint8_t rgbw[] = {
+        0x01, 0x02, 0x03, 0xA5,
+        0x04, 0x05, 0x06, 0xB6,
+        0x07, 0x08, 0x09, 0xC7,
+    };
+    auto ch = createRGBWChannelData(22, 3, rgbw);
+
+    engine.enqueue(ch);
+    engine.show();
+
+    auto* record = mock->getLastCreateRecord();
+    auto* inst = mock->getLastInstance();
+    FL_REQUIRE(record != nullptr);
+    FL_REQUIRE(inst != nullptr);
+    FL_CHECK(record->isRgbw == true);
+    FL_CHECK(record->totalLeds == 3);
+    FL_CHECK(inst->getFrameBufferSize() == 12);
+
+    const auto& frameData = inst->getRawBuffer();
+    FL_REQUIRE(frameData.size() == 12);
+    FL_CHECK(frameData[3] == 0xA5);
+    FL_CHECK(frameData[7] == 0xB6);
+    FL_CHECK(frameData[11] == 0xC7);
 }
 
 //=============================================================================

--- a/tests/platforms/esp/32/drivers/uart/channel_driver_uart.cpp
+++ b/tests/platforms/esp/32/drivers/uart/channel_driver_uart.cpp
@@ -194,7 +194,8 @@ public:
         for (size_t i = 0; i < encodedData.size(); i++) {
             encodedData[i] = static_cast<uint8_t>(i);
         }
-        return fl::make_shared<ChannelData>(pin, timing, fl::move(encodedData));
+        return fl::make_shared<ChannelData>(
+                pin, timing, fl::move(encodedData), ChannelPixelFormat::RGB);
     }
 
     bool pollUntilReady(uint32_t timeout_ms = 1000) {
@@ -1068,7 +1069,8 @@ FL_TEST_CASE("ChannelEngineUART - Edge cases") {
     FL_SUBCASE("Empty channel (0 LEDs)") {
         ChipsetTimingConfig timing(WS2812_T0H, WS2812_T0L, WS2812_T1H, WS2812_T1L);
         fl::vector_psram<uint8_t> emptyData;
-        auto data = fl::make_shared<ChannelData>(17, timing, fl::move(emptyData));
+        auto data = fl::make_shared<ChannelData>(
+                17, timing, fl::move(emptyData), ChannelPixelFormat::RGB);
         fixture.mDriver.enqueue(data);
         fixture.mDriver.show();
         FL_CHECK(fixture.mDriver.poll() == IChannelDriver::DriverState::READY);
@@ -1135,7 +1137,8 @@ FL_TEST_CASE("ChannelEngineUART - canHandle validates timing") {
         // TM1829-1600k: T1=100, T2=300, T3=200, period=600ns → 8.3 Mbps
         ChipsetTimingConfig timing(100, 300, 200, 500);
         fl::vector_psram<uint8_t> data(30);
-        auto ch = fl::make_shared<ChannelData>(17, timing, fl::move(data));
+        auto ch = fl::make_shared<ChannelData>(
+                17, timing, fl::move(data), ChannelPixelFormat::RGB);
         FL_CHECK_FALSE(fixture.mDriver.canHandle(ch));
     }
 }


### PR DESCRIPTION
## Summary

- Add explicit `ChannelPixelFormat` metadata to `ChannelData` and set it from `Channel::showPixels()` based on RGB/RGBW/RGBWW channel settings.
- Update the Teensy ObjectFLED channel engine to group by timing plus explicit pixel format, rejecting unsupported formats instead of inferring RGBW from total byte count.
- Copy encoded channel bytes directly into ObjectFLED's raw frame buffer for RGB and RGBW, preserving nonzero W bytes and avoiding RGBW re-interpretation.
- Add unit coverage for ambiguous 12-byte RGB data, exact RGBW 1/2/3/4/6/9-pixel layouts, and W-channel preservation.

## Validation

- `git diff --check`
- `bash test --unit --no-fingerprint` (254/254 passed)
- `bash lint --cpp` (passed; existing PlatformIO-internal-usage warnings remain warn-only)
- `bash autoresearch teensy41 --object-fled --tx-pin 22 --rx-pin 8 --timeout 120 --skip-lint`
  - build/deploy succeeded through fbuild on `COM20`
  - GPIO pre-test passed for `TX 22 -> RX 8`
  - ObjectFLED still fails as `zero_capture`: RX captured `0/300` bytes while ObjectFLED diagnostics show DMA started/drained (`dma.numbytes=300`, `framebufferIndex=300`)

Hardware acceptance is intentionally not claimed by this PR.