### PR TITLE
diag(teensy4): emit FlexPWM RX register snapshot on every runSingleTest

### DIFF
--- a/ci/autoresearch/context.py
+++ b/ci/autoresearch/context.py
@@ -369,6 +369,69 @@ def display_objectfled_diagnostics(result: dict[str, Any]) -> None:
         for line in snapshot.splitlines():
             print(f"      {line}")
 
+    flex_diag = result.get("flexPwmRxDiagnostics")
+    if isinstance(flex_diag, dict):
+        print()
+        print("  FlexPWM RX diagnostics")
+        keys = (
+            "format",
+            "requestedPin",
+            "requestedPinSupported",
+            "requestedDmaSource",
+            "requestedSubmodule",
+            "requestedChannelB",
+            "hasSelectRegister",
+            "activeInstance",
+            "activePin",
+            "activePinMatches",
+            "configured",
+            "receiveDone",
+            "edgesValid",
+            "edgeCount",
+            "captureBufferSize",
+            "activeSubmodule",
+            "activeChannelB",
+            "activeDmaSource",
+            "activeMuxValueLive",
+            "activeMuxValueExpected",
+            "activeSelectValueLive",
+            "activeSelectValueExpected",
+            "mctrl",
+            "ctrl",
+            "ctrl2",
+            "dmaen",
+            "captctrla",
+            "captctrlb",
+            "captcompa",
+            "captcompb",
+            "cval2",
+            "cval3",
+            "cval4",
+            "cval5",
+            "dmaChannel",
+            "dmaErq",
+            "dmaHrs",
+            "dmaInt",
+            "dmaErr",
+            "dmaEs",
+            "dmamuxChcfg",
+            "hasTcd",
+            "saddr",
+            "soff",
+            "attr",
+            "nbytes",
+            "slast",
+            "daddr",
+            "doff",
+            "citer",
+            "dlastsga",
+            "csr",
+            "biter",
+        )
+        for key in keys:
+            if key in flex_diag:
+                print(f"    {key}: {flex_diag[key]}")
+
 
 def print_run_summary(ctx: RunContext) -> None:
     """Print the compact configuration header."""

--- a/examples/AutoResearch/AutoResearchRemoteRunSingleTest.cpp
+++ b/examples/AutoResearch/AutoResearchRemoteRunSingleTest.cpp
@@ -38,6 +38,9 @@
 #include "AutoResearchTimingDrift.h"
 #include "AutoResearchParlioStream.h"
 #include "platforms/arm/teensy/teensy4_common/drivers/objectfled/objectfled_diagnostics.h"
+#if defined(FL_IS_TEENSY_4X)
+#include "platforms/arm/teensy/teensy4_common/rx_flexpwm_channel.h"
+#endif
 #include "fl/chipsets/spi.h"
 #include "fl/channels/config.h"
 #include <Arduino.h>
