### PR TITLE
fix(rmt_rx): retry begin() without DMA when the DMA arm path fails (#3591)

### DIFF
--- a/src/platforms/esp/32/drivers/rmt_rx/rmt_rx_5/rmt_rx_channel_5.cpp.hpp
+++ b/src/platforms/esp/32/drivers/rmt_rx/rmt_rx_5/rmt_rx_channel_5.cpp.hpp
@@ -636,6 +636,24 @@ class RmtRxChannelImpl : public RmtRxChannel {
     }
 
     bool begin(const RxConfig &config) FL_NO_EXCEPT override {
+        if (beginImpl(config)) {
+            return true;
+        }
+        // FastLED#3591 — on ESP32-S3 the DMA-mode arm path can fail
+        // (bench: every non-RMT driver's capture returned begin=false
+        // with use_dma=true while the same capture succeeds without
+        // DMA). DMA only extends the capture window; a shorter window
+        // beats no capture, so retry once in non-DMA mode.
+        if (config.use_dma) {
+            FL_WARN_F("[RMT RX] begin() failed in DMA mode — retrying without DMA");
+            RxConfig retry = config;
+            retry.use_dma = false;
+            return beginImpl(retry);
+        }
+        return false;
+    }
+
+    bool beginImpl(const RxConfig &config) FL_NO_EXCEPT {
         // FastLED#3569 — clamp the DMA request BEFORE the rebuild
         // comparison below. Chips without RMT DMA (classic ESP32, C3,
         // C6, …) hard-fail rmt_new_rx_channel() when with_dma is


### PR DESCRIPTION
On ESP32-S3 (the only bench chip with RMT RX DMA silicon), every non-RMT driver's loopback capture failed to arm: the harness passes `use_dma=true` for non-RMT TX paths and the DMA-mode `begin()` returned false silently — SPI/UART/LCD_CLOCKLESS/LCD_SPI all reported `captureWaitResult=-1` while RMT (non-DMA loopback) passed 4/4. Bisect proof: forcing `use_dma=false` flipped UART to 4/4 instantly.

DMA only extends the capture window; a shorter window beats no capture. `begin()` now retries once in non-DMA mode (with a warning) when the DMA attempt fails. Body moved to `beginImpl()`; DMA-successful and non-DMA paths are unchanged.

## Bench matrix after the fix
| Board | Result |
|-------|--------|
| S3 (GPIO1→2) | UART 0/4 → **4/4**, LCD_CLOCKLESS 0/4 → **4/4**, LCD_SPI 0/4 → **4/4**, RMT 4/4; SPI arms now but 0-edge (transmit-not-captured family → #3586) |
| WROOM | I2S / I2S0 / RMT / UART / SPI — 4/4 each |
| C6 | SPI / UART — 4/4 |
| P4 | RMT / SPI / UART — 4/4 |

Host: 347/347; lint clean.

Refs #3591, #3576, #3586.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved receiver startup reliability by automatically retrying initialization in non-DMA mode if DMA-based setup fails.
  * Added clearer logging when DMA initialization cannot be completed, helping diagnose capture issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->