### PR TITLE
test(rmt4): Rmt4PeripheralMock + 22 host unit tests, no threads (#3462)

### DIFF
--- a/src/platforms/esp/32/drivers/rmt/rmt_4/irmt4_peripheral.h
+++ b/src/platforms/esp/32/drivers/rmt/rmt_4/irmt4_peripheral.h
@@ -55,16 +55,12 @@
 
 // IWYU pragma: private
 
+// This interface is platform-agnostic (no ESP32 guard) so it can be
+// included from host-side mock builds. Mirrors `IRMT5Peripheral`
+// — the concrete real-hardware impl (`Rmt4PeripheralESP`) keeps the
+// platform guard; this header does not.
+
 #include "fl/stl/compiler_control.h"
-#include "platforms/is_platform.h"
-
-#if defined(FL_IS_ESP32)
-#include "platforms/esp/32/feature_flags/enabled.h"
-#endif
-
-#if defined(FL_IS_ESP32) && FASTLED_ESP32_HAS_RMT &&                           \
-    !FASTLED_ESP32_RMT5_ONLY_PLATFORM && !FASTLED_RMT5
-
 #include "fl/stl/cstddef.h"
 #include "fl/stl/noexcept.h"
 #include "fl/stl/stdint.h"
@@ -201,5 +197,3 @@ class IRMT4Peripheral {
 
 } // namespace detail
 } // namespace fl
-
-#endif // FL_IS_ESP32 && FASTLED_ESP32_HAS_RMT && !RMT5-only && !FASTLED_RMT5

--- a/src/platforms/shared/mock/esp/32/drivers/_build.cpp.hpp
+++ b/src/platforms/shared/mock/esp/32/drivers/_build.cpp.hpp
@@ -4,6 +4,7 @@
 /// @brief Unity build header for platforms\shared\mock\esp\32\drivers/ directory
 /// Includes all implementation files in alphabetical order
 
+#include "platforms/shared/mock/esp/32/drivers/rmt4_peripheral_mock.cpp.hpp"
 #include "platforms/shared/mock/esp/32/drivers/rmt5_peripheral_mock.cpp.hpp"
 #include "platforms/shared/mock/esp/32/drivers/spi_peripheral_mock.cpp.hpp"
 #include "platforms/shared/mock/esp/32/drivers/uart_peripheral_mock.cpp.hpp"

