### PR TITLE
feat(uart): UART2 second lane on classic ESP32 (#3576 Phase 2)

### DIFF
--- a/src/fl/channels/README.md
+++ b/src/fl/channels/README.md
@@ -278,6 +278,7 @@ Engines are tried in priority order (highest first) until one accepts the channe
 | **I2S** | 1 | ESP32-S3 | LCD_CAM via legacy I80 bus (experimental) |
 | **SPI** | 0 | ESP32, S2, S3 | DMA-based, deprioritized due to reliability |
 | **UART** | -1 | All ESP32 variants | Wave10/wave4 frame-geometry encoding, per-chipset selection |
+| **UART2** (second lane) | -2 | ESP32-dev (original) | Second concurrent UART lane on the UART2 block (`Bus::UART` instance 1); UART0 stays reserved for the console |
 
 **Classic-ESP32 32-lane operation (FastLED#3576 Phase 1):** the I2S engines are capacity-aware — the primary bank accepts at most 16 clockless channels per frame, so the 17th+ channel overflows to the `I2S0` second bank, then to RMT. Each I2S block is a shared resource between its clockless bank and the clocked-SPI driver: ownership is arbitrated at `initialize()` time by the port-claim registry (`platforms/esp/32/drivers/i2s/i2s_port_claim.h`) — whichever mode claims a block first per session keeps it, and the other driver's channels fall through the priority list cleanly.
 

--- a/src/fl/channels/bus_priorities.h
+++ b/src/fl/channels/bus_priorities.h
@@ -53,7 +53,7 @@ constexpr int default_bus_priority(Bus b, fl::u8 which) FL_NO_EXCEPT {
         b == Bus::QUAD_SPI  ? 1  :
         b == Bus::OCTAL_SPI ? 1  :
         b == Bus::BIT_BANG  ? 0  :
-        b == Bus::UART      ? -1 :
+        b == Bus::UART      ? (which == 0 ? -1 : -2) :
         0;
 }
 

--- a/src/platforms/esp/32/channel_drivers_esp32.impl.hpp
+++ b/src/platforms/esp/32/channel_drivers_esp32.impl.hpp
@@ -8,6 +8,7 @@
 #include "fl/channels/bus.h"
 #include "fl/channels/bus_traits.h"
 #include "fl/stl/compiler_control.h"
+#include "platforms/is_platform.h"  // FL_IS_ESP_32DEV (UART2 second-lane guard)
 #include "platforms/esp/32/feature_flags/enabled.h"
 #include "platforms/shared/bitbang/bus_traits.h"  // ok platform headers // IWYU pragma: keep
 
@@ -53,6 +54,12 @@ inline void enableAllChannelDrivers() FL_NO_EXCEPT {
     // clocked-SPI driver — the port-claim registry arbitrates at
     // initialize() time.
     fl::enableDriver<fl::Bus::FLEX_IO, 1>();
+#endif
+#if FASTLED_ESP32_HAS_UART && defined(FL_IS_ESP_32DEV)
+    // FastLED#3576 Phase 2 — second UART lane on UART2 ("UART2",
+    // Bus::UART instance 1). Classic ESP32 only for now (three UARTs:
+    // UART0 = console, UART1 = primary lane, UART2 = this).
+    fl::enableDriver<fl::Bus::UART, 1>();
 #endif
     // FastLED#3526 — the modern classic-ESP32 I2S parallel-out engine
     // (`ChannelEngineI2sEsp32Dev`) wraps the SAME I2S1 peripheral as

--- a/src/platforms/esp/32/drivers/i2s/i2s_port_claim.cpp.hpp
+++ b/src/platforms/esp/32/drivers/i2s/i2s_port_claim.cpp.hpp
@@ -33,8 +33,10 @@ bool i2sPortClaim(int port, const char *owner) FL_NO_EXCEPT {
         g_i2s_port_owner[port] = owner;
         return true;
     }
-    FL_WARN_F("i2sPortClaim: I2S%s already owned by %s (requested by %s)",
-              port, g_i2s_port_owner[port], owner);
+    // Surprising-but-by-design behavior (mode contention on I2S0) —
+    // warn once per call site, not once per frame.
+    FL_WARN_F_ONCE("i2sPortClaim: I2S%s already owned by %s (requested by %s)",
+                   port, g_i2s_port_owner[port], owner);
     return false;
 }
 

--- a/src/platforms/esp/32/drivers/uart/bus_traits.h
+++ b/src/platforms/esp/32/drivers/uart/bus_traits.h
@@ -28,12 +28,15 @@ namespace fl {
 
 namespace detail {
 /// @brief UART singleton: peripheral + driver lifetimes paired.
+/// One holder per UART block (FastLED#3576 Phase 2): uart_num 1 =
+/// primary lane ("UART"), uart_num 2 = second lane ("UART2"). UART0 is
+/// the console and is never used.
 struct UartBusHolder {
     fl::shared_ptr<UartPeripheralEsp> peripheral;
     fl::shared_ptr<ChannelEngineUART> driver;
-    UartBusHolder() FL_NO_EXCEPT
+    explicit UartBusHolder(int uart_num) FL_NO_EXCEPT
         : peripheral(fl::make_shared<UartPeripheralEsp>()),
-          driver(fl::make_shared<ChannelEngineUART>(peripheral)) {}
+          driver(fl::make_shared<ChannelEngineUART>(peripheral, uart_num)) {}
 };
 }  // namespace detail
 
@@ -41,7 +44,7 @@ template<> struct BusTraits<Bus::UART> {
     using Driver = ChannelEngineUART;
 
     static fl::shared_ptr<Driver> instancePtr() FL_NO_EXCEPT {
-        static detail::UartBusHolder gHolder;
+        static detail::UartBusHolder gHolder(/*uart_num=*/1);
         return gHolder.driver;
     }
 
@@ -49,6 +52,24 @@ template<> struct BusTraits<Bus::UART> {
 
     static void registerWithManager() FL_NO_EXCEPT {
         ChannelManager::instance().addDriver(default_bus_priority(Bus::UART, 0), instancePtr());
+    }
+};
+
+// FastLED#3576 Phase 2 — second UART lane on UART2 ("UART2",
+// `Bus::UART` instance 1). Classic ESP32 has three UARTs: UART0 is the
+// console (off-limits), UART1 is the primary lane, UART2 is this one.
+template<> struct BusTraits<Bus::UART, 1> {
+    using Driver = ChannelEngineUART;
+
+    static fl::shared_ptr<Driver> instancePtr() FL_NO_EXCEPT {
+        static detail::UartBusHolder gHolder(/*uart_num=*/2);
+        return gHolder.driver;
+    }
+
+    static Driver& instance() FL_NO_EXCEPT { return *instancePtr(); }
+
+    static void registerWithManager() FL_NO_EXCEPT {
+        ChannelManager::instance().addDriver(default_bus_priority(Bus::UART, 1), instancePtr());
     }
 };
 

--- a/src/platforms/esp/32/drivers/uart/channel_driver_uart.cpp.hpp
+++ b/src/platforms/esp/32/drivers/uart/channel_driver_uart.cpp.hpp
@@ -25,11 +25,13 @@ namespace fl {
 // Constructor / Destructor
 //=============================================================================
 
-ChannelEngineUART::ChannelEngineUART(fl::shared_ptr<IUartPeripheral> peripheral) FL_NO_EXCEPT
+ChannelEngineUART::ChannelEngineUART(fl::shared_ptr<IUartPeripheral> peripheral,
+                                     int uart_num) FL_NO_EXCEPT
     : mPeripheral(fl::move(peripheral)),
       mInitialized(false),
       mCurrentBaudRate(0),
       mCurrentDataBits(0),
+      mUartNum(uart_num),
       mCurrentGroupIndex(0) {
     if (!mPeripheral) {
         FL_WARN_F("UART: Null peripheral pointer in constructor");
@@ -288,7 +290,7 @@ void ChannelEngineUART::beginTransmission(
             4096,               // mTxBufferSize (4 KB for DMA)
             256,                // mRxBufferSize (minimum required by ESP-IDF)
             1,                  // mStopBits (N1)
-            1,                  // mUartNum (UART1)
+            mUartNum,           // which UART block (1 or 2 — FastLED#3576 Phase 2)
             required_data_bits  // mDataBits (8 = wave10, 6 = wave8-frame)
         );
 

--- a/src/platforms/esp/32/drivers/uart/channel_driver_uart.h
+++ b/src/platforms/esp/32/drivers/uart/channel_driver_uart.h
@@ -48,7 +48,11 @@ namespace fl {
 /// LED data transmission. Uses wave10 encoding with dynamic LUT generation.
 class ChannelEngineUART : public IChannelDriver {
 public:
-    explicit ChannelEngineUART(fl::shared_ptr<IUartPeripheral> peripheral) FL_NO_EXCEPT;
+    /// @param uart_num Which UART block this engine drives (FastLED#3576
+    ///        Phase 2): 1 = primary lane ("UART"), 2 = second lane
+    ///        ("UART2"). UART0 is the console and is never used.
+    explicit ChannelEngineUART(fl::shared_ptr<IUartPeripheral> peripheral,
+                               int uart_num = 1) FL_NO_EXCEPT;
     ~ChannelEngineUART() override;
 
     bool canHandle(const ChannelDataPtr& data) const FL_NO_EXCEPT override;
@@ -57,7 +61,12 @@ public:
     void show() FL_NO_EXCEPT override;
     DriverState poll() FL_NO_EXCEPT override;
 
-    fl::string getName() const FL_NO_EXCEPT override { return fl::string::from_literal("UART"); }
+    fl::string getName() const FL_NO_EXCEPT override {
+        // Distinct names per lane so affinity binding and the
+        // AutoResearch exclusive-driver selector can target each block.
+        return (mUartNum == 2) ? fl::string::from_literal("UART2")
+                               : fl::string::from_literal("UART");
+    }
 
     Capabilities getCapabilities() const FL_NO_EXCEPT override {
         return Capabilities(true, false);  // Clockless only
@@ -91,6 +100,7 @@ private:
     bool mInitialized;
     u32 mCurrentBaudRate; ///< Currently configured baud rate
     u8 mCurrentDataBits;  ///< Currently configured UART word length (wave geometry)
+    int mUartNum;         ///< Which UART block this engine drives (FastLED#3576 Phase 2)
 
     fl::vector<u8> mScratchBuffer;
     fl::vector<u8> mEncodedBuffer;


### PR DESCRIPTION
Phase 2 of the #3576 program: a second concurrent UART LED lane on the UART2 block (`Bus::UART` instance 1, driver name **"UART2"**). UART0 stays reserved for the console.

- `ChannelEngineUART` is parameterized by `uart_num` (1 = "UART", 2 = "UART2"); the peripheral config carries it instead of the hardcoded UART1.
- `BusTraits<Bus::UART, 1>` with its own peripheral+engine holder; enrolled by `enableAllDrivers()` on classic ESP32 only for now (S3/C6 get theirs in the Phase 9 board audit).
- `default_bus_priority(UART, which)`: secondary lane one below primary (-2 vs -1).
- Both waveN geometries (#3574) apply per lane with independent baud/word-length.
- `i2sPortClaim` contention warning → `FL_WARN_F_ONCE` per review direction.
- `fl/channels/README.md` engine table updated.

## Verification
- Bench (WROOM COM11, GPIO33→34): **UART2 `passed: true`, 4/4 patterns byte-exact** on the UART2 block; regression UART (lane 1), I2S, I2S0 all 4/4.
- Host: 345/345; lint clean.

Refs #3576.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for an additional UART lane on ESP32-dev (original) devices, enabling a second concurrent UART channel while keeping the console channel reserved.
  * UART channels now report a lane-specific name where applicable.

* **Bug Fixes**
  * Improved UART channel selection so the correct hardware block is used for each lane.
  * Reduced repeated warning spam when a shared port claim fails due to contention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->