### PR TITLE
feat(autoresearch): LPC845 SPI+DMA async driver validation harness (#3456)

### DIFF
--- a/ci/autoresearch/args.py
+++ b/ci/autoresearch/args.py
@@ -106,6 +106,11 @@ class Args:
     # Drives `ChannelEngineLpcSctDma` and captures via `LpcSctRxChannel`.
     pwm_dma_cl: bool
 
+    # LPC845 SPI+DMA async driver bench (#3456, Phase 1 of #3453 bring-up).
+    # Drives `ARMHardwareSPIOutputDMA<>` and reports timing + async-proof
+    # metrics. Mutually exclusive with --pwm-dma-cl (both claim DMA0).
+    dma_spi: bool
+
     # Multi-frame capture — number of back-to-back show()/capture cycles per pattern.
     # None = driver-default (SPI → 2, others → 1). Explicit value overrides.
     # See issues #2254 and #2288 (ESP32-S3 SPI second-frame degradation).
@@ -394,6 +399,17 @@ See Also:
             "readback. Requires a jumper from --tx-pin (data) to --rx-pin. "
             "Mutually exclusive with --ws2812-loopback (both target the "
             "same SCT peripheral).",
+        )
+        lpc_group.add_argument(
+            "--dma-spi",
+            action="store_true",
+            help="LPC845-only: SPI+DMA async driver bench (FastLED #3456, "
+            "Phase 1 of #3453). Drives `ARMHardwareSPIOutputDMA<>` and "
+            "reports (a) single-shot transfer timing, (b) beacon-toggle "
+            "count during overlap to affirmatively prove CPU is free "
+            "during DMA, (c) SCK rate measurement via wall clock. "
+            "Mutually exclusive with --pwm-dma-cl (both claim DMA0 "
+            "channels and the LowMemory flash budget doesn't fit both).",
         )
 
         # Standard options
@@ -741,6 +757,7 @@ See Also:
             pin_toggle_rx=parsed.pin_toggle_rx,
             ws2812_loopback=parsed.ws2812_loopback,
             pwm_dma_cl=parsed.pwm_dma_cl,
+            dma_spi=parsed.dma_spi,
             frames=parsed.frames,
             tight_timing=parsed.tight_timing,
             tight_timing_iterations=parsed.tight_timing_iterations,

--- a/ci/autoresearch/phases.py
+++ b/ci/autoresearch/phases.py
@@ -1680,7 +1680,24 @@ async def _run_tests_or_special_mode(ctx: RunContext, qctx: QuietContext) -> int
                     "exclusive: both target the SCT peripheral."
                 )
                 return 1
+            if getattr(ctx.args, "dma_spi", False):
+                print(
+                    "--pwm-dma-cl and --dma-spi are mutually exclusive: "
+                    "both claim DMA0 channels and the LowMemory flash "
+                    "budget doesn't fit both."
+                )
+                return 1
             return await _run_lpc_pwm_dma_cl_tests(ctx)
+        # FastLED #3456: --dma-spi runs the SPI+DMA async driver bench.
+        # Phase 1 of the #3453 bring-up.
+        if getattr(ctx.args, "dma_spi", False):
+            if final_environment not in LPC_WS2812_ENVS:
+                print(
+                    "--dma-spi is only supported on LPC845 boards "
+                    "(lpc845brk, lpc845, lpcxpresso845max)."
+                )
+                return 1
+            return await _run_lpc_dma_spi_tests(ctx)
         return await _run_bring_up_tests(ctx)
 
     # GPIO-only mode
@@ -2468,6 +2485,58 @@ async def _run_lpc_pwm_dma_cl_tests(ctx: RunContext) -> int:
         str(tx_pin),
         "--rx-pin",
         str(rx_pin),
