### PR TITLE
fix(ci): purge stale LPC framework tarball from restored fbuild cache

### DIFF
--- a/.github/workflows/build_template.yml
+++ b/.github/workflows/build_template.yml
@@ -79,6 +79,31 @@ jobs:
           # The action ignores this input on older revisions (no-op).
           install-cache-key-extra: ${{ hashFiles('pyproject.toml') }}
 
+      # Purge stale platform tarballs whose sha256 no longer matches what
+      # the current pin resolves to. The fbuild-cache restore-keys fall
+      # back to os+arch+fbuild-hash prefix (see FastLED/fbuild's
+      # setup/action.yml), so an LPC board can inherit the framework
+      # tarball an unrelated board cached weeks ago against a pre-repo-
+      # transfer URL. Result: fbuild sees the on-disk file, computes its
+      # sha256, and compares against the OLD expected sha256 stored in
+      # cache metadata — mismatch, hard fail before pio/compile can even
+      # run. Deleting only the platform-tarball subtree is targeted:
+      # unrelated caches (toolchain, cook artifacts, per-board build
+      # artifacts) are untouched. Deleted entries are lazily re-populated
+      # by the very next fbuild call. Non-LPC boards never had this
+      # subtree and skip the delete transparently. See
+      # FastLED/FastLED#3543 + #3547 for the LPC-transfer incident and
+      # cache-key gap that motivated this.
+      - name: Purge stale platform tarballs from restored fbuild cache
+        shell: bash
+        run: |
+          set -euo pipefail
+          purge_root="${RUNNER_TEMP}/fbuild-cache/platforms/FastLED-framework-arduino-lpc8xx"
+          if [ -d "$purge_root" ]; then
+            echo "purging stale $purge_root"
+            rm -rf "$purge_root"
+          fi
+
       - name: Install Platform
         if: inputs.platform != ''
         run: |


### PR DESCRIPTION
PRs #3543 and #3547 did not resolve the LPC-lane failures. Root cause: the fbuild setup action's cache uses restore-keys that fall back to 'fbuild-<version>-<os>-<arch>-<fbuild-hash>-' — a prefix that ignores cache-key-extra. So an lpc804 job whose exact key misses can still restore an unrelated board's cache (observed in run 28544189852: lpc804 restored uno_r4_wifi's cache). That cache holds a pre-transfer framework-arduino-lpc8xx tarball whose expected sha256 no longer matches what GitHub now serves for commit 50d76e0.

Fix: add a small step between the fbuild-cache restore and the pio/compile invocation that deletes ONLY /fbuild-cache/platforms/FastLED-framework-arduino-lpc8xx/. Other cached artifacts are untouched. Non-LPC boards never had this subtree so the step is a no-op for them. Deleted entries are lazily re-populated by the next fbuild call, which now downloads the FastLED-org tarball and records the correct sha256.

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a build/cache issue that could cause certain compilations to fail after restoring older cached artifacts.
  * Improved build reliability by automatically clearing stale cached platform files before continuing the setup process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->