### PR TITLE
fix(autoresearch): widen SPI+DMA harness gate to LPC804 (#3456 follow-up)

### DIFF
--- a/ci/autoresearch/args.py
+++ b/ci/autoresearch/args.py
@@ -403,13 +403,15 @@ See Also:
         lpc_group.add_argument(
             "--dma-spi",
             action="store_true",
-            help="LPC845-only: SPI+DMA async driver bench (FastLED #3456, "
-            "Phase 1 of #3453). Drives `ARMHardwareSPIOutputDMA<>` and "
-            "reports (a) single-shot transfer timing, (b) beacon-toggle "
-            "count during overlap to affirmatively prove CPU is free "
-            "during DMA, (c) SCK rate measurement via wall clock. "
-            "Mutually exclusive with --pwm-dma-cl (both claim DMA0 "
-            "channels and the LowMemory flash budget doesn't fit both).",
+            help="LPC845/LPC804 SPI+DMA async driver bench (FastLED "
+            "#3456, Phase 1 of #3453). Drives `ARMHardwareSPIOutputDMA<>` "
+            "and reports (a) single-shot transfer timing, (b) beacon-"
+            "toggle count during overlap to affirmatively prove CPU is "
+            "free during DMA, (c) SCK rate measurement via wall clock. "
+            "On LPC845 mutually exclusive with --pwm-dma-cl (both claim "
+            "DMA0 channels and the LowMemory flash budget doesn't fit "
+            "both). LPC804 requires fbuild >= 2.3.16 for the vendor DMA0 "
+            "typedef (framework-arduino-lpc8xx#35 + fbuild#916).",
         )
 
         # Standard options

--- a/ci/autoresearch/phases.py
+++ b/ci/autoresearch/phases.py
@@ -266,6 +266,10 @@ LPC_BRING_UP_ENVS = {
     "lpcxpresso804",
 }
 LPC_WS2812_ENVS = {"lpc845brk", "lpc845", "lpcxpresso845max"}
+# SPI+DMA harness (#3456) covers both LPC845 and LPC804 — the driver
+# `spi_arm_lpc_dma.h` was widened to LPC804 in #3500 once fbuild >=
+# 2.3.16 ships the vendor DMA0 typedef from framework-arduino-lpc8xx#35.
+LPC_DMA_SPI_ENVS = LPC_WS2812_ENVS | {"lpcxpresso804"}
 LPC_IEEE754_BUILD_ENVS = {
     "lpc845brk": "lpc845brk_ieee754",
 }
@@ -1689,12 +1693,13 @@ async def _run_tests_or_special_mode(ctx: RunContext, qctx: QuietContext) -> int
                 return 1
             return await _run_lpc_pwm_dma_cl_tests(ctx)
         # FastLED #3456: --dma-spi runs the SPI+DMA async driver bench.
-        # Phase 1 of the #3453 bring-up.
+        # Phase 1 of the #3453 bring-up. Covers both LPC845 and LPC804
+        # (driver was widened to LPC804 in #3500).
         if getattr(ctx.args, "dma_spi", False):
-            if final_environment not in LPC_WS2812_ENVS:
+            if final_environment not in LPC_DMA_SPI_ENVS:
                 print(
-                    "--dma-spi is only supported on LPC845 boards "
-                    "(lpc845brk, lpc845, lpcxpresso845max)."
+                    "--dma-spi is only supported on LPC845/LPC804 boards "
+                    "(lpc845brk, lpc845, lpcxpresso845max, lpcxpresso804)."
                 )
                 return 1
             return await _run_lpc_dma_spi_tests(ctx)
@@ -2506,19 +2511,25 @@ async def _run_lpc_dma_spi_tests(ctx: RunContext) -> int:
     `examples/AutoResearch/AutoResearchSpiDma.h`.
     """
     final_environment = (ctx.final_environment or "").lower()
-    if final_environment not in LPC_WS2812_ENVS:
+    if final_environment not in LPC_DMA_SPI_ENVS:
         print(
-            "--dma-spi is only supported on LPC845 boards "
-            "(lpc845brk, lpc845, lpcxpresso845max)."
+            "--dma-spi is only supported on LPC845/LPC804 boards "
+            "(lpc845brk, lpc845, lpcxpresso845max, lpcxpresso804)."
         )
         return 1
 
     upload_port = ctx.upload_port
     assert upload_port is not None
 
+    # LPC845 F_CPU = 24 MHz; LPC804 F_CPU = 15 MHz — the Python runner
+    # needs the correct core clock to center the SCK measurement band.
+    is_lpc804 = final_environment == "lpcxpresso804"
+    core_hz = 15_000_000 if is_lpc804 else 24_000_000
+
     print()
     print("=" * 60)
     print("LPC SPI+DMA async driver bench — #3456 (Phase 1 of #3453)")
+    print(f"   Target: {final_environment} (core_hz={core_hz})")
     print(
         "   Driver: ARMHardwareSPIOutputDMA<> (src/platforms/arm/lpc/spi_arm_lpc_dma.h)"
     )
@@ -2537,6 +2548,8 @@ async def _run_lpc_dma_spi_tests(ctx: RunContext) -> int:
         "ci/autoresearch/test_lpc_dma_spi.py",
         "--port",
         upload_port,
+        "--core-hz",
+        str(core_hz),
     ]
     result = subprocess.run(cmd)
     return 0 if result.returncode == 0 else 1

--- a/examples/AutoResearch/AutoResearchLowMemory.h
+++ b/examples/AutoResearch/AutoResearchLowMemory.h
@@ -96,17 +96,23 @@
 #include "AutoResearchPwmDmaClockless.h"
 #endif
 
-// FastLED #3456: LPC845 SPI+DMA async AutoResearch harness (Phase 1 of
+// FastLED #3456: LPC8xx SPI+DMA async AutoResearch harness (Phase 1 of
 // #3453 bench bring-up). Opt-in via `-DFASTLED_LPC_SPI_DMA=1`; the
-// header self-gates on `FL_IS_ARM_LPC_845 && FASTLED_LPC_SPI_DMA`.
-// Mutually exclusive with FASTLED_LPC_PWM_DMA — both share DMA0
-// channels and the LowMemory flash budget doesn't fit both. Enforced
-// host-side by `bash autoresearch` refusing `--dma-spi --pwm-dma-cl`.
+// header self-gates on `(FL_IS_ARM_LPC_845 || FL_IS_ARM_LPC_804) &&
+// FASTLED_LPC_SPI_DMA` — driver-side gate matches (#3454 for LPC845,
+// #3500 widened for LPC804 once fbuild >= 2.3.16 ships the vendor
+// DMA0 typedef). Mutually exclusive with FASTLED_LPC_PWM_DMA on LPC845
+// (both share DMA0 channels and the LowMemory flash budget doesn't fit
+// both). LPC804 has no `FASTLED_LPC_PWM_DMA` (SCT+DMA clockless is
+// LPC845-only), so the LPC804 build never triggers the collision.
+// Enforced host-side by `bash autoresearch` refusing `--dma-spi
+// --pwm-dma-cl`.
 #if defined(FL_IS_ARM_LPC_845) && defined(FASTLED_LPC_SPI_DMA) && \
     defined(FASTLED_LPC_PWM_DMA)
-#error "FASTLED_LPC_SPI_DMA and FASTLED_LPC_PWM_DMA are mutually exclusive: both claim DMA0 channels and the LowMemory flash budget doesn't fit both. Pick one for the AutoResearch build."
+#error "FASTLED_LPC_SPI_DMA and FASTLED_LPC_PWM_DMA are mutually exclusive on LPC845: both claim DMA0 channels and the LowMemory flash budget doesn't fit both. Pick one for the AutoResearch build."
 #endif
-#if defined(FL_IS_ARM_LPC_845) && defined(FASTLED_LPC_SPI_DMA)
+#if (defined(FL_IS_ARM_LPC_845) || defined(FL_IS_ARM_LPC_804)) && \
+    defined(FASTLED_LPC_SPI_DMA)
 #include "AutoResearchSpiDma.h"
 #endif
 
@@ -383,8 +389,10 @@ inline void autoResearchLowMemorySetup() {
 
     // FastLED #3456: SPI+DMA async AutoResearch harness. Binds
     // dmaSpiTransferOnce / dmaSpiTransferOverlap / dmaSpiMeasureSck.
-    // Header self-gates on FL_IS_ARM_LPC_845 && FASTLED_LPC_SPI_DMA.
-#if defined(FL_IS_ARM_LPC_845) && defined(FASTLED_LPC_SPI_DMA)
+    // Header self-gates on (FL_IS_ARM_LPC_845 || FL_IS_ARM_LPC_804)
+    // && FASTLED_LPC_SPI_DMA.
+#if (defined(FL_IS_ARM_LPC_845) || defined(FL_IS_ARM_LPC_804)) && \
+    defined(FASTLED_LPC_SPI_DMA)
     autoresearch::dma_spi::bind(remote);
 #endif
 

--- a/examples/AutoResearch/AutoResearchSpiDma.h
+++ b/examples/AutoResearch/AutoResearchSpiDma.h
@@ -1,12 +1,17 @@
-// AutoResearchSpiDma.h — LPC845 SPI + DMA async driver AutoResearch
+// AutoResearchSpiDma.h — LPC8xx SPI + DMA async driver AutoResearch
 // validation harness (FastLED #3456, Phase 1 of #3453 bench bring-up).
 //
-// Device-side RPC handlers that exercise the LPC845 SPI-with-DMA0
+// Device-side RPC handlers that exercise the LPC8xx SPI-with-DMA0
 // async driver (`ARMHardwareSPIOutputDMA<>` from
-// `platforms/arm/lpc/spi_arm_lpc_dma.h`, PR #3454) on real silicon.
+// `platforms/arm/lpc/spi_arm_lpc_dma.h`, PR #3454 for LPC845 + #3500
+// gate-widening for LPC804) on real silicon.
 //
-// Gated on `FL_IS_ARM_LPC_845 && FASTLED_LPC_SPI_DMA`. The whole file
-// compiles out on any other build target.
+// Gated on `(FL_IS_ARM_LPC_845 || FL_IS_ARM_LPC_804) && FASTLED_LPC_SPI_DMA`.
+// LPC845 F_CPU = 24 MHz → default harness divider 6 gives ~4 MHz SCK.
+// LPC804 F_CPU = 15 MHz → default harness divider 6 gives ~2.5 MHz SCK
+// (pass `--core-hz 15000000` to the Python runner so the SCK measurement
+// band is centered correctly). The whole file compiles out on any other
+// build target.
 //
 // **Sibling of `AutoResearchPwmDmaClockless.h`** (#3468) — same
 // architectural shape, different peripheral. The two must not be
@@ -50,7 +55,8 @@
 
 #include <FastLED.h>
 
-#if defined(FL_IS_ARM_LPC_845) && defined(FASTLED_LPC_SPI_DMA)
+#if (defined(FL_IS_ARM_LPC_845) || defined(FL_IS_ARM_LPC_804)) && \
+    defined(FASTLED_LPC_SPI_DMA)
 
 #include "fl/remote/remote.h"
 #include "fl/stl/noexcept.h"
@@ -224,4 +230,4 @@ inline void bind(fl::Remote& remote) FL_NO_EXCEPT {
 }  // namespace dma_spi
 }  // namespace autoresearch
 
-#endif  // FL_IS_ARM_LPC_845 && FASTLED_LPC_SPI_DMA
+#endif  // (FL_IS_ARM_LPC_845 || FL_IS_ARM_LPC_804) && FASTLED_LPC_SPI_DMA


### PR DESCRIPTION
## Summary

The underlying driver `spi_arm_lpc_dma.h` was widened to LPC804 in #3500 once fbuild ≥ 2.3.16 ships the vendor DMA0 typedef, but the AutoResearch harness gate stayed LPC845-only — so LPC804 users can never exercise the `dmaSpi*` RPCs even with `FASTLED_LPC_SPI_DMA=1` set.

Direct follow-up to #3503 (which landed the harness) and #3500 (which widened the driver gate).

## Changes

- Widen `AutoResearchSpiDma.h` self-gate from `FL_IS_ARM_LPC_845` to `(FL_IS_ARM_LPC_845 || FL_IS_ARM_LPC_804)`. Header comments now note the F_CPU delta (24 MHz vs 15 MHz → default divider 6 yields 4 MHz vs 2.5 MHz SCK).
- Widen `AutoResearchLowMemory.h` include + bind gates to match. The compile-time mutex against `FASTLED_LPC_PWM_DMA` stays LPC845-only (LPC804 has no PWM+DMA clockless driver), so the LPC804 path never triggers the collision.
- Add `LPC_DMA_SPI_ENVS = LPC_WS2812_ENVS | {\"lpcxpresso804\"}` in `ci/autoresearch/phases.py` and switch the phase gate + error message to use it.
- Pass `--core-hz` to `test_lpc_dma_spi.py` based on the target environment (15_000_000 for `lpcxpresso804`, else 24_000_000) so the SCK measurement band is centered correctly on LPC804 too.
- Update `--dma-spi` `--help` text to note LPC804 support + the fbuild release prerequisite.

## Test plan

- [x] `bash compile wasm --examples AutoResearch` — clean
- [x] `bash lint` — clean
- [ ] `bash autoresearch lpcxpresso804 --dma-spi` — pending silicon + fbuild ≥ 2.3.16

## Related

- #3456 — SPI+DMA validation harness scope (delivered by #3503)
- #3500 — widen `spi_arm_lpc_dma.h` gate to LPC804
- #3499 — LPC804 SPI DMA support meta
- `framework-arduino-lpc8xx#35` — vendor DMA0 typedef prerequisite
- `fbuild#916` — bump ArduinoCore-LPC8xx pin for the DMA0 block

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded SPI+DMA AutoResearch support to include LPC804 boards alongside LPC845.
  * CLI help and test execution now reflect the broader LPC8xx coverage and adjust timing settings per target.

* **Bug Fixes**
  * Updated platform checks and error messages so SPI+DMA validation matches the supported LPC845/LPC804 environments.
  * Improved target-specific configuration during test runs to use the correct core speed for each board.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->