### PR TITLE
fix(ci): exclude RGBWColorimetric from attiny88 example sweep

### DIFF
--- a/.github/workflows/build_attiny88.yml
+++ b/.github/workflows/build_attiny88.yml
@@ -24,4 +24,9 @@ jobs:
   build:
     uses: ./.github/workflows/build_template.yml
     with:
-      args: attiny88 all
+      # RGBWColorimetric hits the SK6812 clockless_blocking timing floor
+      # (T3 >= 3 cycles ~= 375ns at 8 MHz, SK6812 T3 = 300ns) — the
+      # FL_STATIC_ASSERT in src/platforms/avr/attiny/clockless_blocking.h
+      # fires at compile time. Exclude the one example, keep the other 31
+      # in the sweep.
+      args: attiny88 all --exclude-examples RGBWColorimetric


### PR DESCRIPTION
attiny88 CI has been red since 2026-06-23 (tree-restore commit abd8e8c1). RGBWColorimetric fails the SK6812 clockless_blocking timing floor:

    lib/FastLED/fl/stl/static_assert.h:76:31: error: static assertion failed: Not enough cycles - use a higher clock speed

At 8 MHz the SK6812 T3 requirement of 300 ns is below the 3-cycle (375 ns) floor enforced at src/platforms/avr/attiny/clockless_blocking.h:170. The other 31 examples pass; only this one hits the wall.

Exclude the single example via '--exclude-examples RGBWColorimetric' on the existing 'all' keyword — same shape as attiny4313's explicit filter.

Verified locally on Windows: 'bash compile attiny88 --examples RGBWColorimetric' fails with the same static-assert; 'bash compile attiny88 --examples Blink' succeeds.

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build process to skip one problematic example during the `attiny88` full build sweep, helping avoid compile-time failures.
  * Kept a related example in the sweep so build coverage remains broad.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->