### PR TITLE
feat(lpc): drive SCT+DMA chunk progression via poll() — no busy-wait (#3459)

### DIFF
--- a/src/platforms/arm/lpc/drivers/sct_dma/channel_engine_lpc_sct_dma.cpp.hpp
+++ b/src/platforms/arm/lpc/drivers/sct_dma/channel_engine_lpc_sct_dma.cpp.hpp
@@ -101,11 +101,15 @@ IChannelDriver::DriverState ChannelEngineLpcSctDma::poll() FL_NO_EXCEPT {
     if (!mTransmissionActive) {
         return DriverState::READY;
     }
-    // Probe the helper's DMA done flag. On LPC845 this reads
-    // DMA0->COMMON[0].ACTIVE; on host it returns true immediately so
-    // the state machine settles to READY on the next poll — matching the
-    // contract verified by `tests/fl/channels/lpc_sct_dma_engine.cpp`.
-    if (!mTransmitter.isDone()) {
+    // Drive chunk progression via the runtime transmitter. On LPC845
+    // this probes `DMA0->COMMON[0].ACTIVE` for the three SCT-tied
+    // channels — when they drop, if bytes remain the next chunk gets
+    // encoded and kicked in this same call. #3459 acceptance
+    // criterion 3: no busy-wait in show(); the state machine
+    // transitions READY→BUSY→DRAINING→READY are all driven from
+    // here. On host the transmit was synchronous so pollAndAdvance()
+    // immediately returns true.
+    if (!mTransmitter.pollAndAdvance()) {
         return DriverState::DRAINING;
     }
     mTransmissionActive = false;

--- a/src/platforms/arm/lpc/drivers/sct_dma/lpc_sct_dma_runtime.cpp.hpp
+++ b/src/platforms/arm/lpc/drivers/sct_dma/lpc_sct_dma_runtime.cpp.hpp
@@ -170,15 +170,19 @@ void encodeChunkFromBytes(const u8* bytes, u32 bytes_avail,
 
 }  // namespace
 
-void LpcSctDmaTransmitter::transmit(const u8* bytes, u32 len, bool is_rgbw) FL_NO_EXCEPT {
-    if (bytes == nullptr || len == 0u) {
-        return;
-    }
-    (void)is_rgbw;  // bytes are already chipset-encoded by ChannelData; the
-                    // is_rgbw flag is reserved for future per-pixel padding
-                    // logic (RGBW-XTRA0). For now the byte stream is consumed
-                    // verbatim.
+namespace {
 
+// Encode + arm the next chunk (up to `chunk_bits` bits from
+// `bytes + byte_offset`) into the transmitter's per-instance buffer,
+// then release SCT HALT so the SCT match events start streaming DMA.
+// Returns the number of BITS actually kicked (== chunk_bits for
+// non-final chunks; possibly less for the last).
+void kickNextChunk(u32* channel_buf,
+                    const u8* bytes,
+                    u32 total_len,
+                    u32 byte_offset,
+                    u32 pin_mask,
+                    u32& chunk_bits_out) FL_NO_EXCEPT {
     constexpr u32 chunk_words = FASTLED_LPC_PWM_DMA_CHUNK_BITS;
     constexpr u32 xfercfg_base =
         (1UL << 0) |                            // CFGVALID
@@ -187,44 +191,103 @@ void LpcSctDmaTransmitter::transmit(const u8* bytes, u32 len, bool is_rgbw) FL_N
         (0UL << 14);                            // DSTINC = no
     const u32 base = FASTLED_LPC_PWM_DMA_BASECH;
 
-    u32* rise_stream   = &mChannelBuf[0];
-    u32* t0fall_stream = &mChannelBuf[chunk_words];
-    u32* t1fall_stream = &mChannelBuf[2u * chunk_words];
+    const u32 bytes_remaining = total_len - byte_offset;
+    const u32 bits_remaining = bytes_remaining * 8u;
+    const u32 chunk_bits = bits_remaining > chunk_words ? chunk_words : bits_remaining;
 
-    u32 byte_offset = 0;
-    while (byte_offset < len) {
-        const u32 bytes_remaining = len - byte_offset;
-        const u32 bits_remaining = bytes_remaining * 8u;
-        const u32 chunk_bits = bits_remaining > chunk_words ? chunk_words : bits_remaining;
+    u32* rise_stream   = &channel_buf[0];
+    u32* t0fall_stream = &channel_buf[chunk_words];
+    u32* t1fall_stream = &channel_buf[2u * chunk_words];
 
-        encodeChunkFromBytes(bytes + byte_offset, bytes_remaining,
-                              chunk_bits, mPinMask,
-                              rise_stream, t0fall_stream, t1fall_stream);
+    encodeChunkFromBytes(bytes + byte_offset, bytes_remaining,
+                          chunk_bits, pin_mask,
+                          rise_stream, t0fall_stream, t1fall_stream);
 
-        // Arm the 3 DMA channels for this chunk.
-        const u32 count_field = ((chunk_bits - 1u) & 0x3FFu) << 16;
-        for (u32 i = 0; i < 3; ++i) {
-            DMA0->CHANNEL[base + i].XFERCFG = xfercfg_base | count_field;
-        }
-        DMA0->COMMON[0].SETVALID = (7UL << base);
-
-        // Release HALT — SCT runs, match events fire, DMA channels stream.
-        SCT0->CTRL &= ~0x00000004UL;
-
-        // Block until the 3 channels complete this chunk. TODO(2842):
-        // wire SCT MATCH_END → NVIC IRQn so this becomes a WFI rather
-        // than a busy-wait — same TODO the legacy template carries.
-        const u32 mask = (7UL << base);
-        while ((DMA0->COMMON[0].ACTIVE & mask) != 0u) {
-            // busy
-        }
-        SCT0->CTRL |= 0x00000004UL;     // halt for next chunk
-
-        byte_offset += chunk_bits / 8u;
+    // Arm the 3 DMA channels for this chunk.
+    const u32 count_field = ((chunk_bits - 1u) & 0x3FFu) << 16;
+    for (u32 i = 0; i < 3; ++i) {
+        DMA0->CHANNEL[base + i].XFERCFG = xfercfg_base | count_field;
     }
+    DMA0->COMMON[0].SETVALID = (7UL << base);
+
+    // Release HALT — SCT runs, match events fire, DMA channels stream
+    // asynchronously. Control returns to the caller; poll() advances
+    // when this chunk completes.
+    SCT0->CTRL &= ~0x00000004UL;
+
+    chunk_bits_out = chunk_bits;
+}
+
+}  // namespace
+
+void LpcSctDmaTransmitter::transmit(const u8* bytes, u32 len, bool is_rgbw) FL_NO_EXCEPT {
+    (void)is_rgbw;  // bytes are already chipset-encoded by ChannelData; the
+                    // is_rgbw flag is reserved for future per-pixel padding
+                    // logic (RGBW-XTRA0). For now the byte stream is consumed
+                    // verbatim.
+
+    if (bytes == nullptr || len == 0u) {
+        mCurrentBytes = nullptr;
+        mCurrentLen = 0;
+        mBytesSent = 0;
+        mTransmitInProgress = false;
+        return;
+    }
+
+    // Latch the buffer + progression state and kick the first chunk.
+    // The caller drives progression from here via pollAndAdvance().
+    mCurrentBytes = bytes;
+    mCurrentLen = len;
+    mBytesSent = 0;
+    mTransmitInProgress = true;
+
+    u32 chunk_bits = 0;
+    kickNextChunk(mChannelBuf, mCurrentBytes, mCurrentLen, mBytesSent,
+                   mPinMask, chunk_bits);
+    mBytesSent += chunk_bits / 8u;
+}
+
+bool LpcSctDmaTransmitter::pollAndAdvance() FL_NO_EXCEPT {
+    if (!mTransmitInProgress) {
+        return true;
+    }
+
+    // Is the current chunk still streaming? Any of the 3 SCT-tied DMA
+    // channels reporting ACTIVE means we're mid-chunk.
+    const u32 mask = (7UL << FASTLED_LPC_PWM_DMA_BASECH);
+    if ((DMA0->COMMON[0].ACTIVE & mask) != 0u) {
+        return false;   // still DRAINING
+    }
+
+    // Chunk done — halt SCT before we advance so it doesn't consume
+    // stale match events between chunks.
+    SCT0->CTRL |= 0x00000004UL;
+
+    if (mBytesSent >= mCurrentLen) {
+        // Full frame transmitted; idle.
+        mTransmitInProgress = false;
+        mCurrentBytes = nullptr;
+        mCurrentLen = 0;
+        return true;
+    }
+
+    // Encode + kick the next chunk. Poll() will observe DRAINING again
+    // until that chunk drains.
+    u32 chunk_bits = 0;
+    kickNextChunk(mChannelBuf, mCurrentBytes, mCurrentLen, mBytesSent,
+                   mPinMask, chunk_bits);
+    mBytesSent += chunk_bits / 8u;
+    return false;
 }
 
 bool LpcSctDmaTransmitter::isDone() const FL_NO_EXCEPT {
+    // Legacy done probe: idle if no transmission in flight AND no DMA
+    // channel is currently active. Callers that use the older isDone()
+    // interface won't auto-advance chunks; poll() with pollAndAdvance()
+    // is the preferred surface.
+    if (mTransmitInProgress) {
+        return false;
+    }
     const u32 mask = (7UL << FASTLED_LPC_PWM_DMA_BASECH);
     return (DMA0->COMMON[0].ACTIVE & mask) == 0u;
 }
@@ -255,12 +318,16 @@ void LpcSctDmaTransmitter::transmit(const u8* bytes, u32 len, bool is_rgbw) FL_N
     // No SCT/DMA peripheral on host. Instead, capture the byte stream
     // so the caller can round-trip it through the LPC RX device's
     // decoder (#3468 TX→RX readback contract). The channels-API
-    // engine's poll() still flips back to READY on the next call.
+    // engine's poll() flips back to READY on the next call.
     //
     // Overwrite semantics: each transmit() replaces the prior capture.
     // Callers that need to accumulate across frames should copy the
     // span out between calls.
     mTxCapture.clear();
+    mCurrentBytes = nullptr;
+    mCurrentLen = 0;
+    mBytesSent = 0;
+    mTransmitInProgress = false;  // host completes synchronously
     if (bytes == nullptr || len == 0u) {
         return;
     }
@@ -268,6 +335,10 @@ void LpcSctDmaTransmitter::transmit(const u8* bytes, u32 len, bool is_rgbw) FL_N
     for (u32 i = 0; i < len; ++i) {
         mTxCapture.push_back(bytes[i]);
     }
+}
+
+bool LpcSctDmaTransmitter::pollAndAdvance() FL_NO_EXCEPT {
+    return true;  // host completes transmit() synchronously.
 }
 
 bool LpcSctDmaTransmitter::isDone() const FL_NO_EXCEPT {

--- a/src/platforms/arm/lpc/drivers/sct_dma/lpc_sct_dma_runtime.h
+++ b/src/platforms/arm/lpc/drivers/sct_dma/lpc_sct_dma_runtime.h
@@ -102,20 +102,51 @@ public:
     /// @param t3_ns  Third phase length, nanoseconds (e.g. 450).
     void configureForChannel(u8 pin, u32 t1_ns, u32 t2_ns, u32 t3_ns) FL_NO_EXCEPT;
 
-    /// @brief Encode and transmit a raw byte stream as a chunked SCT+DMA
-    ///        stream. Blocks at chunk boundaries until each chunk's DMA
-    ///        completes (matches the legacy template's per-chunk
-    ///        synchronous wait — TODO(2842): wire the SCT MATCH_END
-    ///        interrupt for true async).
+    /// @brief Start a chunked SCT+DMA transmission of a raw byte stream.
+    ///
+    /// **Async semantics (LPC845):** encodes and kicks the first chunk,
+    /// then returns immediately. The caller drives chunk progression by
+    /// calling `pollAndAdvance()` until it returns true. Closes #3459
+    /// acceptance criterion 3 — no busy-wait in `show()`; the state
+    /// machine transitions `READY → BUSY → DRAINING → READY` are entirely
+    /// driven from the engine's `poll()` cycle.
+    ///
+    /// **Sync semantics (host / stub):** there's no DMA to wait on, so
+    /// the entire byte stream is copied into `mTxCapture` and
+    /// transmission is complete on return. `pollAndAdvance()` immediately
+    /// returns true.
+    ///
     /// @param bytes  Raw RGB / RGBW bytes (already chipset-encoded —
     ///               `ChannelData` stores them that way).
     /// @param len    Byte count.
     /// @param is_rgbw  When true, the byte stream is 4 bytes per LED.
     void transmit(const u8* bytes, u32 len, bool is_rgbw) FL_NO_EXCEPT;
 
-    /// @brief True once the most recent chunk's DMA channels have all
-    ///        cleared their `ACTIVE` flag. Used by `poll()` to advance
-    ///        the engine's state machine to `READY`.
+    /// @brief Advance the chunk-stream state machine by one step.
+    ///
+    /// Call from the engine's `poll()`. Semantics:
+    ///
+    ///   - Returns `true` when transmission is fully complete (all chunks
+    ///     have finished). The engine can then transition to `READY`.
+    ///   - Returns `false` while a chunk's DMA is still active OR another
+    ///     chunk has just been kicked. The engine stays in `DRAINING`.
+    ///
+    /// On LPC845 this probes `DMA0->COMMON[0].ACTIVE` for the three
+    /// SCT-tied channels. When they drop, if bytes remain the next chunk
+    /// is encoded and kicked in this same call; if bytes are exhausted
+    /// the transmission is marked idle.
+    ///
+    /// On host the transmit was fully synchronous, so this always
+    /// returns true.
+    bool pollAndAdvance() FL_NO_EXCEPT;
+
+    /// @brief Legacy done-flag probe. Prefer `pollAndAdvance()`.
+    ///
+    /// Returns true when no transmission is in flight. Kept for
+    /// backwards compatibility with callers that don't want to drive
+    /// chunk progression themselves — those callers pay the cost that
+    /// their poll() loop can't advance chunks (multi-chunk frames stall
+    /// after chunk 1).
     bool isDone() const FL_NO_EXCEPT;
 
     /// @brief Return the byte stream captured by the most recent
@@ -161,6 +192,15 @@ private:
     u32 mBitEnd = 0;
 
     bool mInitialized = false;
+
+    // Chunk-progression state for async transmission (LPC845). On host
+    // these members exist too but transmit() completes synchronously so
+    // they remain in the "idle" state (mTransmitInProgress == false)
+    // immediately after transmit() returns.
+    const u8* mCurrentBytes = nullptr;
+    u32 mCurrentLen = 0;
+    u32 mBytesSent = 0;
+    bool mTransmitInProgress = false;
 
     // Host-only TX byte capture. Populated by `transmit()` on host/stub
     // builds so tests can round-trip the byte stream through the LPC RX

--- a/tests/platforms/arm/lpc/drivers/sct_dma/channel_engine_lpc_sct_dma.cpp
+++ b/tests/platforms/arm/lpc/drivers/sct_dma/channel_engine_lpc_sct_dma.cpp
@@ -376,4 +376,79 @@ FL_TEST_CASE("#3468: capture buffer is cleared between transmits") {
     }
 }
 
+// =============================================================================
+// #3459 acceptance criterion 3: no busy-wait in show().
+//
+// The engine's state machine transitions READY → BUSY → DRAINING → READY
+// must all be driven from poll() calls, not from inside show(). show()
+// kicks the transmission and returns; poll() advances chunk boundaries
+// on LPC845 and settles to READY when the full frame has drained.
+//
+// On host there is no DMA to wait on, so transmit() completes
+// synchronously and the first poll() after show() returns READY.
+// The tests below pin the observable contract on host: pollAndAdvance()
+// is idempotent when the transmitter is idle, and the poll()-driven
+// state machine can process multiple back-to-back frames without a
+// busy-wait inside show().
+// =============================================================================
+
+FL_TEST_CASE("#3459 item 3: pollAndAdvance() returns true when idle") {
+    ChannelEngineLpcSctDma engine;
+    // No transmission has been kicked; transmitter is idle.
+    FL_CHECK(engine.transmitter().pollAndAdvance() == true);
+    // Calling again does not change state.
+    FL_CHECK(engine.transmitter().pollAndAdvance() == true);
+}
+
+FL_TEST_CASE("#3459 item 3: show() does not busy-wait; multiple frames drain via poll()") {
+    // Drive three frames back-to-back through the engine's show()/poll()
+    // cycle. On host each transmit() completes synchronously so poll()
+    // returns READY immediately, but the test still exercises the loop
+    // caller would use on silicon: show() → poll() until READY → next
+    // show(). If show() had a hidden busy-wait this loop would still
+    // pass (blocking is invisible from outside), but if the state
+    // machine mis-tracked mTransmissionActive across frames the second
+    // or third show()+poll() would leak state and fail.
+    const u8 kFrame0[] = {0x11, 0x22, 0x33};
+    const u8 kFrame1[] = {0x44, 0x55, 0x66, 0x77, 0x88, 0x99};
+    const u8 kFrame2[] = {0xAA, 0xBB, 0xCC};
+
+    ChannelEngineLpcSctDma engine;
+
+    // Frame 0
+    auto ch0 = makeClocklessChannelData(/*pin=*/11, /*num_leds=*/1, kFrame0);
+    engine.enqueue(ch0);
+    engine.show();
+    // poll() must drive the state to READY. It should complete
+    // within a bounded number of calls (host: 1; silicon: chunk count).
+    for (int i = 0; i < 100; ++i) {
+        if (engine.poll() == DriverState::READY) break;
+    }
+    FL_CHECK(engine.poll() == DriverState::READY);
+    FL_REQUIRE(engine.transmitter().getCapturedTxBytes().size() == sizeof(kFrame0));
+
+    // Frame 1
+    auto ch1 = makeClocklessChannelData(/*pin=*/11, /*num_leds=*/2, kFrame1);
+    engine.enqueue(ch1);
+    engine.show();
+    for (int i = 0; i < 100; ++i) {
+        if (engine.poll() == DriverState::READY) break;
+    }
+    FL_CHECK(engine.poll() == DriverState::READY);
+    FL_REQUIRE(engine.transmitter().getCapturedTxBytes().size() == sizeof(kFrame1));
+
+    // Frame 2
+    auto ch2 = makeClocklessChannelData(/*pin=*/11, /*num_leds=*/1, kFrame2);
+    engine.enqueue(ch2);
+    engine.show();
+    for (int i = 0; i < 100; ++i) {
+        if (engine.poll() == DriverState::READY) break;
+    }
+    FL_CHECK(engine.poll() == DriverState::READY);
+    FL_REQUIRE(engine.transmitter().getCapturedTxBytes().size() == sizeof(kFrame2));
+    for (fl::size i = 0; i < sizeof(kFrame2); ++i) {
+        FL_CHECK(engine.transmitter().getCapturedTxBytes()[i] == kFrame2[i]);
+    }
+}
+
 }  // FL_TEST_FILE


### PR DESCRIPTION
## Summary

Closes **#3459 acceptance criterion 3**: state machine transitions `READY → BUSY → DRAINING → READY` are now driven by `poll()` — no busy-wait inside `show()`.

The previous `LpcSctDmaTransmitter::transmit()` looped internally, kicking each chunk's DMA and then busy-waiting on `DMA0->COMMON[0].ACTIVE` before moving to the next chunk. That blocked `show()` for the entire frame duration (~6 ms per 200-LED WS2812 frame).

## Refactor shape

- `transmit(bytes, len, is_rgbw)` on LPC845 latches progression state (`mCurrentBytes` / `mCurrentLen` / `mBytesSent` / `mTransmitInProgress`), encodes+kicks the first chunk, and returns.
- New `pollAndAdvance()` public method — the engine's `poll()` calls this each tick. If the chunk is still active, returns `false` (engine stays DRAINING). If done + bytes remain, encodes+kicks the next chunk in the same call and returns `false`. If done + all bytes sent, marks idle and returns `true` (engine transitions to READY).
- Internal `kickNextChunk()` file-scope helper shares the encode+arm+release-HALT sequence.

Engine `poll()` now delegates to `pollAndAdvance()`. Legacy `isDone()` stays for backwards compat, documented as legacy.

Host stub still populates `mTxCapture` synchronously — all existing #3468 TX→RX readback tests pass unchanged.

## New tests

- `"#3459 item 3: pollAndAdvance() returns true when idle"` — idempotency contract.
- `"#3459 item 3: show() does not busy-wait; multiple frames drain via poll()"` — three back-to-back frames through the show()→poll()-until-READY→show() loop pins the state machine tracks `mTransmissionActive` correctly across frames.

## Results

- `bash test --cpp --clean` → **344/344 passed**.
- C++ lint (Python path) → clean.

## Still open on #3459

- **Item 2** — `addLeds<WS2812, PIN, GRB>` routes through `ChannelEngineLpcSctDma::show()` (not the legacy template). Requires either a new `ClocklessController` specialization forwarding to the channels-API engine or removing the legacy template specialization when the channels-API path is available. Deferred pending silicon validation.
- Silicon bench validation of the SCT/DMA register layout + INMUX / SRAMBASE / WFI-IRQ TODOs, tracked separately on #3300 / #3450.

Refs #3459.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added non-blocking progress for DMA transmissions, allowing frames to advance incrementally instead of waiting in a blocking loop.
  * Improved support for multi-chunk transfers so longer frames can complete reliably over repeated polling.

* **Bug Fixes**
  * Fixed state handling between back-to-back transmissions to prevent leftover data from affecting the next frame.
  * Improved completion handling so idle transmissions and synchronous host behavior remain consistent.

* **Tests**
  * Added coverage for polling-based transmission progression and consecutive frame handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->