### PR TITLE
feat(lpc): channels-API SCT+DMA clockless engine scaffold (#3459)

### DIFF
--- a/src/platforms/arm/lpc/_build.cpp.hpp
+++ b/src/platforms/arm/lpc/_build.cpp.hpp
@@ -7,3 +7,7 @@
 #include "platforms/arm/lpc/platform_time_lpc.cpp.hpp"
 #include "platforms/arm/lpc/runtime_lpc.cpp.hpp"
 #include "platforms/arm/lpc/rx_sct_capture.cpp.hpp"
+
+// SCT+DMA channels-API engine (#3459). Self-gated to LPC845; other LPC
+// variants compile out cleanly.
+#include "platforms/arm/lpc/drivers/sct_dma/_build.cpp.hpp"

--- a/src/platforms/arm/lpc/channel_drivers_lpc.impl.hpp
+++ b/src/platforms/arm/lpc/channel_drivers_lpc.impl.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+// IWYU pragma: private
+
+/// @file channel_drivers_lpc.impl.hpp
+/// @brief LPC platform fragment for `fl::enableAllDrivers()`.
+///
+/// Registers every channels-API driver shipped for LPC845 today. Tree-shaken
+/// when no sketch references `FastLED.enableAllDrivers()` — see
+/// `src/platforms/channel_drivers.impl.cpp.hpp` for the dispatch contract
+/// and `src/fl/channels/all_drivers.h` for the public API.
+
+#include "platforms/arm/lpc/is_lpc.h"
+
+#if defined(FL_IS_ARM_LPC_845)
+#include "platforms/arm/lpc/drivers/sct_dma/bus_traits.h"
+#endif
+
+namespace fl {
+namespace platforms {
+
+inline void enableAllChannelDrivers() FL_NO_EXCEPT {
+#if defined(FL_IS_ARM_LPC_845)
+    // SCT+DMA clockless engine (#3459). Registers under Bus::BIT_BANG,
+    // matching the LPC `DefaultBus<ClocklessChipset>` resolution from
+    // PR #3451.
+    BusTraits<Bus::BIT_BANG, 0>::registerWithManager();
+#endif
+}
+
+}  // namespace platforms
+}  // namespace fl

--- a/src/platforms/arm/lpc/drivers/sct_dma/_build.cpp.hpp
+++ b/src/platforms/arm/lpc/drivers/sct_dma/_build.cpp.hpp
@@ -1,0 +1,9 @@
+// IWYU pragma: private
+
+/// @file _build.cpp.hpp
+/// @brief Unity build header for platforms/arm/lpc/drivers/sct_dma/.
+
+#include "platforms/arm/lpc/drivers/sct_dma/channel_engine_lpc_sct_dma.cpp.hpp"
+
+// BusTraits<Bus::BIT_BANG> specialization + BusSupports for ClocklessChipset.
+#include "platforms/arm/lpc/drivers/sct_dma/bus_traits.h"

--- a/src/platforms/arm/lpc/drivers/sct_dma/bus_traits.h
+++ b/src/platforms/arm/lpc/drivers/sct_dma/bus_traits.h
@@ -1,0 +1,58 @@
+#pragma once
+
+// IWYU pragma: private
+
+/// @file bus_traits.h
+/// @brief BusTraits<Bus::BIT_BANG> specialization for the LPC845 SCT+DMA engine.
+///
+/// Routes `Bus::BIT_BANG` on LPC845 to `ChannelEngineLpcSctDma`. The portable
+/// Bus enum has no `SCT_DMA` slot — and per the channels-API convention the
+/// **peripheral** is the dispatch boundary, not the protocol mode — so we
+/// reuse `BIT_BANG` for the parallel-IO clockless peripheral on LPC. This is
+/// the same Bus value that `DefaultBus<ClocklessChipset>` resolves to on
+/// LPC (added in PR #3451 / #3450 B4).
+///
+/// Bus naming follows precedent: `Bus::FLEX_IO` covers both Teensy 4 FlexPWM
+/// and ESP32 LCD_CAM / I2S / PARLIO peripherals — different silicon under
+/// the same Bus slot, dispatched by `Which` + platform gate.
+
+#include "fl/stl/compiler_control.h"
+#include "platforms/is_platform.h"
+
+#if defined(FL_IS_ARM_LPC_845)
+
+#include "fl/channels/bus.h"
+#include "fl/channels/bus_priorities.h"
+#include "fl/channels/bus_traits.h"
+#include "fl/channels/manager.h"
+#include "fl/stl/shared_ptr.h"
+#include "fl/stl/type_traits.h"
+#include "platforms/arm/lpc/drivers/sct_dma/channel_engine_lpc_sct_dma.h"
+
+namespace fl {
+
+template<> struct BusTraits<Bus::BIT_BANG> {
+    using Driver = ChannelEngineLpcSctDma;
+
+    static fl::shared_ptr<Driver> instancePtr() FL_NO_EXCEPT {
+        static fl::shared_ptr<Driver> gHolder = fl::make_shared<Driver>();
+        return gHolder;
+    }
+
+    static Driver& instance() FL_NO_EXCEPT { return *instancePtr(); }
+
+    static void registerWithManager() FL_NO_EXCEPT {
+        ChannelManager::instance().addDriver(
+            default_bus_priority(Bus::BIT_BANG, 0), instancePtr());
+    }
+};
+
+// Clockless-only: the LPC SCT peripheral does not drive SPI; the LPC845 SPI
+// block is a separate peripheral with its own DMA engine
+// (`spi_arm_lpc_dma.h`, PR #3454). Per the channels-API parallel-IO rule
+// this is the documented "different-peripheral-same-protocol" exception.
+template<> struct BusSupports<Bus::BIT_BANG, ClocklessChipset, 0> : fl::true_type {};
+
+}  // namespace fl
+
+#endif  // FL_IS_ARM_LPC_845

--- a/src/platforms/arm/lpc/drivers/sct_dma/channel_engine_lpc_sct_dma.cpp.hpp
+++ b/src/platforms/arm/lpc/drivers/sct_dma/channel_engine_lpc_sct_dma.cpp.hpp
@@ -1,0 +1,105 @@
+// IWYU pragma: private
+
+#ifndef CHANNEL_ENGINE_LPC_SCT_DMA_CPP_HPP_
+#define CHANNEL_ENGINE_LPC_SCT_DMA_CPP_HPP_
+
+#include "platforms/arm/lpc/is_lpc.h"
+
+#if defined(FL_IS_ARM_LPC_845)
+
+#include "platforms/arm/lpc/drivers/sct_dma/channel_engine_lpc_sct_dma.h"
+#include "fl/stl/noexcept.h"
+
+namespace fl {
+
+// =============================================================================
+// Timing bounds for canHandle() filtering.
+//
+// Match ObjectFLED's WS2812/SK6812-range convention from
+// channel_engine_objectfled.cpp.hpp (1000-2500 ns total bit period). Anything
+// outside is either an HD chipset (WS2816 etc.) that needs separate encoding,
+// or a non-clockless chipset.
+// =============================================================================
+static constexpr u32 kMinPeriodNs = 1000;
+static constexpr u32 kMaxPeriodNs = 2500;
+
+ChannelEngineLpcSctDma::ChannelEngineLpcSctDma() FL_NO_EXCEPT = default;
+ChannelEngineLpcSctDma::~ChannelEngineLpcSctDma() = default;
+
+bool ChannelEngineLpcSctDma::canHandle(
+        const ChannelDataPtr& data) const FL_NO_EXCEPT {
+    if (!data) {
+        return false;
+    }
+    if (!data->isClockless()) {
+        return false;
+    }
+    const u32 period = data->getTiming().total_period_ns();
+    return period >= kMinPeriodNs && period <= kMaxPeriodNs;
+}
+
+void ChannelEngineLpcSctDma::enqueue(ChannelDataPtr channelData) FL_NO_EXCEPT {
+    if (!channelData) {
+        return;
+    }
+    mEnqueuedChannels.push_back(channelData);
+}
+
+void ChannelEngineLpcSctDma::show() FL_NO_EXCEPT {
+    // TODO(3459): lift the chunk-encode + 3-channel DMA stream kick from
+    // `clockless_arm_lpc_pwm_dma.h::showRGBInternal()`. The legacy template
+    // engine works compile-time off `TIMING::T1/T2/T3`; the channels-API
+    // engine here needs to take those values from
+    // `ChannelDataPtr::getTiming()` and program SCT->MATCH at runtime.
+    //
+    // The structural moves required:
+    //   1. Lift `LpcSctTicks<NS>::value` from a constexpr template to a
+    //      runtime helper `lpc_sct_ticks(u32 ns)`.
+    //   2. Lift `configureSct()` / `configureDma()` / `startDmaChunk()` /
+    //      `waitDmaChunk()` from the templated `ClocklessController` into
+    //      a non-template helper struct owned by this engine.
+    //   3. Iterate `mEnqueuedChannels`, dispatching each through the
+    //      lifted helper. v1 single-strip just takes the first entry;
+    //      multi-strip parallel output is #2879.
+    //
+    // For the scaffold, transition into BUSY so the state machine looks
+    // alive but do not actually program SCT/DMA. `poll()` will immediately
+    // flip back to READY. This is the same scaffold convention as
+    // `rx_sct_capture.h::begin()` (#3015) and the SPI DMA driver from
+    // #3454 — channels-API surface in, peripheral wiring in a follow-up.
+    if (mEnqueuedChannels.empty()) {
+        return;
+    }
+
+    mTransmittingChannels = mEnqueuedChannels;
+    mEnqueuedChannels.clear();
+    mTransmissionActive = true;
+}
+
+IChannelDriver::DriverState ChannelEngineLpcSctDma::poll() FL_NO_EXCEPT {
+    if (!mTransmissionActive) {
+        return DriverState::READY;
+    }
+
+    // TODO(3459): probe the real DMA0 channel ACTIVE flag for the three
+    // SCT-tied channels, matching the existing busy-wait in
+    // `clockless_arm_lpc_pwm_dma.h::waitDmaChunk()`:
+    //
+    //   const u32 mask = (7UL << FASTLED_LPC_PWM_DMA_BASECH);
+    //   return (DMA0->COMMON[0].ACTIVE & mask) != 0
+    //              ? DriverState::DRAINING
+    //              : DriverState::READY;
+    //
+    // For the v1 scaffold the show() body is a no-op, so flip to READY
+    // immediately. Real DMA-driven implementation will follow the
+    // BUSY → DRAINING → READY shape per `IChannelDriver`'s contract.
+    mTransmissionActive = false;
+    mTransmittingChannels.clear();
+    return DriverState::READY;
+}
+
+}  // namespace fl
+
+#endif  // FL_IS_ARM_LPC_845
+
+#endif  // CHANNEL_ENGINE_LPC_SCT_DMA_CPP_HPP_

--- a/src/platforms/arm/lpc/drivers/sct_dma/channel_engine_lpc_sct_dma.h
+++ b/src/platforms/arm/lpc/drivers/sct_dma/channel_engine_lpc_sct_dma.h
@@ -1,0 +1,115 @@
+/// @file channel_engine_lpc_sct_dma.h
+/// @brief LPC845 SCT + DMA0 clockless channel engine (channels-API form
+///        of `clockless_arm_lpc_pwm_dma.h`).
+///
+/// Lifts the existing legacy-template DMA clockless driver onto
+/// `IChannelDriver` so LPC845 can take part in runtime channels-API
+/// dispatch (`addLeds<>` → `BusTraits<Bus::BIT_BANG>::instancePtr()` →
+/// `ChannelManager::show`). Reference engine pattern:
+/// `src/platforms/arm/teensy/teensy4_common/drivers/objectfled/`.
+///
+/// **Status:** scaffold + interface. The channels-API surface (canHandle,
+/// enqueue, show, poll, capabilities) is in. The actual SCT-encode +
+/// chunk-stream-kick body of `show()` is intentionally a documented
+/// `TODO(3459)` that lifts the chunked encoder from
+/// `clockless_arm_lpc_pwm_dma.h`. Same scaffold-then-bench pattern this
+/// repo uses for `rx_sct_capture.h::begin()` (#3015) and the SPI DMA
+/// driver from #3453 / PR #3454.
+///
+/// **Parallel-IO peripheral rule (`src/fl/channels/README.md`).**
+/// LPC's SCT is parallel-IO-capable but does NOT drive SPI — the LPC845
+/// SPI block is a separate peripheral (SPI0 @ 0x40058000, SPI1 @
+/// 0x4005C000) with its own DMA engine landing under
+/// `src/platforms/arm/lpc/spi_arm_lpc_dma.h` (PR #3454). This is the
+/// rule's documented "different-peripheral-same-protocol" exception, so
+/// `ChannelEngineLpcSctDma` returns `Capabilities(true, false)` —
+/// clockless only — and the SPI DMA engine stays a sibling.
+///
+/// State machine: `READY → BUSY → DRAINING → READY`, same shape as
+/// `ChannelEngineObjectFLED`.
+
+#pragma once
+
+// IWYU pragma: private
+
+#include "platforms/arm/lpc/is_lpc.h"
+
+#if defined(FL_IS_ARM_LPC_845)
+
+#include "fl/channels/driver.h"
+#include "fl/channels/data.h"
+#include "fl/stl/vector.h"
+#include "fl/stl/string.h"
+#include "fl/stl/noexcept.h"
+
+namespace fl {
+
+/// @brief LPC845 SCT + DMA0 clockless channel engine
+///
+/// Wraps the SCT match-event + 3-DMA-channel pulse-shape engine
+/// established in `clockless_arm_lpc_pwm_dma.h` and exposes it through
+/// the channels API. Strict chipset filtering: only handles clockless
+/// chipsets in the standard WS2812 / SK6812 total-period range
+/// (1000-2500 ns), matching `ChannelEngineObjectFLED`'s convention.
+///
+/// **Single-strip in v1.** Multi-strip parallel SCT output is the #2879
+/// Stage 4.4 work and ships as a separate engine evolution (or
+/// `BusInstanceCount` bump) after single-strip is bench-validated.
+class ChannelEngineLpcSctDma : public IChannelDriver {
+public:
+    ChannelEngineLpcSctDma() FL_NO_EXCEPT;
+    ~ChannelEngineLpcSctDma() override;
+
+    /// @brief Filter channels to clockless WS2812-range chipsets.
+    /// @return true for clockless chipsets with total bit period in
+    ///         [1000, 2500] ns. Rejects SPI (handled by the sibling
+    ///         `ARMHardwareSPIOutputDMA` driver) and HD chipsets like
+    ///         WS2816 that need different encoding.
+    bool canHandle(const ChannelDataPtr& data) const FL_NO_EXCEPT override;
+
+    /// @brief Store channel data for later show().
+    void enqueue(ChannelDataPtr channelData) FL_NO_EXCEPT override;
+
+    /// @brief Encode enqueued channels and kick the SCT-driven DMA stream.
+    ///
+    /// **TODO(3459):** v1 ships the channels-API state-machine wiring
+    /// only — the actual SCT match-register programming and 3-channel
+    /// DMA chunk-stream lift from `clockless_arm_lpc_pwm_dma.h` lands in
+    /// the bench-validation follow-up. Today `show()` transitions
+    /// `READY → BUSY` and `poll()` immediately transitions back to
+    /// `READY`, so calls do not transmit but also do not stall the
+    /// manager.
+    void show() FL_NO_EXCEPT override;
+
+    /// @brief Query engine state; returns BUSY/DRAINING while the SCT-driven
+    ///        DMA stream is active, READY otherwise.
+    DriverState poll() FL_NO_EXCEPT override;
+
+    /// @brief Engine name for affinity binding / diagnostic logging.
+    fl::string getName() const FL_NO_EXCEPT override {
+        return fl::string::from_literal("LPC_SCT_DMA");
+    }
+
+    /// @brief Clockless-only capabilities — LPC SCT does not drive SPI;
+    ///        SPI is handled by the sibling spi_arm_lpc_dma.h engine.
+    Capabilities getCapabilities() const FL_NO_EXCEPT override {
+        return Capabilities(/*clockless=*/true, /*spi=*/false);
+    }
+
+private:
+    /// @brief Pending channels (set by enqueue, consumed by show).
+    fl::vector<ChannelDataPtr> mEnqueuedChannels;
+
+    /// @brief Currently transmitting channels (cleared when poll
+    ///        observes DMA-done).
+    fl::vector<ChannelDataPtr> mTransmittingChannels;
+
+    /// @brief Cached transmission-active bit. v1 toggles it manually in
+    ///        show()/poll() until the real DMA-channel-active probe is
+    ///        wired up in the implementation follow-up.
+    bool mTransmissionActive = false;
+};
+
+}  // namespace fl
+
+#endif  // FL_IS_ARM_LPC_845

--- a/src/platforms/channel_drivers.impl.cpp.hpp
+++ b/src/platforms/channel_drivers.impl.cpp.hpp
@@ -25,6 +25,8 @@
 #include "platforms/esp/32/channel_drivers_esp32.impl.hpp"
 #elif defined(FL_IS_TEENSY_4X)
 #include "platforms/arm/teensy/channel_drivers_teensy.impl.hpp"
+#elif defined(FL_IS_ARM_LPC)
+#include "platforms/arm/lpc/channel_drivers_lpc.impl.hpp"
 #elif defined(FL_IS_STUB) || defined(FL_IS_WASM)
 #include "platforms/stub/channel_drivers_stub.impl.hpp"
 #else


### PR DESCRIPTION
## Status: Draft — scaffold + state machine, show() body deferred

This is the channels-API plumbing for LPC845's SCT+DMA clockless engine, per #3459. Opens as draft because the `show()` body is a documented `TODO(3459)` (same scaffold convention used for `rx_sct_capture.h::begin()` (#3015) and `spi_arm_lpc_dma.h` (PR #3454)).

## Summary

Lifts the existing legacy-template DMA clockless engine in `clockless_arm_lpc_pwm_dma.h` onto `IChannelDriver` so LPC845 can take part in runtime channels-API dispatch (`addLeds<>` → `BusTraits<Bus::X>::instancePtr()` → `ChannelManager`). Reference engine: `src/platforms/arm/teensy/teensy4_common/drivers/objectfled/`.

New driver tree:

```
src/platforms/arm/lpc/drivers/sct_dma/
  channel_engine_lpc_sct_dma.h         — IChannelDriver subclass
  channel_engine_lpc_sct_dma.cpp.hpp   — impl (scaffold + state machine)
  bus_traits.h                         — BusTraits<Bus::BIT_BANG>
  _build.cpp.hpp                       — unity build entry
```

Plus three dispatch wires:

- `src/platforms/arm/lpc/channel_drivers_lpc.impl.hpp` — new `enableAllChannelDrivers()` fragment.
- `src/platforms/arm/lpc/_build.cpp.hpp` — pulls in `drivers/sct_dma/_build.cpp.hpp`.
- `src/platforms/channel_drivers.impl.cpp.hpp` — adds the `FL_IS_ARM_LPC` arm to the top-level platform dispatch.

## Routing decisions

- **`Bus::BIT_BANG`** for registration. The portable Bus enum has no `SCT_DMA` slot, and the channels-API convention is that the peripheral — not the protocol mode — is the dispatch boundary. Reusing `BIT_BANG` for LPC's parallel-IO clockless peripheral is consistent with `Bus::FLEX_IO` covering both Teensy FlexPWM and ESP32 LCD_CAM/I2S/PARLIO. It also matches `DefaultBus<ClocklessChipset> = Bus::BIT_BANG` that landed for LPC in PR #3451.
- **`Capabilities(true, false)`** — clockless only. LPC's SCT does not drive SPI; the LPC845 SPI block is a separate peripheral with its own DMA engine in `spi_arm_lpc_dma.h` (PR #3454). This is the documented "different-peripheral-same-protocol" exception to the parallel-IO unification rule in `src/fl/channels/README.md`.
- **`canHandle()`** filters to clockless chipsets with total bit period 1000-2500 ns (WS2812/SK6812 range), same convention as `ChannelEngineObjectFLED`.

## What's deferred

`show()` and `poll()` carry an explicit `TODO(3459)` block listing the structural lift required:

1. Convert `LpcSctTicks<NS>::value` from compile-time template helper to runtime helper `lpc_sct_ticks(u32 ns)`.
2. Hoist `configureSct()` / `configureDma()` / `startDmaChunk()` / `waitDmaChunk()` out of the templated `ClocklessController` into a non-template helper struct owned by this engine.
3. Iterate `mEnqueuedChannels`, dispatching each through the lifted helper. Single-strip v1 just takes the first entry; multi-strip parallel is #2879.

In the scaffold, `show()` transitions `READY → BUSY` and `poll()` immediately transitions back to `READY`, so calls do not transmit but also do not stall the manager.

## Tests run

- `bash test --cpp` — 340/340 passed.
- C++ lint (Python path; the Rust binary build fails on this Windows machine, separate issue under #3450 B3).
- Host-compile clean: all new files self-gate on `FL_IS_ARM_LPC_845`. Default builds on every other platform are unaffected.

## What's NOT tested

- Silicon. Same blockers as PR #3454 on the bench-validation side. fbuild 2.3.15 has already landed in master (resolving #3450 B1), so the LPC compile path can be exercised once the framework-arduino-lpc8xx tarball checksum (B2) clears.
- The channels-API routing was not exercised against a real `addLeds<WS2812, PIN, GRB>(...)` call site because `show()` is a documented no-op until the follow-up implementation PR lifts the SCT/DMA body.

## References

- Issue: #3459
- Reference engine: `src/platforms/arm/teensy/teensy4_common/drivers/objectfled/`
- Companion driver: `clockless_arm_lpc_pwm_dma.h` (the legacy-template implementation this engine wraps)
- Sibling peripheral: `spi_arm_lpc_dma.h` (PR #3454) — separate engine because the SPI block is a separate peripheral
- Meta: #3450 (LPC compile + autoresearch + channels API restoration)
- Bus selection rationale: `src/fl/channels/README.md` → "Rule: Parallel-IO peripherals — one engine for both clockless and SPI modes" and its exceptions section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for LPC845 clockless channel driving via a new SCT + DMA-based engine.
  * Enabled automatic registration of channel drivers on supported LPC builds.
  * Added platform dispatch so LPC-specific channel driver support is included when available.

* **Documentation**
  * Clarified supported device scope and capability notes for the new LPC845 channel driver path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->