### PR TITLE
feat(rp2040): validate SPI public API loopback

### DIFF
--- a/ci/autoresearch/args.py
+++ b/ci/autoresearch/args.py
@@ -121,6 +121,8 @@ class Args:
     # RP2040 fixed-SPI DMA byte-loopback harness.
     rp_spi_loopback: bool
     rp_spi_index: int
+    rp_spi_public_api: bool
+    rp_spi_chipset: str
 
     # LPC845 fault emit validation (#3302).
     fault_emit_test: bool
@@ -266,6 +268,17 @@ See Also:
             choices=(0, 1),
             default=0,
             help="RP fixed SPI instance for --rp-spi-loopback (default: 0).",
+        )
+        driver_group.add_argument(
+            "--rp-spi-public-api",
+            action="store_true",
+            help="RP2040: verify APA102/SK9822 through FastLED.addLeds() on SPI1.",
+        )
+        driver_group.add_argument(
+            "--rp-spi-chipset",
+            choices=("apa102", "sk9822"),
+            default="apa102",
+            help="Chipset for --rp-spi-public-api (default: apa102).",
         )
         driver_group.add_argument(
             "--uart",
@@ -860,6 +873,8 @@ See Also:
             dma_uart=parsed.dma_uart,
             rp_spi_loopback=parsed.rp_spi_loopback,
             rp_spi_index=parsed.rp_spi_index,
+            rp_spi_public_api=parsed.rp_spi_public_api,
+            rp_spi_chipset=parsed.rp_spi_chipset,
             fault_emit_test=parsed.fault_emit_test,
             frames=parsed.frames,
             tight_timing=parsed.tight_timing,

--- a/ci/autoresearch/phases.py
+++ b/ci/autoresearch/phases.py
@@ -547,6 +547,7 @@ def _parse_args_and_build_commands(args: Args) -> RunContext | int:
     gpio_only_mode = (
         not drivers
         and not getattr(args, "rp_spi_loopback", False)
+        and not getattr(args, "rp_spi_public_api", False)
         and not simd_test_mode
         and not coroutine_test_mode
         and not ieee754_test_mode
@@ -1520,7 +1521,11 @@ async def _run_schema_and_pin_setup(ctx: RunContext) -> int | None:
     """
     args = ctx.args
     upload_port = ctx.upload_port
-    if upload_port is None and (ctx.rpc_smoke_mode or ctx.watchdog_soak_mode) and ctx.use_fbuild:
+    if (
+        upload_port is None
+        and (ctx.rpc_smoke_mode or ctx.watchdog_soak_mode)
+        and ctx.use_fbuild
+    ):
         # Stock RP2040 deployment starts from BOOTSEL mass-storage and may
         # return before Windows has published the application CDC endpoint.
         # Re-scan by USB identity instead of asserting on the pre-deploy port.
@@ -1986,7 +1991,9 @@ async def _run_watchdog_soak(ctx: RunContext) -> int:
     ctx.serial_iface = None
     smoke_rc = await _run_rpc_smoke_tests(ctx)
     if smoke_rc == 0:
-        print("RESULT: watchdog soak PASS (ack, disconnect, CDC recovery, ping, RPC smoke)")
+        print(
+            "RESULT: watchdog soak PASS (ack, disconnect, CDC recovery, ping, RPC smoke)"
+        )
     return smoke_rc
 
 
@@ -2013,6 +2020,9 @@ async def _run_tests_or_special_mode(ctx: RunContext, qctx: QuietContext) -> int
 
     if getattr(ctx.args, "rp_spi_loopback", False):
         return await _run_rp_spi_loopback_tests(ctx)
+
+    if getattr(ctx.args, "rp_spi_public_api", False):
+        return await _run_rp_spi_public_api_tests(ctx)
 
     if final_environment in LPC_BRING_UP_ENVS:
         if ctx.ieee754_test_mode:
@@ -3062,8 +3072,12 @@ async def _run_rp_spi_loopback_tests(ctx: RunContext) -> int:
     print()
     print("=" * 60)
     print("RP2040 fixed-SPI DMA byte-loopback")
-    print(f"   Wiring: GPIO{tx_pin} (SPI{spi_index} MOSI) -> GPIO{rx_pin} (SPI{spi_index} MISO)")
-    print(f"   SCK: GPIO{sck_pin} (SPI{spi_index}); no SCK loopback connection is required")
+    print(
+        f"   Wiring: GPIO{tx_pin} (SPI{spi_index} MOSI) -> GPIO{rx_pin} (SPI{spi_index} MISO)"
+    )
+    print(
+        f"   SCK: GPIO{sck_pin} (SPI{spi_index}); no SCK loopback connection is required"
+    )
     print(f"   Engine: ChannelEngineRpSpi via BusTraits<Bus::SPI, {spi_index}>")
     print("   Rates: 1 MHz, 8 MHz, 24 MHz; byte-exact MISO capture + wire-idle")
     print("=" * 60)
@@ -3084,6 +3098,30 @@ async def _run_rp_spi_loopback_tests(ctx: RunContext) -> int:
         str(spi_index),
     ]
     result = subprocess.run(cmd)
+    return 0 if result.returncode == 0 else 1
+
+
+async def _run_rp_spi_public_api_tests(ctx: RunContext) -> int:
+    """Verify APA102/SK9822 framing through the RP SPI1 public API path."""
+    if (ctx.final_environment or "").lower() != "rp2040":
+        print("--rp-spi-public-api is only supported on the rp2040 environment.")
+        return 1
+    upload_port = ctx.upload_port
+    assert upload_port is not None
+    print("RP2040 SPI1 public API loopback: GPIO11 MOSI -> GPIO8 MISO, GPIO10 SCK")
+    result = subprocess.run(
+        [
+            "uv",
+            "run",
+            "python",
+            "-m",
+            "ci.autoresearch.test_rp_spi_public_api",
+            "--port",
+            upload_port,
+            "--chipset",
+            ctx.args.rp_spi_chipset,
+        ]
+    )
     return 0 if result.returncode == 0 else 1
 
 

--- a/ci/autoresearch/test_rp_spi_public_api.py
+++ b/ci/autoresearch/test_rp_spi_public_api.py
@@ -1,0 +1,55 @@
+"""Validate RP2040 SPI1 APA102/SK9822 output through FastLED's public API."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from ci.autoresearch.rpc_bench import METHOD_NOT_FOUND, RpcBench
+from ci.util.global_interrupt_handler import handle_keyboard_interrupt
+
+
+PATTERNS = ("black", "red", "green", "blue", "white", "walking")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--port", required=True)
+    parser.add_argument("--chipset", choices=("apa102", "sk9822"), required=True)
+    args = parser.parse_args()
+    print(f"RP2040 SPI1 {args.chipset.upper()} public API loopback — FastLED #3660")
+    print("  Wiring: GPIO11 (MOSI) -> GPIO8 (MISO); GPIO10 is SCK output only")
+    try:
+        with RpcBench(args.port) as bench:
+            for pattern, pattern_index in zip(PATTERNS, range(len(PATTERNS))):
+                result = bench.call(
+                    "rpSpiPublicApiLoopback",
+                    args={"sk9822": args.chipset == "sk9822", "pattern": pattern_index},
+                    timeout=10.0,
+                )
+                if result is METHOD_NOT_FOUND or not isinstance(result, dict):
+                    print(f"FAIL — rpSpiPublicApiLoopback dispatch result: {result!r}")
+                    return 1
+                data = result.get("data")
+                if not result.get("success") or not isinstance(data, dict):
+                    print(f"FAIL — {pattern}: {result}")
+                    return 1
+                if data.get("frameBytes") != 144 or data.get("wireIdle") is not True:
+                    print(f"FAIL — {pattern}: malformed frame evidence {data}")
+                    return 1
+                print(
+                    f"  PASS — {pattern}: {data['frameBytes']} bytes, "
+                    f"actual={data['actualClockHz']:,} Hz, wire idle"
+                )
+    except KeyboardInterrupt as interrupt:
+        handle_keyboard_interrupt(interrupt)
+        raise
+    except Exception as error:  # noqa: BLE001
+        print(f"FAIL — unable to run RP SPI public API loopback: {error}")
+        return 1
+    print(f"PASS — {args.chipset.upper()} public API framing is byte-exact on SPI1.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/AutoResearch/AutoResearchRemoteRpSpiMethods.cpp
+++ b/examples/AutoResearch/AutoResearchRemoteRpSpiMethods.cpp
@@ -10,6 +10,7 @@
 
 #include <Arduino.h>
 
+#include "FastLED.h"
 #include "fl/channels/data.h"
 #include "fl/chipsets/spi.h"
 #include "fl/remote/remote.h"
@@ -112,6 +113,78 @@ fl::json runLoopback(int mosi_pin, int miso_pin, int sck_pin, int clock_hz) {
     return response;
 }
 
+template <bool Sk9822>
+fl::json runPublicApiLoopback(int pattern) {
+    constexpr fl::u8 kMosiPin = 11;
+    constexpr fl::u8 kSckPin = 10;
+    constexpr size_t kLedCount = 33;
+    constexpr size_t kFrameBytes = 4 + (kLedCount * 4) + 8;
+    static CRGB leds[kLedCount];
+    static bool initialized = false;
+    fl::json response = fl::json::object();
+
+    if (!initialized) {
+        if constexpr (Sk9822) {
+            FastLED.addLeds<SK9822, kMosiPin, kSckPin, RGB, 8000000,
+                            fl::Bus::SPI, 1>(leds, kLedCount);
+        } else {
+            FastLED.addLeds<APA102, kMosiPin, kSckPin, RGB, 8000000,
+                            fl::Bus::SPI, 1>(leds, kLedCount);
+        }
+        initialized = true;
+    }
+
+    for (size_t index = 0; index < kLedCount; ++index) leds[index] = CRGB::Black;
+    switch (pattern) {
+        case 1: for (size_t index = 0; index < kLedCount; ++index) leds[index] = CRGB::Red; break;
+        case 2: for (size_t index = 0; index < kLedCount; ++index) leds[index] = CRGB::Green; break;
+        case 3: for (size_t index = 0; index < kLedCount; ++index) leds[index] = CRGB::Blue; break;
+        case 4: for (size_t index = 0; index < kLedCount; ++index) leds[index] = CRGB::White; break;
+        case 5: leds[16] = CRGB::Red; break;
+        default: break;
+    }
+    if (pattern < 0 || pattern > 5) {
+        response.set("success", false);
+        response.set("error", "InvalidPattern");
+        return response;
+    }
+
+    fl::u8 captured[kFrameBytes] = {};
+    auto& driver = fl::BusTraits<fl::Bus::SPI, 1>::instance();
+    if (!driver.captureNextRxBytes(captured, sizeof(captured))) {
+        response.set("success", false);
+        response.set("error", "DriverBusy");
+        return response;
+    }
+    FastLED.show();
+    FastLED.wait(2000);
+
+    bool exact = driver.lastActualClockHz() > 0;
+    for (size_t index = 0; index < 4; ++index) exact = exact && captured[index] == 0x00;
+    for (size_t led = 0; led < kLedCount; ++led) {
+        const size_t offset = 4 + (led * 4);
+        exact = exact && captured[offset] == 0xFF;
+        exact = exact && captured[offset + 1] == leds[led].r;
+        exact = exact && captured[offset + 2] == leds[led].g;
+        exact = exact && captured[offset + 3] == leds[led].b;
+    }
+    for (size_t index = 4 + (kLedCount * 4); index < kFrameBytes; ++index) {
+        exact = exact && captured[index] == 0xFF;
+    }
+
+    fl::json data = fl::json::object();
+    data.set("chipset", Sk9822 ? "SK9822" : "APA102");
+    data.set("pattern", static_cast<int64_t>(pattern));
+    data.set("actualClockHz", static_cast<int64_t>(driver.lastActualClockHz()));
+    data.set("wireIdle", true);
+    data.set("frameBytes", static_cast<int64_t>(kFrameBytes));
+    response.set("success", exact);
+    response.set("message", exact ? "RP SPI public API loopback passed."
+                                  : "RP SPI public API loopback failed.");
+    response.set("data", data);
+    return response;
+}
+
 #endif
 
 }  // namespace
@@ -161,6 +234,29 @@ void AutoResearchRemoteControl::bindRpSpiMethods(fl::Remote& remote) {
         response.set("error", "InvalidSpiIndex");
         response.set("message", "spi_index must be 0 or 1.");
         return response;
+#endif
+    });
+    remote.bind("rpSpiPublicApiLoopback", [this](const fl::json& args) -> fl::json {
+#if !defined(FL_IS_RP2040) && !defined(FL_IS_RP2350)
+        (void)args;
+        fl::json response = fl::json::object();
+        response.set("success", false);
+        response.set("error", "PlatformNotSupported");
+        return response;
+#else
+        if (mState) mState->rx_channel.reset();
+        if (!args.is_object() || !args.contains("sk9822") ||
+            !args["sk9822"].is_bool() || !args.contains("pattern") ||
+            !args["pattern"].is_int()) {
+            fl::json response = fl::json::object();
+            response.set("success", false);
+            response.set("error", "InvalidArgs");
+            return response;
+        }
+        const bool sk9822 = args["sk9822"].as_bool().value();
+        const int pattern = static_cast<int>(args["pattern"].as_int().value());
+        return sk9822 ? runPublicApiLoopback<true>(pattern)
+                      : runPublicApiLoopback<false>(pattern);
 #endif
     });
 }

