### PR TITLE
fix(stl/net): OOM + concurrency hardening from the #3588 crash hunt

### DIFF
--- a/examples/AutoResearch/AutoResearchNet.cpp
+++ b/examples/AutoResearch/AutoResearchNet.cpp
@@ -17,6 +17,7 @@
 #if !(defined(FASTLED_AUTORESEARCH_LOW_MEMORY) && FASTLED_AUTORESEARCH_LOW_MEMORY)
 
 #include "AutoResearchNet.h"
+#include "FastLED.h"
 #include "fl/stl/json.h"
 #include "fl/log/log.h"
 
@@ -158,21 +159,29 @@ static bool startHttpServer() {
         return fl::asio::http::Response::ok("pong");
     });
 
+    // NOTE (FastLED#3588): these handlers execute ON the esp_http_server
+    // task, concurrently with the main loop. Building fl::json here
+    // reproducibly corrupted main-task json objects on classic ESP32
+    // (bisect: string-only handlers are stable, fl::json handlers crash
+    // the main task within one request). Until fl::json is audited for
+    // cross-task use, handlers format responses with fl::snprintf.
     s_http_server->get("/status", [](const fl::asio::http::Request&) {
-        fl::json json = fl::json::object();
-        json.set("uptime_ms", static_cast<int64_t>(millis()));
-        json.set("free_heap", static_cast<int64_t>(ESP.getFreeHeap()));
+        char body[128];
 #if defined(FL_IS_ESP_32S3)
-        json.set("chip", "esp32s3");
+        const char* chip = "esp32s3";
 #elif defined(FL_IS_ESP_32C6)
-        json.set("chip", "esp32c6");
+        const char* chip = "esp32c6";
 #elif defined(FL_IS_ESP_32C3)
-        json.set("chip", "esp32c3");
+        const char* chip = "esp32c3";
 #else
-        json.set("chip", "esp32");
+        const char* chip = "esp32";
 #endif
-        fl::asio::http::Response resp;
-        resp.json(json);
+        fl::snprintf(body, sizeof(body),
+                     "{\"uptime_ms\":%u,\"free_heap\":%u,\"chip\":\"%s\"}",
+                     static_cast<unsigned>(millis()),
+                     static_cast<unsigned>(ESP.getFreeHeap()), chip);
+        fl::asio::http::Response resp = fl::asio::http::Response::ok(body);
+        resp.header("Content-Type", "application/json");
         return resp;
     });
 
@@ -184,11 +193,10 @@ static bool startHttpServer() {
     });
 
     s_http_server->get("/leds", [](const fl::asio::http::Request&) {
-        fl::json json = fl::json::object();
-        json.set("num_leds", static_cast<int64_t>(10));
-        json.set("brightness", static_cast<int64_t>(64));
-        fl::asio::http::Response resp;
-        resp.json(json);
+        // Static body — see the fl::json cross-task note above (#3588).
+        fl::asio::http::Response resp =
+            fl::asio::http::Response::ok("{\"num_leds\":10,\"brightness\":64}");
+        resp.header("Content-Type", "application/json");
         return resp;
     });
 
