### PR TITLE
fix(lpc): FL_STATIC_ASSERT (not raw static_assert) in rx_sct_capture

### DIFF
--- a/src/platforms/arm/lpc/rx_sct_capture.cpp.hpp
+++ b/src/platforms/arm/lpc/rx_sct_capture.cpp.hpp
@@ -37,6 +37,7 @@
 
 #include "fl/channels/rx/decode_ws2812.h"
 #include "fl/log/log.h"
+#include "fl/stl/static_assert.h"
 
 namespace fl {
 
@@ -112,11 +113,11 @@ constexpr fl::u32 kDmaBase      = 0x50008000u;
 // time without needing `reinterpret_cast` (which isn't a constant
 // expression). Any future vendor-header bump that moves a base
 // address surfaces here as a build error, not a silent misbehavior.
-static_assert(kSysconBase   == SYSCON_BASE,   "kSysconBase mismatch vs vendor SYSCON_BASE");
-static_assert(kSwmBase      == SWM0_BASE,     "kSwmBase mismatch vs vendor SWM0_BASE");
-static_assert(kInputMuxBase == INPUTMUX_BASE, "kInputMuxBase mismatch vs vendor INPUTMUX_BASE");
-static_assert(kSctBase      == SCT0_BASE,     "kSctBase mismatch vs vendor SCT0_BASE");
-static_assert(kDmaBase      == DMA0_BASE,     "kDmaBase mismatch vs vendor DMA0_BASE");
+FL_STATIC_ASSERT(kSysconBase   == SYSCON_BASE,   "kSysconBase mismatch vs vendor SYSCON_BASE");
+FL_STATIC_ASSERT(kSwmBase      == SWM0_BASE,     "kSwmBase mismatch vs vendor SWM0_BASE");
+FL_STATIC_ASSERT(kInputMuxBase == INPUTMUX_BASE, "kInputMuxBase mismatch vs vendor INPUTMUX_BASE");
+FL_STATIC_ASSERT(kSctBase      == SCT0_BASE,     "kSctBase mismatch vs vendor SCT0_BASE");
+FL_STATIC_ASSERT(kDmaBase      == DMA0_BASE,     "kDmaBase mismatch vs vendor DMA0_BASE");
 #endif
 
 constexpr fl::u32 kOffSYSAHBCLKCTRL0 = 0x080u;


### PR DESCRIPTION
Regression from #3535 — my vendor CMSIS base-address identity checks used raw `static_assert(...)`. `BannedMacrosChecker` flags 5 violations with rationale "FL_STATIC_ASSERT keeps compile-time assertions portable on old embedded toolchains."

Fix: include `fl/stl/static_assert.h` and replace 5 `static_assert` sites with `FL_STATIC_ASSERT`.

## Verification

- `bash test --cpp` — 345/345 pass
- `FL_STATIC_ASSERT`s still fire against LPC845 vendor CMSIS macros the same way
- `BannedMacrosChecker` should now find 0 violations in this file

Refs: #3535 (introduced), #3517 Phase C.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal build-time checks for one supported hardware target.
  * No user-facing behavior or public API changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->