### PR TITLE
fix(teensy4-rx): pin 22/23 SELECT_INPUT=1, pin 36 SELECT_INPUT=4 (datasheet audit)

### DIFF
--- a/src/platforms/arm/teensy/teensy4_common/rx_flexpwm_channel.cpp.hpp
+++ b/src/platforms/arm/teensy/teensy4_common/rx_flexpwm_channel.cpp.hpp
@@ -122,14 +122,20 @@ static const FlexPwmPinInfo kPinMap[] = {
      &IOMUXC_FLEXPWM1_PWMA3_SELECT_INPUT, 4},
 
     // Pin 22: FlexPWM4_SM0_A (GPIO_AD_B1_08, ALT1)
+    // SELECT_INPUT=1 routes from GPIO_AD_B1_08 per the i.MX RT1062
+    // IOMUXC_FLEXPWM4_PWMA0_SELECT_INPUT daisy table. Previous value 0
+    // selected a different pad and would have silently failed FlexPWM RX
+    // capture on pin 22 (same class of bug as #3402's pin 8 fix).
     {22, &IMXRT_FLEXPWM4, 0, false, DMAMUX_SOURCE_FLEXPWM4_READ0,
      &IOMUXC_SW_MUX_CTL_PAD_GPIO_AD_B1_08, 1,
-     &IOMUXC_FLEXPWM4_PWMA0_SELECT_INPUT, 0},
+     &IOMUXC_FLEXPWM4_PWMA0_SELECT_INPUT, 1},
 
     // Pin 23: FlexPWM4_SM1_A (GPIO_AD_B1_09, ALT1)
+    // SELECT_INPUT=1 routes from GPIO_AD_B1_09 per the i.MX RT1062
+    // IOMUXC_FLEXPWM4_PWMA1_SELECT_INPUT daisy table.
     {23, &IMXRT_FLEXPWM4, 1, false, DMAMUX_SOURCE_FLEXPWM4_READ1,
      &IOMUXC_SW_MUX_CTL_PAD_GPIO_AD_B1_09, 1,
-     &IOMUXC_FLEXPWM4_PWMA1_SELECT_INPUT, 0},
+     &IOMUXC_FLEXPWM4_PWMA1_SELECT_INPUT, 1},
 
     // Pin 29: FlexPWM3_SM1_B (GPIO_EMC_31, ALT1)
     {29, &IMXRT_FLEXPWM3, 1, true, DMAMUX_SOURCE_FLEXPWM3_READ1,
@@ -140,9 +146,12 @@ static const FlexPwmPinInfo kPinMap[] = {
     // Teensy 4.1 only pins
 
     // Pin 36: FlexPWM2_SM3_A (GPIO_B1_02, ALT6)
+    // SELECT_INPUT=4 routes from GPIO_B1_02 per the i.MX RT1062
+    // IOMUXC_FLEXPWM2_PWMA3_SELECT_INPUT daisy table. Mirrors the same
+    // GPIO_B1_xx / FlexPWM*_PWMA3 / ALT6 pattern as pin 8.
     {36, &IMXRT_FLEXPWM2, 3, false, DMAMUX_SOURCE_FLEXPWM2_READ3,
      &IOMUXC_SW_MUX_CTL_PAD_GPIO_B1_02, 6,
-     &IOMUXC_FLEXPWM2_PWMA3_SELECT_INPUT, 1},
+     &IOMUXC_FLEXPWM2_PWMA3_SELECT_INPUT, 4},
 
     // Pin 49: FlexPWM1_SM2_A (GPIO_EMC_23, ALT1) [bottom pads]
     {49, &IMXRT_FLEXPWM1, 2, false, DMAMUX_SOURCE_FLEXPWM1_READ2,


### PR DESCRIPTION
## Summary
Three more FlexPWM input-capture daisy-chain values were wrong — same class of bug as #3402's pin 8 fix. Independent subagent audit cross-checked every pin in `kPinMap[]` against the i.MX RT1062 `IOMUXC_FLEXPWM*_SELECT_INPUT` tables and identified these three:

| Pin | Pad | Register | Was | Should be |
|-----|-----|---------|-----|----------|
| 22 | `GPIO_AD_B1_08` | `IOMUXC_FLEXPWM4_PWMA0_SELECT_INPUT` | 0 | **1** |
| 23 | `GPIO_AD_B1_09` | `IOMUXC_FLEXPWM4_PWMA1_SELECT_INPUT` | 0 | **1** |
| 36 | `GPIO_B1_02` | `IOMUXC_FLEXPWM2_PWMA3_SELECT_INPUT` | 1 | **4** |

With the wrong DAISY value the FlexPWM submodule listens to an unrelated pad, so any AutoResearch run that uses one of these pins as RX would silently fail with `zero_capture` — exactly the signature pin 8 produced before #3402.

## Sanity check on canonical test
The canonical `TX 22 -> RX 8` test uses pin 8 as RX (already correct in #3402). Re-ran to confirm no regression:
```
TEST OBJECT_FLED lanes=1 leds=100 FAIL 32 ms class=decode_mismatch
Byte corruption: 0.7% (8/1200 total bytes)
```

Unchanged — 99.3% bit accuracy, same as before.

## Audit context
This PR is the first concrete fix from a four-agent datasheet audit launched after #3402 showed the SELECT_INPUT class of bug. Agent A audited the FlexPWM RX pin map (12 pins × 5 fields each). Agents B/C/D audited ObjectFLED standard-alias arithmetic, `imxrt.h` symbol → datasheet match, and the FlexPWM RX DMA TCD semantics respectively.

Agent A also confirmed pins 2, 4, 5, 6, 8, 29, 49, 53, 54 are all correct.

## Test plan
- [x] `bash test --unit` → 254/254 passed
- [x] `bash lint --cpp` → clean
- [x] `bash autoresearch teensy41 --object-fled --tx-pin 22 --rx-pin 8 --timeout 60 --skip-lint` → no regression (99.3% bit accuracy unchanged)
- [ ] Future: re-test with pin 22/23/36 as RX once a hardware setup with one of those pins as RX is available.

Refs: #3359

🤖 Generated with [Claude Code](https://claude.com/claude-code)