### PR TITLE
feat(autoresearch): accept LPC-Link2 CMSIS-DAP VID:PID for LPC845-BRK

### DIFF
--- a/ci/tests/test_autoresearch_phases.py
+++ b/ci/tests/test_autoresearch_phases.py
@@ -1025,7 +1025,10 @@ class TestAutoDetectUploadPort:
 
         assert result.ok is True
         assert result.selected_port == "COM9"
-        detect_chip.assert_called_once_with("COM9", timeout=3.0)
+        # FastLED #3446: the 3.0s explicit timeout override was removed so
+        # the call picks up `detect_attached_chip`'s richer default. Test
+        # now just asserts the call happened with the port name.
+        detect_chip.assert_called_once_with("COM9")
 
     def test_expected_environment_positive_mismatch_fails(self) -> None:
         port = ListPortInfo("COM9")
@@ -1054,6 +1057,67 @@ class TestAutoDetectUploadPort:
         assert "No USB serial port matched expected environment" in (
             result.error_message or ""
         )
+
+    def test_lpc845brk_lpcxpresso_vcom_fingerprint_matches(self) -> None:
+        """LPC845-BRK with LPCXpresso VCOM firmware (16C0:0483) is accepted."""
+        port = ListPortInfo("COM12")
+        port.description = "USB Serial Device"
+        port.hwid = "USB VID:PID=16C0:0483"
+        port.vid = 0x16C0
+        port.pid = 0x0483
+
+        with patch(
+            "ci.util.port_utils.serial.tools.list_ports.comports",
+            return_value=[port],
+        ):
+            result = auto_detect_upload_port("lpc845brk")
+
+        assert result.ok is True
+        assert result.selected_port == "COM12"
+
+    def test_lpc845brk_lpc_link2_cmsis_dap_fingerprint_matches(self) -> None:
+        """LPC845-BRK with LPC-Link2 CMSIS-DAP firmware (1FC9:0132) is accepted.
+
+        FastLED #3468 follow-up: newer LPC845-BRK boards ship with NXP's own
+        LPC-Link2 CMSIS-DAP firmware pre-flashed on the debug probe. The
+        probe still exposes the LPC845's USART0 as a VCOM alongside the
+        CMSIS-DAP HID interface — VID:PID 1FC9:0132 belongs to NXP rather
+        than the community "V-USB" pool. Both firmwares are valid for
+        AutoResearch.
+        """
+        port = ListPortInfo("COM10")
+        port.description = "USB Serial Device"
+        port.hwid = "USB VID:PID=1FC9:0132"
+        port.vid = 0x1FC9
+        port.pid = 0x0132
+
+        with patch(
+            "ci.util.port_utils.serial.tools.list_ports.comports",
+            return_value=[port],
+        ):
+            result = auto_detect_upload_port("lpc845brk")
+
+        assert result.ok is True
+        assert result.selected_port == "COM10"
+
+    def test_lpc845brk_neither_fingerprint_matches_reports_both(self) -> None:
+        """Error message lists BOTH accepted VID:PIDs when neither is found."""
+        port = ListPortInfo("COM7")
+        port.description = "USB Serial Device"
+        port.hwid = "USB VID:PID=303A:1001"
+        port.vid = 0x303A
+        port.pid = 0x1001
+
+        with patch(
+            "ci.util.port_utils.serial.tools.list_ports.comports",
+            return_value=[port],
+        ):
+            result = auto_detect_upload_port("lpc845brk")
+
+        assert result.ok is False
+        assert result.selected_port is None
+        assert "16C0:0483" in (result.error_message or "")
+        assert "1FC9:0132" in (result.error_message or "")
 
 
 # ============================================================

