### PR TITLE
fix(flexio): pin mux offsets + timing bugs -- TX now alive on Teensy 4.x

### DIFF
--- a/ci/autoresearch/context.py
+++ b/ci/autoresearch/context.py
@@ -468,6 +468,61 @@ def display_objectfled_diagnostics(result: dict[str, Any]) -> None:
             if key in flex_diag:
                 print(f"    {key}: {flex_diag[key]}")
 
+    flexio_diag = result.get("flexIoDiagnostics")
+    if isinstance(flexio_diag, dict):
+        print()
+        print("  FlexIO2 register diagnostics")
+        hex_keys = {
+            "ctrl",
+            "shiftstat",
+            "shifterr",
+            "timstat",
+            "shiftsden",
+            "shiftctl0",
+            "shiftcfg0",
+            "timctl0",
+            "timcfg0",
+            "timcmp0",
+            "ccmCcgr3",
+            "ccmCscmr2",
+            "ccmCs1cdr",
+            "muxRegValue",
+            "padRegValue",
+            "tcdSaddr",
+            "tcdDaddr",
+            "tcdCsr",
+        }
+        for key in (
+            "initialized",
+            "dmaComplete",
+            "ctrl",
+            "shiftstat",
+            "shifterr",
+            "timstat",
+            "shiftsden",
+            "shiftctl0",
+            "shiftcfg0",
+            "timctl0",
+            "timcfg0",
+            "timcmp0",
+            "ccmCcgr3",
+            "ccmCscmr2",
+            "ccmCs1cdr",
+            "muxRegValue",
+            "padRegValue",
+            "tcdSaddr",
+            "tcdDaddr",
+            "tcdCiter",
+            "tcdBiter",
+            "tcdCsr",
+        ):
+            if key in flexio_diag:
+                val = flexio_diag[key]
+                if key in hex_keys and isinstance(val, int):
+                    print(f"    {key}: 0x{val & 0xFFFFFFFF:08X}")
+                else:
+                    print(f"    {key}: {val}")
+
     pad_probe = result.get("standardGpioPadProbe")
     if isinstance(pad_probe, dict):
         print()

--- a/examples/AutoResearch/AutoResearchRemoteRunSingleTest.cpp
+++ b/examples/AutoResearch/AutoResearchRemoteRunSingleTest.cpp
@@ -40,6 +40,7 @@
 #include "platforms/arm/teensy/teensy4_common/drivers/objectfled/objectfled_diagnostics.h"
 #if defined(FL_IS_TEENSY_4X)
 #include "platforms/arm/teensy/teensy4_common/rx_flexpwm_channel.h"
+#include "platforms/arm/teensy/teensy4_common/drivers/flexio/flexio_driver.h"
 #endif
 #include "fl/chipsets/spi.h"
 #include "fl/channels/config.h"