--- a/src/platforms/shared/mock/esp/32/drivers/rmt4_peripheral_mock.cpp.hpp
+++ b/src/platforms/shared/mock/esp/32/drivers/rmt4_peripheral_mock.cpp.hpp
@@ -1,0 +1,271 @@
+// IWYU pragma: private
+
+/// @file rmt4_peripheral_mock.cpp.hpp
+/// @brief Concrete `Rmt4PeripheralMock` implementation (#3462).
+
+// Host-only. Mirrors the rmt5 mock's gate.
+#include "platforms/is_platform.h"
+#if defined(FASTLED_STUB_IMPL) ||                                              \
+    (!defined(ARDUINO) &&                                                      \
+     (defined(FL_IS_LINUX) || defined(FL_IS_APPLE) || defined(FL_IS_WIN)))
+
+#include "platforms/shared/mock/esp/32/drivers/rmt4_peripheral_mock.h"
+
+#include "fl/log/log.h"
+#include "fl/stl/bit_cast.h"
+#include "fl/stl/cstdlib.h"
+#include "fl/stl/flat_map.h"
+#include "fl/stl/noexcept.h"
+#include "fl/stl/singleton.h"
+
+namespace fl {
+namespace detail {
+
+//=============================================================================
+// Concrete impl (private to this TU)
+//=============================================================================
+
+class Rmt4PeripheralMockImpl : public Rmt4PeripheralMock {
+  public:
+    Rmt4PeripheralMockImpl() FL_NO_EXCEPT
+        : mChannels(),
+          mNextIsrCookie(1),
+          mIsrHandler(nullptr),
+          mIsrArg(nullptr),
+          mIsrCookie(nullptr),
+          mFailConfigureChannel(false),
+          mFailInstallDriver(false),
+          mFailSetTxThresholdIntrEnable(false),
+          mFailSetTxIntrEnable(false),
+          mFailSetGpio(false),
+          mFailInstallIsr(false),
+          mIsrInvocations(0),
+          mLastSimKind(SimulatedKind::NONE),
+          mLastSimChannel(-1) {}
+
+    ~Rmt4PeripheralMockImpl() override = default;
+
+    //=== IRMT4Peripheral =====================================================
+
+    bool configureChannel(const Rmt4ChannelConfig &cfg) FL_NO_EXCEPT override {
+        if (mFailConfigureChannel) {
+            return false;
+        }
+        Rmt4ChannelMockState &state = mChannels[cfg.mChannel];
+        state.last_config = cfg;
+        state.any_call_recorded = true;
+        return true;
+    }
+
+    bool installDriver(int channel) FL_NO_EXCEPT override {
+        if (mFailInstallDriver) {
+            return false;
+        }
+        Rmt4ChannelMockState &state = mChannels[channel];
+        state.driver_installed = true;
+        state.any_call_recorded = true;
+        return true;
+    }
+
+    bool uninstallDriver(int channel) FL_NO_EXCEPT override {
+        Rmt4ChannelMockState &state = mChannels[channel];
+        state.driver_installed = false;
+        state.any_call_recorded = true;
+        return true;
+    }
+
+    bool setTxThresholdIntrEnable(int channel, bool enable,
+                                  u16 threshold) FL_NO_EXCEPT override {
+        if (mFailSetTxThresholdIntrEnable) {
+            return false;
+        }
+        Rmt4ChannelMockState &state = mChannels[channel];
+        state.threshold_intr_enabled = enable;
+        state.last_threshold = threshold;
+        state.any_call_recorded = true;
+        return true;
+    }
+
+    bool setTxIntrEnable(int channel, bool enable) FL_NO_EXCEPT override {
+        if (mFailSetTxIntrEnable) {
+            return false;
+        }
+        Rmt4ChannelMockState &state = mChannels[channel];
+        state.tx_intr_enabled = enable;
+        state.any_call_recorded = true;
+        return true;
+    }
+
+    bool setGpio(int channel, int gpio_pin, bool invert) FL_NO_EXCEPT override {
+        if (mFailSetGpio) {
+            return false;
+        }
+        Rmt4ChannelMockState &state = mChannels[channel];
+        state.last_gpio_pin = gpio_pin;
+        state.last_gpio_invert = invert;
+        state.any_call_recorded = true;
+        return true;
+    }
+
+    bool installIsr(Rmt4IsrHandler handler, void *arg,
+                    void **out_handle) FL_NO_EXCEPT override {
+        if (out_handle == nullptr) {
+            return false;
+        }
+        if (mFailInstallIsr) {
+            *out_handle = nullptr;
+            return false;
+        }
+        mIsrHandler = handler;
+        mIsrArg = arg;
+        // Hand back a unique non-null cookie. We just monotonically
+        // bump a counter and cast it to void* — the test only needs
+        // identity comparison and non-null check.
+        intptr_t cookie_id = mNextIsrCookie++;
+        mIsrCookie = fl::bit_cast<void *>(cookie_id);
+        *out_handle = mIsrCookie;
+        return true;
+    }
+
+    void freeIsr(void *handle) FL_NO_EXCEPT override {
+        // Only clear if the caller passed back the cookie we issued.
+        // Spurious nullptr calls are a no-op (matches the real impl).
+        if (handle == nullptr) {
+            return;
+        }
+        if (handle == mIsrCookie) {
+            mIsrHandler = nullptr;
+            mIsrArg = nullptr;
+            mIsrCookie = nullptr;
+        }
+    }
+
+    //=== Mock-only simulation ================================================
+
+    void simulateThresholdInterrupt(int channel) FL_NO_EXCEPT override {
+        mLastSimKind = SimulatedKind::THRESHOLD;
+        mLastSimChannel = channel;
+        invokeIsr();
+    }
+
+    void simulateTxDoneInterrupt(int channel) FL_NO_EXCEPT override {
+        mLastSimKind = SimulatedKind::TX_DONE;
+        mLastSimChannel = channel;
+        invokeIsr();
+    }
+
+    SimulatedKind lastSimulatedKind() const FL_NO_EXCEPT override {
+        return mLastSimKind;
+    }
+
+    int lastSimulatedChannel() const FL_NO_EXCEPT override {
+        return mLastSimChannel;
+    }
+
+    u32 isrInvocationCount() const FL_NO_EXCEPT override {
+        return mIsrInvocations;
+    }
+
+    //=== Error injection =====================================================
+
+    void setConfigureChannelFailure(bool fail) FL_NO_EXCEPT override {
+        mFailConfigureChannel = fail;
+    }
+    void setInstallDriverFailure(bool fail) FL_NO_EXCEPT override {
+        mFailInstallDriver = fail;
+    }
+    void setTxThresholdIntrEnableFailure(bool fail) FL_NO_EXCEPT override {
+        mFailSetTxThresholdIntrEnable = fail;
+    }
+    void setTxIntrEnableFailure(bool fail) FL_NO_EXCEPT override {
+        mFailSetTxIntrEnable = fail;
+    }
+    void setGpioFailure(bool fail) FL_NO_EXCEPT override {
+        mFailSetGpio = fail;
+    }
+    void setInstallIsrFailure(bool fail) FL_NO_EXCEPT override {
+        mFailInstallIsr = fail;
+    }
+
+    //=== State inspection ====================================================
+
+    const Rmt4ChannelMockState &
+    getChannelState(int channel) const FL_NO_EXCEPT override {
+        auto it = mChannels.find(channel);
+        if (it == mChannels.end()) {
+            return mEmptyState;
+        }
+        return it->second;
+    }
+
+    bool isIsrRegistered() const FL_NO_EXCEPT override {
+        return mIsrCookie != nullptr;
+    }
+
+    Rmt4IsrHandler getRegisteredIsrHandler() const FL_NO_EXCEPT override {
+        return mIsrHandler;
+    }
+
+    void *getRegisteredIsrArg() const FL_NO_EXCEPT override { return mIsrArg; }
+
+    //=== Reset ==============================================================
+
+    void reset() FL_NO_EXCEPT override {
+        mChannels.clear();
+        mIsrHandler = nullptr;
+        mIsrArg = nullptr;
+        mIsrCookie = nullptr;
+        // mNextIsrCookie intentionally NOT reset — keeps cookies
+        // monotonically unique across resets within a process, which
+        // makes cookie-aliasing bugs in callers easier to spot.
+        mFailConfigureChannel = false;
+        mFailInstallDriver = false;
+        mFailSetTxThresholdIntrEnable = false;
+        mFailSetTxIntrEnable = false;
+        mFailSetGpio = false;
+        mFailInstallIsr = false;
+        mIsrInvocations = 0;
+        mLastSimKind = SimulatedKind::NONE;
+        mLastSimChannel = -1;
+    }
+
+  private:
+    void invokeIsr() FL_NO_EXCEPT {
+        if (mIsrHandler != nullptr) {
+            ++mIsrInvocations;
+            (*mIsrHandler)(mIsrArg);
+        }
+    }
+
+    fl::flat_map<int, Rmt4ChannelMockState> mChannels;
+    Rmt4ChannelMockState mEmptyState; // returned when channel unknown
+
+    intptr_t mNextIsrCookie;
+    Rmt4IsrHandler mIsrHandler;
+    void *mIsrArg;
+    void *mIsrCookie;
+
+    bool mFailConfigureChannel;
+    bool mFailInstallDriver;
+    bool mFailSetTxThresholdIntrEnable;
+    bool mFailSetTxIntrEnable;
+    bool mFailSetGpio;
+    bool mFailInstallIsr;
+
+    u32 mIsrInvocations;
+    SimulatedKind mLastSimKind;
+    int mLastSimChannel;
+};
+
+//=============================================================================
+// Singleton accessor
+//=============================================================================
+
+Rmt4PeripheralMock &Rmt4PeripheralMock::instance() FL_NO_EXCEPT {
+    return Singleton<Rmt4PeripheralMockImpl>::instance();
+}
+
+} // namespace detail
+} // namespace fl
+
+#endif // host build

