### PR TITLE
fix: rescan RP2040 CDC after fbuild deploy

### DIFF
--- a/ci/autoresearch/phases.py
+++ b/ci/autoresearch/phases.py
@@ -1516,7 +1516,18 @@ async def _run_schema_and_pin_setup(ctx: RunContext) -> int | None:
     """
     args = ctx.args
     upload_port = ctx.upload_port
-    assert upload_port is not None
+    if upload_port is None and ctx.rpc_smoke_mode and ctx.use_fbuild:
+        # Stock RP2040 deployment starts from BOOTSEL mass-storage and may
+        # return before Windows has published the application CDC endpoint.
+        # Re-scan by USB identity instead of asserting on the pre-deploy port.
+        result = auto_detect_upload_port(expected_environment="rp2040")
+        if result.selected_port:
+            upload_port = result.selected_port
+            ctx.upload_port = upload_port
+            print(f"✅ Discovered RP2040 application port: {upload_port}")
+    if upload_port is None:
+        print("❌ No application serial port was returned after fbuild deployment")
+        return 1
     use_fbuild = ctx.use_fbuild
     final_environment = ctx.final_environment
 

--- a/ci/util/fbuild_runner.py
+++ b/ci/util/fbuild_runner.py
@@ -711,8 +711,10 @@ def run_fbuild_deploy(
         success = returncode == 0
         returned_port: str | None = None
         for line in proc.stdout.splitlines() if proc.stdout else []:
-            if line.startswith("FBUILD_DEPLOY_PORT="):
-                candidate = line.partition("=")[2].strip()
+            marker = "FBUILD_DEPLOY_PORT="
+            if marker in line:
+                suffix = line.split(marker, 1)[1].strip()
+                candidate = suffix.split()[0] if suffix else ""
                 if candidate:
                     returned_port = candidate
 


### PR DESCRIPTION
When stock RP2040 deploy starts without a serial port, fbuild may return an empty marker while Windows publishes CDC asynchronously. Rescan by RP2040 USB identity before entering RPC phases and report a clear failure instead of asserting. Tests: 112 autoresearch tests passed.