### PR TITLE
fix(uart): wave10 minimum symbol separation — UART + SPI loopback GREEN (fixes #3572)

### DIFF
--- a/src/platforms/esp/32/drivers/uart/wave8_encoder_uart.cpp.hpp
+++ b/src/platforms/esp/32/drivers/uart/wave8_encoder_uart.cpp.hpp
@@ -121,6 +121,25 @@ Wave10Lut buildWave10Lut(const ChipsetTimingConfig& timing) FL_NO_EXCEPT {
     if (pulses_1 < 1) pulses_1 = 1;
     if (pulses_1 > 4) pulses_1 = 4;
 
+    // FastLED#3569 follow-up (UART bench): enforce a minimum ABSOLUTE
+    // wire separation between the 0 and 1 symbols, widening T1H upward.
+    // Best-fit rounding alone can land them one pulse apart, and at
+    // high baud one pulse is too little: WS2812B-V5 (T0H=225, T1H=580,
+    // pulse=245 ns) rounds to (1, 2) = 245 vs 490 ns, inside real LEDs'
+    // 0/1 ambiguity band (the WS281x sampling threshold sits near
+    // 550-625 ns) — it flapped the RX decoder's 500 ns threshold on the
+    // WROOM bench. A longer HIGH still reads as 1, so rounding T1H up
+    // is safe: (1, 2) → (1, 3) = 245 vs 735 ns, matching the proven
+    // legacy WS2812 LUT shape. Slow chipsets (WS2811-400: 500 ns
+    // pulses) already have ≥ 500 ns of single-pulse separation and are
+    // left untouched.
+    constexpr u32 kMinSymbolSeparationNs = 400;
+    while (pulses_1 < 4 &&
+           static_cast<u32>(pulses_1 - pulses_0) * pulse_width_ns <
+               kMinSymbolSeparationNs) {
+        ++pulses_1;
+    }
+
     // Build LUT entries for all 4 two-bit combinations
     result.lut[0] = buildUartByte(pulses_0, pulses_0); // "00"
     result.lut[1] = buildUartByte(pulses_0, pulses_1); // "01"
@@ -157,15 +176,30 @@ bool canRepresentTiming(const ChipsetTimingConfig& timing) FL_NO_EXCEPT {
     // Check 4: Pulse counts must be distinguishable
     if (pulses_0 == pulses_1) return false;
 
-    // Check 5 & 6: Quantized timing must be within half a pulse width of nominal.
-    // This is the natural quantization error bound for best-fit rounding.
-    // For chipsets with wider pulses (lower baud), tolerance scales accordingly.
+    // Mirror buildWave10Lut's minimum-separation bump so feasibility is
+    // judged against the counts that will actually be transmitted.
+    constexpr u32 kMinSymbolSeparationNs = 400;
+    const u8 pulses_1_raw = pulses_1;
+    while (pulses_1 < 4 &&
+           static_cast<u32>(pulses_1 - pulses_0) * pulse_width_ns <
+               kMinSymbolSeparationNs) {
+        ++pulses_1;
+    }
+
+    // Check 5 & 6: Quantized timing must be within half a pulse width of
+    // nominal — the natural error bound for best-fit rounding. When the
+    // separation bump deliberately widened T1H (longer HIGH still reads
+    // as 1), allow the extra pulse it added on top of that bound; the
+    // shortened T1L tail this costs is harmless as long as one LOW pulse
+    // remains, which the [1, 4] range guarantees.
     const u32 tolerance_ns = pulse_width_ns / 2;
     const u32 actual_t0h = static_cast<u32>(pulses_0) * pulse_width_ns;
     const u32 actual_t1h = static_cast<u32>(pulses_1) * pulse_width_ns;
+    const u32 t1h_tolerance_ns =
+        tolerance_ns + static_cast<u32>(pulses_1 - pulses_1_raw) * pulse_width_ns;
 
     if (absDiff(actual_t0h, t0h_ns) > tolerance_ns) return false;
-    if (absDiff(actual_t1h, t1h_ns) > tolerance_ns) return false;
+    if (absDiff(actual_t1h, t1h_ns) > t1h_tolerance_ns) return false;
 
     return true;
 }

--- a/tests/platforms/esp/32/drivers/uart/wave8_encoder_uart.cpp
+++ b/tests/platforms/esp/32/drivers/uart/wave8_encoder_uart.cpp
@@ -212,6 +212,37 @@ FL_TEST_CASE("Wave10 - buildWave10Lut for WS2812") {
     }
 }
 
+FL_TEST_CASE("Wave10 - buildWave10Lut for WS2812B-V5 enforces symbol separation") {
+    // WS2812B-V5: T1=225, T2=355, T3=645, period=1225 — the AutoResearch
+    // bench default. pulse_width = 1225/5 = 245ns.
+    // T0H = 225 → 1 pulse (245ns). T1H = 580 → best-fit rounds to 2
+    // (490ns), only 245ns above the 0-symbol — under the 400ns minimum
+    // wire separation (real LEDs' 0/1 sampling threshold sits near
+    // 550-625ns; the bench RX decoder's 500ns threshold flapped —
+    // FastLED#3569 WROOM bench). The separation rule must widen it to
+    // 3 pulses (735ns).
+    ChipsetTimingConfig timing(225, 355, 645, 280);
+    FL_REQUIRE(canRepresentTiming(timing));
+    Wave10Lut lut = buildWave10Lut(timing);
+
+    FL_SUBCASE("1-symbol gets >=2 pulses of separation") {
+        auto p00 = measureHalfFrames(lut.lut[0]);
+        FL_CHECK_EQ(p00.high_count_a, 1);
+        FL_CHECK_EQ(p00.high_count_b, 1);
+
+        auto p11 = measureHalfFrames(lut.lut[3]);
+        FL_CHECK_EQ(p11.high_count_a, 3);
+        FL_CHECK_EQ(p11.high_count_b, 3);
+    }
+
+    FL_SUBCASE("LUT matches the proven legacy WS2812 shape") {
+        FL_CHECK_EQ(lut.lut[0], 0xEF);  // "00"
+        FL_CHECK_EQ(lut.lut[1], 0x8F);  // "01"
+        FL_CHECK_EQ(lut.lut[2], 0xEC);  // "10"
+        FL_CHECK_EQ(lut.lut[3], 0x8C);  // "11"
+    }
+}
+
 FL_TEST_CASE("Wave10 - buildWave10Lut for SK6812") {
     // SK6812: T1=300, T2=600, T3=300, period=1200
     ChipsetTimingConfig timing(300, 600, 300, 80);


### PR DESCRIPTION
Fixes #3572.

Bench validation sweep on ESP32-WROOM COM11 (jumper GPIO33→34): **all four channel drivers now pass byte-exact 10-LED loopback, 4/4 patterns each** — RMT, I2S, UART, SPI.

## UART — the one real bug

`buildWave10Lut()` best-fit rounding put WS2812B-V5's 1-symbol at 2 UART pulses (490 ns), only 245 ns above the 0-symbol — inside real WS281x parts' 0/1 sampling band and flapping the bench decoder's 500 ns threshold (wrong bytes / failed decodes, bench-captured `H475/H500` flapping). Fix: enforce a **400 ns minimum absolute wire separation**, widening T1H upward (longer HIGH still reads as 1): V5 → (1,3) = 245 vs 735 ns, matching the proven legacy WS2812 LUT shape. `canRepresentTiming()` mirrors the bump. Canonical WS2812 (1,3), SK6812 (1,4), and slow chipsets (WS2811-400 — 500 ns pulses already exceed the floor) are unchanged; unit test pins the V5 shape.

**Bench after fix:** `{"driver":"UART","passed":true,"passedTests":4,"captureEvidenceBytes":120,"captureEvidenceRawEdges":256}`

## SPI — no code change needed

`{"driver":"SPI","passed":true,"passedTests":4,...}` on the same bench. Its earlier crashes were the #3571 heap-exhaustion family. The driver is **already async** at the channel level (`spi_device_queue_trans` ISR-driven DMA + non-blocking `poll()` pipeline); the remaining #3179 scope (ISR-chunked ring-buffer streaming) is a peak-memory optimization for very long strips, tracked separately.

## Verification

- `bash test --cpp`: green (incl. new Wave10 V5 separation test; WS2811-400/SK6812/WS2812 pinning tests unchanged).
- `bash lint`: clean.
- Bench regression: RMT 4/4, I2S 4/4, UART 4/4, SPI 4/4 — byte-exact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved UART timing support for a WS2812B-V5-style profile, making closely spaced signal values more reliably distinguishable.
  * Updated the timing selection logic so valid signal patterns can be generated even when a small minimum separation is required.

* **Tests**
  * Added coverage for the new timing profile to verify LUT generation, timing acceptance, and expected output patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->