### PR TITLE
fix(teensy-flexio): TRGSEL=3 for Timer 1/Timer 3 + emit FlexPWM RX diag for FlexIO

### DIFF
--- a/ci/autoresearch/context.py
+++ b/ci/autoresearch/context.py
@@ -370,26 +370,29 @@ def display_tight_timing(result: dict[str, Any]) -> None:
 
 
 def display_objectfled_diagnostics(result: dict[str, Any]) -> None:
-    """Display ObjectFLED register snapshots attached to runSingleTest."""
+    """Display ObjectFLED register snapshots attached to runSingleTest.
+
+    Also dumps the FlexPWM RX diagnostics + standardGpioPadProbe if
+    present, regardless of whether ObjectFLED was the test driver -- the
+    FlexPWM RX block is useful for ANY Teensy driver that uses a
+    FlexPWM-capable pin as the receiver (e.g. FlexIO TX -> pin 22 RX
+    during #3410 bring-up).
+    """
     diagnostics = result.get("objectFledDiagnostics")
-    if not isinstance(diagnostics, dict):
-        return
-    if diagnostics.get("enabled") is not True:
-        return
+    if isinstance(diagnostics, dict) and diagnostics.get("enabled") is True:
+        event_count = diagnostics.get("eventCount", "?")
+        overflow_count = diagnostics.get("overflowCount", "?")
+        fmt = diagnostics.get("format", "unknown")
+        snapshot = diagnostics.get("snapshot")
 
-    event_count = diagnostics.get("eventCount", "?")
-    overflow_count = diagnostics.get("overflowCount", "?")
-    fmt = diagnostics.get("format", "unknown")
-    snapshot = diagnostics.get("snapshot")
-
-    print()
-    print("  ObjectFLED diagnostics")
-    print(f"    format: {fmt}")
-    print(f"    events: {event_count}, overflow: {overflow_count}")
-    if isinstance(snapshot, str) and snapshot:
-        print("    snapshot:")
-        for line in snapshot.splitlines():
-            print(f"      {line}")
+        print()
+        print("  ObjectFLED diagnostics")
+        print(f"    format: {fmt}")
+        print(f"    events: {event_count}, overflow: {overflow_count}")
+        if isinstance(snapshot, str) and snapshot:
+            print("    snapshot:")
+            for line in snapshot.splitlines():
+                print(f"      {line}")
 
     flex_diag = result.get("flexPwmRxDiagnostics")
     if isinstance(flex_diag, dict):

