### PR TITLE
test(lpc): add fault emit autoresearch mode

### DIFF
--- a/agents/docs/hardware-autoresearch.md
+++ b/agents/docs/hardware-autoresearch.md
@@ -71,6 +71,27 @@ bash autoresearch esp32s3 --rmt --timeout 120
 bash autoresearch --all --skip-lint --timeout 180
 ```
 
+### LPC845 Fault-Emit Validation
+
+Use this mode when validating the LPC845 crash diagnostics tracked by
+[FastLED #3302](https://github.com/FastLED/FastLED/issues/3302). It builds the
+low-memory AutoResearch sketch with `FASTLED_AUTORESEARCH_FAULT_TEST=1`, flashes
+the attached LPC845, deliberately triggers OOM and stack-blow RPCs, and asserts
+that the device emits a `FAULT:` diagnostic before reset.
+
+```bash
+fbuild port scan
+bash autoresearch lpc845 --fault-emit-test --upload-port COM10 --timeout 120s --skip-lint
+```
+
+The test intentionally crashes the target twice. A pass means both triggers
+emitted `FAULT:` diagnostics and the harness re-flashed between triggers. If it
+fails with no `FAULT:` line, treat the LPC safety nets as regressed: consult
+[FastLED #3300](https://github.com/FastLED/FastLED/issues/3300),
+[FastLED #3302](https://github.com/FastLED/FastLED/issues/3302), and
+[ArduinoCore-LPC8xx #30](https://github.com/zackees/ArduinoCore-LPC8xx/pull/30)
+before debugging unrelated AutoResearch transport layers.
+
 ### Common Options
 - `--skip-lint` - Skip linting for faster iteration
 - `--timeout <seconds>` - Custom timeout (default: 120s)

--- a/autoresearch
+++ b/autoresearch
@@ -40,6 +40,8 @@ Driver Selection (optional - omit for GPIO-only mode):
   --pwm-dma-cl        LPC845-only: channels-API SCT+DMA clockless
                       self-loopback (FastLED #3468). Jumper P0_10↔P0_11.
   --dma-uart          LPC845-only: raw async UART TX DMA bench
+  --fault-emit-test   LPC845-only: trigger intentional OOM/stack faults and
+                      assert FAULT diagnostics (FastLED #3302)
   --all               Test all drivers
   --simd              Test SIMD operations only (no LED drivers needed)
   --coroutine         Test coroutine/task creation, stop, await (no LED drivers needed)

--- a/ci/autoresearch/args.py
+++ b/ci/autoresearch/args.py
@@ -117,6 +117,9 @@ class Args:
     # exclusive with the other LPC DMA harnesses at the flash budget.
     dma_uart: bool
 
+    # LPC845 fault emit validation (#3302).
+    fault_emit_test: bool
+
     # Multi-frame capture — number of back-to-back show()/capture cycles per pattern.
     # None = driver-default (SPI → 2, others → 1). Explicit value overrides.
     # See issues #2254 and #2288 (ESP32-S3 SPI second-frame degradation).
@@ -428,6 +431,13 @@ See Also:
             "while USART0 keeps serving the RPC console. Reports "
             "stream timing + beacon-toggle async proof. Mutually "
             "exclusive with --dma-spi / --pwm-dma-cl (flash budget).",
+        )
+        lpc_group.add_argument(
+            "--fault-emit-test",
+            action="store_true",
+            help="LPC845-only fault-emission validation (#3302). Builds "
+            "the gated low-memory fault RPCs, triggers intentional OOM "
+            "and stack-blow faults, and asserts a FAULT diagnostic appears.",
         )
         lpc_description = lpc_group.description or ""
         lpc_group.description = (
@@ -783,6 +793,7 @@ See Also:
             pwm_dma_cl=parsed.pwm_dma_cl,
             dma_spi=parsed.dma_spi,
             dma_uart=parsed.dma_uart,
+            fault_emit_test=parsed.fault_emit_test,
             frames=parsed.frames,
             tight_timing=parsed.tight_timing,
             tight_timing_iterations=parsed.tight_timing_iterations,

--- a/ci/autoresearch/phases.py
+++ b/ci/autoresearch/phases.py
@@ -945,6 +945,8 @@ def _parse_args_and_build_commands(args: Args) -> RunContext | int:
             lpc_bench_defines.append(f"FL_LPC_UART_DMA_CLOCKLESS_RX_PIN={args.rx_pin}")
     if getattr(args, "pwm_dma_cl", False):
         lpc_bench_defines.append("FASTLED_LPC_PWM_DMA=1")
+    if getattr(args, "fault_emit_test", False):
+        lpc_bench_defines.append("FASTLED_AUTORESEARCH_FAULT_TEST=1")
 
     # Resolve project root (always the user's invocation cwd) and build_dir.
     #
@@ -1259,6 +1261,8 @@ async def _resolve_port_and_environment(ctx: RunContext) -> int | None:
                 )
         if getattr(args, "pwm_dma_cl", False):
             deferred_defines.append("FASTLED_LPC_PWM_DMA=1")
+        if getattr(args, "fault_emit_test", False):
+            deferred_defines.append("FASTLED_AUTORESEARCH_FAULT_TEST=1")
 
         try:
             ctx.build_dir = synthesise_autoresearch_project(
@@ -1813,6 +1817,14 @@ async def _run_tests_or_special_mode(ctx: RunContext, qctx: QuietContext) -> int
                 )
                 return 1
             return await _run_lpc_uart_dma_tests(ctx)
+        if getattr(ctx.args, "fault_emit_test", False):
+            if final_environment not in LPC_WS2812_ENVS:
+                print(
+                    "--fault-emit-test is only supported on LPC845 boards "
+                    "(lpc845brk, lpc845, lpcxpresso845max)."
+                )
+                return 1
+            return await _run_lpc_fault_emit_tests(ctx)
         return await _run_bring_up_tests(ctx)
 
     # GPIO-only mode
@@ -2440,6 +2452,116 @@ async def _run_bring_up_tests(ctx: RunContext) -> int:
     finally:
         if iface is not None:
             await iface.close()
+
+
+async def _run_lpc_fault_emit_tests(ctx: RunContext) -> int:
+    """Run FastLED #3302 intentional-fault diagnostic validation."""
+
+    upload_port = ctx.upload_port
+    assert upload_port is not None
+    build_dir = ctx.build_dir
+    final_environment = (ctx.final_environment or "lpc845").lower()
+    build_environment = _build_environment_for_mode(ctx) or final_environment
+
+    print()
+    print("=" * 60)
+    print("LPC845 FAULT-EMIT MODE — intentional OOM + stack fault (#3302)")
+    print("=" * 60)
+    print("   Firmware flag: -DFASTLED_AUTORESEARCH_FAULT_TEST=1")
+    print("   Expected: each trigger emits FAULT diagnostics before reset")
+    print()
+
+    async def trigger_and_capture(method: str) -> tuple[bool, str]:
+        from ci.util.serial_interface import create_serial_interface
+
+        iface = create_serial_interface(upload_port)
+        lines: list[str] = []
+        try:
+            print(f"   Connecting serial for {method}...", end="", flush=True)
+            await iface.connect()
+            await iface.reset_device(None)
+            async for _line in iface.read_lines(timeout=2.0):
+                pass
+            print(f" {Fore.GREEN}ok{Style.RESET_ALL}")
+
+            request = (
+                json.dumps(
+                    {"jsonrpc": "2.0", "method": method, "params": [], "id": 1},
+                    separators=(",", ":"),
+                )
+                + "\n"
+            )
+            print(f"   TX: {request.strip()}", flush=True)
+            await iface.write(request)
+
+            deadline = time.monotonic() + 8.0
+            saw_fault = False
+            saw_normal_result = False
+            while time.monotonic() < deadline:
+                async for line in iface.read_lines(timeout=0.5):
+                    lines.append(line)
+                    if "FAULT:" in line:
+                        saw_fault = True
+                    if "REMOTE:" in line and '"result"' in line:
+                        saw_normal_result = True
+                if saw_fault or saw_normal_result:
+                    break
+
+            output = "\n".join(lines)
+            print(f"   RX: {output!r}", flush=True)
+            if saw_normal_result:
+                print(
+                    f"   {Fore.RED}FAIL{Style.RESET_ALL} - {method} returned "
+                    "normally instead of faulting"
+                )
+                return False, output
+            if saw_fault:
+                print(f"   {Fore.GREEN}PASS{Style.RESET_ALL} - {method} emitted FAULT")
+                return True, output
+            print(f"   {Fore.RED}FAIL{Style.RESET_ALL} - {method} did not emit FAULT")
+            return False, output
+        finally:
+            try:
+                await iface.close()
+            except KeyboardInterrupt as ki:
+                handle_keyboard_interrupt(ki)
+                raise
+            except Exception as e:
+                print(
+                    f"   {Fore.YELLOW}WARN{Style.RESET_ALL} - serial close "
+                    f"after {method} fault raised: {e}"
+                )
+
+    results: list[tuple[str, bool, str]] = []
+    for index, method in enumerate(("trigger_oom", "trigger_stackblow")):
+        if index > 0:
+            print()
+            print("   Re-flashing fresh fault-test firmware before next trigger...")
+            if not _build_and_deploy_nxplpc(
+                build_dir,
+                environment=build_environment,
+                upload_port=upload_port,
+                verbose=ctx.args.verbose,
+            ):
+                return 1
+        ok, output = await trigger_and_capture(method)
+        results.append((method, ok, output))
+        if not ok:
+            print()
+            print(f"{Fore.RED}FAULT-EMIT TEST FAILED{Style.RESET_ALL}")
+            return 1
+
+    print()
+    print("=" * 60)
+    print(f"{Fore.GREEN}PASS - #3302 fault emit validation confirmed.{Style.RESET_ALL}")
+    for method, _ok, output in results:
+        first_fault = next(
+            (line for line in output.splitlines() if "FAULT:" in line),
+            "<missing>",
+        )
+        print(f"   {method}: {first_fault}")
+    print("=" * 60)
+    return 0
 
 
 async def _run_lpc_pin_toggle_rx_tests(ctx: RunContext) -> int:

--- a/examples/AutoResearch/AutoResearchLowMemory.h
+++ b/examples/AutoResearch/AutoResearchLowMemory.h
@@ -46,7 +46,8 @@
 // flag set, `LpcSctRxChannel::begin()` programs the SCT for hardware
 // edge-capture; without it the driver is a no-op stub (host tests still
 // work via `injectEdges()`).
-#if !defined(FASTLED_AUTORESEARCH_IEEE754_MODE)
+#if !defined(FASTLED_AUTORESEARCH_IEEE754_MODE) && \
+    !defined(FASTLED_AUTORESEARCH_FAULT_TEST)
 #ifndef FASTLED_LPC_RX_SCT
 #define FASTLED_LPC_RX_SCT 1
 #endif
@@ -55,8 +56,8 @@
 // The LPC845-BRK low-memory build fits FastLED + Remote + the WS2812 loopback
 // RPC in normal mode. The dedicated IEEE754 mode deliberately omits it.
 #if defined(FL_IS_ARM_LPC_845) && !defined(FASTLED_AUTORESEARCH_IEEE754_MODE) && \
-    !defined(FASTLED_LPC_SPI_DMA) && !defined(FASTLED_LPC_PWM_DMA) && \
-    !FASTLED_AUTORESEARCH_LPC_UART_DMA
+    !defined(FASTLED_AUTORESEARCH_FAULT_TEST) && !defined(FASTLED_LPC_SPI_DMA) && \
+    !defined(FASTLED_LPC_PWM_DMA) && !FASTLED_AUTORESEARCH_LPC_UART_DMA
 #define FASTLED_AUTORESEARCH_LPC_WS2812 1
 #endif
 
@@ -71,6 +72,7 @@
 #include <Arduino.h>
 #include "fl/remote/remote.h"
 #include "fl/remote/transport/serial.h"
+#include "fl/stl/compiler_control.h"
 #include "fl/wdt/watchdog.h"
 #include "fl/log/log.h"
 #include "fl/stl/cstdio.h"  // fl::serial_begin -- HWCDC-safe Serial.begin wrapper
@@ -84,7 +86,8 @@
 // types are platform-gated behind `FL_IS_ARM_LPC` -- they only exist on
 // the real LPC build. So the include + every RX usage below must be gated
 // the same way.
-#if defined(FL_IS_ARM_LPC) && !defined(FASTLED_AUTORESEARCH_IEEE754_MODE)
+#if defined(FL_IS_ARM_LPC) && !defined(FASTLED_AUTORESEARCH_IEEE754_MODE) && \
+    !defined(FASTLED_AUTORESEARCH_FAULT_TEST)
 #include "fl/channels/rx_sct_capture.h"
 #include "fl/stl/strstream.h"
 #endif
@@ -139,7 +142,8 @@
 namespace {
 fl::Remote* g_low_memory_remote = nullptr;
 
-#if defined(FL_IS_ARM_LPC) && !defined(FASTLED_AUTORESEARCH_IEEE754_MODE)
+#if defined(FL_IS_ARM_LPC) && !defined(FASTLED_AUTORESEARCH_IEEE754_MODE) && \
+    !defined(FASTLED_AUTORESEARCH_FAULT_TEST)
 // Period-stat helpers for `pinToggleRx`. Mirrors the FlexIO RX benchmark
 // logic in `examples/AutoResearch/AutoResearchRemote.cpp::flexioRxBenchmark`
 // but inline so we don't pull in the AutoResearch ObjectFLED bus.
@@ -183,7 +187,31 @@ inline LowMemPinTogglePeriodStats computeLowMemPeriodStats(
     s.max_ns   = max_ns;
     return s;
 }
-#endif  // FL_IS_ARM_LPC && !FASTLED_AUTORESEARCH_IEEE754_MODE
+#endif  // FL_IS_ARM_LPC && !FASTLED_AUTORESEARCH_IEEE754_MODE && !FAULT_TEST
+
+#if defined(FL_IS_ARM_LPC_845) && defined(FASTLED_AUTORESEARCH_FAULT_TEST)
+FL_NO_RETURN FL_NO_INLINE void triggerLowMemoryNullFault() FL_NO_EXCEPT {
+    volatile fl::u32* const p =
+        reinterpret_cast<volatile fl::u32*>(0u);  // ok reinterpret cast - fault test
+    *p = 0x3302u;
+    while (true) {}
+}
+
+FL_DISABLE_WARNING_PUSH
+FL_DISABLE_WARNING(infinite-recursion)
+FL_NO_INLINE int recurseLowMemoryStackBlow(int depth) FL_NO_EXCEPT {
+    volatile fl::u8 pad[64] = {0};
+    pad[static_cast<fl::u8>(depth) & 0x3Fu] = static_cast<fl::u8>(depth);
+    // LPC845/M0+ has no stack-limit trap; unbounded recursion can corrupt the
+    // runtime before the HardFault handler can emit. Burn stack frames, then
+    // force the HardFault path while the diagnostic surface is still intact.
+    if (depth >= 32) {
+        triggerLowMemoryNullFault();
+    }
+    return recurseLowMemoryStackBlow(depth + 1) + pad[depth & 0x3F];
+}
+FL_DISABLE_WARNING_POP
+#endif  // FL_IS_ARM_LPC_845 && FASTLED_AUTORESEARCH_FAULT_TEST
 
 }  // namespace
 
@@ -211,6 +239,26 @@ inline void autoResearchLowMemorySetup() {
         return v;
     });
 
+#if defined(FL_IS_ARM_LPC_845) && defined(FASTLED_AUTORESEARCH_FAULT_TEST)
+    remote.bind("trigger_oom", []() -> bool {
+        // Intentional #3302 fault input: ask the 16 KB SRAM target for
+        // far more RAM than exists. If the platform allocator returns null
+        // instead of trapping, dereference null to exercise HardFault emit.
+        volatile char* const p = new char[16UL * 1024UL * 1024UL];  // ok bare allocation
+        if (p == nullptr) {
+            triggerLowMemoryNullFault();
+        }
+        p[0] = 0x33;
+        triggerLowMemoryNullFault();
+        return false;
+    });
+    remote.bind("trigger_stackblow", []() -> bool {
+        (void)recurseLowMemoryStackBlow(0);
+        triggerLowMemoryNullFault();
+        return false;
+    });
+#endif  // FL_IS_ARM_LPC_845 && FASTLED_AUTORESEARCH_FAULT_TEST
+
 #if defined(FASTLED_AUTORESEARCH_IEEE754_MODE)
     remote.bind("ieee754CodecTest", [](const fl::json& args) -> fl::json {
         (void)args;
@@ -226,7 +274,8 @@ inline void autoResearchLowMemorySetup() {
     });
 #endif
 
-#if defined(FL_IS_ARM_LPC) && !defined(FASTLED_AUTORESEARCH_IEEE754_MODE)
+#if defined(FL_IS_ARM_LPC) && !defined(FASTLED_AUTORESEARCH_IEEE754_MODE) && \
+    !defined(FASTLED_AUTORESEARCH_FAULT_TEST)
     // pinToggleRx (FastLED #3021 Phase 1) — bit-bang square wave on tx_pin
     // and capture SCT edges on rx_pin. CSV stats out.
     remote.bind("pinToggleRx",


### PR DESCRIPTION
## Summary
- add LPC845-only `--fault-emit-test` AutoResearch mode
- gate `trigger_oom` and `trigger_stackblow` RPCs behind `FASTLED_AUTORESEARCH_FAULT_TEST=1`
- document the fault-emission workflow in `agents/docs/hardware-autoresearch.md`

Closes #3302.
Part of #3348.

## Local validation
- `fbuild port scan` confirmed LPC-Link2 CMSIS-DAP on COM10.
- `bash lint ci/autoresearch/args.py ci/autoresearch/phases.py examples/AutoResearch/AutoResearchLowMemory.h`
- `bash autoresearch lpc845 --fault-emit-test --upload-port COM10 --timeout 120s --skip-lint`

Observed fault diagnostics:
- `trigger_oom: FAULT: HardFault PC=0x10001E70 LR=0xFFFFFFF9 xPSR=0x10000020`
- `trigger_stackblow: FAULT: HardFault PC=0x10002FC0 LR=0xFFFFFFF9 xPSR=0x00000000`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new LPC845 fault-validation mode for AutoResearch.
  * This mode can intentionally trigger memory and stack failures and verify that the device reports a `FAULT:` diagnostic before resetting.

* **Documentation**
  * Updated the hardware AutoResearch guide with step-by-step instructions, required setup, and expected pass/fail results for the new validation flow.
  * Added command-line help for the new option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->