### PR TITLE
fix(rpc): FL_NO_EXCEPT on TypeToJson<u32> and <u16> convert()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 /docs/doxygen-awesome-css
 components/
 
+# Cross-repo agent workspace (clud-extern-repos convention)
+.extern-repos/
+
 # Build outputs
 .build/
 .cached/

--- a/src/fl/remote/rpc/type_to_json.h
+++ b/src/fl/remote/rpc/type_to_json.h
@@ -34,7 +34,7 @@ struct TypeToJson<fl::string> {
 // AutoResearch RPCs from #3517).
 template <>
 struct TypeToJson<fl::u32> {
-    static json convert(const fl::u32& value) {
+    static json convert(const fl::u32& value) FL_NO_EXCEPT {
         return json(static_cast<fl::i64>(value));
     }
 };
@@ -43,7 +43,7 @@ struct TypeToJson<fl::u32> {
 // GCC 15 despite implicit promotion — safer to be explicit.
 template <>
 struct TypeToJson<fl::u16> {
-    static json convert(const fl::u16& value) {
+    static json convert(const fl::u16& value) FL_NO_EXCEPT {
         return json(static_cast<fl::i64>(value));
     }
 };


### PR DESCRIPTION
Two NoexceptAstChecker (ratchet) violations landed on master via #3527, breaking every unit tests windows run since. Both are pure integer conversions that cannot throw. Fix: add FL_NO_EXCEPT — matches every other TypeToJson<> specialization in the file. Verified locally: bash lint --cpp completes green.

Generated with Claude Code