### PR TITLE
fix(stl): make_shared must not construct on null under OOM (#3588 root cause)

### DIFF
--- a/src/fl/stl/flat_map.h
+++ b/src/fl/stl/flat_map.h
@@ -7,6 +7,7 @@
 #include "fl/stl/comparators.h"
 #include "fl/stl/flat_map_basic.h"  // type-erased binary-search helpers (#3235 Tier 2D)
 #include "fl/stl/pair.h"
+#include "fl/stl/singleton.h"  // fl::Singleton — OOM sink for operator[] (#3588)
 #include "fl/stl/vector.h"
 #include "fl/stl/allocator.h"
 #include "fl/stl/memory_resource.h"
@@ -106,9 +107,27 @@ class flat_map {
         if (it != end() && !mLess(key, it->first) && !mLess(it->first, key)) {
             return it->second;
         }
-        // Key not found, insert it with default value
+        // Key not found, insert it with default value.
         bool success = mData.insert(it, value_type(key, Value()));
-        FASTLED_ASSERT(success, "Insert failed in flat_map::operator[]");
+        if (!success) {
+            // FastLED#3588: under memory pressure the backing vector
+            // could not grow, so the key was NOT inserted. The old code
+            // then did `find(key)` (which returns end(), the key being
+            // absent) and returned `end()->second` — a reference ONE PAST
+            // the buffer. The caller's assignment through it wrote a value
+            // into the neighboring heap allocation, corrupting it (e.g. a
+            // shared_ptr control block, detonating later as a wild-pointer
+            // refcount decrement). Degrade gracefully instead: hand back a
+            // discardable sink so the caller's write is dropped rather than
+            // corrupting the heap. This matches the library's no-throw OOM
+            // policy (a failed insert simply does not take effect). The
+            // sink is a process-lifetime Singleton (shared, never
+            // destroyed) so the reference stays valid across DLL
+            // boundaries and does not add per-map storage.
+            Value& sink = fl::SingletonShared<Value, 3588>::instance();
+            sink = Value();
+            return sink;
+        }
         // Find the newly inserted element
         it = find(key);
         return it->second;

--- a/src/fl/stl/json.h
+++ b/src/fl/stl/json.h
@@ -291,6 +291,7 @@ public:
     
     // Constructor for fl::vector<float> - converts to JSON array
     json(const fl::vector<float>& vec) FL_NO_EXCEPT : mValue(fl::make_shared<json_value>(json_array{})) {
+        if (!mValue) { return; }  // FastLED#3588: OOM-degraded empty
         auto ptr = mValue->data.ptr<json_array>();
         if (ptr) {
             for (const auto& item : vec) {
@@ -368,6 +369,7 @@ public:
     // Assignment operator for fl::vector<float>
     json& operator=(fl::vector<float> vec) FL_NO_EXCEPT {
         mValue = fl::make_shared<json_value>(json_array{});
+        if (!mValue) { return *this; }  // FastLED#3588: OOM-degraded empty
         auto ptr = mValue->data.ptr<json_array>();
         if (ptr) {
             for (const auto& item : vec) {
@@ -700,6 +702,8 @@ public:
         if (!mValue) {
             mValue = fl::make_shared<json_value>(json_array{});
         }
+        // FastLED#3588: make_shared may degrade to empty under OOM.
+        if (!mValue) { return json(nullptr); }
         // If we're indexing into a specialized array, convert it to regular json_array first
         if (mValue->data.is<fl::vector<i16>>() ||
             mValue->data.is<fl::vector<u8>>() ||
@@ -751,6 +755,8 @@ public:
         if (!mValue || !mValue->is_object()) {
             mValue = fl::make_shared<json_value>(json_object{});
         }
+        // FastLED#3588: make_shared may degrade to empty under OOM.
+        if (!mValue) { return json(nullptr); }
         // Get reference to the json_value
         auto objPtr = mValue->data.ptr<json_object>();
         if (objPtr) {
@@ -863,6 +869,12 @@ public:
         if (!mValue || !mValue->is_object()) {
             mValue = fl::make_shared<json_value>(json_object{});
         }
+        // FastLED#3588: make_shared degrades to an empty shared_ptr under
+        // OOM, so mValue can be null here — dereferencing it would read
+        // through null. Degrade gracefully (the set becomes a no-op).
+        if (!mValue) {
+            return;
+        }
         // Directly assign the value to the object without going through json::operator[]
         auto objPtr = mValue->data.ptr<json_object>();
         if (objPtr) {
@@ -909,6 +921,8 @@ public:
         if (!mValue || !mValue->is_array()) {
             mValue = fl::make_shared<json_value>(json_array{});
         }
+        // FastLED#3588: make_shared may degrade to empty under OOM.
+        if (!mValue) { return; }
         // If we're pushing to a packed array, convert it to regular json_array first
         if (mValue->is_array() &&
             (mValue->data.is<fl::vector<i16>>() ||

--- a/src/fl/stl/shared_ptr.h
+++ b/src/fl/stl/shared_ptr.h
@@ -412,14 +412,23 @@ private:
 // make_shared with optimized inlined storage (single allocation)
 template<typename T, typename... Args>
 shared_ptr<T> make_shared(Args&&... args) FL_NO_EXCEPT {
-    auto* control = new detail::InlinedControlBlock<T>();
-    if (control == nullptr) {
-        // OOM (embedded new returns null with -fno-exceptions): degrade
-        // to an empty shared_ptr instead of placement-constructing at a
-        // garbage offset from null (FastLED#3588 — crashed classic
-        // ESP32 when WiFi + HTTP server pushed free heap under 20 KB).
-        return shared_ptr<T>();
+    // Allocate the control block's raw memory explicitly and null-check it
+    // BEFORE constructing. `new detail::InlinedControlBlock<T>()` cannot be
+    // trusted to skip construction on allocation failure: its custom
+    // operator new returns null under OOM, but the new-expression still
+    // runs the constructor on that null pointer — writing through address 0
+    // (EXCVADDR 0 crash) — and the old `if (control == nullptr)` guard was
+    // dead code because it ran only AFTER the null construction. This was
+    // the primary FastLED#3588 corruptor: under low free heap (which an
+    // active WiFi SoftAP creates, but so does any memory pressure) every
+    // make_shared<json_value> in the JSON-RPC build path faulted. Separate
+    // allocation from construction so the null check actually protects it.
+    void* mem = detail::InlinedControlBlock<T>::operator new(
+        sizeof(detail::InlinedControlBlock<T>));
+    if (mem == nullptr) {
+        return shared_ptr<T>();  // OOM — degrade to an empty shared_ptr
     }
+    auto* control = ::new (mem) detail::InlinedControlBlock<T>();  // global placement new on valid memory
     T* obj = control->get_object();
     new(obj) T(fl::forward<Args>(args)...);  // Placement new
     control->object_constructed = true;

--- a/src/fl/stl/string.h
+++ b/src/fl/stl/string.h
@@ -28,8 +28,17 @@
 #include "fl/stl/move.h"
 #include "fl/stl/noexcept.h"
 
+// Inline (SSO) buffer size for fl::string, in bytes. Every fl::string
+// object carries this buffer, and — because fl::json_value's variant is
+// sized to its largest alternative (fl::string) — EVERY json value (even
+// an int or bool) pays for it too. At the old default of 64 a single
+// JSON-RPC response with a few hundred values consumed tens of KB and
+// exhausted the heap on classic ESP32 once WiFi was up (FastLED#3588).
+// 32 still keeps typical keys/short values inline while roughly halving
+// the per-string and per-json-value footprint. Override by defining
+// FASTLED_STR_INLINED_SIZE before including FastLED.
 #ifndef FASTLED_STR_INLINED_SIZE
-#define FASTLED_STR_INLINED_SIZE 64
+#define FASTLED_STR_INLINED_SIZE 32
 #endif
 
 

--- a/tests/fl/stl/string_search_a.cpp
+++ b/tests/fl/stl/string_search_a.cpp
@@ -350,14 +350,17 @@ FL_TEST_CASE("String find_first_of operations") {
     }
 
     FL_SUBCASE("find_first_of on heap string") {
-        // Create a string that uses heap allocation
+        // Create a string that uses heap allocation. Positions are
+        // relative to the inline size so this works for any
+        // FASTLED_STR_INLINED_SIZE (the 'b' position must stay in range).
+        const fl::size bpos = FASTLED_STR_INLINED_SIZE + 5;
         fl::string s(FASTLED_STR_INLINED_SIZE + 10, 'x');
-        s.replace(10, 1, "a");  // Put an 'a' at position 10
-        s.replace(50, 1, "b");  // Put a 'b' at position 50
+        s.replace(10, 1, "a");     // Put an 'a' at position 10
+        s.replace(bpos, 1, "b");   // Put a 'b' past the inline boundary
 
         FL_CHECK(s.find_first_of("ab") == 10);  // Find 'a' at position 10
-        FL_CHECK(s.find_first_of("ab", 11) == 50);  // Find 'b' at position 50
-        FL_CHECK(s.find_first_of("ab", 51) == fl::string::npos);  // No more matches
+        FL_CHECK(s.find_first_of("ab", 11) == bpos);  // Find 'b'
+        FL_CHECK(s.find_first_of("ab", bpos + 1) == fl::string::npos);  // No more matches
     }
 
     FL_SUBCASE("find_first_of comparison with find") {
@@ -552,13 +555,16 @@ FL_TEST_CASE("String find_last_of operations") {
     }
 
     FL_SUBCASE("find_last_of on heap string") {
-        // Create a string that uses heap allocation
+        // Create a string that uses heap allocation. Positions are
+        // relative to the inline size so this works for any
+        // FASTLED_STR_INLINED_SIZE (the 'b' position must stay in range).
+        const fl::size bpos = FASTLED_STR_INLINED_SIZE + 5;
         fl::string s(FASTLED_STR_INLINED_SIZE + 10, 'x');
-        s.replace(10, 1, "a");  // Put an 'a' at position 10
-        s.replace(50, 1, "b");  // Put a 'b' at position 50
+        s.replace(10, 1, "a");     // Put an 'a' at position 10
+        s.replace(bpos, 1, "b");   // Put a 'b' past the inline boundary
 
-        FL_CHECK(s.find_last_of("ab") == 50);  // Last match is 'b' at position 50
-        FL_CHECK(s.find_last_of("ab", 49) == 10);  // Before position 50, 'a' at position 10
+        FL_CHECK(s.find_last_of("ab") == bpos);  // Last match is 'b'
+        FL_CHECK(s.find_last_of("ab", bpos - 1) == 10);  // Before 'b', 'a' at position 10
         FL_CHECK(s.find_last_of("ab", 9) == fl::string::npos);  // No matches before position 10
     }
 

--- a/tests/fl/stl/string_search_b.cpp
+++ b/tests/fl/stl/string_search_b.cpp
@@ -181,12 +181,13 @@ FL_TEST_CASE("String find_first_not_of operations") {
 
     FL_SUBCASE("find_first_not_of on heap string") {
         // Create a string that uses heap allocation
+        const fl::size zpos = FASTLED_STR_INLINED_SIZE + 5;  // in-range for any inline size
         fl::string s(FASTLED_STR_INLINED_SIZE + 10, 'x');
-        s.replace(10, 1, "y");  // Put a 'y' at position 10
-        s.replace(50, 1, "z");  // Put a 'z' at position 50
+        s.replace(10, 1, "y");     // Put a 'y' at position 10
+        s.replace(zpos, 1, "z");   // Put a 'z' past the inline boundary
 
         FL_CHECK(s.find_first_not_of("x") == 10);  // First non-'x' is 'y' at position 10
-        FL_CHECK(s.find_first_not_of("x", 11) == 50);  // Next non-'x' is 'z' at position 50
+        FL_CHECK(s.find_first_not_of("x", 11) == zpos);  // Next non-'x' is 'z'
         FL_CHECK(s.find_first_not_of("xyz") == fl::string::npos);  // All are x, y, or z
     }
 
@@ -486,12 +487,13 @@ FL_TEST_CASE("String find_last_not_of operations") {
 
     FL_SUBCASE("find_last_not_of on heap string") {
         // Create a string that uses heap allocation
+        const fl::size zpos = FASTLED_STR_INLINED_SIZE + 5;  // in-range for any inline size
         fl::string s(FASTLED_STR_INLINED_SIZE + 10, 'x');
-        s.replace(10, 1, "y");  // Put a 'y' at position 10
-        s.replace(50, 1, "z");  // Put a 'z' at position 50
+        s.replace(10, 1, "y");     // Put a 'y' at position 10
+        s.replace(zpos, 1, "z");   // Put a 'z' past the inline boundary
 
-        FL_CHECK(s.find_last_not_of("x") == 50);  // Last non-'x' is 'z' at position 50
-        FL_CHECK(s.find_last_not_of("x", 49) == 10);  // Previous non-'x' is 'y' at position 10
+        FL_CHECK(s.find_last_not_of("x") == zpos);  // Last non-'x' is 'z'
+        FL_CHECK(s.find_last_not_of("x", zpos - 1) == 10);  // Previous non-'x' is 'y' at position 10
         FL_CHECK(s.find_last_not_of("xyz") == fl::string::npos);  // All are x, y, or z
     }
 


### PR DESCRIPTION
## Root cause of #3588 (found by reproducing with NO WiFi)
Leaking heap down to the ~23 KB an active SoftAP leaves reproduces the crash **with WiFi off** — proving WiFi was incidental (it only consumed heap).

`fl::make_shared<T>()` did `new InlinedControlBlock<T>()`. That class's custom `operator new` returns null under OOM, but the new-expression **still ran the constructor on the null pointer** (writing through ~address 0), and the `if (control == nullptr)` guard was dead code (it ran *after* the null construction). Under low heap, every `make_shared<json_value>` in the RPC response path corrupted a neighbouring `shared_ptr` control block — detonating later as the wild-pointer refcount decrement in `remove_shared_ref()` from the issue. Host ASAN never sees it (the host never fails the allocation).

## Fixes
- **`shared_ptr.h`** — make_shared allocates the control block, null-checks it, *then* placement-constructs. **This is the corruption fix.**
- **`flat_map.h`** — `operator[]` no longer dereferences `end()` after a failed OOM insert (that returned a ref one past the buffer); returns a discardable `SingletonShared` sink instead.
- **`json.h`** — guard methods that deref `mValue` right after a `make_shared` that can now return empty under OOM.

## Why OOM happened at all
- **`FASTLED_STR_INLINED_SIZE` 64 → 32.** Every `fl::string` carried a 64-byte inline buffer, and since `json_value`'s variant is sized to `fl::string`, **every** json value (even an int/bool) paid for it. Halving it freed **~11 KB baseline heap** on the bench (34 KB free after SoftAP vs ~23 KB).

## Verified
500 `help` calls at a forced ~23 KB heap (no WiFi) — no crash; 200 `help` under active SoftAP — no crash. Host 349/349 (fixed two tests that hard-coded position-50 assuming a ≥40-byte inline buffer). Lint clean.

Large responses building under concurrent traffic can still exhaust memory — a separate response-size problem being addressed by **async streaming** in a follow-up.

Fixes #3588.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved safety when memory is tight by preventing invalid string, map, and JSON operations from dereferencing unavailable storage.
  * `flat_map` now safely handles failed inserts without returning corrupted references.
  * `json` now gracefully skips or returns empty values when automatic container creation cannot allocate memory.
  * `make_shared` now more reliably returns an empty result when allocation fails.

* **Tests**
  * Updated string search coverage to use inline-buffer-relative positions, keeping checks valid with the new default string size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->