### PR TITLE
docs(i2s): move wave8-encoding docs from engine to peripheral (#3526)

### DIFF
--- a/src/platforms/esp/32/drivers/i2s/channel_engine_i2s_esp32dev.cpp.hpp
+++ b/src/platforms/esp/32/drivers/i2s/channel_engine_i2s_esp32dev.cpp.hpp
@@ -378,12 +378,13 @@ bool ChannelEngineI2sEsp32Dev::ensureScratchBuffer(size_t required)
 }
 
 size_t ChannelEngineI2sEsp32Dev::packScratchBuffer() FL_NO_EXCEPT {
-    // Stage 1: linear byte concatenation. Sufficient to exercise the
-    // full peripheral + state-machine surface against the mock.
-    //
-    // Stage 2 replaces this with the parallel bit-transpose + wave8
-    // slot expansion so the emitted waveform drives real WS2812
-    // timing. The peripheral surface is unchanged across stages.
+    // Linear byte concatenation. Wave8 encoding happens inside the
+    // peripheral's `transmit()` implementation on real hardware — the
+    // engine hands over raw bytes; the peripheral is responsible for
+    // encoding them into I2S1's DMA-ready pulse-major layout. This
+    // keeps the mock peripheral's capture semantics simple (it sees
+    // exactly the bytes each channel produced) and lets host tests
+    // remain byte-value-sensitive without depending on wave8 details.
     size_t offset = 0;
     for (const auto &data : mInFlightChannels) {
         if (!data) {

--- a/src/platforms/esp/32/drivers/i2s/channel_engine_i2s_esp32dev.h
+++ b/src/platforms/esp/32/drivers/i2s/channel_engine_i2s_esp32dev.h
@@ -18,25 +18,21 @@
 ///   - State machine: READY → enqueue → READY → show → BUSY →
 ///     poll* → READY (peripheral completion callback flips the flag).
 ///
-/// ## Staging
+/// ## Layering
 ///
-/// Stage 1 (this file's initial impl): pre-computation strategy.
 /// `show()` linearly copies every enqueued channel's encoded pixel
 /// bytes into a single DMA-capable scratch buffer, then calls
-/// `peripheral->transmit()` once. The buffer stays valid until the
-/// completion callback fires. This keeps the engine's state machine
-/// simple, exercises the full peripheral surface (allocateBuffer /
-/// transmit / registerTransmitCallback / freeBuffer), and is fully
-/// testable against the mock. It does NOT yet run the parallel
-/// bit-transpose or the wave8 slot encoding.
+/// `peripheral->transmit()` once. The scratch buffer stays valid
+/// until the peripheral's completion callback fires.
 ///
-/// Stage 2 (follow-up PR against the same file): the encoder step
-/// runs the actual per-lane bit-transpose + wave8 slot expansion so
-/// the emitted waveform drives real WS2812 timing.
-///
-/// The peripheral interface + engine state machine are stable across
-/// stages — Stage 2 replaces the body of `packScratchBuffer()`
-/// without touching the surface.
+/// Wave8 pulse-major encoding lives inside the peripheral's
+/// `transmit()` implementation, NOT in this engine's
+/// `packScratchBuffer()`. Rationale: the encoded byte stream is a
+/// hardware-specific DMA layout (16 lanes × 8 pulses per byte at the
+/// wave8 pixel clock), so the encoding step belongs next to the DMA
+/// register writes. The engine hands over raw channel bytes; the
+/// peripheral chooses whether to run the encoder (`_esp` impl) or
+/// capture the raw bytes for test observation (`_mock` impl).
 
 #pragma once
 
@@ -116,9 +112,10 @@ class ChannelEngineI2sEsp32Dev : public IChannelDriver {
     bool ensureScratchBuffer(size_t required) FL_NO_EXCEPT;
 
     /// @brief Copy encoded pixel bytes from every enqueued channel
-    ///        into the scratch buffer. Stage 1: linear concatenation.
-    ///        Stage 2: parallel bit-transpose + wave8 slot expansion.
-    ///        Returns the total byte count written.
+    ///        into the scratch buffer as a linear concatenation.
+    ///        Wave8 pulse-major encoding is the peripheral's
+    ///        responsibility (see the class docstring's Layering
+    ///        section). Returns the total byte count written.
     size_t packScratchBuffer() FL_NO_EXCEPT;
 
     /// @brief Free the current scratch buffer (if any). Called when


### PR DESCRIPTION
## Summary

- `packScratchBuffer()` docs now reflect that it is a **linear byte concatenation** and NOT a placeholder for wave8 encoding.
- Wave8 pulse-major encoding is documented as the **peripheral impl's** responsibility — the encoded byte stream is a hardware-specific DMA layout (16 lanes × 8 pulses per byte at the wave8 pixel clock), so it belongs next to the DMA register writes, not in the engine.
- Mock peripheral captures raw channel bytes → host tests stay byte-value-sensitive without depending on wave8 encoding details.
- Drops two leftover includes (`fl/channels/wave8.h`, `platforms/esp/32/drivers/i2s/wave8_encoder_i2s1.h`) from an aborted attempt to inline wave8 in the engine's pack step.

Corrects the ##Staging language in the class docstring — replaces \"Stage 2 replaces the body of packScratchBuffer()\" with the layering rationale.

Part of the FastLED#3526 meta issue for the classic-ESP32 I2S bring-up.

## Test plan

- [x] `bash test channel_engine_i2s_esp32dev` — passes
- [x] `bash lint --cpp` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how I2S audio data is handled during transmission.
  * Updated comments to reflect the final processing flow, making it clearer that raw bytes are copied first and encoding happens later in the transmission layer.
  * Removed outdated staging language from inline documentation for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->