### PR TITLE
fix(i2s,rmt-rx,autoresearch): I2S loopback GREEN on WROOM bench (#3569)

### DIFF
--- a/examples/AutoResearch/AutoResearchPlatform.h
+++ b/examples/AutoResearch/AutoResearchPlatform.h
@@ -31,7 +31,13 @@ constexpr int defaultTxPin() {
 #elif defined(FL_IS_TEENSY_4X)
     return 1;  // Teensy 4.x: any GPIO works for TX
 #elif defined(FL_IS_ESP_32DEV)
-    return 18;  // ESP32 (classic): avoid GPIO0/1/3 (boot strap + UART0). See #3452.
+    // ESP32 (classic): GPIO 33 → GPIO 34 jumper. GPIO34 is input-only
+    // (no output driver, no boot-strap role) which makes it an ideal RX
+    // pin, and 33/34 avoid GPIO0/1/3 (boot strap + UART0, see #3452).
+    // The WROOM COM11 bench harness is physically wired 33 → 34
+    // (verified electrically in FastLED#3569 — the previously-documented
+    // 18 → 19 pair was never connected there).
+    return 33;
 #else
     return 1;  // Other variants
 #endif
@@ -57,7 +63,7 @@ constexpr int defaultRxPin() {
 #elif defined(FL_IS_TEENSY_4X)
     return 2;  // Teensy 4.x: FlexPWM-capable pin, jumper wire from pin 1
 #elif defined(FL_IS_ESP_32DEV)
-    return 19;  // ESP32 (classic): partner pin to GPIO 18 above. See #3452.
+    return 34;  // ESP32 (classic): input-only pad, jumper wire from GPIO 33.
 #else
     return 0;  // Other variants
 #endif

--- a/examples/AutoResearch/AutoResearchRemoteSystemMethods.cpp
+++ b/examples/AutoResearch/AutoResearchRemoteSystemMethods.cpp
@@ -201,6 +201,45 @@ void AutoResearchRemoteControl::bindSystemMethods(fl::Remote& remote) {
         response.set("serial_safe", false);
         return response;
     });
+
+    // FastLED#3569 bench diagnostic — read up to 16 u32 words of
+    // memory-mapped register space without resetting the chip (esptool
+    // pokes force a reset, wiping the very peripheral state under
+    // investigation). Params: [{addr: <u32>, count?: 1-16}]. The caller
+    // is expected to pass valid peripheral/SRAM addresses; an unmapped
+    // address faults exactly as it would from any other code.
+    remote.bind("peekMem", [this](const fl::json& args) -> fl::json {
+        fl::json response = fl::json::object();
+        if (!args.is_object() || !args.contains("addr") ||
+            !args["addr"].is_int()) {
+            response.set("success", false);
+            response.set("error", "InvalidArgs");
+            response.set("message", "Expected {addr: u32, count?: 1-16}");
+            return response;
+        }
+        const uint32_t addr =
+            static_cast<uint32_t>(args["addr"].as_int().value());
+        int count = 1;
+        if (args.contains("count") && args["count"].is_int()) {
+            count = static_cast<int>(args["count"].as_int().value());
+        }
+        if (count < 1 || count > 16 || (addr & 3u) != 0) {
+            response.set("success", false);
+            response.set("error", "InvalidArgs");
+            response.set("message", "count must be 1-16, addr 4-byte aligned");
+            return response;
+        }
+        fl::json values = fl::json::array();
+        const volatile uint32_t* p =
+            reinterpret_cast<const volatile uint32_t*>(addr);  // ok reinterpret cast - caller-supplied MMIO/SRAM address, bench diagnostic
+        for (int i = 0; i < count; ++i) {
+            values.push_back(static_cast<int64_t>(p[i]));
+        }
+        response.set("success", true);
+        response.set("addr", static_cast<int64_t>(addr));
+        response.set("values", values);
+        return response;
+    });
 }
 
 #endif // !(FASTLED_AUTORESEARCH_LOW_MEMORY)

--- a/examples/AutoResearch/AutoResearchTest.cpp
+++ b/examples/AutoResearch/AutoResearchTest.cpp
@@ -66,8 +66,10 @@ void dumpRawEdgeTiming(fl::shared_ptr<fl::RxChannel> rx_channel,
         return;
     }
 
-    // Allocate edge buffer sized to requested count (max 256 to avoid stack overflow)
-    fl::FixedVector<fl::EdgeTime, 256> edges;
+    // Heap-allocated edge buffer (was a 2 KB FixedVector on the stack —
+    // the capture path already runs the loopTask close to its limit,
+    // FastLED#3569).
+    fl::vector<fl::EdgeTime> edges;
     size_t buffer_size = range.count < 256 ? range.count : 256;
     edges.resize(buffer_size);  // Default initializes to EdgeTime()
 
@@ -469,11 +471,13 @@ size_t capture(fl::shared_ptr<fl::RxChannel> rx_channel,
     auto wait_result = rx_channel->wait(rx_wait_ms);
     if (diagnostics) {
         diagnostics->captureWaitResult = static_cast<int>(wait_result);
-        fl::FixedVector<fl::EdgeTime, 256> edges;
+        // Heap-allocated (was 2 KB + 256 B FixedVectors on the loopTask
+        // stack at its deepest point — FastLED#3569).
+        fl::vector<fl::EdgeTime> edges;
         edges.resize(256);
         diagnostics->rawEdgesAfterWait = static_cast<int>(rx_channel->getRawEdgeTimes(edges, 0));
         diagnostics->decodeOutputCapacity = static_cast<int>(rx_buffer.size());
-        fl::FixedVector<fl::EdgeTime, 32> sample_edges;
+        fl::vector<fl::EdgeTime> sample_edges;
         sample_edges.resize(32);
         const size_t sample_count = rx_channel->getRawEdgeTimes(sample_edges, 0);
         fl::sstream sample;

--- a/src/platforms/esp/32/drivers/i2s/channel_engine_i2s_esp32dev.cpp.hpp
+++ b/src/platforms/esp/32/drivers/i2s/channel_engine_i2s_esp32dev.cpp.hpp
@@ -220,11 +220,27 @@ void ChannelEngineI2sEsp32Dev::show() FL_NO_EXCEPT {
     // from the show() prologue so a SPI-only batch doesn't waste
     // an I2S1 claim that the SPI delegate would immediately race with).
     if (!mPeripheralInitialized) {
-        // Wave8 pixel clock = 8 MHz (WS2812 800 kHz × 8 pulses/bit).
-        // Peripheral picks its own N/A/B divider via `solveI2sClockDivider`.
+        // Wave8 pixel clock derived from the chipset timing: 8 pulses
+        // per bit → clk = 8 / bit_period. For WS2812 (1.25 µs period)
+        // that's 6.4 MHz; other chipsets get their own rate. (An
+        // earlier hardcoded 8 MHz produced a 1.0 µs bit period —
+        // bench-measured H750/L250 — 25% faster than spec;
+        // FastLED#3569.) All lanes share one clock — lane 0's timing
+        // wins; heterogeneous-timing batches are a follow-up.
+        u32 bit_period_ns = 0;
+        for (const auto &data : mInFlightChannels) {
+            if (data) {
+                bit_period_ns = data->getTiming().total_period_ns();
+                break;
+            }
+        }
+        const u32 pixel_clk_hz =
+            (bit_period_ns != 0)
+                ? static_cast<u32>(8000000000ULL / bit_period_ns)
+                : 6400000u;  // WS2812-equivalent fallback
         I2sEsp32DevPeripheralConfig cfg(
             /*port=*/1,
-            /*clk=*/8000000u,
+            /*clk=*/pixel_clk_hz,
             /*width=*/static_cast<u8>(mInFlightChannels.size()));
         if (!mPeripheral->initialize(cfg)) {
             FL_WARN_F("ChannelEngineI2sEsp32Dev: peripheral initialize failed");
@@ -470,15 +486,28 @@ size_t ChannelEngineI2sEsp32Dev::packScratchBuffer() FL_NO_EXCEPT {
         ++lane_idx;
     }
 
-    // Build the wave8 LUT for the target chipset timing, cached on the
-    // engine instance and filled IN PLACE via the out-param
-    // `buildWave8ByteExpansionLUT` overload — the by-value overload
-    // materialises a 2 KB temporary on the loop-task stack, which is
-    // what tripped the FastLED#3569 stack-canary panic inside the
-    // already-deep RPC → show() call chain. Rebuild when the timing
-    // changes (exact T1/T2/T3 comparison). Default chipset is fixed
-    // WS2812B 800 kHz until per-channel timing dispatch lands.
-    const ChipsetTiming timing = to_runtime_timing<TIMING_WS2812_800KHZ>();
+    // Build the wave8 LUT for the batch's chipset timing (lane 0's
+    // timing wins — all lanes share one waveform; heterogeneous-timing
+    // batches are a follow-up). Cached on the engine instance and
+    // filled IN PLACE via the out-param `buildWave8ByteExpansionLUT`
+    // overload — the by-value overload materialises a 2 KB temporary
+    // on the loop-task stack, which is what tripped the FastLED#3569
+    // stack-canary panic inside the already-deep RPC → show() call
+    // chain. Rebuild when the timing changes (exact T1/T2/T3
+    // comparison).
+    ChipsetTiming timing = to_runtime_timing<TIMING_WS2812_800KHZ>();
+    for (const auto &data : mInFlightChannels) {
+        if (!data) continue;
+        const ChipsetTimingConfig &cfg = data->getTiming();
+        if (cfg.total_period_ns() != 0) {
+            timing.T1 = cfg.t1_ns;
+            timing.T2 = cfg.t2_ns;
+            timing.T3 = cfg.t3_ns;
+            timing.RESET = cfg.reset_us;
+            timing.name = cfg.name;
+        }
+        break;
+    }
     if (!mWave8LutValid || mCachedT1 != timing.T1 || mCachedT2 != timing.T2 ||
         mCachedT3 != timing.T3) {
         const Wave8BitExpansionLut bit_lut = buildWave8ExpansionLUT(timing);  // 64 bytes — stack-safe

--- a/src/platforms/esp/32/drivers/i2s/i2s_peripheral_esp32dev_esp.cpp.hpp
+++ b/src/platforms/esp/32/drivers/i2s/i2s_peripheral_esp32dev_esp.cpp.hpp
@@ -286,7 +286,12 @@ bool I2sPeripheralEsp32DevEsp::initialize(
     // DMA drains the descriptor into the FIFO, up to 64 samples before
     // they reach the pins.)
     i2s->conf1.val = 0;
-    i2s->conf1.tx_stop_en = 1;
+    // tx_stop_en stays 0 (Yves baseline): bench-tested `= 1` produced
+    // ZERO wire output — the FIFO is empty at the instant `tx_start`
+    // is set (DMA prefetch hasn't landed yet), so the auto-stop latches
+    // before the first sample ever ships. Post-frame underrun clocking
+    // is handled by stopping TX from the completion path instead.
+    i2s->conf1.tx_stop_en = 0;
     i2s->conf1.tx_pcm_bypass = 1;
 
     // Mono channel mode routing everything to the right channel path

--- a/src/platforms/esp/32/drivers/i2s/wave8_encoder_i2s1.cpp.hpp
+++ b/src/platforms/esp/32/drivers/i2s/wave8_encoder_i2s1.cpp.hpp
@@ -122,9 +122,15 @@ bool wave8I2s1ExpandTo32Samples(fl::span<const fl::u8> pulses,
     for (fl::size_t p = 0; p < pulse_count; ++p) {
         const fl::u32 lo = src[2 * p + 0];  // lanes 0-7
         const fl::u32 hi = src[2 * p + 1];  // lanes 8-15
-        // Sample bit (n + 8) drives DATA_OUT(n) in tx_bits_mod=32 LCD
-        // mode (see header) — place the 16 lanes at bits 8..23.
-        dst[p] = (lo << 8) | (hi << 16);
+        // Lane n → memory bit (16 + n). Bench-derived (FastLED#3569):
+        // with tx_bits_mod=32 / tx_fifo_mod=3 / tx_chan_mod=1 (mono) /
+        // tx_right_first=1, classic-ESP32 I2S1 emits ONE 16-bit parallel
+        // sample per 32-bit memory word, sourced from the HIGH half-word
+        // — the low 16 bits are discarded. Verified by bisection: lanes
+        // at bits 8..23 → no signal on DATA_OUT0; bits 0..15 → none;
+        // all-32-broadcast → clean lane-0 waveform. So DATA_OUT(n) =
+        // memory bit (16 + n).
+        dst[p] = (lo << 16) | (hi << 24);
     }
     return true;
 }

--- a/src/platforms/esp/32/drivers/i2s/wave8_encoder_i2s1.h
+++ b/src/platforms/esp/32/drivers/i2s/wave8_encoder_i2s1.h
@@ -108,18 +108,22 @@ bool encodeChannelWave8_i2s1(fl::span<const fl::u8> input,
 // ============================================================================
 //
 // Classic-ESP32 I2S1 in Yves's proven register config (LCD mode,
-// `tx_bits_mod = 32`, `tx_fifo_mod = 3`) clocks ONE 32-bit sample per
-// pixel-clock period, and presents sample bit `n + 8` on `DATA_OUT(n)`
-// (bits 0..7 of every sample never reach any DATA_OUT line). Evidence:
-// Yves's driver put controller `i`'s data at word bit `i + 8`
-// (`has_data_mask |= 1 << (i + 8)`) while routing that controller's pin
-// to `I2S1O_DATA_OUT0_IDX + i` — and produced correct waveforms for
-// years. The raw wave8 stream (2 bytes per pulse) therefore CANNOT be
-// DMA'd directly: lane 0 would land at sample bit 0 (invisible) and two
-// pulse periods would be packed into each sample (halving the pulse
+// `tx_bits_mod = 32`, `tx_fifo_mod = 3`, `tx_chan_mod = 1` mono,
+// `tx_right_first = 1`) consumes one 32-bit memory word per pixel-clock
+// period but emits only its HIGH half-word as a 16-bit parallel sample:
+// `DATA_OUT(n)` presents memory bit `16 + n`; the low 16 bits are
+// discarded by the mono channel path. Bench-derived on ESP32-WROOM
+// (FastLED#3569) by bisection with a working RMT-RX loopback: lanes
+// placed at bits 8..23 → no signal on DATA_OUT0; bits 0..15 → none;
+// all-32-bit broadcast → clean lane-0 waveform ⇒ the tap is in bits
+// 24..31 for lanes 8..15 and 16..23 for lanes 0..7.
+//
+// The raw wave8 stream (2 bytes per pulse) therefore CANNOT be DMA'd
+// directly: lane 0 would land in the discarded low half-word, and two
+// pulse periods would be packed into each word (halving the pulse
 // rate). This expansion pass rewrites each 2-byte pulse into one 4-byte
-// sample with the 16 lanes at bits 8..23, so lane `n` comes out on
-// `DATA_OUT(n)` at the correct 1-sample-per-pulse rate.
+// sample with the 16 lanes at memory bits 16..31, so lane `n` comes out
+// on `DATA_OUT(n)` at the correct 1-sample-per-pulse rate.
 
 /// @brief Bytes per input byte-position after 32-bit sample expansion.
 ///
@@ -140,8 +144,9 @@ constexpr fl::size_t wave8I2s1Encoded32FrameSize(fl::size_t bytes_per_lane) FL_N
 ///                Size must be even.
 /// @param output  DMA-ready sample buffer, 4-byte aligned, at least
 ///                `pulses.size() * 2` bytes. Each sample is
-///                `lanes0_7 << 8 | lanes8_15 << 16` (bits 8..23 map to
-///                DATA_OUT0..15). Must NOT alias `pulses`.
+///                `lanes0_7 << 16 | lanes8_15 << 24` (memory bits
+///                16..31 map to DATA_OUT0..15). Must NOT alias
+///                `pulses`.
 /// @return true on success; false on size/alignment violations.
 bool wave8I2s1ExpandTo32Samples(fl::span<const fl::u8> pulses,
                                 fl::span<fl::u8> output) FL_NO_EXCEPT;

--- a/src/platforms/esp/32/drivers/rmt_rx/rmt_rx_5/rmt_rx_channel_5.cpp.hpp
+++ b/src/platforms/esp/32/drivers/rmt_rx/rmt_rx_5/rmt_rx_channel_5.cpp.hpp
@@ -704,6 +704,22 @@ class RmtRxChannelImpl : public RmtRxChannel {
         mStartLow = config.start_low;
         mIoLoopBack = config.io_loop_back;
         mUseDma = use_dma_req;
+#if !SOC_RMT_SUPPORT_RX_PINGPONG
+        // FastLED#3569 — on chips without RX ping-pong a non-DMA receive is
+        // strictly one-shot: symbols beyond the channel's hardware block can
+        // NEVER arrive. mBufferSize drives the accumulation-buffer sizing in
+        // allocateAndArm(), which grabs up to 25% of free heap — callers like
+        // AutoResearch pass edge_capacity = rx_buffer_bytes * 8 (≈256k
+        // symbols ≈ 1 MB), which strangled the WROOM heap on every capture
+        // arm and cascaded into null-alloc StoreProhibited crashes while the
+        // extra capacity bought nothing. Clamp to the hardware capacity.
+        if (!mUseDma && mBufferSize > kNonDmaRxSymbols) {
+            FL_LOG_RX("RX begin: clamping buffer_size " << mBufferSize
+                      << " -> " << kNonDmaRxSymbols
+                      << " (one-shot hw capacity, no RX ping-pong)");
+            mBufferSize = kNonDmaRxSymbols;
+        }
+#endif
 
         FL_LOG_RX("RX begin: signal_range_min="
                << mSignalRangeMinNs
@@ -1301,7 +1317,14 @@ class RmtRxChannelImpl : public RmtRxChannel {
         // MALLOC_CAP_INTERNAL memory â€” a plain fl::vector can land in PSRAM on
         // ESP32-S3, which ESP-IDF rejects with "user buffer not in the internal
         // RAM". See issue #2254.
+#if SOC_RMT_SUPPORT_RX_PINGPONG
         constexpr size_t NONDMA_BUFFER_SIZE = 4096;
+#else
+        // One-shot chips (no RX ping-pong): a receive can never deliver
+        // more than the channel's hardware block, so a 4096-symbol
+        // (16 KB) bounce buffer is pure heap waste (FastLED#3569).
+        constexpr size_t NONDMA_BUFFER_SIZE = kNonDmaRxSymbols;
+#endif
         // DMA user buffer sized to fit within num_dma_nodes Ã— 4092 bytes. With
         // mem_block_symbols=14336 we get 14 DMA nodes = 57288 bytes = 14322
         // symbols capacity. Pass 14000 symbols (= 56000 bytes) with margin.

--- a/tests/platforms/esp/32/drivers/i2s/channel_engine_i2s_esp32dev.cpp
+++ b/tests/platforms/esp/32/drivers/i2s/channel_engine_i2s_esp32dev.cpp
@@ -227,9 +227,9 @@ FL_TEST_CASE("I2sEsp32Dev - transmit emits wave8-encoded 32-bit samples") {
     // Two strips, 3 bytes each. Wave8 pulse-major encoding produces
     // `bytes_per_lane * 128` raw pulse bytes; the FastLED#3569 32-bit
     // sample expansion doubles that (`3 * 256 = 768`) — one u32 sample
-    // per pulse period with the 16 lanes at bits 8..23 (I2S1
-    // tx_bits_mod=32 LCD mode presents sample bit n+8 on DATA_OUT(n)).
-    // Verify:
+    // per pulse period with the 16 lanes at memory bits 16..31
+    // (bench-derived: I2S1 in tx_bits_mod=32 mono LCD mode emits only
+    // the high half-word; DATA_OUT(n) = memory bit 16+n). Verify:
     // - Size matches wave8I2s1Encoded32FrameSize()
     // - Output matches encodeChannelWave8_i2s1() +
     //   wave8I2s1ExpandTo32Samples() on the same lane-strided input
@@ -254,7 +254,13 @@ FL_TEST_CASE("I2sEsp32Dev - transmit emits wave8-encoded 32-bit samples") {
         ref_input[0 * 3 + i] = 0xAA;   // lane 0
         ref_input[1 * 3 + i] = 0xBB;   // lane 1
     }
+    // The engine derives the LUT from the CHANNEL's timing (see
+    // makeChannelData: 350/300/550) — build the reference from the same
+    // values, not a chipset constant.
     ChipsetTiming timing = to_runtime_timing<TIMING_WS2812_800KHZ>();
+    timing.T1 = 350;
+    timing.T2 = 300;
+    timing.T3 = 550;
     Wave8BitExpansionLut bit_lut = buildWave8ExpansionLUT(timing);
     Wave8ByteExpansionLut byte_lut = buildWave8ByteExpansionLUT(bit_lut);
     fl::vector<fl::u8> ref_wave8(kWave8Size, 0);
@@ -271,19 +277,18 @@ FL_TEST_CASE("I2sEsp32Dev - transmit emits wave8-encoded 32-bit samples") {
         FL_REQUIRE_EQ(rec.buffer_copy[i], ref_output[i]);
     }
 
-    // Spot-check the sample layout: lanes 0-7 = sample bits 8-15
-    // (byte 1), lanes 8-15 = sample bits 16-23 (byte 2). Bytes 0 and 3
-    // (sample bits 0-7 / 24-31 — never presented on DATA_OUT) must
-    // stay zero. Note: zero-padded lanes still carry the wave8 "0-bit"
-    // waveform (all lanes go high during the T1 phase), so bytes 1-2
-    // are nonzero even for inactive lanes — they're simply never
-    // routed to a GPIO.
+    // Spot-check the sample layout: lanes 0-7 = memory bits 16-23
+    // (byte 2), lanes 8-15 = memory bits 24-31 (byte 3). Bytes 0-1
+    // (the discarded low half-word) must stay zero. Note: zero-padded
+    // lanes still carry the wave8 "0-bit" waveform (all lanes go high
+    // during the T1 phase), so bytes 2-3 are nonzero even for inactive
+    // lanes — they're simply never routed to a GPIO.
     bool saw_lane0_high = false;
     for (size_t p = 0; p < kExpectedSize / 4; ++p) {
-        FL_REQUIRE_EQ(rec.buffer_copy[4 * p + 0], 0u);  // sample bits 0-7 unused
-        FL_REQUIRE_EQ(rec.buffer_copy[4 * p + 3], 0u);  // sample bits 24-31 unused
-        if (rec.buffer_copy[4 * p + 1] & 0x01u) {
-            saw_lane0_high = true;  // lane 0 data present at sample bit 8
+        FL_REQUIRE_EQ(rec.buffer_copy[4 * p + 0], 0u);  // low half-word unused
+        FL_REQUIRE_EQ(rec.buffer_copy[4 * p + 1], 0u);  // low half-word unused
+        if (rec.buffer_copy[4 * p + 2] & 0x01u) {
+            saw_lane0_high = true;  // lane 0 data present at memory bit 16
         }
     }
     FL_CHECK(saw_lane0_high);


### PR DESCRIPTION
**Bench milestone: the modern classic-ESP32 I2S engine passes byte-exact loopback on real hardware.** `runSingleTest {driver: I2S, laneSizes: [10], pattern: ALL_ONES}` on ESP32-WROOM COM11: `passed: true, passedTests: 4/4, captureEvidenceBytes: 120, rawEdges: 256`. RMT control also 4/4. This closes the wire-verification gap that #3569/#3568/#3515 Phase D were blocked on.

## Bench-derived driver corrections

1. **Sample layout**: I2S1 in `tx_bits_mod=32` mono LCD mode emits only the **high half-word** of each 32-bit memory word — `DATA_OUT(n)` = memory bit `16+n`; the low 16 bits are discarded. Found by bisection against a working RMT-RX loopback (lanes at bits 8..23 → silent; 0..15 → silent; all-32 broadcast → clean waveform). The expansion pass now packs the 16 lanes at bits 16..31.
2. **Timing derived from the chipset, not hardcoded**: pixel clock = 8 pulses / bit-period from the channel's `ChipsetTimingConfig` (6.4 MHz for WS2812 — the previous 8 MHz hardcode gave a 1.0 µs bit, 25% out of spec), and the wave8 LUT is built from the channel's T1/T2/T3 so the wire waveform matches what the chipset and the RX decoder expect.
3. `tx_stop_en` stays 0 — bench-tested `=1` latches the auto-stop at `tx_start` (FIFO momentarily empty before DMA prefetch lands) and nothing ever ships.

## Crash-family fix (RMT RX heap)

Callers pass `edge_capacity ≈ 256k symbols`; on one-shot chips (no RX ping-pong) the accumulation buffer grabbed 25% of free heap per capture arm for capacity that can never arrive — cascading into the null-alloc StoreProhibited / LoadStoreAlignment crashes once real capture data started flowing. Both the accumulation size and the non-DMA bounce buffer now clamp to the hardware one-shot capacity.

## AutoResearch bench plumbing

- Classic-ESP32 default pins 18/19 → **33/34** (matches the physical COM11 harness — the 18/19 pair was never connected, proven electrically; GPIO34 is input-only, ideal RX). Also stops the boot-time shared RX on a dead pin from hogging 4 RMT mem blocks.
- Edge diagnostic buffers: stack `FixedVector` → `fl::vector`.
- New `peekMem` RPC — reads MMIO/SRAM without resetting the chip; this is what showed the DMA completing (`out_eof`/`out_total_eof` raw, EOF descriptor consumed, pin routed) while the pin stayed silent, isolating the fault to the sample-bit mapping.

## Verification

- `bash test --cpp --clean`: 345/345.
- `bash lint`: clean.
- Live bench: I2S 4/4 byte-exact, RMT 4/4 byte-exact, no crashes across repeated runs.

Related: #3569, #3568, #3526, #3515 Phase D.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a remote memory inspection command for the AutoResearch tools, returning a range of 32-bit values when given a valid address and count.
  * Improved ESP32 timing handling so waveform output adapts more closely to the active channel’s configured timing.

* **Bug Fixes**
  * Updated default ESP32 GPIO wiring for AutoResearch examples.
  * Reduced receive-buffer sizing risks on ESP32 RMT capture paths.
  * Adjusted I2S waveform encoding and stop behavior for more reliable transmission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->