### PR TITLE
chore: bump fbuild to 2.3.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,9 +5,12 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    # Pin to fbuild 2.3.13 (released 2026-06-29).
+    # Pin to fbuild 2.3.14 (released 2026-06-30).
     #
     # Pin history:
+    #   2.3.14 -- carries the async/subprocess timeout fixes and daemon
+    #             serial-WebSocket hardening needed after the fbuild async
+    #             migration (FastLED/fbuild#828/#832/#833/#842/#843).
     #   2.3.13 -- carries the serial monitor reset/preemption fixes needed
     #             for AutoResearch to keep using fbuild serial after a
     #             daemon reset path closes the active monitor session
@@ -126,7 +129,7 @@ dependencies = [
     # primitive (FastLED/fbuild#532, #577/#580), and an
     # http-connect-timeout fix on the managed-zccache client
     # (FastLED/fbuild#573).
-    "fbuild==2.3.13",
+    "fbuild==2.3.14",
     "platformio>=6.1.19,<6.2",
     "python-dateutil",
     "ruff",


### PR DESCRIPTION
## Summary

- bump the FastLED fbuild pin from `2.3.13` to `2.3.14`
- update the nearby pin-history comment for the new async/subprocess timeout and serial-WebSocket hardening release

## Validation

- `python -m pip index versions fbuild` reports `LATEST: 2.3.14`
- `python -c "import pathlib,tomllib; d=tomllib.loads(pathlib.Path('pyproject.toml').read_text()); assert 'fbuild==2.3.14' in d['project']['dependencies']"`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a project dependency to the latest patch release.
  * Refreshed the accompanying release history notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->