### PR TITLE
fix(lpc): use vendor SYSCON_SYSAHBCLKCTRL0_*_MASK — closes #3517 Phase B.3 SYSCON audit

### DIFF
--- a/src/platforms/arm/lpc/drivers/sct_dma/lpc_sct_dma_runtime.cpp.hpp
+++ b/src/platforms/arm/lpc/drivers/sct_dma/lpc_sct_dma_runtime.cpp.hpp
@@ -52,12 +52,11 @@ void LpcSctDmaTransmitter::init() FL_NO_EXCEPT {
     }
 
     // ----- Power up SCT + DMA in SYSAHBCLKCTRL0 -----
-    // Inherits the legacy template's bit assignments verbatim:
-    //   bit  8 = SCT clock
-    //   bit 29 = DMA clock
-    // TODO(2842): verify SYSCON->SYSAHBCLKCTRL0 bit assignments against
-    // UM11029 §4.6.13.
-    SYSCON->SYSAHBCLKCTRL0 |= (1UL << 8) | (1UL << 29);
+    // UM11029 §4.6.13 Table 41. Verified against NXP mcux-sdk:
+    //   SYSCON_SYSAHBCLKCTRL0_SCT_MASK = 0x100U    (SHIFT = 8U)
+    //   SYSCON_SYSAHBCLKCTRL0_DMA_MASK = 0x20000000U (SHIFT = 29U)
+    SYSCON->SYSAHBCLKCTRL0 |=
+        SYSCON_SYSAHBCLKCTRL0_SCT_MASK | SYSCON_SYSAHBCLKCTRL0_DMA_MASK;
 
     // ----- SCT skeleton -----
     // CONFIG: UNIFY (bit 0) — one 32-bit counter; CLKMODE = SYS clock.

--- a/src/platforms/arm/lpc/spi_arm_lpc_dma.h
+++ b/src/platforms/arm/lpc/spi_arm_lpc_dma.h
@@ -183,11 +183,11 @@ public:
         spi->TXCTL = FL_LPC_SPI_TXCTL_LEN_8BIT | FL_LPC_SPI_TXCTL_RXIGNORE;
 
         // ----- DMA0 power-up + channel configuration ---------------------
-        // SYSAHBCLKCTRL0 bit 29 = DMA. Already shared with the PWM-DMA
-        // clockless driver if both are gated on; the OR-set is idempotent.
-        // TODO(3453): verify SYSCON->SYSAHBCLKCTRL0 bit 29 against
-        // UM11029 §4.6.13.
-        SYSCON->SYSAHBCLKCTRL0 |= (1UL << 29);
+        // DMA clock enable, UM11029 §4.6.13 Table 41 bit 29.
+        // Cross-checked against NXP mcux-sdk `SYSCON_SYSAHBCLKCTRL0_DMA_MASK`
+        // = 0x20000000U (SHIFT = 29U). Shared with the PWM+DMA clockless
+        // driver if both are gated on; the OR-set is idempotent.
+        SYSCON->SYSAHBCLKCTRL0 |= SYSCON_SYSAHBCLKCTRL0_DMA_MASK;
 
         // Enable the controller (master enable, not yet channel-enabled).
         DMA0->CTRL = 1UL;


### PR DESCRIPTION
Phase B.3 of #3517 partial delivery — migrate the two `SYSCON->SYSAHBCLKCTRL0 |= (1UL << 29)` sites to vendor CMSIS macros with UM section citations.

## Verified against NXP mcux-sdk

    #define SYSCON_SYSAHBCLKCTRL0_DMA_MASK  (0x20000000U)  // SHIFT = 29U
    #define SYSCON_SYSAHBCLKCTRL0_SCT_MASK  (0x100U)       // SHIFT = 8U

Both match the existing raw literals. UM11029 §4.6.13 Table 41 is the datasheet source.

## Sites touched

- `src/platforms/arm/lpc/spi_arm_lpc_dma.h` — replaces `(1UL << 29)` with `SYSCON_SYSAHBCLKCTRL0_DMA_MASK`, drops `TODO(3453): verify SYSCON->SYSAHBCLKCTRL0 bit 29`
- `src/platforms/arm/lpc/drivers/sct_dma/lpc_sct_dma_runtime.cpp.hpp` — replaces `(1UL << 8) | (1UL << 29)` with `SYSCON_SYSAHBCLKCTRL0_SCT_MASK | SYSCON_SYSAHBCLKCTRL0_DMA_MASK`, drops `TODO(2842)`

No behavioral change — the mask values are identical.

## Verification

- [x] `bash test --cpp` — 345/345 pass

Refs: #3517 Phase B.3, `agents/docs/register-maps.md`.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated low-level hardware initialization to use standard named clock-enable constants instead of hard-coded bit values.
  * Kept device startup behavior unchanged while improving consistency and maintainability across ARM/LPC DMA and SPI support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->