### PR TITLE
feat(stl): JsonStreamWriter — stream JSON without an N-sized buffer (#3588 follow-up)

### DIFF
--- a/src/fl/stl/_build.cpp.hpp
+++ b/src/fl/stl/_build.cpp.hpp
@@ -19,6 +19,7 @@
 #include "fl/stl/ios.cpp.hpp"
 #include "fl/stl/istream.cpp.hpp"
 #include "fl/stl/json.cpp.hpp"
+#include "fl/stl/json_stream_writer.cpp.hpp"
 #include "fl/stl/malloc.cpp.hpp"
 #include "fl/stl/memory_resource.cpp.hpp"
 #include "fl/stl/not_null.cpp.hpp"

--- a/src/fl/stl/json_stream_writer.cpp.hpp
+++ b/src/fl/stl/json_stream_writer.cpp.hpp
@@ -1,0 +1,160 @@
+#pragma once
+
+// IWYU pragma: private
+
+#include "fl/stl/json_stream_writer.h"
+
+#include "fl/stl/charconv.h" // fl::itoa64
+#include "fl/stl/move.h"     // fl::move
+
+namespace fl {
+
+JsonStreamWriter::JsonStreamWriter(Sink sink) FL_NO_EXCEPT
+    : mSink(fl::move(sink)), mLen(0), mDepth(0), mPendingKey(false) {}
+
+JsonStreamWriter::~JsonStreamWriter() FL_NO_EXCEPT { flush(); }
+
+void JsonStreamWriter::flush() FL_NO_EXCEPT {
+    if (mLen > 0) {
+        if (mSink) {
+            mSink(mBuf, mLen);
+        }
+        mLen = 0;
+    }
+}
+
+void JsonStreamWriter::putc(char c) FL_NO_EXCEPT {
+    if (mLen >= kBufSize) {
+        flush();
+    }
+    mBuf[mLen++] = c;
+}
+
+void JsonStreamWriter::puts(const char *s) FL_NO_EXCEPT {
+    if (!s) {
+        return;
+    }
+    for (; *s; ++s) {
+        putc(*s);
+    }
+}
+
+void JsonStreamWriter::putEscaped(const char *s) FL_NO_EXCEPT {
+    putc('"');
+    if (s) {
+        for (; *s; ++s) {
+            const unsigned char c = static_cast<unsigned char>(*s);
+            switch (c) {
+                case '"':  puts("\\\""); break;
+                case '\\': puts("\\\\"); break;
+                case '\n': puts("\\n"); break;
+                case '\r': puts("\\r"); break;
+                case '\t': puts("\\t"); break;
+                case '\b': puts("\\b"); break;
+                case '\f': puts("\\f"); break;
+                default:
+                    if (c < 0x20) {
+                        // Control character → \u00XX
+                        static const char *kHex = "0123456789abcdef";
+                        puts("\\u00");
+                        putc(kHex[(c >> 4) & 0xF]);
+                        putc(kHex[c & 0xF]);
+                    } else {
+                        putc(static_cast<char>(c));
+                    }
+                    break;
+            }
+        }
+    }
+    putc('"');
+}
+
+void JsonStreamWriter::prefixForValue() FL_NO_EXCEPT {
+    if (mPendingKey) {
+        // We just wrote a key + ':'; the value follows directly.
+        mPendingKey = false;
+        return;
+    }
+    // Element in an array (or a bare top-level value). Add a comma if this
+    // container already has a prior element.
+    if (mDepth > 0) {
+        if (mNeedComma[mDepth - 1]) {
+            putc(',');
+        }
+        mNeedComma[mDepth - 1] = true;
+    }
+}
+
+void JsonStreamWriter::prefixForKey() FL_NO_EXCEPT {
+    if (mDepth > 0) {
+        if (mNeedComma[mDepth - 1]) {
+            putc(',');
+        }
+        mNeedComma[mDepth - 1] = true;
+    }
+}
+
+void JsonStreamWriter::beginObject() FL_NO_EXCEPT {
+    prefixForValue();
+    putc('{');
+    if (mDepth < kMaxDepth) {
+        mNeedComma[mDepth] = false;
+    }
+    ++mDepth;
+}
+
+void JsonStreamWriter::endObject() FL_NO_EXCEPT {
+    if (mDepth > 0) {
+        --mDepth;
+    }
+    putc('}');
+}
+
+void JsonStreamWriter::beginArray() FL_NO_EXCEPT {
+    prefixForValue();
+    putc('[');
+    if (mDepth < kMaxDepth) {
+        mNeedComma[mDepth] = false;
+    }
+    ++mDepth;
+}
+
+void JsonStreamWriter::endArray() FL_NO_EXCEPT {
+    if (mDepth > 0) {
+        --mDepth;
+    }
+    putc(']');
+}
+
+void JsonStreamWriter::key(const char *k) FL_NO_EXCEPT {
+    prefixForKey();
+    putEscaped(k);
+    putc(':');
+    mPendingKey = true;
+}
+
+void JsonStreamWriter::value(const char *s) FL_NO_EXCEPT {
+    prefixForValue();
+    putEscaped(s);
+}
+
+void JsonStreamWriter::value(fl::i64 n) FL_NO_EXCEPT {
+    prefixForValue();
+    char buf[24];
+    int len = fl::itoa64(n, buf, 10);
+    for (int i = 0; i < len; ++i) {
+        putc(buf[i]);
+    }
+}
+
+void JsonStreamWriter::value(bool b) FL_NO_EXCEPT {
+    prefixForValue();
+    puts(b ? "true" : "false");
+}
+
+void JsonStreamWriter::valueNull() FL_NO_EXCEPT {
+    prefixForValue();
+    puts("null");
+}
+
+} // namespace fl

--- a/src/fl/stl/json_stream_writer.h
+++ b/src/fl/stl/json_stream_writer.h
@@ -1,0 +1,86 @@
+#pragma once
+
+// JsonStreamWriter — emit a JSON document incrementally to a byte sink
+// without ever allocating a buffer proportional to the document size.
+//
+// Motivation (FastLED#3588 follow-up): building a large JSON-RPC response
+// as an fl::json object and then serializing it to an fl::string allocates
+// TWO buffers proportional to the whole response (N-sized), which exhausts
+// the heap on classic ESP32 once WiFi is up. A streaming writer keeps only
+// a small fixed buffer live, so an arbitrarily large response (e.g. a
+// `help` listing of hundreds of methods) can be returned with a bounded,
+// tiny memory footprint. Peak memory = one small buffer + the nesting
+// depth, not the document.
+//
+// The writer performs no heap allocation itself: the scratch buffer and the
+// container-nesting stack are fixed-size members. It handles commas between
+// elements, object key/value alternation, and JSON string escaping.
+
+#include "fl/stl/int.h"
+#include "fl/stl/function.h"
+#include "fl/stl/noexcept.h"
+
+namespace fl {
+
+class JsonStreamWriter {
+  public:
+    // Sink receives UTF-8 bytes to write to the transport (serial, socket,
+    // …). It is called many times with small spans; it must not retain the
+    // pointer past the call.
+    using Sink = fl::function<void(const char *data, fl::size len)>;
+
+    // kMaxDepth bounds object/array nesting. JSON-RPC responses are shallow;
+    // 24 is far more than enough and costs 24 bytes.
+    static constexpr fl::size kMaxDepth = 24;
+    // Scratch buffer size. Bytes accumulate here and flush to the sink when
+    // full, so the sink sees reasonably-sized writes without any heap use.
+    static constexpr fl::size kBufSize = 128;
+
+    explicit JsonStreamWriter(Sink sink) FL_NO_EXCEPT;
+    ~JsonStreamWriter() FL_NO_EXCEPT;  // flushes
+
+    JsonStreamWriter(const JsonStreamWriter &) FL_NO_EXCEPT = delete;
+    JsonStreamWriter &operator=(const JsonStreamWriter &) FL_NO_EXCEPT = delete;
+
+    // Structure.
+    void beginObject() FL_NO_EXCEPT;
+    void endObject() FL_NO_EXCEPT;
+    void beginArray() FL_NO_EXCEPT;
+    void endArray() FL_NO_EXCEPT;
+
+    // Object key. Must be followed by exactly one value (or begin*).
+    void key(const char *k) FL_NO_EXCEPT;
+
+    // Values.
+    void value(const char *s) FL_NO_EXCEPT;   // JSON string (escaped)
+    void value(fl::i64 n) FL_NO_EXCEPT;       // JSON number
+    void value(int n) FL_NO_EXCEPT { value(static_cast<fl::i64>(n)); }
+    void value(bool b) FL_NO_EXCEPT;          // true / false
+    void valueNull() FL_NO_EXCEPT;            // null
+
+    // Convenience: key + value in one call.
+    void member(const char *k, const char *s) FL_NO_EXCEPT { key(k); value(s); }
+    void member(const char *k, fl::i64 n) FL_NO_EXCEPT { key(k); value(n); }
+    void member(const char *k, int n) FL_NO_EXCEPT { key(k); value(static_cast<fl::i64>(n)); }
+    void member(const char *k, bool b) FL_NO_EXCEPT { key(k); value(b); }
+
+    // Flush the scratch buffer to the sink. Called automatically on
+    // destruction; call explicitly to finish a top-level document.
+    void flush() FL_NO_EXCEPT;
+
+  private:
+    void putc(char c) FL_NO_EXCEPT;
+    void puts(const char *s) FL_NO_EXCEPT;
+    void putEscaped(const char *s) FL_NO_EXCEPT;
+    void prefixForValue() FL_NO_EXCEPT;  // emit comma/nothing before a value
+    void prefixForKey() FL_NO_EXCEPT;    // emit comma before a new key
+
+    Sink mSink;
+    char mBuf[kBufSize];
+    fl::size mLen;                 // bytes currently in mBuf
+    bool mNeedComma[kMaxDepth];    // does the current container have a prior element?
+    fl::size mDepth;              // current nesting depth
+    bool mPendingKey;             // true after key(), expecting a value next
+};
+
+} // namespace fl

--- a/tests/fl/stl/json_stream_writer.cpp
+++ b/tests/fl/stl/json_stream_writer.cpp
@@ -1,0 +1,88 @@
+#include "test.h"
+#include "fl/stl/json_stream_writer.h"
+#include "fl/stl/string.h"
+
+FL_TEST_FILE(FL_FILEPATH) {
+
+FL_TEST_CASE("JsonStreamWriter emits correct JSON") {
+    FL_SUBCASE("flat object") {
+        fl::string out;
+        {
+            fl::JsonStreamWriter w([&](const char *p, fl::size n) {
+                out.append(p, n);
+            });
+            w.beginObject();
+            w.member("name", "ping");
+            w.member("count", (fl::i64)3);
+            w.member("ok", true);
+            w.endObject();
+        }  // dtor flushes
+        FL_CHECK_EQ(out, fl::string("{\"name\":\"ping\",\"count\":3,\"ok\":true}"));
+    }
+
+    FL_SUBCASE("array of objects (the help shape)") {
+        fl::string out;
+        {
+            fl::JsonStreamWriter w([&](const char *p, fl::size n) { out.append(p, n); });
+            w.beginObject();
+            w.key("result");
+            w.beginArray();
+            for (int i = 0; i < 3; ++i) {
+                w.beginObject();
+                w.member("i", (fl::i64)i);
+                w.endObject();
+            }
+            w.endArray();
+            w.endObject();
+        }
+        FL_CHECK_EQ(out, fl::string("{\"result\":[{\"i\":0},{\"i\":1},{\"i\":2}]}"));
+    }
+
+    FL_SUBCASE("string escaping") {
+        fl::string out;
+        {
+            fl::JsonStreamWriter w([&](const char *p, fl::size n) { out.append(p, n); });
+            w.value("a\"b\\c\nd");
+        }
+        FL_CHECK_EQ(out, fl::string("\"a\\\"b\\\\c\\nd\""));
+    }
+
+    FL_SUBCASE("null and nested") {
+        fl::string out;
+        {
+            fl::JsonStreamWriter w([&](const char *p, fl::size n) { out.append(p, n); });
+            w.beginObject();
+            w.key("v"); w.valueNull();
+            w.key("nested"); w.beginObject();
+            w.member("x", (fl::i64)-5);
+            w.endObject();
+            w.endObject();
+        }
+        FL_CHECK_EQ(out, fl::string("{\"v\":null,\"nested\":{\"x\":-5}}"));
+    }
+
+    FL_SUBCASE("large array uses bounded memory (no N-sized buffer)") {
+        // The writer's own footprint is fixed regardless of output size:
+        // the whole document streams through a 128-byte scratch buffer.
+        fl::size total = 0;
+        fl::size max_single_write = 0;
+        {
+            fl::JsonStreamWriter w([&](const char *, fl::size n) {
+                total += n;
+                if (n > max_single_write) max_single_write = n;
+            });
+            w.beginArray();
+            for (int i = 0; i < 1000; ++i) {
+                w.beginObject();
+                w.member("name", "some_method_name");
+                w.member("index", (fl::i64)i);
+                w.endObject();
+            }
+            w.endArray();
+        }
+        FL_CHECK(total > 20000);  // large document produced
+        FL_CHECK(max_single_write <= fl::JsonStreamWriter::kBufSize);  // never a big buffer
+    }
+}
+
+}


### PR DESCRIPTION
The #3588 root-cause fix (#3603, make_shared null-construction under OOM) stops the heap **corruption**, but building a large JSON-RPC response as an `fl::json` object and serializing it to an `fl::string` still allocates two buffers proportional to the whole response. A `help` listing of ~200 methods (or a big `runSingleTest` result) can still exhaust the heap on classic ESP32 with WiFi up.

`JsonStreamWriter` emits a JSON document incrementally to a byte sink through a **fixed 128-byte scratch buffer** and a fixed-depth nesting stack — **no heap allocation of its own**. An arbitrarily large document streams with a bounded, tiny footprint (peak memory = one small buffer, not the document). Handles commas, key/value alternation, string escaping, numbers/bools/null.

```cpp
fl::JsonStreamWriter w(sink);
w.beginObject();
w.key("result"); w.beginArray();
for (m : methods) { w.beginObject(); w.member("name", m.name); ... w.endObject(); }
w.endArray();
w.endObject();  // dtor flushes
```

Host-tested: escaping, nesting, null, and a 1000-element array verified to stream through the fixed buffer with no single write exceeding `kBufSize`. Host 349/349, lint clean, esp32dev builds.

**Integration path (follow-up):** wire the RPC transport to expose a raw byte sink so `help`/large handlers stream directly instead of returning a full `fl::json`. This primitive is the mechanism; the RPC-protocol plumbing needs on-device verification and lands separately.

Refs #3588.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a streaming JSON writer for incremental output, including support for objects, arrays, keys, strings, numbers, booleans, and null values.
  * Added automatic buffering and flushing to help generate JSON with limited memory use.

* **Tests**
  * Added coverage for JSON formatting, escaping, nested structures, and large outputs to verify consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->