### PR TITLE
feat(autoresearch): stock RP2040 no-port RPC smoke

### DIFF
--- a/ci/autoresearch/args.py
+++ b/ci/autoresearch/args.py
@@ -28,6 +28,7 @@ class Args:
     simd: bool
     coroutine: bool
     ieee754: bool
+    rpc_smoke: bool
     # Wave2D perf benchmark — accepts "<W>x<H>" (e.g. "32x32") or None.
     # Cf. issue #3124 for the future --perf-XX / --test-XX convention.
     wave2d_perf: str | None
@@ -311,6 +312,11 @@ See Also:
             "--ieee754",
             action="store_true",
             help="Run on-device integer IEEE 754 decimal codec verification (#3039)",
+        )
+        driver_group.add_argument(
+            "--rpc-smoke",
+            action="store_true",
+            help="Validate pin-free JSON-RPC discovery, health, payload, and error handling",
         )
         driver_group.add_argument(
             "--wave2d-perf",
@@ -786,6 +792,7 @@ See Also:
             simd=parsed.simd,
             coroutine=parsed.coroutine,
             ieee754=parsed.ieee754,
+            rpc_smoke=parsed.rpc_smoke,
             wave2d_perf=parsed.wave2d_perf,
             environment=parsed.environment,
             verbose=parsed.verbose,

--- a/ci/autoresearch/build_driver.py
+++ b/ci/autoresearch/build_driver.py
@@ -3,8 +3,18 @@
 from __future__ import annotations
 
 import subprocess
+from dataclasses import dataclass
 from pathlib import Path
 from typing import IO, Protocol, runtime_checkable
+
+
+@dataclass(frozen=True)
+class DeployResult:
+    """Structured build/deploy result, including post-flash port handoff."""
+
+    success: bool
+    port: str | None = None
+    message: str = ""
 
 
 @runtime_checkable
@@ -34,7 +44,7 @@ class BuildDriver(Protocol):
         clean: bool = False,
         quiet: bool = False,
         log_file: IO[str] | None = None,
-    ) -> bool: ...
+    ) -> bool | DeployResult: ...
 
     def firmware_path(self, build_dir: Path, environment: str) -> Path: ...
 
@@ -66,10 +76,10 @@ class FbuildDriver:
         clean: bool = False,
         quiet: bool = False,
         log_file: IO[str] | None = None,
-    ) -> bool:
+    ) -> DeployResult:
         from ci.util.fbuild_runner import run_fbuild_deploy
 
