### PR TITLE
fix(examples): wire ASan DLL PATH prep into example runner debug mode

### DIFF
--- a/.github/workflows/example_test_windows.yml
+++ b/.github/workflows/example_test_windows.yml
@@ -20,6 +20,21 @@ on:
       - 'pyproject.toml'
       - 'test'
       - 'test.py'
+  pull_request:
+    branches:
+      - master
+    paths:
+      - 'src/**'
+      - 'examples/**'
+      - 'ci/**'
+      - '.github/workflows/example_test*.yml'
+      - '.github/workflows/template_example_test.yml'
+      - 'CMakeLists.txt'
+      - 'meson.build'
+      - 'examples/meson.build'
+      - 'pyproject.toml'
+      - 'test'
+      - 'test.py'
 jobs:
   test:
     uses: ./.github/workflows/template_example_test.yml

--- a/ci/util/meson_example_runner.py
+++ b/ci/util/meson_example_runner.py
@@ -433,6 +433,25 @@ def run_meson_examples(
             num_tests_failed=0,
         )
 
+    # Wire up ASan/LSan runtime discovery when the caller asked for debug
+    # sanitizers. On Windows this appends the clang-tool-chain MinGW sysroot
+    # bin/ (which owns libclang_rt.asan_dynamic-x86_64.dll) to PATH; without
+    # it every example .exe fails to start with 0xC0000135 STATUS_DLL_NOT_FOUND
+    # — the failure mode that had `example tests windows` red on master
+    # since 2026-06-23. Mirrors the same call ci/meson/runner.py makes for
+    # the unit-test runner; the example runner had grown its own --debug
+    # path without the equivalent env prep.
+    if build_mode == "debug":
+        from clang_tool_chain import (  # noqa: PLC0415 - lazy import: ~60ms
+            prepare_sanitizer_environment,
+        )
+
+        sanitizer_env = prepare_sanitizer_environment(
+            base_env=os.environ.copy(),
+            compiler_flags=["-fsanitize=address"],
+        )
+        os.environ.update(sanitizer_env)
+
     # Construct mode-specific build directory
     # This enables caching per mode when source unchanged but flags differ
     # Example: .build/meson -> .build/meson-debug


### PR DESCRIPTION
master's example tests windows has been red since 2026-06-23 (commit abd8e8c1, ~1.5 weeks). Every example .exe launched after --debug died with 0xC0000135 STATUS_DLL_NOT_FOUND because libclang_rt.asan_dynamic-x86_64.dll was not on PATH.

The unit-test runner (ci/meson/runner.py) already calls prepare_sanitizer_environment to inject the MinGW sysroot bin/ into PATH when build_mode is debug; the example runner had grown its own --debug path without the equivalent env prep.

Mirror the unit-test runner's call site: when build_mode == debug, call clang_tool_chain.prepare_sanitizer_environment and merge the result into os.environ.

Verified locally on Windows with a cold .build/meson-debug: the Blink example runs green under ASan.

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Example Windows tests now run for pull requests targeting the main branch, using the same file-change filters as regular pushes.
  * Debug example runs now automatically set up sanitizer runtime environment support, helping surface memory issues earlier.

* **Bug Fixes**
  * Improved consistency between push and pull request validation for relevant changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->