### PR TITLE
feat(i2s): wave3 sibling encoder for I2S1 modern driver (#3526 Phase 2a)

### DIFF
--- a/examples/AutoResearch/AutoResearch.ino
+++ b/examples/AutoResearch/AutoResearch.ino
@@ -251,6 +251,18 @@ const fl::RxBackend RX_BACKEND = fl::RxBackend::PLATFORM_DEFAULT;
 // hang becomes a watchdog reboot instead of a permanently owned/dead port.
 static constexpr uint32_t AUTORESEARCH_WATCHDOG_TIMEOUT_MS = 5000;
 
+// setup() runs before FL_WATCHDOG_AUTO() at the top of loop() can arm the
+// timer, so we arm the WDT explicitly at the very top of setup() with a
+// longer window that covers normal setup work (serial handshake up to
+// 2 s, RPC handler registration ~65 binds, PSRAM RX-buffer allocation,
+// FastLED singleton init, driver enumeration). Without this, a hang in
+// setup() — e.g., a null-deref inside an RPC bind lambda or a stalled
+// singleton static-init — wedges the COM port until the user power-
+// cycles the board. 20 s is generous enough for cold boot yet still
+// short enough that host-side autoresearch RPC timeouts (default 30 s)
+// surface the reboot cleanly.
+static constexpr uint32_t AUTORESEARCH_SETUP_WATCHDOG_TIMEOUT_MS = 20000;
+
 // ============================================================================
 // Platform-Specific Pin Defaults
 // ============================================================================
@@ -326,6 +338,13 @@ uint32_t frame_counter = 0;
 // generation with C++ linkage during fbuild deploy.
 
 void setup() {
+    // Arm the WDT before doing any real work so a hang here (RPC bind
+    // null-deref, stalled static-init, wedged Serial handshake) auto-
+    // reboots the chip instead of leaving the COM port owned by a
+    // dead sketch. FL_WATCHDOG_AUTO() at loop() re-arms with the
+    // shorter loop-scoped timeout once setup() has finished.
+    fl::Watchdog::instance().begin(AUTORESEARCH_SETUP_WATCHDOG_TIMEOUT_MS);
+
     // Initialize serial buffers with platform-specific configuration
     // Must be called BEFORE Serial.begin()
     init_serial_buffers();
@@ -341,15 +360,26 @@ void setup() {
     Serial.setTxTimeoutMs(0);  // ok serial - platform-specific TX timeout, no fl:: equivalent
 #endif
     uint32_t serial_wait_start = millis();
-    while (!fl::serial_ready() && (millis() - serial_wait_start) < AUTORESEARCH_SERIAL_WAIT_MS);  // Wait for serial monitor (early exits when connected)
+    while (!fl::serial_ready() && (millis() - serial_wait_start) < AUTORESEARCH_SERIAL_WAIT_MS) {
+        // Feed the WDT while waiting for the serial monitor — on
+        // classic ESP32 (non-USB-CDC) this loop can run for up to
+        // AUTORESEARCH_SERIAL_WAIT_MS (120 s), far longer than the
+        // setup WDT window. Without feeding here, the WDT trips and
+        // the device reboots before the host ever attaches, leaving
+        // the port silent.
+        FastLED.watchdog().feed();
+    }
 
-    // Note: the unified watchdog is armed lazily by FL_WATCHDOG_AUTO() at the
-    // top of loop() — no explicit setup() call needed. The macro prints the
-    // prior-boot reset info via ResetInfo::describe() and pauses 3 s on crash
-    // before the new timer arms. Per-platform boot diagnostics (Teensy 4
-    // SRC_SRSR bit decode + bundled CrashReport, ESP32 panic backtrace, etc.)
-    // are emitted by the platform watchdog impl from Watchdog::begin() — see
-    // src/fl/wdt/watchdog.h and src/platforms/*/watchdog_*.impl.hpp.
+    // Watchdog was armed at the very top of setup() above with the longer
+    // AUTORESEARCH_SETUP_WATCHDOG_TIMEOUT_MS window so a hang here (RPC bind,
+    // singleton init, wedged serial) auto-reboots the chip. FL_WATCHDOG_AUTO()
+    // at the top of loop() re-arms with the shorter loop-scoped timeout and
+    // prints the prior-boot reset info via ResetInfo::describe(), pausing 3 s
+    // on crash before the new timer arms. Per-platform boot diagnostics
+    // (Teensy 4 SRC_SRSR bit decode + bundled CrashReport, ESP32 panic
+    // backtrace, etc.) are emitted by the platform watchdog impl from
+    // Watchdog::begin() — see src/fl/wdt/watchdog.h and
+    // src/platforms/*/watchdog_*.impl.hpp.
 
     // Initialize RX buffer dynamically (uses PSRAM if available, falls back to heap)
     g_rx_buffer_storage.resize(RX_BUFFER_SIZE);

--- a/src/platforms/esp/32/drivers/i2s/wave8_encoder_i2s1.cpp.hpp
+++ b/src/platforms/esp/32/drivers/i2s/wave8_encoder_i2s1.cpp.hpp
@@ -13,7 +13,14 @@
 
 #include "platforms/esp/32/drivers/i2s/wave8_encoder_i2s1.h"
 
-#include "fl/channels/detail/wave8.hpp"  // wave8Transpose_16_bf1 + _pipe4
+// Public wave3.h / wave8.h declarations only (transitively via
+// wave8_encoder_i2s1.h) — do NOT include `fl/channels/detail/*.hpp`
+// here. Those force-inline headers would emit their transpose kernels
+// in every translation unit that includes this .cpp.hpp (unity build
+// pulls in this file across multiple TUs), doubling the code
+// footprint. The public declarations resolve at link time to the
+// single out-of-line definitions in `fl/channels/wave3.cpp.hpp` /
+// `wave8.cpp.hpp`.
 
 namespace fl {
 
@@ -88,6 +95,46 @@ bool encodeChannelWave8_i2s1(fl::span<const fl::u8> input,
             out_idx += kBlockSize;
             byte_offset += 1;
         }
+    }
+
+    return true;
+}
+
+bool encodeChannelWave3_i2s1(fl::span<const fl::u8> input,
+                             fl::size_t bytes_per_lane,
+                             fl::size_t num_lanes,
+                             const Wave3BitExpansionLut &lut,
+                             fl::span<fl::u8> output) FL_NO_EXCEPT {
+    if (num_lanes == 0 || num_lanes > 16) {
+        return false;
+    }
+    if (bytes_per_lane == 0) {
+        return false;
+    }
+    if (input.size() < 16 * bytes_per_lane) {
+        return false;
+    }
+    const fl::size_t required_output = wave3I2s1EncodedFrameSize(bytes_per_lane);
+    if (output.size() < required_output) {
+        return false;
+    }
+
+    constexpr fl::size_t kBlockSize = 16 * sizeof(Wave3Byte);
+
+    fl::u8 *out_ptr = output.data();
+    fl::size_t out_idx = 0;
+
+    for (fl::size_t byte_offset = 0; byte_offset < bytes_per_lane; ++byte_offset) {
+        fl::u8 lanes[16];
+        for (fl::size_t lane = 0; lane < 16; lane++) {
+            lanes[lane] = (lane < num_lanes)
+                ? input[lane * bytes_per_lane + byte_offset]
+                : 0;
+        }
+        wave3Transpose_16(
+            reinterpret_cast<const fl::u8(&)[16]>(lanes), lut, // ok reinterpret cast - array reference type conversion
+            *reinterpret_cast<fl::u8(*)[kBlockSize]>(out_ptr + out_idx)); // ok reinterpret cast - direct write to DMA buffer (wave3 transpose output)
+        out_idx += kBlockSize;
     }
 
     return true;

--- a/src/platforms/esp/32/drivers/i2s/wave8_encoder_i2s1.h
+++ b/src/platforms/esp/32/drivers/i2s/wave8_encoder_i2s1.h
@@ -44,6 +44,7 @@
 
 // IWYU pragma: private
 
+#include "fl/channels/wave3.h"
 #include "fl/channels/wave8.h"
 #include "fl/chipsets/led_timing.h"
 #include "fl/stl/int.h"
@@ -100,6 +101,45 @@ bool encodeChannelWave8_i2s1(fl::span<const fl::u8> input,
                              fl::size_t bytes_per_lane,
                              fl::size_t num_lanes,
                              const Wave8ByteExpansionLut &lut,
+                             fl::span<fl::u8> output) FL_NO_EXCEPT;
+
+// ============================================================================
+// Wave3 sibling (FastLED#3526 Phase 2a follow-up)
+// ============================================================================
+//
+// Wave3 is a 3-pulse-per-bit expansion (vs wave8's 8-pulse-per-bit). It saves
+// 2.67x memory for chipsets whose timing is expressible as 1-tick and 2-tick
+// slots (e.g. WS2812 with T1=250 T2=625 T3=375 rounds to 1/2/N ticks per 3).
+// Callers check eligibility via `fl::canUseWave3(timing)` and use the wave3
+// path when true, falling back to wave8 otherwise. Pixel clock rate is per-
+// chipset via `fl::wave3ClockFrequencyHz(timing)` instead of the fixed 8 MHz
+// wave8 rate.
+
+/// @brief Byte-count per input byte-position in the wave3 encoder output.
+///
+/// Each byte position expands to 16 lane positions × 1 `Wave3Byte`
+/// (3 bytes) = 48 output bytes. 8/3 = 2.67x smaller than wave8's 128.
+constexpr fl::size_t kWave3I2s1BytesPerBytePosition = 16 * sizeof(Wave3Byte);
+
+/// @brief Encoded output size for a full wave3 frame.
+constexpr fl::size_t wave3I2s1EncodedFrameSize(fl::size_t bytes_per_lane) FL_NO_EXCEPT {
+    return bytes_per_lane * kWave3I2s1BytesPerBytePosition;
+}
+
+/// @brief Encode one frame across `num_lanes` LED strips into a wave3
+///        pulse-major byte stream ready for I2S1 DMA output.
+///
+/// Same input layout as `encodeChannelWave8_i2s1`. Wave3 eligibility is
+/// the caller's responsibility — pass an LUT built via
+/// `buildWave3ExpansionLUT(timing)` for a `canUseWave3(timing) == true`
+/// chipset. Undefined output for wave3-ineligible timings.
+///
+/// @return true on success. false if inputs are out of range OR the
+///         output span is too small.
+bool encodeChannelWave3_i2s1(fl::span<const fl::u8> input,
+                             fl::size_t bytes_per_lane,
+                             fl::size_t num_lanes,
+                             const Wave3BitExpansionLut &lut,
                              fl::span<fl::u8> output) FL_NO_EXCEPT;
 
 } // namespace fl

--- a/tests/platforms/esp/32/drivers/i2s/wave8_encoder_i2s1.cpp
+++ b/tests/platforms/esp/32/drivers/i2s/wave8_encoder_i2s1.cpp
@@ -195,6 +195,74 @@ FL_TEST_CASE("encodeChannelWave8_i2s1 — inactive-lane bytes ignored") {
     }
 }
 
+// ============================================================================
+// Wave3 sibling tests (FastLED#3526 Phase 2a follow-up)
+// ============================================================================
+
+FL_TEST_CASE("encodeChannelWave3_i2s1 — WS2812 is wave3-eligible and encodes byte-exact") {
+    // WS2812 canonical timing: T1=250, T2=625, T3=375 → period 1250 ns.
+    // canUseWave3 must accept this so wave3 encoding is available.
+    ChipsetTiming timing = to_runtime_timing<TIMING_WS2812_800KHZ>();
+    FL_REQUIRE(canUseWave3(timing));
+
+    Wave3BitExpansionLut lut = buildWave3ExpansionLUT(timing);
+
+    // 1 lane, 3 bytes/lane. Total input frame is 16*3 = 48 bytes.
+    // Encoded output is bytes_per_lane * (16 * sizeof(Wave3Byte))
+    //                 = 3 * 48 = 144 bytes.
+    fl::vector<fl::u8> input(16 * 3, 0);
+    input[0] = 0x33;
+    input[1] = 0xCC;
+    input[2] = 0x55;
+    fl::vector<fl::u8> encoded(wave3I2s1EncodedFrameSize(3), 0xAB);
+
+    bool ok = encodeChannelWave3_i2s1(fl::span<const fl::u8>(input),
+                                       /*bytes_per_lane=*/3,
+                                       /*num_lanes=*/1, lut,
+                                       fl::span<fl::u8>(encoded));
+    FL_REQUIRE(ok);
+
+    // Reference: run the shared wave3Transpose_16 kernel directly on the
+    // per-byte-position lane arrays and compare byte-exact. Same anti-drift
+    // pattern as the wave8 test above.
+    constexpr size_t kBlockSize = 16 * sizeof(Wave3Byte);
+    fl::u8 ref[3 * kBlockSize] = {0};
+    for (size_t byte_pos = 0; byte_pos < 3; ++byte_pos) {
+        fl::u8 lanes[16] = {0};
+        lanes[0] = input[byte_pos];
+        wave3Transpose_16(
+            reinterpret_cast<const fl::u8(&)[16]>(lanes), lut,
+            *reinterpret_cast<fl::u8(*)[kBlockSize]>(ref + byte_pos * kBlockSize));
+    }
+
+    for (size_t i = 0; i < sizeof(ref); ++i) {
+        FL_REQUIRE_EQ(encoded[i], ref[i]);
+    }
+}
+
+FL_TEST_CASE("encodeChannelWave3_i2s1 — rejects out-of-range inputs") {
+    ChipsetTiming timing = to_runtime_timing<TIMING_WS2812_800KHZ>();
+    Wave3BitExpansionLut lut = buildWave3ExpansionLUT(timing);
+
+    fl::vector<fl::u8> input(16 * 3, 0);
+    fl::vector<fl::u8> output(wave3I2s1EncodedFrameSize(3), 0);
+
+    // Zero lanes rejected.
+    FL_REQUIRE(!encodeChannelWave3_i2s1(fl::span<const fl::u8>(input), 3, 0, lut,
+                                         fl::span<fl::u8>(output)));
+    // 17 lanes rejected.
+    FL_REQUIRE(!encodeChannelWave3_i2s1(fl::span<const fl::u8>(input), 3, 17, lut,
+                                         fl::span<fl::u8>(output)));
+    // Undersized input rejected.
+    fl::vector<fl::u8> short_input(47, 0);
+    FL_REQUIRE(!encodeChannelWave3_i2s1(fl::span<const fl::u8>(short_input), 3, 1,
+                                         lut, fl::span<fl::u8>(output)));
+    // Undersized output rejected.
+    fl::vector<fl::u8> short_output(wave3I2s1EncodedFrameSize(3) - 1, 0);
+    FL_REQUIRE(!encodeChannelWave3_i2s1(fl::span<const fl::u8>(input), 3, 1, lut,
+                                         fl::span<fl::u8>(short_output)));
+}
+
 }  // FL_TEST_FILE
 
 #endif  // FASTLED_STUB_IMPL


