### PR TITLE
fix(examples): ESP32 compile matrix — S2 dram0 overflow + H2 WiFi-less build (#3576 Phase 4)

### DIFF
--- a/examples/AutoResearch/AutoResearchNet.cpp
+++ b/examples/AutoResearch/AutoResearchNet.cpp
@@ -31,7 +31,15 @@ AutoResearchNetState& getNetState() {
 // ESP32 Implementation
 // ============================================================================
 
+// ESP32-H2 (and other WiFi-less ESP32 family members) must take the
+// stub branch — esp_wifi.h does not even preprocess there
+// (CONFIG_ESP_WIFI_* are absent from its sdkconfig). Gate on actual
+// WiFi silicon, not on the family macro. (FastLED#3576 Phase 4)
 #if defined(FL_IS_ESP32)
+#include "soc/soc_caps.h"  // SOC_WIFI_SUPPORTED
+#endif
+
+#if defined(FL_IS_ESP32) && defined(SOC_WIFI_SUPPORTED) && SOC_WIFI_SUPPORTED
 
 // Unified HTTP server API (must be included before Arduino.h to avoid INADDR_NONE conflict)
 #include "fl/stl/asio/http/server.h"
@@ -448,7 +456,7 @@ fl::json stopNet() {
     return response;
 }
 
-#else  // !FL_IS_ESP32
+#else  // !FL_IS_ESP32 || !SOC_WIFI_SUPPORTED
 
 // ============================================================================
 // Stub Implementation for Non-ESP32 Platforms

--- a/examples/AutoResearch/AutoResearchOta.cpp
+++ b/examples/AutoResearch/AutoResearchOta.cpp
@@ -29,7 +29,15 @@ AutoResearchOtaState& getOtaState() {
 // ESP32 Implementation
 // ============================================================================
 
+// ESP32-H2 (and other WiFi-less ESP32 family members) must take the
+// stub branch — esp_wifi.h does not even preprocess there
+// (CONFIG_ESP_WIFI_* are absent from its sdkconfig). Gate on actual
+// WiFi silicon, not on the family macro. (FastLED#3576 Phase 4)
 #if defined(FL_IS_ESP32)
+#include "soc/soc_caps.h"  // SOC_WIFI_SUPPORTED
+#endif
+
+#if defined(FL_IS_ESP32) && defined(SOC_WIFI_SUPPORTED) && SOC_WIFI_SUPPORTED
 
 #include "fl/net/ota.h"
 #include "fl/stl/cstring.h"
@@ -184,7 +192,7 @@ fl::json stopOta() {
     return response;
 }
 
-#else  // !FL_IS_ESP32
+#else  // !FL_IS_ESP32 || !SOC_WIFI_SUPPORTED
 
 // ============================================================================
 // Stub Implementation for Non-ESP32 Platforms

--- a/examples/AutoResearch/AutoResearchRemoteBenchmarkMethods.cpp
+++ b/examples/AutoResearch/AutoResearchRemoteBenchmarkMethods.cpp
@@ -19,6 +19,7 @@
 #include "AutoResearchNet.h"
 #include "AutoResearchOta.h"
 #include "fl/remote/transport/serial.h"
+#include "fl/stl/vector.h"
 #include "fl/system/heap.h"
 #include "Common.h"
 #include "AutoResearchTest.h"
@@ -82,8 +83,17 @@ void AutoResearchRemoteControl::bindBenchmarkMethods(fl::Remote& remote) {
             response.set("error", "out_of_range");
             return response;
         }
-        static uint8_t src_buf[8192];
-        static uint8_t dst_buf[8192];
+        // Heap-allocated on first use: 16 KB of static buffers
+        // overflowed ESP32-S2's dram0 bss by 3.7 KB (FastLED#3576
+        // Phase 4 compile matrix).
+        static fl::vector<uint8_t> src_vec;
+        static fl::vector<uint8_t> dst_vec;
+        if (src_vec.size() < 8192) {
+            src_vec.resize(8192);
+            dst_vec.resize(8192);
+        }
+        uint8_t *src_buf = src_vec.data();
+        uint8_t *dst_buf = dst_vec.data();
         for (int i = 0; i < bytes; ++i) {
             src_buf[i] = static_cast<uint8_t>(i & 0xFF);
         }


### PR DESCRIPTION
Phase 4 of #3576: verified the AutoResearch harness compiles across the IDF and chip matrix, and fixed the two failures found.

## Matrix (AutoResearch, `--no-filter`)

| Target | Result |
|--------|--------|
| esp32dev @ IDF 4.4 (platform v4.4.0) | ✅ |
| esp32dev @ IDF 5.5 (pioarduino) | ✅ |
| esp32dev @ IDF 6.0 (pioarduino prep_IDF6) | ✅ |
| esp32s3 / esp32c6 / esp32p4 / esp32c3 | ✅ |
| esp32s2 | ❌ → ✅ (this PR) |
| esp32h2 | ❌ → ✅ (this PR) |

## Fixes
- **esp32s2**: `.dram0.bss` overflowed by 3696 bytes — the RPC benchmark handler held two static 8 KB buffers; now heap-allocated on first use (frees 16 KB of bss everywhere).
- **esp32h2**: the WiFi/OTA example TUs gated on the family macro `FL_IS_ESP32`, but H2 has no WiFi silicon and `esp_wifi.h` fails to preprocess there. Guard is now `FL_IS_ESP32 && SOC_WIFI_SUPPORTED`, routing WiFi-less chips to the existing stub branch.

Host: 345/345; lint clean.

Refs #3576.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ESP32 compatibility by only enabling Wi‑Fi-based networking and OTA features when supported by the hardware.
  * ESP32 variants without Wi‑Fi now use the fallback behavior instead of failing to build or run Wi‑Fi setup paths.
* **Refactor**
  * Updated the remote memcpy benchmark to use dynamically managed buffers for more reliable memory handling during execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->