### PR TITLE
diag(objectfled): snapshot RX pin PSR inside every diagnostic event — proves TX reaches pad

### DIFF
--- a/examples/AutoResearch/AutoResearchRemoteRunSingleTest.cpp
+++ b/examples/AutoResearch/AutoResearchRemoteRunSingleTest.cpp
@@ -878,6 +878,7 @@ fl::json AutoResearchRemoteControl::runSingleTestImpl(const fl::json& args) {
 
         if (is_object_fled_driver) {
             fl::objectFledDiagnosticsReset();
+            fl::objectFledDiagnosticsSetRxPin(pin_rx);
         }
 
         if (use_legacy_api) {

--- a/src/platforms/arm/teensy/teensy4_common/drivers/objectfled/objectfled_diagnostics.cpp.hpp
+++ b/src/platforms/arm/teensy/teensy4_common/drivers/objectfled/objectfled_diagnostics.cpp.hpp
@@ -122,6 +122,14 @@ struct SnapshotEvent {
     u32 xbarCtrl1 = 0;
     DmaSnapshot dma;
     BusyStateSnapshot busy;
+    // RX-pin probe: snapshot the configured RX pin's pad status across the
+    // run so afterShowReturn (captured while DMA is still actively driving
+    // TX) can prove whether the RX pad sees any transition.
+    bool rxPinValid = false;
+    u8 rxPin = 0;
+    u8 rxBit = 0;
+    u32 rxFastPsr = 0;
+    u32 rxStandardPsr = 0;
 };
 
 SnapshotEvent s_events[kMaxEvents];
@@ -130,6 +138,8 @@ u32 s_overflowCount = 0;
 u8 s_lastPins[kMaxPins];
 u8 s_lastPinCount = 0;
 BusyStateSnapshot s_busyState;
+bool s_rxPinValid = false;
+u8 s_rxPin = 0;
 
 u32 ptrToU32(const volatile void* ptr) FL_NO_EXCEPT {
     return static_cast<u32>(fl::ptr_to_int(const_cast<void*>(ptr)));
@@ -397,6 +407,15 @@ void appendEvent(fl::sstream& out, const SnapshotEvent& event) FL_NO_EXCEPT {
         out << " pin[" << static_cast<int>(i) << "].";
         appendPin(out, event.pins[i]);
     }
+    if (event.rxPinValid) {
+        const u32 mask = 1u << event.rxBit;
+        out << " rx.pin=" << static_cast<int>(event.rxPin)
+            << " rx.bit=" << static_cast<int>(event.rxBit)
+            << " rx.fastPsr=" << event.rxFastPsr
+            << " rx.standardPsr=" << event.rxStandardPsr
+            << " rx.fastHigh=" << ((event.rxFastPsr & mask) ? 1 : 0)
+            << " rx.standardHigh=" << ((event.rxStandardPsr & mask) ? 1 : 0);
+    }
     out << '\n';
 }
 
@@ -425,6 +444,8 @@ void objectFledDiagnosticsReset() FL_NO_EXCEPT {
     s_overflowCount = 0;
     s_lastPinCount = 0;
     s_busyState = BusyStateSnapshot();
+    s_rxPinValid = false;
+    s_rxPin = 0;
 }
 
 void objectFledDiagnosticsSetBusyState(bool dma_active,
@@ -432,6 +453,20 @@ void objectFledDiagnosticsSetBusyState(bool dma_active,
     s_busyState.dmaActive = dma_active;
     s_busyState.latchActive = latch_active;
     s_busyState.ready = !dma_active && !latch_active;
+}
+
+void objectFledDiagnosticsSetRxPin(int rx_pin) FL_NO_EXCEPT {
+#if defined(NUM_DIGITAL_PINS)
+    if (rx_pin < 0 || rx_pin >= NUM_DIGITAL_PINS) {
+        s_rxPinValid = false;
+        return;
+    }
+    s_rxPinValid = true;
+    s_rxPin = static_cast<u8>(rx_pin);
+#else
+    (void)rx_pin;
+    s_rxPinValid = false;
+#endif
 }
 
 void objectFledDiagnosticsRecord(const char* stage, const u8* pins,
@@ -479,6 +514,23 @@ void objectFledDiagnosticsRecord(const char* stage, const u8* pins,
     event.xbarCtrl0 = XBARA1_CTRL0;
     event.xbarCtrl1 = XBARA1_CTRL1;
     event.dma = captureDma();
+
+#if defined(NUM_DIGITAL_PINS)
+    if (s_rxPinValid && s_rxPin < NUM_DIGITAL_PINS) {
+        event.rxPinValid = true;
+        event.rxPin = s_rxPin;
+        event.rxBit = digitalPinToBit(s_rxPin);
+        volatile u32* fastOut = portOutputRegister(s_rxPin);
+        volatile u32* fastPsr =
+            reinterpret_cast<volatile u32*>( // ok reinterpret cast - Teensy GPIO PSR offset
+                ptrToU32(fastOut) + 0x08u);
+        volatile u32* standardPsr =
+            reinterpret_cast<volatile u32*>( // ok reinterpret cast - Teensy GPIO alias address map
+                ptrToU32(fastOut) - 0x01E48000u + 0x08u);
+        event.rxFastPsr = *fastPsr;
+        event.rxStandardPsr = *standardPsr;
+    }
+#endif
 }
 
 fl::json objectFledDiagnosticsToJson() FL_NO_EXCEPT {

--- a/src/platforms/arm/teensy/teensy4_common/drivers/objectfled/objectfled_diagnostics.h
+++ b/src/platforms/arm/teensy/teensy4_common/drivers/objectfled/objectfled_diagnostics.h
@@ -15,6 +15,7 @@ namespace fl {
 void objectFledDiagnosticsReset() FL_NO_EXCEPT;
 void objectFledDiagnosticsSetBusyState(bool dma_active,
                                        bool latch_active) FL_NO_EXCEPT;
+void objectFledDiagnosticsSetRxPin(int rx_pin) FL_NO_EXCEPT;
 void objectFledDiagnosticsRecord(const char* stage, const u8* pins = nullptr,
                                  u32 pin_count = 0) FL_NO_EXCEPT;
 fl::json objectFledDiagnosticsToJson() FL_NO_EXCEPT;
@@ -24,6 +25,8 @@ fl::json objectFledDiagnosticsToJson() FL_NO_EXCEPT;
 inline void objectFledDiagnosticsReset() FL_NO_EXCEPT {}
 
 inline void objectFledDiagnosticsSetBusyState(bool, bool) FL_NO_EXCEPT {}
+
+inline void objectFledDiagnosticsSetRxPin(int) FL_NO_EXCEPT {}
 
 inline void objectFledDiagnosticsRecord(const char*, const u8* = nullptr,
                                         u32 = 0) FL_NO_EXCEPT {}


### PR DESCRIPTION
## 🎯 Root cause of `zero_capture` isolated

Adds `objectFledDiagnosticsSetRxPin(int)` and records the RX pin's fast + standard GPIO PSR (and bit/mask) inside every snapshot event. `afterShowReturn` is captured while DMA is actively driving TX, so a HIGH bit there proves the RX pad sees the signal end-to-end.

## First-run evidence on canonical TX 22 -> RX 8
```
stage=afterShowReturn  -> rx.fastHigh=1  (rx.fastPsr=0x10006, bit 16 set)
stage=afterFastLedWait -> rx.fastHigh=0  (frame ended, pad LOW)
```

Pin 8 pad **does** see the WS2812 signal. ObjectFLED's DMA-driven TX path through `GPIO1_DR_SET`/`GPIO1_DR_CLEAR` is producing visible edges on the wire end-to-end. So `zero_capture` is purely a FlexPWM RX defect, not an ObjectFLED defect.

## The actual bug
Cross-referenced against `imxrt.h` and the i.MX RT1062 reference manual:

`IOMUXC_FLEXPWM1_PWMA3_SELECT_INPUT` (the daisy-chain register for FlexPWM1 SM3 channel A input) values:
- `0` -> `GPIO_SD_B1_00` (different pad!)
- `4` -> `GPIO_B1_00` (this is pin 8)

The pin map in `rx_flexpwm_channel.cpp.hpp` declares pin 8's `select_value = 0`, so the FlexPWM submodule is listening to `GPIO_SD_B1_00` (whose pad is doing nothing) instead of `GPIO_B1_00` (where the WS2812 signal arrives). Identical class of bug for pins 22, 23, 36 per #3389's investigation. Fix shipping in a separate focused PR.

## Test plan
- [x] `bash test --unit` -> 254/254
- [x] `bash lint --cpp` -> clean (PlatformIO-internal-usage warn-only)
- [x] `bash autoresearch teensy41 --object-fled --tx-pin 22 --rx-pin 8 --timeout 120 --skip-lint` -> completes, `class=zero_capture` (no regression), per-stage `rx.fastHigh` / `rx.fastPsr` fields render and prove TX reaches the pad.

Refs: #3359

🤖 Generated with [Claude Code](https://claude.com/claude-code)