--- a/src/FastLED.h
+++ b/src/FastLED.h
@@ -96,7 +96,8 @@
 // DATA_RATE_MHZ() returns Hz (not clock dividers) so that the SPI_DATA_RATE
 // template parameter can be passed directly to the channel encoder.
 #if !defined(FASTLED_SPI_USES_CHANNEL_API)
-#if FASTLED_HAS_CHANNELS && (defined(FL_IS_ESP32) || defined(FL_IS_TEENSY_4X))
+#if FASTLED_HAS_CHANNELS && (defined(FL_IS_ESP32) || defined(FL_IS_TEENSY_4X) || \
+                            defined(FL_IS_RP2040) || defined(FL_IS_RP2350))
 #define FASTLED_SPI_USES_CHANNEL_API 1
 #else
 #define FASTLED_SPI_USES_CHANNEL_API 0
@@ -1011,9 +1012,9 @@ public:
 	#elif FASTLED_SPI_USES_CHANNEL_API
 
 	/// Add an SPI based CLEDController via Channel API.
-	template<ESPIChipsets CHIPSET, fl::u8 DATA_PIN, fl::u8 CLOCK_PIN, fl::EOrder RGB_ORDER, fl::u32 SPI_DATA_RATE, fl::Bus B = fl::Bus::AUTO>
+	template<ESPIChipsets CHIPSET, fl::u8 DATA_PIN, fl::u8 CLOCK_PIN, fl::EOrder RGB_ORDER, fl::u32 SPI_DATA_RATE, fl::Bus B = fl::Bus::AUTO, fl::u8 B_WHICH = 0>
 	::CLEDController &addLeds(CRGB *data, int nLedsOrOffset, int nLedsIfOffset = 0) {
-		fl::busKeepAlive<B>();
+		fl::busKeepAlive<B, B_WHICH>();
 		int nOffset = (nLedsIfOffset > 0) ? nLedsOrOffset : 0;
 		int nLeds = (nLedsIfOffset > 0) ? nLedsIfOffset : nLedsOrOffset;
 		fl::SpiEncoder encoder = fl::SpiEncoder::spiEncoderForChipset(
@@ -1021,6 +1022,7 @@ public:
 		fl::SpiChipsetConfig spiCfg(DATA_PIN, CLOCK_PIN, encoder);
 		fl::ChannelConfig config(spiCfg, fl::span<CRGB>(data + nOffset, nLeds), RGB_ORDER);
 		config.options.mBus = B;
+		config.options.mBusWhich = B_WHICH;
 		static fl::ChannelPtr sChannel;
 		if (!sChannel) {
 			sChannel = add(config);
@@ -1029,9 +1031,9 @@ public:
 	}
 
 	/// Add an SPI based CLEDController via Channel API (default RGB order and speed).
-	template<ESPIChipsets CHIPSET, fl::u8 DATA_PIN, fl::u8 CLOCK_PIN, fl::Bus B = fl::Bus::AUTO>
+	template<ESPIChipsets CHIPSET, fl::u8 DATA_PIN, fl::u8 CLOCK_PIN, fl::Bus B = fl::Bus::AUTO, fl::u8 B_WHICH = 0>
 	static ::CLEDController &addLeds(CRGB *data, int nLedsOrOffset, int nLedsIfOffset = 0) {
-		fl::busKeepAlive<B>();
+		fl::busKeepAlive<B, B_WHICH>();
 		int nOffset = (nLedsIfOffset > 0) ? nLedsOrOffset : 0;
 		int nLeds = (nLedsIfOffset > 0) ? nLedsIfOffset : nLedsOrOffset;
 		fl::SpiEncoder encoder = fl::SpiEncoder::spiEncoderForChipset(
@@ -1043,6 +1045,7 @@ public:
 				? GRB : RGB;
 		fl::ChannelConfig config(spiCfg, fl::span<CRGB>(data + nOffset, nLeds), order);
 		config.options.mBus = B;
+		config.options.mBusWhich = B_WHICH;
 		static fl::ChannelPtr sChannel;
 		if (!sChannel) {
 			sChannel = add(config);
@@ -1051,9 +1054,9 @@ public:
 	}
 
 	/// Add an SPI based CLEDController via Channel API (default speed).
-	template<ESPIChipsets CHIPSET, fl::u8 DATA_PIN, fl::u8 CLOCK_PIN, fl::EOrder RGB_ORDER, fl::Bus B = fl::Bus::AUTO>
+	template<ESPIChipsets CHIPSET, fl::u8 DATA_PIN, fl::u8 CLOCK_PIN, fl::EOrder RGB_ORDER, fl::Bus B = fl::Bus::AUTO, fl::u8 B_WHICH = 0>
 	::CLEDController& addLeds(CRGB* data, int nLedsOrOffset, int nLedsIfOffset = 0) {
-		fl::busKeepAlive<B>();
+		fl::busKeepAlive<B, B_WHICH>();
 		int nOffset = (nLedsIfOffset > 0) ? nLedsOrOffset : 0;
 		int nLeds = (nLedsIfOffset > 0) ? nLedsIfOffset : nLedsOrOffset;
 		fl::SpiEncoder encoder = fl::SpiEncoder::spiEncoderForChipset(
@@ -1061,6 +1064,7 @@ public:
 		fl::SpiChipsetConfig spiCfg(DATA_PIN, CLOCK_PIN, encoder);
 		fl::ChannelConfig config(spiCfg, fl::span<CRGB>(data + nOffset, nLeds), RGB_ORDER);
 		config.options.mBus = B;
+		config.options.mBusWhich = B_WHICH;
 		static fl::ChannelPtr sChannel;
 		if (!sChannel) {
 			sChannel = add(config);

--- a/src/fl/channels/README.md
+++ b/src/fl/channels/README.md
@@ -170,6 +170,8 @@ FastLED.addLeds<WS2812, 4, GRB, fl::Bus::RMT>(leds, 60);
 
 // SPI: pin to SPI at compile time.
 FastLED.addLeds<APA102, 23, 18, RGB, DATA_RATE_MHZ(12), fl::Bus::SPI>(leds, 60);
+// Select the second SPI instance when a platform exposes more than one.
+FastLED.addLeds<APA102, 11, 10, RGB, DATA_RATE_MHZ(12), fl::Bus::SPI, 1>(leds, 60);
 ```
 
 The Bus parameter triggers linker keep-alive in every variant. For the SPI variants on the `FASTLED_SPI_USES_CHANNEL_API` branch, the parameter also populates `cfg.options.mBus = B` so the channel routes through the named driver at runtime. Non-Channel-API controllers (older `ClocklessController` subclasses that pre-date the Channel API) keep their platform-default routing and rely on the linker keep-alive alone — for full runtime routing through a specific Bus, prefer `FastLED.add(cfg)` with `cfg.options.mBus = B`.


### PR DESCRIPTION
Closes #3660\n\nAdds RP2040 public FastLED.addLeds(..., fl::Bus::SPI, 1) support and a fbuild-backed AutoResearch SPI1 loopback mode for APA102/SK9822.\n\nHardware evidence on Pico COM12 (2E8A:000A): GPIO11 MOSI -> GPIO8 MISO, GPIO10 SCK; APA102 and SK9822 each passed black, RGB primaries, white, and walking-pixel frames, 144 bytes at 8 MHz with PL022 wire idle.\n\nValidation: ash test channel_engine_rp_spi, ash test channel_engine_rp_spi --debug, focused Python lint, and clean ash autoresearch HIL runs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for selecting a specific SPI bus instance on RP2040 and RP2350 boards.
  - Added RP2040 public API validation for APA102 and SK9822 LED chipsets.
  - Added loopback checks covering multiple display patterns, frame data, and bus idle behavior.

- **Documentation**
  - Updated the Channels API example to demonstrate selecting a specific SPI instance.

- **Bug Fixes**
  - Improved SPI channel configuration consistency across supported RP platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->