### PR TITLE
fix(autoresearch): extend 16 KB loop stack to all ESP32 variants (#3576 Phase 9)

### DIFF
--- a/examples/AutoResearch/AutoResearch.ino
+++ b/examples/AutoResearch/AutoResearch.ino
@@ -230,7 +230,11 @@ void loop()  { autoResearchLowMemoryLoop(); }
 // capture tier the extra 8 KB of stack exhausted the heap outright
 // (`fl::aligned_alloc` returned null inside fl::json::set →
 // StoreProhibited at 0x400d2ece). Keep the two changes paired.
-#if defined(FL_IS_ESP_32DEV) && defined(SET_LOOP_TASK_STACK_SIZE)
+// FastLED#3576 Phase 9: extended from classic-only to all ESP32
+// variants — ESP32-P4 hit the same ~8 KB-deep chain and died with a
+// "Stack protection fault" in loopTask (stack dump full of wave8 LUT
+// data) on its default 8 KB stack during SPI/UART/PARLIO tests.
+#if defined(FL_IS_ESP32) && defined(SET_LOOP_TASK_STACK_SIZE)
 SET_LOOP_TASK_STACK_SIZE(16 * 1024);
 #endif
 


### PR DESCRIPTION
The #3569 loop-stack fix was gated to classic ESP32; ESP32-P4 ran the same ~8 KB-deep test chain on the 8 KB Arduino default and hit a hard **Stack protection fault** in loopTask (stack dump full of wave8 LUT bytes) on every SPI/UART/PARLIO test.

Bench verification (P4, COM25, GPIO5→6 jumper): **SPI and UART went 0/4-with-panic → 4/4 byte-exact**; RMT stays 4/4. PARLIO now runs without crashing but its capture failure matches the C6 signature — #3586 is cross-chip.

Refs #3576, #3569, #3586.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Broadened support for the larger loop task stack setting to cover the full ESP32 family, improving stability on more board variants.
  * Reduced the risk of stack protection faults during SPI, UART, and PARLIO testing on affected ESP32 devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->