### PR TITLE
feat(rmt4): port RmtMemoryManager — WiFi-resistant TX + TX/RX ledger (#3469)

### DIFF
--- a/src/platforms/esp/32/drivers/rmt/rmt_4/_build.cpp.hpp
+++ b/src/platforms/esp/32/drivers/rmt/rmt_4/_build.cpp.hpp
@@ -5,7 +5,9 @@
 /// Includes all implementation files in alphabetical order
 
 #include "platforms/esp/32/drivers/rmt/rmt_4/channel_driver_rmt4.cpp.hpp"
+#include "platforms/esp/32/drivers/rmt/rmt_4/network_state_tracker_4.cpp.hpp"
 #include "platforms/esp/32/drivers/rmt/rmt_4/rmt4_peripheral_esp.cpp.hpp"
+#include "platforms/esp/32/drivers/rmt/rmt_4/rmt_memory_manager_4.cpp.hpp"
 
 // BusTraits<Bus::RMT> specialization (RMT4 path, mutually exclusive with RMT5).
 #include "platforms/esp/32/drivers/rmt/rmt_4/bus_traits.h"

--- a/src/platforms/esp/32/drivers/rmt/rmt_4/channel_driver_rmt4.cpp.hpp
+++ b/src/platforms/esp/32/drivers/rmt/rmt_4/channel_driver_rmt4.cpp.hpp
@@ -21,7 +21,9 @@
 #include "fl/stl/move.h" // fl::move
 #include "fl/stl/noexcept.h"
 #include "platforms/esp/32/drivers/rmt/rmt_4/channel_driver_rmt4.h"
+#include "platforms/esp/32/drivers/rmt/rmt_4/network_state_tracker_4.h"
 #include "platforms/esp/32/drivers/rmt/rmt_4/rmt4_peripheral_esp.h"
+#include "platforms/esp/32/drivers/rmt/rmt_4/rmt_memory_manager_4.h"
 
 namespace fl {
 
@@ -96,6 +98,11 @@ ChannelEngineRMT4Impl::~ChannelEngineRMT4Impl() {
                                              false);
                 mPeripheral->uninstallDriver(static_cast<int>(state.channel));
             }
+            // Give the pool word count back to the manager (#3469). A
+            // miss here is silent — the manager already logs on the
+            // free() path.
+            RmtMemoryManager4::instance().free(static_cast<int>(state.channel),
+                                               /*is_tx=*/true);
             state.inUse = false;
         }
     }
@@ -371,11 +378,44 @@ bool ChannelEngineRMT4Impl::configureChannel(
     state->maxCyclesPerFill = state->cyclesPerFill + state->cyclesPerFill / 2;
     state->lastFill = 0;
 
+    // Register the TX allocation with the RMT4 memory manager (#3469).
+    // The manager tracks the global pool (512 words on classic ESP32,
+    // 256 on S2), refuses overallocation, and — once
+    // NetworkStateTracker4 is wired to a real detector — will return
+    // 3 mem blocks instead of 2 during WiFi bursts. Today's stub
+    // always returns 2, so behaviour is bit-for-bit identical to the
+    // pre-#3469 driver until the follow-up flips the network detector
+    // on.
+    //
+    // Free any prior allocation for this channel first, so Strategy 2
+    // (reconfigure an idle channel for a new pin/timing) doesn't hit
+    // the duplicate-alloc check. Silent-miss on the first-time-configure
+    // path is expected.
+    (void)RmtMemoryManager4::instance().free(static_cast<int>(state->channel),
+                                             /*is_tx=*/true);
+
+    const bool network_active = NetworkStateTracker4::instance().isActive();
+    size_t alloc_words = 0;
+    if (!RmtMemoryManager4::instance().tryAllocateTx(
+            static_cast<int>(state->channel), network_active, alloc_words)) {
+        // Pool exhausted — refuse. The caller (acquireChannel) will
+        // treat this the same as a hardware-channel-count miss and
+        // defer this strip to the pending queue.
+        FL_WARN_F("configureChannel: memory manager refused TX allocation "
+                  "on channel %s",
+                  state->channel);
+        return false;
+    }
+
     // Apply the channel configuration via the peripheral.
+    const u8 mem_blocks =
+        RmtMemoryManager4::instance().calculateMemoryBlocks(network_active);
     detail::Rmt4ChannelConfig cfg(static_cast<int>(state->channel),
                                   static_cast<int>(pin), DIVIDER_RMT4,
-                                  FASTLED_RMT_MEM_BLOCKS, PULSES_PER_FILL_RMT4);
+                                  mem_blocks, PULSES_PER_FILL_RMT4);
     if (!mPeripheral->configureChannel(cfg)) {
+        RmtMemoryManager4::instance().free(static_cast<int>(state->channel),
+                                           /*is_tx=*/true);
         return false;
     }
 

