### PR TITLE
chore(lpc): use canonical FastLED/* URLs after org transfer

### DIFF
--- a/ci/boards.py
+++ b/ci/boards.py
@@ -1131,9 +1131,10 @@ RPI_PICO2 = Board(
 )
 
 # NXP LPC8xx family. PlatformIO has no native Arduino-capable nxplpc
-# platform, so use the zackees fork that layers ArduinoCore-LPC8xx on top of
+# platform, so use the FastLED fork (transferred from zackees/ in 2026-06-28) that
+# layers framework-arduino-lpc8xx on top of
 # platformio/platform-nxplpc.
-_NXPLPC_PLATFORM = "https://github.com/zackees/platform-nxplpc-arduino.git#12265f765aebd3893465d6d7ad76be66d89ba015"
+_NXPLPC_PLATFORM = "https://github.com/FastLED/platform-nxp-lpc8xx.git#12265f765aebd3893465d6d7ad76be66d89ba015"
 
 LPC845BRK = Board(
     board_name="lpc845brk",

--- a/platformio.ini
+++ b/platformio.ini
@@ -171,7 +171,7 @@ extra_scripts = pre:ci/ci-flags.py
 
 [env:lpc845brk]
 ; NXP LPC845-BRK bring-up target — built via the fbuild nxplpc orchestrator
-; which consumes zackees/ArduinoCore-LPC8xx. PlatformIO does not have a
+; which consumes FastLED/framework-arduino-lpc8xx. PlatformIO does not have a
 ; native nxplpc platform; this env is here only so the AutoResearch wrapper
 ; (`bash autoresearch lpc845brk`) can resolve a known environment name and
 ; dispatch to the consolidated bring-up sketch at examples/AutoResearch/
@@ -187,9 +187,9 @@ extra_scripts = pre:ci/ci-flags.py
 ;                                    for the FastLED controller lifetime.
 ; The WS2812 loopback RPC is now derived from the LPC845 platform predicate
 ; inside AutoResearchLowMemory.h; no user build flag is required.
-; justification: bump zackees/platform-nxplpc-arduino to v0.2.0 — picks up post-#3437-step-1 ArduinoCore-LPC8xx with full NXP CMSIS PAL in variants/lpc845/+lpc804/
+; justification: bump FastLED/platform-nxp-lpc8xx to v0.2.0 — picks up post-#3437-step-1 ArduinoCore-LPC8xx with full NXP CMSIS PAL in variants/lpc845/+lpc804/
 ; added-in: PR-3438
-platform = https://github.com/zackees/platform-nxplpc-arduino.git#12265f765aebd3893465d6d7ad76be66d89ba015
+platform = https://github.com/FastLED/platform-nxp-lpc8xx.git#12265f765aebd3893465d6d7ad76be66d89ba015
 board = lpc845brk
 framework = arduino
 build_flags =
@@ -217,7 +217,7 @@ build_flags =
 ;
 ; All four use the same nxplpc + ArduinoCore-LPC8xx stack (see lpc845brk
 ; comment above for the dispatch rationale). Each maps 1:1 to one of the
-; `variants/<name>/` entries in zackees/ArduinoCore-LPC8xx, matching the
+; `variants/<name>/` entries in FastLED/framework-arduino-lpc8xx, matching the
 ; five upstream `fbuild build . -e <variant>` jobs that already pass on
 ; that repo (see #2990 body).
 ; --------------------------------------------------------------------------
@@ -225,28 +225,28 @@ build_flags =
 [env:lpc845]
 ; justification: same platform pin as env:lpc845brk above — full NXP CMSIS PAL via platform-nxplpc-arduino v0.2.0. FastLED #3437.
 ; added-in: PR-3438
-platform = https://github.com/zackees/platform-nxplpc-arduino.git#12265f765aebd3893465d6d7ad76be66d89ba015
+platform = https://github.com/FastLED/platform-nxp-lpc8xx.git#12265f765aebd3893465d6d7ad76be66d89ba015
 board = lpc845
 framework = arduino
 
 [env:lpc804]
 ; justification: same platform pin as env:lpc845brk above. FastLED #3437.
 ; added-in: PR-3438
-platform = https://github.com/zackees/platform-nxplpc-arduino.git#12265f765aebd3893465d6d7ad76be66d89ba015
+platform = https://github.com/FastLED/platform-nxp-lpc8xx.git#12265f765aebd3893465d6d7ad76be66d89ba015
 board = lpc804
 framework = arduino
 
 [env:lpcxpresso845max]
 ; justification: same platform pin as env:lpc845brk above. FastLED #3437.
 ; added-in: PR-3438
-platform = https://github.com/zackees/platform-nxplpc-arduino.git#12265f765aebd3893465d6d7ad76be66d89ba015
+platform = https://github.com/FastLED/platform-nxp-lpc8xx.git#12265f765aebd3893465d6d7ad76be66d89ba015
 board = lpcxpresso845max
 framework = arduino
 
 [env:lpcxpresso804]
 ; justification: same platform pin as env:lpc845brk above. FastLED #3437.
 ; added-in: PR-3438
-platform = https://github.com/zackees/platform-nxplpc-arduino.git#12265f765aebd3893465d6d7ad76be66d89ba015
+platform = https://github.com/FastLED/platform-nxp-lpc8xx.git#12265f765aebd3893465d6d7ad76be66d89ba015
 board = lpcxpresso804
 framework = arduino
 


### PR DESCRIPTION
Cleanup pass after the 2026-06-28 org transfer:

- `zackees/platform-nxplpc-arduino` -> `FastLED/platform-nxp-lpc8xx`
- `zackees/ArduinoCore-LPC8xx` -> `FastLED/framework-arduino-lpc8xx`

Both transfers + renames preserve full GitHub redirects from the old URLs, so existing pins and checkouts keep working. This PR makes the canonical URLs first-class in `ci/boards.py` and `platformio.ini` so anyone reading the pin sees the maintainer org directly.

SHA pin unchanged (`12265f765aebd3893465d6d7ad76be66d89ba015`). No behavioral change.

Companion PRs already merged:
- [FastLED/platform-nxp-lpc8xx#10](https://github.com/FastLED/platform-nxp-lpc8xx/pull/10) — same cleanup in the platform's own `platform.json`
- [FastLED/fbuild#788](https://github.com/FastLED/fbuild/pull/788) — same cleanup in fbuild's `ACLPC_URL`

Catalog of all FastLED-curated platforms / frameworks / pins now lives at [FastLED/registry](https://github.com/FastLED/registry).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated LPC8xx board build settings to use a newer PlatformIO source, improving consistency for board setup and builds.
  * Aligned the related LPC845 and canary environments with the same platform source so the supported board configurations stay in sync.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->