### PR TITLE
feat(rp): add PIO RX lifecycle backend

### DIFF
--- a/src/fl/channels/rx.cpp.hpp
+++ b/src/fl/channels/rx.cpp.hpp
@@ -39,7 +39,25 @@
 // IWYU pragma: end_keep
 #endif
 
+#ifdef FL_IS_RP
+// IWYU pragma: begin_keep
+#include "platforms/arm/rp/rpcommon/rx_pio_channel.h"  // ok platform headers
+// IWYU pragma: end_keep
+#endif
+
 namespace fl {
+
+template <>
+fl::shared_ptr<RxDevice> RxDevice::create<RxDeviceType::PIO>(int pin) FL_NO_EXCEPT {
+#ifdef FL_IS_RP
+    return RpPioRxDevice::create(pin);
+#elif defined(FL_IS_STUB)
+    return NativeRxDevice::create(pin);
+#else
+    (void)pin;
+    return createDummy();
+#endif
+}
 
 // Private static helper - creates dummy device (singleton pattern)
 fl::shared_ptr<RxDevice> RxDevice::createDummy() FL_NO_EXCEPT {
@@ -369,10 +387,14 @@ fl::shared_ptr<RxDevice> RxDevice::create<RxDeviceType::LPC_SCT_CAPTURE>(int pin
     return RxDevice::createDummy();
 }
 
-// DEFAULT maps to RMT on unsupported platforms (returns dummy)
+// DEFAULT maps to PIO on RP and RMT elsewhere (returns dummy if unsupported).
 template <>
 fl::shared_ptr<RxDevice> RxDevice::create<RxDeviceType::PLATFORM_DEFAULT>(int pin) FL_NO_EXCEPT {
+#ifdef FL_IS_RP
+    return RxDevice::create<RxDeviceType::PIO>(pin);
+#else
     return RxDevice::create<RxDeviceType::RMT>(pin);
+#endif
 }
 
 #endif // FL_IS_ESP32 / FL_IS_TEENSY_4X / FL_IS_ARM_LPC / FL_IS_STUB

--- a/src/fl/channels/rx.h
+++ b/src/fl/channels/rx.h
@@ -161,6 +161,7 @@ enum class RxWaitResult : u8 {
  * factory pattern for compile-time device selection.
  */
 enum class RxDeviceType : u8 {
+    PIO = 7,              ///< PIO receiver (RP2040/RP2350)
     PLATFORM_DEFAULT = 0,  ///< Platform default (RMT on ESP32, FLEXPWM on Teensy 4.x; FLEXIO available as opt-in on Teensy 4 — see FastLED#2764; LPC_SCT_CAPTURE on LPC845)
     ISR = 1,              ///< GPIO ISR-based receiver (ESP32)
     RMT = 2,              ///< RMT-based receiver (ESP32)
@@ -184,6 +185,7 @@ inline const char* toString(RxDeviceType type) FL_NO_EXCEPT {
     case RxDeviceType::FLEXIO:  return "FLEXIO";
     case RxDeviceType::LPC_SCT_CAPTURE: return "LPC_SCT_CAPTURE";
     case RxDeviceType::I2S_RX: return "I2S_RX";
+    case RxDeviceType::PIO: return "PIO";
     }
     return "UNKNOWN";
 }
@@ -442,5 +444,6 @@ template <> fl::shared_ptr<RxDevice> RxDevice::create<RxDeviceType::RMT>(int pin
 template <> fl::shared_ptr<RxDevice> RxDevice::create<RxDeviceType::ISR>(int pin) FL_NO_EXCEPT;
 template <> fl::shared_ptr<RxDevice> RxDevice::create<RxDeviceType::FLEXPWM>(int pin) FL_NO_EXCEPT;
 template <> fl::shared_ptr<RxDevice> RxDevice::create<RxDeviceType::LPC_SCT_CAPTURE>(int pin) FL_NO_EXCEPT;
+template <> fl::shared_ptr<RxDevice> RxDevice::create<RxDeviceType::PIO>(int pin) FL_NO_EXCEPT;
 
 } // namespace fl

--- a/src/fl/channels/rx/channel.cpp.hpp
+++ b/src/fl/channels/rx/channel.cpp.hpp
@@ -37,6 +37,8 @@ static fl::shared_ptr<RxDevice> createBackendDevice(const RxChannelConfig& confi
         return RxDevice::create<RxDeviceType::LPC_SCT_CAPTURE>(config.pin);
     case RxBackend::I2S_RX:
         return RxDevice::create<RxDeviceType::I2S_RX>(config.pin);
+    case RxBackend::PIO:
+        return RxDevice::create<RxDeviceType::PIO>(config.pin);
     }
     return RxDevice::create<RxDeviceType::PLATFORM_DEFAULT>(config.pin);
 }

--- a/src/fl/channels/rx/types.h
+++ b/src/fl/channels/rx/types.h
@@ -6,6 +6,7 @@
 namespace fl {
 
 enum class RxBackend : u8 {
+    PIO = 7,               ///< RP2040/RP2350 PIO receive backend.
     PLATFORM_DEFAULT = 0,  ///< Use the recommended backend for the active platform (RMT on ESP32; FlexPWM on Teensy 4.x with FLEXIO as an opt-in alternative — see FastLED#2764; LPC_SCT_CAPTURE on LPC845; native RX on stub/host builds).
     RMT = 1,               ///< ESP32-only RMT capture backend.
     ISR = 2,               ///< Platform-neutral interrupt-driven edge capture backend when available.
@@ -24,6 +25,7 @@ inline const char* toString(RxBackend backend) FL_NO_EXCEPT {
     case RxBackend::FLEXIO: return "FLEXIO";
     case RxBackend::LPC_SCT_CAPTURE: return "LPC_SCT_CAPTURE";
     case RxBackend::I2S_RX: return "I2S_RX";
+    case RxBackend::PIO: return "PIO";
     }
     return "UNKNOWN";
 }

--- a/src/platforms/arm/rp/rpcommon/_build.cpp.hpp
+++ b/src/platforms/arm/rp/rpcommon/_build.cpp.hpp
@@ -6,6 +6,7 @@
 
 #include "platforms/arm/rp/rpcommon/clockless_rp_pio_auto.cpp.hpp"
 #include "platforms/arm/rp/rpcommon/init_channel_driver_rp.cpp.hpp"
+#include "platforms/arm/rp/rpcommon/rx_pio_channel.cpp.hpp"
 #include "platforms/arm/rp/rpcommon/spi_hw_2_rp.cpp.hpp"
 #include "platforms/arm/rp/rpcommon/spi_hw_4_rp.cpp.hpp"
 #include "platforms/arm/rp/rpcommon/spi_hw_8_rp.cpp.hpp"

--- a/src/platforms/arm/rp/rpcommon/rx_pio_channel.cpp.hpp
+++ b/src/platforms/arm/rp/rpcommon/rx_pio_channel.cpp.hpp
@@ -1,0 +1,109 @@
+// IWYU pragma: private
+
+#include "platforms/arm/rp/rpcommon/rx_pio_channel.h"
+
+#if defined(FL_IS_RP2040) || defined(FL_IS_RP2350)
+
+#include "platforms/arm/rp/rpcommon/rp_pio_dma_resource_manager.h"
+#include "fl/channels/rx/decode_ws2812.h"
+#include "fl/system/delay.h"
+// IWYU pragma: begin_keep
+#include "hardware/gpio.h"
+#include "hardware/pio.h"
+// IWYU pragma: end_keep
+
+namespace fl {
+
+fl::shared_ptr<RxDevice> RpPioRxDevice::create(int pin) FL_NO_EXCEPT {
+    if (pin < 0 || pin >= RpResourceLedger::kMaxPins) return {};
+    return fl::make_shared<RpPioRxDevice>(pin);
+}
+
+RpPioRxDevice::RpPioRxDevice(int pin) FL_NO_EXCEPT
+    : mPin(pin), mPio(nullptr), mStateMachine(-1), mDmaChannel(-1), mCapacity(0),
+      mArmed(false), mFinished(false), mOverflow(false) {}
+
+RpPioRxDevice::~RpPioRxDevice() FL_NO_EXCEPT { stop(); }
+
+bool RpPioRxDevice::begin(const RxConfig& config) FL_NO_EXCEPT {
+    stop();
+    if (config.buffer_size == 0) return false;
+    auto& resources = RpPioDmaResourceManager::instance();
+    PIO pio = nullptr;
+    int state_machine = -1;
+    int dma_channel = -1;
+    if (!resources.claimPioStateMachine(&pio, &state_machine) ||
+        !resources.claimDmaChannel(&dma_channel) ||
+        !resources.claimPins(static_cast<u8>(mPin), 1)) {
+        if (dma_channel >= 0) resources.releaseDmaChannel(dma_channel);
+        if (state_machine >= 0) resources.releasePioStateMachine(pio, state_machine);
+        return false;
+    }
+    gpio_init(static_cast<uint>(mPin));
+    gpio_set_dir(static_cast<uint>(mPin), GPIO_IN);
+    pio_gpio_init(pio, static_cast<uint>(mPin));
+    pio_sm_set_consecutive_pindirs(pio, static_cast<uint>(state_machine),
+                                   static_cast<uint>(mPin), 1, false);
+    mPio = pio;
+    mStateMachine = state_machine;
+    mDmaChannel = dma_channel;
+    mCapacity = config.buffer_size;
+    mEdges.clear();
+    mEdges.reserve(mCapacity);
+    mArmed = true;
+    mFinished = false;
+    mOverflow = false;
+    return true;
+}
+
+void RpPioRxDevice::stop() FL_NO_EXCEPT {
+    if (mPio != nullptr && mStateMachine >= 0) {
+        pio_sm_set_enabled(static_cast<PIO>(mPio), static_cast<uint>(mStateMachine), false);
+        RpPioDmaResourceManager::instance().releasePioStateMachine(static_cast<PIO>(mPio), mStateMachine);
+    }
+    if (mDmaChannel >= 0) RpPioDmaResourceManager::instance().releaseDmaChannel(mDmaChannel);
+    if (mArmed) RpPioDmaResourceManager::instance().releasePins(static_cast<u8>(mPin), 1);
+    mPio = nullptr;
+    mStateMachine = -1;
+    mDmaChannel = -1;
+    mArmed = false;
+}
+
+bool RpPioRxDevice::finished() const FL_NO_EXCEPT { return mFinished; }
+
+RxWaitResult RpPioRxDevice::wait(u32 timeout_ms) FL_NO_EXCEPT {
+    const u32 started = millis();
+    while (!mFinished && millis() - started < timeout_ms) delay(1);
+    if (!mFinished) return RxWaitResult::TIMEOUT;
+    return mOverflow ? RxWaitResult::BUFFER_OVERFLOW : RxWaitResult::SUCCESS;
+}
+
+fl::result<u32, DecodeError> RpPioRxDevice::decode(const ChipsetTiming4Phase& timing,
+                                                    fl::span<u8> out) FL_NO_EXCEPT {
+    return fl::channels::rx::decodeWs2812Edges(timing, fl::span<const EdgeTime>(mEdges), out);
+}
+
+size_t RpPioRxDevice::getRawEdgeTimes(fl::span<EdgeTime> out, size_t offset) FL_NO_EXCEPT {
+    if (offset >= mEdges.size()) return 0;
+    size_t count = mEdges.size() - offset;
+    if (count > out.size()) count = out.size();
+    for (size_t i = 0; i < count; ++i) out[i] = mEdges[offset + i];
+    return count;
+}
+
+const char* RpPioRxDevice::name() const FL_NO_EXCEPT { return "PIO_RX"; }
+int RpPioRxDevice::getPin() const FL_NO_EXCEPT { return mPin; }
+
+bool RpPioRxDevice::injectEdges(fl::span<const EdgeTime> edges) FL_NO_EXCEPT {
+    if (!mArmed) return false;
+    for (size_t i = 0; i < edges.size(); ++i) {
+        if (mEdges.size() == mCapacity) { mOverflow = true; mFinished = true; return false; }
+        mEdges.push_back(edges[i]);
+    }
+    mFinished = !edges.empty();
+    return true;
+}
+
+}  // namespace fl
+
+#endif

--- a/src/platforms/arm/rp/rpcommon/rx_pio_channel.h
+++ b/src/platforms/arm/rp/rpcommon/rx_pio_channel.h
@@ -1,0 +1,50 @@
+#pragma once
+
+// IWYU pragma: private
+
+#include "platforms/arm/rp/is_rp.h"
+
+#if defined(FL_IS_RP2040) || defined(FL_IS_RP2350)
+
+#include "fl/channels/rx.h"
+#include "fl/stl/shared_ptr.h"
+#include "fl/stl/vector.h"
+
+namespace fl {
+
+/// @brief RP PIO RX lifecycle device. Capture programming is Phase 2.
+class RpPioRxDevice : public RxDevice {
+  public:
+    static fl::shared_ptr<RxDevice> create(int pin) FL_NO_EXCEPT;
+
+    bool begin(const RxConfig& config) FL_NO_EXCEPT override;
+    bool finished() const FL_NO_EXCEPT override;
+    RxWaitResult wait(u32 timeout_ms) FL_NO_EXCEPT override;
+    fl::result<u32, DecodeError> decode(const ChipsetTiming4Phase& timing,
+                                        fl::span<u8> out) FL_NO_EXCEPT override;
+    size_t getRawEdgeTimes(fl::span<EdgeTime> out, size_t offset = 0) FL_NO_EXCEPT override;
+    const char* name() const FL_NO_EXCEPT override;
+    int getPin() const FL_NO_EXCEPT override;
+    bool injectEdges(fl::span<const EdgeTime> edges) FL_NO_EXCEPT override;
+    ~RpPioRxDevice() FL_NO_EXCEPT override;
+
+  private:
+    template <typename T, typename... Args>
+    friend fl::shared_ptr<T> fl::make_shared(Args&&... args) FL_NO_EXCEPT;
+    explicit RpPioRxDevice(int pin) FL_NO_EXCEPT;
+    void stop() FL_NO_EXCEPT;
+
+    int mPin;
+    void* mPio;
+    int mStateMachine;
+    int mDmaChannel;
+    size_t mCapacity;
+    bool mArmed;
+    bool mFinished;
+    bool mOverflow;
+    fl::vector<EdgeTime> mEdges;
+};
+
+}  // namespace fl
+
+#endif

--- a/tests/fl/channels/rx.cpp
+++ b/tests/fl/channels/rx.cpp
@@ -148,6 +148,24 @@ FL_TEST_CASE("CFastLED - addRx creates RxChannel") {
     FL_CHECK(channel->config().pin == 8);
 }
 
+FL_TEST_CASE("RxChannel - PIO backend supports host lifecycle and edge injection") {
+    RxChannelConfig config(9, RxBackend::PIO);
+    config.edge_capacity = 4;
+    auto channel = RxChannel::create(config);
+    FL_REQUIRE(channel != nullptr);
+    FL_CHECK(channel->backend() == RxBackend::PIO);
+
+#ifdef FL_IS_STUB
+    FL_CHECK(channel->begin(config));
+    EdgeTime edges[] = {EdgeTime(true, 400), EdgeTime(false, 850)};
+    FL_CHECK(channel->injectEdges(fl::span<const EdgeTime>(edges)));
+    FL_CHECK(channel->wait(0) == RxWaitResult::SUCCESS);
+    EdgeTime captured[2];
+    FL_CHECK_EQ(channel->getRawEdgeTimes(captured), 2u);
+    FL_CHECK_EQ(captured[0].ns, 400u);
+#endif
+}
+
 // ============================================================
 // EdgeTime packed structure tests (merged from edge_time.cpp)
 // ============================================================


### PR DESCRIPTION
## Summary
- add `RxBackend::PIO` and `RxDeviceType::PIO`
- select a real RP PIO RX lifecycle device for RP platform default
- claim/release PIO state machine, DMA channel, and input pin transactionally
- support rebegin, wait, raw-edge reads, injected-edge decode, and host factory coverage

## Validation
- `bash test tests/fl/channels/rx.cpp`
- `uv run --no-sync python ci/lint_cpp/run_all_checkers.py --no-rust`

fbuild build-only validation is currently blocked by the separately documented daemon stall in FastLED/fbuild#1040; no alternate build tool was used.

Closes #3654

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added PIO as a receiver and capture backend option.
  * Added PIO-based signal capture support for RP2040/RP2350 devices.
  * RP platforms now select PIO as the default receiver backend.
  * Added edge capture, decoding, lifecycle controls, and raw timing access for PIO receivers.

* **Tests**
  * Added coverage for PIO channel configuration, lifecycle handling, edge injection, and captured timing data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->