### PR TITLE
fix(ci): prevent macOS 26 streaming runner hangs

### DIFF
--- a/ci/autoresearch/phases.py
+++ b/ci/autoresearch/phases.py
@@ -1931,6 +1931,8 @@ async def _run_watchdog_soak(ctx: RunContext) -> int:
     finally:
         try:
             await client.close()
+        except KeyboardInterrupt as ki:
+            handle_keyboard_interrupt(ki)
         except Exception:
             pass
 
@@ -1973,6 +1975,8 @@ async def _run_watchdog_soak(ctx: RunContext) -> int:
     finally:
         try:
             await recovery.close()
+        except KeyboardInterrupt as ki:
+            handle_keyboard_interrupt(ki)
         except Exception:
             pass
     ctx.upload_port = new_port

--- a/ci/meson/README.md
+++ b/ci/meson/README.md
@@ -46,7 +46,7 @@ The `ci.meson` package is organized into 9 focused modules following a tier-base
 
 ### Tier 4: Advanced Operations
 
-- **`streaming.py`** (~770 lines) - Parallel streaming compilation and testing
+- **`streaming.py`** (~770 lines) - Streaming compilation followed by parallel testing
   - Functions: `stream_compile_and_run_tests()`
 
 ### Tier 5: Orchestration
@@ -56,7 +56,7 @@ The `ci.meson` package is organized into 9 focused modules following a tier-base
   - Backed by: `runner_helpers.py`, `streaming_runner.py`, `sequential_runner.py`
 
 - **`runner_helpers.py`** (~420 lines) - Timing, recovery, cleanup, failure logs
-- **`streaming_runner.py`** (~360 lines) - Streaming compile + parallel test execution
+- **`streaming_runner.py`** (~360 lines) - Compile-then-run parallel test execution
 - **`sequential_runner.py`** (~545 lines) - Per-target compile + direct test invocation
 
 ## Migration Guide