--- a/src/platforms/esp/32/drivers/rmt/rmt_4/network_state_tracker_4.cpp.hpp
+++ b/src/platforms/esp/32/drivers/rmt/rmt_4/network_state_tracker_4.cpp.hpp
@@ -1,0 +1,41 @@
+// IWYU pragma: private
+
+/// @file network_state_tracker_4.cpp.hpp
+/// @brief RMT4 network state tracker — stub impl (#3469).
+
+#include "platforms/is_platform.h"
+#ifdef FL_IS_ESP32
+
+#include "fl/stl/compiler_control.h"
+#include "platforms/esp/32/feature_flags/enabled.h"
+
+#if FASTLED_ESP32_HAS_RMT && !FASTLED_ESP32_RMT5_ONLY_PLATFORM && !FASTLED_RMT5
+
+#include "platforms/esp/32/drivers/rmt/rmt_4/network_state_tracker_4.h"
+
+#include "fl/stl/noexcept.h"
+
+namespace fl {
+
+bool NetworkStateTracker4::hasChanged() FL_NO_EXCEPT {
+    // Stub: today's poll always returns false, so no state change is
+    // ever observed. See header docblock for the follow-up plan.
+    bool current = isActive();
+    if (current != mLastKnownState) {
+        mLastKnownState = current;
+        return true;
+    }
+    return false;
+}
+
+bool NetworkStateTracker4::isActive() const FL_NO_EXCEPT {
+    // v1 stub. Follow-up PR wires this to the shared NetworkDetector
+    // once that code is lifted out of the FASTLED_RMT5 guard.
+    return false;
+}
+
+} // namespace fl
+
+#endif // FASTLED_ESP32_HAS_RMT && !FASTLED_ESP32_RMT5_ONLY_PLATFORM &&
+       // !FASTLED_RMT5
+#endif // FL_IS_ESP32

--- a/src/platforms/esp/32/drivers/rmt/rmt_4/network_state_tracker_4.h
+++ b/src/platforms/esp/32/drivers/rmt/rmt_4/network_state_tracker_4.h
@@ -1,0 +1,80 @@
+/// @file network_state_tracker_4.h
+/// @brief Singleton network-state hook for the RMT4 driver (#3469).
+///
+/// The RMT5 sibling
+/// (`../rmt_5/network_state_tracker.h`) polls `NetworkDetector` for
+/// live WiFi / Ethernet / BLE status; that infrastructure is currently
+/// guarded on `FASTLED_RMT5` and would need to be lifted to a shared
+/// location before the RMT4 side can call into it. This v1 provides
+/// the same singleton API — `isActive()` + `hasChanged()` + `reset()`
+/// — with a **stub** always-false implementation so the RMT4 driver
+/// can be wired against the manager today. A follow-up PR flips the
+/// stub to a real detector.
+///
+/// The manager (`RmtMemoryManager4::calculateMemoryBlocks(active)`)
+/// then produces `3` when this returns `true`, giving TX one extra
+/// 64-word block of buffer headroom during WiFi bursts. Until the
+/// detector is real the recommendation stays at the historic RMT4
+/// default of `2`, which matches today's behaviour bit-for-bit.
+
+#pragma once
+
+// IWYU pragma: private
+
+#include "fl/stl/compiler_control.h"
+#include "platforms/is_platform.h"
+
+#ifdef FL_IS_ESP32
+
+#include "platforms/esp/32/feature_flags/enabled.h"
+
+#if FASTLED_ESP32_HAS_RMT && !FASTLED_ESP32_RMT5_ONLY_PLATFORM && !FASTLED_RMT5
+
+#include "fl/stl/noexcept.h"
+#include "fl/stl/singleton.h"
+
+namespace fl {
+
+/// @brief Singleton network-state tracker used by the RMT4 memory
+///        manager. Same public shape as the RMT5 sibling for future
+///        code sharing.
+class NetworkStateTracker4 {
+  public:
+    static NetworkStateTracker4 &instance() FL_NO_EXCEPT {
+        return Singleton<NetworkStateTracker4>::instance();
+    }
+
+    /// @brief Update the cached state and return true iff it changed.
+    ///        Currently a no-op (stub always false).
+    bool hasChanged() FL_NO_EXCEPT;
+
+    /// @brief Read the current network state without touching the cache.
+    ///        Currently stubbed to always return false.
+    ///
+    /// A follow-up PR will change this to poll the (lifted) network
+    /// detector.
+    bool isActive() const FL_NO_EXCEPT;
+
+    /// @brief Last cached value (from the most recent `hasChanged()`).
+    bool lastKnownState() const FL_NO_EXCEPT { return mLastKnownState; }
+
+    /// @brief Test-only: reset the cache to false.
+    void reset() FL_NO_EXCEPT { mLastKnownState = false; }
+
+  private:
+    friend class Singleton<NetworkStateTracker4>;
+
+    NetworkStateTracker4() FL_NO_EXCEPT : mLastKnownState(false) {}
+    ~NetworkStateTracker4() = default;
+
+    NetworkStateTracker4(const NetworkStateTracker4 &) = delete;
+    NetworkStateTracker4 &operator=(const NetworkStateTracker4 &) = delete;
+
+    bool mLastKnownState;
+};
+
+} // namespace fl
+
+#endif // FASTLED_ESP32_HAS_RMT && !FASTLED_ESP32_RMT5_ONLY_PLATFORM &&
+       // !FASTLED_RMT5
+#endif // FL_IS_ESP32

