### PR TITLE
fix(autoresearch): use FastLED flush before watchdog hang

### DIFF
--- a/ci/tests/test_autoresearch_phases.py
+++ b/ci/tests/test_autoresearch_phases.py
@@ -1113,6 +1113,50 @@ class TestAutoDetectUploadPort:
         assert result.ok is True
         assert result.selected_port == "COM12"
 
+    def test_rp2040_requires_application_cdc_fingerprint(self) -> None:
+        """A nearby CP210x must never be selected for an RP2040 run."""
+        port = ListPortInfo("COM11")
+        port.description = "Silicon Labs CP210x USB to UART Bridge"
+        port.hwid = "USB VID:PID=10C4:EA60"
+        port.vid = 0x10C4
+        port.pid = 0xEA60
+        with patch(
+            "ci.util.port_utils.serial.tools.list_ports.comports",
+            return_value=[port],
+        ):
+            result = auto_detect_upload_port("rp2040")
+        assert result.ok is False
+        assert result.selected_port is None
+        assert "2E8A:000A" in (result.error_message or "")
+
+    def test_rp2040_application_cdc_fingerprint_matches(self) -> None:
+        port = ListPortInfo("COM11")
+        port.description = "USB Serial Device"
+        port.hwid = "USB VID:PID=2E8A:000A"
+        port.vid = 0x2E8A
+        port.pid = 0x000A
+        with patch(
+            "ci.util.port_utils.serial.tools.list_ports.comports",
+            return_value=[port],
+        ):
+            result = auto_detect_upload_port("rp2040")
+        assert result.ok is True
+        assert result.selected_port == "COM11"
+
+    def test_rpipico2_application_cdc_fingerprint_matches(self) -> None:
+        port = ListPortInfo("COM12")
+        port.description = "USB Serial Device"
+        port.hwid = "USB VID:PID=2E8A:000F"
+        port.vid = 0x2E8A
+        port.pid = 0x000F
+        with patch(
+            "ci.util.port_utils.serial.tools.list_ports.comports",
+            return_value=[port],
+        ):
+            result = auto_detect_upload_port("rpipico2")
+        assert result.ok is True
+        assert result.selected_port == "COM12"
+
     def test_lpc845brk_lpc_link2_cmsis_dap_fingerprint_matches(self) -> None:
         """LPC845-BRK with LPC-Link2 CMSIS-DAP firmware (1FC9:0132) is accepted.
 

--- a/ci/util/port_utils.py
+++ b/ci/util/port_utils.py
@@ -60,6 +60,15 @@ NO_WIFI_ENVIRONMENTS: set[str] = {"esp32h2", "esp32p4"}
 # has a richer fingerprint table; this map only carries the entries
 # autoresearch needs for default-port selection.
 ENVIRONMENT_TO_VCOM_VID_PIDS: dict[str, tuple[tuple[int, int], ...]] = {
+    # RP2040 Pico application CDC (the ROM BOOTSEL interface is 2E8A:0003
+    # and is intentionally not a serial port). Keep this fingerprint strict:
+    # falling back to an arbitrary CP210x/CH340 port can run RPC against a
+    # different attached board.
+    "rp2040": ((0x2E8A, 0x000A), (0x2E8A, 0x000F)),
+    "rpipico": ((0x2E8A, 0x000A),),
+    "rpipicow": ((0x2E8A, 0x000A),),
+    "rpipico2": ((0x2E8A, 0x000F),),
+    "rpipico2w": ((0x2E8A, 0x000F),),
     # LPC8xx family: the on-board debug probe can be either
     #   * LPC11U35 running the LPCXpresso VCOM firmware — 16C0:0483
     #     (the community "V-USB" VID:PID; shared with PJRC Teensy).

--- a/examples/AutoResearch/AutoResearch.ino
+++ b/examples/AutoResearch/AutoResearch.ino
@@ -594,7 +594,7 @@ void loop() {
         // Arduino-Pico's USB CDC stack may still have the JSON response in
         // its buffered writer when the deliberate hang disables interrupts.
         // Flush it explicitly so the host records the ACK before reset.
-        Serial.flush();
+        fl::flush(1000);  // ok autoresearch rpc serial - drain ACK before watchdog hang
 #endif
         // noInterrupts() is an Arduino-only macro; guard it so the host stub
         // build (which compiles this .ino for the unit-test framework) doesn't


### PR DESCRIPTION
Replace raw Serial.flush() with fl::flush() so the watchdog ACK drain follows FastLED's serial wrapper and passes AutoResearch lint. No PlatformIO deployment changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved automatic upload-port detection for RP2040-based boards and multiple RP2040 environment variants.
  * Prevented nearby CP210x devices from being incorrectly selected for RP2040 uploads.

* **Bug Fixes**
  * Improved acknowledgment handling during deliberate hang and watchdog-reset recovery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->