### PR TITLE
fix(channels): unify RGBW settings state

### DIFF
--- a/src/fl/channels/channel.cpp.hpp
+++ b/src/fl/channels/channel.cpp.hpp
@@ -227,10 +227,10 @@ Channel::Channel(const ChipsetVariant& chipset, fl::span<CRGB> leds,
     // Set the LED data array
     setLeds(leds);
 
-    // Sync mSettings from ChannelOptions so the mWhiteCfg variant (and any
-    // other future fields) survives to showPixels(). The setter calls below
-    // are then idempotent overlays on top of the same data.
-    mSettings = options;
+    // Initialize the inherited per-channel controller settings so mWhiteCfg
+    // and future ChannelOptions fields survive to showPixels(). The setter
+    // calls below are idempotent overlays on the same data.
+    CLEDController::mSettings = options;
 
     // Set color correction/temperature/dither/rgbw from ChannelOptions
     setCorrection(options.mCorrection);
@@ -259,9 +259,9 @@ Channel::Channel(int pin, const ChipsetTimingConfig& timing, fl::span<CRGB> leds
     // Set the LED data array
     setLeds(leds);
 
-    // Sync mSettings from ChannelOptions so the mWhiteCfg variant survives
-    // to showPixels(). See sibling ChipsetVariant constructor for rationale.
-    mSettings = options;
+    // Initialize the inherited per-channel controller settings so mWhiteCfg
+    // survives to showPixels(). See the sibling constructor for rationale.
+    CLEDController::mSettings = options;
 
     // Set color correction/temperature/dither/rgbw from ChannelOptions
     setCorrection(options.mCorrection);
@@ -284,9 +284,9 @@ void Channel::applyConfig(const ChannelConfig& config) {
         mName = config.mName.value();
     }
     setLeds(config.mLeds);
-    // Sync mSettings from incoming options so the mWhiteCfg variant survives
-    // to showPixels(). Setters below are idempotent overlays on the same data.
-    mSettings = config.options;
+    // Replace the inherited per-channel controller settings so mWhiteCfg and
+    // future options survive to showPixels(). Setters below are idempotent.
+    CLEDController::mSettings = config.options;
     mBus = config.options.mBus;
     mBusWhich = config.options.mBusWhich;
     setCorrection(config.options.mCorrection);

--- a/src/fl/channels/channel.h
+++ b/src/fl/channels/channel.h
@@ -276,7 +276,6 @@ private:
                                          // disable re-emits the diagnostic.
     const i32 mId;
     fl::string mName;               // User-specified or auto-generated name
-    ChannelOptions mSettings;           // Per-channel settings (gamma, rgbw, etc.)
     ChannelDataPtr mChannelData;
     fl::ScreenMap mScreenMap;        // Screen map for JS canvas visualization
 };

--- a/tests/fl/channels/channel_typed.cpp
+++ b/tests/fl/channels/channel_typed.cpp
@@ -6,8 +6,10 @@
 #include "fl/channels/bus.h"
 #include "fl/channels/bus_traits.h"
 #include "fl/channels/channel.h"
+#include "fl/channels/channel_events.h"
 #include "fl/channels/channel_typed.h"
 #include "fl/channels/config.h"
+#include "fl/channels/data.h"
 #include "fl/channels/manager.h"
 #include "fl/chipsets/chipset_timing_config.h"
 #include "fl/gfx/crgb.h"
@@ -101,6 +103,81 @@ FL_TEST_CASE("runtime FastLED.add(cfg) with cfg.options.mBus = Bus::BIT_BANG") {
     FL_CHECK(channel->getPin() == 2);
 
     channel->removeFromDrawList();
+}
+
+FL_TEST_CASE("ChannelConfig RGBW settings encode four bytes per pixel") {
+    CRGB workspace[2] = {CRGB::Red, CRGB::Blue};
+    auto timing = fl::makeTimingConfig<fl::TIMING_WS2812_800KHZ>();
+    fl::ChannelOptions options;
+    options.mBus = fl::Bus::BIT_BANG;
+    options.mWhiteCfg = fl::RgbwDefault::value();
+
+    fl::enableDrivers<fl::Bus::BIT_BANG>();
+    fl::ChannelConfig config(fl::ClocklessChipset(9, timing),
+                             fl::span<CRGB>(workspace, 2), RGB, options);
+    auto channel = fl::Channel::create(config);
+    FL_REQUIRE(channel != nullptr);
+
+    bool encoded = false;
+    fl::ChannelPixelFormat pixelFormat = fl::ChannelPixelFormat::RGB;
+    size_t encodedBytes = 0;
+    auto& events = fl::ChannelEvents::instance();
+    int listenerId = events.onChannelDataEncoded.add(
+        [&](const fl::IChannel& source, const fl::ChannelData& data) {
+            if (&source == channel.get()) {
+                encoded = true;
+                pixelFormat = data.getPixelFormat();
+                encodedBytes = data.getData().size();
+            }
+        });
+
+    FastLED.add(channel);
+    FastLED.show();
+    FastLED.remove(channel);
+    events.onChannelDataEncoded.remove(listenerId);
+
+    FL_REQUIRE(encoded);
+    FL_CHECK_EQ(pixelFormat, fl::ChannelPixelFormat::RGBW);
+    FL_CHECK_EQ(encodedBytes, 8u);
+}
+
+FL_TEST_CASE("CLEDController RGBW setter reaches Channel encoding") {
+    CRGB workspace[2] = {CRGB::Red, CRGB::Blue};
+    auto timing = fl::makeTimingConfig<fl::TIMING_WS2812_800KHZ>();
+    fl::ChannelOptions options;
+    options.mBus = fl::Bus::BIT_BANG;
+
+    fl::enableDrivers<fl::Bus::BIT_BANG>();
+    fl::ChannelConfig config(fl::ClocklessChipset(10, timing),
+                             fl::span<CRGB>(workspace, 2), RGB, options);
+    auto channel = fl::Channel::create(config);
+    FL_REQUIRE(channel != nullptr);
+
+    fl::CLEDController& controller = *channel;
+    controller.setRgbw(fl::RgbwDefault::value());
+    FL_REQUIRE(controller.getRgbw().active());
+
+    bool encoded = false;
+    fl::ChannelPixelFormat pixelFormat = fl::ChannelPixelFormat::RGB;
+    size_t encodedBytes = 0;
+    auto& events = fl::ChannelEvents::instance();
+    int listenerId = events.onChannelDataEncoded.add(
+        [&](const fl::IChannel& source, const fl::ChannelData& data) {
+            if (&source == channel.get()) {
+                encoded = true;
+                pixelFormat = data.getPixelFormat();
+                encodedBytes = data.getData().size();
+            }
+        });
+
+    FastLED.add(channel);
+    FastLED.show();
+    FastLED.remove(channel);
+    events.onChannelDataEncoded.remove(listenerId);
+
+    FL_REQUIRE(encoded);
+    FL_CHECK_EQ(pixelFormat, fl::ChannelPixelFormat::RGBW);
+    FL_CHECK_EQ(encodedBytes, 8u);
 }
 
 FL_STATIC_ASSERT(


### PR DESCRIPTION
Fixes #3622

## Summary

- remove the redundant `Channel::mSettings` member so `Channel` uses the per-controller `CLEDController::mSettings` inherited by every channel
- explicitly initialize that inherited settings object from `ChannelConfig` and `applyConfig()`
- add encoding regressions for both explicit `ChannelConfig` RGBW and the inherited `CLEDController&` setter surface returned by `FastLED.addLeds<>`

## Root cause

`CLEDController::setRgbw()` updated the base settings object, while `Channel::showPixels()` read a shadowing settings object declared by `Channel`. On the ESP-IDF 5/RMT5 `ClocklessIdf5` path, chained `.setRgbw()` therefore left the encoder in three-byte RGB mode.

## RED -> GREEN

Before the production change, `fl_channels_channel_typed` failed in the inherited setter case under the sanitizer build:

```text
actual pixel format:   RGB (3)
expected pixel format: RGBW (4)
actual encoded size:   6 bytes
expected encoded size: 8 bytes
```

After removing the shadowed state, both the explicit config and inherited setter cases encode RGBW as four bytes per pixel.

## Validation

- `bash test tests/fl/channels/channel_typed`
- `bash test fl_channels_channel_typed --debug`
- `bash test tests/fl/chipsets/encoders`
- `bash lint`
- `bash test --cpp` — 348/348 passed
- `bash compile esp32dev --examples RGBW` — fbuild succeeded
- delegated pre-push C++ review — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected channel configuration handling so RGBW-enabled channels consistently use RGBW pixel encoding.
  * Ensured RGBW output remains correct when settings are applied directly or through controller configuration.

* **Tests**
  * Added coverage verifying RGBW encoding produces the expected data format and byte count.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->