+    ]
+    result = subprocess.run(cmd)
+    return 0 if result.returncode == 0 else 1
+
+
+async def _run_lpc_dma_spi_tests(ctx: RunContext) -> int:
+    """Run the FastLED #3456 SPI+DMA async driver bench.
+
+    Sibling of `_run_lpc_pwm_dma_cl_tests`, but exercises the LPC845
+    `ARMHardwareSPIOutputDMA<>` driver from `spi_arm_lpc_dma.h`.
+    Phase 1 of the #3453 bench bring-up series. LPC845 low-memory
+    builds bind the `dmaSpiTransferOnce` / `dmaSpiTransferOverlap` /
+    `dmaSpiMeasureSck` handlers automatically when `FASTLED_LPC_SPI_DMA`
+    is set at compile time — this phase driver expects that flag to
+    already be present in `build_flags`.
+
+    Compile-time build flag: `-DFASTLED_LPC_SPI_DMA=1` (optionally
+    combined with `-DFASTLED_LPC_SPI_DMA_CHANNEL=4` for SPI1). See
+    `examples/AutoResearch/AutoResearchSpiDma.h`.
+    """
+    final_environment = (ctx.final_environment or "").lower()
+    if final_environment not in LPC_WS2812_ENVS:
+        print(
+            "--dma-spi is only supported on LPC845 boards "
+            "(lpc845brk, lpc845, lpcxpresso845max)."
+        )
+        return 1
+
+    upload_port = ctx.upload_port
+    assert upload_port is not None
+
+    print()
+    print("=" * 60)
+    print("LPC SPI+DMA async driver bench — #3456 (Phase 1 of #3453)")
+    print(
+        "   Driver: ARMHardwareSPIOutputDMA<> (src/platforms/arm/lpc/spi_arm_lpc_dma.h)"
+    )
+    print("   Build flag: -DFASTLED_LPC_SPI_DMA=1 (see")
+    print("   examples/AutoResearch/AutoResearchSpiDma.h)")
+    print("   Optional: -DFASTLED_LPC_SPI_DMA_CHANNEL=4 (SPI1 default)")
+    print("   Wiring: no jumper required for transferOnce/Overlap timing;")
+    print("   SCK measurement is wall-clock derived, not SCT-captured.")
+    print("=" * 60)
+    print()
+
+    cmd = [
+        "uv",
+        "run",
+        "python",
+        "ci/autoresearch/test_lpc_dma_spi.py",
+        "--port",
+        upload_port,
     ]
     result = subprocess.run(cmd)
     return 0 if result.returncode == 0 else 1