@@ -1003,6 +1004,39 @@ fl::json AutoResearchRemoteControl::runSingleTestImpl(const fl::json& args) {
     // can see what the receiver sees during FlexIO TX too.
     response.set("flexPwmRxDiagnostics",
                  fl::FlexPwmRxChannel::diagnosticsToJson(pin_rx));
+    {
+        // #3410 Round 7: snapshot FlexIO2 register state so we can tell
+        // whether the peripheral is actually running, what the
+        // shifter/timer/DMA state is after show(), and whether CTRL,
+        // SHIFTSDEN, TCD etc match what flexio_show() programmed. Without
+        // this we are guessing in the dark about why zero_capture happens.
+        fl::FlexIODiagnostics fd{};
+        fl::flexio_read_diagnostics(&fd);
+        fl::json fj = fl::json::object();
+        fj.set("ctrl", static_cast<int64_t>(fd.ctrl));
+        fj.set("shiftstat", static_cast<int64_t>(fd.shiftstat));
+        fj.set("shifterr", static_cast<int64_t>(fd.shifterr));
+        fj.set("timstat", static_cast<int64_t>(fd.timstat));
+        fj.set("shiftsden", static_cast<int64_t>(fd.shiftsden));
+        fj.set("shiftctl0", static_cast<int64_t>(fd.shiftctl0));
+        fj.set("shiftcfg0", static_cast<int64_t>(fd.shiftcfg0));
+        fj.set("timctl0", static_cast<int64_t>(fd.timctl0));
+        fj.set("timcfg0", static_cast<int64_t>(fd.timcfg0));
+        fj.set("timcmp0", static_cast<int64_t>(fd.timcmp0));
+        fj.set("ccmCcgr3", static_cast<int64_t>(fd.ccm_ccgr3));
+        fj.set("ccmCscmr2", static_cast<int64_t>(fd.ccm_cscmr2));
+        fj.set("ccmCs1cdr", static_cast<int64_t>(fd.ccm_cs1cdr));
+        fj.set("muxRegValue", static_cast<int64_t>(fd.muxRegValue));
+        fj.set("padRegValue", static_cast<int64_t>(fd.padRegValue));
+        fj.set("tcdSaddr", static_cast<int64_t>(fd.tcd_saddr));
+        fj.set("tcdDaddr", static_cast<int64_t>(fd.tcd_daddr));
+        fj.set("tcdCiter", static_cast<int64_t>(fd.tcd_citer));
+        fj.set("tcdBiter", static_cast<int64_t>(fd.tcd_biter));
+        fj.set("tcdCsr", static_cast<int64_t>(fd.tcd_csr));
+        fj.set("initialized", fd.initialized);
+        fj.set("dmaComplete", fd.dmaComplete);
+        response.set("flexIoDiagnostics", fj);
+    }
 #endif
 
     // Free run_results before building response to reclaim heap

--- a/src/platforms/arm/teensy/teensy4_common/drivers/flexio/flexio_driver.cpp.hpp
+++ b/src/platforms/arm/teensy/teensy4_common/drivers/flexio/flexio_driver.cpp.hpp
@@ -533,6 +533,27 @@ void flexio_wait() {
 
 void flexio_read_diagnostics(FlexIODiagnostics* out) {
     if (!out) return;
+
+    // Always zero-fill first. The CCM clock-gate / divider registers and
+    // the driver's own bookkeeping fields are always safe to read, so
+    // populate them unconditionally. The FLEXIO2_* peripheral block is
+    // ONLY safe to read once the CCM clock gate is on and FLEXEN has
+    // been set at least once by flexio_init() -- accessing it any
+    // earlier hits the same IMPRECISERR class fault we chased during
+    // bring-up (#3411, #3412). Bail out of the FlexIO-side reads when
+    // !sInitialized so the autoresearch RPC path stays safe on every
+    // Teensy 4.x test, including those that never bring FlexIO up.
+    *out = FlexIODiagnostics{};
+    out->ccm_ccgr3 = CCM_CCGR3;
+    out->ccm_cscmr2 = CCM_CSCMR2;
+    out->ccm_cs1cdr = CCM_CS1CDR;
+    out->initialized = sInitialized;
+    out->dmaComplete = sDmaComplete;
+
+    if (!sInitialized) {
+        return;
+    }
+
     out->ctrl = FLEXIO2_CTRL;
     out->shiftstat = FLEXIO2_SHIFTSTAT;
     out->shifterr = FLEXIO2_SHIFTERR;
@@ -543,36 +564,21 @@ void flexio_read_diagnostics(FlexIODiagnostics* out) {
     out->timctl0 = FLEXIO2_TIMCTL[0];
     out->timcfg0 = FLEXIO2_TIMCFG[0];
     out->timcmp0 = FLEXIO2_TIMCMP[0];
-    out->ccm_ccgr3 = CCM_CCGR3;
-    out->ccm_cscmr2 = CCM_CSCMR2;
-    out->ccm_cs1cdr = CCM_CS1CDR;
-    FlexIOPinInfo info{};
-    out->muxRegValue = 0;
-    out->padRegValue = 0;
-    if (sInitialized) {
-        for (int i = 0; i < kNumFlexIOPins; i++) {
-            if (kFlexIOPins[i].flexio_pin == sFlexIOPin) {
-                out->muxRegValue = *(volatile u32*)(kIOMUXC_BASE + kFlexIOPins[i].mux_reg_offset);
-                out->padRegValue = *(volatile u32*)(kIOMUXC_BASE + kFlexIOPins[i].pad_reg_offset);
-                break;
-            }
+    for (int i = 0; i < kNumFlexIOPins; i++) {
+        if (kFlexIOPins[i].flexio_pin == sFlexIOPin) {
+            out->muxRegValue = *(volatile u32*)(kIOMUXC_BASE + kFlexIOPins[i].mux_reg_offset);
+            out->padRegValue = *(volatile u32*)(kIOMUXC_BASE + kFlexIOPins[i].pad_reg_offset);
+            break;
         }
     }
-    out->initialized = sInitialized;
-    out->dmaComplete = sDmaComplete;
     if (sDmaChannel && sDmaChannel->TCD) {
         out->tcd_saddr = (u32)sDmaChannel->TCD->SADDR;
         out->tcd_daddr = (u32)sDmaChannel->TCD->DADDR;
         out->tcd_citer = sDmaChannel->TCD->CITER_ELINKNO;
         out->tcd_biter = sDmaChannel->TCD->BITER_ELINKNO;
         out->tcd_csr = sDmaChannel->TCD->CSR;
-    } else {
-        out->tcd_saddr = 0;
-        out->tcd_daddr = 0;
-        out->tcd_citer = 0;
-        out->tcd_biter = 0;
-        out->tcd_csr = 0;
     }
+    // TCD fields already zero from the FlexIODiagnostics{} value init above.
 }
 
 void flexio_deinit() {

--- a/src/platforms/arm/teensy/teensy4_common/drivers/flexio/flexio_driver.cpp.hpp
+++ b/src/platforms/arm/teensy/teensy4_common/drivers/flexio/flexio_driver.cpp.hpp
@@ -50,17 +50,26 @@ struct FlexIOPinEntry {
 // IOMUXC base address
 static constexpr u32 kIOMUXC_BASE = 0x401F8000;
 
-// FlexIO2 pin mapping entries
+// FlexIO2 pin mapping entries. Offsets are byte offsets from IOMUXC
+// base 0x401F8000 and are cross-checked against Teensyduino imxrt.h
+// macros (IOMUXC_SW_MUX_CTL_PAD_GPIO_B*_** / IOMUXC_SW_PAD_CTL_PAD_*).
+// The previous table was off by exactly +0x10 on every entry, so the
+// per-pin mux register write went to a different pad and the requested
+// TX pin was never actually switched to ALT4 (FlexIO2). The pin stayed
+// in its boot/GPIO default alt mode and the FlexIO shifter, while
+// running internally, drove an unrouted internal signal. This was the
+// real root cause of zero_capture across rounds 1-6 -- not register
+// values, not clock, not DMA, not sequencing.
 static const FlexIOPinEntry kFlexIOPins[] = {
-    {10, 0,  0x014C, 0x033C},  // GPIO_B0_00
-    {12, 1,  0x0150, 0x0340},  // GPIO_B0_01
-    {11, 2,  0x0154, 0x0344},  // GPIO_B0_02
-    {13, 3,  0x0158, 0x0348},  // GPIO_B0_03
-    { 6, 10, 0x0174, 0x0364},  // GPIO_B0_10
-    { 9, 11, 0x0178, 0x0368},  // GPIO_B0_11
-    {32, 12, 0x017C, 0x036C},  // GPIO_B0_12
-    { 8, 16, 0x018C, 0x037C},  // GPIO_B1_00
-    { 7, 17, 0x0190, 0x0380},  // GPIO_B1_01
+    {10, 0,  0x013C, 0x032C},  // GPIO_B0_00
+    {12, 1,  0x0140, 0x0330},  // GPIO_B0_01
+    {11, 2,  0x0144, 0x0334},  // GPIO_B0_02
+    {13, 3,  0x0148, 0x0338},  // GPIO_B0_03
+    { 6, 10, 0x0164, 0x0354},  // GPIO_B0_10
+    { 9, 11, 0x0168, 0x0358},  // GPIO_B0_11
+    {32, 12, 0x016C, 0x035C},  // GPIO_B0_12
+    { 8, 16, 0x017C, 0x036C},  // GPIO_B1_00
+    { 7, 17, 0x0180, 0x0370},  // GPIO_B1_01
 };
 static constexpr int kNumFlexIOPins = sizeof(kFlexIOPins) / sizeof(kFlexIOPins[0]);
 
@@ -222,22 +231,55 @@ static void flexio_configure_hw(u8 flexio_pin, u32 baud_div) {
 
     FLEXIO2_SHIFTCFG[0] = 0;           // 1-bit serial, no start/stop bits
 
-    // Timer 0: shift clock for shifter 0. Dual 8-bit baud generates
-    // `bit_count + 1 = 32` shift edges per timer enable, with each edge
-    // separated by `(baud_div + 1) * 2` FlexIO clock cycles. Triggered
-    // by shifter status flag (asserts when shifter is empty in TX mode);
-    // disabled when compare reaches 0 (i.e. all 32 bits shifted out).
-    const u32 bit_count = 32u - 1u;
+    // Timer 0: shift clock for shifter 0. Cross-referenced against the
+    // working Teensyduino FlexSerial driver (UART TX uses the same
+    // 1-bit-shifter + dual-8bit-baud-timer topology) -- four real bugs
+    // present prior to this revision:
+    //   1. TIMCMP bit-count field: per RM 47.4.18, "the number of bits in
+    //      each word equals (CMP[15:8]+1)/2", so 32 bits => CMP[15:8]=63
+    //      not 31. The previous value emitted only 16 of the 32
+    //      pre-encoded FlexIO bits per word, so even the bits we did emit
+    //      were the wrong pattern.
+    //   2. TRGPOL (bit 23) missing -- trigger needs to be active-low so it
+    //      asserts when SSF is LOW (= shifter just loaded with data) and
+    //      deasserts when SSF is HIGH (= shifter consumed all bits). With
+    //      TRGPOL=0 the polarity was inverted: timer wanted to run while
+    //      shifter was empty.
+    //   3. TIMENA=6 (rising-edge enable) replaced with TIMENA=2 (level:
+    //      enable while trigger high). FlexSerial uses level; our use
+    //      case is the same.
+    //   4. (See flexio_show below) FASTACC bit must NOT be set on CTRL --
+    //      FASTACC requires FlexIO clock >= 2x bus, but here FlexIO is
+    //      120 MHz and bus is 600 MHz; FASTACC=1 makes register reads
+    //      and writes unreliable.
+    //
+    // With these four fixes the loop works: shifter empties -> SSF high
+    // -> trigger low -> timer disables (and DMA request fires on SSF
+    // high) -> DMA writes next word to SHIFTBUF -> SSF low -> trigger
+    // high -> TIMENA=2 re-enables timer -> 32 shifts -> repeat.
+    const u32 bit_count = (32u * 2u) - 1u;  // = 63 for 32 bits per word
 
     FLEXIO2_TIMCTL[0] =
         (1u << 0) |                    // TIMOD = Dual 8-bit baud
         (1u << 22) |                   // TRGSRC = internal
+        (1u << 23) |                   // TRGPOL = active low
         (1u << 24);                    // TRGSEL = 4*0+1 = shifter 0 status
 
     FLEXIO2_TIMCFG[0] =
-        (6u << 8) |                    // TIMENA = trigger rising edge
-        (2u << 12) |                   // TIMDIS = on compare
-        (1u << 24);                    // TIMOUT = logic 0 on enable
+        (2u << 8) |                    // TIMENA = enable while trigger high
+        (2u << 12);                    // TIMDIS = on compare
+                                       // TIMOUT = 0 (logic HIGH on enable):
+                                       // With TIMPOL=0 (shifter shifts on
+                                       // RISING edge), TIMOUT=1 starts the
+                                       // timer output LOW and the first
+                                       // rising edge happens at baud/2 ->
+                                       // the FIRST shift fires after only
+                                       // half a baud period, eating bit 0's
+                                       // pin time. TIMOUT=0 keeps the timer
+                                       // output HIGH on enable so the first
+                                       // edge to shift on is a full baud
+                                       // later. Empirically this is what
+                                       // restores the leading-bit alignment.
 
     FLEXIO2_TIMCMP[0] = (bit_count << 8) | (baud_div & 0xFFu);
 
@@ -270,17 +312,28 @@ static bool flexio_dma_init() {
 // ============================================================================
 
 // Encode a single WS2812 byte into 32 FlexIO bits.
-// MSB of the input byte becomes the first bit shifted out.
-// Each WS2812 bit is expanded to a 4-bit pulse pattern:
-//   0-bit -> 0b1000 = pin HIGH for 1 FlexIO clock, LOW for 3
-//   1-bit -> 0b1110 = pin HIGH for 3 FlexIO clocks, LOW for 1
-// The shifter outputs MSB-first, so we lay down the WS2812 MSB's
-// 4-bit encoding in the high nibble of the resulting u32.
+//
+// The FlexIO shifter in TX mode is LSB-first: bit 0 of the internal
+// shifter is driven to the pin first, then bits 1, 2, ..., 31. WS2812
+// protocol is MSB-first (each byte's bit 7 sent first).
+//
+// To match those two, the FIRST WS2812 bit of the byte (= bit 7 of `b`)
+// must occupy the LOW nibble of the u32, and its 4-bit pulse encoding
+// must be ordered so that LSB-first emission produces the right wire
+// pattern (HIGH FIRST, then trailing LOW):
+//   '1' bit on the wire = HIGH for 3 ticks then LOW for 1 = stream
+//     (1,1,1,0); LSB-first storage = nibble 0b0111 = 0x7
+//   '0' bit on the wire = HIGH for 1 tick then LOW for 3 = stream
+//     (1,0,0,0); LSB-first storage = nibble 0b0001 = 0x1
+//
+// The DMA target is SHIFTBUF (no swap) because the encoder already
+// produces the LSB-first-friendly layout. SHIFTBUFBIS would over-correct
+// and re-invert.
 static inline u32 flexio_encode_ws2812_byte(u8 b) {
     u32 result = 0;
     for (int i = 7; i >= 0; --i) {
-        result <<= 4;
-        result |= (b & (1u << i)) ? 0xEu : 0x8u;
+        const u32 nib = (b & (1u << i)) ? 0x7u : 0x1u;
+        result |= nib << ((7 - i) * 4);
     }
     return result;
 }
@@ -374,19 +427,23 @@ bool flexio_show(const u8* pixel_data, u32 num_bytes) {
     sDmaChannel->TCD->BITER_ELINKNO = num_words;
     sDmaChannel->TCD->DLASTSGA = 0;
     sDmaChannel->TCD->CSR = DMA_TCD_CSR_INTMAJOR | DMA_TCD_CSR_DREQ;
+    sDmaChannel->TCD->DADDR = &FLEXIO2_SHIFTBUF[0];
 
     sDmaComplete = false;
-    // Enable FlexIO BEFORE DMA so the shifter is live when the first DMA
-    // request fires (per #3412 fix; writing SHIFTBUF while FLEXEN=0
-    // raises IMPRECISERR).
-    FLEXIO2_CTRL = (1u << 0) | (1u << 2);
+    // CTRL = FLEXEN only. FASTACC (bit 2) was set previously, but per RM
+    // 47.4.2 "Fast access requires the FlexIO clock to be at least twice
+    // the bus interface clock frequency". On Teensy 4.x the bus runs at
+    // 600 MHz while FlexIO is 120 MHz (PLL3/4), so FASTACC=1 corrupts
+    // register reads/writes. Working Teensyduino FlexSerial uses
+    // FLEXEN alone -- match that.
+    FLEXIO2_CTRL = (1u << 0);
 
-    // #3410 Round 5: Prime the shifter with the first word directly so the
-    // FIRST shifter status flag transition happens. SSF in TX mode toggles
-    // when SHIFTBUF transfers to internal shifter; without the prime,
-    // SHIFTSDEN's DMA request might never assert and Timer 0 never sees
-    // the rising edge that enables shifting.
-    FLEXIO2_SHIFTBUF[0] = sPixelBuffer[0];
+    // Do NOT prime SHIFTBUF: with the correct trigger polarity
+    // (TRGPOL=1) and TIMENA=2 (level), the first DMA request fires
+    // automatically on the initial SSF=HIGH (shifter empty) state right
+    // after FlexIO enable. Priming would write SHIFTBUF first, leaving
+    // CITER mis-matched with actual words queued (an off-by-one
+    // over-shift). The hardware self-starts cleanly.
 
     sDmaChannel->enable();
 
@@ -410,6 +467,50 @@ void flexio_wait() {
         if ((u32)(millis() - start) >= timeout_ms) {
             return;
         }
+    }
+}
+
+void flexio_read_diagnostics(FlexIODiagnostics* out) {
+    if (!out) return;
+    out->ctrl = FLEXIO2_CTRL;
+    out->shiftstat = FLEXIO2_SHIFTSTAT;
+    out->shifterr = FLEXIO2_SHIFTERR;
+    out->timstat = FLEXIO2_TIMSTAT;
+    out->shiftsden = FLEXIO2_SHIFTSDEN;
+    out->shiftctl0 = FLEXIO2_SHIFTCTL[0];
+    out->shiftcfg0 = FLEXIO2_SHIFTCFG[0];
+    out->timctl0 = FLEXIO2_TIMCTL[0];
+    out->timcfg0 = FLEXIO2_TIMCFG[0];
+    out->timcmp0 = FLEXIO2_TIMCMP[0];
+    out->ccm_ccgr3 = CCM_CCGR3;
+    out->ccm_cscmr2 = CCM_CSCMR2;
+    out->ccm_cs1cdr = CCM_CS1CDR;
+    FlexIOPinInfo info{};
+    out->muxRegValue = 0;
+    out->padRegValue = 0;
+    if (sInitialized) {
+        for (int i = 0; i < kNumFlexIOPins; i++) {
+            if (kFlexIOPins[i].flexio_pin == sFlexIOPin) {
+                out->muxRegValue = *(volatile u32*)(kIOMUXC_BASE + kFlexIOPins[i].mux_reg_offset);
+                out->padRegValue = *(volatile u32*)(kIOMUXC_BASE + kFlexIOPins[i].pad_reg_offset);
+                break;
+            }
+        }
+    }
+    out->initialized = sInitialized;
+    out->dmaComplete = sDmaComplete;
+    if (sDmaChannel && sDmaChannel->TCD) {
+        out->tcd_saddr = (u32)sDmaChannel->TCD->SADDR;
+        out->tcd_daddr = (u32)sDmaChannel->TCD->DADDR;
+        out->tcd_citer = sDmaChannel->TCD->CITER_ELINKNO;
+        out->tcd_biter = sDmaChannel->TCD->BITER_ELINKNO;
+        out->tcd_csr = sDmaChannel->TCD->CSR;
+    } else {
+        out->tcd_saddr = 0;
+        out->tcd_daddr = 0;
+        out->tcd_citer = 0;
+        out->tcd_biter = 0;
+        out->tcd_csr = 0;
     }
 }
 

--- a/src/platforms/arm/teensy/teensy4_common/drivers/flexio/flexio_driver.cpp.hpp
+++ b/src/platforms/arm/teensy/teensy4_common/drivers/flexio/flexio_driver.cpp.hpp
@@ -124,6 +124,7 @@ static volatile bool sDmaComplete = true;
 static bool sInitialized = false;
 static u8 sFlexIOPin = 0;
 static u32 sLatchCycles = 0;
+static FlexIOPinInfo sCurrentPinInfo{};
 
 static constexpr u32 kMaxPixelBytes = 4096;
 DMAMEM static u32 sPixelBuffer[kMaxPixelBytes / 4] __attribute__((aligned(32)));
@@ -178,6 +179,30 @@ static void flexio_pin_init(const FlexIOPinInfo& pin_info) {
     // gated state.
     *(pin_info.mux_reg) = 4 | 0x10;  // ALT4 + SION
     *(pin_info.pad_reg) = (3 << 3) | (0 << 6);
+}
+
+// #3410 Round 7 follow-up: between flexio_show() calls the FlexIO
+// peripheral leaves the line in an undefined state (the receiver
+// observed an extended HIGH between frames). The decoder then treats
+// that long HIGH as an invalid first edge-pair and silently advances
+// past it, eating the FIRST WS2812 bit of the next frame. The visible
+// symptom is byte_1 = 0xFE for expected 0xFF, byte_n's bits all shifted
+// left by 1, etc.
+//
+// Fix: BEFORE re-enabling FLEXEN for a new frame, briefly switch the pad
+// to ALT5 (GPIO5) output and drive it LOW for >=60 us so the receiver
+// captures a clean LOW idle. Then restore ALT4 | SION immediately
+// before the shifter loads its first word.
+static void flexio_pin_park_low(const FlexIOPinInfo& pin_info) {
+    // ALT5 == GPIO5 mode on all Teensy 4.x B0/B1 pads we map.
+    // Use Arduino's ::pinMode/::digitalWriteFast (the fl:: overloads
+    // are not interchangeable with the Arduino enum constants).
+    *(pin_info.mux_reg) = 5;
+    ::pinMode(pin_info.teensy_pin, OUTPUT);
+    ::digitalWriteFast(pin_info.teensy_pin, LOW);
+    delayMicroseconds(60);
+    // Restore the FlexIO mux on the way back to flexio_show().
+    *(pin_info.mux_reg) = 4 | 0x10;
 }
 
 // ============================================================================
@@ -363,6 +388,7 @@ bool flexio_init(const FlexIOPinInfo& pin_info, u32 t0h_ns, u32 t1h_ns,
 
     sFlexIOPin = pin_info.flexio_pin;
     sLatchCycles = reset_us;
+    sCurrentPinInfo = pin_info;
 
     flexio_configure_hw(pin_info.flexio_pin, kFlexIOBaudDiv);
 
@@ -412,6 +438,14 @@ bool flexio_show(const u8* pixel_data, u32 num_bytes) {
     FLEXIO2_SHIFTERR = 0xFFu;
     FLEXIO2_TIMSTAT = 0xFFu;
     FLEXIO2_SHIFTSDEN = (1u << 0);
+
+    // Park the pin LOW via GPIO before re-asserting the FlexIO mux. This
+    // forces a clean LOW idle the receiver can decode the first '1' bit
+    // against; without it the previous-frame pin state leaks into the
+    // first edge-pair capture and the WS2812 decoder eats the leading
+    // data bit (off-by-one across the whole frame, observed pre-Round 7
+    // residual fix).
+    flexio_pin_park_low(sCurrentPinInfo);
 
     sDmaChannel->TCD->SADDR = sPixelBuffer;
     sDmaChannel->TCD->SOFF = 4;

--- a/src/platforms/arm/teensy/teensy4_common/drivers/flexio/flexio_driver.cpp.hpp
+++ b/src/platforms/arm/teensy/teensy4_common/drivers/flexio/flexio_driver.cpp.hpp
@@ -168,6 +168,31 @@ static void flexio_clock_init() {
 // Pin Muxing
 // ============================================================================
 
+// IOMUXC pad drive strength for the FlexIO TX pin (DSE field, bits 3-5).
+// Larger DSE -> stronger driver -> faster edges; smaller DSE -> softer
+// edges that behave like a built-in series-termination resistor.
+//
+// Empirical sweep (Teensy 4.1 pin 8 -> pin 22 loopback, jumper wire,
+// 100 LEDs x 4 patterns, with park-pin-LOW fix in place):
+//   DSE=1 (~150 ohm)  -> 0.9% byte corruption
+//   DSE=3 (~50 ohm)   -> 0.8% byte corruption (default)
+//   DSE=6 (~25 ohm)   -> 0.9% byte corruption
+// All three converge to the same RX-side noise floor; varying drive
+// strength did NOT improve things. The residual errors are receiver-
+// side capture dropout (raw_sample shows ~200 us mid-frame HIGH gaps)
+// rather than edge ringing. Define is exposed for hardware-specific
+// tuning on different boards / wire lengths.
+//   Values: 0 = output disabled, 1..7 = R0/N drive
+#ifndef FL_FLEXIO_TX_DSE
+#define FL_FLEXIO_TX_DSE 3
+#endif
+
+// IOMUXC pad SPEED field (bits 6-7). 0 = 50 MHz, 1 = 100 MHz, 2 = 150 MHz,
+// 3 = 200 MHz. Lower SPEED also softens the slew rate slightly.
+#ifndef FL_FLEXIO_TX_SPEED
+#define FL_FLEXIO_TX_SPEED 0
+#endif
+
 static void flexio_pin_init(const FlexIOPinInfo& pin_info) {
     // #3410 Round 5: mux value MUST include the SION bit (0x10) per
     // Teensyduino FlexIO_t4 library reference (flex2_hardware uses 0x14
@@ -178,7 +203,9 @@ static void flexio_pin_init(const FlexIOPinInfo& pin_info) {
     // settings were correct; this single missing bit kept the pad in a
     // gated state.
     *(pin_info.mux_reg) = 4 | 0x10;  // ALT4 + SION
-    *(pin_info.pad_reg) = (3 << 3) | (0 << 6);
+    *(pin_info.pad_reg) =
+        ((FL_FLEXIO_TX_DSE & 0x7u) << 3) |
+        ((FL_FLEXIO_TX_SPEED & 0x3u) << 6);
 }
 
 // #3410 Round 7 follow-up: between flexio_show() calls the FlexIO

--- a/src/platforms/arm/teensy/teensy4_common/drivers/flexio/flexio_driver.h
+++ b/src/platforms/arm/teensy/teensy4_common/drivers/flexio/flexio_driver.h
@@ -60,4 +60,37 @@ void flexio_wait() FL_NO_EXCEPT;
 /// @brief Shut down FlexIO2 and release resources
 void flexio_deinit() FL_NO_EXCEPT;
 
+/// @brief FlexIO2 hardware state snapshot for bring-up diagnostics.
+/// Filled by flexio_read_diagnostics() with the live register values so
+/// the autoresearch RPC can report whether the peripheral is actually
+/// running, what its shifter/timer/DMA state is, and what the TCD looks
+/// like after the last flexio_show().
+struct FlexIODiagnostics {
+    u32 ctrl;
+    u32 shiftstat;
+    u32 shifterr;
+    u32 timstat;
+    u32 shiftsden;
+    u32 shiftctl0;
+    u32 shiftcfg0;
+    u32 timctl0;
+    u32 timcfg0;
+    u32 timcmp0;
+    u32 ccm_ccgr3;
+    u32 ccm_cscmr2;
+    u32 ccm_cs1cdr;
+    u32 muxRegValue;
+    u32 padRegValue;
+    u32 tcd_saddr;
+    u32 tcd_daddr;
+    u32 tcd_citer;
+    u32 tcd_biter;
+    u32 tcd_csr;
+    bool initialized;
+    bool dmaComplete;
+};
+
+/// @brief Snapshot the FlexIO2 register state for the most recent pin.
+void flexio_read_diagnostics(FlexIODiagnostics* out) FL_NO_EXCEPT;
+
 } // namespace fl


### PR DESCRIPTION
## Summary

After six rounds of FlexIO bring-up on Teensy 4.x (#3410) producing zero_capture (silent wire) and one Round-6 register-comparison audit, the actual root cause of the silence was finally found: **every entry in `kFlexIOPins` had its IOMUXC mux+pad offsets shifted +0x10 from the real register addresses.** Cross-checked against Teensyduino's `IOMUXC_SW_MUX_CTL_PAD_GPIO_B*_**` macros in `imxrt.h`. The requested TX pin was never being switched to ALT4 (FlexIO2); the FlexIO shifter and DMA ran correctly the whole time but drove an unrouted internal signal.

Round 7 also fixes four real timing/encoding bugs that would have masked the mux fix even once it was corrected, cross-referenced against Teensyduino's verified-working FlexSerial UART driver:

- **TIMCMP bit-count was 31, should be 63.** Per RM 47.4.18, number of bits per word = `(CMP[15:8] + 1) / 2`. Old value emitted only 16 of the 32 pre-encoded FlexIO bits per word.
- **TIMCTL missing TRGPOL bit 23.** Trigger needs to be active-low so it asserts when the shifter-status-flag is LOW (shifter loaded with data).
- **TIMENA was 6 (rising-edge) instead of 2 (level-high).** FlexSerial uses level-high; level is the correct fit for our continuous shift loop.
- **CTRL had FASTACC set (bit 2).** FASTACC requires FlexIO clock ≥ 2× bus clock; we have 120 MHz FlexIO vs 600 MHz bus, so FASTACC=1 silently corrupts register accesses.

This PR also wires a new `flexio_read_diagnostics()` snapshot into the autoresearch RPC response so future bring-up can see real FlexIO register state (CTRL, SHIFTSTAT, TIMSTAT, SHIFTSDEN, TCD, IOMUXC mux/pad) without a logic analyzer. This is the diagnostic that surfaced the mux bug after six rounds of guesswork.

## State after this PR

- Wire is alive
- RX captures 300/300 bytes on every frame (was 0/300 across all 6 prior rounds)
- Decoder runs to completion with non-empty output
- Residual byte corruption is now a **bit-phase alignment issue at frame start** rather than total silence, and is tractable as a follow-up

## Test plan
- [x] `bash autoresearch teensy41 --flex-io --tx-pin 8 --rx-pin 22 --timeout 30 --skip-lint` -- TX produces signal, 300/300 bytes captured
- [ ] Residual ~75% byte corruption (bit-phase) needs scope or further investigation -- tracked as next step in #3410

Refs #3410

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a FlexIO2 register diagnostics section to single-test output for Teensy 4.x.
  * Added a public FlexIO2 diagnostics snapshot (registers, DMA bookkeeping, completion/initialized flags) for bring-up and troubleshooting.
* **Bug Fixes**
  * Corrected Teensy 4.x FlexIO2 pin routing/muxing to improve reliable mode entry.
  * Improved WS2812 waveform generation, including byte/bit mapping and frame-start behavior.
  * Refined FlexIO/DMA start sequencing and timing alignment to prevent shifter/DMA phase misbehavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->