--- a/ci/meson/streaming.py
+++ b/ci/meson/streaming.py
@@ -25,6 +25,7 @@ from ci.meson.link_retry import (
 from ci.meson.mtime_stabilizer import stabilize_dll_mtimes
 from ci.meson.output import print_error, print_success
 from ci.meson.phase_tracker import PhaseTracker
+from ci.util.cpu_count import cpu_count
 from ci.util.global_interrupt_handler import handle_keyboard_interrupt
 from ci.util.tee import StreamTee
 from ci.util.timestamp_print import ts_print as _ts_print
@@ -72,13 +73,13 @@ def stream_compile_only(
     compile_timeout: int = 600,
     build_optimizer: Optional[BuildOptimizer] = None,
     build_timer=None,
-    on_test_compiled: Optional[Callable[[Path], None]] = None,
 ) -> CompileOnlyResult:
     """
     Stream compilation only - collect all compiled test paths without running them.
 
-    Monitors Ninja output to detect when test executables finish linking,
-    collecting them for later execution.
+    Monitors Ninja output to collect test artifacts for later execution.
+    Ninja's ``Linking target`` line is a pre-link announcement, so callers
+    must not execute collected artifacts until this function returns success.
 
     Args:
         build_dir: Meson build directory
@@ -377,12 +378,6 @@ def stream_compile_only(
                             if verbose:
                                 _ts_print(f"[MESON] Test built: {test_path.name}")
                             compiled_tests.append(test_path)
-                            if on_test_compiled is not None:
-                                # Wait for DLL touch thread to finish before
-                                # submitting tests — os.utime() on Windows
-                                # conflicts with LoadLibrary (error 126).
-                                dll_touch_done.wait()
-                                on_test_compiled(test_path)
 
             # Check compilation result
             returncode = cast(int, proc.wait())
@@ -524,6 +519,14 @@ def stream_compile_only(
     while producer.is_alive():
         producer.join(timeout=0.2)
 
+    # The build optimizer may still be touching DLL mtimes after Ninja exits.
+    # Wait before stabilization and before returning artifacts to the caller;
+    # loading a DLL concurrently with os.utime() fails intermittently on
+    # Windows and can race the macOS dynamic loader.
+    # Poll so Ctrl+C remains responsive if the optimizer thread stalls.
+    while not dll_touch_done.wait(timeout=0.2):
+        pass
+
     # Record compilation completion checkpoint and end time for sub-phases
     compile_sub_phases["compile_done"] = time.time()
     if build_timer is not None:
@@ -556,11 +559,10 @@ def stream_compile_and_run_tests(
     max_failures: int = 10,
 ) -> StreamingResult:
     """
-    Stream test compilation and execution with overlap.
+    Compile test artifacts, then execute them concurrently.
 
-    Tests start executing as soon as they finish linking, while remaining
-    tests continue compiling. This reduces total wall-clock time compared
-    to a sequential compile-then-run approach.
+    Ninja emits link status before a library is safe to load. Compilation must
+    finish successfully before any test process starts (FastLED #3642).
 
     Args:
         build_dir: Meson build directory
@@ -580,10 +582,8 @@ def stream_compile_and_run_tests(
     if test_file_filter:
         setattr(test_callback, "_test_file_filter", test_file_filter)
 
-    # Prepare concurrent test execution infrastructure.
-    # Tests are submitted to the executor as they finish linking (during
-    # compilation), overlapping test execution with ongoing compilation.
-    max_workers = min(os.cpu_count() or 4, 16)
+    # Respect --no-parallel/NO_PARALLEL while retaining the existing cap.
+    max_workers = min(cpu_count(), 16)
     halt_event = threading.Event()
     _kill_all = getattr(test_callback, "kill_all", None)
 
@@ -607,38 +607,13 @@ def stream_compile_and_run_tests(
         except Exception as e:
             return _WorkerResult(test_path, TestResult(success=False), str(e))
 
-    # Do NOT use `with` for the executor — its __exit__ calls
-    # shutdown(wait=True) which blocks until every running worker
-    # finishes, making Ctrl+C unresponsive for up to 600s per test.
-    executor = concurrent.futures.ThreadPoolExecutor(max_workers=max_workers)
-    futures: list[concurrent.futures.Future[_WorkerResult]] = []
-    futures_lock = threading.Lock()
-
     # Prepare filter for test_file_filter
     filter_needle = (
         test_file_filter.replace(".hpp", "").lower() if test_file_filter else None
     )
 
-    def _on_test_compiled(test_path: Path) -> None:
-        """Submit a newly compiled test for execution immediately.
-
-        Called from the Ninja producer thread as each test finishes linking,
-        allowing test execution to overlap with ongoing compilation.
-        """
-        if halt_event.is_set():
-            return
-        if filter_needle and filter_needle not in test_path.name.lower():
-            return
-        try:
-            future = executor.submit(_run_one_test, test_path)
-        except RuntimeError:
-            # Executor was shut down (e.g. compilation failed concurrently)
-            return
-        with futures_lock:
-            futures.append(future)
-
-    # Compile and run tests with overlap — tests start executing as soon
-    # as they finish linking while remaining tests continue compiling.
+    # Compile every artifact before launching a dynamic-library runner. Ninja's
+    # link progress line is emitted before ld64/lld finishes writing the file.
     cr = stream_compile_only(
         build_dir=build_dir,
         target=target,
@@ -646,27 +621,56 @@ def stream_compile_and_run_tests(
         compile_timeout=compile_timeout,
         build_optimizer=build_optimizer,
         build_timer=build_timer,
-        on_test_compiled=_on_test_compiled,
     )
 
     if not cr.success:
-        # Compilation failed — cancel pending tests and shutdown
-        halt_event.set()
-        if _kill_all:
-            _kill_all()
-        with futures_lock:
-            for f in futures:
-                f.cancel()
-        executor.shutdown(wait=False, cancel_futures=True)
         return StreamingResult(
             success=False,
             compile_output=cr.compile_output,
             compile_sub_phases=cr.compile_sub_phases,
         )
 
-    # Take snapshot of futures (no more will be added after compile returns)
-    with futures_lock:
-        all_futures = list(futures)
+    # Do NOT use `with` for the executor — its __exit__ calls
+    # shutdown(wait=True) which blocks until every running worker
+    # finishes, making Ctrl+C unresponsive for up to 600s per test.
+    executor = concurrent.futures.ThreadPoolExecutor(max_workers=max_workers)
+    futures: list[concurrent.futures.Future[_WorkerResult]] = []
+
+    def _submit_test(test_path: Path) -> None:
+        """Submit a test only after the complete build succeeds."""
+        if halt_event.is_set():
+            return
+        if filter_needle and filter_needle not in test_path.name.lower():
+            return
+        try:
+            future = executor.submit(_run_one_test, test_path)
+        except RuntimeError:
+            # Executor was shut down during interruption/failure cleanup.
+            return
+        futures.append(future)
+
+    try:
+        for test_path in cr.compiled_tests:
+            _submit_test(test_path)
+    except KeyboardInterrupt as ki:
+        halt_event.set()
+        if _kill_all:
+            _kill_all()
+        for f in futures:
+            f.cancel()
+        executor.shutdown(wait=False, cancel_futures=True)
+        handle_keyboard_interrupt(ki)
+        raise
+    except Exception:
+        halt_event.set()
+        if _kill_all:
+            _kill_all()
+        for f in futures:
+            f.cancel()
+        executor.shutdown(wait=False, cancel_futures=True)
+        raise
+
+    all_futures = list(futures)
 
     if not all_futures:
         # No tests found during compilation (build was fully cached).
@@ -691,7 +695,6 @@ def stream_compile_and_run_tests(
     try:
         # Wait sequentially so output order matches submission order
         # (tests still execute in parallel across worker threads).
-        # Many tests will have already completed during compilation.
         for future in all_futures:
             if halt_event.is_set():
                 break

--- a/ci/meson/streaming_runner.py
+++ b/ci/meson/streaming_runner.py
@@ -2,8 +2,8 @@
 """Streaming execution path for ``run_meson_build_and_test``.
 
 Extracted from ``ci/meson/runner.py``. Runs ``stream_compile_and_run_tests``
-which compiles + executes tests in parallel — as soon as a test finishes
-linking it's launched while other tests are still compiling.
+which compiles all artifacts before executing tests in parallel. The phase
+boundary prevents dynamic loaders from opening partially linked libraries.
 
 This module owns the streaming-specific concerns: a test-callback closure
 that captures per-test output (so failures can be summarized at the end),
@@ -50,15 +50,10 @@ def validate_test_artifact(
     missing or stale, so the caller can surface the failure directly
     instead of silently running broken/old code.
 
-    Why this matters (FastLED #3011): the streaming compiler submits
-    tests to the runner as soon as Ninja prints ``[N/M] Linking <X>``
-    — but that line is Ninja's PRE-link announcement, NOT a success
-    signal. If the link then FAILS (zccache daemon crash under the
-    parallel-link storm, ld.lld permission error, etc.) ``test_path``
-    is either missing entirely (clean build) or stale from a previous
-    build sitting in the same build dir. Running it produces a
-    false pass or false fail; refusing to run it surfaces the link
-    failure where it belongs.
+    Why this matters (FastLED #3011): collected paths come from Ninja's
+    ``[N/M] Linking <X>`` PRE-link announcement. Execution is deferred until
+    the complete build succeeds (FastLED #3642), and this validator remains a
+    defense against a missing or stale artifact left by tool/cache anomalies.
     """
     if not test_path.exists():
         return TestResult(
@@ -271,10 +266,8 @@ def run_streaming_path(ctx: StreamingContext) -> MesonTestResult:
         """
         try:
             # FastLED #3011 — refuse to run missing or stale artifacts.
-            # The streaming compiler submits tests as soon as Ninja prints
-            # "Linking <X>" (a PRE-link announcement, not success). If
-            # the link then fails, what's at test_path is either nothing
-            # or yesterday's DLL — running it produces false pass / fail.
+            # Execution now waits for the full build (FastLED #3642), while
+            # this check preserves defense against anomalous cache/tool output.
             failure = validate_test_artifact(test_path, ctx.start_time)
             if failure is not None:
                 return failure

--- a/ci/tests/test_sketch_filter.py
+++ b/ci/tests/test_sketch_filter.py
@@ -735,9 +735,19 @@ class TestAutoResearchFilter:
 
         assert sketch_filter is not None, "AutoResearch should have a @filter directive"
         assert sketch_filter.require == {
-            "board": ["esp32s3", "esp32c6", "esp32p4", "teensy41", "teensy40"]
+            "board": [
+                "esp32s3",
+                "esp32c6",
+                "esp32p4",
+                "teensy41",
+                "teensy40",
+                "lpc845",
+                "lpc845brk",
+                "lpcxpresso845max",
+                "lpcxpresso804",
+            ]
         }
-        assert sketch_filter.exclude == {"memory": ["low"]}
+        assert sketch_filter.exclude == {}
 
     @pytest.mark.parametrize(
         "board_name",

--- a/ci/tests/test_streaming_runner_artifact_validation.py
+++ b/ci/tests/test_streaming_runner_artifact_validation.py
@@ -1,19 +1,47 @@
 """Tests for streaming-runner artifact validation (FastLED #3011).
 
-`validate_test_artifact` is the gate that catches the false-pass /
-false-fail mode where Ninja's "Linking <X>" announcement submits a
-test to the runner, the link then fails (e.g. zccache daemon crash
-under the parallel-link storm), and the runner loads either a
-missing DLL (clean build) or a stale one from a previous build.
+`validate_test_artifact` is the defense-in-depth gate for missing or stale
+artifacts. Execution waits for the full build to finish (FastLED #3642), and
+the validator catches anomalous cache/tool output before a runner loads it.
 """
 
+import concurrent.futures
+import os
 import time
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from typing import Any, Callable, TypeVar
+from unittest.mock import patch
 
-from ci.meson.streaming import TestResult  # noqa: E402
+from ci.meson.streaming import (  # noqa: E402
+    CompileOnlyResult,
+    stream_compile_and_run_tests,
+)
+from ci.meson.streaming import (
+    TestResult as StreamingTestResult,
+)
 from ci.meson.streaming_runner import validate_test_artifact  # noqa: E402
+
+
+_T = TypeVar("_T")
+
+
+class _ImmediateExecutor:
+    """Deterministic executor for testing compile/run phase ordering."""
+
+    def __init__(self, max_workers: int) -> None:
+        self.max_workers = max_workers
+
+    def submit(
+        self, fn: Callable[..., _T], /, *args: Any, **kwargs: Any
+    ) -> concurrent.futures.Future[_T]:
+        future: concurrent.futures.Future[_T] = concurrent.futures.Future()
+        future.set_result(fn(*args, **kwargs))
+        return future
+
+    def shutdown(self, wait: bool = True, *, cancel_futures: bool = False) -> None:
+        pass
 
 
 class TestValidateTestArtifact(unittest.TestCase):
@@ -35,7 +63,7 @@ class TestValidateTestArtifact(unittest.TestCase):
             build_start = time.time()
             result = validate_test_artifact(dll, build_start)
             self.assertIsNotNone(result)
-            assert isinstance(result, TestResult)
+            assert isinstance(result, StreamingTestResult)
             self.assertFalse(result.success)
             self.assertIn("Test artifact missing", result.output)
             self.assertIn(str(dll), result.output)
@@ -50,7 +78,7 @@ class TestValidateTestArtifact(unittest.TestCase):
             build_start = dll_mtime + 100.0  # 100 s AFTER the file was written
             result = validate_test_artifact(dll, build_start)
             self.assertIsNotNone(result)
-            assert isinstance(result, TestResult)
+            assert isinstance(result, StreamingTestResult)
             self.assertFalse(result.success)
             self.assertIn("Stale test artifact", result.output)
             self.assertIn(str(dll), result.output)
@@ -79,14 +107,113 @@ class TestValidateTestArtifact(unittest.TestCase):
 
             # Missing case
             missing = validate_test_artifact(dll, build_start)
-            assert isinstance(missing, TestResult)
+            assert isinstance(missing, StreamingTestResult)
             self.assertIn("re-run", missing.output.lower())
 
             # Stale case
             dll.write_bytes(b"old")
             stale = validate_test_artifact(dll, dll.stat().st_mtime + 5.0)
-            assert isinstance(stale, TestResult)
+            assert isinstance(stale, StreamingTestResult)
             self.assertIn("zccache stop", stale.output)
+
+
+class TestStreamingExecutionCoordination(unittest.TestCase):
+    """Streaming execution starts only after a successful compile phase."""
+
+    def test_test_starts_after_compile_completes(self) -> None:
+        """A pre-link status callback must not start a test process."""
+        test_path = Path("build/tests/example.dylib")
+        compile_finished = False
+        observed_compile_states: list[bool] = []
+
+        def fake_compile_only(*args: object, **kwargs: object) -> CompileOnlyResult:
+            callback = kwargs.get("on_test_compiled")
+            if callable(callback):
+                callback(test_path)
+
+            nonlocal compile_finished
+            compile_finished = True
+            return CompileOnlyResult(success=True, compiled_tests=[test_path])
+
+        def test_callback(path: Path) -> StreamingTestResult:
+            self.assertEqual(test_path, path)
+            observed_compile_states.append(compile_finished)
+            return StreamingTestResult(success=True)
+
+        with (
+            patch(
+                "ci.meson.streaming.stream_compile_only", side_effect=fake_compile_only
+            ),
+            patch(
+                "ci.meson.streaming.concurrent.futures.ThreadPoolExecutor",
+                side_effect=_ImmediateExecutor,
+            ),
+        ):
+            result = stream_compile_and_run_tests(Path("build"), test_callback)
+
+        self.assertTrue(result.success)
+        self.assertEqual([True], observed_compile_states)
+
+    def test_failed_compile_runs_no_tests(self) -> None:
+        """Artifacts mentioned before a failed link must never execute."""
+        test_path = Path("build/tests/stale.dylib")
+        executed_paths: list[Path] = []
+
+        def fake_compile_only(*args: object, **kwargs: object) -> CompileOnlyResult:
+            callback = kwargs.get("on_test_compiled")
+            if callable(callback):
+                callback(test_path)
+            return CompileOnlyResult(success=False, compiled_tests=[test_path])
+
+        def test_callback(path: Path) -> StreamingTestResult:
+            executed_paths.append(path)
+            return StreamingTestResult(success=True)
+
+        with (
+            patch(
+                "ci.meson.streaming.stream_compile_only", side_effect=fake_compile_only
+            ),
+            patch(
+                "ci.meson.streaming.concurrent.futures.ThreadPoolExecutor",
+                side_effect=_ImmediateExecutor,
+            ),
+        ):
+            result = stream_compile_and_run_tests(Path("build"), test_callback)
+
+        self.assertFalse(result.success)
+        self.assertEqual([], executed_paths)
+
+    def test_no_parallel_uses_one_worker(self) -> None:
+        """NO_PARALLEL must constrain the streaming executor to one worker."""
+        worker_counts: list[int] = []
+
+        def capture_executor(
+            max_workers: int,
+        ) -> _ImmediateExecutor:
+            worker_counts.append(max_workers)
+            return _ImmediateExecutor(max_workers=max_workers)
+
+        with (
+            patch.dict(os.environ, {"NO_PARALLEL": "1"}),
+            patch("ci.util.cpu_count.os.cpu_count", return_value=3),
+            patch(
+                "ci.meson.streaming.stream_compile_only",
+                return_value=CompileOnlyResult(
+                    success=True,
+                    compiled_tests=[Path("build/tests/example.dylib")],
+                ),
+            ),
+            patch(
+                "ci.meson.streaming.concurrent.futures.ThreadPoolExecutor",
+                side_effect=capture_executor,
+            ),
+        ):
+            result = stream_compile_and_run_tests(
+                Path("build"), lambda _: StreamingTestResult(success=True)
+            )
+
+        self.assertTrue(result.success)
+        self.assertEqual([1], worker_counts)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #3642

## Root cause

Ninja emits its Linking target progress line before ld64/lld has finished writing the dynamic library. The streaming path treated that line as completion and launched the shared runner against a partially linked artifact; macOS 26 can hang in dlopen before the runner watchdog starts. The same path also bypassed NO_PARALLEL.

## Resolution

- collect link targets during Ninja output, but launch nothing until the complete build succeeds and artifact mtimes are stable
- honor NO_PARALLEL through the shared CPU-count helper
- keep the cached-build fallback and make optimizer/submission waits cancellation-safe
- add deterministic regressions for compile/run ordering, failed-link suppression, and single-worker mode
- repair two current-master gate failures encountered during validation: KeyboardInterrupt cleanup handling and the AutoResearch filter expectation

## Validation

- RED: 3 focused regressions failed against the previous implementation
- GREEN: 86 focused streaming/filter tests passed
- bash lint
- clean bash test --cpp --clean --no-fingerprint: 350/350 passed
- Python suite with the documented Windows fbuild/QEMU skip: 501 passed, 40 skipped, 5 subtests passed
- pre-push review: clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved build-and-test reliability by completing compilation before launching tests.
  * Added support for parallel test execution while respecting no-parallel settings.
  * Strengthened validation to prevent missing, stale, or failed-build artifacts from running.

* **Bug Fixes**
  * Keyboard interrupts during cleanup are now preserved and handled correctly.

* **Documentation**
  * Updated build and test workflow documentation to reflect the revised execution order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->