-        return run_fbuild_deploy(
+        result = run_fbuild_deploy(
             build_dir,
             environment=environment,
             upload_port=upload_port,
@@ -77,6 +87,11 @@ class FbuildDriver:
             clean=clean,
             quiet=quiet,
             log_file=log_file,
+        )
+        return DeployResult(
+            success=result.success,
+            port=result.port,
+            message=result.output,
         )
 
     def firmware_path(self, build_dir: Path, environment: str) -> Path:

--- a/ci/autoresearch/context.py
+++ b/ci/autoresearch/context.py
@@ -158,6 +158,7 @@ class RunContext:
     decode_mode: bool
     gpio_only_mode: bool
     parallel_mode: bool
+    rpc_smoke_mode: bool = False
 
     # Resolved after port/environment detection
     final_environment: str | None = None

--- a/ci/autoresearch/phases.py
+++ b/ci/autoresearch/phases.py
@@ -19,7 +19,7 @@ from typing import TYPE_CHECKING, Any, TypeGuard
 from colorama import Fore, Style
 
 from ci.autoresearch.args import Args
-from ci.autoresearch.build_driver import select_build_driver
+from ci.autoresearch.build_driver import DeployResult, select_build_driver
 from ci.autoresearch.context import (
     DEFAULT_EXPECT_PATTERNS,
     DEFAULT_FAIL_ON_PATTERN,
@@ -37,7 +37,7 @@ from ci.autoresearch.gpio import (
     run_pin_discovery_segmented,
 )
 from ci.debug_attached import run_cpp_lint
-from ci.rpc_client import RpcClient, RpcCrashError, RpcTimeoutError
+from ci.rpc_client import RpcClient, RpcCrashError, RpcError, RpcTimeoutError
 from ci.util.blocker_alert import blocker_alert
 from ci.util.crash_trace_decoder import CrashTraceDecoder
 from ci.util.global_interrupt_handler import (
@@ -189,6 +189,9 @@ def _autoresearch_watchdog_thread(
                 mon.__exit__(None, None, None)
                 return
         except KeyboardInterrupt as ki:  # noqa: BLE001
+            handle_keyboard_interrupt(ki)
+            raise
+        except KeyboardInterrupt as ki:
             handle_keyboard_interrupt(ki)
             raise
         except Exception:
@@ -399,6 +402,7 @@ def _parse_args_and_build_commands(args: Args) -> RunContext | int:
     simd_test_mode = args.simd
     coroutine_test_mode = args.coroutine
     ieee754_test_mode = args.ieee754
+    rpc_smoke_mode = args.rpc_smoke
 
     # Parse --wave2d-perf "<W>x<H>" — None disables the mode.
     # Cf. #3124 for the planned --perf-XX convention rename.
@@ -495,6 +499,7 @@ def _parse_args_and_build_commands(args: Args) -> RunContext | int:
             or simd_test_mode
             or coroutine_test_mode
             or ieee754_test_mode
+            or rpc_smoke_mode
             or net_server_mode
             or net_client_mode
             or net_loopback_mode
@@ -510,7 +515,13 @@ def _parse_args_and_build_commands(args: Args) -> RunContext | int:
     # Validate mutual exclusivity
     if (
         net_server_mode or net_client_mode or net_loopback_mode or ota_mode or ble_mode
-    ) and (drivers or simd_test_mode or coroutine_test_mode or ieee754_test_mode):
+    ) and (
+        drivers
+        or simd_test_mode
+        or coroutine_test_mode
+        or ieee754_test_mode
+        or rpc_smoke_mode
+    ):
         print(
             f"{Fore.RED}\u274c Error: --net/--net-server/--net-client/--ota/--ble cannot be combined with driver flags, --simd, or --coroutine{Style.RESET_ALL}"
         )
@@ -537,6 +548,7 @@ def _parse_args_and_build_commands(args: Args) -> RunContext | int:
         and not simd_test_mode
         and not coroutine_test_mode
         and not ieee754_test_mode
+        and not rpc_smoke_mode
         and not net_server_mode
         and not net_client_mode
         and not net_loopback_mode
@@ -1059,6 +1071,7 @@ def _parse_args_and_build_commands(args: Args) -> RunContext | int:
         simd_test_mode=simd_test_mode,
         coroutine_test_mode=coroutine_test_mode,
         ieee754_test_mode=ieee754_test_mode,
+        rpc_smoke_mode=rpc_smoke_mode,
         wave2d_perf_grid=wave2d_perf_grid,
         net_server_mode=net_server_mode,
         net_client_mode=net_client_mode,
@@ -1087,9 +1100,12 @@ async def _resolve_port_and_environment(ctx: RunContext) -> int | None:
     is_teensy = (
         ctx.final_environment is not None and "teensy" in ctx.final_environment.lower()
     )
+    stock_rp2040_transport = args.rpc_smoke and (
+        (ctx.final_environment or "").lower() in {"rp2040", "rpipico"}
+    )
 
     upload_port = args.upload_port
-    if not upload_port:
+    if not upload_port and not stock_rp2040_transport:
         expected_environment = None if is_teensy else ctx.final_environment
         max_wait_s = 60
         poll_interval_s = 1.0
@@ -1160,14 +1176,20 @@ async def _resolve_port_and_environment(ctx: RunContext) -> int | None:
 
         upload_port = result.selected_port
 
-    assert upload_port is not None, "upload_port should be set by auto-detection"
+    if stock_rp2040_transport and not upload_port:
+        print(
+            "📦 Stock RP2040 transport: no pre-deploy serial port required; "
+            "fbuild will discover RPI-RP2 and return the application CDC port."
+        )
+    else:
+        assert upload_port is not None, "upload_port should be set by auto-detection"
     ctx.upload_port = upload_port
 
     # Auto-detect environment from attached chip
     detected_chip_type: str | None = None
     detected_environment: str | None = None
 
-    if not ctx.final_environment:
+    if not ctx.final_environment and upload_port is not None:
         print("\U0001f50d Detecting attached chip type...")
         chip_result = detect_attached_chip(upload_port)
         if chip_result.ok and chip_result.environment:
@@ -1387,18 +1409,29 @@ async def _run_build_deploy(ctx: RunContext, qctx: QuietContext) -> int | None:
             qctx.emit("BUILD+DEPLOY FAIL (nxplpc)")
             qctx.emit_log_path()
             return 1
-    elif not build_driver.deploy(
-        build_dir,
-        environment=build_environment,
-        upload_port=upload_port,
-        verbose=args.verbose,
-        clean=args.clean,
-        quiet=args.quiet,
-        log_file=qctx.log_file,
-    ):
-        qctx.emit("BUILD+FLASH FAIL")
-        qctx.emit_log_path()
-        return 1
+    else:
+        deploy_result = build_driver.deploy(
+            build_dir,
+            environment=build_environment,
+            upload_port=upload_port,
+            verbose=args.verbose,
+            clean=args.clean,
+            quiet=args.quiet,
+            log_file=qctx.log_file,
+        )
+        deploy_success = (
+            deploy_result.success
+            if isinstance(deploy_result, DeployResult)
+            else bool(deploy_result)
+        )
+        if isinstance(deploy_result, DeployResult) and deploy_result.port:
+            ctx.upload_port = deploy_result.port
+            upload_port = deploy_result.port
+            print(f"✅ fbuild returned application port: {deploy_result.port}")
+        if not deploy_success:
+            qctx.emit("BUILD+FLASH FAIL")
+            qctx.emit_log_path()
+            return 1
 
     # Wait for serial port to become available after upload
     if upload_port and build_driver.name == "platformio":
@@ -1490,7 +1523,10 @@ async def _run_schema_and_pin_setup(ctx: RunContext) -> int | None:
     # Validate RPC commands against device schema
     constrained_platforms = ["esp32c6", "esp32c2", "esp32p4", "teensy41", "teensy40"]
     skip_schema = (
-        args.skip_schema or args.quiet or final_environment in constrained_platforms
+        args.skip_schema
+        or args.quiet
+        or args.rpc_smoke
+        or final_environment in constrained_platforms
     )
 
     if skip_schema:
@@ -1587,6 +1623,8 @@ async def _run_schema_and_pin_setup(ctx: RunContext) -> int | None:
         print(
             "\n\U0001f4cc IEEE754 codec mode: skipping pin discovery and GPIO pre-test"
         )
+    elif ctx.rpc_smoke_mode:
+        print("\n\U0001f4cc RPC smoke mode: skipping pin discovery and GPIO pre-test")
     elif ctx.net_server_mode or ctx.net_client_mode or ctx.net_loopback_mode:
         print("\n\U0001f4cc Network mode: skipping pin discovery and GPIO pre-test")
     elif ctx.ota_mode:
@@ -1655,7 +1693,8 @@ async def _run_schema_and_pin_setup(ctx: RunContext) -> int | None:
             f"TX={ctx.effective_tx_pin}, RX={ctx.effective_rx_pin}"
         )
 
-    _ensure_leading_set_pins_command(ctx)
+    if not ctx.rpc_smoke_mode:
+        _ensure_leading_set_pins_command(ctx)
 
     # GPIO connectivity pre-test
     if final_environment in LPC_BRING_UP_ENVS:
@@ -1667,6 +1706,8 @@ async def _run_schema_and_pin_setup(ctx: RunContext) -> int | None:
     elif ctx.coroutine_test_mode:
         pass
     elif ctx.ieee754_test_mode:
+        pass
+    elif ctx.rpc_smoke_mode:
         pass
     elif ctx.net_server_mode or ctx.net_client_mode or ctx.net_loopback_mode:
         pass
@@ -1723,6 +1764,107 @@ async def _run_schema_and_pin_setup(ctx: RunContext) -> int | None:
 # ============================================================
 
 
+async def _run_rpc_smoke_tests(ctx: RunContext) -> int:
+    """Validate the pin-free JSON-RPC transport and core system surface."""
+    upload_port = ctx.upload_port
+    if not upload_port:
+        print("❌ RPC smoke requires the post-deploy application port")
+        return 1
+
+    from ci.util.serial_interface import create_serial_interface
+
+    client = RpcClient(
+        upload_port,
+        timeout=min(10.0, max(1.0, ctx.remaining_seconds(minimum=1.0))),
+        serial_interface=ctx.serial_iface
+        or create_serial_interface(upload_port, use_pyserial=not ctx.use_fbuild),
+        crash_decoder=ctx.crash_decoder,
+    )
+
+    async def call(name: str, args: Any = None) -> Any:
+        response = await client.send(
+            name,
+            args=args,
+            timeout=max(1.0, ctx.remaining_seconds(minimum=1.0)),
+        )
+        if not response.success:
+            raise RpcError(f"{name} returned unsuccessful response: {response.data!r}")
+        print(f"REMOTE: {name} -> {response.data!r}")
+        return response.data
+
+    try:
+        await client.connect()
+        await client.drain_boot_output(verbose=False)
+
+        discovered = await call("rpc.discover")
+        if not isinstance(discovered, (dict, list)) or not discovered:
+            raise RpcError("rpc.discover returned an empty or invalid manifest")
+
+        help_manifest = await call("help")
+        if not isinstance(help_manifest, list) or not help_manifest:
+            raise RpcError("help returned an empty or invalid manifest")
+
+        first_ping = await call("ping")
+        await asyncio.sleep(0.01)
+        second_ping = await call("ping")
+        first_uptime = (
+            first_ping.get("uptimeMs") if isinstance(first_ping, dict) else None
+        )
+        second_uptime = (
+            second_ping.get("uptimeMs") if isinstance(second_ping, dict) else None
+        )
+        if (
+            not isinstance(first_uptime, (int, float))
+            or not isinstance(second_uptime, (int, float))
+            or second_uptime < first_uptime
+        ):
+            raise RpcError("ping uptime did not advance monotonically")
+
+        payload = {
+            "text": "rp2040-rpc-smoke",
+            "number": 2040,
+            "nested": {"ok": True, "values": [1, 2, 3]},
+        }
+        echoed = await call("debugTest", payload)
+        if not isinstance(echoed, dict) or echoed.get("received") != payload:
+            raise RpcError(f"debugTest payload mismatch: {echoed!r}")
+
+        status = await call("status")
+        if not isinstance(status, dict) or status.get("ready") is not True:
+            raise RpcError(f"status did not report ready: {status!r}")
+
+        drivers = await call("drivers")
+        if not isinstance(drivers, list):
+            raise RpcError(f"drivers returned a non-array result: {drivers!r}")
+
+        no_serial = await call("testNoSerial")
+        if not isinstance(no_serial, dict) or no_serial.get("success") is not True:
+            raise RpcError(f"testNoSerial failed: {no_serial!r}")
+
+        try:
+            await call("__autoresearch_missing_method__")
+        except RpcError as exc:
+            print(f"REMOTE: missing-method error handled -> {exc}")
+        else:
+            raise RpcError("missing method unexpectedly succeeded")
+
+        print(
+            "RESULT: RPC smoke PASS (discovery, help, ping, payload, status, drivers, testNoSerial, error handling)"
+        )
+        return 0
+    except (RpcCrashError, RpcTimeoutError, RpcError, OSError) as exc:
+        print(f"RESULT: RPC smoke FAIL: {exc}")
+        return 1
+    finally:
+        try:
+            await client.close()
+        except KeyboardInterrupt as ki:
+            handle_keyboard_interrupt(ki)
+            raise
+        except Exception:
+            pass
+
+
 async def _run_tests_or_special_mode(ctx: RunContext, qctx: QuietContext) -> int:
     """Execute GPIO-only, special modes, or main RPC test loop.
 
@@ -1739,6 +1881,9 @@ async def _run_tests_or_special_mode(ctx: RunContext, qctx: QuietContext) -> int
     # BEFORE the gpio_only_mode early-return so the harness actually runs the
     # echo check instead of bailing with a "no tests requested" success.
     final_environment = (ctx.final_environment or "").lower()
+    if ctx.rpc_smoke_mode:
+        return await _run_rpc_smoke_tests(ctx)
+
     if final_environment in LPC_BRING_UP_ENVS:
         if ctx.ieee754_test_mode:
             return await _run_ieee754_tests(ctx)

--- a/ci/rpc_client.py
+++ b/ci/rpc_client.py
@@ -57,13 +57,13 @@ class RpcResponse:
     """
 
     success: bool
-    data: dict[str, Any]
+    data: Any
     raw_line: str
     _id: int = 0  # Internal: Request ID from JSON-RPC 2.0 (always present, hidden from public API)
 
     def get(self, key: str, default: Any = None) -> Any:
         """Get value from response data."""
-        return self.data.get(key, default)
+        return self.data.get(key, default) if isinstance(self.data, dict) else default
 
     def __getitem__(self, key: str) -> Any:
         """Allow dict-like access to response data."""
@@ -71,7 +71,7 @@ class RpcResponse:
 
     def __contains__(self, key: str) -> bool:
         """Check if key exists in response data."""
-        return key in self.data
+        return isinstance(self.data, dict) and key in self.data
 
 
 class RpcTimeoutError(TimeoutError):
@@ -718,12 +718,13 @@ class RpcClient:
                         # Void functions return null - treat as successful execution
                         success = True
 
-                    # Ensure response_data is always a dict for consistent API
-                    final_response_data: dict[str, Any]
-                    if response_data is None or not isinstance(response_data, dict):
-                        final_response_data = {}
-                    else:
-                        final_response_data = response_data  # type: ignore[assignment]
+                    # Preserve array/scalar results as well as object results.
+                    # JSON-RPC discovery/help return arrays; collapsing those
+                    # to {} made it impossible for acceptance modes to validate
+                    # the actual manifest.
+                    final_response_data: Any = (
+                        {} if response_data is None else response_data
+                    )
 
                     return RpcResponse(
                         success=success,

--- a/ci/tests/test_autoresearch_phases.py
+++ b/ci/tests/test_autoresearch_phases.py
@@ -27,6 +27,7 @@ from ci.autoresearch.phases import (
     _run_schema_and_pin_setup,
     _run_tests_or_special_mode,
 )
+from ci.rpc_client import RpcError
 from ci.util.port_utils import ChipDetectionResult, auto_detect_upload_port
 
 
@@ -57,6 +58,7 @@ def _make_args(**overrides) -> Args:
         simd=False,
         coroutine=False,
         ieee754=False,
+        rpc_smoke=False,
         wave2d_perf=None,
         environment=None,
         verbose=False,
@@ -150,6 +152,7 @@ def _make_ctx(**overrides) -> RunContext:
         simd_test_mode=False,
         coroutine_test_mode=False,
         ieee754_test_mode=False,
+        rpc_smoke_mode=False,
         wave2d_perf_grid=None,
         net_server_mode=False,
         net_client_mode=False,
@@ -1500,6 +1503,48 @@ class TestRunTestsOrSpecialMode:
         with patch(f"{_PATCH_MOD}.RpcClient", return_value=mock_client):
             rc = asyncio.run(_run_tests_or_special_mode(ctx, qctx))
         assert rc == 0
+
+    def test_rpc_smoke_mode_validates_core_surface(self) -> None:
+        ctx = _make_ctx(rpc_smoke_mode=True)
+        qctx = QuietContext(quiet=False)
+
+        def response(data):
+            item = MagicMock()
+            item.success = True
+            item.data = data
+            return item
+
+        mock_client = AsyncMock()
+        mock_client.send = AsyncMock(
+            side_effect=[
+                response({"methods": ["ping"]}),
+                response([{"name": "ping"}]),
+                response({"uptimeMs": 1}),
+                response({"uptimeMs": 2}),
+                response(
+                    {
+                        "received": {
+                            "text": "rp2040-rpc-smoke",
+                            "number": 2040,
+                            "nested": {"ok": True, "values": [1, 2, 3]},
+                        }
+                    }
+                ),
+                response({"ready": True}),
+                response([]),
+                response({"success": True}),
+                RpcError("RPC Error -32601: Method not found"),
+            ]
+        )
+        mock_client.connect = AsyncMock()
+        mock_client.drain_boot_output = AsyncMock()
+        mock_client.close = AsyncMock()
+
+        with patch(f"{_PATCH_MOD}.RpcClient", return_value=mock_client):
+            rc = asyncio.run(_run_tests_or_special_mode(ctx, qctx))
+
+        assert rc == 0
+        assert mock_client.send.await_count == 9
 
     def test_ble_mode_delegates(self) -> None:
         ctx = _make_ctx(ble_mode=True)

--- a/ci/tests/test_fbuild_default_selection.py
+++ b/ci/tests/test_fbuild_default_selection.py
@@ -95,6 +95,14 @@ def test_autoresearch_parse_args_warns_for_deprecated_fbuild_flags(
     assert "--no-fbuild is deprecated and has no effect" in captured.err
 
 
+def test_autoresearch_parse_args_supports_pin_free_rpc_smoke() -> None:
+    parsed = Args.parse_args(["rp2040", "--rpc-smoke"])
+
+    assert parsed.environment_positional == "rp2040"
+    assert parsed.rpc_smoke is True
+    assert parsed.auto_discover_pins is True
+
+
 def test_debug_attached_parse_args_warns_for_deprecated_fbuild_flags(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/ci/util/fbuild_runner.py
+++ b/ci/util/fbuild_runner.py
@@ -47,6 +47,7 @@ class FbuildCommandResult:
     success: bool
     output: str
     returncode: int | None = None
+    port: str | None = None
 
 
 @typechecked
@@ -622,7 +623,7 @@ def run_fbuild_deploy(
     timeout: float = 1800,
     quiet: bool = False,
     log_file: IO[str] | None = None,
-) -> bool:
+) -> FbuildCommandResult:
     """Deploy firmware using fbuild with optional monitoring.
 
     Uses the daemon's combined build+deploy path which checks the firmware
@@ -641,7 +642,8 @@ def run_fbuild_deploy(
         log_file: File to redirect verbose output to in quiet mode
 
     Returns:
-        True if deploy (and optional monitoring) succeeded, False otherwise
+        Structured result with success and the post-deploy application port
+        when fbuild reports one.
     """
     import subprocess
 
@@ -656,7 +658,7 @@ def run_fbuild_deploy(
     fbuild_exe = get_fbuild_executable()
     if fbuild_exe is None:
         print("BUILD+FLASH FAIL fbuild not found on PATH")
-        return False
+        return FbuildCommandResult(success=False, output="fbuild not found")
 
     cmd: list[str] = [
         fbuild_exe,
@@ -707,6 +709,12 @@ def run_fbuild_deploy(
             print(proc.stdout, file=out, end="")
         returncode = proc.returncode
         success = returncode == 0
+        returned_port: str | None = None
+        for line in proc.stdout.splitlines() if proc.stdout else []:
+            if line.startswith("FBUILD_DEPLOY_PORT="):
+                candidate = line.partition("=")[2].strip()
+                if candidate:
+                    returned_port = candidate
 
         elapsed = time.monotonic() - t0
         if quiet:
@@ -718,7 +726,12 @@ def run_fbuild_deploy(
             else:
                 print(f"\n❌ Deploy failed (fbuild) [{elapsed:.1f}s]\n")
 
-        return success
+        return FbuildCommandResult(
+            success=success,
+            output=proc.stdout or "",
+            returncode=returncode,
+            port=returned_port,
+        )
 
     except KeyboardInterrupt as ki:
         from ci.util.global_interrupt_handler import handle_keyboard_interrupt
@@ -729,11 +742,13 @@ def run_fbuild_deploy(
     except subprocess.TimeoutExpired:
         elapsed = time.monotonic() - t0
         print(f"BUILD+FLASH FAIL timeout after {elapsed:.1f}s")
-        return False
+        return FbuildCommandResult(
+            success=False, output=f"deploy timeout after {elapsed:.1f}s"
+        )
     except Exception as e:
         elapsed = time.monotonic() - t0
         print(f"BUILD+FLASH FAIL {e}")
-        return False
+        return FbuildCommandResult(success=False, output=f"deploy error: {e}")
 
 
 def run_fbuild_monitor(


### PR DESCRIPTION
Implements the first stock Raspberry Pi Pico bring-up phase for #3626, #3627, and #3628.\n\n- accepts --environment rp2040/--rpc-smoke without a pre-existing serial port\n- consumes fbuild's post-deploy FBUILD_DEPLOY_PORT marker\n- runs pin-free JSON-RPC discovery/help/ping/status/drivers/testNoSerial/error smoke\n- preserves list/scalar JSON-RPC response payloads\n- adds focused parser and RPC tests\n\nValidation: bash lint; 112 focused pytest tests passed. Hardware acceptance remains pending until the attached stock Pico is detected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an optional RPC smoke-test mode for RP2040 targets using `--rpc-smoke`.
  - The smoke test validates discovery, health checks, payload handling, status readiness, drivers, and expected error responses.
  - Deployment results can now report the application port, which is automatically used for subsequent checks.
- **Bug Fixes**
  - RPC responses now preserve arrays, scalars, and other non-object payloads without losing data.
- **Tests**
  - Added coverage for RPC smoke-test execution and command-line parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->