### PR TITLE
Fix LPC UART DMA lint

### DIFF
--- a/src/platforms/arm/lpc/clockless_channel_lpc_uart_dma.h
+++ b/src/platforms/arm/lpc/clockless_channel_lpc_uart_dma.h
@@ -5,6 +5,7 @@
 /// @file clockless_channel_lpc_uart_dma.h
 /// @brief LPC845 channels-API ClocklessController adapter for UART DMA.
 
+#include "platforms/arm/is_arm.h"
 #include "platforms/arm/lpc/is_lpc.h"
 
 #if defined(FL_IS_ARM_LPC_845) && defined(FASTLED_LPC_UART_DMA)

--- a/src/platforms/arm/lpc/drivers/uart_dma/_build.cpp.hpp
+++ b/src/platforms/arm/lpc/drivers/uart_dma/_build.cpp.hpp
@@ -3,16 +3,16 @@
 /// @file _build.cpp.hpp
 /// @brief Unity build header for the LPC845 UART DMA channel engine.
 
-#include <stdint.h>
+#include "fl/stl/int.h"
 
 #if defined(FL_LPC_UART_DMA_LOOPBACK_TEST)
 extern "C" {
-uint8_t* g_fastled_lpc_uart_loopback_rx_dst = nullptr;
-uint32_t g_fastled_lpc_uart_loopback_rx_len = 0;
-uint32_t g_fastled_lpc_uart_loopback_rx_arm_status = 0;
-uint32_t g_fastled_lpc_uart_loopback_rx_arm_tx_len = 0;
-uint32_t g_fastled_lpc_uart_loopback_rx_arm_xfer_readback = 0;
-uint32_t g_fastled_lpc_uart_loopback_rx_arm_desc0_readback = 0;
+fl::u8* g_fastled_lpc_uart_loopback_rx_dst = nullptr;
+fl::u32 g_fastled_lpc_uart_loopback_rx_len = 0;
+fl::u32 g_fastled_lpc_uart_loopback_rx_arm_status = 0;
+fl::u32 g_fastled_lpc_uart_loopback_rx_arm_tx_len = 0;
+fl::u32 g_fastled_lpc_uart_loopback_rx_arm_xfer_readback = 0;
+fl::u32 g_fastled_lpc_uart_loopback_rx_arm_desc0_readback = 0;
 }
 #endif
 

--- a/src/platforms/arm/lpc/drivers/uart_dma/bus_traits.h
+++ b/src/platforms/arm/lpc/drivers/uart_dma/bus_traits.h
@@ -5,6 +5,7 @@
 /// @file bus_traits.h
 /// @brief BusTraits<Bus::UART> specialization for LPC845 UART DMA clockless.
 
+#include "platforms/arm/is_arm.h"
 #include "platforms/arm/lpc/is_lpc.h"
 
 #if defined(FL_IS_ARM_LPC_845) && defined(FASTLED_LPC_UART_DMA)

--- a/src/platforms/arm/lpc/drivers/uart_dma/channel_engine_lpc_uart_dma.cpp.hpp
+++ b/src/platforms/arm/lpc/drivers/uart_dma/channel_engine_lpc_uart_dma.cpp.hpp
@@ -1,5 +1,6 @@
 // IWYU pragma: private
 
+#include "platforms/arm/is_arm.h"
 #include "platforms/arm/lpc/is_lpc.h"
 
 #if defined(FL_IS_ARM_LPC_845) && defined(FASTLED_LPC_UART_DMA)

--- a/src/platforms/arm/lpc/drivers/uart_dma/channel_engine_lpc_uart_dma.h
+++ b/src/platforms/arm/lpc/drivers/uart_dma/channel_engine_lpc_uart_dma.h
@@ -5,6 +5,7 @@
 /// @file channel_engine_lpc_uart_dma.h
 /// @brief LPC845 UART + DMA0 clockless channel engine.
 
+#include "platforms/arm/is_arm.h"
 #include "platforms/arm/lpc/is_lpc.h"
 
 #if defined(FL_IS_ARM_LPC_845) && defined(FASTLED_LPC_UART_DMA)

--- a/src/platforms/arm/lpc/uart_arm_lpc_dma.h
+++ b/src/platforms/arm/lpc/uart_arm_lpc_dma.h
@@ -51,12 +51,12 @@
 
 #if defined(FL_LPC_UART_DMA_LOOPBACK_TEST)
 extern "C" {
-extern uint8_t* g_fastled_lpc_uart_loopback_rx_dst;
-extern uint32_t g_fastled_lpc_uart_loopback_rx_len;
-extern uint32_t g_fastled_lpc_uart_loopback_rx_arm_status;
-extern uint32_t g_fastled_lpc_uart_loopback_rx_arm_tx_len;
-extern uint32_t g_fastled_lpc_uart_loopback_rx_arm_xfer_readback;
-extern uint32_t g_fastled_lpc_uart_loopback_rx_arm_desc0_readback;
+extern fl::u8* g_fastled_lpc_uart_loopback_rx_dst;
+extern fl::u32 g_fastled_lpc_uart_loopback_rx_len;
+extern fl::u32 g_fastled_lpc_uart_loopback_rx_arm_status;
+extern fl::u32 g_fastled_lpc_uart_loopback_rx_arm_tx_len;
+extern fl::u32 g_fastled_lpc_uart_loopback_rx_arm_xfer_readback;
+extern fl::u32 g_fastled_lpc_uart_loopback_rx_arm_desc0_readback;
 }
 #endif
 


### PR DESCRIPTION
## Summary

- Adds the `platforms/arm/is_arm.h` includes required by the LPC UART DMA headers that gate on `FL_IS_ARM_LPC_845`.
- Replaces `stdint.h` / `uint*_t` in the UART DMA loopback globals with `fl/stl/int.h` and `fl::u8` / `fl::u32`.

Follow-up to #3612. The implementation was merged, but CI's `bash lint --cpp` failed on these header-style checks after the early merge.

## Verification

- `bash lint --cpp` PASS
- `bash test --cpp` PASS: 350/350, run after the same lint cleanup on the pre-follow-up branch
- `bash autoresearch lpc845 --uart --upload-port COM10 --no-auto-discover-pins --tx-pin 13 --rx-pin 11 --timeout 120s --skip-lint` PASS after the same lint cleanup: three RGB patterns matched over USART RX-DMA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ARM LPC UART DMA support by adding platform-specific compatibility checks.
  * Updated loopback test type declarations to use project-standard integer types, helping keep builds consistent across targets.
  * No user-facing behavior changes were introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->