### PR TITLE
fix(rx/esp32c2): gate RMT specialisation with FASTLED_ESP32_HAS_RMT

### DIFF
--- a/src/fl/channels/rx.cpp.hpp
+++ b/src/fl/channels/rx.cpp.hpp
@@ -14,6 +14,7 @@
 // IWYU pragma: begin_keep
 #include "platforms/esp/32/drivers/rmt_rx/rmt_rx_channel.h" // ok platform headers
 #include "platforms/esp/32/drivers/gpio_isr_rx/gpio_isr_rx.h" // ok platform headers
+#include "platforms/esp/32/feature_flags/enabled.h" // FASTLED_ESP32_HAS_RMT / FASTLED_RMT5 gates
 #endif
 // IWYU pragma: end_keep
 
@@ -90,14 +91,30 @@ namespace fl {
 
 #ifdef FL_IS_ESP32
 
-// RMT device specialization for ESP32
+// RMT device specialization for ESP32.
+//
+// The `RmtRxChannel::create` impl only exists on chips that actually have RMT
+// silicon: the IDF 4.x impl in `rmt_rx_4/` gates on
+// `FASTLED_ESP32_HAS_RMT && !FASTLED_ESP32_RMT5_ONLY_PLATFORM && !FASTLED_RMT5`
+// and the IDF 5.x impl in `rmt_rx_5/` gates on `FASTLED_RMT5`. On ESP32-C2
+// the SoC has no RMT peripheral (`SOC_RMT_SUPPORTED == 0`, so
+// `FASTLED_ESP32_HAS_RMT == 0`), and the workflow forces
+// `FASTLED_RMT5 = 0` for that chip — so both impls skip and the specialisation
+// link-fails with `undefined reference to fl::RmtRxChannel::create(int)`.
+// Mirror the exact gates the impls use here so the specialisation collapses
+// to a DummyRxDevice on RMT-less chips.
 template <>
 fl::shared_ptr<RxDevice> RxDevice::create<RxDeviceType::RMT>(int pin) FL_NO_EXCEPT {
+#if (FASTLED_ESP32_HAS_RMT && !FASTLED_ESP32_RMT5_ONLY_PLATFORM && !FASTLED_RMT5) || FASTLED_RMT5
     auto device = RmtRxChannel::create(pin);
     if (!device) {
         return fl::make_shared<DummyRxDevice>("RMT RX channel creation failed");
     }
     return device;
+#else
+    (void)pin;
+    return fl::make_shared<DummyRxDevice>("RMT RX not supported on this ESP32 SoC");
+#endif
 }
 
 // ISR device specialization for ESP32


### PR DESCRIPTION
esp32c2 has been red on master since #3467 (RmtRxChannel backport) with 'undefined reference to fl::RmtRxChannel::create(int)'. ESP32-C2 has no RMT peripheral (SOC_RMT_SUPPORTED == 0 → FASTLED_ESP32_HAS_RMT == 0), and platforms/esp/32/feature_flags/enabled.h forces FASTLED_RMT5 = 0 for that chip. So neither rmt_rx_4's nor rmt_rx_5's gate compiles, and RmtRxChannel::create has no definition to link.

Mirror the exact gate at the specialisation site: when the SoC doesn't have RMT silicon, collapse RxDevice::create<RMT> to a DummyRxDevice with a clear failure string instead of trying to call an unlinkable symbol.

Verified locally on Windows: bash compile esp32c2 --examples Blink succeeds (2m04s cold).

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ESP32 RMT receive setup so unsupported chips now fail immediately with a clearer “not supported” message instead of attempting unsupported initialization.
  * Kept the existing fallback behavior for supported chips when RMT channel creation fails, helping avoid confusing or inconsistent startup issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->