### PR TITLE
fix(teensy-flexio): FLEXIO2_CTRL offset 0x000→0x008 — root cause of IMPRECISERR

### DIFF
--- a/src/platforms/arm/teensy/teensy4_common/drivers/flexio/flexio_driver.cpp.hpp
+++ b/src/platforms/arm/teensy/teensy4_common/drivers/flexio/flexio_driver.cpp.hpp
@@ -83,7 +83,15 @@ bool flexio_lookup_pin(u8 teensy_pin, FlexIOPinInfo* info) {
 
 static constexpr u32 kFLEXIO2_BASE = 0x401B0000;
 
-static volatile u32& FLEXIO2_CTRL     = *(volatile u32*)(kFLEXIO2_BASE + 0x000);
+// #3410 Round-2 audit: CTRL is at offset 0x008, NOT 0x000.
+// Offset 0x000 is VERID (read-only Version ID per i.MX RT1062 FlexIO RM).
+// The previous +0x000 address was writing to a read-only register, so
+// FLEXEN / FASTACC / SWRST never actually got set, and subsequent FlexIO
+// register writes (which require the module to be clocked AND enabled)
+// triggered IMPRECISERR. addr2line on the crash addresses pointed at
+// flexio_init's call to flexio_configure_hw -- consistent with FLEXIO2_CTRL
+// writes silently failing.
+static volatile u32& FLEXIO2_CTRL     = *(volatile u32*)(kFLEXIO2_BASE + 0x008);
 static volatile u32& FLEXIO2_SHIFTSTAT = *(volatile u32*)(kFLEXIO2_BASE + 0x010);
 static volatile u32& FLEXIO2_SHIFTERR  = *(volatile u32*)(kFLEXIO2_BASE + 0x014);
 static volatile u32& FLEXIO2_TIMSTAT   = *(volatile u32*)(kFLEXIO2_BASE + 0x018);
@@ -127,19 +135,23 @@ static void flexio_dma_isr() {
 // ============================================================================
 
 static void flexio_clock_init() {
+    // #3410 Round-2 audit: Match Teensyduino FlexIO_t4::setClockSettings()
+    // exactly: gate OFF -> set CSCMR2 (source) -> set CS1CDR (dividers)
+    // -> gate ON. The previous order (CS1CDR before CSCMR2) put dividers
+    // on a not-yet-routed clock source and the FlexIO module never
+    // started clocking -- causing register writes in flexio_configure_hw
+    // to IMPRECISERR (decoded via addr2line to FlexIOPeripheralReal::init).
+    CCM_CCGR3 &= ~CCM_CCGR3_FLEXIO2(CCM_CCGR_ON);
+
+    CCM_CSCMR2 = (CCM_CSCMR2 & ~CCM_CSCMR2_FLEXIO2_CLK_SEL(3)) |
+                 CCM_CSCMR2_FLEXIO2_CLK_SEL(3);
+
+    CCM_CS1CDR = (CCM_CS1CDR & ~(CCM_CS1CDR_FLEXIO2_CLK_PRED(7) |
+                                   CCM_CS1CDR_FLEXIO2_CLK_PODF(7))) |
+                 CCM_CS1CDR_FLEXIO2_CLK_PRED(1) |
+                 CCM_CS1CDR_FLEXIO2_CLK_PODF(1);
+
     CCM_CCGR3 |= CCM_CCGR3_FLEXIO2(CCM_CCGR_ON);
-
-    u32 cs1cdr = CCM_CS1CDR;
-    cs1cdr &= ~(CCM_CS1CDR_FLEXIO2_CLK_PODF(7) |
-                CCM_CS1CDR_FLEXIO2_CLK_PRED(7));
-    cs1cdr |= CCM_CS1CDR_FLEXIO2_CLK_PRED(1) |
-              CCM_CS1CDR_FLEXIO2_CLK_PODF(1);
-    CCM_CS1CDR = cs1cdr;
-
-    u32 cscmr2 = CCM_CSCMR2;
-    cscmr2 &= ~CCM_CSCMR2_FLEXIO2_CLK_SEL(3);
-    cscmr2 |= CCM_CSCMR2_FLEXIO2_CLK_SEL(3);
-    CCM_CSCMR2 = cscmr2;
 }
 
 // ============================================================================
@@ -362,8 +374,13 @@ bool flexio_show(const u8* pixel_data, u32 num_bytes) {
     sDmaChannel->TCD->CSR = DMA_TCD_CSR_INTMAJOR | DMA_TCD_CSR_DREQ;
 
     sDmaComplete = false;
-    sDmaChannel->enable();
+    // #3410 Round-2 audit: Enable FlexIO module BEFORE the DMA channel.
+    // With the previous order (DMA enable first), the DMA could fire on the
+    // very next FLEXIO2_REQUEST0 trigger and write to FLEXIO2_SHIFTBUFBIS
+    // while FLEXIO2_CTRL.FLEXEN was still 0 -- writing to a disabled
+    // shifter register raises IMPRECISERR on i.MX RT1062.
     FLEXIO2_CTRL = (1 << 0) | (1 << 2);
+    sDmaChannel->enable();
 
     return true;
 }


### PR DESCRIPTION
## 🎯 #3410 FlexIO bring-up — Round 2: register-offset bug ELIMINATED IMPRECISERR

`addr2line` decoded the IMPRECISERR crash addresses (0x2BB06, 0x2BB0E, 0x2BADE) to `FlexIOPeripheralReal::init()`. Inspection revealed:

```cpp
// Driver had:
static volatile u32& FLEXIO2_CTRL = *(volatile u32*)(kFLEXIO2_BASE + 0x000);
                                                                    ^^^^^
                                                                    WRONG
```

But per i.MX RT1062 FlexIO chapter (and `imxrt.h:3898`):
- Offset **0x000** = `FLEXIO2_VERID` (READ-ONLY Version ID)
- Offset **0x008** = `FLEXIO2_CTRL`

**Every `FLEXIO2_CTRL = ...` write was hitting VERID instead.** SWRST never reset, FLEXEN never enabled, FASTACC never enabled. Subsequent register writes hit a non-clocked / non-enabled module → IMPRECISERR.

Other offsets in the driver were spot-checked against `imxrt.h` and are correct (SHIFTSTAT 0x010, SHIFTERR 0x014, TIMSTAT 0x018, SHIFTSDEN 0x030, SHIFTCTL[] 0x080, SHIFTCFG[] 0x100, SHIFTBUF[] 0x200, SHIFTBUFBIS[] 0x380, TIMCTL[] 0x400, TIMCFG[] 0x480, TIMCMP[] 0x500). Only CTRL was wrong.

This PR also keeps the audit's defensive sequencing fixes:
1. Clock-gate-OFF before reconfiguring CSCMR2 + CS1CDR, then gate-ON (matches Teensyduino FlexIO_t4::setClockSettings)
2. CSCMR2 (source) set BEFORE CS1CDR (dividers) — Teensyduino order
3. `FLEXIO2_CTRL` (FLEXEN+FASTACC) set BEFORE `sDmaChannel->enable()` — ensures shifter is active before DMA writes to SHIFTBUFBIS

## Hardware result
```
bash autoresearch teensy41 --flex-io --tx-pin 8 --rx-pin 22 --timeout 30 --skip-lint

Before #3411:    timeout, RPC ACK + 120s no response, IMPRECISERR @ 0x2BB06
After #3411:     timeout, IMPRECISERR persists (bounded loops, race fixed, but underlying bug still there)
After this PR:   FAIL 460 ms class=zero_capture, 4 patterns × 0/300 bytes
```

The test now COMPLETES and classifies cleanly. `zero_capture` is the same starting state ObjectFLED was at before its own bring-up — driver no longer hangs/crashes, just needs the actual TX output debugged.

## Test plan
- [x] `bash test --unit` → 254/254 passed
- [x] `bash lint --cpp` → clean
- [x] `bash autoresearch teensy41 --flex-io --tx-pin 8 --rx-pin 22 --timeout 30 --skip-lint` → completes in 460 ms, `class=zero_capture` (no more IMPRECISERR, no more 120s hang)

Refs: #3410, #3411

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected FlexIO2 register access so the Teensy hardware uses the proper control register.
  * Improved clock initialization order to match expected device startup behavior.
  * Enabled FlexIO2 before starting DMA during frame output, reducing the chance of invalid buffer writes while the module is still off.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->