--- a/examples/AutoResearch/AutoResearchRemoteRunSingleTest.cpp
+++ b/examples/AutoResearch/AutoResearchRemoteRunSingleTest.cpp
@@ -994,12 +994,16 @@ fl::json AutoResearchRemoteControl::runSingleTestImpl(const fl::json& args) {
     if (is_object_fled_driver) {
         response.set("objectFledDiagnostics",
                      fl::objectFledDiagnosticsToJson());
-#if defined(FL_IS_TEENSY_4X)
-        response.set("flexPwmRxDiagnostics",
-                     fl::FlexPwmRxChannel::diagnosticsToJson(pin_rx));
-#endif
         response.set("standardGpioPadProbe", standard_gpio_pad_probe);
     }
+#if defined(FL_IS_TEENSY_4X)
+    // FlexPWM RX diagnostics are useful for ANY Teensy driver that uses
+    // pin 22 (or another FlexPWM-capable pin) as RX -- not just ObjectFLED.
+    // #3410 round-3 FlexIO bring-up: emit on every Teensy 4.x test so we
+    // can see what the receiver sees during FlexIO TX too.
+    response.set("flexPwmRxDiagnostics",
+                 fl::FlexPwmRxChannel::diagnosticsToJson(pin_rx));
+#endif
 
     // Free run_results before building response to reclaim heap
     // Only serialize pattern details when tests FAIL (saves heap on passing tests)

--- a/src/platforms/arm/teensy/teensy4_common/drivers/flexio/flexio_driver.cpp.hpp
+++ b/src/platforms/arm/teensy/teensy4_common/drivers/flexio/flexio_driver.cpp.hpp
@@ -219,7 +219,12 @@ static void flexio_configure_hw(u8 flexio_pin, u32 t0h_clocks, u32 t1h_clocks,
         ((u32)flexio_pin << 8) |      // PINSEL = output pin
         (3 << 16) |                   // PINCFG = output
         (1 << 22) |                   // TRGSRC = internal
-        (0 << 24);                    // TRGSEL = Timer 0 output
+        // #3410 Round-3 audit: TRGSEL = 4*M + pattern. For "Timer 0
+        // output" pattern is 3, M is 0 -> TRGSEL = 3 (NOT 0). Value 0
+        // selected "pin 0 input" -- so Timer 1 was waiting on an
+        // external pin instead of Timer 0's shift-clock output and
+        // the PWM never fired.
+        (3 << 24);                    // TRGSEL = Timer 0 output
 
     FLEXIO2_TIMCFG[1] =
         (6 << 8) |                    // TIMENA = trigger rising
@@ -252,7 +257,9 @@ static void flexio_configure_hw(u8 flexio_pin, u32 t0h_clocks, u32 t1h_clocks,
         ((u32)flexio_pin << 8) |      // PINSEL = output pin
         (3 << 16) |                   // PINCFG = output
         (1 << 22) |                   // TRGSRC = internal
-        (0 << 24);                    // TRGSEL = Timer 0
+        // #3410 Round-3 audit: same TRGSEL encoding error as Timer 1.
+        // "Timer 0 output" = pattern 3 + M=0 = TRGSEL value 3.
+        (3 << 24);                    // TRGSEL = Timer 0 output
 
     FLEXIO2_TIMCFG[3] =
         (6 << 8) |                    // TIMENA = trigger rising


### PR DESCRIPTION
## #3410 Round 3

Two changes:

### 1. Timer 1 + Timer 3 TRGSEL encoding fix
Per i.MX RT1062 RM 47.4.10, `TRGSEL = 4*M + pattern`. For "Timer M output" pattern is 3, so for **Timer 0 output** the value is **3** (NOT 0). Driver had Timer 1 + Timer 3 set to TRGSEL=0 which encodes "Pin 0 input" — they were waiting for an external rising edge on pin 0 that never came, so the WS2812 low-bit PWM never fired.

### 2. FlexPWM RX diagnostics emitted for ALL Teensy drivers
Previously only ObjectFLED runs got the FlexPWM RX state dump. FlexIO TX → pin 22 RX needs it too. Now emits unconditionally on Teensy 4.x; `context.py` renders regardless of TX driver.

## Hardware result
```
bash autoresearch teensy41 --flex-io --tx-pin 8 --rx-pin 22 --timeout 30 --skip-lint
TEST FLEX_IO lanes=1 leds=100 FAIL 460 ms class=zero_capture

flexPwmRxDiagnostics (now visible):
  activeMuxValueLive: 17     (pin 22 ALT1 + SION OK)
  activeSelectValueLive: 1   (#3404 fix OK)
  mctrl: 3840, captctrla: 25, dmaen: 96, dmaErq: 24  -- RX armed
  cval2..5: 0, citer: 4096, biter: 4096               -- ZERO edges
```

So **FlexIO TX is still not producing edges on pin 8** even after the TRGSEL fix. The shifter+timer architecture needs deeper auditing — possibly Timer 2's enable condition (currently TRGSEL=1 = shifter status flag, but needs to fire only on data=1 bits) or the shifter SMOD/PINCFG routing.

## Test plan
- [x] `bash test --unit` → 254/254
- [x] `bash lint --cpp` → clean
- [x] `bash autoresearch teensy41 --flex-io ...` → completes 460 ms, no crash, RX diag now visible and shows TX is silent on the wire

Refs: #3410, #3411, #3412

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Teensy diagnostics reporting so FlexPWM RX diagnostics are included for all Teensy 4.x tests, and GPIO pad probe data is only shown when relevant.
  * Fixed timer control settings in FlexIO, improving PWM and latch behavior on affected hardware.
  * Clarified and simplified diagnostics handling so enabled snapshots and register details are shown more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->