### PR TITLE
feat(autoresearch): add flexIoDeviceInfo RPC — Bus::FLEX_IO introspection (#3515 Phase B)

### DIFF
--- a/examples/AutoResearch/AutoResearchFlexIo.h
+++ b/examples/AutoResearch/AutoResearchFlexIo.h
@@ -1,0 +1,150 @@
+/// @file AutoResearchFlexIo.h
+/// @brief `Bus::FLEX_IO` runtime-binding introspection RPC handler
+///        (FastLED#3515 Phase B).
+///
+/// Follows the `Bus::FLEX_IO` runtime-selection convention documented
+/// in `agents/docs/cpp-standards.md` -> "Runtime driver selection is
+/// `Bus::FLEX_IO` — legacy chipset templates are not (REQUIRED)". The
+/// harness is peripheral-agnostic:
+///
+/// - On classic ESP32 `Bus::FLEX_IO, 0` currently routes to the I2S-SPI
+///   driver (`I2S_SPI`); the Yves parallel-out clockless driver joins
+///   the same slot once FastLED#3512 Phase 4 lands.
+/// - On ESP32-P4 / C6 / H2 / C5 it routes to `PARLIO`.
+/// - On ESP32-S3 it routes to `LCD_CLOCKLESS` or `LCD_RGB` depending
+///   on which is registered.
+/// - On Teensy 4.x it routes to `FLEX_IO` (FlexIO2) or `OBJECT_FLED`
+///   depending on instance number.
+///
+/// The `flexIoDeviceInfo` RPC returns a device-info JSON structure the
+/// host can inspect to see which concrete peripheral is bound.
+/// Subtype details (I2S port, DMA channels, pin routing) are the
+/// responsibility of a future driver-specific `getDeviceInfo()` method
+/// — this v1 uses the existing `IChannelDriver::getName()` + build-time
+/// preprocessor macros.
+
+#pragma once
+
+#include "FastLED.h"
+#include "fl/channels/bus.h"
+#include "fl/channels/manager.h"
+#include "fl/stl/int.h"
+#include "fl/stl/json.h"
+#include "fl/stl/string.h"
+#include "platforms/is_platform.h"
+
+namespace autoresearch {
+namespace flex_io {
+
+/// Platform identification string derived from build-time macros.
+inline fl::string siliconName() FL_NO_EXCEPT {
+#if defined(FL_IS_ESP_32DEV)
+    return fl::string::from_literal("ESP32");
+#elif defined(FL_IS_ESP_32S2)
+    return fl::string::from_literal("ESP32-S2");
+#elif defined(FL_IS_ESP_32S3)
+    return fl::string::from_literal("ESP32-S3");
+#elif defined(FL_IS_ESP_32C3)
+    return fl::string::from_literal("ESP32-C3");
+#elif defined(FL_IS_ESP_32C5)
+    return fl::string::from_literal("ESP32-C5");
+#elif defined(FL_IS_ESP_32C6)
+    return fl::string::from_literal("ESP32-C6");
+#elif defined(FL_IS_ESP_32H2)
+    return fl::string::from_literal("ESP32-H2");
+#elif defined(FL_IS_ESP_32P4)
+    return fl::string::from_literal("ESP32-P4");
+#elif defined(FL_IS_TEENSY_4X)
+    return fl::string::from_literal("Teensy-4.x");
+#elif defined(FL_IS_STUB)
+    return fl::string::from_literal("Host-stub");
+#else
+    return fl::string::from_literal("Unknown");
+#endif
+}
+
+/// ESP-IDF version string, or "n/a" on non-ESP32 targets.
+inline fl::string idfVersion() FL_NO_EXCEPT {
+#if defined(FL_IS_ESP32) && defined(ESP_IDF_VERSION_MAJOR)
+    fl::sstream s;
+    s << ESP_IDF_VERSION_MAJOR;
+#if defined(ESP_IDF_VERSION_MINOR)
+    s << '.' << ESP_IDF_VERSION_MINOR;
+#endif
+#if defined(ESP_IDF_VERSION_PATCH)
+    s << '.' << ESP_IDF_VERSION_PATCH;
+#endif
+    return s.str();
+#else
+    return fl::string::from_literal("n/a");
+#endif
+}
+
+/// Return the list of registered driver names. The FLEX_IO slot's
+/// binding is inferred by name — callers can match against the
+/// silicon-specific expected name (`I2S_SPI` / `PARLIO` / `LCD_RGB`
+/// / `LCD_CLOCKLESS` / etc.) or just report the entire list.
+///
+/// Direct `Bus::FLEX_IO, instance` introspection requires the driver
+/// to grow a `getBus() / getInstance()` method — currently
+/// `IChannelDriver::getName()` is the only public identity. When those
+/// getters arrive, this helper collapses to a one-line lookup; for now
+/// it returns all registered names so the host can pick.
+inline fl::vector<fl::string> registeredDriverNames() FL_NO_EXCEPT {
+    fl::vector<fl::string> names;
+    auto& manager = fl::channelManager();
+    auto infos = manager.getDriverInfos();
+    for (const auto& info : infos) {
+        if (!info.name.empty()) {
+            names.push_back(info.name);
+        }
+    }
+    return names;
+}
+
+/// Convenience — first non-empty driver name, or "<none>" if empty.
+inline fl::string firstDriverName() FL_NO_EXCEPT {
+    auto names = registeredDriverNames();
+    if (names.empty()) {
+        return fl::string::from_literal("<none>");
+    }
+    return names[0];
+}
+
+/// Build the device-info JSON returned by the `flexIoDeviceInfo` RPC.
+///
+/// Shape:
+/// ```json
+/// {
+///   "bus": "FLEX_IO",
+///   "instance": 0,
+///   "driverName": "I2S_SPI",          // whatever IChannelDriver::getName() returns
+///   "silicon": "ESP32",
+///   "idfVersion": "5.5.4",
+///   "supportedByBuild": true          // false when no BusTraits<FLEX_IO, N> for this silicon
+/// }
+/// ```
+inline fl::json buildDeviceInfo(fl::u8 instance) FL_NO_EXCEPT {
+    fl::json info = fl::json::object();
+    info.set("bus", "FLEX_IO");
+    info.set("instance", static_cast<int64_t>(instance));
+    // firstDriverName gives the most-preferred registered driver's
+    // name — on classic ESP32 this is typically "I2S_SPI" for the
+    // FLEX_IO slot; on P4/C6/etc. "PARLIO"; on S3 "LCD_CLOCKLESS".
+    info.set("driverName", firstDriverName());
+    // Full driver list so the host can pick the FLEX_IO-bound one by
+    // name if firstDriverName isn't the FLEX_IO owner.
+    fl::json names_arr = fl::json::array();
+    for (const auto& n : registeredDriverNames()) {
+        names_arr.push_back(n);
+    }
+    info.set("registeredDriverNames", names_arr);
+    info.set("silicon", siliconName());
+    info.set("idfVersion", idfVersion());
+    info.set("supportedByBuild",
+             firstDriverName() != fl::string::from_literal("<none>"));
+    return info;
+}
+
+}  // namespace flex_io
+}  // namespace autoresearch

--- a/examples/AutoResearch/AutoResearchRemote.cpp
+++ b/examples/AutoResearch/AutoResearchRemote.cpp
@@ -59,6 +59,7 @@
 #include "AutoResearchParlioEncode.h" // parlioEncodeBenchmark RPC (#2526 follow-up)
 #include "AutoResearchTimingDrift.h"  // timingDriftTest RPC (#2994 repro)
 #include "AutoResearchParlioStream.h" // parlioStreamValidate RPC (#2548 follow-up)
+#include "AutoResearchFlexIo.h"       // flexIoDeviceInfo RPC (#3515 Phase B)
 #include "fl/system/heap.h"
 #include "fl/chipsets/spi.h"
 #include "fl/channels/config.h"

--- a/examples/AutoResearch/AutoResearchRemoteMathMethods.cpp
+++ b/examples/AutoResearch/AutoResearchRemoteMathMethods.cpp
@@ -39,6 +39,7 @@
 #include "AutoResearchParlioEncode.h"
 #include "AutoResearchTimingDrift.h"
 #include "AutoResearchParlioStream.h"
+#include "AutoResearchFlexIo.h"
 #include "AutoResearchIeee754.h"
 #include "fl/chipsets/spi.h"
 #include "fl/channels/config.h"
@@ -422,6 +423,36 @@ void AutoResearchRemoteControl::bindMathMethods(fl::Remote& remote) {
                 static_cast<fl::u64>(r.perpos_pp_us) * kFrameBytePositions / r.iters));
         }
         response.set("sink", static_cast<int64_t>(r.sink));
