### PR TITLE
fix(lint): fall back to bare cargo when soldr shim silently no-ops

### DIFF
--- a/ci/lint_cpp/rust_binary_cache.py
+++ b/ci/lint_cpp/rust_binary_cache.py
@@ -23,9 +23,23 @@ import platform
 import shutil
 import subprocess
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 
 from ci.util.paths import PROJECT_ROOT
+
+
+@dataclass(frozen=True)
+class _BuildStreamResult:
+    """Return type for :func:`_stream_build_cmd`.
+
+    ``line_count`` = non-empty stdout lines observed. The soldr-shim fallback
+    path in :func:`_run_build` treats ``returncode == 0`` combined with
+    ``line_count == 0`` as evidence that the wrapper no-oped.
+    """
+
+    returncode: int
+    line_count: int
 
 
 RUST_CRATE_DIR = PROJECT_ROOT / "ci" / "lint_cpp_rs"
@@ -220,12 +234,11 @@ def _resolve_soldr() -> str:
     return soldr
 
 
-def _stream_build_cmd(cmd: list[str], label: str, verbose: bool) -> tuple[int, int]:
-    """Run ``cmd`` under Popen, prefix-stream its stdout, return (rc, line_count).
+def _stream_build_cmd(cmd: list[str], label: str, verbose: bool) -> _BuildStreamResult:
+    """Run ``cmd`` under Popen, prefix-stream its stdout, return the result.
 
-    ``line_count`` is the number of non-empty output lines observed. Callers use
-    it to detect the "silent no-op" case where a wrapper binary exits 0 without
-    ever calling cargo (see the soldr-shim fallback path below).
+    See :class:`_BuildStreamResult` for the returned fields and the reason
+    ``line_count`` is exposed (soldr-shim fallback detection).
     """
     if verbose:
         print(
@@ -234,7 +247,7 @@ def _stream_build_cmd(cmd: list[str], label: str, verbose: bool) -> tuple[int, i
             flush=True,
         )
         print(
-            f"    cmd: {' '.join(cmd)}",
+            f"    cmd: {subprocess.list2cmdline(cmd)}",
             file=sys.stderr,
             flush=True,
         )
@@ -257,7 +270,7 @@ def _stream_build_cmd(cmd: list[str], label: str, verbose: bool) -> tuple[int, i
         # trailing whitespace only, don't collapse internal spacing).
         print(f"{prefix}{stripped}", file=sys.stderr, flush=True)
     returncode = proc.wait()
-    return returncode, line_count
+    return _BuildStreamResult(returncode=returncode, line_count=line_count)
 
 
 def _run_build(verbose: bool = True) -> None:
@@ -310,9 +323,13 @@ def _run_build(verbose: bool = True) -> None:
 
     soldr = _resolve_soldr()
     soldr_cmd = [soldr, "--no-cache", "cargo", *cargo_args]
-    returncode, line_count = _stream_build_cmd(soldr_cmd, "cargo", verbose)
+    result = _stream_build_cmd(soldr_cmd, "cargo", verbose)
 
-    if returncode == 0 and line_count == 0 and not _binary_path().exists():
+    if (
+        result.returncode == 0
+        and result.line_count == 0
+        and not _binary_path().exists()
+    ):
         # soldr shim exited 0 without invoking cargo. Fall back to bare
         # cargo so lint keeps working while soldr's Windows-shim regression
         # is being worked upstream.
@@ -323,11 +340,11 @@ def _run_build(verbose: bool = True) -> None:
             flush=True,
         )
         cargo_cmd = ["cargo", *cargo_args]
-        returncode, _ = _stream_build_cmd(cargo_cmd, "cargo", verbose)
+        result = _stream_build_cmd(cargo_cmd, "cargo", verbose)
 
-    if returncode != 0:
+    if result.returncode != 0:
         raise RuntimeError(
-            f"Rust C++ linter build failed (exit {returncode}); see "
+            f"Rust C++ linter build failed (exit {result.returncode}); see "
             f"[cargo] lines above for the underlying error."
         )
 

--- a/ci/lint_cpp/rust_binary_cache.py
+++ b/ci/lint_cpp/rust_binary_cache.py
@@ -220,6 +220,46 @@ def _resolve_soldr() -> str:
     return soldr
 
 
+def _stream_build_cmd(cmd: list[str], label: str, verbose: bool) -> tuple[int, int]:
+    """Run ``cmd`` under Popen, prefix-stream its stdout, return (rc, line_count).
+
+    ``line_count`` is the number of non-empty output lines observed. Callers use
+    it to detect the "silent no-op" case where a wrapper binary exits 0 without
+    ever calling cargo (see the soldr-shim fallback path below).
+    """
+    if verbose:
+        print(
+            f"    cwd: {PROJECT_ROOT}",
+            file=sys.stderr,
+            flush=True,
+        )
+        print(
+            f"    cmd: {' '.join(cmd)}",
+            file=sys.stderr,
+            flush=True,
+        )
+    proc = subprocess.Popen(
+        cmd,
+        cwd=str(PROJECT_ROOT),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        bufsize=1,  # line-buffered
+    )
+    assert proc.stdout is not None
+    prefix = f"    [{label}] "
+    line_count = 0
+    for line in proc.stdout:
+        stripped = line.rstrip()
+        if stripped:
+            line_count += 1
+        # Preserve the raw line (cargo emits progress bars via \r; strip
+        # trailing whitespace only, don't collapse internal spacing).
+        print(f"{prefix}{stripped}", file=sys.stderr, flush=True)
+    returncode = proc.wait()
+    return returncode, line_count
+
+
 def _run_build(verbose: bool = True) -> None:
     """Invoke ``soldr cargo build`` for the fastled-lint binary.
 
