### PR TITLE
feat(autoresearch): trigger-time input-mux snapshots in the edge probe (#3586)

### DIFF
--- a/examples/AutoResearch/AutoResearchEdgeProbe.cpp
+++ b/examples/AutoResearch/AutoResearchEdgeProbe.cpp
@@ -26,7 +26,7 @@ volatile fl::u32 g_stamps[kMaxStamps];
 volatile fl::u32 g_count = 0;
 volatile fl::u32 g_selftest_edges = 0;
 volatile fl::u32 g_probe_state = 0; // 1=task started 2=triggered 3=sample done
-volatile fl::u32 g_rmt_live[6] = {0};
+volatile fl::u32 g_rmt_live[8] = {0};
 int g_pin = -1;
 
 // Cycle counter. NOTE: plain `rdcycle` is an ILLEGAL INSTRUCTION on
@@ -125,7 +125,9 @@ void edgeProbeArm(int pin) {
             g_rmt_live[0] = *reinterpret_cast<volatile fl::u32 *>(0x60006038); // ok reinterpret cast - RMT_INT_RAW
             g_rmt_live[1] = *reinterpret_cast<volatile fl::u32 *>(0x60006030); // ok reinterpret cast - CH2STATUS
             g_rmt_live[2] = *reinterpret_cast<volatile fl::u32 *>(0x60006034); // ok reinterpret cast - CH3STATUS
-            g_rmt_live[3] = *reinterpret_cast<volatile fl::u32 *>(0x60006024); // ok reinterpret cast - CH2 RX_CONF1
+            g_rmt_live[3] = *reinterpret_cast<volatile fl::u32 *>(0x6000601C); // ok reinterpret cast - CH2CONF1 (real RX ch)
+            g_rmt_live[6] = *reinterpret_cast<volatile fl::u32 *>(0x60091000 + 0x154 + 71 * 4); // ok reinterpret cast - FUNC71_IN_SEL (RMT_SIG_IN0)
+            g_rmt_live[7] = *reinterpret_cast<volatile fl::u32 *>(0x60091000 + 0x154 + 72 * 4); // ok reinterpret cast - FUNC72_IN_SEL (RMT_SIG_IN1)
 #endif
             fl::u32 idx = 0;
             fl::u32 prev = *in_reg & mask;

--- a/examples/AutoResearch/AutoResearchRemoteSystemMethods.cpp
+++ b/examples/AutoResearch/AutoResearchRemoteSystemMethods.cpp
@@ -361,7 +361,7 @@ void AutoResearchRemoteControl::bindSystemMethods(fl::Remote& remote) {
         {
             const fl::u32 *rl = edgeProbeRmtLive();
             fl::json live = fl::json::array();
-            for (int k = 0; k < 6; ++k) live.push_back(static_cast<int64_t>(rl[k]));
+            for (int k = 0; k < 8; ++k) live.push_back(static_cast<int64_t>(rl[k]));
             response.set("rmtLive", live);
         }
         fl::json runs = fl::json::array();


### PR DESCRIPTION
Extends the edge probe's trigger-time register snapshot with the real RX channel CONF1 (0x1C — the earlier 0x24 read was CH3's reset default) and the FUNC71/72_IN_SEL input-mux routing, captured at the instant the TX waveform is live.

Findings recorded on #3586 with this tooling: input mux, filter, divider, and idle threshold are **byte-identical between working and deaf captures at waveform-live time**; and WS2811-400 timing (625 ns low gaps) still merges into a single envelope symbol while UART's 490 ns gaps capture fine — **the deafness follows the TX driver, not the waveform shape**, eliminating electrical/low-pass models.

Host tests + lint clean; C6 compile clean.

Refs #3586.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded edge-probe RMT live data returned by the remote control API, so callers can now see more live register information.
  * Improved the ESP32C6 edge-probe snapshot to capture additional live register sources, providing more complete diagnostic output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->