### PR TITLE
fix(wasm): make dynamic WASM_BIGINT ABI explicit

### DIFF
--- a/src/platforms/wasm/compiler/build_flags.toml
+++ b/src/platforms/wasm/compiler/build_flags.toml
@@ -264,7 +264,7 @@ link_flags = [
     "-sSTACK_OVERFLOW_CHECK=0",             # Disable stack overflow checking
 
     # Compatibility and Performance Options
-    "-sWASM_BIGINT=0",                      # Disable BigInt for faster execution
+    "-sWASM_BIGINT=0",                      # Quick-mode override: disable BigInt for faster execution
     "-sERROR_ON_UNDEFINED_SYMBOLS=1",       # Error on undefined symbols (was hiding missing addLeds)
 ]
 
@@ -304,6 +304,9 @@ flags = [
 
     # WebAssembly Configuration
     "-sWASM=1",                                # Generate WebAssembly output (not asm.js)
+    # Dynamic main/side modules must agree on i64 import/export types. Quick
+    # mode overrides this below for its faster non-BigInt ABI.
+    "-sWASM_BIGINT=1",                          # Explicit default ABI for all link modes
 
     # Linker Performance Optimization
     "-fuse-ld=wasm-ld",                      # Explicitly use wasm-ld (default, but explicit for clarity)


### PR DESCRIPTION
## Summary\n- add an explicit -sWASM_BIGINT=1 default to [linking.base]\n- retain the quick-mode -sWASM_BIGINT=0 override in [build_modes.quick].link_flags\n\nThe dynamic FastLED WASM main and side modules must use the same i64 ABI. The fastled-wasm dynamic linker consumes the last profile setting, so base + quick override makes the setting explicit for every build mode.\n\nRefs zackees/fastled-wasm#184

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified WebAssembly linking configuration comments.
  * Documented the default BigInt ABI behavior and the quick-mode override.
  * Added guidance that dynamic modules must use compatible i64 import/export types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->