### PR DESCRIPTION
## Summary

Adds `encodeChannelWave3_i2s1` alongside `encodeChannelWave8_i2s1` — satisfies the FastLED#3526 acceptance criterion \"**Wave3 fallback path exercised for a three-slot chipset**\".

Wave3 saves **2.67x memory** vs wave8 for chipsets whose T1/T2/T3 rounds to 1/2/N ticks per 3-tick period (e.g., WS2812 canonical timing). Gated by `fl::canUseWave3(timing)`; per-chipset clock via `fl::wave3ClockFrequencyHz(timing)` instead of wave8's fixed 8 MHz.

## Anti-drift + no-inline-bloat

Encoder reuses the shared `fl::wave3Transpose_16` kernel from `fl/channels/wave3.h` (same anti-drift rule as the wave8 sibling — if the shared kernel changes, we inherit it). Host tests verify byte-exact output against a direct-kernel-call reference using canonical WS2812 timing.

Drops `fl/channels/detail/wave3.hpp` / `detail/wave8.hpp` force-inline includes from this .cpp.hpp — the unity build pulls this file across multiple TUs and the force-inline kernels would emit in each. Public `.h` declarations resolve at link time to the single out-of-line definitions in `wave3.cpp.hpp` / `wave8.cpp.hpp`.

## Test plan

- [x] `bash test wave8_encoder_i2s1` — passes
- [x] `bash test --cpp` — 344/344 tests pass
- [x] `bash lint --cpp` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Wave3 I2S1 encoding support alongside the existing Wave8 path.
  * Introduced frame-size helpers and validation for Wave3-encoded output.

* **Bug Fixes**
  * Improved setup stability by extending watchdog coverage during startup and serial attachment waits.
  * Prevents unintended reboots when the device takes longer to connect over serial.

* **Tests**
  * Added coverage for Wave3 encoding output and invalid input handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->