--- a/ci/util/port_utils.py
+++ b/ci/util/port_utils.py
@@ -43,22 +43,47 @@ CHIP_TO_ENVIRONMENT: dict[str, str] = {
 # ESP32 variants that lack WiFi hardware
 NO_WIFI_ENVIRONMENTS: set[str] = {"esp32h2", "esp32p4"}
 
-# PlatformIO environments → expected USB VID:PID for the data-bearing VCOM
-# port. This bypasses the description-string heuristic for boards whose USB
-# descriptors are too generic to disambiguate (e.g. "USB Serial Device" on
-# Windows for both the LPC845-BRK VCOM and any other Microsoft CDC device).
+# PlatformIO environments → expected USB VID:PID(s) for the data-bearing
+# VCOM port. This bypasses the description-string heuristic for boards
+# whose USB descriptors are too generic to disambiguate (e.g. "USB Serial
+# Device" on Windows for both the LPC845-BRK VCOM and any other Microsoft
+# CDC device).
+#
+# Each entry is a **tuple of accepted VID:PID pairs** — the first port
+# whose (vid, pid) matches any pair is selected. Some boards ship one of
+# several debug-probe firmwares that expose different VID:PIDs; listing
+# them all here lets the same PlatformIO env work regardless of which
+# firmware is on the on-board probe (see the LPC845-BRK note below).
+#
 # Add new entries here when porting to a new board. See FastLED #3300 for
-# the LPC845-BRK case that motivated this map. ci/util/serial_probe.py has
-# a richer fingerprint table; this map only carries the entries autoresearch
-# needs for default-port selection.
+# the LPC845-BRK case that motivated this map. ci/util/serial_probe.py
+# has a richer fingerprint table; this map only carries the entries
+# autoresearch needs for default-port selection.
+ENVIRONMENT_TO_VCOM_VID_PIDS: dict[str, tuple[tuple[int, int], ...]] = {
+    # LPC8xx family: the on-board debug probe can be either
+    #   * LPC11U35 running the LPCXpresso VCOM firmware — 16C0:0483
+    #     (the community "V-USB" VID:PID; shared with PJRC Teensy).
+    #   * LPC-Link2 CMSIS-DAP firmware — 1FC9:0132
+    #     (NXP's own VID:PID; the debug probe presents a single COM
+    #     port that carries the LPC845's USART0 as a virtual serial
+    #     bridge alongside the CMSIS-DAP HID interface).
+    # Newer LPC845-BRK / LPCXpresso boards ship with the LPC-Link2
+    # CMSIS-DAP firmware pre-flashed; either variant is acceptable for
+    # AutoResearch as long as the VCOM stream reaches the host.
+    "lpc845brk": ((0x16C0, 0x0483), (0x1FC9, 0x0132)),
+    "lpc845": ((0x16C0, 0x0483), (0x1FC9, 0x0132)),
+    "lpc804": ((0x16C0, 0x0483), (0x1FC9, 0x0132)),
+    "lpcxpresso845max": ((0x16C0, 0x0483), (0x1FC9, 0x0132)),
+    "lpcxpresso804": ((0x16C0, 0x0483), (0x1FC9, 0x0132)),
+}
+
+# Backwards-compatibility shim — the old single-VID:PID map is derived
+# from the first entry of the new plural form so any external caller
+# that still reads `ENVIRONMENT_TO_VCOM_VID_PID` gets the primary
+# (LPCXpresso VCOM) fingerprint. Deprecated; update callers to consume
+# the plural form and drop this once no in-repo callers remain.
 ENVIRONMENT_TO_VCOM_VID_PID: dict[str, tuple[int, int]] = {
-    # LPC8xx family: LPC11U35-on-board USB-VCOM bridge for USART0.
-    # Same VID:PID across all four LPC8xx canary boards.
-    "lpc845brk": (0x16C0, 0x0483),
-    "lpc845": (0x16C0, 0x0483),
-    "lpc804": (0x16C0, 0x0483),
-    "lpcxpresso845max": (0x16C0, 0x0483),
-    "lpcxpresso804": (0x16C0, 0x0483),
+    env: pids[0] for env, pids in ENVIRONMENT_TO_VCOM_VID_PIDS.items()
 }
 
 
@@ -151,14 +176,19 @@ def auto_detect_upload_port(expected_environment: str | None) -> ComportResult:
 
     # VID:PID-based detection takes precedence over chip-probe and description
     # heuristics. For boards whose VCOM bridges have well-known IDs (LPC845-BRK
-    # via LPC11U35, see FastLED #3300), this is the only reliable signal on
-    # Windows where multiple boards report a generic "USB Serial Device" name.
-    expected_vid_pid = (
-        ENVIRONMENT_TO_VCOM_VID_PID.get(expected_env) if expected_env else None
+    # via LPC11U35 or LPC-Link2 CMSIS-DAP, see FastLED #3300), this is the only
+    # reliable signal on Windows where multiple boards report a generic "USB
+    # Serial Device" name. An environment may map to more than one accepted
+    # VID:PID (e.g. LPC845-BRK boards ship with either LPCXpresso VCOM
+    # firmware 16C0:0483 or LPC-Link2 CMSIS-DAP firmware 1FC9:0132 on the
+    # debug probe) — the first port matching ANY of the entry's pairs wins.
+    expected_vid_pids = (
+        ENVIRONMENT_TO_VCOM_VID_PIDS.get(expected_env) if expected_env else None
     )
-    if expected_vid_pid is not None:
+    if expected_vid_pids:
+        accepted = set(expected_vid_pids)
         for port in usb_ports:
-            if (port.vid, port.pid) == expected_vid_pid:
+            if (port.vid, port.pid) in accepted:
                 return ComportResult(
                     ok=True,
                     selected_port=port.device,
@@ -168,13 +198,15 @@ def auto_detect_upload_port(expected_environment: str | None) -> ComportResult:
         # Fingerprint expected but no port matched. Don't fall through to the
         # ESP probe — the wrong port will fail later with PermissionError or
         # silent timeout. Report explicitly so the user can plug the board in.
-        vid, pid = expected_vid_pid
+        formatted_expected = " or ".join(
+            f"{vid:04X}:{pid:04X}" for vid, pid in expected_vid_pids
+        )
         return ComportResult(
             ok=False,
             selected_port=None,
             error_message=(
                 f"No USB serial port matched expected VCOM fingerprint for "
-                f"'{expected_environment}' (VID:PID {vid:04X}:{pid:04X}). "
+                f"'{expected_environment}' (VID:PID {formatted_expected}). "
                 f"Detected USB ports: "
                 + ", ".join(
                     f"{p.device}={p.vid:04X}:{p.pid:04X}"


### PR DESCRIPTION
## Summary

Newer LPC845-BRK / LPCXpresso boards ship with NXP's LPC-Link2 CMSIS-DAP firmware pre-flashed on the on-board debug probe. That firmware presents the LPC845's USART0 as a VCOM alongside the CMSIS-DAP HID interface at VID:PID **1FC9:0132** (NXP's own VID), not the community-pool **16C0:0483** used by the older LPCXpresso VCOM firmware. `ci/util/port_utils.py` only knew about the latter, so `bash autoresearch lpc845brk` failed at port detection on any board with the newer firmware.

Change the map from single-VID:PID to tuple-of-VID:PIDs so an env accepts any of several firmware variants. All five LPC8xx canary envs now accept both fingerprints; the first port matching any listed pair wins.

## Backwards compat

- Renamed to `ENVIRONMENT_TO_VCOM_VID_PIDS` (plural).
- Kept `ENVIRONMENT_TO_VCOM_VID_PID` as a shim derived from the first entry per env — deprecated, slated for removal once no in-repo callers remain.
- Error message now lists BOTH accepted fingerprints when neither is found.

## Tests

`TestAutoDetectUploadPort` — 5/5 pass:

- New: `test_lpc845brk_lpcxpresso_vcom_fingerprint_matches`
- New: `test_lpc845brk_lpc_link2_cmsis_dap_fingerprint_matches`
- New: `test_lpc845brk_neither_fingerprint_matches_reports_both`
- Fixed a stale pre-existing assertion in `test_expected_environment_probe_failure_falls_back_to_descriptor` after #3446 dropped the explicit `timeout=3.0` override.

Ruff clean.

## Refs

- Unblocks the on-silicon `bash autoresearch --pwm-dma-cl` port detection for #3468's SCT+DMA channels-API validation harness.
- Adjacent to the #3300 / #3450 LPC restoration meta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * USB device detection now supports multiple accepted fingerprints for an environment, improving compatibility with more hardware variants.
  * Added coverage for additional LPC845BRK connection fingerprints.

* **Bug Fixes**
  * Port auto-detection now recognizes either supported VID:PID match instead of requiring one exact pair.
  * Error messages now show all accepted fingerprints when no match is found, making setup issues easier to diagnose.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->