### PR TITLE
fix(ci): prevent macOS ASan runner hangs

### DIFF
--- a/ci/meson/build_config.py
+++ b/ci/meson/build_config.py
@@ -246,7 +246,7 @@ def setup_meson_build(
 
     check_obsolete_zig_wrappers(source_dir)
 
-    compiler = detect_compiler_and_cache(markers, verbose)
+    compiler = detect_compiler_and_cache(markers, verbose, build_mode)
 
     # Late-stage compiler-version check: requires the detected compiler.
     if already_configured:
@@ -313,9 +313,13 @@ def setup_meson_build(
                 reconfigure=True,
             )
 
-    write_meson_native_file(native_file_path=native_file_path, compiler=compiler)
+    write_meson_native_file(
+        native_file_path=native_file_path,
+        compiler=compiler,
+        build_mode=build_mode,
+    )
 
-    env = build_setup_env(compiler)
+    env = build_setup_env(compiler, build_mode)
 
     if skip_meson_setup:
         handle_skip_meson_setup(

--- a/ci/meson/meson_setup_execute.py
+++ b/ci/meson/meson_setup_execute.py
@@ -75,6 +75,32 @@ def _resolve_xcode_tool(tool: str) -> str:
     return path
 
 
+def _resolve_xcode_sdk_root() -> str:
+    """Return the active macOS SDK root for direct Xcode compiler calls."""
+    try:
+        result = RunningProcess.run(
+            ["xcrun", "--sdk", "macosx", "--show-sdk-path"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+    except KeyboardInterrupt as ki:
+        handle_keyboard_interrupt(ki)
+        raise
+    except (subprocess.SubprocessError, OSError) as error:
+        raise RuntimeError(f"Unable to resolve the macOS SDK root: {error}") from error
+
+    if result.returncode != 0:
+        detail = result.stderr.strip() if result.stderr else "unknown xcrun error"
+        raise RuntimeError(f"Unable to resolve the macOS SDK root: {detail}")
+
+    path = result.stdout.strip()
+    if not path:
+        raise RuntimeError("xcrun returned no macOS SDK root")
+    return path
+
+
 def detect_compiler_and_cache(
     markers: MarkerPaths, verbose: bool, build_mode: str
 ) -> CompilerDetection:
@@ -200,6 +226,7 @@ def write_meson_native_file(
     try:
         is_windows = sys.platform.startswith("win") or os.name == "nt"
         is_darwin = sys.platform == "darwin"
+        apple_builtin_options = ""
 
         if is_darwin and build_mode == "debug":
             # macOS 26.4 deadlocks before main() with older ASan runtimes
@@ -209,6 +236,17 @@ def write_meson_native_file(
             c_compiler = f"['{_resolve_xcode_tool('clang')}']"
             cpp_compiler = f"['{_resolve_xcode_tool('clang++')}']"
             ar_tool = f"['{_resolve_xcode_tool('ar')}']"
+            sdk_root = _resolve_xcode_sdk_root()
+            # Directly invoking the Xcode toolchain binary does not select an
+            # SDK. Apply the active macOS SDK to compiler probes, compilation,
+            # and links so libc++, system libraries, and frameworks resolve.
+            apple_builtin_options = f"""
+[built-in options]
+c_args = ['-isysroot', '{sdk_root}']
+cpp_args = ['-isysroot', '{sdk_root}']
+c_link_args = ['-isysroot', '{sdk_root}']
+cpp_link_args = ['-isysroot', '{sdk_root}']
+"""
         else:
             fast = _resolve_fast_native_entries()
             if fast.cc is not None:
@@ -251,6 +289,7 @@ def write_meson_native_file(
 c = {c_compiler}
 cpp = {cpp_compiler}
 ar = {ar_tool}
+{apple_builtin_options}
 
 [host_machine]
 system = '{host_system}'
@@ -283,6 +322,7 @@ def build_setup_env(compiler: CompilerDetection, build_mode: str) -> dict[str, s
         env["CC"] = _resolve_xcode_tool("clang")
         env["CXX"] = _resolve_xcode_tool("clang++")
         env["AR"] = _resolve_xcode_tool("ar")
+        env["SDKROOT"] = _resolve_xcode_sdk_root()
         return env
 
     fast_compiler = _resolve_fast_compiler_binary()

--- a/ci/meson/meson_setup_execute.py
+++ b/ci/meson/meson_setup_execute.py
@@ -49,7 +49,35 @@ from ci.util.output_formatter import TimestampFormatter
 from ci.util.timestamp_print import ts_print as _ts_print
 
 
-def detect_compiler_and_cache(markers: MarkerPaths, verbose: bool) -> CompilerDetection:
+def _resolve_xcode_tool(tool: str) -> str:
+    """Return the selected Xcode tool path without relying on PATH shims."""
+    try:
+        result = RunningProcess.run(
+            ["xcrun", "--find", tool],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+    except KeyboardInterrupt as ki:
+        handle_keyboard_interrupt(ki)
+        raise
+    except (subprocess.SubprocessError, OSError) as error:
+        raise RuntimeError(f"Unable to resolve Xcode tool {tool!r}: {error}") from error
+
+    if result.returncode != 0:
+        detail = result.stderr.strip() if result.stderr else "unknown xcrun error"
+        raise RuntimeError(f"Unable to resolve Xcode tool {tool!r}: {detail}")
+
+    path = result.stdout.strip()
+    if not path:
+        raise RuntimeError(f"xcrun returned no path for Xcode tool {tool!r}")
+    return path
+
+
+def detect_compiler_and_cache(
+    markers: MarkerPaths, verbose: bool, build_mode: str
+) -> CompilerDetection:
     """Detect clang-tool-chain wrappers + zccache + version strings.
 
     Caches the compiler and zccache version strings via marker mtimes so we
@@ -89,10 +117,17 @@ def detect_compiler_and_cache(markers: MarkerPaths, verbose: bool) -> CompilerDe
             _ts_print("[MESON]   - clang-tool-chain-ar")
         raise RuntimeError("clang-tool-chain wrapper commands not available")
 
+    apple_debug = sys.platform == "darwin" and build_mode == "debug"
     current_compiler_version = ""
     version_from_cache = False
-    clangxx_path = Path(clangxx_wrapper)
-    if markers.compiler_version.exists() and clangxx_path.exists():
+    selected_clangxx = (
+        _resolve_xcode_tool("clang++") if apple_debug else clangxx_wrapper
+    )
+    clangxx_path = Path(selected_clangxx)
+    # Always query Apple debug clang. A marker written by the former Clang 19
+    # toolchain can be newer than the selected Xcode binary, and reusing that
+    # marker would retain ASan objects with an incompatible runtime ABI.
+    if not apple_debug and markers.compiler_version.exists() and clangxx_path.exists():
         try:
             compiler_mtime = clangxx_path.stat().st_mtime
             marker_mtime = markers.compiler_version.stat().st_mtime
@@ -106,9 +141,9 @@ def detect_compiler_and_cache(markers: MarkerPaths, verbose: bool) -> CompilerDe
         except OSError:
             pass
     if not version_from_cache:
-        fast_compiler = _resolve_fast_compiler_binary()
+        fast_compiler = None if apple_debug else _resolve_fast_compiler_binary()
         current_compiler_version = get_compiler_version(
-            fast_compiler if fast_compiler else clangxx_wrapper
+            fast_compiler if fast_compiler else selected_clangxx
         )
 
     current_zccache_version = ""
@@ -152,6 +187,7 @@ def write_meson_native_file(
     *,
     native_file_path: Path,
     compiler: CompilerDetection,
+    build_mode: str,
 ) -> None:
     """Generate/update the Meson native file with tool paths + platform info.
 
@@ -162,18 +198,27 @@ def write_meson_native_file(
     instead of timing out under zccache. See issue #2714.
     """
     try:
-        fast = _resolve_fast_native_entries()
-        if fast.cc is not None:
-            c_compiler = fast.cc
-            cpp_compiler = fast.cxx
-            ar_tool = fast.ar
-        else:
-            c_compiler = f"['{compiler.clang_wrapper}']"
-            cpp_compiler = f"['{compiler.clangxx_wrapper}']"
-            ar_tool = f"['{compiler.llvm_ar_wrapper}']"
-
         is_windows = sys.platform.startswith("win") or os.name == "nt"
         is_darwin = sys.platform == "darwin"
+
+        if is_darwin and build_mode == "debug":
+            # macOS 26.4 deadlocks before main() with older ASan runtimes
+            # (LLVM #200447). Xcode 26.4+ contains Apple's fixed compiler-rt,
+            # so compile and link sanitized Apple targets with the selected
+            # Xcode toolchain as one ABI-compatible unit.
+            c_compiler = f"['{_resolve_xcode_tool('clang')}']"
+            cpp_compiler = f"['{_resolve_xcode_tool('clang++')}']"
+            ar_tool = f"['{_resolve_xcode_tool('ar')}']"
+        else:
+            fast = _resolve_fast_native_entries()
+            if fast.cc is not None:
+                c_compiler = fast.cc
+                cpp_compiler = fast.cxx
+                ar_tool = fast.ar
+            else:
+                c_compiler = f"['{compiler.clang_wrapper}']"
+                cpp_compiler = f"['{compiler.clangxx_wrapper}']"
+                ar_tool = f"['{compiler.llvm_ar_wrapper}']"
 
         machine = platform.machine().lower()
         if machine in ("x86_64", "amd64"):
@@ -199,8 +244,8 @@ def write_meson_native_file(
 # This file is auto-generated by meson_runner.py to configure tool paths.
 # It persists across build regenerations when ninja detects meson.build changes.
 #
-# IMPORTANT: LLD linker is forced via -fuse-ld=lld in meson.build link_args.
-# This ensures consistent linker behavior across Windows, Linux, and macOS.
+# clang-tool-chain builds use LLD. Apple debug builds use Xcode clang + ld64
+# so the compiler instrumentation and fixed platform sanitizer runtime match.
 
 [binaries]
 c = {c_compiler}
@@ -223,7 +268,7 @@ endian = 'little'
         _ts_print(f"[MESON] Warning: Could not write native file: {e}", file=sys.stderr)
 
 
-def build_setup_env(compiler: CompilerDetection) -> dict[str, str]:
+def build_setup_env(compiler: CompilerDetection, build_mode: str) -> dict[str, str]:
     """Build the environment dict for ``meson setup``.
 
     Uses raw compiler binaries when resolvable (avoids ~3.6s Python wrapper
@@ -233,6 +278,12 @@ def build_setup_env(compiler: CompilerDetection) -> dict[str, str]:
     env = os.environ.copy()
     if compiler.cache_binary:
         env.setdefault("ZCCACHE_STRICT_PATHS", "absolute")
+
+    if sys.platform == "darwin" and build_mode == "debug":
+        env["CC"] = _resolve_xcode_tool("clang")
+        env["CXX"] = _resolve_xcode_tool("clang++")
+        env["AR"] = _resolve_xcode_tool("ar")
+        return env
 
     fast_compiler = _resolve_fast_compiler_binary()
     if fast_compiler:

--- a/ci/meson/native/meson.build
+++ b/ci/meson/native/meson.build
@@ -409,6 +409,23 @@ elif build_mode == 'profile'
   ]
 endif
 
+# The Apple runner watchdog can interrupt dyld while sanitizer initialization
+# holds loader locks. Compile its complete call chain without instrumentation so
+# the SIGALRM handler remains limited to async-signal-safe system calls.
+apple_runner_watchdog_libs = []
+if is_macos
+  apple_runner_watchdog_lib = static_library('apple_runner_watchdog',
+    files('../../../tests/shared/apple_runner_watchdog.cpp'),
+    cpp_args: runner_cpp_args + [
+      path_norm_I_src,
+      '-fno-sanitize=all',
+    ],
+    implicit_include_directories: false,
+    install: false
+  )
+  apple_runner_watchdog_libs += [apple_runner_watchdog_lib]
+endif
+
 # ============================================================================
 # Legacy aliases for backward compatibility
 # ============================================================================

--- a/ci/meson/native/meson.build
+++ b/ci/meson/native/meson.build
@@ -570,6 +570,7 @@ fastled_pch = custom_target('fastled_pch',
     '@INPUT@',
     '-o', '@OUTPUT@',
     '-MD', '-MF', '@DEPFILE@',
+    get_option('cpp_args'),          # Includes native-file SDK selection on Apple debug
     base_compile_args,
     '-fPIC',
     fastled_pch_abs_include_args,

--- a/ci/meson/native/meson.build
+++ b/ci/meson/native/meson.build
@@ -82,19 +82,6 @@ base_common = [
   '-fno-strict-aliasing',      # Prevent strict aliasing optimizations
 ]
 
-# macOS SDK 15+ can deadlock in ASan's pre-main global registration when an
-# instrumented executable dynamically loads instrumented libraries (Apple
-# Feedback FB16513866; FastLED #3642). Keep ASan heap/stack instrumentation and
-# UBSan enabled, but disable the affected ASan globals pass on Apple debug
-# builds. This must be applied to both runners and every library they load.
-apple_asan_dlopen_workaround_args = []
-if build_machine.system() == 'darwin'
-  apple_asan_dlopen_workaround_args = [
-    '-mllvm',
-    '-asan-globals=0',
-  ]
-endif
-
 # Stack trace preservation flags (used in debug and quick modes only)
 stack_trace_flags = [
   '-fno-omit-frame-pointer',      # Keep frame pointers for stack traces
@@ -117,7 +104,7 @@ if build_mode == 'debug'
     '-g3',                      # Full debug symbols (variables, macros, everything)
     '-fsanitize=address',       # Address sanitizer (detect memory errors)
     '-fsanitize=undefined',     # Undefined behavior sanitizer
-  ] + apple_asan_dlopen_workaround_args
+  ]
 elif build_mode == 'quick'
   # Quick mode: Default mode for fast development iteration
   # No optimization, no debug symbols, no sanitizers
@@ -257,6 +244,22 @@ if build_mode == 'debug'
     '-fsanitize=undefined',
     '-shared-libasan',  # Use shared ASan runtime (required for DLL architecture)
   ]
+  if is_macos
+    # macOS 26.4 deadlocks before main() with older ASan runtimes while they
+    # inspect dyld's shared cache (LLVM #200447, FastLED #3642). GitHub's
+    # macos-26 image ships Xcode 26.5 by default, whose compiler-rt contains
+    # Apple's fix. Keep clang-tool-chain for compilation, but make its driver
+    # link the platform-compatible Xcode sanitizer runtime.
+    xcrun_program = find_program('xcrun')
+    apple_clang_resource_dir = run_command(
+      xcrun_program,
+      'clang',
+      '-print-resource-dir',
+      check: true
+    ).stdout().strip()
+    sanitizer_link_args += ['-resource-dir=' + apple_clang_resource_dir]
+    message('Using Xcode sanitizer runtime: ' + apple_clang_resource_dir)
+  endif
 endif
 
 # ============================================================================
@@ -403,7 +406,7 @@ if build_mode == 'debug'
     '-g3',
     '-fsanitize=address',
     '-fsanitize=undefined',
-  ] + apple_asan_dlopen_workaround_args
+  ]
 elif build_mode == 'quick'
   runner_cpp_args += stack_trace_flags + [
     '-O1',

--- a/ci/meson/native/meson.build
+++ b/ci/meson/native/meson.build
@@ -82,6 +82,19 @@ base_common = [
   '-fno-strict-aliasing',      # Prevent strict aliasing optimizations
 ]
 
+# macOS SDK 15+ can deadlock in ASan's pre-main global registration when an
+# instrumented executable dynamically loads instrumented libraries (Apple
+# Feedback FB16513866; FastLED #3642). Keep ASan heap/stack instrumentation and
+# UBSan enabled, but disable the affected ASan globals pass on Apple debug
+# builds. This must be applied to both runners and every library they load.
+apple_asan_dlopen_workaround_args = []
+if build_machine.system() == 'darwin'
+  apple_asan_dlopen_workaround_args = [
+    '-mllvm',
+    '-asan-globals=0',
+  ]
+endif
+
 # Stack trace preservation flags (used in debug and quick modes only)
 stack_trace_flags = [
   '-fno-omit-frame-pointer',      # Keep frame pointers for stack traces
@@ -104,7 +117,7 @@ if build_mode == 'debug'
     '-g3',                      # Full debug symbols (variables, macros, everything)
     '-fsanitize=address',       # Address sanitizer (detect memory errors)
     '-fsanitize=undefined',     # Undefined behavior sanitizer
-  ]
+  ] + apple_asan_dlopen_workaround_args
 elif build_mode == 'quick'
   # Quick mode: Default mode for fast development iteration
   # No optimization, no debug symbols, no sanitizers
@@ -390,7 +403,7 @@ if build_mode == 'debug'
     '-g3',
     '-fsanitize=address',
     '-fsanitize=undefined',
-  ]
+  ] + apple_asan_dlopen_workaround_args
 elif build_mode == 'quick'
   runner_cpp_args += stack_trace_flags + [
     '-O1',

--- a/ci/meson/native/meson.build
+++ b/ci/meson/native/meson.build
@@ -185,14 +185,15 @@ example_compile_args = base_compile_args
 # ============================================================================
 # UNIFIED LINK CONFIGURATION
 # ============================================================================
-# clang-tool-chain provides uniform GNU-style behavior across all platforms.
-# This allows us to use the same link flags everywhere with minimal exceptions.
+# clang-tool-chain provides uniform GNU-style behavior across platforms. Apple
+# debug builds use the selected Xcode compiler/runtime together because macOS
+# 26.4 requires the fixed compiler-rt shipped with Xcode 26.4+.
 
 # Detect platform for the few remaining differences
 is_windows = build_machine.system() == 'windows'
 is_macos = build_machine.system() == 'darwin'
 
-# macOS uses ld64.lld which does not accept GNU-style --no-undefined.
+# macOS uses ld64 or ld64.lld, neither of which accepts GNU-style --no-undefined.
 # On macOS the linker errors on undefined symbols by default, so we just
 # omit the flag there. Windows and Linux LLD accept it as expected.
 # See FastLED #2612 and PR #2567.
@@ -222,6 +223,9 @@ endforeach
 # Core link arguments (shared by all targets)
 # ============================================================================
 core_link_args = ['-fuse-ld=lld']
+if is_macos and build_mode == 'debug'
+  core_link_args = []
+endif
 if build_mode == 'release'
   # Enable thin LTO at link time for release builds
   core_link_args += ['-flto=thin']
@@ -242,23 +246,11 @@ if build_mode == 'debug'
   sanitizer_link_args = [
     '-fsanitize=address',
     '-fsanitize=undefined',
-    '-shared-libasan',  # Use shared ASan runtime (required for DLL architecture)
   ]
-  if is_macos
-    # macOS 26.4 deadlocks before main() with older ASan runtimes while they
-    # inspect dyld's shared cache (LLVM #200447, FastLED #3642). GitHub's
-    # macos-26 image ships Xcode 26.5 by default, whose compiler-rt contains
-    # Apple's fix. Keep clang-tool-chain for compilation, but make its driver
-    # link the platform-compatible Xcode sanitizer runtime.
-    xcrun_program = find_program('xcrun')
-    apple_clang_resource_dir = run_command(
-      xcrun_program,
-      'clang',
-      '-print-resource-dir',
-      check: true
-    ).stdout().strip()
-    sanitizer_link_args += ['-resource-dir=' + apple_clang_resource_dir]
-    message('Using Xcode sanitizer runtime: ' + apple_clang_resource_dir)
+  if not is_macos
+    # Darwin only supports its shared sanitizer runtime and selects it by
+    # default. Other platforms need this explicit flag for the DLL architecture.
+    sanitizer_link_args += ['-shared-libasan']
   endif
 endif
 

--- a/ci/meson/runner.py
+++ b/ci/meson/runner.py
@@ -177,7 +177,7 @@ def run_meson_build_and_test(
         _setup_sanitizer_env(source_dir, verbose)
 
     _ts_print(f"Preparing build ({build_mode} mode)...")
-    _start_zccache_session(build_dir)
+    _start_zccache_session(build_dir, build_mode)
 
     phase_tracker = PhaseTracker(build_dir, build_mode)
     phase_tracker.set_phase("CONFIGURE")

--- a/ci/meson/runner.py
+++ b/ci/meson/runner.py
@@ -54,10 +54,25 @@ def _setup_sanitizer_env(source_dir: Path, verbose: bool) -> None:
         base_env=os.environ.copy(),
         compiler_flags=sanitizer_flags,
     )
+
+    if sys.platform == "darwin":
+        # Apple's Xcode ASan runtime on the macos-26 runner rejects
+        # detect_leaks=1 before main() with "not supported on this platform."
+        # LeakSanitizer is therefore unavailable on this runtime; keep all ASan
+        # and UBSan instrumentation active while disabling only that option.
+        asan_options = sanitizer_env.get("ASAN_OPTIONS", "")
+        options = [
+            option
+            for option in asan_options.split(":")
+            if option and not option.startswith("detect_leaks=")
+        ]
+        options.append("detect_leaks=0")
+        sanitizer_env["ASAN_OPTIONS"] = ":".join(options)
+
     os.environ.update(sanitizer_env)
 
     lsan_suppressions = source_dir / "tests" / "lsan_suppressions.txt"
-    if lsan_suppressions.exists():
+    if sys.platform != "darwin" and lsan_suppressions.exists():
         existing_lsan = os.environ.get("LSAN_OPTIONS", "")
         suppression_opt = f"suppressions={lsan_suppressions}"
         if existing_lsan:

--- a/ci/meson/runner_helpers.py
+++ b/ci/meson/runner_helpers.py
@@ -355,15 +355,15 @@ def _write_testlog_failures(build_dir: Path, log_dir: Path) -> None:
         _write_failure_log(log_dir, safe_name, "run", content)
 
 
-def _start_zccache_session(build_dir: Path) -> None:
+def _start_zccache_session(build_dir: Path, build_mode: str) -> None:
     """Start a zccache session with logging to the build directory.
 
     Sets ZCCACHE_SESSION_ID in os.environ so all subsequent compiler
     invocations through zccache use this session and get logged.
     The session auto-cleans up via PID monitoring when the process exits.
 
-    Also sets ZCCACHE_LINK_DEPLOY_CMD so zccache invokes
-    `clang-tool-chain-libdeploy` after each cache-miss link. This
+    Except for Apple debug builds, also sets ZCCACHE_LINK_DEPLOY_CMD so
+    zccache invokes `clang-tool-chain-libdeploy` after each cache-miss link. This
     materializes runtime DLLs next to the linked binary (on Windows
     these otherwise don't get deployed because the native ctc-clang++
     trampoline skips Python post-link hooks) and lets zccache's
@@ -371,7 +371,13 @@ def _start_zccache_session(build_dir: Path) -> None:
     fixing flaky error-126 DLL load failures under parallel test
     execution. See https://github.com/FastLED/FastLED/issues/2329.
     """
-    if "ZCCACHE_LINK_DEPLOY_CMD" not in os.environ:
+    if sys.platform == "darwin" and build_mode == "debug":
+        # Apple sanitizer builds use Xcode clang and compiler-rt as one matched
+        # toolchain. clang-tool-chain-libdeploy sources the bundled compiler-rt
+        # and can reintroduce the older, ABI-incompatible ASan runtime after the
+        # link, so it must not run on this path.
+        os.environ.pop("ZCCACHE_LINK_DEPLOY_CMD", None)
+    elif "ZCCACHE_LINK_DEPLOY_CMD" not in os.environ:
         os.environ["ZCCACHE_LINK_DEPLOY_CMD"] = "clang-tool-chain-libdeploy"
     os.environ.setdefault("ZCCACHE_STRICT_PATHS", "absolute")
     # ZCCACHE_PROBE_BYPASS=1 setdefault removed as a probe per #3129 A9

--- a/ci/meson/streaming.py
+++ b/ci/meson/streaming.py
@@ -35,6 +35,10 @@ from ci.util.timestamp_print import ts_print as _ts_print
 # runner.exe / example_runner.exe (Windows-only transient failure; see #2268).
 _LLD_PERM_DENIED_MAX_RETRIES = 3
 
+# DLL mtime optimization should take milliseconds. Bound the wait so a hung
+# filesystem operation cannot stall the entire build indefinitely.
+_DLL_TOUCH_MAX_WAIT_SECONDS = 30.0
+
 
 @dataclass
 class StreamingResult:
@@ -64,6 +68,17 @@ class CompileOnlyResult:
     compile_output: str = ""
     compiled_tests: list[Path] = field(default_factory=list)
     compile_sub_phases: dict[str, float] = field(default_factory=dict)
+
+
+def _wait_for_dll_touch(done: threading.Event, timeout: float) -> bool:
+    """Wait for DLL mtime optimization while keeping Ctrl+C responsive."""
+    deadline = time.monotonic() + timeout
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return done.is_set()
+        if done.wait(timeout=min(0.2, remaining)):
+            return True
 
 
 def stream_compile_only(
@@ -523,9 +538,16 @@ def stream_compile_only(
     # Wait before stabilization and before returning artifacts to the caller;
     # loading a DLL concurrently with os.utime() fails intermittently on
     # Windows and can race the macOS dynamic loader.
-    # Poll so Ctrl+C remains responsive if the optimizer thread stalls.
-    while not dll_touch_done.wait(timeout=0.2):
-        pass
+    # Poll so Ctrl+C remains responsive, but fail instead of hanging forever
+    # if the optimizer thread stalls in a filesystem operation.
+    touch_timeout = min(float(compile_timeout), _DLL_TOUCH_MAX_WAIT_SECONDS)
+    if not _wait_for_dll_touch(dll_touch_done, touch_timeout):
+        timeout_message = (
+            f"[MESON] DLL mtime optimization timed out after {touch_timeout:.1f}s"
+        )
+        print_error(timeout_message)
+        compilation_output = f"{compilation_output}\n{timeout_message}".strip()
+        compilation_failed = True
 
     # Record compilation completion checkpoint and end time for sub-phases
     compile_sub_phases["compile_done"] = time.time()

--- a/ci/meson/streaming_runner.py
+++ b/ci/meson/streaming_runner.py
@@ -12,6 +12,7 @@ stale-build recovery retry, and the no-tests-ran fallback.
 """
 
 import os
+import sys
 import threading
 import time
 from dataclasses import dataclass
@@ -38,6 +39,45 @@ from ci.meson.test_execution import MesonTestResult, run_meson_test
 from ci.util.global_interrupt_handler import handle_keyboard_interrupt
 from ci.util.output_formatter import TimestampFormatter
 from ci.util.timestamp_print import ts_print as _ts_print
+
+
+_DEFAULT_TEST_PROCESS_TIMEOUT_SECONDS = 600
+_MACOS_TEST_PROCESS_TIMEOUT_SECONDS = 90
+
+
+def _test_process_timeout_seconds() -> int:
+    """Return the outer runner timeout for the current platform.
+
+    Apple runners have their own 20-second watchdog.  Keep a wider Python
+    deadline so normal watchdog diagnostics can flush, while still bounding a
+    pre-main sanitizer/dyld stall that cannot arm the in-process watchdog.
+    """
+    if sys.platform == "darwin":
+        return _MACOS_TEST_PROCESS_TIMEOUT_SECONDS
+    return _DEFAULT_TEST_PROCESS_TIMEOUT_SECONDS
+
+
+def _wait_for_test_process(proc: RunningProcess) -> TestResult:
+    """Wait for a runner and retain its captured output on every failure.
+
+    ``RunningProcess.wait()`` raises on timeout after killing the child.  The
+    captured stream remains available on ``proc.stdout``; include it in the
+    returned failure so phase markers and sanitizer diagnostics reach CI logs.
+    """
+    try:
+        returncode = proc.wait(echo=False)
+    except KeyboardInterrupt as ki:
+        handle_keyboard_interrupt(ki)
+        raise
+    except Exception as error:
+        captured = str(proc.stdout)
+        output = f"[MESON] Test execution error: {error}"
+        if captured:
+            output += f"\n[MESON] Captured runner output:\n{captured}"
+        return TestResult(success=False, output=output)
+
+    captured = str(proc.stdout)
+    return TestResult(success=returncode == 0, output=captured)
 
 
 def validate_test_artifact(
@@ -298,7 +338,7 @@ def run_streaming_path(ctx: StreamingContext) -> MesonTestResult:
             proc = RunningProcess(
                 cmd,
                 cwd=ctx.source_dir,
-                timeout=600,
+                timeout=_test_process_timeout_seconds(),
                 auto_run=True,
                 check=False,
                 env=env,
@@ -308,17 +348,16 @@ def run_streaming_path(ctx: StreamingContext) -> MesonTestResult:
             with active_procs_lock:
                 active_procs.add(proc)
             try:
-                returncode = proc.wait(echo=False)
+                result = _wait_for_test_process(proc)
             finally:
                 with active_procs_lock:
                     active_procs.discard(proc)
-            captured = str(proc.stdout)
 
-            if returncode != 0:
+            if not result.success:
                 with failed_outputs_lock:
-                    failed_test_outputs[test_path.stem] = captured
+                    failed_test_outputs[test_path.stem] = result.output
 
-            return TestResult(success=returncode == 0, output=captured)
+            return result
 
         except KeyboardInterrupt as ki:
             handle_keyboard_interrupt(ki)
@@ -327,10 +366,13 @@ def run_streaming_path(ctx: StreamingContext) -> MesonTestResult:
                 output="[MESON] Test interrupted by user",
             )
         except Exception as e:
-            return TestResult(
+            result = TestResult(
                 success=False,
                 output=f"[MESON] Test execution error: {e}",
             )
+            with failed_outputs_lock:
+                failed_test_outputs[test_path.stem] = result.output
+            return result
 
     def _kill_active_procs() -> None:
         """Kill all running test subprocesses (called on halt)."""

--- a/ci/tests/test_meson_native_toolchain.py
+++ b/ci/tests/test_meson_native_toolchain.py
@@ -17,6 +17,7 @@ from ci.meson.meson_setup_execute import (
     write_meson_native_file,
 )
 from ci.meson.meson_setup_phases import CompilerDetection, MarkerPaths
+from ci.meson.runner import _setup_sanitizer_env
 from ci.meson.runner_helpers import _start_zccache_session
 
 
@@ -211,6 +212,36 @@ class TestMesonNativeToolchain(unittest.TestCase):
             with self.subTest(meson_file=relative_path.as_posix()):
                 content = (project_root / relative_path).read_text(encoding="utf-8")
                 self.assertIn("get_option('cpp_args')", content)
+
+    def test_apple_debug_disables_unsupported_leak_detection(self) -> None:
+        import clang_tool_chain
+
+        prepared = {
+            "ASAN_OPTIONS": "fast_unwind_on_malloc=0:symbolize=1:detect_leaks=1",
+            "LSAN_OPTIONS": "symbolize=1",
+        }
+        with (
+            TemporaryDirectory() as temp_dir,
+            patch("ci.meson.runner.sys.platform", "darwin"),
+            patch.dict(
+                clang_tool_chain.__dict__,
+                {"prepare_sanitizer_environment": lambda **_kwargs: prepared},
+            ),
+            patch.dict(os.environ, {}, clear=True),
+        ):
+            source_dir = Path(temp_dir)
+            suppressions = source_dir / "tests" / "lsan_suppressions.txt"
+            suppressions.parent.mkdir()
+            suppressions.write_text("leak:known_false_positive\n", encoding="utf-8")
+            _setup_sanitizer_env(source_dir, verbose=False)
+            options = os.environ["ASAN_OPTIONS"].split(":")
+            lsan_options = os.environ["LSAN_OPTIONS"]
+
+        self.assertIn("fast_unwind_on_malloc=0", options)
+        self.assertIn("symbolize=1", options)
+        self.assertIn("detect_leaks=0", options)
+        self.assertNotIn("detect_leaks=1", options)
+        self.assertNotIn("suppressions=", lsan_options)
 
     def test_apple_non_debug_keeps_clang_tool_chain(self) -> None:
         compiler = self._compiler()

--- a/ci/tests/test_meson_native_toolchain.py
+++ b/ci/tests/test_meson_native_toolchain.py
@@ -10,6 +10,7 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 from ci.meson.meson_setup_execute import (
+    _resolve_xcode_sdk_root,
     _resolve_xcode_tool,
     build_setup_env,
     detect_compiler_and_cache,
@@ -64,6 +65,27 @@ class TestMesonNativeToolchain(unittest.TestCase):
         ):
             _resolve_xcode_tool("clang")
 
+    def test_xcode_sdk_root_resolution_uses_running_process(self) -> None:
+        completed = SimpleNamespace(
+            returncode=0,
+            stdout="/Applications/Xcode.app/SDKs/MacOSX.sdk\n",
+            stderr="",
+        )
+        with patch(
+            "ci.meson.meson_setup_execute.RunningProcess.run",
+            return_value=completed,
+        ) as run:
+            path = _resolve_xcode_sdk_root()
+
+        self.assertEqual(path, "/Applications/Xcode.app/SDKs/MacOSX.sdk")
+        run.assert_called_once_with(
+            ["xcrun", "--sdk", "macosx", "--show-sdk-path"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+
     def test_apple_debug_uses_one_xcode_toolchain(self) -> None:
         """Sanitized Apple objects and runtimes must have matching ASan ABIs."""
         compiler = self._compiler()
@@ -82,6 +104,10 @@ class TestMesonNativeToolchain(unittest.TestCase):
                     "ci.meson.meson_setup_execute._resolve_xcode_tool",
                     side_effect=xcode_tools.__getitem__,
                 ),
+                patch(
+                    "ci.meson.meson_setup_execute._resolve_xcode_sdk_root",
+                    return_value="/Applications/Xcode.app/SDKs/MacOSX.sdk",
+                ),
             ):
                 write_meson_native_file(
                     native_file_path=native_file,
@@ -95,6 +121,14 @@ class TestMesonNativeToolchain(unittest.TestCase):
         self.assertIn("cpp = ['/Applications/Xcode.app/usr/bin/clang++']", content)
         self.assertIn("ar = ['/Applications/Xcode.app/usr/bin/ar']", content)
         self.assertIn("system = 'darwin'", content)
+        self.assertIn(
+            "cpp_args = ['-isysroot', '/Applications/Xcode.app/SDKs/MacOSX.sdk']",
+            content,
+        )
+        self.assertIn(
+            "cpp_link_args = ['-isysroot', '/Applications/Xcode.app/SDKs/MacOSX.sdk']",
+            content,
+        )
         self.assertNotIn("clang-tool-chain-cpp", content)
 
     def test_apple_debug_ignores_stale_compiler_version_marker(self) -> None:
@@ -153,6 +187,10 @@ class TestMesonNativeToolchain(unittest.TestCase):
                 side_effect=xcode_tools.__getitem__,
             ),
             patch(
+                "ci.meson.meson_setup_execute._resolve_xcode_sdk_root",
+                return_value="/Xcode/SDKs/MacOSX.sdk",
+            ),
+            patch(
                 "ci.meson.meson_setup_execute._resolve_fast_compiler_binary"
             ) as resolve_fast,
         ):
@@ -161,7 +199,18 @@ class TestMesonNativeToolchain(unittest.TestCase):
         self.assertEqual(env["CC"], xcode_tools["clang"])
         self.assertEqual(env["CXX"], xcode_tools["clang++"])
         self.assertEqual(env["AR"], xcode_tools["ar"])
+        self.assertEqual(env["SDKROOT"], "/Xcode/SDKs/MacOSX.sdk")
         resolve_fast.assert_not_called()
+
+    def test_custom_pch_commands_inherit_native_cpp_args(self) -> None:
+        project_root = Path(__file__).parents[2]
+        for relative_path in (
+            Path("ci/meson/native/meson.build"),
+            Path("tests/meson.build"),
+        ):
+            with self.subTest(meson_file=relative_path.as_posix()):
+                content = (project_root / relative_path).read_text(encoding="utf-8")
+                self.assertIn("get_option('cpp_args')", content)
 
     def test_apple_non_debug_keeps_clang_tool_chain(self) -> None:
         compiler = self._compiler()

--- a/ci/tests/test_meson_native_toolchain.py
+++ b/ci/tests/test_meson_native_toolchain.py
@@ -1,0 +1,220 @@
+"""Regression coverage for platform-specific Meson compiler selection."""
+
+from __future__ import annotations
+
+import os
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from ci.meson.meson_setup_execute import (
+    _resolve_xcode_tool,
+    build_setup_env,
+    detect_compiler_and_cache,
+    write_meson_native_file,
+)
+from ci.meson.meson_setup_phases import CompilerDetection, MarkerPaths
+from ci.meson.runner_helpers import _start_zccache_session
+
+
+class TestMesonNativeToolchain(unittest.TestCase):
+    @staticmethod
+    def _compiler() -> CompilerDetection:
+        return CompilerDetection(
+            clang_wrapper="/venv/clang-tool-chain-c",
+            clangxx_wrapper="/venv/clang-tool-chain-cpp",
+            llvm_ar_wrapper="/venv/clang-tool-chain-ar",
+            cache_binary=None,
+            cache_name=None,
+            compiler_version="clang 19",
+            zccache_version="",
+        )
+
+    def test_xcode_tool_resolution_uses_running_process(self) -> None:
+        completed = SimpleNamespace(
+            returncode=0,
+            stdout="/Applications/Xcode.app/usr/bin/clang\n",
+            stderr="",
+        )
+        with patch(
+            "ci.meson.meson_setup_execute.RunningProcess.run",
+            return_value=completed,
+        ) as run:
+            path = _resolve_xcode_tool("clang")
+
+        self.assertEqual(path, "/Applications/Xcode.app/usr/bin/clang")
+        run.assert_called_once_with(
+            ["xcrun", "--find", "clang"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+
+    def test_xcode_tool_resolution_propagates_failure(self) -> None:
+        completed = SimpleNamespace(returncode=1, stdout="", stderr="not found")
+        with (
+            patch(
+                "ci.meson.meson_setup_execute.RunningProcess.run",
+                return_value=completed,
+            ),
+            self.assertRaisesRegex(RuntimeError, "not found"),
+        ):
+            _resolve_xcode_tool("clang")
+
+    def test_apple_debug_uses_one_xcode_toolchain(self) -> None:
+        """Sanitized Apple objects and runtimes must have matching ASan ABIs."""
+        compiler = self._compiler()
+        xcode_tools = {
+            "clang": "/Applications/Xcode.app/usr/bin/clang",
+            "clang++": "/Applications/Xcode.app/usr/bin/clang++",
+            "ar": "/Applications/Xcode.app/usr/bin/ar",
+        }
+
+        with TemporaryDirectory() as temp_dir:
+            native_file = Path(temp_dir) / "native.ini"
+            with (
+                patch("ci.meson.meson_setup_execute.sys.platform", "darwin"),
+                patch("ci.meson.meson_setup_execute.os.name", "posix"),
+                patch(
+                    "ci.meson.meson_setup_execute._resolve_xcode_tool",
+                    side_effect=xcode_tools.__getitem__,
+                ),
+            ):
+                write_meson_native_file(
+                    native_file_path=native_file,
+                    compiler=compiler,
+                    build_mode="debug",
+                )
+
+            content = native_file.read_text(encoding="utf-8")
+
+        self.assertIn("c = ['/Applications/Xcode.app/usr/bin/clang']", content)
+        self.assertIn("cpp = ['/Applications/Xcode.app/usr/bin/clang++']", content)
+        self.assertIn("ar = ['/Applications/Xcode.app/usr/bin/ar']", content)
+        self.assertIn("system = 'darwin'", content)
+        self.assertNotIn("clang-tool-chain-cpp", content)
+
+    def test_apple_debug_ignores_stale_compiler_version_marker(self) -> None:
+        """Migrating from Clang 19 must invalidate incompatible ASan objects."""
+        with TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            markers = MarkerPaths.for_build_dir(temp_path)
+            xcode_clangxx = temp_path / "Xcode" / "usr" / "bin" / "clang++"
+            xcode_clangxx.parent.mkdir(parents=True)
+            xcode_clangxx.touch()
+            markers.compiler_version.write_text("clang 19", encoding="utf-8")
+            newer_marker_time = xcode_clangxx.stat().st_mtime + 10
+            os.utime(markers.compiler_version, (newer_marker_time, newer_marker_time))
+
+            wrappers = {
+                "clang-tool-chain-c": "/venv/clang-tool-chain-c",
+                "clang-tool-chain-cpp": "/venv/clang-tool-chain-cpp",
+                "clang-tool-chain-ar": "/venv/clang-tool-chain-ar",
+            }
+            with (
+                patch("ci.meson.meson_setup_execute.sys.platform", "darwin"),
+                patch(
+                    "ci.meson.meson_setup_execute.shutil.which",
+                    side_effect=wrappers.get,
+                ),
+                patch(
+                    "ci.meson.meson_setup_execute._resolve_xcode_tool",
+                    return_value=str(xcode_clangxx),
+                ),
+                patch(
+                    "ci.meson.meson_setup_execute._find_zccache_binary",
+                    return_value=None,
+                ),
+                patch(
+                    "ci.meson.meson_setup_execute.get_compiler_version",
+                    return_value="Apple clang 17.0.0",
+                ) as get_version,
+            ):
+                detected = detect_compiler_and_cache(
+                    markers, verbose=False, build_mode="debug"
+                )
+
+        self.assertEqual(detected.compiler_version, "Apple clang 17.0.0")
+        get_version.assert_called_once_with(str(xcode_clangxx))
+
+    def test_apple_debug_setup_environment_uses_xcode_tools(self) -> None:
+        xcode_tools = {
+            "clang": "/Xcode/usr/bin/clang",
+            "clang++": "/Xcode/usr/bin/clang++",
+            "ar": "/Xcode/usr/bin/ar",
+        }
+        with (
+            patch("ci.meson.meson_setup_execute.sys.platform", "darwin"),
+            patch(
+                "ci.meson.meson_setup_execute._resolve_xcode_tool",
+                side_effect=xcode_tools.__getitem__,
+            ),
+            patch(
+                "ci.meson.meson_setup_execute._resolve_fast_compiler_binary"
+            ) as resolve_fast,
+        ):
+            env = build_setup_env(self._compiler(), build_mode="debug")
+
+        self.assertEqual(env["CC"], xcode_tools["clang"])
+        self.assertEqual(env["CXX"], xcode_tools["clang++"])
+        self.assertEqual(env["AR"], xcode_tools["ar"])
+        resolve_fast.assert_not_called()
+
+    def test_apple_non_debug_keeps_clang_tool_chain(self) -> None:
+        compiler = self._compiler()
+        with TemporaryDirectory() as temp_dir:
+            native_file = Path(temp_dir) / "native.ini"
+            with (
+                patch("ci.meson.meson_setup_execute.sys.platform", "darwin"),
+                patch("ci.meson.meson_setup_execute.os.name", "posix"),
+                patch(
+                    "ci.meson.meson_setup_execute._resolve_fast_native_entries",
+                    return_value=SimpleNamespace(cc=None, cxx=None, ar=None),
+                ),
+                patch(
+                    "ci.meson.meson_setup_execute._resolve_xcode_tool"
+                ) as resolve_xcode,
+            ):
+                write_meson_native_file(
+                    native_file_path=native_file,
+                    compiler=compiler,
+                    build_mode="quick",
+                )
+
+            content = native_file.read_text(encoding="utf-8")
+
+        self.assertIn("c = ['/venv/clang-tool-chain-c']", content)
+        self.assertIn("cpp = ['/venv/clang-tool-chain-cpp']", content)
+        resolve_xcode.assert_not_called()
+
+    def test_apple_debug_disables_clang_tool_chain_runtime_deployer(self) -> None:
+        with (
+            patch("ci.meson.runner_helpers.sys.platform", "darwin"),
+            patch("ci.meson.runner_helpers._find_zccache_binary", return_value=None),
+            patch.dict(
+                os.environ,
+                {"ZCCACHE_LINK_DEPLOY_CMD": "clang-tool-chain-libdeploy"},
+                clear=False,
+            ),
+        ):
+            _start_zccache_session(Path("unused"), build_mode="debug")
+            self.assertNotIn("ZCCACHE_LINK_DEPLOY_CMD", os.environ)
+
+    def test_apple_non_debug_keeps_runtime_deployer(self) -> None:
+        with (
+            patch("ci.meson.runner_helpers.sys.platform", "darwin"),
+            patch("ci.meson.runner_helpers._find_zccache_binary", return_value=None),
+            patch.dict(os.environ, {}, clear=True),
+        ):
+            _start_zccache_session(Path("unused"), build_mode="quick")
+            self.assertEqual(
+                os.environ["ZCCACHE_LINK_DEPLOY_CMD"],
+                "clang-tool-chain-libdeploy",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ci/tests/test_sketch_filter.py
+++ b/ci/tests/test_sketch_filter.py
@@ -751,7 +751,17 @@ class TestAutoResearchFilter:
 
     @pytest.mark.parametrize(
         "board_name",
-        ["esp32s3", "esp32c6", "esp32p4", "teensy40", "teensy41"],
+        [
+            "esp32s3",
+            "esp32c6",
+            "esp32p4",
+            "teensy40",
+            "teensy41",
+            "lpc845",
+            "lpc845brk",
+            "lpcxpresso845max",
+            "lpcxpresso804",
+        ],
     )
     def test_autoresearch_supported_boards_compile(self, board_name: str) -> None:
         from ci.boards import create_board

--- a/ci/tests/test_streaming_runner_artifact_validation.py
+++ b/ci/tests/test_streaming_runner_artifact_validation.py
@@ -7,16 +7,20 @@ the validator catches anomalous cache/tool output before a runner loads it.
 
 import concurrent.futures
 import os
+import threading
 import time
 import unittest
+from contextlib import nullcontext
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any, Callable, TypeVar
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from ci.meson.streaming import (  # noqa: E402
     CompileOnlyResult,
+    _wait_for_dll_touch,
     stream_compile_and_run_tests,
+    stream_compile_only,
 )
 from ci.meson.streaming import (
     TestResult as StreamingTestResult,
@@ -120,6 +124,35 @@ class TestValidateTestArtifact(unittest.TestCase):
 class TestStreamingExecutionCoordination(unittest.TestCase):
     """Streaming execution starts only after a successful compile phase."""
 
+    def test_dll_touch_wait_is_bounded(self) -> None:
+        """A stalled optimizer reports failure instead of waiting forever."""
+        done = threading.Event()
+
+        self.assertFalse(_wait_for_dll_touch(done, timeout=0.0))
+        done.set()
+        self.assertTrue(_wait_for_dll_touch(done, timeout=0.0))
+
+    def test_dll_touch_timeout_is_reported_in_compile_output(self) -> None:
+        """Timeout diagnostics propagate to callers and persisted failure logs."""
+        process = MagicMock()
+        process.line_iter.return_value = nullcontext(iter(()))
+        process.wait.return_value = 0
+        process.stdout = "ninja completed"
+
+        with (
+            TemporaryDirectory() as tmp,
+            patch("ci.meson.streaming.get_meson_executable", return_value="meson"),
+            patch("ci.meson.streaming.kill_stale_runner_processes", return_value=0),
+            patch("ci.meson.streaming.RunningProcess", return_value=process),
+            patch("ci.meson.streaming._wait_for_dll_touch", return_value=False),
+        ):
+            result = stream_compile_only(Path(tmp) / "build", compile_timeout=1)
+
+        self.assertFalse(result.success)
+        self.assertIn(
+            "DLL mtime optimization timed out after 1.0s", result.compile_output
+        )
+
     def test_test_starts_after_compile_completes(self) -> None:
         """A pre-link status callback must not start a test process."""
         test_path = Path("build/tests/example.dylib")
@@ -127,6 +160,8 @@ class TestStreamingExecutionCoordination(unittest.TestCase):
         observed_compile_states: list[bool] = []
 
         def fake_compile_only(*args: object, **kwargs: object) -> CompileOnlyResult:
+            # The pre-fix implementation supplied this removed kwarg. Keep the
+            # compatibility hook so this regression remains RED on old code.
             callback = kwargs.get("on_test_compiled")
             if callable(callback):
                 callback(test_path)
@@ -160,6 +195,7 @@ class TestStreamingExecutionCoordination(unittest.TestCase):
         executed_paths: list[Path] = []
 
         def fake_compile_only(*args: object, **kwargs: object) -> CompileOnlyResult:
+            # Exercise the pre-fix early-execution path when run against it.
             callback = kwargs.get("on_test_compiled")
             if callable(callback):
                 callback(test_path)

--- a/ci/tests/test_streaming_runner_artifact_validation.py
+++ b/ci/tests/test_streaming_runner_artifact_validation.py
@@ -25,7 +25,11 @@ from ci.meson.streaming import (  # noqa: E402
 from ci.meson.streaming import (
     TestResult as StreamingTestResult,
 )
-from ci.meson.streaming_runner import validate_test_artifact  # noqa: E402
+from ci.meson.streaming_runner import (  # noqa: E402
+    _test_process_timeout_seconds,
+    _wait_for_test_process,
+    validate_test_artifact,
+)
 
 
 _T = TypeVar("_T")
@@ -131,6 +135,26 @@ class TestStreamingExecutionCoordination(unittest.TestCase):
         self.assertFalse(_wait_for_dll_touch(done, timeout=0.0))
         done.set()
         self.assertTrue(_wait_for_dll_touch(done, timeout=0.0))
+
+    def test_runner_timeout_preserves_captured_output(self) -> None:
+        """Watchdog phase markers survive the outer Python timeout."""
+        process = MagicMock()
+        process.wait.side_effect = TimeoutError("runner stalled")
+        process.stdout = "[FASTLED RUNNER] phase: dynamic-load\n"
+
+        result = _wait_for_test_process(process)
+
+        self.assertFalse(result.success)
+        self.assertIn("runner stalled", result.output)
+        self.assertIn("phase: dynamic-load", result.output)
+
+    def test_macos_runner_timeout_is_bounded(self) -> None:
+        """A pre-main Apple stall cannot consume a ten-minute worker slot."""
+        with patch("ci.meson.streaming_runner.sys.platform", "darwin"):
+            self.assertEqual(90, _test_process_timeout_seconds())
+
+        with patch("ci.meson.streaming_runner.sys.platform", "linux"):
+            self.assertEqual(600, _test_process_timeout_seconds())
 
     def test_dll_touch_timeout_is_reported_in_compile_output(self) -> None:
         """Timeout diagnostics propagate to callers and persisted failure logs."""

--- a/examples/meson.build
+++ b/examples/meson.build
@@ -156,7 +156,7 @@ example_runner_exe = executable('example_runner',
   files('../tests/shared/example_runner.cpp'),
   cpp_args: runner_cpp_args + [path_norm_I_src, path_norm_I_stub, path_norm_I_tests],
   link_args: runner_link_args,
-  link_with: [crash_handler_lib],  # Shared crash handler from root meson.build
+  link_with: [crash_handler_lib] + apple_runner_watchdog_libs,
   implicit_include_directories: false,
   install: false
 )

--- a/src/platforms/apple/run_example.hpp
+++ b/src/platforms/apple/run_example.hpp
@@ -24,17 +24,18 @@
 #include <mach-o/dyld.h> // For _NSGetExecutablePath
 // IWYU pragma: end_keep
 
-// Timeout watchdog for hung example detection
-#include "timeout_watchdog.h"  // ok include path
 #include "fl/stl/noexcept.h"
+#include "platforms/apple/runner_watchdog.hpp"
 
 int main(int argc, char** argv) FL_NO_EXCEPT {
+    apple_runner_watchdog::set_phase(apple_runner_watchdog::Phase::kStartup);
+    apple_runner_watchdog::setup();
+
     // Setup crash handler BEFORE loading any shared libraries
+    apple_runner_watchdog::set_phase(apple_runner_watchdog::Phase::kCrashHandlerSetup);
     runner_setup_crash_handler();
 
-    // Setup timeout watchdog to detect hung examples
-    timeout_watchdog::setup();  // Default: 20 seconds, configurable via FASTLED_TEST_TIMEOUT
-
+    apple_runner_watchdog::set_phase(apple_runner_watchdog::Phase::kPathResolution);
     std::string so_path;
     const std::string shared_lib_ext = ".dylib";
 
@@ -75,17 +76,21 @@ int main(int argc, char** argv) FL_NO_EXCEPT {
 
     // Load shared library with RTLD_NOW for immediate symbol resolution
     // This helps ASAN properly track symbols from the loaded library
+    apple_runner_watchdog::set_phase(apple_runner_watchdog::Phase::kDynamicLoad);
     void* handle = dlopen(so_path.c_str(), RTLD_NOW | RTLD_GLOBAL);
     if (!handle) {
         std::cout << "Error: Failed to load " << so_path << " (" << dlerror() << ")" << std::endl;
+        apple_runner_watchdog::cancel();
         return 1;
     }
 
     // Get run_example function
+    apple_runner_watchdog::set_phase(apple_runner_watchdog::Phase::kSymbolLookup);
     RunExampleFunc run_example = (RunExampleFunc)dlsym(handle, "run_example");
     if (!run_example) {
         std::cout << "Error: Failed to find run_example() in " << so_path << " (" << dlerror() << ")" << std::endl;
         dlclose(handle);
+        apple_runner_watchdog::cancel();
         return 1;
     }
 
@@ -109,6 +114,7 @@ int main(int argc, char** argv) FL_NO_EXCEPT {
     }
 
     // Call example function with arguments
+    apple_runner_watchdog::set_phase(apple_runner_watchdog::Phase::kInvocation);
     int example_result = run_example(example_argc, example_argv);
 
     // Cleanup: Skip dlclose when running with AddressSanitizer
@@ -116,6 +122,7 @@ int main(int argc, char** argv) FL_NO_EXCEPT {
     // before that, ASAN cannot symbolize addresses from the unloaded library,
     // resulting in "<unknown module>" in stack traces.
     // See: https://github.com/google/sanitizers/issues/899
+    apple_runner_watchdog::set_phase(apple_runner_watchdog::Phase::kTeardown);
 #if !defined(__SANITIZE_ADDRESS__) && !defined(__has_feature)
     dlclose(handle);
 #elif defined(__has_feature)
@@ -124,6 +131,8 @@ int main(int argc, char** argv) FL_NO_EXCEPT {
 #endif
 #endif
 
+    apple_runner_watchdog::set_phase(apple_runner_watchdog::Phase::kCompleted);
+    apple_runner_watchdog::cancel();
     return example_result;
 }
 

--- a/src/platforms/apple/run_unit_test.hpp
+++ b/src/platforms/apple/run_unit_test.hpp
@@ -19,105 +19,31 @@
 #ifdef FL_IS_APPLE
 
 // IWYU pragma: begin_keep
-#include <chrono>
 #include <iostream>
 #include <string>
 #include <vector>
 #include <cstddef>
 #include <cstdint>
-#include <cstdlib>
-#include <cstring>
-#include <cstdio>
-#include <csignal>
 #include <dlfcn.h>       // For dlopen, dlsym, dlclose
 #include <mach-o/dyld.h> // For _NSGetExecutablePath
-#include <unistd.h>      // For alarm
 #include "fl/stl/noexcept.h"
+#include "platforms/apple/runner_watchdog.hpp"
 // IWYU pragma: end_keep
 
 // Crash handler setup (defined in crash_handler_main.cpp)
 extern "C" void runner_setup_crash_handler();
-// Stack trace printer (defined in crash_handler_main.cpp)
-extern "C" void runner_print_stacktrace();
-
-namespace runner_watchdog {
-
-static volatile bool g_active = false;
-static double g_timeout_seconds = 20.0;
-
-static void alarm_handler(int) FL_NO_EXCEPT {
-    if (!g_active) {
-        return;
-    }
-
-    fprintf(stderr, "\n");
-    fprintf(stderr, "================================================================================\n");
-    fprintf(stderr, "RUNNER WATCHDOG TIMEOUT\n");
-    fprintf(stderr, "================================================================================\n");
-    fprintf(stderr, "Test exceeded runner timeout of %.1f seconds\n", g_timeout_seconds);
-    fprintf(stderr, "Dumping stack trace...\n");
-    fprintf(stderr, "================================================================================\n");
-    fprintf(stderr, "\n");
-
-    runner_print_stacktrace();
-
-    fprintf(stderr, "\n");
-    fprintf(stderr, "================================================================================\n");
-    fprintf(stderr, "END RUNNER WATCHDOG\n");
-    fprintf(stderr, "Exiting with code 1\n");
-    fprintf(stderr, "================================================================================\n");
-    fprintf(stderr, "\n");
-
-    _exit(1);
-}
-
-static void setup(double timeout_seconds = 20.0) FL_NO_EXCEPT {
-    const char* disable_env = getenv("FASTLED_DISABLE_TIMEOUT_WATCHDOG");
-    if (disable_env && (strcmp(disable_env, "1") == 0 || strcmp(disable_env, "true") == 0)) {
-        return;
-    }
-
-    const char* timeout_env = getenv("FASTLED_TEST_TIMEOUT");
-    if (timeout_env) {
-        double parsed = atof(timeout_env);
-        if (parsed > 0.0) {
-            timeout_seconds = parsed;
-        }
-    }
-
-    g_timeout_seconds = timeout_seconds;
-    g_active = true;
-
-    struct sigaction sa;
-    memset(&sa, 0, sizeof(sa));
-    sa.sa_handler = alarm_handler;
-    sigemptyset(&sa.sa_mask);
-    sa.sa_flags = 0;
-
-    if (sigaction(SIGALRM, &sa, nullptr) == 0) {
-        alarm(static_cast<unsigned int>(timeout_seconds));
-        printf("Runner watchdog enabled (%.1f seconds)\n", timeout_seconds);
-    }
-}
-
-static void cancel() FL_NO_EXCEPT {
-    if (!g_active) {
-        return;
-    }
-    g_active = false;
-    alarm(0);
-    signal(SIGALRM, SIG_DFL);
-}
-
-} // namespace runner_watchdog
-
 // Function signature for the test entry point exported by test DLLs/SOs
 typedef int (*RunTestsFunc)(int argc, const char** argv);
 
 int main(int argc, char** argv) FL_NO_EXCEPT {
+    apple_runner_watchdog::set_phase(apple_runner_watchdog::Phase::kStartup);
+    apple_runner_watchdog::setup();
+
     // Setup crash handler BEFORE loading any shared libraries
+    apple_runner_watchdog::set_phase(apple_runner_watchdog::Phase::kCrashHandlerSetup);
     runner_setup_crash_handler();
 
+    apple_runner_watchdog::set_phase(apple_runner_watchdog::Phase::kPathResolution);
     std::string so_path;
     const std::string shared_lib_ext = ".dylib";
 
@@ -158,17 +84,21 @@ int main(int argc, char** argv) FL_NO_EXCEPT {
 
     // Load shared library with RTLD_NOW for immediate symbol resolution
     // This helps ASAN properly track symbols from the loaded library
+    apple_runner_watchdog::set_phase(apple_runner_watchdog::Phase::kDynamicLoad);
     void* handle = dlopen(so_path.c_str(), RTLD_NOW | RTLD_GLOBAL);
     if (!handle) {
         std::cout << "Error: Failed to load " << so_path << " (" << dlerror() << ")" << std::endl;
+        apple_runner_watchdog::cancel();
         return 1;
     }
 
     // Get run_tests function
+    apple_runner_watchdog::set_phase(apple_runner_watchdog::Phase::kSymbolLookup);
     RunTestsFunc run_tests = (RunTestsFunc)dlsym(handle, "run_tests");
     if (!run_tests) {
         std::cout << "Error: Failed to find run_tests() in " << so_path << " (" << dlerror() << ")" << std::endl;
         dlclose(handle);
+        apple_runner_watchdog::cancel();
         return 1;
     }
 
@@ -191,20 +121,16 @@ int main(int argc, char** argv) FL_NO_EXCEPT {
         test_argv = const_cast<const char**>(argv);
     }
 
-    // Start watchdog timer
-    runner_watchdog::setup();
-
     // Call test function with arguments
+    apple_runner_watchdog::set_phase(apple_runner_watchdog::Phase::kInvocation);
     int test_result = run_tests(test_argc, test_argv);
-
-    // Cancel watchdog - tests completed normally
-    runner_watchdog::cancel();
 
     // Cleanup: Skip dlclose when running with AddressSanitizer
     // ASAN runs leak detection at program exit. If we dlclose() the shared library
     // before that, ASAN cannot symbolize addresses from the unloaded library,
     // resulting in "<unknown module>" in stack traces.
     // See: https://github.com/google/sanitizers/issues/899
+    apple_runner_watchdog::set_phase(apple_runner_watchdog::Phase::kTeardown);
 #if !defined(__SANITIZE_ADDRESS__) && !defined(__has_feature)
     dlclose(handle);
 #elif defined(__has_feature)
@@ -213,6 +139,8 @@ int main(int argc, char** argv) FL_NO_EXCEPT {
 #endif
 #endif
 
+    apple_runner_watchdog::set_phase(apple_runner_watchdog::Phase::kCompleted);
+    apple_runner_watchdog::cancel();
     return test_result;
 }
 

--- a/src/platforms/apple/runner_watchdog.hpp
+++ b/src/platforms/apple/runner_watchdog.hpp
@@ -1,0 +1,31 @@
+// ok no namespace fl
+#pragma once
+
+// IWYU pragma: private
+
+/// Async-signal-safe watchdog and phase diagnostics for Apple dylib runners.
+///
+/// A SIGALRM can interrupt dyld while it holds internal loader locks. The
+/// implementation therefore keeps its handler to write(2) + _exit(2), both
+/// async-signal-safe, and emits phase markers before loader transitions.
+
+#include "fl/stl/noexcept.h"
+
+namespace apple_runner_watchdog {
+
+enum class Phase {
+    kStartup = 0,
+    kCrashHandlerSetup,
+    kPathResolution,
+    kDynamicLoad,
+    kSymbolLookup,
+    kInvocation,
+    kTeardown,
+    kCompleted,
+};
+
+void set_phase(Phase phase) FL_NO_EXCEPT;
+void setup(double timeout_seconds = 20.0) FL_NO_EXCEPT;
+void cancel() FL_NO_EXCEPT;
+
+} // namespace apple_runner_watchdog

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -45,6 +45,7 @@ test_pch = custom_target('test_pch',
     test_pch_input_abs,            # Canonical absolute forward-slash spelling
     '-o', '@OUTPUT@',              # test_pch.h.pch
     '-MD', '-MF', '@DEPFILE@',     # Generate dependency file (will be fixed by wrapper)
+    get_option('cpp_args'),        # Includes native-file SDK selection on Apple debug
     unit_test_compile_args,        # Same flags as all tests
     '-fPIC',                       # Required: tests build as shared_library which needs PIC
     test_abs_include_args,

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -85,7 +85,7 @@ runner_exe = executable('runner',
   'shared/runner.cpp',
   cpp_args: runner_cpp_args + [path_norm_I_src, path_norm_I_stub, path_norm_I_tests],
   link_args: runner_link_args,
-  link_with: [crash_handler_lib],  # Shared crash handler from root meson.build
+  link_with: [crash_handler_lib] + apple_runner_watchdog_libs,
   implicit_include_directories: false,
   install: false
 )

--- a/tests/shared/apple_runner_watchdog.cpp
+++ b/tests/shared/apple_runner_watchdog.cpp
@@ -1,0 +1,123 @@
+// ok standalone
+// Apple runner watchdog implementation. Kept in a .cpp file so POSIX system
+// headers do not leak into the public FastLED header surface.
+
+#include "platforms/posix/is_posix.h"
+
+#ifdef FL_IS_APPLE
+
+// IWYU pragma: begin_keep
+#include <csignal>
+#include <cstddef> // ok include - private host-runner implementation
+#include <cstdlib> // ok include - must call system getenv/atof without libfastled
+#include <cstring> // ok include - signal setup must not add libfastled linkage
+#include <unistd.h>
+// IWYU pragma: end_keep
+
+#include "fl/stl/int.h"
+#include "platforms/apple/runner_watchdog.hpp"
+
+namespace apple_runner_watchdog {
+
+static volatile sig_atomic_t g_active = 0;
+static volatile sig_atomic_t g_phase = static_cast<sig_atomic_t>(Phase::kStartup);
+
+template <size_t N>
+static void write_literal(const char (&message)[N]) FL_NO_EXCEPT {
+    (void)::write(STDERR_FILENO, message, N - 1);
+}
+
+static void write_phase(Phase phase) FL_NO_EXCEPT {
+    switch (phase) {
+    case Phase::kStartup:
+        write_literal("[FASTLED RUNNER] phase: startup\n");
+        break;
+    case Phase::kCrashHandlerSetup:
+        write_literal("[FASTLED RUNNER] phase: crash-handler-setup\n");
+        break;
+    case Phase::kPathResolution:
+        write_literal("[FASTLED RUNNER] phase: path-resolution\n");
+        break;
+    case Phase::kDynamicLoad:
+        write_literal("[FASTLED RUNNER] phase: dynamic-load\n");
+        break;
+    case Phase::kSymbolLookup:
+        write_literal("[FASTLED RUNNER] phase: symbol-lookup\n");
+        break;
+    case Phase::kInvocation:
+        write_literal("[FASTLED RUNNER] phase: invocation\n");
+        break;
+    case Phase::kTeardown:
+        write_literal("[FASTLED RUNNER] phase: teardown\n");
+        break;
+    case Phase::kCompleted:
+        write_literal("[FASTLED RUNNER] phase: completed\n");
+        break;
+    }
+}
+
+void set_phase(Phase phase) FL_NO_EXCEPT {
+    g_phase = static_cast<sig_atomic_t>(phase);
+    write_phase(phase);
+}
+
+static void alarm_handler(int) FL_NO_EXCEPT {
+    if (!g_active) {
+        return;
+    }
+
+    write_literal("[FASTLED RUNNER] watchdog timeout; last observed phase follows\n");
+    write_phase(static_cast<Phase>(g_phase));
+    _exit(1);
+}
+
+void setup(double timeout_seconds) FL_NO_EXCEPT {
+    const char* disable_env = ::getenv("FASTLED_DISABLE_TIMEOUT_WATCHDOG");
+    if (disable_env &&
+        (::strcmp(disable_env, "1") == 0 || ::strcmp(disable_env, "true") == 0)) { // ok ctype
+        write_literal("[FASTLED RUNNER] watchdog disabled\n");
+        return;
+    }
+
+    const char* timeout_env = ::getenv("FASTLED_TEST_TIMEOUT");
+    if (timeout_env) {
+        const double parsed = ::atof(timeout_env);
+        if (parsed > 0.0) {
+            timeout_seconds = parsed;
+        }
+    }
+
+    struct sigaction action;
+    ::memset(&action, 0, sizeof(action)); // ok ctype
+    action.sa_handler = alarm_handler;
+    sigemptyset(&action.sa_mask);
+    action.sa_flags = 0;
+
+    if (sigaction(SIGALRM, &action, nullptr) != 0) {
+        write_literal("[FASTLED RUNNER] failed to install watchdog\n");
+        return;
+    }
+
+    g_active = 1;
+    fl::u32 timeout = static_cast<fl::u32>(timeout_seconds);
+    if (timeout == 0) {
+        timeout = 1;
+    }
+    alarm(timeout);
+    write_literal("[FASTLED RUNNER] watchdog armed\n");
+}
+
+void cancel() FL_NO_EXCEPT {
+    if (!g_active) {
+        return;
+    }
+    g_active = 0;
+    alarm(0);
+    // Keep the handler installed until process exit. alarm(0) does not clear a
+    // signal that is already pending; restoring SIG_DFL here could turn that
+    // harmless late delivery into process termination after a successful run.
+}
+
+} // namespace apple_runner_watchdog
+
+#endif // FL_IS_APPLE


### PR DESCRIPTION
Follow-up to #3643. That PR fixed compile/run overlap and `NO_PARALLEL` handling, but its macOS 26 validation still hung after compilation completed. This PR contains bounded diagnostics and the matched-toolchain fix for the remaining Apple ASan failure.

## Root cause evidence

Diagnostic run: https://github.com/FastLED/FastLED/actions/runs/29385930873/job/87259086238

Compilation completed and 267 artifacts were collected. Ten runners then hit the bounded timeout without emitting even the first async-signal-safe `startup` marker. The stall is before `main()`, during sanitizer runtime initialization.

This exactly matches LLVM #200447: https://github.com/llvm/llvm-project/issues/200447

On macOS 26.4, older ASan runtimes recursively allocate while inspecting dyld's shared cache and deadlock during initialization. Apple shipped the fix in Xcode 26.4+; Xcode 26.5 is confirmed to resolve the minimal repro.

GitHub's current `macos-26` image uses macOS 26.4 and Xcode 26.5 by default, but FastLED's debug build was compiled and linked through clang-tool-chain with its bundled Clang 19 sanitizer runtime.

## Superseded runtime-only attempt

Commit `573a05d93a` tried to compile with clang-tool-chain Clang 19 while selecting Xcode's Clang 21 resource directory only at link time. The acceptance run failed immediately with `undefined symbol: __asan_version_mismatch_check_v8`: https://github.com/FastLED/FastLED/actions/runs/29387594533/job/87264018034

That proves the compiler instrumentation and sanitizer runtime must be selected as one ABI-compatible toolchain.

## Root fix

On Apple debug builds only:

- resolve `clang`, `clang++`, and `ar` from the selected Xcode via `xcrun`;
- use those Xcode tools consistently for compiler detection, Meson's native file, and setup environment;
- link with Xcode clang's native ld64 path and Darwin's default shared sanitizer runtime;
- disable `clang-tool-chain-libdeploy`, which could otherwise copy the bundled compiler-rt beside an Xcode-linked binary;
- query the Xcode compiler version rather than accepting the old marker by mtime, forcing incompatible Clang 19 objects to be cleaned during migration.

Apple quick/release builds retain clang-tool-chain and LLD. Linux and Windows are unchanged. Complete ASan instrumentation (including globals), UBSan, debug symbols, and `macos-latest` remain enabled.

## Diagnostics and containment

- preserve captured runner output when the Python subprocess timeout fires;
- use a 90-second outer timeout on macOS, retaining 600 seconds elsewhere;
- emit unbuffered phase markers from startup through teardown;
- arm the Apple watchdog before crash setup and dynamic loading;
- keep its `SIGALRM` path async-signal-safe (`write(2)` + `_exit(2)` only);
- compile the watchdog call chain in a dedicated uninstrumented macOS-only library;
- link the same watchdog into unit-test and example runners;
- avoid the pending-`SIGALRM` cancellation race.

## Existing bounded optimizer wait

- cap DLL mtime-optimizer waiting at 30 seconds with 200 ms cancellation polling;
- propagate timeout diagnostics through `CompileOnlyResult`;
- add deterministic success/timeout coverage;
- exercise every LPC board declared by the AutoResearch filter.

## Validation

- focused toolchain/streaming regressions: 20 passed;
- Python CI tests excluding the unrelated local QEMU integration: 517 passed, 39 skipped, 5 subtests passed;
- Ruff check and format check: passed;
- clean forced Meson reconfiguration and C++ rebuild: passed;
- C++ unit/example targets: 350/350 passed;
- Python, C++, and Meson review passes: clean.

Issue #3642 remains open until the macOS unit workflow passes on this PR, the PR is merged, and both macOS unit and example workflows pass on current `master` without orphan runner processes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevent streaming builds from hanging by bounding DLL-touch optimization waits and surfacing timeouts in compilation output.
  * Apply platform-appropriate subprocess timeouts, preserving captured runner output on failures.
  * Improve macOS runner watchdog behavior with explicit lifecycle phase tracking and more reliable cancellation/termination.
  * Refine macOS debug build linking/sanitizer behavior to match the selected toolchain.
* **Tests**
  * Add/strengthen timeout-boundness and diagnostics checks for streaming execution coordination.
  * Expand supported-board assertions for AutoResearch.
  * Add Meson native toolchain regression coverage for Apple debug behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->