### PR TITLE
fix(delay): terminate delaycycles<> binary-split recursion in every TU

### DIFF
--- a/src/platforms/shared/delay_cycles_generic.h
+++ b/src/platforms/shared/delay_cycles_generic.h
@@ -36,6 +36,20 @@ inline void delaycycles() FL_NO_EXCEPT;
 // These provide the minimum base cases to stop the recursive template from infinitely recursing.
 // All specializations (positive and non-positive cycles) are provided in fl/delay.cpp and linked at compile time.
 // Use #ifndef guard to allow delay.cpp to override these with its definitions
+//
+// CRITICAL: the positive base cases <1> and <2> below are what make the
+// binary-split recursion terminate. The split is delaycycles<N>() ->
+// delaycycles<N/2>() + delaycycles<N - N/2>(). For every N >= 2 both children
+// are strictly smaller than N, so the recursion descends. But at N == 1 the
+// split degenerates to <0> + <1> (HALF=0, REMAINDER=1) and re-instantiates <1>
+// FOREVER. The positive specializations that would stop this live in another
+// translation unit (fl/system/delay.cpp.hpp), so any TU that includes only
+// these headers -- e.g. a clockless/SPI driver calling delaycycles<N>() -- has
+// no <1> base, recurses without bound, and OOMs the compiler (and the
+// cpptools/EDG IntelliSense engine, which instantiates the primary template
+// speculatively). Defining <1> (and <2>) here gives the split a floor in EVERY
+// TU. Guarded by FL_DELAY_CPP_SPECIALIZATIONS so delay.cpp.hpp still provides
+// its own out-of-line copies (it #defines that before including this header).
 #ifndef FL_DELAY_CPP_SPECIALIZATIONS
 template<> FASTLED_FORCE_INLINE void delaycycles<-10>() FL_NO_EXCEPT {}
 template<> FASTLED_FORCE_INLINE void delaycycles<-9>() FL_NO_EXCEPT {}
@@ -48,13 +62,16 @@ template<> FASTLED_FORCE_INLINE void delaycycles<-3>() FL_NO_EXCEPT {}
 template<> FASTLED_FORCE_INLINE void delaycycles<-2>() FL_NO_EXCEPT {}
 template<> FASTLED_FORCE_INLINE void delaycycles<-1>() FL_NO_EXCEPT {}
 template<> FASTLED_FORCE_INLINE void delaycycles<0>() FL_NO_EXCEPT {}
+template<> FASTLED_FORCE_INLINE void delaycycles<1>() FL_NO_EXCEPT { FL_NOP; }
+template<> FASTLED_FORCE_INLINE void delaycycles<2>() FL_NO_EXCEPT { FL_NOP2; }
 #endif
 
 /// Delay for N clock cycles (generic NOP-based implementation)
 /// Uses binary splitting to minimize template instantiation depth
 /// Recursively splits the delay into two halves:
 /// delaycycles<N>() → delaycycles<N/2>() + delaycycles<N - N/2>()
-/// Base cases (0-50) are specialized in fl/delay.cpp for efficiency
+/// Terminates at the <0>/<1>/<2> base cases above (present in every TU); larger
+/// cases (3-50) also have out-of-line specializations in fl/system/delay.cpp.hpp.
 template<fl::cycle_t CYCLES>
 FASTLED_FORCE_INLINE void delaycycles() FL_NO_EXCEPT {
   constexpr fl::cycle_t HALF = CYCLES / 2;


### PR DESCRIPTION
My cpptools kept blowing up on this repository and OOM hosing my dev machine. I managed to track it to a naughty recursive template (new concept to me, wild stuff!).

Here's claude's diagnosis and fix:

The generic delaycycles<N>() splits into delaycycles<N/2>() + delaycycles<N - N/2>(). This descends for every N >= 2, but at N == 1 it degenerates to <0> + <1> (HALF=0, REMAINDER=1) and re-instantiates <1> without bound.

The positive base-case specializations that would stop this (delaycycles<1>, <2>, ...) are defined only in fl/system/delay.cpp.hpp, so any translation unit that includes just the headers and calls delaycycles<N>() -- e.g. a clockless or bit-banged SPI driver, or nrf51's INNER_SEI which calls delaycycles<1>() directly -- has no <1> floor. The recursion never terminates, OOMing the compiler and the cpptools/EDG IntelliSense engine (which speculatively instantiates the primary template to full depth).

Add the <1> and <2> base cases to the generic header under the existing FL_DELAY_CPP_SPECIALIZATIONS guard, matching the <=0 bases already there. This gives the split a termination floor in every TU while delay.cpp.hpp keeps providing its out-of-line copies for the build that defines the guard.

Verified: without the fix, delaycycles<1>() fails to compile with "recursive inlining" at -ftemplate-depth=64; with it, delaycycles<N>() compiles and emits exactly N nops.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved short delay handling so very small timing requests are now covered consistently.
  * Fixed missing base cases for 1- and 2-cycle delays, helping ensure delay behavior terminates correctly across all builds.
  * Clarified delay behavior documentation to reflect which timing cases are always available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->