### PR TITLE
fix(teensy-flexio): bound every busy-loop + harden ISR/deinit lifecycle

### DIFF
--- a/src/platforms/arm/teensy/teensy4_common/drivers/flexio/channel_engine_flexio.cpp.hpp
+++ b/src/platforms/arm/teensy/teensy4_common/drivers/flexio/channel_engine_flexio.cpp.hpp
@@ -15,6 +15,12 @@
 #include "fl/log/log.h"
 #include "fl/stl/noexcept.h"
 
+#if defined(FL_IS_TEENSY_4X)
+// IWYU pragma: begin_keep
+#include <Arduino.h>
+// IWYU pragma: end_keep
+#endif
+
 namespace fl {
 
 // Timing period bounds for canHandle() filtering.
@@ -76,10 +82,27 @@ void ChannelEngineFlexIO::show() FL_NO_EXCEPT {
         return;
     }
 
-    // Wait for any previous transmission (per DMA Wait Pattern)
+    // Wait for any previous transmission (per DMA Wait Pattern). Bounded
+    // wait so a stuck FlexIO from a previous show cannot hang subsequent
+    // shows -- if poll never becomes READY, force-drop the previous channel
+    // set and proceed. 100 ms is plenty for any reasonable WS2812 frame.
+#if defined(FL_IS_TEENSY_4X)
+    const u32 spin_start = millis();
+    while (poll() != DriverState::READY) {
+        if ((u32)(millis() - spin_start) >= 100) {
+            // Previous transmission stuck -- force-clear so we can proceed.
+            for (auto& ch : mTransmittingChannels) {
+                ch->setInUse(false);
+            }
+            mTransmittingChannels.clear();
+            break;
+        }
+    }
+#else
     while (poll() != DriverState::READY) {
         // Spin until FlexIO DMA completes
     }
+#endif
 
     // Move enqueued → transmitting
     mTransmittingChannels.swap(mEnqueuedChannels);

--- a/src/platforms/arm/teensy/teensy4_common/drivers/flexio/flexio_driver.cpp.hpp
+++ b/src/platforms/arm/teensy/teensy4_common/drivers/flexio/flexio_driver.cpp.hpp
@@ -12,6 +12,7 @@
 #include "fl/stl/cstring.h"
 
 // IWYU pragma: begin_keep
+#include <Arduino.h>
 #include <imxrt.h>
 #include <DMAChannel.h>
 // IWYU pragma: end_keep
@@ -111,7 +112,13 @@ static constexpr u32 kMaxPixelBytes = 4096;
 DMAMEM static u32 sPixelBuffer[kMaxPixelBytes / 4] __attribute__((aligned(32)));
 
 static void flexio_dma_isr() {
-    sDmaChannel->clearInterrupt();
+    // Guard: deinit() can delete sDmaChannel while a pending IRQ is still
+    // queued at the NVIC. Without this check the next IRQ vector services
+    // a deleted channel and dereferences a freed pointer (IMPRECISERR
+    // data bus fault observed during FlexIO bring-up, #3410).
+    if (sDmaChannel != nullptr) {
+        sDmaChannel->clearInterrupt();
+    }
     sDmaComplete = true;
 }
 
@@ -150,9 +157,20 @@ static void flexio_pin_init(const FlexIOPinInfo& pin_info) {
 
 static void flexio_configure_hw(u8 flexio_pin, u32 t0h_clocks, u32 t1h_clocks,
                                  u32 period_clocks, u32 latch_clocks) {
-    // Software reset
+    // Software reset. Bounded wait — if FLEXIO2 doesn't respond within
+    // a few microseconds, the peripheral isn't actually clocked (CCM
+    // misconfig, clock gate stuck, etc.) and looping forever just turns
+    // a setup-time failure into an RPC timeout. Give up after a short
+    // timeout so the failure is observable.
     FLEXIO2_CTRL = (1 << 1);
-    while (FLEXIO2_CTRL & (1 << 1)) {}
+    {
+        const u32 swrst_start = micros();
+        while (FLEXIO2_CTRL & (1 << 1)) {
+            if ((u32)(micros() - swrst_start) >= 1000) {
+                break;  // 1 ms is >>> the few hundred ns SWRST should take
+            }
+        }
+    }
     FLEXIO2_CTRL = 0;
 
     // Shifter 0: Transmit mode, 1-bit serial, output on flexio_pin
@@ -305,6 +323,17 @@ bool flexio_show(const u8* pixel_data, u32 num_bytes) {
 
     flexio_wait();
 
+    // Quiesce: hard-disable DMA + clear flags before reprogramming the TCD.
+    // flexio_wait can now return early via its 50 ms timeout; if it does,
+    // DMA is still live. Modifying the TCD mid-transfer is undefined
+    // behaviour on i.MX RT eDMA (IMPRECISERR data bus fault observed on
+    // first FlexIO bring-up attempt, #3410).
+    sDmaChannel->disable();
+    sDmaChannel->clearComplete();
+    sDmaChannel->clearInterrupt();
+    sDmaChannel->clearError();
+    sDmaComplete = true;
+
     if (num_bytes > kMaxPixelBytes) {
         num_bytes = kMaxPixelBytes;
     }
@@ -344,20 +373,42 @@ bool flexio_is_done() {
 }
 
 void flexio_wait() {
-    while (!sDmaComplete) {}
+    // Bounded wait so a stuck FlexIO/DMA can't take down the whole RPC test
+    // session. WS2812 frame for 100 LEDs at 800 kHz takes ~3 ms. 50 ms is
+    // plenty of headroom for any reasonable strip length while staying
+    // well below the autoresearch 120 s RPC deadline. If the timeout
+    // elapses, leave sDmaComplete=false so callers can detect the failure
+    // via flexio_is_done() and the driver state remains observable.
+    const u32 start = millis();
+    const u32 timeout_ms = 50;
+    while (!sDmaComplete) {
+        if ((u32)(millis() - start) >= timeout_ms) {
+            return;
+        }
+    }
 }
 
 void flexio_deinit() {
     if (!sInitialized) return;
     flexio_wait();
+    // Shut down FlexIO BEFORE touching DMA so no more shifter-empty DMA
+    // requests can fire while we're tearing the channel down.
     FLEXIO2_CTRL = 0;
     FLEXIO2_SHIFTSDEN = 0;
     if (sDmaChannel) {
+        // Order: disable ERQ -> detach interrupt -> clear pending NVIC IRQ
+        // -> then mark pointer null -> only THEN delete. Without the
+        // detach + IRQ-clear, a pending interrupt vector dereferences a
+        // deleted channel (#3410 IMPRECISERR fault).
         sDmaChannel->disable();
-        delete sDmaChannel;  // ok bare allocation
+        sDmaChannel->detachInterrupt();
+        sDmaChannel->clearInterrupt();
+        DMAChannel* to_delete = sDmaChannel;
         sDmaChannel = nullptr;
+        delete to_delete;  // ok bare allocation
     }
     sInitialized = false;
+    sDmaComplete = true;
 }
 
 // ============================================================================


### PR DESCRIPTION
## #3410 FlexIO bring-up — Round 1: kill the unbounded loops + ISR race

Three distinct unbounded busy-loops + an ISR-vs-deinit race were causing `runSingleTest --flex-io` to either hang the RPC indefinitely or crash the firmware with `IMPRECISERR` data-bus faults.

### Loops bounded
1. `flexio_wait()` — was `while (!sDmaComplete) {}` forever → bounded 50 ms
2. `flexio_configure_hw` SWRST wait → bounded 1 ms
3. `ChannelEngineFlexIO::show()` initial poll spin → bounded 100 ms + force-clears stuck channels

### Race fixed
4. `flexio_show()` now disables DMA + clears complete/interrupt/error before reprogramming TCD (no more mid-transfer TCD writes that triggered IMPRECISERR)
5. `flexio_deinit()` reorders teardown: disable → detach ISR → clear NVIC IRQ → null-pointer → delete (no more late IRQ dereferencing a freed channel)
6. `flexio_dma_isr()` defensively null-checks `sDmaChannel`

### Status
**FlexIO is NOT yet working.** Driver still produces `class=timeout` with crash signature `IMPRECISERR @ 0x2BB06` after these fixes. But the lower-level busy-loops and ISR race no longer mask the real bug. Future investigators get clean signals.

Likely remaining issues per #3410:
- FlexIO2 clock-init race vs DMA arming
- ObjectFLED's pre-registered TMR4/XBAR/DMA ownership conflicting with FlexIO2 hardware setup
- Wrong shifter/timer/DMA-trigger wiring

### Test plan
- [x] `bash test --unit` → 254/254 passed
- [x] `bash lint --cpp` → clean
- [x] `bash autoresearch teensy41 --flex-io --tx-pin 8 --rx-pin 22 --timeout 30 --skip-lint` → still `timeout` but no more 120s hangs; firmware crashes with diagnosable IMPRECISERR instead of silent freeze

Refs: #3410, #3359, #3406

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of FlexIO transfers on Teensy 4.x by preventing rare hangs during wait, reset, and shutdown operations.
  * Added safeguards so interrupted or timed-out transfers recover more cleanly instead of stalling indefinitely.
  * Reduced the chance of crashes during DMA interrupt handling when hardware teardown happens at the same time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->