### PR TITLE
feat(i2s): remove FASTLED_ESP32_I2S selector, add IDF 6.0 CI target (#3515 Phase A)

### DIFF
--- a/.github/workflows/build_esp32dev_idf6.yml
+++ b/.github/workflows/build_esp32dev_idf6.yml
@@ -1,0 +1,48 @@
+name: esp32dev_idf6
+
+# Compile-smoke of the classic-ESP32 I2S clockless driver against ESP-IDF v6.0+
+# via pioarduino's prep_IDF6 branch (arduino-esp32 master with IDF v6.0.1+).
+#
+# This job exercises the `i2s_ll_enable_bus_clock` + `PERIPH_RCC_ATOMIC()` path
+# in `src/platforms/esp/32/drivers/i2s/i2s_periph_compat.h` (landed in #3511 /
+# #3514). Board defaults to `-DFASTLED_ESP32_I2S=1` so the Yves driver actually
+# compiles, not just the stubs.
+#
+# Part of FastLED#3516 meta / #3515 Phase A.
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'src/**'
+      - '!src/platforms/arm/**'
+      - '!src/platforms/wasm/**'
+      - '!src/platforms/avr/**'
+      - 'src/platforms/esp/**'
+      - 'examples/**'
+      - 'ci/**'
+      - '.github/workflows/build_esp32dev_idf6.yml'
+      - '.github/workflows/build_template.yml'
+      - 'CMakeLists.txt'
+      - 'platformio.ini'
+      - 'library.json'
+      - 'library.properties'
+      - 'pyproject.toml'
+      - 'uv.lock'
+  pull_request:
+    paths:
+      - 'src/platforms/esp/32/drivers/i2s/**'
+      - 'src/platforms/esp/clockless.h'
+      - '.github/workflows/build_esp32dev_idf6.yml'
+      - 'ci/boards.py'
+
+jobs:
+  build:
+    uses: ./.github/workflows/build_template.yml
+    with:
+      args: esp32dev_idf6 --examples Blink,SpecialDrivers/ESP/DriverTest

--- a/ci/boards.py
+++ b/ci/boards.py
@@ -17,6 +17,13 @@ ESP32_IDF_5_3_PIOARDUINO = "https://github.com/pioarduino/platform-espressif32/r
 ESP32_IDF_5_4_PIOARDUINO = "https://github.com/pioarduino/platform-espressif32/releases/download/54.03.20/platform-espressif32.zip"
 ESP32_IDF_5_5_PIOARDUINO = "https://github.com/pioarduino/platform-espressif32/releases/download/55.03.34/platform-espressif32.zip"
 ESP32_IDF_5_5_1_PIOARDUINO = "https://github.com/pioarduino/platform-espressif32/releases/download/55.03.35/platform-espressif32.zip"
+# IDF 6.0 preview via pioarduino prep_IDF6 branch (commit 98230ad4aa, 2026-05-25).
+# platform.json in this branch pins framework-arduinoespressif32 to
+# arduino-esp32/archive/master.zip — arduino-esp32 master built on ESP-IDF v6.0.1+.
+# Moves to a release tag when pioarduino cuts one. See FastLED#3516.
+ESP32_IDF_6_PIOARDUINO = (
+    "https://github.com/pioarduino/platform-espressif32.git#prep_IDF6"
+)
 ESP32_IDF_LATEST_PIOARDUINO = ESP32_IDF_5_5_1_PIOARDUINO
 
 ESP32_IDF_LATEST_PIOARDUINO = (
@@ -826,6 +833,20 @@ ESP32DEV_IDF4_4 = Board(
     board_name="esp32dev_idf44",
     real_board_name="esp32dev",
     platform=ESP32_IDF_4_4_LATEST,
+)
+
+# IDF 6.0 target for the classic-ESP32 I2S parallel-out driver bring-up
+# (FastLED#3515). Uses pioarduino's prep_IDF6 branch until an IDF6 release
+# tag ships. No FASTLED_ESP32_I2S selector — the driver auto-compiles via
+# FASTLED_ESP32_HAS_I2S (feature flag) and gc-sections elides it when
+# unused. Users select the I2S driver at runtime via
+# `FastLED.enableDriver<fl::Bus::FLEX_IO, 0>()` or
+# `FastLED.add<Channel::create<fl::Bus::FLEX_IO, 0>()>`.
+ESP32DEV_IDF6 = Board(
+    board_name="esp32dev_idf6",
+    real_board_name="esp32dev",
+    platform=ESP32_IDF_6_PIOARDUINO,
+    platform_needs_install=True,
 )
 
 STM32H747XI_GIGA = Board(

--- a/src/FastLED.h
+++ b/src/FastLED.h
@@ -44,12 +44,12 @@
 #    endif
 #  endif
 #endif
-// ESP32 I2S Driver compatibility warning
+// ESP32 I2S Driver deprecation notice — `FASTLED_ESP32_I2S` was removed
+// per FastLED#3516. If a user defines it we warn them to migrate to the
+// runtime selection API (`FastLED.enableDriver<fl::Bus::FLEX_IO, 0>()`)
+// instead of the compile-time flag.
 #if defined(FASTLED_ESP32_I2S) && !defined(FASTLED_INTERNAL)
-#include "platforms/esp/esp_version.h"  // ok platform headers
-#if defined(ESP_IDF_VERSION_MAJOR) && ESP_IDF_VERSION_MAJOR >= 5
-#warning "ESP32 I2S Driver: ESP-IDF 5.x detected. This driver may not work reliably with ESP-IDF 5.x+. Consider using RMT driver instead or staying on ESP-IDF 4.x. See ESP32_I2S_ISSUES.md for details. Report issues at: https://github.com/FastLED/FastLED/issues"
-#endif
+#warning "FASTLED_ESP32_I2S is deprecated (FastLED#3516). The I2S driver is now always compiled on classic ESP32 (gc-sections elides it when unused) and selected at runtime via `FastLED.enableDriver<fl::Bus::FLEX_IO, 0>()`. Remove the `-DFASTLED_ESP32_I2S` define — the flag is a no-op."
 #endif
 
 // ESP32 RMT Driver conflict prevention

--- a/src/platforms/esp/32/core/fastled_esp32.h
+++ b/src/platforms/esp/32/core/fastled_esp32.h
@@ -31,18 +31,18 @@
 #include "platforms/esp/32/drivers/spi/idf5_clockless_spi_esp32.h"
 #endif
 
-#ifdef FASTLED_ESP32_I2S
-#include "platforms/esp/esp_version.h"
-#if ESP_IDF_VERSION_6_OR_HIGHER
-// I2S parallel driver is not yet ported to ESP-IDF 6.0+.
-// PERIPH_I2S1_MODULE was removed; the driver needs LL API migration.
-// Falling through to RMT/SPI/blocking driver instead.
-#else
-#ifndef FASTLED_INTERNAL
+// Classic-ESP32 I2S parallel-out clockless driver.
+// The `FASTLED_ESP32_I2S` compile-time selector was removed per
+// FastLED#3516 — the driver header is now included whenever the platform
+// supports it (via `FASTLED_ESP32_HAS_I2S` feature flag), so
+// `--gc-sections` can elide it when unused. Users select the driver at
+// runtime via `FastLED.enableDriver<fl::Bus::FLEX_IO, 0>()` (or the
+// modern `FastLED.add<Channel::create<>>()` surface). Legacy
+// `addLeds<>` continues to route to the RMT / PARLIO / SPI default.
+// IDF 6+ path routes through `i2s_periph_compat.h`'s LL API shim.
+#if FASTLED_ESP32_HAS_I2S && !defined(FASTLED_INTERNAL)
 #include "platforms/esp/32/drivers/i2s/clockless_i2s_esp32.h"
 #endif
-#endif // ESP_IDF_VERSION_6_OR_HIGHER
-#endif // FASTLED_ESP32_I2S
 
 // Bulk controller implementations have been replaced by the Channel API
 // See src/fl/channels/README.md for multi-strip support

--- a/src/platforms/esp/clockless.h
+++ b/src/platforms/esp/clockless.h
@@ -28,16 +28,21 @@ namespace fl {
 
 // Define platform-default ClocklessController alias for ESP32
 // Multiple driver types are available (ClocklessIdf4/ClocklessIdf5, ClocklessSPI, ClocklessI2S)
-// This alias selects the preferred default for backward compatibility
-#if defined(FASTLED_ESP32_I2S)
-  // I2S driver requested explicitly. On ESP-IDF 4.x/5.x uses the classic
-  // periph_module path; on IDF 6.x+ routes through the LL-API compat shim
-  // (`i2s_periph_compat.h`). See FastLED#3509.
-  template <int DATA_PIN, typename TIMING, EOrder RGB_ORDER = RGB, int XTRA0 = 0, bool FLIP = false, int WAIT_TIME = 5>
-  using ClocklessController = ClocklessI2S<DATA_PIN, TIMING, RGB_ORDER, XTRA0, FLIP, WAIT_TIME>;
-  #define FL_CLOCKLESS_CONTROLLER_DEFINED 1
-
-#elif FASTLED_ESP32_HAS_PARLIO && \
+// This alias selects the preferred default for backward compatibility.
+//
+// I2S parallel-out is NO LONGER selected via compile-time flag — the
+// `FASTLED_ESP32_I2S` selector was removed per FastLED#3516. The driver
+// still compiles in via `FASTLED_ESP32_HAS_I2S` (auto-enabled on classic
+// ESP32) so `--gc-sections` elides it when unused; users who want I2S
+// bind it at runtime via
+//   `FastLED.enableDriver<fl::Bus::FLEX_IO, 0>()`
+// or the modern channel API
+//   `FastLED.add<Channel::create<fl::Bus::FLEX_IO, 0>()>`.
+//
+// Legacy `addLeds<WS2812, PIN, GRB>()` continues to get the RMT / PARLIO
+// / SPI default below — the unchanged behavior for callers who don't
+// explicitly select a driver.
+#if FASTLED_ESP32_HAS_PARLIO && \
       (defined(FL_IS_ESP_32P4) || defined(FL_IS_ESP_32C6) || \
        defined(FL_IS_ESP_32H2) || defined(FL_IS_ESP_32C5))
   // PARLIO is the clockless default on ESP32-P4/C6/H2/C5.


### PR DESCRIPTION
## Summary

Two interlocking changes for the classic-ESP32 I2S clockless driver:

1. **Removes `FASTLED_ESP32_I2S` compile-time selector.** The driver code now always compiles on classic ESP32 (via the existing `FASTLED_ESP32_HAS_I2S` feature flag); `--gc-sections` elides it when unused. Users select the driver at runtime via `FastLED.enableDriver<fl::Bus::FLEX_IO, 0>()` — matching the modern channel-manager surface.
2. **Adds an IDF 6.0 CI compile target** using pioarduino's `prep_IDF6` branch (`arduino-esp32` master, ESP-IDF v6.0.1+). This exercises the `PERIPH_RCC_ATOMIC()` wrap in `i2s_periph_compat.h` (#3514) end-to-end for the first time.

Part of FastLED#3516 / #3515 Phase A.

## Files changed

- `src/FastLED.h` — `FASTLED_ESP32_I2S` becomes a `#warning` directing users to the runtime-selection API.
- `src/platforms/esp/32/core/fastled_esp32.h` — I2S header gated on `FASTLED_ESP32_HAS_I2S` (feature) instead of the removed selector.
- `src/platforms/esp/clockless.h` — dropped the `#if defined(FASTLED_ESP32_I2S)` branch of the `ClocklessController` alias.
- `ci/boards.py` — new `ESP32_IDF_6_PIOARDUINO` URL + `ESP32DEV_IDF6` board.
- `.github/workflows/build_esp32dev_idf6.yml` — compile-smoke workflow.

## Migration for users on `-DFASTLED_ESP32_I2S=1`

Old:
```
build_flags = -DFASTLED_ESP32_I2S=1
```

```cpp
FastLED.addLeds<WS2812, PIN, GRB>(leds, N);  // routed to I2S via -D flag
```

New (runtime binding):
```cpp
// legacy addLeds<> unchanged — still routes to RMT (default)
FastLED.enableDriver<fl::Bus::FLEX_IO, 0>();  // opt into I2S at runtime
FastLED.addLeds<WS2812, PIN, GRB>(leds, N);
```

The `#warning` in `FastLED.h` fires at compile time so anyone still passing the old flag gets a clean pointer at the migration path.

## Test plan

- [x] `bash test --cpp`: 344/344 pass (this is a pure gating change — host code path unaffected).
- [x] `bash lint --cpp`: clean.
- [ ] CI `build_esp32dev_idf6` — first-ever IDF 6.0 build of FastLED against the pioarduino `prep_IDF6` branch. This is the acceptance gate for #3515 Phase A.
- [ ] Existing `build_esp32_i2s_ws2812` (IDF 5.5) — must stay green with the flag removed.
- [ ] Existing `build_esp32dev_idf4.4` — must stay green with the flag removed.

## Non-goals

- Not moving DMA/ISR machinery into the modern peripheral impl — that's #3512 Phase 2 following the #3515 validation fence.
- Not adding the AutoResearch `--i2s` handler — that's #3515 Phase B, next PR.
- Not touching the ISR-refill invariant — documented + tested in #3515 Phase C, next PR.

## Blockers

If the pioarduino `prep_IDF6` branch head moves in a way that breaks the build, we need to pin to the exact commit `98230ad4aa` in `ci/boards.py`. Currently the URL uses the branch symbol which follows HEAD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CI support for an ESP32 development target using ESP-IDF 6, expanding build coverage for this platform.
* **Bug Fixes**
  * Updated ESP32 driver selection so the app now follows the newer runtime-based approach.
  * Removed reliance on an old compile-time I2S selector and added a clearer warning when it is used.
  * Improved ESP-IDF 6 compatibility for ESP32 clockless/I2S-related builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->