### PR TITLE
feat(net): fl::net::wifi connection API + netActivity RPC (#3576 Phase 6)

### DIFF
--- a/examples/AutoResearch/AutoResearchRemoteNetworkMethods.cpp
+++ b/examples/AutoResearch/AutoResearchRemoteNetworkMethods.cpp
@@ -24,6 +24,8 @@
 #include "Common.h"
 #include "AutoResearchTest.h"
 #include "AutoResearchHelpers.h"
+#include "fl/net/network_detector.h"
+#include "fl/net/wifi.h"
 #include "fl/stl/sstream.h"
 #include "fl/stl/unique_ptr.h"
 #include "fl/stl/optional.h"
@@ -240,6 +242,90 @@ void AutoResearchRemoteControl::bindNetworkMethods(fl::Remote& remote) {
         mState->net_server_active = false;
         mState->net_client_active = false;
         return stopNet();
+    });
+
+    // ========================================================================
+    // WiFi Connection + Network Activity RPC Functions (FastLED#3576 Phase 6)
+    // ========================================================================
+
+    // "wifiConnect" {ssid, password} — async STA join via fl::net::wifi.
+    remote.bind("wifiConnect", [](const fl::json& args) -> fl::json {
+        fl::json response = fl::json::object();
+        fl::string ssid, pass;
+        if (args.contains("ssid") && args["ssid"].is_string()) {
+            ssid = args["ssid"].as_string().value();
+        }
+        if (args.contains("password") && args["password"].is_string()) {
+            pass = args["password"].as_string().value();
+        }
+        if (ssid.empty()) {
+            response.set("success", false);
+            response.set("error", "MissingSsid");
+            return response;
+        }
+        const bool ok = fl::net::wifi::connectSta(ssid.c_str(), pass.c_str());
+        response.set("success", ok);
+        response.set("status", fl::net::wifi::toString(fl::net::wifi::status()));
+        return response;
+    });
+
+    // "wifiAp" {ssid, password, channel} — SoftAP via fl::net::wifi.
+    remote.bind("wifiAp", [](const fl::json& args) -> fl::json {
+        fl::json response = fl::json::object();
+        fl::string ssid, pass;
+        int channel = 1;
+        if (args.contains("ssid") && args["ssid"].is_string()) {
+            ssid = args["ssid"].as_string().value();
+        }
+        if (args.contains("password") && args["password"].is_string()) {
+            pass = args["password"].as_string().value();
+        }
+        if (args.contains("channel") && args["channel"].is_int()) {
+            channel = static_cast<int>(args["channel"].as_int().value());
+        }
+        if (ssid.empty()) {
+            response.set("success", false);
+            response.set("error", "MissingSsid");
+            return response;
+        }
+        const bool ok = fl::net::wifi::startAp(ssid.c_str(), pass.c_str(),
+                                               static_cast<fl::u8>(channel));
+        response.set("success", ok);
+        response.set("apIp", fl::net::wifi::apIpAddress().c_str());
+        return response;
+    });
+
+    // "wifiStatus" — poll the async join.
+    remote.bind("wifiStatus", [](const fl::json& args) -> fl::json {
+        fl::json response = fl::json::object();
+        response.set("success", true);
+        response.set("status", fl::net::wifi::toString(fl::net::wifi::status()));
+        response.set("connected", fl::net::wifi::isConnected());
+        response.set("ip", fl::net::wifi::ipAddress().c_str());
+        response.set("apIp", fl::net::wifi::apIpAddress().c_str());
+        return response;
+    });
+
+    // "wifiStop" — tear down STA + AP.
+    remote.bind("wifiStop", [](const fl::json& args) -> fl::json {
+        fl::net::wifi::stop();
+        fl::json response = fl::json::object();
+        response.set("success", true);
+        return response;
+    });
+
+    // "netActivity" — runtime network-activity snapshot (the detector
+    // the LED drivers consult for deep-yield decisions).
+    remote.bind("netActivity", [](const fl::json& args) -> fl::json {
+        fl::json response = fl::json::object();
+        response.set("success", true);
+        response.set("wifiActive", fl::NetworkDetector::isWiFiActive());
+        response.set("wifiConnected", fl::NetworkDetector::isWiFiConnected());
+        response.set("bluetoothActive", fl::NetworkDetector::isBluetoothActive());
+        response.set("anyNetworkActive", fl::NetworkDetector::isAnyNetworkActive());
+        response.set("anyNetworkConnected", fl::NetworkDetector::isAnyNetworkConnected());
+        response.set("wifiStatus", fl::net::wifi::toString(fl::net::wifi::status()));
+        return response;
     });
 
     // ========================================================================