+        return response;
+    });
+
+    // Register "flexIoDeviceInfo" — introspect which concrete driver
+    // is bound to the `Bus::FLEX_IO` slot at runtime and return a
+    // device-info JSON structure the host can inspect. Peripheral-
+    // agnostic per the "Runtime driver selection is Bus::FLEX_IO"
+    // agent-doc rule (FastLED#3515 Phase B). Optional args:
+    // `{ "instance": 0 | 1 }` — currently only affects the
+    // `instance` echo in the response since the manager's public
+    // API doesn't yet expose per-(bus,instance) lookup. When
+    // IChannelDriver grows getBus/getInstance() methods, this handler
+    // will resolve to the specific driver on that slot.
+    remote.bind("flexIoDeviceInfo", [](const fl::json& args) -> fl::json {
+        fl::u8 instance = 0;
+        fl::json config;
+        if (args.is_object()) {
+            config = args;
+        } else if (args.is_array() && args.size() >= 1 && args[0].is_object()) {
+            config = args[0];
+        }
+        if (!config.is_null() && config.contains("instance") &&
+            config["instance"].is_int()) {
+            int64_t iv = config["instance"].as_int().value();
+            if (iv >= 0 && iv <= 255) {
+                instance = static_cast<fl::u8>(iv);
+            }
+        }
+        fl::json response = autoresearch::flex_io::buildDeviceInfo(instance);
+        response.set("success", true);
         return response;
     });
 }


