### PR TITLE
feat(rp): centralize PIO and DMA resource ownership

### DIFF
--- a/src/platforms/arm/rp/rpcommon/clockless_rp_pio.h
+++ b/src/platforms/arm/rp/rpcommon/clockless_rp_pio.h
@@ -31,6 +31,7 @@
 #pragma GCC diagnostic pop
 
 #include "platforms/arm/rp/rpcommon/pio_gen.h"
+#include "platforms/arm/rp/rpcommon/rp_pio_dma_resource_manager.h"
 #include "fl/stl/allocator.h"
 #include "fl/stl/cstring.h"
 #include "fl/stl/noexcept.h"
@@ -167,44 +168,42 @@ public:
             T3_mult = T3;
         }
         
-        PIO pio;
-        int sm;
+        PIO pio = nullptr;
+        int sm = -1;
         int offset = -1;
-        
-	#if defined(FL_IS_RP2350)
-		// RP2350 features three PIO instances!
-		const PIO pios[NUM_PIOS] = { pio0, pio1, pio2 };
-	#elif defined(FL_IS_RP2040)
-        // RP2040: find an unclaimed PIO state machine and upload the clockless program
-        // There are two PIO instances, each with four state machines
-		const PIO pios[NUM_PIOS] = { pio0, pio1 };
-	#else
-		#error "Unsupported RP platform: expected FL_IS_RP2040 or FL_IS_RP2350"
-	#endif
-        // iterate over PIO instances
-        for (u32 i = 0; i < NUM_PIOS; i++) {
-            pio = pios[i];
-            sm = pio_claim_unused_sm(pio, false); // claim a state machine
-            if (sm == -1) continue; // skip this PIO if no unused sm
-            
+        auto& resources = RpPioDmaResourceManager::instance();
+        while (resources.claimPioStateMachine(&pio, &sm)) {
             offset = add_clockless_pio_program(pio, T1_mult, T2_mult, T3_mult);
             if (offset == -1) {
-                pio_sm_unclaim(pio, sm); // unclaim the state machine and skip this PIO
-                continue;                // if program couldn't be added
+                resources.releasePioStateMachine(pio, sm);
+                pio = nullptr;
+                sm = -1;
+                continue;
             }
-            
-            break; // found pio and sm that work
+            break;
         }
-        if (offset == -1) return; // couldn't find good pio and sm
+        if (offset == -1) return;
 
         // Store PIO, state machine, and offset for later use
         mPio = pio;
         mSm = sm;
         mPioOffset = offset;
 
-        // claim an unused DMA channel (there's 12 in total,, so this should also usually work out fine)
-        dma_channel = dma_claim_unused_channel(false);
-        if (dma_channel == -1) return; // no free DMA channel
+        if (!resources.claimDmaChannel(&dma_channel)) {
+            resources.releasePioStateMachine(mPio, mSm);
+            mPio = nullptr;
+            mSm = -1;
+            return;
+        }
+
+        if (!resources.claimPins(DATA_PIN, 1)) {
+            resources.releaseDmaChannel(dma_channel);
+            resources.releasePioStateMachine(mPio, mSm);
+            dma_channel = -1;
+            mPio = nullptr;
+            mSm = -1;
+            return;
+        }
 
 
         // setup PIO state machine

--- a/src/platforms/arm/rp/rpcommon/clockless_rp_pio_auto.cpp.hpp
+++ b/src/platforms/arm/rp/rpcommon/clockless_rp_pio_auto.cpp.hpp
@@ -9,6 +9,7 @@
 #include "fl/system/fastled.h"
 
 #include "platforms/arm/rp/rpcommon/clockless_rp_pio_auto.h"
+#include "platforms/arm/rp/rpcommon/rp_pio_dma_resource_manager.h"
 #include "platforms/arm/rp/rpcommon/parallel_transpose.h"
 #include "fl/gfx/rectangular_draw_buffer.h"
 #include "fl/stl/singleton.h"
@@ -56,37 +57,43 @@ struct Rp2040PinGroup {
 
     void cleanup() {
         if (dma_chan != -1) {
-            dma_channel_unclaim(dma_chan);
+            RpPioDmaResourceManager::instance().releaseDmaChannel(dma_chan);
             dma_chan = -1;
         }
         if (sm != -1 && pio != nullptr) {
             pio_sm_set_enabled(pio, sm, false);
-            pio_sm_unclaim(pio, sm);
+            RpPioDmaResourceManager::instance().releasePioStateMachine(pio, sm);
             sm = -1;
         }
+        RpPioDmaResourceManager::instance().releasePins(base_pin, num_pins);
         transpose_buffer.reset();
         buffer_size = 0;
     }
 
     bool allocateResources() {
-        // Try to claim PIO and DMA resources
-        pio = pio0;  // Start with pio0
-        sm = pio_claim_unused_sm(pio, false);
-        if (sm == -1) {
-            // Try pio1
-            pio = pio1;
-            sm = pio_claim_unused_sm(pio, false);
-            if (sm == -1) {
-                FL_WARN_F("Failed to claim PIO state machine for pin group starting at GPIO %s", (int)base_pin);
-                return false;
-            }
+        auto& resources = RpPioDmaResourceManager::instance();
+        int state_machine = -1;
+        if (!resources.claimPioStateMachine(&pio, &state_machine)) {
+            FL_WARN_F("Failed to claim PIO state machine for pin group starting at GPIO %s", (int)base_pin);
+            return false;
         }
+        sm = static_cast<i32>(state_machine);
 
-        dma_chan = dma_claim_unused_channel(false);
-        if (dma_chan == -1) {
-            pio_sm_unclaim(pio, sm);
+        int dma_channel = -1;
+        if (!resources.claimDmaChannel(&dma_channel)) {
+            resources.releasePioStateMachine(pio, state_machine);
             sm = -1;
             FL_WARN_F("Failed to claim DMA channel for pin group starting at GPIO %s", (int)base_pin);
+            return false;
+        }
+        dma_chan = static_cast<i32>(dma_channel);
+
+        if (!resources.claimPins(base_pin, num_pins)) {
+            resources.releaseDmaChannel(dma_channel);
+            resources.releasePioStateMachine(pio, state_machine);
+            dma_chan = -1;
+            sm = -1;
+            FL_WARN_F("Failed to claim pins for parallel group starting at GPIO %s", (int)base_pin);
             return false;
         }
 

--- a/src/platforms/arm/rp/rpcommon/clockless_rp_pio_parallel.h
+++ b/src/platforms/arm/rp/rpcommon/clockless_rp_pio_parallel.h
@@ -69,6 +69,7 @@
 #include "platforms/arm/rp/rpcommon/parallel_transpose.h"
 #include "fastled_delay.h"
 #include "platforms/arm/rp/is_rp.h"
+#include "platforms/arm/rp/rpcommon/rp_pio_dma_resource_manager.h"
 
 // Hardware headers for RP2040/RP2350
 #if defined(FL_IS_RP2040) || defined(FL_IS_RP2350)
@@ -177,30 +178,41 @@ public:
         }
 
 #if defined(FL_IS_RP2040) || defined(FL_IS_RP2350)
-        // Initialize GPIO pins
+        auto& resources = RpPioDmaResourceManager::instance();
+        int state_machine = -1;
+        if (!resources.claimPioStateMachine(&mPio, &state_machine)) {
+            fl::free(mTransposeBuffer);
+            mTransposeBuffer = nullptr;
+            return;
+        }
+        mSm = static_cast<u32>(state_machine);
+
+        int dma_channel = -1;
+        if (!resources.claimDmaChannel(&dma_channel)) {
+            resources.releasePioStateMachine(mPio, state_machine);
+            fl::free(mTransposeBuffer);
+            mTransposeBuffer = nullptr;
+            mPio = nullptr;
+            mSm = -1;
+            return;
+        }
+        mDmaChan = static_cast<i32>(dma_channel);
+
+        if (!resources.claimPins(BASE_PIN, NUM_LANES)) {
+            resources.releaseDmaChannel(dma_channel);
+            resources.releasePioStateMachine(mPio, state_machine);
+            fl::free(mTransposeBuffer);
+            mTransposeBuffer = nullptr;
+            mPio = nullptr;
+            mSm = -1;
+            mDmaChan = -1;
+            return;
+        }
+
+        // Configure pins only after ownership has been claimed.
         for (int i = 0; i < NUM_LANES; i++) {
             gpio_init(BASE_PIN + i);
             gpio_set_dir(BASE_PIN + i, GPIO_OUT);
-        }
-
-        // Try to claim PIO and DMA on actual hardware
-        #if defined(FL_IS_RP2040)
-            mPio = pio0;  // Simplified: just use pio0
-        #elif defined(FL_IS_RP2350)
-            mPio = pio0;  // Simplified: just use pio0
-        #endif
-
-        mSm = pio_claim_unused_sm(mPio, false);
-        if (mSm == -1) {
-            fl::free(mTransposeBuffer);
-            return;
-        }
-
-        mDmaChan = dma_claim_unused_channel(false);
-        if (mDmaChan == -1) {
-            pio_sm_unclaim(mPio, mSm);
-            fl::free(mTransposeBuffer);
-            return;
         }
 #endif
     }
@@ -287,14 +299,15 @@ private:
     void cleanup() FL_NO_EXCEPT {
 #if defined(FL_IS_RP2040) || defined(FL_IS_RP2350)
         if (mDmaChan != -1) {
-            dma_channel_unclaim(mDmaChan);
+            RpPioDmaResourceManager::instance().releaseDmaChannel(mDmaChan);
             mDmaChan = -1;
         }
         if (mSm != -1 && mPio != nullptr) {
             pio_sm_set_enabled(mPio, mSm, false);
-            pio_sm_unclaim(mPio, mSm);
+            RpPioDmaResourceManager::instance().releasePioStateMachine(mPio, mSm);
             mSm = -1;
         }
+        RpPioDmaResourceManager::instance().releasePins(BASE_PIN, NUM_LANES);
 #endif
         if (mTransposeBuffer != nullptr) {
             fl::free(mTransposeBuffer);

--- a/src/platforms/arm/rp/rpcommon/rp_pio_dma_resource_manager.h
+++ b/src/platforms/arm/rp/rpcommon/rp_pio_dma_resource_manager.h
@@ -1,0 +1,178 @@
+#pragma once
+
+// IWYU pragma: private
+
+/// @file rp_pio_dma_resource_manager.h
+/// @brief Pico SDK adapter for FastLED's RP PIO, DMA, and pin ownership ledger.
+
+#include "platforms/arm/rp/is_rp.h"
+
+#if defined(FL_IS_RP2040) || defined(FL_IS_RP2350)
+
+#include "platforms/arm/rp/rpcommon/rp_resource_ledger.h"
+#include "fl/stl/singleton.h"
+
+// IWYU pragma: begin_keep
+#include "hardware/dma.h"
+// IWYU pragma: end_keep
+// IWYU pragma: begin_keep
+#include "hardware/pio.h"
+// IWYU pragma: end_keep
+// IWYU pragma: begin_keep
+#include "hardware/sync.h"
+// IWYU pragma: end_keep
+
+namespace fl {
+
+/// @brief Coordinates SDK claims with the host-testable FastLED ownership ledger.
+///
+/// Pico SDK claim functions protect hardware resources shared with user code.
+/// The ledger mirrors successful SDK claims under a hardware spinlock, so
+/// cleanup and partial-initialization rollback are deterministic across both
+/// RP cores.
+class RpPioDmaResourceManager {
+  public:
+    static RpPioDmaResourceManager& instance() FL_NO_EXCEPT {
+        return Singleton<RpPioDmaResourceManager>::instance();
+    }
+
+    bool claimPioStateMachine(PIO* pio_out, int* state_machine_out) FL_NO_EXCEPT {
+        LockGuard lock(*this);
+        if (pio_out == nullptr || state_machine_out == nullptr) {
+            return false;
+        }
+
+        for (u8 pio_index = 0; pio_index < NUM_PIOS; ++pio_index) {
+            PIO pio = pioForIndex(pio_index);
+            int state_machine = pio_claim_unused_sm(pio, false);
+            if (state_machine < 0) {
+                continue;
+            }
+            if (mLedger.claimPioStateMachine(pio_index, static_cast<u8>(state_machine))) {
+                *pio_out = pio;
+                *state_machine_out = state_machine;
+                return true;
+            }
+            pio_sm_unclaim(pio, static_cast<uint>(state_machine));
+        }
+        return false;
+    }
+
+    void releasePioStateMachine(PIO pio, int state_machine) FL_NO_EXCEPT {
+        LockGuard lock(*this);
+        if (pio == nullptr || state_machine < 0) {
+            return;
+        }
+        const int pio_index = pioIndex(pio);
+        if (pio_index < 0) {
+            return;
+        }
+        pio_sm_unclaim(pio, static_cast<uint>(state_machine));
+        mLedger.releasePioStateMachine(static_cast<u8>(pio_index),
+                                       static_cast<u8>(state_machine));
+    }
+
+    bool claimDmaChannel(int* channel_out) FL_NO_EXCEPT {
+        LockGuard lock(*this);
+        if (channel_out == nullptr) {
+            return false;
+        }
+        const int channel = dma_claim_unused_channel(false);
+        if (channel < 0) {
+            return false;
+        }
+        if (mLedger.claimDmaChannel(static_cast<u8>(channel))) {
+            *channel_out = channel;
+            return true;
+        }
+        dma_channel_unclaim(static_cast<uint>(channel));
+        return false;
+    }
+
+    void releaseDmaChannel(int channel) FL_NO_EXCEPT {
+        LockGuard lock(*this);
+        if (channel < 0) {
+            return;
+        }
+        dma_channel_unclaim(static_cast<uint>(channel));
+        mLedger.releaseDmaChannel(static_cast<u8>(channel));
+    }
+
+    bool claimPins(u8 first_pin, u8 count) FL_NO_EXCEPT {
+        LockGuard lock(*this);
+        for (u8 offset = 0; offset < count; ++offset) {
+            if (!mLedger.claimPin(first_pin + offset)) {
+                while (offset > 0) {
+                    --offset;
+                    mLedger.releasePin(first_pin + offset);
+                }
+                return false;
+            }
+        }
+        return true;
+    }
+
+    void releasePins(u8 first_pin, u8 count) FL_NO_EXCEPT {
+        LockGuard lock(*this);
+        for (u8 offset = 0; offset < count; ++offset) {
+            mLedger.releasePin(first_pin + offset);
+        }
+    }
+
+    RpPioDmaResourceManager() FL_NO_EXCEPT
+        : mLedger(NUM_PIOS, RpResourceLedger::kMaxStateMachinesPerPio,
+                  NUM_DMA_CHANNELS, RpResourceLedger::kMaxPins)
+        , mLock(spin_lock_instance(spin_lock_claim_unused(true))) {}
+
+  private:
+    class LockGuard {
+      public:
+        explicit LockGuard(RpPioDmaResourceManager& manager) FL_NO_EXCEPT
+            : mLock(manager.mLock)
+            , mInterruptState(spin_lock_blocking(mLock)) {}
+
+        ~LockGuard() {
+            spin_unlock(mLock, mInterruptState);
+        }
+
+      private:
+        spin_lock_t* mLock;
+        u32 mInterruptState;
+    };
+
+    static PIO pioForIndex(u8 index) FL_NO_EXCEPT {
+        if (index == 0) {
+            return pio0;
+        }
+        if (index == 1) {
+            return pio1;
+        }
+#if defined(FL_IS_RP2350)
+        return pio2;
+#else
+        return nullptr;
+#endif
+    }
+
+    static int pioIndex(PIO pio) FL_NO_EXCEPT {
+        if (pio == pio0) {
+            return 0;
+        }
+        if (pio == pio1) {
+            return 1;
+        }
+#if defined(FL_IS_RP2350)
+        if (pio == pio2) {
+            return 2;
+        }
+#endif
+        return -1;
+    }
+
+    RpResourceLedger mLedger;
+    spin_lock_t* mLock;
+};
+
+}  // namespace fl
+
+#endif  // defined(FL_IS_RP2040) || defined(FL_IS_RP2350)

--- a/src/platforms/arm/rp/rpcommon/rp_resource_ledger.h
+++ b/src/platforms/arm/rp/rpcommon/rp_resource_ledger.h
@@ -1,0 +1,133 @@
+#pragma once
+
+// IWYU pragma: private
+
+/// @file rp_resource_ledger.h
+/// @brief Lock-free ownership ledger shared by RP2040/RP2350 PIO drivers.
+///
+/// The Pico SDK owns the hardware claim bits. This ledger records FastLED's
+/// matching ownership so a driver can make rollback and cleanup deterministic
+/// without relying on a particular peripheral implementation. It deliberately
+/// has no Pico SDK dependency, which keeps the resource contract testable on
+/// the host.
+
+#include "fl/stl/atomic.h"
+#include "fl/stl/int.h"
+#include "fl/stl/noexcept.h"
+
+namespace fl {
+
+class RpResourceLedger {
+  public:
+    static constexpr u8 kMaxPioBlocks = 3;
+    static constexpr u8 kMaxStateMachinesPerPio = 4;
+    static constexpr u8 kMaxDmaChannels = 32;
+    static constexpr u8 kMaxPins = 64;
+
+    RpResourceLedger(u8 pio_blocks = kMaxPioBlocks,
+                     u8 state_machines_per_pio = kMaxStateMachinesPerPio,
+                     u8 dma_channels = kMaxDmaChannels,
+                     u8 pins = kMaxPins) FL_NO_EXCEPT
+        : mPioBlocks(pio_blocks > kMaxPioBlocks ? kMaxPioBlocks : pio_blocks)
+        , mStateMachinesPerPio(state_machines_per_pio > kMaxStateMachinesPerPio
+                                   ? kMaxStateMachinesPerPio
+                                   : state_machines_per_pio)
+        , mDmaChannels(dma_channels > kMaxDmaChannels ? kMaxDmaChannels : dma_channels)
+        , mPins(pins > kMaxPins ? kMaxPins : pins) {
+        reset();
+    }
+
+    bool claimPioStateMachine(u8 pio, u8 state_machine) FL_NO_EXCEPT {
+        if (pio >= mPioBlocks || state_machine >= mStateMachinesPerPio) {
+            return false;
+        }
+        return claimBit(mPioStateMachines[pio], state_machine);
+    }
+
+    bool releasePioStateMachine(u8 pio, u8 state_machine) FL_NO_EXCEPT {
+        if (pio >= mPioBlocks || state_machine >= mStateMachinesPerPio) {
+            return false;
+        }
+        return releaseBit(mPioStateMachines[pio], state_machine);
+    }
+
+    bool isPioStateMachineClaimed(u8 pio, u8 state_machine) const FL_NO_EXCEPT {
+        if (pio >= mPioBlocks || state_machine >= mStateMachinesPerPio) {
+            return false;
+        }
+        return isBitClaimed(mPioStateMachines[pio], state_machine);
+    }
+
+    bool claimDmaChannel(u8 channel) FL_NO_EXCEPT {
+        return channel < mDmaChannels && claimBit(mDmaChannelsClaimed, channel);
+    }
+
+    bool releaseDmaChannel(u8 channel) FL_NO_EXCEPT {
+        return channel < mDmaChannels && releaseBit(mDmaChannelsClaimed, channel);
+    }
+
+    bool isDmaChannelClaimed(u8 channel) const FL_NO_EXCEPT {
+        return channel < mDmaChannels && isBitClaimed(mDmaChannelsClaimed, channel);
+    }
+
+    bool claimPin(u8 pin) FL_NO_EXCEPT {
+        return pin < mPins && claimBit(mPinsClaimed[pin / 32], pin % 32);
+    }
+
+    bool releasePin(u8 pin) FL_NO_EXCEPT {
+        return pin < mPins && releaseBit(mPinsClaimed[pin / 32], pin % 32);
+    }
+
+    bool isPinClaimed(u8 pin) const FL_NO_EXCEPT {
+        return pin < mPins && isBitClaimed(mPinsClaimed[pin / 32], pin % 32);
+    }
+
+    void reset() FL_NO_EXCEPT {
+        for (u8 pio = 0; pio < kMaxPioBlocks; ++pio) {
+            mPioStateMachines[pio].store(0, memory_order_release);
+        }
+        mDmaChannelsClaimed.store(0, memory_order_release);
+        for (u8 word = 0; word < 2; ++word) {
+            mPinsClaimed[word].store(0, memory_order_release);
+        }
+    }
+
+  private:
+    static bool claimBit(atomic<u32>& claims, u8 bit) FL_NO_EXCEPT {
+        const u32 mask = 1u << bit;
+        u32 expected = claims.load(memory_order_acquire);
+        while ((expected & mask) == 0) {
+            if (claims.compare_exchange_weak(expected, expected | mask,
+                                             memory_order_acq_rel)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    static bool releaseBit(atomic<u32>& claims, u8 bit) FL_NO_EXCEPT {
+        const u32 mask = 1u << bit;
+        u32 expected = claims.load(memory_order_acquire);
+        while ((expected & mask) != 0) {
+            if (claims.compare_exchange_weak(expected, expected & ~mask,
+                                             memory_order_acq_rel)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    static bool isBitClaimed(const atomic<u32>& claims, u8 bit) FL_NO_EXCEPT {
+        return (claims.load(memory_order_acquire) & (1u << bit)) != 0;
+    }
+
+    u8 mPioBlocks;
+    u8 mStateMachinesPerPio;
+    u8 mDmaChannels;
+    u8 mPins;
+    atomic<u32> mPioStateMachines[kMaxPioBlocks];
+    atomic<u32> mDmaChannelsClaimed;
+    atomic<u32> mPinsClaimed[2];
+};
+
+}  // namespace fl

--- a/src/platforms/arm/rp/rpcommon/spi_hw_2_rp.cpp.hpp
+++ b/src/platforms/arm/rp/rpcommon/spi_hw_2_rp.cpp.hpp
@@ -25,6 +25,7 @@
 #include "hardware/pio.h"
 // IWYU pragma: end_keep
 #include "platforms/arm/rp/rpcommon/pio_asm.h"
+#include "platforms/arm/rp/rpcommon/rp_pio_dma_resource_manager.h"
 #include "fl/log/log.h"
 #include "fl/stl/limits.h"
 // IWYU pragma: begin_keep
@@ -259,30 +260,20 @@ bool SPIDualRP2040::begin(const SpiHw2::Config& config) {
     mData0Pin = config.data0_pin;
     mData1Pin = config.data1_pin;
 
-    // Find available PIO instance and state machine
-#if defined(FL_IS_RP2040)
-    const PIO pios[NUM_PIOS] = { pio0, pio1 };
-#elif defined(FL_IS_RP2350)
-    const PIO pios[NUM_PIOS] = { pio0, pio1, pio2 };
-#endif
-
+    // Claim PIO through the shared RP ownership manager.
+    auto& resources = RpPioDmaResourceManager::instance();
     mPIO = nullptr;
     mStateMachine = -1;
     mPIOOffset = -1;
 
-    for (u32 i = 0; i < NUM_PIOS; i++) {
-        PIO pio = pios[i];
-        int sm = pio_claim_unused_sm(pio, false);
-        if (sm == -1) continue;
-
-        int offset = add_spi_dual_pio_program(pio);
+    while (resources.claimPioStateMachine(&mPIO, &mStateMachine)) {
+        int offset = add_spi_dual_pio_program(mPIO);
         if (offset == -1) {
-            pio_sm_unclaim(pio, sm);
+            resources.releasePioStateMachine(mPIO, mStateMachine);
+            mPIO = nullptr;
+            mStateMachine = -1;
             continue;
         }
-
-        mPIO = pio;
-        mStateMachine = sm;
         mPIOOffset = offset;
         break;
     }
@@ -293,10 +284,9 @@ bool SPIDualRP2040::begin(const SpiHw2::Config& config) {
     }
 
     // Claim DMA channel
-    mDMAChannel = dma_claim_unused_channel(false);
-    if (mDMAChannel == -1) {
+    if (!resources.claimDmaChannel(&mDMAChannel)) {
         FL_WARN_F("SPIDualRP2040: No available DMA channel");
-        pio_sm_unclaim(mPIO, mStateMachine);
+        resources.releasePioStateMachine(mPIO, mStateMachine);
         return false;
     }
 
@@ -304,8 +294,17 @@ bool SPIDualRP2040::begin(const SpiHw2::Config& config) {
     // Data pins must be consecutive
     if (mData1Pin != mData0Pin + 1) {
         FL_WARN_F("SPIDualRP2040: Data pins must be consecutive (D0, D0+1)");
-        dma_channel_unclaim(mDMAChannel);
-        pio_sm_unclaim(mPIO, mStateMachine);
+        resources.releaseDmaChannel(mDMAChannel);
+        resources.releasePioStateMachine(mPIO, mStateMachine);
+        return false;
+    }
+
+    if (!resources.claimPins(mData0Pin, 2) || !resources.claimPins(mClockPin, 1)) {
+        resources.releasePins(mData0Pin, 2);
+        resources.releasePins(mClockPin, 1);
+        resources.releaseDmaChannel(mDMAChannel);
+        resources.releasePioStateMachine(mPIO, mStateMachine);
+        FL_WARN_F("SPIDualRP2040: Pins are already owned by another RP PIO driver");
         return false;
     }
 
@@ -528,14 +527,16 @@ void SPIDualRP2040::cleanup() {
         // Disable and unclaim PIO state machine
         if (mPIO != nullptr && mStateMachine != -1) {
             pio_sm_set_enabled(mPIO, mStateMachine, false);
-            pio_sm_unclaim(mPIO, mStateMachine);
+            RpPioDmaResourceManager::instance().releasePioStateMachine(mPIO, mStateMachine);
         }
 
         // Release DMA channel
         if (mDMAChannel != -1) {
-            dma_channel_unclaim(mDMAChannel);
+            RpPioDmaResourceManager::instance().releaseDmaChannel(mDMAChannel);
             mDMAChannel = -1;
         }
+        RpPioDmaResourceManager::instance().releasePins(mData0Pin, 2);
+        RpPioDmaResourceManager::instance().releasePins(mClockPin, 1);
 
         mInitialized = false;
     }

--- a/src/platforms/arm/rp/rpcommon/spi_hw_4_rp.cpp.hpp
+++ b/src/platforms/arm/rp/rpcommon/spi_hw_4_rp.cpp.hpp
@@ -25,6 +25,7 @@
 #include "hardware/pio.h"
 // IWYU pragma: end_keep
 #include "platforms/arm/rp/rpcommon/pio_asm.h"
+#include "platforms/arm/rp/rpcommon/rp_pio_dma_resource_manager.h"
 #include "fl/log/log.h"
 #include "fl/stl/limits.h"
 // IWYU pragma: begin_keep
@@ -273,30 +274,20 @@ bool SPIQuadRP2040::begin(const SpiHw4::Config& config) {
     mData2Pin = config.data2_pin;
     mData3Pin = config.data3_pin;
 
-    // Find available PIO instance and state machine
-#if defined(FL_IS_RP2040)
-    const PIO pios[NUM_PIOS] = { pio0, pio1 };
-#elif defined(FL_IS_RP2350)
-    const PIO pios[NUM_PIOS] = { pio0, pio1, pio2 };
-#endif
-
+    // Claim PIO through the shared RP ownership manager.
+    auto& resources = RpPioDmaResourceManager::instance();
     mPIO = nullptr;
     mStateMachine = -1;
     mPIOOffset = -1;
 
-    for (u32 i = 0; i < NUM_PIOS; i++) {
-        PIO pio = pios[i];
-        int sm = pio_claim_unused_sm(pio, false);
-        if (sm == -1) continue;
-
-        int offset = add_spi_quad_pio_program(pio);
+    while (resources.claimPioStateMachine(&mPIO, &mStateMachine)) {
+        int offset = add_spi_quad_pio_program(mPIO);
         if (offset == -1) {
-            pio_sm_unclaim(pio, sm);
+            resources.releasePioStateMachine(mPIO, mStateMachine);
+            mPIO = nullptr;
+            mStateMachine = -1;
             continue;
         }
-
-        mPIO = pio;
-        mStateMachine = sm;
         mPIOOffset = offset;
         break;
     }
@@ -307,10 +298,9 @@ bool SPIQuadRP2040::begin(const SpiHw4::Config& config) {
     }
 
     // Claim DMA channel
-    mDMAChannel = dma_claim_unused_channel(false);
-    if (mDMAChannel == -1) {
+    if (!resources.claimDmaChannel(&mDMAChannel)) {
         FL_WARN_F("SPIQuadRP2040: No available DMA channel");
-        pio_sm_unclaim(mPIO, mStateMachine);
+        resources.releasePioStateMachine(mPIO, mStateMachine);
         return false;
     }
 
@@ -320,10 +310,33 @@ bool SPIQuadRP2040::begin(const SpiHw4::Config& config) {
         // Full quad mode - all 4 pins must be consecutive
         if (mData1Pin != mData0Pin + 1 || mData2Pin != mData0Pin + 2 || mData3Pin != mData0Pin + 3) {
             FL_WARN_F("SPIQuadRP2040: Data pins must be consecutive (D0, D0+1, D0+2, D0+3)");
-            dma_channel_unclaim(mDMAChannel);
-            pio_sm_unclaim(mPIO, mStateMachine);
+            resources.releaseDmaChannel(mDMAChannel);
+            resources.releasePioStateMachine(mPIO, mStateMachine);
             return false;
         }
+    }
+
+    bool pins_claimed = resources.claimPins(mData0Pin, 1) &&
+                        resources.claimPins(mClockPin, 1);
+    if (pins_claimed && mData1Pin >= 0) {
+        pins_claimed = resources.claimPins(mData1Pin, 1);
+    }
+    if (pins_claimed && mData2Pin >= 0) {
+        pins_claimed = resources.claimPins(mData2Pin, 1);
+    }
+    if (pins_claimed && mData3Pin >= 0) {
+        pins_claimed = resources.claimPins(mData3Pin, 1);
+    }
+    if (!pins_claimed) {
+        resources.releasePins(mData0Pin, 1);
+        resources.releasePins(mClockPin, 1);
+        if (mData1Pin >= 0) resources.releasePins(mData1Pin, 1);
+        if (mData2Pin >= 0) resources.releasePins(mData2Pin, 1);
+        if (mData3Pin >= 0) resources.releasePins(mData3Pin, 1);
+        resources.releaseDmaChannel(mDMAChannel);
+        resources.releasePioStateMachine(mPIO, mStateMachine);
+        FL_WARN_F("SPIQuadRP2040: Pins are already owned by another RP PIO driver");
+        return false;
     }
 
     // Initialize active data pins
@@ -567,14 +580,20 @@ void SPIQuadRP2040::cleanup() {
         // Disable and unclaim PIO state machine
         if (mPIO != nullptr && mStateMachine != -1) {
             pio_sm_set_enabled(mPIO, mStateMachine, false);
-            pio_sm_unclaim(mPIO, mStateMachine);
+            RpPioDmaResourceManager::instance().releasePioStateMachine(mPIO, mStateMachine);
         }
 
         // Release DMA channel
         if (mDMAChannel != -1) {
-            dma_channel_unclaim(mDMAChannel);
+            RpPioDmaResourceManager::instance().releaseDmaChannel(mDMAChannel);
             mDMAChannel = -1;
         }
+        auto& resources = RpPioDmaResourceManager::instance();
+        resources.releasePins(mData0Pin, 1);
+        resources.releasePins(mClockPin, 1);
+        if (mData1Pin >= 0) resources.releasePins(mData1Pin, 1);
+        if (mData2Pin >= 0) resources.releasePins(mData2Pin, 1);
+        if (mData3Pin >= 0) resources.releasePins(mData3Pin, 1);
 
         mInitialized = false;
     }

--- a/src/platforms/arm/rp/rpcommon/spi_hw_8_rp.cpp.hpp
+++ b/src/platforms/arm/rp/rpcommon/spi_hw_8_rp.cpp.hpp
@@ -25,6 +25,7 @@
 #include "hardware/pio.h"
 // IWYU pragma: end_keep
 #include "platforms/arm/rp/rpcommon/pio_asm.h"
+#include "platforms/arm/rp/rpcommon/rp_pio_dma_resource_manager.h"
 #include "fl/log/log.h"
 #include "fl/stl/limits.h"
 // IWYU pragma: begin_keep
@@ -286,30 +287,20 @@ bool SpiHw8RP2040::begin(const SpiHw8::Config& config) {
         }
     }
 
-    // Find available PIO instance and state machine
-#if defined(FL_IS_RP2040)
-    const PIO pios[NUM_PIOS] = { pio0, pio1 };
-#elif defined(FL_IS_RP2350)
-    const PIO pios[NUM_PIOS] = { pio0, pio1, pio2 };
-#endif
-
+    // Claim PIO through the shared RP ownership manager.
+    auto& resources = RpPioDmaResourceManager::instance();
     mPIO = nullptr;
     mStateMachine = -1;
     mPIOOffset = -1;
 
-    for (u32 i = 0; i < NUM_PIOS; i++) {
-        PIO pio = pios[i];
-        int sm = pio_claim_unused_sm(pio, false);
-        if (sm == -1) continue;
-
-        int offset = add_spi_octal_pio_program(pio);
+    while (resources.claimPioStateMachine(&mPIO, &mStateMachine)) {
+        int offset = add_spi_octal_pio_program(mPIO);
         if (offset == -1) {
-            pio_sm_unclaim(pio, sm);
+            resources.releasePioStateMachine(mPIO, mStateMachine);
+            mPIO = nullptr;
+            mStateMachine = -1;
             continue;
         }
-
-        mPIO = pio;
-        mStateMachine = sm;
         mPIOOffset = offset;
         break;
     }
@@ -320,10 +311,18 @@ bool SpiHw8RP2040::begin(const SpiHw8::Config& config) {
     }
 
     // Claim DMA channel
-    mDMAChannel = dma_claim_unused_channel(false);
-    if (mDMAChannel == -1) {
+    if (!resources.claimDmaChannel(&mDMAChannel)) {
         FL_WARN_F("SpiHw8RP2040: No available DMA channel");
-        pio_sm_unclaim(mPIO, mStateMachine);
+        resources.releasePioStateMachine(mPIO, mStateMachine);
+        return false;
+    }
+
+    if (!resources.claimPins(mDataPins[0], 8) || !resources.claimPins(mClockPin, 1)) {
+        resources.releasePins(mDataPins[0], 8);
+        resources.releasePins(mClockPin, 1);
+        resources.releaseDmaChannel(mDMAChannel);
+        resources.releasePioStateMachine(mPIO, mStateMachine);
+        FL_WARN_F("SpiHw8RP2040: Pins are already owned by another RP PIO driver");
         return false;
     }
 
@@ -546,14 +545,16 @@ void SpiHw8RP2040::cleanup() {
         // Disable and unclaim PIO state machine
         if (mPIO != nullptr && mStateMachine != -1) {
             pio_sm_set_enabled(mPIO, mStateMachine, false);
-            pio_sm_unclaim(mPIO, mStateMachine);
+            RpPioDmaResourceManager::instance().releasePioStateMachine(mPIO, mStateMachine);
         }
 
         // Release DMA channel
         if (mDMAChannel != -1) {
-            dma_channel_unclaim(mDMAChannel);
+            RpPioDmaResourceManager::instance().releaseDmaChannel(mDMAChannel);
             mDMAChannel = -1;
         }
+        RpPioDmaResourceManager::instance().releasePins(mDataPins[0], 8);
+        RpPioDmaResourceManager::instance().releasePins(mClockPin, 1);
 
         mInitialized = false;
     }

--- a/tests/platforms/arm/rp/rpcommon/rp_resource_ledger.cpp
+++ b/tests/platforms/arm/rp/rpcommon/rp_resource_ledger.cpp
@@ -1,0 +1,68 @@
+/// @file rp_resource_ledger.cpp
+/// @brief Host tests for the RP2040/RP2350 resource ownership contract.
+
+#include "platforms/arm/rp/rpcommon/rp_resource_ledger.h"
+#include "fl/stl/atomic.h"
+#include "fl/stl/thread.h"
+#include "test.h"
+
+FL_TEST_FILE(FL_FILEPATH) {
+
+using namespace fl;
+
+FL_TEST_CASE("RP resource ledger rejects duplicate and out-of-range claims") {
+    RpResourceLedger ledger(2, 4, 12, 30);
+
+    FL_CHECK(ledger.claimPioStateMachine(0, 0));
+    FL_CHECK_FALSE(ledger.claimPioStateMachine(0, 0));
+    FL_CHECK(ledger.isPioStateMachineClaimed(0, 0));
+    FL_CHECK_FALSE(ledger.claimPioStateMachine(2, 0));
+    FL_CHECK_FALSE(ledger.claimPioStateMachine(0, 4));
+
+    FL_CHECK(ledger.claimDmaChannel(11));
+    FL_CHECK_FALSE(ledger.claimDmaChannel(12));
+    FL_CHECK(ledger.claimPin(29));
+    FL_CHECK_FALSE(ledger.claimPin(30));
+}
+
+FL_TEST_CASE("RP resource ledger cleanup restores partial acquisitions") {
+    RpResourceLedger ledger(2, 4, 2, 30);
+
+    FL_REQUIRE(ledger.claimPioStateMachine(1, 3));
+    FL_REQUIRE(ledger.claimDmaChannel(1));
+    FL_REQUIRE(ledger.claimPin(4));
+
+    FL_CHECK(ledger.releasePin(4));
+    FL_CHECK(ledger.releaseDmaChannel(1));
+    FL_CHECK(ledger.releasePioStateMachine(1, 3));
+    FL_CHECK_FALSE(ledger.releasePioStateMachine(1, 3));
+
+    FL_CHECK(ledger.claimPioStateMachine(1, 3));
+    FL_CHECK(ledger.claimDmaChannel(1));
+    FL_CHECK(ledger.claimPin(4));
+}
+
+FL_TEST_CASE("RP resource ledger permits one dual-core winner per resource") {
+    RpResourceLedger ledger(2, 4, 12, 30);
+    atomic<int> winners(0);
+    constexpr int kContenders = 8;
+    thread contenders[kContenders] = {
+        thread([&]() { if (ledger.claimPioStateMachine(0, 1)) { winners.fetch_add(1); } }),
+        thread([&]() { if (ledger.claimPioStateMachine(0, 1)) { winners.fetch_add(1); } }),
+        thread([&]() { if (ledger.claimPioStateMachine(0, 1)) { winners.fetch_add(1); } }),
+        thread([&]() { if (ledger.claimPioStateMachine(0, 1)) { winners.fetch_add(1); } }),
+        thread([&]() { if (ledger.claimPioStateMachine(0, 1)) { winners.fetch_add(1); } }),
+        thread([&]() { if (ledger.claimPioStateMachine(0, 1)) { winners.fetch_add(1); } }),
+        thread([&]() { if (ledger.claimPioStateMachine(0, 1)) { winners.fetch_add(1); } }),
+        thread([&]() { if (ledger.claimPioStateMachine(0, 1)) { winners.fetch_add(1); } }),
+    };
+
+    for (int index = 0; index < kContenders; ++index) {
+        contenders[index].join();
+    }
+
+    FL_CHECK_EQ(winners.load(), 1);
+    FL_CHECK(ledger.isPioStateMachineClaimed(0, 1));
+}
+
+}  // FL_TEST_FILE


### PR DESCRIPTION
## Summary
- add a host-testable RP resource ledger for PIO state machines, DMA channels, and GPIO ownership
- add a Pico-SDK adapter serialized by an RP hardware spinlock
- migrate existing RP clockless, parallel, and 2/4/8-lane SPI allocation paths to transactional claim/release handling

## Validation
- `bash test tests/platforms/arm/rp/rpcommon/rp_resource_ledger.cpp`
- `uv run --no-sync python ci/lint_cpp/run_all_checkers.py --no-rust`
- `fbuild .build/pio/rp2040 build -e rp2040`

`bash lint`'s Rust checker cannot run locally because the installed Rust toolchain lacks `x86_64-pc-windows-msvc`; the Python-only C++ checker passed. fbuild deployment compilation passed, but the separate portless CDC-to-BOOTSEL transition regression is documented on FastLED/fbuild#1040.

Closes #3653

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved RP2040/RP2350 hardware resource management across clockless LED, parallel, and SPI drivers.
  - Prevented conflicts when multiple drivers share PIO state machines, DMA channels, or GPIO pins.
  - Added safer resource cleanup and retry handling when initialization is unsuccessful.

- **Tests**
  - Added coverage for resource conflicts, invalid claims, resource reuse, and concurrent access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->