### PR TITLE
Default LPC845 AUTO to UART DMA

### DIFF
--- a/ci/autoresearch/args.py
+++ b/ci/autoresearch/args.py
@@ -429,8 +429,9 @@ See Also:
             "stream timing + beacon-toggle async proof. Mutually "
             "exclusive with --dma-spi / --pwm-dma-cl (flash budget).",
         )
+        lpc_description = lpc_group.description or ""
         lpc_group.description = (
-            lpc_group.description
+            lpc_description
             + " Use the top-level --uart flag on LPC845 for the UART DMA "
             "clockless FastLED API loopback (#3611)."
         )

--- a/ci/autoresearch/phases.py
+++ b/ci/autoresearch/phases.py
@@ -923,29 +923,26 @@ def _parse_args_and_build_commands(args: Args) -> RunContext | int:
         # ACLPC core with named weak IRQ vector slots
         # (framework-arduino-lpc8xx#38).
         lpc_bench_defines.append("FASTLED_LPC_UART_DMA=1")
+        lpc_bench_defines.append("FASTLED_AUTORESEARCH_LPC_UART_DMA=1")
         lpc_bench_defines.append("FASTLED_LPC_DMA_ISR=1")
     requested_env = (args.environment or args.environment_positional or "").lower()
     if requested_env in LPC_WS2812_ENVS:
         if getattr(args, "pin_toggle_rx", False):
             lpc_bench_defines.append("FASTLED_LPC_RX_SCT=1")
