### PR TITLE
fix(rx): add 'ok platform headers' escape hatch to feature_flags include

### DIFF
--- a/src/fl/channels/rx.cpp.hpp
+++ b/src/fl/channels/rx.cpp.hpp
@@ -14,7 +14,7 @@
 // IWYU pragma: begin_keep
 #include "platforms/esp/32/drivers/rmt_rx/rmt_rx_channel.h" // ok platform headers
 #include "platforms/esp/32/drivers/gpio_isr_rx/gpio_isr_rx.h" // ok platform headers
-#include "platforms/esp/32/feature_flags/enabled.h" // FASTLED_ESP32_HAS_RMT / FASTLED_RMT5 gates
+#include "platforms/esp/32/feature_flags/enabled.h" // ok platform headers
 #endif
 // IWYU pragma: end_keep
 


### PR DESCRIPTION
PR #3560 added an include of platforms/esp/32/feature_flags/enabled.h without the '// ok platform headers' suffix the codebase uses to opt into deep-platform-header allowance. Both PlatformIncludesChecker and PlatformTrampolineChecker rejected it, breaking every unit_test workflow (linux, macos, windows).

The include is legitimate — it sits inside the existing '#ifdef FL_IS_ESP32' block alongside three siblings that already carry the suffix. Add the same suffix.

Verified locally: bash lint --cpp completes green.

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ESP32-specific support by ensuring the correct feature flags are loaded during builds, helping prevent platform-specific issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->