### PR TITLE
feat(i2s): re-include peripheral impl in unity build (#3512 Phase 5)

### DIFF
--- a/src/platforms/esp/32/drivers/i2s/_build.cpp.hpp
+++ b/src/platforms/esp/32/drivers/i2s/_build.cpp.hpp
@@ -17,23 +17,19 @@
 #include "platforms/esp/32/drivers/i2s/i2s_esp32dev.cpp.hpp"
 #include "platforms/esp/32/drivers/i2s/i2s_lcd_cam_peripheral_esp.cpp.hpp"
 #include "platforms/esp/32/drivers/i2s/i2s_lcd_cam_peripheral_mock.cpp.hpp"
+// FastLED#3512 Phase 5: `i2s_peripheral_esp32dev_esp.cpp.hpp` is
+// re-included here. Prior comments claimed the file's `driver/gpio.h`
+// include triggered an `ADC: CONFLICT!` boot loop when linked
+// alongside the restored classic Yves driver — that turned out to be
+// specifically about `driver/i2s.h` from the earlier Stage 2 (#3476)
+// impl, not `driver/gpio.h`. The current Stage 4 impl doesn't include
+// `driver/i2s.h` at all (only very-low-level headers per the file's
+// own doc comment), so the conflict rationale no longer applies. The
+// stub `transmit()` currently does no DMA (see FastLED#3512 Phase 2
+// for that work), so re-including adds a small TU that gc-sections
+// elides completely when nothing calls into `I2sPeripheralEsp32DevEsp`.
+#include "platforms/esp/32/drivers/i2s/i2s_peripheral_esp32dev_esp.cpp.hpp"
 #include "platforms/esp/32/drivers/i2s/i2s_peripheral_esp32dev_mock.cpp.hpp"
-// Stage 5 (#3474): the proven register+DMA+ISR machinery from the
-// classic-ESP32 I2S driver is restored above under
-// `i2s_esp32dev.{h,cpp.hpp}` + `clockless_i2s_esp32.{h,cpp.hpp}` —
-// these are the ~700 LoC that generate real WS2812 parallel-out
-// waveforms on I2S1. Users on classic ESP32 can hit that path via
-// the legacy `addLeds<WS2812, PIN, GRB>()` template. The modern
-// `ChannelEngineI2sEsp32Dev` + mock (still shipped above) exposes
-// the same peripheral behind a mock-testable IChannelDriver
-// interface for future code that wants the modern channel-manager
-// path. `i2s_peripheral_esp32dev_esp.cpp.hpp` (Stage 4 real-hw impl)
-// is intentionally NOT included here — its `driver/gpio.h` include
-// collides with the restored code at link time as an
-// `ADC: CONFLICT!` boot loop. A future PR that reworks the modern
-// peripheral to share I2S1/periph_module state (rather than
-// duplicating it) can drop the modern impl into the unity build
-// cleanly.
 
 #include "platforms/esp/32/drivers/i2s/wave8_encoder_i2s.cpp.hpp"
 

--- a/src/platforms/esp/32/drivers/i2s/i2s_peripheral_esp32dev_esp.cpp.hpp
+++ b/src/platforms/esp/32/drivers/i2s/i2s_peripheral_esp32dev_esp.cpp.hpp
@@ -1,6 +1,13 @@
 // IWYU pragma: private
 
-// UNITY_BUILD_EXCLUDE(Stage-4 real-hardware impl — intentionally NOT included in the i2s unity build because its `driver/gpio.h` include collides at link time with the restored classic `i2s_esp32dev.cpp.hpp` machinery as an `ADC: CONFLICT!` boot loop. See `_build.cpp.hpp` header comment for the design rationale; kept in-tree for a future PR that reworks the modern peripheral to share I2S1/periph_module state with the classic impl.)
+// FastLED#3512 Phase 5: this file is now part of the i2s unity build.
+// The earlier UNITY_BUILD_EXCLUDE marker cited a `driver/gpio.h` collision
+// against the restored classic Yves driver; on re-investigation the
+// actual `ADC: CONFLICT!` issue was `driver/i2s.h` in the Stage 2
+// (#3476) impl. This Stage 4 file drops `driver/i2s.h` entirely (see
+// the docblock below) so the conflict no longer applies. The stub
+// `transmit()` currently does no DMA — Phase 2 replaces it with real
+// register + DMA + ISR machinery reused from the classic driver.
 
 /// @file i2s_peripheral_esp32dev_esp.cpp.hpp
 /// @brief Real-hardware `II2sPeripheralEsp32Dev` impl — Stage 4 rewrite


### PR DESCRIPTION
## Summary

Removes the `UNITY_BUILD_EXCLUDE` marker from `i2s_peripheral_esp32dev_esp.cpp.hpp` and adds the file to `_build.cpp.hpp` alphabetically.

Prior comment claimed the file's `driver/gpio.h` include triggered an `ADC: CONFLICT!` boot loop. Re-investigating: the actual conflict was `driver/i2s.h` in Stage 2 (#3476), NOT `driver/gpio.h`. The current Stage 4 impl doesn't include `driver/i2s.h` at all, so the conflict rationale no longer applies.

The stub `transmit()` currently does no DMA (#3512 Phase 2 does that work), so re-including adds a small TU that `--gc-sections` elides completely when unused.

## Test plan

- [x] `bash test --cpp`: 344/344 pass
- [x] `bash lint --cpp`: clean (unity-build validates alphabetical order)
- [ ] CI: esp32dev, esp32dev_i2s, esp32dev_idf6

Part of FastLED#3516 / #3512 Phase 5.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated ESP32 I2S build integration so the peripheral implementation is included correctly in the unified build.
  * Removed an outdated exclusion that was no longer needed, helping prevent missed functionality in builds.
  * Refreshed build notes to reflect the current conflict status and implementation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->