### PR TITLE
fix(autoresearch): fl:: namespace on ARMHardwareSPIOutputDMA in SPI harness

### DIFF
--- a/examples/AutoResearch/AutoResearchSpiDma.h
+++ b/examples/AutoResearch/AutoResearchSpiDma.h
@@ -85,7 +85,7 @@ namespace dma_spi {
 #define FASTLED_LPC_SPI_DMA_HARNESS_DIVIDER 6
 #endif
 
-using HarnessDriver = ARMHardwareSPIOutputDMA<
+using HarnessDriver = fl::ARMHardwareSPIOutputDMA<
     static_cast<fl::u8>(FASTLED_LPC_SPI_DMA_HARNESS_DATA_PIN),
     static_cast<fl::u8>(FASTLED_LPC_SPI_DMA_HARNESS_CLOCK_PIN),
     static_cast<fl::u32>(FASTLED_LPC_SPI_DMA_HARNESS_DIVIDER)>;


### PR DESCRIPTION
`examples/AutoResearch/AutoResearchSpiDma.h` declared `HarnessDriver` as bare `ARMHardwareSPIOutputDMA<...>` without the `fl::` prefix. Template lives in `namespace fl`; harness is in `namespace autoresearch::dma_spi` — bare name never resolved.

Under #3517 Phase B silicon-validation build (`bash compile lpc845 --examples AutoResearch --defines FASTLED_LPC_SPI_DMA`), fails with:

    error: 'ARMHardwareSPIOutputDMA' does not name a type
    error: 'HarnessDriver' does not name a type
    (+ 7 more cascade errors)

After this fix: builds at 56.43 KB / 64 KB (88.2%). Silicon validation of #3517 Phase B.1 is now unblocked at the code level.

Bug was masked because #3527 (Phase A.2) landed at the same time and everyone's builds hit legacy-header errors first — this SPI harness compile path was never reached.

Refs: #3517 Phase B, #3454.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the hardware SPI DMA driver reference used by the AutoResearch harness to use the correct namespace qualification.
  * This change helps keep the harness aligned with the current library structure and reduces the risk of integration issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->