### PR TITLE
feat(i2s): I2S0 second clockless bank — 32 parallel lanes on classic ESP32 (#3576 Phase 1)

### DIFF
--- a/src/fl/channels/README.md
+++ b/src/fl/channels/README.md
@@ -268,15 +268,18 @@ Engines are tried in priority order (highest first) until one accepts the channe
 
 | Engine | Priority | Platforms | Notes |
 |--------|----------|-----------|-------|
-| **I2S_SPI** | 10 | ESP32-dev (original) | Native I2S parallel SPI for true SPI chipsets |
+| **I2S** (unified) | 10 | ESP32-dev (original) | I2S1 wave8 clockless bank (16 lanes) + SPI-chipset delegation, `Bus::FLEX_IO` instance 0 |
 | **LCD_SPI** | 10 | ESP32-S3 | LCD_CAM SPI driver for true SPI chipsets |
+| **I2S0** (second bank) | 9 | ESP32-dev (original) | Second 16-lane wave8 clockless bank on I2S0 (`Bus::FLEX_IO` instance 1) — 32 parallel lanes total; contended with the clocked-SPI use of I2S0 (port-claim registry, first mode wins) |
 | **PARLIO** | 4 | ESP32-P4, C6, H2, C5 | Parallel I/O with hardware timing |
 | **LCD_RGB** | 3 | ESP32-P4 | LCD RGB peripheral (parallel clockless) |
 | **RMT** | 2 (Recommended default) | All ESP32 variants | Reliable, broad chipset support |
 | **LCD_CLOCKLESS** | 2 | ESP32-S3 | LCD_CAM clockless (replaces the misnamed I2S) |
 | **I2S** | 1 | ESP32-S3 | LCD_CAM via legacy I80 bus (experimental) |
 | **SPI** | 0 | ESP32, S2, S3 | DMA-based, deprioritized due to reliability |
-| **UART** | -1 | All ESP32 variants | Wave8 encoding (experimental, not recommended) |
+| **UART** | -1 | All ESP32 variants | Wave10/wave4 frame-geometry encoding, per-chipset selection |
+
+**Classic-ESP32 32-lane operation (FastLED#3576 Phase 1):** the I2S engines are capacity-aware — the primary bank accepts at most 16 clockless channels per frame, so the 17th+ channel overflows to the `I2S0` second bank, then to RMT. Each I2S block is a shared resource between its clockless bank and the clocked-SPI driver: ownership is arbitrated at `initialize()` time by the port-claim registry (`platforms/esp/32/drivers/i2s/i2s_port_claim.h`) — whichever mode claims a block first per session keeps it, and the other driver's channels fall through the priority list cleanly.
 
 **Teensy 4.x:**
 

--- a/src/fl/channels/bus.h
+++ b/src/fl/channels/bus.h
@@ -118,6 +118,13 @@ template<> struct BusInstanceCount<Bus::UART> { static constexpr fl::u8 value = 
 template<> struct BusInstanceCount<Bus::FLEX_IO> { static constexpr fl::u8 value = 2; };
 template<> struct BusInstanceCount<Bus::SPI> { static constexpr fl::u8 value = 1; };
 template<> struct BusInstanceCount<Bus::UART> { static constexpr fl::u8 value = 2; };
+#elif defined(FL_IS_ESP_32DEV)
+// Classic ESP32 (FastLED#3576 Phase 1): FLEX_IO instance 0 = I2S1
+// primary clockless bank, instance 1 = I2S0 second bank ("I2S0",
+// contended with the clocked-SPI driver via the port-claim registry).
+template<> struct BusInstanceCount<Bus::FLEX_IO> { static constexpr fl::u8 value = 2; };
+template<> struct BusInstanceCount<Bus::SPI> { static constexpr fl::u8 value = 2; };
+template<> struct BusInstanceCount<Bus::UART> { static constexpr fl::u8 value = 2; };
 #endif
 
 inline const char* busName(Bus b, fl::u8 which = 0) FL_NO_EXCEPT {

--- a/src/fl/channels/bus_priorities.h
+++ b/src/fl/channels/bus_priorities.h
@@ -35,13 +35,18 @@ namespace fl {
 /// Higher = preferred. The function is `constexpr` so callers can use it in
 /// constant expressions if needed. Buses without a registered priority fall
 /// back to 0.
-constexpr int default_bus_priority(Bus b, fl::u8 = 0) FL_NO_EXCEPT {
+constexpr int default_bus_priority(Bus b, fl::u8 which) FL_NO_EXCEPT {
     // FORCE-style overrides (FASTLED_ESP32_FORCE_*) are intentionally not
     // applied here -- the legacy initChannelDrivers() retains its own
     // priority-bumping logic for backward compatibility. This table is the
     // baseline used by the new enableDrivers<>() opt-in API.
+    //
+    // Secondary FLEX_IO instances sit one below the primary so the
+    // manager fills the primary bank first and overflows to the
+    // secondary (classic-ESP32 I2S0 second bank, ESP32-P4 LCD_RGB —
+    // FastLED#3576 Phase 1).
     return
-        b == Bus::FLEX_IO   ? 4  :
+        b == Bus::FLEX_IO   ? (which == 0 ? 4 : 3) :
         b == Bus::RMT       ? 2  :
         b == Bus::SPI       ? 1  :
         b == Bus::DUAL_SPI  ? 1  :

--- a/src/platforms/arm/teensy/teensy4_common/drivers/lpuart/bus_traits.h
+++ b/src/platforms/arm/teensy/teensy4_common/drivers/lpuart/bus_traits.h
@@ -30,7 +30,7 @@ template<> struct BusTraits<Bus::UART> {
     static fl::shared_ptr<Driver> instancePtr() FL_NO_EXCEPT;
     static Driver& instance() FL_NO_EXCEPT { return *instancePtr(); }
     static void registerWithManager() FL_NO_EXCEPT {
-        ChannelManager::instance().addDriver(default_bus_priority(Bus::UART), instancePtr());
+        ChannelManager::instance().addDriver(default_bus_priority(Bus::UART, 0), instancePtr());
     }
 };
 

--- a/src/platforms/esp/32/channel_drivers_esp32.impl.hpp
+++ b/src/platforms/esp/32/channel_drivers_esp32.impl.hpp
@@ -45,6 +45,15 @@ inline void enableAllChannelDrivers() FL_NO_EXCEPT {
 #if FASTLED_ESP32_HAS_LCD_RGB
     fl::enableDriver<fl::Bus::FLEX_IO, 1>();
 #endif
+#if FASTLED_ESP32_HAS_I2S
+    // FastLED#3576 Phase 1 — second clockless bank on I2S0 ("I2S0",
+    // FLEX_IO instance 1). Priority one below the primary I2S1 bank so
+    // clockless channels fill 16 lanes there first, then overflow here
+    // (32 lanes total), then RMT. I2S0 hardware is contended with the
+    // clocked-SPI driver — the port-claim registry arbitrates at
+    // initialize() time.
+    fl::enableDriver<fl::Bus::FLEX_IO, 1>();
+#endif
     // FastLED#3526 — the modern classic-ESP32 I2S parallel-out engine
     // (`ChannelEngineI2sEsp32Dev`) wraps the SAME I2S1 peripheral as
     // the current `I2S_SPI` driver at `Bus::FLEX_IO, 0`. Per the

--- a/src/platforms/esp/32/drivers/channel_manager_esp32.cpp.hpp
+++ b/src/platforms/esp/32/drivers/channel_manager_esp32.cpp.hpp
@@ -119,6 +119,10 @@ constexpr int PRIORITY_I2S_SPI = PRIORITY_FORCE; ///< FORCED highest by FASTLED_
 #else
 constexpr int PRIORITY_I2S_SPI = 10; ///< Native I2S parallel SPI driver (ESP32dev, true SPI chipsets)
 #endif
+// FastLED#3576 Phase 1 -- second clockless bank on I2S0 ("I2S0",
+// FLEX_IO instance 1). One below the primary I2S1 engine so channels
+// fill bank 1's 16 lanes first, then overflow here (then RMT).
+constexpr int PRIORITY_I2S_BANK2 = 9;
 #if defined(FASTLED_ESP32_FORCE_LCD_SPI)
 constexpr int PRIORITY_LCD_SPI = PRIORITY_FORCE; ///< FORCED highest by FASTLED_ESP32_FORCE_LCD_SPI
 #else
@@ -269,6 +273,18 @@ static void addI2sSpiIfPossible(ChannelManager& manager) FL_NO_EXCEPT {
         FL_DBG_F("ESP32: Added I2S_SPI driver (priority %s)", PRIORITY_I2S_SPI);
     } else {
         FL_DBG_F("ESP32: I2S_SPI driver creation deferred (no ESP peripheral yet)");
+    }
+    // FastLED#3576 Phase 1 -- second clockless bank on I2S0 (FLEX_IO
+    // instance 1, name "I2S0"). Registered one priority below the
+    // primary so the manager fills I2S1's 16 lanes first and overflows
+    // the 17th+ clockless channel here. Hardware contention with the
+    // clocked-SPI use of I2S0 is arbitrated at initialize() time by the
+    // port-claim registry -- whichever mode wins, the loser's channels
+    // fall through to RMT.
+    auto bank2 = BusTraits<Bus::FLEX_IO, 1>::instancePtr();
+    if (bank2) {
+        manager.addDriver(PRIORITY_I2S_BANK2, bank2);
+        FL_DBG_F("ESP32: Added I2S0 second-bank driver (priority %s)", PRIORITY_I2S_BANK2);
     }
 #else
     (void)manager;

--- a/src/platforms/esp/32/drivers/i2s/_build.cpp.hpp
+++ b/src/platforms/esp/32/drivers/i2s/_build.cpp.hpp
@@ -31,6 +31,7 @@
 // elides completely when nothing calls into `I2sPeripheralEsp32DevEsp`.
 #include "platforms/esp/32/drivers/i2s/i2s_peripheral_esp32dev_esp.cpp.hpp"
 #include "platforms/esp/32/drivers/i2s/i2s_peripheral_esp32dev_mock.cpp.hpp"
+#include "platforms/esp/32/drivers/i2s/i2s_port_claim.cpp.hpp"  // FastLED#3576 Phase 1 — cross-driver I2S0/I2S1 ownership
 
 #include "platforms/esp/32/drivers/i2s/wave8_encoder_i2s.cpp.hpp"
 #include "platforms/esp/32/drivers/i2s/wave8_encoder_i2s1.cpp.hpp"  // FastLED#3526 Phase 2a — general clockless encoder for I2S1

--- a/src/platforms/esp/32/drivers/i2s/channel_engine_i2s_esp32dev.cpp.hpp
+++ b/src/platforms/esp/32/drivers/i2s/channel_engine_i2s_esp32dev.cpp.hpp
@@ -35,7 +35,8 @@ namespace fl {
 //=============================================================================
 
 ChannelEngineI2sEsp32Dev::ChannelEngineI2sEsp32Dev(
-    fl::shared_ptr<II2sPeripheralEsp32Dev> peripheral) FL_NO_EXCEPT
+    fl::shared_ptr<II2sPeripheralEsp32Dev> peripheral,
+    u8 i2s_port) FL_NO_EXCEPT
     : mPeripheral(fl::move(peripheral)),
       mEnqueuedChannels(),
       mInFlightChannels(),
@@ -48,7 +49,8 @@ ChannelEngineI2sEsp32Dev::ChannelEngineI2sEsp32Dev(
       mCachedT1(0),
       mCachedT2(0),
       mCachedT3(0),
-      mWave8LutValid(false) {
+      mWave8LutValid(false),
+      mI2sPort(i2s_port) {
     if (!mPeripheral) {
         FL_WARN_F("ChannelEngineI2sEsp32Dev: null peripheral injected — inert");
         return;
@@ -99,9 +101,27 @@ ChannelEngineI2sEsp32Dev::~ChannelEngineI2sEsp32Dev() {
 bool ChannelEngineI2sEsp32Dev::canHandle(const ChannelDataPtr &data) const
     FL_NO_EXCEPT {
     // Per the parallel-IO rule, this engine handles both clockless
-    // and SPI on the classic-ESP32 I2S peripheral. Reject only null
-    // data.
-    return static_cast<bool>(data);
+    // and SPI on the classic-ESP32 I2S peripheral.
+    if (!data) {
+        return false;
+    }
+    if (data->isSpi()) {
+        return true; // SPI batches delegate — no lane cap here
+    }
+    // FastLED#3576 Phase 1 — 16-lane clockless capacity. Channels bind
+    // to drivers lazily inside their first show, AFTER earlier channels
+    // enqueued this frame, so refusing the 17th here overflows it to
+    // the next-priority driver (the second I2S bank, then RMT). A
+    // channel already enqueued this frame stays accepted.
+    if (mEnqueuedChannels.size() < 16) {
+        return true;
+    }
+    for (const auto &d : mEnqueuedChannels) {
+        if (d == data) {
+            return true;
+        }
+    }
+    return false;
 }
 
 void ChannelEngineI2sEsp32Dev::enqueue(ChannelDataPtr data) FL_NO_EXCEPT {
@@ -239,7 +259,7 @@ void ChannelEngineI2sEsp32Dev::show() FL_NO_EXCEPT {
                 ? static_cast<u32>(8000000000ULL / bit_period_ns)
                 : 6400000u;  // WS2812-equivalent fallback
         I2sEsp32DevPeripheralConfig cfg(
-            /*port=*/1,
+            /*port=*/mI2sPort,
             /*clk=*/pixel_clk_hz,
             /*width=*/static_cast<u8>(mInFlightChannels.size()));
         if (!mPeripheral->initialize(cfg)) {
@@ -565,17 +585,29 @@ void ChannelEngineI2sEsp32Dev::onTransmitDone() FL_NO_EXCEPT {
 //=============================================================================
 
 fl::shared_ptr<IChannelDriver> createI2sEsp32DevEngine() FL_NO_EXCEPT {
+    return createI2sEsp32DevEngine(/*port=*/1);
+}
+
+fl::shared_ptr<IChannelDriver> createI2sEsp32DevEngine(u8 port) FL_NO_EXCEPT {
 #if defined(FL_IS_ESP_32DEV) && FASTLED_ESP32_HAS_I2S
-    // FastLED#3526 Phase 2e — the peripheral is now a `fl::Singleton<>`
-    // (process-lifetime, never destroyed) so the ownership record is
-    // simply the singleton's `mInitialized`. Wrap the singleton
-    // reference in a `shared_ptr` via `make_shared_no_tracking` — no
-    // control block, no delete, zero-overhead non-owning handle.
-    auto& singleton = fl::Singleton<I2sPeripheralEsp32DevEsp>::instance();
+    // FastLED#3576 Phase 1 — one peripheral singleton PER I2S BLOCK
+    // (`fl::Singleton<T, N>` tag = port). Process-lifetime, never
+    // destroyed; cross-driver hardware arbitration (vs the clocked-SPI
+    // driver on I2S0) happens in `initialize()` via the port-claim
+    // registry. Wrap in a `shared_ptr` via `make_shared_no_tracking` —
+    // no control block, no delete, zero-overhead non-owning handle.
+    if (port > 1) {
+        return nullptr;
+    }
     fl::shared_ptr<II2sPeripheralEsp32Dev> peripheral =
-        fl::make_shared_no_tracking<II2sPeripheralEsp32Dev>(singleton);
-    return fl::make_shared<ChannelEngineI2sEsp32Dev>(peripheral);
+        (port == 0)
+            ? fl::make_shared_no_tracking<II2sPeripheralEsp32Dev>(
+                  fl::Singleton<I2sPeripheralEsp32DevEsp, 0>::instance())
+            : fl::make_shared_no_tracking<II2sPeripheralEsp32Dev>(
+                  fl::Singleton<I2sPeripheralEsp32DevEsp, 1>::instance());
+    return fl::make_shared<ChannelEngineI2sEsp32Dev>(peripheral, port);
 #else
+    (void)port;
     return nullptr;
 #endif
 }

--- a/src/platforms/esp/32/drivers/i2s/channel_engine_i2s_esp32dev.h
+++ b/src/platforms/esp/32/drivers/i2s/channel_engine_i2s_esp32dev.h
@@ -68,8 +68,13 @@ namespace fl {
 class ChannelEngineI2sEsp32Dev : public IChannelDriver {
   public:
     /// @brief Construct with a peripheral (real or mock).
+    /// @param i2s_port Which I2S block this engine drives (FastLED#3576
+    ///        Phase 1): 1 = primary bank (`Bus::FLEX_IO` instance 0),
+    ///        0 = second bank (`Bus::FLEX_IO` instance 1, contended
+    ///        with the clocked-SPI driver via the port-claim registry).
     explicit ChannelEngineI2sEsp32Dev(
-        fl::shared_ptr<II2sPeripheralEsp32Dev> peripheral) FL_NO_EXCEPT;
+        fl::shared_ptr<II2sPeripheralEsp32Dev> peripheral,
+        u8 i2s_port = 1) FL_NO_EXCEPT;
 
     ~ChannelEngineI2sEsp32Dev() override;
 
@@ -83,7 +88,10 @@ class ChannelEngineI2sEsp32Dev : public IChannelDriver {
     DriverState poll() FL_NO_EXCEPT override;
 
     fl::string getName() const FL_NO_EXCEPT override {
-        return fl::string::from_literal("I2S");
+        // Distinct names per bank so affinity binding and the
+        // AutoResearch exclusive-driver selector can target each block.
+        return (mI2sPort == 0) ? fl::string::from_literal("I2S0")
+                               : fl::string::from_literal("I2S");
     }
 
     /// @brief Reports both clockless and SPI capability per the
@@ -181,6 +189,9 @@ class ChannelEngineI2sEsp32Dev : public IChannelDriver {
     u32 mCachedT2;
     u32 mCachedT3;
     bool mWave8LutValid;
+
+    // FastLED#3576 Phase 1 — which I2S block this engine drives (0/1).
+    u8 mI2sPort;
 };
 
 /// @brief Factory that builds a `ChannelEngineI2sEsp32Dev` wrapping a
@@ -195,5 +206,13 @@ class ChannelEngineI2sEsp32Dev : public IChannelDriver {
 /// returns nullptr so the channel-manager registration path skips
 /// cleanly.
 fl::shared_ptr<IChannelDriver> createI2sEsp32DevEngine() FL_NO_EXCEPT;
+
+/// @brief Port-selecting factory (FastLED#3576 Phase 1). `port == 1` is
+///        the primary bank (identical to the no-arg overload); `port ==
+///        0` builds the second bank ("I2S0", `Bus::FLEX_IO` instance 1)
+///        wrapping the per-port peripheral singleton. I2S0 is contended
+///        with the clocked-SPI driver — the port-claim registry
+///        arbitrates at initialize() time.
+fl::shared_ptr<IChannelDriver> createI2sEsp32DevEngine(u8 port) FL_NO_EXCEPT;
 
 } // namespace fl

--- a/src/platforms/esp/32/drivers/i2s/i2s_peripheral_esp32dev_esp.cpp.hpp
+++ b/src/platforms/esp/32/drivers/i2s/i2s_peripheral_esp32dev_esp.cpp.hpp
@@ -44,6 +44,7 @@
 
 #include "platforms/esp/32/drivers/i2s/i2s_peripheral_esp32dev_esp.h"
 #include "platforms/esp/32/drivers/i2s/i2s_periph_compat.h"  // fl_i2s_periph_enable — IDF-version-safe power gate
+#include "platforms/esp/32/drivers/i2s/i2s_port_claim.h"     // cross-driver I2S port ownership (FastLED#3576)
 
 #include "fl/log/log.h"
 #include "fl/stl/noexcept.h"
@@ -74,6 +75,10 @@ namespace {
 // APB reference; the divider formula is
 // `f_out = I2S_BASE_CLK / (N + B/A)`.
 constexpr u32 kI2sBaseClkHz = 80000000u;
+
+// Owner tag for the cross-driver port-claim registry. Stable literal —
+// claim identity is the pointer.
+constexpr const char *kI2sClocklessOwner = "I2S_CLOCKLESS";
 
 /// @brief Solve the classic-ESP32 I2S1 fractional clock divider
 ///        (`clkm_conf.clkm_div_{num,a,b}`) for a target frequency.
@@ -196,16 +201,20 @@ I2sPeripheralEsp32DevEsp::~I2sPeripheralEsp32DevEsp() {
 bool I2sPeripheralEsp32DevEsp::initialize(
     const I2sEsp32DevPeripheralConfig &cfg) FL_NO_EXCEPT {
     if (mInitialized) {
-        // FastLED#3526 Phase 2e — peripheral is a `fl::Singleton<>` so
-        // there is one process-wide instance. `mInitialized` is now the
-        // sole ownership record for I2S1 (former
-        // `g_i2s1_hardware_claimed_by_modern` global was folded into
-        // this member).
-        FL_WARN_F("I2sPeripheralEsp32DevEsp: I2S1 already claimed");
+        FL_WARN_F("I2sPeripheralEsp32DevEsp: already initialized");
         return false;
     }
     mConfig = cfg;
     const int i2s_device = static_cast<int>(mConfig.mI2sPort);
+
+    // FastLED#3576 Phase 1 — cross-driver ownership: I2S0 is contended
+    // between the second clockless bank and the clocked-SPI driver
+    // (`I2sSpiPeripheralEsp`). First claim wins; released in
+    // deinitialize(). The per-instance `mInitialized` flag alone can't
+    // see the other driver class.
+    if (!i2sPortClaim(i2s_device, kI2sClocklessOwner)) {
+        return false;
+    }
 
     // Power-gate + reset the peripheral via the IDF-version-safe wrapper
     // (routes to `periph_module_enable(PERIPH_I2S{n}_MODULE)` on IDF
@@ -321,6 +330,7 @@ bool I2sPeripheralEsp32DevEsp::initialize(
                                    &i2s_dma_isr_trampoline, this, &mIsrHandle);
     if (err != ESP_OK) {
         FL_WARN_F("I2sPeripheralEsp32DevEsp: esp_intr_alloc failed err=%s", static_cast<int>(err));
+        i2sPortRelease(i2s_device, kI2sClocklessOwner);
         return false;
     }
 
@@ -355,6 +365,7 @@ void I2sPeripheralEsp32DevEsp::deinitialize() FL_NO_EXCEPT {
         mDescriptors = nullptr;
         mDescriptorCapacity = 0;
     }
+    i2sPortRelease(i2s_device, kI2sClocklessOwner);
     mInitialized = false;
     mBusy = false;
 }
@@ -527,8 +538,13 @@ bool I2sPeripheralEsp32DevEsp::routeLanePin(u8 lane, i32 gpio_pin) FL_NO_EXCEPT 
     // Compute the SoC signal index for this lane. Signal indices are
     // contiguous within each I2S block (I2S{n}O_DATA_OUT0_IDX ..
     // I2S{n}O_DATA_OUT23_IDX) — one add per lane covers the range.
+    //
+    // I2S0 quirk (FastLED#3576 Phase 1 bench): in the same 32-bit mono
+    // LCD config, I2S0 presents the emitted half-word on DATA_OUT8..23
+    // (one byte higher than I2S1's DATA_OUT0..15) — lane n therefore
+    // routes signal OUT(8+n) on port 0 and OUT(n) on port 1.
     const int base_signal = (i2s_device == 0)
-        ? static_cast<int>(I2S0O_DATA_OUT0_IDX)
+        ? static_cast<int>(I2S0O_DATA_OUT0_IDX) + 8
         : static_cast<int>(I2S1O_DATA_OUT0_IDX);
 
     if (gpio_pin < 0) {

--- a/src/platforms/esp/32/drivers/i2s/i2s_port_claim.cpp.hpp
+++ b/src/platforms/esp/32/drivers/i2s/i2s_port_claim.cpp.hpp
@@ -1,0 +1,60 @@
+// IWYU pragma: private
+
+/// @file i2s_port_claim.cpp.hpp
+/// @brief Impl of the classic-ESP32 I2S port-claim registry
+///        (FastLED#3576 Phase 1). See i2s_port_claim.h.
+
+#include "platforms/is_platform.h"
+#ifdef FL_IS_ESP32
+
+#include "platforms/esp/32/feature_flags/enabled.h"
+
+#if FASTLED_ESP32_HAS_I2S
+
+#include "platforms/esp/32/drivers/i2s/i2s_port_claim.h"
+
+#include "fl/log/log.h"
+
+namespace fl {
+
+namespace {
+// One owner slot per I2S block. Owner identity is the string POINTER
+// (drivers pass stable literals), so idempotent re-claims by the same
+// driver are free.
+const char *g_i2s_port_owner[2] = {nullptr, nullptr};
+} // anonymous namespace
+
+bool i2sPortClaim(int port, const char *owner) FL_NO_EXCEPT {
+    if (port < 0 || port > 1 || owner == nullptr) {
+        return false;
+    }
+    if (g_i2s_port_owner[port] == nullptr ||
+        g_i2s_port_owner[port] == owner) {
+        g_i2s_port_owner[port] = owner;
+        return true;
+    }
+    FL_WARN_F("i2sPortClaim: I2S%s already owned by %s (requested by %s)",
+              port, g_i2s_port_owner[port], owner);
+    return false;
+}
+
+void i2sPortRelease(int port, const char *owner) FL_NO_EXCEPT {
+    if (port < 0 || port > 1) {
+        return;
+    }
+    if (g_i2s_port_owner[port] == owner) {
+        g_i2s_port_owner[port] = nullptr;
+    }
+}
+
+const char *i2sPortOwner(int port) FL_NO_EXCEPT {
+    if (port < 0 || port > 1) {
+        return nullptr;
+    }
+    return g_i2s_port_owner[port];
+}
+
+} // namespace fl
+
+#endif // FASTLED_ESP32_HAS_I2S
+#endif // FL_IS_ESP32

--- a/src/platforms/esp/32/drivers/i2s/i2s_port_claim.h
+++ b/src/platforms/esp/32/drivers/i2s/i2s_port_claim.h
@@ -1,0 +1,45 @@
+/// @file i2s_port_claim.h
+/// @brief Cross-driver hardware-claim registry for the classic-ESP32
+///        I2S ports (FastLED#3576 Phase 1).
+///
+/// Classic ESP32 has two identical I2S blocks. Three drivers can want
+/// them:
+///   - I2S1: the modern wave8 clockless bank (`ChannelEngineI2sEsp32Dev`
+///     port 1, `Bus::FLEX_IO` instance 0)
+///   - I2S0: EITHER the second clockless bank (port 0, `Bus::FLEX_IO`
+///     instance 1) OR the clocked-SPI driver (`I2sSpiPeripheralEsp`,
+///     APA102-class chipsets)
+///
+/// Each peripheral impl previously tracked ownership with its own
+/// `mInitialized` member — invisible to the other driver classes, so
+/// two drivers could program the same silicon. This registry is the
+/// single ownership record: `initialize()` claims, `deinitialize()`
+/// releases, first claim wins.
+///
+/// Not ISR-safe and not thread-safe by design: claims happen on the
+/// show()/setup() path only (same as every other channel-driver
+/// lifecycle operation).
+
+#pragma once
+
+// IWYU pragma: private
+
+#include "fl/stl/noexcept.h"
+
+namespace fl {
+
+/// @brief Try to claim an I2S port (0 or 1) for `owner`.
+/// @param owner Stable string literal naming the claiming driver.
+/// @return true if the port was free (or already held by this exact
+///         owner pointer — claims are idempotent per owner); false if
+///         another driver holds it.
+bool i2sPortClaim(int port, const char *owner) FL_NO_EXCEPT;
+
+/// @brief Release a port previously claimed by `owner`. No-op if the
+///        port is not held by `owner`.
+void i2sPortRelease(int port, const char *owner) FL_NO_EXCEPT;
+
+/// @brief Current owner name for diagnostics, or nullptr if free.
+const char *i2sPortOwner(int port) FL_NO_EXCEPT;
+
+} // namespace fl

--- a/src/platforms/esp/32/drivers/i2s_spi/bus_traits.h
+++ b/src/platforms/esp/32/drivers/i2s_spi/bus_traits.h
@@ -66,6 +66,30 @@ template<> struct BusTraits<Bus::FLEX_IO, 0> {
 // -> "Parallel-IO Driver: Unified Clockless + SPI Engine").
 template<> struct BusSupports<Bus::FLEX_IO, SpiChipsetConfig, 0> : fl::true_type {};
 
+// FastLED#3576 Phase 1 — second clockless bank on I2S0 ("I2S0",
+// `Bus::FLEX_IO` instance 1). Classic ESP32 has two identical I2S
+// blocks; instance 0 wraps I2S1 (primary), instance 1 wraps I2S0.
+// I2S0 is contended with the clocked-SPI driver — the port-claim
+// registry (`i2s_port_claim.h`) arbitrates at initialize() time, so
+// whichever mode touches I2S0 first per session wins and the other
+// fails cleanly.
+template<> struct BusTraits<Bus::FLEX_IO, 1> {
+    using Driver = IChannelDriver;
+
+    static fl::shared_ptr<Driver> instancePtr() FL_NO_EXCEPT {
+        static fl::shared_ptr<Driver> gHolder = createI2sEsp32DevEngine(/*port=*/0);
+        return gHolder;
+    }
+
+    static Driver& instance() FL_NO_EXCEPT { return *instancePtr(); }
+
+    static void registerWithManager() FL_NO_EXCEPT {
+        ChannelManager::instance().addDriver(default_bus_priority(Bus::FLEX_IO, 1), instancePtr());
+    }
+};
+
+template<> struct BusSupports<Bus::FLEX_IO, SpiChipsetConfig, 1> : fl::true_type {};
+
 }  // namespace fl
 
 #endif  // FL_IS_ESP32 && FASTLED_ESP32_HAS_I2S

--- a/src/platforms/esp/32/drivers/i2s_spi/i2s_spi_peripheral_esp.cpp.hpp
+++ b/src/platforms/esp/32/drivers/i2s_spi/i2s_spi_peripheral_esp.cpp.hpp
@@ -48,6 +48,8 @@ FL_EXTERN_C_BEGIN
 #include "platforms/esp/esp_version.h"
 FL_EXTERN_C_END
 
+#include "platforms/esp/32/drivers/i2s/i2s_port_claim.h"  // cross-driver I2S0 ownership (FastLED#3576)
+
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
 // IWYU pragma: begin_keep
 #include "esp_private/periph_ctrl.h"
@@ -65,6 +67,9 @@ FL_EXTERN_C_END
 // ESP32 lldesc_t has 12-bit size/length fields, max usable value = 4092
 // (must be divisible by 4 for DMA alignment).
 #define I2S_DMA_MAX_DATA_LEN 4092
+
+// Owner tag for the cross-driver I2S port-claim registry (FastLED#3576).
+static constexpr const char *kI2sSpiOwner = "I2S_SPI";
 
 namespace fl {
 namespace detail {
@@ -168,6 +173,13 @@ bool I2sSpiPeripheralEsp::initialize(const I2sSpiConfig &config) FL_NO_EXCEPT {
 
     if (config.clock_gpio < 0) {
         FL_WARN_F("I2sSpiPeripheralEsp: Invalid clock_gpio");
+        return false;
+    }
+
+    // FastLED#3576 Phase 1 — I2S0 is contended with the second
+    // clockless bank (ChannelEngineI2sEsp32Dev port 0). First claim
+    // wins; released in deinitialize().
+    if (!i2sPortClaim(0, kI2sSpiOwner)) {
         return false;
     }
 
@@ -282,6 +294,7 @@ bool I2sSpiPeripheralEsp::initialize(const I2sSpiConfig &config) FL_NO_EXCEPT {
         heap_caps_malloc(dmaBytes, MALLOC_CAP_DMA | MALLOC_CAP_8BIT));
     if (mDmaBuffer == nullptr) {
         FL_WARN_F("I2sSpiPeripheralEsp: Failed to allocate DMA buffer");
+        i2sPortRelease(0, kI2sSpiOwner);
         return false;
     }
     fl::memset(mDmaBuffer, 0, dmaBytes);
@@ -301,6 +314,7 @@ bool I2sSpiPeripheralEsp::initialize(const I2sSpiConfig &config) FL_NO_EXCEPT {
         heap_caps_free(mDmaBuffer);
         mDmaBuffer = nullptr;
         mDmaBufferWords = 0;
+        i2sPortRelease(0, kI2sSpiOwner);
         return false;
     }
     fl::memset(mDmaDescs, 0, mDmaDescCount * sizeof(lldesc_t));
@@ -341,6 +355,7 @@ bool I2sSpiPeripheralEsp::initialize(const I2sSpiConfig &config) FL_NO_EXCEPT {
         heap_caps_free(mDmaBuffer);
         mDmaBuffer = nullptr;
         mDmaBufferWords = 0;
+        i2sPortRelease(0, kI2sSpiOwner);
         return false;
     }
 
@@ -381,6 +396,7 @@ void I2sSpiPeripheralEsp::deinitialize() FL_NO_EXCEPT {
     if (mInitialized) {
         periph_module_disable(PERIPH_I2S0_MODULE);
     }
+    i2sPortRelease(0, kI2sSpiOwner);
 
     mInitialized = false;
     mCallback = nullptr;

--- a/src/platforms/esp/32/drivers/rmt/rmt_4/bus_traits.h
+++ b/src/platforms/esp/32/drivers/rmt/rmt_4/bus_traits.h
@@ -58,7 +58,7 @@ template <> struct BusTraits<Bus::RMT> {
     static Driver &instance() FL_NO_EXCEPT { return *instancePtr(); }
 
     static void registerWithManager() FL_NO_EXCEPT {
-        ChannelManager::instance().addDriver(default_bus_priority(Bus::RMT),
+        ChannelManager::instance().addDriver(default_bus_priority(Bus::RMT, 0),
                                              instancePtr());
     }
 };

--- a/src/platforms/esp/32/drivers/rmt/rmt_5/bus_traits.h
+++ b/src/platforms/esp/32/drivers/rmt/rmt_5/bus_traits.h
@@ -37,7 +37,7 @@ template<> struct BusTraits<Bus::RMT> {
     static Driver& instance() FL_NO_EXCEPT { return *instancePtr(); }
 
     static void registerWithManager() FL_NO_EXCEPT {
-        ChannelManager::instance().addDriver(default_bus_priority(Bus::RMT), instancePtr());
+        ChannelManager::instance().addDriver(default_bus_priority(Bus::RMT, 0), instancePtr());
     }
 };
 

--- a/src/platforms/esp/32/drivers/spi/bus_traits.h
+++ b/src/platforms/esp/32/drivers/spi/bus_traits.h
@@ -41,7 +41,7 @@ template<> struct BusTraits<Bus::SPI> {
     static Driver& instance() FL_NO_EXCEPT { return *instancePtr(); }
 
     static void registerWithManager() FL_NO_EXCEPT {
-        ChannelManager::instance().addDriver(default_bus_priority(Bus::SPI), instancePtr());
+        ChannelManager::instance().addDriver(default_bus_priority(Bus::SPI, 0), instancePtr());
     }
 };
 

--- a/src/platforms/esp/32/drivers/uart/bus_traits.h
+++ b/src/platforms/esp/32/drivers/uart/bus_traits.h
@@ -48,7 +48,7 @@ template<> struct BusTraits<Bus::UART> {
     static Driver& instance() FL_NO_EXCEPT { return *instancePtr(); }
 
     static void registerWithManager() FL_NO_EXCEPT {
-        ChannelManager::instance().addDriver(default_bus_priority(Bus::UART), instancePtr());
+        ChannelManager::instance().addDriver(default_bus_priority(Bus::UART, 0), instancePtr());
     }
 };
 

--- a/src/platforms/shared/bitbang/bus_traits.h
+++ b/src/platforms/shared/bitbang/bus_traits.h
@@ -40,7 +40,7 @@ template<> struct BusTraits<Bus::BIT_BANG> {
     static Driver& instance() FL_NO_EXCEPT { return *instancePtr(); }
 
     static void registerWithManager() FL_NO_EXCEPT {
-        ChannelManager::instance().addDriver(default_bus_priority(Bus::BIT_BANG), instancePtr());
+        ChannelManager::instance().addDriver(default_bus_priority(Bus::BIT_BANG, 0), instancePtr());
     }
 };
 

--- a/tests/platforms/esp/32/drivers/i2s/channel_engine_i2s_esp32dev.cpp
+++ b/tests/platforms/esp/32/drivers/i2s/channel_engine_i2s_esp32dev.cpp
@@ -152,6 +152,41 @@ FL_TEST_CASE("I2sEsp32Dev - engine name is I2S") {
     FL_CHECK(engine.getName() == fl::string::from_literal("I2S"));
 }
 
+FL_TEST_CASE("I2sEsp32Dev - second bank (port 0) is named I2S0 and plumbs the port") {
+    resetMockState();
+    ChannelEngineI2sEsp32Dev engine(createMockPeripheral(), /*i2s_port=*/0);
+    auto &mock = I2sPeripheralEsp32DevMock::instance();
+    FL_CHECK(engine.getName() == fl::string::from_literal("I2S0"));
+
+    // First clockless show lazily initializes the peripheral — the
+    // config must carry port 0 (FastLED#3576 Phase 1).
+    engine.enqueue(makeChannelData(0, 3, 0x11));
+    engine.show();
+    FL_CHECK_EQ(static_cast<int>(mock.getConfig().mI2sPort), 0);
+}
+
+FL_TEST_CASE("I2sEsp32Dev - canHandle enforces the 16-lane clockless capacity") {
+    resetMockState();
+    ChannelEngineI2sEsp32Dev engine(createMockPeripheral());
+
+    fl::vector<ChannelDataPtr> held;
+    for (int i = 0; i < 16; ++i) {
+        auto data = makeChannelData(/*pin=*/i, /*bytes=*/3, 0x10);
+        FL_CHECK(engine.canHandle(data));
+        engine.enqueue(data);
+        held.push_back(data);
+    }
+    // 17th distinct clockless channel overflows to the next-priority
+    // driver (the I2S0 second bank / RMT) — refused here.
+    auto overflow = makeChannelData(/*pin=*/16, /*bytes=*/3, 0x10);
+    FL_CHECK_FALSE(engine.canHandle(overflow));
+    // Channels already enqueued this frame stay accepted.
+    FL_CHECK(engine.canHandle(held[3]));
+    // SPI batches are not lane-capped (they delegate).
+    auto spi = makeSpiChannelData(/*dataPin=*/17, /*clockPin=*/18, /*bytes=*/4);
+    FL_CHECK(engine.canHandle(spi));
+}
+
 FL_TEST_CASE(
     "I2sEsp32Dev - reports Capabilities(true,true) per parallel-IO rule") {
     resetMockState();


### PR DESCRIPTION
Phase 1 of the #3576 program. Classic ESP32's second I2S block (I2S0) now hosts a second 16-lane wave8 clockless bank — **32 parallel clockless lanes total**.

## Design

- **Per-port engines**: `createI2sEsp32DevEngine(port)` with per-port peripheral singletons; the second bank registers as `Bus::FLEX_IO` instance 1 with the distinct name **"I2S0"** (targetable via affinity / AutoResearch's exclusive-driver selector).
- **Overflow**: the primary bank's `canHandle()` enforces a 16-lane clockless capacity, so the 17th+ channel of a frame overflows to the second bank (registered one priority below), then RMT. SPI batches are uncapped (delegated).
- **Hardware arbitration**: I2S0 is contended between this bank and the clocked-SPI driver. New cross-driver port-claim registry (`i2s_port_claim.{h,cpp.hpp}`) — both peripherals claim at `initialize()` and release at `deinitialize()`/failure; first mode wins, the loser fails cleanly.
- **Silicon quirk found on the bench**: in the identical 32-bit mono LCD config, **I2S0 presents the emitted half-word on `DATA_OUT8..23`** (I2S1 uses `DATA_OUT0..15`). Register dumps via `peekMem` showed a perfect config + completed DMA with a silent pin; the +8 signal-offset in `routeLanePin` fixed it.
- Per review direction, `default_bus_priority(bus, which)` now takes `which` **explicitly** (no default) and is instance-aware — secondary FLEX_IO instances sit one below the primary (matches P4 LCD_RGB's slot). All call sites updated.
- `fl/channels/README.md` updated (engine table + 32-lane operation section).

## Verification

- Host: 345/345 (new tests: port plumb-through to the mock config, "I2S0" naming, 16-lane capacity + SPI exemption + re-accept of enqueued channels); lint clean.
- Bench (WROOM COM11, GPIO33→34): **I2S0 bank `passed: true`, 4/4 patterns byte-exact** — first wire-verified I2S0 clockless frame. Regression: I2S (bank 1), RMT, UART, SPI all 4/4.

Refs #3576.

🤖 Generated with [Claude Code](https://claude.com/claude-code)