### PR TITLE
chore(deps): bump fbuild to 2.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,9 +5,17 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    # Pin to fbuild 2.3.24 (released 2026-07-02).
+    # Pin to fbuild 2.4.0 (released 2026-07-06).
     #
     # Pin history:
+    #   2.4.0 -- carries daemon serial lock diagnostics/recovery for stale
+    #             serial sessions: `daemon locks` now exposes owner metadata,
+    #             ages/activity, and pending attaches, while `clear-locks`
+    #             can target stale sessions by port/client id without OS
+    #             process spelunking (FastLED/fbuild#976/#978). Release was
+    #             unblocked by the native Windows soldr watchdog alignment and
+    #             Linux-hosted x64 Windows release lane in FastLED/fbuild#979
+    #             and FastLED/fbuild#980.
     #   2.3.24 -- latest PyPI/GitHub release as of 2026-07-05; rolls up the
     #             post-2.3.15 daemon spawn, serial attach/reset-dispatch, and
     #             deploy fixes needed for current hardware validation runs
@@ -140,7 +148,7 @@ dependencies = [
     # primitive (FastLED/fbuild#532, #577/#580), and an
     # http-connect-timeout fix on the managed-zccache client
     # (FastLED/fbuild#573).
-    "fbuild==2.3.24",
+    "fbuild==2.4.0",
     "platformio>=6.1.19,<6.2",
     "python-dateutil",
     "ruff",


### PR DESCRIPTION
﻿## Summary
- pin fbuild to 2.4.0
- document the serial lock diagnostics/recovery rollout and release unblock PRs

## Verification
- `uv lock --upgrade-package fbuild`
- `uv run --frozen fbuild --version`
- `uv run --frozen python -c "import importlib.metadata as m; print(m.version('fbuild'))"`
- `uv run --frozen fbuild daemon locks --help`
- `uv run --frozen fbuild daemon clear-locks --help`
- `git diff --check`

## Upstream
- FastLED/fbuild#978
- FastLED/fbuild#979
- FastLED/fbuild#980
- fbuild v2.4.0: https://github.com/FastLED/fbuild/releases/tag/v2.4.0


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a pinned dependency to a newer release.
  * Refreshed the accompanying version history notes to reflect the latest release information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->