### PR TITLE
fix(compiler_control): drop invalid `-fno-lto` optimize pragma (#3417)

### DIFF
--- a/src/fl/stl/compiler_control.h
+++ b/src/fl/stl/compiler_control.h
@@ -247,10 +247,14 @@
     #define _FL_TIMING_OPT_PRAGMA _Pragma("GCC optimize(\"O2\")")
   #endif
 
+  // `-fno-lto` is deliberately omitted: GCC rejects it as an `optimize`
+  // attribute/pragma argument (-Wattributes, -Wpragmas). LTO is a whole-program
+  // decision resolved by the link-time plugin, not by per-function codegen, so
+  // the optimize attribute cannot express it. Targets that need cycle-exact
+  // codegen under LTO must disable it at the build-flags level (FastLED #3417).
   #define FL_BEGIN_OPTIMIZE_FOR_EXACT_TIMING        \
       _Pragma("GCC push_options")                   \
       _FL_TIMING_OPT_PRAGMA                         \
-      _Pragma("GCC optimize(\"-fno-lto\")")         \
       _Pragma("GCC optimize(\"-fno-schedule-insns\")")  \
       _Pragma("GCC optimize(\"-fno-schedule-insns2\")") \
       _Pragma("GCC optimize(\"-fno-reorder-blocks\")")  \


### PR DESCRIPTION
Fixes #3417.

## Summary

- Removes `_Pragma("GCC optimize(\"-fno-lto\")")` from `FL_BEGIN_OPTIMIZE_FOR_EXACT_TIMING` in `src/fl/stl/compiler_control.h`. GCC rejects `-fno-lto` as an `optimize` attribute/pragma argument, so the line was a silent no-op that triggered `-Wattributes` / `-Wpragmas` warnings at every cycle-critical function in the M0 clockless driver.
- Adds an inline comment explaining why LTO suppression cannot be expressed per-function and must happen at the build-flags level.
- Other `-fno-*` pragmas in the macro (`schedule-insns`, `schedule-insns2`, `reorder-blocks`, `tree-vectorize`, `tree-reassoc`, `unroll-loops`) are valid for the optimize attribute and remain — they continue to provide per-function codegen stability for WS2812 bit timing.

## Why

The macro's intent is "make this function safe for cycle-exact codegen, even under LTO." That intent was not being satisfied: GCC's `optimize` attribute only accepts optimization-level strings and a subset of `-f*` flags that govern *per-function* code generation. `-flto` / `-fno-lto` is a whole-program flag resolved at the link stage — no per-function override is possible. See #3417 for the full root-cause analysis.

This is a latent issue (present since at least `b84830f09`, Mar 2026) that #3397 made more visible by adding additional functions (`fl_nop_run<N>`, `fl_nop_loop<N>`) under the timing-critical optimization umbrella.

## Test plan

- [x] `bash compile lpc845brk --examples AutoResearch` — compiles clean, no `-Wattributes` / `-Wpragmas` warnings
- [x] Flash/RAM footprint unchanged: 53.48 KB / 9.06 KB (vs. pre-fix 53.48 KB / 9.06 KB — bit-identical, since the dropped pragma was already a no-op)
- [ ] CI matrix to confirm no other platforms regress

## Follow-up (not in this PR)

If we want a real header-only LTO escape hatch for cycle-critical functions, GCC 8+ supports `__attribute__((noipa))` which prevents inter-procedural analysis (including LTO inlining). A future PR could add `FL_NO_LTO_FUNCTION` (mapped to `noipa` on GCC, `noinline` elsewhere) and apply it to the M0 entry points. Out of scope here — this PR just removes the silent no-op + warning spam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compiler compatibility for optimized builds by removing an unsupported optimization setting.
  * Clarified how timing-related optimization is applied, helping ensure more reliable builds with GCC.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->