### PR TITLE
fix(cstring): make fl::strncpy always null-terminate (#3588)

### DIFF
--- a/src/fl/stl/cstring.cpp.hpp
+++ b/src/fl/stl/cstring.cpp.hpp
@@ -48,7 +48,25 @@ char* strcpy(char* dest, const char* src) FL_NO_EXCEPT {
 }
 
 char* strncpy(char* dest, const char* src, size_t n) FL_NO_EXCEPT {
-    return ::strncpy(dest, src, n);
+    // Unlike ::strncpy, this ALWAYS null-terminates: it copies at most n
+    // characters from src, then writes a terminator at dest[copied]
+    // (copied <= n). Callers pass n = capacity - 1 (dest sized >= n+1),
+    // so the terminator is always in bounds. This closes the classic
+    // strncpy hazard where a source of length >= n leaves dest
+    // unterminated and downstream string walks run off the buffer
+    // (FastLED#3588: an unterminated HTTP request URI let a query-strip
+    // loop write a stray null byte one past a heap allocation).
+    size_t i = 0;
+    for (; i < n && src[i] != '\0'; ++i) {
+        dest[i] = src[i];
+    }
+    dest[i] = '\0';
+    // Preserve ::strncpy's zero-padding of the remaining destination
+    // bytes so callers relying on that behavior are unaffected.
+    for (size_t j = i + 1; j < n; ++j) {
+        dest[j] = '\0';
+    }
+    return dest;
 }
 
 char* strcat(char* dest, const char* src) FL_NO_EXCEPT {

--- a/src/fl/stl/cstring.h
+++ b/src/fl/stl/cstring.h
@@ -31,7 +31,11 @@ int strncmp(const char* s1, const char* s2, size_t n) FL_NO_EXCEPT;
 // fl::strcpy - wrapper for strcpy (use with caution - prefer strncpy)
 char* strcpy(char* dest, const char* src) FL_NO_EXCEPT;
 
-// fl::strncpy - wrapper for strncpy
+// fl::strncpy - bounded string copy that ALWAYS null-terminates.
+// Copies at most n chars from src, then writes a terminator at
+// dest[copied] (copied <= n). Pass n = capacity - 1 (dest sized >= n+1).
+// Differs from ::strncpy, which leaves dest unterminated when
+// strlen(src) >= n. Remaining destination bytes up to n are zero-padded.
 char* strncpy(char* dest, const char* src, size_t n) FL_NO_EXCEPT;
 
 // fl::strcat - wrapper for strcat (use with caution - prefer strncat)

--- a/tests/fl/stl/cstring.cpp
+++ b/tests/fl/stl/cstring.cpp
@@ -151,13 +151,16 @@ FL_TEST_CASE("fl::strncpy") {
         FL_CHECK_EQ(buffer[4], '\0');
     }
 
-    FL_SUBCASE("copy with n < source length - no null terminator") {
+    FL_SUBCASE("copy with n < source length - always null terminated") {
+        // fl::strncpy differs from ::strncpy: it ALWAYS terminates. With
+        // n=3 and a longer source it copies 3 chars then writes the
+        // terminator at buffer[3] (in bounds; callers size dest >= n+1).
         fl::memset(buffer, 'X', sizeof(buffer));
         fl::strncpy(buffer, "hello", 3);
         FL_CHECK_EQ(buffer[0], 'h');
         FL_CHECK_EQ(buffer[1], 'e');
         FL_CHECK_EQ(buffer[2], 'l');
-        FL_CHECK_EQ(buffer[3], 'X');  // Original content preserved
+        FL_CHECK_EQ(buffer[3], '\0');  // Always null-terminated
     }
 
     FL_SUBCASE("return value is destination") {


### PR DESCRIPTION
`fl::strncpy` was a raw pass-through to `::strncpy`, which does **not** null-terminate when `strlen(src) >= n`. Every FastLED caller passes `n = sizeof(dst) - 1` (reserving a terminator byte), so the safe contract is: copy at most `n` chars, then always terminate at `dest[copied]` (in bounds). Remaining bytes are still zero-padded.

**Closes a real buffer overrun found auditing #3588:** the HTTP marshaling path does `fl::strncpy(item->uri, req->uri, sizeof(item->uri)-1)` into `char uri[160]`; for a URI ≥159 bytes the old strncpy left `uri` unterminated, and the query-strip loop `for (char* c = item->uri; *c; ++c)` would walk past the array and write a stray null byte one past the buffer on the first `?` in adjacent memory. All call sites already pass `sizeof(dst)-1` and are now safe without changes.

**Honest scope:** this is *not* the sole #3588 corruptor — the short-URI repro still crashes (a `json_value` control block is stomped by a separate writer, still under investigation). But this is a genuine latent overrun worth fixing on its own, and the user requested the reimplementation.

The cstring test subcase that asserted the old unterminated behavior is updated to assert guaranteed termination. Host 348/348, lint clean.

Refs #3588.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bounded string copying so the destination is always null-terminated.
  * Remaining buffer bytes are now cleared after copying, making the result more predictable when the source is longer than the limit.

* **Documentation**
  * Updated the string-copying API notes to clearly describe the new termination behavior and how it differs from standard library behavior.

* **Tests**
  * Adjusted coverage to verify the new always-terminated behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->