### PR TITLE
chore(deps): bump fbuild to 2.5.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,9 +5,13 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    # Pin to fbuild 2.4.0 (released 2026-07-06).
+    # Pin to fbuild 2.5.1 (released 2026-07-13).
     #
     # Pin history:
+    #   2.5.1 -- upgrades PyO3 to 0.29 and fixes duplicate objc dylib
+    #             linkage on macOS (FastLED/fbuild#1026/#1027). It includes
+    #             the 2.5.0 USB inventory, deploy tooling, build-cache,
+    #             daemon arbitration, and build-flag propagation rollup.
     #   2.4.0 -- carries daemon serial lock diagnostics/recovery for stale
     #             serial sessions: `daemon locks` now exposes owner metadata,
     #             ages/activity, and pending attaches, while `clear-locks`
@@ -148,7 +152,7 @@ dependencies = [
     # primitive (FastLED/fbuild#532, #577/#580), and an
     # http-connect-timeout fix on the managed-zccache client
     # (FastLED/fbuild#573).
-    "fbuild==2.4.0",
+    "fbuild==2.5.1",
     "platformio>=6.1.19,<6.2",
     "python-dateutil",
     "ruff",


### PR DESCRIPTION
## Summary
- pin FastLED development tooling to fbuild 2.5.1
- document the 2.5.0/2.5.1 feature and macOS linkage rollup in the dependency history

## Validation
- `uv lock --check`
- `uv run --frozen fbuild --version` -> `fbuild 2.5.1`
- `uv run --frozen pytest ci/tests/test_fbuild_default_selection.py -q` -> 5 passed
- `bash lint` -> passed

Related to #3626.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build tooling to a newer pinned release.
  * Improved compatibility and reliability for macOS builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->