### PR TITLE
fix(i2s-esp32dev): wrap IDF 6 LL calls in PERIPH_RCC_ATOMIC critical section

### DIFF
--- a/src/platforms/esp/32/drivers/i2s/i2s_periph_compat.h
+++ b/src/platforms/esp/32/drivers/i2s/i2s_periph_compat.h
@@ -47,8 +47,17 @@ FL_EXTERN_C_BEGIN
 // IDF 6.x+ — periph_module_* was removed. Route through the LL API that
 // replaces it. `hal/i2s_ll.h` is a private HAL header but the public
 // surface for direct-register users on IDF 6 is precisely this file.
+//
+// Both `i2s_ll_enable_bus_clock` and `i2s_ll_reset_register` are wrapped
+// in `PERIPH_RCC_ATOMIC() { ... }` critical sections per the IDF 6
+// convention. The macro-form of both functions in `hal/i2s_ll.h`
+// requires `__DECLARE_RCC_ATOMIC_ENV` to be declared in scope, which
+// `PERIPH_RCC_ATOMIC()` from `esp_private/periph_ctrl.h` provides.
+// (Verified against espressif/esp-idf@master/components/esp_driver_i2s/
+// i2s_platform.c which uses the same pattern.)
 // IWYU pragma: begin_keep
 #include "hal/i2s_ll.h"
+#include "esp_private/periph_ctrl.h"  // PERIPH_RCC_ATOMIC() critical section
 #include "soc/soc_caps.h"
 // IWYU pragma: end_keep
 #endif
@@ -85,9 +94,15 @@ inline bool fl_i2s_periph_enable(int port) FL_NO_EXCEPT {
 #else
     // IDF 6.x — LL API replaces the removed periph_module surface.
     // Enable the bus clock and reset the peripheral register block.
-    // Bench validation on real IDF 6 silicon is FastLED#3509 Phase 7.
-    i2s_ll_enable_bus_clock(port, true);
-    i2s_ll_reset_register(port);
+    // Both calls must live inside `PERIPH_RCC_ATOMIC()` because the
+    // macro-form of the functions in `hal/i2s_ll.h` requires the
+    // `__DECLARE_RCC_ATOMIC_ENV` variable that macro provides.
+    // Same pattern as IDF 6's own components/esp_driver_i2s/
+    // i2s_platform.c.
+    PERIPH_RCC_ATOMIC() {
+        i2s_ll_enable_bus_clock(port, true);
+        i2s_ll_reset_register(port);
+    }
     return true;
 #endif
 }
@@ -110,7 +125,9 @@ inline bool fl_i2s_periph_disable(int port) FL_NO_EXCEPT {
     }
     return true;
 #else
-    i2s_ll_enable_bus_clock(port, false);
+    PERIPH_RCC_ATOMIC() {
+        i2s_ll_enable_bus_clock(port, false);
+    }
     return true;
 #endif
 }


### PR DESCRIPTION
## Summary

Defect fix on the Phase 3 IDF 6 compat shim that landed in #3511. Verified against real ESP-IDF master source that the LL API calls need to be wrapped in `PERIPH_RCC_ATOMIC() { }` — otherwise the caller fails to compile against IDF 6 because `__DECLARE_RCC_ATOMIC_ENV` isn't in scope.

## Verification against real ESP-IDF master (fa8039b5)

Fetched `components/esp_hal_i2s/esp32/include/hal/i2s_ll.h` from `espressif/esp-idf@master`:

```c
static inline void i2s_ll_enable_bus_clock(int i2s_id, bool enable) { ... }
/// use a macro to wrap the function, force the caller to use it in a critical section
/// the critical section needs to declare the __DECLARE_RCC_ATOMIC_ENV variable in advance
#define i2s_ll_enable_bus_clock(...) do { \
        (void)__DECLARE_RCC_ATOMIC_ENV; \
        i2s_ll_enable_bus_clock(__VA_ARGS__); \
    } while(0)

static inline void i2s_ll_reset_register(int i2s_id) { ... }
#define i2s_ll_reset_register(...) do { \
        (void)__DECLARE_RCC_ATOMIC_ENV; \
        i2s_ll_reset_register(__VA_ARGS__); \
    } while(0)
```

The macro-form of both functions requires `__DECLARE_RCC_ATOMIC_ENV` to be declared in scope. My compat shim from #3511 called them raw, which would fail compile.

Correct caller pattern (from `components/esp_driver_i2s/i2s_platform.c` in the same tree):

```c
PERIPH_RCC_ATOMIC() {
    i2s_ll_enable_bus_clock(id, true);
    i2s_ll_reset_register(id);
    i2s_ll_enable_core_clock(I2S_LL_GET_HW(id), true);
}
```

The `PERIPH_RCC_ATOMIC()` macro (in `esp_private/periph_ctrl.h`) provides the `__DECLARE_RCC_ATOMIC_ENV` variable and manages the critical section.

## Fix

```cpp
#include "esp_private/periph_ctrl.h"  // added

inline bool fl_i2s_periph_enable(int port) {
    // ...
#else
    PERIPH_RCC_ATOMIC() {                        // <-- added wrap
        i2s_ll_enable_bus_clock(port, true);
        i2s_ll_reset_register(port);
    }
    return true;
#endif
}
```

## Test plan

- [x] `bash test --cpp`: 344/344 pass (host suite unchanged — shim is IDF 6-only)
- [x] `bash lint --cpp`: clean
- [x] Symbol signatures verified against real ESP-IDF master source
- [ ] CI (esp32dev IDF 5.x — should be no-op, LL path is IDF 6-only)
- [ ] Real IDF 6 silicon bench — tracked under #3512 Phase 7 when pioarduino ships an IDF 6 platform binding

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved I2S reliability on ESP32 platforms by making clock and reset operations safer during enable/disable transitions.
  * Reduced the chance of intermittent audio or peripheral startup issues in newer ESP-IDF releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->