--- a/src/platforms/shared/mock/esp/32/drivers/rmt4_peripheral_mock.h
+++ b/src/platforms/shared/mock/esp/32/drivers/rmt4_peripheral_mock.h
@@ -1,0 +1,231 @@
+/// @file rmt4_peripheral_mock.h
+/// @brief Mock RMT4 peripheral for host-side unit testing (#3462).
+///
+/// Follows the `Rmt5PeripheralMock` / `UartPeripheralMock` pattern:
+///
+/// - Abstract public class. Concrete `Rmt4PeripheralMockImpl` lives in
+///   the `.cpp.hpp` so test TUs never see ESP-IDF types.
+/// - Singleton via `fl::Singleton<Impl>` — there is only one RMT
+///   peripheral on real silicon, so the mock matches that.
+/// - **Single-threaded by design.** No `std::thread`, no
+///   `std::condition_variable`, no async callbacks. Tests advance
+///   simulation manually via `simulateThresholdInterrupt()` /
+///   `simulateTxDoneInterrupt()` which invoke the stored ISR handler
+///   synchronously on the test thread.
+/// - Error-injection knobs for each lifecycle entry point so the
+///   engine's negative-path branches can be exercised.
+///
+/// ## Why no threads
+///
+/// The engine's ISR is `void(*)(void* arg)` and the FastLED unit-test
+/// framework runs tests sequentially. Spawning a thread inside the
+/// mock to "deliver" the interrupt would (a) introduce races between
+/// the test thread and the simulation thread, (b) defeat the
+/// deterministic ordering FL_CHECK assertions depend on, and (c) bind
+/// every test to a `join()` or `sleep()` for timing. The peer mocks
+/// (`Rmt5PeripheralMock`, `UartPeripheralMock`, the FlexIO one, etc.)
+/// all deliberately stay on the test thread; this one does too.
+///
+/// ## Usage
+///
+/// ```cpp
+/// auto& mock = Rmt4PeripheralMock::instance();
+/// mock.reset();
+///
+/// detail::Rmt4ChannelConfig cfg(0, 18, 2, 2, 64);
+/// FL_CHECK(mock.configureChannel(cfg));
+/// FL_CHECK(mock.installDriver(0));
+///
+/// void* cookie = nullptr;
+/// FL_CHECK(mock.installIsr(&my_handler, &my_ctx, &cookie));
+/// FL_CHECK(cookie != nullptr);
+///
+/// // Fire the ISR synchronously from the test thread.
+/// mock.simulateThresholdInterrupt(0);
+/// ```
+///
+/// ## What this mock does NOT cover
+///
+/// The engine's IRAM ISR (`ChannelEngineRMT4Impl::handleInterrupt`)
+/// reads `RMT.int_st.val` and writes `RMT.int_clr.val` directly —
+/// those globals don't exist on the host. So integration tests that
+/// instantiate `ChannelEngineRMT4Impl` against this mock are blocked
+/// on a separate "host-build support for RMT register stubs" task,
+/// not on the mock. This file covers the **mock's own contract** in
+/// full; engine-level integration is a follow-up.
+
+#pragma once
+
+// IWYU pragma: private
+
+// Mock implementation has no platform guards — runs on all platforms
+// for testing. Mirrors `Rmt5PeripheralMock`.
+
+#include "fl/stl/cstddef.h"
+#include "fl/stl/noexcept.h"
+#include "fl/stl/stdint.h"
+#include "fl/stl/vector.h"
+#include "platforms/esp/32/drivers/rmt/rmt_4/irmt4_peripheral.h"
+
+namespace fl {
+namespace detail {
+
+//=============================================================================
+// Mock Peripheral Interface (abstract — concrete impl is in .cpp.hpp)
+//=============================================================================
+
+/// @brief Recorded state for one RMT channel in the mock.
+///
+/// Tests use this to assert that the engine made the right lifecycle
+/// calls with the right arguments. Mirrors the per-channel hardware
+/// state that the real `Rmt4PeripheralESP` would push into silicon.
+struct Rmt4ChannelMockState {
+    Rmt4ChannelConfig last_config;
+    bool driver_installed;
+    bool threshold_intr_enabled;
+    u16 last_threshold;
+    bool tx_intr_enabled;
+    int last_gpio_pin;
+    bool last_gpio_invert;
+    bool any_call_recorded;
+
+    Rmt4ChannelMockState() FL_NO_EXCEPT : last_config(),
+                                          driver_installed(false),
+                                          threshold_intr_enabled(false),
+                                          last_threshold(0),
+                                          tx_intr_enabled(false),
+                                          last_gpio_pin(-1),
+                                          last_gpio_invert(false),
+                                          any_call_recorded(false) {}
+};
+
+/// @brief Mock RMT4 peripheral. Abstract — use `instance()`.
+class Rmt4PeripheralMock : public IRMT4Peripheral {
+  public:
+    //=========================================================================
+    // Singleton Access
+    //=========================================================================
+
+    /// @brief Get the singleton mock peripheral instance.
+    ///
+    /// Mirrors the hardware constraint that there is only one RMT
+    /// peripheral on real silicon. Instance is constructed on first
+    /// access and persists for the program lifetime.
+    static Rmt4PeripheralMock &instance() FL_NO_EXCEPT;
+
+    //=========================================================================
+    // Lifecycle
+    //=========================================================================
+
+    ~Rmt4PeripheralMock() override = default;
+
+    //=========================================================================
+    // IRMT4Peripheral interface — implementations record into the mock state.
+    //=========================================================================
+
+    bool
+    configureChannel(const Rmt4ChannelConfig &cfg) FL_NO_EXCEPT override = 0;
+    bool installDriver(int channel) FL_NO_EXCEPT override = 0;
+    bool uninstallDriver(int channel) FL_NO_EXCEPT override = 0;
+    bool setTxThresholdIntrEnable(int channel, bool enable,
+                                  u16 threshold) FL_NO_EXCEPT override = 0;
+    bool setTxIntrEnable(int channel, bool enable) FL_NO_EXCEPT override = 0;
+    bool setGpio(int channel, int gpio_pin,
+                 bool invert) FL_NO_EXCEPT override = 0;
+    bool installIsr(Rmt4IsrHandler handler, void *arg,
+                    void **out_handle) FL_NO_EXCEPT override = 0;
+    void freeIsr(void *handle) FL_NO_EXCEPT override = 0;
+
+    //=========================================================================
+    // Mock-only Simulation API (no threads — runs on the calling thread)
+    //=========================================================================
+
+    /// @brief Invoke the stored ISR handler synchronously on the
+    ///        calling thread, simulating a half-buffer threshold
+    ///        interrupt for `channel`.
+    ///
+    /// The real engine's ISR (`ChannelEngineRMT4Impl::handleInterrupt`)
+    /// reads `RMT.int_st.val` to decide which channels fired. The mock
+    /// records `channel` for inspection but the handler itself is
+    /// what gets called — the handler decides what to do with the bit
+    /// based on the captured channel.
+    ///
+    /// Use `simulateThresholdInterrupt(ch)` followed by inspecting
+    /// `lastSimulatedChannel()` and `lastSimulatedKind()` from the
+    /// handler under test.
+    virtual void simulateThresholdInterrupt(int channel) FL_NO_EXCEPT = 0;
+
+    /// @brief Simulate a TX-done interrupt for `channel`. Same
+    ///        delivery semantics as `simulateThresholdInterrupt()`.
+    virtual void simulateTxDoneInterrupt(int channel) FL_NO_EXCEPT = 0;
+
+    /// @brief Kind of the most recent simulated interrupt.
+    enum class SimulatedKind { NONE, THRESHOLD, TX_DONE };
+
+    /// @brief Return the kind of the last `simulate*Interrupt()` call.
+    virtual SimulatedKind lastSimulatedKind() const FL_NO_EXCEPT = 0;
+
+    /// @brief Return the channel number passed to the last
+    ///        `simulate*Interrupt()` call. -1 if no simulation has
+    ///        fired since the most recent `reset()`.
+    virtual int lastSimulatedChannel() const FL_NO_EXCEPT = 0;
+
+    /// @brief Number of times the stored ISR handler has been invoked
+    ///        since the most recent `reset()`.
+    virtual u32 isrInvocationCount() const FL_NO_EXCEPT = 0;
+
+    //=========================================================================
+    // Error-injection knobs
+    //=========================================================================
+
+    /// @brief Make the next `configureChannel()` call return false.
+    /// @param fail true = next call fails; false = clear the flag.
+    virtual void setConfigureChannelFailure(bool fail) FL_NO_EXCEPT = 0;
+
+    /// @brief Make the next `installDriver()` call return false.
+    virtual void setInstallDriverFailure(bool fail) FL_NO_EXCEPT = 0;
+
+    /// @brief Make the next `setTxThresholdIntrEnable()` call return false.
+    virtual void setTxThresholdIntrEnableFailure(bool fail) FL_NO_EXCEPT = 0;
+
+    /// @brief Make the next `setTxIntrEnable()` call return false.
+    virtual void setTxIntrEnableFailure(bool fail) FL_NO_EXCEPT = 0;
+
+    /// @brief Make the next `setGpio()` call return false.
+    virtual void setGpioFailure(bool fail) FL_NO_EXCEPT = 0;
+
+    /// @brief Make the next `installIsr()` call return false (and
+    ///        leave `*out_handle = nullptr`).
+    virtual void setInstallIsrFailure(bool fail) FL_NO_EXCEPT = 0;
+
+    //=========================================================================
+    // Read-only state inspection
+    //=========================================================================
+
+    /// @brief Get the recorded state for `channel`. Channel index is
+    ///        the same value the engine passed to the lifecycle calls.
+    virtual const Rmt4ChannelMockState &
+    getChannelState(int channel) const FL_NO_EXCEPT = 0;
+
+    /// @brief Return true iff `installIsr()` has been called and the
+    ///        cookie has not been freed.
+    virtual bool isIsrRegistered() const FL_NO_EXCEPT = 0;
+
+    /// @brief Return the handler registered via `installIsr()`. Null
+    ///        if no ISR is currently registered.
+    virtual Rmt4IsrHandler getRegisteredIsrHandler() const FL_NO_EXCEPT = 0;
+
+    /// @brief Return the `arg` registered via `installIsr()`.
+    virtual void *getRegisteredIsrArg() const FL_NO_EXCEPT = 0;
+
+    //=========================================================================
+    // Reset
+    //=========================================================================
+
+    /// @brief Reset mock to initial state. Clears all per-channel
+    ///        state, error-injection flags, and ISR registration.
+    virtual void reset() FL_NO_EXCEPT = 0;
+};
+
+} // namespace detail
+} // namespace fl

