### PR TITLE
fix(autoresearch): keep pin-free RPC available

### DIFF
--- a/ci/rpc_client.py
+++ b/ci/rpc_client.py
@@ -752,6 +752,8 @@ class RpcClient:
             raise
         except RpcCrashError:
             raise  # Re-raise crash errors without masking them
+        except RpcError:
+            raise  # Preserve structured JSON-RPC errors for the caller.
         except Exception as e:
             if self.verbose:
                 print(f"⚠️  [RPC] Exception during read_lines: {e}")

--- a/ci/rpc_schema_validator.py
+++ b/ci/rpc_schema_validator.py
@@ -13,7 +13,7 @@ Usage:
     try:
         validator.validate_request('runSingleTest', {'driver': 'PARLIO', 'laneSizes': [10]})
         # Send request to device...
-    except ValidationError as e:
+    except ValueError as e:
         print(f"Invalid request: {e}")
 """
 
@@ -22,7 +22,7 @@ import time
 from typing import Any, Optional, cast
 
 import serial
-from pydantic import BaseModel, ValidationError
+from pydantic import BaseModel
 
 from ci.util.global_interrupt_handler import handle_keyboard_interrupt
 
@@ -48,6 +48,60 @@ class RpcSchema(BaseModel):
 
     jsonrpc: str
     methods: dict[str, MethodInfo]
+
+
+def parse_rpc_schema(result: Any) -> RpcSchema:
+    """Normalize supported ``rpc.discover`` results into ``RpcSchema``.
+
+    FastLED devices use a compact tuple representation to keep embedded
+    serialization costs low::
+
+        {"schema": [[name, return_type, [[param, type], ...], mode], ...]}
+
+    Keep accepting the older expanded representation so the host harness can
+    validate firmware on either side of the schema-format migration.
+    """
+    if not isinstance(result, dict):
+        raise ValueError("rpc.discover result must be an object")
+
+    if "methods" in result:
+        return RpcSchema.model_validate(result)
+
+    compact_methods = result.get("schema")
+    if not isinstance(compact_methods, list):
+        raise ValueError("rpc.discover result has neither 'methods' nor 'schema'")
+
+    methods: dict[str, MethodInfo] = {}
+    for index, method in enumerate(compact_methods):
+        if not isinstance(method, list) or len(method) < 3:
+            raise ValueError(f"schema entry {index} must contain name, return type, and params")
+
+        name, return_type, compact_params = method[:3]
+        if not isinstance(name, str) or not name:
+            raise ValueError(f"schema entry {index} has an invalid method name")
+        if name in methods:
+            raise ValueError(f"schema contains duplicate method '{name}'")
+        if not isinstance(return_type, str):
+            raise ValueError(f"schema entry {index} has an invalid return type")
+        if not isinstance(compact_params, list):
+            raise ValueError(f"schema entry {index} has invalid params")
+
+        params: list[ParamInfo] = []
+        for param_index, param in enumerate(compact_params):
+            if not isinstance(param, list) or len(param) < 2:
+                raise ValueError(
+                    f"schema entry {index} param {param_index} must contain name and type"
+                )
+            param_name, param_type = param[:2]
+            if not isinstance(param_name, str) or not isinstance(param_type, str):
+                raise ValueError(
+                    f"schema entry {index} param {param_index} has invalid name or type"
+                )
+            params.append(ParamInfo(name=param_name, type=param_type))
+
+        methods[name] = MethodInfo(returnType=return_type, params=params)
+
+    return RpcSchema(jsonrpc="2.0", methods=methods)
 
 
 class RpcSchemaValidator:
@@ -107,7 +161,7 @@ class RpcSchemaValidator:
                             response = json.loads(json_str)
 
                             if "result" in response:
-                                self.schema = RpcSchema(**response["result"])
+                                self.schema = parse_rpc_schema(response["result"])
                                 print(
                                     f"✅ Fetched schema: {len(self.schema.methods)} methods"
                                 )
@@ -140,7 +194,7 @@ class RpcSchemaValidator:
             args: Method arguments (object or array)
 
         Raises:
-            ValidationError: If request doesn't match schema
+            ValueError: If request doesn't match schema
             KeyError: If method not found in schema
         """
         if not self.schema:
@@ -153,12 +207,21 @@ class RpcSchemaValidator:
 
         method_info = self.schema.methods[method]
 
+        # Most FastLED handlers intentionally accept one opaque ``const json&``
+        # payload. The compact device schema represents that as arg0:unknown;
+        # it proves the method exists but cannot describe the payload's keys.
+        if len(method_info.params) == 1:
+            only_param = method_info.params[0]
+            if only_param.name == "arg0" and only_param.type == "unknown":
+                return
+
+        if not method_info.params and args in (None, [], {}):
+            return
+
         # Validate against expected parameters
         # Note: The RPC system unwraps single-element arrays, so we validate the object directly
         if not isinstance(args, dict):
