### PR TITLE
fix(ci): exclude RGBWColorimetric from attiny85 example sweep

### DIFF
--- a/.github/workflows/build_attiny85.yml
+++ b/.github/workflows/build_attiny85.yml
@@ -24,4 +24,9 @@ jobs:
   build:
     uses: ./.github/workflows/build_template.yml
     with:
-      args: attiny85 all
+      # RGBWColorimetric hits the SK6812 clockless_blocking timing floor
+      # (T3 >= 3 cycles ~= 375ns at 8 MHz, SK6812 T3 = 300ns) — the
+      # FL_STATIC_ASSERT in src/platforms/avr/attiny/clockless_blocking.h
+      # fires at compile time. Same exclusion applied to attiny88 in
+      # #3546. Keep the rest of the sweep.
+      args: attiny85 all --exclude-examples RGBWColorimetric


### PR DESCRIPTION
Same SK6812 timing-floor failure as attiny88 (#3546): the FL_STATIC_ASSERT in src/platforms/avr/attiny/clockless_blocking.h:170 requires T3 >= 3 cycles, which at 8 MHz means >= 375 ns; SK6812 T3 is 300 ns.

Mirror the attiny88 exclusion. Verified locally on Windows: 'bash compile attiny85 --examples RGBWColorimetric' fails with the same static-assert.

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build reliability for the ATtiny85 target by skipping an example that could fail compilation on this platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->