### PR TITLE
feat(boards): promote `lpc845` to preferred name, deprecate `lpc845brk` alias (#3220)

### DIFF
--- a/agents/docs/hardware-autoresearch.md
+++ b/agents/docs/hardware-autoresearch.md
@@ -28,7 +28,8 @@ bash autoresearch --spi
 bash autoresearch --uart
 bash autoresearch --i2s                       # ESP32-S3 only
 bash autoresearch --lcd-rgb                   # ESP32-P4 only
-bash autoresearch lpc845brk --ieee754         # LPC low-memory IEEE 754 codec check
+bash autoresearch lpc845 --ieee754            # LPC low-memory IEEE 754 codec check
+                                              # (lpc845brk still works as a deprecated alias — #3220)
 
 # Test multiple drivers (sequentially)
 bash autoresearch --parlio --rmt              # Auto-detect environment

--- a/ci/boards.py
+++ b/ci/boards.py
@@ -1144,15 +1144,26 @@ RPI_PICO2 = Board(
 # redundant but stays valid PlatformIO syntax (name @ source URI).
 _NXPLPC_PLATFORM = "nxplpc@https://github.com/FastLED/platform-nxp-lpc8xx.git#12265f765aebd3893465d6d7ad76be66d89ba015"
 
-LPC845BRK = Board(
-    board_name="lpc845brk",
+# Preferred name for the LPC845 canary board target (FastLED #3220).
+# `LPC845` is the canonical entry — `bash compile lpc845 …` and
+# `bash autoresearch lpc845 …` are the documented spellings in
+# `agents/docs/hardware-autoresearch.md`. `LPC845BRK` below is retained
+# as a deprecated alias so pre-#3220 scripts and CI matrices keep
+# working; it slates for removal one release / CI cycle after this
+# lands (see #3220 acceptance).
+LPC845 = Board(
+    board_name="lpc845",
     platform=_NXPLPC_PLATFORM,
     platform_needs_install=True,
     framework="arduino",
 )
 
-LPC845 = Board(
-    board_name="lpc845",
+# Deprecated alias — prefer `LPC845` above. Same platform + framework;
+# named for the LPC845-BRK breakout board specifically. Kept working
+# so `bash compile lpc845brk …` still resolves during the transition.
+# FastLED #3220 tracks removal.
+LPC845BRK = Board(
+    board_name="lpc845brk",
     platform=_NXPLPC_PLATFORM,
     platform_needs_install=True,
     framework="arduino",

--- a/examples/AutoResearch/AutoResearch.ino
+++ b/examples/AutoResearch/AutoResearch.ino
@@ -1,6 +1,6 @@
 // @filter
 // require:
-//   - board: esp32s3,esp32c6,esp32p4,teensy41,teensy40,lpc845brk,lpcxpresso845max,lpcxpresso804
+//   - board: esp32s3,esp32c6,esp32p4,teensy41,teensy40,lpc845,lpc845brk,lpcxpresso845max,lpcxpresso804
 // @end-filter
 //
 // Low-memory mode (FastLED #3030): on Low-tier targets (LPC8xx etc., per


### PR DESCRIPTION
## Summary

The LPC845 canary target has historically been named `lpc845brk` after the specific breakout board. That name leaks a form-factor spelling into user-facing commands where the target is really the LPC845 chip family and the breakout is just the reference board. #3220 tracks the rename to `lpc845` — clearer, easier to discover, consistent with the other family targets.

Both boards already existed in `ci/boards.py`. This change:

- Promotes `LPC845` above `LPC845BRK` in the declaration order.
- Adds explicit "preferred" / "deprecated alias" docstrings.
- Updates the two remaining docs / examples that still spell `lpc845brk`:
  - `agents/docs/hardware-autoresearch.md` — usage example now uses `lpc845` with a callout that `lpc845brk` still works as a deprecated alias.
  - `examples/AutoResearch/AutoResearch.ino` — filter-header board list adds `lpc845` alongside the existing `lpc845brk` entry so the example matrix CI covers both spellings during the transition.

`ci/util/port_utils.py` and `ci/autoresearch/phases.py` already accept both names via `LPC_WS2812_ENVS = {\"lpc845brk\", \"lpc845\", \"lpcxpresso845max\"}` — no code changes needed there.

## Deprecation timeline

`lpc845brk` stays as a working alias for at least one release / CI cycle per #3220's acceptance criterion. A follow-up (post-silicon validation) can remove the alias once no downstream sketch or CI matrix references it.

## Tests

- Board config imports both names, same platform pin.
- `ruff check ci/boards.py` clean.
- \`pytest ci/tests/test_board_to_platformio_ini.py\` 3/3 pass.

Closes #3220.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated hardware AutoResearch usage examples to show the preferred `lpc845` target for IEEE 754 checks.
  * Clarified that `lpc845brk` is still available as a deprecated alias.

* **Bug Fixes**
  * Aligned supported board references so examples and board selection use the same canonical `lpc845` name.
  * Kept backward compatibility for existing `lpc845brk` workflows during the transition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->