-            raise ValidationError(
-                f"Expected object for {method}, got {type(args).__name__}"
-            )
+            raise ValueError(f"Expected object for {method}, got {type(args).__name__}")
 
         # Type narrowing: after isinstance check, args is guaranteed to be dict
         args_dict = cast(dict[str, Any], args)
@@ -178,9 +241,7 @@ class RpcSchemaValidator:
             errors.append(f"Unknown parameters: {extra}")
 
         if errors:
-            raise ValidationError(
-                f"Validation errors for {method}: {'; '.join(errors)}"
-            )
+            raise ValueError(f"Validation errors for {method}: {'; '.join(errors)}")
 
     def get_method_schema(self, method: str) -> MethodInfo:
         """Get schema for a specific method"""
@@ -229,7 +290,7 @@ def main():
                 {"driver": "PARLIO", "laneSizes": [10], "iterations": 1},
             )
             print("  ✅ Valid request")
-        except ValidationError as e:
+        except ValueError as e:
             print(f"  ❌ Invalid request: {e}")
 
     except KeyboardInterrupt as ki:

--- a/ci/tests/test_rpc_client_errors.py
+++ b/ci/tests/test_rpc_client_errors.py
@@ -1,0 +1,41 @@
+"""Regression tests for JSON-RPC error propagation."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+
+import pytest
+
+from ci.rpc_client import RpcClient, RpcError
+
+
+class _ErrorSerial:
+    async def connect(self) -> None:
+        pass
+
+    async def close(self) -> None:
+        pass
+
+    async def write(self, data: str) -> None:
+        assert '"id":1' in data
+
+    async def read_lines(self, timeout: float) -> AsyncIterator[str]:  # noqa: ARG002
+        yield (
+            'REMOTE: {"jsonrpc":"2.0","id":1,'
+            '"error":{"code":-32601,"message":"Method not found: missing"}}'
+        )
+
+    async def reset_device(self, board: str | None) -> bool:  # pragma: no cover
+        return True
+
+
+def test_json_rpc_error_is_not_masked_as_timeout() -> None:
+    async def _run() -> None:
+        client = RpcClient("FAKE", serial_interface=_ErrorSerial())
+        await client.connect(boot_wait=0, drain_boot=False)
+        with pytest.raises(RpcError, match=r"-32601.*Method not found"):
+            await client.send("missing", timeout=0.1)
+        await client.close()
+
+    asyncio.run(_run())

--- a/ci/tests/test_rpc_schema_validator.py
+++ b/ci/tests/test_rpc_schema_validator.py
@@ -1,0 +1,91 @@
+import pytest
+
+from ci.rpc_schema_validator import RpcSchemaValidator, parse_rpc_schema
+
+
+def test_parse_compact_fastled_schema() -> None:
+    schema = parse_rpc_schema(
+        {
+            "schema": [
+                ["ping", "json", [], "sync"],
+                ["echo", "int", [["value", "int"]], "sync"],
+            ]
+        }
+    )
+
+    assert schema.jsonrpc == "2.0"
+    assert list(schema.methods) == ["ping", "echo"]
+    assert schema.methods["echo"].returnType == "int"
+    assert schema.methods["echo"].params[0].name == "value"
+    assert schema.methods["echo"].params[0].type == "int"
+
+
+def test_parse_expanded_legacy_schema() -> None:
+    schema = parse_rpc_schema(
+        {
+            "jsonrpc": "2.0",
+            "methods": {
+                "ping": {
+                    "returnType": "json",
+                    "params": [],
+                }
+            },
+        }
+    )
+
+    assert schema.methods["ping"].returnType == "json"
+
+
+@pytest.mark.parametrize(
+    "result",
+    [
+        {},
+        {"schema": "not-a-list"},
+        {"schema": [["missing-params", "json"]]},
+        {"schema": [["bad-params", "json", "not-a-list"]]},
+        {"schema": [["duplicate", "json", []], ["duplicate", "json", []]]},
+    ],
+)
+def test_parse_rejects_malformed_compact_schema(result: object) -> None:
+    with pytest.raises(ValueError):
+        parse_rpc_schema(result)
+
+
+def _validator_for(result: object) -> RpcSchemaValidator:
+    validator = object.__new__(RpcSchemaValidator)
+    validator.schema = parse_rpc_schema(result)
+    return validator
+
+
+@pytest.mark.parametrize("payload", [[], {}, [1, 2], {"driver": "PIO"}])
+def test_opaque_json_parameter_accepts_any_payload(payload: object) -> None:
+    validator = _validator_for(
+        {"schema": [["runSingleTest", "unknown", [["arg0", "unknown"]], "async"]]}
+    )
+
+    validator.validate_request("runSingleTest", payload)
+
+
+@pytest.mark.parametrize("payload", [None, [], {}])
+def test_no_parameter_method_accepts_empty_payload(payload: object) -> None:
+    validator = _validator_for({"schema": [["ping", "json", [], "sync"]]})
+
+    validator.validate_request("ping", payload)
+
+
+def test_expanded_typed_schema_still_checks_parameter_names() -> None:
+    validator = _validator_for(
+        {
+            "jsonrpc": "2.0",
+            "methods": {
+                "echo": {
+                    "returnType": "int",
+                    "params": [{"name": "value", "type": "int"}],
+                }
+            },
+        }
+    )
+
+    validator.validate_request("echo", {"value": 42})
+    with pytest.raises(ValueError, match="Missing required parameters"):
+        validator.validate_request("echo", {"wrong": 42})

--- a/examples/AutoResearch/AutoResearch.ino
+++ b/examples/AutoResearch/AutoResearch.ino
@@ -458,6 +458,24 @@ void setup() {
     // if RPC routing is broken on a platform, fix the routing (see #2541).
 
     // ========================================================================
+    // Remote RPC Function Registration (before fallible peripheral setup)
+    // ========================================================================
+    // Pin-free bring-up and diagnostics must remain reachable even when a
+    // platform has no usable RX channel yet. In particular, stock RP2040
+    // boards can fail createRxDevice() during initial bring-up; registering
+    // below that early return left a live CDC transport with an empty RPC
+    // registry.
+    ss.clear();
+    ss << "\n[REMOTE RPC] Registering JSON RPC functions for dynamic control";
+    RemoteControlSingleton::instance().registerFunctions(g_autoresearch_state);
+
+    autoresearch::setupRpcAsyncTask(RemoteControlSingleton::instance(), 10);
+
+    // Stub: register self-running autoresearch client (no-op on hardware).
+    autoresearch::maybeRegisterStubAutorun(RemoteControlSingleton::instance(),
+                                          g_autoresearch_state);
+
+    // ========================================================================
     // RX Channel Setup
     // ========================================================================
 
@@ -484,29 +502,6 @@ void setup() {
 
     // PARLIO streaming validation (#2548) is now RPC-driven via the
     // `parlioStreamValidate` handler registered in AutoResearchRemote.cpp.
-
-    // ========================================================================
-    // Remote RPC Function Registration (EARLY - before GPIO baseline test)
-    // ========================================================================
-    // IMPORTANT: Register RPC functions BEFORE the GPIO baseline test so that
-    // even if setup() fails early, the testGpioConnection command can be used
-    // to diagnose hardware connection issues.
-
-    ss.clear();
-    ss << "\n[REMOTE RPC] Registering JSON RPC functions for dynamic control";
-
-    // Initialize RemoteControl singleton and register all RPC functions
-    RemoteControlSingleton::instance().registerFunctions(g_autoresearch_state);
-
-
-    // ========================================================================
-    // Async Task Setup - JSON-RPC Processing
-    // ========================================================================
-    autoresearch::setupRpcAsyncTask(RemoteControlSingleton::instance(), 10);
-
-    // Stub: register self-running autoresearch client (no-op on ESP32)
-    autoresearch::maybeRegisterStubAutorun(RemoteControlSingleton::instance(),
-                                          g_autoresearch_state);
 
     // ========================================================================
     // GPIO Baseline Test - Verify GPIO→GPIO path works before testing PARLIO


### PR DESCRIPTION
## Summary

- register AutoResearch RPC methods and start the RPC task before fallible RX/peripheral initialization, keeping pin-free diagnostics reachable on a stock unsoldered Pico
- preserve structured JSON-RPC errors instead of masking them as timeouts
- accept FastLED's compact `rpc.discover` schema while retaining legacy expanded-schema support
- handle opaque `arg0:unknown` payloads honestly without weakening typed-schema checks

Closes #3628. Advances #3629 and #3630.

## Validation

- `uv run --no-sync pytest ci/tests/test_rpc_schema_validator.py ci/tests/test_rpc_client_errors.py ci/tests/test_rpc_client_connect_spin_poll.py ci/tests/test_autoresearch_rpc_acceptance.py -q` — 37 passed
- targeted Ruff checks passed
- repeated real builds of AutoResearch for `rp2040` through fbuild
- genuine Pico 1 COM12, VID:PID `2E8A:000A`, serial `5303284720C4641C`
- RPC smoke PASS with 61 discovered methods and correct `-32601` propagation
- SIMD 85/85 PASS plus benchmark
- IEEE-754 35/35 PASS
- deliberate watchdog hang ACK, USB disconnect/reset, COM12 recovery, post-reset ping, and full RPC smoke PASS
- ten consecutive fbuild deploy-to-RPC cycles: 10/10 PASS

No GPIO discovery, pins, jumpers, headers, logic analyser, or LED strip were used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - JSON-RPC server errors are now reported accurately instead of being incorrectly shown as timeouts.
  - RPC schema validation now supports both compact and expanded schema formats.
  - Validation messages are clearer for malformed schemas and invalid requests.
  - Methods with flexible or no parameters now accept appropriate payloads.
  - Remote RPC diagnostics remain available even when peripheral setup encounters an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->