--- a/src/fl/net/_build.cpp.hpp
+++ b/src/fl/net/_build.cpp.hpp
@@ -4,6 +4,7 @@
 // begin current directory includes
 #include "fl/net/ble.cpp.hpp"
 #include "fl/net/ota.cpp.hpp"
+#include "fl/net/wifi.cpp.hpp"
 
 // begin sub directory includes
 #include "fl/net/http/_build.cpp.hpp"

--- a/src/fl/net/wifi.cpp.hpp
+++ b/src/fl/net/wifi.cpp.hpp
@@ -1,0 +1,52 @@
+// IWYU pragma: private
+// src/fl/net/wifi.cpp.hpp
+//
+// Stub implementations for platforms without WiFi support. On WiFi
+// silicon the real implementation is compiled via the platform build
+// chain (platforms/esp/32/net/_build.cpp.hpp). Same split as
+// fl/net/ble.cpp.hpp.
+
+#pragma once
+
+#include "fl/net/wifi.h"
+#include "fl/stl/noexcept.h"
+
+namespace fl {
+namespace net {
+namespace wifi {
+
+const char* toString(Status s) FL_NO_EXCEPT {
+    switch (s) {
+    case Status::UNSUPPORTED: return "UNSUPPORTED";
+    case Status::IDLE:        return "IDLE";
+    case Status::CONNECTING:  return "CONNECTING";
+    case Status::CONNECTED:   return "CONNECTED";
+    case Status::FAILED:      return "FAILED";
+    case Status::AP_ACTIVE:   return "AP_ACTIVE";
+    }
+    return "UNKNOWN";
+}
+
+} // namespace wifi
+} // namespace net
+} // namespace fl
+
+#if !FL_WIFI_AVAILABLE
+
+namespace fl {
+namespace net {
+namespace wifi {
+
+bool connectSta(const char*, const char*) FL_NO_EXCEPT { return false; }
+bool startAp(const char*, const char*, u8) FL_NO_EXCEPT { return false; }
+void stop() FL_NO_EXCEPT {}
+Status status() FL_NO_EXCEPT { return Status::UNSUPPORTED; }
+bool isConnected() FL_NO_EXCEPT { return false; }
+fl::string ipAddress() FL_NO_EXCEPT { return fl::string(); }
+fl::string apIpAddress() FL_NO_EXCEPT { return fl::string(); }
+
+} // namespace wifi
+} // namespace net
+} // namespace fl
+
+#endif // !FL_WIFI_AVAILABLE

