### PR TITLE
fix(lpc): unblock LPC845 compile path for SCT+DMA channels-API engine (#3468)

### DIFF
--- a/ci/boards.py
+++ b/ci/boards.py
@@ -1134,7 +1134,15 @@ RPI_PICO2 = Board(
 # platform, so use the FastLED fork (transferred from zackees/ in 2026-06-28) that
 # layers framework-arduino-lpc8xx on top of
 # platformio/platform-nxplpc.
-_NXPLPC_PLATFORM = "https://github.com/FastLED/platform-nxp-lpc8xx.git#12265f765aebd3893465d6d7ad76be66d89ba015"
+#
+# The `nxplpc@` prefix is a compatibility workaround for fbuild 2.3.15
+# whose platform matcher only substring-matches `nxplpc` (no separator)
+# and rejects the hyphenated `nxp-lpc` in the raw GitHub URL. The
+# matcher fix landed as FastLED/fbuild#900 but was cut AFTER 2.3.15 was
+# released (fbuild 2.3.15 released 20:09 UTC, matcher merge 21:47 UTC).
+# Once fbuild 2.3.16 ships with #900 the `nxplpc@` prefix becomes
+# redundant but stays valid PlatformIO syntax (name @ source URI).
+_NXPLPC_PLATFORM = "nxplpc@https://github.com/FastLED/platform-nxp-lpc8xx.git#12265f765aebd3893465d6d7ad76be66d89ba015"
 
 LPC845BRK = Board(
     board_name="lpc845brk",

--- a/src/platforms/arm/lpc/led_sysdefs_arm_lpc.h
+++ b/src/platforms/arm/lpc/led_sysdefs_arm_lpc.h
@@ -120,6 +120,19 @@ typedef fl::u8           boolean;
 #pragma pop_macro("OUTPUT")
 #pragma pop_macro("INPUT")
 
+// Signal to shared ARM headers that this build has the CMSIS PAL
+// (`__get_PRIMASK`, `__enable_irq`, `__disable_irq`, `SysTick`,
+// etc.) on the include path via the vendor `<LPC845.h>` / `<LPC804.h>`
+// includes above (which pull in `core_cm0plus.h`). Without this,
+// `src/platforms/arm/common/m0clockless_c.h` re-defines the CMSIS
+// intrinsics locally and the vendor + FastLED versions collide with a
+// `redefinition of fl::u32 __get_PRIMASK()` error at compile time —
+// exactly what `m0clockless_c.h:51` guards against with
+// `#if !defined(FASTLED_HAS_CMSIS)`.
+#ifndef FASTLED_HAS_CMSIS
+#define FASTLED_HAS_CMSIS 1
+#endif
+
 // V7 of FastLED #3437: hard-require the vendor PAL. If the toolchain
 // failed to put <LPC845.h> / <LPC804.h> on the include path, fail at
 // preprocessing time rather than silently fall back on hand-rolled

--- a/src/platforms/shared/bitbang/bus_traits.h
+++ b/src/platforms/shared/bitbang/bus_traits.h
@@ -17,7 +17,15 @@
 #include "fl/channels/manager.h"
 #include "fl/stl/shared_ptr.h"
 #include "fl/stl/type_traits.h"
+#include "platforms/is_platform.h"
 #include "platforms/shared/bitbang/bitbang_channel_driver.h"
+
+// LPC845 claims `Bus::BIT_BANG` for its dedicated SCT+DMA clockless
+// engine (see `src/platforms/arm/lpc/drivers/sct_dma/bus_traits.h` —
+// FastLED #3459 / PR #3460). The shared bit-bang specialization must
+// step aside on that platform to avoid a redefinition. Every other
+// platform continues to use the universal-GPIO fallback below.
+#if !defined(FL_IS_ARM_LPC_845)
 
 namespace fl {
 
@@ -40,3 +48,5 @@ template<> struct BusSupports<Bus::BIT_BANG, ClocklessChipset> : fl::true_type {
 template<> struct BusSupports<Bus::BIT_BANG, SpiChipsetConfig>  : fl::true_type {};
 
 }  // namespace fl
+
+#endif  // !FL_IS_ARM_LPC_845


### PR DESCRIPTION
## Summary

Three separate compile-path fixes surfaced while validating the #3468 harness on real LPC845-BRK silicon (VID:PID 1FC9:0132 on COM10). Each is a legitimate bug fix; they land together because they're only observable end-to-end when the LPC compile path actually gets exercised.

## Fixes

1. **`ci/boards.py`** — `nxplpc@` prefix workaround. fbuild 2.3.15 was cut BEFORE my matcher fix `FastLED/fbuild#900` merged (20:09 vs 21:47 UTC), so 2.3.15's substring matcher still rejects the hyphenated `nxp-lpc` GitHub URL. `nxplpc@<URL>` is valid PlatformIO name-at-source syntax and makes the substring match under 2.3.15. Redundant once 2.3.16 ships with #900 but stays valid.

2. **`src/platforms/arm/lpc/led_sysdefs_arm_lpc.h`** — define `FASTLED_HAS_CMSIS`. The guard at `m0clockless_c.h:51` (comment says "LPC builds set FASTLED_HAS_CMSIS in led_sysdefs") was referenced but the define was never actually added. Result: `redefinition of 'fl::u32 __get_PRIMASK()'` because both the FastLED local stub and the vendor CMSIS `core_cm0plus.h` were active.

3. **`src/platforms/shared/bitbang/bus_traits.h`** — LPC845 gate. The shared `BitBangChannelDriver` unconditionally specializes `BusTraits<Bus::BIT_BANG>`, which collides with `ChannelEngineLpcSctDma`'s BIT_BANG registration on LPC845. Gate the shared specialization on `!FL_IS_ARM_LPC_845` so the dedicated SCT+DMA engine owns the slot.

## Verification

Applied all three fixes and confirmed the LPC compile now goes green:

```
bash compile lpc845brk --examples AutoResearch --build-flag "-DFASTLED_LPC_PWM_DMA=1"

Board: NXP LPC845-BRK / LPC845 @ 24MHz
Toolchain: arm-none-eabi-gcc 15.2.1
Flash: 53.52KB / 64.00KB (83.6%)
RAM:   9.07KB / 16.00KB (56.7%)
Artifact: firmware.elf (159.79KB) / firmware.bin (53.54KB)
build succeeded in 212.2s
```

- `bash test --cpp` → **343/343 passed**
- C++ lint (Python path) → clean

## What's still open on the actual on-wire verification

- **fbuild-side:** An additional blocker surfaced during this bring-up — the `FastLED/framework-arduino-lpc8xx` tarball SHA256 changed after the 2026-06-28 org transfer (`e6bbcc3392…` → `e64f0cb81a…`). Needs a fbuild-side update to `ACLPC_CHECKSUM` in `crates/fbuild-packages/src/library/arduino_core_lpc8xx.rs`. I have the fix on a local fbuild branch and will push it to fbuild as a follow-up PR.
- **Flash + serial:** `bash autoresearch --pwm-dma-cl` hits pre-existing infrastructure gaps unrelated to #3468 — `ci/util/port_utils.py` only recognises the LPCXpresso VCOM fingerprint (VID:PID 16C0:0483), not the LPC-Link2 CMSIS-DAP variant (1FC9:0132), and fbuild's LPC deploy path uses `lpc21isp` which requires ISP-mode entry rather than the board's default CMSIS-DAP SWD.

The **host TX→RX byte-flow readback contract** (#3468 primary acceptance) is already confirmed in PR #3472 (`tests/fl/channels/lpc_sct_dma_engine.cpp` "#3468: end-to-end TX→RX readback through engine.show()"). This PR takes it one step further by unblocking the compile path so anyone with an LPC845-BRK can now build the firmware and run the on-silicon self-loopback once fbuild + port fingerprint clear.

Refs #3468.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build compatibility for LPC845/LPC804-based boards.
  * Prevented CMSIS-related compile conflicts on supported LPC targets.
  * Avoided a bit-bang trait redefinition issue on LPC845 platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->