### PR TITLE
fix(autoresearch): correct classic-ESP32 macro + gate pins 6/7/8 (follow-up to #3447)

### DIFF
--- a/examples/AutoResearch/LegacyClocklessProxy.h
+++ b/examples/AutoResearch/LegacyClocklessProxy.h
@@ -21,19 +21,26 @@ enum class LegacyClocklessChipset : uint8_t {
 #define AUTORESEARCH_LEGACY_SUPPORTS_PIN_22 0
 #endif
 
-// GPIO8 on the classic ESP32 (esp32dev / WROOM modules) is reserved
-// for SPI flash (D2/HD) and FastLED's `_ESPPIN<8>::validpin()` reflects
-// that with a compile-time false. Trying to instantiate any clockless
-// driver bound to pin 8 fails the FastLED static_assert. Other ESP32
-// variants (S2/S3/C-series) repurpose GPIO8 and accept it as a valid
-// output pin, and every non-ESP family treats pin 8 as a normal digital.
-#if defined(FL_IS_ESP_32) && !defined(FL_IS_ESP_32S2) && \
-    !defined(FL_IS_ESP_32S3) && !defined(FL_IS_ESP_32C2) && \
-    !defined(FL_IS_ESP_32C3) && !defined(FL_IS_ESP_32C5) && \
-    !defined(FL_IS_ESP_32C6) && !defined(FL_IS_ESP_32H2) && \
-    !defined(FL_IS_ESP_32P4)
+// GPIO6/7/8 on the classic ESP32 (esp32dev / WROOM modules) are
+// reserved for SPI flash (SD2/SD3/CMD/CLK/SD0/SD1 — pins 6-11) and
+// FastLED's `FASTLED_UNUSABLE_PIN_MASK` for esp32dev marks pins
+// {6, 7, 8, 9, 10, 11, 20} as `validpin() == false`. Instantiating any
+// clockless driver bound to those pins fails the FastLED static_assert
+// at compile time. Other ESP32 variants (S2/S3/C-series, P4) repurpose
+// GPIO6-8 and accept them as valid output pins, and every non-ESP
+// family treats them as normal digital pins. The classic-ESP32
+// sentinel is `FL_IS_ESP_32DEV` (defined in `src/platforms/esp/is_esp.h`);
+// the prior #3447 attempt used `FL_IS_ESP_32` which is not a real macro,
+// so the gate never fired and esp32dev compile still hit the
+// static_assert. LegacyClocklessProxy iterates pins 0-8 so all three
+// of 6/7/8 must be excluded for the classic ESP32 build.
+#if defined(FL_IS_ESP_32DEV)
+#define AUTORESEARCH_LEGACY_SUPPORTS_PIN_6 0
+#define AUTORESEARCH_LEGACY_SUPPORTS_PIN_7 0
 #define AUTORESEARCH_LEGACY_SUPPORTS_PIN_8 0
 #else
+#define AUTORESEARCH_LEGACY_SUPPORTS_PIN_6 1
+#define AUTORESEARCH_LEGACY_SUPPORTS_PIN_7 1
 #define AUTORESEARCH_LEGACY_SUPPORTS_PIN_8 1
 #endif
 
@@ -113,8 +120,12 @@ public:
             case 3: mController = create<3>(leds, numLeds, chipset, rgbw); break;
             case 4: mController = create<4>(leds, numLeds, chipset, rgbw); break;
             case 5: mController = create<5>(leds, numLeds, chipset, rgbw); break;
+#if AUTORESEARCH_LEGACY_SUPPORTS_PIN_6
             case 6: mController = create<6>(leds, numLeds, chipset, rgbw); break;
+#endif
+#if AUTORESEARCH_LEGACY_SUPPORTS_PIN_7
             case 7: mController = create<7>(leds, numLeds, chipset, rgbw); break;
+#endif
 #if AUTORESEARCH_LEGACY_SUPPORTS_PIN_8
             case 8: mController = create<8>(leds, numLeds, chipset, rgbw); break;
 #endif


### PR DESCRIPTION
## Summary

Follow-up to #3447. The pin-8 gate in that PR had two bugs:

1. `FL_IS_ESP_32` is not a real macro. The actual classic-ESP32 sentinel is `FL_IS_ESP_32DEV` (see `src/platforms/esp/is_esp.h:68`). The gate never fired — esp32dev compile still hit `_ESPPIN<8, 256, false>::validpin() == false`.
2. Even with the right macro, only gating pin 8 isn't enough — classic ESP32's `FASTLED_UNUSABLE_PIN_MASK` covers pins `{6, 7, 8, 9, 10, 11, 20}` (SPI flash SD0/SD1/SD2/SD3/CMD/CLK pads + GPIO20). `LegacyClocklessProxy` iterates pins 0-8 so the SK6812/WS2812B instantiations on pins 6 and 7 were still failing the static_assert.

## Fix

Introduce three macros — `AUTORESEARCH_LEGACY_SUPPORTS_PIN_{6,7,8}` — each gated by `defined(FL_IS_ESP_32DEV)`. Classic ESP32 builds skip those three cases; every other family (including ESP32-S2/S3/C/H/P, Teensy, AVR, ARM, RP2040) keeps them.

## Verification

```
bash compile esp32dev --examples AutoResearch --no-filter
→ SUCCESS: AutoResearch (01m:35s)
```

Previously failed with `error: static assertion failed: This pin has been marked as an invalid pin` for pins 6, 7, and 8 in sequence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
