### PR TITLE
fix(teensy4-rx): pin 8 SELECT_INPUT=4 + DMA quiesce before TCD reconfig

### DIFF
--- a/src/platforms/arm/teensy/teensy4_common/rx_flexpwm_channel.cpp.hpp
+++ b/src/platforms/arm/teensy/teensy4_common/rx_flexpwm_channel.cpp.hpp
@@ -114,9 +114,12 @@ static const FlexPwmPinInfo kPinMap[] = {
      &IOMUXC_FLEXPWM2_PWMA2_SELECT_INPUT, 1},
 
     // Pin 8: FlexPWM1_SM3_A (GPIO_B1_00, ALT6)
+    // SELECT_INPUT=4 routes from GPIO_B1_00 (pin 8). The previous value 0
+    // selected GPIO_SD_B1_00, an unrelated pad, so FlexPWM never saw the
+    // pin 8 signal -- #3359 zero_capture root cause for canonical TX22->RX8.
     {8, &IMXRT_FLEXPWM1, 3, false, DMAMUX_SOURCE_FLEXPWM1_READ3,
      &IOMUXC_SW_MUX_CTL_PAD_GPIO_B1_00, 6,
-     &IOMUXC_FLEXPWM1_PWMA3_SELECT_INPUT, 0},
+     &IOMUXC_FLEXPWM1_PWMA3_SELECT_INPUT, 4},
 
     // Pin 22: FlexPWM4_SM0_A (GPIO_AD_B1_08, ALT1)
     {22, &IMXRT_FLEXPWM4, 0, false, DMAMUX_SOURCE_FLEXPWM4_READ0,
@@ -498,6 +501,19 @@ void FlexPwmRxChannelImpl::configureDma() {
     }
 
     mDma.begin();
+
+    // Quiesce the channel before rewriting the TCD. configureDma() runs
+    // once per test pattern (i.e. per capture()) and the previous pattern
+    // may have left ERQ set, a pending interrupt latched, or an in-flight
+    // hardware request mid-minor-loop. Modifying the TCD while a transfer
+    // is active is undefined behavior on i.MX RT eDMA and was the trigger
+    // for the runSingleTest hang/DACCVIOL we hit in #3400 once
+    // SELECT_INPUT started routing real edges into the submodule.
+    mDma.disable();
+    mDma.clearComplete();
+    mDma.clearInterrupt();
+    mDma.clearError();
+
     mDma.TCD->SADDR = const_cast<u16 *>(capture_reg);
     mDma.TCD->SOFF = 4;
     mDma.TCD->ATTR = DMA_TCD_ATTR_SSIZE(1) | DMA_TCD_ATTR_DSIZE(1);


### PR DESCRIPTION
## Re-applies #3400's routing fix with the actual DMA-side defensive sequence

After #3400 was reverted in #3401, this PR ships both pieces together:

### 1. Pin 8 SELECT_INPUT 0 → 4
`GPIO_B1_00` (pin 8) is `SELECT_INPUT = 4` for `IOMUXC_FLEXPWM1_PWMA3_SELECT_INPUT`. The previous `0` selected `GPIO_SD_B1_00`, an unrelated pad — FlexPWM never saw pin 8's signal.

### 2. Quiesce the DMA channel before rewriting the TCD
`configureDma()` runs once per `capture()` call. The previous test pattern may have left ERQ set with an in-flight minor loop. Modifying the TCD while a transfer is active is undefined behavior on i.MX RT eDMA and was the trigger for the runSingleTest hang / `DACCVIOL @ 0x519E5153` in the original #3400. Now `configureDma()` does:
```
mDma.disable();
mDma.clearComplete();
mDma.clearInterrupt();
mDma.clearError();
```
before any TCD writes. The completion ISR can stay attached.

## Hardware evidence (two consecutive runs)
```
bash autoresearch teensy41 --object-fled --tx-pin 22 --rx-pin 8 --timeout 60 --skip-lint

Run 1: TEST OBJECT_FLED lanes=1 leds=100 FAIL 31 ms class=decode_mismatch
       cval2=27520 cval3=27554 citer=1696
Run 2: TEST OBJECT_FLED lanes=1 leds=100 FAIL 31 ms class=decode_mismatch
       cval2=27635           citer=1696
```

Deterministic, no hang, no crash. Each test pattern captures one full WS2812 frame (2400 minor loops out of the 4096-CITER buffer) and the decoder operates on real edge data. Bytes-decoded is still `0/300` — that is a decoder/timing issue, not an RX-path issue, and is the next leaf task.

## Test plan
- [x] `bash test --unit` → 254/254 passed
- [x] `bash lint --cpp` → clean (PlatformIO-internal-usage warn-only)
- [x] `bash autoresearch teensy41 --object-fled --tx-pin 22 --rx-pin 8 --timeout 60 --skip-lint` → deterministic `class=decode_mismatch` in ~31 ms, real `cval` and `citer` values, no hang/crash.

Refs: #3359

🤖 Generated with [Claude Code](https://claude.com/claude-code)