### PR TITLE
ci(build): add workflow_dispatch trigger to build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,12 @@ on:
       - 'platformio.ini'
       - 'library.json'
       - 'library.properties'
+  # Manual trigger so the cross-platform matrix can be exercised on a
+  # feature branch before merge. The matrix is otherwise post-merge only
+  # — useful for big refactors (e.g. #3444 bus enum migration) where the
+  # contributor wants per-board signal before the breaking-swap lands on
+  # master.
+  workflow_dispatch:
 
 jobs:
   build_uno:


### PR DESCRIPTION
## Summary

Adds `workflow_dispatch:` trigger to `.github/workflows/build.yml` so the cross-platform build matrix can be exercised on a feature branch before merge.

## Why

`build.yml` only fires on `push` to `master` today. For large refactors (e.g. the just-merged #3444 bus enum migration), there's no way to get per-board signal on a feature branch before the merge — which forces a merge-then-fix-forward cycle for any board the local WASM/Teensy validation didn't cover.

`workflow_dispatch` lets a maintainer run the matrix on demand against any branch via the Actions UI or:

```
gh workflow run build.yml --ref <branch>
```

## What this doesn't change

- Path filters are unchanged. `workflow_dispatch` ignores them anyway.
- No new permissions, no new jobs, no new boards.
- Push behaviour is identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a manual option to start the cross-platform build workflow.
  * Build checks can now be run on feature branches without waiting for a push event.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->