### PR TITLE
feat(autoresearch): dual-device WiFi bench green + C6 USB-CDC truncation fix + parlioMetrics RPC (#3576 Phase 7)

### DIFF
--- a/examples/AutoResearch/AutoResearch.ino
+++ b/examples/AutoResearch/AutoResearch.ino
@@ -392,6 +392,16 @@ void setup() {
         // the port silent.
         FastLED.watchdog().feed();
     }
+#if defined(ARDUINO_USB_CDC_ON_BOOT) && ARDUINO_USB_CDC_ON_BOOT
+    if (fl::serial_ready()) {
+        // A host is attached and draining: allow writes to block up to
+        // 100 ms instead of dropping. With tx timeout 0, every RPC
+        // response longer than the 64-byte USB-Serial-JTAG FIFO was
+        // truncated mid-line on the C6 bench (host parse failures).
+        // Headless boots keep the drop-fast behavior above.
+        Serial.setTxTimeoutMs(100);  // ok serial - platform-specific TX timeout, no fl:: equivalent
+    }
+#endif
 
     // Watchdog was armed at the very top of setup() above with the longer
     // AUTORESEARCH_SETUP_WATCHDOG_TIMEOUT_MS window so a hang here (RPC bind,

--- a/examples/AutoResearch/AutoResearchRemoteSystemMethods.cpp
+++ b/examples/AutoResearch/AutoResearchRemoteSystemMethods.cpp
@@ -25,6 +25,13 @@
 #include "AutoResearchHelpers.h"
 #include "fl/stl/sstream.h"
 #include "fl/stl/unique_ptr.h"
+#include "platforms/is_platform.h"
+#ifdef FL_IS_ESP32
+#include "platforms/esp/32/feature_flags/enabled.h"
+#if FASTLED_ESP32_HAS_PARLIO
+#include "platforms/esp/32/drivers/parlio/parlio_engine.h"
+#endif
+#endif
 #include "fl/stl/optional.h"
 #include "fl/stl/json.h"
 #include "fl/task/task.h"
@@ -201,6 +208,28 @@ void AutoResearchRemoteControl::bindSystemMethods(fl::Remote& remote) {
         response.set("serial_safe", false);
         return response;
     });
+
+    // "parlioMetrics" — PARLIO engine ISR/DMA counters (C6 bring-up,
+    // FastLED#3576 Phase 7). Reads the engine's debug metrics AFTER a
+    // test to see whether the TX ISRs ever fired.
+#if defined(FL_IS_ESP32) && FASTLED_ESP32_HAS_PARLIO
+    remote.bind("parlioMetrics", [](const fl::json& args) -> fl::json {
+        fl::json response = fl::json::object();
+        const auto m = fl::detail::ParlioEngine::getInstance().getDebugMetrics();
+        response.set("success", true);
+        response.set("isrCount", static_cast<int64_t>(m.mIsrCount));
+        response.set("txDoneCount", static_cast<int64_t>(m.mTxDoneCount));
+        response.set("chunksQueued", static_cast<int64_t>(m.mChunksQueued));
+        response.set("chunksCompleted", static_cast<int64_t>(m.mChunksCompleted));
+        response.set("bytesTotal", static_cast<int64_t>(m.mBytesTotal));
+        response.set("bytesTransmitted", static_cast<int64_t>(m.mBytesTransmitted));
+        response.set("underruns", static_cast<int64_t>(m.mUnderrunCount));
+        response.set("errorCode", static_cast<int64_t>(m.mErrorCode));
+        response.set("hardwareIdle", m.mHardwareIdle);
+        response.set("transmissionActive", m.mTransmissionActive);
+        return response;
+    });
+#endif
 
     // FastLED#3569 bench diagnostic — read up to 16 u32 words of
     // memory-mapped register space without resetting the chip (esptool


### PR DESCRIPTION
Phase 7 milestone: **first cross-device network validation** on the attached bench.

## Dual-device sequence (verified live)
1. WROOM (COM11): `startNetServer` → SoftAP `FastLED-AutoResearch` @ 192.168.4.1 + HTTP server.
2. C6 (COM9): `wifiConnect` (the new `fl::net::wifi::connectSta` from #3584) → joined, DHCP **192.168.4.2**.
3. C6 `netActivity` flips `wifiActive:true` during association.
4. C6 `runNetClientTest {host_ip:192.168.4.1, port:80}` → HTTP GET across the air.
5. Clean teardown both sides (`wifiStop` / `stopNet`).

## Fixes / additions
- **C6 USB-Serial-JTAG truncation**: boot sets `setTxTimeoutMs(0)` (drop-fast so headless boots never stall, #2668) — but with a host attached that truncated every RPC response longer than the 64-byte HWCDC FIFO, systematically breaking host-side parsing. Now, once `fl::serial_ready()` sees a host, the TX timeout is raised to 100 ms. Headless behavior unchanged.
- **`parlioMetrics` RPC**: PARLIO engine debug counters (isrCount, txDoneCount, chunks, bytes, underruns, errorCode) — used to prove DMA-complete in the #3586 investigation; permanently useful for lane-sweep monitoring.

## C6 driver matrix (recorded in #3586)
UART/SPI: 4/4 byte-exact on the GPIO1→GPIO0 loopback. RMT + PARLIO: transmit runs (DMA/ISR healthy, pin routed, clock divider correct, wire toggles per GPIO_IN probe) but the capture sees nothing — deep-dive issue filed with all register evidence.

Host: 346/346; lint clean.

Refs #3576, #3586.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new system metrics endpoint for supported ESP32 setups, returning real-time PARLIO transmission statistics and status information.
* **Bug Fixes**
  * Improved USB serial behavior in the AutoResearch example by enabling a short transmit timeout when the host is connected, helping prevent stalls during output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->