### PR TITLE
fix(autoresearch): complete RP2040 RPC watchdog handshake

### DIFF
--- a/ci/autoresearch/phases.py
+++ b/ci/autoresearch/phases.py
@@ -1915,7 +1915,9 @@ async def _run_watchdog_soak(ctx: RunContext) -> int:
             return 1
         before_uptime = before.data.get("uptimeMs")
         print(f"WATCHDOG: pre-reset ping uptimeMs={before_uptime}")
-        acknowledgement = await client.send("deliberateHang", args={}, timeout=8.0)
+        acknowledgement = await client.send(
+            "deliberateHang", args={}, timeout=8.0, return_on_ack=True
+        )
         if not acknowledgement.success:
             print(
                 f"RESULT: watchdog soak FAIL: deliberateHang acknowledgement "

--- a/ci/rpc_client.py
+++ b/ci/rpc_client.py
@@ -359,6 +359,7 @@ class RpcClient:
         args: list[Any] | dict[str, Any] | None = None,
         timeout: float | None = None,
         retries: int = 1,
+        return_on_ack: bool = False,
     ) -> RpcResponse:
         """Send JSON-RPC command and wait for response with mandatory ID correlation (async).
 
@@ -414,7 +415,9 @@ class RpcClient:
 
                 # Await response with ID matching (mandatory)
                 response = await self._wait_for_response(
-                    attempt_timeout, expected_id=request_id
+                    attempt_timeout,
+                    expected_id=request_id,
+                    return_on_ack=return_on_ack,
                 )
                 return response
 
@@ -582,7 +585,9 @@ class RpcClient:
             f"No response with key '{match_key}' after {retries} attempts"
         )
 
-    async def _wait_for_response(self, timeout: float, expected_id: int) -> RpcResponse:
+    async def _wait_for_response(
+        self, timeout: float, expected_id: int, return_on_ack: bool = False
+    ) -> RpcResponse:
         """Wait for and parse JSON-RPC response with mandatory ID matching (async).
 
         Args:
@@ -686,6 +691,13 @@ class RpcClient:
                         and "acknowledged" in response_data
                         and response_data["acknowledged"] is True
                     ):
+                        if return_on_ack:
+                            return RpcResponse(
+                                success=True,
+                                data=response_data,
+                                raw_line=line,
+                                _id=response_id,
+                            )
                         # ACK -> keep iterating the SAME generator so the
                         # final REMOTE response line goes to the SAME
                         # consumer. (Pre-#3219 fix recursed into a fresh

--- a/ci/tests/test_autoresearch_phases.py
+++ b/ci/tests/test_autoresearch_phases.py
@@ -1113,6 +1113,50 @@ class TestAutoDetectUploadPort:
         assert result.ok is True
         assert result.selected_port == "COM12"
 
