### PR TITLE
fix: flush watchdog RPC acknowledgement before hang

### DIFF
--- a/examples/AutoResearch/AutoResearch.ino
+++ b/examples/AutoResearch/AutoResearch.ino
@@ -589,7 +589,13 @@ void loop() {
     // and is reflashable.
     // ========================================================================
     if (g_autoresearch_state->deliberate_hang_requested) {
-        delay(200);  // give Serial TX FIFO time to flush
+        delay(200);  // give the RPC response time to enter the USB TX FIFO
+#if !defined(FL_IS_STUB) && !defined(FL_IS_WASM)
+        // Arduino-Pico's USB CDC stack may still have the JSON response in
+        // its buffered writer when the deliberate hang disables interrupts.
+        // Flush it explicitly so the host records the ACK before reset.
+        Serial.flush();
+#endif
         // noInterrupts() is an Arduino-only macro; guard it so the host stub
         // build (which compiles this .ino for the unit-test framework) doesn't
         // hit an undeclared identifier. On host the while(1) below still spins


### PR DESCRIPTION
Flush the USB CDC TX buffer after deliberateHang's response delay and before disabling interrupts. This makes the watchdog acceptance probe observe the required acknowledgement on RP2040 CDC. Existing 112 autoresearch tests pass; hardware retest pending board recovery.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved serial output reliability during deliberate watchdog-reset scenarios.
  * Ensured acknowledgment messages are fully transmitted before the system enters the intentional hang state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->