@@ -810,6 +813,10 @@ fl::json AutoResearchRemoteControl::runSingleTestImpl(const fl::json& args) {
     if (is_object_fled_driver) {
         response.set("objectFledDiagnostics",
                      fl::objectFledDiagnosticsToJson());
+#if defined(FL_IS_TEENSY_4X)
+        response.set("flexPwmRxDiagnostics",
+                     fl::FlexPwmRxChannel::diagnosticsToJson(pin_rx));
+#endif
     }
 
     // Free run_results before building response to reclaim heap

--- a/src/platforms/arm/teensy/teensy4_common/rx_flexpwm_channel.cpp.hpp
+++ b/src/platforms/arm/teensy/teensy4_common/rx_flexpwm_channel.cpp.hpp
@@ -46,6 +46,7 @@
 #include "fl/log/log.h"
 #include "fl/stl/result.h"
 #include "fl/stl/cstring.h"
+#include "fl/stl/bit_cast.h"
 
 // IWYU pragma: begin_keep
 #include <Arduino.h>
@@ -342,6 +343,8 @@ class FlexPwmRxChannelImpl : public FlexPwmRxChannel {
 
     static void dmaIsr();
     static FlexPwmRxChannelImpl *sActiveInstance;
+
+    friend fl::json FlexPwmRxChannel::diagnosticsToJson(int requested_pin) FL_NO_EXCEPT;
 
     int mPin = -1;
     const FlexPwmPinInfo *mPinInfo = nullptr;
@@ -768,6 +771,116 @@ fl::shared_ptr<FlexPwmRxChannel> FlexPwmRxChannel::create(int pin) {
         return fl::shared_ptr<FlexPwmRxChannel>();
     }
     return fl::make_shared<FlexPwmRxChannelImpl>(pin);
+}
+
+// ---------------------------------------------------------------------------
+// Diagnostics
+// ---------------------------------------------------------------------------
+
+static u32 flexPwmDiagPtrToU32(const volatile void *ptr) FL_NO_EXCEPT {
+    return static_cast<u32>(fl::ptr_to_int(const_cast<void *>(ptr)));
+}
+
+static void flexPwmDiagSetU32(fl::json &obj, const char *key, u32 value) FL_NO_EXCEPT {
+    obj.set(key, static_cast<i64>(value));
+}
+
+static void flexPwmDiagSetPtr(fl::json &obj, const char *key,
+                              const volatile void *ptr) FL_NO_EXCEPT {
+    flexPwmDiagSetU32(obj, key, flexPwmDiagPtrToU32(ptr));
+}
+
+fl::json FlexPwmRxChannel::diagnosticsToJson(int requested_pin) FL_NO_EXCEPT {
+    fl::json out = fl::json::object();
+    out.set("format", "flexpwm-rx-diag-v1");
+    out.set("requestedPin", static_cast<i64>(requested_pin));
+
+    const FlexPwmPinInfo *info = lookupPin(requested_pin);
+    out.set("requestedPinSupported", info != nullptr);
+    if (info) {
+        out.set("requestedDmaSource", static_cast<i64>(info->dma_source));
+        out.set("requestedSubmodule", static_cast<i64>(info->submodule));
+        out.set("requestedChannelB", info->channel_b);
+        flexPwmDiagSetPtr(out, "requestedMuxRegister", info->mux_register);
+        flexPwmDiagSetU32(out, "requestedMuxValue", info->mux_value);
+        if (info->select_register) {
+            out.set("hasSelectRegister", true);
+            flexPwmDiagSetPtr(out, "requestedSelectRegister", info->select_register);
+            flexPwmDiagSetU32(out, "requestedSelectValue", info->select_value);
+        } else {
+            out.set("hasSelectRegister", false);
+        }
+    }
+
+    FlexPwmRxChannelImpl *active = FlexPwmRxChannelImpl::sActiveInstance;
+    out.set("activeInstance", active != nullptr);
+    if (!active || !active->mPinInfo) {
+        return out;
+    }
+
+    out.set("activePin", static_cast<i64>(active->mPin));
+    out.set("activePinMatches", active->mPin == requested_pin);
+    out.set("configured", active->mConfigured);
+    out.set("receiveDone", static_cast<bool>(active->mReceiveDone));
+    out.set("edgesValid", active->mEdgesValid);
+    out.set("edgeCount", static_cast<i64>(active->mEdges.size()));
+    out.set("captureBufferSize", static_cast<i64>(active->mCaptureBuffer.size()));
+    out.set("signalRangeMaxNs", static_cast<i64>(active->mSignalRangeMaxNs));
+
+    const FlexPwmPinInfo *active_info = active->mPinInfo;
+    out.set("activeSubmodule", static_cast<i64>(active_info->submodule));
+    out.set("activeChannelB", active_info->channel_b);
+    out.set("activeDmaSource", static_cast<i64>(active_info->dma_source));
+    flexPwmDiagSetU32(out, "activeMuxValueLive", *(active_info->mux_register));
+    flexPwmDiagSetU32(out, "activeMuxValueExpected", active_info->mux_value | 0x10);
+    if (active_info->select_register) {
+        flexPwmDiagSetU32(out, "activeSelectValueLive", *(active_info->select_register));
+        flexPwmDiagSetU32(out, "activeSelectValueExpected", active_info->select_value);
+    }
+
+    const u8 sm = active_info->submodule;
+    IMXRT_FLEXPWM_t *pwm = active_info->pwm;
+    flexPwmDiagSetPtr(out, "pwm", pwm);
+    flexPwmDiagSetU32(out, "mctrl", pwm->MCTRL);
+    flexPwmDiagSetU32(out, "ctrl", pwm->SM[sm].CTRL);
+    flexPwmDiagSetU32(out, "ctrl2", pwm->SM[sm].CTRL2);
+    flexPwmDiagSetU32(out, "dmaen", pwm->SM[sm].DMAEN);
+    flexPwmDiagSetU32(out, "captctrla", pwm->SM[sm].CAPTCTRLA);
+    flexPwmDiagSetU32(out, "captctrlb", pwm->SM[sm].CAPTCTRLB);
+    flexPwmDiagSetU32(out, "captcompa", pwm->SM[sm].CAPTCOMPA);
+    flexPwmDiagSetU32(out, "captcompb", pwm->SM[sm].CAPTCOMPB);
+    flexPwmDiagSetU32(out, "cval2", pwm->SM[sm].CVAL2);
+    flexPwmDiagSetU32(out, "cval3", pwm->SM[sm].CVAL3);
+    flexPwmDiagSetU32(out, "cval4", pwm->SM[sm].CVAL4);
+    flexPwmDiagSetU32(out, "cval5", pwm->SM[sm].CVAL5);
+
+    out.set("dmaChannel", static_cast<i64>(active->mDma.channel));
+    flexPwmDiagSetU32(out, "dmaErq", DMA_ERQ);
+    flexPwmDiagSetU32(out, "dmaHrs", DMA_HRS);
+    flexPwmDiagSetU32(out, "dmaInt", DMA_INT);
+    flexPwmDiagSetU32(out, "dmaErr", DMA_ERR);
+    flexPwmDiagSetU32(out, "dmaEs", DMA_ES);
+    flexPwmDiagSetU32(out, "dmamuxChcfg", *(&DMAMUX_CHCFG0 + active->mDma.channel));
+
+    if (active->mDma.TCD) {
+        out.set("hasTcd", true);
+        flexPwmDiagSetPtr(out, "tcdAddress", active->mDma.TCD);
+        flexPwmDiagSetPtr(out, "saddr", active->mDma.TCD->SADDR);
+        flexPwmDiagSetU32(out, "soff", static_cast<u32>(active->mDma.TCD->SOFF));
+        flexPwmDiagSetU32(out, "attr", active->mDma.TCD->ATTR);
+        flexPwmDiagSetU32(out, "nbytes", active->mDma.TCD->NBYTES);
+        flexPwmDiagSetU32(out, "slast", static_cast<u32>(active->mDma.TCD->SLAST));
+        flexPwmDiagSetPtr(out, "daddr", active->mDma.TCD->DADDR);
+        flexPwmDiagSetU32(out, "doff", static_cast<u32>(active->mDma.TCD->DOFF));
+        flexPwmDiagSetU32(out, "citer", active->mDma.TCD->CITER);
+        flexPwmDiagSetU32(out, "dlastsga", static_cast<u32>(active->mDma.TCD->DLASTSGA));
+        flexPwmDiagSetU32(out, "csr", active->mDma.TCD->CSR);
+        flexPwmDiagSetU32(out, "biter", active->mDma.TCD->BITER);
+    } else {
+        out.set("hasTcd", false);
+    }
+
+    return out;
 }
 
 } // namespace fl

