### PR TITLE
docs+fix: Bus::FLEX_IO runtime-selection guardrail + restore Yves opt-in

### DIFF
--- a/agents/docs/cpp-standards.md
+++ b/agents/docs/cpp-standards.md
@@ -229,6 +229,39 @@ For a subsystem (e.g., `Watchdog`, `Audio`, `Codec`) that has multi-tier platfor
 - **Exception:** genuinely separate peripherals (e.g. ESP32 LPSPI vs I2S_SPI are different silicon blocks with completely different register surfaces) get separate drivers. The "parallel-IO" qualifier excludes the different-peripheral-same-protocol case.
 - **History:** Established 2026-06-27 during #3428 FlexIO-SPI/ObjectFLED-SPI implementation. Initial design forked into separate FLEX_IO_SPI / OBJECT_FLED_SPI bus slots; user reverted because forking made the maintenance surface 4× larger with no benefit. See `src/fl/channels/README.md` → "Rule: Parallel-IO peripherals — one engine for both clockless and SPI modes" for the full pattern + reference code.
 
+## Runtime driver selection is `Bus::FLEX_IO` — legacy chipset templates are not (REQUIRED)
+- **Rule:** When adding an AutoResearch harness, on-device test, or any test-driver code that exercises a parallel-IO peripheral (FlexIO, ObjectFLED, ESP32 PARLIO, LCD_CAM, I2S1 parallel-out, etc.), **reach for the `Bus::FLEX_IO` runtime-selection surface**, never the legacy chipset template class directly.
+- **Old (wrong) way — reaching for the class template:**
+  ```cpp
+  // Rebuilds a whole custom pipeline around one specific driver's
+  // template and blocks driver unification. NEVER do this in a
+  // test harness or validation sketch.
+  ClocklessI2S<PIN, WS2812_TIMING, GRB> controller;   // ← wrong
+  FastLED.addLeds(&controller, leds, N);
+  ```
+- **New (right) way — runtime binding through `Bus::FLEX_IO`:**
+  ```cpp
+  // Bind whatever peripheral BusTraits<Bus::FLEX_IO, 0> resolves to
+  // on this silicon (classic ESP32 → I2S1; ESP32-P4/C6/H2/C5 →
+  // PARLIO; Teensy 4.x → FlexIO or ObjectFLED; ESP32-S3 → LCD_CAM).
+  FastLED.setExclusiveDriver<fl::Bus::FLEX_IO, 0>();
+  FastLED.addLeds<WS2812, PIN, GRB>(leds, N);
+  ```
+- **Subtype information (which concrete peripheral is actually bound, which port/instance number, which mode) goes into a device-info JSON structure returned by the RPC handler.** The handler is peripheral-agnostic; the runtime driver reports what it is. Example shape:
+  ```json
+  {
+    "bus": "FLEX_IO",
+    "instance": 0,
+    "peripheral": "I2S1_PARALLEL",
+    "port": 1,
+    "silicon": "ESP32-D0WD-V3",
+    "mode": "clockless"
+  }
+  ```
+- **Caveat — mind the `Bus::FLEX_IO, 0` binding on classic ESP32 today:** as of 2026-07-01, the `Bus::FLEX_IO, 0` slot on classic ESP32 routes to the **I2S-SPI** driver (`src/platforms/esp/32/drivers/i2s_spi/`), NOT the Yves parallel-out clockless driver (`src/platforms/esp/32/drivers/i2s/clockless_i2s_esp32.h`). The unified clockless-plus-SPI engine that would make the parallel-out clockless reachable via `Bus::FLEX_IO, 0` is tracked in [FastLED#3512 Phase 4](https://github.com/FastLED/FastLED/issues/3512). Until Phase 4 lands, an AutoResearch harness or test harness that wants to validate the Yves clockless parallel-out driver cannot reach it through the modern channel API — that harness is genuinely blocked on Phase 4. Do NOT invent a workaround by reaching for `ClocklessI2S<>` directly; write the harness once Phase 4 makes it reachable via `Bus::FLEX_IO, 0`.
+- **Rationale:** the whole point of the parallel-IO unified-engine rule (previous section) is that the `Bus::FLEX_IO` slot dispatches per-silicon to the right peripheral in the right mode, and users select drivers at runtime rather than compile-time. If a test harness reaches for one specific chipset template, that harness only works for one specific driver — and every future driver has to grow its own harness. One `Bus::FLEX_IO` harness works across every parallel-IO driver on every silicon, with subtype info flowing through the device-info JSON.
+- **History:** Established 2026-07-01 during [FastLED#3515 Phase B](https://github.com/FastLED/FastLED/issues/3515) drafting. Agent initially reached for `ClocklessI2S<>` directly to write an I2S-specific harness; user rejected because the modern channel-manager surface makes I2S "just a `Bus::FLEX_IO` implementation," and subtype info belongs in a device-info JSON, not baked into the harness. See [FastLED#3516](https://github.com/FastLED/FastLED/issues/3516) meta and the surrounding refactor phases.
+
 ## Channel Engine DMA Wait Pattern
 - **`onBeginFrame()` / `show()` must wait for `poll() == READY` before starting a new frame** — use a simple `while (poll() != READY)` loop
 - **Yield in wait loops with `fl::task::run()`** — never busy-spin without yielding. Use `fl::task::run(250, fl::task::ExecFlags::SYSTEM)` inside wait loops to yield to the OS scheduler (FreeRTOS `vTaskDelay(0)` on ESP32, `std::this_thread::yield()` on host). This prevents watchdog timeouts and starvation of WiFi/BT/system tasks. Include `fl/task/executor.h`.

--- a/src/FastLED.h
+++ b/src/FastLED.h
@@ -44,12 +44,19 @@
 #    endif
 #  endif
 #endif
-// ESP32 I2S Driver deprecation notice — `FASTLED_ESP32_I2S` was removed
-// per FastLED#3516. If a user defines it we warn them to migrate to the
-// runtime selection API (`FastLED.enableDriver<fl::Bus::FLEX_IO, 0>()`)
-// instead of the compile-time flag.
+// ESP32 I2S Driver: `FASTLED_ESP32_I2S` is temporarily still honored as an
+// opt-in for the Yves parallel-out clockless driver, pending FastLED#3512
+// Phase 4 which will wire the Yves driver through `Bus::FLEX_IO, 0` in the
+// modern channel manager. Once Phase 4 lands, this flag is removed and
+// users select the driver at runtime via
+// `FastLED.setExclusiveDriver<fl::Bus::FLEX_IO, 0>()`.
+// The old ESP-IDF 5.x compatibility warning below fires so users know the
+// driver is on a deprecation path (FastLED#3516 tracks the migration).
 #if defined(FASTLED_ESP32_I2S) && !defined(FASTLED_INTERNAL)
-#warning "FASTLED_ESP32_I2S is deprecated (FastLED#3516). The I2S driver is now always compiled on classic ESP32 (gc-sections elides it when unused) and selected at runtime via `FastLED.enableDriver<fl::Bus::FLEX_IO, 0>()`. Remove the `-DFASTLED_ESP32_I2S` define — the flag is a no-op."
+#include "platforms/esp/esp_version.h"  // ok platform headers
+#if defined(ESP_IDF_VERSION_MAJOR) && ESP_IDF_VERSION_MAJOR >= 5
+#warning "ESP32 I2S Driver: ESP-IDF 5.x+ detected. The Yves parallel-out clockless driver works via `-DFASTLED_ESP32_I2S=1` but is on a deprecation path (FastLED#3516). Once FastLED#3512 Phase 4 wires the driver through `Bus::FLEX_IO, 0`, migrate to `FastLED.setExclusiveDriver<fl::Bus::FLEX_IO, 0>()` and drop the flag."
+#endif
 #endif
 
 // ESP32 RMT Driver conflict prevention

--- a/src/platforms/esp/clockless.h
+++ b/src/platforms/esp/clockless.h
@@ -30,19 +30,24 @@ namespace fl {
 // Multiple driver types are available (ClocklessIdf4/ClocklessIdf5, ClocklessSPI, ClocklessI2S)
 // This alias selects the preferred default for backward compatibility.
 //
-// I2S parallel-out is NO LONGER selected via compile-time flag — the
-// `FASTLED_ESP32_I2S` selector was removed per FastLED#3516. The driver
-// still compiles in via `FASTLED_ESP32_HAS_I2S` (auto-enabled on classic
-// ESP32) so `--gc-sections` elides it when unused; users who want I2S
-// bind it at runtime via
-//   `FastLED.enableDriver<fl::Bus::FLEX_IO, 0>()`
-// or the modern channel API
-//   `FastLED.add<Channel::create<fl::Bus::FLEX_IO, 0>()>`.
-//
-// Legacy `addLeds<WS2812, PIN, GRB>()` continues to get the RMT / PARLIO
-// / SPI default below — the unchanged behavior for callers who don't
-// explicitly select a driver.
-#if FASTLED_ESP32_HAS_PARLIO && \
+// The `FASTLED_ESP32_I2S` compile-time selector is kept for now because the
+// Yves parallel-out clockless driver is NOT yet reachable via
+// `Bus::FLEX_IO, 0` on classic ESP32 (that slot currently routes to the
+// I2S-SPI driver). Once FastLED#3512 Phase 4 wires the Yves clockless
+// through the modern channel-manager, this selector can be removed and
+// users migrate to `FastLED.setExclusiveDriver<fl::Bus::FLEX_IO, 0>()`.
+// See `agents/docs/cpp-standards.md` -> "Runtime driver selection is
+// `Bus::FLEX_IO` — legacy chipset templates are not (REQUIRED)" for the
+// full rationale and the future removal path.
+#if defined(FASTLED_ESP32_I2S) && !ESP_IDF_VERSION_6_OR_HIGHER
+  // I2S driver requested explicitly. On ESP-IDF 4.x/5.x uses the classic
+  // periph_module path; on IDF 6.x+ the compat shim in
+  // `i2s_periph_compat.h` handles the LL-API branch.
+  template <int DATA_PIN, typename TIMING, EOrder RGB_ORDER = RGB, int XTRA0 = 0, bool FLIP = false, int WAIT_TIME = 5>
+  using ClocklessController = ClocklessI2S<DATA_PIN, TIMING, RGB_ORDER, XTRA0, FLIP, WAIT_TIME>;
+  #define FL_CLOCKLESS_CONTROLLER_DEFINED 1
+
+#elif FASTLED_ESP32_HAS_PARLIO && \
       (defined(FL_IS_ESP_32P4) || defined(FL_IS_ESP_32C6) || \
        defined(FL_IS_ESP_32H2) || defined(FL_IS_ESP_32C5))
   // PARLIO is the clockless default on ESP32-P4/C6/H2/C5.


### PR DESCRIPTION
## Summary

Two interlocking changes prompted by user feedback during FastLED#3515 Phase B drafting:

1. **New REQUIRED agent-doc rule** captured in `agents/docs/cpp-standards.md`: any AutoResearch harness / test-driver code exercising a parallel-IO peripheral MUST reach for the `Bus::FLEX_IO` runtime-selection surface, not the legacy chipset class template. Subtype information (which peripheral is bound, port/instance, mode) belongs in a device-info JSON structure returned by the runtime engine — not baked into the harness.

2. **Fix**: restore the `FASTLED_ESP32_I2S` compile-time opt-in that #3518 removed. The removal was premature because the Yves parallel-out clockless driver is NOT yet reachable via `Bus::FLEX_IO, 0` on classic ESP32 (that slot currently routes to the I2S-SPI driver in `drivers/i2s_spi/`). Users on `-DFASTLED_ESP32_I2S=1` with `addLeds<WS2812, PIN, GRB>()` would silently fall through to RMT after #3518. This restores the working opt-in with a doc-comment marking it as stopgap pending #3512 Phase 4.

## Files

- **`agents/docs/cpp-standards.md`** — new REQUIRED section: "Runtime driver selection is `Bus::FLEX_IO` — legacy chipset templates are not." Includes:
  - Old (wrong) vs new (right) code samples
  - Device-info JSON schema example
  - Caveat about the current `Bus::FLEX_IO, 0` binding on classic ESP32
  - History note explaining the FastLED#3515 Phase B episode that prompted this rule
- **`src/platforms/esp/clockless.h`** — put back the `#if defined(FASTLED_ESP32_I2S)` branch that #3518 removed. Includes an in-code comment pointing at the removal path (FastLED#3512 Phase 4).
- **`src/FastLED.h`** — reverted the "flag was removed" claim in the `#warning`. Now says the flag is on a deprecation path (FastLED#3516) with the migration note pointing at #3512 Phase 4.

## What this documents for future agents

The bad path I fell into:
```cpp
// ❌ Reaching for the class template — blocks driver unification
ClocklessI2S<PIN, WS2812_TIMING, GRB> controller;
FastLED.addLeds(&controller, leds, N);
```

The right path once #3512 Phase 4 lands:
```cpp
// ✅ Runtime binding through Bus::FLEX_IO
FastLED.setExclusiveDriver<fl::Bus::FLEX_IO, 0>();
FastLED.addLeds<WS2812, PIN, GRB>(leds, N);
```

And subtype info via device-info JSON:
```json
{
  "bus": "FLEX_IO",
  "instance": 0,
  "peripheral": "I2S1_PARALLEL",
  "port": 1,
  "silicon": "ESP32-D0WD-V3",
  "mode": "clockless"
}
```

## Test plan

- [x] `bash test --cpp`: 344/344 pass.
- [x] `bash lint --cpp`: clean.
- [ ] CI (esp32dev IDF 5.5, IDF 4.4, IDF 6.0) — no behavioral change; users on `-DFASTLED_ESP32_I2S=1` continue to get the Yves driver on `addLeds<>` calls.

## Part of

FastLED#3516 meta / FastLED#3515 Phase C (documentation ratchet portion). The host-test portion of Phase C is deferred to a follow-up once #3512 Phase 4 exposes the peripheral surface that can be exercised without reaching for the classic template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for selecting parallel-IO drivers at runtime, including platform-specific notes and device-info reporting details.
  * Clarified the current migration path for legacy ESP32 driver usage.

* **Bug Fixes**
  * Improved compatibility for ESP32-based builds by adjusting driver selection behavior based on the platform version.
  * Refined fallback behavior so the intended driver is chosen more reliably at build and runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->