--- a/src/platforms/esp/32/drivers/rmt/rmt_4/rmt_memory_manager_4.cpp.hpp
+++ b/src/platforms/esp/32/drivers/rmt/rmt_4/rmt_memory_manager_4.cpp.hpp
@@ -1,0 +1,57 @@
+// IWYU pragma: private
+
+/// @file rmt_memory_manager_4.cpp.hpp
+/// @brief Platform-default singleton constructor for `RmtMemoryManager4`
+///        (#3469). Class body itself is header-inline — see the .h
+///        for the docblock.
+
+#include "platforms/is_platform.h"
+#ifdef FL_IS_ESP32
+
+#include "fl/stl/compiler_control.h"
+#include "platforms/esp/32/feature_flags/enabled.h"
+
+#if FASTLED_ESP32_HAS_RMT && !FASTLED_ESP32_RMT5_ONLY_PLATFORM && !FASTLED_RMT5
+
+#include "platforms/esp/32/drivers/rmt/rmt_4/rmt_memory_manager_4.h"
+
+// SOC_RMT_MEM_WORDS_PER_CHANNEL is 64 on both classic ESP32 and S2 on
+// IDF 4.x. Guarded fallback in case the SOC header isn't pulled in on
+// some corners of the toolchain.
+#ifndef FASTLED_RMT4_MEM_WORDS_PER_CHANNEL
+#if defined(SOC_RMT_MEM_WORDS_PER_CHANNEL)
+#define FASTLED_RMT4_MEM_WORDS_PER_CHANNEL SOC_RMT_MEM_WORDS_PER_CHANNEL
+#else
+#define FASTLED_RMT4_MEM_WORDS_PER_CHANNEL 64
+#endif
+#endif
+
+namespace fl {
+
+namespace {
+
+/// @brief Total pool size in words for the current platform.
+///        Classic ESP32 = 8 channels × 64 words = 512.
+///        ESP32-S2      = 4 channels × 64 words = 256.
+constexpr size_t platformPoolWords() FL_NO_EXCEPT {
+#if defined(FL_IS_ESP_32S2)
+    return 4 * FASTLED_RMT4_MEM_WORDS_PER_CHANNEL;
+#else
+    return 8 * FASTLED_RMT4_MEM_WORDS_PER_CHANNEL;
+#endif
+}
+
+} // anonymous namespace
+
+RmtMemoryManager4 &RmtMemoryManager4::instance() FL_NO_EXCEPT {
+    // Function-local static: single global manager, constructed on
+    // first use with the platform's pool size baked in.
+    static RmtMemoryManager4 sInstance(platformPoolWords());
+    return sInstance;
+}
+
+} // namespace fl
+
+#endif // FASTLED_ESP32_HAS_RMT && !FASTLED_ESP32_RMT5_ONLY_PLATFORM &&
+       // !FASTLED_RMT5
+#endif // FL_IS_ESP32

