### PR TITLE
build: update fbuild for RP2040 AutoResearch deploy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,8 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    # Pin to fbuild 2.5.1 (released 2026-07-13).
+    # Pin to fbuild 2.5.2 (released 2026-07-15). This includes the RP2040
+    # UF2 deploy-path handling required by AutoResearch hardware validation.
     #
     # Pin history:
     #   2.5.1 -- upgrades PyO3 to 0.29 and fixes duplicate objc dylib
@@ -152,7 +153,7 @@ dependencies = [
     # primitive (FastLED/fbuild#532, #577/#580), and an
     # http-connect-timeout fix on the managed-zccache client
     # (FastLED/fbuild#573).
-    "fbuild==2.5.1",
+    "fbuild==2.5.2",
     "platformio>=6.1.19,<6.2",
     "python-dateutil",
     "ruff",


### PR DESCRIPTION
Updates the development fbuild pin from 2.5.1 to 2.5.2, which contains the RP2040 UF2 deploy-path handling required by the #3648 hardware bring-up.\n\nValidated on the attached Pico over the sanctioned fbuild → AutoResearch → JSON-RPC flow: deployment returned COM12 and the GPIO0↔GPIO1 loopback was discovered successfully.\n\nRefs FastLED/fbuild#1049 and #3648.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build tooling to version 2.5.2.
  * Refreshed related release and deployment notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->