### PR TITLE
feat(autoresearch): passive edge-probe mode + pre-filter RX telemetry (#3586)

### DIFF
--- a/examples/AutoResearch/AutoResearchEdgeProbe.cpp
+++ b/examples/AutoResearch/AutoResearchEdgeProbe.cpp
@@ -49,14 +49,23 @@ void ARDUINO_ISR_ATTR edgeIsr() {
 
 } // namespace
 
-void edgeProbeArm(int pin) {
-    if (g_pin >= 0) {
+void edgeProbeArm(int pin) { edgeProbeArmMode(pin, false); }
+
+void edgeProbeArmMode(int pin, bool passive) {
+    if (g_pin >= 0 && !passive) {
         detachInterrupt(digitalPinToInterrupt(g_pin));
     }
     g_count = 0;
     g_pin = pin;
-    pinMode(pin, INPUT);
-    attachInterrupt(digitalPinToInterrupt(pin), edgeIsr, CHANGE);
+    if (!passive) {
+        // Active mode reconfigures the pad; passive mode leaves the pad
+        // completely untouched (for probing pins owned by a receiver).
+        pinMode(pin, INPUT);
+        attachInterrupt(digitalPinToInterrupt(pin), edgeIsr, CHANGE);
+    }
+    if (passive) {
+        g_selftest_edges = 0;
+    } else {
     // Self-test: flip the pad's pull resistors to generate edges the
     // ISR must record. Proves the interrupt path end-to-end without
     // touching the output driver (jumpered TX pins stay unharmed).
@@ -68,6 +77,7 @@ void edgeProbeArm(int pin) {
     }
     g_selftest_edges = g_count;
     g_count = 0; // restart clean for the real capture
+    }
 
     // TX drivers reconfigure the probed pad when the test starts,
     // clearing the input-enable and the interrupt binding. Spawn a
@@ -178,6 +188,7 @@ fl::u32 edgeProbeCpuMhz() {
 #else // !FL_IS_ESP32
 
 void edgeProbeArm(int) {}
+void edgeProbeArmMode(int, bool) {}
 const fl::u32 *edgeProbeStamps(fl::u32 &count) {
     count = 0;
     return nullptr;

--- a/examples/AutoResearch/AutoResearchEdgeProbe.h
+++ b/examples/AutoResearch/AutoResearchEdgeProbe.h
@@ -12,6 +12,10 @@
 /// Arm the probe on a pin (re-arming resets the buffer).
 void edgeProbeArm(int pin);
 
+/// Passive variant: no pinMode/attachInterrupt/pull toggles — only the
+/// triggered tight-loop sampler task. Safe on pads owned by a receiver.
+void edgeProbeArmMode(int pin, bool passive);
+
 /// Timestamp buffer: entry = (level_before_edge << 31) | cycle_count.
 /// Returns the buffer; count receives the number of valid entries.
 const fl::u32 *edgeProbeStamps(fl::u32 &count);

--- a/examples/AutoResearch/AutoResearchRemoteSystemMethods.cpp
+++ b/examples/AutoResearch/AutoResearchRemoteSystemMethods.cpp
@@ -341,10 +341,14 @@ void AutoResearchRemoteControl::bindSystemMethods(fl::Remote& remote) {
     remote.bind("edgeProbe", [](const fl::json& args) -> fl::json {
         fl::json response = fl::json::object();
         int pin = 0;
+        bool passive = false;
         if (args.is_object() && args.contains("pin") && args["pin"].is_int()) {
             pin = static_cast<int>(args["pin"].as_int().value());
         }
-        edgeProbeArm(pin);
+        if (args.is_object() && args.contains("passive") && args["passive"].is_bool()) {
+            passive = args["passive"].as_bool().value();
+        }
+        edgeProbeArmMode(pin, passive);
         response.set("success", true);
         response.set("pin", static_cast<int64_t>(pin));
         response.set("selfTestEdges", static_cast<int64_t>(edgeProbeSelfTestEdges()));

--- a/src/platforms/esp/32/drivers/rmt_rx/rmt_rx_5/rmt_rx_channel_5.cpp.hpp
+++ b/src/platforms/esp/32/drivers/rmt_rx/rmt_rx_5/rmt_rx_channel_5.cpp.hpp
@@ -563,6 +563,10 @@ volatile fl::u32 g_rmtrx_wait_dbg[4] = {0, 0, 0, 0};
 volatile fl::u32 g_rmtrx_max_symbols = 0;
 // FL_LINT_ALLOW_GLOBAL(bench probe read via peekMem at a fixed symbol address)
 volatile fl::u32 g_rmtrx_first_symbols[4] = {0};
+// FL_LINT_ALLOW_GLOBAL(bench probe read via peekMem at a fixed symbol address)
+volatile fl::u32 g_rmtrx_cb_raw_symbols = 0;
+// FL_LINT_ALLOW_GLOBAL(bench probe read via peekMem at a fixed symbol address)
+volatile fl::u32 g_rmtrx_cb_first_raw = 0;
 
 class RmtRxChannelImpl : public RmtRxChannel {
   public:
@@ -1629,6 +1633,11 @@ class RmtRxChannelImpl : public RmtRxChannel {
         self->mCallbackCount =
             self->mCallbackCount + 1; // Debug: Track callback invocations
         size_t received_count = data->num_symbols;
+        g_rmtrx_cb_raw_symbols = static_cast<fl::u32>(received_count);
+        if (received_count > 0) {
+            g_rmtrx_cb_first_raw =
+                *reinterpret_cast<const fl::u32 *>(data->received_symbols); // ok reinterpret cast - bench telemetry
+        }
         const rmt_symbol_word_t *src = data->received_symbols;
         size_t src_offset = 0; // symbols consumed by in-stream skip
 


### PR DESCRIPTION
- `edgeProbe` gains `{passive:true}`: no pad reconfiguration — only the triggered tight-loop sampler. Safe on pads owned by an armed receiver (active mode destroyed the RX arm).
- rmt_rx: pre-filter callback telemetry (`g_rmtrx_cb_raw_symbols`, `g_rmtrx_cb_first_raw`).

**Findings (on #3586):** pin 0 — the receiver's own pad — carries the full crisp PARLIO waveform through the jumper, yet the RMT hardware's raw callback delivers exactly ONE symbol spanning the whole frame as continuous HIGH (731 µs). Probe presence doesn't alter pass/fail. All registers byte-identical to working captures. Next step requires an oscilloscope or vendor-level RMT input-path review.

Host tests + lint clean; C6 compile clean.

Refs #3586.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional passive arming mode for edge probing, giving users more control over how the probe is initialized.
  * The remote probe command now accepts a `passive` option and can be called with just a pin or with both pin and mode settings.

* **Bug Fixes**
  * Improved probe re-arming behavior so passive mode avoids interrupt reconfiguration and resets counters appropriately.

* **Chores**
  * Expanded low-level receive telemetry to capture additional callback details for easier debugging and analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->