### PR TITLE
[codex] fix AutoResearch network client endpoints

### DIFF
--- a/examples/AutoResearch/AutoResearchNet.cpp
+++ b/examples/AutoResearch/AutoResearchNet.cpp
@@ -332,9 +332,11 @@ fl::json runNetClientTest(const char* host_ip, uint16_t port) {
 
     // Build URLs
     char url_ping[128];
-    char url_data[128];
+    char url_status[128];
+    char url_leds[128];
     snprintf(url_ping, sizeof(url_ping), "http://%s:%u/ping", host_ip, port);
-    snprintf(url_data, sizeof(url_data), "http://%s:%u/data", host_ip, port);
+    snprintf(url_status, sizeof(url_status), "http://%s:%u/status", host_ip, port);
+    snprintf(url_leds, sizeof(url_leds), "http://%s:%u/leds", host_ip, port);
 
     // Test 1: GET /ping
     {
@@ -350,9 +352,23 @@ fl::json runNetClientTest(const char* host_ip, uint16_t port) {
 
     FastLED.watchdog().feed();  // between blocking HTTP tests (single-core WDT)
 
-    // Test 2: GET /data
+    // Test 2: GET /status
     {
-        fl::json r = runHttpGetTest(url_data, "GET /data");
+        fl::json r = runHttpGetTest(url_status, "GET /status");
+        auto passed = r[fl::string("passed")].as_bool();
+        if (passed.has_value() && passed.value()) {
+            tests_passed++;
+        } else {
+            tests_failed++;
+        }
+        results.push_back(r);
+    }
+
+    FastLED.watchdog().feed();  // between blocking HTTP tests (single-core WDT)
+
+    // Test 3: GET /leds
+    {
+        fl::json r = runHttpGetTest(url_leds, "GET /leds");
         auto passed = r[fl::string("passed")].as_bool();
         if (passed.has_value() && passed.value()) {
             tests_passed++;


### PR DESCRIPTION
## Summary

Fixes AutoResearch `runNetClientTest` to call the routes actually registered by `startNetServer`.

The client helper now checks:

- `GET /ping`
- `GET /status`
- `GET /leds`

instead of the stale `GET /data` route, which the WROOM server does not expose.

## Root cause

`startNetServer()` registers `/ping`, `/status`, `/echo`, and `/leds`. `runNetClientTest()` still built a `/data` URL, so the dual-device C6-to-WROOM traffic helper returned `tests_passed=1, tests_failed=1` with a 404 even when the server was reachable.

## Validation

Hardware setup discovered with `fbuild port scan`:

- `COM11`: CP210x NodeMCU/WROOM-class ESP32 server
- `COM9`: ESP32-C6 client

Reflashed both boards through `bash autoresearch ... --upload-port ... --skip-lint` after this patch; fbuild deploy succeeded on both.

Dual-device run after the fix:

- C6 joined WROOM AP as `192.168.4.2`
- First `runNetClientTest` passed all 3 endpoints: `/ping`, `/status`, `/leds`
- I2S under active C6 traffic:
  - `[10]`: pass
  - `[10,10]`: pass
  - `[10,10,10,10]`: pass
  - `[10]*8`: timed out after 180s, WROOM still responded to `ping`

Baselines:

- No traffic: `[10]*8` passed in 160 ms and `[10]*16` passed in 370 ms
- AP associated but idle: `[10,10]` and `[10]*4` passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability when making consecutive HTTP requests, helping the example run more reliably.
  * Updated endpoint checks to validate the app’s current status and LED responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->