### PR TITLE
feat(rp2040): batch compatible PIO TX lanes

### DIFF
--- a/src/platforms/arm/rp/rpcommon/channel_engine_rp_pio.cpp.hpp
+++ b/src/platforms/arm/rp/rpcommon/channel_engine_rp_pio.cpp.hpp
@@ -10,7 +10,7 @@ ChannelEngineRpPio::ChannelEngineRpPio(
     fl::shared_ptr<IRpPioTxPeripheral> peripheral, u8 which) FL_NO_EXCEPT
     : mPeripheral(fl::move(peripheral)), mWhich(which), mCurrentChannel(0),
       mLatchStartUs(0), mLatchDurationUs(0), mActive(false),
-      mLatchPending(false), mFailed(false) {}
+      mActiveLaneCount(1), mLatchPending(false), mFailed(false) {}
 
 ChannelEngineRpPio::~ChannelEngineRpPio() {
     releaseInFlight();
@@ -74,7 +74,7 @@ IChannelDriver::DriverState ChannelEngineRpPio::poll() FL_NO_EXCEPT {
         return DriverState::DRAINING;
     }
     mLatchPending = false;
-    ++mCurrentChannel;
+    mCurrentChannel += mActiveLaneCount;
     if (startNextTransmission()) return DriverState::BUSY;
     if (mCurrentChannel < mInFlightChannels.size()) {
         return fail("RP PIO: unable to start queued channel");
@@ -94,17 +94,39 @@ bool ChannelEngineRpPio::beginTransmission(const ChannelDataPtr& channel) FL_NO_
     if (!mPeripheral || !canHandle(channel)) return false;
     const fl::vector_psram<u8>& input = channel->getData();
     if (input.empty()) return false;
+    // Batch only an adjacent run that is provably safe: same wire timing,
+    // byte count, and consecutive pins. This keeps a short/mismatched strip
+    // from receiving padding or a different timing waveform.
+    u8 run = 1;
+    while (run < 8 && mCurrentChannel + run < mInFlightChannels.size()) {
+        const ChannelDataPtr& next = mInFlightChannels[mCurrentChannel + run];
+        if (!next || next->getPin() != channel->getPin() + run ||
+            next->getTiming() != channel->getTiming() ||
+            next->getData().size() != input.size()) break;
+        ++run;
+    }
+    mActiveLaneCount = run >= 8 ? 8 : run >= 4 ? 4 : run >= 2 ? 2 : 1;
     RpPioTxConfig config;
     config.tx_pin = static_cast<u8>(channel->getPin());
+    config.lane_count = mActiveLaneCount;
     config.timing = channel->getTiming();
     if (!mPeripheral->configure(config)) return false;
 
     // Autopull is configured for eight bits. Every byte occupies the MSB of
     // one DMA word, so the PIO emits exactly the requested bytes: no final
     // zero-padding can become a partial extra LED symbol.
-    mPioWords.resize(input.size());
-    for (size_t index = 0; index < input.size(); ++index) {
-        mPioWords[index] = static_cast<u32>(input[index]) << 24;
+    mPioWords.clear();
+    for (size_t byte_index = 0; byte_index < input.size(); ++byte_index) {
+        for (int bit = 7; bit >= 0; --bit) {
+            u32 plane = 0;
+            for (u8 lane = 0; lane < mActiveLaneCount; ++lane) {
+                const u8 value = mInFlightChannels[mCurrentChannel + lane]
+                                     ->getData()[byte_index];
+                plane |= static_cast<u32>((value >> bit) & 1u)
+                         << (mActiveLaneCount - 1u - lane);
+            }
+            mPioWords.push_back(plane << (32u - mActiveLaneCount));
+        }
     }
     return mPeripheral->startTxDma(mPioWords.data(), mPioWords.size());
 }
@@ -119,6 +141,7 @@ void ChannelEngineRpPio::releaseInFlight() FL_NO_EXCEPT {
     mLatchStartUs = 0;
     mLatchDurationUs = 0;
     mLatchPending = false;
+    mActiveLaneCount = 1;
 }
 
 IChannelDriver::DriverState ChannelEngineRpPio::fail(const char* message) FL_NO_EXCEPT {

--- a/src/platforms/arm/rp/rpcommon/channel_engine_rp_pio.h
+++ b/src/platforms/arm/rp/rpcommon/channel_engine_rp_pio.h
@@ -46,6 +46,7 @@ class ChannelEngineRpPio final : public IChannelDriver {
     size_t mCurrentChannel;
     u32 mLatchStartUs;
     u32 mLatchDurationUs;
+    u8 mActiveLaneCount;
     bool mActive;
     bool mLatchPending;
     bool mFailed;

--- a/src/platforms/arm/rp/rpcommon/irp_pio_tx_peripheral.h
+++ b/src/platforms/arm/rp/rpcommon/irp_pio_tx_peripheral.h
@@ -14,6 +14,7 @@ namespace fl {
 
 struct RpPioTxConfig {
     u8 tx_pin = 0;
+    u8 lane_count = 1;
     ChipsetTimingConfig timing;
 };
 

--- a/src/platforms/arm/rp/rpcommon/rp_pio_dma_resource_manager.h
+++ b/src/platforms/arm/rp/rpcommon/rp_pio_dma_resource_manager.h
@@ -144,7 +144,7 @@ class RpPioDmaResourceManager {
 
     /// @brief Atomically claim one PIO state machine, DMA channel, and GPIO.
     bool claimPioDmaAndPin(PIO* pio_out, int* state_machine_out,
-                           int* dma_channel_out, u8 pin,
+                           int* dma_channel_out, u8 pin, u8 pin_count,
                            u8 pio_index) FL_NO_EXCEPT {
         LockGuard lock(*this);
         if (pio_out == nullptr || state_machine_out == nullptr ||
@@ -159,7 +159,7 @@ class RpPioDmaResourceManager {
             pio_sm_unclaim(claimed_pio, static_cast<uint>(claimed_sm));
             return false;
         }
-        if (claimed_sm < 0 || !mLedger.claimPin(pin)) {
+        if (claimed_sm < 0) {
             if (claimed_sm >= 0) {
                 pio_sm_unclaim(claimed_pio, static_cast<uint>(claimed_sm));
                 mLedger.releasePioStateMachine(static_cast<u8>(pioIndex(claimed_pio)),
@@ -167,10 +167,21 @@ class RpPioDmaResourceManager {
             }
             return false;
         }
+        u8 claimed_pins = 0;
+        while (claimed_pins < pin_count && mLedger.claimPin(pin + claimed_pins)) {
+            ++claimed_pins;
+        }
+        if (claimed_pins != pin_count) {
+            while (claimed_pins > 0) mLedger.releasePin(pin + --claimed_pins);
+            pio_sm_unclaim(claimed_pio, static_cast<uint>(claimed_sm));
+            mLedger.releasePioStateMachine(static_cast<u8>(pioIndex(claimed_pio)),
+                                           static_cast<u8>(claimed_sm));
+            return false;
+        }
         const int dma = dma_claim_unused_channel(false);
         if (dma < 0 || !mLedger.claimDmaChannel(static_cast<u8>(dma))) {
             if (dma >= 0) dma_channel_unclaim(static_cast<uint>(dma));
-            mLedger.releasePin(pin);
+            for (u8 offset = 0; offset < pin_count; ++offset) mLedger.releasePin(pin + offset);
             pio_sm_unclaim(claimed_pio, static_cast<uint>(claimed_sm));
             mLedger.releasePioStateMachine(static_cast<u8>(pioIndex(claimed_pio)),
                                            static_cast<u8>(claimed_sm));

--- a/src/platforms/arm/rp/rpcommon/rp_pio_tx_peripheral.cpp.hpp
+++ b/src/platforms/arm/rp/rpcommon/rp_pio_tx_peripheral.cpp.hpp
@@ -38,7 +38,7 @@ u32 scaledCycles(u32 ns, u32 clock_hz, float divider) FL_NO_EXCEPT {
 
 RpPioTxPeripheral::RpPioTxPeripheral(u8 pio_index) FL_NO_EXCEPT
     : mPio(nullptr), mStateMachine(-1), mDmaChannel(-1), mPin(-1),
-      mProgramOffset(-1), mPioIndex(pio_index), mProgram(nullptr), mInitialized(false) {}
+      mProgramOffset(-1), mLaneCount(1), mPioIndex(pio_index), mProgram(nullptr), mInitialized(false) {}
 
 RpPioTxPeripheral::~RpPioTxPeripheral() { deinitialize(); }
 
@@ -60,7 +60,7 @@ bool RpPioTxPeripheral::createProgram(const ChipsetTimingConfig& timing) FL_NO_E
     mProgram = new ProgramStorage(); // owned and freed by deinitialize
     if (mProgram == nullptr) return false;
     mProgram->instructions[0] = static_cast<pio_instr>(
-        PIO_INSTR_OUT | PIO_OUT_DST_X | PIO_OUT_CNT(1));
+        PIO_INSTR_OUT | PIO_OUT_DST_X | PIO_OUT_CNT(mLaneCount));
     mProgram->instructions[1] = static_cast<pio_instr>(
         PIO_INSTR_SET | PIO_SET_DST_PINS | PIO_SET_DATA(1) | PIO_DELAY(t1 - 1, 0));
     mProgram->instructions[2] = static_cast<pio_instr>(
@@ -84,15 +84,15 @@ bool RpPioTxPeripheral::createProgram(const ChipsetTimingConfig& timing) FL_NO_E
     pio_sm_config config = pio_get_default_sm_config();
     sm_config_set_wrap(&config, static_cast<uint>(mProgramOffset),
                        static_cast<uint>(mProgramOffset + 3));
-    sm_config_set_set_pins(&config, static_cast<uint>(mPin), 1);
-    sm_config_set_out_pins(&config, static_cast<uint>(mPin), 1);
-    // One DMA word per byte (byte stored in MSB), so autopull after eight
-    // shifts preserves exact byte boundaries and avoids final zero padding.
-    sm_config_set_out_shift(&config, false, true, 8);
+    sm_config_set_set_pins(&config, static_cast<uint>(mPin), mLaneCount);
+    sm_config_set_out_pins(&config, static_cast<uint>(mPin), mLaneCount);
+    // One DMA word per emitted bit-plane. Autopull after lane_count shifts
+    // preserves exact byte boundaries and avoids final zero padding.
+    sm_config_set_out_shift(&config, false, true, mLaneCount);
     sm_config_set_clkdiv(&config, divider);
     pio_gpio_init(pio, static_cast<uint>(mPin));
     pio_sm_set_consecutive_pindirs(pio, static_cast<uint>(mStateMachine),
-                                   static_cast<uint>(mPin), 1, true);
+                                   static_cast<uint>(mPin), mLaneCount, true);
     pio_sm_init(pio, static_cast<uint>(mStateMachine),
                 static_cast<uint>(mProgramOffset), &config);
     pio_sm_set_enabled(pio, static_cast<uint>(mStateMachine), true);
@@ -101,18 +101,21 @@ bool RpPioTxPeripheral::createProgram(const ChipsetTimingConfig& timing) FL_NO_E
 
 bool RpPioTxPeripheral::configure(const RpPioTxConfig& config) FL_NO_EXCEPT {
     deinitialize();
-    if (config.tx_pin > 29) return false;
+    if (config.tx_pin > 29 || (config.lane_count != 1 && config.lane_count != 2 &&
+        config.lane_count != 4 && config.lane_count != 8) ||
+        static_cast<u16>(config.tx_pin) + config.lane_count > 30) return false;
     PIO pio = nullptr;
     int sm = -1;
     int dma = -1;
     if (!RpPioDmaResourceManager::instance().claimPioDmaAndPin(
-            &pio, &sm, &dma, config.tx_pin, mPioIndex)) {
+            &pio, &sm, &dma, config.tx_pin, config.lane_count, mPioIndex)) {
         return false;
     }
     mPio = pio;
     mStateMachine = sm;
     mDmaChannel = dma;
     mPin = config.tx_pin;
+    mLaneCount = config.lane_count;
     if (!createProgram(config.timing)) {
         deinitialize();
         return false;
@@ -177,7 +180,7 @@ void RpPioTxPeripheral::deinitialize() FL_NO_EXCEPT {
     if (mPin >= 0) {
         gpio_set_function(static_cast<uint>(mPin), GPIO_FUNC_SIO);
         gpio_set_dir(static_cast<uint>(mPin), GPIO_IN);
-        RpPioDmaResourceManager::instance().releasePins(static_cast<u8>(mPin), 1);
+        RpPioDmaResourceManager::instance().releasePins(static_cast<u8>(mPin), mLaneCount);
     }
     delete mProgram;
     mPio = nullptr;
@@ -185,6 +188,7 @@ void RpPioTxPeripheral::deinitialize() FL_NO_EXCEPT {
     mDmaChannel = -1;
     mPin = -1;
     mProgramOffset = -1;
+    mLaneCount = 1;
     mProgram = nullptr;
     mInitialized = false;
 }

--- a/src/platforms/arm/rp/rpcommon/rp_pio_tx_peripheral.h
+++ b/src/platforms/arm/rp/rpcommon/rp_pio_tx_peripheral.h
@@ -32,6 +32,7 @@ class RpPioTxPeripheral final : public IRpPioTxPeripheral {
     int mDmaChannel;
     int mPin;
     int mProgramOffset;
+    u8 mLaneCount;
     u8 mPioIndex;
     ProgramStorage* mProgram;
     bool mInitialized;

--- a/tests/platforms/arm/rp/rpcommon/channel_engine_rp_pio.cpp
+++ b/tests/platforms/arm/rp/rpcommon/channel_engine_rp_pio.cpp
@@ -77,13 +77,20 @@ FL_TEST_CASE("RP PIO TX waits for terminal state after DMA") {
     engine.enqueue(channel);
     engine.show();
     FL_REQUIRE(channel->isInUse());
-    FL_CHECK_EQ(peripheral->wordCount, static_cast<size_t>(4));
+    FL_CHECK_EQ(peripheral->wordCount, static_cast<size_t>(32));
     FL_CHECK_EQ(peripheral->firstWord, 0x00000000u);
-    FL_REQUIRE_EQ(peripheral->capturedWords.size(), static_cast<size_t>(4));
+    FL_REQUIRE_EQ(peripheral->capturedWords.size(), static_cast<size_t>(32));
     FL_CHECK_EQ(peripheral->capturedWords[0], 0x00000000u);
-    FL_CHECK_EQ(peripheral->capturedWords[1], 0xFF000000u);
-    FL_CHECK_EQ(peripheral->capturedWords[2], 0xAA000000u);
-    FL_CHECK_EQ(peripheral->capturedWords[3], 0x55000000u);
+    for (size_t index = 0; index < 8; ++index) {
+        FL_CHECK_EQ(peripheral->capturedWords[index], 0u); // 0x00
+        FL_CHECK_EQ(peripheral->capturedWords[8 + index], 0x80000000u); // 0xFF
+    }
+    FL_CHECK_EQ(peripheral->capturedWords[16], 0x80000000u); // 0xAA MSB
+    FL_CHECK_EQ(peripheral->capturedWords[17], 0u);
+    FL_CHECK_EQ(peripheral->capturedWords[18], 0x80000000u);
+    FL_CHECK_EQ(peripheral->capturedWords[19], 0u);
+    FL_CHECK_EQ(peripheral->capturedWords[24], 0u); // 0x55 MSB
+    FL_CHECK_EQ(peripheral->capturedWords[25], 0x80000000u);
     FL_CHECK_EQ(engine.poll(), IChannelDriver::DriverState::BUSY);
     peripheral->dmaBusy = false;
     FL_CHECK_EQ(engine.poll(), IChannelDriver::DriverState::DRAINING);
@@ -123,7 +130,7 @@ FL_TEST_CASE("RP PIO TX rejects a failed second queued start") {
     fl::vector_psram<u8> bytes;
     bytes.push_back(0x42);
     auto first = makeChannel(5, bytes);
-    auto second = makeChannel(6, bytes);
+    auto second = makeChannel(7, bytes); // non-consecutive: must serialize
     engine.enqueue(first);
     engine.enqueue(second);
     engine.show();
@@ -135,6 +142,52 @@ FL_TEST_CASE("RP PIO TX rejects a failed second queued start") {
     FL_CHECK_EQ(engine.poll(), IChannelDriver::DriverState::ERROR);
     FL_CHECK_FALSE(first->isInUse());
     FL_CHECK_FALSE(second->isInUse());
+}
+
+FL_TEST_CASE("RP PIO TX batches only equal-length consecutive compatible lanes") {
+    auto peripheral = fl::make_shared<PioTxMock>();
+    ChannelEngineRpPio engine(peripheral, 0);
+    fl::vector_psram<u8> leftBytes;
+    leftBytes.push_back(0x80);
+    fl::vector_psram<u8> rightBytes;
+    rightBytes.push_back(0x00);
+    auto left = makeChannel(10, leftBytes);
+    auto right = makeChannel(11, rightBytes);
+    engine.enqueue(left);
+    engine.enqueue(right);
+    engine.show();
+    FL_REQUIRE_EQ(peripheral->lastConfig.tx_pin, 10);
+    FL_REQUIRE_EQ(peripheral->lastConfig.lane_count, 2);
+    FL_REQUIRE_EQ(peripheral->capturedWords.size(), static_cast<size_t>(8));
+    // Lane 0 occupies the most-significant emitted bit and lane 1 the next.
+    FL_CHECK_EQ(peripheral->capturedWords[0], 0x80000000u);
+    for (size_t index = 1; index < peripheral->capturedWords.size(); ++index) {
+        FL_CHECK_EQ(peripheral->capturedWords[index], 0u);
+    }
+    peripheral->dmaBusy = false;
+    peripheral->terminal = true;
+    FL_REQUIRE_EQ(engine.poll(), IChannelDriver::DriverState::DRAINING);
+    peripheral->timeUs += 1000;
+    FL_CHECK_EQ(engine.poll(), IChannelDriver::DriverState::READY);
+    FL_CHECK_FALSE(left->isInUse());
+    FL_CHECK_FALSE(right->isInUse());
+}
+
+FL_TEST_CASE("RP PIO TX selects four and eight lane batches only for full runs") {
+    for (u8 lanes = 4; lanes <= 8; lanes = static_cast<u8>(lanes * 2)) {
+        auto peripheral = fl::make_shared<PioTxMock>();
+        ChannelEngineRpPio engine(peripheral, 1);
+        fl::vector_psram<u8> bytes;
+        bytes.push_back(0xFF);
+        for (u8 lane = 0; lane < lanes; ++lane) {
+            engine.enqueue(makeChannel(12 + lane, bytes));
+        }
+        engine.show();
+        FL_CHECK_EQ(peripheral->lastConfig.lane_count, lanes);
+        FL_CHECK_EQ(peripheral->capturedWords.size(), static_cast<size_t>(8));
+        FL_CHECK_EQ(peripheral->capturedWords[0],
+                    ((1u << lanes) - 1u) << (32u - lanes));
+    }
 }
 
 }  // FL_TEST_FILE


### PR DESCRIPTION
Part of #3658.

Adds conservative 2/4/8 lane PIO TX batching on the single-lane foundation in #3666. A batch is admitted only for adjacent channels that have identical ChipsetTimingConfig values, equal byte sizes, and consecutive GPIO pins. All incompatible work remains serialized.

The PIO program changes its OUT/autopull width to the lane count; the encoder emits exact bit planes and host tests cover 1, 2, 4, and 8 lane packing plus error/latch lifecycle.

Validation: bash test channel_engine_rp_pio --debug; bash test channel_engine_rp_pio --cpp; unified C++ lint with --no-rust.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for multi-lane RP PIO transmissions using 2, 4, or 8 adjacent compatible channels.
  * Improved DMA payload packing for parallel lane output.
  * Added support for claiming and releasing contiguous pin ranges.

* **Bug Fixes**
  * Improved resource cleanup when PIO, DMA, or pin allocation fails.
  * Enhanced transmission progress tracking for batched channels.

* **Tests**
  * Added coverage for 2-, 4-, and 8-lane batching, payload placement, lifecycle handling, and cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->