--- a/src/fl/net/wifi.h
+++ b/src/fl/net/wifi.h
@@ -1,0 +1,91 @@
+/// @file wifi.h
+/// @brief fl::net::wifi — platform-neutral WiFi connection API
+///        (FastLED#3576 Phase 6).
+///
+/// FastLED previously had no reusable connection manager: the only
+/// credential-taking API was OTA-scoped (`fl::net::OTA::beginWiFi`) and
+/// examples hand-rolled `esp_wifi_*` calls. This header is the fl-level
+/// surface for bringing a network interface up so the rest of
+/// `fl::net` (fetch, HTTP server, remote RPC) has something to run on.
+///
+/// All calls are asynchronous and non-blocking: `connectSta()` starts a
+/// join and returns; poll `status()` / `isConnected()`. On platforms
+/// without WiFi (host builds, WiFi-less MCUs like ESP32-H2) every call
+/// is a no-op stub that reports `Status::UNSUPPORTED`.
+///
+/// Bluetooth connections live in the sibling `fl::net::ble` API
+/// (GATT transport: `createTransport` / `queryStatus`).
+
+#pragma once
+
+#include "fl/stl/noexcept.h"
+#include "fl/stl/string.h"
+#include "fl/stl/int.h"
+
+#include "fl/stl/has_include.h"
+#include "platforms/is_platform.h"
+
+#ifdef FL_IS_ESP32
+#if FL_HAS_INCLUDE("soc/soc_caps.h")
+// IWYU pragma: begin_keep
+#include "soc/soc_caps.h"  // ok platform headers - SOC_WIFI_SUPPORTED for FL_WIFI_AVAILABLE
+// IWYU pragma: end_keep
+#endif
+#endif
+
+/// 1 when a real WiFi implementation is compiled in; 0 → stubs.
+#if defined(FL_IS_ESP32) && defined(SOC_WIFI_SUPPORTED) && SOC_WIFI_SUPPORTED && \
+    FL_HAS_INCLUDE(<esp_wifi.h>)
+#define FL_WIFI_AVAILABLE 1
+#else
+#define FL_WIFI_AVAILABLE 0
+#endif
+
+namespace fl {
+namespace net {
+namespace wifi {
+
+/// @brief Connection state, advanced by the platform's event handlers.
+enum class Status : u8 {
+    UNSUPPORTED = 0, ///< No WiFi on this platform (stub build)
+    IDLE,            ///< WiFi not started
+    CONNECTING,      ///< STA join in progress
+    CONNECTED,       ///< STA has an IP
+    FAILED,          ///< STA join gave up (bad credentials / no AP)
+    AP_ACTIVE,       ///< SoftAP is up (no STA connection)
+};
+
+/// @brief Human-readable name for a Status value.
+const char* toString(Status s) FL_NO_EXCEPT;
+
+/// @brief Start an asynchronous station-mode join.
+///
+/// Returns immediately; poll status()/isConnected(). Calling again with
+/// different credentials restarts the join. Coexists with an active
+/// SoftAP (APSTA mode).
+/// @return false if the WiFi driver could not be started at all.
+bool connectSta(const char* ssid, const char* password) FL_NO_EXCEPT;
+
+/// @brief Bring up a SoftAP.
+/// @param channel 1-13; pass 0 for the default (channel 1).
+/// @return false if the AP could not be started.
+bool startAp(const char* ssid, const char* password, u8 channel) FL_NO_EXCEPT;
+
+/// @brief Stop WiFi entirely (STA and AP).
+void stop() FL_NO_EXCEPT;
+
+/// @brief Current connection state.
+Status status() FL_NO_EXCEPT;
+
+/// @brief True when the station interface has an IP.
+bool isConnected() FL_NO_EXCEPT;
+
+/// @brief Dotted-quad IP of the station interface ("" until connected).
+fl::string ipAddress() FL_NO_EXCEPT;
+
+/// @brief Dotted-quad IP of the SoftAP interface ("" when AP is down).
+fl::string apIpAddress() FL_NO_EXCEPT;
+
+} // namespace wifi
+} // namespace net
+} // namespace fl

--- a/src/platforms/esp/32/_build.cpp.hpp
+++ b/src/platforms/esp/32/_build.cpp.hpp
@@ -22,4 +22,5 @@
 #include "platforms/esp/32/core/_build.cpp.hpp"
 #include "platforms/esp/32/drivers/_build.cpp.hpp"
 #include "platforms/esp/32/interrupts/_build.cpp.hpp"
+#include "platforms/esp/32/net/_build.cpp.hpp"
 #include "platforms/esp/32/ota/_build.cpp.hpp"

