### PR TITLE
feat(uart): waveN frame geometries — wave4 alongside wave10 with per-chipset selection (fixes #3574)

### DIFF
--- a/examples/AutoResearch/AutoResearchRemoteRunSingleTest.cpp
+++ b/examples/AutoResearch/AutoResearchRemoteRunSingleTest.cpp
@@ -794,6 +794,11 @@ fl::json AutoResearchRemoteControl::runSingleTestImpl(const fl::json& args) {
     } else if (timing_name == "UCS7604-800KHZ") {
         resolved_timing = fl::makeTimingConfig<fl::TIMING_UCS7604_800KHZ>();
         resolved_encoder = fl::encoder_for<fl::TIMING_UCS7604_800KHZ>();
+    } else if (timing_name == "SK6812") {
+        // SK6812 exercises the UART wave8-frame geometry (its T0H/T1H
+        // are exact multiples of period/4 — FastLED#3572 follow-up).
+        resolved_timing = fl::makeTimingConfig<fl::TIMING_SK6812>();
+        resolved_encoder = fl::encoder_for<fl::TIMING_SK6812>();
     } else {
         resolved_timing = fl::makeTimingConfig<fl::TIMING_WS2812B_V5>();
         resolved_encoder = fl::encoder_for<fl::TIMING_WS2812B_V5>();

--- a/src/platforms/esp/32/drivers/uart/channel_driver_uart.cpp.hpp
+++ b/src/platforms/esp/32/drivers/uart/channel_driver_uart.cpp.hpp
@@ -29,6 +29,7 @@ ChannelEngineUART::ChannelEngineUART(fl::shared_ptr<IUartPeripheral> peripheral)
     : mPeripheral(fl::move(peripheral)),
       mInitialized(false),
       mCurrentBaudRate(0),
+      mCurrentDataBits(0),
       mCurrentGroupIndex(0) {
     if (!mPeripheral) {
         FL_WARN_F("UART: Null peripheral pointer in constructor");
@@ -220,7 +221,7 @@ const Wave10Lut& ChannelEngineUART::getOrBuildLut(const ChipsetTimingConfig& tim
     LutCacheEntry newEntry;
     newEntry.mTiming = timing;
     newEntry.mLut = buildWave10Lut(timing);
-    newEntry.mBaudRate = Wave10Lut::computeBaudRate(timing);
+    newEntry.mBaudRate = newEntry.mLut.baudRate(timing);
     mLutCache.push_back(newEntry);
     return mLutCache.back().mLut;
 }
@@ -256,13 +257,23 @@ void ChannelEngineUART::beginTransmission(
         return;
     }
 
-    // Compute required baud rate from timing
-    u32 required_baud = Wave10Lut::computeBaudRate(timing);
+    // Get or build the wave LUT for this timing FIRST — the selected
+    // frame geometry (wave10 = 8 data bits @ 5 pulses/bit, wave8-frame
+    // = 6 data bits @ 4 pulses/bit) determines both the baud rate and
+    // the UART word length.
+    const Wave10Lut& lut = getOrBuildLut(timing);
+    if (lut.pulses_per_bit == 0) {
+        FL_WARN_F("UART: timing not representable by any wave geometry");
+        return;
+    }
+    const u32 required_baud = lut.baudRate(timing);
+    const u8 required_data_bits = lut.dataBits();
 
     // Initialize or reinitialize UART peripheral if needed
-    if (!mInitialized || mCurrentBaudRate != required_baud) {
+    if (!mInitialized || mCurrentBaudRate != required_baud ||
+        mCurrentDataBits != required_data_bits) {
         if (mInitialized) {
-            // Reinitialize with new baud rate
+            // Reinitialize with new baud rate / word length
             FL_DBG_F("UART: Reinitializing peripheral (baud change: %s -> %s)", mCurrentBaudRate, required_baud);
             mPeripheral->deinitialize();
             mInitialized = false;
@@ -271,13 +282,14 @@ void ChannelEngineUART::beginTransmission(
         FL_DBG_F("UART: Initializing peripheral with baud=%s, pin=%s", required_baud, pin);
 
         UartPeripheralConfig config(
-            required_baud,     // mBaudRate (derived from timing)
-            pin,               // mTxPin
-            -1,                // mRxPin (not used)
-            4096,              // mTxBufferSize (4 KB for DMA)
-            256,               // mRxBufferSize (minimum required by ESP-IDF)
-            1,                 // mStopBits (8N1)
-            1                  // mUartNum (UART1)
+            required_baud,      // mBaudRate (derived from timing + geometry)
+            pin,                // mTxPin
+            -1,                 // mRxPin (not used)
+            4096,               // mTxBufferSize (4 KB for DMA)
+            256,                // mRxBufferSize (minimum required by ESP-IDF)
+            1,                  // mStopBits (N1)
+            1,                  // mUartNum (UART1)
+            required_data_bits  // mDataBits (8 = wave10, 6 = wave8-frame)
         );
 
         if (!mPeripheral->initialize(config)) {
@@ -288,10 +300,8 @@ void ChannelEngineUART::beginTransmission(
         FL_DBG_F("UART: Peripheral initialized successfully");
         mInitialized = true;
         mCurrentBaudRate = required_baud;
+        mCurrentDataBits = required_data_bits;
     }
-
-    // Get or build the Wave10 LUT for this timing
-    const Wave10Lut& lut = getOrBuildLut(timing);
 
     // Prepare scratch buffer (copy LED RGB data)
     prepareScratchBuffer(channelData, dataSize);

--- a/src/platforms/esp/32/drivers/uart/channel_driver_uart.h
+++ b/src/platforms/esp/32/drivers/uart/channel_driver_uart.h
@@ -90,6 +90,7 @@ private:
     fl::shared_ptr<IUartPeripheral> mPeripheral;
     bool mInitialized;
     u32 mCurrentBaudRate; ///< Currently configured baud rate
+    u8 mCurrentDataBits;  ///< Currently configured UART word length (wave geometry)
 
     fl::vector<u8> mScratchBuffer;
     fl::vector<u8> mEncodedBuffer;

--- a/src/platforms/esp/32/drivers/uart/iuart_peripheral.h
+++ b/src/platforms/esp/32/drivers/uart/iuart_peripheral.h
@@ -70,6 +70,7 @@ struct UartPeripheralConfig {
     u32 mRxBufferSize;      ///< RX ring buffer size (typically 0 for LED control)
     u8 mStopBits;           ///< Stop bits: 1 or 2 (UART_STOP_BITS_1=1, UART_STOP_BITS_2=2)
     int mUartNum;                ///< UART peripheral number (0, 1, or 2)
+    u8 mDataBits;           ///< Data bits per frame: 5-8 (wave10 uses 8, wave8-frame uses 6)
 
     /// @brief Default constructor (for mock testing)
     UartPeripheralConfig() FL_NO_EXCEPT
@@ -79,7 +80,8 @@ struct UartPeripheralConfig {
           mTxBufferSize(0),
           mRxBufferSize(0),
           mStopBits(1),
-          mUartNum(0) {}
+          mUartNum(0),
+          mDataBits(8) {}
 
     /// @brief Constructor with all parameters
     UartPeripheralConfig(u32 baud_rate,
@@ -88,14 +90,16 @@ struct UartPeripheralConfig {
                          u32 tx_buffer_size,
                          u32 rx_buffer_size,
                          u8 stop_bits,
-                         int uart_num) FL_NO_EXCEPT
+                         int uart_num,
+                         u8 data_bits = 8) FL_NO_EXCEPT
         : mBaudRate(baud_rate),
           mTxPin(tx_pin),
           mRxPin(rx_pin),
           mTxBufferSize(tx_buffer_size),
           mRxBufferSize(rx_buffer_size),
           mStopBits(stop_bits),
-          mUartNum(uart_num) {}
+          mUartNum(uart_num),
+          mDataBits(data_bits) {}
 };
 
 //=============================================================================

--- a/src/platforms/esp/32/drivers/uart/uart_peripheral_esp.cpp.hpp
+++ b/src/platforms/esp/32/drivers/uart/uart_peripheral_esp.cpp.hpp
@@ -91,7 +91,19 @@ bool UartPeripheralEsp::initialize(const UartPeripheralConfig& config) FL_NO_EXC
     // Configure UART parameters
     uart_config_t uart_config = {};
     uart_config.baud_rate = static_cast<int>(config.mBaudRate);
-    uart_config.data_bits = UART_DATA_8_BITS;
+    // Word length per the selected wave geometry: 8 data bits for
+    // wave10 (5 pulses/LED-bit), 6 for wave8-frame (4 pulses/LED-bit).
+    switch (config.mDataBits) {
+    case 5: uart_config.data_bits = UART_DATA_5_BITS; break;
+    case 6: uart_config.data_bits = UART_DATA_6_BITS; break;
+    case 7: uart_config.data_bits = UART_DATA_7_BITS; break;
+    case 8: uart_config.data_bits = UART_DATA_8_BITS; break;
+    default:
+        FL_WARN_F("UartPeripheralEsp: Invalid data bits (%s), defaulting to 8",
+                  static_cast<int>(config.mDataBits));
+        uart_config.data_bits = UART_DATA_8_BITS;
+        break;
+    }
     uart_config.parity = UART_PARITY_DISABLE;
 
     // Map stop bits (1 or 2)

--- a/src/platforms/esp/32/drivers/uart/wave8_encoder_uart.cpp.hpp
+++ b/src/platforms/esp/32/drivers/uart/wave8_encoder_uart.cpp.hpp
@@ -61,33 +61,36 @@ u8 computePulseCount(u32 timing_ns, u32 pulse_width_ns) FL_NO_EXCEPT {
 /// @param pulses_a HIGH pulse count for LED bit A [1, 4]
 /// @param pulses_b HIGH pulse count for LED bit B [1, 4]
 /// @return UART data byte value
-u8 buildUartByte(u8 pulses_a, u8 pulses_b) FL_NO_EXCEPT {
-    // Build the desired 10-bit wire pattern (with TX inversion)
-    // Wire positions: [0=START] [1=~D0] ... [8=~D7] [9=STOP]
+u8 buildUartByte(u8 pulses_a, u8 pulses_b, u8 pulses_per_bit = 5) FL_NO_EXCEPT {
+    // Build the desired 2P-bit wire pattern (with TX inversion), where
+    // P = pulses_per_bit. Wire positions:
+    //   [0=START] [1=~D0] ... [2P-2=~D(2P-3)] [2P-1=STOP]
     //
-    // LED bit A (pos 0-4): pulses_a HIGH bits, then LOW
-    // LED bit B (pos 5-9): pulses_b HIGH bits, then LOW (STOP=L)
+    // LED bit A (pos 0..P-1): pulses_a HIGH bits, then LOW
+    // LED bit B (pos P..2P-1): pulses_b HIGH bits, then LOW (STOP=L)
 
-    int wire[10];
+    const int P = static_cast<int>(pulses_per_bit);
+    int wire[10]; // max frame = 10 (P=5)
 
     // LED bit A: pulses_a HIGH bits starting from position 0
-    for (int i = 0; i < 5; i++) {
+    for (int i = 0; i < P; i++) {
         wire[i] = (i < static_cast<int>(pulses_a)) ? 1 : 0;
     }
 
-    // LED bit B: pulses_b HIGH bits starting from position 5
-    for (int i = 0; i < 5; i++) {
-        wire[5 + i] = (i < static_cast<int>(pulses_b)) ? 1 : 0;
+    // LED bit B: pulses_b HIGH bits starting from position P
+    for (int i = 0; i < P; i++) {
+        wire[P + i] = (i < static_cast<int>(pulses_b)) ? 1 : 0;
     }
 
     // Convert wire pattern back to UART data byte
     // Wire[0] = START (inverted) = always H → no control needed
-    // Wire[1..8] = ~D0..~D7 (inverted data, LSB first)
-    // Wire[9] = STOP (inverted) = always L → no control needed
+    // Wire[1..2P-2] = ~D0..~D(2P-3) (inverted data, LSB first)
+    // Wire[2P-1] = STOP (inverted) = always L → no control needed
     //
     // So: wire[1+i] = ~D_i → D_i = ~wire[1+i] = wire[1+i] ? 0 : 1
     u8 byte_val = 0;
-    for (int i = 0; i < 8; i++) {
+    const int data_bits = 2 * P - 2;
+    for (int i = 0; i < data_bits; i++) {
         int data_bit = wire[1 + i] ? 0 : 1; // Invert: wire HIGH → data 0
         byte_val |= static_cast<u8>(data_bit << i); // LSB first
     }
@@ -95,113 +98,131 @@ u8 buildUartByte(u8 pulses_a, u8 pulses_b) FL_NO_EXCEPT {
     return byte_val;
 }
 
+/// @brief Fit result for one UART wave geometry (P pulses per LED bit)
+struct UartWaveFit {
+    bool ok;
+    u8 pulses_0;
+    u8 pulses_1;
+    u32 total_err_ns; ///< |T0H err| + |T1H err| vs nominal, post-bump
+};
+
+/// @brief Evaluate whether P pulses/LED-bit can represent the timing.
+///
+/// Shared by buildWave10Lut() and canRepresentTiming() so the LUT that
+/// gets built is always judged by the same rules that admitted it.
+UartWaveFit fitUartWave(const ChipsetTimingConfig& timing,
+                        u8 pulses_per_bit) FL_NO_EXCEPT {
+    UartWaveFit fit = {};
+    const u32 period_ns = timing.total_period_ns();
+    if (period_ns == 0) return fit;
+
+    // Baud = one UART bit per pulse = P / period. Must fit the ESP32
+    // UART ceiling.
+    const u64 baud =
+        static_cast<u64>(pulses_per_bit) * 1000000000ULL / period_ns;
+    if (baud == 0 || baud > kMaxUartBaudRate) return fit;
+
+    const u32 pulse_width_ns = period_ns / pulses_per_bit;
+    if (pulse_width_ns == 0) return fit;
+
+    const u32 t0h_ns = timing.t1_ns;
+    const u32 t1h_ns = timing.t1_ns + timing.t2_ns;
+    const u8 max_pulses = static_cast<u8>(pulses_per_bit - 1);
+
+    u8 pulses_0 = computePulseCount(t0h_ns, pulse_width_ns);
+    u8 pulses_1 = computePulseCount(t1h_ns, pulse_width_ns);
+    if (pulses_0 < 1 || pulses_0 > max_pulses) return fit;
+    if (pulses_1 < 1 || pulses_1 > max_pulses) return fit;
+    if (pulses_0 == pulses_1) return fit;
+
+    // FastLED#3569/#3572 — enforce a minimum ABSOLUTE wire separation
+    // between the 0 and 1 symbols, widening T1H upward (a longer HIGH
+    // still reads as 1). Best-fit rounding alone can land them one
+    // pulse apart, and at high baud one pulse is too little: WS2812B-V5
+    // at P=5 rounds to 245 vs 490 ns — inside real WS281x parts'
+    // sampling-threshold band (~550-625 ns); it flapped the WROOM bench
+    // decoder. Slow chipsets (WS2811-400: 500+ ns pulses) already
+    // exceed the floor with single-pulse separation.
+    constexpr u32 kMinSymbolSeparationNs = 400;
+    const u8 pulses_1_raw = pulses_1;
+    while (pulses_1 < max_pulses &&
+           static_cast<u32>(pulses_1 - pulses_0) * pulse_width_ns <
+               kMinSymbolSeparationNs) {
+        ++pulses_1;
+    }
+
+    // Quantized timing must be within half a pulse of nominal — the
+    // natural error bound for best-fit rounding. When the separation
+    // bump deliberately widened T1H, allow exactly the pulses it added
+    // on top of that bound.
+    const u32 tolerance_ns = pulse_width_ns / 2;
+    const u32 actual_t0h = static_cast<u32>(pulses_0) * pulse_width_ns;
+    const u32 actual_t1h = static_cast<u32>(pulses_1) * pulse_width_ns;
+    const u32 t1h_tolerance_ns =
+        tolerance_ns +
+        static_cast<u32>(pulses_1 - pulses_1_raw) * pulse_width_ns;
+    const u32 err_t0h = absDiff(actual_t0h, t0h_ns);
+    const u32 err_t1h = absDiff(actual_t1h, t1h_ns);
+    if (err_t0h > tolerance_ns) return fit;
+    if (err_t1h > t1h_tolerance_ns) return fit;
+
+    fit.ok = true;
+    fit.pulses_0 = pulses_0;
+    fit.pulses_1 = pulses_1;
+    fit.total_err_ns = err_t0h + err_t1h;
+    return fit;
+}
+
 } // anonymous namespace
 
 Wave10Lut buildWave10Lut(const ChipsetTimingConfig& timing) FL_NO_EXCEPT {
     Wave10Lut result = {};
 
-    const u32 period_ns = timing.total_period_ns();
-    if (period_ns == 0) return result;
+    // Evaluate both frame geometries (FastLED#3572 follow-up):
+    //   P=5 — wave10: 8 data bits, baud = 5/period (the classic shape)
+    //   P=4 — wave8-frame: 6 data bits, baud = 4/period (lower baud →
+    //         reaches faster chipsets under the 5 Mbps cap; different
+    //         quantization grid — e.g. SK6812 is exact at period/4)
+    // Pick the feasible geometry with the smaller total quantization
+    // error. P=5 wins ties and near-ties (50 ns hysteresis) so the
+    // long-proven wave10 shapes stay stable for existing chipsets.
+    const UartWaveFit fit5 = fitUartWave(timing, 5);
+    const UartWaveFit fit4 = fitUartWave(timing, 4);
 
-    // Pulse width: each LED bit gets 5 pulses within its half-frame
-    const u32 pulse_width_ns = period_ns / 5;
-    if (pulse_width_ns == 0) return result;
-
-    // T0H and T1H in nanoseconds
-    const u32 t0h_ns = timing.t1_ns;           // T0H = T1
-    const u32 t1h_ns = timing.t1_ns + timing.t2_ns; // T1H = T1 + T2
-
-    // Compute pulse counts
-    u8 pulses_0 = computePulseCount(t0h_ns, pulse_width_ns);
-    u8 pulses_1 = computePulseCount(t1h_ns, pulse_width_ns);
-
-    // Clamp to valid range [1, 4]
-    if (pulses_0 < 1) pulses_0 = 1;
-    if (pulses_0 > 4) pulses_0 = 4;
-    if (pulses_1 < 1) pulses_1 = 1;
-    if (pulses_1 > 4) pulses_1 = 4;
-
-    // FastLED#3569 follow-up (UART bench): enforce a minimum ABSOLUTE
-    // wire separation between the 0 and 1 symbols, widening T1H upward.
-    // Best-fit rounding alone can land them one pulse apart, and at
-    // high baud one pulse is too little: WS2812B-V5 (T0H=225, T1H=580,
-    // pulse=245 ns) rounds to (1, 2) = 245 vs 490 ns, inside real LEDs'
-    // 0/1 ambiguity band (the WS281x sampling threshold sits near
-    // 550-625 ns) — it flapped the RX decoder's 500 ns threshold on the
-    // WROOM bench. A longer HIGH still reads as 1, so rounding T1H up
-    // is safe: (1, 2) → (1, 3) = 245 vs 735 ns, matching the proven
-    // legacy WS2812 LUT shape. Slow chipsets (WS2811-400: 500 ns
-    // pulses) already have ≥ 500 ns of single-pulse separation and are
-    // left untouched.
-    constexpr u32 kMinSymbolSeparationNs = 400;
-    while (pulses_1 < 4 &&
-           static_cast<u32>(pulses_1 - pulses_0) * pulse_width_ns <
-               kMinSymbolSeparationNs) {
-        ++pulses_1;
+    u8 P = 0;
+    UartWaveFit fit = {};
+    constexpr u32 kHysteresisNs = 50;
+    if (fit5.ok && fit4.ok) {
+        if (fit4.total_err_ns + kHysteresisNs < fit5.total_err_ns) {
+            P = 4;
+            fit = fit4;
+        } else {
+            P = 5;
+            fit = fit5;
+        }
+    } else if (fit5.ok) {
+        P = 5;
+        fit = fit5;
+    } else if (fit4.ok) {
+        P = 4;
+        fit = fit4;
+    } else {
+        return result; // infeasible — pulses_per_bit stays 0
     }
 
-    // Build LUT entries for all 4 two-bit combinations
-    result.lut[0] = buildUartByte(pulses_0, pulses_0); // "00"
-    result.lut[1] = buildUartByte(pulses_0, pulses_1); // "01"
-    result.lut[2] = buildUartByte(pulses_1, pulses_0); // "10"
-    result.lut[3] = buildUartByte(pulses_1, pulses_1); // "11"
+    result.pulses_per_bit = P;
+    result.lut[0] = buildUartByte(fit.pulses_0, fit.pulses_0, P); // "00"
+    result.lut[1] = buildUartByte(fit.pulses_0, fit.pulses_1, P); // "01"
+    result.lut[2] = buildUartByte(fit.pulses_1, fit.pulses_0, P); // "10"
+    result.lut[3] = buildUartByte(fit.pulses_1, fit.pulses_1, P); // "11"
 
     return result;
 }
 
 bool canRepresentTiming(const ChipsetTimingConfig& timing) FL_NO_EXCEPT {
-    const u32 period_ns = timing.total_period_ns();
-    if (period_ns == 0) return false;
-
-    // Check 1: Baud rate must be within ESP32 UART limits
-    const u32 baud_rate = Wave10Lut::computeBaudRate(timing);
-    if (baud_rate == 0 || baud_rate > kMaxUartBaudRate) return false;
-
-    // Pulse width for 5-pulse-per-bit model
-    const u32 pulse_width_ns = period_ns / 5;
-    if (pulse_width_ns == 0) return false;
-
-    // T0H and T1H timing
-    const u32 t0h_ns = timing.t1_ns;
-    const u32 t1h_ns = timing.t1_ns + timing.t2_ns;
-
-    // Compute pulse counts
-    u8 pulses_0 = computePulseCount(t0h_ns, pulse_width_ns);
-    u8 pulses_1 = computePulseCount(t1h_ns, pulse_width_ns);
-
-    // Check 2 & 3: Pulse counts must be in valid range [1, 4]
-    if (pulses_0 < 1 || pulses_0 > 4) return false;
-    if (pulses_1 < 1 || pulses_1 > 4) return false;
-
-    // Check 4: Pulse counts must be distinguishable
-    if (pulses_0 == pulses_1) return false;
-
-    // Mirror buildWave10Lut's minimum-separation bump so feasibility is
-    // judged against the counts that will actually be transmitted.
-    constexpr u32 kMinSymbolSeparationNs = 400;
-    const u8 pulses_1_raw = pulses_1;
-    while (pulses_1 < 4 &&
-           static_cast<u32>(pulses_1 - pulses_0) * pulse_width_ns <
-               kMinSymbolSeparationNs) {
-        ++pulses_1;
-    }
-
-    // Check 5 & 6: Quantized timing must be within half a pulse width of
-    // nominal — the natural error bound for best-fit rounding. When the
-    // separation bump deliberately widened T1H (longer HIGH still reads
-    // as 1), allow the extra pulse it added on top of that bound; the
-    // shortened T1L tail this costs is harmless as long as one LOW pulse
-    // remains, which the [1, 4] range guarantees.
-    const u32 tolerance_ns = pulse_width_ns / 2;
-    const u32 actual_t0h = static_cast<u32>(pulses_0) * pulse_width_ns;
-    const u32 actual_t1h = static_cast<u32>(pulses_1) * pulse_width_ns;
-    const u32 t1h_tolerance_ns =
-        tolerance_ns + static_cast<u32>(pulses_1 - pulses_1_raw) * pulse_width_ns;
-
-    if (absDiff(actual_t0h, t0h_ns) > tolerance_ns) return false;
-    if (absDiff(actual_t1h, t1h_ns) > t1h_tolerance_ns) return false;
-
-    return true;
+    // Feasible if EITHER frame geometry fits — same helper as
+    // buildWave10Lut(), so admission and construction can't drift.
+    return fitUartWave(timing, 5).ok || fitUartWave(timing, 4).ok;
 }
 
 FL_IRAM FL_OPTIMIZE_FUNCTION

--- a/src/platforms/esp/32/drivers/uart/wave8_encoder_uart.h
+++ b/src/platforms/esp/32/drivers/uart/wave8_encoder_uart.h
@@ -51,25 +51,49 @@ namespace fl {
 /// @brief Maximum UART baud rate supported by ESP32 variants
 constexpr u32 kMaxUartBaudRate = 5000000;
 
-/// @brief Wave10 lookup table for UART LED encoding
+/// @brief Wave lookup table for UART LED encoding (waveN family)
 ///
 /// Maps 2 LED bits to 1 UART data byte, computed from chipset timing.
-/// The 10-bit UART frame (with TX inversion) provides 5 pulses per LED bit.
+/// The UART frame (with TX inversion) is treated as two P-pulse LED bit
+/// slots, where P = `pulses_per_bit`:
 ///
-/// Valid HIGH pulse count per LED bit: [1, 4]
-/// - Bit A: START=H provides 1 guaranteed HIGH; D3 must be LOW for H→L transition
-/// - Bit B: D4 must be HIGH for leading edge; STOP=L provides trailing LOW
+/// - **P = 5 (wave10, 8 data bits + start/stop = 10-bit frame)** — the
+///   classic geometry: baud = 5/period.
+/// - **P = 4 (wave8-frame, 6 data bits + start/stop = 8-bit frame)** —
+///   20% lower baud (4/period): reaches faster chipsets under the
+///   ESP32's 5 Mbps cap and provides an alternative quantization grid
+///   (e.g. SK6812's T0H/T1H are exact multiples of period/4).
+///
+/// `buildWave10Lut()` evaluates both geometries and picks the feasible
+/// one with the smaller quantization error (preferring P=5 on ties).
+///
+/// Valid HIGH pulse count per LED bit: [1, P-1]
+/// - Bit A: START=H provides 1 guaranteed HIGH; the slot's final pulse
+///   must be LOW for the H→L transition
+/// - Bit B: first data pulse must be HIGH for the leading edge; STOP=L
+///   provides the trailing LOW
 struct Wave10Lut {
-    u8 lut[4]; ///< 2-bit input → UART data byte
+    u8 lut[4];         ///< 2-bit input → UART data byte
+    u8 pulses_per_bit; ///< Frame geometry: 5 (wave10) or 4 (wave8-frame); 0 = infeasible
 
-    /// @brief Compute the baud rate required for this timing
-    /// @param timing Chipset timing configuration
-    /// @return Baud rate in bits per second
+    /// @brief UART word length for this geometry (2P - 2 data bits)
+    u8 dataBits() const FL_NO_EXCEPT {
+        return static_cast<u8>(2 * pulses_per_bit - 2);
+    }
+
+    /// @brief Baud rate this LUT's geometry requires for the timing
+    /// (baud = P / bit_period; one UART bit per pulse).
+    u32 baudRate(const ChipsetTimingConfig& timing) const FL_NO_EXCEPT {
+        const u32 period_ns = timing.total_period_ns();
+        if (period_ns == 0 || pulses_per_bit == 0) return 0;
+        return static_cast<u32>(
+            static_cast<u64>(pulses_per_bit) * 1000000000ULL / period_ns);
+    }
+
+    /// @brief Legacy fixed-wave10 baud computation (P = 5)
+    /// @deprecated Prefer the instance `baudRate()` which respects the
+    /// selected geometry.
     static u32 computeBaudRate(const ChipsetTimingConfig& timing) FL_NO_EXCEPT {
-        // 10 UART bits encode 2 LED bits
-        // baud = 10 / (2 * bit_period) * 1e9
-        // = 10e9 / (2 * period_ns)
-        // = 5e9 / period_ns
         const u32 period_ns = timing.total_period_ns();
         if (period_ns == 0) return 0;
         return static_cast<u32>(5000000000ULL / period_ns);

--- a/tests/platforms/esp/32/drivers/uart/wave8_encoder_uart.cpp
+++ b/tests/platforms/esp/32/drivers/uart/wave8_encoder_uart.cpp
@@ -57,6 +57,27 @@ HalfFramePulses measureHalfFrames(uint8_t byte_val) {
     return result;
 }
 
+/// P=4 variant: frame = [START][D0..D5][STOP] = 8 wire bits, two 4-pulse
+/// LED bit slots (wave8-frame geometry).
+HalfFramePulses measureHalfFramesP4(uint8_t byte_val) {
+    int raw[8];
+    raw[0] = 0; // start bit
+    for (int i = 0; i < 6; i++) {
+        raw[1 + i] = (byte_val >> i) & 1;
+    }
+    raw[7] = 1; // stop bit
+
+    int bits[8];
+    for (int i = 0; i < 8; i++) {
+        bits[i] = raw[i] ? 0 : 1; // TX inversion
+    }
+
+    HalfFramePulses result = {0, 0};
+    for (int i = 0; i < 4 && bits[i] == 1; i++) result.high_count_a++;
+    for (int i = 4; i < 8 && bits[i] == 1; i++) result.high_count_b++;
+    return result;
+}
+
 } // anonymous namespace
 
 //=============================================================================
@@ -177,6 +198,12 @@ FL_TEST_CASE("Wave10 - buildWave10Lut for WS2812") {
     ChipsetTimingConfig timing(250, 625, 375, 280);
     Wave10Lut lut = buildWave10Lut(timing);
 
+    FL_SUBCASE("wave10 geometry selected (P=5, 8 data bits)") {
+        FL_CHECK_EQ(lut.pulses_per_bit, 5);
+        FL_CHECK_EQ(lut.dataBits(), 8);
+        FL_CHECK_EQ(lut.baudRate(timing), 4000000u);
+    }
+
     FL_SUBCASE("LUT matches hardcoded WS2812 values") {
         FL_CHECK_EQ(lut.lut[0], 0xEF);  // "00"
         FL_CHECK_EQ(lut.lut[1], 0x8F);  // "01"
@@ -225,6 +252,10 @@ FL_TEST_CASE("Wave10 - buildWave10Lut for WS2812B-V5 enforces symbol separation"
     FL_REQUIRE(canRepresentTiming(timing));
     Wave10Lut lut = buildWave10Lut(timing);
 
+    FL_SUBCASE("stays on wave10 geometry (P=4 error is worse after its own bump)") {
+        FL_CHECK_EQ(lut.pulses_per_bit, 5);
+    }
+
     FL_SUBCASE("1-symbol gets >=2 pulses of separation") {
         auto p00 = measureHalfFrames(lut.lut[0]);
         FL_CHECK_EQ(p00.high_count_a, 1);
@@ -243,20 +274,31 @@ FL_TEST_CASE("Wave10 - buildWave10Lut for WS2812B-V5 enforces symbol separation"
     }
 }
 
-FL_TEST_CASE("Wave10 - buildWave10Lut for SK6812") {
+FL_TEST_CASE("Wave10 - buildWave10Lut for SK6812 selects wave4 geometry") {
     // SK6812: T1=300, T2=600, T3=300, period=1200
+    // P=5 grid (240ns pulses): T0H 300→1 (err 60), T1H 900→4 (err 60);
+    // total error 120ns. P=4 grid (300ns pulses): T0H 300→1 EXACT,
+    // T1H 900→3 EXACT; total error 0. The geometry selector picks P=4
+    // (6 data bits @ 3.33 Mbps) — SK6812's timing is an exact multiple
+    // of period/4.
     ChipsetTimingConfig timing(300, 600, 300, 80);
     Wave10Lut lut = buildWave10Lut(timing);
 
-    FL_SUBCASE("Pulse counts are correct") {
-        // pulse_width = 1200/5 = 240ns
-        // T0H = 300ns → 300/240 = 1.25 → best-fit: floor=1 (err=60) vs ceil=2 (err=180) → 1
-        // T1H = 900ns → 900/240 = 3.75 → best-fit: floor=3 (err=180) vs ceil=4 (err=60) → 4
-        auto p00 = measureHalfFrames(lut.lut[0]);
-        FL_CHECK_EQ(p00.high_count_a, 1);
+    FL_SUBCASE("wave4 geometry selected") {
+        FL_CHECK_EQ(lut.pulses_per_bit, 4);
+        FL_CHECK_EQ(lut.dataBits(), 6);
+        // baud = 4 / 1200ns = 3.333 MHz
+        FL_CHECK_EQ(lut.baudRate(timing), 3333333u);
+    }
 
-        auto p11 = measureHalfFrames(lut.lut[3]);
-        FL_CHECK_EQ(p11.high_count_a, 4);
+    FL_SUBCASE("Pulse counts are correct (exact fit)") {
+        auto p00 = measureHalfFramesP4(lut.lut[0]);
+        FL_CHECK_EQ(p00.high_count_a, 1);
+        FL_CHECK_EQ(p00.high_count_b, 1);
+
+        auto p11 = measureHalfFramesP4(lut.lut[3]);
+        FL_CHECK_EQ(p11.high_count_a, 3);
+        FL_CHECK_EQ(p11.high_count_b, 3);
     }
 
     FL_SUBCASE("All 4 LUT entries are distinct") {
@@ -268,9 +310,10 @@ FL_TEST_CASE("Wave10 - buildWave10Lut for SK6812") {
         FL_CHECK_NE(lut.lut[2], lut.lut[3]);
     }
 
-    FL_SUBCASE("Baud rate is correct") {
+    FL_SUBCASE("Legacy static baud formula still reports the P=5 rate") {
         u32 baud = Wave10Lut::computeBaudRate(timing);
-        // 5e9 / 1200 = 4166666
+        // 5e9 / 1200 = 4166666 (fixed-wave10 formula — the selected
+        // geometry's actual rate comes from lut.baudRate(), tested above)
         FL_CHECK_EQ(baud, 4166666u);
     }
 }
@@ -379,16 +422,22 @@ FL_TEST_CASE("Wave10 - canRepresentTiming accepts valid chipsets") {
         ChipsetTimingConfig timing(350, 660, 350, 0);
         FL_CHECK(canRepresentTiming(timing));
     }
+
+    FL_SUBCASE("LPD1886-1250kHz (wave10 infeasible at 6.25 Mbps; wave4 fits at 5.0 Mbps)") {
+        // period 800ns: P=4 grid = 200ns pulses — T0H 200→1 exact,
+        // T1H 600→3 exact, separation 400ns exactly at the floor.
+        // New coverage unlocked by the wave8-frame geometry.
+        ChipsetTimingConfig timing(200, 400, 200, 0);
+        FL_CHECK(canRepresentTiming(timing));
+        Wave10Lut lut = buildWave10Lut(timing);
+        FL_CHECK_EQ(lut.pulses_per_bit, 4);
+        FL_CHECK_EQ(lut.baudRate(timing), 5000000u);
+    }
 }
 
 FL_TEST_CASE("Wave10 - canRepresentTiming rejects infeasible chipsets") {
     FL_SUBCASE("TM1829-1600kHz (baud too high: 8.3 Mbps)") {
         ChipsetTimingConfig timing(100, 300, 200, 500);
-        FL_CHECK_FALSE(canRepresentTiming(timing));
-    }
-
-    FL_SUBCASE("LPD1886-1250kHz (baud too high: 6.25 Mbps)") {
-        ChipsetTimingConfig timing(200, 400, 200, 0);
         FL_CHECK_FALSE(canRepresentTiming(timing));
     }
 


### PR DESCRIPTION
Fixes #3574. Follow-up to #3573 per bench review: wave10 (8 UART data bits = two LED bits × 4 controllable pulses, start/stop as fixed H/L bookends) is one point in a geometry family — this PR adds the wave4 sibling and picks per chipset.

## What fits (investigated)

| Geometry | Frame | Data bits | Pulses/LED-bit | Baud @ 800 kHz | Verdict |
|---|---|---|---|---|---|
| wave10 (current) | 10 | 8 | 5 | 4.0 M | default |
| **wave8-frame (new)** | 8 | 6 | **4** | 3.2 M | second grid + faster-chipset coverage |
| 9-bit frame | 9 | 7 | 3 (×3 bits) | 2.4 M | rejected — wave3-eligible timings only |
| 7-bit frame | 7 | 5 | 7 (×1 bit) | 5.6 M | rejected — over the 5 Mbps cap |

## Concrete wins

- **SK6812**: T0H=300/T1H=900 are exact multiples of period/4 — 0 ns quantization error (vs 120 ns total at wave10). Auto-selected.
- **LPD1886-class 1250 kHz** (period 800 ns): infeasible at wave10 (6.25 Mbps > 5 M cap) → now representable at wave4, exactly 5.0 Mbps with 0 ns error.
- **Stability**: 50 ns selection hysteresis prefers wave10, so WS2812 / WS2812B-V5 / WS2811-400 keep their long-proven shapes bit-for-bit.

## Mechanics

Shared `fitUartWave(timing, P)` judges each geometry (baud cap, pulse range [1, P−1], distinctness, the #3572 400 ns minimum symbol separation, quantization tolerance); `buildWave10Lut()` and `canRepresentTiming()` both use it so admission and construction can't drift. `Wave10Lut` carries the selected `pulses_per_bit`; baud and UART word length derive from it; the driver re-inits the peripheral on geometry change; `UartPeripheralEsp` maps 5–8 data bits.

## Verification

- Host: 344/344 green (new tests pin SK6812→wave4 exact fit, LPD1886→wave4 @5.0 M, WS2812/V5/WS2811-400→wave10 unchanged); lint clean.
- Bench (WROOM COM11, GPIO33→34): UART+WS2812B-V5 (wave10) **4/4 byte-exact**; UART+SK6812 (**wave4**, 6 data bits @ 3.33 Mbps) **4/4 byte-exact** — first wire-verified wave8-frame transmission. I2S and SPI regression 4/4 each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved ESP32 UART support to better match LED timing requirements, including automatic selection of the most suitable waveform geometry.
  * Added support for additional UART data-bit settings so more timing profiles can be configured correctly.

* **Bug Fixes**
  * Fixed timing handling for SK6812-based setups so they now use the correct timing and encoding path.
  * Reduced cases where compatible chipsets would be misdetected as unsupported.

* **Tests**
  * Expanded coverage for waveform selection and timing compatibility across multiple chipset configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->