### PR TITLE
chore: bump fbuild to 2.3.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,9 +5,13 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    # Pin to fbuild 2.3.3 (released 2026-06-23).
+    # Pin to fbuild 2.3.13 (released 2026-06-29).
     #
     # Pin history:
+    #   2.3.13 -- carries the serial monitor reset/preemption fixes needed
+    #             for AutoResearch to keep using fbuild serial after a
+    #             daemon reset path closes the active monitor session
+    #             (FastLED/fbuild#811, FastLED/fbuild#822).
     #   2.3.3 -- latest PyPI release as of 2026-06-24; carries the
     #            post-2.3.1 fbuild fixes needed by the current
     #            AutoResearch/ObjectFLED validation pass.
@@ -122,7 +126,7 @@ dependencies = [
     # primitive (FastLED/fbuild#532, #577/#580), and an
     # http-connect-timeout fix on the managed-zccache client
     # (FastLED/fbuild#573).
-    "fbuild==2.3.3",
+    "fbuild==2.3.13",
     "platformio>=6.1.19,<6.2",
     "python-dateutil",
     "ruff",


### PR DESCRIPTION
﻿## Summary
- bump the pinned fbuild dependency from 2.3.3 to 2.3.13
- document that 2.3.13 carries the serial monitor reset/preemption fixes from FastLED/fbuild#811 and FastLED/fbuild#822

## Tests
- uv run --no-project --with fbuild==2.3.13 python -c "import fbuild; print(fbuild.__version__)"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated a bundled dependency to a newer version, which includes stability improvements and fixes for reset/preemption behavior during serial monitoring.

* **Chores**
  * Refreshed dependency version tracking to reflect the latest supported release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->