### PR TITLE
fix(parlio): derive wave8 clock from chipset timing + edge-probe diagnostics (#3586)

### DIFF
--- a/examples/AutoResearch/AutoResearchEdgeProbe.cpp
+++ b/examples/AutoResearch/AutoResearchEdgeProbe.cpp
@@ -1,0 +1,190 @@
+// AutoResearch edge probe implementation (FastLED#3586 tooling).
+// See AutoResearchEdgeProbe.h.
+
+#include "fl/system/sketch_macros.h"
+
+#if SKETCH_HAS_LOTS_OF_MEMORY
+
+#include "AutoResearchEdgeProbe.h"
+
+#include "platforms/is_platform.h"
+
+#ifdef FL_IS_ESP32
+
+#include <Arduino.h>
+#include "esp_cpu.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "soc/io_mux_reg.h"
+#include "soc/gpio_periph.h"
+#include "soc/gpio_reg.h"
+
+namespace {
+
+constexpr fl::u32 kMaxStamps = 200;
+volatile fl::u32 g_stamps[kMaxStamps];
+volatile fl::u32 g_count = 0;
+volatile fl::u32 g_selftest_edges = 0;
+volatile fl::u32 g_probe_state = 0; // 1=task started 2=triggered 3=sample done
+volatile fl::u32 g_rmt_live[6] = {0};
+int g_pin = -1;
+
+// Cycle counter. NOTE: plain `rdcycle` is an ILLEGAL INSTRUCTION on
+// Espressif RISC-V cores (C3/C6/P4 don't implement the standard cycle
+// CSR — they use a custom performance-counter CSR); esp_cpu_get_cycle_count()
+// reads the right register on every ESP32 variant.
+static inline fl::u32 probeCycles() {
+    return static_cast<fl::u32>(esp_cpu_get_cycle_count());
+}
+
+void ARDUINO_ISR_ATTR edgeIsr() {
+    const fl::u32 i = g_count;
+    if (i < kMaxStamps) {
+        // Level BEFORE this edge = inverse of the level now.
+        const fl::u32 lvl_now = static_cast<fl::u32>(digitalRead(g_pin));
+        g_stamps[i] = ((lvl_now ^ 1u) << 31) | (probeCycles() & 0x7FFFFFFFu);
+        g_count = i + 1;
+    }
+}
+
+} // namespace
+
+void edgeProbeArm(int pin) {
+    if (g_pin >= 0) {
+        detachInterrupt(digitalPinToInterrupt(g_pin));
+    }
+    g_count = 0;
+    g_pin = pin;
+    pinMode(pin, INPUT);
+    attachInterrupt(digitalPinToInterrupt(pin), edgeIsr, CHANGE);
+    // Self-test: flip the pad's pull resistors to generate edges the
+    // ISR must record. Proves the interrupt path end-to-end without
+    // touching the output driver (jumpered TX pins stay unharmed).
+    for (int i = 0; i < 4; ++i) {
+        pinMode(pin, INPUT_PULLUP);
+        delayMicroseconds(50);
+        pinMode(pin, INPUT_PULLDOWN);
+        delayMicroseconds(50);
+    }
+    g_selftest_edges = g_count;
+    g_count = 0; // restart clean for the real capture
+
+    // TX drivers reconfigure the probed pad when the test starts,
+    // clearing the input-enable and the interrupt binding. Spawn a
+    // one-shot task that re-enables the INPUT stage mid-test (pure
+    // IO_MUX IE bit — the output routing is untouched) and re-attaches
+    // the interrupt, so patterns after the first get recorded.
+    xTaskCreate([](void *arg) {
+        const int pin = static_cast<int>(reinterpret_cast<intptr_t>(arg));
+        g_probe_state = 1;
+        vTaskDelay(pdMS_TO_TICKS(150));
+        PIN_INPUT_ENABLE(GPIO_PIN_MUX_REG[pin]);
+        // Triggered tight-loop run-length sampler: per-edge interrupts
+        // can't resolve sub-µs LED pulses (~4 µs ISR latency), but a
+        // spin loop reading GPIO_IN can. TX is DMA/ISR-driven, so
+        // starving lower-priority tasks doesn't stop the waveform.
+        fl::u32 mask;
+        volatile fl::u32 *in_reg;
+        if (pin < 32) {
+            mask = 1u << pin;
+            in_reg = reinterpret_cast<volatile fl::u32 *>(GPIO_IN_REG); // ok reinterpret cast - SoC GPIO input register
+        } else {
+#ifdef GPIO_IN1_REG
+            mask = 1u << (pin - 32);
+            in_reg = reinterpret_cast<volatile fl::u32 *>(GPIO_IN1_REG); // ok reinterpret cast - SoC GPIO input register (pins 32+)
+#else
+            mask = 1u << (pin & 31);
+            in_reg = reinterpret_cast<volatile fl::u32 *>(GPIO_IN_REG); // ok reinterpret cast - SoC GPIO input register
+#endif
+        }
+        const fl::u32 idle = *in_reg & mask;
+        // Wait up to ~4 s for the line to move. LED frames can be
+        // shorter than a tick, so poll in tight ~900 µs bursts with a
+        // 1-tick yield between them (a lone vTaskDelay(1) poll misses
+        // whole frames and only sees the settled DC level).
+        bool triggered = false;
+        const fl::u32 burst_cycles = edgeProbeCpuMhz() * 900u;
+        for (int t = 0; t < 2000 && !triggered; ++t) {
+            // Drivers may clear the pad's input-enable on every
+            // pattern re-init — keep re-asserting it.
+            PIN_INPUT_ENABLE(GPIO_PIN_MUX_REG[pin]);
+            const fl::u32 b0 = probeCycles();
+            const fl::u32 lvl0 = *in_reg & mask;
+            while (probeCycles() - b0 < burst_cycles) {
+                if ((*in_reg & mask) != lvl0) { triggered = true; break; }
+            }
+            if (!triggered) {
+                vTaskDelay(1);
+            }
+        }
+        if (triggered) {
+            g_probe_state = 2;
+#if defined(CONFIG_IDF_TARGET_ESP32C6)
+            // Live RMT-RX registers at the instant the waveform is on
+            // the wire (FastLED#3586).
+            g_rmt_live[0] = *reinterpret_cast<volatile fl::u32 *>(0x60006038); // ok reinterpret cast - RMT_INT_RAW
+            g_rmt_live[1] = *reinterpret_cast<volatile fl::u32 *>(0x60006030); // ok reinterpret cast - CH2STATUS
+            g_rmt_live[2] = *reinterpret_cast<volatile fl::u32 *>(0x60006034); // ok reinterpret cast - CH3STATUS
+            g_rmt_live[3] = *reinterpret_cast<volatile fl::u32 *>(0x60006024); // ok reinterpret cast - CH2 RX_CONF1
+#endif
+            fl::u32 idx = 0;
+            fl::u32 prev = *in_reg & mask;
+            fl::u32 last_edge = probeCycles();
+            const fl::u32 start = last_edge;
+            const fl::u32 budget = edgeProbeCpuMhz() * 1000u * 8u; // 8 ms
+            for (;;) {
+                const fl::u32 now = probeCycles();
+                if (now - start > budget) break;
+                const fl::u32 cur = *in_reg & mask;
+                if (cur != prev) {
+                    if (idx < kMaxStamps) {
+                        g_stamps[idx] = ((prev ? 1u : 0u) << 31) | (now & 0x7FFFFFFFu);
+                        ++idx;
+                    }
+                    last_edge = now;
+                    prev = cur;
+                }
+            }
+            g_count = idx;
+#if defined(CONFIG_IDF_TARGET_ESP32C6)
+            // Second snapshot ~8 ms later (post-frame): did the RMT
+            // receiver's interrupt lines fire at all during the frame?
+            g_rmt_live[4] = *reinterpret_cast<volatile fl::u32 *>(0x60006038); // ok reinterpret cast - RMT_INT_RAW post
+            g_rmt_live[5] = *reinterpret_cast<volatile fl::u32 *>(0x60006030); // ok reinterpret cast - CH2STATUS post
+#endif
+            g_probe_state = 3;
+        }
+        vTaskDelete(nullptr);
+    }, "edgeprobe_rearm", 3072, reinterpret_cast<void *>(static_cast<intptr_t>(pin)), 20, nullptr);
+}
+
+const fl::u32 *edgeProbeStamps(fl::u32 &count) {
+    count = g_count;
+    return const_cast<const fl::u32 *>(g_stamps);
+}
+
+fl::u32 edgeProbeSelfTestEdges() { return g_selftest_edges; }
+
+fl::u32 edgeProbeState() { return g_probe_state; }
+
+const fl::u32 *edgeProbeRmtLive() { return const_cast<const fl::u32 *>(g_rmt_live); }
+
+fl::u32 edgeProbeCpuMhz() {
+    return static_cast<fl::u32>(getCpuFrequencyMhz());
+}
+
+#else // !FL_IS_ESP32
+
+void edgeProbeArm(int) {}
+const fl::u32 *edgeProbeStamps(fl::u32 &count) {
+    count = 0;
+    return nullptr;
+}
+fl::u32 edgeProbeCpuMhz() { return 1; }
+fl::u32 edgeProbeSelfTestEdges() { return 0; }
+fl::u32 edgeProbeState() { return 0; }
+const fl::u32 *edgeProbeRmtLive() { static const fl::u32 z[4] = {0}; return z; }
+
+#endif // FL_IS_ESP32
+
+#endif // SKETCH_HAS_LOTS_OF_MEMORY

--- a/examples/AutoResearch/AutoResearchEdgeProbe.h
+++ b/examples/AutoResearch/AutoResearchEdgeProbe.h
@@ -1,0 +1,29 @@
+// AutoResearch edge probe (FastLED#3586 bring-up tooling).
+//
+// A GPIO any-edge ISR that timestamps up to 200 edges with the CPU
+// cycle counter — an in-firmware logic probe for "the driver transmits
+// but the capture backend records nothing" investigations. Armed via
+// the edgeProbe RPC, read back via edgeProbeRead.
+
+#pragma once
+
+#include "fl/stl/int.h"
+
+/// Arm the probe on a pin (re-arming resets the buffer).
+void edgeProbeArm(int pin);
+
+/// Timestamp buffer: entry = (level_before_edge << 31) | cycle_count.
+/// Returns the buffer; count receives the number of valid entries.
+const fl::u32 *edgeProbeStamps(fl::u32 &count);
+
+/// CPU frequency in MHz for cycle→ns conversion.
+fl::u32 edgeProbeCpuMhz();
+
+/// Edges recorded by the arm-time pull-toggle self-test.
+fl::u32 edgeProbeSelfTestEdges();
+
+/// Probe task progress: 0=not started 1=started 2=triggered 3=sampled.
+fl::u32 edgeProbeState();
+
+/// RMT registers snapshotted at trigger time (INT_RAW, CH2STATUS, CH3STATUS, CH2_RX_CONF1).
+const fl::u32 *edgeProbeRmtLive();

--- a/examples/AutoResearch/AutoResearchRemoteSystemMethods.cpp
+++ b/examples/AutoResearch/AutoResearchRemoteSystemMethods.cpp
@@ -23,6 +23,7 @@
 #include "Common.h"
 #include "AutoResearchTest.h"
 #include "AutoResearchHelpers.h"
+#include "AutoResearchEdgeProbe.h"
 #include "fl/stl/sstream.h"
 #include "fl/stl/unique_ptr.h"
 #include "platforms/is_platform.h"
@@ -30,6 +31,11 @@
 #include "platforms/esp/32/feature_flags/enabled.h"
 #if FASTLED_ESP32_HAS_PARLIO
 #include "platforms/esp/32/drivers/parlio/parlio_engine.h"
+FL_EXTERN_C_BEGIN
+// IWYU pragma: begin_keep
+#include "driver/parlio_tx.h"  // ok platform headers - parlioRawTest RPC
+// IWYU pragma: end_keep
+FL_EXTERN_C_END
 #endif
 FL_EXTERN_C_BEGIN
 // IWYU pragma: begin_keep
@@ -244,6 +250,140 @@ void AutoResearchRemoteControl::bindSystemMethods(fl::Remote& remote) {
     // investigation). Params: [{addr: <u32>, count?: 1-16}]. The caller
     // is expected to pass valid peripheral/SRAM addresses; an unmapped
     // address faults exactly as it would from any other code.
+    // "parlioRawTest" — minimal IDF parlio TX (FastLED#3586): 1-bit
+    // unit @ requested clock on a pin, transmit an alternating pattern.
+    // Bypasses the FastLED engine completely to split engine bugs from
+    // IDF-driver/silicon behavior.
+#if defined(FL_IS_ESP32) && FASTLED_ESP32_HAS_PARLIO
+    remote.bind("parlioRawTest", [](const fl::json& args) -> fl::json {
+        fl::json response = fl::json::object();
+        int pin = 1;
+        int hz = 8000000;
+        int width = 1;
+        int pattern = 0xAA;
+        int qnb = 0;
+        int mts = 1024;
+        int burst = 0;
+        int depth = 4;
+        int chunks = 1;
+        if (args.is_object()) {
+            if (args.contains("pin") && args["pin"].is_int()) pin = (int)args["pin"].as_int().value();
+            if (args.contains("hz") && args["hz"].is_int()) hz = (int)args["hz"].as_int().value();
+            if (args.contains("width") && args["width"].is_int()) width = (int)args["width"].as_int().value();
+            if (args.contains("pattern") && args["pattern"].is_int()) pattern = (int)args["pattern"].as_int().value();
+            if (args.contains("qnb") && args["qnb"].is_int()) qnb = (int)args["qnb"].as_int().value();
+            if (args.contains("mts") && args["mts"].is_int()) mts = (int)args["mts"].as_int().value();
+            if (args.contains("burst") && args["burst"].is_int()) burst = (int)args["burst"].as_int().value();
+            if (args.contains("depth") && args["depth"].is_int()) depth = (int)args["depth"].as_int().value();
+            if (args.contains("chunks") && args["chunks"].is_int()) chunks = (int)args["chunks"].as_int().value();
+        }
+        parlio_tx_unit_config_t cfg = {};
+        cfg.clk_src = PARLIO_CLK_SRC_DEFAULT;
+        cfg.data_width = (size_t)width;
+        cfg.clk_in_gpio_num = (gpio_num_t)-1;
+        cfg.clk_out_gpio_num = (gpio_num_t)-1;
+        cfg.valid_gpio_num = (gpio_num_t)-1;
+        cfg.trans_queue_depth = (size_t)depth;
+        cfg.max_transfer_size = (size_t)mts;
+        cfg.output_clk_freq_hz = (uint32_t)hz;
+        cfg.sample_edge = PARLIO_SAMPLE_EDGE_POS;
+        cfg.bit_pack_order = PARLIO_BIT_PACK_ORDER_MSB;
+        if (burst > 0) cfg.dma_burst_size = (size_t)burst;
+        for (int i = 0; i < 16; ++i) cfg.data_gpio_nums[i] = (gpio_num_t)-1;
+        cfg.data_gpio_nums[0] = (gpio_num_t)pin;
+        parlio_tx_unit_handle_t unit = nullptr;
+        esp_err_t err = parlio_new_tx_unit(&cfg, &unit);
+        if (err != ESP_OK) {
+            response.set("success", false);
+            response.set("error", esp_err_to_name(err));
+            return response;
+        }
+        err = parlio_tx_unit_enable(unit);
+        static uint8_t buf[512];
+        for (int i = 0; i < 512; ++i) buf[i] = (uint8_t)pattern;
+        parlio_transmit_config_t tcfg = {};
+        tcfg.idle_value = 0;
+        tcfg.flags.queue_nonblocking = qnb ? 1 : 0;
+        if (burst > 0) {
+            // dma_burst_size is a unit-config field; already applied below via cfg2 hack? No —
+            // it must be set before creation; handled via the 'burst' arg at cfg time.
+        }
+        esp_err_t terr = ESP_OK;
+        const size_t chunk_bytes = 512 / (chunks > 0 ? chunks : 1);
+        // Repeat for ~3 s so the edge-probe task (which re-arms 150 ms
+        // after the RPC) always overlaps live transmissions.
+        for (int rep = 0; rep < 300 && terr == ESP_OK; ++rep) {
+            for (int c = 0; c < chunks && terr == ESP_OK; ++c) {
+                terr = parlio_tx_unit_transmit(unit, buf + c * chunk_bytes, chunk_bytes * 8, &tcfg);
+            }
+            if (terr == ESP_OK) {
+                (void)parlio_tx_unit_wait_all_done(unit, 100);
+            }
+            vTaskDelay(pdMS_TO_TICKS(10));
+        }
+        esp_err_t werr = parlio_tx_unit_wait_all_done(unit, 1000);
+        parlio_tx_unit_disable(unit);
+        parlio_del_tx_unit(unit);
+        response.set("success", true);
+        response.set("enableErr", esp_err_to_name(err));
+        response.set("txErr", esp_err_to_name(terr));
+        response.set("waitErr", esp_err_to_name(werr));
+        return response;
+    });
+#endif
+
+    // "edgeProbe" / "edgeProbeRead" — ISR-based edge recorder
+    // (FastLED#3586 bring-up): arms a GPIO any-edge interrupt that
+    // timestamps up to 200 edges with the cycle counter. Arm it, run a
+    // test, then read back exact pulse widths — a 6-ns logic probe for
+    // "transmits but capture sees nothing" investigations.
+#if defined(FL_IS_ESP32)
+    remote.bind("edgeProbe", [](const fl::json& args) -> fl::json {
+        fl::json response = fl::json::object();
+        int pin = 0;
+        if (args.is_object() && args.contains("pin") && args["pin"].is_int()) {
+            pin = static_cast<int>(args["pin"].as_int().value());
+        }
+        edgeProbeArm(pin);
+        response.set("success", true);
+        response.set("pin", static_cast<int64_t>(pin));
+        response.set("selfTestEdges", static_cast<int64_t>(edgeProbeSelfTestEdges()));
+        return response;
+    });
+
+    remote.bind("edgeProbeRead", [](const fl::json& args) -> fl::json {
+        fl::json response = fl::json::object();
+        response.set("success", true);
+        fl::u32 count = 0;
+        const fl::u32 *stamps = edgeProbeStamps(count);
+        response.set("edges", static_cast<int64_t>(count));
+        response.set("probeState", static_cast<int64_t>(edgeProbeState()));
+        {
+            const fl::u32 *rl = edgeProbeRmtLive();
+            fl::json live = fl::json::array();
+            for (int k = 0; k < 6; ++k) live.push_back(static_cast<int64_t>(rl[k]));
+            response.set("rmtLive", live);
+        }
+        fl::json runs = fl::json::array();
+        // Convert consecutive timestamps to durations in ns. Entry i
+        // encodes (level << 31) | cycle_stamp.
+        for (fl::u32 i = 1; i < count && i < 200; ++i) {
+            const fl::u32 prev = stamps[i - 1];
+            const fl::u32 cur = stamps[i];
+            const fl::u32 d_cycles = (cur & 0x7FFFFFFFu) - (prev & 0x7FFFFFFFu);
+            const fl::u32 level = prev >> 31;
+            // cycles -> ns via configured CPU MHz
+            const fl::u64 ns = (static_cast<fl::u64>(d_cycles) * 1000u) / edgeProbeCpuMhz();
+            fl::json e = fl::json::object();
+            e.set("level", static_cast<int64_t>(level));
+            e.set("ns", static_cast<int64_t>(ns));
+            runs.push_back(e);
+        }
+        response.set("runs", runs);
+        return response;
+    });
+#endif
+
     // "heapCheck" — heap integrity + stats (FastLED#3588 corruption
     // bisect). heap_caps_check_integrity_all walks every block; with
     // poisoning configured in the IDF libs it also validates canaries.

--- a/src/platforms/esp/32/drivers/parlio/parlio_engine.cpp.hpp
+++ b/src/platforms/esp/32/drivers/parlio/parlio_engine.cpp.hpp
@@ -1498,7 +1498,17 @@ bool ParlioEngine::initialize(size_t dataWidth,
         mWave3Lut = buildWave3ExpansionLUT(chipsetTiming);
         FL_LOG_PARLIO_F("PARLIO_INIT: Wave3 mode selected (clock=%s Hz)", mClockFreqHz);
     } else {
-        mClockFreqHz = FL_ESP_PARLIO_CLOCK_FREQ_HZ;
+        // FastLED#3586: derive the wave8 clock from the CHIPSET timing —
+        // 8 samples per bit → clock = 8 / bit_period. The old hardcoded
+        // 8 MHz (FL_ESP_PARLIO_CLOCK_FREQ_HZ) transmitted WS2812 with a
+        // 1.0 µs bit period instead of 1.25 µs (bench-measured 25% fast
+        // on ESP32-C6: T1H 643 ns / T1L 356 ns on the wire).
+        const u32 bit_period_ns = static_cast<u32>(mTimingT1Ns) +
+                                  static_cast<u32>(mTimingT2Ns) +
+                                  static_cast<u32>(mTimingT3Ns);
+        mClockFreqHz = (bit_period_ns > 0)
+                           ? static_cast<u32>(8000000000ULL / bit_period_ns)
+                           : FL_ESP_PARLIO_CLOCK_FREQ_HZ;
         FL_LOG_PARLIO_F("PARLIO_INIT: Wave8 mode selected (clock=%s Hz)", mClockFreqHz);
     }
     // Always build wave8 LUT (needed as fallback and for SPI mode)

--- a/tests/platforms/esp/32/drivers/parlio/parlio_driver.cpp
+++ b/tests/platforms/esp/32/drivers/parlio/parlio_driver.cpp
@@ -2618,7 +2618,7 @@ FL_TEST_CASE("Wave3 integration - WS2812B_V5 falls back to wave8") {
     // Verify clock frequency is wave8 clock (8 MHz)
     auto& mock7 = ParlioPeripheralMock::instance();
     const auto& config7 = mock7.getConfig();
-    FL_CHECK_EQ(config7.clock_freq_hz, (u32)8000000);
+    FL_CHECK_EQ(config7.clock_freq_hz, (u32)6530612);  // wave8 clock derived from WS2812B_V5 timing: 8e9 / 1225 ns (FastLED#3586)
 }
 
 FL_TEST_CASE("Wave3 integration - transmit produces correct output size") {
@@ -2679,7 +2679,7 @@ FL_TEST_CASE("Wave3 corner case - mode switch wave3 to wave8") {
     FL_REQUIRE(init_ok);
 
     u32 wave8_clock = mock9.getConfig().clock_freq_hz;
-    FL_CHECK_EQ(wave8_clock, (u32)8000000);  // Should be wave8 clock
+    FL_CHECK_EQ(wave8_clock, (u32)6530612);  // wave8 clock derived from WS2812B_V5 timing: 8e9 / 1225 ns (FastLED#3586)  // Should be wave8 clock
 
     // Verify transmission works in wave8 mode
     uint8_t scratch[15] = {0xFF, 0xAA, 0x55, 0xF0, 0x0F,
@@ -2701,7 +2701,7 @@ FL_TEST_CASE("Wave3 corner case - mode switch wave8 to wave3") {
     FL_REQUIRE(init_ok);
 
     auto& mock10 = ParlioPeripheralMock::instance();
-    FL_CHECK_EQ(mock10.getConfig().clock_freq_hz, (u32)8000000);
+    FL_CHECK_EQ(mock10.getConfig().clock_freq_hz, (u32)6530612);  // wave8 clock derived from WS2812B_V5 timing: 8e9 / 1225 ns (FastLED#3586)
 
     // Second: reinit with WS2812 (wave3) — different timing forces reinit
     ChipsetTimingConfig timing_ws2812 = getWS2812Timing();
@@ -2786,7 +2786,7 @@ FL_TEST_CASE("Wave3 corner case - mock reset between modes") {
     ChipsetTimingConfig timing_v5(225, 355, 645, 280, "WS2812B_V5");
     init_ok = driver.initialize(1, pins, timing_v5, 10);
     FL_REQUIRE(init_ok);
-    FL_CHECK_EQ(mock11.getConfig().clock_freq_hz, (u32)8000000);
+    FL_CHECK_EQ(mock11.getConfig().clock_freq_hz, (u32)6530612);  // wave8 clock derived from WS2812B_V5 timing: 8e9 / 1225 ns (FastLED#3586)
 
     // Verify transmission works after reset+reinit
     uint8_t scratch[15] = {0xFF, 0xAA, 0x55, 0xF0, 0x0F,


### PR DESCRIPTION
Two deliverables from the #3586 deep-dive:

## 1. PARLIO wave8 clock derived from chipset timing
The wave8 clock was the hardcoded 8 MHz `FL_ESP_PARLIO_CLOCK_FREQ_HZ`; it must be `8 samples/bit ÷ bit_period` (WS2812B_V5's 1225 ns → 6.53 MHz). **Bench-measured on ESP32-C6 with the new in-firmware edge probe: the old constant transmitted WS2812 with a 1.0 µs bit period (T1H 643 ns / T1L 356 ns on the wire) — 25% fast.** Same mandate as the classic-I2S engine: pixel clocks derive from `ChipsetTimingConfig`, never hardcoded. Mock tests updated.

## 2. Edge-probe diagnostic suite (AutoResearch)
`edgeProbe` / `edgeProbeRead` RPCs: an in-firmware logic probe (trigger on activity, run-length record with the cycle counter) plus `parlioRawTest` (minimal IDF parlio transmit, parameterized) for engine-vs-IDF bisection. Portability lessons hard-encoded: `rdcycle` is an **illegal instruction** on Espressif RISC-V (use `esp_cpu_get_cycle_count()`); classic `GPIO.in` is a bare u32; LED frames complete inside one FreeRTOS tick (burst-poll triggers required).

## #3586 status
Waveform proven present and now timing-correct; the capture blindness (RMT-RX records zero symbols for PARLIO/RMT-TX frames while UART/SPI/BIT_BANG capture fine on the same jumper) persists — full forensic addendum with the elimination table posted on the issue.

Host: 347/347; lint clean; esp32dev/s3/p4/c6 compile clean. Bench: C6 SPI/UART 4/4, P4 RMT/SPI/UART 4/4 on the new clock.

Refs #3586, #3576.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an AutoResearch edge-probe tool for capturing GPIO edge timings on supported ESP32 devices.
  * Expanded remote control support with new commands to run edge probing and inspect captured edge data.
  * Added a PARLIO transmit test mode for ESP32 builds with PARLIO support.

* **Bug Fixes**
  * Improved clock selection for certain PARLIO timing configurations so output frequency better matches the configured waveform timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->