--- a/tests/platforms/shared/mock/esp/32/drivers/rmt4_peripheral_mock.cpp
+++ b/tests/platforms/shared/mock/esp/32/drivers/rmt4_peripheral_mock.cpp
@@ -1,0 +1,401 @@
+/// @file rmt4_peripheral_mock.cpp
+/// @brief Tests for `Rmt4PeripheralMock` (#3462).
+///
+/// Covers the mock's own contract:
+/// - Per-channel lifecycle recording (configure / install / uninstall /
+///   threshold-intr / tx-intr / gpio).
+/// - ISR install / free cookie symmetry.
+/// - Synchronous `simulate*Interrupt()` delivery on the test thread.
+/// - Error-injection knobs for every fallible call site.
+/// - `reset()` returns the mock to a clean state.
+///
+/// Engine-integration tests (`ChannelEngineRMT4Impl` + mock) are NOT
+/// covered here because the engine's IRAM ISR references
+/// `RMT.int_st.val` / `RMT.int_clr.val` which don't exist on the host
+/// build. Once host-build RMT register stubs land that integration can
+/// be added in a follow-up.
+
+#ifdef FASTLED_STUB_IMPL // Host-only — the mock has no platform guard
+                         // but production builds shouldn't pull in tests.
+
+#include "platforms/shared/mock/esp/32/drivers/rmt4_peripheral_mock.h"
+#include "fl/stl/cstddef.h"
+#include "fl/stl/stdint.h"
+#include "test.h"
+
+using namespace fl;
+using namespace fl::detail;
+
+namespace {
+
+/// @brief Static counter incremented by `countingHandler` to verify the
+///        mock actually invokes the registered ISR.
+static u32 s_handler_calls = 0;
+
+/// @brief Static arg pointer captured by the most recent
+///        `countingHandler` call. Lets tests verify that the mock
+///        passes the right `arg` through to the handler.
+static void *s_handler_last_arg = nullptr;
+
+extern "C" void countingHandler(void *arg) {
+    ++s_handler_calls;
+    s_handler_last_arg = arg;
+}
+
+void resetMockState() {
+    Rmt4PeripheralMock::instance().reset();
+    s_handler_calls = 0;
+    s_handler_last_arg = nullptr;
+}
+
+} // anonymous namespace
+
+//=============================================================================
+// Channel lifecycle recording
+//=============================================================================
+
+FL_TEST_CASE("RMT4 mock - configureChannel records exact arguments") {
+    resetMockState();
+    auto &mock = Rmt4PeripheralMock::instance();
+
+    Rmt4ChannelConfig cfg(/*channel=*/3, /*gpio=*/18, /*clk_div=*/2,
+                          /*mem_blocks=*/2, /*threshold=*/64);
+    FL_CHECK(mock.configureChannel(cfg));
+
+    const auto &state = mock.getChannelState(3);
+    FL_CHECK(state.any_call_recorded);
+    FL_CHECK(state.last_config.mChannel == 3);
+    FL_CHECK(state.last_config.mGpioPin == 18);
+    FL_CHECK(state.last_config.mClockDivider == 2u);
+    FL_CHECK(state.last_config.mMemBlocks == 2u);
+    FL_CHECK(state.last_config.mTxThreshold == 64u);
+}
+
+FL_TEST_CASE("RMT4 mock - install/uninstall toggles driver_installed flag") {
+    resetMockState();
+    auto &mock = Rmt4PeripheralMock::instance();
+
+    FL_CHECK(mock.installDriver(0));
+    FL_CHECK(mock.getChannelState(0).driver_installed);
+
+    FL_CHECK(mock.uninstallDriver(0));
+    FL_CHECK_FALSE(mock.getChannelState(0).driver_installed);
+}
+
+FL_TEST_CASE(
+    "RMT4 mock - setTxThresholdIntrEnable records enable + threshold") {
+    resetMockState();
+    auto &mock = Rmt4PeripheralMock::instance();
+
+    FL_CHECK(mock.setTxThresholdIntrEnable(2, true, 128));
+    const auto &state = mock.getChannelState(2);
+    FL_CHECK(state.threshold_intr_enabled);
+    FL_CHECK(state.last_threshold == 128u);
+
+    FL_CHECK(mock.setTxThresholdIntrEnable(2, false, 0));
+    FL_CHECK_FALSE(mock.getChannelState(2).threshold_intr_enabled);
+}
+
+FL_TEST_CASE("RMT4 mock - setTxIntrEnable records the enable bit") {
+    resetMockState();
+    auto &mock = Rmt4PeripheralMock::instance();
+
+    FL_CHECK(mock.setTxIntrEnable(1, true));
+    FL_CHECK(mock.getChannelState(1).tx_intr_enabled);
+
+    FL_CHECK(mock.setTxIntrEnable(1, false));
+    FL_CHECK_FALSE(mock.getChannelState(1).tx_intr_enabled);
+}
+
+FL_TEST_CASE("RMT4 mock - setGpio records pin and invert") {
+    resetMockState();
+    auto &mock = Rmt4PeripheralMock::instance();
+
+    FL_CHECK(mock.setGpio(/*channel=*/4, /*gpio_pin=*/19, /*invert=*/true));
+    const auto &state = mock.getChannelState(4);
+    FL_CHECK(state.last_gpio_pin == 19);
+    FL_CHECK(state.last_gpio_invert);
+}
+
+FL_TEST_CASE("RMT4 mock - multiple channels record independently") {
+    resetMockState();
+    auto &mock = Rmt4PeripheralMock::instance();
+
+    mock.setGpio(0, 18, false);
+    mock.setGpio(1, 19, true);
+    mock.installDriver(0);
+
+    FL_CHECK(mock.getChannelState(0).last_gpio_pin == 18);
+    FL_CHECK_FALSE(mock.getChannelState(0).last_gpio_invert);
+    FL_CHECK(mock.getChannelState(0).driver_installed);
+
+    FL_CHECK(mock.getChannelState(1).last_gpio_pin == 19);
+    FL_CHECK(mock.getChannelState(1).last_gpio_invert);
+    FL_CHECK_FALSE(mock.getChannelState(1).driver_installed);
+}
+
+//=============================================================================
+// ISR install/free cookie symmetry
+//=============================================================================
+
+FL_TEST_CASE("RMT4 mock - installIsr returns unique non-null cookie") {
+    resetMockState();
+    auto &mock = Rmt4PeripheralMock::instance();
+
+    int ctx = 42;
+    void *cookie = nullptr;
+    FL_CHECK(mock.installIsr(&countingHandler, &ctx, &cookie));
+    FL_CHECK(cookie != nullptr);
+    FL_CHECK(mock.isIsrRegistered());
+    FL_CHECK(mock.getRegisteredIsrHandler() == &countingHandler);
+    FL_CHECK(mock.getRegisteredIsrArg() == &ctx);
+}
+
+FL_TEST_CASE("RMT4 mock - freeIsr with the issued cookie clears registration") {
+    resetMockState();
+    auto &mock = Rmt4PeripheralMock::instance();
+
+    int ctx = 0;
+    void *cookie = nullptr;
+    FL_CHECK(mock.installIsr(&countingHandler, &ctx, &cookie));
+
+    mock.freeIsr(cookie);
+    FL_CHECK_FALSE(mock.isIsrRegistered());
+    FL_CHECK(mock.getRegisteredIsrHandler() == nullptr);
+    FL_CHECK(mock.getRegisteredIsrArg() == nullptr);
+}
+
+FL_TEST_CASE("RMT4 mock - free-then-install hands back a fresh cookie") {
+    resetMockState();
+    auto &mock = Rmt4PeripheralMock::instance();
+
+    int ctx = 0;
+    void *cookie_a = nullptr;
+    void *cookie_b = nullptr;
+    FL_CHECK(mock.installIsr(&countingHandler, &ctx, &cookie_a));
+    mock.freeIsr(cookie_a);
+    FL_CHECK(mock.installIsr(&countingHandler, &ctx, &cookie_b));
+
+    FL_CHECK(cookie_a != cookie_b);
+    FL_CHECK(cookie_b != nullptr);
+}
+
+FL_TEST_CASE("RMT4 mock - freeIsr with nullptr or stale cookie is a no-op") {
+    resetMockState();
+    auto &mock = Rmt4PeripheralMock::instance();
+
+    int ctx = 0;
+    void *cookie = nullptr;
+    FL_CHECK(mock.installIsr(&countingHandler, &ctx, &cookie));
+
+    // Wrong cookie value: registration must stay intact.
+    void *bogus = reinterpret_cast<void *>(0xdeadbeef);
+    mock.freeIsr(bogus);
+    FL_CHECK(mock.isIsrRegistered());
+
+    // Nullptr cookie: no-op.
+    mock.freeIsr(nullptr);
+    FL_CHECK(mock.isIsrRegistered());
+
+    // Real cookie: clears.
+    mock.freeIsr(cookie);
+    FL_CHECK_FALSE(mock.isIsrRegistered());
+}
+
+FL_TEST_CASE("RMT4 mock - installIsr with null out_handle returns false") {
+    resetMockState();
+    auto &mock = Rmt4PeripheralMock::instance();
+
+    int ctx = 0;
+    FL_CHECK_FALSE(mock.installIsr(&countingHandler, &ctx, /*out=*/nullptr));
+    FL_CHECK_FALSE(mock.isIsrRegistered());
+}
+
+//=============================================================================
+// Synchronous interrupt simulation (no threads)
+//=============================================================================
+
+FL_TEST_CASE("RMT4 mock - simulateThresholdInterrupt invokes the stored ISR") {
+    resetMockState();
+    auto &mock = Rmt4PeripheralMock::instance();
+
+    int ctx = 0;
+    void *cookie = nullptr;
+    FL_CHECK(mock.installIsr(&countingHandler, &ctx, &cookie));
+
+    mock.simulateThresholdInterrupt(/*channel=*/3);
+
+    FL_CHECK(s_handler_calls == 1u);
+    FL_CHECK(s_handler_last_arg == &ctx);
+    FL_CHECK(mock.isrInvocationCount() == 1u);
+    FL_CHECK(mock.lastSimulatedKind() ==
+             Rmt4PeripheralMock::SimulatedKind::THRESHOLD);
+    FL_CHECK(mock.lastSimulatedChannel() == 3);
+}
+
+FL_TEST_CASE("RMT4 mock - simulateTxDoneInterrupt invokes the stored ISR") {
+    resetMockState();
+    auto &mock = Rmt4PeripheralMock::instance();
+
+    int ctx = 0;
+    void *cookie = nullptr;
+    FL_CHECK(mock.installIsr(&countingHandler, &ctx, &cookie));
+
+    mock.simulateTxDoneInterrupt(/*channel=*/7);
+
+    FL_CHECK(s_handler_calls == 1u);
+    FL_CHECK(mock.lastSimulatedKind() ==
+             Rmt4PeripheralMock::SimulatedKind::TX_DONE);
+    FL_CHECK(mock.lastSimulatedChannel() == 7);
+}
+
+FL_TEST_CASE("RMT4 mock - simulate without an installed ISR is a no-op") {
+    resetMockState();
+    auto &mock = Rmt4PeripheralMock::instance();
+
+    // No installIsr() yet. simulate*Interrupt() must not crash and
+    // must not bump the invocation count.
+    mock.simulateThresholdInterrupt(0);
+    mock.simulateTxDoneInterrupt(0);
+    FL_CHECK(s_handler_calls == 0u);
+    FL_CHECK(mock.isrInvocationCount() == 0u);
+
+    // Sentinel state is still recorded though — the simulate calls
+    // themselves are observable through last*() even without a handler.
+    FL_CHECK(mock.lastSimulatedKind() ==
+             Rmt4PeripheralMock::SimulatedKind::TX_DONE);
+    FL_CHECK(mock.lastSimulatedChannel() == 0);
+}
+
+FL_TEST_CASE("RMT4 mock - multiple simulations accumulate invocation count") {
+    resetMockState();
+    auto &mock = Rmt4PeripheralMock::instance();
+
+    int ctx = 0;
+    void *cookie = nullptr;
+    mock.installIsr(&countingHandler, &ctx, &cookie);
+
+    mock.simulateThresholdInterrupt(0);
+    mock.simulateThresholdInterrupt(0);
+    mock.simulateTxDoneInterrupt(0);
+
+    FL_CHECK(s_handler_calls == 3u);
+    FL_CHECK(mock.isrInvocationCount() == 3u);
+}
+
+//=============================================================================
+// Error injection
+//=============================================================================
+
+FL_TEST_CASE("RMT4 mock - setConfigureChannelFailure makes configure fail") {
+    resetMockState();
+    auto &mock = Rmt4PeripheralMock::instance();
+
+    mock.setConfigureChannelFailure(true);
+    Rmt4ChannelConfig cfg(0, 18, 2, 2, 64);
+    FL_CHECK_FALSE(mock.configureChannel(cfg));
+    // Nothing was recorded for the channel.
+    FL_CHECK_FALSE(mock.getChannelState(0).any_call_recorded);
+
+    mock.setConfigureChannelFailure(false);
+    FL_CHECK(mock.configureChannel(cfg));
+    FL_CHECK(mock.getChannelState(0).any_call_recorded);
+}
+
+FL_TEST_CASE("RMT4 mock - setInstallDriverFailure makes installDriver fail") {
+    resetMockState();
+    auto &mock = Rmt4PeripheralMock::instance();
+
+    mock.setInstallDriverFailure(true);
+    FL_CHECK_FALSE(mock.installDriver(0));
+    FL_CHECK_FALSE(mock.getChannelState(0).driver_installed);
+
+    mock.setInstallDriverFailure(false);
+    FL_CHECK(mock.installDriver(0));
+    FL_CHECK(mock.getChannelState(0).driver_installed);
+}
+
+FL_TEST_CASE("RMT4 mock - setTxThresholdIntrEnableFailure makes call fail") {
+    resetMockState();
+    auto &mock = Rmt4PeripheralMock::instance();
+    mock.setTxThresholdIntrEnableFailure(true);
+    FL_CHECK_FALSE(mock.setTxThresholdIntrEnable(0, true, 64));
+    FL_CHECK_FALSE(mock.getChannelState(0).threshold_intr_enabled);
+}
+
+FL_TEST_CASE("RMT4 mock - setTxIntrEnableFailure makes call fail") {
+    resetMockState();
+    auto &mock = Rmt4PeripheralMock::instance();
+    mock.setTxIntrEnableFailure(true);
+    FL_CHECK_FALSE(mock.setTxIntrEnable(0, true));
+    FL_CHECK_FALSE(mock.getChannelState(0).tx_intr_enabled);
+}
+
+FL_TEST_CASE("RMT4 mock - setGpioFailure makes call fail") {
+    resetMockState();
+    auto &mock = Rmt4PeripheralMock::instance();
+    mock.setGpioFailure(true);
+    FL_CHECK_FALSE(mock.setGpio(0, 18, false));
+    // last_gpio_pin sentinel is still -1 (unset).
+    FL_CHECK(mock.getChannelState(0).last_gpio_pin == -1);
+}
+
+FL_TEST_CASE("RMT4 mock - setInstallIsrFailure clears out_handle to nullptr") {
+    resetMockState();
+    auto &mock = Rmt4PeripheralMock::instance();
+
+    int ctx = 0;
+    void *cookie = reinterpret_cast<void *>(0xfeedface);
+    mock.setInstallIsrFailure(true);
+
+    FL_CHECK_FALSE(mock.installIsr(&countingHandler, &ctx, &cookie));
+    FL_CHECK(cookie == nullptr);
+    FL_CHECK_FALSE(mock.isIsrRegistered());
+}
+
+//=============================================================================
+// reset()
+//=============================================================================
+
+FL_TEST_CASE("RMT4 mock - reset clears all per-channel state and flags") {
+    resetMockState();
+    auto &mock = Rmt4PeripheralMock::instance();
+
+    // Populate everything.
+    Rmt4ChannelConfig cfg(0, 18, 2, 2, 64);
+    mock.configureChannel(cfg);
+    mock.installDriver(0);
+    mock.setTxThresholdIntrEnable(0, true, 64);
+    mock.setGpio(0, 18, true);
+
+    int ctx = 0;
+    void *cookie = nullptr;
+    mock.installIsr(&countingHandler, &ctx, &cookie);
+    mock.simulateThresholdInterrupt(0);
+
+    mock.setConfigureChannelFailure(true);
+    mock.setInstallDriverFailure(true);
+
+    // Sanity: state is populated.
+    FL_REQUIRE(mock.getChannelState(0).driver_installed);
+    FL_REQUIRE(mock.isIsrRegistered());
+    FL_REQUIRE(mock.isrInvocationCount() == 1u);
+
+    // Reset.
+    mock.reset();
+
+    FL_CHECK_FALSE(mock.getChannelState(0).any_call_recorded);
+    FL_CHECK_FALSE(mock.getChannelState(0).driver_installed);
+    FL_CHECK_FALSE(mock.isIsrRegistered());
+    FL_CHECK(mock.isrInvocationCount() == 0u);
+    FL_CHECK(mock.lastSimulatedKind() ==
+             Rmt4PeripheralMock::SimulatedKind::NONE);
+    FL_CHECK(mock.lastSimulatedChannel() == -1);
+
+    // Error-injection flags must have been cleared too — otherwise
+    // the next test in the same process would see stale failures.
+    FL_CHECK(mock.configureChannel(cfg));
+    FL_CHECK(mock.installDriver(0));
+}
+
+#endif // FASTLED_STUB_IMPL


