### PR TITLE
feat(channels): add LPC DefaultBus<> specializations (#3450 B4)

### DIFF
--- a/src/fl/channels/bus.h
+++ b/src/fl/channels/bus.h
@@ -79,6 +79,27 @@ template<> struct DefaultBus<SpiChipsetConfig> {
     static constexpr Bus value = Bus::FLEX_IO;
 };
 
+#elif defined(FL_IS_ARM_LPC)
+
+// LPC8xx / LPC11Uxx / LPC15xx have no parallel-IO clockless peripheral.
+// Clockless output goes through the shared M0 cycle-counted C++ driver
+// (FASTLED_M0_USE_C_IMPLEMENTATION in led_sysdefs_arm_lpc.h), which is
+// what Bus::BIT_BANG names — the same engine that LPC's
+// ClocklessController template uses today.
+template<> struct DefaultBus<ClocklessChipset> {
+    static constexpr Bus value = Bus::BIT_BANG;
+};
+
+// LPC845 / LPC804 have a hardware SPI driver (spi_arm_lpc.h, UM11029).
+// LPC11xx / LPC15xx do not yet ship one (#2845 Stage 4) — they fall
+// through to the unspecialized DefaultBus, which is intentional: a
+// link error there is the right signal that no SPI driver is wired.
+#if defined(FL_IS_ARM_LPC_845) || defined(FL_IS_ARM_LPC_804)
+template<> struct DefaultBus<SpiChipsetConfig> {
+    static constexpr Bus value = Bus::SPI;
+};
+#endif
+
 #endif
 
 template<Bus B> struct BusInstanceCount {


### PR DESCRIPTION
## Summary

Adds LPC `DefaultBus<>` specializations in `src/fl/channels/bus.h`. Resolves blocker **B4** from the #3450 meta — the in-fastled3 piece of the LPC compile + autoresearch + channels-API restoration.

- `DefaultBus<ClocklessChipset>` → `Bus::BIT_BANG` for the whole LPC family (`FL_IS_ARM_LPC`). LPC8xx / LPC11Uxx / LPC15xx have no parallel-IO clockless peripheral; clockless output already routes through the shared M0 cycle-counted C++ driver (`FASTLED_M0_USE_C_IMPLEMENTATION` in `src/platforms/arm/lpc/led_sysdefs_arm_lpc.h`), which is exactly what `Bus::BIT_BANG` names. Plugging the trait is a no-op at the hardware level — it just stops the channels-API selector from hitting the unspecialized primary template.
- `DefaultBus<SpiChipsetConfig>` → `Bus::SPI` for LPC845 / LPC804 only. Those chips ship the hardware SPI driver in `src/platforms/arm/lpc/spi_arm_lpc.h` (UM11029 SPI peripheral block, `SPI0 @ 0x40058000`, `SPI1 @ 0x4005C000` on LPC845). LPC11xx / LPC15xx have separate SPI register layouts (#2845 Stage 4) and intentionally fall through to the unspecialized primary — a link error there is the right signal that no SPI driver is wired.

## Scope of #3450 covered

This is B4. The other three blockers from the meta are cross-repo and tracked separately:
- **B1** — fbuild matcher rejected hyphenated `nxp-lpc` GitHub URL form: FastLED/fbuild#900 (open).
- **B2** — `framework-arduino-lpc8xx` tarball checksum mismatch from the 2026-06-28 org transfer: needs an upstream re-record alongside the next fbuild release.
- **B3** — Editable `pip install -e ~/dev/fbuild` on Windows fails because rust-toolchain.toml's host-unspecified 1.94.1 pin selects `windows-gnu` and rust-lld can't find `-lcfgmgr32`: fbuild-side fix.

#3450 stays open until B1–B3 and the #3300 hardware bring-up also flip.

## Test plan

- [x] `bash lint` — clean (Python, C++ via fastled-lint, JS, meson, root-pio lockdown, size thresholds — all green)
- [x] `bash test --cpp` — 340/340 passed in 77.9s
- [ ] LPC hardware compile (`bash compile lpc845brk --examples Blink`) — gated on B1/B2 landing per the meta; cannot validate end-to-end on this machine until fbuild 2.3.15 ships

Closes #3450 (B4 acceptance box only — meta stays open for the remaining blockers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved automatic bus selection on supported LPC platforms.
  * Clockless chipsets now use bit-banged communication by default on LPC targets.
  * SPI chipsets now default to SPI on LPC 845 and LPC 804 devices.

* **Bug Fixes**
  * Reduced the need for manual bus configuration on these platform variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->