### PR TITLE
fix(ci): make _is_plain_int a TypeGuard so ty narrows int comparisons

### DIFF
--- a/ci/autoresearch/phases.py
+++ b/ci/autoresearch/phases.py
@@ -14,7 +14,7 @@ import sys
 import threading
 import time
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypeGuard
 
 from colorama import Fore, Style
 
@@ -2483,7 +2483,7 @@ async def _run_coroutine_tests(ctx: RunContext) -> int:
 _TEST_RPC_METHODS = frozenset({"runSingleTest", "runParallelTest"})
 
 
-def _is_plain_int(value: Any) -> bool:
+def _is_plain_int(value: Any) -> TypeGuard[int]:
     return isinstance(value, int) and not isinstance(value, bool)
 
 


### PR DESCRIPTION
## Summary
`ty` was failing on every `_is_plain_int(x) and x > 0` style guard in `ci/autoresearch/phases.py` because the predicate returned plain `bool`, so the subsequent comparisons saw `Any | None` instead of narrowed `int`. Annotating the predicate as `TypeGuard[int]` lets `ty` narrow correctly and turns the seven existing comparison-side errors into no-ops at runtime (logic unchanged).

## Test plan
- [x] `uv run ty check ci/autoresearch/phases.py` -> All checks passed
- [x] `bash lint` -> all checks pass

Refs: #3359

🤖 Generated with [Claude Code](https://claude.com/claude-code)