### PR TITLE
Add LPC845 UART DMA clockless default

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,7 @@
 | Writing/editing C++ code | `agents/docs/cpp-standards.md` |
 | Verifying a peripheral exists on a chip before writing driver code | `agents/docs/peripheral-existence.md` (halt on phantom — do not fabricate missing `<Peripheral>_Type` in vendor headers) |
 | Defining a register map / accessing MCU peripherals | `agents/docs/register-maps.md` (use vendor CMSIS PAL — do not hand-roll shims) |
+| Looking up MCU datasheets / user manuals | Prefer https://github.com/FastLED/datasheets when available, then vendor primary documentation |
 | Creating an API wrapper type | `agents/docs/cpp-standards.md` → "API Object Pattern" |
 | Adding a global setting / configuration knob | `agents/docs/cpp-standards.md` → "Public Settings Pattern" (new setters go on `CFastLED`, not as bare `fl::set_*` free functions) |
 | Writing/editing Python code | `agents/docs/python-standards.md` |

--- a/autoresearch
+++ b/autoresearch
@@ -32,13 +32,14 @@ Driver Selection (optional - omit for GPIO-only mode):
   --parlio            Test parallel I/O driver
   --rmt               Test RMT (Remote Control) driver
   --spi               Test SPI driver
-  --uart              Test UART driver
+  --uart              Test UART driver (LPC845: UART DMA clockless RX-DMA loopback)
   --lcd               Test LCD_CLOCKLESS driver (ESP32-S3 only)
   --lcd-spi           Test LCD_SPI driver (ESP32-S3 only)
   --lcd-rgb           Test LCD RGB driver (ESP32-P4 only)
   --object-fled       Test ObjectFLED DMA driver (Teensy 4.x only)
   --pwm-dma-cl        LPC845-only: channels-API SCT+DMA clockless
                       self-loopback (FastLED #3468). Jumper P0_10↔P0_11.
+  --dma-uart          LPC845-only: raw async UART TX DMA bench
   --all               Test all drivers
   --simd              Test SIMD operations only (no LED drivers needed)
   --coroutine         Test coroutine/task creation, stop, await (no LED drivers needed)

--- a/ci/autoresearch/args.py
+++ b/ci/autoresearch/args.py
@@ -246,7 +246,7 @@ See Also:
         driver_group.add_argument(
             "--uart",
             action="store_true",
-            help="Test only UART driver",
+            help="Test only UART driver (LPC845: UART DMA clockless RX-DMA loopback)",
         )
         driver_group.add_argument(
             "--lcd",
@@ -428,6 +428,11 @@ See Also:
             "while USART0 keeps serving the RPC console. Reports "
             "stream timing + beacon-toggle async proof. Mutually "
             "exclusive with --dma-spi / --pwm-dma-cl (flash budget).",
+        )
+        lpc_group.description = (
+            lpc_group.description
+            + " Use the top-level --uart flag on LPC845 for the UART DMA "
+            "clockless FastLED API loopback (#3611)."
         )
 
         # Standard options

--- a/ci/autoresearch/phases.py
+++ b/ci/autoresearch/phases.py
@@ -924,6 +924,28 @@ def _parse_args_and_build_commands(args: Args) -> RunContext | int:
         # (framework-arduino-lpc8xx#38).
         lpc_bench_defines.append("FASTLED_LPC_UART_DMA=1")
         lpc_bench_defines.append("FASTLED_LPC_DMA_ISR=1")
+    requested_env = (args.environment or args.environment_positional or "").lower()
+    if requested_env in LPC_WS2812_ENVS:
+        if getattr(args, "pin_toggle_rx", False):
+            lpc_bench_defines.append("FASTLED_LPC_RX_SCT=1")
+        if (
+            getattr(args, "ws2812_loopback", False)
+            or getattr(args, "pwm_dma_cl", False)
+        ):
+            lpc_bench_defines.append("FASTLED_LPC_RX_SCT_DMA=1")
+    if getattr(args, "uart", False) and requested_env in LPC_WS2812_ENVS:
+        lpc_bench_defines.append("FASTLED_LPC_UART_DMA=1")
+        lpc_bench_defines.append("FASTLED_LPC_DMA_ISR=1")
+        lpc_bench_defines.append("FL_LPC_UART_DMA_CLOCKLESS_TEST=1")
+        lpc_bench_defines.append("FL_LPC_UART_DMA_LOOPBACK_TEST=1")
+        if args.tx_pin is not None:
+            lpc_bench_defines.append(
+                f"FL_LPC_UART_DMA_CLOCKLESS_TX_PIN={args.tx_pin}"
+            )
+        if args.rx_pin is not None:
+            lpc_bench_defines.append(
+                f"FL_LPC_UART_DMA_CLOCKLESS_RX_PIN={args.rx_pin}"
+            )
     if getattr(args, "pwm_dma_cl", False):
         lpc_bench_defines.append("FASTLED_LPC_PWM_DMA=1")
 
@@ -1213,6 +1235,29 @@ async def _resolve_port_and_environment(ctx: RunContext) -> int | None:
         if getattr(args, "dma_uart", False):
             deferred_defines.append("FASTLED_LPC_UART_DMA=1")
             deferred_defines.append("FASTLED_LPC_DMA_ISR=1")
+        if (ctx.final_environment or "").lower() in LPC_WS2812_ENVS:
+            if getattr(args, "pin_toggle_rx", False):
+                deferred_defines.append("FASTLED_LPC_RX_SCT=1")
+            if (
+                getattr(args, "ws2812_loopback", False)
+                or getattr(args, "pwm_dma_cl", False)
+            ):
+                deferred_defines.append("FASTLED_LPC_RX_SCT_DMA=1")
+        if getattr(args, "uart", False) and (
+            ctx.final_environment or ""
+        ).lower() in LPC_WS2812_ENVS:
+            deferred_defines.append("FASTLED_LPC_UART_DMA=1")
+            deferred_defines.append("FASTLED_LPC_DMA_ISR=1")
+            deferred_defines.append("FL_LPC_UART_DMA_CLOCKLESS_TEST=1")
+            deferred_defines.append("FL_LPC_UART_DMA_LOOPBACK_TEST=1")
+            if args.tx_pin is not None:
+                deferred_defines.append(
+                    f"FL_LPC_UART_DMA_CLOCKLESS_TX_PIN={args.tx_pin}"
+                )
+            if args.rx_pin is not None:
+                deferred_defines.append(
+                    f"FL_LPC_UART_DMA_CLOCKLESS_RX_PIN={args.rx_pin}"
+                )
         if getattr(args, "pwm_dma_cl", False):
             deferred_defines.append("FASTLED_LPC_PWM_DMA=1")
 
@@ -1739,6 +1784,19 @@ async def _run_tests_or_special_mode(ctx: RunContext, qctx: QuietContext) -> int
                 )
                 return 1
             return await _run_lpc_dma_spi_tests(ctx)
+        # FastLED #3611: on LPC845, --uart runs the end-to-end UART DMA
+        # clockless loopback through the normal FastLED LED API.
+        if getattr(ctx.args, "uart", False) and final_environment in LPC_WS2812_ENVS:
+            if getattr(ctx.args, "dma_spi", False) or getattr(
+                ctx.args, "pwm_dma_cl", False
+            ):
+                print(
+                    "--uart is mutually exclusive with --dma-spi / "
+                    "--pwm-dma-cl on LPC845 (LowMemory flash budget fits "
+                    "one bench)."
+                )
+                return 1
+            return await _run_lpc_uart_clockless_tests(ctx)
         # #3453 follow-up: --dma-uart runs the async UART TX bench.
         if getattr(ctx.args, "dma_uart", False):
             if final_environment not in LPC_DMA_SPI_ENVS:
@@ -2578,6 +2636,52 @@ async def _run_lpc_dma_spi_tests(ctx: RunContext) -> int:
         upload_port,
         "--core-hz",
         str(core_hz),
+    ]
+    result = subprocess.run(cmd)
+    return 0 if result.returncode == 0 else 1
+
+
+async def _run_lpc_uart_clockless_tests(ctx: RunContext) -> int:
+    """Run the FastLED #3611 UART DMA clockless loopback bench."""
+    final_environment = (ctx.final_environment or "").lower()
+    if final_environment not in LPC_WS2812_ENVS:
+        print(
+            "--uart clockless loopback is only supported on LPC845 boards "
+            "(lpc845brk, lpc845, lpcxpresso845max)."
+        )
+        return 1
+
+    upload_port = ctx.upload_port
+    assert upload_port is not None
+
+    tx_pin = ctx.args.tx_pin if ctx.args.tx_pin is not None else 10
+    rx_pin = ctx.args.rx_pin if ctx.args.rx_pin is not None else 11
+
+    print()
+    print("=" * 60)
+    print("LPC845 UART DMA clockless MODE - RX-DMA loopback (#3611)")
+    print(f"   Wiring required: jumper P0_{tx_pin} -> P0_{rx_pin} on LPC845-BRK")
+    print("   API: FastLED.addLeds<WS2812, PIN, GRB>() + FastLED.show()")
+    print("   Driver: ChannelEngineLpcUartDma via Bus::UART / Bus::AUTO")
+    print(
+        "   Verifier: USART TX-DMA on the data pin, USART RX-DMA on --rx-pin"
+    )
+    print("   Build flags: -DFASTLED_LPC_UART_DMA=1 -DFASTLED_LPC_DMA_ISR=1")
+    print("=" * 60)
+    print()
+
+    cmd = [
+        "uv",
+        "run",
+        "python",
+        "-m",
+        "ci.autoresearch.test_lpc_uart_clockless",
+        "--port",
+        upload_port,
+        "--tx-pin",
+        str(tx_pin),
+        "--rx-pin",
+        str(rx_pin),
     ]
     result = subprocess.run(cmd)
     return 0 if result.returncode == 0 else 1

--- a/ci/autoresearch/rpc_bench.py
+++ b/ci/autoresearch/rpc_bench.py
@@ -69,6 +69,49 @@ class RpcBench:
                 return METHOD_NOT_FOUND
             return None
         # Non-empty dict result — hand it straight back.
+        return self._extract_result(resp)
+
+    def call_flat(
+        self,
+        method: str,
+        args: list[Any] | None = None,
+        timeout: float | None = None,
+    ) -> Any:
+        """Call RPC methods bound with positional C++ parameters."""
+
+        async def _call_flat():
+            if not self._client.is_connected:
+                raise RpcError("Not connected")
+            serial = self._client._serial
+            if serial is None:
+                raise RpcError("Not connected")
+            request_id = self._client._next_id
+            self._client._next_id = (request_id + 1) & 0xFFFFFFFF
+            cmd = {
+                "method": method,
+                "params": args if args is not None else [],
+                "id": request_id,
+            }
+            await serial.write(json.dumps(cmd, separators=(",", ":")) + "\n")
+            self._client._sent_count += 1
+            effective_timeout = timeout if timeout is not None else self._client.timeout
+            return await self._client._wait_for_response(
+                effective_timeout, expected_id=request_id
+            )
+
+        try:
+            resp = self._loop.run_until_complete(_call_flat())
+        except RpcTimeoutError:
+            return None
+        except RpcError as e:
+            msg = str(e).lower()
+            if "not found" in msg or "unknown method" in msg or "method" in msg:
+                return METHOD_NOT_FOUND
+            return None
+        return self._extract_result(resp)
+
+    @staticmethod
+    def _extract_result(resp) -> Any:
         if isinstance(resp.data, dict) and resp.data:
             return resp.data
         # CSV/string result: recover from the raw line RpcClient preserved.
@@ -82,6 +125,19 @@ class RpcBench:
         except (json.JSONDecodeError, ValueError):
             return resp.data
         return obj.get("result", resp.data)
