### PR TITLE
[codex] Harden ObjectFLED ownership and test paths

### DIFF
--- a/src/third_party/object_fled/src/ObjectFLED.h
+++ b/src/third_party/object_fled/src/ObjectFLED.h
@@ -99,6 +99,12 @@ namespace fl {
 //Usage: ObjectFLED myCube ( Num_LEDs, *drawBuffer, LED_type, numPins, *pinList, serpentineNumber )
 class ObjectFLED {
 public:
+	// Teensy 4.x hardware ownership:
+	// ObjectFLED owns QTimer4 channels 0-2, XBAR1 DMA request outputs 30/31/94,
+	// the corresponding DMAMUX requests, its allocated DMA channels, and the
+	// selected pins' standard GPIO aliases while an instance is active. It does
+	// not restore prior owners for those resources; conflicting peripherals must
+	// be treated as unsupported while ObjectFLED is in use.
 	// Usage: ObjectFLED myCube ( Num_LEDs, *drawBuffer, LED_type, numPins, *pinList, serpentineNumber )
 	// Example:
     // byte pinList[NUM_CHANNELS] = {1, 8, 14, 17, 24, 29, 20, 0, 15, 16, 18, 19, 21, 22, 23, 25};
@@ -202,6 +208,7 @@ private:
 	uint32_t numbytesLocal;
 	uint8_t pin_bitnumLocal[NUM_DIGITAL_PINS];
 	uint8_t pin_offsetLocal[NUM_DIGITAL_PINS];
+	bool initialized = false;
 };	// class ObjectFLED
 
 

--- a/src/third_party/object_fled/src/OjectFLED.cpp.hpp
+++ b/src/third_party/object_fled/src/OjectFLED.cpp.hpp
@@ -111,6 +111,45 @@ static void force_pin_to_gpio_mux(uint8_t pin) {
 	*portConfigRegister(pin) = 5 | 0x10;
 }
 
+static void configure_objectfled_xbar_dma_edges() {
+	// XBAR CTRL registers hold two request-control slots each. STS bits are
+	// write-one-to-clear, so keep non-owned STS bits at zero while preserving
+	// their edge/interrupt/DMA enable settings.
+	constexpr uint16_t ctrl0ConfigMask =
+		XBARA_CTRL_EDGE0(3) | XBARA_CTRL_DEN0 |
+		XBARA_CTRL_EDGE1(3) | XBARA_CTRL_DEN1;
+	constexpr uint16_t ctrl1ConfigMask =
+		XBARA_CTRL_EDGE0(3) | XBARA_CTRL_DEN0;
+
+	uint16_t ctrl0 = XBARA1_CTRL0;
+	ctrl0 &= ~(ctrl0ConfigMask | XBARA_CTRL_STS0 | XBARA_CTRL_STS1);
+	ctrl0 |= XBARA_CTRL_STS1 | XBARA_CTRL_EDGE1(3) | XBARA_CTRL_DEN1 |
+			 XBARA_CTRL_STS0 | XBARA_CTRL_EDGE0(3) | XBARA_CTRL_DEN0;
+	XBARA1_CTRL0 = ctrl0;
+
+	uint16_t ctrl1 = XBARA1_CTRL1;
+	ctrl1 &= ~(ctrl1ConfigMask | XBARA_CTRL_STS0 | XBARA_CTRL_STS1);
+	ctrl1 |= XBARA_CTRL_STS0 | XBARA_CTRL_EDGE0(3) | XBARA_CTRL_DEN0;
+	XBARA1_CTRL1 = ctrl1;
+}
+
+static void clear_objectfled_xbar_dma_status() {
+	uint16_t ctrl0 = XBARA1_CTRL0;
+	ctrl0 &= ~(XBARA_CTRL_STS0 | XBARA_CTRL_STS1);
+	XBARA1_CTRL0 = ctrl0 | XBARA_CTRL_STS1 | XBARA_CTRL_STS0;
+
+	uint16_t ctrl1 = XBARA1_CTRL1;
+	ctrl1 &= ~(XBARA_CTRL_STS0 | XBARA_CTRL_STS1);
+	XBARA1_CTRL1 = ctrl1 | XBARA_CTRL_STS0;
+}
+
+static bool objectfled_has_dma_tcds(const ObjectFLEDDmaManager& dma) {
+	return dma.dma1.TCD != nullptr &&
+		   dma.dma2.TCD != nullptr &&
+		   dma.dma3.TCD != nullptr &&
+		   dma.dma2next.TCD != nullptr;
+}
+
 
 void ObjectFLED::begin(uint16_t latchDelay) {
 	LATCH_DELAY = latchDelay;
@@ -144,6 +183,7 @@ void ObjectFLED::beginInternal(uint16_t period, uint16_t t0h, uint16_t t1h, uint
 // init timers, xbar to DMA, DMA bitdata -> GPIOR; clears frameBuffer (total LEDs * 3 bytes)
 void ObjectFLED::begin(void) {
 	auto& dma = ObjectFLEDDmaManager::getInstance();
+	initialized = false;
 
 	// Set each pin's bitmask bit, store offset & bit# for pin
 	uint32_t tempBitmask[4] = {0};
@@ -202,6 +242,7 @@ void ObjectFLED::begin(void) {
 		FL_WARN_F("All %s pins failed validation.", (int)numpinsLocal);
 		FL_WARN_F("ObjectFLED driver is disabled - no LEDs will be updated.");
 		FL_WARN_F("================================================================================");
+		numpinsLocal = 0;
 		return;
 	}
 
@@ -247,12 +288,18 @@ void ObjectFLED::begin(void) {
 	xbar_connect(XBARA1_IN_QTIMER4_TIMER0, XBARA1_OUT_DMA_CH_MUX_REQ30);	
 	xbar_connect(XBARA1_IN_QTIMER4_TIMER1, XBARA1_OUT_DMA_CH_MUX_REQ31);
 	xbar_connect(XBARA1_IN_QTIMER4_TIMER2, XBARA1_OUT_DMA_CH_MUX_REQ94);
-	XBARA1_CTRL0 = XBARA_CTRL_STS1 | XBARA_CTRL_EDGE1(3) | XBARA_CTRL_DEN1 |
-					XBARA_CTRL_STS0 | XBARA_CTRL_EDGE0(3) | XBARA_CTRL_DEN0;
-	XBARA1_CTRL1 = XBARA_CTRL_STS0 | XBARA_CTRL_EDGE0(3) | XBARA_CTRL_DEN0;
 
 	// configure DMA channels
 	dma.dma1.begin();
+	dma.dma2.begin();
+	dma.dma3.begin();
+	if (!objectfled_has_dma_tcds(dma)) {
+		numpinsLocal = 0;
+		return;
+	}
+
+	configure_objectfled_xbar_dma_edges();
+
 	dma.dma1.TCD->SADDR = dma.bitmask;					// source 4*32b GPIO pin mask
 	dma.dma1.TCD->SOFF = 8;								// bytes offset added to SADDR after each transfer
 	// SMOD(4) low bits of SADDR to update with adds of SOFF
@@ -284,12 +331,10 @@ void ObjectFLED::begin(void) {
 	dma.dma2next.TCD->BITER_ELINKNO = BYTES_PER_DMA * 8;
 	dma.dma2next.TCD->CSR = 0;
 
-	dma.dma2.begin();
 	dma.dma2 = dma.dma2next; // copies TCD
 	dma.dma2.triggerAtHardwareEvent(DMAMUX_SOURCE_XBAR1_1);
 	dma.dma2.attachInterrupt(isr);
 
-	dma.dma3.begin();
 	dma.dma3.TCD->SADDR = dma.bitmask;
 	dma.dma3.TCD->SOFF = 8;
 	dma.dma3.TCD->ATTR = DMA_TCD_ATTR_SSIZE(3) | DMA_TCD_ATTR_SMOD(4) | DMA_TCD_ATTR_DSIZE(2);
@@ -304,6 +349,7 @@ void ObjectFLED::begin(void) {
 	dma.dma3.TCD->BITER_ELINKNO = numbytesLocal * 8;
 	dma.dma3.TCD->CSR = DMA_TCD_CSR_DREQ | DMA_TCD_CSR_DONE;
 	dma.dma3.triggerAtHardwareEvent(DMAMUX_SOURCE_XBAR1_2);
+	initialized = true;
 }	// begin()
 
 
@@ -489,6 +535,10 @@ void ObjectFLED::showRawFrameBuffer(void) {
 }
 
 void ObjectFLED::showInternal(bool regenerateFrameBuffer) {
+	if (!initialized || numpinsLocal == 0 || frameBufferLocal == nullptr) {
+		return;
+	}
+
 	auto& dma = ObjectFLEDDmaManager::getInstance();
 
 	// Acquire DMA (blocks if another instance transmitting)
@@ -531,8 +581,7 @@ void ObjectFLED::showInternal(bool regenerateFrameBuffer) {
 	TMR4_SCTRL2 = TMR_SCTRL_OEN | TMR_SCTRL_FORCE;
 
 	// clear any prior pending DMA requests
-	XBARA1_CTRL0 |= XBARA_CTRL_STS1 | XBARA_CTRL_STS0;
-	XBARA1_CTRL1 |= XBARA_CTRL_STS0;
+	clear_objectfled_xbar_dma_status();
 
 	// fill the DMA transmit buffer
 	memset(dma.bitdata, 0, sizeof(dma.bitdata));	//BYTES_PER_DMA * 64 words32
@@ -638,6 +687,9 @@ void ObjectFLED::isr(void)
 
 int ObjectFLED::busy(void)
 {
+	if (!initialized) {
+		return 0;
+	}
 	auto& dma = ObjectFLEDDmaManager::getInstance();
 	if (micros() - update_begin_micros < dma.numbytes * TH_TL / 1000 * 8 + LATCH_DELAY) {
 		return 1;
@@ -726,8 +778,10 @@ void drawSquare(void* leds, uint16_t planeY, uint16_t planeX, int yCorner, int x
 
 ObjectFLED::~ObjectFLED() {
 	// Wait for prior xmission to end, don't need to wait for latch time before deleting buffer
-	while (micros() - update_begin_micros < numbytesLocal * 8 * TH_TL / 1000 + 5);
-	waitForDmaToFinish();
+	if (initialized) {
+		while (micros() - update_begin_micros < numbytesLocal * 8 * TH_TL / 1000 + 5);
+		waitForDmaToFinish();
+	}
 	delete[] frameBufferLocal;
 }
 

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -31,6 +31,7 @@ test_abs_include_args = [
 # chain with "module file has a different size or modification time than expected".
 # Instead, test_pch.h directly #includes FastLED.h, making this PCH self-contained.
 cpp_compiler = meson.get_compiler('cpp')
+test_pch_input_abs = path_norm_root + '/tests/test_pch.h'
 test_pch = custom_target('test_pch',
   input: 'test_pch.h',
   output: 'test_pch.h.pch',      # Only PCH is an output; .d file is depfile only
@@ -41,7 +42,7 @@ test_pch = custom_target('test_pch',
     cpp_compiler.cmd_array(),
     '-c',                          # Suppress linker step (MinGW driver adds link job without -c)
     '-x', 'c++-header',           # Treat input as C++ header
-    '@INPUT@',                     # test_pch.h
+    test_pch_input_abs,            # Canonical absolute forward-slash spelling
     '-o', '@OUTPUT@',              # test_pch.h.pch
     '-MD', '-MF', '@DEPFILE@',     # Generate dependency file (will be fixed by wrapper)
     unit_test_compile_args,        # Same flags as all tests
@@ -177,7 +178,12 @@ shared_test_cpp_args = test_abs_include_args + unit_test_compile_args + [
 ]
 
 test_shared_objs_lib = static_library('test_shared_objs',
-  ['doctest_main.cpp', 'shared/fl_unittest.cpp', 'misc' / 'coroutine_impl.cpp', test_pch],
+  [
+    path_norm_root + '/tests/doctest_main.cpp',
+    path_norm_root + '/tests/shared/fl_unittest.cpp',
+    path_norm_root + '/tests/misc/coroutine_impl.cpp',
+    test_pch,
+  ],
   cpp_args: shared_test_cpp_args,
   pic: true,
   implicit_include_directories: false,
@@ -192,8 +198,9 @@ foreach test_name : test_names
 
   # Test sources: only the unique test file + PCH dependency
   # doctest_main.cpp and fl_unittest.cpp are pre-compiled in shared_test_objects
+  test_source_abs = path_norm_root + '/tests/' + test_file
   test_sources = [
-    test_file,
+    test_source_abs,
     test_pch,
   ]
   test_cpp_args = shared_test_cpp_args


### PR DESCRIPTION
## Summary
- document ObjectFLED as an exclusive owner of its Teensy4 timer/XBAR/DMAMUX/DMA/GPIO resources while active
- mask XBAR control/status updates so ObjectFLED no longer clobbers unrelated XBAR slots
- guard DMA/TCD allocation before programming transfer descriptors and make show/busy no-op when init failed
- canonicalize Meson PCH and test source paths on Windows instead of adding a second include guard to `data.h`

## Validation
- `git diff --check teensy-fix...HEAD`
- `bash test --unit --no-fingerprint` -> PASS 254/254
- `bash lint --cpp` -> PASS; existing PlatformIO usage backlog remains warn-only
- `bash autoresearch teensy41 --object-fled --tx-pin 22 --rx-pin 8 --timeout 120 --skip-lint` -> deploy + GPIO pre-test PASS, ObjectFLED still FAIL `zero_capture`

## AutoResearch signal
- Confirmed soldered loopback: `TX 22 -> RX 8`
- AutoResearch used the fbuild serial adapter on COM20; no manual serial utility used
- ObjectFLED DMA advanced to `framebufferIndex=300` for `numbytes=300` and returned ready
- RX captured `0/300` bytes, so this is not hardware acceptance