+    def test_rp2040_requires_application_cdc_fingerprint(self) -> None:
+        """A nearby CP210x must never be selected for an RP2040 run."""
+        port = ListPortInfo("COM11")
+        port.description = "Silicon Labs CP210x USB to UART Bridge"
+        port.hwid = "USB VID:PID=10C4:EA60"
+        port.vid = 0x10C4
+        port.pid = 0xEA60
+        with patch(
+            "ci.util.port_utils.serial.tools.list_ports.comports",
+            return_value=[port],
+        ):
+            result = auto_detect_upload_port("rp2040")
+        assert result.ok is False
+        assert result.selected_port is None
+        assert "2E8A:000A" in (result.error_message or "")
+
+    def test_rp2040_application_cdc_fingerprint_matches(self) -> None:
+        port = ListPortInfo("COM11")
+        port.description = "USB Serial Device"
+        port.hwid = "USB VID:PID=2E8A:000A"
+        port.vid = 0x2E8A
+        port.pid = 0x000A
+        with patch(
+            "ci.util.port_utils.serial.tools.list_ports.comports",
+            return_value=[port],
+        ):
+            result = auto_detect_upload_port("rp2040")
+        assert result.ok is True
+        assert result.selected_port == "COM11"
+
+    def test_rpipico2_application_cdc_fingerprint_matches(self) -> None:
+        port = ListPortInfo("COM12")
+        port.description = "USB Serial Device"
+        port.hwid = "USB VID:PID=2E8A:000F"
+        port.vid = 0x2E8A
+        port.pid = 0x000F
+        with patch(
+            "ci.util.port_utils.serial.tools.list_ports.comports",
+            return_value=[port],
+        ):
+            result = auto_detect_upload_port("rpipico2")
+        assert result.ok is True
+        assert result.selected_port == "COM12"
+
     def test_lpc845brk_lpc_link2_cmsis_dap_fingerprint_matches(self) -> None:
         """LPC845-BRK with LPC-Link2 CMSIS-DAP firmware (1FC9:0132) is accepted.
 

--- a/ci/util/port_utils.py
+++ b/ci/util/port_utils.py
@@ -60,6 +60,15 @@ NO_WIFI_ENVIRONMENTS: set[str] = {"esp32h2", "esp32p4"}
 # has a richer fingerprint table; this map only carries the entries
 # autoresearch needs for default-port selection.
 ENVIRONMENT_TO_VCOM_VID_PIDS: dict[str, tuple[tuple[int, int], ...]] = {
+    # RP2040 Pico application CDC (the ROM BOOTSEL interface is 2E8A:0003
+    # and is intentionally not a serial port). Keep this fingerprint strict:
+    # falling back to an arbitrary CP210x/CH340 port can run RPC against a
+    # different attached board.
+    "rp2040": ((0x2E8A, 0x000A), (0x2E8A, 0x000F)),
+    "rpipico": ((0x2E8A, 0x000A),),
+    "rpipicow": ((0x2E8A, 0x000A),),
+    "rpipico2": ((0x2E8A, 0x000F),),
+    "rpipico2w": ((0x2E8A, 0x000F),),
     # LPC8xx family: the on-board debug probe can be either
     #   * LPC11U35 running the LPCXpresso VCOM firmware — 16C0:0483
     #     (the community "V-USB" VID:PID; shared with PJRC Teensy).

--- a/examples/AutoResearch/AutoResearch.ino
+++ b/examples/AutoResearch/AutoResearch.ino
@@ -594,7 +594,7 @@ void loop() {
         // Arduino-Pico's USB CDC stack may still have the JSON response in
         // its buffered writer when the deliberate hang disables interrupts.
         // Flush it explicitly so the host records the ACK before reset.
-        Serial.flush();
+        fl::flush(1000);  // ok autoresearch rpc serial - drain ACK before watchdog hang
 #endif
         // noInterrupts() is an Arduino-only macro; guard it so the host stub
         // build (which compiles this .ino for the unit-test framework) doesn't

--- a/examples/AutoResearch/AutoResearchRemoteSystemMethods.cpp
+++ b/examples/AutoResearch/AutoResearchRemoteSystemMethods.cpp
@@ -146,7 +146,7 @@ void AutoResearchRemoteControl::bindSystemMethods(fl::Remote& remote) {
         response.set("hangDelayMs", static_cast<int64_t>(200));
         response.set("watchdogExpected", true);
         return response;
-    });
+    }, fl::RpcMode::ASYNC);
 
     // Register "drivers" function - list available drivers
     remote.bind("drivers", [this](const fl::json& args) -> fl::json {


### PR DESCRIPTION
Completes the RP2040 AutoResearch RPC watchdog handshake by returning on the async acknowledgement before the intentional hang, while preserving strict response correlation. Includes the Pico runtime VID/PID mapping and no-port stock BOOTSEL flow already on this branch. Validation: uv run --no-sync pytest ci/tests/test_autoresearch_phases.py -q (91 passed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for automatically detecting USB serial ports across RP2040-based board environments.
  - Added asynchronous acknowledgement handling for long-running remote operations.

- **Bug Fixes**
  - Improved deliberate-hang recovery by ensuring acknowledgements are transmitted before the watchdog reset.
  - Watchdog soak testing now proceeds immediately after receiving confirmation, improving recovery reliability.
  - Added validation to avoid selecting incorrect USB serial devices during RP2040 detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->