### PR TITLE
feat(rp2040): add single-lane PIO channel TX

### DIFF
--- a/src/fl/channels/bus.h
+++ b/src/fl/channels/bus.h
@@ -131,6 +131,7 @@ template<> struct BusInstanceCount<Bus::UART> { static constexpr fl::u8 value = 
 #elif defined(FL_IS_ARM_LPC_845)
 template<> struct BusInstanceCount<Bus::UART> { static constexpr fl::u8 value = 1; };
 #elif defined(FL_IS_RP2040) || defined(FL_IS_RP2350)
+template<> struct BusInstanceCount<Bus::FLEX_IO> { static constexpr fl::u8 value = 2; };
 template<> struct BusInstanceCount<Bus::UART> { static constexpr fl::u8 value = 2; };
 #endif
 

--- a/src/platforms/arm/rp/rpcommon/_build.cpp.hpp
+++ b/src/platforms/arm/rp/rpcommon/_build.cpp.hpp
@@ -5,9 +5,11 @@
 /// Includes all implementation files in alphabetical order
 
 #include "platforms/arm/rp/rpcommon/clockless_rp_pio_auto.cpp.hpp"
+#include "platforms/arm/rp/rpcommon/channel_engine_rp_pio.cpp.hpp"
 #include "platforms/arm/rp/rpcommon/channel_engine_rp_uart.cpp.hpp"
 #include "platforms/arm/rp/rpcommon/init_channel_driver_rp.cpp.hpp"
 #include "platforms/arm/rp/rpcommon/rp_uart_peripheral.cpp.hpp"
+#include "platforms/arm/rp/rpcommon/rp_pio_tx_peripheral.cpp.hpp"
 #include "fl/channels/uart_wave_encoder.cpp.hpp"
 #include "platforms/arm/rp/rpcommon/rx_pio_channel.cpp.hpp"
 #include "platforms/arm/rp/rpcommon/spi_hw_2_rp.cpp.hpp"

--- a/src/platforms/arm/rp/rpcommon/channel_engine_rp_pio.cpp.hpp
+++ b/src/platforms/arm/rp/rpcommon/channel_engine_rp_pio.cpp.hpp
@@ -1,0 +1,135 @@
+// IWYU pragma: private
+
+#include "platforms/arm/rp/rpcommon/channel_engine_rp_pio.h"
+
+#include "fl/stl/utility.h"
+
+namespace fl {
+
+ChannelEngineRpPio::ChannelEngineRpPio(
+    fl::shared_ptr<IRpPioTxPeripheral> peripheral, u8 which) FL_NO_EXCEPT
+    : mPeripheral(fl::move(peripheral)), mWhich(which), mCurrentChannel(0),
+      mLatchStartUs(0), mLatchDurationUs(0), mActive(false),
+      mLatchPending(false), mFailed(false) {}
+
+ChannelEngineRpPio::~ChannelEngineRpPio() {
+    releaseInFlight();
+    if (mPeripheral) {
+        mPeripheral->abort();
+        mPeripheral->deinitialize();
+    }
+}
+
+bool ChannelEngineRpPio::canHandle(const ChannelDataPtr& data) const FL_NO_EXCEPT {
+    if (!data || !data->isClockless() || data->getPin() < 0 || data->getPin() > 29) {
+        return false;
+    }
+    const ChipsetTimingConfig& timing = data->getTiming();
+    // pio_gen needs at least one cycle in each segment and subtracts two from
+    // the low tail instruction. Reject impossible runtime programs early.
+    return timing.t1_ns != 0 && timing.t2_ns != 0 && timing.t3_ns != 0 &&
+           timing.total_period_ns() >= 250;
+}
+
+void ChannelEngineRpPio::enqueue(ChannelDataPtr channelData) FL_NO_EXCEPT {
+    if (channelData && canHandle(channelData)) {
+        mPendingChannels.push_back(fl::move(channelData));
+    }
+}
+
+void ChannelEngineRpPio::show() FL_NO_EXCEPT {
+    if (mActive || mPendingChannels.empty()) {
+        return;
+    }
+    mInFlightChannels = fl::move(mPendingChannels);
+    mPendingChannels.clear();
+    mCurrentChannel = 0;
+    mFailed = false;
+    mError.clear();
+    for (const ChannelDataPtr& channel : mInFlightChannels) {
+        if (channel) channel->setInUse(true);
+    }
+    mActive = true;
+    if (!startNextTransmission()) {
+        mFailed = true;
+        mError = "RP PIO: unable to start queued channel";
+    }
+}
+
+IChannelDriver::DriverState ChannelEngineRpPio::poll() FL_NO_EXCEPT {
+    if (mFailed) return fail(mError.c_str());
+    if (!mActive) return DriverState::READY;
+    if (!mPeripheral) return fail("RP PIO: missing peripheral");
+    if (mPeripheral->hasError()) return fail("RP PIO: peripheral error");
+    if (mPeripheral->isDmaBusy()) return DriverState::BUSY;
+    if (!mPeripheral->isTerminalComplete()) return DriverState::DRAINING;
+
+    if (!mLatchPending) {
+        mLatchDurationUs = mInFlightChannels[mCurrentChannel]->getTiming().reset_us;
+        mLatchStartUs = mPeripheral->nowMicros();
+        mLatchPending = true;
+        if (mLatchDurationUs != 0) return DriverState::DRAINING;
+    }
+    if (static_cast<u32>(mPeripheral->nowMicros() - mLatchStartUs) < mLatchDurationUs) {
+        return DriverState::DRAINING;
+    }
+    mLatchPending = false;
+    ++mCurrentChannel;
+    if (startNextTransmission()) return DriverState::BUSY;
+    if (mCurrentChannel < mInFlightChannels.size()) {
+        return fail("RP PIO: unable to start queued channel");
+    }
+    mPeripheral->deinitialize();
+    releaseInFlight();
+    mActive = false;
+    return DriverState::READY;
+}
+
+bool ChannelEngineRpPio::startNextTransmission() FL_NO_EXCEPT {
+    return mCurrentChannel < mInFlightChannels.size() &&
+           beginTransmission(mInFlightChannels[mCurrentChannel]);
+}
+
+bool ChannelEngineRpPio::beginTransmission(const ChannelDataPtr& channel) FL_NO_EXCEPT {
+    if (!mPeripheral || !canHandle(channel)) return false;
+    const fl::vector_psram<u8>& input = channel->getData();
+    if (input.empty()) return false;
+    RpPioTxConfig config;
+    config.tx_pin = static_cast<u8>(channel->getPin());
+    config.timing = channel->getTiming();
+    if (!mPeripheral->configure(config)) return false;
+
+    // Autopull is configured for eight bits. Every byte occupies the MSB of
+    // one DMA word, so the PIO emits exactly the requested bytes: no final
+    // zero-padding can become a partial extra LED symbol.
+    mPioWords.resize(input.size());
+    for (size_t index = 0; index < input.size(); ++index) {
+        mPioWords[index] = static_cast<u32>(input[index]) << 24;
+    }
+    return mPeripheral->startTxDma(mPioWords.data(), mPioWords.size());
+}
+
+void ChannelEngineRpPio::releaseInFlight() FL_NO_EXCEPT {
+    for (const ChannelDataPtr& channel : mInFlightChannels) {
+        if (channel) channel->setInUse(false);
+    }
+    mInFlightChannels.clear();
+    mPioWords.clear();
+    mCurrentChannel = 0;
+    mLatchStartUs = 0;
+    mLatchDurationUs = 0;
+    mLatchPending = false;
+}
+
+IChannelDriver::DriverState ChannelEngineRpPio::fail(const char* message) FL_NO_EXCEPT {
+    if (mPeripheral) {
+        mPeripheral->abort();
+        mPeripheral->deinitialize();
+    }
+    releaseInFlight();
+    mActive = false;
+    mFailed = false;
+    return DriverState(DriverState::ERROR, fl::string(message));
+}
+
+}  // namespace fl

--- a/src/platforms/arm/rp/rpcommon/channel_engine_rp_pio.h
+++ b/src/platforms/arm/rp/rpcommon/channel_engine_rp_pio.h
@@ -1,0 +1,55 @@
+#pragma once
+
+// IWYU pragma: private
+
+#include "fl/channels/data.h"
+#include "fl/channels/driver.h"
+#include "fl/stl/shared_ptr.h"
+#include "fl/stl/vector.h"
+#include "platforms/arm/rp/rpcommon/irp_pio_tx_peripheral.h"
+
+namespace fl {
+
+/// Single-lane PIO clockless engine. Consecutive multi-lane batching is only
+/// admitted once all lanes have exactly the same timing; this engine keeps the
+/// initial single-lane path explicit rather than silently batching mismatch.
+class ChannelEngineRpPio final : public IChannelDriver {
+  public:
+    explicit ChannelEngineRpPio(fl::shared_ptr<IRpPioTxPeripheral> peripheral,
+                                u8 which) FL_NO_EXCEPT;
+    ~ChannelEngineRpPio() override;
+
+    bool canHandle(const ChannelDataPtr& data) const FL_NO_EXCEPT override;
+    void enqueue(ChannelDataPtr channelData) FL_NO_EXCEPT override;
+    void show() FL_NO_EXCEPT override;
+    DriverState poll() FL_NO_EXCEPT override;
+
+    fl::string getName() const FL_NO_EXCEPT override {
+        return mWhich == 0 ? fl::string::from_literal("PIO0")
+                           : fl::string::from_literal("PIO1");
+    }
+    Capabilities getCapabilities() const FL_NO_EXCEPT override {
+        return Capabilities(true, false);
+    }
+
+  private:
+    bool startNextTransmission() FL_NO_EXCEPT;
+    bool beginTransmission(const ChannelDataPtr& channel) FL_NO_EXCEPT;
+    void releaseInFlight() FL_NO_EXCEPT;
+    DriverState fail(const char* message) FL_NO_EXCEPT;
+
+    fl::shared_ptr<IRpPioTxPeripheral> mPeripheral;
+    fl::vector<ChannelDataPtr> mPendingChannels;
+    fl::vector<ChannelDataPtr> mInFlightChannels;
+    fl::vector<u32> mPioWords;
+    u8 mWhich;
+    size_t mCurrentChannel;
+    u32 mLatchStartUs;
+    u32 mLatchDurationUs;
+    bool mActive;
+    bool mLatchPending;
+    bool mFailed;
+    fl::string mError;
+};
+
+}  // namespace fl

--- a/src/platforms/arm/rp/rpcommon/init_channel_driver_rp.cpp.hpp
+++ b/src/platforms/arm/rp/rpcommon/init_channel_driver_rp.cpp.hpp
@@ -31,6 +31,7 @@
 #include "platforms/shared/spi_hw_8.h"
 #include "platforms/arm/rp/rpcommon/init_channel_driver.h"
 #include "platforms/arm/rp/rpcommon/rp_uart_bus_traits.h"
+#include "platforms/arm/rp/rpcommon/rp_pio_tx_bus_traits.h"
 
 namespace fl {
 
@@ -137,6 +138,8 @@ void initChannelDrivers() {
     // USB CDC remains the sketch/RPC transport and is never registered here.
     BusTraits<Bus::UART, 0>::registerWithManager();
     BusTraits<Bus::UART, 1>::registerWithManager();
+    BusTraits<Bus::FLEX_IO, 0>::registerWithManager();
+    BusTraits<Bus::FLEX_IO, 1>::registerWithManager();
 
     FL_DBG_F("RP2040/RP2350: Channel drivers initialized");
 }

--- a/src/platforms/arm/rp/rpcommon/irp_pio_tx_peripheral.h
+++ b/src/platforms/arm/rp/rpcommon/irp_pio_tx_peripheral.h
@@ -1,0 +1,38 @@
+#pragma once
+
+// IWYU pragma: private
+
+/// @file irp_pio_tx_peripheral.h
+/// @brief Host-testable terminal-completion contract for RP PIO LED TX.
+
+#include "fl/chipsets/chipset_timing_config.h"
+#include "fl/stl/cstddef.h"
+#include "fl/stl/int.h"
+#include "fl/stl/noexcept.h"
+
+namespace fl {
+
+struct RpPioTxConfig {
+    u8 tx_pin = 0;
+    ChipsetTimingConfig timing;
+};
+
+/// DMA completion is not wire completion: the PIO TX FIFO can be empty while
+/// the state machine is still generating the final bit. `isTerminalComplete()`
+/// becomes true only after the state machine reaches its next blocking `out`
+/// instruction with the FIFO empty, proving the previous bit's low tail ended.
+class IRpPioTxPeripheral {
+  public:
+    virtual ~IRpPioTxPeripheral() FL_NO_EXCEPT = default;
+
+    virtual bool configure(const RpPioTxConfig& config) FL_NO_EXCEPT = 0;
+    virtual bool startTxDma(const u32* words, size_t word_count) FL_NO_EXCEPT = 0;
+    virtual bool isDmaBusy() const FL_NO_EXCEPT = 0;
+    virtual bool isTerminalComplete() const FL_NO_EXCEPT = 0;
+    virtual bool hasError() const FL_NO_EXCEPT = 0;
+    virtual u32 nowMicros() const FL_NO_EXCEPT = 0;
+    virtual void abort() FL_NO_EXCEPT = 0;
+    virtual void deinitialize() FL_NO_EXCEPT = 0;
+};
+
+}  // namespace fl

--- a/src/platforms/arm/rp/rpcommon/rp_pio_dma_resource_manager.h
+++ b/src/platforms/arm/rp/rpcommon/rp_pio_dma_resource_manager.h
@@ -142,6 +142,46 @@ class RpPioDmaResourceManager {
         return true;
     }
 
+    /// @brief Atomically claim one PIO state machine, DMA channel, and GPIO.
+    bool claimPioDmaAndPin(PIO* pio_out, int* state_machine_out,
+                           int* dma_channel_out, u8 pin,
+                           u8 pio_index) FL_NO_EXCEPT {
+        LockGuard lock(*this);
+        if (pio_out == nullptr || state_machine_out == nullptr ||
+            dma_channel_out == nullptr) {
+            return false;
+        }
+        if (pio_index >= NUM_PIOS) return false;
+        PIO claimed_pio = pioForIndex(pio_index);
+        const int claimed_sm = pio_claim_unused_sm(claimed_pio, false);
+        if (claimed_sm >= 0 &&
+            !mLedger.claimPioStateMachine(pio_index, static_cast<u8>(claimed_sm))) {
+            pio_sm_unclaim(claimed_pio, static_cast<uint>(claimed_sm));
+            return false;
+        }
+        if (claimed_sm < 0 || !mLedger.claimPin(pin)) {
+            if (claimed_sm >= 0) {
+                pio_sm_unclaim(claimed_pio, static_cast<uint>(claimed_sm));
+                mLedger.releasePioStateMachine(static_cast<u8>(pioIndex(claimed_pio)),
+                                               static_cast<u8>(claimed_sm));
+            }
+            return false;
+        }
+        const int dma = dma_claim_unused_channel(false);
+        if (dma < 0 || !mLedger.claimDmaChannel(static_cast<u8>(dma))) {
+            if (dma >= 0) dma_channel_unclaim(static_cast<uint>(dma));
+            mLedger.releasePin(pin);
+            pio_sm_unclaim(claimed_pio, static_cast<uint>(claimed_sm));
+            mLedger.releasePioStateMachine(static_cast<u8>(pioIndex(claimed_pio)),
+                                           static_cast<u8>(claimed_sm));
+            return false;
+        }
+        *pio_out = claimed_pio;
+        *state_machine_out = claimed_sm;
+        *dma_channel_out = dma;
+        return true;
+    }
+
     bool claimPins(u8 first_pin, u8 count) FL_NO_EXCEPT {
         LockGuard lock(*this);
         for (u8 offset = 0; offset < count; ++offset) {

--- a/src/platforms/arm/rp/rpcommon/rp_pio_tx_bus_traits.h
+++ b/src/platforms/arm/rp/rpcommon/rp_pio_tx_bus_traits.h
@@ -1,0 +1,61 @@
+#pragma once
+
+// IWYU pragma: private
+
+#include "platforms/arm/rp/is_rp.h"
+
+#if defined(FL_IS_RP2040) || defined(FL_IS_RP2350)
+
+#include "fl/channels/bus.h"
+#include "fl/channels/bus_priorities.h"
+#include "fl/channels/bus_traits.h"
+#include "fl/channels/manager.h"
+#include "fl/stl/shared_ptr.h"
+#include "fl/stl/type_traits.h"
+#include "platforms/arm/rp/rpcommon/channel_engine_rp_pio.h"
+#include "platforms/arm/rp/rpcommon/rp_pio_tx_peripheral.h"
+
+namespace fl {
+namespace detail {
+
+template<u8 Which>
+struct RpPioTxBusHolder {
+    fl::shared_ptr<RpPioTxPeripheral> peripheral;
+    fl::shared_ptr<ChannelEngineRpPio> driver;
+    RpPioTxBusHolder() FL_NO_EXCEPT
+        : peripheral(fl::make_shared<RpPioTxPeripheral>(Which)),
+          driver(fl::make_shared<ChannelEngineRpPio>(peripheral, Which)) {}
+};
+
+template<u8 Which>
+inline fl::shared_ptr<ChannelEngineRpPio> rpPioTxInstancePtr() FL_NO_EXCEPT {
+    static RpPioTxBusHolder<Which> holder;
+    return holder.driver;
+}
+
+}  // namespace detail
+
+template<> struct BusTraits<Bus::FLEX_IO, 0> {
+    using Driver = ChannelEngineRpPio;
+    static fl::shared_ptr<Driver> instancePtr() FL_NO_EXCEPT { return detail::rpPioTxInstancePtr<0>(); }
+    static Driver& instance() FL_NO_EXCEPT { return *instancePtr(); }
+    static void registerWithManager() FL_NO_EXCEPT {
+        ChannelManager::instance().addDriver(default_bus_priority(Bus::FLEX_IO, 0), instancePtr());
+    }
+};
+
+template<> struct BusTraits<Bus::FLEX_IO, 1> {
+    using Driver = ChannelEngineRpPio;
+    static fl::shared_ptr<Driver> instancePtr() FL_NO_EXCEPT { return detail::rpPioTxInstancePtr<1>(); }
+    static Driver& instance() FL_NO_EXCEPT { return *instancePtr(); }
+    static void registerWithManager() FL_NO_EXCEPT {
+        ChannelManager::instance().addDriver(default_bus_priority(Bus::FLEX_IO, 1), instancePtr());
+    }
+};
+
+template<> struct BusSupports<Bus::FLEX_IO, ClocklessChipset, 0> : fl::true_type {};
+template<> struct BusSupports<Bus::FLEX_IO, ClocklessChipset, 1> : fl::true_type {};
+
+}  // namespace fl
+
+#endif

--- a/src/platforms/arm/rp/rpcommon/rp_pio_tx_peripheral.cpp.hpp
+++ b/src/platforms/arm/rp/rpcommon/rp_pio_tx_peripheral.cpp.hpp
@@ -1,0 +1,194 @@
+// IWYU pragma: private
+
+#include "platforms/arm/rp/rpcommon/rp_pio_tx_peripheral.h"
+
+#if defined(FL_IS_RP2040) || defined(FL_IS_RP2350)
+
+#include "fl/stl/chrono.h"
+#include "platforms/arm/rp/rpcommon/pio_asm.h"
+#include "platforms/arm/rp/rpcommon/rp_pio_dma_resource_manager.h"
+
+// IWYU pragma: begin_keep
+#include "hardware/clocks.h"
+#include "hardware/dma.h"
+#include "hardware/gpio.h"
+#include "hardware/pio.h"
+// IWYU pragma: end_keep
+
+namespace fl {
+
+struct RpPioTxPeripheral::ProgramStorage {
+    pio_instr instructions[4];
+    pio_program program;
+    u32 terminal_pc;
+
+    ProgramStorage() FL_NO_EXCEPT : instructions{0, 0, 0, 0}, program{}, terminal_pc(0) {}
+};
+
+namespace {
+
+u32 scaledCycles(u32 ns, u32 clock_hz, float divider) FL_NO_EXCEPT {
+    const float cycles = (static_cast<float>(ns) * static_cast<float>(clock_hz)) /
+                         1000000000.0f / divider;
+    const u32 rounded = static_cast<u32>(cycles + 0.5f);
+    return rounded == 0 ? 1 : rounded;
+}
+
+}  // namespace
+
+RpPioTxPeripheral::RpPioTxPeripheral(u8 pio_index) FL_NO_EXCEPT
+    : mPio(nullptr), mStateMachine(-1), mDmaChannel(-1), mPin(-1),
+      mProgramOffset(-1), mPioIndex(pio_index), mProgram(nullptr), mInitialized(false) {}
+
+RpPioTxPeripheral::~RpPioTxPeripheral() { deinitialize(); }
+
+bool RpPioTxPeripheral::createProgram(const ChipsetTimingConfig& timing) FL_NO_EXCEPT {
+    const u32 clock_hz = clock_get_hz(clk_sys);
+    if (clock_hz == 0) return false;
+    const float raw_max = static_cast<float>(timing.t1_ns > timing.t2_ns
+                                                  ? (timing.t1_ns > timing.t3_ns ? timing.t1_ns : timing.t3_ns)
+                                                  : (timing.t2_ns > timing.t3_ns ? timing.t2_ns : timing.t3_ns)) *
+                          static_cast<float>(clock_hz) / 1000000000.0f;
+    // Four instructions use a five-bit delay field. The low-tail instruction
+    // consumes two cycles outside its delay field, so preserve at least 2.
+    const float divider = raw_max > 16.0f ? raw_max / 16.0f : 1.0f;
+    const u32 t1 = scaledCycles(timing.t1_ns, clock_hz, divider);
+    const u32 t2 = scaledCycles(timing.t2_ns, clock_hz, divider);
+    const u32 t3 = scaledCycles(timing.t3_ns, clock_hz, divider);
+    if (t1 > 16 || t2 > 16 || t3 < 2 || t3 > 17) return false;
+
+    mProgram = new ProgramStorage(); // owned and freed by deinitialize
+    if (mProgram == nullptr) return false;
+    mProgram->instructions[0] = static_cast<pio_instr>(
+        PIO_INSTR_OUT | PIO_OUT_DST_X | PIO_OUT_CNT(1));
+    mProgram->instructions[1] = static_cast<pio_instr>(
+        PIO_INSTR_SET | PIO_SET_DST_PINS | PIO_SET_DATA(1) | PIO_DELAY(t1 - 1, 0));
+    mProgram->instructions[2] = static_cast<pio_instr>(
+        PIO_INSTR_MOV | PIO_MOV_DST_PINS | PIO_MOV_SRC_X | PIO_DELAY(t2 - 1, 0));
+    mProgram->instructions[3] = static_cast<pio_instr>(
+        PIO_INSTR_SET | PIO_SET_DST_PINS | PIO_SET_DATA(0) | PIO_DELAY(t3 - 2, 0));
+    mProgram->program.instructions = mProgram->instructions;
+    mProgram->program.length = 4;
+    mProgram->program.origin = -1;
+#if defined(PICO_SDK_VERSION_MAJOR) && PICO_SDK_VERSION_MAJOR >= 2
+    mProgram->program.pio_version = 0;
+    #if defined(PICO_PIO_VERSION) && PICO_PIO_VERSION > 0
+    mProgram->program.used_gpio_ranges = 0;
+    #endif
+#endif
+    PIO pio = static_cast<PIO>(mPio);
+    if (!pio_can_add_program(pio, &mProgram->program)) return false;
+    mProgramOffset = static_cast<int>(pio_add_program(pio, &mProgram->program));
+    mProgram->terminal_pc = static_cast<u32>(mProgramOffset);
+
+    pio_sm_config config = pio_get_default_sm_config();
+    sm_config_set_wrap(&config, static_cast<uint>(mProgramOffset),
+                       static_cast<uint>(mProgramOffset + 3));
+    sm_config_set_set_pins(&config, static_cast<uint>(mPin), 1);
+    sm_config_set_out_pins(&config, static_cast<uint>(mPin), 1);
+    // One DMA word per byte (byte stored in MSB), so autopull after eight
+    // shifts preserves exact byte boundaries and avoids final zero padding.
+    sm_config_set_out_shift(&config, false, true, 8);
+    sm_config_set_clkdiv(&config, divider);
+    pio_gpio_init(pio, static_cast<uint>(mPin));
+    pio_sm_set_consecutive_pindirs(pio, static_cast<uint>(mStateMachine),
+                                   static_cast<uint>(mPin), 1, true);
+    pio_sm_init(pio, static_cast<uint>(mStateMachine),
+                static_cast<uint>(mProgramOffset), &config);
+    pio_sm_set_enabled(pio, static_cast<uint>(mStateMachine), true);
+    return true;
+}
+
+bool RpPioTxPeripheral::configure(const RpPioTxConfig& config) FL_NO_EXCEPT {
+    deinitialize();
+    if (config.tx_pin > 29) return false;
+    PIO pio = nullptr;
+    int sm = -1;
+    int dma = -1;
+    if (!RpPioDmaResourceManager::instance().claimPioDmaAndPin(
+            &pio, &sm, &dma, config.tx_pin, mPioIndex)) {
+        return false;
+    }
+    mPio = pio;
+    mStateMachine = sm;
+    mDmaChannel = dma;
+    mPin = config.tx_pin;
+    if (!createProgram(config.timing)) {
+        deinitialize();
+        return false;
+    }
+    dma_channel_config dma_config = dma_channel_get_default_config(static_cast<uint>(mDmaChannel));
+    channel_config_set_transfer_data_size(&dma_config, DMA_SIZE_32);
+    channel_config_set_read_increment(&dma_config, true);
+    channel_config_set_write_increment(&dma_config, false);
+    channel_config_set_dreq(&dma_config, pio_get_dreq(static_cast<PIO>(mPio),
+                                                       static_cast<uint>(mStateMachine), true));
+    dma_channel_configure(static_cast<uint>(mDmaChannel), &dma_config,
+                          &static_cast<PIO>(mPio)->txf[mStateMachine], nullptr,
+                          0, false);
+    mInitialized = true;
+    return true;
+}
+
+bool RpPioTxPeripheral::startTxDma(const u32* words, size_t word_count) FL_NO_EXCEPT {
+    if (!mInitialized || words == nullptr || word_count == 0 ||
+        dma_channel_is_busy(static_cast<uint>(mDmaChannel))) return false;
+    dma_channel_set_read_addr(static_cast<uint>(mDmaChannel), words, false);
+    dma_channel_set_trans_count(static_cast<uint>(mDmaChannel),
+                                static_cast<uint32_t>(word_count), true);
+    return true;
+}
+
+bool RpPioTxPeripheral::isDmaBusy() const FL_NO_EXCEPT {
+    return mDmaChannel >= 0 && dma_channel_is_busy(static_cast<uint>(mDmaChannel));
+}
+
+bool RpPioTxPeripheral::isTerminalComplete() const FL_NO_EXCEPT {
+    if (!mInitialized || isDmaBusy()) return false;
+    const PIO pio = static_cast<PIO>(mPio);
+    // At offset 0 the next `out x, 1` is blocked by autopull because FIFO is
+    // empty. Reaching it proves the last bit's T3 low tail executed.
+    return pio_sm_is_tx_fifo_empty(pio, static_cast<uint>(mStateMachine)) &&
+           pio_sm_get_pc(pio, static_cast<uint>(mStateMachine)) ==
+               static_cast<uint>(mProgram->terminal_pc);
+}
+
+bool RpPioTxPeripheral::hasError() const FL_NO_EXCEPT { return false; }
+u32 RpPioTxPeripheral::nowMicros() const FL_NO_EXCEPT { return fl::micros(); }
+
+void RpPioTxPeripheral::abort() FL_NO_EXCEPT {
+    if (mDmaChannel >= 0) dma_channel_abort(static_cast<uint>(mDmaChannel));
+}
+
+void RpPioTxPeripheral::deinitialize() FL_NO_EXCEPT {
+    abort();
+    PIO pio = static_cast<PIO>(mPio);
+    if (pio != nullptr && mStateMachine >= 0) {
+        pio_sm_set_enabled(pio, static_cast<uint>(mStateMachine), false);
+        pio_sm_clear_fifos(pio, static_cast<uint>(mStateMachine));
+    }
+    if (pio != nullptr && mProgram != nullptr && mProgramOffset >= 0) {
+        pio_remove_program(pio, &mProgram->program, static_cast<uint>(mProgramOffset));
+    }
+    if (mDmaChannel >= 0) RpPioDmaResourceManager::instance().releaseDmaChannel(mDmaChannel);
+    if (pio != nullptr && mStateMachine >= 0) {
+        RpPioDmaResourceManager::instance().releasePioStateMachine(pio, mStateMachine);
+    }
+    if (mPin >= 0) {
+        gpio_set_function(static_cast<uint>(mPin), GPIO_FUNC_SIO);
+        gpio_set_dir(static_cast<uint>(mPin), GPIO_IN);
+        RpPioDmaResourceManager::instance().releasePins(static_cast<u8>(mPin), 1);
+    }
+    delete mProgram;
+    mPio = nullptr;
+    mStateMachine = -1;
+    mDmaChannel = -1;
+    mPin = -1;
+    mProgramOffset = -1;
+    mProgram = nullptr;
+    mInitialized = false;
+}
+
+}  // namespace fl
+
+#endif

--- a/src/platforms/arm/rp/rpcommon/rp_pio_tx_peripheral.h
+++ b/src/platforms/arm/rp/rpcommon/rp_pio_tx_peripheral.h
@@ -1,0 +1,42 @@
+#pragma once
+
+// IWYU pragma: private
+
+#include "platforms/arm/rp/is_rp.h"
+
+#if defined(FL_IS_RP2040) || defined(FL_IS_RP2350)
+
+#include "platforms/arm/rp/rpcommon/irp_pio_tx_peripheral.h"
+
+namespace fl {
+
+class RpPioTxPeripheral final : public IRpPioTxPeripheral {
+  public:
+    explicit RpPioTxPeripheral(u8 pio_index) FL_NO_EXCEPT;
+    ~RpPioTxPeripheral() override;
+    bool configure(const RpPioTxConfig& config) FL_NO_EXCEPT override;
+    bool startTxDma(const u32* words, size_t word_count) FL_NO_EXCEPT override;
+    bool isDmaBusy() const FL_NO_EXCEPT override;
+    bool isTerminalComplete() const FL_NO_EXCEPT override;
+    bool hasError() const FL_NO_EXCEPT override;
+    u32 nowMicros() const FL_NO_EXCEPT override;
+    void abort() FL_NO_EXCEPT override;
+    void deinitialize() FL_NO_EXCEPT override;
+
+  private:
+    struct ProgramStorage;
+    bool createProgram(const ChipsetTimingConfig& timing) FL_NO_EXCEPT;
+
+    void* mPio;
+    int mStateMachine;
+    int mDmaChannel;
+    int mPin;
+    int mProgramOffset;
+    u8 mPioIndex;
+    ProgramStorage* mProgram;
+    bool mInitialized;
+};
+
+}  // namespace fl
+
+#endif

--- a/tests/platforms/arm/rp/rpcommon/channel_engine_rp_pio.cpp
+++ b/tests/platforms/arm/rp/rpcommon/channel_engine_rp_pio.cpp
@@ -1,0 +1,140 @@
+/// @file channel_engine_rp_pio.cpp
+/// @brief Host lifecycle tests for RP PIO clockless TX.
+
+#include "test.h"
+
+#include "fl/channels/data.h"
+#include "fl/chipsets/led_timing.h"
+#include "fl/stl/move.h"
+#include "fl/stl/shared_ptr.h"
+#include "platforms/arm/rp/rpcommon/channel_engine_rp_pio.h"
+#include "platforms/arm/rp/rpcommon/channel_engine_rp_pio.cpp.hpp"
+
+FL_TEST_FILE(FL_FILEPATH) {
+
+using namespace fl;
+
+namespace {
+
+class PioTxMock final : public IRpPioTxPeripheral {
+  public:
+    bool configure(const RpPioTxConfig& config) FL_NO_EXCEPT override {
+        lastConfig = config;
+        ++configureCalls;
+        return configureOk;
+    }
+    bool startTxDma(const u32* words, size_t word_count) FL_NO_EXCEPT override {
+        ++startCalls;
+        firstWord = word_count == 0 ? 0 : words[0];
+        wordCount = word_count;
+        capturedWords.clear();
+        for (size_t index = 0; index < word_count; ++index) {
+            capturedWords.push_back(words[index]);
+        }
+        dmaBusy = startOk;
+        return startOk;
+    }
+    bool isDmaBusy() const FL_NO_EXCEPT override { return dmaBusy; }
+    bool isTerminalComplete() const FL_NO_EXCEPT override { return terminal; }
+    bool hasError() const FL_NO_EXCEPT override { return error; }
+    u32 nowMicros() const FL_NO_EXCEPT override { return timeUs; }
+    void abort() FL_NO_EXCEPT override { ++abortCalls; dmaBusy = false; }
+    void deinitialize() FL_NO_EXCEPT override { ++deinitializeCalls; }
+
+    RpPioTxConfig lastConfig;
+    bool configureOk = true;
+    bool startOk = true;
+    bool dmaBusy = false;
+    bool terminal = false;
+    bool error = false;
+    int configureCalls = 0;
+    int startCalls = 0;
+    int abortCalls = 0;
+    int deinitializeCalls = 0;
+    size_t wordCount = 0;
+    u32 firstWord = 0;
+    u32 timeUs = 0;
+    fl::vector<u32> capturedWords;
+};
+
+ChannelDataPtr makeChannel(int pin, const fl::vector_psram<u8>& bytes) {
+    fl::vector_psram<u8> copy = bytes;
+    return ChannelData::create(pin, makeTimingConfig<TIMING_WS2812_800KHZ>(),
+                               fl::move(copy));
+}
+
+}  // namespace
+
+FL_TEST_CASE("RP PIO TX waits for terminal state after DMA") {
+    auto peripheral = fl::make_shared<PioTxMock>();
+    ChannelEngineRpPio engine(peripheral, 0);
+    fl::vector_psram<u8> bytes;
+    bytes.push_back(0x00);
+    bytes.push_back(0xFF);
+    bytes.push_back(0xAA);
+    bytes.push_back(0x55);
+    auto channel = makeChannel(2, bytes);
+    engine.enqueue(channel);
+    engine.show();
+    FL_REQUIRE(channel->isInUse());
+    FL_CHECK_EQ(peripheral->wordCount, static_cast<size_t>(4));
+    FL_CHECK_EQ(peripheral->firstWord, 0x00000000u);
+    FL_REQUIRE_EQ(peripheral->capturedWords.size(), static_cast<size_t>(4));
+    FL_CHECK_EQ(peripheral->capturedWords[0], 0x00000000u);
+    FL_CHECK_EQ(peripheral->capturedWords[1], 0xFF000000u);
+    FL_CHECK_EQ(peripheral->capturedWords[2], 0xAA000000u);
+    FL_CHECK_EQ(peripheral->capturedWords[3], 0x55000000u);
+    FL_CHECK_EQ(engine.poll(), IChannelDriver::DriverState::BUSY);
+    peripheral->dmaBusy = false;
+    FL_CHECK_EQ(engine.poll(), IChannelDriver::DriverState::DRAINING);
+    FL_CHECK(channel->isInUse());
+    peripheral->terminal = true;
+    FL_CHECK_EQ(engine.poll(), IChannelDriver::DriverState::DRAINING);
+    peripheral->timeUs += 1000;
+    FL_CHECK_EQ(engine.poll(), IChannelDriver::DriverState::READY);
+    FL_CHECK_FALSE(channel->isInUse());
+    FL_CHECK_EQ(peripheral->deinitializeCalls, 1);
+}
+
+FL_TEST_CASE("RP PIO TX preserves pending work and cleans up errors") {
+    auto peripheral = fl::make_shared<PioTxMock>();
+    ChannelEngineRpPio engine(peripheral, 1);
+    fl::vector_psram<u8> firstBytes;
+    firstBytes.push_back(0x12);
+    fl::vector_psram<u8> secondBytes;
+    secondBytes.push_back(0x34);
+    auto first = makeChannel(3, firstBytes);
+    auto second = makeChannel(4, secondBytes);
+    engine.enqueue(first);
+    engine.show();
+    engine.enqueue(second);
+    FL_CHECK_FALSE(second->isInUse());
+    peripheral->error = true;
+    FL_CHECK_EQ(engine.poll(), IChannelDriver::DriverState::ERROR);
+    FL_CHECK_FALSE(first->isInUse());
+    FL_CHECK_FALSE(second->isInUse());
+    FL_CHECK(peripheral->abortCalls > 0);
+    FL_CHECK(peripheral->deinitializeCalls > 0);
+}
+
+FL_TEST_CASE("RP PIO TX rejects a failed second queued start") {
+    auto peripheral = fl::make_shared<PioTxMock>();
+    ChannelEngineRpPio engine(peripheral, 0);
+    fl::vector_psram<u8> bytes;
+    bytes.push_back(0x42);
+    auto first = makeChannel(5, bytes);
+    auto second = makeChannel(6, bytes);
+    engine.enqueue(first);
+    engine.enqueue(second);
+    engine.show();
+    peripheral->dmaBusy = false;
+    peripheral->terminal = true;
+    FL_REQUIRE_EQ(engine.poll(), IChannelDriver::DriverState::DRAINING);
+    peripheral->timeUs += 1000;
+    peripheral->configureOk = false;
+    FL_CHECK_EQ(engine.poll(), IChannelDriver::DriverState::ERROR);
+    FL_CHECK_FALSE(first->isInUse());
+    FL_CHECK_FALSE(second->isInUse());
+}
+
+}  // FL_TEST_FILE


### PR DESCRIPTION
Part of #3658.

Implements the single-lane PIO TX foundation:
- Bus FLEX_IO instances 0/1 bind to physical PIO0/PIO1.
- Atomic PIO-SM/DMA/GPIO acquisition and full PIO program cleanup.
- Exact byte-to-autopull-word packing without partial LED padding.
- DMA BUSY, terminal PIO DRAINING, reset/latch, then READY.
- Terminal completion requires DMA idle, TX FIFO empty, and PC stalled at the next blocking out instruction, proving the prior T3 low tail completed.

Does not close #3658: compatible 2/4/8-lane batching and physical RX-oracle proof remain tracked there.

Validation: bash test channel_engine_rp_pio --debug; bash test channel_engine_rp_pio --cpp; unified C++ lint with --no-rust.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added RP2040/RP2350 PIO-based transmission support for clockless LED devices.
  * Enabled two FLEX I/O channels for PIO-driven output.
  * Added DMA-backed transmission with resource management and cleanup.
  * Improved transmission status handling, including completion and error reporting.

* **Tests**
  * Added coverage for data transmission, lifecycle states, cleanup, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->