### PR TITLE
feat(rp2040): add UART DMA channel driver

### DIFF
--- a/src/fl/channels/bus.h
+++ b/src/fl/channels/bus.h
@@ -130,6 +130,8 @@ template<> struct BusInstanceCount<Bus::SPI> { static constexpr fl::u8 value = 2
 template<> struct BusInstanceCount<Bus::UART> { static constexpr fl::u8 value = 2; };
 #elif defined(FL_IS_ARM_LPC_845)
 template<> struct BusInstanceCount<Bus::UART> { static constexpr fl::u8 value = 1; };
+#elif defined(FL_IS_RP2040) || defined(FL_IS_RP2350)
+template<> struct BusInstanceCount<Bus::UART> { static constexpr fl::u8 value = 2; };
 #endif
 
 inline const char* busName(Bus b, fl::u8 which = 0) FL_NO_EXCEPT {

--- a/src/fl/channels/uart_wave_encoder.cpp.hpp
+++ b/src/fl/channels/uart_wave_encoder.cpp.hpp
@@ -1,0 +1,6 @@
+#pragma once
+
+// The encoder implementation is include-once so platform unity builds may
+// share it without duplicate symbols.  The legacy implementation path is
+// retained for source compatibility while this is the neutral build entry.
+#include "platforms/esp/32/drivers/uart/wave8_encoder_uart.cpp.hpp"

--- a/src/fl/channels/uart_wave_encoder.h
+++ b/src/fl/channels/uart_wave_encoder.h
@@ -1,0 +1,12 @@
+#pragma once
+
+/// @file uart_wave_encoder.h
+/// @brief Platform-neutral UART wave4/wave5 encoder API.
+///
+/// The implementation originated with the ESP UART backend, but it models
+/// only an inverted UART frame and `ChipsetTimingConfig`; RP UART DMA and
+/// future backends consume this stable channel-layer API.  Keep the legacy
+/// ESP-path header as a forwarding-compatible include while callers use this
+/// neutral path.
+
+#include "platforms/esp/32/drivers/uart/wave8_encoder_uart.h"

--- a/src/platforms/arm/rp/rpcommon/_build.cpp.hpp
+++ b/src/platforms/arm/rp/rpcommon/_build.cpp.hpp
@@ -5,7 +5,10 @@
 /// Includes all implementation files in alphabetical order
 
 #include "platforms/arm/rp/rpcommon/clockless_rp_pio_auto.cpp.hpp"
+#include "platforms/arm/rp/rpcommon/channel_engine_rp_uart.cpp.hpp"
 #include "platforms/arm/rp/rpcommon/init_channel_driver_rp.cpp.hpp"
+#include "platforms/arm/rp/rpcommon/rp_uart_peripheral.cpp.hpp"
+#include "fl/channels/uart_wave_encoder.cpp.hpp"
 #include "platforms/arm/rp/rpcommon/rx_pio_channel.cpp.hpp"
 #include "platforms/arm/rp/rpcommon/spi_hw_2_rp.cpp.hpp"
 #include "platforms/arm/rp/rpcommon/spi_hw_4_rp.cpp.hpp"

--- a/src/platforms/arm/rp/rpcommon/channel_engine_rp_uart.cpp.hpp
+++ b/src/platforms/arm/rp/rpcommon/channel_engine_rp_uart.cpp.hpp
@@ -1,0 +1,202 @@
+// IWYU pragma: private
+
+#include "platforms/arm/rp/rpcommon/channel_engine_rp_uart.h"
+
+#include "fl/stl/utility.h"
+
+namespace fl {
+
+namespace {
+// RP2040 PL011 is clocked from clk_peri.  Keep a conservative 6.25 MHz
+// ceiling here rather than inheriting ESP32's 5 MHz policy; the achieved-baud
+// check below is the final hardware-specific timing admission.
+constexpr u32 kRpUartMaxBaudRate = 6250000;
+}
+
+ChannelEngineRpUart::ChannelEngineRpUart(
+    fl::shared_ptr<IRpUartPeripheral> peripheral, u8 uart_index) FL_NO_EXCEPT
+    : mPeripheral(fl::move(peripheral)), mUartIndex(uart_index),
+      mCurrentChannel(0), mLatchStartUs(0), mLatchDurationUs(0),
+      mActive(false), mLatchPending(false), mFailed(false) {}
+
+ChannelEngineRpUart::~ChannelEngineRpUart() {
+    releaseInFlight();
+    if (mPeripheral) {
+        mPeripheral->abort();
+        mPeripheral->deinitialize();
+    }
+}
+
+bool ChannelEngineRpUart::isValidTxPin(int pin) const FL_NO_EXCEPT {
+    static constexpr int kUart0TxPins[] = {0, 12, 16, 28};
+    static constexpr int kUart1TxPins[] = {4, 8, 20, 24};
+    const int* pins = mUartIndex == 0 ? kUart0TxPins : kUart1TxPins;
+    for (size_t index = 0; index < 4; ++index) {
+        if (pin == pins[index]) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool ChannelEngineRpUart::canHandle(const ChannelDataPtr& data) const FL_NO_EXCEPT {
+    return data && data->isClockless() && isValidTxPin(data->getPin()) &&
+           canRepresentTimingForMaxBaud(data->getTiming(), kRpUartMaxBaudRate);
+}
+
+void ChannelEngineRpUart::enqueue(ChannelDataPtr channelData) FL_NO_EXCEPT {
+    if (channelData && canHandle(channelData)) {
+        mPendingChannels.push_back(fl::move(channelData));
+    }
+}
+
+void ChannelEngineRpUart::show() FL_NO_EXCEPT {
+    if (mActive || mPendingChannels.empty()) {
+        return;
+    }
+    mInFlightChannels = fl::move(mPendingChannels);
+    mPendingChannels.clear();
+    mCurrentChannel = 0;
+    mFailed = false;
+    mError.clear();
+    for (const ChannelDataPtr& channel : mInFlightChannels) {
+        if (channel) {
+            channel->setInUse(true);
+        }
+    }
+    mActive = true;
+    if (!startNextTransmission()) {
+        // show() has no status return. Preserve the error until the manager's
+        // next poll, while still releasing the input buffers on that poll.
+        mFailed = true;
+        mError = "RP UART: unable to start queued channel";
+    }
+}
+
+IChannelDriver::DriverState ChannelEngineRpUart::poll() FL_NO_EXCEPT {
+    if (mFailed) {
+        return fail(mError.c_str());
+    }
+    if (!mActive) {
+        return DriverState::READY;
+    }
+    if (!mPeripheral) {
+        return fail("RP UART: missing peripheral");
+    }
+    if (mPeripheral->hasError()) {
+        return fail("RP UART: peripheral error");
+    }
+    if (mPeripheral->isDmaBusy()) {
+        return DriverState::BUSY;
+    }
+    // PL011 TXFE may be set before the final byte leaves the shift register.
+    // The peripheral checks UARTFR.BUSY, so DRAINING is an actual wire state.
+    if (mPeripheral->isWireBusy()) {
+        return DriverState::DRAINING;
+    }
+    if (!mLatchPending) {
+        // A UART shift-register drain only establishes wire-idle. Keep the
+        // line low for this chipset's reset/latch interval before either
+        // reconfiguring the pin for another strip or releasing it to user
+        // code. The peripheral-owned clock keeps host tests deterministic.
+        mLatchDurationUs = mInFlightChannels[mCurrentChannel]->getTiming().reset_us;
+        mLatchStartUs = mPeripheral->nowMicros();
+        mLatchPending = true;
+        if (mLatchDurationUs != 0) {
+            return DriverState::DRAINING;
+        }
+    }
+    if (static_cast<u32>(mPeripheral->nowMicros() - mLatchStartUs) <
+        mLatchDurationUs) {
+        return DriverState::DRAINING;
+    }
+    mLatchPending = false;
+    ++mCurrentChannel;
+    if (startNextTransmission()) {
+        return DriverState::BUSY;
+    }
+    if (mCurrentChannel < mInFlightChannels.size()) {
+        return fail("RP UART: unable to start queued channel");
+    }
+    mPeripheral->deinitialize();
+    releaseInFlight();
+    mActive = false;
+    return DriverState::READY;
+}
+
+bool ChannelEngineRpUart::startNextTransmission() FL_NO_EXCEPT {
+    while (mCurrentChannel < mInFlightChannels.size()) {
+        if (beginTransmission(mInFlightChannels[mCurrentChannel])) {
+            return true;
+        }
+        return false;
+    }
+    return false;
+}
+
+bool ChannelEngineRpUart::beginTransmission(const ChannelDataPtr& channel) FL_NO_EXCEPT {
+    if (!mPeripheral || !canHandle(channel)) {
+        return false;
+    }
+    const fl::vector_psram<u8>& input = channel->getData();
+    if (input.empty()) {
+        return false;
+    }
+    const Wave10Lut lut = buildWave10LutForMaxBaud(channel->getTiming(),
+                                                    kRpUartMaxBaudRate);
+    if (lut.pulses_per_bit == 0) {
+        return false;
+    }
+    RpUartConfig config;
+    config.uart_index = mUartIndex;
+    config.tx_pin = static_cast<u8>(channel->getPin());
+    config.baud_rate = lut.baudRate(channel->getTiming());
+    config.data_bits = lut.dataBits();
+    config.invert_tx = true;
+    if (!mPeripheral->configure(config)) {
+        return false;
+    }
+    const u32 actual_baud = mPeripheral->actualBaudRate();
+    const u32 requested_baud = config.baud_rate;
+    const u32 baud_error = actual_baud > requested_baud
+                               ? actual_baud - requested_baud
+                               : requested_baud - actual_baud;
+    // The LUT admits half-pulse timing error. Limit the UART-divider error
+    // to 1%, leaving that margin intact instead of silently stretching every
+    // high/low symbol beyond the timing model.
+    if (actual_baud == 0 || static_cast<u64>(baud_error) * 100u > requested_baud) {
+        return false;
+    }
+    mEncodedBuffer.resize(calculateUartBufferSize(input.size()));
+    const size_t encoded = encodeLedsToUart(input.data(), input.size(),
+                                            mEncodedBuffer.data(),
+                                            mEncodedBuffer.size(), lut);
+    return encoded != 0 && mPeripheral->startTxDma(mEncodedBuffer.data(), encoded);
+}
+
+void ChannelEngineRpUart::releaseInFlight() FL_NO_EXCEPT {
+    for (const ChannelDataPtr& channel : mInFlightChannels) {
+        if (channel) {
+            channel->setInUse(false);
+        }
+    }
+    mInFlightChannels.clear();
+    mEncodedBuffer.clear();
+    mCurrentChannel = 0;
+    mLatchStartUs = 0;
+    mLatchDurationUs = 0;
+    mLatchPending = false;
+}
+
+IChannelDriver::DriverState ChannelEngineRpUart::fail(const char* message) FL_NO_EXCEPT {
+    if (mPeripheral) {
+        mPeripheral->abort();
+        mPeripheral->deinitialize();
+    }
+    releaseInFlight();
+    mActive = false;
+    mFailed = false;
+    return DriverState(DriverState::ERROR, fl::string(message));
+}
+
+}  // namespace fl

--- a/src/platforms/arm/rp/rpcommon/channel_engine_rp_uart.h
+++ b/src/platforms/arm/rp/rpcommon/channel_engine_rp_uart.h
@@ -1,0 +1,57 @@
+#pragma once
+
+// IWYU pragma: private
+
+/// @file channel_engine_rp_uart.h
+/// @brief RP2040/RP2350 UART TX DMA clockless channel engine.
+
+#include "fl/channels/data.h"
+#include "fl/channels/driver.h"
+#include "fl/stl/shared_ptr.h"
+#include "fl/stl/vector.h"
+#include "platforms/arm/rp/rpcommon/irp_uart_peripheral.h"
+#include "fl/channels/uart_wave_encoder.h"
+
+namespace fl {
+
+class ChannelEngineRpUart final : public IChannelDriver {
+  public:
+    ChannelEngineRpUart(fl::shared_ptr<IRpUartPeripheral> peripheral,
+                        u8 uart_index) FL_NO_EXCEPT;
+    ~ChannelEngineRpUart() override;
+
+    bool canHandle(const ChannelDataPtr& data) const FL_NO_EXCEPT override;
+    void enqueue(ChannelDataPtr channelData) FL_NO_EXCEPT override;
+    void show() FL_NO_EXCEPT override;
+    DriverState poll() FL_NO_EXCEPT override;
+
+    fl::string getName() const FL_NO_EXCEPT override {
+        return mUartIndex == 0 ? fl::string::from_literal("UART0")
+                               : fl::string::from_literal("UART1");
+    }
+    Capabilities getCapabilities() const FL_NO_EXCEPT override {
+        return Capabilities(true, false);
+    }
+
+  private:
+    bool startNextTransmission() FL_NO_EXCEPT;
+    bool beginTransmission(const ChannelDataPtr& channel) FL_NO_EXCEPT;
+    void releaseInFlight() FL_NO_EXCEPT;
+    DriverState fail(const char* message) FL_NO_EXCEPT;
+    bool isValidTxPin(int pin) const FL_NO_EXCEPT;
+
+    fl::shared_ptr<IRpUartPeripheral> mPeripheral;
+    fl::vector<ChannelDataPtr> mPendingChannels;
+    fl::vector<ChannelDataPtr> mInFlightChannels;
+    fl::vector<u8> mEncodedBuffer;
+    u8 mUartIndex;
+    size_t mCurrentChannel;
+    u32 mLatchStartUs;
+    u32 mLatchDurationUs;
+    bool mActive;
+    bool mLatchPending;
+    bool mFailed;
+    fl::string mError;
+};
+
+}  // namespace fl

--- a/src/platforms/arm/rp/rpcommon/init_channel_driver_rp.cpp.hpp
+++ b/src/platforms/arm/rp/rpcommon/init_channel_driver_rp.cpp.hpp
@@ -30,6 +30,7 @@
 #include "platforms/shared/spi_hw_4.h"
 #include "platforms/shared/spi_hw_8.h"
 #include "platforms/arm/rp/rpcommon/init_channel_driver.h"
+#include "platforms/arm/rp/rpcommon/rp_uart_bus_traits.h"
 
 namespace fl {
 
@@ -131,6 +132,11 @@ void initChannelDrivers() {
 
     // Register true SPI hardware (priority 6-8)
     detail::addSpiHardwareIfPossible(manager);
+
+    // RP2040 has two PL011 UART blocks. They are explicit Bus::UART lanes;
+    // USB CDC remains the sketch/RPC transport and is never registered here.
+    BusTraits<Bus::UART, 0>::registerWithManager();
+    BusTraits<Bus::UART, 1>::registerWithManager();
 
     FL_DBG_F("RP2040/RP2350: Channel drivers initialized");
 }

--- a/src/platforms/arm/rp/rpcommon/irp_uart_peripheral.h
+++ b/src/platforms/arm/rp/rpcommon/irp_uart_peripheral.h
@@ -1,0 +1,40 @@
+#pragma once
+
+// IWYU pragma: private
+
+/// @file irp_uart_peripheral.h
+/// @brief Host-testable asynchronous UART+DMA contract for RP2040/RP2350.
+
+#include "fl/stl/cstddef.h"
+#include "fl/stl/int.h"
+#include "fl/stl/noexcept.h"
+
+namespace fl {
+
+struct RpUartConfig {
+    u8 uart_index = 0;
+    u8 tx_pin = 0;
+    u32 baud_rate = 0;
+    u8 data_bits = 8;
+    bool invert_tx = true;
+};
+
+/// DMA completion only means that the UART FIFO has accepted every source
+/// byte.  `isWireBusy()` remains true while the PL011 shift register sends the
+/// final start/data/stop bits, which is why it is deliberately separate.
+class IRpUartPeripheral {
+  public:
+    virtual ~IRpUartPeripheral() FL_NO_EXCEPT = default;
+
+    virtual bool configure(const RpUartConfig& config) FL_NO_EXCEPT = 0;
+    virtual u32 actualBaudRate() const FL_NO_EXCEPT = 0;
+    virtual bool startTxDma(const u8* data, size_t size) FL_NO_EXCEPT = 0;
+    virtual bool isDmaBusy() const FL_NO_EXCEPT = 0;
+    virtual bool isWireBusy() const FL_NO_EXCEPT = 0;
+    virtual bool hasError() const FL_NO_EXCEPT = 0;
+    virtual u32 nowMicros() const FL_NO_EXCEPT = 0;
+    virtual void abort() FL_NO_EXCEPT = 0;
+    virtual void deinitialize() FL_NO_EXCEPT = 0;
+};
+
+}  // namespace fl

--- a/src/platforms/arm/rp/rpcommon/rp_pio_dma_resource_manager.h
+++ b/src/platforms/arm/rp/rpcommon/rp_pio_dma_resource_manager.h
@@ -98,6 +98,50 @@ class RpPioDmaResourceManager {
         mLedger.releaseDmaChannel(static_cast<u8>(channel));
     }
 
+    /// @brief Claim a hardware UART block and mirror it in the FastLED ledger.
+    ///
+    /// Pico SDK exposes no uart_claim_* API.  Serial ownership is therefore
+    /// coordinated exclusively under this manager's spinlock; callers must
+    /// release it before returning the UART to user code.
+    bool claimUart(u8 uart) FL_NO_EXCEPT {
+        LockGuard lock(*this);
+        return mLedger.claimUart(uart);
+    }
+
+    void releaseUart(u8 uart) FL_NO_EXCEPT {
+        LockGuard lock(*this);
+        mLedger.releaseUart(uart);
+    }
+
+    /// @brief Atomically acquire the complete UART TX resource set.
+    ///
+    /// A UART driver must not momentarily own only the UART block while a PIO
+    /// lane claims its pin (or vice versa).  This single critical section is
+    /// the UART equivalent of a transaction: UART ownership, GPIO ownership,
+    /// and an SDK DMA claim either all succeed or are rolled back here.
+    bool claimUartDmaAndPin(u8 uart, u8 pin, int* dma_channel_out) FL_NO_EXCEPT {
+        LockGuard lock(*this);
+        if (dma_channel_out == nullptr || !mLedger.claimUart(uart)) {
+            return false;
+        }
+        if (!mLedger.claimPin(pin)) {
+            mLedger.releaseUart(uart);
+            return false;
+        }
+        const int dma_channel = dma_claim_unused_channel(false);
+        if (dma_channel < 0 ||
+            !mLedger.claimDmaChannel(static_cast<u8>(dma_channel))) {
+            if (dma_channel >= 0) {
+                dma_channel_unclaim(static_cast<uint>(dma_channel));
+            }
+            mLedger.releasePin(pin);
+            mLedger.releaseUart(uart);
+            return false;
+        }
+        *dma_channel_out = dma_channel;
+        return true;
+    }
+
     bool claimPins(u8 first_pin, u8 count) FL_NO_EXCEPT {
         LockGuard lock(*this);
         for (u8 offset = 0; offset < count; ++offset) {

--- a/src/platforms/arm/rp/rpcommon/rp_resource_ledger.h
+++ b/src/platforms/arm/rp/rpcommon/rp_resource_ledger.h
@@ -23,6 +23,7 @@ class RpResourceLedger {
     static constexpr u8 kMaxStateMachinesPerPio = 4;
     static constexpr u8 kMaxDmaChannels = 32;
     static constexpr u8 kMaxPins = 64;
+    static constexpr u8 kMaxUarts = 2;
 
     RpResourceLedger(u8 pio_blocks = kMaxPioBlocks,
                      u8 state_machines_per_pio = kMaxStateMachinesPerPio,
@@ -70,6 +71,23 @@ class RpResourceLedger {
         return channel < mDmaChannels && isBitClaimed(mDmaChannelsClaimed, channel);
     }
 
+    /// @brief Claim one of the RP2040/RP2350 hardware UART blocks.
+    ///
+    /// The SDK has no UART claim bit equivalent to PIO SM/DMA claims.  Keep
+    /// this ownership here so a FastLED UART lane cannot reconfigure a UART
+    /// concurrently used by another FastLED lane (or after partial rollback).
+    bool claimUart(u8 uart) FL_NO_EXCEPT {
+        return uart < kMaxUarts && claimBit(mUartsClaimed, uart);
+    }
+
+    bool releaseUart(u8 uart) FL_NO_EXCEPT {
+        return uart < kMaxUarts && releaseBit(mUartsClaimed, uart);
+    }
+
+    bool isUartClaimed(u8 uart) const FL_NO_EXCEPT {
+        return uart < kMaxUarts && isBitClaimed(mUartsClaimed, uart);
+    }
+
     bool claimPin(u8 pin) FL_NO_EXCEPT {
         return pin < mPins && claimBit(mPinsClaimed[pin / 32], pin % 32);
     }
@@ -87,6 +105,7 @@ class RpResourceLedger {
             mPioStateMachines[pio].store(0, memory_order_release);
         }
         mDmaChannelsClaimed.store(0, memory_order_release);
+        mUartsClaimed.store(0, memory_order_release);
         for (u8 word = 0; word < 2; ++word) {
             mPinsClaimed[word].store(0, memory_order_release);
         }
@@ -127,6 +146,7 @@ class RpResourceLedger {
     u8 mPins;
     atomic<u32> mPioStateMachines[kMaxPioBlocks];
     atomic<u32> mDmaChannelsClaimed;
+    atomic<u32> mUartsClaimed;
     atomic<u32> mPinsClaimed[2];
 };
 

--- a/src/platforms/arm/rp/rpcommon/rp_uart_bus_traits.h
+++ b/src/platforms/arm/rp/rpcommon/rp_uart_bus_traits.h
@@ -1,0 +1,63 @@
+#pragma once
+
+// IWYU pragma: private
+
+#include "platforms/arm/rp/is_rp.h"
+
+#if defined(FL_IS_RP2040) || defined(FL_IS_RP2350)
+
+#include "fl/channels/bus.h"
+#include "fl/channels/bus_priorities.h"
+#include "fl/channels/bus_traits.h"
+#include "fl/channels/manager.h"
+#include "fl/stl/shared_ptr.h"
+#include "fl/stl/type_traits.h"
+#include "platforms/arm/rp/rpcommon/channel_engine_rp_uart.h"
+#include "platforms/arm/rp/rpcommon/rp_uart_peripheral.h"
+
+namespace fl {
+namespace detail {
+
+struct RpUartBusHolder {
+    fl::shared_ptr<RpUartPeripheral> peripheral;
+    fl::shared_ptr<ChannelEngineRpUart> driver;
+    explicit RpUartBusHolder(u8 uart_index) FL_NO_EXCEPT
+        : peripheral(fl::make_shared<RpUartPeripheral>()),
+          driver(fl::make_shared<ChannelEngineRpUart>(peripheral, uart_index)) {}
+};
+
+template<u8 UartIndex>
+inline fl::shared_ptr<ChannelEngineRpUart> rpUartInstancePtr() FL_NO_EXCEPT {
+    static RpUartBusHolder holder(UartIndex);
+    return holder.driver;
+}
+
+}  // namespace detail
+
+template<> struct BusTraits<Bus::UART, 0> {
+    using Driver = ChannelEngineRpUart;
+    static fl::shared_ptr<Driver> instancePtr() FL_NO_EXCEPT {
+        return detail::rpUartInstancePtr<0>();
+    }
+    static Driver& instance() FL_NO_EXCEPT { return *instancePtr(); }
+    static void registerWithManager() FL_NO_EXCEPT {
+        ChannelManager::instance().addDriver(default_bus_priority(Bus::UART, 0), instancePtr());
+    }
+};
+
+template<> struct BusTraits<Bus::UART, 1> {
+    using Driver = ChannelEngineRpUart;
+    static fl::shared_ptr<Driver> instancePtr() FL_NO_EXCEPT {
+        return detail::rpUartInstancePtr<1>();
+    }
+    static Driver& instance() FL_NO_EXCEPT { return *instancePtr(); }
+    static void registerWithManager() FL_NO_EXCEPT {
+        ChannelManager::instance().addDriver(default_bus_priority(Bus::UART, 1), instancePtr());
+    }
+};
+
+template<> struct BusSupports<Bus::UART, ClocklessChipset> : fl::true_type {};
+
+}  // namespace fl
+
+#endif  // defined(FL_IS_RP2040) || defined(FL_IS_RP2350)

--- a/src/platforms/arm/rp/rpcommon/rp_uart_peripheral.cpp.hpp
+++ b/src/platforms/arm/rp/rpcommon/rp_uart_peripheral.cpp.hpp
@@ -1,0 +1,163 @@
+// IWYU pragma: private
+
+#include "platforms/arm/rp/rpcommon/rp_uart_peripheral.h"
+
+#if defined(FL_IS_RP2040) || defined(FL_IS_RP2350)
+
+#include "platforms/arm/rp/rpcommon/rp_pio_dma_resource_manager.h"
+#include "fl/stl/chrono.h"
+#include "fl/stl/stdint.h"
+
+// IWYU pragma: begin_keep
+#include "hardware/dma.h"
+#include "hardware/gpio.h"
+#include "hardware/regs/uart.h"
+#include "hardware/structs/uart.h"
+#include "hardware/uart.h"
+// IWYU pragma: end_keep
+
+namespace fl {
+
+namespace {
+
+uart_inst_t* uartForIndex(int index) FL_NO_EXCEPT {
+    return index == 0 ? uart0 : (index == 1 ? uart1 : nullptr);
+}
+
+bool pinInList(u8 pin, const u8* pins, size_t count) FL_NO_EXCEPT {
+    for (size_t index = 0; index < count; ++index) {
+        if (pins[index] == pin) {
+            return true;
+        }
+    }
+    return false;
+}
+
+}  // namespace
+
+RpUartPeripheral::RpUartPeripheral() FL_NO_EXCEPT
+    : mDmaChannel(-1), mUartIndex(-1), mTxPin(-1), mInitialized(false),
+      mOwnsUart(false), mOwnsPin(false), mActualBaudRate(0) {}
+
+RpUartPeripheral::~RpUartPeripheral() { deinitialize(); }
+
+bool RpUartPeripheral::isValidTxPin(const RpUartConfig& config) const FL_NO_EXCEPT {
+    // RP2040 datasheet table 2.19.2.  These mux assignments are also valid
+    // for the RP2350 compatibility UART blocks; do not infer USB CDC pins.
+    static constexpr u8 kUart0TxPins[] = {0, 12, 16, 28};
+    static constexpr u8 kUart1TxPins[] = {4, 8, 20, 24};
+    return config.uart_index == 0
+               ? pinInList(config.tx_pin, kUart0TxPins, 4)
+               : config.uart_index == 1 && pinInList(config.tx_pin, kUart1TxPins, 4);
+}
+
+bool RpUartPeripheral::configure(const RpUartConfig& config) FL_NO_EXCEPT {
+    deinitialize();
+    if (!isValidTxPin(config) || config.baud_rate == 0 ||
+        config.data_bits < 5 || config.data_bits > 8) {
+        return false;
+    }
+
+    RpPioDmaResourceManager& resources = RpPioDmaResourceManager::instance();
+    if (!resources.claimUartDmaAndPin(config.uart_index, config.tx_pin,
+                                      &mDmaChannel)) {
+        return false;
+    }
+    mOwnsUart = true;
+    mOwnsPin = true;
+    mUartIndex = config.uart_index;
+    mTxPin = config.tx_pin;
+
+    uart_inst_t* uart = uartForIndex(mUartIndex);
+    if (uart == nullptr) {
+        deinitialize();
+        return false;
+    }
+    gpio_set_function(static_cast<uint>(mTxPin), UART_FUNCSEL_NUM(uart, mTxPin));
+    gpio_set_outover(static_cast<uint>(mTxPin),
+                     config.invert_tx ? GPIO_OVERRIDE_INVERT : GPIO_OVERRIDE_NORMAL);
+    mActualBaudRate = uart_init(uart, config.baud_rate);
+    if (mActualBaudRate == 0) {
+        deinitialize();
+        return false;
+    }
+    uart_set_format(uart, config.data_bits, 1, UART_PARITY_NONE);
+    uart_set_hw_flow(uart, false, false);
+    uart_set_fifo_enabled(uart, true);
+    mInitialized = true;
+    return true;
+}
+
+u32 RpUartPeripheral::actualBaudRate() const FL_NO_EXCEPT {
+    return mActualBaudRate;
+}
+
+bool RpUartPeripheral::startTxDma(const u8* data, size_t size) FL_NO_EXCEPT {
+    if (!mInitialized || data == nullptr || size == 0 || mDmaChannel < 0) {
+        return false;
+    }
+    uart_inst_t* uart = uartForIndex(mUartIndex);
+    if (uart == nullptr || dma_channel_is_busy(static_cast<uint>(mDmaChannel))) {
+        return false;
+    }
+    dma_channel_config config = dma_channel_get_default_config(static_cast<uint>(mDmaChannel));
+    channel_config_set_transfer_data_size(&config, DMA_SIZE_8);
+    channel_config_set_read_increment(&config, true);
+    channel_config_set_write_increment(&config, false);
+    channel_config_set_dreq(&config, uart_get_dreq_num(uart, true));
+    dma_channel_configure(static_cast<uint>(mDmaChannel), &config,
+                          &uart_get_hw(uart)->dr, data,
+                          static_cast<uint32_t>(size), true);
+    return true;
+}
+
+bool RpUartPeripheral::isDmaBusy() const FL_NO_EXCEPT {
+    return mDmaChannel >= 0 && dma_channel_is_busy(static_cast<uint>(mDmaChannel));
+}
+
+bool RpUartPeripheral::isWireBusy() const FL_NO_EXCEPT {
+    uart_inst_t* uart = uartForIndex(mUartIndex);
+    return uart != nullptr && (uart_get_hw(uart)->fr & UART_UARTFR_BUSY_BITS) != 0;
+}
+
+bool RpUartPeripheral::hasError() const FL_NO_EXCEPT { return false; }
+
+u32 RpUartPeripheral::nowMicros() const FL_NO_EXCEPT { return fl::micros(); }
+
+void RpUartPeripheral::abort() FL_NO_EXCEPT {
+    if (mDmaChannel >= 0) {
+        dma_channel_abort(static_cast<uint>(mDmaChannel));
+    }
+}
+
+void RpUartPeripheral::deinitialize() FL_NO_EXCEPT {
+    abort();
+    RpPioDmaResourceManager& resources = RpPioDmaResourceManager::instance();
+    if (mInitialized) {
+        uart_inst_t* uart = uartForIndex(mUartIndex);
+        if (uart != nullptr) {
+            uart_deinit(uart);
+        }
+    }
+    if (mDmaChannel >= 0) {
+        resources.releaseDmaChannel(mDmaChannel);
+    }
+    if (mOwnsPin) {
+        gpio_set_outover(static_cast<uint>(mTxPin), GPIO_OVERRIDE_NORMAL);
+        resources.releasePins(static_cast<u8>(mTxPin), 1);
+    }
+    if (mOwnsUart) {
+        resources.releaseUart(static_cast<u8>(mUartIndex));
+    }
+    mDmaChannel = -1;
+    mUartIndex = -1;
+    mTxPin = -1;
+    mInitialized = false;
+    mOwnsPin = false;
+    mOwnsUart = false;
+    mActualBaudRate = 0;
+}
+
+}  // namespace fl
+
+#endif  // defined(FL_IS_RP2040) || defined(FL_IS_RP2350)

--- a/src/platforms/arm/rp/rpcommon/rp_uart_peripheral.h
+++ b/src/platforms/arm/rp/rpcommon/rp_uart_peripheral.h
@@ -1,0 +1,42 @@
+#pragma once
+
+// IWYU pragma: private
+
+#include "platforms/arm/rp/is_rp.h"
+
+#if defined(FL_IS_RP2040) || defined(FL_IS_RP2350)
+
+#include "platforms/arm/rp/rpcommon/irp_uart_peripheral.h"
+
+namespace fl {
+
+class RpUartPeripheral final : public IRpUartPeripheral {
+  public:
+    RpUartPeripheral() FL_NO_EXCEPT;
+    ~RpUartPeripheral() override;
+
+    bool configure(const RpUartConfig& config) FL_NO_EXCEPT override;
+    u32 actualBaudRate() const FL_NO_EXCEPT override;
+    bool startTxDma(const u8* data, size_t size) FL_NO_EXCEPT override;
+    bool isDmaBusy() const FL_NO_EXCEPT override;
+    bool isWireBusy() const FL_NO_EXCEPT override;
+    bool hasError() const FL_NO_EXCEPT override;
+    u32 nowMicros() const FL_NO_EXCEPT override;
+    void abort() FL_NO_EXCEPT override;
+    void deinitialize() FL_NO_EXCEPT override;
+
+  private:
+    bool isValidTxPin(const RpUartConfig& config) const FL_NO_EXCEPT;
+
+    int mDmaChannel;
+    int mUartIndex;
+    int mTxPin;
+    u32 mActualBaudRate;
+    bool mInitialized;
+    bool mOwnsUart;
+    bool mOwnsPin;
+};
+
+}  // namespace fl
+
+#endif  // defined(FL_IS_RP2040) || defined(FL_IS_RP2350)

--- a/src/platforms/esp/32/drivers/uart/wave8_encoder_uart.cpp.hpp
+++ b/src/platforms/esp/32/drivers/uart/wave8_encoder_uart.cpp.hpp
@@ -1,3 +1,5 @@
+#pragma once
+
 // IWYU pragma: private
 
 /// @file wave8_encoder_uart.cpp
@@ -111,7 +113,8 @@ struct UartWaveFit {
 /// Shared by buildWave10Lut() and canRepresentTiming() so the LUT that
 /// gets built is always judged by the same rules that admitted it.
 UartWaveFit fitUartWave(const ChipsetTimingConfig& timing,
-                        u8 pulses_per_bit) FL_NO_EXCEPT {
+                        u8 pulses_per_bit,
+                        u32 max_baud_rate) FL_NO_EXCEPT {
     UartWaveFit fit = {};
     const u32 period_ns = timing.total_period_ns();
     if (period_ns == 0) return fit;
@@ -120,7 +123,7 @@ UartWaveFit fitUartWave(const ChipsetTimingConfig& timing,
     // UART ceiling.
     const u64 baud =
         static_cast<u64>(pulses_per_bit) * 1000000000ULL / period_ns;
-    if (baud == 0 || baud > kMaxUartBaudRate) return fit;
+    if (baud == 0 || baud > max_baud_rate) return fit;
 
     const u32 pulse_width_ns = period_ns / pulses_per_bit;
     if (pulse_width_ns == 0) return fit;
@@ -176,6 +179,11 @@ UartWaveFit fitUartWave(const ChipsetTimingConfig& timing,
 } // anonymous namespace
 
 Wave10Lut buildWave10Lut(const ChipsetTimingConfig& timing) FL_NO_EXCEPT {
+    return buildWave10LutForMaxBaud(timing, kMaxUartBaudRate);
+}
+
+Wave10Lut buildWave10LutForMaxBaud(const ChipsetTimingConfig& timing,
+                                   u32 max_baud_rate) FL_NO_EXCEPT {
     Wave10Lut result = {};
 
     // Evaluate both frame geometries (FastLED#3572 follow-up):
@@ -186,8 +194,8 @@ Wave10Lut buildWave10Lut(const ChipsetTimingConfig& timing) FL_NO_EXCEPT {
     // Pick the feasible geometry with the smaller total quantization
     // error. P=5 wins ties and near-ties (50 ns hysteresis) so the
     // long-proven wave10 shapes stay stable for existing chipsets.
-    const UartWaveFit fit5 = fitUartWave(timing, 5);
-    const UartWaveFit fit4 = fitUartWave(timing, 4);
+    const UartWaveFit fit5 = fitUartWave(timing, 5, max_baud_rate);
+    const UartWaveFit fit4 = fitUartWave(timing, 4, max_baud_rate);
 
     u8 P = 0;
     UartWaveFit fit = {};
@@ -220,9 +228,15 @@ Wave10Lut buildWave10Lut(const ChipsetTimingConfig& timing) FL_NO_EXCEPT {
 }
 
 bool canRepresentTiming(const ChipsetTimingConfig& timing) FL_NO_EXCEPT {
+    return canRepresentTimingForMaxBaud(timing, kMaxUartBaudRate);
+}
+
+bool canRepresentTimingForMaxBaud(const ChipsetTimingConfig& timing,
+                                  u32 max_baud_rate) FL_NO_EXCEPT {
     // Feasible if EITHER frame geometry fits — same helper as
     // buildWave10Lut(), so admission and construction can't drift.
-    return fitUartWave(timing, 5).ok || fitUartWave(timing, 4).ok;
+    return fitUartWave(timing, 5, max_baud_rate).ok ||
+           fitUartWave(timing, 4, max_baud_rate).ok;
 }
 
 FL_IRAM FL_OPTIMIZE_FUNCTION

--- a/src/platforms/esp/32/drivers/uart/wave8_encoder_uart.h
+++ b/src/platforms/esp/32/drivers/uart/wave8_encoder_uart.h
@@ -116,6 +116,10 @@ struct Wave10Lut {
 /// @return Populated Wave10Lut, or all-zero LUT if timing is infeasible
 Wave10Lut buildWave10Lut(const ChipsetTimingConfig& timing) FL_NO_EXCEPT;
 
+/// @brief Build a UART waveform LUT with a backend-specific baud ceiling.
+Wave10Lut buildWave10LutForMaxBaud(const ChipsetTimingConfig& timing,
+                                   u32 max_baud_rate) FL_NO_EXCEPT;
+
 /// @brief Check if a chipset timing can be accurately represented by UART
 ///
 /// Validates that:
@@ -129,6 +133,10 @@ Wave10Lut buildWave10Lut(const ChipsetTimingConfig& timing) FL_NO_EXCEPT;
 /// @param timing Chipset timing configuration
 /// @return true if timing is representable, false otherwise
 bool canRepresentTiming(const ChipsetTimingConfig& timing) FL_NO_EXCEPT;
+
+/// @brief Timing feasibility with a backend-specific baud ceiling.
+bool canRepresentTimingForMaxBaud(const ChipsetTimingConfig& timing,
+                                  u32 max_baud_rate) FL_NO_EXCEPT;
 
 namespace detail {
 

--- a/tests/platforms/arm/rp/rpcommon/channel_engine_rp_uart.cpp
+++ b/tests/platforms/arm/rp/rpcommon/channel_engine_rp_uart.cpp
@@ -1,0 +1,185 @@
+/// @file channel_engine_rp_uart.cpp
+/// @brief Host tests for RP UART DMA state and ownership boundaries.
+
+#include "test.h"
+
+#include "fl/channels/data.h"
+#include "fl/chipsets/led_timing.h"
+#include "fl/stl/move.h"
+#include "fl/stl/shared_ptr.h"
+#include "platforms/arm/rp/rpcommon/channel_engine_rp_uart.h"
+
+// The hardware unity build is intentionally RP-gated.  Include the pure
+// engine implementation in this host test so the lifecycle contract remains
+// testable without a Pico SDK installation.
+#include "platforms/arm/rp/rpcommon/channel_engine_rp_uart.cpp.hpp"
+
+FL_TEST_FILE(FL_FILEPATH) {
+
+using namespace fl;
+
+namespace {
+
+class RpUartPeripheralMock final : public IRpUartPeripheral {
+  public:
+    bool configure(const RpUartConfig& config) FL_NO_EXCEPT override {
+        lastConfig = config;
+        achievedBaud = static_cast<u32>(
+            static_cast<i32>(config.baud_rate) + baudOffset);
+        ++configureCalls;
+        return configureOk;
+    }
+    u32 actualBaudRate() const FL_NO_EXCEPT override { return achievedBaud; }
+    bool startTxDma(const u8* data, size_t size) FL_NO_EXCEPT override {
+        ++startCalls;
+        bytes = size;
+        dmaBusy = startOk;
+        firstByte = size == 0 ? 0 : data[0];
+        return startOk;
+    }
+    bool isDmaBusy() const FL_NO_EXCEPT override { return dmaBusy; }
+    bool isWireBusy() const FL_NO_EXCEPT override { return wireBusy; }
+    bool hasError() const FL_NO_EXCEPT override { return error; }
+    u32 nowMicros() const FL_NO_EXCEPT override { return timeUs; }
+    void abort() FL_NO_EXCEPT override { ++abortCalls; dmaBusy = false; }
+    void deinitialize() FL_NO_EXCEPT override { ++deinitializeCalls; }
+
+    RpUartConfig lastConfig;
+    bool configureOk = true;
+    bool startOk = true;
+    bool dmaBusy = false;
+    bool wireBusy = false;
+    bool error = false;
+    int configureCalls = 0;
+    int startCalls = 0;
+    int abortCalls = 0;
+    int deinitializeCalls = 0;
+    size_t bytes = 0;
+    u8 firstByte = 0;
+    u32 timeUs = 0;
+    u32 achievedBaud = 0;
+    i32 baudOffset = 0;
+};
+
+ChannelDataPtr makeWs2812Channel(int pin, u8 value) {
+    fl::vector_psram<u8> bytes;
+    bytes.push_back(value);
+    return ChannelData::create(pin, makeTimingConfig<TIMING_WS2812_800KHZ>(),
+                               fl::move(bytes));
+}
+
+}  // namespace
+
+FL_TEST_CASE("RP UART accepts only hardware-UART TX pins") {
+    auto peripheral = fl::make_shared<RpUartPeripheralMock>();
+    ChannelEngineRpUart uart0(peripheral, 0);
+    ChannelEngineRpUart uart1(peripheral, 1);
+    FL_CHECK(uart0.canHandle(makeWs2812Channel(0, 0)));
+    FL_CHECK(uart0.canHandle(makeWs2812Channel(28, 0)));
+    FL_CHECK_FALSE(uart0.canHandle(makeWs2812Channel(8, 0)));
+    FL_CHECK(uart1.canHandle(makeWs2812Channel(8, 0)));
+    FL_CHECK_FALSE(uart1.canHandle(makeWs2812Channel(0, 0)));
+}
+
+FL_TEST_CASE("RP UART encoder represents every byte and preserves DMA versus wire drain") {
+    auto peripheral = fl::make_shared<RpUartPeripheralMock>();
+    ChannelEngineRpUart engine(peripheral, 0);
+    for (int value = 0; value < 256; ++value) {
+        auto channel = makeWs2812Channel(0, static_cast<u8>(value));
+        engine.enqueue(channel);
+        FL_CHECK_FALSE(channel->isInUse());
+        engine.show();
+        FL_REQUIRE(channel->isInUse());
+        FL_REQUIRE_EQ(peripheral->lastConfig.uart_index, 0);
+        FL_REQUIRE_EQ(peripheral->lastConfig.tx_pin, 0);
+        FL_REQUIRE_EQ(peripheral->bytes, static_cast<size_t>(4));
+        FL_REQUIRE_EQ(engine.poll(), IChannelDriver::DriverState::BUSY);
+        peripheral->dmaBusy = false;
+        peripheral->wireBusy = true;
+        FL_REQUIRE_EQ(engine.poll(), IChannelDriver::DriverState::DRAINING);
+        FL_REQUIRE(channel->isInUse());
+        peripheral->wireBusy = false;
+        FL_REQUIRE_EQ(engine.poll(), IChannelDriver::DriverState::DRAINING);
+        peripheral->timeUs += 1000;
+        FL_REQUIRE_EQ(engine.poll(), IChannelDriver::DriverState::READY);
+        FL_REQUIRE_FALSE(channel->isInUse());
+    }
+}
+
+FL_TEST_CASE("RP UART releases in-flight channels on peripheral failure") {
+    auto peripheral = fl::make_shared<RpUartPeripheralMock>();
+    ChannelEngineRpUart engine(peripheral, 1);
+    auto channel = makeWs2812Channel(8, 0xAA);
+    engine.enqueue(channel);
+    engine.show();
+    FL_REQUIRE(channel->isInUse());
+    peripheral->error = true;
+    FL_CHECK_EQ(engine.poll(), IChannelDriver::DriverState::ERROR);
+    FL_CHECK_FALSE(channel->isInUse());
+    FL_CHECK(peripheral->abortCalls > 0);
+    FL_CHECK(peripheral->deinitializeCalls > 0);
+}
+
+FL_TEST_CASE("RP UART keeps a second frame pending until its own show") {
+    auto peripheral = fl::make_shared<RpUartPeripheralMock>();
+    ChannelEngineRpUart engine(peripheral, 0);
+    auto first = makeWs2812Channel(0, 0x55);
+    auto second = makeWs2812Channel(0, 0xAA);
+    engine.enqueue(first);
+    engine.show();
+    FL_REQUIRE(first->isInUse());
+    engine.enqueue(second);
+    FL_REQUIRE_FALSE(second->isInUse());
+    peripheral->dmaBusy = false;
+    FL_REQUIRE_EQ(engine.poll(), IChannelDriver::DriverState::DRAINING);
+    peripheral->timeUs += 1000;
+    FL_REQUIRE_EQ(engine.poll(), IChannelDriver::DriverState::READY);
+    FL_REQUIRE_FALSE(first->isInUse());
+    FL_REQUIRE_FALSE(second->isInUse());
+    engine.show();
+    FL_CHECK(second->isInUse());
+}
+
+FL_TEST_CASE("RP UART start failure clears ownership and reports error on poll") {
+    auto peripheral = fl::make_shared<RpUartPeripheralMock>();
+    peripheral->startOk = false;
+    ChannelEngineRpUart engine(peripheral, 1);
+    auto channel = makeWs2812Channel(8, 0xFF);
+    engine.enqueue(channel);
+    engine.show();
+    FL_CHECK(channel->isInUse());
+    FL_CHECK_EQ(engine.poll(), IChannelDriver::DriverState::ERROR);
+    FL_CHECK_FALSE(channel->isInUse());
+    FL_CHECK(peripheral->abortCalls > 0);
+    FL_CHECK(peripheral->deinitializeCalls > 0);
+}
+
+FL_TEST_CASE("RP UART rejects an out-of-margin achieved baud rate") {
+    auto peripheral = fl::make_shared<RpUartPeripheralMock>();
+    peripheral->baudOffset = -50000;
+    ChannelEngineRpUart engine(peripheral, 1);
+    auto channel = makeWs2812Channel(8, 0xFF);
+    engine.enqueue(channel);
+    engine.show();
+    FL_CHECK_EQ(engine.poll(), IChannelDriver::DriverState::ERROR);
+    FL_CHECK_FALSE(channel->isInUse());
+}
+
+FL_TEST_CASE("RP UART reports a failed second start after preserving its latch interval") {
+    auto peripheral = fl::make_shared<RpUartPeripheralMock>();
+    ChannelEngineRpUart engine(peripheral, 0);
+    auto first = makeWs2812Channel(0, 0x00);
+    auto second = makeWs2812Channel(0, 0xFF);
+    engine.enqueue(first);
+    engine.enqueue(second);
+    engine.show();
+    peripheral->dmaBusy = false;
+    FL_REQUIRE_EQ(engine.poll(), IChannelDriver::DriverState::DRAINING);
+    peripheral->timeUs += 1000;
+    peripheral->configureOk = false;
+    FL_CHECK_EQ(engine.poll(), IChannelDriver::DriverState::ERROR);
+    FL_CHECK_FALSE(first->isInUse());
+    FL_CHECK_FALSE(second->isInUse());
+}
+
+}  // FL_TEST_FILE

--- a/tests/platforms/arm/rp/rpcommon/rp_resource_ledger.cpp
+++ b/tests/platforms/arm/rp/rpcommon/rp_resource_ledger.cpp
@@ -21,6 +21,9 @@ FL_TEST_CASE("RP resource ledger rejects duplicate and out-of-range claims") {
 
     FL_CHECK(ledger.claimDmaChannel(11));
     FL_CHECK_FALSE(ledger.claimDmaChannel(12));
+    FL_CHECK(ledger.claimUart(0));
+    FL_CHECK_FALSE(ledger.claimUart(0));
+    FL_CHECK_FALSE(ledger.claimUart(2));
     FL_CHECK(ledger.claimPin(29));
     FL_CHECK_FALSE(ledger.claimPin(30));
 }
@@ -30,15 +33,18 @@ FL_TEST_CASE("RP resource ledger cleanup restores partial acquisitions") {
 
     FL_REQUIRE(ledger.claimPioStateMachine(1, 3));
     FL_REQUIRE(ledger.claimDmaChannel(1));
+    FL_REQUIRE(ledger.claimUart(1));
     FL_REQUIRE(ledger.claimPin(4));
 
     FL_CHECK(ledger.releasePin(4));
     FL_CHECK(ledger.releaseDmaChannel(1));
+    FL_CHECK(ledger.releaseUart(1));
     FL_CHECK(ledger.releasePioStateMachine(1, 3));
     FL_CHECK_FALSE(ledger.releasePioStateMachine(1, 3));
 
     FL_CHECK(ledger.claimPioStateMachine(1, 3));
     FL_CHECK(ledger.claimDmaChannel(1));
+    FL_CHECK(ledger.claimUart(1));
     FL_CHECK(ledger.claimPin(4));
 }
 


### PR DESCRIPTION
Closes #3657\n\nImplements Phase 4 UART TX DMA bring-up for RP2040/RP2350:\n- UART0/UART1 Bus::UART lanes with documented TX pin mux validation\n- transactional UART/DMA/GPIO ownership plus rollback\n- DMA BUSY, PL011 wire DRAINING, latch interval, and error cleanup\n- neutral UART wave encoder entry point with backend-specific baud ceilings\n- host coverage for 256 bytes, queues, error cleanup, latch, baud admission, and ledger ownership\n\nValidation:\n- ash test channel_engine_rp_uart --debug\n- ash test channel_engine_rp_uart --cpp\n- ash test rp_resource_ledger --debug\n- uv run --no-sync python ci/lint_cpp/run_all_checkers.py --no-rust\n\nHardware fbuild target is not configured in this repository's platformio.ini; physical validation remains tracked by #3631/#3661.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added UART-based clockless LED output support for RP2040 and RP2350 boards.
  * Enabled both UART0 and UART1 for supported hardware TX pins.
  * Added DMA-driven transmission with queuing, timing validation, and automatic resource management.
  * Added configurable baud-rate limits to improve compatibility across chipset timings.
* **Bug Fixes**
  * Improved cleanup and recovery when UART, DMA, or transmission setup fails.
* **Tests**
  * Added coverage for encoding, queuing, timing validation, failure handling, and hardware-resource ownership.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->