### PR TITLE
fix(autoresearch): select RP PIO driver by name

### DIFF
--- a/ci/autoresearch/phases.py
+++ b/ci/autoresearch/phases.py
@@ -81,6 +81,14 @@ def _is_teensy4_environment(final_environment: str | None) -> bool:
 def _driver_name_for_environment(driver: str, final_environment: str | None) -> str:
     if driver == "SPI" and _is_teensy4_environment(final_environment):
         return "SPI_UNIFIED"
+    if (
+        driver == "FLEX_IO"
+        and final_environment is not None
+        and final_environment.lower() in ("rp2040", "rpipico")
+    ):
+        # RP exposes concrete PIO engines, which are the names accepted by
+        # the RPC driver registry. PIO1 leaves PIO0 available to the RX oracle.
+        return "PIO1"
     return driver
 
 

--- a/ci/tests/test_autoresearch_phases.py
+++ b/ci/tests/test_autoresearch_phases.py
@@ -560,6 +560,25 @@ class TestParseArgsAndBuildCommands:
         assert command["params"]["driver"] == "FLEX_IO"
         assert "pinTx" not in command["params"]
 
+    def test_flex_io_driver_name_maps_to_pio1_on_rp2040(
+        self, fake_project_dir: Path
+    ) -> None:
+        args = _make_args(
+            parlio=False,
+            flex_io=True,
+            environment_positional="rp2040",
+            project_dir=fake_project_dir,
+            use_root_platformio_ini=False,
+        )
+        with patch(
+            "ci.autoresearch.staging.synthesise_autoresearch_project",
+            return_value=fake_project_dir,
+        ):
+            result = _parse_args_and_build_commands(args)
+        assert isinstance(result, RunContext)
+        assert result.drivers == ["PIO1"]
+        assert result.json_rpc_commands[0]["params"]["driver"] == "PIO1"
+
     def test_lpuart_is_deprecated_alias_for_uart(
         self, fake_project_dir: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:


### PR DESCRIPTION
Maps the cross-platform --flex-io selector to PIO1 on RP2040/Pico targets, which is the concrete driver name exposed by the RPC registry. PIO1 is selected so PIO0 remains available to the RX oracle.\n\nHIL: fbuild deployed to COM12; GPIO11 -> GPIO8 connectivity passed and the command reached PIO1. The remaining waveform capture failure is tracked in #3658 and is not claimed resolved here.\n\nValidation: bash lint ci/autoresearch/phases.py ci/tests/test_autoresearch_phases.py; git diff --check. The focused bash test wrapper stalled without output and was terminated after its bounded run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Flex I/O driver selection for RP2040 and RPipico environments.
  * RPC commands now correctly use the PIO1 driver in these configurations.

* **Tests**
  * Added coverage to verify Flex I/O driver mapping for RP2040 setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->