### PR TITLE
fix(teensy4-rx): route FlexPWM1_SM3_A from GPIO_B1_00 (pin 8); skip DMA completion ISR

### DIFF
--- a/src/platforms/arm/teensy/teensy4_common/rx_flexpwm_channel.cpp.hpp
+++ b/src/platforms/arm/teensy/teensy4_common/rx_flexpwm_channel.cpp.hpp
@@ -114,9 +114,12 @@ static const FlexPwmPinInfo kPinMap[] = {
      &IOMUXC_FLEXPWM2_PWMA2_SELECT_INPUT, 1},
 
     // Pin 8: FlexPWM1_SM3_A (GPIO_B1_00, ALT6)
+    // SELECT_INPUT=4 routes from GPIO_B1_00 (pin 8). The previous value 0
+    // selected GPIO_SD_B1_00, an unrelated pad, so FlexPWM never saw the
+    // pin 8 signal -- #3359 zero_capture root cause for canonical TX22->RX8.
     {8, &IMXRT_FLEXPWM1, 3, false, DMAMUX_SOURCE_FLEXPWM1_READ3,
      &IOMUXC_SW_MUX_CTL_PAD_GPIO_B1_00, 6,
-     &IOMUXC_FLEXPWM1_PWMA3_SELECT_INPUT, 0},
+     &IOMUXC_FLEXPWM1_PWMA3_SELECT_INPUT, 4},
 
     // Pin 22: FlexPWM4_SM0_A (GPIO_AD_B1_08, ALT1)
     {22, &IMXRT_FLEXPWM4, 0, false, DMAMUX_SOURCE_FLEXPWM4_READ0,
@@ -513,8 +516,14 @@ void FlexPwmRxChannelImpl::configureDma() {
     mDma.TCD->BITER = mCaptureBuffer.size() / 2;
     mDma.TCD->CSR = DMA_TCD_CSR_DREQ;
     mDma.triggerAtHardwareEvent(mPinInfo->dma_source);
-    mDma.interruptAtCompletion();
-    mDma.attachInterrupt(dmaIsr);
+    // NOTE: dmaIsr is intentionally NOT attached. On Teensy 4.x, once
+    // SELECT_INPUT is corrected so FlexPWM actually captures the WS2812
+    // signal, registering a major-loop completion interrupt for the
+    // RX DMA channel caused runSingleTest to hang (>120 s RPC timeout
+    // with no firmware response). The wait() loop below already covers
+    // termination via the CITER-inactivity branch (mSignalRangeMaxNs),
+    // so the ISR is a convenience the driver does not need. Root cause
+    // of the ISR-induced hang is tracked separately in #3359 follow-up.
     mDma.enable();
 }
 


### PR DESCRIPTION
## 🎯 First real capture data on canonical TX 22 -> RX 8

Two coupled changes that move ObjectFLED + FlexPWM RX acceptance from `zero_capture` to `decode_mismatch` (real capture data flowing).

### 1. Pin 8 SELECT_INPUT was wrong
The pin map declared `SELECT_INPUT=0` for pin 8 which is `GPIO_SD_B1_00` (an unrelated pad). FlexPWM1 SM3 channel A was listening to the wrong pad even though pin 8's IOMUX + SION routed the input correctly. The diagnostic snapshot from #3399 already proved pin 8's pad sees the WS2812 signal (`rx.fastHigh=1` at `afterShowReturn`), while FlexPWM still reported `cval2..5 = 0`. Classic SELECT_INPUT signature.

Corrected to `4` (`GPIO_B1_00`) per the i.MX RT1062 `IOMUXC_FLEXPWM1_PWMA3_SELECT_INPUT` table.

### 2. DMA completion ISR caused runSingleTest to hang
With the SELECT_INPUT corrected, registering `interruptAtCompletion()` + `attachInterrupt(dmaIsr)` caused runSingleTest to ACK then never return (>120 s RPC timeout, no firmware response). Disabling the ISR registration restored normal execution. `wait()` already terminates via the CITER-inactivity branch (`mSignalRangeMaxNs`), so the ISR is a convenience the driver does not need.

Root-cause investigation of the ISR-induced hang is deferred to a follow-up — immediate priority is unblocking acceptance.

## Hardware evidence
```
bash autoresearch teensy41 --object-fled --tx-pin 22 --rx-pin 8 --timeout 60 --skip-lint

TEST OBJECT_FLED lanes=1 leds=100 FAIL 31 ms class=decode_mismatch
flexPwmRxDiagnostics:
  cval2=27599   <- was 0 before; now real capture register values
  cval3=27633
  citer=1696    <- was 4096 (max); decremented by 2400 minor loops
                   == one full WS2812 frame captured
```

`decode_mismatch` (not `zero_capture`, not `timeout`) is real progress. The next debugging surface is decoder-side, not RX-side. PASS still requires the captured bytes to match the expected pattern, which is the next leaf task.

## Test plan
- [x] `bash test --unit` -> 254/254 passed
- [x] `bash lint --cpp` -> clean (PlatformIO-internal-usage warn-only)
- [x] `bash autoresearch teensy41 --object-fled --tx-pin 22 --rx-pin 8 --timeout 60 --skip-lint` -> completes in 31 ms, `class=decode_mismatch`, FlexPWM RX captured one full WS2812 frame's worth of edges.

Refs: #3359

🤖 Generated with [Claude Code](https://claude.com/claude-code)