### PR DESCRIPTION
## Summary

Adds the host-side test seam the `IRMT4Peripheral` wrapper from #3458 (PR #3461) was built for. Mirrors `Rmt5PeripheralMock` exactly — abstract public class + concrete `Impl` private to `.cpp.hpp`, singleton matching the real-hardware "one RMT peripheral" constraint, and **single-threaded by design** (no `std::thread`, no condition variable, no async callbacks). Tests advance the simulation manually via `simulateThresholdInterrupt(ch)` / `simulateTxDoneInterrupt(ch)` which invoke the stored ISR handler synchronously on the test thread. The peer mocks (rmt5, uart, flexio, parlio, i2s_lcd_cam, objectfled, lpuart) all follow the same pattern.

Closes #3462.

## Coverage — 22 tests, all pass

```
[doctest] test cases: 22 | 22 passed | 0 failed
```

| Group | Cases |
|---|---|
| Channel lifecycle recording | configure / install+uninstall / threshold-intr / tx-intr / setGpio / multi-channel independence |
| ISR cookie symmetry | install returns unique non-null cookie / free clears registration / free-then-install hands back fresh cookie / nullptr+stale cookies are no-ops / null out_handle returns false |
| Simulation API (single-threaded) | threshold fires handler / tx-done fires handler / simulate without handler is no-op / multiple sims accumulate count |
| Error injection | every fallible call (configure / install / threshold-intr / tx-intr / gpio / installIsr) returns false when the knob is set; state stays untouched |
| Reset | clears per-channel state, ISR registration, error flags, invocation count, sentinels (cookies intentionally stay monotonic across resets) |