@@ -234,7 +242,11 @@ static fl::json runHttpGetTest(const char* url, const char* test_name) {
 
     esp_http_client_config_t config = {};
     config.url = url;
-    config.timeout_ms = 5000;
+    // Must stay below the task-WDT window: esp_http_client_perform()
+    // blocks the loop task, and on single-core chips (ESP32-C6) a 5 s
+    // block starved the idle task -> WDT panic_abort mid-test
+    // (FastLED#3576 Phase 7 dual-device bench).
+    config.timeout_ms = 2000;
 
     esp_http_client_handle_t client = esp_http_client_init(&config);
     if (!client) {
@@ -335,6 +347,8 @@ fl::json runNetClientTest(const char* host_ip, uint16_t port) {
         }
         results.push_back(r);
     }
+
+    FastLED.watchdog().feed();  // between blocking HTTP tests (single-core WDT)
 
     // Test 2: GET /data
     {

--- a/examples/AutoResearch/AutoResearchRemoteSystemMethods.cpp
+++ b/examples/AutoResearch/AutoResearchRemoteSystemMethods.cpp
@@ -31,6 +31,13 @@
 #if FASTLED_ESP32_HAS_PARLIO
 #include "platforms/esp/32/drivers/parlio/parlio_engine.h"
 #endif
+FL_EXTERN_C_BEGIN
+// IWYU pragma: begin_keep
+#include "esp_heap_caps.h"  // ok platform headers - heapCheck RPC
+#include "freertos/FreeRTOS.h"  // ok platform headers - heapCheck RPC
+#include "freertos/task.h"  // ok platform headers - heapCheck RPC
+// IWYU pragma: end_keep
+FL_EXTERN_C_END
 #endif
 #include "fl/stl/optional.h"
 #include "fl/stl/json.h"
@@ -237,6 +244,23 @@ void AutoResearchRemoteControl::bindSystemMethods(fl::Remote& remote) {
     // investigation). Params: [{addr: <u32>, count?: 1-16}]. The caller
     // is expected to pass valid peripheral/SRAM addresses; an unmapped
     // address faults exactly as it would from any other code.
+    // "heapCheck" — heap integrity + stats (FastLED#3588 corruption
+    // bisect). heap_caps_check_integrity_all walks every block; with
+    // poisoning configured in the IDF libs it also validates canaries.
+#if defined(FL_IS_ESP32)
+    remote.bind("heapCheck", [](const fl::json& args) -> fl::json {
+        fl::json response = fl::json::object();
+        const bool intact = heap_caps_check_integrity_all(true);
+        response.set("success", true);
+        response.set("intact", intact);
+        response.set("free", static_cast<int64_t>(heap_caps_get_free_size(MALLOC_CAP_8BIT)));
+        response.set("minFree", static_cast<int64_t>(heap_caps_get_minimum_free_size(MALLOC_CAP_8BIT)));
+        response.set("largest", static_cast<int64_t>(heap_caps_get_largest_free_block(MALLOC_CAP_8BIT)));
+        response.set("loopStackHighWater", static_cast<int64_t>(uxTaskGetStackHighWaterMark(nullptr)));
+        return response;
+    });
+#endif
+
     remote.bind("peekMem", [this](const fl::json& args) -> fl::json {
         fl::json response = fl::json::object();
         if (!args.is_object() || !args.contains("addr") ||

--- a/src/fl/stl/allocator.h
+++ b/src/fl/stl/allocator.h
@@ -7,6 +7,7 @@
 #include "fl/stl/bit_cast.h"
 #include "fl/stl/stdint.h"
 #include "fl/stl/bitset.h"
+#include "fl/stl/detail/slab_mutex.h"
 #include "fl/stl/malloc.h"
 #include "fl/stl/align.h"
 #include "fl/stl/noexcept.h"
@@ -481,6 +482,9 @@ private:
     };
 
     Slab* mSlabs;
+    // Guards the slab list + block bitsets (FastLED#3588). A no-op on
+    // single-threaded platforms.
+    mutable fl::detail::slab_mutex mMutex;
     fl::size mTotalAllocated;
     fl::size mTotalDeallocated;
 
@@ -622,7 +626,15 @@ public:
         if (n == 0) {
             return nullptr;
         }
-        
+
+        // Thread safety (FastLED#3588): slab-backed containers
+        // (fl::map/set via allocator_slab) share a static per-type
+        // SlabAllocator across FreeRTOS tasks — e.g. the esp_http_server
+        // task building Response headers while the main loop mutates its
+        // own maps. Unsynchronized free-list/bitset updates corrupted
+        // the slab and crashed classic ESP32 under WiFi traffic.
+        fl::detail::slab_lock_guard guard(mMutex);
+
         // Try to allocate from slab first
         void* ptr = allocateFromSlab(n);
         if (ptr) {
@@ -642,7 +654,8 @@ public:
         if (!ptr) {
             return;
         }
-        
+        fl::detail::slab_lock_guard guard(mMutex); // see allocate()
+
         // Try to deallocate from slab first
         bool found_in_slab = false;
         for (Slab* slab = mSlabs; slab; slab = slab->next) {
@@ -679,6 +692,7 @@ public:
 
     // Cleanup all slabs
     void cleanup() FL_NO_EXCEPT {
+        fl::detail::slab_lock_guard guard(mMutex); // see allocate()
         while (mSlabs) {
             Slab* next = mSlabs->next;
             mSlabs->~Slab();

--- a/src/fl/stl/asio/http/server.cpp.hpp
+++ b/src/fl/stl/asio/http/server.cpp.hpp
@@ -846,6 +846,14 @@ bool Server::start(int port) {
 
     httpd_config_t config = HTTPD_DEFAULT_CONFIG();
     config.server_port = static_cast<u16>(port);
+    // Route handlers execute ON the httpd task and run full fl::json /
+    // fl::string / Response machinery. The IDF default stack (4 KB) is
+    // not enough for that: overflows landed in adjacent heap blocks and
+    // corrupted unrelated main-task objects (FastLED#3588 — classic
+    // ESP32 crashed building RPC responses while a client hammered the
+    // server). FreeRTOS heap-allocated task stacks give no early
+    // warning, so size generously.
+    config.stack_size = 8192;
 
     esp_err_t err = httpd_start(&s_esp_httpd, &config);
     if (err != ESP_OK) {

--- a/src/fl/stl/detail/slab_mutex.h
+++ b/src/fl/stl/detail/slab_mutex.h
@@ -1,0 +1,131 @@
+#pragma once
+// allow-include-after-namespace
+
+// IWYU pragma: private
+
+/// @file slab_mutex.h
+/// @brief Minimal mutex for the allocator layer (FastLED#3588).
+///
+/// fl/stl/allocator.h sits below vector/function in the include graph,
+/// and the full fl/stl/mutex.h platform chain circles back into those
+/// headers — so the slab allocator gets its own tiny lock with zero
+/// fl:: dependencies beyond noexcept.
+///
+/// Semantics: plain mutual exclusion, non-recursive, never used from
+/// ISRs (slab-backed containers are task-level constructs).
+
+#include "fl/stl/noexcept.h"
+
+#if defined(ESP32) || defined(ESP_PLATFORM)
+
+FL_EXTERN_C_BEGIN
+// IWYU pragma: begin_keep
+#include "freertos/FreeRTOS.h"
+#include "freertos/semphr.h"
+// IWYU pragma: end_keep
+FL_EXTERN_C_END
+
+namespace fl {
+namespace detail {
+
+class slab_mutex {
+  public:
+    slab_mutex() FL_NO_EXCEPT : mHandle(xSemaphoreCreateMutex()) {}
+    ~slab_mutex() FL_NO_EXCEPT {
+        if (mHandle) {
+            vSemaphoreDelete(mHandle);
+        }
+    }
+    slab_mutex(const slab_mutex &) FL_NO_EXCEPT = delete;
+    slab_mutex &operator=(const slab_mutex &) FL_NO_EXCEPT = delete;
+
+    void lock() FL_NO_EXCEPT {
+        // Scheduler not running yet (static init) → single-threaded,
+        // skip. Never called from ISRs by contract.
+        if (mHandle && xTaskGetSchedulerState() == taskSCHEDULER_RUNNING) {
+            (void)xSemaphoreTake(mHandle, portMAX_DELAY);
+        }
+    }
+    void unlock() FL_NO_EXCEPT {
+        if (mHandle && xTaskGetSchedulerState() == taskSCHEDULER_RUNNING) {
+            (void)xSemaphoreGive(mHandle);
+        }
+    }
+
+  private:
+    SemaphoreHandle_t mHandle;
+};
+
+} // namespace detail
+} // namespace fl
+
+#elif defined(FASTLED_TESTING) || defined(FL_IS_STUB) || defined(_WIN32) || \
+    defined(__linux__) || defined(__APPLE__)
+
+#include "fl/stl/atomic.h"
+
+namespace fl {
+namespace detail {
+
+/// Host build: atomic spinlock. Slab critical sections are short
+/// (bitset scans); on a preemptive host OS brief spinning is fine and
+/// avoids pulling <mutex> or the fl/stl/mutex.h chain (include cycle)
+/// into the allocator layer.
+class slab_mutex {
+  public:
+    slab_mutex() FL_NO_EXCEPT : mFlag(0) {}
+    slab_mutex(const slab_mutex &) FL_NO_EXCEPT = delete;
+    slab_mutex &operator=(const slab_mutex &) FL_NO_EXCEPT = delete;
+
+    void lock() FL_NO_EXCEPT {
+        int expected = 0;
+        while (!mFlag.compare_exchange_weak(expected, 1)) {
+            expected = 0;
+        }
+    }
+    void unlock() FL_NO_EXCEPT { mFlag.store(0); }
+
+  private:
+    fl::atomic<int> mFlag;
+};
+
+} // namespace detail
+} // namespace fl
+
+#else
+
+namespace fl {
+namespace detail {
+
+/// Single-threaded MCUs: no-op.
+class slab_mutex {
+  public:
+    slab_mutex() FL_NO_EXCEPT = default;
+    void lock() FL_NO_EXCEPT {}
+    void unlock() FL_NO_EXCEPT {}
+};
+
+} // namespace detail
+} // namespace fl
+
+#endif
+
+namespace fl {
+namespace detail {
+
+/// RAII guard for slab_mutex.
+class slab_lock_guard {
+  public:
+    explicit slab_lock_guard(slab_mutex &m) FL_NO_EXCEPT : mMutex(m) {
+        mMutex.lock();
+    }
+    ~slab_lock_guard() FL_NO_EXCEPT { mMutex.unlock(); }
+    slab_lock_guard(const slab_lock_guard &) FL_NO_EXCEPT = delete;
+    slab_lock_guard &operator=(const slab_lock_guard &) FL_NO_EXCEPT = delete;
+
+  private:
+    slab_mutex &mMutex;
+};
+
+} // namespace detail
+} // namespace fl

--- a/src/fl/stl/detail/string_holder.cpp.hpp
+++ b/src/fl/stl/detail/string_holder.cpp.hpp
@@ -11,12 +11,25 @@
 namespace fl {
 
 // StringHolder implementations
-// Assumes fl::malloc/fl::realloc/fl::free cannot return NULL (OOM is terminal)
+//
+// OOM hardening (FastLED#3588): on classic ESP32 with WiFi + an HTTP
+// server active, free heap drops below 20 KB and fl::malloc genuinely
+// returns NULL. The previous "OOM is terminal" assumption turned that
+// into UB (writes through null; realloc leak plus null mData with a
+// stale nonzero capacity) and crashed unattended bench devices. On
+// failure a holder now degrades to a coherent empty state
+// (mData=null, mLength=0, mCapacity=0) and grow() keeps the old
+// buffer.
 
 StringHolder::StringHolder(const char *str)
     : mData((char*)fl::malloc(strlen(str) + 1))
     , mLength(strlen(str))
     , mCapacity(mLength + 1) {
+    if (mData == nullptr) {
+        mLength = 0;
+        mCapacity = 0;
+        return;
+    }
     fl::memcpy(mData, str, mLength);
     mData[mLength] = '\0';
 }
@@ -25,6 +38,11 @@ StringHolder::StringHolder(size length)
     : mData((char*)fl::malloc(length + 1))
     , mLength(length)
     , mCapacity(length + 1) {
+    if (mData == nullptr) {
+        mLength = 0;
+        mCapacity = 0;
+        return;
+    }
     mData[mLength] = '\0';
 }
 
@@ -32,6 +50,11 @@ StringHolder::StringHolder(const char *str, size length)
     : mData((char*)fl::malloc(length + 1))
     , mLength(length)
     , mCapacity(length + 1) {
+    if (mData == nullptr) {
+        mLength = 0;
+        mCapacity = 0;
+        return;
+    }
     fl::memcpy(mData, str, mLength);
     mData[mLength] = '\0';
 }
@@ -48,9 +71,14 @@ void StringHolder::grow(size newLength) {
         return;
     }
 
-    // Use fl::realloc for efficient growth without memory move
-    // fl::realloc may expand in place or copy to larger block as needed
-    mData = (char*)fl::realloc(mData, newLength + 1);
+    // Use fl::realloc for efficient growth without memory move.
+    // Keep the old buffer if the allocation fails — the string simply
+    // does not grow (callers observe the unchanged length).
+    char *grown = (char*)fl::realloc(mData, newLength + 1);
+    if (grown == nullptr) {
+        return;
+    }
+    mData = grown;
     mLength = newLength;
     mCapacity = newLength + 1;
     mData[mLength] = '\0'; // Ensure null-termination

--- a/src/fl/stl/shared_ptr.h
+++ b/src/fl/stl/shared_ptr.h
@@ -413,6 +413,13 @@ private:
 template<typename T, typename... Args>
 shared_ptr<T> make_shared(Args&&... args) FL_NO_EXCEPT {
     auto* control = new detail::InlinedControlBlock<T>();
+    if (control == nullptr) {
+        // OOM (embedded new returns null with -fno-exceptions): degrade
+        // to an empty shared_ptr instead of placement-constructing at a
+        // garbage offset from null (FastLED#3588 — crashed classic
+        // ESP32 when WiFi + HTTP server pushed free heap under 20 KB).
+        return shared_ptr<T>();
+    }
     T* obj = control->get_object();
     new(obj) T(fl::forward<Args>(args)...);  // Placement new
     control->object_constructed = true;
@@ -422,7 +429,14 @@ shared_ptr<T> make_shared(Args&&... args) FL_NO_EXCEPT {
 template<typename T, typename Deleter, typename... Args>
 shared_ptr<T> make_shared_with_deleter(Deleter d, Args&&... args) FL_NO_EXCEPT {
     T* obj = new T(fl::forward<Args>(args)...);
+    if (obj == nullptr) {
+        return shared_ptr<T>(); // OOM — see make_shared
+    }
     auto* control = new detail::ControlBlock<T, Deleter>(obj, d);
+    if (control == nullptr) {
+        d(obj);
+        return shared_ptr<T>(); // OOM — see make_shared
+    }
     //new(control->get_object()) T(fl::forward<Args>(args)...);
     //control->object_constructed = true;
     return shared_ptr<T>(obj, control, detail::make_shared_tag{});
@@ -440,7 +454,14 @@ shared_ptr<T> make_shared_no_tracking(T& obj) FL_NO_EXCEPT {
 template<typename T>
 shared_ptr<T> make_shared_array(size_t n) FL_NO_EXCEPT {
     T* arr = new T[n]();  // Zero-initialize the array
+    if (arr == nullptr) {
+        return shared_ptr<T>(); // OOM — see make_shared
+    }
     auto* control = new detail::ControlBlock<T, detail::array_delete<T>>(arr, detail::array_delete<T>{});
+    if (control == nullptr) {
+        delete[] arr;
+        return shared_ptr<T>(); // OOM — see make_shared
+    }
     return shared_ptr<T>(arr, control, detail::make_shared_tag{});
 }
 

--- a/tests/fl/stl/json_cross_thread.cpp
+++ b/tests/fl/stl/json_cross_thread.cpp
@@ -1,0 +1,107 @@
+// Cross-thread stress test for fl::json / fl::string / fl::map
+// (FastLED#3588). On classic ESP32, an esp_http_server task building
+// Request/Response objects (fl::string + fl::map) concurrently with the
+// main loop building fl::json RPC responses corrupts main-task json
+// objects (LoadProhibited on garbage pointers inside shared_ptr
+// machinery). This test reproduces that workload shape host-side where
+// ASAN/UBSAN (debug mode) can catch the culprit.
+//
+// Each thread uses ONLY its own objects — no shared containers — so any
+// sanitizer hit or crash indicates hidden shared state inside the fl::
+// implementation (allocator pools, sentinels, COW holders, ...).
+
+#include "test.h"
+
+#include "fl/stl/json.h"
+#include "fl/stl/map.h"
+#include "fl/stl/string.h"
+
+#include "fl/stl/atomic.h"
+
+#include <thread>  // ok include - host-only stress test; fl::thread not available
+
+FL_TEST_FILE(FL_FILEPATH) {
+
+namespace {
+
+// Mimics the AutoResearch runSingleTest response builder (main task).
+void jsonResponderWorkload(fl::atomic<bool>& stop, fl::atomic<int>& iters) {
+    while (!stop.load()) {
+        fl::json response = fl::json::object();
+        response.set("driver", "I2S");
+        response.set("passed", true);
+        fl::json patterns = fl::json::array();
+        for (int p = 0; p < 4; ++p) {
+            fl::json entry = fl::json::object();
+            entry.set("runNumber", static_cast<int64_t>(p));
+            entry.set("totalLeds", static_cast<int64_t>(10));
+            entry.set("decodeBytes", static_cast<int64_t>(30 * p));
+            entry.set("captureWaitResult", static_cast<int64_t>(1));
+            patterns.push_back(entry);
+        }
+        response.set("patterns", patterns);
+        response.set("duration_ms", static_cast<int64_t>(699));
+        fl::string serialized = response.to_string();
+        FL_CHECK(serialized.size() > 0);
+        iters.fetch_add(1);
+    }
+}
+
+// Mimics the esp_http_server glue (httpd task): Request headers/query
+// maps + response strings.
+void httpHandlerWorkload(fl::atomic<bool>& stop, fl::atomic<int>& iters) {
+    while (!stop.load()) {
+        fl::map<fl::string, fl::string> headers;
+        headers["Host"] = "192.168.4.1";
+        headers["User-Agent"] = "esp-idf/5.5 http_client";
+        headers["Accept"] = "*/*";
+        headers["Content-Type"] = "application/json";
+        fl::map<fl::string, fl::string> query;
+        query["a"] = "1";
+        query["b"] = "2";
+
+        fl::json body = fl::json::object();
+        body.set("uptime_ms", static_cast<int64_t>(123456));
+        body.set("free_heap", static_cast<int64_t>(25000));
+        body.set("chip", "esp32");
+        fl::string serialized = body.to_string();
+        FL_CHECK(serialized.size() > 0);
+
+        fl::string status_line;
+        status_line += "HTTP/1.1 200 OK\r\n";
+        for (auto it = headers.begin(); it != headers.end(); ++it) {
+            status_line += it->first;
+            status_line += ": ";
+            status_line += it->second;
+            status_line += "\r\n";
+        }
+        FL_CHECK(status_line.size() > 20);
+        iters.fetch_add(1);
+    }
+}
+
+} // namespace
+
+FL_TEST_CASE("json + map/string workloads race-free across threads") {
+    fl::atomic<bool> stop(false);
+    fl::atomic<int> json_iters(0);
+    fl::atomic<int> http_iters(0);
+
+    std::thread responder([&]() { jsonResponderWorkload(stop, json_iters); });  // okay std namespace - fl::thread not available
+    std::thread handler1([&]() { httpHandlerWorkload(stop, http_iters); });     // okay std namespace - fl::thread not available
+    std::thread handler2([&]() { httpHandlerWorkload(stop, http_iters); });     // okay std namespace - fl::thread not available
+
+    // Run long enough for allocator/COW interleavings to collide.
+    while (json_iters.load() < 2000 || http_iters.load() < 2000) {
+        std::this_thread::yield();  // okay std namespace - host-only stress test
+    }
+    stop.store(true);
+    responder.join();
+    handler1.join();
+    handler2.join();
+
+    FL_CHECK(json_iters.load() >= 2000);
+    FL_CHECK(http_iters.load() >= 2000);
+}
+
+}


### PR DESCRIPTION
Hardening batch from root-causing the classic-ESP32 crash under WiFi + HTTP server + client traffic (#3588). The exact corrupter is still open (full forensic record on the issue); every change here is independently correct and verified.

## Library fixes
- **StringHolder OOM**: alloc failure → coherent empty state instead of UB (the code carried a literal "OOM is terminal" assumption; under WiFi+server classic ESP32 drops below 20 KB free and `fl::malloc` genuinely returns null; `grow()` also leaked the old buffer and left a null `mData` with stale capacity).
- **`make_shared` family null-safety**: embedded `new` returns null with `-fno-exceptions`; the factories placement-constructed at an offset from null. Now return an empty `shared_ptr`.
- **SlabAllocator thread safety**: the static per-type slab behind `fl::map/set/multi_map/multi_set` is shared across FreeRTOS tasks (esp_http_server builds Request/Response header maps on its own task) with zero synchronization. New `fl::detail::slab_mutex` (FreeRTOS mutex on ESP32 / atomic spinlock on host / no-op on single-threaded MCUs) guards allocate/deallocate/cleanup. The full `fl/stl/mutex.h` chain can't be used at the allocator layer (include cycle).
- **asio http Server (ESP32)**: httpd task stack 4 KB (IDF default) → 8 KB; route handlers execute ON that task running full fl:: machinery.

## Bench fixes (AutoResearch)
- HTTP client timeout 5 s → 2 s + WDT feed between blocking performs — **fixes a reproducible ESP32-C6 tick-hook WDT `panic_abort`** during `runNetClientTest` (single-core starvation, decoded from the RISC-V crash regs).
- Server route handlers format responses with `fl::snprintf` instead of building `fl::json` on the httpd task (defensive pending #3588 root cause).

## Regression net
- `tests/fl/stl/json_cross_thread.cpp`: cross-thread fl::json + map/string stress mirroring the device workload. ASAN-clean on host — the remaining corruption needs ESP32-specific machinery (documented on the issue).

Host: 347/347; lint clean; esp32dev/esp32c6 compile clean. C6 traffic loop now survives; the WROOM crash under concurrent traffic remains open in #3588.

Refs #3588, #3576.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new remote health check that reports heap integrity and memory/stack statistics on supported devices.

* **Bug Fixes**
  * Improved HTTP server stability by increasing task stack size and avoiding fragile JSON construction in request handlers.
  * Hardened string and shared-memory utilities to handle allocation failures safely.
  * Added thread-safe locking for slab allocations to reduce cross-task corruption issues.

* **Tests**
  * Added a cross-thread stress test for JSON, string, and map usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->