### PR DESCRIPTION
## Summary

New peripheral-agnostic AutoResearch harness following the `Bus::FLEX_IO` runtime-selection convention documented in `agents/docs/cpp-standards.md` -> \"Runtime driver selection is `Bus::FLEX_IO` — legacy chipset templates are not (REQUIRED)\".

- `AutoResearchFlexIo.h` — introspection helpers (`siliconName`, `idfVersion`, `registeredDriverNames`, `firstDriverName`, `buildDeviceInfo`).
- New `flexIoDeviceInfo` RPC handler returning a JSON device-info structure.
- On classic ESP32 currently reports \`I2S_SPI\` (that's what's on `Bus::FLEX_IO, 0` today); once #3512 Phase 4 wires the Yves clockless into that slot, same harness reports it without any changes.

## Test plan

- [x] `bash test --cpp`: 344/344 pass.
- [x] `bash lint --cpp`: clean.
- [ ] CI: no behavioral change on non-AutoResearch builds — the header + RPC handler is only compiled into AutoResearch example TU.

## What this does NOT do

- No timing bench yet — that comes once #3512 Phase 4 makes the classic-ESP32 Yves clockless reachable via the modern channel API.
- No reaching for `ClocklessI2S<>` directly (would violate the agent-doc rule from #3519).

Part of FastLED#3516 / #3515 Phase B (v1 introspection).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new FLEX_IO device-info response that reports the selected driver, available drivers, platform/build details, and instance number.
  * Exposed a new remote call to retrieve this FLEX_IO device information with optional instance input.
  * Enabled the FLEX_IO integration in the standard remote build so the feature is available more broadly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->