### PR TITLE
feat(rp): add fixed SPI loopback AutoResearch

### DIFF
--- a/ci/autoresearch/args.py
+++ b/ci/autoresearch/args.py
@@ -118,6 +118,10 @@ class Args:
     # exclusive with the other LPC DMA harnesses at the flash budget.
     dma_uart: bool
 
+    # RP2040 fixed-SPI DMA byte-loopback harness.
+    rp_spi_loopback: bool
+    rp_spi_index: int
+
     # LPC845 fault emit validation (#3302).
     fault_emit_test: bool
 
@@ -249,6 +253,19 @@ See Also:
             "--spi",
             action="store_true",
             help="Test only SPI driver (Teensy 4.x resolves to SPI_UNIFIED)",
+        )
+        driver_group.add_argument(
+            "--rp-spi-loopback",
+            action="store_true",
+            help="RP2040-only: fixed SPI0/SPI1 DMA byte-loopback "
+            + "through the channel engine; requires MOSI-to-MISO jumper.",
+        )
+        driver_group.add_argument(
+            "--rp-spi-index",
+            type=int,
+            choices=(0, 1),
+            default=0,
+            help="RP fixed SPI instance for --rp-spi-loopback (default: 0).",
         )
         driver_group.add_argument(
             "--uart",
@@ -841,6 +858,8 @@ See Also:
             pwm_dma_cl=parsed.pwm_dma_cl,
             dma_spi=parsed.dma_spi,
             dma_uart=parsed.dma_uart,
+            rp_spi_loopback=parsed.rp_spi_loopback,
+            rp_spi_index=parsed.rp_spi_index,
             fault_emit_test=parsed.fault_emit_test,
             frames=parsed.frames,
             tight_timing=parsed.tight_timing,

--- a/ci/autoresearch/phases.py
+++ b/ci/autoresearch/phases.py
@@ -546,6 +546,7 @@ def _parse_args_and_build_commands(args: Args) -> RunContext | int:
 
     gpio_only_mode = (
         not drivers
+        and not getattr(args, "rp_spi_loopback", False)
         and not simd_test_mode
         and not coroutine_test_mode
         and not ieee754_test_mode
@@ -2010,6 +2011,9 @@ async def _run_tests_or_special_mode(ctx: RunContext, qctx: QuietContext) -> int
     if ctx.rpc_smoke_mode:
         return await _run_rpc_smoke_tests(ctx)
 
+    if getattr(ctx.args, "rp_spi_loopback", False):
+        return await _run_rp_spi_loopback_tests(ctx)
+
     if final_environment in LPC_BRING_UP_ENVS:
         if ctx.ieee754_test_mode:
             return await _run_ieee754_tests(ctx)
@@ -3035,6 +3039,49 @@ async def _run_lpc_dma_spi_tests(ctx: RunContext) -> int:
         upload_port,
         "--core-hz",
         str(core_hz),
+    ]
+    result = subprocess.run(cmd)
+    return 0 if result.returncode == 0 else 1
+
+
+async def _run_rp_spi_loopback_tests(ctx: RunContext) -> int:
+    """Run byte-exact loopback through the RP fixed-SPI channel engine."""
+    final_environment = (ctx.final_environment or "").lower()
+    if final_environment != "rp2040":
+        print("--rp-spi-loopback is only supported on the rp2040 environment.")
+        return 1
+
+    upload_port = ctx.upload_port
+    assert upload_port is not None
+    spi_index = ctx.args.rp_spi_index
+    default_tx_pin = 3 if spi_index == 0 else 11
+    default_rx_pin = 0 if spi_index == 0 else 8
+    sck_pin = 2 if spi_index == 0 else 10
+    tx_pin = ctx.args.tx_pin if ctx.args.tx_pin is not None else default_tx_pin
+    rx_pin = ctx.args.rx_pin if ctx.args.rx_pin is not None else default_rx_pin
+    print()
+    print("=" * 60)
+    print("RP2040 fixed-SPI DMA byte-loopback")
+    print(f"   Wiring: GPIO{tx_pin} (SPI{spi_index} MOSI) -> GPIO{rx_pin} (SPI{spi_index} MISO)")
+    print(f"   SCK: GPIO{sck_pin} (SPI{spi_index}); no SCK loopback connection is required")
+    print(f"   Engine: ChannelEngineRpSpi via BusTraits<Bus::SPI, {spi_index}>")
+    print("   Rates: 1 MHz, 8 MHz, 24 MHz; byte-exact MISO capture + wire-idle")
+    print("=" * 60)
+    print()
+    cmd = [
+        "uv",
+        "run",
+        "python",
+        "-m",
+        "ci.autoresearch.test_rp_spi_loopback",
+        "--port",
+        upload_port,
+        "--mosi-pin",
+        str(tx_pin),
+        "--miso-pin",
+        str(rx_pin),
+        "--spi-index",
+        str(spi_index),
     ]
     result = subprocess.run(cmd)
     return 0 if result.returncode == 0 else 1

--- a/ci/autoresearch/test_rp_spi_loopback.py
+++ b/ci/autoresearch/test_rp_spi_loopback.py
@@ -1,0 +1,128 @@
+"""Validate RP2040 fixed-SPI DMA loopback through ChannelEngineRpSpi.
+
+The companion AutoResearch RPC sends a fixed 32-byte pattern through
+``BusTraits<Bus::SPI, N>``. RX DMA captures MISO while the engine waits for
+the PL022 wire-idle state. SPI0 uses GPIO3 (MOSI) -> GPIO0 (MISO), GPIO2
+(SCK); SPI1 uses GPIO11 (MOSI) -> GPIO8 (MISO), GPIO10 (SCK).
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from typing import Any
+
+from ci.autoresearch.rpc_bench import METHOD_NOT_FOUND, RpcBench
+from ci.util.global_interrupt_handler import handle_keyboard_interrupt
+
+
+DEFAULT_PORT = "COM10"
+RATES_HZ = (1_000_000, 8_000_000, 24_000_000)
+
+
+def pins_for_spi(spi_index: int) -> tuple[int, int, int]:
+    """Return the canonical MOSI, MISO, and SCK pins for an RP SPI instance."""
+    return (3, 0, 2) if spi_index == 0 else (11, 8, 10)
+
+
+def run_case(
+    bench: RpcBench,
+    spi_index: int,
+    mosi_pin: int,
+    miso_pin: int,
+    sck_pin: int,
+    clock_hz: int,
+) -> bool:
+    """Run one rate and require byte-exact capture plus engine wire-idle."""
+    print(f"  rpSpiLoopback(SPI{spi_index}, {clock_hz:,} Hz)")
+    result: Any = bench.call(
+        "rpSpiLoopback",
+        args={
+            "spi_index": spi_index,
+            "mosi_pin": mosi_pin,
+            "miso_pin": miso_pin,
+            "sck_pin": sck_pin,
+            "clock_hz": clock_hz,
+        },
+        timeout=10.0,
+    )
+    if result is METHOD_NOT_FOUND:
+        print("    FAIL — firmware does not expose rpSpiLoopback")
+        return False
+    if not isinstance(result, dict):
+        print(f"    FAIL — malformed RPC result: {result!r}")
+        return False
+    data = result.get("data")
+    if not result.get("success") or not isinstance(data, dict):
+        print(f"    FAIL — {result.get('error', result.get('message', result))}")
+        if isinstance(data, dict):
+            print(f"      capture: {data}")
+        return False
+    expected = data.get("expected")
+    received = data.get("received")
+    actual_clock = data.get("actualClockHz")
+    wire_idle = data.get("wireIdle")
+    valid = (
+        expected == received
+        and wire_idle is True
+        and isinstance(actual_clock, int)
+        and actual_clock > 0
+    )
+    if not valid:
+        print(f"    FAIL — {data}")
+        return False
+    print(
+        f"    PASS — {len(expected)} bytes exact, actual={actual_clock:,} Hz, "
+        "PL022 wire idle"
+    )
+    return True
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="RP2040 fixed-SPI DMA byte-loopback through ChannelEngineRpSpi"
+    )
+    parser.add_argument("--port", default=DEFAULT_PORT)
+    parser.add_argument("--spi-index", type=int, choices=(0, 1), default=0)
+    parser.add_argument("--mosi-pin", type=int)
+    parser.add_argument("--miso-pin", type=int)
+    args = parser.parse_args()
+    default_mosi, default_miso, sck_pin = pins_for_spi(args.spi_index)
+    mosi_pin = args.mosi_pin if args.mosi_pin is not None else default_mosi
+    miso_pin = args.miso_pin if args.miso_pin is not None else default_miso
+
+    print(f"RP2040 SPI{args.spi_index} DMA byte-loopback — FastLED #3659")
+    print(f"  Port: {args.port}")
+    print(f"  Wiring: GPIO{mosi_pin} (MOSI) -> GPIO{miso_pin} (MISO)")
+    print(f"  SCK: GPIO{sck_pin} (output only)")
+    try:
+        with RpcBench(args.port) as bench:
+            schema = bench.call_flat("rpc.discover", args=[])
+            methods = schema.get("schema", []) if isinstance(schema, dict) else []
+            method_names = {
+                entry[0]
+                for entry in methods
+                if isinstance(entry, list) and entry and isinstance(entry[0], str)
+            }
+            if "rpSpiLoopback" not in method_names:
+                print("FAIL — deployed firmware schema does not contain rpSpiLoopback")
+                return 1
+            passed = all(
+                run_case(bench, args.spi_index, mosi_pin, miso_pin, sck_pin, clock_hz)
+                for clock_hz in RATES_HZ
+            )
+    except KeyboardInterrupt as interrupt:
+        handle_keyboard_interrupt(interrupt)
+        raise
+    except Exception as error:  # noqa: BLE001
+        print(f"FAIL — unable to run RP SPI loopback: {error}")
+        return 1
+    if passed:
+        print(f"PASS — SPI{args.spi_index} DMA loopback is byte-exact at all requested rates.")
+        return 0
+    print("FAIL — RP SPI loopback did not meet the byte-exact contract.")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ci/tests/test_autoresearch_phases.py
+++ b/ci/tests/test_autoresearch_phases.py
@@ -103,6 +103,8 @@ def _make_args(**overrides) -> Args:
         pwm_dma_cl=False,
         dma_spi=False,
         dma_uart=False,
+        rp_spi_loopback=False,
+        rp_spi_index=0,
         fault_emit_test=False,
         # Default existing-test behavior: use the legacy root-platformio.ini
         # path so the ``fake_project_dir`` fixture's hand-written ini is the
@@ -657,6 +659,28 @@ class TestParseArgsAndBuildCommands:
         assert isinstance(result, RunContext)
         assert result.gpio_only_mode is True
         assert result.drivers == []
+
+    def test_rp_spi_loopback_is_not_gpio_only(self, fake_project_dir: Path) -> None:
+        args = _make_args(
+            parlio=False,
+            rp_spi_loopback=True,
+            environment_positional="rp2040",
+            project_dir=fake_project_dir,
+            use_root_platformio_ini=False,
+        )
+        with patch(
+            "ci.autoresearch.staging.synthesise_autoresearch_project",
+            return_value=fake_project_dir,
+        ):
+            result = _parse_args_and_build_commands(args)
+        assert isinstance(result, RunContext)
+        assert result.gpio_only_mode is False
+        assert result.drivers == []
+
+    def test_rp_spi_loopback_flag_parses(self) -> None:
+        args = Args.parse_args(["--rp-spi-loopback", "--rp-spi-index", "1"])
+        assert args.rp_spi_loopback is True
+        assert args.rp_spi_index == 1
 
     def test_simd_mode(self, fake_project_dir: Path) -> None:
         args = _make_args(parlio=False, simd=True, project_dir=fake_project_dir)
@@ -1519,6 +1543,23 @@ class TestRunTestsOrSpecialMode:
         qctx = QuietContext(quiet=False)
         rc = asyncio.run(_run_tests_or_special_mode(ctx, qctx))
         assert rc == 0
+
+    def test_rp_spi_loopback_delegates_on_rp2040(self) -> None:
+        ctx = _make_ctx(
+            args=_make_args(parlio=False, rp_spi_loopback=True),
+            drivers=[],
+            gpio_only_mode=False,
+            final_environment="rp2040",
+        )
+        qctx = QuietContext(quiet=False)
+        with patch(
+            f"{_PATCH_MOD}._run_rp_spi_loopback_tests",
+            new_callable=AsyncMock,
+            return_value=0,
+        ) as loopback:
+            rc = asyncio.run(_run_tests_or_special_mode(ctx, qctx))
+        assert rc == 0
+        loopback.assert_awaited_once_with(ctx)
 
     def test_simd_mode_pass(self) -> None:
         ctx = _make_ctx(simd_test_mode=True)

--- a/examples/AutoResearch/AutoResearchRemote.cpp
+++ b/examples/AutoResearch/AutoResearchRemote.cpp
@@ -441,6 +441,7 @@ void AutoResearchRemoteControl::registerFunctions(fl::shared_ptr<AutoResearchSta
     bindNetworkMethods(*mRemote);
     bindAsyncMethods(*mRemote);
     bindBenchmarkMethods(*mRemote);
+    bindRpSpiMethods(*mRemote);
 }
 
 

--- a/examples/AutoResearch/AutoResearchRemote.h
+++ b/examples/AutoResearch/AutoResearchRemote.h
@@ -116,4 +116,5 @@ private:
     void bindNetworkMethods(fl::Remote& remote);
     void bindAsyncMethods(fl::Remote& remote);
     void bindBenchmarkMethods(fl::Remote& remote);
+    void bindRpSpiMethods(fl::Remote& remote);
 };

--- a/examples/AutoResearch/AutoResearchRemoteRpSpiMethods.cpp
+++ b/examples/AutoResearch/AutoResearchRemoteRpSpiMethods.cpp
@@ -1,0 +1,168 @@
+// RP2040/RP2350 fixed-SPI byte-loopback AutoResearch RPC.
+
+#include "fl/system/sketch_macros.h"
+#if !defined(FASTLED_AUTORESEARCH_LOW_MEMORY) && !FL_PLATFORM_HAS_LARGE_MEMORY
+#define FASTLED_AUTORESEARCH_LOW_MEMORY 1
+#endif
+#if !(defined(FASTLED_AUTORESEARCH_LOW_MEMORY) && FASTLED_AUTORESEARCH_LOW_MEMORY)
+
+#include "AutoResearchRemote.h"
+
+#include <Arduino.h>
+
+#include "fl/channels/data.h"
+#include "fl/chipsets/spi.h"
+#include "fl/remote/remote.h"
+#include "fl/stl/json.h"
+#include "fl/stl/move.h"
+#include "fl/stl/vector.h"
+#include "platforms/arm/rp/is_rp.h"
+
+#if defined(FL_IS_RP2040) || defined(FL_IS_RP2350)
+#include "platforms/arm/rp/rpcommon/rp_spi_bus_traits.h"
+#endif
+
+namespace {
+
+#if defined(FL_IS_RP2040) || defined(FL_IS_RP2350)
+
+constexpr fl::u8 kLoopbackPattern[] = {
+    0x00, 0xFF, 0x55, 0xAA, 0x12, 0x34, 0x56, 0x78,
+    0x87, 0x65, 0x43, 0x21, 0x0F, 0xF0, 0xCC, 0x33,
+    0x11, 0xEE, 0x22, 0xDD, 0x44, 0xBB, 0x88, 0x77,
+    0x66, 0x99, 0x3C, 0xC3, 0x5A, 0xA5, 0x7E, 0x81,
+};
+
+bool parseInt(const fl::json& config, const char* key, int* value) {
+    if (!config.contains(key) || !config[key].is_int()) return false;
+    *value = static_cast<int>(config[key].as_int().value());
+    return true;
+}
+
+template <fl::u8 Which>
+fl::json runLoopback(int mosi_pin, int miso_pin, int sck_pin, int clock_hz) {
+    fl::json response = fl::json::object();
+    const int expected_mosi = Which == 0 ? 3 : 11;
+    const int expected_miso = Which == 0 ? 0 : 8;
+    const int expected_sck = Which == 0 ? 2 : 10;
+    if (mosi_pin != expected_mosi || miso_pin != expected_miso ||
+        sck_pin != expected_sck) {
+        response.set("success", false);
+        response.set("error", "UnsupportedPins");
+        response.set("message", "Pins do not select the requested RP fixed SPI instance.");
+        return response;
+    }
+    if (clock_hz < 100000 || clock_hz > 62500000) {
+        response.set("success", false);
+        response.set("error", "InvalidClock");
+        response.set("message", "clock_hz must be in [100000, 62500000].");
+        return response;
+    }
+
+    fl::vector_psram<fl::u8> tx;
+    tx.assign(kLoopbackPattern, kLoopbackPattern + sizeof(kLoopbackPattern));
+    fl::u8 captured[sizeof(kLoopbackPattern)] = {};
+    auto channel = fl::ChannelData::create(
+        fl::SpiChipsetConfig(mosi_pin, sck_pin,
+                             fl::SpiEncoder::apa102(static_cast<fl::u32>(clock_hz))),
+        fl::move(tx));
+    auto& driver = fl::BusTraits<fl::Bus::SPI, Which>::instance();
+    if (!driver.captureNextRxBytes(captured, sizeof(captured))) {
+        response.set("success", false);
+        response.set("error", "DriverBusy");
+        response.set("message", "RP SPI driver was busy before the loopback transfer.");
+        return response;
+    }
+    driver.enqueue(channel);
+    driver.show();
+
+    fl::IChannelDriver::DriverState state = fl::IChannelDriver::DriverState::BUSY;
+    const unsigned long start_ms = millis();
+    while (millis() - start_ms < 2000) {
+        state = driver.poll();
+        if (state == fl::IChannelDriver::DriverState::READY ||
+            state == fl::IChannelDriver::DriverState::ERROR) {
+            break;
+        }
+        delay(1);
+    }
+
+    bool exact_match = state == fl::IChannelDriver::DriverState::READY;
+    fl::json expected = fl::json::array();
+    fl::json received = fl::json::array();
+    for (size_t index = 0; index < sizeof(kLoopbackPattern); ++index) {
+        expected.push_back(static_cast<int64_t>(kLoopbackPattern[index]));
+        received.push_back(static_cast<int64_t>(captured[index]));
+        exact_match = exact_match && captured[index] == kLoopbackPattern[index];
+    }
+
+    fl::json data = fl::json::object();
+    data.set("driver", Which == 0 ? "SPI0" : "SPI1");
+    data.set("mosiPin", static_cast<int64_t>(mosi_pin));
+    data.set("misoPin", static_cast<int64_t>(miso_pin));
+    data.set("sckPin", static_cast<int64_t>(sck_pin));
+    data.set("requestedClockHz", static_cast<int64_t>(clock_hz));
+    data.set("actualClockHz", static_cast<int64_t>(driver.lastActualClockHz()));
+    data.set("wireIdle", state == fl::IChannelDriver::DriverState::READY);
+    data.set("expected", expected);
+    data.set("received", received);
+    response.set("success", exact_match);
+    response.set("message", exact_match ? "RP SPI loopback passed." : "RP SPI loopback failed.");
+    response.set("data", data);
+    return response;
+}
+
+#endif
+
+}  // namespace
+
+void AutoResearchRemoteControl::bindRpSpiMethods(fl::Remote& remote) {
+    remote.bind("rpSpiLoopback", [this](const fl::json& args) -> fl::json {
+#if !defined(FL_IS_RP2040) && !defined(FL_IS_RP2350)
+        (void)args;
+        fl::json response = fl::json::object();
+        response.set("success", false);
+        response.set("error", "PlatformNotSupported");
+        response.set("message", "rpSpiLoopback requires an RP2040 or RP2350 target.");
+        return response;
+#else
+        // AutoResearch's GPIO pre-test owns its RX pin through a PIO receive
+        // channel. Release that diagnostic reservation before fixed SPI claims
+        // the same MISO pin through the RP resource manager.
+        if (mState) mState->rx_channel.reset();
+        if (!args.is_object()) {
+            fl::json response = fl::json::object();
+            response.set("success", false);
+            response.set("error", "InvalidArgs");
+            response.set("message", "Expected an object with spi_index, mosi_pin, miso_pin, sck_pin, and clock_hz.");
+            return response;
+        }
+        const fl::json config = args;
+        int spi_index = -1;
+        int mosi_pin = -1;
+        int miso_pin = -1;
+        int sck_pin = -1;
+        int clock_hz = 0;
+        if (!parseInt(config, "spi_index", &spi_index) ||
+            !parseInt(config, "mosi_pin", &mosi_pin) ||
+            !parseInt(config, "miso_pin", &miso_pin) ||
+            !parseInt(config, "sck_pin", &sck_pin) ||
+            !parseInt(config, "clock_hz", &clock_hz)) {
+            fl::json response = fl::json::object();
+            response.set("success", false);
+            response.set("error", "InvalidArgs");
+            response.set("message", "spi_index, mosi_pin, miso_pin, sck_pin, and clock_hz must be integers.");
+            return response;
+        }
+        if (spi_index == 0) return runLoopback<0>(mosi_pin, miso_pin, sck_pin, clock_hz);
+        if (spi_index == 1) return runLoopback<1>(mosi_pin, miso_pin, sck_pin, clock_hz);
+        fl::json response = fl::json::object();
+        response.set("success", false);
+        response.set("error", "InvalidSpiIndex");
+        response.set("message", "spi_index must be 0 or 1.");
+        return response;
+#endif
+    });
+}
+
+#endif  // !(defined(FASTLED_AUTORESEARCH_LOW_MEMORY) && FASTLED_AUTORESEARCH_LOW_MEMORY)

--- a/src/platforms/arm/rp/rpcommon/channel_engine_rp_spi.cpp.hpp
+++ b/src/platforms/arm/rp/rpcommon/channel_engine_rp_spi.cpp.hpp
@@ -14,7 +14,8 @@ constexpr u32 kRpSpiTimeoutUs = 1000000;
 ChannelEngineRpSpi::ChannelEngineRpSpi(
     fl::shared_ptr<IRpSpiPeripheral> peripheral, u8 spi_index) FL_NO_EXCEPT
     : mPeripheral(fl::move(peripheral)), mSpiIndex(spi_index),
-      mCurrentChannel(0), mStartUs(0), mActive(false), mFailed(false) {}
+      mCurrentChannel(0), mStartUs(0), mLastActualClockHz(0),
+      mRxCapture(nullptr), mRxCaptureSize(0), mActive(false), mFailed(false) {}
 
 ChannelEngineRpSpi::~ChannelEngineRpSpi() {
     releaseInFlight();
@@ -76,6 +77,13 @@ void ChannelEngineRpSpi::show() FL_NO_EXCEPT {
     }
 }
 
+bool ChannelEngineRpSpi::captureNextRxBytes(u8* data, size_t size) FL_NO_EXCEPT {
+    if (mActive || data == nullptr || size == 0) return false;
+    mRxCapture = data;
+    mRxCaptureSize = size;
+    return true;
+}
+
 IChannelDriver::DriverState ChannelEngineRpSpi::poll() FL_NO_EXCEPT {
     if (mFailed) return fail(mError.c_str());
     if (!mActive) return DriverState::READY;
@@ -123,10 +131,19 @@ bool ChannelEngineRpSpi::beginTransmission(const ChannelDataPtr& channel) FL_NO_
     config.cpol = false;
     config.cpha = false;
     config.msb_first = true;
-    if (!mPeripheral->configure(config) || mPeripheral->actualClockHz() == 0 ||
-        !mPeripheral->startTxDma(channel->getData().data(), channel->getData().size())) {
+    if (!mPeripheral->configure(config) || mPeripheral->actualClockHz() == 0) {
         return false;
     }
+    mLastActualClockHz = mPeripheral->actualClockHz();
+    const bool capture_requested = mRxCapture != nullptr;
+    const bool started = capture_requested
+        ? mPeripheral->startTxDmaCaptureRx(channel->getData().data(),
+                                           channel->getData().size(), mRxCapture,
+                                           mRxCaptureSize)
+        : mPeripheral->startTxDma(channel->getData().data(), channel->getData().size());
+    mRxCapture = nullptr;
+    mRxCaptureSize = 0;
+    if (!started) return false;
     mStartUs = mPeripheral->nowMicros();
     return true;
 }
@@ -138,6 +155,8 @@ void ChannelEngineRpSpi::releaseInFlight() FL_NO_EXCEPT {
     mInFlightChannels.clear();
     mCurrentChannel = 0;
     mStartUs = 0;
+    mRxCapture = nullptr;
+    mRxCaptureSize = 0;
 }
 
 IChannelDriver::DriverState ChannelEngineRpSpi::fail(const char* message) FL_NO_EXCEPT {

--- a/src/platforms/arm/rp/rpcommon/channel_engine_rp_spi.h
+++ b/src/platforms/arm/rp/rpcommon/channel_engine_rp_spi.h
@@ -21,6 +21,11 @@ class ChannelEngineRpSpi final : public IChannelDriver {
     void show() FL_NO_EXCEPT override;
     DriverState poll() FL_NO_EXCEPT override;
 
+    /// Capture MISO for the next queued transfer. This is an internal
+    /// diagnostic hook; normal FastLED output continues to discard RX bytes.
+    bool captureNextRxBytes(u8* data, size_t size) FL_NO_EXCEPT;
+    u32 lastActualClockHz() const FL_NO_EXCEPT { return mLastActualClockHz; }
+
     fl::string getName() const FL_NO_EXCEPT override {
         return mSpiIndex == 0 ? fl::string::from_literal("SPI0")
                               : fl::string::from_literal("SPI1");
@@ -42,6 +47,9 @@ class ChannelEngineRpSpi final : public IChannelDriver {
     u8 mSpiIndex;
     size_t mCurrentChannel;
     u32 mStartUs;
+    u32 mLastActualClockHz;
+    u8* mRxCapture;
+    size_t mRxCaptureSize;
     bool mActive;
     bool mFailed;
     fl::string mError;

--- a/src/platforms/arm/rp/rpcommon/irp_spi_peripheral.h
+++ b/src/platforms/arm/rp/rpcommon/irp_spi_peripheral.h
@@ -33,6 +33,12 @@ class IRpSpiPeripheral {
     virtual bool configure(const RpSpiConfig& config) FL_NO_EXCEPT = 0;
     virtual u32 actualClockHz() const FL_NO_EXCEPT = 0;
     virtual bool startTxDma(const u8* data, size_t size) FL_NO_EXCEPT = 0;
+    /// Start a TX transfer while capturing the simultaneous MISO bytes.
+    ///
+    /// This is used by the RP SPI loopback diagnostic. Production callers use
+    /// startTxDma(), which drains RX into a single-byte sink.
+    virtual bool startTxDmaCaptureRx(const u8* data, size_t size,
+                                     u8* rx_data, size_t rx_size) FL_NO_EXCEPT = 0;
     virtual bool isTxDmaBusy() const FL_NO_EXCEPT = 0;
     virtual bool isRxDmaBusy() const FL_NO_EXCEPT = 0;
     virtual bool isWireBusy() const FL_NO_EXCEPT = 0;

--- a/src/platforms/arm/rp/rpcommon/rp_spi_peripheral.cpp.hpp
+++ b/src/platforms/arm/rp/rpcommon/rp_spi_peripheral.cpp.hpp
@@ -88,8 +88,19 @@ bool RpSpiPeripheral::configure(const RpSpiConfig& config) FL_NO_EXCEPT {
 u32 RpSpiPeripheral::actualClockHz() const FL_NO_EXCEPT { return mActualClockHz; }
 
 bool RpSpiPeripheral::startTxDma(const u8* data, size_t size) FL_NO_EXCEPT {
+    return startTxDmaImpl(data, size, nullptr, 0);
+}
+
+bool RpSpiPeripheral::startTxDmaCaptureRx(const u8* data, size_t size,
+                                          u8* rx_data, size_t rx_size) FL_NO_EXCEPT {
+    return startTxDmaImpl(data, size, rx_data, rx_size);
+}
+
+bool RpSpiPeripheral::startTxDmaImpl(const u8* data, size_t size, u8* rx_data,
+                                     size_t rx_size) FL_NO_EXCEPT {
     if (!mInitialized || data == nullptr || size == 0 || mTxDmaChannel < 0 ||
-        mRxDmaChannel < 0 || size > 0xffffffffu) {
+        mRxDmaChannel < 0 || size > 0xffffffffu ||
+        (rx_data != nullptr && rx_size < size)) {
         return false;
     }
     spi_inst_t* spi = spiForIndex(mSpiIndex);
@@ -99,10 +110,10 @@ bool RpSpiPeripheral::startTxDma(const u8* data, size_t size) FL_NO_EXCEPT {
         static_cast<uint>(mRxDmaChannel));
     channel_config_set_transfer_data_size(&rx_config, DMA_SIZE_8);
     channel_config_set_read_increment(&rx_config, false);
-    channel_config_set_write_increment(&rx_config, false);
+    channel_config_set_write_increment(&rx_config, rx_data != nullptr);
     channel_config_set_dreq(&rx_config, spi_get_dreq(spi, false));
     dma_channel_configure(static_cast<uint>(mRxDmaChannel), &rx_config,
-                          &mRxSink, &spi_get_hw(spi)->dr,
+                          rx_data == nullptr ? &mRxSink : rx_data, &spi_get_hw(spi)->dr,
                           static_cast<uint32_t>(size), false);
     dma_channel_config tx_config = dma_channel_get_default_config(
         static_cast<uint>(mTxDmaChannel));

--- a/src/platforms/arm/rp/rpcommon/rp_spi_peripheral.h
+++ b/src/platforms/arm/rp/rpcommon/rp_spi_peripheral.h
@@ -18,6 +18,8 @@ class RpSpiPeripheral final : public IRpSpiPeripheral {
     bool configure(const RpSpiConfig& config) FL_NO_EXCEPT override;
     u32 actualClockHz() const FL_NO_EXCEPT override;
     bool startTxDma(const u8* data, size_t size) FL_NO_EXCEPT override;
+    bool startTxDmaCaptureRx(const u8* data, size_t size,
+                             u8* rx_data, size_t rx_size) FL_NO_EXCEPT override;
     bool isTxDmaBusy() const FL_NO_EXCEPT override;
     bool isRxDmaBusy() const FL_NO_EXCEPT override;
     bool isWireBusy() const FL_NO_EXCEPT override;
@@ -27,6 +29,9 @@ class RpSpiPeripheral final : public IRpSpiPeripheral {
     void deinitialize() FL_NO_EXCEPT override;
 
   private:
+    bool startTxDmaImpl(const u8* data, size_t size, u8* rx_data,
+                        size_t rx_size) FL_NO_EXCEPT;
+
     int mTxDmaChannel;
     int mRxDmaChannel;
     int mSpiIndex;

--- a/tests/platforms/arm/rp/rpcommon/channel_engine_rp_spi.cpp
+++ b/tests/platforms/arm/rp/rpcommon/channel_engine_rp_spi.cpp
@@ -33,6 +33,13 @@ class SpiMock final : public IRpSpiPeripheral {
         rxBusy = startOk;
         return startOk;
     }
+    bool startTxDmaCaptureRx(const u8* data, size_t size, u8* rx_data,
+                             size_t rx_size) FL_NO_EXCEPT override {
+        ++captureCalls;
+        if (rx_data == nullptr || rx_size < size) return false;
+        for (size_t index = 0; index < size; ++index) rx_data[index] = data[index];
+        return startTxDma(data, size);
+    }
     bool isTxDmaBusy() const FL_NO_EXCEPT override { return txBusy; }
     bool isRxDmaBusy() const FL_NO_EXCEPT override { return rxBusy; }
     bool isWireBusy() const FL_NO_EXCEPT override { return wireBusy; }
@@ -52,6 +59,7 @@ class SpiMock final : public IRpSpiPeripheral {
     u32 timeUs = 0;
     int configureCalls = 0;
     int startCalls = 0;
+    int captureCalls = 0;
     int abortCalls = 0;
     int deinitializeCalls = 0;
     size_t byteCount = 0;
@@ -111,6 +119,19 @@ FL_TEST_CASE("RP SPI1 accepts only canonical RX SCK MOSI triples and clamps cloc
     FL_CHECK_EQ(peripheral->lastConfig.miso_pin, 24);
     FL_CHECK_EQ(peripheral->lastConfig.clock_hz, 62500000u);
     FL_CHECK_EQ(peripheral->startCalls, 1);
+}
+
+FL_TEST_CASE("RP SPI captures exact loopback bytes through the channel engine") {
+    auto peripheral = fl::make_shared<SpiMock>();
+    ChannelEngineRpSpi engine(peripheral, 0);
+    u8 captured[2] = {0, 0};
+    FL_REQUIRE(engine.captureNextRxBytes(captured, sizeof(captured)));
+    engine.enqueue(makeChannel(3, 2, 8000000));
+    engine.show();
+    FL_CHECK_EQ(peripheral->captureCalls, 1);
+    FL_CHECK_EQ(captured[0], 0xA5);
+    FL_CHECK_EQ(captured[1], 0x5A);
+    FL_CHECK_EQ(engine.lastActualClockHz(), 6000000u);
 }
 
 FL_TEST_CASE("RP SPI releases all channels on RX or peripheral failure") {


### PR DESCRIPTION
## Summary

- add a documented `--rp-spi-loopback` AutoResearch mode for RP fixed SPI0/SPI1
- capture SPI MISO through the real `ChannelEngineRpSpi` DMA path and require byte-exact data plus PL022 wire-idle
- validate SPI0 on attached Raspberry Pi Pico at 1, 8, and 24 MHz

## Validation

- `bash test channel_engine_rp_spi --debug`
- `bash autoresearch rp2040 --rp-spi-loopback --rp-spi-index 0 --tx-pin 3 --rx-pin 0 --upload-port COM12 --timeout 120s --skip-lint`

Refs #3659

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added RP2040 SPI loopback testing through the AutoResearch runner.
  * Added support for selecting SPI interfaces, configuring pins, and testing multiple clock rates.
  * Added RPC reporting for loopback results, including captured bytes, clock speed, wiring, and validation status.
  * Added DMA-based SPI receive capture for diagnostic loopback transfers.

* **Tests**
  * Added coverage for argument parsing, test dispatch, DMA capture, and byte-accurate loopback validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->