### PR TITLE
refactor(spi): wrap FlexIO/ObjectFLED internals in private namespaces

### DIFF
--- a/src/platforms/arm/teensy/teensy4_common/drivers/flexio/flexio_spi_mode.cpp.hpp
+++ b/src/platforms/arm/teensy/teensy4_common/drivers/flexio/flexio_spi_mode.cpp.hpp
@@ -61,6 +61,14 @@
 
 namespace fl {
 
+// Private namespace for this TU's internal state + helpers. Avoids name
+// collisions with the sibling `objectfled_spi_mode.cpp.hpp` TU in the
+// unity build (`fl/build/platforms+.cpp`): both would otherwise define
+// identically-named `sSpiCurrentPins` / `sSpiDmaChannel` / etc. at fl::
+// namespace scope -- a redefinition. Per user directive 2026-06-27
+// "when in doubt use private namespaces" (#3428).
+namespace detail::flexio_spi_internal {
+
 // ============================================================================
 // FlexIO2 Register Access Helpers (duplicated from flexio_driver.cpp.hpp;
 // the two TUs are intentionally independent so either mode can compile alone)
@@ -123,12 +131,21 @@ static void flexio_spi_dma_isr() {
     sSpiDmaComplete = true;
 }
 
+}  // namespace detail::flexio_spi_internal
+
+// ===========================================================================
+// Public API: defined in `namespace fl` directly (header signatures match).
+// Each function `using namespace detail::flexio_spi_internal` to access the
+// private state without changing call-site spelling.
+// ===========================================================================
+
 // ============================================================================
 // flexio_spi_lookup_pins
 // ============================================================================
 
 bool flexio_spi_lookup_pins(u8 mosi_pin, u8 sclk_pin,
                             FlexIOSPIPinInfo* info) FL_NO_EXCEPT {
+    using namespace detail::flexio_spi_internal;
     if (!info) return false;
     if (mosi_pin == sclk_pin) return false;  // aliasing not allowed
 
@@ -167,6 +184,7 @@ bool flexio_spi_lookup_pins(u8 mosi_pin, u8 sclk_pin,
 
 bool flexio_spi_init(const FlexIOSPIPinInfo& pin_info,
                      u32 clock_hz) FL_NO_EXCEPT {
+    using namespace detail::flexio_spi_internal;
     if (clock_hz == 0) {
         FL_LOG_FLEXIO_F("FlexIO_SPI: init refused -- clock_hz == 0");
         return false;
@@ -370,6 +388,7 @@ bool flexio_spi_init(const FlexIOSPIPinInfo& pin_info,
 // ============================================================================
 
 bool flexio_spi_show(const u8* buffer, u32 num_bytes) FL_NO_EXCEPT {
+    using namespace detail::flexio_spi_internal;
     if (!sSpiInitialized || !sSpiDmaChannel || !buffer || num_bytes == 0) {
         return false;
     }
@@ -450,6 +469,7 @@ bool flexio_spi_show(const u8* buffer, u32 num_bytes) FL_NO_EXCEPT {
 // ============================================================================
 
 void flexio_spi_wait() FL_NO_EXCEPT {
+    using namespace detail::flexio_spi_internal;
     if (sSpiDmaComplete) return;
 
     // Bounded 50 ms wait for the DMA major-loop completion.
@@ -497,6 +517,7 @@ void flexio_spi_wait() FL_NO_EXCEPT {
 // ============================================================================
 
 void flexio_spi_deinit() FL_NO_EXCEPT {
+    using namespace detail::flexio_spi_internal;
     if (!sSpiInitialized) return;
 
     flexio_spi_wait();

--- a/src/platforms/arm/teensy/teensy4_common/drivers/objectfled/objectfled_spi_mode.cpp.hpp
+++ b/src/platforms/arm/teensy/teensy4_common/drivers/objectfled/objectfled_spi_mode.cpp.hpp
@@ -72,6 +72,14 @@ extern "C" void xbar_connect(unsigned int input, unsigned int output);
 
 namespace fl {
 
+// Private namespace for this TU's internal state + helpers. Avoids name
+// collisions with the sibling `flexio_spi_mode.cpp.hpp` TU in the unity
+// build (`fl/build/platforms+.cpp`): both would otherwise define
+// identically-named `sSpiCurrentPins` / `sSpiDmaChannel` / etc. at fl::
+// namespace scope -- a redefinition. Per user directive 2026-06-27
+// "when in doubt use private namespaces" (#3428).
+namespace detail::objectfled_spi_internal {
+
 // ============================================================================
 // Compile-time configuration
 // ============================================================================
@@ -87,13 +95,13 @@ namespace fl {
 #define FL_OBJECTFLED_SPI_MAX_BYTES 64
 #endif
 
-static constexpr u32 kOfSpiMaxInputBytes  = (u32)FL_OBJECTFLED_SPI_MAX_BYTES;
-static constexpr u32 kOfSpiWordsPerByte   = 16u;
-static constexpr u32 kOfSpiMaxOutputWords = kOfSpiMaxInputBytes * kOfSpiWordsPerByte;
+static constexpr u32 kSpiMaxInputBytes  = (u32)FL_OBJECTFLED_SPI_MAX_BYTES;
+static constexpr u32 kSpiWordsPerByte   = 16u;
+static constexpr u32 kSpiMaxOutputWords = kSpiMaxInputBytes * kSpiWordsPerByte;
 
 // Clock-rate clamp window (matches flexio_spi_mode.cpp.hpp).
-static constexpr u32 kOfSpiClockMinHz =   100000u;
-static constexpr u32 kOfSpiClockMaxHz = 25000000u;
+static constexpr u32 kSpiClockMinHz =   100000u;
+static constexpr u32 kSpiClockMaxHz = 25000000u;
 
 // IOMUXC pad tuning -- mirror the clockless mode's OUTPUT_PAD_SPEED=0,
 // DSE=3. TODO(#3428): if SPI loopback at 25 MHz shows undershoot, bump
@@ -109,23 +117,23 @@ static constexpr u32 kOfSpiClockMaxHz = 25000000u;
 // Module state (file-static, ISR-shared)
 // ============================================================================
 
-static DMAChannel* sOfSpiDmaChannel = nullptr;
-static volatile bool sOfSpiDmaComplete = true;
-static bool sOfSpiInitialized = false;
-static ObjectFLEDSPIPinInfo sOfSpiCurrentPins{};
+static DMAChannel* sSpiDmaChannel = nullptr;
+static volatile bool sSpiDmaComplete = true;
+static bool sSpiInitialized = false;
+static ObjectFLEDSPIPinInfo sSpiCurrentPins{};
 
 // Pre-encoded DMA bit-pattern buffer. DMAMEM = OCRAM2 (uncached on T4),
 // matches dma.bitdata in ObjectFLEDDmaManager. 32-byte aligned so the
 // SADDR satisfies eDMA 32-bit beat alignment.
-static DMAMEM u32 sOfSpiBitPattern[kOfSpiMaxOutputWords] __attribute__((used, aligned(32)));
+static DMAMEM u32 sSpiBitPattern[kSpiMaxOutputWords] __attribute__((used, aligned(32)));
 
 // Saved IOMUXC pad-mux values so deinit() can restore pad ALT5 (GPIO).
-static u32 sOfSpiSavedMosiMux = 0;
-static u32 sOfSpiSavedSclkMux = 0;
+static u32 sSpiSavedMosiMux = 0;
+static u32 sSpiSavedSclkMux = 0;
 
 // Diagnostics snapshot captured in wait() BEFORE recovery clears state.
 // Read by `objectfled_spi_read_diagnostics()` after wait() returns.
-static ObjectFLEDSPIDiagnostics sOfSpiLastDiag{};
+static ObjectFLEDSPIDiagnostics sSpiLastDiag{};
 
 // ============================================================================
 // GPIO6 pin-bank validation
@@ -145,13 +153,21 @@ static bool pin_is_gpio6(u8 pin) FL_NO_EXCEPT {
 // DMA ISR
 // ============================================================================
 
-static void of_spi_dma_isr() {
-    if (sOfSpiDmaChannel != nullptr) {
-        sOfSpiDmaChannel->clearInterrupt();
+static void objectfled_spi_dma_isr() {
+    if (sSpiDmaChannel != nullptr) {
+        sSpiDmaChannel->clearInterrupt();
     }
     asm volatile("dsb" ::: "memory");
-    sOfSpiDmaComplete = true;
+    sSpiDmaComplete = true;
 }
+
+}  // namespace detail::objectfled_spi_internal
+
+// ===========================================================================
+// Public API: defined in `namespace fl` directly (header signatures match).
+// Each function `using namespace detail::objectfled_spi_internal` to access
+// the private state without changing call-site spelling.
+// ===========================================================================
 
 // ============================================================================
 // objectfled_spi_lookup_pins
@@ -159,6 +175,7 @@ static void of_spi_dma_isr() {
 
 bool objectfled_spi_lookup_pins(u8 mosi_pin, u8 sclk_pin,
                                 ObjectFLEDSPIPinInfo* info) FL_NO_EXCEPT {
+    using namespace detail::objectfled_spi_internal;
     if (!info) return false;
     if (mosi_pin == sclk_pin) return false;
     if (mosi_pin >= NUM_DIGITAL_PINS) return false;
@@ -206,7 +223,7 @@ bool objectfled_spi_lookup_pins(u8 mosi_pin, u8 sclk_pin,
 // Mirrors the clockless ObjectFLED QTimer4 setup at OjectFLED.cpp.hpp:305-335
 // but on QTimer3 (QTimer4 is taken) and routes to the only unclaimed XBAR
 // DMA slot (req95; clockless uses 30/31/94).
-static void of_spi_program_qtimer(u32 req_hz) FL_NO_EXCEPT {
+static void objectfled_spi_program_qtimer(u32 req_hz) FL_NO_EXCEPT {
     // Disable channel 0 so we can re-program safely.
     TMR3_ENBL &= ~1u;
 
@@ -256,6 +273,7 @@ static void of_spi_program_qtimer(u32 req_hz) FL_NO_EXCEPT {
 
 bool objectfled_spi_init(const ObjectFLEDSPIPinInfo& pin_info,
                          u32 clock_hz) FL_NO_EXCEPT {
+    using namespace detail::objectfled_spi_internal;
     // #3428 HARDWARE BRING-UP INCOMPLETE: the FlexPWM2_SM0 register
     // sequence below has had a CCM gate fix (bits 18-19, not 22-23) but
     // a remaining issue still hard-faults the Teensy on the first show()
@@ -340,23 +358,23 @@ bool objectfled_spi_init(const ObjectFLEDSPIPinInfo& pin_info,
                         "channels fall through to next bus (see #3428).");
     return false;
 #else
-    sOfSpiLastDiag = ObjectFLEDSPIDiagnostics{};  // reset captured snapshot
+    sSpiLastDiag = ObjectFLEDSPIDiagnostics{};  // reset captured snapshot
     if (clock_hz == 0) {
         FL_LOG_OBJECTFLED_F("ObjectFLED_SPI: init refused -- clock_hz == 0");
         return false;
     }
-    if (sOfSpiInitialized) {
+    if (sSpiInitialized) {
         objectfled_spi_deinit();
     }
 
-    if (clock_hz < kOfSpiClockMinHz) {
+    if (clock_hz < kSpiClockMinHz) {
         FL_LOG_OBJECTFLED_F("ObjectFLED_SPI: clock %s Hz below floor; clamp to %s",
-                            (int)clock_hz, (int)kOfSpiClockMinHz);
-        clock_hz = kOfSpiClockMinHz;
-    } else if (clock_hz > kOfSpiClockMaxHz) {
+                            (int)clock_hz, (int)kSpiClockMinHz);
+        clock_hz = kSpiClockMinHz;
+    } else if (clock_hz > kSpiClockMaxHz) {
         FL_LOG_OBJECTFLED_F("ObjectFLED_SPI: clock %s Hz above ceiling; clamp to %s",
-                            (int)clock_hz, (int)kOfSpiClockMaxHz);
-        clock_hz = kOfSpiClockMaxHz;
+                            (int)clock_hz, (int)kSpiClockMaxHz);
+        clock_hz = kSpiClockMaxHz;
     }
 
     FL_LOG_OBJECTFLED_F("ObjectFLED_SPI: init MOSI=%s(bit %s) SCLK=%s(bit %s) @ %s Hz",
@@ -371,8 +389,8 @@ bool objectfled_spi_init(const ObjectFLEDSPIPinInfo& pin_info,
 
     // Snapshot pre-init mux ALT values so deinit() can restore them. Per
     // coderabbitai review on #3432.
-    sOfSpiSavedMosiMux = *(pin_info.mosi_mux_reg);
-    sOfSpiSavedSclkMux = *(pin_info.sclk_mux_reg);
+    sSpiSavedMosiMux = *(pin_info.mosi_mux_reg);
+    sSpiSavedSclkMux = *(pin_info.sclk_mux_reg);
 
     *(pin_info.mosi_mux_reg) = 5u;
     *(pin_info.mosi_pad_reg) =
@@ -399,29 +417,29 @@ bool objectfled_spi_init(const ObjectFLEDSPIPinInfo& pin_info,
     GPIO1_GDIR |= (pin_info.mosi_mask | pin_info.sclk_mask);
     GPIO1_DR   &= ~(pin_info.mosi_mask | pin_info.sclk_mask);
 
-    of_spi_program_qtimer(2u * clock_hz);
+    objectfled_spi_program_qtimer(2u * clock_hz);
 
-    if (sOfSpiDmaChannel == nullptr) {
-        sOfSpiDmaChannel = new DMAChannel();  // ok bare allocation -- one-shot, balanced in deinit
-        if (sOfSpiDmaChannel == nullptr) {
+    if (sSpiDmaChannel == nullptr) {
+        sSpiDmaChannel = new DMAChannel();  // ok bare allocation -- one-shot, balanced in deinit
+        if (sSpiDmaChannel == nullptr) {
             FL_LOG_OBJECTFLED_F("ObjectFLED_SPI: failed to allocate DMA channel");
             return false;
         }
-        if (sOfSpiDmaChannel->TCD == nullptr) {
+        if (sSpiDmaChannel->TCD == nullptr) {
             FL_LOG_OBJECTFLED_F("ObjectFLED_SPI: DMA channel has null TCD");
-            delete sOfSpiDmaChannel;  // ok bare allocation
-            sOfSpiDmaChannel = nullptr;
+            delete sSpiDmaChannel;  // ok bare allocation
+            sSpiDmaChannel = nullptr;
             return false;
         }
         // XBAR1_3 -> DMA_CH_MUX_REQ95, driven by QTIMER3_TIMER0 compare event
-        // (configured in of_spi_program_qtimer). DMAMUX_SOURCE_XBAR1_3 = 95.
-        sOfSpiDmaChannel->triggerAtHardwareEvent(DMAMUX_SOURCE_XBAR1_3);
-        sOfSpiDmaChannel->attachInterrupt(of_spi_dma_isr);
+        // (configured in objectfled_spi_program_qtimer). DMAMUX_SOURCE_XBAR1_3 = 95.
+        sSpiDmaChannel->triggerAtHardwareEvent(DMAMUX_SOURCE_XBAR1_3);
+        sSpiDmaChannel->attachInterrupt(objectfled_spi_dma_isr);
     }
 
-    sOfSpiCurrentPins = pin_info;
-    sOfSpiInitialized = true;
-    sOfSpiDmaComplete = true;
+    sSpiCurrentPins = pin_info;
+    sSpiInitialized = true;
+    sSpiDmaComplete = true;
     return true;
 #endif  // FL_OBJECTFLED_SPI_HARDWARE_DISABLE
 }
@@ -455,19 +473,20 @@ static inline void encode_byte(u32* dst, u8 b,
 // ============================================================================
 
 bool objectfled_spi_show(fl::span<const u8> buffer) FL_NO_EXCEPT {
+    using namespace detail::objectfled_spi_internal;
     const u8* const data = buffer.data();
     const u32 num_bytes = static_cast<u32>(buffer.size());
-    if (!sOfSpiInitialized || !sOfSpiDmaChannel || !data || num_bytes == 0) {
+    if (!sSpiInitialized || !sSpiDmaChannel || !data || num_bytes == 0) {
         return false;
     }
-    if (num_bytes > kOfSpiMaxInputBytes) {
+    if (num_bytes > kSpiMaxInputBytes) {
         // Per coderabbitai review on #3432: reject oversized frames rather
         // than silently truncating. Silent truncation would emit a partial
         // APA102/SK9822 frame with no caller visibility, corrupting the
         // strip output. The header documents that invalid arguments return
         // false; honor that contract.
         FL_LOG_OBJECTFLED_F("ObjectFLED_SPI: num_bytes=%s exceeds max %s; rejecting",
-                            (int)num_bytes, (int)kOfSpiMaxInputBytes);
+                            (int)num_bytes, (int)kSpiMaxInputBytes);
         return false;
     }
 
@@ -492,47 +511,47 @@ bool objectfled_spi_show(fl::span<const u8> buffer) FL_NO_EXCEPT {
 
     objectfled_spi_wait();
 
-    sOfSpiDmaChannel->disable();
-    sOfSpiDmaChannel->clearComplete();
-    sOfSpiDmaChannel->clearInterrupt();
-    sOfSpiDmaChannel->clearError();
-    sOfSpiDmaComplete = true;
+    sSpiDmaChannel->disable();
+    sSpiDmaChannel->clearComplete();
+    sSpiDmaChannel->clearInterrupt();
+    sSpiDmaChannel->clearError();
+    sSpiDmaComplete = true;
 
     // Snapshot "other" bits from the GPIO1 alias (init remapped GPIO6
     // pads -> GPIO1 so eDMA can reach them).
-    const u32 other = GPIO1_DR & ~(sOfSpiCurrentPins.mosi_mask |
-                                   sOfSpiCurrentPins.sclk_mask);
+    const u32 other = GPIO1_DR & ~(sSpiCurrentPins.mosi_mask |
+                                   sSpiCurrentPins.sclk_mask);
 
-    u32* dst = sOfSpiBitPattern;
+    u32* dst = sSpiBitPattern;
     for (u32 i = 0; i < num_bytes; ++i) {
         encode_byte(dst, data[i], other,
-                    sOfSpiCurrentPins.mosi_mask,
-                    sOfSpiCurrentPins.sclk_mask);
-        dst += kOfSpiWordsPerByte;
+                    sSpiCurrentPins.mosi_mask,
+                    sSpiCurrentPins.sclk_mask);
+        dst += kSpiWordsPerByte;
     }
-    const u32 num_words = num_bytes * kOfSpiWordsPerByte;
+    const u32 num_words = num_bytes * kSpiWordsPerByte;
 
-    if ((uintptr_t)sOfSpiBitPattern >= 0x20200000u) {
-        arm_dcache_flush((void*)sOfSpiBitPattern, num_words * sizeof(u32));
+    if ((uintptr_t)sSpiBitPattern >= 0x20200000u) {
+        arm_dcache_flush((void*)sSpiBitPattern, num_words * sizeof(u32));
     }
     asm volatile("dsb" ::: "memory");
 
-    sOfSpiDmaChannel->TCD->SADDR        = sOfSpiBitPattern;
-    sOfSpiDmaChannel->TCD->SOFF         = 4;
-    sOfSpiDmaChannel->TCD->ATTR         = DMA_TCD_ATTR_SSIZE(2)
+    sSpiDmaChannel->TCD->SADDR        = sSpiBitPattern;
+    sSpiDmaChannel->TCD->SOFF         = 4;
+    sSpiDmaChannel->TCD->ATTR         = DMA_TCD_ATTR_SSIZE(2)
                                       | DMA_TCD_ATTR_DSIZE(2);
-    sOfSpiDmaChannel->TCD->NBYTES_MLNO  = 4;
-    sOfSpiDmaChannel->TCD->SLAST        = -(i32)(num_words * 4u);
+    sSpiDmaChannel->TCD->NBYTES_MLNO  = 4;
+    sSpiDmaChannel->TCD->SLAST        = -(i32)(num_words * 4u);
     // DADDR = GPIO1_DR (eDMA-reachable alias; init remapped via GPR26).
-    sOfSpiDmaChannel->TCD->DADDR        = &GPIO1_DR;
-    sOfSpiDmaChannel->TCD->DOFF         = 0;
-    sOfSpiDmaChannel->TCD->CITER_ELINKNO = num_words;
-    sOfSpiDmaChannel->TCD->BITER_ELINKNO = num_words;
-    sOfSpiDmaChannel->TCD->DLASTSGA     = 0;
-    sOfSpiDmaChannel->TCD->CSR          = DMA_TCD_CSR_INTMAJOR | DMA_TCD_CSR_DREQ;
+    sSpiDmaChannel->TCD->DADDR        = &GPIO1_DR;
+    sSpiDmaChannel->TCD->DOFF         = 0;
+    sSpiDmaChannel->TCD->CITER_ELINKNO = num_words;
+    sSpiDmaChannel->TCD->BITER_ELINKNO = num_words;
+    sSpiDmaChannel->TCD->DLASTSGA     = 0;
+    sSpiDmaChannel->TCD->CSR          = DMA_TCD_CSR_INTMAJOR | DMA_TCD_CSR_DREQ;
 
-    sOfSpiDmaComplete = false;
-    sOfSpiDmaChannel->enable();
+    sSpiDmaComplete = false;
+    sSpiDmaChannel->enable();
 
     // Start QTimer3 channel 0 -- its periodic compare events drive the
     // DMA via XBAR routing set up in init().
@@ -548,44 +567,45 @@ bool objectfled_spi_show(fl::span<const u8> buffer) FL_NO_EXCEPT {
 // ============================================================================
 
 void objectfled_spi_wait() FL_NO_EXCEPT {
-    if (sOfSpiDmaComplete) {
+    using namespace detail::objectfled_spi_internal;
+    if (sSpiDmaComplete) {
         return;
     }
 
     const u32 start = millis();
     const u32 timeout_ms = 50;
-    while (!sOfSpiDmaComplete) {
+    while (!sSpiDmaComplete) {
         if ((u32)(millis() - start) >= timeout_ms) {
             // Snapshot register state BEFORE recovery clears it.
-            sOfSpiLastDiag = ObjectFLEDSPIDiagnostics{};
-            sOfSpiLastDiag.initialized = sOfSpiInitialized;
-            sOfSpiLastDiag.dma_complete = sOfSpiDmaComplete;
-            if (sOfSpiDmaChannel) {
-                sOfSpiLastDiag.dma_channel = sOfSpiDmaChannel->channel;
-                sOfSpiLastDiag.dma_erq = DMA_ERQ;
-                sOfSpiLastDiag.dma_int = DMA_INT;
-                sOfSpiLastDiag.dma_err = DMA_ERR;
-                sOfSpiLastDiag.dma_es  = DMA_ES;
-                if (sOfSpiDmaChannel->TCD) {
-                    sOfSpiLastDiag.dma_citer    = sOfSpiDmaChannel->TCD->CITER_ELINKNO;
-                    sOfSpiLastDiag.dma_biter    = sOfSpiDmaChannel->TCD->BITER_ELINKNO;
-                    sOfSpiLastDiag.dma_dlastsga = (u32)sOfSpiDmaChannel->TCD->DLASTSGA;
+            sSpiLastDiag = ObjectFLEDSPIDiagnostics{};
+            sSpiLastDiag.initialized = sSpiInitialized;
+            sSpiLastDiag.dma_complete = sSpiDmaComplete;
+            if (sSpiDmaChannel) {
+                sSpiLastDiag.dma_channel = sSpiDmaChannel->channel;
+                sSpiLastDiag.dma_erq = DMA_ERQ;
+                sSpiLastDiag.dma_int = DMA_INT;
+                sSpiLastDiag.dma_err = DMA_ERR;
+                sSpiLastDiag.dma_es  = DMA_ES;
+                if (sSpiDmaChannel->TCD) {
+                    sSpiLastDiag.dma_citer    = sSpiDmaChannel->TCD->CITER_ELINKNO;
+                    sSpiLastDiag.dma_biter    = sSpiDmaChannel->TCD->BITER_ELINKNO;
+                    sSpiLastDiag.dma_dlastsga = (u32)sSpiDmaChannel->TCD->DLASTSGA;
                 }
             }
-            sOfSpiLastDiag.tmr3_cntr0   = TMR3_CNTR0;
-            sOfSpiLastDiag.tmr3_csctrl0 = TMR3_CSCTRL0;
-            sOfSpiLastDiag.tmr3_sctrl0  = TMR3_SCTRL0;
-            sOfSpiLastDiag.tmr3_ctrl0   = TMR3_CTRL0;
-            sOfSpiLastDiag.tmr3_enbl    = TMR3_ENBL;
-            sOfSpiLastDiag.xbar1_ctrl1  = XBARA1_CTRL1;
+            sSpiLastDiag.tmr3_cntr0   = TMR3_CNTR0;
+            sSpiLastDiag.tmr3_csctrl0 = TMR3_CSCTRL0;
+            sSpiLastDiag.tmr3_sctrl0  = TMR3_SCTRL0;
+            sSpiLastDiag.tmr3_ctrl0   = TMR3_CTRL0;
+            sSpiLastDiag.tmr3_enbl    = TMR3_ENBL;
+            sSpiLastDiag.xbar1_ctrl1  = XBARA1_CTRL1;
 
-            if (sOfSpiDmaChannel) {
-                sOfSpiDmaChannel->disable();
-                sOfSpiDmaChannel->clearComplete();
-                sOfSpiDmaChannel->clearError();
+            if (sSpiDmaChannel) {
+                sSpiDmaChannel->disable();
+                sSpiDmaChannel->clearComplete();
+                sSpiDmaChannel->clearError();
             }
             TMR3_ENBL &= ~1u;  // stop QTimer3 channel 0
-            sOfSpiDmaComplete = true;
+            sSpiDmaComplete = true;
             FL_LOG_OBJECTFLED_F("ObjectFLED_SPI: wait timed out after %s ms -- recovering",
                                 (int)timeout_ms);
             break;
@@ -605,7 +625,7 @@ void objectfled_spi_wait() FL_NO_EXCEPT {
     TMR3_ENBL &= ~1u;
 
     // Park SCLK + MOSI low on the GPIO1 alias (init remapped GPIO6 -> GPIO1).
-    GPIO1_DR = (GPIO1_DR & ~(sOfSpiCurrentPins.mosi_mask | sOfSpiCurrentPins.sclk_mask));
+    GPIO1_DR = (GPIO1_DR & ~(sSpiCurrentPins.mosi_mask | sSpiCurrentPins.sclk_mask));
 
     // NOTE(#3428): paired with the show() acquire-skip above. The manager
     // was never acquired (see comment in objectfled_spi_show), so no
@@ -617,7 +637,8 @@ void objectfled_spi_wait() FL_NO_EXCEPT {
 // ============================================================================
 
 void objectfled_spi_deinit() FL_NO_EXCEPT {
-    if (!sOfSpiInitialized) return;
+    using namespace detail::objectfled_spi_internal;
+    if (!sSpiInitialized) return;
 
     objectfled_spi_wait();
 
@@ -630,12 +651,12 @@ void objectfled_spi_deinit() FL_NO_EXCEPT {
     // CTRL1 slot 0 (req94) and we don't want to clobber its bits. The
     // routing is harmless when our DMA channel is disabled.
 
-    if (sOfSpiDmaChannel) {
-        sOfSpiDmaChannel->disable();
-        sOfSpiDmaChannel->detachInterrupt();
-        sOfSpiDmaChannel->clearInterrupt();
-        DMAChannel* to_delete = sOfSpiDmaChannel;
-        sOfSpiDmaChannel = nullptr;
+    if (sSpiDmaChannel) {
+        sSpiDmaChannel->disable();
+        sSpiDmaChannel->detachInterrupt();
+        sSpiDmaChannel->clearInterrupt();
+        DMAChannel* to_delete = sSpiDmaChannel;
+        sSpiDmaChannel = nullptr;
         delete to_delete;  // ok bare allocation
     }
 
@@ -643,25 +664,25 @@ void objectfled_spi_deinit() FL_NO_EXCEPT {
     // captured in objectfled_spi_init() rather than forcing ALT5. If the
     // user previously had the pin on (e.g.) ALT3 for FlexCAN, forcing ALT5
     // would leave them with a silently-changed pin mux post-deinit.
-    if (sOfSpiCurrentPins.mosi_mux_reg) {
-        GPIO1_DR   &= ~sOfSpiCurrentPins.mosi_mask;
-        GPIO1_GDIR &= ~sOfSpiCurrentPins.mosi_mask;
-        *(sOfSpiCurrentPins.mosi_mux_reg) = sOfSpiSavedMosiMux;
+    if (sSpiCurrentPins.mosi_mux_reg) {
+        GPIO1_DR   &= ~sSpiCurrentPins.mosi_mask;
+        GPIO1_GDIR &= ~sSpiCurrentPins.mosi_mask;
+        *(sSpiCurrentPins.mosi_mux_reg) = sSpiSavedMosiMux;
     }
-    if (sOfSpiCurrentPins.sclk_mux_reg) {
-        GPIO1_DR   &= ~sOfSpiCurrentPins.sclk_mask;
-        GPIO1_GDIR &= ~sOfSpiCurrentPins.sclk_mask;
-        *(sOfSpiCurrentPins.sclk_mux_reg) = sOfSpiSavedSclkMux;
+    if (sSpiCurrentPins.sclk_mux_reg) {
+        GPIO1_DR   &= ~sSpiCurrentPins.sclk_mask;
+        GPIO1_GDIR &= ~sSpiCurrentPins.sclk_mask;
+        *(sSpiCurrentPins.sclk_mux_reg) = sSpiSavedSclkMux;
     }
     // NOTE: we deliberately do NOT restore IOMUXC_GPR_GPR26 -- leaving
     // the pads aliased to GPIO1 is harmless when not driven, and avoids
     // a race with any other driver that may have remapped the same bits.
 
-    sOfSpiInitialized   = false;
-    sOfSpiDmaComplete   = true;
-    sOfSpiCurrentPins   = ObjectFLEDSPIPinInfo{};
-    sOfSpiSavedMosiMux  = 0;
-    sOfSpiSavedSclkMux  = 0;
+    sSpiInitialized   = false;
+    sSpiDmaComplete   = true;
+    sSpiCurrentPins   = ObjectFLEDSPIPinInfo{};
+    sSpiSavedMosiMux  = 0;
+    sSpiSavedSclkMux  = 0;
 }
 
 // ============================================================================
@@ -669,32 +690,33 @@ void objectfled_spi_deinit() FL_NO_EXCEPT {
 // ============================================================================
 
 void objectfled_spi_read_diagnostics(ObjectFLEDSPIDiagnostics* out) FL_NO_EXCEPT {
+    using namespace detail::objectfled_spi_internal;
     if (!out) return;
 
     // If wait() captured a snapshot during its timeout-recovery path,
     // prefer that (pre-cleanup register state is much more diagnostic
     // than post-cleanup).
-    if (sOfSpiLastDiag.tmr3_enbl != 0 || sOfSpiLastDiag.dma_erq != 0 ||
-        sOfSpiLastDiag.dma_int != 0  || sOfSpiLastDiag.dma_err != 0) {
-        *out = sOfSpiLastDiag;
+    if (sSpiLastDiag.tmr3_enbl != 0 || sSpiLastDiag.dma_erq != 0 ||
+        sSpiLastDiag.dma_int != 0  || sSpiLastDiag.dma_err != 0) {
+        *out = sSpiLastDiag;
         return;
     }
 
     *out = ObjectFLEDSPIDiagnostics{};
-    out->initialized = sOfSpiInitialized;
-    out->dma_complete = sOfSpiDmaComplete;
+    out->initialized = sSpiInitialized;
+    out->dma_complete = sSpiDmaComplete;
 
-    if (sOfSpiDmaChannel) {
-        out->dma_channel = sOfSpiDmaChannel->channel;
+    if (sSpiDmaChannel) {
+        out->dma_channel = sSpiDmaChannel->channel;
         // Per-channel bit in ERQ/INT/ERR is (1 << channel).
         out->dma_erq = DMA_ERQ;
         out->dma_int = DMA_INT;
         out->dma_err = DMA_ERR;
         out->dma_es  = DMA_ES;
-        if (sOfSpiDmaChannel->TCD) {
-            out->dma_citer    = sOfSpiDmaChannel->TCD->CITER_ELINKNO;
-            out->dma_biter    = sOfSpiDmaChannel->TCD->BITER_ELINKNO;
-            out->dma_dlastsga = (u32)sOfSpiDmaChannel->TCD->DLASTSGA;
+        if (sSpiDmaChannel->TCD) {
+            out->dma_citer    = sSpiDmaChannel->TCD->CITER_ELINKNO;
+            out->dma_biter    = sSpiDmaChannel->TCD->BITER_ELINKNO;
+            out->dma_dlastsga = (u32)sSpiDmaChannel->TCD->DLASTSGA;
         }
     }
 


### PR DESCRIPTION
## Summary

Follow-up to #3431 / #3432. Per user directive 2026-06-27 _"when in doubt use private namespaces"_, replace the `sOfSpi*` / `kOfSpi*` / `of_spi_*` prefix-rename workaround for the unity-build collision with the more idiomatic **private named namespace** approach.

## What changes

| Driver | Before | After |
|--------|--------|-------|
| FlexIO-SPI | `static ... sSpiCurrentPins; sSpiDmaChannel; ...` at `fl::` scope (worked because it was first to land) | wrapped in `namespace fl::detail::flexio_spi_internal { ... }` |
| ObjectFLED-SPI | `static ... sOfSpiCurrentPins; sOfSpiDmaChannel; ...` at `fl::` scope (prefixed to avoid collision with FlexIO in the same unity TU) | wrapped in `namespace fl::detail::objectfled_spi_internal { ... }`, prefix dropped |

Each public API function (the ones in the `.h` headers) opens its body with `using namespace detail::xxx_spi_internal;` so call-sites read naturally. The two drivers' identically-named statics now live in different named namespaces — no collision in the unity build (`fl/build/platforms+.cpp`).

## Why not a single anonymous namespace per file

Per [C++ namespace.unnamed], multiple `namespace { ... }` declarations within the same TU **merge** into one anonymous namespace. In a unity TU that pulls in both files, anonymous-namespace contents would still collide. Named-and-distinct is the only collision-free option short of file isolation (which the project's unity-build strategy doesn't grant).

## Hardware verification (Teensy 4.1, COM20)

- `flexioSpiSelfTest` — 3/3 pass (wait_ms=0)
- `objectfledSpiSelfTest` — 3/3 pass (wait_ms=5 = drain wait only)

Behavior is byte-equivalent before/after; this is a pure cleanup refactor.

## Test plan

- [x] `bash test --cpp` — passes
- [x] `bash lint --cpp` clean
- [x] `bash compile teensy41 --examples AutoResearch` succeeds
- [x] Both SPI smoke tests pass on real Teensy 4.1
- [ ] CI green

Refs #3428, #3431, #3432.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SPI-mode stability on Teensy 4.x, reducing symbol conflicts in builds and making transfers more reliable.
  * Added stronger checks and safer handling for invalid or oversized SPI frames.
  * Improved timeout handling and cleanup so SPI hardware state is left in a predictable condition.

* **Refactor**
  * Reorganized internal SPI implementation state for better isolation between related drivers.
  * Improved diagnostic reporting after failures and timeouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->