--- a/src/platforms/esp/32/net/_build.cpp.hpp
+++ b/src/platforms/esp/32/net/_build.cpp.hpp
@@ -1,0 +1,8 @@
+// IWYU pragma: private
+
+/// @file _build.hpp
+/// @brief Unity build header for platforms\esp\32\net/ directory
+///
+/// fl::net::wifi ESP-IDF implementation (FastLED#3576 Phase 6).
+
+#include "platforms/esp/32/net/wifi_esp32.cpp.hpp"

--- a/src/platforms/esp/32/net/wifi_esp32.cpp.hpp
+++ b/src/platforms/esp/32/net/wifi_esp32.cpp.hpp
@@ -1,0 +1,272 @@
+// IWYU pragma: private
+
+/// @file wifi_esp32.cpp.hpp
+/// @brief ESP-IDF implementation of the fl::net::wifi connection API
+///        (FastLED#3576 Phase 6). Stubs for other platforms live in
+///        fl/net/wifi.cpp.hpp.
+///
+/// STA joins are asynchronous: connectSta() kicks the driver and
+/// returns; WIFI_EVENT / IP_EVENT handlers advance the Status machine
+/// (CONNECTING → CONNECTED on GOT_IP; a bounded retry loop on
+/// disconnect, then FAILED). SoftAP can coexist (APSTA).
+
+#include "fl/net/wifi.h"
+
+#if FL_WIFI_AVAILABLE
+
+#include "fl/log/log.h"
+#include "fl/stl/cstring.h"
+#include "fl/stl/noexcept.h"
+
+FL_EXTERN_C_BEGIN
+// IWYU pragma: begin_keep
+#include <esp_event.h>
+#include <esp_netif.h>
+#include <esp_wifi.h>
+// IWYU pragma: end_keep
+FL_EXTERN_C_END
+
+namespace fl {
+namespace net {
+namespace wifi {
+
+namespace {
+
+// Bounded auto-reconnect before declaring FAILED. Enough to ride out a
+// slow AP boot on the dual-device bench without wedging the caller.
+constexpr int kMaxStaRetries = 6;
+
+struct WifiState {
+    Status status = Status::IDLE;
+    esp_netif_t *sta_netif = nullptr;
+    esp_netif_t *ap_netif = nullptr;
+    bool driver_started = false;
+    bool ap_active = false;
+    bool sta_requested = false;
+    bool handlers_registered = false;
+    int retries = 0;
+};
+
+// FL_LINT_ALLOW_GLOBAL(referenced from a C event-handler callback registered with the IDF event loop; zero-init POD keeps status readable before begin)
+WifiState g_state;
+
+void wifiEventHandler(void *, esp_event_base_t base, i32 id, void *) {
+    if (base == WIFI_EVENT) {
+        if (id == WIFI_EVENT_STA_START) {
+            esp_wifi_connect();
+        } else if (id == WIFI_EVENT_STA_DISCONNECTED) {
+            if (g_state.sta_requested && g_state.retries < kMaxStaRetries) {
+                ++g_state.retries;
+                g_state.status = Status::CONNECTING;
+                esp_wifi_connect();
+            } else if (g_state.sta_requested) {
+                g_state.status = Status::FAILED;
+            }
+        }
+    } else if (base == IP_EVENT && id == IP_EVENT_STA_GOT_IP) {
+        g_state.retries = 0;
+        g_state.status = Status::CONNECTED;
+    }
+}
+
+/// One-time driver + netif + event plumbing. Idempotent.
+bool ensureDriver() FL_NO_EXCEPT {
+    esp_err_t err = esp_netif_init();
+    if (err != ESP_OK && err != ESP_ERR_INVALID_STATE) {
+        FL_WARN_F("wifi: esp_netif_init failed: %s", esp_err_to_name(err));
+        return false;
+    }
+    err = esp_event_loop_create_default();
+    if (err != ESP_OK && err != ESP_ERR_INVALID_STATE) {
+        FL_WARN_F("wifi: event loop create failed: %s", esp_err_to_name(err));
+        return false;
+    }
+    if (!g_state.handlers_registered) {
+        if (esp_event_handler_instance_register(WIFI_EVENT, ESP_EVENT_ANY_ID,
+                                                &wifiEventHandler, nullptr,
+                                                nullptr) != ESP_OK ||
+            esp_event_handler_instance_register(IP_EVENT, IP_EVENT_STA_GOT_IP,
+                                                &wifiEventHandler, nullptr,
+                                                nullptr) != ESP_OK) {
+            FL_WARN_F("wifi: event handler registration failed");
+            return false;
+        }
+        g_state.handlers_registered = true;
+    }
+    wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
+    err = esp_wifi_init(&cfg);
+    if (err != ESP_OK && err != ESP_ERR_INVALID_STATE) {
+        FL_WARN_F("wifi: esp_wifi_init failed: %s", esp_err_to_name(err));
+        return false;
+    }
+    return true;
+}
+
+bool applyMode() FL_NO_EXCEPT {
+    wifi_mode_t mode = WIFI_MODE_NULL;
+    if (g_state.sta_requested && g_state.ap_active) {
+        mode = WIFI_MODE_APSTA;
+    } else if (g_state.sta_requested) {
+        mode = WIFI_MODE_STA;
+    } else if (g_state.ap_active) {
+        mode = WIFI_MODE_AP;
+    }
+    esp_err_t err = esp_wifi_set_mode(mode);
+    if (err != ESP_OK) {
+        FL_WARN_F("wifi: set_mode failed: %s", esp_err_to_name(err));
+        return false;
+    }
+    return true;
+}
+
+fl::string netifIp(esp_netif_t *netif) FL_NO_EXCEPT {
+    if (netif == nullptr) {
+        return fl::string();
+    }
+    esp_netif_ip_info_t info;
+    if (esp_netif_get_ip_info(netif, &info) != ESP_OK ||
+        info.ip.addr == 0) {
+        return fl::string();
+    }
+    char buf[16];
+    esp_ip4addr_ntoa(&info.ip, buf, sizeof(buf));
+    return fl::string(buf);
+}
+
+} // anonymous namespace
+
+bool connectSta(const char *ssid, const char *password) FL_NO_EXCEPT {
+    if (ssid == nullptr || *ssid == '\0') {
+        return false;
+    }
+    if (!ensureDriver()) {
+        return false;
+    }
+    if (g_state.sta_netif == nullptr) {
+        g_state.sta_netif = esp_netif_create_default_wifi_sta();
+        if (g_state.sta_netif == nullptr) {
+            FL_WARN_F("wifi: STA netif creation failed");
+            return false;
+        }
+    }
+
+    wifi_config_t cfg;
+    fl::memset(&cfg, 0, sizeof(cfg));
+    fl::strncpy(reinterpret_cast<char *>(cfg.sta.ssid), ssid, // ok reinterpret cast - IDF field is uint8_t[]
+                sizeof(cfg.sta.ssid) - 1);
+    if (password != nullptr) {
+        fl::strncpy(reinterpret_cast<char *>(cfg.sta.password), password, // ok reinterpret cast - IDF field is uint8_t[]
+                    sizeof(cfg.sta.password) - 1);
+    }
+
+    g_state.sta_requested = true;
+    g_state.retries = 0;
+    g_state.status = Status::CONNECTING;
+    if (!applyMode()) {
+        return false;
+    }
+    esp_err_t err = esp_wifi_set_config(WIFI_IF_STA, &cfg);
+    if (err != ESP_OK) {
+        FL_WARN_F("wifi: STA set_config failed: %s", esp_err_to_name(err));
+        return false;
+    }
+    err = esp_wifi_start();
+    if (err != ESP_OK && err != ESP_ERR_INVALID_STATE) {
+        FL_WARN_F("wifi: start failed: %s", esp_err_to_name(err));
+        return false;
+    }
+    if (g_state.driver_started) {
+        // Driver was already running (mode change) — STA_START will not
+        // re-fire, so kick the join directly.
+        esp_wifi_connect();
+    }
+    g_state.driver_started = true;
+    return true;
+}
+
+bool startAp(const char *ssid, const char *password, u8 channel) FL_NO_EXCEPT {
+    if (ssid == nullptr || *ssid == '\0') {
+        return false;
+    }
+    if (!ensureDriver()) {
+        return false;
+    }
+    if (g_state.ap_netif == nullptr) {
+        g_state.ap_netif = esp_netif_create_default_wifi_ap();
+        if (g_state.ap_netif == nullptr) {
+            FL_WARN_F("wifi: AP netif creation failed");
+            return false;
+        }
+    }
+
+    wifi_config_t cfg;
+    fl::memset(&cfg, 0, sizeof(cfg));
+    fl::strncpy(reinterpret_cast<char *>(cfg.ap.ssid), ssid, // ok reinterpret cast - IDF field is uint8_t[]
+                sizeof(cfg.ap.ssid) - 1);
+    cfg.ap.ssid_len = static_cast<u8>(fl::strlen(ssid));
+    cfg.ap.channel = (channel >= 1 && channel <= 13) ? channel : 1;
+    cfg.ap.max_connection = 4;
+    if (password != nullptr && fl::strlen(password) >= 8) {
+        fl::strncpy(reinterpret_cast<char *>(cfg.ap.password), password, // ok reinterpret cast - IDF field is uint8_t[]
+                    sizeof(cfg.ap.password) - 1);
+        cfg.ap.authmode = WIFI_AUTH_WPA2_PSK;
+    } else {
+        cfg.ap.authmode = WIFI_AUTH_OPEN;
+    }
+
+    g_state.ap_active = true;
+    if (!applyMode()) {
+        g_state.ap_active = false;
+        return false;
+    }
+    esp_err_t err = esp_wifi_set_config(WIFI_IF_AP, &cfg);
+    if (err != ESP_OK) {
+        FL_WARN_F("wifi: AP set_config failed: %s", esp_err_to_name(err));
+        g_state.ap_active = false;
+        return false;
+    }
+    err = esp_wifi_start();
+    if (err != ESP_OK && err != ESP_ERR_INVALID_STATE) {
+        FL_WARN_F("wifi: start failed: %s", esp_err_to_name(err));
+        g_state.ap_active = false;
+        return false;
+    }
+    g_state.driver_started = true;
+    if (g_state.status == Status::IDLE ||
+        g_state.status == Status::UNSUPPORTED) {
+        g_state.status = Status::AP_ACTIVE;
+    }
+    return true;
+}
+
+void stop() FL_NO_EXCEPT {
+    g_state.sta_requested = false;
+    g_state.ap_active = false;
+    if (g_state.driver_started) {
+        esp_wifi_stop();
+        g_state.driver_started = false;
+    }
+    g_state.status = Status::IDLE;
+}
+
+Status status() FL_NO_EXCEPT {
+    return g_state.status;
+}
+
+bool isConnected() FL_NO_EXCEPT {
+    return g_state.status == Status::CONNECTED;
+}
+
+fl::string ipAddress() FL_NO_EXCEPT {
+    return netifIp(g_state.sta_netif);
+}
+
+fl::string apIpAddress() FL_NO_EXCEPT {
+    return netifIp(g_state.ap_netif);
+}
+
+} // namespace wifi
+} // namespace net
+} // namespace fl
+
+#endif // FL_WIFI_AVAILABLE

