### PR TITLE
[codex] bump fbuild to 2.3.24

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,9 +5,13 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    # Pin to fbuild 2.3.15 (released 2026-06-30).
+    # Pin to fbuild 2.3.24 (released 2026-07-02).
     #
     # Pin history:
+    #   2.3.24 -- latest PyPI/GitHub release as of 2026-07-05; rolls up the
+    #             post-2.3.15 daemon spawn, serial attach/reset-dispatch, and
+    #             deploy fixes needed for current hardware validation runs
+    #             (FastLED/fbuild#889/#893/#895/#897/#906/#908/#923/#928/#935).
     #   2.3.15 -- carries the Windows compile env fix (TMP/TEMP propagation)
     #             AND the path-separator fix that surfaced immediately after
     #             (forward-slash paths so cc1's spec-file pass doesn't eat
@@ -136,7 +140,7 @@ dependencies = [
     # primitive (FastLED/fbuild#532, #577/#580), and an
     # http-connect-timeout fix on the managed-zccache client
     # (FastLED/fbuild#573).
-    "fbuild==2.3.15",
+    "fbuild==2.3.24",
     "platformio>=6.1.19,<6.2",
     "python-dateutil",
     "ruff",


### PR DESCRIPTION
## Summary

Bumps the local FastLED Python dependency pin from `fbuild==2.3.15` to `fbuild==2.3.24` and records the release in the existing pin-history block.

## Why

The newer fbuild release rolls up post-2.3.15 daemon spawn, serial attach/reset-dispatch, and deploy fixes needed for current hardware validation work. During the dual-device AutoResearch run, the older local setup had a stale/mismatched daemon state; after syncing to 2.3.24 the CLI, package metadata, and daemon all reported the same version.

## Validation

- `uv lock --upgrade-package fbuild`
- `uv sync --refresh-package fbuild`
- `.venv\Scripts\fbuild.exe --version` -> `fbuild 2.3.24`
- `.venv\Scripts\python.exe -m pip show fbuild` -> `Version: 2.3.24`
- Reflashed AutoResearch on `COM11` (`esp32dev`) and `COM9` (`esp32c6`) through fbuild; deploy succeeded on both boards.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a bundled dependency to a newer version and refreshed the related release notes. No user-facing behavior changes are expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->