--- a/src/platforms/esp/32/drivers/rmt/rmt_4/rmt_memory_manager_4.h
+++ b/src/platforms/esp/32/drivers/rmt/rmt_4/rmt_memory_manager_4.h
@@ -1,0 +1,231 @@
+/// @file rmt_memory_manager_4.h
+/// @brief RMT memory allocation manager for classic ESP32 / IDF 4.x (#3469).
+///
+/// Ported from the RMT5 `RmtMemoryManager`, simplified for the RMT4
+/// hardware model:
+///
+///   - Classic ESP32: 8 flexible RMT channels × 64 words per block =
+///     512 words in a single shared global pool.
+///   - ESP32-S2 (IDF 4 path): 4 flexible channels × 64 words = 256
+///     words in a single shared global pool.
+///   - No DMA on the RMT4 hardware — the entire DMA slot ledger from
+///     the RMT5 sibling is deleted, not ported.
+///
+/// The manager tracks allocations per-channel and exposes the
+/// adaptive-buffer recommendation used by TX during network-active
+/// windows. Wiring the recommendation into `rmt_config.mem_block_num`
+/// gives TX more headroom before the ISR misses its refill deadline
+/// — the reactive `checkTime` truncation in
+/// `channel_driver_rmt4.h::fillNextBuffer` stays as a belt-and-braces
+/// safety net.
+///
+/// **The class body is header-inline** on purpose — it's a pure
+/// accounting ledger with no ESP-IDF dependencies. Host unit tests
+/// build it from the test TU directly (see
+/// `tests/platforms/esp/32/drivers/rmt/rmt_4/rmt_memory_manager_4.cpp`).
+/// Only the platform-default `instance()` singleton constructor lives
+/// out-of-line in the `.cpp.hpp` behind the usual `FL_IS_ESP32 &&
+/// !FASTLED_RMT5` guard.
+
+#pragma once
+
+// IWYU pragma: private
+
+#include "fl/log/log.h"
+#include "fl/stl/compiler_control.h"
+#include "fl/stl/noexcept.h"
+#include "fl/stl/stdint.h"
+#include "fl/stl/vector.h"
+
+namespace fl {
+
+/// @brief Error codes for RMT4 memory allocation.
+enum class RmtMemoryError4 : u8 {
+    OK = 0,
+    INSUFFICIENT_MEMORY = 1,       ///< Global pool exhausted.
+    CHANNEL_ALREADY_ALLOCATED = 2, ///< Channel ID has an active allocation.
+    CHANNEL_NOT_FOUND = 3,         ///< free()/lookup miss.
+    INVALID_CHANNEL_ID = 4,        ///< Channel ID out of range.
+};
+
+/// @brief One record in the ledger. Kept small so the vector stays
+///        cheap even with all channels in use.
+struct RmtAllocation4 {
+    int channel_id; ///< TX: 0..N-1 raw RMT channel. RX: 128 + (pin & 0x7F).
+    u16 words;      ///< Symbol-word count consumed from the pool.
+    bool is_tx;     ///< true if TX, false if RX.
+};
+
+namespace detail {
+/// @brief Words per RMT hardware memory block on classic ESP32 / S2.
+///        Kept as a header-inline constant so the class body doesn't
+///        need to include the ESP-IDF SOC header.
+constexpr size_t kRmt4WordsPerBlock = 64;
+constexpr size_t kRmt4TxIdleWords = 2 * kRmt4WordsPerBlock;
+constexpr size_t kRmt4TxNetworkActiveWords = 3 * kRmt4WordsPerBlock;
+} // namespace detail
+
+/// @brief RMT4 memory allocator — global-pool tracker for classic
+///        ESP32 / S2 with the IDF 4.x driver.
+///
+/// Everything is single-threaded from the RMT4 driver's perspective
+/// (setup and Show run on the Arduino main task). No lock is taken
+/// inside the manager.
+class RmtMemoryManager4 {
+  public:
+    /// @brief Get the platform-default singleton instance. Only
+    ///        defined on `FL_IS_ESP32 && !FASTLED_RMT5` — host tests
+    ///        should use the test-only pool-size constructor below
+    ///        instead.
+    static RmtMemoryManager4 &instance() FL_NO_EXCEPT;
+
+    /// @brief Test-only constructor to inject a custom pool size.
+    explicit RmtMemoryManager4(size_t total_words) FL_NO_EXCEPT
+        : mPoolWords(total_words),
+          mAllocatedWords(0),
+          mAllocations() {
+        mAllocations.reserve(8);
+    }
+
+    ~RmtMemoryManager4() FL_NO_EXCEPT = default;
+
+    RmtMemoryManager4(const RmtMemoryManager4 &) = delete;
+    RmtMemoryManager4 &operator=(const RmtMemoryManager4 &) = delete;
+
+    //=========================================================================
+    // Allocation
+    //=========================================================================
+
+    bool tryAllocateTx(int channel_id, bool network_active,
+                       size_t &out_words) FL_NO_EXCEPT {
+        for (const auto &alloc : mAllocations) {
+            if (alloc.channel_id == channel_id && alloc.is_tx) {
+                FL_WARN_F("RmtMemoryManager4: TX channel %s already allocated",
+                          channel_id);
+                return false;
+            }
+        }
+
+        size_t desired = network_active ? detail::kRmt4TxNetworkActiveWords
+                                        : detail::kRmt4TxIdleWords;
+
+        if (desired > availableWords()) {
+            if (network_active &&
+                detail::kRmt4TxIdleWords <= availableWords()) {
+                desired = detail::kRmt4TxIdleWords; // Graceful demotion.
+            } else {
+                FL_WARN_F("RmtMemoryManager4: TX allocation refused, pool "
+                          "exhausted (want %s, have %s / %s)",
+                          desired, availableWords(), mPoolWords);
+                return false;
+            }
+        }
+
+        RmtAllocation4 rec = {};
+        rec.channel_id = channel_id;
+        rec.words = static_cast<u16>(desired);
+        rec.is_tx = true;
+        mAllocations.push_back(rec);
+        mAllocatedWords += desired;
+        out_words = desired;
+        return true;
+    }
+
+    bool tryAllocateRx(int channel_id, size_t symbols,
+                       size_t &out_words) FL_NO_EXCEPT {
+        for (const auto &alloc : mAllocations) {
+            if (alloc.channel_id == channel_id && !alloc.is_tx) {
+                FL_WARN_F("RmtMemoryManager4: RX channel %s already allocated",
+                          channel_id);
+                return false;
+            }
+        }
+        if (symbols == 0) {
+            FL_WARN_F("RmtMemoryManager4: RX allocation refused, zero symbols");
+            return false;
+        }
+        if (symbols > availableWords()) {
+            FL_WARN_F(
+                "RmtMemoryManager4: RX allocation refused, pool exhausted "
+                "(want %s, have %s / %s)",
+                symbols, availableWords(), mPoolWords);
+            return false;
+        }
+
+        RmtAllocation4 rec = {};
+        rec.channel_id = channel_id;
+        rec.words = static_cast<u16>(symbols);
+        rec.is_tx = false;
+        mAllocations.push_back(rec);
+        mAllocatedWords += symbols;
+        out_words = symbols;
+        return true;
+    }
+
+    /// @brief Release an allocation. Silent on miss — callers use
+    ///        this in a "free-before-reallocate" idiom where the
+    ///        first-time-configure path always misses.
+    bool free(int channel_id, bool is_tx) FL_NO_EXCEPT {
+        for (size_t i = 0; i < mAllocations.size(); ++i) {
+            if (mAllocations[i].channel_id == channel_id &&
+                mAllocations[i].is_tx == is_tx) {
+                mAllocatedWords -= mAllocations[i].words;
+                mAllocations[i] = mAllocations.back();
+                mAllocations.pop_back();
+                return true;
+            }
+        }
+        return false;
+    }
+
+    //=========================================================================
+    // Queries
+    //=========================================================================
+
+    size_t allocatedWords() const FL_NO_EXCEPT { return mAllocatedWords; }
+    size_t poolSize() const FL_NO_EXCEPT { return mPoolWords; }
+    size_t availableWords() const FL_NO_EXCEPT {
+        return (mPoolWords > mAllocatedWords) ? (mPoolWords - mAllocatedWords)
+                                              : 0;
+    }
+
+    bool hasActiveRxChannels() const FL_NO_EXCEPT {
+        for (const auto &alloc : mAllocations) {
+            if (!alloc.is_tx) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// @brief Adaptive-buffer recommendation for a TX channel.
+    /// @param network_active  Result of `NetworkStateTracker4::isActive()`.
+    /// @return 3 (triple-buffer) when the network is active AND the
+    ///         pool has room; otherwise 2 (double-buffer, historic default).
+    u8 calculateMemoryBlocks(bool network_active) const FL_NO_EXCEPT {
+        if (!network_active) {
+            return 2;
+        }
+        constexpr size_t kExtraBlockWords = detail::kRmt4WordsPerBlock;
+        if (availableWords() >= kExtraBlockWords) {
+            return 3;
+        }
+        return 2;
+    }
+
+    //=========================================================================
+    // Test helpers
+    //=========================================================================
+
+    void reset() FL_NO_EXCEPT {
+        mAllocations.clear();
+        mAllocatedWords = 0;
+    }
+
+  private:
+    size_t mPoolWords;
+    size_t mAllocatedWords;
+    fl::vector<RmtAllocation4> mAllocations;
+};
+
+} // namespace fl

--- a/src/platforms/esp/32/drivers/rmt_rx/rmt_rx_4/rmt_rx_channel_4.cpp.hpp
+++ b/src/platforms/esp/32/drivers/rmt_rx/rmt_rx_4/rmt_rx_channel_4.cpp.hpp
@@ -59,6 +59,7 @@
 #include "fl/stl/noexcept.h"
 #include "fl/stl/static_assert.h"
 #include "fl/stl/type_traits.h"
+#include "platforms/esp/32/drivers/rmt/rmt_4/rmt_memory_manager_4.h"
 #include "platforms/esp/esp_version.h"
 
 FL_EXTERN_C_BEGIN
@@ -259,11 +260,33 @@ class RmtRxChannelImpl : public RmtRxChannel {
           mResolutionHz(0),
           mBufferSize(0),
           mInternalBuffer(),
-          mRingbufHandle(nullptr) {
+          mRingbufHandle(nullptr),
+          mMemoryChannelId(128 + (pin & 0x7F)),
+          mMemoryRegistered(false) {
         FL_LOG_RX("RmtRxChannelImpl(pin=" << pin << ") constructed");
+
+        // Pre-register a minimum RX allocation with the RMT4 memory
+        // manager (#3469). Same channel-id offset convention as the
+        // RMT5 sibling (128 + (pin & 0x7F)) so TX (which uses raw
+        // channel numbers 0..7) never collides with an RX record.
+        // Failure is non-fatal — the RX device still constructs; the
+        // caller can retry allocation at begin() time.
+        constexpr size_t kMinRxSymbols = 64;
+        size_t reserved = 0;
+        if (RmtMemoryManager4::instance().tryAllocateRx(
+                mMemoryChannelId, kMinRxSymbols, reserved)) {
+            mMemoryRegistered = true;
+        }
     }
 
-    ~RmtRxChannelImpl() override { teardown(); }
+    ~RmtRxChannelImpl() override {
+        teardown();
+        if (mMemoryRegistered) {
+            (void)RmtMemoryManager4::instance().free(mMemoryChannelId,
+                                                     /*is_tx=*/false);
+            mMemoryRegistered = false;
+        }
+    }
 
     bool begin(const RxConfig &config) FL_NO_EXCEPT override {
         // Re-arm path: if already installed, just clear our buffer and
@@ -564,6 +587,10 @@ class RmtRxChannelImpl : public RmtRxChannel {
     size_t mBufferSize;
     fl::vector<RmtSymbol> mInternalBuffer;
     RingbufHandle_t mRingbufHandle;
+    // RMT4 memory-manager coordination (#3469). RX uses an offset ID so
+    // it doesn't collide with TX's raw 0..N-1 channel numbering.
+    int mMemoryChannelId;
+    bool mMemoryRegistered;
 };
 
 //=============================================================================

--- a/tests/platforms/esp/32/drivers/rmt/rmt_4/rmt_memory_manager_4.cpp
+++ b/tests/platforms/esp/32/drivers/rmt/rmt_4/rmt_memory_manager_4.cpp
@@ -1,0 +1,195 @@
+/// @file rmt_memory_manager_4.cpp
+/// @brief Host tests for `RmtMemoryManager4` (#3469).
+///
+/// The manager is IDF-agnostic (it's a pure accounting ledger with no
+/// ESP-IDF dependencies) so it builds and runs on the host directly.
+/// Tests use the test-only pool-size constructor to control the
+/// assertions independent of the platform's real 512-word pool.
+
+#include "platforms/esp/32/drivers/rmt/rmt_4/rmt_memory_manager_4.h"
+
+#include "fl/stl/cstddef.h"
+#include "test.h"
+
+using namespace fl;
+
+FL_TEST_CASE("RmtMemoryManager4 - pool starts empty") {
+    RmtMemoryManager4 mgr(/*total_words=*/512);
+    FL_CHECK(mgr.poolSize() == 512u);
+    FL_CHECK(mgr.allocatedWords() == 0u);
+    FL_CHECK(mgr.availableWords() == 512u);
+    FL_CHECK_FALSE(mgr.hasActiveRxChannels());
+}
+
+FL_TEST_CASE("RmtMemoryManager4 - TX idle allocation reserves 128 words") {
+    RmtMemoryManager4 mgr(512);
+    size_t got = 0;
+    FL_CHECK(
+        mgr.tryAllocateTx(/*channel_id=*/0, /*network_active=*/false, got));
+    FL_CHECK(got == 128u);
+    FL_CHECK(mgr.allocatedWords() == 128u);
+    FL_CHECK(mgr.availableWords() == 384u);
+}
+
+FL_TEST_CASE(
+    "RmtMemoryManager4 - TX network-active allocation reserves 192 words") {
+    RmtMemoryManager4 mgr(512);
+    size_t got = 0;
+    FL_CHECK(mgr.tryAllocateTx(0, /*network_active=*/true, got));
+    FL_CHECK(got == 192u);
+    FL_CHECK(mgr.allocatedWords() == 192u);
+}
+
+FL_TEST_CASE(
+    "RmtMemoryManager4 - graceful demotion when 192 doesn't fit but 128 does") {
+    // Pool of 150 words: 128 (idle) fits, 192 (network-active) does not.
+    RmtMemoryManager4 mgr(150);
+    size_t got = 0;
+    FL_CHECK(mgr.tryAllocateTx(0, /*network_active=*/true, got));
+    FL_CHECK(got == 128u); // Demoted from 192.
+    FL_CHECK(mgr.allocatedWords() == 128u);
+}
+
+FL_TEST_CASE("RmtMemoryManager4 - refuses TX when pool exhausted") {
+    RmtMemoryManager4 mgr(200);
+    size_t got = 0;
+    FL_CHECK(mgr.tryAllocateTx(0, false, got));       // 128 words fit.
+    FL_CHECK_FALSE(mgr.tryAllocateTx(1, false, got)); // 128 more do not.
+    FL_CHECK(mgr.allocatedWords() == 128u);
+}
+
+FL_TEST_CASE(
+    "RmtMemoryManager4 - refuses duplicate TX allocation on same channel") {
+    RmtMemoryManager4 mgr(512);
+    size_t got = 0;
+    FL_CHECK(mgr.tryAllocateTx(3, false, got));
+    FL_CHECK_FALSE(mgr.tryAllocateTx(3, false, got));
+    FL_CHECK(mgr.allocatedWords() == 128u);
+}
+
+FL_TEST_CASE("RmtMemoryManager4 - RX allocation records symbol count") {
+    RmtMemoryManager4 mgr(512);
+    size_t got = 0;
+    FL_CHECK(mgr.tryAllocateRx(/*channel_id=*/128 + 34, /*symbols=*/64, got));
+    FL_CHECK(got == 64u);
+    FL_CHECK(mgr.allocatedWords() == 64u);
+    FL_CHECK(mgr.hasActiveRxChannels());
+}
+
+FL_TEST_CASE("RmtMemoryManager4 - RX rejects zero-symbol requests") {
+    RmtMemoryManager4 mgr(512);
+    size_t got = 0;
+    FL_CHECK_FALSE(mgr.tryAllocateRx(200, 0, got));
+    FL_CHECK(mgr.allocatedWords() == 0u);
+    FL_CHECK_FALSE(mgr.hasActiveRxChannels());
+}
+
+FL_TEST_CASE("RmtMemoryManager4 - free() releases the words back to the pool") {
+    RmtMemoryManager4 mgr(512);
+    size_t got = 0;
+    mgr.tryAllocateTx(0, false, got);
+    FL_CHECK(mgr.allocatedWords() == 128u);
+    FL_CHECK(mgr.free(0, /*is_tx=*/true));
+    FL_CHECK(mgr.allocatedWords() == 0u);
+    FL_CHECK(mgr.availableWords() == 512u);
+}
+
+FL_TEST_CASE("RmtMemoryManager4 - free() with wrong is_tx returns false") {
+    RmtMemoryManager4 mgr(512);
+    size_t got = 0;
+    mgr.tryAllocateTx(0, false, got);
+    FL_CHECK_FALSE(mgr.free(0, /*is_tx=*/false)); // wrong direction
+    FL_CHECK(mgr.allocatedWords() == 128u);       // unchanged
+}
+
+FL_TEST_CASE(
+    "RmtMemoryManager4 - free() on unknown channel returns false silently") {
+    RmtMemoryManager4 mgr(512);
+    FL_CHECK_FALSE(mgr.free(0, true));
+    FL_CHECK(mgr.allocatedWords() == 0u);
+}
+
+FL_TEST_CASE("RmtMemoryManager4 - free-then-realloc is the reconfigure idiom") {
+    RmtMemoryManager4 mgr(512);
+    size_t got = 0;
+    mgr.tryAllocateTx(0, false, got);          // idle
+    (void)mgr.free(0, true);                   // "reconfigure" — free first
+    FL_CHECK(mgr.tryAllocateTx(0, true, got)); // network-active
+    FL_CHECK(got == 192u);
+    FL_CHECK(mgr.allocatedWords() == 192u);
+}
+
+FL_TEST_CASE("RmtMemoryManager4 - hasActiveRxChannels tracks RX lifetime") {
+    RmtMemoryManager4 mgr(512);
+    size_t got = 0;
+    FL_CHECK_FALSE(mgr.hasActiveRxChannels());
+    mgr.tryAllocateRx(128 + 34, 64, got);
+    FL_CHECK(mgr.hasActiveRxChannels());
+    mgr.free(128 + 34, /*is_tx=*/false);
+    FL_CHECK_FALSE(mgr.hasActiveRxChannels());
+}
+
+FL_TEST_CASE("RmtMemoryManager4 - hasActiveRxChannels ignores TX allocations") {
+    RmtMemoryManager4 mgr(512);
+    size_t got = 0;
+    mgr.tryAllocateTx(0, false, got);
+    FL_CHECK_FALSE(mgr.hasActiveRxChannels());
+}
+
+FL_TEST_CASE(
+    "RmtMemoryManager4 - calculateMemoryBlocks returns 2 when network idle") {
+    RmtMemoryManager4 mgr(512);
+    FL_CHECK(mgr.calculateMemoryBlocks(/*network_active=*/false) == 2);
+}
+
+FL_TEST_CASE(
+    "RmtMemoryManager4 - calculateMemoryBlocks returns 3 when active + room") {
+    RmtMemoryManager4 mgr(512);
+    FL_CHECK(mgr.calculateMemoryBlocks(/*network_active=*/true) == 3);
+}
+
+FL_TEST_CASE("RmtMemoryManager4 - calculateMemoryBlocks falls back to 2 when "
+             "the extra block doesn't fit") {
+    // Fill the pool to within 63 words of the limit; the extra 64-word
+    // block for triple-buffering can't fit, so the recommendation must
+    // gracefully demote.
+    RmtMemoryManager4 mgr(200); // starts idle
+    size_t got = 0;
+    mgr.tryAllocateTx(0, /*network_active=*/false, got);
+    // 200 - 128 = 72 words free — one 64-word block still fits.
+    FL_CHECK(mgr.calculateMemoryBlocks(/*network_active=*/true) == 3);
+
+    mgr.tryAllocateRx(128 + 34, /*symbols=*/16, got);
+    // 72 - 16 = 56 words free — the extra 64-word block no longer fits.
+    FL_CHECK(mgr.calculateMemoryBlocks(/*network_active=*/true) == 2);
+}
+
+FL_TEST_CASE("RmtMemoryManager4 - reset() clears every allocation") {
+    RmtMemoryManager4 mgr(512);
+    size_t got = 0;
+    mgr.tryAllocateTx(0, false, got);
+    mgr.tryAllocateTx(1, true, got);
+    mgr.tryAllocateRx(128 + 33, 64, got);
+    FL_CHECK(mgr.allocatedWords() > 0u);
+    FL_CHECK(mgr.hasActiveRxChannels());
+
+    mgr.reset();
+
+    FL_CHECK(mgr.allocatedWords() == 0u);
+    FL_CHECK_FALSE(mgr.hasActiveRxChannels());
+    FL_CHECK(mgr.availableWords() == 512u);
+}
+
+FL_TEST_CASE(
+    "RmtMemoryManager4 - multiple TX channels coexist up to pool limit") {
+    // 512-word pool at 128 words per idle TX channel = 4 concurrent TX.
+    RmtMemoryManager4 mgr(512);
+    size_t got = 0;
+    FL_CHECK(mgr.tryAllocateTx(0, false, got));
+    FL_CHECK(mgr.tryAllocateTx(1, false, got));
+    FL_CHECK(mgr.tryAllocateTx(2, false, got));
+    FL_CHECK(mgr.tryAllocateTx(3, false, got));
+    FL_CHECK(mgr.allocatedWords() == 512u);
+    FL_CHECK(mgr.availableWords() == 0u);
+    FL_CHECK_FALSE(mgr.tryAllocateTx(4, false, got)); // fifth doesn't fit
+}


### PR DESCRIPTION
## Summary

Ports the RMT5 `RmtMemoryManager` accounting ledger + adaptive buffer-block strategy to the classic-ESP32 / IDF 4.x RMT driver. Follows the `rmt_4` / `rmt_5` split precedent from #3461 and #3467.

The manager:
- tracks the global word-pool (512 words on classic ESP32, 256 on S2)
- records per-channel allocations (TX vs RX) so TX can see RX presence via `hasActiveRxChannels()`
- exposes `calculateMemoryBlocks(network_active)` returning **3** (triple-buffer) when the network is active AND the pool has room for the extra 64-word block, else **2** (RMT4 historic default)

Closes #3469.

## What's out (deliberate)

- **No DMA accounting** — RMT4 hardware has no DMA channel. The RMT5 manager's DMA slot ledger is not ported.
- **No dedicated TX/RX pools** — RMT4 is always a global-pool platform.
- **Real network detection is a stub** — `NetworkStateTracker4::isActive()` returns `false` in v1. That means today's behaviour is **bit-for-bit identical to pre-#3469** — the manager plumbing is in place, but TX still gets 2 mem blocks per channel. Follow-up PR flips the stub to poll a shared network detector.
- **No ISR-side refactor** — `PULSES_PER_FILL_RMT4` stays fixed. Higher `mem_block_num` values in `rmt_config()` give the ISR more headroom before it misses its deadline; the reactive `checkTime` truncation in `fillNextBuffer` stays as a belt-and-braces safety net.

## Wiring

- **`ChannelEngineRMT4Impl::configureChannel`** — free-then-tryAllocateTx idiom. Failure returns `false`; the caller (`acquireChannel`) treats this the same as a HW-channel-count miss and defers the strip to the pending queue. Uses `calculateMemoryBlocks(network_active)` to fill `Rmt4ChannelConfig::mMemBlocks`.
- **`ChannelEngineRMT4Impl` destructor** — releases every in-use channel's allocation.
- **`rmt_rx_4/RmtRxChannelImpl` constructor** — pre-registers a 64-symbol RX reservation with channel-id `128 + (pin & 0x7F)` so TX (raw 0..N-1 IDs) never collides.
- **`rmt_rx_4/RmtRxChannelImpl` destructor** — releases the RX reservation.

## Tests

19 host `FL_TEST_CASE`s in `tests/platforms/esp/32/drivers/rmt/rmt_4/rmt_memory_manager_4.cpp` cover:

- pool starts empty
- TX idle = 128 words, network-active = 192
- graceful demotion to 128 when 192 doesn't fit
- pool-exhausted refusals
- duplicate-alloc refusals
- RX symbol-count recording, zero-symbol rejection
- `free()` releases correctly; wrong `is_tx` and unknown-channel misses
- free-then-realloc reconfigure idiom
- `hasActiveRxChannels()` tracks RX lifetime, ignores TX
- `calculateMemoryBlocks()` 2/3 selection + fallback when the extra block doesn't fit
- `reset()` clears the ledger
- 4 concurrent TX up to pool limit, 5th refused

## Test plan

- [x] `bash test rmt_memory_manager_4 --cpp --clean` — **19 / 19 pass** on a fresh build.
- [x] `bash test --cpp` — full host suite **342 / 342 pass** (no regression).
- [x] `clang-format --dry-run --Werror` clean on every touched file.
- [ ] `bash compile esp32dev --examples AutoResearch` — blocked on the pre-existing fbuild Windows spec-file backslash regression that also reproduces on plain master. **Not introduced by this PR.** CI on Linux exercises the cross-compile.
- [ ] WROOM live validation of the network-active bump — rides on the same fbuild blocker.

The manager class body is **header-inline** on purpose so host tests build it directly without needing the ESP-IDF headers. Only the platform-default `instance()` singleton lives in the `.cpp.hpp` behind the usual `FL_IS_ESP32 && !FASTLED_RMT5` guard.

## Follow-ups called out in the file docblocks

- Wire `NetworkStateTracker4::isActive()` to a real detector once the RMT5 `NetworkDetector` is lifted out of its `#if FASTLED_RMT5` guard to a shared location.
- Move the `PULSES_PER_FILL_RMT4` threshold to a per-channel `state->mem_blocks * 32` computation so the ISR actually exploits the extra buffer headroom during network bursts. Requires ISR path touch — separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added smarter ESP32 RMT4 channel memory handling for both transmit and receive paths.
  * The driver can now adapt memory usage based on network activity and better share limited hardware resources across channels.

* **Bug Fixes**
  * Improved cleanup so channel memory is returned properly when channels shut down.
  * Reduced the risk of memory leaks or failed reconfiguration when channel setup is interrupted.

* **Tests**
  * Added coverage for memory allocation, release, and capacity behavior across common RMT4 usage scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->