@@ -240,18 +280,26 @@ def _run_build(verbose: bool = True) -> None:
     runners, logging wrappers, CI harnesses), cargo's diagnostics
     disappear. The explicit stream + prefix makes every cargo line
     identifiable and visible even under those layers.
+
+    Broken-shim fallback
+    --------------------
+    soldr 0.7.87 (current PyPI head) ships as a ~118 KB Windows shim that,
+    on cold runners, exits 0 without invoking cargo or producing any
+    stdout — see the empty ``[cargo]`` prefix stream in FastLED CI unit
+    tests on windows-latest. When we detect that signature (rc == 0 AND
+    zero output lines AND binary not produced), fall back to invoking
+    ``cargo build`` directly. This loses soldr's cache assist but keeps
+    lint functional; the outer binary-cache layer still avoids re-building
+    on unchanged crate sources.
     """
-    soldr = _resolve_soldr()
-    cmd = [
-        soldr,
-        "--no-cache",
-        "cargo",
+    cargo_args = [
         "build",
         "--manifest-path",
         str(RUST_MANIFEST),
         "--bin",
         RUST_BINARY_NAME,
     ]
+
     if verbose:
         print(
             f"🔨 Building Rust C++ linter ({RUST_BINARY_NAME}) — this runs once "
@@ -259,34 +307,23 @@ def _run_build(verbose: bool = True) -> None:
             file=sys.stderr,
             flush=True,
         )
-        print(
-            f"    cwd: {PROJECT_ROOT}",
-            file=sys.stderr,
-            flush=True,
-        )
-        print(
-            f"    cmd: {' '.join(cmd)}",
-            file=sys.stderr,
-            flush=True,
-        )
 
-    # Popen + explicit stream. stderr merged into stdout so line ordering
-    # matches what a user would see running the command interactively.
-    proc = subprocess.Popen(
-        cmd,
-        cwd=str(PROJECT_ROOT),
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        text=True,
-        bufsize=1,  # line-buffered
-    )
-    assert proc.stdout is not None
-    prefix = "    [cargo] "
-    for line in proc.stdout:
-        # Preserve the raw line (cargo emits progress bars via \r; strip
-        # trailing whitespace only, don't collapse internal spacing).
-        print(f"{prefix}{line.rstrip()}", file=sys.stderr, flush=True)
-    returncode = proc.wait()
+    soldr = _resolve_soldr()
+    soldr_cmd = [soldr, "--no-cache", "cargo", *cargo_args]
+    returncode, line_count = _stream_build_cmd(soldr_cmd, "cargo", verbose)
+
+    if returncode == 0 and line_count == 0 and not _binary_path().exists():
+        # soldr shim exited 0 without invoking cargo. Fall back to bare
+        # cargo so lint keeps working while soldr's Windows-shim regression
+        # is being worked upstream.
+        print(
+            "    ⚠  soldr shim exited 0 with no cargo output and no binary "
+            "produced — falling back to bare `cargo build`.",
+            file=sys.stderr,
+            flush=True,
+        )
+        cargo_cmd = ["cargo", *cargo_args]
+        returncode, _ = _stream_build_cmd(cargo_cmd, "cargo", verbose)
 
     if returncode != 0:
         raise RuntimeError(


### PR DESCRIPTION
Fixes the red unit tests windows workflow. Root cause: soldr 0.7.87 shim exits 0 without invoking cargo on cold Windows runners. Fix adds a fallback to bare cargo in ci/lint_cpp/rust_binary_cache.py when soldr silently no-ops (rc==0, no output, no binary). Verified locally on Windows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Rust binary build reliability by adding a fallback to a direct build when the wrapper completes without producing the expected output.
  * Enhanced build output handling by streaming and prefixing command logs for clearer progress and failure visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->