### PR TITLE
Stream large JSON-RPC responses

### DIFF
--- a/examples/AutoResearch/AutoResearchRemote.cpp
+++ b/examples/AutoResearch/AutoResearchRemote.cpp
@@ -92,6 +92,21 @@ void printRemoteResponseRaw(const fl::json& response) {
     Serial.flush();                     // ok serial - ok autoresearch rpc serial - host waits for RPC boundary
 }
 
+void printRemoteStreamRaw(fl::JsonStreamCallback writeJson) {
+    static const char kPrefix[] = "REMOTE: ";
+    Serial.write(reinterpret_cast<const uint8_t*>(kPrefix), sizeof(kPrefix) - 1);  // ok serial - ok autoresearch rpc serial - RPC response boundary
+
+    fl::JsonStreamWriter writer([](const char* data, fl::size len) {
+        Serial.write(reinterpret_cast<const uint8_t*>(data), static_cast<size_t>(len));  // ok serial - ok autoresearch rpc serial - streamed JSON bytes
+    });
+    if (writeJson) {
+        writeJson(writer);
+    }
+    writer.flush();
+    Serial.println();  // ok serial - ok autoresearch rpc serial - RPC response boundary
+    Serial.flush();    // ok serial - ok autoresearch rpc serial - host waits for RPC boundary
+}
+
 }  // namespace
 
 void printStreamRaw(const char* messageType, const fl::json& data) {
@@ -399,7 +414,8 @@ fl::json AutoResearchRemoteControl::findConnectedPinsImpl(const fl::json& args) 
 AutoResearchRemoteControl::AutoResearchRemoteControl()
     : mRemote(fl::make_unique<fl::Remote>(
         fl::createSerialRequestSource(),
-        printRemoteResponseRaw
+        printRemoteResponseRaw,
+        printRemoteStreamRaw
     )) {
     // mState will be set by registerFunctions()
 }

--- a/examples/AutoResearch/AutoResearchRemotePinMethods.cpp
+++ b/examples/AutoResearch/AutoResearchRemotePinMethods.cpp
@@ -50,6 +50,64 @@
 #include "fl/stl/detail/memory_file_handle.h"
 #include "fl/fx/frame.h"
 
+namespace {
+
+struct HelpEntry {
+    const char* name;
+    const char* phase;
+    const char* args;
+    const char* returns;
+    const char* description;
+};
+
+void streamHelpEntry(fl::JsonStreamWriter& writer, const HelpEntry& entry) {
+    writer.beginObject();
+    writer.member("name", entry.name);
+    writer.member("phase", entry.phase);
+    writer.member("args", entry.args);
+    writer.member("returns", entry.returns);
+    writer.member("description", entry.description);
+    writer.endObject();
+}
+
+static const HelpEntry kHelpEntries[] = {
+    {"start", "Phase 1: Basic Control", "[]", "void", "Trigger test matrix execution"},
+    {"status", "Phase 1: Basic Control", "[]", "{startReceived, testComplete, frameCounter, state}", "Query current test state"},
+    {"drivers", "Phase 1: Basic Control", "[]", "[{name, priority, enabled}, ...]", "List available drivers"},
+    {"getConfig", "Phase 2: Configuration", "[]", "{drivers, laneRange, stripSizes, totalTestCases}", "Query current test matrix configuration"},
+    {"setDrivers", "Phase 2: Configuration", "[driver1, driver2, ...]", "{success, driversSet, testCases}", "Configure enabled drivers"},
+    {"setLaneRange", "Phase 2: Configuration", "[minLanes, maxLanes]", "{success, minLanes, maxLanes, testCases}", "Configure lane range (1-16)"},
+    {"setStripSizes", "Phase 2: Configuration", "[size] or [shortSize, longSize]", "{success, stripSizesSet, testCases}", "Configure strip sizes"},
+    {"runTestCase", "Phase 3: Selective Execution", "[testCaseIndex]", "{success, testCaseIndex, result}", "Run single test case by index"},
+    {"runDriver", "Phase 3: Selective Execution", "[driverName]", "{success, driver, testsRun, results}", "Run all tests for specific driver"},
+    {"runAll", "Phase 3: Selective Execution", "[]", "{success, totalCases, passedCases, skippedCases, results}", "Run full test matrix with JSON results"},
+    {"getResults", "Phase 3: Selective Execution", "[]", "[{driver, lanes, stripSize, ...}, ...]", "Return all test results"},
+    {"getResult", "Phase 3: Selective Execution", "[testCaseIndex]", "{driver, lanes, stripSize, ...}", "Return specific test case result"},
+    {"reset", "Phase 4: Utility", "[]", "{success, message, testCasesCleared}", "Reset test state without device reboot"},
+    {"halt", "Phase 4: Utility", "[]", "{success, message}", "Trigger sketch halt"},
+    {"ping", "Phase 4: Utility", "[]", "{success, message, timestamp, uptimeMs, frameCounter}", "Health check with timestamp"},
+    {"getPins", "Phase 5: Pin Configuration", "[]", "{txPin, rxPin, defaults: {txPin, rxPin}, platform}", "Query current and default pin configuration"},
+    {"setTxPin", "Phase 5: Pin Configuration", "[pin]", "{success, txPin, previousTxPin, testCases}", "Set TX pin (regenerates test cases)"},
+    {"setRxPin", "Phase 5: Pin Configuration", "[pin]", "{success, rxPin, previousRxPin, rxChannelRecreated}", "Set RX pin (recreates RX channel)"},
+    {"setPins", "Phase 5: Pin Configuration", "[{txPin, rxPin}] or [txPin, rxPin]", "{success, txPin, rxPin, rxChannelRecreated, testCases}", "Set both TX and RX pins atomically"},
+    {"findConnectedPins", "Phase 5: Pin Configuration", "[{startPin, endPin, autoApply}] (all optional)", "{success, found, txPin, rxPin, autoApplied, testedPairs}", "Probe adjacent pin pairs to find jumper wire connection"},
+    {"help", "Phase 4: Utility", "[]", "[{name, phase, args, returns, description}, ...]", "List all RPC functions with descriptions"},
+    {"testSimd", "Phase 4: Utility", "[]", "{success, passed, totalTests, passedTests, failedTests, failures:[string]}", "Run comprehensive SIMD test suite (85 tests)"},
+    {"testSimdBenchmark", "Phase 4: Utility", "[{iterations}] (optional, default 10000)", "{success, iterations, float_us, s16x16_us, simd_us}", "Benchmark multiply speed: float vs s16x16 vs s16x16x4 SIMD"},
+    {"animartrixPerlinBench", "Phase 4: Utility", "[{iterations}] (optional, default 100, max 10000)", "{success, iterations, pnoise_calls_per_iter, pnoise_float_us, pnoise_i16_us, speedup_x1000}", "Animartrix-representative Perlin noise bench: scalar float pnoise vs s16x16 fixed-point pnoise2d (16x16 grid per iter, mirrors a real frame). Answers: how much does fixed-point beat float for Animartrix's hot path on this hardware?"},
+    {"wave8ExpandBenchmark", "Phase 4: Utility", "[{iterations}] (optional, default 30000, max 200000)", "{success, iterations, expand_nibble_us, expand_byte_us, expand_batched_us, transpose16_nibble_us, transpose16_byte_us, sink}", "Bench PARLIO Wave8 expansion (#2526): nibble vs byte vs batched LUT, plus full per-byte-position cost (expansion + 16-lane transpose)"},
+    {"ieee754CodecTest", "Phase 4: Utility", "[]", "{success, tests_run, tests_failed, first_failure, expected_bits, actual_bits}", "On-device verification of the integer-only IEEE 754 decimal codec (#3039): parse, format, round-trip, overflow/underflow, and NaN rejection without strtof/libm."},
+    {"parlioEncodeBenchmark", "Phase 4: Utility", "[{iterations}] (optional, default 12000, max 200000)", "{success, iters, lanes, leds_per_lane, scratchPsramOk, outputPsramOk, perpos_ss_us, perpos_sp_us, perpos_ps_us, perpos_pp_us, frame_ss_us, frame_sp_us, frame_ps_us, frame_pp_us, sink}", "Bench full PARLIO encode hot loop (16-lane gather + BF1 pipe4 direct encode) with SRAM and optional PSRAM placements; answers PSRAM hypothesis + ISR-streaming feasibility"},
+    {"timingDriftTest", "Phase 4: Utility", "[{pin, numLeds, iterations}] (all optional; default pin=4, numLeds=35, iterations=10)", "{success, pin, num_leds, iterations, cpu_mhz, show_count, show_min_us, show_max_us, show_total_us, iter_ms:[...]}", "Issue #2994 repro for compounded per-sequence timing drift on master vs 3.10.3. Replays the reporter's WS2812B-ring + millisDelay-gated fade sketch and returns per-sequence wall time (theoretical 2495 ms; on 3.10.3 rock-steady, on master 2563-2752)."},
+    {"parlioStreamValidate", "Phase 4: Utility", "[{baseTxPin, txPins, numLanes, numLeds, iterations, timeoutMs}] (all optional; txPins overrides contiguous baseTxPin)", "{success, completed, baseTxPin, txPins, lanes, leds_per_lane, iterations, perIterUs:[...], steadyAvgUs, failedIter, underrunCount, txDoneCount, workerIsrCount, ringError, hardwareIdle}", "Functional test of the PARLIO ISR-chunked streaming engine (#2548). Drives N back-to-back FastLED.show() calls through the production engine (which uses BF1+pipe4 on 16-lane Wave8 since #2559) and verifies all complete within timeout. Catches hangs/stalls."},
+    {"flexioRxBenchmark", "Phase 4: Utility", "[{frequency_hz=1000, duration_ms=100, tx_pin=3, rx_pin=4}] (all optional)", "{success, frequency_hz, duration_ms, tx_pin, rx_pin, edges_captured, periods, period_mean_ns, period_sigma_ns, period_min_ns, period_max_ns}", "Square-wave validation for the FlexIO RX backend (Teensy 4.x only, FastLED#2764 Phase 2). Drives tx_pin via analogWriteFrequency at 50%% duty, captures via RxBackend::FLEXIO on rx_pin, reports per-period statistics."},
+    {"flexioObjectFledTest", "Phase 4: Utility", "[{test_case=0..4, tx_pin=3, rx_pin=4, capture_ms=50}] (all optional)", "{success, test_case, tx_pin, rx_pin, num_leds, expected_bytes, decoded_bytes, matched, mismatched, edges_captured}", "End-to-end ObjectFLED TX -> FlexIO RX loopback verification (Teensy 4.x only, FastLED#2764 Phase 3). Drives WS2812 patterns through Bus::FLEX_IO slot 0, captures via RxBackend::FLEXIO, decodes the bit stream, and reports byte-level match counts. Five fixed test patterns: 0=red, 1=RGB triple, 2=all zeros, 3=all ones, 4=100-LED alternating."},
+};
+
+static const fl::size kHelpEntryCount = sizeof(kHelpEntries) / sizeof(kHelpEntries[0]);
+
+}  // namespace
+
 
 void AutoResearchRemoteControl::bindPinMethods(fl::Remote& remote) {
     // Register "setDebug" function - enable/disable runtime debug logging
@@ -350,267 +408,20 @@ void AutoResearchRemoteControl::bindPinMethods(fl::Remote& remote) {
     });
 
     // Register "help" function - list all RPC functions with descriptions
-    remote.bind("help", [this](const fl::json& args) -> fl::json {
-        fl::json functions = fl::json::array();
+    remote.bindStreaming("help", [](fl::JsonStreamWriter& writer, const fl::json& args, const fl::json& requestId) {
+        (void)args;
+        (void)requestId;
 
-        // Phase 1: Basic Control
-        fl::json start_fn = fl::json::object();
-        start_fn.set("name", "start");
-        start_fn.set("phase", "Phase 1: Basic Control");
-        start_fn.set("args", "[]");
-        start_fn.set("returns", "void");
-        start_fn.set("description", "Trigger test matrix execution");
-        functions.push_back(start_fn);
-
-        fl::json status_fn = fl::json::object();
-        status_fn.set("name", "status");
-        status_fn.set("phase", "Phase 1: Basic Control");
-        status_fn.set("args", "[]");
-        status_fn.set("returns", "{startReceived, testComplete, frameCounter, state}");
-        status_fn.set("description", "Query current test state");
-        functions.push_back(status_fn);
-
-        fl::json drivers_fn = fl::json::object();
-        drivers_fn.set("name", "drivers");
-        drivers_fn.set("phase", "Phase 1: Basic Control");
-        drivers_fn.set("args", "[]");
-        drivers_fn.set("returns", "[{name, priority, enabled}, ...]");
-        drivers_fn.set("description", "List available drivers");
-        functions.push_back(drivers_fn);
-
-        // Phase 2: Configuration
-        fl::json getConfig_fn = fl::json::object();
-        getConfig_fn.set("name", "getConfig");
-        getConfig_fn.set("phase", "Phase 2: Configuration");
-        getConfig_fn.set("args", "[]");
-        getConfig_fn.set("returns", "{drivers, laneRange, stripSizes, totalTestCases}");
-        getConfig_fn.set("description", "Query current test matrix configuration");
-        functions.push_back(getConfig_fn);
-
-        fl::json setDrivers_fn = fl::json::object();
-        setDrivers_fn.set("name", "setDrivers");
-        setDrivers_fn.set("phase", "Phase 2: Configuration");
-        setDrivers_fn.set("args", "[driver1, driver2, ...]");
-        setDrivers_fn.set("returns", "{success, driversSet, testCases}");
-        setDrivers_fn.set("description", "Configure enabled drivers");
-        functions.push_back(setDrivers_fn);
-
-        fl::json setLaneRange_fn = fl::json::object();
-        setLaneRange_fn.set("name", "setLaneRange");
-        setLaneRange_fn.set("phase", "Phase 2: Configuration");
-        setLaneRange_fn.set("args", "[minLanes, maxLanes]");
-        setLaneRange_fn.set("returns", "{success, minLanes, maxLanes, testCases}");
-        setLaneRange_fn.set("description", "Configure lane range (1-16)");
-        functions.push_back(setLaneRange_fn);
-
-        fl::json setStripSizes_fn = fl::json::object();
-        setStripSizes_fn.set("name", "setStripSizes");
-        setStripSizes_fn.set("phase", "Phase 2: Configuration");
-        setStripSizes_fn.set("args", "[size] or [shortSize, longSize]");
-        setStripSizes_fn.set("returns", "{success, stripSizesSet, testCases}");
-        setStripSizes_fn.set("description", "Configure strip sizes");
-        functions.push_back(setStripSizes_fn);
-
-        // Phase 3: Selective Execution
-        fl::json runTestCase_fn = fl::json::object();
-        runTestCase_fn.set("name", "runTestCase");
-        runTestCase_fn.set("phase", "Phase 3: Selective Execution");
-        runTestCase_fn.set("args", "[testCaseIndex]");
-        runTestCase_fn.set("returns", "{success, testCaseIndex, result}");
-        runTestCase_fn.set("description", "Run single test case by index");
-        functions.push_back(runTestCase_fn);
-
-        fl::json runDriver_fn = fl::json::object();
-        runDriver_fn.set("name", "runDriver");
-        runDriver_fn.set("phase", "Phase 3: Selective Execution");
-        runDriver_fn.set("args", "[driverName]");
-        runDriver_fn.set("returns", "{success, driver, testsRun, results}");
-        runDriver_fn.set("description", "Run all tests for specific driver");
-        functions.push_back(runDriver_fn);
-
-        fl::json runAll_fn = fl::json::object();
-        runAll_fn.set("name", "runAll");
-        runAll_fn.set("phase", "Phase 3: Selective Execution");
-        runAll_fn.set("args", "[]");
-        runAll_fn.set("returns", "{success, totalCases, passedCases, skippedCases, results}");
-        runAll_fn.set("description", "Run full test matrix with JSON results");
-        functions.push_back(runAll_fn);
-
-        fl::json getResults_fn = fl::json::object();
-        getResults_fn.set("name", "getResults");
-        getResults_fn.set("phase", "Phase 3: Selective Execution");
-        getResults_fn.set("args", "[]");
-        getResults_fn.set("returns", "[{driver, lanes, stripSize, ...}, ...]");
-        getResults_fn.set("description", "Return all test results");
-        functions.push_back(getResults_fn);
-
-        fl::json getResult_fn = fl::json::object();
-        getResult_fn.set("name", "getResult");
-        getResult_fn.set("phase", "Phase 3: Selective Execution");
-        getResult_fn.set("args", "[testCaseIndex]");
-        getResult_fn.set("returns", "{driver, lanes, stripSize, ...}");
-        getResult_fn.set("description", "Return specific test case result");
-        functions.push_back(getResult_fn);
-
-        // Phase 4: Utility and Control
-        fl::json reset_fn = fl::json::object();
-        reset_fn.set("name", "reset");
-        reset_fn.set("phase", "Phase 4: Utility");
-        reset_fn.set("args", "[]");
-        reset_fn.set("returns", "{success, message, testCasesCleared}");
-        reset_fn.set("description", "Reset test state without device reboot");
-        functions.push_back(reset_fn);
-
-        fl::json halt_fn = fl::json::object();
-        halt_fn.set("name", "halt");
-        halt_fn.set("phase", "Phase 4: Utility");
-        halt_fn.set("args", "[]");
-        halt_fn.set("returns", "{success, message}");
-        halt_fn.set("description", "Trigger sketch halt");
-        functions.push_back(halt_fn);
-
-        fl::json ping_fn = fl::json::object();
-        ping_fn.set("name", "ping");
-        ping_fn.set("phase", "Phase 4: Utility");
-        ping_fn.set("args", "[]");
-        ping_fn.set("returns", "{success, message, timestamp, uptimeMs, frameCounter}");
-        ping_fn.set("description", "Health check with timestamp");
-        functions.push_back(ping_fn);
-
-        // Phase 5: Pin Configuration
-        fl::json getPins_fn = fl::json::object();
-        getPins_fn.set("name", "getPins");
-        getPins_fn.set("phase", "Phase 5: Pin Configuration");
-        getPins_fn.set("args", "[]");
-        getPins_fn.set("returns", "{txPin, rxPin, defaults: {txPin, rxPin}, platform}");
-        getPins_fn.set("description", "Query current and default pin configuration");
-        functions.push_back(getPins_fn);
-
-        fl::json setTxPin_fn = fl::json::object();
-        setTxPin_fn.set("name", "setTxPin");
-        setTxPin_fn.set("phase", "Phase 5: Pin Configuration");
-        setTxPin_fn.set("args", "[pin]");
-        setTxPin_fn.set("returns", "{success, txPin, previousTxPin, testCases}");
-        setTxPin_fn.set("description", "Set TX pin (regenerates test cases)");
-        functions.push_back(setTxPin_fn);
-
-        fl::json setRxPin_fn = fl::json::object();
-        setRxPin_fn.set("name", "setRxPin");
-        setRxPin_fn.set("phase", "Phase 5: Pin Configuration");
-        setRxPin_fn.set("args", "[pin]");
-        setRxPin_fn.set("returns", "{success, rxPin, previousRxPin, rxChannelRecreated}");
-        setRxPin_fn.set("description", "Set RX pin (recreates RX channel)");
-        functions.push_back(setRxPin_fn);
-
-        fl::json setPins_fn = fl::json::object();
-        setPins_fn.set("name", "setPins");
-        setPins_fn.set("phase", "Phase 5: Pin Configuration");
-        setPins_fn.set("args", "[{txPin, rxPin}] or [txPin, rxPin]");
-        setPins_fn.set("returns", "{success, txPin, rxPin, rxChannelRecreated, testCases}");
-        setPins_fn.set("description", "Set both TX and RX pins atomically");
-        functions.push_back(setPins_fn);
-
-        fl::json findConnectedPins_fn = fl::json::object();
-        findConnectedPins_fn.set("name", "findConnectedPins");
-        findConnectedPins_fn.set("phase", "Phase 5: Pin Configuration");
-        findConnectedPins_fn.set("args", "[{startPin, endPin, autoApply}] (all optional)");
-        findConnectedPins_fn.set("returns", "{success, found, txPin, rxPin, autoApplied, testedPairs}");
-        findConnectedPins_fn.set("description", "Probe adjacent pin pairs to find jumper wire connection");
-        functions.push_back(findConnectedPins_fn);
-
-        fl::json help_fn = fl::json::object();
-        help_fn.set("name", "help");
-        help_fn.set("phase", "Phase 4: Utility");
-        help_fn.set("args", "[]");
-        help_fn.set("returns", "[{name, phase, args, returns, description}, ...]");
-        help_fn.set("description", "List all RPC functions with descriptions");
-        functions.push_back(help_fn);
-
-        fl::json testSimd_fn = fl::json::object();
-        testSimd_fn.set("name", "testSimd");
-        testSimd_fn.set("phase", "Phase 4: Utility");
-        testSimd_fn.set("args", "[]");
-        testSimd_fn.set("returns", "{success, passed, totalTests, passedTests, failedTests, failures:[string]}");
-        testSimd_fn.set("description", "Run comprehensive SIMD test suite (85 tests)");
-        functions.push_back(testSimd_fn);
-
-        fl::json testSimdBenchmark_fn = fl::json::object();
-        testSimdBenchmark_fn.set("name", "testSimdBenchmark");
-        testSimdBenchmark_fn.set("phase", "Phase 4: Utility");
-        testSimdBenchmark_fn.set("args", "[{iterations}] (optional, default 10000)");
-        testSimdBenchmark_fn.set("returns", "{success, iterations, float_us, s16x16_us, simd_us}");
-        testSimdBenchmark_fn.set("description", "Benchmark multiply speed: float vs s16x16 vs s16x16x4 SIMD");
-        functions.push_back(testSimdBenchmark_fn);
-
-        fl::json animartrixPerlinBench_fn = fl::json::object();
-        animartrixPerlinBench_fn.set("name", "animartrixPerlinBench");
-        animartrixPerlinBench_fn.set("phase", "Phase 4: Utility");
-        animartrixPerlinBench_fn.set("args", "[{iterations}] (optional, default 100, max 10000)");
-        animartrixPerlinBench_fn.set("returns", "{success, iterations, pnoise_calls_per_iter, pnoise_float_us, pnoise_i16_us, speedup_x1000}");
-        animartrixPerlinBench_fn.set("description", "Animartrix-representative Perlin noise bench: scalar float pnoise vs s16x16 fixed-point pnoise2d (16x16 grid per iter, mirrors a real frame). Answers: how much does fixed-point beat float for Animartrix's hot path on this hardware?");
-        functions.push_back(animartrixPerlinBench_fn);
-
-        fl::json wave8ExpandBenchmark_fn = fl::json::object();
-        wave8ExpandBenchmark_fn.set("name", "wave8ExpandBenchmark");
-        wave8ExpandBenchmark_fn.set("phase", "Phase 4: Utility");
-        wave8ExpandBenchmark_fn.set("args", "[{iterations}] (optional, default 30000, max 200000)");
-        wave8ExpandBenchmark_fn.set("returns", "{success, iterations, expand_nibble_us, expand_byte_us, expand_batched_us, transpose16_nibble_us, transpose16_byte_us, sink}");
-        wave8ExpandBenchmark_fn.set("description", "Bench PARLIO Wave8 expansion (#2526): nibble vs byte vs batched LUT, plus full per-byte-position cost (expansion + 16-lane transpose)");
-        functions.push_back(wave8ExpandBenchmark_fn);
-
-        fl::json ieee754CodecTest_fn = fl::json::object();
-        ieee754CodecTest_fn.set("name", "ieee754CodecTest");
-        ieee754CodecTest_fn.set("phase", "Phase 4: Utility");
-        ieee754CodecTest_fn.set("args", "[]");
-        ieee754CodecTest_fn.set("returns", "{success, tests_run, tests_failed, first_failure, expected_bits, actual_bits}");
-        ieee754CodecTest_fn.set("description", "On-device verification of the integer-only IEEE 754 decimal codec (#3039): parse, format, round-trip, overflow/underflow, and NaN rejection without strtof/libm.");
-        functions.push_back(ieee754CodecTest_fn);
-
-        fl::json parlioEncodeBenchmark_fn = fl::json::object();
-        parlioEncodeBenchmark_fn.set("name", "parlioEncodeBenchmark");
-        parlioEncodeBenchmark_fn.set("phase", "Phase 4: Utility");
-        parlioEncodeBenchmark_fn.set("args", "[{iterations}] (optional, default 12000, max 200000)");
-        parlioEncodeBenchmark_fn.set("returns", "{success, iters, lanes, leds_per_lane, scratchPsramOk, outputPsramOk, perpos_ss_us, perpos_sp_us, perpos_ps_us, perpos_pp_us, frame_ss_us, frame_sp_us, frame_ps_us, frame_pp_us, sink}");
-        parlioEncodeBenchmark_fn.set("description", "Bench full PARLIO encode hot loop (16-lane gather + BF1 pipe4 direct encode) with SRAM and optional PSRAM placements; answers PSRAM hypothesis + ISR-streaming feasibility");
-        functions.push_back(parlioEncodeBenchmark_fn);
-
-        fl::json timingDriftTest_fn = fl::json::object();
-        timingDriftTest_fn.set("name", "timingDriftTest");
-        timingDriftTest_fn.set("phase", "Phase 4: Utility");
-        timingDriftTest_fn.set("args", "[{pin, numLeds, iterations}] (all optional; default pin=4, numLeds=35, iterations=10)");
-        timingDriftTest_fn.set("returns", "{success, pin, num_leds, iterations, cpu_mhz, show_count, show_min_us, show_max_us, show_total_us, iter_ms:[...]}");
-        timingDriftTest_fn.set("description", "Issue #2994 repro for compounded per-sequence timing drift on master vs 3.10.3. Replays the reporter's WS2812B-ring + millisDelay-gated fade sketch and returns per-sequence wall time (theoretical 2495 ms; on 3.10.3 rock-steady, on master 2563-2752).");
-        functions.push_back(timingDriftTest_fn);
-
-        fl::json parlioStreamValidate_fn = fl::json::object();
-        parlioStreamValidate_fn.set("name", "parlioStreamValidate");
-        parlioStreamValidate_fn.set("phase", "Phase 4: Utility");
-        parlioStreamValidate_fn.set("args", "[{baseTxPin, txPins, numLanes, numLeds, iterations, timeoutMs}] (all optional; txPins overrides contiguous baseTxPin)");
-        parlioStreamValidate_fn.set("returns", "{success, completed, baseTxPin, txPins, lanes, leds_per_lane, iterations, perIterUs:[...], steadyAvgUs, failedIter, underrunCount, txDoneCount, workerIsrCount, ringError, hardwareIdle}");
-        parlioStreamValidate_fn.set("description", "Functional test of the PARLIO ISR-chunked streaming engine (#2548). Drives N back-to-back FastLED.show() calls through the production engine (which uses BF1+pipe4 on 16-lane Wave8 since #2559) and verifies all complete within timeout. Catches hangs/stalls.");
-        functions.push_back(parlioStreamValidate_fn);
-
-        fl::json flexioRxBenchmark_fn = fl::json::object();
-        flexioRxBenchmark_fn.set("name", "flexioRxBenchmark");
-        flexioRxBenchmark_fn.set("phase", "Phase 4: Utility");
-        flexioRxBenchmark_fn.set("args", "[{frequency_hz=1000, duration_ms=100, tx_pin=3, rx_pin=4}] (all optional)");
-        flexioRxBenchmark_fn.set("returns", "{success, frequency_hz, duration_ms, tx_pin, rx_pin, edges_captured, periods, period_mean_ns, period_sigma_ns, period_min_ns, period_max_ns}");
-        flexioRxBenchmark_fn.set("description", "Square-wave validation for the FlexIO RX backend (Teensy 4.x only, FastLED#2764 Phase 2). Drives tx_pin via analogWriteFrequency at 50%% duty, captures via RxBackend::FLEXIO on rx_pin, reports per-period statistics.");
-        functions.push_back(flexioRxBenchmark_fn);
-
-        fl::json flexioObjectFledTest_fn = fl::json::object();
-        flexioObjectFledTest_fn.set("name", "flexioObjectFledTest");
-        flexioObjectFledTest_fn.set("phase", "Phase 4: Utility");
-        flexioObjectFledTest_fn.set("args", "[{test_case=0..4, tx_pin=3, rx_pin=4, capture_ms=50}] (all optional)");
-        flexioObjectFledTest_fn.set("returns", "{success, test_case, tx_pin, rx_pin, num_leds, expected_bytes, decoded_bytes, matched, mismatched, edges_captured}");
-        flexioObjectFledTest_fn.set("description", "End-to-end ObjectFLED TX -> FlexIO RX loopback verification (Teensy 4.x only, FastLED#2764 Phase 3). Drives WS2812 patterns through Bus::FLEX_IO slot 0, captures via RxBackend::FLEXIO, decodes the bit stream, and reports byte-level match counts. Five fixed test patterns: 0=red, 1=RGB triple, 2=all zeros, 3=all ones, 4=100-LED alternating.");
-        functions.push_back(flexioObjectFledTest_fn);
-
-        fl::json response = fl::json::object();
-        response.set("success", true);
-        response.set("totalFunctions", static_cast<int64_t>(functions.size()));
-        response.set("functions", functions);
-        return response;
+        writer.beginObject();
+        writer.member("success", true);
+        writer.member("totalFunctions", static_cast<fl::i64>(kHelpEntryCount));
+        writer.key("functions");
+        writer.beginArray();
+        for (fl::size i = 0; i < kHelpEntryCount; ++i) {
+            streamHelpEntry(writer, kHelpEntries[i]);
+        }
+        writer.endArray();
+        writer.endObject();
     });
 }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -190,6 +190,13 @@ dependencies = [
     # incremental builds produce stale .obj files after a git pull that
     # changes transitive headers (symptom: `undefined symbol: ...` link
     # errors hours after a header actually changed).
+    # 1.12.13 (released 2026-07-05): picks up running-process 4.5.8,
+    # suppresses Windows console flashes during compiler identity probes,
+    # and fixes daemon wedging on large-crate full-codegen misses
+    # (zackees/zccache#957, #958, #959).
+    # 1.12.12 (released 2026-07-02): journals embedded compile outcomes,
+    # restoring hit-ratio/miss-reason telemetry for soldr-routed rustc
+    # compiles (zackees/zccache#950).
     # 1.12.5 (released 2026-06-14): native-file lifecycle fix on Windows
     # (zackees/zccache#710, surfaced in FastLED #3048). The meson-snapshot
     # restore path no longer leaves `meson_native.txt` in a broken state
@@ -198,7 +205,7 @@ dependencies = [
     # `FileNotFoundError: meson_native.txt` / `ninja: error: rebuilding
     # 'build.ninja': subcommand failed` cascade we hit during long-session
     # `bash test --cpp` cycles.
-    "zccache>=1.12.7",
+    "zccache>=1.12.13",
     "ninja",
     "meson>=1.11.0",
     "download",

--- a/src/fl/remote/remote.cpp.hpp
+++ b/src/fl/remote/remote.cpp.hpp
@@ -308,8 +308,18 @@ void Remote::clear(ClearFlags flags) {
 // Constructor
 
 Remote::Remote(RequestSource source, ResponseSink sink)
+    : Remote(fl::move(source), fl::move(sink), ResponseStreamSink{})
+{}
+
+Remote::Remote(RequestSource source, ResponseSink sink, ResponseStreamSink streamSink)
     : Server(fl::move(source), fl::move(sink))
 {
+#if FL_PLATFORM_HAS_LARGE_MEMORY
+    setResponseStreamSink(fl::move(streamSink));
+#else
+    (void)streamSink;
+#endif
+
     // Set request handler to processRpc
     setRequestHandler([this](const fl::json& request) {
         return processRpc(request);
@@ -322,6 +332,14 @@ Remote::Remote(RequestSource source, ResponseSink sink)
             mResponseSink(response);
         }
     });
+
+#if FL_PLATFORM_HAS_LARGE_MEMORY
+    mRpc.setResponseStreamSink([this](fl::JsonStreamCallback writeJson) {
+        if (mResponseStreamSink) {
+            mResponseStreamSink(fl::move(writeJson));
+        }
+    });
+#endif
 }
 
 // Server Coordination

--- a/src/fl/remote/remote.cpp.hpp
+++ b/src/fl/remote/remote.cpp.hpp
@@ -307,11 +307,11 @@ void Remote::clear(ClearFlags flags) {
 
 // Constructor
 
-Remote::Remote(RequestSource source, ResponseSink sink)
+Remote::Remote(RequestSource source, ResponseSink sink) FL_NO_EXCEPT
     : Remote(fl::move(source), fl::move(sink), ResponseStreamSink{})
 {}
 
-Remote::Remote(RequestSource source, ResponseSink sink, ResponseStreamSink streamSink)
+Remote::Remote(RequestSource source, ResponseSink sink, ResponseStreamSink streamSink) FL_NO_EXCEPT
     : Server(fl::move(source), fl::move(sink))
 {
 #if FL_PLATFORM_HAS_LARGE_MEMORY

--- a/src/fl/remote/remote.h
+++ b/src/fl/remote/remote.h
@@ -70,12 +70,12 @@ public:
      *   );
      *   // In main loop: transport->update(millis()); remote.update(millis());
      */
-    Remote(RequestSource source, ResponseSink sink);
+    Remote(RequestSource source, ResponseSink sink) FL_NO_EXCEPT;
 
     /**
      * @brief Construct with I/O callbacks, including streamed response output.
      */
-    Remote(RequestSource source, ResponseSink sink, ResponseStreamSink streamSink);
+    Remote(RequestSource source, ResponseSink sink, ResponseStreamSink streamSink) FL_NO_EXCEPT;
 
     // Non-copyable, non-movable (lambda captures 'this')
     Remote(const Remote&) FL_NO_EXCEPT = delete;
@@ -109,7 +109,7 @@ public:
     }
 
     /// Register method that streams its JSON-RPC result directly to the transport.
-    void bindStreaming(const char* name, fl::StreamingRpcHandler fn) {
+    void bindStreaming(const char* name, fl::StreamingRpcHandler fn) FL_NO_EXCEPT {
         mRpc.bindStreaming(name, fl::move(fn));
     }
 

--- a/src/fl/remote/remote.h
+++ b/src/fl/remote/remote.h
@@ -11,6 +11,7 @@
 #include "fl/stl/strstream.h"  // IWYU pragma: keep
 #include "fl/remote/rpc/rpc.h"
 #include "fl/remote/rpc/rpc_mode.h"
+#include "fl/remote/rpc/response_stream.h"
 #include "fl/remote/rpc/server.h"
 #include "fl/remote/types.h"
 #include "fl/net/rpc_scheduler.h"
@@ -71,6 +72,11 @@ public:
      */
     Remote(RequestSource source, ResponseSink sink);
 
+    /**
+     * @brief Construct with I/O callbacks, including streamed response output.
+     */
+    Remote(RequestSource source, ResponseSink sink, ResponseStreamSink streamSink);
+
     // Non-copyable, non-movable (lambda captures 'this')
     Remote(const Remote&) FL_NO_EXCEPT = delete;
     Remote(Remote&&) FL_NO_EXCEPT = delete;
@@ -100,6 +106,11 @@ public:
                    fl::function<void(fl::ResponseSend&, const fl::json&)> fn,
                    fl::RpcMode mode = fl::RpcMode::ASYNC) {
         mRpc.bindAsync(name, fl::move(fn), mode);
+    }
+
+    /// Register method that streams its JSON-RPC result directly to the transport.
+    void bindStreaming(const char* name, fl::StreamingRpcHandler fn) {
+        mRpc.bindStreaming(name, fl::move(fn));
     }
 
     /// Get bound method by name for direct C++ invocation

--- a/src/fl/remote/rpc/response_stream.h
+++ b/src/fl/remote/rpc/response_stream.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include "fl/stl/function.h"
+#include "fl/stl/json.h"
+#include "fl/stl/json_stream_writer.h"
+#include "fl/stl/noexcept.h"
+
+namespace fl {
+
+using JsonStreamCallback = fl::function<void(fl::JsonStreamWriter&)>;
+using ResponseStreamSink = fl::function<void(fl::JsonStreamCallback)>;
+using StreamingRpcHandler =
+    fl::function<void(fl::JsonStreamWriter&, const fl::json&, const fl::json&)>;
+
+inline void streamJsonRpcId(fl::JsonStreamWriter& writer,
+                            const fl::json& id) FL_NO_EXCEPT {
+    if (!id.has_value() || id.is_null()) {
+        writer.valueNull();
+        return;
+    }
+    if (id.is_string()) {
+        fl::string s = id.as_string().value_or("");
+        writer.value(s.c_str());
+        return;
+    }
+    if (id.is_bool()) {
+        writer.value(id.as_bool().value_or(false));
+        return;
+    }
+    if (id.is_int()) {
+        writer.value(id.as_int().value_or(0));
+        return;
+    }
+    if (id.is_number()) {
+        writer.value(static_cast<fl::i64>(id.as_float().value_or(0.0f)));
+        return;
+    }
+    writer.valueNull();
+}
+
+inline void streamJsonRpcResultEnvelope(
+    fl::JsonStreamWriter& writer,
+    const fl::json& requestId,
+    bool includeId,
+    const fl::JsonStreamCallback& writeResult) FL_NO_EXCEPT {
+    writer.beginObject();
+    writer.member("jsonrpc", "2.0");
+    writer.key("result");
+    if (writeResult) {
+        writeResult(writer);
+    } else {
+        writer.valueNull();
+    }
+    if (includeId) {
+        writer.key("id");
+        streamJsonRpcId(writer, requestId);
+    }
+    writer.endObject();
+}
+
+} // namespace fl

--- a/src/fl/remote/rpc/rpc.cpp.hpp
+++ b/src/fl/remote/rpc/rpc.cpp.hpp
@@ -25,6 +25,14 @@ void Rpc::setResponseSink(fl::function<void(const fl::json&)> sink) {
     mResponseSink = fl::move(sink);
 }
 
+void Rpc::setResponseStreamSink(fl::ResponseStreamSink sink) {
+#if FL_PLATFORM_HAS_LARGE_MEMORY
+    mResponseStreamSink = fl::move(sink);
+#else
+    (void)sink;
+#endif
+}
+
 // =============================================================================
 // Rpc::bindAsync() - Bind async method with ResponseSend parameter
 // =============================================================================
@@ -58,6 +66,38 @@ void Rpc::bindAsync(const char* name,
     entry.mInvoker = fl::make_shared<PlaceholderInvoker>();
 
     mRegistry[key] = fl::move(entry);
+}
+
+// =============================================================================
+// Rpc::bindStreaming() - Bind streaming method with JsonStreamWriter parameter
+// =============================================================================
+
+void Rpc::bindStreaming(const char* name, fl::StreamingRpcHandler fn) {
+#if FL_PLATFORM_HAS_LARGE_MEMORY
+    fl::string key(name);
+
+    detail::RpcEntry entry;
+    entry.mTypeTag = detail::TypeTag<void(const json&)>::id();
+    entry.mMode = RpcMode::SYNC;
+    entry.mIsStreaming = true;
+    entry.mStreamingFn = fl::move(fn);
+
+    entry.mSchemaGenerator = fl::make_shared<detail::TypedSchemaGenerator<void(const json&)>>();
+    entry.mDescription = "";
+    entry.mTags = {};
+
+    struct PlaceholderInvoker : public detail::ErasedInvoker {
+        fl::tuple<TypeConversionResult, json> invoke(const json&) override {
+            return fl::make_tuple(TypeConversionResult::success(), json(nullptr));
+        }
+    };
+    entry.mInvoker = fl::make_shared<PlaceholderInvoker>();
+
+    mRegistry[key] = fl::move(entry);
+#else
+    (void)name;
+    (void)fn;
+#endif
 }
 
 // =============================================================================
@@ -131,6 +171,34 @@ json Rpc::handle(const json& request) {
     // Check if this is an async function
     const detail::RpcEntry& entry = it->second;
 #if FL_PLATFORM_HAS_LARGE_MEMORY
+    if (entry.mIsStreaming) {
+        if (!mResponseStreamSink) {
+            return detail::makeJsonRpcError(-32603, "Streaming response sink not configured", request["id"]);
+        }
+
+        fl::StreamingRpcHandler streamFn = entry.mStreamingFn;
+        fl::json paramsCopy = params;
+        fl::json requestId = request.contains("id") ? request["id"] : json(nullptr);
+        const bool includeId = request.contains("id");
+        mResponseStreamSink([streamFn, paramsCopy, requestId, includeId](fl::JsonStreamWriter& writer) {
+            streamJsonRpcResultEnvelope(
+                writer,
+                requestId,
+                includeId,
+                [streamFn, paramsCopy, requestId](fl::JsonStreamWriter& resultWriter) {
+                    if (streamFn) {
+                        streamFn(resultWriter, paramsCopy, requestId);
+                    } else {
+                        resultWriter.valueNull();
+                    }
+                });
+        });
+
+        fl::json skip = fl::json::object();
+        skip.set("noEnqueue", true);
+        return skip;
+    }
+
     bool isAsync = (entry.mMode == RpcMode::ASYNC || entry.mMode == RpcMode::ASYNC_STREAM);
 
     // Check if this is a response-aware function (uses ResponseSend&)

--- a/src/fl/remote/rpc/rpc.cpp.hpp
+++ b/src/fl/remote/rpc/rpc.cpp.hpp
@@ -25,7 +25,7 @@ void Rpc::setResponseSink(fl::function<void(const fl::json&)> sink) {
     mResponseSink = fl::move(sink);
 }
 
-void Rpc::setResponseStreamSink(fl::ResponseStreamSink sink) {
+void Rpc::setResponseStreamSink(fl::ResponseStreamSink sink) FL_NO_EXCEPT {
 #if FL_PLATFORM_HAS_LARGE_MEMORY
     mResponseStreamSink = fl::move(sink);
 #else
@@ -58,7 +58,7 @@ void Rpc::bindAsync(const char* name,
 
     // Create a placeholder invoker (actual invocation handled in handle())
     struct PlaceholderInvoker : public detail::ErasedInvoker {
-        fl::tuple<TypeConversionResult, json> invoke(const json&) override {
+        fl::tuple<TypeConversionResult, json> invoke(const json&) FL_NO_EXCEPT override {
             // Should not be called - handle() will call mResponseAwareFn directly
             return fl::make_tuple(TypeConversionResult::success(), json(nullptr));
         }
@@ -72,7 +72,7 @@ void Rpc::bindAsync(const char* name,
 // Rpc::bindStreaming() - Bind streaming method with JsonStreamWriter parameter
 // =============================================================================
 
-void Rpc::bindStreaming(const char* name, fl::StreamingRpcHandler fn) {
+void Rpc::bindStreaming(const char* name, fl::StreamingRpcHandler fn) FL_NO_EXCEPT {
 #if FL_PLATFORM_HAS_LARGE_MEMORY
     fl::string key(name);
 
@@ -87,7 +87,7 @@ void Rpc::bindStreaming(const char* name, fl::StreamingRpcHandler fn) {
     entry.mTags = {};
 
     struct PlaceholderInvoker : public detail::ErasedInvoker {
-        fl::tuple<TypeConversionResult, json> invoke(const json&) override {
+        fl::tuple<TypeConversionResult, json> invoke(const json&) FL_NO_EXCEPT override {
             return fl::make_tuple(TypeConversionResult::success(), json(nullptr));
         }
     };

--- a/src/fl/remote/rpc/rpc.h
+++ b/src/fl/remote/rpc/rpc.h
@@ -75,6 +75,7 @@
 #include "fl/remote/rpc/rpc_handle.h"
 #include "fl/remote/rpc/rpc_registry.h"
 #include "fl/remote/rpc/rpc_mode.h"
+#include "fl/remote/rpc/response_stream.h"
 #include "fl/remote/rpc/runtime_rpc_binding.h"  // RuntimeRpcBinding (low-memory dispatch, #3246)
 #include "fl/system/sketch_macros.h"             // FL_PLATFORM_HAS_LARGE_MEMORY
 
@@ -225,6 +226,9 @@ public:
     /// Set response sink for sending ACK responses (used by async functions)
     void setResponseSink(fl::function<void(const fl::json&)> sink);
 
+    /// Set response stream sink for methods registered with bindStreaming().
+    void setResponseStreamSink(fl::ResponseStreamSink sink);
+
     // =========================================================================
     // Method Registration (Binding)
     // =========================================================================
@@ -259,6 +263,11 @@ public:
     void bindAsync(const char* name,
                    fl::function<void(ResponseSend&, const json&)> fn,
                    fl::RpcMode mode = fl::RpcMode::ASYNC);
+
+    /// Bind a method that streams its JSON-RPC result directly to the transport.
+    /// The callback writes only the `result` payload; the RPC layer writes the
+    /// JSON-RPC envelope and request id.
+    void bindStreaming(const char* name, fl::StreamingRpcHandler fn);
 
     // =========================================================================
     // Method Retrieval
@@ -396,6 +405,9 @@ public:
 private:
     fl::unordered_map<fl::string, detail::RpcEntry> mRegistry;
     fl::function<void(const fl::json&)> mResponseSink;  // For sending ACK responses
+#if FL_PLATFORM_HAS_LARGE_MEMORY
+    fl::ResponseStreamSink mResponseStreamSink;
+#endif
 };
 
 // RpcFactory is kept as an alias for backwards compatibility

--- a/src/fl/remote/rpc/rpc.h
+++ b/src/fl/remote/rpc/rpc.h
@@ -227,7 +227,7 @@ public:
     void setResponseSink(fl::function<void(const fl::json&)> sink);
 
     /// Set response stream sink for methods registered with bindStreaming().
-    void setResponseStreamSink(fl::ResponseStreamSink sink);
+    void setResponseStreamSink(fl::ResponseStreamSink sink) FL_NO_EXCEPT;
 
     // =========================================================================
     // Method Registration (Binding)
@@ -267,7 +267,7 @@ public:
     /// Bind a method that streams its JSON-RPC result directly to the transport.
     /// The callback writes only the `result` payload; the RPC layer writes the
     /// JSON-RPC envelope and request id.
-    void bindStreaming(const char* name, fl::StreamingRpcHandler fn);
+    void bindStreaming(const char* name, fl::StreamingRpcHandler fn) FL_NO_EXCEPT;
 
     // =========================================================================
     // Method Retrieval

--- a/src/fl/remote/rpc/rpc_registry.h
+++ b/src/fl/remote/rpc/rpc_registry.h
@@ -9,6 +9,8 @@
 #include "fl/stl/unordered_map.h"  // IWYU pragma: keep
 #include "fl/remote/rpc/rpc_invokers.h"  // IWYU pragma: keep
 #include "fl/remote/rpc/rpc_mode.h"
+#include "fl/remote/rpc/response_stream.h"
+#include "fl/system/sketch_macros.h"
 #include "fl/stl/noexcept.h"
 
 namespace fl {
@@ -52,6 +54,12 @@ struct RpcEntry {
     // For response-aware async methods (with ResponseSend& parameter)
     fl::function<void(ResponseSend&, const json&)> mResponseAwareFn;
     bool mIsResponseAware = false;
+
+#if FL_PLATFORM_HAS_LARGE_MEMORY
+    // For streamed sync methods that write their JSON-RPC result directly.
+    StreamingRpcHandler mStreamingFn;
+    bool mIsStreaming = false;
+#endif
 };
 
 // =============================================================================

--- a/src/fl/remote/rpc/server.cpp.hpp
+++ b/src/fl/remote/rpc/server.cpp.hpp
@@ -29,6 +29,14 @@ void Server::setResponseSink(ResponseSink sink) {
     mResponseSink = fl::move(sink);
 }
 
+void Server::setResponseStreamSink(ResponseStreamSink sink) {
+#if FL_PLATFORM_HAS_LARGE_MEMORY
+    mResponseStreamSink = fl::move(sink);
+#else
+    (void)sink;
+#endif
+}
+
 size_t Server::update() {
     size_t processed = pull();
     size_t sent = push();

--- a/src/fl/remote/rpc/server.cpp.hpp
+++ b/src/fl/remote/rpc/server.cpp.hpp
@@ -29,7 +29,7 @@ void Server::setResponseSink(ResponseSink sink) {
     mResponseSink = fl::move(sink);
 }
 
-void Server::setResponseStreamSink(ResponseStreamSink sink) {
+void Server::setResponseStreamSink(ResponseStreamSink sink) FL_NO_EXCEPT {
 #if FL_PLATFORM_HAS_LARGE_MEMORY
     mResponseStreamSink = fl::move(sink);
 #else

--- a/src/fl/remote/rpc/server.h
+++ b/src/fl/remote/rpc/server.h
@@ -77,7 +77,7 @@ public:
      * The callback is invoked once per complete streamed JSON document. It
      * owns transport framing such as serial prefixes and trailing newlines.
      */
-    void setResponseStreamSink(ResponseStreamSink sink);
+    void setResponseStreamSink(ResponseStreamSink sink) FL_NO_EXCEPT;
 
     /**
      * @brief Main update: pull + push

--- a/src/fl/remote/rpc/server.h
+++ b/src/fl/remote/rpc/server.h
@@ -5,6 +5,8 @@
 #include "fl/stl/optional.h"
 #include "fl/stl/vector.h"
 #include "fl/stl/noexcept.h"
+#include "fl/remote/rpc/response_stream.h"
+#include "fl/system/sketch_macros.h"
 
 namespace fl {
 
@@ -70,6 +72,14 @@ public:
     void setResponseSink(ResponseSink sink);
 
     /**
+     * @brief Set streaming response sink callback
+     *
+     * The callback is invoked once per complete streamed JSON document. It
+     * owns transport framing such as serial prefixes and trailing newlines.
+     */
+    void setResponseStreamSink(ResponseStreamSink sink);
+
+    /**
      * @brief Main update: pull + push
      */
     size_t update();
@@ -88,6 +98,9 @@ protected:
     RequestSource mRequestSource;
     ResponseSink mResponseSink;
     RequestHandler mRequestHandler;
+#if FL_PLATFORM_HAS_LARGE_MEMORY
+    ResponseStreamSink mResponseStreamSink;
+#endif
     fl::vector<fl::json> mOutgoingQueue;
 };
 

--- a/src/fl/remote/transport/serial.h
+++ b/src/fl/remote/transport/serial.h
@@ -26,6 +26,7 @@
 #include "fl/stl/string.h"
 #include "fl/stl/strstream.h"
 #include "fl/stl/string_view.h"
+#include "fl/remote/rpc/response_stream.h"
 
 namespace fl {
 
@@ -88,6 +89,9 @@ inline fl::optional<fl::string> readSerialLine(SerialReader& serial, char delimi
 /// @note Works across all FastLED platforms
 struct SerialWriter {
     void println(const char* str) { fl::println(str); }
+    void write(const char* data, fl::size len) {
+        fl::write_bytes(reinterpret_cast<const fl::u8*>(data), len);  // ok reinterpret cast
+    }
 };
 
 // =============================================================================
@@ -165,6 +169,29 @@ createSerialResponseSink(const char* prefix = "REMOTE: ") {
         SerialWriter serial;
         fl::string formatted = formatJsonResponse(response, prefix);
         writeSerialLine(serial, formatted);
+    };
+}
+
+/// @brief Create a streamed JSON-RPC ResponseSink that writes directly to serial
+/// @param prefix Optional prefix to prepend to responses (default: "REMOTE: ")
+/// @return Streaming response sink suitable for fl::Remote constructor
+inline fl::ResponseStreamSink
+createSerialResponseStreamSink(const char* prefix = "REMOTE: ") {
+    return [prefix](fl::JsonStreamCallback writeJson) {
+        SerialWriter serial;
+        if (prefix && prefix[0] != '\0') {
+            serial.write(prefix, fl::strlen(prefix));
+        }
+
+        fl::JsonStreamWriter writer([&serial](const char* data, fl::size len) {
+            serial.write(data, len);
+        });
+        if (writeJson) {
+            writeJson(writer);
+        }
+        writer.flush();
+        serial.write("\n", 1);
+        fl::flush();
     };
 }
 

--- a/src/fl/remote/transport/serial.h
+++ b/src/fl/remote/transport/serial.h
@@ -89,7 +89,7 @@ inline fl::optional<fl::string> readSerialLine(SerialReader& serial, char delimi
 /// @note Works across all FastLED platforms
 struct SerialWriter {
     void println(const char* str) { fl::println(str); }
-    void write(const char* data, fl::size len) {
+    void write(const char* data, fl::size len) FL_NO_EXCEPT {
         fl::write_bytes(reinterpret_cast<const fl::u8*>(data), len);  // ok reinterpret cast
     }
 };
@@ -176,7 +176,7 @@ createSerialResponseSink(const char* prefix = "REMOTE: ") {
 /// @param prefix Optional prefix to prepend to responses (default: "REMOTE: ")
 /// @return Streaming response sink suitable for fl::Remote constructor
 inline fl::ResponseStreamSink
-createSerialResponseStreamSink(const char* prefix = "REMOTE: ") {
+createSerialResponseStreamSink(const char* prefix = "REMOTE: ") FL_NO_EXCEPT {
     return [prefix](fl::JsonStreamCallback writeJson) {
         SerialWriter serial;
         if (prefix && prefix[0] != '\0') {

--- a/src/fl/stl/json_stream_writer.cpp.hpp
+++ b/src/fl/stl/json_stream_writer.cpp.hpp
@@ -23,7 +23,7 @@ void JsonStreamWriter::flush() FL_NO_EXCEPT {
     }
 }
 
-void JsonStreamWriter::putc(char c) FL_NO_EXCEPT {
+void JsonStreamWriter::writeChar(char c) FL_NO_EXCEPT {
     if (mLen >= kBufSize) {
         flush();
     }
@@ -35,12 +35,12 @@ void JsonStreamWriter::puts(const char *s) FL_NO_EXCEPT {
         return;
     }
     for (; *s; ++s) {
-        putc(*s);
+        writeChar(*s);
     }
 }
 
 void JsonStreamWriter::putEscaped(const char *s) FL_NO_EXCEPT {
-    putc('"');
+    writeChar('"');
     if (s) {
         for (; *s; ++s) {
             const unsigned char c = static_cast<unsigned char>(*s);
@@ -57,16 +57,16 @@ void JsonStreamWriter::putEscaped(const char *s) FL_NO_EXCEPT {
                         // Control character → \u00XX
                         static const char *kHex = "0123456789abcdef";
                         puts("\\u00");
-                        putc(kHex[(c >> 4) & 0xF]);
-                        putc(kHex[c & 0xF]);
+                        writeChar(kHex[(c >> 4) & 0xF]);
+                        writeChar(kHex[c & 0xF]);
                     } else {
-                        putc(static_cast<char>(c));
+                        writeChar(static_cast<char>(c));
                     }
                     break;
             }
         }
     }
-    putc('"');
+    writeChar('"');
 }
 
 void JsonStreamWriter::prefixForValue() FL_NO_EXCEPT {
@@ -79,7 +79,7 @@ void JsonStreamWriter::prefixForValue() FL_NO_EXCEPT {
     // container already has a prior element.
     if (mDepth > 0) {
         if (mNeedComma[mDepth - 1]) {
-            putc(',');
+            writeChar(',');
         }
         mNeedComma[mDepth - 1] = true;
     }
@@ -88,7 +88,7 @@ void JsonStreamWriter::prefixForValue() FL_NO_EXCEPT {
 void JsonStreamWriter::prefixForKey() FL_NO_EXCEPT {
     if (mDepth > 0) {
         if (mNeedComma[mDepth - 1]) {
-            putc(',');
+            writeChar(',');
         }
         mNeedComma[mDepth - 1] = true;
     }
@@ -96,7 +96,7 @@ void JsonStreamWriter::prefixForKey() FL_NO_EXCEPT {
 
 void JsonStreamWriter::beginObject() FL_NO_EXCEPT {
     prefixForValue();
-    putc('{');
+    writeChar('{');
     if (mDepth < kMaxDepth) {
         mNeedComma[mDepth] = false;
     }
@@ -107,12 +107,12 @@ void JsonStreamWriter::endObject() FL_NO_EXCEPT {
     if (mDepth > 0) {
         --mDepth;
     }
-    putc('}');
+    writeChar('}');
 }
 
 void JsonStreamWriter::beginArray() FL_NO_EXCEPT {
     prefixForValue();
-    putc('[');
+    writeChar('[');
     if (mDepth < kMaxDepth) {
         mNeedComma[mDepth] = false;
     }
@@ -123,13 +123,13 @@ void JsonStreamWriter::endArray() FL_NO_EXCEPT {
     if (mDepth > 0) {
         --mDepth;
     }
-    putc(']');
+    writeChar(']');
 }
 
 void JsonStreamWriter::key(const char *k) FL_NO_EXCEPT {
     prefixForKey();
     putEscaped(k);
-    putc(':');
+    writeChar(':');
     mPendingKey = true;
 }
 
@@ -143,7 +143,7 @@ void JsonStreamWriter::value(fl::i64 n) FL_NO_EXCEPT {
     char buf[24];
     int len = fl::itoa64(n, buf, 10);
     for (int i = 0; i < len; ++i) {
-        putc(buf[i]);
+        writeChar(buf[i]);
     }
 }
 

--- a/src/fl/stl/json_stream_writer.h
+++ b/src/fl/stl/json_stream_writer.h
@@ -69,7 +69,7 @@ class JsonStreamWriter {
     void flush() FL_NO_EXCEPT;
 
   private:
-    void putc(char c) FL_NO_EXCEPT;
+    void writeChar(char c) FL_NO_EXCEPT;
     void puts(const char *s) FL_NO_EXCEPT;
     void putEscaped(const char *s) FL_NO_EXCEPT;
     void prefixForValue() FL_NO_EXCEPT;  // emit comma/nothing before a value

--- a/tests/fl/remote/rpc.cpp
+++ b/tests/fl/remote/rpc.cpp
@@ -4,3 +4,4 @@
 #include "tests/fl/remote/rpc/response_send.hpp"
 #include "tests/fl/remote/rpc/rpc.hpp"
 #include "tests/fl/remote/rpc/runtime_rpc_binding.hpp"
+#include "tests/fl/remote/rpc/streaming.hpp"

--- a/tests/fl/remote/rpc/streaming.hpp
+++ b/tests/fl/remote/rpc/streaming.hpp
@@ -1,0 +1,84 @@
+#include "fl/remote/remote.h"
+#include "fl/stl/json.h"
+#include "fl/stl/string.h"
+#include "fl/stl/vector.h"
+#include "test.h"
+
+using namespace fl;
+
+FL_TEST_CASE("Rpc: bindStreaming writes a JSON-RPC result envelope") {
+    fl::string streamed;
+    fl::vector<fl::json> queued;
+
+    Remote remote(
+        []() { return fl::optional<fl::json>(); },
+        [&queued](const fl::json& response) { queued.push_back(response); },
+        [&streamed](fl::JsonStreamCallback writeJson) {
+            fl::JsonStreamWriter writer([&streamed](const char* data, fl::size len) {
+                streamed.append(data, len);
+            });
+            writeJson(writer);
+            writer.flush();
+        });
+
+    remote.bindStreaming("help", [](fl::JsonStreamWriter& writer,
+                                    const fl::json& params,
+                                    const fl::json& requestId) {
+        FL_CHECK(params.is_array());
+        FL_CHECK_EQ(requestId.as_int().value_or(0), 77);
+        writer.beginObject();
+        writer.member("success", true);
+        writer.member("totalFunctions", 2);
+        writer.key("functions");
+        writer.beginArray();
+        writer.beginObject();
+        writer.member("name", "a");
+        writer.endObject();
+        writer.beginObject();
+        writer.member("name", "b");
+        writer.endObject();
+        writer.endArray();
+        writer.endObject();
+    });
+
+    fl::json request = fl::json::object();
+    request.set("jsonrpc", "2.0");
+    request.set("method", "help");
+    request.set("params", fl::json::array());
+    request.set("id", 77);
+
+    fl::json response = remote.processRpc(request);
+    FL_CHECK(response.contains("noEnqueue"));
+    FL_CHECK(response["noEnqueue"].as_bool().value_or(false));
+    FL_CHECK(queued.empty());
+
+    fl::json parsed = fl::json::parse(streamed);
+    FL_CHECK_EQ(parsed["jsonrpc"].as_string().value_or(""), "2.0");
+    FL_CHECK_EQ(parsed["id"].as_int().value_or(0), 77);
+    FL_CHECK(parsed["result"]["success"].as_bool().value_or(false));
+    FL_CHECK_EQ(parsed["result"]["totalFunctions"].as_int().value_or(0), 2);
+    FL_CHECK_EQ(parsed["result"]["functions"].size(), 2);
+    FL_CHECK_EQ(parsed["result"]["functions"][1]["name"].as_string().value_or(""), "b");
+}
+
+FL_TEST_CASE("Rpc: streaming method without stream sink returns an error") {
+    Rpc rpc;
+    rpc.bindStreaming("large", [](fl::JsonStreamWriter& writer,
+                                  const fl::json& params,
+                                  const fl::json& requestId) {
+        (void)params;
+        (void)requestId;
+        writer.valueNull();
+    });
+
+    fl::json request = fl::json::object();
+    request.set("jsonrpc", "2.0");
+    request.set("method", "large");
+    request.set("params", fl::json::array());
+    request.set("id", 9);
+
+    fl::json response = rpc.handle(request);
+    FL_REQUIRE(response.contains("error"));
+    FL_CHECK_EQ(response["error"]["code"].as_int().value_or(0), -32603);
+    FL_CHECK_EQ(response["id"].as_int().value_or(0), 9);
+}

--- a/tests/fl/remote/transport/serial.cpp
+++ b/tests/fl/remote/transport/serial.cpp
@@ -179,6 +179,46 @@ FL_TEST_CASE("Serial: formatJsonResponse - with prefix") {
     FL_REQUIRE(formatted.find("42") != fl::string::npos);
 }
 
+FL_TEST_CASE("Serial: createSerialResponseStreamSink - streams framed JSON") {
+    fl::string output;
+    fl::size maxWrite = 0;
+
+    fl::inject_write_bytes_handler([&](const fl::u8* data, fl::size size) -> fl::size {
+        output.append(reinterpret_cast<const char*>(data), size);  // ok reinterpret cast
+        if (size > maxWrite) {
+            maxWrite = size;
+        }
+        return size;
+    });
+
+    auto sink = fl::createSerialResponseStreamSink("REMOTE: ");
+    sink([](fl::JsonStreamWriter& writer) {
+        writer.beginObject();
+        writer.member("jsonrpc", "2.0");
+        writer.key("result");
+        writer.beginArray();
+        for (int i = 0; i < 64; ++i) {
+            writer.value("abcdef0123456789");
+        }
+        writer.endArray();
+        writer.member("id", 5);
+        writer.endObject();
+    });
+
+    fl::clear_io_handlers();
+
+    FL_REQUIRE(output.starts_with("REMOTE: "));
+    FL_REQUIRE(output.back() == '\n');
+    FL_CHECK(maxWrite <= fl::JsonStreamWriter::kBufSize);
+
+    fl::string jsonText = output.substr(fl::strlen("REMOTE: "));
+    jsonText = jsonText.substr(0, jsonText.size() - 1);
+    fl::json parsed = fl::json::parse(jsonText);
+    FL_CHECK_EQ(parsed["jsonrpc"].as_string().value_or(""), "2.0");
+    FL_CHECK_EQ(parsed["id"].as_int().value_or(0), 5);
+    FL_CHECK_EQ(parsed["result"].size(), 64);
+}
+
 // =============================================================================
 // String Optimization Comparison Tests
 // =============================================================================


### PR DESCRIPTION
## Summary
- add a streamed JSON-RPC response path with `bindStreaming()` and transport-level JSON document streaming
- add serial streaming response support that writes chunks directly through the transport
- convert AutoResearch `help` to stream its result with `JsonStreamWriter` instead of building a full `fl::json` array/string
- keep the new streaming headers AVR-safe, satisfy the C++ noexcept linter, and bump the zccache floor to `>=1.12.13`

Closes #3605

## Tests
- `bash lint --cpp`
- `bash test tests/fl/remote/rpc.cpp`
- `bash test tests/fl/remote/transport/serial.cpp`
- `bash test tests/fl/remote/remote.cpp`
- `bash compile uno --examples Blink --max-failures 1`
- `bash compile esp32s3 --examples AutoResearch --max-failures 1`

Note: on-device WiFi heap validation was not run in this environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added streaming support for remote JSON-RPC results, enabling incremental response output for larger payloads.
  * Updated the remote “help” RPC to stream function metadata while keeping the same overall response shape.
  * Enhanced serial transport to support framed streaming responses with consistent prefixing and flushing.

* **Bug Fixes**
  * Streaming RPC requests now return a clear JSON-RPC error when streaming response support is not configured.

* **Tests**
  * Added unit tests covering streaming RPC envelope formatting and serial framing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->