### PR TITLE
feat(i2s): engine mode-dispatch scaffolding for SPI batches (#3526 Phase 2c prep)

### DIFF
--- a/src/platforms/esp/32/drivers/i2s/channel_engine_i2s_esp32dev.cpp.hpp
+++ b/src/platforms/esp/32/drivers/i2s/channel_engine_i2s_esp32dev.cpp.hpp
@@ -143,6 +143,50 @@ void ChannelEngineI2sEsp32Dev::show() FL_NO_EXCEPT {
     mInFlightChannels = fl::move(mEnqueuedChannels);
     mEnqueuedChannels.clear();
 
+    // FastLED#3526 Phase 2c — per-channel mode dispatch. The parallel-IO
+    // unified-engine rule (agents/docs/cpp-standards.md) says the peripheral
+    // is the dispatch boundary, not the mode. Since I2S1 can only run one
+    // mode at a time (clockless bit-shift vs SPI clocked), we check whether
+    // the in-flight batch is homogeneous. Mixed batches (some clockless,
+    // some SPI) or SPI batches are rejected until Phase 2c-SPI machinery
+    // ships — for now the SPI transmit path is a documented stub. Clockless
+    // batches take the existing wave8-encoding path.
+    bool has_clockless = false;
+    bool has_spi = false;
+    for (const auto &data : mInFlightChannels) {
+        if (!data) continue;
+        if (data->isClockless()) has_clockless = true;
+        if (data->isSpi()) has_spi = true;
+    }
+    if (has_spi && has_clockless) {
+        FL_WARN_F("ChannelEngineI2sEsp32Dev: mixed clockless+SPI batches not supported yet — FastLED#3526 Phase 2c stub");
+        for (auto &data : mInFlightChannels) {
+            if (data) {
+                data->setInUse(false);
+            }
+        }
+        mInFlightChannels.clear();
+        mState = DriverState::ERROR;
+        return;
+    }
+    if (has_spi) {
+        // Phase 2c-SPI: peripheral needs to be reconfigured for SPI mode
+        // (clock rate + FIFO width + DMA slot) and encoding switches from
+        // wave8 pulse-major to raw byte stream. The peripheral surface for
+        // SPI mode is still bench-blocked; refuse cleanly rather than
+        // silently sending garbage.
+        FL_WARN_F("ChannelEngineI2sEsp32Dev: SPI mode not yet wired — FastLED#3526 Phase 2c pending bench validation");
+        for (auto &data : mInFlightChannels) {
+            if (data) {
+                data->setInUse(false);
+            }
+        }
+        mInFlightChannels.clear();
+        mState = DriverState::ERROR;
+        return;
+    }
+    // Clockless batch — take the existing wave8-encoding path below.
+
     // Pack every channel's encoded bytes into the scratch buffer.
     size_t required = 0;
     for (const auto &data : mInFlightChannels) {

--- a/tests/platforms/esp/32/drivers/i2s/channel_engine_i2s_esp32dev.cpp
+++ b/tests/platforms/esp/32/drivers/i2s/channel_engine_i2s_esp32dev.cpp
@@ -19,6 +19,7 @@
 #include "platforms/esp/32/drivers/i2s/channel_engine_i2s_esp32dev.h"
 #include "platforms/esp/32/drivers/i2s/i2s_peripheral_esp32dev_mock.h"
 
+#include "fl/channels/config.h"  // for SpiChipsetConfig / SpiEncoder
 #include "fl/channels/data.h"
 #include "fl/chipsets/led_timing.h"
 #include "fl/stl/cstddef.h"
@@ -104,6 +105,25 @@ ChannelDataPtr makeChannelData(int pin, size_t byte_count,
     }
 
     return ChannelData::create(pin, timing, fl::move(encoded));
+}
+
+/// @brief Build a `ChannelData` marked as SPI chipset (APA102-style)
+///        so the engine's Phase 2c dispatch treats it as SPI. Used by
+///        the Phase 2c dispatch tests below to confirm the SPI branch
+///        rejects cleanly rather than silently sending garbage.
+ChannelDataPtr makeSpiChannelData(int dataPin, int clockPin,
+                                  size_t byte_count,
+                                  u8 fill_byte = 0x00) {
+    SpiEncoder timing{SpiChipset::APA102, /*clockHz=*/6000000};
+    SpiChipsetConfig spi_cfg(dataPin, clockPin, timing);
+    ChipsetVariant chipset(spi_cfg);
+
+    fl::vector_psram<u8> encoded;
+    encoded.resize(byte_count);
+    for (size_t i = 0; i < byte_count; ++i) {
+        encoded[i] = fill_byte;
+    }
+    return ChannelData::create(chipset, fl::move(encoded));
 }
 
 } // anonymous namespace
@@ -495,6 +515,63 @@ FL_TEST_CASE("I2sPeripheralEsp32DevMock - refill callback respects failure knob"
     FL_REQUIRE_FALSE(mock.registerBufferRefillCallback(&refillCb, &state));
     mock.simulateBufferRefill(0);
     FL_CHECK(state.total_calls == 0);
+}
+
+// =============================================================================
+// FastLED#3526 Phase 2c — mode dispatch scaffolding
+// =============================================================================
+//
+// The engine's `show()` dispatches on the batch's clockless-vs-SPI
+// composition. Mixed batches and pure-SPI batches route to a stub
+// error path until the SPI transmit machinery lands (bench-blocked).
+// Clockless batches take the existing wave8-encoding path.
+
+FL_TEST_CASE("I2sEsp32Dev - pure clockless batch still succeeds") {
+    resetMockState();
+    ChannelEngineI2sEsp32Dev engine(createMockPeripheral());
+    auto &mock = I2sPeripheralEsp32DevMock::instance();
+
+    engine.enqueue(makeChannelData(0, 6, 0xAA));
+    engine.enqueue(makeChannelData(1, 6, 0xBB));
+    engine.show();
+
+    // Clockless batch is fully accepted — reaches BUSY, not ERROR.
+    FL_REQUIRE(engine.currentState() == IChannelDriver::DriverState::BUSY);
+    FL_CHECK(mock.getTransmitCount() == 1u);
+}
+
+FL_TEST_CASE("I2sEsp32Dev - pure SPI batch rejected as Phase 2c stub") {
+    resetMockState();
+    ChannelEngineI2sEsp32Dev engine(createMockPeripheral());
+    auto &mock = I2sPeripheralEsp32DevMock::instance();
+
+    auto spi_data = makeSpiChannelData(/*dataPin=*/23, /*clockPin=*/18, 6, 0xCC);
+    engine.enqueue(spi_data);
+    engine.show();
+
+    // SPI path is stubbed — engine drops to ERROR without touching the
+    // peripheral, and releases the channel's in-use mark.
+    FL_REQUIRE(engine.currentState() == IChannelDriver::DriverState::ERROR);
+    FL_CHECK(mock.getTransmitCount() == 0u);
+    FL_CHECK_FALSE(spi_data->isInUse());
+}
+
+FL_TEST_CASE("I2sEsp32Dev - mixed clockless+SPI batch rejected as Phase 2c stub") {
+    resetMockState();
+    ChannelEngineI2sEsp32Dev engine(createMockPeripheral());
+    auto &mock = I2sPeripheralEsp32DevMock::instance();
+
+    auto clockless_data = makeChannelData(0, 6, 0xAA);
+    auto spi_data = makeSpiChannelData(23, 18, 6, 0xCC);
+    engine.enqueue(clockless_data);
+    engine.enqueue(spi_data);
+    engine.show();
+
+    // Mixed batch — same stub outcome as pure SPI.
+    FL_REQUIRE(engine.currentState() == IChannelDriver::DriverState::ERROR);
+    FL_CHECK(mock.getTransmitCount() == 0u);
+    FL_CHECK_FALSE(clockless_data->isInUse());
+    FL_CHECK_FALSE(spi_data->isInUse());
 }
 
 FL_TEST_CASE("I2sPeripheralEsp32DevMock - refill + tx-done coexist") {


### PR DESCRIPTION
## Summary

Adds per-channel mode dispatch in `ChannelEngineI2sEsp32Dev::show()` so mixed clockless+SPI batches and pure-SPI batches are refused cleanly with `DriverState::ERROR` instead of silently sending garbage.

Sets up Phase 2c architecture: peripheral is the dispatch boundary (parallel-IO unified-engine rule), and I2S1 can only run one mode at a time.

Once the real SPI transmit machinery lands (Phase 2c-SPI PR, bench-blocked), the two ERROR early-outs become full `showSpi()` calls with no other engine changes needed.

## Behavior matrix

| Batch | Result |
|-------|--------|
| All clockless (existing) | Wave8 encoding → peripheral transmit ✅ |
| All SPI | ERROR state (Phase 2c-SPI stub) |
| Mixed clockless + SPI | ERROR state (mixed batches never allowed) |

## Test plan

- [x] `bash test --cpp`: 345/345 pass (3 new subcases inside existing test)
- [x] `bash lint --cpp`: clean
- [x] All 4 existing engine tests still pass — clockless path bit-identical

Part of FastLED#3516 meta / FastLED#3526 Phase 2c prep.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transmit setup handling for mixed channel batches, with clearer rejection of unsupported combinations.
  * Unsupported SPI-related batch states now fail safely, leaving the engine in an error state and releasing channels properly.
  * Clockless-only batches continue to transmit normally.

* **Tests**
  * Added coverage for valid clockless batches and rejected SPI-only and mixed batches to verify correct engine behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->