### PR TITLE
fix(ci): include ci/boards.py in per-board fbuild cache key

### DIFF
--- a/.github/workflows/build_template.yml
+++ b/.github/workflows/build_template.yml
@@ -63,7 +63,16 @@ jobs:
       - name: Set up fbuild (install + cache)
         uses: FastLED/fbuild/.github/actions/setup@main
         with:
-          cache-key-extra: ${{ steps.fbuild_board.outputs.name }}-${{ hashFiles('platformio.ini', 'library.json', 'pyproject.toml', 'uv.lock') }}
+          # `ci/boards.py` holds the pinned platform SHAs (e.g. `_NXPLPC_PLATFORM`
+          # for LPC804/845). When one of those pins changes the framework
+          # tarball fbuild is expected to download changes too, and the
+          # per-board cache from the previous SHA holds a stale
+          # tarball + expected sha256 — fbuild then reports
+          # `sha256 mismatch for ...` on cache restore even though the pin
+          # is now correct. Hash `ci/boards.py` here so pin bumps bust the
+          # per-board cache. See FastLED/FastLED#3543 for the LPC-transfer
+          # incident that surfaced this gap.
+          cache-key-extra: ${{ steps.fbuild_board.outputs.name }}-${{ hashFiles('platformio.ini', 'library.json', 'pyproject.toml', 'uv.lock', 'ci/boards.py') }}
           # Binary install cache is intentionally board-independent — every
           # job in this repo's board matrix shares the same fbuild binary,
           # so key the install cache solely on the fbuild pin in pyproject.


### PR DESCRIPTION
PR #3543 bumped the LPC platform pin to point past the FastLED-org repo transfer, but every subsequent LPC CI run still fails with 'sha256 mismatch for FastLED-framework-arduino-lpc8xx/.../50d76e0d63c...tar.gz: expected e6bbcc339..., got e64f0cb81...' — the exact byte-difference the pin bump was supposed to fix.

Root cause: the per-board fbuild cache key hashes 'platformio.ini + library.json + pyproject.toml + uv.lock' but NOT 'ci/boards.py' (which owns _NXPLPC_PLATFORM). Pin changes therefore hit the warm cache from the old pin, and fbuild explodes when the on-disk tarball's sha256 doesn't match the new expected sha256.

Add 'ci/boards.py' to the hashFiles set. Only bumps to that file produce a new cache generation; unrelated edits still hit the warm cache.

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build cache invalidation so updates to board pinning settings are correctly reflected in future builds.
  * Prevents outdated cached build results from being reused when board-related configuration changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->