## What's NOT here (issue points 3–9)

The issue listed engine-integration tests that instantiate `ChannelEngineRMT4Impl` against the mock and exercise the three `acquireChannel` strategies, channel exhaustion via `mPendingChannels`, and the `BUSY → READY` poll cycle. Those are **blocked by a separate gap** — the engine's IRAM ISR (`handleInterrupt`) references `RMT.int_st.val` and `RMT.int_clr.val` directly, neither of which exists on the host build. Adding host stubs for the RMT register globals is a follow-up of its own; the mock's contract (what the wrapper exists to support) is fully covered here.

## Side change — `irmt4_peripheral.h` platform guard lifted

The interface header had `#if defined(FL_IS_ESP32) && ...` around its entire body. That blocked host inclusion and would have made the mock unable to see `IRMT4Peripheral` on a host build. Lifting it matches `IRMT5Peripheral`, which has the same docblock comment ("This interface is platform-agnostic (no ESP32 guard)") and no guard. The concrete `Rmt4PeripheralESP` keeps its own guard — that's where the ESP-IDF types come in. No other call sites changed.

## Test plan

- [x] `bash test rmt4_peripheral_mock --cpp --clean` — 22 / 22 pass on a fresh build.
- [x] `bash test --cpp` — full host suite 340 / 340 pass.
- [x] `clang-format --dry-run --Werror` clean on all four new + edited files.
- [ ] On-device validation N/A (the mock is host-only; the production `Rmt4PeripheralESP` is unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added broader host-side support for simulating peripheral behavior, including interrupt handling and channel state tracking.
  * Expanded platform compatibility so the interface is available in more build environments.

* **Tests**
  * Added coverage for simulated interrupts, channel lifecycle events, error handling, and reset behavior.
  * Verified isolation across channels and correct registration behavior for interrupt callbacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->