--- a/tests/fl/net/wifi.cpp
+++ b/tests/fl/net/wifi.cpp
@@ -1,0 +1,36 @@
+// Host-side tests for the fl::net::wifi connection API (FastLED#3576
+// Phase 6). The host build has no WiFi silicon, so this exercises the
+// stub contract: every call must be a safe no-op reporting UNSUPPORTED
+// — sketches using the API must run unmodified on WiFi-less targets.
+
+#include "test.h"
+#include "fl/net/wifi.h"
+
+FL_TEST_FILE(FL_FILEPATH) {
+
+FL_TEST_CASE("wifi stub: status is UNSUPPORTED and calls are safe no-ops") {
+    using namespace fl::net::wifi;
+
+    FL_CHECK(status() == Status::UNSUPPORTED);
+    FL_CHECK_FALSE(isConnected());
+
+    FL_CHECK_FALSE(connectSta("ssid", "password"));
+    FL_CHECK_FALSE(startAp("ap", "password", 1));
+    stop(); // must not crash
+
+    FL_CHECK(ipAddress().empty());
+    FL_CHECK(apIpAddress().empty());
+    FL_CHECK(status() == Status::UNSUPPORTED);
+}
+
+FL_TEST_CASE("wifi: toString covers every status") {
+    using namespace fl::net::wifi;
+    FL_CHECK_EQ(fl::string(toString(Status::UNSUPPORTED)), fl::string("UNSUPPORTED"));
+    FL_CHECK_EQ(fl::string(toString(Status::IDLE)), fl::string("IDLE"));
+    FL_CHECK_EQ(fl::string(toString(Status::CONNECTING)), fl::string("CONNECTING"));
+    FL_CHECK_EQ(fl::string(toString(Status::CONNECTED)), fl::string("CONNECTED"));
+    FL_CHECK_EQ(fl::string(toString(Status::FAILED)), fl::string("FAILED"));
+    FL_CHECK_EQ(fl::string(toString(Status::AP_ACTIVE)), fl::string("AP_ACTIVE"));
+}
+
+}