-        if (
-            getattr(args, "ws2812_loopback", False)
-            or getattr(args, "pwm_dma_cl", False)
+        if getattr(args, "ws2812_loopback", False) or getattr(
+            args, "pwm_dma_cl", False
         ):
             lpc_bench_defines.append("FASTLED_LPC_RX_SCT_DMA=1")
     if getattr(args, "uart", False) and requested_env in LPC_WS2812_ENVS:
         lpc_bench_defines.append("FASTLED_LPC_UART_DMA=1")
+        lpc_bench_defines.append("FASTLED_AUTORESEARCH_LPC_UART_DMA=1")
         lpc_bench_defines.append("FASTLED_LPC_DMA_ISR=1")
         lpc_bench_defines.append("FL_LPC_UART_DMA_CLOCKLESS_TEST=1")
         lpc_bench_defines.append("FL_LPC_UART_DMA_LOOPBACK_TEST=1")
         if args.tx_pin is not None:
-            lpc_bench_defines.append(
-                f"FL_LPC_UART_DMA_CLOCKLESS_TX_PIN={args.tx_pin}"
-            )
+            lpc_bench_defines.append(f"FL_LPC_UART_DMA_CLOCKLESS_TX_PIN={args.tx_pin}")
         if args.rx_pin is not None:
-            lpc_bench_defines.append(
-                f"FL_LPC_UART_DMA_CLOCKLESS_RX_PIN={args.rx_pin}"
-            )
+            lpc_bench_defines.append(f"FL_LPC_UART_DMA_CLOCKLESS_RX_PIN={args.rx_pin}")
     if getattr(args, "pwm_dma_cl", False):
         lpc_bench_defines.append("FASTLED_LPC_PWM_DMA=1")
 
@@ -1234,19 +1231,21 @@ async def _resolve_port_and_environment(ctx: RunContext) -> int | None:
             deferred_defines.append("FASTLED_LPC_DMA_ISR=1")
         if getattr(args, "dma_uart", False):
             deferred_defines.append("FASTLED_LPC_UART_DMA=1")
+            deferred_defines.append("FASTLED_AUTORESEARCH_LPC_UART_DMA=1")
             deferred_defines.append("FASTLED_LPC_DMA_ISR=1")
         if (ctx.final_environment or "").lower() in LPC_WS2812_ENVS:
             if getattr(args, "pin_toggle_rx", False):
                 deferred_defines.append("FASTLED_LPC_RX_SCT=1")
-            if (
-                getattr(args, "ws2812_loopback", False)
-                or getattr(args, "pwm_dma_cl", False)
+            if getattr(args, "ws2812_loopback", False) or getattr(
+                args, "pwm_dma_cl", False
             ):
                 deferred_defines.append("FASTLED_LPC_RX_SCT_DMA=1")
-        if getattr(args, "uart", False) and (
-            ctx.final_environment or ""
-        ).lower() in LPC_WS2812_ENVS:
+        if (
+            getattr(args, "uart", False)
+            and (ctx.final_environment or "").lower() in LPC_WS2812_ENVS
+        ):
             deferred_defines.append("FASTLED_LPC_UART_DMA=1")
+            deferred_defines.append("FASTLED_AUTORESEARCH_LPC_UART_DMA=1")
             deferred_defines.append("FASTLED_LPC_DMA_ISR=1")
             deferred_defines.append("FL_LPC_UART_DMA_CLOCKLESS_TEST=1")
             deferred_defines.append("FL_LPC_UART_DMA_LOOPBACK_TEST=1")
@@ -2663,9 +2662,7 @@ async def _run_lpc_uart_clockless_tests(ctx: RunContext) -> int:
     print(f"   Wiring required: jumper P0_{tx_pin} -> P0_{rx_pin} on LPC845-BRK")
     print("   API: FastLED.addLeds<WS2812, PIN, GRB>() + FastLED.show()")
     print("   Driver: ChannelEngineLpcUartDma via Bus::UART / Bus::AUTO")
-    print(
-        "   Verifier: USART TX-DMA on the data pin, USART RX-DMA on --rx-pin"
-    )
+    print("   Verifier: USART TX-DMA on the data pin, USART RX-DMA on --rx-pin")
     print("   Build flags: -DFASTLED_LPC_UART_DMA=1 -DFASTLED_LPC_DMA_ISR=1")
     print("=" * 60)
     print()

--- a/ci/autoresearch/test_lpc_uart_clockless.py
+++ b/ci/autoresearch/test_lpc_uart_clockless.py
@@ -22,6 +22,14 @@ DEFAULT_BAUD = 115200
 DEFAULT_LED_COUNT = 8
 
 
+def lpc_swm_pin_label(pin: int) -> str:
+    if 0 <= pin <= 31:
+        return f"P0_{pin}"
+    if 0x20 <= pin <= 0x35:
+        return f"P1_{pin - 0x20}"
+    return f"pin {pin}"
+
+
 def send_rpc(
     s: "RpcBench",
     method: str,
@@ -144,8 +152,9 @@ def main() -> int:
     print("LPC UART DMA clockless RX-DMA loopback - FastLED #3611")
     print(f"  Port: {args.port} @ {DEFAULT_BAUD}")
     print(
-        f"  UART loopback: bridge U1_TXD P0_{args.tx_pin} -> "
-        f"U1_RXD P0_{args.rx_pin}"
+        "  UART loopback: bridge "
+        f"U1_TXD {lpc_swm_pin_label(args.tx_pin)} -> "
+        f"U1_RXD {lpc_swm_pin_label(args.rx_pin)}"
     )
 
     try:

--- a/examples/AutoResearch/AutoResearchLowMemory.h
+++ b/examples/AutoResearch/AutoResearchLowMemory.h
@@ -38,6 +38,10 @@
 #define FASTLED_AUTORESEARCH_IEEE754_MODE 1
 #endif
 
+#if !defined(FASTLED_AUTORESEARCH_LPC_UART_DMA)
+#define FASTLED_AUTORESEARCH_LPC_UART_DMA 0
+#endif
+
 // Opt in to the SCT input-capture RX backend (FastLED #3021). With this
 // flag set, `LpcSctRxChannel::begin()` programs the SCT for hardware
 // edge-capture; without it the driver is a no-op stub (host tests still
@@ -52,7 +56,7 @@
 // RPC in normal mode. The dedicated IEEE754 mode deliberately omits it.
 #if defined(FL_IS_ARM_LPC_845) && !defined(FASTLED_AUTORESEARCH_IEEE754_MODE) && \
     !defined(FASTLED_LPC_SPI_DMA) && !defined(FASTLED_LPC_PWM_DMA) && \
-    !defined(FASTLED_LPC_UART_DMA)
+    !FASTLED_AUTORESEARCH_LPC_UART_DMA
 #define FASTLED_AUTORESEARCH_LPC_WS2812 1
 #endif
 
@@ -117,15 +121,18 @@
 #include "AutoResearchSpiDma.h"
 #endif
 
-// #3453 follow-up: LPC845 async UART TX harness (DMA + ISR chunk chain).
-// Opt-in via `-DFASTLED_LPC_UART_DMA=1` (+ `-DFASTLED_LPC_DMA_ISR=1` for
-// the ISR chaining; without it streams are capped at one descriptor).
-// Same flash-budget exclusivity as the other DMA harnesses.
-#if defined(FL_IS_ARM_LPC_845) && defined(FASTLED_LPC_UART_DMA) && \
-    (defined(FASTLED_LPC_SPI_DMA) || defined(FASTLED_LPC_PWM_DMA))
-#error "FASTLED_LPC_UART_DMA is mutually exclusive with the SPI/PWM DMA harnesses on LPC845: the LowMemory flash budget fits one bench at a time. Pick one for the AutoResearch build."
+// #3453 follow-up: LPC845 async UART TX harness (DMA + ISR chunk chain) and
+// #3611 UART clockless loopback verifier. The UART DMA driver is now the
+// LPC845 library default, so the AutoResearch RPC harness has its own flag.
+#if defined(FL_IS_ARM_LPC_845) && FASTLED_AUTORESEARCH_LPC_UART_DMA && \
+    !FASTLED_LPC_UART_DMA
+#error "FASTLED_AUTORESEARCH_LPC_UART_DMA requires FASTLED_LPC_UART_DMA=1."
 #endif
-#if defined(FL_IS_ARM_LPC_845) && defined(FASTLED_LPC_UART_DMA)
+#if defined(FL_IS_ARM_LPC_845) && FASTLED_AUTORESEARCH_LPC_UART_DMA && \
+    (defined(FASTLED_LPC_SPI_DMA) || defined(FASTLED_LPC_PWM_DMA))
+#error "FASTLED_AUTORESEARCH_LPC_UART_DMA is mutually exclusive with the SPI/PWM DMA harnesses on LPC845: the LowMemory flash budget fits one bench at a time. Pick one for the AutoResearch build."
+#endif
+#if defined(FL_IS_ARM_LPC_845) && FASTLED_AUTORESEARCH_LPC_UART_DMA
 #include "AutoResearchUartDma.h"
 #endif
 
@@ -407,10 +414,10 @@ inline void autoResearchLowMemorySetup() {
     autoresearch::dma_spi::bind(remote);
 #endif
 
-    // #3453 follow-up: async UART TX bench. Binds uartDmaStreamOnce /
-    // uartDmaStreamOverlap. Header self-gates on
-    // FL_IS_ARM_LPC_845 && FASTLED_LPC_UART_DMA.
-#if defined(FL_IS_ARM_LPC_845) && defined(FASTLED_LPC_UART_DMA)
+    // #3453/#3611: UART DMA AutoResearch harness. Binds either the raw
+    // UART DMA stream bench or the clockless loopback verifier, depending
+    // on the build flags injected by `bash autoresearch`.
+#if defined(FL_IS_ARM_LPC_845) && FASTLED_AUTORESEARCH_LPC_UART_DMA
     autoresearch::uart_dma::bind(remote);
 #endif
 

--- a/examples/AutoResearch/AutoResearchUartDma.h
+++ b/examples/AutoResearch/AutoResearchUartDma.h
@@ -29,7 +29,7 @@
 
 #include <FastLED.h>
 
-#if defined(FL_IS_ARM_LPC_845) && defined(FASTLED_LPC_UART_DMA)
+#if defined(FL_IS_ARM_LPC_845) && FASTLED_LPC_UART_DMA
 
 #if defined(FL_LPC_UART_DMA_CLOCKLESS_TEST)
 #include "fl/channels/bus.h"
@@ -51,10 +51,10 @@ namespace uart_dma {
 // header; the bench never reads the wire (wall-clock timing only), the
 // pin just has to exist for SWM. 1 Mbaud keeps a 2048-byte stream at
 // ~20 ms — inside the RPC window with margin.
-#ifndef FASTLED_LPC_UART_DMA_HARNESS_TX_PIN
+#if !defined(FASTLED_LPC_UART_DMA_HARNESS_TX_PIN)
 #define FASTLED_LPC_UART_DMA_HARNESS_TX_PIN 9
 #endif
-#ifndef FASTLED_LPC_UART_DMA_HARNESS_BAUD
+#if !defined(FASTLED_LPC_UART_DMA_HARNESS_BAUD)
 #define FASTLED_LPC_UART_DMA_HARNESS_BAUD 1000000
 #endif
 
@@ -65,7 +65,7 @@ using HarnessDriver = fl::ARMHardwareUARTOutputDMA<
 // Stream source. 2048 bytes = two full 1024-transfer descriptors →
 // at least one ISR chunk-chain per stream, which is the property under
 // test. Must outlive the stream (DMA reads it in place).
-#ifndef FASTLED_LPC_UART_DMA_HARNESS_BYTES
+#if !defined(FASTLED_LPC_UART_DMA_HARNESS_BYTES)
 #define FASTLED_LPC_UART_DMA_HARNESS_BYTES 2048
 #endif
 
@@ -178,10 +178,10 @@ inline int argInt(const fl::json& args, fl::size i, int fallback) FL_NO_EXCEPT {
 
 #if defined(FL_LPC_UART_DMA_CLOCKLESS_TEST)
 
-#ifndef FL_LPC_UART_DMA_CLOCKLESS_TX_PIN
+#if !defined(FL_LPC_UART_DMA_CLOCKLESS_TX_PIN)
 #define FL_LPC_UART_DMA_CLOCKLESS_TX_PIN 10
 #endif
-#ifndef FL_LPC_UART_DMA_CLOCKLESS_LEDS
+#if !defined(FL_LPC_UART_DMA_CLOCKLESS_LEDS)
 #define FL_LPC_UART_DMA_CLOCKLESS_LEDS 8
 #endif
 
@@ -324,10 +324,12 @@ inline fl::string clocklessLoopbackSelfHandler(
         int capture_ms) FL_NO_EXCEPT {
     if (led_count != FL_LPC_UART_DMA_CLOCKLESS_LEDS ||
         data_pin != FL_LPC_UART_DMA_CLOCKLESS_TX_PIN ||
-        rx_pin < 0 || rx_pin > 31 || capture_ms <= 0 || capture_ms > 200) {
+        rx_pin < 0 || rx_pin > 0x35 ||
+        !fl::lpc::LpcUartDmaRuntime::isMovableUartPin(
+            static_cast<fl::u8>(rx_pin)) ||
+        capture_ms <= 0 || capture_ms > 200) {
         return fl::string("0,args");
     }
-    (void)rx_pin;
 
     ensureClocklessFastLedRegistered();
     FastLED.setBrightness(255);
@@ -356,7 +358,8 @@ inline fl::string clocklessLoopbackSelfHandler(
         received[i] = 0xA5u;
     }
     fl::lpc::LpcUartDmaRuntime::prepareLoopbackRxBuffer(
-        received, static_cast<fl::u32>(expected_count));
+        received, static_cast<fl::u32>(expected_count),
+        static_cast<fl::u8>(rx_pin));
 
     FastLED.show();
 
@@ -437,7 +440,9 @@ inline fl::string clocklessLoopbackSelfHandler(
 inline fl::string clocklessProbeHandler(
         int step, int data_pin, int rx_pin) FL_NO_EXCEPT {
     if (data_pin != FL_LPC_UART_DMA_CLOCKLESS_TX_PIN ||
-        rx_pin < 0 || rx_pin > 31) {
+        rx_pin < 0 || rx_pin > 0x35 ||
+        !fl::lpc::LpcUartDmaRuntime::isMovableUartPin(
+            static_cast<fl::u8>(rx_pin))) {
         return fl::string("0,args");
     }
     if (step <= 0) {

--- a/src/fl/channels/bus.h
+++ b/src/fl/channels/bus.h
@@ -81,13 +81,12 @@ template<> struct DefaultBus<SpiChipsetConfig> {
 
 #elif defined(FL_IS_ARM_LPC)
 
-// LPC8xx / LPC11Uxx / LPC15xx have no parallel-IO clockless peripheral.
-// Clockless output goes through the shared M0 cycle-counted C++ driver
+// LPC845 defaults clockless AUTO to the USART DMA engine. Other LPC8xx /
+// LPC11Uxx / LPC15xx targets keep the shared cycle-counted C++ driver
 // (FASTLED_M0_USE_C_IMPLEMENTATION in led_sysdefs_arm_lpc.h), which is
-// what Bus::BIT_BANG names — the same engine that LPC's
-// ClocklessController template uses today.
+// what Bus::BIT_BANG names.
 template<> struct DefaultBus<ClocklessChipset> {
-#if defined(FL_IS_ARM_LPC_845) && defined(FASTLED_LPC_UART_DMA)
+#if defined(FL_IS_ARM_LPC_845) && FASTLED_LPC_UART_DMA
     static constexpr Bus value = Bus::UART;
 #else
     static constexpr Bus value = Bus::BIT_BANG;

--- a/src/fl/channels/bus_info.h
+++ b/src/fl/channels/bus_info.h
@@ -148,7 +148,7 @@ template<> struct DeviceInfoResolver<Bus::UART, 0> {
 
 template<> struct DeviceInfoResolver<Bus::UART, 0> {
     static inline DeviceInfo get() FL_NO_EXCEPT {
-#if defined(FASTLED_LPC_UART_DMA)
+#if FASTLED_LPC_UART_DMA
         return makeInfo(Bus::UART, 0, "LPC_USART_DMA", "USART TX DMA");
 #else
         return makeNoop(Bus::UART, 0, "UART DMA disabled");

--- a/src/platforms/arm/lpc/README.md
+++ b/src/platforms/arm/lpc/README.md
@@ -24,6 +24,10 @@ The LPC family currently covers two ARM cores:
 | **LPC11xx legacy** | LPC1110, LPC1112, LPC1114, LPC1115 | Cortex-M0 | — | Dedicated `fastpin_arm_lpc11_legacy.h` ([#2878](https://github.com/FastLED/FastLED/pull/2878)) + shared M0 C++ clockless | ✅ Compiles; hardware bring-up pending |
 | **LPC15xx** | LPC1517…LPC1549 | Cortex-M3 | 12 MHz (IRC) | Shared LPC8xx fastpin + M3-compatible C++ clockless (#2872) | ✅ Compiles; hardware bring-up pending |
 
+Note: LPC845 clockless `Bus::AUTO` now resolves to the USART DMA engine
+by default (`FASTLED_LPC_UART_DMA=1`). Define `FASTLED_LPC_UART_DMA=0`
+to force the older bit-bang default.
+
 ## Hardware verification via AutoResearch loopback ([#2880](https://github.com/FastLED/FastLED/issues/2880))
 
 **No maintainer sign-off required.** Verification is fully automated: wire a TX↔RX jumper on the LPC845-BRK and run AutoResearch. The Python orchestrator asserts pass/fail from the JSON-RPC results that come back over the same serial link.
@@ -154,8 +158,8 @@ worked anti-example.
 - `drivers/sct_dma/channel_engine_lpc_sct_dma.{h,cpp.hpp}` — Channels-API `IChannelDriver` for the LPC845 SCT + 3-DMA-channel clockless engine ([#3460](https://github.com/FastLED/FastLED/pull/3460)). Wraps the same SCT/DMA machinery as `clockless_arm_lpc_pwm_dma.h` but plugs into the portable `ChannelManager` dispatch, with async `pollAndAdvance()` chunk progression (no busy-wait in `show()`). Host-side TX→RX byte-match test through `engine.show()` verified in [#3472](https://github.com/FastLED/FastLED/pull/3472).
 - `drivers/sct_dma/lpc_sct_dma_runtime.{h,cpp.hpp}` — Runtime SCT+DMA helper (chunked encode → 3 DMA channels → GPIO SET/CLR), shared by the channels-API engine.
 - `drivers/sct_dma/bus_traits.h` — `BusTraits<Bus::BIT_BANG>` specialization routing LPC845 bit-bang bus to the SCT/DMA channels engine when `FASTLED_LPC_PWM_DMA` is set; kept behind `!FL_IS_ARM_LPC_845` in the shared bit-bang traits to avoid duplicate specialization.
-- `drivers/uart_dma/*` — `BusTraits<Bus::UART>` specialization and `ChannelEngineLpcUartDma`, routing LPC845 clockless AUTO/UART output through USART TX + DMA when `FASTLED_LPC_UART_DMA` is set.
-- `clockless_channel_lpc_uart_dma.h` — Legacy `addLeds<WS2812, PIN, GRB>()` adapter that selects the UART DMA channel engine by default under `FASTLED_LPC_UART_DMA`.
+- `drivers/uart_dma/*` — `BusTraits<Bus::UART>` specialization and `ChannelEngineLpcUartDma`, routing LPC845 clockless AUTO/UART output through USART TX + DMA by default (`FASTLED_LPC_UART_DMA=1`).
+- `clockless_channel_lpc_uart_dma.h` — Legacy `addLeds<WS2812, PIN, GRB>()` adapter that selects the UART DMA channel engine by default on LPC845.
 - `rx_sct_capture.{h,cpp.hpp}` — LPC845 SCT input-capture RX device used by the AutoResearch loopback harness; drives byte-match assertions for the bit-bang, PWM+DMA, and channels-API TX paths.
 - `led_sysdefs_arm_lpc.h` — System defines (sets `FL_IS_ARM_M0_PLUS`, `F_CPU`, forces `FASTLED_M0_USE_C_IMPLEMENTATION`, includes `<LPC845.h>` / `<LPC804.h>` CMSIS device headers).
 - `fastpin_arm_lpc.h` — see above.
@@ -173,7 +177,7 @@ Build-time opt-ins (default off). Define before including `FastLED.h` or via bui
 - **`FASTLED_LPC_SPI_DMA`** — LPC845 only. Activates the DMA-async SPI driver (`spi_arm_lpc_dma.h`) in place of the polled `spi_arm_lpc.h` for APA102 / SK9822 / WS2801. Fires a compile-time `#error` if set on an LPC804 build (silicon has no DMA peripheral).
 - **`FASTLED_LPC_SPI_DMA_CHANNEL`** — LPC845 + `FASTLED_LPC_SPI_DMA`. DMA0 channel index feeding SPI TX. Default `4` (SPI0_TX); override to `6` for SPI1_TX.
 - **`FASTLED_LPC_SPI_DMA_MAX_BYTES`** — LPC845 + `FASTLED_LPC_SPI_DMA`. Static DMA descriptor pool size (default `2048`).
-- **`FASTLED_LPC_UART_DMA`** — LPC845 only. Activates the UART DMA clockless engine and makes clockless AUTO/default bus selection resolve to `Bus::UART`. AutoResearch `--uart` verifies this path with a TX→RX jumper and USART RX-DMA byte compare.
+- **`FASTLED_LPC_UART_DMA`** — LPC845 only. Defaults to `1`. Keeps the UART DMA clockless engine active and makes clockless AUTO/default bus selection resolve to `Bus::UART`; define `FASTLED_LPC_UART_DMA=0` to force the older bit-bang default. AutoResearch `--uart` verifies this path with a TX→RX jumper and USART RX-DMA byte compare. The LPC845 switch matrix can route U1/U2 TXD/RXD to PIO0_0..PIO0_31 or PIO1_0..PIO1_21; DMA request channels remain fixed by USART instance (U1 RX/TX = DMA 2/3, U2 RX/TX = DMA 4/5).
 - **`FASTLED_M0_USE_C_IMPLEMENTATION`** — Already set unconditionally by `led_sysdefs_arm_lpc.h`. The LPC8xx GPIO controller exposes SET[port] and CLR[port] at byte offsets `0x2200 / 0x2280` from the controller base, beyond the 5-bit imm5*4 encoding the M0/M0+ STR-immediate-offset instruction supports. The shared inline-assembly clockless driver assumes both offsets fit a single str-with-immediate; LPC routes through the portable C++ implementation, which performs an indexed store instead.
 - **`FASTLED_ALLOW_INTERRUPTS`** — Default `1`.
 - **`FASTLED_USE_PROGMEM`** — Default `0`.

--- a/src/platforms/arm/lpc/channel_drivers_lpc.impl.hpp
+++ b/src/platforms/arm/lpc/channel_drivers_lpc.impl.hpp
@@ -14,7 +14,7 @@
 #include "platforms/arm/lpc/is_lpc.h"
 
 #if defined(FL_IS_ARM_LPC_845)
-#if defined(FASTLED_LPC_UART_DMA)
+#if FASTLED_LPC_UART_DMA
 #include "platforms/arm/lpc/drivers/uart_dma/bus_traits.h"
 #endif
 #if defined(FASTLED_LPC_PWM_DMA)
@@ -29,7 +29,7 @@ namespace platforms {
 
 inline void enableAllChannelDrivers() FL_NO_EXCEPT {
 #if defined(FL_IS_ARM_LPC_845)
-#if defined(FASTLED_LPC_UART_DMA)
+#if FASTLED_LPC_UART_DMA
     BusTraits<Bus::UART, 0>::registerWithManager();
 #endif
     // Register the LPC clockless fallback bus as SCT+DMA when

--- a/src/platforms/arm/lpc/clockless_channel_lpc_uart_dma.h
+++ b/src/platforms/arm/lpc/clockless_channel_lpc_uart_dma.h
@@ -8,7 +8,7 @@
 #include "platforms/arm/is_arm.h"
 #include "platforms/arm/lpc/is_lpc.h"
 
-#if defined(FL_IS_ARM_LPC_845) && defined(FASTLED_LPC_UART_DMA)
+#if defined(FL_IS_ARM_LPC_845) && FASTLED_LPC_UART_DMA
 
 #define FL_CLOCKLESS_CONTROLLER_DEFINED 1
 #define FL_CLOCKLESS_LPC_UART_CHANNEL_ENGINE_DEFINED 1

--- a/src/platforms/arm/lpc/drivers/uart_dma/_build.cpp.hpp
+++ b/src/platforms/arm/lpc/drivers/uart_dma/_build.cpp.hpp
@@ -13,6 +13,7 @@ fl::u32 g_fastled_lpc_uart_loopback_rx_arm_status = 0;
 fl::u32 g_fastled_lpc_uart_loopback_rx_arm_tx_len = 0;
 fl::u32 g_fastled_lpc_uart_loopback_rx_arm_xfer_readback = 0;
 fl::u32 g_fastled_lpc_uart_loopback_rx_arm_desc0_readback = 0;
+fl::u8 g_fastled_lpc_uart_loopback_rx_pin = 0xFFu;
 }
 #endif
 

--- a/src/platforms/arm/lpc/drivers/uart_dma/bus_traits.h
+++ b/src/platforms/arm/lpc/drivers/uart_dma/bus_traits.h
@@ -8,7 +8,7 @@
 #include "platforms/arm/is_arm.h"
 #include "platforms/arm/lpc/is_lpc.h"
 
-#if defined(FL_IS_ARM_LPC_845) && defined(FASTLED_LPC_UART_DMA)
+#if defined(FL_IS_ARM_LPC_845) && FASTLED_LPC_UART_DMA
 
 #include "fl/channels/bus.h"
 #include "fl/channels/bus_traits.h"

--- a/src/platforms/arm/lpc/drivers/uart_dma/channel_engine_lpc_uart_dma.cpp.hpp
+++ b/src/platforms/arm/lpc/drivers/uart_dma/channel_engine_lpc_uart_dma.cpp.hpp
@@ -3,7 +3,7 @@
 #include "platforms/arm/is_arm.h"
 #include "platforms/arm/lpc/is_lpc.h"
 
-#if defined(FL_IS_ARM_LPC_845) && defined(FASTLED_LPC_UART_DMA)
+#if defined(FL_IS_ARM_LPC_845) && FASTLED_LPC_UART_DMA
 
 #include "platforms/arm/lpc/drivers/uart_dma/channel_engine_lpc_uart_dma.h"
 #include "fl/chipsets/chipset_timing_config.h"
@@ -132,7 +132,8 @@ bool ChannelEngineLpcUartDma::canHandle(
         return false;
     }
     const int pin = data->getPin();
-    if (pin < 0 || pin > 31) {
+    if (pin < 0 || pin > 0x35 ||
+        !lpc::LpcUartDmaRuntime::isMovableUartPin(static_cast<u8>(pin))) {
         return false;
     }
     return lpcUartCanRepresentTiming(data->getTiming());

--- a/src/platforms/arm/lpc/drivers/uart_dma/channel_engine_lpc_uart_dma.h
+++ b/src/platforms/arm/lpc/drivers/uart_dma/channel_engine_lpc_uart_dma.h
@@ -8,7 +8,7 @@
 #include "platforms/arm/is_arm.h"
 #include "platforms/arm/lpc/is_lpc.h"
 
-#if defined(FL_IS_ARM_LPC_845) && defined(FASTLED_LPC_UART_DMA)
+#if defined(FL_IS_ARM_LPC_845) && FASTLED_LPC_UART_DMA
 
 #include "fl/channels/data.h"
 #include "fl/channels/driver.h"

--- a/src/platforms/arm/lpc/fastled_arm_lpc.h
+++ b/src/platforms/arm/lpc/fastled_arm_lpc.h
@@ -34,10 +34,10 @@
 //                            0x50000000 GPIO controller with 12-bit
 //                            masked-access semantics per UM10398 sec. 9.
 
-// LPC845 can opt into UART+DMA clockless output with FASTLED_LPC_UART_DMA=1.
-// That adapter supplies fl::ClocklessController first so AUTO/default
-// clockless output uses the UART DMA engine.
-#if defined(FL_IS_ARM_LPC_845) && defined(FASTLED_LPC_UART_DMA)
+// LPC845 defaults clockless AUTO output to UART+DMA
+// (FASTLED_LPC_UART_DMA=1 from is_lpc.h). The adapter supplies
+// fl::ClocklessController first so default addLeds<> uses the UART DMA engine.
+#if defined(FL_IS_ARM_LPC_845) && FASTLED_LPC_UART_DMA
 #include "platforms/arm/lpc/clockless_channel_lpc_uart_dma.h"
 #endif
 

--- a/src/platforms/arm/lpc/is_lpc.h
+++ b/src/platforms/arm/lpc/is_lpc.h
@@ -111,3 +111,21 @@
     defined(FL_IS_ARM_LPC_11) || defined(FL_IS_ARM_LPC_15)
 #define FL_IS_ARM_LPC
 #endif
+
+// LPC845 clockless AUTO defaults to the USART+DMA channel engine. Define
+// FASTLED_LPC_UART_DMA=0 before including FastLED to force the older bit-bang
+// default. Non-LPC845 builds normalize the feature macro to 0 so downstream
+// gates can use `#if FASTLED_LPC_UART_DMA`.
+#if !defined(FASTLED_LPC_UART_DMA)
+#if defined(FL_IS_ARM_LPC_845)
+#define FASTLED_LPC_UART_DMA 1
+#else
+#define FASTLED_LPC_UART_DMA 0
+#endif
+#endif
+
+// The DMA ISR hub is defaulted on with LPC845 UART DMA so frames longer than
+// one 1024-byte DMA descriptor keep streaming. Users can still override it.
+#if FASTLED_LPC_UART_DMA && !defined(FASTLED_LPC_DMA_ISR)
+#define FASTLED_LPC_DMA_ISR 1
+#endif

--- a/src/platforms/arm/lpc/uart_arm_lpc_dma.h
+++ b/src/platforms/arm/lpc/uart_arm_lpc_dma.h
@@ -38,9 +38,10 @@
 
 #include "fl/stl/int.h"
 #include "fl/stl/noexcept.h"
+#include "fl/stl/static_assert.h"
 #include "platforms/arm/is_arm.h"
 
-#if defined(FL_IS_ARM_LPC_845) && defined(FASTLED_LPC_UART_DMA)
+#if defined(FL_IS_ARM_LPC_845) && FASTLED_LPC_UART_DMA
 
 // IWYU pragma: begin_keep
 #include <LPC845.h>
@@ -57,6 +58,7 @@ extern fl::u32 g_fastled_lpc_uart_loopback_rx_arm_status;
 extern fl::u32 g_fastled_lpc_uart_loopback_rx_arm_tx_len;
 extern fl::u32 g_fastled_lpc_uart_loopback_rx_arm_xfer_readback;
 extern fl::u32 g_fastled_lpc_uart_loopback_rx_arm_desc0_readback;
+extern fl::u8 g_fastled_lpc_uart_loopback_rx_pin;
 }
 #endif
 
@@ -66,12 +68,13 @@ namespace fl {
 // reserved for the console, USART3/4 share their IRQ slots with pin
 // interrupts and their FCLKSEL/clock plumbing differs (no FRG output on
 // some muxes); add them when a board actually needs four lanes.
-#ifndef FASTLED_LPC_UART_DMA_INSTANCE
+#if !defined(FASTLED_LPC_UART_DMA_INSTANCE)
 #define FASTLED_LPC_UART_DMA_INSTANCE 1
 #endif
 
 /// @brief LPC845 USARTn TX + DMA0 async output.
-/// @tparam _TX_PIN  PIO0_n index the SWM routes Un_TXD onto.
+/// @tparam _TX_PIN  SWM pin code the driver routes Un_TXD onto:
+///                  PIO0_n => n, PIO1_n => 0x20 + n.
 /// @tparam _BAUD    Wire baud rate (main_clk 24 MHz / 16x OSR ⇒ max
 ///                  practical ~1.5 Mbaud at integer BRG; 3 Mbaud needs
 ///                  OSR=8 — the driver picks OSR/BRG for minimal error).
@@ -98,6 +101,13 @@ class LpcUartDmaRuntime {
     static constexpr u32 kUsartCfgRxPol = (1UL << 22);
     static constexpr u32 kUsartCfgTxPol = (1UL << 23);
     static constexpr u32 kSwmPinMask = 0xFFu;
+    static constexpr u8 kSwmPinUnassigned = 0xFFu;
+    // UM11029 Tables 181/182: U1/U2 TXD/RXD movable-function assignments
+    // accept PIO0_0..PIO0_31 and PIO1_0..PIO1_21.
+    static constexpr u8 kLastMovableUartPin = 0x35u;
+    static constexpr bool swmPinAllowed(u8 pin) FL_NO_EXCEPT {
+        return pin <= kLastMovableUartPin;
+    }
     static constexpr u32 swmMask(u32 shift) FL_NO_EXCEPT {
         return kSwmPinMask << shift;
     }
@@ -105,6 +115,11 @@ class LpcUartDmaRuntime {
         return (static_cast<u32>(pin) & kSwmPinMask) << shift;
     }
 #if defined(FL_LPC_UART_DMA_LOOPBACK_TEST)
+#if !defined(FL_LPC_UART_DMA_CLOCKLESS_RX_PIN)
+#define FL_LPC_UART_DMA_CLOCKLESS_RX_PIN 0xFF
+#endif
+    static constexpr u8 kDefaultLoopbackRxPin =
+        static_cast<u8>(FL_LPC_UART_DMA_CLOCKLESS_RX_PIN);
     static constexpr u32 kDmaBase = 0x50008000u;
     static volatile u32& dmaReg(u32 offset) FL_NO_EXCEPT {
         return *reinterpret_cast<volatile u32*>(kDmaBase + offset);  // ok reinterpret cast - DMA0 MMIO
@@ -121,10 +136,18 @@ public:
         volatile bool running = false;
     };
 
+    static constexpr bool isMovableUartPin(u8 pin) FL_NO_EXCEPT {
+        return swmPinAllowed(pin);
+    }
+
 #if defined(FL_LPC_UART_DMA_LOOPBACK_TEST)
-    static void prepareLoopbackRxBuffer(u8* dst, u32 len) FL_NO_EXCEPT {
+    static void prepareLoopbackRxBuffer(
+            u8* dst, u32 len,
+            u8 rxPin = kDefaultLoopbackRxPin) FL_NO_EXCEPT {
         g_fastled_lpc_uart_loopback_rx_dst = dst;
         g_fastled_lpc_uart_loopback_rx_len = len;
+        g_fastled_lpc_uart_loopback_rx_pin =
+            swmPinAllowed(rxPin) ? rxPin : kSwmPinUnassigned;
         g_fastled_lpc_uart_loopback_rx_arm_status = 0;
         g_fastled_lpc_uart_loopback_rx_arm_tx_len = 0;
         g_fastled_lpc_uart_loopback_rx_arm_xfer_readback = 0;
@@ -136,6 +159,8 @@ public:
         if (g_fastled_lpc_uart_loopback_rx_dst == nullptr || len == 0u) {
             return 0;
         }
+        // The RX GPIO can move through SWM, but UM11029 Table 296 fixes the
+        // DMA request to the selected USART instance: U1_RX=2, U2_RX=4.
         const u32 mask = (1UL << kLoopbackRxDmaChannel);
         if ((dmaReg(0x058u) & mask) != 0u) {  // INTA0: SETINTA completion.
             return len;
@@ -158,6 +183,7 @@ public:
         dmaReg(0x058u) = mask;  // INTA0 W1C
         g_fastled_lpc_uart_loopback_rx_dst = nullptr;
         g_fastled_lpc_uart_loopback_rx_len = 0;
+        g_fastled_lpc_uart_loopback_rx_pin = kSwmPinUnassigned;
     }
 #endif
 
@@ -167,37 +193,13 @@ public:
                                   SYSCON_SYSAHBCLKCTRL0_SWM_MASK;
         SYSCON->PRESETCTRL0 |= SYSCON_PRESETCTRL0_UART2_RST_N_MASK;
         SYSCON->FCLKSEL[2] = SYSCON_FCLKSEL_SEL(0x1u);
-#if defined(FL_LPC_UART_DMA_CLOCKLESS_RX_PIN)
-        // UM11029 Table 182: PINASSIGN2[23:16]=U2_TXD_O,
-        // PINASSIGN2[31:24]=U2_RXD_I.
-        SWM0->PINASSIGN.PINASSIGN2 =
-            (SWM0->PINASSIGN.PINASSIGN2 &
-             ~(swmMask(16u) | swmMask(24u))) |
-            swmValue(txPin, 16u) |
-            swmValue(static_cast<u8>(FL_LPC_UART_DMA_CLOCKLESS_RX_PIN), 24u);
-#else
-        SWM0->PINASSIGN.PINASSIGN2 =
-            (SWM0->PINASSIGN.PINASSIGN2 & ~SWM_PINASSIGN2_U2_TXD_O_MASK) |
-            SWM_PINASSIGN2_U2_TXD_O(txPin);
-#endif
+        routeUart2Pins(txPin);
 #else
         SYSCON->SYSAHBCLKCTRL0 |= SYSCON_SYSAHBCLKCTRL0_UART1_MASK |
                                   SYSCON_SYSAHBCLKCTRL0_SWM_MASK;
         SYSCON->PRESETCTRL0 |= SYSCON_PRESETCTRL0_UART1_RST_N_MASK;
         SYSCON->FCLKSEL[1] = SYSCON_FCLKSEL_SEL(0x1u);
-#if defined(FL_LPC_UART_DMA_CLOCKLESS_RX_PIN)
-        // UM11029 Table 181: PINASSIGN1[15:8]=U1_TXD_O,
-        // PINASSIGN1[23:16]=U1_RXD_I.
-        SWM0->PINASSIGN.PINASSIGN1 =
-            (SWM0->PINASSIGN.PINASSIGN1 &
-             ~(swmMask(8u) | swmMask(16u))) |
-            swmValue(txPin, 8u) |
-            swmValue(static_cast<u8>(FL_LPC_UART_DMA_CLOCKLESS_RX_PIN), 16u);
-#else
-        SWM0->PINASSIGN.PINASSIGN1 =
-            (SWM0->PINASSIGN.PINASSIGN1 & ~SWM_PINASSIGN1_U1_TXD_O_MASK) |
-            SWM_PINASSIGN1_U1_TXD_O(txPin);
-#endif
+        routeUart1Pins(txPin);
 #endif
 
         USART_Type* u = uartBlock();
@@ -230,9 +232,9 @@ public:
 #if defined(FL_LPC_UART_DMA_LOOPBACK_TEST)
         // AutoResearch-only: when an RX pin is provided, verify through the
         // board-level jumper. Otherwise fall back to UM11029 Table 324 LOOP.
-#if !defined(FL_LPC_UART_DMA_CLOCKLESS_RX_PIN)
-        cfg |= kUsartCfgLoop;
-#endif
+        if (!hasLoopbackRxPin()) {
+            cfg |= kUsartCfgLoop;
+        }
         // The clockless UART path intentionally inverts TX, so the verifier
         // inverts RX too whether the signal arrives by pin or internal LOOP.
         if (invertTx) {
@@ -333,6 +335,46 @@ public:
     }
 
 private:
+    static bool hasLoopbackRxPin() FL_NO_EXCEPT {
+#if defined(FL_LPC_UART_DMA_LOOPBACK_TEST)
+        return swmPinAllowed(g_fastled_lpc_uart_loopback_rx_pin);
+#else
+        return false;
+#endif
+    }
+
+    static u8 loopbackRxPin() FL_NO_EXCEPT {
+#if defined(FL_LPC_UART_DMA_LOOPBACK_TEST)
+        return g_fastled_lpc_uart_loopback_rx_pin;
+#else
+        return kSwmPinUnassigned;
+#endif
+    }
+
+    static void routeUart1Pins(u8 txPin) FL_NO_EXCEPT {
+        u32 assign = (SWM0->PINASSIGN.PINASSIGN1 & ~swmMask(8u)) |
+                     swmValue(txPin, 8u);
+        if (hasLoopbackRxPin()) {
+            // UM11029 Table 181: PINASSIGN1[15:8]=U1_TXD_O and
+            // PINASSIGN1[23:16]=U1_RXD_I. Both accept any movable UART pin.
+            assign = (assign & ~swmMask(16u)) |
+                     swmValue(loopbackRxPin(), 16u);
+        }
+        SWM0->PINASSIGN.PINASSIGN1 = assign;
+    }
+
+    static void routeUart2Pins(u8 txPin) FL_NO_EXCEPT {
+        u32 assign = (SWM0->PINASSIGN.PINASSIGN2 & ~swmMask(16u)) |
+                     swmValue(txPin, 16u);
+        if (hasLoopbackRxPin()) {
+            // UM11029 Table 182: PINASSIGN2[23:16]=U2_TXD_O and
+            // PINASSIGN2[31:24]=U2_RXD_I. Both accept any movable UART pin.
+            assign = (assign & ~swmMask(24u)) |
+                     swmValue(loopbackRxPin(), 24u);
+        }
+        SWM0->PINASSIGN.PINASSIGN2 = assign;
+    }
+
 #if defined(FL_LPC_UART_DMA_LOOPBACK_TEST)
     static void armLoopbackRxIfRequested(u32 txLen) FL_NO_EXCEPT {
         u8* const dst = g_fastled_lpc_uart_loopback_rx_dst;
@@ -362,6 +404,8 @@ private:
         }
         u->STAT = (1u << 8) | (1u << 13) | (1u << 14);
 
+        // The RX GPIO can move through SWM, but UM11029 Table 296 fixes the
+        // DMA request to the selected USART instance: U1_RX=2, U2_RX=4.
         const u32 mask = (1UL << kLoopbackRxDmaChannel);
         dmaReg(0x028u) = mask;  // ENABLECLR0
         while ((dmaReg(0x038u) & mask) != 0u) {
@@ -408,6 +452,10 @@ private:
 
 template <u8 _TX_PIN, u32 _BAUD>
 class ARMHardwareUARTOutputDMA {
+    FL_STATIC_ASSERT(lpc::LpcUartDmaRuntime::isMovableUartPin(_TX_PIN),
+                     "LPC845 UART DMA TX pin must be a movable USART pin "
+                     "(PIO0_0..PIO0_31 or PIO1_0..PIO1_21)");
+
     static inline USART_Type* uart_block() __attribute__((always_inline)) {
 #if FASTLED_LPC_UART_DMA_INSTANCE == 2
         return USART2;


### PR DESCRIPTION
## Summary
- default LPC845 clockless AUTO to the USART DMA channel engine with `FASTLED_LPC_UART_DMA` normalized to `1`/`0`
- enable the LPC DMA ISR hub by default when UART DMA is active so descriptor chaining works without extra user defines
- allow the UART loopback RX pin to be any LPC845 movable USART pin while keeping DMA channel selection tied to the USART instance
- keep AutoResearch's UART RPC harness opt-in via `FASTLED_AUTORESEARCH_LPC_UART_DMA` so the library default does not bloat normal LowMemory builds

## References
- Follow-up to https://github.com/FastLED/FastLED/issues/3611
- Previous PRs: https://github.com/FastLED/FastLED/pull/3612, https://github.com/FastLED/FastLED/pull/3613
- Datasheets source: https://github.com/FastLED/datasheets/tree/main/nxp/mcu/LPC845
- UM11029 Tables 181/182: U1/U2 TXD/RXD SWM assignments accept PIO0_0..PIO0_31 and PIO1_0..PIO1_21
- UM11029 Table 296: DMA requests remain fixed by USART instance (U1 RX/TX = DMA 2/3, U2 RX/TX = DMA 4/5)

## Local verification
- `bash lint --cpp`
- `bash test --cpp` (350/350 passed earlier on this branch)
- `bash lint` (passed earlier on this branch)
- `bash compile lpc845 --examples Blink`
- linker map contains `ChannelEngineLpcUartDma` and `LpcUartDmaRuntime::{init,armNextChunk,onDmaChunkDone}` in the plain Blink build
- `bash autoresearch lpc845 --uart --upload-port COM10 --no-auto-discover-pins --tx-pin 13 --rx-pin 11 --timeout 120s --skip-lint`
  - PASS: probe step 0 `1,entry`
  - PASS: probe step 7 `1,uart_rx_dma,0`
  - PASS: 3 loopback payloads matched expected bytes (`0xFF0000`, `0x00FF00`, `0x55AA33`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * LPC845 now uses UART DMA as the default clockless bus path, with a clear fallback to bit-banged behavior when disabled.
  * UART DMA loopback testing now supports more flexible pin selection and improved pin labeling in logs.

* **Bug Fixes**
  * Fixed cases where LPC845 UART DMA setup could fail when optional settings were unset.
  * Improved validation so only supported UART pins are accepted for DMA/loopback use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->