### PR TITLE
diag(objectfled): snapshot XBARA1_SEL0/SEL1 (correct timer→DMA wiring registers)

### DIFF
--- a/src/platforms/arm/teensy/teensy4_common/drivers/objectfled/objectfled_diagnostics.cpp.hpp
+++ b/src/platforms/arm/teensy/teensy4_common/drivers/objectfled/objectfled_diagnostics.cpp.hpp
@@ -116,6 +116,8 @@ struct SnapshotEvent {
     u32 tmrEnbl = 0;
     u32 xbarSel15 = 0;
     u32 xbarSel47 = 0;
+    u32 xbarSel0 = 0;
+    u32 xbarSel1 = 0;
     u32 xbarCtrl0 = 0;
     u32 xbarCtrl1 = 0;
     DmaSnapshot dma;
@@ -362,6 +364,8 @@ void appendEvent(fl::sstream& out, const SnapshotEvent& event) FL_NO_EXCEPT {
         << " gpr28=" << event.gpr[2]
         << " gpr29=" << event.gpr[3]
         << " tmr4.enbl=" << event.tmrEnbl
+        << " xbar.sel0=" << event.xbarSel0
+        << " xbar.sel1=" << event.xbarSel1
         << " xbar.sel15=" << event.xbarSel15
         << " xbar.sel47=" << event.xbarSel47
         << " xbar.ctrl0=" << event.xbarCtrl0
@@ -470,6 +474,8 @@ void objectFledDiagnosticsRecord(const char* stage, const u8* pins,
     event.tmr[2] = captureTimerChannel(2);
     event.xbarSel15 = XBARA1_SEL15;
     event.xbarSel47 = XBARA1_SEL47;
+    event.xbarSel0 = XBARA1_SEL0;
+    event.xbarSel1 = XBARA1_SEL1;
     event.xbarCtrl0 = XBARA1_CTRL0;
     event.xbarCtrl1 = XBARA1_CTRL1;
     event.dma = captureDma();


### PR DESCRIPTION
## Summary
The existing ObjectFLED snapshot reads `XBARA1_SEL15` / `XBARA1_SEL47` but ObjectFLED actually programs `XBARA1_SEL0` and `XBARA1_SEL1`. Teensy core maps `XBARA1_OUT_DMA_CH_MUX_REQ30 = 0`, `REQ31 = 1`, `REQ94 = 2` (XBAR output indices, not register addresses), and `xbar_connect()` writes to `XBARA1_SEL(output / 2)`.

Adds `xbar.sel0` and `xbar.sel1` to every snapshot event. No runtime behavior change.

## First run evidence on canonical TX 22 -> RX 8
```
xbar.sel0=0x2524  -> output 0 src=0x24=36 (QTIMER4_TIMER0)
                     output 1 src=0x25=37 (QTIMER4_TIMER1)
xbar.sel1=0x0026  -> output 2 src=0x26=38 (QTIMER4_TIMER2)
```

ObjectFLED's TMR4 -> XBAR -> DMAMUX -> DMA wiring is confirmed correct. Combined with prior diagnostics this rules out one more layer; zero_capture root cause remains unidentified.

## Test plan
- [x] `bash test --unit` -> 254/254
- [x] `bash lint --cpp` -> clean (PlatformIO-internal-usage warnings unchanged)
- [x] `bash autoresearch teensy41 --object-fled --tx-pin 22 --rx-pin 8 --timeout 120 --skip-lint` -> completes normally, `class=zero_capture`, new `xbar.sel0`/`sel1` fields render with the QTIMER4 source bytes.

Refs: #3359

🤖 Generated with [Claude Code](https://claude.com/claude-code)