### PR TITLE
feat(rp2040): add fixed SPI0/SPI1 DMA channel drivers

### DIFF
--- a/src/fl/channels/bus.h
+++ b/src/fl/channels/bus.h
@@ -103,6 +103,12 @@ template<> struct DefaultBus<SpiChipsetConfig> {
 };
 #endif
 
+#elif defined(FL_IS_RP2040) || defined(FL_IS_RP2350)
+
+template<> struct DefaultBus<SpiChipsetConfig> {
+    static constexpr Bus value = Bus::SPI;
+};
+
 #endif
 
 template<Bus B> struct BusInstanceCount {
@@ -132,6 +138,7 @@ template<> struct BusInstanceCount<Bus::UART> { static constexpr fl::u8 value = 
 template<> struct BusInstanceCount<Bus::UART> { static constexpr fl::u8 value = 1; };
 #elif defined(FL_IS_RP2040) || defined(FL_IS_RP2350)
 template<> struct BusInstanceCount<Bus::FLEX_IO> { static constexpr fl::u8 value = 2; };
+template<> struct BusInstanceCount<Bus::SPI> { static constexpr fl::u8 value = 2; };
 template<> struct BusInstanceCount<Bus::UART> { static constexpr fl::u8 value = 2; };
 #endif
 
@@ -181,13 +188,20 @@ inline const char* busDriverName(Bus b, fl::u8 which = 0, bool spi = false) FL_N
 #endif
         case Bus::AUTO:
         case Bus::BIT_BANG:
-        case Bus::SPI:
         case Bus::DUAL_SPI:
         case Bus::QUAD_SPI:
         case Bus::OCTAL_SPI:
         case Bus::RMT:
             (void)spi;
             return busName(b, which);
+        case Bus::SPI:
+#if defined(FL_IS_RP2040) || defined(FL_IS_RP2350)
+            (void)spi;
+            return which == 0 ? "SPI0" : "SPI1";
+#else
+            (void)spi;
+            return busName(b, which);
+#endif
         case Bus::UART:
             (void)which;
             (void)spi;

--- a/src/platforms/arm/rp/rpcommon/_build.cpp.hpp
+++ b/src/platforms/arm/rp/rpcommon/_build.cpp.hpp
@@ -6,9 +6,11 @@
 
 #include "platforms/arm/rp/rpcommon/clockless_rp_pio_auto.cpp.hpp"
 #include "platforms/arm/rp/rpcommon/channel_engine_rp_pio.cpp.hpp"
+#include "platforms/arm/rp/rpcommon/channel_engine_rp_spi.cpp.hpp"
 #include "platforms/arm/rp/rpcommon/channel_engine_rp_uart.cpp.hpp"
 #include "platforms/arm/rp/rpcommon/init_channel_driver_rp.cpp.hpp"
 #include "platforms/arm/rp/rpcommon/rp_uart_peripheral.cpp.hpp"
+#include "platforms/arm/rp/rpcommon/rp_spi_peripheral.cpp.hpp"
 #include "platforms/arm/rp/rpcommon/rp_pio_tx_peripheral.cpp.hpp"
 #include "fl/channels/uart_wave_encoder.cpp.hpp"
 #include "platforms/arm/rp/rpcommon/rx_pio_channel.cpp.hpp"

--- a/src/platforms/arm/rp/rpcommon/channel_engine_rp_spi.cpp.hpp
+++ b/src/platforms/arm/rp/rpcommon/channel_engine_rp_spi.cpp.hpp
@@ -1,0 +1,154 @@
+// IWYU pragma: private
+
+#include "platforms/arm/rp/rpcommon/channel_engine_rp_spi.h"
+
+#include "fl/stl/utility.h"
+
+namespace fl {
+
+namespace {
+constexpr u32 kRpSpiMaxClockHz = 62500000;
+constexpr u32 kRpSpiTimeoutUs = 1000000;
+}
+
+ChannelEngineRpSpi::ChannelEngineRpSpi(
+    fl::shared_ptr<IRpSpiPeripheral> peripheral, u8 spi_index) FL_NO_EXCEPT
+    : mPeripheral(fl::move(peripheral)), mSpiIndex(spi_index),
+      mCurrentChannel(0), mStartUs(0), mActive(false), mFailed(false) {}
+
+ChannelEngineRpSpi::~ChannelEngineRpSpi() {
+    releaseInFlight();
+    if (mPeripheral) {
+        mPeripheral->abort();
+        mPeripheral->deinitialize();
+    }
+}
+
+bool ChannelEngineRpSpi::pinsForChannel(const ChannelDataPtr& channel,
+                                        u8* miso_pin) const FL_NO_EXCEPT {
+    if (!channel || !channel->isSpi() || miso_pin == nullptr) return false;
+    const SpiChipsetConfig* config = channel->getChipset().ptr<SpiChipsetConfig>();
+    if (config == nullptr) return false;
+    static constexpr u8 kSpi0Mosi[] = {3, 7, 19, 23};
+    static constexpr u8 kSpi0Sck[] = {2, 6, 18, 22};
+    static constexpr u8 kSpi0Miso[] = {0, 4, 16, 20};
+    static constexpr u8 kSpi1Mosi[] = {11, 15, 27};
+    static constexpr u8 kSpi1Sck[] = {10, 14, 26};
+    static constexpr u8 kSpi1Miso[] = {8, 12, 24};
+    const u8* mosi = mSpiIndex == 0 ? kSpi0Mosi : kSpi1Mosi;
+    const u8* sck = mSpiIndex == 0 ? kSpi0Sck : kSpi1Sck;
+    const u8* miso = mSpiIndex == 0 ? kSpi0Miso : kSpi1Miso;
+    const size_t count = mSpiIndex == 0 ? 4 : (mSpiIndex == 1 ? 3 : 0);
+    for (size_t index = 0; index < count; ++index) {
+        if (config->dataPin == mosi[index] && config->clockPin == sck[index]) {
+            *miso_pin = miso[index];
+            return true;
+        }
+    }
+    return false;
+}
+
+bool ChannelEngineRpSpi::canHandle(const ChannelDataPtr& data) const FL_NO_EXCEPT {
+    u8 miso_pin = 0;
+    const SpiChipsetConfig* config = data ? data->getChipset().ptr<SpiChipsetConfig>() : nullptr;
+    return config != nullptr && config->timing.clock_hz != 0 &&
+           pinsForChannel(data, &miso_pin);
+}
+
+void ChannelEngineRpSpi::enqueue(ChannelDataPtr channelData) FL_NO_EXCEPT {
+    if (channelData && canHandle(channelData)) mPendingChannels.push_back(fl::move(channelData));
+}
+
+void ChannelEngineRpSpi::show() FL_NO_EXCEPT {
+    if (mActive || mPendingChannels.empty()) return;
+    mInFlightChannels = fl::move(mPendingChannels);
+    mPendingChannels.clear();
+    mCurrentChannel = 0;
+    mFailed = false;
+    mError.clear();
+    for (const ChannelDataPtr& channel : mInFlightChannels) {
+        if (channel) channel->setInUse(true);
+    }
+    mActive = true;
+    if (!startNextTransmission()) {
+        mFailed = true;
+        mError = "RP SPI: unable to start queued channel";
+    }
+}
+
+IChannelDriver::DriverState ChannelEngineRpSpi::poll() FL_NO_EXCEPT {
+    if (mFailed) return fail(mError.c_str());
+    if (!mActive) return DriverState::READY;
+    if (!mPeripheral) return fail("RP SPI: missing peripheral");
+    if (mPeripheral->hasError()) return fail("RP SPI: peripheral error");
+    if (static_cast<u32>(mPeripheral->nowMicros() - mStartUs) > kRpSpiTimeoutUs) {
+        return fail("RP SPI: transfer timeout");
+    }
+    if (mPeripheral->isTxDmaBusy() || mPeripheral->isRxDmaBusy()) {
+        return DriverState::BUSY;
+    }
+    // TX DMA completing only proves the FIFO accepted the bytes. PL022 BUSY
+    // is the wire-idle proof and must clear before the channel is released.
+    if (mPeripheral->isWireBusy()) return DriverState::DRAINING;
+    ++mCurrentChannel;
+    if (startNextTransmission()) return DriverState::BUSY;
+    if (mCurrentChannel < mInFlightChannels.size()) {
+        return fail("RP SPI: unable to start queued channel");
+    }
+    mPeripheral->deinitialize();
+    releaseInFlight();
+    mActive = false;
+    return DriverState::READY;
+}
+
+bool ChannelEngineRpSpi::startNextTransmission() FL_NO_EXCEPT {
+    return mCurrentChannel < mInFlightChannels.size() &&
+           beginTransmission(mInFlightChannels[mCurrentChannel]);
+}
+
+bool ChannelEngineRpSpi::beginTransmission(const ChannelDataPtr& channel) FL_NO_EXCEPT {
+    if (!mPeripheral || !canHandle(channel) || channel->getData().empty()) return false;
+    const SpiChipsetConfig& chipset = channel->getChipset().get<SpiChipsetConfig>();
+    u8 miso_pin = 0;
+    if (!pinsForChannel(channel, &miso_pin)) return false;
+    RpSpiConfig config;
+    config.spi_index = mSpiIndex;
+    config.mosi_pin = static_cast<u8>(chipset.dataPin);
+    config.miso_pin = miso_pin;
+    config.sck_pin = static_cast<u8>(chipset.clockPin);
+    config.clock_hz = chipset.timing.clock_hz > kRpSpiMaxClockHz
+                          ? kRpSpiMaxClockHz : chipset.timing.clock_hz;
+    // All supported clocked LED encoders emit eight-bit, MSB-first mode-0.
+    config.data_bits = 8;
+    config.cpol = false;
+    config.cpha = false;
+    config.msb_first = true;
+    if (!mPeripheral->configure(config) || mPeripheral->actualClockHz() == 0 ||
+        !mPeripheral->startTxDma(channel->getData().data(), channel->getData().size())) {
+        return false;
+    }
+    mStartUs = mPeripheral->nowMicros();
+    return true;
+}
+
+void ChannelEngineRpSpi::releaseInFlight() FL_NO_EXCEPT {
+    for (const ChannelDataPtr& channel : mInFlightChannels) {
+        if (channel) channel->setInUse(false);
+    }
+    mInFlightChannels.clear();
+    mCurrentChannel = 0;
+    mStartUs = 0;
+}
+
+IChannelDriver::DriverState ChannelEngineRpSpi::fail(const char* message) FL_NO_EXCEPT {
+    if (mPeripheral) {
+        mPeripheral->abort();
+        mPeripheral->deinitialize();
+    }
+    releaseInFlight();
+    mActive = false;
+    mFailed = false;
+    return DriverState(DriverState::ERROR, fl::string(message));
+}
+
+}  // namespace fl

--- a/src/platforms/arm/rp/rpcommon/channel_engine_rp_spi.h
+++ b/src/platforms/arm/rp/rpcommon/channel_engine_rp_spi.h
@@ -1,0 +1,50 @@
+#pragma once
+
+// IWYU pragma: private
+
+#include "fl/channels/data.h"
+#include "fl/channels/driver.h"
+#include "fl/stl/shared_ptr.h"
+#include "fl/stl/vector.h"
+#include "platforms/arm/rp/rpcommon/irp_spi_peripheral.h"
+
+namespace fl {
+
+class ChannelEngineRpSpi final : public IChannelDriver {
+  public:
+    ChannelEngineRpSpi(fl::shared_ptr<IRpSpiPeripheral> peripheral,
+                       u8 spi_index) FL_NO_EXCEPT;
+    ~ChannelEngineRpSpi() override;
+
+    bool canHandle(const ChannelDataPtr& data) const FL_NO_EXCEPT override;
+    void enqueue(ChannelDataPtr channelData) FL_NO_EXCEPT override;
+    void show() FL_NO_EXCEPT override;
+    DriverState poll() FL_NO_EXCEPT override;
+
+    fl::string getName() const FL_NO_EXCEPT override {
+        return mSpiIndex == 0 ? fl::string::from_literal("SPI0")
+                              : fl::string::from_literal("SPI1");
+    }
+    Capabilities getCapabilities() const FL_NO_EXCEPT override {
+        return Capabilities(false, true);
+    }
+
+  private:
+    bool startNextTransmission() FL_NO_EXCEPT;
+    bool beginTransmission(const ChannelDataPtr& channel) FL_NO_EXCEPT;
+    bool pinsForChannel(const ChannelDataPtr& channel, u8* miso_pin) const FL_NO_EXCEPT;
+    void releaseInFlight() FL_NO_EXCEPT;
+    DriverState fail(const char* message) FL_NO_EXCEPT;
+
+    fl::shared_ptr<IRpSpiPeripheral> mPeripheral;
+    fl::vector<ChannelDataPtr> mPendingChannels;
+    fl::vector<ChannelDataPtr> mInFlightChannels;
+    u8 mSpiIndex;
+    size_t mCurrentChannel;
+    u32 mStartUs;
+    bool mActive;
+    bool mFailed;
+    fl::string mError;
+};
+
+}  // namespace fl

--- a/src/platforms/arm/rp/rpcommon/init_channel_driver_rp.cpp.hpp
+++ b/src/platforms/arm/rp/rpcommon/init_channel_driver_rp.cpp.hpp
@@ -31,6 +31,7 @@
 #include "platforms/shared/spi_hw_8.h"
 #include "platforms/arm/rp/rpcommon/init_channel_driver.h"
 #include "platforms/arm/rp/rpcommon/rp_uart_bus_traits.h"
+#include "platforms/arm/rp/rpcommon/rp_spi_bus_traits.h"
 #include "platforms/arm/rp/rpcommon/rp_pio_tx_bus_traits.h"
 
 namespace fl {
@@ -138,6 +139,11 @@ void initChannelDrivers() {
     // USB CDC remains the sketch/RPC transport and is never registered here.
     BusTraits<Bus::UART, 0>::registerWithManager();
     BusTraits<Bus::UART, 1>::registerWithManager();
+    // Keep fixed PL022 SPI separate from the PIO multi-lane adapter above.
+    // Explicit Bus::SPI instance selection names SPI0 or SPI1 and therefore
+    // cannot be silently routed to a PIO parallel-SPI implementation.
+    BusTraits<Bus::SPI, 0>::registerWithManager();
+    BusTraits<Bus::SPI, 1>::registerWithManager();
     BusTraits<Bus::FLEX_IO, 0>::registerWithManager();
     BusTraits<Bus::FLEX_IO, 1>::registerWithManager();
 

--- a/src/platforms/arm/rp/rpcommon/irp_spi_peripheral.h
+++ b/src/platforms/arm/rp/rpcommon/irp_spi_peripheral.h
@@ -1,0 +1,45 @@
+#pragma once
+
+// IWYU pragma: private
+
+/// @file irp_spi_peripheral.h
+/// @brief Host-testable contract for RP2040 PL022 SPI DMA TX.
+
+#include "fl/stl/cstddef.h"
+#include "fl/stl/int.h"
+#include "fl/stl/noexcept.h"
+
+namespace fl {
+
+struct RpSpiConfig {
+    u8 spi_index = 0;
+    u8 mosi_pin = 0;
+    u8 miso_pin = 0;
+    u8 sck_pin = 0;
+    u32 clock_hz = 0;
+    u8 data_bits = 8;
+    bool cpol = false;
+    bool cpha = false;
+    bool msb_first = true;
+};
+
+/// PL022 receives one byte for every byte it clocks out.  Implementations
+/// must drain RX with DMA as well as feeding TX, otherwise the RX FIFO can
+/// overrun and stall a long LED frame even though FastLED is transmit-only.
+class IRpSpiPeripheral {
+  public:
+    virtual ~IRpSpiPeripheral() FL_NO_EXCEPT = default;
+
+    virtual bool configure(const RpSpiConfig& config) FL_NO_EXCEPT = 0;
+    virtual u32 actualClockHz() const FL_NO_EXCEPT = 0;
+    virtual bool startTxDma(const u8* data, size_t size) FL_NO_EXCEPT = 0;
+    virtual bool isTxDmaBusy() const FL_NO_EXCEPT = 0;
+    virtual bool isRxDmaBusy() const FL_NO_EXCEPT = 0;
+    virtual bool isWireBusy() const FL_NO_EXCEPT = 0;
+    virtual bool hasError() const FL_NO_EXCEPT = 0;
+    virtual u32 nowMicros() const FL_NO_EXCEPT = 0;
+    virtual void abort() FL_NO_EXCEPT = 0;
+    virtual void deinitialize() FL_NO_EXCEPT = 0;
+};
+
+}  // namespace fl

--- a/src/platforms/arm/rp/rpcommon/rp_pio_dma_resource_manager.h
+++ b/src/platforms/arm/rp/rpcommon/rp_pio_dma_resource_manager.h
@@ -113,6 +113,51 @@ class RpPioDmaResourceManager {
         mLedger.releaseUart(uart);
     }
 
+    /// @brief Atomically claim a PL022 SPI block, its TX/RX DMA lanes, and
+    /// the canonical MOSI/MISO/SCK GPIO triple.
+    bool claimSpiDmaAndPins(u8 spi, u8 mosi_pin, u8 miso_pin, u8 sck_pin,
+                            int* tx_dma_out, int* rx_dma_out) FL_NO_EXCEPT {
+        LockGuard lock(*this);
+        if (tx_dma_out == nullptr || rx_dma_out == nullptr ||
+            !mLedger.claimSpi(spi)) {
+            return false;
+        }
+        const u8 pins[] = {mosi_pin, miso_pin, sck_pin};
+        u8 claimed_pins = 0;
+        while (claimed_pins < 3 && mLedger.claimPin(pins[claimed_pins])) {
+            ++claimed_pins;
+        }
+        if (claimed_pins != 3) {
+            while (claimed_pins > 0) mLedger.releasePin(pins[--claimed_pins]);
+            mLedger.releaseSpi(spi);
+            return false;
+        }
+        const int tx_dma = dma_claim_unused_channel(false);
+        if (tx_dma < 0 || !mLedger.claimDmaChannel(static_cast<u8>(tx_dma))) {
+            if (tx_dma >= 0) dma_channel_unclaim(static_cast<uint>(tx_dma));
+            for (u8 pin : pins) mLedger.releasePin(pin);
+            mLedger.releaseSpi(spi);
+            return false;
+        }
+        const int rx_dma = dma_claim_unused_channel(false);
+        if (rx_dma < 0 || !mLedger.claimDmaChannel(static_cast<u8>(rx_dma))) {
+            if (rx_dma >= 0) dma_channel_unclaim(static_cast<uint>(rx_dma));
+            dma_channel_unclaim(static_cast<uint>(tx_dma));
+            mLedger.releaseDmaChannel(static_cast<u8>(tx_dma));
+            for (u8 pin : pins) mLedger.releasePin(pin);
+            mLedger.releaseSpi(spi);
+            return false;
+        }
+        *tx_dma_out = tx_dma;
+        *rx_dma_out = rx_dma;
+        return true;
+    }
+
+    void releaseSpi(u8 spi) FL_NO_EXCEPT {
+        LockGuard lock(*this);
+        mLedger.releaseSpi(spi);
+    }
+
     /// @brief Atomically acquire the complete UART TX resource set.
     ///
     /// A UART driver must not momentarily own only the UART block while a PIO
@@ -160,11 +205,6 @@ class RpPioDmaResourceManager {
             return false;
         }
         if (claimed_sm < 0) {
-            if (claimed_sm >= 0) {
-                pio_sm_unclaim(claimed_pio, static_cast<uint>(claimed_sm));
-                mLedger.releasePioStateMachine(static_cast<u8>(pioIndex(claimed_pio)),
-                                               static_cast<u8>(claimed_sm));
-            }
             return false;
         }
         u8 claimed_pins = 0;

--- a/src/platforms/arm/rp/rpcommon/rp_resource_ledger.h
+++ b/src/platforms/arm/rp/rpcommon/rp_resource_ledger.h
@@ -3,7 +3,7 @@
 // IWYU pragma: private
 
 /// @file rp_resource_ledger.h
-/// @brief Lock-free ownership ledger shared by RP2040/RP2350 PIO drivers.
+/// @brief Lock-free ownership ledger shared by RP2040/RP2350 channel drivers.
 ///
 /// The Pico SDK owns the hardware claim bits. This ledger records FastLED's
 /// matching ownership so a driver can make rollback and cleanup deterministic
@@ -24,6 +24,7 @@ class RpResourceLedger {
     static constexpr u8 kMaxDmaChannels = 32;
     static constexpr u8 kMaxPins = 64;
     static constexpr u8 kMaxUarts = 2;
+    static constexpr u8 kMaxSpis = 2;
 
     RpResourceLedger(u8 pio_blocks = kMaxPioBlocks,
                      u8 state_machines_per_pio = kMaxStateMachinesPerPio,
@@ -88,6 +89,18 @@ class RpResourceLedger {
         return uart < kMaxUarts && isBitClaimed(mUartsClaimed, uart);
     }
 
+    bool claimSpi(u8 spi) FL_NO_EXCEPT {
+        return spi < kMaxSpis && claimBit(mSpisClaimed, spi);
+    }
+
+    bool releaseSpi(u8 spi) FL_NO_EXCEPT {
+        return spi < kMaxSpis && releaseBit(mSpisClaimed, spi);
+    }
+
+    bool isSpiClaimed(u8 spi) const FL_NO_EXCEPT {
+        return spi < kMaxSpis && isBitClaimed(mSpisClaimed, spi);
+    }
+
     bool claimPin(u8 pin) FL_NO_EXCEPT {
         return pin < mPins && claimBit(mPinsClaimed[pin / 32], pin % 32);
     }
@@ -106,6 +119,7 @@ class RpResourceLedger {
         }
         mDmaChannelsClaimed.store(0, memory_order_release);
         mUartsClaimed.store(0, memory_order_release);
+        mSpisClaimed.store(0, memory_order_release);
         for (u8 word = 0; word < 2; ++word) {
             mPinsClaimed[word].store(0, memory_order_release);
         }
@@ -147,6 +161,7 @@ class RpResourceLedger {
     atomic<u32> mPioStateMachines[kMaxPioBlocks];
     atomic<u32> mDmaChannelsClaimed;
     atomic<u32> mUartsClaimed;
+    atomic<u32> mSpisClaimed;
     atomic<u32> mPinsClaimed[2];
 };
 

--- a/src/platforms/arm/rp/rpcommon/rp_spi_bus_traits.h
+++ b/src/platforms/arm/rp/rpcommon/rp_spi_bus_traits.h
@@ -1,0 +1,61 @@
+#pragma once
+
+// IWYU pragma: private
+
+#include "platforms/arm/rp/is_rp.h"
+
+#if defined(FL_IS_RP2040) || defined(FL_IS_RP2350)
+
+#include "fl/channels/bus.h"
+#include "fl/channels/bus_priorities.h"
+#include "fl/channels/bus_traits.h"
+#include "fl/channels/manager.h"
+#include "fl/stl/shared_ptr.h"
+#include "fl/stl/type_traits.h"
+#include "platforms/arm/rp/rpcommon/channel_engine_rp_spi.h"
+#include "platforms/arm/rp/rpcommon/rp_spi_peripheral.h"
+
+namespace fl {
+namespace detail {
+
+template<u8 Which>
+struct RpSpiBusHolder {
+    fl::shared_ptr<RpSpiPeripheral> peripheral;
+    fl::shared_ptr<ChannelEngineRpSpi> driver;
+    RpSpiBusHolder() FL_NO_EXCEPT
+        : peripheral(fl::make_shared<RpSpiPeripheral>()),
+          driver(fl::make_shared<ChannelEngineRpSpi>(peripheral, Which)) {}
+};
+
+template<u8 Which>
+inline fl::shared_ptr<ChannelEngineRpSpi> rpSpiInstancePtr() FL_NO_EXCEPT {
+    static RpSpiBusHolder<Which> holder;
+    return holder.driver;
+}
+
+}  // namespace detail
+
+template<> struct BusTraits<Bus::SPI, 0> {
+    using Driver = ChannelEngineRpSpi;
+    static fl::shared_ptr<Driver> instancePtr() FL_NO_EXCEPT { return detail::rpSpiInstancePtr<0>(); }
+    static Driver& instance() FL_NO_EXCEPT { return *instancePtr(); }
+    static void registerWithManager() FL_NO_EXCEPT {
+        ChannelManager::instance().addDriver(default_bus_priority(Bus::SPI, 0), instancePtr());
+    }
+};
+
+template<> struct BusTraits<Bus::SPI, 1> {
+    using Driver = ChannelEngineRpSpi;
+    static fl::shared_ptr<Driver> instancePtr() FL_NO_EXCEPT { return detail::rpSpiInstancePtr<1>(); }
+    static Driver& instance() FL_NO_EXCEPT { return *instancePtr(); }
+    static void registerWithManager() FL_NO_EXCEPT {
+        ChannelManager::instance().addDriver(default_bus_priority(Bus::SPI, 1), instancePtr());
+    }
+};
+
+template<> struct BusSupports<Bus::SPI, SpiChipsetConfig, 0> : fl::true_type {};
+template<> struct BusSupports<Bus::SPI, SpiChipsetConfig, 1> : fl::true_type {};
+
+}  // namespace fl
+
+#endif  // defined(FL_IS_RP2040) || defined(FL_IS_RP2350)

--- a/src/platforms/arm/rp/rpcommon/rp_spi_peripheral.cpp.hpp
+++ b/src/platforms/arm/rp/rpcommon/rp_spi_peripheral.cpp.hpp
@@ -1,0 +1,173 @@
+// IWYU pragma: private
+
+#include "platforms/arm/rp/rpcommon/rp_spi_peripheral.h"
+
+#if defined(FL_IS_RP2040) || defined(FL_IS_RP2350)
+
+#include "platforms/arm/rp/rpcommon/rp_pio_dma_resource_manager.h"
+#include "fl/stl/chrono.h"
+
+// IWYU pragma: begin_keep
+#include "hardware/dma.h"
+#include "hardware/gpio.h"
+#include "hardware/spi.h"
+// IWYU pragma: end_keep
+
+namespace fl {
+
+namespace {
+
+spi_inst_t* spiForIndex(int index) FL_NO_EXCEPT {
+    return index == 0 ? spi0 : (index == 1 ? spi1 : nullptr);
+}
+
+bool validPins(const RpSpiConfig& config) FL_NO_EXCEPT {
+    static constexpr u8 kSpi0Mosi[] = {3, 7, 19, 23};
+    static constexpr u8 kSpi0Miso[] = {0, 4, 16, 20};
+    static constexpr u8 kSpi0Sck[] = {2, 6, 18, 22};
+    static constexpr u8 kSpi1Mosi[] = {11, 15, 27};
+    static constexpr u8 kSpi1Miso[] = {8, 12, 24};
+    static constexpr u8 kSpi1Sck[] = {10, 14, 26};
+    const u8* mosi = config.spi_index == 0 ? kSpi0Mosi : kSpi1Mosi;
+    const u8* miso = config.spi_index == 0 ? kSpi0Miso : kSpi1Miso;
+    const u8* sck = config.spi_index == 0 ? kSpi0Sck : kSpi1Sck;
+    const size_t count = config.spi_index == 0 ? 4 : (config.spi_index == 1 ? 3 : 0);
+    for (size_t index = 0; index < count; ++index) {
+        if (config.mosi_pin == mosi[index] && config.miso_pin == miso[index] &&
+            config.sck_pin == sck[index]) return true;
+    }
+    return false;
+}
+
+}  // namespace
+
+RpSpiPeripheral::RpSpiPeripheral() FL_NO_EXCEPT
+    : mTxDmaChannel(-1), mRxDmaChannel(-1), mSpiIndex(-1), mMosiPin(-1),
+      mMisoPin(-1), mSckPin(-1), mRxSink(0), mActualClockHz(0),
+      mInitialized(false), mOwnsSpi(false), mOwnsPins(false) {}
+
+RpSpiPeripheral::~RpSpiPeripheral() { deinitialize(); }
+
+bool RpSpiPeripheral::configure(const RpSpiConfig& config) FL_NO_EXCEPT {
+    deinitialize();
+    if (!validPins(config) || config.clock_hz == 0 || config.data_bits != 8 ||
+        config.cpol || config.cpha || !config.msb_first) return false;
+    RpPioDmaResourceManager& resources = RpPioDmaResourceManager::instance();
+    if (!resources.claimSpiDmaAndPins(config.spi_index, config.mosi_pin,
+                                      config.miso_pin, config.sck_pin,
+                                      &mTxDmaChannel, &mRxDmaChannel)) {
+        return false;
+    }
+    mOwnsSpi = true;
+    mOwnsPins = true;
+    mSpiIndex = config.spi_index;
+    mMosiPin = config.mosi_pin;
+    mMisoPin = config.miso_pin;
+    mSckPin = config.sck_pin;
+    spi_inst_t* spi = spiForIndex(mSpiIndex);
+    if (spi == nullptr) {
+        deinitialize();
+        return false;
+    }
+    gpio_set_function(static_cast<uint>(mMosiPin), GPIO_FUNC_SPI);
+    gpio_set_function(static_cast<uint>(mMisoPin), GPIO_FUNC_SPI);
+    gpio_set_function(static_cast<uint>(mSckPin), GPIO_FUNC_SPI);
+    mActualClockHz = spi_init(spi, config.clock_hz);
+    if (mActualClockHz == 0) {
+        deinitialize();
+        return false;
+    }
+    // LED chipsets use Motorola SPI mode 0 and wire-order MSB first.
+    spi_set_format(spi, 8, SPI_CPOL_0, SPI_CPHA_0, SPI_MSB_FIRST);
+    mActualClockHz = spi_get_baudrate(spi);
+    mInitialized = mActualClockHz != 0;
+    if (!mInitialized) deinitialize();
+    return mInitialized;
+}
+
+u32 RpSpiPeripheral::actualClockHz() const FL_NO_EXCEPT { return mActualClockHz; }
+
+bool RpSpiPeripheral::startTxDma(const u8* data, size_t size) FL_NO_EXCEPT {
+    if (!mInitialized || data == nullptr || size == 0 || mTxDmaChannel < 0 ||
+        mRxDmaChannel < 0 || size > 0xffffffffu) {
+        return false;
+    }
+    spi_inst_t* spi = spiForIndex(mSpiIndex);
+    if (spi == nullptr || dma_channel_is_busy(static_cast<uint>(mTxDmaChannel)) ||
+        dma_channel_is_busy(static_cast<uint>(mRxDmaChannel))) return false;
+    dma_channel_config rx_config = dma_channel_get_default_config(
+        static_cast<uint>(mRxDmaChannel));
+    channel_config_set_transfer_data_size(&rx_config, DMA_SIZE_8);
+    channel_config_set_read_increment(&rx_config, false);
+    channel_config_set_write_increment(&rx_config, false);
+    channel_config_set_dreq(&rx_config, spi_get_dreq(spi, false));
+    dma_channel_configure(static_cast<uint>(mRxDmaChannel), &rx_config,
+                          &mRxSink, &spi_get_hw(spi)->dr,
+                          static_cast<uint32_t>(size), false);
+    dma_channel_config tx_config = dma_channel_get_default_config(
+        static_cast<uint>(mTxDmaChannel));
+    channel_config_set_transfer_data_size(&tx_config, DMA_SIZE_8);
+    channel_config_set_read_increment(&tx_config, true);
+    channel_config_set_write_increment(&tx_config, false);
+    channel_config_set_dreq(&tx_config, spi_get_dreq(spi, true));
+    // Arm RX first: every transmitted byte creates an RX FIFO entry.
+    dma_start_channel_mask(1u << static_cast<uint>(mRxDmaChannel));
+    dma_channel_configure(static_cast<uint>(mTxDmaChannel), &tx_config,
+                          &spi_get_hw(spi)->dr, data,
+                          static_cast<uint32_t>(size), true);
+    return true;
+}
+
+bool RpSpiPeripheral::isTxDmaBusy() const FL_NO_EXCEPT {
+    return mTxDmaChannel >= 0 && dma_channel_is_busy(static_cast<uint>(mTxDmaChannel));
+}
+
+bool RpSpiPeripheral::isRxDmaBusy() const FL_NO_EXCEPT {
+    return mRxDmaChannel >= 0 && dma_channel_is_busy(static_cast<uint>(mRxDmaChannel));
+}
+
+bool RpSpiPeripheral::isWireBusy() const FL_NO_EXCEPT {
+    spi_inst_t* spi = spiForIndex(mSpiIndex);
+    return spi != nullptr && spi_is_busy(spi);
+}
+
+bool RpSpiPeripheral::hasError() const FL_NO_EXCEPT { return false; }
+
+u32 RpSpiPeripheral::nowMicros() const FL_NO_EXCEPT { return fl::micros(); }
+
+void RpSpiPeripheral::abort() FL_NO_EXCEPT {
+    if (mTxDmaChannel >= 0) dma_channel_abort(static_cast<uint>(mTxDmaChannel));
+    if (mRxDmaChannel >= 0) dma_channel_abort(static_cast<uint>(mRxDmaChannel));
+}
+
+void RpSpiPeripheral::deinitialize() FL_NO_EXCEPT {
+    abort();
+    RpPioDmaResourceManager& resources = RpPioDmaResourceManager::instance();
+    if (mInitialized) {
+        spi_inst_t* spi = spiForIndex(mSpiIndex);
+        if (spi != nullptr) spi_deinit(spi);
+    }
+    if (mTxDmaChannel >= 0) resources.releaseDmaChannel(mTxDmaChannel);
+    if (mRxDmaChannel >= 0) resources.releaseDmaChannel(mRxDmaChannel);
+    if (mOwnsPins) {
+        resources.releasePins(static_cast<u8>(mMosiPin), 1);
+        resources.releasePins(static_cast<u8>(mMisoPin), 1);
+        resources.releasePins(static_cast<u8>(mSckPin), 1);
+    }
+    if (mOwnsSpi) resources.releaseSpi(static_cast<u8>(mSpiIndex));
+    mTxDmaChannel = -1;
+    mRxDmaChannel = -1;
+    mSpiIndex = -1;
+    mMosiPin = -1;
+    mMisoPin = -1;
+    mSckPin = -1;
+    mRxSink = 0;
+    mActualClockHz = 0;
+    mInitialized = false;
+    mOwnsSpi = false;
+    mOwnsPins = false;
+}
+
+}  // namespace fl
+
+#endif  // defined(FL_IS_RP2040) || defined(FL_IS_RP2350)

--- a/src/platforms/arm/rp/rpcommon/rp_spi_peripheral.h
+++ b/src/platforms/arm/rp/rpcommon/rp_spi_peripheral.h
@@ -1,0 +1,45 @@
+#pragma once
+
+// IWYU pragma: private
+
+#include "platforms/arm/rp/is_rp.h"
+
+#if defined(FL_IS_RP2040) || defined(FL_IS_RP2350)
+
+#include "platforms/arm/rp/rpcommon/irp_spi_peripheral.h"
+
+namespace fl {
+
+class RpSpiPeripheral final : public IRpSpiPeripheral {
+  public:
+    RpSpiPeripheral() FL_NO_EXCEPT;
+    ~RpSpiPeripheral() override;
+
+    bool configure(const RpSpiConfig& config) FL_NO_EXCEPT override;
+    u32 actualClockHz() const FL_NO_EXCEPT override;
+    bool startTxDma(const u8* data, size_t size) FL_NO_EXCEPT override;
+    bool isTxDmaBusy() const FL_NO_EXCEPT override;
+    bool isRxDmaBusy() const FL_NO_EXCEPT override;
+    bool isWireBusy() const FL_NO_EXCEPT override;
+    bool hasError() const FL_NO_EXCEPT override;
+    u32 nowMicros() const FL_NO_EXCEPT override;
+    void abort() FL_NO_EXCEPT override;
+    void deinitialize() FL_NO_EXCEPT override;
+
+  private:
+    int mTxDmaChannel;
+    int mRxDmaChannel;
+    int mSpiIndex;
+    int mMosiPin;
+    int mMisoPin;
+    int mSckPin;
+    u8 mRxSink;
+    u32 mActualClockHz;
+    bool mInitialized;
+    bool mOwnsSpi;
+    bool mOwnsPins;
+};
+
+}  // namespace fl
+
+#endif  // defined(FL_IS_RP2040) || defined(FL_IS_RP2350)

--- a/tests/platforms/arm/rp/rpcommon/channel_engine_rp_spi.cpp
+++ b/tests/platforms/arm/rp/rpcommon/channel_engine_rp_spi.cpp
@@ -1,0 +1,144 @@
+/// @file channel_engine_rp_spi.cpp
+/// @brief Host lifecycle tests for fixed RP2040 PL022 SPI TX.
+
+#include "test.h"
+
+#include "fl/channels/config.h"
+#include "fl/channels/data.h"
+#include "fl/chipsets/spi.h"
+#include "fl/stl/move.h"
+#include "fl/stl/shared_ptr.h"
+#include "platforms/arm/rp/rpcommon/channel_engine_rp_spi.h"
+#include "platforms/arm/rp/rpcommon/channel_engine_rp_spi.cpp.hpp"
+
+FL_TEST_FILE(FL_FILEPATH) {
+
+using namespace fl;
+
+namespace {
+
+class SpiMock final : public IRpSpiPeripheral {
+  public:
+    bool configure(const RpSpiConfig& config) FL_NO_EXCEPT override {
+        lastConfig = config;
+        ++configureCalls;
+        return configureOk;
+    }
+    u32 actualClockHz() const FL_NO_EXCEPT override { return actualHz; }
+    bool startTxDma(const u8* data, size_t size) FL_NO_EXCEPT override {
+        ++startCalls;
+        firstByte = size == 0 ? 0 : data[0];
+        byteCount = size;
+        txBusy = startOk;
+        rxBusy = startOk;
+        return startOk;
+    }
+    bool isTxDmaBusy() const FL_NO_EXCEPT override { return txBusy; }
+    bool isRxDmaBusy() const FL_NO_EXCEPT override { return rxBusy; }
+    bool isWireBusy() const FL_NO_EXCEPT override { return wireBusy; }
+    bool hasError() const FL_NO_EXCEPT override { return error; }
+    u32 nowMicros() const FL_NO_EXCEPT override { return timeUs; }
+    void abort() FL_NO_EXCEPT override { ++abortCalls; txBusy = false; rxBusy = false; }
+    void deinitialize() FL_NO_EXCEPT override { ++deinitializeCalls; }
+
+    RpSpiConfig lastConfig;
+    bool configureOk = true;
+    bool startOk = true;
+    bool txBusy = false;
+    bool rxBusy = false;
+    bool wireBusy = false;
+    bool error = false;
+    u32 actualHz = 6000000;
+    u32 timeUs = 0;
+    int configureCalls = 0;
+    int startCalls = 0;
+    int abortCalls = 0;
+    int deinitializeCalls = 0;
+    size_t byteCount = 0;
+    u8 firstByte = 0;
+};
+
+ChannelDataPtr makeChannel(int mosi, int sck, u32 clock_hz, u8 first_byte = 0xA5) {
+    fl::vector_psram<u8> bytes;
+    bytes.push_back(first_byte);
+    bytes.push_back(0x5A);
+    return ChannelData::create(
+        SpiChipsetConfig(mosi, sck, SpiEncoder::apa102(clock_hz)), fl::move(bytes));
+}
+
+}  // namespace
+
+FL_TEST_CASE("RP SPI0 DMA waits for both FIFOs and PL022 wire idle") {
+    auto peripheral = fl::make_shared<SpiMock>();
+    ChannelEngineRpSpi engine(peripheral, 0);
+    auto channel = makeChannel(3, 2, 6000000);
+    engine.enqueue(channel);
+    engine.show();
+    FL_REQUIRE(channel->isInUse());
+    FL_CHECK_EQ(peripheral->lastConfig.spi_index, 0);
+    FL_CHECK_EQ(peripheral->lastConfig.mosi_pin, 3);
+    FL_CHECK_EQ(peripheral->lastConfig.miso_pin, 0);
+    FL_CHECK_EQ(peripheral->lastConfig.sck_pin, 2);
+    FL_CHECK_EQ(peripheral->lastConfig.data_bits, 8);
+    FL_CHECK_FALSE(peripheral->lastConfig.cpol);
+    FL_CHECK_FALSE(peripheral->lastConfig.cpha);
+    FL_CHECK(peripheral->lastConfig.msb_first);
+    FL_CHECK_EQ(peripheral->byteCount, static_cast<size_t>(2));
+    FL_CHECK_EQ(peripheral->firstByte, 0xA5);
+    FL_CHECK_EQ(engine.poll(), IChannelDriver::DriverState::BUSY);
+    peripheral->txBusy = false;
+    FL_CHECK_EQ(engine.poll(), IChannelDriver::DriverState::BUSY);
+    peripheral->rxBusy = false;
+    peripheral->wireBusy = true;
+    FL_CHECK_EQ(engine.poll(), IChannelDriver::DriverState::DRAINING);
+    peripheral->wireBusy = false;
+    FL_CHECK_EQ(engine.poll(), IChannelDriver::DriverState::READY);
+    FL_CHECK_FALSE(channel->isInUse());
+    FL_CHECK_EQ(peripheral->deinitializeCalls, 1);
+}
+
+FL_TEST_CASE("RP SPI1 accepts only canonical RX SCK MOSI triples and clamps clock") {
+    auto peripheral = fl::make_shared<SpiMock>();
+    ChannelEngineRpSpi engine(peripheral, 1);
+    auto valid = makeChannel(27, 26, 100000000);
+    auto mismatched = makeChannel(27, 14, 12000000);
+    FL_CHECK(engine.canHandle(valid));
+    FL_CHECK_FALSE(engine.canHandle(mismatched));
+    engine.enqueue(valid);
+    engine.enqueue(mismatched);
+    engine.show();
+    FL_CHECK_EQ(peripheral->lastConfig.spi_index, 1);
+    FL_CHECK_EQ(peripheral->lastConfig.miso_pin, 24);
+    FL_CHECK_EQ(peripheral->lastConfig.clock_hz, 62500000u);
+    FL_CHECK_EQ(peripheral->startCalls, 1);
+}
+
+FL_TEST_CASE("RP SPI releases all channels on RX or peripheral failure") {
+    auto peripheral = fl::make_shared<SpiMock>();
+    ChannelEngineRpSpi engine(peripheral, 0);
+    auto first = makeChannel(7, 6, 12000000);
+    auto pending = makeChannel(19, 18, 12000000);
+    engine.enqueue(first);
+    engine.show();
+    engine.enqueue(pending);
+    peripheral->error = true;
+    FL_CHECK_EQ(engine.poll(), IChannelDriver::DriverState::ERROR);
+    FL_CHECK_FALSE(first->isInUse());
+    FL_CHECK_FALSE(pending->isInUse());
+    FL_CHECK(peripheral->abortCalls > 0);
+    FL_CHECK(peripheral->deinitializeCalls > 0);
+}
+
+FL_TEST_CASE("RP SPI times out a stalled transfer and releases its ownership") {
+    auto peripheral = fl::make_shared<SpiMock>();
+    ChannelEngineRpSpi engine(peripheral, 0);
+    auto channel = makeChannel(23, 22, 6000000);
+    engine.enqueue(channel);
+    engine.show();
+    peripheral->timeUs = 1000001;
+    FL_CHECK_EQ(engine.poll(), IChannelDriver::DriverState::ERROR);
+    FL_CHECK_FALSE(channel->isInUse());
+    FL_CHECK(peripheral->abortCalls > 0);
+}
+
+}  // FL_TEST_FILE

--- a/tests/platforms/arm/rp/rpcommon/rp_resource_ledger.cpp
+++ b/tests/platforms/arm/rp/rpcommon/rp_resource_ledger.cpp
@@ -24,6 +24,9 @@ FL_TEST_CASE("RP resource ledger rejects duplicate and out-of-range claims") {
     FL_CHECK(ledger.claimUart(0));
     FL_CHECK_FALSE(ledger.claimUart(0));
     FL_CHECK_FALSE(ledger.claimUart(2));
+    FL_CHECK(ledger.claimSpi(1));
+    FL_CHECK_FALSE(ledger.claimSpi(1));
+    FL_CHECK_FALSE(ledger.claimSpi(2));
     FL_CHECK(ledger.claimPin(29));
     FL_CHECK_FALSE(ledger.claimPin(30));
 }
@@ -34,17 +37,20 @@ FL_TEST_CASE("RP resource ledger cleanup restores partial acquisitions") {
     FL_REQUIRE(ledger.claimPioStateMachine(1, 3));
     FL_REQUIRE(ledger.claimDmaChannel(1));
     FL_REQUIRE(ledger.claimUart(1));
+    FL_REQUIRE(ledger.claimSpi(0));
     FL_REQUIRE(ledger.claimPin(4));
 
     FL_CHECK(ledger.releasePin(4));
     FL_CHECK(ledger.releaseDmaChannel(1));
     FL_CHECK(ledger.releaseUart(1));
+    FL_CHECK(ledger.releaseSpi(0));
     FL_CHECK(ledger.releasePioStateMachine(1, 3));
     FL_CHECK_FALSE(ledger.releasePioStateMachine(1, 3));
 
     FL_CHECK(ledger.claimPioStateMachine(1, 3));
     FL_CHECK(ledger.claimDmaChannel(1));
     FL_CHECK(ledger.claimUart(1));
+    FL_CHECK(ledger.claimSpi(0));
     FL_CHECK(ledger.claimPin(4));
 }
 


### PR DESCRIPTION
Implements Phase 6 software scope for #3659 / #3648.\n\n- Adds separate fixed-function PL022 SPI0/SPI1 IChannelDriver lanes with canonical RP2040 mux triples.\n- Uses Pico SDK mode-0, MSB-first SPI with paired TX and RX-drain DMA, ownership rollback, timeout/error cleanup, and spi_is_busy() wire-idle gating.\n- Makes RP true-SPI the default SpiChipsetConfig bus while retaining the PIO parallel-SPI adapter separately.\n\nValidated locally:\n- ash test channel_engine_rp_spi --debug\n- ash test channel_engine_rp_spi --cpp\n- ash test rp_resource_ledger --cpp\n- uv run --no-sync python ci/lint_cpp/run_all_checkers.py --no-rust\n\nThe attached-board SPI0/SPI1 MOSI-to-MISO loopback acceptance remains tracked by #3659 and hardware gate #3631; the Pico headers are not installed.\n\nCloses #3659

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added native SPI bus support for RP2040 and RP2350 boards, including both SPI0 and SPI1.
  * Enabled DMA-driven SPI channel transmissions with validated pin mappings and configurable clock limits.
  * Added reliable handling for queued transfers, completion states, errors, timeouts, and resource cleanup.

* **Bug Fixes**
  * Improved SPI resource allocation and rollback when setup fails.

* **Tests**
  * Added coverage for SPI transfers, pin validation, clock limiting, failures, timeouts, and resource ownership.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->