--- a/ci/autoresearch/test_lpc_dma_spi.py
+++ b/ci/autoresearch/test_lpc_dma_spi.py
@@ -1,0 +1,310 @@
+"""FastLED #3456 — bench-validate the LPC845 SPI+DMA async driver.
+
+Sibling of `test_lpc_pwm_dma_cl.py` for the SPI+DMA async path.
+Drives `ARMHardwareSPIOutputDMA<>` on the LPC845-BRK and checks:
+
+    1. `dmaSpiTransferOnce(byte_count, byte_pattern)`
+        Single-shot DMA transfer with a CPU-poll wait. Passes if the
+        RPC returns success and the wall-clock duration is within a
+        loose upper bound (transfer + RPC overhead).
+
+    2. `dmaSpiTransferOverlap(byte_count, byte_pattern)`
+        The affirmative async proof. Kicks the DMA stream, then runs a
+        tight `volatile` counter until `done()` returns true. A
+        non-zero counter under DMA load proves the CPU was free while
+        the DMA0 channel drove SPI TX.
+
+    3. `dmaSpiMeasureSck(divider_hint)`
+        Measures the effective SCK rate via wall-clock over a fixed
+        512-byte burst. Compared against the compile-time driver
+        divider (default 6 → 4 MHz on the 24 MHz LPC845 FRO).
+
+The three RPCs are bound automatically when the LPC845 firmware is
+compiled with `-DFASTLED_LPC_SPI_DMA=1`; the `bash autoresearch
+--dma-spi` wrapper expects that flag to already be present in
+`build_flags` (add it to `platformio.ini` or pass it via the fbuild
+config for `lpc845`).
+
+**Silicon status.** This is the on-device Phase-1 bench for #3453 —
+the driver header self-gates and compiles clean, but every timing
+band below is only meaningful when run against real LPC845 silicon.
+Host-only CI cannot execute this runner.
+
+Usage:
+    uv run python ci/autoresearch/test_lpc_dma_spi.py [--port COM10]
+
+Exits 0 on success, 1 on any failed assertion / RPC error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from typing import Any
+
+
+try:
+    import serial  # type: ignore
+except ImportError:
+    serial = None  # type: ignore
+
+
+DEFAULT_PORT = "COM10"
+DEFAULT_BAUD = 115200
+
+# Compile-time defaults in AutoResearchSpiDma.h. If the host overrides
+# via -DFASTLED_LPC_SPI_DMA_HARNESS_DIVIDER=<N>, adjust here or pass
+# --divider on the CLI.
+DEFAULT_HARNESS_DIVIDER = 6
+DEFAULT_HARNESS_CORE_HZ = 24_000_000
+
+
+def send_rpc(
+    s: "serial.Serial",
+    method: str,
+    args: list[Any] | None = None,
+    request_id: int = 1,
+    timeout: float = 10.0,
+) -> dict[str, Any] | None:
+    """JSON-RPC send/receive helper.
+
+    Mirrors `test_lpc_pwm_dma_cl.py::send_rpc` — kept inline so the
+    runner has no cross-file dependencies beyond stdlib + pyserial.
+    """
+    params = args if args is not None else []
+    req = {"jsonrpc": "2.0", "method": method, "params": params, "id": request_id}
+    s.write((json.dumps(req, separators=(",", ":")) + "\n").encode("ascii"))
+    s.flush()
+
+    deadline = time.time() + timeout
+    buf = b""
+    while time.time() < deadline:
+        chunk = s.read(s.in_waiting or 1)
+        if not chunk:
+            continue
+        buf += chunk
+        while b"\n" in buf:
+            line, _, buf = buf.partition(b"\n")
+            text = line.decode("ascii", errors="replace").strip()
+            for prefix in ("REMOTE: ", "RESULT: "):
+                if text.startswith(prefix):
+                    text = text[len(prefix) :]
+                    break
+            if not (text.startswith("{") and text.endswith("}")):
+                continue
+            try:
+                msg = json.loads(text)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(msg, dict) and msg.get("id") == request_id:
+                return msg
+    return None
+
+
+def parse_csv_result(result: Any) -> list[str] | None:
+    if not isinstance(result, str) or not result:
+        return None
+    parts = result.split(",")
+    if not parts or parts[0] != "1":
+        return None
+    return parts
+
+
+def run_transfer_once(
+    s: "serial.Serial",
+    byte_count: int,
+    byte_pattern: int,
+    divider: int,
+    core_hz: int,
+) -> bool:
+    print()
+    print(
+        f"  RPC dmaSpiTransferOnce(byte_count={byte_count}, byte_pattern=0x{byte_pattern:02X})"
+    )
+    reply = send_rpc(s, "dmaSpiTransferOnce", args=[byte_count, byte_pattern])
+    if reply is None or "result" not in reply:
+        print("    FAIL — no reply")
+        return False
+    parts = parse_csv_result(reply["result"])
+    if parts is None or len(parts) < 4:
+        print(f"    FAIL — malformed CSV: {reply['result']!r}")
+        return False
+
+    try:
+        started_us = int(parts[1])
+        done_us = int(parts[2])
+    except ValueError as e:
+        print(f"    FAIL — CSV parse error: {e}")
+        return False
+
+    duration_us = done_us - started_us
+    # Loose upper bound: 8 bits/byte * byte_count / SCK_hz + 3ms slack
+    # for RPC framing and TX-idle drain. Effective SCK = core / divider.
+    sck_hz = max(1, core_hz // max(1, divider))
+    theoretical_us = int(1_000_000 * 8 * byte_count / sck_hz)
+    upper_bound_us = theoretical_us + 3_000
+    ok = 0 < duration_us < upper_bound_us
+    verdict = "PASS" if ok else "FAIL"
+    print(
+        f"    {verdict} — duration={duration_us} us "
+        f"(theoretical={theoretical_us} us, upper_bound={upper_bound_us} us)"
+    )
+    return ok
+
+
+def run_transfer_overlap(
+    s: "serial.Serial",
+    byte_count: int,
+    byte_pattern: int,
+) -> bool:
+    print()
+    print(
+        f"  RPC dmaSpiTransferOverlap(byte_count={byte_count}, byte_pattern=0x{byte_pattern:02X})"
+    )
+    reply = send_rpc(s, "dmaSpiTransferOverlap", args=[byte_count, byte_pattern])
+    if reply is None or "result" not in reply:
+        print("    FAIL — no reply")
+        return False
+    parts = parse_csv_result(reply["result"])
+    if parts is None or len(parts) < 3:
+        print(f"    FAIL — malformed CSV: {reply['result']!r}")
+        return False
+
+    try:
+        total_us = int(parts[1])
+        toggle_count = int(parts[2])
+    except ValueError as e:
+        print(f"    FAIL — CSV parse error: {e}")
+        return False
+
+    # The affirmative async claim: non-zero toggle count under DMA load.
+    # Any positive count proves the CPU was free to run the beacon loop
+    # while the DMA channel drove the SPI TX pipeline. The absolute
+    # count depends on core clock + compiler codegen for the volatile
+    # counter loop — we just require > 0.
+    ok = toggle_count > 0 and total_us > 0
+    verdict = "PASS" if ok else "FAIL"
+    print(
+        f"    {verdict} — total={total_us} us, toggles={toggle_count} "
+        f"({toggle_count / max(1, total_us):.1f}/us)"
+    )
+    if not ok:
+        print("           toggle_count == 0 means DMA blocked the CPU")
+        print("           (or the volatile counter got optimized out).")
+    return ok
+
+
+def run_measure_sck(
+    s: "serial.Serial",
+    divider: int,
+    core_hz: int,
+) -> bool:
+    print()
+    print(f"  RPC dmaSpiMeasureSck(divider_hint={divider})")
+    reply = send_rpc(s, "dmaSpiMeasureSck", args=[divider])
+    if reply is None or "result" not in reply:
+        print("    FAIL — no reply")
+        return False
+    parts = parse_csv_result(reply["result"])
+    if parts is None or len(parts) < 3:
+        print(f"    FAIL — malformed CSV: {reply['result']!r}")
+        return False
+
+    try:
+        total_us = int(parts[1])
+        byte_count = int(parts[2])
+    except ValueError as e:
+        print(f"    FAIL — CSV parse error: {e}")
+        return False
+
+    if total_us <= 0 or byte_count <= 0:
+        print(f"    FAIL — zero total_us or byte_count ({total_us=}, {byte_count=})")
+        return False
+
+    measured_sck_hz = int(8 * byte_count * 1_000_000 / total_us)
+    expected_sck_hz = max(1, core_hz // max(1, divider))
+    # Loose ±25% band — the total_us includes the SPI master
+    # shift-register drain, which adds a fixed ~2 byte-times of
+    # overhead. On a 512-byte burst that's ~0.5% at 4 MHz, but on
+    # slower dividers it grows.
+    lo = int(expected_sck_hz * 0.75)
+    hi = int(expected_sck_hz * 1.25)
+    ok = lo <= measured_sck_hz <= hi
+    verdict = "PASS" if ok else "FAIL"
+    print(
+        f"    {verdict} — measured SCK={measured_sck_hz} Hz "
+        f"(expected ~{expected_sck_hz} Hz, band [{lo}, {hi}])"
+    )
+    return ok
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description="LPC845 SPI+DMA async driver bench (#3456)"
+    )
+    ap.add_argument("--port", default=DEFAULT_PORT)
+    ap.add_argument(
+        "--divider",
+        type=int,
+        default=DEFAULT_HARNESS_DIVIDER,
+        help="Compile-time SPI divider baked into the harness "
+        "(FASTLED_LPC_SPI_DMA_HARNESS_DIVIDER; default 6 → 4 MHz).",
+    )
+    ap.add_argument(
+        "--core-hz",
+        type=int,
+        default=DEFAULT_HARNESS_CORE_HZ,
+        help="LPC845 core clock in Hz (default 24_000_000).",
+    )
+    args = ap.parse_args()
+
+    if serial is None:
+        print("pyserial not available; install with `uv sync`")
+        return 1
+
+    print("LPC SPI+DMA async driver bench — FastLED #3456 (Phase 1 of #3453)")
+    print(f"  Port: {args.port} @ {DEFAULT_BAUD}")
+    print(
+        f"  Expected SCK: {args.core_hz // max(1, args.divider)} Hz "
+        f"(core={args.core_hz}, divider={args.divider})"
+    )
+
+    try:
+        s = serial.Serial(args.port, DEFAULT_BAUD, timeout=0.1)
+    except serial.SerialException as e:
+        print(f"Could not open {args.port}: {e}")
+        return 1
+
+    # Give the LPC845 a moment to boot after opening the port.
+    time.sleep(0.5)
+    s.reset_input_buffer()
+
+    all_pass = True
+
+    # Case 1: small single-shot transfer.
+    all_pass &= run_transfer_once(s, 32, 0xA5, args.divider, args.core_hz)
+
+    # Case 2: larger single-shot transfer — exercises the DMA descriptor
+    # path proper (bytes > 16 → DMA engages per the driver's fast-path).
+    all_pass &= run_transfer_once(s, 256, 0x5A, args.divider, args.core_hz)
+
+    # Case 3: async proof.
+    all_pass &= run_transfer_overlap(s, 512, 0xFF)
+
+    # Case 4: SCK rate measurement.
+    all_pass &= run_measure_sck(s, args.divider, args.core_hz)
+
+    print()
+    print("=" * 60)
+    if all_pass:
+        print("PASS — #3456 SPI+DMA async bench green.")
+        return 0
+    else:
+        print("FAIL — one or more cases did not meet expected bounds.")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/AutoResearch/AutoResearchLowMemory.h
+++ b/examples/AutoResearch/AutoResearchLowMemory.h
@@ -96,6 +96,20 @@
 #include "AutoResearchPwmDmaClockless.h"
 #endif
 
+// FastLED #3456: LPC845 SPI+DMA async AutoResearch harness (Phase 1 of
+// #3453 bench bring-up). Opt-in via `-DFASTLED_LPC_SPI_DMA=1`; the
+// header self-gates on `FL_IS_ARM_LPC_845 && FASTLED_LPC_SPI_DMA`.
+// Mutually exclusive with FASTLED_LPC_PWM_DMA — both share DMA0
+// channels and the LowMemory flash budget doesn't fit both. Enforced
+// host-side by `bash autoresearch` refusing `--dma-spi --pwm-dma-cl`.
+#if defined(FL_IS_ARM_LPC_845) && defined(FASTLED_LPC_SPI_DMA) && \
+    defined(FASTLED_LPC_PWM_DMA)
+#error "FASTLED_LPC_SPI_DMA and FASTLED_LPC_PWM_DMA are mutually exclusive: both claim DMA0 channels and the LowMemory flash budget doesn't fit both. Pick one for the AutoResearch build."
+#endif
+#if defined(FL_IS_ARM_LPC_845) && defined(FASTLED_LPC_SPI_DMA)
+#include "AutoResearchSpiDma.h"
+#endif
+
 namespace {
 fl::Remote* g_low_memory_remote = nullptr;
 
@@ -365,6 +379,13 @@ inline void autoResearchLowMemorySetup() {
     // FL_IS_ARM_LPC_845 && FASTLED_LPC_PWM_DMA.
 #if defined(FL_IS_ARM_LPC_845) && defined(FASTLED_LPC_PWM_DMA)
     autoresearch::pwm_dma_cl::bind(remote);
+#endif
+
+    // FastLED #3456: SPI+DMA async AutoResearch harness. Binds
+    // dmaSpiTransferOnce / dmaSpiTransferOverlap / dmaSpiMeasureSck.
+    // Header self-gates on FL_IS_ARM_LPC_845 && FASTLED_LPC_SPI_DMA.
+#if defined(FL_IS_ARM_LPC_845) && defined(FASTLED_LPC_SPI_DMA)
+    autoresearch::dma_spi::bind(remote);
 #endif
 
 #endif  // FL_IS_ARM_LPC && !FASTLED_AUTORESEARCH_IEEE754_MODE

--- a/examples/AutoResearch/AutoResearchSpiDma.h
+++ b/examples/AutoResearch/AutoResearchSpiDma.h
@@ -1,0 +1,227 @@
+// AutoResearchSpiDma.h — LPC845 SPI + DMA async driver AutoResearch
+// validation harness (FastLED #3456, Phase 1 of #3453 bench bring-up).
+//
+// Device-side RPC handlers that exercise the LPC845 SPI-with-DMA0
+// async driver (`ARMHardwareSPIOutputDMA<>` from
+// `platforms/arm/lpc/spi_arm_lpc_dma.h`, PR #3454) on real silicon.
+//
+// Gated on `FL_IS_ARM_LPC_845 && FASTLED_LPC_SPI_DMA`. The whole file
+// compiles out on any other build target.
+//
+// **Sibling of `AutoResearchPwmDmaClockless.h`** (#3468) — same
+// architectural shape, different peripheral. The two must not be
+// compiled into the same build (both claim DMA0 channels and the
+// LowMemory flash budget doesn't fit both). Enforced host-side by
+// `bash autoresearch` refusing `--dma-spi --pwm-dma-cl` together.
+//
+// Handlers registered (call `autoresearch::dma_spi::bind(remote)` from
+// AutoResearchLowMemory.h when `FASTLED_LPC_SPI_DMA` is defined):
+//
+//   `dmaSpiTransferOnce(byte_count, byte_pattern)`
+//     Fill an `byte_count`-byte buffer with `byte_pattern`, call
+//     `kickDmaStream()`, wait for `done()`, return CSV
+//     `"success,started_us,done_us,cpu_busy_bit"`. `cpu_busy_bit` is
+//     always 0 in this handler (we wait on the CPU); the async proof
+//     is via `dmaSpiTransferOverlap` below.
+//
+//   `dmaSpiTransferOverlap(byte_count, byte_pattern)`
+//     Kick the same stream but run a tight beacon-toggle counter
+//     between `kickDmaStream()` and `done() == true`. Reports CSV
+//     `"success,total_us,toggle_count"`. Non-zero `toggle_count`
+//     under DMA load is the affirmative async claim — the CPU was
+//     free to run application code while the DMA0 channel drove
+//     SPI TX.
+//
+//   `dmaSpiMeasureSck(divider)`
+//     Emits a short burst at the passed divider; returns
+//     `"success,total_us,byte_count"` so the host can compute the
+//     effective SCK rate via `SCK_hz = byte_count * 8 / total_s`.
+//     No SCT input capture on the SCK pin (that's issue #3015 Phase 3
+//     territory — the SCT capture backend is opt-in and doesn't ship
+//     the mux configuration for arbitrary SPI pins yet); the host
+//     compares the measured effective rate against the requested
+//     divider band as a first-order sanity check.
+//
+// Buffer sizing: the harness reuses the driver's static encode buffer
+// (`FASTLED_LPC_SPI_DMA_MAX_BYTES`, default 2048). Requests larger
+// than that are clamped by the driver.
+
+#pragma once
+
+#include <FastLED.h>
+
+#if defined(FL_IS_ARM_LPC_845) && defined(FASTLED_LPC_SPI_DMA)
+
+#include "fl/remote/remote.h"
+#include "fl/stl/noexcept.h"
+#include "fl/stl/sstream.h"
+#include "platforms/arm/lpc/spi_arm_lpc_dma.h" // ok platform headers — AutoResearch driver-specific test needs the concrete SPI DMA driver
+
+namespace autoresearch {
+namespace dma_spi {
+
+// Default pin assignment matches the LPC845-BRK SPI0 typical routing.
+// FastPin::setOutput() runs against these, but the actual MOSI/SCK
+// carrier is routed by SWM independently — fbuild's SystemInit
+// configures SPI0 to sensible defaults.
+//
+// If the user needs to move pins, override at compile time via
+// `-DFASTLED_LPC_SPI_DMA_HARNESS_DATA_PIN=<N>` /
+// `-DFASTLED_LPC_SPI_DMA_HARNESS_CLOCK_PIN=<N>` /
+// `-DFASTLED_LPC_SPI_DMA_HARNESS_DIVIDER=<N>`.
+#ifndef FASTLED_LPC_SPI_DMA_HARNESS_DATA_PIN
+#define FASTLED_LPC_SPI_DMA_HARNESS_DATA_PIN 17
+#endif
+#ifndef FASTLED_LPC_SPI_DMA_HARNESS_CLOCK_PIN
+#define FASTLED_LPC_SPI_DMA_HARNESS_CLOCK_PIN 13
+#endif
+#ifndef FASTLED_LPC_SPI_DMA_HARNESS_DIVIDER
+// 24 MHz core / 6 → 4 MHz SCK. Fast enough that a 256-byte transfer
+// completes in ~0.5 ms — well inside the RPC response window.
+#define FASTLED_LPC_SPI_DMA_HARNESS_DIVIDER 6
+#endif
+
+using HarnessDriver = ARMHardwareSPIOutputDMA<
+    static_cast<fl::u8>(FASTLED_LPC_SPI_DMA_HARNESS_DATA_PIN),
+    static_cast<fl::u8>(FASTLED_LPC_SPI_DMA_HARNESS_CLOCK_PIN),
+    static_cast<fl::u32>(FASTLED_LPC_SPI_DMA_HARNESS_DIVIDER)>;
+
+// Bench buffer: sized to the driver's encode-buffer capacity so callers
+// can hit the widest DMA descriptor the driver will accept.
+inline fl::u8* harnessBuffer() FL_NO_EXCEPT {
+    static fl::u8 buf[FASTLED_LPC_SPI_DMA_MAX_BYTES] = {0};
+    return buf;
+}
+
+// Lazy driver instantiation — first RPC call configures SPI+DMA once.
+inline HarnessDriver& harnessDriver() FL_NO_EXCEPT {
+    static HarnessDriver drv;
+    static bool inited = false;
+    if (!inited) {
+        drv.init();
+        inited = true;
+    }
+    return drv;
+}
+
+// Bounds guard for host-supplied lengths — matches
+// FASTLED_LPC_SPI_DMA_MAX_BYTES so we can't overflow the static
+// encode buffer even if the host misbehaves.
+inline int clampByteCount(int n) FL_NO_EXCEPT {
+    if (n <= 0) return 0;
+    const int cap = static_cast<int>(FASTLED_LPC_SPI_DMA_MAX_BYTES);
+    return (n > cap) ? cap : n;
+}
+
+// One-shot DMA transfer with CPU wait. CSV: "success,started_us,done_us,cpu_busy".
+inline fl::string transferOnceHandler(int byte_count, int byte_pattern) FL_NO_EXCEPT {
+    const int len = clampByteCount(byte_count);
+    if (len == 0) return fl::string("0,0,0,0");
+    fl::u8* buf = harnessBuffer();
+    const fl::u8 pat = static_cast<fl::u8>(byte_pattern & 0xFF);
+    for (int i = 0; i < len; ++i) buf[i] = pat;
+
+    HarnessDriver& drv = harnessDriver();
+    // Ensure prior stream has drained before we time this one.
+    drv.waitFully();
+
+    const fl::u32 t_start = micros();
+    HarnessDriver::kickDmaStream(buf, static_cast<fl::u32>(len));
+    // Poll for done() without WFI so the elapsed measurement matches
+    // the CPU-busy-wait cost path. (Callers wanting the WFI sleep path
+    // use `waitDma()` — that's not what we're measuring here.)
+    while (!HarnessDriver::done()) {
+        // spin
+    }
+    const fl::u32 t_end = micros();
+
+    fl::sstream s;
+    s << 1 << ',' << t_start << ',' << t_end << ',' << 0;
+    return s.str();
+}
+
+// Async proof — kick and beacon-toggle a counter while DMA runs.
+// CSV: "success,total_us,toggle_count". Non-zero toggle_count is the
+// affirmative async claim.
+inline fl::string transferOverlapHandler(int byte_count, int byte_pattern) FL_NO_EXCEPT {
+    const int len = clampByteCount(byte_count);
+    if (len == 0) return fl::string("0,0,0");
+    fl::u8* buf = harnessBuffer();
+    const fl::u8 pat = static_cast<fl::u8>(byte_pattern & 0xFF);
+    for (int i = 0; i < len; ++i) buf[i] = pat;
+
+    HarnessDriver& drv = harnessDriver();
+    drv.waitFully();
+
+    const fl::u32 t_start = micros();
+    HarnessDriver::kickDmaStream(buf, static_cast<fl::u32>(len));
+
+    // Beacon-toggle loop. Volatile counter forces the compiler to
+    // emit real memory ops each iteration — otherwise the loop
+    // collapses and the "async proof" becomes an over-optimized nop.
+    volatile fl::u32 toggle_count = 0;
+    while (!HarnessDriver::done()) {
+        ++toggle_count;
+    }
+    const fl::u32 t_end = micros();
+    const fl::u32 total_us = t_end - t_start;
+
+    fl::sstream s;
+    s << 1 << ',' << total_us << ',' << toggle_count;
+    return s.str();
+}
+
+// SCK measurement via wall-clock timing. CSV: "success,total_us,byte_count".
+// Host computes effective SCK from `byte_count * 8 / total_us`. The
+// `divider_hint` parameter is echoed back for the log — the compile-time
+// driver divider is what actually runs (`FASTLED_LPC_SPI_DMA_HARNESS_DIVIDER`).
+inline fl::string measureSckHandler(int divider_hint) FL_NO_EXCEPT {
+    (void)divider_hint;
+    // 512 bytes @ 4 MHz SCK ≈ 1.024 ms — small enough for RPC latency,
+    // big enough that the timer resolution isn't the dominant term.
+    constexpr int kBenchBytes = 512;
+    fl::u8* buf = harnessBuffer();
+    for (int i = 0; i < kBenchBytes; ++i) buf[i] = 0xA5;
+
+    HarnessDriver& drv = harnessDriver();
+    drv.waitFully();
+
+    const fl::u32 t_start = micros();
+    HarnessDriver::kickDmaStream(buf, static_cast<fl::u32>(kBenchBytes));
+    while (!HarnessDriver::done()) {
+        // spin
+    }
+    // Include the SPI master shift-register drain so the wire time
+    // covers full byte delivery (kickDmaStream returns when DMA is
+    // drained, but the SPI master can still be clocking out the
+    // final byte in the shift register).
+    drv.waitFully();
+    const fl::u32 t_end = micros();
+    const fl::u32 total_us = t_end - t_start;
+
+    fl::sstream s;
+    s << 1 << ',' << total_us << ',' << kBenchBytes;
+    return s.str();
+}
+
+// Bind the three handlers on the passed-in `Remote`. Call from
+// AutoResearchLowMemory.h under `#if defined(FASTLED_LPC_SPI_DMA)`.
+inline void bind(fl::Remote& remote) FL_NO_EXCEPT {
+    remote.bind("dmaSpiTransferOnce",
+        [](int byte_count, int byte_pattern) -> fl::string {
+            return transferOnceHandler(byte_count, byte_pattern);
+        });
+    remote.bind("dmaSpiTransferOverlap",
+        [](int byte_count, int byte_pattern) -> fl::string {
+            return transferOverlapHandler(byte_count, byte_pattern);
+        });
+    remote.bind("dmaSpiMeasureSck",
+        [](int divider_hint) -> fl::string {
+            return measureSckHandler(divider_hint);
+        });
+}
+
+}  // namespace dma_spi
+}  // namespace autoresearch
+
+#endif  // FL_IS_ARM_LPC_845 && FASTLED_LPC_SPI_DMA


### PR DESCRIPTION
Closes #3456.

## Summary

Phase 1 of the #3453 bench bring-up series. Adds the device-side + host-side plumbing to exercise `ARMHardwareSPIOutputDMA<>` (from #3454) on real LPC845 silicon via the AutoResearch RPC contract, mirroring the pattern established by `--pwm-dma-cl` (#3468).

### Device-side

`examples/AutoResearch/AutoResearchSpiDma.h`, self-gated on `FL_IS_ARM_LPC_845 && FASTLED_LPC_SPI_DMA`, exposes three RPC handlers:

- `dmaSpiTransferOnce(byte_count, byte_pattern)` — single-shot DMA transfer with CPU-poll wait; reports timing.
- `dmaSpiTransferOverlap(byte_count, byte_pattern)` — kicks the stream then runs a `volatile` beacon-toggle counter until `done()`. Non-zero counter under DMA load is the affirmative async claim (proves the CPU was free to run application code while DMA drove SPI TX).
- `dmaSpiMeasureSck(divider_hint)` — 512-byte burst; host computes effective SCK Hz via wall-clock. No SCT input capture on SCK (that's #3015 Phase 3 territory).

Wired into `AutoResearchLowMemory.h` with a compile-time `#error` if the user tries to combine `FASTLED_LPC_SPI_DMA` with `FASTLED_LPC_PWM_DMA` — both claim DMA0 channels and the LowMemory flash budget doesn't fit both.

### Host-side

- `--dma-spi` flag on `bash autoresearch`, LPC845-only, mutually exclusive with `--pwm-dma-cl` (both would fight over DMA0 channels).
- New `_run_lpc_dma_spi_tests` phase entry in `ci/autoresearch/phases.py`.
- `ci/autoresearch/test_lpc_dma_spi.py` test runner: 4 cases —
  - `transferOnce@32B` — small transfer sanity
  - `transferOnce@256B` — crosses the driver's polled-vs-DMA fast-path threshold at 16B
  - `transferOverlap@512B` — affirmative async proof (requires non-zero beacon-toggle count)
  - `measureSck@512B` — ±25% band vs. compile-time divider

### Compile-time contract

The user compiles with `-DFASTLED_LPC_SPI_DMA=1` (add to `platformio.ini` or fbuild config) before running the wrapper. Optional overrides:
- `-DFASTLED_LPC_SPI_DMA_HARNESS_DATA_PIN=<N>` (default 17)
- `-DFASTLED_LPC_SPI_DMA_HARNESS_CLOCK_PIN=<N>` (default 13)
- `-DFASTLED_LPC_SPI_DMA_HARNESS_DIVIDER=<N>` (default 6 → 4 MHz SCK on the 24 MHz LPC845 FRO)
- `-DFASTLED_LPC_SPI_DMA_CHANNEL=4` (SPI1 default per driver)

## Silicon status

Silicon validation deferred to the next hardware bring-up run — the harness compiles clean on host and gates out on all non-LPC targets. This PR delivers the plumbing that #3456 requested; the pass/fail bands themselves are only meaningful when run against real LPC845 hardware.

## Test plan

- [x] `bash compile wasm --examples AutoResearch` — WASM compiles clean (gates correctly compile out on non-LPC)
- [x] `bash test --cpp --clean` — 344/344 tests pass
- [x] `bash lint` — clean
- [ ] `bash autoresearch lpc845 --dma-spi` — pending silicon access

## Related

- #3453 — LPC8xx async DMA output drivers meta (this is Phase 1 device-side deliverable)
- #3454 — SPI DMA driver PR (the thing this harness exercises)
- #3468 — sibling `--pwm-dma-cl` harness pattern
- #3500 — LPC804 SPI DMA gate widening (this harness also covers LPC804 once fbuild ≥ 2.3.16 ships)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new LPC845 SPI+DMA async AutoResearch option for hardware validation.
  * Introduced a serial-based test flow that checks transfer completion, async overlap, and effective clock timing.
  * Expanded the LowMemory example to support the new SPI+DMA harness and RPC handlers.

* **Bug Fixes**
  * Prevents incompatible LPC DMA configurations from being selected together.
  * Adds input clamping and safer setup for transfer tests to avoid oversized requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->