--- a/src/platforms/arm/teensy/teensy4_common/rx_flexpwm_channel.h
+++ b/src/platforms/arm/teensy/teensy4_common/rx_flexpwm_channel.h
@@ -10,6 +10,7 @@
 #if defined(FL_IS_TEENSY_4X)
 
 #include "fl/channels/rx.h"
+#include "fl/stl/json.h"
 #include "fl/stl/shared_ptr.h"
 #include "fl/stl/noexcept.h"
 
@@ -43,6 +44,10 @@ class FlexPwmRxChannel : public RxDevice {
     const char *name() const override;
     int getPin() const FL_NO_EXCEPT override;
     bool injectEdges(fl::span<const EdgeTime> edges) FL_NO_EXCEPT override;
+
+    /// Capture FlexPWM/DMA/IOMUX register snapshot for the active receiver.
+    /// Diagnostics only — does not modify hardware state.
+    static fl::json diagnosticsToJson(int requested_pin) FL_NO_EXCEPT;
 
   protected:
     friend class fl::shared_ptr<FlexPwmRxChannel>;


### PR DESCRIPTION
## Summary
Adds a read-only JSON snapshot of the active FlexPWM input-capture receiver and attaches it to every ObjectFLED `runSingleTest` response.

First diagnostic run on canonical `TX 22 -> RX 8` confirms the zero-capture root cause is **upstream of the receiver**:
- FlexPWM RX is fully armed: `mctrl=0xF00` (submodule 3 RUN set), `captctrla=0x19` (EDGA0/1 + ARMA), `dmaen=0x60` (CAPTDE=1, CA1DE)
- Receiver mux/select live values match expected: `activeMuxValueLive=22` (ALT6 + SION), `activeSelectValueLive=0`
- DMA channel 3 ERQ enabled, TCD descriptor sane
- **`cval2=cval3=cval4=cval5=0` and `citer=4096` never decrements** -> zero edges latched, zero DMA minor loops fired

Conclusion: pin 22 is not toggling during ObjectFLED transmission, even though `objectFledDiagnostics` shows DMA completed (`framebufferIndex=300`, `busy.ready=1`). The next investigation step is whether `GPIO1_DR_SET` / `GPIO1_DR_CLEAR` writes actually drive the pad after `IOMUXC_GPR_GPR26` bit 24 is cleared.

## What changed
- `src/platforms/arm/teensy/teensy4_common/rx_flexpwm_channel.{h,cpp.hpp}`: new `static fl::json FlexPwmRxChannel::diagnosticsToJson(int requested_pin)`. Reads only; never modifies hardware.
- `examples/AutoResearch/AutoResearchRemoteRunSingleTest.cpp`: emits `flexPwmRxDiagnostics` next to existing `objectFledDiagnostics` whenever the run targets ObjectFLED.
- `ci/autoresearch/context.py`: renders the new JSON block under the existing ObjectFLED diagnostics section.

Strictly observability - no change to RX wait logic, ObjectFLED begin/show, or AutoResearch run flow.

## Test plan
- [x] `bash test --unit` -> 254/254 pass
- [x] `bash lint --cpp` -> clean (PlatformIO-internal-usage warnings unchanged)
- [x] `bash autoresearch teensy41 --object-fled --tx-pin 22 --rx-pin 8 --timeout 90 --skip-lint` -> completes in <30s, returns `class=zero_capture` (no regression from prior `teensy-fix` baseline), now emits `flexPwmRxDiagnostics` block with `cval2..5=0` proving zero edges latched.

Refs: #3359

🤖 Generated with [Claude Code](https://claude.com/claude-code)