### PR TITLE
refactor(rmt4): extract IRMT4Peripheral lifecycle wrapper (#3458)

### DIFF
--- a/src/platforms/esp/32/drivers/rmt/rmt_4/README.md
+++ b/src/platforms/esp/32/drivers/rmt/rmt_4/README.md
@@ -11,6 +11,10 @@ This directory contains the **ChannelManager-based RMT4 driver** for ESP32 platf
 - ✅ **Direct hardware memory access** - High-performance pixel transmission
 - ✅ **Polling-based architecture** - Compatible with ChannelManager pattern
 - ✅ **Identical timing characteristics** - Drop-in replacement for legacy RMT4
+- ✅ **`IRMT4Peripheral` lifecycle wrapper** (#3458) - ESP-IDF API surface is
+   isolated behind a virtual interface mirroring `IUartPeripheral` /
+   `IRMT5Peripheral`. The ISR hot path stays inline IRAM and is **not**
+   virtualised (see `irmt4_peripheral.h` for the interface scope).
 
 ---
 

--- a/src/platforms/esp/32/drivers/rmt/rmt_4/_build.cpp.hpp
+++ b/src/platforms/esp/32/drivers/rmt/rmt_4/_build.cpp.hpp
@@ -5,6 +5,7 @@
 /// Includes all implementation files in alphabetical order
 
 #include "platforms/esp/32/drivers/rmt/rmt_4/channel_driver_rmt4.cpp.hpp"
+#include "platforms/esp/32/drivers/rmt/rmt_4/rmt4_peripheral_esp.cpp.hpp"
 
 // BusTraits<Bus::RMT> specialization (RMT4 path, mutually exclusive with RMT5).
 #include "platforms/esp/32/drivers/rmt/rmt_4/bus_traits.h"

--- a/src/platforms/esp/32/drivers/rmt/rmt_4/bus_traits.h
+++ b/src/platforms/esp/32/drivers/rmt/rmt_4/bus_traits.h
@@ -17,7 +17,8 @@
 #include "platforms/esp/32/feature_flags/enabled.h"
 #endif
 
-#if defined(FL_IS_ESP32) && FASTLED_ESP32_HAS_RMT && !FASTLED_ESP32_RMT5_ONLY_PLATFORM && !FASTLED_RMT5
+#if defined(FL_IS_ESP32) && FASTLED_ESP32_HAS_RMT &&                           \
+    !FASTLED_ESP32_RMT5_ONLY_PLATFORM && !FASTLED_RMT5
 
 #include "fl/channels/bus.h"
 #include "fl/channels/bus_priorities.h"
@@ -27,26 +28,43 @@
 #include "fl/stl/shared_ptr.h"
 #include "fl/stl/type_traits.h"
 #include "platforms/esp/32/drivers/rmt/rmt_4/channel_driver_rmt4.h"
+#include "platforms/esp/32/drivers/rmt/rmt_4/rmt4_peripheral_esp.h"
 
 namespace fl {
 
-template<> struct BusTraits<Bus::RMT> {
+namespace detail {
+/// @brief RMT4 singleton: peripheral + driver lifetimes paired (#3458).
+///
+/// Mirrors `UartBusHolder` — same shape so the channel-driver registry
+/// is uniform across ESP32 peripherals. The peripheral is owned by this
+/// holder; the engine holds a `shared_ptr` to it.
+struct Rmt4BusHolder {
+    fl::shared_ptr<Rmt4PeripheralESP> peripheral;
+    fl::shared_ptr<ChannelEngineRMT4> driver;
+    Rmt4BusHolder() FL_NO_EXCEPT
+        : peripheral(fl::make_shared<Rmt4PeripheralESP>()),
+          driver(ChannelEngineRMT4::create(peripheral)) {}
+};
+} // namespace detail
+
+template <> struct BusTraits<Bus::RMT> {
     using Driver = ChannelEngineRMT4;
 
     static fl::shared_ptr<Driver> instancePtr() FL_NO_EXCEPT {
-        static fl::shared_ptr<Driver> gHolder = ChannelEngineRMT4::create();
-        return gHolder;
+        static detail::Rmt4BusHolder gHolder;
+        return gHolder.driver;
     }
 
-    static Driver& instance() FL_NO_EXCEPT { return *instancePtr(); }
+    static Driver &instance() FL_NO_EXCEPT { return *instancePtr(); }
 
     static void registerWithManager() FL_NO_EXCEPT {
-        ChannelManager::instance().addDriver(default_bus_priority(Bus::RMT), instancePtr());
+        ChannelManager::instance().addDriver(default_bus_priority(Bus::RMT),
+                                             instancePtr());
     }
 };
 
-template<> struct BusSupports<Bus::RMT, ClocklessChipset> : fl::true_type {};
+template <> struct BusSupports<Bus::RMT, ClocklessChipset> : fl::true_type {};
 
-}  // namespace fl
+} // namespace fl
 
-#endif  // FL_IS_ESP32 && FASTLED_ESP32_HAS_RMT && RMT4 path
+#endif // FL_IS_ESP32 && FASTLED_ESP32_HAS_RMT && RMT4 path

--- a/src/platforms/esp/32/drivers/rmt/rmt_4/channel_driver_rmt4.cpp.hpp
+++ b/src/platforms/esp/32/drivers/rmt/rmt_4/channel_driver_rmt4.cpp.hpp
@@ -12,35 +12,45 @@
 // Skip entirely if platform has no RMT hardware (ESP32-C2)
 #if !FASTLED_ESP32_HAS_RMT
 // No RMT hardware available
-#elif defined(FL_IS_ESP_32C6) || defined(FL_IS_ESP_32C5) || \
+#elif defined(FL_IS_ESP_32C6) || defined(FL_IS_ESP_32C5) ||                    \
     defined(CONFIG_IDF_TARGET_ESP32P4) || defined(CONFIG_IDF_TARGET_ESP32H2)
 // Skip RMT4 implementation for RMT5-only chips
-#elif !FASTLED_RMT5  // Only compile for RMT4 (IDF 4.x)
+#elif !FASTLED_RMT5 // Only compile for RMT4 (IDF 4.x)
 
-#include "platforms/esp/32/drivers/rmt/rmt_4/channel_driver_rmt4.h"
 #include "fl/log/log.h"
-#include "fl/log/log.h"
+#include "fl/stl/move.h" // fl::move
 #include "fl/stl/noexcept.h"
+#include "platforms/esp/32/drivers/rmt/rmt_4/channel_driver_rmt4.h"
+#include "platforms/esp/32/drivers/rmt/rmt_4/rmt4_peripheral_esp.h"
 
 namespace fl {
 
 // ═══════════════════════════════════════════════════════════════════════════
-// Factory Method
+// Factory Methods
 // ═══════════════════════════════════════════════════════════════════════════
 
 ChannelEngineRMT4Ptr ChannelEngineRMT4::create() FL_NO_EXCEPT {
     return fl::make_shared<ChannelEngineRMT4Impl>();
 }
 
+ChannelEngineRMT4Ptr ChannelEngineRMT4::create(
+    fl::shared_ptr<detail::IRMT4Peripheral> peripheral) FL_NO_EXCEPT {
+    return fl::make_shared<ChannelEngineRMT4Impl>(fl::move(peripheral));
+}
+
 // ═══════════════════════════════════════════════════════════════════════════
-// Constructor
+// Constructors
 // ═══════════════════════════════════════════════════════════════════════════
 
 ChannelEngineRMT4Impl::ChannelEngineRMT4Impl() FL_NO_EXCEPT
-    : mRMT_intr_handle(nullptr)
-    , mRmtSpinlock(portMUX_INITIALIZER_UNLOCKED)
-    , mInitialized(false)
-{
+    : ChannelEngineRMT4Impl(fl::make_shared<Rmt4PeripheralESP>()) {}
+
+ChannelEngineRMT4Impl::ChannelEngineRMT4Impl(
+    fl::shared_ptr<detail::IRMT4Peripheral> peripheral) FL_NO_EXCEPT
+    : mPeripheral(fl::move(peripheral)),
+      mRMT_intr_handle(nullptr),
+      mRmtSpinlock(portMUX_INITIALIZER_UNLOCKED),
+      mInitialized(false) {
     FL_WARN_F("ChannelEngineRMT4: Initializing RMT4 driver for IDF 4.x");
 
     // Reserve space for channels (inlined vector, no heap allocation)
@@ -48,18 +58,16 @@ ChannelEngineRMT4Impl::ChannelEngineRMT4Impl() FL_NO_EXCEPT
     mEnqueuedChannels.reserve(16);
     mPendingChannels.reserve(16);
 
-    // Register global ISR handler for RMT interrupts
-    // NOTE: The ISR must be registered once for all RMT channels
-    esp_err_t err = esp_intr_alloc(
-        ETS_RMT_INTR_SOURCE,
-        ESP_INTR_FLAG_IRAM | ESP_INTR_FLAG_LEVEL3,
-        &ChannelEngineRMT4Impl::handleInterrupt,
-        this,  // Pass 'this' pointer to ISR for dispatch
-        &mRMT_intr_handle
-    );
+    if (!mPeripheral) {
+        FL_WARN_F("ChannelEngineRMT4: null peripheral injected — driver inert");
+        return;
+    }
 
-    if (err != ESP_OK) {
-        FL_WARN_F("ChannelEngineRMT4: Failed to allocate RMT interrupt, error=%s", err);
+    // Register the single global ISR for all RMT channels via the
+    // peripheral abstraction. ISR signature matches `intr_handler_t`.
+    if (!mPeripheral->installIsr(&ChannelEngineRMT4Impl::handleInterrupt, this,
+                                 &mRMT_intr_handle)) {
+        FL_WARN_F("ChannelEngineRMT4: peripheral->installIsr failed");
         return;
     }
 
@@ -74,21 +82,20 @@ ChannelEngineRMT4Impl::ChannelEngineRMT4Impl() FL_NO_EXCEPT
 ChannelEngineRMT4Impl::~ChannelEngineRMT4Impl() {
     FL_WARN_F("ChannelEngineRMT4: Shutting down");
 
-    // Free the interrupt handler
-    if (mRMT_intr_handle != nullptr) {
-        esp_intr_free(mRMT_intr_handle);
-        mRMT_intr_handle = nullptr;
+    // Free the global ISR via the peripheral abstraction.
+    if (mPeripheral && mRMT_intr_handle != nullptr) {
+        mPeripheral->freeIsr(mRMT_intr_handle);
     }
+    mRMT_intr_handle = nullptr;
 
-    // Release all channels and uninstall RMT drivers
-    for (auto& state : mChannels) {
+    // Release all channels and uninstall RMT drivers via the peripheral.
+    for (auto &state : mChannels) {
         if (state.inUse) {
-            // Disable interrupts for this channel
-            rmt_set_tx_intr_en(state.channel, false);
-
-            // Uninstall the RMT driver for this channel
-            rmt_driver_uninstall(state.channel);
-
+            if (mPeripheral) {
+                mPeripheral->setTxIntrEnable(static_cast<int>(state.channel),
+                                             false);
+                mPeripheral->uninstallDriver(static_cast<int>(state.channel));
+            }
             state.inUse = false;
         }
     }
@@ -105,7 +112,8 @@ ChannelEngineRMT4Impl::~ChannelEngineRMT4Impl() {
 // IChannelDriver Interface
 // ═══════════════════════════════════════════════════════════════════════════
 
-bool ChannelEngineRMT4Impl::canHandle(const ChannelDataPtr& data) const FL_NO_EXCEPT {
+bool ChannelEngineRMT4Impl::canHandle(const ChannelDataPtr &data) const
+    FL_NO_EXCEPT {
     if (!data) {
         return false;
     }
@@ -117,13 +125,14 @@ bool ChannelEngineRMT4Impl::canHandle(const ChannelDataPtr& data) const FL_NO_EX
 // Timing Symbol Helpers
 // ═══════════════════════════════════════════════════════════════════════════
 
-rmt_item32_t ChannelEngineRMT4Impl::makeZeroSymbol(const ChipsetTimingConfig& timing) FL_NO_EXCEPT {
+rmt_item32_t ChannelEngineRMT4Impl::makeZeroSymbol(
+    const ChipsetTimingConfig &timing) FL_NO_EXCEPT {
     // Zero bit timing: T0H (high) + T0L (low)
     // For WS2812: T0H=400ns, T0L=850ns
 
-    u32 T1 = timing.t1_ns;  // T0H in nanoseconds
-    u32 T2 = timing.t2_ns;  // T0L (partial)
-    u32 T3 = timing.t3_ns;  // T0L (remaining)
+    u32 T1 = timing.t1_ns; // T0H in nanoseconds
+    u32 T2 = timing.t2_ns; // T0L (partial)
+    u32 T3 = timing.t3_ns; // T0L (remaining)
 
     // Convert to CPU cycles, then to RMT cycles
     u32 T1_cycles = NS_TO_ESP_CYCLES(T1);
@@ -131,21 +140,22 @@ rmt_item32_t ChannelEngineRMT4Impl::makeZeroSymbol(const ChipsetTimingConfig& ti
     u32 T3_cycles = NS_TO_ESP_CYCLES(T3);
 
     rmt_item32_t zero;
-    zero.level0 = 1;  // High during T0H
+    zero.level0 = 1; // High during T0H
     zero.duration0 = ESP_TO_RMT_CYCLES(T1_cycles);
-    zero.level1 = 0;  // Low during T0L
+    zero.level1 = 0; // Low during T0L
     zero.duration1 = ESP_TO_RMT_CYCLES(T2_cycles + T3_cycles);
 
     return zero;
 }
 
-rmt_item32_t ChannelEngineRMT4Impl::makeOneSymbol(const ChipsetTimingConfig& timing) FL_NO_EXCEPT {
+rmt_item32_t ChannelEngineRMT4Impl::makeOneSymbol(
+    const ChipsetTimingConfig &timing) FL_NO_EXCEPT {
     // One bit timing: T1H (high) + T1L (low)
     // For WS2812: T1H=850ns, T1L=400ns
 
-    u32 T1 = timing.t1_ns;  // T1H (partial)
-    u32 T2 = timing.t2_ns;  // T1H (remaining)
-    u32 T3 = timing.t3_ns;  // T1L
+    u32 T1 = timing.t1_ns; // T1H (partial)
+    u32 T2 = timing.t2_ns; // T1H (remaining)
+    u32 T3 = timing.t3_ns; // T1L
 
     // Convert to CPU cycles, then to RMT cycles
     u32 T1_cycles = NS_TO_ESP_CYCLES(T1);
@@ -153,9 +163,9 @@ rmt_item32_t ChannelEngineRMT4Impl::makeOneSymbol(const ChipsetTimingConfig& tim
     u32 T3_cycles = NS_TO_ESP_CYCLES(T3);
 
     rmt_item32_t one;
-    one.level0 = 1;  // High during T1H
+    one.level0 = 1; // High during T1H
     one.duration0 = ESP_TO_RMT_CYCLES(T1_cycles + T2_cycles);
-    one.level1 = 0;  // Low during T1L
+    one.level1 = 0; // Low during T1L
     one.duration1 = ESP_TO_RMT_CYCLES(T3_cycles);
 
     return one;
@@ -166,20 +176,23 @@ rmt_item32_t ChannelEngineRMT4Impl::makeOneSymbol(const ChipsetTimingConfig& tim
 // ═══════════════════════════════════════════════════════════════════════════
 
 // ═══════════════════════════════════════════════════════════════════════════
-// Channel Management - Stubs (to be implemented in Phase 3B)
+// Channel Management
+//
+// All ESP-IDF lifecycle calls go through `mPeripheral` (`IRMT4Peripheral`).
+// ISR hot-path code (`fillNextBuffer`, `tx_start`, register writes) stays
+// inline in the header — see #3458.
 // ═══════════════════════════════════════════════════════════════════════════
 
-ChannelEngineRMT4Impl::ChannelState* ChannelEngineRMT4Impl::acquireChannel(
-    gpio_num_t pin,
-    const ChipsetTimingConfig& timing
-) FL_NO_EXCEPT {
+ChannelEngineRMT4Impl::ChannelState *ChannelEngineRMT4Impl::acquireChannel(
+    gpio_num_t pin, const ChipsetTimingConfig &timing) FL_NO_EXCEPT {
     // Three-tier channel allocation strategy (same as RMT5):
     // Strategy 1: Reuse channel with matching pin (zero-cost reuse)
-    // Strategy 2: Reconfigure any idle channel (requires hardware reconfiguration)
-    // Strategy 3: Create new channel if hardware available
+    // Strategy 2: Reconfigure any idle channel (requires hardware
+    // reconfiguration) Strategy 3: Create new channel if hardware available
 
-    // Strategy 1: Find idle channel with matching pin (perfect match, no reconfiguration)
-    for (auto& state : mChannels) {
+    // Strategy 1: Find idle channel with matching pin (perfect match, no
+    // reconfiguration)
+    for (auto &state : mChannels) {
         if (!state.inUse && state.pin == pin) {
             state.inUse = true;
             // Recalculate timing symbols in case timing changed
@@ -195,31 +208,36 @@ ChannelEngineRMT4Impl::ChannelState* ChannelEngineRMT4Impl::acquireChannel(
             state.lastFill = 0;
             state.transmissionStartTime = 0;
 
-            FL_WARN_F("acquireChannel: Reusing channel %s for pin %s", state.channel, static_cast<int>(pin));
+            FL_WARN_F("acquireChannel: Reusing channel %s for pin %s",
+                      state.channel, static_cast<int>(pin));
             return &state;
         }
     }
 
     // Strategy 2: Find any idle channel and reconfigure it
-    for (auto& state : mChannels) {
+    for (auto &state : mChannels) {
         if (!state.inUse) {
             state.inUse = true;
 
             // Reconfigure hardware for new pin/timing
             if (!configureChannel(&state, pin, timing)) {
-                FL_WARN_F("acquireChannel: Failed to reconfigure channel %s", state.channel);
+                FL_WARN_F("acquireChannel: Failed to reconfigure channel %s",
+                          state.channel);
                 state.inUse = false;
                 return nullptr;
             }
 
-            FL_WARN_F("acquireChannel: Reconfigured channel %s for pin %s", state.channel, static_cast<int>(pin));
+            FL_WARN_F("acquireChannel: Reconfigured channel %s for pin %s",
+                      state.channel, static_cast<int>(pin));
             return &state;
         }
     }
 
     // Strategy 3: Create new channel if hardware available
     if (mChannels.size() >= FASTLED_RMT_MAX_CHANNELS) {
-        FL_WARN_F("acquireChannel: All %s RMT channels in use, time-multiplexing required", FASTLED_RMT_MAX_CHANNELS);
+        FL_WARN_F("acquireChannel: All %s RMT channels in use, "
+                  "time-multiplexing required",
+                  FASTLED_RMT_MAX_CHANNELS);
         return nullptr;
     }
 
@@ -241,22 +259,27 @@ ChannelEngineRMT4Impl::ChannelState* ChannelEngineRMT4Impl::acquireChannel(
 
     // Configure the hardware
     if (!configureChannel(&newState, pin, timing)) {
-        FL_WARN_F("acquireChannel: Failed to configure new channel %s", newState.channel);
+        FL_WARN_F("acquireChannel: Failed to configure new channel %s",
+                  newState.channel);
         return nullptr;
     }
 
     // Add to channels list
     mChannels.push_back(newState);
-    ChannelState* stablePtr = &mChannels.back();
+    ChannelState *stablePtr = &mChannels.back();
 
-    FL_WARN_F("acquireChannel: Created new channel %s for pin %s (total: %s/%s)", stablePtr->channel, static_cast<int>(pin), mChannels.size(), FASTLED_RMT_MAX_CHANNELS);
+    FL_WARN_F(
+        "acquireChannel: Created new channel %s for pin %s (total: %s/%s)",
+        stablePtr->channel, static_cast<int>(pin), mChannels.size(),
+        FASTLED_RMT_MAX_CHANNELS);
 
     return stablePtr;
 }
 
-void ChannelEngineRMT4Impl::releaseChannel(ChannelState* state) FL_NO_EXCEPT {
+void ChannelEngineRMT4Impl::releaseChannel(ChannelState *state) FL_NO_EXCEPT {
     // Release channel back to idle state (mark as available for reuse)
-    // NOTE: We do NOT destroy the RMT channel - keep it configured for fast reuse
+    // NOTE: We do NOT destroy the RMT channel - keep it configured for fast
+    // reuse
 
     if (!state) {
         FL_WARN_F("releaseChannel: null state pointer");
@@ -264,7 +287,8 @@ void ChannelEngineRMT4Impl::releaseChannel(ChannelState* state) FL_NO_EXCEPT {
     }
 
     if (!state->inUse) {
-        FL_WARN_F("releaseChannel: Channel %s already released", state->channel);
+        FL_WARN_F("releaseChannel: Channel %s already released",
+                  state->channel);
         return;
     }
 
@@ -272,17 +296,24 @@ void ChannelEngineRMT4Impl::releaseChannel(ChannelState* state) FL_NO_EXCEPT {
     // This prevents race conditions if channel is reacquired immediately
     rmt_channel_t channel = state->channel;
 
-    // Disable TX interrupts for this channel (platform-specific)
-#if defined(FL_IS_ESP_32C3) || defined(FL_IS_ESP_32H2) || defined(FL_IS_ESP_32S3) || defined(FL_IS_ESP_32C6)
+    // Disable TX interrupts for this channel (platform-specific direct
+    // register writes — fastest path; the peripheral surface only
+    // covers the per-channel `rmt_set_tx_intr_en()` lifecycle call).
+#if defined(FL_IS_ESP_32C3) || defined(FL_IS_ESP_32H2) ||                      \
+    defined(FL_IS_ESP_32S3) || defined(FL_IS_ESP_32C6)
     RMT.int_ena.val &= ~(1 << channel);
 #elif defined(FL_IS_ESP_32S2) || defined(FL_IS_ESP_32DEV)
     RMT.int_ena.val &= ~(1 << (channel * 3));
 #else
-    // Fallback to API call for unknown platforms
-    rmt_set_tx_intr_en(channel, false);
+    // Fallback for unknown ESP32 variants — go through the peripheral.
+    if (mPeripheral) {
+        mPeripheral->setTxIntrEnable(static_cast<int>(channel), false);
+    }
 #endif
 
-    // Disconnect the GPIO from the RMT controller
+    // Disconnect the GPIO from the RMT controller. This call is also
+    // used from the IRAM ISR (`onTxDoneInterrupt`), so it stays as a
+    // direct ROM call rather than going through `IRMT4Peripheral`.
     gpio_matrix_out(state->pin, SIG_GPIO_OUT_IDX, 0, 0);
 
     // Mark channel as idle (available for reuse)
@@ -304,23 +335,24 @@ void ChannelEngineRMT4Impl::releaseChannel(ChannelState* state) FL_NO_EXCEPT {
     // - state->memStart, state->memPtr (hardware memory pointers)
     // - RMT driver remains installed (fast reacquisition)
 
-    FL_WARN_F("releaseChannel: Released channel %s on pin %s", state->channel, static_cast<int>(state->pin));
+    FL_WARN_F("releaseChannel: Released channel %s on pin %s", state->channel,
+              static_cast<int>(state->pin));
 }
 
 bool ChannelEngineRMT4Impl::configureChannel(
-    ChannelState* state,
-    gpio_num_t pin,
-    const ChipsetTimingConfig& timing
-) FL_NO_EXCEPT {
-    // Port of ESP32RMTController::init() and startOnChannel() logic
-    // Configures RMT hardware for the given pin and timing
+    ChannelState *state, gpio_num_t pin,
+    const ChipsetTimingConfig &timing) FL_NO_EXCEPT {
+    // Port of ESP32RMTController::init() and startOnChannel() logic.
+    // All ESP-IDF lifecycle calls go through `mPeripheral` (#3458).
 
     if (!state) {
         FL_WARN_F("configureChannel: null state pointer");
         return false;
     }
-
-    esp_err_t err = ESP_OK;
+    if (!mPeripheral) {
+        FL_WARN_F("configureChannel: null peripheral");
+        return false;
+    }
 
     // Update state configuration
     state->pin = pin;
@@ -334,63 +366,47 @@ bool ChannelEngineRMT4Impl::configureChannel(
     u32 T1_cycles = NS_TO_ESP_CYCLES(timing.t1_ns);
     u32 T2_cycles = NS_TO_ESP_CYCLES(timing.t2_ns);
     u32 T3_cycles = NS_TO_ESP_CYCLES(timing.t3_ns);
-    state->cyclesPerFill = (T1_cycles + T2_cycles + T3_cycles) * PULSES_PER_FILL_RMT4;
+    state->cyclesPerFill =
+        (T1_cycles + T2_cycles + T3_cycles) * PULSES_PER_FILL_RMT4;
     state->maxCyclesPerFill = state->cyclesPerFill + state->cyclesPerFill / 2;
     state->lastFill = 0;
 
-    // RMT configuration for transmission
-    rmt_config_t rmt_tx;
-    fl::memset(&rmt_tx, 0, sizeof(rmt_config_t));
-    rmt_tx.channel = state->channel;
-    rmt_tx.rmt_mode = RMT_MODE_TX;
-    rmt_tx.gpio_num = pin;
-    rmt_tx.mem_block_num = FASTLED_RMT_MEM_BLOCKS;
-    rmt_tx.clk_div = DIVIDER_RMT4;
-    rmt_tx.tx_config.loop_en = false;
-    rmt_tx.tx_config.carrier_level = RMT_CARRIER_LEVEL_LOW;
-    rmt_tx.tx_config.carrier_en = false;
-    rmt_tx.tx_config.idle_level = RMT_IDLE_LEVEL_LOW;
-    rmt_tx.tx_config.idle_output_en = true;
-
-    // Apply the configuration
-    err = rmt_config(&rmt_tx);
-    if (err != ESP_OK) {
-        FL_WARN_F("configureChannel: rmt_config failed, error=%s", err);
+    // Apply the channel configuration via the peripheral.
+    detail::Rmt4ChannelConfig cfg(static_cast<int>(state->channel),
+                                  static_cast<int>(pin), DIVIDER_RMT4,
+                                  FASTLED_RMT_MEM_BLOCKS, PULSES_PER_FILL_RMT4);
+    if (!mPeripheral->configureChannel(cfg)) {
         return false;
     }
 
-    // Install RMT driver (no internal buffer - we use custom ISR)
-    err = rmt_driver_install(state->channel, 0, 0);
-    if (err != ESP_OK) {
-        FL_WARN_F("configureChannel: rmt_driver_install failed, error=%s", err);
+    // Install the ESP-IDF RMT driver with no internal ring buffer —
+    // FastLED's custom ISR owns the double-buffer refill.
+    if (!mPeripheral->installDriver(static_cast<int>(state->channel))) {
         return false;
     }
 
-    // Set up threshold interrupt for double-buffer refill
-    err = rmt_set_tx_thr_intr_en(state->channel, true, PULSES_PER_FILL_RMT4);
-    if (err != ESP_OK) {
-        FL_WARN_F("configureChannel: rmt_set_tx_thr_intr_en failed, error=%s", err);
-        rmt_driver_uninstall(state->channel);
+    // Arm the half-buffer threshold interrupt.
+    if (!mPeripheral->setTxThresholdIntrEnable(static_cast<int>(state->channel),
+                                               true, PULSES_PER_FILL_RMT4)) {
+        mPeripheral->uninstallDriver(static_cast<int>(state->channel));
         return false;
     }
 
-    // Get pointer to RMT hardware memory (direct access for ISR)
+    // Direct access to the RMT hardware buffer is part of the ISR hot
+    // path and must remain inline here (cannot go through the
+    // peripheral abstraction without breaking IRAM placement).
     state->memStart = &(RMTMEM.chan[state->channel].data32[0]);
     state->memPtr = state->memStart;
 
-    // Assign the pin to this channel (must be done before transmission)
-#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 4, 0)
-    err = rmt_set_gpio(state->channel, RMT_MODE_TX, pin, false);
-#else
-    err = rmt_set_pin(state->channel, RMT_MODE_TX, pin);
-#endif
-    if (err != ESP_OK) {
-        FL_WARN_F("configureChannel: rmt_set_gpio/rmt_set_pin failed, error=%s", err);
-        rmt_driver_uninstall(state->channel);
+    // Assign the GPIO via the peripheral.
+    if (!mPeripheral->setGpio(static_cast<int>(state->channel),
+                              static_cast<int>(pin), false)) {
+        mPeripheral->uninstallDriver(static_cast<int>(state->channel));
         return false;
     }
 
-    FL_WARN_F("configureChannel: Configured channel %s on pin %s", state->channel, static_cast<int>(pin));
+    FL_WARN_F("configureChannel: Configured channel %s on pin %s",
+              state->channel, static_cast<int>(pin));
 
     return true;
 }
@@ -405,15 +421,18 @@ void ChannelEngineRMT4Impl::processPendingChannels() FL_NO_EXCEPT {
     // as they complete (managed by pollDerived())
 
     // Iterate through pending queue (use index because we may remove items)
-    for (size_t i = 0; i < mPendingChannels.size(); ) {
-        const ChannelDataPtr& data = mPendingChannels[i];
+    for (size_t i = 0; i < mPendingChannels.size();) {
+        const ChannelDataPtr &data = mPendingChannels[i];
 
         // Try to acquire a hardware channel for this strip
-        ChannelState* state = acquireChannel(static_cast<gpio_num_t>(data->getPin()), data->getTiming());
+        ChannelState *state = acquireChannel(
+            static_cast<gpio_num_t>(data->getPin()), data->getTiming());
 
         if (state == nullptr) {
             // All channels busy - time-multiplexing will resume later in poll()
-            FL_WARN_F("processPendingChannels: All %s channels busy, deferring %s pending strips", FASTLED_RMT_MAX_CHANNELS, (mPendingChannels.size() - i));
+            FL_WARN_F("processPendingChannels: All %s channels busy, deferring "
+                      "%s pending strips",
+                      FASTLED_RMT_MAX_CHANNELS, (mPendingChannels.size() - i));
             break;
         }
 
@@ -427,7 +446,8 @@ void ChannelEngineRMT4Impl::processPendingChannels() FL_NO_EXCEPT {
     }
 }
 
-void ChannelEngineRMT4Impl::startTransmission(ChannelState* state, const ChannelDataPtr& data) FL_NO_EXCEPT {
+void ChannelEngineRMT4Impl::startTransmission(
+    ChannelState *state, const ChannelDataPtr &data) FL_NO_EXCEPT {
     // Initialize channel state and start RMT transmission
     // Port of: ESP32RMTController::startOnChannel() from idf4_rmt_impl.cpp
     //
@@ -450,12 +470,19 @@ void ChannelEngineRMT4Impl::startTransmission(ChannelState* state, const Channel
     data->setInUse(true);
 
     // Get pointer to encoded pixel data
-    const auto& dataBuffer = data->getData();
+    const auto &dataBuffer = data->getData();
     state->pixelData = dataBuffer.data();
     state->pixelDataSize = dataBuffer.size();
 
     // DEBUG: Log pixel data details
-    FL_DBG_F("RMT4: startTransmission() called with %s bytes, first 3 bytes: %s %s %s", state->pixelDataSize, (state->pixelDataSize > 0 ? static_cast<int>(state->pixelData[0]) : -1), (state->pixelDataSize > 1 ? static_cast<int>(state->pixelData[1]) : -1), (state->pixelDataSize > 2 ? static_cast<int>(state->pixelData[2]) : -1));
+    FL_DBG_F(
+        "RMT4: startTransmission() called with %s bytes, first 3 bytes: %s %s "
+        "%s",
+        state->pixelDataSize,
+        (state->pixelDataSize > 0 ? static_cast<int>(state->pixelData[0]) : -1),
+        (state->pixelDataSize > 1 ? static_cast<int>(state->pixelData[1]) : -1),
+        (state->pixelDataSize > 2 ? static_cast<int>(state->pixelData[2])
+                                  : -1));
 
     // Reset transmission state
     state->pixelDataPos = 0;
@@ -463,17 +490,18 @@ void ChannelEngineRMT4Impl::startTransmission(ChannelState* state, const Channel
     state->memPtr = state->memStart;
     state->transmissionComplete = false;
     state->lastFill = 0;
-    state->transmissionStartTime = fl::millis();  // Start timeout timer
+    state->transmissionStartTime = fl::millis(); // Start timeout timer
 
     // Fill both halves of the double-buffer
     // (false = skip time check on initial fill)
     fillNextBuffer(state, false);
     fillNextBuffer(state, false);
 
-    // Enable TX interrupts for this channel
-    esp_err_t err = rmt_set_tx_intr_en(state->channel, true);
-    if (err != ESP_OK) {
-        FL_WARN_F("startTransmission: rmt_set_tx_intr_en failed, error=%s", err);
+    // Enable TX interrupts for this channel via the peripheral.
+    if (!mPeripheral ||
+        !mPeripheral->setTxIntrEnable(static_cast<int>(state->channel), true)) {
+        FL_WARN_F("startTransmission: setTxIntrEnable failed on channel %s",
+                  state->channel);
         // Mark complete to trigger cleanup in poll()
         state->transmissionComplete = true;
         data->setInUse(false);
@@ -485,7 +513,9 @@ void ChannelEngineRMT4Impl::startTransmission(ChannelState* state, const Channel
     tx_start(state);
     portEXIT_CRITICAL(&mRmtSpinlock);
 
-    FL_DBG_F("RMT4: Transmission started on channel %s, pin %s, %s bytes", state->channel, static_cast<int>(state->pin), state->pixelDataSize);
+    FL_DBG_F("RMT4: Transmission started on channel %s, pin %s, %s bytes",
+             state->channel, static_cast<int>(state->pin),
+             state->pixelDataSize);
 }
 
 // Note: findChannelByNumber() and tx_start() are now inlined in the header
@@ -508,7 +538,8 @@ void ChannelEngineRMT4Impl::show() FL_NO_EXCEPT {
     // Trigger transmission of all enqueued data
     // Called by ChannelManager when user calls FastLED.show()
 
-    FL_WARN_F("show: Transmitting %s enqueued channels", mEnqueuedChannels.size());
+    FL_WARN_F("show: Transmitting %s enqueued channels",
+              mEnqueuedChannels.size());
 
     if (!mEnqueuedChannels.empty()) {
         // Pass batched data to internal transmission handler
@@ -534,7 +565,7 @@ IChannelDriver::DriverState ChannelEngineRMT4Impl::poll() FL_NO_EXCEPT {
     bool anyTimeout = false;
 
     // Check all active channels for completion or timeout
-    for (auto& state : mChannels) {
+    for (auto &state : mChannels) {
         if (!state.inUse) {
             continue;
         }
@@ -556,12 +587,18 @@ IChannelDriver::DriverState ChannelEngineRMT4Impl::poll() FL_NO_EXCEPT {
             u32 elapsed = fl::millis() - state.transmissionStartTime;
             if (elapsed > FASTLED_RMT4_TRANSMISSION_TIMEOUT_MS) {
                 // Timeout detected - force channel reset
-                FL_WARN_F("poll: Channel %s timed out after %sms (limit: %sms)", state.channel, elapsed, FASTLED_RMT4_TRANSMISSION_TIMEOUT_MS);
+                FL_WARN_F("poll: Channel %s timed out after %sms (limit: %sms)",
+                          state.channel, elapsed,
+                          FASTLED_RMT4_TRANSMISSION_TIMEOUT_MS);
 
-                // Disable interrupts for this channel
-                rmt_set_tx_intr_en(state.channel, false);
+                // Disable interrupts for this channel via the peripheral.
+                if (mPeripheral) {
+                    mPeripheral->setTxIntrEnable(
+                        static_cast<int>(state.channel), false);
+                }
 
-                // Disconnect GPIO
+                // Disconnect GPIO (kept as direct ROM call — also used
+                // from the IRAM ISR, can't go through virtual dispatch).
                 gpio_matrix_out(state.pin, SIG_GPIO_OUT_IDX, 0, 0);
 
                 // Clear in-use flag on source data
@@ -573,7 +610,7 @@ IChannelDriver::DriverState ChannelEngineRMT4Impl::poll() FL_NO_EXCEPT {
                 releaseChannel(&state);
 
                 anyTimeout = true;
-                continue;  // Skip anyBusy flag for this channel
+                continue; // Skip anyBusy flag for this channel
             }
 #endif
             anyBusy = true;
@@ -597,7 +634,8 @@ IChannelDriver::DriverState ChannelEngineRMT4Impl::poll() FL_NO_EXCEPT {
     return anyBusy ? DriverState::BUSY : DriverState::READY;
 }
 
-void ChannelEngineRMT4Impl::beginTransmission(fl::span<const ChannelDataPtr> channelData) FL_NO_EXCEPT {
+void ChannelEngineRMT4Impl::beginTransmission(
+    fl::span<const ChannelDataPtr> channelData) FL_NO_EXCEPT {
     // Main entry point for LED data transmission
     // Called by ChannelManager when user calls FastLED.show()
     //
@@ -613,25 +651,25 @@ void ChannelEngineRMT4Impl::beginTransmission(fl::span<const ChannelDataPtr> cha
     FL_WARN_F("beginTransmission: Queueing %s channels", channelData.size());
 
 #if FASTLED_ESP32_FLASH_LOCK == 1
-    // Block flash operations during LED transmission to prevent timing glitches
-    // This is especially important when WiFi is active
-    #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 0, 0)
+// Block flash operations during LED transmission to prevent timing glitches
+// This is especially important when WiFi is active
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 0, 0)
     // IDF 4.x+ uses esp_flash_app_disable_protect()
     // Note: This API may not be available on all IDF versions
     // For now, we'll skip the flash lock and document the limitation
     FL_DBG_F("RMT4: Flash lock not yet implemented for IDF 4.x+");
-    #else
+#else
     // IDF 3.x uses spi_flash_op_lock()
     spi_flash_op_lock();
     FL_DBG_F("RMT4: Flash operations locked");
-    #endif
+#endif
 #endif
 
     // Clear pending queue (should be empty, but ensure clean state)
     mPendingChannels.clear();
 
     // Add all channels to pending queue
-    for (const auto& data : channelData) {
+    for (const auto &data : channelData) {
         if (data) {
             mPendingChannels.push_back(data);
         } else {
@@ -643,11 +681,11 @@ void ChannelEngineRMT4Impl::beginTransmission(fl::span<const ChannelDataPtr> cha
     processPendingChannels();
 
 #if FASTLED_ESP32_FLASH_LOCK == 1
-    #if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(4, 0, 0)
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(4, 0, 0)
     // Release flash lock after transmission starts
     spi_flash_op_unlock();
     FL_DBG_F("RMT4: Flash operations unlocked");
-    #endif
+#endif
 #endif
 }
 

--- a/src/platforms/esp/32/drivers/rmt/rmt_4/channel_driver_rmt4.h
+++ b/src/platforms/esp/32/drivers/rmt/rmt_4/channel_driver_rmt4.h
@@ -1,8 +1,9 @@
 /// @file channel_driver_rmt4.h
 /// @brief RMT4 interface for ChannelEngine (ESP32 IDF 4.x)
 ///
-/// This header defines both the public interface and implementation for RMT4 ChannelEngine.
-/// IRAM_ATTR functions are inlined here to avoid duplicate attribute warnings.
+/// This header defines both the public interface and implementation for RMT4
+/// ChannelEngine. IRAM_ATTR functions are inlined here to avoid duplicate
+/// attribute warnings.
 
 #pragma once
 
@@ -21,19 +22,22 @@
 
 // Detect misconfiguration: RMT5-only chip with FASTLED_RMT5=0
 #if FASTLED_RMT5 == 0
-#error "ESP32-C6/C5/P4/H2 only support RMT5 (new driver). These chips do not have RMT4 hardware. Remove -DFASTLED_RMT5=0 from build flags or set FASTLED_RMT5=1."
+#error                                                                         \
+    "ESP32-C6/C5/P4/H2 only support RMT5 (new driver). These chips do not have RMT4 hardware. Remove -DFASTLED_RMT5=0 from build flags or set FASTLED_RMT5=1."
 #endif
 
 // Skip RMT4 implementation for RMT5-only chips
-#elif !FASTLED_RMT5  // Only compile for RMT4 (IDF 4.x)
+#elif !FASTLED_RMT5 // Only compile for RMT4 (IDF 4.x)
 
-#include "fl/channels/driver.h"
 #include "fl/channels/data.h"
-#include "fl/stl/span.h"
+#include "fl/channels/driver.h"
 #include "fl/stl/compiler_control.h"
-#include "platforms/esp/32/core/clock_cycles.h"
-#include "fl/stl/vector.h"
 #include "fl/stl/noexcept.h"
+#include "fl/stl/shared_ptr.h"
+#include "fl/stl/span.h"
+#include "fl/stl/vector.h"
+#include "platforms/esp/32/core/clock_cycles.h"
+#include "platforms/esp/32/drivers/rmt/rmt_4/irmt4_peripheral.h"
 
 FL_EXTERN_C_BEGIN
 // IWYU pragma: begin_keep
@@ -107,7 +111,8 @@ FL_EXTERN_C_END
 #define FASTLED_RMT_MEM_BLOCKS 2
 #endif
 
-#define MAX_PULSES_RMT4 (FASTLED_RMT_MEM_WORDS_PER_CHANNEL * FASTLED_RMT_MEM_BLOCKS)
+#define MAX_PULSES_RMT4                                                        \
+    (FASTLED_RMT_MEM_WORDS_PER_CHANNEL * FASTLED_RMT_MEM_BLOCKS)
 #define PULSES_PER_FILL_RMT4 (MAX_PULSES_RMT4 / 2)
 
 // Clock divider
@@ -179,25 +184,35 @@ FASTLED_SHARED_PTR(ChannelEngineRMT4);
 /// - Double-buffer ISR-driven refill (WiFi interference resistant)
 /// - Time-multiplexing support (>8 strips via channel sharing)
 /// - Direct hardware memory access for performance
-/// - Zero global state (everything encapsulated in driver)
+/// - Lifecycle calls routed through `IRMT4Peripheral` (#3458) — the
+///   ISR hot path stays inline IRAM and is not virtualised.
 class ChannelEngineRMT4 : public IChannelDriver {
-public:
-    /// @brief Create RMT4 driver instance
+  public:
+    /// @brief Create RMT4 driver instance with the default real-hardware
+    ///        peripheral.
     /// @return Shared pointer to driver implementation
     static ChannelEngineRMT4Ptr create() FL_NO_EXCEPT;
+
+    /// @brief Create RMT4 driver instance with an injected peripheral
+    ///        (test seam — pass a mock to drive the engine without
+    ///        touching real ESP-IDF APIs).
+    static ChannelEngineRMT4Ptr
+    create(fl::shared_ptr<detail::IRMT4Peripheral> peripheral) FL_NO_EXCEPT;
 
     virtual ~ChannelEngineRMT4() = default;
 
     /// @brief Check if driver can handle channel data (clockless only)
     /// @param data Channel data to check
     /// @return true if clockless channel (rejects SPI), false otherwise
-    virtual bool canHandle(const ChannelDataPtr& data) const FL_NO_EXCEPT = 0;
+    virtual bool canHandle(const ChannelDataPtr &data) const FL_NO_EXCEPT = 0;
 
     /// @brief Get the driver name for affinity binding
     /// @return "RMT"
-    fl::string getName() const FL_NO_EXCEPT override { return fl::string::from_literal("RMT"); }
+    fl::string getName() const FL_NO_EXCEPT override {
+        return fl::string::from_literal("RMT");
+    }
 
-protected:
+  protected:
     ChannelEngineRMT4() = default;
 };
 
@@ -213,8 +228,18 @@ protected:
 /// - Double-buffer management
 /// - Time-multiplexing queue
 class ChannelEngineRMT4Impl final : public ChannelEngineRMT4 {
-public:
+  public:
+    /// @brief Default constructor uses the real-hardware peripheral.
+    ///        Kept for the legacy `idf4_clockless_rmt_esp32.h` path that
+    ///        instantiates this class through `fl::make_shared` without
+    ///        threading a peripheral through.
     ChannelEngineRMT4Impl() FL_NO_EXCEPT;
+
+    /// @brief Inject a peripheral (real or mock). Production use is via
+    ///        the factory; tests construct directly with a mock.
+    explicit ChannelEngineRMT4Impl(
+        fl::shared_ptr<detail::IRMT4Peripheral> peripheral) FL_NO_EXCEPT;
+
     ~ChannelEngineRMT4Impl() override;
 
     /// @brief Enqueue channel data for transmission
@@ -226,7 +251,7 @@ public:
     /// @brief Query driver state (hardware polling implementation)
     DriverState poll() FL_NO_EXCEPT override;
 
-private:
+  private:
     // ═══════════════════════════════════════════════════════════════════════════
     // Channel State Structure
     // ═══════════════════════════════════════════════════════════════════════════
@@ -245,11 +270,11 @@ private:
 
         // Double-Buffer State
         int whichHalf;
-        volatile rmt_item32_t* memPtr;
-        volatile rmt_item32_t* memStart;
+        volatile rmt_item32_t *memPtr;
+        volatile rmt_item32_t *memStart;
 
         // Pixel Data Buffer
-        const u8* pixelData;
+        const u8 *pixelData;
         size_t pixelDataSize;
         volatile size_t pixelDataPos;
 
@@ -259,7 +284,7 @@ private:
         volatile u32 lastFill;
 
         // Timeout Detection
-        u32 transmissionStartTime;  // millis() when transmission started
+        u32 transmissionStartTime; // millis() when transmission started
 
         // Source reference
         ChannelDataPtr sourceData;
@@ -270,9 +295,14 @@ private:
     // ═══════════════════════════════════════════════════════════════════════════
 
     fl::vector_inlined<ChannelState, FASTLED_RMT_MAX_CHANNELS> mChannels;
-    fl::vector_inlined<ChannelDataPtr, 16> mEnqueuedChannels;  // Batched between enqueue() and show()
-    fl::vector_inlined<ChannelDataPtr, 16> mPendingChannels;    // Awaiting HW channels
-    intr_handle_t mRMT_intr_handle;
+    fl::vector_inlined<ChannelDataPtr, 16>
+        mEnqueuedChannels; // Batched between enqueue() and show()
+    fl::vector_inlined<ChannelDataPtr, 16>
+        mPendingChannels; // Awaiting HW channels
+    fl::shared_ptr<detail::IRMT4Peripheral>
+        mPeripheral; // Hardware lifecycle wrapper (#3458)
+    void
+        *mRMT_intr_handle; // intr_handle_t, opaque via the peripheral interface
     portMUX_TYPE mRmtSpinlock;
     bool mInitialized;
 
@@ -281,9 +311,9 @@ private:
     // reordering on Xtensa (l32r: literal placed after use)
     // ═══════════════════════════════════════════════════════════════════════════
 
-    static FL_NO_INLINE IRAM_ATTR void handleInterrupt(void* arg) FL_NO_EXCEPT {
+    static FL_NO_INLINE IRAM_ATTR void handleInterrupt(void *arg) FL_NO_EXCEPT {
         // Main ISR dispatcher
-        auto* driver = static_cast<ChannelEngineRMT4Impl*>(arg);
+        auto *driver = static_cast<ChannelEngineRMT4Impl *>(arg);
 
         // Enter critical section and read interrupt status
         portENTER_CRITICAL_ISR(&driver->mRmtSpinlock);
@@ -312,7 +342,7 @@ private:
 #endif
 
             // Check if this channel is active
-            ChannelState* state = driver->findChannelByNumber(channel);
+            ChannelState *state = driver->findChannelByNumber(channel);
             if (state != nullptr && state->inUse) {
                 // Handle threshold interrupt (half-buffer empty, needs refill)
                 if (intr_st & BIT(tx_next_bit)) {
@@ -329,9 +359,10 @@ private:
         }
     }
 
-    FL_NO_INLINE IRAM_ATTR void onThresholdInterrupt(int channelNum) FL_NO_EXCEPT {
+    FL_NO_INLINE IRAM_ATTR void
+    onThresholdInterrupt(int channelNum) FL_NO_EXCEPT {
         // Threshold interrupt: Half of the RMT buffer has been transmitted
-        ChannelState* state = findChannelByNumber(channelNum);
+        ChannelState *state = findChannelByNumber(channelNum);
         if (state == nullptr || !state->inUse) {
             return;
         }
@@ -342,7 +373,7 @@ private:
 
     FL_NO_INLINE IRAM_ATTR void onTxDoneInterrupt(int channelNum) FL_NO_EXCEPT {
         // TX done interrupt: Transmission is complete on this channel
-        ChannelState* state = findChannelByNumber(channelNum);
+        ChannelState *state = findChannelByNumber(channelNum);
         if (state == nullptr || !state->inUse) {
             return;
         }
@@ -371,7 +402,8 @@ private:
         state->transmissionComplete = true;
     }
 
-    FL_NO_INLINE IRAM_ATTR void fillNextBuffer(ChannelState* state, bool checkTime) FL_NO_EXCEPT {
+    FL_NO_INLINE IRAM_ATTR void fillNextBuffer(ChannelState *state,
+                                               bool checkTime) FL_NO_EXCEPT {
         // Fill the next half of the RMT double-buffer with pixel data
         if (!state) {
             return;
@@ -393,7 +425,7 @@ private:
         FASTLED_REGISTER u32 zero_val = state->zero.val;
 
         // Calculate pointer to current buffer half
-        volatile FASTLED_REGISTER rmt_item32_t* pItem = state->memPtr;
+        volatile FASTLED_REGISTER rmt_item32_t *pItem = state->memPtr;
 
         // Fill one half of the buffer
         for (FASTLED_REGISTER int i = 0; i < PULSES_PER_FILL_RMT4 / 8; i++) {
@@ -421,15 +453,13 @@ private:
         state->memPtr = pItem;
     }
 
-    static FL_NO_INLINE IRAM_ATTR void convertByteToRMT(
-        u8 byteval,
-        const rmt_item32_t& zero,
-        const rmt_item32_t& one,
-        volatile rmt_item32_t* pItem
-    ) FL_NO_EXCEPT {
+    static FL_NO_INLINE IRAM_ATTR void
+    convertByteToRMT(u8 byteval, const rmt_item32_t &zero,
+                     const rmt_item32_t &one,
+                     volatile rmt_item32_t *pItem) FL_NO_EXCEPT {
         // Convert 1 byte → 8 RMT symbols (MSB first)
         u32 pixel_u32 = byteval;
-        pixel_u32 <<= 24;  // Shift to MSB position for bit extraction
+        pixel_u32 <<= 24; // Shift to MSB position for bit extraction
 
         u32 tmp[8];
         for (u32 j = 0; j < 8; j++) {
@@ -452,7 +482,8 @@ private:
         pItem[7].val = tmp[7];
     }
 
-    static FL_NO_INLINE IRAM_ATTR void tx_start(ChannelState* state) FL_NO_EXCEPT {
+    static FL_NO_INLINE IRAM_ATTR void
+    tx_start(ChannelState *state) FL_NO_EXCEPT {
         // Start RMT transmission by setting hardware flag
         if (!state) {
             return;
@@ -533,9 +564,10 @@ private:
 #endif
     }
 
-    FL_NO_INLINE IRAM_ATTR ChannelState* findChannelByNumber(int channelNum) FL_NO_EXCEPT {
+    FL_NO_INLINE IRAM_ATTR ChannelState *
+    findChannelByNumber(int channelNum) FL_NO_EXCEPT {
         // Linear search through active channels
-        for (auto& state : mChannels) {
+        for (auto &state : mChannels) {
             if (state.inUse && state.channel == channelNum) {
                 return &state;
             }
@@ -548,20 +580,27 @@ private:
     // ═══════════════════════════════════════════════════════════════════════════
 
     /// @brief Begin LED data transmission for all channels (internal helper)
-    void beginTransmission(fl::span<const ChannelDataPtr> channelData) FL_NO_EXCEPT;
+    void
+    beginTransmission(fl::span<const ChannelDataPtr> channelData) FL_NO_EXCEPT;
 
-    ChannelState* acquireChannel(gpio_num_t pin, const ChipsetTimingConfig& timing) FL_NO_EXCEPT;
-    void releaseChannel(ChannelState* state) FL_NO_EXCEPT;
-    bool configureChannel(ChannelState* state, gpio_num_t pin, const ChipsetTimingConfig& timing) FL_NO_EXCEPT;
+    ChannelState *
+    acquireChannel(gpio_num_t pin,
+                   const ChipsetTimingConfig &timing) FL_NO_EXCEPT;
+    void releaseChannel(ChannelState *state) FL_NO_EXCEPT;
+    bool configureChannel(ChannelState *state, gpio_num_t pin,
+                          const ChipsetTimingConfig &timing) FL_NO_EXCEPT;
     void processPendingChannels() FL_NO_EXCEPT;
-    void startTransmission(ChannelState* state, const ChannelDataPtr& data) FL_NO_EXCEPT;
+    void startTransmission(ChannelState *state,
+                           const ChannelDataPtr &data) FL_NO_EXCEPT;
 
     // ═══════════════════════════════════════════════════════════════════════════
     // Helpers
     // ═══════════════════════════════════════════════════════════════════════════
 
-    static rmt_item32_t makeZeroSymbol(const ChipsetTimingConfig& timing) FL_NO_EXCEPT;
-    static rmt_item32_t makeOneSymbol(const ChipsetTimingConfig& timing) FL_NO_EXCEPT;
+    static rmt_item32_t
+    makeZeroSymbol(const ChipsetTimingConfig &timing) FL_NO_EXCEPT;
+    static rmt_item32_t
+    makeOneSymbol(const ChipsetTimingConfig &timing) FL_NO_EXCEPT;
 };
 
 } // namespace fl

--- a/src/platforms/esp/32/drivers/rmt/rmt_4/irmt4_peripheral.h
+++ b/src/platforms/esp/32/drivers/rmt/rmt_4/irmt4_peripheral.h
@@ -1,0 +1,205 @@
+/// @file irmt4_peripheral.h
+/// @brief Virtual interface for the IDF-4.x RMT peripheral hardware
+///        abstraction (classic-ESP32 / S2 path).
+///
+/// Companion to `IRMT5Peripheral` (under `../rmt_5/`) for the legacy
+/// IDF 4.x RMT driver. Mirrors the `IUartPeripheral` shape: lifecycle
+/// + control surface only — the hot-path ISR + double-buffer refill
+/// stays inline in `ChannelEngineRMT4Impl` to remain in IRAM with no
+/// vtable lookups.
+///
+/// ## Why this exists (issue #3458)
+///
+/// The rmt_4 driver historically inlined every ESP-IDF call right into
+/// `ChannelEngineRMT4Impl::{configureChannel,releaseChannel,~Impl}`.
+/// That ties the engine class directly to `driver/rmt.h` and forces every
+/// engine consumer (channel manager + legacy `addLeds<>` template path)
+/// to recompile against the ESP-IDF surface. Extracting this thin
+/// virtual interface gives us:
+///
+/// 1. **Pattern parity.** `BusTraits<Bus::RMT>` now uses the same
+///    `XBusHolder { peripheral, driver }` shape that UART / FlexIO use,
+///    so the channel-driver registry is uniform across peripherals.
+/// 2. **Testability.** A mock implementation can sit in for
+///    `Rmt4PeripheralESP` so the engine's channel-management logic
+///    (acquire / reconfigure / release strategies) can be exercised on
+///    a host build.
+/// 3. **Hot-path stays hot.** Only the lifecycle calls go through the
+///    interface. The IRAM ISR continues to touch `RMT.*` registers and
+///    `RMTMEM.chan[...]` directly.
+///
+/// ## Interface scope — what's IN
+///
+/// - `rmt_config()` channel setup
+/// - `rmt_driver_install()` / `rmt_driver_uninstall()`
+/// - `rmt_set_tx_thr_intr_en()` threshold-interrupt arming
+/// - `rmt_set_tx_intr_en()` per-channel interrupt toggle
+/// - `rmt_set_gpio()` / `rmt_set_pin()` pin assignment
+/// - `esp_intr_alloc()` / `esp_intr_free()` global ISR install/free
+///
+/// ## Interface scope — what's OUT
+///
+/// - Direct `RMT.*` register access from the ISR — must stay inline in
+///   IRAM.
+/// - `gpio_matrix_out()` disconnect from ISR — same reason.
+/// - The double-buffer refill (`fillNextBuffer`) — same reason.
+/// - The `tx_start` per-platform register writes — same reason.
+///
+/// These are all `static FL_NO_INLINE IRAM_ATTR` methods on the engine
+/// and stay there. Virtual dispatch in the ISR would defeat the literal-
+/// pool placement guarantees that `FL_NO_INLINE` exists to enforce on
+/// Xtensa (see the `#2247` / `#2252` history in this directory's
+/// `README.md`).
+
+#pragma once
+
+// IWYU pragma: private
+
+#include "fl/stl/compiler_control.h"
+#include "platforms/is_platform.h"
+
+#if defined(FL_IS_ESP32)
+#include "platforms/esp/32/feature_flags/enabled.h"
+#endif
+
+#if defined(FL_IS_ESP32) && FASTLED_ESP32_HAS_RMT &&                           \
+    !FASTLED_ESP32_RMT5_ONLY_PLATFORM && !FASTLED_RMT5
+
+#include "fl/stl/cstddef.h"
+#include "fl/stl/noexcept.h"
+#include "fl/stl/stdint.h"
+
+namespace fl {
+
+namespace detail {
+
+//=============================================================================
+// Configuration Structures
+//=============================================================================
+
+/// @brief RMT4 TX channel configuration (one strip / pin).
+///
+/// Captures everything `rmt_config()` needs plus the FastLED-specific
+/// threshold count. Channel number is part of the config because the
+/// engine assigns channels statically (`channel = mChannels.size()`)
+/// rather than letting ESP-IDF allocate.
+struct Rmt4ChannelConfig {
+    int mChannel;      ///< RMT hardware channel (0..FASTLED_RMT_MAX_CHANNELS-1)
+    int mGpioPin;      ///< GPIO pin for this channel
+    u32 mClockDivider; ///< RMT clock divider (typically DIVIDER_RMT4 = 2)
+    u8 mMemBlocks;     ///< RMT memory blocks per channel (typically
+                       ///< FASTLED_RMT_MEM_BLOCKS)
+    u16 mTxThreshold;  ///< Half-buffer threshold for refill interrupt
+                       ///< (PULSES_PER_FILL_RMT4)
+
+    Rmt4ChannelConfig() FL_NO_EXCEPT : mChannel(-1),
+                                       mGpioPin(-1),
+                                       mClockDivider(0),
+                                       mMemBlocks(0),
+                                       mTxThreshold(0) {}
+
+    Rmt4ChannelConfig(int channel, int gpio_pin, u32 clk_div, u8 mem_blocks,
+                      u16 threshold) FL_NO_EXCEPT : mChannel(channel),
+                                                    mGpioPin(gpio_pin),
+                                                    mClockDivider(clk_div),
+                                                    mMemBlocks(mem_blocks),
+                                                    mTxThreshold(threshold) {}
+};
+
+//=============================================================================
+// ISR Trampoline
+//=============================================================================
+
+/// @brief Function pointer signature for the global RMT ISR.
+///
+/// Matches `intr_handler_t` from `esp_intr_alloc.h` without leaking the
+/// ESP-IDF type through this interface. The concrete impl casts to the
+/// real signature.
+using Rmt4IsrHandler = void (*)(void *arg);
+
+//=============================================================================
+// Virtual Peripheral Interface
+//=============================================================================
+
+/// @brief Virtual interface for IDF-4.x RMT peripheral lifecycle calls.
+///
+/// Pure virtual. Concrete implementations:
+/// - `Rmt4PeripheralESP` — thin wrapper around `driver/rmt.h` (real hw).
+/// - (future) `Rmt4PeripheralMock` — host-side simulation for unit tests.
+///
+/// All methods return `bool` (true = success) so callers don't have to
+/// reason about ESP-IDF `esp_err_t` codes at the engine layer.
+class IRMT4Peripheral {
+  public:
+    virtual ~IRMT4Peripheral() = default;
+
+    //=========================================================================
+    // Channel Lifecycle
+    //=========================================================================
+
+    /// @brief Configure an RMT TX channel from a `Rmt4ChannelConfig`.
+    ///
+    /// Maps to `rmt_config()` with the standard FastLED clockless preset:
+    /// idle-low output enabled, no carrier, no loop mode.
+    virtual bool
+    configureChannel(const Rmt4ChannelConfig &cfg) FL_NO_EXCEPT = 0;
+
+    /// @brief Install the ESP-IDF RMT driver for one channel with no
+    ///        internal ring buffer (FastLED uses a custom double-buffer
+    ///        refill ISR).
+    ///
+    /// Maps to `rmt_driver_install(channel, 0, 0)`.
+    virtual bool installDriver(int channel) FL_NO_EXCEPT = 0;
+
+    /// @brief Uninstall the ESP-IDF RMT driver for one channel.
+    /// Maps to `rmt_driver_uninstall(channel)`.
+    virtual bool uninstallDriver(int channel) FL_NO_EXCEPT = 0;
+
+    //=========================================================================
+    // Interrupt Control
+    //=========================================================================
+
+    /// @brief Arm the half-buffer threshold interrupt.
+    /// Maps to `rmt_set_tx_thr_intr_en(channel, enable, threshold)`.
+    virtual bool setTxThresholdIntrEnable(int channel, bool enable,
+                                          u16 threshold) FL_NO_EXCEPT = 0;
+
+    /// @brief Toggle the per-channel TX interrupt enable bit.
+    /// Maps to `rmt_set_tx_intr_en(channel, enable)`.
+    virtual bool setTxIntrEnable(int channel, bool enable) FL_NO_EXCEPT = 0;
+
+    //=========================================================================
+    // GPIO Assignment
+    //=========================================================================
+
+    /// @brief Assign a GPIO to a channel.
+    ///
+    /// On IDF >= 4.4 maps to `rmt_set_gpio(channel, RMT_MODE_TX, pin,
+    /// invert)`; on older IDF to `rmt_set_pin(channel, RMT_MODE_TX,
+    /// pin)` and `invert` is ignored.
+    virtual bool setGpio(int channel, int gpio_pin,
+                         bool invert) FL_NO_EXCEPT = 0;
+
+    //=========================================================================
+    // Global ISR
+    //=========================================================================
+
+    /// @brief Install the global RMT ISR (one for all channels).
+    /// Maps to `esp_intr_alloc(ETS_RMT_INTR_SOURCE, IRAM | LEVEL3,
+    /// handler, arg, out_handle)`.
+    ///
+    /// `out_handle` receives the `intr_handle_t` cast to `void*` so the
+    /// engine can later pass it back to `freeIsr()` without leaking the
+    /// ESP-IDF type through this header.
+    virtual bool installIsr(Rmt4IsrHandler handler, void *arg,
+                            void **out_handle) FL_NO_EXCEPT = 0;
+
+    /// @brief Free a previously-installed global RMT ISR.
+    /// Maps to `esp_intr_free(handle)`. Safe to call with nullptr.
+    virtual void freeIsr(void *handle) FL_NO_EXCEPT = 0;
+};
+
+} // namespace detail
+} // namespace fl
+
+#endif // FL_IS_ESP32 && FASTLED_ESP32_HAS_RMT && !RMT5-only && !FASTLED_RMT5

--- a/src/platforms/esp/32/drivers/rmt/rmt_4/rmt4_peripheral_esp.cpp.hpp
+++ b/src/platforms/esp/32/drivers/rmt/rmt_4/rmt4_peripheral_esp.cpp.hpp
@@ -1,0 +1,153 @@
+// IWYU pragma: private
+
+/// @file rmt4_peripheral_esp.cpp.hpp
+/// @brief `Rmt4PeripheralESP` — `IRMT4Peripheral` implementation that
+///        forwards to ESP-IDF v4.x `driver/rmt.h`.
+
+#include "platforms/is_platform.h"
+#ifdef FL_IS_ESP32
+
+#include "fl/stl/compiler_control.h"
+#include "platforms/esp/32/feature_flags/enabled.h"
+
+#if !FASTLED_ESP32_HAS_RMT
+// No RMT hardware available
+#elif defined(FL_IS_ESP_32C6) || defined(FL_IS_ESP_32C5) ||                    \
+    defined(CONFIG_IDF_TARGET_ESP32P4) || defined(CONFIG_IDF_TARGET_ESP32H2)
+// Skip for RMT5-only chips
+#elif !FASTLED_RMT5 // Only compile for the RMT4 path
+
+#include "platforms/esp/32/drivers/rmt/rmt_4/rmt4_peripheral_esp.h"
+
+#include "fl/log/log.h"
+#include "fl/stl/noexcept.h"
+#include "platforms/esp/esp_version.h"
+
+FL_EXTERN_C_BEGIN
+// IWYU pragma: begin_keep
+#include "driver/gpio.h"
+#include "driver/rmt.h"
+#if defined(ESP_IDF_VERSION_MAJOR) && ESP_IDF_VERSION_MAJOR > 3
+#include "esp_intr_alloc.h"
+#else
+#include "esp_intr.h"
+#endif
+// IWYU pragma: end_keep
+FL_EXTERN_C_END
+
+namespace fl {
+
+bool Rmt4PeripheralESP::configureChannel(const detail::Rmt4ChannelConfig &cfg)
+    FL_NO_EXCEPT {
+    rmt_config_t rmt_tx = {};
+    rmt_tx.channel = static_cast<rmt_channel_t>(cfg.mChannel);
+    rmt_tx.rmt_mode = RMT_MODE_TX;
+    rmt_tx.gpio_num = static_cast<gpio_num_t>(cfg.mGpioPin);
+    rmt_tx.mem_block_num = cfg.mMemBlocks;
+    rmt_tx.clk_div = cfg.mClockDivider;
+    rmt_tx.tx_config.loop_en = false;
+    rmt_tx.tx_config.carrier_level = RMT_CARRIER_LEVEL_LOW;
+    rmt_tx.tx_config.carrier_en = false;
+    rmt_tx.tx_config.idle_level = RMT_IDLE_LEVEL_LOW;
+    rmt_tx.tx_config.idle_output_en = true;
+
+    esp_err_t err = rmt_config(&rmt_tx);
+    if (err != ESP_OK) {
+        FL_WARN_F(
+            "Rmt4PeripheralESP: rmt_config failed on channel %s, error=%s",
+            cfg.mChannel, err);
+        return false;
+    }
+    return true;
+}
+
+bool Rmt4PeripheralESP::installDriver(int channel) FL_NO_EXCEPT {
+    esp_err_t err =
+        rmt_driver_install(static_cast<rmt_channel_t>(channel), 0, 0);
+    if (err != ESP_OK) {
+        FL_WARN_F("Rmt4PeripheralESP: rmt_driver_install failed on channel %s, "
+                  "error=%s",
+                  channel, err);
+        return false;
+    }
+    return true;
+}
+
+bool Rmt4PeripheralESP::uninstallDriver(int channel) FL_NO_EXCEPT {
+    esp_err_t err = rmt_driver_uninstall(static_cast<rmt_channel_t>(channel));
+    return err == ESP_OK;
+}
+
+bool Rmt4PeripheralESP::setTxThresholdIntrEnable(int channel, bool enable,
+                                                 u16 threshold) FL_NO_EXCEPT {
+    esp_err_t err = rmt_set_tx_thr_intr_en(static_cast<rmt_channel_t>(channel),
+                                           enable, threshold);
+    if (err != ESP_OK) {
+        FL_WARN_F("Rmt4PeripheralESP: rmt_set_tx_thr_intr_en failed on channel "
+                  "%s, error=%s",
+                  channel, err);
+        return false;
+    }
+    return true;
+}
+
+bool Rmt4PeripheralESP::setTxIntrEnable(int channel, bool enable) FL_NO_EXCEPT {
+    esp_err_t err =
+        rmt_set_tx_intr_en(static_cast<rmt_channel_t>(channel), enable);
+    if (err != ESP_OK) {
+        FL_WARN_F("Rmt4PeripheralESP: rmt_set_tx_intr_en failed on channel %s, "
+                  "error=%s",
+                  channel, err);
+        return false;
+    }
+    return true;
+}
+
+bool Rmt4PeripheralESP::setGpio(int channel, int gpio_pin,
+                                bool invert) FL_NO_EXCEPT {
+    esp_err_t err;
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 4, 0)
+    err = rmt_set_gpio(static_cast<rmt_channel_t>(channel), RMT_MODE_TX,
+                       static_cast<gpio_num_t>(gpio_pin), invert);
+#else
+    (void)invert;
+    err = rmt_set_pin(static_cast<rmt_channel_t>(channel), RMT_MODE_TX,
+                      static_cast<gpio_num_t>(gpio_pin));
+#endif
+    if (err != ESP_OK) {
+        FL_WARN_F("Rmt4PeripheralESP: rmt_set_gpio/rmt_set_pin failed on "
+                  "channel %s pin %s, error=%s",
+                  channel, gpio_pin, err);
+        return false;
+    }
+    return true;
+}
+
+bool Rmt4PeripheralESP::installIsr(detail::Rmt4IsrHandler handler, void *arg,
+                                   void **out_handle) FL_NO_EXCEPT {
+    if (out_handle == nullptr) {
+        return false;
+    }
+    intr_handle_t handle = nullptr;
+    esp_err_t err = esp_intr_alloc(ETS_RMT_INTR_SOURCE,
+                                   ESP_INTR_FLAG_IRAM | ESP_INTR_FLAG_LEVEL3,
+                                   handler, arg, &handle);
+    if (err != ESP_OK) {
+        FL_WARN_F("Rmt4PeripheralESP: esp_intr_alloc failed, error=%s", err);
+        *out_handle = nullptr;
+        return false;
+    }
+    *out_handle = static_cast<void *>(handle);
+    return true;
+}
+
+void Rmt4PeripheralESP::freeIsr(void *handle) FL_NO_EXCEPT {
+    if (handle != nullptr) {
+        esp_intr_free(static_cast<intr_handle_t>(handle));
+    }
+}
+
+} // namespace fl
+
+#endif // !FASTLED_RMT5 and not RMT5-only chip
+#endif // FL_IS_ESP32

--- a/src/platforms/esp/32/drivers/rmt/rmt_4/rmt4_peripheral_esp.h
+++ b/src/platforms/esp/32/drivers/rmt/rmt_4/rmt4_peripheral_esp.h
@@ -1,0 +1,56 @@
+/// @file rmt4_peripheral_esp.h
+/// @brief Real-hardware `IRMT4Peripheral` for classic-ESP32 / IDF 4.x.
+///
+/// Pairs with `irmt4_peripheral.h`. Concrete implementation that wraps
+/// the `driver/rmt.h` lifecycle API. Owns no state of its own — all
+/// hardware state lives on the per-channel `ChannelState` in
+/// `ChannelEngineRMT4Impl`.
+
+#pragma once
+
+// IWYU pragma: private
+
+#include "fl/stl/compiler_control.h"
+#include "platforms/is_platform.h"
+
+#if defined(FL_IS_ESP32)
+#include "platforms/esp/32/feature_flags/enabled.h"
+#endif
+
+#if defined(FL_IS_ESP32) && FASTLED_ESP32_HAS_RMT &&                           \
+    !FASTLED_ESP32_RMT5_ONLY_PLATFORM && !FASTLED_RMT5
+
+#include "fl/stl/noexcept.h"
+#include "platforms/esp/32/drivers/rmt/rmt_4/irmt4_peripheral.h"
+
+namespace fl {
+
+/// @brief Real-hardware peripheral wrapper for the IDF-4.x RMT driver.
+///
+/// Stateless thin wrapper around `driver/rmt.h`. All ESP-IDF type
+/// dependencies live in the `.cpp.hpp` so this header stays cheap to
+/// include from `bus_traits.h`.
+class Rmt4PeripheralESP : public detail::IRMT4Peripheral {
+  public:
+    Rmt4PeripheralESP() FL_NO_EXCEPT = default;
+    ~Rmt4PeripheralESP() override = default;
+
+    bool configureChannel(const detail::Rmt4ChannelConfig &cfg)
+        FL_NO_EXCEPT override;
+    bool installDriver(int channel) FL_NO_EXCEPT override;
+    bool uninstallDriver(int channel) FL_NO_EXCEPT override;
+
+    bool setTxThresholdIntrEnable(int channel, bool enable,
+                                  u16 threshold) FL_NO_EXCEPT override;
+    bool setTxIntrEnable(int channel, bool enable) FL_NO_EXCEPT override;
+
+    bool setGpio(int channel, int gpio_pin, bool invert) FL_NO_EXCEPT override;
+
+    bool installIsr(detail::Rmt4IsrHandler handler, void *arg,
+                    void **out_handle) FL_NO_EXCEPT override;
+    void freeIsr(void *handle) FL_NO_EXCEPT override;
+};
+
+} // namespace fl
+
+#endif // FL_IS_ESP32 && FASTLED_ESP32_HAS_RMT && !RMT5-only && !FASTLED_RMT5


### PR DESCRIPTION
## Summary

Brings the classic-ESP32 RMT (rmt_4) driver in line with the `ChannelEngine + Peripheral` API-object pattern that UART, FlexIO, and RMT5 already use. This is Phase 1 + Phase 3 of the plan in #3458 — peripheral wrapper + bus-holder shape cleanup. Phase 2 (the actual ESP-IDF lifecycle calls) was already implemented; the stale "Stubs (to be implemented in Phase 3B)" comment misled the survey.

Closes #3458.

## What changes

**New files**
- `irmt4_peripheral.h` — `IRMT4Peripheral` virtual interface + `Rmt4ChannelConfig`. Companion to `IRMT5Peripheral` / `IUartPeripheral`.
- `rmt4_peripheral_esp.h` / `rmt4_peripheral_esp.cpp.hpp` — `Rmt4PeripheralESP`, the real-hardware wrapper around `driver/rmt.h`.

**Edited files**
- `channel_driver_rmt4.h` — engine now holds `shared_ptr<IRMT4Peripheral>`; added overloaded factory `create(peripheral)` and an injecting constructor for the holder.
- `channel_driver_rmt4.cpp.hpp` — every ESP-IDF lifecycle call (`rmt_config`, `rmt_driver_install`, `rmt_set_tx_intr_en`, `rmt_set_tx_thr_intr_en`, `rmt_set_gpio` / `rmt_set_pin`, `esp_intr_alloc` / `esp_intr_free`) is routed through `mPeripheral`. Removed the stale "Phase 3B stubs" banner.
- `bus_traits.h` — uses `detail::Rmt4BusHolder { peripheral, driver }`, mirroring `detail::UartBusHolder` exactly.
- `_build.cpp.hpp` — includes the new peripheral `.cpp.hpp`.
- `README.md` — documents the new abstraction + ISR carve-out.

## What stays inline IRAM (NOT virtualised)

The IRAM ISR hot path stays exactly where it was — virtual dispatch from an ISR defeats the `FL_NO_INLINE` literal-pool placement guarantees that `#2247` / `#2252` established. The interface header's docblock spells this out under "Interface scope — what's OUT":

- direct `RMT.*` register reads/writes
- `gpio_matrix_out()` disconnect
- `fillNextBuffer()` double-buffer refill
- `tx_start()` per-platform register kicks

## Validation

- [x] `bash test --cpp` — **340/340 pass** on this branch.
- [x] `clang-format --dry-run --Werror` clean on all new + edited files.
- [ ] `bash compile esp32dev --examples AutoResearch` — currently blocked on this Windows box by a separate fbuild spec-file backslash regression (`cc1plus: fatal error: C:Usersniteris.fbuild...`) that also reproduces on plain master. **Not introduced by this PR.** CI on Linux exercises the build.

## Out of scope (called out explicitly)

- `Rmt4PeripheralMock` for host-side unit tests of the engine's channel-management strategies — straightforward follow-up, but not in this PR.
- RMT5 (S3/C3/C6/H2/P4) — separate driver, already conforms.
- The TX (`rmt_4`) + RX (`rmt_rx`) peripheral merge — flagged in the survey, explicitly deferred.
- No `Bus::RMT_SPI` enum, no SPI mode work — RMT is not a parallel-IO peripheral, so the `agents/docs/cpp-standards.md` unified-engine rule does not apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved ESP32 RMT4 support with a more robust driver lifecycle, helping the platform manage channels and interrupts more reliably.
  * Expanded build support to include the updated RMT4 implementation in unified builds.

* **Bug Fixes**
  * Added stricter safeguards for channel setup and release to reduce misconfiguration and improve reuse.
  * Improved handling of interrupt and transmission shutdown paths for better stability on supported ESP32 targets.

* **Documentation**
  * Updated the RMT4 README to reflect the latest driver capabilities and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->