### PR TITLE
Fix macOS sanitizer setup for example runner

### DIFF
--- a/ci/meson/runner.py
+++ b/ci/meson/runner.py
@@ -16,7 +16,6 @@ This file owns the entry point ``run_meson_build_and_test`` and the CLI.
 
 import argparse
 import glob
-import os
 import sys
 import time
 from pathlib import Path
@@ -31,6 +30,7 @@ from ci.meson.build_timer import BuildTimer
 from ci.meson.compiler import check_meson_installed
 from ci.meson.phase_tracker import PhaseTracker
 from ci.meson.runner_helpers import _safe_rmtree, _start_zccache_session
+from ci.meson.sanitizer_env import setup_sanitizer_env
 from ci.meson.sequential_runner import (
     DirectTestContext,
     SequentialCompileContext,
@@ -41,49 +41,6 @@ from ci.meson.streaming_runner import StreamingContext, run_streaming_path
 from ci.meson.test_execution import MesonTestResult, run_meson_test
 from ci.util.build_lock import libfastled_build_lock
 from ci.util.timestamp_print import ts_print as _ts_print
-
-
-def _setup_sanitizer_env(source_dir: Path, verbose: bool) -> None:
-    """Configure ASan/LSan options for debug builds via clang-tool-chain."""
-    from clang_tool_chain import (
-        prepare_sanitizer_environment,  # noqa: PLC0415 - lazy: ~60ms on non-debug
-    )
-
-    sanitizer_flags = ["-fsanitize=address"]
-    sanitizer_env = prepare_sanitizer_environment(
-        base_env=os.environ.copy(),
-        compiler_flags=sanitizer_flags,
-    )
-
-    if sys.platform == "darwin":
-        # Apple's Xcode ASan runtime on the macos-26 runner rejects
-        # detect_leaks=1 before main() with "not supported on this platform."
-        # LeakSanitizer is therefore unavailable on this runtime; keep all ASan
-        # and UBSan instrumentation active while disabling only that option.
-        asan_options = sanitizer_env.get("ASAN_OPTIONS", "")
-        options = [
-            option
-            for option in asan_options.split(":")
-            if option and not option.startswith("detect_leaks=")
-        ]
-        options.append("detect_leaks=0")
-        sanitizer_env["ASAN_OPTIONS"] = ":".join(options)
-
-    os.environ.update(sanitizer_env)
-
-    lsan_suppressions = source_dir / "tests" / "lsan_suppressions.txt"
-    if sys.platform != "darwin" and lsan_suppressions.exists():
-        existing_lsan = os.environ.get("LSAN_OPTIONS", "")
-        suppression_opt = f"suppressions={lsan_suppressions}"
-        if existing_lsan:
-            os.environ["LSAN_OPTIONS"] = f"{existing_lsan}:{suppression_opt}"
-        else:
-            os.environ["LSAN_OPTIONS"] = suppression_opt
-
-    if verbose:
-        symbolizer_path = sanitizer_env.get("ASAN_SYMBOLIZER_PATH")
-        if symbolizer_path:
-            _ts_print(f"[MESON] Set ASAN_SYMBOLIZER_PATH={symbolizer_path}")
 
 
 def _resolve_test_name_candidates(
@@ -189,7 +146,7 @@ def run_meson_build_and_test(
 
     use_debug = build_mode == "debug"
     if use_debug:
-        _setup_sanitizer_env(source_dir, verbose)
+        setup_sanitizer_env(source_dir, verbose)
 
     _ts_print(f"Preparing build ({build_mode} mode)...")
     _start_zccache_session(build_dir, build_mode)

--- a/ci/meson/sanitizer_env.py
+++ b/ci/meson/sanitizer_env.py
@@ -1,0 +1,49 @@
+"""Shared sanitizer environment setup for unit and example runners."""
+
+import os
+import sys
+from pathlib import Path
+
+from ci.util.timestamp_print import ts_print as _ts_print
+
+
+def setup_sanitizer_env(source_dir: Path, verbose: bool) -> None:
+    """Configure platform-compatible ASan/LSan options for debug builds."""
+    from clang_tool_chain import (
+        prepare_sanitizer_environment,  # noqa: PLC0415 - lazy: ~60ms on non-debug
+    )
+
+    sanitizer_env = prepare_sanitizer_environment(
+        base_env=os.environ.copy(),
+        compiler_flags=["-fsanitize=address"],
+    )
+
+    if sys.platform == "darwin":
+        # Apple's Xcode ASan runtime on the macos-26 runner rejects
+        # detect_leaks=1 before main() with "not supported on this platform."
+        # LeakSanitizer is therefore unavailable on this runtime; keep all ASan
+        # and UBSan instrumentation active while disabling only that option.
+        asan_options = sanitizer_env.get("ASAN_OPTIONS", "")
+        options = [
+            option
+            for option in asan_options.split(":")
+            if option and not option.startswith("detect_leaks=")
+        ]
+        options.append("detect_leaks=0")
+        sanitizer_env["ASAN_OPTIONS"] = ":".join(options)
+
+    os.environ.update(sanitizer_env)
+
+    lsan_suppressions = source_dir / "tests" / "lsan_suppressions.txt"
+    if sys.platform != "darwin" and lsan_suppressions.exists():
+        existing_lsan = os.environ.get("LSAN_OPTIONS", "")
+        suppression_opt = f"suppressions={lsan_suppressions}"
+        if existing_lsan:
+            os.environ["LSAN_OPTIONS"] = f"{existing_lsan}:{suppression_opt}"
+        else:
+            os.environ["LSAN_OPTIONS"] = suppression_opt
+
+    if verbose:
+        symbolizer_path = sanitizer_env.get("ASAN_SYMBOLIZER_PATH")
+        if symbolizer_path:
+            _ts_print(f"[MESON] Set ASAN_SYMBOLIZER_PATH={symbolizer_path}")

--- a/ci/tests/test_meson_native_toolchain.py
+++ b/ci/tests/test_meson_native_toolchain.py
@@ -17,8 +17,8 @@ from ci.meson.meson_setup_execute import (
     write_meson_native_file,
 )
 from ci.meson.meson_setup_phases import CompilerDetection, MarkerPaths
-from ci.meson.runner import _setup_sanitizer_env
 from ci.meson.runner_helpers import _start_zccache_session
+from ci.meson.sanitizer_env import setup_sanitizer_env
 
 
 class TestMesonNativeToolchain(unittest.TestCase):
@@ -222,7 +222,7 @@ class TestMesonNativeToolchain(unittest.TestCase):
         }
         with (
             TemporaryDirectory() as temp_dir,
-            patch("ci.meson.runner.sys.platform", "darwin"),
+            patch("ci.meson.sanitizer_env.sys.platform", "darwin"),
             patch.dict(
                 clang_tool_chain.__dict__,
                 {"prepare_sanitizer_environment": lambda **_kwargs: prepared},
@@ -233,7 +233,7 @@ class TestMesonNativeToolchain(unittest.TestCase):
             suppressions = source_dir / "tests" / "lsan_suppressions.txt"
             suppressions.parent.mkdir()
             suppressions.write_text("leak:known_false_positive\n", encoding="utf-8")
-            _setup_sanitizer_env(source_dir, verbose=False)
+            setup_sanitizer_env(source_dir, verbose=False)
             options = os.environ["ASAN_OPTIONS"].split(":")
             lsan_options = os.environ["LSAN_OPTIONS"]
 
@@ -242,6 +242,17 @@ class TestMesonNativeToolchain(unittest.TestCase):
         self.assertIn("detect_leaks=0", options)
         self.assertNotIn("detect_leaks=1", options)
         self.assertNotIn("suppressions=", lsan_options)
+
+    def test_unit_and_example_runners_share_sanitizer_setup(self) -> None:
+        project_root = Path(__file__).parents[2]
+        for relative_path in (
+            Path("ci/meson/runner.py"),
+            Path("ci/util/meson_example_runner.py"),
+        ):
+            with self.subTest(runner=relative_path.as_posix()):
+                content = (project_root / relative_path).read_text(encoding="utf-8")
+                self.assertIn("setup_sanitizer_env(source_dir, verbose)", content)
+                self.assertNotIn("prepare_sanitizer_environment", content)
 
     def test_apple_non_debug_keeps_clang_tool_chain(self) -> None:
         compiler = self._compiler()

--- a/ci/util/meson_example_runner.py
+++ b/ci/util/meson_example_runner.py
@@ -22,6 +22,7 @@ from running_process import RunningProcess
 
 from ci.meson.build_config import perform_ninja_maintenance, setup_meson_build
 from ci.meson.compiler import check_meson_installed, get_meson_executable
+from ci.meson.sanitizer_env import setup_sanitizer_env
 from ci.meson.test_execution import MesonTestResult
 from ci.util.build_lock import libfastled_build_lock
 from ci.util.output_formatter import TimestampFormatter
@@ -438,19 +439,10 @@ def run_meson_examples(
     # bin/ (which owns libclang_rt.asan_dynamic-x86_64.dll) to PATH; without
     # it every example .exe fails to start with 0xC0000135 STATUS_DLL_NOT_FOUND
     # — the failure mode that had `example tests windows` red on master
-    # since 2026-06-23. Mirrors the same call ci/meson/runner.py makes for
-    # the unit-test runner; the example runner had grown its own --debug
-    # path without the equivalent env prep.
+    # since 2026-06-23. The shared helper also applies the macOS-specific
+    # ASan options used by the unit-test runner.
     if build_mode == "debug":
-        from clang_tool_chain import (  # noqa: PLC0415 - lazy import: ~60ms
-            prepare_sanitizer_environment,
-        )
-
-        sanitizer_env = prepare_sanitizer_environment(
-            base_env=os.environ.copy(),
-            compiler_flags=["-fsanitize=address"],
-        )
-        os.environ.update(sanitizer_env)
+        setup_sanitizer_env(source_dir, verbose)
 
     # Construct mode-specific build directory
     # This enables caching per mode when source unchanged but flags differ


### PR DESCRIPTION
## Summary
- centralize debug sanitizer environment setup in one shared helper
- make both the unit-test runner and example runner consume that helper
- on Darwin, replace unsupported detect_leaks=1 with detect_leaks=0 while retaining ASan and UBSan
- add regression coverage that prevents the two runners from drifting again

## Root cause
PR #3644 fixed the macOS sanitizer runtime and options for the unit-test path. The example runner still had a copied sanitizer setup that reintroduced detect_leaks=1, causing every debug example to abort before entering main on macOS 26.

## Validation
- uv run pytest ci/tests/test_meson_native_toolchain.py -q: 12 passed, 4 subtests passed
- uv run pytest ci/tests -q --ignore=ci/tests/test_fbuild_qemu.py: 521 passed, 39 skipped, 9 subtests passed
- bash lint: passed
- focused Python review: clean after removing one stale import

## Acceptance
Refs #3642. Keep the issue open through merge; close it only after both macOS unit tests and macOS example tests are green on current master.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved debug test runs by configuring AddressSanitizer and LeakSanitizer settings consistently across native and example test runners.
  * Fixed macOS debug runs by disabling unsupported leak detection while preserving other sanitizer checks.
  * Improved resolution of specifically requested Meson tests, including fallback and fuzzy name matching.

* **Refactor**
  * Consolidated sanitizer environment setup to provide more consistent behavior across test workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->