+
+    def reset_and_drain(self) -> bool:
+        """Reset through the fbuild serial backend and drain boot output."""
+
+        async def _reset() -> bool:
+            serial = self._client._serial
+            if serial is None:
+                return False
+            ok = await serial.reset_device(None)
+            await self._client.drain_boot_output()
+            return ok
+
+        return bool(self._loop.run_until_complete(_reset()))
 
     def close(self) -> None:
         try:

--- a/ci/autoresearch/test_lpc_uart_clockless.py
+++ b/ci/autoresearch/test_lpc_uart_clockless.py
@@ -1,0 +1,202 @@
+"""FastLED #3611 - LPC845 UART DMA clockless loopback via FastLED API.
+
+This runner calls the device-side `uartDmaClocklessLoopbackSelf` RPC bound by
+examples/AutoResearch/AutoResearchUartDma.h when FASTLED_LPC_UART_DMA=1. The
+firmware drives LEDs through the normal FastLED.addLeds<WS2812, PIN, GRB>() +
+FastLED.show() path, routes USART RXD to --rx-pin through the LPC845 switch
+matrix, and verifies the USART RX-DMA bytes against the expected clockless
+expansion.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from ci.autoresearch.rpc_bench import METHOD_NOT_FOUND, RpcBench  # noqa: E402
+from ci.util.global_interrupt_handler import handle_keyboard_interrupt  # noqa: E402
+
+
+DEFAULT_PORT = "COM10"
+DEFAULT_BAUD = 115200
+DEFAULT_LED_COUNT = 8
+
+
+def send_rpc(
+    s: "RpcBench",
+    method: str,
+    args=None,
+    timeout: float = 10.0,
+):
+    """Call through RpcBench so serial stays on fbuild's monitor path."""
+    result = s.call(method, args=args, timeout=timeout)
+    if result is None:
+        return None
+    if result is METHOD_NOT_FOUND:
+        return {"error": {"code": -32601, "message": "method not found"}}
+    return {"result": result}
+
+
+def send_rpc_flat(
+    s: "RpcBench",
+    method: str,
+    args=None,
+    timeout: float = 10.0,
+):
+    """Call low-memory LPC positional RPC methods."""
+    result = s.call_flat(method, args=args, timeout=timeout)
+    if result is None:
+        return None
+    if result is METHOD_NOT_FOUND:
+        return {"error": {"code": -32601, "message": "method not found"}}
+    return {"result": result}
+
+
+def expected_grb_bytes(led_count: int, rgb: int) -> list[int]:
+    r = (rgb >> 16) & 0xFF
+    g = (rgb >> 8) & 0xFF
+    b = rgb & 0xFF
+    return [g, r, b] * led_count
+
+
+def print_device_failure(csv: str, data_pin: int, rx_pin: int) -> None:
+    parts = csv.split(",")
+    if len(parts) >= 2 and parts[0] == "0" and parts[1] == "loopback":
+        rx_count = parts[2] if len(parts) > 2 else "?"
+        expected_count = parts[3] if len(parts) > 3 else "?"
+        stream_done = parts[4] if len(parts) > 4 else "?"
+        print(
+            "    FAIL - UART RX-DMA mismatch: "
+            f"received={rx_count}, expected={expected_count}, "
+            f"uart_stream_done={stream_done}"
+        )
+        if len(parts) > 5:
+            print(f"      diagnostics: {parts[5:]}")
+        return
+
+    print(f"    FAIL - device reported failure: {csv!r}")
+
+
+def run_capture_self(
+    s: "RpcBench",
+    led_count: int,
+    rgb: int,
+    data_pin: int,
+    rx_pin: int,
+    capture_ms: int,
+) -> bool:
+    print()
+    print(
+        f"  RPC uartDmaClocklessLoopbackSelf(led_count={led_count}, "
+        f"rgb=0x{rgb:06X}, data_pin={data_pin}, rx_pin={rx_pin}, "
+        f"capture_ms={capture_ms})"
+    )
+    reply = send_rpc(
+        s,
+        "uartDmaClocklessLoopbackSelf",
+        args=[led_count, rgb, data_pin, rx_pin, capture_ms],
+    )
+    if reply is None or "result" not in reply:
+        print("    FAIL - no reply or error result")
+        return False
+
+    csv = reply["result"]
+    if not isinstance(csv, str) or not csv:
+        print(f"    FAIL - malformed result: {csv!r}")
+        return False
+
+    parts = csv.split(",")
+    if not parts or parts[0] != "1":
+        print_device_failure(csv, data_pin, rx_pin)
+        return False
+
+    if len(parts) < 2:
+        print(f"    FAIL - CSV missing length field: {csv!r}")
+        return False
+
+    try:
+        n_decoded = int(parts[1])
+        decoded_bytes = [int(x) for x in parts[2 : 2 + n_decoded]]
+    except (ValueError, IndexError) as e:
+        print(f"    FAIL - CSV parse error: {e} ({csv!r})")
+        return False
+
+    expected = expected_grb_bytes(led_count, rgb)
+    if decoded_bytes != expected:
+        print("    FAIL - byte mismatch")
+        print(f"      expected: {expected}")
+        print(f"      decoded:  {decoded_bytes}")
+        return False
+
+    print(f"    PASS - {n_decoded} bytes match expected pattern")
+    return True
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description="LPC845 UART DMA clockless FastLED API loopback (#3611)"
+    )
+    ap.add_argument("--port", default=DEFAULT_PORT)
+    ap.add_argument("--tx-pin", type=int, default=10)
+    ap.add_argument("--rx-pin", type=int, default=11)
+    args = ap.parse_args()
+
+    print("LPC UART DMA clockless RX-DMA loopback - FastLED #3611")
+    print(f"  Port: {args.port} @ {DEFAULT_BAUD}")
+    print(
+        f"  UART loopback: bridge U1_TXD P0_{args.tx_pin} -> "
+        f"U1_RXD P0_{args.rx_pin}"
+    )
+
+    try:
+        s = RpcBench(args.port)
+    except KeyboardInterrupt as ki:
+        handle_keyboard_interrupt(ki)
+        raise
+    except Exception as e:  # noqa: BLE001
+        print(f"Could not connect to {args.port}: {e}")
+        return 1
+
+    with s:
+        s.reset_and_drain()
+        echo = send_rpc_flat(s, "echo", args=[42], timeout=5.0)
+        if not echo or echo.get("result") != 42:
+            print(
+                "ERROR: echo failed; is AutoResearch firmware flashed and "
+                f"running? Got: {echo}",
+                file=sys.stderr,
+            )
+            return 2
+        print("[lpc-uart-clockless] echo ok")
+
+        for step in (0, 7):
+            probe = send_rpc(
+                s,
+                "uartDmaClocklessProbe",
+                args=[step, args.tx_pin, args.rx_pin],
+                timeout=5.0,
+            )
+            print(f"[lpc-uart-clockless] probe step {step}: {probe}")
+
+        all_pass = True
+        all_pass &= run_capture_self(
+            s, DEFAULT_LED_COUNT, 0xFF0000, args.tx_pin, args.rx_pin, 40
+        )
+        all_pass &= run_capture_self(
+            s, DEFAULT_LED_COUNT, 0x00FF00, args.tx_pin, args.rx_pin, 40
+        )
+        all_pass &= run_capture_self(
+            s, DEFAULT_LED_COUNT, 0x55AA33, args.tx_pin, args.rx_pin, 40
+        )
+
+    print()
+    print("=" * 60)
+    if all_pass:
+        print("PASS - #3611 UART DMA FastLED API loopback confirmed.")
+        return 0
+    print("FAIL - one or more UART DMA loopback cases mismatched.")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ci/autoresearch/test_lpc_ws2812_loopback.py
+++ b/ci/autoresearch/test_lpc_ws2812_loopback.py
@@ -62,7 +62,7 @@ def send_rpc(
     (RpcClient assigns its own correlation ids).
     """
     _ = request_id
-    result = s.call(method, args=args, timeout=timeout)
+    result = s.call_flat(method, args=args, timeout=timeout)
     if result is None:
         return None
     if result is METHOD_NOT_FOUND:

--- a/examples/AutoResearch/AutoResearchLowMemory.h
+++ b/examples/AutoResearch/AutoResearchLowMemory.h
@@ -50,12 +50,17 @@
 
 // The LPC845-BRK low-memory build fits FastLED + Remote + the WS2812 loopback
 // RPC in normal mode. The dedicated IEEE754 mode deliberately omits it.
-#if defined(FL_IS_ARM_LPC_845) && !defined(FASTLED_AUTORESEARCH_IEEE754_MODE)
+#if defined(FL_IS_ARM_LPC_845) && !defined(FASTLED_AUTORESEARCH_IEEE754_MODE) && \
+    !defined(FASTLED_LPC_SPI_DMA) && !defined(FASTLED_LPC_PWM_DMA) && \
+    !defined(FASTLED_LPC_UART_DMA)
 #define FASTLED_AUTORESEARCH_LPC_WS2812 1
 #endif
 
-// The WS2812 loopback uses the SCT->DMA RX capture path.
-#if defined(FASTLED_AUTORESEARCH_LPC_WS2812) && !defined(FASTLED_LPC_RX_SCT_DMA)
+// The WS2812 loopback uses the SCT->DMA RX capture path. The UART clockless
+// verifier uses USART RX-DMA instead, so keep SCT-DMA out of that build;
+// UM11029 Table 296 fixes USART1_RX/USART1_TX on DMA channels 2/3.
+#if defined(FASTLED_AUTORESEARCH_LPC_WS2812) && \
+    !defined(FASTLED_LPC_RX_SCT_DMA)
 #define FASTLED_LPC_RX_SCT_DMA 1
 #endif
 

--- a/examples/AutoResearch/AutoResearchUartDma.h
+++ b/examples/AutoResearch/AutoResearchUartDma.h
@@ -31,6 +31,12 @@
 
 #if defined(FL_IS_ARM_LPC_845) && defined(FASTLED_LPC_UART_DMA)
 
+#if defined(FL_LPC_UART_DMA_CLOCKLESS_TEST)
+#include "fl/channels/bus.h"
+#include "fl/channels/bus_traits.h"
+#include "fl/chipsets/chipset_timing_config.h"
+#include "fl/chipsets/timing_traits.h"
+#endif
 #include "fl/remote/remote.h"
 #include "fl/stl/noexcept.h"
 #include "fl/stl/sstream.h"
@@ -38,6 +44,8 @@
 
 namespace autoresearch {
 namespace uart_dma {
+
+#if !defined(FL_LPC_UART_DMA_CLOCKLESS_TEST)
 
 // Default TXD routing + baud. PIO0_9 is unclaimed on the LPC845-BRK
 // header; the bench never reads the wire (wall-clock timing only), the
@@ -68,11 +76,7 @@ inline fl::u8* harnessBuffer() FL_NO_EXCEPT {
 
 inline HarnessDriver& harnessDriver() FL_NO_EXCEPT {
     static HarnessDriver drv;
-    static bool inited = false;
-    if (!inited) {
-        drv.init();
-        inited = true;
-    }
+    drv.init();
     return drv;
 }
 
@@ -166,11 +170,288 @@ inline fl::string streamOverlapHandler(int byte_count, int byte_pattern) FL_NO_E
 // Args as a JSON array (house RpcClient convention — single `const
 // fl::json&` that is the positional-arg array). Lets the bench run over
 // fbuild's Rust serial monitor instead of raw pyserial.
+#endif  // !FL_LPC_UART_DMA_CLOCKLESS_TEST
+
 inline int argInt(const fl::json& args, fl::size i, int fallback) FL_NO_EXCEPT {
     return static_cast<int>(args[i].as_int().value_or(fallback));
 }
 
+#if defined(FL_LPC_UART_DMA_CLOCKLESS_TEST)
+
+#ifndef FL_LPC_UART_DMA_CLOCKLESS_TX_PIN
+#define FL_LPC_UART_DMA_CLOCKLESS_TX_PIN 10
+#endif
+#ifndef FL_LPC_UART_DMA_CLOCKLESS_LEDS
+#define FL_LPC_UART_DMA_CLOCKLESS_LEDS 8
+#endif
+
+inline fl::CRGB* clocklessLeds() FL_NO_EXCEPT {
+    static fl::CRGB leds[FL_LPC_UART_DMA_CLOCKLESS_LEDS];
+    return leds;
+}
+
+inline bool ensureClocklessFastLedRegistered() FL_NO_EXCEPT {
+    static bool registered = false;
+    if (!registered) {
+        FastLED.addLeds<WS2812,
+                        static_cast<fl::u8>(FL_LPC_UART_DMA_CLOCKLESS_TX_PIN),
+                        GRB>(clocklessLeds(), FL_LPC_UART_DMA_CLOCKLESS_LEDS);
+        registered = true;
+    }
+    return registered;
+}
+
+inline USART_Type* clocklessUartBlock() FL_NO_EXCEPT {
+#if FASTLED_LPC_UART_DMA_INSTANCE == 2
+    return USART2;
+#else
+    return USART1;
+#endif
+}
+
+inline volatile fl::u32& clocklessDmaReg(fl::u32 offset) FL_NO_EXCEPT {
+    return *reinterpret_cast<volatile fl::u32*>(0x50008000u + offset);  // ok reinterpret cast - DMA0 MMIO
+}
+
+inline fl::u32 clocklessUartActualBaud() FL_NO_EXCEPT {
+    USART_Type* u = clocklessUartBlock();
+    const fl::u32 osr = (u->OSR & 0xFu) + 1u;
+    const fl::u32 brg = (u->BRG & 0xFFFFu) + 1u;
+    return F_CPU / (osr * brg);
+}
+
+inline void clocklessUartDrainRx(fl::u32& errors) FL_NO_EXCEPT {
+    USART_Type* u = clocklessUartBlock();
+    constexpr fl::u32 kRxRdy = (1u << 0);
+    constexpr fl::u32 kOverrun = (1u << 8);
+    constexpr fl::u32 kFrame = (1u << 13);
+    constexpr fl::u32 kParity = (1u << 14);
+    while ((u->STAT & kRxRdy) != 0u) {
+        errors |= (u->RXDATSTAT & (kOverrun | kFrame | kParity));
+    }
+    u->STAT = kOverrun | kFrame | kParity;
+}
+
+inline fl::u32 clocklessAbsDiff(fl::u32 a, fl::u32 b) FL_NO_EXCEPT {
+    return a > b ? a - b : b - a;
+}
+
+inline fl::u8 clocklessPulseCount(fl::u32 timing_ns, fl::u32 pulse_ns) FL_NO_EXCEPT {
+    if (pulse_ns == 0u) {
+        return 0;
+    }
+    const fl::u8 lo = static_cast<fl::u8>(timing_ns / pulse_ns);
+    const fl::u8 hi = static_cast<fl::u8>(lo + 1u);
+    const fl::u32 err_lo = clocklessAbsDiff(static_cast<fl::u32>(lo) * pulse_ns, timing_ns);
+    const fl::u32 err_hi = clocklessAbsDiff(static_cast<fl::u32>(hi) * pulse_ns, timing_ns);
+    return err_hi < err_lo ? hi : lo;
+}
+
+inline fl::u8 clocklessBuildUartByte(fl::u8 pulses_a, fl::u8 pulses_b) FL_NO_EXCEPT {
+    fl::u8 value = 0;
+    for (int i = 0; i < 8; ++i) {
+        const int pulse = i + 1;
+        const bool wire_high =
+            (pulse < 5 && pulse < static_cast<int>(pulses_a)) ||
+            (pulse >= 5 && (pulse - 5) < static_cast<int>(pulses_b));
+        if (!wire_high) {
+            value |= static_cast<fl::u8>(1u << i);
+        }
+    }
+    return value;
+}
+
+inline bool clocklessBuildUartLut(fl::u8 lut[4], fl::u32& baud_out) FL_NO_EXCEPT {
+    const fl::ChipsetTimingConfig timing =
+        fl::makeTimingConfig<fl::TIMING_WS2812_800KHZ>();
+    constexpr fl::u8 kPulsesPerBit = 5;
+    const fl::u32 period_ns = timing.total_period_ns();
+    if (period_ns == 0u) {
+        return false;
+    }
+
+    const fl::u32 pulse_ns = period_ns / kPulsesPerBit;
+    const fl::u8 pulses0 = clocklessPulseCount(timing.t1_ns, pulse_ns);
+    const fl::u8 pulses1 = clocklessPulseCount(timing.t1_ns + timing.t2_ns, pulse_ns);
+    if (pulses0 < 1u || pulses0 > 4u || pulses1 < 1u || pulses1 > 4u ||
+        pulses0 == pulses1) {
+        return false;
+    }
+
+    lut[0] = clocklessBuildUartByte(pulses0, pulses0);
+    lut[1] = clocklessBuildUartByte(pulses0, pulses1);
+    lut[2] = clocklessBuildUartByte(pulses1, pulses0);
+    lut[3] = clocklessBuildUartByte(pulses1, pulses1);
+    baud_out = static_cast<fl::u32>(
+        static_cast<fl::u64>(kPulsesPerBit) * 1000000000ULL / period_ns);
+    return true;
+}
+
+inline fl::size clocklessEncodeExpectedUartBytes(
+        int led_count, fl::u32 rgb, fl::u8* out, fl::size out_cap,
+        fl::u32& expected_baud) FL_NO_EXCEPT {
+    fl::u8 lut[4] = {0, 0, 0, 0};
+    if (!clocklessBuildUartLut(lut, expected_baud)) {
+        return 0;
+    }
+
+    const fl::size byte_count = static_cast<fl::size>(led_count) * 3u;
+    const fl::size encoded_count = byte_count * 4u;
+    if (encoded_count > out_cap) {
+        return 0;
+    }
+
+    const fl::u8 r = static_cast<fl::u8>((rgb >> 16) & 0xFF);
+    const fl::u8 g = static_cast<fl::u8>((rgb >> 8) & 0xFF);
+    const fl::u8 b = static_cast<fl::u8>(rgb & 0xFF);
+    fl::size o = 0;
+    for (int i = 0; i < led_count; ++i) {
+        const fl::u8 grb[3] = {g, r, b};
+        for (fl::u8 byte : grb) {
+            out[o++] = lut[(byte >> 6) & 0x03u];
+            out[o++] = lut[(byte >> 4) & 0x03u];
+            out[o++] = lut[(byte >> 2) & 0x03u];
+            out[o++] = lut[byte & 0x03u];
+        }
+    }
+    return encoded_count;
+}
+
+// CSV success: "1,n_decoded,<grb byte0>,<grb byte1>,...".
+// CSV failure: "0,loopback,<rx_count>,<expected_count>,<stream_done>,<stat>,<cfg>,<errors>,<expected_baud>,<actual_baud>,<mismatch_index>,<expected>,<actual>".
+inline fl::string clocklessLoopbackSelfHandler(
+        int led_count, fl::u32 rgb, int data_pin, int rx_pin,
+        int capture_ms) FL_NO_EXCEPT {
+    if (led_count != FL_LPC_UART_DMA_CLOCKLESS_LEDS ||
+        data_pin != FL_LPC_UART_DMA_CLOCKLESS_TX_PIN ||
+        rx_pin < 0 || rx_pin > 31 || capture_ms <= 0 || capture_ms > 200) {
+        return fl::string("0,args");
+    }
+    (void)rx_pin;
+
+    ensureClocklessFastLedRegistered();
+    FastLED.setBrightness(255);
+    fl::CRGB* leds = clocklessLeds();
+    const fl::u8 r = static_cast<fl::u8>((rgb >> 16) & 0xFF);
+    const fl::u8 g = static_cast<fl::u8>((rgb >> 8) & 0xFF);
+    const fl::u8 b = static_cast<fl::u8>(rgb & 0xFF);
+    for (int i = 0; i < led_count; ++i) {
+        leds[i] = fl::CRGB(r, g, b);
+    }
+
+    constexpr fl::size kMaxEncoded =
+        FL_LPC_UART_DMA_CLOCKLESS_LEDS * 3u * 4u;
+    static fl::u8 expected[kMaxEncoded];
+    static fl::u8 received[kMaxEncoded];
+    fl::u32 expected_baud = 0;
+    const fl::size expected_count = clocklessEncodeExpectedUartBytes(
+        led_count, rgb, expected, kMaxEncoded, expected_baud);
+    if (expected_count == 0u) {
+        return fl::string("0,encode");
+    }
+
+    fl::u32 errors = 0;
+    clocklessUartDrainRx(errors);
+    for (fl::size i = 0; i < expected_count; ++i) {
+        received[i] = 0xA5u;
+    }
+    fl::lpc::LpcUartDmaRuntime::prepareLoopbackRxBuffer(
+        received, static_cast<fl::u32>(expected_count));
+
+    FastLED.show();
+
+    USART_Type* u = clocklessUartBlock();
+    auto& driver = fl::BusTraits<fl::Bus::UART>::instance();
+    bool stream_done = false;
+    const fl::u32 start = millis();
+    while ((millis() - start) < static_cast<fl::u32>(capture_ms)) {
+        const auto state = driver.poll();
+        stream_done = (state.state == fl::IChannelDriver::DriverState::READY);
+        if (stream_done &&
+            fl::lpc::LpcUartDmaRuntime::loopbackRxReceivedCount() >= expected_count) {
+            break;
+        }
+    }
+
+    stream_done = driver.waitForReady(1000);
+    const fl::size rx_count =
+        static_cast<fl::size>(fl::lpc::LpcUartDmaRuntime::loopbackRxReceivedCount());
+    errors |= (u->STAT & ((1u << 8) | (1u << 13) | (1u << 14)));
+    constexpr fl::u32 kLoopbackRxDmaChannel =
+        (FASTLED_LPC_UART_DMA_INSTANCE == 2) ? 4u : 2u;
+    const fl::u32 rx_dma_base = 0x400u + 16u * kLoopbackRxDmaChannel;
+    const fl::u32 rx_dma_cfg = clocklessDmaReg(rx_dma_base + 0x0u);
+    const fl::u32 rx_dma_ctlstat = clocklessDmaReg(rx_dma_base + 0x4u);
+    const fl::u32 rx_dma_xfercfg = clocklessDmaReg(rx_dma_base + 0x8u);
+    const fl::u32 rx_dma_active = clocklessDmaReg(0x030u);
+    const fl::u32 rx_dma_busy = clocklessDmaReg(0x038u);
+    const fl::u32 rx_dma_err = clocklessDmaReg(0x040u);
+    const fl::u32 rx_requested_len = g_fastled_lpc_uart_loopback_rx_len;
+    fl::lpc::LpcUartDmaRuntime::clearLoopbackRxBuffer();
+
+    fl::size mismatch = expected_count;
+    const fl::size compare_count =
+        rx_count < expected_count ? rx_count : expected_count;
+    for (fl::size i = 0; i < compare_count; ++i) {
+        if (received[i] != expected[i]) {
+            mismatch = i;
+            break;
+        }
+    }
+
+    if (rx_count != expected_count || mismatch != expected_count || errors != 0u) {
+        fl::sstream d;
+        d << 0 << ",loopback," << static_cast<fl::u32>(rx_count) << ','
+          << static_cast<fl::u32>(expected_count) << ','
+          << (stream_done ? 1 : 0) << ',' << u->STAT << ',' << u->CFG << ','
+          << errors << ',' << expected_baud << ',' << clocklessUartActualBaud()
+          << ',' << rx_dma_cfg << ',' << rx_dma_ctlstat << ','
+          << rx_dma_xfercfg << ',' << rx_dma_active << ','
+          << rx_dma_busy << ',' << rx_dma_err << ','
+          << rx_requested_len << ','
+          << g_fastled_lpc_uart_loopback_rx_arm_status << ','
+          << g_fastled_lpc_uart_loopback_rx_arm_tx_len << ','
+          << g_fastled_lpc_uart_loopback_rx_arm_xfer_readback << ','
+          << g_fastled_lpc_uart_loopback_rx_arm_desc0_readback << ',';
+        if (mismatch != expected_count) {
+            d << static_cast<fl::u32>(mismatch) << ','
+              << static_cast<fl::u32>(expected[mismatch]) << ','
+              << static_cast<fl::u32>(received[mismatch]);
+        } else {
+            d << static_cast<fl::u32>(expected_count) << ",0,0";
+        }
+        return d.str();
+    }
+
+    const fl::u32 n_decoded = static_cast<fl::u32>(led_count * 3);
+    fl::sstream s;
+    s << 1 << ',' << n_decoded;
+    for (int i = 0; i < led_count; ++i) {
+        s << ',' << static_cast<fl::u32>(g)
+          << ',' << static_cast<fl::u32>(r)
+          << ',' << static_cast<fl::u32>(b);
+    }
+    return s.str();
+}
+
+inline fl::string clocklessProbeHandler(
+        int step, int data_pin, int rx_pin) FL_NO_EXCEPT {
+    if (data_pin != FL_LPC_UART_DMA_CLOCKLESS_TX_PIN ||
+        rx_pin < 0 || rx_pin > 31) {
+        return fl::string("0,args");
+    }
+    if (step <= 0) {
+        return fl::string("1,entry");
+    }
+    fl::sstream s;
+    s << 1 << ",uart_rx_dma," << clocklessUartBlock()->CFG;
+    return s.str();
+}
+
+#endif  // FL_LPC_UART_DMA_CLOCKLESS_TEST
+
 inline void bind(fl::Remote& remote) FL_NO_EXCEPT {
+#if !defined(FL_LPC_UART_DMA_CLOCKLESS_TEST)
     remote.bind("uartDmaStreamOnce",
         [](const fl::json& args) -> fl::string {
             return streamOnceHandler(argInt(args, 0, 0), argInt(args, 1, 0));
@@ -179,6 +460,25 @@ inline void bind(fl::Remote& remote) FL_NO_EXCEPT {
         [](const fl::json& args) -> fl::string {
             return streamOverlapHandler(argInt(args, 0, 0), argInt(args, 1, 0));
         });
+#endif
+#if defined(FL_LPC_UART_DMA_CLOCKLESS_TEST)
+    remote.bind("uartDmaClocklessProbe",
+        [](const fl::json& args) -> fl::string {
+            return clocklessProbeHandler(
+                argInt(args, 0, 0),
+                argInt(args, 1, FL_LPC_UART_DMA_CLOCKLESS_TX_PIN),
+                argInt(args, 2, 11));
+        });
+    remote.bind("uartDmaClocklessLoopbackSelf",
+        [](const fl::json& args) -> fl::string {
+            return clocklessLoopbackSelfHandler(
+                argInt(args, 0, FL_LPC_UART_DMA_CLOCKLESS_LEDS),
+                static_cast<fl::u32>(argInt(args, 1, 0)),
+                argInt(args, 2, FL_LPC_UART_DMA_CLOCKLESS_TX_PIN),
+                argInt(args, 3, 11),
+                argInt(args, 4, 30));
+        });
+#endif
 }
 
 }  // namespace uart_dma

--- a/src/fl/channels/bus.h
+++ b/src/fl/channels/bus.h
@@ -87,7 +87,11 @@ template<> struct DefaultBus<SpiChipsetConfig> {
 // what Bus::BIT_BANG names — the same engine that LPC's
 // ClocklessController template uses today.
 template<> struct DefaultBus<ClocklessChipset> {
+#if defined(FL_IS_ARM_LPC_845) && defined(FASTLED_LPC_UART_DMA)
+    static constexpr Bus value = Bus::UART;
+#else
     static constexpr Bus value = Bus::BIT_BANG;
+#endif
 };
 
 // LPC845 / LPC804 have a hardware SPI driver (spi_arm_lpc.h, UM11029).
@@ -125,6 +129,8 @@ template<> struct BusInstanceCount<Bus::UART> { static constexpr fl::u8 value = 
 template<> struct BusInstanceCount<Bus::FLEX_IO> { static constexpr fl::u8 value = 2; };
 template<> struct BusInstanceCount<Bus::SPI> { static constexpr fl::u8 value = 2; };
 template<> struct BusInstanceCount<Bus::UART> { static constexpr fl::u8 value = 2; };
+#elif defined(FL_IS_ARM_LPC_845)
+template<> struct BusInstanceCount<Bus::UART> { static constexpr fl::u8 value = 1; };
 #endif
 
 inline const char* busName(Bus b, fl::u8 which = 0) FL_NO_EXCEPT {

--- a/src/fl/channels/bus_info.h
+++ b/src/fl/channels/bus_info.h
@@ -144,6 +144,18 @@ template<> struct DeviceInfoResolver<Bus::UART, 0> {
     }
 };
 
+#elif defined(FL_IS_ARM_LPC_845)
+
+template<> struct DeviceInfoResolver<Bus::UART, 0> {
+    static inline DeviceInfo get() FL_NO_EXCEPT {
+#if defined(FASTLED_LPC_UART_DMA)
+        return makeInfo(Bus::UART, 0, "LPC_USART_DMA", "USART TX DMA");
+#else
+        return makeNoop(Bus::UART, 0, "UART DMA disabled");
+#endif
+    }
+};
+
 #elif defined(FL_IS_ESP32)
 
 template<> struct DeviceInfoResolver<Bus::RMT, 0> {

--- a/src/platforms/arm/lpc/README.md
+++ b/src/platforms/arm/lpc/README.md
@@ -40,9 +40,10 @@ What the harness asserts:
 - **`bash autoresearch lpc845brk --bring-up`** — `echo` RPC round-trips; FL_WARN literal reaches the host; proves Serial + JSON-RPC + log pipeline intact.
 - **`bash autoresearch lpc845brk --pin-toggle-rx`** — SCT input-capture latches a bit-banged square wave; orchestrator asserts mean ±2 % and σ thresholds across 1/10/100 kHz rates ([#3035](https://github.com/FastLED/FastLED/issues/3035) Phase 1).
 - **`bash autoresearch lpc845brk --ws2812-loopback`** — WS2812 byte-match: `FastLED.show()` drives 1/3/100 LEDs through the bit-bang clockless path, SCT-RX latches the wire, decoder asserts `mismatched == 0` ([#3035](https://github.com/FastLED/FastLED/issues/3035) Phase 2b).
+- **`bash autoresearch lpc845brk --uart`** — UART DMA WS2812 byte-match: `FastLED.addLeds<WS2812, PIN, GRB>()` drives the default `Bus::UART` path, a jumper bridges TX to the configured USART RX pin, USART RX-DMA captures the encoded bytes, and the host byte-compares decoded GRB data. `--dma-uart` remains the raw async USART transport bench.
 - **Link-symbol check** — `arm-none-eabi-nm -C firmware.elf | grep -E '(aeabi_d|aeabi_f|f2iz|d2iz|__l2f|__floatdisf)'` stays empty after [#3038](https://github.com/FastLED/FastLED/pull/3038). The harness can fold this into its reporting path so the no-soft-FP invariant is asserted on every run.
 
-Once all four run green against an LPC845-BRK with the loopback jumper, [#2880](https://github.com/FastLED/FastLED/issues/2880) closes and the table above flips its LPC845 / LPC804 rows to "✅ hardware verified". No human-eyeball scope trace required.
+Once the required checks run green against an LPC845-BRK with the loopback jumper, [#2880](https://github.com/FastLED/FastLED/issues/2880) closes and the table above flips its LPC845 / LPC804 rows to "✅ hardware verified". No human-eyeball scope trace required.
 
 ## Register-map authoring note (issue #2990)
 
@@ -153,6 +154,8 @@ worked anti-example.
 - `drivers/sct_dma/channel_engine_lpc_sct_dma.{h,cpp.hpp}` — Channels-API `IChannelDriver` for the LPC845 SCT + 3-DMA-channel clockless engine ([#3460](https://github.com/FastLED/FastLED/pull/3460)). Wraps the same SCT/DMA machinery as `clockless_arm_lpc_pwm_dma.h` but plugs into the portable `ChannelManager` dispatch, with async `pollAndAdvance()` chunk progression (no busy-wait in `show()`). Host-side TX→RX byte-match test through `engine.show()` verified in [#3472](https://github.com/FastLED/FastLED/pull/3472).
 - `drivers/sct_dma/lpc_sct_dma_runtime.{h,cpp.hpp}` — Runtime SCT+DMA helper (chunked encode → 3 DMA channels → GPIO SET/CLR), shared by the channels-API engine.
 - `drivers/sct_dma/bus_traits.h` — `BusTraits<Bus::BIT_BANG>` specialization routing LPC845 bit-bang bus to the SCT/DMA channels engine when `FASTLED_LPC_PWM_DMA` is set; kept behind `!FL_IS_ARM_LPC_845` in the shared bit-bang traits to avoid duplicate specialization.
+- `drivers/uart_dma/*` — `BusTraits<Bus::UART>` specialization and `ChannelEngineLpcUartDma`, routing LPC845 clockless AUTO/UART output through USART TX + DMA when `FASTLED_LPC_UART_DMA` is set.
+- `clockless_channel_lpc_uart_dma.h` — Legacy `addLeds<WS2812, PIN, GRB>()` adapter that selects the UART DMA channel engine by default under `FASTLED_LPC_UART_DMA`.
 - `rx_sct_capture.{h,cpp.hpp}` — LPC845 SCT input-capture RX device used by the AutoResearch loopback harness; drives byte-match assertions for the bit-bang, PWM+DMA, and channels-API TX paths.
 - `led_sysdefs_arm_lpc.h` — System defines (sets `FL_IS_ARM_M0_PLUS`, `F_CPU`, forces `FASTLED_M0_USE_C_IMPLEMENTATION`, includes `<LPC845.h>` / `<LPC804.h>` CMSIS device headers).
 - `fastpin_arm_lpc.h` — see above.
@@ -170,6 +173,7 @@ Build-time opt-ins (default off). Define before including `FastLED.h` or via bui
 - **`FASTLED_LPC_SPI_DMA`** — LPC845 only. Activates the DMA-async SPI driver (`spi_arm_lpc_dma.h`) in place of the polled `spi_arm_lpc.h` for APA102 / SK9822 / WS2801. Fires a compile-time `#error` if set on an LPC804 build (silicon has no DMA peripheral).
 - **`FASTLED_LPC_SPI_DMA_CHANNEL`** — LPC845 + `FASTLED_LPC_SPI_DMA`. DMA0 channel index feeding SPI TX. Default `4` (SPI0_TX); override to `6` for SPI1_TX.
 - **`FASTLED_LPC_SPI_DMA_MAX_BYTES`** — LPC845 + `FASTLED_LPC_SPI_DMA`. Static DMA descriptor pool size (default `2048`).
+- **`FASTLED_LPC_UART_DMA`** — LPC845 only. Activates the UART DMA clockless engine and makes clockless AUTO/default bus selection resolve to `Bus::UART`. AutoResearch `--uart` verifies this path with a TX→RX jumper and USART RX-DMA byte compare.
 - **`FASTLED_M0_USE_C_IMPLEMENTATION`** — Already set unconditionally by `led_sysdefs_arm_lpc.h`. The LPC8xx GPIO controller exposes SET[port] and CLR[port] at byte offsets `0x2200 / 0x2280` from the controller base, beyond the 5-bit imm5*4 encoding the M0/M0+ STR-immediate-offset instruction supports. The shared inline-assembly clockless driver assumes both offsets fit a single str-with-immediate; LPC routes through the portable C++ implementation, which performs an indexed store instead.
 - **`FASTLED_ALLOW_INTERRUPTS`** — Default `1`.
 - **`FASTLED_USE_PROGMEM`** — Default `0`.

--- a/src/platforms/arm/lpc/channel_drivers_lpc.impl.hpp
+++ b/src/platforms/arm/lpc/channel_drivers_lpc.impl.hpp
@@ -14,7 +14,14 @@
 #include "platforms/arm/lpc/is_lpc.h"
 
 #if defined(FL_IS_ARM_LPC_845)
+#if defined(FASTLED_LPC_UART_DMA)
+#include "platforms/arm/lpc/drivers/uart_dma/bus_traits.h"
+#endif
+#if defined(FASTLED_LPC_PWM_DMA)
 #include "platforms/arm/lpc/drivers/sct_dma/bus_traits.h"
+#else
+#include "platforms/shared/bitbang/bus_traits.h"
+#endif
 #endif
 
 namespace fl {
@@ -22,9 +29,11 @@ namespace platforms {
 
 inline void enableAllChannelDrivers() FL_NO_EXCEPT {
 #if defined(FL_IS_ARM_LPC_845)
-    // SCT+DMA clockless engine (#3459). Registers under Bus::BIT_BANG,
-    // matching the LPC `DefaultBus<ClocklessChipset>` resolution from
-    // PR #3451.
+#if defined(FASTLED_LPC_UART_DMA)
+    BusTraits<Bus::UART, 0>::registerWithManager();
+#endif
+    // Register the LPC clockless fallback bus as SCT+DMA when
+    // FASTLED_LPC_PWM_DMA is enabled, otherwise as shared bit-bang.
     BusTraits<Bus::BIT_BANG, 0>::registerWithManager();
 #endif
 }

--- a/src/platforms/arm/lpc/clockless_channel_lpc_uart_dma.h
+++ b/src/platforms/arm/lpc/clockless_channel_lpc_uart_dma.h
@@ -1,0 +1,93 @@
+#pragma once
+
+// IWYU pragma: private
+
+/// @file clockless_channel_lpc_uart_dma.h
+/// @brief LPC845 channels-API ClocklessController adapter for UART DMA.
+
+#include "platforms/arm/lpc/is_lpc.h"
+
+#if defined(FL_IS_ARM_LPC_845) && defined(FASTLED_LPC_UART_DMA)
+
+#define FL_CLOCKLESS_CONTROLLER_DEFINED 1
+#define FL_CLOCKLESS_LPC_UART_CHANNEL_ENGINE_DEFINED 1
+
+#include "eorder.h"
+#include "fl/channels/bus.h"
+#include "fl/channels/data.h"
+#include "fl/channels/driver.h"
+#include "fl/channels/manager.h"
+#include "fl/chipsets/timing_traits.h"
+#include "fl/log/log.h"
+#include "fl/stl/compiler_control.h"
+#include "fl/stl/noexcept.h"
+#include "fl/stl/shared_ptr.h"
+#include "fl/stl/vector.h"
+#include "pixel_iterator.h"
+#include "platforms/arm/lpc/drivers/uart_dma/bus_traits.h"
+
+namespace fl {
+
+FL_STATIC_ASSERT(DefaultBus<ClocklessChipset>::value == Bus::UART,
+                 "FASTLED_LPC_UART_DMA must make LPC845 clockless AUTO resolve to Bus::UART");
+
+template <int DATA_PIN,
+          typename TIMING,
+          EOrder RGB_ORDER = RGB,
+          int XTRA0 = 0,
+          bool FLIP = false,
+          int WAIT_TIME = 0>
+class ClocklessController : public CPixelLEDController<RGB_ORDER> {
+private:
+    ChannelDataPtr mChannelData;
+    fl::shared_ptr<IChannelDriver> mDriver;
+
+public:
+    ClocklessController()
+        : mDriver(getLpcEngine())
+    {
+        ChipsetTimingConfig timing = makeTimingConfig<TIMING>();
+        mChannelData = ChannelData::create(DATA_PIN, timing);
+    }
+
+    void init() override {}
+    u16 getMaxRefreshRate() const override { return 400; }
+
+protected:
+    void showPixels(PixelController<RGB_ORDER>& pixels) override {
+        if (!mDriver) {
+            FL_WARN_F_EVERY(100, "LPC UART DMA channel engine unavailable");
+            return;
+        }
+        if (mChannelData->isInUse() && !mDriver->waitForReady()) {
+            FL_ERROR_F("LPC UART DMA: engine still busy after wait");
+            return;
+        }
+
+        fl::PixelIterator iterator = pixels.as_iterator(this->getRgbw());
+        auto& data = mChannelData->getData();
+        data.clear();
+        iterator.writeWS2812(&data);
+
+        mDriver->enqueue(mChannelData);
+        mDriver->show();
+    }
+
+    static fl::shared_ptr<IChannelDriver> getLpcEngine() FL_NO_EXCEPT {
+        return BusTraits<Bus::UART>::instancePtr();
+    }
+};
+
+template <int DATA_PIN, typename TIMING_LIKE, EOrder RGB_ORDER = RGB,
+          int XTRA0 = 0, bool FLIP = false, int WAIT_TIME = 0>
+struct ClocklessControllerAdapter
+    : public ClocklessController<DATA_PIN, TIMING_LIKE, RGB_ORDER, XTRA0, FLIP, WAIT_TIME> {};
+
+template <int DATA_PIN, typename TIMING, EOrder RGB_ORDER = RGB,
+          int XTRA0 = 0, bool FLIP = false, int WAIT_TIME = 0>
+class ClocklessBlockController
+    : public ClocklessController<DATA_PIN, TIMING, RGB_ORDER, XTRA0, FLIP, WAIT_TIME> {};
+
+}  // namespace fl
+
+#endif  // FL_IS_ARM_LPC_845 && FASTLED_LPC_UART_DMA

--- a/src/platforms/arm/lpc/drivers/_build.cpp.hpp
+++ b/src/platforms/arm/lpc/drivers/_build.cpp.hpp
@@ -9,3 +9,4 @@
 
 // begin sub directory includes
 #include "platforms/arm/lpc/drivers/sct_dma/_build.cpp.hpp"
+#include "platforms/arm/lpc/drivers/uart_dma/_build.cpp.hpp"

--- a/src/platforms/arm/lpc/drivers/sct_dma/bus_traits.h
+++ b/src/platforms/arm/lpc/drivers/sct_dma/bus_traits.h
@@ -19,7 +19,7 @@
 #include "fl/stl/compiler_control.h"
 #include "platforms/is_platform.h"
 
-#if defined(FL_IS_ARM_LPC_845)
+#if defined(FL_IS_ARM_LPC_845) && defined(FASTLED_LPC_PWM_DMA)
 
 #include "fl/channels/bus.h"
 #include "fl/channels/bus_priorities.h"
@@ -55,4 +55,4 @@ template<> struct BusSupports<Bus::BIT_BANG, ClocklessChipset, 0> : fl::true_typ
 
 }  // namespace fl
 
-#endif  // FL_IS_ARM_LPC_845
+#endif  // FL_IS_ARM_LPC_845 && FASTLED_LPC_PWM_DMA

--- a/src/platforms/arm/lpc/drivers/uart_dma/_build.cpp.hpp
+++ b/src/platforms/arm/lpc/drivers/uart_dma/_build.cpp.hpp
@@ -1,0 +1,19 @@
+// IWYU pragma: private
+
+/// @file _build.cpp.hpp
+/// @brief Unity build header for the LPC845 UART DMA channel engine.
+
+#include <stdint.h>
+
+#if defined(FL_LPC_UART_DMA_LOOPBACK_TEST)
+extern "C" {
+uint8_t* g_fastled_lpc_uart_loopback_rx_dst = nullptr;
+uint32_t g_fastled_lpc_uart_loopback_rx_len = 0;
+uint32_t g_fastled_lpc_uart_loopback_rx_arm_status = 0;
+uint32_t g_fastled_lpc_uart_loopback_rx_arm_tx_len = 0;
+uint32_t g_fastled_lpc_uart_loopback_rx_arm_xfer_readback = 0;
+uint32_t g_fastled_lpc_uart_loopback_rx_arm_desc0_readback = 0;
+}
+#endif
+
+#include "platforms/arm/lpc/drivers/uart_dma/channel_engine_lpc_uart_dma.cpp.hpp"

--- a/src/platforms/arm/lpc/drivers/uart_dma/bus_traits.h
+++ b/src/platforms/arm/lpc/drivers/uart_dma/bus_traits.h
@@ -1,0 +1,42 @@
+#pragma once
+
+// IWYU pragma: private
+
+/// @file bus_traits.h
+/// @brief BusTraits<Bus::UART> specialization for LPC845 UART DMA clockless.
+
+#include "platforms/arm/lpc/is_lpc.h"
+
+#if defined(FL_IS_ARM_LPC_845) && defined(FASTLED_LPC_UART_DMA)
+
+#include "fl/channels/bus.h"
+#include "fl/channels/bus_traits.h"
+#include "fl/channels/config.h"
+#include "fl/channels/manager.h"
+#include "fl/stl/noexcept.h"
+#include "fl/stl/shared_ptr.h"
+#include "fl/stl/type_traits.h"
+#include "platforms/arm/lpc/drivers/uart_dma/channel_engine_lpc_uart_dma.h"
+
+namespace fl {
+
+template<> struct BusTraits<Bus::UART> {
+    using Driver = ChannelEngineLpcUartDma;
+
+    static fl::shared_ptr<Driver> instancePtr() FL_NO_EXCEPT {
+        static fl::shared_ptr<Driver> gHolder = fl::make_shared<Driver>();
+        return gHolder;
+    }
+
+    static Driver& instance() FL_NO_EXCEPT { return *instancePtr(); }
+
+    static void registerWithManager() FL_NO_EXCEPT {
+        ChannelManager::instance().addDriver(1, instancePtr());
+    }
+};
+
+template<> struct BusSupports<Bus::UART, ClocklessChipset, 0> : fl::true_type {};
+
+}  // namespace fl
+
+#endif  // FL_IS_ARM_LPC_845 && FASTLED_LPC_UART_DMA

--- a/src/platforms/arm/lpc/drivers/uart_dma/channel_engine_lpc_uart_dma.cpp.hpp
+++ b/src/platforms/arm/lpc/drivers/uart_dma/channel_engine_lpc_uart_dma.cpp.hpp
@@ -1,0 +1,232 @@
+// IWYU pragma: private
+
+#include "platforms/arm/lpc/is_lpc.h"
+
+#if defined(FL_IS_ARM_LPC_845) && defined(FASTLED_LPC_UART_DMA)
+
+#include "platforms/arm/lpc/drivers/uart_dma/channel_engine_lpc_uart_dma.h"
+#include "fl/chipsets/chipset_timing_config.h"
+#include "fl/log/log.h"
+#include "fl/stl/cstddef.h"
+#include "fl/stl/noexcept.h"
+#include "fl/stl/stdint.h"
+#include "fl/stl/utility.h"
+
+namespace fl {
+
+namespace {
+
+struct LpcUartWave10Lut {
+    u8 lut[4] = {0, 0, 0, 0};
+    u32 baud = 0;
+    bool ok = false;
+};
+
+u32 lpcUartAbsDiff(u32 a, u32 b) FL_NO_EXCEPT {
+    return a > b ? a - b : b - a;
+}
+
+u8 lpcUartComputePulseCount(u32 timingNs, u32 pulseWidthNs) FL_NO_EXCEPT {
+    if (pulseWidthNs == 0) {
+        return 0;
+    }
+    const u8 lo = static_cast<u8>(timingNs / pulseWidthNs);
+    const u8 hi = static_cast<u8>(lo + 1u);
+    const u32 errLo = lpcUartAbsDiff(static_cast<u32>(lo) * pulseWidthNs, timingNs);
+    const u32 errHi = lpcUartAbsDiff(static_cast<u32>(hi) * pulseWidthNs, timingNs);
+    return errHi < errLo ? hi : lo;
+}
+
+u8 buildUartByte(u8 pulsesA, u8 pulsesB) FL_NO_EXCEPT {
+    int wire[10];
+    for (int i = 0; i < 5; ++i) {
+        wire[i] = i < static_cast<int>(pulsesA) ? 1 : 0;
+        wire[5 + i] = i < static_cast<int>(pulsesB) ? 1 : 0;
+    }
+
+    u8 value = 0;
+    for (int i = 0; i < 8; ++i) {
+        const int dataBit = wire[1 + i] ? 0 : 1;
+        value |= static_cast<u8>(dataBit << i);
+    }
+    return value;
+}
+
+LpcUartWave10Lut buildLpcUartWave10Lut(
+        const ChipsetTimingConfig& timing) FL_NO_EXCEPT {
+    LpcUartWave10Lut result;
+    constexpr u8 kPulsesPerBit = 5;
+    constexpr u32 kMaxBaud = 4000000;
+    constexpr u32 kMinSymbolSeparationNs = 400;
+
+    const u32 periodNs = timing.total_period_ns();
+    if (periodNs == 0) {
+        return result;
+    }
+    const u32 baud = static_cast<u32>(
+        static_cast<u64>(kPulsesPerBit) * 1000000000ULL / periodNs);
+    if (baud == 0 || baud > kMaxBaud) {
+        return result;
+    }
+
+    const u32 pulseWidthNs = periodNs / kPulsesPerBit;
+    const u32 t0hNs = timing.t1_ns;
+    const u32 t1hNs = timing.t1_ns + timing.t2_ns;
+    u8 pulses0 = lpcUartComputePulseCount(t0hNs, pulseWidthNs);
+    u8 pulses1 = lpcUartComputePulseCount(t1hNs, pulseWidthNs);
+    if (pulses0 < 1 || pulses0 > 4 || pulses1 < 1 || pulses1 > 4) {
+        return result;
+    }
+    if (pulses0 == pulses1) {
+        return result;
+    }
+    if (static_cast<u32>(pulses1 - pulses0) * pulseWidthNs <
+        kMinSymbolSeparationNs) {
+        return result;
+    }
+
+    const u32 toleranceNs = pulseWidthNs / 2;
+    const u32 err0 = lpcUartAbsDiff(static_cast<u32>(pulses0) * pulseWidthNs, t0hNs);
+    const u32 err1 = lpcUartAbsDiff(static_cast<u32>(pulses1) * pulseWidthNs, t1hNs);
+    if (err0 > toleranceNs || err1 > toleranceNs) {
+        return result;
+    }
+
+    result.lut[0] = buildUartByte(pulses0, pulses0);
+    result.lut[1] = buildUartByte(pulses0, pulses1);
+    result.lut[2] = buildUartByte(pulses1, pulses0);
+    result.lut[3] = buildUartByte(pulses1, pulses1);
+    result.baud = baud;
+    result.ok = true;
+    return result;
+}
+
+bool lpcUartCanRepresentTiming(
+        const ChipsetTimingConfig& timing) FL_NO_EXCEPT {
+    return buildLpcUartWave10Lut(timing).ok;
+}
+
+size_t encodeLpcUartBytes(const u8* input, size_t inputSize, u8* output,
+                          size_t outputCapacity,
+                          const LpcUartWave10Lut& lut) FL_NO_EXCEPT {
+    const size_t required = inputSize * 4u;
+    if (required > outputCapacity) {
+        return 0;
+    }
+    for (size_t i = 0; i < inputSize; ++i) {
+        const u8 byte = input[i];
+        output[i * 4u + 0u] = lut.lut[(byte >> 6) & 0x03u];
+        output[i * 4u + 1u] = lut.lut[(byte >> 4) & 0x03u];
+        output[i * 4u + 2u] = lut.lut[(byte >> 2) & 0x03u];
+        output[i * 4u + 3u] = lut.lut[byte & 0x03u];
+    }
+    return required;
+}
+
+}  // namespace
+
+bool ChannelEngineLpcUartDma::canHandle(
+        const ChannelDataPtr& data) const FL_NO_EXCEPT {
+    if (!data || !data->isClockless()) {
+        return false;
+    }
+    const int pin = data->getPin();
+    if (pin < 0 || pin > 31) {
+        return false;
+    }
+    return lpcUartCanRepresentTiming(data->getTiming());
+}
+
+void ChannelEngineLpcUartDma::enqueue(ChannelDataPtr channelData) FL_NO_EXCEPT {
+    if (channelData) {
+        mEnqueuedChannels.push_back(channelData);
+    }
+}
+
+void ChannelEngineLpcUartDma::show() FL_NO_EXCEPT {
+    if (mTransmissionActive || mEnqueuedChannels.empty()) {
+        return;
+    }
+    mTransmittingChannels = fl::move(mEnqueuedChannels);
+    mEnqueuedChannels.clear();
+    mCurrentChannel = 0;
+    startNextTransmission();
+}
+
+IChannelDriver::DriverState ChannelEngineLpcUartDma::poll() FL_NO_EXCEPT {
+    if (!mTransmissionActive) {
+        return DriverState::READY;
+    }
+    if (!lpc::LpcUartDmaRuntime::streamDone()) {
+        return DriverState::DRAINING;
+    }
+    if (mCurrentChannel < mTransmittingChannels.size() &&
+        mTransmittingChannels[mCurrentChannel]) {
+        mTransmittingChannels[mCurrentChannel]->setInUse(false);
+    }
+    ++mCurrentChannel;
+    if (startNextTransmission()) {
+        return DriverState::DRAINING;
+    }
+
+    mTransmissionActive = false;
+    mTransmittingChannels.clear();
+    mCurrentChannel = 0;
+    mPollNeededCallback.invoke();
+    return DriverState::READY;
+}
+
+bool ChannelEngineLpcUartDma::startNextTransmission() FL_NO_EXCEPT {
+    while (mCurrentChannel < mTransmittingChannels.size()) {
+        if (beginTransmission(mTransmittingChannels[mCurrentChannel])) {
+            mTransmissionActive = true;
+            return true;
+        }
+        if (mTransmittingChannels[mCurrentChannel]) {
+            mTransmittingChannels[mCurrentChannel]->setInUse(false);
+        }
+        ++mCurrentChannel;
+    }
+    return false;
+}
+
+bool ChannelEngineLpcUartDma::beginTransmission(
+        const ChannelDataPtr& channel) FL_NO_EXCEPT {
+    if (!channel || !canHandle(channel)) {
+        return false;
+    }
+    const fl::vector_psram<u8>& data = channel->getData();
+    if (data.empty()) {
+        return false;
+    }
+
+    const LpcUartWave10Lut lut = buildLpcUartWave10Lut(channel->getTiming());
+    if (!lut.ok) {
+        return false;
+    }
+
+    const size_t encodedSize = data.size() * 4u;
+    mEncodedBuffer.resize(encodedSize);
+    const size_t written = encodeLpcUartBytes(
+        data.data(), data.size(), mEncodedBuffer.data(), mEncodedBuffer.size(),
+        lut);
+    if (written == 0) {
+        FL_WARN_F("LPC UART DMA: encode failed for %u bytes",
+                  static_cast<unsigned>(data.size()));
+        return false;
+    }
+
+    lpc::LpcUartDmaRuntime::init(
+        static_cast<u8>(channel->getPin()), lut.baud, /*invertTx=*/true);
+    if (!lpc::LpcUartDmaRuntime::kickDmaStreamAsync(
+            mEncodedBuffer.data(), static_cast<u32>(written))) {
+        FL_WARN_F("LPC UART DMA: DMA stream kick failed");
+        return false;
+    }
+    channel->setInUse(true);
+    return true;
+}
+
+}  // namespace fl
+
+#endif  // FL_IS_ARM_LPC_845 && FASTLED_LPC_UART_DMA

--- a/src/platforms/arm/lpc/drivers/uart_dma/channel_engine_lpc_uart_dma.h
+++ b/src/platforms/arm/lpc/drivers/uart_dma/channel_engine_lpc_uart_dma.h
@@ -1,0 +1,58 @@
+#pragma once
+
+// IWYU pragma: private
+
+/// @file channel_engine_lpc_uart_dma.h
+/// @brief LPC845 UART + DMA0 clockless channel engine.
+
+#include "platforms/arm/lpc/is_lpc.h"
+
+#if defined(FL_IS_ARM_LPC_845) && defined(FASTLED_LPC_UART_DMA)
+
+#include "fl/channels/data.h"
+#include "fl/channels/driver.h"
+#include "fl/stl/cstddef.h"
+#include "fl/stl/noexcept.h"
+#include "fl/stl/string.h"
+#include "fl/stl/vector.h"
+#include "platforms/arm/lpc/uart_arm_lpc_dma.h"
+
+namespace fl {
+
+class ChannelEngineLpcUartDma : public IChannelDriver {
+public:
+    ChannelEngineLpcUartDma() FL_NO_EXCEPT = default;
+    ~ChannelEngineLpcUartDma() override = default;
+
+    bool canHandle(const ChannelDataPtr& data) const FL_NO_EXCEPT override;
+    void enqueue(ChannelDataPtr channelData) FL_NO_EXCEPT override;
+    void show() FL_NO_EXCEPT override;
+    DriverState poll() FL_NO_EXCEPT override;
+
+    fl::string getName() const FL_NO_EXCEPT override {
+        return fl::string::from_literal("UART");
+    }
+
+    Capabilities getCapabilities() const FL_NO_EXCEPT override {
+        return Capabilities(/*clockless=*/true, /*spi=*/false);
+    }
+
+    void setPollNeededCallback(PollNeededCallback callback) FL_NO_EXCEPT override {
+        mPollNeededCallback.set(callback);
+    }
+
+private:
+    bool startNextTransmission() FL_NO_EXCEPT;
+    bool beginTransmission(const ChannelDataPtr& channel) FL_NO_EXCEPT;
+
+    fl::vector<ChannelDataPtr> mEnqueuedChannels;
+    fl::vector<ChannelDataPtr> mTransmittingChannels;
+    fl::vector<u8> mEncodedBuffer;
+    size_t mCurrentChannel = 0;
+    bool mTransmissionActive = false;
+    PollNeededCallbackSlot mPollNeededCallback;
+};
+
+}  // namespace fl
+
+#endif  // FL_IS_ARM_LPC_845 && FASTLED_LPC_UART_DMA

--- a/src/platforms/arm/lpc/fastled_arm_lpc.h
+++ b/src/platforms/arm/lpc/fastled_arm_lpc.h
@@ -34,16 +34,21 @@
 //                            0x50000000 GPIO controller with 12-bit
 //                            masked-access semantics per UM10398 sec. 9.
 
-// LPC845 has an optional PWM+DMA-to-GPIO clockless driver (Stage 2c of #2836,
-// see #2842). It is opt-in via FASTLED_LPC_PWM_DMA=1 because it consumes the
-// SCT plus 3 DMA channels — a global resource users may want for other
-// peripherals. When the macro is set on an LPC845 build, the channels-API
-// SCT+DMA engine supplies fl::ClocklessController via
-// `clockless_channel_lpc.h` (#3517 Phase A.2 — the classic legacy template
-// in `clockless_arm_lpc_pwm_dma.h` is superseded and slated for retirement
-// once silicon validation confirms parity). Without the flag the Stage 2a
-// bit-bang driver in `clockless_arm_lpc.h` remains the default.
-#if defined(FL_IS_ARM_LPC_845) && defined(FASTLED_LPC_PWM_DMA)
+// LPC845 can opt into UART+DMA clockless output with FASTLED_LPC_UART_DMA=1.
+// That adapter supplies fl::ClocklessController first so AUTO/default
+// clockless output uses the UART DMA engine.
+#if defined(FL_IS_ARM_LPC_845) && defined(FASTLED_LPC_UART_DMA)
+#include "platforms/arm/lpc/clockless_channel_lpc_uart_dma.h"
+#endif
+
+// LPC845 also has an optional PWM+DMA-to-GPIO clockless driver (Stage 2c of
+// #2836, see #2842). It is opt-in via FASTLED_LPC_PWM_DMA=1 because it
+// consumes the SCT plus 3 DMA channels, a global resource users may want for
+// other peripherals. When UART has not already provided the template, the
+// channels-API SCT+DMA engine supplies fl::ClocklessController via
+// `clockless_channel_lpc.h` (#3517 Phase A.2). Without either DMA flag the
+// Stage 2a bit-bang driver in `clockless_arm_lpc.h` remains the default.
+#if !defined(FL_CLOCKLESS_CONTROLLER_DEFINED) && defined(FL_IS_ARM_LPC_845) && defined(FASTLED_LPC_PWM_DMA)
 #include "platforms/arm/lpc/clockless_channel_lpc.h"
 #endif
 // Include the bit-bang default on any build that has NOT already picked a

--- a/src/platforms/arm/lpc/uart_arm_lpc_dma.h
+++ b/src/platforms/arm/lpc/uart_arm_lpc_dma.h
@@ -49,6 +49,17 @@
 #include "platforms/arm/lpc/lpc_dma_descriptor_table.h"
 #include "platforms/arm/lpc/lpc_dma_isr.h"
 
+#if defined(FL_LPC_UART_DMA_LOOPBACK_TEST)
+extern "C" {
+extern uint8_t* g_fastled_lpc_uart_loopback_rx_dst;
+extern uint32_t g_fastled_lpc_uart_loopback_rx_len;
+extern uint32_t g_fastled_lpc_uart_loopback_rx_arm_status;
+extern uint32_t g_fastled_lpc_uart_loopback_rx_arm_tx_len;
+extern uint32_t g_fastled_lpc_uart_loopback_rx_arm_xfer_readback;
+extern uint32_t g_fastled_lpc_uart_loopback_rx_arm_desc0_readback;
+}
+#endif
+
 namespace fl {
 
 // USART instance selector. Only USART1/USART2 are wired here — USART0 is
@@ -64,6 +75,337 @@ namespace fl {
 /// @tparam _BAUD    Wire baud rate (main_clk 24 MHz / 16x OSR ⇒ max
 ///                  practical ~1.5 Mbaud at integer BRG; 3 Mbaud needs
 ///                  OSR=8 — the driver picks OSR/BRG for minimal error).
+namespace lpc {
+
+class LpcUartDmaRuntime {
+    static inline USART_Type* uartBlock() FL_NO_EXCEPT {
+#if FASTLED_LPC_UART_DMA_INSTANCE == 2
+        return USART2;
+#else
+        return USART1;
+#endif
+    }
+
+    static constexpr u32 kDmaChannel =
+        (FASTLED_LPC_UART_DMA_INSTANCE == 2) ? 5u : 3u;
+#if defined(FL_LPC_UART_DMA_LOOPBACK_TEST)
+    // UM11029 Table 296: USART1_RX is DMA channel 2; USART2_RX is channel 4.
+    static constexpr u32 kLoopbackRxDmaChannel =
+        (FASTLED_LPC_UART_DMA_INSTANCE == 2) ? 4u : 2u;
+#endif
+    static constexpr u32 kMaxChunk = 1024u;
+    static constexpr u32 kUsartCfgLoop = (1UL << 15);
+    static constexpr u32 kUsartCfgRxPol = (1UL << 22);
+    static constexpr u32 kUsartCfgTxPol = (1UL << 23);
+    static constexpr u32 kSwmPinMask = 0xFFu;
+    static constexpr u32 swmMask(u32 shift) FL_NO_EXCEPT {
+        return kSwmPinMask << shift;
+    }
+    static constexpr u32 swmValue(u8 pin, u32 shift) FL_NO_EXCEPT {
+        return (static_cast<u32>(pin) & kSwmPinMask) << shift;
+    }
+#if defined(FL_LPC_UART_DMA_LOOPBACK_TEST)
+    static constexpr u32 kDmaBase = 0x50008000u;
+    static volatile u32& dmaReg(u32 offset) FL_NO_EXCEPT {
+        return *reinterpret_cast<volatile u32*>(kDmaBase + offset);  // ok reinterpret cast - DMA0 MMIO
+    }
+    static constexpr u32 dmaChCfg(u32 ch) FL_NO_EXCEPT { return 0x400u + 16u * ch; }
+    static constexpr u32 dmaChCtlStat(u32 ch) FL_NO_EXCEPT { return 0x404u + 16u * ch; }
+    static constexpr u32 dmaChXferCfg(u32 ch) FL_NO_EXCEPT { return 0x408u + 16u * ch; }
+#endif
+
+public:
+    struct StreamState {
+        const u8* volatile src = nullptr;
+        volatile u32 remaining = 0;
+        volatile bool running = false;
+    };
+
+#if defined(FL_LPC_UART_DMA_LOOPBACK_TEST)
+    static void prepareLoopbackRxBuffer(u8* dst, u32 len) FL_NO_EXCEPT {
+        g_fastled_lpc_uart_loopback_rx_dst = dst;
+        g_fastled_lpc_uart_loopback_rx_len = len;
+        g_fastled_lpc_uart_loopback_rx_arm_status = 0;
+        g_fastled_lpc_uart_loopback_rx_arm_tx_len = 0;
+        g_fastled_lpc_uart_loopback_rx_arm_xfer_readback = 0;
+        g_fastled_lpc_uart_loopback_rx_arm_desc0_readback = 0;
+    }
+
+    static u32 loopbackRxReceivedCount() FL_NO_EXCEPT {
+        const u32 len = g_fastled_lpc_uart_loopback_rx_len;
+        if (g_fastled_lpc_uart_loopback_rx_dst == nullptr || len == 0u) {
+            return 0;
+        }
+        const u32 mask = (1UL << kLoopbackRxDmaChannel);
+        if ((dmaReg(0x058u) & mask) != 0u) {  // INTA0: SETINTA completion.
+            return len;
+        }
+        const u32 xfer = dmaReg(dmaChXferCfg(kLoopbackRxDmaChannel));
+        if ((xfer & 1u) == 0u) {
+            return len;
+        }
+        const u32 residual = (xfer >> 16) & 0x3FFu;
+        if (residual >= len) {
+            return 0;
+        }
+        return len - 1u - residual;
+    }
+
+    static void clearLoopbackRxBuffer() FL_NO_EXCEPT {
+        const u32 mask = (1UL << kLoopbackRxDmaChannel);
+        dmaReg(0x028u) = mask;  // ENABLECLR0
+        dmaReg(0x078u) = mask;  // ABORT0
+        dmaReg(0x058u) = mask;  // INTA0 W1C
+        g_fastled_lpc_uart_loopback_rx_dst = nullptr;
+        g_fastled_lpc_uart_loopback_rx_len = 0;
+    }
+#endif
+
+    static void init(u8 txPin, u32 baud, bool invertTx) FL_NO_EXCEPT {
+#if FASTLED_LPC_UART_DMA_INSTANCE == 2
+        SYSCON->SYSAHBCLKCTRL0 |= SYSCON_SYSAHBCLKCTRL0_UART2_MASK |
+                                  SYSCON_SYSAHBCLKCTRL0_SWM_MASK;
+        SYSCON->PRESETCTRL0 |= SYSCON_PRESETCTRL0_UART2_RST_N_MASK;
+        SYSCON->FCLKSEL[2] = SYSCON_FCLKSEL_SEL(0x1u);
+#if defined(FL_LPC_UART_DMA_CLOCKLESS_RX_PIN)
+        // UM11029 Table 182: PINASSIGN2[23:16]=U2_TXD_O,
+        // PINASSIGN2[31:24]=U2_RXD_I.
+        SWM0->PINASSIGN.PINASSIGN2 =
+            (SWM0->PINASSIGN.PINASSIGN2 &
+             ~(swmMask(16u) | swmMask(24u))) |
+            swmValue(txPin, 16u) |
+            swmValue(static_cast<u8>(FL_LPC_UART_DMA_CLOCKLESS_RX_PIN), 24u);
+#else
+        SWM0->PINASSIGN.PINASSIGN2 =
+            (SWM0->PINASSIGN.PINASSIGN2 & ~SWM_PINASSIGN2_U2_TXD_O_MASK) |
+            SWM_PINASSIGN2_U2_TXD_O(txPin);
+#endif
+#else
+        SYSCON->SYSAHBCLKCTRL0 |= SYSCON_SYSAHBCLKCTRL0_UART1_MASK |
+                                  SYSCON_SYSAHBCLKCTRL0_SWM_MASK;
+        SYSCON->PRESETCTRL0 |= SYSCON_PRESETCTRL0_UART1_RST_N_MASK;
+        SYSCON->FCLKSEL[1] = SYSCON_FCLKSEL_SEL(0x1u);
+#if defined(FL_LPC_UART_DMA_CLOCKLESS_RX_PIN)
+        // UM11029 Table 181: PINASSIGN1[15:8]=U1_TXD_O,
+        // PINASSIGN1[23:16]=U1_RXD_I.
+        SWM0->PINASSIGN.PINASSIGN1 =
+            (SWM0->PINASSIGN.PINASSIGN1 &
+             ~(swmMask(8u) | swmMask(16u))) |
+            swmValue(txPin, 8u) |
+            swmValue(static_cast<u8>(FL_LPC_UART_DMA_CLOCKLESS_RX_PIN), 16u);
+#else
+        SWM0->PINASSIGN.PINASSIGN1 =
+            (SWM0->PINASSIGN.PINASSIGN1 & ~SWM_PINASSIGN1_U1_TXD_O_MASK) |
+            SWM_PINASSIGN1_U1_TXD_O(txPin);
+#endif
+#endif
+
+        USART_Type* u = uartBlock();
+        u->CFG = 0;
+        u32 bestOsr = 15u;
+        u32 bestBrg = 0u;
+        u32 bestErr = 0xFFFFFFFFu;
+        for (u32 osr = 15u; osr >= 4u; --osr) {
+            const u32 div = (osr + 1u) * baud;
+            u32 brg = (F_CPU + div / 2u) / div;
+            if (brg == 0u) {
+                brg = 1u;
+            }
+            const u32 actual = F_CPU / ((osr + 1u) * brg);
+            const u32 err = actual > baud ? actual - baud : baud - actual;
+            if (err < bestErr) {
+                bestErr = err;
+                bestOsr = osr;
+                bestBrg = brg - 1u;
+            }
+        }
+        u->OSR = bestOsr & USART_OSR_OSRVAL_MASK;
+        u->BRG = bestBrg & USART_BRG_BRGVAL_MASK;
+
+        u32 cfg = USART_CFG_ENABLE_MASK | USART_CFG_DATALEN(0x1u);
+        if (invertTx) {
+            // UM11029 Table 324: USART CFG bit 23 is TXPOL.
+            cfg |= kUsartCfgTxPol;
+        }
+#if defined(FL_LPC_UART_DMA_LOOPBACK_TEST)
+        // AutoResearch-only: when an RX pin is provided, verify through the
+        // board-level jumper. Otherwise fall back to UM11029 Table 324 LOOP.
+#if !defined(FL_LPC_UART_DMA_CLOCKLESS_RX_PIN)
+        cfg |= kUsartCfgLoop;
+#endif
+        // The clockless UART path intentionally inverts TX, so the verifier
+        // inverts RX too whether the signal arrives by pin or internal LOOP.
+        if (invertTx) {
+            cfg |= kUsartCfgRxPol;
+        }
+#endif
+        u->CFG = cfg;
+
+        SYSCON->SYSAHBCLKCTRL0 |= SYSCON_SYSAHBCLKCTRL0_DMA_MASK;
+        DMA0->CTRL = 1UL;
+        fl::lpc::ensureDmaSramBase();
+        DMA0->CHANNEL[kDmaChannel].CFG = (1UL << 0);
+        DMA0->COMMON[0].ENABLESET = (1UL << kDmaChannel);
+    }
+
+    static bool done() FL_NO_EXCEPT {
+        return (DMA0->COMMON[0].ACTIVE & (1UL << kDmaChannel)) == 0u;
+    }
+
+    static bool armNextChunk() FL_NO_EXCEPT {
+        StreamState& stream = streamState();
+        const u32 n = stream.remaining < kMaxChunk
+                          ? static_cast<u32>(stream.remaining)
+                          : kMaxChunk;
+        if (n == 0u) {
+            return false;
+        }
+        const u32 srambase = DMA0->SRAMBASE;
+        if (srambase == 0u) {
+            return false;
+        }
+
+        const u8* base = stream.src;
+        stream.src = base + n;
+        stream.remaining = stream.remaining - n;
+
+        volatile u32* descr =
+            reinterpret_cast<volatile u32*>(srambase + 16u * kDmaChannel);  // ok reinterpret cast - raw DMA descriptor address
+        descr[0] = 0u;
+        descr[1] = reinterpret_cast<u32>(&base[n - 1u]);  // ok reinterpret cast - DMA descriptor source end address
+        descr[2] = reinterpret_cast<u32>(&uartBlock()->TXDAT);  // ok reinterpret cast - DMA descriptor destination address
+        descr[3] = 0u;
+
+        DMA0->CHANNEL[kDmaChannel].XFERCFG =
+            (1UL << 0) | (1UL << 2) | (1UL << 4) |
+            (0UL << 8) |
+            (1UL << 12) |
+            (0UL << 14) |
+            (((n - 1u) & 0x3FFu) << 16);
+        DMA0->COMMON[0].SETVALID = (1UL << kDmaChannel);
+        return true;
+    }
+
+    static void onDmaChunkDone(void*) FL_NO_EXCEPT {
+        if (!armNextChunk()) {
+            DMA0->COMMON[0].INTENCLR = (1UL << kDmaChannel);
+            streamState().running = false;
+        }
+    }
+
+    static bool kickDmaStreamAsync(const u8* src, u32 len) FL_NO_EXCEPT {
+        if (len == 0u) {
+            return true;
+        }
+#if !FASTLED_LPC_DMA_ISR
+        if (len > kMaxChunk) {
+            return false;
+        }
+#endif
+        StreamState& stream = streamState();
+        while (!done()) {
+            __asm volatile("wfi" ::: "memory");
+        }
+        while (stream.running) {
+            __asm volatile("wfi" ::: "memory");
+        }
+        fl::lpc::registerDmaChannelIsr(kDmaChannel, &onDmaChunkDone, nullptr);
+#if defined(FL_LPC_UART_DMA_LOOPBACK_TEST)
+        armLoopbackRxIfRequested(len);
+#else
+        (void)len;
+#endif
+        stream.src = src;
+        stream.remaining = len;
+        stream.running = true;
+        if (!armNextChunk()) {
+            stream.running = false;
+            return false;
+        }
+        return true;
+    }
+
+    static bool streamDone() FL_NO_EXCEPT {
+        if (streamState().running || !done()) {
+            return false;
+        }
+        return (uartBlock()->STAT & USART_STAT_TXIDLE_MASK) != 0u;
+    }
+
+private:
+#if defined(FL_LPC_UART_DMA_LOOPBACK_TEST)
+    static void armLoopbackRxIfRequested(u32 txLen) FL_NO_EXCEPT {
+        u8* const dst = g_fastled_lpc_uart_loopback_rx_dst;
+        const u32 len = g_fastled_lpc_uart_loopback_rx_len;
+        g_fastled_lpc_uart_loopback_rx_arm_tx_len = txLen;
+        if (dst == nullptr || len == 0u) {
+            g_fastled_lpc_uart_loopback_rx_arm_status = 1;
+            return;
+        }
+        if (len > txLen) {
+            g_fastled_lpc_uart_loopback_rx_arm_status = 2;
+            return;
+        }
+        if (len > kMaxChunk) {
+            g_fastled_lpc_uart_loopback_rx_arm_status = 3;
+            return;
+        }
+        const u32 srambase = DMA0->SRAMBASE;
+        if (srambase == 0u) {
+            g_fastled_lpc_uart_loopback_rx_arm_status = 4;
+            return;
+        }
+
+        USART_Type* u = uartBlock();
+        while ((u->STAT & (1u << 0)) != 0u) {
+            (void)u->RXDATSTAT;
+        }
+        u->STAT = (1u << 8) | (1u << 13) | (1u << 14);
+
+        const u32 mask = (1UL << kLoopbackRxDmaChannel);
+        dmaReg(0x028u) = mask;  // ENABLECLR0
+        while ((dmaReg(0x038u) & mask) != 0u) {
+        }
+        dmaReg(0x078u) = mask;  // ABORT0
+        dmaReg(0x058u) = mask;  // INTA0 W1C
+        dmaReg(dmaChXferCfg(kLoopbackRxDmaChannel)) = 0u;
+
+        volatile u32* descr =
+            reinterpret_cast<volatile u32*>(srambase + 16u * kLoopbackRxDmaChannel);  // ok reinterpret cast - raw DMA descriptor address
+        const u32 xfercfg =
+            (1UL << 0) |        // CFGVALID
+            (1UL << 2) |        // SWTRIG: request paces after channel is triggered
+            (1UL << 4) |        // SETINTA: AutoResearch completion probe
+            (0UL << 8) |        // WIDTH = 8-bit
+            (0UL << 12) |       // SRCINC = none
+            (1UL << 14) |       // DSTINC = +1 byte
+            (((len - 1u) & 0x3FFu) << 16);
+        // UM11029 Table 299: the initial single-buffer descriptor's +0 word
+        // is reserved; the live transfer config is DMA CHANNEL[n].XFERCFG.
+        descr[0] = 0u;
+        descr[1] = reinterpret_cast<u32>(&u->RXDAT);  // ok reinterpret cast - USART RX data register
+        descr[2] = reinterpret_cast<u32>(&dst[len - 1u]);  // ok reinterpret cast - DMA descriptor destination end
+        descr[3] = 0u;
+
+        dmaReg(dmaChCfg(kLoopbackRxDmaChannel)) = (1UL << 0);  // PERIPHREQEN
+        dmaReg(0x020u) = mask;  // ENABLESET0
+        dmaReg(dmaChXferCfg(kLoopbackRxDmaChannel)) = xfercfg;
+        dmaReg(0x068u) = mask;  // SETVALID0
+        g_fastled_lpc_uart_loopback_rx_arm_xfer_readback =
+            dmaReg(dmaChXferCfg(kLoopbackRxDmaChannel));
+        g_fastled_lpc_uart_loopback_rx_arm_desc0_readback = descr[0];
+        g_fastled_lpc_uart_loopback_rx_arm_status = 5;
+    }
+#endif
+
+    static StreamState& streamState() FL_NO_EXCEPT {
+        static StreamState state;
+        return state;
+    }
+};
+
+}  // namespace lpc
+
 template <u8 _TX_PIN, u32 _BAUD>
 class ARMHardwareUARTOutputDMA {
     static inline USART_Type* uart_block() __attribute__((always_inline)) {
@@ -167,6 +509,7 @@ public:
 
         volatile u32* descr =
             reinterpret_cast<volatile u32*>(srambase + 16u * kDmaChannel);  // ok reinterpret cast - SRAMBASE + channel offset = raw descriptor table address
+        descr[0] = 0u;
         descr[1] = reinterpret_cast<u32>(&base[n - 1u]);  // ok reinterpret cast - LPC DMA descriptor requires raw address
         descr[2] = reinterpret_cast<u32>(&uart_block()->TXDAT);  // ok reinterpret cast - LPC DMA descriptor requires raw address
         descr[3] = 0u;

--- a/src/platforms/shared/bitbang/bus_traits.h
+++ b/src/platforms/shared/bitbang/bus_traits.h
@@ -25,7 +25,7 @@
 // FastLED #3459 / PR #3460). The shared bit-bang specialization must
 // step aside on that platform to avoid a redefinition. Every other
 // platform continues to use the universal-GPIO fallback below.
-#if !defined(FL_IS_ARM_LPC_845)
+#if !(defined(FL_IS_ARM_LPC_845) && defined(FASTLED_LPC_PWM_DMA))
 
 namespace fl {
 
@@ -49,4 +49,4 @@ template<> struct BusSupports<Bus::BIT_BANG, SpiChipsetConfig>  : fl::true_type 
 
 }  // namespace fl
 
-#endif  // !FL_IS_ARM_LPC_845
+#endif  // !(FL_IS_ARM_LPC_845 && FASTLED_LPC_PWM_DMA)


### PR DESCRIPTION
## Summary

- Adds an LPC845 `Bus::UART` clockless channel engine that encodes WS2812 bytes to UART symbols and streams them through USART TX DMA.
- Makes LPC845 clockless AUTO/default routing resolve to UART DMA when `FASTLED_LPC_UART_DMA=1`, including the legacy `FastLED.addLeds<WS2812, PIN, GRB>()` adapter.
- Adds AutoResearch `--uart` coverage that drives through the normal FastLED API and verifies the encoded bytes with USART RX-DMA on the configured RX pin.
- Keeps the public bus as `Bus::UART`; USART instance selection remains hidden in the LPC driver.

Closes #3611.

## Datasheet / docs used

- LPC845 datasheets repo: https://github.com/FastLED/datasheets/tree/main/nxp/mcu/LPC845
- Channels API bus docs: https://github.com/FastLED/FastLED/blob/master/src/fl/channels/README.md
- Hardware AutoResearch runbook: https://github.com/FastLED/FastLED/blob/master/agents/docs/hardware-autoresearch.md
- LPC AutoResearch notes: https://github.com/FastLED/FastLED/blob/master/src/platforms/arm/lpc/README.md#hardware-verification-via-autoresearch-loopback-2880
- PR #3349 phatpaul register-map/testing discussion: https://github.com/FastLED/FastLED/pull/3349#issuecomment-4811566535

Datasheet facts applied from UM11029: USART1 RX/TX use fixed DMA channels 2/3, USART2 RX/TX use fixed channels 4/5, SWM PINASSIGN routes USART TXD/RXD, USART CFG provides LOOP/RXPOL/TXPOL, and initial DMA descriptor word 0 is reserved while live transfer config is `CHANNEL[n].XFERCFG`.

## Hardware verification

- `bash test --cpp`
  - PASS: 350/350
- `bash autoresearch lpc845 --uart --upload-port COM10 --no-auto-discover-pins --tx-pin 13 --rx-pin 11 --timeout 120s --skip-lint`
  - PASS: `0xFF0000`, `0x00FF00`, `0x55AA33`; each returned `24 bytes match expected pattern`
  - Build flags included `FASTLED_LPC_UART_DMA=1`, `FASTLED_LPC_DMA_ISR=1`, `FL_LPC_UART_DMA_CLOCKLESS_TEST=1`, `FL_LPC_UART_DMA_LOOPBACK_TEST=1`, `FL_LPC_UART_DMA_CLOCKLESS_TX_PIN=13`, `FL_LPC_UART_DMA_CLOCKLESS_RX_PIN=11`
  - Firmware size: Flash 63.41 KB / 64.00 KB, RAM 9.61 KB / 16.00 KB
- `bash autoresearch lpc845 --dma-uart --upload-port COM10 --no-auto-discover-pins --timeout 60s --skip-lint`
  - PASS: `uartDmaStreamOnce(2048, 0xA5)` total 20508 us for 2048 bytes
  - PASS: `uartDmaStreamOverlap(2048, 0x5A)` total 20510 us, toggles=8455

Both AutoResearch runs emitted the existing PlatformIO `pio platform show` warning after the successful fbuild deploy/test path; exit code was 0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added LPC845 UART DMA clockless support for FastLED output, including a new UART-based path and automatic selection when enabled.
  * Added a new verification workflow for UART RX loopback testing on supported LPC boards.

* **Bug Fixes**
  * Tightened LPC build selection so only one clockless DMA path is chosen at a time.
  * Improved compatibility and reporting for UART DMA device detection and channel selection.

* **Documentation**
  * Updated help text and LPC platform docs with UART test instructions and setup guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->