### PR TITLE
fix(wasm): install the public @fastled/gfx dependency

### DIFF
--- a/.github/workflows/build_wasm.yml
+++ b/.github/workflows/build_wasm.yml
@@ -91,13 +91,11 @@ jobs:
       - name: Compile fastled.js, fastled.wasm, and index.html
         run: |
           uv run ci/wasm_compile.py examples/wasm
-        continue-on-error: ${{ matrix.os != 'ubuntu-latest' }}
         shell: bash
 
       - name: Scan for wasm/js/html artifacts
         run: |
           find . -name "*.wasm" -o -name "*.js" -o -name "*.html"
-        continue-on-error: ${{ matrix.os != 'ubuntu-latest' }}
 
       - name: Check for required artifacts
         run: |

--- a/ci/esbuild_frontend.py
+++ b/ci/esbuild_frontend.py
@@ -17,6 +17,7 @@ PROJECT_ROOT = Path(__file__).parent.parent
 FRONTEND_DIR = PROJECT_ROOT / "src" / "platforms" / "wasm" / "compiler"
 INSTALL_ROOT = Path.home() / ".fastled" / "toolchains" / "esbuild"
 ARCHIVE_CACHE_DIR = Path.home() / ".fastled" / "toolchains" / "archives"
+FRONTEND_DEPENDENCY_MARKER = "fastled-dependencies.sha256"
 
 
 def _platform_arch() -> tuple[str, str]:
@@ -101,11 +102,37 @@ def _copy_file(src: Path, dst: Path) -> None:
 def _get_source_mtime(source_dir: Path) -> float:
     max_mtime = 0.0
     for path in source_dir.rglob("*"):
-        if "dist" in path.parts:
+        if "dist" in path.parts or "node_modules" in path.parts:
             continue
         if path.is_file():
             max_mtime = max(max_mtime, path.stat().st_mtime)
     return max_mtime
+
+
+def _frontend_dependency_hash() -> str:
+    """Hash the manifests which determine a reproducible frontend install."""
+    digest = hashlib.sha256()
+    for name in ("package.json", "package-lock.json"):
+        manifest = FRONTEND_DIR / name
+        if not manifest.is_file():
+            raise RuntimeError(f"Missing frontend dependency manifest: {manifest}")
+        digest.update(name.encode("utf-8"))
+        digest.update(manifest.read_bytes())
+    return digest.hexdigest()
+
+
+def ensure_frontend_dependencies() -> None:
+    """Materialize the lockfile before esbuild resolves bare package imports."""
+    dependency_hash = _frontend_dependency_hash()
+    node_modules = FRONTEND_DIR / "node_modules"
+    marker = node_modules / FRONTEND_DEPENDENCY_MARKER
+    if marker.is_file() and marker.read_text(encoding="utf-8").strip() == dependency_hash:
+        return
+
+    result = subprocess.run(["npm", "ci", "--ignore-scripts"], cwd=str(FRONTEND_DIR))
+    if result.returncode != 0:
+        raise RuntimeError(f"npm ci failed with exit code {result.returncode}")
+    marker.write_text(f"{dependency_hash}\n", encoding="utf-8")
 
 
 def _compute_dir_hash(directory: Path) -> str:
@@ -131,7 +158,6 @@ def _run_esbuild(args: list[str]) -> None:
     result = subprocess.run(
         [
             str(esbuild),
-            "--alias:three=./vendor/three/build/three.module.js",
             *args,
         ],
         cwd=str(FRONTEND_DIR),
@@ -141,6 +167,7 @@ def _run_esbuild(args: list[str]) -> None:
 
 
 def build_dist() -> Path:
+    ensure_frontend_dependencies()
     dist_dir = FRONTEND_DIR / "dist"
     marker = dist_dir / ".esbuild_marker"
     source_mtime = _get_source_mtime(FRONTEND_DIR)

--- a/ci/tests/test_esbuild_frontend.py
+++ b/ci/tests/test_esbuild_frontend.py
@@ -1,0 +1,46 @@
+"""Regression checks for clean WASM frontend dependency installation."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib
+from pathlib import Path
+
+
+def test_frontend_dependency_hash_tracks_both_manifests(monkeypatch, tmp_path: Path) -> None:
+    module = importlib.import_module("ci.esbuild_frontend")
+    (tmp_path / "package.json").write_text('{"dependencies":{}}', encoding="utf-8")
+    (tmp_path / "package-lock.json").write_text('{"lockfileVersion":3}', encoding="utf-8")
+    monkeypatch.setattr(module, "FRONTEND_DIR", tmp_path)
+
+    actual = module._frontend_dependency_hash()
+    expected = hashlib.sha256(
+        b'package.json{"dependencies":{}}package-lock.json{"lockfileVersion":3}'
+    ).hexdigest()
+    assert actual == expected
+
+
+def test_frontend_dependencies_run_npm_ci_once_per_manifest_hash(monkeypatch, tmp_path: Path) -> None:
+    module = importlib.import_module("ci.esbuild_frontend")
+    (tmp_path / "package.json").write_text('{"dependencies":{}}', encoding="utf-8")
+    lockfile = tmp_path / "package-lock.json"
+    lockfile.write_text('{"lockfileVersion":3}', encoding="utf-8")
+    monkeypatch.setattr(module, "FRONTEND_DIR", tmp_path)
+
+    calls: list[tuple[list[str], str]] = []
+
+    def fake_run(args: list[str], cwd: str):
+        calls.append((args, cwd))
+        (tmp_path / "node_modules").mkdir(exist_ok=True)
+        return type("Result", (), {"returncode": 0})()
+
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+    module.ensure_frontend_dependencies()
+    module.ensure_frontend_dependencies()
+    lockfile.write_text('{"lockfileVersion":3,"changed":true}', encoding="utf-8")
+    module.ensure_frontend_dependencies()
+
+    assert calls == [
+        (["npm", "ci", "--ignore-scripts"], str(tmp_path)),
+        (["npm", "ci", "--ignore-scripts"], str(tmp_path)),
+    ]


### PR DESCRIPTION
Summary: run lockfile-pinned npm ci before bundling the WASM frontend; resolve Three.js from the same installed dependency graph as @fastled/gfx; invalidate frontend dependencies when package manifests change; and report the original WASM compile failure directly. Coordinated with zackees/ledmapper#404. Validation: focused pytest and ruff checks plus a clean node_modules build_dist run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Frontend builds now reliably install or refresh dependencies when project manifests change.
  * Build caching is more accurate, reducing stale output issues.
  * Build validation now reports artifact-generation errors instead of silently continuing.

* **Chores**
  * Improved build consistency across supported environments.
  * Added automated checks to verify dependency detection and installation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->