### PR TITLE
fix(autoresearch): tolerate empty RP2040 port marker

### DIFF
--- a/ci/util/fbuild_runner.py
+++ b/ci/util/fbuild_runner.py
@@ -711,8 +711,10 @@ def run_fbuild_deploy(
         success = returncode == 0
         returned_port: str | None = None
         for line in proc.stdout.splitlines() if proc.stdout else []:
-            if line.startswith("FBUILD_DEPLOY_PORT="):
-                candidate = line.partition("=")[2].strip()
+            marker = "FBUILD_DEPLOY_PORT="
+            if marker in line:
+                suffix = line.split(marker, 1)[1].strip()
+                candidate = suffix.split()[0] if suffix else ""
                 if candidate:
                     returned_port = candidate
 


### PR DESCRIPTION
Follow-up to #3633 and fbuild #1042. The fbuild deployer now correctly refuses unrelated COM ports while waiting for RP2040 CDC; this runner change handles the explicit empty marker without crashing and lets the deploy result report the real failure. Focused autoresearch tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment port detection when the port information appears alongside other output text.
  * Deployment handling now reliably extracts the assigned application port from varied command output formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->