### PR TITLE
chore(deps): bump fbuild pin to 2.3.15

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,7 +136,7 @@ dependencies = [
     # primitive (FastLED/fbuild#532, #577/#580), and an
     # http-connect-timeout fix on the managed-zccache client
     # (FastLED/fbuild#573).
-    "fbuild==2.3.14",
+    "fbuild==2.3.15",
     "platformio>=6.1.19,<6.2",
     "python-dateutil",
     "ruff",


### PR DESCRIPTION
## Summary

The pin comment in pyproject.toml already documented the 2.3.15 release (FastLED/fbuild#875, #885, #890 — Windows compile env hardening + spec-file backslash fix) but the specifier was still on 2.3.14. fbuild 2.3.15 is published on PyPI; sync the actual pin.

## Test plan

- [x] uv lock resolves cleanly to fbuild 2.3.15 (verified locally)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a project dependency to the latest patch version for improved maintenance and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->