### PR TITLE
fix(lpc): bump platform-nxp-lpc8xx pin past the FastLED-org transfer

### DIFF
--- a/ci/boards.py
+++ b/ci/boards.py
@@ -1163,7 +1163,7 @@ RPI_PICO2 = Board(
 # released (fbuild 2.3.15 released 20:09 UTC, matcher merge 21:47 UTC).
 # Once fbuild 2.3.16 ships with #900 the `nxplpc@` prefix becomes
 # redundant but stays valid PlatformIO syntax (name @ source URI).
-_NXPLPC_PLATFORM = "nxplpc@https://github.com/FastLED/platform-nxp-lpc8xx.git#12265f765aebd3893465d6d7ad76be66d89ba015"
+_NXPLPC_PLATFORM = "nxplpc@https://github.com/FastLED/platform-nxp-lpc8xx.git#4b6d395cbbfb9faf97a53af3733ad802dc160f1d"
 
 # Preferred name for the LPC845 canary board target (FastLED #3220).
 # `LPC845` is the canonical entry — `bash compile lpc845 …` and


### PR DESCRIPTION
Every LPC build (lpc804, lpc845, lpcxpresso804, lpcxpresso845max) has been failing on master with:

    build error: package error: checksum mismatch for FastLED-framework-arduino-lpc8xx / 0.2.0+g50d76e0_staging / 50d76e0d63c2d2a2b365b29de47100d93c530c83.tar.gz:
    expected e6bbcc339...
    got      e64f0cb81...

Root cause: the framework repo was transferred to the FastLED org on 2026-06-28 (zackees/ArduinoCore-LPC8xx → FastLED/framework-arduino-lpc8xx), and platform-nxp-lpc8xx#10 (commit 4b6d395cbb) rewrote the framework URL in platform.json to use the canonical FastLED/* URL. Our pin was stuck one commit BEFORE that URL rewrite, so fbuild kept resolving the old zackees/* URL, GitHub followed the transfer redirect and returned a byte-different tarball for the same commit sha, and fbuild's cached checksum no longer matched.

Bump the pin from 12265f76 (pre-transfer) to 4b6d395cbb (post-transfer). The framework SHA (50d76e0) is unchanged — same source tree — but the URL now hits the canonical FastLED endpoint.

Verified locally on Windows: bash compile lpc804 --examples Blink succeeds (Flash 7.33KB / 32KB).

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the pinned platform version used for LPC8xx board support to a newer revision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->