### PR DESCRIPTION
Phase 6 of #3576: the fl-level WiFi connection API (explicit program goal: "FastLED should implement the APIs for connection for WiFi and Bluetooth") and the network-activity RPC for the dual-device bench.

## `fl::net::wifi` (`src/fl/net/wifi.h`)
- `connectSta(ssid, pass)` — asynchronous station join; poll `status()` / `isConnected()`. Event-driven state machine: CONNECTING → CONNECTED on GOT_IP, bounded 6-retry reconnect, then FAILED.
- `startAp(ssid, pass, channel)` — SoftAP (WPA2 with ≥8-char pass, open otherwise); APSTA coexistence with a station join.
- `stop()`, `status()`, `ipAddress()`, `apIpAddress()`, `toString(Status)`.
- `FL_WIFI_AVAILABLE` = `FL_IS_ESP32 && SOC_WIFI_SUPPORTED && FL_HAS_INCLUDE(<esp_wifi.h>)`. Real implementation in `platforms/esp/32/net/wifi_esp32.cpp.hpp`; all other platforms (host, WiFi-less MCUs like ESP32-H2) get safe no-op stubs reporting `Status::UNSUPPORTED` — same real/stub split as `fl/net/ble`.
- Bluetooth connections: the existing `fl::net::ble` GATT transport API already covers create/status/teardown; documented as the BLE counterpart.

## AutoResearch RPC (dual-device prep)
`wifiConnect` / `wifiAp` / `wifiStatus` / `wifiStop` + **`netActivity`** (NetworkDetector snapshot: wifiActive, wifiConnected, bluetoothActive, anyNetworkActive/Connected — the same detector the LED drivers consult for deep-yield decisions).

## Verification
- WROOM bench, live RPC session: `netActivity` IDLE → `wifiAp` brings up 192.168.4.1 and flips the detector (`wifiActive:true`, `anyNetworkActive:true`) → `wifiStatus` AP_ACTIVE → `wifiStop` → IDLE. RMT regression 4/4.
- Host: 346/346 (new stub-contract + toString tests); lint clean; esp32dev compile clean.

Refs #3576.

🤖 Generated with [Claude Code](https://claude.com/claude-code)