### PR TITLE
test(rp2040): cover long SPI API frames

### DIFF
--- a/ci/autoresearch/test_rp_spi_public_api.py
+++ b/ci/autoresearch/test_rp_spi_public_api.py
@@ -34,7 +34,7 @@ def main() -> int:
                 if not result.get("success") or not isinstance(data, dict):
                     print(f"FAIL — {pattern}: {result}")
                     return 1
-                if data.get("frameBytes") != 144 or data.get("wireIdle") is not True:
+                if data.get("frameBytes") != 1068 or data.get("wireIdle") is not True:
                     print(f"FAIL — {pattern}: malformed frame evidence {data}")
                     return 1
                 print(

--- a/examples/AutoResearch/AutoResearchRemoteRpSpiMethods.cpp
+++ b/examples/AutoResearch/AutoResearchRemoteRpSpiMethods.cpp
@@ -117,8 +117,8 @@ template <bool Sk9822>
 fl::json runPublicApiLoopback(int pattern) {
     constexpr fl::u8 kMosiPin = 11;
     constexpr fl::u8 kSckPin = 10;
-    constexpr size_t kLedCount = 33;
-    constexpr size_t kFrameBytes = 4 + (kLedCount * 4) + 8;
+    constexpr size_t kLedCount = 257;
+    constexpr size_t kFrameBytes = 4 + (kLedCount * 4) + 36;
     static CRGB leds[kLedCount];
     static bool initialized = false;
     fl::json response = fl::json::object();


### PR DESCRIPTION
Follow-up to #3672 for #3660.\n\nExtends the fbuild/AutoResearch public API loopback to 257 LEDs (1,068 bytes), preserving APA102/SK9822 all-ones end-frame validation on SPI1.\n\nHIL: COM12 Pico GPIO11 MOSI -> GPIO8 MISO, GPIO10 SCK; APA102 and SK9822 both passed black, RGB primaries, white, and walking pixel at 8 MHz with PL022 wire idle.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SPI loopback validation for larger LED data frames.
  * Updated framing checks to accurately detect valid and malformed transmissions.
  * Continued validation of idle-line behavior and response handling.

* **Tests**
  * Expanded coverage for APA102/SK9822-compatible frames with increased LED counts and payload sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->