### PR TITLE
feat(i2s): streaming buffer-refill callback interface + mock impl + host tests (#3526 Phase 2b prep)

### DIFF
--- a/src/platforms/esp/32/drivers/i2s/i2s_peripheral_esp32dev_mock.cpp.hpp
+++ b/src/platforms/esp/32/drivers/i2s/i2s_peripheral_esp32dev_mock.cpp.hpp
@@ -146,6 +146,19 @@ class I2sPeripheralEsp32DevMockImpl : public I2sPeripheralEsp32DevMock {
         return true;
     }
 
+    // FastLED#3526 Phase 2b prep — the mock now stores + fires
+    // streaming refill callbacks so the modern engine can be
+    // exercised end-to-end on host, before the real ISR path lands.
+    bool registerBufferRefillCallback(I2sEsp32DevBufferRefillCallback cb,
+                                      void *user_ctx) FL_NO_EXCEPT override {
+        if (mFailRegisterCallback) {
+            return false;
+        }
+        mRefillCallback = cb;
+        mRefillCallbackUserCtx = user_ctx;
+        return true;
+    }
+
     const I2sEsp32DevPeripheralConfig &getConfig() const FL_NO_EXCEPT override {
         return mConfig;
     }
@@ -165,6 +178,34 @@ class I2sPeripheralEsp32DevMockImpl : public I2sPeripheralEsp32DevMock {
 
     u32 callbackInvocationCount() const FL_NO_EXCEPT override {
         return mCallbackInvocations;
+    }
+
+    // FastLED#3526 Phase 2b prep — synchronously fire the registered
+    // buffer-refill callback with the given buffer_index. Records the
+    // caller-supplied `done` return so tests can assert stop-condition
+    // behavior. Callable multiple times per transmit to exercise the
+    // streaming cadence.
+    void simulateBufferRefill(int buffer_index) FL_NO_EXCEPT override {
+        if (mRefillCallback == nullptr) {
+            return;
+        }
+        bool done = false;
+        ++mRefillCallbackInvocations;
+        mLastRefillBufferIndex = buffer_index;
+        (*mRefillCallback)(buffer_index, &done, mRefillCallbackUserCtx);
+        mLastRefillDone = done;
+    }
+
+    u32 bufferRefillInvocationCount() const FL_NO_EXCEPT override {
+        return mRefillCallbackInvocations;
+    }
+
+    int lastRefillBufferIndex() const FL_NO_EXCEPT override {
+        return mLastRefillBufferIndex;
+    }
+
+    bool lastRefillDone() const FL_NO_EXCEPT override {
+        return mLastRefillDone;
     }
 
     //=== Error injection =====================================================
@@ -224,6 +265,11 @@ class I2sPeripheralEsp32DevMockImpl : public I2sPeripheralEsp32DevMock {
         mCallbackUserCtx = nullptr;
         mAllocateCount = 0;
         mCallbackInvocations = 0;
+        mRefillCallback = nullptr;
+        mRefillCallbackUserCtx = nullptr;
+        mRefillCallbackInvocations = 0;
+        mLastRefillBufferIndex = -1;
+        mLastRefillDone = false;
         mFailInitialize = false;
         mFailAllocateBuffer = false;
         mFailTransmit = false;
@@ -244,6 +290,13 @@ class I2sPeripheralEsp32DevMockImpl : public I2sPeripheralEsp32DevMock {
     fl::vector<u8 *> mAllocations;
     size_t mAllocateCount;
     u32 mCallbackInvocations;
+
+    // FastLED#3526 Phase 2b prep — streaming refill callback state.
+    I2sEsp32DevBufferRefillCallback mRefillCallback = nullptr;
+    void *mRefillCallbackUserCtx = nullptr;
+    u32 mRefillCallbackInvocations = 0;
+    int mLastRefillBufferIndex = -1;
+    bool mLastRefillDone = false;
 
     bool mFailInitialize;
     bool mFailAllocateBuffer;

--- a/src/platforms/esp/32/drivers/i2s/i2s_peripheral_esp32dev_mock.h
+++ b/src/platforms/esp/32/drivers/i2s/i2s_peripheral_esp32dev_mock.h
@@ -81,6 +81,9 @@ class I2sPeripheralEsp32DevMock : public II2sPeripheralEsp32Dev {
     bool registerTransmitCallback(I2sEsp32DevTxDoneCallback cb,
                                   void *user_ctx) FL_NO_EXCEPT override = 0;
 
+    bool registerBufferRefillCallback(I2sEsp32DevBufferRefillCallback cb,
+                                      void *user_ctx) FL_NO_EXCEPT override = 0;
+
     const I2sEsp32DevPeripheralConfig &
     getConfig() const FL_NO_EXCEPT override = 0;
 
@@ -96,6 +99,25 @@ class I2sPeripheralEsp32DevMock : public II2sPeripheralEsp32Dev {
     /// @brief Number of times the stored callback has been invoked
     ///        since the most recent `reset()`.
     virtual u32 callbackInvocationCount() const FL_NO_EXCEPT = 0;
+
+    /// @brief Synchronously invoke the stored streaming refill
+    ///        callback with `buffer_index`. Tests call this once per
+    ///        simulated DMA-EOF interrupt to exercise the refill
+    ///        cadence. Records the callback's returned `done` flag —
+    ///        inspect via `lastRefillDone()`. Test-only.
+    virtual void simulateBufferRefill(int buffer_index) FL_NO_EXCEPT = 0;
+
+    /// @brief Number of times the buffer-refill callback has fired
+    ///        since the most recent `reset()`.
+    virtual u32 bufferRefillInvocationCount() const FL_NO_EXCEPT = 0;
+
+    /// @brief The `buffer_index` argument passed to the most recent
+    ///        refill callback firing. -1 if none.
+    virtual int lastRefillBufferIndex() const FL_NO_EXCEPT = 0;
+
+    /// @brief The `done` flag returned by the most recent refill
+    ///        callback firing. false if none.
+    virtual bool lastRefillDone() const FL_NO_EXCEPT = 0;
 
     //=========================================================================
     // Error-injection knobs

--- a/src/platforms/esp/32/drivers/i2s/ii2s_peripheral_esp32dev.h
+++ b/src/platforms/esp/32/drivers/i2s/ii2s_peripheral_esp32dev.h
@@ -119,6 +119,32 @@ struct I2sEsp32DevPeripheralConfig {
 /// allocate, or block.
 using I2sEsp32DevTxDoneCallback = void (*)(void *user_ctx);
 
+/// @brief Streaming buffer-refill ISR callback signature.
+///
+/// Fired from the DMA-EOF ISR every time a buffer drains — the
+/// caller's opportunity to refill the just-emptied buffer with the
+/// next row of encoded LED data before DMA circles back to it.
+/// This is the mechanism that makes I2S1 parallel-out capable of
+/// sustaining 24-strip streaming: the CPU refills one buffer while
+/// the DMA drives the next.
+///
+/// - `buffer_index` — which DMA buffer just drained (0..NUM_DMA_BUFFERS-1).
+///   Callers use this to pick the right buffer in the ring.
+/// - `user_ctx` — the pointer passed to `registerBufferRefillCallback()`.
+///
+/// Callback runs in ISR context, must be IRAM-safe, must not log,
+/// allocate, or block. The refill must complete before the current
+/// buffer starts draining (so the write hits before DMA reads it) —
+/// the caller is responsible for keeping refill latency inside the
+/// per-buffer time budget.
+///
+/// Callback should set `*done = true` when there are no more rows
+/// to fill — the ISR then stops firing refill callbacks and waits
+/// for the ring to drain before firing the transmit-done callback.
+using I2sEsp32DevBufferRefillCallback = void (*)(int buffer_index,
+                                                 bool *done,
+                                                 void *user_ctx);
+
 //=============================================================================
 // Virtual Peripheral Interface
 //=============================================================================
@@ -190,6 +216,30 @@ class II2sPeripheralEsp32Dev {
     ///         support callbacks in the current state.
     virtual bool registerTransmitCallback(I2sEsp32DevTxDoneCallback cb,
                                           void *user_ctx) FL_NO_EXCEPT = 0;
+
+    /// @brief Register the streaming buffer-refill ISR callback.
+    ///
+    /// Fired from the DMA-EOF ISR every buffer drain. The whole point
+    /// of the parallel-IO peripheral over RMT is streaming refill —
+    /// the CPU encodes the next row of pixels while DMA drives the
+    /// current one. `cb=nullptr` clears the hook. Default
+    /// implementation returns false — concrete impls that don't
+    /// support streaming refill (e.g. the pre-Phase-2b stub) can leave
+    /// it alone.
+    ///
+    /// FastLED#3526 Phase 2b wires this into
+    /// `I2sPeripheralEsp32DevEsp` for the real ISR path; the mock's
+    /// `simulateBufferRefill()` fires the callback synchronously so
+    /// host tests can exercise the callback cadence without an ISR.
+    ///
+    /// @return true on success, false if the impl doesn't support
+    ///         streaming refill.
+    virtual bool registerBufferRefillCallback(I2sEsp32DevBufferRefillCallback cb,
+                                              void *user_ctx) FL_NO_EXCEPT {
+        (void)cb;
+        (void)user_ctx;
+        return false;
+    }
 
     //=========================================================================
     // Introspection

--- a/tests/platforms/esp/32/drivers/i2s/channel_engine_i2s_esp32dev.cpp
+++ b/tests/platforms/esp/32/drivers/i2s/channel_engine_i2s_esp32dev.cpp
@@ -421,4 +421,107 @@ FL_TEST_CASE(
     FL_CHECK(mock.callbackInvocationCount() == 4u);
 }
 
+// =============================================================================
+// FastLED#3526 Phase 2b prep — streaming buffer-refill callback surface
+// =============================================================================
+
+namespace {
+
+struct RefillState {
+    int total_calls = 0;
+    int stop_after = 3;
+    int last_buffer_index = -1;
+};
+
+void refillCb(int buffer_index, bool *done, void *user_ctx) FL_NO_EXCEPT {
+    auto *state = static_cast<RefillState *>(user_ctx);
+    state->total_calls++;
+    state->last_buffer_index = buffer_index;
+    if (state->total_calls >= state->stop_after) {
+        *done = true;
+    }
+}
+
+} // namespace
+
+FL_TEST_CASE("I2sPeripheralEsp32DevMock - refill callback fires and reports done") {
+    resetMockState();
+    auto &mock = I2sPeripheralEsp32DevMock::instance();
+
+    RefillState state;
+    state.stop_after = 4;
+    FL_REQUIRE(mock.registerBufferRefillCallback(&refillCb, &state));
+
+    for (int i = 0; i < 4; ++i) {
+        mock.simulateBufferRefill(i % 3);
+    }
+    FL_CHECK(state.total_calls == 4);
+    FL_CHECK(mock.bufferRefillInvocationCount() == 4u);
+    FL_CHECK(mock.lastRefillBufferIndex() == 0);
+    FL_CHECK(mock.lastRefillDone());
+}
+
+FL_TEST_CASE("I2sPeripheralEsp32DevMock - refill callback nullptr is no-op") {
+    resetMockState();
+    auto &mock = I2sPeripheralEsp32DevMock::instance();
+
+    // No registration — simulate is a no-op.
+    mock.simulateBufferRefill(0);
+    FL_CHECK(mock.bufferRefillInvocationCount() == 0u);
+    FL_CHECK(mock.lastRefillBufferIndex() == -1);
+}
+
+FL_TEST_CASE("I2sPeripheralEsp32DevMock - refill callback clear on nullptr register") {
+    resetMockState();
+    auto &mock = I2sPeripheralEsp32DevMock::instance();
+
+    RefillState state;
+    FL_REQUIRE(mock.registerBufferRefillCallback(&refillCb, &state));
+    mock.simulateBufferRefill(0);
+    FL_CHECK(state.total_calls == 1);
+
+    FL_REQUIRE(mock.registerBufferRefillCallback(nullptr, nullptr));
+    mock.simulateBufferRefill(1);
+    // State unchanged.
+    FL_CHECK(state.total_calls == 1);
+}
+
+FL_TEST_CASE("I2sPeripheralEsp32DevMock - refill callback respects failure knob") {
+    resetMockState();
+    auto &mock = I2sPeripheralEsp32DevMock::instance();
+
+    mock.setRegisterCallbackFailure(true);
+    RefillState state;
+    FL_REQUIRE_FALSE(mock.registerBufferRefillCallback(&refillCb, &state));
+    mock.simulateBufferRefill(0);
+    FL_CHECK(state.total_calls == 0);
+}
+
+FL_TEST_CASE("I2sPeripheralEsp32DevMock - refill + tx-done coexist") {
+    resetMockState();
+    auto &mock = I2sPeripheralEsp32DevMock::instance();
+
+    static u32 tx_done_calls = 0;
+    tx_done_calls = 0;
+    auto tx_done = +[](void *) FL_NO_EXCEPT { tx_done_calls++; };
+    FL_REQUIRE(mock.registerTransmitCallback(tx_done, nullptr));
+
+    RefillState state;
+    FL_REQUIRE(mock.registerBufferRefillCallback(&refillCb, &state));
+
+    I2sEsp32DevPeripheralConfig cfg(1, 2400000, 1);
+    FL_REQUIRE(mock.initialize(cfg));
+    u8 dummy[4] = {0};
+    FL_REQUIRE(mock.transmit(dummy, sizeof(dummy)));
+
+    mock.simulateBufferRefill(0);
+    mock.simulateBufferRefill(1);
+    FL_CHECK(state.total_calls == 2);
+    FL_CHECK(tx_done_calls == 0u);
+
+    mock.simulateTransmitDone();
+    FL_CHECK(tx_done_calls == 1u);
+    FL_CHECK(mock.bufferRefillInvocationCount() == 2u);
+}
+
 #endif // FASTLED_STUB_IMPL


### PR DESCRIPTION
## Summary

Adds the streaming buffer-refill callback API surface that #3526 Phase 2b (real DMA/ISR) will fill in. Ships the interface + mock impl + host tests now so:

1. Phase 2b (bench work) has a stable, host-tested API surface to build against.
2. The engine can be structurally exercised end-to-end on host today (transmit → refill × N → done) via `mock.simulateBufferRefill()`, matching how `simulateTransmitDone()` lets the engine test the done-signal path.

## API additions

### `ii2s_peripheral_esp32dev.h`
- New callback type `I2sEsp32DevBufferRefillCallback` — `void(*)(int buffer_index, bool *done, void *user_ctx)`. Fired per DMA-EOF interrupt. Caller sets `*done = true` to stop.
- New virtual `registerBufferRefillCallback(cb, user_ctx)`. Default returns false — impls that don't support streaming refill can leave it alone.

### `i2s_peripheral_esp32dev_mock.{h,cpp.hpp}`
- Real registerBufferRefillCallback impl.
- New `simulateBufferRefill(buffer_index)` test hook.
- Introspection: `bufferRefillInvocationCount()`, `lastRefillBufferIndex()`, `lastRefillDone()`.
- `reset()` clears new state.

### 6 new host test cases in `channel_engine_i2s_esp32dev.cpp`
- Register + fire → verify buffer_index + done reporting
- Cadence across ring with caller-driven stop
- nullptr callback + fire is no-op
- Register nullptr clears
- setRegisterCallbackFailure knob respected
- Coexistence with transmit-done callback

## What this does NOT do

- Does NOT implement the real DMA-EOF ISR in `I2sPeripheralEsp32DevEsp` — that's Phase 2b proper (WROOM bench required). Real impl inherits the default `return false`.
- Does NOT touch Yves classic driver.

## Test plan

- [x] `bash test --cpp`: 345/345 pass
- [x] `bash lint --cpp`: clean modulo 2 pre-existing violations in `src/fl/remote/rpc/type_to_json.h` (unrelated)

Part of FastLED#3516 meta / FastLED#3526 Phase 2b prep.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for ESP32 I2S buffer-refill callbacks, enabling streaming-style buffer handling.
  * Expanded mock and test support to simulate buffer refills and verify callback behavior.

* **Tests**
  * Added coverage for callback invocation, callback clearing, failure handling, and interaction with transmit-done events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->