### PR TITLE
fix(spi): make SK9822 framing datasheet-conformant

### DIFF
--- a/src/fl/chipsets/encoders/apa102.h
+++ b/src/fl/chipsets/encoders/apa102.h
@@ -131,8 +131,10 @@ FL_OPTIMIZE_O2
 void encodeAPA102_AutoBrightness(InputIterator first, InputIterator last,
                                  OutputIterator out) FL_NO_EXCEPT {
     if (first == last) {
-        // Empty range - just write start frame (no end frame needed for 0 LEDs)
+        // Preserve a complete frame even at zero LEDs. This matters when a
+        // previously longer cascade is reconfigured through the public API.
         *out++ = 0x00; *out++ = 0x00; *out++ = 0x00; *out++ = 0x00;
+        *out++ = 0xFF; *out++ = 0xFF; *out++ = 0xFF; *out++ = 0xFF;
         return;
     }
 

--- a/src/fl/chipsets/encoders/pixel_iterator.h
+++ b/src/fl/chipsets/encoders/pixel_iterator.h
@@ -250,7 +250,7 @@ class PixelIterator {
     /// @brief Encode pixels in SK9822 format (zero allocation)
     /// @param out Output buffer to write encoded bytes
     /// @param hd_gamma Enable high-definition gamma correction (per-LED brightness)
-    /// @note Protocol: Same as APA102 but end frame uses 0x00 instead of 0xFF
+    /// @note Protocol: Same as APA102, including the all-ones end clock frame.
     template <typename CONTAINER_UIN8_T>
     void writeSK9822(CONTAINER_UIN8_T* out, bool hd_gamma = false) FL_NO_EXCEPT {
         auto back_ins = fl::back_inserter(*out);

--- a/src/fl/chipsets/encoders/sk9822.h
+++ b/src/fl/chipsets/encoders/sk9822.h
@@ -4,13 +4,12 @@
 /// @brief SK9822 SPI chipset encoder
 ///
 /// Free function encoder for SK9822 chipsets.
-/// SK9822 is nearly identical to APA102, with one key difference:
-/// end frame uses 0x00 instead of 0xFF.
+/// SK9822 uses the APA102-style all-ones end clock frame.
 ///
 /// Protocol:
 /// - Start frame: 4 bytes of 0x00
 /// - LED data: [0xE0|brightness][B][G][R] (4 bytes per LED)
-/// - End frame: ⌈num_leds/32⌉ DWords of 0x00 (differs from APA102)
+/// - End frame: ceil(num_leds/32) DWords of 0xFF
 ///
 /// Brightness modes:
 /// - Global: All LEDs use same 5-bit brightness
@@ -58,10 +57,12 @@ void encodeSK9822(InputIterator first, InputIterator last, OutputIterator out,
         ++num_leds;
     }
 
-    // SK9822 difference: end frame uses 0x00 instead of 0xFF
+    // The vendor datasheet requires all ones for the end clocks. These clocks
+    // shift the final LED frame through a long cascade; a zero frame is not a
+    // substitute because it is itself a valid start-frame pattern.
     size_t end_dwords = (num_leds / 32) + 1;
     for (size_t i = 0; i < end_dwords * 4; i++) {
-        *out++ = 0x00;
+        *out++ = 0xFF;
     }
 }
 
@@ -100,10 +101,10 @@ void encodeSK9822_HD(InputIterator first, InputIterator last,
         ++num_leds;
     }
 
-    // SK9822 difference: end frame uses 0x00
+    // See encodeSK9822(): the end clocks are all ones.
     size_t end_dwords = (num_leds / 32) + 1;
     for (size_t i = 0; i < end_dwords * 4; i++) {
-        *out++ = 0x00;
+        *out++ = 0xFF;
     }
 }
 
@@ -121,8 +122,9 @@ FL_NO_INLINE_IF_AVR
 void encodeSK9822_AutoBrightness(InputIterator first, InputIterator last,
                                  OutputIterator out) FL_NO_EXCEPT {
     if (first == last) {
-        // Empty range - just write start frame
+        // Keep zero LEDs as a full frame, matching the non-auto encoder.
         *out++ = 0x00; *out++ = 0x00; *out++ = 0x00; *out++ = 0x00;
+        *out++ = 0xFF; *out++ = 0xFF; *out++ = 0xFF; *out++ = 0xFF;
         return;
     }
 
@@ -164,10 +166,10 @@ void encodeSK9822_AutoBrightness(InputIterator first, InputIterator last,
         ++num_leds;
     }
 
-    // End frame (SK9822 uses 0x00)
+    // End frame: all ones clock the final data through the cascade.
     size_t end_dwords = (num_leds / 32) + 1;
     for (size_t i = 0; i < end_dwords * 4; i++) {
-        *out++ = 0x00;
+        *out++ = 0xFF;
     }
 }
 

--- a/tests/fl/chipsets/spi_frame_protocol.cpp
+++ b/tests/fl/chipsets/spi_frame_protocol.cpp
@@ -1,0 +1,103 @@
+/// @file spi_frame_protocol.cpp
+/// @brief Golden framing tests for APA102 and SK9822 channel encoders.
+
+#include "test.h"
+
+#include "fl/chipsets/encoders/apa102.h"
+#include "fl/chipsets/encoders/sk9822.h"
+#include "fl/stl/array.h"
+#include "fl/stl/iterator.h"
+#include "fl/stl/vector.h"
+
+FL_TEST_FILE(FL_FILEPATH) {
+
+using namespace fl;
+
+namespace {
+
+using Pixel = fl::array<u8, 3>;
+
+fl::vector<Pixel> makePixels(size_t count) {
+    fl::vector<Pixel> result;
+    for (size_t index = 0; index < count; ++index) {
+        // Arrays are already in wire BGR order.
+        result.push_back(Pixel{{static_cast<u8>(index),
+                                static_cast<u8>(index + 1),
+                                static_cast<u8>(index + 2)}});
+    }
+    return result;
+}
+
+size_t frameSize(size_t led_count) {
+    return 4 + led_count * 4 + 4 * (led_count / 32 + 1);
+}
+
+fl::vector<u8> encodeApa102(size_t led_count, u8 brightness) {
+    fl::vector<Pixel> input = makePixels(led_count);
+    fl::vector<u8> output;
+    encodeAPA102(input.begin(), input.end(), fl::back_inserter(output), brightness);
+    return output;
+}
+
+fl::vector<u8> encodeSk9822(size_t led_count, u8 brightness) {
+    fl::vector<Pixel> input = makePixels(led_count);
+    fl::vector<u8> output;
+    encodeSK9822(input.begin(), input.end(), fl::back_inserter(output), brightness);
+    return output;
+}
+
+void checkFrame(const fl::vector<u8>& encoded, size_t led_count,
+                u8 brightness) {
+    FL_REQUIRE_EQ(encoded.size(), frameSize(led_count));
+    for (size_t index = 0; index < 4; ++index) {
+        FL_CHECK_EQ(encoded[index], 0x00);
+    }
+    if (led_count != 0) {
+        FL_CHECK_EQ(encoded[4], static_cast<u8>(0xE0 | (brightness & 0x1F)));
+        FL_CHECK_EQ(encoded[5], 0x00);
+        FL_CHECK_EQ(encoded[6], 0x01);
+        FL_CHECK_EQ(encoded[7], 0x02);
+        const size_t last = 4 + (led_count - 1) * 4;
+        FL_CHECK_EQ(encoded[last], static_cast<u8>(0xE0 | (brightness & 0x1F)));
+        FL_CHECK_EQ(encoded[last + 1], static_cast<u8>(led_count - 1));
+    }
+    for (size_t index = 4 + led_count * 4; index < encoded.size(); ++index) {
+        FL_CHECK_EQ(encoded[index], 0xFF);
+    }
+}
+
+}  // namespace
+
+FL_TEST_CASE("APA102 and SK9822 use exact all-ones end clocks at cascade boundaries") {
+    const size_t counts[] = {0, 1, 31, 32, 33, 257};
+    for (size_t count : counts) {
+        const fl::vector<u8> apa = encodeApa102(count, 31);
+        const fl::vector<u8> sk = encodeSk9822(count, 31);
+        checkFrame(apa, count, 31);
+        checkFrame(sk, count, 31);
+        FL_REQUIRE_EQ(sk.size(), apa.size());
+        for (size_t index = 0; index < apa.size(); ++index) {
+            FL_CHECK_EQ(sk[index], apa[index]);
+        }
+    }
+}
+
+FL_TEST_CASE("SPI LED frame brightness clamps without changing BGR payload or end clocks") {
+    const u8 brightnesses[] = {0, 1, 31, 32, 255};
+    for (u8 brightness : brightnesses) {
+        checkFrame(encodeApa102(1, brightness), 1, brightness);
+        checkFrame(encodeSk9822(1, brightness), 1, brightness);
+    }
+}
+
+FL_TEST_CASE("Auto-brightness encoders keep an empty public frame complete") {
+    fl::vector<Pixel> empty;
+    fl::vector<u8> apa;
+    fl::vector<u8> sk;
+    encodeAPA102_AutoBrightness(empty.begin(), empty.end(), fl::back_inserter(apa));
+    encodeSK9822_AutoBrightness(empty.begin(), empty.end(), fl::back_inserter(sk));
+    checkFrame(apa, 0, 31);
+    checkFrame(sk, 0, 31);
+}
+
+}  // FL_TEST_FILE


### PR DESCRIPTION
Implements the Phase 7 software framing correction for #3660 / #3648.\n\n- Replaces SK9822's incorrect all-zero end frame with all-one end clocks in normal, HD, and auto-brightness encoders.\n- Makes APA102 and SK9822 auto-brightness zero-LED frames complete (start + end), matching their normal encoders.\n- Adds golden tests for 0/1/31/32/33/257 LEDs, brightness boundaries, BGR byte order, exact size, and every end-clock byte.\n\nValidated locally:\n- ash test spi_frame_protocol --debug\n- ash test spi_frame_protocol --cpp\n- ash test fl_channels_channel --cpp\n- uv run --no-sync python ci/lint_cpp/run_all_checkers.py --no-rust\n\nThe attached-board Phase 7 public-API and loopback evidence remains tracked by #3660 and hardware gate #3631.\n\nCloses #3660

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected SK9822 frame termination to use the required all-ones end frame.
  * Ensured empty APA102 and SK9822 inputs produce complete frames.
  * Improved reliability for brightness handling while preserving pixel data.

* **Tests**
  * Added coverage for APA102 and SK9822 framing, cascade boundaries, brightness clamping, and empty inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->