### PR TITLE
fix(autoresearch): use GPIO18/19 as default TX/RX on classic ESP32 (#3452)

### DIFF
--- a/examples/AutoResearch/AutoResearch.ino
+++ b/examples/AutoResearch/AutoResearch.ino
@@ -506,56 +506,11 @@ void loop() {
     // feeds on construction (now) and again on destruction (end of scope).
     FL_WATCHDOG_AUTO(AUTORESEARCH_WATCHDOG_TIMEOUT_MS);
 
-    // autoresearch-runtime-output-lint: begin
-    // FastLED #3452 diagnostic: PROOF-OF-LIFE heartbeat. Prints
-    // unconditionally on the first iteration and then once per second
-    // with the live `fl::available()` count. Goes through BOTH the
-    // fl::println path AND a raw Serial.print so we can tell whether
-    // the FastLED IO singleton is wedged or the underlying UART is.
-    // Non-destructive — never consumes a byte. Remove once root-caused.
-    static uint32_t s_loopIter = 0;
-    static uint32_t s_lastHeartbeat = 0;
-    s_loopIter++;
-    uint32_t now_ms = millis();
-    bool emit_now = (s_loopIter == 1) || (now_ms - s_lastHeartbeat >= 1000);
-    if (emit_now) {
-        s_lastHeartbeat = now_ms;
-        // Path A: through fl::println (uses FastLED's UART driver)
-        fl::sstream dbg;
-        dbg << "[#3452] loop_alive iter=" << s_loopIter
-            << " ms=" << now_ms
-            << " avail=" << fl::available();
-        fl::println(dbg.str().c_str());  // ok autoresearch rpc serial - issue #3452 diagnostic, removed after root-cause
-        // Path B: through raw Arduino Serial.print (bypasses fl::print)
-        Serial.print("[#3452:raw] iter=");  // ok autoresearch rpc serial - issue #3452 diagnostic
-        Serial.print(s_loopIter);  // ok autoresearch rpc serial - issue #3452 diagnostic
-        Serial.print(" avail=");  // ok autoresearch rpc serial - issue #3452 diagnostic
-        Serial.println(Serial.available());  // ok autoresearch rpc serial - issue #3452 diagnostic
-    }
-    // autoresearch-runtime-output-lint: end
-
-    // autoresearch-runtime-output-lint: begin
-    // FastLED #3452 diagnostic: bracket the task-run pump so we can tell
-    // whether it returns. If we see "before iter=N" but no "after iter=N",
-    // one of the tasks is blocking forever.
-    if (s_loopIter <= 3) {
-        Serial.print("[#3452:raw] before for(100) iter=");  // ok autoresearch rpc serial - issue #3452 diagnostic
-        Serial.println(s_loopIter);                          // ok autoresearch rpc serial - issue #3452 diagnostic
-    }
-    // autoresearch-runtime-output-lint: end
-
     // Aggressively pump async tasks (including JSON-RPC task)
     // This ensures RPC commands are processed frequently even without delay() calls
     for (int i = 0; i < 100; i++) {
         fl::task::run();
     }
-
-    // autoresearch-runtime-output-lint: begin
-    if (s_loopIter <= 3) {
-        Serial.print("[#3452:raw] after for(100) iter=");  // ok autoresearch rpc serial - issue #3452 diagnostic
-        Serial.println(s_loopIter);                         // ok autoresearch rpc serial - issue #3452 diagnostic
-    }
-    // autoresearch-runtime-output-lint: end
 
     // ========================================================================
     // Watchdog autoresearch trigger (FastLED#2731) — when the host RPC sends
@@ -587,7 +542,7 @@ void loop() {
 
     // Run GPIO baseline test once after device is ready (allows JSON-RPC to be operational first)
     // This test is informational only - we continue regardless of pass/fail
-    if (!g_autoresearch_state->gpio_baseline_test_done) {
+    if (!g_autoresearch_state->gpio_baseline_test_done && g_autoresearch_state->rx_channel) {
         // Wait 500ms after boot to ensure JSON-RPC is fully operational
         if (millis() > 500) {
             g_autoresearch_state->gpio_baseline_test_done = true;

--- a/examples/AutoResearch/AutoResearch.ino
+++ b/examples/AutoResearch/AutoResearch.ino
@@ -534,11 +534,28 @@ void loop() {
     }
     // autoresearch-runtime-output-lint: end
 
+    // autoresearch-runtime-output-lint: begin
+    // FastLED #3452 diagnostic: bracket the task-run pump so we can tell
+    // whether it returns. If we see "before iter=N" but no "after iter=N",
+    // one of the tasks is blocking forever.
+    if (s_loopIter <= 3) {
+        Serial.print("[#3452:raw] before for(100) iter=");  // ok autoresearch rpc serial - issue #3452 diagnostic
+        Serial.println(s_loopIter);                          // ok autoresearch rpc serial - issue #3452 diagnostic
+    }
+    // autoresearch-runtime-output-lint: end
+
     // Aggressively pump async tasks (including JSON-RPC task)
     // This ensures RPC commands are processed frequently even without delay() calls
     for (int i = 0; i < 100; i++) {
         fl::task::run();
     }
+
+    // autoresearch-runtime-output-lint: begin
+    if (s_loopIter <= 3) {
+        Serial.print("[#3452:raw] after for(100) iter=");  // ok autoresearch rpc serial - issue #3452 diagnostic
+        Serial.println(s_loopIter);                         // ok autoresearch rpc serial - issue #3452 diagnostic
+    }
+    // autoresearch-runtime-output-lint: end
 
     // ========================================================================
     // Watchdog autoresearch trigger (FastLED#2731) — when the host RPC sends

--- a/examples/AutoResearch/AutoResearch.ino
+++ b/examples/AutoResearch/AutoResearch.ino
@@ -506,6 +506,34 @@ void loop() {
     // feeds on construction (now) and again on destruction (end of scope).
     FL_WATCHDOG_AUTO(AUTORESEARCH_WATCHDOG_TIMEOUT_MS);
 
+    // autoresearch-runtime-output-lint: begin
+    // FastLED #3452 diagnostic: PROOF-OF-LIFE heartbeat. Prints
+    // unconditionally on the first iteration and then once per second
+    // with the live `fl::available()` count. Goes through BOTH the
+    // fl::println path AND a raw Serial.print so we can tell whether
+    // the FastLED IO singleton is wedged or the underlying UART is.
+    // Non-destructive — never consumes a byte. Remove once root-caused.
+    static uint32_t s_loopIter = 0;
+    static uint32_t s_lastHeartbeat = 0;
+    s_loopIter++;
+    uint32_t now_ms = millis();
+    bool emit_now = (s_loopIter == 1) || (now_ms - s_lastHeartbeat >= 1000);
+    if (emit_now) {
+        s_lastHeartbeat = now_ms;
+        // Path A: through fl::println (uses FastLED's UART driver)
+        fl::sstream dbg;
+        dbg << "[#3452] loop_alive iter=" << s_loopIter
+            << " ms=" << now_ms
+            << " avail=" << fl::available();
+        fl::println(dbg.str().c_str());  // ok autoresearch rpc serial - issue #3452 diagnostic, removed after root-cause
+        // Path B: through raw Arduino Serial.print (bypasses fl::print)
+        Serial.print("[#3452:raw] iter=");  // ok autoresearch rpc serial - issue #3452 diagnostic
+        Serial.print(s_loopIter);  // ok autoresearch rpc serial - issue #3452 diagnostic
+        Serial.print(" avail=");  // ok autoresearch rpc serial - issue #3452 diagnostic
+        Serial.println(Serial.available());  // ok autoresearch rpc serial - issue #3452 diagnostic
+    }
+    // autoresearch-runtime-output-lint: end
+
     // Aggressively pump async tasks (including JSON-RPC task)
     // This ensures RPC commands are processed frequently even without delay() calls
     for (int i = 0; i < 100; i++) {

--- a/examples/AutoResearch/AutoResearchPlatform.h
+++ b/examples/AutoResearch/AutoResearchPlatform.h
@@ -9,6 +9,12 @@
 namespace autoresearch {
 
 // Default TX pin for each platform
+//
+// NOTE: Avoid GPIO0/1/3 on classic ESP32 — GPIO1 is UART0 TX (console output),
+// GPIO3 is UART0 RX, and GPIO0 is a boot-strap pin. Toggling GPIO1 from
+// AutoResearch's GPIO baseline test (testRxChannel) silences the console and
+// causes FastLED #3452 (RPC silence). Use GPIO 18/19 which are general-purpose
+// and don't collide with peripheral fixed-function muxing on the WROOM module.
 constexpr int defaultTxPin() {
 #if defined(FL_IS_STUB)
     return 1;  // Stub: TX and RX same pin — NativeRxDevice monitors TX output directly
@@ -24,12 +30,17 @@ constexpr int defaultTxPin() {
     return 5;  // ESP32-P4: Connect GPIO 5 (TX) to GPIO 6 (RX) with jumper wire
 #elif defined(FL_IS_TEENSY_4X)
     return 1;  // Teensy 4.x: any GPIO works for TX
+#elif defined(FL_IS_ESP_32DEV)
+    return 18;  // ESP32 (classic): avoid GPIO0/1/3 (boot strap + UART0). See #3452.
 #else
-    return 1;  // ESP32 (classic) and other variants
+    return 1;  // Other variants
 #endif
 }
 
 // Default RX pin for each platform
+//
+// NOTE: See defaultTxPin() above for the classic-ESP32 GPIO0/1/3 caveat — the
+// default RX pin must also avoid those. GPIO 19 is a safe partner for GPIO 18.
 constexpr int defaultRxPin() {
 #if defined(FL_IS_STUB)
     return 1;  // Stub: same pin as TX — internal loopback
@@ -45,8 +56,10 @@ constexpr int defaultRxPin() {
     return 6;  // ESP32-P4: jumper wire from GPIO 5
 #elif defined(FL_IS_TEENSY_4X)
     return 2;  // Teensy 4.x: FlexPWM-capable pin, jumper wire from pin 1
+#elif defined(FL_IS_ESP_32DEV)
+    return 19;  // ESP32 (classic): partner pin to GPIO 18 above. See #3452.
 #else
-    return 0;  // ESP32 (classic) and other variants
+    return 0;  // Other variants
 #endif
 }
 


### PR DESCRIPTION
## Summary

Resolves **#3452** — \"RPC silence on classic ESP32-WROOM\".

The autoresearch sketch defaulted `PIN_TX=1` / `PIN_RX=0` on classic ESP32 (`FL_IS_ESP_32DEV` / `esp32dev`). **GPIO 1 is the UART0 TX pin** — the Arduino `Serial` console output that `bash autoresearch` reads via the USB-Serial bridge — and **GPIO 0 is a boot-strap pin**. The first loop() iteration calls `testRxChannel(rx_channel, PIN_TX, PIN_RX, ...)` which toggles `PIN_TX` as a digital output, instantly killing UART0. That's the \"device boots, emits ready, then goes silent\" symptom.

Switching the classic-ESP32 defaults to GPIO 18 / 19 — both general-purpose, not muxed to UART0, not on the boot-strap list — restores the console for the lifetime of the sketch. Other platform defaults are untouched.

Also adds a null guard around the GPIO baseline test so a future RX-channel creation failure cannot panic loop() with a nullptr deref.

Diagnostic heartbeat prints that lived briefly on `diag/3452-loop-heartbeat` are removed; the root cause is fixed, the bisection scaffolding isn't needed.

## Validation

Tested on the user's WROOM board (COM11). Pre-fix: device sends `RESULT: {... \"ready\":true ... \"pinTx\":1, \"pinRx\":0 ...}` and then UART0 stays silent forever. Post-fix:

```
RESULT: {\"chip\":\"ESP32 (Xtensa)\",\"type\":\"ready\",\"pinRx\":19,\"pinTx\":18,\"ready\":true,\"drivers\":5,...}
RESULT: {\"hz\":40000000,\"type\":\"gpioBaseline\",\"pinRx\":19,\"pinTx\":18,\"success\":false,...}
>>> ping
REMOTE: {\"id\":1,\"error\":{...},\"jsonrpc\":\"2.0\"}     ← RPC alive
RESULT: {\"type\":\"status\",\"ready\":true,\"uptimeMs\":5040}    ← loop running
RESULT: {\"type\":\"status\",\"ready\":true,\"uptimeMs\":10041}
```

## Test plan

- [x] WROOM board on COM11 boots and serves RPC continuously
- [ ] `bash autoresearch` end-to-end on classic ESP32 (next PR — separate handler issue tracked locally)
- [ ] Other ESP32 variants (S3, C3, S2, C6, P4) and Teensy 4.x defaults verified not regressed (no behavior change there — only the classic-ESP32 `#else` branch moved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup reliability by avoiding a GPIO baseline test when no receive channel is available.
  * Updated default UART pin selection on classic ESP32 boards to safer pins, reducing conflicts with boot and console behavior.
* **Documentation**
  * Added clearer guidance about avoiding certain GPIO pins on classic ESP32 devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->