### PR TITLE
Revert "fix(teensy4-rx): SELECT_INPUT pin 8 + skip ISR (#3400)" — reproducible hang/crash

### DIFF
--- a/src/platforms/arm/teensy/teensy4_common/rx_flexpwm_channel.cpp.hpp
+++ b/src/platforms/arm/teensy/teensy4_common/rx_flexpwm_channel.cpp.hpp
@@ -114,12 +114,9 @@ static const FlexPwmPinInfo kPinMap[] = {
      &IOMUXC_FLEXPWM2_PWMA2_SELECT_INPUT, 1},
 
     // Pin 8: FlexPWM1_SM3_A (GPIO_B1_00, ALT6)
-    // SELECT_INPUT=4 routes from GPIO_B1_00 (pin 8). The previous value 0
-    // selected GPIO_SD_B1_00, an unrelated pad, so FlexPWM never saw the
-    // pin 8 signal -- #3359 zero_capture root cause for canonical TX22->RX8.
     {8, &IMXRT_FLEXPWM1, 3, false, DMAMUX_SOURCE_FLEXPWM1_READ3,
      &IOMUXC_SW_MUX_CTL_PAD_GPIO_B1_00, 6,
-     &IOMUXC_FLEXPWM1_PWMA3_SELECT_INPUT, 4},
+     &IOMUXC_FLEXPWM1_PWMA3_SELECT_INPUT, 0},
 
     // Pin 22: FlexPWM4_SM0_A (GPIO_AD_B1_08, ALT1)
     {22, &IMXRT_FLEXPWM4, 0, false, DMAMUX_SOURCE_FLEXPWM4_READ0,
@@ -516,14 +513,8 @@ void FlexPwmRxChannelImpl::configureDma() {
     mDma.TCD->BITER = mCaptureBuffer.size() / 2;
     mDma.TCD->CSR = DMA_TCD_CSR_DREQ;
     mDma.triggerAtHardwareEvent(mPinInfo->dma_source);
-    // NOTE: dmaIsr is intentionally NOT attached. On Teensy 4.x, once
-    // SELECT_INPUT is corrected so FlexPWM actually captures the WS2812
-    // signal, registering a major-loop completion interrupt for the
-    // RX DMA channel caused runSingleTest to hang (>120 s RPC timeout
-    // with no firmware response). The wait() loop below already covers
-    // termination via the CITER-inactivity branch (mSignalRangeMaxNs),
-    // so the ISR is a convenience the driver does not need. Root cause
-    // of the ISR-induced hang is tracked separately in #3359 follow-up.
+    mDma.interruptAtCompletion();
+    mDma.attachInterrupt(dmaIsr);
     mDma.enable();
 }
 


### PR DESCRIPTION
Reverts #3400.

## Reason
PR #3400 changed pin 8's SELECT_INPUT from 0 to 4 and disabled the FlexPWM RX DMA completion ISR. One initial run produced `decode_mismatch in 31 ms` with real `cval2/cval3/citer` values (proving the SELECT_INPUT fix was directionally correct). Subsequent runs consistently regressed:

- **Most runs**: `runSingleTest` RPC ACKed but no final response within the 120 s deadline. Firmware hangs.
- **One run produced a hard CrashReport**: `(DACCVIOL) Data Access Violation - Accessed Address: 0x519E5153` (wild pointer, outside any valid Teensy 4.x memory region).

So the SELECT_INPUT fix exposes a downstream bug — likely DMA TCD reconfigured while a pending hardware request is still in flight on the channel — that is worse than the original `zero_capture` failure.

Reverting to put `teensy-fix` back in the diagnosable-but-not-crashing state. The follow-up will:
1. Re-apply pin 8 `SELECT_INPUT = 4`
2. **Also** add `mDma.disable()` before TCD reconfig in `configureDma()` and an explicit `mDma.clearComplete()`/`mDma.clearInterrupt()` so the channel is fully quiesced before being re-armed for the next test pattern
3. Re-enable the completion ISR (its removal was a workaround, not a fix)

Refs: #3359

🤖 Generated with [Claude Code](https://claude.com/claude-code)