### PR TITLE
Revert "fix(objectfled): GPIO alias diagnostics (#3389)"

### DIFF
--- a/ci/autoresearch/context.py
+++ b/ci/autoresearch/context.py
@@ -264,12 +264,6 @@ def display_pattern_details(result: dict[str, Any]) -> None:
         mismatched_bytes = pat.get("mismatchedBytes", 0)
         lsb_only = pat.get("lsbOnlyErrors", 0)
         captured_bytes = pat.get("capturedBytes")
-        capture_wait = pat.get("captureWaitResult")
-        raw_edges = pat.get("rawEdgesAfterWait")
-        decode_ok = pat.get("decodeOk")
-        decode_error = pat.get("decodeError")
-        decode_bytes = pat.get("decodeBytes")
-        decode_capacity = pat.get("decodeOutputCapacity")
         capture_failed = bool(pat.get("captureFailed", False))
 
         agg_total_bytes += total_bytes
@@ -282,21 +276,6 @@ def display_pattern_details(result: dict[str, Any]) -> None:
         print(f"    Mismatched LEDs:  {mismatched_leds}/{num_leds}")
         if captured_bytes is not None:
             print(f"    Captured bytes:   {captured_bytes}/{total_bytes}")
-        if capture_wait is not None or raw_edges is not None:
-            print(f"    RX wait/raw:      {capture_wait}/{raw_edges}")
-        if (
-            decode_ok is not None
-            or decode_error is not None
-            or decode_bytes is not None
-            or decode_capacity is not None
-        ):
-            print(
-                "    Decode status:    "
-                f"ok={decode_ok} error={decode_error} bytes={decode_bytes}/{decode_capacity}"
-            )
-        raw_sample = pat.get("rawEdgeSample")
-        if raw_sample:
-            print(f"    Raw sample:       {raw_sample}")
         if capture_failed:
             print(f"    Capture status:   RX produced no decodable bytes")
         print(
@@ -385,53 +364,6 @@ def display_objectfled_diagnostics(result: dict[str, Any]) -> None:
     print("  ObjectFLED diagnostics")
     print(f"    format: {fmt}")
     print(f"    events: {event_count}, overflow: {overflow_count}")
-    probe = result.get("objectFledStandardGpioProbe")
-    if isinstance(probe, dict):
-        connected = probe.get("connected", "?")
-        low = probe.get("rxWhenStandardLow", "?")
-        high = probe.get("rxWhenStandardHigh", "?")
-        offset = probe.get("offset", "?")
-        bit = probe.get("bit", "?")
-        print(
-            "    standard GPIO probe: "
-            f"connected={connected} rxLow={low} rxHigh={high} "
-            f"offset={offset} bit={bit}"
-        )
-    rx_probe = result.get("objectFledRxCaptureProbe")
-    if isinstance(rx_probe, dict):
-        captured = rx_probe.get("captured", "?")
-        raw_edges = rx_probe.get("rawEdges", "?")
-        engine = rx_probe.get("engine", "?")
-        wait_result = rx_probe.get("waitResult", "?")
-        print(
-            "    RX capture probe: "
-            f"engine={engine} waitResult={wait_result} "
-            f"captured={captured} rawEdges={raw_edges}"
-        )
-        rx_diag = rx_probe.get("diagnosticsAfterWait")
-        if isinstance(rx_diag, dict):
-            mux = rx_diag.get("muxRegisterValue", "?")
-            mux_expected = rx_diag.get("muxExpectedValue", "?")
-            select = rx_diag.get("selectRegisterValue", "?")
-            select_expected = rx_diag.get("selectExpectedValue", "?")
-            dma_source = rx_diag.get("dmaSource", "?")
-            dmamux = rx_diag.get("dmamuxChcfg", "?")
-            citer = rx_diag.get("citer", "?")
-            biter = rx_diag.get("biter", "?")
-            csr = rx_diag.get("csr", "?")
-            dma_erq = rx_diag.get("dmaErq", "?")
-            cval2 = rx_diag.get("cval2", "?")
-            cval3 = rx_diag.get("cval3", "?")
-            cval4 = rx_diag.get("cval4", "?")
-            cval5 = rx_diag.get("cval5", "?")
-            print(
-                "      FlexPWM after wait: "
-                f"pin={rx_diag.get('pin', '?')} "
-                f"mux={mux}/{mux_expected} select={select}/{select_expected} "
-                f"source={dma_source} dmamux={dmamux} "
-                f"citer={citer} biter={biter} csr={csr} erq={dma_erq} "
-                f"cval={cval2},{cval3},{cval4},{cval5}"
-            )
     if isinstance(snapshot, str) and snapshot:
         print("    snapshot:")
         for line in snapshot.splitlines():

--- a/ci/autoresearch/phases.py
+++ b/ci/autoresearch/phases.py
@@ -735,6 +735,8 @@ def _parse_args_and_build_commands(args: Args) -> RunContext | int:
     rpc_commands_list: list[dict[str, Any]] = []
 
     if per_lane_counts is not None:
+        set_lane_sizes_cmd = {"method": "setLaneSizes", "params": [per_lane_counts]}
+        rpc_commands_list.append(set_lane_sizes_cmd)
         print(
             f"\u2139\ufe0f  Setting per-lane LED counts: {', '.join(str(c) for c in per_lane_counts)} ({len(per_lane_counts)} lanes)"
         )
@@ -759,87 +761,84 @@ def _parse_args_and_build_commands(args: Args) -> RunContext | int:
     drivers_list = config["drivers"]
     lane_range = config.get("laneRange", {"min": 1, "max": 1})
     strip_sizes = config.get("stripSizes", [100])
-    if per_lane_counts is not None:
-        lane_size_sets = [per_lane_counts]
-    else:
-        lane_size_sets = [
-            [strip_size] * lane_count
-            for lane_count in range(lane_range["min"], lane_range["max"] + 1)
-            for strip_size in strip_sizes
-        ]
 
     if parallel_mode:
-        for lane_sizes in lane_size_sets:
-            driver_entries: list[dict[str, Any]] = []
-            for driver in drivers_list:
-                driver_entry: dict[str, Any] = {
-                    "driver": driver,
-                    "laneSizes": lane_sizes,
-                }
-                driver_entries.append(driver_entry)
-            parallel_config: dict[str, Any] = {
-                "drivers": driver_entries,
-                "pattern": "MSB_LSB_A",
-                "iterations": 1,
-                "timing": timing_name,
-            }
-            rpc_command = {"method": "runParallelTest", "params": parallel_config}
-            rpc_commands_list.append(rpc_command)
-
-        print(
-            f"\u2139\ufe0f  Generated {len(rpc_commands_list)} parallel test(s) "
-            f"({len(drivers_list)} drivers \u00d7 {len(lane_size_sets)} lane-size set(s))"
-        )
-    else:
-        for driver in drivers_list:
-            for lane_sizes in lane_size_sets:
-                lane_count = len(lane_sizes)
-                test_config: dict[str, Any] = {
-                    "driver": driver,
-                    "laneSizes": lane_sizes,
+        for lane_count in range(lane_range["min"], lane_range["max"] + 1):
+            for strip_size in strip_sizes:
+                lane_sizes = [strip_size] * lane_count
+                driver_entries: list[dict[str, Any]] = []
+                for driver in drivers_list:
+                    driver_entry: dict[str, Any] = {
+                        "driver": driver,
+                        "laneSizes": lane_sizes,
+                    }
+                    driver_entries.append(driver_entry)
+                parallel_config: dict[str, Any] = {
+                    "drivers": driver_entries,
                     "pattern": "MSB_LSB_A",
                     "iterations": 1,
                     "timing": timing_name,
                 }
-                if args.legacy:
-                    test_config["useLegacyApi"] = True
-                    if args.legacy_rgbw_small_counts:
-                        test_config["legacyRgbw"] = True
-                    if args.legacy_mixed_timings:
-                        test_config["legacyChipsets"] = [
-                            "WS2812B" if i % 2 == 0 else "SK6812"
-                            for i in range(lane_count)
-                        ]
-                # Multi-frame capture: back-to-back show()/capture cycles per pattern.
-                # Defaults: SPI -> 2 (catches #2254/#2288 second-frame degradation),
-                # others -> 1. User can override with --frames N.
-                if args.frames is not None:
-                    frame_count = args.frames
-                elif driver == "SPI":
-                    frame_count = 2
-                else:
-                    frame_count = 1
-                if frame_count > 1:
-                    test_config["frameCount"] = frame_count
-                if args.contaminate_tx_mux:
-                    test_config["contaminateTxMux"] = True
-                if args.tight_timing:
-                    if (
-                        args.tight_timing_iterations < 1
-                        or args.tight_timing_iterations > 64
-                    ):
-                        print("Error: --tight-timing-iterations must be in [1, 64]")
-                        return 1
-                    if args.tight_timing_max_overhead_us < 1:
-                        print("Error: --tight-timing-max-overhead-us must be >= 1")
-                        return 1
-                    test_config["tightTiming"] = True
-                    test_config["tightTimingIterations"] = args.tight_timing_iterations
-                    test_config["tightTimingMaxOverheadUs"] = (
-                        args.tight_timing_max_overhead_us
-                    )
-                rpc_command = {"method": "runSingleTest", "params": test_config}
+                rpc_command = {"method": "runParallelTest", "params": parallel_config}
                 rpc_commands_list.append(rpc_command)
+
+        print(
+            f"\u2139\ufe0f  Generated {len(rpc_commands_list)} parallel test(s) "
+            f"({len(drivers_list)} drivers \u00d7 {lane_range['max'] - lane_range['min'] + 1} lane count(s) \u00d7 {len(strip_sizes)} strip size(s))"
+        )
+    else:
+        for driver in drivers_list:
+            for lane_count in range(lane_range["min"], lane_range["max"] + 1):
+                for strip_size in strip_sizes:
+                    lane_sizes = [strip_size] * lane_count
+                    test_config: dict[str, Any] = {
+                        "driver": driver,
+                        "laneSizes": lane_sizes,
+                        "pattern": "MSB_LSB_A",
+                        "iterations": 1,
+                        "timing": timing_name,
+                    }
+                    if args.legacy:
+                        test_config["useLegacyApi"] = True
+                        if args.legacy_rgbw_small_counts:
+                            test_config["legacyRgbw"] = True
+                        if args.legacy_mixed_timings:
+                            test_config["legacyChipsets"] = [
+                                "WS2812B" if i % 2 == 0 else "SK6812"
+                                for i in range(lane_count)
+                            ]
+                    # Multi-frame capture: back-to-back show()/capture cycles per pattern.
+                    # Defaults: SPI -> 2 (catches #2254/#2288 second-frame degradation),
+                    # others -> 1. User can override with --frames N.
+                    if args.frames is not None:
+                        frame_count = args.frames
+                    elif driver == "SPI":
+                        frame_count = 2
+                    else:
+                        frame_count = 1
+                    if frame_count > 1:
+                        test_config["frameCount"] = frame_count
+                    if args.contaminate_tx_mux:
+                        test_config["contaminateTxMux"] = True
+                    if args.tight_timing:
+                        if (
+                            args.tight_timing_iterations < 1
+                            or args.tight_timing_iterations > 64
+                        ):
+                            print("Error: --tight-timing-iterations must be in [1, 64]")
+                            return 1
+                        if args.tight_timing_max_overhead_us < 1:
+                            print("Error: --tight-timing-max-overhead-us must be >= 1")
+                            return 1
+                        test_config["tightTiming"] = True
+                        test_config["tightTimingIterations"] = (
+                            args.tight_timing_iterations
+                        )
+                        test_config["tightTimingMaxOverheadUs"] = (
+                            args.tight_timing_max_overhead_us
+                        )
+                    rpc_command = {"method": "runSingleTest", "params": test_config}
+                    rpc_commands_list.append(rpc_command)
 
     json_rpc_cmd_str = json.dumps(rpc_commands_list)
 

--- a/ci/tests/test_autoresearch_phases.py
+++ b/ci/tests/test_autoresearch_phases.py
@@ -646,9 +646,9 @@ class TestParseArgsAndBuildCommands:
         args = _make_args(lane_counts="100,200,300", project_dir=fake_project_dir)
         result = _parse_args_and_build_commands(args)
         assert isinstance(result, RunContext)
-        assert len(result.json_rpc_commands) == 1
-        assert result.json_rpc_commands[0]["method"] == "runSingleTest"
-        assert result.json_rpc_commands[0]["params"]["laneSizes"] == [100, 200, 300]
+        # setLaneSizes + runSingleTest = 2 commands
+        assert len(result.json_rpc_commands) == 2
+        assert result.json_rpc_commands[0]["method"] == "setLaneSizes"
 
     def test_lane_counts_accepts_16_lanes(self, fake_project_dir: Path) -> None:
         args = _make_args(
@@ -657,8 +657,8 @@ class TestParseArgsAndBuildCommands:
         )
         result = _parse_args_and_build_commands(args)
         assert isinstance(result, RunContext)
-        assert result.json_rpc_commands[0]["method"] == "runSingleTest"
-        assert result.json_rpc_commands[0]["params"]["laneSizes"] == [100] * 16
+        assert result.json_rpc_commands[0]["method"] == "setLaneSizes"
+        assert result.json_rpc_commands[0]["params"] == [[100] * 16]
 
     def test_lane_counts_rejects_17_lanes(self, fake_project_dir: Path) -> None:
         args = _make_args(

--- a/examples/AutoResearch/AutoResearchRemoteRunSingleTest.cpp
+++ b/examples/AutoResearch/AutoResearchRemoteRunSingleTest.cpp
@@ -38,7 +38,6 @@
 #include "AutoResearchTimingDrift.h"
 #include "AutoResearchParlioStream.h"
 #include "platforms/arm/teensy/teensy4_common/drivers/objectfled/objectfled_diagnostics.h"
-#include "platforms/arm/teensy/teensy4_common/rx_flexpwm_channel.h"
 #include "fl/chipsets/spi.h"
 #include "fl/channels/config.h"
 #include <Arduino.h>
@@ -97,256 +96,6 @@ bool contaminateTxMuxWithPwm(int pin) {
 #else
     (void)pin;
     return false;
-#endif
-}
-
-#if defined(FL_IS_TEENSY_4X)
-volatile uint32_t* standardGpioAddrForFast(volatile uint32_t* fast_gpio) {
-    return reinterpret_cast<volatile uint32_t*>(
-        reinterpret_cast<uintptr_t>(fast_gpio) - 0x01E48000u);
-}
-
-volatile uint32_t* gpioDrSetAddr(volatile uint32_t* gpio_dr) {
-    return reinterpret_cast<volatile uint32_t*>(
-        reinterpret_cast<uintptr_t>(gpio_dr) + 0x84u);
-}
-
-volatile uint32_t* gpioDrClearAddr(volatile uint32_t* gpio_dr) {
-    return reinterpret_cast<volatile uint32_t*>(
-        reinterpret_cast<uintptr_t>(gpio_dr) + 0x88u);
-}
-#endif
-
-fl::json probeObjectFledStandardGpioConnection(int tx_pin, int rx_pin) {
-    fl::json probe = fl::json::object();
-    probe.set("requested", true);
-    probe.set("txPin", static_cast<int64_t>(tx_pin));
-    probe.set("rxPin", static_cast<int64_t>(rx_pin));
-#if !defined(FL_IS_TEENSY_4X)
-    probe.set("supported", false);
-    probe.set("message", "Teensy 4.x only");
-    return probe;
-#else
-    probe.set("supported", true);
-    if (tx_pin < 0 || tx_pin >= NUM_DIGITAL_PINS ||
-        rx_pin < 0 || rx_pin >= NUM_DIGITAL_PINS) {
-        probe.set("success", false);
-        probe.set("error", "InvalidPin");
-        return probe;
-    }
-
-    volatile uint32_t* fast_output = portOutputRegister(tx_pin);
-    volatile uint32_t* fast_mode = portModeRegister(tx_pin);
-    volatile uint32_t* standard_output = standardGpioAddrForFast(fast_output);
-    volatile uint32_t* standard_mode = standardGpioAddrForFast(fast_mode);
-    volatile uint32_t* mux = portConfigRegister(tx_pin);
-    volatile uint32_t* pad = portControlRegister(tx_pin);
-
-    const uint32_t gpio6_base = reinterpret_cast<uintptr_t>(&GPIO6_DR);
-    const uint32_t output_addr = reinterpret_cast<uintptr_t>(fast_output);
-    const uint8_t offset = static_cast<uint8_t>((output_addr - gpio6_base) >> 14);
-    const uint8_t bit = digitalPinToBit(tx_pin);
-    const uint32_t mask = 1u << bit;
-
-    probe.set("bit", static_cast<int64_t>(bit));
-    probe.set("mask", static_cast<int64_t>(mask));
-    probe.set("offset", static_cast<int64_t>(offset));
-    if (offset > 3) {
-        probe.set("success", false);
-        probe.set("error", "UnsupportedGpioBank");
-        return probe;
-    }
-
-    volatile uint32_t* gpr = &IOMUXC_GPR_GPR26 + offset;
-    const uint32_t saved_gpr = *gpr;
-    const uint32_t saved_mux = *mux;
-    const uint32_t saved_pad = *pad;
-    const uint32_t saved_fast_mode = *fast_mode;
-    const uint32_t saved_standard_mode = *standard_mode;
-    const uint32_t saved_fast_out = *fast_output;
-    const uint32_t saved_standard_out = *standard_output;
-
-    CCM_CCGR1 |= CCM_CCGR1_GPIO1(CCM_CCGR_ON);
-    CCM_CCGR0 |= CCM_CCGR0_GPIO2(CCM_CCGR_ON);
-    CCM_CCGR2 |= CCM_CCGR2_GPIO3(CCM_CCGR_ON);
-    CCM_CCGR3 |= CCM_CCGR3_GPIO4(CCM_CCGR_ON);
-
-    pinMode(rx_pin, INPUT_PULLUP);
-    *mux = 5 | 0x10;
-    *gpr &= ~mask;
-    *fast_mode |= mask;
-    *standard_mode |= mask;
-
-    *gpioDrClearAddr(fast_output) = mask;
-    *gpioDrClearAddr(standard_output) = mask;
-    delay(5);
-    const int rx_when_low = digitalRead(rx_pin);
-    const uint32_t std_out_low = *standard_output;
-    const uint32_t fast_out_low = *fast_output;
-
-    *gpioDrSetAddr(standard_output) = mask;
-    delay(5);
-    const int rx_when_high = digitalRead(rx_pin);
-    const uint32_t std_out_high = *standard_output;
-    const uint32_t fast_out_high = *fast_output;
-
-    *gpioDrClearAddr(standard_output) = mask;
-    delay(1);
-
-    if ((saved_fast_out & mask) != 0) {
-        *gpioDrSetAddr(fast_output) = mask;
-    } else {
-        *gpioDrClearAddr(fast_output) = mask;
-    }
-    if ((saved_standard_out & mask) != 0) {
-        *gpioDrSetAddr(standard_output) = mask;
-    } else {
-        *gpioDrClearAddr(standard_output) = mask;
-    }
-    *fast_mode = saved_fast_mode;
-    *standard_mode = saved_standard_mode;
-    *pad = saved_pad;
-    *mux = saved_mux;
-    *gpr = saved_gpr;
-    pinMode(tx_pin, INPUT);
-    pinMode(rx_pin, INPUT);
-
-    const bool connected = (rx_when_low == LOW) && (rx_when_high == HIGH);
-    probe.set("success", true);
-    probe.set("connected", connected);
-    probe.set("rxWhenStandardLow", rx_when_low == LOW ? "LOW" : "HIGH");
-    probe.set("rxWhenStandardHigh", rx_when_high == HIGH ? "HIGH" : "LOW");
-    probe.set("standardOutLow", static_cast<int64_t>(std_out_low));
-    probe.set("standardOutHigh", static_cast<int64_t>(std_out_high));
-    probe.set("fastOutLow", static_cast<int64_t>(fast_out_low));
-    probe.set("fastOutHigh", static_cast<int64_t>(fast_out_high));
-    return probe;
-#endif
-}
-
-fl::json probeObjectFledRxCapture(int tx_pin, int rx_pin,
-                                  fl::shared_ptr<fl::RxChannel> rx_channel) {
-    fl::json probe = fl::json::object();
-    probe.set("requested", true);
-    probe.set("txPin", static_cast<int64_t>(tx_pin));
-    probe.set("rxPin", static_cast<int64_t>(rx_pin));
-#if !defined(FL_IS_TEENSY_4X)
-    (void)rx_channel;
-    probe.set("supported", false);
-    probe.set("message", "Teensy 4.x only");
-    return probe;
-#else
-    probe.set("supported", true);
-    if (!rx_channel) {
-        probe.set("success", false);
-        probe.set("error", "NoRxChannel");
-        return probe;
-    }
-    probe.set("engine", rx_channel->getEngineName().c_str());
-    if (tx_pin < 0 || tx_pin >= NUM_DIGITAL_PINS ||
-        rx_pin < 0 || rx_pin >= NUM_DIGITAL_PINS) {
-        probe.set("success", false);
-        probe.set("error", "InvalidPin");
-        return probe;
-    }
-
-    fl::RxChannelConfig rx_config(rx_pin);
-    rx_config.hz = 40000000;
-    rx_config.edge_capacity = 64;
-    rx_config.start_low = true;
-    if (!rx_channel->begin(rx_config)) {
-        probe.set("success", false);
-        probe.set("error", "RxBeginFailed");
-        return probe;
-    }
-    probe.set("diagnosticsAfterBegin",
-              fl::flexPwmRxDiagnosticsToJson(rx_pin));
-
-    volatile uint32_t* fast_output = portOutputRegister(tx_pin);
-    volatile uint32_t* fast_mode = portModeRegister(tx_pin);
-    volatile uint32_t* standard_output = standardGpioAddrForFast(fast_output);
-    volatile uint32_t* standard_mode = standardGpioAddrForFast(fast_mode);
-    volatile uint32_t* mux = portConfigRegister(tx_pin);
-    volatile uint32_t* pad = portControlRegister(tx_pin);
-
-    const uint32_t gpio6_base = reinterpret_cast<uintptr_t>(&GPIO6_DR);
-    const uint32_t output_addr = reinterpret_cast<uintptr_t>(fast_output);
-    const uint8_t offset = static_cast<uint8_t>((output_addr - gpio6_base) >> 14);
-    const uint8_t bit = digitalPinToBit(tx_pin);
-    const uint32_t mask = 1u << bit;
-    probe.set("bit", static_cast<int64_t>(bit));
-    probe.set("offset", static_cast<int64_t>(offset));
-    if (offset > 3) {
-        probe.set("success", false);
-        probe.set("error", "UnsupportedGpioBank");
-        return probe;
-    }
-
-    volatile uint32_t* gpr = &IOMUXC_GPR_GPR26 + offset;
-    const uint32_t saved_gpr = *gpr;
-    const uint32_t saved_mux = *mux;
-    const uint32_t saved_pad = *pad;
-    const uint32_t saved_fast_mode = *fast_mode;
-    const uint32_t saved_standard_mode = *standard_mode;
-    const uint32_t saved_fast_out = *fast_output;
-    const uint32_t saved_standard_out = *standard_output;
-
-    CCM_CCGR1 |= CCM_CCGR1_GPIO1(CCM_CCGR_ON);
-    CCM_CCGR0 |= CCM_CCGR0_GPIO2(CCM_CCGR_ON);
-    CCM_CCGR2 |= CCM_CCGR2_GPIO3(CCM_CCGR_ON);
-    CCM_CCGR3 |= CCM_CCGR3_GPIO4(CCM_CCGR_ON);
-
-    *mux = 5 | 0x10;
-    *gpr &= ~mask;
-    *fast_mode |= mask;
-    *standard_mode |= mask;
-    *gpioDrClearAddr(fast_output) = mask;
-    *gpioDrClearAddr(standard_output) = mask;
-    delayMicroseconds(100);
-    probe.set("diagnosticsBeforePulses",
-              fl::flexPwmRxDiagnosticsToJson(rx_pin));
-
-    for (int i = 0; i < 4; ++i) {
-        *gpioDrSetAddr(standard_output) = mask;
-        delayMicroseconds(40);
-        *gpioDrClearAddr(standard_output) = mask;
-        delayMicroseconds(40);
-    }
-
-    probe.set("diagnosticsAfterPulses",
-              fl::flexPwmRxDiagnosticsToJson(rx_pin));
-    const fl::RxWaitResult wait_result = rx_channel->wait(50);
-    probe.set("waitResult", static_cast<int64_t>(wait_result));
-    probe.set("diagnosticsAfterWait",
-              fl::flexPwmRxDiagnosticsToJson(rx_pin));
-    fl::vector<fl::EdgeTime> edges;
-    edges.assign(32, fl::EdgeTime());
-    const size_t edge_count =
-        rx_channel->getRawEdgeTimes(fl::span<fl::EdgeTime>(edges), 0);
-    probe.set("diagnosticsAfterRead",
-              fl::flexPwmRxDiagnosticsToJson(rx_pin));
-
-    if ((saved_fast_out & mask) != 0) {
-        *gpioDrSetAddr(fast_output) = mask;
-    } else {
-        *gpioDrClearAddr(fast_output) = mask;
-    }
-    if ((saved_standard_out & mask) != 0) {
-        *gpioDrSetAddr(standard_output) = mask;
-    } else {
-        *gpioDrClearAddr(standard_output) = mask;
-    }
-    *fast_mode = saved_fast_mode;
-    *standard_mode = saved_standard_mode;
-    *pad = saved_pad;
-    *mux = saved_mux;
-    *gpr = saved_gpr;
-    pinMode(tx_pin, INPUT);
-
-    probe.set("success", true);
-    probe.set("rawEdges", static_cast<int64_t>(edge_count));
-    probe.set("captured", edge_count > 0);
-    return probe;
 #endif
 }
 
@@ -804,14 +553,6 @@ fl::json AutoResearchRemoteControl::runSingleTestImpl(const fl::json& args) {
     // ========== EXECUTION ==========
 
     uint32_t start_ms = millis();
-    fl::json object_fled_standard_gpio_probe;
-    fl::json object_fled_rx_capture_probe = fl::json::object();
-    fl::json object_fled_diagnostics;
-    if (is_object_fled_driver) {
-        object_fled_rx_capture_probe.set("requested", false);
-        object_fled_standard_gpio_probe =
-            probeObjectFledStandardGpioConnection(pin_tx, pin_rx);
-    }
 
     if (contaminate_tx_mux) {
         if (!is_object_fled_driver) {
@@ -977,12 +718,6 @@ fl::json AutoResearchRemoteControl::runSingleTestImpl(const fl::json& args) {
         passed = (total_tests > 0) && (passed_tests == total_tests);
     }
 
-    if (is_object_fled_driver && !passed) {
-        object_fled_diagnostics = fl::objectFledDiagnosticsToJson();
-        object_fled_rx_capture_probe =
-            probeObjectFledRxCapture(pin_tx, pin_rx, rx_channel_to_use);
-    }
-
     if (measure_tight_timing) {
         if (use_legacy_api) {
             tight_timing_passed = false;
@@ -1073,13 +808,8 @@ fl::json AutoResearchRemoteControl::runSingleTestImpl(const fl::json& args) {
         response.set("tightTiming", tight_timing_response);
     }
     if (is_object_fled_driver) {
-        response.set("objectFledStandardGpioProbe",
-                     object_fled_standard_gpio_probe);
-        response.set("objectFledRxCaptureProbe",
-                     object_fled_rx_capture_probe);
-        if (!passed) {
-            response.set("objectFledDiagnostics", object_fled_diagnostics);
-        }
+        response.set("objectFledDiagnostics",
+                     fl::objectFledDiagnosticsToJson());
     }
 
     // Free run_results before building response to reclaim heap
@@ -1096,13 +826,6 @@ fl::json AutoResearchRemoteControl::runSingleTestImpl(const fl::json& args) {
             pat.set("capturedBytes", static_cast<int64_t>(rr.capturedBytes));
             pat.set("captureWaitResult", static_cast<int64_t>(rr.captureWaitResult));
             pat.set("rawEdgesAfterWait", static_cast<int64_t>(rr.rawEdgesAfterWait));
-            pat.set("decodeOk", static_cast<int64_t>(rr.decodeOk));
-            pat.set("decodeError", static_cast<int64_t>(rr.decodeError));
-            pat.set("decodeBytes", static_cast<int64_t>(rr.decodeBytes));
-            pat.set("decodeOutputCapacity", static_cast<int64_t>(rr.decodeOutputCapacity));
-            if (!rr.rawEdgeSample.empty()) {
-                pat.set("rawEdgeSample", rr.rawEdgeSample.c_str());
-            }
             pat.set("captureFailed", rr.captureFailed);
             pat.set("mismatchedBytes", static_cast<int64_t>(rr.mismatchedBytes));
             pat.set("lsbOnlyErrors", static_cast<int64_t>(rr.lsbOnlyErrors));

--- a/examples/AutoResearch/AutoResearchTest.cpp
+++ b/examples/AutoResearch/AutoResearchTest.cpp
@@ -339,10 +339,6 @@ size_t capture(fl::shared_ptr<fl::RxChannel> rx_channel,
     if (diagnostics) {
         diagnostics->captureWaitResult = -1;
         diagnostics->rawEdgesAfterWait = 0;
-        diagnostics->decodeOk = -1;
-        diagnostics->decodeError = -1;
-        diagnostics->decodeBytes = 0;
-        diagnostics->decodeOutputCapacity = static_cast<int>(rx_buffer.size());
     }
 
     if (!rx_channel) {
@@ -454,17 +450,6 @@ size_t capture(fl::shared_ptr<fl::RxChannel> rx_channel,
         fl::FixedVector<fl::EdgeTime, 256> edges;
         edges.resize(256);
         diagnostics->rawEdgesAfterWait = static_cast<int>(rx_channel->getRawEdgeTimes(edges, 0));
-        fl::FixedVector<fl::EdgeTime, 32> sample_edges;
-        sample_edges.resize(32);
-        const size_t sample_count = rx_channel->getRawEdgeTimes(sample_edges, 0);
-        fl::sstream sample;
-        for (size_t i = 0; i < sample_count; ++i) {
-            if (i > 0) {
-                sample << ' ';
-            }
-            sample << (sample_edges[i].high ? 'H' : 'L') << sample_edges[i].ns;
-        }
-        diagnostics->rawEdgeSample = sample.str();
     }
     FL_WARN("[CAPTURE] RX wait returned: " << static_cast<int>(wait_result));
 
@@ -511,13 +496,6 @@ size_t capture(fl::shared_ptr<fl::RxChannel> rx_channel,
                 << " T1L=" << uart_timing.T3);
 
         auto decode_result = rx_channel->decode(rx_timing, rx_buffer);
-        if (diagnostics) {
-            diagnostics->decodeOk = decode_result.ok() ? 1 : 0;
-            diagnostics->decodeError =
-                decode_result.ok() ? -1 : static_cast<int>(decode_result.error());
-            diagnostics->decodeBytes =
-                decode_result.ok() ? static_cast<int>(decode_result.value()) : 0;
-        }
         if (!decode_result.ok()) {
             FL_WARN("[CAPTURE] UART decode failed (error: " << static_cast<int>(decode_result.error()) << ")");
             // Was EdgeRange(0, 256) -- 257 FL_WARN lines per decode failure
@@ -653,13 +631,6 @@ dumpRawEdgeTiming(rx_channel, timing, fl::EdgeRange(0, 32));
 
     FL_WARN("[CAPTURE] Decoding...");
     auto decode_result = rx_channel->decode(rx_timing, rx_buffer);
-    if (diagnostics) {
-        diagnostics->decodeOk = decode_result.ok() ? 1 : 0;
-        diagnostics->decodeError =
-            decode_result.ok() ? -1 : static_cast<int>(decode_result.error());
-        diagnostics->decodeBytes =
-            decode_result.ok() ? static_cast<int>(decode_result.value()) : 0;
-    }
 
     if (!decode_result.ok()) {
         // Use FL_WARN instead of FL_ERROR to avoid triggering bash autoresearch exit

--- a/examples/AutoResearch/AutoResearchTest.h
+++ b/examples/AutoResearch/AutoResearchTest.h
@@ -88,11 +88,6 @@ struct RunResult {
     int capturedBytes;              ///< Bytes decoded from the RX channel
     int captureWaitResult;          ///< RxWaitResult value, or -1 before wait
     int rawEdgesAfterWait;          ///< Raw edges visible after RX wait/decode
-    int decodeOk;                   ///< 1 if RX decode returned success, 0 on error, -1 before decode
-    int decodeError;                ///< DecodeError value, or -1 when decode succeeded/not run
-    int decodeBytes;                ///< Bytes reported directly by decode()
-    int decodeOutputCapacity;       ///< Output span size passed to decode()
-    fl::string rawEdgeSample;       ///< Compact first-edge sample for failures
     int mismatchedBytes;            ///< Number of individual bytes that differ
     int lsbOnlyErrors;              ///< Bytes where (expected ^ actual) == 0x01
     fl::vector<LEDError> errors;    ///< First few errors (up to 10)
@@ -101,8 +96,7 @@ struct RunResult {
 
     RunResult() : run_number(0), total_leds(0), mismatches(0),
                   totalBytes(0), capturedBytes(0), captureWaitResult(-1),
-                  rawEdgesAfterWait(0), decodeOk(-1), decodeError(-1),
-                  decodeBytes(0), decodeOutputCapacity(0), mismatchedBytes(0), lsbOnlyErrors(0),
+                  rawEdgesAfterWait(0), mismatchedBytes(0), lsbOnlyErrors(0),
                   captureFailed(false), passed(false) {}
 };
 

--- a/src/platforms/arm/teensy/teensy4_common/drivers/objectfled/objectfled_diagnostics.cpp.hpp
+++ b/src/platforms/arm/teensy/teensy4_common/drivers/objectfled/objectfled_diagnostics.cpp.hpp
@@ -41,14 +41,6 @@ struct PinRegisterSnapshot {
     u32 modeValue = 0;
     u32 inputRegister = 0;
     u32 inputValue = 0;
-    u32 fastModeRegister = 0;
-    u32 fastModeValue = 0;
-    u32 standardOutputRegister = 0;
-    u32 standardOutputValue = 0;
-    u32 standardModeRegister = 0;
-    u32 standardModeValue = 0;
-    u32 standardInputRegister = 0;
-    u32 standardInputValue = 0;
 };
 
 struct TimerChannelSnapshot {
@@ -120,7 +112,6 @@ struct SnapshotEvent {
     u8 pinCount = 0;
     PinRegisterSnapshot pins[kMaxPins];
     u32 gpr[4] = {0, 0, 0, 0};
-    u32 ccgr[4] = {0, 0, 0, 0};
     TimerChannelSnapshot tmr[3];
     u32 tmrEnbl = 0;
     u32 xbarSel15 = 0;
@@ -173,8 +164,6 @@ PinRegisterSnapshot capturePin(u8 pin) FL_NO_EXCEPT {
     out.modeValue = *modeReg;
     out.inputRegister = ptrToU32(inputReg);
     out.inputValue = *inputReg;
-    out.fastModeRegister = ptrToU32(modeReg);
-    out.fastModeValue = *modeReg;
     out.muxRegister = ptrToU32(muxReg);
     out.mux = *muxReg;
     out.padRegister = ptrToU32(padReg);
@@ -191,15 +180,7 @@ PinRegisterSnapshot capturePin(u8 pin) FL_NO_EXCEPT {
         out.gprMask = out.mask;
         out.mappedToStandard = ((*gprReg & out.mask) == 0);
 
-        volatile u32* standardOutputReg = standardGpioAddr(outputReg);
         volatile u32* standardModeReg = standardGpioAddr(modeReg);
-        volatile u32* standardInputReg = standardGpioAddr(inputReg);
-        out.standardOutputRegister = ptrToU32(standardOutputReg);
-        out.standardOutputValue = *standardOutputReg;
-        out.standardModeRegister = ptrToU32(standardModeReg);
-        out.standardModeValue = *standardModeReg;
-        out.standardInputRegister = ptrToU32(standardInputReg);
-        out.standardInputValue = *standardInputReg;
         out.modeRegister = ptrToU32(standardModeReg);
         out.modeValue = *standardModeReg;
     }
@@ -366,15 +347,7 @@ void appendPin(fl::sstream& out, const PinRegisterSnapshot& pin) FL_NO_EXCEPT {
         << " modeReg=" << pin.modeRegister
         << " mode=" << pin.modeValue
         << " inReg=" << pin.inputRegister
-        << " in=" << pin.inputValue
-        << " fastModeReg=" << pin.fastModeRegister
-        << " fastMode=" << pin.fastModeValue
-        << " stdOutReg=" << pin.standardOutputRegister
-        << " stdOut=" << pin.standardOutputValue
-        << " stdModeReg=" << pin.standardModeRegister
-        << " stdMode=" << pin.standardModeValue
-        << " stdInReg=" << pin.standardInputRegister
-        << " stdIn=" << pin.standardInputValue;
+        << " in=" << pin.inputValue;
 }
 
 void appendEvent(fl::sstream& out, const SnapshotEvent& event) FL_NO_EXCEPT {
@@ -388,10 +361,6 @@ void appendEvent(fl::sstream& out, const SnapshotEvent& event) FL_NO_EXCEPT {
         << " gpr27=" << event.gpr[1]
         << " gpr28=" << event.gpr[2]
         << " gpr29=" << event.gpr[3]
-        << " ccgr0=" << event.ccgr[0]
-        << " ccgr1=" << event.ccgr[1]
-        << " ccgr2=" << event.ccgr[2]
-        << " ccgr3=" << event.ccgr[3]
         << " tmr4.enbl=" << event.tmrEnbl
         << " xbar.sel15=" << event.xbarSel15
         << " xbar.sel47=" << event.xbarSel47
@@ -495,10 +464,6 @@ void objectFledDiagnosticsRecord(const char* stage, const u8* pins,
     event.gpr[1] = IOMUXC_GPR_GPR27;
     event.gpr[2] = IOMUXC_GPR_GPR28;
     event.gpr[3] = IOMUXC_GPR_GPR29;
-    event.ccgr[0] = CCM_CCGR0;
-    event.ccgr[1] = CCM_CCGR1;
-    event.ccgr[2] = CCM_CCGR2;
-    event.ccgr[3] = CCM_CCGR3;
     event.tmrEnbl = TMR4_ENBL;
     event.tmr[0] = captureTimerChannel(0);
     event.tmr[1] = captureTimerChannel(1);

--- a/src/platforms/arm/teensy/teensy4_common/rx_flexpwm_channel.cpp.hpp
+++ b/src/platforms/arm/teensy/teensy4_common/rx_flexpwm_channel.cpp.hpp
@@ -46,7 +46,6 @@
 #include "fl/log/log.h"
 #include "fl/stl/result.h"
 #include "fl/stl/cstring.h"
-#include "fl/stl/bit_cast.h"
 
 // IWYU pragma: begin_keep
 #include <Arduino.h>
@@ -116,17 +115,17 @@ static const FlexPwmPinInfo kPinMap[] = {
     // Pin 8: FlexPWM1_SM3_A (GPIO_B1_00, ALT6)
     {8, &IMXRT_FLEXPWM1, 3, false, DMAMUX_SOURCE_FLEXPWM1_READ3,
      &IOMUXC_SW_MUX_CTL_PAD_GPIO_B1_00, 6,
-     &IOMUXC_FLEXPWM1_PWMA3_SELECT_INPUT, 4},
+     &IOMUXC_FLEXPWM1_PWMA3_SELECT_INPUT, 0},
 
     // Pin 22: FlexPWM4_SM0_A (GPIO_AD_B1_08, ALT1)
     {22, &IMXRT_FLEXPWM4, 0, false, DMAMUX_SOURCE_FLEXPWM4_READ0,
      &IOMUXC_SW_MUX_CTL_PAD_GPIO_AD_B1_08, 1,
-     &IOMUXC_FLEXPWM4_PWMA0_SELECT_INPUT, 1},
+     &IOMUXC_FLEXPWM4_PWMA0_SELECT_INPUT, 0},
 
     // Pin 23: FlexPWM4_SM1_A (GPIO_AD_B1_09, ALT1)
     {23, &IMXRT_FLEXPWM4, 1, false, DMAMUX_SOURCE_FLEXPWM4_READ1,
      &IOMUXC_SW_MUX_CTL_PAD_GPIO_AD_B1_09, 1,
-     &IOMUXC_FLEXPWM4_PWMA1_SELECT_INPUT, 1},
+     &IOMUXC_FLEXPWM4_PWMA1_SELECT_INPUT, 0},
 
     // Pin 29: FlexPWM3_SM1_B (GPIO_EMC_31, ALT1)
     {29, &IMXRT_FLEXPWM3, 1, true, DMAMUX_SOURCE_FLEXPWM3_READ1,
@@ -139,7 +138,7 @@ static const FlexPwmPinInfo kPinMap[] = {
     // Pin 36: FlexPWM2_SM3_A (GPIO_B1_02, ALT6)
     {36, &IMXRT_FLEXPWM2, 3, false, DMAMUX_SOURCE_FLEXPWM2_READ3,
      &IOMUXC_SW_MUX_CTL_PAD_GPIO_B1_02, 6,
-     &IOMUXC_FLEXPWM2_PWMA3_SELECT_INPUT, 4},
+     &IOMUXC_FLEXPWM2_PWMA3_SELECT_INPUT, 1},
 
     // Pin 49: FlexPWM1_SM2_A (GPIO_EMC_23, ALT1) [bottom pads]
     {49, &IMXRT_FLEXPWM1, 2, false, DMAMUX_SOURCE_FLEXPWM1_READ2,
@@ -219,20 +218,6 @@ static inline int decodeBitFromHigh(u32 high_ns,
 static inline bool isResetPulse(u32 low_ns,
                                 const ChipsetTiming4Phase &timing) {
     return low_ns >= (static_cast<u32>(timing.reset_min_us) * 1000u);
-}
-
-static u32 flexPwmRxPtrToU32(const volatile void *ptr) FL_NO_EXCEPT {
-    return static_cast<u32>(fl::ptr_to_int(const_cast<void *>(ptr)));
-}
-
-static void flexPwmRxSetU32(fl::json &obj, const char *key,
-                            u32 value) FL_NO_EXCEPT {
-    obj.set(key, static_cast<i64>(value));
-}
-
-static void flexPwmRxSetPtr(fl::json &obj, const char *key,
-                            const volatile void *ptr) FL_NO_EXCEPT {
-    flexPwmRxSetU32(obj, key, flexPwmRxPtrToU32(ptr));
 }
 
 /// Check if a pulse is a gap to tolerate (longer than normal but shorter
@@ -351,12 +336,9 @@ class FlexPwmRxChannelImpl : public FlexPwmRxChannel {
     bool injectEdges(fl::span<const EdgeTime> edges) override;
 
   private:
-    friend fl::json flexPwmRxDiagnosticsToJson(int pin) FL_NO_EXCEPT;
-
     void configureFlexPwm();
     void configureDma();
     void buildEdgeTimesFromCaptures();
-    fl::json diagnosticsToJson() const FL_NO_EXCEPT;
 
     static void dmaIsr();
     static FlexPwmRxChannelImpl *sActiveInstance;
@@ -373,7 +355,6 @@ class FlexPwmRxChannelImpl : public FlexPwmRxChannel {
     volatile bool mReceiveDone = false;
     bool mConfigured = false;
     bool mStartLow = true;
-    u16 mArmedCiter = 0;
 
     // Decoded edge cache (built from mCaptureBuffer or injected)
     fl::vector<EdgeTime> mEdges;
@@ -527,7 +508,6 @@ void FlexPwmRxChannelImpl::configureDma() {
     mDma.TCD->CITER = mCaptureBuffer.size() / 2;
     mDma.TCD->DLASTSGA = 0;
     mDma.TCD->BITER = mCaptureBuffer.size() / 2;
-    mArmedCiter = mDma.TCD->CITER;
     mDma.TCD->CSR = DMA_TCD_CSR_DREQ;
     mDma.triggerAtHardwareEvent(mPinInfo->dma_source);
     mDma.interruptAtCompletion();
@@ -568,8 +548,8 @@ bool FlexPwmRxChannelImpl::finished() const {
 
 RxWaitResult FlexPwmRxChannelImpl::wait(u32 timeout_ms) {
     u32 start = millis();
-    const u16 armed_citer = mArmedCiter;
-    u16 last_citer = mDma.TCD->CITER;
+    const u16 initial_citer = mDma.TCD->CITER;
+    u16 last_citer = initial_citer;
     u32 last_change_time = micros();
     bool exited_on_timeout = false;
 
@@ -577,9 +557,10 @@ RxWaitResult FlexPwmRxChannelImpl::wait(u32 timeout_ms) {
         u32 now_ms = millis();
         if ((now_ms - start) >= timeout_ms) {
             // Hit caller's timeout. Don't claim SUCCESS unless DMA actually
-            // moved since begin() armed it. AutoResearch calls wait() after
-            // FastLED.wait(), so comparing only against wait-entry CITER
-            // falsely reports TIMEOUT for already-captured frames.
+            // moved -- if CITER is still at its initial value we got zero
+            // edges and must report TIMEOUT honestly so capture() can bail
+            // and runMultiTest() can emit a real failure instead of decoding
+            // a stale/empty buffer.
             exited_on_timeout = true;
             break;
         }
@@ -606,12 +587,12 @@ RxWaitResult FlexPwmRxChannelImpl::wait(u32 timeout_ms) {
     }
 
     // Honesty: distinguish "actually got data" from "timeout with nothing".
-    //   - mReceiveDone              -> full buffer, definitely SUCCESS
-    //   - CITER moved since begin() -> partial buffer, SUCCESS (caller decodes
-    //                                  what arrived)
-    //   - CITER unchanged           -> nothing arrived; do not pretend it did
+    //   - mReceiveDone     -> full buffer, definitely SUCCESS
+    //   - CITER moved      -> partial buffer, SUCCESS (caller decodes what
+    //                          arrived; inactivity-detection path lands here)
+    //   - CITER unchanged  -> nothing arrived; do not pretend it did
     const u16 current_citer = mDma.TCD->CITER;
-    const bool dma_progressed = mReceiveDone || (current_citer != armed_citer);
+    const bool dma_progressed = mReceiveDone || (current_citer != initial_citer);
     if (!dma_progressed) {
         return RxWaitResult::TIMEOUT;
     }
@@ -774,109 +755,6 @@ bool FlexPwmRxChannelImpl::injectEdges(fl::span<const EdgeTime> edges) {
     mEdgesValid = true;
     mReceiveDone = true;
     return true;
-}
-
-fl::json FlexPwmRxChannelImpl::diagnosticsToJson() const FL_NO_EXCEPT {
-    fl::json out = fl::json::object();
-    out.set("active", true);
-    out.set("pin", static_cast<i64>(mPin));
-    out.set("configured", mConfigured);
-    out.set("receiveDone", static_cast<bool>(mReceiveDone));
-    out.set("edgesValid", mEdgesValid);
-    out.set("edgeCount", static_cast<i64>(mEdges.size()));
-    out.set("captureBufferSize", static_cast<i64>(mCaptureBuffer.size()));
-    out.set("signalRangeMaxNs", static_cast<i64>(mSignalRangeMaxNs));
-
-    if (!mPinInfo) {
-        out.set("pinSupported", false);
-        return out;
-    }
-
-    out.set("pinSupported", true);
-    out.set("submodule", static_cast<i64>(mPinInfo->submodule));
-    out.set("channelB", mPinInfo->channel_b);
-    out.set("dmaSource", static_cast<i64>(mPinInfo->dma_source));
-    flexPwmRxSetPtr(out, "muxRegister", mPinInfo->mux_register);
-    flexPwmRxSetU32(out, "muxRegisterValue", *(mPinInfo->mux_register));
-    flexPwmRxSetU32(out, "muxExpectedValue", mPinInfo->mux_value | 0x10);
-    if (mPinInfo->select_register) {
-        out.set("hasSelectRegister", true);
-        flexPwmRxSetPtr(out, "selectRegister", mPinInfo->select_register);
-        flexPwmRxSetU32(out, "selectRegisterValue", *(mPinInfo->select_register));
-        flexPwmRxSetU32(out, "selectExpectedValue", mPinInfo->select_value);
-    } else {
-        out.set("hasSelectRegister", false);
-    }
-
-    const u8 sm = mPinInfo->submodule;
-    IMXRT_FLEXPWM_t *pwm = mPinInfo->pwm;
-    flexPwmRxSetPtr(out, "pwm", pwm);
-    flexPwmRxSetU32(out, "mctrl", pwm->MCTRL);
-    flexPwmRxSetU32(out, "ctrl", pwm->SM[sm].CTRL);
-    flexPwmRxSetU32(out, "ctrl2", pwm->SM[sm].CTRL2);
-    flexPwmRxSetU32(out, "dmaen", pwm->SM[sm].DMAEN);
-    flexPwmRxSetU32(out, "captctrla", pwm->SM[sm].CAPTCTRLA);
-    flexPwmRxSetU32(out, "captctrlb", pwm->SM[sm].CAPTCTRLB);
-    flexPwmRxSetU32(out, "captcompa", pwm->SM[sm].CAPTCOMPA);
-    flexPwmRxSetU32(out, "captcompb", pwm->SM[sm].CAPTCOMPB);
-    flexPwmRxSetU32(out, "cval2", pwm->SM[sm].CVAL2);
-    flexPwmRxSetU32(out, "cval3", pwm->SM[sm].CVAL3);
-    flexPwmRxSetU32(out, "cval4", pwm->SM[sm].CVAL4);
-    flexPwmRxSetU32(out, "cval5", pwm->SM[sm].CVAL5);
-
-    out.set("dmaChannel", static_cast<i64>(mDma.channel));
-    flexPwmRxSetU32(out, "armedCiter", mArmedCiter);
-    flexPwmRxSetU32(out, "dmaErq", DMA_ERQ);
-    flexPwmRxSetU32(out, "dmaHrs", DMA_HRS);
-    flexPwmRxSetU32(out, "dmaInt", DMA_INT);
-    flexPwmRxSetU32(out, "dmaErr", DMA_ERR);
-    flexPwmRxSetU32(out, "dmaEs", DMA_ES);
-    flexPwmRxSetU32(out, "dmamuxChcfg", *(&DMAMUX_CHCFG0 + mDma.channel));
-    if (mDma.TCD) {
-        out.set("hasTcd", true);
-        flexPwmRxSetPtr(out, "tcdAddress", mDma.TCD);
-        flexPwmRxSetPtr(out, "saddr", mDma.TCD->SADDR);
-        out.set("soff", static_cast<i64>(mDma.TCD->SOFF));
-        flexPwmRxSetU32(out, "attr", mDma.TCD->ATTR);
-        flexPwmRxSetU32(out, "nbytes", mDma.TCD->NBYTES);
-        out.set("slast", static_cast<i64>(mDma.TCD->SLAST));
-        flexPwmRxSetPtr(out, "daddr", mDma.TCD->DADDR);
-        out.set("doff", static_cast<i64>(mDma.TCD->DOFF));
-        flexPwmRxSetU32(out, "citer", mDma.TCD->CITER);
-        out.set("dlastsga", static_cast<i64>(mDma.TCD->DLASTSGA));
-        flexPwmRxSetU32(out, "csr", mDma.TCD->CSR);
-        flexPwmRxSetU32(out, "biter", mDma.TCD->BITER);
-    } else {
-        out.set("hasTcd", false);
-    }
-
-    return out;
-}
-
-fl::json flexPwmRxDiagnosticsToJson(int pin) FL_NO_EXCEPT {
-    fl::json out = fl::json::object();
-    out.set("supported", true);
-    out.set("requestedPin", static_cast<i64>(pin));
-
-    const FlexPwmPinInfo *info = lookupPin(pin);
-    out.set("pinSupported", info != nullptr);
-    if (info) {
-        out.set("requestedDmaSource", static_cast<i64>(info->dma_source));
-        out.set("requestedSubmodule", static_cast<i64>(info->submodule));
-        out.set("requestedChannelB", info->channel_b);
-    }
-
-    FlexPwmRxChannelImpl *active = FlexPwmRxChannelImpl::sActiveInstance;
-    if (!active) {
-        out.set("active", false);
-        return out;
-    }
-
-    out = active->diagnosticsToJson();
-    out.set("supported", true);
-    out.set("requestedPin", static_cast<i64>(pin));
-    out.set("requestedPinMatchesActive", active->mPin == pin);
-    return out;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/platforms/arm/teensy/teensy4_common/rx_flexpwm_channel.h
+++ b/src/platforms/arm/teensy/teensy4_common/rx_flexpwm_channel.h
@@ -10,7 +10,6 @@
 #if defined(FL_IS_TEENSY_4X)
 
 #include "fl/channels/rx.h"
-#include "fl/stl/json.h"
 #include "fl/stl/shared_ptr.h"
 #include "fl/stl/noexcept.h"
 
@@ -50,8 +49,6 @@ class FlexPwmRxChannel : public RxDevice {
     FlexPwmRxChannel() = default;
     ~FlexPwmRxChannel() override = default;
 };
-
-fl::json flexPwmRxDiagnosticsToJson(int pin) FL_NO_EXCEPT;
 
 } // namespace fl
 

--- a/src/third_party/object_fled/src/ObjectFLEDDmaManager.cpp.hpp
+++ b/src/third_party/object_fled/src/ObjectFLEDDmaManager.cpp.hpp
@@ -11,18 +11,6 @@ namespace fl {
 DMAMEM uint32_t ObjectFLEDDmaManager::bitdata[BYTES_PER_DMA * 64] __attribute__((used, aligned(32)));
 DMAMEM uint32_t ObjectFLEDDmaManager::bitmask[4] __attribute__((used, aligned(32)));
 
-namespace {
-
-void markDmaStopped(DMAChannel& channel) {
-    channel.disable();
-    channel.clearInterrupt();
-    if (channel.TCD != nullptr) {
-        channel.TCD->CSR = DMA_TCD_CSR_DREQ | DMA_TCD_CSR_DONE;
-    }
-}
-
-} // namespace
-
 void ObjectFLEDDmaManager::acquire(void* owner) {
     // Wait for any current transmission to complete
     waitForCompletion();
@@ -42,20 +30,11 @@ void ObjectFLEDDmaManager::release(void* owner) {
     mCurrentOwner = nullptr;
 }
 
-bool ObjectFLEDDmaManager::waitForCompletion(uint32_t timeout_us) {
-    const uint32_t start = micros();
-
+void ObjectFLEDDmaManager::waitForCompletion() {
+    // Spin-wait for DMA completion with periodic delays
     while (!dma3.complete()) {
-        if (timeout_us > 0 && static_cast<uint32_t>(micros() - start) >= timeout_us) {
-            markDmaStopped(dma1);
-            markDmaStopped(dma2);
-            markDmaStopped(dma3);
-            return false;
-        }
         delayMicroseconds(10);
     }
-
-    return true;
 }
 
 bool ObjectFLEDDmaManager::isBusy() {

--- a/src/third_party/object_fled/src/ObjectFLEDDmaManager.h
+++ b/src/third_party/object_fled/src/ObjectFLEDDmaManager.h
@@ -27,7 +27,7 @@ class ObjectFLEDDmaManager {
 
     void acquire(void* owner);
     void release(void* owner);
-    bool waitForCompletion(uint32_t timeout_us = 250000);
+    void waitForCompletion();
     bool isBusy();
     void* getCurrentOwner() const { return mCurrentOwner; }
 

--- a/src/third_party/object_fled/src/OjectFLED.cpp.hpp
+++ b/src/third_party/object_fled/src/OjectFLED.cpp.hpp
@@ -105,35 +105,10 @@ static volatile uint32_t *standard_gpio_addr(volatile uint32_t *fastgpio) {
 	return (volatile uint32_t *)((uint32_t)fastgpio - 0x01E48000);
 }
 
-static volatile uint32_t *gpio_dr_clear_addr(volatile uint32_t *gpioDr) {
-	return (volatile uint32_t *)((uint32_t)gpioDr + 0x88);
-}
-
 static void force_pin_to_gpio_mux(uint8_t pin) {
 	// Teensy 4.x GPIO pads use MUX_MODE=5. Keep SION set so diagnostics can
 	// observe the pad input path while DMA drives the standard GPIO alias.
 	*portConfigRegister(pin) = 5 | 0x10;
-}
-
-static void enable_standard_gpio_clocks() {
-	// Teensy startup defaults to fast GPIO6-9. ObjectFLED remaps selected pins
-	// back to DMA-visible GPIO1-4, whose clocks are otherwise not guaranteed on.
-	CCM_CCGR1 |= CCM_CCGR1_GPIO1(CCM_CCGR_ON);
-	CCM_CCGR0 |= CCM_CCGR0_GPIO2(CCM_CCGR_ON);
-	CCM_CCGR2 |= CCM_CCGR2_GPIO3(CCM_CCGR_ON);
-	CCM_CCGR3 |= CCM_CCGR3_GPIO4(CCM_CCGR_ON);
-}
-
-static void configure_pin_output_aliases(uint8_t pin, uint32_t mask) {
-	volatile uint32_t *fastOutput = portOutputRegister(pin);
-	volatile uint32_t *standardOutput = standard_gpio_addr(fastOutput);
-	volatile uint32_t *fastMode = portModeRegister(pin);
-	volatile uint32_t *standardMode = standard_gpio_addr(fastMode);
-
-	*gpio_dr_clear_addr(fastOutput) = mask;
-	*gpio_dr_clear_addr(standardOutput) = mask;
-	*fastMode |= mask;
-	*standardMode |= mask;
 }
 
 static void configure_objectfled_xbar_dma_edges() {
@@ -209,7 +184,6 @@ void ObjectFLED::beginInternal(uint16_t period, uint16_t t0h, uint16_t t1h, uint
 void ObjectFLED::begin(void) {
 	auto& dma = ObjectFLEDDmaManager::getInstance();
 	initialized = false;
-	enable_standard_gpio_clocks();
 
 	// Set each pin's bitmask bit, store offset & bit# for pin
 	uint32_t tempBitmask[4] = {0};
@@ -258,7 +232,7 @@ void ObjectFLED::begin(void) {
 			((OUTPUT_PAD_DSE & 0x7) << 3);	//DSE = 0b011 for LED overclock
 		//clear pin bit in IOMUX_GPR26 to map GPIO6-9 to GPIO1-4 for DMA
 		*(&IOMUXC_GPR_GPR26 + offset) &= ~mask;
-		configure_pin_output_aliases(pin, mask);
+		*standard_gpio_addr(portModeRegister(pin)) |= mask;		//GDIR? bit flag set output mode
 	}
 
 	// Check if any valid pins were configured


### PR DESCRIPTION
Reverts #3389.

## Reason
Canonical AutoResearch run after merge regressed from `zero_capture` failure (returns within ~30s) to `timeout` failure (RPC ACK received but final response never sent within 120s). The runSingleTest body hangs somewhere in the new code path.

Symptom before #3389: `bash autoresearch teensy41 --object-fled --tx-pin 22 --rx-pin 8 --timeout 120 --skip-lint` returned `class=zero_capture`, `RX captured 0/300 bytes`, with full ObjectFLED diagnostics attached.

Symptom after #3389:
```
[2/2] Calling runSingleTest()...
[RPC] ACK received for request 2, continuing wait for final response within caller deadline...
[RPC] Timeout: No response with ID 2 within 115.34s
FAILURE class=timeout method=runSingleTest
```

Reverting to keep `teensy-fix` in a known-failing-but-responsive state while the GPIO clock/alias and FlexPWM SELECT_INPUT fixes are re-applied as smaller, individually-validated commits.

Refs: #3359

🤖 Generated with [Claude Code](https://claude.com/claude-code)